### PR TITLE
Update PolyXP documentation.

### DIFF
--- a/pennylane/ops/cv.py
+++ b/pennylane/ops/cv.py
@@ -1030,7 +1030,8 @@ class PolyXP(CVObservable):
     For second-order observables the representation is a real symmetric
     matrix :math:`A` such that :math:`P(\x,\p) = \mathbf{r}^T A \mathbf{r}`.
 
-    Used by :meth:`QNode._pd_analytic` for evaluating arbitrary order-2 CV expectation values.
+    Used for evaluating arbitrary order-2 CV expectation values of
+    :class:`~.pennylane.tape.CVParamShiftTape`.
 
     **Details:**
 
@@ -1041,6 +1042,7 @@ class PolyXP(CVObservable):
 
     Args:
         q (array[float]): expansion coefficients
+
     """
     num_wires = AnyWires
     num_params = 1


### PR DESCRIPTION
**Context:** The docstring of the CV `PolyXP` observable referred to its usage in `QNode._pd_analytic`, which no longer exists.

**Description of the Change:** Docstring is updated to reference the param-shift tape where `PolyXP` is currently being used.

**Benefits:** Brings docs up to date :tada:

**Possible Drawbacks:** None, though it would be helpful to include usage examples for the CV observables at some point.

**Related GitHub Issues:** None
