### PR TITLE
Run device comparison test in tape mode

### DIFF
--- a/pennylane/devices/tests/test_compare_default_qubit.py
+++ b/pennylane/devices/tests/test_compare_default_qubit.py
@@ -198,7 +198,9 @@ class TestComparison:
                         params = list(np.pi * np.random.rand(gate.num_params))
                         gate(
                             *params,
-                            wires=np.random.choice(range(n_wires), size=gate.num_wires, replace=False)
+                            wires=np.random.choice(
+                                range(n_wires), size=gate.num_wires, replace=False
+                            )
                         )
                 return qml.expval(qml.PauliZ(0))
 


### PR DESCRIPTION
We are currently seeing the `cirq.simulator` device failing with a [strange error](https://github.com/PennyLaneAI/plugin-test-matrix/runs/1665972116?check_suite_focus=true) when tested against the shared device tests. The `test_four_qubit_random_circuit` test in particular is the one failing.

This test works by randomly generating parameters on the [line](https://github.com/PennyLaneAI/pennylane/blob/f4f2bd4bec288948118962b6d7227b3d16e88b0b/pennylane/devices/tests/test_compare_default_qubit.py#L191) `params = list(np.pi * np.random.rand(gate.num_params))`, which is placed *within* the QNode function (`circuit()`). Here, `params` is a list of PennyLane tensors.

In non-tape mode, parameters are expected to be initialized outside of the QNode and are then unwrapped to base NumPy arrays when sent to the device. By defining the parameters as we do in the test above, we see them reach the device in PennyLane Tensor form. In the Cirq device, most gates do not seem to mind working with a PennyLane tensor, but at least the `rz` gate finds this representation problematic and causes an error.

To fix this, we could either:
1. Have the test convert to a list of NumPy arrays
2. Add a line in the Device to ensure we convert to a list of NumPy arrays
3. Perform the test in tape mode

Indeed, this issue is strongly linked to https://github.com/PennyLaneAI/pennylane/pull/941, which ensures that unwrapping always occurs in tape mode.

Since we are anyway moving towards tape mode, I propose to adopt option 3 in this PR. Keeping the defined parameters as a list of PennyLane tensors is anyway a nice compatibility test.