### PR TITLE
Use has_path instead of nodes_between

### DIFF
--- a/pennylane/beta/tapes/circuit_graph.py
+++ b/pennylane/beta/tapes/circuit_graph.py
@@ -197,6 +197,19 @@ class CircuitGraph:
         B.add(b)
         return A & B
 
+    def has_path(self, a, b):
+        """Checks if a path exists between the two given nodes.
+
+        Args:
+            a (Operator): initial node
+            b (Operator): final node
+
+        Returns:
+            bool: returns ``True`` if a path exists
+        """
+        return nx.has_path(self._graph, a, b)
+
+
     def invisible_operations(self):
         """Operations that cannot affect the circuit output.
 

--- a/pennylane/beta/tapes/tape.py
+++ b/pennylane/beta/tapes/tape.py
@@ -880,7 +880,7 @@ class QuantumTape(AnnotatedQueue):
             # loop over all observables
             for ob in self.observables:
                 # check if op is an ancestor of ob
-                has_path = self.graph.has_path(ob, op)
+                has_path = self.graph.has_path(op, ob)
 
                 # Use finite differences if there is a path, else the gradient is zero
                 best.append("F" if has_path else "0")

--- a/pennylane/beta/tapes/tape.py
+++ b/pennylane/beta/tapes/tape.py
@@ -879,13 +879,11 @@ class QuantumTape(AnnotatedQueue):
 
             # loop over all observables
             for ob in self.observables:
-                # get the set of operations betweens the
-                # operation and the observable
-                S = self.graph.nodes_between(op, ob)
+                # check if op is an ancestor of ob
+                has_path = self.graph.has_path(ob, op)
 
-                # If there is no path between them, gradient is zero
-                # Otherwise, use finite differences
-                best.append("0" if not S else "F")
+                # Use finite differences if there is a path, else the gradient is zero
+                best.append("F" if has_path else "0")
 
             if all(k == "0" for k in best):
                 return "0"


### PR DESCRIPTION
This PR changes the `QuantumTape._grad_method()` to make it more efficient. This method loops over the circuit graph observables and checks if a path exists between a given operator and observable. Presently, this is done by checking the size of the `CircuitGraph.nodes_between()` set, which is size zero if no path exists. However, a more direct approach is to use the new `CircuitGraph.has_path()` method, which internally uses `networkx.algorithms.shortest_paths.generic.has_path()`.

We can benchmark performance between different approaches for both calling the QNode and evaluating its gradient. Using a 6 qubit, 6 layer circuit we compare: (A) approach in this PR, (B) approach in `quantum-tape` branch, (C) approach in `quantum-tape` branch with the `if` statement in line 875 commented out, and (C) approach in `master` branch.

For calling the QNode:

(A) 9.868972063064575 s
(B) 35.24369978904724 s
(C) 7.191902160644531 s
(D) 38.738312005996704 s

This is the time after 500 circuit runs, but there is still a variance. We see that `quantum-tape` and `master` (B) and (D) are similar. The approach here (A) is just a bit slower than (C). In (C), we have simply removed all use of the circuit graph, but this can have a cost when calculating the gradient, which may be calculated for parameters it does not depend on.

For finding the gradient:

(A) 34.37288570404053 s
(B) 35.72118377685547 s
(C) 33.51405596733093 s
(D) 51.98287034034729 s

This is the total time after 20 repetitions. We see that all of the `quantum-tape` based approaches are faster than `master` :tada: Also, we see that (A) (B) and (C) are roughly equivalent for calculating the gradient. For the gradient calculation in (A), 61.51% of the time is spent executing the circuit and 24.51% of the time on getting its parameters - we could look to speed up `get_parameters()` next.

Overall, it looks like (A) is an improvement for circuit evaluation and doesn't hurt for gradient evaluation, so I think it makes sense to add.

(script for (A), needs a few changes to use `master)
```python
import time
import cProfile
import pstats

import tensorflow as tf

import pennylane as qml
from pennylane import numpy as np

from pennylane.beta.tapes import QuantumTape, qnode
from pennylane.beta.queuing import expval, var, sample, probs
from pennylane.beta.interfaces.autograd import AutogradInterface
from pennylane.beta.interfaces.tf import TFInterface

layers = 6
qubits = 6

dev = qml.device("default.qubit", wires=qubits)

@qnode(dev)
def circuit(weights):
    for l in range(layers):
        for i in range(qubits):
            qml.Rot(*weights[l, i], wires=i)
        for i in range(qubits):
            qml.CNOT(wires=[i, (i + 1) % qubits])
    
    return expval(qml.PauliZ(0))


weights = qml.init.strong_ent_layers_uniform(layers, qubits)

repeats = 500

pr = cProfile.Profile()
pr.enable()

t0 = time.time()

for i in range(repeats):
    circuit(weights)

t1 = time.time()
print(t1 - t0)  
pr.disable()

pr.dump_stats("pennylane.pstats")
!gprof2dot -f pstats "pennylane.pstats" | dot -Tpng -o output.png
```