### PR TITLE
Revert "Add deprecation warning to qnn module (#1170)"

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -666,11 +666,6 @@
 * Adds an informative error message for removal of the `analytic` keyword in devices. Users are directed to use `shots=None` instead.
   [(#1196)](https://github.com/PennyLaneAI/pennylane/pull/1196)
 
-* A deprecation warning is now raised when loading content from the `qnn` module. In release 
-  `0.16.0`, the `qnn` module will no-longer be automatically loaded due to its dependency on
-  TensorFlow and Torch. Instead, users will need to do `from pennylane import qnn`.
-  [(#1170)](https://github.com/PennyLaneAI/pennylane/pull/1170)
-
 * Devices do not have an `analytic` argument or attribute anymore. 
   Instead, `shots` is the source of truth for whether a simulator 
   estimates return values from a finite number of shots, or whether 

--- a/pennylane/qnn/cost.py
+++ b/pennylane/qnn/cost.py
@@ -15,15 +15,7 @@
 This submodule contains frequently used loss and cost functions.
 """
 # pylint: disable=too-many-arguments
-from warnings import warn
-
 import pennylane as qml
-
-WARNING_STRING = (
-    "SquaredErrorLoss will no longer be directly imported in PennyLane from "
-    "release 0.16.0. It will be accessible by importing the qnn module. Consider adding "
-    "'from pennylane import qnn' to your existing code now."
-)
 
 
 class SquaredErrorLoss:
@@ -103,7 +95,6 @@ class SquaredErrorLoss:
         diff_method="best",
         **kwargs,
     ):
-        warn(WARNING_STRING, DeprecationWarning, stacklevel=2)
         self.qnodes = qml.map(
             ansatz,
             observables,

--- a/pennylane/qnn/keras.py
+++ b/pennylane/qnn/keras.py
@@ -16,7 +16,6 @@ API."""
 import inspect
 from collections.abc import Iterable
 from typing import Optional
-from warnings import warn
 
 try:
     import tensorflow as tf
@@ -30,12 +29,6 @@ except ImportError:
 
     Layer = ABC
     CORRECT_TF_VERSION = False
-
-WARNING_STRING = (
-    "KerasLayer will no longer be directly imported in PennyLane from "
-    "release 0.16.0. It will be accessible by importing the qnn module. Consider adding "
-    "'from pennylane import qnn' to your existing code now."
-)
 
 
 class KerasLayer(Layer):
@@ -211,8 +204,6 @@ class KerasLayer(Layer):
                 "pip install tensorflow --upgrade\nAlternatively, visit "
                 "https://www.tensorflow.org/install for detailed instructions."
             )
-
-        warn(WARNING_STRING, DeprecationWarning, stacklevel=2)
 
         self.weight_shapes = {
             weight: (tuple(size) if isinstance(size, Iterable) else (size,) if size > 1 else ())

--- a/pennylane/qnn/torch.py
+++ b/pennylane/qnn/torch.py
@@ -18,7 +18,6 @@ import inspect
 import math
 from collections.abc import Iterable
 from typing import Callable, Optional
-from warnings import warn
 
 try:
     import torch
@@ -32,12 +31,6 @@ except ImportError:
 
     Module = Mock
     TORCH_IMPORTED = False
-
-WARNING_STRING = (
-    "TorchLayer will no longer be directly imported in PennyLane from "
-    "release 0.16.0. It will be accessible by importing the qnn module. Consider adding "
-    "'from pennylane import qnn' to your existing code now."
-)
 
 
 class TorchLayer(Module):
@@ -211,9 +204,6 @@ class TorchLayer(Module):
                 "visit https://pytorch.org/get-started/locally/ for detailed "
                 "instructions."
             )
-
-        warn(WARNING_STRING, DeprecationWarning, stacklevel=2)
-
         super().__init__()
 
         weight_shapes = {

--- a/tests/qnn/test_cost.py
+++ b/tests/qnn/test_cost.py
@@ -18,7 +18,7 @@ import numpy as np
 import pennylane as qml
 import pytest
 
-from pennylane.qnn.cost import SquaredErrorLoss, WARNING_STRING
+from pennylane.qnn.cost import SquaredErrorLoss
 
 
 ALLOWED_INTERFACES = ["tf", "jax", "autograd", "torch"]
@@ -91,15 +91,3 @@ class TestSquaredErrorLoss:
         res = loss(phis, target=np.array([1.0, 0.5, 0.1]))
 
         assert np.allclose(res, np.array([0.21, 0.25, 0.03]), atol=0.01, rtol=0.01)
-
-
-def test_deprecation_warning():
-    """Test if deprecation warning is raised"""
-    if int(qml.__version__.split(".")[1]) >= 16:
-        pytest.fail("Deprecation warnings for the qnn module should be removed")
-
-    dev = qml.device("default.qubit", wires=3)
-    observables = [qml.PauliZ(0), qml.PauliX(0), qml.PauliZ(1) @ qml.PauliZ(2)]
-
-    with pytest.warns(DeprecationWarning, match=WARNING_STRING):
-        SquaredErrorLoss(rx_ansatz, observables, dev)

--- a/tests/qnn/test_keras.py
+++ b/tests/qnn/test_keras.py
@@ -18,7 +18,7 @@ import numpy as np
 import pytest
 
 import pennylane as qml
-from pennylane.qnn.keras import KerasLayer, WARNING_STRING
+from pennylane.qnn.keras import KerasLayer
 
 tf = pytest.importorskip("tensorflow", minversion="2")
 
@@ -496,16 +496,6 @@ class TestKerasLayer:
 
         output_shape = layer.compute_output_shape(inputs_shape)
         assert output_shape.as_list() == [None, 1]
-
-    @pytest.mark.parametrize("n_qubits, output_dim", indices_up_to(1))
-    def test_deprecation_warning(self, get_circuit, output_dim):
-        """Test if deprecation warning is raised"""
-        if int(qml.__version__.split(".")[1]) >= 16:
-            pytest.fail("Deprecation warnings for the qnn module should be removed")
-
-        c, w = get_circuit
-        with pytest.warns(DeprecationWarning, match=WARNING_STRING):
-            KerasLayer(c, w, output_dim)
 
 
 @pytest.mark.parametrize("interface", ["autograd", "torch", "tf"])

--- a/tests/qnn/test_qnn_torch.py
+++ b/tests/qnn/test_qnn_torch.py
@@ -20,7 +20,7 @@ import numpy as np
 import pytest
 
 import pennylane as qml
-from pennylane.qnn.torch import TorchLayer, WARNING_STRING
+from pennylane.qnn.torch import TorchLayer
 
 torch = pytest.importorskip("torch")
 
@@ -415,16 +415,6 @@ class TestTorchLayer:
                 loss.backward()
             except Exception:
                 pytest.fail("Exception raised in torch CUDA backward")
-
-    @pytest.mark.parametrize("n_qubits, output_dim", indices_up_to(1))
-    def test_deprecation_warning(self, get_circuit):
-        """Test if deprecation warning is raised"""
-        if int(qml.__version__.split(".")[1]) >= 16:
-            pytest.fail("Deprecation warnings for the qnn module should be removed")
-
-        c, w = get_circuit
-        with pytest.warns(DeprecationWarning, match=WARNING_STRING):
-            TorchLayer(c, w)
 
 
 @pytest.mark.parametrize("interface", ["autograd", "torch", "tf"])


### PR DESCRIPTION
This reverts commit 816885aaf5e0e723861142348b3b8479536c0d4b.

Deprecation is no longer needed because of the use of lazy importing in https://github.com/PennyLaneAI/pennylane/pull/1228