### PR TITLE
Tape validation for the JAX interface (batch execute)

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -387,6 +387,14 @@
 
 <h3>Improvements</h3>
 
+* The execution of QNodes that have
+
+  - multiple return types;
+  - a return type other than Variance and Expectation
+
+  now raises a descriptive error message when using the JAX interface.
+  [(#2011)](https://github.com/PennyLaneAI/pennylane/pull/2011)
+
 * The PennyLane `qchem` package is now lazily imported; it will only be imported
   the first time it is accessed.
   [(#1962)](https://github.com/PennyLaneAI/pennylane/pull/1962)

--- a/pennylane/interfaces/batch/jax.py
+++ b/pennylane/interfaces/batch/jax.py
@@ -86,6 +86,7 @@ def execute(tapes, device, execute_fn, gradient_fn, gradient_kwargs, _n=1, max_d
         _n=_n,
     )
 
+
 def _validate_tapes(tapes):
     """Validates that the input tapes are compatible with JAX support.
 

--- a/pennylane/interfaces/batch/jax.py
+++ b/pennylane/interfaces/batch/jax.py
@@ -23,6 +23,7 @@ from jax.experimental import host_callback
 
 import numpy as np
 import pennylane as qml
+from pennylane.operation import Variance, Expectation
 
 dtype = jnp.float64
 
@@ -85,6 +86,27 @@ def execute(tapes, device, execute_fn, gradient_fn, gradient_kwargs, _n=1, max_d
         _n=_n,
     )
 
+def _validate_tapes(tapes):
+    """Validates that the input tapes are compatible with JAX support.
+
+    Raises:
+        ValueError: if tapes with non-scalar outputs were provided or a return
+        type other than variance and expectation value was used
+    """
+    for t in tapes:
+
+        if len(t.observables) != 1:
+            raise ValueError(
+                "The JAX interface currently only supports quantum nodes with a single return type."
+            )
+
+        for o in t.observables:
+            return_type = o.return_type
+            if return_type is not Variance and return_type is not Expectation:
+                raise ValueError(
+                    f"Only Variance and Expectation returns are supported for the JAX interface, given {return_type}."
+                )
+
 
 def _execute(
     params,
@@ -95,6 +117,8 @@ def _execute(
     gradient_kwargs=None,
     _n=1,
 ):  # pylint: disable=dangerous-default-value,unused-argument
+
+    _validate_tapes(tapes)
 
     # Only have scalar outputs
     total_size = len(tapes)
@@ -206,6 +230,8 @@ def _execute_with_fwd(
     gradient_kwargs=None,
     _n=1,
 ):  # pylint: disable=dangerous-default-value,unused-argument
+
+    _validate_tapes(tapes)
 
     # Only have scalar outputs
     total_size = len(tapes)

--- a/tests/interfaces/test_batch_jax_qnode.py
+++ b/tests/interfaces/test_batch_jax_qnode.py
@@ -313,7 +313,10 @@ class TestQNode:
             qml.CNOT(wires=[0, 1])
             return qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliZ(1))
 
-        with pytest.raises(ValueError, match="JAX interface currently only supports quantum nodes with a single return type"):
+        with pytest.raises(
+            ValueError,
+            match="JAX interface currently only supports quantum nodes with a single return type",
+        ):
             my_circuit(1)
 
     @pytest.mark.parametrize("ret", [qml.probs(wires=0), qml.state()])
@@ -328,15 +331,18 @@ class TestQNode:
         if diff_method == "adjoint":
             pytest.skip("Adjoint does not support states")
 
-
         @qml.qnode(dev, interface="jax", diff_method=diff_method, mode=mode)
         def my_circuit(param):
             qml.RX(param, wires=0)
             qml.CNOT(wires=[0, 1])
             return qml.apply(ret)
 
-        with pytest.raises(ValueError, match="Only Variance and Expectation returns are supported for the JAX interface"):
+        with pytest.raises(
+            ValueError,
+            match="Only Variance and Expectation returns are supported for the JAX interface",
+        ):
             my_circuit(1)
+
 
 class TestShotsIntegration:
     """Test that the QNode correctly changes shot value, and

--- a/tests/interfaces/test_batch_jax_qnode.py
+++ b/tests/interfaces/test_batch_jax_qnode.py
@@ -300,6 +300,43 @@ class TestQNode:
         )
         assert np.allclose(res, expected, atol=tol, rtol=0)
 
+    def test_multiple_outputs_raises(self, dev_name, diff_method, mode, tol):
+        """Test executing a QNode that has multiple outputs raises an error."""
+        dev = qml.device(dev_name, wires=2)
+
+        if diff_method == "backprop":
+            pytest.skip("Test is not applicable for backprop")
+
+        @qml.qnode(dev, interface="jax", diff_method=diff_method, mode=mode)
+        def my_circuit(param):
+            qml.RX(param, wires=0)
+            qml.CNOT(wires=[0, 1])
+            return qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliZ(1))
+
+        with pytest.raises(ValueError, match="JAX interface currently only supports quantum nodes with a single return type"):
+            my_circuit(1)
+
+    @pytest.mark.parametrize("ret", [qml.probs(wires=0), qml.state()])
+    def test_not_expval_or_var_raises(self, dev_name, diff_method, mode, ret, tol):
+        """Test executing a QNode that has a return type other than expval or
+        var raises an error."""
+        dev = qml.device(dev_name, wires=2)
+
+        if diff_method == "backprop":
+            pytest.skip("Test is not applicable for backprop")
+
+        if diff_method == "adjoint":
+            pytest.skip("Adjoint does not support states")
+
+
+        @qml.qnode(dev, interface="jax", diff_method=diff_method, mode=mode)
+        def my_circuit(param):
+            qml.RX(param, wires=0)
+            qml.CNOT(wires=[0, 1])
+            return qml.apply(ret)
+
+        with pytest.raises(ValueError, match="Only Variance and Expectation returns are supported for the JAX interface"):
+            my_circuit(1)
 
 class TestShotsIntegration:
     """Test that the QNode correctly changes shot value, and


### PR DESCRIPTION
Adds a validation step to using the JAX interface akin to the [previous version of the interface](https://github.com/PennyLaneAI/pennylane/blob/488312df98b796556dcbddae63c63ff88c81c998/pennylane/interfaces/jax.py#L84) before batch execution.