### PR TITLE
Enable serialization of `pennylane.qnn.KerasLayer` when using Keras Functional API

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -4,6 +4,25 @@
 
 <h3>Improvements</h3>
 
+* `qnn.KerasLayer` now supports serialization when used in Keras "Functional"
+  API. [(#953)](https://github.com/PennyLaneAI/pennylane/pull/953)
+  
+  This unlocks additional functionality from `tf.keras`, e.g. cloning 
+  models:
+
+  ```python
+  from tensorflow import keras
+  from pennylane.qnn import KerasLayer
+
+  inputs = keras.layers.Input(shape=(num_qubits,))
+  circuit = KerasLayer(my_qnode, weight_shapes=my_weight_shapes, output_dim=num_qubits)(inputs)
+
+  model = keras.Model(inputs=inputs, outputs=circuit)
+
+  # This works now!
+  model_copy = keras.models.clone_model(model)
+  ```
+
 <h3>Breaking changes</h3>
 
 <h3>Documentation</h3>
@@ -13,6 +32,8 @@
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):
+
+Lucas Wolf
 
 # Release 0.13.0 (current release)
 

--- a/pennylane/qnn/keras.py
+++ b/pennylane/qnn/keras.py
@@ -372,6 +372,9 @@ class KerasLayer(Layer):
         return self._input_arg
 
     def get_config(self):
+        """Returns `__init__` args used to construct this instance, allowing
+        serialization of models contianing `KerasLayer`.
+        """
         return {
             "qnode": self.qnode,
             "weight_shapes": self.weight_shapes,

--- a/pennylane/qnn/keras.py
+++ b/pennylane/qnn/keras.py
@@ -378,8 +378,6 @@ class KerasLayer(Layer):
             'weight_shapes': self.weight_shapes,
             'output_dim': self.output_dim,
             'weight_specs': self.weight_specs,
-            'trainable': self.trainable,
-            'dtype': self.dtype,
-            'name': self.name
+            **{k: v for k, v in super().get_config().items() if k != 'dynamic'}
         }
 

--- a/pennylane/qnn/keras.py
+++ b/pennylane/qnn/keras.py
@@ -371,13 +371,11 @@ class KerasLayer(Layer):
         ``"inputs"``."""
         return self._input_arg
 
-
     def get_config(self):
         return {
-            'qnode': self.qnode,
-            'weight_shapes': self.weight_shapes,
-            'output_dim': self.output_dim,
-            'weight_specs': self.weight_specs,
-            **{k: v for k, v in super().get_config().items() if k != 'dynamic'}
+            "qnode": self.qnode,
+            "weight_shapes": self.weight_shapes,
+            "output_dim": self.output_dim,
+            "weight_specs": self.weight_specs,
+            **{k: v for k, v in super().get_config().items() if k != "dynamic"},
         }
-

--- a/pennylane/qnn/keras.py
+++ b/pennylane/qnn/keras.py
@@ -370,3 +370,16 @@ class KerasLayer(Layer):
         `Layer <https://www.tensorflow.org/api_docs/python/tf/keras/layers/Layer>`__. Set to
         ``"inputs"``."""
         return self._input_arg
+
+
+    def get_config(self):
+        return {
+            'qnode': self.qnode,
+            'weight_shapes': self.weight_shapes,
+            'output_dim': self.output_dim,
+            'weight_specs': self.weight_specs,
+            'trainable': self.trainable,
+            'dtype': self.dtype,
+            'name': self.name
+        }
+


### PR DESCRIPTION
**Context:**
This PR allows `KerasLayer` to be serialized when used with Keras' "Functional API."

Example:


```python3
from tensorflow import keras
from pennylane.qnn import KerasLayer

inputs = keras.layers.Input(shape=(num_qubits,))
circuit = KerasLayer(my_qnode, weight_shapes=my_weight_shapes, output_dim=num_qubits)(inputs)

model = keras.Model(inputs=inputs, outputs=circuit)

# This works now!
model_copy = keras.models.clone_model(model)
```


**Description of the Change:**
This PR adds a `get_config` method to `KerasLayer` that returns the arguments supplied to `__init__` when Keras reconstructs the model during deserialization.

**Benefits:**
See above.

**Possible Drawbacks:**
None.

**Related GitHub Issues:**
N/A