### PR TITLE
Change all .format() instances to f-strings

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -352,6 +352,9 @@
 
 <h3>Improvements</h3>
 
+* Change all instances of `"{}".format(..)` to `f"{..}"`.
+  [(#1970)](https://github.com/PennyLaneAI/pennylane/pull/1970)
+
 * Tests do not loop over automatically imported and instantiated operations any more,
 
 * The QNode has been re-written to support batch execution across the board,

--- a/pennylane/__init__.py
+++ b/pennylane/__init__.py
@@ -315,10 +315,8 @@ def device(name, *args, **kwargs):
 
         if Version(version()) not in Spec(plugin_device_class.pennylane_requires):
             raise DeviceError(
-                "The {} plugin requires PennyLane versions {}, however PennyLane "
-                "version {} is installed.".format(
-                    name, plugin_device_class.pennylane_requires, __version__
-                )
+                f"The {name} plugin requires PennyLane versions {plugin_device_class.pennylane_requires}, however PennyLane "
+                "version {__version__} is installed."
             )
 
         # Construct the device

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -150,12 +150,14 @@ class Device(abc.ABC):
     def __str__(self):
         """Verbose string representation."""
         package = self.__module__.split(".")[0]
-        return f"{self.name}\nShort name: {self.short_name}\n" \
-               f"Package: {package}\n" \
-               f"Plugin version: {self.version}\n" \
-               f"Author: {self.author}\n" \
-               f"Wires: {self.num_wires}\n" \
-               f"Shots: {self.shots}"
+        return (
+            f"{self.name}\nShort name: {self.short_name}\n"
+            f"Package: {package}\n"
+            f"Plugin version: {self.version}\n"
+            f"Author: {self.author}\n"
+            f"Wires: {self.num_wires}\n"
+            f"Shots: {self.shots}"
+        )
 
     @property
     @abc.abstractmethod

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -145,21 +145,17 @@ class Device(abc.ABC):
 
     def __repr__(self):
         """String representation."""
-        return "<{} device (wires={}, shots={}) at {}>".format(
-            self.__class__.__name__, self.num_wires, self.shots, hex(id(self))
-        )
+        return f"<{self.__class__.__name__} device (wires={self.num_wires}, shots={self.shots}) at {hex(id(self)}>"
 
     def __str__(self):
         """Verbose string representation."""
-        return "{}\nShort name: {}\nPackage: {}\nPlugin version: {}\nAuthor: {}\nWires: {}\nShots: {}".format(
-            self.name,
-            self.short_name,
-            self.__module__.split(".")[0],
-            self.version,
-            self.author,
-            self.num_wires,
-            self.shots,
-        )
+        package = self.__module__.split(".")[0]
+        return f"{self.name}\nShort name: {self.short_name}\n" \
+               f"Package: {package}\n" \
+               f"Plugin version: {self.version}\n" \
+               f"Author: {self.author}\n" \
+               f"Wires: {self.num_wires}\n" \
+               f"Shots: {self.shots}"
 
     @property
     @abc.abstractmethod
@@ -258,7 +254,7 @@ class Device(abc.ABC):
             # device is in sampling mode (unbatched)
             if shots < 1:
                 raise DeviceError(
-                    "The specified number of shots needs to be at least 1. Got {}.".format(shots)
+                    f"The specified number of shots needs to be at least 1. Got {shots}."
                 )
 
             self._shots = shots
@@ -349,9 +345,7 @@ class Device(abc.ABC):
             mapped_wires = wires.map(self.wire_map)
         except WireError as e:
             raise WireError(
-                "Did not find some of the wires {} on device with wires {}.".format(
-                    wires, self.wires
-                )
+                f"Did not find some of the wires {wires} on device with wires {self.wires}."
             ) from e
 
         return mapped_wires
@@ -450,7 +444,7 @@ class Device(abc.ABC):
 
                 elif obs.return_type is not None:
                     raise qml.QuantumFunctionError(
-                        "Unsupported return type specified for observable {}".format(obs.name)
+                        f"Unsupported return type specified for observable {obs.name}"
                     )
 
             self.post_measure()
@@ -886,15 +880,13 @@ class Device(abc.ABC):
                 ) or self.capabilities().get("inverse_operations", False)
                 if not supports_inv:
                     raise DeviceError(
-                        "The inverse of gates are not supported on device {}".format(
-                            self.short_name
-                        )
+                        f"The inverse of gates are not supported on device {self.short_name}"
                     )
                 operation_name = o.base_name
 
             if not self.supports_operation(operation_name):
                 raise DeviceError(
-                    "Gate {} not supported on device {}".format(operation_name, self.short_name)
+                    f"Gate {operation_name} not supported on device {self.short_name}"
                 )
 
         for o in observables:
@@ -908,15 +900,13 @@ class Device(abc.ABC):
                 ) or self.capabilities().get("tensor_observables", False)
                 if not supports_tensor:
                     raise DeviceError(
-                        "Tensor observables not supported on device {}".format(self.short_name)
+                        f"Tensor observables not supported on device {self.short_name}"
                     )
 
                 for i in o.obs:
                     if not self.supports_observable(i.name):
                         raise DeviceError(
-                            "Observable {} not supported on device {}".format(
-                                i.name, self.short_name
-                            )
+                            f"Observable {i.name} not supported on device {self.short_name}"
                         )
             else:
                 observable_name = o.name
@@ -928,17 +918,13 @@ class Device(abc.ABC):
                     ) or self.capabilities().get("inverse_operations", False)
                     if not supports_inv:
                         raise DeviceError(
-                            "The inverse of gates are not supported on device {}".format(
-                                self.short_name
-                            )
+                            f"The inverse of gates are not supported on device {self.short_name}"
                         )
                     observable_name = o.base_name
 
                 if not self.supports_observable(observable_name):
                     raise DeviceError(
-                        "Observable {} not supported on device {}".format(
-                            observable_name, self.short_name
-                        )
+                        f"Observable {observable_name} not supported on device {self.short_name}"
                     )
 
     @abc.abstractmethod
@@ -987,7 +973,7 @@ class Device(abc.ABC):
             float: variance :math:`\mathrm{var}(A) = \bra{\psi}A^2\ket{\psi} - \bra{\psi}A\ket{\psi}^2`
         """
         raise NotImplementedError(
-            "Returning variances from QNodes not currently supported by {}".format(self.short_name)
+            f"Returning variances from QNodes not currently supported by {self.short_name}"
         )
 
     def sample(self, observable, wires, par):
@@ -1011,7 +997,7 @@ class Device(abc.ABC):
             array[float]: samples in an array of dimension ``(shots,)``
         """
         raise NotImplementedError(
-            "Returning samples from QNodes not currently supported by {}".format(self.short_name)
+            f"Returning samples from QNodes not currently supported by {self.short_name}"
         )
 
     def probability(self, wires=None):
@@ -1029,7 +1015,7 @@ class Device(abc.ABC):
             state tuples are in lexicographical order.
         """
         raise NotImplementedError(
-            "Returning probability not currently supported by {}".format(self.short_name)
+            f"Returning probability not currently supported by {self.short_name}"
         )
 
     @abc.abstractmethod

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -145,7 +145,7 @@ class Device(abc.ABC):
 
     def __repr__(self):
         """String representation."""
-        return f"<{self.__class__.__name__} device (wires={self.num_wires}, shots={self.shots}) at {hex(id(self)}>"
+        return f"<{self.__class__.__name__} device (wires={self.num_wires}, shots={self.shots}) at {hex(id(self))}>"
 
     def __str__(self):
         """Verbose string representation."""

--- a/pennylane/_grad.py
+++ b/pennylane/_grad.py
@@ -250,7 +250,7 @@ def _fd_first_order_centered(f, argnum, delta, *args, idx=None, **kwargs):
 
     if argnum > len(args) - 1:
         raise ValueError(
-            "The value of 'argnum' has to be between 0 and {}; got {}".format(len(args) - 1, argnum)
+            f"The value of 'argnum' has to be between 0 and {len(args) - 1}; got {argnum}"
         )
 
     x = onp.array(args[argnum])
@@ -258,8 +258,7 @@ def _fd_first_order_centered(f, argnum, delta, *args, idx=None, **kwargs):
 
     if x.ndim == 0 and idx is not None:
         raise ValueError(
-            "Argument {} is not an array, 'idx' should be set to 'None';"
-            " got {}".format(argnum, idx)
+            f"Argument {argnum} is not an array, 'idx' should be set to 'None'; got {idx}"
         )
 
     if idx is None:
@@ -298,30 +297,27 @@ def _fd_second_order_centered(f, argnum, delta, *args, idx=None, **kwargs):
 
     if argnum > len(args) - 1:
         raise ValueError(
-            "The value of 'argnum' has to be between 0 and {}; got {}".format(len(args) - 1, argnum)
+            f"The value of 'argnum' has to be between 0 and {len(args) - 1}; got {argnum}"
         )
 
     x = onp.array(args[argnum])
 
     if x.ndim == 0 and idx is not None:
         raise ValueError(
-            "Argument {} is not an array, 'idx' should be set to 'None';"
-            " got {}".format(argnum, idx)
+            f"Argument {argnum} is not an array, 'idx' should be set to 'None'; got {idx}"
         )
 
     if idx is None:
         if x.ndim != 0:
             raise ValueError(
-                "Argument {} is an array, 'idx' should contain the indices of the arguments"
-                " to differentiate; got idx = {}".format(argnum, idx)
+                f"Argument {argnum} is an array, 'idx' should contain the indices of the arguments"
+                f" to differentiate; got idx = {idx}"
             )
         idx = [(), ()]
     else:
         if len(idx) > 2:
             raise ValueError(
-                "The number of indices given in 'idx' can not be greater than two; got {} indices".format(
-                    len(idx)
-                )
+                f"The number of indices given in 'idx' can not be greater than two; got {len(idx)} indices"
             )
 
     i, j = idx
@@ -428,14 +424,12 @@ def finite_diff(f, N=1, argnum=0, idx=None, delta=0.01):
     """
 
     if not callable(f):
-        error_message = "{} object is not callable. \n" "'f' should be a callable function".format(
-            type(f)
-        )
+        error_message = f"{type(f)} object is not callable. \n'f' should be a callable function"
         raise TypeError(error_message)
 
     if delta <= 0.0:
         raise ValueError(
-            "The value of the step size 'delta' has to be greater than 0; got {}".format(delta)
+            f"The value of the step size 'delta' has to be greater than 0; got {delta}"
         )
 
     if N == 1:
@@ -445,6 +439,6 @@ def finite_diff(f, N=1, argnum=0, idx=None, delta=0.01):
         return partial(_fd_second_order_centered, f, argnum, delta, idx=idx)
 
     raise ValueError(
-        "At present, finite-difference approximations are supported up to second-order."
-        " The value of 'N' can be 1 or 2; got {}".format(N)
+        f"At present, finite-difference approximations are supported up to second-order."
+        " The value of 'N' can be 1 or 2; got {N}"
     )

--- a/pennylane/_grad.py
+++ b/pennylane/_grad.py
@@ -440,5 +440,5 @@ def finite_diff(f, N=1, argnum=0, idx=None, delta=0.01):
 
     raise ValueError(
         f"At present, finite-difference approximations are supported up to second-order."
-        " The value of 'N' can be 1 or 2; got {N}"
+        f" The value of 'N' can be 1 or 2; got {N}"
     )

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -420,7 +420,7 @@ class QubitDevice(Device):
 
             elif obs.return_type is not None:
                 raise qml.QuantumFunctionError(
-                    "Unsupported return type specified for observable {}".format(obs.name)
+                    f"Unsupported return type specified for observable {obs.name}"
                 )
 
         return results

--- a/pennylane/about.py
+++ b/pennylane/about.py
@@ -36,15 +36,15 @@ def about():
     """
     plugin_devices = iter_entry_points("pennylane.plugins")
     _internal_main.main(["show", "pennylane"])
-    print("Platform info:           {}".format(platform.platform(aliased=True)))
-    print("Python version:          {0}.{1}.{2}".format(*sys.version_info[0:3]))
-    print("Numpy version:           {}".format(numpy.__version__))
-    print("Scipy version:           {}".format(scipy.__version__))
+    print(f"Platform info:           {platform.platform(aliased=True)}")
+    print(f"Python version:          {sys.version_info[0]}.{sys.version_info[1]}.{sys.version_info[2]}")
+    print(f"Numpy version:           {numpy.__version__}")
+    print(f"Scipy version:           {scipy.__version__}")
 
     print("Installed devices:")
 
     for d in plugin_devices:
-        print("- {} ({}-{})".format(d.name, d.dist.project_name, d.dist.version))
+        print(f"- {d.name} ({d.dist.project_name}-{d.dist.version})")
 
 
 if __name__ == "__main__":

--- a/pennylane/about.py
+++ b/pennylane/about.py
@@ -37,7 +37,9 @@ def about():
     plugin_devices = iter_entry_points("pennylane.plugins")
     _internal_main.main(["show", "pennylane"])
     print(f"Platform info:           {platform.platform(aliased=True)}")
-    print(f"Python version:          {sys.version_info[0]}.{sys.version_info[1]}.{sys.version_info[2]}")
+    print(
+        f"Python version:          {sys.version_info[0]}.{sys.version_info[1]}.{sys.version_info[2]}"
+    )
     print(f"Numpy version:           {numpy.__version__}")
     print(f"Scipy version:           {scipy.__version__}")
 

--- a/pennylane/beta/devices/default_tensor.py
+++ b/pennylane/beta/devices/default_tensor.py
@@ -219,7 +219,7 @@ class DefaultTensor(Device):
         Returns:
             tn.Node: the newly created node
         """
-        name = "{}{}".format(name, (tuple([wires]) if isinstance(wires, int) else wires.labels))
+        name = f"{name}{(tuple([wires]) if isinstance(wires, int) else wires.labels)}"
         if isinstance(A, tn.Node):
             A.set_name(name)
             A.backend = self.backend
@@ -260,8 +260,8 @@ class DefaultTensor(Device):
             for tensor, wires, name in zip(tensors, tensor_wires, names):
                 if len(tensor.shape) != len(wires):
                     raise ValueError(
-                        "Tensor provided has shape={}, which is incompatible "
-                        "with provided wires {}.".format(tensor.shape, wires.tolist())
+                        f"Tensor provided has shape={tensor.shape}, which is incompatible "
+                        f"with provided wires {wires.tolist()}."
                     )
                 node = self._add_node(tensor, wires=wires, name=name)
                 self._free_wire_edges.extend(node.edges)
@@ -271,8 +271,8 @@ class DefaultTensor(Device):
             for tensor, wires, name in zip(tensors, tensor_wires, names):
                 if len(tensor.shape) != len(wires):
                     raise ValueError(
-                        "Tensor provided has shape={}, which is incompatible "
-                        "with provided wires {}.".format(tensor.shape, wires.tolist())
+                        f"Tensor provided has shape={tensor.shape}, which is incompatible "
+                        f"with provided wires {wires.tolist()}."
                     )
                 tensor = self._expand_dims(tensor, 0)
                 tensor = self._expand_dims(tensor, -1)
@@ -330,9 +330,7 @@ class DefaultTensor(Device):
                 and wires.tolist() != list(range(self.num_wires))
             ):
                 raise ValueError(
-                    "The default.tensor plugin can apply {} only to all of the {} wires.".format(
-                        operation, self.num_wires
-                    )
+                    f"The default.tensor plugin can apply {operation} only to all of the {self.num_wires} wires."
                 )
             self._clear_network_data()
             self._add_state_prep_nodes(operation, par)
@@ -361,9 +359,7 @@ class DefaultTensor(Device):
             elements = set(par[0].tolist())
             if n == 0 or n > self.num_wires or not elements.issubset({0, 1}):
                 raise ValueError(
-                    "BasisState parameter must be an array of 0 or 1 integers of length at most {}.".format(
-                        self.num_wires
-                    )
+                    f"BasisState parameter must be an array of 0 or 1 integers of length at most {self.num_wires}."
                 )
             zero_vec = self._array(self._zero_state, dtype=self.C_DTYPE)
             one_vec = zero_vec[::-1]
@@ -521,7 +517,7 @@ class DefaultTensor(Device):
 
         if self._abs(self._imag(expval)) > TOL:
             warnings.warn(
-                "Nonvanishing imaginary part {} in expectation value.".format(expval.imag),
+                f"Nonvanishing imaginary part {expval.imag} in expectation value.",
                 RuntimeWarning,
             )
         return self._real(expval)
@@ -696,8 +692,8 @@ class DefaultTensor(Device):
         """
         if method not in contract_fns:
             raise ValueError(
-                "The contraction method ``{}`` was not found. Supported methods are"
-                "'auto', 'greedy', 'branch', or 'optimal'.".format(method)
+                f"The contraction method ``{method}`` was not found. Supported methods are "
+                f"'auto', 'greedy', 'branch', or 'optimal'."
             )
 
         self._contraction_method = method

--- a/pennylane/collections/dot.py
+++ b/pennylane/collections/dot.py
@@ -69,7 +69,7 @@ def _get_dot_func(interface, x=None):
 
         return np.dot, x
 
-    raise ValueError("Unknown interface {}".format(interface))
+    raise ValueError(f"Unknown interface {interface}")
 
 
 def dot(x, y):

--- a/pennylane/collections/qnode_collection.py
+++ b/pennylane/collections/qnode_collection.py
@@ -183,8 +183,8 @@ class QNodeCollection(Sequence):
 
         if self.qnodes and (qnodes[0].interface != self.interface):
             raise ValueError(
-                "Interface mismatch. Provided QNodes use the {} interface, "
-                "QNode collection uses the {} interface".format(qnodes[0].interface, self.interface)
+                f"Interface mismatch. Provided QNodes use the {qnodes[0].interface} interface, "
+                f"QNode collection uses the {self.interface} interface"
             )
 
         self.qnodes.extend(qnodes)

--- a/pennylane/collections/sum.py
+++ b/pennylane/collections/sum.py
@@ -69,7 +69,7 @@ def sum(x):
 
             return apply(jnp.sum, x)
 
-        raise ValueError("Unknown interface {}".format(x.interface))
+        raise ValueError(f"Unknown interface {x.interface}")
 
     import numpy as np
 

--- a/pennylane/configuration.py
+++ b/pennylane/configuration.py
@@ -59,11 +59,11 @@ class Configuration:
 
     def __str__(self):
         if self._config:
-            return "{}".format(self._config)
+            return f"{self._config}"
         return ""
 
     def __repr__(self):
-        return "PennyLane Configuration <{}>".format(self._filepath)
+        return f"PennyLane Configuration <{self._filepath}>"
 
     @property
     def path(self):

--- a/pennylane/devices/default_gaussian.py
+++ b/pennylane/devices/default_gaussian.py
@@ -837,9 +837,7 @@ class DefaultGaussian(Device):
         elif observable == "QuadOperator":
             phi = par[0]
         else:
-            raise NotImplementedError(
-                f"default.gaussian does not support sampling {observable}"
-            )
+            raise NotImplementedError(f"default.gaussian does not support sampling {observable}")
 
         cov, mu = self.reduced_state(wires)
         rot = rotation(phi)

--- a/pennylane/devices/default_gaussian.py
+++ b/pennylane/devices/default_gaussian.py
@@ -838,7 +838,7 @@ class DefaultGaussian(Device):
             phi = par[0]
         else:
             raise NotImplementedError(
-                "default.gaussian does not support sampling {}".format(observable)
+                f"default.gaussian does not support sampling {observable}"
             )
 
         cov, mu = self.reduced_state(wires)

--- a/pennylane/devices/default_mixed.py
+++ b/pennylane/devices/default_mixed.py
@@ -278,16 +278,8 @@ class DefaultMixed(QubitDevice):
 
         # index mapping for einsum, e.g., 'iga,abcdef,idh->gbchef'
         einsum_indices = (
-            "{kraus_index}{new_row_indices}{row_indices}, {state_indices},"
-            "{kraus_index}{col_indices}{new_col_indices}->{new_state_indices}".format(
-                kraus_index=kraus_index,
-                new_col_indices=new_col_indices,
-                col_indices=col_indices,
-                state_indices=state_indices,
-                row_indices=row_indices,
-                new_row_indices=new_row_indices,
-                new_state_indices=new_state_indices,
-            )
+            f"{kraus_index}{new_row_indices}{row_indices}, {state_indices},"
+            f"{kraus_index}{col_indices}{new_col_indices}->{new_state_indices}"
         )
 
         self._state = self._einsum(einsum_indices, kraus, self._state, kraus_dagger)
@@ -317,9 +309,7 @@ class DefaultMixed(QubitDevice):
         col_wires_list = [w + self.num_wires for w in row_wires_list]
         col_indices = "".join(ABC_ARRAY[col_wires_list].tolist())
 
-        einsum_indices = "{row_indices},{state_indices},{col_indices}->{state_indices}".format(
-            col_indices=col_indices, state_indices=state_indices, row_indices=row_indices
-        )
+        einsum_indices = f"{row_indices},{state_indices},{col_indices}->{state_indices}"
 
         self._state = self._einsum(einsum_indices, eigvals, self._state, self._conj(eigvals))
 
@@ -495,8 +485,8 @@ class DefaultMixed(QubitDevice):
 
             if i > 0 and isinstance(operation, (QubitStateVector, BasisState)):
                 raise DeviceError(
-                    "Operation {} cannot be used after other Operations have already been applied "
-                    "on a {} device.".format(operation.name, self.short_name)
+                    f"Operation {operation.name} cannot be used after other Operations have already been applied "
+                    f"on a {self.short_name} device."
                 )
 
         for operation in operations:

--- a/pennylane/devices/tests/conftest.py
+++ b/pennylane/devices/tests/conftest.py
@@ -79,9 +79,7 @@ def skip_if():
             # skip if capability not found, or if capability has specific value
             if capability not in dev_capabilities or dev_capabilities[capability] == value:
                 pytest.skip(
-                    "Test skipped for {} device with capability {}:{}.".format(
-                        dev.name, capability, value
-                    )
+                    f"Test skipped for {dev.name} device with capability {capability}:{value}."
                 )
 
     return _skip_if
@@ -99,12 +97,11 @@ def device(device_kwargs):
         try:
             dev = qml.device(**device_kwargs)
         except qml.DeviceError:
+            dev_name = device_kwargs["name"]
             # exit the tests if the device cannot be created
             pytest.exit(
-                "Device {} cannot be created. To run the device tests on an external device, the "
-                "plugin and all of its dependencies must be installed.".format(
-                    device_kwargs["name"]
-                )
+                f"Device {dev_name} cannot be created. To run the device tests on an external device, the "
+                f"plugin and all of its dependencies must be installed."
             )
 
         capabilities = dev.capabilities()
@@ -123,7 +120,7 @@ def pytest_runtest_setup(item):
     # skip tests marked as broken
     for mark in item.iter_markers(name="broken"):
         if mark.args:
-            pytest.skip("Broken test skipped: {}".format(*mark.args))
+            pytest.skip(f"Broken test skipped: {mark.args}")
         else:
             pytest.skip("Test skipped as corresponding code base is currently broken!")
 

--- a/pennylane/drawer/representation_resolver.py
+++ b/pennylane/drawer/representation_resolver.py
@@ -406,9 +406,8 @@ class RepresentationResolver:
             )
 
         else:
-            representation = "{}({})".format(
-                name, ", ".join([self.single_parameter_representation(par) for par in op.data])
-            )
+            r = ", ".join([self.single_parameter_representation(par) for par in op.data])
+            representation = f"{name}({r})"
 
         if getattr(op, "inverse", False):
             representation += self.charset.to_superscript("-1")

--- a/pennylane/fourier/utils.py
+++ b/pennylane/fourier/utils.py
@@ -24,7 +24,7 @@ def format_nvec(nvec):
     if isinstance(nvec, int):
         return str(nvec)
 
-    nvec_str = ["{}".format(n) if n < 0 else " {}".format(n) for n in nvec]
+    nvec_str = [f"{n}" if n < 0 else f" {n}" for n in nvec]
 
     return " ".join(nvec_str)
 

--- a/pennylane/grouping/group_observables.py
+++ b/pennylane/grouping/group_observables.py
@@ -69,18 +69,15 @@ class PauliGroupingStrategy:  # pylint: disable=too-many-instance-attributes
 
         if grouping_type.lower() not in GROUPING_TYPES:
             raise ValueError(
-                "Grouping type must be one of: {}, instead got {}.".format(
-                    GROUPING_TYPES, grouping_type
-                )
+                f"Grouping type must be one of: {GROUPING_TYPES}, instead got {grouping_type}."
             )
 
         self.grouping_type = grouping_type.lower()
 
         if graph_colourer.lower() not in GRAPH_COLOURING_METHODS.keys():
             raise ValueError(
-                "Graph colouring method must be one of: {}, instead got {}.".format(
-                    list(GRAPH_COLOURING_METHODS.keys()), graph_colourer
-                )
+                f"Graph colouring method must be one of: {list(GRAPH_COLOURING_METHODS.keys())}, "
+                f"instead got {graph_colourer}."
             )
 
         self.graph_colourer = GRAPH_COLOURING_METHODS[graph_colourer.lower()]

--- a/pennylane/grouping/optimize_measurements.py
+++ b/pennylane/grouping/optimize_measurements.py
@@ -84,7 +84,7 @@ def optimize_measurements(observables, coefficients=None, grouping="qwc", colour
         ) = diagonalize_qwc_groupings(grouped_obs)
     else:
         raise NotImplementedError(
-            "Measurement reduction by '{}' grouping not implemented.".format(grouping.lower())
+            f"Measurement reduction by '{grouping.lower()}' grouping not implemented."
         )
 
     if coefficients is None:

--- a/pennylane/grouping/transformations.py
+++ b/pennylane/grouping/transformations.py
@@ -46,8 +46,8 @@ def qwc_rotation(pauli_operators):
     paulis_with_identity = (qml.Identity, qml.PauliX, qml.PauliY, qml.PauliZ)
     if not all(isinstance(element, paulis_with_identity) for element in pauli_operators):
         raise TypeError(
-            "All values of input pauli_operators must be either Identity, PauliX, PauliY, or PauliZ instances,"
-            " instead got pauli_operators = {}.".format(pauli_operators)
+            f"All values of input pauli_operators must be either Identity, PauliX, PauliY, or PauliZ instances,"
+            f" instead got pauli_operators = {pauli_operators}."
         )
     with qml.tape.OperationRecorder() as rec:
 
@@ -81,7 +81,7 @@ def diagonalize_pauli_word(pauli_word):
     """
 
     if not is_pauli_word(pauli_word):
-        raise TypeError("Input must be a Pauli word, instead got: {}.".format(pauli_word))
+        raise TypeError(f"Input must be a Pauli word, instead got: {pauli_word}.")
 
     paulis_with_identity = (qml.PauliX, qml.PauliY, qml.PauliZ, qml.Identity)
     diag_term = None
@@ -144,9 +144,7 @@ def diagonalize_qwc_pauli_words(qwc_grouping):
                 pauli_to_binary(qwc_grouping[j], wire_map=wire_map),
             ):
                 raise ValueError(
-                    "{} and {} are not qubit-wise commuting.".format(
-                        qwc_grouping[i], qwc_grouping[j]
-                    )
+                    f"{qwc_grouping[i]} and {qwc_grouping[j]} are not qubit-wise commuting."
                 )
 
     pauli_operators = []

--- a/pennylane/grouping/utils.py
+++ b/pennylane/grouping/utils.py
@@ -74,7 +74,7 @@ def is_pauli_word(observable):
 
     if not isinstance(observable, Observable):
         raise TypeError(
-            "Expected {} instance, instead got {} instance.".format(Observable, type(observable))
+            f"Expected {Observable} instance, instead got {type(observable)} instance."
         )
 
     pauli_word_names = ["Identity", "PauliX", "PauliY", "PauliZ"]
@@ -116,7 +116,7 @@ def are_identical_pauli_words(pauli_1, pauli_2):
 
     if not (is_pauli_word(pauli_1) and is_pauli_word(pauli_2)):
         raise TypeError(
-            "Expected Pauli word observables, instead got {} and {}.".format(pauli_1, pauli_2)
+            f"Expected Pauli word observables, instead got {pauli_1} and {pauli_2}."
         )
 
     paulis_with_identity = (PauliX, PauliY, PauliZ, Identity)
@@ -219,7 +219,7 @@ def pauli_to_binary(pauli_word, n_qubits=None, wire_map=None):
 
     if not is_pauli_word(pauli_word):
         raise TypeError(
-            "Expected a Pauli word Observable instance, instead got {}.".format(pauli_word)
+            f"Expected a Pauli word Observable instance, instead got {pauli_word}."
         )
 
     if wire_map is None:
@@ -231,8 +231,8 @@ def pauli_to_binary(pauli_word, n_qubits=None, wire_map=None):
         n_qubits = n_qubits_min
     elif n_qubits < n_qubits_min:
         raise ValueError(
-            "n_qubits must support the highest mapped wire index {},"
-            " instead got n_qubits={}.".format(n_qubits_min, n_qubits)
+            f"n_qubits must support the highest mapped wire index {n_qubits_min},"
+            f" instead got n_qubits={n_qubits}."
         )
 
     pauli_wires = pauli_word.wires.map(wire_map).tolist()
@@ -306,16 +306,12 @@ def binary_to_pauli(binary_vector, wire_map=None):  # pylint: disable=too-many-b
 
     if len(binary_vector) % 2 != 0:
         raise ValueError(
-            "Length of binary_vector must be even, instead got vector of shape {}.".format(
-                np.shape(binary_vector)
-            )
+            f"Length of binary_vector must be even, instead got vector of shape {np.shape(binary_vector)}."
         )
 
     if not np.array_equal(binary_vector, binary_vector.astype(bool)):
         raise ValueError(
-            "Input vector must have strictly binary components, instead got {}.".format(
-                binary_vector
-            )
+            f"Input vector must have strictly binary components, instead got {binary_vector}."
         )
 
     n_qubits = len(binary_vector) // 2
@@ -323,8 +319,8 @@ def binary_to_pauli(binary_vector, wire_map=None):  # pylint: disable=too-many-b
     if wire_map is not None:
         if set(wire_map.values()) != set(range(n_qubits)):
             raise ValueError(
-                "The values of wire_map must be integers 0 to N, for 2N-dimensional binary vector."
-                " Instead got wire_map values: {}".format(wire_map.values())
+                f"The values of wire_map must be integers 0 to N, for 2N-dimensional binary vector."
+                f" Instead got wire_map values: {wire_map.values()}"
             )
         label_map = {explicit_index: wire_label for wire_label, explicit_index in wire_map.items()}
     else:
@@ -620,16 +616,13 @@ def is_qwc(pauli_vec_1, pauli_vec_2):
 
     if len(pauli_vec_1) != len(pauli_vec_2):
         raise ValueError(
-            "Vectors a and b must be the same dimension, instead got shapes {} and {}.".format(
-                np.shape(pauli_vec_1), np.shape(pauli_vec_2)
-            )
+            f"Vectors a and b must be the same dimension, instead got "
+            f"shapes {np.shape(pauli_vec_1)} and {np.shape(pauli_vec_2)}."
         )
 
     if len(pauli_vec_1) % 2 != 0:
         raise ValueError(
-            "Symplectic vector-space must have even dimension, instead got vectors of shape {}.".format(
-                np.shape(pauli_vec_1)
-            )
+            f"Symplectic vector-space must have even dimension, instead got vectors of shape {np.shape(pauli_vec_1)}."
         )
 
     if not (
@@ -637,9 +630,7 @@ def is_qwc(pauli_vec_1, pauli_vec_2):
         and np.array_equal(pauli_vec_2, pauli_vec_2.astype(bool))
     ):
         raise ValueError(
-            "Vectors a and b must have strictly binary components, instead got {} and {}".format(
-                pauli_vec_1, pauli_vec_2
-            )
+            f"Vectors a and b must have strictly binary components, instead got {pauli_vec_1} and {pauli_vec_2}"
         )
 
     n_qubits = int(len(pauli_vec_1) / 2)
@@ -705,8 +696,8 @@ def observables_to_binary_matrix(observables, n_qubits=None, wire_map=None):
         n_qubits = n_qubits_min
     elif n_qubits < n_qubits_min:
         raise ValueError(
-            "n_qubits must support the highest mapped wire index {},"
-            " instead got n_qubits={}.".format(n_qubits_min, n_qubits)
+            f"n_qubits must support the highest mapped wire index {n_qubits_min},"
+            f" instead got n_qubits={n_qubits}."
         )
 
     binary_mat = np.zeros((m_cols, 2 * n_qubits))
@@ -752,7 +743,7 @@ def qwc_complement_adj_matrix(binary_observables):
         binary_observables = np.asarray(binary_observables)
 
     if not np.array_equal(binary_observables, binary_observables.astype(bool)):
-        raise ValueError("Expected a binary array, instead got {}".format(binary_observables))
+        raise ValueError(f"Expected a binary array, instead got {binary_observables}")
 
     m_terms = np.shape(binary_observables)[0]
     adj = np.zeros((m_terms, m_terms))

--- a/pennylane/grouping/utils.py
+++ b/pennylane/grouping/utils.py
@@ -73,9 +73,7 @@ def is_pauli_word(observable):
     """
 
     if not isinstance(observable, Observable):
-        raise TypeError(
-            f"Expected {Observable} instance, instead got {type(observable)} instance."
-        )
+        raise TypeError(f"Expected {Observable} instance, instead got {type(observable)} instance.")
 
     pauli_word_names = ["Identity", "PauliX", "PauliY", "PauliZ"]
     if isinstance(observable, Tensor):
@@ -115,9 +113,7 @@ def are_identical_pauli_words(pauli_1, pauli_2):
     """
 
     if not (is_pauli_word(pauli_1) and is_pauli_word(pauli_2)):
-        raise TypeError(
-            f"Expected Pauli word observables, instead got {pauli_1} and {pauli_2}."
-        )
+        raise TypeError(f"Expected Pauli word observables, instead got {pauli_1} and {pauli_2}.")
 
     paulis_with_identity = (PauliX, PauliY, PauliZ, Identity)
 
@@ -218,9 +214,7 @@ def pauli_to_binary(pauli_word, n_qubits=None, wire_map=None):
     """
 
     if not is_pauli_word(pauli_word):
-        raise TypeError(
-            f"Expected a Pauli word Observable instance, instead got {pauli_word}."
-        )
+        raise TypeError(f"Expected a Pauli word Observable instance, instead got {pauli_word}.")
 
     if wire_map is None:
         num_wires = len(pauli_word.wires)

--- a/pennylane/init.py
+++ b/pennylane/init.py
@@ -55,7 +55,7 @@ def particle_conserving_u2_uniform(n_layers, n_wires, low=0, high=2 * pi, seed=N
 
     if n_wires < 2:
         raise ValueError(
-            "The number of qubits must be greater than one; got 'n_wires' = {}".format(n_wires)
+            f"The number of qubits must be greater than one; got 'n_wires' = {n_wires}"
         )
 
     params = np.random.uniform(low=low, high=high, size=(n_layers, 2 * n_wires - 1))
@@ -90,7 +90,7 @@ def particle_conserving_u2_normal(n_layers, n_wires, mean=0, std=0.1, seed=None)
 
     if n_wires < 2:
         raise ValueError(
-            "The number of qubits must be greater than one; got 'n_wires' = {}".format(n_wires)
+            f"The number of qubits must be greater than one; got 'n_wires' = {n_wires}"
         )
 
     params = np.random.normal(loc=mean, scale=std, size=(n_layers, 2 * n_wires - 1))
@@ -125,7 +125,7 @@ def particle_conserving_u1_uniform(n_layers, n_wires, low=0, high=2 * pi, seed=N
 
     if n_wires < 2:
         raise ValueError(
-            "The number of qubits must be greater than one; got 'n_wires' = {}".format(n_wires)
+            f"The number of qubits must be greater than one; got 'n_wires' = {n_wires}"
         )
 
     params = np.random.uniform(low=low, high=high, size=(n_layers, n_wires - 1, 2))
@@ -160,7 +160,7 @@ def particle_conserving_u1_normal(n_layers, n_wires, mean=0, std=0.1, seed=None)
 
     if n_wires < 2:
         raise ValueError(
-            "The number of qubits must be greater than one; got 'n_wires' = {}".format(n_wires)
+            f"The number of qubits must be greater than one; got 'n_wires' = {n_wires}"
         )
 
     params = np.random.normal(loc=mean, scale=std, size=(n_layers, n_wires - 1, 2))

--- a/pennylane/measure.py
+++ b/pennylane/measure.py
@@ -91,13 +91,13 @@ class MeasurementProcess:
     def __repr__(self):
         """Representation of this class."""
         if self.obs is None:
-            return "{}(wires={})".format(self.return_type.value, self.wires.tolist())
+            return f"{self.return_type.value}(wires={self.wires.tolist()})"
 
         # Todo: when tape is core the return type will always be taken from the MeasurementProcess
         if self.obs.return_type is None:
-            return "{}({})".format(self.return_type.value, self.obs)
+            return f"{self.return_type.value}({self.obs})"
 
-        return "{}".format(self.obs)
+        return "{self.obs}"
 
     def __copy__(self):
         cls = self.__class__
@@ -252,7 +252,7 @@ def expval(op):
     """
     if not isinstance(op, (Observable, qml.Hamiltonian)):
         raise qml.QuantumFunctionError(
-            "{} is not an observable: cannot be used with expval".format(op.name)
+            f"{op.name} is not an observable: cannot be used with expval"
         )
 
     return MeasurementProcess(Expectation, obs=op)
@@ -287,7 +287,7 @@ def var(op):
     """
     if not isinstance(op, Observable):
         raise qml.QuantumFunctionError(
-            "{} is not an observable: cannot be used with var".format(op.name)
+            f"{op.name} is not an observable: cannot be used with var"
         )
 
     return MeasurementProcess(Variance, obs=op)
@@ -364,7 +364,7 @@ def sample(op=None, wires=None):
     """
     if not isinstance(op, Observable) and op is not None:  # None type is also allowed for op
         raise qml.QuantumFunctionError(
-            "{} is not an observable: cannot be used with sample".format(op.name)
+            f"{op.name} is not an observable: cannot be used with sample"
         )
 
     if wires is not None:
@@ -443,9 +443,7 @@ def probs(wires=None, op=None):
 
     if op is not None and not hasattr(op, "diagonalizing_gates"):
         raise qml.QuantumFunctionError(
-            "{} has not diagonalizing_gates attribute: cannot be used to rotate the probability".format(
-                op
-            )
+            f"{op} has not diagonalizing_gates attribute: cannot be used to rotate the probability"
         )
 
     if wires is not None:

--- a/pennylane/measure.py
+++ b/pennylane/measure.py
@@ -97,7 +97,7 @@ class MeasurementProcess:
         if self.obs.return_type is None:
             return f"{self.return_type.value}({self.obs})"
 
-        return "{self.obs}"
+        return f"{self.obs}"
 
     def __copy__(self):
         cls = self.__class__

--- a/pennylane/measure.py
+++ b/pennylane/measure.py
@@ -286,9 +286,7 @@ def var(op):
         QuantumFunctionError: `op` is not an instance of :class:`~.Observable`
     """
     if not isinstance(op, Observable):
-        raise qml.QuantumFunctionError(
-            f"{op.name} is not an observable: cannot be used with var"
-        )
+        raise qml.QuantumFunctionError(f"{op.name} is not an observable: cannot be used with var")
 
     return MeasurementProcess(Variance, obs=op)
 

--- a/pennylane/numpy/tensor.py
+++ b/pennylane/numpy/tensor.py
@@ -125,7 +125,7 @@ class tensor(_np.ndarray):
 
     def __repr__(self):
         string = super().__repr__()
-        return string[:-1] + ", requires_grad={})".format(self.requires_grad)
+        return string[:-1] + f", requires_grad={self.requires_grad})"
 
     def __array_wrap__(self, obj):
         out_arr = tensor(obj, requires_grad=self.requires_grad)
@@ -303,7 +303,7 @@ def tensor_to_arraybox(x, *args):
             return ArrayBox(x, *args)
 
         raise NonDifferentiableError(
-            "{} is non-differentiable. Set the requires_grad attribute to True.".format(x)
+            f"{x} is non-differentiable. Set the requires_grad attribute to True."
         )
 
     return ArrayBox(x, *args)

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -462,7 +462,7 @@ class Operator(abc.ABC):
         self.queue_idx = None  #: int, None: index of the Operator in the circuit queue, or None if not in a queue
 
         if wires is None:
-            raise ValueError("Must specify the wires that {} acts on".format(self.name))
+            raise ValueError(f"Must specify the wires that {self.name} acts on")
 
         self._num_params = len(params)
         # Check if the expected number of parameters coincides with the one received.
@@ -470,8 +470,8 @@ class Operator(abc.ABC):
         # subclasses may overwrite it to define a fixed expected value.
         if len(params) != self.num_params:
             raise ValueError(
-                "{}: wrong number of parameters. "
-                "{} parameters passed, {} expected.".format(self.name, len(params), self.num_params)
+                f"{self.name}: wrong number of parameters. "
+                f"{len(params)} parameters passed, {self.num_params} expected."
             )
 
         if isinstance(wires, Wires):
@@ -486,8 +486,8 @@ class Operator(abc.ABC):
             and len(self._wires) != self.num_wires
         ):
             raise ValueError(
-                "{}: wrong number of wires. "
-                "{} wires given, {} expected.".format(self.name, len(self._wires), self.num_wires)
+                f"{self.name}: wrong number of wires. "
+                f"{len(self._wires)} wires given, {self.num_wires} expected."
             )
 
         self.data = list(params)  #: list[Any]: parameters of the operator
@@ -499,8 +499,8 @@ class Operator(abc.ABC):
         """Constructor-call-like representation."""
         if self.parameters:
             params = ", ".join([repr(p) for p in self.parameters])
-            return "{}({}, wires={})".format(self.name, params, self.wires.tolist())
-        return "{}(wires={})".format(self.name, self.wires.tolist())
+            return f"{self.name}({params}, wires={self.wires.tolist()})"
+        return f"{self.name}(wires={self.wires.tolist()})"
 
     @property
     def num_params(self):
@@ -1002,7 +1002,7 @@ class Observable(Operator):
             return temp
 
         if self.return_type is Probability:
-            return repr(self.return_type) + "(wires={})".format(self.wires.tolist())
+            return repr(self.return_type) + f"(wires={self.wires.tolist()})"
 
         return repr(self.return_type) + "(" + temp + ")"
 
@@ -1210,7 +1210,7 @@ class Tensor(Observable):
             return s
 
         if self.return_type is Probability:
-            return repr(self.return_type) + "(wires={})".format(self.wires.tolist())
+            return repr(self.return_type) + f"(wires={self.wires.tolist()})"
 
         return repr(self.return_type) + "(" + s + ")"
 
@@ -1476,8 +1476,8 @@ class Tensor(Observable):
             if len(o.wires) > 1:
                 # todo: deal with multi-qubit operations that do not act on consecutive qubits
                 raise ValueError(
-                    "Can only compute sparse representation for tensors whose operations "
-                    "act on consecutive wires; got {}.".format(o)
+                    f"Can only compute sparse representation for tensors whose operations "
+                    f"act on consecutive wires; got {o}."
                 )
             # store the single-qubit ops according to the order of their wires
             idx = wires.index(o.wires)
@@ -1561,7 +1561,7 @@ class CV:
             raise ValueError("Only order-1 and order-2 arrays supported.")
 
         if U_dim != 1 + 2 * nw:
-            raise ValueError("{}: Heisenberg matrix is the wrong size {}.".format(self.name, U_dim))
+            raise ValueError(f"{self.name}: Heisenberg matrix is the wrong size {U_dim}.")
 
         if len(wires) == 0 or len(self.wires) == len(wires):
             # no expansion necessary (U is a full-system matrix in the correct order)
@@ -1569,9 +1569,7 @@ class CV:
 
         if not wires.contains_wires(self.wires):
             raise ValueError(
-                "{}: Some observable wires {} do not exist on this device with wires {}".format(
-                    self.name, self.wires, wires
-                )
+                f"{self.name}: Some observable wires {self.wires} do not exist on this device with wires {wires}"
             )
 
         # get the indices that the operation's wires have on the device
@@ -1745,9 +1743,7 @@ class CVOperation(CV, Operation):
         # not defined?
         if U is None:
             raise RuntimeError(
-                "{} is not a Gaussian operation, or is missing the _heisenberg_rep method.".format(
-                    self.name
-                )
+                f"{self.name} is not a Gaussian operation, or is missing the _heisenberg_rep method."
             )
 
         return self.heisenberg_expand(U, wires)

--- a/pennylane/ops/qubit/hamiltonian.py
+++ b/pennylane/ops/qubit/hamiltonian.py
@@ -295,8 +295,8 @@ class Hamiltonian(Observable):
             or any(i not in range(len(self.ops)) for i in [i for sl in value for i in sl])
         ):
             raise ValueError(
-                "The grouped index value needs to be a list of lists of integers between 0 and the "
-                "number of observables in the Hamiltonian; got {}".format(value)
+                f"The grouped index value needs to be a list of lists of integers between 0 and the "
+                f"number of observables in the Hamiltonian; got {value}"
             )
         self._grouping_indices = value
 

--- a/pennylane/optimize/rotoselect.py
+++ b/pennylane/optimize/rotoselect.py
@@ -141,7 +141,7 @@ class RotoselectOptimizer:
             assert len(x_flat) == len(generators)
         except AssertionError as e:
             raise ValueError(
-                "Number of parameters {} must be equal to the number of generators.".format(x)
+                f"Number of parameters {x} must be equal to the number of generators."
             ) from e
 
         for d, _ in enumerate(x_flat):

--- a/pennylane/qaoa/cost.py
+++ b/pennylane/qaoa/cost.py
@@ -59,7 +59,7 @@ def bit_driver(wires, b):
     elif b == 1:
         coeffs = [1 for _ in wires]
     else:
-        raise ValueError("'b' must be either 0 or 1, got {}".format(b))
+        raise ValueError(f"'b' must be either 0 or 1, got {b}")
 
     ops = [qml.PauliZ(w) for w in wires]
     return qml.Hamiltonian(coeffs, ops)
@@ -160,7 +160,7 @@ def edge_driver(graph, reward):
         )
 
     if not isinstance(graph, nx.Graph):
-        raise ValueError("Input graph must be a nx.Graph, got {}".format(type(graph).__name__))
+        raise ValueError(f"Input graph must be a nx.Graph, got {type(graph).__name__}")
 
     coeffs = []
     ops = []
@@ -251,7 +251,7 @@ def maxcut(graph):
     """
 
     if not isinstance(graph, nx.Graph):
-        raise ValueError("Input graph must be a nx.Graph, got {}".format(type(graph).__name__))
+        raise ValueError(f"Input graph must be a nx.Graph, got {type(graph).__name__}")
 
     identity_h = qml.Hamiltonian(
         [-0.5 for e in graph.edges], [qml.Identity(e[0]) @ qml.Identity(e[1]) for e in graph.edges]
@@ -320,7 +320,7 @@ def max_independent_set(graph, constrained=True):
     """
 
     if not isinstance(graph, nx.Graph):
-        raise ValueError("Input graph must be a nx.Graph, got {}".format(type(graph).__name__))
+        raise ValueError(f"Input graph must be a nx.Graph, got {type(graph).__name__}")
 
     if constrained:
         cost_h = bit_driver(graph.nodes, 1)
@@ -396,7 +396,7 @@ def min_vertex_cover(graph, constrained=True):
     """
 
     if not isinstance(graph, nx.Graph):
-        raise ValueError("Input graph must be a nx.Graph, got {}".format(type(graph).__name__))
+        raise ValueError(f"Input graph must be a nx.Graph, got {type(graph).__name__}")
 
     if constrained:
         cost_h = bit_driver(graph.nodes, 0)
@@ -474,7 +474,7 @@ def max_clique(graph, constrained=True):
     """
 
     if not isinstance(graph, nx.Graph):
-        raise ValueError("Input graph must be a nx.Graph, got {}".format(type(graph).__name__))
+        raise ValueError(f"Input graph must be a nx.Graph, got {type(graph).__name__}")
 
     if constrained:
         cost_h = bit_driver(graph.nodes, 1)
@@ -626,7 +626,7 @@ def max_weight_cycle(graph, constrained=True):
         ``0`` and ``3`` wires.
     """
     if not isinstance(graph, nx.Graph):
-        raise ValueError("Input graph must be a nx.Graph, got {}".format(type(graph).__name__))
+        raise ValueError(f"Input graph must be a nx.Graph, got {type(graph).__name__}")
 
     mapping = qaoa.cycle.wires_to_edges(graph)
 

--- a/pennylane/qaoa/layers.py
+++ b/pennylane/qaoa/layers.py
@@ -92,9 +92,7 @@ def cost_layer(gamma, hamiltonian):
     """
     if not isinstance(hamiltonian, qml.Hamiltonian):
         raise ValueError(
-            "hamiltonian must be of type pennylane.Hamiltonian, got {}".format(
-                type(hamiltonian).__name__
-            )
+            f"hamiltonian must be of type pennylane.Hamiltonian, got {type(hamiltonian).__name__}"
         )
 
     if not _diagonal_terms(hamiltonian):
@@ -152,9 +150,7 @@ def mixer_layer(alpha, hamiltonian):
     """
     if not isinstance(hamiltonian, qml.Hamiltonian):
         raise ValueError(
-            "hamiltonian must be of type pennylane.Hamiltonian, got {}".format(
-                type(hamiltonian).__name__
-            )
+            f"hamiltonian must be of type pennylane.Hamiltonian, got {type(hamiltonian).__name__}"
         )
 
     qml.templates.ApproxTimeEvolution(hamiltonian, alpha, 1)

--- a/pennylane/qaoa/mixers.py
+++ b/pennylane/qaoa/mixers.py
@@ -100,9 +100,7 @@ def xy_mixer(graph):
     """
 
     if not isinstance(graph, nx.Graph):
-        raise ValueError(
-            f"Input graph must be a nx.Graph object, got {type(graph).__name__}"
-        )
+        raise ValueError(f"Input graph must be a nx.Graph object, got {type(graph).__name__}")
 
     edges = graph.edges
     coeffs = 2 * [0.5 for e in edges]
@@ -162,9 +160,7 @@ def bit_flip_mixer(graph, b):
     """
 
     if not isinstance(graph, nx.Graph):
-        raise ValueError(
-            f"Input graph must be a nx.Graph object, got {type(graph).__name__}"
-        )
+        raise ValueError(f"Input graph must be a nx.Graph object, got {type(graph).__name__}")
 
     if b not in [0, 1]:
         raise ValueError(f"'b' must be either 0 or 1, got {b}")

--- a/pennylane/qaoa/mixers.py
+++ b/pennylane/qaoa/mixers.py
@@ -101,7 +101,7 @@ def xy_mixer(graph):
 
     if not isinstance(graph, nx.Graph):
         raise ValueError(
-            "Input graph must be a nx.Graph object, got {}".format(type(graph).__name__)
+            f"Input graph must be a nx.Graph object, got {type(graph).__name__}"
         )
 
     edges = graph.edges
@@ -163,11 +163,11 @@ def bit_flip_mixer(graph, b):
 
     if not isinstance(graph, nx.Graph):
         raise ValueError(
-            "Input graph must be a nx.Graph object, got {}".format(type(graph).__name__)
+            f"Input graph must be a nx.Graph object, got {type(graph).__name__}"
         )
 
     if b not in [0, 1]:
-        raise ValueError("'b' must be either 0 or 1, got {}".format(b))
+        raise ValueError(f"'b' must be either 0 or 1, got {b}")
 
     sign = 1 if b == 0 else -1
 

--- a/pennylane/qnn/keras.py
+++ b/pennylane/qnn/keras.py
@@ -242,15 +242,13 @@ class KerasLayer(Layer):
 
         if self.input_arg not in sig:
             raise TypeError(
-                "QNode must include an argument with name {} for inputting data".format(
-                    self.input_arg
-                )
+                f"QNode must include an argument with name {self.input_arg} for inputting data"
             )
 
         if self.input_arg in set(weight_shapes.keys()):
             raise ValueError(
-                "{} argument should not have its dimension specified in "
-                "weight_shapes".format(self.input_arg)
+                f"{self.input_arg} argument should not have its dimension specified in "
+                f"weight_shapes"
             )
 
         param_kinds = [p.kind for p in sig.values()]

--- a/pennylane/qnn/torch.py
+++ b/pennylane/qnn/torch.py
@@ -240,15 +240,13 @@ class TorchLayer(Module):
 
         if self.input_arg not in sig:
             raise TypeError(
-                "QNode must include an argument with name {} for inputting data".format(
-                    self.input_arg
-                )
+                f"QNode must include an argument with name {self.input_arg} for inputting data"
             )
 
         if self.input_arg in set(weight_shapes.keys()):
             raise ValueError(
-                "{} argument should not have its dimension specified in "
-                "weight_shapes".format(self.input_arg)
+                f"{self.input_arg} argument should not have its dimension specified in "
+                f"weight_shapes"
             )
 
         param_kinds = [p.kind for p in sig.values()]

--- a/pennylane/qnode.py
+++ b/pennylane/qnode.py
@@ -518,7 +518,7 @@ class QNode:
                 # check here only if enough wires
                 if len(obj.wires) != self.device.num_wires:
                     raise qml.QuantumFunctionError(
-                        "Operator {} must act on all wires".format(obj.name)
+                        f"Operator {obj.name} must act on all wires"
                     )
 
             if isinstance(obj, qml.ops.qubit.SparseHamiltonian) and self.gradient_fn == "backprop":

--- a/pennylane/qnode.py
+++ b/pennylane/qnode.py
@@ -517,9 +517,7 @@ class QNode:
             if getattr(obj, "num_wires", None) is qml.operation.WiresEnum.AllWires:
                 # check here only if enough wires
                 if len(obj.wires) != self.device.num_wires:
-                    raise qml.QuantumFunctionError(
-                        f"Operator {obj.name} must act on all wires"
-                    )
+                    raise qml.QuantumFunctionError(f"Operator {obj.name} must act on all wires")
 
             if isinstance(obj, qml.ops.qubit.SparseHamiltonian) and self.gradient_fn == "backprop":
                 raise qml.QuantumFunctionError(

--- a/pennylane/qnode_old.py
+++ b/pennylane/qnode_old.py
@@ -621,9 +621,7 @@ class QNode:
             if getattr(obj, "num_wires", None) is qml.operation.WiresEnum.AllWires:
                 # check here only if enough wires
                 if len(obj.wires) != self.device.num_wires:
-                    raise qml.QuantumFunctionError(
-                        f"Operator {obj.name} must act on all wires"
-                    )
+                    raise qml.QuantumFunctionError(f"Operator {obj.name} must act on all wires")
 
             if (
                 isinstance(obj, qml.ops.qubit.SparseHamiltonian)

--- a/pennylane/qnode_old.py
+++ b/pennylane/qnode_old.py
@@ -622,7 +622,7 @@ class QNode:
                 # check here only if enough wires
                 if len(obj.wires) != self.device.num_wires:
                     raise qml.QuantumFunctionError(
-                        "Operator {} must act on all wires".format(obj.name)
+                        f"Operator {obj.name} must act on all wires"
                     )
 
             if (

--- a/pennylane/tape/reversible.py
+++ b/pennylane/tape/reversible.py
@@ -115,11 +115,7 @@ class ReversibleTape(JacobianTape):
             vec1_indices,
         )
 
-        einsum_str = "{vec1_indices},{obs_indices},{vec2_indices}->".format(
-            vec1_indices=vec1_indices,
-            obs_indices=obs_indices,
-            vec2_indices=vec2_indices,
-        )
+        einsum_str = f"{vec1_indices},{obs_indices},{vec2_indices}->"
 
         return np.einsum(einsum_str, np.conj(vec1), mat, vec2)
 
@@ -172,8 +168,8 @@ class ReversibleTape(JacobianTape):
 
         if op.name not in ["RX", "RY", "RZ", "Rot"]:
             raise ValueError(
-                "The {} gate is not currently supported with the "
-                "reversible gradient method.".format(op.name)
+                f"The {op.name} gate is not currently supported with the "
+                f"reversible gradient method."
             )
 
         # get the stored final state of the original circuit, which we start from here

--- a/pennylane/templates/broadcast.py
+++ b/pennylane/templates/broadcast.py
@@ -107,7 +107,7 @@ def _preprocess(parameters, pattern, wires):
     if isinstance(pattern, str):
         _wires = wires
         if pattern not in OPTIONS:
-            raise ValueError(f"did not recognize pattern {pattern}".format())
+            raise ValueError(f"did not recognize pattern {pattern}")
     else:
         # turn custom pattern into list of Wires objects
         _wires = [Wires(w) for w in pattern]
@@ -131,9 +131,7 @@ def _preprocess(parameters, pattern, wires):
         num_params = PATTERN_TO_NUM_PARAMS[pattern](_wires)
         if shape[0] != num_params:
             raise ValueError(
-                "Parameters must contain entries for {} unitaries; got {} entries".format(
-                    num_params, shape[0]
-                )
+                f"Parameters must contain entries for {num_params} unitaries; got {shape[0]} entries"
             )
 
     wire_sequence = PATTERN_TO_WIRES[pattern](_wires)

--- a/pennylane/templates/layer.py
+++ b/pennylane/templates/layer.py
@@ -32,9 +32,7 @@ def _preprocess(args, depth):
 
         if shape(arg)[0] != depth:
             raise ValueError(
-                "Each positional argument must have length matching 'depth'; expected {} got {}".format(
-                    depth, len(arg)
-                )
+                f"Each positional argument must have length matching 'depth'; expected {depth} got {len(arg)}"
             )
 
 

--- a/pennylane/templates/layers/particle_conserving_u1.py
+++ b/pennylane/templates/layers/particle_conserving_u1.py
@@ -234,8 +234,8 @@ class ParticleConservingU1(Operation):
 
         if len(wires) < 2:
             raise ValueError(
-                "Expected the number of qubits to be greater than one; "
-                "got wires {}".format(wires)
+                f"Expected the number of qubits to be greater than one; "
+                f"got wires {wires}"
             )
 
         shape = qml.math.shape(weights)
@@ -295,6 +295,6 @@ class ParticleConservingU1(Operation):
 
         if n_wires < 2:
             raise ValueError(
-                "The number of qubits must be greater than one; got 'n_wires' = {}".format(n_wires)
+                f"The number of qubits must be greater than one; got 'n_wires' = {n_wires}"
             )
         return n_layers, n_wires - 1, 2

--- a/pennylane/templates/layers/particle_conserving_u1.py
+++ b/pennylane/templates/layers/particle_conserving_u1.py
@@ -234,8 +234,7 @@ class ParticleConservingU1(Operation):
 
         if len(wires) < 2:
             raise ValueError(
-                f"Expected the number of qubits to be greater than one; "
-                f"got wires {wires}"
+                f"Expected the number of qubits to be greater than one; " f"got wires {wires}"
             )
 
         shape = qml.math.shape(weights)

--- a/pennylane/templates/layers/particle_conserving_u2.py
+++ b/pennylane/templates/layers/particle_conserving_u2.py
@@ -155,8 +155,8 @@ class ParticleConservingU2(Operation):
 
         if len(wires) < 2:
             raise ValueError(
-                "This template requires the number of qubits to be greater than one;"
-                "got a wire sequence with {} elements".format(len(wires))
+                f"This template requires the number of qubits to be greater than one;"
+                f"got a wire sequence with {len(wires)} elements"
             )
 
         shape = qml.math.shape(weights)
@@ -212,6 +212,6 @@ class ParticleConservingU2(Operation):
 
         if n_wires < 2:
             raise ValueError(
-                "The number of qubits must be greater than one; got 'n_wires' = {}".format(n_wires)
+                f"The number of qubits must be greater than one; got 'n_wires' = {n_wires}"
             )
         return n_layers, 2 * n_wires - 1

--- a/pennylane/templates/subroutines/all_singles_doubles.py
+++ b/pennylane/templates/subroutines/all_singles_doubles.py
@@ -120,27 +120,21 @@ class AllSinglesDoubles(Operation):
 
         if len(wires) < 2:
             raise ValueError(
-                "The number of qubits (wires) can not be less than 2; got len(wires) = {}".format(
-                    len(wires)
-                )
+                f"The number of qubits (wires) can not be less than 2; got len(wires) = {len(wires)}"
             )
 
         if doubles is not None:
             for d_wires in doubles:
                 if len(d_wires) != 4:
                     raise ValueError(
-                        "Expected entries of 'doubles' to be of size 4; got {} of length {}".format(
-                            d_wires, len(d_wires)
-                        )
+                        f"Expected entries of 'doubles' to be of size 4; got {d_wires} of length {len(d_wires)}"
                     )
 
         if singles is not None:
             for s_wires in singles:
                 if len(s_wires) != 2:
                     raise ValueError(
-                        "Expected entries of 'singles' to be of size 2; got {} of length {}".format(
-                            s_wires, len(s_wires)
-                        )
+                        f"Expected entries of 'singles' to be of size 2; got {s_wires} of length {len(s_wires)}"
                     )
 
         weights_shape = qml.math.shape(weights)
@@ -194,8 +188,8 @@ class AllSinglesDoubles(Operation):
         if singles is None or not singles:
             if doubles is None or not doubles:
                 raise ValueError(
-                    "'singles' and 'doubles' lists can not be both empty;"
-                    " got singles = {}, doubles = {}".format(singles, doubles)
+                    f"'singles' and 'doubles' lists can not be both empty;"
+                    f" got singles = {singles}, doubles = {doubles}"
                 )
             if doubles is not None:
                 shape_ = (len(doubles),)

--- a/pennylane/templates/subroutines/approx_time_evolution.py
+++ b/pennylane/templates/subroutines/approx_time_evolution.py
@@ -143,7 +143,7 @@ class ApproxTimeEvolution(Operation):
 
             except KeyError as error:
                 raise ValueError(
-                    "hamiltonian must be written in terms of Pauli matrices, got {}".format(error)
+                    f"hamiltonian must be written in terms of Pauli matrices, got {error}"
                 ) from error
 
             # skips terms composed solely of identities

--- a/pennylane/templates/subroutines/fermionic_double_excitation.py
+++ b/pennylane/templates/subroutines/fermionic_double_excitation.py
@@ -491,13 +491,13 @@ class FermionicDoubleExcitation(Operation):
 
         if len(wires1) < 2:
             raise ValueError(
-                "expected at least two wires representing the occupied orbitals; "
-                "got {}".format(len(wires1))
+                f"expected at least two wires representing the occupied orbitals; "
+                f"got {len(wires1)}"
             )
         if len(wires2) < 2:
             raise ValueError(
-                "expected at least two wires representing the unoccupied orbitals; "
-                "got {}".format(len(wires2))
+                f"expected at least two wires representing the unoccupied orbitals; "
+                f"got {len(wires2)}"
             )
 
         shape = qml.math.shape(weight)

--- a/pennylane/templates/subroutines/fermionic_single_excitation.py
+++ b/pennylane/templates/subroutines/fermionic_single_excitation.py
@@ -128,7 +128,7 @@ class FermionicSingleExcitation(Operation):
 
     def __init__(self, weight, wires=None, do_queue=True, id=None):
         if len(wires) < 2:
-            raise ValueError("expected at least two wires; got {}".format(len(wires)))
+            raise ValueError(f"expected at least two wires; got {len(wires)}")
 
         shape = qml.math.shape(weight)
         if shape != ():

--- a/pennylane/templates/subroutines/uccsd.py
+++ b/pennylane/templates/subroutines/uccsd.py
@@ -147,17 +147,13 @@ class UCCSD(Operation):
 
         if (not s_wires) and (not d_wires):
             raise ValueError(
-                "s_wires and d_wires lists can not be both empty; got ph={}, pphh={}".format(
-                    s_wires, d_wires
-                )
+                f"s_wires and d_wires lists can not be both empty; got ph={s_wires}, pphh={d_wires}"
             )
 
         for d_wires_ in d_wires:
             if len(d_wires_) != 2:
                 raise ValueError(
-                    "expected entries of d_wires to be of size 2; got {} of length {}".format(
-                        d_wires_, len(d_wires_)
-                    )
+                    f"expected entries of d_wires to be of size 2; got {d_wires_} of length {len(d_wires_)}"
                 )
 
         shape = qml.math.shape(weights)

--- a/pennylane/templates/utils.py
+++ b/pennylane/templates/utils.py
@@ -38,9 +38,7 @@ def check_wires(wires):
     if isinstance(wires, int):
         wires = [wires]
 
-    msg = "wires must be a positive integer or a " "list of positive integers; got {}.".format(
-        wires
-    )
+    msg = f"wires must be a positive integer or a list of positive integers; got {wires}."
     if not isinstance(wires, Iterable):
         raise ValueError(msg)
     if not all([isinstance(w, int) for w in wires]):
@@ -73,7 +71,7 @@ def get_shape(inpt):
             shape = inpt.shape
         except AttributeError as e:
             raise ValueError(
-                "could not extract shape of object of type {}".format(type(inpt))
+                f"could not extract shape of object of type {type(inpt)}"
             ) from e
 
         # turn result into tuple to avoid type TensorShape
@@ -193,8 +191,8 @@ def check_number_of_layers(list_of_weights):
 
     if n_different_first_dims > 1:
         raise ValueError(
-            "The first dimension of all parameters needs to be the number of layers in the "
-            "template; got differing first dimensions: {}.".format(*different_first_dims)
+            f"The first dimension of all parameters needs to be the number of layers in the "
+            f"template; got differing first dimensions: {*different_first_dims}."
         )
 
     return first_dimensions[0]

--- a/pennylane/templates/utils.py
+++ b/pennylane/templates/utils.py
@@ -70,9 +70,7 @@ def get_shape(inpt):
         try:
             shape = inpt.shape
         except AttributeError as e:
-            raise ValueError(
-                f"could not extract shape of object of type {type(inpt)}"
-            ) from e
+            raise ValueError(f"could not extract shape of object of type {type(inpt)}") from e
 
         # turn result into tuple to avoid type TensorShape
         shape = tuple(shape)

--- a/pennylane/templates/utils.py
+++ b/pennylane/templates/utils.py
@@ -192,7 +192,7 @@ def check_number_of_layers(list_of_weights):
     if n_different_first_dims > 1:
         raise ValueError(
             f"The first dimension of all parameters needs to be the number of layers in the "
-            f"template; got differing first dimensions: {*different_first_dims}."
+            f"template; got differing first dimensions: {different_first_dims}."
         )
 
     return first_dimensions[0]

--- a/pennylane/utils.py
+++ b/pennylane/utils.py
@@ -158,8 +158,8 @@ def sparse_hamiltonian(H, wires=None):
             if len(o.wires) > 1:
                 # todo: deal with operations created from multi-qubit operations such as Hermitian
                 raise ValueError(
-                    "Can only sparsify Hamiltonians whose constituent observables consist of "
-                    "(tensor products of) single-qubit operators; got {}.".format(op)
+                    f"Can only sparsify Hamiltonians whose constituent observables consist of "
+                    f"(tensor products of) single-qubit operators; got {op}."
                 )
             obs.append(scipy.sparse.coo_matrix(o.matrix))
 
@@ -231,7 +231,7 @@ def _unflatten(flat, model):
             res.append(val)
         return res, flat
 
-    raise TypeError("Unsupported type in the model: {}".format(type(model)))
+    raise TypeError(f"Unsupported type in the model: {type(model)}")
 
 
 def unflatten(flat, model):

--- a/pennylane/wires.py
+++ b/pennylane/wires.py
@@ -58,7 +58,7 @@ def _process(wires):
             # if object is not hashable, cannot identify unique wires
             if str(e).startswith("unhashable"):
                 raise WireError(
-                    "Wires must be hashable; got object of type {}.".format(type(wires))
+                    f"Wires must be hashable; got object of type {type(wires)}."
                 ) from e
         return (wires,)
 
@@ -68,10 +68,10 @@ def _process(wires):
         set_of_wires = set(wires)
     except TypeError as e:
         if str(e).startswith("unhashable"):
-            raise WireError("Wires must be hashable; got {}.".format(wires)) from e
+            raise WireError(f"Wires must be hashable; got {wires}.") from e
 
     if len(set_of_wires) != len(tuple_of_wires):
-        raise WireError("Wires must be unique; got {}.".format(wires))
+        raise WireError(f"Wires must be unique; got {wires}.")
 
     return tuple_of_wires
 
@@ -122,7 +122,7 @@ class Wires(Sequence):
 
     def __repr__(self):
         """Method defining the string representation of this class."""
-        return "<Wires = {}>".format(list(self._labels))
+        return f"<Wires = {list(self._labels)}>"
 
     def __eq__(self, other):
         """Method to support the '==' operator. This will also implicitly define the '!=' operator."""
@@ -225,7 +225,7 @@ class Wires(Sequence):
         try:
             return self._labels.index(wire)
         except ValueError as e:
-            raise WireError("Wire with label {} not found in {}.".format(wire, self)) from e
+            raise WireError(f"Wire with label {wire} not found in {self}.") from e
 
     def indices(self, wires):
         """
@@ -269,7 +269,7 @@ class Wires(Sequence):
         for w in self:
             if w not in wire_map:
                 raise WireError(
-                    "No mapping for wire label {} specified in wire map {}.".format(w, wire_map)
+                    f"No mapping for wire label {w} specified in wire map {wire_map}."
                 )
 
         new_wires = [wire_map[w] for w in self]
@@ -278,8 +278,8 @@ class Wires(Sequence):
             new_wires = Wires(new_wires)
         except WireError as e:
             raise WireError(
-                "Failed to implement wire map {}. Make sure that the new labels are unique and "
-                "valid wire labels.".format(wire_map)
+                f"Failed to implement wire map {wire_map}. Make sure that the new labels "
+                f"are unique and valid wire labels."
             ) from e
 
         return new_wires
@@ -324,7 +324,7 @@ class Wires(Sequence):
         for i in indices:
             if i > len(self._labels):
                 raise WireError(
-                    "Cannot subset wire at index {} from {} wires.".format(i, len(self._labels))
+                    f"Cannot subset wire at index {i} from {len(self._labels)} wires."
                 )
 
         subset = tuple(self._labels[i] for i in indices)
@@ -344,7 +344,7 @@ class Wires(Sequence):
 
         if n_samples > len(self._labels):
             raise WireError(
-                "Cannot sample {} wires from {} wires.".format(n_samples, len(self._labels))
+                f"Cannot sample {n_samples} wires from {len(self._labels)} wires."
             )
 
         if seed is not None:
@@ -380,7 +380,7 @@ class Wires(Sequence):
         for wires in list_of_wires:
             if not isinstance(wires, Wires):
                 raise WireError(
-                    "Expected a Wires object; got {} of type {}.".format(wires, type(wires))
+                    f"Expected a Wires object; got {wires} of type {type(wires)}."
                 )
 
         first_wires_obj = list_of_wires[0]
@@ -424,7 +424,7 @@ class Wires(Sequence):
         for wires in list_of_wires:
             if not isinstance(wires, Wires):
                 raise WireError(
-                    "Expected a Wires object; got {} of type {}".format(wires, type(wires))
+                    f"Expected a Wires object; got {wires} of type {type(wires)}"
                 )
 
             extension = [label for label in wires.labels if label not in seen_labels]
@@ -461,7 +461,7 @@ class Wires(Sequence):
         for wires in list_of_wires:
             if not isinstance(wires, Wires):
                 raise WireError(
-                    "Expected a Wires object; got {} of type {}.".format(wires, type(wires))
+                    f"Expected a Wires object; got {wires} of type {type(wires)}."
                 )
 
         label_sets = [wire.toset() for wire in list_of_wires]

--- a/pennylane/wires.py
+++ b/pennylane/wires.py
@@ -57,9 +57,7 @@ def _process(wires):
         except TypeError as e:
             # if object is not hashable, cannot identify unique wires
             if str(e).startswith("unhashable"):
-                raise WireError(
-                    f"Wires must be hashable; got object of type {type(wires)}."
-                ) from e
+                raise WireError(f"Wires must be hashable; got object of type {type(wires)}.") from e
         return (wires,)
 
     try:
@@ -268,9 +266,7 @@ class Wires(Sequence):
 
         for w in self:
             if w not in wire_map:
-                raise WireError(
-                    f"No mapping for wire label {w} specified in wire map {wire_map}."
-                )
+                raise WireError(f"No mapping for wire label {w} specified in wire map {wire_map}.")
 
         new_wires = [wire_map[w] for w in self]
 
@@ -323,9 +319,7 @@ class Wires(Sequence):
 
         for i in indices:
             if i > len(self._labels):
-                raise WireError(
-                    f"Cannot subset wire at index {i} from {len(self._labels)} wires."
-                )
+                raise WireError(f"Cannot subset wire at index {i} from {len(self._labels)} wires.")
 
         subset = tuple(self._labels[i] for i in indices)
         return Wires(subset, _override=True)
@@ -343,9 +337,7 @@ class Wires(Sequence):
         """
 
         if n_samples > len(self._labels):
-            raise WireError(
-                f"Cannot sample {n_samples} wires from {len(self._labels)} wires."
-            )
+            raise WireError(f"Cannot sample {n_samples} wires from {len(self._labels)} wires.")
 
         if seed is not None:
             np.random.seed(seed)
@@ -379,9 +371,7 @@ class Wires(Sequence):
 
         for wires in list_of_wires:
             if not isinstance(wires, Wires):
-                raise WireError(
-                    f"Expected a Wires object; got {wires} of type {type(wires)}."
-                )
+                raise WireError(f"Expected a Wires object; got {wires} of type {type(wires)}.")
 
         first_wires_obj = list_of_wires[0]
         sets_of_wires = [wire.toset() for wire in list_of_wires]
@@ -423,9 +413,7 @@ class Wires(Sequence):
         seen_labels = set()
         for wires in list_of_wires:
             if not isinstance(wires, Wires):
-                raise WireError(
-                    f"Expected a Wires object; got {wires} of type {type(wires)}"
-                )
+                raise WireError(f"Expected a Wires object; got {wires} of type {type(wires)}")
 
             extension = [label for label in wires.labels if label not in seen_labels]
             combined.extend(extension)
@@ -460,9 +448,7 @@ class Wires(Sequence):
 
         for wires in list_of_wires:
             if not isinstance(wires, Wires):
-                raise WireError(
-                    f"Expected a Wires object; got {wires} of type {type(wires)}."
-                )
+                raise WireError(f"Expected a Wires object; got {wires} of type {type(wires)}.")
 
         label_sets = [wire.toset() for wire in list_of_wires]
         seen_ever = set()

--- a/qchem/pennylane_qchem/qchem/obs.py
+++ b/qchem/pennylane_qchem/qchem/obs.py
@@ -193,12 +193,12 @@ def spin2(electrons, orbitals, mapping="jordan_wigner", wires=None):
 
     if electrons <= 0:
         raise ValueError(
-            "'electrons' must be greater than 0; got for 'electrons' {}".format(electrons)
+            f"'electrons' must be greater than 0; got for 'electrons' {electrons}"
         )
 
     if orbitals <= 0:
         raise ValueError(
-            "'orbitals' must be greater than 0; got for 'orbitals' {}".format(orbitals)
+            f"'orbitals' must be greater than 0; got for 'orbitals' {orbitals}"
         )
 
     sz = np.where(np.arange(orbitals) % 2 == 0, 0.5, -0.5)
@@ -296,8 +296,8 @@ def observable(fermion_ops, init_term=0, mapping="jordan_wigner", wires=None):
 
     if mapping.strip().lower() not in ("jordan_wigner", "bravyi_kitaev"):
         raise TypeError(
-            "The '{}' transformation is not available. \n "
-            "Please set 'mapping' to 'jordan_wigner' or 'bravyi_kitaev'.".format(mapping)
+            f"The '{mapping}' transformation is not available. \n "
+            f"Please set 'mapping' to 'jordan_wigner' or 'bravyi_kitaev'."
         )
 
     # Initialize the FermionOperator
@@ -305,9 +305,7 @@ def observable(fermion_ops, init_term=0, mapping="jordan_wigner", wires=None):
     for ops in fermion_ops:
         if not isinstance(ops, openfermion.ops.FermionOperator):
             raise TypeError(
-                "Elements in the lists are expected to be of type 'FermionOperator'; got {}".format(
-                    type(ops)
-                )
+                f"Elements in the lists are expected to be of type 'FermionOperator'; got {type(ops)}"
             )
         mb_obs += ops
 
@@ -363,7 +361,7 @@ def spin_z(orbitals, mapping="jordan_wigner", wires=None):
 
     if orbitals <= 0:
         raise ValueError(
-            "'orbitals' must be greater than 0; got for 'orbitals' {}".format(orbitals)
+            f"'orbitals' must be greater than 0; got for 'orbitals' {orbitals}"
         )
 
     r = np.arange(orbitals)
@@ -427,7 +425,7 @@ def particle_number(orbitals, mapping="jordan_wigner", wires=None):
 
     if orbitals <= 0:
         raise ValueError(
-            "'orbitals' must be greater than 0; got for 'orbitals' {}".format(orbitals)
+            f"'orbitals' must be greater than 0; got for 'orbitals' {orbitals}"
         )
 
     r = np.arange(orbitals)
@@ -502,9 +500,7 @@ def one_particle(matrix_elements, core=None, active=None, cutoff=1.0e-12):
 
     if matrix_elements.ndim != 2:
         raise ValueError(
-            "'matrix_elements' must be a 2D array; got matrix_elements.ndim = {}".format(
-                matrix_elements.ndim
-            )
+            f"'matrix_elements' must be a 2D array; got matrix_elements.ndim = {matrix_elements.ndim}"
         )
 
     if not core:
@@ -512,9 +508,7 @@ def one_particle(matrix_elements, core=None, active=None, cutoff=1.0e-12):
     else:
         if any(i > orbitals - 1 or i < 0 for i in core):
             raise ValueError(
-                "Indices of core orbitals must be between 0 and {}; got core = {}".format(
-                    orbitals - 1, core
-                )
+                f"Indices of core orbitals must be between 0 and {orbitals - 1}; got core = {core}"
             )
 
         # Compute contribution due to core orbitals
@@ -528,9 +522,7 @@ def one_particle(matrix_elements, core=None, active=None, cutoff=1.0e-12):
 
     if any(i > orbitals - 1 or i < 0 for i in active):
         raise ValueError(
-            "Indices of active orbitals must be between 0 and {}; got active = {}".format(
-                orbitals - 1, active
-            )
+            f"Indices of active orbitals must be between 0 and {orbitals - 1}; got active = {active}"
         )
 
     # Indices of the matrix elements with absolute values >= cutoff
@@ -673,9 +665,7 @@ def two_particle(matrix_elements, core=None, active=None, cutoff=1.0e-12):
 
     if matrix_elements.ndim != 4:
         raise ValueError(
-            "'matrix_elements' must be a 4D array; got 'matrix_elements.ndim = ' {}".format(
-                matrix_elements.ndim
-            )
+            f"'matrix_elements' must be a 4D array; got 'matrix_elements.ndim = ' {matrix_elements.ndim}"
         )
 
     if not core:
@@ -683,9 +673,7 @@ def two_particle(matrix_elements, core=None, active=None, cutoff=1.0e-12):
     else:
         if any(i > orbitals - 1 or i < 0 for i in core):
             raise ValueError(
-                "Indices of core orbitals must be between 0 and {}; got core = {}".format(
-                    orbitals - 1, core
-                )
+                f"Indices of core orbitals must be between 0 and {orbitals - 1}; got core = {core}"
             )
 
         # Compute the contribution of core orbitals
@@ -706,9 +694,7 @@ def two_particle(matrix_elements, core=None, active=None, cutoff=1.0e-12):
 
     if any(i > orbitals - 1 or i < 0 for i in active):
         raise ValueError(
-            "Indices of active orbitals must be between 0 and {}; got active = {}".format(
-                orbitals - 1, active
-            )
+            f"Indices of active orbitals must be between 0 and {orbitals - 1}; got active = {active}"
         )
 
     # Indices of the matrix elements with absolute values >= cutoff
@@ -905,15 +891,15 @@ def dipole(
 
     if mult != 1:
         raise ValueError(
-            "Currently, this functionality is constrained to Hartree-Fock states with spin multiplicity = 1;"
-            " got multiplicity 2S+1 =  {}".format(mult)
+            f"Currently, this functionality is constrained to Hartree-Fock states with spin multiplicity = 1;"
+            f" got multiplicity 2S+1 =  {mult}"
         )
 
     for i in symbols:
         if i not in atomic_numbers:
             raise ValueError(
-                "Currently, only first- or second-row elements of the periodic table are supported;"
-                " got element {}".format(i)
+                f"Currently, only first- or second-row elements of the periodic table are supported;"
+                f" got element {i}"
             )
 
     hf_file = qml.qchem.meanfield(symbols, coordinates, name, charge, mult, basis, package, outpath)

--- a/qchem/pennylane_qchem/qchem/obs.py
+++ b/qchem/pennylane_qchem/qchem/obs.py
@@ -192,14 +192,10 @@ def spin2(electrons, orbitals, mapping="jordan_wigner", wires=None):
     """
 
     if electrons <= 0:
-        raise ValueError(
-            f"'electrons' must be greater than 0; got for 'electrons' {electrons}"
-        )
+        raise ValueError(f"'electrons' must be greater than 0; got for 'electrons' {electrons}")
 
     if orbitals <= 0:
-        raise ValueError(
-            f"'orbitals' must be greater than 0; got for 'orbitals' {orbitals}"
-        )
+        raise ValueError(f"'orbitals' must be greater than 0; got for 'orbitals' {orbitals}")
 
     sz = np.where(np.arange(orbitals) % 2 == 0, 0.5, -0.5)
 
@@ -360,9 +356,7 @@ def spin_z(orbitals, mapping="jordan_wigner", wires=None):
     """
 
     if orbitals <= 0:
-        raise ValueError(
-            f"'orbitals' must be greater than 0; got for 'orbitals' {orbitals}"
-        )
+        raise ValueError(f"'orbitals' must be greater than 0; got for 'orbitals' {orbitals}")
 
     r = np.arange(orbitals)
     sz_orb = np.where(np.arange(orbitals) % 2 == 0, 0.5, -0.5)
@@ -424,9 +418,7 @@ def particle_number(orbitals, mapping="jordan_wigner", wires=None):
     """
 
     if orbitals <= 0:
-        raise ValueError(
-            f"'orbitals' must be greater than 0; got for 'orbitals' {orbitals}"
-        )
+        raise ValueError(f"'orbitals' must be greater than 0; got for 'orbitals' {orbitals}")
 
     r = np.arange(orbitals)
     table = np.vstack([r, r, np.ones([orbitals])]).T

--- a/qchem/pennylane_qchem/qchem/structure.py
+++ b/qchem/pennylane_qchem/qchem/structure.py
@@ -113,13 +113,13 @@ def _process_wires(wires, n_wires=None):
 
     else:
         raise ValueError(
-            "Expected type Wires, list, tuple, or dict for `wires`, got {}".format(type(wires))
+            f"Expected type Wires, list, tuple, or dict for `wires`, got {type(wires)}"
         )
 
     if len(wires) != n_wires:
         # check length consistency when all checking and cleaning are done.
         raise ValueError(
-            "Length of `wires` ({}) does not match `n_wires` ({})".format(len(wires), n_wires)
+            f"Length of `wires` ({len(wires)}) does not match `n_wires` ({n_wires})"
         )
 
     return wires
@@ -213,8 +213,8 @@ def read_structure(filepath, outpath="."):
             )
         except subprocess.CalledProcessError as e:
             raise RuntimeError(
-                "Open Babel error. See the following Open Babel "
-                "output for details:\n\n {}\n{}".format(e.stdout, e.stderr)
+                f"Open Babel error. See the following Open Babel "
+                f"output for details:\n\n {e.stdout}\n{e.stderr}"
             ) from e
     else:
         copyfile(file_in, file_out)
@@ -292,16 +292,16 @@ def meanfield(
 
     if coordinates.size != 3 * len(symbols):
         raise ValueError(
-            "The size of the array 'coordinates' has to be 3*len(symbols) = {};"
-            " got 'coordinates.size' = {}".format(3 * len(symbols), coordinates.size)
+            f"The size of the array 'coordinates' has to be 3*len(symbols) = {3 * len(symbols)};"
+            f" got 'coordinates.size' = {coordinates.size}"
         )
 
     package = package.strip().lower()
 
     if package not in ("psi4", "pyscf"):
         error_message = (
-            "Integration with quantum chemistry package '{}' is not available. \n Please set"
-            " 'package' to 'pyscf' or 'psi4'.".format(package)
+            f"Integration with quantum chemistry package '{package}' is not available. \n Please set"
+            f" 'package' to 'pyscf' or 'psi4'."
         )
         raise TypeError(error_message)
 
@@ -393,39 +393,34 @@ def active_space(electrons, orbitals, mult=1, active_electrons=None, active_orbi
     else:
         if active_electrons <= 0:
             raise ValueError(
-                "The number of active electrons ({}) "
-                "has to be greater than 0.".format(active_electrons)
+                f"The number of active electrons ({active_electrons}) "
+                f"has to be greater than 0."
             )
 
         if active_electrons > electrons:
             raise ValueError(
-                "The number of active electrons ({}) "
-                "can not be greater than the total "
-                "number of electrons ({}).".format(active_electrons, electrons)
+                f"The number of active electrons ({active_electrons}) "
+                f"can not be greater than the total "
+                f"number of electrons ({electrons})."
             )
 
         if active_electrons < mult - 1:
             raise ValueError(
-                "For a reference state with multiplicity {}, "
-                "the number of active electrons ({}) should be "
-                "greater than or equal to {}.".format(mult, active_electrons, mult - 1)
-            )
+                f"For a reference state with multiplicity {mult}, "
+                f"the number of active electrons ({active_electrons}) should be "
+                f"greater than or equal to {mult - 1}.")
 
         if mult % 2 == 1:
             if active_electrons % 2 != 0:
                 raise ValueError(
-                    "For a reference state with multiplicity {}, "
-                    "the number of active electrons ({}) should be even.".format(
-                        mult, active_electrons
-                    )
+                    f"For a reference state with multiplicity {mult}, "
+                    f"the number of active electrons ({active_electrons}) should be even."
                 )
         else:
             if active_electrons % 2 != 1:
                 raise ValueError(
-                    "For a reference state with multiplicity {}, "
-                    "the number of active electrons ({}) should be odd.".format(
-                        mult, active_electrons
-                    )
+                    f"For a reference state with multiplicity {mult}, "
+                    f"the number of active electrons ({active_electrons}) should be odd."
                 )
 
         ncore_orbs = (electrons - active_electrons) // 2
@@ -436,23 +431,21 @@ def active_space(electrons, orbitals, mult=1, active_electrons=None, active_orbi
     else:
         if active_orbitals <= 0:
             raise ValueError(
-                "The number of active orbitals ({}) "
-                "has to be greater than 0.".format(active_orbitals)
+                f"The number of active orbitals ({active_orbitals}) "
+                f"has to be greater than 0."
             )
 
         if ncore_orbs + active_orbitals > orbitals:
             raise ValueError(
-                "The number of core ({}) + active orbitals ({}) can not be "
-                "greater than the total number of orbitals ({})".format(
-                    ncore_orbs, active_orbitals, orbitals
-                )
+                f"The number of core ({ncore_orbs}) + active orbitals ({active_orbitals}) can not be "
+                f"greater than the total number of orbitals ({orbitals})"
             )
 
         homo = (electrons + mult - 1) / 2
         if ncore_orbs + active_orbitals <= homo:
             raise ValueError(
-                "For n_active_orbitals={}, there are no virtual orbitals "
-                "in the active space.".format(active_orbitals)
+                f"For n_active_orbitals={active_orbitals}, there are no virtual orbitals "
+                f"in the active space."
             )
 
         active = list(range(ncore_orbs, ncore_orbs + active_orbitals))
@@ -509,8 +502,8 @@ def decompose(hf_file, mapping="jordan_wigner", core=None, active=None):
 
     if mapping not in ("jordan_wigner", "bravyi_kitaev"):
         raise TypeError(
-            "The '{}' transformation is not available. \n "
-            "Please set 'mapping' to 'jordan_wigner' or 'bravyi_kitaev'.".format(mapping)
+            f"The '{mapping}' transformation is not available. \n "
+            f"Please set 'mapping' to 'jordan_wigner' or 'bravyi_kitaev'."
         )
 
     # fermionic-to-qubit transformation of the Hamiltonian
@@ -631,8 +624,8 @@ def _terms_to_qubit_operator(coeffs, ops, wires=None):
         extra_obsvbs = set(op.name) - {"PauliX", "PauliY", "PauliZ", "Identity"}
         if extra_obsvbs != set():
             raise ValueError(
-                "Expected only PennyLane observables PauliX/Y/Z or Identity, "
-                + "but also got {}.".format(extra_obsvbs)
+                f"Expected only PennyLane observables PauliX/Y/Z or Identity, "
+                f"but also got {extra_obsvbs}."
             )
 
         # Pauli axis names, note s[-1] expects only 'Pauli{X,Y,Z}'
@@ -644,7 +637,7 @@ def _terms_to_qubit_operator(coeffs, ops, wires=None):
         else:
             term_str = " ".join(
                 [
-                    "{}{}".format(pauli, qubit_indexed_wires.index(wire))
+                    f"{pauli}{qubit_indexed_wires.index(wire)}"
                     for pauli, wire in zip(pauli_names, op.wires)
                     if pauli != "Identity"
                 ]
@@ -714,8 +707,8 @@ def convert_observable(qubit_observable, wires=None, tol=1e08):
         np.iscomplex(np.real_if_close(coef, tol=tol)) for coef in qubit_observable.terms.values()
     ):
         raise TypeError(
-            "The coefficients entering the QubitOperator must be real;"
-            " got complex coefficients in the operator {}".format(qubit_observable)
+            f"The coefficients entering the QubitOperator must be real;"
+            f" got complex coefficients in the operator {qubit_observable}"
         )
 
     return Hamiltonian(*_qubit_operator_to_terms(qubit_observable, wires=wires))
@@ -893,21 +886,19 @@ def excitations(electrons, orbitals, delta_sz=0):
 
     if not electrons > 0:
         raise ValueError(
-            "The number of active electrons has to be greater than 0 \n"
-            "Got n_electrons = {}".format(electrons)
+            f"The number of active electrons has to be greater than 0 \n"
+            f"Got n_electrons = {electrons}"
         )
 
     if orbitals <= electrons:
         raise ValueError(
-            "The number of active spin-orbitals ({}) "
-            "has to be greater than the number of active electrons ({}).".format(
-                orbitals, electrons
-            )
+            f"The number of active spin-orbitals ({orbitals}) "
+            f"has to be greater than the number of active electrons ({electrons})."
         )
 
     if delta_sz not in (0, 1, -1, 2, -2):
         raise ValueError(
-            "Expected values for 'delta_sz' are 0, +/- 1 and +/- 2 but got ({}).".format(delta_sz)
+            f"Expected values for 'delta_sz' are 0, +/- 1 and +/- 2 but got ({delta_sz})."
         )
 
     # define the spin projection 'sz' of the single-particle states
@@ -964,15 +955,13 @@ def hf_state(electrons, orbitals):
 
     if electrons <= 0:
         raise ValueError(
-            "The number of active electrons has to be larger than zero; got 'electrons' = {}".format(
-                electrons
-            )
+            f"The number of active electrons has to be larger than zero; got 'electrons' = {electrons}"
         )
 
     if electrons > orbitals:
         raise ValueError(
-            "The number of active orbitals cannot be smaller than the number of active electrons;"
-            " got 'orbitals'={} < 'electrons'={}".format(orbitals, electrons)
+            f"The number of active orbitals cannot be smaller than the number of active electrons;"
+            f" got 'orbitals'={orbitals} < 'electrons'={electrons}"
         )
 
     state = np.where(np.arange(orbitals) < electrons, 1, 0)
@@ -1023,28 +1012,22 @@ def excitations_to_wires(singles, doubles, wires=None):
 
     if (not singles) and (not doubles):
         raise ValueError(
-            "'singles' and 'doubles' lists can not be both empty;\
-            got singles = {}, doubles = {}".format(
-                singles, doubles
-            )
+            f"'singles' and 'doubles' lists can not be both empty; "
+            f"got singles = {singles}, doubles = {doubles}"
         )
 
     expected_shape = (2,)
     for single_ in singles:
         if np.array(single_).shape != expected_shape:
             raise ValueError(
-                "Expected entries of 'singles' to be of shape (2,); got {}".format(
-                    np.array(single_).shape
-                )
+                f"Expected entries of 'singles' to be of shape (2,); got {np.array(single_).shape}"
             )
 
     expected_shape = (4,)
     for double_ in doubles:
         if np.array(double_).shape != expected_shape:
             raise ValueError(
-                "Expected entries of 'doubles' to be of shape (4,); got {}".format(
-                    np.array(double_).shape
-                )
+                f"Expected entries of 'doubles' to be of shape (4,); got {np.array(double_).shape}"
             )
 
     max_idx = 0
@@ -1056,7 +1039,7 @@ def excitations_to_wires(singles, doubles, wires=None):
     if wires is None:
         wires = range(max_idx + 1)
     elif len(wires) != max_idx + 1:
-        raise ValueError("Expected number of wires is {}; got {}".format(max_idx + 1, len(wires)))
+        raise ValueError(f"Expected number of wires is {max_idx + 1}; got {len(wires)}")
 
     singles_wires = []
     for r, p in singles:

--- a/qchem/pennylane_qchem/qchem/structure.py
+++ b/qchem/pennylane_qchem/qchem/structure.py
@@ -118,9 +118,7 @@ def _process_wires(wires, n_wires=None):
 
     if len(wires) != n_wires:
         # check length consistency when all checking and cleaning are done.
-        raise ValueError(
-            f"Length of `wires` ({len(wires)}) does not match `n_wires` ({n_wires})"
-        )
+        raise ValueError(f"Length of `wires` ({len(wires)}) does not match `n_wires` ({n_wires})")
 
     return wires
 
@@ -393,8 +391,7 @@ def active_space(electrons, orbitals, mult=1, active_electrons=None, active_orbi
     else:
         if active_electrons <= 0:
             raise ValueError(
-                f"The number of active electrons ({active_electrons}) "
-                f"has to be greater than 0."
+                f"The number of active electrons ({active_electrons}) " f"has to be greater than 0."
             )
 
         if active_electrons > electrons:
@@ -408,7 +405,8 @@ def active_space(electrons, orbitals, mult=1, active_electrons=None, active_orbi
             raise ValueError(
                 f"For a reference state with multiplicity {mult}, "
                 f"the number of active electrons ({active_electrons}) should be "
-                f"greater than or equal to {mult - 1}.")
+                f"greater than or equal to {mult - 1}."
+            )
 
         if mult % 2 == 1:
             if active_electrons % 2 != 0:
@@ -431,8 +429,7 @@ def active_space(electrons, orbitals, mult=1, active_electrons=None, active_orbi
     else:
         if active_orbitals <= 0:
             raise ValueError(
-                f"The number of active orbitals ({active_orbitals}) "
-                f"has to be greater than 0."
+                f"The number of active orbitals ({active_orbitals}) " f"has to be greater than 0."
             )
 
         if ncore_orbs + active_orbitals > orbitals:

--- a/qchem/tests/conftest.py
+++ b/qchem/tests/conftest.py
@@ -56,7 +56,7 @@ def requires_babel(babel_support):
     params=[
         None,
         qml.wires.Wires(
-            list("ab") + [-3, 42] + ["xyz", "23", "wireX"] + ["w{}".format(i) for i in range(20)]
+            list("ab") + [-3, 42] + ["xyz", "23", "wireX"] + [f"w{i}" for i in range(20)]
         ),
         list(range(100, 120)),
         {13 - i: "abcdefghijklmn"[i] for i in range(14)},

--- a/tests/beta/test_default_tensor.py
+++ b/tests/beta/test_default_tensor.py
@@ -412,7 +412,7 @@ class TestDefaultTensorNetworkParametrize:
         assert "state" in dev._nodes and len(dev._nodes) == 1
         assert len(dev._nodes["state"]) == 2
         assert all(
-            [dev._nodes["state"][idx].name == "ZeroState({},)".format(idx) for idx in range(2)]
+            [dev._nodes["state"][idx].name == f"ZeroState({idx},)" for idx in range(2)]
         )
 
         shape = (1, 2, 1) if rep == "mps" else (2,)

--- a/tests/beta/test_default_tensor.py
+++ b/tests/beta/test_default_tensor.py
@@ -411,9 +411,7 @@ class TestDefaultTensorNetworkParametrize:
         assert dev._contracted_state_node is None
         assert "state" in dev._nodes and len(dev._nodes) == 1
         assert len(dev._nodes["state"]) == 2
-        assert all(
-            [dev._nodes["state"][idx].name == f"ZeroState({idx},)" for idx in range(2)]
-        )
+        assert all([dev._nodes["state"][idx].name == f"ZeroState({idx},)" for idx in range(2)])
 
         shape = (1, 2, 1) if rep == "mps" else (2,)
         reshaped_zero_state = dev._zero_state.reshape(shape)

--- a/tests/ops/qubit/test_parametric_ops.py
+++ b/tests/ops/qubit/test_parametric_ops.py
@@ -1210,14 +1210,14 @@ class TestPauliRot:
             # this is the identity
             expected_gen = qml.Identity(wires=0)
         else:
-            expected_gen = getattr(qml, "Pauli{}".format(pauli_word[0]))(wires=0)
+            expected_gen = getattr(qml, f"Pauli{pauli_word[0]}")(wires=0)
 
         for i, pauli in enumerate(pauli_word[1:]):
             i += 1
             if pauli == "I":
                 expected_gen = expected_gen @ qml.Identity(wires=i)
             else:
-                expected_gen = expected_gen @ getattr(qml, "Pauli{}".format(pauli))(wires=i)
+                expected_gen = expected_gen @ getattr(qml, f"Pauli{pauli}")(wires=i)
 
         expected_gen_mat = expected_gen.matrix
 

--- a/tests/qnn/test_keras.py
+++ b/tests/qnn/test_keras.py
@@ -129,9 +129,7 @@ class TestKerasLayer:
         w[qml.qnn.keras.KerasLayer._input_arg] = n_qubits
         with pytest.raises(
             ValueError,
-            match="{} argument should not have its dimension".format(
-                qml.qnn.keras.KerasLayer._input_arg
-            ),
+            match=f"{qml.qnn.keras.KerasLayer._input_arg} argument should not have its dimension",
         ):
             KerasLayer(c, w, output_dim)
 

--- a/tests/qnn/test_qnn_torch.py
+++ b/tests/qnn/test_qnn_torch.py
@@ -462,9 +462,7 @@ class TestTorchLayerIntegration:
 
         clayer_weights = set(f"clayer{i + 1}.weight" for i in range(3))
         clayer_biases = set(f"clayer{i + 1}.bias" for i in range(3))
-        qlayer_params = set(
-            f"qlayer{i + 1}.w{j + 1}" for i in range(2) for j in range(len(w))
-        )
+        qlayer_params = set(f"qlayer{i + 1}.w{j + 1}" for i in range(2) for j in range(len(w)))
 
         all_params = clayer_weights | clayer_biases | qlayer_params
 

--- a/tests/qnn/test_qnn_torch.py
+++ b/tests/qnn/test_qnn_torch.py
@@ -96,9 +96,7 @@ class TestTorchLayer:
         w[qml.qnn.torch.TorchLayer._input_arg] = n_qubits
         with pytest.raises(
             ValueError,
-            match="{} argument should not have its dimension".format(
-                qml.qnn.torch.TorchLayer._input_arg
-            ),
+            match=f"{qml.qnn.torch.TorchLayer._input_arg} argument should not have its dimension",
         ):
             TorchLayer(c, w)
 
@@ -462,10 +460,10 @@ class TestTorchLayerIntegration:
         state_dict = module.state_dict()
         dict_keys = set(state_dict.keys())
 
-        clayer_weights = set("clayer{}.weight".format(i + 1) for i in range(3))
-        clayer_biases = set("clayer{}.bias".format(i + 1) for i in range(3))
+        clayer_weights = set(f"clayer{i + 1}.weight" for i in range(3))
+        clayer_biases = set(f"clayer{i + 1}.bias" for i in range(3))
         qlayer_params = set(
-            "qlayer{}.w{}".format(i + 1, j + 1) for i in range(2) for j in range(len(w))
+            f"qlayer{i + 1}.w{j + 1}" for i in range(2) for j in range(len(w))
         )
 
         all_params = clayer_weights | clayer_biases | qlayer_params

--- a/tests/tape/test_reversible.py
+++ b/tests/tape/test_reversible.py
@@ -112,7 +112,7 @@ class TestReversibleTape:
             op(0.542, wires=[0, 1])
             qml.expval(qml.PauliZ(0))
 
-        with pytest.raises(ValueError, match="The {} gate is not currently supported".format(name)):
+        with pytest.raises(ValueError, match=f"The {name} gate is not currently supported"):
             tape.jacobian(dev)
 
     def test_var_exception(self):

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -339,7 +339,7 @@ class TestInternalFunctions:
 
         with pytest.raises(
             DeviceError,
-            match="Gate {} not supported on device {}".format("CNOT", "MockDevice"),
+            match="Gate CNOT not supported on device MockDevice",
         ):
             dev.check_validity(queue, observables)
 
@@ -444,13 +444,13 @@ class TestInternalFunctions:
 
         with pytest.raises(
             DeviceError,
-            match="The inverse of gates are not supported on device {}".format(dev.short_name),
+            match=f"The inverse of gates are not supported on device {dev.short_name}",
         ):
             dev.check_validity([qml.PauliZ(0).inv()], [])
 
         with pytest.raises(
             DeviceError,
-            match="The inverse of gates are not supported on device {}".format(dev.short_name),
+            match=f"The inverse of gates are not supported on device {dev.short_name}",
         ):
             dev.check_validity([], [qml.PauliZ(0).inv()])
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -89,6 +89,4 @@ class TestLoad:
                 continue
 
             if mock_plugin_converters[plugin_converter].called:
-                raise Exception(
-                    f"The other plugin converter {plugin_converter} was called."
-                )
+                raise Exception(f"The other plugin converter {plugin_converter} was called.")

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -90,5 +90,5 @@ class TestLoad:
 
             if mock_plugin_converters[plugin_converter].called:
                 raise Exception(
-                    "The other plugin converter {} was called.".format(plugin_converter)
+                    f"The other plugin converter {plugin_converter} was called."
                 )

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -308,7 +308,7 @@ class TestOperatorIntegration:
 
         with pytest.raises(
             qml.QuantumFunctionError,
-            match="Operator {} must act on all wires".format(DummyOp.__name__),
+            match=f"Operator {DummyOp.__name__} must act on all wires",
         ):
             circuit()
 

--- a/tests/test_qubit_device.py
+++ b/tests/test_qubit_device.py
@@ -429,7 +429,7 @@ class TestStatesToBinary:
         dev = mock_qubit_device()
         res = dev.states_to_binary(samples, wires)
 
-        format_smt = "{{:0{}b}}".format(wires)
+        format_smt = f"{{:0{wires}b}}"
         expected = np.array([[int(x) for x in list(format_smt.format(i))] for i in samples])
 
         assert np.all(res == expected)


### PR DESCRIPTION
**Context:**

Presumably due to changes in the PEP standard, covecov is starting to complain about our use of ``"my string {}".format(i)`` instead of ``f"my string {i}"``. 

**Description of the Change:**

This PR changes all code instances of format into f-strings.

**Benefits:**

Hopefully no one else has to worry
