### PR TITLE
Minor docstring fix

### DIFF
--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -543,7 +543,7 @@ class Operation(Operator):
             idx (int): parameter index
 
         Returns:
-            list[[float, float, float]]: list of multiplier, coefficient, shift for each execution
+            list[[float, float, float]]: list of multiplier, coefficient, shift for each term in the gradient recipe
         """
         # get the gradient recipe for this parameter
         recipe = self.grad_recipe[idx]

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -543,7 +543,7 @@ class Operation(Operator):
             idx (int): parameter index
 
         Returns:
-            float, float: multiplier, shift
+            list[[float, float, float]]: list of multiplier, coefficient, shift for each execution
         """
         # get the gradient recipe for this parameter
         recipe = self.grad_recipe[idx]
@@ -553,7 +553,7 @@ class Operation(Operator):
         a = 1
 
         # We set the default recipe following:
-        # ∂f(x) = c*f(x+s) - c*f(x-s)
+        # ∂f(x) = c*f(a*x+s) - c*f(a*x-s)
         # where we express a positive and a negative shift by default
         default_param_shift = [[multiplier, a, shift], [-multiplier, a, -shift]]
         param_shift = default_param_shift if recipe is None else recipe


### PR DESCRIPTION
The docstring for `Operation.get_parameter_shift` was incorrect, as it implied that the function would only return two floats.

This corrects it to specify what is actually getting returned.