### PR TITLE
Update `QNGOptimizer` to handle deprecations

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -625,6 +625,10 @@
 
 <h3>Improvements</h3>
 
+* Updated the `qml.QNGOptimizer.step_and_cost` method to avoid the use of
+  deprecated functionality.
+  [(#1834)](https://github.com/PennyLaneAI/pennylane/pull/1834)
+
 * The default for an `Operation`'s `control_wires` attribute is now an empty `Wires`
   object instead of the attribute raising a `NonImplementedError`.
   [(#1821)](https://github.com/PennyLaneAI/pennylane/pull/1821)
@@ -895,12 +899,6 @@
 
   If `hybrid=False`, the changed expansion rule might lead to a changed output.
 
-* The `qml.metric_tensor` keyword argument `diag_approx` is deprecated.
-  Approximations can be controlled with the more fine-grained `approx`
-  keyword argument, with `approx="block-diag"` (the default) reproducing
-  the old behaviour.
-  [(#1721)](https://github.com/PennyLaneAI/pennylane/pull/1721)
-
 * The `default.qubit.torch` device automatically determines if computations
   should be run on a CPU or a GPU and doesn't take a `torch_device` argument
   anymore.
@@ -926,6 +924,14 @@
   [(#1822)](https://github.com/PennyLaneAI/pennylane/pull/1822)
 
 <h3>Deprecations</h3>
+
+* The `qml.metric_tensor` and `qml.QNGOptimizer` keyword argument `diag_approx`
+  is deprecated.
+  Approximations can be controlled with the more fine-grained `approx` keyword
+  argument, with `approx="block-diag"` (the default) reproducing the old
+  behaviour.
+  [(#1721)](https://github.com/PennyLaneAI/pennylane/pull/1721)
+  [(#1834)](https://github.com/PennyLaneAI/pennylane/pull/1834)
 
 * Allowing cost functions to be differentiated using `qml.grad` or
   `qml.jacobian` without explicitly marking parameters as trainable is being

--- a/pennylane/optimize/qng.py
+++ b/pennylane/optimize/qng.py
@@ -192,7 +192,11 @@ class QNGOptimizer(GradientDescentOptimizer):
 
         if recompute_tensor or self.metric_tensor is None:
             if metric_tensor_fn is None:
-                metric_tensor_fn = qml.metric_tensor(qnode, diag_approx=self.diag_approx)
+
+                if self.diag_approx:
+                    metric_tensor_fn = qml.metric_tensor(qnode, approx="diag")
+                else:
+                    metric_tensor_fn = qml.metric_tensor(qnode)
 
             self.metric_tensor = metric_tensor_fn(*args, **kwargs)
             self.metric_tensor += self.lam * np.identity(self.metric_tensor.shape[0])

--- a/pennylane/optimize/qng.py
+++ b/pennylane/optimize/qng.py
@@ -15,7 +15,7 @@
 # pylint: disable=too-many-branches
 # pylint: disable=too-many-arguments
 
-import numpy as np
+from pennylane import numpy as np
 
 import pennylane as qml
 from pennylane.utils import _flatten, unflatten
@@ -202,7 +202,7 @@ class QNGOptimizer(GradientDescentOptimizer):
             self.metric_tensor += self.lam * np.identity(self.metric_tensor.shape[0])
 
         g, forward = self.compute_grad(qnode, args, kwargs, grad_fn=grad_fn)
-        new_args = self.apply_grad(g, args)
+        new_args = np.array(self.apply_grad(g, args))
 
         if forward is None:
             forward = qnode(*args, **kwargs)

--- a/pennylane/optimize/qng.py
+++ b/pennylane/optimize/qng.py
@@ -202,7 +202,7 @@ class QNGOptimizer(GradientDescentOptimizer):
             self.metric_tensor += self.lam * np.identity(self.metric_tensor.shape[0])
 
         g, forward = self.compute_grad(qnode, args, kwargs, grad_fn=grad_fn)
-        new_args = np.array(self.apply_grad(g, args))
+        new_args = np.array(self.apply_grad(g, args), requires_grad=True)
 
         if forward is None:
             forward = qnode(*args, **kwargs)

--- a/tests/optimize/test_qng.py
+++ b/tests/optimize/test_qng.py
@@ -228,7 +228,7 @@ class TestOptimize:
         # check final cost
         assert np.allclose(cost_fn(theta), -1.41421356, atol=tol, rtol=0)
 
-    def test_single_qubit_vqe_using_vqecost(self, tol):
+    def test_single_qubit_vqe_using_vqecost(self, tol, recwarn):
         """Test single-qubit VQE using ExpvalCost
         has the correct QNG value every step, the correct parameter updates,
         and correct cost after 200 steps"""
@@ -252,7 +252,7 @@ class TestOptimize:
             return np.array([da, db])
 
         eta = 0.01
-        init_params = np.array([0.011, 0.012])
+        init_params = np.array([0.011, 0.012], requires_grad=True)
         num_steps = 200
 
         opt = qml.QNGOptimizer(eta)
@@ -275,3 +275,4 @@ class TestOptimize:
 
         # check final cost
         assert np.allclose(cost_fn(theta), -1.41421356, atol=tol, rtol=0)
+        assert len(recwarn) == 0

--- a/tests/optimize/test_qng.py
+++ b/tests/optimize/test_qng.py
@@ -332,9 +332,8 @@ class TestOptimize:
         "diag_approx, approx_expected", [(True, "diag"), (False, "block-diag")]
     )
     def test_deprecate_diag_approx(self, diag_approx, approx_expected):
-        """Test single-qubit VQE by returning qml.expval(H) in the QNode and
-        check for the correct QNG value every step, the correct parameter updates, and
-        correct cost after 200 steps"""
+        """Test that using the diag_approx argument raises a warning due to
+        deprecation."""
         with pytest.warns(UserWarning, match="keyword argument diag_approx is deprecated"):
             opt = qml.QNGOptimizer(0.1, diag_approx=True)
 

--- a/tests/optimize/test_qng.py
+++ b/tests/optimize/test_qng.py
@@ -14,6 +14,7 @@
 """Tests for the QNG optimizer"""
 import pytest
 import scipy as sp
+import warnings
 
 import pennylane as qml
 from pennylane import numpy as np
@@ -327,3 +328,15 @@ class TestOptimize:
         # check final cost
         assert np.allclose(circuit(x, y), -1.41421356, atol=tol, rtol=0)
         assert len(recwarn) == 0
+
+    @pytest.mark.parametrize("diag_approx, approx_expected", [(True, "diag"), (False, "block-diag")])
+    def test_deprecate_diag_approx(self, diag_approx, approx_expected):
+        """Test single-qubit VQE by returning qml.expval(H) in the QNode and
+        check for the correct QNG value every step, the correct parameter updates, and
+        correct cost after 200 steps"""
+        with pytest.warns(
+            UserWarning, match="keyword argument diag_approx is deprecated"
+        ):
+            opt = qml.QNGOptimizer(0.1, diag_approx=True)
+
+        assert opt.approx == "diag"

--- a/tests/optimize/test_qng.py
+++ b/tests/optimize/test_qng.py
@@ -278,7 +278,6 @@ class TestOptimize:
         assert np.allclose(cost_fn(theta), -1.41421356, atol=tol, rtol=0)
         assert len(recwarn) == 0
 
-
     def test_single_qubit_vqe_using_expval_h_multiple_input_params(self, tol, recwarn):
         """Test single-qubit VQE by returning qml.expval(H) in the QNode and
         check for the correct QNG value every step, the correct parameter updates, and
@@ -329,14 +328,14 @@ class TestOptimize:
         assert np.allclose(circuit(x, y), -1.41421356, atol=tol, rtol=0)
         assert len(recwarn) == 0
 
-    @pytest.mark.parametrize("diag_approx, approx_expected", [(True, "diag"), (False, "block-diag")])
+    @pytest.mark.parametrize(
+        "diag_approx, approx_expected", [(True, "diag"), (False, "block-diag")]
+    )
     def test_deprecate_diag_approx(self, diag_approx, approx_expected):
         """Test single-qubit VQE by returning qml.expval(H) in the QNode and
         check for the correct QNG value every step, the correct parameter updates, and
         correct cost after 200 steps"""
-        with pytest.warns(
-            UserWarning, match="keyword argument diag_approx is deprecated"
-        ):
+        with pytest.warns(UserWarning, match="keyword argument diag_approx is deprecated"):
             opt = qml.QNGOptimizer(0.1, diag_approx=True)
 
         assert opt.approx == "diag"


### PR DESCRIPTION
**Context**

The `QNGOptimizer` raises deprecation warnings because (see [related demo](http://pennylane.ai-dev.s3-website-us-east-1.amazonaws.com/qml/demos/tutorial_quantum_natural_gradient.html#quantum-natural-gradient-optimization)):

* inputs have to explicitly specify requires_grad=True;
* the keyword argument diag_approx is deprecated.

**Changes**

* Switches to using PennyLane NumPy for the optimizer
* Switches how the optimizer uses `qml.metric_tensor`
* Adds a deprecation warning when `diag_approx` is specified with `QNGOptimizer`