### PR TITLE
Hotfixes to allow PennyLane to work with the latest NumPy version

### DIFF
--- a/pennylane/math/numpy_box.py
+++ b/pennylane/math/numpy_box.py
@@ -50,8 +50,12 @@ class NumpyBox(qml.math.TensorBox):
                 tensor = np.asarray(tensor)
             except:
                 # In NumPy v1.20, there is a change in bheaviour for array-like objects that do not
-                # define `__len__` and `__getitem__`. Currently this will affect lists of Torch
+                # define `__len__` and `__getitem__`. This will affect *ragged* lists of Torch
                 # arrays, but not lists of TensorFlow nor Autograd arrays.
+                #
+                # Currently this except branch will only be trigged by the `CVNeuralNetLayers` template
+                # when using the Torch interface, as this is the only template that will
+                # recieve ragged arrays.
                 #
                 # In NumPy < 1.20, the following call would result in an object array:
                 #

--- a/pennylane/math/numpy_box.py
+++ b/pennylane/math/numpy_box.py
@@ -49,7 +49,7 @@ class NumpyBox(qml.math.TensorBox):
             try:
                 tensor = np.asarray(tensor)
             except:
-                # In NumPy v1.20, there is a change in bheaviour for array-like objects that do not
+                # In NumPy v1.20, there is a change in behaviour for array-like objects that do not
                 # define `__len__` and `__getitem__`. This will affect *ragged* lists of Torch
                 # arrays, but not lists of TensorFlow nor Autograd arrays.
                 #

--- a/pennylane/math/numpy_box.py
+++ b/pennylane/math/numpy_box.py
@@ -49,6 +49,22 @@ class NumpyBox(qml.math.TensorBox):
             try:
                 tensor = np.asarray(tensor)
             except:
+                # In NumPy v1.20, there is a change in bheaviour for array-like objects that do not
+                # define `__len__` and `__getitem__`. Currently this will affect lists of Torch
+                # arrays, but not lists of TensorFlow nor Autograd arrays.
+                #
+                # In NumPy < 1.20, the following call would result in an object array:
+                #
+                # >>> np.array([array_like])
+                #
+                # However, in NumPy >= 1.20, this instead acts like so:
+                #
+                # >>> np.array([np.array(array_like)])
+                #
+                # Unfortunately, there is no way to return to the old behaviour. The below hotfix
+                # is based on a suggestion from the NumPy release notes,
+                # https://numpy.org/doc/stable/release/1.20.0-notes.html#arraylike-objects-which-do-not-define-len-and-getitem.
+
                 object_tensor = np.empty(len(tensor), dtype=object)
                 object_tensor[:] = tensor
                 tensor = object_tensor

--- a/pennylane/math/numpy_box.py
+++ b/pennylane/math/numpy_box.py
@@ -46,7 +46,12 @@ class NumpyBox(qml.math.TensorBox):
 
     def __init__(self, tensor):
         if not isinstance(tensor, np.ndarray):
-            tensor = np.asarray(tensor)
+            try:
+                tensor = np.asarray(tensor)
+            except:
+                object_tensor = np.empty(len(tensor), dtype=object)
+                object_tensor[:] = tensor
+                tensor = object_tensor
 
         super().__init__(tensor)
 

--- a/pennylane/math/numpy_box.py
+++ b/pennylane/math/numpy_box.py
@@ -48,7 +48,7 @@ class NumpyBox(qml.math.TensorBox):
         if not isinstance(tensor, np.ndarray):
             try:
                 tensor = np.asarray(tensor)
-            except:
+            except RuntimeError:
                 # In NumPy v1.20, there is a change in behaviour for array-like objects that do not
                 # define `__len__` and `__getitem__`. This will affect *ragged* lists of Torch
                 # arrays, but not lists of TensorFlow nor Autograd arrays.

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -432,10 +432,12 @@ class Operator(abc.ABC):
             )
 
         if len(params) != self.num_params:
-            # HOTFIX: the following line is added to support Torch and NumPy v1.20.
-            # This is required because NumPy v1.20 appears to insert an
-            # additional dimension for object arrays.
-            params = params[0]
+            if len(params) == 1 and isinstance(params[0], (list, tuple)):
+                # HOTFIX: the following line is added to support Torch and NumPy v1.20.
+                # This is required because NumPy v1.20 changes how `np.expand_dims` works
+                # for object arrays.
+                params = params[0]
+
             if len(params) != self.num_params:
                 raise ValueError(
                     "{}: wrong number of parameters. "

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -432,10 +432,12 @@ class Operator(abc.ABC):
             )
 
         if len(params) != self.num_params:
-            raise ValueError(
-                "{}: wrong number of parameters. "
-                "{} parameters passed, {} expected.".format(self.name, len(params), self.num_params)
-            )
+            params = params[0]
+            if len(params) != self.num_params:
+                raise ValueError(
+                    "{}: wrong number of parameters. "
+                    "{} parameters passed, {} expected.".format(self.name, len(params), self.num_params)
+                )
 
         # check the validity of the params
         if self.do_check_domain:

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -432,6 +432,9 @@ class Operator(abc.ABC):
             )
 
         if len(params) != self.num_params:
+            # HOTFIX: the following line is added to support Torch and NumPy v1.20.
+            # This is required because NumPy v1.20 appears to insert an
+            # additional dimension for object arrays.
             params = params[0]
             if len(params) != self.num_params:
                 raise ValueError(

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -439,7 +439,9 @@ class Operator(abc.ABC):
             if len(params) != self.num_params:
                 raise ValueError(
                     "{}: wrong number of parameters. "
-                    "{} parameters passed, {} expected.".format(self.name, len(params), self.num_params)
+                    "{} parameters passed, {} expected.".format(
+                        self.name, len(params), self.num_params
+                    )
                 )
 
         # check the validity of the params


### PR DESCRIPTION
**Context:**

In NumPy v1.20, there is a change in behaviour for array-like objects that do not define `__len__` and `__getitem__`. This will affect *ragged* lists of Torch arrays, but not lists of TensorFlow nor Autograd arrays.

Currently this except branch will only be trigged by the `CVNeuralNetLayers` template when using the Torch interface, as this is the only template that will recieve ragged arrays.

In NumPy < 1.20, the following call would result in an object array:

```python
>>> np.array([array_like])
```

However, in NumPy >= 1.20, this instead acts like so:

```python
>>> np.array([np.array(array_like)])
```

Unfortunately, there is no way to return to the old behaviour. The below hotfix is based on a suggestion from the NumPy release notes, https://numpy.org/doc/stable/release/1.20.0-notes.html#arraylike-objects-which-do-not-define-len-and-getitem.

**Description of the Change:**

* Adds a try-except to the NumPy interface to attempt to catch this issue, and implements the workaround suggested in the NumPy release notes.

**Benefits:**

* The Torch interface works again with the `CVNeuralNetLayers` template.

**Possible Drawbacks:**

* Ideally, this should be fixed upstream by PyTorch, by implementing the `__len__` and `__getitem__` special methods on PyTorch tensors.

**Related GitHub Issues:** #1056 
