### PR TITLE
[BugFix] Error in documentation's numpy differentiation code example

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -462,11 +462,16 @@
 
 <h3>Bug fixes</h3>
 
-* Fixes a bug where the adjoint of `qml.QFT` when using the `qml.adjoint` function
+* Fixed an example in the documentation's 
+  [introduction to numpy gradients](https://pennylane.readthedocs.io/en/stable/introduction/interfaces/numpy.html), where 
+  the wires were a non-differentiable argument to the QNode. 
+  [(#1499)](https://github.com/PennyLaneAI/pennylane/pull/1499)
+
+* Fixed a bug where the adjoint of `qml.QFT` when using the `qml.adjoint` function
   was not correctly computed.
   [(#1451)](https://github.com/PennyLaneAI/pennylane/pull/1451)
 
-* Fixes the differentiability of the operation`IsingYY` for Autograd, Jax and Tensorflow.
+* Fixed the differentiability of the operation`IsingYY` for Autograd, Jax and Tensorflow.
   [(#1425)](https://github.com/PennyLaneAI/pennylane/pull/1425)
   
 * Fixed a bug in the `torch` interface that prevented gradients from being

--- a/doc/introduction/interfaces/numpy.rst
+++ b/doc/introduction/interfaces/numpy.rst
@@ -146,7 +146,7 @@ tensor([0.1, 0.2], requires_grad=False)
     The ``requires_grad`` argument can be passed to any NumPy function provided by PennyLane,
     including NumPy functions that create arrays like ``np.random.random``, ``np.zeros``, etc.
 
-An alternative way to avoid differentiation logic to be applied to positional arguments is to
+An alternative way to avoid having positional arguments turned into differentiable PennyLane NumPy arrays is to
 use a keyword argument syntax when the QNode is evaluated or when its gradient is computed.
 
 For example, consider the following QNode that accepts one trainable argument ``weights``,

--- a/doc/introduction/interfaces/numpy.rst
+++ b/doc/introduction/interfaces/numpy.rst
@@ -172,7 +172,7 @@ For ``data``, which is a PennyLane NumPy array, we can simply specify ``requires
 >>> np.random.seed(42)  # make the results reproducable
 >>> data = np.random.random([2**3], requires_grad=False)
 
-But ``wires`` is a list in this example, and if we turned it into a PennyLane NumPy array we would have to
+But ``wires`` is a list in this example, and if we turn it into a PennyLane NumPy array we would have to
 create a device that understands custom wire labels of this type.
 It is much easier to use the second option laid out above, and pass ``wires`` to the
 QNode using keyword argument syntax:

--- a/doc/introduction/interfaces/numpy.rst
+++ b/doc/introduction/interfaces/numpy.rst
@@ -154,7 +154,7 @@ and two non-trainable arguments ``data`` and ``wires``:
     dev = qml.device('default.qubit', wires=5)
 
     @qml.qnode(dev)
-    def circuit(weights, data, wires):
+    def circuit(weights, data, wires=None):
         qml.templates.AmplitudeEmbedding(data, wires=wires, normalize=True)
         qml.RX(weights[0], wires=wires[0])
         qml.RY(weights[1], wires=wires[1])
@@ -163,20 +163,22 @@ and two non-trainable arguments ``data`` and ``wires``:
         qml.CNOT(wires=[wires[0], wires[2]])
         return qml.expval(qml.PauliZ(wires[0]))
 
-We must specify that ``data`` and ``wires`` are NumPy arrays with ``requires_grad=False``:
+Since ``wires`` is a keyword argument, it will be automatically non-trainable. However, we
+must make ``data`` non-trainable by specifying it as a NumPy array with ``requires_grad=False``:
 
+>>> np.random.seed(42)  # make the results reproducable
 >>> weights = np.array([0.1, 0.2, 0.3])
 >>> data = np.random.random([2**3], requires_grad=False)
->>> wires = np.array([2, 0, 1], requires_grad=False)
->>> circuit(weights, data, wires)
-0.16935626052294817
+>>> wires = [2, 0, 1]
+>>> circuit(weights, data, wires=wires)
+0.4124409353413991
 
-When we compute the derivative, arguments with ``requires_grad=False`` are explicitly ignored
-by :func:`~.grad`:
+When we compute the derivative, arguments with ``requires_grad=False``, as well as keyword arguments,
+are explicitly ignored by :func:`~.grad`:
 
 >>> grad_fn = qml.grad(circuit)
->>> grad_fn(weights, data, wires)
-(array([-1.69923049e-02,  0.00000000e+00, -8.32667268e-17]),)
+>>> grad_fn(weights, data, wires=wires)
+[-4.1382126e-02  0.0000000e+00 -6.9388939e-18]
 
 .. note::
 


### PR DESCRIPTION
**Context:**

Updates a failing code example.

**Description of the Change:**

Use keyword argument to mark a non-differentiable wires argument.
Add a random seed to make example reproducable.

Updated example reads:


![Screenshot from 2021-08-05 12-34-00](https://user-images.githubusercontent.com/23052011/128336216-6e287c6d-5bd6-4877-b6ae-a6a4e952d6cc.png)



**Related GitHub Issues:**
#1498