### PR TITLE
Version bump for bugfix release

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,28 +1,55 @@
-# Release 0.7.0-dev
+# Release 0.6.1
 
 ### New features since last release
 
-### Breaking changes
+* Added a `print_applied` method to QNodes, allowing the operation
+  and observable queue to be printed as last constructed.
+  [#378](https://github.com/XanaduAI/pennylane/pull/378)
 
 ### Improvements
 
-* A new `Operator` base class is introduced, which is inherited by both the `Observable` class and the
-  `Operation` class.
+* A new `Operator` base class is introduced, which is inherited by both the
+  `Observable` class and the `Operation` class.
   [#355](https://github.com/XanaduAI/pennylane/pull/355)
 
 * Removed deprecated `@abstractproperty` decorators
   in `_device.py`.
   [#374](https://github.com/XanaduAI/pennylane/pull/374)
 
+* Comprehensive gradient tests have been added for the interfaces.
+  [#381](https://github.com/XanaduAI/pennylane/pull/381)
+
 ### Documentation
 
+* The new restructured documentation has been polished and updated.
+  [#387](https://github.com/XanaduAI/pennylane/pull/387)
+  [#375](https://github.com/XanaduAI/pennylane/pull/375)
+  [#372](https://github.com/XanaduAI/pennylane/pull/372)
+  [#370](https://github.com/XanaduAI/pennylane/pull/370)
+  [#369](https://github.com/XanaduAI/pennylane/pull/369)
+  [#367](https://github.com/XanaduAI/pennylane/pull/367)
+  [#364](https://github.com/XanaduAI/pennylane/pull/364)
+
+* Updated the development guides.
+  [#382](https://github.com/XanaduAI/pennylane/pull/382)
+  [#379](https://github.com/XanaduAI/pennylane/pull/379)
+
+* Added all modules, classes, and functions to the API section
+  in the documentation.
+  [#373](https://github.com/XanaduAI/pennylane/pull/373)
+
 ### Bug fixes
+
+* Replaces the existing `np.linalg.norm` normalization with hand-coded
+  normalization, allowing `AmplitudeEmbedding` to be used with differentiable
+  parameters. AmplitudeEmbedding tests have been added and improved.
+  [#376](https://github.com/XanaduAI/pennylane/pull/376)
 
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
 
-Antal Száva
+Josh Izaac, Nathan Killoran, Maria Schuld, Antal Száva
 
 ---
 

--- a/pennylane/_version.py
+++ b/pennylane/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = '0.7.0-dev'
+__version__ = '0.6.1'

--- a/pennylane/plugins/default_gaussian.py
+++ b/pennylane/plugins/default_gaussian.py
@@ -647,8 +647,8 @@ class DefaultGaussian(Device):
     """
     name = 'Default Gaussian PennyLane plugin'
     short_name = 'default.gaussian'
-    pennylane_requires = '0.7'
-    version = '0.7.0'
+    pennylane_requires = '0.6'
+    version = '0.6.1'
     author = 'Xanadu Inc.'
 
     _operation_map = {

--- a/pennylane/plugins/default_qubit.py
+++ b/pennylane/plugins/default_qubit.py
@@ -258,8 +258,8 @@ class DefaultQubit(Device):
     """
     name = 'Default qubit PennyLane plugin'
     short_name = 'default.qubit'
-    pennylane_requires = '0.7'
-    version = '0.7.0'
+    pennylane_requires = '0.6'
+    version = '0.6.1'
     author = 'Xanadu Inc.'
     _capabilities = {"model": "qubit", "tensor_observables": True}
 


### PR DESCRIPTION
**Description of the Change:** Bumps the version number of PennyLane to 0.6.1, in preparation of a bugfix release that will allow us to pin the docs to stable.

**Benefits:** Pinning the docs to stable will avoid 'documentation drift' between GitHub latest and the PyPI release that may confuse people using the stable release.

**Possible Drawbacks:** n/a

**Related GitHub Issues:** n/a
