### PR TITLE
Support for MultiRZ and CRot in default.qubit.tf

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -304,6 +304,11 @@
 
 <h3>Bug fixes</h3>
 
+* The `default.qubit.tf` device is updated to handle TensorFlow objects (e.g.,
+  `tf.Variable`) as gate parameters correctly when using the `MultiRZ` and
+  `CRot` operations.
+  [(#921)](https://github.com/PennyLaneAI/pennylane/pull/921)
+
 * PennyLane tensor objects are now unwrapped in BaseQNode when passed as a
   keyword argument to the quantum function.
   [(#903)](https://github.com/PennyLaneAI/pennylane/pull/903)

--- a/pennylane/devices/default_qubit_tf.py
+++ b/pennylane/devices/default_qubit_tf.py
@@ -168,7 +168,8 @@ class DefaultQubitTF(DefaultQubit):
         # TODO: add support for the CRot operation
         # Remove CRot from the supported operations so that it will be
         # decomposed by default
-        self.operations.remove("CRot")
+        if "CRot" in self.operations:
+            self.operations.remove("CRot")
 
         # Versions of TF before 2.3.0 do not support using the special apply methods as they
         # raise an error when calculating the gradient. For versions of TF after 2.3.0,

--- a/pennylane/devices/default_qubit_tf.py
+++ b/pennylane/devices/default_qubit_tf.py
@@ -164,6 +164,7 @@ class DefaultQubitTF(DefaultQubit):
         # prevent using special apply method for this gate due to slowdown in TF implementation
         del self._apply_ops["CZ"]
 
+        self.parametric_ops["MultiRZ"] = lambda args:  tf_ops.MultiRZ(args, len(self.wires))
         # Versions of TF before 2.3.0 do not support using the special apply methods as they
         # raise an error when calculating the gradient. For versions of TF after 2.3.0,
         # special apply methods are also not supported when using more than 8 wires due to
@@ -199,6 +200,7 @@ class DefaultQubitTF(DefaultQubit):
             object will be returned.
         """
         if unitary.name in self.parametric_ops:
+            print(self.parametric_ops[unitary.name](*unitary.parameters))
             return self.parametric_ops[unitary.name](*unitary.parameters)
 
         if isinstance(unitary, DiagonalOperation):

--- a/pennylane/devices/default_qubit_tf.py
+++ b/pennylane/devices/default_qubit_tf.py
@@ -139,6 +139,7 @@ class DefaultQubitTF(DefaultQubit):
         "CRX": tf_ops.CRX,
         "CRY": tf_ops.CRY,
         "CRZ": tf_ops.CRZ,
+        "CRot": tf_ops.CRot,
     }
 
     C_DTYPE = tf.complex128
@@ -164,12 +165,6 @@ class DefaultQubitTF(DefaultQubit):
 
         # prevent using special apply method for this gate due to slowdown in TF implementation
         del self._apply_ops["CZ"]
-
-        # TODO: add support for the CRot operation
-        # Remove CRot from the supported operations so that it will be
-        # decomposed by default
-        if "CRot" in self.operations:
-            self.operations.remove("CRot")
 
         # Versions of TF before 2.3.0 do not support using the special apply methods as they
         # raise an error when calculating the gradient. For versions of TF after 2.3.0,

--- a/pennylane/devices/default_qubit_tf.py
+++ b/pennylane/devices/default_qubit_tf.py
@@ -165,6 +165,11 @@ class DefaultQubitTF(DefaultQubit):
         # prevent using special apply method for this gate due to slowdown in TF implementation
         del self._apply_ops["CZ"]
 
+        # TODO: add support for the CRot operation
+        # Remove CRot from the supported operations so that it will be
+        # decomposed by default
+        self.operations.remove("CRot")
+
         # Versions of TF before 2.3.0 do not support using the special apply methods as they
         # raise an error when calculating the gradient. For versions of TF after 2.3.0,
         # special apply methods are also not supported when using more than 8 wires due to

--- a/pennylane/devices/default_qubit_tf.py
+++ b/pennylane/devices/default_qubit_tf.py
@@ -200,7 +200,7 @@ class DefaultQubitTF(DefaultQubit):
             object will be returned.
         """
         if unitary.name in self.parametric_ops:
-            if unitary.name is "MultiRZ":
+            if unitary.name == "MultiRZ":
                 return self.parametric_ops[unitary.name](unitary.parameters, len(unitary.wires))
             return self.parametric_ops[unitary.name](*unitary.parameters)
 

--- a/pennylane/devices/default_qubit_tf.py
+++ b/pennylane/devices/default_qubit_tf.py
@@ -135,6 +135,7 @@ class DefaultQubitTF(DefaultQubit):
         "RY": tf_ops.RY,
         "RZ": tf_ops.RZ,
         "Rot": tf_ops.Rot,
+        "MultiRZ": tf_ops.MultiRZ,
         "CRX": tf_ops.CRX,
         "CRY": tf_ops.CRY,
         "CRZ": tf_ops.CRZ,
@@ -164,7 +165,6 @@ class DefaultQubitTF(DefaultQubit):
         # prevent using special apply method for this gate due to slowdown in TF implementation
         del self._apply_ops["CZ"]
 
-        self.parametric_ops["MultiRZ"] = lambda args:  tf_ops.MultiRZ(args, len(self.wires))
         # Versions of TF before 2.3.0 do not support using the special apply methods as they
         # raise an error when calculating the gradient. For versions of TF after 2.3.0,
         # special apply methods are also not supported when using more than 8 wires due to
@@ -200,7 +200,8 @@ class DefaultQubitTF(DefaultQubit):
             object will be returned.
         """
         if unitary.name in self.parametric_ops:
-            print(self.parametric_ops[unitary.name](*unitary.parameters))
+            if unitary.name is "MultiRZ":
+                return self.parametric_ops[unitary.name](unitary.parameters, len(unitary.wires))
             return self.parametric_ops[unitary.name](*unitary.parameters)
 
         if isinstance(unitary, DiagonalOperation):

--- a/pennylane/devices/tf_ops.py
+++ b/pennylane/devices/tf_ops.py
@@ -108,7 +108,7 @@ def MultiRZ(theta, n):
 
     Args:
         theta (float): rotation angle
-        n (int): Number of wires the rotation acts on
+        n (int): number of wires the rotation acts on
 
     Returns:
         tf.Tensor[complex]: diagonal part of the MultiRZ matrix

--- a/pennylane/devices/tf_ops.py
+++ b/pennylane/devices/tf_ops.py
@@ -105,10 +105,17 @@ def Rot(a, b, c):
 
 def MultiRZ(theta, n):
     r"""Arbitrary multi Z rotation.
+
+    Args:
+        theta (float): rotation angle
+        n (int): Number of wires the rotation acts on
+
+    Returns:
+        tf.Tensor[complex]: diagonal part of the MultiRZ matrix
     """
     theta = tf.cast(theta, dtype=C_DTYPE)
     multi_Z_rot_eigs = tf.exp(-1j * theta / 2 * pauli_eigs(n))
-    return tf.linalg.diag(multi_Z_rot_eigs)
+    return tf.convert_to_tensor(multi_Z_rot_eigs)
 
 def CRX(theta):
     r"""Two-qubit controlled rotation about the x axis.

--- a/pennylane/devices/tf_ops.py
+++ b/pennylane/devices/tf_ops.py
@@ -16,6 +16,7 @@ Utility functions and numerical implementations of quantum operations TensorFlow
 """
 import tensorflow as tf
 from numpy import kron
+from pennylane.utils import pauli_eigs
 
 C_DTYPE = tf.complex128
 R_DTYPE = tf.float64
@@ -101,6 +102,13 @@ def Rot(a, b, c):
     """
     return tf.linalg.diag(RZ(c)) @ RY(b) @ tf.linalg.diag(RZ(a))
 
+
+def MultiRZ(theta, n):
+    r"""Arbitrary multi Z rotation.
+    """
+    theta = tf.cast(theta, dtype=C_DTYPE)
+    multi_Z_rot_eigs = tf.exp(-1j * theta / 2 * pauli_eigs(n))
+    return tf.linalg.diag(multi_Z_rot_eigs)
 
 def CRX(theta):
     r"""Two-qubit controlled rotation about the x axis.

--- a/pennylane/devices/tf_ops.py
+++ b/pennylane/devices/tf_ops.py
@@ -117,6 +117,7 @@ def MultiRZ(theta, n):
     multi_Z_rot_eigs = tf.exp(-1j * theta / 2 * pauli_eigs(n))
     return tf.convert_to_tensor(multi_Z_rot_eigs)
 
+
 def CRX(theta):
     r"""Two-qubit controlled rotation about the x axis.
 

--- a/tests/devices/test_default_qubit_tf.py
+++ b/tests/devices/test_default_qubit_tf.py
@@ -928,6 +928,69 @@ class TestQNodeIntegration:
         expected = np.array([amplitude, 0, np.conj(amplitude), 0])
         assert np.allclose(state, expected, atol=tol, rtol=0)
 
+    @pytest.mark.parametrize("theta", [0.5432, -0.232])
+    @pytest.mark.parametrize("op,func", single_qubit_param)
+    def test_one_qubit_param_gates(self, theta, op, func, init_state, tol):
+        """Test the integration of the one-qubit single parameter rotations by passing
+        a TF data structure as a parameter"""
+        dev = qml.device("default.qubit.tf", wires=1)
+        state = init_state(1)
+
+        @qml.qnode(dev, interface='tf')
+        def circuit(params):
+            qml.QubitStateVector(state, wires=[0])
+            op(params[0], wires=[0])
+            return qml.expval(qml.PauliZ(0))
+
+        # Pass a TF Variable to the qfunc
+        params = tf.Variable(np.array([theta]))
+        circuit(params)
+        res = dev.state
+        expected = func(theta) @ state
+        assert np.allclose(res.numpy(), expected, atol=tol, rtol=0)
+
+    @pytest.mark.parametrize("theta", [0.5432, 4.213])
+    @pytest.mark.parametrize("op,func", two_qubit_param)
+    def test_two_qubit_param_gates(self, theta, op, func, init_state, tol):
+        """Test the integration of the two-qubit single parameter rotations by passing
+        a TF data structure as a parameter"""
+        dev = qml.device("default.qubit.tf", wires=2)
+        state = init_state(2)
+
+        @qml.qnode(dev, interface='tf')
+        def circuit(params):
+            qml.QubitStateVector(state, wires=[0,1])
+            op(params[0], wires=[0, 1])
+            return qml.expval(qml.PauliZ(0))
+
+        # Pass a TF Variable to the qfunc
+        params = tf.Variable(np.array([theta]))
+        circuit(params)
+        res = dev.state
+        expected = func(theta) @ state
+        assert np.allclose(res.numpy(), expected, atol=tol, rtol=0)
+
+    def test_controlled_rotation_integration(self, init_state, tol):
+        """Test the integration of the two-qubit controlled rotation by passing
+        a TF data structure as a parameter"""
+        dev = qml.device("default.qubit.tf", wires=2)
+        a = 1.7
+        b = 1.3432
+        c = -0.654
+        state = init_state(2)
+
+        @qml.qnode(dev, interface='tf')
+        def circuit(params):
+            qml.QubitStateVector(state, wires=[0,1])
+            qml.CRot(params[0], params[1], params[2], wires=[0,1])
+            return qml.expval(qml.PauliZ(0))
+
+        # Pass a TF Variable to the qfunc
+        params = tf.Variable(np.array([a,b,c]))
+        circuit(params)
+        res = dev.state
+        expected = CRot3(a, b, c) @ state
+        assert np.allclose(res.numpy(), expected, atol=tol, rtol=0)
 
 class TestPassthruIntegration:
     """Tests for integration with the PassthruQNode"""

--- a/tests/devices/test_default_qubit_tf.py
+++ b/tests/devices/test_default_qubit_tf.py
@@ -47,6 +47,8 @@ from gate_data import (
     CRoty,
     CRotz,
     CRot3,
+    MultiRZ1,
+    MultiRZ2,
 )
 
 np.random.seed(42)
@@ -72,9 +74,9 @@ A = np.array([[1.02789352, 1.61296440 - 0.3498192j], [1.61296440 + 0.3498192j, 1
 #####################################################
 
 single_qubit = [(qml.S, S), (qml.T, T), (qml.PauliX, X), (qml.PauliY, Y), (qml.PauliZ, Z), (qml.Hadamard, H)]
-single_qubit_param = [(qml.PhaseShift, Rphi), (qml.RX, Rotx), (qml.RY, Roty), (qml.RZ, Rotz)]
+single_qubit_param = [(qml.PhaseShift, Rphi), (qml.RX, Rotx), (qml.RY, Roty), (qml.RZ, Rotz), (qml.MultiRZ, MultiRZ1)]
 two_qubit = [(qml.CZ, CZ), (qml.CNOT, CNOT), (qml.SWAP, SWAP)]
-two_qubit_param = [(qml.CRX, CRotx), (qml.CRY, CRoty), (qml.CRZ, CRotz)]
+two_qubit_param = [(qml.CRX, CRotx), (qml.CRY, CRoty), (qml.CRZ, CRotz), (qml.MultiRZ, MultiRZ2)]
 three_qubit = [(qml.Toffoli, Toffoli), (qml.CSWAP, CSWAP)]
 
 

--- a/tests/gate_data.py
+++ b/tests/gate_data.py
@@ -177,3 +177,33 @@ def CRot3(a, b, c):
             ],
         ]
     )
+
+def MultiRZ1(theta):
+    r"""Arbitrary multi Z rotation on one wire.
+
+    Args:
+        theta (float): rotation angle
+
+    Returns:
+        array: the one-wire MultiRZ matrix
+    """
+    return np.array([[np.exp(-1j * theta / 2), 0.0 + 0.0j], [0.0 + 0.0j, np.exp(1j * theta / 2)]])
+
+
+def MultiRZ2(theta):
+    r"""Arbitrary multi Z rotation on two wires.
+
+    Args:
+        theta (float): rotation angle
+
+    Returns:
+        array: the two-wire MultiRZ matrix
+    """
+    return np.array(
+        [
+            [np.exp(-1j * theta / 2), 0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j],
+            [0.0 + 0.0j, np.exp(1j * theta / 2), 0.0 + 0.0j, 0.0 + 0.0j],
+            [0.0 + 0.0j, 0.0 + 0.0j, np.exp(1j * theta / 2), 0.0 + 0.0j],
+            [0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j, np.exp(-1j * theta / 2)],
+        ]
+    )


### PR DESCRIPTION
**Context:**

Passing a TensorFlow `Variable` to the  `MultiRZ` operation with the `default.qubit.tf` device results in an error:
```python
import pennylane as qml
import tensorflow as tf
import numpy as np

x = tf.Variable(np.array([1.7]))

dev = qml.device('default.qubit.tf', wires=3)

@qml.qnode(dev, interface='tf')
def circuit(params):
    qml.MultiRZ(params[0], wires=[0])
    return qml.expval(qml.PauliZ(0))

circuit(x)
```
```
~/anaconda3/lib/python3.7/site-packages/tensorflow/python/framework/constant_op.py in convert_to_eager_tensor(value, ctx, dtype)
     96       dtype = dtypes.as_dtype(dtype).as_datatype_enum
     97   ctx.ensure_initialized()
---> 98   return ops.EagerTensor(value, ctx.device_name, dtype)
     99 
    100 

TypeError: Cannot convert (-0-1j) to EagerTensor of dtype double
```
propagated from:
```
~/xanadu/pennylane/pennylane/ops/qubit.py in _eigvals(cls, theta, n)
    836     @classmethod
    837     def _eigvals(cls, theta, n):
--> 838         return np.exp(-1j * theta / 2 * pauli_eigs(n))
```
This error arises because the `default.qubit.tf` device needs to handle internal data using TensorFlow data structures and operations. However, this device is using the definition of `MultiRZ` for `default.qubit` which does not use TF.

Custom supported operations are implemented in the [`tf_ops.py file`](https://github.com/PennyLaneAI/pennylane/blob/master/pennylane/devices/tf_ops.py) and wired in to the device using the [`parametric_ops dictionary`](https://github.com/PennyLaneAI/pennylane/blob/855327baf4e013d7c8eee43105c4680686eb75d3/pennylane/devices/default_qubit_tf.py#L132).

**Description of the Change:**
* Updates `default.qubit.tf` to support `MultiRZ`
* Temporarily removes `CRot` from the supported operations due to a similar error. `CRot` can be used, but the decomposition will be applied by default.

**Benefits:**
No errors when using `MultiRZ` and further PennyLane subpackages such as `qaoa` that depend on `MultiRZ`.

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
Thanks to @stfnmangini for discovering the issue!