### PR TITLE
Renamed `qml.Interferometer` to `qml.InterferometerUnitary`

### DIFF
--- a/doc/introduction/operations.rst
+++ b/doc/introduction/operations.rst
@@ -262,7 +262,7 @@ CV Gates
     ~pennylane.CrossKerr
     ~pennylane.CubicPhase
     ~pennylane.Displacement
-    ~pennylane.Interferometer
+    ~pennylane.InterferometerUnitary
     ~pennylane.Kerr
     ~pennylane.QuadraticPhase
     ~pennylane.Rotation

--- a/pennylane/circuit_drawer/representation_resolver.py
+++ b/pennylane/circuit_drawer/representation_resolver.py
@@ -420,7 +420,7 @@ class RepresentationResolver:
             "FockDensityMatrix",
             "FockStateVector",
             "QubitStateVector",
-            "Interferometer",
+            "InterferometerUnitary",
         }:
             representation = name + RepresentationResolver._format_matrix_arguments(
                 op.data, "M", self.matrix_cache

--- a/pennylane/devices/default_gaussian.py
+++ b/pennylane/devices/default_gaussian.py
@@ -305,8 +305,8 @@ def controlled_phase(s):
     return S
 
 
-def interferometer(U):
-    """Interferometer
+def interferometer_unitary(U):
+    """InterferometerUnitary
 
     Args:
         U (array): unitary matrix
@@ -668,7 +668,7 @@ class DefaultGaussian(Device):
         "SqueezedState": squeezed_state,
         "ThermalState": thermal_state,
         "GaussianState": gaussian_state,
-        "Interferometer": interferometer,
+        "InterferometerUnitary": interferometer_unitary,
     }
 
     _observable_map = {

--- a/pennylane/ops/cv.py
+++ b/pennylane/ops/cv.py
@@ -553,8 +553,8 @@ class CubicPhase(CVOperation):
         return CubicPhase(-self.parameters[0], wires=self.wires, do_queue=do_queue)
 
 
-class Interferometer(CVOperation):
-    r"""pennylane.Interferometer(U, wires)
+class InterferometerUnitary(CVOperation):
+    r"""pennylane.InterferometerUnitary(U, wires)
     A linear interferometer transforming the bosonic operators according to
     the unitary matrix :math:`U`.
 
@@ -588,15 +588,6 @@ class Interferometer(CVOperation):
         wires (Sequence[int] or int): the wires the operation acts on
     """
 
-    def __init__(self, *args, **kwargs):
-        warnings.warn(
-            "'Interferometer' is deprecated and will be renamed 'InterferometerUnitary'",
-            UserWarning,
-            stacklevel=2,
-        )
-
-        super().__init__(*args, **kwargs)
-
     num_params = 1
     num_wires = AnyWires
     par_domain = "A"
@@ -618,7 +609,7 @@ class Interferometer(CVOperation):
 
     def adjoint(self, do_queue=False):
         U = self.parameters[0]
-        return Interferometer(qml_math.T(qml_math.conj(U)), wires=self.wires, do_queue=do_queue)
+        return InterferometerUnitary(qml_math.T(qml_math.conj(U)), wires=self.wires, do_queue=do_queue)
 
 
 # =============================================================================
@@ -1170,7 +1161,7 @@ ops = {
     "Squeezing",
     "TwoModeSqueezing",
     "CubicPhase",
-    "Interferometer",
+    "InterferometerUnitary",
     "CatState",
     "CoherentState",
     "FockDensityMatrix",

--- a/tests/circuit_drawer/test_representation_resolver.py
+++ b/tests/circuit_drawer/test_representation_resolver.py
@@ -139,8 +139,8 @@ class TestRepresentationResolver:
             (qml.CrossKerr(3.14, wires=[1, 2]), 1, "CrossKerr(3.14)"),
             (qml.CrossKerr(3.14, wires=[1, 2]), 2, "CrossKerr(3.14)"),
             (qml.CubicPhase(3.14, wires=[1]), 1, "V(3.14)"),
-            (qml.Interferometer(np.eye(4), wires=[1, 3]), 1, "Interferometer(M0)"),
-            (qml.Interferometer(np.eye(4), wires=[1, 3]), 3, "Interferometer(M0)"),
+            (qml.InterferometerUnitary(np.eye(4), wires=[1, 3]), 1, "InterferometerUnitary(M0)"),
+            (qml.InterferometerUnitary(np.eye(4), wires=[1, 3]), 3, "InterferometerUnitary(M0)"),
             (qml.CatState(3.14, 2.14, 1, wires=[1]), 1, "CatState(3.14, 2.14, 1)"),
             (qml.CoherentState(3.14, 2.14, wires=[1]), 1, "CoherentState(3.14, 2.14)"),
             (
@@ -280,8 +280,8 @@ class TestRepresentationResolver:
             (qml.CrossKerr(3.14, wires=[1, 2]), 1, "CrossKerr(3.14)"),
             (qml.CrossKerr(3.14, wires=[1, 2]), 2, "CrossKerr(3.14)"),
             (qml.CubicPhase(3.14, wires=[1]), 1, "V(3.14)"),
-            (qml.Interferometer(np.eye(4), wires=[1, 3]), 1, "Interferometer(M0)"),
-            (qml.Interferometer(np.eye(4), wires=[1, 3]), 3, "Interferometer(M0)"),
+            (qml.InterferometerUnitary(np.eye(4), wires=[1, 3]), 1, "InterferometerUnitary(M0)"),
+            (qml.InterferometerUnitary(np.eye(4), wires=[1, 3]), 3, "InterferometerUnitary(M0)"),
             (qml.CatState(3.14, 2.14, 1, wires=[1]), 1, "CatState(3.14, 2.14, 1)"),
             (qml.CoherentState(3.14, 2.14, wires=[1]), 1, "CoherentState(3.14, 2.14)"),
             (

--- a/tests/devices/test_default_gaussian.py
+++ b/tests/devices/test_default_gaussian.py
@@ -412,7 +412,7 @@ class TestDefaultGaussianDevice:
                     p = [cov, mu]
                     w = list(range(2))
                     expected_out = [cov, mu]
-                elif gate_name == "Interferometer":
+                elif gate_name == "InterferometerUnitary":
                     w = list(range(2))
                     p = [U]
                     S = fn(*p)
@@ -464,12 +464,12 @@ class TestDefaultGaussianDevice:
 
         with pytest.raises(ValueError, match="Incorrect number of subsystems"):
             p = U
-            gaussian_dev.apply("Interferometer", wires=Wires([0]), par=[p])
+            gaussian_dev.apply("InterferometerUnitary", wires=Wires([0]), par=[p])
 
         with pytest.raises(qml.wires.WireError, match="Did not find some of the wires"):
             p = U2
             # dev = DefaultGaussian(wires=4, shots=1000, hbar=hbar)
-            gaussian_dev.apply("Interferometer", wires=Wires([0, 1, 2]), par=[p])
+            gaussian_dev.apply("InterferometerUnitary", wires=Wires([0, 1, 2]), par=[p])
 
     def test_expectation(self, tol):
         """Test that expectation values are calculated correctly"""
@@ -819,7 +819,7 @@ class TestDefaultGaussianIntegration:
 
         if g == "GaussianState":
             p = [np.diag([0.5234] * 4), np.array([0.432, 0.123, 0.342, 0.123])]
-        elif g == "Interferometer":
+        elif g == "InterferometerUnitary":
             p = [U]
         else:
             p = [0.432423, -0.12312, 0.324, 0.763][: op.num_params]

--- a/tests/gradients/test_parameter_shift_cv.py
+++ b/tests/gradients/test_parameter_shift_cv.py
@@ -661,7 +661,7 @@ class TestExpectationQuantumGradients:
             assert np.allclose(grad_A, grad_F, atol=tol, rtol=0)
 
     @pytest.mark.parametrize("t", [0, 1])
-    def test_interferometer(self, t, tol):
+    def test_interferometer_unitary(self, t, tol):
         """An integration test for CV gates that support analytic differentiation
         if succeeding the gate to be differentiated, but cannot be differentiated
         themselves (for example, they may be Gaussian but accept no parameters,
@@ -670,7 +670,7 @@ class TestExpectationQuantumGradients:
         This ensures that, assuming their _heisenberg_rep is defined, the quantum
         gradient analytic method can still be used, and returns the correct result.
 
-        Currently, the only such operation is qml.Interferometer. In the future,
+        Currently, the only such operation is qml.InterferometerUnitary. In the future,
         we may consider adding a qml.GaussianTransfom operator.
         """
 
@@ -690,7 +690,7 @@ class TestExpectationQuantumGradients:
             # @qml.qnode(dev)
             # def circuit(r, phi):
             #     qml.Displacement(r, phi, wires=0)
-            #     qml.Interferometer(U, wires=[0, 1])
+            #     qml.InterferometerUnitary(U, wires=[0, 1])
             #     return qml.expval(qml.X(0))
             #
             # r = 0.543
@@ -711,7 +711,7 @@ class TestExpectationQuantumGradients:
 
         with qml.tape.JacobianTape() as tape:
             qml.Displacement(0.543, 0, wires=0)
-            qml.Interferometer(U, wires=[0, 1])
+            qml.InterferometerUnitary(U, wires=[0, 1])
             qml.expval(qml.X(0))
 
         tape.trainable_params = {t}

--- a/tests/ops/test_cv_ops.py
+++ b/tests/ops/test_cv_ops.py
@@ -55,7 +55,7 @@ class TestCV:
             (cv.Displacement(2.004, 8.673, wires=0), 3),  # phi > 2pi
             (cv.Beamsplitter(0.456, -0.789, wires=[0, 2]), 5),
             (cv.TwoModeSqueezing(2.532, 1.778, wires=[1, 2]), 5),
-            (cv.Interferometer(np.array([[1, 1], [1, -1]]) * -1.0j / np.sqrt(2.0), wires=1), 5),
+            (cv.InterferometerUnitary(np.array([[1, 1], [1, -1]]) * -1.0j / np.sqrt(2.0), wires=1), 5),
             (cv.ControlledAddition(2.551, wires=[0, 2]), 5),
             (cv.ControlledPhase(2.189, wires=[3, 1]), 5),
         ],
@@ -69,14 +69,6 @@ class TestCV:
         np_testing.assert_allclose(res1, np.eye(size), atol=tol)
         np_testing.assert_allclose(res2, np.eye(size), atol=tol)
         assert op.wires == op_d.wires
-
-    def test_Interferometer_deprecation_warning(self):
-        """Tests whether a ``UserWarning`` is raised when ``Interferometer`` gate is used."""
-        with pytest.warns(
-            UserWarning,
-            match="'Interferometer' is deprecated and will be renamed 'InterferometerUnitary'",
-        ):
-            cv.Interferometer(np.array([[1, 1], [1, -1]]) * -1.0j / np.sqrt(2.0), wires=1)
 
     @pytest.mark.parametrize(
         "op",

--- a/tests/tape/test_cv_param_shift.py
+++ b/tests/tape/test_cv_param_shift.py
@@ -631,7 +631,7 @@ class TestExpectationQuantumGradients:
             assert np.allclose(grad_A, grad_F, atol=tol, rtol=0)
 
     @pytest.mark.parametrize("t", [0, 1])
-    def test_interferometer(self, t, tol):
+    def test_interferometer_unitary(self, t, tol):
         """An integration test for CV gates that support analytic differentiation
         if succeeding the gate to be differentiated, but cannot be differentiated
         themselves (for example, they may be Gaussian but accept no parameters,
@@ -640,7 +640,7 @@ class TestExpectationQuantumGradients:
         This ensures that, assuming their _heisenberg_rep is defined, the quantum
         gradient analytic method can still be used, and returns the correct result.
 
-        Currently, the only such operation is qml.Interferometer. In the future,
+        Currently, the only such operation is qml.InterferometerUnitary. In the future,
         we may consider adding a qml.GaussianTransfom operator.
         """
 
@@ -660,7 +660,7 @@ class TestExpectationQuantumGradients:
             # @qml.qnode(dev)
             # def circuit(r, phi):
             #     qml.Displacement(r, phi, wires=0)
-            #     qml.Interferometer(U, wires=[0, 1])
+            #     qml.InterferometerUnitary(U, wires=[0, 1])
             #     return qml.expval(qml.X(0))
 
             #
@@ -681,7 +681,7 @@ class TestExpectationQuantumGradients:
 
         with CVParamShiftTape() as tape:
             qml.Displacement(0.543, 0, wires=0)
-            qml.Interferometer(U, wires=[0, 1])
+            qml.InterferometerUnitary(U, wires=[0, 1])
             qml.expval(qml.X(0))
 
         tape._update_gradient_info()

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -57,7 +57,7 @@ class TestOperation:
 
         # fixed parameter values
         if test_class.par_domain == "A":
-            if test_class.__name__ == "Interferometer":
+            if test_class.__name__ == "InterferometerUnitary":
                 ww = list(range(2))
                 par = [
                     np.array(


### PR DESCRIPTION
**Context:**
`qml.Interferometer` has been renamed `qml.InterferometerUnitary` in order to distinguish it from `qml.templates.Interferometer`.

**Description of the Change:**
- Renamed `qml.Interferometer` to `qml.InterferometerUnitary` and updated references to it throughout the code base.
- Removed the deprecation warning regarding the renaming of the operation.
- Updated the test cases.

**Benefits:**
- Improves the distinction between the operation and the template.
- `qml.templates.Interferometer` can now be turned into an operation since the name conflict has been resolved.

**Related GitHub Issues:**
#1709
