### PR TITLE
Modify 'qchem.meanfield' function to avoid creating a directory tree

### DIFF
--- a/qchem/CHANGELOG.md
+++ b/qchem/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 <h3>Improvements</h3>
 
+* The ``meanfield`` function has been modified to avoid creating
+  a directory tree to the HF data file. Now the filename output by
+  the function encodes the qchem package and basis set
+  used to run the HF calculations. This ensures compatibility
+  with multiprocessing environment
+  [(#1854)](https://github.com/PennyLaneAI/pennylane/pull/1854)
+
 <h3>Bug fixes</h3>
 
 <h3>Breaking changes</h3>
@@ -11,6 +18,8 @@
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):
+
+Alain Delgado Gran
 
 # Release 0.19.0
 

--- a/qchem/pennylane_qchem/qchem/structure.py
+++ b/qchem/pennylane_qchem/qchem/structure.py
@@ -221,7 +221,7 @@ def read_structure(filepath, outpath="."):
 
     symbols = []
     coordinates = []
-    with open(file_out) as f:
+    with open(file_out, encoding="utf-8") as f:
         for line in f.readlines()[2:]:
             symbol, x, y, z = line.split()
             symbols.append(symbol)

--- a/qchem/pennylane_qchem/qchem/structure.py
+++ b/qchem/pennylane_qchem/qchem/structure.py
@@ -248,8 +248,7 @@ def meanfield(
     This function uses OpenFermion-PySCF and OpenFermion-Psi4 plugins to
     perform the Hartree-Fock (HF) calculation for the polyatomic system using the quantum
     chemistry packages ``PySCF`` and ``Psi4``, respectively. The mean field electronic
-    structure is saved in an hdf5-formatted file in the directory
-    ``os.path.join(outpath, package, basis)``.
+    structure is saved in an hdf5-formatted file.
 
     The charge of the molecule can be given to simulate cationic/anionic systems.
     Also, the spin multiplicity can be input to determine the number of unpaired electrons

--- a/qchem/pennylane_qchem/qchem/structure.py
+++ b/qchem/pennylane_qchem/qchem/structure.py
@@ -288,7 +288,7 @@ def meanfield(
 
     >>> symbols, coordinates = (['H', 'H'], np.array([0., 0., -0.66140414, 0., 0., 0.66140414]))
     >>> meanfield(symbols, coordinates, name="h2")
-    ./pyscf/sto-3g/h2
+    ./h2_pyscf_sto-3g
     """
 
     if coordinates.size != 3 * len(symbols):
@@ -306,16 +306,8 @@ def meanfield(
         )
         raise TypeError(error_message)
 
-    package_dir = os.path.join(outpath.strip(), package)
-    basis_dir = os.path.join(package_dir, basis.strip())
-
-    if not os.path.isdir(package_dir):
-        os.mkdir(package_dir)
-        os.mkdir(basis_dir)
-    elif not os.path.isdir(basis_dir):
-        os.mkdir(basis_dir)
-
-    path_to_file = os.path.join(basis_dir, name.strip())
+    filename = name + "_" + package.lower() + "_" + basis.strip()
+    path_to_file = os.path.join(outpath.strip(), filename)
 
     geometry = [
         [symbol, tuple(coordinates[3 * i : 3 * i + 3] * bohr_angs)]

--- a/qchem/tests/test_meanfield.py
+++ b/qchem/tests/test_meanfield.py
@@ -20,7 +20,8 @@ def test_path_to_file(package, basis, tmpdir, psi4_support):
     if package == "Psi4" and not psi4_support:
         pytest.skip("Skipped, no Psi4 support")
 
-    exp_path = os.path.join(tmpdir.strpath, package.lower(), basis.strip(), name)
+    filename = name.strip() + "_" + package.lower() + "_" + basis.strip()
+    exp_path = os.path.join(tmpdir.strpath, filename)
 
     res_path = qchem.meanfield(
         symbols, coordinates, name=name, basis=basis, package=package, outpath=tmpdir.strpath


### PR DESCRIPTION
**Context:**
The function ``qchem.meanfield`` runs the HF calculation, using either PySCF or Psi4, and outputs the path to the file containing the HF data. Currently, this functions creates a directory tree based on the used  QChem package and the chosen basis set. For example:

```python
>>> qml.qchem.meanfield(symbols, coords, name="h2")
./pyscf/sto-3g/h2
```
Creating this directory structure causes problems when PennyLane is run in a  multiprocessing environment as pointed out by @mlxd.

**Description of the Change:**
Modify ``menafield`` function to encode the package and the basis set information in the name of the file instead of creating the dir tree.

```python
>>> qml.qchem.meanfield(symbols, coords, name="h2")
./h2_pyscf_sto-3g
```
**Benefits:**
Suppress creation of the dir tree, simplify the output of the function and ensures compatibility with multiprocessing environments.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None