### PR TITLE
Update docstrings

### DIFF
--- a/pennylane/optimize/gradient_descent.py
+++ b/pennylane/optimize/gradient_descent.py
@@ -48,7 +48,8 @@ class GradientDescentOptimizer:
         self._stepsize = stepsize
 
     def step_and_cost(self, objective_fn, x, grad_fn=None):
-        """Update x with one step of the optimizer and return the corresponding objective function value.
+        """Update x with one step of the optimizer and return the corresponding objective
+        function value prior to the step.
 
         Args:
             objective_fn (function): the objective function for optimization
@@ -59,6 +60,7 @@ class GradientDescentOptimizer:
 
         Returns:
             tuple: the new variable values :math:`x^{(t+1)}` and the objective function output
+                prior to the step
         """
 
         g, forward = self.compute_grad(objective_fn, x, grad_fn=grad_fn)

--- a/pennylane/optimize/qng.py
+++ b/pennylane/optimize/qng.py
@@ -155,7 +155,8 @@ class QNGOptimizer(GradientDescentOptimizer):
         self.lam = lam
 
     def step_and_cost(self, qnode, x, recompute_tensor=True, metric_tensor_fn=None):
-        """Update x with one step of the optimizer and return the corresponding objective function value.
+        """Update x with one step of the optimizer and return the corresponding objective
+        function value prior to the step.
 
         Args:
             qnode (QNode): the QNode for optimization
@@ -169,6 +170,7 @@ class QNGOptimizer(GradientDescentOptimizer):
 
         Returns:
             tuple: the new variable values :math:`x^{(t+1)}` and the objective function output
+                prior to the step
         """
         # pylint: disable=arguments-differ
         if not hasattr(qnode, "metric_tensor") and not metric_tensor_fn:

--- a/pennylane/optimize/rotoselect.py
+++ b/pennylane/optimize/rotoselect.py
@@ -93,8 +93,8 @@ class RotoselectOptimizer:
         self.possible_generators = possible_generators or [qml.RX, qml.RY, qml.RZ]
 
     def step_and_cost(self, objective_fn, x, generators):
-        r"""Update x with one step of the optimizer and return the corresponding objective function
-        value.
+        r"""Update x with one step of the optimizer and return the corresponding objective
+        function value prior to the step.
 
         Args:
             objective_fn (function): The objective function for optimization. It must have the
@@ -107,7 +107,7 @@ class RotoselectOptimizer:
 
         Returns:
             tuple: the new variable values :math:`x^{(t+1)}`, the new generators, and the objective
-                function output
+                function output prior to the step
         """
         x_new, generators = self.step(objective_fn, x, generators)
 

--- a/pennylane/optimize/rotosolve.py
+++ b/pennylane/optimize/rotosolve.py
@@ -77,8 +77,8 @@ class RotosolveOptimizer:
     # pylint: disable=too-few-public-methods
 
     def step_and_cost(self, objective_fn, x):
-        r"""Update x with one step of the optimizer and return the corresponding objective function
-        value.
+        r"""Update x with one step of the optimizer and return the corresponding objective
+        function value prior to the step.
 
         Args:
             objective_fn (function): The objective function for optimization. It should take a
@@ -89,6 +89,7 @@ class RotosolveOptimizer:
 
         Returns:
             tuple: the new variable values :math:`x^{(t+1)}` and the objective function output
+                prior to the step
         """
         x_new = self.step(objective_fn, x)
 


### PR DESCRIPTION
**Context:**
The `step_and_cost` function returns the objective function/cost value _prior_ to the step. This might be a bit unclear, and not fully intuitive, but is due to the forward pass being calculated before performing the step.

**Description of the Change:**
The docstrings for all `step_and_cost` function are updated to include a clarification that the cost returned is _prior_ to the step.

**Benefits:**
Clearer docstrings for `step_and_cost`

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None