### PR TITLE
ExpvalCost raises an error if instantiated with variance measurements

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -95,6 +95,10 @@
 
 <h3>Bug fixes</h3>
 
+* The `ExpvalCost` class raises an error if instantiated
+  with non-expectation measurement statistics.
+  [(#)](https://github.com/PennyLaneAI/pennylane/pull/)
+
 <h3>Documentation</h3>
 
 - Typos addressed in templates documentation.

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -97,7 +97,7 @@
 
 * The `ExpvalCost` class raises an error if instantiated
   with non-expectation measurement statistics.
-  [(#)](https://github.com/PennyLaneAI/pennylane/pull/)
+  [(#1106)](https://github.com/PennyLaneAI/pennylane/pull/1106)
 
 <h3>Documentation</h3>
 

--- a/pennylane/vqe/vqe.py
+++ b/pennylane/vqe/vqe.py
@@ -474,7 +474,7 @@ class ExpvalCost:
         optimize=False,
         **kwargs,
     ):
-        if kwargs.get("measure", "expval") is not "expval":
+        if kwargs.get("measure", "expval") != "expval":
             raise ValueError("ExpvalCost can only be used to construct sums of expectation values.")
 
         coeffs, observables = hamiltonian.terms

--- a/pennylane/vqe/vqe.py
+++ b/pennylane/vqe/vqe.py
@@ -474,6 +474,9 @@ class ExpvalCost:
         optimize=False,
         **kwargs,
     ):
+        if kwargs.get("measure", "expval") is not "expval":
+            raise ValueError("ExpvalCost can only be used to construct sums of expectation values.")
+
         coeffs, observables = hamiltonian.terms
 
         self.hamiltonian = hamiltonian

--- a/tests/test_vqe.py
+++ b/tests/test_vqe.py
@@ -1056,6 +1056,20 @@ class TestVQE:
         with pytest.raises(ValueError, match="Using multiple devices is not supported when"):
             qml.ExpvalCost(qml.templates.StronglyEntanglingLayers, h, dev, optimize=True)
 
+    def test_variance_error(self):
+        """Test that an error is raised if attempting to use ExpvalCost to measure
+        variances"""
+        dev = qml.device("default.qubit", wires=4)
+        hamiltonian = big_hamiltonian
+
+        with pytest.raises(ValueError, match="sums of expectation values"):
+            qml.ExpvalCost(
+                qml.templates.StronglyEntanglingLayers,
+                hamiltonian,
+                dev,
+                measure="var"
+            )
+
 
 @pytest.mark.usefixtures("tape_mode")
 class TestAutogradInterface:


### PR DESCRIPTION
**Context:** The `ExpvalCost` function assumes a cost function consisting of a sum of expectation values. However, since it accepts arbitrary keyword arguments, it is easy to pass `measure="var"` and assume it will now return variances of the Hamiltonian.

**Description of the Change:** Adds keyword validation, raising an error if a non-expectation statistic is requested.

**Benefits:** Clearer behaviour.

**Possible Drawbacks:** n/a

**Related GitHub Issues:** #1105 
