### PR TITLE
`ExpvalCost` when `optimize=True` with shots batch

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -51,6 +51,10 @@
 
 <h3>Bug fixes</h3>
 
+* `ExpvalCost` now returns corrects results shape when `optimize=True` with 
+  shots batch.
+  [(#1897)](https://github.com/PennyLaneAI/pennylane/pull/1897)
+  
 * `qml.CSWAP` and `qml.CRot` now define `control_wires`, and `qml.SWAP` 
   returns the default empty wires object.
   [(#1830)](https://github.com/PennyLaneAI/pennylane/pull/1830)
@@ -65,4 +69,5 @@
 
 This release contains contributions from (in alphabetical order): 
 
-Guillermo Alonso-Linaje, Olivia Di Matteo, Jalani Kanem, Christina Lee, Alejandro Montanez, Maria Schuld, Jay Soni
+Guillermo Alonso-Linaje, Olivia Di Matteo, Jalani Kanem, Christina Lee, Alejandro Montanez, Romain Moyard,
+Maria Schuld, Jay Soni

--- a/pennylane/vqe/vqe.py
+++ b/pennylane/vqe/vqe.py
@@ -126,14 +126,14 @@ class ExpvalCost:
     """
 
     def __init__(
-            self,
-            ansatz,
-            hamiltonian,
-            device,
-            interface="autograd",
-            diff_method="best",
-            optimize=False,
-            **kwargs,
+        self,
+        ansatz,
+        hamiltonian,
+        device,
+        interface="autograd",
+        diff_method="best",
+        optimize=False,
+        **kwargs,
     ):
         if kwargs.get("measure", "expval") != "expval":
             raise ValueError("ExpvalCost can only be used to construct sums of expectation values.")

--- a/pennylane/vqe/vqe.py
+++ b/pennylane/vqe/vqe.py
@@ -187,12 +187,9 @@ class ExpvalCost:
 
                     for o, c in zip(obs_groupings, coeffs_groupings):
                         res = circuit(*qnode_args, obs=o, **qnode_kwargs)
-                        if isinstance(res[0], list):
-                            for i, batch_res in enumerate(res):
-                                total[i] += sum([r * c_ for r, c_ in zip(batch_res, c)])
-                        else:
-                            for i, batch_res in enumerate(res):
-                                total[i] += sum(batch_res * c)
+
+                        for i, batch_res in enumerate(res):
+                            total[i] += sum(batch_res * c)
                 else:
                     total = 0
                     for o, c in zip(obs_groupings, coeffs_groupings):

--- a/tests/test_vqe.py
+++ b/tests/test_vqe.py
@@ -370,7 +370,8 @@ class TestVQE:
 
     @pytest.mark.slow
     @pytest.mark.parametrize("interface", ["tf", "torch", "autograd"])
-    def test_optimize(self, interface, tf_support, torch_support):
+    @pytest.mark.parametrize("shots", [None, [(8000, 5)], [(8000, 5), (9000, 4)]])
+    def test_optimize(self, interface, tf_support, torch_support, shots):
         """Test that an ExpvalCost with observable optimization gives the same result as another
         ExpvalCost without observable optimization."""
         if interface == "tf" and not tf_support:
@@ -378,7 +379,7 @@ class TestVQE:
         if interface == "torch" and not torch_support:
             pytest.skip("This test requires Torch")
 
-        dev = qml.device("default.qubit", wires=4)
+        dev = qml.device("default.qubit", wires=4, shots=shots)
         hamiltonian = big_hamiltonian
 
         cost = qml.ExpvalCost(
@@ -393,7 +394,7 @@ class TestVQE:
             qml.templates.StronglyEntanglingLayers,
             hamiltonian,
             dev,
-            optimize=False,
+ze=False,
             interface=interface,
             diff_method="parameter-shift",
         )
@@ -412,7 +413,7 @@ class TestVQE:
         assert exec_opt == 5  # Number of groups in the Hamiltonian
         assert exec_no_opt == 15
 
-        assert np.allclose(c1, c2)
+        assert np.allclose(c1, c2, atol=1e-1)
 
     @pytest.mark.parametrize("interface", ["tf", "torch", "autograd"])
     def test_optimize_multiple_terms(self, interface, tf_support, torch_support):

--- a/tests/test_vqe.py
+++ b/tests/test_vqe.py
@@ -394,7 +394,7 @@ class TestVQE:
             qml.templates.StronglyEntanglingLayers,
             hamiltonian,
             dev,
-ze=False,
+            optimize=False,
             interface=interface,
             diff_method="parameter-shift",
         )


### PR DESCRIPTION
**Context:**
`ExpvalCost` returns wrong values when `optimize=True` because of the shape of results due to shots (e.g (8000,5)).

**Description of the Change:**
Change the function to take into account the shape of the results.

**Benefits:**
It now returns the correct values.

**Related GitHub Issues:**
Closes https://github.com/PennyLaneAI/pennylane/issues/1480