### PR TITLE
Skip device tests that use Hermitian and QubitUnitary if not supported by device

### DIFF
--- a/pennylane/devices/tests/test_gates.py
+++ b/pennylane/devices/tests/test_gates.py
@@ -385,6 +385,10 @@ class TestGatesQubit:
         """Test QubitUnitary gate."""
         n_wires = int(np.log2(len(mat)))
         dev = device(n_wires)
+
+        if "QubitUnitary" not in dev.operations:
+            pytest.skip("Skipped because device does not support QubitUnitary.")
+
         skip_if(dev, {"returns_probs": False})
 
         rnd_state = init_state(n_wires)
@@ -405,6 +409,7 @@ class TestGatesQubit:
         """Test three qubit gates without parameters."""
         n_wires = 3
         dev = device(n_wires)
+
         skip_if(dev, {"returns_probs": False})
 
         rnd_state = init_state(n_wires)

--- a/pennylane/devices/tests/test_measurements.py
+++ b/pennylane/devices/tests/test_measurements.py
@@ -184,6 +184,9 @@ class TestExpval:
         n_wires = 2
         dev = device(n_wires)
 
+        if "Hermitian" not in dev.observables:
+            pytest.skip("Skipped because device does not support the Hermitian observable.")
+
         theta = 0.432
         phi = 0.123
 
@@ -209,6 +212,9 @@ class TestExpval:
         """Test that arbitrary multi-mode Hermitian expectation values are correct"""
         n_wires = 2
         dev = device(n_wires)
+
+        if "Hermitian" not in dev.observables:
+            pytest.skip("Skipped because device does not support the Hermitian observable.")
 
         theta = 0.432
         phi = 0.123
@@ -299,6 +305,10 @@ class TestTensorExpval:
         """Test that a tensor product involving qml.Hermitian works correctly"""
         n_wires = 3
         dev = device(n_wires)
+
+        if "Hermitian" not in dev.observables:
+            pytest.skip("Skipped because device does not support the Hermitian observable.")
+
         skip_if(dev, {"supports_tensor_observables": False})
 
         theta = 0.432
@@ -361,6 +371,9 @@ class TestSample:
         n_wires = 1
         dev = device(n_wires)
 
+        if "Hermitian" not in dev.observables:
+            pytest.skip("Skipped because device does not support the Hermitian observable.")
+
         A_ = np.array([[1, 2j], [-2j, 0]])
         theta = 0.543
 
@@ -390,6 +403,9 @@ class TestSample:
         """
         n_wires = 2
         dev = device(n_wires)
+
+        if "Hermitian" not in dev.observables:
+            pytest.skip("Skipped because device does not support the Hermitian observable.")
 
         theta = 0.543
         A_ = np.array(
@@ -514,6 +530,10 @@ class TestTensorSample:
         """Test that a tensor product involving qml.Hermitian works correctly"""
         n_wires = 3
         dev = device(n_wires)
+
+        if "Hermitian" not in dev.observables:
+            pytest.skip("Skipped because device does not support the Hermitian observable.")
+
         skip_if(dev, {"supports_tensor_observables": False})
 
         theta = 0.432
@@ -629,6 +649,9 @@ class TestVar:
         n_wires = 2
         dev = device(n_wires)
 
+        if "Hermitian" not in dev.observables:
+            pytest.skip("Skipped because device does not support the Hermitian observable.")
+
         phi = 0.543
         theta = 0.6543
         # test correct variance for <H> of a rotated state
@@ -724,6 +747,10 @@ class TestTensorVar:
         """Test that a tensor product involving qml.Hermitian works correctly"""
         n_wires = 3
         dev = device(n_wires)
+
+        if "Hermitian" not in dev.observables:
+            pytest.skip("Skipped because device does not support the Hermitian observable.")
+
         skip_if(dev, {"supports_tensor_observables": False})
 
         theta = 0.432


### PR DESCRIPTION
For devices like 'lighting.qubit', which does not support `Hermitian` observables and `QubitUnitary` gates, the shared device tests using such operations fail. This PR is a hotfix which queries the device and skips tests if necessary.

In the long run we would want a more general strategy of flagging tests based on device capabilities.