### PR TITLE
Update default_gaussian.py

### DIFF
--- a/pennylane/devices/default_gaussian.py
+++ b/pennylane/devices/default_gaussian.py
@@ -350,7 +350,7 @@ def vacuum_state(wires, hbar=2.0):
     r"""Returns the vacuum state.
 
     Args:
-        wires (int): the number of wires to create the vacuum for
+        wires (int): the number of wires to initialize in the vacuum state
         hbar (float): (default 2) the value of :math:`\hbar` in the commutation
             relation :math:`[\x,\p]=i\hbar`
     Returns:

--- a/pennylane/devices/default_gaussian.py
+++ b/pennylane/devices/default_gaussian.py
@@ -350,7 +350,7 @@ def vacuum_state(wires, hbar=2.0):
     r"""Returns the vacuum state.
 
     Args:
-        basis (str): Returns the vector of means and the covariance matrix
+        wires (int): the number of wires to create the vacuum for
         hbar (float): (default 2) the value of :math:`\hbar` in the commutation
             relation :math:`[\x,\p]=i\hbar`
     Returns:

--- a/pennylane/devices/default_gaussian.py
+++ b/pennylane/devices/default_gaussian.py
@@ -437,10 +437,10 @@ def gaussian_state(cov, mu, hbar=2.0):
     r"""Returns a Gaussian state.
 
     This is simply a bare wrapper function,
-    since the means vector and covariance matrix
+    since the covariance matrix and means vector
     can be passed via the parameters unchanged.
 
-    Note that both the means vector and covariance
+    Note that both the covariance and means vector
     matrix should be in :math:`(\x_1,\dots, \x_N, \p_1, \dots, \p_N)`
     ordering.
 


### PR DESCRIPTION
Adjusts two existing parts of the documentation where we'd like the mention of the covariance matrix and the vector of means to be swapped. The order we would like is to have the covariance matrix first and the vector of means second. This adheres to the order used in Strawberry Fields.

This change is related to #1331 but falls out of its scope.