### PR TITLE
Add blog to navbar

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -9,6 +9,7 @@ numpy
 pygments-github-lexers
 semantic_version==2.6
 scipy
+docutils==0.16
 sphinx==3.5.3
 sphinx-automodapi
 sphinx-copybutton

--- a/doc/xanadu_theme/header.html
+++ b/doc/xanadu_theme/header.html
@@ -39,6 +39,9 @@
           <span class="sr-only">(current)</span>
       </li>
       <li class="nav-item">
+        <a class="nav-link" href="https://pennylane.ai/blog">Blog</a>
+      </li>
+      <li class="nav-item">
         <a class="nav-link" href="https://qhack.ai"><img src="https://pennylane.ai/img/qhack_plain_black.png"></a>
       </li>
     </ul>

--- a/doc/xanadu_theme/layout.html
+++ b/doc/xanadu_theme/layout.html
@@ -3,6 +3,7 @@
 {# Do this so that bootstrap is included before the main css file #}
 {%- block htmltitle %}
   <link href="https://fonts.googleapis.com/css?family=Noto+Serif" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Noto+Sans" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css?family=Roboto&display=swap" rel="stylesheet">
 
   <!-- Font Awesome -->

--- a/doc/xanadu_theme/static/xanadu.css_t
+++ b/doc/xanadu_theme/static/xanadu.css_t
@@ -1,13 +1,5 @@
 /* Sphinx themes
 -------------------------------------------------- */
-@font-face {
-  font-family: 'Product Sans';
-  font-style: normal;
-  font-weight: 400;
-  src: local('Open Sans'), local('OpenSans'), url(https://fonts.gstatic.com/s/productsans/v5/HYvgU2fE2nRJvZ5JFAumwegdm0LZdjqr5-oayXSOefg.woff2) format('woff2');
-}
-
-
 
 body {
   /*background-color: #edf0f2;*/
@@ -92,7 +84,7 @@ h1, h2, h3, h4, h5, h6 {
   color: black;
   font-weight: normal;
   padding: 0;
-  font-family: 'Product Sans', 'Roboto', sans-serif!important;
+  font-family: 'Noto Sans', 'Roboto', sans-serif!important;
 }
 
 h1, h2, h3 {
@@ -372,7 +364,7 @@ div.sphinxsidebar p {
   margin: 20px 0px 10px 21px;
   font-weight: normal;
   padding: 0;
-  font-family: 'Product Sans', 'Roboto', sans-serif!important;
+  font-family: 'Noto Sans', 'Roboto', sans-serif!important;
   font-size: 24px;
   color: #515151;
   /*text-align: center;*/
@@ -2013,7 +2005,7 @@ footer.page-footer .footer-copyright {
     margin-left: 20px;
     font-size: initial;
     color: black;
-    font-family: 'Product Sans', 'Roboto', sans-serif !important;
+    font-family: 'Noto Sans', 'Roboto', sans-serif !important;
     margin-bottom: -9px;
     border-bottom: 3px solid;
     border-bottom-color: white;


### PR DESCRIPTION
* Adds the blog to the navbar

* [Docutils version 0.17](https://docutils.sourceforge.io/RELEASE-NOTES.html#release-0-17-2021-04-03), released on April 3rd, contains a new HTML5 writer that uses HTML5 semantic tags (`<main>`, `<section>`, `<header>`, `<footer>`, `<aside>`, `<figure>`, and `<figcaption>`) rather than `<div>`. This breaks the CSS on the website.

  This PR pins docutils to version 0.16.