### PR TITLE
Fix broken QChem CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -181,7 +181,6 @@ jobs:
 
       - name: Run tests
         run: |
-          python -c "import h5py; print(h5py.version.info)"
           cd qchem && python -m pytest tests --cov=pennylane_qchem $COVERAGE_FLAGS
 
       - name: Upload coverage to Codecov


### PR DESCRIPTION
We are currently experiencing issues with h5py and the CI check.  This unpins the version to see if we can get the tests to work.