### PR TITLE
Small update in DisplacementEmbedding docstring

### DIFF
--- a/pennylane/templates/embeddings/displacement.py
+++ b/pennylane/templates/embeddings/displacement.py
@@ -28,9 +28,8 @@ from pennylane.templates.utils import (
 
 @template
 def DisplacementEmbedding(features, wires, method="amplitude", c=0.1):
-    r"""
-    Encodes :math:`N` features into the displacement amplitudes :math:`r` or phases :math:`\phi` of :math:`M` modes,
-     where :math:`N\leq M`.
+    r"""Encodes :math:`N` features into the displacement amplitudes :math:`r` or phases :math:`\phi` of :math:`M` modes,
+    where :math:`N\leq M`.
 
     The mathematical definition of the displacement gate is given by the operator
 

--- a/pennylane/templates/embeddings/displacement.py
+++ b/pennylane/templates/embeddings/displacement.py
@@ -28,7 +28,8 @@ from pennylane.templates.utils import (
 
 @template
 def DisplacementEmbedding(features, wires, method="amplitude", c=0.1):
-    r"""Encodes :math:`N` features into the displacement amplitudes :math:`r` or phases :math:`\phi` of :math:`M` modes,
+    r"""
+    Encodes :math:`N` features into the displacement amplitudes :math:`r` or phases :math:`\phi` of :math:`M` modes,
      where :math:`N\leq M`.
 
     The mathematical definition of the displacement gate is given by the operator


### PR DESCRIPTION
A slight change in the docstring. Helps with rendering the [first line of the docs](https://pennylane.readthedocs.io/en/stable/code/api/pennylane.templates.embeddings.DisplacementEmbedding.html).