### PR TITLE
Adjust `template` decorator deprecation warning

### DIFF
--- a/pennylane/templates/decorator.py
+++ b/pennylane/templates/decorator.py
@@ -70,4 +70,5 @@ def template(func):
             func(*args, **kwargs)
 
         return rec.queue
+
     return wrapper

--- a/tests/templates/test_decorator.py
+++ b/tests/templates/test_decorator.py
@@ -107,6 +107,7 @@ class TestDecorator:
     def test_deprecated_decorator_no_warn_if_not_called(self, recwarn):
         """Test that decorating a function with the template decorator does not
         raise a warning if the function is not being called."""
+
         @template
         def my_template(wires):
             decorated_dummy_template(wires)


### PR DESCRIPTION
**Context & Changes**

A recent addition in #1794 has deprecated the use of the `template` decorator. As per the addition, a warning is raised each time a function is being decorated.

As some PennyLane functions use the `template` decorator, multiple warnings are emitted even when importing PennyLane.

This PR updates the deprecation warnings to be raised only when a function wrapped with the `template` decorator is called.

**Further notes**

Internal functions using the `template` decorator should be adjusted, such that this decorator is not being used. Without this step, users using PennyLane functionality will face deprecation warnings without directly using the `template` decorator.

E.g., the following raises a deprecation warning related to the use of the `template` decorator:
```python
import pennylane as qml

pauli_operators = [qml.PauliX('a'), qml.PauliY('b'), qml.PauliZ('c')]
qml.grouping.qwc_rotation(pauli_operators)
```
