### PR TITLE
Update vqe.py

### DIFF
--- a/pennylane/vqe/vqe.py
+++ b/pennylane/vqe/vqe.py
@@ -42,7 +42,7 @@ class Hamiltonian:
         simplify (bool): Specifies whether the Hamiltonian is simplified upon initialization
                          (like-terms are combined). The default value is `False`.
 
-    .. seealso:: :class:`~.ExpvalCost`, :func:`~.generate_hamiltonian`
+    .. seealso:: :class:`~.ExpvalCost`, :func:`~.molecular_hamiltonian`
 
     **Example:**
 
@@ -66,7 +66,7 @@ class Hamiltonian:
     >>> print(H)
     (0.8) [Hermitian0'1]
 
-    Alternatively, the :func:`~.generate_hamiltonian` function from the
+    Alternatively, the :func:`~.molecular_hamiltonian` function from the
     :doc:`/introduction/chemistry` module can be used to generate a molecular
     Hamiltonian.
     """
@@ -396,7 +396,7 @@ class ExpvalCost:
         callable: a cost function with signature ``cost_fn(params, **kwargs)`` that evaluates
         the expectation of the Hamiltonian on the provided device(s)
 
-    .. seealso:: :class:`~.Hamiltonian`, :func:`~.generate_hamiltonian`, :func:`~.map`, :func:`~.dot`
+    .. seealso:: :class:`~.Hamiltonian`, :func:`~.molecular_hamiltonian`, :func:`~.map`, :func:`~.dot`
 
     **Example:**
 


### PR DESCRIPTION
Updates to mention to `molecular_hamiltonian` in docs after [past changes in qchem](https://github.com/PennyLaneAI/pennylane/blob/master/qchem/CHANGELOG.md):
> generate_hamiltonian has been renamed to molecular_hamiltonian. The modified function contains an extended docstring that outlines the main steps to build the Hamiltonian.