### PR TITLE
Update the bug assignment action to label unitary hack issue

### DIFF
--- a/.github/workflows/assign_bugs.yml
+++ b/.github/workflows/assign_bugs.yml
@@ -10,5 +10,8 @@ jobs:
       - uses: Naturalclar/issue-action@v2.0.2
         with:
           title-or-body: "title"
-          parameters: '[ {"keywords": ["[BUG]", "bug"], "labels": ["bug :bug:"], "assignees": ["antalszava"]}]'
+          parameters: '[
+                         {"keywords": ["[BUG]", "bug"], "labels": ["bug :bug:"], "assignees": ["antalszava"]},
+                         {"keywords": ["unitaryHACK", "unitaryhack"], "labels": ["unitaryhack"], "assignees": ["antalszava"]}
+                        ]'
           github-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Two examples:

https://github.com/antalszava/bugs-scan/issues/20
https://github.com/antalszava/bugs-scan/issues/19

```python
parameters: '[ {"keywords": ["[BUG]", "bug"], "labels": ["bug :bug:"], "assignees": ["antalszava"]}, {"keywords": ["unitaryHACK", "unitaryhack"], "labels": ["unitaryhack"], "assignees": ["antalszava"]}]'
          github-token: "${{ secrets.GITHUB_TOKEN }}"
```