### PR TITLE
Generalize fourier spectrum

### DIFF
--- a/pennylane/argmap.py
+++ b/pennylane/argmap.py
@@ -1,0 +1,251 @@
+# Copyright 2018-2021 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+This module contains the :class:`ArgMap` class, which is a flexible-access container.
+"""
+from functools import lru_cache
+from pennylane import numpy as np
+
+
+class ArgMapError(Exception):
+    r"""Exception raised by an :class:`~.pennylane.argmap.ArgMap` instance
+    when it is unable to create an instance, or access or write a requested item."""
+
+
+@lru_cache(maxsize=None)
+def _interpret_key(key, single_arg):
+    r"""Interpret ArgMap key into argument and parameter index."""
+    if key in (None, (None, None), ()):
+        return None, None
+    if single_arg:
+        # Only param_key given and param_key is int
+        if np.issubdtype(type(key), int):
+            return None, key
+        if isinstance(key, tuple):
+            # Only param_key given and param_key is tuple OR (None, param_key) given
+            sub_key = key[1] if key[0] is None else key
+            return None, sub_key
+    else:
+        # Only arg_key given
+        if np.issubdtype(type(key), int):
+            return key, None
+        # (arg_key, param_key) given
+        if isinstance(key, tuple) and len(key) == 2:
+            if key[1] == ():
+                key = (key[0], None)
+            return key
+    raise ArgMapError(f"Could not interpret key {key}.")
+
+
+class ArgMap(dict):
+    r"""Argument index map for storing objects per QNode argument and parameter.
+
+    Args:
+        data (list[tuple] or dict or object): Data to store in the ArgMap.
+            If not a dict and ``single_object=False``, ``data`` must be possible
+            to be parsed via ``dict(data)``.
+        single_arg (bool): Whether the ``ArgMap`` stores objects for a single argument.
+        single_object (bool): Whether the ``ArgMap`` stores only a single object.
+
+    An ``ArgMap`` acts as a dictionary with a restricted type of keys in the context of
+    a given ``QNode``. Each key takes the form ``tuple[int, tuple[int] or int]``.
+    The first ``int`` in the tuple describes the argument index of the ``QNode``,
+    while the second entry describes the index within that argument.
+    That is ``(2, (0, 3))`` describes the parameter in the ``0``th row and ``3``rd
+    column of the ``2``nd argument of a QNode. The second entry of the tuple may be an
+    ``int`` instead, indexing a one-dimensional array.
+
+    If the argument index (first entry) of a key is ``None``, this indicates that there is
+    only one argument in the QNode, and all keys of the ``ArgMap`` should have the form
+    ``(None, tuple[int] or int)``.
+    If the parameter index (second entry) of a key is ``None``, the respective argument
+    is a scalar and no other key with the same argument index can exist in the ``ArgMap``.
+    If both entries are ``None``, i.e. ``key=(None, None)``, the QNode only takes a single
+    scalar argument.
+
+    The main feature of an ``ArgMap`` is its flexible access: Users can specify only an
+    argument index or only a parameter index if this fully uniquely describes the
+    parameter.
+
+    **Example**
+    Suppose we have the following ``QNode`` instance:
+
+    .. code-block:: python
+
+        dev = qml.device('default.qubit', wires=2)
+        @qml.qnode(dev)
+        def circuit(arg1, arg2, arg3):
+            qml.Rot(arg1, wires=0)
+            qml.RX(arg2, wires=0)
+            qml.Rot(arg3, wires=1)
+            return qml.expval(qml.PauliY(0) @ qml.PauliY(1))
+
+    Then we might want to set up an ``ArgMap`` to store the generators of the rotations in
+    this circuit, depending on the parameter that controls them:
+
+    .. code-block:: python
+
+        generators = qml.ArgMap({
+            (0, 0): qml.PauliZ(0),
+            (0, 1): qml.PauliY(0),
+            (0, 2): qml.PauliZ(0),
+            1: qml.PauliX(0),
+            (1, 0): qml.PauliZ(1),
+            (1, 1): qml.PauliY(1),
+            (1, 2): qml.PauliZ(1),
+        })
+
+    Then the generators can be accessed by using the tuples ``(arg_index, par_index)`` as key
+    with ``par_index=None`` for the ``PauliX(0)`` generator. The latter may alternatively
+    be accessed directly via ``generators[1]``.
+    """
+
+    def __init__(self, data=None, single_arg=False, single_object=False, like=None):
+        if like is not None:
+            if not isinstance(like, ArgMap):
+                raise ArgMapError("Trying to inherit properties from non-ArgMap object.")
+            single_arg, single_object = like.single_arg, like.single_object
+        self.single_arg = single_arg
+        self.single_object = single_object
+        _data = self._preprocess_data(data)
+        super().__init__(_data)
+        self.consistency_check()
+
+    def _preprocess_data(self, data):
+        if data is None:
+            data = {}
+        if self.single_object:
+            return {(None, None): data}
+
+        if not isinstance(data, dict):
+            try:
+                data = dict(data)
+            except (ValueError, TypeError) as e:
+                raise ArgMapError(
+                    f"The input could not be interpreted as dictionary; input:\n{data}"
+                ) from e
+
+        return {_interpret_key(key, self.single_arg): val for key, val in data.items()}
+
+    def __getitem__(self, key):
+        key = _interpret_key(key, self.single_arg)
+        return super().__getitem__(key)
+
+    def __setitem__(self, key, value):
+        key = _interpret_key(key, self.single_arg)
+        return super().__setitem__(key, value)
+
+    def setdefault(self, key, default=None):
+        key = _interpret_key(key, self.single_arg)
+        return super().setdefault(key, default)
+
+    def __eq__(self, other):
+        if isinstance(other, ArgMap):
+            if (self.single_arg + other.single_arg) % 2:
+                return False
+            if (self.single_object + other.single_object) % 2:
+                return False
+        return super().__eq__(other)
+
+    def __ne__(self, other):
+        if isinstance(other, ArgMap):
+            if (self.single_arg + other.single_arg) % 2:
+                return True
+            if (self.single_object + other.single_object) % 2:
+                return True
+        return super().__ne__(other)
+
+    def get(self, key, default=None):
+        key = _interpret_key(key, self.single_arg)
+        return super().get(key, default)
+
+    def consistency_check(self, check_values=False):
+        r"""Check the stored keys and optionally values for consistency."""
+        if self.single_object:
+            self._check_single_object()
+            if check_values:
+                self._check_values()
+            return
+        if any((key == (None, None) for key in self)):
+            raise ArgMapError(
+                "The key (None, None) indicates single object but ArgMap.single_object=False."
+            )
+        if self.single_arg:
+            self._check_single_arg()
+        else:
+            self._check_multiple_args()
+        if check_values:
+            self._check_values()
+
+    def _check_values(self):
+        types = [(key, type(val)) for key, val in self.items()]
+        if not all((_type[1] == types[0][1] for _type in types)):
+            raise ArgMapError(
+                "\n".join(
+                    (
+                        ["Inconsistent value types in ArgMap"]
+                        + [f"{_type[0]}: {_type[1]}" for _type in types]
+                    )
+                )
+            )
+
+    def _check_single_object(self):
+        if not len(self) == 1:
+            raise ArgMapError(f"ArgMap.single_object=True but len(ArgMap)={len(self)}.")
+        key = list(self)[0]
+        if key != (None, None):
+            raise ArgMapError(f"ArgMap.single_object=True but key={key}; expected (None, None).")
+
+    def _check_single_arg(self):
+        shapes = {}
+        for key in self:
+            if np.issubdtype(type(key[1]), int):
+                par_key_type = int
+            else:
+                if not isinstance(key[1], tuple):
+                    raise ArgMapError(f"Invalid key {key} in ArgMap; expected (None, tuple[int]).")
+                if not all((np.issubdtype(type(k), int) for k in key[1])):
+                    raise ArgMapError(
+                        f"Invalid entries in parameter index in ArgMap: {key[1]}; "
+                        "expected integers."
+                    )
+                par_key_type = len(key[1])
+            if shapes.setdefault(None, par_key_type) != par_key_type:
+                raise ArgMapError("Inconsistent keys in ArgMap for the only argument index.")
+
+    def _check_multiple_args(self):
+        shapes = {}
+        for key in self:
+            if not np.issubdtype(type(key[0]), int):
+                raise ArgMapError(f"Invalid argument index {key[0]}; expected integer.")
+            if np.issubdtype(type(key[1]), int):
+                par_key_type = int
+            elif key[1] is None:
+                par_key_type = None
+            else:
+                if not isinstance(key[1], tuple):
+                    raise ArgMapError(f"Invalid key {key} in ArgMap; expected (int, tuple[int]).")
+                if not all((np.issubdtype(type(k), int) for k in key[1])):
+                    raise ArgMapError(
+                        f"Invalid entries in parameter index in ArgMap: {key[1]}; "
+                        "expected integers."
+                    )
+                par_key_type = len(key[1])
+            if shapes.setdefault(key[0], par_key_type) != par_key_type:
+                raise ArgMapError(f"Inconsistent keys in ArgMap for argument with index {key[0]}")
+
+
+# Todo: figure out behaviour for keys = {(0, 1), (2, 3), (1, 2)}
+#       - with single_arg=True -> single array-valued argument
+#       - with single_arg=False -> pairs of argument and param indices

--- a/pennylane/fourier/spectrum.py
+++ b/pennylane/fourier/spectrum.py
@@ -31,7 +31,7 @@ def _get_spectrum(op, decimals=8):
     We only compute non-negative frequencies in this subroutine.
 
     Args:
-        op (~pennylane.operation.Operation): :class:`~.pennylane.Operation` to extract 
+        op (~pennylane.operation.Operation): :class:`~.pennylane.Operation` to extract
             the frequencies for
         decimals (int): Number of decimal places to round the frequencies to
 
@@ -168,7 +168,7 @@ def spectrum(qnode, argnum=None, encoding_gates=None, decimals=5):
         That is, a parameter that does not control any gate has the spectrum ``[0]``.
 
     The returned spectrum is an ``~.pennylane.argmap.ArgMap`` with the frequency spectra as
-    values. See the 
+    values. See the
     `ArgMap documentation <https://pennylane.readthedocs.io/en/stable/code/api/pennylane.argmap.ArgMap.html>`_
     for details on its structure.
 
@@ -287,7 +287,7 @@ def spectrum(qnode, argnum=None, encoding_gates=None, decimals=5):
         of the circuit.
 
     Above, we selected all input-encoding parameters for the spectrum computation, using
-    the ``argnum`` keyword argument. We may also restrict the full analysis to a single 
+    the ``argnum`` keyword argument. We may also restrict the full analysis to a single
     QNode argument, again using ``argnum``:
 
     >>> res = spectrum(circuit, argnum=[0])(x, y, z, w)
@@ -394,7 +394,7 @@ def spectrum(qnode, argnum=None, encoding_gates=None, decimals=5):
                     )
                 # Get the spectrum of the current operation
                 spec = _get_spectrum(op, decimals=decimals)
-                if len(class_jac.shape)==1:
+                if len(class_jac.shape) == 1:
                     jac_of_op = {None: jac_of_op}
                     par_ids = [None]
                 else:

--- a/pennylane/transforms/classical_jacobian.py
+++ b/pennylane/transforms/classical_jacobian.py
@@ -192,6 +192,7 @@ def classical_jacobian(qnode, argnum=None):
                 sub_args = args
             else:
                 sub_args = tuple((args[i] for i in argnum))
+            print(sub_args)
 
             with tf.GradientTape() as tape:
                 gate_params = classical_preprocessing(*args, **kwargs)

--- a/tests/fourier/test_spectrum.py
+++ b/tests/fourier/test_spectrum.py
@@ -18,40 +18,96 @@ import pytest
 import numpy as np
 import pennylane as qml
 from pennylane import numpy as pnp
-from pennylane.fourier.spectrum import spectrum, _join_spectra, _get_spectrum
+from pennylane.argmap import ArgMap
+from pennylane.fourier.spectrum import (
+    spectrum,
+    _join_spectra,
+    _get_spectrum,
+    _get_and_validate_classical_jacobian,
+)
+from pennylane.transforms import classical_jacobian
 
+def circuit_0(a):
+    [qml.RX(a, wires=0) for i in range(4)]
+    return qml.expval(qml.PauliZ(0))
+
+def circuit_1(a, b):
+    qml.RZ(-a / 3, wires=0)
+    qml.RX(a / 5, wires=1)
+    qml.CNOT(wires=[0, 1])
+    qml.RY(b * 2, wires=1)
+    qml.RZ(-b, wires=1)
+    return qml.expval(qml.PauliZ(0))
+
+def circuit_2(x):
+    [qml.RX(x[i], wires=0) for i in range(3)]
+    return qml.expval(qml.PauliZ(0))
+
+def circuit_3(x, y):
+    [qml.RX(0.1*(i+1)*x[i], wires=0) for i in range(3)]
+    for i in range(2):
+        [qml.RY((i+j)*y[i, j], wires=1) for j in range(2)]
+    return qml.expval(qml.PauliZ(0))
+
+def circuit_4(x, y):
+    perm_4 = ([2, 0, 1], [1, 2, 0, 3])
+    for i in perm_4[0]:
+        qml.RX(1.2*(i+1)*x[i], wires=0)
+    for j in perm_4[1]:
+        qml.RY(y[j // 2, j % 2], wires=1)
+    return qml.expval(qml.PauliZ(0))
+
+def circuit_5(x, y, z):
+    [qml.RX(i*x[i], wires=0) for i in range(3)]
+    qml.RZ(y[0, 1] - y[1, 0], wires=1)
+    qml.RY(z[0] + 0.2 * z[1], wires=1)
+    return qml.expval(qml.PauliZ(0))
+
+circuits = [circuit_0, circuit_1, circuit_2, circuit_3, circuit_4, circuit_5]
+
+a = 0.812
+b = -5.231
+x = np.array([0.1, -1.9, 0.7])
+y = np.array([[0.4, 5.5], [1.6, 5.1]])
+z = np.array([-1.9, -0.1, 0.49, 0.24])
+all_args = [(a,), (a, b), (x,), (x, y), (x, y), (x, y, z)]
+
+interfaces = [('tf', 'tensorflow'), ('torch',)*2, ('autograd', 'pennylane'), ('jax',)*2]
 
 class TestHelpers:
     @pytest.mark.parametrize(
         "spectrum1, spectrum2, expected",
         [
-            ([-1, 0, 1], [-1, 0, 1], [-2, -1, 0, 1, 2]),
-            ([-3, 0, 3], [-5, 0, 5], [-8, -5, -3, -2, 0, 2, 3, 5, 8]),
-            ([-2, -1, 0, 1, 2], [-1, 0, 1], [-3, -2, -1, 0, 1, 2, 3]),
-            ([-0.5, 0, 0.5], [-1, 0, 1], [-1.5, -1, -0.5, 0, 0.5, 1.0, 1.5]),
-            ([-0.5, 0, 0.5], [], [-0.5, 0, 0.5]),
-            ([], [-0.5, 0, 0.5], [-0.5, 0, 0.5]),
+            ({0, 1}, {0, 1}, [0, 1, 2]),
+            ({0, 3}, {0, 5}, [0, 2, 3, 5, 8]),
+            ({0, 1, 2}, {0, 1}, [0, 1, 2, 3]),
+            ({0, 0.5}, {0, 1}, [0, 0.5, 1.0, 1.5]),
+            ({0, 0.5}, {}, [0, 0.5]),
+            ({0, 0.5}, {0}, [0, 0.5]),
+            ({}, {0, 0.5}, [0, 0.5]),
+            ({0}, {0, 0.5}, [0, 0.5]),
         ],
     )
     def test_join_spectra(self, spectrum1, spectrum2, expected, tol):
         """Test that spectra are joined correctly."""
         joined = _join_spectra(spectrum1, spectrum2)
-        assert np.allclose(joined, expected, atol=tol, rtol=0)
+        assert np.allclose(sorted(joined), expected, atol=tol, rtol=0)
 
     @pytest.mark.parametrize(
         "op, expected",
         [
-            (qml.RX(0.1, wires=0), [-1, 0, 1]),  # generator is a class
-            (qml.RY(0.1, wires=0), [-1, 0, 1]),  # generator is a class
-            (qml.RZ(0.1, wires=0), [-1, 0, 1]),  # generator is a class
-            (qml.PhaseShift(0.5, wires=0), [-1, 0, 1]),  # generator is an array
-            (qml.ControlledPhaseShift(0.5, wires=[0, 1]), [-1, 0, 1]),  # generator is an array
+            (qml.RX(0.1, wires=0), [0, 1]),  # generator is a class
+            (qml.RY(0.1, wires=0), [0, 1]),  # generator is a class
+            (qml.RZ(0.1, wires=0), [0, 1]),  # generator is a class
+            (qml.PhaseShift(0.5, wires=0), [0, 1]),  # generator is an array
+            (qml.CRX(0.2, wires=[0, 1]), [0, 0.5, 1]),  # generator is an array
+            (qml.ControlledPhaseShift(0.5, wires=[0, 1]), [0, 1]),  # generator is an array
         ],
     )
     def test_get_spectrum(self, op, expected, tol):
         """Test that the spectrum is correctly extracted from an operator."""
         spec = _get_spectrum(op)
-        assert np.allclose(spec, expected, atol=tol, rtol=0)
+        assert np.allclose(sorted(spec), expected, atol=tol, rtol=0)
 
     def test_get_spectrum_complains_no_generator(self):
         """Test that an error is raised if the operator has no generator defined."""
@@ -63,6 +119,11 @@ class TestHelpers:
         # CNOT is an operation where generator is an abstract property
         with pytest.raises(ValueError, match="Generator of operation"):
             _get_spectrum(qml.CNOT(wires=[0, 1]))
+
+
+
+
+
 
 
 class TestCircuits:
@@ -79,37 +140,38 @@ class TestCircuits:
         def circuit(x):
             for l in range(n_layers):
                 for i in range(n_qubits):
-                    qml.RX(x, wires=i, id="x")
+                    qml.RX(x, wires=i)
                     qml.RY(0.4, wires=i)
             return qml.expval(qml.PauliZ(wires=0))
 
         res = spectrum(circuit)(0.1)
         expected_degree = n_qubits * n_layers
-        assert np.allclose(res["x"], range(-expected_degree, expected_degree + 1))
+        assert np.allclose(res[0], range(-expected_degree, expected_degree + 1))
 
-    def test_encoding_gates(self):
+    def test_argnum(self):
         """Test that the spectrum contains the ids provided in encoding_gates, or
         all ids if encoding_gates is None."""
 
         dev = qml.device("default.qubit", wires=1)
 
         @qml.qnode(dev)
-        def circuit(x):
-            qml.RX(x, wires=0, id="x")
-            qml.RY(0.4, wires=0, id="other")
+        def circuit(x, y):
+            qml.RX(x, wires=0)
+            qml.RY(y, wires=0)
             return qml.expval(qml.PauliZ(wires=0))
+        x, y = [0.2, 0.1]
 
-        res = spectrum(circuit, encoding_gates=["x"])(0.1)
-        assert res == {"x": [-1.0, 0.0, 1.0]}
+        res = spectrum(circuit, argnum=[0])(x, y)
+        assert res == ArgMap({0: [-1.0, 0.0, 1.0]})
 
-        res = spectrum(circuit, encoding_gates=["x", "other"])(0.1)
-        assert res == {"x": [-1.0, 0.0, 1.0], "other": [-1.0, 0.0, 1.0]}
+        res = spectrum(circuit, argnum=[0, 1])(x, y)
+        assert res == ArgMap({0: [-1.0, 0.0, 1.0], 1: [-1.0, 0.0, 1.0]})
 
-        res = spectrum(circuit)(0.1)
-        assert res == {"x": [-1.0, 0.0, 1.0], "other": [-1.0, 0.0, 1.0]}
+        res = spectrum(circuit)(x, y)
+        assert res == ArgMap({0: [-1.0, 0.0, 1.0], 1: [-1.0, 0.0, 1.0]})
 
-        res = spectrum(circuit, encoding_gates=["a"])(0.1)
-        assert res == {"a": []}
+        with pytest.raises(ValueError, match="Could not compute Jacobian"):
+            res = spectrum(circuit, argnum=[3])(x, y)
 
     def test_spectrum_changes_with_qnode_args(self):
         """Test that the spectrum changes per call if a qnode argument changes the
@@ -118,18 +180,19 @@ class TestCircuits:
         dev = qml.device("default.qubit", wires=3)
 
         @qml.qnode(dev)
-        def circuit(last_gate):
-            qml.RX(0.1, wires=0, id="x")
-            qml.RX(0.2, wires=1, id="x")
+        def circuit(x, last_gate=False):
+            qml.RX(x, wires=0)
+            qml.RX(x, wires=1)
             if last_gate:
-                qml.RX(0.3, wires=2, id="x")
+                qml.RX(x, wires=2)
             return qml.expval(qml.PauliZ(wires=0))
 
-        res_true = spectrum(circuit)(True)
-        assert np.allclose(res_true["x"], range(-3, 4))
+        x = 0.9
+        res_true = spectrum(circuit, argnum=[0])(x, last_gate=True)
+        assert np.allclose(res_true[0], range(-3, 4))
 
-        res_false = spectrum(circuit)(False)
-        assert np.allclose(res_false["x"], range(-2, 3))
+        res_false = spectrum(circuit, argnum=[0])(x, last_gate=False)
+        assert np.allclose(res_false[0], range(-2, 3))
 
     def test_input_gates_not_of_correct_form(self):
         """Test that an error is thrown if gates marked as encoding gates
@@ -138,69 +201,105 @@ class TestCircuits:
         dev = qml.device("default.qubit", wires=3)
 
         @qml.qnode(dev)
-        def circuit():
-            qml.RX(0.1, wires=0, id="x")
-            qml.Rot(0.2, 0.3, 0.4, wires=1, id="x")
+        def circuit(x):
+            qml.RX(x, wires=0)
+            qml.Rot(0.2, x, 0.4, wires=1)
             return qml.expval(qml.PauliZ(wires=0))
 
         with pytest.raises(ValueError, match="Can only consider one-parameter gates"):
-            spectrum(circuit)()
+            spectrum(circuit)(1.5)
 
 
 def circuit(x, w):
     """Test circuit"""
     for l in range(2):
         for i in range(3):
-            qml.RX(x[i], wires=0, id="x" + str(i))
+            qml.RX(x[i], wires=0)
             qml.RY(w[l][i], wires=0)
             qml.CNOT(wires=[0, 1])
             qml.CNOT(wires=[1, 2])
-    qml.RZ(x[0], wires=0, id="x0")
+    qml.RZ(x[0], wires=0)
     return qml.expval(qml.PauliZ(wires=0))
 
 
-expected_result = {
-    "x0": [-3.0, -2.0, -1.0, 0.0, 1.0, 2.0, 3.0],
-    "x1": [-2.0, -1.0, 0.0, 1.0, 2.0],
-    "x2": [-2.0, -1.0, 0.0, 1.0, 2.0],
-}
+expected_result = ArgMap({
+    (0, (0,)): [-3.0, -2.0, -1.0, 0.0, 1.0, 2.0, 3.0],
+    (0, (1,)): [-2.0, -1.0, 0.0, 1.0, 2.0],
+    (0, (2,)): [-2.0, -1.0, 0.0, 1.0, 2.0],
+})
 
 
-class TestInterfaces:
-    """Test that inputs are correctly identified and spectra computed in
-    all interfaces."""
+class TestAutograd:
+
+    @pytest.mark.parametrize("circuit, args", zip(circuits, all_args))
+    def test_jacobian_validation(self, circuit, args):
+        dev = qml.device("default.qubit", wires=2)
+        qnode = qml.QNode(circuit, dev, interface="autograd")
+        class_jac = classical_jacobian(qnode, argnum=list(range(len(args))))(*args)
+        validated_class_jac = _get_and_validate_classical_jacobian(qnode, argnum=list(range(len(args))), args=args, kwargs={})
+        if isinstance(class_jac, tuple):
+            assert all((np.allclose(_jac, val_jac) for _jac, val_jac in zip(class_jac, validated_class_jac)))
+        else:
+            assert np.allclose(class_jac, validated_class_jac)
 
     def test_integration_autograd(self):
         """Test that the spectra of a circuit is calculated correctly
         in the autograd interface."""
 
-        x = pnp.array([1.0, 2.0, 3.0], requires_grad=False)
-        w = pnp.array([[-1, -2, -3], [-4, -5, -6]], requires_grad=True)
+        x = pnp.array([1.0, 2.0, 3.0])
+        w = pnp.array([[-1, -2, -3], [-4, -5, -6]])
 
         dev = qml.device("default.qubit", wires=3)
         qnode = qml.QNode(circuit, dev, interface="autograd")
 
-        res = spectrum(qnode)(x, w)
-        for (k1, v1), (k2, v2) in zip(res.items(), expected_result.items()):
-            assert k1 == k2
-            assert v1 == v2
+        res = spectrum(qnode, argnum=0)(x, w)
+        assert res
+        assert res==expected_result
+
+class TestTorch:
+
+    @pytest.mark.parametrize("circuit, args", zip(circuits, all_args))
+    def test_jacobian_validation(self, circuit, args):
+        torch = pytest.importorskip("torch")
+        args = tuple((torch.tensor(arg) for arg in args))
+        dev = qml.device("default.qubit", wires=2)
+        qnode = qml.QNode(circuit, dev, interface="torch")
+        class_jac = classical_jacobian(qnode)(*args)
+        validated_class_jac = _get_and_validate_classical_jacobian(qnode, argnum=list(range(len(args))), args=args, kwargs={})
+        if isinstance(class_jac, tuple):
+            assert all((np.allclose(_jac, val_jac) for _jac, val_jac in zip(class_jac, validated_class_jac)))
+        else:
+            assert np.allclose(class_jac, validated_class_jac)
 
     def test_integration_torch(self):
         """Test that the spectra of a circuit is calculated correctly
         in the torch interface."""
 
         torch = pytest.importorskip("torch")
-        x = torch.tensor([1.0, 2.0, 3.0], requires_grad=True)
-        w = torch.tensor([[-1, -2, -3], [-4, -5, -6]], requires_grad=False)
+        x = torch.tensor([1.0, 2.0, 3.0])
+        w = torch.tensor([[-1, -2, -3], [-4, -5, -6]], dtype=float)
 
         dev = qml.device("default.qubit", wires=3)
         qnode = qml.QNode(circuit, dev, interface="torch")
 
-        res = spectrum(qnode)(x, w)
+        res = spectrum(qnode, argnum=0)(x, w)
         assert res
-        for (k1, v1), (k2, v2) in zip(res.items(), expected_result.items()):
-            assert k1 == k2
-            assert v1 == v2
+        assert res==expected_result
+
+class TestTensorflow:
+
+    @pytest.mark.parametrize("circuit, args", zip(circuits, all_args))
+    def test_jacobian_validation(self, circuit, args):
+        tf = pytest.importorskip("tensorflow")
+        args = tuple((tf.Variable(arg, dtype=tf.double) for arg in args))
+        dev = qml.device("default.qubit", wires=2)
+        qnode = qml.QNode(circuit, dev, interface="tf")
+        class_jac = classical_jacobian(qnode)(*args)
+        validated_class_jac = _get_and_validate_classical_jacobian(qnode, argnum=list(range(len(args))), args=args, kwargs={})
+        if isinstance(class_jac, tuple):
+            assert all((np.allclose(_jac, val_jac) for _jac, val_jac in zip(class_jac, validated_class_jac)))
+        else:
+            assert np.allclose(class_jac, validated_class_jac)
 
     def test_integration_tf(self):
         """Test that the spectra of a circuit is calculated correctly
@@ -211,13 +310,11 @@ class TestInterfaces:
         qnode = qml.QNode(circuit, dev, interface="tf")
 
         x = tf.Variable([1.0, 2.0, 3.0])
-        w = tf.constant([[-1, -2, -3], [-4, -5, -6]])
-        res = spectrum(qnode)(x, w)
+        w = tf.constant([[-1, -2, -3], [-4, -5, -6]], dtype=float)
+        res = spectrum(qnode, argnum=[0])(x, w)
 
         assert res
-        for (k1, v1), (k2, v2) in zip(res.items(), expected_result.items()):
-            assert k1 == k2
-            assert v1 == v2
+        assert res==expected_result
 
     def test_integration_jax(self):
         """Test that the spectra of a circuit is calculated correctly
@@ -232,9 +329,7 @@ class TestInterfaces:
         dev = qml.device("default.qubit", wires=3)
         qnode = qml.QNode(circuit, dev, interface="jax")
 
-        res = spectrum(qnode)(x, w)
+        res = spectrum(qnode, argnum=0)(x, w)
 
         assert res
-        for (k1, v1), (k2, v2) in zip(res.items(), expected_result.items()):
-            assert k1 == k2
-            assert v1 == v2
+        assert res==expected_result


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      test directory!

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `doc/releases/changelog-dev.md` file, summarizing the
      change, and including a link back to the PR.

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
This PR generalizes the `qml.fourier.spectrum` to more general circuits. It is part of the series of PRs that replace #1635.
After reconsiderations, this is _not_ implemented with a separate `ArgMap` class (see #1653).

**Description of the Change:**
The spectrum is now computed with respect to _QNode arguments_, and no longer with respect to _gate arguments_. This allows to obtain the function structure with respect to parameters that actually are controlled directly by the user.
Classical preprocessing between QNode and gate parameters is taken into account and factored into the spectrum.
In order for the spectrum to actually describe the QNode fully, the return value needs to be an expectation value/a sum of expectation values, and the preprocessing needs to be linear.
`spectrum` checks whether the Jacobian is constant across `num_pos+1` many points (including the original `args` and `num_pos` additional, random `args`). This does not 100% guarantee linearity of the processing but makes it very unlikely that non-linear processing is overlooked. The test can be deactivated by setting `num_pos=0`.

The arguments and elements of arguments for which the spectrum is computed are controlled by `encoding_args`, which is a `dict` with argument names as keys and a list of index tuples for the respective argument as values. The value may be replaced by an `Ellipsis`, in which case all elements of the argument are considered. If `encoding_args` is a set of argument `names` instead, it is interpreted like `{name: ... for name in names}`.
Alternatively, the arguments to compute the spectrum for can be chosen by their index in the function signature via `argnum`.
If neither `encoding_args` nor `argnum` are provided, those arguments of the QNode that do not have a default defined (and all their elements, if they are array-valued) are considered.

**Benefits:**
More streamlined usage of the `spectrum` functionality on the level of QNodes instead of looking into a QNode.
No gate `id`s have to be assigned anymore.
Preprocessing of QNode arguments into gate arguments is taken into account both in the spectrum output and to exclude a large class of circuits that do yield a Fourier series in the sense considered by this function.

**Possible Drawbacks:**
This is a breaking change in multiple ways: The input arguments changed, the output format changed and the gate `id`s are no longer required or considered.
Also, the content of the output changed because preprocessing is included in the spectrum.

**Related GitHub Issues:**
#1635 
#1653