### PR TITLE
Replace pass with continue

### DIFF
--- a/pennylane/tape/tape.py
+++ b/pennylane/tape/tape.py
@@ -982,7 +982,7 @@ class QuantumTape(AnnotatedQueue):
                 # in which case we just don't append any
                 rotation_gates.extend(observable.diagonalizing_gates())
             except NotImplementedError:
-                pass
+                continue
 
         return rotation_gates
 


### PR DESCRIPTION
It seems that coverage has a strange interference with the use of `pass` (for example when ignoring a `NotImplementedError`). I only found the one occurrence that I just merged.