### PR TITLE
Add controlled unitary gate

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 <h3>Improvements</h3>
 
+- Added the `ControlledQubitUnitary` operation.
+  [(#1069)](https://github.com/PennyLaneAI/pennylane/pull/1069)
+
 <h3>Breaking changes</h3>
 
 <h3>Bug fixes</h3>

--- a/doc/introduction/operations.rst
+++ b/doc/introduction/operations.rst
@@ -81,6 +81,7 @@ Qubit gates
     ~pennylane.Toffoli
     ~pennylane.CSWAP
     ~pennylane.QubitUnitary
+    ~pennylane.ControlledQubitUnitary
     ~pennylane.DiagonalQubitUnitary
     ~pennylane.QFT
 

--- a/pennylane/devices/default_mixed.py
+++ b/pennylane/devices/default_mixed.py
@@ -62,6 +62,7 @@ class DefaultMixed(QubitDevice):
         "BasisState",
         "QubitStateVector",
         "QubitUnitary",
+        "ControlledQubitUnitary",
         "DiagonalQubitUnitary",
         "PauliX",
         "PauliY",

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -97,6 +97,7 @@ class DefaultQubit(QubitDevice):
         "BasisState",
         "QubitStateVector",
         "QubitUnitary",
+        "ControlledQubitUnitary",
         "DiagonalQubitUnitary",
         "PauliX",
         "PauliY",

--- a/pennylane/devices/tests/test_gates.py
+++ b/pennylane/devices/tests/test_gates.py
@@ -56,6 +56,7 @@ ops = {
     "ControlledPhaseShift": qml.ControlledPhaseShift(0, wires=[0, 1]),
     "QubitStateVector": qml.QubitStateVector(np.array([1.0, 0.0]), wires=[0]),
     "QubitUnitary": qml.QubitUnitary(np.eye(2), wires=[0]),
+    "ControlledQubitUnitary": qml.ControlledQubitUnitary(np.eye(2), control_wires=[1], wires=[0]),
     "RX": qml.RX(0, wires=[0]),
     "RY": qml.RY(0, wires=[0]),
     "RZ": qml.RZ(0, wires=[0]),

--- a/pennylane/ops/qubit.py
+++ b/pennylane/ops/qubit.py
@@ -1644,8 +1644,9 @@ class ControlledQubitUnitary(QubitUnitary):
             )
 
         U = params[0]
-        if len(U) != 2 ** len(wires):
-            raise ValueError(f"Input unitary must be of dimension {2 ** len(wires)}")
+        target_dim = 2 ** len(wires)
+        if len(U) != target_dim:
+            raise ValueError(f"Input unitary must be of shape {(target_dim, target_dim)}")
 
         wires = control_wires + wires
 

--- a/pennylane/ops/qubit.py
+++ b/pennylane/ops/qubit.py
@@ -1968,6 +1968,7 @@ ops = {
     "BasisState",
     "QubitStateVector",
     "QubitUnitary",
+    "ControlledQubitUnitary",
     "DiagonalQubitUnitary",
     "QFT",
 }

--- a/pennylane/ops/qubit.py
+++ b/pennylane/ops/qubit.py
@@ -1643,9 +1643,12 @@ class ControlledQubitUnitary(QubitUnitary):
                 "The control wires must be different from the wires specified to apply the unitary on"
             )
 
+        U = params[0]
+        if len(U) != 2 ** len(wires):
+            raise ValueError(f"Input unitary must be of dimension {2 ** len(wires)}")
+
         wires = control_wires + wires
 
-        U = params[0]
         padding = 2 ** len(wires) - len(U)
         CU = block_diag(np.eye(padding), U)
 

--- a/pennylane/ops/qubit.py
+++ b/pennylane/ops/qubit.py
@@ -1615,8 +1615,8 @@ class ControlledQubitUnitary(QubitUnitary):
 
     Args:
         U (array[complex]): square unitary matrix
-        control_wires (Sequence[int] or int): the control wire(s)
-        wires (Sequence[int] or int): the wire(s) the unitary acts on
+        control_wires (Union[Wires, Sequence[int], or int]): the control wire(s)
+        wires (Union[Wires, Sequence[int], or int]): the wire(s) the unitary acts on
 
     **Example**
 
@@ -1631,7 +1631,7 @@ class ControlledQubitUnitary(QubitUnitary):
     par_domain = "A"
     grad_method = None
 
-    def __init__(self, *params, wires=None, do_queue=True, control_wires=None):
+    def __init__(self, *params, control_wires=None, wires=None, do_queue=True):
         if control_wires is None:
             raise ValueError("Must specify control wires")
 
@@ -1640,7 +1640,7 @@ class ControlledQubitUnitary(QubitUnitary):
 
         if Wires.shared_wires([wires, control_wires]):
             raise ValueError(
-                "The control wires must be different from the wires specified to apply the unitary on"
+                "The control wires must be different from the wires specified to apply the unitary on."
             )
 
         U = params[0]

--- a/pennylane/ops/qubit.py
+++ b/pennylane/ops/qubit.py
@@ -1623,8 +1623,8 @@ class ControlledQubitUnitary(QubitUnitary):
     The following shows how a single-qubit unitary can be applied to wire ``2`` with control on
     both wires ``0`` and ``1``:
 
-    >>> X = np.array([[ 0.94877869,  0.31594146], [-0.31594146,  0.94877869]])
-    >>> qml.ControlledQubitUnitary(X, control_wires=[0, 1], wires=2)
+    >>> U = np.array([[ 0.94877869,  0.31594146], [-0.31594146,  0.94877869]])
+    >>> qml.ControlledQubitUnitary(U, control_wires=[0, 1], wires=2)
     """
     num_params = 1
     num_wires = AnyWires

--- a/pennylane/ops/qubit.py
+++ b/pennylane/ops/qubit.py
@@ -1650,6 +1650,9 @@ class ControlledQubitUnitary(QubitUnitary):
 
         wires = control_wires + wires
 
+        # Given that the controlled wires are listed before the target wires, we need to create a
+        # block-diagonal matrix of shape ((I, 0), (0, U)) where U acts on the target wires and I
+        # acts on the control wires.
         padding = 2 ** len(wires) - len(U)
         CU = block_diag(np.eye(padding), U)
 

--- a/pennylane/ops/qubit.py
+++ b/pennylane/ops/qubit.py
@@ -1620,13 +1620,11 @@ class ControlledQubitUnitary(QubitUnitary):
 
     **Example**
 
-    The :class:`~.Toffoli` gate is a controlled-controlled-X gate and can be equivalently applied
-    using
+    The following shows how a single-qubit unitary can be applied to wire ``2`` with control on
+    both wires ``0`` and ``1``:
 
-    >>> X = np.array([[0, 1], [1, 0]])
+    >>> X = np.array([[ 0.94877869,  0.31594146], [-0.31594146,  0.94877869]])
     >>> qml.ControlledQubitUnitary(X, control_wires=[0, 1], wires=2)
-
-    Note: it is better to directly use :class:`~.Toffoli`, the above is for illustration purposes.
     """
     num_params = 1
     num_wires = AnyWires
@@ -1636,6 +1634,7 @@ class ControlledQubitUnitary(QubitUnitary):
     def __init__(self, *params, wires=None, do_queue=True, control_wires=None):
         wires = Wires(wires)
 
+        # The control_wires can be specified as either an argument or keyword argument
         if control_wires is not None:
             control_wires = Wires(control_wires)
         elif len(params) == 2:

--- a/pennylane/ops/qubit.py
+++ b/pennylane/ops/qubit.py
@@ -1640,7 +1640,7 @@ class ControlledQubitUnitary(QubitUnitary):
 
         if Wires.shared_wires([wires, control_wires]):
             raise ValueError(
-                "The control wires must be different from the wires specified to apply the unitary"
+                "The control wires must be different from the wires specified to apply the unitary on"
             )
 
         wires = control_wires + wires

--- a/tests/ops/test_qubit_ops.py
+++ b/tests/ops/test_qubit_ops.py
@@ -768,116 +768,6 @@ class TestOperations:
         with pytest.raises(ValueError, match="must be unitary"):
             qml.QubitUnitary(U3, wires=0).matrix
 
-    X = np.array([[0, 1], [1, 0]])
-
-    def test_controlled_qubit_unitary(self):
-        """Test if ControlledQubitUnitary returns the correct matrix for a control-control-X
-        (Toffoli) gate"""
-        mat = qml.ControlledQubitUnitary(X, control_wires=[0, 1], wires=2).matrix
-        mat2 = qml.Toffoli(wires=[0, 1, 2]).matrix
-        assert np.allclose(mat, mat2)
-
-    def test_controlled_qubit_unitary_no_control(self):
-        """Test if ControlledQubitUnitary raises an error if control wires are not specified"""
-        with pytest.raises(ValueError, match="Must specify control wires"):
-            qml.ControlledQubitUnitary(X, wires=2)
-
-    def test_controlled_qubit_unitary_shared_control(self):
-        """Test if ControlledQubitUnitary raises an error if control wires are shared with wires"""
-        with pytest.raises(ValueError, match="The control wires must be different from the wires"):
-            qml.ControlledQubitUnitary(X, control_wires=[0, 2], wires=2)
-
-    def test_controlled_qubit_unitary_wrong_shape(self):
-        """Test if ControlledQubitUnitary raises a ValueError if a unitary of shape inconsistent
-        with wires is provided"""
-        with pytest.raises(ValueError, match=r"Input unitary must be of shape \(2, 2\)"):
-            qml.ControlledQubitUnitary(np.eye(4), control_wires=[0, 1], wires=2)
-
-    @pytest.mark.parametrize("target_wire", range(3))
-    def test_controlled_qubit_unitary_toffoli(self, target_wire):
-        """Test if ControlledQubitUnitary acts like a Toffoli gate when the input unitary is a
-        single-qubit X. This test allows the target wire to be any of the three wires."""
-        control_wires = list(range(3))
-        del control_wires[target_wire]
-
-        # pick some random unitaries (with a fixed seed) to make the circuit less trivial
-        U1 = unitary_group.rvs(8, random_state=1)
-        U2 = unitary_group.rvs(8, random_state=2)
-
-        dev = qml.device("default.qubit", wires=3)
-
-        @qml.qnode(dev)
-        def f1():
-            qml.QubitUnitary(U1, wires=range(3))
-            qml.ControlledQubitUnitary(X, control_wires=control_wires, wires=target_wire)
-            qml.QubitUnitary(U2, wires=range(3))
-            return qml.state()
-
-        @qml.qnode(dev)
-        def f2():
-            qml.QubitUnitary(U1, wires=range(3))
-            qml.Toffoli(wires=control_wires + [target_wire])
-            qml.QubitUnitary(U2, wires=range(3))
-            return qml.state()
-
-        state_1 = f1()
-        state_2 = f2()
-
-        assert np.allclose(state_1, state_2)
-
-    def test_controlled_qubit_unitary_arbitrary(self):
-        """Test if ControlledQubitUnitary applies correctly for a 2-qubit unitary with 2-qubit
-        control, where the control and target wires are not ordered."""
-        control_wires = [1, 3]
-        target_wires = [2, 0]
-
-        # pick some random unitaries (with a fixed seed) to make the circuit less trivial
-        U1 = unitary_group.rvs(16, random_state=1)
-        U2 = unitary_group.rvs(16, random_state=2)
-
-        # the two-qubit unitary
-        U = unitary_group.rvs(4, random_state=3)
-
-        # the 4-qubit representation of the unitary if the control wires were [0, 1] and the target
-        # wires were [2, 3]
-        U_matrix = np.eye(16, dtype=np.complex128)
-        U_matrix[12:16, 12:16] = U
-
-        # We now need to swap wires so that the control wires are [1, 3] and the target wires are
-        # [2, 0]
-        swap = qml.SWAP.matrix
-
-        # initial wire permutation: 0123
-        # target wire permutation: 1302
-        swap1 = np.kron(swap, np.eye(4))  # -> 1023
-        swap2 = np.kron(np.eye(4), swap)  # -> 1032
-        swap3 = np.kron(np.kron(np.eye(2), swap), np.eye(2))  # -> 1302
-        swap4 = np.kron(np.eye(4), swap)  # -> 1320
-
-        all_swap = swap4 @ swap3 @ swap2 @ swap1
-        U_matrix = all_swap.T @ U_matrix @ all_swap
-
-        dev = qml.device("default.qubit", wires=4)
-
-        @qml.qnode(dev)
-        def f1():
-            qml.QubitUnitary(U1, wires=range(4))
-            qml.ControlledQubitUnitary(U, control_wires=control_wires, wires=target_wires)
-            qml.QubitUnitary(U2, wires=range(4))
-            return qml.state()
-
-        @qml.qnode(dev)
-        def f2():
-            qml.QubitUnitary(U1, wires=range(4))
-            qml.QubitUnitary(U_matrix, wires=range(4))
-            qml.QubitUnitary(U2, wires=range(4))
-            return qml.state()
-
-        state_1 = f1()
-        state_2 = f2()
-
-        assert np.allclose(state_1, state_2)
-
     @pytest.mark.parametrize("phi", [-0.1, 0.2, 0.5])
     def test_controlled_phase_shift_matrix_and_eigvals(self, phi):
         """Tests that the ControlledPhaseShift operation calculates the correct matrix and
@@ -1406,3 +1296,117 @@ def test_identity_eigvals(tol):
     res = qml.Identity._eigvals()
     expected = np.array([1, 1])
     assert np.allclose(res, expected, atol=tol, rtol=0)
+
+
+class TestControlledQubitUnitary:
+    """Tests for the ControlledQubitUnitary operation"""
+
+    X = np.array([[0, 1], [1, 0]])
+
+    def test_matrix(self):
+        """Test if ControlledQubitUnitary returns the correct matrix for a control-control-X
+        (Toffoli) gate"""
+        mat = qml.ControlledQubitUnitary(X, control_wires=[0, 1], wires=2).matrix
+        mat2 = qml.Toffoli(wires=[0, 1, 2]).matrix
+        assert np.allclose(mat, mat2)
+
+    def test_no_control(self):
+        """Test if ControlledQubitUnitary raises an error if control wires are not specified"""
+        with pytest.raises(ValueError, match="Must specify control wires"):
+            qml.ControlledQubitUnitary(X, wires=2)
+
+    def test_shared_control(self):
+        """Test if ControlledQubitUnitary raises an error if control wires are shared with wires"""
+        with pytest.raises(ValueError, match="The control wires must be different from the wires"):
+            qml.ControlledQubitUnitary(X, control_wires=[0, 2], wires=2)
+
+    def test_wrong_shape(self):
+        """Test if ControlledQubitUnitary raises a ValueError if a unitary of shape inconsistent
+        with wires is provided"""
+        with pytest.raises(ValueError, match=r"Input unitary must be of shape \(2, 2\)"):
+            qml.ControlledQubitUnitary(np.eye(4), control_wires=[0, 1], wires=2)
+
+    @pytest.mark.parametrize("target_wire", range(3))
+    def test_toffoli(self, target_wire):
+        """Test if ControlledQubitUnitary acts like a Toffoli gate when the input unitary is a
+        single-qubit X. This test allows the target wire to be any of the three wires."""
+        control_wires = list(range(3))
+        del control_wires[target_wire]
+
+        # pick some random unitaries (with a fixed seed) to make the circuit less trivial
+        U1 = unitary_group.rvs(8, random_state=1)
+        U2 = unitary_group.rvs(8, random_state=2)
+
+        dev = qml.device("default.qubit", wires=3)
+
+        @qml.qnode(dev)
+        def f1():
+            qml.QubitUnitary(U1, wires=range(3))
+            qml.ControlledQubitUnitary(X, control_wires=control_wires, wires=target_wire)
+            qml.QubitUnitary(U2, wires=range(3))
+            return qml.state()
+
+        @qml.qnode(dev)
+        def f2():
+            qml.QubitUnitary(U1, wires=range(3))
+            qml.Toffoli(wires=control_wires + [target_wire])
+            qml.QubitUnitary(U2, wires=range(3))
+            return qml.state()
+
+        state_1 = f1()
+        state_2 = f2()
+
+        assert np.allclose(state_1, state_2)
+
+    def test_arbitrary_multiqubit(self):
+        """Test if ControlledQubitUnitary applies correctly for a 2-qubit unitary with 2-qubit
+        control, where the control and target wires are not ordered."""
+        control_wires = [1, 3]
+        target_wires = [2, 0]
+
+        # pick some random unitaries (with a fixed seed) to make the circuit less trivial
+        U1 = unitary_group.rvs(16, random_state=1)
+        U2 = unitary_group.rvs(16, random_state=2)
+
+        # the two-qubit unitary
+        U = unitary_group.rvs(4, random_state=3)
+
+        # the 4-qubit representation of the unitary if the control wires were [0, 1] and the target
+        # wires were [2, 3]
+        U_matrix = np.eye(16, dtype=np.complex128)
+        U_matrix[12:16, 12:16] = U
+
+        # We now need to swap wires so that the control wires are [1, 3] and the target wires are
+        # [2, 0]
+        swap = qml.SWAP.matrix
+
+        # initial wire permutation: 0123
+        # target wire permutation: 1302
+        swap1 = np.kron(swap, np.eye(4))  # -> 1023
+        swap2 = np.kron(np.eye(4), swap)  # -> 1032
+        swap3 = np.kron(np.kron(np.eye(2), swap), np.eye(2))  # -> 1302
+        swap4 = np.kron(np.eye(4), swap)  # -> 1320
+
+        all_swap = swap4 @ swap3 @ swap2 @ swap1
+        U_matrix = all_swap.T @ U_matrix @ all_swap
+
+        dev = qml.device("default.qubit", wires=4)
+
+        @qml.qnode(dev)
+        def f1():
+            qml.QubitUnitary(U1, wires=range(4))
+            qml.ControlledQubitUnitary(U, control_wires=control_wires, wires=target_wires)
+            qml.QubitUnitary(U2, wires=range(4))
+            return qml.state()
+
+        @qml.qnode(dev)
+        def f2():
+            qml.QubitUnitary(U1, wires=range(4))
+            qml.QubitUnitary(U_matrix, wires=range(4))
+            qml.QubitUnitary(U2, wires=range(4))
+            return qml.state()
+
+        state_1 = f1()
+        state_2 = f2()
+
+        assert np.allclose(state_1, state_2)

--- a/tests/ops/test_qubit_ops.py
+++ b/tests/ops/test_qubit_ops.py
@@ -841,9 +841,7 @@ class TestOperations:
         # the 4-qubit representation of the unitary if the control wires were [0, 1] and the target
         # wires were [2, 3]
         U_matrix = np.eye(16, dtype=np.complex128)
-        for i in range(4):
-            for j in range(4):
-                U_matrix[i + 12, j + 12] = U[i, j]
+        U_matrix[12:16, 12:16] = U
 
         # We now need to swap wires so that the control wires are [1, 3] and the target wires are
         # [2, 0]

--- a/tests/ops/test_qubit_ops.py
+++ b/tests/ops/test_qubit_ops.py
@@ -767,6 +767,25 @@ class TestOperations:
         with pytest.raises(ValueError, match="must be unitary"):
             qml.QubitUnitary(U3, wires=0).matrix
 
+    X = np.array([[0, 1], [1, 0]])
+
+    def test_controlled_qubit_unitary(self):
+        """Test if ControlledQubitUnitary returns the correct matrix for a control-control-X
+        (Toffoli) gate"""
+        mat = qml.ControlledQubitUnitary(X, control_wires=[0, 1], wires=2).matrix
+        mat2 = qml.Toffoli(wires=[0, 1, 2]).matrix
+        assert np.allclose(mat, mat2)
+
+    def test_controlled_qubit_unitary_no_control(self):
+        """Test if ControlledQubitUnitary raises an error if control wires are not specified"""
+        with pytest.raises(ValueError, match="Must specify control wires"):
+            qml.ControlledQubitUnitary(X, wires=2)
+
+    def test_controlled_qubit_unitary_shared_control(self):
+        """Test if ControlledQubitUnitary raises an error if control wires are shared with wires"""
+        with pytest.raises(ValueError, match="The control wires must be different from the wires"):
+            qml.ControlledQubitUnitary(X, control_wires=[0, 2], wires=2)
+
     @pytest.mark.parametrize("phi", [-0.1, 0.2, 0.5])
     def test_controlled_phase_shift_matrix_and_eigvals(self, phi):
         """Tests that the ControlledPhaseShift operation calculates the correct matrix and

--- a/tests/ops/test_qubit_ops.py
+++ b/tests/ops/test_qubit_ops.py
@@ -790,7 +790,7 @@ class TestOperations:
     def test_controlled_qubit_unitary_wrong_shape(self):
         """Test if ControlledQubitUnitary raises a ValueError if a unitary of shape inconsistent
         with wires is provided"""
-        with pytest.raises(ValueError, match="Input unitary must be of dimension 2"):
+        with pytest.raises(ValueError, match=r"Input unitary must be of shape \(2, 2\)"):
             qml.ControlledQubitUnitary(np.eye(4), control_wires=[0, 1], wires=2)
 
     @pytest.mark.parametrize("target_wire", range(3))

--- a/tests/ops/test_qubit_ops.py
+++ b/tests/ops/test_qubit_ops.py
@@ -787,6 +787,12 @@ class TestOperations:
         with pytest.raises(ValueError, match="The control wires must be different from the wires"):
             qml.ControlledQubitUnitary(X, control_wires=[0, 2], wires=2)
 
+    def test_controlled_qubit_unitary_wrong_shape(self):
+        """Test if ControlledQubitUnitary raises a ValueError if a unitary of shape inconsistent
+        with wires is provided"""
+        with pytest.raises(ValueError, match="Input unitary must be of dimension 2"):
+            qml.ControlledQubitUnitary(np.eye(4), control_wires=[0, 1], wires=2)
+
     @pytest.mark.parametrize("target_wire", range(3))
     def test_controlled_qubit_unitary_toffoli(self, target_wire):
         """Test if ControlledQubitUnitary acts like a Toffoli gate when the input unitary is a

--- a/tests/ops/test_qubit_ops.py
+++ b/tests/ops/test_qubit_ops.py
@@ -790,7 +790,7 @@ class TestOperations:
     @pytest.mark.parametrize("target_wire", range(3))
     def test_controlled_qubit_unitary_toffoli(self, target_wire):
         """Test if ControlledQubitUnitary acts like a Toffoli gate when the input unitary is a
-        single-qubit X"""
+        single-qubit X. This test allows the target wire to be any of the three wires."""
         control_wires = list(range(3))
         del control_wires[target_wire]
 

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -202,6 +202,19 @@ class TestOperation:
             with pytest.raises(ValueError, match="Unknown parameter domain"):
                 test_class(*pars, wires=ww)
 
+    def test_controlled_qubit_unitary_init(self):
+        """Test for the init of ControlledQubitUnitary"""
+        control_wires = [3, 2]
+        target_wires = [1, 0]
+        U = qml.CRX._matrix(0.4)
+
+        op = qml.ControlledQubitUnitary(U, control_wires=control_wires, wires=target_wires)
+        target_data = [np.block([[np.eye(12), np.zeros((12, 4))], [np.zeros((4, 12)), U]])]
+
+        assert op.name == qml.ControlledQubitUnitary.__name__
+        assert np.allclose(target_data, op.data)
+        assert op._wires == Wires(control_wires) + Wires(target_wires)
+
     @pytest.fixture(scope="function")
     def qnode_for_inverse(self, mock_device):
         """Provides a QNode for the subsequent tests of inv"""

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -123,6 +123,9 @@ class TestOperation:
     def test_operation_init(self, test_class, monkeypatch):
         "Operation subclass initialization."
 
+        if test_class == qml.ControlledQubitUnitary:
+            pytest.skip("ControlledQubitUnitary alters the input params and wires in its __init__")
+
         n = test_class.num_params
         w = test_class.num_wires
         ww = list(range(w))


### PR DESCRIPTION
**Context:**

Adds a new gate, `ControlledQubitUnitary`, which allows users to specify the matrix of a unitary, the control wire(s) and the target wire(s).

**Description of the Change:**

This gate has been added as an operation in `pennylane/ops/qubit.py`. It inherits from `QubitUnitary` and just performs some tweaks in the `__init__`.

**Possible Drawbacks:**

The underlying matrix could get quite large if the user specifies a lot of control wires. However this seems anyway expected if we are working in the matrix representation.