### PR TITLE
Hide :orphan: from displaying in the release notes

### DIFF
--- a/doc/xanadu_theme/layout.html
+++ b/doc/xanadu_theme/layout.html
@@ -308,5 +308,17 @@ if (downloadNote.length >= 1) {
 }
 </script>
 <script type="text/javascript">jQuery.noConflict(true);</script>
+<script type="text/javascript">
+  let divs = document.getElementsByClassName('field-odd');
+
+  for (let x = 0; x < divs.length; x++) {
+      let div = divs[x];
+      let content = div.innerHTML.trim();
+
+      if (content == 'orphan') {
+          div.style.display = 'none';
+      }
+  }
+</script>
         {% include "footer.html" %}
 {%- endblock %}


### PR DESCRIPTION
**Context:** After the changes introduced in #1650, the `:orphan:` directive was needed in the changelog files in order to stop Sphinx from raising warnings. Unfortunately, Sphinx will render these.

**Description of the Change:** Adds javascript to the Sphinx theme to hide the `:orphan:` directives in the rendered docs.

**Benefits:** As above.

**Possible Drawbacks:** None.

**Related GitHub Issues:** n/a
