### PR TITLE
Differentiating `qml.QubitUnitary` using `default.qubit.autograd`

### DIFF
--- a/pennylane/devices/default_qubit_autograd.py
+++ b/pennylane/devices/default_qubit_autograd.py
@@ -181,4 +181,7 @@ class DefaultQubitAutograd(DefaultQubit):
         if isinstance(unitary, DiagonalOperation):
             return unitary.eigvals
 
+        if op_name == "QubitUnitary":
+            return unitary.data[0] + 0j
+
         return unitary.matrix


### PR DESCRIPTION
**Context:**

```python
import pennylane as qml
from pennylane import numpy as np

dev = qml.device('default.qubit', wires=3)

U = np.eye(8)

@qml.qnode(dev)
def c(U):
    qml.QubitUnitary(U, wires=[0,1,2])
    return qml.expval(qml.PauliZ(0))

qml.grad(c)(U)
```

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
