### PR TITLE
Speed up QAOA with `expval(H)`

### DIFF
--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -468,8 +468,8 @@ class DefaultQubit(QubitDevice):
         Returns:
             float: returns the expectation value of the observable
         """
-        # intercept Hamiltonians here; in future, we want a logic that handles
-        # general observables that do not define eigenvalues
+        # intercept other Hamiltonians
+        # TODO: find a better way, in which devices do not have to reproduce this logic.
         if observable.name in ("Hamiltonian", "SparseHamiltonian"):
             assert self.shots is None, f"{observable.name} must be used with shots=None"
 


### PR DESCRIPTION
**Context:**

Althought the new syntax `expval(H)` is much faster for VQE with `default.qubit`, QAOA problems run faster with the old syntax `ExpvalCost(...,optimize=True)`. The reason is that `optimize` switches on grouping, and for QAOA (where observables commute) this leads to one qnode with many measurements. Simulating such a qnode using the standard logic of sampling observable eigenvalues according to a probability dictated by the final state is faster than the `state*H*state` product executed in the new VQE workflow.

However, the new VQE syntax `does` have a way to switch on grouping. But if the device supports `H` as an observable, grouping is ignored.  

**Description of the Change:**

The qnode logic of treating Hamiltonians is extended to always "split" the Hamiltonian if it has grouping information already pre-computed. This change will not only affect Hamiltonians with commuting observables, but it is the logical thing to do: if a user explicitly computed a grouping for the Hamiltonian, she expects that PennyLane splits it accordingly.

**Benefits:**

Still working on the benchmarks, cannot see a benefit yet...

**Possible Drawbacks:**


