### PR TITLE
Fix error in the calculation of  'v_core' in the 'two_particle' function

### DIFF
--- a/qchem/CHANGELOG.md
+++ b/qchem/CHANGELOG.md
@@ -19,6 +19,10 @@
 
 <h3>Bug fixes</h3>
 
+* Fix calculation of the contribution of core orbitals to two-particle operators in the
+  function two_particle.
+  [(#825)](https://github.com/PennyLaneAI/pennylane/pull/825)
+
 <h3>Documentation</h3>
 
 <h3>Contributors</h3>

--- a/qchem/pennylane_qchem/qchem/obs.py
+++ b/qchem/pennylane_qchem/qchem/obs.py
@@ -622,8 +622,9 @@ def two_particle(matrix_elements, core=None, active=None, cutoff=1.0e-12):
 
     If an active space is defined (see :func:`~.active_space`), the summation indices
     run over the active orbitals and the contribution due to core orbitals, is computed as
-    :math:`V_\mathrm{core} = 2 \sum_{\alpha, \beta \in \mathrm{core}}
-    \langle \alpha, \beta \vert \hat{v} \vert \alpha, \beta \rangle`.
+    :math:`V_\mathrm{core} = \sum_{\alpha,\beta \in \mathrm{core}}
+    [2 \langle \alpha, \beta \vert \hat{v} \vert \beta, \alpha \rangle
+    - \langle \alpha, \beta \vert \hat{v} \vert \alpha, \beta \rangle ]`.
 
     Args:
         matrix_elements (array[float]): 4D NumPy array with the matrix elements
@@ -659,7 +660,7 @@ def two_particle(matrix_elements, core=None, active=None, cutoff=1.0e-12):
      [1.         0.         0.         1.         0.70510563]
      [1.         1.         1.         1.         0.70510563]]
     >>> print(v_core)
-    1.364779066
+    0.682389533
     """
 
     orbitals = matrix_elements.shape[0]
@@ -681,9 +682,14 @@ def two_particle(matrix_elements, core=None, active=None, cutoff=1.0e-12):
                 )
             )
 
-        # Compute contribution due to core orbitals
-        v_core = 2 * sum(
-            [matrix_elements[alpha, beta, alpha, beta] for alpha in core for beta in core]
+        # Compute the contribution of core orbitals
+        v_core = sum(
+            [
+                2 * matrix_elements[alpha, beta, beta, alpha]
+                - matrix_elements[alpha, beta, alpha, beta]
+                for alpha in core
+                for beta in core
+            ]
         )
 
     if active is None:

--- a/qchem/tests/test_two_particle.py
+++ b/qchem/tests/test_two_particle.py
@@ -128,10 +128,10 @@ table_3 = np.array(
     ("name", "core", "active", "table_exp", "v_core_exp"),
     [
         ("h2_pyscf", None, None, table_1, 0),
-        ("h2_pyscf", [0], None, table_2, 1.3647790663040844),
+        ("h2_pyscf", [0], None, table_2, 0.6823895331520422),
         ("h2_pyscf", None, [0, 1], table_1, 0),
-        ("h2_pyscf", [0], [1], table_2, 1.3647790663040844),
-        ("lih", [0], [1, 2], table_3, 3.3171333741748206),
+        ("h2_pyscf", [0], [1], table_2, 0.6823895331520422),
+        ("lih", [0], [1, 2], table_3, 1.6585666870874103),
     ],
 )
 def test_table_two_particle(name, core, active, table_exp, v_core_exp, tol):


### PR DESCRIPTION
**Context:**
Generalization of PL-QChem to build arbitrary electronic Hamiltonians

**Description of the Change:**
Fix error in the calculation of the contribution of core orbitals to two-particle operators in the function ``two_particle``.

**Benefits:**
The contribution of core orbitals is computed correctly.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None