### PR TITLE
Fixed bug in PauliRot where keyword args (theta and Pauli_word) were not being registered

### DIFF
--- a/pennylane/ops/qubit/parametric_ops.py
+++ b/pennylane/ops/qubit/parametric_ops.py
@@ -566,10 +566,8 @@ class PauliRot(Operation):
         "Z": np.array([[1, 0], [0, 1]]),
     }
 
-    def __init__(self, *params, wires=None, do_queue=True):
-        super().__init__(*params, wires=wires, do_queue=do_queue)
-
-        pauli_word = params[1]
+    def __init__(self, theta, pauli_word, wires=None, do_queue=True):
+        super().__init__(theta, pauli_word, wires=wires, do_queue=do_queue)
 
         if not PauliRot._check_pauli_word(pauli_word):
             raise ValueError(


### PR DESCRIPTION
**Context:**
In the docs the call to PauliRot required 3 arguments `qml.PauliRot(theta, pauli_word, wires)`, but when calling these arguments through keywords we run into an error. 

This works 

```
@qml.qnode(dev)
def circuit(theta):
    qml.PauliRot(theta, 'Z', wires=0)
    return qml.state()
```

But this didn't

```
@qml.qnode(dev)
def circuit(theta):
    qml.PauliRot(theta=theta, pauli_word='Z', wires=0)
    return qml.state()
```

**Description of the Change:**
Updated the `__init__` method to contain the same call signature as the documentation. 

**Related GitHub Issues:**
Link to issue: [1901](https://github.com/PennyLaneAI/pennylane/issues/1901)