### PR TITLE
Resolve error from texted-based circuit drawer for tapes

### DIFF
--- a/pennylane/drawer/circuit_drawer.py
+++ b/pennylane/drawer/circuit_drawer.py
@@ -368,6 +368,7 @@ class CircuitDrawer:
             ("U", self.representation_resolver.unitary_matrix_cache),
             ("H", self.representation_resolver.hermitian_matrix_cache),
             ("M", self.representation_resolver.matrix_cache),
+            ("T", self.representation_resolver.tape_cache.values())
         ]:
             for idx, matrix in enumerate(cache):
                 rendered_string += f"{symbol}{idx} =\n{matrix}\n"

--- a/pennylane/drawer/circuit_drawer.py
+++ b/pennylane/drawer/circuit_drawer.py
@@ -66,16 +66,16 @@ class CircuitDrawer:
         self.active_wires = self.extract_active_wires(raw_operation_grid, raw_observable_grid)
 
         if charset is None:
-            self.charset = CHARSETS["unicode"]()
+            self.charset = CHARSETS["unicode"]
         elif isinstance(charset, type) and issubclass(charset, CharSet):
-            self.charset = charset()
+            self.charset = charset
         else:
             if charset not in CHARSETS:
                 supported_char = ", ".join(CHARSETS.keys())
                 raise ValueError(
                     f"Charset '{charset}' is not supported. Supported charsets: {supported_char}."
                 )
-            self.charset = CHARSETS[charset]()
+            self.charset = CHARSETS[charset]
 
         if show_all_wires:
             # if the provided wires include empty wires, make sure they are included

--- a/pennylane/drawer/representation_resolver.py
+++ b/pennylane/drawer/representation_resolver.py
@@ -33,6 +33,7 @@ class RepresentationResolver:
         self.matrix_cache = []
         self.unitary_matrix_cache = []
         self.hermitian_matrix_cache = []
+        self.tape_cache = {}
 
     # Symbol for uncontrolled wires
     resolution_dict = {
@@ -330,6 +331,15 @@ class RepresentationResolver:
             ]
 
             return (" " + self.charset.OTIMES + " ").join(constituent_representations)
+
+        if isinstance(op, qml.tape.QuantumTape):
+            if op in self.tape_cache:
+                idx = list(self.tape_cache).index(op)
+            else:
+                idx = len(self.tape_cache)
+                self.tape_cache[op] = op.draw()
+
+            return f"QuantumTape:T{idx}"
 
         representation = ""
         base_name = getattr(op, "base_name", op.name)

--- a/pennylane/drawer/representation_resolver.py
+++ b/pennylane/drawer/representation_resolver.py
@@ -18,7 +18,7 @@ Operations to their string representations.
 import numpy as np
 import pennylane as qml
 
-from .charsets import UnicodeCharSet
+from .charsets import CHARSETS, UnicodeCharSet
 
 
 class RepresentationResolver:
@@ -337,7 +337,8 @@ class RepresentationResolver:
                 idx = list(self.tape_cache).index(op)
             else:
                 idx = len(self.tape_cache)
-                self.tape_cache[op] = op.draw()
+                charset_string = next((k for k, v in CHARSETS.items() if v is self.charset), None)
+                self.tape_cache[op] = op.draw(charset=charset_string)
 
             return f"QuantumTape:T{idx}"
 

--- a/tests/drawer/test_circuit_drawer.py
+++ b/tests/drawer/test_circuit_drawer.py
@@ -73,7 +73,7 @@ class TestInitialization:
             dummy_raw_operation_grid, dummy_raw_observable_grid, Wires(range(6)), charset=None
         )
 
-        assert isinstance(drawer_None.charset, UnicodeCharSet)
+        assert drawer_None.charset is UnicodeCharSet
 
     @pytest.mark.parametrize("charset", ("unicode", "ascii"))
     def test_charset_string(self, charset):
@@ -82,7 +82,7 @@ class TestInitialization:
             dummy_raw_operation_grid, dummy_raw_observable_grid, Wires(range(6)), charset=charset
         )
 
-        assert isinstance(drawer_str.charset, CHARSETS[charset])
+        assert drawer_str.charset is CHARSETS[charset]
 
     @pytest.mark.parametrize("charset", (UnicodeCharSet, AsciiCharSet))
     def test_charset_class(self, charset):
@@ -91,7 +91,7 @@ class TestInitialization:
             dummy_raw_operation_grid, dummy_raw_observable_grid, Wires(range(6)), charset=charset
         )
 
-        assert isinstance(drawer_class.charset, charset)
+        assert drawer_class.charset is charset
 
     def test_charset_error(self):
 

--- a/tests/drawer/test_circuit_drawer.py
+++ b/tests/drawer/test_circuit_drawer.py
@@ -805,6 +805,46 @@ class TestCircuitDrawerIntegration:
         )
         assert tape.draw(max_length=60) == expected
 
+    def test_nested_tapes(self):
+
+        with qml.tape.QuantumTape() as tape:
+            with qml.tape.QuantumTape():
+                qml.PauliX(0)
+                qml.CNOT(wires=[0, 2])
+                with qml.tape.QuantumTape():
+                    qml.QuantumPhaseEstimation(
+                        qml.PauliY.matrix, target_wires=[1], estimation_wires=[2]
+                    )
+                    qml.CNOT(wires=[1, 2])
+            qml.Hadamard(1)
+            with qml.tape.QuantumTape():
+                qml.SWAP(wires=[0, 1])
+            qml.state()
+
+        expected = (
+            " 0: ──╭QuantumTape:T0─────╭QuantumTape:T1──╭┤ State \n"
+            + " 1: ──├QuantumTape:T0──H──╰QuantumTape:T1──├┤ State \n"
+            + " 2: ──╰QuantumTape:T0──────────────────────╰┤ State \n"
+            + "T0 =\n"
+            + " 0: ──X──╭C───────────────────┤  \n"
+            + " 2: ─────╰X──╭QuantumTape:T2──┤  \n"
+            + " 1: ─────────╰QuantumTape:T2──┤  \n"
+            + "T2 =\n"
+            + " 1: ──╭QuantumPhaseEstimation(M0)──╭C──┤  \n"
+            + " 2: ──╰QuantumPhaseEstimation(M0)──╰X──┤  \n"
+            + "M0 =\n"
+            + "[[ 0.+0.j -0.-1.j]\n"
+            + " [ 0.+1.j  0.+0.j]]\n"
+            + "\n"
+            + "\n"
+            + "T1 =\n"
+            + " 0: ──╭SWAP──┤  \n"
+            + " 1: ──╰SWAP──┤  \n"
+            + "\n"
+        )
+
+        assert tape.draw(wire_order=qml.wires.Wires([0, 1, 2])) == expected
+
 
 class TestWireOrdering:
     """Tests for wire ordering functionality"""

--- a/tests/drawer/test_representation_resolver.py
+++ b/tests/drawer/test_representation_resolver.py
@@ -35,6 +35,14 @@ def ascii_representation_resolver():
     return RepresentationResolver(charset=qml.drawer.charsets.AsciiCharSet)
 
 
+def two_wire_quantum_tape():
+    """An instance of a QuantumTape to be used as operation in a circuit."""
+    with qml.tape.QuantumTape() as quantum_tape:
+        qml.Hadamard(wires=0)
+        qml.CNOT(wires=[0, 1])
+    return quantum_tape
+
+
 class TestRepresentationResolver:
     """Test the RepresentationResolver class."""
 
@@ -205,6 +213,8 @@ class TestRepresentationResolver:
             (qml.Toffoli(wires=[0, 2, 1]).inv(), 2, "C"),
             (qml.measure.sample(wires=[0, 1]), 0, "basis"),  # not providing an observable in
             (qml.measure.sample(wires=[0, 1]), 1, "basis"),  # sample gets displayed as raw
+            (two_wire_quantum_tape(), 0, "QuantumTape:T0"),
+            (two_wire_quantum_tape(), 1, "QuantumTape:T0"),
         ],
     )
     def test_operator_representation_unicode(
@@ -347,6 +357,8 @@ class TestRepresentationResolver:
             (qml.Toffoli(wires=[0, 2, 1]).inv(), 2, "C"),
             (qml.measure.sample(wires=[0, 1]), 0, "basis"),  # not providing an observable in
             (qml.measure.sample(wires=[0, 1]), 1, "basis"),  # sample gets displayed as raw
+            (two_wire_quantum_tape(), 0, "QuantumTape:T0"),
+            (two_wire_quantum_tape(), 1, "QuantumTape:T0"),
         ],
     )
     def test_operator_representation_ascii(self, ascii_representation_resolver, op, wire, target):


### PR DESCRIPTION
**Context:**
As discovered in issue #1967, the text-based circuit drawer throws an error when the operations list of a circuit contains a tape. This can happen manually when nesting a tape inside a circuit or tape, e.g.:
```py
import pennylane as qml

dev = qml.device("default.qubit", wires=3)

@qml.qnode(dev)
def qpe_circuit():
    with qml.tape.QuantumTape():
        qml.PauliX(0)
        qml.CNOT(wires=[0,2])
    qml.Hadamard(1)
    return qml.state()

print(qml.draw(qpe_circuit)())
```
but also when an operation needs to be decomposed before printing, such as an adjoint template without a defined `.adjoint()` method that manipulates the `.inv` attribute instead, e.g. (v0.19.0 only, fixed in current dev branch):
```py
dev = qml.device("default.qubit", wires=2)

@qml.qnode(dev)
def qpe_circuit():
    qml.adjoint(qml.QuantumPhaseEstimation)(
        qml.PauliX.matrix,
        target_wires=[0],
        estimation_wires=[1],
    )
    return qml.state()

print(qml.draw(qpe_circuit)())
```

**Description of the Change:**
The issue is resolved by adding support for drawing tapes as operations to the circuit drawer.
The contents of the tape are also drawn separately and attached to the main circuit drawing in a manner similar to how matrix arguments are already included.
Nested tapes are also supported and rendered by recursive traversal, e.g.: 
```py
@qml.qnode(dev)
def qpe_circuit():
    with qml.tape.QuantumTape():
        qml.PauliX(0)
        qml.CNOT(wires=[0,2])
        with qml.tape.QuantumTape():
            qml.QuantumPhaseEstimation(qml.PauliY.matrix, target_wires=[1], estimation_wires=[2])
            qml.CNOT(wires=[1,2])
    qml.Hadamard(1)
    with qml.tape.QuantumTape():
        qml.SWAP(wires=[0,1])
    return qml.state()
```

is drawn as:
```
 0: ──╭QuantumTape:T0─────╭QuantumTape:T1──╭┤ State 
 1: ──├QuantumTape:T0──H──╰QuantumTape:T1──├┤ State 
 2: ──╰QuantumTape:T0──────────────────────╰┤ State 
T0 =
 0: ──X──╭C───────────────────┤  
 2: ─────╰X──╭QuantumTape:T2──┤  
 1: ─────────╰QuantumTape:T2──┤  
T2 =
 1: ──╭QuantumPhaseEstimation(M0)──╭C──┤  
 2: ──╰QuantumPhaseEstimation(M0)──╰X──┤  
M0 =
[[ 0.+0.j -0.-1.j]
 [ 0.+1.j  0.+0.j]]


T1 =
 0: ──╭SWAP──┤  
 1: ──╰SWAP──┤  
```

**Benefits:** No errors are thrown when the drawer attempts to render a tape.

**Possible Drawbacks:**

**Related GitHub Issues:** Closes #1967
