### PR TITLE
Jax interface for all devices.

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 <h3>New features since last release</h3>
 
+<h4>JAX is now supported on all devices</h4>
+
+* JAX can nw be used as the interface to any device
+
+  Here is an example of how to use JAX with Cirq:
+
+  ```python
+  dev = qml.device('cirq.simulator', wires=1)
+  @qml.qnode(dev, interface="jax")
+  def circuit(x):
+      qml.RX(x[1], wires=0)
+      qml.Rot(x[0], x[1], x[2], wires=0)
+      return qml.expval(qml.PauliZ(0))
+
+  weights = jnp.array([0.2, 0.5, 0.1])
+  print(circuit(weights)) # DeviceArray(...)
+
+  ```
 <h3>Improvements</h3>
 
 <h3>Breaking changes</h3>
@@ -14,7 +32,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-
+Chase Roberts
 
 # Release 0.14.0 (current release)
 

--- a/pennylane/tape/interfaces/jax.py
+++ b/pennylane/tape/interfaces/jax.py
@@ -1,0 +1,116 @@
+# Copyright 2018-2021 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+This module contains the mixin interface class for creating differentiable quantum tapes with
+JAX.
+"""
+import jax
+import jax.experimental.host_callback as host_callback
+import jax.numpy as jnp
+from functools import partial
+from pennylane.tape.queuing import AnnotatedQueue
+from pennylane.operation import Variance, Expectation
+
+
+class JAXInterface(AnnotatedQueue):
+    """Mixin class for applying an JAX interface to a :class:`~.JacobianTape`.
+
+    JAX-compatible quantum tape classes can be created via subclassing:
+
+    .. code-block:: python
+
+        class MyAutogradQuantumTape(AutogradInterface, JacobianTape):
+
+    Alternatively, the jax interface can be dynamically applied to existing
+    quantum tapes via the :meth:`~.apply` class method. This modifies the
+    tape **in place**.
+
+    Once created, the autograd interface can be used to perform quantum-classical
+    differentiable programming.
+
+    .. note::
+
+        If using a device that supports native autograd computation and backpropagation, such as
+        :class:`~.DefaultQubitJAX`, the Autograd interface **does not need to be applied**. It
+        is only applied to tapes executed on non-JAX compatible devices.
+
+    **Example**
+
+    Once a JAX quantum tape has been created, it can be differentiated using JAX:
+
+    .. code-block:: python
+
+        tape = AutogradInterface.apply(JacobianTape())
+
+        with tape:
+            qml.Rot(0, 0, 0, wires=0)
+            expval(qml.PauliX(0))
+
+        def cost_fn(x, y, z, device):
+            tape.set_parameters([x, y ** 2, y * np.sin(z)], trainable_only=False)
+            return tape.execute(device=device)
+
+    >>> x = jnp.array(0.1, requires_grad=False)
+    >>> y = jnp.array(0.2, requires_grad=True)
+    >>> z = jnp.array(0.3, requires_grad=True)
+    >>> dev = qml.device("default.qubit", wires=2)
+    >>> cost_fn(x, y, z, device=dev)
+    [0.03991951]
+    >>> jac_fn = jax.vjp(cost_fn)
+    >>> jac_fn(x, y, z, device=dev)
+    DeviceArray[[ 0.39828408, -0.00045133]]
+    """
+
+    # pylint: disable=attribute-defined-outside-init
+    dtype = jnp.float64
+
+    @property
+    def interface(self):  # pylint: disable=missing-function-docstring
+        return "jax"
+
+    def _execute(self, params, device):
+        # TODO(chase): Add support for this.
+        if len(self.observables) != 1:
+            raise ValueError("Only one return type is supported currently")
+        return_type = self.observables[0].return_type
+        if return_type is not Variance and return_type is not Expectation:
+            raise ValueError(
+                f"Only Variance and Expectation returns are support, given {return_type}"
+            )
+        exec_fn = partial(self.execute_device, device=device)
+
+        return host_callback.call(
+            exec_fn, params, result_shape=jax.ShapeDtypeStruct((1,), JAXInterface.dtype)
+        )
+
+    @classmethod
+    def apply(cls, tape):
+        """Apply the autograd interface to an existing tape in-place.
+
+        Args:
+            tape (.JacobianTape): a quantum tape to apply the Autograd interface to
+
+        **Example**
+
+        >>> with JacobianTape() as tape:
+        ...     qml.RX(0.5, wires=0)
+        ...     expval(qml.PauliZ(0))
+        >>> AutogradInterface.apply(tape)
+        >>> tape
+        <AutogradQuantumTape: wires=<Wires = [0]>, params=1>
+        """
+        tape_class = getattr(tape, "__bare__", tape.__class__)
+        tape.__bare__ = tape_class
+        tape.__class__ = type("JAXQuantumTape", (cls, tape_class), {})
+        return tape

--- a/pennylane/tape/interfaces/jax.py
+++ b/pennylane/tape/interfaces/jax.py
@@ -51,7 +51,7 @@ class JAXInterface(AnnotatedQueue):
 
     .. code-block:: python
 
-        tape = AutogradInterface.apply(JacobianTape())
+        tape = JAXInterface.apply(JacobianTape())
 
         with tape:
             qml.Rot(0, 0, 0, wires=0)
@@ -96,19 +96,19 @@ class JAXInterface(AnnotatedQueue):
 
     @classmethod
     def apply(cls, tape):
-        """Apply the autograd interface to an existing tape in-place.
+        """Apply the JAX interface to an existing tape in-place.
 
         Args:
-            tape (.JacobianTape): a quantum tape to apply the Autograd interface to
+            tape (.JacobianTape): a quantum tape to apply the JAX interface to
 
         **Example**
 
         >>> with JacobianTape() as tape:
         ...     qml.RX(0.5, wires=0)
         ...     expval(qml.PauliZ(0))
-        >>> AutogradInterface.apply(tape)
+        >>> JAXInterface.apply(tape)
         >>> tape
-        <AutogradQuantumTape: wires=<Wires = [0]>, params=1>
+        <JAXQuantumTape: wires=<Wires = [0]>, params=1>
         """
         tape_class = getattr(tape, "__bare__", tape.__class__)
         tape.__bare__ = tape_class

--- a/pennylane/tape/interfaces/jax.py
+++ b/pennylane/tape/interfaces/jax.py
@@ -15,10 +15,10 @@
 This module contains the mixin interface class for creating differentiable quantum tapes with
 JAX.
 """
+from functools import partial
 import jax
 import jax.experimental.host_callback as host_callback
 import jax.numpy as jnp
-from functools import partial
 from pennylane.tape.queuing import AnnotatedQueue
 from pennylane.operation import Variance, Expectation
 

--- a/pennylane/tape/qnode.py
+++ b/pennylane/tape/qnode.py
@@ -754,7 +754,7 @@ class QNode:
             AutogradInterface.apply(self.qtape)
 
     def to_jax(self):
-        """Apply the TensorFlow interface to the internal quantum tape.
+        """Apply the JAX interface to the internal quantum tape.
 
         Args:
             dtype (tf.dtype): The dtype that the TensorFlow QNode should

--- a/pennylane/tape/qnode.py
+++ b/pennylane/tape/qnode.py
@@ -766,6 +766,7 @@ class QNode:
         # pylint: disable=import-outside-toplevel
         try:
             from pennylane.tape.interfaces.jax import JAXInterface
+
             if self.interface != "jax" and self.interface is not None:
                 # Since the interface is changing, need to re-validate the tape class.
                 self._tape, interface, self.device, diff_options = self.get_tape(
@@ -776,7 +777,6 @@ class QNode:
                 self.diff_options.update(diff_options)
             else:
                 self.interface = "jax"
-
 
             if self.qtape is not None:
                 JAXInterface.apply(self.qtape)

--- a/pennylane/tape/qnode.py
+++ b/pennylane/tape/qnode.py
@@ -754,13 +754,46 @@ class QNode:
             AutogradInterface.apply(self.qtape)
 
     def to_jax(self):
-        """Validation checks when a user expects to use the JAX interface."""
+        """Apply the TensorFlow interface to the internal quantum tape.
+
+        Args:
+            dtype (tf.dtype): The dtype that the TensorFlow QNode should
+                output. If not provided, the default is ``tf.float64``.
+
+        Raises:
+            .QuantumFunctionError: if TensorFlow >= 2.1 is not installed
+        """
+        # pylint: disable=import-outside-toplevel
         if self.diff_method != "backprop":
             raise qml.QuantumFunctionError(
                 "The JAX interface can only be used with "
                 "diff_method='backprop' on supported devices"
             )
-        self.interface = "jax"
+        try:
+            import jax
+            from pennylane.tape.interfaces.jax import JAXInterface
+
+            if self.interface != "jax" and self.interface is not None:
+                # Since the interface is changing, need to re-validate the tape class.
+                self._tape, interface, self.device, diff_options = self.get_tape(
+                    self._original_device, "jax", self.diff_method
+                )
+
+                self.interface = interface
+                self.diff_options.update(diff_options)
+            else:
+                self.interface = "jax"
+
+            self.dtype = dtype or self.dtype or JAXInterface.dtype
+
+            if self.qtape is not None:
+                JAXInterface.apply(self.qtape, dtype=self.dtype)
+
+        except ImportError as e:
+            raise qml.QuantumFunctionError(
+                "JAX not found. Please install the latest "
+                "version of JAX to enable the 'jax' interface."
+            ) from e
 
     INTERFACE_MAP = {"autograd": to_autograd, "torch": to_torch, "tf": to_tf, "jax": to_jax}
 

--- a/pennylane/tape/qnode.py
+++ b/pennylane/tape/qnode.py
@@ -757,8 +757,8 @@ class QNode:
         """Apply the JAX interface to the internal quantum tape.
 
         Args:
-            dtype (tf.dtype): The dtype that the TensorFlow QNode should
-                output. If not provided, the default is ``tf.float64``.
+            dtype (tf.dtype): The dtype that the JAX QNode should
+                output. If not provided, the default is ``jnp.float64``.
 
         Raises:
             .QuantumFunctionError: if TensorFlow >= 2.1 is not installed

--- a/pennylane/tape/qnode.py
+++ b/pennylane/tape/qnode.py
@@ -764,15 +764,8 @@ class QNode:
             .QuantumFunctionError: if TensorFlow >= 2.1 is not installed
         """
         # pylint: disable=import-outside-toplevel
-        if self.diff_method != "backprop":
-            raise qml.QuantumFunctionError(
-                "The JAX interface can only be used with "
-                "diff_method='backprop' on supported devices"
-            )
         try:
-            import jax
             from pennylane.tape.interfaces.jax import JAXInterface
-
             if self.interface != "jax" and self.interface is not None:
                 # Since the interface is changing, need to re-validate the tape class.
                 self._tape, interface, self.device, diff_options = self.get_tape(
@@ -784,10 +777,9 @@ class QNode:
             else:
                 self.interface = "jax"
 
-            self.dtype = dtype or self.dtype or JAXInterface.dtype
 
             if self.qtape is not None:
-                JAXInterface.apply(self.qtape, dtype=self.dtype)
+                JAXInterface.apply(self.qtape)
 
         except ImportError as e:
             raise qml.QuantumFunctionError(

--- a/tests/devices/test_default_qubit_jax.py
+++ b/tests/devices/test_default_qubit_jax.py
@@ -436,25 +436,6 @@ class TestHighLevelIntegration:
         grad = jax.grad(cost)(weights)
         assert grad.shape == weights.shape
 
-    def test_non_backprop_error(self):
-        """Test that an error is raised in tape mode if the diff method is not backprop"""
-        if not qml.tape_mode_active():
-            pytest.skip("Test only applies in tape mode")
-
-        dev = qml.device("default.qubit.jax", wires=2)
-
-        def circuit(weights):
-            qml.RX(weights[0], wires=0)
-            qml.RY(weights[1], wires=1)
-            qml.CNOT(wires=[0, 1])
-            return qml.expval(qml.PauliZ(0))
-
-        qnode = qml.QNode(circuit, dev, interface="jax", diff_method="parameter-shift")
-        weights = jnp.array([0.1, 0.2])
-
-        with pytest.raises(qml.QuantumFunctionError, match="The JAX interface can only be used with"):
-            qnode(weights)
-
 
 class TestOps:
     """Unit tests for operations supported by the default.qubit.jax device"""

--- a/tests/tape/interfaces/test_tape_jax.py
+++ b/tests/tape/interfaces/test_tape_jax.py
@@ -1,0 +1,106 @@
+# Copyright 2018-2020 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for the JAX interface"""
+import pytest
+import jax
+import jax.numpy as jnp
+import numpy as np
+from functools import partial
+import pennylane as qml
+from pennylane.tape import JacobianTape
+from pennylane.tape.interfaces.jax import JAXInterface
+
+
+class TestJAXQuantumTape:
+    """Test the JAX interface applied to a tape"""
+
+    def test_interface_str(self):
+        """Test that the interface string is correctly identified as JAX"""
+        with JAXInterface.apply(JacobianTape()) as tape:
+            qml.RX(0.5, wires=0)
+            qml.expval(qml.PauliX(0))
+
+        assert tape.interface == "jax"
+        assert isinstance(tape, JAXInterface)
+
+    def test_get_parameters(self):
+        """Test that the get_parameters function correctly gets the trainable parameters and all
+        parameters, depending on the trainable_only argument"""
+        a = jnp.array(0.1)
+        b = jnp.array(0.2)
+        c = jnp.array(0.3)
+        d = jnp.array(0.4)
+
+        with JAXInterface.apply(JacobianTape()) as tape:
+            qml.Rot(a, b, c, wires=0)
+            qml.RX(d, wires=1)
+            qml.CNOT(wires=[0, 1])
+            qml.expval(qml.PauliX(0))
+
+        np.testing.assert_array_equal(tape.get_parameters(), [a, b, c, d])
+
+    def test_execution(self):
+        """Test execution"""
+        a = jnp.array(0.1)
+        b = jnp.array(0.2)
+
+        def cost(a, b, device):
+            with JAXInterface.apply(JacobianTape()) as tape:
+                qml.RY(a, wires=0)
+                qml.RX(b, wires=0)
+                qml.expval(qml.PauliZ(0))
+            return tape.execute(device)
+
+        dev = qml.device("default.qubit", wires=1)
+        res = cost(a, b, device=dev)
+        assert res.shape == (1,)
+        # Easiest way to test object is a device array instead of np.array
+        assert "DeviceArray" in res.__repr__()
+
+
+    def test_state_raises(self):
+        """Test returning state raises exception"""
+        a = jnp.array(0.1)
+        b = jnp.array(0.2)
+
+        def cost(a, b, device):
+            with JAXInterface.apply(JacobianTape()) as tape:
+                qml.RY(a, wires=0)
+                qml.RX(b, wires=0)
+                qml.state()
+            return tape.execute(device)
+
+        dev = qml.device("default.qubit", wires=1)
+        with pytest.raises(ValueError):
+            res = cost(a, b, device=dev)
+
+    def test_execution_with_jit(self):
+        """Test execution"""
+        a = jnp.array(0.1)
+        b = jnp.array(0.2)
+
+        def cost(a, b, device):
+            with JAXInterface.apply(JacobianTape()) as tape:
+                qml.RY(a, wires=0)
+                qml.RX(b, wires=0)
+                qml.expval(qml.PauliZ(0))
+            return tape.execute(device)
+
+        # Not a JAX device!
+        dev = qml.device("default.qubit", wires=1)
+        dev_cost = partial(cost, device=dev)
+        res = jax.jit(dev_cost)(a, b)
+        assert res.shape == (1,)
+        # Easiest way to test object is a device array instead of np.array
+        assert "DeviceArray" in res.__repr__()

--- a/tests/tape/interfaces/test_tape_jax.py
+++ b/tests/tape/interfaces/test_tape_jax.py
@@ -105,3 +105,21 @@ class TestJAXQuantumTape:
         assert res.shape == (1,)
         # Easiest way to test object is a device array instead of np.array
         assert "DeviceArray" in res.__repr__()
+
+    def test_qnode_interface(self):
+
+        dev = qml.device("default.mixed", wires=1)
+
+        @qml.qnode(dev, interface="jax")
+        def circuit(a, b):
+            qml.RY(a, wires=0)
+            qml.RX(b, wires=0)
+            return qml.expval(qml.PauliZ(0))
+
+        a = jnp.array(0.1)
+        b = jnp.array(0.2)
+
+        res = circuit(a, b)
+        assert "DeviceArray" in res.__repr__()
+
+

--- a/tests/tape/interfaces/test_tape_jax.py
+++ b/tests/tape/interfaces/test_tape_jax.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2020 Xanadu Quantum Technologies Inc.
+# Copyright 2018-2021 Xanadu Quantum Technologies Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -82,6 +82,7 @@ class TestJAXQuantumTape:
             return tape.execute(device)
 
         dev = qml.device("default.qubit", wires=1)
+        # TODO(chase): Make this actually work and not raise an error.
         with pytest.raises(ValueError):
             res = cost(a, b, device=dev)
 

--- a/tests/tape/interfaces/test_tape_jax.py
+++ b/tests/tape/interfaces/test_tape_jax.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 """Unit tests for the JAX interface"""
 import pytest
-import jax
-import jax.numpy as jnp
+jax = pytest.importorskip("jax")
+jnp = pytest.importorskip("jax.numpy")
 import numpy as np
 from functools import partial
 import pennylane as qml


### PR DESCRIPTION
**Context:**
Previously, only the `default.qubit.jax` device supported the JAX interface. This PR adds JAX interface support to all devices.

**Description of the Change:**
The recent addition of `jax.experimental.host_callback` allows us to finally do `jax -> numpy -> numpy -> jax` within a `jax.jit` function! This PR adds the needed scaffolding to do it. 

**Benefits:**
Everyone can start using JAX more and I won't take any more execuses.

**Possible Drawbacks:**
None.

**Related GitHub Issues:**
#943 

**TODOs**

* Gradient support
* Vmap support