### PR TITLE
Add function to apply instantiated operations to queuing contexts

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 <h3>New features since last release</h3>
 
-* The new ``qml.apply_op`` function can be used to add operations that might have
-  already been instantiated elsewhere to the QNode:
+* The new ``qml.apply`` function can be used to add operations that might have
+  already been instantiated elsewhere to the QNode and other queuing contexts:
   [(#1433)](https://github.com/PennyLaneAI/pennylane/pull/1433)
 
   ```python
@@ -13,7 +13,7 @@
   @qml.qnode(dev)
   def circuit(x):
       qml.RY(x, wires=0)
-      qml.apply_op(op)
+      qml.apply(op)
       return qml.expval(qml.PauliZ(0))
   ```
 
@@ -30,6 +30,11 @@
 <h3>Improvements</h3>
 
 <h3>Breaking changes</h3>
+
+* The existing `pennylane.collections.apply` function is no longer accessible
+  via `qml.apply`, and needs to be imported directly from the ``collections``
+  package.
+  [(#1358)](https://github.com/PennyLaneAI/pennylane/pull/1358)
 
 <h3>Bug fixes</h3>
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 <h3>New features since last release</h3>
 
+* The new ``qml.apply_op`` function can be used to add operations that might have
+  already been instantiated elsewhere to the QNode:
+  [(#1433)](https://github.com/PennyLaneAI/pennylane/pull/1433)
+
+  ```python
+  op = qml.RX(0.4, wires=0)
+  dev = qml.device("default.qubit", wires=2)
+
+  @qml.qnode(dev)
+  def circuit(x):
+      qml.RY(x, wires=0)
+      qml.apply_op(op)
+      return qml.expval(qml.PauliZ(0))
+  ```
+
+  ```pycon
+  >>> print(qml.draw(circuit)(0.6))
+  0: ──RY(0.6)──RX(0.4)──┤ ⟨Z⟩
+  ```
+
+  Previously instantiated measurements can also be applied to QNodes.
+
 * Ising YY gate functionality added.
   [(#1358)](https://github.com/PennyLaneAI/pennylane/pull/1358)
 
@@ -17,7 +39,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-Ashish Panigrahi
+Josh Izaac, Ashish Panigrahi
 
 
 # Release 0.16.0 (current release)

--- a/pennylane/__init__.py
+++ b/pennylane/__init__.py
@@ -21,6 +21,8 @@ import numpy as _np
 import pkg_resources
 from semantic_version import Spec, Version
 
+from .queuing import apply_op, QueuingContext
+
 import pennylane.init
 import pennylane.fourier
 import pennylane.kernels
@@ -60,7 +62,6 @@ from pennylane.vqe import ExpvalCost, Hamiltonian, VQECost
 
 # QueuingContext and collections needs to be imported after all other pennylane imports
 from .collections import QNodeCollection, apply, dot, map, sum
-from .queuing import QueuingContext
 import pennylane.grouping  # pylint:disable=wrong-import-order
 
 # Look for an existing configuration file

--- a/pennylane/__init__.py
+++ b/pennylane/__init__.py
@@ -21,7 +21,7 @@ import pkg_resources
 import numpy as _np
 from semantic_version import Spec, Version
 
-from pennylane.queuing import apply_op, QueuingContext
+from pennylane.queuing import apply, QueuingContext
 
 import pennylane.init
 import pennylane.fourier
@@ -61,7 +61,7 @@ from pennylane.utils import inv
 from pennylane.vqe import ExpvalCost, Hamiltonian, VQECost
 
 # QueuingContext and collections needs to be imported after all other pennylane imports
-from .collections import QNodeCollection, apply, dot, map, sum
+from .collections import QNodeCollection, dot, map, sum
 import pennylane.grouping  # pylint:disable=wrong-import-order
 
 # Look for an existing configuration file

--- a/pennylane/__init__.py
+++ b/pennylane/__init__.py
@@ -16,12 +16,12 @@ This is the top level module from which all basic functions and classes of
 PennyLane can be directly imported.
 """
 from importlib import reload
+import pkg_resources
 
 import numpy as _np
-import pkg_resources
 from semantic_version import Spec, Version
 
-from .queuing import apply_op, QueuingContext
+from pennylane.queuing import apply_op, QueuingContext
 
 import pennylane.init
 import pennylane.fourier

--- a/pennylane/measure.py
+++ b/pennylane/measure.py
@@ -187,18 +187,20 @@ class MeasurementProcess:
 
         return tape
 
-    def queue(self):
+    def queue(self, context=qml.QueuingContext):
         """Append the measurement process to an annotated queue."""
         if self.obs is not None:
             try:
-                qml.QueuingContext.update_info(self.obs, owner=self)
+                context.update_info(self.obs, owner=self)
             except qml.queuing.QueuingError:
-                self.obs.queue()
-                qml.QueuingContext.update_info(self.obs, owner=self)
+                self.obs.queue(context=context)
+                context.update_info(self.obs, owner=self)
 
-            qml.QueuingContext.append(self, owns=self.obs)
+            context.append(self, owns=self.obs)
         else:
-            qml.QueuingContext.append(self)
+            context.append(self)
+
+        return self
 
 
 def expval(op):

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -464,10 +464,9 @@ class Operator(abc.ABC):
         """Current parameter values."""
         return self.data.copy()
 
-    def queue(self):
+    def queue(self, context=qml.QueuingContext):
         """Append the operator to the Operator queue."""
-        qml.QueuingContext.append(self)
-
+        context.append(self)
         return self  # so pre-constructed Observable instances can be queued and returned in a single statement
 
 
@@ -1112,27 +1111,31 @@ class Tensor(Observable):
     par_domain = None
 
     def __init__(self, *args):  # pylint: disable=super-init-not-called
-
         self._eigvals_cache = None
         self.obs = []
+        self._args = args
 
-        for o in args:
-            if isinstance(o, Tensor):
-                self.obs.extend(o.obs)
-            elif isinstance(o, Observable):
-                self.obs.append(o)
-            else:
-                raise ValueError("Can only perform tensor products between observables.")
+    def queue(self, context=qml.QueuingContext):
+        for o in self._args:
+
+            if not self.obs:
+                if isinstance(o, Tensor):
+                    self.obs.extend(o.obs)
+                elif isinstance(o, Observable):
+                    self.obs.append(o)
+                else:
+                    raise ValueError("Can only perform tensor products between observables.")
 
             try:
-                qml.QueuingContext.update_info(o, owner=self)
+                context.update_info(o, owner=self)
             except qml.queuing.QueuingError:
-                o.queue()
-                qml.QueuingContext.update_info(o, owner=self)
+                o.queue(context=context)
+                context.update_info(o, owner=self)
             except NotImplementedError:
                 pass
 
-        qml.QueuingContext.append(self, owns=tuple(args))
+        context.append(self, owns=tuple(self._args))
+        return self
 
     def __copy__(self):
         cls = self.__class__

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -1114,12 +1114,12 @@ class Tensor(Observable):
         self._eigvals_cache = None
         self.obs = []
         self._args = args
-        self.queue()
+        self.queue(init=True)
 
-    def queue(self, context=qml.QueuingContext):
+    def queue(self, context=qml.QueuingContext, init=False):
         for o in self._args:
 
-            if not self.obs:
+            if init:
                 if isinstance(o, Tensor):
                     self.obs.extend(o.obs)
                 elif isinstance(o, Observable):

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -1114,6 +1114,7 @@ class Tensor(Observable):
         self._eigvals_cache = None
         self.obs = []
         self._args = args
+        self.queue()
 
     def queue(self, context=qml.QueuingContext):
         for o in self._args:

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -1116,7 +1116,7 @@ class Tensor(Observable):
         self._args = args
         self.queue(init=True)
 
-    def queue(self, context=qml.QueuingContext, init=False):
+    def queue(self, context=qml.QueuingContext, init=False):  # pylint: disable=arguments-differ
         for o in self._args:
 
             if init:

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -1117,7 +1117,12 @@ class Tensor(Observable):
         self.queue(init=True)
 
     def queue(self, context=qml.QueuingContext, init=False):  # pylint: disable=arguments-differ
-        for o in self._args:
+        constituents = self.obs
+
+        if init:
+            constituents = self._args
+
+        for o in constituents:
 
             if init:
                 if isinstance(o, Tensor):
@@ -1135,7 +1140,7 @@ class Tensor(Observable):
             except NotImplementedError:
                 pass
 
-        context.append(self, owns=tuple(self._args))
+        context.append(self, owns=tuple(constituents))
         return self
 
     def __copy__(self):

--- a/pennylane/queuing.py
+++ b/pennylane/queuing.py
@@ -274,8 +274,8 @@ def apply(op, context=QueuingContext):
 
     **Example**
 
-    In PennyLane, operations and measurements are 'queued' or applied to a QNode
-    when they are instantiated.
+    In PennyLane, **operations and measurements are 'queued' or applied to a QNode
+    when they are instantiated**.
 
     The ``apply`` function can be used to add operations that might have
     already been instantiated elsewhere to the QNode:
@@ -287,8 +287,8 @@ def apply(op, context=QueuingContext):
 
         @qml.qnode(dev)
         def circuit(x):
-            qml.RY(x, wires=0)
-            qml.apply(op)
+            qml.RY(x, wires=0)  # applied during instantiation
+            qml.apply(op)  # manually applied
             return qml.expval(qml.PauliZ(0))
 
     >>> print(qml.draw(circuit)(0.6))
@@ -341,10 +341,15 @@ def apply(op, context=QueuingContext):
                 qml.Hadamard(wires=1)
 
                 with qml.tape.QuantumTape() as tape2:
+                    # Due to the nesting behaviour of queuing contexts,
+                    # tape2 will be queued to tape1.
+
+                    # The following PauliX operation will be queued
+                    # to the active queuing context, tape2, during instantiation.
                     op1 = qml.PauliX(wires=0)
 
-                    # apply the same operation to tape1
-                    # without leaving the tape2 context
+                    # We can use qml.apply to apply the same operation to tape1
+                    # without leaving the tape2 context.
                     qml.apply(op1, context=tape1)
 
                     qml.RZ(0.2, wires=0)

--- a/pennylane/queuing.py
+++ b/pennylane/queuing.py
@@ -220,6 +220,9 @@ class Queue(QueuingContext):
     def _remove(self, obj):
         self.queue.remove(obj)
 
+    append = _append
+    remove = _remove
+
 
 class AnnotatedQueue(QueuingContext):
     """Lightweight class that maintains a basic queue of operations, in addition
@@ -246,7 +249,34 @@ class AnnotatedQueue(QueuingContext):
 
         return self._queue[obj]
 
+    append = _append
+    remove = _remove
+    update_info = _update_info
+    get_info = _get_info
+
     @property
     def queue(self):
         """Returns a list of objects in the annotated queue"""
         return list(self._queue.keys())
+
+
+def apply_op(op, context=QueuingContext):
+    """Apply an instantiated ``Operator`` to a queuing context.
+
+    Args:
+        op (.Operator): the Operator to apply/queue
+        context (.QueuingContext): The queuing context to queue the operator to.
+            Note that if no context is specified, the operator is
+            applied to currently active queuing context.
+    """
+    if QueuingContext.recording() is None:
+        raise RuntimeError("No queuing context available to append operation to.")
+
+    if hasattr(op, "queue"):
+        # operator provides its own logic for queuing
+        op.queue(context=context)
+    else:
+        # append the operator directly to the relevant queuing context
+        context.append(op)
+
+    return

--- a/pennylane/queuing.py
+++ b/pennylane/queuing.py
@@ -15,6 +15,7 @@
 This module contains the :class:`QueuingContext` abstract base class.
 """
 import abc
+import copy
 from collections import OrderedDict, deque
 
 
@@ -269,8 +270,11 @@ def apply_op(op, context=QueuingContext):
             Note that if no context is specified, the operator is
             applied to currently active queuing context.
     """
-    if QueuingContext.recording() is None:
+    if not QueuingContext.recording():
         raise RuntimeError("No queuing context available to append operation to.")
+
+    if op in getattr(context, "queue", QueuingContext.active_context().queue):
+        op = copy.copy(op)
 
     if hasattr(op, "queue"):
         # operator provides its own logic for queuing
@@ -278,3 +282,5 @@ def apply_op(op, context=QueuingContext):
     else:
         # append the operator directly to the relevant queuing context
         context.append(op)
+
+    return op

--- a/pennylane/queuing.py
+++ b/pennylane/queuing.py
@@ -221,6 +221,9 @@ class Queue(QueuingContext):
     def _remove(self, obj):
         self.queue.remove(obj)
 
+    # Overwrite the inherited class methods, so that if queue.append is called,
+    # it is appended to the instantiated queue (rather than being added to the
+    # currently active queuing context, which may be a different queue).
     append = _append
     remove = _remove
 
@@ -250,6 +253,9 @@ class AnnotatedQueue(QueuingContext):
 
         return self._queue[obj]
 
+    # Overwrite the inherited class methods, so that if annotated_queue.append is called,
+    # it is appended to the instantiated queue (rather than being added to the
+    # currently active queuing context, which may be a different queue).
     append = _append
     remove = _remove
     update_info = _update_info
@@ -274,7 +280,7 @@ def apply(op, context=QueuingContext):
 
     **Example**
 
-    In PennyLane, **operations and measurements are 'queued' or applied to a QNode
+    In PennyLane, **operations and measurements are 'queued' or added to a circuit
     when they are instantiated**.
 
     The ``apply`` function can be used to add operations that might have

--- a/pennylane/queuing.py
+++ b/pennylane/queuing.py
@@ -278,5 +278,3 @@ def apply_op(op, context=QueuingContext):
     else:
         # append the operator directly to the relevant queuing context
         context.append(op)
-
-    return

--- a/pennylane/queuing.py
+++ b/pennylane/queuing.py
@@ -268,8 +268,7 @@ def apply(op, context=QueuingContext):
         op (.Operator or .MeasurementProcess): the operator or measurement to apply/queue
         context (.QueuingContext): The queuing context to queue the operator to.
             Note that if no context is specified, the operator is
-            applied to currently active queuing context.
-
+            applied to the currently active queuing context.
     Returns:
         .Operator or .MeasurementProcess: the input operator is returned for convenience
 

--- a/pennylane/queuing.py
+++ b/pennylane/queuing.py
@@ -261,7 +261,7 @@ class AnnotatedQueue(QueuingContext):
         return list(self._queue.keys())
 
 
-def apply_op(op, context=QueuingContext):
+def apply(op, context=QueuingContext):
     """Apply an instantiated operator or measurement to a queuing context.
 
     Args:
@@ -278,7 +278,7 @@ def apply_op(op, context=QueuingContext):
     In PennyLane, operations and measurements are 'queued' or applied to a QNode
     when they are instantiated.
 
-    The ``apply_op`` function can be used to add operations that might have
+    The ``apply`` function can be used to add operations that might have
     already been instantiated elsewhere to the QNode:
 
     .. code-block:: python
@@ -289,7 +289,7 @@ def apply_op(op, context=QueuingContext):
         @qml.qnode(dev)
         def circuit(x):
             qml.RY(x, wires=0)
-            qml.apply_op(op)
+            qml.apply(op)
             return qml.expval(qml.PauliZ(0))
 
     >>> print(qml.draw(circuit)(0.6))
@@ -301,9 +301,9 @@ def apply_op(op, context=QueuingContext):
 
         @qml.qnode(dev)
         def circuit(x):
-            qml.apply_op(op)
+            qml.apply(op)
             qml.RY(x, wires=0)
-            qml.apply_op(op)
+            qml.apply(op)
             return qml.expval(qml.PauliZ(0))
 
     >>> print(qml.draw(circuit)(0.6))
@@ -312,7 +312,7 @@ def apply_op(op, context=QueuingContext):
     .. UsageDetails::
 
         Instantiated measurements can also be applied to queuing contexts
-        using ``apply_op``:
+        using ``apply``:
 
         .. code-block:: python
 
@@ -323,13 +323,13 @@ def apply_op(op, context=QueuingContext):
             def circuit(x):
                 qml.RY(x, wires=0)
                 qml.CNOT(wires=[0, 1])
-                return qml.apply_op(meas)
+                return qml.apply(meas)
 
         >>> print(qml.draw(circuit)(0.6))
          0: ──RY(0.6)──╭C──╭┤ ⟨Z ⊗ Y⟩
          1: ───────────╰X──╰┤ ⟨Z ⊗ Y⟩
 
-        By default, ``apply_op`` will queue operators to the currently
+        By default, ``apply`` will queue operators to the currently
         active queuing context.
 
         When working with low-level queuing contexts such as quantum tapes,
@@ -346,7 +346,7 @@ def apply_op(op, context=QueuingContext):
 
                     # apply the same operation to tape1
                     # without leaving the tape2 context
-                    qml.apply_op(op1, context=tape1)
+                    qml.apply(op1, context=tape1)
 
                     qml.RZ(0.2, wires=0)
 

--- a/pennylane/vqe/vqe.py
+++ b/pennylane/vqe/vqe.py
@@ -404,18 +404,18 @@ class Hamiltonian:
             return self
         raise ValueError(f"Cannot subtract {type(H)} from Hamiltonian")
 
-    def queue(self):
+    def queue(self, context=qml.QueuingContext):
         """Queues a qml.Hamiltonian instance"""
         for o in self.ops:
             try:
-                qml.QueuingContext.update_info(o, owner=self)
+                context.update_info(o, owner=self)
             except QueuingError:
-                o.queue()
-                qml.QueuingContext.update_info(o, owner=self)
+                o.queue(context=context)
+                context.update_info(o, owner=self)
             except NotImplementedError:
                 pass
 
-        qml.QueuingContext.append(self, owns=tuple(self.ops))
+        context.append(self, owns=tuple(self.ops))
         return self
 
 

--- a/tests/collections/test_collections.py
+++ b/tests/collections/test_collections.py
@@ -217,7 +217,7 @@ class TestApply:
         else:
             sfn = np.sum
 
-        cost = qml.apply(sfn, qc)
+        cost = qml.collections.apply(sfn, qc)
 
         params = [0.5643, -0.45]
         res = cost(params)
@@ -250,7 +250,7 @@ class TestApply:
             sinfn = np.sin
             sfn = np.sum
 
-        cost = qml.apply(sfn, qml.apply(sinfn, qc))
+        cost = qml.collections.apply(sfn, qml.collections.apply(sinfn, qc))
 
         params = [0.5643, -0.45]
         res = cost(params)

--- a/tests/test_queuing.py
+++ b/tests/test_queuing.py
@@ -438,20 +438,20 @@ test_observables = [
 
 
 class TestApplyOp:
-    """Tests for the apply_op function"""
+    """Tests for the apply function"""
 
     def test_error(self):
         """Test that applying an operation without an active
         context raises an error"""
         with pytest.raises(RuntimeError, match="No queuing context"):
-            qml.apply_op(qml.PauliZ(0))
+            qml.apply(qml.PauliZ(0))
 
     def test_default_queue_operation_inside(self):
         """Test applying an operation instantiated within the queuing
         context to the existing active queue"""
         with qml.tape.QuantumTape() as tape:
             op1 = qml.PauliZ(0)
-            op2 = qml.apply_op(op1)
+            op2 = qml.apply(op1)
 
         assert tape.operations == [op1, op2]
 
@@ -461,7 +461,7 @@ class TestApplyOp:
         op = qml.PauliZ(0)
 
         with qml.tape.QuantumTape() as tape:
-            qml.apply_op(op)
+            qml.apply(op)
 
         assert tape.operations == [op]
 
@@ -472,7 +472,7 @@ class TestApplyOp:
         op = qml.expval(obs)
 
         with qml.tape.QuantumTape() as tape:
-            qml.apply_op(op)
+            qml.apply(op)
 
         assert tape.measurements == [op]
 
@@ -483,7 +483,7 @@ class TestApplyOp:
 
         with qml.tape.QuantumTape() as tape:
             op1 = qml.expval(obs)
-            op2 = qml.apply_op(op1)
+            op2 = qml.apply(op1)
 
         assert tape.measurements == [op1, op2]
 
@@ -493,7 +493,7 @@ class TestApplyOp:
         with qml.tape.QuantumTape() as tape1:
             with qml.tape.QuantumTape() as tape2:
                 op1 = qml.PauliZ(0)
-                op2 = qml.apply_op(op1, tape1)
+                op2 = qml.apply(op1, tape1)
 
         assert tape1.operations == [tape2, op2]
         assert tape2.operations == [op1]
@@ -505,7 +505,7 @@ class TestApplyOp:
 
         with qml.tape.QuantumTape() as tape1:
             with qml.tape.QuantumTape() as tape2:
-                qml.apply_op(op, tape1)
+                qml.apply(op, tape1)
 
         assert tape1.operations == [tape2, op]
         assert tape2.operations == []
@@ -518,7 +518,7 @@ class TestApplyOp:
 
         with qml.tape.QuantumTape() as tape1:
             with qml.tape.QuantumTape() as tape2:
-                qml.apply_op(op, tape1)
+                qml.apply(op, tape1)
 
         assert tape1.measurements == [op]
         assert tape2.measurements == []
@@ -531,7 +531,7 @@ class TestApplyOp:
         with qml.tape.QuantumTape() as tape1:
             with qml.tape.QuantumTape() as tape2:
                 op1 = qml.expval(obs)
-                op2 = qml.apply_op(op1, tape1)
+                op2 = qml.apply(op1, tape1)
 
         assert tape1.measurements == [op2]
         assert tape2.measurements == [op1]
@@ -541,8 +541,8 @@ class TestApplyOp:
         added to the queuing context"""
         with qml.tape.QuantumTape() as tape1:
             with qml.tape.QuantumTape() as tape2:
-                op1 = qml.apply_op(5)
-                op2 = qml.apply_op(6, tape1)
+                op1 = qml.apply(5)
+                op2 = qml.apply(6, tape1)
 
         assert tape1.queue == [tape2, op2]
         assert tape2.queue == [op1]

--- a/tests/test_queuing.py
+++ b/tests/test_queuing.py
@@ -535,3 +535,19 @@ class TestApplyOp:
 
         assert tape1.measurements == [op2]
         assert tape2.measurements == [op1]
+
+    def test_apply_no_queue_method(self):
+        """Test that an object with no queue method is still
+        added to the queuing context"""
+        with qml.tape.QuantumTape() as tape1:
+            with qml.tape.QuantumTape() as tape2:
+                op1 = qml.apply_op(5)
+                op2 = qml.apply_op(6, tape1)
+
+        assert tape1.queue == [tape2, op2]
+        assert tape2.queue == [op1]
+
+        # note that tapes don't know how to process integers,
+        # so they are not included after queue processing
+        assert tape1.operations == [tape2]
+        assert tape2.operations == []

--- a/tests/test_queuing.py
+++ b/tests/test_queuing.py
@@ -319,29 +319,10 @@ class TestAnnotatedQueue:
     def test_append_annotating_object(self):
         """Test appending an object that writes annotations when queuing itself"""
 
-        class AnnotatingTensor(qml.operation.Tensor):
-            """Dummy tensor class that queues itself on initialization
-            to an annotating queue."""
-
-            def __init__(self, *args):
-                super().__init__(*args)
-                self.queue()
-
-            def queue(self):
-                QueuingContext.append(self, owns=tuple(self.obs))
-
-                for o in self.obs:
-                    try:
-                        QueuingContext.update_info(o, owner=self)
-                    except AttributeError:
-                        pass
-
-                return self
-
         with AnnotatedQueue() as q:
             A = qml.PauliZ(0)
             B = qml.PauliY(1)
-            tensor_op = AnnotatingTensor(A, B)
+            tensor_op = qml.operation.Tensor(A, B)
 
         assert q.queue == [A, B, tensor_op]
         assert q._get_info(A) == {"owner": tensor_op}

--- a/tests/test_vqe.py
+++ b/tests/test_vqe.py
@@ -810,6 +810,8 @@ class TestHamiltonian:
         queue = [
             qml.Hadamard(wires=1),
             qml.PauliX(wires=0),
+            qml.PauliZ(0),
+            qml.PauliZ(2),
             qml.PauliZ(0) @ qml.PauliZ(2),
             qml.PauliX(1),
             qml.PauliZ(1),
@@ -824,6 +826,8 @@ class TestHamiltonian:
             qml.Hadamard(wires=1)
             qml.PauliX(wires=0)
             H.queue()
+
+        print(tape.queue[-1].ops)
 
         assert np.all([q1.compare(q2) for q1, q2 in zip(tape.queue, queue)])
 

--- a/tests/test_vqe.py
+++ b/tests/test_vqe.py
@@ -827,8 +827,6 @@ class TestHamiltonian:
             qml.PauliX(wires=0)
             H.queue()
 
-        print(tape.queue[-1].ops)
-
         assert np.all([q1.compare(q2) for q1, q2 in zip(tape.queue, queue)])
 
         # Inside of tape


### PR DESCRIPTION
**Context:**

Currently, there is no consistent, user-facing approach for applying (already instantiated) operators to a queuing context. Instead, there is a combination of different approaches:

- `op.queue()`: the most common approach. Almost all operators provide their own queuing logic currently, bar `Tensor`, which inherits a basic implementation from the base class and leads to inconsistent behaviour.

- `qml.QueuingContext.append()`: appends the object _directly_ to the currently active queuing context.

- `context._append()` appends the object to a specific queuing context.

This situation is not ideal, since `op.queue()` is not consistent, not documented, and not user-facing.

**Description of the Change:**

- Adds `Tensor.queue()` to make the `Tensor` class consistent with other `Operator` subclasses. This results in several accidental bug fixes that have plagued the Hamiltonian class (see #1142)

- Modifies the existing `queue()` methods, so that they now take an optional `context` keyword argument. This allows operators to be queued to _specific_, _provided_, contexts, rather than just the currently active context.

- Adds a new function `qml.apply`, which will be the new user and developer facing method for queuing already instantiated operations.

**Benefits:**

- There is now a consistent, documented, and well-tested method for queuing instantiated operators to queuing contexts.

**Possible Drawbacks:**

- The existing `qml.apply` function was an import of `qml.collections.apply`. This function was infrequently used or advertised, and now must be accessed by importing directly from the collections module.

**Related GitHub Issues:** n/a
