### PR TITLE
Incrementing the version number to `0.21.0-dev`

### DIFF
--- a/doc/releases/changelog-0.20.0.md
+++ b/doc/releases/changelog-0.20.0.md
@@ -1,6 +1,6 @@
 :orphan:
 
-# Release 0.20.0-dev (current release)
+# Release 0.20.0 (current release)
 
 <h3>New features since last release</h3>
 

--- a/doc/releases/changelog-0.20.0.md
+++ b/doc/releases/changelog-0.20.0.md
@@ -1,6 +1,6 @@
 :orphan:
 
-# Release 0.20.0-dev (development release)
+# Release 0.20.0-dev (current release)
 
 <h3>New features since last release</h3>
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1,0 +1,19 @@
+:orphan:
+
+# Release 0.21.0-dev (development release)
+
+<h3>New features since last release</h3>
+
+<h3>Improvements</h3>
+
+<h3>Breaking changes</h3>
+
+<h3>Deprecations</h3>
+
+<h3>Bug fixes</h3>
+
+<h3>Documentation</h3>
+
+<h3>Contributors</h3>
+
+This release contains contributions from (in alphabetical order):

--- a/pennylane/_version.py
+++ b/pennylane/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.20.0-dev"
+__version__ = "0.21.0-dev"

--- a/qchem/CHANGELOG.md
+++ b/qchem/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Release 0.20.0-dev
+# Release 0.21.0-dev
 
 <h3>New features</h3>
 

--- a/qchem/pennylane_qchem/_version.py
+++ b/qchem/pennylane_qchem/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.20.0-dev"
+__version__ = "0.21.0-dev"


### PR DESCRIPTION
Updates PennyLane and PennyLane-QChem as we're entering a new development version (v0.20.0 coming up):

* Moves the v0.20.0 changelog into a separate file
* Updates the dev changelog file to have empty sections
* Increments the version number to v0.21.0-dev

*Note*: QChem is not being released with v0.20.0.

See the same PR for the [v0.20.0 bump](https://github.com/PennyLaneAI/pennylane/pull/1832).