### PR TITLE
Added adjoints for some CV gates

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * A new adjoint transform has been added. 
   [(#1111)](https://github.com/PennyLaneAI/pennylane/pull/1111)
-  [(#1135)](https://github.com/PennyLaneAI/pennylane/pull/1111)
+  [(#1135)](https://github.com/PennyLaneAI/pennylane/pull/1135)
 
   This new method allows users to apply the adjoint of an arbitrary sequence of operations.
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * A new adjoint transform has been added. 
   [(#1111)](https://github.com/PennyLaneAI/pennylane/pull/1111)
+  [(#1135)](https://github.com/PennyLaneAI/pennylane/pull/1111)
 
   This new method allows users to apply the adjoint of an arbitrary sequence of operations.
 

--- a/pennylane/ops/cv.py
+++ b/pennylane/ops/cv.py
@@ -416,6 +416,9 @@ class ControlledAddition(CVOperation):
         U[3, 1] = p[0]
         return U
 
+    def adjoint(self, do_queue=False):
+        return ControlledAddition(-self.parameters[0], wires=self.wires, do_queue=do_queue)
+
 
 class ControlledPhase(CVOperation):
     r"""pennylane.ControlledPhase(s, wires)
@@ -465,6 +468,9 @@ class ControlledPhase(CVOperation):
         U[4, 1] = p[0]
         return U
 
+    def adjoint(self, do_queue=False):
+        return ControlledPhase(-self.parameters[0], wires=self.wires, do_queue=do_queue)
+
 
 class Kerr(CVOperation):
     r"""pennylane.Kerr(kappa, wires)
@@ -488,6 +494,8 @@ class Kerr(CVOperation):
     par_domain = "R"
     grad_method = "F"
 
+    def adjoint(self, do_queue=False):
+        return Kerr(-self.parameters[0], wires=self.wires, do_queue=do_queue)
 
 class CrossKerr(CVOperation):
     r"""pennylane.CrossKerr(kappa, wires)
@@ -511,6 +519,9 @@ class CrossKerr(CVOperation):
     par_domain = "R"
     grad_method = "F"
 
+    def adjoint(self, do_queue=False):
+        return CrossKerr(-self.parameters[0], wires=self.wires, do_queue=do_queue)
+
 
 class CubicPhase(CVOperation):
     r"""pennylane.CubicPhase(gamma, wires)
@@ -533,6 +544,9 @@ class CubicPhase(CVOperation):
     num_wires = 1
     par_domain = "R"
     grad_method = "F"
+
+    def adjoint(self, do_queue=False):
+        return CubicPhase(-self.parameters[0], wires=self.wires, do_queue=do_queue)
 
 
 class Interferometer(CVOperation):

--- a/pennylane/ops/cv.py
+++ b/pennylane/ops/cv.py
@@ -102,6 +102,9 @@ class Rotation(CVOperation):
     def _heisenberg_rep(p):
         return _rotation(p[0])
 
+    def adjoint(self, do_queue=False):
+        return Rotation(-self.parameters[0], wires=self.wires, do_queue=do_queue)
+
 
 class Squeezing(CVOperation):
     r"""pennylane.Squeezing(r, phi, wires)
@@ -146,6 +149,11 @@ class Squeezing(CVOperation):
     def _heisenberg_rep(p):
         R = _rotation(p[1] / 2)
         return R @ np.diag([1, math.exp(-p[0]), math.exp(p[0])]) @ R.T
+
+    def adjoint(self, do_queue=False):
+        r, phi = self.parameters
+        new_phi = (phi + np.pi) % (2 * np.pi)
+        return Squeezing(r, new_phi, wires=self.wires, do_queue=do_queue)
 
 
 class Displacement(CVOperation):
@@ -192,6 +200,11 @@ class Displacement(CVOperation):
         s = math.sin(p[1])
         scale = 2  # sqrt(2 * hbar)
         return np.array([[1, 0, 0], [scale * c * p[0], 1, 0], [scale * s * p[0], 0, 1]])
+
+    def adjoint(self, do_queue=False):
+        a, phi = self.parameters
+        new_phi = (phi + np.pi) % (2 * np.pi)
+        return Displacement(a, new_phi, wires=self.wires, do_queue=do_queue)
 
 
 class Beamsplitter(CVOperation):
@@ -242,6 +255,10 @@ class Beamsplitter(CVOperation):
         U[1:3, 3:5] = -s * R.T
         U[3:5, 1:3] = s * R
         return U
+
+    def adjoint(self, do_queue=False):
+        theta, phi = self.parameters
+        return Beamsplitter(-theta, phi, wires=self.wires, do_queue=do_queue)
 
 
 class TwoModeSqueezing(CVOperation):
@@ -299,6 +316,11 @@ class TwoModeSqueezing(CVOperation):
         U[1:3, 3:5] = S @ R.T
         U[3:5, 1:3] = S @ R.T
         return U
+
+    def adjoint(self, do_queue=False):
+        r, phi = self.parameters
+        new_phi = (phi + np.pi) % (2 * np.pi)
+        return TwoModeSqueezing(r, new_phi, wires=self.wires, do_queue=do_queue)
 
 
 class QuadraticPhase(CVOperation):
@@ -565,6 +587,10 @@ class Interferometer(CVOperation):
         M = np.eye(2 * N + 1)
         M[1 : 2 * N + 1, 1 : 2 * N + 1] = S
         return M
+
+    def adjoint(self, do_queue=False):
+        U = self.parameters[0]
+        return Interferometer(U.conj().T, wires=self.wires, do_queue=do_queue)
 
 
 # =============================================================================

--- a/pennylane/ops/cv.py
+++ b/pennylane/ops/cv.py
@@ -497,6 +497,7 @@ class Kerr(CVOperation):
     def adjoint(self, do_queue=False):
         return Kerr(-self.parameters[0], wires=self.wires, do_queue=do_queue)
 
+
 class CrossKerr(CVOperation):
     r"""pennylane.CrossKerr(kappa, wires)
     Cross-Kerr interaction.

--- a/tests/ops/test_cv_ops.py
+++ b/tests/ops/test_cv_ops.py
@@ -44,6 +44,8 @@ class TestCV:
     @pytest.mark.parametrize("op,size", [
             (cv.Squeezing(0.123, -0.456, wires=1), 3),
             (cv.Squeezing(0.668, -10.0, wires=0), 3), # phi > 2pi
+            (cv.Rotation(2.005, wires=1), 3),
+            (cv.Rotation(-1.365, wires=1), 3),
             (cv.Displacement(2.841, 0.456, wires=0), 3),
             (cv.Displacement(3.142, -7.0, wires=0), 3), # phi < -2pi
             (cv.Beamsplitter(0.456, -0.789, wires=[0, 2]), 5),

--- a/tests/ops/test_cv_ops.py
+++ b/tests/ops/test_cv_ops.py
@@ -49,7 +49,7 @@ class TestCV:
             (cv.Rotation(-1.365, wires=1), 3),
             (cv.Displacement(2.841, 0.456, wires=0), 3),
             (cv.Displacement(3.142, -7.221, wires=0), 3), # phi < -2pi
-            (cv.Displacement(2.004, 8.673, wires=0), 3), # phi > -2pi
+            (cv.Displacement(2.004, 8.673, wires=0), 3), # phi > 2pi
             (cv.Beamsplitter(0.456, -0.789, wires=[0, 2]), 5),
             (cv.TwoModeSqueezing(2.532, 1.778, wires=[1, 2]), 5),
             (cv.Interferometer(

--- a/tests/ops/test_cv_ops.py
+++ b/tests/ops/test_cv_ops.py
@@ -21,6 +21,7 @@ import pytest
 
 import pennylane
 from pennylane import numpy as np
+import numpy.testing as np_testing
 from pennylane.ops import cv
 from pennylane.wires import Wires
 
@@ -39,6 +40,26 @@ class TestCV:
             [[1, 0, 0], [0, np.cos(phi), -np.sin(phi)], [0, np.sin(phi), np.cos(phi)]]
         )
         assert np.allclose(matrix, true_matrix)
+
+    @pytest.mark.parametrize("op,size", [
+            (cv.Squeezing(0.123, 0.456, wires=1), 3),
+            (cv.Rotation(0.123, wires=0), 3),
+            (cv.Displacement(0.123, 0.456, wires=0), 3),
+            (cv.Beamsplitter(0.456, 0.789, wires=[0, 2]), 5),
+            (cv.TwoModeSqueezing(2.532, 1.778, wires=[1, 2]), 5),
+            (cv.Interferometer(
+                np.array([[1, 1], [1, -1]]) * -1.j / np.sqrt(2.0),
+                wires=1), 5),
+        ])
+    def test_adjoint_cv_ops(self, op, size, tol):
+        op_d = op.adjoint()
+        op_heis = op._heisenberg_rep(op.parameters)
+        op_d_heis = op_d._heisenberg_rep(op_d.parameters)
+        res1 = np.dot(op_heis, op_d_heis)
+        res2 = np.dot(op_d_heis, op_heis)
+        np_testing.assert_allclose(res1, np.eye(size), atol=tol)
+        np_testing.assert_allclose(res2, np.eye(size), atol=tol)
+        assert op.wires == op_d.wires
 
 
     @pytest.mark.parametrize("phi", phis)

--- a/tests/ops/test_cv_ops.py
+++ b/tests/ops/test_cv_ops.py
@@ -42,14 +42,17 @@ class TestCV:
         assert np.allclose(matrix, true_matrix)
 
     @pytest.mark.parametrize("op,size", [
-            (cv.Squeezing(0.123, 0.456, wires=1), 3),
-            (cv.Rotation(0.123, wires=0), 3),
-            (cv.Displacement(0.123, 0.456, wires=0), 3),
-            (cv.Beamsplitter(0.456, 0.789, wires=[0, 2]), 5),
+            (cv.Squeezing(0.123, -0.456, wires=1), 3),
+            (cv.Squeezing(0.668, -10.0, wires=0), 3), # phi > 2pi
+            (cv.Displacement(2.841, 0.456, wires=0), 3),
+            (cv.Displacement(3.142, -7.0, wires=0), 3), # phi < -2pi
+            (cv.Beamsplitter(0.456, -0.789, wires=[0, 2]), 5),
             (cv.TwoModeSqueezing(2.532, 1.778, wires=[1, 2]), 5),
             (cv.Interferometer(
                 np.array([[1, 1], [1, -1]]) * -1.j / np.sqrt(2.0),
                 wires=1), 5),
+            (cv.ControlledAddition(2.551, wires=[0, 2]), 5),
+            (cv.ControlledPhase(2.189, wires=[3, 1]), 5),
         ])
     def test_adjoint_cv_ops(self, op, size, tol):
         op_d = op.adjoint()
@@ -61,6 +64,14 @@ class TestCV:
         np_testing.assert_allclose(res2, np.eye(size), atol=tol)
         assert op.wires == op_d.wires
 
+    @pytest.mark.parametrize("op", [
+            cv.CrossKerr(-1.724, wires=[2, 0]),
+            cv.CubicPhase(0.997, wires=2),
+            cv.Kerr(2.568, wires=2),
+        ])
+    def test_adjoint_no_heisenberg_rep_defined(self, op, tol):
+        op_d = op.adjoint()
+        assert op.parameters[0] == -op_d.parameters[0]
 
     @pytest.mark.parametrize("phi", phis)
     @pytest.mark.parametrize("mag", mags)

--- a/tests/ops/test_cv_ops.py
+++ b/tests/ops/test_cv_ops.py
@@ -43,11 +43,13 @@ class TestCV:
 
     @pytest.mark.parametrize("op,size", [
             (cv.Squeezing(0.123, -0.456, wires=1), 3),
-            (cv.Squeezing(0.668, -10.0, wires=0), 3), # phi > 2pi
+            (cv.Squeezing(0.668, 10.0, wires=0), 3), # phi > 2pi
+            (cv.Squeezing(1.992, -9.782, wires=0), 3), # phi < -2pi
             (cv.Rotation(2.005, wires=1), 3),
             (cv.Rotation(-1.365, wires=1), 3),
             (cv.Displacement(2.841, 0.456, wires=0), 3),
-            (cv.Displacement(3.142, -7.0, wires=0), 3), # phi < -2pi
+            (cv.Displacement(3.142, -7.221, wires=0), 3), # phi < -2pi
+            (cv.Displacement(2.004, 8.673, wires=0), 3), # phi > -2pi
             (cv.Beamsplitter(0.456, -0.789, wires=[0, 2]), 5),
             (cv.TwoModeSqueezing(2.532, 1.778, wires=[1, 2]), 5),
             (cv.Interferometer(


### PR DESCRIPTION
**Context:**
Added adjoint definitions for some CV ops.

**Benefits:**
Users can now use `qml.adjoint` when using CVOperations.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None.
