### PR TITLE
Define the generator for the MultiRZ operation

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -86,9 +86,12 @@
 
 <h3>Improvements</h3>
 
+* The MultiRZ gate now has a defined generator.
+  [(#912)](https://github.com/PennyLaneAI/pennylane/pull/912)
+
 * The CRot gate now has a ``decomposition`` method, which breaks the gate down into rotations
   and CNOT gates. This allows ``CRot`` to be used on devices that do not natively support it.
-  [(#908)](https://github.com/PennyLaneAI/pennylane/pull/908) 
+  [(#908)](https://github.com/PennyLaneAI/pennylane/pull/908)
 
 * QNodes in tape mode now support returning observables on the same wire if the observables are
   qubit-wise commuting Pauli words. Qubit-wise commuting observables can be evaluated with a

--- a/pennylane/ops/qubit.py
+++ b/pennylane/ops/qubit.py
@@ -825,6 +825,10 @@ class MultiRZ(DiagonalOperation):
         return multi_Z_rot_matrix
 
     @property
+    def generator(self):
+        return [np.diag(pauli_eigs(len(self.wires))), -1/2]
+
+    @property
     def matrix(self):
         # Redefine the property here to pass additionally the number of wires to the ``_matrix`` method
         if self.inverse:

--- a/pennylane/ops/qubit.py
+++ b/pennylane/ops/qubit.py
@@ -829,7 +829,7 @@ class MultiRZ(DiagonalOperation):
     @property
     def generator(self):
         if self._generator is None:
-            self._generator = [np.diag(pauli_eigs(len(self.wires))), -1/2]
+            self._generator = [np.diag(pauli_eigs(len(self.wires))), -1 / 2]
         return self._generator
 
     @property

--- a/pennylane/ops/qubit.py
+++ b/pennylane/ops/qubit.py
@@ -824,9 +824,13 @@ class MultiRZ(DiagonalOperation):
 
         return multi_Z_rot_matrix
 
+    _generator = None
+
     @property
     def generator(self):
-        return [np.diag(pauli_eigs(len(self.wires))), -1/2]
+        if self._generator is None:
+            self._generator = [np.diag(pauli_eigs(len(self.wires))), -1/2]
+        return self._generator
 
     @property
     def matrix(self):

--- a/tests/ops/test_qubit_ops.py
+++ b/tests/ops/test_qubit_ops.py
@@ -1157,6 +1157,26 @@ class TestMultiRZ:
             np.squeeze(decomp_circuit.jacobian(angle)), abs=tol
         )
 
+    @pytest.mark.parametrize("qubits", range(3, 6))
+    def test_multirz_generator(self, qubits, mocker):
+        """Test that the generator of the MultiRZ gate is correct."""
+        op = qml.MultiRZ(0.3, wires=range(qubits))
+        gen = op.generator
+
+        expected_gen = qml.PauliZ(wires=0)
+        for i in range(1, qubits):
+            expected_gen = expected_gen @ qml.PauliZ(wires=i)
+
+        expected_gen_mat = expected_gen.matrix
+
+        assert np.allclose(gen[0], expected_gen_mat)
+        assert gen[1] == -0.5
+
+        spy = mocker.spy(qml.utils, "pauli_eigs")
+
+        op.generator
+        spy.assert_not_called()
+
 
 class TestDiagonalQubitUnitary:
     """Test the DiagonalQubitUnitary operation."""


### PR DESCRIPTION
**Context:**

* For the metric tensor computation, all parametrized gates must provide their generator. If a gate does not provide its generator, the metric tensor computation will raise an error.

* The `qml.MultiRZ` gate allows us to very efficiently implement `exp(-i θ Z ⊗ Z ⊗ ... ⊗  Z/2)` on simulator devices, since it is a diagonal in the computational basis. However, if a device does not support `qml.MultiRZ`, the operation on `N` wires simply gets decomposed into `2N-2` CNOTs and a single RZ.

* `qml.MultiRZ` does not provide a generator. Therefore, when using the `QNGOptimizer`, one of two things could happen:

  1. The device supports `MultiRZ` natively: QNG optimization will fail since the generator is unknown
  2. The device does not support `MultiRZ` natively: QNG optimization will work, since the decomposition results in an `RZ` gate, which *does* have its generator defined.
 
**Description of the Change:**

* Defines the generator of the `MultiRZ` gate as a diagonal numeric matrix.

**Benefits:**

* Circuits which contain `qml.MultiRZ` can now be used with QNG optimization, regardless of whether the device natively supports it or not.

**Possible Drawbacks:**

* Since the generator is numeric, if `MultiRZ` is applied to N qubits, a `2**N` matrix for the generator will be created. This obviously scales **really** badly. It would probably be better on `default.qubit` to simply force decomposition of the `MultiRZ` gate, rather than use this fix.

In fact, the entire metric tensor code is quite old and due for a re-write. In particular, we should:

* Have all operations provide Hamiltonians of Pauli operators as generators, and avoid numeric matrices

* For each block diagonal of the metric tensor, the diagonalization should be done systematically using the `qml.grouping` module, rather than numerically.

**Related GitHub Issues:** n/a
