### PR TITLE
Add ``__add__`` to Wires class.

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 <h3>New features since last release</h3>
 
-* Addition of two `Wires` objects is now supported and will return 
+* Summation of two `Wires` objects is now supported and will return 
   a `Wires` object containing the set of all wires defined by the 
   terms in the summation.
   [(#812)](https://github.com/PennyLaneAI/pennylane/pull/812)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 <h3>New features since last release</h3>
 
+* Addition of two `Wires` objects is now supported and will return 
+  a `Wires` object containing the set of all wires defined by the 
+  terms in the summation.
+  [(#812)](https://github.com/PennyLaneAI/pennylane/pull/812)
+
 * Quantum noisy channels: quantum channels provide a general
   formalism for discussing state evolution, including the evolution
   of pure states into mixed states due to noise and decoherence. It

--- a/pennylane/wires.py
+++ b/pennylane/wires.py
@@ -192,7 +192,7 @@ class Wires(Sequence):
         """
         Return the indices of the wires in this Wires object.
 
-        ** Example:**
+        **Example:**
 
         >>> wires1 =  Wires([4, 0, 1])
         >>> wires2 = Wires([1, 4])
@@ -215,7 +215,7 @@ class Wires(Sequence):
     def map(self, wire_map):
         """Returns a new Wires object with different labels, using the rule defined in mapping.
 
-        Example:
+        **Example:**
 
         >>> wires = Wires(['a', 'b', 'c'])
         >>> wire_map = {'a': 4, 'b':2, 'c': 3}
@@ -252,7 +252,7 @@ class Wires(Sequence):
         Returns a new Wires object which is a subset of this Wires object. The wires of the new
         object are the wires at positions specified by 'indices'. Also accepts a single index as input.
 
-        For example:
+        **Example:**
 
         >>> wires = Wires([4, 0, 1, 5, 6])
         >>> wires.subset([2, 3, 0])
@@ -264,7 +264,7 @@ class Wires(Sequence):
         so that  ``wires.subset(i) == wires.subset(i % n_wires)`` where ``n_wires`` is the number of wires of this
         object.
 
-        For example:
+        **Example:**
 
         >>> wires = Wires([4, 0, 1, 5, 6])
         >>> wires.subset([5, 1, 7], periodic_boundary=True)
@@ -324,7 +324,7 @@ class Wires(Sequence):
 
         This is similar to a set intersection method, but keeps the order of wires as they appear in the list.
 
-        For example:
+        **Example:**
 
         >>> wires1 =  Wires([4, 0, 1])
         >>> wires2 = Wires([3, 0, 4])
@@ -362,7 +362,7 @@ class Wires(Sequence):
 
         This is similar to a set combine method, but keeps the order of wires as they appear in the list.
 
-        For example:
+        **Example:**
 
         >>> wires1 = Wires([4, 0, 1])
         >>> wires2 = Wires([3, 0, 4])
@@ -401,7 +401,7 @@ class Wires(Sequence):
     def unique_wires(list_of_wires):
         """Return the wires that are unique to any Wire object in the list.
 
-        For example:
+        **Example:**
 
         >>> wires1 = Wires([4, 0, 1])
         >>> wires2 = Wires([0, 2, 3])

--- a/pennylane/wires.py
+++ b/pennylane/wires.py
@@ -106,6 +106,37 @@ class Wires(Sequence):
         """Implements the hash function."""
         return hash(repr(self.labels))
 
+    def __add__(self, other):
+        """Defines the addition to return a Wires object containing all wires of the two terms.
+
+         ** Example:**
+
+        >>> wires1 =  Wires([4, 0, 1])
+        >>> wires2 = Wires([1, 2])
+        >>> wires1 + wires2
+        Wires([4, 0, 1, 2])
+
+        Args:
+            other (Iterable[Number,str], Number, Wires): object to add from the right
+
+        Returns:
+            Wires: all wires appearing in either object
+        """
+        other = Wires(other)
+        return Wires(Wires.all_wires([self, other]))
+
+    def __radd__(self, other):
+        """Defines addition according to __add__ if the left object has no addition defined.
+
+        Args:
+            other (Iterable[Number,str], Number, Wires): object to add from the left
+
+        Returns:
+            Wires: all wires appearing in either object
+        """
+        other = Wires(other)
+        return Wires(Wires.all_wires([other, self]))
+
     def __array__(self):
         """Defines a numpy array representation of the Wires object.
 
@@ -161,7 +192,7 @@ class Wires(Sequence):
         """
         Return the indices of the wires in this Wires object.
 
-        For example,
+        ** Example:**
 
         >>> wires1 =  Wires([4, 0, 1])
         >>> wires2 = Wires([1, 4])

--- a/pennylane/wires.py
+++ b/pennylane/wires.py
@@ -109,7 +109,7 @@ class Wires(Sequence):
     def __add__(self, other):
         """Defines the addition to return a Wires object containing all wires of the two terms.
 
-         ** Example:**
+         **Example:**
 
         >>> wires1 =  Wires([4, 0, 1])
         >>> wires2 = Wires([1, 2])

--- a/pennylane/wires.py
+++ b/pennylane/wires.py
@@ -109,18 +109,18 @@ class Wires(Sequence):
     def __add__(self, other):
         """Defines the addition to return a Wires object containing all wires of the two terms.
 
-         **Example:**
-
-        >>> wires1 =  Wires([4, 0, 1])
-        >>> wires2 = Wires([1, 2])
-        >>> wires1 + wires2
-        Wires([4, 0, 1, 2])
-
         Args:
             other (Iterable[Number,str], Number, Wires): object to add from the right
 
         Returns:
             Wires: all wires appearing in either object
+
+        **Example**
+
+        >>> wires1 =  Wires([4, 0, 1])
+        >>> wires2 = Wires([1, 2])
+        >>> wires1 + wires2
+        Wires([4, 0, 1, 2])
         """
         other = Wires(other)
         return Wires(Wires.all_wires([self, other]))
@@ -192,7 +192,13 @@ class Wires(Sequence):
         """
         Return the indices of the wires in this Wires object.
 
-        **Example:**
+        Args:
+            wires (Iterable[Number, str], Number, str, Wires): Wire(s) whose indices are to be found
+
+        Returns:
+            List: index list
+
+        **Example**
 
         >>> wires1 =  Wires([4, 0, 1])
         >>> wires2 = Wires([1, 4])
@@ -200,12 +206,6 @@ class Wires(Sequence):
         [2, 0]
         >>> wires1.indices([1, 4])
         [2, 0]
-
-        Args:
-            wires (Iterable[Number, str], Number, str, Wires): Wire(s) whose indices are to be found
-
-        Returns:
-            List: index list
         """
         if not isinstance(wires, Iterable):
             return [self.index(wires)]
@@ -215,16 +215,15 @@ class Wires(Sequence):
     def map(self, wire_map):
         """Returns a new Wires object with different labels, using the rule defined in mapping.
 
-        **Example:**
+        Args:
+            wire_map (dict): Dictionary containing all wire labels used in this object as keys, and unique
+                             new labels as their values
+        **Example**
 
         >>> wires = Wires(['a', 'b', 'c'])
         >>> wire_map = {'a': 4, 'b':2, 'c': 3}
         >>> wires.map(wire_map)
         <Wires = [4, 2, 3]>
-
-        Args:
-            wire_map (dict): Dictionary containing all wire labels used in this object as keys, and unique
-                             new labels as their values
         """
         # Make sure wire_map has `Wires` keys and values so that the `in` operator always works
         wire_map = {Wires(k): Wires(v) for k, v in wire_map.items()}
@@ -252,7 +251,14 @@ class Wires(Sequence):
         Returns a new Wires object which is a subset of this Wires object. The wires of the new
         object are the wires at positions specified by 'indices'. Also accepts a single index as input.
 
-        **Example:**
+        Args:
+            indices (List[int] or int): indices or index of the wires we want to select
+            periodic_boundary (bool): controls periodic boundary conditions in the indexing
+
+        Returns:
+            Wires: subset of wires
+
+        **Example**
 
         >>> wires = Wires([4, 0, 1, 5, 6])
         >>> wires.subset([2, 3, 0])
@@ -264,18 +270,10 @@ class Wires(Sequence):
         so that  ``wires.subset(i) == wires.subset(i % n_wires)`` where ``n_wires`` is the number of wires of this
         object.
 
-        **Example:**
-
         >>> wires = Wires([4, 0, 1, 5, 6])
         >>> wires.subset([5, 1, 7], periodic_boundary=True)
         <Wires = [4, 0, 1]>
 
-        Args:
-            indices (List[int] or int): indices or index of the wires we want to select
-            periodic_boundary (bool): controls periodic boundary conditions in the indexing
-
-        Returns:
-            Wires: subset of wires
         """
 
         if isinstance(indices, int):
@@ -324,7 +322,13 @@ class Wires(Sequence):
 
         This is similar to a set intersection method, but keeps the order of wires as they appear in the list.
 
-        **Example:**
+        Args:
+            list_of_wires (List[Wires]): list of Wires objects
+
+        Returns:
+            Wires: shared wires
+
+        **Example**
 
         >>> wires1 =  Wires([4, 0, 1])
         >>> wires2 = Wires([3, 0, 4])
@@ -333,12 +337,6 @@ class Wires(Sequence):
         <Wires = [4, 0]>
         >>> Wires.shared_wires([wires2, wires1, wires3])
         <Wires = [0, 4]>
-
-        Args:
-            list_of_wires (List[Wires]): list of Wires objects
-
-        Returns:
-            Wires: shared wires
         """
 
         for wires in list_of_wires:
@@ -362,15 +360,6 @@ class Wires(Sequence):
 
         This is similar to a set combine method, but keeps the order of wires as they appear in the list.
 
-        **Example:**
-
-        >>> wires1 = Wires([4, 0, 1])
-        >>> wires2 = Wires([3, 0, 4])
-        >>> wires3 = Wires([5, 3])
-        >>> list_of_wires = [wires1, wires2, wires3]
-        >>> Wires.all_wires(list_of_wires)
-        <Wires = [4, 0, 1, 3, 5]>
-
         Args:
             list_of_wires (List[Wires]): List of Wires objects
             sort (bool): Toggle for sorting the combined wire labels. The sorting is based on
@@ -378,6 +367,15 @@ class Wires(Sequence):
 
         Returns:
             Wires: combined wires
+
+        **Example**
+
+        >>> wires1 = Wires([4, 0, 1])
+        >>> wires2 = Wires([3, 0, 4])
+        >>> wires3 = Wires([5, 3])
+        >>> list_of_wires = [wires1, wires2, wires3]
+        >>> Wires.all_wires(list_of_wires)
+        <Wires = [4, 0, 1, 3, 5]>
         """
 
         combined = []
@@ -401,19 +399,19 @@ class Wires(Sequence):
     def unique_wires(list_of_wires):
         """Return the wires that are unique to any Wire object in the list.
 
-        **Example:**
+        Args:
+            list_of_wires (List[Wires]): list of Wires objects
+
+        Returns:
+            Wires: unique wires
+
+        **Example**
 
         >>> wires1 = Wires([4, 0, 1])
         >>> wires2 = Wires([0, 2, 3])
         >>> wires3 = Wires([5, 3])
         >>> Wires.unique_wires([wires1, wires2, wires3])
         <Wires = [4, 1, 2, 5]>
-
-        Args:
-            list_of_wires (List[Wires]): list of Wires objects
-
-        Returns:
-            Wires: unique wires
         """
 
         for wires in list_of_wires:

--- a/tests/test_wires.py
+++ b/tests/test_wires.py
@@ -135,6 +135,19 @@ class TestWires:
 
         assert (0, 3) in wires
 
+    def test_add_two_wires_objects(self):
+        """Tests that wires objects add correctly."""
+        wires1 = Wires([4, 0, 1])
+        wires2 = Wires([1, 2])
+        assert wires1 + wires2 == Wires([4, 0, 1, 2])
+
+    def test_add_wires_object_with_iterable(self):
+        """Tests that wires objects add correctly."""
+        wires1 = [4, 0, 1]
+        wires2 = Wires([1, 2])
+        assert wires1 + wires2 == Wires([4, 0, 1, 2])
+        assert wires2 + wires1 == Wires([1, 2, 4, 0])
+
     def test_representation(self):
         """Tests the string representation."""
 

--- a/tests/test_wires.py
+++ b/tests/test_wires.py
@@ -148,6 +148,12 @@ class TestWires:
         assert wires1 + wires2 == Wires([4, 0, 1, 2])
         assert wires2 + wires1 == Wires([1, 2, 4, 0])
 
+    def test_add_wires_with_inbuilt_sum(self):
+        """Tests that wires objects add correctly using sum()."""
+        wires1 = [4, 0, 1]
+        wires2 = Wires([1, 2])
+        assert sum([wires1, wires2], Wires([]))
+
     def test_representation(self):
         """Tests the string representation."""
 


### PR DESCRIPTION
@cgogolin had the great request to add ``_add__`` and ``__radd__`` to the wires class as a shortcut to ``all_wires()``:

``` python
wires1 = Wires([2, 1, 3])
wires2 = Wires([1, 4, 5, 2])
wires3 = Wires([6, 5])

print(wires1 + wires2 + wires3) # <Wires = [2, 1, 3, 4, 5, 6]>
```

This PR adds the two functions and two tests. 

**Drawbacks:**

Unfortunately, this does not allow native use of ``sum([wires1, wires2, wires3])``, which would be quite elegant in our code base. ``sum`` requires a start object which is ``0`` by default, so the ``0`` wire would always be added. 
One could pass the start object explicitly and use ``sum([wires1 + wires2 + wires3], Wires([]))`` which produces the same result, but is arguably more confusing than ``all_wires([wires1 + wires2 + wires3])``.