### PR TITLE
Ensure that the correct version of keras is installed for TensorFlow CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Conditionally install TensorFlow
         if: contains(matrix.config.interfaces, 'tf')
-        run: pip3 install tensorflow==$TF_VERSION
+        run: pip3 install tensorflow==$TF_VERSION keras==$TF_VERSION
 
       # Jax releases new version very frequently, so we should always build
       # to the latest release. We can always fix a version later if it breaks.


### PR DESCRIPTION
**Context:** Keras 2.7 was just released, however it appears to be incompatible with TF 2.6. 

**Description of the Change:** Ensures that the CI installs TF 2.6 and Keras 2.6

**Benefits:** CI runs.

**Possible Drawbacks:** Users pip installing TensorFlow will also get the incompatible Keras version. This is something that will need to be fixed by TensorFlow.

**Related GitHub Issues:** https://github.com/tensorflow/tensorflow/issues/52922
