### PR TITLE
Have no assignee when auto asigning bugs

### DIFF
--- a/.github/workflows/assign_bugs.yml
+++ b/.github/workflows/assign_bugs.yml
@@ -11,6 +11,6 @@ jobs:
         with:
           title-or-body: "title"
           parameters: '[
-                         {"keywords": ["[BUG]", "bug"], "labels": ["bug :bug:"], "assignees": ["antalszava"]}
+                         {"keywords": ["[BUG]", "bug"], "labels": ["bug :bug:"], "assignees": []}
                         ]'
           github-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
For now, assigning someone from the team works such that we hardcode the person into the GitHub action. This can result in confusion though, so this PR removes the assignee.