### PR TITLE
Bump autoray requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@ toml==0.10
 appdirs==1.4
 semantic_version==2.6
 dask[delayed]==2021.08
-autoray==0.2.5
+autoray>=0.2.5
 matplotlib==3.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@ toml==0.10
 appdirs==1.4
 semantic_version==2.6
 dask[delayed]==2021.08
-autoray==0.2
+autoray==0.2.5
 matplotlib==3.4


### PR DESCRIPTION
Importing PennyLane seems to result in an error with `autoray <v0.2.5`. This PR bumps the version number in the `requirements.txt` iterates on the version of `autoray` required.

Closes #1941.