### PR TITLE
Fix metric tensor for circuits with inverted gates

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -528,6 +528,10 @@
 
 <h3>Bug fixes</h3>
 
+* Fixes a bug where the metric tensor was computed incorrectly when using
+  gates with `gate.inverse=True`.
+  [(#1987)](https://github.com/PennyLaneAI/pennylane/pull/1987)
+
 * Corrects the documentation of `qml.transforms.classical_jacobian`
   for the Autograd interface (and improves test coverage).
   [(#1978)](https://github.com/PennyLaneAI/pennylane/pull/1978)

--- a/pennylane/ops/qubit/matrix_ops.py
+++ b/pennylane/ops/qubit/matrix_ops.py
@@ -286,8 +286,8 @@ class DiagonalQubitUnitary(Operation):
     def _eigvals(cls, *params):
         D = qml.math.asarray(params[0])
 
-        if not qml.math.allclose(D * qml.math.conj(D), qml.math.ones_like(D)):
-            raise ValueError("Operator must be unitary.")
+        # if not qml.math.allclose(D * qml.math.conj(D), qml.math.ones_like(D)):
+        # raise ValueError("Operator must be unitary.")
 
         return D
 

--- a/pennylane/ops/qubit/matrix_ops.py
+++ b/pennylane/ops/qubit/matrix_ops.py
@@ -286,8 +286,8 @@ class DiagonalQubitUnitary(Operation):
     def _eigvals(cls, *params):
         D = qml.math.asarray(params[0])
 
-        # if not qml.math.allclose(D * qml.math.conj(D), qml.math.ones_like(D)):
-        # raise ValueError("Operator must be unitary.")
+        if not qml.math.allclose(D * qml.math.conj(D), qml.math.ones_like(D)):
+            raise ValueError("Operator must be unitary.")
 
         return D
 

--- a/pennylane/transforms/metric_tensor.py
+++ b/pennylane/transforms/metric_tensor.py
@@ -58,13 +58,16 @@ def expand_fn(
 def metric_tensor(
     tape, approx=None, diag_approx=None, allow_nonunitary=True, aux_wire=None, device_wires=None
 ):
-    r"""Returns a function that computes the block-diagonal approximation of the metric tensor
-    of a given QNode or quantum tape.
+    r"""Returns a function that computes the metric tensor of a given QNode or quantum tape.
 
     .. note::
 
         Only gates that have a single parameter and define a ``generator`` are supported.
         All other parametrized gates will be decomposed if possible.
+
+        The ``generator`` of all parametrized operations, with respect to which the
+        tensor is computed, are assumed to be Hermitian.
+        This is the case for unitary single-parameter operations.
 
     Args:
         tape (pennylane.QNode or .QuantumTape): quantum tape or QNode to find the metric tensor of
@@ -370,6 +373,10 @@ def _metric_tensor_cov_matrix(tape, diag_approx):
             corresponding to one tape in the first return value
         list[list[float]]: Coefficients to scale the results for each observable, one inner list
             corresponding to one tape in the first return value
+
+    This method assumes the ``generator`` of all parametrized operations with respect to
+    which the tensor is computed to be Hermitian. This is the case for unitary single-parameter
+    operations.
     """
     # get the circuit graph
     graph = tape.graph
@@ -387,6 +394,8 @@ def _metric_tensor_cov_matrix(tape, diag_approx):
         # for each operation in the layer, get the generator
         for op in curr_ops:
             gen, s = op.generator
+            if op.inverse:
+                s = -s
             w = op.wires
             coeffs_list[-1].append(s)
 

--- a/tests/transforms/test_metric_tensor.py
+++ b/tests/transforms/test_metric_tensor.py
@@ -309,7 +309,7 @@ class TestMetricTensor:
         def final(x, y, z, h, g, f):
             non_parametrized_layer(a, b, c)
             qml.RX(x, wires=0)
-            qml.RY(y, wires=1)
+            qml.RY(-y, wires=1).inv()
             qml.RZ(z, wires=2)
             non_parametrized_layer(a, b, c)
             qml.RY(f, wires=1)

--- a/tests/transforms/test_metric_tensor.py
+++ b/tests/transforms/test_metric_tensor.py
@@ -628,8 +628,8 @@ def fubini_ansatz2(params, wires=None):
     qml.RY(params0, wires=0)
     qml.RY(params0, wires=1)
     qml.CNOT(wires=[0, 1])
-    qml.RX(params1, wires=0)
-    qml.RX(params1, wires=1)
+    qml.RX(params1, wires=0).inv()
+    qml.RX(params1, wires=1).inv()
 
 
 def fubini_ansatz3(params, wires=None):
@@ -640,7 +640,7 @@ def fubini_ansatz3(params, wires=None):
     qml.RX(fixed_pars[3], wires=1)
     qml.CNOT(wires=[0, 1])
     qml.CNOT(wires=[1, 2])
-    qml.RX(params0, wires=0)
+    qml.RX(params0, wires=0).inv()
     qml.RX(params0, wires=1)
     qml.CNOT(wires=[0, 1])
     qml.CNOT(wires=[1, 2])


### PR DESCRIPTION
**Context:**
The generator  and coefficient stored in `op.generator` are not modified when an operation is inverted. Therefore,
using this information in the metric tensor led to the wrong result for inverted gates. This is now fixed and three tests were modified to include this szenario.
Note that this bug affects both, the new Hadamard test-based metric tensor introduced in #1725 and the block-diagonal original version.

**Description of the Change:**
The coefficient is inverted with a minus sign if the operation in question has the `inverse` flag set to `True`. The documentation clearly states now that this assumes the generator of the operations for which the metric tensor is computed to be Hermitian.

**Benefits:**
bug fix and better documentation as well as test coverage.

**Possible Drawbacks:** n/a

**Related GitHub Issues:** n/a
