### PR TITLE
Fixing compatibility related to scalar NumPy tensors and hashing

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -150,13 +150,13 @@
   tensor(6, requires_grad=True)
   ```
 
-  This may require small updates to user code. A convenience method, `np.tensor.data()`,
+  This may require small updates to user code. A convenience method, `np.tensor.unwrap()`,
   has been added to help ease the transition. This converts PennyLane NumPy tensors
   to standard NumPy arrays and Python scalars:
 
   ```pycon
   >>> x = np.array(1.543, requires_grad=False)
-  >>> x.data()
+  >>> x.unwrap()
   1.543
   ```
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -150,13 +150,13 @@
   tensor(6, requires_grad=True)
   ```
 
-  This may require small updates to user code. A convenience method, `np.tensor.numpy()`,
+  This may require small updates to user code. A convenience method, `np.tensor.data()`,
   has been added to help ease the transition. This converts PennyLane NumPy tensors
   to standard NumPy arrays and Python scalars:
 
   ```pycon
   >>> x = np.array(1.543, requires_grad=False)
-  >>> x.numpy()
+  >>> x.data()
   1.543
   ```
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -135,6 +135,34 @@
 
 <h3>Breaking changes</h3>
 
+* The PennyLane NumPy module now returns scalar (zero-dimensional) arrays where
+  Python scalars were previously returned.
+  [(#820)](https://github.com/PennyLaneAI/pennylane/pull/820)
+  [(#833)](https://github.com/PennyLaneAI/pennylane/pull/833)
+
+  For example, this affects array element indexing, and summation:
+
+  ```pycon
+  >>> x = np.array([1, 2, 3], requires_grad=False)
+  >>> x[0]
+  tensor(1, requires_grad=False)
+  >>> np.sum(x)
+  tensor(6, requires_grad=True)
+  ```
+
+  This may require small updates to user code. A convenience method, `np.tensor.numpy()`,
+  has been added to help ease the transition. This converts PennyLane NumPy tensors
+  to standard NumPy arrays and Python scalars:
+
+  ```pycon
+  >>> x = np.array(1.543, requires_grad=False)
+  >>> x.numpy()
+  1.543
+  ```
+
+  Note, however, that information regarding array differentiability will be
+  lost.
+
 <h3>Bug fixes</h3>
 
 * Changed to use lists for storing variable values inside `BaseQNode`

--- a/pennylane/numpy/tensor.py
+++ b/pennylane/numpy/tensor.py
@@ -189,7 +189,7 @@ class tensor(_np.ndarray):
         """Converts the tensor to a standard, non-differentiable NumPy ndarray or Python scalar if
         the tensor is 0-dimensional.
 
-        This method is an alias for :meth:`~.data`. See :meth:`~.data` for more details.
+        This method is an alias for :meth:`~.unwrap`. See :meth:`~.unwrap` for more details.
         """
         return self.unwrap()
 

--- a/pennylane/numpy/tensor.py
+++ b/pennylane/numpy/tensor.py
@@ -164,6 +164,10 @@ class tensor(_np.ndarray):
         >>> x[0] = 5
         >>> y
         array([5, 2])
+        >>> y[1] = 7
+        >>> x
+        tensor([5, 7], requires_grad=True)
+
 
         To create a copy, the ``copy()`` method can be used:
 

--- a/pennylane/numpy/tensor.py
+++ b/pennylane/numpy/tensor.py
@@ -123,11 +123,14 @@ class tensor(_np.ndarray):
 
     def __hash__(self):
         if self.ndim == 0:
+            # Allowing hashing if the tensor is a scalar.
+            # We hash both the scalar value *and* the differentiability information,
+            # to match the behaviour of PyTorch.
             return hash((self.item(), self.requires_grad))
 
         raise TypeError("unhashable type: 'numpy.tensor'")
 
-    def numpy(self):
+    def data(self):
         """Converts the tensor to a standard, non-differentiable NumPy ndarray or Python scalar if
         the tensor is 0-dimensional.
 
@@ -146,21 +149,21 @@ class tensor(_np.ndarray):
         >>> x = np.array([1, 2], requires_grad=True)
         >>> x
         tensor([1, 2], requires_grad=True)
-        >>> x.numpy()
+        >>> x.data()
         array([1, 2])
 
         Zero dimensional array are converted to Python scalars:
 
         >>> x = np.array(1.543, requires_grad=False)
-        >>> x.numpy()
+        >>> x.data()
         1.543
-        >>> type(x.numpy())
+        >>> type(x.data())
         float
 
         The underlying data is **not** copied:
 
         >>> x = np.array([1, 2], requires_grad=True)
-        >>> y = x.numpy()
+        >>> y = x.data()
         >>> x[0] = 5
         >>> y
         array([5, 2])
@@ -172,7 +175,7 @@ class tensor(_np.ndarray):
         To create a copy, the ``copy()`` method can be used:
 
         >>> x = np.array([1, 2], requires_grad=True)
-        >>> y = x.numpy().copy()
+        >>> y = x.data().copy()
         >>> x[0] = 5
         >>> y
         array([1, 2])
@@ -181,6 +184,14 @@ class tensor(_np.ndarray):
             return self.view(onp.ndarray).item()
 
         return self.view(onp.ndarray)
+
+    def numpy(self):
+        """Converts the tensor to a standard, non-differentiable NumPy ndarray or Python scalar if
+        the tensor is 0-dimensional.
+
+        This method is an alias for :meth:`~.data`. See :meth:`~.data` for more details.
+        """
+        return self.data()
 
 
 class NonDifferentiableError(Exception):

--- a/pennylane/numpy/tensor.py
+++ b/pennylane/numpy/tensor.py
@@ -121,6 +121,63 @@ class tensor(_np.ndarray):
 
         return item
 
+    def __hash__(self):
+        if self.ndim == 0:
+            return hash((self.item(), self.requires_grad))
+
+        raise TypeError("unhashable type: 'numpy.tensor'")
+
+    def numpy(self):
+        """Converts the tensor to a standard, non-differentiable NumPy ndarray or Python scalar if
+        the tensor is 0-dimensional.
+
+        All information regarding differentiability of the tensor will be lost.
+
+        .. warning::
+
+            The returned array is a new view onto the **same data**. That is,
+            the tensor and the returned ``ndarray`` share the same underlying storage.
+            Changes to the tensor object will be reflected within the returned array,
+            and vice versa.
+
+        **Example**
+
+        >>> from pennylane import numpy as np
+        >>> x = np.array([1, 2], requires_grad=True)
+        >>> x
+        tensor([1, 2], requires_grad=True)
+        >>> x.numpy()
+        array([1, 2])
+
+        Zero dimensional array are converted to Python scalars:
+
+        >>> x = np.array(1.543, requires_grad=False)
+        >>> x.numpy()
+        1.543
+        >>> type(x.numpy())
+        float
+
+        The underlying data is **not** copied:
+
+        >>> x = np.array([1, 2], requires_grad=True)
+        >>> y = x.numpy()
+        >>> x[0] = 5
+        >>> y
+        array([5, 2])
+
+        To create a copy, the ``copy()`` method can be used:
+
+        >>> x = np.array([1, 2], requires_grad=True)
+        >>> y = x.numpy().copy()
+        >>> x[0] = 5
+        >>> y
+        array([1, 2])
+        """
+        if self.ndim == 0:
+            return self.view(onp.ndarray).item()
+
+        return self.view(onp.ndarray)
+
 
 class NonDifferentiableError(Exception):
     """Exception raised if attempting to differentiate non-trainable

--- a/pennylane/numpy/tensor.py
+++ b/pennylane/numpy/tensor.py
@@ -130,7 +130,7 @@ class tensor(_np.ndarray):
 
         raise TypeError("unhashable type: 'numpy.tensor'")
 
-    def data(self):
+    def unwrap(self):
         """Converts the tensor to a standard, non-differentiable NumPy ndarray or Python scalar if
         the tensor is 0-dimensional.
 
@@ -149,21 +149,21 @@ class tensor(_np.ndarray):
         >>> x = np.array([1, 2], requires_grad=True)
         >>> x
         tensor([1, 2], requires_grad=True)
-        >>> x.data()
+        >>> x.unwrap()
         array([1, 2])
 
         Zero dimensional array are converted to Python scalars:
 
         >>> x = np.array(1.543, requires_grad=False)
-        >>> x.data()
+        >>> x.unwrap()
         1.543
-        >>> type(x.data())
+        >>> type(x.unwrap())
         float
 
         The underlying data is **not** copied:
 
         >>> x = np.array([1, 2], requires_grad=True)
-        >>> y = x.data()
+        >>> y = x.unwrap()
         >>> x[0] = 5
         >>> y
         array([5, 2])
@@ -175,7 +175,7 @@ class tensor(_np.ndarray):
         To create a copy, the ``copy()`` method can be used:
 
         >>> x = np.array([1, 2], requires_grad=True)
-        >>> y = x.data().copy()
+        >>> y = x.unwrap().copy()
         >>> x[0] = 5
         >>> y
         array([1, 2])
@@ -191,7 +191,7 @@ class tensor(_np.ndarray):
 
         This method is an alias for :meth:`~.data`. See :meth:`~.data` for more details.
         """
-        return self.data()
+        return self.unwrap()
 
 
 class NonDifferentiableError(Exception):

--- a/tests/test_numpy_wrapper.py
+++ b/tests/test_numpy_wrapper.py
@@ -117,7 +117,7 @@ ARRAY_CREATION_FNS = [
     [np.empty_like, {}],
     [np.ones_like, {}],
     [np.zeros_like, {}],
-    [np.full_like, {"fill_value": 5}]
+    [np.full_like, {"fill_value": 5}],
 ]
 
 # The following NumPy functions all create
@@ -129,7 +129,7 @@ ARRAY_SHAPE_FNS = [
     [np.zeros, {}],
     [np.full, {"fill_value": 5}],
     [np.arange, {}],
-    [np.eye, {}]
+    [np.eye, {}],
 ]
 
 
@@ -179,18 +179,18 @@ class TestNumpyIntegration:
     def test_tensor_creation_from_string(self):
         """Test that a tensor is properly created from a string."""
         string = "5, 4, 1, 2"
-        x = np.fromstring(string, dtype=int, sep=',')
+        x = np.fromstring(string, dtype=int, sep=",")
 
         assert isinstance(x, np.tensor)
         assert x.requires_grad
 
-        x = np.fromstring(string, requires_grad=True, dtype=int, sep=',')
+        x = np.fromstring(string, requires_grad=True, dtype=int, sep=",")
         assert x.requires_grad
 
         x.requires_grad = False
         assert not x.requires_grad
 
-        x = np.fromstring(string, requires_grad=False, dtype=int, sep=',')
+        x = np.fromstring(string, requires_grad=False, dtype=int, sep=",")
         assert not x.requires_grad
 
     def test_wrapped_docstring(self, capsys):
@@ -300,7 +300,6 @@ class TestNumpyIntegration:
         assert isinstance(res, np.tensor)
         assert not res.requires_grad
 
-
     def test_binary_operators(self):
         """Test that binary operators (add, subtract, divide, multiply, matmul)
         correctly work on tensors."""
@@ -357,11 +356,12 @@ class TestAutogradIntegration:
 
     def test_gradient(self):
         """Test gradient computations continue to work"""
+
         def cost(x):
             return np.sum(np.sin(x))
 
         grad_fn = qml.grad(cost, argnum=[0])
-        arr1 = np.array([0., 1., 2.])
+        arr1 = np.array([0.0, 1.0, 2.0])
 
         res = grad_fn(arr1)
         expected = np.cos(arr1)
@@ -370,11 +370,77 @@ class TestAutogradIntegration:
 
     def test_non_differentiable_gradient(self):
         """Test gradient computation with requires_grad=False raises an error"""
+
         def cost(x):
             return np.sum(np.sin(x))
 
         grad_fn = qml.grad(cost, argnum=[0])
-        arr1 = np.array([0., 1., 2.], requires_grad=False)
+        arr1 = np.array([0.0, 1.0, 2.0], requires_grad=False)
 
         with pytest.raises(np.NonDifferentiableError, match="non-differentiable"):
             grad_fn(arr1)
+
+
+class TestScalarHashing:
+    """Test for the hashing capability of scalar arrays."""
+
+    def test_create_set_scalar_arrays(self):
+        """Test that a collection of scalar arrays can be properly hashed
+        when creating a set"""
+        data = [np.array(1), np.array(2), np.array(1), np.array(3)]
+        res = set(data)
+        expected = {np.array(1), np.array(2), np.array(3)}
+        assert res == expected
+
+    def test_requires_grad_hashing(self):
+        """Test that the gradient information is correctly taken into account when hashing"""
+        data = [np.array(1), np.array(2), np.array(1, requires_grad=False), np.array(3)]
+        res = set(data)
+        expected = {np.array(1, requires_grad=False), np.array(1), np.array(2), np.array(3)}
+        assert res == expected
+
+    def test_create_set_from_array_iteration(self):
+        """Test that a one dimensional array correctly produces a set via iteration"""
+        data = np.array([1, 2, 1, 3], requires_grad=True)
+        res = set(data)
+        expected = {
+            np.array(1, requires_grad=True),
+            np.array(2, requires_grad=True),
+            np.array(3, requires_grad=True),
+        }
+        assert res == expected
+
+        data = np.array([1, 2, 1, 3], requires_grad=False)
+        res = set(data)
+        expected = {
+            np.array(1, requires_grad=False),
+            np.array(2, requires_grad=False),
+            np.array(3, requires_grad=False),
+        }
+        assert res == expected
+
+    def test_nonzero_dim_arrays_non_hashable(self):
+        """Test that a non-scalar array continues to remain non-hashable"""
+        with pytest.raises(TypeError, match=r"unhashable type: 'numpy\.tensor'"):
+            set(np.array([[1, 2], [3, 4]]))
+
+
+class TestNumpyConversion:
+    """Tests for the tensor.numpy() method"""
+
+    def test_convert_scalar_array(self):
+        """Test that a scalar array converts to a python literal"""
+        data = np.array(1.543)
+        res = data.numpy()
+        assert res == data.item()
+        assert isinstance(res, float)
+
+    def test_convert_array(self):
+        """Test that a numpy array successfully converts"""
+        data = np.array([1, 2, 3])
+        res = data.numpy()
+
+        assert np.shares_memory(res, data)
+        assert np.all(res == data)
+        assert isinstance(res, np.ndarray)
+        assert not isinstance(res, np.tensor)

--- a/tests/test_numpy_wrapper.py
+++ b/tests/test_numpy_wrapper.py
@@ -431,7 +431,7 @@ class TestNumpyConversion:
     def test_convert_scalar_array(self):
         """Test that a scalar array converts to a python literal"""
         data = np.array(1.543)
-        res = data.data()
+        res = data.unwrap()
         assert res == data.item()
         assert isinstance(res, float)
 

--- a/tests/test_numpy_wrapper.py
+++ b/tests/test_numpy_wrapper.py
@@ -426,7 +426,8 @@ class TestScalarHashing:
 
 
 class TestNumpyConversion:
-    """Tests for the tensor.numpy() method"""
+    """Tests for the tensor.unwrap() and tensor.numpy() methods"""
+
 
     def test_convert_scalar_array(self):
         """Test that a scalar array converts to a python literal"""

--- a/tests/test_numpy_wrapper.py
+++ b/tests/test_numpy_wrapper.py
@@ -431,7 +431,7 @@ class TestNumpyConversion:
     def test_convert_scalar_array(self):
         """Test that a scalar array converts to a python literal"""
         data = np.array(1.543)
-        res = data.numpy()
+        res = data.data()
         assert res == data.item()
         assert isinstance(res, float)
 


### PR DESCRIPTION
**Context:**

The PennyLane NumPy wrapper was recently modified so that indexed elements are returned as NumPy tensors:

```pycon
>>> fd = np.array([1, 2], requires_grad=False)
>>> fd[0]
np.array(1, requires_grad=False)
```

This is to ensure that the differentiability information (the `requires_grad` attribute) is not lost upon indexing. This matches the behaviour of other autodifferentiation frameworks:

```pycon
>>> fd = torch.tensor([1., 2.], requires_grad=True)
>>> fd[0]
tensor(1., grad_fn=<SelectBackward>)
```

A side effect, however, is that NumPy arrays aren't hashable; so functions (such as `set()`) which would previously iterate fine over 1D arrays, no longer work:

```pycon
>>> import numpy as onp
>>> set(onp.array([1, 2, 3]))
>>> {1, 2, 3}
>>> set(np.array([1, 2, 3]))
TypeError: unhashable type: 'numpy.tensor'
```

**Description of the Change:**

* Makes **scalar** arrays (e.g., `array.ndim == 0`) hashable:
  
  ```pycon
  >>> set(np.array([1, 1, 2, 3]))
  {tensor(1, requires_grad=True),
   tensor(2, requires_grad=True),
   tensor(3, requires_grad=True)}
  ```

  Both the scalar _and_ the gradient info is taken into account, so `np.array(1, requires_grad=True)` is considered a different object to `np.array(1, requires_grad=False)`.

* Arrays with dimension continue to be non-hashable, like standard NumPy arrays.

* Finally, I realised that there will be (rare) times when a PennyLane NumPy tensor will need to be converted back to a standard NumPy ndarray or python scalar, for example to avoid changes in logical behaviour compared to vanilla NumPy (such as described above) and gradient info is no longer needed. To help, I've added a `tensor.unwrap()` function, since this is not very obvious.  

**Benefits:**

* Less surprising to users who are used to standard NumPy behaviour.

**Possible Drawbacks:**

* This PR won't result in proper backwards compatibility; in a lot of cases, we distinctly want a set of _integers_, not a set of scalar arrays, and we no longer care about gradient info. In these cases, we would still have to explicit do `set(array.tolist())` or `set(array.unwrap())`.

Note that this is not really a drawback per se, just a general note. We are _already_ breaking NumPy compatibility by (a) forcing all NumPy arrays to store gradient info, and (b) forcing numpy functions that previously returned Python scalars to now return numpy scalars.

So, in a sense, keeping complete backwards compatibility and tracking gradient info are mutually exclusive; choosing one will always require losing the other. In this case, tracking gradient info is likely to provide a greater net benefit than NumPy backwards compatibility.

**Related GitHub Issues:** n/a
