### PR TITLE
Use lists to store variable values inside BaseQNode

### DIFF
--- a/benchmark/bm_jacobian_end_weighted.py
+++ b/benchmark/bm_jacobian_end_weighted.py
@@ -31,7 +31,7 @@ class Benchmark(bu.BaseBenchmark):
     and evaluates its Jacobian.
     """
 
-    name = "Jacobian evaluation uniform"
+    name = "Jacobian evaluation end weighted"
     min_wires = 2
     n_vals = range(3, 27, 3)
 

--- a/benchmark/bm_jacobian_front_weighted.py
+++ b/benchmark/bm_jacobian_front_weighted.py
@@ -31,7 +31,7 @@ class Benchmark(bu.BaseBenchmark):
     and evaluates its Jacobian.
     """
 
-    name = "Jacobian evaluation uniform"
+    name = "Jacobian evaluation front weighted"
     min_wires = 2
     n_vals = range(3, 27, 3)
 

--- a/pennylane/qnodes/base.py
+++ b/pennylane/qnodes/base.py
@@ -326,7 +326,7 @@ class BaseQNode(qml.QueuingContext):
             args (tuple[Any]): positional (differentiable) arguments
             kwargs (dict[str, Any]): auxiliary arguments
         """
-        Variable.positional_arg_values = np.array(list(_flatten(args)))
+        Variable.positional_arg_values = list(_flatten(args))
         if not self.mutable:
             # only immutable circuits access auxiliary arguments through Variables
             Variable.kwarg_values = {k: np.array(list(_flatten(v))) for k, v in kwargs.items()}

--- a/tests/qnodes/test_qnode_base.py
+++ b/tests/qnodes/test_qnode_base.py
@@ -834,6 +834,22 @@ class TestQNodeArgs:
         c = node(1.0, x=np.pi, y=10)
         assert c == pytest.approx(-1.0, abs=tol)
 
+    def test_complex_positional_argument_qubitunitary(self, tol):
+        """Tests that matrices containing complex positional arguments can be
+        passed to the QubitUnitary operation."""
+
+        dev = qml.device('default.qubit', wires=1)
+
+        @qml.qnode(dev)
+        def circuit(matrix):
+            qml.PauliY(0)
+            qml.QubitUnitary(matrix, wires=0)
+            return qml.expval(qml.PauliZ(0))
+
+        matrix = np.array([[1, 0], [0, 0.70710678 + 0.70710678*1.j]])
+        res = circuit(matrix)
+        assert np.isclose(res, -1, atol=tol)
+
 
 class TestQNodeCaching:
     """Tests for the QNode construction caching"""

--- a/tests/qnodes/test_qnode_base.py
+++ b/tests/qnodes/test_qnode_base.py
@@ -841,13 +841,15 @@ class TestQNodeArgs:
         dev = qml.device('default.qubit', wires=1)
 
         @qml.qnode(dev)
-        def circuit(matrix):
+        def circuit(phi, matrix):
+            qml.RZ(phi, wires=0)
             qml.PauliY(0)
             qml.QubitUnitary(matrix, wires=0)
             return qml.expval(qml.PauliZ(0))
 
         matrix = np.array([[1, 0], [0, 0.70710678 + 0.70710678*1.j]])
-        res = circuit(matrix)
+        arg = 0
+        res = circuit(arg, matrix)
         assert np.isclose(res, -1, atol=tol)
 
 


### PR DESCRIPTION
**Context:**
Addresses the #541 issue where a solution to use `lists` internally was suggested. One thing that remained to be explored was whether the change would cause performance loss. Based on benchmarking results, this would not be the case (see **Benchmarking**).


**Description of the Change:**
Applies the change.

**Benefits:**
QubitUnitary can take complex matrices without any performance loss.

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
https://github.com/PennyLaneAI/pennylane/issues/541

**Benchmarking**
Applied the following benchmarks on `default.qubit` and `default.tensor`:
1. Jacobian evaluation uniform
2. Jacobian evaluation front weighted
3. Jacobian evaluation end weighted

*Results:*
1.
* `master` (`14bda6ac`)
```
default.qubit
Timing per loop: [0.19840829 0.19787588 0.19762318 0.19980317 0.19615907]
default.tensor
Timing per loop: [0.50932707 0.50348395 0.54625363 0.57281405 0.55785945]
```
* `qubitunitary_complex`
```
default.qubit
Timing per loop: [0.19553053 0.19500705 0.19569578 0.19744387 0.19749935]
default.tensor
Timing per loop: [0.49085307 0.49242561 0.49676146 0.54970572 0.62043535]
```
2.
* `master` (`14bda6ac`)
```
default.qubit
Timing per loop: [0.20309578 0.21512501 0.22550888 0.24620993 0.22120042]
default.tensor
Timing per loop: [0.4929203  0.48407429 0.54492312 0.53483668 0.54251883]
```
* `qubitunitary_complex`
```
default.qubit
Timing per loop: [0.19708943 0.20109075 0.19832086 0.2071503  0.20457063]
default.tensor
Timing per loop: [0.51847664 0.53745936 0.48450679 0.48453104 0.52049141]
```
3.
* `master` (`14bda6ac`)
```
default.qubit
Timing per loop: [0.19275536 0.20681204 0.19992238 0.19130773 0.19192726]
default.tensor
Timing per loop: [0.48060049 0.4990576  0.50941739 0.48260766 0.50668955]
```
* `qubitunitary_complex`
```
default.qubit
Timing per loop: [0.19727101 0.19401318 0.19108269 0.19018666 0.19539026]
default.tensor
Timing per loop: [0.47466162 0.47048175 0.49106096 0.51919899 0.5440684 ]
```