### PR TITLE
Incrementing the version number to `0.18.0-dev`

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -8,9 +8,9 @@
   [(#1505)](https://github.com/PennyLaneAI/pennylane/pull/1505)
 
   This allows manipulation of Observables inside a tape context. An example is
-  `expval(Tensor(qml.PauliX(0), qml.Identity(1)).prune())` which makes the expval an owner
-  of the pruned tensor and its constituent observables, but leaves the original tensor in
-  the queue without an owner.
+  `expval(Tensor(qml.PauliX(0), qml.Identity(1)).prune())` which makes the expval
+  an owner of the pruned tensor and its constituent observables, but leaves the
+  original tensor in the queue without an owner.
 
 <h3>Breaking changes</h3>
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,4 +1,30 @@
-# Release 0.17.0-dev (development release)
+# Release 0.18.0-dev (development release)
+
+<h3>New features since last release</h3>
+
+<h3>Improvements</h3>
+
+* The tape does not verify any more that all Observables have owners in the annotated queue.
+  [(#1505)](https://github.com/PennyLaneAI/pennylane/pull/1505)
+
+  This allows manipulation of Observables inside a tape context. An example is
+  `expval(Tensor(qml.PauliX(0), qml.Identity(1)).prune())` which makes the expval an owner
+  of the pruned tensor and its constituent observables, but leaves the original tensor in
+  the queue without an owner.
+
+<h3>Breaking changes</h3>
+
+<h3>Bug fixes</h3>
+
+<h3>Documentation</h3>
+
+<h3>Contributors</h3>
+
+This release contains contributions from (in alphabetical order):
+
+Maria Schuld.
+
+# Release 0.17.0 (current release)
 
 <h3>New features since last release</h3>
 
@@ -465,13 +491,6 @@
 
 <h3>Improvements</h3>
 
-* The tape does not verify any more that all Observables have owners in the annotated queue.
-  [(#1505)](https://github.com/PennyLaneAI/pennylane/pull/1505)
-  This allows manipulation of Observables inside a tape context. An example is 
-  `expval(Tensor(qml.PauliX(0), qml.Identity(1)).prune())` which makes the expval an owner 
-  of the pruned tensor and its constituent observables, but leaves the original tensor in 
-  the queue without an owner.
-
 * The `step` and `step_and_cost` methods of `QNGOptimizer` now accept a custom `grad_fn`
   keyword argument to use for gradient computations.
   [(#1487)](https://github.com/PennyLaneAI/pennylane/pull/1487)
@@ -605,7 +624,7 @@ Arshpreet Singh Khangura, Ashish Panigrahi,
 Maria Schuld, Jay Soni, Antal Száva, David Wierichs.
 
 
-# Release 0.16.0 (current release)
+# Release 0.16.0
 
 <h3>New features since last release</h3>
 

--- a/pennylane/_version.py
+++ b/pennylane/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.17.0-dev"
+__version__ = "0.17.0"

--- a/qchem/CHANGELOG.md
+++ b/qchem/CHANGELOG.md
@@ -1,4 +1,18 @@
-# Release 0.17.0-dev
+# Release 0.18.0-dev
+
+<h3>New features</h3>
+
+<h3>Improvements</h3>
+
+<h3>Bug fixes</h3>
+
+<h3>Breaking changes</h3>
+
+<h3>Contributors</h3>
+
+This release contains contributions from (in alphabetical order):
+
+# Release 0.17.0
 
 <h3>New features</h3>
 

--- a/qchem/pennylane_qchem/_version.py
+++ b/qchem/pennylane_qchem/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.17.0-dev"
+__version__ = "0.18.0-dev"


### PR DESCRIPTION
**Summary**

* Increments the version number similarly to https://github.com/PennyLaneAI/pennylane/pull/1410.
    * Note: the remaining core devices (e.g., `default.tensor`, `default.gaussian`) now also depend on the `_version.py` file, hence change is made only there.
* Incorporates the changelog entry from https://github.com/PennyLaneAI/pennylane/pull/1505 in the new section of the changelog.