### PR TITLE
`qml.math.is_independent` no deprecation warnings with `qml.grad`/`qml.jacobian`

### DIFF
--- a/pennylane/_grad.py
+++ b/pennylane/_grad.py
@@ -86,8 +86,10 @@ class grad:
         argnum = []
 
         for idx, arg in enumerate(args):
+
             trainable = getattr(arg, "requires_grad", None)
             array_box = isinstance(arg, ArrayBox)
+
             if trainable is None and not array_box:
 
                 warnings.warn(
@@ -97,6 +99,8 @@ class grad:
                     "identified.",
                     UserWarning,
                 )
+
+            if trainable is None:
                 trainable = True
 
             if trainable:
@@ -186,8 +190,10 @@ def jacobian(func, argnum=None):
         argnum = []
 
         for idx, arg in enumerate(args):
+
             trainable = getattr(arg, "requires_grad", None)
             array_box = isinstance(arg, ArrayBox)
+
             if trainable is None and not array_box:
 
                 warnings.warn(
@@ -197,6 +203,8 @@ def jacobian(func, argnum=None):
                     "identified.",
                     UserWarning,
                 )
+
+            if trainable is None:
                 trainable = True
 
             if trainable:

--- a/pennylane/_grad.py
+++ b/pennylane/_grad.py
@@ -20,6 +20,7 @@ from functools import partial
 import numpy as onp
 from autograd import jacobian as _jacobian
 from autograd.core import make_vjp as _make_vjp
+from autograd.numpy.numpy_boxes import ArrayBox
 from autograd.extend import vspace
 from autograd.wrap_util import unary_to_nary
 
@@ -86,7 +87,8 @@ class grad:
 
         for idx, arg in enumerate(args):
             trainable = getattr(arg, "requires_grad", None)
-            if trainable is None:
+            array_box = isinstance(arg, ArrayBox)
+            if trainable is None and not array_box:
 
                 warnings.warn(
                     "Starting with PennyLane v0.20.0, when using Autograd, inputs "
@@ -185,7 +187,8 @@ def jacobian(func, argnum=None):
 
         for idx, arg in enumerate(args):
             trainable = getattr(arg, "requires_grad", None)
-            if trainable is None:
+            array_box = isinstance(arg, ArrayBox)
+            if trainable is None and not array_box:
 
                 warnings.warn(
                     "Starting with PennyLane v0.20.0, when using Autograd, inputs "

--- a/pennylane/math/is_independent.py
+++ b/pennylane/math/is_independent.py
@@ -328,8 +328,8 @@ def is_independent(
 
     .. code-block:: pycon
 
-        >>> x = np.array([0.2, 9.1, -3.2])
-        >>> weights = np.array([1.1, -0.7, 1.8])
+        >>> x = np.array([0.2, 9.1, -3.2], requires_grad=True)
+        >>> weights = np.array([1.1, -0.7, 1.8], requires_grad=True)
         >>> qml.math.is_independent(lin, "autograd", (x,), {"weights": weights})
         False
 

--- a/pennylane/math/is_independent.py
+++ b/pennylane/math/is_independent.py
@@ -22,7 +22,8 @@ a function is independent of its arguments for the interfaces
 """
 import warnings
 
-from pennylane import numpy as np
+import numpy as np
+from pennylane import numpy as pnp
 
 from autograd.tracer import isbox, new_box, trace_stack
 from autograd.core import VJPNode
@@ -196,12 +197,13 @@ def _get_random_args(args, interface, num, seed, bounds):
     else:
         np.random.seed(seed)
         rnd_args = [
-            tuple(
-                np.random.random(np.shape(arg), requires_grad=True) * width + bounds[0]
-                for arg in args
-            )
+            tuple(np.random.random(np.shape(arg)) * width + bounds[0] for arg in args)
             for _ in range(num)
         ]
+        if interface == "autograd":
+
+            # Mark the arguments as trainable with Autograd
+            rnd_args = pnp.array(rnd_args, requires_grad=True)
 
     return rnd_args
 

--- a/pennylane/math/is_independent.py
+++ b/pennylane/math/is_independent.py
@@ -196,7 +196,10 @@ def _get_random_args(args, interface, num, seed, bounds):
     else:
         np.random.seed(seed)
         rnd_args = [
-            tuple(np.random.random(np.shape(arg), requires_grad=True) * width + bounds[0] for arg in args)
+            tuple(
+                np.random.random(np.shape(arg), requires_grad=True) * width + bounds[0]
+                for arg in args
+            )
             for _ in range(num)
         ]
 

--- a/pennylane/math/is_independent.py
+++ b/pennylane/math/is_independent.py
@@ -22,7 +22,7 @@ a function is independent of its arguments for the interfaces
 """
 import warnings
 
-import numpy as np
+from pennylane import numpy as np
 
 from autograd.tracer import isbox, new_box, trace_stack
 from autograd.core import VJPNode
@@ -196,7 +196,7 @@ def _get_random_args(args, interface, num, seed, bounds):
     else:
         np.random.seed(seed)
         rnd_args = [
-            tuple(np.random.random(np.shape(arg)) * width + bounds[0] for arg in args)
+            tuple(np.random.random(np.shape(arg), requires_grad=True) * width + bounds[0] for arg in args)
             for _ in range(num)
         ]
 

--- a/tests/math/test_is_independent.py
+++ b/tests/math/test_is_independent.py
@@ -213,6 +213,7 @@ class TestIsIndependentAutograd:
         The only warning that is emitted is due to the output being independent
         of the input.
         """
+
         def lin(x):
             return pnp.sum(x)
 
@@ -223,7 +224,7 @@ class TestIsIndependentAutograd:
         # Check that there's only one warning (emitted by autograd)
         assert len(recwarn) == 1
         assert recwarn.list[0].category == UserWarning
-        assert recwarn.list[0].message.args[0] == 'Output seems independent of input.'
+        assert recwarn.list[0].message.args[0] == "Output seems independent of input."
 
         # Check that there's only one message in the warning
         assert len(recwarn.list[0].message.args) == 1
@@ -231,6 +232,7 @@ class TestIsIndependentAutograd:
     def test_no_trainable_params_deprecation_jac(self, recwarn):
         """Tests that no deprecation arises when using qml.jacobian with
         qml.math.is_independent."""
+
         def lin(x, weights=None):
             return np.dot(x, weights)
 
@@ -239,6 +241,7 @@ class TestIsIndependentAutograd:
         jac = qml.jacobian(lin)
         assert qml.math.is_independent(jac, "autograd", (x,), {"weights": weights})
         assert len(recwarn) == 0
+
 
 if have_jax:
 

--- a/tests/math/test_is_independent.py
+++ b/tests/math/test_is_independent.py
@@ -209,9 +209,6 @@ class TestIsIndependentAutograd:
     def test_no_trainable_params_deprecation_grad(self, recwarn):
         """Tests that no deprecation warning arises when using qml.grad with
         qml.math.is_independent.
-
-        The only warning that is emitted is due to the output being independent
-        of the input.
         """
 
         def lin(x):
@@ -221,13 +218,7 @@ class TestIsIndependentAutograd:
         jac = qml.grad(lin)
         assert qml.math.is_independent(jac, "autograd", (x,), {})
 
-        # Check that there's only one warning (emitted by autograd)
-        assert len(recwarn) == 1
-        assert recwarn.list[0].category == UserWarning
-        assert recwarn.list[0].message.args[0] == "Output seems independent of input."
-
-        # Check that there's only one message in the warning
-        assert len(recwarn.list[0].message.args) == 1
+        assert len(recwarn) == 0
 
     def test_no_trainable_params_deprecation_jac(self, recwarn):
         """Tests that no deprecation arises when using qml.jacobian with


### PR DESCRIPTION
Adjusts the deprecation from https://github.com/PennyLaneAI/pennylane/pull/1773 to consider `ArrayBox` objects and updates `math/is_independent.py` such that `qml.math.is_independent` doesn't emit any deprecation warnings when using `qml.grad`/`qml.jacobian`.