### PR TITLE
Fix sampling test for projector observable

### DIFF
--- a/pennylane/devices/tests/test_measurements.py
+++ b/pennylane/devices/tests/test_measurements.py
@@ -816,8 +816,8 @@ class TestTensorSample:
 
         skip_if(dev, {"supports_tensor_observables": False})
 
-        theta = 0.432
-        phi = 0.123
+        theta = 1.432
+        phi = 1.123
         varphi = -0.543
 
         @qml.qnode(dev)


### PR DESCRIPTION
**Context:**

With the addition of the projector observables in https://github.com/PennyLaneAI/pennylane/pull/1356, tests for sampling were added to the device test suite. [This](https://github.com/PennyLaneAI/pennylane/blob/a458d9baf2cee166fce98a7fe02b216d4c5e1b32/pennylane/devices/tests/test_measurements.py#L806) test checks on line [853](https://github.com/PennyLaneAI/pennylane/blob/a458d9baf2cee166fce98a7fe02b216d4c5e1b32/pennylane/devices/tests/test_measurements.py#L853) that the output samples span the full set of expected results, i.e., `{-1, 0, 1}`.

However, the test is not likely to pass on all devices, even for devices that are working as expected:
- The probability of sampling `-1` is `0.0001583`. With the `20000` shots used by the device, we only expect a few counts of `-1`.
- Although this is a probabilistic test, the random seed is fixed in the tests. For the fixed random seed used, `default.qubit` luckily happens to pass, and passes every time since the seed is fixed.
- This is not guaranteed for other devices that may generate randomness differently. For example, for the Braket device this test fails because the fixed seed there happens to not generate a `-1`.

**Description of the Change:**

We just need to change the parameters so that the probability of generating each of `{-1, 0, 1}` is suitably high so that we expect nonzero counts for each with `20000` shots. This PR updates the parameters so that the probabilities are as follows:
```
{1.0: 0.3785898, -0.0: 0.5080185, -1.0: 0.1133917}
```

Code:
```python
import pennylane as qml
from collections import Counter

dev = qml.device("default.qubit", wires=3)

theta = 1.432
phi = 1.123
varphi = -0.543

@qml.qnode(dev)
def circuit(basis_state):
    qml.RX(theta, wires=[0])
    qml.RX(phi, wires=[1])
    qml.RX(varphi, wires=[2])
    qml.CNOT(wires=[0, 1])
    qml.CNOT(wires=[1, 2])
    return qml.sample(qml.PauliZ(wires=[0]) @ qml.Projector(basis_state, wires=[1, 2]))

shots = int(1e7)
res = circuit([0, 0], shots=shots)
counts = Counter(res.tolist())
probs = {k: v / shots for k, v in counts.items()}
print(probs)
```

**Possible Drawbacks:**

The parameters are now different for this specific test than the usual ones in the rest of `test_measurements.py`.