### PR TITLE
AmplitudeEmbedding: Fix warning from implicit cast of complex to real

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -591,6 +591,10 @@
   optimization step updates.
   [(#1929)](https://github.com/PennyLaneAI/pennylane/pull/1929)
 
+* `AmplitudeEmbedding` template no longer produces a `ComplexWarning`
+  when the `features` parameter is batched and provided as a 2D array.
+  [(#1990)](https://github.com/PennyLaneAI/pennylane/pull/1990)
+
 <h3>Documentation</h3>
 
 * Added examples in documentation for some operations.

--- a/pennylane/templates/embeddings/amplitude.py
+++ b/pennylane/templates/embeddings/amplitude.py
@@ -159,11 +159,9 @@ class AmplitudeEmbedding(Operation):
         """
 
         # check if features is batched
-        dims = qml.math.shape(features)
-        batched = len(dims) > 1
+        batched = len(qml.math.shape(features)) > 1
 
         features_batch = features if batched else [features]
-        processed = np.empty(dims if batched else (1, *dims), dtype=np.complex128)
 
         # apply pre-processing to each features tensor in the batch
         for i, feature_set in enumerate(features_batch):
@@ -207,6 +205,6 @@ class AmplitudeEmbedding(Operation):
                         "Use 'normalize=True' to automatically normalize."
                     )
 
-            processed[i] = qml.math.cast(feature_set, np.complex128)
+            features_batch[i] = feature_set
 
-        return processed if batched else processed[0]
+        return qml.math.cast(features_batch if batched else features_batch[0], np.complex128)

--- a/pennylane/templates/embeddings/amplitude.py
+++ b/pennylane/templates/embeddings/amplitude.py
@@ -159,9 +159,11 @@ class AmplitudeEmbedding(Operation):
         """
 
         # check if features is batched
-        batched = len(qml.math.shape(features)) > 1
+        dims = qml.math.shape(features)
+        batched = len(dims) > 1
 
         features_batch = features if batched else [features]
+        processed = np.empty(dims if batched else (1, *dims), dtype=np.complex128)
 
         # apply pre-processing to each features tensor in the batch
         for i, feature_set in enumerate(features_batch):
@@ -205,6 +207,6 @@ class AmplitudeEmbedding(Operation):
                         "Use 'normalize=True' to automatically normalize."
                     )
 
-            features_batch[i] = qml.math.cast(feature_set, np.complex128)
+            processed[i] = qml.math.cast(feature_set, np.complex128)
 
-        return features_batch if batched else features_batch[0]
+        return processed if batched else processed[0]


### PR DESCRIPTION
**Context:**
When the `features` argument to the amplitude embedding template is batched in the form of a 2d numpy array, each feature set is processed and cast to a complex array, after which it is assigned back to the input array. This causes the warning `ComplexWarning: Casting complex values to real discards the imaginary part` when the input array is not already complex, due to the (implicit) assignment cast. 

**Description of the Change:** Pre-allocate a complex array to store the processed features in.

**Benefits:** No warning is raised and complex values are used as well when the template argument is batched.

**Possible Drawbacks:**

**Related GitHub Issues:** Closes #1986 
