### PR TITLE
Fixes a bug where batch transforms wouldn't work with templates

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -315,6 +315,10 @@
 * Fixes a bug in `default.mixed`, to ensure that returned probabilities are always non-negative.
   [(#1680)](https://github.com/PennyLaneAI/pennylane/pull/1680)
 
+* Fixes a bug where gradient transforms would fail to apply to QNodes
+  containing classical processing.
+  [(#)]()
+
 <h3>Documentation</h3>
 
 * Adds a link to https://pennylane.ai/qml/demonstrations.html in the navbar.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -317,7 +317,7 @@
 
 * Fixes a bug where gradient transforms would fail to apply to QNodes
   containing classical processing.
-  [(#)]()
+  [(#1699)](https://github.com/PennyLaneAI/pennylane/pull/1699)
 
 <h3>Documentation</h3>
 

--- a/pennylane/gradients/gradient_transform.py
+++ b/pennylane/gradients/gradient_transform.py
@@ -150,7 +150,7 @@ class gradient_transform(qml.batch_transform):
         # inside the QNode.
         hybrid = tkwargs.pop("hybrid", self.hybrid)
         _wrapper = super().default_qnode_wrapper(qnode, targs, tkwargs)
-        cjac_fn = qml.transforms.classical_jacobian(qnode)
+        cjac_fn = qml.transforms.classical_jacobian(qnode, expand_fn=gradient_expand)
 
         def jacobian_wrapper(*args, **kwargs):
             qjac = _wrapper(*args, **kwargs)

--- a/pennylane/transforms/classical_jacobian.py
+++ b/pennylane/transforms/classical_jacobian.py
@@ -19,7 +19,7 @@ import pennylane as qml
 from pennylane import numpy as np
 
 
-def classical_jacobian(qnode, argnum=None):
+def classical_jacobian(qnode, argnum=None, expand_fn=None):
     r"""Returns a function to extract the Jacobian
     matrix of the classical part of a QNode.
 
@@ -30,6 +30,8 @@ def classical_jacobian(qnode, argnum=None):
         qnode (pennylane.QNode): QNode to compute the (classical) Jacobian of
         argnum (int or Sequence[int]): indices of QNode arguments with respect to which
             the (classical) Jacobian is computed
+        expand_fn (None or function): an expansion function (if required) to be applied to the
+            QNode quantum tape before the classical Jacobian is computed
 
     Returns:
         function: Function which accepts the same arguments as the QNode.
@@ -137,7 +139,12 @@ def classical_jacobian(qnode, argnum=None):
         """Returns the trainable gate parameters for a given QNode input."""
         trainable_only = kwargs.pop("_trainable_only", True)
         qnode.construct(args, kwargs)
-        return qml.math.stack(qnode.qtape.get_parameters(trainable_only=trainable_only))
+        tape = qnode.qtape
+
+        if expand_fn is not None:
+            tape = expand_fn(tape)
+
+        return qml.math.stack(tape.get_parameters(trainable_only=trainable_only))
 
     if qnode.interface == "autograd":
 

--- a/pennylane/transforms/metric_tensor.py
+++ b/pennylane/transforms/metric_tensor.py
@@ -230,7 +230,11 @@ def qnode_execution_wrapper(self, qnode, targs, tkwargs):
         qnode = qnode.qnodes.qnodes[0]
 
     mt_fn = self.default_qnode_wrapper(qnode, targs, tkwargs)
-    cjac_fn = qml.transforms.classical_jacobian(qnode)
+
+    if isinstance(qnode, qml.beta.QNode):
+        cjac_fn = qml.transforms.classical_jacobian(qnode, expand_fn=self.expand_fn)
+    else:
+        cjac_fn = qml.transforms.classical_jacobian(qnode)
 
     def wrapper(*args, **kwargs):
         mt = mt_fn(*args, **kwargs)


### PR DESCRIPTION
**Context:** I discovered while hacking that batch transforms would not correctly apply to QNodes containing templates. This is because templates may perform classical computation, which the transform needs to take into account. However, the classical Jacobian computation was not using the same decomposition as the quantum component, resulting in a failure to perform the matrix multiplication due to a shape mismatch.

**Description of the Change:** Modifies the `classical_jacobian` function to use the same circuit decomposition as the quantum component.

**Benefits:** Batch transforms now work with templates.

**Possible Drawbacks:** n/a

**Related GitHub Issues:** n/a
