### PR TITLE
Diff option backprop check rc

### DIFF
--- a/pennylane/qnode.py
+++ b/pennylane/qnode.py
@@ -592,7 +592,11 @@ class QNode:
         state_returns = any([m.return_type is State for m in measurement_processes])
 
         # apply the interface (if any)
-        if self.diff_options["method"] != "backprop" and self.interface is not None:
+
+        explicit_backprop = self.diff_options["method"] == "backprop"
+        best_and_passthru = self.diff_options["method"] == "best" and "passthru_interface" in self.device.capabilities()
+        not_backprop_diff = not explicit_backprop and not best_and_passthru
+        if not_backprop_diff and self.interface is not None:
             # pylint: disable=protected-access
             if state_returns and self.interface in ["torch", "tf"]:
                 # The state is complex and we need to indicate this in the to_torch or to_tf

--- a/pennylane/qnode.py
+++ b/pennylane/qnode.py
@@ -598,8 +598,8 @@ class QNode:
             self.diff_options["method"] == "best"
             and "passthru_interface" in self.device.capabilities()
         )
-        not_backprop_diff = not explicit_backprop and not best_and_passthru
-        if not_backprop_diff and self.interface is not None:
+        backprop_diff = explicit_backprop or best_and_passthru
+        if not backprop_diff and self.interface is not None:
             # pylint: disable=protected-access
             if state_returns and self.interface in ["torch", "tf"]:
                 # The state is complex and we need to indicate this in the to_torch or to_tf

--- a/pennylane/qnode.py
+++ b/pennylane/qnode.py
@@ -594,7 +594,10 @@ class QNode:
         # apply the interface (if any)
 
         explicit_backprop = self.diff_options["method"] == "backprop"
-        best_and_passthru = self.diff_options["method"] == "best" and "passthru_interface" in self.device.capabilities()
+        best_and_passthru = (
+            self.diff_options["method"] == "best"
+            and "passthru_interface" in self.device.capabilities()
+        )
         not_backprop_diff = not explicit_backprop and not best_and_passthru
         if not_backprop_diff and self.interface is not None:
             # pylint: disable=protected-access

--- a/tests/beta/test_default_tensor_tf.py
+++ b/tests/beta/test_default_tensor_tf.py
@@ -453,7 +453,7 @@ class TestJacobianIntegration:
 
         dev = qml.device("default.tensor.tf", wires=1, representation=rep)
 
-        @qml.qnode(dev)
+        @qml.qnode(dev, diff_method='parameter-shift')
         def circuit(p):
             qml.RX(3 * p[0], wires=0)
             qml.RY(p[1], wires=0)
@@ -484,7 +484,7 @@ class TestJacobianIntegration:
         p = np.array([x, y, z])
         dev = qml.device("default.tensor.tf", wires=1, representation=rep)
 
-        @qml.qnode(dev)
+        @qml.qnode(dev, diff_method='parameter-shift')
         def circuit(x):
             qml.RX(x[1], wires=0)
             qml.Rot(x[0], x[1], x[2], wires=0)
@@ -567,7 +567,7 @@ class TestInterfaceDeviceIntegration:
 
         dev = qml.device("default.tensor.tf", wires=2, representation=rep)
 
-        @qml.qnode(dev, interface=interface)
+        @qml.qnode(dev, interface=interface, diff_method='parameter-shift')
         def circuit_fn(a, b):
             qml.RX(a, wires=0)
             qml.CRX(b, wires=[0, 1])

--- a/tests/beta/test_default_tensor_tf.py
+++ b/tests/beta/test_default_tensor_tf.py
@@ -453,7 +453,7 @@ class TestJacobianIntegration:
 
         dev = qml.device("default.tensor.tf", wires=1, representation=rep)
 
-        @qml.qnode(dev, diff_method='parameter-shift')
+        @qml.qnode(dev, diff_method="parameter-shift")
         def circuit(p):
             qml.RX(3 * p[0], wires=0)
             qml.RY(p[1], wires=0)
@@ -484,7 +484,7 @@ class TestJacobianIntegration:
         p = np.array([x, y, z])
         dev = qml.device("default.tensor.tf", wires=1, representation=rep)
 
-        @qml.qnode(dev, diff_method='parameter-shift')
+        @qml.qnode(dev, diff_method="parameter-shift")
         def circuit(x):
             qml.RX(x[1], wires=0)
             qml.Rot(x[0], x[1], x[2], wires=0)
@@ -567,7 +567,7 @@ class TestInterfaceDeviceIntegration:
 
         dev = qml.device("default.tensor.tf", wires=2, representation=rep)
 
-        @qml.qnode(dev, interface=interface, diff_method='parameter-shift')
+        @qml.qnode(dev, interface=interface, diff_method="parameter-shift")
         def circuit_fn(a, b):
             qml.RX(a, wires=0)
             qml.CRX(b, wires=[0, 1])

--- a/tests/devices/test_default_qubit_jax.py
+++ b/tests/devices/test_default_qubit_jax.py
@@ -320,34 +320,34 @@ class TestPassthruIntegration:
         assert jnp.allclose(grad, expected, atol=tol, rtol=0)
 
 
-@pytest.mark.parametrize("theta", np.linspace(-2 * np.pi, np.pi, 7))
-def test_CRot_gradient(theta, tol):
-    """Tests that the automatic gradient of a arbitrary controlled Euler-angle-parameterized
-    gate is correct."""
-    dev = qml.device("default.qubit.jax", wires=2)
-    a, b, c = np.array([theta, theta ** 3, np.sqrt(2) * theta])
+    @pytest.mark.parametrize("theta", np.linspace(-2 * np.pi, np.pi, 7))
+    def test_CRot_gradient(self, theta, tol):
+        """Tests that the automatic gradient of a arbitrary controlled Euler-angle-parameterized
+        gate is correct."""
+        dev = qml.device("default.qubit.jax", wires=2)
+        a, b, c = np.array([theta, theta ** 3, np.sqrt(2) * theta])
 
-    @qml.qnode(dev, diff_method="backprop", interface="jax")
-    def circuit(a, b, c):
-        qml.QubitStateVector(np.array([1.0, -1.0]) / np.sqrt(2), wires=0)
-        qml.CRot(a, b, c, wires=[0, 1])
-        return qml.expval(qml.PauliX(0))
+        @qml.qnode(dev, diff_method="backprop", interface="jax")
+        def circuit(a, b, c):
+            qml.QubitStateVector(np.array([1.0, -1.0]) / np.sqrt(2), wires=0)
+            qml.CRot(a, b, c, wires=[0, 1])
+            return qml.expval(qml.PauliX(0))
 
-    res = circuit(a, b, c)
-    expected = -np.cos(b / 2) * np.cos(0.5 * (a + c))
-    assert np.allclose(res, expected, atol=tol, rtol=0)
+        res = circuit(a, b, c)
+        expected = -np.cos(b / 2) * np.cos(0.5 * (a + c))
+        assert np.allclose(res, expected, atol=tol, rtol=0)
 
-    grad = jax.grad(circuit, argnums=(0, 1, 2))(a, b, c)
-    expected = np.array(
-        [
+        grad = jax.grad(circuit, argnums=(0, 1, 2))(a, b, c)
+        expected = np.array(
             [
-                0.5 * np.cos(b / 2) * np.sin(0.5 * (a + c)),
-                0.5 * np.sin(b / 2) * np.cos(0.5 * (a + c)),
-                0.5 * np.cos(b / 2) * np.sin(0.5 * (a + c)),
+                [
+                    0.5 * np.cos(b / 2) * np.sin(0.5 * (a + c)),
+                    0.5 * np.sin(b / 2) * np.cos(0.5 * (a + c)),
+                    0.5 * np.cos(b / 2) * np.sin(0.5 * (a + c)),
+                ]
             ]
-        ]
-    )
-    assert np.allclose(grad, expected, atol=tol, rtol=0)
+        )
+        assert np.allclose(grad, expected, atol=tol, rtol=0)
 
     def test_prob_differentiability(self, tol):
         """Test that the device probability can be differentiated"""
@@ -459,6 +459,19 @@ def test_CRot_gradient(theta, tol):
         ):
             qml.qnode(dev, diff_method="backprop", interface=interface)(circuit)
 
+    def test_no_jax_interface_applied(self):
+        """Tests that the JAX interface is not applied and no error is raised if qml.probs is used with the Jax
+        interface when diff_method='backprop'
+
+        When the JAX interface is applied, we can only get the expectation value and the variance of a QNode.
+        """
+        dev = qml.device("default.qubit.jax", wires=1, shots=None)
+
+        def circuit():
+            return qml.probs(wires=0)
+
+        qnode = qml.qnode(dev, diff_method="backprop", interface="jax")(circuit)
+        assert jnp.allclose(qnode(), jnp.array([1, 0]))
 
 class TestHighLevelIntegration:
     """Tests for integration with higher level components of PennyLane."""

--- a/tests/devices/test_default_qubit_jax.py
+++ b/tests/devices/test_default_qubit_jax.py
@@ -319,7 +319,6 @@ class TestPassthruIntegration:
         expected = jnp.sin(a)
         assert jnp.allclose(grad, expected, atol=tol, rtol=0)
 
-
     @pytest.mark.parametrize("theta", np.linspace(-2 * np.pi, np.pi, 7))
     def test_CRot_gradient(self, theta, tol):
         """Tests that the automatic gradient of a arbitrary controlled Euler-angle-parameterized
@@ -472,6 +471,7 @@ class TestPassthruIntegration:
 
         qnode = qml.qnode(dev, diff_method="backprop", interface="jax")(circuit)
         assert jnp.allclose(qnode(), jnp.array([1, 0]))
+
 
 class TestHighLevelIntegration:
     """Tests for integration with higher level components of PennyLane."""


### PR DESCRIPTION
**Context**

In the QNode, for cases when `diff_method!='backprop'`, we apply the interface that was specified by the user.

With the changes in https://github.com/PennyLaneAI/pennylane/pull/1568, at the point where this is being done, we might have `diff_method='best'` represent backpropagation when we have a backpropagation device at hand. Therefore, we might be applying the interface even when we'll be using backpropagation. This is unwanted behaviour as the interface should not be applied when using backpropagation, as we're leaning on the machine learning framework to perform the gradient computation (instead of providing a gradient with the interface).

**Changes**

Extends the criterion used for checking when to apply the interface to a QNode.