### PR TITLE
Add variance support to the UI

### DIFF
--- a/pennylane/decorator.py
+++ b/pennylane/decorator.py
@@ -107,5 +107,15 @@ def qnode(device):
         def wrapper(*args, **kwargs):
             """Wrapper function"""
             return qnode(*args, **kwargs)
+
+        # bind the jacobian method to the wrapped function
+        wrapper.jacobian = qnode.jacobian
+
+        # bind the variance method to the wrapped function
+        wrapper.var = qnode.var
+
+        # bind the qnode attributes to the wrapped function
+        wrapper.__dict__.update(qnode.__dict__)
+
         return wrapper
     return qfunc_decorator

--- a/pennylane/plugins/default_gaussian.py
+++ b/pennylane/plugins/default_gaussian.py
@@ -805,6 +805,16 @@ class DefaultGaussian(Device):
 
         return ev
 
+    def var(self, expectation, wires, par):
+        mu, cov = self.reduced_state(wires)
+
+        if expectation == 'PolyXP':
+            mu, cov = self._state
+
+        _, var = self._expectation_map[expectation](mu, cov, wires, par, hbar=self.hbar)
+
+        return var
+
     def reset(self):
         """Reset the device"""
         # init the state vector to |00..0>

--- a/tests/test_default_qubit.py
+++ b/tests/test_default_qubit.py
@@ -424,6 +424,39 @@ class TestDefaultQubitDevice(BaseTest):
                 self.assertEqual(len(l.records), 1)
                 self.assertIn('Nonvanishing imaginary part', l.output[0])
 
+    def test_var(self):
+        """Test that the correct variances are returned"""
+        self.logTestName()
+
+        # variance for sigma_z on eigenstate {1, 0} should be zero
+        @qml.qnode(self.dev)
+        def qfunc():
+            return qml.expval.PauliZ(0)
+
+        self.assertAllAlmostEqual(qfunc.var(), 0, delta=self.tol)
+
+        # variance for sigma_y on Rx(x)|0> is cos^2(x)
+        @qml.qnode(self.dev)
+        def qfunc(x):
+            qml.RX(x, wires=0)
+            return qml.expval.PauliY(0)
+
+        x = 0.5432
+        self.assertAllAlmostEqual(qfunc.var(x), np.cos(x)**2, delta=self.tol)
+
+        # variance for sigma_z on Rx(x)|0> is sin^2(x)
+        @qml.qnode(self.dev)
+        def qfunc(x):
+            qml.RX(x, wires=0)
+            return qml.expval.PauliZ(0)
+
+        self.assertAllAlmostEqual(qfunc.var(x), np.sin(x)**2, delta=self.tol)
+
+        # text exception raised if matrix is not 2x2
+        with self.assertRaisesRegex(ValueError, "2x2 matrix required"):
+            print('here')
+            self.dev.var('Hermitian', [0], [np.identity(4)])
+
 
 class TestDefaultQubitIntegration(BaseTest):
     """Integration tests for default.qubit. This test ensures it integrates


### PR DESCRIPTION
**Description of the Change:**

* Adds `Device.var(x)` abstract method to the device class, for returning the _variance_ of the QNode's output at parameter(s) `x`. This does not have to be defined in plugin devices, unlike `expval`; if the variance is requested on a device which does not support it, a `DeviceError` will be raised.

* Adds `QNode.var(x)` method, which works like `QNode.evaluate()`, but calls `Device.var()` instead.

* Adds `var`, `jacobian`, and all attributes such as `device`, `num_wires`, to the decorator wrapped function.

**Benefits:**

* Provides a method for user to access expectation value variances, **if** the plugin calculates them.

* Users can now access common QNode methods and attributes even if they use the decorator interface.

**Possible Drawbacks:**

* If we move to a system where variances can be explicitly returned from a qfunc like expectation values, than this approach will be deprecated.

**Related GitHub Issues:** #106 
