### PR TITLE
Implement special handling on QubitDevice.var for Projector observable to improve memory usage

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -243,6 +243,8 @@ random_mat2 = rng.standard_normal(3, requires_grad=False)
 
 <h3>Improvements</h3>
 
+* Implemented special handle on QubitDevice.var for Projector observable
+
 * The `benchmark` module was deleted, since it was outdated and is superseded by
   the new separate [benchmark repository](https://github.com/PennyLaneAI/benchmark).
   [(#1343)](https://github.com/PennyLaneAI/pennylane/pull/1343)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -243,7 +243,8 @@ random_mat2 = rng.standard_normal(3, requires_grad=False)
 
 <h3>Improvements</h3>
 
-* Implemented special handle on QubitDevice.var for Projector observable
+* Implement special handling on QubitDevice.var for Projector observable to improve memory usage.
+  [(#1368)](https://github.com/PennyLaneAI/pennylane/pull/1368)
 
 * The `benchmark` module was deleted, since it was outdated and is superseded by
   the new separate [benchmark repository](https://github.com/PennyLaneAI/benchmark).

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -243,7 +243,7 @@ random_mat2 = rng.standard_normal(3, requires_grad=False)
 
 <h3>Improvements</h3>
 
-* Implement special handling on QubitDevice.var for Projector observable to improve memory usage.
+* Implement special handling for measuring the variance of Projector observables to improve memory usage.
   [(#1368)](https://github.com/PennyLaneAI/pennylane/pull/1368)
 
 * The `benchmark` module was deleted, since it was outdated and is superseded by

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -754,6 +754,14 @@ class QubitDevice(Device):
 
     def var(self, observable, shot_range=None, bin_size=None):
 
+        if observable.name == "Projector":
+            # branch specifically to handle the projector observable
+            idx = int("".join(str(i) for i in observable.parameters[0]), 2)
+            probs = self.probability(
+                wires=observable.wires, shot_range=shot_range, bin_size=bin_size
+            )
+            return probs[idx] - probs[idx] ** 2
+
         if self.shots is None:
             # exact variance value
             eigvals = self._asarray(observable.eigvals, dtype=self.R_DTYPE)


### PR DESCRIPTION
**Context:**
Currently, the ```QubitDevice.var``` compute the variance using ```dot(eigvals, prob)```.
Since the variance of a Projector observable simply depends on a single element of the probability vector, it would lead to much more efficient memory usage if the element is indexed directly without allocating memory for the ```eigvals``` array when a large number of wires is involved. 

**Description of the Change:**
Implement special handling on QubitDevice.var for Projector observable.

**Benefits:**
More efficient memory usage when a large number of wires is used. 

**Related GitHub PR:**
[PR#1356](https://github.com/PennyLaneAI/pennylane/pull/1356)