### PR TITLE
Turn to passing JAX arrays to `jnp.allclose`

### DIFF
--- a/tests/devices/test_default_qubit_jax.py
+++ b/tests/devices/test_default_qubit_jax.py
@@ -372,7 +372,7 @@ class TestPassthruIntegration:
 
         grad = jax.jit(jax.grad(cost, argnums=(0, 1)))(a, b)
         expected = [jnp.sin(a) * jnp.cos(b), jnp.cos(a) * jnp.sin(b)]
-        assert jnp.allclose(grad, expected, atol=tol, rtol=0)
+        assert jnp.allclose(jnp.array(grad), jnp.array(expected), atol=tol, rtol=0)
 
     def test_backprop_gradient(self, tol):
         """Tests that the gradient of the qnode is correct"""
@@ -394,7 +394,7 @@ class TestPassthruIntegration:
         expected_grad = jnp.array(
             [-0.5 * jnp.sin(a) * (jnp.cos(b) + 1), 0.5 * jnp.sin(b) * (1 - jnp.cos(a))]
         )
-        assert jnp.allclose(res, expected_grad, atol=tol, rtol=0)
+        assert jnp.allclose(jnp.array(res), jnp.array(expected_grad), atol=tol, rtol=0)
 
     @pytest.mark.parametrize("operation", [qml.U3, qml.U3.decomposition])
     @pytest.mark.parametrize("diff_method", ["backprop"])


### PR DESCRIPTION
Due to a [breaking change in JAX v0.2.21](https://github.com/google/jax/releases/tag/jax-v0.2.21), some JAX NumPy functions expect array arguments. Such a function is `jnp.allclose`.

> Many more jax.numpy functions now require array-like inputs, and will error
if passed a list (#7747 #7802 #7907 ).
See #7737 for a discussion of the rationale behind this change.

This PR updates failing tests such that the arguments passed to `jnp.allclose` are JAX NumPy arrays.