### PR TITLE
Tape hash

### DIFF
--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -183,8 +183,8 @@ class QubitDevice(Device):
         Returns:
             array[float]: measured value(s)
         """
-        # TODO: Remove try/except and consider merging with previous caching
-        # case when circuit is always QuantumTape
+        # TODO: Remove try/except when circuit is always QuantumTape and
+        # consider merging with caching case
         try:
             self._circuit_hash = circuit.graph.hash
         except AttributeError as e:

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -183,6 +183,13 @@ class QubitDevice(Device):
         Returns:
             array[float]: measured value(s)
         """
+        # TODO: Remove try/except and consider merging with previous caching
+        # case when circuit is always QuantumTape
+        try:
+            self._circuit_hash = circuit.graph.hash
+        except AttributeError as e:
+            self._circuit_hash = circuit.hash
+
         if self._cache:
             try:  # TODO: Remove try/except when circuit is always QuantumTape
                 circuit_hash = circuit.graph.hash
@@ -216,13 +223,6 @@ class QubitDevice(Device):
 
         # increment counter for number of executions of qubit device
         self._num_executions += 1
-
-        # TODO: Remove try/except and consider merging with previous caching
-        # case when circuit is always QuantumTape
-        try:
-            self._circuit_hash = circuit.graph.hash
-        except AttributeError as e:
-            self._circuit_hash = circuit.hash
 
         return results
 

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -202,14 +202,12 @@ class QubitDevice(Device):
 
         # compute the required statistics
         results = self.statistics(circuit.observables)
+        all_sampled = all(m.return_type is Sample for m in circuit.observables)
 
-        # Ensures that a combination with sample does not put
-        # expvals and vars in superfluous arrays
-        all_sampled = all(obs.return_type is Sample for obs in circuit.observables)
-        if circuit.is_sampled and not all_sampled:
-            results = self._asarray(results, dtype="object")
-        else:
+        if all_sampled or not circuit.is_sampled:
             results = self._asarray(results)
+        else:
+            results = tuple([self._asarray(r) for r in results])
 
         if self._cache and circuit_hash not in self._cache_execute:
             self._cache_execute[circuit_hash] = results

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -185,20 +185,15 @@ class QubitDevice(Device):
         """
         if self._cache:
             try:  # TODO: Remove try/except when circuit is always QuantumTape
-                circuit_hash = circuit.graph.hash
+                if circuit._graph is not None:
+                    circuit_hash = circuit.graph.hash
+
+                    if circuit_hash in self._cache_execute:
+                        return self._cache_execute[circuit_hash]
             except AttributeError as e:
                 raise ValueError("Caching is only available when using tape mode") from e
-            if circuit_hash in self._cache_execute:
-                return self._cache_execute[circuit_hash]
 
         self.check_validity(circuit.operations, circuit.observables)
-
-        # TODO: Remove try/except and consider merging with previous caching
-        # case when circuit is always QuantumTape
-        try:
-            self._circuit_hash = circuit.graph.hash
-        except AttributeError as e:
-            self._circuit_hash = circuit.hash
 
         # apply all circuit operations
         self.apply(circuit.operations, rotations=circuit.diagonalizing_gates, **kwargs)
@@ -223,6 +218,14 @@ class QubitDevice(Device):
 
         # increment counter for number of executions of qubit device
         self._num_executions += 1
+
+
+        # TODO: Remove try/except and consider merging with previous caching
+        # case when circuit is always QuantumTape
+        try:
+            self._circuit_hash = circuit.graph.hash
+        except AttributeError as e:
+            self._circuit_hash = circuit.hash
 
         return results
 

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -193,7 +193,12 @@ class QubitDevice(Device):
 
         self.check_validity(circuit.operations, circuit.observables)
 
-        self._circuit_hash = circuit.hash
+        # TODO: Remove try/except and consider merging with previous caching
+        # case when circuit is always QuantumTape
+        try:
+            self._circuit_hash = circuit.graph.hash
+        except AttributeError as e:
+            self._circuit_hash = circuit.hash
 
         # apply all circuit operations
         self.apply(circuit.operations, rotations=circuit.diagonalizing_gates, **kwargs)

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -219,7 +219,6 @@ class QubitDevice(Device):
         # increment counter for number of executions of qubit device
         self._num_executions += 1
 
-
         # TODO: Remove try/except and consider merging with previous caching
         # case when circuit is always QuantumTape
         try:

--- a/pennylane/circuit_graph.py
+++ b/pennylane/circuit_graph.py
@@ -161,7 +161,7 @@ class CircuitGraph:
         for k, op in enumerate(ops):
             op.queue_idx = k  # store the queue index in the Operator
 
-            if hasattr(op, "return_type") and  op.return_type is qml.operation.State:
+            if hasattr(op, "return_type") and op.return_type is qml.operation.State:
                 # State measurements contain no wires by default, but wires are
                 # required for the circuit drawer, so we recreate the state
                 # measurement with all wires

--- a/pennylane/circuit_graph.py
+++ b/pennylane/circuit_graph.py
@@ -160,6 +160,14 @@ class CircuitGraph:
         """int: number of wires the circuit contains"""
         for k, op in enumerate(ops):
             op.queue_idx = k  # store the queue index in the Operator
+
+            if hasattr(op, "return_type") and  op.return_type is qml.operation.State:
+                # State measurements contain no wires by default, but wires are
+                # required for the circuit drawer, so we recreate the state
+                # measurement with all wires
+                op = qml.tape.MeasurementProcess(qml.operation.State, wires=wires)
+                op.queue_idx = k
+
             for w in op.wires:
                 # get the index of the wire on the device
                 wire = wires.index(w)

--- a/pennylane/tape/circuit_graph.py
+++ b/pennylane/tape/circuit_graph.py
@@ -54,11 +54,6 @@ class TapeCircuitGraph(CircuitGraph):
 
         self._depth = None
 
-        for m in self._observables:
-            if m.return_type is qml.operation.State:
-                # state measurements are applied to all device wires
-                m._wires = wires  # pylint: disable=protected-access
-
         super().__init__(ops + obs, variable_deps={}, wires=wires)
 
         # For computing depth; want only a graph with the operations, not

--- a/pennylane/tape/tapes/tape.py
+++ b/pennylane/tape/tapes/tape.py
@@ -254,7 +254,6 @@ class QuantumTape(AnnotatedQueue):
         self.wires = qml.wires.Wires([])
         self.num_wires = 0
 
-        self.hash = 0
         self.is_sampled = False
         self.inverse = False
 

--- a/tests/test_qubit_device.py
+++ b/tests/test_qubit_device.py
@@ -765,6 +765,22 @@ class TestExecution:
             node_3(0.432, 0.12)
         assert dev_1.num_executions == num_evals_1 + num_evals_3
 
+    def test_same_hash(self):
+        """Test that executing the same tape twice produces the same circuit
+        hash."""
+        dev = qml.device("default.qubit", wires=2)
+
+        with QuantumTape() as tape0:
+            qml.RZ(0.3, wires=[0])
+            qml.expval(qml.PauliX(0))
+
+        tape0.execute(dev)
+        orig_hash = dev.circuit_hash
+
+        tape0.execute(dev)
+        new_hash = dev.circuit_hash
+        assert orig_hash == new_hash
+
     def test_different_hash(self):
         """Test that executing different tapes affects the circuit hash."""
         dev = qml.device("default.qubit", wires=2)

--- a/tests/test_qubit_device.py
+++ b/tests/test_qubit_device.py
@@ -26,6 +26,7 @@ from pennylane.operation import Sample, Variance, Expectation, Probability, Stat
 from pennylane.circuit_graph import CircuitGraph
 from pennylane.variable import Variable
 from pennylane.wires import Wires
+from pennylane.tape import QuantumTape
 from pennylane.tape.measure import state
 
 mock_qubit_device_paulis = ["PauliX", "PauliY", "PauliZ"]
@@ -763,6 +764,26 @@ class TestExecution:
         for _ in range(num_evals_3):
             node_3(0.432, 0.12)
         assert dev_1.num_executions == num_evals_1 + num_evals_3
+
+    def test_different_hash(self):
+        """Test that executing different tapes affects the circuit hash."""
+        dev = qml.device("default.qubit", wires=2)
+
+        with QuantumTape() as tape0:
+            qml.RZ(0.3, wires=[0])
+            qml.expval(qml.PauliX(0))
+
+        tape0.execute(dev)
+        orig_hash = dev.circuit_hash
+
+        with QuantumTape() as tape1:
+            qml.RY(1.3, wires=[0])
+            qml.RX(0.9, wires=[0])
+            qml.expval(qml.PauliX(0))
+
+        tape1.execute(dev)
+        new_hash = dev.circuit_hash
+        assert orig_hash != new_hash
 
 
 class TestBatchExecution:


### PR DESCRIPTION
**Context**

The hash for every tape is initialized to 0. This causes certain features such as parametric compilation to behave in unexpected ways.

**Changes**

* Removes the `tape.hash` attribute such that the `tape.graph.hash` property can be used

**Related issue**

Parametric compilation in the Forest plugin: https://github.com/PennyLaneAI/pennylane-forest/issues/66

**Further note**

For some reason constructing the `CircuitGraph` of a `QuantumTape` needs to happen after the operations are applied (hence the change in the order of statements within `QubitDevice.execute`.

This phenomenon might also affect caching, as it can happen that we are trying to construct the circuit graph of a tape for the first time just to obtain the hash of the circuit.

The error seems to be related to jacobian computations `ValueError: cannot reshape array of size 4 into shape (2,)`. See [this log](https://github.com/PennyLaneAI/pennylane/runs/1772886525).