### PR TITLE
Add pytest.ini file to device test suite in new folder

### DIFF
--- a/pennylane/devices/tests/pytest.ini
+++ b/pennylane/devices/tests/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    skip_unsupported: skip a test if it uses an operation unsupported on a device


### PR DESCRIPTION
Re-add the pytest.ini file that was accidentally deleted.