### PR TITLE
Modify qml.grad so that it stores and makes accessible the value of the intermediate forward pass

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -274,6 +274,23 @@
   restart the kernel/runtime.
   [(#907)](https://github.com/PennyLaneAI/pennylane/pull/907)
 
+* When using `grad_fn = qml.grad(cost)` to compute the gradient of a cost function with the Autograd
+  interface, the value of the intermediate forward pass is now available via the `grad_fn.forward`
+  property:
+  [(#914)](https://github.com/PennyLaneAI/pennylane/pull/914)
+
+  ```python
+  def cost_fn(x, y):
+      return 2*np.sin(x[0])*np.exp(-x[1]) + x[0]**3 + np.cos(y)
+
+  params = np.array([0.1, 0.5], requires_grad=True)
+  data = np.array(0.65, requires_grad=False)
+  grad_fn = qml.grad(cost_fn)
+
+  grad_fn(params, data)  # perform backprop and evaluate the gradient
+  grad_fn.forward  # the cost function value
+  ```
+
 <h3>Breaking changes</h3>
 
 - The ``VQECost`` class has been renamed to ``ExpvalCost`` to reflect its general applicability

--- a/doc/code/qml.rst
+++ b/doc/code/qml.rst
@@ -6,4 +6,4 @@ qml
 .. automodapi:: pennylane
     :no-heading:
     :include-all-objects:
-    :skip: iter_entry_points, Version, Spec, plugin_devices, plugin_converters, default_config, reload
+    :skip: iter_entry_points, Version, Spec, plugin_devices, plugin_converters, default_config, reload, make_vjp, unary_to_nary, vspace

--- a/pennylane/__init__.py
+++ b/pennylane/__init__.py
@@ -248,8 +248,6 @@ class grad:
     Args:
         func (function): a plain QNode, or a Python function that contains
             a combination of quantum and classical nodes
-
-    Keyword Args:
         argnum (int, list(int), None): Which argument(s) to take the gradient
             with respect to. By default, the arguments themselves are used
             to determine differentiability, by examining the ``requires_grad``
@@ -262,19 +260,17 @@ class grad:
         the arguments in ``argnum``.
     """
 
-    def __init__(self, fun, argnum=None, *args, **kwargs):
+    def __init__(self, fun, argnum=None):
         self._forward = None
         self._grad_fn = None
 
         self._fun = fun
         self._argnum = argnum
-        self._grad_args = args
-        self._grad_kwargs = kwargs
 
         if self._argnum is not None:
             # If the differentiable argnum is provided, we can construct
             # the gradient function at once during initialization
-            self._grad_fn = self._grad_with_forward(fun, argnum=argnum, *args, **kwargs)
+            self._grad_fn = self._grad_with_forward(fun, argnum=argnum)
 
     def _get_grad_fn(self, args):
         """Get the required gradient function.
@@ -298,8 +294,9 @@ class grad:
             if getattr(arg, "requires_grad", True):
                 argnum.append(idx)
 
-        return grad._grad_with_forward(
-            self._fun, argnum=argnum, *self._grad_args, **self._grad_kwargs
+        return self._grad_with_forward(
+            self._fun,
+            argnum=argnum,
         )
 
     def __call__(self, *args, **kwargs):

--- a/pennylane/__init__.py
+++ b/pennylane/__init__.py
@@ -274,7 +274,7 @@ class grad:
         if self._argnum is not None:
             # If the differentiable argnum is provided, we can construct
             # the gradient function at once during initialization
-            self._grad_fn = grad._grad_with_forward(fun, argnum=argnum, *args, **kwargs)
+            self._grad_fn = self._grad_with_forward(fun, argnum=argnum, *args, **kwargs)
 
     def _get_grad_fn(self, args):
         """Get the required gradient function.

--- a/pennylane/__init__.py
+++ b/pennylane/__init__.py
@@ -233,7 +233,7 @@ def device(name, *args, **kwargs):
 make_vjp = unary_to_nary(_make_vjp)
 
 
-class _grad:
+class grad:
     """Returns the gradient as a callable function of (functions of) QNodes.
 
     Function arguments with the property ``requires_grad`` set to ``False``
@@ -274,7 +274,7 @@ class _grad:
         if self._argnum is not None:
             # If the differentiable argnum is provided, we can construct
             # the gradient function at once during initialization
-            self._grad_fn = _grad._grad_with_forward(fun, argnum=argnum, *args, **kwargs)
+            self._grad_fn = grad._grad_with_forward(fun, argnum=argnum, *args, **kwargs)
 
     def _get_grad_fn(self, args):
         """Get the required gradient function.
@@ -298,7 +298,7 @@ class _grad:
             if getattr(arg, "requires_grad", True):
                 argnum.append(idx)
 
-        return _grad._grad_with_forward(
+        return grad._grad_with_forward(
             self._fun, argnum=argnum, *self._grad_args, **self._grad_kwargs
         )
 

--- a/pennylane/__init__.py
+++ b/pennylane/__init__.py
@@ -305,9 +305,9 @@ class grad:
     def __call__(self, *args, **kwargs):
         """Evaluates the gradient function, and saves the function value
         calculated during the forward pass in :attr:`.forward`."""
-        grad, ans = self._get_grad_fn(args)(*args, **kwargs)
+        grad_value, ans = self._get_grad_fn(args)(*args, **kwargs)
         self._forward = ans
-        return grad
+        return grad_value
 
     @property
     def forward(self):
@@ -330,8 +330,8 @@ class grad:
                 "Try jacobian, elementwise_grad or holomorphic_grad."
             )
 
-        grad = vjp(vspace(ans).ones())
-        return grad, ans
+        grad_value = vjp(vspace(ans).ones())
+        return grad_value, ans
 
 
 def jacobian(func, argnum=None):

--- a/pennylane/__init__.py
+++ b/pennylane/__init__.py
@@ -22,7 +22,6 @@ import numpy as _np
 from autograd.wrap_util import unary_to_nary
 from autograd.core import make_vjp as _make_vjp, make_jvp as _make_jvp
 from autograd.extend import vspace
-
 from autograd import jacobian as _jacobian
 
 from semantic_version import Version, Spec

--- a/tests/test_classical_gradients.py
+++ b/tests/test_classical_gradients.py
@@ -14,7 +14,7 @@
 """
 Sanity checks for classical automatic gradient formulas (without QNodes).
 """
-
+import autograd
 import pytest
 
 import pennylane as qml
@@ -229,6 +229,60 @@ class TestGradientMultivarMultidim:
         auto_grad = g(x_vec_multidim)
         correct_grad = gradf(x_vec_multidim)
         assert np.allclose(auto_grad, correct_grad, atol=tol, rtol=0)
+
+
+class TestGrad:
+    """Unit tests for the gradient function"""
+
+    def test_non_scalar_cost_gradient(self):
+        """Test gradient computation with a non-scalar cost function raises an error"""
+
+        def cost(x):
+            return np.sin(x)
+
+        grad_fn = qml.grad(cost, argnum=[0])
+        arr1 = np.array([0.0, 1.0, 2.0], requires_grad=True)
+
+        with pytest.raises(TypeError, match="only applies to real scalar-output functions"):
+            grad_fn(arr1)
+
+    def test_agrees_with_autograd(self, tol):
+        """Test that the grad function agrees with autograd"""
+
+        def cost(x):
+            return np.sum(np.sin(x) * x[0] ** 3)
+
+        grad_fn = qml.grad(cost)
+        params = np.array([0.5, 1.0, 2.0], requires_grad=True)
+        res = grad_fn(params)
+        expected = autograd.grad(cost)(params)
+
+        assert np.allclose(res, expected, atol=tol, rtol=0)
+
+    def test_forward_pass_value_storing(self, tol):
+        """Test that the intermediate forward pass value is accessible and correct"""
+
+        def cost(x):
+            return np.sum(np.sin(x) * x[0] ** 3)
+
+        grad_fn = qml.grad(cost)
+        params = np.array([-0.654, 1.0, 2.0], requires_grad=True)
+
+        assert grad_fn.forward is None
+
+        grad = grad_fn(params)
+
+        res = grad_fn.forward
+        expected = cost(params)
+        assert np.allclose(res, expected, atol=tol, rtol=0)
+
+        # change the parameters
+        params2 = np.array([1.4, 1.0, 2.0], requires_grad=True)
+        grad = grad_fn(params2)
+
+        res = grad_fn.forward
+        expected = cost(params2)
+        assert np.allclose(res, expected, atol=tol, rtol=0)
 
 
 class TestJacobian:


### PR DESCRIPTION
**Context:**

If we would like to track the cost function during optimization, the ability to access the value of the cost function computed during the optimization step is ideal, rather than requiring the cost function to be recomputed manually and externally.

However, none of the optimizers explicitly compute the forward pass/cost function internally. So there is no explicit cost value that can be provided.

This is a quirk of Autograd - unlike PyTorch and TensorFlow, which enforce (via their UI) the need to manually perform a forward pass before you can access the backward pass, Autograd has no such restriction. Instead, calling ``autograd.grad()`` causes Autograd to perform both the forward pass and the backward pass at once.

**Description of the Change:**

* Modifies `grad_fn = qml.grad(cost_fn)` so that the implicit forward pass value is stored as an attribute, `grad_fn.forward`. This allows for both:

  - backcompatibility with the existing UI

  - the ability to easily extract the intermediate forward pass value if needed.

  For example, consider the following script (which remains compatible with the `master` branch):

  ```python
  from pennylane import numpy as np
  import pennylane as qml

  def cost_fn(x, y):
      return 2*np.sin(x[0])*np.exp(-x[1]) + x[0]**3 + np.cos(y)

  params = np.array([0.1, 0.5], requires_grad=True)
  data = np.array(0.65, requires_grad=False)
  grad_fn = qml.grad(cost_fn)
  ```

  Before the `grad_fn` is evaluated, the stored forward pass is not available:
  ```pycon
  >>> grad_fn.forward
  None
  ```

  Evaluating the gradient makes it accessible:
  ```pycon
  >>> print("Gradient:", grad_fn(params, data))
  Gradient: (array([ 1.23700107, -0.12110406]),)
  >>> print("Stored forward pass value:", grad_fn.forward)
  Stored forward pass value: 0.9181878546693896
  ```

  Double checking this agrees with cost function evaluation:
  ```pycon
  >>> print("Cost function:", cost_fn(params, data))
  Cost function: 0.9181878546693896
  ```

**Benefits:**

* Significant saving in number of quantum evaluations required if needing to track the cost function value during backpropagation.

* As a side effect of this change, the new `qml.grad` implementation is slightly leaner - there is no more function wrapping happening if the user does not provide `argnums`, which leads to a slightly cleaner and more performant UI.

* Note that this *only* applies to the autograd interface - PyTorch and TF both require manual forward passes before the backward pass is accessible.

**Possible Drawbacks:**

* We replicate the logic of `autograd.grad` here, rather than importing it directly. Normally I would not recommend modifying an external package function, since we would have to maintain it, and might miss breaking changes/bug fixes. However, in this case it should be okay, because:

  - The logic we are replicating is only two lines

  - Autograd is not maintained, so we do not expect any changes or bugfixes

* This PR does not yet allow the cost function to be returned from the optimizers, but it lays the necessary groundwork. A follow up PR should be added to modify the optimizers, to (optionally) accept a callback function `callback_fn(params, cost, grad)`, allowing the user to arbitrarily access and process the parameters, cost value, and gradient value at each step.

**Related GitHub Issues:** n/a
