### PR TITLE
Fixes vector-Hessian product bug

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -16,7 +16,12 @@
 
 * Quantum function transforms now preserve the format of the measurement
   results, so that a single measurement returns a single value rather than
-  an array with a single element. [(#1434)](https://github.com/PennyLaneAI/pennylane/pull/1434/files)
+  an array with a single element. [(#1434)](https://github.com/PennyLaneAI/pennylane/pull/1434)
+
+* Fixed a bug in the parameter-shift Hessian implementation, which resulted
+  in the incorrect Hessian being returned for a cost function
+  that performed post-processing on a vector-valued QNode.
+  [(#)](https://github.com/PennyLaneAI/pennylane/pull/)
 
 <h3>Documentation</h3>
 
@@ -24,7 +29,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-Olivia Di Matteo, Ashish Panigrahi
+Olivia Di Matteo, Josh Izaac, Ashish Panigrahi.
 
 
 # Release 0.16.0 (current release)

--- a/pennylane/interfaces/autograd.py
+++ b/pennylane/interfaces/autograd.py
@@ -259,7 +259,7 @@ class AutogradInterface(AnnotatedQueue):
                     hessian = _evaluate_grad_matrix(p, "hessian")
 
                     if dy.size > 1:
-                        vhp = dy @ ddy @ hessian @ dy.T
+                        vhp = dy @ ddy @ hessian @ dy.T / np.linalg.norm(dy) ** 2
                     else:
                         vhp = ddy @ hessian
                         vhp = vhp.flatten()

--- a/pennylane/interfaces/tf.py
+++ b/pennylane/interfaces/tf.py
@@ -212,7 +212,11 @@ class TFInterface(AnnotatedQueue):
 
                     vhp = tf.cond(
                         tf.rank(hessian) > 2,
-                        lambda: dy_row @ ddy @ hessian @ tf.transpose(dy_row) / tf.linalg.norm(dy_row) ** 2,
+                        lambda: dy_row
+                        @ ddy
+                        @ hessian
+                        @ tf.transpose(dy_row)
+                        / tf.linalg.norm(dy_row) ** 2,
                         lambda: ddy @ hessian,
                     )
 

--- a/pennylane/interfaces/tf.py
+++ b/pennylane/interfaces/tf.py
@@ -212,7 +212,7 @@ class TFInterface(AnnotatedQueue):
 
                     vhp = tf.cond(
                         tf.rank(hessian) > 2,
-                        lambda: dy_row @ ddy @ hessian @ tf.transpose(dy_row),
+                        lambda: dy_row @ ddy @ hessian @ tf.transpose(dy_row) / tf.linalg.norm(dy_row) ** 2,
                         lambda: ddy @ hessian,
                     )
 

--- a/pennylane/interfaces/torch.py
+++ b/pennylane/interfaces/torch.py
@@ -144,6 +144,7 @@ class _TorchInterface(torch.autograd.Function):
 
                 if torch.squeeze(ddy).ndim > 1:
                     vhp = ctx_.dy.view(1, -1) @ ddy @ hessian @ ctx_.dy.view(-1, 1)
+                    vhp = vhp / torch.linalg.norm(ctx_.dy) ** 2
                 else:
                     vhp = ddy @ hessian
 

--- a/pennylane/interfaces/torch.py
+++ b/pennylane/interfaces/torch.py
@@ -15,7 +15,7 @@
 This module contains the mixin interface class for creating differentiable quantum tapes with
 PyTorch.
 """
-# pylint: disable=protected-access, attribute-defined-outside-init, arguments-differ, no-member, import-self
+# pylint: disable=protected-access, attribute-defined-outside-init, arguments-differ, no-member, import-self, too-many-statements
 import numpy as np
 import semantic_version
 import torch


### PR DESCRIPTION
**Context:** The existing parameter-shift Hessian implementation returns incorrect Hessians for cost functions that perform post-processing on a vector-valued QNode.

**Description of the Change:**

- The bug was fixed in all three main interfaces (autograd, PyTorch, TF), by making sure that the vector-Hessian product is divided by the norm squared of `dy`.

- Tests were added for all three interfaces to ensure that this bug is fixed.

**Benefits:** Fixes the aforementioned bug.

**Possible Drawbacks:** n/a

**Related GitHub Issues:** Fixes #1424
