### PR TITLE
Modify rule for auto-labelling issues describing malfunctions

### DIFF
--- a/.github/workflows/assign_bugs.yml
+++ b/.github/workflows/assign_bugs.yml
@@ -9,6 +9,6 @@ jobs:
     steps:
       - uses: Naturalclar/issue-action@v2.0.2
         with:
-          title-or-body: "both"
+          title-or-body: "title"
           parameters: '[ {"keywords": ["[BUG]", "bug"], "labels": ["bug :bug:"], "assignees": ["antalszava"]}]'
           github-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
**Changes**

Change to only checking the title of issues when automatically tagging bugs. This will necessitate the title to include either `[BUG]` or `bug` to be automatically labelled with the `"bug"` label and assigned. On the other hand, it will more so trigger labelling in cases where explicitly intended.

**Checking this functionality**

Keyword only in body: https://github.com/antalszava/bugs-scan/issues/11
Keyword in title: https://github.com/antalszava/bugs-scan/issues/12