### PR TITLE
Update OpenFermion import paths

### DIFF
--- a/qchem/CHANGELOG.md
+++ b/qchem/CHANGELOG.md
@@ -1,18 +1,14 @@
-# Release 0.14.0-dev
-
-<h3>New features since last release</h3>
-
-<h3>Improvements</h3>
-
-<h3>Breaking changes</h3>
-
-<h3>Documentation</h3>
+# Release 0.13.1
 
 <h3>Bug fixes</h3>
+
+* Updates `PennyLane-QChem` to support the new OpenFermion v1.0 release.
 
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):
+
+Josh Izaac
 
 # Release 0.13.0
 

--- a/qchem/CHANGELOG.md
+++ b/qchem/CHANGELOG.md
@@ -3,6 +3,7 @@
 <h3>Bug fixes</h3>
 
 * Updates `PennyLane-QChem` to support the new OpenFermion v1.0 release.
+  [(#973)](https://github.com/PennyLaneAI/pennylane/pull/973)
 
 <h3>Contributors</h3>
 

--- a/qchem/pennylane_qchem/_version.py
+++ b/qchem/pennylane_qchem/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.14.0-dev"
+__version__ = "0.13.1"

--- a/qchem/pennylane_qchem/qchem/structure.py
+++ b/qchem/pennylane_qchem/qchem/structure.py
@@ -18,8 +18,7 @@ import subprocess
 from shutil import copyfile
 
 import numpy as np
-from openfermion.hamiltonians import MolecularData
-from openfermion.ops._qubit_operator import QubitOperator
+from openfermion import MolecularData, QubitOperator
 from openfermion.transforms import bravyi_kitaev, get_fermion_operator, jordan_wigner
 from openfermionpsi4 import run_psi4
 from openfermionpyscf import run_pyscf

--- a/qchem/requirements.txt
+++ b/qchem/requirements.txt
@@ -1,7 +1,7 @@
 numpy
 scipy
 pennylane>=0.13.0
-openfermion==0.10.0
+openfermion==1.0
 openfermionpsi4==0.4
 pyscf==1.7.2
 openfermionpyscf==0.4

--- a/qchem/requirements.txt
+++ b/qchem/requirements.txt
@@ -2,6 +2,6 @@ numpy
 scipy
 pennylane>=0.13.0
 openfermion==1.0
-openfermionpsi4==0.4
+openfermionpsi4==0.5
 pyscf==1.7.2
-openfermionpyscf==0.4
+openfermionpyscf==0.5

--- a/qchem/setup.py
+++ b/qchem/setup.py
@@ -20,8 +20,8 @@ requirements = [
     "pennylane>=0.13",
     "scipy",
     "openfermion>=1.0",
-    "openfermionpyscf; platform_system != 'Windows'",
-    "openfermionpsi4",
+    "openfermionpyscf>=0.5; platform_system != 'Windows'",
+    "openfermionpsi4>=0.5",
     "pyscf==1.7.2; platform_system != 'Windows'",
 ]
 

--- a/qchem/setup.py
+++ b/qchem/setup.py
@@ -19,7 +19,7 @@ with open("pennylane_qchem/_version.py") as f:
 requirements = [
     "pennylane>=0.13",
     "scipy",
-    "openfermion",
+    "openfermion>=1.0",
     "openfermionpyscf; platform_system != 'Windows'",
     "openfermionpsi4",
     "pyscf==1.7.2; platform_system != 'Windows'",

--- a/qchem/tests/test_active_space.py
+++ b/qchem/tests/test_active_space.py
@@ -4,7 +4,7 @@ import pytest
 
 from pennylane import qchem
 
-from openfermion.hamiltonians import MolecularData
+from openfermion import MolecularData
 
 ref_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "test_ref_files")
 

--- a/qchem/tests/test_convert_observable.py
+++ b/qchem/tests/test_convert_observable.py
@@ -3,7 +3,7 @@ import os
 import numpy as np
 import pennylane as qml
 import pytest
-from openfermion.ops._qubit_operator import QubitOperator
+from openfermion import QubitOperator
 
 from pennylane import qchem
 

--- a/qchem/tests/test_meanfield.py
+++ b/qchem/tests/test_meanfield.py
@@ -2,7 +2,7 @@ import os
 
 import numpy as np
 import pytest
-from openfermion.hamiltonians import MolecularData
+from openfermion import MolecularData
 
 from pennylane import qchem
 

--- a/qchem/tests/test_observable.py
+++ b/qchem/tests/test_observable.py
@@ -5,7 +5,7 @@ import pytest
 
 from pennylane import qchem
 
-from openfermion.ops import FermionOperator, QubitOperator
+from openfermion import FermionOperator, QubitOperator
 
 t = FermionOperator("0^ 0", 0.5) + FermionOperator("1^ 1", -0.5)
 

--- a/qchem/tests/test_one_particle.py
+++ b/qchem/tests/test_one_particle.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 from pennylane import qchem
-from openfermion.hamiltonians import MolecularData
+from openfermion import MolecularData
 
 ref_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "test_ref_files")
 

--- a/qchem/tests/test_particle_number_obs.py
+++ b/qchem/tests/test_particle_number_obs.py
@@ -5,7 +5,7 @@ import pytest
 
 from pennylane import qchem
 
-from openfermion.ops._qubit_operator import QubitOperator
+from openfermion import QubitOperator
 
 terms_h20_jw_full = {
     (): (7 + 0j),

--- a/qchem/tests/test_s2_obs.py
+++ b/qchem/tests/test_s2_obs.py
@@ -5,7 +5,7 @@ import pytest
 
 from pennylane import qchem
 
-from openfermion.ops._qubit_operator import QubitOperator
+from openfermion import QubitOperator
 
 
 me_1 = np.array([[0.0, 0.0, 0.0, 0.0, 0.25],])

--- a/qchem/tests/test_sz_obs.py
+++ b/qchem/tests/test_sz_obs.py
@@ -5,7 +5,7 @@ import pytest
 
 from pennylane import qchem
 
-from openfermion.ops._qubit_operator import QubitOperator
+from openfermion import QubitOperator
 
 
 terms_1_jw = {

--- a/qchem/tests/test_two_particle.py
+++ b/qchem/tests/test_two_particle.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 from pennylane import qchem
-from openfermion.hamiltonians import MolecularData
+from openfermion import MolecularData
 
 ref_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "test_ref_files")
 


### PR DESCRIPTION
**Context:** OpenFermion v1.0 was recently released, which features a reorganization of the library. As a result, `qml.qchem` will fail on import if the latest version of OpenFermion is installed.

**Description of the Change:**

* Updates the import paths.

**Benefits:**

* The new import paths are backwards compatible with OpenFermion v0.11; qchem was previously importing based on the file location rather than the documented import location.

**Possible Drawbacks:**

* A bugfix release of QChem will need to be made ASAP to allow QChem to continue working for current users.

**Related GitHub Issues:** n/a
