### PR TITLE
Add support for unwrapping of parameters, and determining trainability

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -411,7 +411,7 @@
   PR [(#1377)](https://github.com/PennyLaneAI/pennylane/pull/1377).
   [(#1438)](https://github.com/PennyLaneAI/pennylane/pull/1438)
 
-* The `qml.math` module, for autodiff framework-agnostic tensor manipulation,
+* The `qml.math` module, for framework-agnostic tensor manipulation,
   has two new functions available:
   [(#1490)](https://github.com/PennyLaneAI/pennylane/pull/1490)
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -406,6 +406,19 @@
 * Added the `id` attribute to templates, which was missing from 
   PR [(#1377)](https://github.com/PennyLaneAI/pennylane/pull/1377).
   [(#1438)](https://github.com/PennyLaneAI/pennylane/pull/1438)
+
+* The `qml.math` module, for autodiff framework-agnostic tensor manipulation,
+  has two new functions available:
+  [(#1490)](https://github.com/PennyLaneAI/pennylane/pull/1490)
+
+  - `qml.math.get_trainable_indices(sequence_of_tensors)`: returns the indices corresponding to
+    trainable tensors in the input sequence.
+
+  - `qml.math.unwrap(sequence_of_tensors)`: unwraps a sequence of tensor-like objects to NumPy
+    arrays.
+
+  In addition, the behaviour of `qml.math.requires_grad` has been improved in order to
+  correctly determine trainability during Autograd and JAX backwards passes.
   
 <h3>Breaking changes</h3>
 

--- a/pennylane/math/__init__.py
+++ b/pennylane/math/__init__.py
@@ -39,8 +39,10 @@ from .multi_dispatch import (
     concatenate,
     diag,
     dot,
+    get_trainable_indices,
     ones_like,
     stack,
+    unwrap,
     where,
 )
 
@@ -84,4 +86,6 @@ __all__ = [
     "requires_grad",
     "cov_matrix",
     "marginal_prob",
+    "unwrap",
+    "get_trainable",
 ]

--- a/pennylane/math/__init__.py
+++ b/pennylane/math/__init__.py
@@ -87,5 +87,5 @@ __all__ = [
     "cov_matrix",
     "marginal_prob",
     "unwrap",
-    "get_trainable",
+    "get_trainable_indices",
 ]

--- a/pennylane/math/multi_dispatch.py
+++ b/pennylane/math/multi_dispatch.py
@@ -15,10 +15,12 @@
 # pylint: disable=import-outside-toplevel,too-many-return-statements
 import warnings
 
+from autograd.numpy.numpy_boxes import ArrayBox
 from autoray import numpy as np
+from numpy import ndarray
 
 from . import single_dispatch  # pylint:disable=unused-import
-from .utils import cast, get_interface
+from .utils import cast, get_interface, requires_grad
 
 
 def _multi_dispatch(values):
@@ -250,6 +252,29 @@ def dot(tensor1, tensor2):
     return np.dot(x, y, like=interface)
 
 
+def get_trainable_indices(values):
+    """Returns a set containing the trainable indices of a sequence of
+    values.
+
+    Args:
+        values (Sequence[tensor_like]): Sequence of tensor-like objects to inspect
+
+    Returns:
+        set[int]: set containing the indices of the trainable tensor-like objects
+        within the input sequence.
+
+    **Example**
+    """
+    interface = _multi_dispatch(values)
+    trainable_params = set()
+
+    for idx, p in enumerate(values):
+        if requires_grad(p, interface=interface):
+            trainable_params.add(idx)
+
+    return trainable_params
+
+
 def ones_like(tensor, dtype=None):
     """Returns a tensor of all ones with the same shape and dtype
     as the input tensor.
@@ -340,3 +365,52 @@ def where(condition, x, y):
     tensor([ 0.6000,  0.2300,  0.7000, -4.0000, -5.0000], grad_fn=<SWhereBackward>)
     """
     return np.where(condition, x, y, like=_multi_dispatch([condition, x, y]))
+
+
+def unwrap(values, max_depth=None):
+    """Unwrap a sequence of objects to NumPy arrays.
+
+    Note that tensors on GPUs will automatically be copied
+    to the CPU.
+
+    Args:
+        values (Sequence[tensor_like]): sequence of tensor-like objects to unwrap
+        max_depth (int): Positive integer indicating the depth of unwrapping to perform
+            for nested tensor-objects. This argument only applies when unwrapping
+            Autograd ``ArrayBox`` objects.
+
+    **Example**
+
+    >>> values = [np.array([0.1, 0.2]), torch.tensor(0.1, dtype=torch.float64), torch.tensor([0.5, 0.2])]
+    >>> math.unwrap(values)
+    [array([0.1, 0.2]), 0.1, array([0.5, 0.2], dtype=float32)]
+
+    This function will continue to work during backpropagation:
+
+    >>> def cost_fn(params):
+    ...     unwrapped_params = math.unwrap(params)
+    ...     print("Unwrapped:", [(i, type(i)) for i in unwrapped_params])
+    ...     return np.sum(np.sin(params))
+    >>> params = np.array([0.1, 0.2, 0.3])
+    >>> grad = autograd.grad(cost_fn)(params)
+    Unwrapped: [(0.1, <class 'float'>), (0.2, <class 'float'>), (0.3, <class 'float'>)]
+    >>> print(grad)
+    [0.99500417 0.98006658 0.95533649]
+    """
+    interface = _multi_dispatch(values)
+
+    res = []
+
+    for t in values:
+        if isinstance(t, ArrayBox):
+            a = np.to_numpy(t, max_depth=max_depth)
+        else:
+            a = np.to_numpy(t)
+
+        if isinstance(a, ndarray) and not a.shape:
+            # if NumPy array is scalar, convert to a Python float
+            res.append(a.tolist())
+        else:
+            res.append(a)
+
+    return res

--- a/pennylane/math/multi_dispatch.py
+++ b/pennylane/math/multi_dispatch.py
@@ -397,8 +397,6 @@ def unwrap(values, max_depth=None):
     >>> print(grad)
     [0.99500417 0.98006658 0.95533649]
     """
-    interface = _multi_dispatch(values)
-
     res = []
 
     for t in values:

--- a/pennylane/math/multi_dispatch.py
+++ b/pennylane/math/multi_dispatch.py
@@ -264,6 +264,15 @@ def get_trainable_indices(values):
         within the input sequence.
 
     **Example**
+
+    >>> def cost_fn(params):
+    ...     print("Trainable:", qml.math.get_trainable_indices(params))
+    ...     return np.sum(np.sin(params[0] * params[1]))
+    >>> values = [np.array([0.1, 0.2], requires_grad=True),
+    ... np.array([0.5, 0.2], requires_grad=False)]
+    >>> cost_fn(values)
+    Trainable: {0}
+    tensor(0.0899685, requires_grad=True)
     """
     interface = _multi_dispatch(values)
     trainable_params = set()

--- a/pennylane/math/multi_dispatch.py
+++ b/pennylane/math/multi_dispatch.py
@@ -257,10 +257,10 @@ def get_trainable_indices(values):
     values.
 
     Args:
-        values (Sequence[tensor_like]): Sequence of tensor-like objects to inspect
+        values (Iterable[tensor_like]): Sequence of tensor-like objects to inspect
 
     Returns:
-        set[int]: set containing the indices of the trainable tensor-like objects
+        set[int]: Set containing the indices of the trainable tensor-like objects
         within the input sequence.
 
     **Example**

--- a/pennylane/math/utils.py
+++ b/pennylane/math/utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Utility functions"""
 # pylint: disable=import-outside-toplevel
+from autograd.numpy.numpy_boxes import ArrayBox
 import autoray as ar
 from autoray import numpy as np
 import numpy as _np
@@ -179,7 +180,7 @@ def get_interface(tensor):
     return res
 
 
-def requires_grad(tensor):
+def requires_grad(tensor, interface=None):
     """Returns True if the tensor is considered trainable.
 
     .. warning::
@@ -193,6 +194,8 @@ def requires_grad(tensor):
 
     Args:
         tensor (tensor_like): input tensor
+        interface (str): The name of the interface. If not provided,
+            will be determined automatically.
 
     **Example**
 
@@ -229,7 +232,7 @@ def requires_grad(tensor):
     ...     print(requires_grad(x))
     True
     """
-    interface = get_interface(tensor)
+    interface = interface or get_interface(tensor)
 
     if interface == "tensorflow":
         import tensorflow as tf
@@ -241,13 +244,23 @@ def requires_grad(tensor):
 
         return should_record_backprop([tf.convert_to_tensor(tensor)])
 
-    if interface in ("torch", "autograd"):
-        return tensor.requires_grad
+    if interface == "autograd":
+        if isinstance(tensor, ArrayBox):
+            return True
+
+        # Currently, in the Autograd interface, we assume
+        # that all objects are differentiable by default.
+        return getattr(tensor, "requires_grad", True)
+
+    if interface == "torch":
+        return getattr(tensor, "requires_grad", False)
 
     if interface == "numpy":
         return False
 
     if interface == "jax":
-        return True
+        import jax
+
+        return isinstance(tensor, jax.interpreters.ad.JVPTracer)
 
     raise ValueError(f"Argument {tensor} is an unknown object")

--- a/pennylane/math/utils.py
+++ b/pennylane/math/utils.py
@@ -194,8 +194,8 @@ def requires_grad(tensor, interface=None):
 
     Args:
         tensor (tensor_like): input tensor
-        interface (str): The name of the interface. If not provided,
-            will be determined automatically.
+        interface (str): The name of the interface. Will be determined automatically 
+            if not provided.
 
     **Example**
 

--- a/pennylane/math/utils.py
+++ b/pennylane/math/utils.py
@@ -194,7 +194,7 @@ def requires_grad(tensor, interface=None):
 
     Args:
         tensor (tensor_like): input tensor
-        interface (str): The name of the interface. Will be determined automatically 
+        interface (str): The name of the interface. Will be determined automatically
             if not provided.
 
     **Example**

--- a/tests/math/test_functions.py
+++ b/tests/math/test_functions.py
@@ -692,7 +692,7 @@ class TestRequiresGrad:
         assert not fn.requires_grad(t)
 
     def test_autograd_backwards(self):
-        """jax.DeviceArrays will always return True"""
+        """Autograd trainability corresponds to the requires_grad attribute during the backwards pass."""
         res = None
 
         def cost_fn(t, s):

--- a/tests/math/test_functions.py
+++ b/tests/math/test_functions.py
@@ -1543,7 +1543,7 @@ class TestUnwrap:
 
 
 class TestGetTrainable:
-    """Test getting trainable indices"""
+    """Tests for getting trainable indices"""
 
     def test_tensorflow(self):
         """Test that the trainability indices of a sequence of TensorFlow values

--- a/tests/math/test_functions.py
+++ b/tests/math/test_functions.py
@@ -1455,7 +1455,6 @@ class TestUnwrap:
         ]
         res = qml.math.unwrap(values)
         expected = [np.array([0.1, 0.2]), 0.1, np.array([0.5, 0.2])]
-        print(res)
         assert all(np.allclose(a, b) for a, b in zip(res, expected))
 
     def test_torch_unwrapping(self):

--- a/tests/math/test_functions.py
+++ b/tests/math/test_functions.py
@@ -20,6 +20,7 @@ import pytest
 import pennylane as qml
 from pennylane import numpy as np
 from pennylane import math as fn
+from autograd.numpy.numpy_boxes import ArrayBox
 
 
 tf = pytest.importorskip("tensorflow", minversion="2.1")
@@ -661,10 +662,26 @@ class TestRequiresGrad:
         """Vanilla NumPy arrays, sequences, and lists will always return False"""
         assert not fn.requires_grad(t)
 
-    @pytest.mark.parametrize("t", [jnp.array([1, 2, 3])])
-    def test_jax(self, t):
-        """jax.DeviceArrays will always return True"""
-        assert fn.requires_grad(t)
+    def test_jax(self):
+        """JAX DeviceArrays differentiability depends on the argnums argument"""
+        res = None
+
+        def cost_fn(t, s):
+            nonlocal res
+            res = [fn.requires_grad(t), fn.requires_grad(s)]
+            return jnp.sum(t * s)
+
+        t = jnp.array([1.0, 2.0, 3.0])
+        s = jnp.array([-2.0, -3.0, -4.0])
+
+        jax.grad(cost_fn, argnums=0)(t, s)
+        assert res == [True, False]
+
+        jax.grad(cost_fn, argnums=1)(t, s)
+        assert res == [False, True]
+
+        jax.grad(cost_fn, argnums=[0, 1])(t, s)
+        assert res == [True, True]
 
     def test_autograd(self):
         """Autograd arrays will simply return their requires_grad attribute"""
@@ -673,6 +690,38 @@ class TestRequiresGrad:
 
         t = np.array([1.0, 2.0], requires_grad=False)
         assert not fn.requires_grad(t)
+
+    def test_autograd_backwards(self):
+        """jax.DeviceArrays will always return True"""
+        res = None
+
+        def cost_fn(t, s):
+            nonlocal res
+            res = [fn.requires_grad(t), fn.requires_grad(s)]
+            return np.sum(t * s)
+
+        t = np.array([1.0, 2.0, 3.0])
+        s = np.array([-2.0, -3.0, -4.0])
+
+        qml.grad(cost_fn)(t, s)
+        assert res == [True, True]
+
+        t.requires_grad = False
+        qml.grad(cost_fn)(t, s)
+        assert res == [False, True]
+
+        t.requires_grad = True
+        s.requires_grad = False
+        qml.grad(cost_fn)(t, s)
+        assert res == [True, False]
+
+        t.requires_grad = False
+        s.requires_grad = False
+
+        with pytest.warns(UserWarning, match="Output seems independent of input"):
+            qml.grad(cost_fn)(t, s)
+
+        assert res == [False, False]
 
     def test_torch(self):
         """Torch tensors will simply return their requires_grad attribute"""
@@ -1392,3 +1441,179 @@ class TestCoercion:
         res = qml.math.coerce(tensors, like="torch")
         dtypes = [r.dtype for r in res]
         assert all(d is torch.complex64 for d in dtypes)
+
+
+class TestUnwrap:
+    """Test tensor unwrapping"""
+
+    def test_tensorflow_unwrapping(self):
+        """Test that a sequence of TensorFlow values is properly unwrapped"""
+        values = [
+            onp.array([0.1, 0.2]),
+            tf.Variable(0.1, dtype=tf.float64),
+            tf.constant([0.5, 0.2]),
+        ]
+        res = qml.math.unwrap(values)
+        expected = [np.array([0.1, 0.2]), 0.1, np.array([0.5, 0.2])]
+        print(res)
+        assert all(np.allclose(a, b) for a, b in zip(res, expected))
+
+    def test_torch_unwrapping(self):
+        """Test that a sequence of Torch values is properly unwrapped"""
+        values = [
+            onp.array([0.1, 0.2]),
+            torch.tensor(0.1, dtype=torch.float64),
+            torch.tensor([0.5, 0.2]),
+        ]
+        res = qml.math.unwrap(values)
+        expected = [np.array([0.1, 0.2]), 0.1, np.array([0.5, 0.2])]
+        assert all(np.allclose(a, b) for a, b in zip(res, expected))
+
+    def test_autograd_unwrapping_forward(self):
+        """Test that a sequence of Autograd values is properly unwrapped
+        during the forward pass"""
+        unwrapped_params = None
+
+        def cost_fn(params):
+            nonlocal unwrapped_params
+            unwrapped_params = qml.math.unwrap(params)
+            return np.sum(np.sin(params[0] * params[2])) + params[1]
+
+        values = [onp.array([0.1, 0.2]), np.tensor(0.1, dtype=np.float64), np.tensor([0.5, 0.2])]
+        cost_fn(values)
+
+        expected = [np.array([0.1, 0.2]), 0.1, np.array([0.5, 0.2])]
+        assert all(np.allclose(a, b) for a, b in zip(unwrapped_params, expected))
+        assert all(not isinstance(a, np.tensor) for a in unwrapped_params)
+
+    def test_autograd_unwrapping_backward(self):
+        """Test that a sequence of Autograd values is properly unwrapped
+        during the backward pass"""
+        unwrapped_params = None
+
+        def cost_fn(*params):
+            nonlocal unwrapped_params
+            unwrapped_params = qml.math.unwrap(params)
+            return np.sum(np.sin(params[0] * params[2])) + params[1]
+
+        values = [onp.array([0.1, 0.2]), np.tensor(0.1, dtype=np.float64), np.tensor([0.5, 0.2])]
+        grad = qml.grad(cost_fn)(*values)
+
+        expected = [np.array([0.1, 0.2]), 0.1, np.array([0.5, 0.2])]
+        assert all(np.allclose(a, b) for a, b in zip(unwrapped_params, expected))
+        assert all(not isinstance(a, ArrayBox) for a in unwrapped_params)
+
+    def test_autograd_unwrapping_backward_nested(self):
+        """Test that a sequence of Autograd values is properly unwrapped
+        during multiple backward passes"""
+        unwrapped_params = None
+
+        def cost_fn(p, max_depth=None):
+            nonlocal unwrapped_params
+            unwrapped_params = qml.math.unwrap(p, max_depth)
+            return np.sum(np.sin(np.prod(p)))
+
+        values = np.tensor([0.1, 0.2, 0.3])
+        hess = qml.jacobian(qml.grad(cost_fn))(values)
+
+        expected = np.array([0.1, 0.2, 0.3])
+        assert np.allclose(unwrapped_params, expected)
+        assert not isinstance(unwrapped_params, ArrayBox)
+
+        # Specifying max_depth=1 will result in the second backward
+        # pass not being unwrapped
+        hess = qml.jacobian(qml.grad(cost_fn))(values, max_depth=1)
+        assert all(isinstance(a, ArrayBox) for a in unwrapped_params)
+
+    def test_jax_unwrapping(self):
+        """Test that a sequence of Autograd values is properly unwrapped
+        during the forward pass"""
+        unwrapped_params = None
+
+        def cost_fn(params):
+            nonlocal unwrapped_params
+            unwrapped_params = qml.math.unwrap(params)
+            return np.sum(np.sin(params[0])) + params[2]
+
+        values = [jnp.array([0.1, 0.2]), onp.array(0.1, dtype=np.float64), jnp.array([0.5, 0.2])]
+        cost_fn(values)
+
+        expected = [np.array([0.1, 0.2]), 0.1, np.array([0.5, 0.2])]
+        assert all(np.allclose(a, b) for a, b in zip(unwrapped_params, expected))
+        assert all(not isinstance(a, np.tensor) for a in unwrapped_params)
+
+
+class TestGetTrainable:
+    """Test getting trainable indices"""
+
+    def test_tensorflow(self):
+        """Test that the trainability indices of a sequence of TensorFlow values
+        is correctly extracted"""
+        values = [
+            onp.array([0.1, 0.2]),
+            tf.Variable(0.1, dtype=tf.float64),
+            tf.constant([0.5, 0.2]),
+        ]
+
+        # outside of a gradient tape, no indices are trainable
+        res = qml.math.get_trainable_indices(values)
+        assert not res
+
+        # within a gradient tape, Variables are automatically watched
+        with tf.GradientTape():
+            res = qml.math.get_trainable_indices(values)
+
+        assert res == {1}
+
+        # Watching can be set manually
+        with tf.GradientTape() as tape:
+            tape.watch([values[2]])
+            res = qml.math.get_trainable_indices(values)
+
+        assert res == {1, 2}
+
+    def test_torch(self):
+        """Test that the trainability indices of a sequence of Torch values
+        is correctly extracted"""
+        values = [
+            onp.array([0.1, 0.2]),
+            torch.tensor(0.1, requires_grad=True),
+            torch.tensor([0.5, 0.2]),
+        ]
+        res = qml.math.get_trainable_indices(values)
+        assert res == {1}
+
+    def test_autograd(self):
+        """Test that the trainability indices of a sequence of Autograd arrays
+        is correctly extracted"""
+        res = None
+
+        def cost_fn(params):
+            nonlocal res
+            res = qml.math.get_trainable_indices(params)
+            return np.sum(np.sin(params[0] * params[2])) + params[1]
+
+        values = [[0.1, 0.2], np.tensor(0.1, requires_grad=True), np.tensor([0.5, 0.2])]
+        cost_fn(values)
+
+        # Currently, we assume *all* objects are trainable by default in Autograd
+        assert res == {0, 1, 2}
+
+    def test_autograd_unwrapping_backward(self):
+        """Test that the trainability indices of a sequence of Autograd arrays
+        is correctly extracted on the backward pass"""
+        res = None
+
+        def cost_fn(*params):
+            nonlocal res
+            res = qml.math.get_trainable_indices(params)
+            return np.sum(np.sin(params[0] * params[2])) + params[1]
+
+        values = [
+            np.array([0.1, 0.2]),
+            np.tensor(0.1, requires_grad=True),
+            np.tensor([0.5, 0.2], requires_grad=False),
+        ]
+        grad = qml.grad(cost_fn)(*values)
+
+        assert res == {0, 1}


### PR DESCRIPTION
**Context:** Cleans up the behaviour of `qml.math`, and adds better support for (a) unwrapping lists of tensors to NumPy arrays, and (b) determining trainability.

**Description of the Change:**

- `qml.math.requires_grad` is updated to work properly for both Autograd and JAX parameters, on both the forward and backward passes.

- `qml.math.get_trainable_indices` is added, which allows a sequence of tensor-like objects to be passed, and the indices corresponding to trainable tensors being returned.

- `qml.math.unwrap` unwraps a sequence of tensor-like objects to NumPy arrays.

**Benefits:** Clean and well-tested, interface agnostic methods for determining tensor trainability and conversions to NumPy arrays.

**Possible Drawbacks:** For the Autograd interface, assuming that `requires_grad=True` on non-tensor objects remains hard-coded in (for now).

**Related GitHub Issues:** n/a
