### PR TITLE
Mark tests slower than 1.5 seconds

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -303,6 +303,10 @@
 
 <h3>Improvements</h3>
 
+* The slowest tests, more than 1.5 seconds, now have the pytest mark `slow`, and can be
+  selected or deselected during local execution of tests.
+  [(#1563)](https://github.com/PennyLaneAI/pennylane/pull/1633)
+
 * Hamiltonians are now natively supported on the `default.qubit` device if `shots=None`. 
   This makes VQE workflows a lot faster in some cases.
   [(#1551)](https://github.com/PennyLaneAI/pennylane/pull/1551)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -305,7 +305,7 @@
 
 * The slowest tests, more than 1.5 seconds, now have the pytest mark `slow`, and can be
   selected or deselected during local execution of tests.
-  [(#1563)](https://github.com/PennyLaneAI/pennylane/pull/1633)
+  [(#1633)](https://github.com/PennyLaneAI/pennylane/pull/1633)
 
 * Hamiltonians are now natively supported on the `default.qubit` device if `shots=None`. 
   This makes VQE workflows a lot faster in some cases.

--- a/tests/circuit_drawer/test_circuit_drawer.py
+++ b/tests/circuit_drawer/test_circuit_drawer.py
@@ -709,6 +709,7 @@ class TestCircuitDrawerIntegration:
 
         assert output == drawn_wide_cv_qnode
 
+    @pytest.mark.slow
     def test_cv_circuit_with_values(
         self, parameterized_cv_qnode, drawn_parameterized_cv_qnode_with_values
     ):

--- a/tests/circuit_graph/test_qasm.py
+++ b/tests/circuit_graph/test_qasm.py
@@ -699,6 +699,7 @@ class TestQNodeQasmIntegrationTests:
 
         assert res == expected
 
+
 @pytest.mark.slow
 class TestQASMConformanceTests:
     """Conformance tests to ensure that the CircuitGraph

--- a/tests/circuit_graph/test_qasm.py
+++ b/tests/circuit_graph/test_qasm.py
@@ -699,7 +699,7 @@ class TestQNodeQasmIntegrationTests:
 
         assert res == expected
 
-
+@pytest.mark.slow
 class TestQASMConformanceTests:
     """Conformance tests to ensure that the CircuitGraph
     serialized QASM conforms to the QASM standard as implemented

--- a/tests/gradients/test_finite_difference.py
+++ b/tests/gradients/test_finite_difference.py
@@ -504,6 +504,7 @@ class TestFiniteDiffGradients:
         expected = np.array([-np.cos(x) * np.cos(y) / 2, np.sin(x) * np.sin(y) / 2])
         assert np.allclose(res, expected, atol=tol, rtol=0)
 
+    @pytest.mark.slow
     def test_tf(self, approx_order, strategy, tol):
         """Tests that the output of the finite-difference transform
         can be differentiated using TF, yielding second derivatives."""

--- a/tests/gradients/test_parameter_shift.py
+++ b/tests/gradients/test_parameter_shift.py
@@ -818,6 +818,7 @@ class TestParamShiftGradients:
         )
         assert np.allclose(res, expected, atol=tol, rtol=0)
 
+    @pytest.mark.slow
     def test_tf(self, tol):
         """Tests that the output of the finite-difference transform
         can be differentiated using TF, yielding second derivatives."""
@@ -1130,6 +1131,7 @@ class TestHamiltonianExpvalGradients:
         assert np.allclose(res[1][:, 2:5], np.zeros([2, 3, 3]), atol=tol, rtol=0)
         assert np.allclose(res[2][:, -1], np.zeros([2, 1, 1]), atol=tol, rtol=0)
 
+    @pytest.mark.slow
     def test_tf(self, tol):
         """Test gradient of multiple trainable Hamiltonian coefficients
         using tf"""
@@ -1176,6 +1178,7 @@ class TestHamiltonianExpvalGradients:
         assert np.allclose(hess[1][:, 2:5], np.zeros([2, 3, 3]), atol=tol, rtol=0)
         assert np.allclose(hess[2][:, -1], np.zeros([2, 1, 1]), atol=tol, rtol=0)
 
+    @pytest.mark.slow
     def test_jax(self, tol):
         """Test gradient of multiple trainable Hamiltonian coefficients
         using JAX"""

--- a/tests/gradients/test_vjp.py
+++ b/tests/gradients/test_vjp.py
@@ -259,6 +259,7 @@ class TestVJPGradients:
         exp = qml.jacobian(lambda x: expected(x)[0])(params.detach().numpy())
         assert np.allclose(params.grad, exp, atol=tol, rtol=0)
 
+    @pytest.mark.slow
     def test_tf(self, tol):
         """Tests that the output of the VJP transform
         can be differentiated using TF."""
@@ -282,6 +283,7 @@ class TestVJPGradients:
         res = t.jacobian(vjp, params)
         assert np.allclose(res, qml.jacobian(expected)(params.numpy()), atol=tol, rtol=0)
 
+    @pytest.mark.slow
     def test_jax(self, tol):
         """Tests that the output of the VJP transform
         can be differentiated using JAX."""

--- a/tests/interfaces/test_batch_tensorflow.py
+++ b/tests/interfaces/test_batch_tensorflow.py
@@ -686,6 +686,7 @@ class TestTensorFlowExecuteIntegration:
 class TestHigherOrderDerivatives:
     """Test that the TensorFlow execute function can be differentiated"""
 
+    @pytest.mark.slow
     @pytest.mark.parametrize(
         "params",
         [

--- a/tests/interfaces/test_tape_tf.py
+++ b/tests/interfaces/test_tape_tf.py
@@ -169,6 +169,7 @@ class TestTFQuantumTape:
             assert args[1]["order"] == 2
             assert args[1]["h"] == 1e-8
 
+    @pytest.mark.slow
     def test_reusing_quantum_tape(self, tol):
         """Test re-using a quantum tape by passing new parameters"""
         a = tf.Variable(0.1, dtype=tf.float64)
@@ -518,6 +519,7 @@ class TestTFPassthru:
 
         spy.assert_not_called()
 
+    @pytest.mark.slow
     def test_reusing_quantum_tape(self, mocker, tol):
         """Test re-using a quantum tape by passing new parameters"""
         spy = mocker.spy(JacobianTape, "jacobian")

--- a/tests/math/test_functions.py
+++ b/tests/math/test_functions.py
@@ -675,6 +675,7 @@ class TestRequiresGrad:
         """Vanilla NumPy arrays, sequences, and lists will always return False"""
         assert not fn.requires_grad(t)
 
+    @pytest.mark.slow
     def test_jax(self):
         """JAX DeviceArrays differentiability depends on the argnums argument"""
         res = None
@@ -1368,6 +1369,7 @@ class TestCovMatrix:
         expected = self.expected_grad(weights)
         assert np.allclose(grad, expected, atol=tol, rtol=0)
 
+    @pytest.mark.slow
     def test_jax(self, tol):
         """Test that the covariance matrix computes the correct
         result, and is differentiable, using the JAX interface"""

--- a/tests/optimize/test_shot_adaptive.py
+++ b/tests/optimize/test_shot_adaptive.py
@@ -526,6 +526,7 @@ class TestOptimization:
         assert np.allclose(circuit(params), -1, atol=0.1, rtol=0.2)
         assert opt.shots_used > min_shots
 
+    @pytest.mark.slow
     def test_vqe_optimization(self):
         """Test that a simple VQE circuit can be optimized"""
         dev = qml.device("default.qubit", wires=2, shots=100)

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    slow: marks tests as slow (deselect with '-m "not slow"')

--- a/tests/qnn/test_keras.py
+++ b/tests/qnn/test_keras.py
@@ -404,6 +404,7 @@ class TestKerasLayer:
         assert layer_out.shape == (batch_size, output_dim)
         assert np.allclose(layer_out[0], c(x[0], *weights))
 
+    @pytest.mark.slow
     @pytest.mark.parametrize("n_qubits, output_dim", indices_up_to(2))
     @pytest.mark.parametrize("batch_size", [2, 4, 6])
     @pytest.mark.parametrize("middle_dim", [2, 5, 8])

--- a/tests/templates/test_subroutines/test_double_excitation.py
+++ b/tests/templates/test_subroutines/test_double_excitation.py
@@ -294,6 +294,7 @@ class TestInterfaces:
         # without error
         grad_fn(weight)
 
+    @pytest.mark.slow
     def test_jax(self):
         """Tests the jax interface."""
 

--- a/tests/templates/test_subroutines/test_ucssd.py
+++ b/tests/templates/test_subroutines/test_ucssd.py
@@ -340,6 +340,7 @@ class TestInterfaces:
 
         assert np.allclose(grads, grads2, atol=tol, rtol=0)
 
+    @pytest.mark.slow
     def test_jax(self, tol):
         """Tests the jax interface."""
 

--- a/tests/test_about.py
+++ b/tests/test_about.py
@@ -27,6 +27,7 @@ import pytest
 import pennylane as qml
 
 
+@pytest.mark.slow
 def test_about():
     """
     about: Tests if the about string prints correct.

--- a/tests/test_vqe.py
+++ b/tests/test_vqe.py
@@ -366,6 +366,7 @@ class TestVQE:
             assert qnode.diff_options["h"] == 123
             assert qnode.diff_options["order"] == 2
 
+    @pytest.mark.slow
     @pytest.mark.parametrize("interface", ["tf", "torch", "autograd"])
     def test_optimize(self, interface, tf_support, torch_support):
         """Test that an ExpvalCost with observable optimization gives the same result as another
@@ -519,6 +520,7 @@ class TestVQE:
         dc = qml.grad(cost)(w)
         assert np.allclose(dc, 0)
 
+    @pytest.mark.slow
     def test_optimize_grad_torch(self, torch_support):
         """Test that the gradient of ExpvalCost is accessible and correct when using observable
         optimization and the Torch interface."""
@@ -544,6 +546,7 @@ class TestVQE:
 
         assert np.allclose(dc, big_hamiltonian_grad)
 
+    @pytest.mark.slow
     def test_optimize_grad_tf(self, tf_support):
         """Test that the gradient of ExpvalCost is accessible and correct when using observable
         optimization and the TensorFlow interface."""
@@ -827,6 +830,7 @@ class TestNewVQE:
         dc = qml.grad(circuit)(w)
         assert np.allclose(dc, 0, atol=tol)
 
+    @pytest.mark.slow
     def test_grad_torch(self, torch_support, tol):
         """Tests VQE gradients in the torch interface."""
         if not torch_support:
@@ -870,6 +874,7 @@ class TestNewVQE:
 
         assert np.allclose(dc, big_hamiltonian_grad, atol=tol)
 
+    @pytest.mark.slow
     def test_grad_jax(self, tol):
         """Tests VQE gradients in the jax interface."""
         jax = pytest.importorskip("jax")

--- a/tests/transforms/test_qmc_transform.py
+++ b/tests/transforms/test_qmc_transform.py
@@ -96,6 +96,7 @@ def test_apply_controlled_v(n_wires):
 class TestApplyControlledQ:
     """Tests for the apply_controlled_Q function"""
 
+    @pytest.mark.slow
     @pytest.mark.parametrize("n_wires", range(2, 5))
     def test_apply(self, n_wires):
         """Test if the apply_controlled_Q performs the correct transformation by reconstructing the
@@ -137,6 +138,7 @@ class TestApplyControlledQ:
 class TestQuantumMonteCarlo:
     """Tests for the quantum_monte_carlo function"""
 
+    @pytest.mark.slow
     @pytest.mark.parametrize("n_wires", range(2, 4))
     def test_apply(self, n_wires):
         """Test if the quantum_monte_carlo performs the correct transformation by reconstructing the
@@ -181,6 +183,7 @@ class TestQuantumMonteCarlo:
                 lambda: None, wires=wires, target_wire=0, estimation_wires=estimation_wires
             )
 
+    @pytest.mark.slow
     def test_integration(self):
         """Test if quantum_monte_carlo generates the correct circuit by comparing it to the
         QuantumMonteCarlo template on the practical example specified in the usage details. Custom


### PR DESCRIPTION
This PR marks the 35 or so slowest tests that took longer than 1.5 seconds on my computer as "slow".

You can locally run all not slow tests via the command:

```
pytest -m "not slow" files_to_check
```

This will hopefully make the local execution of the test suite easier.

I also added the `pytest.ini` file to register the `"slow"` mark.

In the future, slow tests that get added should be marked via `@pytest.mark.slow`.