### PR TITLE
fix docstrings in hf module

### DIFF
--- a/pennylane/hf/hamiltonian.py
+++ b/pennylane/hf/hamiltonian.py
@@ -82,7 +82,7 @@ def generate_electron_integrals(mol, core=None, active=None):
     >>> geometry = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad = False)
     >>> alpha = np.array([[3.42525091, 0.62391373, 0.1688554],
     >>>                   [3.42525091, 0.62391373, 0.1688554]], requires_grad=True)
-    >>> mol = Molecule(symbols, geometry, alpha=alpha)
+    >>> mol = qml.hf.Molecule(symbols, geometry, alpha=alpha)
     >>> args = [alpha]
     >>> generate_electron_integrals(mol)(*args)
     (1.0,
@@ -157,7 +157,7 @@ def generate_fermionic_hamiltonian(mol, cutoff=1.0e-12, core=None, active=None):
     >>> geometry = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad = False)
     >>> alpha = np.array([[3.42525091, 0.62391373, 0.1688554],
     >>>                   [3.42525091, 0.62391373, 0.1688554]], requires_grad=True)
-    >>> mol = Molecule(symbols, geometry, alpha=alpha)
+    >>> mol = qml.hf.Molecule(symbols, geometry, alpha=alpha)
     >>> args = [alpha]
     >>> h = generate_fermionic_hamiltonian(mol)(*args)
     """
@@ -220,7 +220,7 @@ def generate_hamiltonian(mol, cutoff=1.0e-12, core=None, active=None):
     >>> geometry = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad = False)
     >>> alpha = np.array([[3.42525091, 0.62391373, 0.1688554],
     >>>                   [3.42525091, 0.62391373, 0.1688554]], requires_grad=True)
-    >>> mol = Molecule(symbols, geometry, alpha=alpha)
+    >>> mol = qml.hf.Molecule(symbols, geometry, alpha=alpha)
     >>> args = [alpha]
     >>> h = generate_hamiltonian(mol)(*args)
     >>> h.terms[0]

--- a/pennylane/hf/hartree_fock.py
+++ b/pennylane/hf/hartree_fock.py
@@ -192,7 +192,7 @@ def nuclear_energy(charges, r):
 
     >>> symbols  = ['H', 'F']
     >>> geometry = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 2.0]], requires_grad = True)
-    >>> mol = qml.hf. Molecule(symbols, geometry)
+    >>> mol = qml.hf.Molecule(symbols, geometry)
     >>> args = [mol.coordinates]
     >>> e = nuclear_energy(mol.nuclear_charges, mol.coordinates)(*args)
     >>> print(e)

--- a/pennylane/hf/hartree_fock.py
+++ b/pennylane/hf/hartree_fock.py
@@ -102,10 +102,10 @@ def generate_scf(mol, n_steps=50, tol=1e-8):
     >>> symbols  = ['H', 'H']
     >>> geometry = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad = False)
     >>> alpha = np.array([[3.42525091, 0.62391373, 0.1688554],
-    >>>                   [3.42525091, 0.62391373, 0.1688554]], requires_grad=True),
-    >>> mol = Molecule(symbols, geometry, alpha=alpha)
+    >>>                   [3.42525091, 0.62391373, 0.1688554]], requires_grad=True)
+    >>> mol = qml.hf.Molecule(symbols, geometry, alpha=alpha)
     >>> args = [alpha]
-    >>> v_fock, coeffs, fock_matrix, h_core, repulsion_tensor = generate_hartree_fock(mol)(*args)
+    >>> v_fock, coeffs, fock_matrix, h_core, repulsion_tensor = generate_scf(mol)(*args)
     >>> v_fock
     array([-0.67578019,  0.94181155])
     """
@@ -192,7 +192,7 @@ def nuclear_energy(charges, r):
 
     >>> symbols  = ['H', 'F']
     >>> geometry = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 2.0]], requires_grad = True)
-    >>> mol = Molecule(symbols, geometry)
+    >>> mol = qml.hf. Molecule(symbols, geometry)
     >>> args = [mol.coordinates]
     >>> e = nuclear_energy(mol.nuclear_charges, mol.coordinates)(*args)
     >>> print(e)
@@ -235,8 +235,8 @@ def hf_energy(mol):
     >>> symbols  = ['H', 'H']
     >>> geometry = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad = False)
     >>> alpha = np.array([[3.42525091, 0.62391373, 0.1688554],
-    >>>                   [3.42525091, 0.62391373, 0.1688554]], requires_grad=True),
-    >>> mol = Molecule(symbols, geometry, alpha=alpha)
+    >>>                   [3.42525091, 0.62391373, 0.1688554]], requires_grad=True)
+    >>> mol = qml.hf.Molecule(symbols, geometry, alpha=alpha)
     >>> args = [alpha]
     >>> hf_energy(mol)(*args)
     -1.065999461545263

--- a/pennylane/hf/integrals.py
+++ b/pennylane/hf/integrals.py
@@ -48,7 +48,7 @@ def primitive_norm(l, alpha):
 
     >>> l = (0, 0, 0)
     >>> alpha = np.array([3.425250914])
-    >>> n = gaussian_norm(l, alpha)
+    >>> n = primitive_norm(l, alpha)
     >>> print(n)
     array([1.79444183])
     """
@@ -240,7 +240,7 @@ def gaussian_overlap(la, lb, ra, rb, alpha, beta):
     **Example**
 
     >>> la, lb = (0, 0, 0), (0, 0, 0)
-    >>> ra, rb = np.array(([0., 0., 0.]), np.array(([0., 0., 0.])
+    >>> ra, rb = np.array([0., 0., 0.]), np.array([0., 0., 0.])
     >>> alpha = np.array([np.pi/2])
     >>> beta = np.array([np.pi/2])
     >>> o = gaussian_overlap(la, lb, ra, rb, alpha, beta)
@@ -268,7 +268,7 @@ def generate_overlap(basis_a, basis_b):
 
     >>> symbols  = ['H', 'H']
     >>> geometry = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad = False)
-    >>> mol = Molecule(symbols, geometry)
+    >>> mol = qml.hf.Molecule(symbols, geometry)
     >>> args = []
     >>> generate_overlap(mol.basis_set[0], mol.basis_set[0])(*args)
     1.0
@@ -372,7 +372,8 @@ def gaussian_kinetic(la, lb, ra, rb, alpha, beta):
     **Example**
 
     >>> la, lb = (0, 0, 0), (0, 0, 0)
-    >>> ra, rb = np.array(([0., 0., 0.]), np.array(([0., 0., 0.])
+    >>> ra = np.array([0., 0., 0.])
+    >>> rb = rb = np.array([0., 0., 0.])
     >>> alpha = np.array([np.pi/2])
     >>> beta = np.array([np.pi/2])
     >>> t = gaussian_kinetic(la, lb, ra, rb, alpha, beta)
@@ -425,7 +426,7 @@ def generate_kinetic(basis_a, basis_b):
     >>> geometry = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad = False)
     >>> alpha = np.array([[3.425250914, 0.6239137298, 0.168855404],
     >>>                   [3.425250914, 0.6239137298, 0.168855404]], requires_grad = True)
-    >>> mol = hf.Molecule(symbols, geometry, alpha=alpha)
+    >>> mol = qml.hf.Molecule(symbols, geometry, alpha=alpha)
     >>> args = [mol.alpha]
     >>> generate_kinetic(mol.basis_set[0], mol.basis_set[1])(*args)
     0.38325367405312843
@@ -633,7 +634,7 @@ def generate_attraction(r, basis_a, basis_b):
     >>> geometry = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad = False)
     >>> alpha = np.array([[3.425250914, 0.6239137298, 0.168855404],
     >>>                   [3.425250914, 0.6239137298, 0.168855404]], requires_grad = True)
-    >>> mol = Molecule(symbols, geometry, alpha=alpha)
+    >>> mol = qml.hf.Molecule(symbols, geometry, alpha=alpha)
     >>> basis_a = mol.basis_set[0]
     >>> basis_b = mol.basis_set[1]
     >>> args = [mol.alpha]
@@ -783,7 +784,7 @@ def generate_repulsion(basis_a, basis_b, basis_c, basis_d):
     >>>                   [3.425250914, 0.6239137298, 0.168855404],
     >>>                   [3.425250914, 0.6239137298, 0.168855404],
     >>>                   [3.425250914, 0.6239137298, 0.168855404]], requires_grad = True)
-    >>> mol = Molecule(symbols, geometry, alpha=alpha)
+    >>> mol = qml.hf.Molecule(symbols, geometry, alpha=alpha)
     >>> basis_a = mol.basis_set[0]
     >>> basis_b = mol.basis_set[1]
     >>> args = [mol.alpha]

--- a/pennylane/hf/matrices.py
+++ b/pennylane/hf/matrices.py
@@ -48,7 +48,7 @@ def molecular_density_matrix(n_electron, c):
 
     >>> c = np.array([[-0.54828771,  1.21848441], [-0.54828771, -1.21848441]])
     >>> n_electron = 2
-    >>> density_matrix(n_electron, c)
+    >>> molecular_density_matrix(n_electron, c)
     array([[0.30061941, 0.30061941], [0.30061941, 0.30061941]])
     """
     p = anp.dot(c[:, : n_electron // 2], anp.conjugate(c[:, : n_electron // 2]).T)
@@ -69,10 +69,10 @@ def generate_overlap_matrix(basis_functions):
     >>> symbols  = ['H', 'H']
     >>> geometry = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad = False)
     >>> alpha = np.array([[3.42525091, 0.62391373, 0.1688554],
-    >>>                   [3.42525091, 0.62391373, 0.1688554]], requires_grad=True),
-    >>> mol = Molecule(symbols, geometry, alpha=alpha)
+    >>>                   [3.42525091, 0.62391373, 0.1688554]], requires_grad=True)
+    >>> mol = qml.hf.Molecule(symbols, geometry, alpha=alpha)
     >>> args = [alpha]
-    >>> overlap_matrix(mol.basis_set)(*args)
+    >>> generate_overlap_matrix(mol.basis_set)(*args)
     array([[1.0, 0.7965883009074122], [0.7965883009074122, 1.0]])
     """
 
@@ -119,10 +119,10 @@ def generate_kinetic_matrix(basis_functions):
     >>> symbols  = ['H', 'H']
     >>> geometry = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad = False)
     >>> alpha = np.array([[3.42525091, 0.62391373, 0.1688554],
-    >>>                   [3.42525091, 0.62391373, 0.1688554]], requires_grad=True),
-    >>> mol = Molecule(symbols, geometry, alpha=alpha)
+    >>>                   [3.42525091, 0.62391373, 0.1688554]], requires_grad=True)
+    >>> mol = qml.hf.Molecule(symbols, geometry, alpha=alpha)
     >>> args = [alpha]
-    >>> kinetic_matrix(mol.basis_set)(*args)
+    >>> generate_kinetic_matrix(mol.basis_set)(*args)
     array([[0.76003189, 0.38325367], [0.38325367, 0.76003189]])
     """
 
@@ -172,10 +172,10 @@ def generate_attraction_matrix(basis_functions, charges, r):
     >>> symbols  = ['H', 'H']
     >>> geometry = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad = False)
     >>> alpha = np.array([[3.42525091, 0.62391373, 0.1688554],
-    >>>                   [3.42525091, 0.62391373, 0.1688554]], requires_grad=True),
-    >>> mol = Molecule(symbols, geometry, alpha=alpha)
+    >>>                   [3.42525091, 0.62391373, 0.1688554]], requires_grad=True)
+    >>> mol = qml.hf.Molecule(symbols, geometry, alpha=alpha)
     >>> args = [alpha]
-    >>> attraction_matrix(mol.basis_set, mol.nuclear_charges, mol.coordinates)(*args)
+    >>> generate_attraction_matrix(mol.basis_set, mol.nuclear_charges, mol.coordinates)(*args)
     array([[-2.03852057, -1.60241667], [-1.60241667, -2.03852057]])
     """
 
@@ -241,10 +241,10 @@ def generate_repulsion_tensor(basis_functions):
     >>> symbols  = ['H', 'H']
     >>> geometry = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad = False)
     >>> alpha = np.array([[3.42525091, 0.62391373, 0.1688554],
-    >>>                   [3.42525091, 0.62391373, 0.1688554]], requires_grad=True),
-    >>> mol = Molecule(symbols, geometry, alpha=alpha)
+    >>>                   [3.42525091, 0.62391373, 0.1688554]], requires_grad=True)
+    >>> mol = qml.hf.Molecule(symbols, geometry, alpha=alpha)
     >>> args = [alpha]
-    >>> repulsion_tensor(mol.basis_set)(*args)
+    >>> generate_repulsion_tensor(mol.basis_set)(*args)
     array([[[[0.77460595, 0.56886144], [0.56886144, 0.65017747]],
             [[0.56886144, 0.45590152], [0.45590152, 0.56886144]]],
            [[[0.56886144, 0.45590152], [0.45590152, 0.56886144]],
@@ -319,10 +319,10 @@ def generate_core_matrix(basis_functions, charges, r):
     >>> symbols  = ['H', 'H']
     >>> geometry = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad = False)
     >>> alpha = np.array([[3.42525091, 0.62391373, 0.1688554],
-    >>>                   [3.42525091, 0.62391373, 0.1688554]], requires_grad=True),
-    >>> mol = Molecule(symbols, geometry, alpha=alpha)
+    >>>                   [3.42525091, 0.62391373, 0.1688554]], requires_grad=True)
+    >>> mol = qml.hf.Molecule(symbols, geometry, alpha=alpha)
     >>> args = [alpha]
-    >>> core_matrix(mol.basis_set, mol.nuclear_charges, mol.coordinates)(*args)
+    >>> generate_core_matrix(mol.basis_set, mol.nuclear_charges, mol.coordinates)(*args)
     array([[-1.27848869, -1.21916299], [-1.21916299, -1.27848869]])
     """
 

--- a/pennylane/hf/molecule.py
+++ b/pennylane/hf/molecule.py
@@ -49,7 +49,7 @@ class Molecule:
     **Example**
 
     >>> symbols  = ['H', 'H']
-    >>> geometry = pnp.array([[0.0, 0.0, -0.694349],
+    >>> geometry = np.array([[0.0, 0.0, -0.694349],
     >>>                       [0.0, 0.0,  0.694349]], requires_grad = True)
     >>> mol = Molecule(symbols, geometry)
     >>> print(mol.n_electrons)


### PR DESCRIPTION
A couple of docstrings in the new hf module have typos or outdated names.  This PR fixes them.