### PR TITLE
Fix `qml.adjoint` with no queuing context

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -465,6 +465,13 @@
 
 <h3>Improvements</h3>
 
+* The tape does not verify any more that all Observables have owners in the annotated queue.
+  [(#1505)](https://github.com/PennyLaneAI/pennylane/pull/1505)
+  This allows manipulation of Observables inside a tape context. An example is 
+  `expval(Tensor(qml.PauliX(0), qml.Identity(1)).prune())` which makes the expval an owner 
+  of the pruned tensor and its constituent observables, but leaves the original tensor in 
+  the queue without an owner.
+
 * The `step` and `step_and_cost` methods of `QNGOptimizer` now accept a custom `grad_fn`
   keyword argument to use for gradient computations.
   [(#1487)](https://github.com/PennyLaneAI/pennylane/pull/1487)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -627,6 +627,15 @@ Maria Schuld.
   
 <h3>Breaking changes</h3>
 
+* Removed the deprecated tape methods `get_resources` and `get_depth` as they are
+  superseded by the `specs` tape attribute.
+  [(#1522)](https://github.com/PennyLaneAI/pennylane/pull/1522)
+
+* Specifying `shots=None` with `qml.sample` was previously deprecated.
+  From this release onwards, setting `shots=None` when sampling will
+  raise an error.
+  [(#1522)](https://github.com/PennyLaneAI/pennylane/pull/1522)
+
 * The existing `pennylane.collections.apply` function is no longer accessible
   via `qml.apply`, and needs to be imported directly from the ``collections``
   package.

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,7 +2,60 @@
 
 <h3>New features since last release</h3>
 
+* Hamiltonians are now trainable with respect to their coefficients.
+  [(#1483)](https://github.com/PennyLaneAI/pennylane/pull/1483)
+
+  ``` python
+  from pennylane import numpy as np
+  
+  dev = qml.device("default.qubit", wires=2)
+  @qml.qnode(dev)
+  def circuit(coeffs, param):
+      qml.RX(param, wires=0)
+      qml.RY(param, wires=0)
+      return qml.expval(
+          qml.Hamiltonian(coeffs, [qml.PauliX(0), qml.PauliZ(0)], simplify=True)
+      )
+    
+  coeffs = np.array([-0.05, 0.17])
+  param = np.array(1.7)
+  grad_fn = qml.grad(circuit)
+  ```
+  ``` pycon
+  >>> grad_fn(coeffs, param)
+  (array([-0.12777055,  0.0166009 ]), array(0.0917819))
+  ```
+
 <h3>Improvements</h3>
+
+* The `group_observables` transform is now differentiable.
+  [(#1483)](https://github.com/PennyLaneAI/pennylane/pull/1483)
+ 
+  For example:
+
+  ``` python
+  import jax
+  from jax import numpy as jnp
+  
+  coeffs = jnp.array([1., 2., 3.])
+  obs = [PauliX(wires=0), PauliX(wires=1), PauliZ(wires=1)]
+
+  def group(coeffs, select=None):
+    _, grouped_coeffs = qml.grouping.group_observables(obs, coeffs)
+    # in this example, grouped_coeffs is a list of two jax tensors
+    # [DeviceArray([1., 2.], dtype=float32), DeviceArray([3.], dtype=float32)]
+    return grouped_coeffs[select]
+
+  jac_fn = jax.jacobian(group)
+  ```
+  ```pycon
+  >>> jac_fn(coeffs, select=0)
+  [[1. 0. 0.]
+  [0. 1. 0.]]
+  
+  >>> jac_fn(coeffs, select=1)
+  [[0., 0., 1.]]
+  ```
 
 * The tape does not verify any more that all Observables have owners in the annotated queue.
   [(#1505)](https://github.com/PennyLaneAI/pennylane/pull/1505)
@@ -153,7 +206,7 @@ Maria Schuld.
   Total shots:  200
   Total shots:  300
   ```
-
+  
 * VQE problems can now intuitively been set up by passing the Hamiltonian 
   as an observable. [(#1474)](https://github.com/PennyLaneAI/pennylane/pull/1474)
 
@@ -490,6 +543,14 @@ Maria Schuld.
   ```
 
 <h3>Improvements</h3>
+
+* The tape does not verify any more that all Observables have owners in the annotated queue.
+  [(#1505)](https://github.com/PennyLaneAI/pennylane/pull/1505)
+
+  This allows manipulation of Observables inside a tape context. An example is 
+  `expval(Tensor(qml.PauliX(0), qml.Identity(1)).prune())` which makes the expval an owner 
+  of the pruned tensor and its constituent observables, but leaves the original tensor in 
+  the queue without an owner.
 
 * The `step` and `step_and_cost` methods of `QNGOptimizer` now accept a custom `grad_fn`
   keyword argument to use for gradient computations.

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,4 +1,30 @@
-# Release 0.17.0-dev (development release)
+# Release 0.18.0-dev (development release)
+
+<h3>New features since last release</h3>
+
+<h3>Improvements</h3>
+
+* The tape does not verify any more that all Observables have owners in the annotated queue.
+  [(#1505)](https://github.com/PennyLaneAI/pennylane/pull/1505)
+
+  This allows manipulation of Observables inside a tape context. An example is
+  `expval(Tensor(qml.PauliX(0), qml.Identity(1)).prune())` which makes the expval
+  an owner of the pruned tensor and its constituent observables, but leaves the
+  original tensor in the queue without an owner.
+
+<h3>Breaking changes</h3>
+
+<h3>Bug fixes</h3>
+
+<h3>Documentation</h3>
+
+<h3>Contributors</h3>
+
+This release contains contributions from (in alphabetical order):
+
+Maria Schuld.
+
+# Release 0.17.0 (current release)
 
 <h3>New features since last release</h3>
 
@@ -465,13 +491,6 @@
 
 <h3>Improvements</h3>
 
-* The tape does not verify any more that all Observables have owners in the annotated queue.
-  [(#1505)](https://github.com/PennyLaneAI/pennylane/pull/1505)
-  This allows manipulation of Observables inside a tape context. An example is 
-  `expval(Tensor(qml.PauliX(0), qml.Identity(1)).prune())` which makes the expval an owner 
-  of the pruned tensor and its constituent observables, but leaves the original tensor in 
-  the queue without an owner.
-
 * The `step` and `step_and_cost` methods of `QNGOptimizer` now accept a custom `grad_fn`
   keyword argument to use for gradient computations.
   [(#1487)](https://github.com/PennyLaneAI/pennylane/pull/1487)
@@ -605,7 +624,7 @@ Arshpreet Singh Khangura, Ashish Panigrahi,
 Maria Schuld, Jay Soni, Antal Száva, David Wierichs.
 
 
-# Release 0.16.0 (current release)
+# Release 0.16.0
 
 <h3>New features since last release</h3>
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   TF_VERSION: 2.4
-  TORCH_VERSION: 1.7
+  TORCH_VERSION: 1.9.0+cpu
   COVERAGE_FLAGS: "--cov=pennylane --cov-report=term-missing --cov-report=xml --no-flaky-report -p no:warnings --tb=native"
 
 

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ help:
 	@echo "  wheel              to build the PennyLane wheel"
 	@echo "  dist               to package the source distribution"
 	@echo "  clean              to delete all temporary, cache, and build files"
+	@echo "  docs               to build the PennyLane documentation"
 	@echo "  clean-docs         to delete all built documentation"
 	@echo "  test               to run the test suite"
 	@echo "  coverage           to generate a coverage report"

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -18,5 +18,5 @@ sphinxcontrib-bibtex==0.4.2
 tensorflow==2.5.0
 tensornetwork==0.3
 toml
-torch==1.7.0+cpu
-torchvision==0.8.1+cpu
+torch==1.9.0+cpu
+torchvision==0.10.0+cpu

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -489,14 +489,13 @@ class QubitDevice(Device):
             array[int]: the sampled basis states
         """
         if self.shots is None:
-            warnings.warn(
+
+            raise qml.QuantumFunctionError(
                 "The number of shots has to be explicitly set on the device "
-                "when using sample-based measurements. Since no shots are specified, "
-                "a default of 1000 shots is used.",
-                UserWarning,
+                "when using sample-based measurements."
             )
 
-        shots = self.shots or 1000
+        shots = self.shots
 
         basis_states = np.arange(number_of_states)
         return np.random.choice(basis_states, shots, p=state_probability)

--- a/pennylane/_version.py
+++ b/pennylane/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.17.0-dev"
+__version__ = "0.17.0"

--- a/pennylane/math/single_dispatch.py
+++ b/pennylane/math/single_dispatch.py
@@ -133,6 +133,7 @@ ar.autoray._SUBMODULE_ALIASES["tensorflow", "arccos"] = "tensorflow.math"
 ar.autoray._SUBMODULE_ALIASES["tensorflow", "arctan"] = "tensorflow.math"
 ar.autoray._SUBMODULE_ALIASES["tensorflow", "arctan2"] = "tensorflow.math"
 ar.autoray._SUBMODULE_ALIASES["tensorflow", "diag"] = "tensorflow.linalg"
+ar.autoray._SUBMODULE_ALIASES["tensorflow", "kron"] = "tensorflow.experimental.numpy"
 
 
 ar.autoray._FUNC_ALIASES["tensorflow", "arcsin"] = "asin"

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -1116,10 +1116,10 @@ class Observable(Operator):
         >>> ob1.compare(ob2)
         False
         """
-        if isinstance(other, (Tensor, Observable)):
-            return other._obs_data() == self._obs_data()
         if isinstance(other, qml.Hamiltonian):
             return other.compare(self)
+        if isinstance(other, (Tensor, Observable)):
+            return other._obs_data() == self._obs_data()
 
         raise ValueError(
             "Can only compare an Observable/Tensor, and a Hamiltonian/Observable/Tensor."
@@ -1127,12 +1127,10 @@ class Observable(Operator):
 
     def __add__(self, other):
         r"""The addition operation between Observables/Tensors/qml.Hamiltonian objects."""
-        if isinstance(other, (Observable, Tensor)):
-            return qml.Hamiltonian([1, 1], [self, other], simplify=True)
-
         if isinstance(other, qml.Hamiltonian):
             return other + self
-
+        if isinstance(other, (Observable, Tensor)):
+            return qml.Hamiltonian([1, 1], [self, other], simplify=True)
         raise ValueError(f"Cannot add Observable and {type(other)}")
 
     def __mul__(self, a):

--- a/pennylane/qnode.py
+++ b/pennylane/qnode.py
@@ -617,8 +617,8 @@ class QNode:
                 tapes, fn = qml.transforms.hamiltonian_expand(self.qtape, group=False)
             except ValueError as e:
                 raise ValueError(
-                    "At the moment, only single expectations of Hamiltonian observables can be returned"
-                    "on the {} device.".format(self.device.name)
+                    "Only a single expectation of a Hamiltonian observable can be returned"
+                    "when using the {} device.".format(self.device.name)
                 ) from e
             results = [tape.execute(device=self.device) for tape in tapes]
             res = fn(results)

--- a/pennylane/tape/tape.py
+++ b/pennylane/tape/tape.py
@@ -450,9 +450,6 @@ class QuantumTape(AnnotatedQueue):
                 if obj.return_type is qml.operation.Sample:
                     self.is_sampled = True
 
-            elif isinstance(obj, qml.operation.Observable) and "owner" not in info:
-                raise ValueError(f"Observable {obj} does not have a measurement type specified.")
-
         self._update()
 
     def _update_circuit_info(self):

--- a/pennylane/tape/tape.py
+++ b/pennylane/tape/tape.py
@@ -19,7 +19,6 @@ from collections import Counter, deque, defaultdict
 import contextlib
 import copy
 from threading import RLock
-import warnings
 
 import numpy as np
 
@@ -1002,77 +1001,6 @@ class QuantumTape(AnnotatedQueue):
             )
 
         return self._graph
-
-    def get_resources(self):
-        """Resource requirements of a quantum circuit.
-
-        Returns:
-            dict[str, int]: how many times constituent operations are applied
-
-        **Example**
-
-        .. code-block:: python3
-
-            with qml.tape.QuantumTape() as tape:
-                qml.Hadamard(wires=0)
-                qml.RZ(0.26, wires=1)
-                qml.CNOT(wires=[1, 0])
-                qml.Rot(1.8, -2.7, 0.2, wires=0)
-                qml.Hadamard(wires=1)
-                qml.CNOT(wires=[0, 1])
-                qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
-
-        Asking for the resources produces a dictionary as shown below:
-
-        >>> tape.get_resources()
-        {'Hadamard': 2, 'RZ': 1, 'CNOT': 2, 'Rot': 1}
-
-        """
-
-        warnings.warn(
-            "``tape.get_resources``is now deprecated and will be removed in v0.17. "
-            "Please use the more general ``tape.specs`` instead.",
-            UserWarning,
-        )
-
-        return self.specs["gate_types"]
-
-    def get_depth(self):
-        """Depth of the quantum circuit.
-
-        Returns:
-            int: Circuit depth, computed as the longest path in the
-            circuit's directed acyclic graph representation.
-
-        **Example**
-
-        .. code-block:: python3
-
-            with QuantumTape() as tape:
-                qml.Hadamard(wires=0)
-                qml.PauliX(wires=1)
-                qml.CRX(2.3, wires=[0, 1])
-                qml.Rot(1.2, 3.2, 0.7, wires=[1])
-                qml.CRX(-2.3, wires=[0, 1])
-                qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
-
-        The depth can be obtained like so:
-
-        >>> tape.get_depth()
-        4
-
-        """
-
-        warnings.warn(
-            "``tape.get_depth`` is now deprecated and will be removed in v0.17. "
-            "Please use the more general ``tape.specs`` instead.",
-            UserWarning,
-        )
-
-        if self._depth is None:
-            self._depth = self.graph.get_depth()
-
-        return self._depth
 
     @property
     def specs(self):

--- a/pennylane/transforms/adjoint.py
+++ b/pennylane/transforms/adjoint.py
@@ -113,20 +113,44 @@ def adjoint(fn):
 
     @wraps(fn)
     def wrapper(*args, **kwargs):
-        with get_active_tape().stop_recording(), QuantumTape() as tape:
-            fn(*args, **kwargs)
+        active_tape = get_active_tape()
 
-        if not tape.operations:
-            tape = fn(*args, **kwargs)
+        if active_tape is not None:
+            with active_tape.stop_recording(), QuantumTape() as tape:
+                fn(*args, **kwargs)
 
-        for op in reversed(tape.operations):
-            try:
-                op.adjoint()
-            except NotImplementedError:
-                # Expand the operation and adjoint the result.
-                # We do not do anything with the output since
-                # calling adjoint on the expansion will automatically
-                # queue the new operations.
-                adjoint(op.expand)()
+            if not tape.operations:
+                tape = fn(*args, **kwargs)
+
+            for op in reversed(tape.operations):
+                try:
+                    op.adjoint()
+                except NotImplementedError:
+                    # Expand the operation and adjoint the result.
+                    # We do not do anything with the output since
+                    # calling adjoint on the expansion will automatically
+                    # queue the new operations.
+                    adjoint(op.expand)()
+        else:
+            with QuantumTape() as tape:
+                ops = fn(*args, **kwargs)
+
+            if not tape.operations:
+                tape = fn(*args, **kwargs)
+
+            adjoint_ops = []
+            for op in reversed(tape.operations):
+                try:
+                    new_op = op.adjoint()
+                    adjoint_ops.append(new_op)
+                except NotImplementedError:
+                    new_ops = adjoint(op.expand)()
+                    adjoint_ops.extend(new_ops)
+
+            if len(adjoint_ops) == 1:
+                adjoint_ops = adjoint_ops[0]
+
+            return adjoint_ops
+
 
     return wrapper

--- a/pennylane/transforms/adjoint.py
+++ b/pennylane/transforms/adjoint.py
@@ -120,6 +120,7 @@ def adjoint(fn):
                 fn(*args, **kwargs)
 
             if not tape.operations:
+                # we called op.expand(): get the outputted tape
                 tape = fn(*args, **kwargs)
 
             for op in reversed(tape.operations):
@@ -132,10 +133,14 @@ def adjoint(fn):
                     # queue the new operations.
                     adjoint(op.expand)()
         else:
+            # Not within a queuing context: return the results
+
             with QuantumTape() as tape:
-                ops = fn(*args, **kwargs)
+                fn(*args, **kwargs)
 
             if not tape.operations:
+                # since there are no operations, we called op.expand(): get the
+                # outputted tape
                 tape = fn(*args, **kwargs)
 
             adjoint_ops = []

--- a/pennylane/transforms/adjoint.py
+++ b/pennylane/transforms/adjoint.py
@@ -149,7 +149,7 @@ def adjoint(fn):
                     new_op = op.adjoint()
                     adjoint_ops.append(new_op)
                 except NotImplementedError:
-                    new_ops = adjoint(op.expand)()
+                    new_ops = adjoint(op.expand)().operations
                     adjoint_ops.extend(new_ops)
 
             if len(adjoint_ops) == 1:

--- a/pennylane/transforms/adjoint.py
+++ b/pennylane/transforms/adjoint.py
@@ -136,13 +136,14 @@ def adjoint(fn):
                 new_op = op.adjoint()
                 adjoint_ops.append(new_op)
             except NotImplementedError:
-                new_ops = adjoint(op.expand)().operations
+                new_ops = adjoint(op.expand)()
+                if isinstance(new_ops, QuantumTape):
+                    new_ops = new_ops.operations
                 adjoint_ops.extend(new_ops)
 
         if len(adjoint_ops) == 1:
             adjoint_ops = adjoint_ops[0]
 
         return adjoint_ops
-
 
     return wrapper

--- a/pennylane/vqe/vqe.py
+++ b/pennylane/vqe/vqe.py
@@ -17,8 +17,9 @@ computations using PennyLane.
 """
 # pylint: disable=too-many-arguments, too-few-public-methods
 from collections.abc import Sequence
-import itertools
 import warnings
+import itertools
+from copy import copy
 
 import pennylane as qml
 from pennylane import numpy as np
@@ -29,22 +30,17 @@ from pennylane.wires import Wires
 OBS_MAP = {"PauliX": "X", "PauliY": "Y", "PauliZ": "Z", "Hadamard": "H", "Identity": "I"}
 
 
-class Hamiltonian:
-    r"""Lightweight class for representing Hamiltonians for Variational Quantum
-    Eigensolver problems.
+class Hamiltonian(qml.operation.Observable):
+    r"""Operator representing a Hamiltonian.
 
-    Hamiltonians can be expressed as linear combinations of observables, e.g.,
-    :math:`\sum_{k=0}^{N-1} c_k O_k`.
-
-    This class keeps track of the terms (coefficients and observables) separately.
+    The Hamiltonian is represented as a linear combination of other operators, e.g.,
+    :math:`\sum_{k=0}^{N-1} c_k O_k`, where the :math:`c_k` are trainable parameters.
 
     Args:
-        coeffs (Iterable[float]): coefficients of the Hamiltonian expression
-        observables (Iterable[Observable]): observables in the Hamiltonian expression
+        coeffs (tensor_like): coefficients of the Hamiltonian expression
+        observables (Iterable[Observable]): observables in the Hamiltonian expression, of same length as coeffs
         simplify (bool): Specifies whether the Hamiltonian is simplified upon initialization
                          (like-terms are combined). The default value is `False`.
-
-    .. seealso:: :class:`~.ExpvalCost`, :func:`~.molecular_hamiltonian`
 
     **Example:**
 
@@ -52,6 +48,15 @@ class Hamiltonian:
     as well as the list of observables:
 
     >>> coeffs = [0.2, -0.543]
+    >>> obs = [qml.PauliX(0) @ qml.PauliZ(1), qml.PauliZ(0) @ qml.Hadamard(2)]
+    >>> H = qml.Hamiltonian(coeffs, obs)
+    >>> print(H)
+      (-0.543) [Z0 H2]
+    + (0.2) [X0 Z1]
+
+    The coefficients can be a trainable tensor, for example:
+
+    >>> coeffs = tf.Variable([0.2, -0.543], dtype=tf.double)
     >>> obs = [qml.PauliX(0) @ qml.PauliZ(1), qml.PauliZ(0) @ qml.Hadamard(2)]
     >>> H = qml.Hamiltonian(coeffs, obs)
     >>> print(H)
@@ -73,36 +78,37 @@ class Hamiltonian:
     :doc:`/introduction/chemistry` module can be used to generate a molecular
     Hamiltonian.
 
-    .. Warning::
+    In many cases, Hamiltonians can be constructed using Pythonic arithmetic operations.
+    For example:
 
-        Hamiltonians can be constructed using Pythonic arithmetic operations. For example:
+    >>> qml.Hamiltonian([1.], [qml.PauliX(0)]) + 2 * qml.PauliZ(0) @ qml.PauliZ(1)
 
-        >>> qml.PauliX(0) + 2 * qml.PauliZ(0) @ qml.PauliZ(1)
+    is equivalent to the following Hamiltonian:
 
-        is equivalent to the following Hamiltonian:
+    >>> qml.Hamiltonian([1, 2], [qml.PauliX(0), qml.PauliZ(0) @ qml.PauliZ(1)])
 
-        >>> qml.Hamiltonian([1, 2], [qml.PauliX(0), qml.PauliZ(0) @ qml.PauliZ(1)])
+    While scalar multiplication requires native python floats or integer types,
+    addition, subtraction, and tensor multiplication of Hamiltonians with Hamiltonians or
+    other observables is possible with tensor-valued coefficients, i.e.,
 
-        When Hamiltonians are defined using arithmetic operations **inside of QNodes**, constituent observables
-        may be queued as operations/an error may be thrown. Thus, Hamiltonians must be defined either outside of QNodes,
-        or inside of QNodes using the conventional method.
-
-        Note that this issue also arises when calling the ``simplify()`` method.
+    >>> H1 = qml.Hamiltonian(torch.tensor([1.]), [qml.PauliX(0)])
+    >>> H2 = qml.Hamiltonian(torch.tensor([2., 3.]), [qml.PauliY(0), qml.PauliX(1)])
+    >>> H3 = qml.Hamiltonian(torch.tensor([1., 2., 3.]), [qml.PauliX(0), qml.PauliY(0), qml.PauliX(1)])
+    >>> H3.compare(H1 + H2)
+    True
     """
-    # Todo: this is a temporary solution to make the circuit drawer work
-    num_params = 0
 
-    def __init__(self, coeffs, observables, simplify=False):
+    num_wires = qml.operation.AnyWires
+    num_params = 1
+    par_domain = "A"
+    grad_method = "A"  # supports analytic gradients
 
-        if len(coeffs) != len(observables):
+    def __init__(self, coeffs, observables, simplify=False, id=None, do_queue=True):
+
+        if qml.math.shape(coeffs)[0] != len(observables):
             raise ValueError(
                 "Could not create valid Hamiltonian; "
                 "number of coefficients and operators does not match."
-            )
-
-        if any(np.imag(coeffs) != 0):
-            raise ValueError(
-                "Could not create valid Hamiltonian; " "coefficients are not real-valued."
             )
 
         for obs in observables:
@@ -111,16 +117,23 @@ class Hamiltonian:
                     "Could not create circuits. Some or all observables are not valid."
                 )
 
-        self._coeffs = list(coeffs)
+        self._coeffs = coeffs
         self._ops = list(observables)
+        self._wires = qml.wires.Wires.all_wires([op.wires for op in self.ops], sort=True)
 
-        self.data = []
         self.return_type = None
 
         if simplify:
             self.simplify()
 
-        self.queue()
+        coeffs_flat = [self._coeffs[i] for i in range(qml.math.shape(self._coeffs)[0])]
+        # overwrite this attribute, now that we have the correct info
+        self.num_params = qml.math.shape(self._coeffs)[0]
+
+        # create the operator using each coefficient as a separate parameter;
+        # this causes H.data to be a list of tensor scalars,
+        # while H.coeffs is the original tensor
+        super().__init__(*coeffs_flat, wires=self._wires, id=id, do_queue=do_queue)
 
     @property
     def coeffs(self):
@@ -156,7 +169,7 @@ class Hamiltonian:
         Returns:
             (Wires): Combined wires present in all terms, sorted.
         """
-        return qml.wires.Wires.all_wires([op.wires for op in self.ops], sort=True)
+        return self._wires
 
     @property
     def name(self):
@@ -174,35 +187,39 @@ class Hamiltonian:
           (-1) [X0]
         + (1) [Y2]
         """
-        coeffs = []
+        data = []
         ops = []
 
-        for c, op in zip(self.coeffs, self.ops):
+        for i in range(len(self.ops)):  # pylint: disable=consider-using-enumerate
+            op = self.ops[i]
+            c = self.coeffs[i]
             op = op if isinstance(op, Tensor) else Tensor(op)
 
             ind = None
-            for i, other in enumerate(ops):
-                if op.compare(other):
-                    ind = i
+            for j, o in enumerate(ops):
+                if op.compare(o):
+                    ind = j
                     break
 
             if ind is not None:
-                coeffs[ind] += c
-                if np.allclose([coeffs[ind]], [0]):
-                    del coeffs[ind]
+                data[ind] += c
+                if np.isclose(qml.math.toarray(data[ind]), np.array(0.0)):
+                    del data[ind]
                     del ops[ind]
             else:
                 ops.append(op.prune())
-                coeffs.append(c)
+                data.append(c)
 
-        self._coeffs = coeffs
+        self._coeffs = qml.math.stack(data) if data else []
+        self.data = data
         self._ops = ops
 
     def __str__(self):
         # Lambda function that formats the wires
         wires_print = lambda ob: ",".join(map(str, ob.wires.tolist()))
 
-        paired_coeff_obs = list(zip(self.coeffs, self.ops))
+        list_of_coeffs = self.data  # list of scalar tensors
+        paired_coeff_obs = list(zip(list_of_coeffs, self.ops))
         paired_coeff_obs.sort(key=lambda pair: (len(pair[1].wires), pair[0]))
 
         terms_ls = []
@@ -223,7 +240,7 @@ class Hamiltonian:
 
     def __repr__(self):
         # Constructor-call-like representation
-        return f"<Hamiltonian: terms={len(self.coeffs)}, wires={self.wires.tolist()}>"
+        return f"<Hamiltonian: terms={qml.math.shape(self.coeffs)[0]}, wires={self.wires.tolist()}>"
 
     def _obs_data(self):
         r"""Extracts the data from a Hamiltonian and serializes it in an order-independent fashion.
@@ -247,12 +264,13 @@ class Hamiltonian:
         """
         data = set()
 
-        for co, op in zip(*self.terms):
+        coeffs_arr = qml.math.toarray(self.coeffs)
+        for co, op in zip(coeffs_arr, self.ops):
             obs = op.non_identity_obs if isinstance(op, Tensor) else [op]
             tensor = []
             for ob in obs:
                 parameters = tuple(
-                    param.tostring() for param in ob.parameters
+                    str(param) for param in ob.parameters
                 )  # Converts params into immutable type
                 tensor.append((ob.name, ob.wires, parameters))
             data.add((co, frozenset(tensor)))
@@ -314,8 +332,8 @@ class Hamiltonian:
 
     def __matmul__(self, H):
         r"""The tensor product operation between a Hamiltonian and a Hamiltonian/Tensor/Observable."""
-        coeffs1 = self.coeffs.copy()
-        terms1 = self.ops.copy()
+        coeffs1 = copy(self.coeffs)
+        ops1 = self.ops.copy()
 
         if isinstance(H, Hamiltonian):
             shared_wires = Wires.shared_wires([self.wires, H.wires])
@@ -326,34 +344,35 @@ class Hamiltonian:
                 )
 
             coeffs2 = H.coeffs
-            terms2 = H.ops
+            ops2 = H.ops
 
-            coeffs = [c[0] * c[1] for c in itertools.product(coeffs1, coeffs2)]
-            term_list = itertools.product(terms1, terms2)
-            terms = [qml.operation.Tensor(t[0], t[1]) for t in term_list]
+            coeffs = qml.math.kron(coeffs1, coeffs2)
+            ops_list = itertools.product(ops1, ops2)
+            terms = [qml.operation.Tensor(t[0], t[1]) for t in ops_list]
 
             return qml.Hamiltonian(coeffs, terms, simplify=True)
 
         if isinstance(H, (Tensor, Observable)):
-            coeffs = coeffs1
-            terms = [term @ H for term in terms1]
+            terms = [op @ H for op in ops1]
 
-            return qml.Hamiltonian(coeffs, terms, simplify=True)
+            return qml.Hamiltonian(coeffs1, terms, simplify=True)
 
         raise ValueError(f"Cannot tensor product Hamiltonian and {type(H)}")
 
     def __add__(self, H):
         r"""The addition operation between a Hamiltonian and a Hamiltonian/Tensor/Observable."""
-        coeffs = self.coeffs.copy()
         ops = self.ops.copy()
+        self_coeffs = copy(self.coeffs)
 
         if isinstance(H, Hamiltonian):
-            coeffs.extend(H.coeffs.copy())
+            coeffs = qml.math.concatenate([self_coeffs, copy(H.coeffs)], axis=0)
             ops.extend(H.ops.copy())
             return qml.Hamiltonian(coeffs, ops, simplify=True)
 
         if isinstance(H, (Tensor, Observable)):
-            coeffs.append(1)
+            coeffs = qml.math.concatenate(
+                [self_coeffs, qml.math.cast_like([1.0], self_coeffs)], axis=0
+            )
             ops.append(H)
             return qml.Hamiltonian(coeffs, ops, simplify=True)
 
@@ -362,7 +381,8 @@ class Hamiltonian:
     def __mul__(self, a):
         r"""The scalar multiplication operation between a scalar and a Hamiltonian."""
         if isinstance(a, (int, float)):
-            coeffs = [a * c for c in self.coeffs.copy()]
+            self_coeffs = copy(self.coeffs)
+            coeffs = qml.math.multiply(qml.math.cast_like([a], self_coeffs), self_coeffs)
             return qml.Hamiltonian(coeffs, self.ops.copy())
 
         raise ValueError(f"Cannot multiply Hamiltonian by {type(a)}")
@@ -378,13 +398,15 @@ class Hamiltonian:
     def __iadd__(self, H):
         r"""The inplace addition operation between a Hamiltonian and a Hamiltonian/Tensor/Observable."""
         if isinstance(H, Hamiltonian):
-            self._coeffs.extend(H.coeffs.copy())
+            self._coeffs = qml.math.concatenate([self._coeffs, H.coeffs], axis=0)
             self._ops.extend(H.ops.copy())
             self.simplify()
             return self
 
         if isinstance(H, (Tensor, Observable)):
-            self._coeffs.append(1)
+            self._coeffs = qml.math.concatenate(
+                [self._coeffs, qml.math.cast_like([1.0], self._coeffs)], axis=0
+            )
             self._ops.append(H)
             self.simplify()
             return self
@@ -394,7 +416,7 @@ class Hamiltonian:
     def __imul__(self, a):
         r"""The inplace scalar multiplication operation between a scalar and a Hamiltonian."""
         if isinstance(a, (int, float)):
-            self._coeffs = [a * c for c in self.coeffs]
+            self._coeffs = qml.math.multiply(qml.math.cast_like([a], self._coeffs), self._coeffs)
             return self
 
         raise ValueError(f"Cannot multiply Hamiltonian by {type(a)}")
@@ -547,7 +569,7 @@ class ExpvalCost:
         self._multiple_devices = isinstance(device, Sequence)
         """Bool: Records if multiple devices are input"""
 
-        if all(c == 0 for c in coeffs) or not coeffs:
+        if np.isclose(qml.math.toarray(qml.math.count_nonzero(coeffs)), 0):
             self.cost_fn = lambda *args, **kwargs: np.array(0)
             return
 

--- a/qchem/CHANGELOG.md
+++ b/qchem/CHANGELOG.md
@@ -1,4 +1,18 @@
-# Release 0.17.0-dev
+# Release 0.18.0-dev
+
+<h3>New features</h3>
+
+<h3>Improvements</h3>
+
+<h3>Bug fixes</h3>
+
+<h3>Breaking changes</h3>
+
+<h3>Contributors</h3>
+
+This release contains contributions from (in alphabetical order):
+
+# Release 0.17.0
 
 <h3>New features</h3>
 

--- a/qchem/pennylane_qchem/_version.py
+++ b/qchem/pennylane_qchem/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.17.0-dev"
+__version__ = "0.18.0-dev"

--- a/tests/grouping/test_optimize_measurements.py
+++ b/tests/grouping/test_optimize_measurements.py
@@ -15,6 +15,7 @@
 Unit tests for ``optimize_measurements`` function in ``grouping/optimize_measurements.py``.
 """
 import pytest
+import numpy as np
 from pennylane import Identity, PauliX, PauliY, PauliZ
 from pennylane.grouping.utils import are_identical_pauli_words
 from pennylane.grouping.optimize_measurements import optimize_measurements
@@ -108,7 +109,8 @@ class TestOptimizeMeasurements:
         assert len(grouped_coeffs) == len(grouped_coeffs)
 
         assert all(
-            grouped_coeffs[i] == grouped_coeffs_sol[i] for i in range(len(grouped_coeffs_sol))
+            np.allclose(grouped_coeffs[i], grouped_coeffs_sol[i])
+            for i in range(len(grouped_coeffs_sol))
         )
 
     @pytest.mark.parametrize(
@@ -140,7 +142,8 @@ class TestOptimizeMeasurements:
         assert len(grouped_coeffs) == len(grouped_coeffs)
 
         assert all(
-            grouped_coeffs[i] == grouped_coeffs_sol[i] for i in range(len(grouped_coeffs_sol))
+            np.allclose(grouped_coeffs[i], grouped_coeffs_sol[i])
+            for i in range(len(grouped_coeffs_sol))
         )
 
     def test_optimize_measurements_not_implemented_catch(self):

--- a/tests/ops/test_hamiltonian.py
+++ b/tests/ops/test_hamiltonian.py
@@ -1,0 +1,642 @@
+# Copyright 2018-2021 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Tests for the Hamiltonian class.
+"""
+import numpy as np
+import pytest
+
+import pennylane as qml
+from pennylane import numpy as pnp
+
+# Make test data in different interfaces, if installed
+COEFFS_PARAM_INTERFACE = [
+    ([-0.05, 0.17], 1.7, "autograd"),
+    (np.array([-0.05, 0.17]), np.array(1.7), "autograd"),
+    (pnp.array([-0.05, 0.17], requires_grad=True), pnp.array(1.7, requires_grad=True), "autograd"),
+]
+
+try:
+    from jax import numpy as jnp
+
+    COEFFS_PARAM_INTERFACE.append((jnp.array([-0.05, 0.17]), jnp.array(1.7), "jax"))
+except ImportError:
+    pass
+
+try:
+    import tf
+
+    COEFFS_PARAM_INTERFACE.append(
+        (tf.Variable([-0.05, 0.17], dtype=tf.double), tf.Variable(1.7, dtype=tf.double), "tf")
+    )
+except ImportError:
+    pass
+
+try:
+    import torch
+
+    COEFFS_PARAM_INTERFACE.append((torch.tensor([-0.05, 0.17]), torch.tensor([1.7]), "torch"))
+except ImportError:
+    pass
+
+
+def circuit1(param):
+    """First Pauli subcircuit"""
+    qml.RX(param, wires=0)
+    qml.RY(param, wires=0)
+    return qml.expval(qml.PauliX(0))
+
+
+def circuit2(param):
+    """Second Pauli subcircuit"""
+    qml.RX(param, wires=0)
+    qml.RY(param, wires=0)
+    return qml.expval(qml.PauliZ(0))
+
+
+dev = qml.device("default.qubit", wires=2)
+
+
+class TestHamiltonianCoefficients:
+    """Test the creation of a Hamiltonian"""
+
+    @pytest.mark.parametrize("coeffs", [el[0] for el in COEFFS_PARAM_INTERFACE])
+    def test_creation_different_coeff_types(self, coeffs):
+        """Check that Hamiltonian's coefficients and data attributes are set correctly."""
+        H = qml.Hamiltonian(coeffs, [qml.PauliX(0), qml.PauliZ(0)])
+        assert np.allclose(coeffs, H.coeffs)
+        assert np.allclose([coeffs[i] for i in range(qml.math.shape(coeffs)[0])], H.data)
+
+    @pytest.mark.parametrize("coeffs", [el[0] for el in COEFFS_PARAM_INTERFACE])
+    def test_simplify(self, coeffs):
+        """Test that simplify works with different coefficient types."""
+        H1 = qml.Hamiltonian(coeffs, [qml.PauliX(0), qml.PauliZ(1)])
+        H2 = qml.Hamiltonian(coeffs, [qml.PauliX(0), qml.Identity(0) @ qml.PauliZ(1)])
+        H2.simplify()
+        assert H1.compare(H2)
+        assert H1.data == H2.data
+
+
+class TestHamiltonianArithmeticTF:
+    """Tests creation of Hamiltonians using arithmetic
+    operations with TensorFlow tensor coefficients."""
+
+    def test_hamiltonian_equal(self):
+        """Tests equality"""
+        tf = pytest.importorskip("tensorflow")
+
+        coeffs = tf.Variable([0.5, -1.6])
+        obs = [qml.PauliX(0), qml.PauliY(1)]
+        H1 = qml.Hamiltonian(coeffs, obs)
+
+        coeffs2 = tf.Variable([-1.6, 0.5])
+        obs2 = [qml.PauliY(1), qml.PauliX(0)]
+        H2 = qml.Hamiltonian(coeffs2, obs2)
+
+        assert H1.compare(H2)
+
+    def test_hamiltonian_add(self):
+        """Tests that Hamiltonians are added correctly"""
+        tf = pytest.importorskip("tensorflow")
+
+        coeffs = tf.Variable([0.5, -1.6])
+        obs = [qml.PauliX(0), qml.PauliY(1)]
+        H1 = qml.Hamiltonian(coeffs, obs)
+
+        coeffs2 = tf.Variable([0.5, -0.4])
+        H2 = qml.Hamiltonian(coeffs2, obs)
+
+        coeffs_expected = tf.Variable([1.0, -2.0])
+        H = qml.Hamiltonian(coeffs_expected, obs)
+
+        assert H.compare(H1 + H2)
+
+        H1 += H2
+        assert H.compare(H1)
+
+    def test_hamiltonian_sub(self):
+        """Tests that Hamiltonians are subtracted correctly"""
+        tf = pytest.importorskip("tensorflow")
+
+        coeffs = tf.Variable([1.0, -2.0])
+        obs = [qml.PauliX(0), qml.PauliY(1)]
+        H1 = qml.Hamiltonian(coeffs, obs)
+
+        coeffs2 = tf.Variable([0.5, -0.4])
+        H2 = qml.Hamiltonian(coeffs2, obs)
+
+        coeffs_expected = tf.Variable([0.5, -1.6])
+        H = qml.Hamiltonian(coeffs_expected, obs)
+
+        assert H.compare(H1 - H2)
+
+        H1 -= H2
+        assert H.compare(H1)
+
+    def test_hamiltonian_matmul(self):
+        """Tests that Hamiltonians are tensored correctly"""
+        tf = pytest.importorskip("tensorflow")
+
+        coeffs = tf.Variable([1.0, 2.0])
+        obs = [qml.PauliX(0), qml.PauliY(1)]
+        H1 = qml.Hamiltonian(coeffs, obs)
+
+        coeffs2 = tf.Variable([-1.0, -2.0])
+        obs2 = [qml.PauliX(2), qml.PauliY(3)]
+        H2 = qml.Hamiltonian(coeffs2, obs2)
+
+        coeffs_expected = tf.Variable([-4.0, -2.0, -2.0, -1.0])
+        obs_expected = [
+            qml.PauliY(1) @ qml.PauliY(3),
+            qml.PauliX(0) @ qml.PauliY(3),
+            qml.PauliX(2) @ qml.PauliY(1),
+            qml.PauliX(0) @ qml.PauliX(2),
+        ]
+        H = qml.Hamiltonian(coeffs_expected, obs_expected)
+
+        assert H.compare(H1 @ H2)
+
+
+class TestHamiltonianArithmeticTorch:
+    """Tests creation of Hamiltonians using arithmetic
+    operations with torch tensor coefficients."""
+
+    def test_hamiltonian_equal(self):
+        """Tests equality"""
+        torch = pytest.importorskip("torch")
+
+        coeffs = torch.tensor([0.5, -1.6])
+        obs = [qml.PauliX(0), qml.PauliY(1)]
+        H1 = qml.Hamiltonian(coeffs, obs)
+
+        coeffs2 = torch.tensor([-1.6, 0.5])
+        obs2 = [qml.PauliY(1), qml.PauliX(0)]
+        H2 = qml.Hamiltonian(coeffs2, obs2)
+
+        assert H1.compare(H2)
+
+    def test_hamiltonian_add(self):
+        """Tests that Hamiltonians are added correctly"""
+        torch = pytest.importorskip("torch")
+
+        coeffs = torch.tensor([0.5, -1.6])
+        obs = [qml.PauliX(0), qml.PauliY(1)]
+        H1 = qml.Hamiltonian(coeffs, obs)
+
+        coeffs2 = torch.tensor([0.5, -0.4])
+        H2 = qml.Hamiltonian(coeffs2, obs)
+
+        coeffs_expected = torch.tensor([1.0, -2.0])
+        H = qml.Hamiltonian(coeffs_expected, obs)
+
+        assert H.compare(H1 + H2)
+
+        H1 += H2
+        assert H.compare(H1)
+
+    def test_hamiltonian_sub(self):
+        """Tests that Hamiltonians are subtracted correctly"""
+        torch = pytest.importorskip("torch")
+
+        coeffs = torch.tensor([1.0, -2.0])
+        obs = [qml.PauliX(0), qml.PauliY(1)]
+        H1 = qml.Hamiltonian(coeffs, obs)
+
+        coeffs2 = torch.tensor([0.5, -0.4])
+        H2 = qml.Hamiltonian(coeffs2, obs)
+
+        coeffs_expected = torch.tensor([0.5, -1.6])
+        H = qml.Hamiltonian(coeffs_expected, obs)
+
+        assert H.compare(H1 - H2)
+
+        H1 -= H2
+        assert H.compare(H1)
+
+    def test_hamiltonian_matmul(self):
+        """Tests that Hamiltonians are tensored correctly"""
+        torch = pytest.importorskip("torch")
+
+        coeffs = torch.tensor([1.0, 2.0])
+        obs = [qml.PauliX(0), qml.PauliY(1)]
+        H1 = qml.Hamiltonian(coeffs, obs)
+
+        coeffs2 = torch.tensor([-1.0, -2.0])
+        obs2 = [qml.PauliX(2), qml.PauliY(3)]
+        H2 = qml.Hamiltonian(coeffs2, obs2)
+
+        coeffs_expected = torch.tensor([-4.0, -2.0, -2.0, -1.0])
+        obs_expected = [
+            qml.PauliY(1) @ qml.PauliY(3),
+            qml.PauliX(0) @ qml.PauliY(3),
+            qml.PauliX(2) @ qml.PauliY(1),
+            qml.PauliX(0) @ qml.PauliX(2),
+        ]
+        H = qml.Hamiltonian(coeffs_expected, obs_expected)
+
+        assert H.compare(H1 @ H2)
+
+
+class TestHamiltonianArithmeticAutograd:
+    """Tests creation of Hamiltonians using arithmetic
+    operations with autograd tensor coefficients."""
+
+    def test_hamiltonian_equal(self):
+        """Tests equality"""
+        coeffs = pnp.array([0.5, -1.6])
+        obs = [qml.PauliX(0), qml.PauliY(1)]
+        H1 = qml.Hamiltonian(coeffs, obs)
+
+        coeffs2 = pnp.array([-1.6, 0.5])
+        obs2 = [qml.PauliY(1), qml.PauliX(0)]
+        H2 = qml.Hamiltonian(coeffs2, obs2)
+
+        assert H1.compare(H2)
+
+    def test_hamiltonian_add(self):
+        """Tests that Hamiltonians are added correctly"""
+        coeffs = pnp.array([0.5, -1.6])
+        obs = [qml.PauliX(0), qml.PauliY(1)]
+        H1 = qml.Hamiltonian(coeffs, obs)
+
+        coeffs2 = pnp.array([0.5, -0.4])
+        H2 = qml.Hamiltonian(coeffs2, obs)
+
+        coeffs_expected = pnp.array([1.0, -2.0])
+        H = qml.Hamiltonian(coeffs_expected, obs)
+
+        assert H.compare(H1 + H2)
+
+        H1 += H2
+        assert H.compare(H1)
+
+    def test_hamiltonian_sub(self):
+        """Tests that Hamiltonians are subtracted correctly"""
+        coeffs = pnp.array([1.0, -2.0])
+        obs = [qml.PauliX(0), qml.PauliY(1)]
+        H1 = qml.Hamiltonian(coeffs, obs)
+
+        coeffs2 = pnp.array([0.5, -0.4])
+        H2 = qml.Hamiltonian(coeffs2, obs)
+
+        coeffs_expected = pnp.array([0.5, -1.6])
+        H = qml.Hamiltonian(coeffs_expected, obs)
+
+        assert H.compare(H1 - H2)
+
+        H1 -= H2
+        assert H.compare(H1)
+
+    def test_hamiltonian_matmul(self):
+        """Tests that Hamiltonians are tensored correctly"""
+        coeffs = pnp.array([1.0, 2.0])
+        obs = [qml.PauliX(0), qml.PauliY(1)]
+        H1 = qml.Hamiltonian(coeffs, obs)
+
+        coeffs2 = pnp.array([-1.0, -2.0])
+        obs2 = [qml.PauliX(2), qml.PauliY(3)]
+        H2 = qml.Hamiltonian(coeffs2, obs2)
+
+        coeffs_expected = pnp.array([-4.0, -2.0, -2.0, -1.0])
+        obs_expected = [
+            qml.PauliY(1) @ qml.PauliY(3),
+            qml.PauliX(0) @ qml.PauliY(3),
+            qml.PauliX(2) @ qml.PauliY(1),
+            qml.PauliX(0) @ qml.PauliX(2),
+        ]
+        H = qml.Hamiltonian(coeffs_expected, obs_expected)
+
+        assert H.compare(H1 @ H2)
+
+
+class TestHamiltonianArithmeticJax:
+    """Tests creation of Hamiltonians using arithmetic
+    operations with jax tensor coefficients."""
+
+    def test_hamiltonian_equal(self):
+        """Tests equality"""
+        jax = pytest.importorskip("jax")
+        from jax import numpy as jnp
+
+        coeffs = jnp.array([0.5, -1.6])
+        obs = [qml.PauliX(0), qml.PauliY(1)]
+        H1 = qml.Hamiltonian(coeffs, obs)
+
+        coeffs2 = jnp.array([-1.6, 0.5])
+        obs2 = [qml.PauliY(1), qml.PauliX(0)]
+        H2 = qml.Hamiltonian(coeffs2, obs2)
+
+        assert H1.compare(H2)
+
+    def test_hamiltonian_add(self):
+        """Tests that Hamiltonians are added correctly"""
+        jax = pytest.importorskip("jax")
+        from jax import numpy as jnp
+
+        coeffs = jnp.array([0.5, -1.6])
+        obs = [qml.PauliX(0), qml.PauliY(1)]
+        H1 = qml.Hamiltonian(coeffs, obs)
+
+        coeffs2 = jnp.array([0.5, -0.4])
+        H2 = qml.Hamiltonian(coeffs2, obs)
+
+        coeffs_expected = jnp.array([1.0, -2.0])
+        H = qml.Hamiltonian(coeffs_expected, obs)
+
+        assert H.compare(H1 + H2)
+
+        H1 += H2
+        assert H.compare(H1)
+
+    def test_hamiltonian_sub(self):
+        """Tests that Hamiltonians are subtracted correctly"""
+        jax = pytest.importorskip("jax")
+        from jax import numpy as jnp
+
+        coeffs = jnp.array([1.0, -2.0])
+        obs = [qml.PauliX(0), qml.PauliY(1)]
+        H1 = qml.Hamiltonian(coeffs, obs)
+
+        coeffs2 = jnp.array([0.5, -0.4])
+        H2 = qml.Hamiltonian(coeffs2, obs)
+
+        coeffs_expected = jnp.array([0.5, -1.6])
+        H = qml.Hamiltonian(coeffs_expected, obs)
+
+        assert H.compare(H1 - H2)
+
+        H1 -= H2
+        assert H.compare(H1)
+
+    def test_hamiltonian_matmul(self):
+        """Tests that Hamiltonians are tensored correctly"""
+        jax = pytest.importorskip("jax")
+        from jax import numpy as jnp
+
+        coeffs = jnp.array([1.0, 2.0])
+        obs = [qml.PauliX(0), qml.PauliY(1)]
+        H1 = qml.Hamiltonian(coeffs, obs)
+
+        coeffs2 = jnp.array([-1.0, -2.0])
+        obs2 = [qml.PauliX(2), qml.PauliY(3)]
+        H2 = qml.Hamiltonian(coeffs2, obs2)
+
+        coeffs_expected = jnp.array([-4.0, -2.0, -2.0, -1.0])
+        obs_expected = [
+            qml.PauliY(1) @ qml.PauliY(3),
+            qml.PauliX(0) @ qml.PauliY(3),
+            qml.PauliX(2) @ qml.PauliY(1),
+            qml.PauliX(0) @ qml.PauliX(2),
+        ]
+        H = qml.Hamiltonian(coeffs_expected, obs_expected)
+
+        assert H.compare(H1 @ H2)
+
+
+class TestHamiltonianEvaluation:
+    """Test the usage of a Hamiltonian as an observable"""
+
+    @pytest.mark.parametrize("coeffs, param, interface", COEFFS_PARAM_INTERFACE)
+    def test_vqe_forward_different_coeff_types(self, coeffs, param, interface):
+        """Check that manually splitting a Hamiltonian expectation has the same
+        result as passing the Hamiltonian as an observable"""
+        dev = qml.device("default.qubit", wires=2)
+        H = qml.Hamiltonian(coeffs, [qml.PauliX(0), qml.PauliZ(0)])
+
+        @qml.qnode(dev, interface=interface)
+        def circuit():
+            qml.RX(param, wires=0)
+            qml.RY(param, wires=0)
+            return qml.expval(H)
+
+        @qml.qnode(dev, interface=interface)
+        def circuit1():
+            qml.RX(param, wires=0)
+            qml.RY(param, wires=0)
+            return qml.expval(qml.PauliX(0))
+
+        @qml.qnode(dev, interface=interface)
+        def circuit2():
+            qml.RX(param, wires=0)
+            qml.RY(param, wires=0)
+            return qml.expval(qml.PauliZ(0))
+
+        res = circuit()
+        res_expected = coeffs[0] * circuit1() + coeffs[1] * circuit2()
+        assert np.isclose(res, res_expected)
+
+    def test_simplify_reduces_tape_parameters(self):
+        """Test that simplifying a Hamiltonian reduces the number of parameters on a tape"""
+        dev = qml.device("default.qubit", wires=2)
+
+        @qml.qnode(dev)
+        def circuit():
+            qml.RY(0.1, wires=0)
+            return qml.expval(
+                qml.Hamiltonian([1.0, 2.0], [qml.PauliX(1), qml.PauliX(1)], simplify=True)
+            )
+
+        circuit()
+        pars = circuit.qtape.get_parameters(trainable_only=False)
+        # simplify worked and added 1. and 2.
+        assert pars == [0.1, 3.0]
+
+
+class TestHamiltonianDifferentiation:
+    """Test that the Hamiltonian coefficients are differentiable"""
+
+    @pytest.mark.parametrize("simplify", [True, False])
+    def test_vqe_differentiation_paramshift(self, simplify):
+        """Test the parameter-shift method by comparing the differentiation of linearly combined subcircuits
+        with the differentiation of a Hamiltonian expectation"""
+        coeffs = np.array([-0.05, 0.17])
+        param = np.array(1.7)
+
+        # differentiating a circuit with measurement expval(H)
+        @qml.qnode(dev, diff_method="parameter-shift")
+        def circuit(coeffs, param):
+            qml.RX(param, wires=0)
+            qml.RY(param, wires=0)
+            return qml.expval(
+                qml.Hamiltonian(coeffs, [qml.PauliX(0), qml.PauliZ(0)], simplify=simplify)
+            )
+
+        grad_fn = qml.grad(circuit)
+        grad = grad_fn(coeffs, param)
+
+        # differentiating a cost that combines circuits with
+        # measurements expval(Pauli)
+        half1 = qml.QNode(circuit1, dev, diff_method="parameter-shift")
+        half2 = qml.QNode(circuit2, dev, diff_method="parameter-shift")
+
+        def combine(coeffs, param):
+            return coeffs[0] * half1(param) + coeffs[1] * half2(param)
+
+        grad_fn_expected = qml.grad(combine)
+        grad_expected = grad_fn_expected(coeffs, param)
+
+        assert np.allclose(grad[0], grad_expected[0])
+        assert np.allclose(grad[1], grad_expected[1])
+
+    @pytest.mark.parametrize("simplify", [True, False])
+    def test_vqe_differentiation_autograd(self, simplify):
+        """Test the autograd interface by comparing the differentiation of linearly combined subcircuits
+        with the differentiation of a Hamiltonian expectation"""
+        coeffs = pnp.array([-0.05, 0.17], requires_grad=True)
+        param = pnp.array(1.7, requires_grad=True)
+
+        # differentiating a circuit with measurement expval(H)
+        @qml.qnode(dev, interface="autograd")
+        def circuit(coeffs, param):
+            qml.RX(param, wires=0)
+            qml.RY(param, wires=0)
+            return qml.expval(
+                qml.Hamiltonian(coeffs, [qml.PauliX(0), qml.PauliZ(0)], simplify=simplify)
+            )
+
+        grad_fn = qml.grad(circuit)
+        grad = grad_fn(coeffs, param)
+
+        # differentiating a cost that combines circuits with
+        # measurements expval(Pauli)
+        half1 = qml.QNode(circuit1, dev, interface="autograd")
+        half2 = qml.QNode(circuit2, dev, interface="autograd")
+
+        def combine(coeffs, param):
+            return coeffs[0] * half1(param) + coeffs[1] * half2(param)
+
+        grad_fn_expected = qml.grad(combine)
+        grad_expected = grad_fn_expected(coeffs, param)
+
+        assert np.allclose(grad[0], grad_expected[0])
+        assert np.allclose(grad[1], grad_expected[1])
+
+    @pytest.mark.parametrize("simplify", [True, False])
+    def test_vqe_differentiation_jax(self, simplify):
+        """Test the jax interface by comparing the differentiation of linearly combined subcircuits
+        with the differentiation of a Hamiltonian expectation"""
+
+        jax = pytest.importorskip("jax")
+        jnp = pytest.importorskip("jax.numpy")
+        coeffs = jnp.array([-0.05, 0.17])
+        param = jnp.array(1.7)
+
+        # differentiating a circuit with measurement expval(H)
+        @qml.qnode(dev, interface="jax", diff_method="backprop")
+        def circuit(coeffs, param):
+            qml.RX(param, wires=0)
+            qml.RY(param, wires=0)
+            return qml.expval(
+                qml.Hamiltonian(coeffs, [qml.PauliX(0), qml.PauliZ(0)], simplify=simplify)
+            )
+
+        grad_fn = jax.grad(circuit)
+        grad = grad_fn(coeffs, param)
+
+        # differentiating a cost that combines circuits with
+        # measurements expval(Pauli)
+        half1 = qml.QNode(circuit1, dev, interface="jax", diff_method="backprop")
+        half2 = qml.QNode(circuit2, dev, interface="jax", diff_method="backprop")
+
+        def combine(coeffs, param):
+            return coeffs[0] * half1(param) + coeffs[1] * half2(param)
+
+        grad_fn_expected = jax.grad(combine)
+        grad_expected = grad_fn_expected(coeffs, param)
+
+        assert np.allclose(grad[0], grad_expected[0])
+        assert np.allclose(grad[1], grad_expected[1])
+
+    @pytest.mark.parametrize("simplify", [True, False])
+    def test_vqe_differentiation_torch(self, simplify):
+        """Test the torch interface by comparing the differentiation of linearly combined subcircuits
+        with the differentiation of a Hamiltonian expectation"""
+
+        torch = pytest.importorskip("torch")
+        coeffs = torch.tensor([-0.05, 0.17], requires_grad=True)
+        param = torch.tensor(1.7, requires_grad=True)
+
+        # differentiating a circuit with measurement expval(H)
+        @qml.qnode(dev, interface="torch")
+        def circuit(coeffs, param):
+            qml.RX(param, wires=0)
+            qml.RY(param, wires=0)
+            return qml.expval(
+                qml.Hamiltonian(coeffs, [qml.PauliX(0), qml.PauliZ(0)], simplify=simplify)
+            )
+
+        res = circuit(coeffs, param)
+        res.backward()
+        grad = (coeffs.grad, param.grad)
+
+        # differentiating a cost that combines circuits with
+        # measurements expval(Pauli)
+
+        # we need to create new tensors here
+        coeffs2 = torch.tensor([-0.05, 0.17], requires_grad=True)
+        param2 = torch.tensor(1.7, requires_grad=True)
+
+        half1 = qml.QNode(circuit1, dev, interface="torch")
+        half2 = qml.QNode(circuit2, dev, interface="torch")
+
+        def combine(coeffs, param):
+            return coeffs[0] * half1(param) + coeffs[1] * half2(param)
+
+        res_expected = combine(coeffs2, param2)
+        res_expected.backward()
+        grad_expected = (coeffs2.grad, param2.grad)
+
+        assert np.allclose(grad[0], grad_expected[0])
+        assert np.allclose(grad[1], grad_expected[1])
+
+    @pytest.mark.parametrize("simplify", [True, False])
+    def test_vqe_differentiation_tf(self, simplify):
+        """Test the tf interface by comparing the differentiation of linearly combined subcircuits
+        with the differentiation of a Hamiltonian expectation"""
+
+        tf = pytest.importorskip("tf")
+        coeffs = tf.Variable([-0.05, 0.17], dtype=tf.double)
+        param = tf.Variable(1.7, dtype=tf.double)
+
+        # differentiating a circuit with measurement expval(H)
+        @qml.qnode(dev, interface="tf", diff_method="backprop")
+        def circuit(coeffs, param):
+            qml.RX(param, wires=0)
+            qml.RY(param, wires=0)
+            return qml.expval(
+                qml.Hamiltonian(coeffs, [qml.PauliX(0), qml.PauliZ(0)], simplify=simplify)
+            )
+
+        with tf.GradientTape() as tape:
+            res = circuit(coeffs, param)
+        grad = tape.gradient(res, [coeffs, param])
+
+        # differentiating a cost that combines circuits with
+        # measurements expval(Pauli)
+
+        # we need to create new tensors here
+        coeffs2 = tf.Variable([-0.05, 0.17], dtype=tf.double)
+        param2 = tf.Variable(1.7, dtype=tf.double)
+        half1 = qml.QNode(circuit1, dev, interface="tf", diff_method="backprop")
+        half2 = qml.QNode(circuit2, dev, interface="tf", diff_method="backprop")
+
+        def combine(coeffs, param):
+            return coeffs[0] * half1(param) + coeffs[1] * half2(param)
+
+        with tf.GradientTape() as tape2:
+            res_expected = combine(coeffs2, param2)
+        grad_expected = tape2.gradient(res_expected, [coeffs2, param2])
+
+        assert np.allclose(grad[0], grad_expected[0])
+        assert np.allclose(grad[1], grad_expected[1])

--- a/tests/tape/test_tape.py
+++ b/tests/tape/test_tape.py
@@ -401,25 +401,18 @@ class TestResourceEstimation:
         """Test that empty tapes return empty resource counts."""
         tape = make_empty_tape
 
-        with pytest.warns(UserWarning, match=r"``tape.get_resources``is now deprecated"):
-            info = tape.get_resources()
-        assert len(info) == 0
-
-        with pytest.warns(UserWarning, match=r"``tape.get_depth`` is now deprecated"):
-            depth = tape.get_depth()
-        assert depth == 0
+        assert len(tape.specs["gate_types"]) == 0
+        assert tape.specs["depth"] == 0
 
     def test_resources_tape(self, make_tape):
         """Test that regular tapes return correct number of resources."""
         tape = make_tape
 
-        with pytest.warns(UserWarning, match=r"``tape.get_depth`` is now deprecated"):
-            depth = tape.get_depth()
+        depth = tape.specs["depth"]
         assert depth == 3
 
         # Verify resource counts
-        with pytest.warns(UserWarning, match=r"``tape.get_resources``is now deprecated"):
-            resources = tape.get_resources()
+        resources = tape.specs["gate_types"]
         assert len(resources) == 3
         assert resources["RX"] == 2
         assert resources["Rot"] == 1
@@ -429,12 +422,10 @@ class TestResourceEstimation:
         """Test that tapes return correct number of resources after adding to them."""
         tape = make_extendible_tape
 
-        with pytest.warns(UserWarning, match=r"``tape.get_depth`` is now deprecated"):
-            depth = tape.get_depth()
+        depth = tape.specs["depth"]
         assert depth == 3
 
-        with pytest.warns(UserWarning, match=r"``tape.get_resources``is now deprecated"):
-            resources = tape.get_resources()
+        resources = tape.specs["gate_types"]
         assert len(resources) == 3
         assert resources["RX"] == 2
         assert resources["Rot"] == 1
@@ -446,11 +437,9 @@ class TestResourceEstimation:
             qml.expval(qml.PauliX(wires="a"))
             qml.probs(wires=[0, "a"])
 
-        with pytest.warns(UserWarning, match=r"``tape.get_depth`` is now deprecated"):
-            assert tape.get_depth() == 4
+        assert tape.specs["depth"] == 4
 
-        with pytest.warns(UserWarning, match=r"``tape.get_resources``is now deprecated"):
-            resources = tape.get_resources()
+        resources = tape.specs["gate_types"]
         assert len(resources) == 4
         assert resources["RX"] == 2
         assert resources["Rot"] == 1

--- a/tests/tape/test_tape.py
+++ b/tests/tape/test_tape.py
@@ -251,21 +251,6 @@ class TestConstruction:
                 qml.RX(0.5, wires=0)
                 qml.expval(qml.PauliZ(wires=1))
 
-    def test_observable_with_no_measurement(self):
-        """Test that an exception is raised if an observable is used without a measurement"""
-
-        with pytest.raises(ValueError, match="does not have a measurement type specified"):
-            with QuantumTape() as tape:
-                qml.RX(0.5, wires=0)
-                qml.Hermitian(np.array([[0, 1], [1, 0]]), wires=1)
-                qml.expval(qml.PauliZ(wires=1))
-
-        with pytest.raises(ValueError, match="does not have a measurement type specified"):
-            with QuantumTape() as tape:
-                qml.RX(0.5, wires=0)
-                qml.PauliX(wires=0) @ qml.PauliY(wires=1)
-                qml.expval(qml.PauliZ(wires=1))
-
     def test_sampling(self):
         """Test that the tape correctly marks itself as returning samples"""
         with QuantumTape() as tape:

--- a/tests/templates/test_state_preparations/test_mottonen_state_prep.py
+++ b/tests/templates/test_state_preparations/test_mottonen_state_prep.py
@@ -252,7 +252,7 @@ class TestDecomposition:
         # when the RZ cascade is skipped, CNOT gates should only be those required for RY cascade
         circuit(state_vector)
 
-        assert circuit.qtape.get_resources()["CNOT"] == n_CNOT
+        assert circuit.qtape.specs["gate_types"]["CNOT"] == n_CNOT
 
     def test_custom_wire_labels(self, tol):
         """Test that template can deal with non-numeric, nonconsecutive wire labels."""

--- a/tests/test_measure.py
+++ b/tests/test_measure.py
@@ -273,7 +273,7 @@ class TestSample:
 
     def test_providing_no_observable_and_no_wires(self):
         """Test that we can provide no observable and no wires to sample function"""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit", wires=2, shots=1000)
 
         @qml.qnode(dev)
         def circuit():
@@ -289,7 +289,7 @@ class TestSample:
         """Test that we can provide no observable but specify wires to the sample function"""
         wires = [0, 2]
         wires_obj = qml.wires.Wires(wires)
-        dev = qml.device("default.qubit", wires=3)
+        dev = qml.device("default.qubit", wires=3, shots=1000)
 
         @qml.qnode(dev)
         def circuit():

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -908,6 +908,70 @@ class TestTensor:
         assert type(O_pruned) == type(expected)
         assert O_pruned.wires == expected.wires
 
+    def test_prune_while_queueing_return_tensor(self):
+        """Tests that pruning a tensor to a tensor in a tape context registers
+        the pruned tensor as owned by the measurement,
+        and turns the original tensor into an orphan without an owner."""
+
+        with qml.tape.QuantumTape() as tape:
+            # we assign operations to variables here so we can compare them below
+            a = qml.PauliX(wires=0)
+            b = qml.PauliY(wires=1)
+            c = qml.Identity(wires=2)
+            T = qml.operation.Tensor(a, b, c)
+            T_pruned = T.prune()
+            m = qml.expval(T_pruned)
+
+        ann_queue = tape._queue
+
+        # the pruned tensor became the owner of Paulis
+        assert ann_queue[a]["owner"] == T_pruned
+        assert ann_queue[b]["owner"] == T_pruned
+
+        # the Identity is still owned by the original Tensor
+        assert ann_queue[c]["owner"] == T
+        # the original tensor still owns all three observables
+        # but is not owned by a measurement
+        assert ann_queue[T]["owns"] == (a, b, c)
+        assert not hasattr(ann_queue[T], "owner")
+
+        # the pruned tensor is owned by the measurement
+        # and owns the two Paulis
+        assert ann_queue[T_pruned]["owner"] == m
+        assert ann_queue[T_pruned]["owns"] == (a, b)
+        assert ann_queue[m]["owns"] == T_pruned
+
+    def test_prune_while_queueing_return_obs(self):
+        """Tests that pruning a tensor to an observable in a tape context registers
+        the pruned observable as owned by the measurement,
+        and turns the original tensor into an orphan without an owner."""
+
+        with qml.tape.QuantumTape() as tape:
+            a = qml.PauliX(wires=0)
+            c = qml.Identity(wires=2)
+            T = qml.operation.Tensor(a, c)
+            T_pruned = T.prune()
+            m = qml.expval(T_pruned)
+
+        ann_queue = tape._queue
+
+        # the pruned tensor is the Pauli observable
+        assert T_pruned == a
+        # pruned tensor/Pauli is owned by the measurement
+        # since the entry in the dictionary got updated
+        # when the pruned tensor's owner was memorized
+        assert ann_queue[a]["owner"] == m
+        # the Identity is still owned by the original Tensor
+        assert ann_queue[c]["owner"] == T
+
+        # the original tensor still owns both observables
+        # but is not owned by a measurement
+        assert ann_queue[T]["owns"] == (a, c)
+        assert not hasattr(ann_queue[T], "owner")
+
+        # the measurement owns the Pauli/pruned tensor
+        assert ann_queue[m]["owns"] == T_pruned
+
 
 equal_obs = [
     (qml.PauliZ(0), qml.PauliZ(0), True),

--- a/tests/test_qaoa.py
+++ b/tests/test_qaoa.py
@@ -54,7 +54,7 @@ for k, v in complete_edge_weight_data.items():
 
 def decompose_hamiltonian(hamiltonian):
 
-    coeffs = hamiltonian.coeffs
+    coeffs = list(qml.math.toarray(hamiltonian.coeffs))
     ops = [i.name for i in hamiltonian.ops]
     wires = [i.wires for i in hamiltonian.ops]
 
@@ -623,7 +623,7 @@ MWC = list(zip(DIGRAPHS, MWC_CONSTRAINED, COST_HAMILTONIANS, MIXER_HAMILTONIANS,
 
 def decompose_hamiltonian(hamiltonian):
 
-    coeffs = hamiltonian.coeffs
+    coeffs = list(qml.math.toarray(hamiltonian.coeffs))
     ops = [i.name for i in hamiltonian.ops]
     wires = [i.wires for i in hamiltonian.ops]
 
@@ -1114,7 +1114,7 @@ class TestCycles:
         ]
         expected_coeffs = [np.log(0.5), np.log(1), np.log(1.5), np.log(2), np.log(2.5), np.log(3)]
 
-        assert expected_coeffs == h.coeffs
+        assert np.allclose(expected_coeffs, h.coeffs)
         assert all([op.wires == exp.wires for op, exp in zip(h.ops, expected_ops)])
         assert all([type(op) is type(exp) for op, exp in zip(h.ops, expected_ops)])
 
@@ -1160,7 +1160,7 @@ class TestCycles:
             np.log(7),
         ]
 
-        assert expected_coeffs == h.coeffs
+        assert np.allclose(expected_coeffs, h.coeffs)
         assert all([op.wires == exp.wires for op, exp in zip(h.ops, expected_ops)])
         assert all([type(op) is type(exp) for op, exp in zip(h.ops, expected_ops)])
 
@@ -1252,7 +1252,7 @@ class TestCycles:
 
         expected_coeffs = [2, 2, -2, -2]
 
-        assert expected_coeffs == h.coeffs
+        assert np.allclose(expected_coeffs, h.coeffs)
         for i, expected_op in enumerate(expected_ops):
             assert str(h.ops[i]) == str(expected_op)
         assert all([op.wires == exp.wires for op, exp in zip(h.ops, expected_ops)])
@@ -1274,7 +1274,7 @@ class TestCycles:
         ]
         expected_coeffs = [4, 2, -2, -2, -2, -2, 2]
 
-        assert expected_coeffs == h.coeffs
+        assert np.allclose(expected_coeffs, h.coeffs)
         for i, expected_op in enumerate(expected_ops):
             assert str(h.ops[i]) == str(expected_op)
         assert all([op.wires == exp.wires for op, exp in zip(h.ops, expected_ops)])
@@ -1290,7 +1290,7 @@ class TestCycles:
         expected_ops = [qml.PauliZ(wires=[0])]
         expected_coeffs = [0]
 
-        assert expected_coeffs == h.coeffs
+        assert np.allclose(expected_coeffs, h.coeffs)
         for i, expected_op in enumerate(expected_ops):
             assert str(h.ops[i]) == str(expected_op)
         assert all([op.wires == exp.wires for op, exp in zip(h.ops, expected_ops)])
@@ -1313,7 +1313,7 @@ class TestCycles:
         ]
         expected_coeffs = [4, -2, -2, 2, 2, -2, -2]
 
-        assert expected_coeffs == h.coeffs
+        assert np.allclose(expected_coeffs, h.coeffs)
         for i, expected_op in enumerate(expected_ops):
             assert str(h.ops[i]) == str(expected_op)
         assert all([op.wires == exp.wires for op, exp in zip(h.ops, expected_ops)])

--- a/tests/test_qubit_device.py
+++ b/tests/test_qubit_device.py
@@ -413,8 +413,9 @@ class TestSampleBasisStates:
         dev.shots = None
         state_probs = [0.1, 0.2, 0.3, 0.4]
 
-        with pytest.warns(
-            UserWarning, match="The number of shots has to be explicitly set on the device"
+        with pytest.raises(
+            qml.QuantumFunctionError,
+            match="The number of shots has to be explicitly set on the device",
         ):
             dev.sample_basis_states(number_of_states, state_probs)
 

--- a/tests/test_vqe.py
+++ b/tests/test_vqe.py
@@ -707,6 +707,23 @@ class TestHamiltonian:
         old_H.simplify()
         assert old_H.compare(new_H)
 
+    def test_simplify_while_queueing(self):
+        """Tests that simplifying a Hamiltonian in a tape context
+        queues the simplified Hamiltonian."""
+
+        with qml.tape.QuantumTape() as tape:
+            a = qml.PauliX(wires=0)
+            b = qml.PauliY(wires=1)
+            c = qml.Identity(wires=2)
+            d = b @ c
+            H = qml.Hamiltonian([1.0, 2.0], [a, d])
+            H.simplify()
+
+        # check that H is simplified
+        assert H.ops == [a, b]
+        # check that the simplified Hamiltonian is in the queue
+        assert H in tape._queue
+
     def test_data(self):
         """Tests the obs_data method"""
 

--- a/tests/transforms/test_adjoint.py
+++ b/tests/transforms/test_adjoint.py
@@ -86,6 +86,7 @@ def test_nested_adjoint_on_function():
         my_circuit(), np.array([-0.995707, 0.068644 + 6.209710e-02j]), atol=1e-6, rtol=1e-6
     )
 
+
 class TestOutsideOfQueuing:
     """Test that operations and templates work with the adjoint transform when
     created outside of a queuing context"""
@@ -114,17 +115,17 @@ class TestOutsideOfQueuing:
         assert rx_adjoint.wires == expected.wires
 
     template_ops = [
-            (qml.templates.AngleEmbedding, [np.ones((1))], [2,3]),
-            (qml.templates.StronglyEntanglingLayers, [np.ones((1,2,3))], [2,3]),
-            (qml.templates.Interferometer, [[1], [0.3], [0.2, 0.3]], [2,3])
-            ]
+        (qml.templates.AngleEmbedding, [np.ones((1))], [2, 3]),
+        (qml.templates.StronglyEntanglingLayers, [np.ones((1, 2, 3))], [2, 3]),
+        (qml.templates.Interferometer, [[1], [0.3], [0.2, 0.3]], [2, 3]),
+    ]
 
     @pytest.mark.parametrize("template, par, wires", template_ops)
     def test_templates_adjoint(self, template, par, wires):
         """Test that the adjoint correctly inverts angle embedding"""
         res = qml.adjoint(template)(*par, wires=wires)
-        result = res if hasattr(res, "__iter__") else [res] # handle single operation case
-        expected_ops= template(*par, wires=wires)
+        result = res if hasattr(res, "__iter__") else [res]  # handle single operation case
+        expected_ops = template(*par, wires=wires)
 
         if hasattr(expected_ops, "expand"):
             expected_ops = expected_ops.expand().operations
@@ -134,6 +135,7 @@ class TestOutsideOfQueuing:
             assert type(o1) == type(o2)
             assert o1.parameters == o2.parameters
             assert o1.wires == o2.wires
+
 
 test_functions = [
     lambda fn, *args, **kwargs: adjoint(fn)(*args, **kwargs),

--- a/tests/transforms/test_adjoint.py
+++ b/tests/transforms/test_adjoint.py
@@ -86,6 +86,54 @@ def test_nested_adjoint_on_function():
         my_circuit(), np.array([-0.995707, 0.068644 + 6.209710e-02j]), atol=1e-6, rtol=1e-6
     )
 
+class TestOutsideOfQueuing:
+    """Test that operations and templates work with the adjoint transform when
+    created outside of a queuing context"""
+
+    non_param_ops = [(qml.S, 0), (qml.PauliZ, 3), (qml.CNOT, [32, 3])]
+
+    @pytest.mark.parametrize("op,wires", non_param_ops)
+    def test_single_op_non_param_adjoint(self, op, wires):
+        """Test that the adjoint correctly inverts angle embedding"""
+        rx_adjoint = qml.adjoint(op)(wires=wires)
+        expected = op(wires=wires).adjoint()
+
+        assert type(rx_adjoint) == type(expected)
+        assert rx_adjoint.wires == expected.wires
+
+    param_ops = [(qml.RX, [0.123], 0), (qml.Rot, [0.1, 0.2, 0.3], [1]), (qml.CRY, [0.1], [1, 4])]
+
+    @pytest.mark.parametrize("op,par,wires", param_ops)
+    def test_single_op_param_adjoint(self, op, par, wires):
+        """Test that the adjoint correctly inverts angle embedding"""
+        rx_adjoint = qml.adjoint(op)(*par, wires=wires)
+        expected = op(*par, wires=wires).adjoint()
+
+        assert type(rx_adjoint) == type(expected)
+        assert rx_adjoint.parameters == expected.parameters
+        assert rx_adjoint.wires == expected.wires
+
+    template_ops = [
+            (qml.templates.AngleEmbedding, [np.ones((1))], [2,3]),
+            (qml.templates.StronglyEntanglingLayers, [np.ones((1,2,3))], [2,3]),
+            (qml.templates.Interferometer, [[1], [0.3], [0.2, 0.3]], [2,3])
+            ]
+
+    @pytest.mark.parametrize("template, par, wires", template_ops)
+    def test_templates_adjoint(self, template, par, wires):
+        """Test that the adjoint correctly inverts angle embedding"""
+        res = qml.adjoint(template)(*par, wires=wires)
+        result = res if hasattr(res, "__iter__") else [res] # handle single operation case
+        expected_ops= template(*par, wires=wires)
+
+        if hasattr(expected_ops, "expand"):
+            expected_ops = expected_ops.expand().operations
+
+        for o1, o2 in zip(result, reversed(expected_ops)):
+            o2 = o2.adjoint()
+            assert type(o1) == type(o2)
+            assert o1.parameters == o2.parameters
+            assert o1.wires == o2.wires
 
 test_functions = [
     lambda fn, *args, **kwargs: adjoint(fn)(*args, **kwargs),

--- a/tests/transforms/test_hamiltonian_expand.py
+++ b/tests/transforms/test_hamiltonian_expand.py
@@ -34,7 +34,6 @@ with pennylane.tape.QuantumTape() as tape2:
     qml.Hadamard(1)
     qml.PauliZ(1)
     qml.PauliX(2)
-
     H2 = qml.Hamiltonian(
         [1, 3, -2, 1, 1],
         [
@@ -130,7 +129,18 @@ class TestHamiltonianExpval:
         H = qml.Hamiltonian(
             [-0.2, 0.5, 1], [qml.PauliX(1), qml.PauliZ(1) @ qml.PauliY(2), qml.PauliZ(0)]
         )
-        var = np.array([0.1, 0.67, 0.3, 0.4, -0.5, 0.7])
+
+        var = [
+            np.array(0.1),
+            np.array(0.67),
+            np.array(0.3),
+            np.array(0.4),
+            np.array(-0.5),
+            np.array(0.7),
+            np.array(0.4),
+            np.array(-0.5),
+            np.array(0.7),
+        ]
         output = 0.42294409781940356
         output2 = [
             9.68883500e-02,
@@ -139,6 +149,9 @@ class TestHamiltonianExpval:
             -1.94289029e-09,
             3.50307411e-01,
             -3.41123470e-01,
+            0.0,  # these three are the Hamiltonian parameters
+            0.0,
+            0.0,
         ]
 
         with qml.tape.JacobianTape() as tape:
@@ -161,7 +174,9 @@ class TestHamiltonianExpval:
             return fn(res)
 
         assert np.isclose(cost(var), output)
-        assert np.allclose(qml.grad(cost)(var), output2)
+        grad = qml.grad(cost)(var)
+        for g, o in zip(grad, output2):
+            assert np.allclose(g, o)
 
     def test_hamiltonian_dif_tensorflow(self):
         """Tests that the hamiltonian_expand tape transform is differentiable with the Tensorflow interface"""


### PR DESCRIPTION
**Context:**

The logic for the `qml.adjoint` top-level function was created by assuming that a queuing context (e.g., a QNode, tape, etc.) is active. The logic includes stopping the recoding of that queuing context such that the operations passed to `qml.adjoint` can be recorded by a temporary tape. This temporary tape is then used for creating the adjoint of the operation/list of operations.

When we have no active queuing context recording, the stopping logic raises an error (see #1457).

**Description of the Change:**

Changes the logic of `qml.adjoint` to work when we're not within a queuing context. Further changes the `adjoint` method of the `ControlledOperation` class used for `qml.ctrl`.

**Benefits:**

The `qml.adjoint` transform works for operations and templates outside of queuing contexts too. Further to that, any operation/template transformed by `qml.ctrl` have their `adjoint` method working well too outside of queuing contexts.

**Possible Drawbacks:**

N/A

**Related GitHub Issues:**
#1457