### PR TITLE
Add support for computing the Hessian for vector-valued QNodes

### DIFF
--- a/pennylane/tape/tapes/jacobian_tape.py
+++ b/pennylane/tape/tapes/jacobian_tape.py
@@ -731,7 +731,9 @@ class JacobianTape(QuantumTape):
             if hessian is None:
                 # create the Hessian matrix
                 if self.output_dim is not None:
-                    hessian = np.zeros((len(params), len(params), np.prod(self.output_dim)), dtype=float)
+                    hessian = np.zeros(
+                        (len(params), len(params), np.prod(self.output_dim)), dtype=float
+                    )
                 else:
                     hessian = np.zeros((len(params), len(params)), dtype=float)
 

--- a/pennylane/tape/tapes/jacobian_tape.py
+++ b/pennylane/tape/tapes/jacobian_tape.py
@@ -666,9 +666,6 @@ class JacobianTape(QuantumTape):
         if any([m.return_type is State for m in self.measurements]):
             raise ValueError("The Hessian method does not support circuits that return the state")
 
-        if self.output_dim != 1:
-            raise NotImplementedError
-
         method = options.get("method", "analytic")
 
         if method != "analytic":
@@ -733,7 +730,10 @@ class JacobianTape(QuantumTape):
 
             if hessian is None:
                 # create the Hessian matrix
-                hessian = np.zeros((len(params), len(params)), dtype=float)
+                if self.output_dim is not None:
+                    hessian = np.zeros((len(params), len(params), np.prod(self.output_dim)), dtype=float)
+                else:
+                    hessian = np.zeros((len(params), len(params)), dtype=float)
 
             if i == j:
                 hessian[i, i] = g


### PR DESCRIPTION
```python
import pennylane as qml
from pennylane import numpy as np
import tensorflow as tf

dev = qml.device('default.qubit', wires=1)

@qml.qnode(dev, interface='tf', diff_method="parameter-shift")
def circuit(p):
    qml.RX(p[0], wires=0)
    qml.RY(p[1], wires=0)
    return qml.probs(wires=0)

p = tf.Variable([0.1, 0.2, 0.3], dtype=tf.float64)

with tf.GradientTape() as tape1:
    with tf.GradientTape() as tape2:
        res = circuit(p)
    g = tape2.gradient(res, p)
hessian = tape1.jacobian(g, p)
print(hessian)
```

gives
```
tf.Tensor(
[[-0.47766824  0.47766824  0.        ]
 [-0.47766824  0.47766824  0.        ]
 [ 0.          0.          0.        ]], shape=(3, 3), dtype=float64)
```