### PR TITLE
Update matplotlib circuit drawing to work with matplotlib v3.5

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -51,6 +51,9 @@
 
 <h3>Bug fixes</h3>
 
+* `qml.circuit_drawer.MPLDrawer` was slightly modified to work with
+  matplotlib version 3.5.
+
 * `qml.CSWAP` and `qml.CRot` now define `control_wires`, and `qml.SWAP` 
   returns the default empty wires object.
   [(#1830)](https://github.com/PennyLaneAI/pennylane/pull/1830)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -53,6 +53,7 @@
 
 * `qml.circuit_drawer.MPLDrawer` was slightly modified to work with
   matplotlib version 3.5.
+  [(#1899)](https://github.com/PennyLaneAI/pennylane/pull/1899)
 
 * `qml.CSWAP` and `qml.CRot` now define `control_wires`, and `qml.SWAP` 
   returns the default empty wires object.

--- a/pennylane/circuit_drawer/mpldrawer.py
+++ b/pennylane/circuit_drawer/mpldrawer.py
@@ -776,7 +776,7 @@ class MPLDrawer:
         arrow_height = -0.5 * self._box_length
 
         lines_options["zorder"] += 1
-        arrow = plt.arrow(
+        arrow = self.ax.arrow(
             arrow_start_x,
             arrow_start_y,
             arrow_width,
@@ -784,4 +784,3 @@ class MPLDrawer:
             head_width=self._box_length / 8.0,
             **lines_options,
         )
-        self._ax.add_line(arrow)

--- a/pennylane/circuit_drawer/mpldrawer.py
+++ b/pennylane/circuit_drawer/mpldrawer.py
@@ -776,7 +776,7 @@ class MPLDrawer:
         arrow_height = -0.5 * self._box_length
 
         lines_options["zorder"] += 1
-        arrow = self.ax.arrow(
+        self.ax.arrow(
             arrow_start_x,
             arrow_start_y,
             arrow_width,


### PR DESCRIPTION
The CI tests were failing when matplotlib updated to version 3.5.  

Now, the `arrow` in the measurement box was added twice to the axes.  I therefore use a different call signature.  `ax.arrow` creates the arrow *and* adds them to the axes.  Before, I created them and then manually added it to the axes.