### PR TITLE
Fix GPU usage with `default.qubit.torch`

### DIFF
--- a/pennylane/devices/default_qubit_torch.py
+++ b/pennylane/devices/default_qubit_torch.py
@@ -176,8 +176,15 @@ class DefaultQubitTorch(DefaultQubit):
     _norm = staticmethod(torch.norm)
     _flatten = staticmethod(torch.flatten)
 
-    def __init__(self, wires, *, shots=None, analytic=None, torch_device="cpu"):
-        self._torch_device = torch_device
+    def __init__(self, wires, *, shots=None, analytic=None, torch_device=None):
+
+        if torch_device is None:
+            self._torch_device = "cpu"
+            self._user_def_torch_device = False
+        else:
+            self._torch_device = torch_device
+            self._user_def_torch_device = True
+
         super().__init__(wires, shots=shots, cache=0, analytic=analytic)
 
         # Move state to torch device (e.g. CPU, GPU, XLA, ...)

--- a/pennylane/devices/default_qubit_torch.py
+++ b/pennylane/devices/default_qubit_torch.py
@@ -185,8 +185,7 @@ class DefaultQubitTorch(DefaultQubit):
         self._state = self._state.to(self._torch_device)
         self._pre_rotated_state = self._state
 
-    @staticmethod
-    def _asarray(a, dtype=None):
+    def _asarray(self, a, dtype=None):
         if isinstance(a, list):
             # Handle unexpected cases where we don't have a list of tensors
             if not isinstance(a[0], torch.Tensor):
@@ -197,7 +196,11 @@ class DefaultQubitTorch(DefaultQubit):
             res = torch.cat([torch.reshape(i, (-1,)) for i in res], dim=0)
         else:
             res = torch.as_tensor(a, dtype=dtype)
+
+        res = torch.as_tensor(res, device=self._torch_device)
         return res
+
+    _cast = _asarray
 
     @staticmethod
     def _dot(x, y):
@@ -208,9 +211,6 @@ class DefaultQubitTorch(DefaultQubit):
                 return torch.tensordot(x.to(y.device), y, dims=1)
 
         return torch.tensordot(x, y, dims=1)
-
-    def _cast(self, a, dtype=None):
-        return torch.as_tensor(self._asarray(a, dtype=dtype), device=self._torch_device)
 
     @staticmethod
     def _reduce_sum(array, axes):

--- a/pennylane/devices/default_qubit_torch.py
+++ b/pennylane/devices/default_qubit_torch.py
@@ -100,7 +100,7 @@ class DefaultQubitTorch(DefaultQubit):
     >>> res = circuit(weights)
     >>> res.backward()
     >>> print(weights.grad)
-    tensor([-2.2527e-01, -1.0086e+00,  1.3878e-17])
+    tensor([-2.2527e-01, -1.0086e+00,  2.9919e-17], device='cuda:0')
 
 
     There are a couple of things to keep in mind when using the ``"backprop"``

--- a/pennylane/qnode.py
+++ b/pennylane/qnode.py
@@ -671,8 +671,8 @@ class QNode:
             if any_op_uses_cuda and self.device._torch_device == "cpu":
 
                 if self.device._user_def_torch_device:
-                    warnings.warn("Although the CPU was requested as the Torch " \
-                            "device, some tensors are using the GPU. Pass "
+                    warnings.warn("The requested Torch device was the CPU, " \
+                            "but some tensors are using the GPU. Pass " \
                             "torch_device='cuda' when creating the PennyLane device " \
                             "to use the GPU.")
                 else:

--- a/pennylane/qnode.py
+++ b/pennylane/qnode.py
@@ -396,8 +396,10 @@ class QNode:
             # device is analytic and has child devices that support backpropagation natively
 
             if interface in backprop_devices:
-                # TODO: need a better way of passing existing device init options
-                # to a new device?
+                # TODO: need a better way of passing existing device init
+                # options to a new device? Note: some device init options may
+                # be circuit dependent (e.g., GPU usage based on the gate
+                # parameters for Torch). See update_device_options method.
                 device = qml.device(
                     backprop_devices[interface],
                     wires=device.wires,
@@ -654,6 +656,30 @@ class QNode:
         if self.diff_options["method"] == "backprop":
             params = self.qtape.get_parameters(trainable_only=False)
             self.qtape.trainable_params = qml.math.get_trainable_indices(params)
+
+        self.update_device_options()
+
+    def update_device_options(self):
+        """Update the device options once the QNode has been constructed."""
+
+        if self.device.short_name == 'default.qubit.torch':
+
+            # Check if we should be using CUDA
+            ops_and_obs = self.qtape.operations + self.qtape.observables
+            any_op_uses_cuda = any(data.is_cuda for op in ops_and_obs for data in op.data)
+
+            if any_op_uses_cuda and self.device._torch_device == "cpu":
+
+                if self.device._user_def_torch_device:
+                    warnings.warn("Although the CPU was requested as the Torch " \
+                            "device, some tensors are using the GPU. Pass "
+                            "torch_device='cuda' when creating the PennyLane device " \
+                            "to use the GPU.")
+                else:
+
+                    # As there are tensors using the GPU, switch the underlying
+                    # torch device
+                    self.device._torch_device = "cuda"
 
     def __call__(self, *args, **kwargs):
 

--- a/tests/qnn/test_qnn_torch.py
+++ b/tests/qnn/test_qnn_torch.py
@@ -411,8 +411,13 @@ class TestTorchLayer:
                 qlayer = qml.qnn.TorchLayer(circuit, weight_shapes)
 
                 x = torch.rand((5, n_qubits), dtype=torch.float64).to(torch.device("cuda"))
-                loss = torch.sum(qlayer(x)).squeeze()
+                res = qlayer(x)
+                assert res.is_cuda
+
+                loss = torch.sum(res).squeeze()
                 loss.backward()
+                assert loss.is_cuda
+
             except Exception:
                 pytest.fail("Exception raised in torch CUDA backward")
 

--- a/tests/tape/test_qnode.py
+++ b/tests/tape/test_qnode.py
@@ -1187,6 +1187,38 @@ class TestIntegration:
 
         assert np.allclose(res, expected, atol=tol, rtol=0)
 
+    def test_switched_to_cuda(self):
+        """Test that if any tensor passed to operators is on the GPU then CUDA
+        is set internally as a device option for 'default.qubit.torch'."""
+        torch = pytest.importorskip("torch")
+        if not torch.cuda.is_available():
+            pytest.skip("Cuda device not available")
+        else:
+            n_qubits = 3
+            n_layers = 1
+
+            dev = qml.device("default.qubit", wires=n_qubits)
+
+            @qml.qnode(dev)
+            def circuit(inputs, weights):
+                qml.templates.AngleEmbedding(inputs, wires=range(n_qubits))
+                qml.templates.BasicEntanglerLayers(weights, wires=range(n_qubits))
+                return [qml.expval(qml.PauliZ(wires=i)) for i in range(n_qubits)]
+
+            weight_shapes = {"weights": (n_layers, n_qubits)}
+
+            qlayer = qml.qnn.TorchLayer(circuit, weight_shapes)
+
+            x = torch.rand((5, n_qubits), dtype=torch.float64).to(torch.device("cuda"))
+            res = qlayer(x)
+            assert circuit.device.short_name == 'default.qubit.torch'
+            assert circuit.device._torch_device == 'cuda'
+            assert res.is_cuda
+
+            loss = torch.sum(res).squeeze()
+            loss.backward()
+            assert loss.is_cuda
+
 
 class TestMutability:
     """Test for QNode immutability"""

--- a/tests/tape/test_qnode.py
+++ b/tests/tape/test_qnode.py
@@ -1251,6 +1251,8 @@ class TestIntegration:
             with pytest.warns(UserWarning, match=warn_sub_text):
                 qlayer(arr)
 
+            assert qnode.device._torch_device == "cpu"
+
 class TestMutability:
     """Test for QNode immutability"""
 


### PR DESCRIPTION
**Context**

In PennyLane v0.18.0, the `default.qubit.torch` device was added. This device is now being used by QNodes for backpropagation with Torch tensors. The QNode, however, doesn't have a logic for checking what the `torch_device` keyword argument should be when creating a backdrop device.

Therefore, there may be issues with passing Torch tensors using CUDA as QNode arguments (see #1688). This could be aided by defining `dev = qml.device('default.qubit.torch', wires=3, torch_device='cuda')` explicitly.

Further to this, the `default.qubit.torch` device only considers the Torch device 

**Changes**

1. Changes the `_as_array` method to always put the output on the Torch device specified internally;
2. Changes the QNode to specify `torch_device='cuda'` internally when creating a `dev = qml.device('default.qubit.torch', wires=3)` device for backpropagation.

**Related issues**

Closes https://github.com/PennyLaneAI/pennylane/issues/1688.