### PR TITLE
Update the norm check for `QubitStateVector` in `default.qubit` (v0.19.1)

### DIFF
--- a/doc/development/release_notes.md
+++ b/doc/development/release_notes.md
@@ -4,6 +4,8 @@ Release notes
 This page contains the release notes for PennyLane.
 
 
+.. mdinclude:: ../releases/changelog-0.19.1.md
+
 .. mdinclude:: ../releases/changelog-0.19.0.md
 
 .. mdinclude:: ../releases/changelog-0.18.0.md

--- a/doc/releases/changelog-0.19.0.md
+++ b/doc/releases/changelog-0.19.0.md
@@ -1,6 +1,6 @@
 :orphan:
 
-# Release 0.19.0 (current release)
+# Release 0.19.0
 
 <h3>New features since last release</h3>
 

--- a/doc/releases/changelog-0.19.1.md
+++ b/doc/releases/changelog-0.19.1.md
@@ -1,0 +1,16 @@
+:orphan:
+
+# Release 0.19.1 (current release)
+
+<h3>Bug fixes</h3>
+
+* Fixes a bug where using JAX's jit function on certain QNodes that contain
+  the `qml.QubitStateVector` operation raised an error with earlier JAX
+  versions (e.g., `jax==0.2.10` and `jaxlib==0.1.64`).
+  [(#1923)](https://github.com/PennyLaneAI/pennylane/pull/1923)
+
+<h3>Contributors</h3>
+
+This release contains contributions from (in alphabetical order):
+
+Josh Izaac, Romain Moyard, Antal Száva.

--- a/doc/releases/changelog-0.19.1.md
+++ b/doc/releases/changelog-0.19.1.md
@@ -7,7 +7,7 @@
 * Fixes a bug where using JAX's jit function on certain QNodes that contain
   the `qml.QubitStateVector` operation raised an error with earlier JAX
   versions (e.g., `jax==0.2.10` and `jaxlib==0.1.64`).
-  [(#1923)](https://github.com/PennyLaneAI/pennylane/pull/1923)
+  [(#1924)](https://github.com/PennyLaneAI/pennylane/pull/1924)
 
 <h3>Contributors</h3>
 

--- a/pennylane/_version.py
+++ b/pennylane/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.19.0"
+__version__ = "0.19.1"

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -633,8 +633,9 @@ class DefaultQubit(QubitDevice):
         if len(qml.math.shape(state)) != 1 or n_state_vector != 2 ** len(device_wires):
             raise ValueError("State vector must be of length 2**wires.")
 
-        if not qml.math.is_abstract(state):
-            if not qml.math.allclose(qml.math.linalg.norm(state, ord=2), 1.0, atol=tolerance):
+        norm = qml.math.linalg.norm(state, ord=2)
+        if not qml.math.is_abstract(norm):
+            if not qml.math.allclose(norm, 1.0, atol=tolerance):
                 raise ValueError("Sum of amplitudes-squared does not equal one.")
 
         if len(device_wires) == self.num_wires and sorted(device_wires) == device_wires:


### PR DESCRIPTION
**Context:**

There is a check in `default.qubit` to ensure that the input statevector is normalized for the `QubitStateVector` operation.

For certain tensors, in particular those that are abstract (have no numeric value at the time), this check would result in an error. For this reason, there is first a condition checking whether that the input tensor is abstract or not.

The issue seems to arise still, however, because it seems that the output of extracting the norm for an input tensor could still be abstract.

This issue arises with:
* JAX Jitting when using `jax==0.2.10` and  `jaxlib==0.1.64`
* Input tensors with a complex dtype
* Specifying the input statevector outside of the QNode (without making it an input parameter of the QNode). If the input statevector was an input parameter, jitting would continue to work.

**Description of the Change:**

* The abstraction check is changed to check the normalized statevector rather than the input statevector;
* Prepares a new changelog for the v0.19.1 bug fix.

**Benefits:**
JAX Jitting works with `QubitStateVector` even with earlier JAX versions.

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
QML repository failures for the `dev` and `master` checks:
* https://github.com/PennyLaneAI/qml/runs/4275830784?check_suite_focus=true#step:8:2440
* https://github.com/PennyLaneAI/qml/runs/4275800151?check_suite_focus=true#step:8:2552