### PR TITLE
relevant tests skip if cvxpy or dask is not installed

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -398,6 +398,8 @@ and requirements-ci.txt (unpinned). This latter would be used by the CI.
 
 <h3>Bug fixes</h3>
 
+* Dask and CVXPY dependent tests are skipped if those packages are not installed.
+
 * The `qml.layer` template now works with tensorflow variables.
 [(#1615)](https://github.com/PennyLaneAI/pennylane/pull/1615)
 

--- a/tests/circuit_graph/test_circuit_graph_hash.py
+++ b/tests/circuit_graph/test_circuit_graph_hash.py
@@ -614,6 +614,7 @@ class TestQNodeCircuitHashDifferentHashIntegration:
 
         assert circuit_hash_1 != circuit_hash_2
 
+    @pytest.mark.usefixtures("skip_if_no_dask_support")
     def test_compiled_program_was_stored(self):
         """Test that QVM device stores the compiled program correctly"""
         dev = qml.device("default.qubit", wires=3)

--- a/tests/collections/test_qnode_collection.py
+++ b/tests/collections/test_qnode_collection.py
@@ -177,7 +177,7 @@ class TestEvalation:
     def test_eval_autograd(self, qnodes, parallel, interface, dask_support):
         """Test correct evaluation of the QNodeCollection using
         the Autograd interface"""
-                
+
         if (not dask_support) and (parallel):
             pytest.skip("Skipped, no dask support")
 

--- a/tests/collections/test_qnode_collection.py
+++ b/tests/collections/test_qnode_collection.py
@@ -174,9 +174,13 @@ class TestEvalation:
     """Tests for the QNodeCollection evaluation"""
 
     @pytest.mark.parametrize("interface", ["autograd"])
-    def test_eval_autograd(self, qnodes, parallel, interface):
+    def test_eval_autograd(self, qnodes, parallel, interface, dask_support):
         """Test correct evaluation of the QNodeCollection using
         the Autograd interface"""
+                
+        if (not dask_support) and (parallel):
+            pytest.skip("Skipped, no dask support")
+
         qnode1, qnode2 = qnodes
         qc = qml.QNodeCollection([qnode1, qnode2])
         params = [0.5643, -0.45]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,22 +112,25 @@ def gaussian_device_4modes():
 
 ############### Package Support ##########################
 
+
 @pytest.fixture(scope="session")
 def dask_support():
     """Boolean fixture for dask support"""
     try:
         import dask
-        
+
         dask_support = True
     except ImportError as e:
         dask_support = False
 
     return dask_support
 
+
 @pytest.fixture()
 def skip_if_no_dask_support(dask_support):
     if not dask_support:
         pytest.skip("Skipped, no dask support")
+
 
 @pytest.fixture(scope="session")
 def torch_support():
@@ -172,6 +175,7 @@ def skip_if_no_tf_support(tf_support):
 @pytest.fixture
 def skip_if_no_jax_support():
     pytest.importorskip("jax")
+
 
 #######################################################################
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -110,6 +110,25 @@ def gaussian_device_4modes():
     return DummyDevice(wires=4)
 
 
+############### Package Support ##########################
+
+@pytest.fixture(scope="session")
+def dask_support():
+    """Boolean fixture for dask support"""
+    try:
+        import dask
+        
+        dask_support = True
+    except ImportError as e:
+        dask_support = False
+
+    return dask_support
+
+@pytest.fixture()
+def skip_if_no_dask_support(dask_support):
+    if not dask_support:
+        pytest.skip("Skipped, no dask support")
+
 @pytest.fixture(scope="session")
 def torch_support():
     """Boolean fixture for PyTorch support"""
@@ -153,6 +172,8 @@ def skip_if_no_tf_support(tf_support):
 @pytest.fixture
 def skip_if_no_jax_support():
     pytest.importorskip("jax")
+
+#######################################################################
 
 
 @pytest.fixture(scope="module", params=[1, 2, 3])

--- a/tests/kernels/test_kernels.py
+++ b/tests/kernels/test_kernels.py
@@ -34,10 +34,12 @@ def cvxpy_support():
 
     return cvxpy_support
 
+
 @pytest.fixture()
 def skip_if_no_cvxpy_support(cvxpy_support):
     if not cvxpy_support:
         pytest.skip("Skipped, no cvxpy support")
+
 
 @qml.template
 def _simple_ansatz(x, params):

--- a/tests/kernels/test_kernels.py
+++ b/tests/kernels/test_kernels.py
@@ -23,6 +23,22 @@ import math
 import sys
 
 
+@pytest.fixture()
+def cvxpy_support():
+    try:
+        import cvxpy
+
+        cvxpy_support = True
+    except:
+        cvxpy_support = False
+
+    return cvxpy_support
+
+@pytest.fixture()
+def skip_if_no_cvxpy_support(cvxpy_support):
+    if not cvxpy_support:
+        pytest.skip("Skipped, no cvxpy support")
+
 @qml.template
 def _simple_ansatz(x, params):
     """A simple quantum circuit ansatz."""
@@ -361,18 +377,13 @@ class TestRegularization:
             (np.array([[0, 1.000001], [1, 0]]), True, np.array([[1, 1], [1, 1]])),
         ],
     )
+    @pytest.mark.usefixtures("skip_if_no_cvxpy_support")
     def test_closest_psd_matrix(self, input, fix_diagonal, expected_output):
         """Test obtaining the closest positive semi-definite matrix using a semi-definite program."""
         try:
             import cvxpy as cp
 
             output = kern.closest_psd_matrix(input, fix_diagonal=fix_diagonal, feastol=1e-10)
-        except ModuleNotFoundError:
-            pytest.skip(
-                "cvxpy seems to not be installed on the system."
-                "It is required for qml.kernels.closest_psd_matrix"
-                " and can be installed via `pip install cvxpy`."
-            )
         except cp.error.SolverError:
             pytest.skip(
                 "The cvxopt solver seems to not be installed on the system."
@@ -402,6 +413,7 @@ class TestRegularization:
             (np.diag([1, -1]), "I am not a solver"),
         ],
     )
+    @pytest.mark.usefixtures("skip_if_no_cvxpy_support")
     def test_closest_psd_matrix_solve_error(self, input, solver):
         """Test verbose error raising if problem.solve crashes."""
         with pytest.raises(Exception) as solve_error:

--- a/tests/tape/test_qnode.py
+++ b/tests/tape/test_qnode.py
@@ -770,6 +770,7 @@ class TestDecorator:
         assert func.qtape is not old_tape
 
 
+@pytest.mark.usefixtures("skip_if_no_dask_support")
 class TestQNodeCollection:
     """Unittests for the QNodeCollection"""
 


### PR DESCRIPTION
Fixes #1593 

Currently, the `tests` folder does not pass cleanly if only pennylane and required dependencies are installed, as dask and cvxpy are not required dependencies.  This PR skips tests that require one of these modules, but the module is not installed. 

I am still investigating the device suite tests, but those will be a separate PR.