### PR TITLE
Prevent measuring the same wire with multiple observables in tape mode

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -154,6 +154,8 @@
 
 <h3>Bug fixes</h3>
 
+* The new tape mode now prevents multiple expectation values from being evaluated on the same wire.
+
 * The `PauliRot` operation now gracefully handles single-qubit Paulis, and all-identity Paulis
   [(#860)](https://github.com/PennyLaneAI/pennylane/pull/860).
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -154,7 +154,9 @@
 
 <h3>Bug fixes</h3>
 
-* The new tape mode now prevents multiple expectation values from being evaluated on the same wire.
+* The new tape mode now prevents multiple expectation values and variances from being evaluated on
+  the same wire.
+  [(#877)](https://github.com/PennyLaneAI/pennylane/pull/877)
 
 * The `PauliRot` operation now gracefully handles single-qubit Paulis, and all-identity Paulis
   [(#860)](https://github.com/PennyLaneAI/pennylane/pull/860).

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -154,8 +154,7 @@
 
 <h3>Bug fixes</h3>
 
-* The new tape mode now prevents multiple expectation values and variances from being evaluated on
-  the same wire.
+* The new tape mode now prevents multiple observables from being evaluated on the same wire.
   [(#877)](https://github.com/PennyLaneAI/pennylane/pull/877)
 
 * The `PauliRot` operation now gracefully handles single-qubit Paulis, and all-identity Paulis

--- a/pennylane/tape/tapes/tape.py
+++ b/pennylane/tape/tapes/tape.py
@@ -330,6 +330,13 @@ class QuantumTape(AnnotatedQueue):
             elif isinstance(obj, qml.operation.Observable) and "owner" not in info:
                 raise ValueError(f"Observable {obj} does not have a measurement type specified.")
 
+        # check that no wires are measured more than once
+        m_wires = list(w for m in self._measurements for w in m.obs.wires)
+        if len(m_wires) != len(set(m_wires)):
+            raise qml.QuantumFunctionError(
+                "Each wire in the quantum circuit can only be measured once."
+            )
+
         self._update()
 
     def _update_circuit_info(self):

--- a/pennylane/tape/tapes/tape.py
+++ b/pennylane/tape/tapes/tape.py
@@ -40,6 +40,8 @@ STATE_PREP_OPS = (
     qml.GaussianState,
 )
 
+FORBIDDEN_ON_SAME_WIRE = [qml.operation.Expectation, qml.operation.Variance]
+
 
 def expand_tape(tape, depth=1, stop_at=None, expand_measurements=False):
     """Expand all objects in a tape to a specific depth.
@@ -330,14 +332,14 @@ class QuantumTape(AnnotatedQueue):
             elif isinstance(obj, qml.operation.Observable) and "owner" not in info:
                 raise ValueError(f"Observable {obj} does not have a measurement type specified.")
 
-
-        m_wires_exp = []  # The wires upon which an expectation value is measured
+        m_wires = []  # The wires upon which an expectation value or variance is measured
         for m in self._measurements:
-            m_wires_exp.extend([w for w in m.wires if m.return_type is qml.operation.Expectation])
+            m_wires.extend([w for w in m.wires if m.return_type in FORBIDDEN_ON_SAME_WIRE])
 
-        if len(m_wires_exp) != len(set(m_wires_exp)):
+        if len(m_wires) != len(set(m_wires)):
             raise qml.QuantumFunctionError(
-                "Each wire in the quantum circuit can only be measured by one expectation value."
+                "Each wire in the quantum circuit can only be measured by one expectation value "
+                "or variance."
             )
 
         self._update()

--- a/pennylane/tape/tapes/tape.py
+++ b/pennylane/tape/tapes/tape.py
@@ -40,7 +40,7 @@ STATE_PREP_OPS = (
     qml.GaussianState,
 )
 
-FORBIDDEN_ON_SAME_WIRE = [qml.operation.Expectation, qml.operation.Variance]
+OBSERVABLE_MEASUREMENTS = [qml.operation.Expectation, qml.operation.Variance, qml.operation.Sample]
 
 
 def expand_tape(tape, depth=1, stop_at=None, expand_measurements=False):
@@ -332,14 +332,13 @@ class QuantumTape(AnnotatedQueue):
             elif isinstance(obj, qml.operation.Observable) and "owner" not in info:
                 raise ValueError(f"Observable {obj} does not have a measurement type specified.")
 
-        m_wires = []  # The wires upon which an expectation value or variance is measured
+        m_wires = []  # The wires upon which an observable is measured
         for m in self._measurements:
-            m_wires.extend([w for w in m.wires if m.return_type in FORBIDDEN_ON_SAME_WIRE])
+            m_wires.extend([w for w in m.wires if m.return_type in OBSERVABLE_MEASUREMENTS])
 
         if len(m_wires) != len(set(m_wires)):
             raise qml.QuantumFunctionError(
-                "Each wire in the quantum circuit can only be measured by one expectation value "
-                "or variance."
+                "Each wire in the quantum circuit can only be measured by a single observable"
             )
 
         self._update()

--- a/pennylane/tape/tapes/tape.py
+++ b/pennylane/tape/tapes/tape.py
@@ -40,8 +40,6 @@ STATE_PREP_OPS = (
     qml.GaussianState,
 )
 
-OBSERVABLE_MEASUREMENTS = [qml.operation.Expectation, qml.operation.Variance, qml.operation.Sample]
-
 
 def expand_tape(tape, depth=1, stop_at=None, expand_measurements=False):
     """Expand all objects in a tape to a specific depth.
@@ -334,7 +332,8 @@ class QuantumTape(AnnotatedQueue):
 
         m_wires = []  # The wires upon which an observable is measured
         for m in self._measurements:
-            m_wires.extend([w for w in m.wires if m.return_type in OBSERVABLE_MEASUREMENTS])
+            if m.obs is not None:
+                m_wires.extend(m.wires)
 
         if len(m_wires) != len(set(m_wires)):
             raise qml.QuantumFunctionError(

--- a/pennylane/tape/tapes/tape.py
+++ b/pennylane/tape/tapes/tape.py
@@ -330,11 +330,14 @@ class QuantumTape(AnnotatedQueue):
             elif isinstance(obj, qml.operation.Observable) and "owner" not in info:
                 raise ValueError(f"Observable {obj} does not have a measurement type specified.")
 
-        # check that no wires are measured more than once
-        m_wires = list(w for m in self._measurements for w in m.obs.wires)
-        if len(m_wires) != len(set(m_wires)):
+
+        m_wires_exp = []  # The wires upon which an expectation value is measured
+        for m in self._measurements:
+            m_wires_exp.extend([w for w in m.wires if m.return_type is qml.operation.Expectation])
+
+        if len(m_wires_exp) != len(set(m_wires_exp)):
             raise qml.QuantumFunctionError(
-                "Each wire in the quantum circuit can only be measured once."
+                "Each wire in the quantum circuit can only be measured by one expectation value."
             )
 
         self._update()

--- a/tests/tape/interfaces/test_tape_autograd.py
+++ b/tests/tape/interfaces/test_tape_autograd.py
@@ -458,7 +458,7 @@ class TestAutogradPassthru:
         assert expected.shape == (1, 1)
         assert np.allclose(res, np.squeeze(expected), atol=tol, rtol=0)
 
-    def test_jacsobian(self, mocker, tol):
+    def test_jacobian(self, mocker, tol):
         """Test jacobian calculation"""
         spy = mocker.spy(JacobianTape, "jacobian")
         a = np.array(0.1, requires_grad=True)

--- a/tests/tape/interfaces/test_tape_autograd.py
+++ b/tests/tape/interfaces/test_tape_autograd.py
@@ -458,7 +458,7 @@ class TestAutogradPassthru:
         assert expected.shape == (1, 1)
         assert np.allclose(res, np.squeeze(expected), atol=tol, rtol=0)
 
-    def test_jacobian(self, mocker, tol):
+    def test_jacsobian(self, mocker, tol):
         """Test jacobian calculation"""
         spy = mocker.spy(JacobianTape, "jacobian")
         a = np.array(0.1, requires_grad=True)
@@ -469,7 +469,7 @@ class TestAutogradPassthru:
                 qml.RY(a, wires=0)
                 qml.RX(b, wires=0)
                 qml.expval(qml.PauliZ(0))
-                qml.expval(qml.PauliY(0))
+                qml.expval(qml.PauliY(1))
             return tape.execute(device)
 
         dev = qml.device("default.qubit.autograd", wires=2)
@@ -482,7 +482,7 @@ class TestAutogradPassthru:
             qml.RY(a, wires=0)
             qml.RX(b, wires=0)
             qml.expval(qml.PauliZ(0))
-            qml.expval(qml.PauliY(0))
+            qml.expval(qml.PauliY(1))
 
         expected = tape.jacobian(dev)
         assert expected.shape == (2, 2)

--- a/tests/tape/tapes/test_jacobian_tape.py
+++ b/tests/tape/tapes/test_jacobian_tape.py
@@ -541,14 +541,14 @@ class TestJacobianCVIntegration:
         with JacobianTape() as tape:
             qml.ThermalState(n, wires=0)
             qml.Displacement(a, 0, wires=0)
-            qml.expval(qml.NumberOperator(0))
+            qml.expval(qml.NumberOperator(1))
             qml.var(qml.NumberOperator(0))
 
         tape.trainable_params = {0, 1}
         res = tape.jacobian(dev)
         assert res.shape == (2, 2)
 
-        expected = np.array([[1, 2 * a], [2 * a ** 2 + 2 * n + 1, 2 * a * (2 * n + 1)]])
+        expected = np.array([[0, 0], [2 * a ** 2 + 2 * n + 1, 2 * a * (2 * n + 1)]])
         assert np.allclose(res, expected, atol=tol, rtol=0)
 
     def test_trainable_measurement(self, tol):

--- a/tests/tape/tapes/test_tape.py
+++ b/tests/tape/tapes/test_tape.py
@@ -559,6 +559,15 @@ class TestParameters:
 
         assert np.all(obs.data[0] == H2)
 
+    def test_multiple_expectations_same_wire(self, make_tape):
+        """Test if a QuantumFunctionError is raised if more than one expectation value is
+        evaluated on a given wire"""
+        tape, _ = make_tape
+
+        with pytest.raises(qml.QuantumFunctionError, match="Each wire in the quantum circuit"):
+            with tape:
+                qml.expval(qml.PauliZ("a"))
+
 
 class TestInverse:
     """Tests for tape inversion"""

--- a/tests/tape/tapes/test_tape.py
+++ b/tests/tape/tapes/test_tape.py
@@ -568,6 +568,15 @@ class TestParameters:
             with tape:
                 qml.expval(qml.PauliZ("a"))
 
+    def test_multiple_expectations_and_vars_same_wire(self, make_tape):
+        """Test if a QuantumFunctionError is raised if a variance measurement follows an
+        expectation value measurement on the same wire"""
+        tape, _ = make_tape
+
+        with pytest.raises(qml.QuantumFunctionError, match="Each wire in the quantum circuit"):
+            with tape:
+                qml.var(qml.PauliZ("a"))
+
 
 class TestInverse:
     """Tests for tape inversion"""

--- a/tests/tape/tapes/test_tape.py
+++ b/tests/tape/tapes/test_tape.py
@@ -577,6 +577,15 @@ class TestParameters:
             with tape:
                 qml.var(qml.PauliZ("a"))
 
+    def test_multiple_expectations_and_sample_same_wire(self, make_tape):
+        """Test if a QuantumFunctionError is raised if a sampling measurement follows an
+        expectation value measurement on the same wire"""
+        tape, _ = make_tape
+
+        with pytest.raises(qml.QuantumFunctionError, match="Each wire in the quantum circuit"):
+            with tape:
+                qml.sample(qml.PauliZ("a"))
+
 
 class TestInverse:
     """Tests for tape inversion"""


### PR DESCRIPTION
Measuring the same wire with multiple observables is not permitted in the original core of PennyLane:
```python
import pennylane as qml

dev = qml.device("default.qubit", wires=2)

@qml.qnode(dev)
def f(x):
    qml.RX(x, wires=0)
    qml.RX(0.2, wires=1)
    qml.CNOT(wires=[0, 1])
    return qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliX(0))

f(0.2)
```
This will raise a `QuantumFunctionError`. The justification for this is that a single run of a device is not sufficient to measure these two observables, since the don't qubit-wise commute.

However, in tape-mode the above code executes without an error. This PR introduces a check to prevent this.

This PR does raise the question of *do we want to prevent this behaviour?* Currently, I think we should, since the results when using devices inheriting from `DefaultQubit` are wrong.