### PR TITLE
Minor refactor of the 'obs' module

### DIFF
--- a/qchem/CHANGELOG.md
+++ b/qchem/CHANGELOG.md
@@ -45,6 +45,18 @@
   ```
 <h3>Improvements</h3>
 
+* The naming convention used in the `structure` module has been propagated
+  to the `obs` module.
+  [(#)]()
+
+  The changes include:
+
+  - `n_electrons` renamed to `electrons`.
+  - `n_orbitals` renamed to `orbitals`.
+
+  In addition, the argument `orbitals` is used now to pass the number of *spin*
+  orbitals.
+
 * The functions involved in observable conversions from/to OpenFermion now accept
   a new `wires` argument that can be used to specify the qubits-to-wires mapping
   when custom wires are used in Pennylane ansatz.

--- a/qchem/CHANGELOG.md
+++ b/qchem/CHANGELOG.md
@@ -47,7 +47,7 @@
 
 * The naming convention used in the `structure` module has been propagated
   to the `obs` module.
-  [(#)]()
+  [(#759)](https://github.com/PennyLaneAI/pennylane/pull/759)
 
   The changes include:
 

--- a/qchem/pennylane_qchem/qchem/obs.py
+++ b/qchem/pennylane_qchem/qchem/obs.py
@@ -381,7 +381,7 @@ def particle_number(orbitals, mapping="jordan_wigner", wires=None):
 
         \hat{N} = \sum_\alpha \hat{c}_\alpha^\dagger \hat{c}_\alpha,
 
-    where the index :math:`\alpha` runs over the basis of single-particle orbitals
+    where the index :math:`\alpha` runs over the basis of single-particle states
     :math:`\vert \alpha \rangle`, and the operators :math:`\hat{c}^\dagger` and :math:`\hat{c}` are
     the particle creation and annihilation operators, respectively.
 

--- a/qchem/pennylane_qchem/qchem/obs.py
+++ b/qchem/pennylane_qchem/qchem/obs.py
@@ -95,7 +95,7 @@ def _spin2_matrix_elements(sz):
     return np.vstack([diag, off_diag])
 
 
-def spin2(n_electrons, n_orbitals, mapping="jordan_wigner", wires=None):
+def spin2(electrons, orbitals, mapping="jordan_wigner", wires=None):
     r"""Computes the total spin operator :math:`\hat{S}^2`.
 
     The total spin operator :math:`\hat{S}^2` is given by
@@ -127,10 +127,10 @@ def spin2(n_electrons, n_orbitals, mapping="jordan_wigner", wires=None):
     and annihilation operators, respectively.
 
     Args:
-        n_electrons (int): Number of electrons. If an active space is defined, 'n_electrons'
-            is the number of active electrons.
-        n_orbitals (int): Number of orbitals. If an active space is defined, 'n_orbitals'
-            is the number of active orbitals.
+        electrons (int): Number of electrons. If an active space is defined, this is
+            the number of active electrons.
+        orbitals (int): Number of spin-orbitals. If an active space is defined,  this is
+            the number of active spin-orbitals.
         mapping (str): Specifies the transformation to map the fermionic operator to the
             Pauli basis. Input values can be ``'jordan_wigner'`` or ``'bravyi_kitaev'``.
         wires (Wires, list, tuple, dict): Custom wire mapping used to convert the qubit operator
@@ -145,9 +145,9 @@ def spin2(n_electrons, n_orbitals, mapping="jordan_wigner", wires=None):
 
     **Example**
 
-    >>> n_electrons = 2
-    >>> n_orbitals = 2
-    >>> S2 = spin2(n_electrons, n_orbitals, mapping="jordan_wigner")
+    >>> electrons = 2
+    >>> orbitals = 4
+    >>> S2 = spin2(electrons, orbitals, mapping="jordan_wigner")
     >>> print(S2)
     (0.75) [I0]
     + (0.375) [Z1]
@@ -169,7 +169,7 @@ def spin2(n_electrons, n_orbitals, mapping="jordan_wigner", wires=None):
     + (0.125) [X0 X1 Y2 Y3]
     + (0.125) [X0 Y1 X2 Y3]
 
-    >>> S2 = spin2(n_electrons, n_orbitals, mapping="jordan_wigner", wires=['w0','w1','w2','w3'])
+    >>> S2 = spin2(electrons, orbitals, mapping="jordan_wigner", wires=['w0','w1','w2','w3'])
     >>> print(S2)
     (0.75) [Iw0]
     + (0.375) [Zw1]
@@ -192,21 +192,21 @@ def spin2(n_electrons, n_orbitals, mapping="jordan_wigner", wires=None):
     + (0.125) [Xw0 Yw1 Xw2 Yw3]
     """
 
-    if n_electrons <= 0:
+    if electrons <= 0:
         raise ValueError(
-            "'n_electrons' must be greater than 0; got for 'n_electrons' {}".format(n_electrons)
+            "'electrons' must be greater than 0; got for 'electrons' {}".format(electrons)
         )
 
-    if n_orbitals <= 0:
+    if orbitals <= 0:
         raise ValueError(
-            "'n_orbitals' must be greater than 0; got for 'n_orbitals' {}".format(n_orbitals)
+            "'orbitals' must be greater than 0; got for 'orbitals' {}".format(orbitals)
         )
 
-    sz = np.where(np.arange(2 * n_orbitals) % 2 == 0, 0.5, -0.5)
+    sz = np.where(np.arange(orbitals) % 2 == 0, 0.5, -0.5)
 
     table = _spin2_matrix_elements(sz)
 
-    return observable(table, init_term=3 / 4 * n_electrons, mapping=mapping, wires=wires)
+    return observable(table, init_term=3 / 4 * electrons, mapping=mapping, wires=wires)
 
 
 def observable(me_table, init_term=0, mapping="jordan_wigner", wires=None):
@@ -318,7 +318,7 @@ def observable(me_table, init_term=0, mapping="jordan_wigner", wires=None):
     return structure.convert_observable(jordan_wigner(mb_obs), wires=wires)
 
 
-def spin_z(n_orbitals, mapping="jordan_wigner", wires=None):
+def spin_z(orbitals, mapping="jordan_wigner", wires=None):
     r"""Computes the total spin projection operator :math:`\hat{S}_z` in the Pauli basis.
 
     The total spin projection operator :math:`\hat{S}_z` is given by
@@ -334,8 +334,8 @@ def spin_z(n_orbitals, mapping="jordan_wigner", wires=None):
     are the particle creation and annihilation operators, respectively.
 
     Args:
-        n_orbitals (str): Number of orbitals. If an active space is defined, 'n_orbitals'
-            is the number of active orbitals.
+        orbitals (str): Number of spin-orbitals. If an active space is defined, this is
+            the number of active spin-orbitals.
         mapping (str): Specifies the transformation to map the fermionic operator to the
             Pauli basis. Input values can be ``'jordan_wigner'`` or ``'bravyi_kitaev'``.
         wires (Wires, list, tuple, dict): Custom wire mapping used to convert the qubit operator
@@ -350,8 +350,8 @@ def spin_z(n_orbitals, mapping="jordan_wigner", wires=None):
 
     **Example**
 
-    >>> n_orbitals = 2
-    >>> Sz = spin_z(n_orbitals, mapping="jordan_wigner")
+    >>> orbitals = 4
+    >>> Sz = spin_z(orbitals, mapping="jordan_wigner")
     >>> print(Sz)
     (-0.25) [Z0]
     + (0.25) [Z1]
@@ -359,20 +359,19 @@ def spin_z(n_orbitals, mapping="jordan_wigner", wires=None):
     + (0.25) [Z3]
     """
 
-    if n_orbitals <= 0:
+    if orbitals <= 0:
         raise ValueError(
-            "'n_orbitals' must be greater than 0; got for 'n_orbitals' {}".format(n_orbitals)
+            "'orbitals' must be greater than 0; got for 'orbitals' {}".format(orbitals)
         )
 
-    n_spin_orbs = 2 * n_orbitals
-    r = np.arange(n_spin_orbs)
-    sz_orb = np.where(np.arange(n_spin_orbs) % 2 == 0, 0.5, -0.5)
+    r = np.arange(orbitals)
+    sz_orb = np.where(np.arange(orbitals) % 2 == 0, 0.5, -0.5)
     table = np.vstack([r, r, sz_orb]).T
 
     return observable(table, mapping=mapping, wires=wires)
 
 
-def particle_number(n_orbitals, mapping="jordan_wigner", wires=None):
+def particle_number(orbitals, mapping="jordan_wigner", wires=None):
     r"""Computes the particle number operator :math:`\hat{N}=\sum_\alpha \hat{n}_\alpha`
     in the Pauli basis.
 
@@ -387,8 +386,8 @@ def particle_number(n_orbitals, mapping="jordan_wigner", wires=None):
     the particle creation and annihilation operators, respectively.
 
     Args:
-        n_orbitals (int): Number of orbitals. If an active space is defined, 'n_orbitals'
-            is the number of active orbitals.
+        orbitals (int): Number of spin-orbitals. If an active space is defined, this is
+            the number of active spin-orbitals.
         mapping (str): Specifies the transformation to map the fermionic operator to the
             Pauli basis. Input values can be ``'jordan_wigner'`` or ``'bravyi_kitaev'``.
         wires (Wires, list, tuple, dict): Custom wire mapping used to convert the qubit operator
@@ -403,15 +402,15 @@ def particle_number(n_orbitals, mapping="jordan_wigner", wires=None):
 
     **Example**
 
-    >>> n_orbitals = 2
-    >>> N = particle_number(n_orbitals, mapping="jordan_wigner")
+    >>> orbitals = 4
+    >>> N = particle_number(orbitals, mapping="jordan_wigner")
     >>> print(N)
     (2.0) [I0]
     + (-0.5) [Z0]
     + (-0.5) [Z1]
     + (-0.5) [Z2]
     + (-0.5) [Z3]
-    >>> N = particle_number(n_orbitals, mapping="jordan_wigner", wires=['w0','w1','w2','w3'])
+    >>> N = particle_number(orbitals, mapping="jordan_wigner", wires=['w0','w1','w2','w3'])
     >>> print(N)
     (2.0) [Iw0]
     + (-0.5) [Zw0]
@@ -420,14 +419,13 @@ def particle_number(n_orbitals, mapping="jordan_wigner", wires=None):
     + (-0.5) [Zw3]
     """
 
-    if n_orbitals <= 0:
+    if orbitals <= 0:
         raise ValueError(
-            "'n_orbitals' must be greater than 0; got for 'n_orbitals' {}".format(n_orbitals)
+            "'orbitals' must be greater than 0; got for 'orbitals' {}".format(orbitals)
         )
 
-    n_spin_orbs = 2 * n_orbitals
-    r = np.arange(n_spin_orbs)
-    table = np.vstack([r, r, np.ones([n_spin_orbs])]).T
+    r = np.arange(orbitals)
+    table = np.vstack([r, r, np.ones([orbitals])]).T
 
     return observable(table, mapping=mapping, wires=wires)
 

--- a/qchem/pennylane_qchem/qchem/obs.py
+++ b/qchem/pennylane_qchem/qchem/obs.py
@@ -129,7 +129,7 @@ def spin2(electrons, orbitals, mapping="jordan_wigner", wires=None):
     Args:
         electrons (int): Number of electrons. If an active space is defined, this is
             the number of active electrons.
-        orbitals (int): Number of spin-orbitals. If an active space is defined,  this is
+        orbitals (int): Number of *spin* orbitals. If an active space is defined,  this is
             the number of active spin-orbitals.
         mapping (str): Specifies the transformation to map the fermionic operator to the
             Pauli basis. Input values can be ``'jordan_wigner'`` or ``'bravyi_kitaev'``.
@@ -334,7 +334,7 @@ def spin_z(orbitals, mapping="jordan_wigner", wires=None):
     are the particle creation and annihilation operators, respectively.
 
     Args:
-        orbitals (str): Number of spin-orbitals. If an active space is defined, this is
+        orbitals (str): Number of *spin* orbitals. If an active space is defined, this is
             the number of active spin-orbitals.
         mapping (str): Specifies the transformation to map the fermionic operator to the
             Pauli basis. Input values can be ``'jordan_wigner'`` or ``'bravyi_kitaev'``.
@@ -386,7 +386,7 @@ def particle_number(orbitals, mapping="jordan_wigner", wires=None):
     the particle creation and annihilation operators, respectively.
 
     Args:
-        orbitals (int): Number of spin-orbitals. If an active space is defined, this is
+        orbitals (int): Number of *spin* orbitals. If an active space is defined, this is
             the number of active spin-orbitals.
         mapping (str): Specifies the transformation to map the fermionic operator to the
             Pauli basis. Input values can be ``'jordan_wigner'`` or ``'bravyi_kitaev'``.

--- a/qchem/tests/test_particle_number_obs.py
+++ b/qchem/tests/test_particle_number_obs.py
@@ -63,15 +63,15 @@ terms_lih_anion_bk = {
 
 
 @pytest.mark.parametrize(
-    ("n_orbitals", "mapping", "terms_exp"),
+    ("orbitals", "mapping", "terms_exp"),
     [
-        (7, "JORDAN_wigner", terms_h20_jw_full),
-        (3, "JORDAN_wigner", terms_h20_jw_23),
-        (4, "bravyi_KITAEV", terms_h20_bk_44),
-        (5, "bravyi_KITAEV", terms_lih_anion_bk),
+        (14, "JORDAN_wigner", terms_h20_jw_full),
+        (6, "JORDAN_wigner", terms_h20_jw_23),
+        (8, "bravyi_KITAEV", terms_h20_bk_44),
+        (10, "bravyi_KITAEV", terms_lih_anion_bk),
     ],
 )
-def test_particle_number_observable(n_orbitals, mapping, terms_exp, custom_wires, monkeypatch):
+def test_particle_number_observable(orbitals, mapping, terms_exp, custom_wires, monkeypatch):
     r"""Tests the correctness of the particle number observable :math:`\hat{N}` generated
     by the ``'particle_number'`` function.
 
@@ -80,7 +80,7 @@ def test_particle_number_observable(n_orbitals, mapping, terms_exp, custom_wires
     something useful to the users as well.
     """
 
-    N = qchem.particle_number(n_orbitals, mapping=mapping, wires=custom_wires)
+    N = qchem.particle_number(orbitals, mapping=mapping, wires=custom_wires)
 
     particle_number_qubit_op = QubitOperator()
     monkeypatch.setattr(particle_number_qubit_op, "terms", terms_exp)
@@ -89,12 +89,12 @@ def test_particle_number_observable(n_orbitals, mapping, terms_exp, custom_wires
 
 
 @pytest.mark.parametrize(
-    ("n_orbitals", "msg_match"),
-    [(-3, "'n_orbitals' must be greater than 0"), (0, "'n_orbitals' must be greater than 0"),],
+    ("orbitals", "msg_match"),
+    [(-3, "'orbitals' must be greater than 0"), (0, "'orbitals' must be greater than 0"),],
 )
-def test_exception_particle_number(n_orbitals, msg_match):
+def test_exception_particle_number(orbitals, msg_match):
     """Test that the function `'particle_number'` throws an exception if the
     number of orbitals is less than zero."""
 
     with pytest.raises(ValueError, match=msg_match):
-        qchem.particle_number(n_orbitals)
+        qchem.particle_number(orbitals)

--- a/qchem/tests/test_s2_obs.py
+++ b/qchem/tests/test_s2_obs.py
@@ -173,10 +173,10 @@ terms_bk = {
 
 
 @pytest.mark.parametrize(
-    ("n_electrons", "n_orbitals", "mapping", "terms_exp"),
-    [(2, 2, "JORDAN_wigner", terms_jw), (3, 3, "bravyi_KITAEV", terms_bk),],
+    ("electrons", "orbitals", "mapping", "terms_exp"),
+    [(2, 4, "JORDAN_wigner", terms_jw), (3, 6, "bravyi_KITAEV", terms_bk),],
 )
-def test_spin2(n_electrons, n_orbitals, mapping, terms_exp, monkeypatch):
+def test_spin2(electrons, orbitals, mapping, terms_exp, monkeypatch):
     r"""Tests the correctness of the total spin observable :math:`\hat{S}^2`
     built by the function `'spin2'`.
 
@@ -185,7 +185,7 @@ def test_spin2(n_electrons, n_orbitals, mapping, terms_exp, monkeypatch):
     something useful to the users as well.
     """
 
-    S2 = qchem.spin2(n_electrons, n_orbitals, mapping=mapping)
+    S2 = qchem.spin2(electrons, orbitals, mapping=mapping)
 
     S2_qubit_op = QubitOperator()
     monkeypatch.setattr(S2_qubit_op, "terms", terms_exp)
@@ -194,17 +194,17 @@ def test_spin2(n_electrons, n_orbitals, mapping, terms_exp, monkeypatch):
 
 
 @pytest.mark.parametrize(
-    ("n_electrons", "n_orbitals", "msg_match"),
+    ("electrons", "orbitals", "msg_match"),
     [
-        (-2, 2, "'n_electrons' must be greater than 0"),
-        (0, 2, "'n_electrons' must be greater than 0"),
-        (3, -3, "'n_orbitals' must be greater than 0"),
-        (3, 0, "'n_orbitals' must be greater than 0"),
+        (-2, 4, "'electrons' must be greater than 0"),
+        (0, 4, "'electrons' must be greater than 0"),
+        (3, -6, "'orbitals' must be greater than 0"),
+        (3, 0, "'orbitals' must be greater than 0"),
     ],
 )
-def test_exception_spin2(n_electrons, n_orbitals, msg_match):
+def test_exception_spin2(electrons, orbitals, msg_match):
     """Test that the function `'spin2'` throws an exception if the
     number of electrons or the number of orbitals is less than zero."""
 
     with pytest.raises(ValueError, match=msg_match):
-        qchem.spin2(n_electrons, n_orbitals)
+        qchem.spin2(electrons, orbitals)

--- a/qchem/tests/test_sz_obs.py
+++ b/qchem/tests/test_sz_obs.py
@@ -26,10 +26,10 @@ terms_2_bk = {
 
 
 @pytest.mark.parametrize(
-    ("n_orbitals", "mapping", "terms_exp"),
-    [(2, "JORDAN_wigner", terms_1_jw), (3, "bravyi_KITAEV", terms_2_bk),],
+    ("orbitals", "mapping", "terms_exp"),
+    [(4, "JORDAN_wigner", terms_1_jw), (6, "bravyi_KITAEV", terms_2_bk),],
 )
-def test_spin_z(n_orbitals, mapping, terms_exp, monkeypatch):
+def test_spin_z(orbitals, mapping, terms_exp, monkeypatch):
     r"""Tests the correctness of the :math:`\hat{S}_z` observable built by the
     function `'spin_z'`.
 
@@ -38,7 +38,7 @@ def test_spin_z(n_orbitals, mapping, terms_exp, monkeypatch):
     useful to the users as well.
     """
 
-    Sz = qchem.spin_z(n_orbitals, mapping=mapping)
+    Sz = qchem.spin_z(orbitals, mapping=mapping)
 
     Sz_qubit_op = QubitOperator()
     monkeypatch.setattr(Sz_qubit_op, "terms", terms_exp)
@@ -47,12 +47,12 @@ def test_spin_z(n_orbitals, mapping, terms_exp, monkeypatch):
 
 
 @pytest.mark.parametrize(
-    ("n_orbitals", "msg_match"),
-    [(-3, "'n_orbitals' must be greater than 0"), (0, "'n_orbitals' must be greater than 0"),],
+    ("orbitals", "msg_match"),
+    [(-3, "'orbitals' must be greater than 0"), (0, "'orbitals' must be greater than 0"),],
 )
-def test_exception_spin_z(n_orbitals, msg_match):
+def test_exception_spin_z(orbitals, msg_match):
     """Test that the function `'spin_z'` throws an exception if the
     number of orbitals is less than zero."""
 
     with pytest.raises(ValueError, match=msg_match):
-        qchem.spin_z(n_orbitals)
+        qchem.spin_z(orbitals)


### PR DESCRIPTION
**Context:**
This is a very minor refactor of the functions in the `obs` module for the sake of consistency in the used naming convention throughout QChem.

Merging into (#750).

**Description of the Change:**
The naming convention used in the `structure` module has been propagated to the `obs` module.

The changes include:

  - `n_electrons` renamed to `electrons`.
  - `n_orbitals` renamed to `orbitals`.

  In addition, the argument `orbitals` is used now to pass the number of *spin*  orbitals.

**Benefits:**
Unified naming convention.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None