### PR TITLE
Adds handling of single-qubit Paulis and all-identity Pauli to PauliRot operation. 

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -77,8 +77,8 @@
 
 <h3>Bug fixes</h3>
 
-* The `PauliRot` operation now gracefully handles single-qubit Paulis, and
-	all-identity Paulis [(#860)](https://github.com/PennyLaneAI/pennylane/pull/860).
+* The `PauliRot` operation now gracefully handles single-qubit Paulis, and all-identity Paulis
+  [(#860)](https://github.com/PennyLaneAI/pennylane/pull/860).
 
 <h3>Contributors</h3>
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -77,11 +77,14 @@
 
 <h3>Bug fixes</h3>
 
+* The `PauliRot` operation now gracefully handles single-qubit Paulis, and
+	all-identity Paulis.
+
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):
 
-Thomas Bromley, Josh Izaac, Nathan Killoran, Maria Schuld
+Thomas Bromley, Olivia Di Matteo, Josh Izaac, Nathan Killoran, Maria Schuld
 
 # Release 0.12.0 (current release)
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -78,7 +78,7 @@
 <h3>Bug fixes</h3>
 
 * The `PauliRot` operation now gracefully handles single-qubit Paulis, and
-	all-identity Paulis.
+	all-identity Paulis [(#860)](https://github.com/PennyLaneAI/pennylane/pull/860).
 
 <h3>Contributors</h3>
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,7 +6,7 @@ ignore:
 
 codecov:
   notify:
-    after_n_builds: 6
+    after_n_builds: 7
 
 comment:
-  after_n_builds: 6
+  after_n_builds: 7

--- a/pennylane/ops/qubit.py
+++ b/pennylane/ops/qubit.py
@@ -930,6 +930,10 @@ class PauliRot(Operation):
     @staticmethod
     @template
     def decomposition(theta, pauli_word, wires):
+        # Catch cases when the wire is passed as a single int.
+        if isinstance(wires, int):
+            wires = [wires]
+
         # Check for identity and do nothing
         if pauli_word == "I" * len(wires):
             return

--- a/pennylane/ops/qubit.py
+++ b/pennylane/ops/qubit.py
@@ -868,7 +868,7 @@ class PauliRot(Operation):
             )
 
         num_wires = 1 if isinstance(wires, int) else len(wires)
-        
+
         if not len(pauli_word) == num_wires:
             raise ValueError(
                 "The given Pauli word has length {}, length {} was expected for wires {}".format(
@@ -902,7 +902,7 @@ class PauliRot(Operation):
         # Simplest case is if the Pauli is the identity matrix
         if pauli_word == 'I' * len(pauli_word):
             return np.exp(-1j * theta / 2) * np.eye(2 ** len(pauli_word))
-        
+
         # We first generate the matrix excluding the identity parts and expand it afterwards.
         # To this end, we have to store on which wires the non-identity parts act
         non_identity_wires, non_identity_gates = zip(
@@ -930,6 +930,10 @@ class PauliRot(Operation):
     @staticmethod
     @template
     def decomposition(theta, pauli_word, wires):
+        # Check for identity and do nothing
+        if pauli_word == 'I' * len(wires):
+            return
+
         active_wires, active_gates = zip(
             *[(wire, gate) for wire, gate in zip(wires, pauli_word) if gate != "I"]
         )

--- a/pennylane/ops/qubit.py
+++ b/pennylane/ops/qubit.py
@@ -867,10 +867,12 @@ class PauliRot(Operation):
                 " Allowed characters are I, X, Y and Z".format(pauli_word)
             )
 
-        if not len(pauli_word) == len(wires):
+        num_wires = 1 if isinstance(wires, int) else len(wires)
+        
+        if not len(pauli_word) == num_wires:
             raise ValueError(
                 "The given Pauli word has length {}, length {} was expected for wires {}".format(
-                    len(pauli_word), len(wires), wires
+                    len(pauli_word), num_wires, wires
                 )
             )
 

--- a/pennylane/ops/qubit.py
+++ b/pennylane/ops/qubit.py
@@ -1647,11 +1647,7 @@ class Hermitian(Observable):
         Returns:
             list: list containing the gates diagonalizing the Hermitian observable
         """
-        return [
-            QubitUnitary(
-                self.eigendecomposition["eigvec"].conj().T, wires=list(self.wires)
-            )
-        ]
+        return [QubitUnitary(self.eigendecomposition["eigvec"].conj().T, wires=list(self.wires))]
 
 
 ops = {

--- a/pennylane/ops/qubit.py
+++ b/pennylane/ops/qubit.py
@@ -925,6 +925,10 @@ class PauliRot(Operation):
 
     @classmethod
     def _eigvals(cls, theta, pauli_word):
+        # Identity must be treated specially because its eigenvalues are all the same
+        if pauli_word == "I" * len(pauli_word):
+            return np.exp(-1j * theta / 2) * np.ones(2 ** len(pauli_word))
+
         return MultiRZ._eigvals(theta, len(pauli_word))
 
     @staticmethod

--- a/pennylane/ops/qubit.py
+++ b/pennylane/ops/qubit.py
@@ -23,7 +23,10 @@ import numpy as np
 
 from pennylane.templates import template
 from pennylane.operation import AnyWires, Observable, Operation, DiagonalOperation
-from pennylane.templates.state_preparations import BasisStatePreparation, MottonenStatePreparation
+from pennylane.templates.state_preparations import (
+    BasisStatePreparation,
+    MottonenStatePreparation,
+)
 from pennylane.utils import pauli_eigs, expand
 from pennylane._queuing import OperationRecorder
 
@@ -178,7 +181,11 @@ class PauliY(Observable, Operation):
             list(~.Operation): A list of gates that diagonalize PauliY in the
                 computational basis.
         """
-        return [PauliZ(wires=self.wires), S(wires=self.wires), Hadamard(wires=self.wires)]
+        return [
+            PauliZ(wires=self.wires),
+            S(wires=self.wires),
+            Hadamard(wires=self.wires),
+        ]
 
     @staticmethod
     def decomposition(wires):
@@ -725,14 +732,24 @@ class Rot(Operation):
 
         return np.array(
             [
-                [cmath.exp(-0.5j * (phi + omega)) * c, -cmath.exp(0.5j * (phi - omega)) * s],
-                [cmath.exp(-0.5j * (phi - omega)) * s, cmath.exp(0.5j * (phi + omega)) * c],
+                [
+                    cmath.exp(-0.5j * (phi + omega)) * c,
+                    -cmath.exp(0.5j * (phi - omega)) * s,
+                ],
+                [
+                    cmath.exp(-0.5j * (phi - omega)) * s,
+                    cmath.exp(0.5j * (phi + omega)) * c,
+                ],
             ]
         )
 
     @staticmethod
     def decomposition(phi, theta, omega, wires):
-        decomp_ops = [RZ(phi, wires=wires), RY(theta, wires=wires), RZ(omega, wires=wires)]
+        decomp_ops = [
+            RZ(phi, wires=wires),
+            RY(theta, wires=wires),
+            RZ(omega, wires=wires),
+        ]
         return decomp_ops
 
 
@@ -900,7 +917,7 @@ class PauliRot(Operation):
             )
 
         # Simplest case is if the Pauli is the identity matrix
-        if pauli_word == 'I' * len(pauli_word):
+        if pauli_word == "I" * len(pauli_word):
             return np.exp(-1j * theta / 2) * np.eye(2 ** len(pauli_word))
 
         # We first generate the matrix excluding the identity parts and expand it afterwards.
@@ -931,7 +948,7 @@ class PauliRot(Operation):
     @template
     def decomposition(theta, pauli_word, wires):
         # Check for identity and do nothing
-        if pauli_word == 'I' * len(wires):
+        if pauli_word == "I" * len(wires):
             return
 
         active_wires, active_gates = zip(
@@ -999,7 +1016,10 @@ class CRX(Operation):
     num_wires = 2
     par_domain = "R"
     grad_method = "A"
-    generator = [np.array([[0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]]), -1 / 2]
+    generator = [
+        np.array([[0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]]),
+        -1 / 2,
+    ]
 
     @classmethod
     def _matrix(cls, *params):
@@ -1066,7 +1086,10 @@ class CRY(Operation):
     num_wires = 2
     par_domain = "R"
     grad_method = "A"
-    generator = [np.array([[0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, -1j], [0, 0, 1j, 0]]), -1 / 2]
+    generator = [
+        np.array([[0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, -1j], [0, 0, 1j, 0]]),
+        -1 / 2,
+    ]
 
     @classmethod
     def _matrix(cls, *params):
@@ -1131,7 +1154,10 @@ class CRZ(DiagonalOperation):
     num_wires = 2
     par_domain = "R"
     grad_method = "A"
-    generator = [np.array([[0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 1, 0], [0, 0, 0, -1]]), -1 / 2]
+    generator = [
+        np.array([[0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 1, 0], [0, 0, 0, -1]]),
+        -1 / 2,
+    ]
 
     @classmethod
     def _matrix(cls, *params):
@@ -1210,8 +1236,18 @@ class CRot(Operation):
             [
                 [1, 0, 0, 0],
                 [0, 1, 0, 0],
-                [0, 0, cmath.exp(-0.5j * (phi + omega)) * c, -cmath.exp(0.5j * (phi - omega)) * s],
-                [0, 0, cmath.exp(-0.5j * (phi - omega)) * s, cmath.exp(0.5j * (phi + omega)) * c],
+                [
+                    0,
+                    0,
+                    cmath.exp(-0.5j * (phi + omega)) * c,
+                    -cmath.exp(0.5j * (phi - omega)) * s,
+                ],
+                [
+                    0,
+                    0,
+                    cmath.exp(-0.5j * (phi - omega)) * s,
+                    cmath.exp(0.5j * (phi + omega)) * c,
+                ],
             ]
         )
 
@@ -1299,7 +1335,10 @@ class U2(Operation):
     def _matrix(cls, *params):
         phi, lam = params
         return INV_SQRT2 * np.array(
-            [[1, -cmath.exp(1j * lam)], [cmath.exp(1j * phi), cmath.exp(1j * (phi + lam))]]
+            [
+                [1, -cmath.exp(1j * lam)],
+                [cmath.exp(1j * phi), cmath.exp(1j * (phi + lam))],
+            ]
         )
 
     @staticmethod
@@ -1608,7 +1647,11 @@ class Hermitian(Observable):
         Returns:
             list: list containing the gates diagonalizing the Hermitian observable
         """
-        return [QubitUnitary(self.eigendecomposition["eigvec"].conj().T, wires=list(self.wires))]
+        return [
+            QubitUnitary(
+                self.eigendecomposition["eigvec"].conj().T, wires=list(self.wires)
+            )
+        ]
 
 
 ops = {

--- a/pennylane/ops/qubit.py
+++ b/pennylane/ops/qubit.py
@@ -23,10 +23,7 @@ import numpy as np
 
 from pennylane.templates import template
 from pennylane.operation import AnyWires, Observable, Operation, DiagonalOperation
-from pennylane.templates.state_preparations import (
-    BasisStatePreparation,
-    MottonenStatePreparation,
-)
+from pennylane.templates.state_preparations import BasisStatePreparation, MottonenStatePreparation
 from pennylane.utils import pauli_eigs, expand
 from pennylane._queuing import OperationRecorder
 
@@ -181,11 +178,7 @@ class PauliY(Observable, Operation):
             list(~.Operation): A list of gates that diagonalize PauliY in the
                 computational basis.
         """
-        return [
-            PauliZ(wires=self.wires),
-            S(wires=self.wires),
-            Hadamard(wires=self.wires),
-        ]
+        return [PauliZ(wires=self.wires), S(wires=self.wires), Hadamard(wires=self.wires)]
 
     @staticmethod
     def decomposition(wires):
@@ -732,24 +725,14 @@ class Rot(Operation):
 
         return np.array(
             [
-                [
-                    cmath.exp(-0.5j * (phi + omega)) * c,
-                    -cmath.exp(0.5j * (phi - omega)) * s,
-                ],
-                [
-                    cmath.exp(-0.5j * (phi - omega)) * s,
-                    cmath.exp(0.5j * (phi + omega)) * c,
-                ],
+                [cmath.exp(-0.5j * (phi + omega)) * c, -cmath.exp(0.5j * (phi - omega)) * s],
+                [cmath.exp(-0.5j * (phi - omega)) * s, cmath.exp(0.5j * (phi + omega)) * c],
             ]
         )
 
     @staticmethod
     def decomposition(phi, theta, omega, wires):
-        decomp_ops = [
-            RZ(phi, wires=wires),
-            RY(theta, wires=wires),
-            RZ(omega, wires=wires),
-        ]
+        decomp_ops = [RZ(phi, wires=wires), RY(theta, wires=wires), RZ(omega, wires=wires)]
         return decomp_ops
 
 
@@ -1016,10 +999,7 @@ class CRX(Operation):
     num_wires = 2
     par_domain = "R"
     grad_method = "A"
-    generator = [
-        np.array([[0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]]),
-        -1 / 2,
-    ]
+    generator = [np.array([[0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]]), -1 / 2]
 
     @classmethod
     def _matrix(cls, *params):
@@ -1086,10 +1066,7 @@ class CRY(Operation):
     num_wires = 2
     par_domain = "R"
     grad_method = "A"
-    generator = [
-        np.array([[0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, -1j], [0, 0, 1j, 0]]),
-        -1 / 2,
-    ]
+    generator = [np.array([[0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, -1j], [0, 0, 1j, 0]]), -1 / 2]
 
     @classmethod
     def _matrix(cls, *params):
@@ -1154,10 +1131,7 @@ class CRZ(DiagonalOperation):
     num_wires = 2
     par_domain = "R"
     grad_method = "A"
-    generator = [
-        np.array([[0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 1, 0], [0, 0, 0, -1]]),
-        -1 / 2,
-    ]
+    generator = [np.array([[0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 1, 0], [0, 0, 0, -1]]), -1 / 2]
 
     @classmethod
     def _matrix(cls, *params):
@@ -1236,18 +1210,8 @@ class CRot(Operation):
             [
                 [1, 0, 0, 0],
                 [0, 1, 0, 0],
-                [
-                    0,
-                    0,
-                    cmath.exp(-0.5j * (phi + omega)) * c,
-                    -cmath.exp(0.5j * (phi - omega)) * s,
-                ],
-                [
-                    0,
-                    0,
-                    cmath.exp(-0.5j * (phi - omega)) * s,
-                    cmath.exp(0.5j * (phi + omega)) * c,
-                ],
+                [0, 0, cmath.exp(-0.5j * (phi + omega)) * c, -cmath.exp(0.5j * (phi - omega)) * s],
+                [0, 0, cmath.exp(-0.5j * (phi - omega)) * s, cmath.exp(0.5j * (phi + omega)) * c],
             ]
         )
 
@@ -1335,10 +1299,7 @@ class U2(Operation):
     def _matrix(cls, *params):
         phi, lam = params
         return INV_SQRT2 * np.array(
-            [
-                [1, -cmath.exp(1j * lam)],
-                [cmath.exp(1j * phi), cmath.exp(1j * (phi + lam))],
-            ]
+            [[1, -cmath.exp(1j * lam)], [cmath.exp(1j * phi), cmath.exp(1j * (phi + lam))]]
         )
 
     @staticmethod

--- a/pennylane/ops/qubit.py
+++ b/pennylane/ops/qubit.py
@@ -899,6 +899,10 @@ class PauliRot(Operation):
                 " Allowed characters are I, X, Y and Z".format(pauli_word)
             )
 
+        # Simplest case is if the Pauli is the identity matrix
+        if pauli_word == 'I' * len(pauli_word):
+            return np.exp(-1j * theta / 2) * np.eye(2 ** len(pauli_word))
+        
         # We first generate the matrix excluding the identity parts and expand it afterwards.
         # To this end, we have to store on which wires the non-identity parts act
         non_identity_wires, non_identity_gates = zip(

--- a/tests/ops/test_qubit_ops.py
+++ b/tests/ops/test_qubit_ops.py
@@ -740,6 +740,16 @@ PAULI_ROT_PARAMETRIC_MATRIX_TEST_DATA = [
 PAULI_ROT_MATRIX_TEST_DATA = [
     (
         np.pi,
+        "Z",
+        np.array(
+            [
+                [-1j, 0],
+                [0, 1j]
+            ]
+        )
+    ),
+    (
+        np.pi,
         "XIZ",
         np.array(
             [
@@ -821,6 +831,15 @@ class TestPauliRot:
         )
 
         assert np.allclose(res, expected, atol=tol, rtol=0)
+        
+    def test_PauliRot_decomposition_Identity(self):
+        """Test that decomposing the all-identity Pauli has no effect."""
+
+        theta = 0.4
+        op = qml.PauliRot(theta, "II", wires=[0, 1])
+        decomp_ops = op.decomposition(theta, "II", wires=[0, 1])
+
+        assert len(decomp_ops) == 0
 
     def test_PauliRot_decomposition_ZZ(self):
         """Test that the decomposition for a ZZ rotation is correct."""

--- a/tests/ops/test_qubit_ops.py
+++ b/tests/ops/test_qubit_ops.py
@@ -740,16 +740,6 @@ PAULI_ROT_PARAMETRIC_MATRIX_TEST_DATA = [
 PAULI_ROT_MATRIX_TEST_DATA = [
     (
         np.pi,
-        "Z",
-        np.array(
-            [
-                [-1j, 0],
-                [0, 1j]
-            ]
-        )
-    ),
-    (
-        np.pi,
         "XIZ",
         np.array(
             [

--- a/tests/ops/test_qubit_ops.py
+++ b/tests/ops/test_qubit_ops.py
@@ -821,7 +821,22 @@ class TestPauliRot:
         )
 
         assert np.allclose(res, expected, atol=tol, rtol=0)
+
+    def test_PauliRot_wire_as_int(self):
+        """Test that passing a single wire as an integer works."""
+
+        theta = 0.4
+        op = qml.PauliRot(theta, "Z", wires=0)
+        decomp_ops = op.decomposition(theta, "Z", wires=0)
+
+        assert len(decomp_ops) == 1
+
+        assert decomp_ops[0].name == "MultiRZ"
+
+        assert decomp_ops[0].wires == Wires([0])
+        assert decomp_ops[0].data[0] == theta
         
+
     def test_PauliRot_decomposition_Identity(self):
         """Test that decomposing the all-identity Pauli has no effect."""
 

--- a/tests/ops/test_qubit_ops.py
+++ b/tests/ops/test_qubit_ops.py
@@ -829,13 +829,27 @@ class TestPauliRot:
         op = qml.PauliRot(theta, "Z", wires=0)
         decomp_ops = op.decomposition(theta, "Z", wires=0)
 
+        assert np.allclose(op.eigvals, np.array([np.exp(-1j * theta / 2), np.exp(1j * theta / 2)]))
+        assert np.allclose(op.matrix, np.diag([np.exp(-1j * theta / 2), np.exp(1j * theta / 2)]))
+
         assert len(decomp_ops) == 1
 
         assert decomp_ops[0].name == "MultiRZ"
 
         assert decomp_ops[0].wires == Wires([0])
         assert decomp_ops[0].data[0] == theta
-        
+
+    def test_PauliRot_all_Identity(self):
+        """Test handling of the all-identity Pauli."""
+
+        theta = 0.4
+        op = qml.PauliRot(theta, "II", wires=[0, 1])
+        decomp_ops = op.decomposition(theta, "II", wires=[0, 1])
+
+        assert np.allclose(op.eigvals, np.exp(-1j * theta / 2) * np.ones(4))
+        assert np.allclose(op.matrix / op.matrix[0, 0], np.eye(4))
+
+        assert len(decomp_ops) == 0
 
     def test_PauliRot_decomposition_Identity(self):
         """Test that decomposing the all-identity Pauli has no effect."""


### PR DESCRIPTION
**Context:** Applying `PauliRot` with the Pauli `II...I` previously threw an error as assumptions in `_matrix` and `decomposition` methods assumed at least one non-identity Pauli. Furthermore, in debugging this, it was found that input verification in the constructor did not account for the case where `wires` was a single `int`.

**Description of the Change:** Both issues have been addressed through checks to handle the special cases.

**Benefits:** Programs no longer terminate when encountering the above issues.

**Possible Drawbacks:** None

**Related GitHub Issues:** #856
