### PR TITLE
make default precision equal to jax.config's jax_enable_x64

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -380,9 +380,13 @@
 
 <h3>Improvements</h3>
 
-* Changed the default precision used by the JAX device. It remains unchanged for
-  `jax.config.config.read('jax_enable_x64')==False` and changed to double precision
-  if `jax.config.config.read('jax_enable_x64')==True`.
+* The precision used by `default.qubit.jax` now matches the float precision
+  indicated by 
+  ```
+  from jax.config import config
+  config.read('jax_enable_x64')
+  ```
+  where `True` means `float64`/`complex128` and `False` means `float32`/`complex64`.
   [(#1485)](https://github.com/PennyLaneAI/pennylane/pull/1485)
 
 * The `./pennylane/ops/qubit.py` file is broken up into a folder of six separate files.

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -380,6 +380,11 @@
 
 <h3>Improvements</h3>
 
+* Changed the default precision used by the JAX device. It remains unchanged for
+  `jax.config.config.read('jax_enable_x64')==False` and changed to double precision
+  if `jax.config.config.read('jax_enable_x64')==True`.
+  [(#1485)](https://github.com/PennyLaneAI/pennylane/pull/1485)
+
 * The `./pennylane/ops/qubit.py` file is broken up into a folder of six separate files.
   [(#1467)](https://github.com/PennyLaneAI/pennylane/pull/1467)
 
@@ -444,7 +449,7 @@
 This release contains contributions from (in alphabetical order):
 
 Olivia Di Matteo, Josh Izaac, Leonhard Kunczik, Christina Lee, Romain Moyard, Ashish Panigrahi,
-Maria Schuld, Jay Soni, Antal Száva
+Maria Schuld, Jay Soni, Antal Száva, David Wierichs
 
 
 # Release 0.16.0 (current release)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -382,7 +382,7 @@
 
 * The precision used by `default.qubit.jax` now matches the float precision
   indicated by 
-  ```
+  ```python
   from jax.config import config
   config.read('jax_enable_x64')
   ```

--- a/pennylane/devices/default_qubit_jax.py
+++ b/pennylane/devices/default_qubit_jax.py
@@ -159,7 +159,7 @@ class DefaultQubitJax(DefaultQubit):
         "DoubleExcitationMinus": jax_ops.DoubleExcitationMinus,
     }
 
-    if jax_config.read('jax_enable_x64'):
+    if jax_config.read("jax_enable_x64"):
         C_DTYPE = jnp.complex128
         R_DTYPE = jnp.float64
     else:

--- a/pennylane/devices/default_qubit_jax.py
+++ b/pennylane/devices/default_qubit_jax.py
@@ -26,6 +26,7 @@ import numpy as np
 try:
     import jax.numpy as jnp
     import jax
+    from jax.config import config as jax_config
 
 except ImportError as e:  # pragma: no cover
     raise ImportError("default.qubit.jax device requires installing jax>0.2.0") from e
@@ -158,8 +159,12 @@ class DefaultQubitJax(DefaultQubit):
         "DoubleExcitationMinus": jax_ops.DoubleExcitationMinus,
     }
 
-    C_DTYPE = jnp.complex64
-    R_DTYPE = jnp.float32
+    if jax_config.read('jax_enable_x64'):
+        C_DTYPE = jnp.complex128
+        R_DTYPE = jnp.float64
+    else:
+        C_DTYPE = jnp.complex64
+        R_DTYPE = jnp.float32
     _asarray = staticmethod(jnp.array)
     _dot = staticmethod(jnp.dot)
     _abs = staticmethod(jnp.abs)

--- a/pennylane/devices/default_qubit_jax.py
+++ b/pennylane/devices/default_qubit_jax.py
@@ -159,12 +159,6 @@ class DefaultQubitJax(DefaultQubit):
         "DoubleExcitationMinus": jax_ops.DoubleExcitationMinus,
     }
 
-    if jax_config.read("jax_enable_x64"):
-        C_DTYPE = jnp.complex128
-        R_DTYPE = jnp.float64
-    else:
-        C_DTYPE = jnp.complex64
-        R_DTYPE = jnp.float32
     _asarray = staticmethod(jnp.array)
     _dot = staticmethod(jnp.dot)
     _abs = staticmethod(jnp.abs)
@@ -186,6 +180,12 @@ class DefaultQubitJax(DefaultQubit):
     _stack = staticmethod(jnp.stack)
 
     def __init__(self, wires, *, shots=None, prng_key=None, analytic=None):
+        if jax_config.read("jax_enable_x64"):
+            C_DTYPE = jnp.complex128
+            R_DTYPE = jnp.float64
+        else:
+            C_DTYPE = jnp.complex64
+            R_DTYPE = jnp.float32
         super().__init__(wires, shots=shots, cache=0, analytic=analytic)
 
         # prevent using special apply methods for these gates due to slowdown in jax

--- a/pennylane/devices/default_qubit_jax.py
+++ b/pennylane/devices/default_qubit_jax.py
@@ -181,11 +181,11 @@ class DefaultQubitJax(DefaultQubit):
 
     def __init__(self, wires, *, shots=None, prng_key=None, analytic=None):
         if jax_config.read("jax_enable_x64"):
-            C_DTYPE = jnp.complex128
-            R_DTYPE = jnp.float64
+            self.C_DTYPE = jnp.complex128
+            self.R_DTYPE = jnp.float64
         else:
-            C_DTYPE = jnp.complex64
-            R_DTYPE = jnp.float32
+            self.C_DTYPE = jnp.complex64
+            self.R_DTYPE = jnp.float32
         super().__init__(wires, shots=shots, cache=0, analytic=analytic)
 
         # prevent using special apply methods for these gates due to slowdown in jax

--- a/tests/devices/test_default_qubit_jax.py
+++ b/tests/devices/test_default_qubit_jax.py
@@ -2,6 +2,7 @@ import pytest
 
 jax = pytest.importorskip("jax", minversion="0.2")
 jnp = jax.numpy
+from jax.config import config
 import numpy as np
 import pennylane as qml
 from pennylane.devices.default_qubit_jax import DefaultQubitJax
@@ -62,6 +63,17 @@ class TestQNodeIntegration:
         assert dev.shots == None
         assert dev.short_name == "default.qubit.jax"
         assert dev.capabilities()["passthru_interface"] == "jax"
+
+    @pytest.mark.parametrize(
+        "jax_enable_x64, c_dtype, r_dtype",
+        ([True, np.complex128, np.float64], [False, np.complex64, np.float32]),
+    )
+    def test_float_precision(self, jax_enable_x64, c_dtype, r_dtype):
+        """Test that the plugin device uses the same float precision as the jax config."""
+        config.update("jax_enable_x64", jax_enable_x64)
+        dev = qml.device("default.qubit.jax", wires=2)
+        assert dev.state.dtype == c_dtype
+        assert dev.state.real.dtype == r_dtype
 
     def test_qubit_circuit(self, tol):
         """Test that the device provides the correct


### PR DESCRIPTION
The default qubit jax device currently always uses `float32` precision.
This change makes the device check the status of `jax.config.config.read('jax_enable_x64')`, which is the variable set to `True` by jax users to enable `float64` precision (also see [the jax gotcha](https://jax.readthedocs.io/en/latest/notebooks/Common_Gotchas_in_JAX.html#double-64bit-precision)).

**Benefit**
When users consciously change the default of jax' precision, the PennyLane device should play along and now does.

**Possible drawbacks**
The behaviour changes when `jax.config.config.read('jax_enable_x64')=True` but into the direction of what users would presumably expect.

An alternative method would be to use this update as new default but provide an override `precision` kwarg to allow for explicitly setting the precision. 