### PR TITLE
Update tape's to_openqasm method

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -84,6 +84,11 @@
 
 <h3>Improvements</h3>
 
+* The `tape.to_openqasm()` method now has a `measure_all` argument that specifies whether the
+  serialized OpenQASM script includes computational basis measurements on all of the qubits or
+  just those specified by the tape.
+  [(#1483)](https://github.com/PennyLaneAI/pennylane/pull/1483)
+
 * An error is raised when no arguments are passed to a `qml.operation.Observable` to inform the user about specifying wires.
   [(#1547)](https://github.com/PennyLaneAI/pennylane/pull/1547)
 
@@ -145,7 +150,7 @@ and requirements-ci.txt (unpinned). This latter would be used by the CI.
 
 This release contains contributions from (in alphabetical order):
 
-Josh Izaac, Prateek Jain, Johannes Jakob Meyer, Maria Schuld, Ingrid Strandberg.
+Thomas Bromley, Josh Izaac, Prateek Jain, Johannes Jakob Meyer, Maria Schuld, Ingrid Strandberg.
 
 # Release 0.17.0 (current release)
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -87,7 +87,7 @@
 * The `tape.to_openqasm()` method now has a `measure_all` argument that specifies whether the
   serialized OpenQASM script includes computational basis measurements on all of the qubits or
   just those specified by the tape.
-  [(#1483)](https://github.com/PennyLaneAI/pennylane/pull/1483)
+  [(#1559)](https://github.com/PennyLaneAI/pennylane/pull/1559)
 
 * An error is raised when no arguments are passed to a `qml.operation.Observable` to inform the user about specifying wires.
   [(#1547)](https://github.com/PennyLaneAI/pennylane/pull/1547)

--- a/pennylane/tape/tape.py
+++ b/pennylane/tape/tape.py
@@ -1098,11 +1098,13 @@ class QuantumTape(AnnotatedQueue):
             show_all_wires=show_all_wires,
         )
 
-    def to_openqasm(self, wires=None, rotations=True):
+    def to_openqasm(self, wires=None, rotations=True, include_measurements=True):
         """Serialize the circuit as an OpenQASM 2.0 program.
 
-        Only operations are serialized; all measurements
-        are assumed to take place in the computational basis.
+        Measurements are assumed to be performed in the computational basis. An optional
+        ``rotations`` argument can be provided so that output of the OpenQASM circuit is diagonal
+        in the eigenbasis of the tape's observables. The computational basis measurements can be
+        turned off by setting ``include_measurements=False``.
 
         .. note::
 
@@ -1114,6 +1116,8 @@ class QuantumTape(AnnotatedQueue):
             rotations (bool): in addition to serializing user-specified
                 operations, also include the gates that diagonalize the
                 measured wires such that they are in the eigenbasis of the circuit observables.
+            include_measurements (bool): whether to include computational basis measurements on all
+                of the qubits
 
         Returns:
             str: OpenQASM serialization of the circuit
@@ -1175,8 +1179,9 @@ class QuantumTape(AnnotatedQueue):
         # and then only measure wires which are requested by the user. However,
         # some devices which consume QASM require all registers be measured, so
         # measure all wires to be safe.
-        for wire in range(len(wires)):
-            qasm_str += "measure q[{wire}] -> c[{wire}];\n".format(wire=wire)
+        if include_measurements:
+            for wire in range(len(wires)):
+                qasm_str += "measure q[{wire}] -> c[{wire}];\n".format(wire=wire)
 
         return qasm_str
 

--- a/pennylane/tape/tape.py
+++ b/pennylane/tape/tape.py
@@ -1181,13 +1181,13 @@ class QuantumTape(AnnotatedQueue):
         # measure all wires by default to be safe.
         if measure_all:
             for wire in range(len(wires)):
-                qasm_str += "measure q[{wire}] -> c[{wire}];\n".format(wire=wire)
+                qasm_str += f"measure q[{wire}] -> c[{wire}];\n"
         else:
             measured_wires = qml.wires.Wires.all_wires([m.wires for m in self.measurements])
 
             for w in measured_wires:
                 wire_indx = self.wires.index(w)
-                qasm_str += "measure q[{wire}] -> c[{wire}];\n".format(wire=wire_indx)
+                qasm_str += f"measure q[{wire_indx}] -> c[{wire_indx}];\n"
 
         return qasm_str
 

--- a/pennylane/tape/tape.py
+++ b/pennylane/tape/tape.py
@@ -1103,7 +1103,7 @@ class QuantumTape(AnnotatedQueue):
 
         Measurements are assumed to be performed on all qubits in the computational basis. An
         optional ``rotations`` argument can be provided so that output of the OpenQASM circuit is
-        diagonal in the eigenbasis of the tape's observables. The measurements outputs can be
+        diagonal in the eigenbasis of the tape's observables. The measurement outputs can be
         restricted to only those specified in the tape by setting ``measure_all=False``.
 
         .. note::

--- a/pennylane/tape/tape.py
+++ b/pennylane/tape/tape.py
@@ -1178,7 +1178,7 @@ class QuantumTape(AnnotatedQueue):
         # NOTE: This is not strictly necessary, we could inspect self.observables,
         # and then only measure wires which are requested by the user. However,
         # some devices which consume QASM require all registers be measured, so
-        # measure all wires to be safe.
+        # measure all wires by default to be safe.
         if include_measurements:
             for wire in range(len(wires)):
                 qasm_str += "measure q[{wire}] -> c[{wire}];\n".format(wire=wire)

--- a/tests/circuit_graph/test_qasm.py
+++ b/tests/circuit_graph/test_qasm.py
@@ -276,7 +276,7 @@ class TestToQasmUnitTests:
 
     def test_only_tape_measurements(self):
         """Test that no computational basis measurements are added other
-        than those already in the tape when ``include_measurements=False``."""
+        than those already in the tape when ``measure_all=False``."""
         with qml.tape.QuantumTape() as circuit:
             qml.RX(0.43, wires="a")
             qml.RY(0.35, wires="b")

--- a/tests/circuit_graph/test_qasm.py
+++ b/tests/circuit_graph/test_qasm.py
@@ -274,6 +274,38 @@ class TestToQasmUnitTests:
 
         assert res == qasm2
 
+    def test_no_measurements(self):
+        """Test that no computational basis measurements are added when
+        ``include_measurements=False``."""
+        with qml.tape.QuantumTape() as circuit:
+            qml.RX(0.43, wires=0)
+            qml.RY(0.35, wires=1)
+            qml.RZ(0.35, wires=2)
+            qml.CNOT(wires=[0, 1])
+            qml.Hadamard(wires=2)
+            qml.CNOT(wires=[2, 0])
+            qml.PauliX(wires=1)
+
+        res = circuit.to_openqasm(include_measurements=False)
+
+        expected = dedent(
+            """\
+            OPENQASM 2.0;
+            include "qelib1.inc";
+            qreg q[3];
+            creg c[3];
+            rx(0.43) q[0];
+            ry(0.35) q[1];
+            rz(0.35) q[2];
+            cx q[0],q[1];
+            h q[2];
+            cx q[2],q[0];
+            x q[1];
+            """
+        )
+
+        assert res == expected
+
 
 class TestQNodeQasmIntegrationTests:
     """Test that the QASM serialization works correctly

--- a/tests/circuit_graph/test_qasm.py
+++ b/tests/circuit_graph/test_qasm.py
@@ -278,15 +278,17 @@ class TestToQasmUnitTests:
         """Test that no computational basis measurements are added when
         ``include_measurements=False``."""
         with qml.tape.QuantumTape() as circuit:
-            qml.RX(0.43, wires=0)
-            qml.RY(0.35, wires=1)
+            qml.RX(0.43, wires="a")
+            qml.RY(0.35, wires="b")
             qml.RZ(0.35, wires=2)
-            qml.CNOT(wires=[0, 1])
+            qml.CNOT(wires=["a", "b"])
             qml.Hadamard(wires=2)
-            qml.CNOT(wires=[2, 0])
-            qml.PauliX(wires=1)
+            qml.CNOT(wires=[2, "a"])
+            qml.PauliX(wires="b")
+            qml.expval(qml.PauliZ("a"))
+            qml.expval(qml.PauliZ(2))
 
-        res = circuit.to_openqasm(include_measurements=False)
+        res = circuit.to_openqasm(measure_all=False)
 
         expected = dedent(
             """\
@@ -301,6 +303,8 @@ class TestToQasmUnitTests:
             h q[2];
             cx q[2],q[0];
             x q[1];
+            measure q[0] -> c[0];
+            measure q[2] -> c[2];
             """
         )
 

--- a/tests/circuit_graph/test_qasm.py
+++ b/tests/circuit_graph/test_qasm.py
@@ -274,9 +274,9 @@ class TestToQasmUnitTests:
 
         assert res == qasm2
 
-    def test_no_measurements(self):
-        """Test that no computational basis measurements are added when
-        ``include_measurements=False``."""
+    def test_only_tape_measurements(self):
+        """Test that no computational basis measurements are added other
+        than those already in the tape when ``include_measurements=False``."""
         with qml.tape.QuantumTape() as circuit:
             qml.RX(0.43, wires="a")
             qml.RY(0.35, wires="b")


### PR DESCRIPTION
The `tape.to_openqasm()` method now has a `measure_all` argument that specifies whether the serialized OpenQASM script includes computational basis measurements on all of the qubits or just those specified by the tape.

```python
import pennylane as qml
from scipy.stats import ortho_group

with qml.tape.QuantumTape() as tape:
    qml.RX(0.2, wires=0)
    qml.RY(0.6, wires=1)
    qml.CNOT(wires=[0, 1])
    qml.expval(qml.PauliZ(0))
```
With `measure_all=True` (current, and default in this PR):
```pycon
>>> print(tape.to_openqasm(measure_all=True))
OPENQASM 2.0;
include "qelib1.inc";
qreg q[2];
creg c[2];
rx(0.2) q[0];
ry(0.6) q[1];
cx q[0],q[1];
measure q[0] -> c[0];
measure q[1] -> c[1];
```
New option:
```pycon
>>> print(tape.to_openqasm(measure_all=False))
OPENQASM 2.0;
include "qelib1.inc";
qreg q[2];
creg c[2];
rx(0.2) q[0];
ry(0.6) q[1];
cx q[0],q[1];
measure q[0] -> c[0];
```

This addressed the comment [here](https://github.com/PennyLaneAI/pennylane/issues/1500#issuecomment-893763852).