### PR TITLE
Extend `ControlledQubitUnitary` docstring

### DIFF
--- a/pennylane/ops/qubit.py
+++ b/pennylane/ops/qubit.py
@@ -1852,6 +1852,12 @@ class ControlledQubitUnitary(QubitUnitary):
     r"""ControlledQubitUnitary(U, control_wires, wires, control_values)
     Apply an arbitrary fixed unitary to ``wires`` with control from the ``control_wires``.
 
+    In addition to default ``Operation`` instance attributes, the following are
+    available for ``ControlledQubitUnitary``:
+
+    * ``control_wires``: wires that act as control for the operation
+    * ``U``: unitary applied to the target wires
+
     **Details:**
 
     * Number of wires: Any (the operation can act on any number of wires)


### PR DESCRIPTION
Extends the docstring of ``ControlledQubitUnitary`` to document new instance attributes.