### PR TITLE
Remove more `analytic` occurrences

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -54,6 +54,9 @@
 
 <h3>Documentation</h3>
 
+* Removes more occurrences of ``analytic``.
+  [(#1261)](https://github.com/PennyLaneAI/pennylane/pull/1261)
+
 * Updated the order of the parameters to the `GaussianState` operation to match
   the way that the PennyLane-SF plugin uses them.
   [(#1255)](https://github.com/PennyLaneAI/pennylane/pull/1255)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -54,7 +54,7 @@
 
 <h3>Documentation</h3>
 
-* Removes more occurrences of ``analytic``.
+* Removes occurrences of the deprecated device argument ``analytic`` from the documentation.
   [(#1261)](https://github.com/PennyLaneAI/pennylane/pull/1261)
 
 * Updated the order of the parameters to the `GaussianState` operation to match

--- a/doc/development/plugins.rst
+++ b/doc/development/plugins.rst
@@ -141,13 +141,13 @@ following arguments:
   or iterable that contains unique labels for the subsystems as numbers (i.e., ``[-1, 0, 2]``)
   and/or strings (``['ancilla', 'q1', 'q2']``).
 
-* ``shots=1000`` (*int*): number of circuit evaluations/random samples used to estimate
-  expectation values of observables in non-analytic mode.
-
-* ``analytic=True`` (*bool*): If ``True``, the device calculates probability, expectation
-  values, and variances analytically. If ``False``, a finite number of samples
-  are used to estimate these quantities. Note that hardware devices should always set
-  ``analytic=False``.
+* ``shots=1000`` (*None*, *int* or *List[iint]*): number of circuit
+  evaluations/random samples used to estimate probabilities, expectation
+  values, variances  of observables in non-analytic mode. If ``None``, the device
+  calculates probability, expectation values, and variances analytically.  If an
+  integer, it specifies the number of samples to estimate these quantities.  If a
+  list of integers is passed, the circuit evaluations are batched over the list
+  of shots.
 
 To add your own device arguments, or to override any of the above defaults, simply
 overwrite the ``__init__.py`` method. For example, here is a device where the number
@@ -167,7 +167,7 @@ of low-level hardware control options:
         observables = {"PauliZ", "PauliX", "PauliY"}
 
         def __init__(self, shots=1024, hardware_options=None):
-            super().__init__(wires=24, shots=shots, analytic=False)
+            super().__init__(wires=24, shots=shots)
             self.hardware_options = hardware_options or hardware_defaults
 
 Note that we have also overridden the default shot number.
@@ -193,7 +193,7 @@ To execute operations on the device, the following methods **must** be defined:
 
     apply
 
-If the device is a statevector simulator (it has an ``analytic`` attribute)
+If the device is a statevector simulator (it can perform analytic computations when ``shots=None``)
 then it **must** also overwrite:
 
 .. autosummary::
@@ -241,7 +241,7 @@ your plugin which, by default, performs the following process:
     self.apply(circuit.operations, rotations=circuit.diagonalizing_gates)
 
     # generate computational basis samples
-    if (not self.analytic) or circuit.is_sampled:
+    if self.shots is not None or circuit.is_sampled:
         self._samples = self.generate_samples()
 
     # compute the required statistics
@@ -410,7 +410,7 @@ test utility:
 
 .. code-block:: console
 
-    pl-device-test --device device_shortname --shots 10000 --analytic False
+    pl-device-test --device device_shortname --shots 10000
 
 In general, as all supported operations have their gradient formula defined and tested by
 PennyLane, testing that your device calculates the correct gradients is not required.

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -40,7 +40,6 @@ hbar = 2
 
 [strawberryfields.global]
 hbar = 1
-shots = None
 
     [strawberryfields.fock]
     cutoff_dim = 10

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -40,8 +40,7 @@ hbar = 2
 
 [strawberryfields.global]
 hbar = 1
-shots = 1000
-analytic = true
+shots = None
 
     [strawberryfields.fock]
     cutoff_dim = 10


### PR DESCRIPTION
Some more places where `analytic` appeared:
1. In the building a plugin guide: `DeviceError: The analytic argument has been replaced by shots=None. Please use shots=None instead of analytic=True.`
2. One test file

There was another which made me wonder: `./pennylane/optimize/shot_adaptive.py:        if dev.analytic:` (`check_device` method). @josh146 would this be intended because `Device.analytic` is still valid?