### PR TITLE
Remove `pass` from .coveragerc

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -20,7 +20,6 @@ exclude_lines =
 
     # Don't complain if non-runnable code isn't run:
     if 0:
-    pass
     if __name__ == .__main__.:
 
     # Ignore things that would have trivial tests


### PR DESCRIPTION
Note: the changelog has not been updated since this is CI related.