### PR TITLE
Raise an error for `qml.sample` and `shots=None` in `default.qubit.jax`

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -395,6 +395,11 @@ and requirements-ci.txt (unpinned). This latter would be used by the CI.
 
 <h3>Breaking changes</h3>
 
+* Specifying `shots=None` with `qml.sample` was previously deprecated.
+  From this release onwards, setting `shots=None` when sampling will
+  raise an error also for `default.qubit.jax`.
+  [(#1629)](https://github.com/PennyLaneAI/pennylane/pull/1629)
+
 * The class `qml.Interferometer` is deprecated and will be renamed `qml.InterferometerUnitary`
   after one release cycle.
   [(#1546)](https://github.com/PennyLaneAI/pennylane/pull/1546)
@@ -444,7 +449,7 @@ This release contains contributions from (in alphabetical order):
 
 Vishnu Ajith, Akash Narayanan B, Thomas Bromley, Sahaj Dhamija, Tanya Garg, Josh Izaac, Prateek Jain,
 Ankit Khandelwal, Christina Lee, Johannes Jakob Meyer, Romain Moyard, Esteban Payares, Pratul Saini,
-Maria Schuld, Arshpreet Singh, Ingrid Strandberg, Slimane Thabet, David Wierichs, Vincent Wong.
+Maria Schuld, Arshpreet Singh, Ingrid Strandberg, Slimane Thabet, Antal Száva, David Wierichs, Vincent Wong.
 
 # Release 0.17.0 (current release)
 

--- a/pennylane/devices/default_qubit_jax.py
+++ b/pennylane/devices/default_qubit_jax.py
@@ -14,9 +14,7 @@
 """This module contains an jax implementation of the :class:`~.DefaultQubit`
 reference plugin.
 """
-
-import warnings
-
+import pennylane as qml
 from pennylane.operation import DiagonalOperation
 from pennylane.devices import DefaultQubit
 from pennylane.devices import jax_ops
@@ -252,15 +250,13 @@ class DefaultQubitJax(DefaultQubit):
             List[int]: the sampled basis states
         """
         if self.shots is None:
-            warnings.warn(
-                "The number of shots has to be explicitly set on the jax device "
-                "when using sample-based measurements. Since no shots are specified, "
-                "a default of 1000 shots is used.\n"
-                "This warning will be replaced with an error in a future release.",
-                UserWarning,
+
+            raise qml.QuantumFunctionError(
+                "The number of shots has to be explicitly set on the device "
+                "when using sample-based measurements."
             )
 
-        shots = self.shots or 1000
+        shots = self.shots
 
         if self._prng_key is None:
             # Assuming op-by-op, so we'll just make one.

--- a/tests/devices/test_default_qubit_jax.py
+++ b/tests/devices/test_default_qubit_jax.py
@@ -186,8 +186,7 @@ class TestQNodeIntegration:
         assert not np.all(a == b)
 
     def test_sampling_analytic_mode(self):
-        """Test that when sampling with shots=None an error is raised.
-        """
+        """Test that when sampling with shots=None an error is raised."""
         dev = qml.device("default.qubit.jax", wires=1, shots=None)
 
         @qml.qnode(dev, interface="jax", diff_method="backprop")
@@ -195,8 +194,9 @@ class TestQNodeIntegration:
             return qml.sample(qml.PauliZ(wires=0))
 
         with pytest.raises(
-            qml.QuantumFunctionError, match="The number of shots has to be explicitly set on the device "\
-                "when using sample-based measurements."
+            qml.QuantumFunctionError,
+            match="The number of shots has to be explicitly set on the device "
+            "when using sample-based measurements.",
         ):
             res = circuit()
 

--- a/tests/devices/test_default_qubit_jax.py
+++ b/tests/devices/test_default_qubit_jax.py
@@ -186,8 +186,7 @@ class TestQNodeIntegration:
         assert not np.all(a == b)
 
     def test_sampling_analytic_mode(self):
-        """Test that when sampling with shots=None, dev uses 1000 shots and
-        raises deprecation warning.
+        """Test that when sampling with shots=None an error is raised.
         """
         dev = qml.device("default.qubit.jax", wires=1, shots=None)
 
@@ -195,12 +194,11 @@ class TestQNodeIntegration:
         def circuit():
             return qml.sample(qml.PauliZ(wires=0))
 
-        with pytest.warns(
-            UserWarning, match="The number of shots has to be explicitly set on the jax device"
+        with pytest.raises(
+            qml.QuantumFunctionError, match="The number of shots has to be explicitly set on the device "\
+                "when using sample-based measurements."
         ):
             res = circuit()
-
-        assert len(res) == 1000
 
     def test_gates_dont_crash(self):
         """Test for gates that weren't covered by other tests."""


### PR DESCRIPTION
Fully deprecate `qml.sample` when `shots=None`: raise an error for `default.qubit.jax` instead of a warning. This is a change that was more generally adapted for `QubitDevice` in https://github.com/PennyLaneAI/pennylane/pull/1522.