### PR TITLE
Add tensor unwrapping in BaseQNode for keyword arguments 

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -193,8 +193,8 @@
 
 <h3>Bug fixes</h3>
 
-* PennyLane tensor objects are now unwrapped if passed as a keyword argument to
-  the quantum function of a QNode.
+* PennyLane tensor objects are now unwrapped in BaseQNode when passed as a
+  keyword argument to the quantum function.
   [(#903)](https://github.com/PennyLaneAI/pennylane/pull/903)
   [(#893)](https://github.com/PennyLaneAI/pennylane/pull/893)
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -193,6 +193,11 @@
 
 <h3>Bug fixes</h3>
 
+* PennyLane tensor objects are now unwrapped if passed as a keyword argument to
+  the quantum function of a QNode.
+  [(#903)](https://github.com/PennyLaneAI/pennylane/pull/903)
+  [(#893)](https://github.com/PennyLaneAI/pennylane/pull/893)
+
 * The new tape mode now prevents multiple observables from being evaluated on the same wire
   if the observables are not qubit-wise commuting Pauli words.
   [(#882)](https://github.com/PennyLaneAI/pennylane/pull/882)
@@ -213,7 +218,8 @@
 
 This release contains contributions from (in alphabetical order):
 
-Thomas Bromley, Christina Lee, Olivia Di Matteo, Anthony Hayes, Josh Izaac, Nathan Killoran, Maria Schuld
+Thomas Bromley, Christina Lee, Olivia Di Matteo, Anthony Hayes, Josh Izaac, Nathan Killoran,
+Maria Schuld, Antal Száva
 
 
 # Release 0.12.0 (current release)

--- a/pennylane/qnodes/base.py
+++ b/pennylane/qnodes/base.py
@@ -453,6 +453,10 @@ class BaseQNode(qml.QueuingContext):
                 Each positional argument is replaced with a :class:`~.variable.Variable` instance.
             kwargs (dict[str, Any]): Auxiliary arguments passed to the quantum function.
         """
+        for k, v in kwargs.items():
+            if isinstance(v, qml.numpy.tensor):
+                kwargs[k] = v.unwrap()
+
         # Get the name of the qfunc's arguments
         full_argspec = inspect.getfullargspec(self.func)
 

--- a/pennylane/qnodes/base.py
+++ b/pennylane/qnodes/base.py
@@ -453,9 +453,7 @@ class BaseQNode(qml.QueuingContext):
                 Each positional argument is replaced with a :class:`~.variable.Variable` instance.
             kwargs (dict[str, Any]): Auxiliary arguments passed to the quantum function.
         """
-        for k, v in kwargs.items():
-            if isinstance(v, qml.numpy.tensor):
-                kwargs[k] = v.unwrap()
+        kwargs = self.unwrap_tensor_kwargs(kwargs)
 
         # Get the name of the qfunc's arguments
         full_argspec = inspect.getfullargspec(self.func)
@@ -528,6 +526,25 @@ class BaseQNode(qml.QueuingContext):
             kwarg_vars[variable_name] = kwarg_variable
 
         return arg_vars, kwarg_vars
+
+    @staticmethod
+    def unwrap_tensor_kwargs(kwargs):
+        """Unwraps the pennylane.numpy.tensor objects that were passed as
+        keyword arguments so that they can be handled as gate parameters by
+        arbitrary devices.
+
+        Args:
+            kwargs (dict[str, Any]): Auxiliary arguments passed to the quantum function.
+
+        Returns:
+            dict[str, Any]: Auxiliary arguments passed to the quantum function
+            in an unwrapped form (if applicable).
+        """
+        for k, v in kwargs.items():
+            if isinstance(v, qml.numpy.tensor):
+                kwargs[k] = v.unwrap()
+
+        return kwargs
 
     def _construct(self, args, kwargs):
         """Construct the quantum circuit graph by calling the quantum function.

--- a/pennylane/templates/layers/random.py
+++ b/pennylane/templates/layers/random.py
@@ -25,6 +25,7 @@ from pennylane.templates.utils import (
     get_shape,
 )
 from pennylane.wires import Wires
+from pennylane.numpy import tensor
 
 
 def random_layer(weights, wires, ratio_imprim, imprimitive, rotations, seed):
@@ -49,7 +50,12 @@ def random_layer(weights, wires, ratio_imprim, imprimitive, rotations, seed):
             # Apply a random rotation gate to a random wire
             gate = np.random.choice(rotations)
             rnd_wire = wires.select_random(1)
-            gate(weights[i], wires=rnd_wire)
+
+            if isinstance(weights[i], tensor):
+                gate(weights[i].unwrap(), wires=rnd_wire)
+            else:
+                gate(weights[i], wires=rnd_wire)
+
             i += 1
         else:
             # Apply the imprimitive to two random wires

--- a/pennylane/templates/layers/random.py
+++ b/pennylane/templates/layers/random.py
@@ -51,10 +51,7 @@ def random_layer(weights, wires, ratio_imprim, imprimitive, rotations, seed):
             gate = np.random.choice(rotations)
             rnd_wire = wires.select_random(1)
 
-            if isinstance(weights[i], tensor):
-                gate(weights[i].unwrap(), wires=rnd_wire)
-            else:
-                gate(weights[i], wires=rnd_wire)
+            gate(weights[i], wires=rnd_wire)
 
             i += 1
         else:

--- a/pennylane/templates/layers/random.py
+++ b/pennylane/templates/layers/random.py
@@ -25,7 +25,6 @@ from pennylane.templates.utils import (
     get_shape,
 )
 from pennylane.wires import Wires
-from pennylane.numpy import tensor
 
 
 def random_layer(weights, wires, ratio_imprim, imprimitive, rotations, seed):

--- a/tests/templates/test_subroutines.py
+++ b/tests/templates/test_subroutines.py
@@ -913,7 +913,7 @@ class TestUCCSDUnitary:
                 [[0, 1, 2]],
                 [],
                 np.array([1.2, 1, 0, 0]),
-                "BasisState parameter must consist of 0 or 1 integers",
+                "Elements of 'init_state' must be integers",
             ),
             (
                 np.array([-2.8]),

--- a/tests/test_numpy_wrapper.py
+++ b/tests/test_numpy_wrapper.py
@@ -497,3 +497,34 @@ class TestNumpyConversion:
         assert np.all(res == data)
         assert isinstance(res, np.ndarray)
         assert not isinstance(res, np.tensor)
+
+    def test_single_gate_parameter(self):
+        """Test that a QNode handles passing multiple tensor objects to the
+        same gate without an error"""
+        dev = qml.device("default.qubit", wires=4)
+
+        @qml.qnode(dev)
+        def circuit(phi=None):
+            for y in phi:
+                for idx, x in enumerate(y):
+                    qml.RX(x, wires=idx)
+            return qml.expval(qml.PauliZ(0))
+
+        phi = np.tensor([[0.04439891, 0.14490549, 3.29725643, 2.51240058]])
+
+        circuit(phi=phi)
+
+    def test_multiple_gate_parameter(self):
+        """Test that a QNode handles passing multiple tensor objects to the
+        same gate without an error"""
+        dev = qml.device("default.qubit", wires=1)
+
+        @qml.qnode(dev)
+        def circuit(phi=None):
+            for idx, x in enumerate(phi):
+                qml.Rot(*x, wires=idx)
+            return qml.expval(qml.PauliZ(0))
+
+        phi = np.tensor([[0.04439891, 0.14490549, 3.29725643]])
+
+        circuit(phi=phi)

--- a/tests/test_numpy_wrapper.py
+++ b/tests/test_numpy_wrapper.py
@@ -499,8 +499,8 @@ class TestNumpyConversion:
         assert not isinstance(res, np.tensor)
 
     def test_single_gate_parameter(self, monkeypatch):
-        """Test that a QNode passes as unwrapped PennyLane tensor to a gate
-        taking a single parameter when supplied a tensor"""
+        """Test that when supplied a PennyLane tensor, a QNode passes an
+        unwrapped tensor as the argument to a gate taking a single parameter"""
         dev = qml.device("default.qubit", wires=4)
 
         @qml.qnode(dev)
@@ -526,8 +526,8 @@ class TestNumpyConversion:
             assert isinstance(rec.queue[0].parameters[0], float)
 
     def test_multiple_gate_parameter(self):
-        """Test that a QNode passes as unwrapped PennyLane tensor to a gate
-        taking multiple parameters when supplied a tensor"""
+        """Test that when supplied a PennyLane tensor, a QNode passes arguments
+        as unwrapped tensors to a gate taking multiple parameters"""
         dev = qml.device("default.qubit", wires=1)
 
         @qml.qnode(dev)


### PR DESCRIPTION
**Context:**
* #900
* #893

**Description of the Change:**
Adds tensor unwrapping in BaseQNode for keyword arguments.

**Benefits:**
A more general solution compared to #893 for handling `pennylane.numpy.tensor` objects as gate parameters.

Related PennyLane-Qiskit tests:
* https://github.com/PennyLaneAI/pennylane-qiskit/pull/115

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
Closes #900 