### PR TITLE
Correct PR number in changelog

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -28,7 +28,7 @@
 * A new test series, pennylane/devices/tests/test_compare_default_qubit.py, has been added, allowing to test if
   a chosen device gives the same result as the default device. Three tests are added `test_hermitian_expectation`,
   `test_pauliz_expectation_analytic`, and `test_random_circuit`.
-  [(#848)](https://github.com/PennyLaneAI/pennylane/pull/848)
+  [(#897)](https://github.com/PennyLaneAI/pennylane/pull/897)
   
 <h3>Breaking changes</h3>
 


### PR DESCRIPTION
Corrects #897 PR number to point to PR instead of the issue in changelog.