### PR TITLE
Update broken PennyLane links

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -334,11 +334,11 @@ html_theme_options = {
     "table_header_border": "#19b37b",
     "download_button": "#19b37b",
     # gallery options
-    # "github_repo": "XanaduAI/PennyLane",
+    # "github_repo": "PennyLaneAI/pennylane",
     # "gallery_dirs": "tutorials",
 }
 
-edit_on_github_project = 'XanaduAI/pennylane'
+edit_on_github_project = 'PennyLaneAI/pennylane'
 edit_on_github_branch = 'master/doc'
 
 # -- Options for HTMLHelp output ------------------------------------------

--- a/doc/development/guide/adr.rst
+++ b/doc/development/guide/adr.rst
@@ -31,7 +31,7 @@ On the other hand, the following changes typically require an ADR proposal:
 * Structural changes to the source code, documentation, or tests
 
 If you are unsure if a change requires an ADR proposal or not, please open a
-`GitHub issue <https://github.com/XanaduAI/pennylane/issue>`__ or post in the
+`GitHub issue <https://github.com/PennyLaneAI/pennylane/issues>`__ or post in the
 `discussion forum <https://discuss.pennylane.ai>`__ to discuss it with the PennyLane
 development team.
 
@@ -44,7 +44,6 @@ The ADR is a Markdown or reStructuredText document that outlines:
 * The context behind this design discussion,
 
 * Analysis of potential options, pros/cons of each approach, and any implementation 'gotchas' that
-
   might arise, and
 
 * A summary of the decision and an outline of the required work package.

--- a/doc/development/guide/installation.rst
+++ b/doc/development/guide/installation.rst
@@ -96,7 +96,7 @@ using development mode:
 
 .. code-block:: bash
 
-    git clone https://github.com/XanaduAI/pennylane
+    git clone https://github.com/PennyLaneAI/pennylane
     cd pennylane
     pip install -e .
 

--- a/doc/development/guide/pullrequests.rst
+++ b/doc/development/guide/pullrequests.rst
@@ -50,16 +50,16 @@ automatically to the comment box when you create a new issue.
 
 * Once you have submitted the pull request, three things will automatically occur:
 
-  - The **test suite** will automatically run on `Travis CI <https://travis-ci.org/XanaduAI/pennylane>`_
+  - The **test suite** will automatically run on `Travis CI <https://travis-ci.org/PennyLaneAI/pennylane>`_
     to ensure that all tests continue to pass.
 
   - Once the test suite is finished, a **code coverage report** will be generated on
-    `Codecov <https://codecov.io/gh/XanaduAI/pennylane>`_. This will calculate the percentage
+    `Codecov <https://codecov.io/gh/PennyLaneAI/pennylane>`_. This will calculate the percentage
     of PennyLane covered by the test suite, to ensure that all new code additions
     are adequately tested.
 
   - Finally, the **code quality** is calculated by
-    `Codefactor <https://app.codacy.com/app/XanaduAI/pennylane/dashboard>`_,
+    `Codefactor <https://app.codacy.com/app/PennyLaneAI/pennylane/dashboard>`_,
     to ensure all new code additions adhere to our code quality standards.
 
 Based on these reports, we may ask you to make small changes to your branch before

--- a/doc/development/guide/pullrequests.rst
+++ b/doc/development/guide/pullrequests.rst
@@ -50,7 +50,7 @@ automatically to the comment box when you create a new issue.
 
 * Once you have submitted the pull request, three things will automatically occur:
 
-  - The **test suite** will automatically run on `Travis CI <https://travis-ci.org/PennyLaneAI/pennylane>`_
+  - The **test suite** will automatically run on `GitHub Actions <https://github.com/PennyLaneAI/pennylane/actions>`_
     to ensure that all tests continue to pass.
 
   - Once the test suite is finished, a **code coverage report** will be generated on
@@ -59,7 +59,7 @@ automatically to the comment box when you create a new issue.
     are adequately tested.
 
   - Finally, the **code quality** is calculated by
-    `Codefactor <https://app.codacy.com/app/PennyLaneAI/pennylane/dashboard>`_,
+    `Codefactor <https://www.codefactor.io/repository/github/pennylaneai/pennylane>`_,
     to ensure all new code additions adhere to our code quality standards.
 
 Based on these reports, we may ask you to make small changes to your branch before

--- a/doc/development/plugins.rst
+++ b/doc/development/plugins.rst
@@ -36,13 +36,6 @@ A quick primer on terminology of PennyLane plugins in this section:
 Creating your device
 --------------------
 
-.. note::
-
-    A handy `plugin template repository <https://github.com/XanaduAI/pennylane-plugin-template>`__
-    is available, providing the boilerplate and file structure required to easily create your
-    own PennyLane plugin, as well as a suite of integration tests to ensure the plugin
-    returns correct expectation values.
-
 The first step in creating your PennyLane plugin is to create your device class.
 This is as simple as importing the abstract base class :class:`~.QubitDevice` from PennyLane,
 and subclassing it:
@@ -393,19 +386,21 @@ then be accessible via PennyLane.
 Testing
 -------
 
-All plugins should come with extensive unit tests, to ensure that the device supports the correct
-gates and observables, and is applying them correctly. For an example of a plugin test suite, see
-``tests/test_default_qubit.py`` and ``tests/test_default_gaussian.py`` in the main
-`PennyLane repository <https://github.com/XanaduAI/pennylane/>`_.
+All plugins should come with extensive unit tests, to ensure that each logical unit of the
+device has correct execution.
 
-Integration tests to check that the expectation values, variance, and samples are correct for
-various circuits and observables are provided in the
-`PennyLane Plugin Template <https://github.com/XanaduAI/pennylane-plugin-template>`__ repository.
+Integration tests to check that the probabilities, expectation values, variance, and samples are
+correct for various circuits and observables are provided as part of the PennyLane device
+test utility:
+
+
+.. code-block:: console
+
+    pl-device-test --device device_shortname --shots 10000 --analytic False
 
 In general, as all supported operations have their gradient formula defined and tested by
-PennyLane, testing that your device calculates the correct gradients is not required — just
-that it *applies* and *measures* quantum operations and observables correctly.
-
+PennyLane, testing that your device calculates the correct gradients is not required.
+For more details on the PennyLane device test utility, see :mod:`pennylane.devices.tests`.
 
 Supporting new operations
 -------------------------

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -152,8 +152,8 @@ If you are doing research using PennyLane, please cite
 Support and contribution
 ------------------------
 
-- **Source Code:** https://github.com/XanaduAI/PennyLane
-- **Issue Tracker:** https://github.com/XanaduAI/PennyLane/issues
+- **Source Code:** https://github.com/PennyLaneAI/pennylane
+- **Issue Tracker:** https://github.com/PennyLaneAI/pennylane/issues
 
 If you are having issues, please let us know by posting the issue on our GitHub issue tracker.
 

--- a/doc/xanadu_theme/footer.html
+++ b/doc/xanadu_theme/footer.html
@@ -14,7 +14,7 @@
           <hr width=100px class="d-inline-block mt-0 mb-1 Deep-purple accent-4">
           <ul class="list-unstyled">
             <li><a class="" href="https://pennylane.ai/">Home page</a></li>
-            <li><a class="" href="https://github.com/XanaduAI/pennylane">GitHub</a></li>
+            <li><a class="" href="https://github.com/PennyLaneAI/pennylane">GitHub</a></li>
             <li><a class="" href="https://pennylane.readthedocs.io/">Documentation</a></li>
             <li><a class="" href="https://discuss.pennylane.ai/">Discussion forum</a></li>
             <li><a class="" href="https://twitter.com/pennylaneai/">Twitter</a></li>

--- a/doc/xanadu_theme/header.html
+++ b/doc/xanadu_theme/header.html
@@ -53,7 +53,7 @@
         </a>
       </li>
       <li class="nav-item">
-        <a class="nav-link" href="https://github.com/XanaduAI/PennyLane">
+        <a class="nav-link" href="https://github.com/PennyLaneAI/pennylane">
           <i class="fab fa-github"></i> GitHub
         </a>
       </li>

--- a/doc/xanadu_theme/layout.html
+++ b/doc/xanadu_theme/layout.html
@@ -294,7 +294,7 @@ if (downloadNote.length >= 1) {
     var tutorialUrlArray = $("#tutorial-type").text().split('/');
         tutorialUrlArray[0] = "examples"
 
-    var githubLink = "https://github.com/XanaduAI/pennylane/blob/master/" + tutorialUrlArray.join("/") + ".py",
+    var githubLink = "https://github.com/PennyLaneAI/pennylane/blob/master/" + tutorialUrlArray.join("/") + ".py",
         pythonLink = $(".reference.download")[0].href,
         notebookLink = $(".reference.download")[1].href,
         notebookDownloadPath = notebookLink.split('_downloads')[1].split('/').pop();

--- a/pennylane/__init__.py
+++ b/pennylane/__init__.py
@@ -105,11 +105,11 @@ def device(name, *args, **kwargs):
     * :mod:`'default.gaussian' <pennylane.devices.default_gaussian>`: a simple simulator
       of Gaussian states and operations on continuous-variable circuit architectures.
 
-    * :mod:`'default.qubit.tf' <pennylane.devices.default_qubit.tf>`: a state simulator
+    * :mod:`'default.qubit.tf' <pennylane.devices.default_qubit_tf>`: a state simulator
       of qubit-based quantum circuit architectures written in TensorFlow, which allows
       automatic differentiation through the simulation.
 
-    * :mod:`'default.qubit.autograd' <pennylane.devices.default_qubit.autograd>`: a state simulator
+    * :mod:`'default.qubit.autograd' <pennylane.devices.default_qubit_autograd>`: a state simulator
       of qubit-based quantum circuit architectures which allows
       automatic differentiation through the simulation via python's autograd library.
 


### PR DESCRIPTION
**Context:** Due to the change of GitHub organization, various links needed to be updated.

**Description of the Change:**

* Changes `XanaduAI/pennylane` to `PennyLaneAI/pennylane` across the board

* Updates the `plugins.rst` page to remove reference to the outdated plugin template repo, and to add in a link to the shared device tests.

**Benefits:** n/a

**Possible Drawbacks:** Similar changes will need to be made in ~PennyLaneAI/pennylane.ai~, PennyLaneAI/qml, and all plugins.

**Related GitHub Issues:** Fixes #767 
