### PR TITLE
[Code Together] Categorizing the qubit gates in the documentation #1566

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -257,12 +257,16 @@ and requirements-ci.txt (unpinned). This latter would be used by the CI.
 * The `qml.Identity` operation is placed under the sections Qubit observables and CV observables.
   [(#1576)](https://github.com/PennyLaneAI/pennylane/pull/1576)
 
+* Recategorized Qubit operations into new and existing categories so that code for each
+operation is easier to locate.
+  [(#1566)](https://github.com/PennyLaneAI/pennylane/pull/1583)
+
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):
 
 
-Akash Narayanan B, Thomas Bromley, Tanya Garg, Josh Izaac, Prateek Jain, Johannes Jakob Meyer, Maria Schuld,
+Akash Narayanan B, Thomas Bromley, Tanya Garg, Josh Izaac, Prateek Jain, Johannes Jakob Meyer, Pratul Saini, Maria Schuld,
 Ingrid Strandberg, David Wierichs, Vincent Wong.
 
 

--- a/doc/introduction/operations.rst
+++ b/doc/introduction/operations.rst
@@ -309,16 +309,3 @@ CV observables
 
 :html:`</div>`
 
-Shared operations
------------------
-
-The only operation shared by both qubit and continouous-variable architectures is the Identity.
-
-:html:`<div class="summary-table">`
-
-.. autosummary::
-    :nosignatures:
-
-    ~pennylane.Identity
-
-:html:`</div>`

--- a/doc/introduction/operations.rst
+++ b/doc/introduction/operations.rst
@@ -44,8 +44,9 @@ Qubit operations
 
 .. _intro_ref_ops_qgates:
 
-Qubit gates
-^^^^^^^^^^^
+Non-parametric Ops
+^^^^^^^^^^^^^^^^^^ 
+
 
 :html:`<div class="summary-table">`
 
@@ -59,6 +60,27 @@ Qubit gates
     ~pennylane.S
     ~pennylane.T
     ~pennylane.SX
+    ~pennylane.CNOT
+    ~pennylane.CZ
+    ~pennylane.CY
+    ~pennylane.SWAP
+    ~pennylane.ISWAP
+    ~pennylane.CSWAP
+    ~pennylane.Toffoli
+    ~pennylane.MultiControlledX
+
+:html:`</div>`
+
+
+Parametric Ops
+^^^^^^^^^^^^^^
+
+
+:html:`<div class="summary-table">`
+
+.. autosummary::
+    :nosignatures:
+
     ~pennylane.Rot
     ~pennylane.RX
     ~pennylane.RY
@@ -66,39 +88,68 @@ Qubit gates
     ~pennylane.MultiRZ
     ~pennylane.PauliRot
     ~pennylane.PhaseShift
-    ~pennylane.CPhase
     ~pennylane.ControlledPhaseShift
-    ~pennylane.CNOT
-    ~pennylane.CZ
-    ~pennylane.CY
-    ~pennylane.SWAP
-    ~pennylane.ISWAP
-    ~pennylane.IsingXX
-    ~pennylane.IsingYY
-    ~pennylane.IsingZZ
-    ~pennylane.U1
-    ~pennylane.U2
-    ~pennylane.U3
-    ~pennylane.CRot
+    ~pennylane.CPhase
     ~pennylane.CRX
     ~pennylane.CRY
     ~pennylane.CRZ
-    ~pennylane.Toffoli
-    ~pennylane.CSWAP
-    ~pennylane.QubitUnitary
-    ~pennylane.ControlledQubitUnitary
-    ~pennylane.MultiControlledX
-    ~pennylane.DiagonalQubitUnitary
+    ~pennylane.CRot
+    ~pennylane.U1
+    ~pennylane.U2
+    ~pennylane.U3
+    ~pennylane.IsingXX
+    ~pennylane.IsingYY
+    ~pennylane.IsingZZ
+
+:html:`</div>`
+
+
+Quantum Chemistry Ops
+^^^^^^^^^^^^^^^^^^^^^
+
+
+:html:`<div class="summary-table">`
+
+.. autosummary::
+    :nosignatures:
+
     ~pennylane.SingleExcitation
     ~pennylane.SingleExcitationPlus
     ~pennylane.SingleExcitationMinus
     ~pennylane.DoubleExcitation
     ~pennylane.DoubleExcitationPlus
     ~pennylane.DoubleExcitationMinus
+
+:html:`</div>`
+
+
+Matrix Ops
+^^^^^^^^^^
+
+
+:html:`<div class="summary-table">`
+
+.. autosummary::
+    :nosignatures:
+
+    ~pennylane.QubitUnitary
+    ~pennylane.ControlledQubitUnitary
+    ~pennylane.DiagonalQubitUnitary
+
+:html:`</div>`
+
+
+Arithmetic Ops
+^^^^^^^^^^^^^^
+
+
+:html:`<div class="summary-table">`
+
+.. autosummary::
+    :nosignatures:
+
     ~pennylane.QubitCarry
     ~pennylane.QubitSum
-    ~pennylane.Hamiltonian
-
 
 :html:`</div>`
 
@@ -159,6 +210,7 @@ Qubit observables
     ~pennylane.PauliZ
     ~pennylane.Projector
     ~pennylane.Hamiltonian
+    ~pennylane.SparseHamiltonian
 
 :html:`</div>`
 
@@ -248,12 +300,25 @@ CV observables
     :nosignatures:
 
     ~pennylane.FockStateProjector
-    ~pennylane.Identity
     ~pennylane.NumberOperator
     ~pennylane.TensorN
     ~pennylane.P
     ~pennylane.PolyXP
     ~pennylane.QuadOperator
     ~pennylane.X
+
+:html:`</div>`
+
+Shared operations
+-----------------
+
+The only operation shared by both qubit and continouous-variable architectures is the Identity.
+
+:html:`<div class="summary-table">`
+
+.. autosummary::
+    :nosignatures:
+
+    ~pennylane.Identity
 
 :html:`</div>`

--- a/doc/introduction/operations.rst
+++ b/doc/introduction/operations.rst
@@ -302,6 +302,7 @@ CV observables
     :nosignatures:
 
     ~pennylane.FockStateProjector
+    ~pennylane.Identity
     ~pennylane.NumberOperator
     ~pennylane.TensorN
     ~pennylane.P

--- a/doc/introduction/operations.rst
+++ b/doc/introduction/operations.rst
@@ -65,6 +65,8 @@ Non-parametric Ops
     ~pennylane.CY
     ~pennylane.SWAP
     ~pennylane.ISWAP
+    ~pennylane.SISWAP
+    ~pennylane.SQISW
     ~pennylane.CSWAP
     ~pennylane.Toffoli
     ~pennylane.MultiControlledX

--- a/doc/introduction/operations.rst
+++ b/doc/introduction/operations.rst
@@ -91,24 +91,7 @@ Parametric Ops
     ~pennylane.PauliRot
     ~pennylane.PhaseShift
     ~pennylane.ControlledPhaseShift
-<<<<<<< HEAD
     ~pennylane.CPhase
-=======
-    ~pennylane.CNOT
-    ~pennylane.CZ
-    ~pennylane.CY
-    ~pennylane.SWAP
-    ~pennylane.ISWAP
-    ~pennylane.SISWAP
-    ~pennylane.SQISW
-    ~pennylane.IsingXX
-    ~pennylane.IsingYY
-    ~pennylane.IsingZZ
-    ~pennylane.U1
-    ~pennylane.U2
-    ~pennylane.U3
-    ~pennylane.CRot
->>>>>>> 068439feb3f74f36b0109ed5a3bee9d236314c7f
     ~pennylane.CRX
     ~pennylane.CRY
     ~pennylane.CRZ


### PR DESCRIPTION
**Description of the Change:** The documentation in [pennylane/doc/introduction/operations.rst](https://github.com/PennyLaneAI/pennylane/blob/master/doc/introduction/operations.rst) has been updated to mirror the code in [pennylane/ops/qubit](https://github.com/PennyLaneAI/pennylane/tree/master/pennylane/ops/qubit). Specifically, `Qubit Gates` has been divided into categories that already exist and other new categories.

**Benefits:** The documentation is now more in line with the code and hence operations will be easier to find.

**Related GitHub Issues:** #1566 
