### PR TITLE
Fixes a bug where decompositions would reset the differentiation method of a QNode

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -165,7 +165,7 @@
 
 * Fixes a bug where decompositions would reset the differentiation method
   of a QNode.
-  [(#)](https://github.com/PennyLaneAI/pennylane/pull/)
+  [(#1117)](https://github.com/PennyLaneAI/pennylane/pull/1117)
 
 <h3>Documentation</h3>
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -163,6 +163,10 @@
   with non-expectation measurement statistics.
   [(#1106)](https://github.com/PennyLaneAI/pennylane/pull/1106)
 
+* Fixes a bug where decompositions would reset the differentiation method
+  of a QNode.
+  [(#)](https://github.com/PennyLaneAI/pennylane/pull/)
+
 <h3>Documentation</h3>
 
 - Typos addressed in templates documentation.

--- a/pennylane/tape/qnode.py
+++ b/pennylane/tape/qnode.py
@@ -516,9 +516,6 @@ class QNode:
                         "Operator {} must act on all wires".format(obj.name)
                     )
 
-        # provide the jacobian options
-        self.qtape.jacobian_options = self.diff_options
-
         # pylint: disable=protected-access
         obs_on_same_wire = len(self.qtape._obs_sharing_wires) > 0
         ops_not_supported = any(
@@ -535,6 +532,9 @@ class QNode:
                 stop_at=lambda obj: not isinstance(obj, qml.tape.QuantumTape)
                 and self.device.supports_operation(obj.name),
             )
+
+        # provide the jacobian options
+        self.qtape.jacobian_options = self.diff_options
 
     def __call__(self, *args, **kwargs):
 

--- a/tests/tape/tapes/test_qnode.py
+++ b/tests/tape/tapes/test_qnode.py
@@ -328,7 +328,7 @@ class TestTapeConstruction:
         dev = MyDev(wires=2)
 
         def func(x, y):
-            # the U2 operation is not support on default.qubit
+            # the U2 operation is not supported on default.qubit
             # and is decomposed.
             qml.U2(x, y, wires=0)
             qml.CNOT(wires=[0, 1])

--- a/tests/tape/tapes/test_qnode.py
+++ b/tests/tape/tapes/test_qnode.py
@@ -307,6 +307,55 @@ class TestTapeConstruction:
 
         assert jac.shape == (4, 2)
 
+    def test_diff_method_expansion(self, monkeypatch, mocker):
+        """Test that a QNode with tape expansion during construction
+        preserves the differentiation method."""
+
+        class MyDev(qml.devices.DefaultQubit):
+            """Dummy device that supports device Jacobians"""
+
+            @classmethod
+            def capabilities(cls):
+                capabilities = super().capabilities().copy()
+                capabilities.update(
+                    provides_jacobian=True,
+                )
+                return capabilities
+
+            def jacobian(self, *args, **kwargs):
+                return np.zeros((2, 4))
+
+        dev = MyDev(wires=2)
+
+        def func(x, y):
+            # the U2 operation is not support on default.qubit
+            # and is decomposed.
+            qml.U2(x, y, wires=0)
+            qml.CNOT(wires=[0, 1])
+            return qml.probs(wires=0)
+
+        qn = QNode(func, dev, diff_method="device", h=1e-8, order=2)
+
+        assert qn.diff_options["method"] == "device"
+        assert qn.diff_options["h"] == 1e-8
+        assert qn.diff_options["order"] == 2
+
+        x = 0.12
+        y = 0.54
+
+        spy = mocker.spy(JacobianTape, "expand")
+        res = qn(x, y)
+
+        spy.assert_called_once()
+        assert qn.qtape.jacobian_options["method"] == "device"
+        assert qn.qtape.jacobian_options["h"] == 1e-8
+        assert qn.qtape.jacobian_options["order"] == 2
+
+        spy = mocker.spy(JacobianTape, "jacobian")
+        jac = qml.jacobian(qn)(x, y)
+
+        assert spy.call_args_list[0][1]["method"] == "device"
+
     def test_returning_non_measurements(self):
         """Test that an exception is raised if a non-measurement
         is returned from the QNode."""


### PR DESCRIPTION
**Context:** During tape construction, the differentiation options of the tape are set _prior_ to any potential tape expansion. Since tape expansion is a tape-to-tape transformation that outputs a new tape, if a decomposition is required, the tape differentiation options are lost.

**Description of the Change:** Moves the setting of the differentiation options to _after_ potential tape expansion.

**Benefits:** Preserves differentiation options, even if a decomposition is performed.

**Possible Drawbacks:** We plan to move tape expansion to the device, as a result, the logic that causes this bug within the QNode will be removed. This is not a drawback, just something to keep in mind --- an expected future change would have also eliminated this bug!

**Related GitHub Issues:** Closes #1115 
