### PR TITLE
Multi amplitude embedding with transform

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -281,7 +281,8 @@
 
 * Added density matrix initialization gate for mixed state simulation. [(#1686)](https://github.com/PennyLaneAI/pennylane/issues/1686)
 
-* The `merge_amplitude_embedding` transformation has been created to automatically merge all gates of this type into one. [(#1933)](https://github.com/PennyLaneAI/pennylane/pull/1933)
+* The `merge_amplitude_embedding` transformation has been created to automatically merge all gates of this type into one.
+  [(#1933)](https://github.com/PennyLaneAI/pennylane/pull/1933)
 
 <h3>Improvements</h3>
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -281,6 +281,8 @@
 
 * Added density matrix initialization gate for mixed state simulation. [(#1686)](https://github.com/PennyLaneAI/pennylane/issues/1686)
 
+* The `merge_amplitude_embedding` transformation has been created to automatically merge all gates of this type into one. [(#1933)](https://github.com/PennyLaneAI/pennylane/pull/1933)
+
 <h3>Improvements</h3>
 
 * Tests do not loop over automatically imported and instantiated operations any more,

--- a/pennylane/transforms/__init__.py
+++ b/pennylane/transforms/__init__.py
@@ -130,7 +130,7 @@ from .optimization import (
     merge_rotations,
     single_qubit_fusion,
     merge_amplitude_embedding,
-    remove_barrier
+    remove_barrier,
 )
 from .specs import specs
 from .qmc import apply_controlled_Q, quantum_monte_carlo

--- a/pennylane/transforms/__init__.py
+++ b/pennylane/transforms/__init__.py
@@ -129,6 +129,8 @@ from .optimization import (
     commute_controlled,
     merge_rotations,
     single_qubit_fusion,
+    merge_amplitude_embedding,
+    remove_barrier
 )
 from .specs import specs
 from .qmc import apply_controlled_Q, quantum_monte_carlo

--- a/pennylane/transforms/optimization/__init__.py
+++ b/pennylane/transforms/optimization/__init__.py
@@ -19,4 +19,5 @@ from .remove_barrier import remove_barrier
 from .cancel_inverses import cancel_inverses
 from .commute_controlled import commute_controlled
 from .merge_rotations import merge_rotations
+from .merge_amplitude_embedding import merge_amplitude_embedding
 from .single_qubit_fusion import single_qubit_fusion

--- a/pennylane/transforms/optimization/merge_amplitude_embedding.py
+++ b/pennylane/transforms/optimization/merge_amplitude_embedding.py
@@ -60,7 +60,7 @@ def merge_amplitude_embedding(tape):
     """
     # Make a working copy of the list to traverse
     list_copy = tape.operations.copy()
-
+    not_amplitude_embedding = []
     visited_wires = set()
     input_wires, input_vectors = [], []
     while len(list_copy) > 0:
@@ -69,7 +69,7 @@ def merge_amplitude_embedding(tape):
 
         # Check if the current gate is an AmplitudeEmbedding.
         if not isinstance(current_gate, AmplitudeEmbedding):
-            apply(current_gate)
+            not_amplitude_embedding.append(current_gate)
             list_copy.pop(0)
             visited_wires = visited_wires.union(wires_set)
             continue
@@ -96,6 +96,9 @@ def merge_amplitude_embedding(tape):
             final_wires = final_wires + w
 
         AmplitudeEmbedding(final_vector, wires=final_wires)
+
+        for gate in not_amplitude_embedding:
+            apply(gate)
 
     # Queue the measurements normally
     for m in tape.measurements:

--- a/pennylane/transforms/optimization/merge_amplitude_embedding.py
+++ b/pennylane/transforms/optimization/merge_amplitude_embedding.py
@@ -74,19 +74,17 @@ def merge_amplitude_embedding(tape):
             visited_wires = visited_wires.union(wires_set)
             continue
 
-        else:
-            # Check the qubits have not been used.
-            if len(visited_wires.intersection(wires_set)) > 0:
-                raise DeviceError(
-                    "Operation {} cannot be used after other Operation applied in the same qubit ".format(
-                        current_gate.name
-                    )
+        # Check the qubits have not been used.
+        if len(visited_wires.intersection(wires_set)) > 0:
+            raise DeviceError(
+                "Operation {} cannot be used after other Operation applied in the same qubit ".format(
+                    current_gate.name
                 )
-            else:
-                input_wires.append(current_gate.wires)
-                input_vectors.append(current_gate.parameters[0])
-            list_copy.pop(0)
-            visited_wires = visited_wires.union(wires_set)
+            )
+        input_wires.append(current_gate.wires)
+        input_vectors.append(current_gate.parameters[0])
+        list_copy.pop(0)
+        visited_wires = visited_wires.union(wires_set)
 
     if len(input_wires) > 0:
         final_wires = input_wires[0]

--- a/pennylane/transforms/optimization/merge_amplitude_embedding.py
+++ b/pennylane/transforms/optimization/merge_amplitude_embedding.py
@@ -1,0 +1,101 @@
+# Copyright 2018-2021 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Transform for merging AmplitudeEmbedding gates in a quantum circuit."""
+from pennylane import apply
+from pennylane.transforms import qfunc_transform
+
+from pennylane import AmplitudeEmbedding
+from pennylane._device import DeviceError
+from pennylane.math import kron
+
+@qfunc_transform
+def merge_amplitude_embedding(tape):
+    r"""Quantum function transform to combine amplitude embedding templates that act on different qubits.
+
+    Args:
+        qfunc (function): A quantum function.
+
+    Returns:
+        function: the transformed quantum function
+
+    **Example**
+
+    Consider the following quantum function.
+
+    .. code-block:: python
+
+        def qfunc():
+            qml.CNOT(wires = [0,1])
+            qml.AmplitudeEmbedding([0,1], wires = 2)
+            qml.AmplitudeEmbedding([0,1], wires = 3)
+            return qml.state()
+
+    The circuit before compilation will not work because of using two amplitude embedding.
+
+    Using the transformation we can join the different amplitude embedding into a single one:
+
+    >>> dev = qml.device('default.qubit', wires=4)
+    >>> optimized_qfunc = qml.transforms.merge_amplitude_embedding(qfunc)
+    >>> optimized_qnode = qml.QNode(optimized_qfunc, dev)
+    >>> print(qml.draw(optimized_qnode)())
+
+      0: ──╭C───────────────────────╭┤ State
+      1: ──╰X───────────────────────├┤ State
+      2: ──╭AmplitudeEmbedding(M0)──├┤ State
+      3: ──╰AmplitudeEmbedding(M0)──╰┤ State
+      M0 = [0.+0.j 0.+0.j 0.+0.j 1.+0.j]
+
+    """
+    # Make a working copy of the list to traverse
+    list_copy = tape.operations.copy()
+
+    visited_wires = set()
+    input_wires, input_vectors = [], []
+    while len(list_copy) > 0:
+        current_gate = list_copy[0]
+        wires_set = set(current_gate.wires)
+
+        # Check if the current gate is an AmplitudeEmbedding.
+        if not isinstance(current_gate, AmplitudeEmbedding):
+            apply(current_gate)
+            list_copy.pop(0)
+            visited_wires = visited_wires.union(wires_set)
+            continue
+
+        else:
+            # Check the qubits have not been used.
+            if len(visited_wires.intersection(wires_set)) > 0:
+                raise DeviceError("Operation {} cannot be used after other Operation applied in the same qubit ".format(current_gate.name))
+            else:
+                input_wires.append(current_gate.wires)
+                input_vectors.append(current_gate.parameters[0])
+            list_copy.pop(0)
+            visited_wires = visited_wires.union(wires_set)
+
+    if len(input_wires) > 0:
+        final_wires = input_wires[0]
+        final_vector = input_vectors[0]
+
+        # Merge all parameters and qubits into a single one.
+        for w, v in zip(input_wires[1:], input_vectors[1:]):
+            final_vector = kron(final_vector,v)
+            final_wires = final_wires + w
+
+        AmplitudeEmbedding(final_vector, wires = final_wires)
+
+
+
+    # Queue the measurements normally
+    for m in tape.measurements:
+        apply(m)

--- a/pennylane/transforms/optimization/merge_amplitude_embedding.py
+++ b/pennylane/transforms/optimization/merge_amplitude_embedding.py
@@ -19,6 +19,7 @@ from pennylane import AmplitudeEmbedding
 from pennylane._device import DeviceError
 from pennylane.math import kron
 
+
 @qfunc_transform
 def merge_amplitude_embedding(tape):
     r"""Quantum function transform to combine amplitude embedding templates that act on different qubits.
@@ -76,7 +77,11 @@ def merge_amplitude_embedding(tape):
         else:
             # Check the qubits have not been used.
             if len(visited_wires.intersection(wires_set)) > 0:
-                raise DeviceError("Operation {} cannot be used after other Operation applied in the same qubit ".format(current_gate.name))
+                raise DeviceError(
+                    "Operation {} cannot be used after other Operation applied in the same qubit ".format(
+                        current_gate.name
+                    )
+                )
             else:
                 input_wires.append(current_gate.wires)
                 input_vectors.append(current_gate.parameters[0])
@@ -89,12 +94,10 @@ def merge_amplitude_embedding(tape):
 
         # Merge all parameters and qubits into a single one.
         for w, v in zip(input_wires[1:], input_vectors[1:]):
-            final_vector = kron(final_vector,v)
+            final_vector = kron(final_vector, v)
             final_wires = final_wires + w
 
-        AmplitudeEmbedding(final_vector, wires = final_wires)
-
-
+        AmplitudeEmbedding(final_vector, wires=final_wires)
 
     # Queue the measurements normally
     for m in tape.measurements:

--- a/pennylane/transforms/optimization/merge_amplitude_embedding.py
+++ b/pennylane/transforms/optimization/merge_amplitude_embedding.py
@@ -77,9 +77,7 @@ def merge_amplitude_embedding(tape):
         # Check the qubits have not been used.
         if len(visited_wires.intersection(wires_set)) > 0:
             raise DeviceError(
-                "Operation {} cannot be used after other Operation applied in the same qubit ".format(
-                    current_gate.name
-                )
+                f"Operation {current_gate.name} cannot be used after other Operation applied in the same qubit "
             )
         input_wires.append(current_gate.wires)
         input_vectors.append(current_gate.parameters[0])

--- a/pennylane/transforms/optimization/merge_amplitude_embedding.py
+++ b/pennylane/transforms/optimization/merge_amplitude_embedding.py
@@ -97,8 +97,8 @@ def merge_amplitude_embedding(tape):
 
         AmplitudeEmbedding(final_vector, wires=final_wires)
 
-        for gate in not_amplitude_embedding:
-            apply(gate)
+    for gate in not_amplitude_embedding:
+        apply(gate)
 
     # Queue the measurements normally
     for m in tape.measurements:

--- a/tests/transforms/test_optimization/test_merge_amplitude_embedding.py
+++ b/tests/transforms/test_optimization/test_merge_amplitude_embedding.py
@@ -1,0 +1,192 @@
+# Copyright 2018-2021 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from pennylane import numpy as np
+
+import pennylane as qml
+from pennylane.wires import Wires
+from pennylane.transforms.optimization import merge_amplitude_embedding
+from pennylane._device import DeviceError
+
+
+class TestMergeAmplitudeEmbedding:
+    """Test that amplitude embedding gates are combined into a single."""
+
+
+    def test_multi_amplitude_embedding(self):
+        """Test that the transformation is working correctly by joining two amplitudeEmbedding."""
+
+        def qfunc():
+            qml.AmplitudeEmbedding([0,1], wires=0)
+            qml.AmplitudeEmbedding([0,1], wires=1)
+            qml.state()
+
+        transformed_qfunc = merge_amplitude_embedding(qfunc)
+        ops = qml.transforms.make_tape(transformed_qfunc)().operations
+
+        assert len(ops) == 1
+
+        # Check that the solution is as expected.
+
+        dev = qml.device("default.qubit", wires = 2)
+        assert qml.QNode(transformed_qfunc, dev)()[-1] == 1
+
+
+    def test_repeated_qubit(self):
+        """Check that AmplitudeEmbedding cannot be applied if the qubit has already been used."""
+
+        def qfunc():
+            qml.CNOT(wires = [0,1])
+            qml.AmplitudeEmbedding([0,1], wires=1)
+
+        transformed_qfunc = merge_amplitude_embedding(qfunc)
+        ops = qml.transforms.make_tape(transformed_qfunc)().operations
+
+        dev = qml.device("default.qubit", wires=2)
+        qnode = qml.QNode(transformed_qfunc, )
+
+        with pytest.raises(DeviceError, match="applied in the same qubit"):
+            qnode()
+
+
+# Example QNode and device for interface testing
+dev = qml.device("default.qubit", wires=3)
+
+# Test each of single-qubit, two-qubit, and Rot gates
+def qfunc(amplitude):
+    qml.Hadamard(wires = 2)
+    qml.AmplitudeEmbedding(amplitude, wires=0)
+    qml.AmplitudeEmbedding(amplitude, wires=1)
+    qml.CNOT(wires = [0,1])
+    return qml.expval(qml.PauliX(0) @ qml.PauliX(2))
+
+
+transformed_qfunc = merge_amplitude_embedding(qfunc)
+
+expected_op_list = ["Hadamard", "AmplitudeEmbedding", "CNOT"]
+expected_wires_list = [
+    Wires(2),
+    Wires([0,1]),
+    Wires([0,1]),
+]
+
+'''
+class TestMergeRotationsInterfaces:
+    """Test that rotation merging works in all interfaces."""
+
+    def test_merge_rotations_autograd(self):
+        """Test QNode and gradient in autograd interface."""
+
+        original_qnode = qml.QNode(qfunc, dev)
+        transformed_qnode = qml.QNode(transformed_qfunc, dev)
+
+        input = np.array([0.1, 0.2, 0.3, 0.4], requires_grad=True)
+
+        # Check that the numerical output is the same
+        assert qml.math.allclose(original_qnode(input), transformed_qnode(input))
+
+        # Check that the gradient is the same
+        assert qml.math.allclose(
+            qml.grad(original_qnode)(input), qml.grad(transformed_qnode)(input)
+        )
+
+        # Check operation list
+        ops = transformed_qnode.qtape.operations
+        compare_operation_lists(ops, expected_op_list, expected_wires_list)
+
+    def test_merge_rotations_torch(self):
+        """Test QNode and gradient in torch interface."""
+        torch = pytest.importorskip("torch", minversion="1.8")
+
+        original_qnode = qml.QNode(qfunc, dev, interface="torch")
+        transformed_qnode = qml.QNode(transformed_qfunc, dev, interface="torch")
+
+        original_input = torch.tensor([0.1, 0.2, 0.3, 0.4], requires_grad=True)
+        transformed_input = torch.tensor([0.1, 0.2, 0.3, 0.4], requires_grad=True)
+
+        original_result = original_qnode(original_input)
+        transformed_result = transformed_qnode(transformed_input)
+
+        # Check that the numerical output is the same
+        assert qml.math.allclose(original_result, transformed_result.detach().numpy())
+
+        # Check that the gradient is the same
+        original_result.backward()
+        transformed_result.backward()
+
+        assert qml.math.allclose(original_input.grad, transformed_input.grad)
+
+        # Check operation list
+        ops = transformed_qnode.qtape.operations
+        compare_operation_lists(ops, expected_op_list, expected_wires_list)
+
+    def test_merge_rotations_tf(self):
+        """Test QNode and gradient in tensorflow interface."""
+        tf = pytest.importorskip("tensorflow")
+
+        original_qnode = qml.QNode(qfunc, dev, interface="tf")
+        transformed_qnode = qml.QNode(transformed_qfunc, dev, interface="tf")
+
+        original_input = tf.Variable([0.1, 0.2, 0.3, 0.4])
+        transformed_input = tf.Variable([0.1, 0.2, 0.3, 0.4])
+
+        original_result = original_qnode(original_input)
+        transformed_result = transformed_qnode(transformed_input)
+
+        # Check that the numerical output is the same
+        assert qml.math.allclose(original_result, transformed_result)
+
+        # Check that the gradient is the same
+        with tf.GradientTape() as tape:
+            loss = original_qnode(original_input)
+        original_grad = tape.gradient(loss, original_input)
+
+        with tf.GradientTape() as tape:
+            loss = transformed_qnode(transformed_input)
+        transformed_grad = tape.gradient(loss, transformed_input)
+
+        assert qml.math.allclose(original_grad, transformed_grad)
+
+        # Check operation list
+        ops = transformed_qnode.qtape.operations
+        compare_operation_lists(ops, expected_op_list, expected_wires_list)
+
+    def test_merge_rotations_jax(self):
+        """Test QNode and gradient in JAX interface."""
+        jax = pytest.importorskip("jax")
+        from jax import numpy as jnp
+
+        from jax.config import config
+
+        remember = config.read("jax_enable_x64")
+        config.update("jax_enable_x64", True)
+
+        original_qnode = qml.QNode(qfunc, dev, interface="jax")
+        transformed_qnode = qml.QNode(transformed_qfunc, dev, interface="jax")
+
+        input = jnp.array([0.1, 0.2, 0.3, 0.4], dtype=jnp.float64)
+
+        # Check that the numerical output is the same
+        assert qml.math.allclose(original_qnode(input), transformed_qnode(input))
+
+        # Check that the gradient is the same
+        assert qml.math.allclose(
+            jax.grad(original_qnode)(input), jax.grad(transformed_qnode)(input)
+        )
+
+        # Check operation list
+        ops = transformed_qnode.qtape.operations
+        compare_operation_lists(ops, expected_op_list, expected_wires_list)
+'''

--- a/tests/transforms/test_optimization/test_merge_amplitude_embedding.py
+++ b/tests/transforms/test_optimization/test_merge_amplitude_embedding.py
@@ -27,8 +27,8 @@ class TestMergeAmplitudeEmbedding:
         """Test that the transformation is working correctly by joining two amplitudeEmbedding."""
 
         def qfunc():
-            qml.AmplitudeEmbedding([0., 1.], wires=0)
-            qml.AmplitudeEmbedding([0., 1.], wires=1)
+            qml.AmplitudeEmbedding([0.0, 1.0], wires=0)
+            qml.AmplitudeEmbedding([0.0, 1.0], wires=1)
             qml.state()
 
         transformed_qfunc = merge_amplitude_embedding(qfunc)
@@ -45,8 +45,8 @@ class TestMergeAmplitudeEmbedding:
         """Check that AmplitudeEmbedding cannot be applied if the qubit has already been used."""
 
         def qfunc():
-            qml.CNOT(wires=[0., 1.])
-            qml.AmplitudeEmbedding([0., 1.], wires=1)
+            qml.CNOT(wires=[0.0, 1.0])
+            qml.AmplitudeEmbedding([0.0, 1.0], wires=1)
 
         transformed_qfunc = merge_amplitude_embedding(qfunc)
 
@@ -72,7 +72,7 @@ class TestMergeAmplitudeEmbeddingInterfaces:
         optimized_qfunc = qml.transforms.merge_amplitude_embedding(qfunc)
         optimized_qnode = qml.QNode(optimized_qfunc, dev)
 
-        amplitude = np.array([0., 1.], requires_grad=True)
+        amplitude = np.array([0.0, 1.0], requires_grad=True)
         # Check the state |11> is being generated.
         assert optimized_qnode(amplitude)[-1] == 1
 
@@ -89,7 +89,7 @@ class TestMergeAmplitudeEmbeddingInterfaces:
         optimized_qfunc = qml.transforms.merge_amplitude_embedding(qfunc)
         optimized_qnode = qml.QNode(optimized_qfunc, dev, interface="torch")
 
-        amplitude = torch.tensor([0., 1.], requires_grad=True)
+        amplitude = torch.tensor([0.0, 1.0], requires_grad=True)
         # Check the state |11> is being generated.
         assert optimized_qnode(amplitude)[-1] == 1
 
@@ -106,7 +106,7 @@ class TestMergeAmplitudeEmbeddingInterfaces:
         optimized_qfunc = qml.transforms.merge_amplitude_embedding(qfunc)
         optimized_qnode = qml.QNode(optimized_qfunc, dev, interface="tf")
 
-        amplitude = tf.Variable([0., 1.])
+        amplitude = tf.Variable([0.0, 1.0])
         # Check the state |11> is being generated.
         assert optimized_qnode(amplitude)[-1] == 1
 
@@ -129,6 +129,6 @@ class TestMergeAmplitudeEmbeddingInterfaces:
         optimized_qfunc = qml.transforms.merge_amplitude_embedding(qfunc)
         optimized_qnode = qml.QNode(optimized_qfunc, dev, interface="jax")
 
-        amplitude = jnp.array([0., 1.], dtype=jnp.float64)
+        amplitude = jnp.array([0.0, 1.0], dtype=jnp.float64)
         # Check the state |11> is being generated.
         assert optimized_qnode(amplitude)[-1] == 1

--- a/tests/transforms/test_optimization/test_merge_amplitude_embedding.py
+++ b/tests/transforms/test_optimization/test_merge_amplitude_embedding.py
@@ -39,7 +39,6 @@ class TestMergeAmplitudeEmbedding:
         assert len(ops) == 3
 
         # Check that the solution is as expected.
-
         dev = qml.device("default.qubit", wires=2)
         assert np.allclose(qml.QNode(transformed_qfunc, dev)()[-1], 1)
 

--- a/tests/transforms/test_optimization/test_merge_amplitude_embedding.py
+++ b/tests/transforms/test_optimization/test_merge_amplitude_embedding.py
@@ -36,7 +36,7 @@ class TestMergeAmplitudeEmbedding:
         transformed_qfunc = merge_amplitude_embedding(qfunc)
         ops = qml.transforms.make_tape(transformed_qfunc)().operations
 
-        assert len(ops) == 1
+        assert len(ops) == 3
 
         # Check that the solution is as expected.
 

--- a/tests/transforms/test_optimization/test_merge_amplitude_embedding.py
+++ b/tests/transforms/test_optimization/test_merge_amplitude_embedding.py
@@ -29,6 +29,8 @@ class TestMergeAmplitudeEmbedding:
         def qfunc():
             qml.AmplitudeEmbedding([0.0, 1.0], wires=0)
             qml.AmplitudeEmbedding([0.0, 1.0], wires=1)
+            qml.Hadamard(wires = 0)
+            qml.Hadamard(wires = 0)
             qml.state()
 
         transformed_qfunc = merge_amplitude_embedding(qfunc)

--- a/tests/transforms/test_optimization/test_merge_amplitude_embedding.py
+++ b/tests/transforms/test_optimization/test_merge_amplitude_embedding.py
@@ -24,7 +24,7 @@ class TestMergeAmplitudeEmbedding:
     """Test that amplitude embedding gates are combined into a single."""
 
     def test_multi_amplitude_embedding(self):
-        """Test that the transformation is working correctly by joining two amplitudeEmbedding."""
+        """Test that the transformation is working correctly by joining two AmplitudeEmbedding."""
 
         def qfunc():
             qml.AmplitudeEmbedding([0.0, 1.0], wires=0)

--- a/tests/transforms/test_optimization/test_merge_amplitude_embedding.py
+++ b/tests/transforms/test_optimization/test_merge_amplitude_embedding.py
@@ -60,7 +60,7 @@ class TestMergeAmplitudeEmbedding:
 
 
 class TestMergeAmplitudeEmbeddingInterfaces:
-    """Test that amplitude merging works in all interfaces."""
+    """Test that merging amplitude embedding operations works in all interfaces."""
 
     def test_merge_amplitude_embedding_autograd(self):
         """Test QNode in autograd interface."""

--- a/tests/transforms/test_optimization/test_merge_amplitude_embedding.py
+++ b/tests/transforms/test_optimization/test_merge_amplitude_embedding.py
@@ -27,8 +27,8 @@ class TestMergeAmplitudeEmbedding:
         """Test that the transformation is working correctly by joining two amplitudeEmbedding."""
 
         def qfunc():
-            qml.AmplitudeEmbedding([0, 1], wires=0)
-            qml.AmplitudeEmbedding([0, 1], wires=1)
+            qml.AmplitudeEmbedding([0., 1.], wires=0)
+            qml.AmplitudeEmbedding([0., 1.], wires=1)
             qml.state()
 
         transformed_qfunc = merge_amplitude_embedding(qfunc)
@@ -45,8 +45,8 @@ class TestMergeAmplitudeEmbedding:
         """Check that AmplitudeEmbedding cannot be applied if the qubit has already been used."""
 
         def qfunc():
-            qml.CNOT(wires=[0, 1])
-            qml.AmplitudeEmbedding([0, 1], wires=1)
+            qml.CNOT(wires=[0., 1.])
+            qml.AmplitudeEmbedding([0., 1.], wires=1)
 
         transformed_qfunc = merge_amplitude_embedding(qfunc)
 
@@ -72,7 +72,7 @@ class TestMergeAmplitudeEmbeddingInterfaces:
         optimized_qfunc = qml.transforms.merge_amplitude_embedding(qfunc)
         optimized_qnode = qml.QNode(optimized_qfunc, dev)
 
-        amplitude = np.array([0, 1], requires_grad=True)
+        amplitude = np.array([0., 1.], requires_grad=True)
         # Check the state |11> is being generated.
         assert optimized_qnode(amplitude)[-1] == 1
 
@@ -89,7 +89,7 @@ class TestMergeAmplitudeEmbeddingInterfaces:
         optimized_qfunc = qml.transforms.merge_amplitude_embedding(qfunc)
         optimized_qnode = qml.QNode(optimized_qfunc, dev, interface="torch")
 
-        amplitude = torch.tensor([0, 1], requires_grad=True)
+        amplitude = torch.tensor([0., 1.], requires_grad=True)
         # Check the state |11> is being generated.
         assert optimized_qnode(amplitude)[-1] == 1
 
@@ -106,7 +106,7 @@ class TestMergeAmplitudeEmbeddingInterfaces:
         optimized_qfunc = qml.transforms.merge_amplitude_embedding(qfunc)
         optimized_qnode = qml.QNode(optimized_qfunc, dev, interface="tf")
 
-        amplitude = tf.Variable([0, 1])
+        amplitude = tf.Variable([0., 1.])
         # Check the state |11> is being generated.
         assert optimized_qnode(amplitude)[-1] == 1
 
@@ -129,6 +129,6 @@ class TestMergeAmplitudeEmbeddingInterfaces:
         optimized_qfunc = qml.transforms.merge_amplitude_embedding(qfunc)
         optimized_qnode = qml.QNode(optimized_qfunc, dev, interface="jax")
 
-        amplitude = jnp.array([0, 1], dtype=jnp.float64)
+        amplitude = jnp.array([0., 1.], dtype=jnp.float64)
         # Check the state |11> is being generated.
         assert optimized_qnode(amplitude)[-1] == 1

--- a/tests/transforms/test_optimization/test_merge_amplitude_embedding.py
+++ b/tests/transforms/test_optimization/test_merge_amplitude_embedding.py
@@ -41,7 +41,7 @@ class TestMergeAmplitudeEmbedding:
         # Check that the solution is as expected.
 
         dev = qml.device("default.qubit", wires=2)
-        assert qml.QNode(transformed_qfunc, dev)()[-1] == 1
+        assert np.allclose(qml.QNode(transformed_qfunc, dev)()[-1], 1)
 
     def test_repeated_qubit(self):
         """Check that AmplitudeEmbedding cannot be applied if the qubit has already been used."""

--- a/tests/transforms/test_optimization/test_merge_amplitude_embedding.py
+++ b/tests/transforms/test_optimization/test_merge_amplitude_embedding.py
@@ -16,7 +16,6 @@ import pytest
 from pennylane import numpy as np
 
 import pennylane as qml
-from pennylane.wires import Wires
 from pennylane.transforms.optimization import merge_amplitude_embedding
 from pennylane._device import DeviceError
 
@@ -24,13 +23,12 @@ from pennylane._device import DeviceError
 class TestMergeAmplitudeEmbedding:
     """Test that amplitude embedding gates are combined into a single."""
 
-
     def test_multi_amplitude_embedding(self):
         """Test that the transformation is working correctly by joining two amplitudeEmbedding."""
 
         def qfunc():
-            qml.AmplitudeEmbedding([0,1], wires=0)
-            qml.AmplitudeEmbedding([0,1], wires=1)
+            qml.AmplitudeEmbedding([0, 1], wires=0)
+            qml.AmplitudeEmbedding([0, 1], wires=1)
             qml.state()
 
         transformed_qfunc = merge_amplitude_embedding(qfunc)
@@ -40,131 +38,80 @@ class TestMergeAmplitudeEmbedding:
 
         # Check that the solution is as expected.
 
-        dev = qml.device("default.qubit", wires = 2)
+        dev = qml.device("default.qubit", wires=2)
         assert qml.QNode(transformed_qfunc, dev)()[-1] == 1
-
 
     def test_repeated_qubit(self):
         """Check that AmplitudeEmbedding cannot be applied if the qubit has already been used."""
 
         def qfunc():
-            qml.CNOT(wires = [0,1])
-            qml.AmplitudeEmbedding([0,1], wires=1)
+            qml.CNOT(wires=[0, 1])
+            qml.AmplitudeEmbedding([0, 1], wires=1)
 
         transformed_qfunc = merge_amplitude_embedding(qfunc)
-        ops = qml.transforms.make_tape(transformed_qfunc)().operations
 
         dev = qml.device("default.qubit", wires=2)
-        qnode = qml.QNode(transformed_qfunc, )
+        qnode = qml.QNode(transformed_qfunc, dev)
 
         with pytest.raises(DeviceError, match="applied in the same qubit"):
             qnode()
 
 
-# Example QNode and device for interface testing
-dev = qml.device("default.qubit", wires=3)
+class TestMergeAmplitudeEmbeddingInterfaces:
+    """Test that amplitude merging works in all interfaces."""
 
-# Test each of single-qubit, two-qubit, and Rot gates
-def qfunc(amplitude):
-    qml.Hadamard(wires = 2)
-    qml.AmplitudeEmbedding(amplitude, wires=0)
-    qml.AmplitudeEmbedding(amplitude, wires=1)
-    qml.CNOT(wires = [0,1])
-    return qml.expval(qml.PauliX(0) @ qml.PauliX(2))
+    def test_merge_amplitude_embedding_autograd(self):
+        """Test QNode in autograd interface."""
 
+        def qfunc(amplitude):
+            qml.AmplitudeEmbedding(amplitude, wires=0)
+            qml.AmplitudeEmbedding(amplitude, wires=1)
+            return qml.state()
 
-transformed_qfunc = merge_amplitude_embedding(qfunc)
+        dev = qml.device("default.qubit", wires=2)
+        optimized_qfunc = qml.transforms.merge_amplitude_embedding(qfunc)
+        optimized_qnode = qml.QNode(optimized_qfunc, dev)
 
-expected_op_list = ["Hadamard", "AmplitudeEmbedding", "CNOT"]
-expected_wires_list = [
-    Wires(2),
-    Wires([0,1]),
-    Wires([0,1]),
-]
+        amplitude = np.array([0, 1], requires_grad=True)
+        # Check the state |11> is being generated.
+        assert optimized_qnode(amplitude)[-1] == 1
 
-'''
-class TestMergeRotationsInterfaces:
-    """Test that rotation merging works in all interfaces."""
-
-    def test_merge_rotations_autograd(self):
-        """Test QNode and gradient in autograd interface."""
-
-        original_qnode = qml.QNode(qfunc, dev)
-        transformed_qnode = qml.QNode(transformed_qfunc, dev)
-
-        input = np.array([0.1, 0.2, 0.3, 0.4], requires_grad=True)
-
-        # Check that the numerical output is the same
-        assert qml.math.allclose(original_qnode(input), transformed_qnode(input))
-
-        # Check that the gradient is the same
-        assert qml.math.allclose(
-            qml.grad(original_qnode)(input), qml.grad(transformed_qnode)(input)
-        )
-
-        # Check operation list
-        ops = transformed_qnode.qtape.operations
-        compare_operation_lists(ops, expected_op_list, expected_wires_list)
-
-    def test_merge_rotations_torch(self):
-        """Test QNode and gradient in torch interface."""
+    def test_merge_amplitude_embedding_torch(self):
+        """Test QNode in torch interface."""
         torch = pytest.importorskip("torch", minversion="1.8")
 
-        original_qnode = qml.QNode(qfunc, dev, interface="torch")
-        transformed_qnode = qml.QNode(transformed_qfunc, dev, interface="torch")
+        def qfunc(amplitude):
+            qml.AmplitudeEmbedding(amplitude, wires=0)
+            qml.AmplitudeEmbedding(amplitude, wires=1)
+            return qml.state()
 
-        original_input = torch.tensor([0.1, 0.2, 0.3, 0.4], requires_grad=True)
-        transformed_input = torch.tensor([0.1, 0.2, 0.3, 0.4], requires_grad=True)
+        dev = qml.device("default.qubit", wires=2)
+        optimized_qfunc = qml.transforms.merge_amplitude_embedding(qfunc)
+        optimized_qnode = qml.QNode(optimized_qfunc, dev, interface="torch")
 
-        original_result = original_qnode(original_input)
-        transformed_result = transformed_qnode(transformed_input)
+        amplitude = torch.tensor([0, 1], requires_grad=True)
+        # Check the state |11> is being generated.
+        assert optimized_qnode(amplitude)[-1] == 1
 
-        # Check that the numerical output is the same
-        assert qml.math.allclose(original_result, transformed_result.detach().numpy())
-
-        # Check that the gradient is the same
-        original_result.backward()
-        transformed_result.backward()
-
-        assert qml.math.allclose(original_input.grad, transformed_input.grad)
-
-        # Check operation list
-        ops = transformed_qnode.qtape.operations
-        compare_operation_lists(ops, expected_op_list, expected_wires_list)
-
-    def test_merge_rotations_tf(self):
-        """Test QNode and gradient in tensorflow interface."""
+    def test_merge_amplitude_embedding_tf(self):
+        """Test QNode in tensorflow interface."""
         tf = pytest.importorskip("tensorflow")
 
-        original_qnode = qml.QNode(qfunc, dev, interface="tf")
-        transformed_qnode = qml.QNode(transformed_qfunc, dev, interface="tf")
+        def qfunc(amplitude):
+            qml.AmplitudeEmbedding(amplitude, wires=0)
+            qml.AmplitudeEmbedding(amplitude, wires=1)
+            return qml.state()
 
-        original_input = tf.Variable([0.1, 0.2, 0.3, 0.4])
-        transformed_input = tf.Variable([0.1, 0.2, 0.3, 0.4])
+        dev = qml.device("default.qubit", wires=2)
+        optimized_qfunc = qml.transforms.merge_amplitude_embedding(qfunc)
+        optimized_qnode = qml.QNode(optimized_qfunc, dev, interface="tf")
 
-        original_result = original_qnode(original_input)
-        transformed_result = transformed_qnode(transformed_input)
+        amplitude = tf.Variable([0, 1])
+        # Check the state |11> is being generated.
+        assert optimized_qnode(amplitude)[-1] == 1
 
-        # Check that the numerical output is the same
-        assert qml.math.allclose(original_result, transformed_result)
-
-        # Check that the gradient is the same
-        with tf.GradientTape() as tape:
-            loss = original_qnode(original_input)
-        original_grad = tape.gradient(loss, original_input)
-
-        with tf.GradientTape() as tape:
-            loss = transformed_qnode(transformed_input)
-        transformed_grad = tape.gradient(loss, transformed_input)
-
-        assert qml.math.allclose(original_grad, transformed_grad)
-
-        # Check operation list
-        ops = transformed_qnode.qtape.operations
-        compare_operation_lists(ops, expected_op_list, expected_wires_list)
-
-    def test_merge_rotations_jax(self):
-        """Test QNode and gradient in JAX interface."""
+    def test_merge_amplitude_embedding_jax(self):
+        """Test QNode in JAX interface."""
         jax = pytest.importorskip("jax")
         from jax import numpy as jnp
 
@@ -173,20 +120,15 @@ class TestMergeRotationsInterfaces:
         remember = config.read("jax_enable_x64")
         config.update("jax_enable_x64", True)
 
-        original_qnode = qml.QNode(qfunc, dev, interface="jax")
-        transformed_qnode = qml.QNode(transformed_qfunc, dev, interface="jax")
+        def qfunc(amplitude):
+            qml.AmplitudeEmbedding(amplitude, wires=0)
+            qml.AmplitudeEmbedding(amplitude, wires=1)
+            return qml.state()
 
-        input = jnp.array([0.1, 0.2, 0.3, 0.4], dtype=jnp.float64)
+        dev = qml.device("default.qubit", wires=2)
+        optimized_qfunc = qml.transforms.merge_amplitude_embedding(qfunc)
+        optimized_qnode = qml.QNode(optimized_qfunc, dev, interface="jax")
 
-        # Check that the numerical output is the same
-        assert qml.math.allclose(original_qnode(input), transformed_qnode(input))
-
-        # Check that the gradient is the same
-        assert qml.math.allclose(
-            jax.grad(original_qnode)(input), jax.grad(transformed_qnode)(input)
-        )
-
-        # Check operation list
-        ops = transformed_qnode.qtape.operations
-        compare_operation_lists(ops, expected_op_list, expected_wires_list)
-'''
+        amplitude = jnp.array([0, 1], dtype=jnp.float64)
+        # Check the state |11> is being generated.
+        assert optimized_qnode(amplitude)[-1] == 1

--- a/tests/transforms/test_optimization/test_merge_amplitude_embedding.py
+++ b/tests/transforms/test_optimization/test_merge_amplitude_embedding.py
@@ -57,6 +57,20 @@ class TestMergeAmplitudeEmbedding:
         with pytest.raises(DeviceError, match="applied in the same qubit"):
             qnode()
 
+    def test_decorator(self):
+        """Check that the decorator works."""
+
+        @merge_amplitude_embedding
+        def qfunc():
+            qml.AmplitudeEmbedding([0, 1, 0, 0], wires=[0, 1])
+            qml.AmplitudeEmbedding([0, 1], wires=2)
+
+            return qml.state()
+
+        dev = qml.device("default.qubit", wires=3)
+        qnode = qml.QNode(qfunc, dev)
+        assert qnode()[3] == 1.0
+
 
 class TestMergeAmplitudeEmbeddingInterfaces:
     """Test that merging amplitude embedding operations works in all interfaces."""

--- a/tests/transforms/test_optimization/test_merge_amplitude_embedding.py
+++ b/tests/transforms/test_optimization/test_merge_amplitude_embedding.py
@@ -29,8 +29,8 @@ class TestMergeAmplitudeEmbedding:
         def qfunc():
             qml.AmplitudeEmbedding([0.0, 1.0], wires=0)
             qml.AmplitudeEmbedding([0.0, 1.0], wires=1)
-            qml.Hadamard(wires = 0)
-            qml.Hadamard(wires = 0)
+            qml.Hadamard(wires=0)
+            qml.Hadamard(wires=0)
             qml.state()
 
         transformed_qfunc = merge_amplitude_embedding(qfunc)


### PR DESCRIPTION
**Context:** In certain situations it may be convenient to be able to use more than one `AmplitudeEmbedding` in the same circuit. A first approximation has been made but it has been decided to use circuit transformations to merge these gates. [(#1890)](https://github.com/PennyLaneAI/pennylane/pull/1890)

**Description of the Change:** A `merge_amplitude_embedding` transformation has been created, which takes a quantum function and returns it transformed by joining all gates of this type together.

**Example:**

```python
import pennylane as qml
from pennylane.transforms import merge_amplitude_embedding

@merge_amplitude_embedding
def qfunc():
    
    qml.AmplitudeEmbedding([0,1,0,0], wires = [0,1])
    qml.AmplitudeEmbedding([0,1], wires = 2)
    
    return qml.expval(qml.PauliZ(wires = 0))

dev = qml.device("default.qubit", wires = 3)
qnode = qml.QNode(qfunc, dev)
print(qml.draw(qnode)())
```

 0: ──╭AmplitudeEmbedding(M0)──┤ ⟨Z⟩ 
 1: ──├AmplitudeEmbedding(M0)──┤     
 2: ──╰AmplitudeEmbedding(M0)──┤     
M0 =
[0.+0.j 0.+0.j 0.+0.j 1.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j]

**Benefits:**

Convenience when programming some routines such as the calculation of the inner product through the swap test.

**Possible Drawbacks:**

**Related GitHub Issues:**
[(#1140)](https://github.com/PennyLaneAI/pennylane/issues/1140)
