### PR TITLE
Pin PySCF to version < 2.0

### DIFF
--- a/doc/development/guide/installation.rst
+++ b/doc/development/guide/installation.rst
@@ -62,7 +62,7 @@ are required:
 
 * `OpenFermion <https://github.com/quantumlib/OpenFermion>`__ >= 0.10
 
-* `pySCF <https://sunqm.github.io/pyscf>`__
+* `pySCF <https://sunqm.github.io/pyscf>`__ < 2.0
   and `OpenFermion-PySCF <https://github.com/quantumlib/OpenFermion-pyscf>`__ >= 0.4
 
 * `Psi4 <http://www.psicode.org/>`__ and

--- a/qchem/README.rst
+++ b/qchem/README.rst
@@ -32,7 +32,7 @@ Installation
 
 PennyLane-Qchem requires Python version 3.5 and above, and the following dependencies:
 
-* `pySCF <https://sunqm.github.io/pyscf>`__
+* `pySCF <https://sunqm.github.io/pyscf>`__ < 2.0
   and `OpenFermion-PySCF <https://github.com/quantumlib/OpenFermion-pyscf>`__ >= 0.5
 
 * (optional) `Psi4 <http://www.psicode.org/>`__

--- a/qchem/requirements.txt
+++ b/qchem/requirements.txt
@@ -4,5 +4,5 @@ pennylane>=0.13.0
 openfermion==1.0
 openfermionpsi4==0.5
 h5py<=3.2.1
-pyscf>=1.7.2
+pyscf>=1.7.2,<2.0
 openfermionpyscf==0.5

--- a/qchem/setup.py
+++ b/qchem/setup.py
@@ -23,7 +23,7 @@ requirements = [
     "openfermionpyscf>=0.5; platform_system != 'Windows'",
     "openfermionpsi4>=0.5",
     "h5py<=3.2.1",
-    "pyscf>=1.7.2; platform_system != 'Windows'",
+    "pyscf>=1.7.2,<2.0; platform_system != 'Windows'",
 ]
 
 info = {


### PR DESCRIPTION
**Context:** PySCF 2.0 was [released on PyPI today](https://pypi.org/project/pyscf/#history), however it seemingly fails to install.

**Description of the Change:** Pins PySCF in QChem to version `>=1.7.2, <2.0` to ensure tests and documentation continue to work.

**Benefits:** PennyLane CI continues to pass.

**Possible Drawbacks:** Will need to investigate and see if it is possible to support PySCF 2.0. The [GitHub release notes](https://github.com/pyscf/pyscf/releases) do not provide many details regarding breaking changes.

**Related GitHub Issues:** n/a
