### PR TITLE
refine qubit unitary input check

### DIFF
--- a/pennylane/ops/qubit.py
+++ b/pennylane/ops/qubit.py
@@ -1594,7 +1594,7 @@ class QubitUnitary(Operation):
     def _matrix(cls, *params):
         U = np.asarray(params[0])
 
-        if U.shape[0] != U.shape[1]:
+        if U.ndim != 2 or U.shape[0] != U.shape[1]:
             raise ValueError("Operator must be a square matrix.")
 
         if not np.allclose(U @ U.conj().T, np.identity(U.shape[0])):

--- a/tests/ops/test_qubit_ops.py
+++ b/tests/ops/test_qubit_ops.py
@@ -768,6 +768,15 @@ class TestOperations:
         with pytest.raises(ValueError, match="must be unitary"):
             qml.QubitUnitary(U3, wires=0).matrix
 
+    @pytest.mark.parametrize("U", [np.array([0]), np.array([1,0,0,1]), np.array([[[1,0],[0,1]]])])
+    def test_qubit_unitary_not_matrix_exception(self, U):
+        """Tests that the unitary operator raises the proper errors for arrays
+        that are not two-dimensional."""
+
+        # test non-square matrix
+        with pytest.raises(ValueError, match="must be a square matrix"):
+            qml.QubitUnitary(U, wires=0).matrix
+
     @pytest.mark.parametrize("phi", [-0.1, 0.2, 0.5])
     def test_controlled_phase_shift_matrix_and_eigvals(self, phi):
         """Tests that the ControlledPhaseShift operation calculates the correct matrix and


### PR DESCRIPTION
**Context:**
The input checks to `QubitUnitary` is assumed to be a two-dimensional array and a less readable error is outputted if this is not the case:
```python
import pennylane as qml

dev = qml.device('default.qubit', wires=3)

@qml.qnode(dev)
def circuit():
    qml.QubitUnitary(np.array([1,0,0,1]), wires=[0,1])
    return qml.expval(qml.PauliZ(0))

circuit()
```
```
~/xanadu/pennylane/pennylane/ops/qubit.py in _matrix(cls, *params)
   1595         U = np.asarray(params[0])
   1596 
-> 1597         if U.shape[0] != U.shape[1]:
   1598             raise ValueError("Operator must be a square matrix.")
   1599 

IndexError: tuple index out of range
```

**Description of the Change:**
Refines the input check to check for the dimensionality of the array.

**Benefits:**
User convenience.

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
N/A