### PR TITLE
[PROTOTYPE] Template matching for patterns of non-parametrized gates.

### DIFF
--- a/pennylane/transforms/__init__.py
+++ b/pennylane/transforms/__init__.py
@@ -114,6 +114,7 @@ from .optimization import (
     cancel_inverses,
     commute_controlled,
     merge_rotations,
+    pattern_match,
     single_qubit_fusion,
 )
 from .specs import specs

--- a/pennylane/transforms/optimization/__init__.py
+++ b/pennylane/transforms/optimization/__init__.py
@@ -18,4 +18,5 @@ This subpackage contains quantum function transforms for optimizing quantum circ
 from .cancel_inverses import cancel_inverses
 from .commute_controlled import commute_controlled
 from .merge_rotations import merge_rotations
+from .pattern_match import pattern_match
 from .single_qubit_fusion import single_qubit_fusion

--- a/pennylane/transforms/optimization/pattern_match.py
+++ b/pennylane/transforms/optimization/pattern_match.py
@@ -14,21 +14,31 @@
 """Transform for simple template optimization."""
 
 from pennylane import apply
+from pennylane.tape import get_active_tape
 from pennylane.wires import Wires
 from pennylane.transforms import qfunc_transform
 import pennylane.ops.qubit as ops
 
 from .optimization_utils import find_next_gate
 
+# Instead of using the circuit DAG, I tried doing this with string matching.
+# It works, but its maybe not the best solution.
 templates = {
     2 : {
-        "S0 S0" : [ops.PauliZ],
-        "T0 T0" : [ops.S]
+        "S0 S0" : [(ops.PauliZ, 0)],
+        "T0 T0" : [(ops.S, 0)],
+    },
+    3 : {
+        "Hadamard0 PauliX0 Hadamard0" : [(ops.PauliZ, 0)],
+        "Hadamard0 PauliZ0 Hadamard0" : [(ops.PauliX, 0)],
+        "CNOT01 PauliX0 CNOT01" : [(ops.PauliX, 0), (ops.PauliX, 1)],
+        "CNOT01 Toffoli012 CNOT01" : [(ops.Toffoli, [0, 1, 2]), (ops.CNOT, [0, 2])]
     },
     4: {
-        "CNOT01 H0 H1 CNOT10": [ops.Hadamard, ops.Hadamard]
+        "CNOT01 Hadamard0 Hadamard1 CNOT10": [(ops.Hadamard, 0), (ops.Hadamard, 1)]
     }
 }
+
 
 def _gates_to_string(gate_list, wire_map):
     """Convert a list of gates into string format suitable for a template."""
@@ -45,6 +55,7 @@ def _gates_to_string(gate_list, wire_map):
         gate_string_list.append(this_gate_string)
             
     return " ".join(gate_string_list)
+
 
 def _replace_with_template(gate_string, wire_map):
     """Convert a string indicating a list of gates to the actual list 
@@ -64,7 +75,6 @@ def _replace_with_template(gate_string, wire_map):
     if template_set_idx in templates.keys():
         # Check if this sequence is a defined template
         if gate_string in templates[template_set_idx].keys():
-            
             op_list = templates[template_set_idx][gate_string]
             
             for op, which_wires in op_list:
@@ -73,110 +83,138 @@ def _replace_with_template(gate_string, wire_map):
                     
                 wires_with_labels = [reverse_wire_map[w] for w in which_wires]
                 
-                blob.append(op(wires=qml.wires.Wires(wires_with_labels)))
-
-        # If it isn't, return None
+                blob.append(op(wires=Wires(wires_with_labels)))
+        else:
+            # If it isn't, return None
+            return None
+    else:
         return None
 
     return blob
-        
+
+
+def _replace_patterns_in_tape(op_list):
+    """Loop through the operations on a tape and replace any templates  
+    that are found."""
+
+    global_something_was_changed = False
+
+    idx = 0
+
+    # Go through the list once
+    while idx < len(op_list):
+        current_gate = op_list[idx]
+
+        # Keep track of whether anything actually changed 
+        something_was_changed = False
+
+        # Go through the templates in increasing size
+        for template_size in list(templates.keys()):
+            # Only look if there is even a chance that we'll have enough gates
+            if len(op_list) - idx < template_size:
+                continue
+
+            # Get the block of upcoming gates that act on this gates wires
+            gate_list = [current_gate]
+            gate_list_idxs = [idx]
+            gate_offset = 1
+
+            # Get the next number of gates needed to potentially have a template of this size
+            for _ in range(template_size - 1):
+                wires_in_block = Wires.all_wires([g.wires for g in gate_list])
+
+                next_gate_idx = find_next_gate(wires_in_block, op_list[idx + gate_offset:])
+
+                if next_gate_idx is not None:
+                    gate_list.append(op_list[idx + gate_offset + next_gate_idx])
+                    gate_list_idxs.append(idx + gate_offset + next_gate_idx)
+                    gate_offset += next_gate_idx + 1
+                else:
+                    break
+
+            # If there is a block of gates, test whether it's a template of this size
+            used_wires = Wires.all_wires([g.wires for g in gate_list])
+            wire_map = {used_wires[x] : x for x in range(len(used_wires))}
+            gate_string = _gates_to_string(gate_list, wire_map)
+
+            # Check for a match
+            replacement = _replace_with_template(gate_string, wire_map)
+
+            # If we found a replacement, replace applicable gates with gates from the template
+            if replacement is not None:
+                for gate_idx in gate_list_idxs[::-1]:
+                    op_list.pop(gate_idx)
+
+                    # Add any replacements that can be added
+                    if len(replacement) > 0:
+                        op_list.insert(gate_idx, replacement.pop())
+
+                while len(replacement) > 0:
+                    op_list.insert(gate_list_idxs[0], replacement.pop())
+
+                something_was_changed = True
+                global_something_was_changed = True
+
+        # If anything was changed, the gate at the current index has been replaced,
+        # so loop back over the same index and see if we can do anything new. If not,
+        # we move to the next gate.
+        if not something_was_changed:
+            idx += 1
+
+    return op_list, global_something_was_changed
+
+
 @qfunc_transform
 def pattern_match(tape):
-    """Quantum function transform to remove any operations that are applied next to their
-    (self-)inverse.
+    """Quantum function transform to find and replace small patterns in a circuit.
 
     Args:
         qfunc (function): A quantum function.
 
     Returns:
+        function: A quantum function with its templates replaced.
+
+    **Example**
+
+    Consider the following quantum function:
+
+    .. code-block:: python3
+        def my_circuit():
+            qml.S(wires=0)
+            qml.S(wires=0)
+            qml.T(wires=0)
+            qml.T(wires=1)
+            qml.T(wires=1)
+            qml.CNOT(wires=[1, 0])
+            qml.Hadamard(wires=1)
+            qml.Hadamard(wires=0)
+            qml.CNOT(wires=[0, 1])
+            return qml.expval(qml.PauliZ(wires=0))
+
+    The two S gates on the first qubit can be replaced by a Z; the two T gates on
+    the second qubits can be replaced with an S. Furthermore, the last four gates
+    can be replaced by simply a Hadamard on each of the two qubits. If we express
+    these relationships as templates, the ``pattern_match`` transform will replace
+    them by the more efficient versions.
+
+    >>> dev = qml.device('default.qubit', wires=2)
+    >>> qfunc = qml.transforms.pattern_match(my_circuit)
+    >>> qnode = qml.QNode(qfunc, dev)
+    >>> print(qml.draw(qnode)())
+     0: ──Z──T──H──┤ ⟨Z⟩ 
+     1: ──S──H─────┤     
     """
 
     list_copy = tape.operations.copy()
 
-    something_was_changed = True
+    current_tape = get_active_tape()
     
-    # Loop through the list of operations and find templates until there aren't any more
-    while something_was_changed:
+    something_was_changed = True
 
-        something_was_changed = False
-
-        op_list = []
-        
-        while len(list_copy) > 0:
-            current_gate = list_copy[0]
-
-            # Get the largest block of upcoming gates that act on this gates wires
-            gate_list = []
-            gate_list_idxs = []
-            gate_offset = 1
-
-            while True:
-                next_gate_idx = find_next_gate(current_gate.wires, list_copy[gate_offset:])
-                if next_gate_idx is not None:
-                    print(f"Next gate is {list_copy[next_gate_idx+1]}")
-                    gate_list.append(list_copy[gate_offset + next_gate_idx])
-                    gate_list_idxs.append(gate_offset + next_gate_idx)
-                    print(gate_list)
-                    gate_offset += next_gate_idx + 1
-                else:
-                    break
-
-            # If there is no block of gates, simply add this gate and move on
-            if len(gate_list) == 0:
-                op_list.append(list_copy[0])
-                list_copy.pop(0)
-                continue
-
-            # If there is a block of gates, test whether it's a template
-            used_wires = Wires.all_wires([g.wires for g in gate_list])
-            wire_map = {used_wires[x] : x for x in range(len(used_wires))}
-
-            # It could be that the block we found is larger than any of the
-            # template sizes; we have to check the first two elements, see if
-            # there is a match; if not, then second and third elements, etc.
-            # up to max template size
-            for template_size in list(templates.keys()):
-                # Don't look if we don't have enough gates for a possible match
-                if len(gate_list) >= template_size:
-                    window_start_idx = 0
-
-                    while window_start_idx < len(gate_list) - template_size:
-                        gates_in_window = gate_list[window_start_idx:window_start_idx+template_size]
-                        gate_string = _gates_to_string(gates_in_window, wire_map)
-
-                        # Check for a match
-                        replacement = _replace_with_template(gate_string, wire_map)
-
-                        # If we found a replacement, add it to the list, then remove all the
-                        # other gates in the template
-                        if replacement is not None:
-                            print(f"Found replacement for template {gate_string}")
-
-                            # Remove the old gates from the current gate list
-                            for gate_idx in range(window_start_idx, template_size+1):
-                                gate_list.pop(gate_idx)
-
-                            # Add the new gates
-                            for idx, gate in replacement:
-                                gate_list.insert(window_start_idx + idx, gate)
-                            something_was_changed = True
-
-            # Add our completed template to the op list
-            op_list.extend(gate_list)
-            
-            # After finding all the templates in this section, we need to remove those original
-            # gates from the list copy, and replace them with the gates in the modified template
-            for gate_idx in gate_list_idxs[::-1]:
-                list_copy.pop(gate_idx)
-
-            for gate in gate_list[::-1]:
-                list_copy.insert(0, gate)
-            
-            # In either case, remove the first element from the list and move on
-            list_copy.pop(0)            
-
-        # For the next iteration, copy the current op_list into the list_copy
-        list_copy = op_list.copy()
-        
-    for op in op_list + tape.measurements:
+    # Loop through the tape until we find no more matching patterns
+    with current_tape.stop_recording():
+        while something_was_changed is True:
+            list_copy, something_was_changed = _replace_patterns_in_tape(list_copy)
+         
+    for op in list_copy + tape.measurements:
         apply(op)

--- a/pennylane/transforms/optimization/pattern_match.py
+++ b/pennylane/transforms/optimization/pattern_match.py
@@ -53,10 +53,10 @@ def _gates_to_string(gate_list, wire_map):
 
 
 def _replace_with_template(gate_string, wire_map):
-    """Convert a string indicating a list of gates to the actual list 
+    """Convert a string indicating a list of gates to the actual list
     of gates to apply, given a particular wire map.
 
-    Returns: None if no valid template is found, otherwise the set of 
+    Returns: None if no valid template is found, otherwise the set of
     operations in the template.
     """
 
@@ -89,7 +89,7 @@ def _replace_with_template(gate_string, wire_map):
 
 
 def _replace_patterns_in_tape(op_list):
-    """Loop through the operations on a tape and replace any templates  
+    """Loop through the operations on a tape and replace any templates
     that are found."""
 
     global_something_was_changed = False
@@ -196,8 +196,8 @@ def pattern_match(tape):
     >>> qfunc = qml.transforms.pattern_match(my_circuit)
     >>> qnode = qml.QNode(qfunc, dev)
     >>> print(qml.draw(qnode)())
-     0: ──Z──T──H──┤ ⟨Z⟩ 
-     1: ──S──H─────┤     
+     0: ──Z──T──H──┤ ⟨Z⟩
+     1: ──S──H─────┤
     """
 
     list_copy = tape.operations.copy()

--- a/pennylane/transforms/optimization/pattern_match.py
+++ b/pennylane/transforms/optimization/pattern_match.py
@@ -1,0 +1,182 @@
+# Copyright 2018-2021 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Transform for simple template optimization."""
+
+from pennylane import apply
+from pennylane.wires import Wires
+from pennylane.transforms import qfunc_transform
+import pennylane.ops.qubit as ops
+
+from .optimization_utils import find_next_gate
+
+templates = {
+    2 : {
+        "S0 S0" : [ops.PauliZ],
+        "T0 T0" : [ops.S]
+    },
+    4: {
+        "CNOT01 H0 H1 CNOT10": [ops.Hadamard, ops.Hadamard]
+    }
+}
+
+def _gates_to_string(gate_list, wire_map):
+    """Convert a list of gates into string format suitable for a template."""
+    gate_string_list = []
+
+    # TODO: sort the gates based on wire order
+    
+    for gate in gate_list:
+        this_gate_string = gate.name
+
+        for wire_label in gate.wires.labels:
+            this_gate_string += str(wire_map[wire_label])
+        
+        gate_string_list.append(this_gate_string)
+            
+    return " ".join(gate_string_list)
+
+def _replace_with_template(gate_string, wire_map):
+    """Convert a string indicating a list of gates to the actual list 
+    of gates to apply, given a particular wire map.
+
+    Returns: None if no valid template is found, otherwise the set of 
+    operations in the template.
+    """
+    
+    reverse_wire_map = {val: key for key, val in wire_map.items()}
+    
+    blob = []
+    
+    # Count the number of spaces to indicate how many gates were in the template
+    template_set_idx = gate_string.count(" ") + 1
+    
+    if template_set_idx in templates.keys():
+        # Check if this sequence is a defined template
+        if gate_string in templates[template_set_idx].keys():
+            
+            op_list = templates[template_set_idx][gate_string]
+            
+            for op, which_wires in op_list:
+                if not isinstance(which_wires, list):
+                    which_wires = [which_wires]
+                    
+                wires_with_labels = [reverse_wire_map[w] for w in which_wires]
+                
+                blob.append(op(wires=qml.wires.Wires(wires_with_labels)))
+
+        # If it isn't, return None
+        return None
+
+    return blob
+        
+@qfunc_transform
+def pattern_match(tape):
+    """Quantum function transform to remove any operations that are applied next to their
+    (self-)inverse.
+
+    Args:
+        qfunc (function): A quantum function.
+
+    Returns:
+    """
+
+    list_copy = tape.operations.copy()
+
+    something_was_changed = True
+    
+    # Loop through the list of operations and find templates until there aren't any more
+    while something_was_changed:
+
+        something_was_changed = False
+
+        op_list = []
+        
+        while len(list_copy) > 0:
+            current_gate = list_copy[0]
+
+            # Get the largest block of upcoming gates that act on this gates wires
+            gate_list = []
+            gate_list_idxs = []
+            gate_offset = 1
+
+            while True:
+                next_gate_idx = find_next_gate(current_gate.wires, list_copy[gate_offset:])
+                if next_gate_idx is not None:
+                    print(f"Next gate is {list_copy[next_gate_idx+1]}")
+                    gate_list.append(list_copy[gate_offset + next_gate_idx])
+                    gate_list_idxs.append(gate_offset + next_gate_idx)
+                    print(gate_list)
+                    gate_offset += next_gate_idx + 1
+                else:
+                    break
+
+            # If there is no block of gates, simply add this gate and move on
+            if len(gate_list) == 0:
+                op_list.append(list_copy[0])
+                list_copy.pop(0)
+                continue
+
+            # If there is a block of gates, test whether it's a template
+            used_wires = Wires.all_wires([g.wires for g in gate_list])
+            wire_map = {used_wires[x] : x for x in range(len(used_wires))}
+
+            # It could be that the block we found is larger than any of the
+            # template sizes; we have to check the first two elements, see if
+            # there is a match; if not, then second and third elements, etc.
+            # up to max template size
+            for template_size in list(templates.keys()):
+                # Don't look if we don't have enough gates for a possible match
+                if len(gate_list) >= template_size:
+                    window_start_idx = 0
+
+                    while window_start_idx < len(gate_list) - template_size:
+                        gates_in_window = gate_list[window_start_idx:window_start_idx+template_size]
+                        gate_string = _gates_to_string(gates_in_window, wire_map)
+
+                        # Check for a match
+                        replacement = _replace_with_template(gate_string, wire_map)
+
+                        # If we found a replacement, add it to the list, then remove all the
+                        # other gates in the template
+                        if replacement is not None:
+                            print(f"Found replacement for template {gate_string}")
+
+                            # Remove the old gates from the current gate list
+                            for gate_idx in range(window_start_idx, template_size+1):
+                                gate_list.pop(gate_idx)
+
+                            # Add the new gates
+                            for idx, gate in replacement:
+                                gate_list.insert(window_start_idx + idx, gate)
+                            something_was_changed = True
+
+            # Add our completed template to the op list
+            op_list.extend(gate_list)
+            
+            # After finding all the templates in this section, we need to remove those original
+            # gates from the list copy, and replace them with the gates in the modified template
+            for gate_idx in gate_list_idxs[::-1]:
+                list_copy.pop(gate_idx)
+
+            for gate in gate_list[::-1]:
+                list_copy.insert(0, gate)
+            
+            # In either case, remove the first element from the list and move on
+            list_copy.pop(0)            
+
+        # For the next iteration, copy the current op_list into the list_copy
+        list_copy = op_list.copy()
+        
+    for op in op_list + tape.measurements:
+        apply(op)


### PR DESCRIPTION
**Context:** Addition of compilation tools to PennyLane.

**Description of the Change:** Adds `pattern_match` transform and a hard-coded set of templates that can be used to replaced small chunks of circuits with optimized versions.

I've prototyped a version here that loops through a circuit finding blocks of fixed length at each gate; these are then converted to a wire-label-agnostic string (e.g., `"Hadamard0 PauliZ0 Hadamard0"`) which is matched to a dictionary containing the alternative implementations.

**Example usage**

How the templates are expressed (the number corresponds to the number of gates in the original template):
```python
import pennylane.ops.qubit as ops

templates = {
    2: {"S0 S0": [(ops.PauliZ, 0)], "T0 T0": [(ops.S, 0)],},
    3: {
        "Hadamard0 PauliX0 Hadamard0": [(ops.PauliZ, 0)],
        "Hadamard0 PauliZ0 Hadamard0": [(ops.PauliX, 0)],
        "CNOT01 PauliX0 CNOT01": [(ops.PauliX, 0), (ops.PauliX, 1)],
        "CNOT01 Toffoli012 CNOT01": [(ops.Toffoli, [0, 1, 2]), (ops.CNOT, [0, 2])],
    },
    4: {"CNOT01 Hadamard0 Hadamard1 CNOT10": [(ops.Hadamard, 0), (ops.Hadamard, 1)]},
}

```


```python
def my_circuit():
    # SS = Z
    qml.S(wires=0)
    qml.S(wires=0)

    qml.T(wires=0)

    # TT = S
    qml.T(wires=1)
    qml.T(wires=1)

    # Note that in this chunk the wires are "upside down", but the template is still recognized
    qml.CNOT(wires=[1, 0])
    qml.Hadamard(wires=1)
    qml.Hadamard(wires=0)
    qml.CNOT(wires=[0, 1])

    return qml.expval(qml.PauliZ(wires=0))
```

```pycon
>>> dev = qml.device('default.qubit', wires=2)
>>> qfunc = qml.transforms.pattern_match(my_circuit)
>>> qnode = qml.QNode(qfunc, dev)
>>> print(qml.draw(qnode)())
   0: ──Z──T──H──┤ ⟨Z⟩ 
   1: ──S──H─────┤     
```

**Benefits:** TODO

**Possible Drawbacks:** More research needs to be done to determine how to do this more optimally. I've tried to avoid constructing the DAG in all these compilation transforms, but this is one case where it may be valuable to construct it rather than iterating over a list of gates.

**Related GitHub Issues:** None
