### PR TITLE
Add Toffoli gate to operations page

### DIFF
--- a/doc/introduction/operations.rst
+++ b/doc/introduction/operations.rst
@@ -69,6 +69,7 @@ Qubit gates
     ~pennylane.S
     ~pennylane.SWAP
     ~pennylane.T
+    ~pennylane.Toffoli
 
 :html:`</div>`
 


### PR DESCRIPTION
Quick PR that adds the Toffoli gate to the ops page in the docs.