### PR TITLE
Update device_kwargs

### DIFF
--- a/pennylane/devices/tests/conftest.py
+++ b/pennylane/devices/tests/conftest.py
@@ -223,6 +223,7 @@ def pytest_generate_tests(metafunc):
             # translate command line string to None if necessary
             device_kwargs["shots"] = None if (opt.shots == "None") else int(opt.shots)
 
+        device_kwargs.update(opt.device_kwargs)
         list_of_device_kwargs.append(device_kwargs)
 
     # define the device_kwargs parametrization:

--- a/pennylane/devices/tests/conftest.py
+++ b/pennylane/devices/tests/conftest.py
@@ -223,7 +223,9 @@ def pytest_generate_tests(metafunc):
             # translate command line string to None if necessary
             device_kwargs["shots"] = None if (opt.shots == "None") else int(opt.shots)
 
+        # store user defined device kwargs
         device_kwargs.update(opt.device_kwargs)
+
         list_of_device_kwargs.append(device_kwargs)
 
     # define the device_kwargs parametrization:


### PR DESCRIPTION
**Context**

When invoking the device test suite, certain keyword arguments did not take effect. They were parsed correctly, but seem to have not been passed to the corresponding tests. An example of this was seen in the Qiskit plugin, where a `statevector_simulator` was swapped for `qasm_simulator` under the hood ([see here for more context](https://github.com/PennyLaneAI/pennylane-qiskit/pull/130#discussion_r601805065)).

**Changes**

Updates the dictionary that is passed upon device test suite runs. [Recreates the logic ](https://github.com/PennyLaneAI/pennylane/blame/c02ec7896dbf9feecd2baca1a303f2cb3f1cb3e1/pennylane/devices/tests/conftest.py#L209)that was previously responsible for passing the device keyword arguments (`**opt.device_kwargs`).

*Note*: not updating the changelog as this change is an update to a recent change.