### PR TITLE
[WIP] Fix parametric ops GPU compatibility

### DIFF
--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -679,7 +679,8 @@ class DefaultQubit(QubitDevice):
 
         # get computational basis state number
         basis_states = 2 ** (self.num_wires - 1 - np.array(device_wires))
-        num = int(np.dot(state, basis_states))
+        basis_states = qml.math.convert_like(basis_states, state)
+        num = int(qml.math.dot(state, basis_states))
 
         self._state = self._create_basis_state(num)
 

--- a/pennylane/devices/default_qubit_torch.py
+++ b/pennylane/devices/default_qubit_torch.py
@@ -152,9 +152,9 @@ class DefaultQubitTorch(DefaultQubit):
     _norm = staticmethod(torch.norm)
     _flatten = staticmethod(torch.flatten)
 
-    def __init__(self, wires, *, shots=None, analytic=None):
+    def __init__(self, wires, *, shots=None, analytic=None, torch_device=None):
 
-        self._torch_device = "cpu"
+        self._torch_device = torch_device
 
         super().__init__(wires, shots=shots, cache=0, analytic=analytic)
 

--- a/pennylane/math/single_dispatch.py
+++ b/pennylane/math/single_dispatch.py
@@ -352,7 +352,13 @@ def _coerce_types_torch(tensors):
     """Coerce a list of tensors to all have the same dtype
     without any loss of information."""
     torch = _i("torch")
-    tensors = [torch.as_tensor(t) for t in tensors]
+    # Extract existing set devices, if any
+    device_set = set([t.device for t in tensors if isinstance(t, torch.Tensor)])
+    if len(device_set) > 1:
+        raise ValueError('Cannot coerce.')
+
+    device = device_set.pop() if len(device_set) == 1 else None
+    tensors = [torch.as_tensor(t, device=device) for t in tensors]
     dtypes = {i.dtype for i in tensors}
 
     if len(dtypes) == 1:

--- a/pennylane/ops/qubit/observables.py
+++ b/pennylane/ops/qubit/observables.py
@@ -60,12 +60,12 @@ class Hermitian(Observable):
 
     @classmethod
     def _matrix(cls, *params):
-        A = np.asarray(params[0])
+        A = qml.math.asarray(params[0])
 
         if A.shape[0] != A.shape[1]:
             raise ValueError("Observable must be a square matrix.")
 
-        if not np.allclose(A, A.conj().T):
+        if not qml.math.allclose(A, A.conj().T):
             raise ValueError("Observable must be Hermitian.")
 
         return A
@@ -83,6 +83,7 @@ class Hermitian(Observable):
             dict[str, array]: dictionary containing the eigenvalues and the eigenvectors of the Hermitian observable
         """
         Hmat = self.matrix
+        Hmat = qml.math.to_numpy(Hmat)
         Hkey = tuple(Hmat.flatten().tolist())
         if Hkey not in Hermitian._eigs:
             w, U = np.linalg.eigh(Hmat)

--- a/pennylane/ops/qubit/parametric_ops.py
+++ b/pennylane/ops/qubit/parametric_ops.py
@@ -72,8 +72,9 @@ class RX(Operation):
 
         js = -1j * s
 
+        zeros = qml.math.zeros_like(js)
         return qml.math.diag([c, c]) + qml.math.stack(
-            [qml.math.stack([0, js]), qml.math.stack([js, 0])]
+            [qml.math.stack([zeros, js]), qml.math.stack([js, zeros])]
         )
 
     def adjoint(self):

--- a/tests/devices/test_default_qubit_torch.py
+++ b/tests/devices/test_default_qubit_torch.py
@@ -24,10 +24,12 @@ import functools
 
 torch = pytest.importorskip("torch", minversion="1.8.1")
 
-#TODO: make this togglable via the command line
-use_cuda = torch.cuda.is_available()
-if use_cuda:
-    torch.tensor = functools.partial(torch.tensor, device='cuda')
+use_cuda = torch.cuda.is_available() #TODO: make this togglable via the command line
+torch_device = 'cuda' if use_cuda else 'cpu'
+
+torch.tensor = functools.partial(torch.tensor, device=torch_device)
+torch.zeros = functools.partial(torch.zeros, device=torch_device)
+torch.linspace = functools.partial(torch.linspace, device=torch_device)
 
 import pennylane as qml
 from pennylane import numpy as pnp
@@ -152,6 +154,17 @@ def init_state(scope="session"):
 
     return _init_state
 
+@pytest.fixture
+def device(scope="function"):
+    """Creates a Torch device"""
+
+    def _dev(wires):
+        """Torch device"""
+        dev = DefaultQubitTorch(wires=wires)
+        dev._torch_device = 'cuda' if use_cuda else 'cpu'
+        return dev
+
+    return _dev
 
 #####################################################
 # Initialization test
@@ -175,10 +188,11 @@ def test_analytic_deprecation():
 class TestApply:
     """Test application of PennyLane operations."""
 
-    def test_basis_state(self, tol):
+    def test_basis_state(self, device, tol):
         """Test basis state initialization"""
 
-        dev = DefaultQubitTorch(wires=4)
+        dev = device(wires=4)
+        #dev = DefaultQubitTorch(wires=4)
         state = torch.tensor([0, 0, 1, 0], dtype=torch.complex128)
 
         dev.apply([qml.BasisState(state, wires=[0, 1, 2, 3])])
@@ -190,9 +204,9 @@ class TestApply:
         assert isinstance(res, torch.Tensor)
         assert torch.allclose(res, expected, atol=tol, rtol=0)
 
-    def test_invalid_basis_state_length(self, tol):
+    def test_invalid_basis_state_length(self, device, tol):
         """Test that an exception is raised if the basis state is the wrong size"""
-        dev = DefaultQubitTorch(wires=4)
+        dev = device(wires=4)
         state = torch.tensor([0, 0, 1, 0])
 
         with pytest.raises(
@@ -200,9 +214,9 @@ class TestApply:
         ):
             dev.apply([qml.BasisState(state, wires=[0, 1, 2])])
 
-    def test_invalid_basis_state(self, tol):
+    def test_invalid_basis_state(self, device, tol):
         """Test that an exception is raised if the basis state is invalid"""
-        dev = DefaultQubitTorch(wires=4)
+        dev = device(wires=4)
         state = torch.tensor([0, 0, 1, 2])
 
         with pytest.raises(
@@ -210,10 +224,9 @@ class TestApply:
         ):
             dev.apply([qml.BasisState(state, wires=[0, 1, 2, 3])])
 
-    def test_qubit_state_vector(self, init_state, tol):
+    def test_qubit_state_vector(self, device, init_state, tol):
         """Test qubit state vector application"""
-        dev = DefaultQubitTorch(wires=1)
-        dev._torch_device = 'cuda' if use_cuda else 'cpu'
+        dev = device(wires=1)
         state = init_state(1)
 
         dev.apply([qml.QubitStateVector(state, wires=[0])])
@@ -223,10 +236,9 @@ class TestApply:
         assert isinstance(res, torch.Tensor)
         assert torch.allclose(res, expected, atol=tol, rtol=0)
 
-    def test_full_subsystem_statevector(self, mocker):
+    def test_full_subsystem_statevector(self, device, mocker):
         """Test applying a state vector to the full subsystem"""
-        dev = DefaultQubitTorch(wires=["a", "b", "c"])
-        dev._torch_device = 'cuda' if use_cuda else 'cpu'
+        dev = device(wires=["a", "b", "c"])
         state = torch.tensor([1, 0, 0, 0, 1, 0, 1, 1], dtype=torch.complex128) / 2.0
         state_wires = qml.wires.Wires(["a", "b", "c"])
 
@@ -236,10 +248,9 @@ class TestApply:
         assert torch.allclose(torch.reshape(dev._state, (-1,)), state)
         spy.assert_not_called()
 
-    def test_partial_subsystem_statevector(self, mocker):
+    def test_partial_subsystem_statevector(self, device, mocker):
         """Test applying a state vector to a subset of wires of the full subsystem"""
-        dev = DefaultQubitTorch(wires=["a", "b", "c"])
-        dev._torch_device = 'cuda' if use_cuda else 'cpu'
+        dev = device(wires=["a", "b", "c"])
         state = torch.tensor([1, 0, 1, 0], dtype=torch.complex128) / torch.tensor(math.sqrt(2.0))
         state_wires = qml.wires.Wires(["a", "c"])
 
@@ -250,10 +261,10 @@ class TestApply:
         assert torch.allclose(res, state)
         spy.assert_called()
 
-    def test_invalid_qubit_state_vector_size(self):
+    def test_invalid_qubit_state_vector_size(self, device):
         """Test that an exception is raised if the state
         vector is the wrong size"""
-        dev = DefaultQubitTorch(wires=2)
+        dev = device(wires=2)
         state = torch.tensor([0, 1])
 
         with pytest.raises(ValueError, match=r"State vector must be of length 2\*\*wires"):
@@ -262,18 +273,18 @@ class TestApply:
     @pytest.mark.parametrize(
         "state", [torch.tensor([0, 12]), torch.tensor([1.0, -1.0], requires_grad=True)]
     )
-    def test_invalid_qubit_state_vector_norm(self, state):
+    def test_invalid_qubit_state_vector_norm(self, device, state):
         """Test that an exception is raised if the state
         vector is not normalized"""
-        dev = DefaultQubitTorch(wires=2)
+        dev = device(wires=2)
 
         with pytest.raises(ValueError, match=r"Sum of amplitudes-squared does not equal one"):
             dev.apply([qml.QubitStateVector(state, wires=[0])])
 
-    def test_invalid_state_prep(self):
+    def test_invalid_state_prep(self, device):
         """Test that an exception is raised if a state preparation is not the
         first operation in the circuit."""
-        dev = DefaultQubitTorch(wires=2)
+        dev = device(wires=2)
         state = torch.tensor([0, 12])
 
         with pytest.raises(
@@ -283,10 +294,9 @@ class TestApply:
             dev.apply([qml.PauliZ(0), qml.QubitStateVector(state, wires=[0])])
 
     @pytest.mark.parametrize("op,mat", single_qubit)
-    def test_single_qubit_no_parameters(self, init_state, op, mat, tol):
+    def test_single_qubit_no_parameters(self, device, init_state, op, mat, tol):
         """Test non-parametrized single qubit operations"""
-        dev = DefaultQubitTorch(wires=1)
-        dev._torch_device = 'cuda' if use_cuda else 'cpu'
+        dev = device(wires=1)
         state = init_state(1)
 
         queue = [qml.QubitStateVector(state, wires=[0])]
@@ -301,10 +311,9 @@ class TestApply:
 
     @pytest.mark.parametrize("theta", [0.5432, -0.232])
     @pytest.mark.parametrize("op,func", single_qubit_param)
-    def test_single_qubit_parameters(self, init_state, op, func, theta, tol):
+    def test_single_qubit_parameters(self, device, init_state, op, func, theta, tol):
         """Test parametrized single qubit operations"""
-        dev = DefaultQubitTorch(wires=1)
-        dev._torch_device = 'cuda' if use_cuda else 'cpu'
+        dev = device(wires=1)
         state = init_state(1)
 
         queue = [qml.QubitStateVector(state, wires=[0])]
@@ -318,9 +327,9 @@ class TestApply:
 
     @pytest.mark.parametrize("theta", [0.5432, -0.232])
     @pytest.mark.parametrize("op,func", single_qubit_param)
-    def test_single_qubit_parameters_inverse(self, init_state, op, func, theta, tol):
+    def test_single_qubit_parameters_inverse(self, device, init_state, op, func, theta, tol):
         """Test parametrized single qubit operations"""
-        dev = DefaultQubitTorch(wires=1)
+        dev = device(wires=1)
         state = init_state(1)
 
         queue = [qml.QubitStateVector(state, wires=[0])]
@@ -333,9 +342,9 @@ class TestApply:
         expected = torch.matmul(op_mat, state)
         assert torch.allclose(res, expected, atol=tol, rtol=0)
 
-    def test_rotation(self, init_state, tol):
+    def test_rotation(self, device, init_state, tol):
         """Test three axis rotation gate"""
-        dev = DefaultQubitTorch(wires=1)
+        dev = device(wires=1)
         state = init_state(1)
 
         a = 0.542
@@ -351,9 +360,9 @@ class TestApply:
         expected = op_mat @ state
         assert torch.allclose(res, expected, atol=tol, rtol=0)
 
-    def test_controlled_rotation(self, init_state, tol):
+    def test_controlled_rotation(self, device, init_state, tol):
         """Test three axis controlled-rotation gate"""
-        dev = DefaultQubitTorch(wires=2)
+        dev = device(wires=2)
         state = init_state(2)
 
         a = 0.542
@@ -369,10 +378,10 @@ class TestApply:
         expected = op_mat @ state
         assert torch.allclose(res, expected, atol=tol, rtol=0)
 
-    def test_inverse_operation(self, init_state, tol):
+    def test_inverse_operation(self, device, init_state, tol):
         """Test that the inverse of an operation is correctly applied"""
         """Test three axis rotation gate"""
-        dev = DefaultQubitTorch(wires=1)
+        dev = device(wires=1)
         state = init_state(1)
 
         a = 0.542
@@ -389,9 +398,9 @@ class TestApply:
         assert torch.allclose(res, expected, atol=tol, rtol=0)
 
     @pytest.mark.parametrize("op,mat", two_qubit)
-    def test_two_qubit_no_parameters(self, init_state, op, mat, tol):
+    def test_two_qubit_no_parameters(self, device, init_state, op, mat, tol):
         """Test non-parametrized two qubit operations"""
-        dev = DefaultQubitTorch(wires=2)
+        dev = device(wires=2)
         state = init_state(2)
 
         queue = [qml.QubitStateVector(state, wires=[0, 1])]
@@ -403,10 +412,10 @@ class TestApply:
         assert torch.allclose(res, expected, atol=tol, rtol=0)
 
     @pytest.mark.parametrize("mat", [U, U2])
-    def test_qubit_unitary(self, init_state, mat, tol):
+    def test_qubit_unitary(self, device, init_state, mat, tol):
         """Test application of arbitrary qubit unitaries"""
         N = int(math.log(len(mat), 2))
-        dev = DefaultQubitTorch(wires=N)
+        dev = device(wires=N)
         state = init_state(N)
 
         queue = [qml.QubitStateVector(state, wires=range(N))]
@@ -417,9 +426,9 @@ class TestApply:
         expected = mat @ state
         assert torch.allclose(res, expected, atol=tol, rtol=0)
 
-    def test_diagonal_qubit_unitary(self, init_state, tol):
+    def test_diagonal_qubit_unitary(self, device, init_state, tol):
         """Tests application of a diagonal qubit unitary"""
-        dev = DefaultQubitTorch(wires=1)
+        dev = device(wires=1)
         state = init_state(1)
 
         diag = torch.tensor(
@@ -433,9 +442,9 @@ class TestApply:
         expected = torch.diag(diag) @ state
         assert torch.allclose(res, expected, atol=tol, rtol=0)
 
-    def test_diagonal_qubit_unitary_inverse(self, init_state, tol):
+    def test_diagonal_qubit_unitary_inverse(self, device, init_state, tol):
         """Tests application of a diagonal qubit unitary"""
-        dev = DefaultQubitTorch(wires=1)
+        dev = device(wires=1)
         state = init_state(1)
 
         diag = torch.tensor(
@@ -453,9 +462,9 @@ class TestApply:
         assert torch.allclose(res, expected, atol=tol, rtol=0)
 
     @pytest.mark.parametrize("op, mat", three_qubit)
-    def test_three_qubit_no_parameters(self, init_state, op, mat, tol):
+    def test_three_qubit_no_parameters(self, device, init_state, op, mat, tol):
         """Test non-parametrized three qubit operations"""
-        dev = DefaultQubitTorch(wires=3)
+        dev = device(wires=3)
         state = init_state(3)
 
         queue = [qml.QubitStateVector(state, wires=[0, 1, 2])]
@@ -468,9 +477,9 @@ class TestApply:
 
     @pytest.mark.parametrize("theta", [0.5432, -0.232])
     @pytest.mark.parametrize("op,func", two_qubit_param)
-    def test_two_qubit_parameters(self, init_state, op, func, theta, tol):
+    def test_two_qubit_parameters(self, device, init_state, op, func, theta, tol):
         """Test two qubit parametrized operations"""
-        dev = DefaultQubitTorch(wires=2)
+        dev = device(wires=2)
         state = init_state(2)
 
         queue = [qml.QubitStateVector(state, wires=[0, 1])]
@@ -484,9 +493,9 @@ class TestApply:
 
     @pytest.mark.parametrize("theta", [0.5432, -0.232])
     @pytest.mark.parametrize("op,func", four_qubit_param)
-    def test_four_qubit_parameters(self, init_state, op, func, theta, tol):
+    def test_four_qubit_parameters(self, device, init_state, op, func, theta, tol):
         """Test two qubit parametrized operations"""
-        dev = DefaultQubitTorch(wires=4)
+        dev = device(wires=4)
         state = init_state(4)
 
         queue = [qml.QubitStateVector(state, wires=[0, 1, 2, 3])]
@@ -498,10 +507,10 @@ class TestApply:
         expected = op_mat @ state
         assert torch.allclose(res, expected, atol=tol, rtol=0)
 
-    def test_apply_ops_above_8_wires_using_special(self):
+    def test_apply_ops_above_8_wires_using_special(self, device):
         """Test that special apply methods that involve slicing function correctly when using 9
         wires"""
-        dev = DefaultQubitTorch(wires=9)
+        dev = device(wires=9)
         dev._apply_ops = {"CNOT": dev._apply_cnot}
 
         queue = [qml.CNOT(wires=[1, 2])]
@@ -554,9 +563,9 @@ class TestExpval:
     ]
 
     @pytest.mark.parametrize("gate,obs,expected", single_wire_expval_test_data)
-    def test_single_wire_expectation(self, gate, obs, expected, theta, phi, varphi, tol):
+    def test_single_wire_expectation(self, device, gate, obs, expected, theta, phi, varphi, tol):
         """Test that single qubit gates with single qubit expectation values"""
-        dev = DefaultQubitTorch(wires=2)
+        dev = device(wires=2)
 
         with qml.tape.QuantumTape() as tape:
             queue = [gate(theta, wires=0), gate(phi, wires=1), qml.CNOT(wires=[0, 1])]
@@ -565,11 +574,12 @@ class TestExpval:
         res = dev.execute(tape)
 
         expected_res = expected(theta, phi)
+        print(res.device, expected_res.device)
         assert torch.allclose(res, expected_res, atol=tol, rtol=0)
 
-    def test_hermitian_expectation(self, theta, phi, varphi, tol):
+    def test_hermitian_expectation(self, device, theta, phi, varphi, tol):
         """Test that arbitrary Hermitian expectation values are correct"""
-        dev = DefaultQubitTorch(wires=2)
+        dev = device(wires=2)
 
         Hermitian_mat = torch.tensor(
             [[1.02789352, 1.61296440 - 0.3498192j], [1.61296440 + 0.3498192j, 1.23920938 + 0j]],
@@ -593,7 +603,7 @@ class TestExpval:
 
         assert torch.allclose(res, expected, atol=tol, rtol=0)
 
-    def test_multi_mode_hermitian_expectation(self, theta, phi, varphi, tol):
+    def test_multi_mode_hermitian_expectation(self, device, theta, phi, varphi, tol):
         """Test that arbitrary multi-mode Hermitian expectation values are correct"""
         Hermit_mat2 = torch.tensor(
             [
@@ -605,7 +615,7 @@ class TestExpval:
             dtype=torch.complex128,
         )
 
-        dev = DefaultQubitTorch(wires=2)
+        dev = device(wires=2)
 
         with qml.tape.QuantumTape() as tape:
             queue = [qml.RY(theta, wires=0), qml.RY(phi, wires=1), qml.CNOT(wires=[0, 1])]
@@ -625,9 +635,9 @@ class TestExpval:
 
         assert torch.allclose(res, expected, atol=tol, rtol=0)
 
-    def test_paulix_pauliy(self, theta, phi, varphi, tol):
+    def test_paulix_pauliy(self, device, theta, phi, varphi, tol):
         """Test that a tensor product involving PauliX and PauliY works correctly"""
-        dev = qml.device("default.qubit.torch", wires=3)
+        dev = device(wires=3)
         dev.reset()
 
         obs = qml.PauliX(0) @ qml.PauliY(2)
@@ -649,9 +659,9 @@ class TestExpval:
 
         assert torch.allclose(res, expected, atol=tol, rtol=0)
 
-    def test_pauliz_identity(self, theta, phi, varphi, tol):
+    def test_pauliz_identity(self, device, theta, phi, varphi, tol):
         """Test that a tensor product involving PauliZ and Identity works correctly"""
-        dev = qml.device("default.qubit.torch", wires=3)
+        dev = device(wires=3)
         dev.reset()
 
         obs = qml.PauliZ(0) @ qml.Identity(1) @ qml.PauliZ(2)
@@ -673,9 +683,9 @@ class TestExpval:
 
         assert torch.allclose(res, expected, atol=tol, rtol=0)
 
-    def test_pauliz_hadamard(self, theta, phi, varphi, tol):
+    def test_pauliz_hadamard(self, device, theta, phi, varphi, tol):
         """Test that a tensor product involving PauliZ and PauliY and hadamard works correctly"""
-        dev = qml.device("default.qubit.torch", wires=3)
+        dev = device(wires=3)
         obs = qml.PauliZ(0) @ qml.Hadamard(1) @ qml.PauliY(2)
 
         dev.reset()
@@ -698,9 +708,9 @@ class TestExpval:
 
         assert torch.allclose(res, expected, atol=tol, rtol=0)
 
-    def test_hermitian(self, theta, phi, varphi, tol):
+    def test_hermitian(self, device, theta, phi, varphi, tol):
         """Test that a tensor product involving qml.Hermitian works correctly"""
-        dev = qml.device("default.qubit.torch", wires=3)
+        dev = device(wires=3)
         dev.reset()
 
         Hermit_mat3 = torch.tensor(
@@ -737,9 +747,9 @@ class TestExpval:
 
         assert torch.allclose(res, expected, atol=tol, rtol=0)
 
-    def test_hermitian_hermitian(self, theta, phi, varphi, tol):
+    def test_hermitian_hermitian(self, device, theta, phi, varphi, tol):
         """Test that a tensor product involving two Hermitian matrices works correctly"""
-        dev = qml.device("default.qubit.torch", wires=3)
+        dev = device(wires=3)
 
         A1 = torch.tensor([[1, 2], [2, 4]], dtype=torch.complex128)
 
@@ -793,9 +803,9 @@ class TestExpval:
 
         assert torch.allclose(res, expected, atol=tol, rtol=0)
 
-    def test_hermitian_identity_expectation(self, theta, phi, varphi, tol):
+    def test_hermitian_identity_expectation(self, device, theta, phi, varphi, tol):
         """Test that a tensor product involving an Hermitian matrix and the identity works correctly"""
-        dev = qml.device("default.qubit.torch", wires=2)
+        dev = device(wires=2)
 
         A = torch.tensor(
             [[1.02789352, 1.61296440 - 0.3498192j], [1.61296440 + 0.3498192j, 1.23920938 + 0j]],
@@ -820,9 +830,9 @@ class TestExpval:
 
         assert torch.allclose(res, torch.real(expected), atol=tol, rtol=0)
 
-    def test_hermitian_two_wires_identity_expectation(self, theta, phi, varphi, tol):
+    def test_hermitian_two_wires_identity_expectation(self, device, theta, phi, varphi, tol):
         """Test that a tensor product involving an Hermitian matrix for two wires and the identity works correctly"""
-        dev = qml.device("default.qubit.torch", wires=3, shots=None)
+        dev = device(wires=3)
 
         A = torch.tensor(
             [[1.02789352, 1.61296440 - 0.3498192j], [1.61296440 + 0.3498192j, 1.23920938 + 0j]],
@@ -852,9 +862,9 @@ class TestExpval:
 class TestVar:
     """Tests for the variance"""
 
-    def test_var(self, theta, phi, varphi, tol):
+    def test_var(self, device, theta, phi, varphi, tol):
         """Tests for variance calculation"""
-        dev = DefaultQubitTorch(wires=1)
+        dev = device(wires=1)
         # test correct variance for <Z> of a rotated state
 
         with qml.tape.QuantumTape() as tape:
@@ -867,9 +877,9 @@ class TestVar:
         )
         assert torch.allclose(res, expected, atol=tol, rtol=0)
 
-    def test_var_hermitian(self, theta, phi, varphi, tol):
+    def test_var_hermitian(self, device, theta, phi, varphi, tol):
         """Tests for variance calculation using an arbitrary Hermitian observable"""
-        dev = DefaultQubitTorch(wires=2)
+        dev = device(wires=2)
 
         # test correct variance for <H> of a rotated state
         H = torch.tensor([[4, -1 + 6j], [-1 - 6j, 2]], dtype=torch.complex128)
@@ -888,9 +898,9 @@ class TestVar:
 
         assert torch.allclose(res, expected, atol=tol, rtol=0)
 
-    def test_paulix_pauliy(self, theta, phi, varphi, tol):
+    def test_paulix_pauliy(self, device, theta, phi, varphi, tol):
         """Test that a tensor product involving PauliX and PauliY works correctly"""
-        dev = qml.device("default.qubit.torch", wires=3)
+        dev = device(wires=3)
 
         obs = qml.PauliX(0) @ qml.PauliY(2)
 
@@ -918,9 +928,9 @@ class TestVar:
 
         assert torch.allclose(res, expected, atol=tol, rtol=0)
 
-    def test_pauliz_hadamard(self, theta, phi, varphi, tol):
+    def test_pauliz_hadamard(self, device, theta, phi, varphi, tol):
         """Test that a tensor product involving PauliZ and PauliY and hadamard works correctly"""
-        dev = qml.device("default.qubit.torch", wires=3)
+        dev = device(wires=3)
         obs = qml.PauliZ(0) @ qml.Hadamard(1) @ qml.PauliY(2)
 
         dev.reset()
@@ -946,9 +956,9 @@ class TestVar:
 
         assert torch.allclose(res, expected, atol=tol, rtol=0)
 
-    def test_hermitian(self, theta, phi, varphi, tol):
+    def test_hermitian(self, device, theta, phi, varphi, tol):
         """Test that a tensor product involving qml.Hermitian works correctly"""
-        dev = qml.device("default.qubit.torch", wires=3)
+        dev = device(wires=3)
 
         A = torch.tensor(
             [
@@ -1053,7 +1063,7 @@ class TestQNodeIntegration:
         assert dev.short_name == "default.qubit.torch"
         assert dev.capabilities()["passthru_interface"] == "torch"
 
-    def test_qubit_circuit(self, tol):
+    def test_qubit_circuit(self, device, tol):
         """Test that the torch device provides correct
         result for a simple circuit using the old QNode."""
         p = torch.tensor(0.543, dtype=torch.float64)
@@ -1070,20 +1080,21 @@ class TestQNodeIntegration:
         assert circuit.gradient_fn == "backprop"
         assert torch.allclose(circuit(p), expected, atol=tol, rtol=0)
 
-    def test_correct_state(self, tol):
+    def test_correct_state(self, device, tol):
         """Test that the device state is correct after applying a
         quantum function on the device"""
-
-        dev = qml.device("default.qubit.torch", wires=2)
+        dev = qml.device("default.qubit.torch", wires=2, torch_device=torch_device)
 
         state = dev.state
         expected = torch.tensor([1, 0, 0, 0], dtype=torch.complex128)
         assert torch.allclose(state, expected, atol=tol, rtol=0)
 
+        input_param = torch.tensor(math.pi / 4)
+
         @qml.qnode(dev, interface="torch", diff_method="backprop")
         def circuit():
             qml.Hadamard(wires=0)
-            qml.RZ(math.pi / 4, wires=0)
+            qml.RZ(input_param, wires=0)
             return qml.expval(qml.PauliZ(0))
 
         circuit()
@@ -1182,7 +1193,10 @@ class TestQNodeIntegration:
 class TestPassthruIntegration:
     """Tests for integration with the PassthruQNode"""
 
-    def test_jacobian_variable_multiply(self, tol):
+    # TODO: this test warns with CUDA (maybe CPU too) on res.backward(): [W
+    # Copy.cpp:244] Warning: Casting complex values to real discards the
+    # imaginary part (function operator())
+    def test_jacobian_variable_multiply(self, device, tol):
         """Test that jacobian of a QNode with an attached default.qubit.torch device
         gives the correct result in the case of parameters multiplied by scalars"""
         x = torch.tensor(0.43316321, dtype=torch.float64, requires_grad=True)
@@ -1218,7 +1232,7 @@ class TestPassthruIntegration:
         assert torch.allclose(y.grad, y_grad)
         assert torch.allclose(z.grad, z_grad)
 
-    def test_jacobian_repeated(self, tol):
+    def test_jacobian_repeated(self, device, tol):
         """Test that jacobian of a QNode with an attached default.qubit.torch device
         gives the correct result in the case of repeated parameters"""
         x = torch.tensor(0.43316321, dtype=torch.float64, requires_grad=True)
@@ -1250,7 +1264,7 @@ class TestPassthruIntegration:
         )
         assert torch.allclose(p.grad, expected_grad, atol=tol, rtol=0)
 
-    def test_jacobian_agrees_backprop_parameter_shift(self, tol):
+    def test_jacobian_agrees_backprop_parameter_shift(self, device, tol):
         """Test that jacobian of a QNode with an attached default.qubit.torch device
         gives the correct result with respect to the parameter-shift method"""
         p = pnp.array([0.43316321, 0.2162158, 0.75110998, 0.94714242], requires_grad=True)
@@ -1273,12 +1287,12 @@ class TestPassthruIntegration:
         res = circuit1(p_torch)
         res.backward()
 
-        assert np.allclose(res.detach().numpy(), circuit2(p).numpy(), atol=tol, rtol=0)
+        assert np.allclose(qml.math.to_numpy(res), circuit2(p).numpy(), atol=tol, rtol=0)
 
         p_grad = p_torch.grad
-        assert np.allclose(p_grad.detach().numpy(), qml.jacobian(circuit2)(p), atol=tol, rtol=0)
+        assert np.allclose(qml.math.to_numpy(p_grad), qml.jacobian(circuit2)(p), atol=tol, rtol=0)
 
-    def test_state_differentiability(self, tol):
+    def test_state_differentiability(self, device, tol):
         """Test that the device state can be differentiated"""
         dev = qml.device("default.qubit.torch", wires=1)
 
@@ -1298,7 +1312,7 @@ class TestPassthruIntegration:
         expected = torch.sin(a)
         assert torch.allclose(grad, expected, atol=tol, rtol=0)
 
-    def test_prob_differentiability(self, tol):
+    def test_prob_differentiability(self, device, tol):
         """Test that the device probability can be differentiated"""
         dev = qml.device("default.qubit.torch", wires=2)
 
@@ -1324,7 +1338,7 @@ class TestPassthruIntegration:
         assert torch.allclose(a.grad, torch.sin(a) * torch.cos(b), atol=tol, rtol=0)
         assert torch.allclose(b.grad, torch.cos(a) * torch.sin(b), atol=tol, rtol=0)
 
-    def test_backprop_gradient(self, tol):
+    def test_backprop_gradient(self, device, tol):
         """Tests that the gradient of the qnode is correct"""
         dev = qml.device("default.qubit.torch", wires=2)
 
@@ -1355,11 +1369,13 @@ class TestPassthruIntegration:
         using the PyTorch interface, using a variety of differentiation methods."""
         dev = qml.device("default.qubit.torch", wires=1)
 
+        input_state = torch.tensor(1j * torch.tensor([1, -1]) / math.sqrt(2))
+
         @qml.qnode(dev, diff_method=diff_method, interface="torch")
         def circuit(x, weights, w):
             """In this example, a mixture of scalar
             arguments, array arguments, and keyword arguments are used."""
-            qml.QubitStateVector(1j * torch.tensor([1, -1]) / math.sqrt(2), wires=w)
+            qml.QubitStateVector(input_state, wires=w)
             operation(x, weights[0], weights[1], wires=w)
             return qml.expval(qml.PauliX(w))
 
@@ -1404,7 +1420,7 @@ class TestPassthruIntegration:
         )
         assert torch.allclose(params.grad, expected_grad, atol=tol, rtol=0)
 
-    def test_inverse_operation_jacobian_backprop(self, tol):
+    def test_inverse_operation_jacobian_backprop(self, device, tol):
         """Test that inverse operations work in backprop
         mode"""
         dev = qml.device("default.qubit.torch", wires=1)
@@ -1462,7 +1478,7 @@ class TestSamples:
         assert res.shape == (shots,)
         assert torch.allclose(torch.unique(res), torch.tensor([-1, 1], dtype=torch.int64))
 
-    def test_estimating_marginal_probability(self, tol):
+    def test_estimating_marginal_probability(self, device, tol):
         """Test that the probability of a subset of wires is accurately estimated."""
         dev = qml.device("default.qubit.torch", wires=2, shots=1000)
 
@@ -1478,7 +1494,7 @@ class TestSamples:
         expected = torch.tensor([0, 1], dtype=torch.float64)
         assert torch.allclose(res, expected, atol=tol, rtol=0)
 
-    def test_estimating_full_probability(self, tol):
+    def test_estimating_full_probability(self, device, tol):
         """Test that the probability of a subset of wires is accurately estimated."""
         dev = qml.device("default.qubit.torch", wires=2, shots=1000)
 
@@ -1495,7 +1511,7 @@ class TestSamples:
         expected = torch.tensor([0, 0, 0, 1], dtype=torch.float64)
         assert torch.allclose(res, expected, atol=tol, rtol=0)
 
-    def test_estimating_expectation_values(self, tol):
+    def test_estimating_expectation_values(self, device, tol):
         """Test that estimating expectation values using a finite number
         of shots produces a numeric tensor"""
         dev = qml.device("default.qubit.torch", wires=3, shots=1000)


### PR DESCRIPTION
**Context:**

With recent changes in `default.qubit` (https://github.com/PennyLaneAI/pennylane/pull/1749), the backpropagation variants of the device no longer define their own ML framework-specific implementation of parametric operations.

This means, that the pipeline defined in `pennylane/ops/qubit/parametric_ops.py` is being used by all backpropagation devices.

Some matrix definitions include scalars/constants (e.g., 0 or 1) that don't have an explicit type definition. When using Torch with GPU, such objects will be put on the CPU resulting in an error.

Such an operation is `qml.RX`:
```python
import pennylane as qml
import torch

dev = qml.device("default.qubit.torch", wires=1)

@qml.qnode(dev, interface='torch')
def circuit(x, y):
    qml.RX(x, wires=0)
    qml.RZ(y, wires=0)
    return qml.expval(qml.PauliZ(0))

x = torch.tensor(0.3, device='cuda')
y =  torch.tensor(0., device='cuda')

circuit(x, y)
```
```
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cpu and cuda:0! (when checking argument for argument tensors in method wrapper___cat)
```

**Description of the Change:**

* Changes the definition of parametric operations that include arithmetics where Torch does automatic type inference (`qml.RX` for now, rest of the ops are TODO)
* Changes the tests for `default.qubit.torch` such that they can optionally be run on the GPU (TODO: add the option to select tests to be run on GPU)

**Benefits:**
Fixed compatibility with GPU and better GPU testing with Torch.

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
N/A