### PR TITLE
 Fix parametric ops GPU compatibility (`v0.19.1`)

### DIFF
--- a/doc/releases/changelog-0.19.1.md
+++ b/doc/releases/changelog-0.19.1.md
@@ -4,10 +4,9 @@
 
 <h3>Bug fixes</h3>
 
-* Fixes several bugs with using parametric operations with the
-  `default.qubit.tensor` device on GPU.
-  The device takes the `torch_device` argument to allow running
-  non-parametric QNodes on the GPU.
+* Fixes several bugs when using parametric operations with the
+  `default.qubit.tensor` device on GPU. The device takes the `torch_device`
+  argument once again to allow running non-parametric QNodes on the GPU.
   [(#1927)](https://github.com/PennyLaneAI/pennylane/pull/1927)
 
 * Fixes a bug where using JAX's jit function on certain QNodes that contain

--- a/doc/releases/changelog-0.19.1.md
+++ b/doc/releases/changelog-0.19.1.md
@@ -4,6 +4,12 @@
 
 <h3>Bug fixes</h3>
 
+* Fixes several bugs with using parametric operations with the
+  `default.qubit.tensor` device on GPU.
+  The device takes the `torch_device` argument to allow running
+  non-parametric QNodes on the GPU.
+  [(#1927)](https://github.com/PennyLaneAI/pennylane/pull/1927)
+
 * Fixes a bug where using JAX's jit function on certain QNodes that contain
   the `qml.QubitStateVector` operation raised an error with earlier JAX
   versions (e.g., `jax==0.2.10` and `jaxlib==0.1.64`).

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -679,7 +679,8 @@ class DefaultQubit(QubitDevice):
 
         # get computational basis state number
         basis_states = 2 ** (self.num_wires - 1 - np.array(device_wires))
-        num = int(np.dot(state, basis_states))
+        basis_states = qml.math.convert_like(basis_states, state)
+        num = int(qml.math.dot(state, basis_states))
 
         self._state = self._create_basis_state(num)
 

--- a/pennylane/devices/default_qubit_torch.py
+++ b/pennylane/devices/default_qubit_torch.py
@@ -156,7 +156,7 @@ class DefaultQubitTorch(DefaultQubit):
 
         # Store if the user specified a Torch device. Otherwise the execute
         # method attempts to infer the Torch device from the gate parameters.
-        self._torch_device_requested = torch_device is not None
+        self._torch_device_specified = torch_device is not None
         self._torch_device = torch_device
 
         super().__init__(wires, shots=shots, cache=0, analytic=analytic)
@@ -169,14 +169,17 @@ class DefaultQubitTorch(DefaultQubit):
     def execute(self, circuit, **kwargs):
         ops_and_obs = circuit.operations + circuit.observables
 
-        if not self._torch_device_requested:
+        if not self._torch_device_specified:
             if any(
                 data.is_cuda for op in ops_and_obs for data in op.data if hasattr(data, "is_cuda")
             ):
+
                 self._torch_device = "cuda"
             else:
+
                 # need to reset in case last execution moved to cuda
                 self._torch_device = "cpu"
+
         return super().execute(circuit, **kwargs)
 
     def _asarray(self, a, dtype=None):

--- a/pennylane/devices/default_qubit_torch.py
+++ b/pennylane/devices/default_qubit_torch.py
@@ -180,6 +180,9 @@ class DefaultQubitTorch(DefaultQubit):
                 # need to reset in case last execution moved to cuda
                 self._torch_device = "cpu"
 
+        if self._state.device != self._torch_device:
+            self._state = self._state.to(self._torch_device)
+
         return super().execute(circuit, **kwargs)
 
     def _asarray(self, a, dtype=None):
@@ -278,6 +281,4 @@ class DefaultQubitTorch(DefaultQubit):
         Returns:
             torch.Tensor[complex]: output state
         """
-        if state.device != self._torch_device:
-            state = state.to(self._torch_device)
         return super()._apply_operation(state, operation)

--- a/pennylane/devices/default_qubit_torch.py
+++ b/pennylane/devices/default_qubit_torch.py
@@ -180,8 +180,10 @@ class DefaultQubitTorch(DefaultQubit):
                 # need to reset in case last execution moved to cuda
                 self._torch_device = "cpu"
 
-        if self._state.device != self._torch_device:
-            self._state = self._state.to(self._torch_device)
+            # If we've changed the device, place the state on the correct
+            # device
+            if self._state.device != self._torch_device:
+                self._state = self._state.to(self._torch_device)
 
         return super().execute(circuit, **kwargs)
 

--- a/pennylane/devices/default_qubit_torch.py
+++ b/pennylane/devices/default_qubit_torch.py
@@ -171,8 +171,8 @@ class DefaultQubitTorch(DefaultQubit):
         ops_and_obs = circuit.operations + circuit.observables
 
         some_params_cuda = any(
-                data.is_cuda for op in ops_and_obs for data in op.data if hasattr(data, "is_cuda")
-            )
+            data.is_cuda for op in ops_and_obs for data in op.data if hasattr(data, "is_cuda")
+        )
         if not self._torch_device_specified:
             if some_params_cuda:
 
@@ -188,13 +188,17 @@ class DefaultQubitTorch(DefaultQubit):
                 self._state = self._state.to(self._torch_device)
         else:
             cuda_params_but_not_cuda_specified = some_params_cuda and self._torch_device != "cuda"
-            not_cuda_params_but_cuda_specified = not some_params_cuda and self._torch_device == "cuda"
+            not_cuda_params_but_cuda_specified = (
+                not some_params_cuda and self._torch_device == "cuda"
+            )
             if cuda_params_but_not_cuda_specified or not_cuda_params_but_cuda_specified:
 
-                warnings.warn(f"Torch device {self._torch_device} specified "
-                        "upon PennyLane device creation does not match the "\
-                        "Torch device of the gate parameters; "\
-                                f"{self._torch_device} will be used.")
+                warnings.warn(
+                    f"Torch device {self._torch_device} specified "
+                    "upon PennyLane device creation does not match the "
+                    "Torch device of the gate parameters; "
+                    f"{self._torch_device} will be used."
+                )
 
         return super().execute(circuit, **kwargs)
 

--- a/pennylane/devices/default_qubit_torch.py
+++ b/pennylane/devices/default_qubit_torch.py
@@ -165,7 +165,8 @@ class DefaultQubitTorch(DefaultQubit):
 
     def execute(self, circuit, **kwargs):
         ops_and_obs = circuit.operations + circuit.observables
-        if any(data.is_cuda for op in ops_and_obs for data in op.data if hasattr(data, "is_cuda")):
+        cuda_was_set = self._torch_device == 'cuda'
+        if any(data.is_cuda for op in ops_and_obs for data in op.data if hasattr(data, "is_cuda")) or cuda_was_set:
             self._torch_device = "cuda"
         else:
             # need to reset in case last execution moved to cuda

--- a/pennylane/devices/default_qubit_torch.py
+++ b/pennylane/devices/default_qubit_torch.py
@@ -165,8 +165,11 @@ class DefaultQubitTorch(DefaultQubit):
 
     def execute(self, circuit, **kwargs):
         ops_and_obs = circuit.operations + circuit.observables
-        cuda_was_set = self._torch_device == 'cuda'
-        if any(data.is_cuda for op in ops_and_obs for data in op.data if hasattr(data, "is_cuda")) or cuda_was_set:
+        cuda_was_set = self._torch_device == "cuda"
+        if (
+            any(data.is_cuda for op in ops_and_obs for data in op.data if hasattr(data, "is_cuda"))
+            or cuda_was_set
+        ):
             self._torch_device = "cuda"
         else:
             # need to reset in case last execution moved to cuda

--- a/pennylane/devices/default_qubit_torch.py
+++ b/pennylane/devices/default_qubit_torch.py
@@ -15,6 +15,7 @@
 reference plugin.
 """
 import semantic_version
+import warnings
 
 try:
     import torch
@@ -169,10 +170,11 @@ class DefaultQubitTorch(DefaultQubit):
     def execute(self, circuit, **kwargs):
         ops_and_obs = circuit.operations + circuit.observables
 
-        if not self._torch_device_specified:
-            if any(
+        some_params_cuda = any(
                 data.is_cuda for op in ops_and_obs for data in op.data if hasattr(data, "is_cuda")
-            ):
+            )
+        if not self._torch_device_specified:
+            if some_params_cuda:
 
                 self._torch_device = "cuda"
             else:
@@ -184,6 +186,15 @@ class DefaultQubitTorch(DefaultQubit):
             # device
             if self._state.device != self._torch_device:
                 self._state = self._state.to(self._torch_device)
+        else:
+            cuda_params_but_not_cuda_specified = some_params_cuda and self._torch_device != "cuda"
+            not_cuda_params_but_cuda_specified = not some_params_cuda and self._torch_device == "cuda"
+            if cuda_params_but_not_cuda_specified or not_cuda_params_but_cuda_specified:
+
+                warnings.warn(f"Torch device {self._torch_device} specified "
+                        "upon PennyLane device creation does not match the "\
+                        "Torch device of the gate parameters; "\
+                                f"{self._torch_device} will be used.")
 
         return super().execute(circuit, **kwargs)
 

--- a/pennylane/devices/default_qubit_torch.py
+++ b/pennylane/devices/default_qubit_torch.py
@@ -152,9 +152,9 @@ class DefaultQubitTorch(DefaultQubit):
     _norm = staticmethod(torch.norm)
     _flatten = staticmethod(torch.flatten)
 
-    def __init__(self, wires, *, shots=None, analytic=None):
+    def __init__(self, wires, *, shots=None, analytic=None, torch_device=None):
 
-        self._torch_device = "cpu"
+        self._torch_device = torch_device
 
         super().__init__(wires, shots=shots, cache=0, analytic=analytic)
 

--- a/pennylane/interfaces/torch.py
+++ b/pennylane/interfaces/torch.py
@@ -74,7 +74,7 @@ class _TorchInterface(torch.autograd.Function):
         tape.set_parameters(ctx.all_params, trainable_only=False)
 
         if hasattr(res, "numpy"):
-            res = res.numpy()
+            res = qml.math.to_numpy(res)
 
         use_adjoint_cached_state = False
         # tape might not be a jacobian tape

--- a/pennylane/math/single_dispatch.py
+++ b/pennylane/math/single_dispatch.py
@@ -336,7 +336,16 @@ def _coerce_types_torch(tensors):
     """Coerce a list of tensors to all have the same dtype
     without any loss of information."""
     torch = _i("torch")
-    tensors = [torch.as_tensor(t) for t in tensors]
+
+    # Extract existing set devices, if any
+    device_set = set(t.device for t in tensors if isinstance(t, torch.Tensor))
+    if len(device_set) > 1:
+        #TODO:
+        raise ValueError('Cannot coerce.')
+
+    device = device_set.pop() if len(device_set) == 1 else None
+    tensors = [torch.as_tensor(t, device=device) for t in tensors]
+
     dtypes = {i.dtype for i in tensors}
 
     if len(dtypes) == 1:

--- a/pennylane/math/single_dispatch.py
+++ b/pennylane/math/single_dispatch.py
@@ -340,7 +340,8 @@ def _coerce_types_torch(tensors):
     # Extract existing set devices, if any
     device_set = set(t.device for t in tensors if isinstance(t, torch.Tensor))
     if len(device_set) > 1:
-        raise ValueError("Multiple Torch devices were specified, coercing is not possible.")
+        device_names = ", ".join(str(d) for d in device_set)
+        raise RuntimeError(f"Expected all tensors to be on the same device, but found at least two devices, {device_names}!")
 
     device = device_set.pop() if len(device_set) == 1 else None
     tensors = [torch.as_tensor(t, device=device) for t in tensors]

--- a/pennylane/math/single_dispatch.py
+++ b/pennylane/math/single_dispatch.py
@@ -341,7 +341,9 @@ def _coerce_types_torch(tensors):
     device_set = set(t.device for t in tensors if isinstance(t, torch.Tensor))
     if len(device_set) > 1:
         device_names = ", ".join(str(d) for d in device_set)
-        raise RuntimeError(f"Expected all tensors to be on the same device, but found at least two devices, {device_names}!")
+        raise RuntimeError(
+            f"Expected all tensors to be on the same device, but found at least two devices, {device_names}!"
+        )
 
     device = device_set.pop() if len(device_set) == 1 else None
     tensors = [torch.as_tensor(t, device=device) for t in tensors]

--- a/pennylane/math/single_dispatch.py
+++ b/pennylane/math/single_dispatch.py
@@ -340,8 +340,7 @@ def _coerce_types_torch(tensors):
     # Extract existing set devices, if any
     device_set = set(t.device for t in tensors if isinstance(t, torch.Tensor))
     if len(device_set) > 1:
-        # TODO:
-        raise ValueError("Cannot coerce.")
+        raise ValueError("Multiple Torch devices were specified, coercing is not possible.")
 
     device = device_set.pop() if len(device_set) == 1 else None
     tensors = [torch.as_tensor(t, device=device) for t in tensors]

--- a/pennylane/math/single_dispatch.py
+++ b/pennylane/math/single_dispatch.py
@@ -340,8 +340,8 @@ def _coerce_types_torch(tensors):
     # Extract existing set devices, if any
     device_set = set(t.device for t in tensors if isinstance(t, torch.Tensor))
     if len(device_set) > 1:
-        #TODO:
-        raise ValueError('Cannot coerce.')
+        # TODO:
+        raise ValueError("Cannot coerce.")
 
     device = device_set.pop() if len(device_set) == 1 else None
     tensors = [torch.as_tensor(t, device=device) for t in tensors]

--- a/pennylane/ops/qubit/observables.py
+++ b/pennylane/ops/qubit/observables.py
@@ -61,12 +61,12 @@ class Hermitian(Observable):
 
     @classmethod
     def _matrix(cls, *params):
-        A = np.asarray(params[0])
+        A = qml.math.asarray(params[0])
 
         if A.shape[0] != A.shape[1]:
             raise ValueError("Observable must be a square matrix.")
 
-        if not np.allclose(A, A.conj().T):
+        if not qml.math.allclose(A, A.conj().T):
             raise ValueError("Observable must be Hermitian.")
 
         return A
@@ -84,6 +84,7 @@ class Hermitian(Observable):
             dict[str, array]: dictionary containing the eigenvalues and the eigenvectors of the Hermitian observable
         """
         Hmat = self.matrix
+        Hmat = qml.math.to_numpy(Hmat)
         Hkey = tuple(Hmat.flatten().tolist())
         if Hkey not in Hermitian._eigs:
             w, U = np.linalg.eigh(Hmat)

--- a/pennylane/ops/qubit/parametric_ops.py
+++ b/pennylane/ops/qubit/parametric_ops.py
@@ -829,7 +829,7 @@ class CRX(Operation):
 
         c = qml.math.cos(theta / 2)
         s = qml.math.sin(theta / 2)
-        z = qml.math.zeros([4], like=interface)
+        z = qml.math.convert_like(qml.math.zeros([4]), theta)
 
         if interface == "tensorflow":
             c = qml.math.cast_like(c, 1j)
@@ -922,7 +922,7 @@ class CRY(Operation):
 
         c = qml.math.cos(theta / 2)
         s = qml.math.sin(theta / 2)
-        z = qml.math.zeros([4], like=interface)
+        z = qml.math.convert_like(qml.math.zeros([4]), theta)
 
         mat = qml.math.diag([1, 1, c, c])
         return mat + qml.math.stack(

--- a/pennylane/ops/qubit/parametric_ops.py
+++ b/pennylane/ops/qubit/parametric_ops.py
@@ -650,9 +650,16 @@ class PauliRot(Operation):
 
         # Simplest case is if the Pauli is the identity matrix
         if pauli_word == "I" * len(pauli_word):
-            return qml.math.array(
-                qml.math.exp(-1j * theta / 2) * qml.math.eye(2 ** len(pauli_word)), like=interface
-            )
+
+            exp = qml.math.exp(-1j * theta / 2)
+            iden = qml.math.eye(2 ** len(pauli_word))
+            if interface == "torch":
+                # Use convert_like to ensure that the tensor is put on the correct
+                # Torch device
+                iden =  qml.math.convert_like(iden, theta)
+                return exp * iden
+
+            return qml.math.array(exp * iden, like=interface)
 
         # We first generate the matrix excluding the identity parts and expand it afterwards.
         # To this end, we have to store on which wires the non-identity parts act

--- a/pennylane/ops/qubit/parametric_ops.py
+++ b/pennylane/ops/qubit/parametric_ops.py
@@ -829,7 +829,13 @@ class CRX(Operation):
 
         c = qml.math.cos(theta / 2)
         s = qml.math.sin(theta / 2)
-        z = qml.math.convert_like(qml.math.zeros([4]), theta)
+
+        if interface == "torch":
+            # Use convert_like to ensure that the tensor is put on the correct
+            # Torch device
+            z = qml.math.convert_like(qml.math.zeros([4]), theta)
+        else:
+            z = qml.math.zeros([4], like=interface)
 
         if interface == "tensorflow":
             c = qml.math.cast_like(c, 1j)
@@ -922,7 +928,13 @@ class CRY(Operation):
 
         c = qml.math.cos(theta / 2)
         s = qml.math.sin(theta / 2)
-        z = qml.math.convert_like(qml.math.zeros([4]), theta)
+
+        if interface == "torch":
+            # Use convert_like to ensure that the tensor is put on the correct
+            # Torch device
+            z = qml.math.convert_like(qml.math.zeros([4]), theta)
+        else:
+            z = qml.math.zeros([4], like=interface)
 
         mat = qml.math.diag([1, 1, c, c])
         return mat + qml.math.stack(

--- a/pennylane/ops/qubit/parametric_ops.py
+++ b/pennylane/ops/qubit/parametric_ops.py
@@ -656,7 +656,7 @@ class PauliRot(Operation):
             if interface == "torch":
                 # Use convert_like to ensure that the tensor is put on the correct
                 # Torch device
-                iden =  qml.math.convert_like(iden, theta)
+                iden = qml.math.convert_like(iden, theta)
                 return exp * iden
 
             return qml.math.array(exp * iden, like=interface)

--- a/pennylane/ops/qubit/qchem_ops.py
+++ b/pennylane/ops/qubit/qchem_ops.py
@@ -606,10 +606,9 @@ class OrbitalRotation(Operation):
         # Additionally, there was a typo in the sign of a matrix element "s" at [2, 8], which is fixed here.
 
         phi = params[0]
-        interface = qml.math.get_interface(phi)
         c = qml.math.cos(phi / 2)
         s = qml.math.sin(phi / 2)
-        z = qml.math.zeros([16], like=interface)
+        z = qml.math.convert_like(qml.math.zeros([16]), phi)
 
         diag = qml.math.diag([1, c, c, c ** 2, c, 1, c ** 2, c, c, c ** 2, 1, c, c ** 2, c, c, 1])
 

--- a/pennylane/ops/qubit/qchem_ops.py
+++ b/pennylane/ops/qubit/qchem_ops.py
@@ -608,7 +608,15 @@ class OrbitalRotation(Operation):
         phi = params[0]
         c = qml.math.cos(phi / 2)
         s = qml.math.sin(phi / 2)
-        z = qml.math.convert_like(qml.math.zeros([16]), phi)
+
+        interface = qml.math.get_interface(phi)
+
+        if interface == "torch":
+            # Use convert_like to ensure that the tensor is put on the correct
+            # Torch device
+            z = qml.math.convert_like(qml.math.zeros([16]), phi)
+        else:
+            z = qml.math.zeros([16], like=interface)
 
         diag = qml.math.diag([1, c, c, c ** 2, c, 1, c ** 2, c, c, c ** 2, 1, c, c ** 2, c, c, 1])
 

--- a/pennylane/tape/jacobian_tape.py
+++ b/pennylane/tape/jacobian_tape.py
@@ -298,7 +298,7 @@ class JacobianTape(QuantumTape):
                     array[float]: 1-dimensional array of length determined by the tape output
                     measurement statistics
                 """
-                shifted = np.array(results[0])
+                shifted = qml.math.to_numpy(results[0])
                 unshifted = y0
 
                 if unshifted is None:
@@ -582,7 +582,7 @@ class JacobianTape(QuantumTape):
                 # this computation is only performed once, for all parameters.
                 # convert to float64 to eliminate floating point errors when params float32
                 params_f64 = np.array(params, dtype=np.float64)
-                options["y0"] = np.asarray(self.execute_device(params_f64, device))
+                options["y0"] = qml.math.to_numpy(self.execute_device(params_f64, device))
 
         # some gradient methods need the device or the device wires
         options["device"] = device

--- a/tests/devices/test_default_qubit_torch.py
+++ b/tests/devices/test_default_qubit_torch.py
@@ -1251,9 +1251,6 @@ class TestQNodeIntegration:
 class TestPassthruIntegration:
     """Tests for integration with the PassthruQNode"""
 
-    # TODO: this test warns with CUDA (maybe CPU too) on res.backward(): [W
-    # Copy.cpp:244] Warning: Casting complex values to real discards the
-    # imaginary part (function operator())
     def test_jacobian_variable_multiply(self, device, torch_device, tol):
         """Test that jacobian of a QNode with an attached default.qubit.torch device
         gives the correct result in the case of parameters multiplied by scalars"""

--- a/tests/devices/test_default_qubit_torch.py
+++ b/tests/devices/test_default_qubit_torch.py
@@ -24,8 +24,8 @@ import functools
 
 torch = pytest.importorskip("torch", minversion="1.8.1")
 
-use_cuda = torch.cuda.is_available() #TODO: make this togglable via the command line
-torch_device = 'cuda' if use_cuda else 'cpu'
+use_cuda = torch.cuda.is_available()  # TODO: make this togglable via the command line
+torch_device = "cuda" if use_cuda else "cpu"
 
 torch.tensor = functools.partial(torch.tensor, device=torch_device)
 torch.zeros = functools.partial(torch.zeros, device=torch_device)
@@ -150,9 +150,10 @@ def init_state(scope="session"):
         torch.manual_seed(42)
         state = torch.rand([2 ** n], dtype=torch.complex128) + torch.rand([2 ** n]) * 1j
         state /= torch.linalg.norm(state)
-        return torch.tensor(state) # converting to tensor will set the device to CUDA if enabled
+        return torch.tensor(state)  # converting to tensor will set the device to CUDA if enabled
 
     return _init_state
+
 
 @pytest.fixture
 def device(scope="function"):
@@ -161,10 +162,11 @@ def device(scope="function"):
     def _dev(wires):
         """Torch device"""
         dev = DefaultQubitTorch(wires=wires)
-        dev._torch_device = 'cuda' if use_cuda else 'cpu'
+        dev._torch_device = "cuda" if use_cuda else "cpu"
         return dev
 
     return _dev
+
 
 #####################################################
 # Initialization test
@@ -192,7 +194,7 @@ class TestApply:
         """Test basis state initialization"""
 
         dev = device(wires=4)
-        #dev = DefaultQubitTorch(wires=4)
+        # dev = DefaultQubitTorch(wires=4)
         state = torch.tensor([0, 0, 1, 0], dtype=torch.complex128)
 
         dev.apply([qml.BasisState(state, wires=[0, 1, 2, 3])])

--- a/tests/devices/test_default_qubit_torch.py
+++ b/tests/devices/test_default_qubit_torch.py
@@ -24,13 +24,6 @@ import functools
 
 torch = pytest.importorskip("torch", minversion="1.8.1")
 
-use_cuda = torch.cuda.is_available()
-# torch_device = "cuda" if use_cuda else "cpu"
-
-# torch.tensor = functools.partial(torch.tensor, device=torch_device)
-# torch.zeros = functools.partial(torch.zeros, device=torch_device)
-# torch.linspace = functools.partial(torch.linspace, device=torch_device)
-
 torch_devices = [None]
 
 if torch.cuda.is_available():
@@ -603,8 +596,6 @@ class TestExpval:
     ):
         """Test that single qubit gates with single qubit expectation values"""
         dev = device(wires=2, torch_device=torch_device)
-
-        par = torch.tensor(theta, device=torch_device)
 
         with qml.tape.QuantumTape() as tape:
             queue = [gate(theta, wires=0), gate(phi, wires=1), qml.CNOT(wires=[0, 1])]

--- a/tests/devices/test_default_qubit_torch.py
+++ b/tests/devices/test_default_qubit_torch.py
@@ -1019,7 +1019,7 @@ class TestVar:
                 [-5 - 2j, -5 - 4j, -4 - 3j, -6],
             ],
             dtype=torch.complex128,
-            device=torch_device
+            device=torch_device,
         )
 
         obs = qml.PauliZ(0) @ qml.Hermitian(A, wires=[1, 2])

--- a/tests/devices/test_default_qubit_torch.py
+++ b/tests/devices/test_default_qubit_torch.py
@@ -22,6 +22,8 @@ import cmath
 import math
 import functools
 
+pytestmark = pytest.mark.gpu
+
 torch = pytest.importorskip("torch", minversion="1.8.1")
 
 torch_devices = [None]

--- a/tests/devices/test_default_qubit_torch.py
+++ b/tests/devices/test_default_qubit_torch.py
@@ -1345,10 +1345,11 @@ class TestPassthruIntegration:
         res = circuit1(p_torch)
         res.backward()
 
-        assert np.allclose(qml.math.to_numpy(res), circuit2(p).numpy(), atol=tol, rtol=0)
+
+        assert qml.math.allclose(res, circuit2(p), atol=tol, rtol=0)
 
         p_grad = p_torch.grad
-        assert np.allclose(qml.math.to_numpy(p_grad), qml.jacobian(circuit2)(p), atol=tol, rtol=0)
+        assert qml.math.allclose(p_grad, qml.jacobian(circuit2)(p), atol=tol, rtol=0)
 
     def test_state_differentiability(self, device, torch_device, tol):
         """Test that the device state can be differentiated"""

--- a/tests/devices/test_default_qubit_torch.py
+++ b/tests/devices/test_default_qubit_torch.py
@@ -25,11 +25,11 @@ import functools
 torch = pytest.importorskip("torch", minversion="1.8.1")
 
 use_cuda = torch.cuda.is_available()
-#torch_device = "cuda" if use_cuda else "cpu"
+# torch_device = "cuda" if use_cuda else "cpu"
 
-#torch.tensor = functools.partial(torch.tensor, device=torch_device)
-#torch.zeros = functools.partial(torch.zeros, device=torch_device)
-#torch.linspace = functools.partial(torch.linspace, device=torch_device)
+# torch.tensor = functools.partial(torch.tensor, device=torch_device)
+# torch.zeros = functools.partial(torch.zeros, device=torch_device)
+# torch.linspace = functools.partial(torch.linspace, device=torch_device)
 
 torch_devices = [None]
 
@@ -86,10 +86,12 @@ np.random.seed(42)
 # Test matrices
 #####################################################
 
-U = np.array([
+U = np.array(
+    [
         [0.83645892 - 0.40533293j, -0.20215326 + 0.30850569j],
         [-0.23889780 - 0.28101519j, -0.88031770 - 0.29832709j],
-    ])
+    ]
+)
 
 U2 = np.array([[0, 1, 1, 1], [1, 0, 1, -1], [1, -1, 0, 1], [1, 1, -1, 0]]) / np.sqrt(3)
 
@@ -340,7 +342,9 @@ class TestApply:
 
     @pytest.mark.parametrize("theta", [0.5432, -0.232])
     @pytest.mark.parametrize("op,func", single_qubit_param)
-    def test_single_qubit_parameters_inverse(self, device, torch_device, init_state, op, func, theta, tol):
+    def test_single_qubit_parameters_inverse(
+        self, device, torch_device, init_state, op, func, theta, tol
+    ):
         """Test parametrized single qubit operations"""
         dev = device(wires=1, torch_device=torch_device)
         state = init_state(1, torch_device=torch_device)
@@ -552,7 +556,11 @@ class TestExpval:
 
     # test data; each tuple is of the form (GATE, OBSERVABLE, EXPECTED)
     single_wire_expval_test_data = [
-        (qml.RX, qml.Identity, lambda t, p, t_device: torch.tensor([1.0, 1.0], dtype=torch.float64, device=t_device)),
+        (
+            qml.RX,
+            qml.Identity,
+            lambda t, p, t_device: torch.tensor([1.0, 1.0], dtype=torch.float64, device=t_device),
+        ),
         (
             qml.RX,
             qml.PauliZ,
@@ -570,7 +578,9 @@ class TestExpval:
         (
             qml.RX,
             qml.PauliY,
-            lambda t, p, t_device: torch.tensor([0, -torch.cos(t) * torch.sin(p)], dtype=torch.float64, device=t_device),
+            lambda t, p, t_device: torch.tensor(
+                [0, -torch.cos(t) * torch.sin(p)], dtype=torch.float64, device=t_device
+            ),
         ),
         (
             qml.RY,
@@ -581,14 +591,16 @@ class TestExpval:
                     torch.cos(t) * torch.cos(p) + torch.sin(p),
                 ],
                 dtype=torch.float64,
-                device=t_device
+                device=t_device,
             )
             / math.sqrt(2),
         ),
     ]
 
     @pytest.mark.parametrize("gate,obs,expected", single_wire_expval_test_data)
-    def test_single_wire_expectation(self, device, torch_device, gate, obs, expected, theta, phi, varphi, tol):
+    def test_single_wire_expectation(
+        self, device, torch_device, gate, obs, expected, theta, phi, varphi, tol
+    ):
         """Test that single qubit gates with single qubit expectation values"""
         dev = device(wires=2, torch_device=torch_device)
 
@@ -609,7 +621,8 @@ class TestExpval:
 
         Hermitian_mat = torch.tensor(
             [[1.02789352, 1.61296440 - 0.3498192j], [1.61296440 + 0.3498192j, 1.23920938 + 0j]],
-            dtype=torch.complex128, device=torch_device
+            dtype=torch.complex128,
+            device=torch_device,
         )
 
         with qml.tape.QuantumTape() as tape:
@@ -856,7 +869,9 @@ class TestExpval:
 
         assert torch.allclose(res, torch.real(expected), atol=tol, rtol=0)
 
-    def test_hermitian_two_wires_identity_expectation(self, device, torch_device, theta, phi, varphi, tol):
+    def test_hermitian_two_wires_identity_expectation(
+        self, device, torch_device, theta, phi, varphi, tol
+    ):
         """Test that a tensor product involving an Hermitian matrix for two wires and the identity works correctly"""
         dev = device(wires=3, torch_device=torch_device)
 
@@ -1137,7 +1152,9 @@ class TestQNodeIntegration:
 
         amplitude = cmath.exp(-1j * cmath.pi / 8) / cmath.sqrt(2)
 
-        expected = torch.tensor([amplitude, 0, amplitude.conjugate(), 0], dtype=torch.complex128, device=torch_device)
+        expected = torch.tensor(
+            [amplitude, 0, amplitude.conjugate(), 0], dtype=torch.complex128, device=torch_device
+        )
         assert torch.allclose(state, expected, atol=tol, rtol=0)
 
     @pytest.mark.parametrize("theta", [0.5432, -0.232])
@@ -1430,7 +1447,9 @@ class TestPassthruIntegration:
         phi = torch.tensor(-0.234, dtype=torch.float64, device=torch_device)
         lam = torch.tensor(0.654, dtype=torch.float64, device=torch_device)
 
-        params = torch.tensor([theta, phi, lam], dtype=torch.float64, requires_grad=True, device=torch_device)
+        params = torch.tensor(
+            [theta, phi, lam], dtype=torch.float64, requires_grad=True, device=torch_device
+        )
 
         res = cost(params)
         res.backward()
@@ -1450,8 +1469,9 @@ class TestPassthruIntegration:
                     + torch.sin(lam) * torch.cos(phi),
                     torch.cos(theta) * torch.sin(lam) * torch.cos(phi)
                     + torch.cos(lam) * torch.sin(phi),
-                ]
-            , device=torch_device)
+                ],
+                device=torch_device,
+            )
             * 2
             * (torch.sin(lam) * torch.sin(phi) - torch.cos(theta) * torch.cos(lam) * torch.cos(phi))
         )
@@ -1514,7 +1534,9 @@ class TestSamples:
 
         assert torch.is_tensor(res)
         assert res.shape == (shots,)
-        assert torch.allclose(torch.unique(res), torch.tensor([-1, 1], dtype=torch.int64, device=torch_device))
+        assert torch.allclose(
+            torch.unique(res), torch.tensor([-1, 1], dtype=torch.int64, device=torch_device)
+        )
 
     def test_estimating_marginal_probability(self, device, torch_device, tol):
         """Test that the probability of a subset of wires is accurately estimated."""

--- a/tests/devices/test_default_qubit_torch.py
+++ b/tests/devices/test_default_qubit_torch.py
@@ -1448,7 +1448,7 @@ class TestPassthruIntegration:
                     torch.cos(theta) * torch.sin(lam) * torch.cos(phi)
                     + torch.cos(lam) * torch.sin(phi),
                 ]
-            )
+            , device=torch_device)
             * 2
             * (torch.sin(lam) * torch.sin(phi) - torch.cos(theta) * torch.cos(lam) * torch.cos(phi))
         )

--- a/tests/devices/test_default_qubit_torch.py
+++ b/tests/devices/test_default_qubit_torch.py
@@ -240,7 +240,7 @@ class TestApply:
     def test_full_subsystem_statevector(self, device, torch_device, mocker):
         """Test applying a state vector to the full subsystem"""
         dev = device(wires=["a", "b", "c"], torch_device=torch_device)
-        state = torch.tensor([1, 0, 0, 0, 1, 0, 1, 1], dtype=torch.complex128) / 2.0
+        state = torch.tensor([1, 0, 0, 0, 1, 0, 1, 1], dtype=torch.complex128, device=torch_device) / 2.0
         state_wires = qml.wires.Wires(["a", "b", "c"])
 
         spy = mocker.spy(dev, "_scatter")
@@ -252,7 +252,7 @@ class TestApply:
     def test_partial_subsystem_statevector(self, device, torch_device, mocker):
         """Test applying a state vector to a subset of wires of the full subsystem"""
         dev = device(wires=["a", "b", "c"], torch_device=torch_device)
-        state = torch.tensor([1, 0, 1, 0], dtype=torch.complex128) / torch.tensor(math.sqrt(2.0))
+        state = torch.tensor([1, 0, 1, 0], dtype=torch.complex128, device=torch_device) / torch.tensor(math.sqrt(2.0))
         state_wires = qml.wires.Wires(["a", "c"])
 
         spy = mocker.spy(dev, "_scatter")
@@ -1318,13 +1318,14 @@ class TestPassthruIntegration:
                 0,
             ],
             dtype=torch.float64,
+            device=torch_device
         )
         assert torch.allclose(p.grad, expected_grad, atol=tol, rtol=0)
 
     def test_jacobian_agrees_backprop_parameter_shift(self, device, torch_device, tol):
         """Test that jacobian of a QNode with an attached default.qubit.torch device
         gives the correct result with respect to the parameter-shift method"""
-        p = pnp.array([0.43316321, 0.2162158, 0.75110998, 0.94714242], requires_grad=True, device=torch_device)
+        p = pnp.array([0.43316321, 0.2162158, 0.75110998, 0.94714242], requires_grad=True)
 
         def circuit(x):
             for i in range(0, len(p), 2):
@@ -1340,7 +1341,7 @@ class TestPassthruIntegration:
         circuit1 = qml.QNode(circuit, dev1, diff_method="backprop", interface="torch")
         circuit2 = qml.QNode(circuit, dev2, diff_method="parameter-shift")
 
-        p_torch = torch.tensor(p, requires_grad=True)
+        p_torch = torch.tensor(p, requires_grad=True, device=torch_device)
         res = circuit1(p_torch)
         res.backward()
 

--- a/tests/devices/test_default_qubit_torch.py
+++ b/tests/devices/test_default_qubit_torch.py
@@ -240,7 +240,10 @@ class TestApply:
     def test_full_subsystem_statevector(self, device, torch_device, mocker):
         """Test applying a state vector to the full subsystem"""
         dev = device(wires=["a", "b", "c"], torch_device=torch_device)
-        state = torch.tensor([1, 0, 0, 0, 1, 0, 1, 1], dtype=torch.complex128, device=torch_device) / 2.0
+        state = (
+            torch.tensor([1, 0, 0, 0, 1, 0, 1, 1], dtype=torch.complex128, device=torch_device)
+            / 2.0
+        )
         state_wires = qml.wires.Wires(["a", "b", "c"])
 
         spy = mocker.spy(dev, "_scatter")
@@ -252,7 +255,9 @@ class TestApply:
     def test_partial_subsystem_statevector(self, device, torch_device, mocker):
         """Test applying a state vector to a subset of wires of the full subsystem"""
         dev = device(wires=["a", "b", "c"], torch_device=torch_device)
-        state = torch.tensor([1, 0, 1, 0], dtype=torch.complex128, device=torch_device) / torch.tensor(math.sqrt(2.0))
+        state = torch.tensor(
+            [1, 0, 1, 0], dtype=torch.complex128, device=torch_device
+        ) / torch.tensor(math.sqrt(2.0))
         state_wires = qml.wires.Wires(["a", "c"])
 
         spy = mocker.spy(dev, "_scatter")
@@ -1318,7 +1323,7 @@ class TestPassthruIntegration:
                 0,
             ],
             dtype=torch.float64,
-            device=torch_device
+            device=torch_device,
         )
         assert torch.allclose(p.grad, expected_grad, atol=tol, rtol=0)
 
@@ -1344,7 +1349,6 @@ class TestPassthruIntegration:
         p_torch = torch.tensor(p, requires_grad=True, device=torch_device)
         res = circuit1(p_torch)
         res.backward()
-
 
         assert qml.math.allclose(res, circuit2(p), atol=tol, rtol=0)
 

--- a/tests/devices/test_default_qubit_torch.py
+++ b/tests/devices/test_default_qubit_torch.py
@@ -24,7 +24,7 @@ import functools
 
 torch = pytest.importorskip("torch", minversion="1.8.1")
 
-use_cuda = torch.cuda.is_available()  # TODO: make this togglable via the command line
+use_cuda = torch.cuda.is_available()
 torch_device = "cuda" if use_cuda else "cpu"
 
 torch.tensor = functools.partial(torch.tensor, device=torch_device)
@@ -194,7 +194,6 @@ class TestApply:
         """Test basis state initialization"""
 
         dev = device(wires=4)
-        # dev = DefaultQubitTorch(wires=4)
         state = torch.tensor([0, 0, 1, 0], dtype=torch.complex128)
 
         dev.apply([qml.BasisState(state, wires=[0, 1, 2, 3])])

--- a/tests/gpu/test_torch.py
+++ b/tests/gpu/test_torch.py
@@ -178,3 +178,21 @@ class TestqnnTorchLayer:
         loss = torch.sum(res).squeeze()
         loss.backward()
         assert loss.is_cuda
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="no cuda support")
+class TestParametricOps:
+    """Test that certain parametric operations perform computations correctly
+    with Torch devices internally."""
+
+    @pytest.mark.parametrize("theta", np.linspace(0, 2 * np.pi, 7))
+    def test_pauli_rot_identity(self, theta):
+        """Test that the PauliRot operation returns the correct matrix when
+        providing a gate parameter on the GPU and only specifying the identity
+        operation."""
+        x = torch.tensor(theta, device="cuda")
+        mat = qml.PauliRot(x, "I", wires=[0]).matrix
+
+        val = np.cos(-theta / 2) + 1j * np.sin(-theta / 2)
+        exp = torch.tensor(np.diag([val, val]), device="cuda")
+        assert torch.allclose(mat, exp)

--- a/tests/gpu/test_torch.py
+++ b/tests/gpu/test_torch.py
@@ -124,6 +124,24 @@ class TestTorchDevice:
         res.backward()
         assert x.grad.is_cuda
 
+    @pytest.mark.parametrize("init_device, par_device", [("cpu", "cuda"), ("cuda", "cpu")])
+    def test_different_devices_creation_and_parameters_warn(self, init_device, par_device):
+        """Test that a warning is raised if the Torch device specified on
+        PennyLane device creation differs the Torch device of gate
+        parameters.
+        """
+        print(init_device, par_device)
+        dev = qml.device("default.qubit.torch", wires=1, torch_device=init_device)
+
+        p = torch.tensor(0.543, dtype=torch.float64, device=par_device)
+
+        @qml.qnode(dev, interface="torch")
+        def circuit(x):
+            qml.RX(x, wires=0)
+            return qml.expval(qml.PauliY(0))
+
+        with pytest.warns(UserWarning, match=f"Torch device {init_device} specified upon PennyLane device creation does not match"):
+            circuit(p)
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="no cuda support")
 class TestqnnTorchLayer:

--- a/tests/gpu/test_torch.py
+++ b/tests/gpu/test_torch.py
@@ -15,8 +15,9 @@ import pytest
 import pennylane as qml
 from pennylane import numpy as np
 
-torch = pytest.importorskip("torch")
+pytestmark = pytest.mark.gpu
 
+torch = pytest.importorskip("torch")
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="no cuda support")
 class TestTorchDevice:

--- a/tests/gpu/test_torch.py
+++ b/tests/gpu/test_torch.py
@@ -127,10 +127,9 @@ class TestTorchDevice:
     @pytest.mark.parametrize("init_device, par_device", [("cpu", "cuda"), ("cuda", "cpu")])
     def test_different_devices_creation_and_parameters_warn(self, init_device, par_device):
         """Test that a warning is raised if the Torch device specified on
-        PennyLane device creation differs the Torch device of gate
+        PennyLane device creation differs from the Torch device of gate
         parameters.
         """
-        print(init_device, par_device)
         dev = qml.device("default.qubit.torch", wires=1, torch_device=init_device)
 
         p = torch.tensor(0.543, dtype=torch.float64, device=par_device)

--- a/tests/gpu/test_torch.py
+++ b/tests/gpu/test_torch.py
@@ -19,6 +19,7 @@ pytestmark = pytest.mark.gpu
 
 torch = pytest.importorskip("torch")
 
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="no cuda support")
 class TestTorchDevice:
     def test_device_to_cuda(self):

--- a/tests/gpu/test_torch.py
+++ b/tests/gpu/test_torch.py
@@ -139,8 +139,12 @@ class TestTorchDevice:
             qml.RX(x, wires=0)
             return qml.expval(qml.PauliY(0))
 
-        with pytest.warns(UserWarning, match=f"Torch device {init_device} specified upon PennyLane device creation does not match"):
+        with pytest.warns(
+            UserWarning,
+            match=f"Torch device {init_device} specified upon PennyLane device creation does not match",
+        ):
             circuit(p)
+
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="no cuda support")
 class TestqnnTorchLayer:

--- a/tests/interfaces/test_batch_torch.py
+++ b/tests/interfaces/test_batch_torch.py
@@ -348,7 +348,7 @@ execute_kwargs = [
     },
 ]
 
-
+@pytest.mark.gpu
 @pytest.mark.parametrize("torch_device", torch_devices)
 @pytest.mark.parametrize("execute_kwargs", execute_kwargs)
 class TestTorchExecuteIntegration:

--- a/tests/interfaces/test_batch_torch.py
+++ b/tests/interfaces/test_batch_torch.py
@@ -462,9 +462,8 @@ class TestTorchExecuteIntegration:
             qml.expval(qml.PauliZ(0))
 
         res = sum(execute([tape1, tape2, tape3], dev, **execute_kwargs))
-        expected = torch.tensor(
-            1 + np.cos(0.5) + torch.cos(x) * torch.cos(y), dtype=res.dtype, device=res.device
-        )
+        expected = torch.tensor( 1 + np.cos(0.5), dtype=res.dtype) + torch.cos(x) * torch.cos(y)
+        expected = expected.to(device=res.device)
 
         assert torch.allclose(res, expected, atol=tol, rtol=0)
 

--- a/tests/interfaces/test_batch_torch.py
+++ b/tests/interfaces/test_batch_torch.py
@@ -348,6 +348,7 @@ execute_kwargs = [
     },
 ]
 
+
 @pytest.mark.gpu
 @pytest.mark.parametrize("torch_device", torch_devices)
 @pytest.mark.parametrize("execute_kwargs", execute_kwargs)
@@ -462,7 +463,7 @@ class TestTorchExecuteIntegration:
             qml.expval(qml.PauliZ(0))
 
         res = sum(execute([tape1, tape2, tape3], dev, **execute_kwargs))
-        expected = torch.tensor( 1 + np.cos(0.5), dtype=res.dtype) + torch.cos(x) * torch.cos(y)
+        expected = torch.tensor(1 + np.cos(0.5), dtype=res.dtype) + torch.cos(x) * torch.cos(y)
         expected = expected.to(device=res.device)
 
         assert torch.allclose(res, expected, atol=tol, rtol=0)

--- a/tests/math/test_functions.py
+++ b/tests/math/test_functions.py
@@ -1584,7 +1584,10 @@ class TestCoercion:
             torch.tensor(1 + 3j, dtype=torch.complex64, device="cuda"),
         ]
 
-        with pytest.raises(RuntimeError, match="Expected all tensors to be on the same device, but found at least two devices"):
+        with pytest.raises(
+            RuntimeError,
+            match="Expected all tensors to be on the same device, but found at least two devices",
+        ):
             res = qml.math.coerce(tensors, like="torch")
 
 

--- a/tests/math/test_functions.py
+++ b/tests/math/test_functions.py
@@ -1571,6 +1571,23 @@ class TestCoercion:
         dtypes = [r.dtype for r in res]
         assert all(d is torch.complex64 for d in dtypes)
 
+    def test_torch_coercion_error(self):
+        """Test Torch coercion error if multiple devices were specified."""
+
+        if not torch.cuda.is_available():
+            pytest.skip("A GPU would be required to run this test, but CUDA is not available.")
+
+        tensors = [
+            torch.tensor([0.2], device='cpu'),
+            np.array([1, 2, 3]),
+            torch.tensor(1 + 3j, dtype=torch.complex64, device='cuda'),
+        ]
+        pytest.mark
+
+        with pytest.raises(
+            ValueError, match="Multiple Torch devices were specified"
+        ):
+            res = qml.math.coerce(tensors, like="torch")
 
 class TestUnwrap:
     """Test tensor unwrapping"""

--- a/tests/math/test_functions.py
+++ b/tests/math/test_functions.py
@@ -1582,7 +1582,6 @@ class TestCoercion:
             np.array([1, 2, 3]),
             torch.tensor(1 + 3j, dtype=torch.complex64, device="cuda"),
         ]
-        pytest.mark
 
         with pytest.raises(ValueError, match="Multiple Torch devices were specified"):
             res = qml.math.coerce(tensors, like="torch")

--- a/tests/math/test_functions.py
+++ b/tests/math/test_functions.py
@@ -1571,6 +1571,7 @@ class TestCoercion:
         dtypes = [r.dtype for r in res]
         assert all(d is torch.complex64 for d in dtypes)
 
+    @pytest.mark.gpu
     def test_torch_coercion_error(self):
         """Test Torch coercion error if multiple devices were specified."""
 
@@ -1583,7 +1584,7 @@ class TestCoercion:
             torch.tensor(1 + 3j, dtype=torch.complex64, device="cuda"),
         ]
 
-        with pytest.raises(ValueError, match="Multiple Torch devices were specified"):
+        with pytest.raises(RuntimeError, match="Expected all tensors to be on the same device, but found at least two devices"):
             res = qml.math.coerce(tensors, like="torch")
 
 

--- a/tests/math/test_functions.py
+++ b/tests/math/test_functions.py
@@ -1578,16 +1578,15 @@ class TestCoercion:
             pytest.skip("A GPU would be required to run this test, but CUDA is not available.")
 
         tensors = [
-            torch.tensor([0.2], device='cpu'),
+            torch.tensor([0.2], device="cpu"),
             np.array([1, 2, 3]),
-            torch.tensor(1 + 3j, dtype=torch.complex64, device='cuda'),
+            torch.tensor(1 + 3j, dtype=torch.complex64, device="cuda"),
         ]
         pytest.mark
 
-        with pytest.raises(
-            ValueError, match="Multiple Torch devices were specified"
-        ):
+        with pytest.raises(ValueError, match="Multiple Torch devices were specified"):
             res = qml.math.coerce(tensors, like="torch")
+
 
 class TestUnwrap:
     """Test tensor unwrapping"""

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')
+    gpu: marks tests run on a GPU (deselect with '-m "not gpu"')


### PR DESCRIPTION
**Context:**

With recent changes in `default.qubit` (https://github.com/PennyLaneAI/pennylane/pull/1749), the backpropagation variants of the device no longer define their own ML framework-specific implementation of parametric operations.

This means, that the pipeline defined in `pennylane/ops/qubit/parametric_ops.py` is being used by all backpropagation devices.

Some matrix definitions include scalars/constants (e.g., 0 or 1) that don't have an explicit type definition. When using Torch with GPU, such objects will be put on the CPU resulting in an error.

Such an operation is `qml.RX`:
```python
import pennylane as qml
import torch

dev = qml.device("default.qubit.torch", wires=1)

@qml.qnode(dev, interface='torch')
def circuit(x, y):
    qml.RX(x, wires=0)
    qml.RZ(y, wires=0)
    return qml.expval(qml.PauliZ(0))

x = torch.tensor(0.3, device='cuda')
y =  torch.tensor(0., device='cuda')

circuit(x, y)
```
```
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cpu and cuda:0! (when checking argument for argument tensors in method wrapper___cat)
```
The cause of the error boils down to:
```python
import pennylane as qml
import torch

a = torch.tensor(0.34, device='cuda')
qml.math.stack([0, a])
```

`qml.math.stack` is used in such a way for several matrix definitions of parametric operations.

Such cases arise also when running the tests contained in `tests/gpu/test_torch.py`.

**Description of the Change:**

* Changes the definition of Tensor coercion in `qml.math` for Torch. The coercion now takes into account any Torch devices that may have been provided and puts the output tensors on any such device. An error is raised if several Torch devices were used by the input tensors;
```python
import pennylane as qml
import torch

a = torch.tensor(0.34, device='cuda')
qml.math.stack([0, a])
```
```
tensor([0.0000, 0.3400], device='cuda:0')
```

* Changes the tests for `default.qubit.torch` such that tests are run on the GPU, if available;
* Re-adds the `torch_device` argument to `default.qubit.torch` to enable evaluating QNodes without input parameters on GPUs.

**Benefits:**

Fixed compatibility with GPUs for `default.qubit.torch` and better GPU testing with Torch.

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
N/A

**Note:**

The following test files contain cases that are run on the GPU:

* `tests/gpu/test_torch.py`
* `tests/devices/test_default_qubit_torch.py`
* `tests/interfaces/test_batch_torch.py`