### PR TITLE
Micro-optimize basis state conversion

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -79,6 +79,10 @@
   (5, 4, 4)
   ```
 
+* An improvement has been made to how `QubitDevice` generates and post-processess samples,
+  allowing QNode measurement statistics to work on devices with more than 32 qubits.
+  [(#)](https://github.com/PennyLaneAI/pennylane/pull/)
+
 <h3>Breaking changes</h3>
 
 * If creating a QNode from a quantum function with an argument named `shots`,

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -656,10 +656,10 @@ class QubitDevice(Device):
         # it corresponds to the orders of the wires passed.
         num_wires = len(device_wires)
         basis_states = self.generate_basis_states(num_wires)
-        basis_states = basis_states[:, np.argsort(np.argsort(device_wires))].T
+        basis_states = basis_states[:, np.argsort(np.argsort(device_wires))]
 
         powers_of_two = 2 ** np.arange(len(device_wires))[::-1]
-        perm = basis_states.T @ powers_of_two
+        perm = basis_states @ powers_of_two
         return self._gather(prob, perm)
 
     def expval(self, observable):

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -564,8 +564,8 @@ class QubitDevice(Device):
         samples = self._samples[:, device_wires]
 
         # convert samples from a list of 0, 1 integers, to base 10 representation
-        unraveled_indices = [2] * len(device_wires)
-        indices = np.ravel_multi_index(samples.T, unraveled_indices)
+        powers_of_two = 2 ** np.arange(len(device_wires))[::-1]
+        indices = samples @ powers_of_two
 
         # count the basis state occurrences, and construct the probability vector
         basis_states, counts = np.unique(indices, return_counts=True)
@@ -656,9 +656,10 @@ class QubitDevice(Device):
         # it corresponds to the orders of the wires passed.
         num_wires = len(device_wires)
         basis_states = self.generate_basis_states(num_wires)
-        perm = np.ravel_multi_index(
-            basis_states[:, np.argsort(np.argsort(device_wires))].T, [2] * len(device_wires)
-        )
+        basis_states = basis_states[:, np.argsort(np.argsort(device_wires))].T
+
+        powers_of_two = 2 ** np.arange(len(device_wires))[::-1]
+        perm = basis_states.T @ powers_of_two
         return self._gather(prob, perm)
 
     def expval(self, observable):
@@ -696,8 +697,8 @@ class QubitDevice(Device):
         # Replace the basis state in the computational basis with the correct eigenvalue.
         # Extract only the columns of the basis samples required based on ``wires``.
         samples = self._samples[:, np.array(device_wires)]  # Add np.array here for Jax support.
-        unraveled_indices = [2] * len(device_wires)
-        indices = np.ravel_multi_index(samples.T, unraveled_indices)
+        powers_of_two = 2 ** np.arange(samples.shape[-1])[::-1]
+        indices = samples @ powers_of_two
         return observable.eigvals[indices]
 
     def adjoint_jacobian(self, tape):


### PR DESCRIPTION
**Context:**

* In https://github.com/aws/amazon-braket-sdk-python/pull/203, it was noted that the current implementation for converting between binary samples and the equivalent base-10 representation does not work for devices with more than 32 qubits.

**Description of the Change:**

* Modifies `QubitDevice`, replacing the current conversion logic with one that works for > 32 qubits.

**Benefits:**

* Samples can now be processed if the devices has more than 32 qubits

* The new logic is easier to read and understand than `np.ravel_multi_index`

* The new logic is ever so slightly faster:

  ![image](https://user-images.githubusercontent.com/2959003/108170086-9b240800-7134-11eb-8e05-225e6b6793ad.png)


**Possible Drawbacks:**

There are two other places where `np.ravel_multi_index` is used:

- `default.qubit`, when applying a statevector to a subset of wires
- `default.mixed`, same as above.

It might be worth exploring if a better implementation can be used here as well.

**Related GitHub Issues:** n/a
