### PR TITLE
[QAOA] Adds .map_wires Method to qml.Hamiltonian Class

### DIFF
--- a/pennylane/vqe/vqe.py
+++ b/pennylane/vqe/vqe.py
@@ -153,6 +153,7 @@ class Hamiltonian:
             or len(non_diagonal_coeffs) == 0
         )
 
+
 class VQECost:
     """Create a VQE cost function, i.e., a cost function returning the
     expectation value of a Hamiltonian.

--- a/pennylane/vqe/vqe.py
+++ b/pennylane/vqe/vqe.py
@@ -124,7 +124,7 @@ class Hamiltonian:
         r""" Checks if a Hamiltonian is diagonal in the computational basis.
 
         Returns:
-            bool: ``True`` if the Hamiltonian is diagonal in the computational basis, ``False`` otherwise
+            bool: ``True`` if the Hamiltonian is diagonal in the computational basis, ``False`` otherwise.
         """
 
         diagonals = ["PauliZ", "Identity"]

--- a/pennylane/vqe/vqe.py
+++ b/pennylane/vqe/vqe.py
@@ -166,6 +166,7 @@ class Hamiltonian:
 
         return qml.Hamiltonian(self.coeffs, new_terms)
 
+
 class VQECost:
     """Create a VQE cost function, i.e., a cost function returning the
     expectation value of a Hamiltonian.

--- a/pennylane/vqe/vqe.py
+++ b/pennylane/vqe/vqe.py
@@ -144,7 +144,10 @@ class Hamiltonian:
                         non_diagonal_coeffs.append(self._coeffs[i])
                     break
 
-        return np.allclose(non_diagonal_coeffs, [0.0 for i in non_diagonal_coeffs]) or len(non_diagonal_coeffs) == 0
+        return (
+            np.allclose(non_diagonal_coeffs, [0.0 for i in non_diagonal_coeffs])
+            or len(non_diagonal_coeffs) == 0
+        )
 
 
 class VQECost:

--- a/pennylane/vqe/vqe.py
+++ b/pennylane/vqe/vqe.py
@@ -128,16 +128,26 @@ class Hamiltonian:
             bool: ``True`` if the Hamiltonian is diagonal in the computational basis, ``False`` otherwise
         """
 
-        # Combines non-diagonal like terms
-        non_diagonl_coeffs = []
+        diagonals = ["PauliZ", "Identity"]
+
+        non_diagonal_coeffs = []
         non_diagonal_gates = []
 
-        for i in self._ops:
-            gates = [i.name] if isinstance(i, str) else i.name
+        for i, term in enumerate(self._ops):
+            gates = [term.name] if isinstance(term.name, str) else term.name
             for j in gates:
                 if j not in diagonals:
-                    if j not in non_diagonal_gates:
-                        non_diagonal_gates.append
+                    if gates not in non_diagonal_gates:
+                        non_diagonal_gates.append(gates)
+                        non_diagonal_coeffs.append(self._coeffs[i])
+                    else:
+                        non_diagonal_coeffs[non_diagonal_gates.index(gates)] += self._coeffs[i]
+                    break
+
+        print(non_diagonal_coeffs)
+        print(non_diagonal_gates)
+
+        return all([True if i == 0 else False for i in non_diagonal_coeffs]) or len(non_diagonal_coeffs) == 0
 
 
 class VQECost:

--- a/pennylane/vqe/vqe.py
+++ b/pennylane/vqe/vqe.py
@@ -144,9 +144,6 @@ class Hamiltonian:
                         non_diagonal_coeffs[non_diagonal_gates.index(gates)] += self._coeffs[i]
                     break
 
-        print(non_diagonal_coeffs)
-        print(non_diagonal_gates)
-
         return all([True if i == 0 else False for i in non_diagonal_coeffs]) or len(non_diagonal_coeffs) == 0
 
 

--- a/pennylane/vqe/vqe.py
+++ b/pennylane/vqe/vqe.py
@@ -132,8 +132,13 @@ class Hamiltonian:
         non_diagonal_coeffs = []
         non_diagonal_obs = []
 
+        # Loops through each term of the Hamiltonian
         for i, term in enumerate(self._ops):
+
+            # Re-packages observables for consistent unpackaging
             gates = [term.name] if isinstance(term.name, str) else term.name
+
+            # Sums coefficients of like terms (provided they aren't diagonal)
             for g in gates:
                 if g not in diagonals:
                     if gates in non_diagonal_obs:
@@ -143,6 +148,7 @@ class Hamiltonian:
                         non_diagonal_coeffs.append(self._coeffs[i])
                     break
 
+        # If simplified Hamiltonian has no non-zero off diagonal terms, output True
         return (
             np.allclose(non_diagonal_coeffs, [0.0 for i in non_diagonal_coeffs])
             or len(non_diagonal_coeffs) == 0

--- a/pennylane/vqe/vqe.py
+++ b/pennylane/vqe/vqe.py
@@ -18,10 +18,7 @@ computations using PennyLane.
 # pylint: disable=too-many-arguments, too-few-public-methods
 import numpy as np
 import pennylane as qml
-import itertools
 from pennylane.operation import Observable, Tensor
-from pennylane.wires import Wires
-from pennylane.utils import decompose_hamiltonian
 
 
 OBS_MAP = {"PauliX": "X", "PauliY": "Y", "PauliZ": "Z", "Hadamard": "H", "Identity": "I"}
@@ -127,25 +124,27 @@ class Hamiltonian:
         r""" Maps the wires of a Hamiltonian to a new set of wires
 
         Args:
-           wire_map (dict) : A dictionary that assigns a new wire to a subset of wires tracked in the Hamiltonian
+           wire_map (dict) : A dictionary that assigns new wires to a subset of the wires tracked in the Hamiltonian
 
         Returns:
             ~.Hamiltonian:
         """
 
         obs = {
-            "Identity" : qml.Identity,
-            "PauliX" : qml.PauliX,
-            "PauliY" : qml.PauliY,
-            "PauliZ" : qml.PauliZ,
-            "Hadamard" : qml.Hadamard,
-            "Hermitian" : qml.Hermitian
+            "Identity": qml.Identity,
+            "PauliX": qml.PauliX,
+            "PauliY": qml.PauliY,
+            "PauliZ": qml.PauliZ,
+            "Hadamard": qml.Hadamard,
+            "Hermitian": qml.Hermitian,
         }
 
         if not isinstance(wire_map, dict):
-            raise ValueError("wire_map must be of type dict, got {}".format(type(wire_map).__name__))
+            raise ValueError(
+                "wire_map must be of type dict, got {}".format(type(wire_map).__name__)
+            )
 
-        f = lambda wire : wire_map[wire] if wire in wire_map.keys() else wire
+        f = lambda wire: wire_map[wire] if wire in wire_map.keys() else wire
         new_terms = []
 
         for term in self.ops:
@@ -166,95 +165,6 @@ class Hamiltonian:
             new_terms.append(qml.operation.Tensor(*tensor_term))
 
         return qml.Hamiltonian(self.coeffs, new_terms)
-
-
-    def decompose(self):
-        r""" Decomposes the terms of the Hamiltonian in terms of Pauli matrices
-
-        Returns:
-             qml.Hamiltonian: The decomposed Hamiltonian
-        """
-
-        terms = []
-
-        for i, term in enumerate(self.ops):
-
-            name = [term.name] if isinstance(term.name, str) else term.name
-            term = qml.operation.Tensor(term) if len(name) == 1 else term
-
-            if "Hermitian" in name:
-                reduced_terms = []
-                for j, t in enumerate(name):
-                    if t == "Hermitian":
-                        reduced = decompose_hamiltonian(term.obs[j].matrix)
-                        reduced_hamiltonian = qml.Hamiltonian(reduced[0], reduced[1])
-                        mapped = reduced_hamiltonian.map_wires({a : b for a, b in enumerate(term.obs[j].wires)})
-                        reduced_terms.append(list(zip(mapped.coeffs, mapped.ops)))
-
-                    else:
-                        reduced_terms.append([(1, term.obs[i])])
-
-                all_terms = list(itertools.product(*reduced_terms))
-
-                for a, b in enumerate(all_terms):
-                    all_terms[a] = ((b[0][0] * self.coeffs[i], b[0][1]), b[1])
-
-                terms.extend(all_terms)
-
-            else:
-                terms.append(((self.coeffs[i], term),))
-
-        final_coeffs = []
-        final_terms = []
-
-        for term in terms:
-            coeff = 1
-            tensor = []
-            for i in term:
-                coeff *= i[0]
-                tensor.append(i[1])
-
-            final_coeffs.append(coeff)
-            final_terms.append(qml.operation.Tensor(*tensor))
-
-        return qml.Hamiltonian(final_coeffs, final_terms)
-
-    def is_diagonal(self):
-        r"""Checks if a Hamiltonian is diagonal in the computational basis.
-
-        Returns:
-            bool: ``True`` if the Hamiltonian is diagonal in the computational basis, ``False`` otherwise.
-        """
-
-        non_diagonal_coeffs = []
-        non_diagonal_obs = []
-
-        # Defines the expanded Hamiltonian
-        exp_h = self.decompose()
-
-        # Loops through each term of the Hamiltonian
-        for i, term in enumerate(exp_h.ops):
-
-            # Prunes identity from all tensor products
-            term = term.prune() if isinstance(term, qml.operation.Tensor) else term
-
-            # Combines like terms (provided they are non-diagonal)
-            if bool(np.count_nonzero(term.matrix - np.diag(np.diagonal(term.matrix)))):
-
-                t = [term.matrix.tolist(), term.wires]
-
-                if t in non_diagonal_obs:
-                    non_diagonal_coeffs[non_diagonal_obs.index(t)] += self._coeffs[i]
-                else:
-                    non_diagonal_obs.append(t)
-                    non_diagonal_coeffs.append(self._coeffs[i])
-
-        # If simplified Hamiltonian has no non-zero off diagonal terms, output True
-        return (
-            np.allclose(non_diagonal_coeffs, [0.0 for i in non_diagonal_coeffs])
-            or len(non_diagonal_coeffs) == 0
-        )
-
 
 class VQECost:
     """Create a VQE cost function, i.e., a cost function returning the

--- a/pennylane/vqe/vqe.py
+++ b/pennylane/vqe/vqe.py
@@ -120,7 +120,6 @@ class Hamiltonian:
 
         return "\n+ ".join(terms)
 
-    @property
     def is_diagonal(self):
         r""" Checks if a Hamiltonian is diagonal in the computational basis.
 

--- a/pennylane/vqe/vqe.py
+++ b/pennylane/vqe/vqe.py
@@ -153,7 +153,6 @@ class Hamiltonian:
             or len(non_diagonal_coeffs) == 0
         )
 
-
 class VQECost:
     """Create a VQE cost function, i.e., a cost function returning the
     expectation value of a Hamiltonian.

--- a/pennylane/vqe/vqe.py
+++ b/pennylane/vqe/vqe.py
@@ -120,6 +120,25 @@ class Hamiltonian:
 
         return "\n+ ".join(terms)
 
+    @property
+    def is_diagonal(self):
+        r""" Checks if a Hamiltonian is diagonal in the computational basis.
+
+        Returns:
+            bool: ``True`` if the Hamiltonian is diagonal in the computational basis, ``False`` otherwise
+        """
+
+        # Combines non-diagonal like terms
+        non_diagonl_coeffs = []
+        non_diagonal_gates = []
+
+        for i in self._ops:
+            gates = [i.name] if isinstance(i, str) else i.name
+            for j in gates:
+                if j not in diagonals:
+                    if j not in non_diagonal_gates:
+                        non_diagonal_gates.append
+
 
 class VQECost:
     """Create a VQE cost function, i.e., a cost function returning the

--- a/pennylane/vqe/vqe.py
+++ b/pennylane/vqe/vqe.py
@@ -144,7 +144,7 @@ class Hamiltonian:
                         non_diagonal_coeffs[non_diagonal_gates.index(gates)] += self._coeffs[i]
                     break
 
-        return all([True if i == 0 else False for i in non_diagonal_coeffs]) or len(non_diagonal_coeffs) == 0
+        return all([not bool(i) for i in non_diagonal_coeffs]) or len(non_diagonal_coeffs) == 0
 
 
 class VQECost:

--- a/pennylane/vqe/vqe.py
+++ b/pennylane/vqe/vqe.py
@@ -131,20 +131,20 @@ class Hamiltonian:
         diagonals = ["PauliZ", "Identity"]
 
         non_diagonal_coeffs = []
-        non_diagonal_gates = []
+        non_diagonal_obs = []
 
         for i, term in enumerate(self._ops):
             gates = [term.name] if isinstance(term.name, str) else term.name
-            for j in gates:
-                if j not in diagonals:
-                    if gates not in non_diagonal_gates:
-                        non_diagonal_gates.append(gates)
-                        non_diagonal_coeffs.append(self._coeffs[i])
+            for g in gates:
+                if g not in diagonals:
+                    if gates in non_diagonal_obs:
+                        non_diagonal_coeffs[non_diagonal_obs.index(gates)] += self._coeffs[i]
                     else:
-                        non_diagonal_coeffs[non_diagonal_gates.index(gates)] += self._coeffs[i]
+                        non_diagonal_obs.append(gates)
+                        non_diagonal_coeffs.append(self._coeffs[i])
                     break
 
-        return all([not bool(i) for i in non_diagonal_coeffs]) or len(non_diagonal_coeffs) == 0
+        return np.allclose(non_diagonal_coeffs, [0.0 for i in non_diagonal_coeffs]) or len(non_diagonal_coeffs) == 0
 
 
 class VQECost:

--- a/test.py
+++ b/test.py
@@ -1,7 +1,0 @@
-import pennylane as qml
-import numpy as np
-
-H = qml.Hamiltonian([2, 1], [qml.Hermitian(np.array([[0, 1], [1, 0]]), 0) @ qml.Hermitian(np.array([[0, 1], [1, 0]]), 1), qml.PauliX(1)])
-#H = qml.Hamiltonian([1, 1], [qml.PauliX(0), qml.PauliX(1)])
-
-print(H.decompose())

--- a/test.py
+++ b/test.py
@@ -1,0 +1,7 @@
+import pennylane as qml
+import numpy as np
+
+H = qml.Hamiltonian([2, 1], [qml.Hermitian(np.array([[0, 1], [1, 0]]), 0) @ qml.Hermitian(np.array([[0, 1], [1, 0]]), 1), qml.PauliX(1)])
+#H = qml.Hamiltonian([1, 1], [qml.PauliX(0), qml.PauliX(1)])
+
+print(H.decompose())

--- a/tests/test_vqe.py
+++ b/tests/test_vqe.py
@@ -29,7 +29,8 @@ try:
     import tensorflow as tf
 
     if tf.__version__[0] == "1":
-        tf.enable_eager_execution()
+        #tf.enable_eager_execution()
+        pass
 
     from tensorflow import Variable
 except ImportError as e:
@@ -191,14 +192,15 @@ class TestHamiltonian:
             ([1, 1, 1], [qml.PauliZ(0) @ qml.PauliZ(1), qml.PauliZ(1), qml.PauliZ(2)], True),
             ([1, 1, 1], [qml.PauliZ(0), qml.PauliZ(1), qml.PauliX(2)], False),
             ([1, -1, 1], [qml.PauliX(0) @ qml.PauliX(1), qml.PauliX(0) @ qml.PauliX(1), qml.Identity(2)], True),
-            ([1, 1, 2], [qml.PauliX(0) @ qml.PauliZ(1), qml.PauliX(0) @ qml.PauliX(2), qml.Identity(2)], False)
+            ([1, -1, 2], [qml.PauliX(0) @ qml.PauliZ(1), qml.PauliX(0) @ qml.PauliZ(1) @ qml.Identity(2), qml.Identity(2)], True),
+            ([1, -1, 2], [qml.Hermitian(np.array([[0, 1], [1, 0]]), 0) @ qml.Identity(1), qml.PauliX(0), qml.PauliZ(1)], True)
         ]
     )
     def test_hamiltonian_is_diagonal(self, coeffs, ops, is_diagonal):
         """Tests that the is_diagonal method has the correct output"""
 
         H = qml.Hamiltonian(coeffs, ops)
-        assert H.is_diagonal == is_diagonal
+        assert H.is_diagonal() == is_diagonal
 
     @pytest.mark.parametrize("coeffs, ops", invalid_hamiltonians)
     def test_hamiltonian_invalid_init_exception(self, coeffs, ops):
@@ -225,7 +227,7 @@ class TestHamiltonian:
         with pytest.raises(ValueError, match="observables are not valid"):
             H = qml.vqe.Hamiltonian(coeffs, obs)
 
-
+'''
 class TestVQE:
     """Test the core functionality of the VQE module"""
 
@@ -499,3 +501,4 @@ class TestMultipleInterfaceIntegration:
 
         assert np.allclose(res, res_tf, atol=tol, rtol=0)
         assert np.allclose(res, res_torch, atol=tol, rtol=0)
+'''

--- a/tests/test_vqe.py
+++ b/tests/test_vqe.py
@@ -184,6 +184,22 @@ class TestHamiltonian:
         H = qml.vqe.Hamiltonian(coeffs, ops)
         assert H.terms == (coeffs, ops)
 
+    @pytest.mark.parametrize(
+        ("coeffs", "ops", "is_diagonal"),
+        [
+            ([1, 1, 1], [qml.PauliZ(0), qml.PauliZ(1), qml.PauliZ(2)], True),
+            ([1, 1, 1], [qml.PauliZ(0) @ qml.PauliZ(1), qml.PauliZ(1), qml.PauliZ(2)], True),
+            ([1, 1, 1], [qml.PauliZ(0), qml.PauliZ(1), qml.PauliX(2)], False),
+            ([1, -1, 1], [qml.PauliX(0) @ qml.PauliX(1), qml.PauliX(0) @ qml.PauliX(1), qml.Identity(2)], True),
+            ([1, 1, 2], [qml.PauliX(0) @ qml.PauliZ(1), qml.PauliX(0) @ qml.PauliX(2), qml.Identity(2)], False)
+        ]
+    )
+    def test_hamiltonian_is_diagonal(self, coeffs, ops, is_diagonal):
+        """Tests that the is_diagonal method has the correct output"""
+
+        H = qml.Hamiltonian(coeffs, ops)
+        assert H.is_diagonal == is_diagonal
+
     @pytest.mark.parametrize("coeffs, ops", invalid_hamiltonians)
     def test_hamiltonian_invalid_init_exception(self, coeffs, ops):
         """Tests that an exception is raised when giving an invalid

--- a/tests/test_vqe.py
+++ b/tests/test_vqe.py
@@ -29,8 +29,7 @@ try:
     import tensorflow as tf
 
     if tf.__version__[0] == "1":
-        #tf.enable_eager_execution()
-        pass
+        tf.enable_eager_execution()
 
     from tensorflow import Variable
 except ImportError as e:
@@ -227,7 +226,6 @@ class TestHamiltonian:
         with pytest.raises(ValueError, match="observables are not valid"):
             H = qml.vqe.Hamiltonian(coeffs, obs)
 
-'''
 class TestVQE:
     """Test the core functionality of the VQE module"""
 
@@ -501,4 +499,3 @@ class TestMultipleInterfaceIntegration:
 
         assert np.allclose(res, res_tf, atol=tol, rtol=0)
         assert np.allclose(res, res_torch, atol=tol, rtol=0)
-'''


### PR DESCRIPTION
**Note:** The purpose of this PR has changed, please read new description and ignore changes in old commits.

**Context:**

**Description of the Change:**

Adds a new method to the `qml.Hamiltonian` class that maps a Hamiltonian to a new set of wires. For instance, if we define the following Hamiltonian:

``` python

import pennylane as qml

coeffs = [1, 1]
ops = [qml.PauliZ(0), qml.PauliX(0) @ qml.PauliX(1)]

hamiltonian = qml.Hamiltonian(coeffs, ops)

```

we will then have:

```
new_hamiltonian = hamiltonian.map_wires({0:3, 1:7})
```

```
>>> print(hamiltonian)
(1.0) [Z3] + (1.0) [X3 X7]
```

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
