### PR TITLE
Bug fix in are_identical_pauli_words function to ensure observables are always pruned

### DIFF
--- a/pennylane/grouping/utils.py
+++ b/pennylane/grouping/utils.py
@@ -99,6 +99,11 @@ def are_identical_pauli_words(pauli_1, pauli_2):
         )
 
     paulis_with_identity = (PauliX, PauliY, PauliZ, Identity)
+
+    # convert tensors of length 1 to plain observables
+    pauli_1 = getattr(pauli_1, "prune", lambda: pauli_1)()
+    pauli_2 = getattr(pauli_2, "prune", lambda: pauli_2)()
+
     if isinstance(pauli_1, paulis_with_identity) and isinstance(pauli_2, paulis_with_identity):
         return (pauli_1.wires, pauli_1.name) == (pauli_2.wires, pauli_2.name)
 

--- a/tests/grouping/test_grouping_utils.py
+++ b/tests/grouping/test_grouping_utils.py
@@ -224,11 +224,11 @@ class TestGroupingUtils:
     def test_are_identical_pauli_words(self):
         """Tests for determining if two Pauli words have the same ``wires`` and ``name`` attributes."""
 
-        pauli_word_0a = Tensor(PauliX(0))
-        pauli_word_0b = PauliX(0)
+        pauli_word_1 = Tensor(PauliX(0))
+        pauli_word_2 = PauliX(0)
 
-        assert are_identical_pauli_words(pauli_word_0a, pauli_word_0b)
-        assert are_identical_pauli_words(pauli_word_0b, pauli_word_0a)
+        assert are_identical_pauli_words(pauli_word_1, pauli_word_2)
+        assert are_identical_pauli_words(pauli_word_2, pauli_word_1)
 
         pauli_word_1 = PauliX(0) @ PauliY(1)
         pauli_word_2 = PauliY(1) @ PauliX(0)

--- a/tests/grouping/test_grouping_utils.py
+++ b/tests/grouping/test_grouping_utils.py
@@ -224,6 +224,12 @@ class TestGroupingUtils:
     def test_are_identical_pauli_words(self):
         """Tests for determining if two Pauli words have the same ``wires`` and ``name`` attributes."""
 
+        pauli_word_0a = Tensor(PauliX(0))
+        pauli_word_0b = PauliX(0)
+
+        assert are_identical_pauli_words(pauli_word_0a, pauli_word_0b)
+        assert are_identical_pauli_words(pauli_word_0b, pauli_word_0a)
+
         pauli_word_1 = PauliX(0) @ PauliY(1)
         pauli_word_2 = PauliY(1) @ PauliX(0)
         pauli_word_3 = Tensor(PauliX(0), PauliY(1))


### PR DESCRIPTION
**Context:**

* The function `qchem._qubit_operator_to_terms` when converting from OpenFermion hamiltonians to PennyLane Hamiltonians, *single term observables are always converted to Tensors*. E.g., `0.6543 [Z0]` will be `Tensor(PauliZ(0))`, and _not_ a plain `PauliZ(0)` observable.

* The `are_identical_pauli_words` function in the grouping module determines equality by first comparing object type, and _then_ object value. As a result, `are_identical_pauli_words(qml.PauliZ(0), Tensor(qml.PauliZ(0))` returns False.

**Description of the Change:**

* The `are_identical_pauli_words` function will now attempt to 'prune' all tensors before comparison, ensuring that `are_identical_pauli_words(qml.PauliZ(0), Tensor(qml.PauliZ(0))` returns True.

**Benefits:**

* The function `group_observables` now returns the correct results when using QChem.

**Possible Drawbacks:**

* I'm not sure why `_qubit_operator_to_terms` always creates tensors, even for single wire observables. Instead of patching `are_identical_pauli_words`, would it make more sense to prune the tensor inside `_qubit_operator_to_terms`?

* I can't work out why this doesn't affect the old core - I assume pruning is happening somewhere in the old code.

**Related GitHub Issues:** n/a
