### PR TITLE
Allow pyscf>=1.7.2 for QChem

### DIFF
--- a/qchem/requirements.txt
+++ b/qchem/requirements.txt
@@ -3,5 +3,5 @@ scipy
 pennylane>=0.13.0
 openfermion==1.0
 openfermionpsi4==0.5
-pyscf==1.7.2
+pyscf>=1.7.2
 openfermionpyscf==0.5

--- a/qchem/setup.py
+++ b/qchem/setup.py
@@ -22,7 +22,7 @@ requirements = [
     "openfermion>=1.0",
     "openfermionpyscf>=0.5; platform_system != 'Windows'",
     "openfermionpsi4>=0.5",
-    "pyscf==1.7.2; platform_system != 'Windows'",
+    "pyscf>=1.7.2; platform_system != 'Windows'",
 ]
 
 info = {


### PR DESCRIPTION
Addresses #1145 as the `pyscf==1.7.2` strict pinning is no longer required.

The [original issue was solved in PySCF](https://github.com/pyscf/pyscf/commit/88aa846aff5ed6696dce2028b1855360c810412f) (see change to the SciPy requirement) after we've done the [strict pinning](https://github.com/PennyLaneAI/pennylane/pull/926).