### PR TITLE
Automatic bug assignment

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -4,7 +4,7 @@ Search existing GitHub issues to make sure the issue does not already exist:
 https://github.com/xanaduai/pennylane/issues
 
 If posting a PennyLane issue, delete everything above the dashed line, and fill
-in the template.
+in the template. If the issue is a bug, start the title of the issue with [BUG].
 
 If making a feature request, delete the following template and describe, in detail,
 the feature and why it is needed.

--- a/.github/workflows/assign_bugs.yml
+++ b/.github/workflows/assign_bugs.yml
@@ -10,5 +10,5 @@ jobs:
       - uses: Naturalclar/issue-action@v2.0.2
         with:
           title-or-body: "both"
-          parameters: '[ {"keywords": ["[BUG]", "bug", "error"], "labels": ["Bug", "BUG"], "assignees": ["antalszava"]}]'
+          parameters: '[ {"keywords": ["[BUG]", "bug"], "labels": ["Bug", "BUG"], "assignees": ["antalszava"]}]'
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/assign_bugs.yml
+++ b/.github/workflows/assign_bugs.yml
@@ -10,5 +10,5 @@ jobs:
       - uses: Naturalclar/issue-action@v2.0.2
         with:
           title-or-body: "both"
-          parameters: '[ {"keywords": ["[BUG]", "bug"], "labels": ["Bug", "BUG"], "assignees": ["antalszava"]}]'
+          parameters: '[ {"keywords": ["[BUG]", "bug"], "labels": ["bug :bug:"], "assignees": ["antalszava"]}]'
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/assign_bugs.yml
+++ b/.github/workflows/assign_bugs.yml
@@ -1,0 +1,14 @@
+name: "Set Bug Issue Label and Assignee"
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  autoassign:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Naturalclar/issue-action@v2.0.2
+        with:
+          title-or-body: "both"
+          parameters: '[ {"keywords": ["[BUG]", "bug", "error"], "labels": ["Bug", "BUG"], "assignees": ["antalszava"]}]'
+          github-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
**Context**

Adds an action that checks if an issue contains the `[BUG]` or `bug` keywords once being opened and:

* Assigns the `bug` label;
* Assigns people listed in advance to the issue.

Updates the issue template to encourage using the `[BUG]` keyword in the title of bug issues.

**Benefits**

Automated bug labelling and assignment to the team.

**Things to note**

* Checking the issue is done based on the text in the title and the body of the issue. That is, an issue labelled as `bug` will not be assigned automatically unless the correct keyword was used in the corresponding texts.
* Users to be assigned & listed are done statically for now. This will likely be subject to change and superceded. The approach taken is a beneficial starting point.

**Examples**

See https://github.com/antalszava/bugs-scan/issues/6 and further issues in the repository for examples.