### PR TITLE
Fix div kernels

### DIFF
--- a/pennylane/kernels/postprocessing.py
+++ b/pennylane/kernels/postprocessing.py
@@ -295,6 +295,11 @@ def mitigate_depolarizing_noise(K, num_wires, method, use_entries=None):
             + noise_rates.reshape((1, len(K)))
             + noise_rates.reshape((len(K), 1))
         )
-        mitigated_matrix = (K - inverse_noise / dim) / (1 - inverse_noise)
+
+        # Substitute zeros with ones to avoid division issues
+        inv_noise_diff = 1 - inverse_noise
+        inv_noise_diff[inv_noise_diff==0] = 1
+
+        mitigated_matrix = (K - inverse_noise / dim) / inv_noise_diff
 
     return mitigated_matrix


### PR DESCRIPTION
**Context**
The following snippet part of the kernels example raises a warning for true divide:
```python
import pennylane as qml
from pennylane import numpy as np

num_wires = 6
wires = range(num_wires)

dev = qml.device('default.qubit', wires=num_wires)

@qml.qnode(dev)
def kernel_circuit(x1, x2):
    qml.templates.AngleEmbedding(x1, wires=wires)
    qml.adjoint(qml.templates.AngleEmbedding)(x2, wires=wires)
    return qml.probs(wires)

kernel = lambda x1, x2: kernel_circuit(x1, x2)[0]

# "Training feature vectors"
X_train = np.random.random((10, 6))

# Create symmetric square kernel matrix (for training)
K = qml.kernels.square_kernel_matrix(X_train, kernel)

# Add some (symmetric) Gaussian noise to the kernel matrix.
N = np.random.randn(10, 10)
K += (N + N.T) / 2

K6 = qml.kernels.mitigate_depolarizing_noise(K, num_wires, method='split_channel')

# "Testing feature vectors"
X_test = np.random.random((5, 6))
# Compute kernel between test and training data.
K_test = qml.kernels.kernel_matrix(X_train, X_test, kernel)
```
```python
/pennylane/pennylane/numpy/tensor.py:155: RuntimeWarning: divide by zero encountered in true_divide
  res = super().__array_ufunc__(ufunc, method, *args, **kwargs)
```
When adding the following snippet, a more descriptive traceback is obtained:
```python
import warnings
warnings.filterwarnings("error")
```
```
---> 28 K6 = qml.kernels.mitigate_depolarizing_noise(K, num_wires, method='split_channel')
     29 
     30 # "Testing feature vectors"

~/xanadu/pennylane/pennylane/kernels/postprocessing.py in mitigate_depolarizing_noise(K, num_wires, method, use_entries)
    296             + noise_rates.reshape((len(K), 1))
    297         )
--> 298         mitigated_matrix = (K - inverse_noise / dim) / (1 - inverse_noise)
    299 
    300     return mitigated_matrix

~/xanadu/pennylane/pennylane/numpy/tensor.py in __array_ufunc__(self, ufunc, method, *inputs, **kwargs)
    153         # call the ndarray.__array_ufunc__ method to compute the result
    154         # of the vectorized ufunc
--> 155         res = super().__array_ufunc__(ufunc, method, *args, **kwargs)
    156 
    157         if ufunc.nout == 1:

RuntimeWarning: divide by zero encountered in true_divide
```
**Changes**

* Changes the `mitigate_depolarizing_noise` method to account for cases where `1 - inverse_noise` denominator might have 0s.

*Note:* as the `kernels` module is being added in this release, no additional changelog entry is required for this change.

**Benefits**

No warnings.