### PR TITLE
Testing documentation

### DIFF
--- a/doc/development/guide/tests.rst
+++ b/doc/development/guide/tests.rst
@@ -4,20 +4,27 @@ Software tests
 Running the tests
 ~~~~~~~~~~~~~~~~~
 
-The PennyLane test suite requires the Python ``pytest`` package, as well as ``pytest-cov``
-for test coverage, ``pytest-mock`` for mocking, and ``flaky`` for automatically rerunning flaky tests; these can be installed via ``pip``:
+The PennyLane test suite requires the Python ``pytest`` package, as well as:
+
+* ``pytest-cov``: determines test coverage
+* ``pytest-mock``: allows replacing components with dummy objects
+* ``flaky``: manages tests with non-deterministic behaviour
+
+ These requirements can be installed via ``pip``:
 
 .. code-block:: bash
 
     pip install pytest pytest-cov pytest-mock flaky
 
-All tests are located in the `tests <https://github.com/PennyLaneAI/pennylane/tree/master/tests>`__ folder of the root PennyLane directory. Run all tests in this folder via:
+The `tests <https://github.com/PennyLaneAI/pennylane/tree/master/tests>`__ folder of the root PennyLane directory contains the PennyLane test suite. Run all tests in this folder via:
 
 .. code-block:: bash
 
-    python -m pytest tests
+    python -m pytest --ignore=tests/beta tests
 
-Using ``python -m`` helps ensure that the tests are running with the correct version of python if you have multiple python versions and environments.  During development, locally executing only relevant files saves time.  For example, if a develop was adding a new non-parametric operation, they could run just:
+Using ``python -m`` ensures that the tests run with the correct Python version if multiple versions are on the system. The `tests/beta` folder can contain failing tests, so ``--ignore=tests/beta`` excludes them from execution.
+
+As the entire test suite takes some time, locally running only relevant files speeds the debugging cycle.  For example, if a developer was adding a new non-parametric operation, they could run:
 
 .. code-block:: bash
 
@@ -35,7 +42,7 @@ Pytest supports many other command-line options, which can be found with the com
 
     pytest --help
 
-Or by visiting the `pytest documentation page <https://docs.pytest.org/en/latest/reference/reference.html#id88>`__ . 
+Or by visiting the `pytest documentation <https://docs.pytest.org/en/latest/reference/reference.html#id88>`__ . 
 
 PennyLane provides a set of tests for all PennyLane plugins. See the documentation on these tests under the section on the `device API <https://pennylane.readthedocs.io/en/latest/code/api/pennylane.devices.tests.html>`__.
 
@@ -45,13 +52,6 @@ All PennyLane tests and the device suite on core devices can be run from the Pen
 
     make test
 
-
-Outside Resources
-~~~~~~~~~~~~~~~~~
-
-`Pytest documentation <https://docs.pytest.org/en/6.2.x/index.html>`__
-
-`Real Python tutorial <https://realpython.com/pytest-python-testing/>`__
 
 Testing Matplotlib based code
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/development/guide/tests.rst
+++ b/doc/development/guide/tests.rst
@@ -7,10 +7,10 @@ Running the tests
 The PennyLane test suite requires the Python ``pytest`` package, as well as:
 
 * ``pytest-cov``: determines test coverage
-* ``pytest-mock``: allows replacing components with dummy objects
+* ``pytest-mock``: allows replacing components with dummy/mock objects
 * ``flaky``: manages tests with non-deterministic behaviour
 
- These requirements can be installed via ``pip``:
+These requirements can be installed via ``pip``:
 
 .. code-block:: bash
 
@@ -44,7 +44,7 @@ Pytest supports many other command-line options, which can be found with the com
 
 Or by visiting the `pytest documentation <https://docs.pytest.org/en/latest/reference/reference.html#id88>`__ . 
 
-PennyLane provides a set of tests for all PennyLane plugins. See the documentation on these tests under the section on the `device API <https://pennylane.readthedocs.io/en/latest/code/api/pennylane.devices.tests.html>`__.
+PennyLane provides a set of integration tests for all PennyLane plugins and devices. See the documentation on these tests under the section on the `device API <https://pennylane.readthedocs.io/en/latest/code/api/pennylane.devices.tests.html>`__.
 
 All PennyLane tests and the device suite on core devices can be run from the PennyLane root folder via:
 

--- a/doc/development/guide/tests.rst
+++ b/doc/development/guide/tests.rst
@@ -44,7 +44,11 @@ Pytest supports many other command-line options, which can be found with the com
 
 Or by visiting the `pytest documentation <https://docs.pytest.org/en/latest/reference/reference.html#id88>`__ . 
 
-PennyLane provides a set of integration tests for all PennyLane plugins and devices. See the documentation on these tests under the section on the `device API <https://pennylane.readthedocs.io/en/latest/code/api/pennylane.devices.tests.html>`__.
+PennyLane provides a set of integration tests for all PennyLane plugins and devices. See the documentation on these tests under the section on the `device API <https://pennylane.readthedocs.io/en/latest/code/api/pennylane.devices.tests.html>`__. These tests can be run from the PennyLane root folder by:
+
+.. code-block:: bash
+
+    pytest pennylane/devices/tests --device=default.qubit --shots=1000
 
 All PennyLane tests and the device suite on core devices can be run from the PennyLane root folder via:
 

--- a/doc/development/guide/tests.rst
+++ b/doc/development/guide/tests.rst
@@ -22,7 +22,7 @@ The `tests <https://github.com/PennyLaneAI/pennylane/tree/master/tests>`__ folde
 
     python -m pytest --ignore=tests/beta tests
 
-Using ``python -m`` ensures that the tests run with the correct Python version if multiple versions are on the system. The `tests/beta` folder can contain failing tests, so ``--ignore=tests/beta`` excludes them from execution.
+Using ``python -m`` ensures that the tests run with the correct Python version if multiple versions are on the system. The ``tests/beta`` folder can contain failing tests, so ``--ignore=tests/beta`` excludes them from execution.
 
 As the entire test suite takes some time, locally running only relevant files speeds the debugging cycle.  For example, if a developer was adding a new non-parametric operation, they could run:
 

--- a/doc/development/guide/tests.rst
+++ b/doc/development/guide/tests.rst
@@ -1,8 +1,8 @@
 Software tests
 ==============
 
-Running the test suite
-~~~~~~~~~~~~~~~~~~~~~~
+Running the tests
+~~~~~~~~~~~~~~~~~
 
 The PennyLane test suite requires the Python ``pytest`` package, as well as ``pytest-cov``
 for test coverage, ``pytest-mock`` for mocking, and ``flaky`` for automatically rerunning flaky tests; these can be installed via ``pip``:
@@ -36,6 +36,15 @@ Pytest supports many other command-line options, which can be found with the com
     pytest --help
 
 Or by visiting the `pytest documentation page <https://docs.pytest.org/en/latest/reference/reference.html#id88>`__ . 
+
+PennyLane provides a set of tests for all PennyLane plugins. See the documentation on these tests under the section on the `device API <https://pennylane.readthedocs.io/en/latest/code/api/pennylane.devices.tests.html>`__.
+
+All PennyLane tests and the device suite on core devices can be run from the PennyLane root folder via:
+
+.. code-block:: bash
+
+    make test
+
 
 Outside Resources
 ~~~~~~~~~~~~~~~~~

--- a/doc/development/guide/tests.rst
+++ b/doc/development/guide/tests.rst
@@ -11,23 +11,38 @@ for test coverage, ``pytest-mock`` for mocking, and ``flaky`` for automatically 
 
     pip install pytest pytest-cov pytest-mock flaky
 
-To ensure that PennyLane is working correctly, the test suite can be run by
-navigating to the source code folder and running
+All tests are located in the `tests <https://github.com/PennyLaneAI/pennylane/tree/master/tests>`__ folder of the root PennyLane directory. Run all tests in this folder via:
 
 .. code-block:: bash
 
-    make test
+    python -m pytest tests
 
-while the test coverage can be checked by running
+Using ``python -m`` helps ensure that the tests are running with the correct version of python if you have multiple python versions and environments.  During development, locally executing only relevant files saves time.  For example, if a develop was adding a new non-parametric operation, they could run just:
 
 .. code-block:: bash
 
-    make coverage
+    python -m pytest tests/ops/qubit/test_non_parametric_ops.py
 
-The output of the above command will show the coverage percentage of each
-file, as well as the line numbers of any lines missing test coverage.
+The slowest tests are marked with ``slow`` and can be deselected by:
 
+.. code-block:: bash
 
+    python -m pytest -m "not slow" tests
+
+Pytest supports many other command-line options, which can be found with the command:
+
+.. code-block:: bash
+
+    pytest --help
+
+Or by visiting the `pytest documentation page <https://docs.pytest.org/en/latest/reference/reference.html#id88>`__ . 
+
+Outside Resources
+~~~~~~~~~~~~~~~~~
+
+`Pytest documentation <https://docs.pytest.org/en/6.2.x/index.html>`__
+
+`Real Python tutorial <https://realpython.com/pytest-python-testing/>`__
 
 Testing Matplotlib based code
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -61,6 +61,9 @@
 
 <h3>Documentation</h3>
 
+* Improves the Developer's Guide Testing document.
+  [(#1896)](https://github.com/PennyLaneAI/pennylane/pull/1896)
+
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order): 

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')
+norecursedirs=beta

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,4 +1,3 @@
 [pytest]
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')
-norecursedirs=beta


### PR DESCRIPTION
This PR adds more information to the [Developer Guide's Testing docs](https://pennylane.readthedocs.io/en/latest/development/guide/tests.html).

It also modifies `pytest.ini` so the `tests/beta` folder will not be included when running `pytest tests`. The beta tests can still be explicitly selected and executed.


[sc-11309]