### PR TITLE
Update Hamiltonian data storing and result of ExpvalCost for trivial Hamiltonians

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -91,6 +91,10 @@
 
 <h3>Bug fixes</h3>
 
+* Fixes a bug where `Hamiltonian` objects created with non-list arguments
+  raised an error for arithmetic operations.
+  [(#1082)](https://github.com/PennyLaneAI/pennylane/pull/1082)
+
 * Fixes a bug where inverse operations could not be differentiated
   using backpropagation on `default.qubit`.
   [(#1072)](https://github.com/PennyLaneAI/pennylane/pull/1072)
@@ -101,7 +105,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-Thomas Bromley, Josh Izaac, Daniel Polatajko, Chase Roberts, Maria Schuld
+Thomas Bromley, Josh Izaac, Daniel Polatajko, Chase Roberts, Maria Schuld, Antal Száva.
 
 # Release 0.14.0 (current release)
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -95,6 +95,10 @@
   raised an error for arithmetic operations.
   [(#1082)](https://github.com/PennyLaneAI/pennylane/pull/1082)
 
+* Fixes a bug where `Hamiltonian` objects with no coefficients or operations
+  would return a faulty result when used with `ExpvalCost`.
+  [(#1082)](https://github.com/PennyLaneAI/pennylane/pull/1082)
+
 * Fixes a bug where inverse operations could not be differentiated
   using backpropagation on `default.qubit`.
   [(#1072)](https://github.com/PennyLaneAI/pennylane/pull/1072)

--- a/pennylane/vqe/vqe.py
+++ b/pennylane/vqe/vqe.py
@@ -486,6 +486,10 @@ class ExpvalCost:
         self._multiple_devices = isinstance(device, Sequence)
         """Bool: Records if multiple devices are input"""
 
+        if all(c == 0 for c in coeffs) or not coeffs:
+            self.cost_fn = lambda *args, **kwargs: np.array(0)
+            return
+
         tape_mode = qml.tape_mode_active()
         self._optimize = optimize
 
@@ -528,11 +532,6 @@ class ExpvalCost:
             self.cost_fn = qml.dot(coeffs, self.qnodes)
 
     def __call__(self, *args, **kwargs):
-        coeffs = self.hamiltonian.coeffs
-        if all(c == 0 for c in coeffs) or not coeffs:
-            # We have a zero Hamiltonian whose measurement statistic is zero
-            return np.array(0)
-
         return self.cost_fn(*args, **kwargs)
 
 

--- a/pennylane/vqe/vqe.py
+++ b/pennylane/vqe/vqe.py
@@ -535,6 +535,10 @@ class ExpvalCost:
             self.cost_fn = qml.dot(coeffs, self.qnodes)
 
     def __call__(self, *args, **kwargs):
+        if all(coeff == 0 for coeff in self.hamiltonian.coeffs):
+            # We have a zero Hamiltonian whose measurement statistic is zero
+            return np.array(0)
+
         return self.cost_fn(*args, **kwargs)
 
 

--- a/pennylane/vqe/vqe.py
+++ b/pennylane/vqe/vqe.py
@@ -165,14 +165,6 @@ class Hamiltonian:
                 ops.append(op.prune())
                 coeffs.append(c)
 
-        if not coeffs:
-            # We have a zero Hamiltonian, add an identity as a dummy operation
-            # for a valid wire
-            coeffs = [0]
-            some_valid_wire = self.ops[0].wires[0] if self.ops else qml.wires.Wires(None)
-
-            ops = [qml.Identity(some_valid_wire)]
-
         self._coeffs = coeffs
         self._ops = ops
 

--- a/pennylane/vqe/vqe.py
+++ b/pennylane/vqe/vqe.py
@@ -90,8 +90,8 @@ class Hamiltonian:
                     "Could not create circuits. Some or all observables are not valid."
                 )
 
-        self._coeffs = coeffs
-        self._ops = observables
+        self._coeffs = list(coeffs)
+        self._ops = list(observables)
 
         if simplify:
             self.simplify()

--- a/pennylane/vqe/vqe.py
+++ b/pennylane/vqe/vqe.py
@@ -165,6 +165,13 @@ class Hamiltonian:
                 ops.append(op.prune())
                 coeffs.append(c)
 
+        if not coeffs:
+            # We have a zero Hamiltonian, add an identity as a dummy operation
+            # for a valid wire
+            coeffs = [0]
+            some_valid_wire = self.ops[0].wires[0]
+            ops = [qml.Identity(some_valid_wire)]
+
         self._coeffs = coeffs
         self._ops = ops
 

--- a/pennylane/vqe/vqe.py
+++ b/pennylane/vqe/vqe.py
@@ -169,7 +169,8 @@ class Hamiltonian:
             # We have a zero Hamiltonian, add an identity as a dummy operation
             # for a valid wire
             coeffs = [0]
-            some_valid_wire = self.ops[0].wires[0]
+            some_valid_wire = self.ops[0].wires[0] if self.ops else qml.wires.Wires(None)
+
             ops = [qml.Identity(some_valid_wire)]
 
         self._coeffs = coeffs
@@ -535,7 +536,8 @@ class ExpvalCost:
             self.cost_fn = qml.dot(coeffs, self.qnodes)
 
     def __call__(self, *args, **kwargs):
-        if all(coeff == 0 for coeff in self.hamiltonian.coeffs):
+        coeffs = self.hamiltonian.coeffs
+        if all(c == 0 for c in coeffs) or not coeffs:
             # We have a zero Hamiltonian whose measurement statistic is zero
             return np.array(0)
 

--- a/tests/test_vqe.py
+++ b/tests/test_vqe.py
@@ -160,6 +160,12 @@ simplify_hamiltonians = [
         qml.Hamiltonian([1, -1], [qml.PauliX(4) @ qml.Identity(0) @ qml.PauliX(1), qml.PauliX(4) @ qml.PauliX(1)]),
         qml.Hamiltonian([0], [qml.Identity(4)]),
     ),
+
+    # Simplifies a zero Hamiltonian (no change)
+    (
+        qml.Hamiltonian([0], [qml.Identity(0)]),
+        qml.Hamiltonian([0], [qml.Identity(0)]),
+    ),
 ]
 
 equal_hamiltonians = [

--- a/tests/test_vqe.py
+++ b/tests/test_vqe.py
@@ -218,13 +218,6 @@ add_hamiltonians = [
         ),
     ),
     (
-        qml.Hamiltonian([1, 1.2, 0.1], [qml.PauliX(0), qml.PauliZ(1), qml.PauliX(2)]),
-        qml.Hamiltonian([0.5, 0.3, 1], [qml.PauliX(0), qml.PauliX(1), qml.PauliX(2)]),
-        qml.Hamiltonian(
-            [1.5, 1.2, 1.1, 0.3], [qml.PauliX(0), qml.PauliZ(1), qml.PauliX(2), qml.PauliX(1)]
-        ),
-    ),
-    (
         qml.Hamiltonian(
             [1.3, 0.2, 0.7], [qml.PauliX(0) @ qml.PauliX(1), qml.Hadamard(1), qml.PauliX(2)]
         ),

--- a/tests/test_vqe.py
+++ b/tests/test_vqe.py
@@ -545,7 +545,6 @@ def mock_device(monkeypatch):
 #####################################################
 # Tests
 
-input_iterable_types = [list, tuple, np.array]
 
 class TestHamiltonian:
     """Test the Hamiltonian class"""

--- a/tests/test_vqe.py
+++ b/tests/test_vqe.py
@@ -293,6 +293,19 @@ sub_hamiltonians = [
         qml.Hamiltonian([1.2, 0.1], [qml.PauliZ(3.1), qml.PauliX(1.6)]),
     ),
 
+    # The result is the zero Hamiltonian
+    (
+        qml.Hamiltonian([1, 1.2, 0.1], [qml.PauliX(0), qml.PauliZ(1), qml.PauliX(2)]),
+        qml.Hamiltonian([1, 1.2, 0.1], [qml.PauliX(0), qml.PauliZ(1), qml.PauliX(2)]),
+        qml.Hamiltonian([0], [qml.Identity(0)]),
+    ),
+    (
+        qml.Hamiltonian([1, 2], [qml.PauliX(4), qml.PauliZ(2)]),
+        qml.Hamiltonian([1, 2], [qml.PauliX(4), qml.PauliZ(2)]),
+        qml.Hamiltonian([0], [qml.Identity(4)]),
+    ),
+
+
     # Case where Hamiltonian arguments coeffs and ops are other iterables than lists
     (
         qml.Hamiltonian((1, 1.2, 0.1), (qml.PauliX(0), qml.PauliZ(1), qml.PauliX(2))),
@@ -324,6 +337,18 @@ mul_hamiltonians = [
             [-1.3, 0.39],
             [qml.Hermitian(np.array([[1, 0], [0, -1]]), "b"), qml.PauliZ(23) @ qml.PauliZ(0)],
         ),
+    ),
+
+    # The result is the zero Hamiltonian
+    (
+        0,
+        qml.Hamiltonian([1], [qml.PauliX(0)]),
+        qml.Hamiltonian([0], [qml.PauliX(0)]),
+    ),
+    (
+        0,
+        qml.Hamiltonian([1, 1.2, 0.1], [qml.PauliX(0), qml.PauliZ(1), qml.PauliX(2)]),
+        qml.Hamiltonian([0, 0, 0], [qml.PauliX(0), qml.PauliZ(1), qml.PauliX(2)]),
     ),
 
     # Case where Hamiltonian arguments coeffs and ops are other iterables than lists

--- a/tests/test_vqe.py
+++ b/tests/test_vqe.py
@@ -239,7 +239,7 @@ add_hamiltonians = [
         qml.Hamiltonian([2, 1.2, 0.1], [qml.PauliX("b"), qml.PauliZ(3.1), qml.PauliX(1.6)]),
     ),
 
-    # Case where Hamiltonian arguments coeffs and ops are different iterables as lists
+    # Case where Hamiltonian arguments coeffs and ops are other iterables than lists
     (
         qml.Hamiltonian((1, 1.2, 0.1), (qml.PauliX(0), qml.PauliZ(1), qml.PauliX(2))),
         qml.Hamiltonian(np.array([0.5, 0.3, 1]), np.array([qml.PauliX(0), qml.PauliX(1), qml.PauliX(2)])),
@@ -293,7 +293,7 @@ sub_hamiltonians = [
         qml.Hamiltonian([1.2, 0.1], [qml.PauliZ(3.1), qml.PauliX(1.6)]),
     ),
 
-    # Case where Hamiltonian arguments coeffs and ops are different iterables as lists
+    # Case where Hamiltonian arguments coeffs and ops are other iterables than lists
     (
         qml.Hamiltonian((1, 1.2, 0.1), (qml.PauliX(0), qml.PauliZ(1), qml.PauliX(2))),
         qml.Hamiltonian(np.array([0.5, 0.3, 1.6]), np.array([qml.PauliX(0), qml.PauliX(1), qml.PauliX(2)])),
@@ -326,7 +326,7 @@ mul_hamiltonians = [
         ),
     ),
 
-    # Case where Hamiltonian arguments coeffs and ops are different iterables as lists
+    # Case where Hamiltonian arguments coeffs and ops are other iterables than lists
     (
         3,
         qml.Hamiltonian((1.5, 0.5), (qml.PauliX(0), qml.PauliZ(1))),
@@ -380,7 +380,7 @@ matmul_hamiltonians = [
         qml.Hamiltonian([1, 1], [qml.PauliX(0) @ qml.PauliX(2), qml.PauliZ(1) @ qml.PauliX(2)]),
     ),
 
-    # Case where Hamiltonian arguments coeffs and ops are different iterables as lists
+    # Case where Hamiltonian arguments coeffs and ops are other iterables than lists
     (
         qml.Hamiltonian((1, 1), (qml.PauliX(0), qml.PauliZ(1))),
         qml.Hamiltonian(np.array([0.5, 0.5]), np.array([qml.PauliZ(2), qml.PauliZ(3)])),

--- a/tests/test_vqe.py
+++ b/tests/test_vqe.py
@@ -196,6 +196,13 @@ add_hamiltonians = [
         ),
     ),
     (
+        qml.Hamiltonian([1, 1.2, 0.1], [qml.PauliX(0), qml.PauliZ(1), qml.PauliX(2)]),
+        qml.Hamiltonian([0.5, 0.3, 1], [qml.PauliX(0), qml.PauliX(1), qml.PauliX(2)]),
+        qml.Hamiltonian(
+            [1.5, 1.2, 1.1, 0.3], [qml.PauliX(0), qml.PauliZ(1), qml.PauliX(2), qml.PauliX(1)]
+        ),
+    ),
+    (
         qml.Hamiltonian(
             [1.3, 0.2, 0.7], [qml.PauliX(0) @ qml.PauliX(1), qml.Hadamard(1), qml.PauliX(2)]
         ),
@@ -230,6 +237,15 @@ add_hamiltonians = [
         qml.Hamiltonian([1, 1.2, 0.1], [qml.PauliX("b"), qml.PauliZ(3.1), qml.PauliX(1.6)]),
         qml.PauliX("b") @ qml.Identity(5),
         qml.Hamiltonian([2, 1.2, 0.1], [qml.PauliX("b"), qml.PauliZ(3.1), qml.PauliX(1.6)]),
+    ),
+
+    # Case where Hamiltonian arguments coeffs and ops are different iterables as lists
+    (
+        qml.Hamiltonian((1, 1.2, 0.1), (qml.PauliX(0), qml.PauliZ(1), qml.PauliX(2))),
+        qml.Hamiltonian(np.array([0.5, 0.3, 1]), np.array([qml.PauliX(0), qml.PauliX(1), qml.PauliX(2)])),
+        qml.Hamiltonian(
+            (1.5, 1.2, 1.1, 0.3), np.array([qml.PauliX(0), qml.PauliZ(1), qml.PauliX(2), qml.PauliX(1)])
+        ),
     ),
 ]
 
@@ -276,6 +292,15 @@ sub_hamiltonians = [
         qml.PauliX("b") @ qml.Identity(1),
         qml.Hamiltonian([1.2, 0.1], [qml.PauliZ(3.1), qml.PauliX(1.6)]),
     ),
+
+    # Case where Hamiltonian arguments coeffs and ops are different iterables as lists
+    (
+        qml.Hamiltonian((1, 1.2, 0.1), (qml.PauliX(0), qml.PauliZ(1), qml.PauliX(2))),
+        qml.Hamiltonian(np.array([0.5, 0.3, 1.6]), np.array([qml.PauliX(0), qml.PauliX(1), qml.PauliX(2)])),
+        qml.Hamiltonian(
+            (0.5, 1.2, -1.5, -0.3), np.array([qml.PauliX(0), qml.PauliZ(1), qml.PauliX(2), qml.PauliX(1)])
+        ),
+    ),
 ]
 
 mul_hamiltonians = [
@@ -299,6 +324,13 @@ mul_hamiltonians = [
             [-1.3, 0.39],
             [qml.Hermitian(np.array([[1, 0], [0, -1]]), "b"), qml.PauliZ(23) @ qml.PauliZ(0)],
         ),
+    ),
+
+    # Case where Hamiltonian arguments coeffs and ops are different iterables as lists
+    (
+        3,
+        qml.Hamiltonian((1.5, 0.5), (qml.PauliX(0), qml.PauliZ(1))),
+        qml.Hamiltonian(np.array([4.5, 1.5]), np.array([qml.PauliX(0), qml.PauliZ(1)])),
     ),
 ]
 
@@ -346,6 +378,21 @@ matmul_hamiltonians = [
         qml.Hamiltonian([1, 1], [qml.PauliX(0), qml.PauliZ(1)]),
         qml.PauliX(2),
         qml.Hamiltonian([1, 1], [qml.PauliX(0) @ qml.PauliX(2), qml.PauliZ(1) @ qml.PauliX(2)]),
+    ),
+
+    # Case where Hamiltonian arguments coeffs and ops are different iterables as lists
+    (
+        qml.Hamiltonian((1, 1), (qml.PauliX(0), qml.PauliZ(1))),
+        qml.Hamiltonian(np.array([0.5, 0.5]), np.array([qml.PauliZ(2), qml.PauliZ(3)])),
+        qml.Hamiltonian(
+            (0.5, 0.5, 0.5, 0.5),
+            np.array([
+                qml.PauliX(0) @ qml.PauliZ(2),
+                qml.PauliX(0) @ qml.PauliZ(3),
+                qml.PauliZ(1) @ qml.PauliZ(2),
+                qml.PauliZ(1) @ qml.PauliZ(3),
+            ]),
+        ),
     ),
 ]
 
@@ -498,6 +545,7 @@ def mock_device(monkeypatch):
 #####################################################
 # Tests
 
+input_iterable_types = [list, tuple, np.array]
 
 class TestHamiltonian:
     """Test the Hamiltonian class"""
@@ -507,7 +555,7 @@ class TestHamiltonian:
         """Tests that the Hamiltonian object is created with
         the correct attributes"""
         H = qml.vqe.Hamiltonian(coeffs, ops)
-        assert H.terms == (coeffs, ops)
+        assert H.terms == (list(coeffs), list(ops))
 
     @pytest.mark.parametrize("coeffs, ops", invalid_hamiltonians)
     def test_hamiltonian_invalid_init_exception(self, coeffs, ops):

--- a/tests/test_vqe.py
+++ b/tests/test_vqe.py
@@ -114,6 +114,7 @@ hamiltonians_with_expvals = [
 
 
 zero_hamiltonians_with_expvals = [
+    ([], [], [0]),
     ((0, 0), (qml.PauliZ(0), qml.PauliZ(1)), [0]),
     ((0,0,0), (qml.PauliX(0) @ qml.Identity(1), qml.PauliX(0), qml.PauliX(1)), [0]),
 ]

--- a/tests/test_vqe.py
+++ b/tests/test_vqe.py
@@ -143,6 +143,16 @@ simplify_hamiltonians = [
             [qml.Hermitian(np.array([[1, 0], [0, -1]]), "a"), qml.PauliX("b") @ qml.PauliY(1.3)],
         ),
     ),
+
+    # Simplifies to zero
+    (
+        qml.Hamiltonian([1, -0.5, -0.5], [qml.PauliX(0) @ qml.Identity(1), qml.PauliX(0), qml.PauliX(0)]),
+        qml.Hamiltonian([0], [qml.Identity(0)]),
+    ),
+    (
+        qml.Hamiltonian([1, -1], [qml.PauliX(4) @ qml.Identity(0) @ qml.PauliX(1), qml.PauliX(4) @ qml.PauliX(1)]),
+        qml.Hamiltonian([0], [qml.Identity(4)]),
+    ),
 ]
 
 equal_hamiltonians = [

--- a/tests/test_vqe.py
+++ b/tests/test_vqe.py
@@ -151,7 +151,7 @@ simplify_hamiltonians = [
         ),
     ),
 
-    # Simplifies to zero
+    # Simplifies to zero Hamiltonian
     (
         qml.Hamiltonian([1, -0.5, -0.5], [qml.PauliX(0) @ qml.Identity(1), qml.PauliX(0), qml.PauliX(0)]),
         qml.Hamiltonian([0], [qml.Identity(0)]),
@@ -256,7 +256,7 @@ add_hamiltonians = [
         qml.Hamiltonian([2, 1.2, 0.1], [qml.PauliX("b"), qml.PauliZ(3.1), qml.PauliX(1.6)]),
     ),
 
-    # Case where Hamiltonian arguments coeffs and ops are other iterables than lists
+    # Case where arguments coeffs and ops to the Hamiltonian are iterables other than lists
     (
         qml.Hamiltonian((1, 1.2, 0.1), (qml.PauliX(0), qml.PauliZ(1), qml.PauliX(2))),
         qml.Hamiltonian(np.array([0.5, 0.3, 1]), np.array([qml.PauliX(0), qml.PauliX(1), qml.PauliX(2)])),
@@ -323,7 +323,7 @@ sub_hamiltonians = [
     ),
 
 
-    # Case where Hamiltonian arguments coeffs and ops are other iterables than lists
+    # Case where arguments coeffs and ops to the Hamiltonian are iterables other than lists
     (
         qml.Hamiltonian((1, 1.2, 0.1), (qml.PauliX(0), qml.PauliZ(1), qml.PauliX(2))),
         qml.Hamiltonian(np.array([0.5, 0.3, 1.6]), np.array([qml.PauliX(0), qml.PauliX(1), qml.PauliX(2)])),
@@ -368,7 +368,7 @@ mul_hamiltonians = [
         qml.Hamiltonian([0, 0, 0], [qml.PauliX(0), qml.PauliZ(1), qml.PauliX(2)]),
     ),
 
-    # Case where Hamiltonian arguments coeffs and ops are other iterables than lists
+    # Case where arguments coeffs and ops to the Hamiltonian are iterables other than lists
     (
         3,
         qml.Hamiltonian((1.5, 0.5), (qml.PauliX(0), qml.PauliZ(1))),
@@ -422,7 +422,7 @@ matmul_hamiltonians = [
         qml.Hamiltonian([1, 1], [qml.PauliX(0) @ qml.PauliX(2), qml.PauliZ(1) @ qml.PauliX(2)]),
     ),
 
-    # Case where Hamiltonian arguments coeffs and ops are other iterables than lists
+    # Case where arguments coeffs and ops to the Hamiltonian are iterables other than lists
     (
         qml.Hamiltonian((1, 1), (qml.PauliX(0), qml.PauliZ(1))),
         qml.Hamiltonian(np.array([0.5, 0.5]), np.array([qml.PauliZ(2), qml.PauliZ(3)])),
@@ -913,9 +913,10 @@ class TestVQE:
         assert np.allclose(dc, big_hamiltonian_grad)
         assert np.allclose(dc2, big_hamiltonian_grad)
 
-    def test_grad_zero_hamiltonian(self):
+    @pytest.mark.parametrize('opt', [True, False])
+    def test_grad_zero_hamiltonian(self, opt):
         """Test that the gradient of ExpvalCost is accessible and correct when using observable
-        optimization and the autograd interface."""
+        optimization and the autograd interface with a zero Hamiltonian."""
         if not qml.tape_mode_active():
             pytest.skip("This test is only intended for tape mode")
 
@@ -923,7 +924,7 @@ class TestVQE:
         hamiltonian = qml.Hamiltonian([0], [qml.PauliX(0)])
 
         cost = qml.ExpvalCost(
-            qml.templates.StronglyEntanglingLayers, hamiltonian, dev, optimize=True, diff_method="parameter-shift"
+            qml.templates.StronglyEntanglingLayers, hamiltonian, dev, optimize=opt, diff_method="parameter-shift"
         )
 
         w = qml.init.strong_ent_layers_uniform(2, 4, seed=1967)

--- a/tests/test_vqe.py
+++ b/tests/test_vqe.py
@@ -154,14 +154,12 @@ simplify_hamiltonians = [
     # Simplifies to zero Hamiltonian
     (
         qml.Hamiltonian([1, -0.5, -0.5], [qml.PauliX(0) @ qml.Identity(1), qml.PauliX(0), qml.PauliX(0)]),
-        qml.Hamiltonian([0], [qml.Identity(0)]),
+        qml.Hamiltonian([], []),
     ),
     (
         qml.Hamiltonian([1, -1], [qml.PauliX(4) @ qml.Identity(0) @ qml.PauliX(1), qml.PauliX(4) @ qml.PauliX(1)]),
-        qml.Hamiltonian([0], [qml.Identity(4)]),
+        qml.Hamiltonian([], []),
     ),
-
-    # Simplifies a zero Hamiltonian (no change)
     (
         qml.Hamiltonian([0], [qml.Identity(0)]),
         qml.Hamiltonian([0], [qml.Identity(0)]),
@@ -320,12 +318,12 @@ sub_hamiltonians = [
     (
         qml.Hamiltonian([1, 1.2, 0.1], [qml.PauliX(0), qml.PauliZ(1), qml.PauliX(2)]),
         qml.Hamiltonian([1, 1.2, 0.1], [qml.PauliX(0), qml.PauliZ(1), qml.PauliX(2)]),
-        qml.Hamiltonian([0], [qml.Identity(0)]),
+        qml.Hamiltonian([], []),
     ),
     (
         qml.Hamiltonian([1, 2], [qml.PauliX(4), qml.PauliZ(2)]),
         qml.Hamiltonian([1, 2], [qml.PauliX(4), qml.PauliZ(2)]),
-        qml.Hamiltonian([0], [qml.Identity(4)]),
+        qml.Hamiltonian([], []),
     ),
 
 


### PR DESCRIPTION
**Context:**

1. The methods for the `Hamiltonian` class responsible for performing arithmetic operations added in https://github.com/PennyLaneAI/pennylane/pull/765 implicitly assume that the input arguments `coeffs` and `ops` are `list` typed. This is so because some `list` specific methods such as `extend`, `copy` are being called, producing errors when `coeffs` or `ops` are other iterables than lists.
2. The `Hamiltonian.simplify` method may result in an empty `coeffs` and `ops` list when subtracting a `Hamiltonian` from itself.

**Description of the Change:**

1. Converts the `coeffs` and `ops` arguments of `Hamiltonian` to `list` internally
2. Changes `ExpvalCost` to always return `np.array(0)` in `__call__` when specifying a zero Hamiltonian (either all entries of `coeffs` are 0 or `coeffs` is an empty list)

**Benefits:**

1. Can do arithmetic operations of `Hamiltonian` objects even if instantiated with non-list arguments
2. Can use `ExpvalCost` with the difference of `Hamiltonian` objects even when that's `0`

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
N/A

**Examples**

1. Adding up `Hamiltonian` objects that take non-lists as arguments (raised a `TypeError` previously)
```python
import pennylane as qml
import numpy as np

h1 = qml.Hamiltonian((1, 1.2, 0.1), np.array([qml.PauliX(0), qml.PauliZ(1), qml.PauliX(2)]))
h2 = qml.Hamiltonian(np.array([0.5, 0.3, 1]), (qml.PauliX(0), qml.PauliX(1), qml.PauliX(2)))

print(h1+h2)
```
```
(1.5) [X0]
+ (1.2) [Z1]
+ (1.1) [X2]
+ (0.3) [X1]
```
2. `ExpvalCost` of the difference of a `Hamiltonian` and itself  (used to return the invalid `<h_minus>= False` result)
```
import pennylane as qml
import numpy as np

nr_qubits = 2

dev = qml.device('default.qubit', wires = nr_qubits)

def circuit(theta, wires):
    qml.PauliX(0)

h1 = qml.Hamiltonian([0.5], [qml.PauliZ(0) @ qml.PauliZ(1)]) 
h2 = qml.Hamiltonian([0.5], [qml.PauliZ(0) @ qml.PauliZ(1)])

h_minus = h1 - h2
print( "<h_minus>=", qml.ExpvalCost(circuit, h_minus, dev)() )
```
```
<h_minus>= 0
```