### PR TITLE
Documentation Updates

### DIFF
--- a/doc/introduction/chemistry.rst
+++ b/doc/introduction/chemistry.rst
@@ -161,26 +161,30 @@ where a quantum computer is used to prepare the trial wave function of a molecul
 the expectation value of the *electronic Hamiltonian*, while a classical optimizer is used to
 find its ground state.
 
-We can use :class:`~.ExpvalCost` to automatically create the required PennyLane QNodes and define
-the cost function:
+PennyLane supports treating Hamiltonians just like any other observable, and the 
+expectation value of a Hamiltonian can be calculated using ``qml.expval``:
 
 .. code-block:: python
 
     import pennylane as qml
-    
+
     dev = qml.device('default.qubit', wires=4)
 
-    def circuit(params, wires):
-        qml.BasisState(np.array([1, 1, 0, 0]), wires=wires)
-        for i in wires:
+    hamiltonian = 2.0 * qml.PauliZ(0) @ qml.PauliZ(1)
+
+    @qml.qnode(dev)
+    def circuit(params):
+        qml.BasisState(np.array([1, 1, 0, 0]), wires=[0,1,2,3])
+        for i in range(4):
             qml.Rot(*params[i], wires=i)
         qml.CNOT(wires=[2, 3])
         qml.CNOT(wires=[2, 0])
         qml.CNOT(wires=[3, 1])
+        return qml.expval(hamiltonian)
 
-    cost = qml.ExpvalCost(circuit, hamiltonian, dev, interface="torch")
-    params = torch.rand([4, 3])
-    cost(params)
+    rng = np.random.default_rng(seed=42)
+    params = rng.random([4, 3])
+    circuit(params)
 
 The rotation angles can be optimized using the machine learning interface of choice
 until the energy difference between two consecutive iterations has converged to near zero.

--- a/doc/introduction/circuits.rst
+++ b/doc/introduction/circuits.rst
@@ -271,18 +271,21 @@ Consider the following two quantum nodes:
 
 
 .. code-block:: python
+
     @qml.qnode(dev1)
     def x_rotations(params):
         qml.RX(params[0], wires=0)
         qml.RX(params[1], wires=1)
         qml.CNOT(wires=[0, 1])
         return qml.expval(qml.PauliZ(0))
+
     @qml.qnode(dev2)
     def y_rotations(params):
         qml.RY(params[0], wires=0)
         qml.RY(params[1], wires=1)
         qml.CNOT(wires=[0, 1])
         return qml.expval(qml.Hadamard(0))
+
 As the QNodes in the collection have the same signature, and we can can construct a
 :class:`~.QNodeCollection` and therefore feed them the same parameters:
 
@@ -291,6 +294,7 @@ As the QNodes in the collection have the same signature, and we can can construc
 2
 >>> qnodes([0.2, 0.1])
 array([0.98006658, 0.70703636])
+
 PennyLane also provides some high-level tools for creating and evaluating
 QNode collections. For example, :func:`~.map` allows a single
 function of quantum operations (or :doc:`template <templates>`) to be mapped across
@@ -299,15 +303,18 @@ multiple observables or devices.
 For example, consider the following quantum function ansatz:
 
 .. code-block:: python
+
     def my_ansatz(params, **kwargs):
         qml.RX(params[0], wires=0)
         qml.RX(params[1], wires=1)
         qml.CNOT(wires=[0, 1])
+
 We can define a list of observables, and two devices:
 
 >>> obs_list = [qml.PauliX(0) @ qml.PauliZ(1), qml.PauliZ(0) @ qml.PauliX(1)]
 >>> qpu1 = qml.device("forest.qvm", device="Aspen-4-4Q-D") # requires PennyLane-Forest
 >>> qpu2 = qml.device("forest.qvm", device="Aspen-7-4Q-B") # requires PennyLane-Forest
+
 .. note::
 
     The two devices above require the `PennyLane-Forest plugin <https://pennylane-forest.rtfd.io>`_
@@ -327,6 +334,7 @@ Functions are available to process QNode collections, including :func:`~.pennyla
 >>> cost_fn = qml.sum(qnodes)
 >>> cost_fn(params)
 0.906
+
 .. note::
 
     QNode collections support an experimental parallel execution mode. See

--- a/doc/introduction/circuits.rst
+++ b/doc/introduction/circuits.rst
@@ -251,6 +251,88 @@ For example:
     result = circuit(0.543)
 
 
+Collections of QNodes
+---------------------
+
+Sometimes you may need multiple QNodes that only differ in the measurement observable
+(like in VQE), or in the device they are run on (for example, if you benchmark different devices),
+or even the quantum circuit that is evaluated. While these QNodes can be defined manually
+"by hand", PennyLane offers **QNode collections** as a convenient way to define and run
+families of QNodes.
+
+QNode collections are a sequence of QNodes that:
+
+1. Have the same function signature, and
+
+2. Can be evaluated independently (that is, the input of any QNode in the collection
+   does not depend on the output of another).
+
+Consider the following two quantum nodes:
+
+
+.. code-block:: python
+    @qml.qnode(dev1)
+    def x_rotations(params):
+        qml.RX(params[0], wires=0)
+        qml.RX(params[1], wires=1)
+        qml.CNOT(wires=[0, 1])
+        return qml.expval(qml.PauliZ(0))
+    @qml.qnode(dev2)
+    def y_rotations(params):
+        qml.RY(params[0], wires=0)
+        qml.RY(params[1], wires=1)
+        qml.CNOT(wires=[0, 1])
+        return qml.expval(qml.Hadamard(0))
+As the QNodes in the collection have the same signature, and we can can construct a
+:class:`~.QNodeCollection` and therefore feed them the same parameters:
+
+>>> qnodes = qml.QNodeCollection([x_rotations, y_rotations])
+>>> len(qnodes)
+2
+>>> qnodes([0.2, 0.1])
+array([0.98006658, 0.70703636])
+PennyLane also provides some high-level tools for creating and evaluating
+QNode collections. For example, :func:`~.map` allows a single
+function of quantum operations (or :doc:`template <templates>`) to be mapped across
+multiple observables or devices.
+
+For example, consider the following quantum function ansatz:
+
+.. code-block:: python
+    def my_ansatz(params, **kwargs):
+        qml.RX(params[0], wires=0)
+        qml.RX(params[1], wires=1)
+        qml.CNOT(wires=[0, 1])
+We can define a list of observables, and two devices:
+
+>>> obs_list = [qml.PauliX(0) @ qml.PauliZ(1), qml.PauliZ(0) @ qml.PauliX(1)]
+>>> qpu1 = qml.device("forest.qvm", device="Aspen-4-4Q-D") # requires PennyLane-Forest
+>>> qpu2 = qml.device("forest.qvm", device="Aspen-7-4Q-B") # requires PennyLane-Forest
+.. note::
+
+    The two devices above require the `PennyLane-Forest plugin <https://pennylane-forest.rtfd.io>`_
+    be installed, as well as the Forest QVM. You can also try replacing them with alternate devices.
+
+Mapping the template across the observables and devices creates a :class:`~.QNodeCollection`:
+
+>>> qnodes = qml.map(my_ansatz, obs_list, [qpu1, qpu2], measure="expval")
+>>> type(qnodes)
+pennylane.collections.qnode_collection.QNodeCollection
+>>> params = [0.54, 0.12]
+>>> qnodes(params)
+array([-0.02854835  0.99280864])
+Functions are available to process QNode collections, including :func:`~.pennylane.collections.dot`,
+:func:`~.pennylane.collections.sum`, and :func:`~.pennylane.collections.apply`:
+
+>>> cost_fn = qml.sum(qnodes)
+>>> cost_fn(params)
+0.906
+.. note::
+
+    QNode collections support an experimental parallel execution mode. See
+    the :class:`~.QNodeCollection` documentation for more details.
+
+
 Importing circuits from other frameworks
 ----------------------------------------
 

--- a/doc/introduction/interfaces/numpy.rst
+++ b/doc/introduction/interfaces/numpy.rst
@@ -53,8 +53,8 @@ returning NumPy arrays.
 
 It can now be used like any other Python/NumPy function:
 
->>> phi = np.array([0.5, 0.1])
->>> theta = 0.2
+>>> phi = np.array([0.5, 0.1], requires_grad=True)
+>>> theta = np.array(0.2, requires_grad=True)
 >>> circuit1(phi, theta)
 array([ 0.87758256,  0.68803733])
 
@@ -108,8 +108,8 @@ with respect to both QNode parameters ``phi`` and ``theta``:
 
 .. code-block:: python
 
-    phi = np.array([0.5, 0.1])
-    theta = 0.2
+    phi = np.array([0.5, 0.1], requires_grad=True)
+    theta = np.array(0.2, requires_grad=True)
     dcircuit = qml.grad(circuit3)
 
 Evaluating this gradient function at specific parameter values:
@@ -125,12 +125,16 @@ How does PennyLane know which arguments of a quantum function to differentiate, 
 For example, you may want to pass arguments to a QNode but *not* have
 PennyLane consider them when computing gradients.
 
-As a basic rule, **all positional arguments provided to the QNode are assumed to be differentiable
-by default**. To accomplish this, arguments are internally turned into arrays of the PennyLane NumPy module,
+Currently, all positional arguments provided to the QNode are assumed to be differentiable
+by default, but this behavior is undergoing deprecation. In a future release, only arguments explicitly
+marked as trainable will be treated as trainable. Not explicitly marking arguments currently raises a 
+deprecation warning.
+
+For now, arguments are internally turned into arrays of the PennyLane NumPy module,
 which have a special flag ``requires_grad`` specifying whether they are trainable or not:
 
 >>> from pennylane import numpy as np
->>> np.array([0.1, 0.2])
+>>> np.array([0.1, 0.2], requires_grad=True)
 tensor([0.1, 0.2], requires_grad=True)
 
 If you would like to provide explicit non-differentiable arguments to the
@@ -169,8 +173,8 @@ and two non-differentiable arguments ``data`` and ``wires``:
 
 For ``data``, which is a PennyLane NumPy array, we can simply specify ``requires_grad=False``:
 
->>> np.random.seed(42)  # make the results reproducable
->>> data = np.random.random([2**3], requires_grad=False)
+>>> rng = np.random.default_rng(seed=42)
+>>> data = rng.random([2**3], requires_grad=False)
 
 But ``wires`` is a list in this example, and if we turn it into a PennyLane NumPy array we would have to
 create a device that understands custom wire labels of this type.
@@ -180,14 +184,14 @@ QNode using keyword argument syntax:
 >>> wires = [2, 0, 1]
 >>> weights = np.array([0.1, 0.2, 0.3])
 >>> circuit(weights, data, wires=wires)
-0.4124409353413991
+tensor(-0.03404945, requires_grad=True)
 
 When we compute the derivative, arguments with ``requires_grad=False`` as well as arguments passed as
 keyword arguments are ignored by :func:`~.grad`:
 
 >>> grad_fn = qml.grad(circuit)
 >>> grad_fn(weights, data, wires=wires)
-[-4.1382126e-02  0.0000000e+00 -6.9388939e-18]
+array([ 3.41633993e-03,  8.23993651e-18, -6.93889390e-18])
 
 .. note::
 
@@ -235,7 +239,7 @@ lead to a final expectation value of 0.5:
     opt = qml.GradientDescentOptimizer(stepsize=0.4)
 
     steps = 100
-    params = np.array([0.011, 0.012, 0.05])
+    params = np.array([0.011, 0.012, 0.05], requires_grad=True)
 
     for i in range(steps):
         # update the circuit parameters
@@ -244,9 +248,9 @@ lead to a final expectation value of 0.5:
 The final weights and circuit value are:
 
 >>> params
-array([ 0.19846757,  0.012     ,  1.03559806])
+tensor([0.19846757, 0.012     , 1.03559806], requires_grad=True)
 >>> circuit4(params)
-0.5
+tensor(0.5, requires_grad=True)
 
 For more details on the NumPy optimizers, check out the tutorials, as well as the
 :mod:`pennylane.optimize` documentation.
@@ -274,8 +278,9 @@ How does automatic differentiation work in the case where the QNode returns mult
 If we were to naively try computing the gradient of ``circuit5`` using the :func:`~.grad` function,
 
 >>> g1 = qml.grad(circuit5)
->>> params = np.array([np.pi/2, 0.2])
+>>> params = np.array([np.pi/2, 0.2], requires_grad=True)
 >>> g1(params)
+TypeError: Grad only applies to real scalar-output functions. Try jacobian, elementwise_grad or holomorphic_grad.
 
 we would get an error message. This is because the `gradient <https://en.wikipedia.org/wiki/Gradient>`_ is
 only defined for scalar functions, i.e., functions which return a single value. In the case where the QNode
@@ -365,7 +370,7 @@ to the ``scipy.minimize`` function:
     def cost(x):
         return np.abs(circuit(x) - 0.5) ** 2
 
-    params = np.array([0.011, 0.012, 0.05])
+    params = np.array([0.011, 0.012, 0.05], requires_grad=True)
 
     minimize(cost, params, method='BFGS')
 

--- a/doc/introduction/interfaces/numpy.rst
+++ b/doc/introduction/interfaces/numpy.rst
@@ -376,9 +376,11 @@ to the ``scipy.minimize`` function:
 
 Some of the SciPy minimization methods require information about the gradient
 of the cost function via the ``jac`` keyword argument. This is easy to include; we
-can simply create a function that computes the gradient using ``qml.grad``:
+can simply create a function that computes the gradient using ``qml.grad``.  Since
+``minimize`` does not use our wrapped version of numpy, we need to explicitly 
+specify which arguments are trainable via the ``argnum`` keyword.
 
->>> minimize(cost, params, method='BFGS', jac=qml.grad(cost))
+>>> minimize(cost, params, method='BFGS', jac=qml.grad(cost, argnum=0))
       fun: 6.3491130264451484e-18
  hess_inv: array([[ 1.85642354e+00, -8.84954187e-22,  3.89539943e+00],
        [-8.84954187e-22,  1.00000000e+00, -4.02571211e-21],

--- a/doc/introduction/interfaces/numpy.rst
+++ b/doc/introduction/interfaces/numpy.rst
@@ -53,8 +53,8 @@ returning NumPy arrays.
 
 It can now be used like any other Python/NumPy function:
 
->>> phi = np.array([0.5, 0.1], requires_grad=True)
->>> theta = np.array(0.2, requires_grad=True)
+>>> phi = np.array([0.5, 0.1])
+>>> theta = 0.2
 >>> circuit1(phi, theta)
 array([ 0.87758256,  0.68803733])
 

--- a/doc/introduction/interfaces/numpy.rst
+++ b/doc/introduction/interfaces/numpy.rst
@@ -125,12 +125,12 @@ How does PennyLane know which arguments of a quantum function to differentiate, 
 For example, you may want to pass arguments to a QNode but *not* have
 PennyLane consider them when computing gradients.
 
-Currently, all positional arguments provided to the QNode are assumed to be differentiable
-by default, but this behavior is undergoing deprecation. In a future release, only arguments explicitly
-marked as trainable will be treated as trainable. Not explicitly marking arguments currently raises a 
+All positional arguments provided to the QNode are assumed to be differentiable
+by default, but this behaviour is deprecated. In a future release, only arguments explicitly
+marked as trainable or marked using the `argnum` keyword argument will be treated as trainable. Not explicitly marking arguments currently raises a 
 deprecation warning.
 
-For now, arguments are internally turned into arrays of the PennyLane NumPy module,
+For now, arguments are internally turned into arrays from the PennyLane NumPy module,
 which have a special flag ``requires_grad`` specifying whether they are trainable or not:
 
 >>> from pennylane import numpy as np
@@ -173,7 +173,7 @@ and two non-differentiable arguments ``data`` and ``wires``:
 
 For ``data``, which is a PennyLane NumPy array, we can simply specify ``requires_grad=False``:
 
->>> rng = np.random.default_rng(seed=42)
+>>> rng = np.random.default_rng(seed=42)  # make the results reproducable
 >>> data = rng.random([2**3], requires_grad=False)
 
 But ``wires`` is a list in this example, and if we turn it into a PennyLane NumPy array we would have to

--- a/doc/introduction/templates.rst
+++ b/doc/introduction/templates.rst
@@ -316,7 +316,7 @@ The shape can for example be used to construct random weights at the beginning o
     weights = np.random.random(size=shape)
 
 >>> circuit(weights)
-0.7258859204630561
+tensor(0.72588592, requires_grad=True)
 
 If a template takes more than one weight tensor, the ``shape`` method returns a list of shape tuples.
 


### PR DESCRIPTION
This PR updates a few things in the introduction section of the documentation like:

* explicitly marking numpy arrays as trainable
* using `qml.expval` instead of `ExpvalCost`
* substituting `"auxiliary"` for  `"ancilla"`
* Removal of section on QNode Collections (outdated way of doing things)