### PR TITLE
Raise a `UserWarning` for a list of shots in `Device.execute`

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -307,7 +307,7 @@
 
 * A warning is raised to inform the user that specifying a list of shots is
   only supported for `QubitDevice` based devices.
-  [(#XXX)](https://github.com/PennyLaneAI/pennylane/pull/XXX)
+  [(#1659)](https://github.com/PennyLaneAI/pennylane/pull/1659)
 
 * The `qml.circuit_drawer.MPLDrawer` class provides manual circuit drawing
   functionality using Matplotlib. While not yet integrated with automatic circuit

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -305,6 +305,10 @@
 
 <h3>Improvements</h3>
 
+* A warning is raised to inform the user that specifying a list of shots is
+  only supported for `QubitDevice` based devices.
+  [(#XXX)](https://github.com/PennyLaneAI/pennylane/pull/XXX)
+
 * The `qml.circuit_drawer.MPLDrawer` class provides manual circuit drawing
   functionality using Matplotlib. While not yet integrated with automatic circuit
   drawing, this class provides customization and control.

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -16,6 +16,7 @@ This module contains the :class:`Device` abstract base class.
 """
 # pylint: disable=too-many-format-args, use-maxsplit-arg
 import abc
+import warnings
 from collections.abc import Iterable, Sequence
 from collections import OrderedDict, namedtuple
 from functools import lru_cache
@@ -406,6 +407,9 @@ class Device(abc.ABC):
         self._parameters.update(parameters)
 
         results = []
+        if self._shot_vector is not None:
+            warnings.warn("Specifying a list of shots is only supported for"\
+                          "QubitDevice based devices. Falling back to executions using all shots in the shot list.")
 
         with self.execution_context():
             self.pre_apply()

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -410,7 +410,7 @@ class Device(abc.ABC):
         if self._shot_vector is not None:
             # The following warning assumes that QubitDevice.execute is stand-alone
             warnings.warn(
-                "Specifying a list of shots is only supported for"
+                "Specifying a list of shots is only supported for "
                 "QubitDevice based devices. Falling back to executions using all shots in the shot list."
             )
 

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -408,6 +408,7 @@ class Device(abc.ABC):
 
         results = []
         if self._shot_vector is not None:
+            # The following warning assumes that QubitDevice.execute is stand-alone
             warnings.warn(
                 "Specifying a list of shots is only supported for"
                 "QubitDevice based devices. Falling back to executions using all shots in the shot list."

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -408,8 +408,10 @@ class Device(abc.ABC):
 
         results = []
         if self._shot_vector is not None:
-            warnings.warn("Specifying a list of shots is only supported for"\
-                          "QubitDevice based devices. Falling back to executions using all shots in the shot list.")
+            warnings.warn(
+                "Specifying a list of shots is only supported for"
+                "QubitDevice based devices. Falling back to executions using all shots in the shot list."
+            )
 
         with self.execution_context():
             self.pre_apply()

--- a/tests/devices/test_default_gaussian.py
+++ b/tests/devices/test_default_gaussian.py
@@ -766,7 +766,8 @@ class TestDefaultGaussianIntegration:
             return qml.sample(qml.X(0))
 
         with pytest.warns(
-            UserWarning, match="Specifying a list of shots is only supported forQubitDevice based devices."
+            UserWarning,
+            match="Specifying a list of shots is only supported forQubitDevice based devices.",
         ):
             circuit()
         assert dev.shots == sum(shots)

--- a/tests/devices/test_default_gaussian.py
+++ b/tests/devices/test_default_gaussian.py
@@ -753,6 +753,24 @@ class TestDefaultGaussianIntegration:
 
         assert np.mean(runs) == pytest.approx(p * np.sqrt(2 * hbar), abs=tol_stochastic)
 
+    def test_shot_list_warns(self):
+        """Test that specifying a list of shots is unsupported for
+        default.gaussian and emits a warning"""
+
+        shots = [10, 10, 10]
+        dev = qml.device("default.gaussian", wires=1, shots=shots)
+
+        @qml.qnode(dev)
+        def circuit():
+            """Test quantum function"""
+            return qml.sample(qml.X(0))
+
+        with pytest.warns(
+            UserWarning, match="Specifying a list of shots is only supported forQubitDevice based devices."
+        ):
+            circuit()
+        assert dev.shots == sum(shots)
+
     @pytest.mark.parametrize("g, qop", set(DefaultGaussian._operation_map.items()))
     def test_supported_gates(self, g, qop, gaussian_dev):
         """Test that all supported gates work correctly"""

--- a/tests/devices/test_default_gaussian.py
+++ b/tests/devices/test_default_gaussian.py
@@ -767,7 +767,7 @@ class TestDefaultGaussianIntegration:
 
         with pytest.warns(
             UserWarning,
-            match="Specifying a list of shots is only supported forQubitDevice based devices.",
+            match="Specifying a list of shots is only supported for QubitDevice based devices.",
         ):
             circuit()
         assert dev.shots == sum(shots)


### PR DESCRIPTION
Adds a `UserWarning` to inform users that specifinyg the list of shots is only supported for `QubitDevice` based devices. See [related comment here](https://github.com/PennyLaneAI/pennylane/pull/1103#issuecomment-784287830) and the original PR: https://github.com/PennyLaneAI/pennylane/pull/1103