### PR TITLE
Restructure metric tensor

### DIFF
--- a/pennylane/qnode.py
+++ b/pennylane/qnode.py
@@ -723,7 +723,7 @@ class QNode:
 
         return qml.math.squeeze(res)
 
-    def metric_tensor(self, *args, allow_nonunitary=True, approx=None, cache_states=False, diag_approx=None, only_construct=False, **kwargs):
+    def metric_tensor(self, *args, approx=None, diag_approx=None, only_construct=False, **kwargs):
         """Evaluate the value of the metric tensor.
 
         Args:
@@ -744,9 +744,9 @@ class QNode:
 
         if only_construct:
             self.construct(args, kwargs)
-            return qml.metric_tensor.construct(self.qtape, allow_nonunitary, approx, cache_states, diag_approx)
+            return qml.metric_tensor.construct(self.qtape, approx, diag_approx)
 
-        return qml.metric_tensor(self, allow_nonunitary, approx, cache_states, diag_approx)(*args, **kwargs)
+        return qml.metric_tensor(self, approx, diag_approx)(*args, **kwargs)
 
     def draw(
         self, charset="unicode", wire_order=None, show_all_wires=False

--- a/pennylane/qnode.py
+++ b/pennylane/qnode.py
@@ -723,7 +723,7 @@ class QNode:
 
         return qml.math.squeeze(res)
 
-    def metric_tensor(self, *args, diag_approx=False, only_construct=False, **kwargs):
+    def metric_tensor(self, *args, allow_nonunitary=True, approx=None, cache_states=False, diag_approx=None, only_construct=False, **kwargs):
         """Evaluate the value of the metric tensor.
 
         Args:
@@ -744,10 +744,9 @@ class QNode:
 
         if only_construct:
             self.construct(args, kwargs)
-            tape = qml.metric_tensor.expand_fn(self.qtape)
-            return qml.metric_tensor.construct(tape, diag_approx=diag_approx)
+            return qml.metric_tensor.construct(self.qtape, allow_nonunitary, approx, cache_states, diag_approx)
 
-        return qml.metric_tensor(self, diag_approx=diag_approx)(*args, **kwargs)
+        return qml.metric_tensor(self, allow_nonunitary, approx, cache_states, diag_approx)(*args, **kwargs)
 
     def draw(
         self, charset="unicode", wire_order=None, show_all_wires=False

--- a/pennylane/transforms/metric_tensor.py
+++ b/pennylane/transforms/metric_tensor.py
@@ -12,17 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Contains the metric tensor transform
+Contains the metric_tensor batch_transform which wraps multiple
+methods of computing the metric tensor.
 """
-import functools
 import warnings
 
 import numpy as np
 import pennylane as qml
 
-
+from pennylane.fourier.qnode_spectrum import expand_multi_par_and_no_gen
 from .batch_transform import batch_transform
-
+from .metric_tensor_cov_matrix import metric_tensor_cov_matrix
 
 SUPPORTED_OPS = ["RX", "RY", "RZ", "PhaseShift"]
 
@@ -31,19 +31,19 @@ def _stopping_critera(obj):
     return getattr(obj, "num_params", 0) == 0 or obj.name in SUPPORTED_OPS
 
 
-def expand_fn(tape):
-    """Expands the tape to contain only operations
-    supported by the ``metric_tensor`` transform (specified
-    by ``SUPPORTED_OPS``).
-    """
-    new_tape = tape.expand(depth=2, stop_at=_stopping_critera)
-    params = new_tape.get_parameters(trainable_only=False)
-    new_tape.trainable_params = qml.math.get_trainable_indices(params)
-    return new_tape
+# def expand_unsupported(tape):
+# """Expands the tape to contain only operations
+# supported by the ``metric_tensor`` transform (specified
+# by ``SUPPORTED_OPS``).
+# """
+# new_tape = tape.expand(depth=2, stop_at=_stopping_critera)
+# params = new_tape.get_parameters(trainable_only=False)
+# new_tape.trainable_params = qml.math.get_trainable_indices(params)
+# return new_tape
 
 
-@functools.partial(batch_transform, expand_fn=expand_fn)
-def metric_tensor(tape, diag_approx=False):
+@batch_transform
+def metric_tensor(tape, allow_nonunitary=True, approx=None, cache_states=False, diag_approx=None):
     """Returns a function that computes the block-diagonal approximation of the metric tensor
     of a given QNode or quantum tape.
 
@@ -149,68 +149,26 @@ def metric_tensor(tape, diag_approx=False):
                [0.        , 0.00415023, 0.        ],
                [0.        , 0.        , 0.24878844]])
     """
-    # get the circuit graph
-    graph = tape.graph
+    # if allow_nonunitary:
+    metric_tensor.expand_fn = expand_multi_par_and_no_gen
+    # else:
+    # metric_tensor.expand_fn = expand_unsupported
+    tape = metric_tensor.expand_fn(tape)
 
-    metric_tensor_tapes = []
-    obs_list = []
-    coeffs_list = []
-    params_list = []
+    if diag_approx is not None:
+        warnings.warn(
+            "The keyword argument diag_approx is deprecated. Please use approx='diag' instead."
+        )
+        if diag_approx:
+            approx = "diag"
 
-    for queue, curr_ops, param_idx, _ in graph.iterate_parametrized_layers():
-        params_list.append(param_idx)
-        coeffs_list.append([])
-        obs_list.append([])
+    if approx in {"diag", "block diag"}:
+        # Only require covariance matrix based transform
+        diag_approx = approx == "diag"
+        # Cut off excess output of cov_matrix transform
+        return metric_tensor_cov_matrix(tape, diag_approx)
 
-        # for each operation in the layer, get the generator
-        for op in curr_ops:
-            gen, s = op.generator
-            w = op.wires
-            coeffs_list[-1].append(s)
-
-            # get the observable corresponding to the generator of the current operation
-            if isinstance(gen, np.ndarray):
-                # generator is a Hermitian matrix
-                obs_list[-1].append(qml.Hermitian(gen, w))
-
-            elif issubclass(gen, qml.operation.Observable):
-                # generator is an existing PennyLane operation
-                obs_list[-1].append(gen(w))
-
-            else:
-                raise qml.QuantumFunctionError(
-                    "Can't generate metric tensor, generator {}"
-                    "has no corresponding observable".format(gen)
-                )
-
-        # Create a quantum tape with all operations
-        # prior to the parametrized layer, and the rotations
-        # to measure in the basis of the parametrized layer generators.
-        with tape.__class__() as layer_tape:
-            for op in queue:
-                qml.apply(op)
-
-            for o in obs_list[-1]:
-                o.diagonalizing_gates()
-
-            qml.probs(wires=tape.wires)
-
-        metric_tensor_tapes.append(layer_tape)
-
-    def processing_fn(probs):
-        gs = []
-
-        for prob, obs, coeffs in zip(probs, obs_list, coeffs_list):
-            # calculate the covariance matrix of this layer
-            scale = qml.math.convert_like(np.outer(coeffs, coeffs), prob)
-            scale = qml.math.cast_like(scale, prob)
-            g = scale * qml.math.cov_matrix(prob, obs, wires=tape.wires, diag_approx=diag_approx)
-            gs.append(g)
-
-        # create the block diagonal metric tensor
-        return qml.math.block_diag(gs)
-
-    return metric_tensor_tapes, processing_fn
+    raise NotImplementedError("No method for the full metric tensor has been implemented yet.")
 
 
 @metric_tensor.custom_qnode_wrapper
@@ -231,10 +189,10 @@ def qnode_execution_wrapper(self, qnode, targs, tkwargs):
 
     mt_fn = self.default_qnode_wrapper(qnode, targs, tkwargs)
 
-    if isinstance(qnode, qml.beta.QNode):
-        cjac_fn = qml.transforms.classical_jacobian(qnode, expand_fn=self.expand_fn)
-    else:
-        cjac_fn = qml.transforms.classical_jacobian(qnode)
+    # if isinstance(qnode, qml.beta.QNode):
+    cjac_fn = qml.transforms.classical_jacobian(qnode, expand_fn=self.expand_fn)
+    # else:
+    # cjac_fn = qml.transforms.classical_jacobian(qnode)
 
     def wrapper(*args, **kwargs):
         mt = mt_fn(*args, **kwargs)


### PR DESCRIPTION
This is the first of two PRs into which #1716 is split up.
We here accomodate for one or more methods that will compute the full metric tensor by renaming the current (block) diagonal implementation and wrapping the renamed method in `metric_tensor`.
Furthermore, the existing implementation is more powerful than it is made by the expansion function: Any operations defining a Hermitian `generator` are supported as we can compute expectation values (and thus the covariance matrix) for these generators.
As a preparatory change, the keyword argument `diag_approx` is deprecated and raises a warning if used. Instead, a new keyword argument `approx` will define the level of approximation, with current options `None`, `"block diag"`(preliminary default) and `diag`. `None` corresponds to no approximation being made, which is not supported yet (raises `NotImplementedError`).

Due to the current default setting, the behaviour of `metric_tensor` is unchanged for this PR, except for potentially fewer decomposition steps occurring during the evaluation.