### PR TITLE
Update the templates quickstart to emphasize the templates gallery

### DIFF
--- a/doc/introduction/templates.rst
+++ b/doc/introduction/templates.rst
@@ -24,58 +24,6 @@ PennyLane conceptually distinguishes different types of templates, such as :ref:
 Most templates are complemented by functions that provide an array of
 random :ref:`initial parameters <intro_ref_temp_init>`.
 
-An example of how to use templates is the following:
-
-.. code-block:: python
-
-    import pennylane as qml
-    from pennylane.templates.embeddings import AngleEmbedding
-    from pennylane.templates.layers import StronglyEntanglingLayers
-    from pennylane.init import strong_ent_layers_uniform
-
-    dev = qml.device('default.qubit', wires=2)
-
-    @qml.qnode(dev)
-    def circuit(weights, x=None):
-        AngleEmbedding(x, [0,1])
-        StronglyEntanglingLayers(weights, wires=[0,1])
-        return qml.expval(qml.PauliZ(0))
-
-    init_weights = strong_ent_layers_uniform(n_layers=3, n_wires=2)
-    print(circuit(init_weights, x=[1., 2.]))
-
-Here, we used the embedding template :func:`~.AngleEmbedding`
-together with the layer template :func:`~.StronglyEntanglingLayers`,
-and the uniform parameter initialization strategy
-:func:`~.strong_ent_layers_uniform`.
-
-Custom templates
-----------------
-
-In addition, custom templates can be created; simply
-decorate a Python function that applies quantum gates
-with the :func:`pennylane.template` decorator:
-
-.. code-block:: python3
-
-    @qml.template
-    def bell_state_preparation(wires):
-        qml.Hadamard(wires=wires[0])
-        qml.CNOT(wires=wires)
-
-This registers the template with PennyLane, making it compatible with
-functions that act on templates, such as :func:`~.pennylane.inv`:
-
-.. code-block:: python3
-
-    dev = qml.device('default.qubit', wires=2)
-
-    @qml.qnode(dev)
-    def circuit():
-        qml.inv(bell_state_preparation(wires=[0, 1]))
-        return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
-
-
 The following is a gallery of built-in templates provided by PennyLane.
 
 .. _intro_ref_temp_emb:
@@ -369,6 +317,32 @@ respective interfaces.
     init_tf = tf.Variable(init_pars)
 
 The initialization functions can be found in the :mod:`~.pennylane.init` module.
+
+Custom templates
+----------------
+
+In addition, custom templates can be created; simply
+decorate a Python function that applies quantum gates
+with the :func:`pennylane.template` decorator:
+
+.. code-block:: python3
+
+    @qml.template
+    def bell_state_preparation(wires):
+        qml.Hadamard(wires=wires[0])
+        qml.CNOT(wires=wires)
+
+This registers the template with PennyLane, making it compatible with
+functions that act on templates, such as :func:`~.pennylane.inv`:
+
+.. code-block:: python3
+
+    dev = qml.device('default.qubit', wires=2)
+
+    @qml.qnode(dev)
+    def circuit():
+        qml.inv(bell_state_preparation(wires=[0, 1]))
+        return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
 Adding a new template
 ---------------------


### PR DESCRIPTION
While reviewing #879, I noticed that the templates quickstart required a lot of scrolling to get to the gallery of templates, kind of defeating its purpose as a quickstart. This PR emphasizes the gallery (the most useful and visually appealing part of the page imo), by:

* Removing the 'how to use a template' codeblock. Every template docstring now has a usage details section, so is perhaps not needed anymore here.

* Moving the 'custom templates' section to the end, after the gallery.