### PR TITLE
Fix drawing a QNode with no operations

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -266,6 +266,9 @@ random_mat2 = rng.standard_normal(3, requires_grad=False)
 
 <h3>Bug fixes</h3>
 
+* Fixes drawing QNodes with no operations.
+  [(#13)](https://github.com/PennyLaneAI/pennylane/pull/13)
+
 * Fixes incorrect wires in the decomposition of the `ControlledPhaseShift` operation.
   [(#1338)](https://github.com/PennyLaneAI/pennylane/pull/1338)
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -267,7 +267,7 @@ random_mat2 = rng.standard_normal(3, requires_grad=False)
 <h3>Bug fixes</h3>
 
 * Fixes drawing QNodes with no operations.
-  [(#13)](https://github.com/PennyLaneAI/pennylane/pull/13)
+  [(#1354)](https://github.com/PennyLaneAI/pennylane/pull/1354)
 
 * Fixes incorrect wires in the decomposition of the `ControlledPhaseShift` operation.
   [(#1338)](https://github.com/PennyLaneAI/pennylane/pull/1338)

--- a/pennylane/circuit_drawer/grid.py
+++ b/pennylane/circuit_drawer/grid.py
@@ -176,7 +176,7 @@ class Grid:
         Returns:
             Grid: A copy of the Grid
         """
-        return Grid(self.raw_grid.copy())
+        return Grid(self.raw_grid.copy()) if self.raw_grid is not None else Grid()
 
     def append_grid_by_layers(self, other_grid):
         """Append the layers of another Grid to this Grid.

--- a/tests/circuit_drawer/test_circuit_drawer.py
+++ b/tests/circuit_drawer/test_circuit_drawer.py
@@ -913,3 +913,21 @@ class TestWireOrdering:
 
         with pytest.raises(ValueError, match="contains wires not contained on the device"):
             res = circuit.draw(wire_order=["q2", 5])
+
+    def test_no_ops_draws(self):
+        """Test that a QNode with no operations still draws correctly"""
+        dev = qml.device("default.qubit", wires=3)
+
+        @qml.qnode(dev)
+        def qnode():
+            return qml.expval(qml.PauliX(wires=[0]) @ qml.PauliX(wires=[1]) @ qml.PauliX(wires=[2]))
+
+        qnode()
+        res = qnode.draw()
+        expected = [
+            " 0: ──╭┤ ⟨X ⊗ X ⊗ X⟩ \n",
+            " 1: ──├┤ ⟨X ⊗ X ⊗ X⟩ \n",
+            " 2: ──╰┤ ⟨X ⊗ X ⊗ X⟩ \n",
+        ]
+
+        assert res == "".join(expected)


### PR DESCRIPTION
**Context**
QNodes with no operations raises an error when drawn.

This error boils down to the grid that the `CircuitDrawer` creates. There is a copying operation that is called on a `None` type object (due to having no operations).

**Changes**

Catches the case where the grid is `None` and no copying of the internal grid happens, instead, an empty grid is used.

**Ralated Issues**
#1326 