### PR TITLE
Add deprecation warning for default.tensor

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -925,6 +925,10 @@
 
 <h3>Deprecations</h3>
 
+* The `default.tensor` device from the beta folder has not been maintained in 
+  years and is deprecated. It will be removed in future releases.
+  [(#1851)](https://github.com/PennyLaneAI/pennylane/pull/1851)
+
 * The `qml.metric_tensor` and `qml.QNGOptimizer` keyword argument `diag_approx`
   is deprecated.
   Approximations can be controlled with the more fine-grained `approx` keyword

--- a/pennylane/beta/devices/default_tensor.py
+++ b/pennylane/beta/devices/default_tensor.py
@@ -155,6 +155,13 @@ class DefaultTensor(Device):
     _zero_state = np.array([1.0, 0.0], dtype=C_DTYPE)
 
     def __init__(self, wires, shots=None, representation="exact", contraction_method="auto"):
+
+        warnings.warn(
+            "The default.tensor device is deprecated and due to be removed in an upcoming PennyLane release.",
+            UserWarning,
+            stacklevel=2,
+        )
+
         super().__init__(wires, shots)
         if representation not in ["exact", "mps"]:
             raise ValueError("Invalid representation. Must be one of 'exact' or 'mps'.")

--- a/pennylane/beta/devices/default_tensor.py
+++ b/pennylane/beta/devices/default_tensor.py
@@ -157,7 +157,7 @@ class DefaultTensor(Device):
     def __init__(self, wires, shots=None, representation="exact", contraction_method="auto"):
 
         warnings.warn(
-            "The default.tensor device is deprecated and due to be removed in an upcoming PennyLane release.",
+            f"The {self.short_name} device is deprecated and due to be removed in an upcoming PennyLane release.",
             UserWarning,
             stacklevel=2,
         )

--- a/tests/beta/test_default_tensor.py
+++ b/tests/beta/test_default_tensor.py
@@ -1829,3 +1829,10 @@ class TestTensorSample:
             )
         ) / 16
         assert np.allclose(var, expected, atol=tol, rtol=0)
+
+
+def test_deprecation_warning():
+    """Test the deprecation warning."""
+
+    with pytest.warns(UserWarning, match="The default.tensor device is deprecated"):
+        qml.device("default.tensor", wires=3)


### PR DESCRIPTION
**Context:**

The `default.tensor` device has never been moved out of the beta folder, and uses a very old device API (that would have to be reassessed in the upcoming device class refactor) as well as old tests (that would have to be rewritten for the current operator class refactor). 

We therefore decided to deprecate the device rather than maintaining it.

**Description of the Change:**

Raises a deprecation warning if the device is loaded.

**Benefits:**

We have plans to use more powerful tensor simulators to build devices in future.

**Possible Drawbacks:**

At the moment there is no alternative device we can guide users towards.

