### PR TITLE
Update deprecated use of `qml.grad`/`qml.jacobian` in docstrings

### DIFF
--- a/pennylane/_grad.py
+++ b/pennylane/_grad.py
@@ -20,6 +20,7 @@ from functools import partial
 import numpy as onp
 from autograd import jacobian as _jacobian
 from autograd.core import make_vjp as _make_vjp
+from autograd.numpy.numpy_boxes import ArrayBox
 from autograd.extend import vspace
 from autograd.wrap_util import unary_to_nary
 
@@ -85,8 +86,11 @@ class grad:
         argnum = []
 
         for idx, arg in enumerate(args):
+
             trainable = getattr(arg, "requires_grad", None)
-            if trainable is None:
+            array_box = isinstance(arg, ArrayBox)
+
+            if trainable is None and not array_box:
 
                 warnings.warn(
                     "Starting with PennyLane v0.20.0, when using Autograd, inputs "
@@ -95,6 +99,8 @@ class grad:
                     "identified.",
                     UserWarning,
                 )
+
+            if trainable is None:
                 trainable = True
 
             if trainable:
@@ -184,8 +190,11 @@ def jacobian(func, argnum=None):
         argnum = []
 
         for idx, arg in enumerate(args):
+
             trainable = getattr(arg, "requires_grad", None)
-            if trainable is None:
+            array_box = isinstance(arg, ArrayBox)
+
+            if trainable is None and not array_box:
 
                 warnings.warn(
                     "Starting with PennyLane v0.20.0, when using Autograd, inputs "
@@ -194,6 +203,8 @@ def jacobian(func, argnum=None):
                     "identified.",
                     UserWarning,
                 )
+
+            if trainable is None:
                 trainable = True
 
             if trainable:

--- a/pennylane/devices/default_qubit_autograd.py
+++ b/pennylane/devices/default_qubit_autograd.py
@@ -50,7 +50,7 @@ class DefaultQubitAutograd(DefaultQubit):
     ...     qml.RX(x[1], wires=0)
     ...     qml.Rot(x[0], x[1], x[2], wires=0)
     ...     return qml.expval(qml.PauliZ(0))
-    >>> weights = np.array([0.2, 0.5, 0.1])
+    >>> weights = np.array([0.2, 0.5, 0.1], requires_grad=True)
     >>> grad_fn = qml.grad(circuit)
     >>> print(grad_fn(weights))
     array([-2.2526717e-01 -1.0086454e+00  1.3877788e-17])

--- a/pennylane/math/is_independent.py
+++ b/pennylane/math/is_independent.py
@@ -23,6 +23,7 @@ a function is independent of its arguments for the interfaces
 import warnings
 
 import numpy as np
+from pennylane import numpy as pnp
 
 from autograd.tracer import isbox, new_box, trace_stack
 from autograd.core import VJPNode
@@ -199,6 +200,10 @@ def _get_random_args(args, interface, num, seed, bounds):
             tuple(np.random.random(np.shape(arg)) * width + bounds[0] for arg in args)
             for _ in range(num)
         ]
+        if interface == "autograd":
+
+            # Mark the arguments as trainable with Autograd
+            rnd_args = pnp.array(rnd_args, requires_grad=True)
 
     return rnd_args
 
@@ -328,8 +333,8 @@ def is_independent(
 
     .. code-block:: pycon
 
-        >>> x = np.array([0.2, 9.1, -3.2])
-        >>> weights = np.array([1.1, -0.7, 1.8])
+        >>> x = np.array([0.2, 9.1, -3.2], requires_grad=True)
+        >>> weights = np.array([1.1, -0.7, 1.8], requires_grad=True)
         >>> qml.math.is_independent(lin, "autograd", (x,), {"weights": weights})
         False
 

--- a/pennylane/math/quantum.py
+++ b/pennylane/math/quantum.py
@@ -67,7 +67,7 @@ def cov_matrix(prob, obs, wires=None, diag_approx=False):
     We can now compute the covariance matrix:
 
     >>> shape = qml.templates.StronglyEntanglingLayers.shape(n_layers=2, n_wires=3)
-    >>> weights = np.random.random(shape)
+    >>> weights = np.random.random(shape, requires_grad=True)
     >>> cov = qml.math.cov_matrix(circuit(weights), obs_list)
     >>> cov
     array([[0.98707611, 0.03665537],

--- a/pennylane/tracker.py
+++ b/pennylane/tracker.py
@@ -102,8 +102,9 @@ class Tracker:
         >>> def shots_info(totals, history, latest):
         ...     if 'shots' in latest.keys():
         ...         print("Total shots: ", totals['shots'])
+        >>> x = np.array(0.1, requires_grad=True)
         >>> with qml.Tracker(circuit.device, callback=shots_info) as tracker:
-        ...     qml.grad(circuit)(0.1)
+        ...     qml.grad(circuit)(x)
         Total shots:  100
         Total shots:  200
         Total shots:  300

--- a/pennylane/tracker.py
+++ b/pennylane/tracker.py
@@ -64,7 +64,7 @@ class Tracker:
             qml.RX(x, wires=0)
             return qml.expval(qml.PauliZ(0))
 
-        x = np.array(0.1)
+        x = np.array(0.1, requires_grad=True)
 
         with qml.Tracker(dev) as tracker:
             qml.grad(circuit)(x)

--- a/pennylane/transforms/batch_params.py
+++ b/pennylane/transforms/batch_params.py
@@ -86,7 +86,7 @@ def batch_params(tape, all_operations=False):
     >>> cost_fn(x, weights)
     tensor(0.03758966, requires_grad=True)
     >>> qml.grad(cost_fn)(x, weights)[0]
-    array([-0.25874785, -0.20385371, -0.48930298])
+    array([-0.30262974,  0.06320878,  0.00811555])
 
     If we pass the ``all_operations`` argument, we can specify that
     *all* operation parameters in the transformed QNode, regardless of whether they

--- a/pennylane/transforms/batch_params.py
+++ b/pennylane/transforms/batch_params.py
@@ -77,9 +77,7 @@ def batch_params(tape, all_operations=False):
     of shape ``(batch_size,)``:
 
     >>> circuit(x, weights)
-    tensor([[-0.15495184],
-            [-0.30994815],
-            [ 0.34075768]], requires_grad=True)
+    tensor([-0.30773348 0.23135516 0.13086565], requires_grad=True)
 
     QNodes with a batch dimension remain fully differentiable:
 

--- a/pennylane/transforms/batch_params.py
+++ b/pennylane/transforms/batch_params.py
@@ -71,7 +71,8 @@ def batch_params(tape, all_operations=False):
 
     >>> batch_size = 3
     >>> x = np.linspace(0.1, 0.5, batch_size)
-    >>> weights = np.random.random((batch_size, 10, 3, 3), requires_grad=True)
+    >>> rng = np.random.default_rng(seed=1234)
+    >>> weights = rng.random((batch_size, 10, 3, 3), requires_grad=True)
 
     If we evaluate the QNode with these inputs, we will get an output
     of shape ``(batch_size,)``:

--- a/pennylane/transforms/batch_params.py
+++ b/pennylane/transforms/batch_params.py
@@ -78,7 +78,7 @@ def batch_params(tape, all_operations=False):
     of shape ``(batch_size,)``:
 
     >>> circuit(x, weights)
-    tensor([-0.30773348 0.23135516 0.13086565], requires_grad=True)
+    tensor([ 0.00800498,  0.2735391 , -0.24395442], requires_grad=True)
 
     QNodes with a batch dimension remain fully differentiable:
 

--- a/pennylane/transforms/batch_params.py
+++ b/pennylane/transforms/batch_params.py
@@ -71,21 +71,23 @@ def batch_params(tape, all_operations=False):
 
     >>> batch_size = 3
     >>> x = np.linspace(0.1, 0.5, batch_size)
-    >>> weights = np.random.random((batch_size, 10, 3, 3))
+    >>> weights = np.random.random((batch_size, 10, 3, 3), requires_grad=True)
 
     If we evaluate the QNode with these inputs, we will get an output
     of shape ``(batch_size,)``:
 
     >>> circuit(x, weights)
-    [-0.30773348  0.23135516  0.13086565]
+    tensor([[-0.15495184],
+            [-0.30994815],
+            [ 0.34075768]], requires_grad=True)
 
     QNodes with a batch dimension remain fully differentiable:
 
     >>> cost_fn = lambda x, weights: np.sum(circuit(x, weights))
     >>> cost_fn(x, weights)
-    -0.8581269507766536
+    tensor(-0.78401022, requires_grad=True)
     >>> qml.grad(cost_fn)(x, weights)[0]
-    [ 0.23235464  0.00928953 -0.30083487]
+    array([-0.25874785, -0.20385371, -0.48930298])
 
     If we pass the ``all_operations`` argument, we can specify that
     *all* operation parameters in the transformed QNode, regardless of whether they
@@ -104,9 +106,9 @@ def batch_params(tape, all_operations=False):
     >>> cost_fn = lambda x, weights: np.sum(circuit(x, weights))
     >>> weights.requires_grad = False
     >>> cost_fn(x, weights)
-    0.5497108163237583
+    tensor(-0.78401022, requires_grad=True)
     >>> qml.grad(cost_fn)(x, weights)[0]
-    0.43792281188363347
+    -0.2587478476364347
     """
     params = tape.get_parameters(trainable_only=not all_operations)
     output_tapes = []

--- a/pennylane/transforms/batch_params.py
+++ b/pennylane/transforms/batch_params.py
@@ -84,7 +84,7 @@ def batch_params(tape, all_operations=False):
 
     >>> cost_fn = lambda x, weights: np.sum(circuit(x, weights))
     >>> cost_fn(x, weights)
-    tensor(-0.78401022, requires_grad=True)
+    tensor(0.03758966, requires_grad=True)
     >>> qml.grad(cost_fn)(x, weights)[0]
     array([-0.25874785, -0.20385371, -0.48930298])
 

--- a/pennylane/transforms/batch_params.py
+++ b/pennylane/transforms/batch_params.py
@@ -105,7 +105,7 @@ def batch_params(tape, all_operations=False):
     >>> cost_fn = lambda x, weights: np.sum(circuit(x, weights))
     >>> weights.requires_grad = False
     >>> cost_fn(x, weights)
-    tensor(-0.78401022, requires_grad=True)
+    tensor(0.03758966, requires_grad=True)
     >>> qml.grad(cost_fn)(x, weights)[0]
     -0.2587478476364347
     """

--- a/pennylane/transforms/batch_params.py
+++ b/pennylane/transforms/batch_params.py
@@ -135,4 +135,4 @@ def batch_params(tape, all_operations=False):
         new_tape.set_parameters(p, trainable_only=not all_operations)
         output_tapes.append(new_tape)
 
-    return output_tapes, qml.math.stack
+    return output_tapes, lambda x: qml.math.squeeze(qml.math.stack(x))

--- a/pennylane/transforms/batch_params.py
+++ b/pennylane/transforms/batch_params.py
@@ -95,7 +95,7 @@ def batch_params(tape, all_operations=False):
 
     .. code-block:: python
 
-        @functools.partial(qml.batch_params, all_operations=True)
+        @qml.batch_params(all_operations=True)
         @qml.beta.qnode(dev)
         def circuit(x, weights):
             qml.RX(x, wires=0)

--- a/pennylane/transforms/batch_params.py
+++ b/pennylane/transforms/batch_params.py
@@ -107,7 +107,7 @@ def batch_params(tape, all_operations=False):
     >>> cost_fn(x, weights)
     tensor(0.03758966, requires_grad=True)
     >>> qml.grad(cost_fn)(x, weights)[0]
-    -0.2587478476364347
+    -0.30262974103192636
     """
     params = tape.get_parameters(trainable_only=not all_operations)
     output_tapes = []

--- a/pennylane/transforms/batch_transform.py
+++ b/pennylane/transforms/batch_transform.py
@@ -150,7 +150,8 @@ class batch_transform:
 
     Batch tape transforms are fully differentiable:
 
-    >>> gradient = qml.grad(circuit)(-0.5)
+    >>> x = np.array(-0.5, requires_grad=True)
+    >>> gradient = qml.grad(circuit)(x)
     >>> print(gradient)
     2.5800122591960153
 

--- a/tests/interfaces/test_batch_autograd.py
+++ b/tests/interfaces/test_batch_autograd.py
@@ -744,7 +744,7 @@ class TestHigherOrderDerivatives:
             np.array([-2.0, 0], requires_grad=True),
         ],
     )
-    def test_parameter_shift_hessian(self, params, tol):
+    def test_parameter_shift_hessian(self, params, tol, recwarn):
         """Tests that the output of the parameter-shift transform
         can be differentiated using autograd, yielding second derivatives."""
         dev = qml.device("default.qubit.autograd", wires=2)
@@ -786,7 +786,11 @@ class TestHigherOrderDerivatives:
         )
         assert np.allclose(res, expected, atol=tol, rtol=0)
 
-    def test_adjoint_hessian(self, tol):
+        # Check that no deprecation warnigns are emitted due to trainable
+        # parameters with the Autograd interface
+        assert len(recwarn) == 0
+
+    def test_adjoint_hessian(self, tol, recwarn):
         """Since the adjoint hessian is not a differentiable transform,
         higher-order derivatives are not supported."""
         dev = qml.device("default.qubit.autograd", wires=2)
@@ -810,6 +814,10 @@ class TestHigherOrderDerivatives:
             res = qml.jacobian(qml.grad(cost_fn))(params)
 
         assert np.allclose(res, np.zeros([2, 2]), atol=tol, rtol=0)
+
+        # Check that no additional deprecation warnigns are emitted due to trainable
+        # parameters with the Autograd interface
+        assert len(recwarn) == 0
 
     def test_max_diff(self, tol):
         """Test that setting the max_diff parameter blocks higher-order

--- a/tests/transforms/test_batch_params.py
+++ b/tests/transforms/test_batch_params.py
@@ -41,7 +41,7 @@ def test_simple_circuit(mocker):
 
     spy = mocker.spy(circuit.device, "batch_execute")
     res = circuit(data, x, weights)
-    assert res.shape == (batch_size, 1, 4)
+    assert res.shape == (batch_size, 4)
     assert len(spy.call_args[0][0]) == batch_size
 
 
@@ -224,7 +224,7 @@ def test_all_operations(mocker):
 
     spy = mocker.spy(circuit.device, "batch_execute")
     res = circuit(x, weights)
-    assert res.shape == (batch_size, 1, 4)
+    assert res.shape == (batch_size, 4)
     assert len(spy.call_args[0][0]) == batch_size
 
 


### PR DESCRIPTION
Updates docstrings that use `qml.grad`/`qml.jacobian` in light of #1773.

The following files were already okay (or are being updated separately):

1. Containing  `qml.grad`:
* `interfaces/batch/__init__.py`
* `transforms/unitary_to_rot.py` (addressed in #1859)
* `transforms/qfunc_transforms.py`
* `transforms/metric_tensor.py`
* `transforms/get_unitary_matrix.py`
* `transforms/batch_transform.py`
* `gradients/__init__.py`

2. Containing  `qml.jacobian`:
* `math/is_independent.py`: https://github.com/PennyLaneAI/pennylane/pull/1862
* `interfaces/autograd.py`
* `interfaces/batch/__init__.py`
* `gradients` (multiple files)

Features explicitly using `qml.grad`/`qml.jacobian`:

* `transforms/classical_jacobian.py`: uses the argnum syntax internally and offers this option too
* `optimize/shot_adaptive.py`: good, uses the `argnum` syntax