### PR TITLE
Speed up default.qubit by using permutations to apply some gates

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 <h3>Improvements</h3>
 
+* Sped up the application of certain gates in ``default.qubit`` by using array/tensor
+  manipulation tricks. The following gates are affected: ``PauliX``, ``PauliY``, ``PauliZ``,
+  ``Hadamard``, ``SWAP``, ``S``, ``T``, ``CNOT``, ``CZ``.
+  [(#772)](https://github.com/PennyLaneAI/pennylane/pull/772)
+
 <h3>Breaking changes</h3>
 
 <h3>Bug fixes</h3>

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -84,6 +84,7 @@ class QubitDevice(Device):
     _tensordot = staticmethod(np.tensordot)
     _conj = staticmethod(np.conj)
     _imag = staticmethod(np.imag)
+    _transpose = staticmethod(np.transpose)
 
     @staticmethod
     def _scatter(indices, array, new_dimensions):

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -85,6 +85,7 @@ class QubitDevice(Device):
     _conj = staticmethod(np.conj)
     _imag = staticmethod(np.imag)
     _roll = staticmethod(np.roll)
+    _stack = staticmethod(np.stack)
 
     @staticmethod
     def _scatter(indices, array, new_dimensions):

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -84,6 +84,7 @@ class QubitDevice(Device):
     _tensordot = staticmethod(np.tensordot)
     _conj = staticmethod(np.conj)
     _imag = staticmethod(np.imag)
+    _roll = staticmethod(np.roll)
 
     @staticmethod
     def _scatter(indices, array, new_dimensions):

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -84,7 +84,6 @@ class QubitDevice(Device):
     _tensordot = staticmethod(np.tensordot)
     _conj = staticmethod(np.conj)
     _imag = staticmethod(np.imag)
-    _transpose = staticmethod(np.transpose)
 
     @staticmethod
     def _scatter(indices, array, new_dimensions):

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -142,6 +142,7 @@ class DefaultQubit(QubitDevice):
             operation (~.Operation): operation to apply on the device
         """
         wires = operation.wires
+        axes = self.wires.indices(wires)
 
         if isinstance(operation, QubitStateVector):
             self._apply_state_vector(operation.parameters[0], wires)
@@ -176,7 +177,7 @@ class DefaultQubit(QubitDevice):
             return
 
         if isinstance(operation, SWAP):
-            self._state = self._apply_swap(self._state, wires)
+            self._state = self._apply_swap(self._state, axes)
             return
 
         matrix = self._get_unitary_matrix(operation)
@@ -254,21 +255,19 @@ class DefaultQubit(QubitDevice):
         state_z = self._apply_z(state, wire)
         return SQRT2INV * (state_x + state_z)
 
-    def _apply_swap(self, state, wires):
-        """Applies SWAP gate by performing a partial transposition along the axes specified by
-        ``wires``.
+    def _apply_swap(self, state, target_axes):
+        """Applies SWAP gate by performing a partial transposition along the specified axes.
 
         Args:
             state (array[complex]): input state
-            wires (Wires): target wires
+            target_axes (List[int]): axes to apply transformation
 
         Returns:
             array[complex]: output state
         """
-        swap_axes = [self.wires.index(wire) for wire in wires]
-        axes = list(range(self.num_wires))
-        axes[swap_axes[0]] = swap_axes[1]
-        axes[swap_axes[1]] = swap_axes[0]
+        axes = list(range(len(state.shape)))
+        axes[target_axes[0]] = target_axes[1]
+        axes[target_axes[1]] = target_axes[0]
         return self._transpose(state, axes)
 
     def _get_unitary_matrix(self, unitary):  # pylint: disable=no-self-use

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -24,7 +24,7 @@ from string import ascii_letters as ABC
 
 import numpy as np
 
-from pennylane import QubitDevice, DeviceError, QubitStateVector, BasisState
+from pennylane import QubitDevice, DeviceError, QubitStateVector, BasisState, SWAP
 from pennylane.operation import DiagonalOperation
 
 ABC_ARRAY = np.array(list(ABC))
@@ -132,6 +132,10 @@ class DefaultQubit(QubitDevice):
             self._apply_basis_state(operation.parameters[0], wires)
             return
 
+        if isinstance(operation, SWAP):
+            self._apply_SWAP(wires)
+            return
+
         matrix = self._get_unitary_matrix(operation)
 
         if isinstance(operation, DiagonalOperation):
@@ -141,6 +145,16 @@ class DefaultQubit(QubitDevice):
             self._apply_unitary_einsum(matrix, wires)
         else:
             self._apply_unitary(matrix, wires)
+
+    def _apply_SWAP(self, wires):
+        """Applies swap gate by performing a partial transposition along the axes specified by
+        ``wires``.
+
+        Args:
+            wires (Wires): target wires
+        """
+        axes = [self.wires.index(w) for w in wires]
+        self._state = self._transpose(self._state, axes)
 
     def _get_unitary_matrix(self, unitary):  # pylint: disable=no-self-use
         """Return the matrix representing a unitary operation.

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -36,8 +36,17 @@ SQRT2INV = 1 / np.sqrt(2)
 TPHASE = np.exp(1j * np.pi / 4)
 
 
-def get_slice(index, axis, num_axes):
-    """TODO"""
+def _get_slice(index, axis, num_axes):
+    """Allows slicing into the index of an array or tensor along an arbitrary axis.
+
+    Args:
+        index (int): the index to access
+        axis (int): the axis to slice into
+        num_axes (int): total number of axes
+
+    Returns:
+        tuple[slice or int]: a tuple that can be used to slice into an array or tensor
+    """
     idx = [slice(None)] * num_axes
     idx[axis] = index
     return tuple(idx)
@@ -194,8 +203,8 @@ class DefaultQubit(QubitDevice):
         """
         axis = self.wires.index(wire)
 
-        sl_0 = get_slice(0, axis, self.num_wires)
-        sl_1 = get_slice(1, axis, self.num_wires)
+        sl_0 = _get_slice(0, axis, self.num_wires)
+        sl_1 = _get_slice(1, axis, self.num_wires)
 
         phase = self._conj(phase) if inverse else phase
 

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -270,11 +270,11 @@ class DefaultQubit(QubitDevice):
         sl_0 = _get_slice(0, axes[0], self.num_wires)
         sl_1 = _get_slice(1, axes[0], self.num_wires)
 
-        # If axis[1] is larger than axis[0], then state[sl_1] will have self.num_wires - 1 axes with
-        # the target axes shifted down by one. Otherwise, if axis[1] is less than axis[0] then its
+        # If axes[1] is larger than axes[0], then state[sl_1] will have self.num_wires - 1 axes with
+        # the target axes shifted down by one. Otherwise, if axes[1] is less than axes[0] then its
         # axis number in state[sl_1] remains unchanged. For example: state has axes [0, 1, 2, 3] and
-        # axis[0] = 1 and axis[1] = 3. Then, state[sl_1] has axes [0, 1, 2] so that the target axis
-        # has shifted from 3 to 2. If axis[0] = 2 and axis[1] = 1, then state[sl_1] has axes
+        # axes[0] = 1 and axes[1] = 3. Then, state[sl_1] has axes [0, 1, 2] so that the target axis
+        # has shifted from 3 to 2. If axes[0] = 2 and axes[1] = 1, then state[sl_1] has axes
         # [0, 1, 2] but with the target axis remaining unchanged.
         if axes[1] > axes[0]:
             target_axes = [axes[1] - 1]

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -482,11 +482,13 @@ class DefaultQubit(QubitDevice):
         )
 
         # We now put together the indices in the notation numpy's einsum requires
-        einsum_indices = "{new_indices}{affected_indices},{state_indices}->{new_state_indices}".format(
-            affected_indices=affected_indices,
-            state_indices=state_indices,
-            new_indices=new_indices,
-            new_state_indices=new_state_indices,
+        einsum_indices = (
+            "{new_indices}{affected_indices},{state_indices}->{new_state_indices}".format(
+                affected_indices=affected_indices,
+                state_indices=state_indices,
+                new_indices=new_indices,
+                new_state_indices=new_state_indices,
+            )
         )
 
         self._state = self._einsum(einsum_indices, mat, self._state)

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -24,8 +24,7 @@ from string import ascii_letters as ABC
 
 import numpy as np
 
-from pennylane import QubitDevice, DeviceError, QubitStateVector, BasisState, SWAP, PauliX, \
-    Hadamard, PauliZ, S, T, PauliY
+from pennylane import QubitDevice, DeviceError, QubitStateVector, BasisState
 from pennylane.operation import DiagonalOperation
 
 ABC_ARRAY = np.array(list(ABC))
@@ -52,6 +51,7 @@ def _get_slice(index, axis, num_axes):
     return tuple(idx)
 
 
+# pylint: disable=unused-import
 class DefaultQubit(QubitDevice):
     """Default qubit device for PennyLane.
 

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -36,7 +36,7 @@ TPHASE = np.exp(1j * np.pi / 4)
 
 
 def _get_slice(index, axis, num_axes):
-    """Allows slicing into the index of an array or tensor along an arbitrary axis.
+    """Allows slicing along an arbitrary axis of an array or tensor.
 
     Args:
         index (int): the index to access

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -250,6 +250,12 @@ class DefaultQubit(QubitDevice):
         sl_0 = _get_slice(0, axes[0], self.num_wires)
         sl_1 = _get_slice(1, axes[0], self.num_wires)
 
+        # If axis[1] is larger than axis[0], then state[sl_1] will have self.num_wires - 1 axes with
+        # the target axes shifted down by one. Otherwise, if axis[1] is less than axis[0] then its
+        # axis number in state[sl_1] remains unchanged. For example: state has axes [0, 1, 2, 3] and
+        # axis[0] = 1 and axis[1] = 3. Then, state[sl_1] has axes [0, 1, 2] so that the target axis
+        # has shifted from 3 to 2. If axis[0] = 2 and axis[1] = 1, then state[sl_1] has axes
+        # [0, 1, 2] but with the target axis remaining unchanged.
         if axes[1] > axes[0]:
             target_axes = [axes[1] - 1]
         else:

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -196,6 +196,11 @@ class DefaultQubit(QubitDevice):
     def _apply_x(self, state, axes, **kwargs):
         """Applies a PauliX gate by rolling 1 unit along the axis specified in ``axes``.
 
+        Rolling by 1 unit along the axis means that the :math:`|0 \rangle` state with index ``0`` is
+        shifted to the :math:`|1 \rangle` state with index ``1``. Likewise, since rolling beyond
+        the last index loops back to the first, :math:`|1 \rangle` is transformed to
+        :math:`|0\rangle`.
+
         Args:
             state (array[complex]): input state
             axes (List[int]): target axes to apply transformation

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -34,6 +34,13 @@ tolerance = 1e-10
 SQRT2INV = 1 / np.sqrt(2)
 
 
+def get_slice(index, axis, num_axes):
+    """TODO"""
+    idx = [slice(None)] * num_axes
+    idx[axis] = index
+    return tuple(idx)
+
+
 class DefaultQubit(QubitDevice):
     """Default qubit device for PennyLane.
 
@@ -169,11 +176,13 @@ class DefaultQubit(QubitDevice):
         return self._roll(state, 1, axis)
 
     def _apply_hadamard(self, state, wire):
+        axis = self.wires.index(wire)
         state_x = self._apply_x(state, wire)
 
+        sl_0 = get_slice(0, axis, self.num_wires)
+        sl_1 = get_slice(1, axis, self.num_wires)
 
-
-        state = self._stack(state)
+        state = self._stack([state[sl_0], -state[sl_1]], axis=axis)
         return SQRT2INV * (state + state_x)
 
     def _apply_swap(self, state, wires):

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -180,7 +180,7 @@ class DefaultQubit(QubitDevice):
             self._apply_unitary(matrix, wires)
 
     def _apply_x(self, state, axes, **kwargs):
-        """Applies PauliX gate by rolling 1 unit along the axis specified in ``axes``.
+        """Applies a PauliX gate by rolling 1 unit along the axis specified in ``axes``.
 
         Args:
             state (array[complex]): input state
@@ -192,7 +192,7 @@ class DefaultQubit(QubitDevice):
         return self._roll(state, 1, axes[0])
 
     def _apply_y(self, state, axes, **kwargs):
-        """Applies PauliY gate by adding a negative sign to the 1 index along the axis specified
+        """Applies a PauliY gate by adding a negative sign to the 1 index along the axis specified
         in ``axes``, rolling one unit along the same axis, and multiplying the result by 1j.
 
         Args:
@@ -205,7 +205,7 @@ class DefaultQubit(QubitDevice):
         return 1j * self._apply_x(self._apply_z(state, axes), axes)
 
     def _apply_z(self, state, axes, **kwargs):
-        """Applies PauliZ gate by adding a negative sign to the 1 index along the axis specified
+        """Applies a PauliZ gate by adding a negative sign to the 1 index along the axis specified
         in ``axes``.
 
         Args:
@@ -260,7 +260,7 @@ class DefaultQubit(QubitDevice):
         return self._stack([state[sl_0], state_x], axis=axes[0])
 
     def _apply_swap(self, state, axes, **kwargs):
-        """Applies SWAP gate by performing a partial transposition along the specified axes.
+        """Applies a SWAP gate by performing a partial transposition along the specified axes.
 
         Args:
             state (array[complex]): input state

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -24,7 +24,7 @@ from string import ascii_letters as ABC
 
 import numpy as np
 
-from pennylane import QubitDevice, DeviceError, QubitStateVector, BasisState, SWAP, Hadamard
+from pennylane import QubitDevice, DeviceError, QubitStateVector, BasisState, SWAP, PauliX
 from pennylane.operation import DiagonalOperation
 
 ABC_ARRAY = np.array(list(ABC))
@@ -132,6 +132,10 @@ class DefaultQubit(QubitDevice):
             self._apply_basis_state(operation.parameters[0], wires)
             return
 
+        if isinstance(operation, PauliX):
+            self._state = self._apply_x(self._state, wires[0])
+            return
+
         if isinstance(operation, SWAP):
             self._state = self._apply_swap(self._state, wires)
             return
@@ -145,6 +149,19 @@ class DefaultQubit(QubitDevice):
             self._apply_unitary_einsum(matrix, wires)
         else:
             self._apply_unitary(matrix, wires)
+
+    def _apply_x(self, state, wire):
+        """Applies PauliX gate by rolling 1 unit along the axis specified by ``wire``.
+
+        Args:
+            state (array[complex]): input state
+            wire (Wires): target wire
+
+        Returns:
+            array[complex]: output state
+        """
+        axis = self.wires.index(wire)
+        return self._roll(state, 1, axis)
 
     def _apply_swap(self, state, wires):
         """Applies SWAP gate by performing a partial transposition along the axes specified by

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -45,6 +45,19 @@ def _get_slice(index, axis, num_axes):
 
     Returns:
         tuple[slice or int]: a tuple that can be used to slice into an array or tensor
+
+    **Example:**
+
+    Accessing the 2 index along axis 1 of a 3-axis array:
+
+    >>> sl = _get_slice(2, 1, 3)
+    >>> sl
+    (slice(None, None, None), 2, slice(None, None, None))
+    >>> a = np.arange(27).reshape((3, 3, 3))
+    >>> a[sl]
+    array([[ 6,  7,  8],
+           [15, 16, 17],
+           [24, 25, 26]])
     """
     idx = [slice(None)] * num_axes
     idx[axis] = index

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -24,7 +24,7 @@ from string import ascii_letters as ABC
 
 import numpy as np
 
-from pennylane import QubitDevice, DeviceError, QubitStateVector, BasisState, SWAP
+from pennylane import QubitDevice, DeviceError, QubitStateVector, BasisState, SWAP, Hadamard
 from pennylane.operation import DiagonalOperation
 
 ABC_ARRAY = np.array(list(ABC))
@@ -133,7 +133,7 @@ class DefaultQubit(QubitDevice):
             return
 
         if isinstance(operation, SWAP):
-            self._apply_SWAP(wires)
+            self._state = self._apply_swap(self._state, wires)
             return
 
         matrix = self._get_unitary_matrix(operation)
@@ -146,18 +146,22 @@ class DefaultQubit(QubitDevice):
         else:
             self._apply_unitary(matrix, wires)
 
-    def _apply_SWAP(self, wires):
-        """Applies swap gate by performing a partial transposition along the axes specified by
+    def _apply_swap(self, state, wires):
+        """Applies SWAP gate by performing a partial transposition along the axes specified by
         ``wires``.
 
         Args:
+            state (array[complex]): input state
             wires (Wires): target wires
+
+        Returns:
+            array[complex]: output state
         """
         swap_axes = [self.wires.index(wire) for wire in wires]
         axes = list(range(self.num_wires))
         axes[swap_axes[0]] = swap_axes[1]
         axes[swap_axes[1]] = swap_axes[0]
-        self._state = self._transpose(self._state, axes)
+        return self._transpose(state, axes)
 
     def _get_unitary_matrix(self, unitary):  # pylint: disable=no-self-use
         """Return the matrix representing a unitary operation.

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -154,7 +154,7 @@ class DefaultQubit(QubitDevice):
             operation (~.Operation): operation to apply on the device
         """
         wires = operation.wires
-        axes = self.wires.indices(wires)
+
 
         if isinstance(operation, QubitStateVector):
             self._apply_state_vector(operation.parameters[0], wires)
@@ -165,6 +165,7 @@ class DefaultQubit(QubitDevice):
             return
 
         if operation.name in self._apply_ops:
+            axes = self.wires.indices(wires)
             self._state = self._apply_ops[operation.name](
                 self._state, axes, inverse=operation.inverse
             )

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -51,7 +51,7 @@ def _get_slice(index, axis, num_axes):
     return tuple(idx)
 
 
-# pylint: disable=unused-import
+# pylint: disable=unused-argument
 class DefaultQubit(QubitDevice):
     """Default qubit device for PennyLane.
 

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -24,13 +24,14 @@ from string import ascii_letters as ABC
 
 import numpy as np
 
-from pennylane import QubitDevice, DeviceError, QubitStateVector, BasisState, SWAP, PauliX
+from pennylane import QubitDevice, DeviceError, QubitStateVector, BasisState, SWAP, PauliX, Hadamard
 from pennylane.operation import DiagonalOperation
 
 ABC_ARRAY = np.array(list(ABC))
 
 # tolerance for numerical errors
 tolerance = 1e-10
+SQRT2INV = 1 / np.sqrt(2)
 
 
 class DefaultQubit(QubitDevice):
@@ -136,6 +137,10 @@ class DefaultQubit(QubitDevice):
             self._state = self._apply_x(self._state, wires[0])
             return
 
+        if isinstance(operation, Hadamard):
+            self._state = self._apply_hadamard(self._state, wires[0])
+            return
+
         if isinstance(operation, SWAP):
             self._state = self._apply_swap(self._state, wires)
             return
@@ -162,6 +167,14 @@ class DefaultQubit(QubitDevice):
         """
         axis = self.wires.index(wire)
         return self._roll(state, 1, axis)
+
+    def _apply_hadamard(self, state, wire):
+        state_x = self._apply_x(state, wire)
+
+
+
+        state = self._stack(state)
+        return SQRT2INV * (state + state_x)
 
     def _apply_swap(self, state, wires):
         """Applies SWAP gate by performing a partial transposition along the axes specified by

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -153,7 +153,10 @@ class DefaultQubit(QubitDevice):
         Args:
             wires (Wires): target wires
         """
-        axes = [self.wires.index(w) for w in wires]
+        swap_axes = [self.wires.index(wire) for wire in wires]
+        axes = list(range(self.num_wires))
+        axes[swap_axes[0]] = swap_axes[1]
+        axes[swap_axes[1]] = swap_axes[0]
         self._state = self._transpose(self._state, axes)
 
     def _get_unitary_matrix(self, unitary):  # pylint: disable=no-self-use

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -260,6 +260,10 @@ class DefaultQubit(QubitDevice):
         """Applies a CNOT gate by slicing along the first axis specified in ``axes`` and then
         applying an X transformation along the second axis.
 
+        By slicing along the first axis, we are able to select all of the amplitudes with a
+        corresponding :math:`|1\rangle` for the control qubit. This means we then just need to apply
+        a :class:`~.PauliX` (NOT) gate to the result.
+
         Args:
             state (array[complex]): input state
             axes (List[int]): target axes to apply transformation
@@ -270,12 +274,12 @@ class DefaultQubit(QubitDevice):
         sl_0 = _get_slice(0, axes[0], self.num_wires)
         sl_1 = _get_slice(1, axes[0], self.num_wires)
 
-        # If axes[1] is larger than axes[0], then state[sl_1] will have self.num_wires - 1 axes with
-        # the target axes shifted down by one. Otherwise, if axes[1] is less than axes[0] then its
-        # axis number in state[sl_1] remains unchanged. For example: state has axes [0, 1, 2, 3] and
-        # axes[0] = 1 and axes[1] = 3. Then, state[sl_1] has axes [0, 1, 2] so that the target axis
-        # has shifted from 3 to 2. If axes[0] = 2 and axes[1] = 1, then state[sl_1] has axes
-        # [0, 1, 2] but with the target axis remaining unchanged.
+        # We will be slicing into the state according to state[sl_1], giving us all of the
+        # amplitudes with a |1> for the control qubit. The resulting array has lost an axis
+        # relative to state and we need to be careful about the axis we apply the PauliX rotation
+        # to. If axes[1] is larger than axes[0], then we need to shift the target axis down by
+        # one, otherwise we can leave as-is. For example: a state has [0, 1, 2, 3], control=1,
+        # target=3. Then, state[sl_1] has 3 axes and target=3 now corresponds to the second axis.
         if axes[1] > axes[0]:
             target_axes = [axes[1] - 1]
         else:

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -114,7 +114,7 @@ class DefaultQubit(QubitDevice):
         self._state = self._create_basis_state(0)
         self._pre_rotated_state = self._state
 
-        self._ops_map = {
+        self._apply_ops = {
             "PauliX": self._apply_x,
             "PauliY": self._apply_y,
             "PauliZ": self._apply_z,
@@ -164,9 +164,8 @@ class DefaultQubit(QubitDevice):
             self._apply_basis_state(operation.parameters[0], wires)
             return
 
-        apply_func = self._ops_map.get(operation.name, None)
-        if apply_func:
-            self._state = apply_func(self._state, axes, inverse=operation.inverse)
+        if operation.name in self._apply_ops:
+            self._state = self._apply_ops[operation.name](self._state, axes, inverse=operation.inverse)
             return
 
         matrix = self._get_unitary_matrix(operation)

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -165,7 +165,9 @@ class DefaultQubit(QubitDevice):
             return
 
         if operation.name in self._apply_ops:
-            self._state = self._apply_ops[operation.name](self._state, axes, inverse=operation.inverse)
+            self._state = self._apply_ops[operation.name](
+                self._state, axes, inverse=operation.inverse
+            )
             return
 
         matrix = self._get_unitary_matrix(operation)
@@ -480,13 +482,11 @@ class DefaultQubit(QubitDevice):
         )
 
         # We now put together the indices in the notation numpy's einsum requires
-        einsum_indices = (
-            "{new_indices}{affected_indices},{state_indices}->{new_state_indices}".format(
-                affected_indices=affected_indices,
-                state_indices=state_indices,
-                new_indices=new_indices,
-                new_state_indices=new_state_indices,
-            )
+        einsum_indices = "{new_indices}{affected_indices},{state_indices}->{new_state_indices}".format(
+            affected_indices=affected_indices,
+            state_indices=state_indices,
+            new_indices=new_indices,
+            new_state_indices=new_state_indices,
         )
 
         self._state = self._einsum(einsum_indices, mat, self._state)

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -155,7 +155,6 @@ class DefaultQubit(QubitDevice):
         """
         wires = operation.wires
 
-
         if isinstance(operation, QubitStateVector):
             self._apply_state_vector(operation.parameters[0], wires)
             return

--- a/pennylane/devices/default_qubit_autograd.py
+++ b/pennylane/devices/default_qubit_autograd.py
@@ -106,6 +106,7 @@ class DefaultQubitAutograd(DefaultQubit):
     _tensordot = staticmethod(np.tensordot)
     _conj = staticmethod(np.conj)
     _imag = staticmethod(np.imag)
+    _roll = staticmethod(np.roll)
 
     @staticmethod
     def _scatter(indices, array, new_dimensions):

--- a/pennylane/devices/default_qubit_autograd.py
+++ b/pennylane/devices/default_qubit_autograd.py
@@ -111,6 +111,9 @@ class DefaultQubitAutograd(DefaultQubit):
 
     def __init__(self, wires, *, shots=1000, analytic=True):
         super().__init__(wires, shots=shots, analytic=analytic)
+
+        # prevent using special apply methods for these gates due to slowdown in Autograd
+        # implementation
         del self._apply_ops["PauliY"]
         del self._apply_ops["Hadamard"]
         del self._apply_ops["CZ"]

--- a/pennylane/devices/default_qubit_autograd.py
+++ b/pennylane/devices/default_qubit_autograd.py
@@ -107,6 +107,7 @@ class DefaultQubitAutograd(DefaultQubit):
     _conj = staticmethod(np.conj)
     _imag = staticmethod(np.imag)
     _roll = staticmethod(np.roll)
+    _stack = staticmethod(np.stack)
 
     @staticmethod
     def _scatter(indices, array, new_dimensions):

--- a/pennylane/devices/default_qubit_autograd.py
+++ b/pennylane/devices/default_qubit_autograd.py
@@ -109,6 +109,12 @@ class DefaultQubitAutograd(DefaultQubit):
     _roll = staticmethod(np.roll)
     _stack = staticmethod(np.stack)
 
+    def __init__(self, wires, *, shots=1000, analytic=True):
+        super().__init__(wires, shots=shots, analytic=analytic)
+        del self._apply_ops["PauliY"]
+        del self._apply_ops["Hadamard"]
+        del self._apply_ops["CZ"]
+
     @staticmethod
     def _scatter(indices, array, new_dimensions):
         new_array = np.zeros(new_dimensions, dtype=array.dtype.type)

--- a/pennylane/devices/default_qubit_tf.py
+++ b/pennylane/devices/default_qubit_tf.py
@@ -161,6 +161,8 @@ class DefaultQubitTF(DefaultQubit):
 
     def __init__(self, wires, *, shots=1000, analytic=True):
         super().__init__(wires, shots=shots, analytic=analytic)
+
+        # prevent using special apply method for this gate due to slowdown in TF implementation
         del self._apply_ops["CZ"]
 
     @staticmethod

--- a/pennylane/devices/default_qubit_tf.py
+++ b/pennylane/devices/default_qubit_tf.py
@@ -157,6 +157,7 @@ class DefaultQubitTF(DefaultQubit):
     _conj = staticmethod(tf.math.conj)
     _imag = staticmethod(tf.math.conj)
     _roll = staticmethod(tf.roll)
+    _stack = staticmethod(tf.stack)
 
     @staticmethod
     def _scatter(indices, array, new_dimensions):

--- a/pennylane/devices/default_qubit_tf.py
+++ b/pennylane/devices/default_qubit_tf.py
@@ -159,6 +159,10 @@ class DefaultQubitTF(DefaultQubit):
     _roll = staticmethod(tf.roll)
     _stack = staticmethod(tf.stack)
 
+    def __init__(self, wires, *, shots=1000, analytic=True):
+        super().__init__(wires, shots=shots, analytic=analytic)
+        del self._apply_ops["CZ"]
+
     @staticmethod
     def _scatter(indices, array, new_dimensions):
         indices = np.expand_dims(indices, 1)

--- a/pennylane/devices/default_qubit_tf.py
+++ b/pennylane/devices/default_qubit_tf.py
@@ -156,6 +156,7 @@ class DefaultQubitTF(DefaultQubit):
     _tensordot = staticmethod(tf.tensordot)
     _conj = staticmethod(tf.math.conj)
     _imag = staticmethod(tf.math.conj)
+    _roll = staticmethod(tf.roll)
 
     @staticmethod
     def _scatter(indices, array, new_dimensions):

--- a/tests/devices/test_default_qubit.py
+++ b/tests/devices/test_default_qubit.py
@@ -1736,13 +1736,49 @@ class TestWiresIntegration:
         assert np.allclose(circuit1(), circuit2(), tol)
 
 
-def test_get_slice():
-    """Test that the _get_slice function returns the expected slice and allows us to slice
-    correctly into an array."""
+class TestGetSlice:
+    """Tests for the _get_slice function."""
 
-    sl = _get_slice(1, 1, 3)
-    array = np.arange(27).reshape((3, 3, 3))
-    target = array[:, 1, :]
+    def test_get_slice(self):
+        """Test that the _get_slice function returns the expected slice and allows us to slice
+        correctly into an array."""
 
-    assert sl == (slice(None, None, None), 1, slice(None, None, None))
-    assert np.allclose(array[sl], target)
+        sl = _get_slice(1, 1, 3)
+        array = np.arange(27).reshape((3, 3, 3))
+        target = array[:, 1, :]
+
+        assert sl == (slice(None, None, None), 1, slice(None, None, None))
+        assert np.allclose(array[sl], target)
+
+    def test_get_slice_first(self):
+        """Test that the _get_slice function returns the expected slice when accessing the first
+        axis of an array."""
+
+        sl = _get_slice(2, 0, 3)
+        array = np.arange(27).reshape((3, 3, 3))
+        target = array[2]
+
+        assert sl == (2, slice(None, None, None), slice(None, None, None))
+        assert np.allclose(array[sl], target)
+
+    def test_get_slice_last(self):
+        """Test that the _get_slice function returns the expected slice when accessing the last
+        axis of an array."""
+
+        sl = _get_slice(0, 2, 3)
+        array = np.arange(27).reshape((3, 3, 3))
+        target = array[:, :, 0]
+
+        assert sl == (slice(None, None, None), slice(None, None, None), 0)
+        assert np.allclose(array[sl], target)
+
+    def test_get_slice_1d(self):
+        """Test that the _get_slice function returns the expected slice when accessing a
+        1-dimensional array."""
+
+        sl = _get_slice(2, 0, 1)
+        array = np.arange(27)
+        target = array[2]
+
+        assert sl == (2,)
+        assert np.allclose(array[sl], target)

--- a/tests/devices/test_default_qubit.py
+++ b/tests/devices/test_default_qubit.py
@@ -21,6 +21,7 @@ import math
 import pytest
 import pennylane as qml
 from pennylane import numpy as np, DeviceError
+from pennylane.devices.default_qubit import _get_slice
 from pennylane.operation import Operation
 
 U = np.array(
@@ -1733,3 +1734,15 @@ class TestWiresIntegration:
         circuit2 = self.make_circuit_expval(wires2)
 
         assert np.allclose(circuit1(), circuit2(), tol)
+
+
+def test_get_slice():
+    """Test that the _get_slice function returns the expected slice and allows us to slice
+    correctly into an array."""
+
+    sl = _get_slice(1, 1, 3)
+    array = np.arange(27).reshape((3, 3, 3))
+    target = array[:, 1, :]
+
+    assert sl == (slice(None, None, None), 1, slice(None, None, None))
+    assert np.allclose(array[sl], target)

--- a/tests/devices/test_default_qubit_autograd.py
+++ b/tests/devices/test_default_qubit_autograd.py
@@ -63,12 +63,15 @@ class TestQNodeIntegration:
         @qml.qnode(dev, interface="autograd", diff_method="backprop")
         def circuit():
             qml.Hadamard(wires=0)
+            qml.RZ(np.pi / 4, wires=0)
             return qml.expval(qml.PauliZ(0))
 
         circuit()
         state = dev.state
 
-        expected = np.array([1.0, 0, 1.0, 0]) / np.sqrt(2)
+        amplitude = np.exp(-1j * np.pi / 8) / np.sqrt(2)
+
+        expected = np.array([amplitude, 0, np.conj(amplitude), 0])
         assert np.allclose(state, expected, atol=tol, rtol=0)
 
 

--- a/tests/devices/test_default_qubit_tf.py
+++ b/tests/devices/test_default_qubit_tf.py
@@ -831,12 +831,15 @@ class TestQNodeIntegration:
         @qml.qnode(dev, interface="tf", diff_method="backprop")
         def circuit():
             qml.Hadamard(wires=0)
+            qml.RZ(np.pi / 4, wires=0)
             return qml.expval(qml.PauliZ(0))
 
         circuit()
         state = dev.state
 
-        expected = tf.constant([1.0, 0, 1.0, 0]) / np.sqrt(2)
+        amplitude = np.exp(-1j * np.pi / 8) / np.sqrt(2)
+
+        expected = np.array([amplitude, 0, np.conj(amplitude), 0])
         assert np.allclose(state, expected, atol=tol, rtol=0)
 
 


### PR DESCRIPTION
**Context:**

This PR uses some array/tensor manipulation tricks such as [roll](https://numpy.org/doc/stable/reference/generated/numpy.roll.html), [transpose](https://numpy.org/doc/stable/reference/generated/numpy.transpose.html) and [slicing](https://stackoverflow.com/questions/42656930/numpy-assignment-like-numpy-take) to speed up the application of some gates:
- PauliX
- PauliY
- PauliZ
- Hadamard
- SWAP
- S
- T
- CNOT
- CZ

For example, `PauliX` can be achieved simply using `np.roll(state, 1, wire_axis)`. Currently in PL, these gates are applied using the `_apply_diagonal_unitary()` and `_apply_unitary_einsum()` methods, which both internally perform a contraction using `einsum`.

**Description of the Change:**

Additional methods have been added to `DefaultQubit` for each of the above gates, e.g., `_apply_x()` for `PauliX`. In the main `apply_operation()` method, we then dispatch to each of the functions using a dictionary that maps from operation name to corresponding method.

**Benefits:**

Increased speed. This can be checked using a benchmark script (see at the bottom). The script makes a trial circuit composed of a single gate that is repeatedly placed on each qubit and then repeated for a chosen depth. The script then times how long multiple runs take to complete. Using this, we can benchmark the new and old approaches in `DefaultQubit` and find the speedup as a function of qubit number:
![image](https://user-images.githubusercontent.com/49409390/90936815-fbc7c780-e3d3-11ea-96e5-1bc3073a4d42.png)
We see a speed up, with different gates performing better than others. `PauliY` and `Hadamard` are the worst performers, possibly because they combine two applications of `PauliX` and `PauliZ`.

Note that the changes in this PR are also compatible with `default.qubit.tf` and `default.qubit.autograd`. The speedup plots are shown below:
![image](https://user-images.githubusercontent.com/49409390/90936974-65e06c80-e3d4-11ea-9b10-357dd4502715.png)
![image](https://user-images.githubusercontent.com/49409390/90936984-6bd64d80-e3d4-11ea-8da0-92896ecf0382.png)

I'm not sure exactly why the `default.qubit.tf` plot looks different. Also, these benchmarks are quite artificial in that we only restrict to the gates that we hope to have sped up - practical circuits may include other gates.

**Possible Drawbacks:**

- Edge cases where the new approach is slower than the old?
- `DefaultQubit` feels a bit busy now with a lot of methods. I couldn't pull out these methods as functions in a separate `ops` file because we need access to, e.g., `self._roll` for the interface-correct function.
- Do we need to test these methods explicitly? We don't for other methods in `DefaultQubit`.
- We don't speed up any gates with trainable parameters such as `Rot`, which are quite common. I don't think there is any fundamental roadblock for doing this though, could be a follow up PR.

**Benchmark script:**
```python
import pennylane as qml
import time
import numpy as np

sped_up_gates = [
    qml.PauliX,
    qml.PauliY,
    qml.PauliZ,
    qml.Hadamard,
    qml.SWAP,
    qml.S,
    qml.T,
    qml.CNOT,
    qml.CZ,
]

layers = 5

def get_time(num_wires, layers, reps, gate):

    gate_num_wires = gate.num_wires
    print("Benchmarking for {} qubits on gate {}".format(num_wires, gate))
    
    dev = qml.device("default.qubit.tf", wires=num_wires)
    
    @qml.qnode(dev, interface="tf")
    def benchmark():
        for l in range(layers):
            for i in range(num_wires):
                wires = [w % num_wires for w in range(i, i + gate_num_wires)]
                gate(wires=wires)
        return qml.expval(qml.PauliZ(0))

    time0 = time.time()

    for r in range(reps):
        benchmark()

    time1 = time.time()

    total_time = time1 - time0
    return total_time

def get_time_over_qubits(range_qubits, layers, reps, gate):
    return [get_time(qubit, layers, reps, gate) for qubit in range_qubits]

def get_time_over_gates(range_qubits, layers, reps, range_gates):
    return np.array([get_time_over_qubits(range_qubits, layers, reps, gate) for gate in range_gates])

results = get_time_over_gates(range(2, 8), layers, 1000, sped_up_gates)
```