### PR TITLE
Sorted `tape.get_parameters`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1028,7 +1028,7 @@
 
 * Fixes a bug where in rare instances the parameters of a tape are returned unsorted
   by `Tape.get_parameters`.
-  [(#1835)](https://github.com/PennyLaneAI/pennylane/pull/1835)
+  [(#1836)](https://github.com/PennyLaneAI/pennylane/pull/1836)
 
 * Fixes a bug with the arrow width in the `measure` of `qml.circuit_drawer.MPLDrawer`. 
   [(#1823)](https://github.com/PennyLaneAI/pennylane/pull/1823)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1026,6 +1026,10 @@
 
 <h3>Bug fixes</h3>
 
+* Fixes a bug where in rare instances the parameters of a tape are returned unsorted
+  by `Tape.get_parameters`.
+  [(#1835)](https://github.com/PennyLaneAI/pennylane/pull/1835)
+
 * Fixes a bug with the arrow width in the `measure` of `qml.circuit_drawer.MPLDrawer`. 
   [(#1823)](https://github.com/PennyLaneAI/pennylane/pull/1823)
 

--- a/pennylane/tape/tape.py
+++ b/pennylane/tape/tape.py
@@ -854,7 +854,7 @@ class QuantumTape(AnnotatedQueue):
         [4, 1, 6]
         """
         if trainable_only:
-            iterator = zip(self.trainable_params, params)
+            iterator = zip(sorted(self.trainable_params), params)
             required_length = self.num_params
         else:
             iterator = enumerate(params)

--- a/pennylane/tape/tape.py
+++ b/pennylane/tape/tape.py
@@ -809,7 +809,6 @@ class QuantumTape(AnnotatedQueue):
             op = self._par_info[p_idx]["op"]
             op_idx = self._par_info[p_idx]["p_idx"]
             params.append(op.data[op_idx])
-
         return params
 
     def set_parameters(self, params, trainable_only=True):

--- a/pennylane/tape/tape.py
+++ b/pennylane/tape/tape.py
@@ -803,7 +803,7 @@ class QuantumTape(AnnotatedQueue):
         [0.432, 0.543, 0.133]
         """
         params = []
-        iterator = self.trainable_params if trainable_only else self._par_info
+        iterator = sorted(self.trainable_params) if trainable_only else self._par_info
 
         for p_idx in iterator:
             op = self._par_info[p_idx]["op"]

--- a/tests/transforms/test_metric_tensor.py
+++ b/tests/transforms/test_metric_tensor.py
@@ -437,7 +437,7 @@ class TestMetricTensor:
             qml.RY(y, wires=1)
             qml.RZ(z, wires=2)
             non_parametrized_layer(a, b, c)
-            return qml.expval(qml.Hermitian(np.kron(Z, Y), wires=[2, 1]))
+            return qml.expval(qml.PauliY(1) @ qml.PauliZ(2))
 
         layer2_off_diag_second_order = qml.QNode(layer2_off_diag_second_order, dev)
 


### PR DESCRIPTION
**Context:**
The `tape` method `get_parameters` relies on `tape.trainable_params` (if `trainable_only=True`), which is a `set`.
This means that if for some reason the internal ordering of `trainable_params` is not preserved (which is not guaranteed in python, in contrast to Python 3.7+ `dict`s), `get_parameters` will return the parameters in an incorrect order. In particular, the `classical_jacobian` outputs a permutation if this happens.

**Description of the Change:**
Adding `sorted` to the indices retrieved from `tape.trainable_params` within `tape.get_parameters`

**Benefits:**
The order of the parameters is stable.

**Possible Drawbacks:**
For large tapes this incurs an overhead, but as `trainable_params` typically is "sorted" already, this overhead is _very_ small:
```python
a, b, c = set(range(int(1e3))), set(range(int(1e4))), set(range(int(1e5)))
sorted(a) # Takes ~0.3 millisecs
sorted(b) # Takes ~1 millisecs
sorted(c) # Takes ~8 millisecs
```

