### PR TITLE
Fix incorrect exception message for unknown interfaces

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -367,6 +367,9 @@
   being set if this is not the case.
   [(#923)](https://github.com/PennyLaneAI/pennylane/pull/923)
 
+* Fixes broken error message if a QNode is instantiated with an unknown exception.
+  [(#930)](https://github.com/PennyLaneAI/pennylane/pull/930)
+
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane/tape/qnode.py
+++ b/pennylane/tape/qnode.py
@@ -131,7 +131,7 @@ class QNode:
         if interface is not None and interface not in self.INTERFACE_MAP:
             raise qml.QuantumFunctionError(
                 f"Unknown interface {interface}. Interface must be "
-                f"one of {self.INTERFACE_MAP.values()}."
+                f"one of {list(self.INTERFACE_MAP.keys())}."
             )
 
         if not isinstance(device, Device):

--- a/tests/tape/tapes/test_qnode.py
+++ b/tests/tape/tapes/test_qnode.py
@@ -25,8 +25,13 @@ class TestValidation:
     def test_invalid_interface(self):
         """Test that an exception is raised for an invalid interface"""
         dev = qml.device("default.qubit", wires=1)
+        test_interface = "something"
+        expected_error = (
+            fr"Unknown interface {test_interface}\. Interface must be "
+            r"one of \['autograd', 'torch', 'tf'\]\."
+        )
 
-        with pytest.raises(qml.QuantumFunctionError, match="Unknown interface"):
+        with pytest.raises(qml.QuantumFunctionError, match=expected_error):
             QNode(None, dev, interface="something")
 
     def test_invalid_device(self):


### PR DESCRIPTION
**Context:** During code review of another PR, I noticed that the exception message for interfaces was not displaying correctly.

**Description of the Change:** Fixes the exception message 

**Benefits:** Bug fixed

**Possible Drawbacks:** n/a

**Related GitHub Issues:** n/a
