### PR TITLE
Followup #899

### DIFF
--- a/tests/qnn/test_qnn_torch.py
+++ b/tests/qnn/test_qnn_torch.py
@@ -439,7 +439,7 @@ class TestTorchLayer:
 
                 qlayer = qml.qnn.TorchLayer(circuit, weight_shapes)
 
-                x = torch.rand((5, n_qubits), dtype=torch.float64)
+                x = torch.rand((5, n_qubits), dtype=torch.float64).to(torch.device('cuda'))
                 loss = torch.sum(qlayer(x)).squeeze()
                 loss.backward()
             except Exception:


### PR DESCRIPTION
**Context:**
In #899, a test of `TorchLayer` to run backward with `CUDA` tensor is implemented. I found that converting operation of the tensor to CUDA device was accidentally removed. This PR fixes that issue.

**Description of the Change:**
Changed the tensor to be fed into the QNode to be on GPU device.

**Benefits:**
The test has actual meaning.

**Possible Drawbacks:**
None.

**Related GitHub Issues:**
#899, #709