### PR TITLE
Fix bug where shots does not reset to None when temporarily changed

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -418,6 +418,10 @@ random_mat2 = rng.standard_normal(3, requires_grad=False)
 
 <h3>Bug fixes</h3>
 
+* Fixes bug where `shots=None` was not reset when changing shots temporarily in a QNode call 
+  like `circuit(0.1, shots=3)`.
+  [(#1392)](https://github.com/XanaduAI/pennylane/pull/1392)
+  
 * Fixes floating point errors with `diff_method="finite-diff"` and `order=1` when parameters are `float32`.
 [(#1381)](https://github.com/PennyLaneAI/pennylane/pull/1381)
 

--- a/pennylane/qnode.py
+++ b/pennylane/qnode.py
@@ -556,7 +556,7 @@ class QNode:
         # If shots specified in call but not in qfunc signature,
         # interpret it as device shots value for this call.
         # TODO: make this more functional by passing shots as qtape.execute(.., shots=shots).
-        original_shots = None
+        original_shots = -1
         if "shots" in kwargs and not self._qfunc_uses_shots_arg:
             original_shots = self.device.shots  # remember device shots
             # remove shots from kwargs and temporarily change on device
@@ -569,7 +569,8 @@ class QNode:
         # execute the tape
         res = self.qtape.execute(device=self.device)
 
-        if original_shots is not None:
+        # if shots was changed
+        if original_shots != -1:
             # reinstate default on device
             self.device.shots = original_shots
 

--- a/tests/tape/test_qnode.py
+++ b/tests/tape/test_qnode.py
@@ -899,15 +899,15 @@ class TestShots:
 
         # check that the circuit is analytic
         res1 = [circuit() for _ in range(100)]
-        assert np.std(res1) == 0.
+        assert np.std(res1) == 0.0
 
         # check that the circuit is temporary non-analytic
         res1 = [circuit(shots=1) for _ in range(100)]
-        assert np.std(res1) != 0.
+        assert np.std(res1) != 0.0
 
         # check that the circuit is analytic again
         res1 = [circuit() for _ in range(100)]
-        assert np.std(res1) == 0.
+        assert np.std(res1) == 0.0
 
     def test_no_shots_per_call_if_user_has_shots_qfunc_kwarg(self):
         """Tests that the per-call shots overwriting is suspended if user

--- a/tests/tape/test_qnode.py
+++ b/tests/tape/test_qnode.py
@@ -899,7 +899,7 @@ class TestShots:
 
         # check that the circuit is analytic
         res1 = [circuit() for _ in range(100)]
-        assert np.std(res1) == 0.
+        assert np.std(res1) == 0.0
         assert circuit.device._shots is None
 
         # check that the circuit is temporary non-analytic
@@ -908,7 +908,7 @@ class TestShots:
 
         # check that the circuit is analytic again
         res1 = [circuit() for _ in range(100)]
-        assert np.std(res1) == 0.
+        assert np.std(res1) == 0.0
         assert circuit.device._shots is None
 
     def test_no_shots_per_call_if_user_has_shots_qfunc_kwarg(self):

--- a/tests/tape/test_qnode.py
+++ b/tests/tape/test_qnode.py
@@ -873,8 +873,8 @@ class TestMutability:
 class TestShots:
     """Unittests for specifying shots per call."""
 
-    def test_specify_shots_per_call(self):
-        """Tests that shots can be set per call."""
+    def test_specify_shots_per_call_sample(self):
+        """Tests that shots can be set per call for a sample return type."""
         dev = qml.device("default.qubit", wires=1, shots=10)
 
         @qml.qnode(dev)
@@ -886,6 +886,28 @@ class TestShots:
         assert len(circuit(0.8, shots=2)) == 2
         assert len(circuit(0.8, shots=3178)) == 3178
         assert len(circuit(0.8)) == 10
+
+    def test_specify_shots_per_call_expval(self):
+        """Tests that shots can be set per call for an expectation value.
+        Note: this test has a vanishingly small probability to fail."""
+        dev = qml.device("default.qubit", wires=1, shots=None)
+
+        @qml.qnode(dev)
+        def circuit():
+            qml.Hadamard(wires=0)
+            return qml.expval(qml.PauliZ(wires=0))
+
+        # check that the circuit is analytic
+        res1 = [circuit() for _ in range(100)]
+        assert np.std(res1) == 0.
+
+        # check that the circuit is temporary non-analytic
+        res1 = [circuit(shots=1) for _ in range(100)]
+        assert np.std(res1) != 0.
+
+        # check that the circuit is analytic again
+        res1 = [circuit() for _ in range(100)]
+        assert np.std(res1) == 0.
 
     def test_no_shots_per_call_if_user_has_shots_qfunc_kwarg(self):
         """Tests that the per-call shots overwriting is suspended if user


### PR DESCRIPTION
 **Context:**

In PR #1075 we introduced a way to temporarily change the shots per call of a qnode. Due to a simple bug, the resetting to original shots value did not work if it was `None`.

**Description of the Change:**

Fix bug, add test.

**Possible Drawbacks:**

The test checks for analytic vs non-analytic behaviour by comparing the variance of a Hadamard circuit's expectation run 100 times, and has a vanishingly small probability of failing (I assume it is 2^100 or so :) - the probability of observing 100 ones or zeros in a coin toss)
