### PR TITLE
Fixes bug in the QAOA _diagonal_terms function to take into account the queuing refactor

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -224,6 +224,7 @@
   - `VQECost` [(#863)](https://github.com/PennyLaneAI/pennylane/pull/863)
   - `qnn.KerasLayer` [(#869)](https://github.com/PennyLaneAI/pennylane/pull/869)
   - `qnn.TorchLayer` [(#865)](https://github.com/PennyLaneAI/pennylane/pull/865)
+  - `qnn.qaoa` [(#905)](https://github.com/PennyLaneAI/pennylane/pull/905)
 
 <h3>Breaking changes</h3>
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -224,7 +224,7 @@
   - `VQECost` [(#863)](https://github.com/PennyLaneAI/pennylane/pull/863)
   - `qnn.KerasLayer` [(#869)](https://github.com/PennyLaneAI/pennylane/pull/869)
   - `qnn.TorchLayer` [(#865)](https://github.com/PennyLaneAI/pennylane/pull/865)
-  - `qnn.qaoa` [(#905)](https://github.com/PennyLaneAI/pennylane/pull/905)
+  - `qaoa` module [(#905)](https://github.com/PennyLaneAI/pennylane/pull/905)
 
 <h3>Breaking changes</h3>
 

--- a/pennylane/qaoa/layers.py
+++ b/pennylane/qaoa/layers.py
@@ -31,8 +31,8 @@ def _diagonal_terms(hamiltonian):
     val = True
 
     for i in hamiltonian.ops:
-        i = Tensor(i) if not isinstance(i, Tensor) else i
-        for j in i.obs:
+        obs = i.obs if isinstance(i, Tensor) else [i]
+        for j in obs:
             if j.name not in ("PauliZ", "Identity"):
                 val = False
                 break


### PR DESCRIPTION
**Context:**

As part of the recent queuing refactor, _all_ operation objects now get queued within a `QueuingContext`. If a container object (such as `Tensor`) is queued, it annotates the queue to claim ownership of the (previously) queued constituent operations. Previously, this was not the case; the `Tensor` class did not queue itself, and the existence of tensor products was assumed implicitly.

The queuing refactor has been completed within [tape mode](https://pennylane.readthedocs.io/en/latest/code/qml_tape.html). 

However, the queuing refactor was not considered when the QAOA module was written, and some functions within the module (e.g., `_diagonal_terms`) create `Tensor` objects _within_ the QNode queuing context for the sole purpose of validation --- the created Tensor objects are not intended to be retained nor queued. This causes issues in tape mode, where the tensor will be attempted to be queued.

**Description of the Change:**

* Modifies the `_diagonal_tape` function to no longer create `Tensor` objects.

* Marks the QAOA test file to be run in both tape and non-tape mode.

* Adds the QAOA example used in the [QAOA module docstring](https://pennylane.readthedocs.io/en/stable/code/qml_qaoa.html) to the `test_qaoa.py` file as an integration test, to ensure that this example continues to work in future.

**Benefits:**

* The QAOA module now functions properly in tape mode

* The change results in no changes to efficiency or logic. In fact, the new logic is likely (negligibly) more efficient, since it avoids object creation.

**Possible Drawbacks:** n/a

**Related GitHub Issues:** n/a
