### PR TITLE
Rewrite the transforms documentation 

### DIFF
--- a/pennylane/transforms/__init__.py
+++ b/pennylane/transforms/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Quantum transforms are composable transformations of quantum functions. A
+Quantum transforms are composable transformations of quantum functions (qfuncs). A
 quantum transform, when applied to a qfunc (a Python function containing
 quantum operations) or a :class:`~pennylane.QNode`, will **transform** the
 quantum circuit in order to achieve the desired result. For example, quantum
@@ -27,7 +27,7 @@ transforms can be used to:
   such as the gradient and the Fisher information matrix.
 
 This module provides a selection of device-independent, differentiable quantum
-gradient transforms. As such, not only is the output of a quantum transform
+transforms. As such, not only is the output of a quantum transform
 differentiable, but quantum transforms *themselves* can be differentiated with
 respect to any floating point arguments.
 
@@ -60,13 +60,16 @@ in quantum executions.
     ~transforms.classical_jacobian
 
 
-Multiple circuit transforms
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Batch circuit transforms
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 These transforms accept QNodes, and return new QNodes
 that compute the desired quantity. The transformed QNode, when
 executed, may result in multiple quantum circuit evaluations
 under the hood.
+
+.. autosummary::
+    :toctree: api
 
     ~batch_params
     ~metric_tensor

--- a/pennylane/transforms/__init__.py
+++ b/pennylane/transforms/__init__.py
@@ -34,6 +34,11 @@ respect to any floating point arguments.
 In addition, this module also includes an API for writing your own quantum
 transforms.
 
+.. note::
+
+    For gradient transforms, please see the :mod:`qml.gradients <pennylane.gradients>`
+    module.
+
 .. currentmodule:: pennylane
 
 Overview

--- a/pennylane/transforms/__init__.py
+++ b/pennylane/transforms/__init__.py
@@ -44,8 +44,8 @@ transforms.
 Overview
 --------
 
-Information
-~~~~~~~~~~~
+Information transforms
+~~~~~~~~~~~~~~~~~~~~~~
 
 These transforms accept QNodes, and return new transformed functions
 that compute the desired quantity. These transforms do not result

--- a/pennylane/transforms/__init__.py
+++ b/pennylane/transforms/__init__.py
@@ -12,60 +12,84 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-This subpackage contains QNode, quantum function, device, and tape transforms.
+Quantum transforms are composable transformations of quantum functions. A
+quantum transform, when applied to a qfunc (a Python function containing
+quantum operations) or a :class:`~pennylane.QNode`, will **transform** the
+quantum circuit in order to achieve the desired result. For example, quantum
+transforms can be used to:
 
+- extract information from the quantum function (e.g., to extract unitary
+  matrices or draw the underlying circuit),
+
+- modify or compile the quantum function,
+
+- generate new quantum functions that compute quantum properties and metrics,
+  such as the gradient and the Fisher information matrix.
+
+This module provides a selection of device-independent, differentiable quantum
+gradient transforms. As such, not only is the output of a quantum transform
+differentiable, but quantum transforms *themselves* can be differentiated with
+respect to any floating point arguments.
+
+In addition, this module also includes an API for writing your own quantum
+transforms.
 
 .. currentmodule:: pennylane
 
-Transforms
-----------
+Overview
+--------
 
-Transforms that act on QNodes
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Information
+~~~~~~~~~~~
 
 These transforms accept QNodes, and return new transformed functions
-that compute the desired quantity.
+that compute the desired quantity. These transforms do not result
+in quantum executions.
 
 .. autosummary::
     :toctree: api
 
-    ~transforms.classical_jacobian
-    ~batch_params
     ~draw
-    ~transforms.get_unitary_matrix
-    ~metric_tensor
     ~specs
+    ~transforms.get_unitary_matrix
+    ~transforms.classical_jacobian
+
+
+Multiple circuit transforms
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+These transforms accept QNodes, and return new QNodes
+that compute the desired quantity. The transformed QNode, when
+executed, may result in multiple quantum circuit evaluations
+under the hood.
+
+    ~batch_params
+    ~metric_tensor
     ~transforms.mitigate_with_zne
+    ~transforms.hamiltonian_expand
+    ~transforms.measurement_grouping
 
-Transforms that act on quantum functions
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-These transforms accept quantum functions (Python functions
-containing quantum operations) that are used to construct QNodes.
+Circuit modification and compilation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This set of transforms map a single quantum function to a new quantum
+function. This includes basic circuit compilation tasks.
 
 .. autosummary::
     :toctree: api
 
     ~adjoint
     ~ctrl
-    ~apply_controlled_Q
-    ~quantum_monte_carlo
-    ~transforms.insert
-
-Transforms for circuit compilation
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-This set of transforms accept quantum functions, and perform basic circuit compilation tasks.
-
-.. autosummary::
-    :toctree: api
-
     ~compile
+    ~transforms.insert
     ~transforms.cancel_inverses
     ~transforms.commute_controlled
     ~transforms.merge_rotations
     ~transforms.single_qubit_fusion
     ~transforms.unitary_to_rot
+    ~apply_controlled_Q
+    ~quantum_monte_carlo
 
 There are also utility functions and decompositions available that assist with
 both transforms, and decompositions within the larger PennyLane codebase.
@@ -76,20 +100,9 @@ both transforms, and decompositions within the larger PennyLane codebase.
     ~transforms.zyz_decomposition
     ~transforms.two_qubit_decomposition
 
-Transforms that act on tapes
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-These transforms accept quantum tapes, and return one or
-more tapes as well as a classical processing function.
-
-.. autosummary::
-    :toctree: api
-
-    ~transforms.measurement_grouping
-    ~transforms.hamiltonian_expand
-
-Decorators and utility functions
---------------------------------
+Custom transforms and utilities
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The following decorators and convenience functions are provided
 to help build custom QNode, quantum function, and tape transforms:

--- a/pennylane/transforms/hamiltonian_expand.py
+++ b/pennylane/transforms/hamiltonian_expand.py
@@ -18,6 +18,10 @@ Contains the hamiltonian expand tape transform
 import pennylane as qml
 
 
+from .batch_transform import batch_transform
+
+
+@batch_transform
 def hamiltonian_expand(tape, group=True):
     r"""
     Splits a tape measuring a Hamiltonian expectation into mutliple tapes of Pauli expectations,


### PR DESCRIPTION
**Context:** As the transforms module has evolved, we should revisit and update the transformation documentation.

**Description of the Change:** Reorganizes the categorization of functions, and adds an introduction paragraph.

**Benefits:** Hopefully easier to navigate?

**Possible Drawbacks:**

- Does not address #1753; transforms are still not mentioned in quickstarts.
- Underneath the function autosummary table, we should have a general 'overview' of the module with code examples, as per the Gradients module and the Fourier module (see #1365).

**Related GitHub Issues:** #1753, #1365
