### PR TITLE
Allow PennyLane to rescan and refresh available plugin devices within the same Python runtime

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -231,6 +231,7 @@
   This will result in an improved experience if installing PennyLane and plugins within
   a running Python session (for example, on Google Colab), and avoid the need to
   restart the kernel/runtime.
+  [(#907)](https://github.com/PennyLaneAI/pennylane/pull/907)
 
 <h3>Breaking changes</h3>
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -225,6 +225,13 @@
   - `qnn.KerasLayer` [(#869)](https://github.com/PennyLaneAI/pennylane/pull/869)
   - `qnn.TorchLayer` [(#865)](https://github.com/PennyLaneAI/pennylane/pull/865)
 
+* A new function, ``qml.refresh_devices()``, has been added, allowing PennyLane to
+  rescan installed PennyLane plugins and refresh the device list. In addition, the ``qml.device``
+  loader will attempt to refresh devices if the required plugin device cannot be found.
+  This will result in an improved experience if installing PennyLane and plugins within
+  a running Python session (for example, on Google Colab), and avoid the need to
+  restart the kernel/runtime.
+
 <h3>Breaking changes</h3>
 
 <h3>Documentation</h3>

--- a/doc/code/qml.rst
+++ b/doc/code/qml.rst
@@ -6,4 +6,4 @@ qml
 .. automodapi:: pennylane
     :no-heading:
     :include-all-objects:
-    :skip: iter_entry_points, Version, Spec, plugin_devices, plugin_converters, default_config
+    :skip: iter_entry_points, Version, Spec, plugin_devices, plugin_converters, default_config, reload

--- a/pennylane/__init__.py
+++ b/pennylane/__init__.py
@@ -70,7 +70,7 @@ def refresh_devices():
     # which is to update the global plugin_devices variable.
 
     # We wish to retain the behaviour of a global plugin_devices dictionary,
-    # as importing pkg_resources can be a very slow operation on systems
+    # as re-importing pkg_resources can be a very slow operation on systems
     # with a large number of installed packages.
     global plugin_devices  # pylint:disable=global-statement
 

--- a/pennylane/__init__.py
+++ b/pennylane/__init__.py
@@ -65,7 +65,15 @@ def _get_device_entrypoints():
 
 def refresh_devices():
     """Scan installed PennyLane plugins to refresh the device list."""
-    global plugin_devices
+
+    # This function does not return anything; instead, it has a side effect
+    # which is to update the global plugin_devices variable.
+
+    # We wish to retain the behaviour of a global plugin_devices dictionary,
+    # as importing pkg_resources can be a very slow operation on systems
+    # with a large number of installed packages.
+    global plugin_devices  # pylint:disable=global-statement
+
     reload(pkg_resources)
     plugin_devices = _get_device_entrypoints()
 

--- a/pennylane/__init__.py
+++ b/pennylane/__init__.py
@@ -57,19 +57,21 @@ from .tape import enable_tape, disable_tape, tape_mode_active
 default_config = Configuration("config.toml")
 
 
-# get list of installed devices
-plugin_devices = {
-    entry.name: entry for entry in pkg_resources.iter_entry_points("pennylane.plugins")
-}
+def _get_device_entrypoints():
+    """Returns a dictionary mapping the device short name to the
+    loadable entrypoint"""
+    return {entry.name: entry for entry in pkg_resources.iter_entry_points("pennylane.plugins")}
 
 
 def refresh_devices():
     """Scan installed PennyLane plugins to refresh the device list."""
     global plugin_devices
     reload(pkg_resources)
-    plugin_devices = {
-        entry.name: entry for entry in pkg_resources.iter_entry_points("pennylane.plugins")
-    }
+    plugin_devices = _get_device_entrypoints()
+
+
+# get list of installed devices
+plugin_devices = _get_device_entrypoints()
 
 
 # get chemistry plugin

--- a/pennylane/__init__.py
+++ b/pennylane/__init__.py
@@ -15,8 +15,6 @@
 This is the top level module from which all basic functions and classes of
 PennyLane can be directly imported.
 """
-import pkg_resources
-
 import numpy as _np
 from autograd import grad as _grad
 from autograd import jacobian as _jacobian
@@ -51,6 +49,8 @@ from .io import *
 import pennylane.proc  # pylint: disable=wrong-import-order
 import pennylane.tape  # pylint: disable=wrong-import-order
 from .tape import enable_tape, disable_tape, tape_mode_active
+
+import pkg_resources  # pylint: disable=wrong-import-order
 
 # Look for an existing configuration file
 default_config = Configuration("config.toml")

--- a/pennylane/__init__.py
+++ b/pennylane/__init__.py
@@ -15,6 +15,9 @@
 This is the top level module from which all basic functions and classes of
 PennyLane can be directly imported.
 """
+from importlib import reload
+import pkg_resources
+
 import numpy as _np
 from autograd import grad as _grad
 from autograd import jacobian as _jacobian
@@ -50,16 +53,8 @@ import pennylane.proc  # pylint: disable=wrong-import-order
 import pennylane.tape  # pylint: disable=wrong-import-order
 from .tape import enable_tape, disable_tape, tape_mode_active
 
-import pkg_resources  # pylint: disable=wrong-import-order
-
 # Look for an existing configuration file
 default_config = Configuration("config.toml")
-
-
-# get list of installed devices
-plugin_devices = {
-    entry.name: entry for entry in pkg_resources.iter_entry_points("pennylane.plugins")
-}
 
 
 # get chemistry plugin
@@ -167,6 +162,13 @@ def device(name, *args, **kwargs):
         config (pennylane.Configuration): a PennyLane configuration object
             that contains global and/or device specific configurations.
     """
+    reload(pkg_resources)
+
+    # get list of installed devices
+    plugin_devices = {
+        entry.name: entry for entry in pkg_resources.iter_entry_points("pennylane.plugins")
+    }
+
     if name in plugin_devices:
         options = {}
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -21,7 +21,7 @@ import pytest
 import numpy as np
 import pennylane as qml
 from pennylane import Device, DeviceError
-from pennylane.qnodes import QuantumFunctionError 
+from pennylane.qnodes import QuantumFunctionError
 from pennylane.qnodes.base import BaseQNode
 from pennylane.wires import Wires
 from collections import OrderedDict
@@ -726,11 +726,13 @@ class TestDeviceInit:
 
     def test_refresh_entrypoints(self, monkeypatch):
         """Test that new entrypoints are found by the refresh_devices function"""
+        assert qml.plugin_devices
 
         with monkeypatch.context() as m:
             # remove all entry points
             m.setattr(pkg_resources, "iter_entry_points", lambda name: [])
 
+            # reimporting PennyLane within the context sets qml.plugin_devices to {}
             importlib.reload(qml)
 
             # since there are no entry points, there will be no plugin devices
@@ -741,17 +743,22 @@ class TestDeviceInit:
         qml.refresh_devices()
         assert qml.plugin_devices
 
+        # Test teardown: re-import PennyLane to revert all changes and
+        # restore the plugin_device dictionary
         importlib.reload(qml)
 
     def test_hot_refresh_entrypoints(self, monkeypatch):
         """Test that new entrypoints are found by the device loader if not currently present"""
+        assert qml.plugin_devices
 
         with monkeypatch.context() as m:
             # remove all entry points
             m.setattr(pkg_resources, "iter_entry_points", lambda name: [])
-            importlib.reload(qml)
-            m.setattr(qml, "refresh_devices", lambda: None)
 
+            # reimporting PennyLane within the context sets qml.plugin_devices to {}
+            importlib.reload(qml)
+
+            m.setattr(qml, "refresh_devices", lambda: None)
             assert not qml.plugin_devices
 
             # since there are no entry points, there will be no plugin devices
@@ -764,6 +771,8 @@ class TestDeviceInit:
         assert qml.plugin_devices
         assert dev.short_name == "default.qubit"
 
+        # Test teardown: re-import PennyLane to revert all changes and
+        # restore the plugin_device dictionary
         importlib.reload(qml)
 
 


### PR DESCRIPTION
**Context:**

PennyLane uses Python [entrypoints](https://packaging.python.org/specifications/entry-points/) to load available plugin devices. To do so, we must import and query the `pkg_resources` built-in library.

However, `pkg_resources` loads all data _on import_, not when extracting entrypoints, which means that any existing Python sessions need to be restarted for newly installed plugins to be made available. This particular impacts users that are installing PennyLane and plugins on [Google Colab](https://colab.research.google.com/), as the error message returned ("Device does not exist!") does not indicate the required action, namely, restarting the runtime.

**Description of the Change:**

* A new function, `qml.refresh_devices()`, has been added, allowing PennyLane to rescan installed PennyLane plugins and refresh the device list. This works by using `importlib.reload` to dynamically reload the `pkg_resource` library.

* In addition, the `qml.device` loader will attempt to refresh devices if the required plugin device cannot be found.

**Benefits:**

* This will result in an improved experience if installing PennyLane and plugins within a running Python session (for example, on Google Colab), and avoid the need to restart the kernel/runtime. **Note, however, that this is _not_ a fix, as this is fundamental Python behaviour. This is instead a workaround.**

See the following example on Colab:

![image](https://user-images.githubusercontent.com/2959003/99370710-fc9bc700-28f8-11eb-9e2b-5ba09951ba39.png)

Please test this out if possible :)

**Possible Drawbacks:**

* Since `pkg_resources` loads all package data on runtime, there can be a non-negligible and very noticeable import time if a lot of packages are installed (on the order of seconds). The user might notice this if the hot refresh is triggered (e.g., by the device not being found).

**Related GitHub Issues:** n/a
