### PR TITLE
Rename VQECost to ExpvalCost

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 <h3>New features since last release</h3>
 
-* The ``VQECost`` class now provides observable optimization using the ``optimize`` argument,
-  resulting in potentially fewer device executions.
+* The ``ExpvalCost`` class (previously ``VQECost``) now provides observable optimization using the
+  ``optimize`` argument, resulting in potentially fewer device executions.
   [(#902)](https://github.com/PennyLaneAI/pennylane/pull/902)
   
   This is achieved by separating the observables composing the Hamiltonian into qubit-wise
@@ -753,7 +753,7 @@ Schuld, Antal Száva.
       qml.layer(qaoa_layer, 2, params[0], params[1])
 
   dev = qml.device('default.qubit', wires=len(wires))
-  cost_function = qml.ExpvalCost(ansatz, cost_h, dev)
+  cost_function = qml.VQECost(ansatz, cost_h, dev)
   ```
 
 * Added an `ApproxTimeEvolution` template to the PennyLane templates module, which
@@ -1551,7 +1551,7 @@ Ville Bergholm, Josh Izaac, Johannes Jakob Meyer, Maria Schuld, Antal Száva.
 
     ```python
     >>> H = qml.vqe.Hamiltonian(coeffs, obs)
-    >>> cost = qml.ExpvalCost(ansatz, hamiltonian, dev, interface="torch")
+    >>> cost = qml.VQECost(ansatz, hamiltonian, dev, interface="torch")
     >>> params = torch.rand([4, 3])
     >>> cost(params)
     tensor(0.0245, dtype=torch.float64)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -276,6 +276,10 @@
 
 <h3>Breaking changes</h3>
 
+- The ``VQECost`` class has been renamed to ``ExpvalCost`` to reflect its general applicability
+  beyond VQE. Use of ``VQECost`` is still possible but will result in a deprecation warning.
+  [(#907)](https://github.com/PennyLaneAI/pennylane/pull/907)
+
 <h3>Documentation</h3>
 
 <h3>Bug fixes</h3>

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -18,8 +18,8 @@
   dev = qml.device("default.qubit", wires=2)
   ansatz = qml.templates.StronglyEntanglingLayers
 
-  cost_opt = qml.VQECost(ansatz, H, dev, optimize=True)
-  cost_no_opt = qml.VQECost(ansatz, H, dev, optimize=False)
+  cost_opt = qml.ExpvalCost(ansatz, H, dev, optimize=True)
+  cost_no_opt = qml.ExpvalCost(ansatz, H, dev, optimize=False)
 
   params = qml.init.strong_ent_layers_uniform(3, 2)
   ```
@@ -749,7 +749,7 @@ Schuld, Antal Száva.
       qml.layer(qaoa_layer, 2, params[0], params[1])
 
   dev = qml.device('default.qubit', wires=len(wires))
-  cost_function = qml.VQECost(ansatz, cost_h, dev)
+  cost_function = qml.ExpvalCost(ansatz, cost_h, dev)
   ```
 
 * Added an `ApproxTimeEvolution` template to the PennyLane templates module, which
@@ -1547,7 +1547,7 @@ Ville Bergholm, Josh Izaac, Johannes Jakob Meyer, Maria Schuld, Antal Száva.
 
     ```python
     >>> H = qml.vqe.Hamiltonian(coeffs, obs)
-    >>> cost = qml.VQECost(ansatz, hamiltonian, dev, interface="torch")
+    >>> cost = qml.ExpvalCost(ansatz, hamiltonian, dev, interface="torch")
     >>> params = torch.rand([4, 3])
     >>> cost(params)
     tensor(0.0245, dtype=torch.float64)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -278,7 +278,7 @@
 
 - The ``VQECost`` class has been renamed to ``ExpvalCost`` to reflect its general applicability
   beyond VQE. Use of ``VQECost`` is still possible but will result in a deprecation warning.
-  [(#907)](https://github.com/PennyLaneAI/pennylane/pull/907)
+  [(#913)](https://github.com/PennyLaneAI/pennylane/pull/913)
 
 <h3>Documentation</h3>
 

--- a/doc/code/qml.rst
+++ b/doc/code/qml.rst
@@ -6,4 +6,4 @@ qml
 .. automodapi:: pennylane
     :no-heading:
     :include-all-objects:
-    :skip: iter_entry_points, Version, Spec, plugin_devices, plugin_converters, default_config, reload
+    :skip: iter_entry_points, Version, Spec, plugin_devices, plugin_converters, default_config, reload, VQECost

--- a/doc/code/qml.rst
+++ b/doc/code/qml.rst
@@ -6,4 +6,4 @@ qml
 .. automodapi:: pennylane
     :no-heading:
     :include-all-objects:
-    :skip: iter_entry_points, Version, Spec, plugin_devices, plugin_converters, default_config, reload, VQECost
+    :skip: iter_entry_points, Version, Spec, plugin_devices, plugin_converters, default_config, reload

--- a/doc/code/qml_qaoa.rst
+++ b/doc/code/qml_qaoa.rst
@@ -51,7 +51,7 @@ computational basis states, and then repeatedly apply QAOA layers with the
 
         qml.layer(qaoa_layer, 2, params[0], params[1])
 
-With the circuit defined, we call the device on which QAOA will be executed, as well as the ``qml.VQECost``, which
+With the circuit defined, we call the device on which QAOA will be executed, as well as the ``qml.ExpvalCost``, which
 creates the QAOA cost function: the expected value of the cost Hamiltonian with respect to the parametrized output
 of the QAOA circuit.
 
@@ -59,7 +59,7 @@ of the QAOA circuit.
 
     # Defines the device and the QAOA cost function
     dev = qml.device('default.qubit', wires=len(wires))
-    cost_function = qml.VQECost(circuit, cost_h, dev)
+    cost_function = qml.ExpvalCost(circuit, cost_h, dev)
 
 >>> print(cost_function([[1, 1], [1, 1]]))
 -1.8260274380964299

--- a/doc/introduction/chemistry.rst
+++ b/doc/introduction/chemistry.rst
@@ -158,7 +158,7 @@ where a quantum computer is used to prepare the trial wave function of a molecul
 the expectation value of the *electronic Hamiltonian*, while a classical optimizer is used to
 find its ground state.
 
-We can use :class:`~.VQECost` to automatically create the required PennyLane QNodes and define 
+We can use :class:`~.ExpvalCost` to automatically create the required PennyLane QNodes and define
 the cost function:
 
 .. code-block:: python
@@ -175,7 +175,7 @@ the cost function:
         qml.CNOT(wires=[2, 0])
         qml.CNOT(wires=[3, 1])
 
-    cost = qml.VQECost(circuit, hamiltonian, dev, interface="torch")
+    cost = qml.ExpvalCost(circuit, hamiltonian, dev, interface="torch")
     params = torch.rand([4, 3])
     cost(params)
 

--- a/pennylane/__init__.py
+++ b/pennylane/__init__.py
@@ -34,7 +34,7 @@ import pennylane.qnn
 import pennylane.qaoa as qaoa
 from pennylane.templates import template, broadcast, layer
 from pennylane.about import about
-from pennylane.vqe import Hamiltonian, ExpvalCost
+from pennylane.vqe import Hamiltonian, ExpvalCost, VQECost
 
 from .circuit_graph import CircuitGraph
 from .configuration import Configuration

--- a/pennylane/__init__.py
+++ b/pennylane/__init__.py
@@ -34,7 +34,7 @@ import pennylane.qnn
 import pennylane.qaoa as qaoa
 from pennylane.templates import template, broadcast, layer
 from pennylane.about import about
-from pennylane.vqe import Hamiltonian, VQECost
+from pennylane.vqe import Hamiltonian, ExpvalCost
 
 from .circuit_graph import CircuitGraph
 from .configuration import Configuration

--- a/pennylane/optimize/qng.py
+++ b/pennylane/optimize/qng.py
@@ -73,7 +73,7 @@ class QNGOptimizer(GradientDescentOptimizer):
 
     .. note::
 
-        The QNG optimizer supports single QNodes or :class:`~.VQECost` objects as objective functions.
+        The QNG optimizer supports single QNodes or :class:`~.ExpvalCost` objects as objective functions.
         Alternatively, the metric tensor can directly be provided to the :func:`step` method of the optimizer,
         using the ``metric_tensor_fn`` argument.
 
@@ -91,7 +91,7 @@ class QNGOptimizer(GradientDescentOptimizer):
         If the objective function is VQE/VQE-like, i.e., a function of a group
         of QNodes that share an ansatz, there are two ways to use the optimizer:
 
-        * Realize the objective function as a :class:`~.VQECost` object, which has
+        * Realize the objective function as a :class:`~.ExpvalCost` object, which has
           a ``metric_tensor`` method.
 
         * Manually provide the ``metric_tensor_fn`` corresponding to the metric tensor of
@@ -100,7 +100,7 @@ class QNGOptimizer(GradientDescentOptimizer):
     **Examples:**
 
     For VQE/VQE-like problems, the objective function for the optimizer can be
-    realized as a VQECost object.
+    realized as an ExpvalCost object.
 
     >>> dev = qml.device("default.qubit", wires=1)
     >>> def circuit(params, wires=0):
@@ -109,7 +109,7 @@ class QNGOptimizer(GradientDescentOptimizer):
     >>> coeffs = [1, 1]
     >>> obs = [qml.PauliX(0), qml.PauliZ(0)]
     >>> H = qml.Hamiltonian(coeffs, obs)
-    >>> cost_fn = qml.VQECost(circuit, H, dev)
+    >>> cost_fn = qml.ExpvalCost(circuit, H, dev)
 
     Once constructed, the cost function can be passed directly to the
     optimizer's ``step`` function:
@@ -174,7 +174,7 @@ class QNGOptimizer(GradientDescentOptimizer):
         if not hasattr(qnode, "metric_tensor") and not metric_tensor_fn:
             raise ValueError(
                 "The objective function must either be encoded as a single QNode or "
-                "a VQECost object for the natural gradient to be automatically computed. "
+                "a ExpvalCost object for the natural gradient to be automatically computed. "
                 "Otherwise, metric_tensor_fn must be explicitly provided to the optimizer."
             )
 

--- a/pennylane/optimize/qng.py
+++ b/pennylane/optimize/qng.py
@@ -91,7 +91,7 @@ class QNGOptimizer(GradientDescentOptimizer):
         If the objective function is VQE/VQE-like, i.e., a function of a group
         of QNodes that share an ansatz, there are two ways to use the optimizer:
 
-        * Realize the objective function as a :class:`~.ExpvalCost` object, which has
+        * Realize the objective function as an :class:`~.ExpvalCost` object, which has
           a ``metric_tensor`` method.
 
         * Manually provide the ``metric_tensor_fn`` corresponding to the metric tensor of
@@ -174,7 +174,7 @@ class QNGOptimizer(GradientDescentOptimizer):
         if not hasattr(qnode, "metric_tensor") and not metric_tensor_fn:
             raise ValueError(
                 "The objective function must either be encoded as a single QNode or "
-                "a ExpvalCost object for the natural gradient to be automatically computed. "
+                "an ExpvalCost object for the natural gradient to be automatically computed. "
                 "Otherwise, metric_tensor_fn must be explicitly provided to the optimizer."
             )
 

--- a/pennylane/templates/layers/particle_conserving_u1.py
+++ b/pennylane/templates/layers/particle_conserving_u1.py
@@ -219,7 +219,7 @@ def ParticleConservingU1(weights, wires, init_state=None):
             ansatz = partial(ParticleConservingU1, init_state=ref_state)
 
             # Define the cost function
-            cost_fn = qml.VQECost(ansatz, h, dev)
+            cost_fn = qml.ExpvalCost(ansatz, h, dev)
 
             # Compute the expectation value of 'h'
             layers = 2

--- a/pennylane/templates/layers/particle_conserving_u2.py
+++ b/pennylane/templates/layers/particle_conserving_u2.py
@@ -140,7 +140,7 @@ def ParticleConservingU2(weights, wires, init_state=None):
             ansatz = partial(ParticleConservingU2, init_state=ref_state)
 
             # Define the cost function
-            cost_fn = qml.VQECost(ansatz, h, dev)
+            cost_fn = qml.ExpvalCost(ansatz, h, dev)
 
             # Compute the expectation value of 'h' for a given set of parameters
             layers = 1

--- a/pennylane/templates/subroutines/uccsd.py
+++ b/pennylane/templates/subroutines/uccsd.py
@@ -145,7 +145,7 @@ def UCCSD(weights, wires, s_wires=None, d_wires=None, init_state=None):
             ansatz = partial(UCCSD, init_state=ref_state, s_wires=s_wires, d_wires=d_wires)
 
             # Define the cost function
-            cost_fn = qml.VQECost(ansatz, h, dev)
+            cost_fn = qml.ExpvalCost(ansatz, h, dev)
 
             # Compute the expectation value of 'h' for given set of parameters 'params'
             params = np.random.normal(0, np.pi, len(singles) + len(doubles))

--- a/pennylane/utils.py
+++ b/pennylane/utils.py
@@ -68,7 +68,7 @@ def decompose_hamiltonian(H, hide_identity=False):
     + (-0.5) [Z0 X1]
     + (-0.5) [Z0 Y1]
 
-    This Hamiltonian can then be used in defining VQE problems using :class:`~.VQECost`.
+    This Hamiltonian can then be used in defining VQE problems using :class:`~.ExpvalCost`.
     """
     n = int(np.log2(len(H)))
     N = 2 ** n

--- a/pennylane/vqe/__init__.py
+++ b/pennylane/vqe/__init__.py
@@ -15,4 +15,4 @@
 This package contains functionality for running Variational Quantum Eigensolver (VQE)
 computations using PennyLane.
 """
-from .vqe import Hamiltonian, ExpvalCost
+from .vqe import Hamiltonian, ExpvalCost, VQECost

--- a/pennylane/vqe/__init__.py
+++ b/pennylane/vqe/__init__.py
@@ -15,4 +15,4 @@
 This package contains functionality for running Variational Quantum Eigensolver (VQE)
 computations using PennyLane.
 """
-from .vqe import Hamiltonian, VQECost
+from .vqe import Hamiltonian, ExpvalCost

--- a/pennylane/vqe/vqe.py
+++ b/pennylane/vqe/vqe.py
@@ -40,7 +40,7 @@ class Hamiltonian:
         simplify (bool): Specifies whether the Hamiltonian is simplified upon initialization
                          (like-terms are combined). The default value is `False`.
 
-    .. seealso:: :class:`~.VQECost`, :func:`~.generate_hamiltonian`
+    .. seealso:: :class:`~.ExpvalCost`, :func:`~.generate_hamiltonian`
 
     **Example:**
 
@@ -346,9 +346,10 @@ class Hamiltonian:
         raise ValueError(f"Cannot subtract {type(H)} from Hamiltonian")
 
 
-class VQECost:
-    """Create a VQE cost function, i.e., a cost function returning the
-    expectation value of a Hamiltonian.
+class ExpvalCost:
+    """Create a cost function that gives the expectation value of an input Hamiltonian.
+
+    This cost function is useful for a range of problems including VQE and QAOA.
 
     Args:
         ansatz (callable): The ansatz for the circuit before the final measurement step.
@@ -382,7 +383,7 @@ class VQECost:
 
     **Example:**
 
-    To construct a ``VQECost`` cost function, we require a Hamiltonian to measure, and an ansatz
+    To construct an ``ExpvalCost`` cost function, we require a Hamiltonian to measure, and an ansatz
     for our variational circuit.
 
     We can construct a Hamiltonian manually,
@@ -404,7 +405,7 @@ class VQECost:
 
     >>> ansatz = qml.templates.StronglyEntanglingLayers
     >>> dev = qml.device("default.qubit", wires=4)
-    >>> cost = qml.VQECost(ansatz, H, dev, interface="torch")
+    >>> cost = qml.ExpvalCost(ansatz, H, dev, interface="torch")
     >>> params = torch.rand([2, 4, 3])
     >>> cost(params)
     tensor(-0.2316, dtype=torch.float64)
@@ -430,8 +431,8 @@ class VQECost:
             dev = qml.device("default.qubit", wires=2)
             ansatz = qml.templates.StronglyEntanglingLayers
 
-            cost_opt = qml.VQECost(ansatz, H, dev, optimize=True)
-            cost_no_opt = qml.VQECost(ansatz, H, dev, optimize=False)
+            cost_opt = qml.ExpvalCost(ansatz, H, dev, optimize=True)
+            cost_no_opt = qml.ExpvalCost(ansatz, H, dev, optimize=False)
 
             params = qml.init.strong_ent_layers_uniform(3, 2)
 
@@ -462,7 +463,7 @@ class VQECost:
         coeffs, observables = hamiltonian.terms
 
         self.hamiltonian = hamiltonian
-        """Hamiltonian: the hamiltonian defining the VQE problem."""
+        """Hamiltonian: the input Hamiltonian."""
 
         self.qnodes = None
         """QNodeCollection: The QNodes to be evaluated. Each QNode corresponds to the expectation
@@ -527,7 +528,7 @@ class VQECost:
                 "optimized observables. Set the argument optimize=False to obtain "
                 "the metric tensor."
             )
-        # We know that for VQE, all the qnodes share the same ansatz so we select the first
+        # all the qnodes share the same ansatz so we select the first
         return self.qnodes.qnodes[0].metric_tensor(
             args=args, kwargs=kwargs, diag_approx=diag_approx, only_construct=only_construct
         )

--- a/pennylane/vqe/vqe.py
+++ b/pennylane/vqe/vqe.py
@@ -535,6 +535,8 @@ class ExpvalCost:
         )
 
 
+# This class is deprecated and does not appear in the documentation
+# pylint: disable=missing-class-docstring
 class VQECost(ExpvalCost):
     def __init__(self, *args, **kwargs):
         warnings.warn(

--- a/pennylane/vqe/vqe.py
+++ b/pennylane/vqe/vqe.py
@@ -17,6 +17,7 @@ computations using PennyLane.
 """
 # pylint: disable=too-many-arguments, too-few-public-methods
 import itertools
+import warnings
 
 import pennylane as qml
 from pennylane import numpy as np
@@ -532,3 +533,12 @@ class ExpvalCost:
         return self.qnodes.qnodes[0].metric_tensor(
             args=args, kwargs=kwargs, diag_approx=diag_approx, only_construct=only_construct
         )
+
+
+class VQECost(ExpvalCost):
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "Use of VQECost is deprecated and should be replaced with ExpvalCost",
+            DeprecationWarning,
+        )
+        super().__init__(*args, **kwargs)

--- a/pennylane/vqe/vqe.py
+++ b/pennylane/vqe/vqe.py
@@ -535,9 +535,14 @@ class ExpvalCost:
         )
 
 
-# This class is deprecated and does not appear in the documentation
-# pylint: disable=missing-class-docstring
 class VQECost(ExpvalCost):
+    """Create a cost function that gives the expectation value of an input Hamiltonian.
+
+    .. warning::
+        Use of :class:`~.VQECost` is deprecated and should be replaced with
+        :class:`~.ExpvalCost`.
+    """
+
     def __init__(self, *args, **kwargs):
         warnings.warn(
             "Use of VQECost is deprecated and should be replaced with ExpvalCost",

--- a/qchem/tests/test_convert_observable.py
+++ b/qchem/tests/test_convert_observable.py
@@ -352,7 +352,7 @@ def test_not_xyz_terms_to_qubit_operator():
 def test_integration_observable_to_vqe_cost(
     monkeypatch, mol_name, terms_ref, expected_cost, custom_wires, tol
 ):
-    r"""Test if `convert_observable()` in qchem integrates with `VQECost()` in pennylane"""
+    r"""Test if `convert_observable()` in qchem integrates with `ExpvalCost()` in pennylane"""
 
     qOp = QubitOperator()
     if terms_ref is not None:
@@ -375,7 +375,7 @@ def test_integration_observable_to_vqe_cost(
         for phi, w in zip(phis, wires):
             qml.RX(phi, wires=w)
 
-    dummy_cost = qml.VQECost(dummy_ansatz, vqe_observable, dev)
+    dummy_cost = qml.ExpvalCost(dummy_ansatz, vqe_observable, dev)
     params = [0.1 * i for i in range(num_qubits)]
     res = dummy_cost(params)
 
@@ -397,7 +397,7 @@ def test_integration_mol_file_to_vqe_cost(
     name, core, active, mapping, expected_cost, custom_wires, tol
 ):
     r"""Test if the output of `decompose()` works with `convert_observable()`
-    to generate `VQECost()`"""
+    to generate `ExpvalCost()`"""
 
     ref_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "test_ref_files")
     hf_file = os.path.join(ref_dir, name)
@@ -424,7 +424,7 @@ def test_integration_mol_file_to_vqe_cost(
 
     phis = np.load(os.path.join(ref_dir, "dummy_ansatz_parameters.npy"))
 
-    dummy_cost = qml.VQECost(dummy_ansatz, vqe_hamiltonian, dev)
+    dummy_cost = qml.ExpvalCost(dummy_ansatz, vqe_hamiltonian, dev)
     res = dummy_cost(phis)
 
     assert np.abs(res - expected_cost) < tol["atol"]

--- a/tests/test_optimize_qng.py
+++ b/tests/test_optimize_qng.py
@@ -40,7 +40,7 @@ class TestExceptions:
         params = 0.5
 
         with pytest.raises(
-            ValueError, match="The objective function must either be encoded as a single QNode or a VQECost object"
+            ValueError, match="The objective function must either be encoded as a single QNode or a ExpvalCost object"
         ):
             opt.step(cost, params)
 
@@ -143,7 +143,7 @@ class TestOptimize:
         assert np.allclose(cost_fn(theta), -1.41421356, atol=tol, rtol=0)
 
     def test_single_qubit_vqe_using_vqecost(self, tol):
-        """Test single-qubit VQE using VQECost 
+        """Test single-qubit VQE using ExpvalCost
         has the correct QNG value every step, the correct parameter updates,
         and correct cost after 200 steps"""
         dev = qml.device("default.qubit", wires=1)
@@ -160,7 +160,7 @@ class TestOptimize:
 
         h = qml.Hamiltonian(coeffs=coeffs, observables=obs_list)
 
-        cost_fn = qml.VQECost(ansatz=circuit, hamiltonian=h, device=dev)
+        cost_fn = qml.ExpvalCost(ansatz=circuit, hamiltonian=h, device=dev)
 
         def gradient(params):
             """Returns the gradient"""

--- a/tests/test_optimize_qng.py
+++ b/tests/test_optimize_qng.py
@@ -40,7 +40,7 @@ class TestExceptions:
         params = 0.5
 
         with pytest.raises(
-            ValueError, match="The objective function must either be encoded as a single QNode or a ExpvalCost object"
+            ValueError, match="The objective function must either be encoded as a single QNode or an ExpvalCost object"
         ):
             opt.step(cost, params)
 

--- a/tests/test_qaoa.py
+++ b/tests/test_qaoa.py
@@ -659,7 +659,7 @@ class TestIntegration:
 
         # Defines the device and the QAOA cost function
         dev = qml.device('default.qubit', wires=len(wires))
-        cost_function = qml.VQECost(circuit, cost_h, dev)
+        cost_function = qml.ExpvalCost(circuit, cost_h, dev)
 
         res = cost_function([[1, 1], [1, 1]])
         expected = -1.8260274380964299

--- a/tests/test_vqe.py
+++ b/tests/test_vqe.py
@@ -730,7 +730,7 @@ class TestVQE:
 
     @pytest.mark.parametrize("interface", ["tf", "torch", "autograd"])
     def test_optimize(self, interface, tf_support, torch_support):
-        """Test that a ExpvalCost with observable optimization gives the same result as another
+        """Test that an ExpvalCost with observable optimization gives the same result as another
         ExpvalCost without observable optimization."""
         if not qml.tape_mode_active():
             pytest.skip("This test is only intended for tape mode")

--- a/tests/test_vqe.py
+++ b/tests/test_vqe.py
@@ -1044,3 +1044,16 @@ class TestMultipleInterfaceIntegration:
 
         assert np.allclose(res, res_tf, atol=tol, rtol=0)
         assert np.allclose(res, res_torch, atol=tol, rtol=0)
+
+
+def test_vqe_cost():
+    """Tests that VQECost raises a DeprecationWarning but otherwise behaves as ExpvalCost"""
+
+    h = qml.Hamiltonian([1], [qml.PauliZ(0)])
+    dev = qml.device("default.qubit", wires=1)
+    ansatz = qml.templates.StronglyEntanglingLayers
+
+    with pytest.warns(DeprecationWarning, match="Use of VQECost is deprecated"):
+        cost = qml.VQECost(ansatz, h, dev)
+
+    assert isinstance(cost, qml.ExpvalCost)

--- a/tests/test_vqe.py
+++ b/tests/test_vqe.py
@@ -683,7 +683,7 @@ class TestVQE:
         """Tests that the cost function evaluates properly"""
         hamiltonian = qml.vqe.Hamiltonian(coeffs, observables)
         dev = qml.device("default.qubit", wires=3)
-        expval = qml.VQECost(ansatz, hamiltonian, dev)
+        expval = qml.ExpvalCost(ansatz, hamiltonian, dev)
         assert type(expval(params)) == np.float64
         assert np.shape(expval(params)) == ()  # expval should be scalar
 
@@ -692,7 +692,7 @@ class TestVQE:
         """Tests that the cost function returns correct expectation values"""
         dev = qml.device("default.qubit", wires=2)
         hamiltonian = qml.vqe.Hamiltonian(coeffs, observables)
-        cost = qml.VQECost(lambda params, **kwargs: None, hamiltonian, dev)
+        cost = qml.ExpvalCost(lambda params, **kwargs: None, hamiltonian, dev)
         assert cost([]) == sum(expected)
 
     @pytest.mark.parametrize("ansatz", JUNK_INPUTS)
@@ -700,7 +700,7 @@ class TestVQE:
         """Tests that the cost function raises an exception if the ansatz is not valid"""
         hamiltonian = qml.vqe.Hamiltonian((1.0,), [qml.PauliZ(0)])
         with pytest.raises(ValueError, match="not a callable function."):
-            cost = qml.VQECost(4, hamiltonian, mock_device())
+            cost = qml.ExpvalCost(4, hamiltonian, mock_device())
 
     @pytest.mark.parametrize("coeffs, observables, expected", hamiltonians_with_expvals)
     def test_passing_kwargs(self, coeffs, observables, expected):
@@ -709,7 +709,7 @@ class TestVQE:
         keyword arguments."""
         dev = qml.device("default.qubit", wires=2)
         hamiltonian = qml.vqe.Hamiltonian(coeffs, observables)
-        cost = qml.VQECost(lambda params, **kwargs: None, hamiltonian, dev, h=123, order=2)
+        cost = qml.ExpvalCost(lambda params, **kwargs: None, hamiltonian, dev, h=123, order=2)
 
         # Checking that the qnodes contain the step size and order
         for qnode in cost.qnodes:
@@ -726,12 +726,12 @@ class TestVQE:
         hamiltonian = qml.vqe.Hamiltonian([1], [qml.PauliZ(0)])
 
         with pytest.raises(ValueError, match="Observable optimization is only supported in tape"):
-            qml.VQECost(lambda params, **kwargs: None, hamiltonian, dev, optimize=True)
+            qml.ExpvalCost(lambda params, **kwargs: None, hamiltonian, dev, optimize=True)
 
     @pytest.mark.parametrize("interface", ["tf", "torch", "autograd"])
     def test_optimize(self, interface, tf_support, torch_support):
-        """Test that a VQECost with observable optimization gives the same result as another
-        VQECost without observable optimization."""
+        """Test that a ExpvalCost with observable optimization gives the same result as another
+        ExpvalCost without observable optimization."""
         if not qml.tape_mode_active():
             pytest.skip("This test is only intended for tape mode")
         if interface == "tf" and not tf_support:
@@ -742,14 +742,14 @@ class TestVQE:
         dev = qml.device("default.qubit", wires=4)
         hamiltonian = big_hamiltonian
 
-        cost = qml.VQECost(
+        cost = qml.ExpvalCost(
             qml.templates.StronglyEntanglingLayers,
             hamiltonian,
             dev,
             optimize=True,
             interface=interface,
         )
-        cost2 = qml.VQECost(
+        cost2 = qml.ExpvalCost(
             qml.templates.StronglyEntanglingLayers,
             hamiltonian,
             dev,
@@ -772,7 +772,7 @@ class TestVQE:
         assert np.allclose(c1, c2)
 
     def test_optimize_grad(self):
-        """Test that the gradient of VQECost is accessible and correct when using observable
+        """Test that the gradient of ExpvalCost is accessible and correct when using observable
         optimization and the autograd interface."""
         if not qml.tape_mode_active():
             pytest.skip("This test is only intended for tape mode")
@@ -780,8 +780,8 @@ class TestVQE:
         dev = qml.device("default.qubit", wires=4)
         hamiltonian = big_hamiltonian
 
-        cost = qml.VQECost(qml.templates.StronglyEntanglingLayers, hamiltonian, dev, optimize=True)
-        cost2 = qml.VQECost(
+        cost = qml.ExpvalCost(qml.templates.StronglyEntanglingLayers, hamiltonian, dev, optimize=True)
+        cost2 = qml.ExpvalCost(
             qml.templates.StronglyEntanglingLayers, hamiltonian, dev, optimize=False
         )
 
@@ -799,7 +799,7 @@ class TestVQE:
         assert np.allclose(dc2, big_hamiltonian_grad)
 
     def test_optimize_grad_torch(self, torch_support):
-        """Test that the gradient of VQECost is accessible and correct when using observable
+        """Test that the gradient of ExpvalCost is accessible and correct when using observable
         optimization and the Torch interface."""
         if not qml.tape_mode_active():
             pytest.skip("This test is only intended for tape mode")
@@ -809,7 +809,7 @@ class TestVQE:
         dev = qml.device("default.qubit", wires=4)
         hamiltonian = big_hamiltonian
 
-        cost = qml.VQECost(
+        cost = qml.ExpvalCost(
             qml.templates.StronglyEntanglingLayers,
             hamiltonian,
             dev,
@@ -826,7 +826,7 @@ class TestVQE:
         assert np.allclose(dc, big_hamiltonian_grad)
 
     def test_optimize_grad_tf(self, tf_support):
-        """Test that the gradient of VQECost is accessible and correct when using observable
+        """Test that the gradient of ExpvalCost is accessible and correct when using observable
         optimization and the TensorFlow interface."""
         if not qml.tape_mode_active():
             pytest.skip("This test is only intended for tape mode")
@@ -836,7 +836,7 @@ class TestVQE:
         dev = qml.device("default.qubit", wires=4)
         hamiltonian = big_hamiltonian
 
-        cost = qml.VQECost(
+        cost = qml.ExpvalCost(
             qml.templates.StronglyEntanglingLayers, hamiltonian, dev, optimize=True, interface="tf"
         )
 
@@ -857,7 +857,7 @@ class TestVQE:
         dev = qml.device("default.qubit", wires=4)
         hamiltonian = big_hamiltonian
 
-        cost = qml.VQECost(qml.templates.StronglyEntanglingLayers, hamiltonian, dev, optimize=True)
+        cost = qml.ExpvalCost(qml.templates.StronglyEntanglingLayers, hamiltonian, dev, optimize=True)
 
         with pytest.raises(ValueError, match="Evaluation of the metric tensor is not supported"):
             cost.metric_tensor(None)
@@ -896,7 +896,7 @@ class TestAutogradInterface:
         a, b = 0.54, 0.123
         params = np.array([a, b])
 
-        cost = qml.VQECost(ansatz, H, dev, interface=interface)
+        cost = qml.ExpvalCost(ansatz, H, dev, interface=interface)
         dcost = qml.grad(cost, argnum=[0])
         res = dcost(params)
 
@@ -939,7 +939,7 @@ class TestTorchInterface:
         a, b = 0.54, 0.123
         params = torch.autograd.Variable(torch.tensor([a, b]), requires_grad=True)
 
-        cost = qml.VQECost(ansatz, H, dev, interface="torch")
+        cost = qml.ExpvalCost(ansatz, H, dev, interface="torch")
         loss = cost(params)
         loss.backward()
 
@@ -986,7 +986,7 @@ class TestTFInterface:
         H = qml.vqe.Hamiltonian(coeffs, observables)
         a, b = 0.54, 0.123
         params = Variable([a, b], dtype=tf.float64)
-        cost = qml.VQECost(ansatz, H, dev, interface="tf")
+        cost = qml.ExpvalCost(ansatz, H, dev, interface="tf")
 
         with tf.GradientTape() as tape:
             loss = cost(params)
@@ -1019,7 +1019,7 @@ class TestMultipleInterfaceIntegration:
         params = Variable(qml.init.strong_ent_layers_normal(n_layers=3, n_wires=2, seed=1))
         ansatz = qml.templates.layers.StronglyEntanglingLayers
 
-        cost = qml.VQECost(ansatz, H, dev, interface="tf")
+        cost = qml.ExpvalCost(ansatz, H, dev, interface="tf")
 
         with tf.GradientTape() as tape:
             loss = cost(params)
@@ -1030,7 +1030,7 @@ class TestMultipleInterfaceIntegration:
         params = torch.autograd.Variable(params, requires_grad=True)
         ansatz = qml.templates.layers.StronglyEntanglingLayers
 
-        cost = qml.VQECost(ansatz, H, dev, interface="torch")
+        cost = qml.ExpvalCost(ansatz, H, dev, interface="torch")
         loss = cost(params)
         loss.backward()
         res_torch = params.grad.numpy()
@@ -1038,7 +1038,7 @@ class TestMultipleInterfaceIntegration:
         # NumPy interface
         params = qml.init.strong_ent_layers_normal(n_layers=3, n_wires=2, seed=1)
         ansatz = qml.templates.layers.StronglyEntanglingLayers
-        cost = qml.VQECost(ansatz, H, dev, interface="autograd")
+        cost = qml.ExpvalCost(ansatz, H, dev, interface="autograd")
         dcost = qml.grad(cost, argnum=[0])
         res = dcost(params)
 


### PR DESCRIPTION
This PR renames `VQECost` to `ExpvalCost` to reflect its more general usage. `VQECost` is available but deprecated.