### PR TITLE
Use math.isclose for normalization

### DIFF
--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -18,14 +18,14 @@ It implements the necessary :class:`~pennylane._device.Device` methods as well a
 :mod:`qubit operations <pennylane.ops.qubit>`, and provides a very simple pure state
 simulation of a qubit-based quantum circuit architecture.
 """
-import itertools
 import functools
+import itertools
+import math
 from string import ascii_letters as ABC
 
 import numpy as np
-import math
 
-from pennylane import QubitDevice, DeviceError, QubitStateVector, BasisState
+from pennylane import BasisState, DeviceError, QubitDevice, QubitStateVector
 from pennylane.operation import DiagonalOperation
 
 ABC_ARRAY = np.array(list(ABC))

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -23,6 +23,7 @@ import functools
 from string import ascii_letters as ABC
 
 import numpy as np
+import math
 
 from pennylane import QubitDevice, DeviceError, QubitStateVector, BasisState
 from pennylane.operation import DiagonalOperation
@@ -195,7 +196,7 @@ class DefaultQubit(QubitDevice):
         if state.ndim != 1 or n_state_vector != 2 ** len(device_wires):
             raise ValueError("State vector must be of length 2**wires.")
 
-        if not np.allclose(np.linalg.norm(state, ord=2), 1.0, atol=tolerance):
+        if not math.isclose(np.linalg.norm(state, ord=2), 1.0, abs_tol=tolerance):
             raise ValueError("Sum of amplitudes-squared does not equal one.")
 
         if (

--- a/pennylane/templates/embeddings/amplitude.py
+++ b/pennylane/templates/embeddings/amplitude.py
@@ -16,14 +16,12 @@ Contains the ``AmplitudeEmbedding`` template.
 """
 # pylint: disable-msg=too-many-branches,too-many-arguments,protected-access
 import math
+
 import numpy as np
-from pennylane.templates.decorator import template
+
 from pennylane.ops import QubitStateVector
-from pennylane.templates.utils import (
-    check_shape,
-    check_type,
-    get_shape,
-)
+from pennylane.templates.decorator import template
+from pennylane.templates.utils import check_shape, check_type, get_shape
 from pennylane.variable import Variable
 from pennylane.wires import Wires
 

--- a/pennylane/templates/embeddings/amplitude.py
+++ b/pennylane/templates/embeddings/amplitude.py
@@ -219,7 +219,7 @@ def AmplitudeEmbedding(features, wires, pad=None, normalize=False):
     else:
         norm = np.sum(np.abs(features) ** 2)
 
-    if not np.isclose(norm, 1.0, atol=TOLERANCE):
+    if not math.isclose(norm, 1.0, abs_tol=TOLERANCE):
         if normalize or pad:
             features = features / math.sqrt(norm)
         else:

--- a/pennylane/templates/state_preparations/mottonen.py
+++ b/pennylane/templates/state_preparations/mottonen.py
@@ -15,11 +15,11 @@ r"""
 Contains the ``MottonenStatePreparation`` template.
 """
 import math
+
 import numpy as np
 from scipy import sparse
 
 import pennylane as qml
-
 from pennylane.templates.decorator import template
 from pennylane.templates.utils import check_shape, get_shape
 from pennylane.variable import Variable

--- a/pennylane/templates/state_preparations/mottonen.py
+++ b/pennylane/templates/state_preparations/mottonen.py
@@ -266,7 +266,7 @@ def MottonenStatePreparation(state_vector, wires):
         norm = np.sum(np.abs(state_vector_values) ** 2)
     else:
         norm = np.sum(np.abs(state_vector) ** 2)
-    if not np.isclose(norm, 1.0, atol=1e-3):
+    if not math.isclose(norm, 1.0, abs_tol=1e-3):
         raise ValueError("'state_vector' has to be of length 1.0, got {}".format(norm))
 
     #######################


### PR DESCRIPTION
**Context:**
https://github.com/PennyLaneAI/pennylane/issues/534 addressed a problem where 

**Description of the Change:**
Turns to using `math.isclose` instead of `np.isclose` in the main codebase of PennyLane.

**Benefits:**
No unexpected cases would arise from the fact that `np.isclose` is [not symmetric in terms of its arguments](https://github.com/numpy/numpy/issues/10161#issue-279344255).

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
https://github.com/PennyLaneAI/pennylane/issues/534