### PR TITLE
Make multi_dispatch treat scipy same as numpy

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -607,6 +607,11 @@
   when the `features` parameter is batched and provided as a 2D array.
   [(#1990)](https://github.com/PennyLaneAI/pennylane/pull/1990)
 
+* Fixes a bug where using SciPy sparse matrices with the new QNode
+  could lead to a warning being raised about prioritizing the TensorFlow
+  and PyTorch interfaces.
+  [(#2001)](https://github.com/PennyLaneAI/pennylane/pull/2001)
+
 <h3>Documentation</h3>
 
 * Added examples in documentation for some operations.

--- a/pennylane/math/multi_dispatch.py
+++ b/pennylane/math/multi_dispatch.py
@@ -44,24 +44,24 @@ def _multi_dispatch(values):
       be treated as non-differentiable NumPy arrays. A warning will be raised
       suggesting that vanilla NumPy be used instead.
 
-    * Vanilla NumPy arrays can be used alongside other tensor objects; they will
-      always be treated as non-differentiable constants.
+    * Vanilla NumPy arrays and SciPy sparse matrices can be used alongside other tensor objects;
+      they will always be treated as non-differentiable constants.
     """
     if "resource_variable" in getattr(values, "__module__", tuple()):
         values = np.asarray(values)
 
     interfaces = {get_interface(v) for v in values}
 
-    if len(set(interfaces) - {"numpy", "autograd"}) > 1:
+    if len(set(interfaces) - {"numpy", "scipy", "autograd"}) > 1:
         # contains multiple non-autograd interfaces
         raise ValueError("Tensors contain mixed types; cannot determine dispatch library")
 
-    non_numpy_interfaces = set(interfaces) - {"numpy"}
+    non_numpy_scipy_interfaces = set(interfaces) - {"numpy", "scipy"}
 
-    if len(non_numpy_interfaces) > 1:
+    if len(non_numpy_scipy_interfaces) > 1:
         # contains autograd and another interface
         warnings.warn(
-            f"Contains tensors of types {non_numpy_interfaces}; dispatch will prioritize "
+            f"Contains tensors of types {non_numpy_scipy_interfaces}; dispatch will prioritize "
             "TensorFlow and PyTorch over autograd. Consider replacing Autograd with vanilla NumPy.",
             UserWarning,
         )

--- a/tests/math/test_functions.py
+++ b/tests/math/test_functions.py
@@ -16,7 +16,6 @@
 import itertools
 import numpy as onp
 import pytest
-import warnings
 
 import pennylane as qml
 from pennylane import numpy as np
@@ -54,19 +53,6 @@ class TestGetMultiTensorbox:
         with pytest.warns(UserWarning, match="Consider replacing Autograd with vanilla NumPy"):
             fn._multi_dispatch([x, y])
 
-    def test_no_warning_scipy_and_autograd(self):
-        """Test that no warning is raised if the sequence of tensors contains
-        SciPy sparse matrices and autograd tensors."""
-        x = sci.sparse.eye(3)
-        y = np.array([0.5, 0.1])
-
-        warnings.filterwarnings(
-            action="error",
-            message="Contains tensors of types {.+}; dispatch will prioritize TensorFlow",
-            category=UserWarning,
-        )
-        fn._multi_dispatch([x, y])
-
     def test_warning_torch_and_autograd(self):
         """Test that a warning is raised if the sequence of tensors contains
         both torch and autograd tensors."""
@@ -75,6 +61,15 @@ class TestGetMultiTensorbox:
 
         with pytest.warns(UserWarning, match="Consider replacing Autograd with vanilla NumPy"):
             fn._multi_dispatch([x, y])
+
+    @pytest.mark.filterwarnings("error:Contains tensors of types {.+}; dispatch will prioritize")
+    def test_no_warning_scipy_and_autograd(self):
+        """Test that no warning is raised if the sequence of tensors contains
+        SciPy sparse matrices and autograd tensors."""
+        x = sci.sparse.eye(3)
+        y = np.array([0.5, 0.1])
+
+        fn._multi_dispatch([x, y])
 
     def test_return_tensorflow_box(self):
         """Test that TensorFlow is correctly identified as the dispatching library."""

--- a/tests/math/test_functions.py
+++ b/tests/math/test_functions.py
@@ -16,6 +16,7 @@
 import itertools
 import numpy as onp
 import pytest
+import warnings
 
 import pennylane as qml
 from pennylane import numpy as np
@@ -28,6 +29,7 @@ tf = pytest.importorskip("tensorflow", minversion="2.1")
 torch = pytest.importorskip("torch")
 jax = pytest.importorskip("jax")
 jnp = pytest.importorskip("jax.numpy")
+sci = pytest.importorskip("scipy")
 
 
 class TestGetMultiTensorbox:
@@ -51,6 +53,19 @@ class TestGetMultiTensorbox:
 
         with pytest.warns(UserWarning, match="Consider replacing Autograd with vanilla NumPy"):
             fn._multi_dispatch([x, y])
+
+    def test_no_warning_scipy_and_autograd(self):
+        """Test that no warning is raised if the sequence of tensors contains
+        SciPy sparse matrices and autograd tensors."""
+        x = sci.sparse.eye(3)
+        y = np.array([0.5, 0.1])
+
+        warnings.filterwarnings(
+            action="error",
+            message="Contains tensors of types {.+}; dispatch will prioritize TensorFlow",
+            category=UserWarning,
+        )
+        fn._multi_dispatch([x, y])
 
     def test_warning_torch_and_autograd(self):
         """Test that a warning is raised if the sequence of tensors contains


### PR DESCRIPTION
**Context:**
When dispatching to an interface for a sequence of tensors, the function `_multi_dispatch` in [multi_dispatch.py](https://github.com/PennyLaneAI/pennylane/blob/master/pennylane/math/multi_dispatch.py) mistakenly lumps the SciPy interface together with "other" interfaces (such as TensorFlow and Torch, i.e. non-NumPy and non-Autograd). This leads to a warning being raised when a SciPy sparse matrix is used together with NumPy/Autograd about prioritizing TensorFlow and Torch:
```
UserWarning: Contains tensors of types {'autograd', 'scipy'}; dispatch will prioritize TensorFlow and PyTorch over autograd. Consider replacing Autograd with vanilla NumPy.
```

**Description of the Change:**
`_multi_dispatch` treats arguments with a 'SciPy' interface (e.g. sparse matrix) the same as for the NumPy interface, that is they are regarded as non-differentiable and can be used alongside other interfaces.

**Benefits:** The warning is not raised, which would be confusing in this situation.

**Possible Drawbacks:**

**Related GitHub Issues:**
