### PR TITLE
Relocate openfermion imports and extract PySCF dependency

### DIFF
--- a/qchem/pennylane_qchem/qchem/obs.py
+++ b/qchem/pennylane_qchem/qchem/obs.py
@@ -16,8 +16,6 @@ values can be used to simulate molecular properties.
 """
 # pylint: disable=too-many-arguments, too-few-public-methods
 import numpy as np
-from openfermion.ops import FermionOperator
-from openfermion.transforms import bravyi_kitaev, jordan_wigner
 
 from . import structure
 
@@ -192,6 +190,8 @@ def spin2(electrons, orbitals, mapping="jordan_wigner", wires=None):
     + (0.125) [Xw0 Yw1 Xw2 Yw3]
     """
 
+    from openfermion.ops import FermionOperator
+
     if electrons <= 0:
         raise ValueError(
             "'electrons' must be greater than 0; got for 'electrons' {}".format(electrons)
@@ -295,6 +295,9 @@ def observable(fermion_ops, init_term=0, mapping="jordan_wigner", wires=None):
     + (-0.075) [Z0 Z2]
     """
 
+    from openfermion.ops import FermionOperator
+    from openfermion.transforms import bravyi_kitaev, jordan_wigner
+
     if mapping.strip().lower() not in ("jordan_wigner", "bravyi_kitaev"):
         raise TypeError(
             "The '{}' transformation is not available. \n "
@@ -360,6 +363,8 @@ def spin_z(orbitals, mapping="jordan_wigner", wires=None):
     + (0.25) [Z3]
     """
 
+    from openfermion.ops import FermionOperator
+
     if orbitals <= 0:
         raise ValueError(
             "'orbitals' must be greater than 0; got for 'orbitals' {}".format(orbitals)
@@ -423,6 +428,8 @@ def particle_number(orbitals, mapping="jordan_wigner", wires=None):
     + (-0.5) [Zw2]
     + (-0.5) [Zw3]
     """
+
+    from openfermion.ops import FermionOperator
 
     if orbitals <= 0:
         raise ValueError(
@@ -496,6 +503,8 @@ def one_particle(matrix_elements, core=None, active=None, cutoff=1.0e-12):
     -0.44829969610163756 [2^ 2] +
     -0.44829969610163756 [3^ 3]
     """
+
+    from openfermion.ops import FermionOperator
 
     orbitals = matrix_elements.shape[0]
 
@@ -667,6 +676,8 @@ def two_particle(matrix_elements, core=None, active=None, cutoff=1.0e-12):
     + 0.08950028803070323 [3^ 3^ 1 1]
     + 0.352552816086392 [3^ 3^ 3 3]
     """
+
+    from openfermion.ops import FermionOperator
 
     orbitals = matrix_elements.shape[0]
 

--- a/qchem/pennylane_qchem/qchem/structure.py
+++ b/qchem/pennylane_qchem/qchem/structure.py
@@ -18,10 +18,6 @@ import subprocess
 from shutil import copyfile
 
 import numpy as np
-from openfermion import MolecularData, QubitOperator
-from openfermion.transforms import bravyi_kitaev, get_fermion_operator, jordan_wigner
-from openfermionpsi4 import run_psi4
-from openfermionpyscf import run_pyscf
 
 import pennylane as qml
 from pennylane import Hamiltonian
@@ -293,6 +289,8 @@ def meanfield(
     >>> meanfield(symbols, coordinates, name="h2")
     ./pyscf/sto-3g/h2
     """
+    
+    from openfermion import MolecularData
 
     if coordinates.size != 3 * len(symbols):
         raise ValueError(
@@ -328,9 +326,11 @@ def meanfield(
     molecule = MolecularData(geometry, basis, mult, charge, filename=path_to_file)
 
     if package == "psi4":
+        from openfermionpsi4 import run_psi4
         run_psi4(molecule, run_scf=1, verbose=0, tolerate_error=1)
 
     if package == "pyscf":
+        from openfermionpyscf import run_pyscf
         run_pyscf(molecule, run_scf=1, verbose=0)
 
     return path_to_file
@@ -500,6 +500,9 @@ def decompose(hf_file, mapping="jordan_wigner", core=None, active=None):
     (-0.2427428049645989+0j) [Z2]
     """
 
+    from openfermion import MolecularData
+    from openfermion.transforms import bravyi_kitaev, get_fermion_operator, jordan_wigner
+
     # loading HF data from the hdf5 file
     molecule = MolecularData(filename=hf_file.strip())
 
@@ -613,6 +616,8 @@ def _terms_to_qubit_operator(coeffs, ops, wires=None):
     0.1 [X0] +
     0.2 [Y0 Z2]
     """
+    from openfermion import QubitOperator
+
     all_wires = Wires.all_wires([op.wires for op in ops], sort=True)
 
     if wires is not None:
@@ -820,7 +825,8 @@ def molecular_hamiltonian(
     + (0.12293305056183801) [Z1 Z3]
     + (0.176276408043196) [Z2 Z3]
     """
-
+    from openfermion import MolecularData
+    
     hf_file = meanfield(symbols, coordinates, name, charge, mult, basis, package, outpath)
 
     molecule = MolecularData(filename=hf_file)


### PR DESCRIPTION
WIP PR. 
- Relocate OpenFermion import statements to reduce the time to import PennyLane.
- Extract PySCF dependency from PennyLane.