### PR TITLE
Fix return of single measurement in qfunc transform.

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -11,13 +11,17 @@
 
 <h3>Bug fixes</h3>
 
+* Quantum function transforms now preserve the format of the measurement
+  results, so that a single measurement returns a single value rather than
+  an array with a single element. [(#1434)](https://github.com/PennyLaneAI/pennylane/pull/1434/files)
+
 <h3>Documentation</h3>
 
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):
 
-Ashish Panigrahi
+Olivia Di Matteo, Ashish Panigrahi
 
 
 # Release 0.16.0 (current release)

--- a/pennylane/transforms/qfunc_transforms.py
+++ b/pennylane/transforms/qfunc_transforms.py
@@ -182,6 +182,10 @@ def _create_qfunc_internal_wrapper(fn, tape_transform, transform_args, transform
     def internal_wrapper(*args, **kwargs):
         tape = make_tape(fn)(*args, **kwargs)
         tape = tape_transform(tape, *transform_args, **transform_kwargs)
+
+        if len(tape.measurements) == 1:
+            return tape.measurements[0]
+
         return tape.measurements
 
     return internal_wrapper


### PR DESCRIPTION
**Context:** After applying a quantum function transform and constructing a QNode, the resultant QNode would return a 1-d array of measurement results even when there was only a single measurement.

**Description of the Change:** The qfunc transform decorator now checks the length of the list of measurements, and returns a list of results only when there are multiple measurements.

**Benefits:** Transformed QNodes that return a 0-d tensor now still return a 0-d tensor.

**Possible Drawbacks:** None

**Related GitHub Issues:** None
