### PR TITLE
Fixes if statement in default.qubit

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -9,15 +9,15 @@
   [(#819)](https://github.com/PennyLaneAI/pennylane/pull/819)
   [(#807)](https://github.com/PennyLaneAI/pennylane/pull/807)
   [(#794)](https://github.com/PennyLaneAI/pennylane/pull/794)
-  
+
   The device can be initialized as
   ```pycon
   >>> dev = qml.device("default.mixed", wires=1)
   ```
-  
+
   This allows the construction of QNodes that include non-unitary operations
   such as noisy channels, as in this simple qubit rotation example
-  
+
   ```pycon
   >>> @qml.qnode(dev)
   ... def circuit(params):
@@ -267,6 +267,10 @@
 * Changed to use lists for storing variable values inside `BaseQNode`
   allowing complex matrices to be passed to `QubitUnitary`.
   [(#773)](https://github.com/PennyLaneAI/pennylane/pull/773)
+
+* Fixed a bug within `default.qubit`, resulting in greater efficiency
+  when applying a state vector to all wires on the device.
+  [(#849)](https://github.com/PennyLaneAI/pennylane/pull/849)
 
 <h3>Documentation</h3>
 

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -412,9 +412,8 @@ class DefaultQubit(QubitDevice):
         if not np.allclose(np.linalg.norm(state, ord=2), 1.0, atol=tolerance):
             raise ValueError("Sum of amplitudes-squared does not equal one.")
 
-        if (
-            len(device_wires) == self.num_wires
-            and sorted(device_wires.labels) == list(device_wires.labels)
+        if len(device_wires) == self.num_wires and sorted(device_wires.labels) == list(
+            device_wires.labels
         ):
             # Initialize the entire wires with the state
             self._state = self._reshape(state, [2] * self.num_wires)

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -414,7 +414,7 @@ class DefaultQubit(QubitDevice):
 
         if (
             len(device_wires) == self.num_wires
-            and sorted(device_wires.labels) == device_wires.labels
+            and sorted(device_wires.labels) == list(device_wires.labels)
         ):
             # Initialize the entire wires with the state
             self._state = self._reshape(state, [2] * self.num_wires)

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -412,8 +412,9 @@ class DefaultQubit(QubitDevice):
         if not np.allclose(np.linalg.norm(state, ord=2), 1.0, atol=tolerance):
             raise ValueError("Sum of amplitudes-squared does not equal one.")
 
-        if len(device_wires) == self.num_wires and sorted(device_wires.labels) == list(
-            device_wires.labels
+        if (
+            len(device_wires) == self.num_wires
+            and sorted(device_wires.labels) == device_wires.tolist()
         ):
             # Initialize the entire wires with the state
             self._state = self._reshape(state, [2] * self.num_wires)

--- a/pennylane/devices/default_qubit_tf.py
+++ b/pennylane/devices/default_qubit_tf.py
@@ -166,7 +166,7 @@ class DefaultQubitTF(DefaultQubit):
         # raise an error when calculating the gradient. For versions of TF after 2.3.0,
         # special apply methods are also not supported when using more than 8 wires due to
         # limitations with TF slicing.
-        if not SUPPORTS_APPLY_OPS or wires > 8:
+        if not SUPPORTS_APPLY_OPS or self.num_wires > 8:
             self._apply_ops = {}
 
     @classmethod


### PR DESCRIPTION
During development of the `default.mixed` device, code coverage tests revealed that an `if` statement in the `_apply_state_vector()` was never evaluating to `True`. This PR fixes the same issue for `default.qubit` and therefore also for other devices that inherit from it. This should increase code coverage.

The issue is simply that `device_wires.labels` is an n-tuple, e.g., `(0, 1, 2)`, while `sorted(device_wires.labels)` is a list, e.g., `[0, 1, 2]`