### PR TITLE
Fixes bug in tape.set_parameters()

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -327,9 +327,9 @@
 
 * Fixes a bug in `QuantumTape.set_parameters()`. The previous implementation assumed
   that the `self.trainable_parms` set would always be iterated over in increasing integer
-  order. However, this is not guarenteed behaviour, and can lead to the incorrect tape parameters
+  order. However, this is not guaranteed behaviour, and can lead to the incorrect tape parameters
   being set if this is not the case.
-  [(#)]()
+  [(#923)](https://github.com/PennyLaneAI/pennylane/pull/923)
 
 <h3>Contributors</h3>
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,14 +2,14 @@
 
 <h3>New features since last release</h3>
 
-* The ``ExpvalCost`` class (previously ``VQECost``) now provides observable optimization using the
-  ``optimize`` argument, resulting in potentially fewer device executions.
+* The `ExpvalCost` class (previously `VQECost`) now provides observable optimization using the
+  `optimize` argument, resulting in potentially fewer device executions.
   [(#902)](https://github.com/PennyLaneAI/pennylane/pull/902)
-  
+
   This is achieved by separating the observables composing the Hamiltonian into qubit-wise
   commuting groups and evaluating those groups on a single QNode using functionality from the
-  ``grouping`` module: 
-  
+  `grouping` module:
+
   ```python
   qml.enable_tape()
   commuting_obs = [qml.PauliX(0), qml.PauliX(0) @ qml.PauliZ(1)]
@@ -23,9 +23,9 @@
 
   params = qml.init.strong_ent_layers_uniform(3, 2)
   ```
-  
+
   Grouping these commuting observables leads to fewer device executions:
-  
+
   ```pycon
   >>> cost_opt(params)
   >>> ex_opt = dev.num_executions
@@ -86,9 +86,9 @@
 
 <h3>Improvements</h3>
 
-* The CRot gate now has a ``decomposition`` method, which breaks the gate down into rotations
-  and CNOT gates. This allows ``CRot`` to be used on devices that do not natively support it.
-  [(#908)](https://github.com/PennyLaneAI/pennylane/pull/908) 
+* The CRot gate now has a `decomposition` method, which breaks the gate down into rotations
+  and CNOT gates. This allows `CRot` to be used on devices that do not natively support it.
+  [(#908)](https://github.com/PennyLaneAI/pennylane/pull/908)
 
 * QNodes in tape mode now support returning observables on the same wire if the observables are
   qubit-wise commuting Pauli words. Qubit-wise commuting observables can be evaluated with a
@@ -96,7 +96,7 @@
   transformed to the computational basis using a shared set of single-qubit rotations.
   [(#882)](https://github.com/PennyLaneAI/pennylane/pull/882)
 
-  The following shows how to return the Pauli words ``XX`` and ``XI``:
+  The following shows how to return the Pauli words `XX` and `XI`:
 
   ```python
   qml.enable_tape()
@@ -266,8 +266,8 @@
   - `qnn.TorchLayer` [(#865)](https://github.com/PennyLaneAI/pennylane/pull/865)
   - `qaoa` module [(#905)](https://github.com/PennyLaneAI/pennylane/pull/905)
 
-* A new function, ``qml.refresh_devices()``, has been added, allowing PennyLane to
-  rescan installed PennyLane plugins and refresh the device list. In addition, the ``qml.device``
+* A new function, `qml.refresh_devices()`, has been added, allowing PennyLane to
+  rescan installed PennyLane plugins and refresh the device list. In addition, the `qml.device`
   loader will attempt to refresh devices if the required plugin device cannot be found.
   This will result in an improved experience if installing PennyLane and plugins within
   a running Python session (for example, on Google Colab), and avoid the need to
@@ -293,8 +293,8 @@
 
 <h3>Breaking changes</h3>
 
-- The ``VQECost`` class has been renamed to ``ExpvalCost`` to reflect its general applicability
-  beyond VQE. Use of ``VQECost`` is still possible but will result in a deprecation warning.
+- The `VQECost` class has been renamed to `ExpvalCost` to reflect its general applicability
+  beyond VQE. Use of `VQECost` is still possible but will result in a deprecation warning.
   [(#913)](https://github.com/PennyLaneAI/pennylane/pull/913)
 
 <h3>Documentation</h3>
@@ -321,9 +321,15 @@
 * Fixes a bug whereby binary Python operators were not properly propagating the `requires_grad`
   attribute to the output tensor.
   [(#889)](https://github.com/PennyLaneAI/pennylane/pull/889)
-  
+
 * Fixes a bug which prevents `TorchLayer` from doing `backward` when CUDA is enabled.
   [(#899)](https://github.com/PennyLaneAI/pennylane/pull/899)
+
+* Fixes a bug in `QuantumTape.set_parameters()`. The previous implementation assumed
+  that the `self.trainable_parms` set would always be iterated over in increasing integer
+  order. However, this is not guarenteed behaviour, and can lead to the incorrect tape parameters
+  being set if this is not the case.
+  [(#)]()
 
 <h3>Contributors</h3>
 

--- a/pennylane/tape/tapes/tape.py
+++ b/pennylane/tape/tapes/tape.py
@@ -704,7 +704,7 @@ class QuantumTape(AnnotatedQueue):
         [4, 1, 6]
         """
         if trainable_only:
-            iterator = zip(self.trainable_params, params)
+            iterator = zip(sorted(self.trainable_params), params)
             required_length = self.num_params
         else:
             iterator = enumerate(params)

--- a/pennylane/tape/tapes/tape.py
+++ b/pennylane/tape/tapes/tape.py
@@ -704,7 +704,7 @@ class QuantumTape(AnnotatedQueue):
         [4, 1, 6]
         """
         if trainable_only:
-            iterator = zip(sorted(self.trainable_params), params)
+            iterator = zip(self.trainable_params, params)
             required_length = self.num_params
         else:
             iterator = enumerate(params)

--- a/tests/tape/tapes/test_tape.py
+++ b/tests/tape/tapes/test_tape.py
@@ -498,6 +498,24 @@ class TestParameters:
             params[4],
         ]
 
+    def test_setting_parameters_unordered(self, make_tape, monkeypatch):
+        """Test that an 'unordered' trainable_params set does not affect
+        the setting of parameter values"""
+        tape, params = make_tape
+        new_params = [-0.654, 0.3]
+
+        with monkeypatch.context() as m:
+            m.setattr(tape, "_trainable_params", {3, 1})
+            tape.set_parameters(new_params)
+
+        assert tape.get_parameters(trainable_only=False) == [
+            params[0],
+            new_params[0],
+            params[2],
+            new_params[1],
+            params[4],
+        ]
+
     def test_setting_all_parameters(self, make_tape):
         """Test that all parameters are correctly modified after construction"""
         tape, params = make_tape

--- a/tests/tape/tapes/test_tape.py
+++ b/tests/tape/tapes/test_tape.py
@@ -508,13 +508,18 @@ class TestParameters:
             m.setattr(tape, "_trainable_params", {3, 1})
             tape.set_parameters(new_params)
 
-        assert tape.get_parameters(trainable_only=False) == [
-            params[0],
-            new_params[0],
-            params[2],
-            new_params[1],
-            params[4],
-        ]
+            assert tape.get_parameters(trainable_only=True) == [
+                new_params[0],
+                new_params[1],
+            ]
+
+            assert tape.get_parameters(trainable_only=False) == [
+                params[0],
+                new_params[0],
+                params[2],
+                new_params[1],
+                params[4],
+            ]
 
     def test_setting_all_parameters(self, make_tape):
         """Test that all parameters are correctly modified after construction"""


### PR DESCRIPTION
**Context:**

Fixes a bug in `QuantumTape.set_parameters()`. The previous implementation assumed that the `self.trainable_parms` set would always be iterated over in increasing integer order. However, this is not guaranteed behaviour, and can lead to the incorrect tape parameters being set if this is not the case.

For example, consider the following edge case:

```python
import pennylane as qml
import numpy as np

N = 5
dev = qml.device("default.qubit", wires=N)

qml.enable_tape()

@qml.qnode(dev)
def circuit(weight):
    qml.templates.DoubleExcitationUnitary(weight, wires1=[0, 1], wires2=[3, 4])
    return [qml.expval(qml.PauliZ(w)) for w in range(N)]
```

The expected result of this circuit is always an all-ones array, however this is not the case:
```pycon
>>> print(circuit( 1.34817))
[0.78127841 0.78127841 1.         0.78127841 0.78127841]
```

Under the hood, this particular circuit is resulting in a set of trainable parameters that is not sorted:
```python
>>> print(circuit.qtape.trainable_params)
{1, 36, 6, 13, 18, 21, 24, 29}
```

This causes `QuantumTape.set_parameters()` to iterate through the parameters to set, and the corresponding value, incorrectly in the line
```python
if trainable_only:
    iterator = zip(self.trainable_params, params)
```

**Description of the Change:**

* Modifies `QuantumTape.set_parameters()` to always sort the set of trainable parameters, before iterating and changing parameter values.

**Benefits:**

Edge cases such as the above example now return the correct result:
```pycon
>>> print(circuit( 1.34817))
[1. 1. 1. 1. 1.]
```

As a result, two templates (`SingleExcitationUnitary` and `DoubleExcitationUnitary`, and by extension `UCCSD`) which were affected by this edge case now work in tape mode.

**Possible Drawbacks:** n/a

**Related GitHub Issues:** n/a
