### PR TITLE
Update QNode docstring

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -53,6 +53,9 @@
 
 <h3>Documentation</h3>
 
+* Remove unsupported `None` option from the `qml.QNode` docstrings.
+  [(#1271)](https://github.com/PennyLaneAI/pennylane/pull/1271)
+
 * Updated the docstring of `qml.PolyXP` to reference the new location of internal
   usage. [(#1262)](https://github.com/PennyLaneAI/pennylane/pull/1262)
 

--- a/pennylane/qnode.py
+++ b/pennylane/qnode.py
@@ -47,15 +47,15 @@ class QNode:
         interface (str): The interface that will be used for classical backpropagation.
             This affects the types of objects that can be passed to/returned from the QNode:
 
-            * ``interface='autograd'``: Allows autograd to backpropagate
+            * ``"autograd"``: Allows autograd to backpropagate
               through the QNode. The QNode accepts default Python types
               (floats, ints, lists) as well as NumPy array arguments,
               and returns NumPy arrays.
 
-            * ``interface='torch'``: Allows PyTorch to backpropogate
+            * ``"torch"``: Allows PyTorch to backpropogate
               through the QNode. The QNode accepts and returns Torch tensors.
 
-            * ``interface='tf'``: Allows TensorFlow in eager mode to backpropogate
+            * ``"tf"``: Allows TensorFlow in eager mode to backpropogate
               through the QNode. The QNode accepts and returns
               TensorFlow ``tf.Variable`` and ``tf.tensor`` objects.
 
@@ -64,7 +64,7 @@ class QNode:
               and returns NumPy arrays. It does not connect to any
               machine learning library automatically for backpropagation.
 
-        diff_method (str, None): the method of differentiation to use in the created QNode
+        diff_method (str): the method of differentiation to use in the created QNode
 
             * ``"best"``: Best available method. Uses classical backpropagation or the
               device directly to compute the gradient if supported, otherwise will use
@@ -846,15 +846,15 @@ def qnode(
         interface (str): The interface that will be used for classical backpropagation.
             This affects the types of objects that can be passed to/returned from the QNode:
 
-            * ``interface='autograd'``: Allows autograd to backpropogate
+            * ``"autograd"``: Allows autograd to backpropogate
               through the QNode. The QNode accepts default Python types
               (floats, ints, lists) as well as NumPy array arguments,
               and returns NumPy arrays.
 
-            * ``interface='torch'``: Allows PyTorch to backpropogate
+            * ``"torch"``: Allows PyTorch to backpropogate
               through the QNode. The QNode accepts and returns Torch tensors.
 
-            * ``interface='tf'``: Allows TensorFlow in eager mode to backpropogate
+            * ``"tf"``: Allows TensorFlow in eager mode to backpropogate
               through the QNode. The QNode accepts and returns
               TensorFlow ``tf.Variable`` and ``tf.tensor`` objects.
 
@@ -863,7 +863,7 @@ def qnode(
               and returns NumPy arrays. It does not connect to any
               machine learning library automatically for backpropagation.
 
-        diff_method (str, None): the method of differentiation to use in the created QNode.
+        diff_method (str): the method of differentiation to use in the created QNode.
 
             * ``"best"``: Best available method. Uses classical backpropagation or the
               device directly to compute the gradient if supported, otherwise will use


### PR DESCRIPTION
**Context:** The QNode docs for `diff_method` did not match current functionality.

**Description of the Change:** Removed `None` from the allowed argument types for the `QNode` since this option is not supported. Also updated the docstring for `interface` so it matched the formatting of the `diff_method`.  

**Benefits:** Docs are up to date!

**Possible Drawbacks:** None

**Related GitHub Issues:** None
