### PR TITLE
Fix missing function call in metric tensor docs example

### DIFF
--- a/pennylane/transforms/metric_tensor.py
+++ b/pennylane/transforms/metric_tensor.py
@@ -183,7 +183,7 @@ def metric_tensor(tape, approx=None, allow_nonunitary=True, aux_wire=None, devic
     For example, we can compute the gradient of the Frobenius norm of the metric tensor
     with respect to the QNode ``weights`` :
 
-    >>> norm_fn = lambda x: qml.math.linalg(mt_fn(x), ord="fro")
+    >>> norm_fn = lambda x: qml.math.linalg.norm(mt_fn(x), ord="fro")
     >>> grad_fn = qml.grad(norm_fn)
     >>> grad_fn(weights)
     array([-0.0282246 ,  0.01340413,  0.        ,  0.        ])


### PR DESCRIPTION
This section in the upcoming [documentation](https://pennylane--2001.org.readthedocs.build/en/2001/code/api/pennylane.metric_tensor.html?highlight=metric_tensor#pennylane.metric_tensor) for the metric tensor has a small error in the example code:

> The returned metric tensor is also fully differentiable in all interfaces. For example, we can compute the gradient of the Frobenius norm of the metric tensor with respect to the QNode weights :
> ```py
> >>> norm_fn = lambda x: qml.math.linalg(mt_fn(x), ord="fro")
> >>> grad_fn = qml.grad(norm_fn)
> >>> grad_fn(weights)
> array([-0.0282246 ,  0.01340413,  0.        ,  0.        ])
> ```
> 

Running the example results in:
```py
TypeError: 'NumpyMimic' object is not callable
```
because the code attempts to call `qml.math.linalg` instead of `qml.math.linalg.norm`.