### PR TITLE
Grouping subpackage docstring updates

### DIFF
--- a/doc/code/qml_grouping.rst
+++ b/doc/code/qml_grouping.rst
@@ -20,8 +20,8 @@ groupings according to a binary relation (e.g. qubit-wise commuting):
 
 .. code-block:: python
 
-    >>> observables = [qml.PauliY(0), qml.PauliX(0) @ qml.PauliX(1), qml.PauliZ(1)]
-    >>> obs_groupings = group_observables(observables)
+    >>> obs = [qml.PauliY(0), qml.PauliX(0) @ qml.PauliX(1), qml.PauliZ(1)]
+    >>> obs_groupings = group_observables(obs)
     >>> obs_groupings
     [[Tensor(PauliX(wires=[0]), PauliX(wires=[1]))],
      [PauliY(wires=[0]), PauliZ(wires=[1])]]
@@ -34,13 +34,9 @@ of observables:
 
 .. code-block:: python
 
-    >>> observables = [qml.PauliY(0), qml.PauliX(0) @ qml.PauliX(1), qml.PauliZ(1)]
-    >>> coefficients = [1.43, 4.21, 0.97]
-    >>> obs_groupings, coeffs_groupings = group_observables(
-                                                            observables,
-                                                            coefficients,
-                                                            'qwc',
-                                                            'rlf')
+    >>> obs = [qml.PauliY(0), qml.PauliX(0) @ qml.PauliX(1), qml.PauliZ(1)]
+    >>> coeffs = [1.43, 4.21, 0.97]
+    >>> obs_groupings, coeffs_groupings = group_observables(obs, coeffs, 'qwc', 'rlf')
     >>> obs_groupings
     [[Tensor(PauliX(wires=[0]), PauliX(wires=[1]))],
      [PauliY(wires=[0]), PauliZ(wires=[1])]]

--- a/doc/xanadu_theme/static/xanadu.css_t
+++ b/doc/xanadu_theme/static/xanadu.css_t
@@ -109,6 +109,7 @@ h1 {
   /*border-bottom: 3px solid #D8E4EF;*/
   /*border-bottom: 3px solid #eee;*/
   padding-bottom: -29px;
+  word-wrap: break-word;
 }
 
 h2 {

--- a/pennylane/grouping/graph_colouring.py
+++ b/pennylane/grouping/graph_colouring.py
@@ -36,7 +36,17 @@ def largest_first(binary_observables, adj):
     """Performs graph colouring using the Largest Degree First heuristic. Runtime is quadratic in
     number of vertices.
 
-    **Usage example:**
+    Args:
+        binary_observables (array[bool]): the set of Pauli words represented by a column matrix
+            of the Pauli words in binary vector represenation
+        adj (array[bool]): the adjacency matrix of the Pauli graph
+
+    Returns:
+        dict(int, list[array[bool]]): keys correspond to colours (labelled by integers) and values
+            are lists of Pauli words of the same colour in
+            binary vector representation.
+
+    **Example**
 
     >>> binary_observables
     array([[1., 1., 0.],
@@ -50,18 +60,6 @@ def largest_first(binary_observables, adj):
     >>> largest_first(binary_observables, adj)
     {1: [array([0., 0., 1., 1.])],
      2: [array([1., 0., 0., 0.]), array([1., 1., 0., 1.])]}
-
-
-    Args:
-        binary_observables (array[bool]): the set of Pauli words represented by a column matrix
-            of the Pauli words in binary vector represenation
-        adj (array[bool]): the adjacency matrix of the Pauli graph
-
-    Returns:
-        dict(int, list[array[bool]]): keys correspond to colours (labelled by integers) and values
-            are lists of Pauli words of the same colour in
-            binary vector representation.
-
     """
 
     n_terms = np.shape(adj)[0]
@@ -91,7 +89,16 @@ def recursive_largest_first(binary_observables, adj):  # pylint:disable=too-many
     lower chromatic number than Largest Degree First, but takes longer (runtime is cubic in number
     of vertices).
 
-    **Usage example:**
+    Args:
+        binary_observables (array[bool]): the set of Pauli words represented by a column matrix of
+            the Pauli words in binary vector represenation
+        adj (array[bool]): the adjacency matrix of the Pauli graph
+
+    Returns:
+        dict(int, list[array[bool]]): keys correspond to colours (labelled by integers) and values
+            are lists of Pauli words of the same colour in binary vector representation.
+
+    **Example**
 
     >>> binary_observables
     array([[1., 1., 0.],
@@ -104,16 +111,6 @@ def recursive_largest_first(binary_observables, adj):  # pylint:disable=too-many
            [1., 1., 0.]])
     >>> recursive_largest_first(binary_observables, adj)
     {1: [array([0., 0., 1., 1.])], 2: [array([1., 1., 0., 1.]), array([1., 0., 0., 0.])]}
-
-    Args:
-        binary_observables (array[bool]): the set of Pauli words represented by a column matrix of
-            the Pauli words in binary vector represenation
-        adj (array[bool]): the adjacency matrix of the Pauli graph
-
-    Returns:
-        dict(int, list[array[bool]]): keys correspond to colours (labelled by integers) and values
-            are lists of Pauli words of the same colour in binary vector representation.
-
     """
 
     def n_0(m_array, coloured):

--- a/pennylane/grouping/graph_colouring.py
+++ b/pennylane/grouping/graph_colouring.py
@@ -43,8 +43,8 @@ def largest_first(binary_observables, adj):
 
     Returns:
         dict(int, list[array[bool]]): keys correspond to colours (labelled by integers) and values
-            are lists of Pauli words of the same colour in
-            binary vector representation.
+        are lists of Pauli words of the same colour in
+        binary vector representation.
 
     **Example**
 
@@ -96,7 +96,7 @@ def recursive_largest_first(binary_observables, adj):  # pylint:disable=too-many
 
     Returns:
         dict(int, list[array[bool]]): keys correspond to colours (labelled by integers) and values
-            are lists of Pauli words of the same colour in binary vector representation.
+        are lists of Pauli words of the same colour in binary vector representation.
 
     **Example**
 

--- a/pennylane/grouping/graph_colouring.py
+++ b/pennylane/grouping/graph_colouring.py
@@ -95,7 +95,7 @@ def recursive_largest_first(binary_observables, adj):  # pylint:disable=too-many
 
     Returns:
         dict(int, list[array[int]]): keys correspond to colours (labelled by integers) and values
-        are lists of Pauli words of the same colour in binary vector representation.
+        are lists of Pauli words of the same colour in binary vector representation
 
     **Example**
 

--- a/pennylane/grouping/graph_colouring.py
+++ b/pennylane/grouping/graph_colouring.py
@@ -37,14 +37,13 @@ def largest_first(binary_observables, adj):
     number of vertices.
 
     Args:
-        binary_observables (array[bool]): the set of Pauli words represented by a column matrix
+        binary_observables (array[int]): the set of Pauli words represented by a column matrix
             of the Pauli words in binary vector represenation
-        adj (array[bool]): the adjacency matrix of the Pauli graph
+        adj (array[int]): the adjacency matrix of the Pauli graph
 
     Returns:
-        dict(int, list[array[bool]]): keys correspond to colours (labelled by integers) and values
-        are lists of Pauli words of the same colour in
-        binary vector representation.
+        dict(int, list[array[int]]): keys correspond to colours (labelled by integers) and values
+        are lists of Pauli words of the same colour in binary vector representation.
 
     **Example**
 
@@ -90,12 +89,12 @@ def recursive_largest_first(binary_observables, adj):  # pylint:disable=too-many
     of vertices).
 
     Args:
-        binary_observables (array[bool]): the set of Pauli words represented by a column matrix of
+        binary_observables (array[int]): the set of Pauli words represented by a column matrix of
             the Pauli words in binary vector represenation
-        adj (array[bool]): the adjacency matrix of the Pauli graph
+        adj (array[int]): the adjacency matrix of the Pauli graph
 
     Returns:
-        dict(int, list[array[bool]]): keys correspond to colours (labelled by integers) and values
+        dict(int, list[array[int]]): keys correspond to colours (labelled by integers) and values
         are lists of Pauli words of the same colour in binary vector representation.
 
     **Example**

--- a/pennylane/grouping/group_observables.py
+++ b/pennylane/grouping/group_observables.py
@@ -49,8 +49,6 @@ class PauliGroupingStrategy:  # pylint: disable=too-many-instance-attributes
     Args:
         observables (list[Observable]): a list of Pauli words to be partitioned according to a
             grouping strategy
-
-    Keyword Args:
         grouping_type (str): the binary relation used to define partitions of the Pauli words
         graph_colourer (str): the heuristic algorithm to employ for graph colouring
 
@@ -89,7 +87,7 @@ class PauliGroupingStrategy:  # pylint: disable=too-many-instance-attributes
     def obtain_binary_repr(self, n_qubits=None, wire_map=None):
         """Converts the list of Pauli words to a binary matrix.
 
-        Keyword args:
+        Args:
             n_qubits (int): number of qubits to specify dimension of binary vector representation
             wire_map (dict): dictionary containing all wire labels used in the Pauli word as keys,
                 and unique integer labels as their values
@@ -187,8 +185,6 @@ def group_observables(observables, coefficients=None, grouping_type="qwc", metho
     Args:
         observables (list[Observable]): a list of Pauli word ``Observable`` instances (Pauli
             operation instances and Tensor instances thereof)
-
-    Keyword args:
         coefficients (list[scalar]): A list of scalar coefficients. If not specified,
             output ``partitioned_coeffs`` is not returned.
         grouping_type (str): The type of binary relation between Pauli words.

--- a/pennylane/grouping/group_observables.py
+++ b/pennylane/grouping/group_observables.py
@@ -55,9 +55,9 @@ class PauliGroupingStrategy:  # pylint: disable=too-many-instance-attributes
         graph_colourer (str): the heuristic algorithm to employ for graph colouring
 
     Raises:
-        ValueError: if arguments specified for `grouping_type` or
-            `graph_colourer` are not recognized as elements of `GROUPING_TYPES` or
-            `GRAPH_COLOURING_METHODS` respectively
+        ValueError: if arguments specified for ``grouping_type`` or
+            ``graph_colourer`` are not recognized as elements of ``GROUPING_TYPES`` or
+            ``GRAPH_COLOURING_METHODS`` respectively
     """
 
     def __init__(self, observables, grouping_type="qwc", graph_colourer="rlf"):
@@ -159,7 +159,7 @@ class PauliGroupingStrategy:  # pylint: disable=too-many-instance-attributes
 
         Returns:
             list[list[Observable]]: a list of the obtained groupings. Each grouping is itself a
-            list of Pauli word `Observable` instances
+            list of Pauli word ``Observable`` instances
         """
 
         if self.adj_matrix is None:
@@ -185,12 +185,12 @@ def group_observables(observables, coefficients=None, grouping_type="qwc", metho
     graph using graph-coloring heuristic algorithms.
 
     Args:
-        observables (list[Observable]): a list of Pauli word `Observable` instances (Pauli
+        observables (list[Observable]): a list of Pauli word ``Observable`` instances (Pauli
             operation instances and Tensor instances thereof)
 
     Keyword args:
         coefficients (list[scalar]): A list of scalar coefficients. If not specified,
-            output `partitioned_coeffs` is not returned.
+            output ``partitioned_coeffs`` is not returned.
         grouping_type (str): The type of binary relation between Pauli words. Can be 'qwc',
             'commuting', or 'anticommuting'.
         method (str): the graph coloring heuristic to use in solving minimum clique cover, which
@@ -200,7 +200,7 @@ def group_observables(observables, coefficients=None, grouping_type="qwc", metho
        tuple:
 
            * list[list[Observable]]: A list of the obtained groupings. Each grouping
-             is itself a list of Pauli word `Observable` instances.
+             is itself a list of Pauli word ``Observable`` instances.
            * list[list[scalar]]: A list of coefficient groupings. Each coefficient
              grouping is itself a list of the grouping's corresponding coefficients. This is only
              output if coefficients are specified.

--- a/pennylane/grouping/group_observables.py
+++ b/pennylane/grouping/group_observables.py
@@ -188,22 +188,6 @@ def group_observables(observables, coefficients=None, grouping_type="qwc", metho
     observables and edges encode the binary relation, then 2) solving minimum clique cover for the
     graph using graph-coloring heuristic algorithms.
 
-    **Example usage:**
-
-    >>> observables = [qml.PauliY(0), qml.PauliX(0) @ qml.PauliX(1), qml.PauliZ(1)]
-    >>> coefficients = [1.43, 4.21, 0.97]
-    >>> obs_groupings, coeffs_groupings = group_observables(
-                                                            observables,
-                                                            coefficients,
-                                                            'anticommuting',
-                                                            'lf')
-    >>> obs_groupings
-    [[Tensor(PauliZ(wires=[1])),
-      Tensor(PauliX(wires=[0]), PauliX(wires=[1]))],
-     [Tensor(PauliY(wires=[0]))]]
-    >>> coeffs_groupings
-    [[0.97, 4.21], [1.43]]
-
     Args:
         observables (list[Observable]): a list of Pauli word `Observable` instances (Pauli
             operation instances and Tensor instances thereof)
@@ -226,6 +210,22 @@ def group_observables(observables, coefficients=None, grouping_type="qwc", metho
     Raises:
         IndexError: if the input list of coefficients is not of the same length as the input list
             of Pauli words
+
+    **Example**
+
+    >>> observables = [qml.PauliY(0), qml.PauliX(0) @ qml.PauliX(1), qml.PauliZ(1)]
+    >>> coefficients = [1.43, 4.21, 0.97]
+    >>> obs_groupings, coeffs_groupings = group_observables(
+                                                            observables,
+                                                            coefficients,
+                                                            'anticommuting',
+                                                            'lf')
+    >>> obs_groupings
+    [[Tensor(PauliZ(wires=[1])),
+      Tensor(PauliX(wires=[0]), PauliX(wires=[1]))],
+     [Tensor(PauliY(wires=[0]))]]
+    >>> coeffs_groupings
+    [[0.97, 4.21], [1.43]]
     """
 
     if coefficients is not None:

--- a/pennylane/grouping/group_observables.py
+++ b/pennylane/grouping/group_observables.py
@@ -58,7 +58,6 @@ class PauliGroupingStrategy:  # pylint: disable=too-many-instance-attributes
         ValueError: if arguments specified for `grouping_type` or
             `graph_colourer` are not recognized as elements of `GROUPING_TYPES` or
             `GRAPH_COLOURING_METHODS` respectively
-
     """
 
     def __init__(self, observables, grouping_type="qwc", graph_colourer="rlf"):
@@ -97,7 +96,6 @@ class PauliGroupingStrategy:  # pylint: disable=too-many-instance-attributes
 
         Returns:
             array[bool]: a column matrix of the Pauli words in binary vector representation
-
         """
 
         if wire_map is None:
@@ -123,7 +121,6 @@ class PauliGroupingStrategy:  # pylint: disable=too-many-instance-attributes
 
         Returns:
             array[bool]: the square and symmetric adjacency matrix
-
         """
 
         if self.binary_observables is None:
@@ -163,7 +160,6 @@ class PauliGroupingStrategy:  # pylint: disable=too-many-instance-attributes
         Returns:
             list[list[Observable]]: a list of the obtained groupings. Each grouping is itself a
             list of Pauli word `Observable` instances
-
         """
 
         if self.adj_matrix is None:
@@ -201,11 +197,11 @@ def group_observables(observables, coefficients=None, grouping_type="qwc", metho
             can be 'lf' (Largest First) or 'rlf' (Recursive Largest First)
 
     Returns:
-       partitioned_paulis (list[list[Observable]]): A list of the obtained groupings. Each grouping
-            is itself a list of Pauli word `Observable` instances.
-       partitioned_coeffs (list[list[scalar]]): A list of coefficient groupings. Each coefficient
-           grouping is itself a list of the grouping's corresponding coefficients. This is only
-           output if coefficients are specified.
+       list[list[Observable]]: A list of the obtained groupings. Each grouping
+       is itself a list of Pauli word `Observable` instances.
+       list[list[scalar]]: A list of coefficient groupings. Each coefficient
+       grouping is itself a list of the grouping's corresponding coefficients. This is only
+       output if coefficients are specified.
 
     Raises:
         IndexError: if the input list of coefficients is not of the same length as the input list

--- a/pennylane/grouping/group_observables.py
+++ b/pennylane/grouping/group_observables.py
@@ -184,7 +184,7 @@ def group_observables(observables, coefficients=None, grouping_type="qwc", metho
 
     Args:
         observables (list[Observable]): a list of Pauli word ``Observable`` instances (Pauli
-            operation instances and Tensor instances thereof)
+            operation instances and ``Tensor`` instances thereof)
         coefficients (list[float]): A list of float coefficients. If not specified,
             output ``partitioned_coeffs`` is not returned.
         grouping_type (str): The type of binary relation between Pauli words.

--- a/pennylane/grouping/group_observables.py
+++ b/pennylane/grouping/group_observables.py
@@ -191,10 +191,10 @@ def group_observables(observables, coefficients=None, grouping_type="qwc", metho
     Keyword args:
         coefficients (list[scalar]): A list of scalar coefficients. If not specified,
             output ``partitioned_coeffs`` is not returned.
-        grouping_type (str): The type of binary relation between Pauli words. Can be 'qwc',
-            'commuting', or 'anticommuting'.
+        grouping_type (str): The type of binary relation between Pauli words.
+            Can be ``'qwc'``, ``'commuting'``, or ``'anticommuting'``.
         method (str): the graph coloring heuristic to use in solving minimum clique cover, which
-            can be 'lf' (Largest First) or 'rlf' (Recursive Largest First)
+            can be ``'lf'`` (Largest First) or ``'rlf'`` (Recursive Largest First)
 
     Returns:
        tuple:

--- a/pennylane/grouping/group_observables.py
+++ b/pennylane/grouping/group_observables.py
@@ -197,11 +197,13 @@ def group_observables(observables, coefficients=None, grouping_type="qwc", metho
             can be 'lf' (Largest First) or 'rlf' (Recursive Largest First)
 
     Returns:
-       list[list[Observable]]: A list of the obtained groupings. Each grouping
-       is itself a list of Pauli word `Observable` instances.
-       list[list[scalar]]: A list of coefficient groupings. Each coefficient
-       grouping is itself a list of the grouping's corresponding coefficients. This is only
-       output if coefficients are specified.
+       tuple:
+
+           * list[list[Observable]]: A list of the obtained groupings. Each grouping
+             is itself a list of Pauli word `Observable` instances.
+           * list[list[scalar]]: A list of coefficient groupings. Each coefficient
+             grouping is itself a list of the grouping's corresponding coefficients. This is only
+             output if coefficients are specified.
 
     Raises:
         IndexError: if the input list of coefficients is not of the same length as the input list

--- a/pennylane/grouping/group_observables.py
+++ b/pennylane/grouping/group_observables.py
@@ -213,13 +213,9 @@ def group_observables(observables, coefficients=None, grouping_type="qwc", metho
 
     **Example**
 
-    >>> observables = [qml.PauliY(0), qml.PauliX(0) @ qml.PauliX(1), qml.PauliZ(1)]
-    >>> coefficients = [1.43, 4.21, 0.97]
-    >>> obs_groupings, coeffs_groupings = group_observables(
-                                                            observables,
-                                                            coefficients,
-                                                            'anticommuting',
-                                                            'lf')
+    >>> obs = [qml.PauliY(0), qml.PauliX(0) @ qml.PauliX(1), qml.PauliZ(1)]
+    >>> coeffs = [1.43, 4.21, 0.97]
+    >>> obs_groupings, coeffs_groupings = group_observables(obs, coeffs, 'anticommuting', 'lf')
     >>> obs_groupings
     [[Tensor(PauliZ(wires=[1])),
       Tensor(PauliX(wires=[0]), PauliX(wires=[1]))],

--- a/pennylane/grouping/group_observables.py
+++ b/pennylane/grouping/group_observables.py
@@ -185,7 +185,7 @@ def group_observables(observables, coefficients=None, grouping_type="qwc", metho
     Args:
         observables (list[Observable]): a list of Pauli word ``Observable`` instances (Pauli
             operation instances and Tensor instances thereof)
-        coefficients (list[scalar]): A list of scalar coefficients. If not specified,
+        coefficients (list[float]): A list of float coefficients. If not specified,
             output ``partitioned_coeffs`` is not returned.
         grouping_type (str): The type of binary relation between Pauli words.
             Can be ``'qwc'``, ``'commuting'``, or ``'anticommuting'``.
@@ -197,7 +197,7 @@ def group_observables(observables, coefficients=None, grouping_type="qwc", metho
 
            * list[list[Observable]]: A list of the obtained groupings. Each grouping
              is itself a list of Pauli word ``Observable`` instances.
-           * list[list[scalar]]: A list of coefficient groupings. Each coefficient
+           * list[list[float]]: A list of coefficient groupings. Each coefficient
              grouping is itself a list of the grouping's corresponding coefficients. This is only
              output if coefficients are specified.
 

--- a/pennylane/grouping/group_observables.py
+++ b/pennylane/grouping/group_observables.py
@@ -93,7 +93,7 @@ class PauliGroupingStrategy:  # pylint: disable=too-many-instance-attributes
                 and unique integer labels as their values
 
         Returns:
-            array[bool]: a column matrix of the Pauli words in binary vector representation
+            array[int]: a column matrix of the Pauli words in binary vector representation
         """
 
         if wire_map is None:
@@ -118,7 +118,7 @@ class PauliGroupingStrategy:  # pylint: disable=too-many-instance-attributes
         matrix, where matrix elements of 1 denote an edge, and matrix elements of 0 denote no edge.
 
         Returns:
-            array[bool]: the square and symmetric adjacency matrix
+            array[int]: the square and symmetric adjacency matrix
         """
 
         if self.binary_observables is None:

--- a/pennylane/grouping/group_observables.py
+++ b/pennylane/grouping/group_observables.py
@@ -184,7 +184,7 @@ def group_observables(observables, coefficients=None, grouping_type="qwc", metho
 
     Args:
         observables (list[Observable]): a list of Pauli word ``Observable`` instances (Pauli
-            operation instances and ``Tensor`` instances thereof)
+            operation instances and :class:`~.Tensor` instances thereof)
         coefficients (list[float]): A list of float coefficients. If not specified,
             output ``partitioned_coeffs`` is not returned.
         grouping_type (str): The type of binary relation between Pauli words.

--- a/pennylane/grouping/optimize_measurements.py
+++ b/pennylane/grouping/optimize_measurements.py
@@ -30,24 +30,6 @@ def optimize_measurements(observables, coefficients=None, grouping="qwc", colour
     found. See arXiv:1907.03358 and arXiv:1907.09386 for technical details of the QWC and fully
     commuting measurement partitioning approaches respectively.
 
-    **Example usage:**
-
-    >>> observables = [qml.PauliY(0), qml.PauliX(0) @ qml.PauliX(1), qml.PauliZ(1)]
-    >>> coefficients = [1.43, 4.21, 0.97]
-    >>> post_rotations,diagonalized_groupings,grouped_coeffs = optimize_measurements(
-                                                                                     observables,
-                                                                                     coefficients,
-                                                                                     'qwc',
-                                                                                     'rlf'
-                                                                                     )
-    >>> print(post_rotations)
-    [[RY(-1.5707963267948966, wires=[0]), RY(-1.5707963267948966, wires=[1])],
-     [RX(1.5707963267948966, wires=[0])]]
-    >>> print(diagonalized_groupings)
-    [[Tensor(PauliZ(wires=[0]), PauliZ(wires=[1]))], [PauliZ(wires=[0]), PauliZ(wires=[1])]]
-    >>> print(grouped_coeffs)
-    [[4.21], [1.43, 0.97]]
-
     Args:
         observables (list[Observable]): a list of Pauli words (Pauli operation instances and Tensor
             instances thereof)
@@ -68,6 +50,23 @@ def optimize_measurements(observables, coefficients=None, grouping="qwc", colour
             coefficient grouping is itself a list of the partitions corresponding coefficients.
             Only output if coefficients are specified.
 
+    **Example**
+
+    >>> observables = [qml.PauliY(0), qml.PauliX(0) @ qml.PauliX(1), qml.PauliZ(1)]
+    >>> coefficients = [1.43, 4.21, 0.97]
+    >>> post_rotations,diagonalized_groupings,grouped_coeffs = optimize_measurements(
+                                                                                     observables,
+                                                                                     coefficients,
+                                                                                     'qwc',
+                                                                                     'rlf'
+                                                                                     )
+    >>> print(post_rotations)
+    [[RY(-1.5707963267948966, wires=[0]), RY(-1.5707963267948966, wires=[1])],
+     [RX(1.5707963267948966, wires=[0])]]
+    >>> print(diagonalized_groupings)
+    [[Tensor(PauliZ(wires=[0]), PauliZ(wires=[1]))], [PauliZ(wires=[0]), PauliZ(wires=[1])]]
+    >>> print(grouped_coeffs)
+    [[4.21], [1.43, 0.97]]
     """
 
     if coefficients is None:

--- a/pennylane/grouping/optimize_measurements.py
+++ b/pennylane/grouping/optimize_measurements.py
@@ -35,7 +35,7 @@ def optimize_measurements(observables, coefficients=None, grouping="qwc", colour
     Args:
         observables (list[Observable]): a list of Pauli words (Pauli operation instances and Tensor
             instances thereof)
-        coefficients (list[scalar]): a list of scalar coefficients, for instance the weights of
+        coefficients (list[float]): a list of float coefficients, for instance the weights of
         the Pauli words comprising a Hamiltonian
         grouping (str): the binary symmetric relation to use for operator partitioning
         colouring_method (str): the graph-colouring heuristic to use in obtaining the operator
@@ -49,7 +49,7 @@ def optimize_measurements(observables, coefficients=None, grouping="qwc", colour
             * list[list[Observable]]: A list of the obtained groupings. Each
               grouping is itself a list of Pauli words diagonal in the
               measurement basis.
-            * list[list[scalar]]: A list of coefficient groupings. Each
+            * list[list[float]]: A list of coefficient groupings. Each
               coefficient grouping is itself a list of the partitions
               corresponding coefficients.  Only output if coefficients are
               specified.

--- a/pennylane/grouping/optimize_measurements.py
+++ b/pennylane/grouping/optimize_measurements.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-The main function for measurement reduction, `optimize_measurements` returns the partitions and
+The main function for measurement reduction, ``optimize_measurements`` returns the partitions and
 corresponding necessary circuit post-rotations for a given list of Pauli words.
 """
 

--- a/pennylane/grouping/optimize_measurements.py
+++ b/pennylane/grouping/optimize_measurements.py
@@ -42,13 +42,17 @@ def optimize_measurements(observables, coefficients=None, grouping="qwc", colour
             partitions
 
     Returns:
-        post_rotations (list[Template]): a list of the post-rotation qml.Templates instances, one
-            for each partition
-        diagonalized_groupings (list[list[Observable]]): A list of the obtained groupings. Each
-            grouping is itself a list of Pauli words diagonal in the measurement basis.
-        grouped_coeffs (list[list[scalar]]): A list of coefficient groupings. Each
-            coefficient grouping is itself a list of the partitions corresponding coefficients.
-            Only output if coefficients are specified.
+        tuple:
+
+            * list[Template]: a list of the post-rotation qml.Templates instances, one
+              for each partition
+            * list[list[Observable]]: A list of the obtained groupings. Each
+              grouping is itself a list of Pauli words diagonal in the
+              measurement basis.
+            * list[list[scalar]]: A list of coefficient groupings. Each
+              coefficient grouping is itself a list of the partitions
+              corresponding coefficients.  Only output if coefficients are
+              specified.
 
     **Example**
 

--- a/pennylane/grouping/optimize_measurements.py
+++ b/pennylane/grouping/optimize_measurements.py
@@ -35,8 +35,6 @@ def optimize_measurements(observables, coefficients=None, grouping="qwc", colour
     Args:
         observables (list[Observable]): a list of Pauli words (Pauli operation instances and Tensor
             instances thereof)
-
-    Keyword args:
         coefficients (list[scalar]): a list of scalar coefficients, for instance the weights of
         the Pauli words comprising a Hamiltonian
         grouping (str): the binary symmetric relation to use for operator partitioning

--- a/pennylane/grouping/optimize_measurements.py
+++ b/pennylane/grouping/optimize_measurements.py
@@ -36,7 +36,7 @@ def optimize_measurements(observables, coefficients=None, grouping="qwc", colour
         observables (list[Observable]): a list of Pauli words (Pauli operation instances and Tensor
             instances thereof)
         coefficients (list[float]): a list of float coefficients, for instance the weights of
-        the Pauli words comprising a Hamiltonian
+            the Pauli words comprising a Hamiltonian
         grouping (str): the binary symmetric relation to use for operator partitioning
         colouring_method (str): the graph-colouring heuristic to use in obtaining the operator
             partitions

--- a/pennylane/grouping/optimize_measurements.py
+++ b/pennylane/grouping/optimize_measurements.py
@@ -52,18 +52,13 @@ def optimize_measurements(observables, coefficients=None, grouping="qwc", colour
 
     **Example**
 
-    >>> observables = [qml.PauliY(0), qml.PauliX(0) @ qml.PauliX(1), qml.PauliZ(1)]
-    >>> coefficients = [1.43, 4.21, 0.97]
-    >>> post_rotations,diagonalized_groupings,grouped_coeffs = optimize_measurements(
-                                                                                     observables,
-                                                                                     coefficients,
-                                                                                     'qwc',
-                                                                                     'rlf'
-                                                                                     )
-    >>> print(post_rotations)
+    >>> obs = [qml.PauliY(0), qml.PauliX(0) @ qml.PauliX(1), qml.PauliZ(1)]
+    >>> coeffs = [1.43, 4.21, 0.97]
+    >>> rotations, groupings, grouped_coeffs = optimize_measurements(obs, coeffs, 'qwc', 'rlf')
+    >>> print(rotations)
     [[RY(-1.5707963267948966, wires=[0]), RY(-1.5707963267948966, wires=[1])],
      [RX(1.5707963267948966, wires=[0])]]
-    >>> print(diagonalized_groupings)
+    >>> print(groupings)
     [[Tensor(PauliZ(wires=[0]), PauliZ(wires=[1]))], [PauliZ(wires=[0]), PauliZ(wires=[1])]]
     >>> print(grouped_coeffs)
     [[4.21], [1.43, 0.97]]

--- a/pennylane/grouping/transformations.py
+++ b/pennylane/grouping/transformations.py
@@ -71,7 +71,7 @@ def diagonalize_pauli_word(pauli_word):
 
     Raises:
         TypeError: if the input is not a Pauli word, i.e., a Pauli operator,
-            ``Identity``, or ``Tensor`` instances thereof
+            :class:`~.Identity`, or :class:`~.Tensor` instances thereof
 
     **Example**
 

--- a/pennylane/grouping/transformations.py
+++ b/pennylane/grouping/transformations.py
@@ -36,7 +36,7 @@ def qwc_rotation(pauli_operators):
         pauli_operators (list[Union[PauliX, PauliY, PauliZ, Identity]]): Single-qubit Pauli
             operations. No Pauli operations in this list may be acting on the same wire.
     Raises:
-        TypeError: if any elements of `pauli_operators` are not instances of qml.PauliX, qml.PauliY,
+        TypeError: if any elements of ``pauli_operators`` are not instances of qml.PauliX, qml.PauliY,
             qml.PauliZ, or qml.Identity
 
     **Example**
@@ -70,7 +70,7 @@ def diagonalize_pauli_word(pauli_word):
         Observable: the Pauli word diagonalized in the computational basis
 
     Raises:
-        TypeError: if the input is not a Pauli word, i.e., a Pauli operator, identity, or `Tensor`
+        TypeError: if the input is not a Pauli word, i.e., a Pauli operator, identity, or ``Tensor``
             instances thereof
 
     **Example**

--- a/pennylane/grouping/transformations.py
+++ b/pennylane/grouping/transformations.py
@@ -71,7 +71,7 @@ def diagonalize_pauli_word(pauli_word):
 
     Raises:
         TypeError: if the input is not a Pauli word, i.e., a Pauli operator, identity, or `Tensor`
-        instances thereof
+            instances thereof
 
     **Example**
 
@@ -112,10 +112,12 @@ def diagonalize_qwc_pauli_words(qwc_grouping):
             qubit-wise commutative Pauli words
 
     Returns:
-        unitary (list[Operation]): an instance of the qwc_rotation template which diagonalizes the
-            qubit-wise commuting grouping
-        diag_terms (list[Observable]): list of Pauli string observables diagonal in the
-            computational basis
+        tuple:
+
+            * list[Operation]: an instance of the qwc_rotation template which
+              diagonalizes the qubit-wise commuting grouping
+            * list[Observable]: list of Pauli string observables diagonal in
+              the computational basis
 
     Raises:
         ValueError: if any 2 elements in the input QWC grouping are not qubit-wise commutative
@@ -186,11 +188,13 @@ def diagonalize_qwc_groupings(qwc_groupings):
             of Pauli string observables
 
     Returns:
-        post_rotations (list[list[Operation]]): a list of instances of the qwc_rotation template
-            which diagonalizes the qubit-wise commuting grouping, order corresponding to
-            qwc_groupings
-        diag_groupings (list[list[Observable]]): a list of QWC groupings diagonalized in the
-            computational basis, order corresponding to qwc_groupings
+        tuple:
+
+            * list[list[Operation]]: a list of instances of the qwc_rotation
+              template which diagonalizes the qubit-wise commuting grouping,
+              order corresponding to qwc_groupings
+            * list[list[Observable]]: a list of QWC groupings diagonalized in the
+              computational basis, order corresponding to qwc_groupings
 
     **Example**
 

--- a/pennylane/grouping/transformations.py
+++ b/pennylane/grouping/transformations.py
@@ -37,7 +37,7 @@ def qwc_rotation(pauli_operators):
             operations. No Pauli operations in this list may be acting on the same wire.
     Raises:
         TypeError: if any elements of ``pauli_operators`` are not instances of
-            ``qml.PauliX``, ``qml.PauliY``, ``qml.PauliZ``, or ``qml.Identity``
+            :class:`~.PauliX`, :class:`~.PauliY`, :class:`~.PauliZ`, or :class:`~.Identity`
 
     **Example**
 
@@ -70,8 +70,8 @@ def diagonalize_pauli_word(pauli_word):
         Observable: the Pauli word diagonalized in the computational basis
 
     Raises:
-        TypeError: if the input is not a Pauli word, i.e., a Pauli operator, identity, or ``Tensor``
-            instances thereof
+        TypeError: if the input is not a Pauli word, i.e., a Pauli operator,
+            ``Identity``, or ``Tensor`` instances thereof
 
     **Example**
 

--- a/pennylane/grouping/transformations.py
+++ b/pennylane/grouping/transformations.py
@@ -32,13 +32,6 @@ import numpy as np
 def qwc_rotation(pauli_operators):
     """Performs circuit implementation of diagonalizing unitary for a Pauli word.
 
-
-    **Usage example:**
-
-    >>> pauli_operators = [qml.PauliX('a'), qml.PauliY('b'), qml.PauliZ('c')]
-    >>> qwc_rotation(pauli_operators)
-    [RY(-1.5707963267948966, wires=['a']), RX(1.5707963267948966, wires=['b'])]
-
     Args:
         pauli_operators (list[Union[PauliX, PauliY, PauliZ, Identity]]): Single-qubit Pauli
             operations. No Pauli operations in this list may be acting on the same wire.
@@ -46,6 +39,11 @@ def qwc_rotation(pauli_operators):
         TypeError: if any elements of `pauli_operators` are not instances of qml.PauliX, qml.PauliY,
             qml.PauliZ, or qml.Identity
 
+    **Example**
+
+    >>> pauli_operators = [qml.PauliX('a'), qml.PauliY('b'), qml.PauliZ('c')]
+    >>> qwc_rotation(pauli_operators)
+    [RY(-1.5707963267948966, wires=['a']), RX(1.5707963267948966, wires=['b'])]
     """
     paulis_with_identity = (qml.Identity, qml.PauliX, qml.PauliY, qml.PauliZ)
     if not all(isinstance(element, paulis_with_identity) for element in pauli_operators):
@@ -65,11 +63,6 @@ def qwc_rotation(pauli_operators):
 def diagonalize_pauli_word(pauli_word):
     """Transforms the Pauli word to diagonal form in the computational basis.
 
-    **Usage example:**
-
-    >>> diagonalize_pauli_word(PauliX('a') @ PauliY('b') @ PauliZ('c'))
-    Tensor(PauliZ(wires=['a']), PauliZ(wires=['b']), PauliZ(wires=['c']))
-
     Args:
         pauli_word (Observable): the Pauli word to diagonalize in computational basis
 
@@ -80,6 +73,10 @@ def diagonalize_pauli_word(pauli_word):
         TypeError: if the input is not a Pauli word, i.e., a Pauli operator, identity, or `Tensor`
         instances thereof
 
+    **Example**
+
+    >>> diagonalize_pauli_word(PauliX('a') @ PauliY('b') @ PauliZ('c'))
+    Tensor(PauliZ(wires=['a']), PauliZ(wires=['b']), PauliZ(wires=['c']))
     """
 
     if not is_pauli_word(pauli_word):
@@ -110,17 +107,6 @@ def diagonalize_pauli_word(pauli_word):
 def diagonalize_qwc_pauli_words(qwc_grouping):
     """Diagonalizes a list of mutually qubit-wise commutative Pauli words.
 
-    **Usage example:**
-
-    >>> qwc_group = [qml.PauliX(0) @ qml.PauliZ(1),
-                     qml.PauliX(0) @ qml.PauliY(3),
-                     qml.PauliZ(1) @ qml.PauliY(3)]
-    >>> diagonalize_qwc_pauli_words(qwc_group)
-    ([RY(-1.5707963267948966, wires=[0]), RX(1.5707963267948966, wires=[3])],
-     [Tensor(PauliZ(wires=[0]), PauliZ(wires=[1])),
-     Tensor(PauliZ(wires=[0]), PauliZ(wires=[3])),
-     Tensor(PauliZ(wires=[1]), PauliZ(wires=[3]))])
-
     Args:
         qwc_grouping (list[Observable]): a list of observables containing mutually
             qubit-wise commutative Pauli words
@@ -134,6 +120,16 @@ def diagonalize_qwc_pauli_words(qwc_grouping):
     Raises:
         ValueError: if any 2 elements in the input QWC grouping are not qubit-wise commutative
 
+    **Example**
+
+    >>> qwc_group = [qml.PauliX(0) @ qml.PauliZ(1),
+                     qml.PauliX(0) @ qml.PauliY(3),
+                     qml.PauliZ(1) @ qml.PauliY(3)]
+    >>> diagonalize_qwc_pauli_words(qwc_group)
+    ([RY(-1.5707963267948966, wires=[0]), RX(1.5707963267948966, wires=[3])],
+     [Tensor(PauliZ(wires=[0]), PauliZ(wires=[1])),
+     Tensor(PauliZ(wires=[0]), PauliZ(wires=[3])),
+     Tensor(PauliZ(wires=[1]), PauliZ(wires=[3]))])
     """
     m_paulis = len(qwc_grouping)
     all_wires = Wires.all_wires([pauli_word.wires for pauli_word in qwc_grouping])
@@ -185,7 +181,18 @@ def diagonalize_qwc_pauli_words(qwc_grouping):
 def diagonalize_qwc_groupings(qwc_groupings):
     """Diagonalizes a list of qubit-wise commutative groupings of Pauli strings.
 
-    **Usage example:**
+    Args:
+        qwc_groupings (list[list[Observable]]): a list of mutually qubit-wise commutative groupings
+            of Pauli string observables
+
+    Returns:
+        post_rotations (list[list[Operation]]): a list of instances of the qwc_rotation template
+            which diagonalizes the qubit-wise commuting grouping, order corresponding to
+            qwc_groupings
+        diag_groupings (list[list[Observable]]): a list of QWC groupings diagonalized in the
+            computational basis, order corresponding to qwc_groupings
+
+    **Example**
 
     >>> qwc_group_1 = [qml.PauliX(0) @ qml.PauliZ(1),
                        qml.PauliX(0) @ qml.PauliY(3),
@@ -201,18 +208,6 @@ def diagonalize_qwc_groupings(qwc_groupings):
        Tensor(PauliZ(wires=[1]), PauliZ(wires=[3]))], [Tensor(PauliZ(wires=[0])),
        Tensor(PauliZ(wires=[0]), PauliZ(wires=[2])), Tensor(PauliZ(wires=[1]),
        PauliZ(wires=[3]))]])
-
-    Args:
-        qwc_groupings (list[list[Observable]]): a list of mutually qubit-wise commutative groupings
-            of Pauli string observables
-
-    Returns:
-        post_rotations (list[list[Operation]]): a list of instances of the qwc_rotation template
-            which diagonalizes the qubit-wise commuting grouping, order corresponding to
-            qwc_groupings
-        diag_groupings (list[list[Observable]]): a list of QWC groupings diagonalized in the
-            computational basis, order corresponding to qwc_groupings
-
     """
 
     post_rotations = []

--- a/pennylane/grouping/transformations.py
+++ b/pennylane/grouping/transformations.py
@@ -36,8 +36,8 @@ def qwc_rotation(pauli_operators):
         pauli_operators (list[Union[PauliX, PauliY, PauliZ, Identity]]): Single-qubit Pauli
             operations. No Pauli operations in this list may be acting on the same wire.
     Raises:
-        TypeError: if any elements of ``pauli_operators`` are not instances of qml.PauliX, qml.PauliY,
-            qml.PauliZ, or qml.Identity
+        TypeError: if any elements of ``pauli_operators`` are not instances of
+            ``qml.PauliX``, ``qml.PauliY``, ``qml.PauliZ``, or ``qml.Identity``
 
     **Example**
 

--- a/pennylane/grouping/utils.py
+++ b/pennylane/grouping/utils.py
@@ -121,7 +121,7 @@ def pauli_to_binary(pauli_word, n_qubits=None, wire_map=None):
             converted to binary vector representation
         n_qubits (int): number of qubits to specify dimension of binary vector representation
         wire_map (dict): dictionary containing all wire labels used in the Pauli word as keys, and
-                         unique integer labels as their values
+             unique integer labels as their values
 
     Returns:
         array: the 2*n_qubits dimensional binary vector representation of the input Pauli word.

--- a/pennylane/grouping/utils.py
+++ b/pennylane/grouping/utils.py
@@ -32,7 +32,7 @@ def is_pauli_word(observable):
     Checks if an observable instance is a Pauli word.
 
     Args:
-        observable (Observable): an observable, either a ``Tensor`` instance or
+        observable (Observable): an observable, either a :class:`~.Tensor` instance or
             single-qubit observable.
 
     Returns:
@@ -66,8 +66,8 @@ def is_pauli_word(observable):
 def are_identical_pauli_words(pauli_1, pauli_2):
     """Performs a check if two Pauli words have the same ``wires`` and ``name`` attributes.
 
-    This is a convenience function that checks if two given ``Tensor`` instances specify the same
-    Pauli word. This function only checks if both ``Tensor`` instances have the same wires and name
+    This is a convenience function that checks if two given :class:`~.Tensor` instances specify the same
+    Pauli word. This function only checks if both :class:`~.Tensor` instances have the same wires and name
     attributes, and hence won't perform any simplification to identify if the two Pauli words are
     algebraically equivalent. For instance, this function will not identify
     that ``PauliX(0) @ PauliX(0) = Identity(0)``, or ``PauliX(0) @ Identity(1)
@@ -81,8 +81,9 @@ def are_identical_pauli_words(pauli_1, pauli_2):
         bool: whether ``pauli_1`` and ``pauli_2`` have the same wires and name attributes
 
     Raises:
-        TypeError: if ``pauli_1`` or ``pauli_2`` are not ``Identity``,
-            ``PauliX``, ``PauliY``, ``PauliZ``, or ``Tensor`` instances
+        TypeError: if ``pauli_1`` or ``pauli_2`` are not :class:`~.Identity`,
+            :class:`~.PauliX`, :class:`~.PauliY`, :class:`~.PauliZ`, or
+            :class:`~.Tensor` instances
 
     **Example**
 
@@ -249,7 +250,7 @@ def binary_to_pauli(binary_vector, wire_map=None):  # pylint: disable=too-many-b
     Returns:
         Tensor: The Pauli word corresponding to the input binary vector. Note
         that if a zero vector is input, then the resulting Pauli word will be
-        an ``Identity`` instance.
+        an :class:`~.Identity` instance.
 
     Raises:
         TypeError: if length of binary vector is not even, or if vector does not have strictly

--- a/pennylane/grouping/utils.py
+++ b/pennylane/grouping/utils.py
@@ -32,8 +32,8 @@ def is_pauli_word(observable):
     Checks if an observable instance is a Pauli word.
 
     Args:
-        observable (Observable): an observable, either a Tensor instance or single-qubit
-            observable.
+        observable (Observable): an observable, either a ``Tensor`` instance or
+            single-qubit observable.
 
     Returns:
         bool: true if the input observable is a Pauli word, false otherwise.
@@ -66,12 +66,12 @@ def is_pauli_word(observable):
 def are_identical_pauli_words(pauli_1, pauli_2):
     """Performs a check if two Pauli words have the same ``wires`` and ``name`` attributes.
 
-    This is a convenience function that checks if two given Tensor instances specify the same
-    Pauli word. This function only checks if both Tensor instances have the same wires and name
+    This is a convenience function that checks if two given ``Tensor`` instances specify the same
+    Pauli word. This function only checks if both ``Tensor`` instances have the same wires and name
     attributes, and hence won't perform any simplification to identify if the two Pauli words are
-    algebraically equivalent. For instance, this function will not identify that
-    PauliX(0) @ PauliX(0) = Identity(0), or PauliX(0) @ Identity(1) = PauliX(0), or
-    Identity(0) = Identity(1), etc.
+    algebraically equivalent. For instance, this function will not identify
+    that ``PauliX(0) @ PauliX(0) = Identity(0)``, or ``PauliX(0) @ Identity(1)
+    = PauliX(0)``, or ``Identity(0) = Identity(1)``, etc.
 
     Args:
         pauli_1 (Union[Identity, PauliX, PauliY, PauliZ, Tensor]): the first Pauli word
@@ -81,8 +81,8 @@ def are_identical_pauli_words(pauli_1, pauli_2):
         bool: whether ``pauli_1`` and ``pauli_2`` have the same wires and name attributes
 
     Raises:
-        TypeError: if pauli_1 or pauli_2 are not Identity, PauliX, PauliY, PauliZ, or Tensor
-            instances
+        TypeError: if ``pauli_1`` or ``pauli_2`` are not ``Identity``,
+            ``PauliX``, ``PauliY``, ``PauliZ``, or ``Tensor`` instances
 
     **Example**
 
@@ -247,9 +247,9 @@ def binary_to_pauli(binary_vector, wire_map=None):  # pylint: disable=too-many-b
             unique integer labels as their values
 
     Returns:
-        Tensor(Union[Identity, PauliX, PauliY, PauliZ]): The Pauli word corresponding to the input
-        binary vector. Note that if a zero vector is input, then the resulting Pauli word will
-        be an ``Identity`` instance.
+        Tensor: The Pauli word corresponding to the input binary vector. Note
+        that if a zero vector is input, then the resulting Pauli word will be
+        an ``Identity`` instance.
 
     Raises:
         TypeError: if length of binary vector is not even, or if vector does not have strictly
@@ -263,14 +263,15 @@ def binary_to_pauli(binary_vector, wire_map=None):  # pylint: disable=too-many-b
     >>> binary_to_pauli([0,1,1,0,1,0])
     Tensor(PauliY(wires=[1]), PauliX(wires=[2]))
 
-    An arbitrary labelling can be assigned by using ``wire_map``
+    An arbitrary labelling can be assigned by using ``wire_map``:
+
     >>> wire_map = {Wires('a'): 0, Wires('b'): 1, Wires('c'): 2}
     >>> binary_to_pauli([0,1,1,0,1,0], wire_map=wire_map)
     Tensor(PauliY(wires=['b']), PauliX(wires=['c']))
 
-    Note that the values of ``wire_map``, if specified, must be 0,1,..., N, where N is the dimension
-    of the vector divided by two, i.e., ``list(wire_map.values())`` must be
-    ``list(range(len(binary_vector)/2))``.
+    Note that the values of ``wire_map``, if specified, must be ``0,1,..., N``,
+    where ``N`` is the dimension of the vector divided by two, i.e.,
+    ``list(wire_map.values())`` must be ``list(range(len(binary_vector)/2))``.
     """
 
     if isinstance(binary_vector, (list, tuple)):

--- a/pennylane/grouping/utils.py
+++ b/pennylane/grouping/utils.py
@@ -423,7 +423,7 @@ def observables_to_binary_matrix(observables, n_qubits=None, wire_map=None):
 
 
     Returns:
-        array[array[bool]]: a matrix whose rows are Pauli words in binary vector representation
+        array[array[int]]: a matrix whose rows are Pauli words in binary vector representation
 
     **Example**
 
@@ -464,11 +464,11 @@ def qwc_complement_adj_matrix(binary_observables):
     commuting.
 
     Args:
-        binary_observables (array[array[bool]]): a matrix whose rows are the Pauli words in the
+        binary_observables (array[array[int]]): a matrix whose rows are the Pauli words in the
             binary vector representation
 
     Returns:
-        array[array[bool]]: the adjacency matrix for the complement of the qubit-wise commutativity graph
+        array[array[int]]: the adjacency matrix for the complement of the qubit-wise commutativity graph
 
     Raises:
         ValueError: if input binary observables contain components which are not strictly binary

--- a/pennylane/grouping/utils.py
+++ b/pennylane/grouping/utils.py
@@ -251,8 +251,8 @@ def binary_to_pauli(binary_vector, wire_map=None):  # pylint: disable=too-many-b
 
     Returns:
         Tensor(Union[Identity, PauliX, PauliY, PauliZ]): The Pauli word corresponding to the input
-            binary vector. Note that if a zero vector is input, then the resulting Pauli word will
-            be an `Identity` instance.
+        binary vector. Note that if a zero vector is input, then the resulting Pauli word will
+        be an `Identity` instance.
 
     Raises:
         TypeError: if length of binary vector is not even, or if vector does not have strictly
@@ -340,7 +340,7 @@ def is_qwc(pauli_vec_1, pauli_vec_2):
 
     Returns:
         bool: returns True if the input Pauli words are qubit-wise commutative, returns False
-            otherwise
+        otherwise
 
     Raises:
         ValueError: if the input vectors are of different dimension, if the vectors are not of even

--- a/pennylane/grouping/utils.py
+++ b/pennylane/grouping/utils.py
@@ -30,15 +30,6 @@ def is_pauli_word(observable):
     """
     Checks if an observable instance is a Pauli word.
 
-    **Example usage:**
-
-    >>> is_pauli_word(qml.Identity(0))
-    True
-    >>> is_pauli_word(qml.PauliX(0) @ qml.PauliZ(2))
-    True
-    >>> is_pauli_word(qml.PauliZ(0) @ qml.Hadamard(1))
-    False
-
     Args:
         observable (Observable): an observable, either a Tensor instance or single-qubit
             observable.
@@ -48,6 +39,15 @@ def is_pauli_word(observable):
 
     Raises:
         TypeError: if input observable is not an Observable instance.
+
+    **Example**
+
+    >>> is_pauli_word(qml.Identity(0))
+    True
+    >>> is_pauli_word(qml.PauliX(0) @ qml.PauliZ(2))
+    True
+    >>> is_pauli_word(qml.PauliZ(0) @ qml.Hadamard(1))
+    False
     """
 
     if not isinstance(observable, Observable):
@@ -72,13 +72,6 @@ def are_identical_pauli_words(pauli_1, pauli_2):
     PauliX(0) @ PauliX(0) = Identity(0), or PauliX(0) @ Identity(1) = PauliX(0), or
     Identity(0) = Identity(1), etc.
 
-    **Usage example:**
-
-    >>> are_identical_pauli_words(qml.PauliZ(0) @ qml.PauliZ(1), qml.PauliZ(0) @ qml.PauliZ(1))
-    True
-    >>> are_identical_pauli_words(qml.PauliZ(0) @ qml.PauliZ(1), qml.PauliZ(0) @ qml.PauliX(3))
-    False
-
     Args:
         pauli_1 (Union[Identity, PauliX, PauliY, PauliZ, Tensor]): the first Pauli word
         pauli_2 (Union[Identity, PauliX, PauliY, PauliZ, Tensor]): the second Pauli word
@@ -90,6 +83,12 @@ def are_identical_pauli_words(pauli_1, pauli_2):
         TypeError: if pauli_1 or pauli_2 are not Identity, PauliX, PauliY, PauliZ, or Tensor
             instances
 
+    **Example**
+
+    >>> are_identical_pauli_words(qml.PauliZ(0) @ qml.PauliZ(1), qml.PauliZ(0) @ qml.PauliZ(1))
+    True
+    >>> are_identical_pauli_words(qml.PauliZ(0) @ qml.PauliZ(1), qml.PauliZ(0) @ qml.PauliX(3))
+    False
     """
 
     if not (is_pauli_word(pauli_1) and is_pauli_word(pauli_2)):
@@ -116,7 +115,24 @@ def pauli_to_binary(pauli_word, n_qubits=None, wire_map=None):
     This functions follows convention that the first half of binary vector components specify
     PauliX placements while the last half specify PauliZ placements.
 
-    **Usage example:**
+    Args:
+        pauli_word (Union[Identity, PauliX, PauliY, PauliZ, Tensor]): the Pauli word to be
+            converted to binary vector representation
+
+    Keyword args:
+        n_qubits (int): number of qubits to specify dimension of binary vector representation
+        wire_map (dict): dictionary containing all wire labels used in the Pauli word as keys, and
+                         unique integer labels as their values
+
+    Returns:
+        array: the 2*n_qubits dimensional binary vector representation of the input Pauli word.
+
+    Raises:
+        TypeError: if the input `pauli_word` is not an instance of Identity, PauliX, PauliY,
+            PauliZ or tensor products thereof
+        ValueError: if `n_qubits` is less than the number of wires acted on by the Pauli word
+
+    **Example**
 
     If `n_qubits` and `wire_map` are both unspecified, the dimensionality of the binary vector
     will be `2 * len(pauli_word.wires)`. Regardless of wire labels, the vector components encoding
@@ -173,23 +189,6 @@ def pauli_to_binary(pauli_word, n_qubits=None, wire_map=None):
     >>> wire_map = {Wires(0):0, Wires(1):1, Wires(5):5}
     >>> pauli_to_binary(qml.PauliX(0) @ qml.PauliX(5),  wire_map=wire_map)
     array([1., 0., 0., 0., 0., 1., 0., 0., 0., 0., 0., 0.])
-
-    Args:
-        pauli_word (Union[Identity, PauliX, PauliY, PauliZ, Tensor]): the Pauli word to be
-            converted to binary vector representation
-
-    Keyword args:
-        n_qubits (int): number of qubits to specify dimension of binary vector representation
-        wire_map (dict): dictionary containing all wire labels used in the Pauli word as keys, and
-                         unique integer labels as their values
-
-    Returns:
-        array: the 2*n_qubits dimensional binary vector representation of the input Pauli word.
-
-    Raises:
-        TypeError: if the input `pauli_word` is not an instance of Identity, PauliX, PauliY,
-            PauliZ or tensor products thereof
-        ValueError: if `n_qubits` is less than the number of wires acted on by the Pauli word
     """
 
     if not is_pauli_word(pauli_word):
@@ -242,23 +241,6 @@ def binary_to_pauli(binary_vector, wire_map=None):  # pylint: disable=too-many-b
     This functions follows the convention that the first half of binary vector components specify
     PauliX placements while the last half specify PauliZ placements.
 
-    **Usage example:**
-
-    If `wire_map` is unspecified, the Pauli operations follow the same enumerations as the vector
-    components, i.e., the `i` and `N+i` components specify the Pauli operation on wire `i`,
-
-    >>> binary_to_pauli([0,1,1,0,1,0])
-    Tensor(PauliY(wires=[1]), PauliX(wires=[2]))
-
-    An arbitrary labelling can be assigned by using `wire_map`
-    >>> wire_map = {Wires('a'): 0, Wires('b'): 1, Wires('c'): 2}
-    >>> binary_to_pauli([0,1,1,0,1,0], wire_map=wire_map)
-    Tensor(PauliY(wires=['b']), PauliX(wires=['c']))
-
-    Note that the values of `wire_map`, if specified, must be 0,1,..., N, where N is the dimension
-    of the vector divided by two, i.e., `list(wire_map.values())` must be
-    `list(range(len(binary_vector)/2))`.
-
     Args:
         binary_vector (Union[list, tuple, array]): binary vector of even dimension representing a
             unique Pauli word
@@ -276,6 +258,22 @@ def binary_to_pauli(binary_vector, wire_map=None):  # pylint: disable=too-many-b
         TypeError: if length of binary vector is not even, or if vector does not have strictly
             binary components
 
+    **Example**
+
+    If `wire_map` is unspecified, the Pauli operations follow the same enumerations as the vector
+    components, i.e., the `i` and `N+i` components specify the Pauli operation on wire `i`,
+
+    >>> binary_to_pauli([0,1,1,0,1,0])
+    Tensor(PauliY(wires=[1]), PauliX(wires=[2]))
+
+    An arbitrary labelling can be assigned by using `wire_map`
+    >>> wire_map = {Wires('a'): 0, Wires('b'): 1, Wires('c'): 2}
+    >>> binary_to_pauli([0,1,1,0,1,0], wire_map=wire_map)
+    Tensor(PauliY(wires=['b']), PauliX(wires=['c']))
+
+    Note that the values of `wire_map`, if specified, must be 0,1,..., N, where N is the dimension
+    of the vector divided by two, i.e., `list(wire_map.values())` must be
+    `list(range(len(binary_vector)/2))`.
     """
 
     if isinstance(binary_vector, (list, tuple)):
@@ -334,13 +332,6 @@ def binary_to_pauli(binary_vector, wire_map=None):  # pylint: disable=too-many-b
 def is_qwc(pauli_vec_1, pauli_vec_2):
     """Checks if two Pauli words in the binary vector representation are qubit-wise commutative.
 
-    **Usage example:**
-
-    >>> is_qwc([1,0,0,1,1,0],[1,0,1,0,1,0])
-    False
-    >>> is_qwc([1,0,1,1,1,0],[1,0,0,1,1,0])
-    True
-
     Args:
         pauli_vec_1 (Union[list, tuple, array]): first binary vector argument in qubit-wise
             commutator
@@ -355,6 +346,12 @@ def is_qwc(pauli_vec_1, pauli_vec_2):
         ValueError: if the input vectors are of different dimension, if the vectors are not of even
         dimension, or if the vector components are not strictly binary
 
+    **Example**
+
+    >>> is_qwc([1,0,0,1,1,0],[1,0,1,0,1,0])
+    False
+    >>> is_qwc([1,0,1,1,1,0],[1,0,0,1,1,0])
+    True
     """
 
     if isinstance(pauli_vec_1, (list, tuple)):
@@ -420,13 +417,6 @@ def observables_to_binary_matrix(observables, n_qubits=None, wire_map=None):
     The dimension of the binary vectors will be implied from the highest wire being acted on
     non-trivially by the Pauli words in observables.
 
-    **Usage example:**
-
-    >>> observables_to_binary_matrix([PauliX(0) @ PauliY(2), PauliZ(0) @ PauliZ(1) @ PauliZ(2)])
-    array([[1., 1., 0., 0., 1., 0.],
-           [0., 0., 0., 1., 1., 1.]])
-
-
     Args:
         observables (list[Union[Identity, PauliX, PauliY, PauliZ, Tensor]]): the list of Pauli
             words
@@ -440,6 +430,11 @@ def observables_to_binary_matrix(observables, n_qubits=None, wire_map=None):
     Returns:
         array[array[bool]]: a matrix whose rows are Pauli words in binary vector representation
 
+    **Example**
+
+    >>> observables_to_binary_matrix([PauliX(0) @ PauliY(2), PauliZ(0) @ PauliZ(1) @ PauliZ(2)])
+    array([[1., 1., 0., 0., 1., 0.],
+           [0., 0., 0., 1., 1., 1.]])
     """
 
     m_cols = len(observables)
@@ -473,18 +468,6 @@ def qwc_complement_adj_matrix(binary_observables):
     and two nodes are connected if and only if the corresponding Pauli words are qubit-wise
     commuting.
 
-    **Usage example:**
-
-    >>> binary_observables
-    array([[1., 0., 1., 0., 0., 1.],
-           [0., 1., 1., 1., 0., 1.],
-           [0., 0., 0., 1., 0., 0.]])
-
-    >>> qwc_complement_adj_matrix(binary_observables)
-    array([[0., 1., 1.],
-           [1., 0., 0.],
-           [1., 0., 0.]])
-
     Args:
         binary_observables (array[array[bool]]): a matrix whose rows are the Pauli words in the
             binary vector representation
@@ -495,6 +478,17 @@ def qwc_complement_adj_matrix(binary_observables):
     Raises:
         ValueError: if input binary observables contain components which are not strictly binary
 
+    **Example**
+
+    >>> binary_observables
+    array([[1., 0., 1., 0., 0., 1.],
+           [0., 1., 1., 1., 0., 1.],
+           [0., 0., 0., 1., 0., 0.]])
+
+    >>> qwc_complement_adj_matrix(binary_observables)
+    array([[0., 1., 1.],
+           [1., 0., 0.],
+           [1., 0., 0.]])
     """
 
     if isinstance(binary_observables, (list, tuple)):

--- a/pennylane/grouping/utils.py
+++ b/pennylane/grouping/utils.py
@@ -125,7 +125,7 @@ def pauli_to_binary(pauli_word, n_qubits=None, wire_map=None):
              unique integer labels as their values
 
     Returns:
-        array: the ``2*n_qubits`` dimensional binary vector representation of the input Pauli word.
+        array: the ``2*n_qubits`` dimensional binary vector representation of the input Pauli word
 
     Raises:
         TypeError: if the input ``pauli_word`` is not an instance of Identity, PauliX, PauliY,

--- a/pennylane/grouping/utils.py
+++ b/pennylane/grouping/utils.py
@@ -64,7 +64,7 @@ def is_pauli_word(observable):
 
 
 def are_identical_pauli_words(pauli_1, pauli_2):
-    """Performs a check if two Pauli words have the same `wires` and `name` attributes.
+    """Performs a check if two Pauli words have the same ``wires`` and ``name`` attributes.
 
     This is a convenience function that checks if two given Tensor instances specify the same
     Pauli word. This function only checks if both Tensor instances have the same wires and name
@@ -78,7 +78,7 @@ def are_identical_pauli_words(pauli_1, pauli_2):
         pauli_2 (Union[Identity, PauliX, PauliY, PauliZ, Tensor]): the second Pauli word
 
     Returns:
-        bool: whether `pauli_1` and `pauli_2` have the same wires and name attributes
+        bool: whether ``pauli_1`` and ``pauli_2`` have the same wires and name attributes
 
     Raises:
         TypeError: if pauli_1 or pauli_2 are not Identity, PauliX, PauliY, PauliZ, or Tensor
@@ -129,15 +129,15 @@ def pauli_to_binary(pauli_word, n_qubits=None, wire_map=None):
         array: the 2*n_qubits dimensional binary vector representation of the input Pauli word.
 
     Raises:
-        TypeError: if the input `pauli_word` is not an instance of Identity, PauliX, PauliY,
+        TypeError: if the input ``pauli_word`` is not an instance of Identity, PauliX, PauliY,
             PauliZ or tensor products thereof
-        ValueError: if `n_qubits` is less than the number of wires acted on by the Pauli word
+        ValueError: if ``n_qubits`` is less than the number of wires acted on by the Pauli word
 
     **Example**
 
-    If `n_qubits` and `wire_map` are both unspecified, the dimensionality of the binary vector
-    will be `2 * len(pauli_word.wires)`. Regardless of wire labels, the vector components encoding
-    Pauli operations will be read from left-to-right in the tensor product when `wire_map` is
+    If ``n_qubits`` and ``wire_map`` are both unspecified, the dimensionality of the binary vector
+    will be ``2 * len(pauli_word.wires)``. Regardless of wire labels, the vector components encoding
+    Pauli operations will be read from left-to-right in the tensor product when ``wire_map`` is
     unspecified, e.g.,
 
     >>> pauli_to_binary(qml.PauliX('a') @ qml.PauliY('b') @ qml.PauliZ('c'))
@@ -148,7 +148,7 @@ def pauli_to_binary(pauli_word, n_qubits=None, wire_map=None):
     The above cases have the same binary representation since they are equivalent up to a
     relabelling of the wires. To keep binary vector component enumeration consistent with wire
     labelling across multiple Pauli words, or define any arbitrary enumeration, one can use
-    keyword argument `wire_map` to set this enumeration.
+    keyword argument ``wire_map`` to set this enumeration.
 
     >>> wire_map = {Wires('a'): 0, Wires('b'): 1, Wires('c'): 2}
     >>> pauli_to_binary(qml.PauliX('a') @ qml.PauliY('b') @ qml.PauliZ('c'), wire_map=wire_map)
@@ -160,7 +160,7 @@ def pauli_to_binary(pauli_word, n_qubits=None, wire_map=None):
     components are consistently mapped from the wire labels, rather than enumerated
     left-to-right.
 
-    If `n_qubits` is unspecified, the dimensionality of the vector representation will be inferred
+    If ``n_qubits`` is unspecified, the dimensionality of the vector representation will be inferred
     from the size of support of the Pauli word,
 
     >>> pauli_to_binary(qml.PauliX(0) @ qml.PauliX(1))
@@ -168,7 +168,7 @@ def pauli_to_binary(pauli_word, n_qubits=None, wire_map=None):
     >>> pauli_to_binary(qml.PauliX(0) @ qml.PauliX(5))
     array([1., 1., 0., 0.])
 
-    Dimensionality higher than twice the support can be specified by `n_qubits`,
+    Dimensionality higher than twice the support can be specified by ``n_qubits``,
 
     >>> pauli_to_binary(qml.PauliX(0) @ qml.PauliX(1), n_qubits=6)
     array([1., 1., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.])
@@ -176,7 +176,7 @@ def pauli_to_binary(pauli_word, n_qubits=None, wire_map=None):
     array([1., 1., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.])
 
     For these Pauli words to have a consistent mapping to vector representation, we once again
-    need to specify a `wire_map`.
+    need to specify a ``wire_map``.
 
     >>> wire_map = {Wires(0):0, Wires(1):1, Wires(5):5}
     >>> pauli_to_binary(qml.PauliX(0) @ qml.PauliX(1), n_qubits=6, wire_map=wire_map)
@@ -184,8 +184,8 @@ def pauli_to_binary(pauli_word, n_qubits=None, wire_map=None):
     >>> pauli_to_binary(qml.PauliX(0) @ qml.PauliX(5), n_qubits=6, wire_map=wire_map)
     array([1., 0., 0., 0., 0., 1., 0., 0., 0., 0., 0., 0.])
 
-    Note that if `n_qubits` is unspecified and `wire_map` is specified, the dimensionality of the
-    vector representation will be inferred from the highest integer in `wire_map.values()`.
+    Note that if ``n_qubits`` is unspecified and ``wire_map`` is specified, the dimensionality of the
+    vector representation will be inferred from the highest integer in ``wire_map.values()``.
 
     >>> wire_map = {Wires(0):0, Wires(1):1, Wires(5):5}
     >>> pauli_to_binary(qml.PauliX(0) @ qml.PauliX(5),  wire_map=wire_map)
@@ -253,7 +253,7 @@ def binary_to_pauli(binary_vector, wire_map=None):  # pylint: disable=too-many-b
     Returns:
         Tensor(Union[Identity, PauliX, PauliY, PauliZ]): The Pauli word corresponding to the input
         binary vector. Note that if a zero vector is input, then the resulting Pauli word will
-        be an `Identity` instance.
+        be an ``Identity`` instance.
 
     Raises:
         TypeError: if length of binary vector is not even, or if vector does not have strictly
@@ -261,20 +261,20 @@ def binary_to_pauli(binary_vector, wire_map=None):  # pylint: disable=too-many-b
 
     **Example**
 
-    If `wire_map` is unspecified, the Pauli operations follow the same enumerations as the vector
-    components, i.e., the `i` and `N+i` components specify the Pauli operation on wire `i`,
+    If ``wire_map`` is unspecified, the Pauli operations follow the same enumerations as the vector
+    components, i.e., the ``i`` and ``N+i`` components specify the Pauli operation on wire ``i``,
 
     >>> binary_to_pauli([0,1,1,0,1,0])
     Tensor(PauliY(wires=[1]), PauliX(wires=[2]))
 
-    An arbitrary labelling can be assigned by using `wire_map`
+    An arbitrary labelling can be assigned by using ``wire_map``
     >>> wire_map = {Wires('a'): 0, Wires('b'): 1, Wires('c'): 2}
     >>> binary_to_pauli([0,1,1,0,1,0], wire_map=wire_map)
     Tensor(PauliY(wires=['b']), PauliX(wires=['c']))
 
-    Note that the values of `wire_map`, if specified, must be 0,1,..., N, where N is the dimension
-    of the vector divided by two, i.e., `list(wire_map.values())` must be
-    `list(range(len(binary_vector)/2))`.
+    Note that the values of ``wire_map``, if specified, must be 0,1,..., N, where N is the dimension
+    of the vector divided by two, i.e., ``list(wire_map.values())`` must be
+    ``list(range(len(binary_vector)/2))``.
     """
 
     if isinstance(binary_vector, (list, tuple)):

--- a/pennylane/grouping/utils.py
+++ b/pennylane/grouping/utils.py
@@ -125,7 +125,7 @@ def pauli_to_binary(pauli_word, n_qubits=None, wire_map=None):
              unique integer labels as their values
 
     Returns:
-        array: the 2*n_qubits dimensional binary vector representation of the input Pauli word.
+        array: the ``2*n_qubits`` dimensional binary vector representation of the input Pauli word.
 
     Raises:
         TypeError: if the input ``pauli_word`` is not an instance of Identity, PauliX, PauliY,
@@ -343,7 +343,7 @@ def is_qwc(pauli_vec_1, pauli_vec_2):
 
     Raises:
         ValueError: if the input vectors are of different dimension, if the vectors are not of even
-        dimension, or if the vector components are not strictly binary
+            dimension, or if the vector components are not strictly binary
 
     **Example**
 
@@ -411,7 +411,7 @@ def is_qwc(pauli_vec_1, pauli_vec_2):
 
 def observables_to_binary_matrix(observables, n_qubits=None, wire_map=None):
     """Converts a list of Pauli words to the binary vector representation and yields a row matrix
-        of the binary vectors.
+    of the binary vectors.
 
     The dimension of the binary vectors will be implied from the highest wire being acted on
     non-trivially by the Pauli words in observables.

--- a/pennylane/grouping/utils.py
+++ b/pennylane/grouping/utils.py
@@ -119,8 +119,6 @@ def pauli_to_binary(pauli_word, n_qubits=None, wire_map=None):
     Args:
         pauli_word (Union[Identity, PauliX, PauliY, PauliZ, Tensor]): the Pauli word to be
             converted to binary vector representation
-
-    Keyword args:
         n_qubits (int): number of qubits to specify dimension of binary vector representation
         wire_map (dict): dictionary containing all wire labels used in the Pauli word as keys, and
                          unique integer labels as their values
@@ -245,8 +243,6 @@ def binary_to_pauli(binary_vector, wire_map=None):  # pylint: disable=too-many-b
     Args:
         binary_vector (Union[list, tuple, array]): binary vector of even dimension representing a
             unique Pauli word
-
-    Keyword args:
         wire_map (dict): dictionary containing all wire labels used in the Pauli word as keys, and
             unique integer labels as their values
 
@@ -421,8 +417,6 @@ def observables_to_binary_matrix(observables, n_qubits=None, wire_map=None):
     Args:
         observables (list[Union[Identity, PauliX, PauliY, PauliZ, Tensor]]): the list of Pauli
             words
-
-    Keyword args:
         n_qubits (int): number of qubits to specify dimension of binary vector representation
         wire_map (dict): dictionary containing all wire labels used in the Pauli words as keys, and
             unique integer labels as their values

--- a/tests/grouping/test_graph_colouring.py
+++ b/tests/grouping/test_graph_colouring.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Unit tests for heuristic Pauli graph colouring functions in `grouping/graph_colouring.py`.
+Unit tests for heuristic Pauli graph colouring functions in ``grouping/graph_colouring.py``.
 """
 import pytest
 import numpy as np

--- a/tests/grouping/test_group_observables.py
+++ b/tests/grouping/test_group_observables.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Unit tests for `PauliGroupingStrategy` and `group_observables` in `grouping/group_observables.py`.
+Unit tests for ``PauliGroupingStrategy`` and ``group_observables`` in ``grouping/group_observables.py``.
 """
 import pytest
 import numpy as np
@@ -218,7 +218,7 @@ anticommuting_sols = [
 
 class TestGroupObservables:
     """
-    Tests for `group_observables` function using QWC, commuting, and anticommuting partitioning.
+    Tests for ``group_observables`` function using QWC, commuting, and anticommuting partitioning.
     """
 
     qwc_tuples = [(obs, qwc_sols[i]) for i, obs in enumerate(observables_list)]
@@ -282,7 +282,7 @@ class TestGroupObservables:
                 assert are_identical_pauli_words(pauli, anticom_partitions_sol[i][j])
 
     def test_group_observables_exception(self):
-        """Tests that the `group_observables` function raises an exception if
+        """Tests that the ``group_observables`` function raises an exception if
         the lengths of coefficients and observables do not agree."""
         observables = [Identity(0), PauliX(1)]
         coefficients = [0.5]
@@ -290,7 +290,7 @@ class TestGroupObservables:
             group_observables(observables, coefficients)
 
     def test_obtain_binary_repr_custom_wire_map(self):
-        """Tests that the `obtain_binary_repr` method sets a custom
+        """Tests that the ``obtain_binary_repr`` method sets a custom
          wire map correctly."""
 
         observables = [Identity("alice"), Identity("bob"), Identity("charlie")]

--- a/tests/grouping/test_grouping_utils.py
+++ b/tests/grouping/test_grouping_utils.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Unit tests for the :mod:`grouping` utility functions in `grouping/utils.py`.
+Unit tests for the :mod:`grouping` utility functions in ``grouping/utils.py``.
 """
 import pytest
 import numpy as np
@@ -51,7 +51,7 @@ class TestGroupingUtils:
     @pytest.mark.parametrize("op,vec", ops_to_vecs_explicit_wires)
     def test_pauli_to_binary_no_wire_map(self, op, vec):
         """Test conversion of Pauli word from operator to binary vector representation when no
-        `wire_map` is specified."""
+        ``wire_map`` is specified."""
 
         assert (pauli_to_binary(op) == vec).all()
 
@@ -65,7 +65,7 @@ class TestGroupingUtils:
     @pytest.mark.parametrize("op,vec", ops_to_vecs_abstract_wires)
     def test_pauli_to_binary_with_wire_map(self, op, vec):
         """Test conversion of Pauli word from operator to binary vector representation if a
-        `wire_map` is specified."""
+        ``wire_map`` is specified."""
 
         wire_map = {Wires("a"): 0, Wires("b"): 1, Wires("c"): 2, Wires(6): 3}
 
@@ -97,7 +97,7 @@ class TestGroupingUtils:
     @pytest.mark.parametrize("vec,op", vecs_to_ops_explicit_wires)
     def test_binary_to_pauli_no_wire_map(self, vec, op):
         """Test conversion of Pauli in binary vector representation to operator form when no
-        `wire_map` is specified."""
+        ``wire_map`` is specified."""
 
         assert are_identical_pauli_words(binary_to_pauli(vec), op)
 
@@ -111,7 +111,7 @@ class TestGroupingUtils:
     @pytest.mark.parametrize("vec,op", vecs_to_ops_abstract_wires)
     def test_binary_to_pauli_with_wire_map(self, vec, op):
         """Test conversion of Pauli in binary vector representation to operator form when
-        `wire_map` is specified."""
+        ``wire_map`` is specified."""
 
         wire_map = {Wires("alice"): 0, Wires("bob"): 1, Wires("ancilla"): 2}
 
@@ -209,7 +209,7 @@ class TestGroupingUtils:
         assert pytest.raises(ValueError, is_qwc, pauli_vec_1, pauli_vec_2)
 
     def test_is_pauli_word(self):
-        """Test for determining whether input `Observable` instance is a Pauli word."""
+        """Test for determining whether input ``Observable`` instance is a Pauli word."""
 
         observable_1 = PauliX(0)
         observable_2 = PauliZ(1) @ PauliX(2) @ PauliZ(4)
@@ -222,7 +222,7 @@ class TestGroupingUtils:
         assert not is_pauli_word(observable_4)
 
     def test_are_identical_pauli_words(self):
-        """Tests for determining if two Pauli words have the same `wires` and `name` attributes."""
+        """Tests for determining if two Pauli words have the same ``wires`` and ``name`` attributes."""
 
         pauli_word_1 = PauliX(0) @ PauliY(1)
         pauli_word_2 = PauliY(1) @ PauliX(0)
@@ -252,7 +252,7 @@ class TestGroupingUtils:
             are_identical_pauli_words(non_pauli_word, non_pauli_word)
 
     def test_qwc_complement_adj_matrix(self):
-        """Tests that the `qwc_complement_adj_matrix` function returns the correct
+        """Tests that the ``qwc_complement_adj_matrix`` function returns the correct
         adjacency matrix."""
         binary_observables = np.array([[1., 0., 1., 0., 0., 1.],
                                        [0., 1., 1., 1., 0., 1.],
@@ -274,7 +274,7 @@ class TestGroupingUtils:
         assert np.all(adj == expected)
 
     def test_qwc_complement_adj_matrix_exception(self):
-        """Tests that the `qwc_complement_adj_matrix` function raises an exception if
+        """Tests that the ``qwc_complement_adj_matrix`` function raises an exception if
         the matrix is not binary."""
         not_binary_observables = np.array([[1.1, 0.5, 1., 0., 0., 1.],
                                            [0., 1.3, 1., 1., 0., 1.],

--- a/tests/grouping/test_optimize_measurements.py
+++ b/tests/grouping/test_optimize_measurements.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Unit tests for `optimize_measurements` function in `grouping/optimize_measurements.py`.
+Unit tests for ``optimize_measurements`` function in ``grouping/optimize_measurements.py``.
 """
 import pytest
 from pennylane import Identity, PauliX, PauliY, PauliZ
@@ -21,7 +21,7 @@ from pennylane.grouping.optimize_measurements import optimize_measurements
 
 
 class TestOptimizeMeasurements:
-    """Tests for the `optimize_measurements` function."""
+    """Tests for the ``optimize_measurements`` function."""
 
     observables_diagonalized = [
         (
@@ -112,7 +112,7 @@ class TestOptimizeMeasurements:
         )
 
     def test_optimize_measurements_not_implemented_catch(self):
-        """Tests that NotImplementedError is raised for methods other than 'qwc'."""
+        """Tests that NotImplementedError is raised for methods other than ``'qwc'``."""
 
         observables = [PauliY(0), PauliX(0) @ PauliX(1), PauliZ(1)]
         grouping = "anticommuting"


### PR DESCRIPTION
This PR contains minor adjustments to standardize the docstrings of the `grouping` subpackage. It mostly addresses formatting and standardization, without substantial content being added (hence separated from #850).

The changes include:

* Placed the `Example` section at the end of each docstring
* Renamed section headers `**Usage example:**`and `**Example usage:**` to `**Example**`
* Shortened variable names in some examples
* Updated the indentation for `Returns` section, removed names of returned objects, updated `tuple` return type docs
* Removed line break at the end of the docstrings
* Adjusted `Raises` in one case

The following is the way a `tuple` return type was documented:
```rst
tuple:
    
    * some_type1: some description or returned obj1
    * some_type2: some description or returned obj2
```
This renders as follows:
<a href=""><img src="https://user-images.githubusercontent.com/24476053/96199320-34dc6e00-0f25-11eb-96f7-8f388179ec5d.png" align="left" height="180" width="650" ></a>