### PR TITLE
Importing collections in vqe/vqe.py fixed

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -476,12 +476,15 @@
 * The `TensorN` observable is updated to support being copied without any parameters or wires passed.
   [(#1047)](https://github.com/PennyLaneAI/pennylane/pull/1047)
 
+* Fixed deprecation warning when importing `Sequence` from `collections` instead of `collections.abc` in `vqe/vqe.py`.
+  [(#1051)](https://github.com/PennyLaneAI/pennylane/pull/1051)
+
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):
 
 Thomas Bromley, Olivia Di Matteo, Theodor Isacsson, Josh Izaac, Christina Lee, Alejandro Montanez,
-Steven Oud, Chase Roberts, Maria Schuld, Antal Száva, David Wierichs, Jiahao Yao.
+Steven Oud, Chase Roberts, Maria Schuld, Antal Száva, David Wierichs, Jiahao Yao, Sankalp Sanand.
 
 # Release 0.13.0 (current release)
 

--- a/pennylane/vqe/vqe.py
+++ b/pennylane/vqe/vqe.py
@@ -16,7 +16,7 @@ This submodule contains functionality for running Variational Quantum Eigensolve
 computations using PennyLane.
 """
 # pylint: disable=too-many-arguments, too-few-public-methods
-from collections import Sequence
+from collections.abc import Sequence
 import itertools
 import warnings
 


### PR DESCRIPTION
**Context:**
As mentioned in the related issue, a deprecation warning was being displayed while running the test suite. A minor change to the import statement fixed the issue.

**Description of the Change:**
Modified the `collections` import statement in the `vqe/vqe.py` file to import `Sequence` from `collections.abc` instead.

**Benefits:**
No more deprecation warning for importing `Sequence` from `collections` instead of `collections.abc` in `vqe/vqe.py`.

**Possible Drawbacks:**

**Related GitHub Issues:**
Issue #1043 
