### PR TITLE
Fix typos in documentation

### DIFF
--- a/doc/development/guide/architecture.rst
+++ b/doc/development/guide/architecture.rst
@@ -81,7 +81,7 @@ differentiation rules. Examples include the :doc:`parameter-shift rule
 <glossary/parameter_shift>`,  where the derivative of a
 quantum function can be expressed by a linear combination of other quantum
 functions. As these rules allow quantum gradients to be obtained from QNodes,
-hybrid computations may include QNodes as part of training deep learnings
+hybrid computations may include QNodes as part of training deep learning
 models.
 
 Users don't typically instantiate QNodes directly---instead, the :func:`~pennylane.qnode` decorator or
@@ -90,15 +90,14 @@ quantum function and device. The constructor attempts to determine the ``"best"`
 subclass/differentiation method for the provided device and interface. For more fine-grained control,
 the differentiation method can be specified directly via the ``diff_method`` option.
 
-A common representation of quantum circuits is by creating a `Directed
+A common representation of quantum circuits is a `Directed
 Acyclic Graph (DAG)
 <https://pennylane.ai/qml/glossary/hybrid_computation.html#directed-acyclic-graphs>`__
-and representing quantum operations within such a graph. Each ``QNode``
-represents the quantum circuit by building such a DAG by creating a
-:class:`~.CircuitGraph` instance.
+where quantum operations are nodes within the graph. Each ``QNode`` builds such 
+a DAG using a :class:`~.CircuitGraph` instance.
 
 For further details on QNodes, and a full list of QNodes with their custom
-differentiation rule, refer to the :doc:`/code/qml_qnodes` module.
+differentiation rules, refer to the :doc:`/code/qml_qnodes` module.
 
 Interfaces
 **********
@@ -140,7 +139,7 @@ number of wires it acts on, etc.) and further convenience methods (e.g.
 
 Two important subclasses of the ``Operator`` class are:
 
-* the :class:`~.Operation` class representing quantum gates and
+* the :class:`~.Operation` class representing quantum gates,
 * the :class:`~.Observable` representing quantum observables specified for
   measurement.
 

--- a/doc/development/guide/architecture.rst
+++ b/doc/development/guide/architecture.rst
@@ -77,10 +77,10 @@ A  quantum node or QNode (represented by a subclass of
 information processing on a quantum device.
 
 Apart from encapsulating quantum functions, QNodes also provide custom quantum
-differentiation rules. Examples include the :doc:`parameter-shift rules
-<glossary/parameter_shift>` parameter-shift rule, where the derivative of
-quantum functions can be expressed by a linear combination of the other quantum
-function. As these rules allow quantum gradients to be obtained from QNodes,
+differentiation rules. Examples include the :doc:`parameter-shift rule
+<glossary/parameter_shift>`,  where the derivative of a
+quantum function can be expressed by a linear combination of other quantum
+functions. As these rules allow quantum gradients to be obtained from QNodes,
 hybrid computations may include QNodes as part of training deep learnings
 models.
 

--- a/doc/development/guide/documentation.rst
+++ b/doc/development/guide/documentation.rst
@@ -3,7 +3,7 @@ Documentation
 
 Good documentation is just as important, if not more important, than the code itself.
 **No matter how good the code is**, without decent documentation, users are deterred from
-using the library, and developers less likely to contribute.
+using the library, and developers are less likely to contribute.
 
 This document describes the requirements, recommendations, and guides for writing documentation
 for PennyLane, as well as details for contributing to and building the PennyLane documentation.
@@ -231,7 +231,7 @@ Some notes on the above structure:
 
 * **Example:** To provide a minimal working example showing basic usage of the function. The example
   should be *minimal* (reduce line counts where possible), but complete; a reader should be able to
-  copy and paste the example and get the same output. See :ref:`code_examples` for guidelines writing
+  copy and paste the example and get the same output. See :ref:`code_examples` for guidelines on writing
   useful code examples in docstrings.
 
 * **Usage details:** To provide a more complicated usage details showing different edge cases and
@@ -458,7 +458,7 @@ Adding a new module to the docs
 
 There are several steps to adding a new module to the documentation:
 
-1. Make sure your module has a one-to-two line module docstring, that summarizes
+1. Make sure your module has a one- to two-line module docstring, that summarizes
    what the module purpose is, and what it contains.
 
 2. Add a file ``doc/code/qml_module_name.rst``, that contains the following:
@@ -475,7 +475,7 @@ Adding a new package to the docs
 Adding a new subpackage to the documentation requires a slightly different process than
 a module:
 
-1. Make sure your package ``__init__.py`` file has a one-to-two line module docstring,
+1. Make sure your package ``__init__.py`` file has a one- to two-line module docstring,
    that summarizes what the package purpose is, and what it contains.
 
 2. At the bottom of the ``__init__.py`` docstring, add an autosummary table that contains

--- a/doc/development/guide/installation.rst
+++ b/doc/development/guide/installation.rst
@@ -32,8 +32,8 @@ of Python packaged for scientific computation.
 Interface dependencies
 ~~~~~~~~~~~~~~~~~~~~~~
 
-For development of the TensorFlow and PyTorch interfaces, additional
-requirements are required.
+For development of the TensorFlow and PyTorch interfaces, there are additional
+requirements:
 
 * **PyTorch interface**: ``pytorch >= 1.1``
 

--- a/doc/development/guide/tests.rst
+++ b/doc/development/guide/tests.rst
@@ -11,7 +11,7 @@ for test coverage and ``pytest-mock`` for mocking; these can be installed via ``
 
     pip install pytest pytest-cov pytest-mock
 
-To ensure that PennyLane is working correctly, the test suite can then be run by
+To ensure that PennyLane is working correctly, the test suite can be run by
 navigating to the source code folder and running
 
 .. code-block:: bash

--- a/doc/development/plugins.rst
+++ b/doc/development/plugins.rst
@@ -76,7 +76,7 @@ Defining all these attributes is mandatory.
 Device capabilities
 -------------------
 
-You must further tell PennyLane about the operations that your device supports
+You must further tell PennyLane about the operations that your device supports, 
 as well as potential further capabilities, by providing the following class attributes/properties:
 
 * :attr:`.Device.operations`: a set of the supported PennyLane operations as strings, e.g.,
@@ -183,7 +183,7 @@ Device execution
 ----------------
 
 Once all the class attributes are defined, it is necessary to define some required class
-methods, to allow PennyLane to apply operations and measure observables on your device.
+methods to allow PennyLane to apply operations and measure observables on your device.
 
 To execute operations on the device, the following methods **must** be defined:
 
@@ -231,7 +231,7 @@ Additional flexibility is sometimes required for interfacing with more
 complicated frameworks.
 
 When PennyLane needs to evaluate a QNode, it accesses the :meth:`~.QubitDevice.execute` method of
-your plugin, which, by default performs the following process:
+your plugin which, by default, performs the following process:
 
 .. code-block:: python
 


### PR DESCRIPTION
**Context:** Was orienting myself by reading the documentation and caught some typos along the way.

**Description of the Change:** Various spelling/grammatical updates throughout the development guide.

**Benefits:** Typos are removed.

**Possible Drawbacks:** None

**Related GitHub Issues:** None
