### PR TITLE
Add representation to MeasurementProcess

### DIFF
--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -429,10 +429,6 @@ class Operator(abc.ABC):
         if do_queue:
             self.queue()
 
-    def __str__(self):
-        """Operator name and some information."""
-        return "{}: {} params, wires {}".format(self.name, len(self.data), self.wires.tolist())
-
     def __repr__(self):
         """Constructor-call-like representation."""
         # FIXME using self.parameters here instead of self.data is dangerous, it assumes the data can be evaluated
@@ -1188,15 +1184,18 @@ class Tensor(Observable):
         copied_op._eigvals_cache = self._eigvals_cache
         return copied_op
 
-    def __str__(self):
-        """Print the tensor product and some information."""
-        return "Tensor product {}: {} params, wires {}".format(
-            [i.name for i in self.obs], len(self.data), self.wires.tolist()
-        )
-
     def __repr__(self):
         """Constructor-call-like representation."""
-        return "Tensor(" + ", ".join([repr(o) for o in self.obs]) + ")"
+
+        s = " @ ".join([repr(o) for o in self.obs])
+
+        if self.return_type is None:
+            return s
+
+        if self.return_type is Probability:
+            return repr(self.return_type) + "(wires={})".format(self.wires.tolist())
+
+        return repr(self.return_type) + "(" + s + ")"
 
     @property
     def name(self):

--- a/pennylane/tape/measure.py
+++ b/pennylane/tape/measure.py
@@ -78,6 +78,10 @@ class MeasurementProcess:
         # Queue the measurement process
         self.queue()
 
+    def __repr__(self):
+        """String representation of this class."""
+        return "{}({})".format(self.return_type.name, self.obs)
+
     def __copy__(self):
         cls = self.__class__
 

--- a/pennylane/tape/measure.py
+++ b/pennylane/tape/measure.py
@@ -83,6 +83,7 @@ class MeasurementProcess:
         if self.obs is None:
             return "{}(wires={})".format(self.return_type.value, self.wires)
 
+        # Todo: when tape is core the return type will always be taken from the MeasurementProcess
         if self.obs.return_type is None:
             return "{}({})".format(self.return_type.value, self.obs)
 

--- a/pennylane/tape/measure.py
+++ b/pennylane/tape/measure.py
@@ -81,7 +81,7 @@ class MeasurementProcess:
     def __repr__(self):
         """Representation of this class."""
         if self.obs is None:
-            return "{}(None)".format(self.return_type.value)
+            return "{}(wires={})".format(self.return_type.value, self.wires)
 
         if self.obs.return_type is None:
             return "{}({})".format(self.return_type.value, self.obs)

--- a/pennylane/tape/measure.py
+++ b/pennylane/tape/measure.py
@@ -79,8 +79,14 @@ class MeasurementProcess:
         self.queue()
 
     def __repr__(self):
-        """String representation of this class."""
-        return "{}({})".format(self.return_type.name, self.obs)
+        """Representation of this class."""
+        if self.obs is None:
+            return "{}(None)".format(self.return_type.value)
+
+        if self.obs.return_type is None:
+            return "{}({})".format(self.return_type.value, self.obs)
+
+        return "{}".format(self.obs)
 
     def __copy__(self):
         cls = self.__class__

--- a/tests/tape/test_tape_measure.py
+++ b/tests/tape/test_tape_measure.py
@@ -199,6 +199,12 @@ class TestProperties:
         m = MeasurementProcess(Expectation, obs=obs)
         assert m.eigvals is None
 
+    def test_repr(self):
+        """Test the string representation of a MeasurementProcess."""
+        m = MeasurementProcess(Expectation, obs=qml.PauliZ(wires='a') @ qml.PauliZ(wires='b'))
+        expected = "Expectation(Tensor product ['PauliZ', 'PauliZ']: 0 params, wires ['a', 'b'])"
+        assert str(m) == expected
+
 
 class TestExpansion:
     """Test for measurement expansion"""

--- a/tests/tape/test_tape_measure.py
+++ b/tests/tape/test_tape_measure.py
@@ -202,7 +202,11 @@ class TestProperties:
     def test_repr(self):
         """Test the string representation of a MeasurementProcess."""
         m = MeasurementProcess(Expectation, obs=qml.PauliZ(wires='a') @ qml.PauliZ(wires='b'))
-        expected = "Expectation(Tensor product ['PauliZ', 'PauliZ']: 0 params, wires ['a', 'b'])"
+        expected = "expval(PauliZ(wires=['a']) @ PauliZ(wires=['b']))"
+        assert str(m) == expected
+
+        m = MeasurementProcess(Probability, obs=qml.PauliZ(wires='a'))
+        expected = "probs(PauliZ(wires=['a']))"
         assert str(m) == expected
 
 

--- a/tests/test_observable.py
+++ b/tests/test_observable.py
@@ -15,14 +15,8 @@
 Unit tests for the :mod:`pennylane.plugin.DefaultGaussian` device.
 """
 # pylint: disable=protected-access,cell-var-from-loop
-from pennylane import numpy as np
-from scipy.linalg import block_diag
 
 import pennylane as qml
-from pennylane.qnodes import QuantumFunctionError
-from pennylane.devices import DefaultQubit
-
-import pytest
 
 
 def test_pass_positional_wires_to_observable():

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -577,6 +577,24 @@ class TestObservableConstruction:
         assert cv_obs.wires == Wires([1])
         assert cv_obs.ev_order == 2
 
+    def test_repr(self):
+        """Test the string representation of a MeasurementProcess."""
+        m = qml.expval(qml.PauliZ(wires=['a']) @ qml.PauliZ(wires=['b']))
+        expected = "expval(PauliZ(wires=['a']) @ PauliZ(wires=['b']))"
+        assert str(m) == expected
+
+        m = qml.probs(wires=['a'])
+        expected = "probs(wires=['a'])"
+        assert str(m) == expected
+
+        m = qml.PauliZ(wires=['a']) @ qml.PauliZ(wires=['b'])
+        expected = "PauliZ(wires=['a']) @ PauliZ(wires=['b'])"
+        assert str(m) == expected
+
+        m = qml.PauliZ(wires=['a'])
+        expected = "PauliZ(wires=['a'])"
+        assert str(m) == expected
+
 
 class TestOperatorIntegration:
     """ Integration tests for the Operator class"""

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -578,7 +578,8 @@ class TestObservableConstruction:
         assert cv_obs.ev_order == 2
 
     def test_repr(self):
-        """Test the string representation of a MeasurementProcess."""
+        """Test the string representation of an observable with and without a return type."""
+
         m = qml.expval(qml.PauliZ(wires=['a']) @ qml.PauliZ(wires=['b']))
         expected = "expval(PauliZ(wires=['a']) @ PauliZ(wires=['b']))"
         assert str(m) == expected


### PR DESCRIPTION
Adds a `__repr__` method to a tape's measurement process.

For example:
``` python
import pennylane as qml

with qml.tape.QuantumTape() as tape:
    qml.tape.measure.expval(qml.PauliZ(wires='a')@qml.PauliZ(wires='b'))
    qml.tape.measure.var(qml.PauliZ(wires='b'))
```
In master:

``` python
print(tape.measurements)
>>>[<pennylane.tape.measure.MeasurementProcess object at 0x7f773edf1820>, <pennylane.tape.measure.MeasurementProcess object at 0x7f773edf19d0>]
```
On this branch:
``` python
print(tape.measurements)
>>>[expval(PauliZ(wires=['a'] @ PauliZ(wires=['b'])), var(PauliZ(wires=['b'])]
```

The observable `__str__` methods have been removed to have `__repr__` as the single source of truth, and since they rendered things funnily. Tests have been added.
