### PR TITLE
Increase stacklevel in shots DeprecationWarning

### DIFF
--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -472,6 +472,7 @@ class QubitDevice(Device):
                 "when using sample-based measurements. Since no shots are specified, "
                 "a default of 1000 shots is used.",
                 DeprecationWarning,
+                stacklevel=2
             )
 
         shots = self.shots or 1000


### PR DESCRIPTION
@antalszava noted that the deprecation warning does not show in common editors (despite begin raised and tested). I realised that other warnings in PL have stack level 2, so adapting it here.