### PR TITLE
Adds a differentiable VJP transform

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -75,15 +75,18 @@
 * A new gradients module `qml.gradients` has been added, which provides
   differentiable quantum gradient transforms.
   [(#1476)](https://github.com/PennyLaneAI/pennylane/pull/1476)
+  [(#1494)](https://github.com/PennyLaneAI/pennylane/pull/1494)
 
   Available quantum gradient transforms include:
 
   - `qml.gradients.finite_diff`
+  - `qml.gradients.vjp`
+  - `qml.gradients.batch_vjp`
 
   For example,
 
   ```pycon
-  >>> with qml.tape.QuantumTape() as tape:
+  >>> with qml.tape.JacobianTape() as tape:
   ...     qml.RX(params[0], wires=0)
   ...     qml.RY(params[1], wires=0)
   ...     qml.RX(params[2], wires=0)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 <h3>New features since last release</h3>
 
+* Vector-Jacobian product transforms have been added to the `qml.gradients` package.
+  [(#1494)](https://github.com/PennyLaneAI/pennylane/pull/1494)
+
+  The new transforms include:
+
+  - `qml.gradients.vjp`
+  - `qml.gradients.batch_vjp`
+  
 <h3>Improvements</h3>
 
 * The tape does not verify any more that all Observables have owners in the annotated queue.
@@ -22,7 +30,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-Maria Schuld.
+Josh Izaac, Maria Schuld.
 
 # Release 0.17.0 (current release)
 
@@ -184,13 +192,10 @@ Maria Schuld.
   [(#1476)](https://github.com/PennyLaneAI/pennylane/pull/1476)
   [(#1479)](https://github.com/PennyLaneAI/pennylane/pull/1479)
   [(#1486)](https://github.com/PennyLaneAI/pennylane/pull/1486)
-  [(#1494)](https://github.com/PennyLaneAI/pennylane/pull/1494)
 
   Available quantum gradient transforms include:
 
   - `qml.gradients.finite_diff`
-  - `qml.gradients.vjp`
-  - `qml.gradients.batch_vjp`
   - `qml.gradients.param_shift`
   - `qml.gradients.param_shift_cv`
 

--- a/doc/code/qml_transforms.rst
+++ b/doc/code/qml_transforms.rst
@@ -4,3 +4,8 @@ qml.transforms
 .. currentmodule:: pennylane.transforms
 
 .. automodule:: pennylane.transforms
+
+
+.. currentmodule:: pennylane.gradients
+
+.. automodapi:: pennylane.gradients

--- a/doc/code/qml_transforms.rst
+++ b/doc/code/qml_transforms.rst
@@ -4,8 +4,3 @@ qml.transforms
 .. currentmodule:: pennylane.transforms
 
 .. automodule:: pennylane.transforms
-
-
-.. currentmodule:: pennylane.gradients
-
-.. automodapi:: pennylane.gradients

--- a/pennylane/gradients/__init__.py
+++ b/pennylane/gradients/__init__.py
@@ -19,4 +19,4 @@ from . import parameter_shift
 
 from .finite_difference import finite_diff, finite_diff_coeffs, generate_shifted_tapes
 from .parameter_shift import param_shift
-from .vjp import batch_vjp, vjp
+from .vjp import compute_vjp, batch_vjp, vjp

--- a/pennylane/gradients/__init__.py
+++ b/pennylane/gradients/__init__.py
@@ -19,3 +19,4 @@ from . import parameter_shift
 
 from .finite_difference import finite_diff, finite_diff_coeffs, generate_shifted_tapes
 from .parameter_shift import param_shift
+from .vjp import batch_vjp, vjp

--- a/pennylane/gradients/vjp.py
+++ b/pennylane/gradients/vjp.py
@@ -1,0 +1,234 @@
+# Copyright 2018-2021 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+This module contains functions for computing the vector-Jacobian product
+of a batch of tapes.
+"""
+from pennylane import math
+
+
+def _vector_jacobian_product(dy, jac):
+    """Compute the vector-Jacobian product for a given
+    vector of gradient outputs dy and a Jacobian Jac"""
+    dy_row = math.reshape(dy, [-1])
+    jac = math.transpose(math.stack(jac))
+    num_params = len(jac)
+    jac = math.reshape(jac, [-1, num_params])
+    return math.tensordot(jac, dy_row, [[0], [0]])
+
+
+def vjp(tape, dy, gradient_fn):
+    """Generate the gradient tapes and processing function required to compute
+    the vector-Jacobian products of a tape.
+
+    Args:
+        tape (.QuantumTape): quantum tape to differentiate
+        dy (tensor_like): Gradient-output vector`. Must have shape
+            matching the output shape of the corresponding tape.
+        gradient_fn (callable): the gradient transform to use to differentiate
+            the tape
+
+    Returns:
+        tensor_like or None: Vector-Jacobian product. Returns None if the tape
+        has no trainable parameters.
+
+    **Example**
+
+    Consider the following Torch-compatible quantum tape:
+
+    .. code-block:: python
+
+        import torch
+        from pennylane.interfaces.torch import TorchInterface
+
+        x = torch.tensor([[0.1, 0.2, 0.3],
+                          [0.4, 0.5, 0.6]], requires_grad=True, dtype=torch.float64)
+
+        with TorchInterface.apply(qml.tape.JacobianTape()) as tape:
+            qml.RX(x[0, 0], wires=0)
+            qml.RY(x[0, 1], wires=1)
+            qml.RZ(x[0, 2], wires=0)
+            qml.CNOT(wires=[0, 1])
+            qml.RX(x[1, 0], wires=1)
+            qml.RY(x[1, 1], wires=0)
+            qml.RZ(x[1, 2], wires=1)
+            qml.expval(qml.PauliZ(0))
+            qml.probs(wires=1)
+
+    We can use the ``vjp`` function to compute the vector-Jacobian product,
+    given a gradient-output vector ``dy``:
+
+    >>> dy = torch.tensor([1., 1., 1.], dtype=torch.float64)
+    >>> vjp_tapes, fn = qml.gradients.vjp(tape, dy, qml.gradients.param_shift)
+
+    Note that ``dy`` has shape ``(3,)``, matching the output dimension of the tape
+    (1 expectation and 2 probability values).
+
+    Executing the VJP tapes, and applying the processing function:
+
+    >>> dev = qml.device("default.qubit", wires=2)
+    >>> vjp = fn([t.execute(dev) for t in vjp_tapes])
+    >>> vjp
+    tensor([-0.6069, -0.0451,  0.0451, -0.0139, -0.2809,  0.2809],
+           dtype=torch.float64, grad_fn=<ViewBackward>)
+
+    The output VJP is also differentiable with respect to the tape parameters:
+
+    >>> cost = torch.sum(vjp)
+    >>> cost.backward()
+    >>> x.grad
+    tensor([[-1.1025e+00, -2.0554e-01, -1.4917e-01],
+            [-1.9429e-09, -9.1580e-01,  1.3878e-09]], dtype=torch.float64)
+    """
+    # t._par_info = {}
+    # t._update()
+    num_params = len(tape.trainable_params)
+
+    if num_params == 0:
+        # The tape has no trainable parameters; the VJP
+        # is simply none.
+        return [], lambda _: None
+
+    if math.allclose(dy, 0):
+        # If the dy vector is zero, then the
+        # corresponding element of the VJP will be zero,
+        # and we can avoid a quantum computation.
+        return [], lambda _: math.convert_like(np.zeros([num_params]), dy)
+
+    gradient_tapes, fn = gradient_fn(tape)
+
+    def processing_fn(results):
+        # postprocess results to compute the Jacobian
+        jac = fn(results)
+        return _vector_jacobian_product(dy, jac)
+
+    return gradient_tapes, processing_fn
+
+
+def batch_vjp(tapes, dys, gradient_fn, reduction="append"):
+    """Generate the gradient tapes and processing function required to compute
+    the vector-Jacobian products of a batch of tapes.
+
+    Args:
+        tapes (Sequence[.QuantumTape]): sequence of quantum tapes to differentiate
+        dys (Sequence[tensor_like]): Sequence of gradient-output vectors ``dy``. Must be the
+            same length as ``tapes``. Each ``dy`` tensor should have shape
+            matching the output shape of the corresponding tape.
+        gradient_fn (callable): the gradient transform to use to differentiate
+            the tapes
+        reduction (str): Determines how the vector-Jacobian products are returned.
+            If ``append``, then the output of the function will be of the form
+            ``List[tensor_like]``, with each element corresponding to the VJP of each
+            input tape. If ``extend``, then the output VJPs will be concatenated.
+
+    Returns:
+        List[tensor_like or None]: list of vector-Jacobian products. ``None`` elements corresponds
+        to tapes with no trainable parameters.
+
+    **Example**
+
+    Consider the following Torch-compatible quantum tapes:
+
+    .. code-block:: python
+
+        x = torch.tensor([[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]], requires_grad=True, dtype=torch.float64)
+
+        def ansatz(x):
+            qml.RX(x[0, 0], wires=0)
+            qml.RY(x[0, 1], wires=1)
+            qml.RZ(x[0, 2], wires=0)
+            qml.CNOT(wires=[0, 1])
+            qml.RX(x[1, 0], wires=1)
+            qml.RY(x[1, 1], wires=0)
+            qml.RZ(x[1, 2], wires=1)
+
+        with TorchInterface.apply(qml.tape.JacobianTape()) as tape1:
+            ansatz(x)
+            qml.expval(qml.PauliZ(0))
+            qml.probs(wires=1)
+
+        with TorchInterface.apply(qml.tape.JacobianTape()) as tape2:
+            ansatz(x)
+            qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
+
+        tapes = [tape1, tape2]
+
+    Both tapes share the same circuit ansatz, but have different measurement outputs.
+
+    We can use the ``batch_vjp`` function to compute the vector-Jacobian product,
+    given a list of gradient-output vectors ``dys`` per tape:
+
+    >>> dys = [torch.tensor([1., 1., 1.], dtype=torch.float64),
+    ...  torch.tensor([1.], dtype=torch.float64)]
+    >>> vjp_tapes, fn = qml.gradients.batch_vjp(tapes, dys, qml.gradients.param_shift)
+
+    Note that each ``dy`` has shape matching the output dimension of the tape
+    (``tape1`` has 1 expectation and 2 probability values --- 3 outputs --- and ``tape2``
+    has 1 expectation value).
+
+    Executing the VJP tapes, and applying the processing function:
+
+    >>> dev = qml.device("default.qubit", wires=2)
+    >>> vjps = fn([t.execute(dev) for t in vjp_tapes])
+    >>> vjps
+    [tensor([-0.6069, -0.0451,  0.0451, -0.0139, -0.2809,  0.2809],
+       dtype=torch.float64, grad_fn=<ViewBackward>),
+       tensor([ 0.1739, -0.1641, -0.0054, -0.2937, -0.4008,  0.0000],
+       dtype=torch.float64, grad_fn=<ViewBackward>)]
+
+    We have two VJPs; one per tape. Each one corresponds to the number of parameters
+    on the tapes (6).
+
+    The output VJPs are also differentiable with respect to the tape parameters:
+
+    >>> cost = torch.sum(vjps[0] + vjps[1])
+    >>> cost.backward()
+    >>> x.grad
+    tensor([[-4.7924e-01, -9.0857e-01, -2.4198e-01],
+            [-9.2973e-02, -1.0772e+00,  4.7184e-09]], dtype=torch.float64)
+    """
+    reshape_info = []
+    gradient_tapes = []
+    processing_fns = []
+
+    # Loop through the tapes and dys vector
+    for tape, dy in zip(tapes, dys):
+        g_tapes, fn = vjp(tape, dy, gradient_fn)
+
+        reshape_info.append(len(g_tapes))
+        processing_fns.append(fn)
+        gradient_tapes.extend(g_tapes)
+
+    def processing_fn(results):
+        vjps = []
+        start = 0
+
+        for t_idx, dy in zip(range(len(tapes)), dys):
+            # extract the correct results from the flat list
+            res_len = reshape_info[t_idx]
+            res_t = results[start : start + res_len]
+            start += res_len
+
+            # postprocess results to compute the VJP
+            vjp = processing_fns[t_idx](res_t)
+
+            if vjp is None:
+                vjps.append(None)
+                continue
+
+            getattr(vjps, reduction)(vjp)
+
+        return vjps
+
+    return gradient_tapes, processing_fn

--- a/pennylane/gradients/vjp.py
+++ b/pennylane/gradients/vjp.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """
 This module contains functions for computing the vector-Jacobian product
-of a batch of tapes.
+of tapes.
 """
 import numpy as np
 
@@ -24,9 +24,6 @@ def _vector_jacobian_product(dy, jac):
     """Compute the vector-Jacobian product for a given
     vector of gradient outputs dy and a Jacobian Jac"""
     dy_row = math.reshape(dy, [-1])
-    jac = math.transpose(math.stack(jac))
-    num_params = len(jac)
-    jac = math.reshape(jac, [-1, num_params])
     return math.tensordot(jac, dy_row, [[0], [0]])
 
 

--- a/pennylane/gradients/vjp.py
+++ b/pennylane/gradients/vjp.py
@@ -49,8 +49,38 @@ def compute_vjp(dy, jac):
 
 
 def vjp(tape, dy, gradient_fn):
-    """Generate the gradient tapes and processing function required to compute
+    r"""Generate the gradient tapes and processing function required to compute
     the vector-Jacobian products of a tape.
+
+    Consider a function :math:`\mathbf{f}(\mathbf{x})`. The Jacobian is given by
+
+    .. math::
+
+        \mathbf{J}_{\mathbf{f}}(\mathbf{x}) = \begin{pmatrix}
+            \frac{\partial f_1}{\partial x_1} &\cdots &\frac{\partial f_1}{\partial x_n}\\
+            \vdots &\ddots &\vdots\\
+            \frac{\partial f_m}{\partial x_1} &\cdots &\frac{\partial f_m}{\partial x_n}\\
+        \end{pmatrix}
+
+    During backpropagation, the chain rule is applied. For example, consider the
+    cost function :math:`h = y\circ f: \mathbb{R}^n \rightarrow \mathbb{R}`,
+    where :math:`y: \mathbb{R}^m \rightarrow \mathbb{R}`.
+    The gradient is:
+
+    .. math::
+
+        \nabla h(\mathbf{x}) = \frac{\partial y}{\partial \mathbf{f}} \frac{\partial \mathbf{f}}{\partial \mathbf{x}}
+        = \frac{\partial y}{\partial \mathbf{f}} \mathbf{J}_{\mathbf{f}}(\mathbf{x}).
+
+    Denote :math:`d\mathbf{y} = \frac{\partial y}{\partial \mathbf{f}}`; we can write this in the form
+    as a matrix multiplication:
+
+    .. math:: \left[\nabla h(\mathbf{x})\right]_{j} = \sum_{i=0}^m d\mathbf{y}_i ~ \mathbf{J}_{ij}.
+
+    Thus, we can see that the gradient of the cost function is given by the so-called
+    **vector-Jacobian product**; the product of the row-vector :math:`d\mathbf{y}`, representing
+    the gradient of subsequent components of the cost function, and :math:`\mathbf{J}`,
+    the Jacobian of the current node of interest.
 
     Args:
         tape (.QuantumTape): quantum tape to differentiate
@@ -137,8 +167,38 @@ def vjp(tape, dy, gradient_fn):
 
 
 def batch_vjp(tapes, dys, gradient_fn, reduction="append"):
-    """Generate the gradient tapes and processing function required to compute
+    r"""Generate the gradient tapes and processing function required to compute
     the vector-Jacobian products of a batch of tapes.
+
+    Consider a function :math:`\mathbf{f}(\mathbf{x})`. The Jacobian is given by
+
+    .. math::
+
+        \mathbf{J}_{\mathbf{f}}(\mathbf{x}) = \begin{pmatrix}
+            \frac{\partial f_1}{\partial x_1} &\cdots &\frac{\partial f_1}{\partial x_n}\\
+            \vdots &\ddots &\vdots\\
+            \frac{\partial f_m}{\partial x_1} &\cdots &\frac{\partial f_m}{\partial x_n}\\
+        \end{pmatrix}
+
+    During backpropagation, the chain rule is applied. For example, consider the
+    cost function :math:`h = y\circ f: \mathbb{R}^n \rightarrow \mathbb{R}`,
+    where :math:`y: \mathbb{R}^m \rightarrow \mathbb{R}`.
+    The gradient is:
+
+    .. math::
+
+        \nabla h(\mathbf{x}) = \frac{\partial y}{\partial \mathbf{f}} \frac{\partial \mathbf{f}}{\partial \mathbf{x}}
+        = \frac{\partial y}{\partial \mathbf{f}} \mathbf{J}_{\mathbf{f}}(\mathbf{x}).
+
+    Denote :math:`d\mathbf{y} = \frac{\partial y}{\partial \mathbf{f}}`; we can write this in the form
+    as a matrix multiplication:
+
+    .. math:: \left[\nabla h(\mathbf{x})\right]_{j} = \sum_{i=0}^m d\mathbf{y}_i ~ \mathbf{J}_{ij}.
+
+    Thus, we can see that the gradient of the cost function is given by the so-called
+    **vector-Jacobian product**; the product of the row-vector :math:`d\mathbf{y}`, representing
+    the gradient of subsequent components of the cost function, and :math:`\mathbf{J}`,
+    the Jacobian of the current node of interest.
 
     Args:
         tapes (Sequence[.QuantumTape]): sequence of quantum tapes to differentiate

--- a/pennylane/gradients/vjp.py
+++ b/pennylane/gradients/vjp.py
@@ -50,7 +50,7 @@ def compute_vjp(dy, jac):
 
 def vjp(tape, dy, gradient_fn):
     r"""Generate the gradient tapes and processing function required to compute
-    the vector-Jacobian products of a tape.
+    the vector-Jacobian product of a tape.
 
     Consider a function :math:`\mathbf{f}(\mathbf{x})`. The Jacobian is given by
 
@@ -60,7 +60,7 @@ def vjp(tape, dy, gradient_fn):
             \frac{\partial f_1}{\partial x_1} &\cdots &\frac{\partial f_1}{\partial x_n}\\
             \vdots &\ddots &\vdots\\
             \frac{\partial f_m}{\partial x_1} &\cdots &\frac{\partial f_m}{\partial x_n}\\
-        \end{pmatrix}
+        \end{pmatrix}.
 
     During backpropagation, the chain rule is applied. For example, consider the
     cost function :math:`h = y\circ f: \mathbb{R}^n \rightarrow \mathbb{R}`,
@@ -73,7 +73,7 @@ def vjp(tape, dy, gradient_fn):
         = \frac{\partial y}{\partial \mathbf{f}} \mathbf{J}_{\mathbf{f}}(\mathbf{x}).
 
     Denote :math:`d\mathbf{y} = \frac{\partial y}{\partial \mathbf{f}}`; we can write this in the form
-    as a matrix multiplication:
+    of a matrix multiplication:
 
     .. math:: \left[\nabla h(\mathbf{x})\right]_{j} = \sum_{i=0}^m d\mathbf{y}_i ~ \mathbf{J}_{ij}.
 
@@ -178,7 +178,7 @@ def batch_vjp(tapes, dys, gradient_fn, reduction="append"):
             \frac{\partial f_1}{\partial x_1} &\cdots &\frac{\partial f_1}{\partial x_n}\\
             \vdots &\ddots &\vdots\\
             \frac{\partial f_m}{\partial x_1} &\cdots &\frac{\partial f_m}{\partial x_n}\\
-        \end{pmatrix}
+        \end{pmatrix}.
 
     During backpropagation, the chain rule is applied. For example, consider the
     cost function :math:`h = y\circ f: \mathbb{R}^n \rightarrow \mathbb{R}`,
@@ -191,7 +191,7 @@ def batch_vjp(tapes, dys, gradient_fn, reduction="append"):
         = \frac{\partial y}{\partial \mathbf{f}} \mathbf{J}_{\mathbf{f}}(\mathbf{x}).
 
     Denote :math:`d\mathbf{y} = \frac{\partial y}{\partial \mathbf{f}}`; we can write this in the form
-    as a matrix multiplication:
+    of a matrix multiplication:
 
     .. math:: \left[\nabla h(\mathbf{x})\right]_{j} = \sum_{i=0}^m d\mathbf{y}_i ~ \mathbf{J}_{ij}.
 

--- a/pennylane/gradients/vjp.py
+++ b/pennylane/gradients/vjp.py
@@ -20,10 +20,31 @@ import numpy as np
 from pennylane import math
 
 
-def _vector_jacobian_product(dy, jac):
-    """Compute the vector-Jacobian product for a given
-    vector of gradient outputs dy and a Jacobian Jac"""
+def compute_vjp(dy, jac):
+    """Convenience function to compute the vector-Jacobian product for a given
+    vector of gradient outputs and a Jacobian.
+
+    Args:
+        dy (tensor_like): vector of gradient outputs
+        jac (tensor_like): Jacobian matrix. For an n-dimensional ``dy``
+            vector, the first n-dimensions of ``jac`` should match
+            the shape of ``dy``.
+
+    Returns:
+        tensor_like: the vector-Jacobian product
+    """
+    if jac is None:
+        return None
+
     dy_row = math.reshape(dy, [-1])
+    jac = math.reshape(jac, [dy_row.shape[0], -1])
+
+    if math.allclose(dy, 0):
+        # If the dy vector is zero, then the
+        # corresponding element of the VJP will be zero.
+        num_params = jac.shape[1]
+        return math.convert_like(np.zeros([num_params]), dy)
+
     return math.tensordot(jac, dy_row, [[0], [0]])
 
 
@@ -110,7 +131,7 @@ def vjp(tape, dy, gradient_fn):
     def processing_fn(results):
         # postprocess results to compute the Jacobian
         jac = fn(results)
-        return _vector_jacobian_product(dy, jac)
+        return compute_vjp(dy, jac)
 
     return gradient_tapes, processing_fn
 

--- a/pennylane/gradients/vjp.py
+++ b/pennylane/gradients/vjp.py
@@ -15,6 +15,8 @@
 This module contains functions for computing the vector-Jacobian product
 of a batch of tapes.
 """
+import numpy as np
+
 from pennylane import math
 
 
@@ -214,20 +216,20 @@ def batch_vjp(tapes, dys, gradient_fn, reduction="append"):
         vjps = []
         start = 0
 
-        for t_idx, dy in zip(range(len(tapes)), dys):
+        for t_idx in range(len(tapes)):
             # extract the correct results from the flat list
             res_len = reshape_info[t_idx]
             res_t = results[start : start + res_len]
             start += res_len
 
             # postprocess results to compute the VJP
-            vjp = processing_fns[t_idx](res_t)
+            vjp_ = processing_fns[t_idx](res_t)
 
-            if vjp is None:
+            if vjp_ is None:
                 vjps.append(None)
                 continue
 
-            getattr(vjps, reduction)(vjp)
+            getattr(vjps, reduction)(vjp_)
 
         return vjps
 

--- a/pennylane/gradients/vjp.py
+++ b/pennylane/gradients/vjp.py
@@ -54,7 +54,7 @@ def vjp(tape, dy, gradient_fn):
 
     Args:
         tape (.QuantumTape): quantum tape to differentiate
-        dy (tensor_like): Gradient-output vector`. Must have shape
+        dy (tensor_like): Gradient-output vector. Must have shape
             matching the output shape of the corresponding tape.
         gradient_fn (callable): the gradient transform to use to differentiate
             the tape

--- a/pennylane/math/utils.py
+++ b/pennylane/math/utils.py
@@ -18,8 +18,6 @@ import autoray as ar
 from autoray import numpy as np
 import numpy as _np
 
-import pennylane as qml
-
 from . import single_dispatch  # pylint:disable=unused-import
 
 

--- a/pennylane/math/utils.py
+++ b/pennylane/math/utils.py
@@ -18,6 +18,8 @@ import autoray as ar
 from autoray import numpy as np
 import numpy as _np
 
+import pennylane as qml
+
 from . import single_dispatch  # pylint:disable=unused-import
 
 
@@ -55,9 +57,14 @@ def allequal(tensor1, tensor2, **kwargs):
 def allclose(a, b, rtol=1e-05, atol=1e-08, **kwargs):
     """Wrapper around np.allclose, allowing tensors ``a`` and ``b``
     to differ in type"""
-    t1 = ar.to_numpy(a)
-    t2 = ar.to_numpy(b)
-    return np.allclose(t1, t2, rtol=rtol, atol=atol, **kwargs)
+    try:
+        res = np.allclose(a, b, rtol=rtol, atol=atol, **kwargs)
+    except (TypeError, AttributeError):
+        t1 = ar.to_numpy(a)
+        t2 = ar.to_numpy(b)
+        res = np.allclose(t1, t2, rtol=rtol, atol=atol, **kwargs)
+
+    return res
 
 
 allclose.__doc__ = _np.allclose.__doc__

--- a/pennylane/math/utils.py
+++ b/pennylane/math/utils.py
@@ -56,8 +56,17 @@ def allclose(a, b, rtol=1e-05, atol=1e-08, **kwargs):
     """Wrapper around np.allclose, allowing tensors ``a`` and ``b``
     to differ in type"""
     try:
+        # Some frameworks may provide their own allclose implementation.
+        # Try and use it if available.
         res = np.allclose(a, b, rtol=rtol, atol=atol, **kwargs)
     except (TypeError, AttributeError):
+        # Otherwise, convert the input to NumPy arrays.
+        #
+        # TODO: replace this with a bespoke, framework agnostic
+        # low-level implementation to avoid the NumPy conversion:
+        #
+        #    np.abs(a - b) <= atol + rtol * np.abs(b)
+        #
         t1 = ar.to_numpy(a)
         t2 = ar.to_numpy(b)
         res = np.allclose(t1, t2, rtol=rtol, atol=atol, **kwargs)

--- a/tests/gradients/test_vjp.py
+++ b/tests/gradients/test_vjp.py
@@ -344,7 +344,7 @@ class TestBatchVJP:
         assert res[1] is not None
 
     def test_all_tapes_no_trainable_parameters(self):
-        """A tape with no trainable parameters will simply return None"""
+        """If all tapes have no trainable parameters all outputs will be None"""
         dev = qml.device("default.qubit", wires=2)
 
         with qml.tape.QuantumTape() as tape1:
@@ -370,7 +370,7 @@ class TestBatchVJP:
         assert fn([]) == [None, None]
 
     def test_zero_dy(self):
-        """ "A zero dy vector will return no tapes and a zero matrix"""
+        """A zero dy vector will return no tapes and a zero matrix"""
         dev = qml.device("default.qubit", wires=2)
 
         with qml.tape.QuantumTape() as tape1:
@@ -399,7 +399,8 @@ class TestBatchVJP:
         assert np.allclose(res[0], 0)
 
     def test_reduction_append(self):
-        """ "Test the 'append' reduction strategy"""
+        """Test the 'append' reduction strategy"""
+
         dev = qml.device("default.qubit", wires=2)
 
         with qml.tape.JacobianTape() as tape1:
@@ -428,7 +429,7 @@ class TestBatchVJP:
         assert all(len(r) == len(t.trainable_params) for t, r in zip(tapes, res))
 
     def test_reduction_extend(self):
-        """ "Test the 'extend' reduction strategy"""
+        """Test the 'extend' reduction strategy"""
         dev = qml.device("default.qubit", wires=2)
 
         with qml.tape.JacobianTape() as tape1:

--- a/tests/gradients/test_vjp.py
+++ b/tests/gradients/test_vjp.py
@@ -208,7 +208,7 @@ class TestVJPGradients:
         torch = pytest.importorskip("torch")
         from pennylane.interfaces.torch import TorchInterface
 
-        dev = qml.device("default.qubit.tf", wires=2)
+        dev = qml.device("default.qubit", wires=2)
 
         params = torch.tensor([0.543, -0.654], requires_grad=True, dtype=torch.float64)
         dy = torch.tensor([-1.0, 0.0, 0.0, 1.0], dtype=torch.float64)

--- a/tests/gradients/test_vjp.py
+++ b/tests/gradients/test_vjp.py
@@ -1,0 +1,426 @@
+# Copyright 2018-2021 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the gradients.vjp module."""
+from functools import partial
+
+import pytest
+
+import pennylane as qml
+from pennylane import numpy as np
+from pennylane.gradients import param_shift
+
+
+class TestVJP:
+    """Tests for the vjp function"""
+
+    def test_no_trainable_parameters(self):
+        """A tape with no trainable parameters will simply return None"""
+
+        with qml.tape.QuantumTape() as tape:
+            qml.RX(0.4, wires=0)
+            qml.CNOT(wires=[0, 1])
+            qml.expval(qml.PauliZ(0))
+
+        tape.trainable_params = {}
+        dy = np.array([1.0])
+        tapes, fn = qml.gradients.vjp(tape, dy, param_shift)
+
+        assert not tapes
+        assert fn(tapes) is None
+
+    def test_zero_dy(self):
+        """A zero dy vector will return no tapes and a zero matrix"""
+
+        with qml.tape.QuantumTape() as tape:
+            qml.RX(0.4, wires=0)
+            qml.RX(0.6, wires=0)
+            qml.CNOT(wires=[0, 1])
+            qml.expval(qml.PauliZ(0))
+
+        tape.trainable_params = {0, 1}
+        dy = np.array([0.0])
+        tapes, fn = qml.gradients.vjp(tape, dy, param_shift)
+
+        assert not tapes
+        assert np.all(fn(tapes) == np.zeros([len(tape.trainable_params)]))
+
+    def test_single_expectation_value(self, tol):
+        """Tests correct output shape and evaluation for a tape
+        with a single expval output"""
+        dev = qml.device("default.qubit", wires=2)
+        x = 0.543
+        y = -0.654
+
+        with qml.tape.JacobianTape() as tape:
+            qml.RX(x, wires=[0])
+            qml.RY(y, wires=[1])
+            qml.CNOT(wires=[0, 1])
+            qml.expval(qml.PauliZ(0) @ qml.PauliX(1))
+
+        tape.trainable_params = {0, 1}
+        dy = np.array([1.0])
+
+        tapes, fn = qml.gradients.vjp(tape, dy, param_shift)
+        assert len(tapes) == 4
+
+        res = fn(dev.batch_execute(tapes))
+        assert res.shape == (2,)
+
+        expected = np.array([-np.sin(y) * np.sin(x), np.cos(y) * np.cos(x)])
+        assert np.allclose(res, expected, atol=tol, rtol=0)
+
+    def test_multiple_expectation_values(self, tol):
+        """Tests correct output shape and evaluation for a tape
+        with multiple expval outputs"""
+        dev = qml.device("default.qubit", wires=2)
+        x = 0.543
+        y = -0.654
+
+        with qml.tape.JacobianTape() as tape:
+            qml.RX(x, wires=[0])
+            qml.RY(y, wires=[1])
+            qml.CNOT(wires=[0, 1])
+            qml.expval(qml.PauliZ(0))
+            qml.expval(qml.PauliX(1))
+
+        tape.trainable_params = {0, 1}
+        dy = np.array([1.0, 2.0])
+
+        tapes, fn = qml.gradients.vjp(tape, dy, param_shift)
+        assert len(tapes) == 4
+
+        res = fn(dev.batch_execute(tapes))
+        assert res.shape == (2,)
+
+        expected = np.array([-np.sin(x), 2 * np.cos(y)])
+        assert np.allclose(res, expected, atol=tol, rtol=0)
+
+    def test_prob_expectation_values(self, tol):
+        """Tests correct output shape and evaluation for a tape
+        with prob and expval outputs"""
+        dev = qml.device("default.qubit", wires=2)
+        x = 0.543
+        y = -0.654
+
+        with qml.tape.JacobianTape() as tape:
+            qml.RX(x, wires=[0])
+            qml.RY(y, wires=[1])
+            qml.CNOT(wires=[0, 1])
+            qml.expval(qml.PauliZ(0))
+            qml.probs(wires=[0, 1])
+
+        tape.trainable_params = {0, 1}
+        dy = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+
+        tapes, fn = qml.gradients.vjp(tape, dy, param_shift)
+        assert len(tapes) == 4
+
+        res = fn(dev.batch_execute(tapes))
+        assert res.shape == (2,)
+
+        expected = (
+            np.array(
+                [
+                    [-2 * np.sin(x), 0],
+                    [
+                        -(np.cos(y / 2) ** 2 * np.sin(x)),
+                        -(np.cos(x / 2) ** 2 * np.sin(y)),
+                    ],
+                    [
+                        -(np.sin(x) * np.sin(y / 2) ** 2),
+                        (np.cos(x / 2) ** 2 * np.sin(y)),
+                    ],
+                    [
+                        (np.sin(x) * np.sin(y / 2) ** 2),
+                        (np.sin(x / 2) ** 2 * np.sin(y)),
+                    ],
+                    [
+                        (np.cos(y / 2) ** 2 * np.sin(x)),
+                        -(np.sin(x / 2) ** 2 * np.sin(y)),
+                    ],
+                ]
+            )
+            / 2
+        )
+
+        assert np.allclose(res, dy @ expected, atol=tol, rtol=0)
+
+
+def expected(params):
+    x, y = 1.0 * params
+    return (
+        np.array(
+            [
+                (np.cos(y / 2) ** 2 * np.sin(x)) + (np.cos(y / 2) ** 2 * np.sin(x)),
+                (np.cos(x / 2) ** 2 * np.sin(y)) - (np.sin(x / 2) ** 2 * np.sin(y)),
+            ]
+        )
+        / 2
+    )
+
+
+def ansatz(x, y):
+    qml.RX(x, wires=[0])
+    qml.RY(y, wires=[1])
+    qml.CNOT(wires=[0, 1])
+    qml.probs(wires=[0, 1])
+
+
+class TestVJPGradients:
+    """Gradient tests for the vjp function"""
+
+    def test_autograd(self, tol):
+        """Tests that the output of the VJP transform
+        can be differentiated using autograd."""
+        dev = qml.device("default.qubit.autograd", wires=2)
+        params = np.array([0.543, -0.654], requires_grad=True)
+
+        def cost_fn(x, dy):
+            with qml.tape.JacobianTape() as tape:
+                ansatz(x[0], x[1])
+
+            tape.trainable_params = {0, 1}
+            tapes, fn = qml.gradients.vjp(tape, dy, param_shift)
+            vjp = fn(dev.batch_execute(tapes))
+            return vjp
+
+        dy = np.array([-1.0, 0.0, 0.0, 1.0], requires_grad=False)
+        res = cost_fn(params, dy)
+        assert np.allclose(res, expected(params), atol=tol, rtol=0)
+
+        res = qml.jacobian(cost_fn)(params, dy)
+        assert np.allclose(res, qml.jacobian(expected)(params), atol=tol, rtol=0)
+
+    def test_torch(self, tol):
+        """Tests that the output of the VJP transform
+        can be differentiated using Torch."""
+        torch = pytest.importorskip("torch")
+        from pennylane.interfaces.torch import TorchInterface
+
+        dev = qml.device("default.qubit.tf", wires=2)
+
+        params = torch.tensor([0.543, -0.654], requires_grad=True, dtype=torch.float64)
+        dy = torch.tensor([-1.0, 0.0, 0.0, 1.0], dtype=torch.float64)
+
+        with TorchInterface.apply(qml.tape.QubitParamShiftTape()) as tape:
+            ansatz(params[0], params[1])
+
+        tape.trainable_params = {0, 1}
+        tapes, fn = qml.gradients.vjp(tape, dy, param_shift)
+        vjp = fn([t.execute(dev) for t in tapes])
+
+        assert np.allclose(vjp.detach(), expected(params.detach()), atol=tol, rtol=0)
+
+        cost = vjp[0, 0]
+        cost.backward()
+
+        exp = qml.jacobian(lambda x: expected(x)[0])(params.detach().numpy())
+        assert np.allclose(params.grad, exp, atol=tol, rtol=0)
+
+    def test_tf(self, tol):
+        """Tests that the output of the VJP transform
+        can be differentiated using TF."""
+        tf = pytest.importorskip("tensorflow")
+
+        dev = qml.device("default.qubit.tf", wires=2)
+
+        params = tf.Variable([0.543, -0.654], dtype=tf.float64)
+        dy = tf.constant([-1.0, 0.0, 0.0, 1.0], dtype=tf.float64)
+
+        with tf.GradientTape() as t:
+            with qml.tape.JacobianTape() as tape:
+                ansatz(params[0], params[1])
+
+            tape.trainable_params = {0, 1}
+            tapes, fn = qml.gradients.vjp(tape, dy, param_shift)
+            vjp = fn(dev.batch_execute(tapes))
+
+        assert np.allclose(vjp, expected(params), atol=tol, rtol=0)
+
+        res = t.jacobian(vjp, params)
+        assert np.allclose(res, qml.jacobian(expected)(params.numpy()), atol=tol, rtol=0)
+
+    def test_jax(self, tol):
+        """Tests that the output of the VJP transform
+        can be differentiated using JAX."""
+        jax = pytest.importorskip("jax")
+        from jax import numpy as jnp
+
+        dev = qml.device("default.qubit.jax", wires=2)
+        params = jnp.array([0.543, -0.654])
+
+        @partial(jax.jit, static_argnums=1)
+        def cost_fn(x, dy):
+            with qml.tape.JacobianTape() as tape:
+                ansatz(x[0], x[1])
+
+            tape.trainable_params = {0, 1}
+            tapes, fn = qml.gradients.vjp(tape, dy, param_shift)
+            vjp = fn(dev.batch_execute(tapes))
+            return vjp
+
+        dy = (-1.0, 0.0, 0.0, 1.0)
+        res = cost_fn(params, dy)
+        assert np.allclose(res, expected(params), atol=tol, rtol=0)
+
+        res = jax.jacobian(cost_fn, argnums=0)(params, dy)
+        exp = qml.jacobian(expected)(np.array(params))
+        assert np.allclose(res, exp, atol=tol, rtol=0)
+
+
+class TestBatchVJP:
+    """Tests for the batch VJP function"""
+
+    def test_one_tape_no_trainable_parameters(self):
+        """A tape with no trainable parameters will simply return None"""
+        dev = qml.device("default.qubit", wires=2)
+
+        with qml.tape.QuantumTape() as tape1:
+            qml.RX(0.4, wires=0)
+            qml.CNOT(wires=[0, 1])
+            qml.expval(qml.PauliZ(0))
+
+        with qml.tape.JacobianTape() as tape2:
+            qml.RX(0.4, wires=0)
+            qml.RX(0.6, wires=0)
+            qml.CNOT(wires=[0, 1])
+            qml.expval(qml.PauliZ(0))
+
+        tape1.trainable_params = {}
+        tape2.trainable_params = {0, 1}
+
+        tapes = [tape1, tape2]
+        dys = [np.array([1.0]), np.array([1.0])]
+
+        v_tapes, fn = qml.gradients.batch_vjp(tapes, dys, param_shift)
+        assert len(v_tapes) == 4
+
+        # Even though there are 3 parameters, only two contribute
+        # to the VJP, so only 2*2=4 quantum evals
+        res = fn(dev.batch_execute(v_tapes))
+        assert res[0] is None
+        assert res[1] is not None
+
+    def test_all_tapes_no_trainable_parameters(self):
+        """A tape with no trainable parameters will simply return None"""
+        dev = qml.device("default.qubit", wires=2)
+
+        with qml.tape.QuantumTape() as tape1:
+            qml.RX(0.4, wires=0)
+            qml.CNOT(wires=[0, 1])
+            qml.expval(qml.PauliZ(0))
+
+        with qml.tape.QuantumTape() as tape2:
+            qml.RX(0.4, wires=0)
+            qml.RX(0.6, wires=0)
+            qml.CNOT(wires=[0, 1])
+            qml.expval(qml.PauliZ(0))
+
+        tape1.trainable_params = set()
+        tape2.trainable_params = set()
+
+        tapes = [tape1, tape2]
+        dys = [np.array([1.0]), np.array([1.0])]
+
+        v_tapes, fn = qml.gradients.batch_vjp(tapes, dys, param_shift)
+
+        assert v_tapes == []
+        assert fn([]) == [None, None]
+
+    def test_zero_dy(self):
+        """ "A zero dy vector will return no tapes and a zero matrix"""
+        dev = qml.device("default.qubit", wires=2)
+
+        with qml.tape.QuantumTape() as tape1:
+            qml.RX(0.4, wires=0)
+            qml.CNOT(wires=[0, 1])
+            qml.expval(qml.PauliZ(0))
+
+        with qml.tape.JacobianTape() as tape2:
+            qml.RX(0.4, wires=0)
+            qml.RX(0.6, wires=0)
+            qml.CNOT(wires=[0, 1])
+            qml.expval(qml.PauliZ(0))
+
+        tape1.trainable_params = {0}
+        tape2.trainable_params = {0, 1}
+
+        tapes = [tape1, tape2]
+        dys = [np.array([0.0]), np.array([1.0])]
+
+        v_tapes, fn = qml.gradients.batch_vjp(tapes, dys, param_shift)
+        res = fn(dev.batch_execute(v_tapes))
+
+        # Even though there are 3 parameters, only two contribute
+        # to the VJP, so only 2*2=4 quantum evals
+        assert len(v_tapes) == 4
+        assert np.allclose(res[0], 0)
+
+    def test_reduction_append(self):
+        """ "Test the 'append' reduction strategy"""
+        dev = qml.device("default.qubit", wires=2)
+
+        with qml.tape.JacobianTape() as tape1:
+            qml.RX(0.4, wires=0)
+            qml.CNOT(wires=[0, 1])
+            qml.expval(qml.PauliZ(0))
+
+        with qml.tape.JacobianTape() as tape2:
+            qml.RX(0.4, wires=0)
+            qml.RX(0.6, wires=0)
+            qml.CNOT(wires=[0, 1])
+            qml.expval(qml.PauliZ(0))
+
+        tape1.trainable_params = {0}
+        tape2.trainable_params = {0, 1}
+
+        tapes = [tape1, tape2]
+        dys = [np.array([1.0]), np.array([1.0])]
+
+        v_tapes, fn = qml.gradients.batch_vjp(tapes, dys, param_shift, reduction="append")
+        res = fn(dev.batch_execute(v_tapes))
+
+        # Returned VJPs will be appended to a list, one vjp per tape
+        assert len(res) == 2
+        assert all(isinstance(r, np.ndarray) for r in res)
+        assert all(len(r) == len(t.trainable_params) for t, r in zip(tapes, res))
+
+    def test_reduction_extend(self):
+        """ "Test the 'extend' reduction strategy"""
+        dev = qml.device("default.qubit", wires=2)
+
+        with qml.tape.JacobianTape() as tape1:
+            qml.RX(0.4, wires=0)
+            qml.CNOT(wires=[0, 1])
+            qml.expval(qml.PauliZ(0))
+
+        with qml.tape.JacobianTape() as tape2:
+            qml.RX(0.4, wires=0)
+            qml.RX(0.6, wires=0)
+            qml.CNOT(wires=[0, 1])
+            qml.expval(qml.PauliZ(0))
+
+        tape1.trainable_params = {0}
+        tape2.trainable_params = {0, 1}
+
+        tapes = [tape1, tape2]
+        dys = [np.array([1.0]), np.array([1.0])]
+
+        v_tapes, fn = qml.gradients.batch_vjp(tapes, dys, param_shift, reduction="extend")
+        res = fn(dev.batch_execute(v_tapes))
+
+        # Returned VJPs will be extended into a list. Each element of the returned
+        # list will correspond to a single input parameter of the combined
+        # tapes.
+        assert len(res) == sum(len(t.trainable_params) for t in tapes)


### PR DESCRIPTION
**Context:** Currently, PennyLane provides a `tape.jacobian()` method, which returns the Jacobian of a quantum circuit. It is then up to the interfaces to take this result, cast it to the correct tensor dtype, and construct the VJP. At the moment, this process is not ideal:

- The Jacobian is always computed prior to the vjp. This sometimes results in redundant quantum evals, especially if `dy = 0`.
- The VJP logic is duplicated across each interface, increasing maintenance burden, and leading to bugs not always being fixed in all places.
- There are no unit-tests for the VJP logic; instead, it is only tested via larger integration tests.
- Finally, the VJP logic is not differentiable, blocking higher order derivatives from being computed.

**Description of the Change:**

- Adds `qml.gradients.vjp` for computing the vector-Jacobian product of a tape
- Adds `qml.gradients.batch_vjp` for computing the vector-Jacobian products of multiple tapes

**Benefits:**

- Users can pass in arbitrary gradient transforms to use in the computation
- Written to be autodifferentiable
- VJP unit tests are now present

**Possible Drawbacks:** None. In a future PR, the vector-Hessian product should also be added:

```python
def vhp(tape, dy, ddy):
    if dy.size > 1:
        vhp = dy @ ddy @ hessian @ dy.T / np.linalg.norm(dy) ** 2
    else:
        vhp = ddy @ hessian
```

**Related GitHub Issues:** n/a
