### PR TITLE
Fixed Error in code on qml.VQECost page #751

### DIFF
--- a/pennylane/vqe/vqe.py
+++ b/pennylane/vqe/vqe.py
@@ -185,7 +185,7 @@ class VQECost:
 
     Next, we can define the cost function:
 
-    >>> cost = qml.VQECost(ansatz, hamiltonian, dev, interface="torch")
+    >>> cost = qml.VQECost(ansatz, H, dev, interface="torch")
     >>> params = torch.rand([4, 3])
     >>> cost(params)
     tensor(0.0245, dtype=torch.float64)


### PR DESCRIPTION
**Context:** In the last cell on qml.VQECost documentation page, code is wrong. In place of hamiltonian it should be H which is already declared above the last cell code block

**Description of the Change:** Changed `hamiltonian` to `H`

**Benefits:** Fixes the code bug

**Possible Drawbacks:** NA

**Related GitHub Issues:** #751 
