### PR TITLE
Increase precision of unitary in device tests

### DIFF
--- a/pennylane/devices/tests/test_gates.py
+++ b/pennylane/devices/tests/test_gates.py
@@ -129,8 +129,14 @@ theta = 0.8364
 phi = -0.1234
 U = np.array(
     [
-        [np.cos(theta/2)*np.exp(np.complex(0, -phi/2)), -np.sin(theta/2)*np.exp(np.complex(0, phi/2))],
-        [np.sin(theta/2)*np.exp(np.complex(0, -phi/2)), np.cos(theta/2)*np.exp(np.complex(0, phi/2))],
+        [
+            np.cos(theta / 2) * np.exp(np.complex(0, -phi / 2)),
+            -np.sin(theta / 2) * np.exp(np.complex(0, phi / 2)),
+        ],
+        [
+            np.sin(theta / 2) * np.exp(np.complex(0, -phi / 2)),
+            np.cos(theta / 2) * np.exp(np.complex(0, phi / 2)),
+        ],
     ]
 )
 

--- a/pennylane/devices/tests/test_gates.py
+++ b/pennylane/devices/tests/test_gates.py
@@ -125,10 +125,12 @@ two_qubit_multi_param = [(qml.CRot, crot)]
 three_qubit = [(qml.Toffoli, toffoli), (qml.CSWAP, CSWAP)]
 
 # single qubit unitary matrix
+theta = 0.8364
+phi = -0.1234
 U = np.array(
     [
-        [0.83645892 - 0.40533293j, -0.20215326 + 0.30850569j],
-        [-0.23889780 - 0.28101519j, -0.88031770 - 0.29832709j],
+        [np.cos(theta/2)*np.exp(np.complex(0, -phi/2)), -np.sin(theta/2)*np.exp(np.complex(0, phi/2))],
+        [np.sin(theta/2)*np.exp(np.complex(0, -phi/2)), np.cos(theta/2)*np.exp(np.complex(0, phi/2))],
     ]
 )
 


### PR DESCRIPTION
The finite precision of a unitary in the shared device tests causes some plugins to fail the tests. 

This PR constructs the unitary from two angles to allow for very high precision.