### PR TITLE
Add qml.CY operation

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -7,53 +7,59 @@
   of pure states into mixed states due to noise and decoherence. It
   allows the user to simulate noise, benchmark algorithms running on
   real hardware, and to test error-correction techniques. Moreover,
-  differentiable quantum channels could be a unique feature for 
+  differentiable quantum channels could be a unique feature for
   PennyLane not present in other libraries.
 
   [(#760)](https://github.com/PennyLaneAI/pennylane/pull/760)
   [(#766)](https://github.com/PennyLaneAI/pennylane/pull/766)
   [(#778)](https://github.com/PennyLaneAI/pennylane/pull/778)
 
+* The controlled-Y operation is now available via `qml.CY`. For devices that do
+  not natively support the controlled-Y operation, it will be decomposed
+  into `qml.RY`, `qml.CNOT`, and `qml.S` operations.
+  [(#806)](https://github.com/PennyLaneAI/pennylane/pull/806)
+
+
 <h3>Improvements</h3>
 
-* Sped up the application of certain gates in ``default.qubit`` by using array/tensor
-  manipulation tricks. The following gates are affected: ``PauliX``, ``PauliY``, ``PauliZ``,
-  ``Hadamard``, ``SWAP``, ``S``, ``T``, ``CNOT``, ``CZ``.
+* Sped up the application of certain gates in `default.qubit` by using array/tensor
+  manipulation tricks. The following gates are affected: `PauliX`, `PauliY`, `PauliZ`,
+  `Hadamard`, `SWAP`, `S`, `T`, `CNOT`, `CZ`.
   [(#772)](https://github.com/PennyLaneAI/pennylane/pull/772)
 
-* Adds arithmetic operations (addition, tensor product, 
-  subtraction, and scalar multiplication) between ``Hamiltonian``, 
-  ``Tensor``, and ``Observable`` objects, and inline arithmetic 
+* Adds arithmetic operations (addition, tensor product,
+  subtraction, and scalar multiplication) between `Hamiltonian`,
+  `Tensor`, and `Observable` objects, and inline arithmetic
   operations between Hamiltonians and other observables.
   [(#765)](https://github.com/PennyLaneAI/pennylane/pull/765)
-  
+
   Hamiltonians can now easily be defined as sums of observables:
-  
+
   ```pycon3
   >>> H = 3 * qml.PauliZ(0) - (qml.PauliX(0) @ qml.PauliX(1)) + qml.Hamiltonian([4], [qml.PauliZ(0)])
   >>> print(H)
   (7.0) [Z0] + (-1.0) [X0 X1]
   ```
 
-* Adds ``compare()`` method to `Observable` and `Hamiltonian` classes, which allows
+* Adds `compare()` method to `Observable` and `Hamiltonian` classes, which allows
   for comparison between observable quantities.
   [(#765)](https://github.com/PennyLaneAI/pennylane/pull/765)
-  
+
   ```pycon3
   >>> H = qml.Hamiltonian([1], [qml.PauliZ(0)])
   >>> obs = qml.PauliZ(0) @ qml.Identity(1)
   >>> print(H.compare(obs))
   True
   ```
-  
+
   ```pycon3
   >>> H = qml.Hamiltonian([2], [qml.PauliZ(0)])
   >>> obs = qml.PauliZ(1) @ qml.Identity(0)
   >>> print(H.compare(obs))
   False
   ```
-  
-* Adds ``simplify()`` method to the ``Hamiltonian`` class.
+
+* Adds `simplify()` method to the `Hamiltonian` class.
   [(#765)](https://github.com/PennyLaneAI/pennylane/pull/765)
 
   ```pycon3
@@ -62,7 +68,7 @@
   >>> print(H)
   (3.0) [Z0]
   ```
-  
+
 * Added a new bit-flip mixer to the `qml.qaoa` module.
   [(#774)](https://github.com/PennyLaneAI/pennylane/pull/774)
 
@@ -70,8 +76,8 @@
 
 <h3>Bug fixes</h3>
 
-* Changed to use lists for storing variable values inside ``BaseQNode``
-  allowing complex matrices to be passed to ``QubitUnitary``.
+* Changed to use lists for storing variable values inside `BaseQNode`
+  allowing complex matrices to be passed to `QubitUnitary`.
   [(#773)](https://github.com/PennyLaneAI/pennylane/pull/773)
 
 <h3>Documentation</h3>
@@ -220,7 +226,7 @@ Aroosa Ijaz, Juan Miguel Arrazola, Thomas Bromley, Jack Ceroni, Josh Izaac, Anta
   can be strings or numbers.
   [(#666)](https://github.com/XanaduAI/pennylane/pull/666)
 
-  Custom wire labels are defined by passing a list to the ``wires`` argument when creating the device:
+  Custom wire labels are defined by passing a list to the `wires` argument when creating the device:
 
   ```pycon
   >>> dev = qml.device("default.qubit", wires=['anc1', 'anc2', 0, 1, 3])
@@ -237,7 +243,7 @@ Aroosa Ijaz, Juan Miguel Arrazola, Thomas Bromley, Jack Ceroni, Josh Izaac, Anta
   ```
 
   The existing behaviour, in which the number of wires is specified on device initialization,
-  continues to work as usual. This gives a default behaviour where wires are labelled 
+  continues to work as usual. This gives a default behaviour where wires are labelled
   by consecutive integers.
 
   ```pycon
@@ -250,7 +256,7 @@ Aroosa Ijaz, Juan Miguel Arrazola, Thomas Bromley, Jack Ceroni, Josh Izaac, Anta
   [(#724)](https://github.com/PennyLaneAI/pennylane/pull/724)
   [(#733)](https://github.com/PennyLaneAI/pennylane/pull/733)
 
-  The test can be invoked against a particular device by calling the ``pl-device-test``
+  The test can be invoked against a particular device by calling the `pl-device-test`
   command line program:
 
   ```console
@@ -433,7 +439,7 @@ Isacsson, Josh Izaac, Nathan Killoran, Maria Schuld, Antal Száva, Nicola Vitucc
 
 <h3>Improvements</h3>
 
-* Improves the wire management by making the ``Operator.wires`` attribute a ``wires`` object.
+* Improves the wire management by making the `Operator.wires` attribute a `wires` object.
   [(#666)](https://github.com/XanaduAI/pennylane/pull/666)
 
 * A significant improvement with respect to how QNodes and interfaces mark quantum function
@@ -691,14 +697,14 @@ Nathan Killoran, Maria Schuld, Antal Száva, Nicola Vitucci.
   <img src="https://pennylane.readthedocs.io/en/latest/_images/iqp.png"
   width=50%></img>
 
-* Added the ``SimplifiedTwoDesign`` template, which implements the circuit
+* Added the `SimplifiedTwoDesign` template, which implements the circuit
   design of [Cerezo et al. (2020)](<https://arxiv.org/abs/2001.00550>).
   [(#556)](https://github.com/XanaduAI/pennylane/pull/556)
 
   <img src="https://pennylane.readthedocs.io/en/latest/_images/simplified_two_design.png"
   width=50%></img>
 
-* Added the ``BasicEntanglerLayers`` template, which is a simple layer architecture
+* Added the `BasicEntanglerLayers` template, which is a simple layer architecture
   of rotations and CNOT nearest-neighbour entanglers.
   [(#555)](https://github.com/XanaduAI/pennylane/pull/555)
 
@@ -793,7 +799,7 @@ Nathan Killoran, Maria Schuld, Antal Száva, Nicola Vitucci.
   - `"backprop"`: Use classical backpropagation. Default on simulator
     devices that are classically end-to-end differentiable.
     The returned QNode can only be used with the same machine learning
-    framework (e.g., ``default.tensor.tf`` simulator with the ``tensorflow`` interface).
+    framework (e.g., `default.tensor.tf` simulator with the `tensorflow` interface).
 
   - `"device"`: Queries the device directly for the gradient.
 

--- a/doc/introduction/operations.rst
+++ b/doc/introduction/operations.rst
@@ -66,8 +66,9 @@ Qubit gates
     ~pennylane.PauliRot
     ~pennylane.PhaseShift
     ~pennylane.CNOT
-    ~pennylane.SWAP
     ~pennylane.CZ
+    ~pennylane.CY
+    ~pennylane.SWAP
     ~pennylane.U1
     ~pennylane.U2
     ~pennylane.U3

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -103,6 +103,7 @@ class DefaultQubit(QubitDevice):
         "SWAP",
         "CSWAP",
         "Toffoli",
+        "CY",
         "CZ",
         "PhaseShift",
         "RX",

--- a/pennylane/devices/tests/test_gates.py
+++ b/pennylane/devices/tests/test_gates.py
@@ -45,6 +45,7 @@ ops = {
     "CRot": qml.CRot(0, 0, 0, wires=[0, 1]),
     "CSWAP": qml.CSWAP(wires=[0, 1, 2]),
     "CZ": qml.CZ(wires=[0, 1]),
+    "CY": qml.CY(wires=[0, 1]),
     "DiagonalQubitUnitary": qml.DiagonalQubitUnitary(np.eye(2), wires=[0]),
     "Hadamard": qml.Hadamard(wires=[0]),
     "MultiRZ": qml.MultiRZ(0, wires=[0]),
@@ -77,6 +78,7 @@ T = np.diag([1, np.exp(1j * np.pi / 4)])
 SWAP = np.array([[1, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 0], [0, 0, 0, 1]])
 CNOT = np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]])
 CZ = np.diag([1, 1, 1, -1])
+CY = np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, -1j], [0, 0, 1j, 0]])
 toffoli = np.diag([1 for i in range(8)])
 toffoli[6:8, 6:8] = np.array([[0, 1], [1, 0]])
 CSWAP = block_diag(I, I, SWAP)
@@ -150,7 +152,7 @@ single_qubit_param = [
     (qml.RZ, rz),
 ]
 # list of all non-parametrized two-qubit gates
-two_qubit = [(qml.CNOT, CNOT), (qml.SWAP, SWAP), (qml.CZ, CZ)]
+two_qubit = [(qml.CNOT, CNOT), (qml.SWAP, SWAP), (qml.CZ, CZ), (qml.CY, CY)]
 # list of all parametrized two-qubit gates
 two_qubit_param = [(qml.CRX, crx), (qml.CRY, cry), (qml.CRZ, crz)]
 two_qubit_multi_param = [(qml.CRot, crot)]

--- a/pennylane/ops/qubit.py
+++ b/pennylane/ops/qubit.py
@@ -364,6 +364,49 @@ class CZ(DiagonalOperation):
         return cls.eigvals
 
 
+class CY(Operation):
+    r"""CY(wires)
+    The controlled-Y operator
+
+    .. math:: CY = \begin{bmatrix}
+            1 & 0 & 0 & 0 \\
+            0 & 1 & 0 & 0\\
+            0 & 0 & 0 & -i\\
+            0 & 0 & i & 0
+        \end{bmatrix}.
+
+    .. note:: The first wire provided corresponds to the **control qubit**.
+
+    **Details:**
+
+    * Number of wires: 2
+    * Number of parameters: 0
+
+    Args:
+        wires (Sequence[int] or int): the wires the operation acts on
+    """
+    num_params = 0
+    num_wires = 2
+    par_domain = None
+    matrix = np.array(
+        [
+            [1, 0, 0, 0],
+            [0, 1, 0, 0],
+            [0, 0, 0, -1j],
+            [0, 0, 1j, 0],
+        ]
+    )
+
+    @classmethod
+    def _matrix(cls, *params):
+        return cls.matrix
+
+    @staticmethod
+    def decomposition(wires):
+        decomp_ops = [CRY(np.pi, wires=wires), S(wires=wires[0])]
+        return decomp_ops
+
+
 class SWAP(Operation):
     r"""SWAP(wires)
     The swap operator
@@ -1569,6 +1612,7 @@ ops = {
     "T",
     "CNOT",
     "CZ",
+    "CY",
     "SWAP",
     "CSWAP",
     "Toffoli",

--- a/tests/ops/test_qubit_ops.py
+++ b/tests/ops/test_qubit_ops.py
@@ -461,6 +461,21 @@ class TestOperations:
 
         assert np.allclose(decomposed_matrix, global_phase * op.matrix, atol=tol, rtol=0)
 
+    def test_CY_decomposition(self, tol):
+        """Tests that the decomposition of the CY gate is correct"""
+        op = qml.CY(wires=[0, 1])
+        res = op.decomposition(op.wires)
+
+        mats = []
+        for i in reversed(res):
+            if len(i.wires) == 1:
+                mats.append(np.kron(i.matrix, np.eye(2)))
+            else:
+                mats.append(i.matrix)
+
+        decomposed_matrix = np.linalg.multi_dot(mats)
+        assert np.allclose(decomposed_matrix, op.matrix, atol=tol, rtol=0)
+
     def test_phase_shift(self, tol):
         """Test phase shift is correct"""
 


### PR DESCRIPTION
**Context:** PennyLane currently has the CX (CNOT) and CZ gates, but does not provide the CY operation.

**Description of the Change:**

* Adds the CY operation to PennyLane, as `qml.CY`.

* Adds the decomposition `CY = S(0) @ CRY(pi/2, [0, 1])` for devices that don't support the CY gate natively. If a device does not support CRY, this will also be decomposed automatically.

* Adds tests.

**Benefits:** n/a

**Possible Drawbacks:** n/a

**Related GitHub Issues:** n/a
