### PR TITLE
add execution property to Device class for tracking the number of device executions over a QNodes lifetime

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -11,6 +11,23 @@
 
 <h3>Improvements</h3>
 
+* The number of device executions over a QNode's lifetime can now be returned using `num_executions`.
+  [(#853)](https://github.com/PennyLaneAI/pennylane/pull/853)
+
+  ```pycon
+  >>> dev = qml.device("default.qubit", wires=2)
+  >>> @qml.qnode(dev)
+  ... def circuit(x, y):
+  ...    qml.RX(x, wires=[0])
+  ...    qml.RY(y, wires=[1])
+  ...    qml.CNOT(wires=[0, 1])
+  ...    return qml.expval(qml.PauliZ(0) @ qml.PauliX(1))
+  >>> for _ in range(10):
+  ...    circuit(0.432, 0.12)
+  >>> print(dev.num_executions)
+  10
+  ```
+
 * The gradient methods in tape mode now fully separate the quantum and classical processing.Rather
   than returning the evaluated gradients directly, they now return a tuple containing the required
   quantum and classical processing steps.

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -98,7 +98,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-Thomas Bromley, Josh Izaac, Nathan Killoran, Maria Schuld
+Thomas Bromley, Anthony Hayes, Josh Izaac, Nathan Killoran, Maria Schuld
 
 # Release 0.12.0 (current release)
 

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -72,9 +72,11 @@ class Device(abc.ABC):
         self._wires = Wires(wires)
         self.num_wires = len(self._wires)
         self._wire_map = self.define_wire_map(self._wires)
+        self._execution = 0
         self._op_queue = None
         self._obs_queue = None
         self._parameters = None
+
 
     def __repr__(self):
         """String representation."""
@@ -153,6 +155,12 @@ class Device(abc.ABC):
         """Ordered dictionary that defines the map from user-provided wire labels to
         the wire labels used on this device"""
         return self._wire_map
+
+    @property
+    def execution(self):
+        """Number of times this device is executed by the evaluation of QNodes
+         running on this device"""
+        return self._execution
 
     @shots.setter
     def shots(self, shots):

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -324,6 +324,9 @@ class Device(abc.ABC):
             self._obs_queue = None
             self._parameters = None
 
+            # increment counter for number of executions of device
+            self._num_executions += 1
+
             # Ensures that a combination with sample does not put
             # expvals and vars in superfluous arrays
             if all(obs.return_type is Sample for obs in observables):

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -72,11 +72,10 @@ class Device(abc.ABC):
         self._wires = Wires(wires)
         self.num_wires = len(self._wires)
         self._wire_map = self.define_wire_map(self._wires)
-        self._execution = 0
+        self._num_executions = 0
         self._op_queue = None
         self._obs_queue = None
         self._parameters = None
-
 
     def __repr__(self):
         """String representation."""
@@ -157,10 +156,14 @@ class Device(abc.ABC):
         return self._wire_map
 
     @property
-    def execution(self):
+    def num_executions(self):
         """Number of times this device is executed by the evaluation of QNodes
-         running on this device"""
-        return self._execution
+        running on this device
+
+        Returns:
+            int: number of executions
+        """
+        return self._num_executions
 
     @shots.setter
     def shots(self, shots):
@@ -216,12 +219,12 @@ class Device(abc.ABC):
         """
         try:
             mapped_wires = wires.map(self.wire_map)
-        except WireError:
+        except WireError as e:
             raise WireError(
                 "Did not find some of the wires {} on device with wires {}.".format(
                     wires, self.wires
                 )
-            )
+            ) from e
 
         return mapped_wires
 

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -181,6 +181,9 @@ class QubitDevice(Device):
         if circuit.is_sampled and not all_sampled:
             return self._asarray(results, dtype="object")
 
+        # increment counter for number of executions of qubit device
+        self._num_executions += 1
+
         return self._asarray(results)
 
     def batch_execute(self, circuits):

--- a/pennylane/qnodes/base.py
+++ b/pennylane/qnodes/base.py
@@ -831,6 +831,9 @@ class BaseQNode(qml.QueuingContext):
                 self.variable_deps,
                 return_native_type=temp,
             )
+
+        self.device._execution += 1
+
         return self.output_conversion(ret)
 
     def evaluate_obs(self, obs, args, kwargs):

--- a/pennylane/qnodes/base.py
+++ b/pennylane/qnodes/base.py
@@ -123,10 +123,10 @@ def decompose_queue(ops, device):
     for op in ops:
         try:
             new_ops.extend(_decompose_queue([op], device))
-        except NotImplementedError:
+        except NotImplementedError as e:
             raise qml.DeviceError(
                 "Gate {} not supported on device {}".format(op.name, device.short_name)
-            )
+            ) from e
 
     return new_ops
 
@@ -832,7 +832,7 @@ class BaseQNode(qml.QueuingContext):
                 return_native_type=temp,
             )
 
-        self.device._execution += 1
+        self.device._num_executions += 1
 
         return self.output_conversion(ret)
 

--- a/pennylane/qnodes/base.py
+++ b/pennylane/qnodes/base.py
@@ -832,8 +832,6 @@ class BaseQNode(qml.QueuingContext):
                 return_native_type=temp,
             )
 
-        self.device._num_executions += 1
-
         return self.output_conversion(ret)
 
     def evaluate_obs(self, obs, args, kwargs):

--- a/tests/qnodes/test_qnode_base.py
+++ b/tests/qnodes/test_qnode_base.py
@@ -1035,7 +1035,7 @@ class TestQNodeEvaluate:
 
         for _ in range(num_evals_1):
             node_1(0.432, 0.12)
-        assert dev_1.execution ==  num_evals_1
+        assert dev_1.num_executions ==  num_evals_1
 
         # test a second instance of a default qubit device
         dev_2 = qml.device("default.qubit", wires=2)
@@ -1050,7 +1050,7 @@ class TestQNodeEvaluate:
 
         for _ in range(num_evals_2):
             node_2(0.432, 0.12)
-        assert dev_2.execution ==  num_evals_2
+        assert dev_2.num_executions ==  num_evals_2
 
         # test a new circuit on an existing instance of a qubit device
         def circuit_3(x, y):
@@ -1063,7 +1063,7 @@ class TestQNodeEvaluate:
 
         for _ in range(num_evals_3):
             node_3(0.432, 0.12)
-        assert dev_1.execution == num_evals_1 + num_evals_3
+        assert dev_1.num_executions == num_evals_1 + num_evals_3
 
         # test default Gaussian device
         dev_gauss = qml.device("default.gaussian", wires=1)
@@ -1078,7 +1078,7 @@ class TestQNodeEvaluate:
 
         for i in range(num_evals_gauss):
             node_gauss(0.015, 0.02, 0.005)
-        assert dev_gauss.execution == num_evals_gauss
+        assert dev_gauss.num_executions == num_evals_gauss
 
 
 class TestDecomposition:

--- a/tests/qnodes/test_qnode_base.py
+++ b/tests/qnodes/test_qnode_base.py
@@ -1020,7 +1020,7 @@ class TestQNodeEvaluate:
 
     def test_device_executions(self):
         """Test the number of times a QNode running on the device is evaluated
-        is equal to the number of times a the device is executed"""
+        is equal to the number of times the device is executed"""
 
         dev_1 = qml.device("default.qubit", wires=2)
 

--- a/tests/qnodes/test_qnode_base.py
+++ b/tests/qnodes/test_qnode_base.py
@@ -1018,68 +1018,6 @@ class TestQNodeEvaluate:
         res = node(0.432, 0.12)
         assert res.shape == (10,)
 
-    def test_device_executions(self):
-        """Test the number of times a QNode running on the device is evaluated
-        is equal to the number of times the device is executed"""
-
-        dev_1 = qml.device("default.qubit", wires=2)
-
-        def circuit_1(x, y):
-            qml.RX(x, wires=[0])
-            qml.RY(y, wires=[1])
-            qml.CNOT(wires=[0, 1])
-            return qml.expval(qml.PauliZ(0) @ qml.PauliX(1))
-
-        node_1 = BaseQNode(circuit_1, dev_1)
-        num_evals_1 = 10
-
-        for _ in range(num_evals_1):
-            node_1(0.432, 0.12)
-        assert dev_1.num_executions ==  num_evals_1
-
-        # test a second instance of a default qubit device
-        dev_2 = qml.device("default.qubit", wires=2)
-
-        def circuit_2(x, y):
-            qml.RX(x, wires=[0])
-            qml.CNOT(wires=[0, 1])
-            return qml.expval(qml.PauliZ(0) @ qml.PauliX(1))
-
-        node_2 = BaseQNode(circuit_2, dev_2)
-        num_evals_2 = 5
-
-        for _ in range(num_evals_2):
-            node_2(0.432, 0.12)
-        assert dev_2.num_executions ==  num_evals_2
-
-        # test a new circuit on an existing instance of a qubit device
-        def circuit_3(x, y):
-            qml.RY(y, wires=[1])
-            qml.CNOT(wires=[0, 1])
-            return qml.expval(qml.PauliZ(0) @ qml.PauliX(1))
-
-        node_3 = BaseQNode(circuit_3, dev_1)
-        num_evals_3 = 7
-
-        for _ in range(num_evals_3):
-            node_3(0.432, 0.12)
-        assert dev_1.num_executions == num_evals_1 + num_evals_3
-
-        # test default Gaussian device
-        dev_gauss = qml.device("default.gaussian", wires=1)
-
-        def circuit_gauss(mag_alpha, phase_alpha, phi):
-            qml.Displacement(mag_alpha, phase_alpha, wires=0)
-            qml.Rotation(phi, wires=0)
-            return qml.expval(qml.NumberOperator(0))
-
-        node_gauss = BaseQNode(circuit_gauss, dev_gauss)
-        num_evals_gauss = 12
-
-        for i in range(num_evals_gauss):
-            node_gauss(0.015, 0.02, 0.005)
-        assert dev_gauss.num_executions == num_evals_gauss
-
 
 class TestDecomposition:
     """Test for queue decomposition"""

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -19,7 +19,8 @@ import pytest
 import numpy as np
 import pennylane as qml
 from pennylane import Device, DeviceError
-from pennylane.qnodes import QuantumFunctionError
+from pennylane.qnodes import QuantumFunctionError 
+from pennylane.qnodes.base import BaseQNode
 from pennylane.wires import Wires
 from collections import OrderedDict
 
@@ -430,6 +431,25 @@ class TestInternalFunctions:
         dev = mock_device()
         expected = 0
         assert dev.num_executions == expected
+
+    def test_device_executions(self):
+        """Test the number of times a device is executed over a QNode's
+        lifetime is tracked by `num_executions`"""
+
+        # test default Gaussian device
+        dev_gauss = qml.device("default.gaussian", wires=1)
+
+        def circuit_gauss(mag_alpha, phase_alpha, phi):
+            qml.Displacement(mag_alpha, phase_alpha, wires=0)
+            qml.Rotation(phi, wires=0)
+            return qml.expval(qml.NumberOperator(0))
+
+        node_gauss = BaseQNode(circuit_gauss, dev_gauss)
+        num_evals_gauss = 12
+
+        for i in range(num_evals_gauss):
+            node_gauss(0.015, 0.02, 0.005)
+        assert dev_gauss.num_executions == num_evals_gauss
 
 
 class TestClassmethods:

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -428,7 +428,7 @@ class TestInternalFunctions:
         """Tests that the number of executions is initialised correctly"""
         dev = mock_device()
         expected = 0
-        assert dev.execution == expected
+        assert dev.num_executions == expected
 
 
 class TestClassmethods:

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -424,6 +424,12 @@ class TestInternalFunctions:
                                 (Wires(-1), Wires(2)), (Wires(3), Wires(3))])
         assert dev.wire_map == expected
 
+    def test_execution_property(self, mock_device):
+        """Tests that the number of executions is initialised correctly"""
+        dev = mock_device()
+        expected = 0
+        assert dev.execution == expected
+
 
 class TestClassmethods:
     """Test the classmethods of Device"""

--- a/tests/test_qubit_device.py
+++ b/tests/test_qubit_device.py
@@ -21,6 +21,7 @@ from random import random
 import pennylane as qml
 from pennylane import QubitDevice, DeviceError
 from pennylane.qnodes import QuantumFunctionError
+from pennylane.qnodes.base import BaseQNode
 from pennylane.operation import Sample, Variance, Expectation, Probability, State
 from pennylane.circuit_graph import CircuitGraph
 from pennylane.variable import Variable
@@ -710,6 +711,57 @@ class TestCapabilities:
                         "returns_probs": True,
                         }
         assert capabilities == QubitDevice.capabilities()
+
+
+class TestExecution:
+    """Tests for the execute method"""
+
+    def test_device_executions(self):
+        """Test the number of times a qubit device is executed over a QNode's
+        lifetime is tracked by `num_executions`"""
+
+        dev_1 = qml.device("default.qubit", wires=2)
+
+        def circuit_1(x, y):
+            qml.RX(x, wires=[0])
+            qml.RY(y, wires=[1])
+            qml.CNOT(wires=[0, 1])
+            return qml.expval(qml.PauliZ(0) @ qml.PauliX(1))
+
+        node_1 = BaseQNode(circuit_1, dev_1)
+        num_evals_1 = 10
+
+        for _ in range(num_evals_1):
+            node_1(0.432, 0.12)
+        assert dev_1.num_executions ==  num_evals_1
+
+        # test a second instance of a default qubit device
+        dev_2 = qml.device("default.qubit", wires=2)
+
+        def circuit_2(x, y):
+            qml.RX(x, wires=[0])
+            qml.CNOT(wires=[0, 1])
+            return qml.expval(qml.PauliZ(0) @ qml.PauliX(1))
+
+        node_2 = BaseQNode(circuit_2, dev_2)
+        num_evals_2 = 5
+
+        for _ in range(num_evals_2):
+            node_2(0.432, 0.12)
+        assert dev_2.num_executions ==  num_evals_2
+
+        # test a new circuit on an existing instance of a qubit device
+        def circuit_3(x, y):
+            qml.RY(y, wires=[1])
+            qml.CNOT(wires=[0, 1])
+            return qml.expval(qml.PauliZ(0) @ qml.PauliX(1))
+
+        node_3 = BaseQNode(circuit_3, dev_1)
+        num_evals_3 = 7
+
+        for _ in range(num_evals_3):
+            node_3(0.432, 0.12)
+        assert dev_1.num_executions == num_evals_1 + num_evals_3
 
 
 class TestBatchExecution:


### PR DESCRIPTION
In response to Issue [847](https://github.com/PennyLaneAI/pennylane/issues/847), during optimization the number of device executions per iteration step can vary based upon factors such as the choice of optimizer and the choice of differentiation method.

An execution property has been added to the `Device` class. This allows executions of all default devices to be tracked.  

This enables easy access to the number of times a device has been executed and facilitates visualisation of this quantity.

May need updating dependent on updates to `shots`. 

(Closes https://github.com/PennyLaneAI/pennylane/issues/847)
