### PR TITLE
bugfix: raise mpl import error inside class initialization

### DIFF
--- a/pennylane/circuit_drawer/mpldrawer.py
+++ b/pennylane/circuit_drawer/mpldrawer.py
@@ -16,14 +16,13 @@ This module contains the MPLDrawer class for creating circuit diagrams with matp
 """
 from collections.abc import Iterable
 
+has_mpl=True
 try:
     import matplotlib.pyplot as plt
     from matplotlib import patches
 except (ModuleNotFoundError, ImportError) as e:
-    raise ImportError(
-        "Module matplotlib is required for ``MPLDrawer`` class. "
-        "You can install matplotlib via \n\n   pip install matplotlib"
-    ) from e
+    has_mpl = False
+
 
 
 def _to_tuple(a):
@@ -216,6 +215,12 @@ class MPLDrawer:
     _swap_dx = 0.2
 
     def __init__(self, n_layers, n_wires, wire_options=None, figsize=None):
+
+        if not has_mpl:
+            raise ImportError(
+            "Module matplotlib is required for ``MPLDrawer`` class. "
+            "You can install matplotlib via \n\n   pip install matplotlib"
+            )
 
         self.n_layers = n_layers
         self.n_wires = n_wires

--- a/pennylane/circuit_drawer/mpldrawer.py
+++ b/pennylane/circuit_drawer/mpldrawer.py
@@ -16,13 +16,12 @@ This module contains the MPLDrawer class for creating circuit diagrams with matp
 """
 from collections.abc import Iterable
 
-has_mpl=True
+has_mpl = True
 try:
     import matplotlib.pyplot as plt
     from matplotlib import patches
 except (ModuleNotFoundError, ImportError) as e:
     has_mpl = False
-
 
 
 def _to_tuple(a):
@@ -218,8 +217,8 @@ class MPLDrawer:
 
         if not has_mpl:
             raise ImportError(
-            "Module matplotlib is required for ``MPLDrawer`` class. "
-            "You can install matplotlib via \n\n   pip install matplotlib"
+                "Module matplotlib is required for ``MPLDrawer`` class. "
+                "You can install matplotlib via \n\n   pip install matplotlib"
             )
 
         self.n_layers = n_layers


### PR DESCRIPTION
Currently, import pennylane in an environment without matplotlib raises an import error, as the `MPLDrawer` class requires it.  This change only raises an import error if someone tries to initialize the class.