### PR TITLE
Fix github issue #1265

### DIFF
--- a/qchem/CHANGELOG.md
+++ b/qchem/CHANGELOG.md
@@ -6,11 +6,17 @@
 
 <h3>Bug fixes</h3>
 
+* The types of the Hamiltonian terms built from an OpenFermion ``QubitOperator`` using the
+  ``convert_observable`` function, are the same with respect to the analogous observable
+  built directly using PennyLane operations.
+
 <h3>Breaking changes</h3>
 
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):
+
+Alain Delgado, Zeyue Niu.
 
 # Release 0.17.0
 

--- a/qchem/CHANGELOG.md
+++ b/qchem/CHANGELOG.md
@@ -9,6 +9,7 @@
 * The types of the Hamiltonian terms built from an OpenFermion ``QubitOperator`` using the
   ``convert_observable`` function, are the same with respect to the analogous observable
   built directly using PennyLane operations.
+  [(#1523)](https://github.com/PennyLaneAI/pennylane/pull/1523)
 
 <h3>Breaking changes</h3>
 

--- a/qchem/pennylane_qchem/qchem/structure.py
+++ b/qchem/pennylane_qchem/qchem/structure.py
@@ -554,7 +554,7 @@ def _qubit_operator_to_terms(qubit_operator, wires=None):
     0.1 [X0] +
     0.2 [Y0 Z2]
     >>> _qubit_operator_to_terms(q_op, wires=['w0','w1','w2','extra_wire'])
-    (array([0.1, 0.2]), [Tensor(PauliX(wires=['w0'])), Tensor(PauliY(wires=['w0']), PauliZ(wires=['w2']))])
+    (array([0.1, 0.2]), [PauliX(wires=['w0']), PauliY(wires=['w0']) @ PauliZ(wires=['w2'])])
     """
     n_wires = (
         1 + max([max([i for i, _ in t]) if t else 1 for t in qubit_operator.terms])
@@ -562,9 +562,6 @@ def _qubit_operator_to_terms(qubit_operator, wires=None):
         else 1
     )
     wires = _process_wires(wires, n_wires=n_wires)
-
-    # if not qubit_operator.terms:  # added since can't unpack empty zip to (coeffs, ops) below
-    #     return np.array([0.0]), [qml.operation.Tensor(qml.Identity(wires[0]))]
 
     if not qubit_operator.terms:  # added since can't unpack empty zip to (coeffs, ops) below
         return np.array([0.0]), [qml.Identity(wires[0])]

--- a/qchem/pennylane_qchem/qchem/structure.py
+++ b/qchem/pennylane_qchem/qchem/structure.py
@@ -567,7 +567,7 @@ def _qubit_operator_to_terms(qubit_operator, wires=None):
     #     return np.array([0.0]), [qml.operation.Tensor(qml.Identity(wires[0]))]
 
     if not qubit_operator.terms:  # added since can't unpack empty zip to (coeffs, ops) below
-        return np.array([0.0]), qml.Identity(wires[0])
+        return np.array([0.0]), [qml.Identity(wires[0])]
 
     xyz2pauli = {"X": qml.PauliX, "Y": qml.PauliY, "Z": qml.PauliZ}
 
@@ -576,7 +576,7 @@ def _qubit_operator_to_terms(qubit_operator, wires=None):
             (
                 coef,
                 qml.operation.Tensor(*[xyz2pauli[q[1]](wires=wires[q[0]]) for q in term])
-                if len(term) > 0
+                if len(term) > 1
                 else (
                     xyz2pauli[term[0][1]](wires=wires[term[0][0]])
                     if len(term) == 1
@@ -636,6 +636,9 @@ def _terms_to_qubit_operator(coeffs, ops, wires=None):
 
     q_op = openfermion.QubitOperator()
     for coeff, op in zip(coeffs, ops):
+
+        if not isinstance(op, qml.operation.Tensor):
+            op = qml.operation.Tensor(op)
 
         extra_obsvbs = set(op.name) - {"PauliX", "PauliY", "PauliZ", "Identity"}
         if extra_obsvbs != set():

--- a/qchem/pennylane_qchem/qchem/structure.py
+++ b/qchem/pennylane_qchem/qchem/structure.py
@@ -563,8 +563,11 @@ def _qubit_operator_to_terms(qubit_operator, wires=None):
     )
     wires = _process_wires(wires, n_wires=n_wires)
 
+    # if not qubit_operator.terms:  # added since can't unpack empty zip to (coeffs, ops) below
+    #     return np.array([0.0]), [qml.operation.Tensor(qml.Identity(wires[0]))]
+
     if not qubit_operator.terms:  # added since can't unpack empty zip to (coeffs, ops) below
-        return np.array([0.0]), [qml.operation.Tensor(qml.Identity(wires[0]))]
+        return np.array([0.0]), qml.Identity(wires[0])
 
     xyz2pauli = {"X": qml.PauliX, "Y": qml.PauliY, "Z": qml.PauliZ}
 
@@ -573,8 +576,12 @@ def _qubit_operator_to_terms(qubit_operator, wires=None):
             (
                 coef,
                 qml.operation.Tensor(*[xyz2pauli[q[1]](wires=wires[q[0]]) for q in term])
-                if term
-                else qml.operation.Tensor(qml.Identity(wires[0]))
+                if len(term) > 0
+                else (
+                    xyz2pauli[term[0][1]](wires=wires[term[0][0]])
+                    if len(term) == 1
+                    else qml.Identity(wires[0])
+                )
                 # example term: ((0,'X'), (2,'Z'), (3,'Y'))
             )
             for term, coef in qubit_operator.terms.items()

--- a/qchem/tests/test_convert_observable.py
+++ b/qchem/tests/test_convert_observable.py
@@ -322,6 +322,27 @@ def test_not_xyz_terms_to_qubit_operator():
         )
 
 
+def test_types_consistency():
+    r"""Test the type consistency of the qubit Hamiltonian constructed by 'convert_observable' from
+    an OpenFermion QubitOperator with respect to the same observable built directly using PennyLane
+    operations"""
+
+    # Reference PL operator
+    pl_ref = 1 * qml.Identity(0) + 2 * qml.PauliZ(0) @ qml.PauliX(1)
+
+    # Corresponding OpenFermion operator
+    of = QubitOperator("", 1) + QubitOperator("Z0 X1", 2)
+
+    pl = qchem.convert_observable(of)
+
+    ops = pl.terms[1]
+    ops_ref = pl_ref.terms[1]
+
+    for i, op in enumerate(ops):
+        assert op.name == ops_ref[i].name
+        assert type(op) == type(ops_ref[i])
+
+
 op_1 = QubitOperator("Y0 Y1", 1 + 0j) + QubitOperator("Y0 X1", 2) + QubitOperator("Z0 Y1", 2.3e-08j)
 op_2 = QubitOperator("Z0 Y1", 2.23e-10j)
 


### PR DESCRIPTION
**Context:** Fix github issue [#1265].  This PR ensures the type consistency of the qubit Hamiltonian terms constructed by the 'convert_observable' function from an OpenFermion QubitOperator with respect to the same observable built directly using PennyLane operations.

**Description of the Change:**
The fix was implemented in the ``_qubit_operator_to_terms`` function of the ``qchem/structure`` module. An extra unit test was added to ``test_convert_observable.py``

**Benefits:**
Properties of Hamiltonian consistently return same type.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
https://github.com/PennyLaneAI/pennylane/issues/1265