### PR TITLE
Fix vjp to work with nested params

### DIFF
--- a/pennylane/tape/interfaces/autograd.py
+++ b/pennylane/tape/interfaces/autograd.py
@@ -199,7 +199,11 @@ class AutogradInterface(AnnotatedQueue):
             self.set_parameters(self._all_params_unwrapped, trainable_only=False)
             jac = self.jacobian(device, params=params, **self.jacobian_options)
             self.set_parameters(self._all_parameter_values, trainable_only=False)
-            vjp = g.flatten() @ jac
+
+            if all(np.ndim(p) == 0 for p in params):
+                vjp = g.flatten() @ jac
+            else:
+                vjp = g @ jac
             return vjp
 
         return gradient_product

--- a/pennylane/tape/interfaces/autograd.py
+++ b/pennylane/tape/interfaces/autograd.py
@@ -202,6 +202,7 @@ class AutogradInterface(AnnotatedQueue):
             jac = self.jacobian(device, params=params, **self.jacobian_options)
             self.set_parameters(self._all_parameter_values, trainable_only=False)
 
+            # only flatten g if all parameters are single values
             if all(np.ndim(p) == 0 for p in params):
                 vjp = g.flatten() @ jac
             else:


### PR DESCRIPTION
**Context:**
The vjp function does not return the expected values.

Without tape mode:
```pycon
>>> vjp = make_vjp(fun, x)
>>> vjp(np.array([1, 0, 0, 0]))
array([-0.654, 0.54])
```

The output of the VJP function should be of size 2, matching the input parameter size.

However, in tape mode, this is happening:
```pycon
>>> vjp = make_vjp(fun, x)
>>> vjp(np.array([1, 0, 0, 0]))
-0.654
```

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
