### PR TITLE
Update `qml.grad` docs: `requires_grad=False` raises when in `argnum`

### DIFF
--- a/pennylane/_grad.py
+++ b/pennylane/_grad.py
@@ -45,8 +45,7 @@ class grad:
         argnum (int, list(int), None): Which argument(s) to take the gradient
             with respect to. By default, the arguments themselves are used
             to determine differentiability, by examining the ``requires_grad``
-            property. Providing this keyword argument overrides this behaviour,
-            allowing argument differentiability to be defined manually for the returned gradient function.
+            property.
 
     Returns:
         function: The function that returns the gradient of the input


### PR DESCRIPTION
**Context**

The `qml.grad` function documentation mentions that the information carried in the `requires_grad` attribute might be overridden when specifying the `argnum` argument, i.e., differentiation can be performed even for parameters that have `requires_grad=False` if they are specified in `argnum`.

This seems to not be the case:
```python
import pennylane.tape
import pennylane as qml
from pennylane import numpy as np

dev = qml.device('default.qubit', wires=2)

@qml.qnode(dev)
def circuit(par, y):
    qml.QubitStateVector(par, wires=[0,1])
    qml.RY(y, wires=0)
    return qml.expval(qml.PauliZ(0))

p = np.array([1,0,0,0])
b =  np.array([0.3], requires_grad=False)
qml.grad(circuit, argnum=1)(p,b)
```
```
~/xanadu/pennylane/pennylane/numpy/tensor.py in tensor_to_arraybox(x, *args)
    285             return ArrayBox(x, *args)
    286 
--> 287         raise NonDifferentiableError(
    288             "{} is non-differentiable. Set the requires_grad attribute to True.".format(x)
    289         )

NonDifferentiableError: [0.3] is non-differentiable. Set the requires_grad attribute to True.
```

**Changes**

Adjusts the docs.