### PR TITLE
Adds analytical channel gradients + (removes unnecessary warnings)

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Release 0.14.0-dev (development release)
 
 <h3>New features since last release</h3>
+* PennyLane now supports analytical gradients for the following noisy channels:
+  `BitFlip`, `PhaseFlip`, and `DepolarizingChannel`. 
+  [(#968)](https://github.com/PennyLaneAI/pennylane/pull/968)
 
 * A new  `qml.draw` function is available, allowing QNodes to be easily
   drawn without execution by providing example input.

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -961,6 +961,7 @@ class Channel(Operation, abc.ABC):
         """
         return self._kraus_matrices(*self.parameters)
 
+
 # =============================================================================
 # Base Observable class
 # =============================================================================

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -961,10 +961,6 @@ class Channel(Operation, abc.ABC):
         """
         return self._kraus_matrices(*self.parameters)
 
-    def __init__(self, *params, wires=None, do_queue=True):
-        super().__init__(*params, wires=wires, do_queue=do_queue)
-
-
 # =============================================================================
 # Base Observable class
 # =============================================================================

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -962,15 +962,6 @@ class Channel(Operation, abc.ABC):
         return self._kraus_matrices(*self.parameters)
 
     def __init__(self, *params, wires=None, do_queue=True):
-
-        # check parameters are valid
-        if self.par_domain == "R" and any(not 0 <= np.real(p) <= 1 for p in params):
-            raise ValueError("Channel probability parameters should be numbers between 0 and 1.")
-
-        # check the grad_method validity
-        if self.par_domain == "R" and self.grad_method not in (None, "F"):
-            raise ValueError("Analytic gradients can not be used for quantum channels.")
-
         super().__init__(*params, wires=wires, do_queue=do_queue)
 
 

--- a/pennylane/ops/channel.py
+++ b/pennylane/ops/channel.py
@@ -211,7 +211,8 @@ class DepolarizingChannel(Channel):
     num_params = 1
     num_wires = 1
     par_domain = "R"
-    grad_method = "F"
+    grad_method = "A"
+    grad_recipe = ([[1, 0, 1], [-1, 0, 0]],)
 
     @classmethod
     def _kraus_matrices(cls, *params):
@@ -255,7 +256,8 @@ class BitFlip(Channel):
     num_params = 1
     num_wires = 1
     par_domain = "R"
-    grad_method = "F"
+    grad_method = "A"
+    grad_recipe = ([[1, 0, 1], [-1, 0, 0]],)
 
     @classmethod
     def _kraus_matrices(cls, *params):
@@ -297,7 +299,8 @@ class PhaseFlip(Channel):
     num_params = 1
     num_wires = 1
     par_domain = "R"
-    grad_method = "F"
+    grad_method = "A"
+    grad_recipe = ([[1, 0, 1], [-1, 0, 0]],)
 
     @classmethod
     def _kraus_matrices(cls, *params):

--- a/tests/ops/test_channel_ops.py
+++ b/tests/ops/test_channel_ops.py
@@ -127,7 +127,7 @@ class TestBitFlip:
         assert np.allclose(op(p, wires=0).kraus_matrices[1], expected_K1, atol=tol, rtol=0)
 
     @pytest.mark.parametrize("angle", np.linspace(0, 2 * np.pi, 7))
-    def test_grad_bitflip(self, angle):
+    def test_grad_bitflip(self, angle, tol):
         """Test that analytical gradient is computed correctly for different states. Channel
         grad recipes are independent of channel parameter"""
 
@@ -142,6 +142,7 @@ class TestBitFlip:
 
         gradient = np.squeeze(qml.grad(circuit)(prob))
         assert gradient == circuit(1)-circuit(0)
+        assert np.allclose(gradient, (-2*np.cos(angle)))
 
 
 class TestPhaseFlip:
@@ -159,7 +160,7 @@ class TestPhaseFlip:
         assert np.allclose(op(p, wires=0).kraus_matrices[1], expected_K1, atol=tol, rtol=0)
 
     @pytest.mark.parametrize("angle", np.linspace(0, 2 * np.pi, 7))
-    def test_grad_phaseflip(self, angle):
+    def test_grad_phaseflip(self, angle, tol):
         """Test that analytical gradient is computed correctly for different states. Channel
         grad recipes are independent of channel parameter"""
 
@@ -174,6 +175,7 @@ class TestPhaseFlip:
 
         gradient = np.squeeze(qml.grad(circuit)(prob))
         assert gradient == circuit(1) - circuit(0)
+        assert np.allclose(gradient, 0.0)
 
 
 class TestDepolarizingChannel:
@@ -193,7 +195,7 @@ class TestDepolarizingChannel:
         assert np.allclose(op(0.1, wires=0).kraus_matrices[1], expected, atol=tol, rtol=0)
 
     @pytest.mark.parametrize("angle", np.linspace(0, 2 * np.pi, 7))
-    def test_grad_depolarizing(self, angle):
+    def test_grad_depolarizing(self, angle, tol):
         """Test that analytical gradient is computed correctly for different states. Channel
         grad recipes are independent of channel parameter"""
 
@@ -208,6 +210,7 @@ class TestDepolarizingChannel:
 
         gradient = np.squeeze(qml.grad(circuit)(prob))
         assert gradient == circuit(1) - circuit(0)
+        assert np.allclose(gradient, -(4/3) * np.cos(angle))
 
 
 class TestQubitChannel:

--- a/tests/ops/test_channel_ops.py
+++ b/tests/ops/test_channel_ops.py
@@ -34,7 +34,7 @@ ch_list = [
     channel.DepolarizingChannel,
 ]
 
-
+pytestmark = pytest.mark.usefixtures("tape_mode")
 class TestChannels:
     """Tests for the quantum channels"""
 
@@ -139,7 +139,7 @@ class TestBitFlip:
             qml.BitFlip(p, wires=0)
             return qml.expval(qml.PauliZ(0))
 
-        gradient = np.squeeze(circuit.jacobian(prob))
+        gradient = np.squeeze(qml.grad(circuit)(prob))
         assert gradient == circuit(1)-circuit(0)
 
 
@@ -171,7 +171,7 @@ class TestPhaseFlip:
             qml.PhaseFlip(p, wires=0)
             return qml.expval(qml.PauliZ(0))
 
-        gradient = np.squeeze(circuit.jacobian(prob))
+        gradient = np.squeeze(qml.grad(circuit)(prob))
         assert gradient == circuit(1) - circuit(0)
 
 
@@ -205,7 +205,7 @@ class TestDepolarizingChannel:
             qml.DepolarizingChannel(p, wires=0)
             return qml.expval(qml.PauliZ(0))
 
-        gradient = np.squeeze(circuit.jacobian(prob))
+        gradient = np.squeeze(qml.grad(circuit)(prob))
         assert gradient == circuit(1) - circuit(0)
 
 

--- a/tests/ops/test_channel_ops.py
+++ b/tests/ops/test_channel_ops.py
@@ -51,18 +51,6 @@ class TestChannels:
         Kraus_sum = np.einsum("ajk,ajl->kl", K_arr.conj(), K_arr)
         assert np.allclose(Kraus_sum, np.eye(2), atol=tol, rtol=0)
 
-    @pytest.mark.parametrize("ops", ch_list)
-    @pytest.mark.parametrize("p", [1.5])
-    def test_valid_input(self, ops, p):
-        """Test input parameters are valid probabilities"""
-        if ops.__name__ == "GeneralizedAmplitudeDamping":
-            with pytest.raises(ValueError, match="Channel probability parameters should be"):
-                ops(0.1, p, wires=0)
-        else:
-            with pytest.raises(ValueError, match="Channel probability parameters should be"):
-                ops(p, wires=0)
-
-
 class TestAmplitudeDamping:
     """Tests for the quantum channel AmplitudeDamping"""
 
@@ -137,6 +125,23 @@ class TestBitFlip:
         expected_K1 = np.sqrt(p) * X
         assert np.allclose(op(p, wires=0).kraus_matrices[1], expected_K1, atol=tol, rtol=0)
 
+    @pytest.mark.parametrize("angle", np.linspace(0, 2 * np.pi, 7))
+    def test_grad_bitflip(self, angle):
+        """Test that analytical gradient is computed correctly for different states. Channel
+        grad recipes are independent of channel parameter"""
+
+        dev = qml.device("default.mixed", wires=1)
+        prob = 0.5
+
+        @qml.qnode(dev)
+        def circuit(p):
+            qml.RX(angle, wires=0)
+            qml.BitFlip(p, wires=0)
+            return qml.expval(qml.PauliZ(0))
+
+        gradient = np.squeeze(circuit.jacobian(prob))
+        assert gradient == circuit(1)-circuit(0)
+
 
 class TestPhaseFlip:
     """Test that various values of p give correct Kraus matrices"""
@@ -151,6 +156,23 @@ class TestPhaseFlip:
 
         expected_K1 = np.sqrt(p) * Z
         assert np.allclose(op(p, wires=0).kraus_matrices[1], expected_K1, atol=tol, rtol=0)
+
+    @pytest.mark.parametrize("angle", np.linspace(0, 2 * np.pi, 7))
+    def test_grad_phaseflip(self, angle):
+        """Test that analytical gradient is computed correctly for different states. Channel
+        grad recipes are independent of channel parameter"""
+
+        dev = qml.device("default.mixed", wires=1)
+        prob = 0.5
+
+        @qml.qnode(dev)
+        def circuit(p):
+            qml.RX(angle, wires=0)
+            qml.PhaseFlip(p, wires=0)
+            return qml.expval(qml.PauliZ(0))
+
+        gradient = np.squeeze(circuit.jacobian(prob))
+        assert gradient == circuit(1) - circuit(0)
 
 
 class TestDepolarizingChannel:
@@ -168,6 +190,23 @@ class TestDepolarizingChannel:
         op = channel.DepolarizingChannel
         expected = np.sqrt(p / 3) * X
         assert np.allclose(op(0.1, wires=0).kraus_matrices[1], expected, atol=tol, rtol=0)
+
+    @pytest.mark.parametrize("angle", np.linspace(0, 2 * np.pi, 7))
+    def test_grad_depolarizing(self, angle):
+        """Test that analytical gradient is computed correctly for different states. Channel
+        grad recipes are independent of channel parameter"""
+
+        dev = qml.device("default.mixed", wires=1)
+        prob = 0.5
+
+        @qml.qnode(dev)
+        def circuit(p):
+            qml.RX(angle, wires=0)
+            qml.DepolarizingChannel(p, wires=0)
+            return qml.expval(qml.PauliZ(0))
+
+        gradient = np.squeeze(circuit.jacobian(prob))
+        assert gradient == circuit(1) - circuit(0)
 
 
 class TestQubitChannel:

--- a/tests/ops/test_channel_ops.py
+++ b/tests/ops/test_channel_ops.py
@@ -20,6 +20,7 @@ import numpy as np
 import pennylane as qml
 from pennylane.ops import channel
 from pennylane.wires import Wires
+pytestmark = pytest.mark.usefixtures("tape_mode")
 
 X = np.array([[0, 1], [1, 0]])
 Y = np.array([[0, -1j], [1j, 0]])

--- a/tests/ops/test_channel_ops.py
+++ b/tests/ops/test_channel_ops.py
@@ -35,7 +35,6 @@ ch_list = [
     channel.DepolarizingChannel,
 ]
 
-pytestmark = pytest.mark.usefixtures("tape_mode")
 class TestChannels:
     """Tests for the quantum channels"""
 

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -406,7 +406,7 @@ class TestOperationConstruction:
 
     def test_list_of_arrays(self):
         """Test that an exception is raised if a list of arrays is expected
-         but a list of mixed types is passed"""
+        but a list of mixed types is passed"""
 
         class DummyOp(qml.operation.Operation):
             r"""Dummy custom operation"""
@@ -580,19 +580,19 @@ class TestObservableConstruction:
     def test_repr(self):
         """Test the string representation of an observable with and without a return type."""
 
-        m = qml.expval(qml.PauliZ(wires=['a']) @ qml.PauliZ(wires=['b']))
+        m = qml.expval(qml.PauliZ(wires=["a"]) @ qml.PauliZ(wires=["b"]))
         expected = "expval(PauliZ(wires=['a']) @ PauliZ(wires=['b']))"
         assert str(m) == expected
 
-        m = qml.probs(wires=['a'])
+        m = qml.probs(wires=["a"])
         expected = "probs(wires=['a'])"
         assert str(m) == expected
 
-        m = qml.PauliZ(wires=['a']) @ qml.PauliZ(wires=['b'])
+        m = qml.PauliZ(wires=["a"]) @ qml.PauliZ(wires=["b"])
         expected = "PauliZ(wires=['a']) @ PauliZ(wires=['b'])"
         assert str(m) == expected
 
-        m = qml.PauliZ(wires=['a'])
+        m = qml.PauliZ(wires=["a"])
         expected = "PauliZ(wires=['a'])"
         assert str(m) == expected
 
@@ -1428,26 +1428,3 @@ class TestChannel:
         expected = np.array([[0, np.sqrt(0.1)], [np.sqrt(0.1), 0]])
         op = DummyOp(0.1, wires=0)
         assert np.all(op.kraus_matrices[0] == expected)
-
-    def test_grad_method(self):
-        """Test that an exception is raised if a gradient method is set to analytic
-        as only finite difference or ``None`` is allowed at the moment. This can be updated
-        once we add gradient recipes for channels. """
-
-        class DummyOp(qml.operation.Channel):
-            r"""Dummy custom channel"""
-            num_wires = 1
-            num_params = 1
-            par_domain = "R"
-            grad_method = "A"
-
-            def _kraus_matrices(self, *params):
-                p = params[0]
-                K1 = np.sqrt(p) * X
-                K2 = np.sqrt(1 - p) * I
-                return [K1, K2]
-
-        with pytest.raises(
-            ValueError, match="Analytic gradients can not be used for quantum channels"
-        ):
-            DummyOp(0.5, wires=0)


### PR DESCRIPTION
This PR adds analytical gradient recipes for channels that support them, namely `BitFlip`, `PhaseFlip`, and `DepolarizingChannel`. It also removes:
1. A warning stating that analytical gradients are not supported for channels (now they are!) 
2. A check that was made to ensure that channel parameters were valid probabilities. This latter led to problems when parameters were circuit variables and in any case was not preventing parameters to have negative values during optimization