### PR TITLE
bugfix for device shot list processing

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -461,6 +461,9 @@ and requirements-ci.txt (unpinned). This latter would be used by the CI.
 
 <h3>Bug fixes</h3>
 
+* Fix bug with shot vectors and `Device` base class.
+  [(#1666)](https://github.com/PennyLaneAI/pennylane/pull/1666)
+
 * Fix bug with norm and Jax tracers (jit) when using `QubiStateVector`.
   [(#1649)](https://github.com/PennyLaneAI/pennylane/pull/1649)
   

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -89,7 +89,7 @@ def _process_shot_sequence(shot_list):
     else:
         raise ValueError(f"Unknown shot sequence format {shot_list}")
 
-    total_shots = np.sum(np.prod(shot_vector, axis=1))
+    total_shots = int(np.sum(np.prod(shot_vector, axis=1)))
     return total_shots, shot_vector
 
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -180,6 +180,24 @@ def test_shot_vector_property():
     assert shot_vector[3].copies == 1
 
 
+def test_process_shot_sequence():
+
+    shot_list = [1,1, 3]
+    total_shots, shot_vector = qml._device._process_shot_sequence(shot_list)
+
+    assert total_shots == 5
+    assert isinstance(total_shots, int)
+
+    assert len(shot_vector) == 2
+
+    for tup in shot_vector:
+        assert isinstance(tup, qml._device.ShotTuple)
+    
+    assert shot_vector[0].shots == 1
+    assert shot_vector[0].copies == 2
+    assert shot_vector[1].shots == 3
+    assert shot_vector[1].copies == 1
+
 class TestDeviceSupportedLogic:
     """Test the logic associated with the supported operations and observables"""
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -166,37 +166,42 @@ def mock_device(monkeypatch):
         yield get_device
 
 
-def test_shot_vector_property():
-    dev = qml.device("default.qubit", wires=1, shots=[1, 3, 3, 4, 4, 4, 3])
-    shot_vector = dev.shot_vector
-    assert len(shot_vector) == 4
-    assert shot_vector[0].shots == 1
-    assert shot_vector[0].copies == 1
-    assert shot_vector[1].shots == 3
-    assert shot_vector[1].copies == 2
-    assert shot_vector[2].shots == 4
-    assert shot_vector[2].copies == 3
-    assert shot_vector[3].shots == 3
-    assert shot_vector[3].copies == 1
+class TestShotVectors:
+    """Tests passing shot vectors, their validation, and processing."""
 
+    def test_shot_vector_property(self):
+        dev = qml.device("default.qubit", wires=1, shots=[1, 3, 3, 4, 4, 4, 3])
+        shot_vector = dev.shot_vector
+        assert len(shot_vector) == 4
+        assert shot_vector[0].shots == 1
+        assert shot_vector[0].copies == 1
+        assert shot_vector[1].shots == 3
+        assert shot_vector[1].copies == 2
+        assert shot_vector[2].shots == 4
+        assert shot_vector[2].copies == 3
+        assert shot_vector[3].shots == 3
+        assert shot_vector[3].copies == 1
 
-def test_process_shot_sequence():
+        assert dev.shots == 22
 
-    shot_list = [1,1, 3]
-    total_shots, shot_vector = qml._device._process_shot_sequence(shot_list)
+    def test_process_shot_sequence(self):
+        """Tests that the helper `_process_shot_sequence` works as expected."""
+        shot_list = [1, 1, 3]
+        total_shots, shot_vector = qml._device._process_shot_sequence(shot_list)
 
-    assert total_shots == 5
-    assert isinstance(total_shots, int)
+        assert total_shots == 5
+        assert isinstance(total_shots, int)
 
-    assert len(shot_vector) == 2
+        assert len(shot_vector) == 2
 
-    for tup in shot_vector:
-        assert isinstance(tup, qml._device.ShotTuple)
-    
-    assert shot_vector[0].shots == 1
-    assert shot_vector[0].copies == 2
-    assert shot_vector[1].shots == 3
-    assert shot_vector[1].copies == 1
+        for tup in shot_vector:
+            assert isinstance(tup, qml._device.ShotTuple)
+
+        assert shot_vector[0].shots == 1
+        assert shot_vector[0].copies == 2
+        assert shot_vector[1].shots == 3
+        assert shot_vector[1].copies == 1
+
 
 class TestDeviceSupportedLogic:
     """Test the logic associated with the supported operations and observables"""


### PR DESCRIPTION
Found when inspecting [PR 1659](https://github.com/PennyLaneAI/pennylane/pull/1659/files).

Previously, this code:
```
import pennylane as qml

dev = qml.device('default.gaussian', wires=1, shots=[2,2])

@qml.qnode(dev)
def circuit():
    return qml.sample(qml.X(0))

circuit(shots=2)
```
Raised the warning:
```
DeviceError: Shots must be a single non-negative integer or a sequence of non-negative integers.
```

This is because the original devices shots (2+2 = 4) was of type `np.int64` instead of type `int`.  

This makes it so device shots will be an int even when derived from a shot list.
