### PR TITLE
Updating qnn.KerasLayer to work in tape mode

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -19,7 +19,7 @@
 * The `qnn.KerasLayer` class now supports differentiating the QNode through classical
   backpropagation in tape mode.
   [(#869)](https://github.com/PennyLaneAI/pennylane/pull/869)
-  
+
   ```python
   qml.enable_tape()
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -16,6 +16,33 @@
 
 <h3>Improvements</h3>
 
+* The `qnn.KerasLayer` class now supports differentiating the QNode through classical
+  backpropagation in tape mode.
+  [(#869)](https://github.com/PennyLaneAI/pennylane/pull/869)
+  
+  ```python
+  qml.enable_tape()
+
+  dev = qml.device("default.qubit.tf", wires=2)
+
+  @qml.qnode(dev, interface="tf", diff_method="backprop")
+  def f(inputs, weights):
+      qml.templates.AngleEmbedding(inputs, wires=range(2))
+      qml.templates.StronglyEntanglingLayers(weights, wires=range(2))
+      return [qml.expval(qml.PauliZ(i)) for i in range(2)]
+
+  weight_shapes = {"weights": (3, 2, 3)}
+
+  qlayer = qml.qnn.KerasLayer(f, weight_shapes, output_dim=2)
+
+  inputs = tf.constant(np.random.random((4, 2)), dtype=tf.float32)
+
+  with tf.GradientTape() as tape:
+      out = qlayer(inputs)
+
+  tape.jacobian(out, qlayer.trainable_weights)
+  ```
+
 * The number of device executions over a QNode's lifetime can now be returned using `num_executions`.
   [(#853)](https://github.com/PennyLaneAI/pennylane/pull/853)
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -92,6 +92,7 @@
 
   - QNode collections [(#863)](https://github.com/PennyLaneAI/pennylane/pull/863)
   - `VQECost` [(#863)](https://github.com/PennyLaneAI/pennylane/pull/863)
+  - `qnn.KerasLayer` [(#869)](https://github.com/PennyLaneAI/pennylane/pull/869)
 
 <h3>Breaking changes</h3>
 

--- a/pennylane/qnn/keras.py
+++ b/pennylane/qnn/keras.py
@@ -209,7 +209,9 @@ class KerasLayer(Layer):
             self.qnode = qnode
 
             dtype = tf.float32 if tf.keras.backend.floatx() == tf.float32 else tf.float64
-            self.qnode.to_tf(dtype=dtype)
+
+            if self.qnode.diff_method != "backprop":
+                self.qnode.to_tf(dtype=dtype)
         else:
             self._signature_validation(qnode, weight_shapes)
             self.qnode = to_tf(qnode, dtype=tf.keras.backend.floatx())

--- a/pennylane/qnn/keras.py
+++ b/pennylane/qnn/keras.py
@@ -207,7 +207,9 @@ class KerasLayer(Layer):
         if qml.tape_mode_active():
             self._signature_validation_tape_mode(qnode, weight_shapes)
             self.qnode = qnode
-            self.qnode.to_tf(dtype=tf.float32)
+
+            dtype = tf.float32 if tf.keras.backend.floatx() == tf.float32 else tf.float64
+            self.qnode.to_tf(dtype=dtype)
         else:
             self._signature_validation(qnode, weight_shapes)
             self.qnode = to_tf(qnode, dtype=tf.keras.backend.floatx())

--- a/pennylane/qnn/keras.py
+++ b/pennylane/qnn/keras.py
@@ -224,9 +224,9 @@ class KerasLayer(Layer):
         super().__init__(dynamic=True, **kwargs)
 
     def _signature_validation_tape_mode(self, qnode, weight_shapes):
-        self.sig = inspect.signature(qnode.func).parameters
+        sig = inspect.signature(qnode.func).parameters
 
-        if self.input_arg not in self.sig:
+        if self.input_arg not in sig:
             raise TypeError(
                 "QNode must include an argument with name {} for inputting data".format(
                     self.input_arg
@@ -239,13 +239,13 @@ class KerasLayer(Layer):
                 "weight_shapes".format(self.input_arg)
             )
 
-        param_kinds = [p.kind for p in self.sig.values()]
+        param_kinds = [p.kind for p in sig.values()]
 
         if inspect.Parameter.VAR_POSITIONAL in param_kinds:
             raise TypeError("Cannot have a variable number of positional arguments")
 
         if inspect.Parameter.VAR_KEYWORD not in param_kinds:
-            if set(weight_shapes.keys()) | {self.input_arg} != set(self.sig.keys()):
+            if set(weight_shapes.keys()) | {self.input_arg} != set(sig.keys()):
                 raise ValueError("Must specify a shape for every non-input parameter in the QNode")
 
     def _signature_validation(self, qnode, weight_shapes):

--- a/pennylane/tape/qnode.py
+++ b/pennylane/tape/qnode.py
@@ -150,6 +150,7 @@ class QNode:
         self.func = func
         self.device = device
         self.qtape = None
+        self.qfunc_output = None
 
         self._tape, self.interface, self.diff_method = self.get_tape(device, interface, diff_method)
         self.diff_options = diff_options or {}
@@ -375,10 +376,12 @@ class QNode:
         self.qtape = self._tape(caching=self._caching)
 
         with self.qtape:
-            measurement_processes = self.func(*args, **kwargs)
+            self.qfunc_output = self.func(*args, **kwargs)
 
-        if not isinstance(measurement_processes, Sequence):
-            measurement_processes = (measurement_processes,)
+        if not isinstance(self.qfunc_output, Sequence):
+            measurement_processes = (self.qfunc_output,)
+        else:
+            measurement_processes = self.qfunc_output
 
         if not all(isinstance(m, qml.tape.MeasurementProcess) for m in measurement_processes):
             raise qml.QuantumFunctionError(
@@ -444,8 +447,14 @@ class QNode:
         # execute the tape
         res = self.qtape.execute(device=self.device)
 
-        # HOTFIX: to maintain compatibility with core, we squeeze
-        # all outputs.
+        if self._caching:
+            self._cache_execute = self.qtape._cache_execute
+
+        if isinstance(self.qfunc_output, Sequence):
+            return res
+
+        # HOTFIX: Output is a single measurement function. To maintain compatibility
+        # with core, we squeeze all outputs.
 
         # Get the namespace associated with the return type
         res_type_namespace = res.__class__.__module__.split(".")[0]
@@ -454,9 +463,6 @@ class QNode:
             # For PennyLane and autograd we must branch, since
             # 'squeeze' does not exist in the top-level of the namespace
             return anp.squeeze(res)
-
-        if self._caching:
-            self._cache_execute = self.qtape._cache_execute
 
         return __import__(res_type_namespace).squeeze(res)
 

--- a/tests/qnn/conftest.py
+++ b/tests/qnn/conftest.py
@@ -19,7 +19,7 @@ import pennylane as qml
 
 
 @pytest.fixture
-def get_circuit(n_qubits, output_dim, interface):
+def get_circuit(n_qubits, output_dim, interface, tape_mode):
     """Fixture for getting a sample quantum circuit with a controllable qubit number and output
     dimension. Returns both the circuit and the shape of the weights."""
 

--- a/tests/qnn/test_keras.py
+++ b/tests/qnn/test_keras.py
@@ -25,40 +25,6 @@ tf = pytest.importorskip("tensorflow", minversion="2")
 pytestmark = pytest.mark.usefixtures("tape_mode")
 
 
-@pytest.fixture
-def get_circuit(n_qubits, output_dim, interface, tape_mode):
-    """Fixture for getting a sample quantum circuit with a controllable qubit number and output
-    dimension. Returns both the circuit and the shape of the weights."""
-
-    dev = qml.device("default.qubit", wires=n_qubits)
-    weight_shapes = {
-        "w1": (3, n_qubits, 3),
-        "w2": (1,),
-        "w3": 1,
-        "w4": [3],
-        "w5": (2, n_qubits, 3),
-        "w6": 3,
-        "w7": 0,
-    }
-
-    @qml.qnode(dev, interface=interface)
-    def circuit(inputs, w1, w2, w3, w4, w5, w6, w7):
-        """A circuit that embeds data using the AngleEmbedding and then performs a variety of
-        operations. The output is a PauliZ measurement on the first output_dim qubits. One set of
-        parameters, w5, are specified as non-trainable."""
-        qml.templates.AngleEmbedding(inputs, wires=list(range(n_qubits)))
-        qml.templates.StronglyEntanglingLayers(w1, wires=list(range(n_qubits)))
-        qml.RX(w2[0], wires=0 % n_qubits)
-        qml.RX(w3, wires=1 % n_qubits)
-        qml.Rot(*w4, wires=2 % n_qubits)
-        qml.templates.StronglyEntanglingLayers(w5, wires=list(range(n_qubits)))
-        qml.Rot(*w6, wires=3 % n_qubits)
-        qml.RX(w7, wires=4 % n_qubits)
-        return [qml.expval(qml.PauliZ(i)) for i in range(output_dim)]
-
-    return circuit, weight_shapes
-
-
 @pytest.mark.usefixtures("get_circuit")
 @pytest.fixture
 def model(get_circuit, n_qubits, output_dim):

--- a/tests/qnn/test_keras.py
+++ b/tests/qnn/test_keras.py
@@ -160,7 +160,9 @@ class TestKerasLayer:
         """Test if a TypeError is raised when instantiated with a variable number of keyword
         arguments"""
         if qml.tape_mode_active():
-            pytest.skip("This functionality is supported in tape mode, so will not raise an exception.")
+            pytest.skip(
+                "This functionality is supported in tape mode, so will not raise an exception."
+            )
 
         c, w = get_circuit
 
@@ -217,7 +219,7 @@ class TestKerasLayer:
 
         layer_out = layer(x)
         circ_weights = layer.qnode_weights.copy()
-        circ_weights["w4"] = tf.convert_to_tensor(circ_weights["w4"])
+        circ_weights["w4"] = tf.convert_to_tensor(circ_weights["w4"])  # To allow for slicing
         circ_weights["w6"] = tf.convert_to_tensor(circ_weights["w6"])
         circuit_out = c(x[0], **circ_weights)
 
@@ -253,7 +255,9 @@ class TestKerasLayer:
         """Test if a TypeError is raised when default arguments that are not the input argument are
         present in the QNode"""
         if qml.tape_mode_active():
-            pytest.skip("This functionality is supported in tape mode, so will not raise an exception.")
+            pytest.skip(
+                "This functionality is supported in tape mode, so will not raise an exception."
+            )
 
         c, w = get_circuit
 
@@ -309,8 +313,8 @@ class TestKerasLayer:
 
         layer_out = layer(x)
         circ_weights = layer.qnode_weights.copy()
-        circ_weights["w4"] = 1.0 * circ_weights["w4"]
-        circ_weights["w6"] = 1.0 * circ_weights["w6"]
+        circ_weights["w4"] = tf.convert_to_tensor(circ_weights["w4"])  # To allow for slicing
+        circ_weights["w6"] = tf.convert_to_tensor(circ_weights["w6"])
         circuit_out = c(x[0], **circ_weights)
 
         assert np.allclose(layer_out, circuit_out)
@@ -471,8 +475,8 @@ class TestKerasLayer:
         g_layer = tape.gradient(out_layer, layer.trainable_variables)
 
         circuit_weights = layer.trainable_variables.copy()
-        circuit_weights[3] = 1.0 * circuit_weights[3]
-        circuit_weights[5] = 1.0 * circuit_weights[5]
+        circuit_weights[3] = tf.convert_to_tensor(circuit_weights[3])  # To allow for slicing
+        circuit_weights[5] = tf.convert_to_tensor(circuit_weights[5])
 
         with tf.GradientTape() as tape:
             out_circuit = c(x[0], *circuit_weights)

--- a/tests/qnn/test_keras.py
+++ b/tests/qnn/test_keras.py
@@ -160,7 +160,7 @@ class TestKerasLayer:
         """Test if a TypeError is raised when instantiated with a variable number of keyword
         arguments"""
         if qml.tape_mode_active():
-            pytest.skip("This functionality is supported in tape mode.")
+            pytest.skip("This functionality is supported in tape mode, so will not raise an exception.")
 
         c, w = get_circuit
 
@@ -217,8 +217,8 @@ class TestKerasLayer:
 
         layer_out = layer(x)
         circ_weights = layer.qnode_weights.copy()
-        circ_weights["w4"] = 1.0 * circ_weights["w4"]
-        circ_weights["w6"] = 1.0 * circ_weights["w6"]
+        circ_weights["w4"] = tf.convert_to_tensor(circ_weights["w4"])
+        circ_weights["w6"] = tf.convert_to_tensor(circ_weights["w6"])
         circuit_out = c(x[0], **circ_weights)
 
         assert np.allclose(layer_out, circuit_out)
@@ -253,7 +253,7 @@ class TestKerasLayer:
         """Test if a TypeError is raised when default arguments that are not the input argument are
         present in the QNode"""
         if qml.tape_mode_active():
-            pytest.skip("This functionality is supported in tape mode.")
+            pytest.skip("This functionality is supported in tape mode, so will not raise an exception.")
 
         c, w = get_circuit
 

--- a/tests/qnn/test_qnn_torch.py
+++ b/tests/qnn/test_qnn_torch.py
@@ -27,40 +27,6 @@ torch = pytest.importorskip("torch")
 pytestmark = pytest.mark.usefixtures("tape_mode")
 
 
-@pytest.fixture
-def get_circuit(n_qubits, output_dim, interface, tape_mode):
-    """Fixture for getting a sample quantum circuit with a controllable qubit number and output
-    dimension. Returns both the circuit and the shape of the weights."""
-
-    dev = qml.device("default.qubit", wires=n_qubits)
-    weight_shapes = {
-        "w1": (3, n_qubits, 3),
-        "w2": (1,),
-        "w3": 1,
-        "w4": [3],
-        "w5": (2, n_qubits, 3),
-        "w6": 3,
-        "w7": 0,
-    }
-
-    @qml.qnode(dev, interface=interface)
-    def circuit(inputs, w1, w2, w3, w4, w5, w6, w7):
-        """A circuit that embeds data using the AngleEmbedding and then performs a variety of
-        operations. The output is a PauliZ measurement on the first output_dim qubits. One set of
-        parameters, w5, are specified as non-trainable."""
-        qml.templates.AngleEmbedding(inputs, wires=list(range(n_qubits)))
-        qml.templates.StronglyEntanglingLayers(w1, wires=list(range(n_qubits)))
-        qml.RX(w2[0], wires=0 % n_qubits)
-        qml.RX(w3, wires=1 % n_qubits)
-        qml.Rot(*w4, wires=2 % n_qubits)
-        qml.templates.StronglyEntanglingLayers(w5, wires=list(range(n_qubits)))
-        qml.Rot(*w6, wires=3 % n_qubits)
-        qml.RX(w7, wires=4 % n_qubits)
-        return [qml.expval(qml.PauliZ(i)) for i in range(output_dim)]
-
-    return circuit, weight_shapes
-
-
 def indices_up_to(n_max):
     """Returns an iterator over the number of qubits and output dimension, up to value n_max.
     The output dimension never exceeds the number of qubits."""


### PR DESCRIPTION
**Context:** The `qnn.KerasLayer` class needs modification to work in tape mode, due to the removal of QNode signature introspection.

**Description of changes:**

* The `KerasLayer` class requires different logic for signature validation and qnode evaluation in tape mode, so the new methods `_signature_validation_tape_mode` and `_evaluate_qnode_tape_mode`, to be called instead if in tape mode. This resulted in some 'rearrangement' of the class, but the underlying changes are minimal.

* The `get_circuit()` fixture is copied into `test_keras_layer.py`, since it needs to be modified for tape mode, _and_ the Torch class hasn't been ported yet (at least in `master`).

* Some of the tests would previously use the `get_circuit` fixture, but monkeypatch the created valid circuit to be non-valid, to test validation. Due to deviations between tape mode and non-tape mode, it is simpler to simply create a small, invalid test QNode within the test itself. This also makes the test more realistic, as sometimes monkeypatching would not replicate the user experience.

* **Support for backprop diff_method has been provided**

**Benefits & drawbacks:**

Similar to in https://github.com/PennyLaneAI/pennylane/pull/865.