### PR TITLE
Makes QNode integration tests more robust and fixes uncovered bugs

### DIFF
--- a/pennylane/tape/tapes/qubit_param_shift.py
+++ b/pennylane/tape/tapes/qubit_param_shift.py
@@ -169,7 +169,13 @@ class QubitParamShiftTape(JacobianTape):
                 array[float]: 1-dimensional array of length determined by the tape output
                 measurement statistics
             """
-            return np.sum([c * r for c, r in zip(coeffs, results)], axis=0)
+            results = np.squeeze(results)
+
+            if results.dtype is not np.dtype("O"):
+                dot = lambda x: np.dot(coeffs, x)
+                return np.apply_along_axis(dot, 0, results)
+
+            return sum([c * r for c, r in zip(coeffs, results)])
 
         return tapes, processing_fn
 
@@ -354,6 +360,12 @@ class QubitParamShiftTape(JacobianTape):
                 array[float]: 1-dimensional array of length determined by the tape output
                 measurement statistics
             """
-            return np.sum([c * r for c, r in zip(coeffs, results)], axis=0)
+            results = np.squeeze(results)
+
+            if results.dtype is not np.dtype("O"):
+                dot = lambda x: np.dot(coeffs, x)
+                return np.apply_along_axis(dot, 0, results)
+
+            return sum([c * r for c, r in zip(coeffs, results)])
 
         return tapes, processing_fn

--- a/pennylane/tape/tapes/qubit_param_shift.py
+++ b/pennylane/tape/tapes/qubit_param_shift.py
@@ -169,7 +169,7 @@ class QubitParamShiftTape(JacobianTape):
                 array[float]: 1-dimensional array of length determined by the tape output
                 measurement statistics
             """
-            return np.dot(coeffs, np.squeeze(results))
+            return np.sum([c * r for c, r in zip(coeffs, results)], axis=0)
 
         return tapes, processing_fn
 
@@ -354,6 +354,6 @@ class QubitParamShiftTape(JacobianTape):
                 array[float]: 1-dimensional array of length determined by the tape output
                 measurement statistics
             """
-            return np.dot(coeffs, np.squeeze(results))
+            return np.sum([c * r for c, r in zip(coeffs, results)], axis=0)
 
         return tapes, processing_fn

--- a/pennylane/tape/tapes/qubit_param_shift.py
+++ b/pennylane/tape/tapes/qubit_param_shift.py
@@ -171,11 +171,16 @@ class QubitParamShiftTape(JacobianTape):
             """
             results = np.squeeze(results)
 
-            if results.dtype is not np.dtype("O"):
-                dot = lambda x: np.dot(coeffs, x)
-                return np.apply_along_axis(dot, 0, results)
+            if results.dtype is np.dtype("O"):
+                # The evaluated quantum results are a ragged array.
+                # Need to use a list comprehension to compute the linear
+                # combination.
+                return sum([c * r for c, r in zip(coeffs, results)])
 
-            return sum([c * r for c, r in zip(coeffs, results)])
+            # The evaluated quantum results are a valid NumPy array,
+            # can instead apply the dot product along the first axis.
+            dot = lambda x: np.dot(coeffs, x)
+            return np.apply_along_axis(dot, 0, results)
 
         return tapes, processing_fn
 
@@ -362,10 +367,15 @@ class QubitParamShiftTape(JacobianTape):
             """
             results = np.squeeze(results)
 
-            if results.dtype is not np.dtype("O"):
-                dot = lambda x: np.dot(coeffs, x)
-                return np.apply_along_axis(dot, 0, results)
+            if results.dtype is np.dtype("O"):
+                # The evaluated quantum results are a ragged array.
+                # Need to use a list comprehension to compute the linear
+                # combination.
+                return sum([c * r for c, r in zip(coeffs, results)])
 
-            return sum([c * r for c, r in zip(coeffs, results)])
+            # The evaluated quantum results are a valid NumPy array,
+            # can instead apply the dot product along the first axis.
+            dot = lambda x: np.dot(coeffs, x)
+            return np.apply_along_axis(dot, 0, results)
 
         return tapes, processing_fn

--- a/tests/tape/interfaces/test_qnode_autograd.py
+++ b/tests/tape/interfaces/test_qnode_autograd.py
@@ -20,8 +20,11 @@ from pennylane.tape import JacobianTape, qnode, QNode, QubitParamShiftTape
 
 
 @pytest.mark.parametrize(
-    "dev_name,diff_method",
-    [["default.qubit", "finite-diff"], ["default.qubit.autograd", "backprop"]],
+    "dev_name,diff_method", [
+        ["default.qubit", "finite-diff"],
+        ["default.qubit", "parameter-shift"],
+        ["default.qubit.autograd", "backprop"],
+    ],
 )
 class TestQNode:
     """Same tests as above, but this time via the QNode interface!"""
@@ -29,8 +32,8 @@ class TestQNode:
     def test_nondiff_param_unwrapping(self, dev_name, diff_method, mocker):
         """Test that non-differentiable parameters are correctly unwrapped
         to NumPy ndarrays or floats (if 0-dimensional)"""
-        if diff_method == "backprop":
-            pytest.skip("Test does not support backprop")
+        if diff_method != "parameter-shift":
+            pytest.skip("Test only supports parameter-shift")
 
         dev = qml.device("default.qubit", wires=1)
 
@@ -98,7 +101,7 @@ class TestQNode:
 
         dev = qml.device(dev_name, wires=1)
 
-        @qnode(dev, interface="autograd", diff_method="parameter-shift")
+        @qnode(dev, interface="autograd", diff_method=diff_method)
         def circuit(a):
             qml.RY(a, wires=0)
             qml.RX(0.2, wires=0)
@@ -128,7 +131,7 @@ class TestQNode:
 
         dev = qml.device(dev_name, wires=1)
 
-        @qnode(dev, interface="tf", diff_method="parameter-shift")
+        @qnode(dev, interface="tf", diff_method=diff_method)
         def circuit(a):
             qml.RY(a, wires=0)
             qml.RX(0.2, wires=0)
@@ -244,8 +247,8 @@ class TestQNode:
     def test_changing_trainability(self, dev_name, diff_method, mocker, tol):
         """Test changing the trainability of parameters changes the
         number of differentiation requests made"""
-        if diff_method == "backprop":
-            pytest.skip("Test does not support backprop")
+        if diff_method != "parameter-shift":
+            pytest.skip("Test only supports parameter-shift")
 
         a = np.array(0.1, requires_grad=True)
         b = np.array(0.2, requires_grad=True)

--- a/tests/tape/interfaces/test_qnode_autograd.py
+++ b/tests/tape/interfaces/test_qnode_autograd.py
@@ -548,6 +548,50 @@ class TestQNode:
         )
         assert np.allclose(res, expected, atol=tol, rtol=0)
 
+    def test_ragged_differentiation_variance(self, dev_name, diff_method, monkeypatch, tol):
+        """Tests correct output shape and evaluation for a tape
+        with prob and variance outputs"""
+        dev = qml.device(dev_name, wires=2)
+        x = np.array(0.543, requires_grad=True)
+        y = np.array(-0.654, requires_grad=True)
+
+        if dev_name == "default.qubit.autograd":
+            # The current DefaultQubitAutograd device provides an _asarray method that does
+            # not work correctly for ragged arrays. For ragged arrays, we would like _asarray to
+            # flatten the array. Here, we patch the _asarray method on the device to achieve this
+            # behaviour.
+            # TODO: once the tape has moved from the beta folder, we should implement
+            # this change directly in the device.
+
+            def _asarray(args, dtype=np.float64):
+                return np.hstack(args).flatten()
+
+            monkeypatch.setattr(dev, "_asarray", _asarray)
+
+        @qnode(dev, diff_method=diff_method, interface="autograd")
+        def circuit(x, y):
+            qml.RX(x, wires=[0])
+            qml.RY(y, wires=[1])
+            qml.CNOT(wires=[0, 1])
+            return [qml.var(qml.PauliZ(0)), qml.probs(wires=[1])]
+
+        res = circuit(x, y)
+
+        expected = np.array(
+            [np.sin(x) ** 2, (1 + np.cos(x) * np.cos(y)) / 2, (1 - np.cos(x) * np.cos(y)) / 2]
+        )
+        assert np.allclose(res, expected, atol=tol, rtol=0)
+
+        res = qml.jacobian(circuit)(x, y)
+        expected = np.array(
+            [
+                [2 * np.cos(x) * np.sin(x), 0],
+                [-np.sin(x) * np.cos(y) / 2, -np.cos(x) * np.sin(y) / 2],
+                [np.cos(y) * np.sin(x) / 2, np.cos(x) * np.sin(y) / 2],
+            ]
+        )
+        assert np.allclose(res, expected, atol=tol, rtol=0)
+
     def test_sampling(self, dev_name, diff_method):
         """Test sampling works as expected"""
         dev = qml.device(dev_name, wires=2, shots=10)

--- a/tests/tape/interfaces/test_qnode_tf.py
+++ b/tests/tape/interfaces/test_qnode_tf.py
@@ -23,7 +23,11 @@ from pennylane.tape import JacobianTape, qnode, QNode
 
 
 @pytest.mark.parametrize(
-    "dev_name,diff_method", [["default.qubit", "finite-diff"], ["default.qubit.tf", "backprop"]]
+    "dev_name,diff_method", [
+        ["default.qubit", "finite-diff"],
+        ["default.qubit", "parameter-shift"],
+        ["default.qubit.tf", "backprop"],
+    ],
 )
 class TestQNode:
     """Same tests as above, but this time via the QNode interface!"""
@@ -202,8 +206,8 @@ class TestQNode:
 
     def test_jacobian_options(self, dev_name, diff_method, mocker, tol):
         """Test setting finite-difference jacobian options"""
-        if diff_method == "backprop":
-            pytest.skip("Test does not support backprop")
+        if diff_method != "finite-diff":
+            pytest.skip("Test only works with finite diff")
 
         spy = mocker.spy(JacobianTape, "numeric_pd")
 

--- a/tests/tape/interfaces/test_qnode_torch.py
+++ b/tests/tape/interfaces/test_qnode_torch.py
@@ -22,14 +22,20 @@ import pennylane as qml
 from pennylane.tape import JacobianTape, qnode, QNode
 
 
+@pytest.mark.parametrize(
+    "dev_name,diff_method", [
+        ["default.qubit", "finite-diff"],
+        ["default.qubit", "parameter-shift"],
+    ],
+)
 class TestQNode:
     """Same tests as above, but this time via the QNode interface!"""
 
-    def test_execution_no_interface(self):
+    def test_execution_no_interface(self, dev_name, diff_method):
         """Test execution works without an interface"""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device(dev_name, wires=1)
 
-        @qnode(dev, diff_method="parameter-shift")
+        @qnode(dev, diff_method=diff_method)
         def circuit(a):
             qml.RY(a, wires=0)
             qml.RX(0.2, wires=0)
@@ -49,11 +55,11 @@ class TestQNode:
         # trainable parameters
         assert circuit.qtape.trainable_params == {0}
 
-    def test_execution_with_interface(self):
+    def test_execution_with_interface(self, dev_name, diff_method):
         """Test execution works with the interface"""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device(dev_name, wires=1)
 
-        @qnode(dev, interface="torch")
+        @qnode(dev, diff_method=diff_method, interface="torch")
         def circuit(a):
             qml.RY(a, wires=0)
             qml.RX(0.2, wires=0)
@@ -78,12 +84,12 @@ class TestQNode:
         assert isinstance(grad, torch.Tensor)
         assert grad.shape == tuple()
 
-    def test_interface_swap(self, tol):
+    def test_interface_swap(self, dev_name, diff_method, tol):
         """Test that the Torch interface can be applied to a QNode
         with a pre-existing interface"""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device(dev_name, wires=1)
 
-        @qnode(dev, interface="autograd")
+        @qnode(dev, diff_method=diff_method, interface="autograd")
         def circuit(a):
             qml.RY(a, wires=0)
             qml.RX(0.2, wires=0)
@@ -108,7 +114,7 @@ class TestQNode:
         assert np.allclose(res1, res2.detach().numpy(), atol=tol, rtol=0)
         assert np.allclose(grad1, grad2, atol=tol, rtol=0)
 
-    def test_jacobian(self, mocker, tol):
+    def test_jacobian(self, dev_name, diff_method, mocker, tol):
         """Test jacobian calculation"""
         spy = mocker.spy(JacobianTape, "jacobian")
 
@@ -118,9 +124,9 @@ class TestQNode:
         a = torch.tensor(a_val, dtype=torch.float64, requires_grad=True)
         b = torch.tensor(b_val, dtype=torch.float64, requires_grad=True)
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device(dev_name, wires=2)
 
-        @qnode(dev, interface="torch")
+        @qnode(dev, diff_method=diff_method, interface="torch")
         def circuit(a, b):
             qml.RY(a, wires=0)
             qml.RX(b, wires=1)
@@ -146,12 +152,12 @@ class TestQNode:
 
         spy.assert_called()
 
-    def test_jacobian_dtype(self, tol):
+    def test_jacobian_dtype(self, dev_name, diff_method, tol):
         """Test calculating the jacobian with a different datatype"""
         a = torch.tensor(0.1, dtype=torch.float32, requires_grad=True)
         b = torch.tensor(0.2, dtype=torch.float32, requires_grad=True)
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device(dev_name, wires=2)
 
         @qnode(dev)
         def circuit(a, b):
@@ -177,15 +183,18 @@ class TestQNode:
         assert a.grad.dtype is torch.float32
         assert b.grad.dtype is torch.float32
 
-    def test_jacobian_options(self, mocker, tol):
+    def test_jacobian_options(self, dev_name, diff_method, mocker, tol):
         """Test setting jacobian options"""
+        if diff_method != "finite-diff":
+            pytest.skip("Test only works with finite-diff")
+
         spy = mocker.spy(JacobianTape, "numeric_pd")
 
         a = torch.tensor([0.1, 0.2], requires_grad=True)
 
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device(dev_name, wires=1)
 
-        @qnode(dev, interface="torch", h=1e-8, order=2)
+        @qnode(dev, diff_method=diff_method, interface="torch", h=1e-8, order=2)
         def circuit(a):
             qml.RY(a[0], wires=0)
             qml.RX(a[1], wires=0)
@@ -198,16 +207,19 @@ class TestQNode:
             assert args[1]["order"] == 2
             assert args[1]["h"] == 1e-8
 
-    def test_changing_trainability(self, mocker, tol):
+    def test_changing_trainability(self, dev_name, diff_method, mocker, tol):
         """Test that changing the trainability of parameters changes the
         number of differentiation requests made"""
+        if diff_method != "finite-diff":
+            pytest.skip("Test only works with finite-diff")
+
         a_val = 0.1
         b_val = 0.2
 
         a = torch.tensor(a_val, dtype=torch.float64, requires_grad=True)
         b = torch.tensor(b_val, dtype=torch.float64, requires_grad=True)
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device(dev_name, wires=2)
 
         @qnode(dev, interface="torch", diff_method="finite-diff")
         def circuit(a, b):
@@ -259,15 +271,15 @@ class TestQNode:
         # JacobianTape.numeric_pd has been called only once
         assert len(spy.call_args_list) == 1
 
-    def test_classical_processing(self, tol):
+    def test_classical_processing(self, dev_name, diff_method, tol):
         """Test classical processing within the quantum tape"""
         a = torch.tensor(0.1, dtype=torch.float64, requires_grad=True)
         b = torch.tensor(0.2, dtype=torch.float64, requires_grad=False)
         c = torch.tensor(0.3, dtype=torch.float64, requires_grad=True)
 
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device(dev_name, wires=1)
 
-        @qnode(dev, interface="torch")
+        @qnode(dev, diff_method=diff_method, interface="torch")
         def circuit(a, b, c):
             qml.RY(a * c, wires=0)
             qml.RZ(b, wires=0)
@@ -285,11 +297,11 @@ class TestQNode:
         assert b.grad is None
         assert isinstance(c.grad, torch.Tensor)
 
-    def test_no_trainable_parameters(self, tol):
+    def test_no_trainable_parameters(self, dev_name, diff_method, tol):
         """Test evaluation and Jacobian if there are no trainable parameters"""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device(dev_name, wires=2)
 
-        @qnode(dev, interface="torch")
+        @qnode(dev, diff_method=diff_method, interface="torch")
         def circuit(a, b):
             qml.RY(a, wires=0)
             qml.RX(b, wires=0)
@@ -315,15 +327,15 @@ class TestQNode:
     @pytest.mark.parametrize(
         "U", [torch.tensor([[0, 1], [1, 0]], requires_grad=False), np.array([[0, 1], [1, 0]])]
     )
-    def test_matrix_parameter(self, U, tol):
+    def test_matrix_parameter(self, dev_name, diff_method, U, tol):
         """Test that the Torch interface works correctly
         with a matrix parameter"""
         a_val = 0.1
         a = torch.tensor(a_val, dtype=torch.float64, requires_grad=True)
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device(dev_name, wires=2)
 
-        @qnode(dev, interface="torch")
+        @qnode(dev, diff_method=diff_method, interface="torch")
         def circuit(U, a):
             qml.QubitUnitary(U, wires=0)
             qml.RY(a, wires=0)
@@ -337,7 +349,7 @@ class TestQNode:
         res.backward()
         assert np.allclose(a.grad, np.sin(a_val), atol=tol, rtol=0)
 
-    def test_differentiable_expand(self, mocker, tol):
+    def test_differentiable_expand(self, dev_name, diff_method, mocker, tol):
         """Test that operation and nested tapes expansion
         is differentiable"""
         mock = mocker.patch.object(qml.operation.Operation, "do_check_domain", False)
@@ -353,12 +365,12 @@ class TestQNode:
 
                 return tape
 
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device(dev_name, wires=1)
         a = np.array(0.1)
         p_val = [0.1, 0.2, 0.3]
         p = torch.tensor(p_val, dtype=torch.float64, requires_grad=True)
 
-        @qnode(dev, interface="torch")
+        @qnode(dev, diff_method=diff_method, interface="torch")
         def circuit(a, p):
             qml.RX(a, wires=0)
             U3(p[0], p[1], p[2], wires=0)
@@ -394,17 +406,17 @@ class TestQNode:
         )
         assert np.allclose(p.grad, expected, atol=tol, rtol=0)
 
-    def test_probability_differentiation(self, tol):
+    def test_probability_differentiation(self, dev_name, diff_method, tol):
         """Tests correct output shape and evaluation for a tape
         with prob and expval outputs"""
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device(dev_name, wires=2)
         x_val = 0.543
         y_val = -0.654
         x = torch.tensor(x_val, requires_grad=True)
         y = torch.tensor(y_val, requires_grad=True)
 
-        @qnode(dev, interface="torch")
+        @qnode(dev, diff_method=diff_method, interface="torch")
         def circuit(x, y):
             qml.RX(x, wires=[0])
             qml.RY(y, wires=[1])
@@ -435,16 +447,16 @@ class TestQNode:
         assert np.allclose(x.grad, expected[0], atol=tol, rtol=0)
         assert np.allclose(y.grad, expected[1], atol=tol, rtol=0)
 
-    def test_ragged_differentiation(self, monkeypatch, tol):
+    def test_ragged_differentiation(self, dev_name, diff_method, monkeypatch, tol):
         """Tests correct output shape and evaluation for a tape
         with prob and expval outputs"""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device(dev_name, wires=2)
         x_val = 0.543
         y_val = -0.654
         x = torch.tensor(x_val, requires_grad=True)
         y = torch.tensor(y_val, requires_grad=True)
 
-        @qnode(dev, interface="torch")
+        @qnode(dev, diff_method=diff_method, interface="torch")
         def circuit(x, y):
             qml.RX(x, wires=[0])
             qml.RY(y, wires=[1])
@@ -475,11 +487,11 @@ class TestQNode:
         assert np.allclose(x.grad, expected[0], atol=tol, rtol=0)
         assert np.allclose(y.grad, expected[1], atol=tol, rtol=0)
 
-    def test_sampling(self):
+    def test_sampling(self, dev_name, diff_method):
         """Test sampling works as expected"""
-        dev = qml.device("default.qubit", wires=2, shots=10)
+        dev = qml.device(dev_name, wires=2, shots=10)
 
-        @qnode(dev, interface="torch")
+        @qnode(dev, diff_method=diff_method, interface="torch")
         def circuit():
             qml.Hadamard(wires=[0])
             qml.CNOT(wires=[0, 1])


### PR DESCRIPTION
**Context:**

* The QNode integration tests were hardcoded to only test finite differences and backprop

**Description of the Change:**

* Makes the QNode integration tests more robust, by adding in support for testing parameter-shift as well.

* A bug was uncovered while making the tests more robust; namely, that differentiating multiple probability outputs was returning the incorrect results. This bug was due to the usage of `np.dot(coeffs, results)` when performing the parameter-shift rule; `np.dot` does not simply perform the dot product along `axis=0` (as intended) when `results` is N-dimensional; in fact, its broadcasting rules [are quite complicated](https://numpy.org/doc/stable/reference/generated/numpy.dot.html).

  To fix this, `np.dot()` was replaced with either:

  - an explicit list comprehension for ragged arrays, to emulate `np.dot(coeffs, results, axis=0)`.
  - `np.apply_over_axis(dot, 0, results)` for non-ragged arrays.

**Benefits:**

* QNode integration tests are more robust.

* Gradients of QNodes with multiple marginal probability outputs now works correctly in parameter-shift mode.

**Possible Drawbacks:** n/a

**Related GitHub Issues:** n/a
