### PR TITLE
Numpy deprecations

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -214,6 +214,10 @@
 
 <h3>Improvements</h3>
 
+* Changed to using `np.object_` instead of `np.object` as per the NumPy
+  deprecations starting version 1.20.
+  [(#1466)](https://github.com/PennyLaneAI/pennylane/pull/1466)
+
 * Change the order of the covariance matrix and the vector of means internally
   in `default.gaussian`. [(#1331)](https://github.com/PennyLaneAI/pennylane/pull/1331)
 
@@ -260,7 +264,7 @@
 This release contains contributions from (in alphabetical order):
 
 Olivia Di Matteo, Josh Izaac, Leonhard Kunczik, Romain Moyard, Ashish Panigrahi, Maria Schuld,
-Jay Soni
+Jay Soni, Antal Száva
 
 
 # Release 0.16.0 (current release)

--- a/pennylane/devices/tests/test_gates.py
+++ b/pennylane/devices/tests/test_gates.py
@@ -219,12 +219,12 @@ phi = -0.1234
 U = np.array(
     [
         [
-            np.cos(theta / 2) * np.exp(np.complex(0, -phi / 2)),
-            -np.sin(theta / 2) * np.exp(np.complex(0, phi / 2)),
+            np.cos(theta / 2) * np.exp(np.complex128(-phi / 2j)),
+            -np.sin(theta / 2) * np.exp(np.complex128(phi / 2j)),
         ],
         [
-            np.sin(theta / 2) * np.exp(np.complex(0, -phi / 2)),
-            np.cos(theta / 2) * np.exp(np.complex(0, phi / 2)),
+            np.sin(theta / 2) * np.exp(np.complex128(-phi / 2j)),
+            np.cos(theta / 2) * np.exp(np.complex128(phi / 2j)),
         ],
     ]
 )

--- a/pennylane/tape/jacobian_tape.py
+++ b/pennylane/tape/jacobian_tape.py
@@ -649,7 +649,7 @@ class JacobianTape(QuantumTape):
                     # assume the dimension is 1
                     self._output_dim = 1
                 # create the Jacobian matrix with appropriate dtype
-                dtype = g.dtype if isinstance(g, (np.ndarray, float)) else np.object
+                dtype = g.dtype if isinstance(g, (np.ndarray, float)) else object
                 jac = np.zeros((self._output_dim, len(params)), dtype=dtype)
 
             jac[:, i] = g

--- a/pennylane/tape/jacobian_tape.py
+++ b/pennylane/tape/jacobian_tape.py
@@ -649,7 +649,7 @@ class JacobianTape(QuantumTape):
                     # assume the dimension is 1
                     self._output_dim = 1
                 # create the Jacobian matrix with appropriate dtype
-                dtype = g.dtype if isinstance(g, (np.ndarray, float)) else numpy.object_
+                dtype = g.dtype if isinstance(g, (np.ndarray, float)) else np.object_
                 jac = np.zeros((self._output_dim, len(params)), dtype=dtype)
 
             jac[:, i] = g


### PR DESCRIPTION
Changes the uses of `np.complex` and `np.object` as per the NumPy deprecations from version 1.20: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations.