### PR TITLE
Fix test suite which fails for default.qubit when in non-analytic mode

### DIFF
--- a/pennylane/devices/tests/test_wires.py
+++ b/pennylane/devices/tests/test_wires.py
@@ -62,4 +62,4 @@ class TestWiresIntegration:
         circuit1 = circuit_factory(dev1, wires1)
         circuit2 = circuit_factory(dev2, wires2)
 
-        assert np.allclose(circuit1(), circuit2(), tol(dev1.analytic))
+        assert np.allclose(circuit1(), circuit2(), atol=tol(dev1.analytic))


### PR DESCRIPTION
The device test suite currently fails when in non-analytic mode using `default.qubit`:
` pytest pennylane/devices/tests/ --analytic False --device default.qubit`
This is because an `np.allclose()` assert needs the tolerance updated to `atol`.