### PR TITLE
[TAPE] Add support for tape gradient bookkeeping and Jacobian computation

### DIFF
--- a/pennylane/beta/queuing/measure.py
+++ b/pennylane/beta/queuing/measure.py
@@ -104,7 +104,7 @@ class MeasurementProcess:
 
         >>> m = MeasurementProcess(Expectation, obs=qml.PauliX(wires=1))
         >>> U.eigvals
-        >>> array([1, -1])
+        array([1, -1])
 
         Returns:
             array: eigvals representation

--- a/pennylane/beta/queuing/measure.py
+++ b/pennylane/beta/queuing/measure.py
@@ -103,7 +103,7 @@ class MeasurementProcess:
         **Example:**
 
         >>> m = MeasurementProcess(Expectation, obs=qml.PauliX(wires=1))
-        >>> U.eigvals
+        >>> m.eigvals
         array([1, -1])
 
         Returns:

--- a/pennylane/beta/tapes/circuit_graph.py
+++ b/pennylane/beta/tapes/circuit_graph.py
@@ -15,6 +15,8 @@
 This module contains the CircuitGraph class which is used to generate a DAG (directed acyclic graph)
 representation of a quantum circuit from an operator and observable queue.
 """
+import networkx as nx
+
 from pennylane import CircuitGraph
 
 
@@ -38,3 +40,15 @@ class NewCircuitGraph(CircuitGraph):
     def observables(self):
         """Observables in the circuit."""
         return self._observables
+
+    def has_path(self, a, b):
+        """Checks if a path exists between the two given nodes.
+
+        Args:
+            a (Operator): initial node
+            b (Operator): final node
+
+        Returns:
+            bool: returns ``True`` if a path exists
+        """
+        return nx.has_path(self._graph, a, b)

--- a/pennylane/beta/tapes/tape.py
+++ b/pennylane/beta/tapes/tape.py
@@ -843,7 +843,7 @@ class QuantumTape(AnnotatedQueue):
         """Execute the tape on a quantum device.
 
         Args:
-            device (~.Device): a PennyLane device
+            device (.Device): a PennyLane device
                 that can execute quantum operations and return measurement statistics
             params (list[Any]): The quantum tape operation parameters. If not provided,
                 the current tape parameters are used (via :meth:`~.get_parameters`).

--- a/pennylane/beta/tapes/tape.py
+++ b/pennylane/beta/tapes/tape.py
@@ -1010,7 +1010,7 @@ class QuantumTape(AnnotatedQueue):
                 info["grad_method"] = self._grad_method(i, use_graph=True)
 
     def _grad_method_validation(self, method):
-        """Validates if the Jacobian method requested is supported by the trainable
+        """Validates if the gradient method requested is supported by the trainable
         parameters, and returns the allowed parameter gradient methods.
 
         This method will generate parameter gradient information if it has not already

--- a/pennylane/beta/tapes/tape.py
+++ b/pennylane/beta/tapes/tape.py
@@ -936,3 +936,374 @@ class QuantumTape(AnnotatedQueue):
     # if they need to perform any logic in between the user's
     # call to tape.execute and the internal call to tape.execute_device.
     _execute = execute_device
+
+    # ========================================================
+    # gradient methods
+    # ========================================================
+
+    def _grad_method(self, idx, use_graph=True, default_method="F"):
+        """Determine the correct partial derivative computation method for each gate parameter.
+
+        Parameter gradient methods include:
+
+        * ``None``: the parameter does not support differentiation.
+
+        * ``"0"``: the variational circuit output does not depend on this
+            parameter (the partial derivative is zero).
+
+        * ``"F"``: the parameter has a non-zero derivative that should be computed
+            using finite-differences.
+
+        * ``"A"``: the parameter has a non-zero derivative that should be computed
+            using an analytic method.
+
+        .. note::
+
+            The base ``QuantumTape`` class only supports numerical differentiation, so
+            this method will always return either ``"F"`` or ``None``. If an inheriting
+            tape supports analytic differentiation for certain operations, make sure
+            that this method is overwritten appropriately to return ``"A"`` where
+            required.
+
+        Args:
+            idx (int): parameter index
+            use_graph: whether to use a directed-acyclic graph to determine
+                if the parameter has a gradient of 0
+            default_method (str): the default differentiation value to return
+                for parameters that where the grad method is not ``"0"`` or ``None``
+
+        Returns:
+            str: partial derivative method to be used
+        """
+        op = self._par_info[idx]["op"]
+
+        if op.grad_method is None:
+            return None
+
+        if (self._graph is not None) or use_graph:
+            # an empty list to store the 'best' partial derivative method
+            # for each observable
+            best = []
+
+            # loop over all observables
+            for ob in self.observables:
+                # check if op is an ancestor of ob
+                has_path = self.graph.has_path(op, ob)
+
+                # Use finite differences if there is a path, else the gradient is zero
+                best.append(default_method if has_path else "0")
+
+            if all(k == "0" for k in best):
+                return "0"
+
+        return default_method
+
+    def _grad_method_validation(self, method):
+        """Validates if the Jacobian method requested is supported by the trainable
+        parameters, and returns the allowed parameter gradient methods.
+
+        This method will generate parameter gradient information if it has not already
+        been generated, and then proceed to validate the gradient method. In particular:
+
+        * An exception will be raised if there exist non-differentiable trainable
+          parameters on the tape.
+
+        * An exception will be raised if the Jacobian method is ``"analytic"`` but there
+          exist some trainable parameters on the tape that only support numeric differentiation.
+
+        If all validations pass, this method will return a tuple containing the allowed parameter
+        gradient methods for each trainable parameter.
+
+        Args:
+            method (str): the overall Jacobian differentiation method
+
+        Returns:
+            tuple[str, None]: the allowed parameter gradient methods for each trainable parameter
+        """
+
+        if "grad_method" not in self._par_info[0]:
+            self._update_gradient_info()
+
+        allowed_param_methods = {
+            idx: info["grad_method"]
+            for idx, info in self._par_info.items()
+            if idx in self.trainable_params
+        }
+
+        # check and raise an error if any parameters are non-differentiable
+        nondiff_params = {idx for idx, g in allowed_param_methods.items() if g is None}
+
+        if nondiff_params:
+            raise ValueError(f"Cannot differentiate with respect to parameter(s) {nondiff_params}")
+
+        numeric_params = {idx for idx, g in allowed_param_methods.items() if g is "F"}
+
+        if method == "analytic":
+            # If explicitly using analytic mode, ensure that all parameters
+            # support analytic differentiation.
+
+            if numeric_params:
+                raise ValueError(
+                    f"The analytic gradient method cannot be used with the argument(s) {numeric_params}."
+                )
+
+        return tuple(allowed_param_methods.values())
+
+    def numeric_pd(self, idx, device, params=None, **options):
+        """Evaluate the gradient of the tape with respect to
+        a single trainable tape parameter using numerical finite-differences.
+
+        Args:
+            idx (int): trainable parameter index to differentiate with respect to
+            device (~.Device, ~.QubitDevice): a PennyLane device
+                that can execute quantum operations and return measurement statistics
+            params (list[Any]): The quantum tape operation parameters. If not provided,
+                the current tape parameter values are used (via :meth:`~.get_parameters`).
+
+        Keyword Args:
+            h=1e-7 (float): finite difference method step size
+            order=1 (int): The order of the finite difference method to use. ``1`` corresponds
+                to forward finite differences, ``2`` to centered finite differences.
+
+        Returns:
+            array[float]: 1-dimensional array of length determined by the tape output
+                measurement statistics
+        """
+        if params is None:
+            params = np.array(self.get_parameters())
+
+        order = options.get("order", 1)
+        h = options.get("h", 1e-7)
+
+        shift = np.zeros_like(params)
+        shift[idx] = h
+
+        if order == 1:
+            # forward finite-difference
+            y0 = options.get("y0", None)
+
+            if y0 is None:
+                y0 = np.asarray(self.execute_device(params, device))
+
+            y = np.array(self.execute_device(params + shift, device))
+            return (y - y0) / h
+
+        if order == 2:
+            # central finite difference
+            shift_forward = np.array(self.execute_device(params + shift / 2, device))
+            shift_backward = np.array(self.execute_device(params - shift / 2, device))
+            return (shift_forward - shift_backward) / h
+
+        raise ValueError("Order must be 1 or 2.")
+
+    def device_pd(self, device, params=None, **options):
+        """Evaluate the gradient of the tape with respect to
+        a single trainable tape parameter by querying the provided device.
+
+        Args:
+            device (~.Device, ~.QubitDevice): a PennyLane device
+                that can execute quantum operations and return measurement statistics
+            params (list[Any]): The quantum tape operation parameters. If not provided,
+                the current tape parameter values are used (via :meth:`~.get_parameters`).
+        """
+        # pylint:disable=unused-argument
+        if params is None:
+            params = np.array(self.get_parameters())
+
+        saved_parameterss = self.get_parameters()
+
+        # temporarily mutate the in-place parameters
+        self.set_parameters(params)
+
+        # TODO: modify devices that have device Jacobian methods to
+        # accept the quantum tape as an argument
+        jac = device.jacobian(self)
+
+        # restore original parameters
+        self.set_parameters(saved_parameterss)
+        return jac
+
+    def analytic_pd(self, idx, device, params=None, **options):
+        """Evaluate the gradient of the tape with respect to
+        a single trainable tape parameter using an analytic method.
+
+        Args:
+            idx (int): trainable parameter index to differentiate with respect to
+            device (~.Device, ~.QubitDevice): a PennyLane device
+                that can execute quantum operations and return measurement statistics
+            params (list[Any]): The quantum tape operation parameters. If not provided,
+                the current tape parameter values are used (via :meth:`~.get_parameters`).
+
+        Returns:
+            array[float]: 1-dimensional array of length determined by the tape output
+                measurement statistics
+        """
+        raise NotImplementedError
+
+    def jacobian(self, device, params=None, **options):
+        r"""Compute the Jacobian of the parametrized quantum circuit recorded by the quantum tape.
+
+        The quantum tape can be interpreted as a simple :math:`\mathbb{R}^m \to \mathbb{R}^n` function,
+        mapping :math:`m` (trainable) gate parameters to :math:`n` measurement statistics,
+        such as expectation values or probabilities.
+
+        By default, the Jacobian will be computed with respect to all parameters on the quantum tape.
+        This can be modified by setting the :attr:`~.trainable_params` attribute of the tape.
+
+        The Jacobian can be computed using several methods:
+
+        * Finite differences (``'numeric'``). The first-order method evaluates the circuit at
+          :math:`n+1` points of the parameter space, the second-order method at :math:`2n` points,
+          where ``n = tape.num_params``.
+
+        * Analytic method (``'analytic'``). Analytic, if implemented by the inheriting quantum tape.
+
+        * Best known method for each parameter (``'best'``): uses the analytic method if
+          possible, otherwise finite difference.
+
+        * Device method (``'device'``): Delegates the computation of the Jacobian to the
+          device executing the circuit. Only supported by devices that provide their
+          own method for computing derivatives; support can be checked by
+          querying the device capabilities: ``dev.capabilities()['provides_jacobian']`` must
+          return ``True``. Examples of supported devices include the experimental
+          :class:`"default.tensor.tf" <~.DefaultTensorTF>` device.
+
+        .. note::
+
+            The finite difference method is sensitive to statistical noise in the circuit output,
+            since it compares the output at two points infinitesimally close to each other. Hence
+            the ``'F'`` method works best with exact expectation values when using simulator
+            devices.
+
+        Args:
+            device (~.Device, ~.QubitDevice): a PennyLane device
+                that can execute quantum operations and return measurement statistics
+            params (list[Any]): The quantum tape operation parameters. If not provided,
+                the current tape parameter values are used (via :meth:`~.get_parameters`).
+
+        Keyword Args:
+            method="best" (str): The differentiation method. Must be one of ``"numeric"``,
+                ``"analytic"``, ``"best"``, or ``"device"``.
+            h=1e-7 (float): finite difference method step size
+            order=1 (int): The order of the finite difference method to use. ``1`` corresponds
+                to forward finite differences, ``2`` to centered finite differences.
+
+        Returns:
+            array[float]: 2-dimensional array of shape ``(tape.num_params, tape.output_dim)``
+
+        **Example**
+
+        .. code-block:: python
+
+            from pennylane.beta.tapes import QuantumTape
+            from pennylane.beta.queuing import expval, var, sample, probs
+
+            with QuantumTape() as tape:
+                qml.RX(0.432, wires=0)
+                qml.RY(0.543, wires=0)
+                qml.CNOT(wires=[0, 'a'])
+                qml.RX(0.133, wires='a')
+                probs(wires=[0, 'a'])
+
+        If parameters are not provided, the existing tape parameters are used:
+
+        >>> dev = qml.device("default.qubit", wires=[0, 'a'])
+        >>> tape.jacobian(dev)
+        array([[-0.178441  , -0.23358253, -0.05892804],
+               [-0.00079144, -0.00103601,  0.05892804],
+               [ 0.00079144,  0.00103601,  0.00737611],
+               [ 0.178441  ,  0.23358253, -0.00737611]])
+
+        Parameters can be optionally passed during execution:
+
+        >>> tape.jacobian(dev, params=[1.0, 0.0, 1.0])
+        array([[-3.24029934e-01, -9.99200722e-09, -3.24029934e-01],
+               [-9.67055711e-02, -2.77555756e-09,  3.24029935e-01],
+               [ 9.67055709e-02,  3.05311332e-09,  9.67055709e-02],
+               [ 3.24029935e-01,  1.08246745e-08, -9.67055711e-02]])
+
+        Parameters provided for execution are temporary, and do not affect
+        the tapes' parameters in-place:
+
+        >>> tape.get_parameters()
+        [0.432, 0.543, 0.133]
+
+        Explicitly setting the trainable parameters can significantly reduce
+        computational resources, as non-trainable parameters are ignored
+        during the computation:
+
+        >>> tape.trainable_params = {0} # set only the first parameter as trainable
+        >>> tape.jacobian(dev)
+        array([[-0.178441  ],
+               [-0.00079144],
+               [ 0.00079144],
+               [ 0.178441  ]])
+
+        If a tape has no trainable parameters, the Jacobian will be empty:
+
+        >>> tape.trainable_params = {}
+        >>> tape.jacobian(dev)
+        array([], shape=(4, 0), dtype=float64)
+        """
+        method = options.get("method", "best")
+
+        if method not in ("best", "numeric", "analytic", "device"):
+            raise ValueError(f"Unknown gradient method '{method}'")
+
+        if params is None:
+            params = self.get_parameters()
+
+        params = np.array(params)
+
+        if method == "device":
+            # Using device mode; simply query the device for the Jacobian
+            return self.device_pd(device, params=params, **options)
+
+        # perform gradient method validation
+        allowed_param_methods = self._grad_method_validation(method)
+
+        if not params.size or all(g == "0" for g in allowed_param_methods):
+            # Either all parameters had grad method 0, or there are no trainable
+            # parameters. Simply return an empty Jacobian.
+            return np.zeros((self.output_dim, len(params)), dtype=float)
+
+        if method == "numeric" or "F" in allowed_param_methods:
+            # there exist parameters that will be differentiated numerically
+
+            if options.get("order", 1) == 1:
+                # First order (forward) finite-difference will be performed.
+                # Compute the value of the tape at the current parameters here. This ensures
+                # this computation is only performed once, for all parameters.
+                options["y0"] = np.asarray(self.execute_device(params, device))
+
+        jac = None
+        p_ind = list(np.ndindex(*params.shape))
+
+        # loop through each parameter and compute the gradient
+        for idx, (l, param_method) in enumerate(zip(p_ind, allowed_param_methods)):
+
+            if param_method == "0":
+                # Independent parameter. Skip, as this parameter has a gradient of 0.
+                continue
+
+            if (method == "best" and param_method == "F") or (method == "numeric"):
+                # finite difference method
+                g = self.numeric_pd(l, device, params=params, **options)
+
+            elif (method == "best" and param_method == "A") or (method == "analytic"):
+                # analytic method
+                g = self.analytic_pd(l, device, params=params, **options)
+
+            if g.dtype is np.dtype("object"):
+                # object arrays cannot be flattened; must hstack them
+                g = np.hstack(g)
+
+            if jac is None:
+                # The Jacobian matrix has not yet been created, as we needed at least
+                # one device execution to occur so that we could ensure that the output
+                # dimension is known.
+                jac = np.zeros((self.output_dim, len(params)), dtype=float)
+
+            jac[:, idx] = g.flatten()
+
+        return jac

--- a/pennylane/beta/tapes/tape.py
+++ b/pennylane/beta/tapes/tape.py
@@ -1090,7 +1090,9 @@ class QuantumTape(AnnotatedQueue):
         shift[idx] = h
 
         if order == 1:
-            # forward finite-difference
+            # Forward finite-difference.
+            # Check if the device has already be pre-computed with
+            # unshifted parameter values, to avoid redundant evaluations.
             y0 = options.get("y0", None)
 
             if y0 is None:

--- a/pennylane/beta/tapes/tape.py
+++ b/pennylane/beta/tapes/tape.py
@@ -1047,7 +1047,7 @@ class QuantumTape(AnnotatedQueue):
         if nondiff_params:
             raise ValueError(f"Cannot differentiate with respect to parameter(s) {nondiff_params}")
 
-        numeric_params = {idx for idx, g in allowed_param_methods.items() if g is "F"}
+        numeric_params = {idx for idx, g in allowed_param_methods.items() if g == "F"}
 
         if method == "analytic":
             # If explicitly using analytic mode, ensure that all parameters

--- a/pennylane/beta/tapes/tape.py
+++ b/pennylane/beta/tapes/tape.py
@@ -1288,7 +1288,7 @@ class QuantumTape(AnnotatedQueue):
                 options["y0"] = np.asarray(self.execute_device(params, device))
 
         jac = None
-        p_ind = list(np.ndindex(*params.shape))
+        p_ind = range(len(params))
 
         # loop through each parameter and compute the gradient
         for idx, (l, param_method) in enumerate(zip(p_ind, allowed_param_methods)):

--- a/pennylane/beta/tapes/tape.py
+++ b/pennylane/beta/tapes/tape.py
@@ -1096,7 +1096,7 @@ class QuantumTape(AnnotatedQueue):
             if y0 is None:
                 y0 = np.asarray(self.execute_device(params, device))
 
-            y = np.array(self.execute_device(params + shift, device))
+            y = np.asarray(self.execute_device(params + shift, device))
             return (y - y0) / h
 
         if order == 2:

--- a/pennylane/beta/tapes/tape.py
+++ b/pennylane/beta/tapes/tape.py
@@ -350,17 +350,6 @@ class QuantumTape(AnnotatedQueue):
         )
         self.num_wires = len(self.wires)
 
-    def _update_gradient_info(self):
-        """Update the parameter information dictionary with gradient information
-        of each parameter"""
-
-        for i, info in self._par_info.items():
-
-            if i not in self.trainable_params:
-                info["grad_method"] = None
-            else:
-                info["grad_method"] = self._grad_method(i, use_graph=True)
-
     def _update_par_info(self):
         """Update the parameter information dictionary"""
         param_count = 0
@@ -384,9 +373,6 @@ class QuantumTape(AnnotatedQueue):
         self._update_circuit_info()
         self._update_par_info()
         self._update_trainable_params()
-
-        if self.interface is not None:
-            self._update_gradient_info()
 
     def expand(self, depth=1, stop_at=None, expand_measurements=False):
         """Expand all operations in the processed queue to a specific depth.
@@ -1012,6 +998,17 @@ class QuantumTape(AnnotatedQueue):
 
         return default_method
 
+    def _update_gradient_info(self):
+        """Update the parameter information dictionary with gradient information
+        of each parameter"""
+
+        for i, info in self._par_info.items():
+
+            if i not in self.trainable_params:
+                info["grad_method"] = None
+            else:
+                info["grad_method"] = self._grad_method(i, use_graph=True)
+
     def _grad_method_validation(self, method):
         """Validates if the Jacobian method requested is supported by the trainable
         parameters, and returns the allowed parameter gradient methods.
@@ -1124,7 +1121,7 @@ class QuantumTape(AnnotatedQueue):
         if params is None:
             params = np.array(self.get_parameters())
 
-        saved_parameterss = self.get_parameters()
+        saved_parameters = self.get_parameters()
 
         # temporarily mutate the in-place parameters
         self.set_parameters(params)
@@ -1134,7 +1131,7 @@ class QuantumTape(AnnotatedQueue):
         jac = device.jacobian(self)
 
         # restore original parameters
-        self.set_parameters(saved_parameterss)
+        self.set_parameters(saved_parameters)
         return jac
 
     def analytic_pd(self, idx, device, params=None, **options):

--- a/pennylane/beta/tapes/tape.py
+++ b/pennylane/beta/tapes/tape.py
@@ -350,6 +350,17 @@ class QuantumTape(AnnotatedQueue):
         )
         self.num_wires = len(self.wires)
 
+    def _update_gradient_info(self):
+        """Update the parameter information dictionary with gradient information
+        of each parameter"""
+
+        for i, info in self._par_info.items():
+
+            if i not in self.trainable_params:
+                info["grad_method"] = None
+            else:
+                info["grad_method"] = self._grad_method(i, use_graph=True)
+
     def _update_par_info(self):
         """Update the parameter information dictionary"""
         param_count = 0
@@ -373,6 +384,9 @@ class QuantumTape(AnnotatedQueue):
         self._update_circuit_info()
         self._update_par_info()
         self._update_trainable_params()
+
+        if self.interface is not None:
+            self._update_gradient_info()
 
     def expand(self, depth=1, stop_at=None, expand_measurements=False):
         """Expand all operations in the processed queue to a specific depth.

--- a/pennylane/beta/tapes/tape.py
+++ b/pennylane/beta/tapes/tape.py
@@ -949,13 +949,13 @@ class QuantumTape(AnnotatedQueue):
         * ``None``: the parameter does not support differentiation.
 
         * ``"0"``: the variational circuit output does not depend on this
-            parameter (the partial derivative is zero).
+          parameter (the partial derivative is zero).
 
         * ``"F"``: the parameter has a non-zero derivative that should be computed
-            using finite-differences.
+          using finite-differences.
 
         * ``"A"``: the parameter has a non-zero derivative that should be computed
-            using an analytic method.
+          using an analytic method.
 
         .. note::
 
@@ -1049,14 +1049,12 @@ class QuantumTape(AnnotatedQueue):
 
         numeric_params = {idx for idx, g in allowed_param_methods.items() if g == "F"}
 
-        if method == "analytic":
-            # If explicitly using analytic mode, ensure that all parameters
-            # support analytic differentiation.
-
-            if numeric_params:
-                raise ValueError(
-                    f"The analytic gradient method cannot be used with the argument(s) {numeric_params}."
-                )
+        # If explicitly using analytic mode, ensure that all parameters
+        # support analytic differentiation.
+        if method == "analytic" and numeric_params:
+            raise ValueError(
+                f"The analytic gradient method cannot be used with the argument(s) {numeric_params}."
+            )
 
         return tuple(allowed_param_methods.values())
 
@@ -1066,7 +1064,7 @@ class QuantumTape(AnnotatedQueue):
 
         Args:
             idx (int): trainable parameter index to differentiate with respect to
-            device (~.Device, ~.QubitDevice): a PennyLane device
+            device (.Device, .QubitDevice): a PennyLane device
                 that can execute quantum operations and return measurement statistics
             params (list[Any]): The quantum tape operation parameters. If not provided,
                 the current tape parameter values are used (via :meth:`~.get_parameters`).
@@ -1078,7 +1076,7 @@ class QuantumTape(AnnotatedQueue):
 
         Returns:
             array[float]: 1-dimensional array of length determined by the tape output
-                measurement statistics
+            measurement statistics
         """
         if params is None:
             params = np.array(self.get_parameters())
@@ -1111,10 +1109,10 @@ class QuantumTape(AnnotatedQueue):
 
     def device_pd(self, device, params=None, **options):
         """Evaluate the gradient of the tape with respect to
-        a single trainable tape parameter by querying the provided device.
+        all trainable tape parameters by querying the provided device.
 
         Args:
-            device (~.Device, ~.QubitDevice): a PennyLane device
+            device (.Device, .QubitDevice): a PennyLane device
                 that can execute quantum operations and return measurement statistics
             params (list[Any]): The quantum tape operation parameters. If not provided,
                 the current tape parameter values are used (via :meth:`~.get_parameters`).
@@ -1142,7 +1140,7 @@ class QuantumTape(AnnotatedQueue):
 
         Args:
             idx (int): trainable parameter index to differentiate with respect to
-            device (~.Device, ~.QubitDevice): a PennyLane device
+            device (.Device, .QubitDevice): a PennyLane device
                 that can execute quantum operations and return measurement statistics
             params (list[Any]): The quantum tape operation parameters. If not provided,
                 the current tape parameter values are used (via :meth:`~.get_parameters`).
@@ -1189,7 +1187,7 @@ class QuantumTape(AnnotatedQueue):
             devices.
 
         Args:
-            device (~.Device, ~.QubitDevice): a PennyLane device
+            device (.Device, .QubitDevice): a PennyLane device
                 that can execute quantum operations and return measurement statistics
             params (list[Any]): The quantum tape operation parameters. If not provided,
                 the current tape parameter values are used (via :meth:`~.get_parameters`).
@@ -1276,7 +1274,7 @@ class QuantumTape(AnnotatedQueue):
         allowed_param_methods = self._grad_method_validation(method)
 
         if not params.size or all(g == "0" for g in allowed_param_methods):
-            # Either all parameters had grad method 0, or there are no trainable
+            # Either all parameters have grad method 0, or there are no trainable
             # parameters. Simply return an empty Jacobian.
             return np.zeros((self.output_dim, len(params)), dtype=float)
 

--- a/tests/beta/tapes/test_tape.py
+++ b/tests/beta/tapes/test_tape.py
@@ -1117,8 +1117,12 @@ class TestJacobian:
             expval(qml.PauliY(0))
 
         dev = qml.device("default.qubit", wires=1)
-        dev.jacobian = mocker.Mock()
 
+        dev.jacobian = mocker.Mock()
+        tape.device_pd(dev)
+        dev.jacobian.assert_called_once()
+
+        dev.jacobian = mocker.Mock()
         tape.jacobian(dev, method="device")
         dev.jacobian.assert_called_once()
 

--- a/tests/beta/tapes/test_tape.py
+++ b/tests/beta/tapes/test_tape.py
@@ -1346,24 +1346,6 @@ class TestJacobianIntegration:
 
         res = tape.jacobian(dev)
         assert res.shape == (6, 3)
-
-    def test_ragged_output(self):
-        """Test that the Jacobian is correctly returned for a tape
-        with ragged output"""
-        dev = qml.device("default.qubit", wires=3)
-        params = [1.0, 1.0, 1.0]
-
-        with QuantumTape() as tape:
-            qml.RX(params[0], wires=[0])
-            qml.RY(params[1], wires=[1])
-            qml.RZ(params[2], wires=[2])
-            qml.CNOT(wires=[0, 1])
-            probs(wires=0)
-            probs(wires=[1, 2])
-
-        res = tape.jacobian(dev)
-        assert res.shape == (6, 3)
-
     def test_single_expectation_value(self, tol):
         """Tests correct output shape and evaluation for a tape
         with a single expval output"""

--- a/tests/beta/tapes/test_tape.py
+++ b/tests/beta/tapes/test_tape.py
@@ -1213,7 +1213,7 @@ class TestJacobian:
         assert len(analytic_spy.call_args_list) == 0
 
         # the numeric pd method is only called for parameter 0
-        assert numeric_spy.call_args[0] == (tape, (0,), dev)
+        assert numeric_spy.call_args[0] == (tape, 0, dev)
 
     def test_no_trainable_parameters(self, mocker):
         """Test that if the tape has no trainable parameters, no

--- a/tests/beta/tapes/test_tape.py
+++ b/tests/beta/tapes/test_tape.py
@@ -167,14 +167,14 @@ class TestConstruction:
     def test_parameter_info(self, make_tape):
         """Test that parameter information is correctly extracted"""
         tape, ops, obs = make_tape
-        # tape._update_gradient_info()
+        tape._update_gradient_info()
         assert tape._trainable_params == set(range(5))
         assert tape._par_info == {
-            0: {"op": ops[0], "p_idx": 0},  # , "grad_method": "F"},
-            1: {"op": ops[1], "p_idx": 0},  # , "grad_method": "F"},
-            2: {"op": ops[1], "p_idx": 1},  # , "grad_method": "F"},
-            3: {"op": ops[1], "p_idx": 2},  # , "grad_method": "F"},
-            4: {"op": ops[3], "p_idx": 0},  # , "grad_method": "0"},
+            0: {"op": ops[0], "p_idx": 0, "grad_method": "F"},
+            1: {"op": ops[1], "p_idx": 0, "grad_method": "F"},
+            2: {"op": ops[1], "p_idx": 1, "grad_method": "F"},
+            3: {"op": ops[1], "p_idx": 2, "grad_method": "F"},
+            4: {"op": ops[3], "p_idx": 0, "grad_method": "0"},
         }
 
     def test_qubit_diagonalization(self, make_tape):

--- a/tests/beta/tapes/test_tape.py
+++ b/tests/beta/tapes/test_tape.py
@@ -994,3 +994,529 @@ class TestCVExecution:
 
         res = tape.execute(dev)
         assert res.shape == (2,)
+
+
+class TestGradMethod:
+    """Tests for parameter gradient methods"""
+
+    def test_non_differentiable(self):
+        """Test that a non-differentiable parameter is
+        correctly marked"""
+        psi = np.array([1, 0, 1, 0]) / np.sqrt(2)
+
+        with QuantumTape() as tape:
+            qml.QubitStateVector(psi, wires=[0, 1])
+            qml.RX(0.543, wires=[0])
+            qml.RY(-0.654, wires=[1])
+            qml.CNOT(wires=[0, 1])
+            probs(wires=[0, 1])
+
+        assert tape._grad_method(0) is None
+        assert tape._grad_method(1) == "F"
+        assert tape._grad_method(2) == "F"
+
+        tape._update_gradient_info()
+
+        assert tape._par_info[0]["grad_method"] is None
+        assert tape._par_info[1]["grad_method"] == "F"
+        assert tape._par_info[2]["grad_method"] == "F"
+
+    def test_independent(self):
+        """Test that an independent variable is properly marked
+        as having a zero gradient"""
+
+        with QuantumTape() as tape:
+            qml.RX(0.543, wires=[0])
+            qml.RY(-0.654, wires=[1])
+            expval(qml.PauliY(0))
+
+        assert tape._grad_method(0) == "F"
+        assert tape._grad_method(1) == "0"
+
+        tape._update_gradient_info()
+
+        assert tape._par_info[0]["grad_method"] == "F"
+        assert tape._par_info[1]["grad_method"] == "0"
+
+        # in non-graph mode, it is impossible to determine
+        # if a parameter is independent or not
+        tape._graph = None
+        assert tape._grad_method(1, use_graph=False) == "F"
+
+
+class TestJacobian:
+    """Unit tests for the jacobian method"""
+
+    def test_unknown_grad_method_error(self):
+        """Test error raised if gradient method is unknown"""
+        tape = QuantumTape()
+        with pytest.raises(ValueError, match="Unknown gradient method"):
+            tape.jacobian(None, method="unknown method")
+
+    def test_non_differentiable_error(self):
+        """Test error raised if attempting to differentiate with
+        respect to a non-differentiable argument"""
+        psi = np.array([1, 0, 1, 0]) / np.sqrt(2)
+
+        with QuantumTape() as tape:
+            qml.QubitStateVector(psi, wires=[0, 1])
+            qml.RX(0.543, wires=[0])
+            qml.RY(-0.654, wires=[1])
+            qml.CNOT(wires=[0, 1])
+            probs(wires=[0, 1])
+
+        # by default all parameters are assumed to be trainable
+        with pytest.raises(
+            ValueError, match=r"Cannot differentiate with respect to parameter\(s\) {0}"
+        ):
+            tape.jacobian(None)
+
+        # setting trainable parameters avoids this
+        tape.trainable_params = {1, 2}
+        dev = qml.device("default.qubit", wires=2)
+        res = tape.jacobian(dev)
+        assert res.shape == (4, 2)
+
+    def test_analytic_method_with_unsupported_params(self):
+        """Test that an exception is raised if method="A" but a parameter
+        only support finite differences"""
+        with QuantumTape() as tape:
+            qml.RX(0.543, wires=[0])
+            qml.RY(-0.654, wires=[0])
+            expval(qml.PauliY(0))
+
+        dev = qml.device("default.qubit", wires=1)
+
+        with pytest.raises(ValueError, match=r"analytic gradient method cannot be used"):
+            tape.jacobian(dev, method="analytic")
+
+    def test_analytic_method(self, mocker):
+        """Test that calling the Jacobian with method=analytic correctly
+        calls the analytic_pd method"""
+        mock = mocker.patch("pennylane.beta.tapes.QuantumTape._grad_method")
+        mock.return_value = "A"
+
+        with QuantumTape() as tape:
+            qml.RX(0.543, wires=[0])
+            qml.RY(-0.654, wires=[0])
+            expval(qml.PauliY(0))
+
+        dev = qml.device("default.qubit", wires=1)
+        tape.analytic_pd = mocker.Mock()
+        tape.analytic_pd.return_value = np.array([1.0])
+
+        tape.jacobian(dev, method="analytic")
+        assert len(tape.analytic_pd.call_args_list) == 2
+
+    def test_device_method(self, mocker):
+        """Test that calling the Jacobian with method=device correctly
+        calls the device_pd method"""
+        with QuantumTape() as tape:
+            qml.RX(0.543, wires=[0])
+            qml.RY(-0.654, wires=[0])
+            expval(qml.PauliY(0))
+
+        dev = qml.device("default.qubit", wires=1)
+        dev.jacobian = mocker.Mock()
+
+        tape.jacobian(dev, method="device")
+        dev.jacobian.assert_called_once()
+
+    def test_no_output_execute(self):
+        """Test that tapes with no measurement process return
+        an empty list."""
+        dev = qml.device("default.qubit", wires=2)
+        params = [0.1, 0.2]
+
+        with QuantumTape() as tape:
+            qml.RX(params[0], wires=[0])
+            qml.RY(params[1], wires=[1])
+
+        res = tape.jacobian(dev)
+        assert res.size == 0
+
+    def test_incorrect_inferred_output_dim(self):
+        """Test that a quantum tape with an incorrect inferred output dimension
+        corrects itself when computing the Jacobian."""
+        dev = qml.device("default.qubit", wires=3)
+        params = [1.0, 1.0, 1.0]
+
+        with QuantumTape() as tape:
+            qml.RX(params[0], wires=[0])
+            qml.RY(params[1], wires=[1])
+            qml.RZ(params[2], wires=[2])
+            qml.CNOT(wires=[0, 1])
+            probs(wires=0)
+            probs(wires=[1])
+
+        # inferred output dim should be correct
+        assert tape.output_dim == sum([2, 2])
+
+        # modify the output dim
+        tape._output_dim = 2
+
+        res = tape.jacobian(dev, order=2)
+
+        # output dim should be correct
+        assert tape.output_dim == sum([2, 2])
+        assert res.shape == (4, 3)
+
+    def test_incorrect_ragged_output_dim(self, mocker):
+        """Test that a quantum tape with an incorrect inferred *ragged* output dimension
+        corrects itself after evaluation."""
+        dev = qml.device("default.qubit", wires=3)
+        params = [1.0, 1.0, 1.0]
+
+        with QuantumTape() as tape:
+            qml.RX(params[0], wires=[0])
+            qml.RY(params[1], wires=[1])
+            qml.RZ(params[2], wires=[2])
+            qml.CNOT(wires=[0, 1])
+            probs(wires=0)
+            probs(wires=[1, 2])
+
+        # inferred output dim should be correct
+        assert tape.output_dim == sum([2, 4])
+
+        # modify the output dim
+        tape._output_dim = 2
+
+        res = tape.jacobian(dev, order=2)
+
+        # output dim should be correct
+        assert tape.output_dim == sum([2, 4])
+        assert res.shape == (6, 3)
+
+    def test_independent_parameter(self, mocker):
+        """Test that an independent parameter is skipped
+        during the Jacobian computation."""
+        numeric_spy = mocker.spy(QuantumTape, "numeric_pd")
+        analytic_spy = mocker.spy(QuantumTape, "analytic_pd")
+
+        with QuantumTape() as tape:
+            qml.RX(0.543, wires=[0])
+            qml.RY(-0.654, wires=[1])
+            expval(qml.PauliZ(0))
+
+        dev = qml.device("default.qubit", wires=2)
+        res = tape.jacobian(dev)
+        assert res.shape == (1, 2)
+
+        # the numeric pd method is only called once
+        assert len(numeric_spy.call_args_list) == 1
+
+        # analytic pd should not be called at all
+        assert len(analytic_spy.call_args_list) == 0
+
+        # the numeric pd method is only called for parameter 0
+        assert numeric_spy.call_args[0] == (tape, (0,), dev)
+
+    def test_no_trainable_parameters(self, mocker):
+        """Test that if the tape has no trainable parameters, no
+        subroutines are called and the returned Jacobian is empty"""
+        numeric_spy = mocker.spy(QuantumTape, "numeric_pd")
+        analytic_spy = mocker.spy(QuantumTape, "analytic_pd")
+
+        with QuantumTape() as tape:
+            qml.RX(0.543, wires=[0])
+            qml.RY(-0.654, wires=[1])
+            expval(qml.PauliZ(0))
+
+        dev = qml.device("default.qubit", wires=2)
+        tape.trainable_params = {}
+
+        res = tape.jacobian(dev)
+        assert res.size == 0
+        assert np.all(res == np.array([[]]))
+
+        numeric_spy.assert_not_called()
+        analytic_spy.assert_not_called()
+
+    def test_y0(self, mocker):
+        """Test that if first order finite differences is used, then
+        the tape is executed only once using the current parameter
+        values."""
+        execute_spy = mocker.spy(QuantumTape, "execute_device")
+        numeric_spy = mocker.spy(QuantumTape, "numeric_pd")
+
+        with QuantumTape() as tape:
+            qml.RX(0.543, wires=[0])
+            qml.RY(-0.654, wires=[0])
+            expval(qml.PauliZ(0))
+
+        dev = qml.device("default.qubit", wires=2)
+        res = tape.jacobian(dev, order=1)
+
+        # the execute device method is called once per parameter,
+        # plus one global call
+        assert len(execute_spy.call_args_list) == tape.num_params + 1
+        assert "y0" in numeric_spy.call_args_list[0][1]
+        assert "y0" in numeric_spy.call_args_list[1][1]
+
+    def test_parameters(self, tol):
+        """Test Jacobian computation works when parameters are both passed and not passed."""
+        dev = qml.device("default.qubit", wires=2)
+        params = [0.1, 0.2]
+
+        with QuantumTape() as tape:
+            qml.RX(params[0], wires=[0])
+            qml.RY(params[1], wires=[1])
+            qml.CNOT(wires=[0, 1])
+            expval(qml.PauliZ(0) @ qml.PauliX(1))
+
+        # test Jacobian with no parameters
+        res1 = tape.jacobian(dev)
+        assert tape.get_parameters() == params
+
+        # test Jacobian with parameters
+        res2 = tape.jacobian(dev, params=[0.5, 0.6])
+        assert tape.get_parameters() == params
+
+        # test setting parameters
+        tape.set_parameters(params=[0.5, 0.6])
+        res3 = tape.jacobian(dev)
+        assert np.allclose(res2, res3, atol=tol, rtol=0)
+        assert not np.allclose(res1, res2, atol=tol, rtol=0)
+        assert tape.get_parameters() == [0.5, 0.6]
+
+    def test_numeric_pd_no_y0(self, mocker, tol):
+        """Test that, if y0 is not passed when calling the numeric_pd method,
+        y0 is calculated."""
+        execute_spy = mocker.spy(QuantumTape, "execute_device")
+
+        dev = qml.device("default.qubit", wires=2)
+        params = [0.1, 0.2]
+
+        with QuantumTape() as tape:
+            qml.RX(params[0], wires=[0])
+            qml.RY(params[1], wires=[1])
+            qml.CNOT(wires=[0, 1])
+            expval(qml.PauliZ(0) @ qml.PauliX(1))
+
+        # compute numeric gradient of parameter 0, without passing y0
+        res1 = tape.numeric_pd(0, dev)
+        assert len(execute_spy.call_args_list) == 2
+
+        # compute y0 in advance
+        y0 = tape.execute(dev)
+        execute_spy.call_args_list = []
+        res2 = tape.numeric_pd(0, dev, y0=y0)
+        assert len(execute_spy.call_args_list) == 1
+        assert np.allclose(res1, res2, atol=tol, rtol=0)
+
+    def test_numeric_unknown_order(self):
+        """Test that an exception is raised if the finite-difference
+        order is not supported"""
+        dev = qml.device("default.qubit", wires=2)
+        params = [0.1, 0.2]
+
+        with QuantumTape() as tape:
+            qml.RX(1, wires=[0])
+            qml.RY(1, wires=[1])
+            qml.RZ(1, wires=[2])
+            qml.CNOT(wires=[0, 1])
+            expval(qml.PauliZ(0) @ qml.PauliX(1) @ qml.PauliZ(2))
+            for k, v in tape._queue.items():
+                print(k, v)
+
+        with pytest.raises(ValueError, match="Order must be 1 or 2"):
+            tape.jacobian(dev, order=3)
+
+
+class TestJacobianIntegration:
+    """Integration tests for the Jacobian method"""
+
+    def test_ragged_output(self):
+        """Test that the Jacobian is correctly returned for a tape
+        with ragged output"""
+        dev = qml.device("default.qubit", wires=3)
+        params = [1.0, 1.0, 1.0]
+
+        with QuantumTape() as tape:
+            qml.RX(params[0], wires=[0])
+            qml.RY(params[1], wires=[1])
+            qml.RZ(params[2], wires=[2])
+            qml.CNOT(wires=[0, 1])
+            probs(wires=0)
+            probs(wires=[1, 2])
+
+        res = tape.jacobian(dev)
+        assert res.shape == (6, 3)
+
+    def test_ragged_output(self):
+        """Test that the Jacobian is correctly returned for a tape
+        with ragged output"""
+        dev = qml.device("default.qubit", wires=3)
+        params = [1.0, 1.0, 1.0]
+
+        with QuantumTape() as tape:
+            qml.RX(params[0], wires=[0])
+            qml.RY(params[1], wires=[1])
+            qml.RZ(params[2], wires=[2])
+            qml.CNOT(wires=[0, 1])
+            probs(wires=0)
+            probs(wires=[1, 2])
+
+        res = tape.jacobian(dev)
+        assert res.shape == (6, 3)
+
+    def test_single_expectation_value(self, tol):
+        """Tests correct output shape and evaluation for a tape
+        with a single expval output"""
+        dev = qml.device("default.qubit", wires=2)
+        x = 0.543
+        y = -0.654
+
+        with QuantumTape() as tape:
+            qml.RX(x, wires=[0])
+            qml.RY(y, wires=[1])
+            qml.CNOT(wires=[0, 1])
+            expval(qml.PauliZ(0) @ qml.PauliX(1))
+
+        res = tape.jacobian(dev)
+        assert res.shape == (1, 2)
+
+        expected = np.array([[-np.sin(y) * np.sin(x), np.cos(y) * np.cos(x)]])
+        assert np.allclose(res, expected, atol=tol, rtol=0)
+
+    def test_multiple_expectation_values(self, tol):
+        """Tests correct output shape and evaluation for a tape
+        with multiple expval outputs"""
+        dev = qml.device("default.qubit", wires=2)
+        x = 0.543
+        y = -0.654
+
+        with QuantumTape() as tape:
+            qml.RX(x, wires=[0])
+            qml.RY(y, wires=[1])
+            qml.CNOT(wires=[0, 1])
+            expval(qml.PauliZ(0))
+            expval(qml.PauliX(1))
+
+        res = tape.jacobian(dev)
+        assert res.shape == (2, 2)
+
+        expected = np.array([[-np.sin(x), 0], [0, np.cos(y)]])
+        assert np.allclose(res, expected, atol=tol, rtol=0)
+
+    def test_var_expectation_values(self, tol):
+        """Tests correct output shape and evaluation for a tape
+        with expval and var outputs"""
+        dev = qml.device("default.qubit", wires=2)
+        x = 0.543
+        y = -0.654
+
+        with QuantumTape() as tape:
+            qml.RX(x, wires=[0])
+            qml.RY(y, wires=[1])
+            qml.CNOT(wires=[0, 1])
+            expval(qml.PauliZ(0))
+            var(qml.PauliX(1))
+
+        res = tape.jacobian(dev)
+        assert res.shape == (2, 2)
+
+        expected = np.array([[-np.sin(x), 0], [0, -2 * np.cos(y) * np.sin(y)]])
+        assert np.allclose(res, expected, atol=tol, rtol=0)
+
+    def test_prob_expectation_values(self, tol):
+        """Tests correct output shape and evaluation for a tape
+        with prob and expval outputs"""
+        dev = qml.device("default.qubit", wires=2)
+        x = 0.543
+        y = -0.654
+
+        with QuantumTape() as tape:
+            qml.RX(x, wires=[0])
+            qml.RY(y, wires=[1])
+            qml.CNOT(wires=[0, 1])
+            expval(qml.PauliZ(0))
+            probs(wires=[0, 1])
+
+        res = tape.jacobian(dev)
+        assert res.shape == (5, 2)
+
+        expected = (
+            np.array(
+                [
+                    [-2 * np.sin(x), 0],
+                    [
+                        -(np.cos(y / 2) ** 2 * np.sin(x)),
+                        -(np.cos(x / 2) ** 2 * np.sin(y)),
+                    ],
+                    [
+                        -(np.sin(x) * np.sin(y / 2) ** 2),
+                        (np.cos(x / 2) ** 2 * np.sin(y)),
+                    ],
+                    [
+                        (np.sin(x) * np.sin(y / 2) ** 2),
+                        (np.sin(x / 2) ** 2 * np.sin(y)),
+                    ],
+                    [
+                        (np.cos(y / 2) ** 2 * np.sin(x)),
+                        -(np.sin(x / 2) ** 2 * np.sin(y)),
+                    ],
+                ]
+            )
+            / 2
+        )
+
+        assert np.allclose(res, expected, atol=tol, rtol=0)
+
+
+class TestJacobianCVIntegration:
+    """Intgration tests for the Jacobian method and CV circuits"""
+
+    def test_single_output_value(self, tol):
+        """Tests correct Jacobian and output shape for a CV tape
+        with a single output"""
+        dev = qml.device("default.gaussian", wires=2)
+        n = 0.543
+        a = -0.654
+
+        with QuantumTape() as tape:
+            qml.ThermalState(n, wires=0)
+            qml.Displacement(a, 0, wires=0)
+            var(qml.NumberOperator(0))
+
+        tape.trainable_params = {0, 1}
+        res = tape.jacobian(dev)
+        assert res.shape == (1, 2)
+
+        expected = np.array([2 * a ** 2 + 2 * n + 1, 2 * a * (2 * n + 1)])
+        assert np.allclose(res, expected, atol=tol, rtol=0)
+
+    def test_multiple_output_values(self, tol):
+        """Tests correct output shape and evaluation for a tape
+        with multiple outputs"""
+        dev = qml.device("default.gaussian", wires=2)
+        n = 0.543
+        a = -0.654
+
+        with QuantumTape() as tape:
+            qml.ThermalState(n, wires=0)
+            qml.Displacement(a, 0, wires=0)
+            expval(qml.NumberOperator(0))
+            var(qml.NumberOperator(0))
+
+        tape.trainable_params = {0, 1}
+        res = tape.jacobian(dev)
+        assert res.shape == (2, 2)
+
+        expected = np.array([[1, 2 * a], [2 * a ** 2 + 2 * n + 1, 2 * a * (2 * n + 1)]])
+        assert np.allclose(res, expected, atol=tol, rtol=0)
+
+    def test_trainable_measurement(self, tol):
+        """Test that a trainable measurement can be differentiated"""
+        dev = qml.device("default.gaussian", wires=2)
+        a = 0.32
+        phi = 0.54
+
+        with QuantumTape() as tape:
+            qml.Displacement(a, 0, wires=0)
+            expval(qml.QuadOperator(phi, wires=0))
+
+        tape.trainable_params = {2}
+        res = tape.jacobian(dev)
+        expected = np.array([[-2 * a * np.sin(phi)]])
+        assert np.allclose(res, expected, atol=tol, rtol=0)


### PR DESCRIPTION
**Context:** Extends the beta quantum tape to support Jacobian computation.

**Description of the Change:**

This PR adds the features and methods found in the `JacobianQNode` to the quantum tape. In particular, this includes:

* Gradient bookkeeping: validating and calculating the allowed parameter gradients, by inspecting the `grad_method` attribute of operations, and ensuring that the requested Jacobian method is supported by all parameters.

* Adds a new `NewCircuitGraph.has_path` method to the circuit graph, to help us determine whether there is a path between a parametrized operation and a measurement. This is a replacement for the `node_between` method, which has additional overhead; we only care that a path exists, we do not care to know the operations inbetween. This method was added and benchmarked by @trbromley.

  This method is used to determine whether there are any _independent_ parameters in the circuit; that is, parameters marked as 'trainable' by the interface, but do not affect the output. By checking this, we can avoid redundant quantum evaluations for this parameter; we simply insert zeros into the Jacobian.

  **Question:** how likely is this to happen? We are trading extra quantum evaluations for additional classical processing (constructing the circuit graph).

* Adds the following methods:

  - `numeric_pd`: for first and second order finite difference
  - `analytic_pd`: abstract, can be defined by subclasses
  - `device_pd`: for querying the device itself for the Jacobian. Devices need to be modified to support receiving a tape in the `device.jacobian` method.
  - `jacobian`: for constructing the jacobian.

**Benefits:**

In porting the `JacobianQNode` methods to the quantum tape, we have the hindsight to perform various optimizations compared to the core implementation.

This includes:

- using `has_path` rather than `nodes_between`

- being more selective as to when the gradient validation occurs

- being more elegant in how gradient options are passed to the various methods

- separating the gradient method validation as its own method, as opposed to including it within the `jacobian` method.

**~Possible Drawbacks~ Future questions:**

It is worth thinking about two things while reviewing this PR:

* How we should 'accumulate' tapes generated by the Jacobian for loop, and submit all tapes via a `device.batch_execute` call. @mariaschuld is currently looking into this.

* How SPSA fits into the Jacobian method. SPSA is a stochastic method of estimating the gradient by considering only a subset of all parameters; it can likely use either finite-diff or parameter-shift under the hood. @antalszava is currently looking into this.

While these won't be implemented here, they are worthwhile keeping in mind!

**Related GitHub Issues:** n/a
