### PR TITLE
Change link for QFT documentation in the template page

### DIFF
--- a/doc/introduction/templates.rst
+++ b/doc/introduction/templates.rst
@@ -209,7 +209,7 @@ Other useful templates which do not belong to the previous categories can be fou
     :figure: ../_static/templates/subroutines/all_singles_doubles.png
 
 .. customgalleryitem::
-    :link: ../code/api/pennylane.templates.subroutines.QuantumFourierTransform.html
+    :link: ../code/api/pennylane.templates.subroutines.QFT.html
     :description: QuantumFourierTransform
     :figure: ../_static/templates/subroutines/qft.svg
 	


### PR DESCRIPTION
**Context:**

Wrong link in the template documentation page. 

**Description of the Change:**

`pennylane.templates.subroutines.QuantumFourierTransform.html` replaced by `pennylane.templates.subroutines.QFT.html`

**Related GitHub Issues:**

Closes https://github.com/PennyLaneAI/pennylane/issues/1728
