### PR TITLE
Fixing a bug in the documentation of StronglyEntanglingLayers

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -359,6 +359,9 @@ random_mat2 = rng.standard_normal(3, requires_grad=False)
 
 <h3>Documentation</h3>
 
+* Fix typo in the documentation of qml.templates.layers.StronglyEntanglingLayers 
+  [(#1367)](https://github.com/PennyLaneAI/pennylane/pull/1367)
+
 * Fixed typo on TensorFlow interface documentation [(#1312)](https://github.com/PennyLaneAI/pennylane/pull/1312)
 
 * Fixed typos in the mathematical expressions in documentation of `qml.DoubleExcitation`.

--- a/pennylane/templates/layers/strongly_entangling.py
+++ b/pennylane/templates/layers/strongly_entangling.py
@@ -47,7 +47,7 @@ class StronglyEntanglingLayers(Operation):
         weights (tensor_like): weight tensor of shape ``(L, M, 3)``
         wires (Iterable): wires that the template acts on
         ranges (Sequence[int]): sequence determining the range hyperparameter for each subsequent layer; if None
-                                using :math:`r=l \mod M` for the :math:`l`th layer and :math:`M` wires.
+                                using :math:`r=l \mod M` for the :math:`l` th layer and :math:`M` wires.
         imprimitive (pennylane.ops.Operation): two-qubit gate to use, defaults to :class:`~pennylane.ops.CNOT`
 
     .. UsageDetails::


### PR DESCRIPTION
**Context:**
Fixing a bug in the documentation of StronglyEntanglingLayers, which causes some text to disappear

**Description of the Change:**
Added a space to exit math mode