### PR TITLE
Fix applying operations in default.qubit.tf when using 9 or more wires

### DIFF
--- a/pennylane/devices/default_qubit_tf.py
+++ b/pennylane/devices/default_qubit_tf.py
@@ -25,7 +25,7 @@ try:
         raise ImportError("default.qubit.tf device requires TensorFlow>=2.0")
 
 except ImportError as e:
-    raise ImportError("default.qubit.tf device requires TensorFlow>=2.0")
+    raise ImportError("default.qubit.tf device requires TensorFlow>=2.0") from e
 
 
 # With TF 2.1+, the legacy tf.einsum was renamed to _einsum_v1, while

--- a/pennylane/devices/default_qubit_tf.py
+++ b/pennylane/devices/default_qubit_tf.py
@@ -159,6 +159,11 @@ class DefaultQubitTF(DefaultQubit):
         # prevent using special apply method for this gate due to slowdown in TF implementation
         del self._apply_ops["CZ"]
 
+        # prevent using special apply methods when using more than 8 wires due to limitations
+        # with TF slicing
+        if wires > 8:
+            self._apply_ops = {}
+
     @classmethod
     def capabilities(cls):
         capabilities = super().capabilities().copy()

--- a/pennylane/devices/default_qubit_tf.py
+++ b/pennylane/devices/default_qubit_tf.py
@@ -15,6 +15,7 @@
 reference plugin.
 """
 import numpy as np
+import semantic_version
 
 from pennylane.operation import DiagonalOperation
 
@@ -23,6 +24,8 @@ try:
 
     if tf.__version__[0] == "1":
         raise ImportError("default.qubit.tf device requires TensorFlow>=2.0")
+
+    SUPPORTS_APPLY_OPS = semantic_version.match(">=2.3.0", tf.__version__)
 
 except ImportError as e:
     raise ImportError("default.qubit.tf device requires TensorFlow>=2.0") from e
@@ -159,9 +162,11 @@ class DefaultQubitTF(DefaultQubit):
         # prevent using special apply method for this gate due to slowdown in TF implementation
         del self._apply_ops["CZ"]
 
-        # prevent using special apply methods when using more than 8 wires due to limitations
-        # with TF slicing
-        if wires > 8:
+        # Versions of TF before 2.3.0 do not support using the special apply methods as they
+        # raise an error when calculating the gradient. For versions of TF after 2.3.0,
+        # special apply methods are also not supported when using more than 8 wires due to
+        # limitations with TF slicing.
+        if not SUPPORTS_APPLY_OPS or wires > 8:
             self._apply_ops = {}
 
     @classmethod

--- a/tests/devices/test_default_qubit_tf.py
+++ b/tests/devices/test_default_qubit_tf.py
@@ -320,6 +320,24 @@ class TestApply:
         expected = func(theta) @ state
         assert np.allclose(res, expected, atol=tol, rtol=0)
 
+    def test_apply_ops_dict_above_8_wires(self):
+        """Test that the apply_ops dictionary is empty when more than 8 wires are used"""
+        dev = DefaultQubitTF(wires=9)
+        assert dev._apply_ops == {}
+
+    @pytest.mark.xfail(
+        raises=tf.errors.UnimplementedError,
+        reason="Slicing is not supported for " "more than 8 wires",
+    )
+    def test_apply_ops_above_8_wires(self):
+        """Test that special apply methods that involve slicing function correctly when using 9
+        wires"""
+        dev = DefaultQubitTF(wires=9)
+        dev._apply_ops = {"CNOT": dev._apply_cnot}
+
+        queue = [qml.CNOT(wires=[1, 2])]
+        dev.apply(queue)
+
 
 THETA = np.linspace(0.11, 1, 3)
 PHI = np.linspace(0.32, 1, 3)

--- a/tests/devices/test_default_qubit_tf.py
+++ b/tests/devices/test_default_qubit_tf.py
@@ -320,16 +320,25 @@ class TestApply:
         expected = func(theta) @ state
         assert np.allclose(res, expected, atol=tol, rtol=0)
 
-    def test_apply_ops_dict_above_8_wires(self):
-        """Test that the apply_ops dictionary is empty when more than 8 wires are used"""
+    def test_apply_ops_above_8_wires(self, mocker):
+        """Test that when 9 wires are used, the _apply_ops dictionary is empty and application of a
+        CNOT gate is performed using _apply_unitary_einsum"""
         dev = DefaultQubitTF(wires=9)
         assert dev._apply_ops == {}
 
+        spy = mocker.spy(DefaultQubitTF, "_apply_unitary_einsum")
+
+        queue = [qml.CNOT(wires=[1, 2])]
+        dev.apply(queue)
+
+        spy.assert_called_once()
+
     @pytest.mark.xfail(
         raises=tf.errors.UnimplementedError,
-        reason="Slicing is not supported for " "more than 8 wires",
+        reason="Slicing is not supported for more than 8 wires",
+        strict=True,
     )
-    def test_apply_ops_above_8_wires(self):
+    def test_apply_ops_above_8_wires_using_special(self):
         """Test that special apply methods that involve slicing function correctly when using 9
         wires"""
         dev = DefaultQubitTF(wires=9)


### PR DESCRIPTION
This PR resolves https://github.com/PennyLaneAI/pennylane/issues/835.

Currently, TensorFlow does not fully support slicing into tensors of rank 9 or above (see discussion in https://github.com/PennyLaneAI/pennylane/issues/835). This impacts `default.qubit.tf`, which uses slicing when applying certain gates such as CNOT through special tensor manipulation tricks. These gates are applied through special methods such as `DefaultQubit._apply_cnot()`.

The following special methods are available, with those having a red circle impacted by the above limitation:
- `_apply_x()` :green_circle: 
- `_apply_y()` :red_circle: 
- `_apply_z()` :red_circle: 
- `_apply_hadamard()` :red_circle: 
- `_apply_s()`, `_apply_t()` :red_circle: 
- `_apply_cnot()` :red_circle: 
- `_apply_swap()` :green_circle: 
- `_apply_cz()` :red_circle:
Most methods are affected. This is due to common use of the underlying `_apply_phase()` method.

Due to the above, this PR simply empties the `_apply_ops` dictionary (which contains these methods) in `DefaultQubitTF` if instantiated with more than 8 wires.

Additional tests are added. One test tries to apply the CNOT gate with nine wires and is marked as an `xfail`, allowing us to see if/when TF fixes this limitation.