### PR TITLE
Fix bug where a QNode with a single probability output was not correctly differentiated

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -238,6 +238,10 @@
 * `qml.vqe.Hamiltonian` prints any observable with any number of strings.
   [(#987)](https://github.com/PennyLaneAI/pennylane/pull/987)
 
+* Fixes a bug where tape-mode parameter-shift differentiation would fail if the QNode
+  contained a single probability output.
+  [(#)](https://github.com/PennyLaneAI/pennylane/pull/)
+
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -240,7 +240,7 @@
 
 * Fixes a bug where tape-mode parameter-shift differentiation would fail if the QNode
   contained a single probability output.
-  [(#)](https://github.com/PennyLaneAI/pennylane/pull/)
+  [(#1007)](https://github.com/PennyLaneAI/pennylane/pull/1007)
 
 <h3>Contributors</h3>
 

--- a/pennylane/tape/tapes/qubit_param_shift.py
+++ b/pennylane/tape/tapes/qubit_param_shift.py
@@ -169,7 +169,7 @@ class QubitParamShiftTape(JacobianTape):
                 array[float]: 1-dimensional array of length determined by the tape output
                 measurement statistics
             """
-            return np.dot(coeffs, results)
+            return np.dot(coeffs, np.squeeze(results))
 
         return tapes, processing_fn
 
@@ -354,6 +354,6 @@ class QubitParamShiftTape(JacobianTape):
                 array[float]: 1-dimensional array of length determined by the tape output
                 measurement statistics
             """
-            return np.dot(coeffs, results)
+            return np.dot(coeffs, np.squeeze(results))
 
         return tapes, processing_fn

--- a/tests/tape/interfaces/test_qnode_autograd.py
+++ b/tests/tape/interfaces/test_qnode_autograd.py
@@ -440,7 +440,32 @@ class TestQNode:
 
     def test_probability_differentiation(self, dev_name, diff_method, tol):
         """Tests correct output shape and evaluation for a tape
-        with prob and expval outputs"""
+        with a single prob output"""
+
+        dev = qml.device(dev_name, wires=2)
+        x = np.array(0.543, requires_grad=True)
+        y = np.array(-0.654, requires_grad=True)
+
+        @qnode(dev, diff_method=diff_method, interface="autograd")
+        def circuit(x, y):
+            qml.RX(x, wires=[0])
+            qml.RY(y, wires=[1])
+            qml.CNOT(wires=[0, 1])
+            return qml.probs(wires=[1])
+
+        res = qml.jacobian(circuit)(x, y)
+
+        expected = np.array(
+            [
+                [-np.sin(x) * np.cos(y) / 2, -np.cos(x) * np.sin(y) / 2],
+                [np.cos(y) * np.sin(x) / 2, np.cos(x) * np.sin(y) / 2],
+            ]
+        )
+        assert np.allclose(res, expected, atol=tol, rtol=0)
+
+    def test_multiple_probability_differentiation(self, dev_name, diff_method, tol):
+        """Tests correct output shape and evaluation for a tape
+        with multiple prob outputs"""
 
         dev = qml.device(dev_name, wires=2)
         x = np.array(0.543, requires_grad=True)

--- a/tests/tape/interfaces/test_qnode_autograd.py
+++ b/tests/tape/interfaces/test_qnode_autograd.py
@@ -461,7 +461,7 @@ class TestQNode:
                 [np.cos(y) * np.sin(x) / 2, np.cos(x) * np.sin(y) / 2],
             ]
         )
-        assert np.testing.assert_allclose(res, expected, atol=tol, rtol=0)
+        assert np..allclose(res, expected, atol=tol, rtol=0)
 
     def test_multiple_probability_differentiation(self, dev_name, diff_method, tol):
         """Tests correct output shape and evaluation for a tape

--- a/tests/tape/interfaces/test_qnode_autograd.py
+++ b/tests/tape/interfaces/test_qnode_autograd.py
@@ -461,7 +461,7 @@ class TestQNode:
                 [np.cos(y) * np.sin(x) / 2, np.cos(x) * np.sin(y) / 2],
             ]
         )
-        assert np..allclose(res, expected, atol=tol, rtol=0)
+        assert np.allclose(res, expected, atol=tol, rtol=0)
 
     def test_multiple_probability_differentiation(self, dev_name, diff_method, tol):
         """Tests correct output shape and evaluation for a tape

--- a/tests/tape/interfaces/test_qnode_autograd.py
+++ b/tests/tape/interfaces/test_qnode_autograd.py
@@ -461,7 +461,7 @@ class TestQNode:
                 [np.cos(y) * np.sin(x) / 2, np.cos(x) * np.sin(y) / 2],
             ]
         )
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        assert np.testing.assert_allclose(res, expected, atol=tol, rtol=0)
 
     def test_multiple_probability_differentiation(self, dev_name, diff_method, tol):
         """Tests correct output shape and evaluation for a tape


### PR DESCRIPTION
**Context:**

QNodes with a single probability output, of the form

```python
@qml.qnode(dev)
def circuit(x, y):
    qml.RX(x, wires=[0])
    qml.RY(y, wires=[1])
    qml.CNOT(wires=[0, 1])
    return qml.probs(wires=[1])
```

would result in the following error when differentiated in tape-mode using the parameter-shift rule:

```
  File "/home/pennylane/tape/tapes/qubit_param_shift.py", line 172, in processing_fn
    return np.dot(coeffs, results)
  File "<__array_function__ internals>", line 6, in dot
ValueError: shapes (2,) and (2,1,2) not aligned: 2 (dim 0) != 1 (dim 1)
```

This is due to the fact that we are using `np.dot(coeffs, results)` as a shorthand for `[c*r for c, r in zip(coeffs, results)]`. However, in the case of returning a single probability array, NumPy attempts to broadcast the dot product instead.

Note that this bug does not affect the case `return qml.probs(wires=0), qml.probs(wires=1)` (e.g., when multiple probability arrays are returned), as `np.dot` behaviour coincides again with `[c*r for c, r in zip(coeffs, results)]`.

**Description of the Change:**

Changes the line to `np.dot(coeffs, np.squeeze(results))`, to avoid broadcasting issues.

**Benefits:**

The use case specified above now works.

**Possible Drawbacks:** n/a

**Related GitHub Issues:** n/a
