### PR TITLE
Warnings for adjoint diff with finite shots

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -577,7 +577,7 @@ random_mat2 = rng.standard_normal(3, requires_grad=False)
 
 <h3>Bug fixes</h3>
 
-* Warns when adjoint differentiation specified or called on a device with finite shots.
+* Warns when adjoint or reversible differentiation specified or called on a device with finite shots.
 [(#1406)](https://github.com/PennyLaneAI/pennylane/pull/1406)
 
 * Fixes a bug where multiple identical Hamiltonian terms will produce a

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -577,6 +577,8 @@ random_mat2 = rng.standard_normal(3, requires_grad=False)
 
 <h3>Bug fixes</h3>
 
+* Warns when adjoint differentiation specified or called on device with finite shots.
+
 * Fixes a bug where multiple identical Hamiltonian terms will produce a
   different result with ``optimize=True`` using ``ExpvalCost``.
   [(#1405)](https://github.com/XanaduAI/pennylane/pull/1405)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -577,7 +577,8 @@ random_mat2 = rng.standard_normal(3, requires_grad=False)
 
 <h3>Bug fixes</h3>
 
-* Warns when adjoint differentiation specified or called on device with finite shots.
+* Warns when adjoint differentiation specified or called on a device with finite shots.
+[(#1406)](https://github.com/PennyLaneAI/pennylane/pull/1406)
 
 * Fixes a bug where multiple identical Hamiltonian terms will produce a
   different result with ``optimize=True`` using ``ExpvalCost``.

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -857,7 +857,7 @@ class QubitDevice(Device):
         if self.shots is not None:
             warnings.warn(
                 "Requested adjoint differentiation to be computed with finite shots."
-                " This computation is always exact when using the adjoint differentiation method.",
+                " The derivative is always exact when using the adjoint differentiation method.",
                 UserWarning,
             )
 

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -856,8 +856,8 @@ class QubitDevice(Device):
 
         if self.shots is not None:
             warnings.warn(
-                "Adjoint diff called on device with finite shots. Adjoint diff always"
-                " calculated exactly.",
+                "Requested adjoint differentiation to be computed with finite shots."
+                " This computation is always exact when using the adjoint differentiation method.",
                 UserWarning,
             )
 

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -854,6 +854,13 @@ class QubitDevice(Device):
             if not hasattr(m.obs, "base_name"):
                 m.obs.base_name = None  # This is needed for when the observable is a tensor product
 
+        if self.shots is not None:
+            warnings.warn(
+                "Adjoint diff called on device with finite shots. Adjoint diff always"
+                " calculated exactly.",
+                UserWarning,
+            )
+
         # Initialization of state
         if starting_state is not None:
             ket = self._reshape(starting_state, [2] * self.num_wires)

--- a/pennylane/qnode.py
+++ b/pennylane/qnode.py
@@ -263,8 +263,8 @@ class QNode:
         This method attempts to determine support for differentiation
         methods using the following order:
 
-        * ``"backprop"``
         * ``"device"``
+        * ``"backprop"``
         * ``"parameter-shift"``
         * ``"finite-diff"``
 
@@ -386,6 +386,13 @@ class QNode:
                 f"The {device.short_name} device does not support reversible differentiation."
             )
 
+        if device.shots is not None:
+            warnings.warn(
+                "Requested reversible differentiation to be computed with finite shots."
+                " Reversible differentiation always calculated exactly.",
+                UserWarning,
+            )
+
         return ReversibleTape, interface, device, {"method": "analytic"}
 
     @staticmethod
@@ -421,8 +428,8 @@ class QNode:
 
         if device.shots is not None:
             warnings.warn(
-                "Adjoint diff requested on device with finite shots. Adjoint"
-                " diff always calculated exactly.",
+                "Requested adjoint differentiation to be computed with finite shots."
+                " Adjoint differentiation always calculated exactly.",
                 UserWarning,
             )
 

--- a/pennylane/qnode.py
+++ b/pennylane/qnode.py
@@ -419,6 +419,13 @@ class QNode:
                 f"The {device.short_name} device does not support adjoint differentiation."
             )
 
+        if device.shots is not None:
+            warnings.warn(
+                "Adjoint diff requested on device with finite shots. Adjoint"
+                " diff always calculated exactly.",
+                UserWarning,
+            )
+
         jac_options = {"method": "device", "jacobian_method": "adjoint_jacobian"}
         # reuse the forward pass
         # torch and tensorflow can cache the state

--- a/pennylane/tape/reversible.py
+++ b/pennylane/tape/reversible.py
@@ -18,6 +18,7 @@ Quantum tape that implements reversible backpropagation.
 import copy
 from functools import reduce
 from string import ascii_letters as ABC
+import warnings
 
 import numpy as np
 
@@ -35,7 +36,7 @@ class ReversibleTape(JacobianTape):
 
     .. note::
 
-        The reversible analytic differentation method has the following restrictions:
+        The reversible analytic differentiation method has the following restrictions:
 
         * As it requires knowledge of the statevector, only statevector simulator devices can be used.
 
@@ -246,6 +247,13 @@ class ReversibleTape(JacobianTape):
 
         # before each Jacobian call, so that the statevector is calculated only once.
         self._final_state = None
+        if device.shots is not None:
+            warnings.warn(
+                "Requested reversible differentiation to be computed with finite shots."
+                " Reversible differentiation always calculated exactly.",
+                UserWarning,
+            )
+
         return super().jacobian(device, params, **options)
 
     def analytic_pd(self, idx, params, **options):

--- a/tests/tape/test_qnode.py
+++ b/tests/tape/test_qnode.py
@@ -266,8 +266,48 @@ class TestValidation:
 
         dev = qml.device("default.qubit", wires=1, shots=1)
 
-        with pytest.warns(UserWarning, match="Adjoint diff requested on device with finite shots."):
+        with pytest.warns(
+            UserWarning, match="Requested adjoint differentiation to be computed with finite shots."
+        ):
             QNode._validate_adjoint_method(dev, "autograd")
+
+    def test_adjoint_finite_shots(self):
+        """Tests that UserWarning is raised on QNode construction when device has finite shots"""
+
+        dev = qml.device("default.qubit", wires=1, shots=1)
+
+        with pytest.warns(
+            UserWarning, match="Requested adjoint differentiation to be computed with finite shots."
+        ):
+
+            @qml.qnode(dev, diff_method="adjoint")
+            def circ():
+                return qml.expval(qml.PauliZ(0))
+
+    def test_validate_reversible_finite_shots(self):
+        """Test that a UserWarning is raised when device has finite shots"""
+
+        dev = qml.device("default.qubit", wires=1, shots=1)
+
+        with pytest.warns(
+            UserWarning,
+            match="Requested reversible differentiation to be computed with finite shots.",
+        ):
+            QNode._validate_reversible_method(dev, "autograd")
+
+    def test_reversible_finite_shots(self):
+        """Tests that UserWarning is raised on QNode construction when device has finite shots"""
+
+        dev = qml.device("default.qubit", wires=1, shots=1)
+
+        with pytest.warns(
+            UserWarning,
+            match="Requested reversible differentiation to be computed with finite shots.",
+        ):
+
+            @qml.qnode(dev, diff_method="reversible")
+            def circ():
+                return qml.expval(qml.PauliZ(0))
 
     def test_qnode_print(self):
         """Test that printing a QNode object yields the right information."""

--- a/tests/tape/test_qnode.py
+++ b/tests/tape/test_qnode.py
@@ -261,6 +261,14 @@ class TestValidation:
         with pytest.raises(ValueError, match="The default.gaussian device does not"):
             QNode._validate_adjoint_method(dev, "tf")
 
+    def test_validate_adjoint_finite_shots(self):
+        """Test that a UserWarning is raised when device has finite shots"""
+
+        dev = qml.device("default.qubit", wires=1, shots=1)
+
+        with pytest.warns(UserWarning, match="Adjoint diff requested on device with finite shots."):
+            QNode._validate_adjoint_method(dev, "autograd")
+
     def test_qnode_print(self):
         """Test that printing a QNode object yields the right information."""
         dev = qml.device("default.qubit", wires=1)

--- a/tests/tape/test_qnode.py
+++ b/tests/tape/test_qnode.py
@@ -272,7 +272,9 @@ class TestValidation:
             QNode._validate_adjoint_method(dev, "autograd")
 
     def test_adjoint_finite_shots(self):
-        """Tests that UserWarning is raised on QNode construction when device has finite shots"""
+        """Tests that UserWarning is raised with the adjoint differentiation method
+        on QNode construction when the device has finite shots
+        """
 
         dev = qml.device("default.qubit", wires=1, shots=1)
 
@@ -285,7 +287,9 @@ class TestValidation:
                 return qml.expval(qml.PauliZ(0))
 
     def test_validate_reversible_finite_shots(self):
-        """Test that a UserWarning is raised when device has finite shots"""
+        """Test that a UserWarning is raised when validating the reversible differentiation method
+        and using a device that has finite shots
+        """
 
         dev = qml.device("default.qubit", wires=1, shots=1)
 
@@ -296,7 +300,9 @@ class TestValidation:
             QNode._validate_reversible_method(dev, "autograd")
 
     def test_reversible_finite_shots(self):
-        """Tests that UserWarning is raised on QNode construction when device has finite shots"""
+        """Tests that UserWarning is raised with the reversible differentiation method
+        on QNode construction when the device has finite shots
+        """
 
         dev = qml.device("default.qubit", wires=1, shots=1)
 

--- a/tests/tape/test_reversible.py
+++ b/tests/tape/test_reversible.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Unit tests for the qubit parameter-shift QubitParamShiftTape"""
+"""Unit tests for the ReversibleTape"""
 import pytest
 from pennylane import numpy as np
 
@@ -159,6 +159,21 @@ class TestReversibleTape:
 
 class TestGradients:
     """Jacobian integration tests for qubit expectations."""
+
+    def test_finite_shots_warning(self):
+        """Test warning raised when calling jacobian with a device with finite shots"""
+
+        with ReversibleTape() as tape:
+            qml.RX(0.1, wires=0)
+            qml.expval(qml.PauliZ(0))
+
+        dev = qml.device("default.qubit", wires=1, shots=1)
+
+        with pytest.warns(
+            UserWarning,
+            match="Requested reversible differentiation to be computed with finite shots.",
+        ):
+            tape.jacobian(dev)
 
     @pytest.mark.parametrize("theta", np.linspace(-2 * np.pi, 2 * np.pi, 7))
     @pytest.mark.parametrize("G", [qml.RX, qml.RY, qml.RZ])

--- a/tests/tape/test_reversible.py
+++ b/tests/tape/test_reversible.py
@@ -161,7 +161,7 @@ class TestGradients:
     """Jacobian integration tests for qubit expectations."""
 
     def test_finite_shots_warning(self):
-        """Test warning raised when calling jacobian with a device with finite shots"""
+        """Test that a warning is raised when calling the jacobian with a device with finite shots"""
 
         with ReversibleTape() as tape:
             qml.RX(0.1, wires=0)
@@ -385,7 +385,7 @@ class TestQNodeIntegration:
     """Test QNode integration with the reversible method"""
 
     def test_finite_shots_warning(self):
-        """ "Tests that a warning is raised if used on a device with finite shots"""
+        """Test that a warning is raised when calling the jacobian with a device with finite shots"""
 
         dev = qml.device("default.qubit", wires=1, shots=1)
 

--- a/tests/tape/test_reversible.py
+++ b/tests/tape/test_reversible.py
@@ -384,6 +384,27 @@ class TestGradients:
 class TestQNodeIntegration:
     """Test QNode integration with the reversible method"""
 
+    def test_finite_shots_warning(self):
+        """ "Tests that a warning is raised if used on a device with finite shots"""
+
+        dev = qml.device("default.qubit", wires=1, shots=1)
+
+        with pytest.warns(
+            UserWarning,
+            match="Requested reversible differentiation to be computed with finite shots.",
+        ):
+
+            @qml.qnode(dev, diff_method="reversible")
+            def circ(x):
+                qml.RX(x, wires=0)
+                return qml.expval(qml.PauliZ(0))
+
+        with pytest.warns(
+            UserWarning,
+            match="Requested reversible differentiation to be computed with finite shots.",
+        ):
+            qml.grad(circ)(0.1)
+
     def test_qnode(self, mocker, tol):
         """Test that specifying diff_method allows the reversible
         method to be selected"""

--- a/tests/test_qubit_device_adjoint_jacobian.py
+++ b/tests/test_qubit_device_adjoint_jacobian.py
@@ -252,6 +252,25 @@ class TestAdjointJacobianQNode:
     def dev(self):
         return qml.device("default.qubit", wires=2)
 
+    def test_finite_shots_warning(self):
+        """Tests that a warning is raised when computing the adjoint diff on a device with finite shots"""
+
+        dev = qml.device("default.qubit", wires=1, shots=1)
+
+        with pytest.warns(
+            UserWarning, match="Requested adjoint differentiation to be computed with finite shots."
+        ):
+
+            @qml.qnode(dev, diff_method="adjoint")
+            def circ(x):
+                qml.RX(x, wires=0)
+                return qml.expval(qml.PauliZ(0))
+
+        with pytest.warns(
+            UserWarning, match="Requested adjoint differentiation to be computed with finite shots."
+        ):
+            qml.grad(circ)(0.1)
+
     def test_qnode(self, mocker, tol, dev):
         """Test that specifying diff_method allows the adjoint method to be selected"""
         args = np.array([0.54, 0.1, 0.5], requires_grad=True)

--- a/tests/test_qubit_device_adjoint_jacobian.py
+++ b/tests/test_qubit_device_adjoint_jacobian.py
@@ -47,7 +47,9 @@ class TestAdjointJacobian:
         with qml.tape.JacobianTape() as tape:
             qml.expval(qml.PauliZ(0))
 
-        with pytest.warns(UserWarning, match="Adjoint diff called on device with finite shots."):
+        with pytest.warns(
+            UserWarning, match="Requested adjoint differentiation to be computed with finite shots."
+        ):
             dev.adjoint_jacobian(tape)
 
     def test_unsupported_op(self, dev):

--- a/tests/test_qubit_device_adjoint_jacobian.py
+++ b/tests/test_qubit_device_adjoint_jacobian.py
@@ -39,6 +39,17 @@ class TestAdjointJacobian:
         with pytest.raises(qml.QuantumFunctionError, match="Adjoint differentiation method does"):
             dev.adjoint_jacobian(tape)
 
+    def test_finite_shots_warns(self):
+        """Tests warning raised when finite shots specified"""
+
+        dev = qml.device("default.qubit", wires=1, shots=1)
+
+        with qml.tape.JacobianTape() as tape:
+            qml.expval(qml.PauliZ(0))
+
+        with pytest.warns(UserWarning, match="Adjoint diff called on device with finite shots."):
+            dev.adjoint_jacobian(tape)
+
     def test_unsupported_op(self, dev):
         """Test if a QuantumFunctionError is raised for an unsupported operation, i.e.,
         multi-parameter operations that are not qml.Rot"""


### PR DESCRIPTION
Fixes Issue #1092 

When a QNode is created with a device with finite shots and adjoint differentiation, the User receives a warning reminding that adjoint differentiation is always exact.

When the adjoint jacobian method is called on a device with finite shots, the User also receives a warning to the same effect.

I only warn instead of interrupting with an error, as finite shots doesn't actually break the code.