### PR TITLE
Fixes the OpenQASM serializer to work with the wires refactor

### DIFF
--- a/pennylane/circuit_graph.py
+++ b/pennylane/circuit_graph.py
@@ -309,7 +309,7 @@ class CircuitGraph:
         # create the QASM code representing the operations
         for op in decomposed_ops:
             gate = OPENQASM_GATES[op.name]
-            wires = ",".join(["q[{}]".format(w) for w in op.wires.tolist()])
+            wires = ",".join(["q[{}]".format(self.wires.index(w)) for w in op.wires.tolist()])
             params = ""
 
             if op.num_params > 0:


### PR DESCRIPTION
**Context:** The OpenQASM specification requires that all register indices are consecutive integers.

**Description of the Change:**

* Modifies the `to_openqasm()` method to serialize the index of each operation wires, rather than the label

* Fixes the corresponding tests

**Benefits:** n/a

**Possible Drawbacks:** n/a

**Related GitHub Issues:** n/a
