### PR TITLE
Reduce cases ignored by coveragerc 

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -11,13 +11,10 @@ exclude_lines =
     pragma: no cover
 
     # Don't complain about debug-only or logging code:
-    def __repr__
-    def __eq__
     if self\.debug
     if "LOGGING" in os.environ
 
     # print statements
-    def __str__
     def __format__
     def _print_list
 
@@ -27,7 +24,6 @@ exclude_lines =
     if __name__ == .__main__.:
 
     # Ignore things that would have trivial tests
-    raise NotImplementedError
     def version
 
 


### PR DESCRIPTION
Apparently, `.coveragerc` is an old file in PennyLane that excludes statements from codecoverage reports. However the CI ignores this file, and it is possible that some issues with claims that `NotImplementedErrors` or `__str__()` and `__repr__()` code pieces being untested stem from this file.