### PR TITLE
Fix bug in CV second order parameter-shift formula, where the incorrect parameter is being differentiated

### DIFF
--- a/pennylane/tape/tapes/cv_param_shift.py
+++ b/pennylane/tape/tapes/cv_param_shift.py
@@ -409,7 +409,9 @@ class CVParamShiftTape(QubitParamShiftTape):
         """
         device = options["device"]
         options["dev_wires"] = device.wires
-        grad_method = self._par_info[idx]["grad_method"]
+
+        t_idx = list(self.trainable_params)[idx]
+        grad_method = self._par_info[t_idx]["grad_method"]
 
         if options.get("force_order2", False) or grad_method == "A2":
 


### PR DESCRIPTION
**Context:** The second order CV parameter shift rule was giving incorrect gradients. We did not notice this until we were updating the [hybrid demo](https://pennylane.ai/qml/demos/tutorial_plugins_hybrid.html), since PennyLane does not provide a non-Gaussian simulator.

**Description of the Change:** Changes the index used to query the gradient method

**Benefits:** Second order parameter-shift now works

**Possible Drawbacks:** n/a

**Related GitHub Issues:** n/a
