### PR TITLE
Default cutoff in fock plugin

### DIFF
--- a/openqml-sf/openqml_sf/fock.py
+++ b/openqml-sf/openqml_sf/fock.py
@@ -79,7 +79,7 @@ class StrawberryFieldsFock(Device):
     _observables = {'Fock', 'X', 'P', 'Homodyne'}
     _circuits = {}
 
-    def __init__(self, wires, *, shots=0, cutoff=5, hbar=2):
+    def __init__(self, wires, *, shots=0, cutoff, hbar=2):
         self.wires = wires
         self.cutoff = cutoff
         self.hbar = hbar


### PR DESCRIPTION
Again, I am not sure whether you will like this, but with the default value of `cutoff=None` the fock backend throws an error. I suggest we either provide a "reasonable" default, or make the cutoff argument mandatory. Alternatively the fock backend of SF could be modified to handle `cutoff=None`, or `cutoff` could be passed on the backend only if it is set to something not `None`. Not sure which is the best option...