### PR TITLE
Added support for output_dim to be a tuple

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -86,6 +86,10 @@
   allowing QNode measurement statistics to work on devices with more than 32 qubits.
   [(#1088)](https://github.com/PennyLaneAI/pennylane/pull/1088)
 
+
+* Due to the addition of `density_matrix()` as a return type from a QNode, tuples are now supported by the `output_dim` parameter in `qnn.KerasLayer`.
+  [(#1070)](https://github.com/PennyLaneAI/pennylane/pull/1070)
+
 <h3>Breaking changes</h3>
 
 * If creating a QNode from a quantum function with an argument named `shots`,
@@ -108,7 +112,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-Thomas Bromley, Kyle Godbey, Josh Izaac, Daniel Polatajko, Chase Roberts, Maria Schuld.
+Thomas Bromley, Kyle Godbey, Josh Izaac, Daniel Polatajko, Chase Roberts, Sankalp Sanand, Maria Schuld.
 
 
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -122,7 +122,6 @@
   allowing QNode measurement statistics to work on devices with more than 32 qubits.
   [(#1088)](https://github.com/PennyLaneAI/pennylane/pull/1088)
 
-
 * Due to the addition of `density_matrix()` as a return type from a QNode, tuples are now supported by the `output_dim` parameter in `qnn.KerasLayer`.
   [(#1070)](https://github.com/PennyLaneAI/pennylane/pull/1070)
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 <h3>Improvements</h3>
 
+- Tuples are now supported by the `output_dim` parameter in `qnn.KerasLayer`. [(#1070)](https://github.com/PennyLaneAI/pennylane/pull/1070)
+
 <h3>Breaking changes</h3>
 
 <h3>Bug fixes</h3>
@@ -18,7 +20,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-Thomas Bromley
+Thomas Bromley, Sankalp Sanand
 
 # Release 0.14.0 (current release)
 

--- a/pennylane/qnn/keras.py
+++ b/pennylane/qnn/keras.py
@@ -186,15 +186,6 @@ class KerasLayer(Layer):
         100/100 [==============================] - 9s 87ms/sample - loss: 0.1474
 
     .. _Layer: https://www.tensorflow.org/api_docs/python/tf/keras/layers/Layer
-
-    **Returning a state**
-
-    If your QNode returns the state of the quantum circuit using :func:`~.state` or
-    :func:`~.density_matrix`, you must immediately follow your quantum Keras Layer with a layer
-    that casts to reals. For example, you could use
-    `tf.keras.layers.Lambda <https://www.tensorflow.org/api_docs/python/tf/keras/layers/Lambda>`__
-    with the function ``lambda x: tf.abs(x)``. This casting is required because TensorFlow's
-    Keras layers require a real input and are differentiated with respect to real parameters.
     """
 
     def __init__(

--- a/pennylane/qnn/keras.py
+++ b/pennylane/qnn/keras.py
@@ -186,6 +186,16 @@ class KerasLayer(Layer):
         100/100 [==============================] - 9s 87ms/sample - loss: 0.1474
 
     .. _Layer: https://www.tensorflow.org/api_docs/python/tf/keras/layers/Layer
+
+        **Returning a state**
+
+        If your QNode returns the state of the quantum circuit using :func:`~.state` or
+        :func:`~.density_matrix`, you must immediately follow your quantum Keras Layer with a layer
+        that casts to reals. For example, you could use
+        `tf.keras.layers.Lambda <https://www.tensorflow.org/api_docs/python/tf/keras/layers/Lambda>`__
+        with the function ``lambda x: tf.abs(x)``. This casting is required because TensorFlow's
+        Keras layers require a real input and are differentiated with respect to real parameters.
+
     """
 
     def __init__(
@@ -217,7 +227,8 @@ class KerasLayer(Layer):
             self.qnode = to_tf(qnode, dtype=tf.keras.backend.floatx())
 
         # Allows output_dim to be specified as an int or as a tuple, e.g, 5, (5,), (5, 2), [5, 2]
-        # Note: Single digit values will be considered an int and multiple as a tuple
+        # Note: Single digit values will be considered an int and multiple as a tuple, e.g [5,] or (5,)
+        # are passed as integer 5 and [5, 2] will be passes as tuple (5, 2)
         if isinstance(output_dim, Iterable) and len(output_dim) > 1:
             self.output_dim = tuple(output_dim)
         else:

--- a/pennylane/qnn/keras.py
+++ b/pennylane/qnn/keras.py
@@ -185,8 +185,6 @@ class KerasLayer(Layer):
         Epoch 8/8
         100/100 [==============================] - 9s 87ms/sample - loss: 0.1474
 
-    .. _Layer: https://www.tensorflow.org/api_docs/python/tf/keras/layers/Layer
-
         **Returning a state**
 
         If your QNode returns the state of the quantum circuit using :func:`~.state` or
@@ -196,6 +194,7 @@ class KerasLayer(Layer):
         with the function ``lambda x: tf.abs(x)``. This casting is required because TensorFlow's
         Keras layers require a real input and are differentiated with respect to real parameters.
 
+    .. _Layer: https://www.tensorflow.org/api_docs/python/tf/keras/layers/Layer
     """
 
     def __init__(

--- a/pennylane/qnn/keras.py
+++ b/pennylane/qnn/keras.py
@@ -186,6 +186,15 @@ class KerasLayer(Layer):
         100/100 [==============================] - 9s 87ms/sample - loss: 0.1474
 
     .. _Layer: https://www.tensorflow.org/api_docs/python/tf/keras/layers/Layer
+
+    **Returning a state**
+
+    If your QNode returns the state of the quantum circuit using :func:`~.state` or
+    :func:`~.density_matrix`, you must immediately follow your quantum Keras Layer with a layer
+    that casts to reals. For example, you could use
+    `tf.keras.layers.Lambda <https://www.tensorflow.org/api_docs/python/tf/keras/layers/Lambda>`__
+    with the function ``lambda x: tf.abs(x)``. This casting is required because TensorFlow's
+    Keras layers require a real input and are differentiated with respect to real parameters.
     """
 
     def __init__(

--- a/pennylane/qnn/keras.py
+++ b/pennylane/qnn/keras.py
@@ -216,8 +216,9 @@ class KerasLayer(Layer):
             self._signature_validation(qnode, weight_shapes)
             self.qnode = to_tf(qnode, dtype=tf.keras.backend.floatx())
 
-        # Allows output_dim to be specified as an int, e.g., 5, or as a length-1 tuple, e.g., (5,)
-        self.output_dim = output_dim[0] if isinstance(output_dim, Iterable) else output_dim
+        # Allows output_dim to be specified as an int, e.g., 5, or as a tuple, e.g., (5, 2)
+        # However the final output_dim type will always be a tuple, e.g., 5 will become (5,)
+        self.output_dim = tuple(output_dim) if isinstance(output_dim, Iterable) else (output_dim,)
 
         self.weight_specs = weight_specs if weight_specs is not None else {}
 

--- a/pennylane/qnn/keras.py
+++ b/pennylane/qnn/keras.py
@@ -218,7 +218,7 @@ class KerasLayer(Layer):
 
         # Allows output_dim to be specified as an int, e.g., 5, or as a tuple, e.g., (5, 2)
         # However the final output_dim type will always be a tuple, e.g., 5 will become (5,)
-        self.output_dim = tuple(output_dim) if isinstance(output_dim, Iterable) else (output_dim,)
+        self.output_dim = tuple(output_dim) if isinstance(output_dim, Iterable) else (output_dim, 1)
 
         self.weight_specs = weight_specs if weight_specs is not None else {}
 
@@ -355,7 +355,7 @@ class KerasLayer(Layer):
         Returns:
             tf.TensorShape: shape of output data
         """
-        return tf.TensorShape([input_shape[0], self.output_dim])
+        return tf.TensorShape(input_shape[0]).concatenate(self.output_dim)
 
     def __str__(self):
         detail = "<Quantum Keras Layer: func={}>"

--- a/pennylane/qnn/keras.py
+++ b/pennylane/qnn/keras.py
@@ -216,9 +216,12 @@ class KerasLayer(Layer):
             self._signature_validation(qnode, weight_shapes)
             self.qnode = to_tf(qnode, dtype=tf.keras.backend.floatx())
 
-        # Allows output_dim to be specified as an int, e.g., 5, or as a tuple, e.g., (5, 2)
-        # However the final output_dim type will always be a tuple, e.g., 5 will become (5,)
-        self.output_dim = tuple(output_dim) if isinstance(output_dim, Iterable) else (output_dim, 1)
+        # Allows output_dim to be specified as an int or as a tuple, e.g, 5, (5,), (5, 2), [5, 2]
+        # Note: Single digit values will be considered an int and multiple as a tuple
+        if (isinstance(output_dim, Iterable) and len(output_dim) > 1):
+            self.output_dim = tuple(output_dim)
+        else:
+            self.output_dim = output_dim[0] if isinstance(output_dim, Iterable) else output_dim
 
         self.weight_specs = weight_specs if weight_specs is not None else {}
 

--- a/pennylane/templates/embeddings/amplitude.py
+++ b/pennylane/templates/embeddings/amplitude.py
@@ -83,7 +83,7 @@ def _preprocess(features, wires, pad_with, normalize):
                 features = features / np.sqrt(norm)
             else:
                 raise ValueError(
-                    f"Features must be a vector of length 1.0; got length {norm}."
+                    f"Features must be a vector of length 1.0; got length {norm}. "
                     "Use 'normalize=True' to automatically normalize."
                 )
 

--- a/tests/qnn/conftest.py
+++ b/tests/qnn/conftest.py
@@ -83,7 +83,7 @@ def get_circuit_dm(n_qubits, output_dim, interface, tape_mode):
         qml.RX(w7, wires=4 % n_qubits)
 
         # Using np.log2() here because output_dim is sampled from varying the number of
-        # qubits(say, nq) and calculated as (2 ** nq, 2 ** nq)
+        # qubits (say, nq) and calculated as (2 ** nq, 2 ** nq)
         return qml.density_matrix(wires=[i for i in range(int(np.log2(output_dim[0])))])
 
     return circuit, weight_shapes

--- a/tests/qnn/conftest.py
+++ b/tests/qnn/conftest.py
@@ -34,19 +34,35 @@ def get_circuit(n_qubits, output_dim, interface, tape_mode):
         "w7": 0,
     }
 
-    @qml.qnode(dev, interface=interface)
-    def circuit(inputs, w1, w2, w3, w4, w5, w6, w7):
-        """A circuit that embeds data using the AngleEmbedding and then performs a variety of
-        operations. The output is a PauliZ measurement on the first output_dim qubits. One set of
-        parameters, w5, are specified as non-trainable."""
-        qml.templates.AngleEmbedding(inputs, wires=list(range(n_qubits)))
-        qml.templates.StronglyEntanglingLayers(w1, wires=list(range(n_qubits)))
-        qml.RX(w2[0], wires=0 % n_qubits)
-        qml.RX(w3, wires=1 % n_qubits)
-        qml.Rot(*w4, wires=2 % n_qubits)
-        qml.templates.StronglyEntanglingLayers(w5, wires=list(range(n_qubits)))
-        qml.Rot(*w6, wires=3 % n_qubits)
-        qml.RX(w7, wires=4 % n_qubits)
-        return [qml.expval(qml.PauliZ(i)) for i in range(output_dim)]
+    if isinstance(output_dim, tuple):
+        @qml.qnode(dev, interface=interface)
+        def circuit(inputs, w1, w2, w3, w4, w5, w6, w7):
+            """Sample circuit to be used for testing density_matrix() return type.
+            """
+            qml.templates.AngleEmbedding(inputs, wires=list(range(n_qubits)))
+            qml.templates.StronglyEntanglingLayers(w1, wires=list(range(n_qubits)))
+            qml.RX(w2[0], wires=0)
+            qml.RX(w3, wires=0)
+            qml.Rot(*w4, wires=0)
+            qml.templates.StronglyEntanglingLayers(w5, wires=list(range(n_qubits)))
+            qml.Rot(*w6, wires=0)
+            qml.RX(w7, wires=0)
+            return qml.density_matrix(wires=[1])
+
+    else:
+        @qml.qnode(dev, interface=interface)
+        def circuit(inputs, w1, w2, w3, w4, w5, w6, w7):
+            """A circuit that embeds data using the AngleEmbedding and then performs a variety of
+            operations. The output is a PauliZ measurement on the first output_dim qubits. One set of
+            parameters, w5, are specified as non-trainable."""
+            qml.templates.AngleEmbedding(inputs, wires=list(range(n_qubits)))
+            qml.templates.StronglyEntanglingLayers(w1, wires=list(range(n_qubits)))
+            qml.RX(w2[0], wires=0 % n_qubits)
+            qml.RX(w3, wires=1 % n_qubits)
+            qml.Rot(*w4, wires=2 % n_qubits)
+            qml.templates.StronglyEntanglingLayers(w5, wires=list(range(n_qubits)))
+            qml.Rot(*w6, wires=3 % n_qubits)
+            qml.RX(w7, wires=4 % n_qubits)
+            return [qml.expval(qml.PauliZ(i)) for i in range(output_dim)]
 
     return circuit, weight_shapes

--- a/tests/qnn/conftest.py
+++ b/tests/qnn/conftest.py
@@ -16,6 +16,7 @@ Common fixtures for the qnn module.
 """
 import pytest
 import pennylane as qml
+import numpy as np
 
 
 @pytest.fixture
@@ -41,13 +42,16 @@ def get_circuit(n_qubits, output_dim, interface, tape_mode):
             """
             qml.templates.AngleEmbedding(inputs, wires=list(range(n_qubits)))
             qml.templates.StronglyEntanglingLayers(w1, wires=list(range(n_qubits)))
-            qml.RX(w2[0], wires=0)
-            qml.RX(w3, wires=0)
-            qml.Rot(*w4, wires=0)
+            qml.RX(w2[0], wires=0 % n_qubits)
+            qml.RX(w3, wires=1 % n_qubits)
+            qml.Rot(*w4, wires=2 % n_qubits)
             qml.templates.StronglyEntanglingLayers(w5, wires=list(range(n_qubits)))
-            qml.Rot(*w6, wires=0)
-            qml.RX(w7, wires=0)
-            return qml.density_matrix(wires=[1])
+            qml.Rot(*w6, wires=3 % n_qubits)
+            qml.RX(w7, wires=4 % n_qubits)
+
+            # Using np.log2() here because output_dim is sampled from varying the number of
+            # qubits(say, nq) and calculated as (2 ** nq, 2 ** nq)
+            return qml.density_matrix(wires=[i for i in range(int(np.log2(output_dim[0])))])
 
     else:
         @qml.qnode(dev, interface=interface)

--- a/tests/qnn/test_keras.py
+++ b/tests/qnn/test_keras.py
@@ -63,14 +63,12 @@ def indices_up_to(n_max, has_tuple=False):
     """Returns an iterator over the number of qubits and output dimension, up to value n_max.
     The output dimension never exceeds the number of qubits."""
     if has_tuple:
-        # If the output_dim is to be used as a tuple, returns values like (2, (2, 2)), (3, (2, 2))
-        # first element is for n_qubits and the second is for output_dim. Since we are using the sample
-        # circuit in `conftest.py` which returns a (2, 2) matrix we keep the output_dim constant here
-        # and min value for n_qubits as 2, although it can be extended if the circuit gets changed
+        # If the output_dim is to be used as a tuple. First element is for n_qubits and
+        # the second is for output_dim. For example, for n_max = 3 it will return,
+        # [(1, (2, 2)), (2, (2, 2)), (3, (2, 2)), (3, (3, 3))]
 
-        a = np.arange(2, n_max + 1)
-        b = np.full((2, n_max - 1), 2)  # n_max + 1 - 2
-        return zip(*[a], zip(*b))
+        a, b = np.tril_indices(n_max)
+        return zip(*[a + 1], zip(*[2 ** (b + 1), 2 ** (b + 1)]))
     else:
         a, b = np.tril_indices(n_max)
         return zip(*[a + 1, b + 1])

--- a/tests/qnn/test_keras.py
+++ b/tests/qnn/test_keras.py
@@ -25,7 +25,6 @@ tf = pytest.importorskip("tensorflow", minversion="2")
 pytestmark = pytest.mark.usefixtures("tape_mode")
 
 
-@pytest.mark.usefixtures("get_circuit")
 @pytest.fixture
 def model(get_circuit, n_qubits, output_dim):
     """Fixture for creating a hybrid Keras model. The model is composed of KerasLayers sandwiched
@@ -57,10 +56,12 @@ def model_dm(get_circuit_dm, n_qubits, output_dim):
         [
             tf.keras.layers.Dense(n_qubits),
             layer1,
+            # Adding a lambda layer to take only the real values from density matrix
+            tf.keras.layers.Lambda(lambda x: tf.abs(x)),
             tf.keras.layers.Flatten(),
             tf.keras.layers.Dense(n_qubits),
             layer2,
-            # Optionally, adding a lambda layer to take only the real values from dm of layer2
+            # Adding a lambda layer to take only the real values from density matrix
             tf.keras.layers.Lambda(lambda x: tf.abs(x)),
             tf.keras.layers.Flatten(),
             tf.keras.layers.Dense(output_dim[0] * output_dim[1])

--- a/tests/qnn/test_keras.py
+++ b/tests/qnn/test_keras.py
@@ -615,6 +615,9 @@ class TestKerasLayerIntegrationDM:
         The model is composed of two KerasLayers sandwiched between Dense neural network layers,
         and the dataset is simply input and output vectors of zeros."""
 
+        if not qml.tape_mode_active():
+            pytest.skip()
+
         x = np.zeros((batch_size, n_qubits))
         y = np.zeros((batch_size, output_dim[0] * output_dim[1]))
 
@@ -626,6 +629,9 @@ class TestKerasLayerIntegrationDM:
     def test_model_gradients_dm(self, model_dm, output_dim, n_qubits):
         """Test if a gradient can be calculated with respect to all of the trainable variables in
         the model."""
+
+        if not qml.tape_mode_active():
+            pytest.skip()
 
         x = tf.zeros((2, n_qubits))
         y = tf.zeros((2, output_dim[0] * output_dim[1]))
@@ -641,6 +647,10 @@ class TestKerasLayerIntegrationDM:
     def test_model_save_weights_dm(self, model_dm, n_qubits, tmpdir):
         """Test if the model_dm can be successfully saved and reloaded using the get_weights()
         method"""
+
+        if not qml.tape_mode_active():
+            pytest.skip()
+
         prediction = model_dm.predict(np.ones(n_qubits))
         weights = model_dm.get_weights()
         file = str(tmpdir) + "/model"

--- a/tests/qnn/test_keras.py
+++ b/tests/qnn/test_keras.py
@@ -34,44 +34,59 @@ def model(get_circuit, n_qubits, output_dim):
     layer1 = KerasLayer(c, w, output_dim)
     layer2 = KerasLayer(c, w, output_dim)
 
-    if isinstance(output_dim, tuple):
-
-        model = tf.keras.models.Sequential()
-        model.add(tf.keras.layers.Dense(n_qubits))
-        model.add(layer1)
-        model.add(tf.keras.layers.Flatten())
-        model.add(tf.keras.layers.Dense(n_qubits))
-        model.add(layer2)
-        model.add(tf.keras.layers.Flatten())
-        model.add(tf.keras.layers.Dense(output_dim[0] * output_dim[1]))
-
-    else:
-        model = tf.keras.models.Sequential(
-            [
-                tf.keras.layers.Dense(n_qubits),
-                layer1,
-                tf.keras.layers.Dense(n_qubits),
-                layer2,
-                tf.keras.layers.Dense(output_dim),
-            ]
-        )
+    model = tf.keras.models.Sequential(
+        [
+            tf.keras.layers.Dense(n_qubits),
+            layer1,
+            tf.keras.layers.Dense(n_qubits),
+            layer2,
+            tf.keras.layers.Dense(output_dim),
+        ]
+    )
 
     return model
 
 
-def indices_up_to(n_max, has_tuple=False):
+@pytest.fixture
+def model_dm(get_circuit_dm, n_qubits, output_dim):
+    c, w = get_circuit_dm
+    layer1 = KerasLayer(c, w, output_dim)
+    layer2 = KerasLayer(c, w, output_dim)
+
+    model = tf.keras.models.Sequential(
+        [
+            tf.keras.layers.Dense(n_qubits),
+            layer1,
+            tf.keras.layers.Flatten(),
+            tf.keras.layers.Dense(n_qubits),
+            layer2,
+            tf.keras.layers.Flatten(),
+            tf.keras.layers.Dense(output_dim[0] * output_dim[1])
+        ]
+    )
+
+    return model
+
+
+def indices_up_to(n_max):
     """Returns an iterator over the number of qubits and output dimension, up to value n_max.
     The output dimension never exceeds the number of qubits."""
-    if has_tuple:
-        # If the output_dim is to be used as a tuple. First element is for n_qubits and
-        # the second is for output_dim. For example, for n_max = 3 it will return,
-        # [(1, (2, 2)), (2, (2, 2)), (3, (2, 2)), (3, (3, 3))]
 
-        a, b = np.tril_indices(n_max)
-        return zip(*[a + 1], zip(*[2 ** (b + 1), 2 ** (b + 1)]))
-    else:
-        a, b = np.tril_indices(n_max)
-        return zip(*[a + 1, b + 1])
+    a, b = np.tril_indices(n_max)
+    return zip(*[a + 1, b + 1])
+
+
+def indices_up_to_dm(n_max):
+    """Returns an iterator over the number of qubits and output dimension, up to value n_max.
+    The output dimension values never exceeds 2 ** (n_max). This is to test for density_matrix
+    qnodes."""
+
+    # If the output_dim is to be used as a tuple. First element is for n_qubits and
+    # the second is for output_dim. For example, for n_max = 3 it will return,
+    # [(1, (2, 2)), (2, (2, 2)), (2, (4, 4)), (3, (2, 2)), (3, (4, 4)), (3, (8, 8))]
+
+    a, b = np.tril_indices(n_max)
+    return zip(*[a + 1], zip(*[2 ** (b + 1), 2 ** (b + 1)]))
 
 
 @pytest.mark.parametrize("interface", ["tf"])  # required for the get_circuit fixture
@@ -554,47 +569,12 @@ class TestKerasLayerIntegration:
 
         model.fit(x, y, batch_size=batch_size, verbose=0)
 
-    @pytest.mark.parametrize("n_qubits, output_dim", indices_up_to(3, has_tuple=True))
-    @pytest.mark.parametrize("batch_size", [2])
-    def test_train_model_for_density_matrix(self, model, batch_size, n_qubits, output_dim):
-        """Test if a model can train using the KerasLayer when QNode returns a density_matrix().
-        The model is composed of two KerasLayers sandwiched between Dense neural network layers,
-        and the dataset is simply input and output vectors of zeros."""
-
-        if not qml.tape_mode_active():
-            pytest.skip("This functionality is only supported in tape mode.")
-
-        x = np.zeros((batch_size, n_qubits))
-        y = np.zeros((batch_size, output_dim[0] * output_dim[1]))
-
-        model.compile(optimizer="sgd", loss="mse")
-
-        model.fit(x, y, batch_size=batch_size, verbose=0)
-
     @pytest.mark.parametrize("n_qubits, output_dim", indices_up_to(2))
     def test_model_gradients(self, model, output_dim, n_qubits):
         """Test if a gradient can be calculated with respect to all of the trainable variables in
         the model"""
         x = tf.zeros((2, n_qubits))
         y = tf.zeros((2, output_dim))
-
-        with tf.GradientTape() as tape:
-            out = model(x)
-            loss = tf.keras.losses.mean_squared_error(out, y)
-
-        gradients = tape.gradient(loss, model.trainable_variables)
-        assert all([g.dtype == tf.keras.backend.floatx() for g in gradients])
-
-    @pytest.mark.parametrize("n_qubits, output_dim", indices_up_to(2, has_tuple=True))
-    def test_model_gradients_for_density_matrix(self, model, output_dim, n_qubits):
-        """Test if a gradient can be calculated with respect to all of the trainable variables in
-        the model if it is using a density_matrix() returning circuit"""
-
-        if not qml.tape_mode_active():
-            pytest.skip("This functionality is only supported in tape mode.")
-
-        x = tf.zeros((2, n_qubits))
-        y = tf.zeros((2, output_dim[0] * output_dim[1]))
 
         with tf.GradientTape() as tape:
             out = model(x)
@@ -614,6 +594,58 @@ class TestKerasLayerIntegration:
         model.load_weights(file)
         prediction_loaded = model.predict(np.ones(n_qubits))
         weights_loaded = model.get_weights()
+
+        assert np.allclose(prediction, prediction_loaded)
+        for i, w in enumerate(weights):
+            assert np.allclose(w, weights_loaded[i])
+
+
+@pytest.mark.parametrize("interface", ["tf"])
+@pytest.mark.usefixtures("get_circuit_dm", "model_dm")
+class TestKerasLayerIntegrationDM:
+    """Integration tests for the pennylane.qnn.keras.KerasLayer class for
+    density_matrix() returning circuits."""
+
+    @pytest.mark.parametrize("n_qubits, output_dim", indices_up_to_dm(3))
+    @pytest.mark.parametrize("batch_size", [2])
+    def test_train_model_dm(self, model_dm, batch_size, n_qubits, output_dim):
+        """Test if a model can train using the KerasLayer when QNode returns a density_matrix().
+        The model is composed of two KerasLayers sandwiched between Dense neural network layers,
+        and the dataset is simply input and output vectors of zeros."""
+
+        x = np.zeros((batch_size, n_qubits))
+        y = np.zeros((batch_size, output_dim[0] * output_dim[1]))
+
+        model_dm.compile(optimizer="sgd", loss="mse")
+
+        model_dm.fit(x, y, batch_size=batch_size, verbose=0)
+
+    @pytest.mark.parametrize("n_qubits, output_dim", indices_up_to_dm(2))
+    def test_model_gradients_dm(self, model_dm, output_dim, n_qubits):
+        """Test if a gradient can be calculated with respect to all of the trainable variables in
+        the model."""
+
+        x = tf.zeros((2, n_qubits))
+        y = tf.zeros((2, output_dim[0] * output_dim[1]))
+
+        with tf.GradientTape() as tape:
+            out = model_dm(x)
+            loss = tf.keras.losses.mean_squared_error(out, y)
+
+        gradients = tape.gradient(loss, model_dm.trainable_variables)
+        assert all([g.dtype == tf.keras.backend.floatx() for g in gradients])
+
+    @pytest.mark.parametrize("n_qubits, output_dim", indices_up_to_dm(2))
+    def test_model_save_weights_dm(self, model_dm, n_qubits, tmpdir):
+        """Test if the model_dm can be successfully saved and reloaded using the get_weights()
+        method"""
+        prediction = model_dm.predict(np.ones(n_qubits))
+        weights = model_dm.get_weights()
+        file = str(tmpdir) + "/model"
+        model_dm.save_weights(file)
+        model_dm.load_weights(file)
+        prediction_loaded = model_dm.predict(np.ones(n_qubits))
+        weights_loaded = model_dm.get_weights()
 
         assert np.allclose(prediction, prediction_loaded)
         for i, w in enumerate(weights):

--- a/tests/qnn/test_keras.py
+++ b/tests/qnn/test_keras.py
@@ -60,6 +60,8 @@ def model_dm(get_circuit_dm, n_qubits, output_dim):
             tf.keras.layers.Flatten(),
             tf.keras.layers.Dense(n_qubits),
             layer2,
+            # Optionally, adding a lambda layer to take only the real values from dm of layer2
+            tf.keras.layers.Lambda(lambda x: tf.abs(x)),
             tf.keras.layers.Flatten(),
             tf.keras.layers.Dense(output_dim[0] * output_dim[1])
         ]

--- a/tests/qnn/test_keras.py
+++ b/tests/qnn/test_keras.py
@@ -435,26 +435,26 @@ class TestKerasLayer:
         assert layer_out.shape == (batch_size, output_dim)
         assert np.allclose(layer_out[0], c(x[0], *weights))
 
-    # @pytest.mark.parametrize("n_qubits, output_dim", indices_up_to(2))
-    # @pytest.mark.parametrize("batch_size", [2, 4, 6])
-    # @pytest.mark.parametrize("middle_dim", [2, 5, 8])
-    # def test_call_broadcast(self, get_circuit, output_dim, middle_dim, batch_size, n_qubits):
-    #     """Test if the call() method performs correctly when the inputs argument has an arbitrary shape (that can
-    #     correctly be broadcast over), i.e., for input of shape (batch_size, dn, ... , d0) it outputs with shape
-    #     (batch_size, dn, ... , d1, output_dim). Also tests if gradients are still backpropagated correctly."""
-    #     c, w = get_circuit
+    @pytest.mark.parametrize("n_qubits, output_dim", indices_up_to(2))
+    @pytest.mark.parametrize("batch_size", [2, 4, 6])
+    @pytest.mark.parametrize("middle_dim", [2, 5, 8])
+    def test_call_broadcast(self, get_circuit, output_dim, middle_dim, batch_size, n_qubits):
+        """Test if the call() method performs correctly when the inputs argument has an arbitrary shape (that can
+        correctly be broadcast over), i.e., for input of shape (batch_size, dn, ... , d0) it outputs with shape
+        (batch_size, dn, ... , d1, output_dim). Also tests if gradients are still backpropagated correctly."""
+        c, w = get_circuit
 
-    #     layer = KerasLayer(c, w, output_dim)
-    #     x = tf.ones((batch_size, middle_dim, n_qubits))
+        layer = KerasLayer(c, w, output_dim)
+        x = tf.ones((batch_size, middle_dim, n_qubits))
 
-    #     with tf.GradientTape() as tape:
-    #         layer_out = layer(x)
+        with tf.GradientTape() as tape:
+            layer_out = layer(x)
 
-    #     g_layer = tape.gradient(layer_out, layer.trainable_variables)
+        g_layer = tape.gradient(layer_out, layer.trainable_variables)
 
-    #     # test gradients are at least calculated
-    #     assert g_layer is not None
-    #     assert layer_out.shape == (batch_size, middle_dim, output_dim)
+        # test gradients are at least calculated
+        assert g_layer is not None
+        assert layer_out.shape == (batch_size, middle_dim, output_dim)
 
     @pytest.mark.parametrize("n_qubits, output_dim", indices_up_to(1))
     def test_str_repr(self, get_circuit, output_dim):

--- a/tests/qnn/test_keras.py
+++ b/tests/qnn/test_keras.py
@@ -62,12 +62,17 @@ def model(get_circuit, n_qubits, output_dim):
 def indices_up_to(n_max, has_tuple=False):
     """Returns an iterator over the number of qubits and output dimension, up to value n_max.
     The output dimension never exceeds the number of qubits."""
-    a, b = np.tril_indices(n_max)
     if has_tuple:
         # If the output_dim is to be used as a tuple, returns values like (2, (2, 2)), (3, (2, 2))
-        # first element is for n_qubits and the second is for output_dim
-        return zip(*[a + 2], zip(*[b + 2, b + 2]))
+        # first element is for n_qubits and the second is for output_dim. Since we are using the
+        # sample circuit in `conftest.py` which returns a (2, 2) matrix we keep the output_dim
+        # constant here, although it can be extended if the circuit gets changed
+
+        a = np.arange(2, n_max + 1)
+        b = np.full((n_max - 1, 2), 2)
+        return zip(*[a], zip(*b))
     else:
+        a, b = np.tril_indices(n_max)
         return zip(*[a + 1, b + 1])
 
 


### PR DESCRIPTION
**Context:**
Until now, only `int` and flat tuples like `(5,)` were acceptable values by the `output_dim` parameter in `qnn.KerasLayer`. After the addition of the `density_matrix()` return type by a QNode in PR #878 the output from a QNode may not necessarily be flat. This PR adds the support for tuples to be passed as an acceptable value to the `output_dim` parameter.

**Description of the Change:**
Now values like `(5, 5)` as well as integers like `2` or flat tuples like `(5,)` can be passed to the `output_dim` parameter. It is also to be noted that if an `Iterable` is passed (e.g, a list like `[5, 5]`) instead, it will be converted to a tuple. Internally the value of `output_dim` will either be a tuple or an integer.

**Example:**

Here, `c` is a circuit that outputs a `density_matrix()` qnode with the shape `output_dim`(a square tuple), and `w` is the shape of weights to be used in the circuit. We need to flatten the outputs if we are expecting the following layer to receive inputs with only 1 axis (excluding batch size as it remains unchanged when flattening). We also add a lambda layer so that only real values in the density matrix are used for processing (read the discussion below to know more).

```
qml.enable_tape()

custom_layer = KerasLayer(c, w, output_dim)

model = tf.keras.models.Sequential(
        [
            tf.keras.layers.Dense(n_qubits),
            layer1,
            # Adding a lambda layer to take only the real values from density matrix
            tf.keras.layers.Lambda(lambda x: tf.abs(x)),
            tf.keras.layers.Flatten(),
            tf.keras.layers.Dense(n_qubits),
            layer2,
            # Adding a lambda layer to take only the real values from density matrix
            tf.keras.layers.Lambda(lambda x: tf.abs(x)),
            tf.keras.layers.Flatten(),
            tf.keras.layers.Dense(output_dim[0] * output_dim[1])
        ]
    )
```

**Benefits:**
* Tuples are now supported as acceptable values by `output_dim` without breaking the current usage patterns.
* This may also enable the use of other Keras Layers like `Conv2D` with our `KerasLayer` in the future.

**Related GitHub Issues:**
Issue #936 
