### PR TITLE
Remove tape check for observable without owners in the queue

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -439,6 +439,13 @@
 
 <h3>Improvements</h3>
 
+* The tape does not verify any more that all Observables have owners in the annotated queue.
+  [(#1505)](https://github.com/PennyLaneAI/pennylane/pull/1505)
+  This allows manipulation of Observables inside a tape context. An example is 
+  `expval(Tensor(qml.PauliX(0), qml.Identity(1)).prune())` which makes the expval an owner 
+  of the pruned tensor and its constituent observables, but leaves the original tensor in 
+  the queue without an owner.
+
 * The `step` and `step_and_cost` methods of `QNGOptimizer` now accept a custom `grad_fn`
   keyword argument to use for gradient computations.
   [(#1487)](https://github.com/PennyLaneAI/pennylane/pull/1487)

--- a/pennylane/tape/tape.py
+++ b/pennylane/tape/tape.py
@@ -450,9 +450,6 @@ class QuantumTape(AnnotatedQueue):
                 if obj.return_type is qml.operation.Sample:
                     self.is_sampled = True
 
-            elif isinstance(obj, qml.operation.Observable) and "owner" not in info:
-                raise ValueError(f"Observable {obj} does not have a measurement type specified.")
-
         self._update()
 
     def _update_circuit_info(self):

--- a/tests/tape/test_tape.py
+++ b/tests/tape/test_tape.py
@@ -251,21 +251,6 @@ class TestConstruction:
                 qml.RX(0.5, wires=0)
                 qml.expval(qml.PauliZ(wires=1))
 
-    def test_observable_with_no_measurement(self):
-        """Test that an exception is raised if an observable is used without a measurement"""
-
-        with pytest.raises(ValueError, match="does not have a measurement type specified"):
-            with QuantumTape() as tape:
-                qml.RX(0.5, wires=0)
-                qml.Hermitian(np.array([[0, 1], [1, 0]]), wires=1)
-                qml.expval(qml.PauliZ(wires=1))
-
-        with pytest.raises(ValueError, match="does not have a measurement type specified"):
-            with QuantumTape() as tape:
-                qml.RX(0.5, wires=0)
-                qml.PauliX(wires=0) @ qml.PauliY(wires=1)
-                qml.expval(qml.PauliZ(wires=1))
-
     def test_sampling(self):
         """Test that the tape correctly marks itself as returning samples"""
         with QuantumTape() as tape:

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -941,7 +941,7 @@ class TestTensor:
         assert ann_queue[T_pruned]["owns"] == (a, b)
         assert ann_queue[m]["owns"] == T_pruned
 
-    def test_prune_while_queueing_return_tensor(self):
+    def test_prune_while_queueing_return_obs(self):
         """Tests that pruning a tensor to an observable in a tape context registers
         the pruned observable as owned by the measurement,
         and turns the original tensor into an orphan without an owner."""

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -957,8 +957,10 @@ class TestTensor:
 
         # the pruned tensor is the Pauli observable
         assert T_pruned == a
-        # at the same time, the pruned tensor owns the Pauli
-        assert ann_queue[a]["owner"] == T_pruned
+        # pruned tensor/Pauli is owned by the measurement
+        # since the entry in the dictionary got updated
+        # when the pruned tensor's owner was memorized
+        assert ann_queue[a]["owner"] == m
         # the Identity is still owned by the original Tensor
         assert ann_queue[c]["owner"] == T
 
@@ -967,10 +969,7 @@ class TestTensor:
         assert ann_queue[T]["owns"] == (a, c)
         assert not hasattr(ann_queue[T], "owner")
 
-        # the pruned tensor is owned by the measurement
-        # and owns the Paulis
-        assert ann_queue[T_pruned]["owner"] == m
-        assert ann_queue[T_pruned]["owns"] == (a)
+        # the measurement owns the Pauli/pruned tensor
         assert ann_queue[m]["owns"] == T_pruned
 
 

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -908,6 +908,14 @@ class TestTensor:
         assert type(O_pruned) == type(expected)
         assert O_pruned.wires == expected.wires
 
+    def test_prune_while_queueing(self):
+        """Tests that pruning in a tape context registers the pruned observable as owned by the measurement,
+        and turns the original tensor into an orphan without an owner."""
+
+        with qml.tape.QuantumTape() as tape:
+            qml.expval(qml.operation.Tensor(qml.PauliX(wires=1), qml.Identity(wires=0)).prune())
+
+        assert tape._queue[qml.PauliX(wires=1)]["owner"] == qml.expval(qml.PauliX(wires=1))
 
 equal_obs = [
     (qml.PauliZ(0), qml.PauliZ(0), True),

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -908,14 +908,71 @@ class TestTensor:
         assert type(O_pruned) == type(expected)
         assert O_pruned.wires == expected.wires
 
-    def test_prune_while_queueing(self):
-        """Tests that pruning in a tape context registers the pruned observable as owned by the measurement,
+    def test_prune_while_queueing_return_tensor(self):
+        """Tests that pruning a tensor to a tensor in a tape context registers
+        the pruned tensor as owned by the measurement,
         and turns the original tensor into an orphan without an owner."""
 
         with qml.tape.QuantumTape() as tape:
-            qml.expval(qml.operation.Tensor(qml.PauliX(wires=1), qml.Identity(wires=0)).prune())
+            # we assign operations to variables here so we can compare them below
+            a = qml.PauliX(wires=0)
+            b = qml.PauliY(wires=1)
+            c = qml.Identity(wires=2)
+            T = qml.operation.Tensor(a, b, c)
+            T_pruned = T.prune()
+            m = qml.expval(T_pruned)
 
-        assert tape._queue[qml.PauliX(wires=1)]["owner"] == qml.expval(qml.PauliX(wires=1))
+        ann_queue = tape._queue
+
+        # the pruned tensor became the owner of Paulis
+        assert ann_queue[a]["owner"] == T_pruned
+        assert ann_queue[b]["owner"] == T_pruned
+
+        # the Identity is still owned by the original Tensor
+        assert ann_queue[c]["owner"] == T
+        # the original tensor still owns all three observables
+        # but is not owned by a measurement
+        assert ann_queue[T]["owns"] == (a, b, c)
+        assert not hasattr(ann_queue[T], "owner")
+
+        # the pruned tensor is owned by the measurement
+        # and owns the two Paulis
+        assert ann_queue[T_pruned]["owner"] == m
+        assert ann_queue[T_pruned]["owns"] == (a, b)
+        assert ann_queue[m]["owns"] == T_pruned
+
+    def test_prune_while_queueing_return_tensor(self):
+        """Tests that pruning a tensor to an observable in a tape context registers
+        the pruned observable as owned by the measurement,
+        and turns the original tensor into an orphan without an owner."""
+
+        with qml.tape.QuantumTape() as tape:
+            a = qml.PauliX(wires=0)
+            c = qml.Identity(wires=2)
+            T = qml.operation.Tensor(a, c)
+            T_pruned = T.prune()
+            m = qml.expval(T_pruned)
+
+        ann_queue = tape._queue
+
+        # the pruned tensor is the Pauli observable
+        assert T_pruned == a
+        # at the same time, the pruned tensor owns the Pauli
+        assert ann_queue[a]["owner"] == T_pruned
+        # the Identity is still owned by the original Tensor
+        assert ann_queue[c]["owner"] == T
+
+        # the original tensor still owns both observables
+        # but is not owned by a measurement
+        assert ann_queue[T]["owns"] == (a, c)
+        assert not hasattr(ann_queue[T], "owner")
+
+        # the pruned tensor is owned by the measurement
+        # and owns the Paulis
+        assert ann_queue[T_pruned]["owner"] == m
+        assert ann_queue[T_pruned]["owns"] == (a)
+        assert ann_queue[m]["owns"] == T_pruned
+
 
 equal_obs = [
     (qml.PauliZ(0), qml.PauliZ(0), True),

--- a/tests/test_vqe.py
+++ b/tests/test_vqe.py
@@ -707,6 +707,23 @@ class TestHamiltonian:
         old_H.simplify()
         assert old_H.compare(new_H)
 
+    def test_simplify_while_queueing(self):
+        """Tests that simplifying a Hamiltonian in a tape context
+        queues the simplified Hamiltonian."""
+
+        with qml.tape.QuantumTape() as tape:
+            a = qml.PauliX(wires=0)
+            b = qml.PauliY(wires=1)
+            c = qml.Identity(wires=2)
+            d = b @ c
+            H = qml.Hamiltonian([1., 2.], [a, d])
+            H.simplify()
+
+        # check that H is simplified
+        assert H.ops == [a, b]
+        # check that the simplified Hamiltonian is in the queue
+        assert H in tape._queue
+
     def test_data(self):
         """Tests the obs_data method"""
 

--- a/tests/test_vqe.py
+++ b/tests/test_vqe.py
@@ -716,7 +716,7 @@ class TestHamiltonian:
             b = qml.PauliY(wires=1)
             c = qml.Identity(wires=2)
             d = b @ c
-            H = qml.Hamiltonian([1., 2.], [a, d])
+            H = qml.Hamiltonian([1.0, 2.0], [a, d])
             H.simplify()
 
         # check that H is simplified


### PR DESCRIPTION
**Context:**

Some observables that are composed of other observables may define methods that change the constituent parts. This leaves observables without measurements in the queue. The tape's `process_queue` method, called upon exiting the queueing context, then throws an error.

The only example (as far as I know) in the current code base is the `Tensor.prune()` function:
``` python

with qml.tape.QuantumTape() as tape:
    a = qml.PauliX(wires=0)
    b = qml.Identity(wires=2)
    T = qml.operation.Tensor(a, b).prune()
    qml.expval(T)

# "ValueError: Observable PauliX(wires=[0]) @ Identity(wires=[2]) does not have a measurement type specified."
```

However, once the Hamiltonian class becomes an Observable, the same is caused by the `Hamiltonain.simplify()` method. 

Note: one could in principle not allow such methods to be called in a tape context, but checking this everywhere is error-prone for development, and once Hamiltonians become trainable there are situations when they are created (and should be simplified) inside a quantum function. 

**Description of the Change:**

Removed the check when processing a tape during exit of the queueing context. 
Added a test that the queue is recorded as expected for `Tensor.prune()`.

**Benefits:**

Allowing "orphan" observables (i.e. those that have no measurement)  in the queue is much safer than manipulating the queue during observable methods. An observable whose owners are not owned by a measurement can simply be regarded as a leftover from processing. 

**Possible Drawbacks:**

The tests pass and the annotated queue is not used much during the code base. Also, this behaviour makes changes to observables to some extend trackable. 

