### PR TITLE
Fix output shape of KerasLayer

### DIFF
--- a/pennylane/qnn/keras.py
+++ b/pennylane/qnn/keras.py
@@ -311,7 +311,7 @@ class KerasLayer(Layer):
         Returns:
             tf.TensorShape: shape of output data
         """
-        return tf.TensorShape(input_shape[0]).concatenate(self.output_dim)
+        return tf.TensorShape([input_shape[0]]).concatenate(self.output_dim)
 
     def __str__(self):
         detail = "<Quantum Keras Layer: func={}>"

--- a/tests/qnn/test_keras.py
+++ b/tests/qnn/test_keras.py
@@ -485,6 +485,18 @@ class TestKerasLayer:
         assert grad is not None
         spy.assert_not_called()
 
+    @pytest.mark.parametrize("n_qubits, output_dim", indices_up_to(1))
+    def test_compute_output_shape(self, get_circuit, output_dim):
+        """Test that the compute_output_shape method returns the expected shape"""
+        c, w = get_circuit
+        layer = KerasLayer(c, w, output_dim)
+
+        inputs = tf.keras.Input(shape=(2,))
+        inputs_shape = inputs.shape
+
+        output_shape = layer.compute_output_shape(inputs_shape)
+        assert output_shape.as_list() == [None, 1]
+
 
 @pytest.mark.parametrize("interface", ["autograd", "torch", "tf"])
 @pytest.mark.parametrize("n_qubits, output_dim", indices_up_to(1))


### PR DESCRIPTION
**Context:**

A minor bug was introduced in https://github.com/PennyLaneAI/pennylane/pull/1070. Currently, the following gives a shape of `<unknown>`:

```python
layer = KerasLayer(...)
inputs = tf.keras.Input(shape=(2,))
inputs_shape = inputs.shape

output_shape = layer.compute_output_shape(inputs_shape)
print(output_shape)
```

(Note that `inputs_shape = (None, 2)`).

The output shape should be `(None, 1)`.

**Description of the Change:**

This PR ensures that the output shape is as expected, i.e., `(None, 1)`. A supporting test is added.
