### PR TITLE
Add example to FockStateVector docs.

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -334,6 +334,10 @@
 
 <h3>Documentation</h3>
 
+* Examples have been added to clarify use of the continuous-variable
+  `FockStateVector` operation in the multi-mode case.
+  [(#1472)](https://github.com/PennyLaneAI/pennylane/pull/1472)
+
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane/ops/cv.py
+++ b/pennylane/ops/cv.py
@@ -781,8 +781,8 @@ class FockStateVector(CVOperation):
                 return qml.expval(qml.NumberOperator(wires=0))
 
         For multiple modes, the input is the tensor product of individual-mode
-        kets. For example, given a set of :math:`M` `N`-dimensional vectors, the
-        input has shape `(N, ) * M`.
+        kets. For example, given a set of :math:`M` :math:`N`:-dimensional vectors, the
+        input has shape ``(N, ) * M``.
 
         .. code-block::
 

--- a/pennylane/ops/cv.py
+++ b/pennylane/ops/cv.py
@@ -763,6 +763,45 @@ class FockStateVector(CVOperation):
     Args:
         state (array): a single ket vector, for single mode state preparation,
             or a multimode ket, with one array dimension per mode
+
+    .. UsageDetails::
+
+        For a single mode with cutoff dimension :math:`N`, the input is a
+        1-dimensional vector of length :math:`N`.
+
+        .. code-block::
+
+            dev_fock = qml.device("strawberryfields.fock", wires=4, cutoff_dim=4)
+
+            state = np.array([0, 0, 1, 0])
+
+            @qml.qnode(dev_fock)
+            def circuit():
+                qml.FockStateVector(state, wires=0)
+                return qml.expval(qml.NumberOperator(wires=0))
+
+        For multiple modes, the input is the tensor product of individual-mode
+        kets. For example, given a set of :math:`M` `N`-dimensional vectors, the
+        input has shape `(N, ) * M`.
+
+        .. code-block::
+
+            used_wires = [0, 3]
+            cutoff_dim = 5
+
+            dev_fock = qml.device("strawberryfields.fock", wires=4, cutoff_dim=cutoff_dim)
+
+            state_1 = np.array([0, 1, 0, 0, 0])
+            state_2 = np.array([0, 0, 0, 1, 0])
+
+            combined_state = np.kron(state_1, state_2).reshape(
+                (cutoff_dim, ) * len(used_wires)
+            )
+
+            @qml.qnode(dev_fock)
+            def circuit():
+                qml.FockStateVector(combined_state, wires=used_wires)
+                return qml.expval(qml.NumberOperator(wires=0))
     """
     num_wires = AnyWires
     num_params = 1

--- a/pennylane/ops/cv.py
+++ b/pennylane/ops/cv.py
@@ -781,7 +781,7 @@ class FockStateVector(CVOperation):
                 return qml.expval(qml.NumberOperator(wires=0))
 
         For multiple modes, the input is the tensor product of individual-mode
-        kets. For example, given a set of :math:`M` :math:`N`:-dimensional vectors, the
+        kets. For example, given a set of :math:`M` :math:`N`-dimensional vectors, the
         input has shape ``(N, ) * M``.
 
         .. code-block::

--- a/pennylane/ops/cv.py
+++ b/pennylane/ops/cv.py
@@ -780,9 +780,9 @@ class FockStateVector(CVOperation):
                 qml.FockStateVector(state, wires=0)
                 return qml.expval(qml.NumberOperator(wires=0))
 
-        For multiple modes, the input is the tensor product of individual-mode
-        kets. For example, given a set of :math:`M` :math:`N`-dimensional vectors, the
-        input has shape ``(N, ) * M``.
+        For multiple modes, the input is the tensor product of single mode
+        kets. For example, given a set of :math:`M` single mode vectors of
+        length :math:`N`, the input should have shape ``(N, ) * M``.
 
         .. code-block::
 
@@ -802,6 +802,7 @@ class FockStateVector(CVOperation):
             def circuit():
                 qml.FockStateVector(combined_state, wires=used_wires)
                 return qml.expval(qml.NumberOperator(wires=0))
+
     """
     num_wires = AnyWires
     num_params = 1


### PR DESCRIPTION
**Context:** As described in [this issue](https://github.com/PennyLaneAI/pennylane-sf/issues/73), the docstring for the `FockStateVector` operation suggests that multi-mode states can be constructed with one dimension per wire, but does not clarify this must be constructed as a tensor product of single-mode states.

**Description of the Change:** Adds single-mode and multi-mode usage examples that specify dimensions required to construct `FockStateVector`.

**Benefits:** Improved clarity of docs.

**Possible Drawbacks:** None

**Related GitHub Issues:** Issue #[73](https://github.com/PennyLaneAI/pennylane-sf/issues/73) over in PennyLane-SF.
