### PR TITLE
Update the state original tape device

### DIFF
--- a/pennylane/tape/qnode.py
+++ b/pennylane/tape/qnode.py
@@ -516,11 +516,11 @@ class QNode:
             self._original_device._num_executions += 1  # pylint: disable=protected-access
 
             # Update for state vector simulators that have the _pre_rotated_state attribute
-            if hasattr(_original_device, "_pre_rotated_state"):
+            if hasattr(self._original_device, "_pre_rotated_state"):
                 self._original_device._pre_rotated_state = self.device._pre_rotated_state
 
             # Update for state vector simulators that have the _state attribute
-            if hasattr(_original_device, "_state"):
+            if hasattr(self._original_device, "_state"):
                 self._original_device._state = self.device._state
 
         if isinstance(self.qfunc_output, Sequence):

--- a/pennylane/tape/qnode.py
+++ b/pennylane/tape/qnode.py
@@ -515,6 +515,14 @@ class QNode:
         if self.device is not self._original_device:
             self._original_device._num_executions += 1  # pylint: disable=protected-access
 
+            # Update for state vector simulators that have the _pre_rotated_state attribute
+            if hasattr(_original_device, "_pre_rotated_state"):
+                self._original_device._pre_rotated_state = self.device._pre_rotated_state
+
+            # Update for state vector simulators that have the _state attribute
+            if hasattr(_original_device, "_state"):
+                self._original_device._state = self.device._state
+
         if isinstance(self.qfunc_output, Sequence):
             return res
 

--- a/tests/tape/test_tape_measure.py
+++ b/tests/tape/test_tape_measure.py
@@ -471,13 +471,17 @@ class TestState:
     @pytest.mark.parametrize(
         "device", ["default.qubit", "default.qubit.tf", "default.qubit.autograd"]
     )
-    def test_devices(self, device, skip_if_no_tf_support):
+
+    @pytest.mark.parametrize(
+        "diff_method", ["best", "finite-diff", "parameter-shift"]
+    )
+    def test_devices(self, device, diff_method, skip_if_no_tf_support):
         """Test that the returned state is equal to the expected returned state for all of
         PennyLane's built in statevector devices"""
 
         dev = qml.device(device, wires=4)
 
-        @qnode(dev, diff_method="parameter-shift")
+        @qnode(dev, diff_method=diff_method)
         def func():
             for i in range(4):
                 qml.Hadamard(i)


### PR DESCRIPTION
**Context:**
With https://github.com/PennyLaneAI/pennylane/pull/1008 devices can be swapped under the hood to get the best differentiation method. This means that certain internal device data may be lost during the QNode call.

**Description of the Change:**
Updates the `_pre_rotated_state` and `_state` private attributes of the original device with the device that was actually used during execution.

*Note*: the way of how the state prior to rotations in being stored might not be completely unified between devices and is not a part of the shared device methods (not a member of `QubitDevice`). Therefore we are attempting to set the affected attributes, but if they do not exist then no change is done.

**Benefits:**
States are updated even if a different device is used under the hood.

**Possible Drawbacks:**
None, though might provide a reason to consider a unified name for storing states in statevector simulator devices.

**Related GitHub Issues:**
#1048