### PR TITLE
[unitaryHACK] Toffoli Decomposition

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 <h3>New features since last release</h3>
 
+* The `qml.Toffoli` operation now has a decomposition over elementary gates. 
+  [(#1320)](https://github.com/PennyLaneAI/pennylane/pull/1320)
+
 * The `qml.SWAP`  operation now has a decomposition over elementary gates. [(#1329)](https://github.com/PennyLaneAI/pennylane/pull/1329)
 
 * Added functionality for constructing and manipulating the Pauli group
@@ -252,7 +255,7 @@ random_mat2 = rng.standard_normal(3, requires_grad=False)
 
 This release contains contributions from (in alphabetical order):
 
-Vishnu Ajith, Thomas Bromley, Olivia Di Matteo, Diego Guala, Anthony Hayes, Josh Izaac, Brian Shi, Antal Száva, Pavan Jayasinha
+Vishnu Ajith, Thomas Bromley, Olivia Di Matteo, Tanya Garg, Diego Guala, Anthony Hayes, Josh Izaac, Brian Shi, Antal Száva, Pavan Jayasinha
 
 # Release 0.15.1 (current release)
 

--- a/pennylane/ops/qubit.py
+++ b/pennylane/ops/qubit.py
@@ -677,22 +677,22 @@ class Toffoli(Operation):
 
     @staticmethod
     def decomposition(wires):
-        decomp_ops = [ 
-            Hadamard(wires=wires[2]), 
-            CNOT(wires=[wires[1], wires[2]]),  
-            T(wires=wires[2]).inv(),
-            CNOT(wires=[wires[0], wires[2]]), 
-            T(wires=wires[2]), 
+        decomp_ops = [
+            Hadamard(wires=wires[2]),
             CNOT(wires=[wires[1], wires[2]]),
             T(wires=wires[2]).inv(),
-            CNOT(wires=[wires[0], wires[2]]), 
-            T(wires=wires[2]), 
+            CNOT(wires=[wires[0], wires[2]]),
+            T(wires=wires[2]),
+            CNOT(wires=[wires[1], wires[2]]),
+            T(wires=wires[2]).inv(),
+            CNOT(wires=[wires[0], wires[2]]),
+            T(wires=wires[2]),
             T(wires=wires[1]),
-            CNOT(wires=[wires[0], wires[1]]), 
-            Hadamard(wires=wires[2]), 
+            CNOT(wires=[wires[0], wires[1]]),
+            Hadamard(wires=wires[2]),
             T(wires=wires[0]),
             T(wires=wires[1]).inv(),
-            CNOT(wires=[wires[0], wires[1]]), 
+            CNOT(wires=[wires[0], wires[1]])
         ]
         return decomp_ops
 

--- a/pennylane/ops/qubit.py
+++ b/pennylane/ops/qubit.py
@@ -692,7 +692,7 @@ class Toffoli(Operation):
             Hadamard(wires=wires[2]),
             T(wires=wires[0]),
             T(wires=wires[1]).inv(),
-            CNOT(wires=[wires[0], wires[1]])
+            CNOT(wires=[wires[0], wires[1]]),
         ]
         return decomp_ops
 

--- a/pennylane/ops/qubit.py
+++ b/pennylane/ops/qubit.py
@@ -675,6 +675,27 @@ class Toffoli(Operation):
     def _matrix(cls, *params):
         return cls.matrix
 
+    @staticmethod
+    def decomposition(wires):
+        decomp_ops = [ 
+            Hadamard(wires=wires[2]), 
+            CNOT(wires=[wires[1], wires[2]]),  
+            T(wires=wires[2]).inv(),
+            CNOT(wires=[wires[0], wires[2]]), 
+            T(wires=wires[2]), 
+            CNOT(wires=[wires[1], wires[2]]),
+            T(wires=wires[2]).inv(),
+            CNOT(wires=[wires[0], wires[2]]), 
+            T(wires=wires[2]), 
+            T(wires=wires[1]),
+            CNOT(wires=[wires[0], wires[1]]), 
+            Hadamard(wires=wires[2]), 
+            T(wires=wires[0]),
+            T(wires=wires[1]).inv(),
+            CNOT(wires=[wires[0], wires[1]]), 
+        ]
+        return decomp_ops
+
     def adjoint(self):
         return Toffoli(wires=self.wires)
 

--- a/tests/ops/test_qubit_ops.py
+++ b/tests/ops/test_qubit_ops.py
@@ -688,7 +688,7 @@ class TestOperations:
     def test_toffoli_decomposition(self, tol):
         """Tests that the decomposition of the Toffoli gate is correct"""
         op = qml.Toffoli(wires=[0, 1, 2])
-        res = op.decompostion(op.wires)
+        res = op.decomposition(op.wires)
 
         assert len(res) == 15
 

--- a/tests/ops/test_qubit_ops.py
+++ b/tests/ops/test_qubit_ops.py
@@ -2485,7 +2485,7 @@ class TestMultiControlledX:
             qml.MultiControlledX(
                 control_wires=control_wires, wires=target_wire, work_wires=work_wires
             )
-        tape = tape.expand(depth=2)
+        tape = tape.expand(depth=1)
         assert all(not isinstance(op, qml.MultiControlledX) for op in tape.operations)
 
         @qml.qnode(dev)

--- a/tests/ops/test_qubit_ops.py
+++ b/tests/ops/test_qubit_ops.py
@@ -714,7 +714,7 @@ class TestOperations:
                     [0, 0, 0, 0, 0, 1, 0, 0],
                     [0, 0, 0, 0, 1, 0, 0, 0],
                     [0, 0, 0, 0, 0, 0, 0, 1],
-                    [0, 0, 0, 0, 0, 0, 1, 0],
+                    [0, 0, 0, 0, 0, 0, 1, 0]
                     ]))
 
         decomposed_matrix = np.linalg.multi_dot(mats)

--- a/tests/ops/test_qubit_ops.py
+++ b/tests/ops/test_qubit_ops.py
@@ -2485,7 +2485,7 @@ class TestMultiControlledX:
             qml.MultiControlledX(
                 control_wires=control_wires, wires=target_wire, work_wires=work_wires
             )
-        tape = tape.expand(depth=1)
+        tape = tape.expand(depth=2)
         assert all(not isinstance(op, qml.MultiControlledX) for op in tape.operations)
 
         @qml.qnode(dev)

--- a/tests/ops/test_qubit_ops.py
+++ b/tests/ops/test_qubit_ops.py
@@ -702,19 +702,9 @@ class TestOperations:
             elif i.wires == Wires([0]):
                 mats.append(np.kron(i.matrix, np.eye(4)))
             elif i.wires == Wires([0, 1]) and i.name == "CNOT":
-                mats.append(
-                    np.kron(
-                        np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]]),
-                        np.eye(2),
-                    )
-                )
+                mats.append(np.kron(i.matrix, np.eye(2)))
             elif i.wires == Wires([1, 2]) and i.name == "CNOT":
-                mats.append(
-                    np.kron(
-                        np.eye(2),
-                        np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]]),
-                    )
-                )
+                mats.append(np.kron(np.eye(2), i.matrix))
             elif i.wires == Wires([0, 2]) and i.name == "CNOT":
                 mats.append(
                     np.array(
@@ -2451,7 +2441,7 @@ class TestMultiControlledX:
                 work_wires=work_wires,
                 control_values=control_values,
             )
-        tape = tape.expand(depth=2)
+        tape = tape.expand(depth=1)
         assert all(not isinstance(op, qml.MultiControlledX) for op in tape.operations)
 
         @qml.qnode(dev)

--- a/tests/ops/test_qubit_ops.py
+++ b/tests/ops/test_qubit_ops.py
@@ -685,6 +685,44 @@ class TestOperations:
 
         assert np.allclose(decomposed_matrix, op.matrix, atol=tol, rtol=0)
 
+    def test_toffoli_decompostion(self, tol):
+        """Tests that the decomposition of the Toffoli gate is correct"""
+        op = qml.Toffoli(wires=[0,1,2])
+        res = op.decompostion(op.wires)
+
+        assert len(res) == 15
+
+        mats = []
+
+        for i in reversed(res):
+            if i.wires == Wires([2]):
+                mats.append(np.kron(np.eye(4), i.matrix))
+            elif i.wires == Wires([1]):
+                mats.append(np.kron(np.eye(2),np.kron(i.matrix, np.eye(2))))
+            elif i.wires == Wires([0]):
+                mats.append(np.kron(i.matrix, np.eye(4)))
+            elif i.wires == Wires([0, 1]) and i.name == "CNOT":
+                mats.append(np.kron(np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]]), np.eye(2)))
+            elif i.wires == Wires([1, 2]) and i.name == "CNOT":
+                mats.append(np.kron(np.eye(2), np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]])))
+            elif i.wires == Wires([0, 2]) and i.name == "CNOT":
+                mats.append(np.array([
+                    [1, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 1, 0, 0, 0, 0, 0, 0], 
+                    [0, 0, 1, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 1, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 1, 0, 0],
+                    [0, 0, 0, 0, 1, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 1],
+                    [0, 0, 0, 0, 0, 0, 1, 0],
+                    ]))
+
+        decomposed_matrix = np.linalg.multi_dot(mats)
+
+        assert np.allclose(decomposed_matrix, op.matrix, atol=tol, rtol=0)
+
+
+
     def test_phase_shift(self, tol):
         """Test phase shift is correct"""
 

--- a/tests/ops/test_qubit_ops.py
+++ b/tests/ops/test_qubit_ops.py
@@ -685,7 +685,7 @@ class TestOperations:
 
         assert np.allclose(decomposed_matrix, op.matrix, atol=tol, rtol=0)
 
-    def test_toffoli_decompostion(self, tol):
+    def test_toffoli_decomposition(self, tol):
         """Tests that the decomposition of the Toffoli gate is correct"""
         op = qml.Toffoli(wires=[0, 1, 2])
         res = op.decompostion(op.wires)

--- a/tests/ops/test_qubit_ops.py
+++ b/tests/ops/test_qubit_ops.py
@@ -687,7 +687,7 @@ class TestOperations:
 
     def test_toffoli_decompostion(self, tol):
         """Tests that the decomposition of the Toffoli gate is correct"""
-        op = qml.Toffoli(wires=[0,1,2])
+        op = qml.Toffoli(wires=[0, 1, 2])
         res = op.decompostion(op.wires)
 
         assert len(res) == 15
@@ -698,30 +698,42 @@ class TestOperations:
             if i.wires == Wires([2]):
                 mats.append(np.kron(np.eye(4), i.matrix))
             elif i.wires == Wires([1]):
-                mats.append(np.kron(np.eye(2),np.kron(i.matrix, np.eye(2))))
+                mats.append(np.kron(np.eye(2), np.kron(i.matrix, np.eye(2))))
             elif i.wires == Wires([0]):
                 mats.append(np.kron(i.matrix, np.eye(4)))
             elif i.wires == Wires([0, 1]) and i.name == "CNOT":
-                mats.append(np.kron(np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]]), np.eye(2)))
+                mats.append(
+                    np.kron(
+                        np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]]),
+                        np.eye(2),
+                    )
+                )
             elif i.wires == Wires([1, 2]) and i.name == "CNOT":
-                mats.append(np.kron(np.eye(2), np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]])))
+                mats.append(
+                    np.kron(
+                        np.eye(2),
+                        np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]]),
+                    )
+                )
             elif i.wires == Wires([0, 2]) and i.name == "CNOT":
-                mats.append(np.array([
-                    [1, 0, 0, 0, 0, 0, 0, 0],
-                    [0, 1, 0, 0, 0, 0, 0, 0], 
-                    [0, 0, 1, 0, 0, 0, 0, 0],
-                    [0, 0, 0, 1, 0, 0, 0, 0],
-                    [0, 0, 0, 0, 0, 1, 0, 0],
-                    [0, 0, 0, 0, 1, 0, 0, 0],
-                    [0, 0, 0, 0, 0, 0, 0, 1],
-                    [0, 0, 0, 0, 0, 0, 1, 0]
-                    ]))
+                mats.append(
+                    np.array(
+                        [
+                            [1, 0, 0, 0, 0, 0, 0, 0],
+                            [0, 1, 0, 0, 0, 0, 0, 0],
+                            [0, 0, 1, 0, 0, 0, 0, 0],
+                            [0, 0, 0, 1, 0, 0, 0, 0],
+                            [0, 0, 0, 0, 0, 1, 0, 0],
+                            [0, 0, 0, 0, 1, 0, 0, 0],
+                            [0, 0, 0, 0, 0, 0, 0, 1],
+                            [0, 0, 0, 0, 0, 0, 1, 0],
+                        ]
+                    )
+                )
 
         decomposed_matrix = np.linalg.multi_dot(mats)
 
         assert np.allclose(decomposed_matrix, op.matrix, atol=tol, rtol=0)
-
-
 
     def test_phase_shift(self, tol):
         """Test phase shift is correct"""

--- a/tests/transforms/test_control.py
+++ b/tests/transforms/test_control.py
@@ -87,7 +87,7 @@ def test_nested_control():
     assert len(tape.operations) == 1
     op = tape.operations[0]
     assert isinstance(op, ControlledOperation)
-    new_tape = expand_tape(tape, 3)
+    new_tape = expand_tape(tape, 2)
     assert_equal_operations(new_tape.operations, [qml.Toffoli(wires=[7, 3, 0])])
 
 
@@ -99,7 +99,7 @@ def test_multi_control():
     assert len(tape.operations) == 1
     op = tape.operations[0]
     assert isinstance(op, ControlledOperation)
-    new_tape = expand_tape(tape, 3)
+    new_tape = expand_tape(tape, 1)
     assert_equal_operations(new_tape.operations, [qml.Toffoli(wires=[7, 3, 0])])
 
 


### PR DESCRIPTION
**Context:**
Added Toffoli decomposition along with tests

**Description of the Change:**
The Toffoli decomposition is done by using Hadamard, CNOT, T and T.inv() gates according to the following circuit
![image](https://user-images.githubusercontent.com/62295887/118373479-b1771e00-b5d4-11eb-989d-1fc31d168464.png)

Made changes in `pennylane/ops/qubit.py` and `tests/ops/test_qubit_ops.py`

*Note*: the tape expansion in some test files (`tests/ops/test_qubit_ops.py` and `tests/transforms/test_control.py`) were adjusted. This was required because the test cases assumed that Toffoli had no decomposition, yielded incorrect results and failed the tests.

**Benefits:**
The user can now see the decomposition of the Toffoli gate into simpler gates

**Related GitHub Issues:**
Fixes #1305 