### PR TITLE
Store wire label indices in dict

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -177,12 +177,15 @@
 
 * * Several improvements have been made to the `Wires` class to reduce overhead:
   [(#967)](https://github.com/PennyLaneAI/pennylane/pull/967)
+  [(#1015)](https://github.com/PennyLaneAI/pennylane/pull/1015)
 
   - Moves the check for uniqueness of wires from `Wires` instantiation to
     the `qml.wires._process` function in order to reduce overhead from repeated
     creation of `Wires` instances.
   
   - Skips calling of Wires on Wires instances on `Operation` instantiation.
+
+  - Stores the indices of `Wires` labels in a dictionary to fasten indexing.
   
 * Adds the `PauliRot` generator to the `qml.operation` module. This 
   generator is required to construct the metric tensor. 
@@ -250,7 +253,8 @@
 
 This release contains contributions from (in alphabetical order):
 
-Olivia Di Matteo, Josh Izaac, Christina Lee, Alejandro Montanez, Steven Oud, Chase Roberts, Maria Schuld, David Wierichs, Jiahao Yao.
+Olivia Di Matteo, Josh Izaac, Christina Lee, Alejandro Montanez, Steven Oud, Chase Roberts,
+Maria Schuld, David Wierichs, Jiahao Yao, Antal Száva.
 
 # Release 0.13.0 (current release)
 

--- a/pennylane/wires.py
+++ b/pennylane/wires.py
@@ -203,6 +203,12 @@ class Wires(Sequence):
 
             wire = wire[0]
 
+        if isinstance(wire, np.ndarray):
+            if wire.size != 1:
+                raise WireError("Can only retrieve index of a Wires object of length 1.") from e
+
+            wire = wire.item()
+
         try:
             return self._label_indices[wire]
         except KeyError as e:

--- a/pennylane/wires.py
+++ b/pennylane/wires.py
@@ -205,7 +205,7 @@ class Wires(Sequence):
 
         if isinstance(wire, np.ndarray):
             if wire.size != 1:
-                raise WireError("Can only retrieve index of a Wires object of length 1.") from e
+                raise WireError("Can only retrieve index of a numpy array of size 1.")
 
             wire = wire.item()
 

--- a/pennylane/wires.py
+++ b/pennylane/wires.py
@@ -82,7 +82,7 @@ class Wires(Sequence):
         else:
             self._labels = _process(wires)
 
-        self._label_indices = {v:k for k,v in enumerate(self._labels)}
+        self._label_indices = {v: k for k, v in enumerate(self._labels)}
 
     def __getitem__(self, idx):
         """Method to support indexing. Returns a Wires object if index is a slice, or a label if index is an integer."""

--- a/pennylane/wires.py
+++ b/pennylane/wires.py
@@ -82,6 +82,8 @@ class Wires(Sequence):
         else:
             self._labels = _process(wires)
 
+        self._label_indices = {v:k for k,v in enumerate(self._labels)}
+
     def __getitem__(self, idx):
         """Method to support indexing. Returns a Wires object if index is a slice, or a label if index is an integer."""
         if isinstance(idx, slice):
@@ -202,8 +204,8 @@ class Wires(Sequence):
             wire = wire[0]
 
         try:
-            return self._labels.index(wire)
-        except ValueError as e:
+            return self._label_indices[wire]
+        except KeyError as e:
             raise WireError("Wire with label {} not found in {}.".format(wire, self)) from e
 
     def indices(self, wires):

--- a/tests/test_wires.py
+++ b/tests/test_wires.py
@@ -252,6 +252,7 @@ class TestWires:
         # check for non-Wires inputs
         assert wires.index(element) == 1
         assert wires.index(np.array(element)) == 1
+        assert wires.index(np.array([element])) == 1
         # check for Wires inputs
         assert wires.index(Wires([element])) == 1
         # check that Wires of length >1 produce an error

--- a/tests/test_wires.py
+++ b/tests/test_wires.py
@@ -237,6 +237,11 @@ class TestWires:
         assert isinstance(list_, list)
         assert list_ == [4, 0, 1]
 
+    @pytest.mark.parametrize("wires, indices", labels_with_indices)
+    def test_wires_label_indices(self, wires, indices):
+        """Test that the indices of the wire labels are stored correctly."""
+        assert Wires(wires)._label_indices == indices
+
     @pytest.mark.parametrize("iterable", [[4, 1, 0, 3],
                                           ['a', 'b', 'c']])
     def test_index_method(self, iterable):
@@ -246,11 +251,14 @@ class TestWires:
         element = iterable[1]
         # check for non-Wires inputs
         assert wires.index(element) == 1
+        assert wires.index(np.array(element)) == 1
         # check for Wires inputs
         assert wires.index(Wires([element])) == 1
         # check that Wires of length >1 produce an error
         with pytest.raises(WireError, match="Can only retrieve index"):
             wires.index(Wires([1, 2]))
+        with pytest.raises(WireError, match="Can only retrieve index"):
+            wires.index(Wires(np.array([1,2])))
         # check that error raised when wire does not exist
         with pytest.raises(WireError, match="Wire with label d not found"):
             wires.index(Wires(['d']))
@@ -361,8 +369,3 @@ class TestWires:
         assert Wires([1, 2, 3]) == (1, 2, 3)
         assert Wires([1, 2, 3]) != (1, 5, 3)
         assert (1, 5, 3) != Wires([1, 2, 3])
-
-    @pytest.mark.parametrize("wires, indices", labels_with_indices)
-    def test_wires_label_indices(self, wires, indices):
-        """Test that the indices of the wire labels are stored correctly."""
-        assert Wires(wires)._label_indices == indices

--- a/tests/test_wires.py
+++ b/tests/test_wires.py
@@ -20,6 +20,14 @@ import pennylane as qml
 from pennylane.wires import Wires, WireError
 
 
+labels_with_indices = [
+        ([1, 2, 3], {1:0, 2:1, 3:2}),
+        (['a', 0, 'label'], {'a':0, 0:1, 'label':2}),
+        (['a'], {'a':0}),
+        ([1, 0], {1:0,0:1}),
+        ([1,2,0], {1:0,2:1, 0:2}),
+]
+
 class TestWires:
     """Tests for the ``Wires`` class."""
 
@@ -353,3 +361,8 @@ class TestWires:
         assert Wires([1, 2, 3]) == (1, 2, 3)
         assert Wires([1, 2, 3]) != (1, 5, 3)
         assert (1, 5, 3) != Wires([1, 2, 3])
+
+    @pytest.mark.parametrize("wires, indices", labels_with_indices)
+    def test_wires_label_indices(self, wires, indices):
+        """Test that the indices of the wire labels are stored correctly."""
+        assert Wires(wires)._label_indices == indices

--- a/tests/test_wires.py
+++ b/tests/test_wires.py
@@ -258,7 +258,7 @@ class TestWires:
         with pytest.raises(WireError, match="Can only retrieve index"):
             wires.index(Wires([1, 2]))
         with pytest.raises(WireError, match="Can only retrieve index"):
-            wires.index(Wires(np.array([1,2])))
+            wires.index(np.array([1,2]))
         # check that error raised when wire does not exist
         with pytest.raises(WireError, match="Wire with label d not found"):
             wires.index(Wires(['d']))


### PR DESCRIPTION
**Context**

Storing the wire label indices in a dictionary helps with faster indexing into wires (~5% less time spent).

**Before**

![image](https://user-images.githubusercontent.com/24476053/105203299-f0a6ce00-5b10-11eb-8399-9c8afee6b49f.png)

**After**

![image](https://user-images.githubusercontent.com/24476053/105203432-192ec800-5b11-11eb-93cd-2bf9ca2ea39a.png)

