### PR TITLE
Correct Typo in qml_templates.rst

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -97,11 +97,14 @@
 
 <h3>Documentation</h3>
 
+- Typos addressed in templates documentation.
+  [(#1094)](https://github.com/PennyLaneAI/pennylane/pull/1094)
+
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):
 
-Thomas Bromley, Josh Izaac, Daniel Polatajko, Chase Roberts, Maria Schuld.
+Thomas Bromley, Kyle Godbey, Josh Izaac, Daniel Polatajko, Chase Roberts, Maria Schuld.
 
 
 

--- a/doc/code/qml_templates.rst
+++ b/doc/code/qml_templates.rst
@@ -26,7 +26,7 @@ Subroutines
     :no-heading:
     :include-all-objects:
 
-State preperations
+State preparations
 ------------------
 
 .. automodapi:: pennylane.templates.state_preparations


### PR DESCRIPTION
**Context:** Typo in documentation

**Description of the Change:** Fixed the offending misspelling of Preparation

**Benefits:** Correctness