### PR TITLE
Add intro doc for thermal relaxation error

### DIFF
--- a/doc/introduction/operations.rst
+++ b/doc/introduction/operations.rst
@@ -193,6 +193,7 @@ Noisy channels
     ~pennylane.PhaseFlip
     ~pennylane.ResetError
     ~pennylane.QubitChannel
+    ~pennylane.ThermalRelaxationError
 
 :html:`</div>`
 


### PR DESCRIPTION
**Context:**
The `ThermalRelaxationError` was not added to the documentation introduction for operations.
