### PR TITLE
Fixes a bug where batch transforms would mutate a QNodes execution options

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -389,7 +389,7 @@
 <h3>Bug fixes</h3>
 
 * Fixes a bug where batch transforms would mutate a QNodes execution options.
-  [()]()
+  [(#1934)](https://github.com/PennyLaneAI/pennylane/pull/1934)
 
 * `qml.draw` now supports arbitrary templates with matrix parameters.
   [(#1917)](https://github.com/PennyLaneAI/pennylane/pull/1917)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -388,6 +388,9 @@
 
 <h3>Bug fixes</h3>
 
+* Fixes a bug where batch transforms would mutate a QNodes execution options.
+  [()]()
+
 * `qml.draw` now supports arbitrary templates with matrix parameters.
   [(#1917)](https://github.com/PennyLaneAI/pennylane/pull/1917)
 

--- a/pennylane/transforms/batch_transform.py
+++ b/pennylane/transforms/batch_transform.py
@@ -288,7 +288,7 @@ class batch_transform:
             tapes, processing_fn = self.construct(qnode.qtape, *targs, **tkwargs)
 
             interface = qnode.interface
-            execute_kwargs = getattr(qnode, "execute_kwargs", {})
+            execute_kwargs = getattr(qnode, "execute_kwargs", {}).copy()
             max_diff = execute_kwargs.pop("max_diff", 2)
             max_diff = transform_max_diff or max_diff
 

--- a/tests/transforms/test_batch_transform.py
+++ b/tests/transforms/test_batch_transform.py
@@ -161,6 +161,9 @@ class TestBatchTransform:
         assert spy.call_args[1]["max_diff"] == 3
         assert spy.call_args[1]["cache"] is cache
 
+        # test that the QNode execution options remain unchanged
+        assert circuit.execute_kwargs["max_diff"] == 3
+
     def test_expand_fn(self, mocker):
         """Test that if an expansion function is provided,
         that the input tape is expanded before being transformed."""


### PR DESCRIPTION
**Context:** Currently, when executing a batch transform, the line

https://github.com/PennyLaneAI/pennylane/blob/7e69c099bfa19de40b5f74157e9ff7895ef97cb6/pennylane/transforms/batch_transform.py#L292

results in the `qnode.execute_kwargs["max_diff"]` key being unintentionally deleted. This can cause issues if attempting to extract higher derivatives after performing a batch transformation.

**Description of the Change:** Copies the execution dictionary, to avoid accidental mutation.

**Benefits:** The QNode execution keyword options are now unaffected by batch transforms.

**Possible Drawbacks:** n/a

**Related GitHub Issues:** n/a
