### PR TITLE
Bugfix: draw template with matrix parameter

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -260,6 +260,7 @@
 <h3>Bug fixes</h3>
 
 * `qml.draw` now supports arbitrary templates with matrix parameters.
+  [(#1917)](https://github.com/PennyLaneAI/pennylane/pull/1917)
 
 * `QuantumTape.trainable_params` now is a list instead of a set, making
   it more stable in very rare edge cases.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -259,7 +259,7 @@
 
 <h3>Bug fixes</h3>
 
-* `qml.CSWAP` and `qml.CRot` now define `control_wires`, and `qml.SWAP`
+* `qml.draw` now supports arbitrary templates with matrix parameters.
 
 * `QuantumTape.trainable_params` now is a list instead of a set, making
   it more stable in very rare edge cases.

--- a/pennylane/circuit_drawer/representation_resolver.py
+++ b/pennylane/circuit_drawer/representation_resolver.py
@@ -416,13 +416,7 @@ class RepresentationResolver:
             )
 
         # Operations that only have matrix arguments
-        elif base_name in {
-            "GaussianState",
-            "FockDensityMatrix",
-            "FockStateVector",
-            "QubitStateVector",
-            "InterferometerUnitary",
-        }:
+        elif len(qml.math.shape(op.data[0])) != 0:
             representation = name + RepresentationResolver._format_matrix_arguments(
                 op.data, "M", self.matrix_cache
             )

--- a/tests/transforms/test_draw.py
+++ b/tests/transforms/test_draw.py
@@ -401,6 +401,19 @@ def test_qubit_circuit_length_under_max_length_kwdarg():
         assert qml.draw(qnode, max_length=60)() == expected
 
 
+def test_matrix_parameter_template():
+    """Assert draw method handles templates with matrix valued parameters."""
+    dev = qml.device("default.qubit", wires=1)
+
+    @qml.qnode(dev)
+    def circuit():
+        qml.AmplitudeEmbedding(np.array([0, 1]), wires=0)
+        return qml.state()
+
+    expected = " 0: ──AmplitudeEmbedding(M0)──┤ State \nM0 =\n[0.+0.j 1.+0.j]\n"
+    assert qml.draw(circuit)() == expected
+
+
 class TestWireOrdering:
     """Tests for wire ordering functionality"""
 


### PR DESCRIPTION
Bugfix for Issue #1916 

Due to the new QNode expansion settings, the qnode tape has unexpanded templates, which the current text circuit drawer was unable to handle.  This bugfix generalizes the treatment of matrix parameters.

This code was previously raising an error:

```python
import pennylane as qml
from pennylane import numpy as np

dev = qml.device('default.qubit', wires = 1)

@qml.qnode(dev)
def circuit():
    qml.AmplitudeEmbedding(np.array([0,1]), wires=0)
    return qml.state()
                        
print(qml.draw(circuit)())
```

But now gives:
```
 0: ──AmplitudeEmbedding(M0)──┤ State 
M0 =
[0.+0.j 1.+0.j]
```