### PR TITLE
Fixes bugs in optimizer docstrings

### DIFF
--- a/pennylane/optimize/gradient_descent.py
+++ b/pennylane/optimize/gradient_descent.py
@@ -63,8 +63,8 @@ class GradientDescentOptimizer:
 
         Returns:
             tuple[list [array], float]: the new variable values :math:`x^{(t+1)}` and the objective
-                function output prior to the step.
-                If single arg is provided, list [array] is replaced by array.
+            function output prior to the step.
+            If single arg is provided, list [array] is replaced by array.
         """
 
         g, forward = self.compute_grad(objective_fn, args, kwargs, grad_fn=grad_fn)
@@ -79,7 +79,7 @@ class GradientDescentOptimizer:
         return new_args, forward
 
     def step(self, objective_fn, *args, grad_fn=None, **kwargs):
-        """Update trainable args with one step of the optimizer.
+        """Update trainable arguments with one step of the optimizer.
 
         Args:
             objective_fn (function): the objective function for optimization
@@ -92,7 +92,7 @@ class GradientDescentOptimizer:
 
         Returns:
             list [array]: the new variable values :math:`x^{(t+1)}`.
-                If single arg is provided, list [array] is replaced by array.
+            If single arg is provided, list [array] is replaced by array.
         """
 
         g, _ = self.compute_grad(objective_fn, args, kwargs, grad_fn=grad_fn)
@@ -106,8 +106,8 @@ class GradientDescentOptimizer:
 
     @staticmethod
     def compute_grad(objective_fn, args, kwargs, grad_fn=None):
-        r"""Compute gradient of the objective_fn at the point x and return it along with the
-        objective function forward pass (if available).
+        r"""Compute gradient of the objective function at the given point and return it along with
+        the objective function forward pass (if available).
 
         Args:
             objective_fn (function): the objective function for optimization
@@ -120,8 +120,8 @@ class GradientDescentOptimizer:
 
         Returns:
             tuple (array): NumPy array containing the gradient :math:`\nabla f(x^{(t)})` and the
-                objective function output. If ``grad_fn`` is provided, the objective function
-                will not be evaluted and instead ``None`` will be returned.
+            objective function output. If ``grad_fn`` is provided, the objective function
+            will not be evaluted and instead ``None`` will be returned.
         """
         g = get_gradient(objective_fn) if grad_fn is None else grad_fn
         grad = g(*args, **kwargs)

--- a/pennylane/optimize/momentum.py
+++ b/pennylane/optimize/momentum.py
@@ -45,7 +45,7 @@ class MomentumOptimizer(GradientDescentOptimizer):
         self.accumulation = None
 
     def apply_grad(self, grad, args):
-        r"""Update the variables args to take a single optimization step. Flattens and unflattens
+        r"""Update the trainable args to take a single optimization step. Flattens and unflattens
         the inputs to maintain nested iterables as the parameters of the optimization.
 
         Args:

--- a/pennylane/optimize/nesterov_momentum.py
+++ b/pennylane/optimize/nesterov_momentum.py
@@ -39,9 +39,9 @@ class NesterovMomentumOptimizer(MomentumOptimizer):
     """
 
     def compute_grad(self, objective_fn, args, kwargs, grad_fn=None):
-        r"""Compute gradient of the objective_fn at at the shifted point :math:`(x -
-        m\times\text{accumulation})` and return it along with the objective function
-        forward pass (if available).
+        r"""Compute gradient of the objective function at at the shifted point :math:`(x -
+        m\times\text{accumulation})` and return it along with the objective function forward pass
+        (if available).
 
         Args:
             objective_fn (function): the objective function for optimization.
@@ -54,8 +54,8 @@ class NesterovMomentumOptimizer(MomentumOptimizer):
 
         Returns:
             tuple [array]: the NumPy array containing the gradient :math:`\nabla f(x^{(t)})` and the
-                objective function output. If ``grad_fn`` is provided, the objective function
-                will not be evaluted and instead ``None`` will be returned.
+            objective function output. If ``grad_fn`` is provided, the objective function
+            will not be evaluted and instead ``None`` will be returned.
         """
         shifted_args = list(args)
 

--- a/pennylane/optimize/qng.py
+++ b/pennylane/optimize/qng.py
@@ -156,8 +156,8 @@ class QNGOptimizer(GradientDescentOptimizer):
         self.lam = lam
 
     def step_and_cost(self, qnode, x, recompute_tensor=True, metric_tensor_fn=None):
-        """Update x with one step of the optimizer and return the corresponding objective
-        function value prior to the step.
+        """Update the parameter array :math:`x` with one step of the optimizer and return the
+        corresponding objective function value prior to the step.
 
         Args:
             qnode (QNode): the QNode for optimization
@@ -171,7 +171,7 @@ class QNGOptimizer(GradientDescentOptimizer):
 
         Returns:
             tuple: the new variable values :math:`x^{(t+1)}` and the objective function output
-                prior to the step
+            prior to the step
         """
         # pylint: disable=arguments-differ
         if (
@@ -200,7 +200,7 @@ class QNGOptimizer(GradientDescentOptimizer):
 
     # pylint: disable=arguments-differ
     def step(self, qnode, x, recompute_tensor=True, metric_tensor_fn=None):
-        """Update x with one step of the optimizer.
+        """Update the parameter array :math:`x` with one step of the optimizer.
 
         Args:
             qnode (QNode): the QNode for optimization
@@ -221,8 +221,8 @@ class QNGOptimizer(GradientDescentOptimizer):
         return x_out
 
     def apply_grad(self, grad, x):
-        r"""Update the variables x to take a single optimization step. Flattens and unflattens
-        the inputs to maintain nested iterables as the parameters of the optimization.
+        r"""Update the parameter array :math:`x` for a single optimization step. Flattens and
+        unflattens the inputs to maintain nested iterables as the parameters of the optimization.
 
         Args:
             grad (array): The gradient of the objective

--- a/pennylane/optimize/rotoselect.py
+++ b/pennylane/optimize/rotoselect.py
@@ -94,8 +94,8 @@ class RotoselectOptimizer:
         self.possible_generators = possible_generators or [qml.RX, qml.RY, qml.RZ]
 
     def step_and_cost(self, objective_fn, x, generators, **kwargs):
-        r"""Update x with one step of the optimizer and return the corresponding objective
-        function value prior to the step.
+        """Update trainable arguments with one step of the optimizer and return the corresponding
+        objective function value prior to the step.
 
         Args:
             objective_fn (function): The objective function for optimization. It must have the
@@ -109,14 +109,14 @@ class RotoselectOptimizer:
 
         Returns:
             tuple: the new variable values :math:`x^{(t+1)}`, the new generators, and the objective
-                function output prior to the step
+            function output prior to the step
         """
         x_new, generators = self.step(objective_fn, x, generators, **kwargs)
 
         return x_new, generators, objective_fn(x, generators, **kwargs)
 
     def step(self, objective_fn, x, generators, **kwargs):
-        r"""Update x with one step of the optimizer.
+        r"""Update trainable arguments with one step of the optimizer.
 
         Args:
             objective_fn (function): The objective function for optimization. It must have the

--- a/pennylane/optimize/rotosolve.py
+++ b/pennylane/optimize/rotosolve.py
@@ -89,8 +89,8 @@ class RotosolveOptimizer:
 
         Returns:
             tuple[list [array], float]: the new variable values :math:`x^{(t+1)}` and the objective
-                function output prior to the step.
-                If single arg is provided, list [array] is replaced by array.
+            function output prior to the step.
+            If single arg is provided, list [array] is replaced by array.
         """
         x_new = self.step(objective_fn, *args, **kwargs)
 
@@ -110,7 +110,7 @@ class RotosolveOptimizer:
 
         Returns:
             list [array]: the new variable values :math:`x^{(t+1)}`.
-                If single arg is provided, list [array] is replaced by array.
+            If single arg is provided, list [array] is replaced by array.
         """
         # will single out one variable to change at a time
         # these hold the arguments not getting updated


### PR DESCRIPTION
**Context:**

* Several of the optimizer docstrings had rendering bugs and outdated terminology

**Description of the Change:** 

* Removes rendering bugs in the `Returns:` statement by removing indentation in continuation lines. While the `Args:` section requires continuation lines be indented since there might be multiple arguments, there is only ever a _single_ return, and so the return is never indented.

* In #959, most of the optimizers were updated to remove restrictions on cost function signatures. As a result, the `x` argument was changed to `*args` to be more general. Some stray `x` mentions in the docstrings were removed.

**Benefits:** Docstrings render correctly.

**Possible Drawbacks:**

I noticed while working on this that the `QNGOptimizer` is the one optimizer that continues to only accept cost functions with a single argument. This was intentional in #959, as at the time the `metric_tensor` method did not allow multiple QNode arguments.

However, the new `qml.metric_tensor` function that was added in #1014 removes this restriction, so we are now unblocked from also updating the `QNGOptimizer`.

**Related GitHub Issues:** n/a
