### PR TITLE
Revert recent improvement to qml.grad until closer to the next release

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -48,11 +48,6 @@
 
 <h3>Bug fixes</h3>
 
-* If only one argument to the function `qml.grad` has the `requires_grad` attribute
-  set to True, then the returned gradient will be a NumPy array, rather than a
-  tuple of length 1.
-  [(#)](https://github.com/PennyLaneAI/pennylane/pull/)
-
 <h3>Documentation</h3>
 
 <h3>Contributors</h3>

--- a/pennylane/_grad.py
+++ b/pennylane/_grad.py
@@ -85,9 +85,6 @@ class grad:
             if getattr(arg, "requires_grad", True):
                 argnum.append(idx)
 
-        if len(argnum) == 1:
-            argnum = argnum[0]
-
         return self._grad_with_forward(
             self._fun,
             argnum=argnum,

--- a/pennylane/optimize/gradient_descent.py
+++ b/pennylane/optimize/gradient_descent.py
@@ -127,9 +127,6 @@ class GradientDescentOptimizer:
         grad = g(*args, **kwargs)
         forward = getattr(g, "forward", None)
 
-        if len(args) == 1:
-            grad = (grad,)
-
         return grad, forward
 
     def apply_grad(self, grad, args):

--- a/pennylane/optimize/nesterov_momentum.py
+++ b/pennylane/optimize/nesterov_momentum.py
@@ -82,7 +82,4 @@ class NesterovMomentumOptimizer(MomentumOptimizer):
         grad = g(*shifted_args, **kwargs)
         forward = getattr(g, "forward", None)
 
-        if len(args) == 1:
-            grad = (grad,)
-
         return grad, forward

--- a/tests/devices/test_default_qubit_autograd.py
+++ b/tests/devices/test_default_qubit_autograd.py
@@ -352,7 +352,7 @@ class TestHighLevelIntegration:
             qml.init.strong_ent_layers_normal(n_wires=2, n_layers=2), requires_grad=True
         )
 
-        grad = qml.grad(circuit)(weights)
+        grad = qml.grad(circuit)(weights)[0]
         assert grad.shape == weights.shape
 
     def test_qnode_collection_integration(self):
@@ -374,7 +374,7 @@ class TestHighLevelIntegration:
         def cost(weights):
             return np.sum(qnodes(weights))
 
-        grad = qml.grad(cost)(weights)
+        grad = qml.grad(cost)(weights)[0]
         assert grad.shape == weights.shape
 
 class TestOps:

--- a/tests/interfaces/test_autograd.py
+++ b/tests/interfaces/test_autograd.py
@@ -541,7 +541,8 @@ class TestParameterHandlingIntegration:
 
         # we do not check for correctness, just that the output
         # is the correct shape
-        assert res.shape == weights.shape
+        assert len(res) == 1
+        assert res[0].shape == weights.shape
 
         # check that the first arg was marked as non-differentiable
         assert circuit.get_trainable_args() == {0}
@@ -586,7 +587,8 @@ class TestParameterHandlingIntegration:
 
         # we do not check for correctness, just that the output
         # is the correct shape
-        assert res.shape == weights.shape
+        assert len(res) == 1
+        assert res[0].shape == weights.shape
 
         # check that the second arg was marked as non-differentiable
         assert circuit.get_trainable_args() == {1}
@@ -631,7 +633,8 @@ class TestParameterHandlingIntegration:
 
         # we do not check for correctness, just that the output
         # is the correct shape
-        assert res.shape == weights.shape
+        assert len(res) == 1
+        assert res[0].shape == weights.shape
 
         # check that the last arg was marked as non-differentiable
         assert circuit.get_trainable_args() == {2}
@@ -745,7 +748,7 @@ class TestParameterHandlingIntegration:
         grad_fn = qml.grad(cost)
         res = grad_fn(weights)
 
-        assert len(res) == 2
+        assert len(res[0]) == 2
 
     def test_gradient_value(self, tol):
         """Test that the returned gradient value for a qubit QNode is correct,

--- a/tests/math/test_autograd_box.py
+++ b/tests/math/test_autograd_box.py
@@ -175,7 +175,7 @@ def test_autodifferentiation():
     cost_fn = lambda a: (qml.math.TensorBox(a).T() ** 2).unbox()[0, 1]
     grad_fn = qml.grad(cost_fn)
 
-    res = grad_fn(x)
+    res = grad_fn(x)[0]
     expected = np.array([[0.0, 0.0, 0.0], [8.0, 0.0, 0.0]])
     assert np.all(res == expected)
 

--- a/tests/math/test_functions.py
+++ b/tests/math/test_functions.py
@@ -975,7 +975,7 @@ class TestScatterElementAdd:
         assert isinstance(res, np.ndarray)
         assert fn.allclose(res, onp.array([[1.0, 1.0, 1.0], [1.0, 1.0, 1.3136]]))
 
-        grad = qml.grad(lambda weights: cost(weights)[1, 2])([x, y])
+        grad = qml.grad(lambda weights: cost(weights)[1, 2])([x, y])[0]
         assert fn.allclose(grad[0], onp.array([[0, 0, 0], [0, 0, 1.]]))
         assert fn.allclose(grad[1], 2 * y)
 

--- a/tests/test_classical_gradients.py
+++ b/tests/test_classical_gradients.py
@@ -306,7 +306,7 @@ class TestGrad:
         res = grad_fn(x, y)
         expected = np.array([np.cos(x) * np.cos(y) + y ** 2])
         assert np.allclose(res, expected, atol=tol, rtol=0)
-        assert spy.call_args_list[0][1]["argnum"] == 0
+        assert spy.call_args_list[0][1]["argnum"] == [0]
 
 
 class TestJacobian:


### PR DESCRIPTION
**Context:** PR #1067 introduced an improvement to `qml.grad`, which removed the need to index into scalar gradients. However, it was determined that we did not want the behaviour of 0.15.0-dev to diverge from 0.14.0 until further in the release cycle.

**Description of the Change:** Reverts the change of #1067

**Benefits:** The same code for extracting the gradient of scalar functions will work on both 0.15.0-dev and 0.14.0

**Possible Drawbacks:** n/a

**Related GitHub Issues:** n/a
