### PR TITLE
Projectq support multiple measurements

### DIFF
--- a/openqml-pq/openqml_pq/projectq.py
+++ b/openqml-pq/openqml_pq/projectq.py
@@ -160,7 +160,7 @@ class ProjectQDevice(Device):
 
         Drawback: This is probably rather resource intensive.
         """
-        if self.eng is not None and self.backend == 'Simulator'::
+        if self.eng is not None and self.backend == 'Simulator':
             pq.ops.All(pq.ops.Measure) | self.reg #avoid an unfriendly error message: https://github.com/ProjectQ-Framework/ProjectQ/issues/2
 
     def filter_kwargs_for_backend(self, kwargs):


### PR DESCRIPTION
This allows multiple expectation values with the ProjectQ plugin in the simulator and the IBM backend despite the fact that the latter only supports a single Z-basis measurement on the hardware qubits.

Implements the "workaround" mentioned in #61, which is something we anyway want to support.

Also fixes a number of smaller bugs.