### PR TITLE
Update changelog entry for #1388

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1023,9 +1023,6 @@ Maria Schuld, Jay Soni, Antal Száva, David Wierichs.
   3.999999999999999
   ```
 
-* QNodes now display readable information when in interactive environments or when printed.
-  [(#1359)](https://github.com/PennyLaneAI/pennylane/pull/1359).
-
 * The `quantum_monte_carlo` transform has been added, allowing an input circuit to be transformed
   into the full quantum Monte Carlo algorithm.
   [(#1316)](https://github.com/PennyLaneAI/pennylane/pull/1316)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 <h3>New features since last release</h3>
 
+* The `frobenius_inner_product` function has been moved to the `qml.math`
+  module, and is now differentiable using all autodiff frameworks.
+  [(#1388)](https://github.com/PennyLaneAI/pennylane/pull/1388)
+
 * Vector-Jacobian product transforms have been added to the `qml.gradients` package.
   [(#1494)](https://github.com/PennyLaneAI/pennylane/pull/1494)
 
@@ -127,7 +131,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-Josh Izaac, Maria Schuld.
+Josh Izaac, Johannes Jakob Meyer, Maria Schuld.
 
 # Release 0.17.0 (current release)
 
@@ -809,7 +813,6 @@ Maria Schuld, Jay Soni, Antal Száva, David Wierichs.
   K_test = qml.kernels.kernel_matrix(X_train, X_test, kernel)
   K1 = qml.kernels.mitigate_depolarizing_noise(K, num_wires, method='single')
   ```
-  [(#1388)](https://github.com/PennyLaneAI/pennylane/pull/1388)
 
 <h4>Extract the fourier representation of quantum circuits</h4>
 


### PR DESCRIPTION
**Context:** The changelog entry for PR #1388 needed to be updated post-merge, due to the merge crossing a release.

**Description of the Change:** Moves the changelog entry.

**Benefits:** New changelog entry accurately reflects placement of the new feature.

**Possible Drawbacks:** n/a

**Related GitHub Issues:** n/a
