### PR TITLE
Remove PySCF dependecy from QChem

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,5 +11,5 @@ jobs:
       with:
         docs-folder: "doc/"
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        pre-build-command: "apt install -y graphviz && pip3 install -r requirements.txt && pip3 install . && pip3 install -r qchem/requirements.txt && pip3 install ./qchem"
+        pre-build-command: "apt install -y graphviz && pip3 install -r requirements.txt && pip3 install . && pip3 install -r qchem/requirements.txt && pip3 install pyscf==1.7.2 openfermionpyscf==0.4 && pip3 install ./qchem"
         build-command: "sphinx-build -b html . _build -W --keep-going"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,5 +11,5 @@ jobs:
       with:
         docs-folder: "doc/"
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        pre-build-command: "apt install -y graphviz && pip3 install -r requirements.txt && pip3 install . && pip3 install -r qchem/requirements.txt && pip3 install pyscf==1.7.2 openfermionpyscf==0.4 && pip3 install ./qchem"
+        pre-build-command: "apt install -y graphviz && pip3 install -r requirements.txt && pip3 install . && pip3 install -r qchem/requirements.txt && pip3 install -r qchem/extra_requirements.txt && pip3 install ./qchem"
         build-command: "sphinx-build -b html . _build -W --keep-going"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -153,7 +153,7 @@ jobs:
         run: |
           sudo apt-get install -y openbabel
           conda install psi4 psi4-rt python=3.7 -c psi4
-          pip install pyscf==1.7.2 openfermionpyscf==0.4
+          pip install -r qchem/extra_requirements.txt
           pip install pytest pytest-cov pytest-mock flaky
 
       - name: Install QChem

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -153,6 +153,7 @@ jobs:
         run: |
           sudo apt-get install -y openbabel
           conda install psi4 psi4-rt python=3.7 -c psi4
+          pip install pyscf==1.7.2 openfermionpyscf==0.4
           pip install pytest pytest-cov pytest-mock flaky
 
       - name: Install QChem

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -23,10 +23,7 @@ python:
   install:
     - requirements: doc/requirements.txt
     - requirements: qchem/requirements.txt
-    - method: pip
-      path: pyscf
-    - method: pip
-      path: openfermionpyscf
+    - requirements: qchem/extra_requirements.txt
     - method: pip
       path: .
     - method: pip

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -24,6 +24,10 @@ python:
     - requirements: doc/requirements.txt
     - requirements: qchem/requirements.txt
     - method: pip
+      path: pyscf
+    - method: pip
+      path: openfermionpyscf
+    - method: pip
       path: .
     - method: pip
       path: qchem

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -12,7 +12,6 @@
 #
 # All configuration values have a default; values that are commented out
 # serve to show the default.
-import pyscf
 import sys, os, re
 
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/qchem/extra_requirements.txt
+++ b/qchem/extra_requirements.txt
@@ -1,0 +1,2 @@
+pyscf==1.7.2
+openfermionpyscf==0.4

--- a/qchem/pennylane_qchem/qchem/structure.py
+++ b/qchem/pennylane_qchem/qchem/structure.py
@@ -22,7 +22,16 @@ from openfermion.hamiltonians import MolecularData
 from openfermion.ops._qubit_operator import QubitOperator
 from openfermion.transforms import bravyi_kitaev, get_fermion_operator, jordan_wigner
 from openfermionpsi4 import run_psi4
-from openfermionpyscf import run_pyscf
+try:
+    from openfermionpyscf import run_pyscf
+except ImportError as e:
+    raise ImportError(
+        "PennyLane-QChem requires PySCF as well as the OpenFermion-PySCF plugin "
+        "You can install them via pip:"
+        "\n\npip install pyscf openfermionpyscf"
+        "\n\nFor more details, see the OpenFermion-PySCF plugin page:"
+        "\nhttps://github.com/quantumlib/OpenFermion-PySCF"
+        ) from e
 
 import pennylane as qml
 from pennylane import Hamiltonian

--- a/qchem/requirements.txt
+++ b/qchem/requirements.txt
@@ -3,5 +3,3 @@ scipy
 pennylane>=0.13.0
 openfermion==0.10.0
 openfermionpsi4==0.4
-pyscf==1.7.2
-openfermionpyscf==0.4

--- a/qchem/setup.py
+++ b/qchem/setup.py
@@ -20,9 +20,7 @@ requirements = [
     "pennylane>=0.13",
     "scipy",
     "openfermion",
-    "openfermionpyscf; platform_system != 'Windows'",
     "openfermionpsi4",
-    "pyscf==1.7.2; platform_system != 'Windows'",
 ]
 
 info = {


### PR DESCRIPTION
**Context:**
Pinning `PySCF==1.7.2` is causing issues with plugins that depend on other versions.

**Description of the Change:**
The dependency on `PySCF` is made optional in PennyLane-QChem. `pyscf` and `openfermionpyscf` are removed from the setup and requirements, and an error is raised (with brief installation instructions) if attempting to use those parts of QChem without them being installed.

**Benefits:**
There should be no version conflicts with QChem and plugins using other versions of PySCF.

**Possible Drawbacks:**
This is a quick fix for now. It would be better to find a version that's compatible everywhere.

**Related GitHub Issues:**
None
