### PR TITLE
Fixes bug in queuing observables of tensors

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -423,6 +423,10 @@
 
 <h3>Bug fixes</h3>
 
+* Fixes an issue where if the constituent observables of a tensor product do not exist in the queue,
+  an error is raised. With this fix, they are first queued before annotation occurs.
+  [(#1038)](https://github.com/PennyLaneAI/pennylane/pull/1038)
+
 * Fixes an issue with tape expansions where information about sampling
   (specifically the `is_sampled` tape attribute) was not preserved.
   [(#1027)](https://github.com/PennyLaneAI/pennylane/pull/1027)

--- a/pennylane/tape/operation.py
+++ b/pennylane/tape/operation.py
@@ -96,6 +96,9 @@ def tensor_init(self, *args):
 
         try:
             QueuingContext.update_info(o, owner=self)
+        except ValueError:
+            o.queue()
+            qml.tape.QueuingContext.update_info(o, owner=self)
         except NotImplementedError:
             pass
 

--- a/tests/tape/test_tape_measure.py
+++ b/tests/tape/test_tape_measure.py
@@ -118,6 +118,34 @@ class TestBetaStatistics:
         assert q._get_info(B) == {"owner": tensor_op}
         assert q._get_info(tensor_op) == {"owns": (A, B), "owner": meas_proc}
 
+    @pytest.mark.parametrize(
+        "op1,op2",
+        [
+            (qml.PauliY, qml.PauliX),
+            (qml.Hadamard, qml.Hadamard),
+            (qml.PauliY, qml.Identity),
+            (qml.Identity, qml.Identity),
+        ],
+    )
+    def test_queueing_tensor_observable(self, op1, op2, stat_func, return_type):
+        """Test that if the constituent components of a tensor operation are not
+        found in the queue for annotation, that they are queued first and then annotated."""
+        A = op1(0)
+        B = op2(1)
+
+        with AnnotatedQueue() as q:
+            tensor_op = A @ B
+            stat_func(tensor_op)
+
+        assert q.queue[:-1] == [A, B, tensor_op]
+        meas_proc = q.queue[-1]
+        assert isinstance(meas_proc, MeasurementProcess)
+        assert meas_proc.return_type == return_type
+
+        assert q._get_info(A) == {"owner": tensor_op}
+        assert q._get_info(B) == {"owner": tensor_op}
+        assert q._get_info(tensor_op) == {"owns": (A, B), "owner": meas_proc}
+
 
 @pytest.mark.parametrize("stat_func", [expval, var, sample])
 class TestBetaStatisticsError:


### PR DESCRIPTION
**Context:**

The [Noisy Optimization with Cirq](https://pennylane.ai/qml/demos/tutorial_noisy_circuit_optimization.html) tutorial currently uses the following pattern:

```python
obs = [qml.PauliX(0) @ qml.PauliZ(1), qml.PauliZ(0) @ qml.PauliY(1)]

@qml.qnode(dev)
def circuit():
    ansatz()
    return qml.expval(obs[0])
```

However, with the completion of the queuing refactor last year, this pattern no longer works. Under the queuing refactor, the following is expected to take place:

* The individual observables queue themselves.
* The tensor product 'annotates' the queue, marking itself as the owner of its constituent observables.
* Finally, the `expval` function annotates the tensor product as an expectation value.

However, because the tensor products and observables are defined _outside_ the queuing context, they do not exist in the queue, and the attempted annotation fails.

**Description of the Change:**

* Adds a try-except to the tensor product queuing, so that if the constituent observables do not exist in the queue, they are first queued before annotation occurs.

**Benefits:**

* The above pattern now works as before

**Possible Drawbacks:** n/a

**Related GitHub Issues:** n/a
