### PR TITLE
Bump required PySCF version for QChem, and make it an optional depend…

### DIFF
--- a/qchem/setup.py
+++ b/qchem/setup.py
@@ -18,6 +18,7 @@ with open("pennylane_qchem/_version.py") as f:
 
 requirements = [
     "pennylane>=0.11",
+    "scipy<=1.5"
     "openfermion",
     "openfermionpyscf; platform_system != 'Windows'",
     "openfermionpsi4",

--- a/qchem/setup.py
+++ b/qchem/setup.py
@@ -18,7 +18,7 @@ with open("pennylane_qchem/_version.py") as f:
 
 requirements = [
     "pennylane>=0.11",
-    "scipy<=1.5"
+    "scipy<1.5"
     "openfermion",
     "openfermionpyscf; platform_system != 'Windows'",
     "openfermionpsi4",

--- a/qchem/setup.py
+++ b/qchem/setup.py
@@ -18,7 +18,7 @@ with open("pennylane_qchem/_version.py") as f:
 
 requirements = [
     "pennylane>=0.11",
-    "scipy<1.5"
+    "scipy<1.5",
     "openfermion",
     "openfermionpyscf; platform_system != 'Windows'",
     "openfermionpsi4",

--- a/qchem/setup.py
+++ b/qchem/setup.py
@@ -16,7 +16,13 @@ from setuptools import setup, find_packages
 with open("pennylane_qchem/_version.py") as f:
     version = f.readlines()[-1].split()[-1].strip("\"'")
 
-requirements = ["pennylane>=0.11", "openfermion", "openfermionpyscf", "openfermionpsi4", "pyscf<=1.7.1"]
+requirements = [
+    "pennylane>=0.11",
+    "openfermion",
+    "openfermionpyscf; platform_system != 'Windows'",
+    "openfermionpsi4",
+    "pyscf; platform_system != 'Windows'",
+]
 
 info = {
     "name": "PennyLane-Qchem",
@@ -27,7 +33,7 @@ info = {
     "packages": find_packages(where="."),
     "description": "Package for quantum chemistry applications",
     "long_description": open("README.rst").read(),
-    'long_description_content_type': "text/x-rst",
+    "long_description_content_type": "text/x-rst",
     "provides": ["pennylane_qchem"],
     "install_requires": requirements,
     "entry_points": {"pennylane.qchem": ["OpenFermion = pennylane_qchem.qchem"]},


### PR DESCRIPTION
**Context:**

* The PySCF setup has a bug which will not allow it to be installed on Windows: https://github.com/pyscf/pyscf/issues/300

**Description of the Change:**

* To allow QChem to be installed on windows, we make PySCF an optional requirement (on Windows only).

**Benefits:**

* Users can now easily install QChem on windows

**Possible Drawbacks:**

* Users will not be able to perform Hartree-Fock computations without separately installing PySCF if on windows.
* The latest version of PySCF doesn't support scipy>1.5. This could cause potential dependency issues.

**Related GitHub Issues:** n/a
