### PR TITLE
Queueing exit

### DIFF
--- a/pennylane/_queuing.py
+++ b/pennylane/_queuing.py
@@ -240,7 +240,7 @@ class OperationRecorder(Queue):
         # Code taken from https://stackoverflow.com/questions/480214
         seen = set()
         seen_add = seen.add
-        self.queue = [x for x in seq if not (x in seen or seen_add(x))]
+        self.queue = [x for x in self.queue if not (x in seen or seen_add(x))]
         self.operations = list(
             filter(
                 lambda op: not (

--- a/pennylane/_queuing.py
+++ b/pennylane/_queuing.py
@@ -57,7 +57,9 @@ class QueuingContext(abc.ABC):
 
     def __exit__(self, exception_type, exception_value, traceback):
         """Remove this instance from the global list of active contexts."""
-        QueuingContext._active_contexts.remove(self)
+        if QueuingContext._active_contexts[-1] is not self:
+            raise AssertionError("Popped queue not active queue.")
+         QueuingContext._active_contexts.pop()
 
     @abc.abstractmethod
     def _append(self, obj, **kwargs):

--- a/pennylane/_queuing.py
+++ b/pennylane/_queuing.py
@@ -236,8 +236,11 @@ class OperationRecorder(Queue):
     def __exit__(self, exception_type, exception_value, traceback):
         super().__exit__(exception_type, exception_value, traceback)
 
-        # Remove duplicates that might have arisen from measurements
-        self.queue = list(OrderedDict.fromkeys(self.queue))
+        # Remove duplicates that might have arisen from measurements.
+        # Code taken from https://stackoverflow.com/questions/480214
+        seen = set()
+        seen_add = seen.add
+        self.queue = [x for x in seq if not (x in seen or seen_add(x))]
         self.operations = list(
             filter(
                 lambda op: not (

--- a/pennylane/_queuing.py
+++ b/pennylane/_queuing.py
@@ -242,7 +242,7 @@ class OperationRecorder(Queue):
         # Code taken from https://stackoverflow.com/questions/480214
         seen = set()
         seen_add = seen.add
-        self.queue = [x for x in self.queue if not (x in seen or seen_add(x))]
+        self.queue #= [x for x in self.queue if not (x in seen or seen_add(x))]
         self.operations = list(
             filter(
                 lambda op: not (

--- a/pennylane/_queuing.py
+++ b/pennylane/_queuing.py
@@ -58,7 +58,7 @@ class QueuingContext(abc.ABC):
     def __exit__(self, exception_type, exception_value, traceback):
         """Remove this instance from the global list of active contexts."""
         if QueuingContext._active_contexts[-1] is not self:
-            raise AssertionError("Popped queue not active queue.")
+            raise AssertionError("Given QueuingContext is not the current one.")
         QueuingContext._active_contexts.pop()
 
     @abc.abstractmethod

--- a/pennylane/_queuing.py
+++ b/pennylane/_queuing.py
@@ -242,7 +242,7 @@ class OperationRecorder(Queue):
         # Code taken from https://stackoverflow.com/questions/480214
         seen = set()
         seen_add = seen.add
-        self.queue #= [x for x in self.queue if not (x in seen or seen_add(x))]
+        # self.queue #= [x for x in self.queue if not (x in seen or seen_add(x))]
         self.operations = list(
             filter(
                 lambda op: not (

--- a/pennylane/_queuing.py
+++ b/pennylane/_queuing.py
@@ -59,7 +59,7 @@ class QueuingContext(abc.ABC):
         """Remove this instance from the global list of active contexts."""
         if QueuingContext._active_contexts[-1] is not self:
             raise AssertionError("Popped queue not active queue.")
-         QueuingContext._active_contexts.pop()
+        QueuingContext._active_contexts.pop()
 
     @abc.abstractmethod
     def _append(self, obj, **kwargs):

--- a/tests/collections/test_collections.py
+++ b/tests/collections/test_collections.py
@@ -320,7 +320,7 @@ class TestDot:
             coeffs = coeffs.numpy()
 
         expected = np.dot(coeffs, qcval)
-        assert np.all(res == expected)
+        np.testing.assert_allclose(res, expected)
 
     @pytest.mark.parametrize("interface", ["autograd", "torch", "tf", None])
     def test_dot_product_qnodes_qnodes(self, qnodes, interface, tf_support, torch_support):


### PR DESCRIPTION

**Context:**
The `__exit__` method in our queueing context takes around 20% of the tape construction time. This micro optimizes it by using slightly faster methods for removing duplicates and popping the queue.

```
(base) chase@LAPTOP-NC0VRTT8:~/benchmark
$ asv compare master queueing_exit

All benchmarks:

       before           after         ratio
     [8792f0f8]       [77b88205]
     <master>         <queueing_exit>
       11.9±0.1ms      11.3±0.05ms     0.95  asv.core_suite.CircuitEvaluation.time_circuit(10, 3)
       22.2±0.1ms       20.9±0.4ms     0.94  asv.core_suite.CircuitEvaluation.time_circuit(10, 6)
       32.3±0.5ms       30.6±0.2ms     0.95  asv.core_suite.CircuitEvaluation.time_circuit(10, 9)
       3.46±0.2ms       3.38±0.2ms     0.98  asv.core_suite.CircuitEvaluation.time_circuit(2, 3)
       5.28±0.3ms       4.93±0.2ms     0.93  asv.core_suite.CircuitEvaluation.time_circuit(2, 6)
       7.06±0.3ms       7.16±0.3ms     1.01  asv.core_suite.CircuitEvaluation.time_circuit(2, 9)
       6.67±0.3ms       6.48±0.4ms     0.97  asv.core_suite.CircuitEvaluation.time_circuit(5, 3)
       11.3±0.1ms       10.7±0.1ms     0.95  asv.core_suite.CircuitEvaluation.time_circuit(5, 6)
      16.0±0.05ms      15.1±0.05ms     0.94  asv.core_suite.CircuitEvaluation.time_circuit(5, 9)
       4.95±0.3ms       4.60±0.2ms     0.93  asv.core_suite.GradientComputation.time_gradient_autograd(2, 3)
       7.75±0.2ms       7.44±0.4ms     0.96  asv.core_suite.GradientComputation.time_gradient_autograd(2, 6)
       10.6±0.6ms       9.64±0.6ms    ~0.91  asv.core_suite.GradientComputation.time_gradient_autograd(5, 3)
       18.7±0.6ms         19.2±1ms     1.02  asv.core_suite.GradientComputation.time_gradient_autograd(5, 6)
       15.8±0.1ms       15.4±0.2ms     0.98  asv.core_suite.GradientComputation.time_gradient_tf(2, 3)
      28.2±0.08ms       27.9±0.3ms     0.99  asv.core_suite.GradientComputation.time_gradient_tf(2, 6)
       44.3±0.2ms       44.0±0.4ms     0.99  asv.core_suite.GradientComputation.time_gradient_tf(5, 3)
       85.2±0.9ms       85.9±0.8ms     1.01  asv.core_suite.GradientComputation.time_gradient_tf(5, 6)
       7.57±0.4ms       7.10±0.5ms     0.94  asv.core_suite.GradientComputation.time_gradient_torch(2, 3)
       19.3±0.6ms       18.3±0.8ms     0.95  asv.core_suite.GradientComputation.time_gradient_torch(2, 6)
       36.7±0.6ms         38.2±4ms     1.04  asv.core_suite.GradientComputation.time_gradient_torch(5, 3)
          128±2ms          124±4ms     0.97  asv.core_suite.GradientComputation.time_gradient_torch(5, 6)
```

**Description of the Change:**
Duplicates are removed with `set` math instead of using `OrderedDict`, popping the queue is now done in O(1) time instead of O(n).

**Benefits:**
It's faster.

**Possible Drawbacks:**
n/a
**Related GitHub Issues:**
n/a