### PR TITLE
Add examples to Squeezing and Displacement Embeddings

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -290,10 +290,11 @@
 * Improves the Developer's Guide Testing document.
   [(#1896)](https://github.com/PennyLaneAI/pennylane/pull/1896)
 
-* Add documentation example for AngleEmbedding, BasisEmbedding and StronglyEntanglingLayers.
+* Add documentation example for AngleEmbedding, BasisEmbedding, StronglyEntanglingLayers, SqueezingEmbedding and DisplacementEmbedding.
   [(#1910)](https://github.com/PennyLaneAI/pennylane/pull/1910)
   [(#1908)](https://github.com/PennyLaneAI/pennylane/pull/1908)
   [(#1912)](https://github.com/PennyLaneAI/pennylane/pull/1912)
+  [(#1920)](https://github.com/PennyLaneAI/pennylane/pull/1920)
 
 <h3>Contributors</h3>
 

--- a/pennylane/templates/embeddings/displacement.py
+++ b/pennylane/templates/embeddings/displacement.py
@@ -41,6 +41,58 @@ class DisplacementEmbedding(Operation):
         c (float): value of the phase of all displacement gates if ``execution='amplitude'``, or
             the amplitude of all displacement gates if ``execution='phase'``
 
+    Example:
+
+        Depending on the ``method`` argument, the feature vector will be encoded in the phase or the amplitude.
+        The argument ``c`` will define the value of the other quantity.
+        The default values are :math:`0.1` for ``c`` and amplitude for ``method``.
+
+        .. code-block:: python
+
+            dev = qml.device('default.gaussian', wires=3)
+
+            @qml.qnode(dev)
+            def circuit(feature_vector):
+                qml.DisplacementEmbedding(features=feature_vector, wires=range(3))
+                qml.QuadraticPhase(0.1, wires=1)
+                return qml.expval(qml.NumberOperator(wires=1))
+
+            X = [1, 2, 3]
+
+        >>> print(circuit(X))
+            4.1215690638748494
+
+        And, the resulting circuit is:
+
+        >>> print(qml.draw(circuit)(X))
+            0: ──D(1, 0.1)──────────┤
+            1: ──D(2, 0.1)──P(0.1)──┤ ⟨n⟩
+            2: ──D(3, 0.1)──────────┤
+
+        Using different parameters:
+
+        .. code-block:: python
+
+            dev = qml.device('default.gaussian', wires=3)
+
+            @qml.qnode(dev)
+            def circuit(feature_vector):
+                qml.DisplacementEmbedding(features=feature_vector, wires=range(3), method='phase', c=0.5)
+                qml.QuadraticPhase(0.1, wires=1)
+                return qml.expval(qml.NumberOperator(wires=1))
+
+            X = [1, 2, 3]
+
+        >>> print(circuit(X)
+            0.23401288309122226
+
+        And, the resulting circuit is:
+
+        >>> print(qml.draw(circuit)(X))
+            0: ──D(0.5, 1)──────────┤
+            1: ──D(0.5, 2)──P(0.1)──┤ ⟨n⟩
+            2: ──D(0.5, 3)──────────┤
+
     Raises:
         ValueError: if inputs do not have the correct format
     """

--- a/pennylane/templates/embeddings/displacement.py
+++ b/pennylane/templates/embeddings/displacement.py
@@ -41,6 +41,9 @@ class DisplacementEmbedding(Operation):
         c (float): value of the phase of all displacement gates if ``execution='amplitude'``, or
             the amplitude of all displacement gates if ``execution='phase'``
 
+    Raises:
+        ValueError: if inputs do not have the correct format
+
     Example:
 
         Depending on the ``method`` argument, the feature vector will be encoded in the phase or the amplitude.

--- a/pennylane/templates/embeddings/displacement.py
+++ b/pennylane/templates/embeddings/displacement.py
@@ -83,7 +83,7 @@ class DisplacementEmbedding(Operation):
 
             X = [1, 2, 3]
 
-        >>> print(circuit(X)
+        >>> print(circuit(X))
             0.23401288309122226
 
         And, the resulting circuit is:

--- a/pennylane/templates/embeddings/displacement.py
+++ b/pennylane/templates/embeddings/displacement.py
@@ -92,9 +92,6 @@ class DisplacementEmbedding(Operation):
             0: ──D(0.5, 1)──────────┤
             1: ──D(0.5, 2)──P(0.1)──┤ ⟨n⟩
             2: ──D(0.5, 3)──────────┤
-
-    Raises:
-        ValueError: if inputs do not have the correct format
     """
 
     num_wires = AnyWires

--- a/pennylane/templates/embeddings/displacement.py
+++ b/pennylane/templates/embeddings/displacement.py
@@ -45,7 +45,7 @@ class DisplacementEmbedding(Operation):
 
         Depending on the ``method`` argument, the feature vector will be encoded in the phase or the amplitude.
         The argument ``c`` will define the value of the other quantity.
-        The default values are :math:`0.1` for ``c`` and amplitude for ``method``.
+        The default values are :math:`0.1` for ``c`` and ``'amplitude'`` for ``method``.
 
         .. code-block:: python
 

--- a/pennylane/templates/embeddings/squeezing.py
+++ b/pennylane/templates/embeddings/squeezing.py
@@ -46,7 +46,7 @@ class SqueezingEmbedding(Operation):
 
         Depending on the ``method`` argument, the feature vector will be encoded in the phase or the amplitude.
         The argument ``c`` will define the value of the other quantity.
-        The default values are :math:`0.1` for ``c`` and amplitude for ``method``.
+        The default values are :math:`0.1` for ``c`` and ``'amplitude'`` for ``method``.
 
         .. code-block:: python
 

--- a/pennylane/templates/embeddings/squeezing.py
+++ b/pennylane/templates/embeddings/squeezing.py
@@ -41,6 +41,8 @@ class SqueezingEmbedding(Operation):
             ``'amplitude'`` uses the amplitude
         c (float): value of the phase of all squeezing gates if ``execution='amplitude'``, or the
             amplitude of all squeezing gates if ``execution='phase'``
+    Raises:
+        ValueError: if inputs do not have the correct format
 
     Example:
 

--- a/pennylane/templates/embeddings/squeezing.py
+++ b/pennylane/templates/embeddings/squeezing.py
@@ -84,7 +84,7 @@ class SqueezingEmbedding(Operation):
 
             X = [1, 2, 3]
 
-        >>> print(circuit(X)
+        >>> print(circuit(X))
             0.22319028857312428
 
         And, the resulting circuit is:

--- a/pennylane/templates/embeddings/squeezing.py
+++ b/pennylane/templates/embeddings/squeezing.py
@@ -42,6 +42,58 @@ class SqueezingEmbedding(Operation):
         c (float): value of the phase of all squeezing gates if ``execution='amplitude'``, or the
             amplitude of all squeezing gates if ``execution='phase'``
 
+    Example:
+
+        Depending on the ``method`` argument, the feature vector will be encoded in the phase or the amplitude.
+        The argument ``c`` will define the value of the other quantity.
+        The default values are :math:`0.1` for ``c`` and amplitude for ``method``.
+
+        .. code-block:: python
+
+            dev = qml.device('default.gaussian', wires=3)
+
+            @qml.qnode(dev)
+            def circuit(feature_vector):
+                qml.SqueezingEmbedding(features=feature_vector, wires=range(3))
+                qml.QuadraticPhase(0.1, wires=1)
+                return qml.expval(qml.NumberOperator(wires=1))
+
+            X = [1, 2, 3]
+
+        >>> print(circuit(X))
+            13.018280763205285
+
+        And, the resulting circuit is:
+
+        >>> print(qml.draw(circuit)(X))
+            0: ──S(1, 0.1)──────────┤
+            1: ──S(2, 0.1)──P(0.1)──┤ ⟨n⟩
+            2: ──S(3, 0.1)──────────┤
+
+        Using different parameters:
+
+        .. code-block:: python
+
+            dev = qml.device('default.gaussian', wires=3)
+
+            @qml.qnode(dev)
+            def circuit(feature_vector):
+                qml.SqueezingEmbedding(features=feature_vector, wires=range(3), method='phase', c=0.5)
+                qml.QuadraticPhase(0.1, wires=1)
+                return qml.expval(qml.NumberOperator(wires=1))
+
+            X = [1, 2, 3]
+
+        >>> print(circuit(X)
+            0.22319028857312428
+
+        And, the resulting circuit is:
+
+        >>> print(qml.draw(circuit)(X))
+            0: ──S(0.5, 1)──────────┤
+            1: ──S(0.5, 2)──P(0.1)──┤ ⟨n⟩
+            2: ──S(0.5, 3)──────────┤
+
     Raises:
         ValueError: if inputs do not have the correct format
     """

--- a/pennylane/templates/embeddings/squeezing.py
+++ b/pennylane/templates/embeddings/squeezing.py
@@ -41,6 +41,7 @@ class SqueezingEmbedding(Operation):
             ``'amplitude'`` uses the amplitude
         c (float): value of the phase of all squeezing gates if ``execution='amplitude'``, or the
             amplitude of all squeezing gates if ``execution='phase'``
+
     Raises:
         ValueError: if inputs do not have the correct format
 

--- a/pennylane/templates/embeddings/squeezing.py
+++ b/pennylane/templates/embeddings/squeezing.py
@@ -95,9 +95,6 @@ class SqueezingEmbedding(Operation):
             0: ──S(0.5, 1)──────────┤
             1: ──S(0.5, 2)──P(0.1)──┤ ⟨n⟩
             2: ──S(0.5, 3)──────────┤
-
-    Raises:
-        ValueError: if inputs do not have the correct format
     """
 
     num_wires = AnyWires


### PR DESCRIPTION
**Description of the Change:**
add examples to Squeezing and Displacement Embeddings
**Benefits:**
better documentation
**Possible Drawbacks:**
none
**Related GitHub Issues:**
#1727 #1735 