### PR TITLE
Fix is_sampled and its test

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -237,6 +237,10 @@
 
 <h3>Bug fixes</h3>
 
+* Fixes a bug and a test where the ``QuantumTape.is_sampled`` attribute was not
+  being updated.
+  [(#1126)](https://github.com/PennyLaneAI/pennylane/pull/1126)
+
 * Fixes a bug where `BasisEmbedding` would not accept inputs whose bits are all ones 
   or all zeros. 
   [(#1114)](https://github.com/PennyLaneAI/pennylane/pull/1114)
@@ -261,7 +265,7 @@
 This release contains contributions from (in alphabetical order):
 
 Thomas Bromley, Olivia Di Matteo, Kyle Godbey, Diego Guala, Josh Izaac, Daniel Polatajko, Chase Roberts,
-Sankalp Sanand, Pritish Sehzpaul, Maria Schuld.
+Sankalp Sanand, Pritish Sehzpaul, Maria Schuld, Antal Száva.
 
 # Release 0.14.1 (current release)
 

--- a/pennylane/tape/tapes/tape.py
+++ b/pennylane/tape/tapes/tape.py
@@ -380,9 +380,8 @@ class QuantumTape(AnnotatedQueue):
         )
         self.num_wires = len(self.wires)
 
-        sample_returns = (m.return_type is Sample for m in self.measurements)
-        self.is_sampled = any(sample_returns)
-        self.all_sampled = all(sample_returns)
+        self.is_sampled = any(m.return_type is Sample for m in self.measurements)
+        self.all_sampled = all(m.return_type is Sample for m in self.measurements)
 
     def _update_observables(self):
         """Update information about observables, including the wires that are acted upon and

--- a/pennylane/tape/tapes/tape.py
+++ b/pennylane/tape/tapes/tape.py
@@ -379,7 +379,10 @@ class QuantumTape(AnnotatedQueue):
             [op.wires for op in self.operations + self.observables]
         )
         self.num_wires = len(self.wires)
-        self.all_sampled = all(m.return_type is Sample for m in self.measurements)
+
+        sample_returns = (m.return_type is Sample for m in self.measurements)
+        self.is_sampled = any(sample_returns)
+        self.all_sampled = all(sample_returns)
 
     def _update_observables(self):
         """Update information about observables, including the wires that are acted upon and

--- a/tests/tape/tapes/test_tape.py
+++ b/tests/tape/tapes/test_tape.py
@@ -856,8 +856,13 @@ class TestExpand:
                 qml.T(wires=0)
                 return sample(qml.PauliZ(0))
 
-            qnode = qml.tape.QNode(circuit, dev)
+            # Choosing parameter-shift not to swap the device under the hood
+            qnode = qml.tape.QNode(circuit, dev, diff_method="parameter-shift")
             qnode()
+
+            # Double-checking that the T gate is not supported
+            assert "T" not in qnode.device.operations
+            assert "T" not in qnode._original_device.operations
 
             assert qnode.qtape.is_sampled
 


### PR DESCRIPTION
**Context:**

The `is_sampled` attribute of a quantum tape is required for generating samples on the device level. The behaviour for this attribute was modified in #1027 and #1040.

Due to a bug, this attribute is not being set currently, although its test case is passing. The reason is that the underlying device gets swapped inside the test case, ultimately leading to unexpected behaviour.

**Description of the Change:**
* Adds the required line for updating the `is_sampled` attribute
* Fixes the test case

**Benefits:**
Sampling works correctly.

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
N/A