### PR TITLE
Update default qubit so that _apply_operation is more functional

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -250,6 +250,10 @@
 
 <h3>Improvements</h3>
 
+* The `default.qubit` device has been updated so that internally it applies operations in a more
+  functional style, i.e., by accepting an input state and returning an evolved state.
+  [(#1025)](https://github.com/PennyLaneAI/pennylane/pull/1025)  
+
 * A new test series, pennylane/devices/tests/test_compare_default_qubit.py, has been added, allowing to test if
   a chosen device gives the same result as the default device. Three tests are added `test_hermitian_expectation`,
   `test_pauliz_expectation_analytic`, and `test_random_circuit`.
@@ -335,7 +339,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-Olivia Di Matteo, Josh Izaac, Christina Lee, Alejandro Montanez, Steven Oud, Chase Roberts, Maria Schuld, David Wierichs, Jiahao Yao.
+Thomas Bromley, Olivia Di Matteo, Josh Izaac, Christina Lee, Alejandro Montanez, Steven Oud, Chase Roberts, Maria Schuld, David Wierichs, Jiahao Yao.
 
 # Release 0.13.0 (current release)
 

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -205,11 +205,11 @@ class DefaultQubit(QubitDevice):
 
         if isinstance(operation, DiagonalOperation):
             return self._apply_diagonal_unitary(state, matrix, wires)
-        elif len(wires) <= 2:
+        if len(wires) <= 2:
             # Einsum is faster for small gates
             return self._apply_unitary_einsum(state, matrix, wires)
-        else:
-            return self._apply_unitary(state, matrix, wires)
+
+        return self._apply_unitary(state, matrix, wires)
 
     def _apply_x(self, state, axes, **kwargs):
         """Applies a PauliX gate by rolling 1 unit along the axis specified in ``axes``.

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -21,6 +21,7 @@ simulation of a qubit-based quantum circuit architecture.
 import itertools
 import functools
 from string import ascii_letters as ABC
+from collections import OrderedDict
 
 import numpy as np
 
@@ -144,6 +145,19 @@ class DefaultQubit(QubitDevice):
             "SWAP": self._apply_swap,
             "CZ": self._apply_cz,
         }
+
+    def map_wires(self, wires):
+        # temporarily overwrite this method to bypass
+        # wire map that produces Wires objects
+        mapped_wires = [self.wire_map[w] for w in wires]
+        return mapped_wires
+
+    def define_wire_map(self, wires):
+        # temporarily overwrite this method to bypass
+        # wire map that produces Wires objects
+        consecutive_wires = range(self.num_wires)
+        wire_map = zip(wires, consecutive_wires)
+        return OrderedDict(wire_map)
 
     def apply(self, operations, rotations=None, **kwargs):
         rotations = rotations or []
@@ -390,6 +404,11 @@ class DefaultQubit(QubitDevice):
             supports_inverse_operations=True,
             supports_analytic_computation=True,
             returns_state=True,
+            passthru_devices={
+                "tf": "default.qubit.tf",
+                "autograd": "default.qubit.autograd",
+                "jax": "default.qubit.jax",
+            },
         )
         return capabilities
 
@@ -463,10 +482,7 @@ class DefaultQubit(QubitDevice):
         if not np.allclose(np.linalg.norm(state, ord=2), 1.0, atol=tolerance):
             raise ValueError("Sum of amplitudes-squared does not equal one.")
 
-        if (
-            len(device_wires) == self.num_wires
-            and sorted(device_wires.labels) == device_wires.tolist()
-        ):
+        if len(device_wires) == self.num_wires and sorted(device_wires) == device_wires:
             # Initialize the entire wires with the state
             self._state = self._reshape(state, [2] * self.num_wires)
             return
@@ -506,7 +522,7 @@ class DefaultQubit(QubitDevice):
             raise ValueError("BasisState parameter and wires must be of equal length.")
 
         # get computational basis state number
-        basis_states = 2 ** (self.num_wires - 1 - device_wires.toarray())
+        basis_states = 2 ** (self.num_wires - 1 - np.array(device_wires))
         num = int(np.dot(state, basis_states))
 
         self._state = self._create_basis_state(num)
@@ -526,15 +542,15 @@ class DefaultQubit(QubitDevice):
         device_wires = self.map_wires(wires)
 
         mat = self._cast(self._reshape(mat, [2] * len(device_wires) * 2), dtype=self.C_DTYPE)
-        axes = (np.arange(len(device_wires), 2 * len(device_wires)), device_wires.labels)
+        axes = (np.arange(len(device_wires), 2 * len(device_wires)), device_wires)
         tdot = self._tensordot(mat, state, axes=axes)
 
         # tensordot causes the axes given in `wires` to end up in the first positions
         # of the resulting tensor. This corresponds to a (partial) transpose of
         # the correct output state
         # We'll need to invert this permutation to put the indices in the correct place
-        unused_idxs = [idx for idx in range(self.num_wires) if idx not in device_wires.labels]
-        perm = list(device_wires.labels) + unused_idxs
+        unused_idxs = [idx for idx in range(self.num_wires) if idx not in device_wires]
+        perm = list(device_wires) + unused_idxs
         inv_perm = np.argsort(perm)  # argsort gives inverse permutation
         return self._transpose(tdot, inv_perm)
 
@@ -561,7 +577,7 @@ class DefaultQubit(QubitDevice):
         state_indices = ABC[: self.num_wires]
 
         # Indices of the quantum state affected by this operation
-        affected_indices = "".join(ABC_ARRAY[device_wires.tolist()].tolist())
+        affected_indices = "".join(ABC_ARRAY[list(device_wires)].tolist())
 
         # All affected indices will be summed over, so we need the same number of new indices
         new_indices = ABC[self.num_wires : self.num_wires + len(device_wires)]
@@ -606,7 +622,7 @@ class DefaultQubit(QubitDevice):
         phases = self._cast(self._reshape(phases, [2] * len(device_wires)), dtype=self.C_DTYPE)
 
         state_indices = ABC[: self.num_wires]
-        affected_indices = "".join(ABC_ARRAY[device_wires.tolist()].tolist())
+        affected_indices = "".join(ABC_ARRAY[list(device_wires)].tolist())
 
         einsum_indices = "{affected_indices},{state_indices}->{state_indices}".format(
             affected_indices=affected_indices, state_indices=state_indices

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -199,9 +199,7 @@ class DefaultQubit(QubitDevice):
 
         if operation.base_name in self._apply_ops:
             axes = self.wires.indices(wires)
-            return self._apply_ops[operation.base_name](
-                state, axes, inverse=operation.inverse
-            )
+            return self._apply_ops[operation.base_name](state, axes, inverse=operation.inverse)
 
         matrix = self._get_unitary_matrix(operation)
 


### PR DESCRIPTION
This is an update to the internals of `default.qubit` so that the `_apply_operation` method accepts an input state and returns an output state. This allows for external functions to interact with the device and request an evolved state - something we need in https://github.com/PennyLaneAI/pennylane/pull/1017.

It appears that we do not need to update the tests, since we have not written fully comprehensive unit tests for each method in `default.qubit`. The current tests use the `apply()` method, which is one step above `_apply_operation`, so at least the new changes are still being tested implicitly.