### PR TITLE
Fix backward pass on GPU in PyTorch interface

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -11,13 +11,16 @@
 
 <h3>Bug fixes</h3>
 
+* Fixed a bug in the `torch` interface that prevented gradients from being
+  computed on a GPU [(#1426)](https://github.com/PennyLaneAI/pennylane/pull/1426).
+
 <h3>Documentation</h3>
 
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):
 
-Ashish Panigrahi
+Olivia Di Matteo, Ashish Panigrahi
 
 
 # Release 0.16.0 (current release)

--- a/pennylane/interfaces/torch.py
+++ b/pennylane/interfaces/torch.py
@@ -194,9 +194,9 @@ class _TorchInterface(torch.autograd.Function):
         # back to the GPU if required.
         if dyv.is_cuda or jac_res.is_cuda:
             if not dyv.is_cuda:
-                dyv = dyv.cuda()
+                dyv = torch.as_tensor(dyv, device=jac_res.get_device())
             if not jac_res.is_cuda:
-                jac_res = jac_res.cuda()
+                jac_res = torch.as_tensor(jac_res, device=dyv.get_device())
 
         vjp = dyv @ jac_res
         vjp = torch.unbind(vjp.view(-1))

--- a/pennylane/interfaces/torch.py
+++ b/pennylane/interfaces/torch.py
@@ -184,7 +184,21 @@ class _TorchInterface(torch.autograd.Function):
     def backward(ctx, dy):  # pragma: no cover
         """Implements the backwards pass QNode vector-Jacobian product"""
         ctx.dy = dy
-        vjp = dy.view(1, -1) @ ctx.jacobian.apply(ctx, *ctx.saved_tensors)
+
+        dyv = dy.view(1, -1)
+        jac_res = ctx.jacobian.apply(ctx, *ctx.saved_tensors)
+
+        # When using CUDA, dyv seems to remain on the GPU, while the result
+        # of jac_res is returned on CPU, even though the saved_tensors arguments are
+        # themselves on the GPU. Check whether this has happened, and move things
+        # back to the GPU if required.
+        if dyv.is_cuda or jac_res.is_cuda:
+            if not dyv.is_cuda:
+                dyv = dyv.cuda()
+            if not jac_res.is_cuda:
+                jac_res = jac_res.cuda()
+
+        vjp = dyv @ jac_res
         vjp = torch.unbind(vjp.view(-1))
         return (None,) + tuple(vjp)
 


### PR DESCRIPTION
**Context:** A user has [reported an error](https://discuss.pennylane.ai/t/transfer-learning-error/1134/3) through the quantum transfer learning demo; when running on the GPU, the line
```
 vjp = dy.view(1, -1) @ ctx.jacobian.apply(ctx, *ctx.saved_tensors)
```
in `torch.py` yields:
```
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu! (when checking arugment for argument mat2 in method wrapper_mm)
```

The reason for the error was discovered to be that the result of `ctx.jacobian.apply()`was on the CPU, even when the tensors it acted on were on the GPU.

**Description of the Change:** Updated the `backward` method in the torch interface to split the above operation into two parts, and check the device of the results. If at least one of them was on the GPU, the other is moved to the GPU if it was not already there.

Note: I needed to use torch 1.9 to test this, due to the issue described [here](https://github.com/allenai/allennlp/issues/5064).

**Benefits:** Running on the GPU with the torch interface should now work. 

**Possible Drawbacks:** While this fix enables the demo to be run on the GPU, we cannot fully test it.

**Related GitHub Issues:** I believe this is the same issue reported in #1290, so merging this should enable us to close that.
