### PR TITLE
Fix circuit drawing for multiple measurements per wire with many observables

### DIFF
--- a/pennylane/circuit_graph.py
+++ b/pennylane/circuit_graph.py
@@ -507,7 +507,7 @@ class CircuitGraph:
 
         if self.max_simultaneous_measurements == 1:
 
-            # There is a single measurement
+            # There is a single measurement for every wire
             for wire in sorted(self._grid):
                 observables[wire] = list(
                     filter(
@@ -522,12 +522,16 @@ class CircuitGraph:
                     observables[wire] = [None]
         else:
 
-            # There are multiple measurements
-            for wire in sorted(self._grid):
-                mp_map = dict(zip(self.observables, range(self.max_simultaneous_measurements)))
+            # There are wire(s) with multiple measurements.
+            # We are creating a separate "visual block" at the end of the
+            # circuit for each observable and mapping observables with block
+            # indices.
+            num_observables = len(self.observables)
+            mp_map = dict(zip(self.observables, range(num_observables)))
 
+            for wire in sorted(self._grid):
                 # Initialize to None everywhere
-                observables[wire] = [None] * self.max_simultaneous_measurements
+                observables[wire] = [None] * num_observables
 
                 for op in self._grid[wire]:
                     if _is_returned_observable(op):

--- a/tests/circuit_drawer/test_circuit_drawer.py
+++ b/tests/circuit_drawer/test_circuit_drawer.py
@@ -806,6 +806,31 @@ class TestCircuitDrawerIntegration:
         )
         assert qnode.draw() == expected
 
+    def test_same_wire_multiple_measurements_many_obs(self):
+        """Test that drawing a QNode with multiple measurements on certain
+        wires works correctly when there are more observables than the number of
+        observables for any wire.
+        """
+        dev = qml.device("default.qubit", wires=4)
+
+        @qml.qnode(dev)
+        def qnode(x, y):
+            qml.RY(x, wires=0)
+            qml.Hadamard(0)
+            qml.RZ(y, wires=0)
+            return [
+                qml.expval(qml.PauliZ(0)),
+                qml.expval(qml.PauliZ(1)),
+                qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
+            ]
+
+        qnode(0.3, 0.2)
+
+        expected = (
+            " 0: ──RY(0.3)──H──RZ(0.2)──┤ ⟨Z⟩ ┤     ╭┤ ⟨Z ⊗ Z⟩ \n"
+            + " 1: ───────────────────────┤     ┤ ⟨Z⟩ ╰┤ ⟨Z ⊗ Z⟩ \n"
+        )
+        assert qnode.draw() == expected
 
 class TestWireOrdering:
     """Tests for wire ordering functionality"""


### PR DESCRIPTION
**Context**

A recent addition has added support for drawing circuits with multiple measurements per wire. An edge case related to having many measurements compared to the number of measurements on any wire was not considered.

**Changes**

Changes to using an internal map of observables by considering the number of all observables as opposed to the maximum number of observables on any wire.

**Related issues**
Closes #1701.