### PR TITLE
Leftover consecutive wires assumption in map and Tensor.prune

### DIFF
--- a/pennylane/collections/map.py
+++ b/pennylane/collections/map.py
@@ -122,7 +122,7 @@ def map(
         if not isinstance(obs, Observable):
             raise ValueError("Could not create QNodes. Some or all observables are not valid.")
 
-        wires = list(range(dev.num_wires))
+        wires = dev.register
 
         # Note: in the following template definition, we pass the observable, measurement,
         # and wires as *default arguments* to named parameters. This is to avoid

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -1192,7 +1192,7 @@ class Tensor(Observable):
         """
         if len(self.non_identity_obs) == 0:
             # Return a single Identity as the tensor only contains Identities
-            obs = qml.Identity(0)
+            obs = qml.Identity(self.wires[0])
         elif len(self.non_identity_obs) == 1:
             obs = self.non_identity_obs[0]
         else:

--- a/pennylane/utils.py
+++ b/pennylane/utils.py
@@ -119,6 +119,11 @@ def _flatten(x):
     """
     if isinstance(x, np.ndarray):
         yield from _flatten(x.flat)  # should we allow object arrays? or just "yield from x.flat"?
+    elif isinstance(x, qml.wires.Wires):
+        # Reursive calls to flatten `Wires` will cause infinite recursion (`Wires` atoms are `Wires`).
+        # Since Wires are always flat, just yield.
+        for item in x:
+            yield item
     elif isinstance(x, Iterable) and not isinstance(x, (str, bytes)):
         for item in x:
             yield from _flatten(item)


### PR DESCRIPTION
**Context:**
Tiny PR into Maria's Wires PR for potential bug fixes. There are two places in the code that still assumes consecutive int wires which could affect qchem's adaptation of custom Wires. Making this separate from qchem since it touches the core codes.

**Description of the Change:**

1. The QNode `map` function still has a ` wires = list(range(dev.num_wires))` line. Replaced with `wires = dev.register`.
2. The `Tensor.prune()` function ignores custom Wires and uses int wire `0` if there are no non-identity. Replaced with `self.wires[0]`.

However, a few tests are failing after the change, all with `maximum recursion depth exceded` error. They all seem to stem from the function `utils._flatten()` where it tries to recursively flatten the new `Wires` class whose elements are still singleton `Wires` and thus causes infinite recursion. The flatten function is called during autograd.

This is fixed by treating `Wires` differently in `_flatten` since they are by design flat. Not sure if this is the correct way to go, or even why wires need to be flattened in the first place 😛 

**Benefits:**
Potential bug fixes.

**Possible Drawbacks:**
Risk of introducing even more bugs.

**Related GitHub Issues:**
