### PR TITLE
Fix to QNode_vjp and QNode.gradient

### DIFF
--- a/openqml/qnode.py
+++ b/openqml/qnode.py
@@ -489,7 +489,7 @@ class QNode:
                 the expectation values. For simulator backends, 0 yields the exact result.
 
         Returns:
-            array[float]: gradient vector/Jacobian matrix, shape == (n_out, len(which))
+            array[float]: Jacobian matrix, shape == (n_out, len(which))
         """
         # in QNode.construct we need to be able to (essentially) apply the unpacking operator to params
         if isinstance(params, numbers.Number):
@@ -538,7 +538,7 @@ class QNode:
                 y0 = None
 
         # compute the partial derivative w.r.t. each parameter using the proper method
-        grad = np.zeros((len(which), self.output_dim), dtype=float)
+        grad = np.zeros((self.output_dim, len(which)), dtype=float)
 
         for i, k in enumerate(which):
             if k not in self.variable_ops:
@@ -547,18 +547,15 @@ class QNode:
 
             par_method = method[k]
             if par_method == 'A':
-                grad[i, :] = self._pd_analytic(flat_params, k, **kwargs)
+                grad[:, i] = self._pd_analytic(flat_params, k, **kwargs)
             elif par_method == 'F':
-                grad[i, :] = self._pd_finite_diff(flat_params, k, h, order, y0, **kwargs)
+                grad[:, i] = self._pd_finite_diff(flat_params, k, h, order, y0, **kwargs)
             elif par_method is None:
                 raise ValueError('Cannot differentiate wrt parameter {}.'.format(k))
             else:
                 raise ValueError('Unknown gradient method.')
 
-        if self.output_dim == 1:
-            return grad[:, 0]
-
-        return grad.T
+        return grad
 
     def _pd_finite_diff(self, params, idx, h=1e-7, order=1, y0=None, **kwargs):
         """Partial derivative of the node using the finite difference method.
@@ -701,19 +698,23 @@ def QNode_vjp(ans, self, args, **kwargs):
     of the QNode evaluation for specific argnums at the specified parameter values.
     """
     def gradient_product(g):
-        """Vector Jacobian product operator"""
+        """Vector Jacobian product operator.
+
+        Args:
+          g (array): scalar or vector multiplying the Jacobian from the left (output side)
+        Returns:
+          nested Sequence[float]: vector-Jacobian product, arranged into the nested structure of the QNode input arguments
+        """
+        # Jacobian matrix of the circuit
+        jac = self.gradient(args, **kwargs)
         if len(g.shape) == 0:
-            if len(args) == 1 and isinstance(args[0], np.ndarray):
-                return [self.gradient(args, **kwargs)]
+            temp = g * jac  # numpy treats 0d arrays as scalars, hence @ cannot be used
+        else:
+            temp = g @ jac
 
-            return g * self.gradient(args, **kwargs)
-
-        if len(args) == 1 and isinstance(args[0], np.ndarray):
-            # This feels hacky, but is required if the argument
-            # is a single np.ndarray
-            return [g] @ self.gradient(args, **kwargs)
-
-        return g @ self.gradient(args, **kwargs)
+        # restore the nested structure of the input args
+        temp = unflatten(temp.flat, args)
+        return temp
 
     return gradient_product
 

--- a/tests/defaults.py
+++ b/tests/defaults.py
@@ -72,7 +72,7 @@ class BaseTest(unittest.TestCase):
             # check each element of the tuple separately (needed for when the tuple elements are themselves batches)
             if np.all([np.all(first[idx] == second[idx]) for idx, _ in enumerate(first)]):
                 return
-            if np.all([np.all(np.abs(first[idx] - second[idx])) <= delta for idx, _ in enumerate(first)]):
+            if np.all([np.all(np.abs(first[idx] - second[idx]) <= delta) for idx, _ in enumerate(first)]):
                 return
         else:
             if np.all(first == second):


### PR DESCRIPTION
Now QNode.gradient now always returns a 2d Jacobian matrix (and probably should be renamed QNode.jacobian). QNode_vjp handles arbitrary nested input arguments using unflatten.

Also fixes a bug in tests/defaults.py

Should fix issue #56.