### PR TITLE
Device tests run in tape

### DIFF
--- a/pennylane/devices/tests/conftest.py
+++ b/pennylane/devices/tests/conftest.py
@@ -262,3 +262,48 @@ def pytest_runtest_makereport(item, call):
                 tr.outcome = "skipped"
 
     return tr
+
+@pytest.fixture
+def in_tape_mode():
+    """Run the test in tape mode"""
+    qml.enable_tape()
+    yield
+    qml.disable_tape()
+
+
+@pytest.fixture(params=[False, True])
+def tape_mode(request, mocker):
+    """Tests using this fixture will be run twice, once in tape mode and once without."""
+
+    if request.param:
+        # Several attributes and methods on the old QNode have a new location on the new QNode/tape.
+        # Here, we dynamically mock so that the tests do not have to be modified to support both
+        # tape and non-tape mode. Once tape mode is default, we can make the equivalent
+        # changes directly in the tests.
+        mocker.patch("pennylane.tape.QNode.ops", property(lambda self: self.qtape.operations + self.qtape.observables), create=True)
+        mocker.patch("pennylane.tape.QNode.h", property(lambda self: self.diff_options["h"]), create=True)
+        mocker.patch("pennylane.tape.QNode.order", property(lambda self: self.diff_options["order"]), create=True)
+        mocker.patch("pennylane.tape.QNode.circuit", property(lambda self: self.qtape.graph), create=True)
+
+        def patched_jacobian(self, args, **kwargs):
+            method = kwargs.get("method", "best")
+
+            if method == "A":
+                method = "analytic"
+            elif method == "F":
+                method = "numeric"
+
+            kwargs["method"] = method
+            dev = kwargs["options"]["device"]
+
+            return self.qtape.jacobian(dev, **kwargs)
+
+
+        mocker.patch("pennylane.tape.QNode.jacobian", patched_jacobian, create=True)
+
+        qml.enable_tape()
+
+    yield
+
+    if request.param:
+        qml.disable_tape()

--- a/pennylane/devices/tests/test_compare_default_qubit.py
+++ b/pennylane/devices/tests/test_compare_default_qubit.py
@@ -20,7 +20,7 @@ import pennylane as qml
 from pennylane import numpy as np  # Import from PennyLane to mirror the standard approach in demos
 from pennylane.templates.layers import RandomLayers
 
-pytestmark = pytest.mark.skip_unsupported
+pytestmark = [pytest.mark.skip_unsupported, pytest.mark.usefixtures("tape_mode")]
 
 
 @flaky(max_runs=10)

--- a/pennylane/devices/tests/test_compare_default_qubit.py
+++ b/pennylane/devices/tests/test_compare_default_qubit.py
@@ -106,7 +106,7 @@ class TestComparison:
         assert np.allclose(qnode(theta, phi), qnode_def(theta, phi), atol=tol(dev.analytic))
         assert np.allclose(grad(theta, phi), grad_def(theta, phi), atol=tol(dev.analytic))
 
-    @pytest.mark.parametrize("ret", [qml.expval, qml.var])
+    @pytest.mark.parametrize("ret", ["expval", "var"])
     def test_random_circuit(self, device, tol, ret):
         """Test that the expectation value of a random circuit is correct"""
         n_wires = 2
@@ -130,9 +130,10 @@ class TestComparison:
         n_layers = np.random.randint(1, 5)
         weights = 2 * np.pi * np.random.rand(n_layers, 1)
 
+        ret_type = getattr(qml, ret)
         def circuit(weights):
             RandomLayers(weights, wires=range(n_wires))
-            return ret(qml.PauliZ(wires=0) @ qml.PauliX(wires=1))
+            return ret_type(qml.PauliZ(wires=0) @ qml.PauliX(wires=1))
 
         qnode_def = qml.QNode(circuit, dev_def)
         qnode = qml.QNode(circuit, dev)

--- a/pennylane/devices/tests/test_gates.py
+++ b/pennylane/devices/tests/test_gates.py
@@ -46,7 +46,7 @@ ops = {
     "CSWAP": qml.CSWAP(wires=[0, 1, 2]),
     "CZ": qml.CZ(wires=[0, 1]),
     "CY": qml.CY(wires=[0, 1]),
-    "DiagonalQubitUnitary": qml.DiagonalQubitUnitary(np.eye(2), wires=[0]),
+    "DiagonalQubitUnitary": qml.DiagonalQubitUnitary(np.array([1, 1]), wires=[0]),
     "Hadamard": qml.Hadamard(wires=[0]),
     "MultiRZ": qml.MultiRZ(0, wires=[0]),
     "PauliX": qml.PauliX(wires=[0]),
@@ -225,7 +225,7 @@ class TestSupportedGates:
 
             @qml.qnode(dev)
             def circuit():
-                ops[operation].inv()
+                ops[operation].queue().inv()
                 return qml.expval(qml.Identity(wires=0))
 
             assert isinstance(circuit(), (float, np.ndarray))

--- a/pennylane/devices/tests/test_gates.py
+++ b/pennylane/devices/tests/test_gates.py
@@ -28,7 +28,7 @@ import pennylane as qml
 from scipy.linalg import block_diag
 from flaky import flaky
 
-pytestmark = pytest.mark.skip_unsupported
+pytestmark = [pytest.mark.skip_unsupported, pytest.mark.usefixtures("tape_mode")]
 
 np.random.seed(42)
 

--- a/pennylane/devices/tests/test_measurements.py
+++ b/pennylane/devices/tests/test_measurements.py
@@ -20,7 +20,7 @@ from flaky import flaky
 
 import pennylane as qml
 
-pytestmark = pytest.mark.skip_unsupported
+pytestmark = [pytest.mark.skip_unsupported, pytest.mark.usefixtures("tape_mode")]
 
 # ==========================================================
 # Some useful global variables

--- a/pennylane/devices/tests/test_properties.py
+++ b/pennylane/devices/tests/test_properties.py
@@ -18,6 +18,8 @@ import pennylane.numpy as pnp
 import pennylane as qml
 from pennylane._device import DeviceError
 
+pytestmark = pytest.mark.usefixtures("tape_mode")
+
 try:
     import tensorflow as tf
 

--- a/pennylane/devices/tests/test_properties.py
+++ b/pennylane/devices/tests/test_properties.py
@@ -135,7 +135,7 @@ class TestCapabilities:
         assert interface in ["tf", "autograd", "jax"]  # for new interface, add test case
 
         qfunc = qfunc_with_scalar_input(cap["model"])
-        qnode = qml.qnodes.passthru.PassthruQNode(qfunc, dev)
+        qnode = qml.QNode(qfunc, dev) if qml.tape_mode_active() else qml.qnodes.passthru.PassthruQNode(qfunc, dev)
         qnode.interface = interface
 
         # assert that we can do a simple gradient computation in the passthru interface

--- a/pennylane/devices/tests/test_wires.py
+++ b/pennylane/devices/tests/test_wires.py
@@ -17,6 +17,7 @@ import pennylane as qml
 import pytest
 from pennylane import numpy as np
 
+pytestmark = pytest.mark.usefixtures("tape_mode")
 
 # ===== Factories for circuits using arbitrary wire labels and numbers
 


### PR DESCRIPTION
**Context:**

The device test suite runs in tape mode.

**Description of the Change:**

* Adds the needed fixture to the dedicated `conftest.py` file of the device test suite
* Adds the fixtures
* Operations that were not instantiated within a QNode are queued
* Moves the return type ref (e.g., `qml.expval`) in the test functions such that the tape version can also be fetched