### PR TITLE
Remove pyscf requirement from docs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -12,7 +12,6 @@
 #
 # All configuration values have a default; values that are commented out
 # serve to show the default.
-import pyscf
 import sys, os, re
 
 # If extensions (or modules to document with autodoc) are in another directory,


### PR DESCRIPTION
At the moment, `pyscf` is not listed in the `docs/requirements.txt` (nor in the `pennylane/requirements.txt`), but it is imported in the `docs/conf.py` file. This PR removes the import.