### PR TITLE
Optimal choice of `apply_unitary` versus `apply_unitary_einsum`

### DIFF
--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -222,8 +222,8 @@ class DefaultQubit(QubitDevice):
 
         if isinstance(operation, DiagonalOperation):
             return self._apply_diagonal_unitary(state, matrix, wires)
-        if len(wires) <= 2:
-            # Einsum is faster for small gates
+        if (self.num_wires<7) or (len(wires) <= 2):
+            # Einsum is faster for small gates or smaller states
             return self._apply_unitary_einsum(state, matrix, wires)
 
         return self._apply_unitary(state, matrix, wires)
@@ -611,7 +611,7 @@ class DefaultQubit(QubitDevice):
         r"""Apply multiplication of a matrix to subsystems of the quantum state.
 
         This function uses einsum instead of tensordot. This approach is only
-        faster for single- and two-qubit gates.
+        faster for single- and two-qubit gates, or when total wires is less than 7.
 
         Args:
             state (array[complex]): input state


### PR DESCRIPTION
Upon investigating the differences between `dev.apply_unitary` and `dev.apply_unitary_einsum` on `"default.qubit"`, I believe the threshold for choosing between the two should be changed.  For lower device sizes, `einsum` is faster for all gate sizes.  Only above 8 device wires does `tensordot` become more efficient for larger gate sizes.

This profiling was done with a matrix generated by `scipy.stats.unitary_group.rvs(2**ii, random_state=5043)`. Seed does marginally affect the timing, but it does not switch the qualitative behaviour particularly much.

"Low" indicates gate wires `(0, 1, .., (gate_wires-1)`, whereas "high" indicates numbering `(device_wires-1, ..., device_wires-1-gate_wires)`.  I wanted to control for wire ordering, as lower dimensions may be easier to sum over.

![image](https://user-images.githubusercontent.com/6364575/118296518-ae7c1080-b4a2-11eb-868b-e1d8ce700a28.png)

![image](https://user-images.githubusercontent.com/6364575/118296380-8391bc80-b4a2-11eb-8c7c-2060653afab5.png)

![image](https://user-images.githubusercontent.com/6364575/118296397-8ab8ca80-b4a2-11eb-8bce-3f56090513a0.png)

I'll will continue this comparison for PyTorch, JAX, and TensorFlow.