### PR TITLE
Fixes bug where applying the Torch interface repeatedly after expansion caused an error

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -770,7 +770,7 @@
   second-order observable.
   [(#1197)](https://github.com/PennyLaneAI/pennylane/pull/1197)
 
-* Fixes a bug where repeated Torch interface after expansion caused an error.
+* Fixes a bug where repeated Torch interface applications after expansion caused an error.
   [(#1223)](https://github.com/PennyLaneAI/pennylane/pull/1223)
 
 <h3>Documentation</h3>

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -770,6 +770,9 @@
   second-order observable.
   [(#1197)](https://github.com/PennyLaneAI/pennylane/pull/1197)
 
+* Fixes a bug where repeated Torch interface after expansion caused an error.
+  [(#)](https://github.com/PennyLaneAI/pennylane/pull/)
+
 <h3>Documentation</h3>
 
 - Typos addressed in templates documentation.

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -771,7 +771,7 @@
   [(#1197)](https://github.com/PennyLaneAI/pennylane/pull/1197)
 
 * Fixes a bug where repeated Torch interface after expansion caused an error.
-  [(#)](https://github.com/PennyLaneAI/pennylane/pull/)
+  [(#1223)](https://github.com/PennyLaneAI/pennylane/pull/1223)
 
 <h3>Documentation</h3>
 

--- a/pennylane/tape/tape.py
+++ b/pennylane/tape/tape.py
@@ -153,6 +153,7 @@ def expand_tape(tape, depth=1, stop_at=None, expand_measurements=False):
         stop_at = lambda obj: False
 
     new_tape = tape.__class__()
+    new_tape.__bare__ = getattr(tape, "__bare__", tape.__class__)
 
     # Check for observables acting on the same wire. If present, observables must be
     # qubit-wise commuting Pauli words. In this case, the tape is expanded with joint

--- a/tests/interfaces/test_tape_torch.py
+++ b/tests/interfaces/test_tape_torch.py
@@ -453,3 +453,24 @@ class TestTorchQuantumTape:
             m.setattr(qml.interfaces.torch, "COMPLEX_SUPPORT", False)
             with pytest.raises(qml.QuantumFunctionError, match=r"Version 1\.6\.0 or above of PyTorch"):
                 TorchInterface.apply(JacobianTape(), dtype=torch.complex128)
+
+    def test_repeated_application_after_expand(self, tol):
+        """Test that the Torch interface continues to work after
+        tape expansions, and repeated torch application"""
+        n_qubits = 2
+        dev = qml.device("default.qubit", wires=n_qubits)
+
+        weights = torch.ones((3,))
+
+        with TorchInterface.apply(qml.tape.QuantumTape()) as tape:
+            qml.U3(*weights, wires=0)
+            qml.expval(qml.PauliZ(wires=0))
+
+        tape = tape.expand()
+
+        res1 = tape.execute(dev)
+
+        TorchInterface.apply(tape)
+        res2 = tape.execute(dev)
+
+        assert np.allclose(res1, res2, atol=tol, rtol=0)


### PR DESCRIPTION
**Context:** Applying the Torch interface, twice, to an expanded tape, resulted in an error. This is because the `expand()` function was not retaining the `__bare__` attribute of the tape, which stores the original (pre-interface) class of the tape.

**Description of the Change:** The `expand()` method now retains the `__bare__` attribute. A test has also been added.

**Benefits:** Fixes the aforementioned bug.

**Possible Drawbacks:** Not a drawback per se, just a note: once we remove tape subclasses (alongside gradient methods becoming transforms), we can remove the `__bare__` attribute.

**Related GitHub Issues:** Closes #1210
