### PR TITLE
[WIP] Cache previous calls to QNode evaluate

### DIFF
--- a/pennylane/qnodes/base.py
+++ b/pennylane/qnodes/base.py
@@ -208,7 +208,9 @@ class BaseQNode(qml.QueuingContext):
         """float: number of circuit evaluations to store in a cache to speed up subsequent 
         evaluations. If set to zero, no caching occurs."""
 
-        self._hash_evaluate = OrderedDict()  #: OrderedDict[tuple[int, int, int]: Any]: TOODO
+        self._hash_evaluate = OrderedDict()  #: OrderedDict[tuple[int, int, int]: Any]: Mapping
+        # from three hashes to the result of evaluating the QNode. The three hashes are generated
+        # from the arguments, keyword arguments, and circuit, respectively.
 
     def __repr__(self):
         """String representation."""

--- a/pennylane/qnodes/base.py
+++ b/pennylane/qnodes/base.py
@@ -825,6 +825,8 @@ class BaseQNode(qml.QueuingContext):
         temp = self.kwargs.get("use_native_type", False)
         if isinstance(self.device, qml.QubitDevice):
             # TODO: remove this if statement once all devices are ported to the QubitDevice API
+            same_circuit = self.circuit.hash == self.device.circuit_hash
+
             ret = self.device.execute(self.circuit, return_native_type=temp)
         else:
             ret = self.device.execute(

--- a/pennylane/qnodes/base.py
+++ b/pennylane/qnodes/base.py
@@ -212,7 +212,7 @@ def _compare_dicts(dict1, dict2):
     values_2 = []
     for key, value in dict1.items():
         values_1.append(value)
-        v2 = values_2.get(key)
+        v2 = dict2.get(key)
         if v2:
             values_2.append(v2)
         else:
@@ -294,8 +294,12 @@ class BaseQNode(qml.QueuingContext):
         self.output_dim = None  #: int: dimension of the QNode output vector
         self.model = self.device.capabilities()["model"]  #: str: circuit type, in {'cv', 'qubit'}
 
-        self._last_call_args = None  #: list: containing the positional arguments that the QNode was last evaluated on
-        self._last_call_kwargs = None  #: dict: containing the keyword arguments that the QNode was last evaluated on
+        self._last_call_args = (
+            None  #: list: containing the positional arguments that the QNode was last evaluated on
+        )
+        self._last_call_kwargs = (
+            None  #: dict: containing the keyword arguments that the QNode was last evaluated on
+        )
         self._previous_result = None  # previous result of evaluating QNode
 
     def __repr__(self):

--- a/pennylane/qnodes/base.py
+++ b/pennylane/qnodes/base.py
@@ -134,34 +134,28 @@ def decompose_queue(ops, device):
 def _compare_objects(object1, object2):
     """Checks if two objects are equal.
 
-    Supports equality checks for NumPy arrays and TensorFlow/PyTorch tensors without requiring an
-    import of PyTorch or TensorFlow.
-
-    The function uses a broad try/except, which returns False on the exception. This allows us to
-    say that two incompatible objects are not equal without throwing an exception.
+    Performs standard equality check for builtin data types. Also supports comparisons between
+    NumPy arrays and TensorFlow/PyTorch tensors. For TensorFlow/PyTorch tensors, we require
+    that ``object1 is object2``, i.e., that they both refer to the same underlying object.
 
     Args:
-        object1: first item to be compared
-        object2: second item to be compared
+        object1: first object to be compared
+        object2: second object to be compared
 
     Returns:
-        bool: whether the two items are equal
+        bool: whether the two objects are equal
     """
-    try:
-        if type(object1) != type(object2):
-            return False
+    comparison = object1 == object2
 
-        comparison = object1 == object2
-
-        if isinstance(comparison, bool):
-            return comparison
-
-        try:
+    if isinstance(comparison, bool):
+        return comparison
+    if all(isinstance(obj, np.ndarray) for obj in [comparison, object1, object2]):
+        if object1.shape == object2.shape:
             return comparison.all()
-        except AttributeError:
-            return comparison.numpy().all()
-    except Exception:
         return False
+
+    # this case is to support TensorFlow/PyTorch tensors
+    return object1 is object2
 
 
 def _compare_lists(list1, list2):

--- a/pennylane/qnodes/base.py
+++ b/pennylane/qnodes/base.py
@@ -205,7 +205,7 @@ class BaseQNode(qml.QueuingContext):
         self.model = self.device.capabilities()["model"]  #: str: circuit type, in {'cv', 'qubit'}
 
         self._caching = kwargs.get("caching", 0)
-        """float: number of circuit evaluations to store in a cache to speed up subsequent 
+        """float: number of circuit evaluations to store in a cache to speed up subsequent
         evaluations. If set to zero, no caching occurs."""
 
         self._hash_evaluate = OrderedDict()  #: OrderedDict[tuple[int, int, int]: Any]: Mapping
@@ -842,7 +842,7 @@ class BaseQNode(qml.QueuingContext):
                     ret = self._hash_evaluate[hash_tuple]
                 else:
                     ret = self.device.execute(self.circuit, return_native_type=temp)
-                    self._hash_evaluate[(hashed_args, hashed_kwargs, hashed_circuit)] = ret
+                    self._hash_evaluate[hash_tuple] = ret
 
                     if len(self._hash_evaluate) > self.caching:
                         self._hash_evaluate.popitem(last=False)

--- a/pennylane/utils.py
+++ b/pennylane/utils.py
@@ -462,8 +462,8 @@ def _hash_object(obj):
         obj (Any): the object to generate a hash for
 
     Returns:
-        int or None: the resulting hash, or ``None`` if the object is a PyTorch/TensorFlow tensor or any
-        other unhashable type.
+        int or None: the resulting hash, or ``None`` if the object is a PyTorch/TensorFlow tensor or
+        any other unhashable type.
     """
     shape = getattr(obj, "shape", None)
     if shape:  # Check if we have a NumPy array or PyTorch/TensorFlow tensor
@@ -506,7 +506,7 @@ def _hash_dict(dictionary):
     """Returns a single hash for an input dictionary.
 
     Loops over the key-value pairs in the dictionary and creates a hash for each,
-    finally combining all the resulting hash into a single one. The values may be iterables and
+    finally combining all the resulting hashes into a single one. The values may be iterables and
     are passed to :func:`~._hash_iterable`. If any of the dictionary values contain a
     PyTorch/TensorFlow tensor, then no hash is generated and ``None`` is returned.
 

--- a/pennylane/utils.py
+++ b/pennylane/utils.py
@@ -520,6 +520,9 @@ def _hash_dict(dictionary):
     hash_list = []
     for key, value in dictionary.items():
         key_hash = hash(key)
+
+        if not isinstance(value, Iterable):
+            value = [value]
         value_hash = _hash_iterable(value)
 
         if value_hash is None:

--- a/pennylane/utils.py
+++ b/pennylane/utils.py
@@ -465,14 +465,17 @@ def _hash_object(obj):
         int or None: the resulting hash, or None if the object is a PyTorch/TensorFlow tensor or any
         other unhashable type.
     """
-    try:
-        hashed = hash(obj)
-    except TypeError:
+    shape = getattr(obj, "shape", None)
+    if shape:  # Check if we have a NumPy array or PyTorch/TensorFlow tensor
         if isinstance(obj, np.ndarray):
-            hashed = hash(obj.tobytes())
-        else:
+            hashed = hash((obj.tobytes(), shape))
+        else:  # We do not want to hash if we have a PyTorch/TensorFlow tensor
             hashed = None
-
+    else:
+        try:
+            hashed = hash(obj)
+        except TypeError:  # Return None for unhashable types
+            hashed = None
     return hashed
 
 

--- a/pennylane/utils.py
+++ b/pennylane/utils.py
@@ -462,7 +462,7 @@ def _hash_object(obj):
         obj (Any): the object to generate a hash for
 
     Returns:
-        int or None: the resulting hash, or None if the object is a PyTorch/TensorFlow tensor or any
+        int or None: the resulting hash, or ``None`` if the object is a PyTorch/TensorFlow tensor or any
         other unhashable type.
     """
     shape = getattr(obj, "shape", None)

--- a/tests/qnodes/test_qnode_base.py
+++ b/tests/qnodes/test_qnode_base.py
@@ -23,8 +23,7 @@ import numpy as np
 
 import pennylane as qml
 from pennylane._device import Device
-from pennylane.qnodes.base import BaseQNode, QuantumFunctionError, decompose_queue, \
-    _compare_objects, _compare_lists, _compare_dicts
+from pennylane.qnodes.base import BaseQNode, QuantumFunctionError, decompose_queue
 from pennylane.variable import Variable
 from pennylane.wires import Wires, WireError
 
@@ -1501,40 +1500,3 @@ class TestTrainableArgs:
         # the user will evaluate the QNode with.
         node.set_trainable_args({0, 1, 6})
         assert node.get_trainable_args() == {0, 1, 6}
-
-
-class TestComparisonFunctions:
-    """Tests for the _compare_objects, _compare_lists, and _compare_dicts functions."""
-
-    tf = pytest.importorskip("tensorflow")
-    torch = pytest.importorskip("torch")
-
-    np_array = np.ones(2)
-    tf_tensor = tf.ones(2)
-    torch_tensor = torch.ones(2)
-    objects = (
-        (1, 1, True),
-        (1, 2, False),
-        (1.0, 1, True),
-        (1.2, 1.2, True),
-        (np_array, np_array, True),
-        (np_array, 2 * np_array, False),
-        (np_array, 1, False),
-        (np_array, [1, 1], False),
-        (np_array, np.ones((2, 2)), False),
-        (np_array, tf_tensor, False),
-        (tf_tensor, tf_tensor, True),
-        (tf_tensor, 2 * tf_tensor, False),
-        (tf_tensor, 1, False),
-        (tf_tensor, [1, 1], False),
-        (tf_tensor, torch_tensor, False),
-        (torch_tensor, torch_tensor, True),
-        (torch_tensor, 2 * torch_tensor, False),
-        (torch_tensor, 1, False),
-        (torch_tensor, [1, 1], False),
-        (np_array, torch_tensor, False),
-    )
-
-    @pytest.mark.parametrize("obj1, obj2, truth", objects)
-    def test_compare_objects(self, obj1, obj2, truth):
-        assert _compare_objects(obj1, obj2) == truth

--- a/tests/qnodes/test_qnode_base.py
+++ b/tests/qnodes/test_qnode_base.py
@@ -23,7 +23,8 @@ import numpy as np
 
 import pennylane as qml
 from pennylane._device import Device
-from pennylane.qnodes.base import BaseQNode, QuantumFunctionError, decompose_queue
+from pennylane.qnodes.base import BaseQNode, QuantumFunctionError, decompose_queue, \
+    _compare_objects, _compare_lists, _compare_dicts
 from pennylane.variable import Variable
 from pennylane.wires import Wires, WireError
 
@@ -1500,3 +1501,40 @@ class TestTrainableArgs:
         # the user will evaluate the QNode with.
         node.set_trainable_args({0, 1, 6})
         assert node.get_trainable_args() == {0, 1, 6}
+
+
+class TestComparisonFunctions:
+    """Tests for the _compare_objects, _compare_lists, and _compare_dicts functions."""
+
+    tf = pytest.importorskip("tensorflow")
+    torch = pytest.importorskip("torch")
+
+    np_array = np.ones(2)
+    tf_tensor = tf.ones(2)
+    torch_tensor = torch.ones(2)
+    objects = (
+        (1, 1, True),
+        (1, 2, False),
+        (1.0, 1, True),
+        (1.2, 1.2, True),
+        (np_array, np_array, True),
+        (np_array, 2 * np_array, False),
+        (np_array, 1, False),
+        (np_array, [1, 1], False),
+        (np_array, np.ones((2, 2)), False),
+        (np_array, tf_tensor, False),
+        (tf_tensor, tf_tensor, True),
+        (tf_tensor, 2 * tf_tensor, False),
+        (tf_tensor, 1, False),
+        (tf_tensor, [1, 1], False),
+        (tf_tensor, torch_tensor, False),
+        (torch_tensor, torch_tensor, True),
+        (torch_tensor, 2 * torch_tensor, False),
+        (torch_tensor, 1, False),
+        (torch_tensor, [1, 1], False),
+        (np_array, torch_tensor, False),
+    )
+
+    @pytest.mark.parametrize("obj1, obj2, truth", objects)
+    def test_compare_objects(self, obj1, obj2, truth):
+        assert _compare_objects(obj1, obj2) == truth

--- a/tests/qnodes/test_qnode_base.py
+++ b/tests/qnodes/test_qnode_base.py
@@ -1504,31 +1504,36 @@ class TestTrainableArgs:
         assert node.get_trainable_args() == {0, 1, 6}
 
 
+wires = Wires(["a", -1])
+w_a = wires[0]
+w_b = wires[1]
+
+
 class TestQNodeCaching:
     """Tests for QNode caching."""
 
-    dev = qml.device("default.qubit", wires=2)
+    dev = qml.device("default.qubit", wires=wires)
 
     @staticmethod
-    def circuit(a, b, c=1, type="expval", wires=0):
+    def circuit(a, b, c=1, type="expval", wires=w_a):
         """A circuit designed to test the caching capabilities of the QNode."""
-        qml.RX(a, wires=0)
-        qml.Rot(*b[0], wires=1)
-        qml.CNOT(wires=[0, 1])
-        qml.RY(b[1], wires=0)
-        qml.RY(c * b[2][0], wires=0)
-        qml.RY(c * b[2][1], wires=1)
+        qml.RX(a, wires=w_a)
+        qml.Rot(*b[0], wires=w_b)
+        qml.CNOT(wires=[w_a, w_b])
+        qml.RY(b[1], wires=w_a)
+        qml.RY(c * b[2][0], wires=w_a)
+        qml.RY(c * b[2][1], wires=w_b)
         if type == "expval":
             return qml.expval(qml.PauliZ(wires=wires))
         elif type == "samples":
             return qml.sample(qml.PauliZ(wires=wires))
         elif type == "probs":
-            return qml.probs(wires=[0, 1])
+            return qml.probs(wires=[w_a, w_b])
         elif type == "mixed":
-            return qml.expval(qml.PauliZ(wires=0)) @ qml.sample(qml.PauliX(wires=1))
+            return qml.expval(qml.PauliZ(wires=w_a)) @ qml.sample(qml.PauliX(wires=w_b))
 
     args = [0.1, [[0.2, 0.3, 0.4], 0.5, [0.6, 0.7]]]
-    kwargs = {"c": 1, "type": "expval", "wires": 0}
+    kwargs = {"c": 1, "type": "expval", "wires": w_a}
     result = 0.45133003
 
     def test_caching_set(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -852,14 +852,31 @@ def test_flatten_iterable(nonflat, flat):
     assert all(comparison)
 
 
+unhashable_objects = []
+unhashable_iterables = []
+unhashable_dicts = []
+
+try:
+    import torch
+    unhashable_objects.append(torch.ones(3))
+    unhashable_iterables.append([1, [torch.ones(3)]])
+    unhashable_dicts.append({"c": torch.ones(4), "e": "f"})
+except ImportError as e:
+    pass
+
+try:
+    import tensorflow as tf
+    unhashable_objects.append(tf.ones(3))
+    unhashable_iterables.append([[[tf.ones(5)], 1], "g"])
+    unhashable_dicts.append({"a": tf.ones(4), "b": 4})
+except ImportError as e:
+    pass
+
+
 class TestHashing:
     """Tests for the _hash_object, _hash_iterable and _hash_dict functions."""
 
-    torch = pytest.importorskip("torch")
-    tf = pytest.importorskip("tensorflow")
-
     objects = [1, 1.4, "test", "tes", np.ones(6), np.ones((3, 2)), np.zeros(6)]
-    unhashable_objects = [torch.ones(3), tf.ones(3)]
 
     @pytest.mark.parametrize("obj", objects)
     def test_hash(self, obj):
@@ -889,10 +906,6 @@ class TestHashing:
         [np.zeros(6), np.zeros(3)],
         [np.zeros((3, 2)), np.zeros(3)],
         [1, [np.ones(3), {"test_dict": np.ones(3), "other": 9}]],
-    ]
-    unhashable_iterables = [
-        [1, [torch.ones(3)]],
-        [[[tf.ones(5)], 1], "g"],
     ]
 
     @pytest.mark.parametrize("iterable", iterables)
@@ -927,10 +940,6 @@ class TestHashing:
         {"a": iterables[0], "c": iterables[2]},
         {4: "2", "e": iterables[3]},
         {"double": iterables[7], 4: 5},
-    ]
-    unhashable_dicts = [
-        {"a": tf.ones(4), "b": 4},
-        {"c": torch.ones(4), "e": "f"},
     ]
 
     @pytest.mark.parametrize("d", dicts)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -25,6 +25,7 @@ import numpy as np
 import pennylane as qml
 import pennylane._queuing
 import pennylane.utils as pu
+from pennylane.wires import Wires
 
 from pennylane import Identity, PauliX, PauliY, PauliZ
 from pennylane.operation import Tensor
@@ -825,3 +826,41 @@ class TestInv:
             ValueError, match="The given operation_list does not only contain Operations"
         ):
             pu.inv(arg)
+
+
+iterable_flat_pairs = (
+    ([1, [2, [3, [4, [5]]]]], [1, 2, 3, 4, 5]),
+    (["a", ["b"], ["c", ["d"], "e"]], ["a", "b", "c", "d", "e"]),
+    ([1.2, [b"b"]], [1.2, b"b"]),
+    ([[1], [2], [np.ones(4)]], [1, 2, np.ones(4)]),
+    ([Wires(["a", 1, "c"]), ["wires"]], [Wires(["a", 1, "c"]), "wires"])
+)
+
+
+@pytest.mark.parametrize("nonflat, flat", iterable_flat_pairs)
+def test_flatten_iterable(nonflat, flat):
+    """Test that the _flatten_iterable function operates correctly."""
+    flattened = list(pu._flatten_iterable(nonflat))
+
+    comparison = []
+    for f1, f2 in zip(flat, flattened):
+        if isinstance(f1, np.ndarray) and isinstance(f2, np.ndarray):
+            comparison.append((f1 == f2).all())
+        else:
+            comparison.append(f1 == f2)
+
+    assert all(comparison)
+
+
+# class TestHashing:
+#     """Tests for the _hash_iterable and _hash_dict functions."""
+#
+#     iterables = [
+#         [1, 1.4, "f", None],
+#         [1, 1.4, [5, 6, "seven"]],
+#         [np.ones(2), [np.zeros(3)]],
+#         [np.ones(2), [1j * np.zeros(3)]],
+#         [1, [2, [3, [4, [5]]]]],
+#         [np.zeros(3), np.zeros(3)],
+#         [np.zeros(4), np.zeros(2)]
+#     ]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -852,9 +852,32 @@ def test_flatten_iterable(nonflat, flat):
     assert all(comparison)
 
 
-# class TestHashing:
-#     """Tests for the _hash_iterable and _hash_dict functions."""
-#
+class TestHashing:
+    """Tests for the _hash_object, _hash_iterable and _hash_dict functions."""
+
+    torch = pytest.importorskip("torch")
+    tf = pytest.importorskip("tensorflow")
+
+    objects = [1, 1.4, "test", "tes", np.ones(6), np.ones((3, 2)), np.zeros(6)]
+    unhashable_objects = [torch.ones(3), tf.ones(3)]
+
+    @pytest.mark.parametrize("obj", objects)
+    def test_hash(self, obj):
+        """Test that a valid hash is generated"""
+        h = pu._hash_object(obj)
+        assert isinstance(h, int)
+
+    @pytest.mark.parametrize("obj1, obj2", itertools.combinations(objects, r=2))
+    def test_hash_object_different(self, obj1, obj2):
+        """Test that a different hash is given for each test object"""
+        assert pu._hash_object(obj1) != pu._hash_object(obj2)
+
+    @pytest.mark.parametrize("obj", unhashable_objects)
+    def test_invalid_hash(self, obj):
+        """Test that None is returned when passed a PyTorch/TensorFlow tensor"""
+        h = pu._hash_object(obj)
+        assert h is None
+
 #     iterables = [
 #         [1, 1.4, "f", None],
 #         [1, 1.4, [5, 6, "seven"]],


### PR DESCRIPTION
This PR is ready for review, but we have decided to hold-off from the review process for now while we wait for progress in https://github.com/PennyLaneAI/pennylane/pull/784, which is a large change and will require some work to port over the caching.

### Benchmarks

We compare the approach implemented here (A) with the current no-caching approach in `master` (B). We look at a 6 qubits, 6 strongly entangling layers circuit and time over 1000 repetitions.

First let's look at the time each approach takes when evaluating *new* arguments. Here we expect that (A) might be marginally slower than (B) due to the added overhead of caching.

(A): 68.03 s
(B): 69.760 s

Actually (A) is faster than (B), but this is likely simply due to some variation in circuit evaluation times. This shows us that the caching overhead is minimal.

Next, let's look at the time each approach takes when evaluating previously-called arguments. This is the setting where we expect (A) to be faster.

(A): 61.081 s
(B): 69.632 s

There is a speed up, but it's not as big as expected! During subsequent benchmarking, it can be seen that the main overhead of the `evaluate()` method is the call to `self._construct()` for creating and accessing the circuit graph. One option we have is to cache both the result of the circuit *and* the circuit itself, as can be seen [here](https://github.com/PennyLaneAI/pennylane/blob/2b3cd8492f5fdcf42ccd35ba2e1e5fd4d88ea292/pennylane/qnodes/base.py#L825). When doing so, the timings are:

(A):    0.123 s
(B): 70.334 s

However, this approach requires use of `copy.deepcopy()`, resulting in an increased overhead when the cache cannot be used:

(A): 71.689 s
(B): 68.478 s

Due to the changes in https://github.com/PennyLaneAI/pennylane/pull/784, it has been decided to hold off for now on progress with this PR and revisit in future.

The benchmarking script used is:
```python
import pennylane as qml
from pennylane import numpy as np
import time

wires = 6
layers = 6
dev = qml.device("default.qubit", wires=wires)

def f(weights):
    qml.templates.StronglyEntanglingLayers(weights, wires=range(wires))
    return qml.expval(qml.PauliZ(0))

qnode = qml.QNode(f, dev)
cached_qnode = qml.QNode(f, dev, caching=10)

def time_new_evals(qnode, reps=1000):   
    p = [qml.init.strong_ent_layers_uniform(layers, wires, seed=i) for i in range(reps)]
    t0 = time.time()
    for i in range(reps):
        qnode(p[i])
    t1 = time.time()
    return t1 - t0

def time_existing_evals(qnode, reps=1000):
    p = [qml.init.strong_ent_layers_uniform(layers, wires, seed=0) for i in range(reps)]
    t0 = time.time()
    for i in range(reps):
        qnode(p[i])
    t1 = time.time()
    return t1 - t0

reps = 1000

print("Time to run evaluate method")
print("===========================")
print(f"(Total over {reps} repetitions)\n")

print("Time when new arguments are used each evaluation")
print("------------------------------------------------")

t_no_cache = time_new_evals(qnode, reps=reps)

print(f"Without caching: {t_no_cache}\n")

t_cache = time_new_evals(cached_qnode, reps=reps)

print(f"With caching:    {t_cache}")
print()

print("Time when existing arguments are used each evaluation")
print("-----------------------------------------------------")

t_no_cache = time_existing_evals(qnode, reps=reps)

print(f"Without caching: {t_no_cache}\n")

t_cache = time_existing_evals(cached_qnode, reps=reps)

print(f"With caching:    {t_cache}")
```