### PR TITLE
Incrementing the version number to `0.17.0-dev`

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,4 +1,20 @@
-# Release 0.16.0-dev (development release)
+# Release 0.17.0-dev (development release)
+
+<h3>New features since last release</h3>
+
+<h3>Improvements</h3>
+
+<h3>Breaking changes</h3>
+
+<h3>Bug fixes</h3>
+
+<h3>Documentation</h3>
+
+<h3>Contributors</h3>
+
+This release contains contributions from (in alphabetical order):
+
+# Release 0.16.0 (current release)
 
 <h3>New features since last release</h3>
 
@@ -652,7 +668,7 @@ Christina Lee, Ryan Levy, Nahum Sá, Maria Schuld, Johannes Jakob Meyer, Brian S
 Vincent Wong, Alberto Maldonado, Ashish Panigrahi.
 
 
-# Release 0.15.1 (current release)
+# Release 0.15.1
 
 <h3>Bug fixes</h3>
 

--- a/pennylane/_version.py
+++ b/pennylane/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.16.0-dev"
+__version__ = "0.17.0-dev"

--- a/pennylane/beta/devices/default_tensor.py
+++ b/pennylane/beta/devices/default_tensor.py
@@ -99,8 +99,8 @@ class DefaultTensor(Device):
     # pylint: disable=attribute-defined-outside-init
     name = "PennyLane TensorNetwork simulator plugin"
     short_name = "default.tensor"
-    pennylane_requires = "0.16"
-    version = "0.16.0"
+    pennylane_requires = "0.17"
+    version = "0.17.0"
     author = "Xanadu Inc."
 
     _operation_map = {

--- a/pennylane/devices/default_gaussian.py
+++ b/pennylane/devices/default_gaussian.py
@@ -649,8 +649,8 @@ class DefaultGaussian(Device):
     """
     name = "Default Gaussian PennyLane plugin"
     short_name = "default.gaussian"
-    pennylane_requires = "0.16"
-    version = "0.16.0"
+    pennylane_requires = "0.17"
+    version = "0.17.0"
     author = "Xanadu Inc."
 
     _operation_map = {

--- a/pennylane/devices/default_mixed.py
+++ b/pennylane/devices/default_mixed.py
@@ -50,8 +50,8 @@ class DefaultMixed(QubitDevice):
 
     name = "Default mixed-state qubit PennyLane plugin"
     short_name = "default.mixed"
-    pennylane_requires = "0.16"
-    version = "0.16.0"
+    pennylane_requires = "0.17"
+    version = "0.17.0"
     author = "Xanadu Inc."
 
     operations = {

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -84,8 +84,8 @@ class DefaultQubit(QubitDevice):
 
     name = "Default qubit PennyLane plugin"
     short_name = "default.qubit"
-    pennylane_requires = "0.16"
-    version = "0.16.0"
+    pennylane_requires = "0.17"
+    version = "0.17.0"
     author = "Xanadu Inc."
 
     operations = {

--- a/qchem/CHANGELOG.md
+++ b/qchem/CHANGELOG.md
@@ -1,4 +1,18 @@
-# Release 0.16.0-dev
+# Release 0.17.0-dev
+
+<h3>New features</h3>
+
+<h3>Improvements</h3>
+
+<h3>Bug fixes</h3>
+
+<h3>Breaking changes</h3>
+
+<h3>Contributors</h3>
+
+This release contains contributions from (in alphabetical order):
+
+# Release 0.16.0
 
 <h3>New features</h3>
 

--- a/qchem/pennylane_qchem/_version.py
+++ b/qchem/pennylane_qchem/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.16.0-dev"
+__version__ = "0.17.0-dev"


### PR DESCRIPTION
Increments the version number to `0.17.0-dev`, similar to how it was done in https://github.com/PennyLaneAI/pennylane/pull/1241/.

Note: authors of new features should add changelog entries to the `0.17.0-dev` section and any improvements or bug fixes for `v0.16.0` should be merged into the [release candidate branch](https://github.com/PennyLaneAI/pennylane/tree/v0.16.0-rc0).

Organizing the changelog for the `v0.16.0` release will be a separate addition that will also be merged into `master`.