### PR TITLE
Make QNode max expansion accessible as a keyword argument

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 * The QNode has a new keyword argument, `max_expansion`, that determines the maximum number of times
   the internal circuit should be expanded when executed on a device.
-  [(#)](https://github.com/PennyLaneAI/pennylane/pull/)
+  [(#1074)](https://github.com/PennyLaneAI/pennylane/pull/1074)
 
 <h3>Breaking changes</h3>
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 <h3>Improvements</h3>
 
+* The QNode has a new keyword argument, `max_expansion`, that determines the maximum number of times
+  the internal circuit should be expanded when executed on a device.
+  [(#)](https://github.com/PennyLaneAI/pennylane/pull/)
+
 <h3>Breaking changes</h3>
 
 <h3>Bug fixes</h3>
@@ -18,7 +22,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-Thomas Bromley
+Thomas Bromley, Josh Izaac
 
 # Release 0.14.0 (current release)
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,8 @@ jobs:
           access_token: ${{ github.token }}
 
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
 
       - name: Set up Python
         uses: actions/setup-python@v2
@@ -94,6 +96,8 @@ jobs:
           access_token: ${{ github.token }}
 
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
 
       - name: Set up Python
         uses: actions/setup-python@v2
@@ -151,6 +155,8 @@ jobs:
           access_token: ${{ github.token }}
 
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
 
       - name: Setup conda
         uses: s-weigand/setup-conda@v1

--- a/pennylane/tape/qnode.py
+++ b/pennylane/tape/qnode.py
@@ -107,6 +107,11 @@ class QNode:
             and is stored and re-used for further quantum evaluations. Only set this to False
             if it is known that the underlying quantum structure is **independent of QNode input**.
 
+        max_expansion (int): The number of times the internal circuit should be expanded when
+            executed on a device. Expansion occurs when an operation or measurement is not
+            supported, and results in a gate decomposition. If any operations in the decomposition
+            remain unsupported by the device, another expansion occurs.
+
     Keyword Args:
         h=1e-7 (float): step size for the finite difference method
         order=1 (int): The order of the finite difference method to use. ``1`` corresponds
@@ -125,7 +130,7 @@ class QNode:
     # pylint:disable=too-many-instance-attributes,too-many-arguments
 
     def __init__(
-        self, func, device, interface="autograd", diff_method="best", mutable=True, **diff_options
+        self, func, device, interface="autograd", diff_method="best", mutable=True, max_expansion=10, **diff_options
     ):
 
         if interface is not None and interface not in self.INTERFACE_MAP:
@@ -156,7 +161,7 @@ class QNode:
         self.diff_options.update(tape_diff_options)
 
         self.dtype = np.float64
-        self.max_expansion = 2
+        self.max_expansion = max_expansion
 
     # pylint: disable=too-many-return-statements
     @staticmethod
@@ -842,6 +847,11 @@ def qnode(device, interface="autograd", diff_method="best", mutable=True, **diff
             and is stored and re-used for further quantum evaluations. Only set this to False
             if it is known that the underlying quantum structure is **independent of QNode input**.
 
+        max_expansion (int): The number of times the internal circuit should be expanded when
+            executed on a device. Expansion occurs when an operation or measurement is not
+            supported, and results in a gate decomposition. If any operations in the decomposition
+            remain unsupported by the device, another expansion occurs.
+
     Keyword Args:
         h=1e-7 (float): Step size for the finite difference method.
         order=1 (int): The order of the finite difference method to use. ``1`` corresponds
@@ -865,6 +875,7 @@ def qnode(device, interface="autograd", diff_method="best", mutable=True, **diff
             interface=interface,
             diff_method=diff_method,
             mutable=mutable,
+            max_expansion=max_expansion,
             **diff_options,
         )
         return update_wrapper(qn, func)

--- a/pennylane/tape/qnode.py
+++ b/pennylane/tape/qnode.py
@@ -130,7 +130,14 @@ class QNode:
     # pylint:disable=too-many-instance-attributes,too-many-arguments
 
     def __init__(
-        self, func, device, interface="autograd", diff_method="best", mutable=True, max_expansion=10, **diff_options
+        self,
+        func,
+        device,
+        interface="autograd",
+        diff_method="best",
+        mutable=True,
+        max_expansion=10,
+        **diff_options,
     ):
 
         if interface is not None and interface not in self.INTERFACE_MAP:

--- a/pennylane/tape/qnode.py
+++ b/pennylane/tape/qnode.py
@@ -777,7 +777,9 @@ class QNode:
     INTERFACE_MAP = {"autograd": to_autograd, "torch": to_torch, "tf": to_tf, "jax": to_jax}
 
 
-def qnode(device, interface="autograd", diff_method="best", mutable=True, **diff_options):
+def qnode(
+    device, interface="autograd", diff_method="best", mutable=True, max_expansion=10, **diff_options
+):
     """Decorator for creating QNodes.
 
     This decorator is used to indicate to PennyLane that the decorated function contains a


### PR DESCRIPTION
**Context:** The maximum number of expansions allowed by a QNode is currently set to 2.

**Description of the Change:**

* The QNode has a new keyword argument, `max_expansion`, that determines the maximum number of times the internal circuit should be expanded when executed on a device. This allows it to be easily user accessible.

* The default number of max expansions has been increased to 10

**Benefits:** Devices that require multiple operation decompositions are now supported

**Possible Drawbacks:** n/a

**Related GitHub Issues:** n/a
