### PR TITLE
avoid redefining a build-in type

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -2,8 +2,8 @@
 pip
 appdirs
 autograd
-jax
-jaxlib
+jax==0.2.7
+jaxlib==0.1.57
 m2r
 numpy
 pygments-github-lexers

--- a/pennylane/circuit_graph.py
+++ b/pennylane/circuit_graph.py
@@ -91,18 +91,18 @@ def _is_observable(x):
     return getattr(x, "return_type", None) is not None
 
 
-def _list_at_index_or_none(list, idx):
+def _list_at_index_or_none(ls, idx):
     """Return the element of a list at the given index if it exists, return None otherwise.
 
     Args:
-        list (list[object]): The target list
+        ls (list[object]): The target list
         idx (int): The target index
 
     Returns:
         Union[object,NoneType]: The element at the target index or None
     """
-    if len(list) > idx:
-        return list[idx]
+    if len(ls) > idx:
+        return ls[idx]
 
     return None
 


### PR DESCRIPTION
This pull request fixes a small function that names a variable `list`, thus overriding python's inbuilt type.