### PR TITLE
Changed the location of the identity observable in the documentation

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -175,11 +175,14 @@ and requirements-ci.txt (unpinned). This latter would be used by the CI.
 
 <h3>Documentation</h3>
 
+* The `qml.Identity` operation is placed under the sections Qubit observables and CV observables.
+  [(#1576)](https://github.com/PennyLaneAI/pennylane/pull/1576)
+
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):
 
-Thomas Bromley, Tanya Garg, Josh Izaac, Prateek Jain, Johannes Jakob Meyer, Akash Narayanan, Maria Schuld,
+Akash Narayanan B, Thomas Bromley, Tanya Garg, Josh Izaac, Prateek Jain, Johannes Jakob Meyer, Maria Schuld,
 Ingrid Strandberg, Vincent Wong.
 
 # Release 0.17.0 (current release)

--- a/doc/introduction/operations.rst
+++ b/doc/introduction/operations.rst
@@ -153,6 +153,7 @@ Qubit observables
 
     ~pennylane.Hadamard
     ~pennylane.Hermitian
+    ~pennylane.Identity
     ~pennylane.PauliX
     ~pennylane.PauliY
     ~pennylane.PauliZ
@@ -247,25 +248,12 @@ CV observables
     :nosignatures:
 
     ~pennylane.FockStateProjector
+    ~pennylane.Identity
     ~pennylane.NumberOperator
     ~pennylane.TensorN
     ~pennylane.P
     ~pennylane.PolyXP
     ~pennylane.QuadOperator
     ~pennylane.X
-
-:html:`</div>`
-
-Shared operations
------------------
-
-The only operation shared by both qubit and continouous-variable architectures is the Identity.
-
-:html:`<div class="summary-table">`
-
-.. autosummary::
-    :nosignatures:
-
-    ~pennylane.Identity
 
 :html:`</div>`


### PR DESCRIPTION
**Description of the Change:**
Removed the Shared operations section at the bottom and placed the identity observable under the sections Qubit observables and CV observables. Please check the [rendered page](https://pennylane--1576.org.readthedocs.build/en/1576/introduction/operations.html#qubit-observables).

**Related GitHub Issues:**
#1567