### PR TITLE
Faster wire combining.

### DIFF
--- a/pennylane/wires.py
+++ b/pennylane/wires.py
@@ -365,7 +365,7 @@ class Wires(Sequence):
 
         first_wires_obj = list_of_wires[0]
         sets_of_wires = [wire.toset() for wire in list_of_wires]
-        # This find the intersection of the labels of all wires in O(n) time.
+        # find the intersection of the labels of all wires in O(n) time.
         intersecting_wires = functools.reduce(
             lambda a, b: a & b, sets_of_wires, first_wires_obj.toset()
         )

--- a/pennylane/wires.py
+++ b/pennylane/wires.py
@@ -96,9 +96,9 @@ class Wires(Sequence):
         """Method checking if Wires object contains an object."""
         if isinstance(item, Wires):
             item = item.toset()
-        # if all wires can be found in tuple, return True, else False
-        items_set = set(item)
-        not_found_items = (items_set ^ set(self.labels)) & items_set
+        else:
+            item = set(item)
+        not_found_items = item - set(self.labels)
         return not bool(not_found_items)
 
     def __repr__(self):
@@ -363,14 +363,16 @@ class Wires(Sequence):
                     "Expected a Wires object; got {} of type {}.".format(wires, type(wires))
                 )
 
-        first_wire = list_of_wires[0]
+        first_wires_obj = list_of_wires[0]
         sets_of_wires = [wire.toset() for wire in list_of_wires]
         # This find the intersection of the labels of all wires in O(n) time.
-        intersecting_wires = functools.reduce(lambda a, b: a & b, sets_of_wires, first_wire.toset())
+        intersecting_wires = functools.reduce(
+            lambda a, b: a & b, sets_of_wires, first_wires_obj.toset()
+        )
         shared = []
         # only need to iterate through the first object,
         # since any wire not in this object will also not be shared
-        for wire in first_wire.tolist():
+        for wire in first_wires_obj.tolist():
             if wire in intersecting_wires:
                 shared.append(wire)
 
@@ -407,13 +409,13 @@ class Wires(Sequence):
 
         label_sets = map(lambda x: x.toset(), list_of_wires)
         # This makes a set of all labels in O(n) time.
-        all_labels = functools.reduce(lambda a, b: a | b, label_sets, set())
+        uncombined_set = functools.reduce(lambda a, b: a | b, label_sets, set())
         combined = []
         for wires in list_of_wires:
-            extension = [wire for wire in wires.labels if wire in all_labels]
+            extension = [wire for wire in wires.labels if wire in uncombined_set]
             combined.extend(extension)
             for wire in extension:
-                all_labels.remove(wire)
+                uncombined_set.remove(wire)
 
         if sort:
             if all([isinstance(w, int) for w in combined]):
@@ -468,6 +470,5 @@ class Wires(Sequence):
                 # check that wire is only contained in one of the Wires objects
                 if wire in seen_once:
                     unique.append(wire)
-                    seen_once.remove(wire)
 
         return Wires(unique)

--- a/pennylane/wires.py
+++ b/pennylane/wires.py
@@ -454,7 +454,11 @@ class Wires(Sequence):
 
         # Find unique set in O(n) time.
         for labels in label_sets:
+            # (seen_once ^ labels) finds all of the unique labels seen once
+            # (seen_ever - seen_once) is the set of labels already seen more than once
+            # Subtracting these two sets makes a set of labels only seen once so far.
             seen_once = (seen_once ^ labels) - (seen_ever - seen_once)
+            # Update seen labels with all new seen labels
             seen_ever.update(labels)
 
         # Get unique values in order they appear.

--- a/pennylane/wires.py
+++ b/pennylane/wires.py
@@ -15,9 +15,9 @@
 This module contains the :class:`Wires` class, which takes care of wire bookkeeping.
 """
 from collections.abc import Sequence, Iterable
+import functools
 import numpy as np
 from numbers import Number
-import functools
 
 
 class WireError(Exception):
@@ -366,8 +366,7 @@ class Wires(Sequence):
         first_wire = list_of_wires[0]
         sets_of_wires = [wire.toset() for wire in list_of_wires]
         # This find the intersection of the labels of all wires in O(n) time.
-        intersecting_wires = functools.reduce(
-            lambda a, b: a & b, sets_of_wires, first_wire.toset())
+        intersecting_wires = functools.reduce(lambda a, b: a & b, sets_of_wires, first_wire.toset())
         shared = []
         # only need to iterate through the first object,
         # since any wire not in this object will also not be shared

--- a/pennylane/wires.py
+++ b/pennylane/wires.py
@@ -401,21 +401,17 @@ class Wires(Sequence):
         >>> Wires.all_wires(list_of_wires)
         <Wires = [4, 0, 1, 3, 5]>
         """
+        combined = []
+        seen_labels = set()
         for wires in list_of_wires:
             if not isinstance(wires, Wires):
                 raise WireError(
                     "Expected a Wires object; got {} of type {}".format(wires, type(wires))
                 )
 
-        label_sets = map(lambda x: x.toset(), list_of_wires)
-        # This makes a set of all labels in O(n) time.
-        uncombined_set = functools.reduce(lambda a, b: a | b, label_sets, set())
-        combined = []
-        for wires in list_of_wires:
-            extension = [wire for wire in wires.labels if wire in uncombined_set]
+            extension = [label for label in wires.labels if label not in seen_labels]
             combined.extend(extension)
-            for wire in extension:
-                uncombined_set.remove(wire)
+            seen_labels.update(extension)
 
         if sort:
             if all([isinstance(w, int) for w in combined]):

--- a/pennylane/wires.py
+++ b/pennylane/wires.py
@@ -366,7 +366,8 @@ class Wires(Sequence):
         first_wire = list_of_wires[0]
         sets_of_wires = [wire.toset() for wire in list_of_wires]
         # This find the intersection of the labels of all wires in O(n) time.
-        intersecting_wires = functools.reduce(lambda a, b: a & b, sets_of_wires)
+        intersecting_wires = functools.reduce(
+            lambda a, b: a & b, sets_of_wires, first_wire.toset())
         shared = []
         # only need to iterate through the first object,
         # since any wire not in this object will also not be shared
@@ -407,7 +408,7 @@ class Wires(Sequence):
 
         label_sets = map(lambda x: x.toset(), list_of_wires)
         # This makes a set of all labels in O(n) time.
-        all_labels = functools.reduce(lambda a, b: a | b, label_sets)
+        all_labels = functools.reduce(lambda a, b: a | b, label_sets, set())
         combined = []
         for wires in list_of_wires:
             extension = [wire for wire in wires.labels if wire in all_labels]


### PR DESCRIPTION
**Context:**
Make wire combining faster with sets.


**Description of the Change:**

Many of the wire combination methods (`shared_wires`, `all_wires` and `unique_wires`) previously used `if wire in list` a lot, which takes linear time when searching. These linear time searches were then looped over, causing the final run times to be O(n^2) where n is the number of labels. We replace many of these methods with faster methods that instead use `set`s, reducing their runtimes to just O(n).

Speedups:
```
all_wires small -10%
shared_wires small +25%
unique_wires small +67%
all_wires large +21%
shared_wires large +72%
unique_wires large +86%
```

See full benchmarks in comment below.


These improvements are orthogonal to David's improvements: #983

**Benefits:**
Wires should be faster

**Possible Drawbacks:**
None

**Related GitHub Issues:**
#967 
