### PR TITLE
[WIP] Add fourth root of X gates.

### DIFF
--- a/pennylane/devices/default_mixed.py
+++ b/pennylane/devices/default_mixed.py
@@ -69,6 +69,7 @@ class DefaultMixed(QubitDevice):
         "S",
         "T",
         "SX",
+        "SSX",
         "CNOT",
         "SWAP",
         "CSWAP",

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -103,6 +103,7 @@ class DefaultQubit(QubitDevice):
         "S",
         "T",
         "SX",
+        "SSX",
         "CNOT",
         "SWAP",
         "CSWAP",

--- a/pennylane/ops/qubit.py
+++ b/pennylane/ops/qubit.py
@@ -376,6 +376,63 @@ class SX(Operation):
         return SX(wires=self.wires).inv()
 
 
+class SSX(Operation):
+    r"""SSX(wires)
+    The single-qubit fourth-root of X operator.
+
+    .. math:: SSX = X^{\frac{1}{4}} = \begin{bmatrix}
+            a + bi &   c - bi \\
+            c - bi &   a + bi \\
+        \end{bmatrix}.
+
+    where :math:`a = \frac{1}{2} + \frac{sqrt{2}}{4}`, :math:`b = \frac{1}{2\sqrt{2}}`, and
+    :math:`c = \frac{1}{2} - \frac{sqrt{2}}{4}`.
+
+    **Details:**
+
+    * Number of wires: 1
+    * Number of parameters: 0
+
+    Args:
+        wires (Sequence[int] or int): the wire the operation acts on
+    """
+    num_params = 0
+    num_wires = 1
+    par_domain = None
+
+    @classmethod
+    def _matrix(cls, *params):
+        return np.array(
+            [
+                [
+                    (2 + 1 / INV_SQRT2) / 4 + 1j * INV_SQRT2 / 2,
+                    (2 - 1 / INV_SQRT2) / 4 - 1j * INV_SQRT2 / 2,
+                ],
+                [
+                    (2 - 1 / INV_SQRT2) / 4 - 1j * INV_SQRT2 / 2,
+                    (2 + 1 / INV_SQRT2) / 4 + 1j * INV_SQRT2 / 2,
+                ],
+            ]
+        )
+
+    @classmethod
+    def _eigvals(cls, *params):
+        return np.array([1, INV_SQRT2 * (1 + 1j)])
+
+    @staticmethod
+    def decomposition(wires):
+        decomp_ops = [
+            RZ(np.pi / 2, wires=wires),
+            RY(np.pi / 4, wires=wires),
+            RZ(13 * np.pi / 4, wires=wires),
+            PhaseShift(-7 * np.pi / 4, wires=wires),
+        ]
+        return decomp_ops
+
+    def adjoint(self):
+        return SSX(wires=self.wires).inv()
+
+
 class CNOT(Operation):
     r"""CNOT(wires)
     The controlled-NOT operator
@@ -2764,6 +2821,7 @@ ops = {
     "S",
     "T",
     "SX",
+    "SSX",
     "CNOT",
     "CZ",
     "CY",

--- a/tests/ops/test_qubit_ops.py
+++ b/tests/ops/test_qubit_ops.py
@@ -358,6 +358,7 @@ class TestOperations:
             qml.RZ(2.774, wires=0),
             qml.S(wires=0),
             qml.SX(wires=0),
+            qml.SSX(wires=0),
             qml.T(wires=0),
             qml.CNOT(wires=[0, 1]),
             qml.CZ(wires=[0, 1]),
@@ -565,6 +566,28 @@ class TestOperations:
         assert res[1].data[0] == np.pi / 2
         assert res[2].data[0] == -np.pi
         assert res[3].data[0] == np.pi / 2
+
+        decomposed_matrix = np.linalg.multi_dot([i.matrix for i in reversed(res)])
+        assert np.allclose(decomposed_matrix, op.matrix, atol=tol, rtol=0)
+
+    def test_ssx_decomposition(self, tol):
+        """Tests that the decomposition of the SSX gate is correct"""
+        op = qml.SSX(wires=0)
+        res = op.decomposition(0)
+
+        assert len(res) == 4
+
+        assert all([res[i].wires == Wires([0]) for i in range(4)])
+
+        assert res[0].name == "RZ"
+        assert res[1].name == "RY"
+        assert res[2].name == "RZ"
+        assert res[3].name == "PhaseShift"
+
+        assert res[0].data[0] == np.pi / 2
+        assert res[1].data[0] == np.pi / 4
+        assert res[2].data[0] == 13 * np.pi / 4
+        assert res[3].data[0] == -7 * np.pi / 4
 
         decomposed_matrix = np.linalg.multi_dot([i.matrix for i in reversed(res)])
         assert np.allclose(decomposed_matrix, op.matrix, atol=tol, rtol=0)


### PR DESCRIPTION
**Context:** Elementary decomposition of some operations (notably, the 3-controlled NOT and consequently `DoubleExcitation` gates) requires the gate $W$ such that $W^4 = X$.  

**Description of the Change:** Adds new gates `SSX` and `ControlledSSX` and their decompositions.

**Benefits:** These gates can now be used in decompositions.

**Possible Drawbacks:** I'm not in love with the name `SSX`, open to alternative suggestions.

**Related GitHub Issues:** #1275 , #1278 
