### PR TITLE
Support returning the metric tensor of ExpvalCost in tape mode

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -261,7 +261,7 @@
 * Support for tape mode has improved across PennyLane. The following features now work in tape mode:
 
   - QNode collections [(#863)](https://github.com/PennyLaneAI/pennylane/pull/863)
-  - `ExpvalCost` [(#863)](https://github.com/PennyLaneAI/pennylane/pull/863) and [(#911)](https://github.com/PennyLaneAI/pennylane/pull/911)
+  - `ExpvalCost` [(#863)](https://github.com/PennyLaneAI/pennylane/pull/863) [(#911)](https://github.com/PennyLaneAI/pennylane/pull/911)
   - `qnn.KerasLayer` [(#869)](https://github.com/PennyLaneAI/pennylane/pull/869)
   - `qnn.TorchLayer` [(#865)](https://github.com/PennyLaneAI/pennylane/pull/865)
   - `qaoa` module [(#905)](https://github.com/PennyLaneAI/pennylane/pull/905)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -261,7 +261,7 @@
 * Support for tape mode has improved across PennyLane. The following features now work in tape mode:
 
   - QNode collections [(#863)](https://github.com/PennyLaneAI/pennylane/pull/863)
-  - `VQECost` [(#863)](https://github.com/PennyLaneAI/pennylane/pull/863) and [(#911)](https://github.com/PennyLaneAI/pennylane/pull/911)
+  - `ExpvalCost` [(#863)](https://github.com/PennyLaneAI/pennylane/pull/863) and [(#911)](https://github.com/PennyLaneAI/pennylane/pull/911)
   - `qnn.KerasLayer` [(#869)](https://github.com/PennyLaneAI/pennylane/pull/869)
   - `qnn.TorchLayer` [(#865)](https://github.com/PennyLaneAI/pennylane/pull/865)
   - `qaoa` module [(#905)](https://github.com/PennyLaneAI/pennylane/pull/905)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -261,7 +261,7 @@
 * Support for tape mode has improved across PennyLane. The following features now work in tape mode:
 
   - QNode collections [(#863)](https://github.com/PennyLaneAI/pennylane/pull/863)
-  - `VQECost` [(#863)](https://github.com/PennyLaneAI/pennylane/pull/863)
+  - `VQECost` [(#863)](https://github.com/PennyLaneAI/pennylane/pull/863) and [(#911)](https://github.com/PennyLaneAI/pennylane/pull/911)
   - `qnn.KerasLayer` [(#869)](https://github.com/PennyLaneAI/pennylane/pull/869)
   - `qnn.TorchLayer` [(#865)](https://github.com/PennyLaneAI/pennylane/pull/865)
   - `qaoa` module [(#905)](https://github.com/PennyLaneAI/pennylane/pull/905)

--- a/pennylane/qnodes/base.py
+++ b/pennylane/qnodes/base.py
@@ -581,7 +581,7 @@ class BaseQNode(qml.QueuingContext):
             qml.disable_tape()
 
         try:
-        # set up the context for Operator entry
+            # set up the context for Operator entry
             with self:
                 try:
                     # generate the program queue by executing the quantum circuit function

--- a/pennylane/qnodes/base.py
+++ b/pennylane/qnodes/base.py
@@ -576,22 +576,32 @@ class BaseQNode(qml.QueuingContext):
         self.queue = []  #: list[Operation]: applied operations
         self.obs_queue = []  #: list[Observable]: applied observables
 
+        tape_mode = qml.tape_mode_active()
+        if tape_mode:
+            qml.disable_tape()
+
+        try:
         # set up the context for Operator entry
-        with self:
-            try:
-                # generate the program queue by executing the quantum circuit function
-                if self.mutable:
-                    # it's ok to directly pass auxiliary arguments since the circuit is re-constructed each time
-                    # (positional args must be replaced because parameter-shift differentiation requires Variables)
-                    res = self.func(*self.arg_vars, **kwargs)
-                else:
-                    # TODO: Maybe we should only convert the kwarg_vars that were actually given
-                    res = self.func(*self.arg_vars, **self.kwarg_vars)
-            except:
-                # The qfunc call may have failed because the user supplied bad parameters, which is why we must wipe the created Variables.
-                self.arg_vars = None
-                self.kwarg_vars = None
-                raise
+            with self:
+                try:
+                    # generate the program queue by executing the quantum circuit function
+                    if self.mutable:
+                        # it's ok to directly pass auxiliary arguments since the circuit is
+                        # re-constructed each time (positional args must be replaced because
+                        # parameter-shift differentiation requires Variables)
+                        res = self.func(*self.arg_vars, **kwargs)
+                    else:
+                        # TODO: Maybe we should only convert the kwarg_vars that were actually given
+                        res = self.func(*self.arg_vars, **self.kwarg_vars)
+                except:
+                    # The qfunc call may have failed because the user supplied bad parameters,
+                    # which is why we must wipe the created Variables.
+                    self.arg_vars = None
+                    self.kwarg_vars = None
+                    raise
+        finally:
+            if tape_mode:
+                qml.enable_tape()
 
         # check the validity of the circuit
         self._check_circuit(res)

--- a/pennylane/vqe/vqe.py
+++ b/pennylane/vqe/vqe.py
@@ -477,13 +477,13 @@ class ExpvalCost:
             try:
                 qml.disable_tape()
                 @qml.qnode(device, interface=interface, diff_method=diff_method, **kwargs)
-                def qnode_for_metric_tensor_in_tape_mode(*qnode_args, _wires=wires, **qnode_kwargs):
+                def qnode_for_metric_tensor_in_tape_mode(*qnode_args, **qnode_kwargs):
                     """The metric tensor cannot currently be calculated in tape-mode QNodes. As a
                     short-term fix for VQECost, we create a non-tape mode QNode just for
                     calculation of the metric tensor. In doing so, we reintroduce the same
                     restrictions of the old QNode but allow users to access new functionality
                     such as measurement grouping and batch execution of the gradient."""
-                    ansatz(*qnode_args, wires=_wires, **qnode_kwargs)
+                    ansatz(*qnode_args, wires=wires, **qnode_kwargs)
                     return qml.expval(qml.PauliZ(0))
                 self._qnode_for_metric_tensor_in_tape_mode = qnode_for_metric_tensor_in_tape_mode
             finally:

--- a/pennylane/vqe/vqe.py
+++ b/pennylane/vqe/vqe.py
@@ -562,6 +562,6 @@ class VQECost(ExpvalCost):
     def __init__(self, *args, **kwargs):
         warnings.warn(
             "Use of VQECost is deprecated and should be replaced with ExpvalCost",
-            DeprecationWarning,
+            DeprecationWarning, 2
         )
         super().__init__(*args, **kwargs)

--- a/pennylane/vqe/vqe.py
+++ b/pennylane/vqe/vqe.py
@@ -476,6 +476,7 @@ class ExpvalCost:
         if tape_mode:
             try:
                 qml.disable_tape()
+
                 @qml.qnode(device, interface=interface, diff_method=diff_method, **kwargs)
                 def qnode_for_metric_tensor_in_tape_mode(*qnode_args, **qnode_kwargs):
                     """The metric tensor cannot currently be calculated in tape-mode QNodes. As a
@@ -485,6 +486,7 @@ class ExpvalCost:
                     such as measurement grouping and batch execution of the gradient."""
                     ansatz(*qnode_args, wires=wires, **qnode_kwargs)
                     return qml.expval(qml.PauliZ(0))
+
                 self._qnode_for_metric_tensor_in_tape_mode = qnode_for_metric_tensor_in_tape_mode
             finally:
                 qml.enable_tape()
@@ -562,6 +564,7 @@ class VQECost(ExpvalCost):
     def __init__(self, *args, **kwargs):
         warnings.warn(
             "Use of VQECost is deprecated and should be replaced with ExpvalCost",
-            DeprecationWarning, 2
+            DeprecationWarning,
+            2,
         )
         super().__init__(*args, **kwargs)

--- a/pennylane/vqe/vqe.py
+++ b/pennylane/vqe/vqe.py
@@ -479,7 +479,7 @@ class ExpvalCost:
                 @qml.qnode(device, interface=interface, diff_method=diff_method, **kwargs)
                 def qnode_for_metric_tensor_in_tape_mode(*qnode_args, **qnode_kwargs):
                     """The metric tensor cannot currently be calculated in tape-mode QNodes. As a
-                    short-term fix for VQECost, we create a non-tape mode QNode just for
+                    short-term fix for ExpvalCost, we create a non-tape mode QNode just for
                     calculation of the metric tensor. In doing so, we reintroduce the same
                     restrictions of the old QNode but allow users to access new functionality
                     such as measurement grouping and batch execution of the gradient."""

--- a/tests/qnodes/test_qnode_base.py
+++ b/tests/qnodes/test_qnode_base.py
@@ -1500,3 +1500,29 @@ class TestTrainableArgs:
         # the user will evaluate the QNode with.
         node.set_trainable_args({0, 1, 6})
         assert node.get_trainable_args() == {0, 1, 6}
+
+
+def test_old_qnode_in_tape_mode():
+    """Test that the old QNode can still be evaluated when running in tape mode"""
+
+    # tape mode should not be active so that we can use the old QNode
+    assert not qml.tape_mode_active()
+
+    try:
+        dev = qml.device("default.qubit", wires=2)
+
+        @qml.qnode(dev)
+        def f(x):
+            qml.RX(x, wires=0)
+            qml.RY(0.4, wires=1)
+            qml.CNOT(wires=[0, 1])
+            return qml.expval(qml.PauliZ(0))
+
+        qml.enable_tape()
+        f(0.4)
+
+        # check that tape mode is turned on again after evaluating the old QNode
+        assert qml.tape_mode_active()
+
+    finally:  # always make sure we turn off tape mode to prevent disrupting the other tests
+        qml.disable_tape()

--- a/tests/qnodes/test_qnode_base.py
+++ b/tests/qnodes/test_qnode_base.py
@@ -1519,7 +1519,10 @@ def test_old_qnode_in_tape_mode():
             return qml.expval(qml.PauliZ(0))
 
         qml.enable_tape()
-        f(0.4)
+        res = f(0.4)
+        exp = 0.9210609940028851
+
+        assert np.allclose(res, exp)
 
         # check that tape mode is turned on again after evaluating the old QNode
         assert qml.tape_mode_active()

--- a/tests/test_vqe.py
+++ b/tests/test_vqe.py
@@ -851,17 +851,56 @@ class TestVQE:
 
     def test_metric_tensor_tape_mode(self):
         """Test that an error is raised if the metric tensor is requested in optimize=True mode."""
-        if not qml.tape_mode_active():
+        # if not not qml.tape_mode_active():
+        #     pytest.skip("This test is only intended for tape mode")
+
+        # dev = qml.device("default.qubit", wires=4)
+        # hamiltonian = big_hamiltonian
+        #
+        # def ansatz(a, b, c, d):
+        #     qml.RX(a, wires=0)
+        #     qml.RX(b, wires=0)
+        #     qml.RX(c, wires=0)
+        #     qml.RX(d, wires=0)
+        #
+        # cost = qml.ExpvalCost(ansatz, hamiltonian, dev)
+        #
+        # args = qml.init.strong_ent_layers_uniform(2, 4, seed=1967)
+        # cost.metric_tensor([1, 2, 3, 4], only_construct=True)
+
+        if not not qml.tape_mode_active():
             pytest.skip("This test is only intended for tape mode")
 
-        dev = qml.device("default.qubit", wires=4)
-        hamiltonian = big_hamiltonian
+        def my_template(params, wires, **kwargs):
+            qml.RX(params[0], wires=wires[0])
+            qml.RX(params[1], wires=wires[1])
+            qml.CNOT(wires=wires)
 
-        cost = qml.ExpvalCost(qml.templates.StronglyEntanglingLayers, hamiltonian, dev, optimize=True)
+        obs_list = [qml.PauliX(0) @ qml.PauliZ(1), qml.PauliZ(0) @ qml.PauliX(1)]
 
-        args = qml.init.strong_ent_layers_uniform(2, 4)
-        cost.metric_tensor(args)
+        dev = qml.device("default.qubit", wires=2)
+        qnodes = qml.map(my_template, obs_list, dev, measure="expval")
 
+        params = [0.54, 0.12]
+        print(qnodes(params))
+        print(qnodes[0](params))
+        print(qnodes[0].metric_tensor(params))
+
+
+
+        # dev = qml.device("default.qubit", wires=2)
+        # assert not qml.tape_mode_active()
+        #
+        # def ansatz(a, b, wires):
+        #     qml.RX(a, wires=0)
+        #     qml.RX(b, wires=1)
+        #     qml.CNOT(wires=[0, 1])
+        #
+        # qnode = qml.map(ansatz, [qml.PauliZ(0) @ qml.PauliZ(1)], dev)
+        #
+        # # mt = qnode[0].metric_tensor([1, 2])
+        # # print(mt)
+        # print(qnode(0.1, 0.2))
 
 @pytest.mark.usefixtures("tape_mode")
 class TestAutogradInterface:

--- a/tests/test_vqe.py
+++ b/tests/test_vqe.py
@@ -849,7 +849,7 @@ class TestVQE:
 
         assert np.allclose(dc, big_hamiltonian_grad)
 
-    def test_metric_tensor(self):
+    def test_metric_tensor_tape_mode(self):
         """Test that an error is raised if the metric tensor is requested in optimize=True mode."""
         if not qml.tape_mode_active():
             pytest.skip("This test is only intended for tape mode")
@@ -859,8 +859,8 @@ class TestVQE:
 
         cost = qml.VQECost(qml.templates.StronglyEntanglingLayers, hamiltonian, dev, optimize=True)
 
-        with pytest.raises(ValueError, match="Evaluation of the metric tensor is not supported"):
-            cost.metric_tensor(None)
+        args = qml.init.strong_ent_layers_uniform(2, 4)
+        cost.metric_tensor(args)
 
 
 @pytest.mark.usefixtures("tape_mode")


### PR DESCRIPTION
This PR provides support for returning the metric tensor in ExpvalCost.

Calculating metric tensors are not supported in general in tape mode, so as a short term fix, this PR creates a non-tape mode QNode. That QNode is then used for evaluation of the metric tensor. This adds back the restrictions we had in the old QNode (e.g., no in-QNode processing, restrictions on qnode signature), but allows the QNG optimizer to have some compatibility with tape mode.

A long term fix is to provide metric tensor evaluation in tape mode QNodes.