### PR TITLE
specify `num_wires` in a general `qml.Hermitian` object

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -740,6 +740,8 @@
   of a QNode.
   [(#1117)](https://github.com/PennyLaneAI/pennylane/pull/1117)
 
+* When creating a generic observable with `qml.Hermitian`, initialization now sets the `num_wires` attribute. [(#1189)](https://github.com/PennyLaneAI/pennylane/pull/1189)
+
 <h3>Documentation</h3>
 
 - Typos addressed in templates documentation.

--- a/pennylane/ops/qubit.py
+++ b/pennylane/ops/qubit.py
@@ -2460,6 +2460,12 @@ class Hermitian(Observable):
     grad_method = "F"
     _eigs = {}
 
+    def __init__(self, *params, wires=None, do_queue=True):
+
+        super().__init__(*params, wires=wires, do_queue=do_queue)
+
+        self.num_wires = len(self._wires) # self._wires defined in Operator __init__
+
     @classmethod
     def _matrix(cls, *params):
         A = np.asarray(params[0])

--- a/pennylane/ops/qubit.py
+++ b/pennylane/ops/qubit.py
@@ -2464,7 +2464,7 @@ class Hermitian(Observable):
 
         super().__init__(*params, wires=wires, do_queue=do_queue)
 
-        self.num_wires = len(self._wires)  # self._wires defined in Operator __init__
+        self.num_wires = len(self._wires)  # self._wires defined in Operator.__init__
 
     @classmethod
     def _matrix(cls, *params):

--- a/pennylane/ops/qubit.py
+++ b/pennylane/ops/qubit.py
@@ -2464,7 +2464,7 @@ class Hermitian(Observable):
 
         super().__init__(*params, wires=wires, do_queue=do_queue)
 
-        self.num_wires = len(self._wires) # self._wires defined in Operator __init__
+        self.num_wires = len(self._wires)  # self._wires defined in Operator __init__
 
     @classmethod
     def _matrix(cls, *params):


### PR DESCRIPTION
Fixes #1188 

Currently, when creating a generic `qml.Hermitian` object, like

```
h = qml.Hermitian(np.array([[0, 1], [1,0]]), 0)
```

the `num_wires` attribute is not set and remains at the default value:

```
>>> h.num_wires
<WiresEnum.AnyWires: -1>
```

This PR adds setting `num_wires` to the initialization of `qml.Hermitian`.