### PR TITLE
Fix GitHub issue #1265

### DIFF
--- a/qchem/CHANGELOG.md
+++ b/qchem/CHANGELOG.md
@@ -9,7 +9,7 @@
 * The types of the Hamiltonian terms built from an OpenFermion ``QubitOperator`` using the
   ``convert_observable`` function, are the same with respect to the analogous observable
   built directly using PennyLane operations.
-  [(#)](https://github.com/PennyLaneAI/pennylane/pull/)
+  [(#1525)](https://github.com/PennyLaneAI/pennylane/pull/1525)
 
 * Requires the H5Py dependency to be `H5Py<=3.2.1` due to incompatibilities between `pyscf>=1.7.2` and `H5Py==3.3.0`.
   [(#1430)](https://github.com/PennyLaneAI/pennylane/pull/1430)

--- a/qchem/CHANGELOG.md
+++ b/qchem/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 <h3>Bug fixes</h3>
 
+* The types of the Hamiltonian terms built from an OpenFermion ``QubitOperator`` using the
+  ``convert_observable`` function, are the same with respect to the analogous observable
+  built directly using PennyLane operations.
+  [(#)](https://github.com/PennyLaneAI/pennylane/pull/)
+
 * Requires the H5Py dependency to be `H5Py<=3.2.1` due to incompatibilities between `pyscf>=1.7.2` and `H5Py==3.3.0`.
   [(#1430)](https://github.com/PennyLaneAI/pennylane/pull/1430)
 

--- a/qchem/pennylane_qchem/qchem/structure.py
+++ b/qchem/pennylane_qchem/qchem/structure.py
@@ -554,7 +554,7 @@ def _qubit_operator_to_terms(qubit_operator, wires=None):
     0.1 [X0] +
     0.2 [Y0 Z2]
     >>> _qubit_operator_to_terms(q_op, wires=['w0','w1','w2','extra_wire'])
-    (array([0.1, 0.2]), [Tensor(PauliX(wires=['w0'])), Tensor(PauliY(wires=['w0']), PauliZ(wires=['w2']))])
+    (array([0.1, 0.2]), [PauliX(wires=['w0']), PauliY(wires=['w0']) @ PauliZ(wires=['w2'])])
     """
     n_wires = (
         1 + max([max([i for i, _ in t]) if t else 1 for t in qubit_operator.terms])
@@ -564,7 +564,7 @@ def _qubit_operator_to_terms(qubit_operator, wires=None):
     wires = _process_wires(wires, n_wires=n_wires)
 
     if not qubit_operator.terms:  # added since can't unpack empty zip to (coeffs, ops) below
-        return np.array([0.0]), [qml.operation.Tensor(qml.Identity(wires[0]))]
+        return np.array([0.0]), [qml.Identity(wires[0])]
 
     xyz2pauli = {"X": qml.PauliX, "Y": qml.PauliY, "Z": qml.PauliZ}
 
@@ -573,8 +573,12 @@ def _qubit_operator_to_terms(qubit_operator, wires=None):
             (
                 coef,
                 qml.operation.Tensor(*[xyz2pauli[q[1]](wires=wires[q[0]]) for q in term])
-                if term
-                else qml.operation.Tensor(qml.Identity(wires[0]))
+                if len(term) > 1
+                else (
+                    xyz2pauli[term[0][1]](wires=wires[term[0][0]])
+                    if len(term) == 1
+                    else qml.Identity(wires[0])
+                )
                 # example term: ((0,'X'), (2,'Z'), (3,'Y'))
             )
             for term, coef in qubit_operator.terms.items()
@@ -629,6 +633,9 @@ def _terms_to_qubit_operator(coeffs, ops, wires=None):
 
     q_op = openfermion.QubitOperator()
     for coeff, op in zip(coeffs, ops):
+
+        if not isinstance(op, qml.operation.Tensor):
+            op = qml.operation.Tensor(op)
 
         extra_obsvbs = set(op.name) - {"PauliX", "PauliY", "PauliZ", "Identity"}
         if extra_obsvbs != set():

--- a/qchem/tests/test_convert_observable.py
+++ b/qchem/tests/test_convert_observable.py
@@ -322,6 +322,28 @@ def test_not_xyz_terms_to_qubit_operator():
         )
 
 
+def test_types_consistency():
+    r"""Test the type consistency of the qubit Hamiltonian constructed by 'convert_observable' from
+    an OpenFermion QubitOperator with respect to the same observable built directly using PennyLane
+    operations"""
+
+    # Reference PL operator
+    pl_ref = 1 * qml.Identity(0) + 2 * qml.PauliZ(0) @ qml.PauliX(1)
+
+    # Corresponding OpenFermion QubitOperator
+    of = QubitOperator("", 1) + QubitOperator("Z0 X1", 2)
+
+    # Build PL operator using 'convert_observable'
+    pl = qchem.convert_observable(of)
+
+    ops = pl.terms[1]
+    ops_ref = pl_ref.terms[1]
+
+    for i, op in enumerate(ops):
+        assert op.name == ops_ref[i].name
+        assert type(op) == type(ops_ref[i])
+
+
 op_1 = QubitOperator("Y0 Y1", 1 + 0j) + QubitOperator("Y0 X1", 2) + QubitOperator("Z0 Y1", 2.3e-08j)
 op_2 = QubitOperator("Z0 Y1", 2.23e-10j)
 


### PR DESCRIPTION
**Context:** Fix github issue #1265.  This PR ensures the type consistency of the qubit Hamiltonian terms constructed by the 'convert_observable' function from an OpenFermion QubitOperator with respect to the same observable built directly using PennyLane operations.

**Description of the Change:**
The fix was implemented in the ``_qubit_operator_to_terms`` function of the ``qchem/structure`` module. An extra unit test was added to ``test_convert_observable.py``

**Benefits:**
Properties of Hamiltonian consistently return same type.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
https://github.com/PennyLaneAI/pennylane/issues/1265