### PR TITLE
[WIRES] Sort observables in Tensor class

### DIFF
--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -1065,11 +1065,12 @@ class Tensor(Observable):
         # observable should be Z^{\otimes n}
         self._eigvals_cache = pauli_eigs(len(self.wires))
 
+        # Sort observables lexicographically by the strings of the wire labels
         # TODO: check for edge cases of the sorting, e.g. Tensor(Hermitian(obs, wires=[0, 2]),
         # Hermitian(obs, wires=[1, 3, 4])
         # Sorting the observables based on wires, so that the order of
         # the eigenvalues is correct
-        obs_sorted = sorted(self.obs, key=lambda x: x.wires.tolist())
+        obs_sorted = sorted(self.obs, key=lambda x: [str(l) for l in x.wires.labels])
 
         # check if there are any non-standard observables (such as Identity)
         if set(self.name) - standard_observables:
@@ -1143,7 +1144,7 @@ class Tensor(Observable):
         """
         # group the observables based on what wires they act on
         U_list = []
-        for _, g in itertools.groupby(self.obs, lambda x: x.wires.tolist()):
+        for _, g in itertools.groupby(self.obs, lambda x: x.wires.labels):
             # extract the matrices of each diagonalizing gate
             mats = [i.matrix for i in g]
 

--- a/pennylane/wires.py
+++ b/pennylane/wires.py
@@ -389,19 +389,3 @@ class Wires(Sequence):
                     unique.append(wire)
 
         return Wires(unique)
-
-    @staticmethod
-    def sort_wires():
-        """
-
-        For example:
-
-        Args:
-
-        Returns:
-
-        """
-
-
-
-        return None

--- a/pennylane/wires.py
+++ b/pennylane/wires.py
@@ -361,3 +361,19 @@ class Wires(Sequence):
                     unique.append(wire)
 
         return Wires(unique)
+
+    @staticmethod
+    def sort_wires():
+        """
+
+        For example:
+
+        Args:
+
+        Returns:
+
+        """
+
+
+
+        return None


### PR DESCRIPTION
This PR temporarily solves the issue of how to order observables with the new wires management with a minimal solution.

Since the Tensor class will be redesigned soon, we limit ourselves here to implement a unique order by list comparison, which sorts lists lexicographically.