### PR TITLE
add QubitOperator

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -27,7 +27,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-Olivia Di Matteo, Ashish Panigrahi
+Olivia Di Matteo, Anthony Hayes, Ashish Panigrahi
 
 
 # Release 0.16.0 (current release)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -7,8 +7,27 @@
 
 <h3>Improvements</h3>
 
-* Add `QubitMatrix` operation for custom operator implementation
+* Add `QubitOperator` operation for custom operator implementation
 [(#1435)](https://github.com/PennyLaneAI/pennylane/pull/1435)
+
+  Example Usage:
+  ```python
+  wires = range(2)
+  dev = qml.device("default.qubit", wires=len(wires))
+
+  eigenstate = 2**(-.5)*np.array([1, 1j])
+  P = np.outer(eplus_i, np.conjugate(eigenstate)) # Projector
+
+  @qml.qnode(dev)
+  def circuit():
+
+      qml.Hadamard(wires=0)
+      qml.CNOT(wires=[0,1])
+
+      qml.QubitOperator(P, wires=1)
+
+      return qml.density_matrix(wires)
+  ```
 
 <h3>Breaking changes</h3>
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 <h3>Improvements</h3>
 
+* Add QubitMatrix operator for custom operator implementation
+[(#1435)](https://github.com/PennyLaneAI/pennylane/pull/1435)
+
 <h3>Breaking changes</h3>
 
 <h3>Bug fixes</h3>
@@ -45,7 +48,7 @@ Olivia Di Matteo, Ashish Panigrahi
       qml.SingleExcitation(param, wires=[0, 1])
       return qml.expval(qml.SparseHamiltonian(H, [0, 1]))
   ```
-  
+
   We can execute this QNode, passing in a sparse identity matrix:
 
   ```pycon

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 <h3>Improvements</h3>
 
-* Add QubitMatrix operator for custom operator implementation
+* Add `QubitMatrix` operation for custom operator implementation
 [(#1435)](https://github.com/PennyLaneAI/pennylane/pull/1435)
 
 <h3>Breaking changes</h3>

--- a/doc/introduction/operations.rst
+++ b/doc/introduction/operations.rst
@@ -86,7 +86,7 @@ Qubit gates
     ~pennylane.Toffoli
     ~pennylane.CSWAP
     ~pennylane.QubitUnitary
-    ~pennylane.QubitMatrix
+    ~pennylane.QubitOperator
     ~pennylane.ControlledQubitUnitary
     ~pennylane.MultiControlledX
     ~pennylane.DiagonalQubitUnitary

--- a/doc/introduction/operations.rst
+++ b/doc/introduction/operations.rst
@@ -86,6 +86,7 @@ Qubit gates
     ~pennylane.Toffoli
     ~pennylane.CSWAP
     ~pennylane.QubitUnitary
+    ~pennylane.QubitMatrix
     ~pennylane.ControlledQubitUnitary
     ~pennylane.MultiControlledX
     ~pennylane.DiagonalQubitUnitary

--- a/pennylane/devices/default_mixed.py
+++ b/pennylane/devices/default_mixed.py
@@ -59,7 +59,7 @@ class DefaultMixed(QubitDevice):
         "BasisState",
         "QubitStateVector",
         "QubitUnitary",
-        "QubitMatrix",
+        "QubitOperator",
         "ControlledQubitUnitary",
         "MultiControlledX",
         "DiagonalQubitUnitary",

--- a/pennylane/devices/default_mixed.py
+++ b/pennylane/devices/default_mixed.py
@@ -59,6 +59,7 @@ class DefaultMixed(QubitDevice):
         "BasisState",
         "QubitStateVector",
         "QubitUnitary",
+        "QubitMatrix",
         "ControlledQubitUnitary",
         "MultiControlledX",
         "DiagonalQubitUnitary",

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -94,7 +94,7 @@ class DefaultQubit(QubitDevice):
         "BasisState",
         "QubitStateVector",
         "QubitUnitary",
-        "QubitMatrix",
+        "QubitOperator",
         "ControlledQubitUnitary",
         "MultiControlledX",
         "DiagonalQubitUnitary",

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -93,6 +93,7 @@ class DefaultQubit(QubitDevice):
         "BasisState",
         "QubitStateVector",
         "QubitUnitary",
+        "QubitMatrix",
         "ControlledQubitUnitary",
         "MultiControlledX",
         "DiagonalQubitUnitary",

--- a/pennylane/ops/qubit.py
+++ b/pennylane/ops/qubit.py
@@ -2165,8 +2165,8 @@ class QubitUnitary(Operation):
         ControlledQubitUnitary(*self.parameters, control_wires=wire, wires=self.wires)
 
 
-class QubitMatrix(Operation):
-    r"""QubitMatrix(A, wires)
+class QubitOperator(Operation):
+    r"""QubitOperator(A, wires)
     Apply an arbitrary square matrix.
 
     **Details:**
@@ -2196,7 +2196,7 @@ class QubitMatrix(Operation):
         return A
 
     def adjoint(self):
-        return QubitMatrix(qml.math.T(qml.math.conj(self.matrix)), wires=self.wires)
+        return QubitOperator(qml.math.T(qml.math.conj(self.matrix)), wires=self.wires)
 
 
 class ControlledQubitUnitary(QubitUnitary):
@@ -3392,7 +3392,7 @@ ops = {
     "BasisState",
     "QubitStateVector",
     "QubitUnitary",
-    "QubitMatrix",
+    "QubitOperator",
     "ControlledQubitUnitary",
     "MultiControlledX",
     "DiagonalQubitUnitary",

--- a/pennylane/ops/qubit.py
+++ b/pennylane/ops/qubit.py
@@ -2193,6 +2193,9 @@ class QubitMatrix(Operation):
 
         return A
 
+    def adjoint(self):
+        return QubitMatrix(qml.math.T(qml.math.conj(self.matrix)), wires=self.wires)
+
 
 class ControlledQubitUnitary(QubitUnitary):
     r"""ControlledQubitUnitary(U, control_wires, wires, control_values)

--- a/pennylane/ops/qubit.py
+++ b/pennylane/ops/qubit.py
@@ -2191,6 +2191,9 @@ class QubitMatrix(Operation):
         if A.shape[0] != A.shape[1]:
             raise ValueError("Operator must be a square matrix.")
 
+        if not np.allclose(A, A.conj().T):
+            raise ValueError("Observable must be Hermitian.")
+
         return A
 
 

--- a/pennylane/ops/qubit.py
+++ b/pennylane/ops/qubit.py
@@ -2167,7 +2167,7 @@ class QubitUnitary(Operation):
 
 class QubitMatrix(Operation):
     r"""QubitMatrix(A, wires)
-    Apply an arbitrary fixed matrix.
+    Apply an arbitrary square matrix.
 
     **Details:**
 

--- a/pennylane/ops/qubit.py
+++ b/pennylane/ops/qubit.py
@@ -2191,9 +2191,6 @@ class QubitMatrix(Operation):
         if A.shape[0] != A.shape[1]:
             raise ValueError("Operator must be a square matrix.")
 
-        if not np.allclose(A, A.conj().T):
-            raise ValueError("Observable must be Hermitian.")
-
         return A
 
 

--- a/pennylane/ops/qubit.py
+++ b/pennylane/ops/qubit.py
@@ -2187,9 +2187,10 @@ class QubitMatrix(Operation):
 
     @classmethod
     def _matrix(cls, *params):
-        A = np.asarray(params[0])
+        A = params[0]
+        shape = qml.math.shape(A)
 
-        if A.shape[0] != A.shape[1]:
+        if shape[0] != shape[1]:
             raise ValueError("Operator must be a square matrix.")
 
         return A

--- a/pennylane/ops/qubit.py
+++ b/pennylane/ops/qubit.py
@@ -2164,6 +2164,36 @@ class QubitUnitary(Operation):
         ControlledQubitUnitary(*self.parameters, control_wires=wire, wires=self.wires)
 
 
+class QubitMatrix(Operation):
+    r"""QubitMatrix(A, wires)
+    Apply an arbitrary fixed matrix.
+
+    **Details:**
+
+    * Number of wires: Any (the operation can act on any number of wires)
+    * Number of parameters: 1
+    * Gradient recipe: None
+
+    Args:
+        A (array[complex]): square matrix
+        wires (Sequence[int] or int): the wire(s) the operation acts on
+    """
+
+    num_wires = AnyWires
+    num_params = 1
+    par_domain = "A"
+    grad_method = None
+
+    @classmethod
+    def _matrix(cls, *params):
+        A = np.asarray(params[0])
+
+        if A.shape[0] != A.shape[1]:
+            raise ValueError("Operator must be a square matrix.")
+
+        return A
+
+
 class ControlledQubitUnitary(QubitUnitary):
     r"""ControlledQubitUnitary(U, control_wires, wires, control_values)
     Apply an arbitrary fixed unitary to ``wires`` with control from the ``control_wires``.
@@ -3318,6 +3348,7 @@ ops = {
     "BasisState",
     "QubitStateVector",
     "QubitUnitary",
+    "QubitMatrix",
     "ControlledQubitUnitary",
     "MultiControlledX",
     "DiagonalQubitUnitary",

--- a/tests/ops/test_qubit_ops.py
+++ b/tests/ops/test_qubit_ops.py
@@ -1476,7 +1476,7 @@ class TestOperations:
         """Test that the expected circuit output is returned when using QubitOperator for a
         Hermitian and a non-Hermitian operator"""
 
-        dev = qml.device("default.qubit.tf", wires=2)
+        dev = qml.device("default.qubit", wires=2)
 
         @qml.qnode(dev)
         def circuit():

--- a/tests/ops/test_qubit_ops.py
+++ b/tests/ops/test_qubit_ops.py
@@ -1464,10 +1464,6 @@ class TestOperations:
         with pytest.raises(ValueError, match="must be a square matrix"):
             qml.QubitMatrix(A1, wires=0).matrix
 
-        # test non-Hermitian matrix
-        A2 = np.array([[0, 1j], [1j, 0]])
-        with pytest.raises(ValueError, match="must be Hermitian"):
-            qml.QubitMatrix(A2, wires=0).matrix
 
     def test_iswap_eigenval(self):
         """Tests that the ISWAP eigenvalue matches the numpy eigenvalues of the ISWAP matrix"""

--- a/tests/ops/test_qubit_ops.py
+++ b/tests/ops/test_qubit_ops.py
@@ -1466,11 +1466,11 @@ class TestOperations:
             qml.QubitOperator(A1, wires=0).matrix
 
     @pytest.mark.parametrize(
-        ("A", "expected_state") ,
+        ("A", "expected_state"),
         [
-            (np.array([[1,0],[0,0]]), 2**(-.5)*np.array([1, 0, 0, 0])),
-            (np.array([[0,0],[0,1j]]), 2**(-.5)*np.array([0, 0, 0, 1j]))
-        ]
+            (np.array([[1, 0], [0, 0]]), 2 ** (-0.5) * np.array([1, 0, 0, 0])),
+            (np.array([[0, 0], [0, 1j]]), 2 ** (-0.5) * np.array([0, 0, 0, 1j])),
+        ],
     )
     def test_qubit_operator_circuit_output(self, A, expected_state):
         """Test that the expected circuit output is returned when using QubitOperator for a
@@ -1481,7 +1481,7 @@ class TestOperations:
         @qml.qnode(dev)
         def circuit():
             qml.Hadamard(wires=0)
-            qml.CNOT(wires=[0,1])
+            qml.CNOT(wires=[0, 1])
             qml.QubitOperator(A, wires=0)
 
             return qml.state()

--- a/tests/ops/test_qubit_ops.py
+++ b/tests/ops/test_qubit_ops.py
@@ -1447,7 +1447,7 @@ class TestOperations:
 
     def test_qubit_matrix(self, tol):
         """Test that QubitMatrix produces the correct output."""
-        A = 0.5*np.array([[1, -1j], [1j, 1]])
+        A = 0.5 * np.array([[1, -1j], [1j, 1]])
         out = qml.QubitMatrix(A, wires=0).matrix
 
         # verify output type
@@ -1457,15 +1457,15 @@ class TestOperations:
         assert np.allclose(out, A, atol=tol, rtol=0)
 
     def test_qubit_matrix_exceptions(self):
-        """Tests that the unitary operator raises the proper errors."""
-        A1 = np.array([[1, 1 ,1, -1]])
+        """Tests that the QubitMatrix operator raises the expected errors."""
+        A1 = np.array([[1, 1, 1, -1]])
 
         # test non-square matrix
         with pytest.raises(ValueError, match="must be a square matrix"):
             qml.QubitMatrix(A1, wires=0).matrix
 
         # test non-Hermitian matrix
-        A2 = np.array([[0, 1j],[1j , 0]])
+        A2 = np.array([[0, 1j], [1j, 0]])
         with pytest.raises(ValueError, match="must be Hermitian"):
             qml.QubitMatrix(A2, wires=0).matrix
 

--- a/tests/ops/test_qubit_ops.py
+++ b/tests/ops/test_qubit_ops.py
@@ -443,7 +443,7 @@ PARAMETRIZED_OPERATIONS = [
     qml.PauliY(wires=0),
     qml.CRot(0.123, 0.456, 0.789, wires=[0, 1]),
     qml.QubitUnitary(np.eye(2) * 1j, wires=0),
-    qml.QubitMatrix(np.eye(2) * 1j, wires=0),
+    qml.QubitOperator(np.eye(2) * 1j, wires=0),
     qml.DiagonalQubitUnitary(np.array([1.0, 1.0j]), wires=1),
     qml.ControlledQubitUnitary(np.eye(2) * 1j, wires=[0], control_wires=[2]),
     qml.MultiControlledX(control_wires=[0, 1], wires=2, control_values="01"),
@@ -1446,10 +1446,10 @@ class TestOperations:
         with pytest.raises(ValueError, match="must be a square matrix"):
             qml.QubitUnitary(U, wires=0).matrix
 
-    def test_qubit_matrix(self, tol):
-        """Test that QubitMatrix produces the correct output."""
+    def test_qubit_operator(self, tol):
+        """Test that QubitOperator produces the correct output."""
         A = 0.5 * np.array([[1, -1j], [1j, 1]])
-        out = qml.QubitMatrix(A, wires=0).matrix
+        out = qml.QubitOperator(A, wires=0).matrix
 
         # verify output type
         assert isinstance(out, np.ndarray)
@@ -1457,13 +1457,13 @@ class TestOperations:
         # verify equivalent to input state
         assert np.allclose(out, A, atol=tol, rtol=0)
 
-    def test_qubit_matrix_exceptions(self):
-        """Tests that the QubitMatrix operator raises the expected errors."""
+    def test_qubit_operator_exceptions(self):
+        """Tests that the QubitOperator operator raises the expected errors."""
         A1 = np.array([[1, 1, 1, -1]])
 
         # test non-square matrix
         with pytest.raises(ValueError, match="must be a square matrix"):
-            qml.QubitMatrix(A1, wires=0).matrix
+            qml.QubitOperator(A1, wires=0).matrix
 
     def test_iswap_eigenval(self):
         """Tests that the ISWAP eigenvalue matches the numpy eigenvalues of the ISWAP matrix"""

--- a/tests/ops/test_qubit_ops.py
+++ b/tests/ops/test_qubit_ops.py
@@ -1445,6 +1445,30 @@ class TestOperations:
         with pytest.raises(ValueError, match="must be a square matrix"):
             qml.QubitUnitary(U, wires=0).matrix
 
+    def test_qubit_matrix(self, tol):
+        """Test that QubitMatrix produces the correct output."""
+        A = 0.5*np.array([[1, -1j], [1j, 1]])
+        out = qml.QubitMatrix(A, wires=0).matrix
+
+        # verify output type
+        assert isinstance(out, np.ndarray)
+
+        # verify equivalent to input state
+        assert np.allclose(out, A, atol=tol, rtol=0)
+
+    def test_qubit_matrix_exceptions(self):
+        """Tests that the unitary operator raises the proper errors."""
+        A1 = np.array([[1, 1 ,1, -1]])
+
+        # test non-square matrix
+        with pytest.raises(ValueError, match="must be a square matrix"):
+            qml.QubitMatrix(A1, wires=0).matrix
+
+        # test non-Hermitian matrix
+        A2 = np.array([[0, 1j],[1j , 0]])
+        with pytest.raises(ValueError, match="must be Hermitian"):
+            qml.QubitMatrix(A2, wires=0).matrix
+
     def test_iswap_eigenval(self):
         """Tests that the ISWAP eigenvalue matches the numpy eigenvalues of the ISWAP matrix"""
         op = qml.ISWAP(wires=[0, 1])

--- a/tests/ops/test_qubit_ops.py
+++ b/tests/ops/test_qubit_ops.py
@@ -1464,7 +1464,6 @@ class TestOperations:
         with pytest.raises(ValueError, match="must be a square matrix"):
             qml.QubitMatrix(A1, wires=0).matrix
 
-
     def test_iswap_eigenval(self):
         """Tests that the ISWAP eigenvalue matches the numpy eigenvalues of the ISWAP matrix"""
         op = qml.ISWAP(wires=[0, 1])

--- a/tests/ops/test_qubit_ops.py
+++ b/tests/ops/test_qubit_ops.py
@@ -1465,6 +1465,29 @@ class TestOperations:
         with pytest.raises(ValueError, match="must be a square matrix"):
             qml.QubitOperator(A1, wires=0).matrix
 
+    @pytest.mark.parametrize(
+        ("A", "expected_state") ,
+        [
+            (np.array([[1,0],[0,0]]), 2**(-.5)*np.array([1, 0, 0, 0])),
+            (np.array([[0,0],[0,1j]]), 2**(-.5)*np.array([0, 0, 0, 1j]))
+        ]
+    )
+    def test_qubit_operator_circuit_output(self, A, expected_state):
+        """Test that the expected circuit output is returned when using QubitOperator for a
+        Hermitian and a non-Hermitian operator"""
+
+        dev = qml.device("default.qubit.tf", wires=2)
+
+        @qml.qnode(dev)
+        def circuit():
+            qml.Hadamard(wires=0)
+            qml.CNOT(wires=[0,1])
+            qml.QubitOperator(A, wires=0)
+
+            return qml.state()
+
+        assert np.allclose(expected_state, circuit())
+
     def test_iswap_eigenval(self):
         """Tests that the ISWAP eigenvalue matches the numpy eigenvalues of the ISWAP matrix"""
         op = qml.ISWAP(wires=[0, 1])

--- a/tests/ops/test_qubit_ops.py
+++ b/tests/ops/test_qubit_ops.py
@@ -443,6 +443,7 @@ PARAMETRIZED_OPERATIONS = [
     qml.PauliY(wires=0),
     qml.CRot(0.123, 0.456, 0.789, wires=[0, 1]),
     qml.QubitUnitary(np.eye(2) * 1j, wires=0),
+    qml.QubitMatrix(np.eye(2) * 1j, wires=0),
     qml.DiagonalQubitUnitary(np.array([1.0, 1.0j]), wires=1),
     qml.ControlledQubitUnitary(np.eye(2) * 1j, wires=[0], control_wires=[2]),
     qml.MultiControlledX(control_wires=[0, 1], wires=2, control_values="01"),


### PR DESCRIPTION
**Context:** It can be useful to include custom operators constructed from numpy arrays in circuits.

**Description of the Change:** add a `qml.QubitOperator(A, wires)` operator which accepts an arbitrary square matrix `A` and the `wires` it acts on 

**Benefits:** Increases overall flexibility, can make state preparation very straight forward (but potentially unphysical)

**Possible Drawbacks:** Might be difficult to integrate, e.g with noise models.

Example use:
```python
wires = range(2)
dev = qml.device("default.qubit", wires=len(wires))

eigenstate = 2**(-.5)*np.array([1, 1j])
P = np.outer(eplus_i, np.conjugate(eigenstate))

@qml.qnode(dev)
def circuit():
    
    qml.Hadamard(wires=0)
    qml.CNOT(wires=[0,1])
    
    qml.QubitOperator(P, wires=1)
    
    return qml.density_matrix(wires)
```