### PR TITLE
Remove expectation and operation map

### DIFF
--- a/doc/API/overview.rst
+++ b/doc/API/overview.rst
@@ -45,10 +45,10 @@ Here, we have begun defining some important class attributes that allow PennyLan
 
 * :attr:`~.Device.short_name`: the string used to identify and load the device by users of PennyLane
 
-* :attr:`~.Device.api_version`: the PennyLane version this device supports. Note that this class attribute supports ``pip`` ``requirements.txt`` style version ranges, for example:
+* :attr:`~.Device.api_version`: the PennyLane version this device supports. Note that this class attribute supports pip *requirements.txt* style version ranges, for example:
 
-   - ``pennylane_requires = "2"`` to support PennyLane version 2.x.x
-   - ``pennylane_requires = ">=0.1.5,<0.6"`` to support a range of PennyLane versions
+  - ``pennylane_requires = "2"`` to support PennyLane version 2.x.x
+  - ``pennylane_requires = ">=0.1.5,<0.6"`` to support a range of PennyLane versions
 
 * :attr:`~.Device.version`: the version number of the device
 
@@ -60,7 +60,7 @@ Defining all these attributes is mandatory.
 Supporting operators and expectations
 -------------------------------------
 
-You must further tell PennyLane about the operations and expectations that your device supports as well as potentially further capabilities, by providing the following class attributes:
+You must further tell PennyLane about the operations and expectations that your device supports as well as potentially further capabilities, by providing the following class attributes/properties:
 
 * :attr:`~.Device.operations`: a set of the supported PennyLane operations as strings, e.g.,
 

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -105,7 +105,6 @@ class Device(abc.ABC):
     """Abstract base class for PennyLane devices.
 
     Args:
-        name (str): name of the device.
         wires (int): number of subsystems in the quantum state represented by the device.
             Default 1 if not specified.
         shots (int): number of circuit evaluations/random samples used to estimate
@@ -115,8 +114,7 @@ class Device(abc.ABC):
     _capabilities = {} #: dict[str->*]: plugin capabilities
     _circuits = {}     #: dict[str->Circuit]: circuit templates associated with this API class
 
-    def __init__(self, name, wires=1, shots=0):
-        self.name = name
+    def __init__(self, wires=1, shots=0):
         self.num_wires = wires
         self.shots = shots
 

--- a/pennylane/optimize/gradient_descent.py
+++ b/pennylane/optimize/gradient_descent.py
@@ -19,7 +19,7 @@ from pennylane.utils import _flatten, unflatten
 
 class GradientDescentOptimizer(object):
     r"""Basic gradient-descent optimizer.
-    
+
     Base class for other gradient-descent-based optimizers.
 
     A step of the gradient descent optimizer computes the new values via the rule

--- a/pennylane/plugins/default_gaussian.py
+++ b/pennylane/plugins/default_gaussian.py
@@ -713,7 +713,7 @@ class DefaultGaussian(Device):
     _circuits = {}
 
     def __init__(self, wires, *, shots=0, hbar=2):
-        super().__init__(self.short_name, wires, shots)
+        super().__init__(wires, shots)
         self.eng = None
         self.hbar = hbar
         self.reset()

--- a/pennylane/plugins/default_qubit.py
+++ b/pennylane/plugins/default_qubit.py
@@ -75,7 +75,6 @@ Code details
 ^^^^^^^^^^^^
 """
 import logging as log
-import collections
 
 import numpy as np
 from scipy.linalg import expm, eigh
@@ -277,7 +276,7 @@ class DefaultQubit(Device):
     }
 
     def __init__(self, wires, *, shots=0):
-        super().__init__(self.short_name, wires, shots)
+        super().__init__(wires, shots)
         self.eng = None
         self._state = None
 

--- a/pennylane/qnode.py
+++ b/pennylane/qnode.py
@@ -133,7 +133,6 @@ Code details
 """
 import inspect
 import copy
-import collections
 
 import logging as log
 
@@ -208,7 +207,7 @@ class QNode:
         self.device = device
         self.num_wires = device.num_wires
         self.ops = []
-        
+
         self.variable_ops = {}
         """ dict[int->list[(int, int)]]: Mapping from free parameter index to the list of
         :class:`Operations <pennylane.operation.Operation>` (in this circuit) that depend on it.
@@ -747,7 +746,7 @@ class QNode:
                     B_inv = B_inv @ temp
                 Z = B @ Z @ B_inv  # conjugation
 
-                ev_successors = self._op_successors(o_idx, 'E')
+                # ev_successors = self._op_successors(o_idx, 'E')
 
                 def tr_obs(ex):
                     """Transform the observable"""


### PR DESCRIPTION
This is the change required to implement the suggestion from #118 in core.

The only other thing necessary would be to add the two methods operations() and expectatons() also to the SF and the PQ plugin devices.