### PR TITLE
Fix gradient in tape mode when measurements are independent of a parameter

### DIFF
--- a/pennylane/tape/tapes/jacobian_tape.py
+++ b/pennylane/tape/tapes/jacobian_tape.py
@@ -493,25 +493,26 @@ class JacobianTape(QuantumTape):
         nonzero_grad_idx = []
 
         for trainable_idx, param_method in enumerate(diff_methods):
-            if param_method != "0":
+            if param_method == "0":
+                continue
 
-                nonzero_grad_idx.append(trainable_idx)
+            nonzero_grad_idx.append(trainable_idx)
 
-                if (method == "best" and param_method[0] == "F") or (method == "numeric"):
-                    # numeric method
-                    tapes, processing_fn = self.numeric_pd(trainable_idx, params=params, **options)
+            if (method == "best" and param_method[0] == "F") or (method == "numeric"):
+                # numeric method
+                tapes, processing_fn = self.numeric_pd(trainable_idx, params=params, **options)
 
-                elif (method == "best" and param_method[0] == "A") or (method == "analytic"):
-                    # analytic method
-                    tapes, processing_fn = self.analytic_pd(trainable_idx, params=params, **options)
+            elif (method == "best" and param_method[0] == "A") or (method == "analytic"):
+                # analytic method
+                tapes, processing_fn = self.analytic_pd(trainable_idx, params=params, **options)
 
-                processing_fns.append(processing_fn)
+            processing_fns.append(processing_fn)
 
-                # we create a flat list here to feed at once to the device
-                all_tapes.extend(tapes)
+            # we create a flat list here to feed at once to the device
+            all_tapes.extend(tapes)
 
-                # to extract the correct result for this parameter later, remember the number of tapes
-                reshape_info.append(len(tapes))
+            # to extract the correct result for this parameter later, remember the number of tapes
+            reshape_info.append(len(tapes))
 
         # execute all tapes at once
         results = device.batch_execute(all_tapes)


### PR DESCRIPTION
This PR fixes a bug in tape mode that occurs when some parameters are independent of a measurement. Consider the following snippet:
```python
import pennylane as qml
from pennylane import numpy as np
qml.enable_tape()

dev = qml.device("default.qubit", wires=2)

@qml.qnode(dev)
def circ(params):
    qml.RX(params[0], wires=0)
    qml.RX(params[1], wires=1)
    return qml.expval(qml.PauliZ(0))

params = np.ones(2)

qml.grad(circ)(params)
```
This takes the gradient of a PauliZ expectation value on the first qubit. We expect to get `(array([-0.52167534, 0]),)` since the second parameter has no effect on the first qubit. Instead, we incorrectly get `(array([-0.52167534, -0.52167534]),)`.

Now suppose we have `return qml.expval(qml.PauliZ(1))`. Instead of getting an incorrect result, we get a `UnboundLocalError: local variable 'processing_fn' referenced before assignment` error.

Both of these problems occur because the `processing_fn` is not defined if `param_method == "0"`, and so we either use a previously defined `processing_fn` or raise an error.

This PR fixes the above problem by skipping the cases where `param_method == "0"`.
