### PR TITLE
Update `Device.expand_fn`

### DIFF
--- a/doc/releases/changelog-0.19.0.md
+++ b/doc/releases/changelog-0.19.0.md
@@ -625,6 +625,10 @@
 
 <h3>Improvements</h3>
 
+* Refactored the `expand_fn` functionality in the Device class to avoid any
+  edge cases leading to failures with plugins.
+  [(#1840)](https://github.com/PennyLaneAI/pennylane/pull/1840)
+
 * Updated the `qml.QNGOptimizer.step_and_cost` method to avoid the use of
   deprecated functionality.
   [(#1834)](https://github.com/PennyLaneAI/pennylane/pull/1834)

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -636,8 +636,9 @@ class Device(abc.ABC):
 
     def expand_fn(self, circuit, max_expansion=10):
         """Method for expanding or decomposing an input circuit.
-        Can be the default or a custom expansion method, see default_expand_fn
-        and custom_expand for more details.
+        Can be the default or a custom expansion method, see
+        :meth:`.Device.default_expand_fn` and :meth:`.Device.custom_expand` for more
+        details.
 
         Args:
             circuit (.QuantumTape): the circuit to expand.

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -635,6 +635,22 @@ class Device(abc.ABC):
         return circuit
 
     def expand_fn(self, circuit, max_expansion=10):
+        """Method for expanding or decomposing an input circuit.
+        Can be the default or a custom expansion method, see default_expand_fn
+        and custom_expand for more details.
+
+        Args:
+            circuit (.QuantumTape): the circuit to expand.
+            max_expansion (int): The number of times the circuit should be
+                expanded. Expansion occurs when an operation or measurement is not
+                supported, and results in a gate decomposition. If any operations
+                in the decomposition remain unsupported by the device, another
+                expansion occurs.
+
+        Returns:
+            .QuantumTape: The expanded/decomposed circuit, such that the device
+            will natively support all operations.
+        """
         return self.default_expand_fn(circuit, max_expansion=max_expansion)
 
     def batch_transform(self, circuit):

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -141,6 +141,7 @@ class Device(abc.ABC):
         self._parameters = None
 
         self.tracker = qml.Tracker()
+        self.custom_expand_fn = None
 
     def __repr__(self):
         """String representation."""
@@ -598,7 +599,7 @@ class Device(abc.ABC):
         before returning, to ensure that the expanded circuit is supported
         on the device.
         """
-        self.expand_fn = types.MethodType(fn, self)
+        self.custom_expand_fn = types.MethodType(fn, self)
 
     def default_expand_fn(self, circuit, max_expansion=10):
         """Method for expanding or decomposing an input circuit.
@@ -652,6 +653,9 @@ class Device(abc.ABC):
             .QuantumTape: The expanded/decomposed circuit, such that the device
             will natively support all operations.
         """
+        if self.custom_expand_fn is not None:
+            return self.custom_expand_fn(circuit, max_expansion=max_expansion)
+
         return self.default_expand_fn(circuit, max_expansion=max_expansion)
 
     def batch_transform(self, circuit):

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -141,7 +141,6 @@ class Device(abc.ABC):
         self._parameters = None
 
         self.tracker = qml.Tracker()
-        self.expand_fn = self.default_expand_fn
 
     def __repr__(self):
         """String representation."""
@@ -634,6 +633,9 @@ class Device(abc.ABC):
             circuit = circuit.expand(depth=max_expansion, stop_at=self.stopping_condition)
 
         return circuit
+
+    def expand_fn(self, circuit, max_expansion=10):
+        return self.default_expand_fn(circuit, max_expansion=max_expansion)
 
     def batch_transform(self, circuit):
         """Apply a differentiable batch transform for preprocessing a circuit


### PR DESCRIPTION
Following up on a change to the `Device` class (https://github.com/PennyLaneAI/pennylane/pull/1795), this PR slightly reorganizes the functionality of `expand_fn` such that the PennyLane-Forest plugin can work well (https://github.com/PennyLaneAI/pennylane-forest/pull/87).

Recent CI runs of the PennyLane-Forest resulted in hanging and were cancelled by GitHub after 6 hours (e.g., [here](https://github.com/PennyLaneAI/plugin-test-matrix/actions/runs/1410305145)).