### PR TITLE
`Tensor.matrix`: Sort before grouping and check partial wires overlaps

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -6,6 +6,20 @@
 
 <h3>Improvements</h3>
 
+* The method `matrix` of `qml.operations.Tensor` now correctly computes
+  the matrix of a multi-observable tensor if multiple observables act on
+  the same wires but are not sorted within the `Tensor` according to the
+  wires they act on. 
+  [(#2010)](https://github.com/XanaduAI/pennylane/pull/2010)
+
+  In addition, a `WireError` is raised whenever any pair of observables in the
+  Tensor has partial but not full overlap of the wires.
+  As an example, the matrix of 
+  `qml.operation.Tensor(qml.PauliX(0), qml.Hermitian(A, [0, 1]))`, where `A`
+  is some Hermitian `4x4` matrix, is not computed but raises a `WireError`.
+  Previously, this computed an `8x8` matrix that does not match the number
+  of wires of this `Tensor`.
+
 <h3>Breaking changes</h3>
 
 <h3>Documentation</h3>

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -1252,7 +1252,7 @@ class Tensor(Observable):
         Returns:
             list[Any]: flattened list containing all dependent parameters
         """
-        return [p for sublist in [o.data for o in self.obs] for p in sublist]
+        return sum((o.data for o in self.obs), start=[])
 
     @property
     def num_params(self):
@@ -1409,9 +1409,13 @@ class Tensor(Observable):
         Returns:
             array: matrix representation
         """
+        # Check for partially (but not fully) overlapping wires in the observables 
+        self.check_wires_partial_overlap()
         # group the observables based on what wires they act on
         U_list = []
-        for _, g in itertools.groupby(self.obs, lambda x: x.wires.labels):
+        key = lambda x: x.wires.labels
+        obs = sorted(self.obs, key=key)
+        for _, g in itertools.groupby(self.obs, key):
             # extract the matrices of each diagonalizing gate
             mats = [i.matrix for i in g]
 
@@ -1425,6 +1429,28 @@ class Tensor(Observable):
         # Return the Hermitian matrix representing the observable
         # over the defined wires.
         return functools.reduce(np.kron, U_list)
+
+    def check_wires_partial_overlap(self):
+        r"""Tests whether any two observables in the Tensor have partially
+        overlapping wires. 
+
+        Raises:
+            .wires.WireError: If any two of the observables in the Tensor
+            share some but not all wires.
+
+        .. note::
+
+            Fully overlapping wires, i.e. observables with
+            same (sets of) wires are not reported, as the ``matrix`` method is
+            well-defined and implemented for this scenario.
+        """
+        for o1, o2 in itertools.combinations(self.obs, r=2):
+            shares = qml.wires.Wires.shared_wires([o1.wires, o2.wires])
+            if shared and shared!=o1.wires:
+                raise qml.wires.WireError(
+                    "The matrix for Tensors of Tensors/Observables with partially "
+                    "overlapping wires is not supported."
+                )
 
     def sparse_matrix(self, wires=None):
         r"""Computes a `scipy.sparse.coo_matrix` representation of this Tensor.

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -1409,7 +1409,7 @@ class Tensor(Observable):
         Returns:
             array: matrix representation
         """
-        # Check for partially (but not fully) overlapping wires in the observables 
+        # Check for partially (but not fully) overlapping wires in the observables
         self.check_wires_partial_overlap()
         # group the observables based on what wires they act on
         U_list = []
@@ -1432,7 +1432,7 @@ class Tensor(Observable):
 
     def check_wires_partial_overlap(self):
         r"""Tests whether any two observables in the Tensor have partially
-        overlapping wires. 
+        overlapping wires.
 
         Raises:
             .wires.WireError: If any two of the observables in the Tensor
@@ -1446,7 +1446,7 @@ class Tensor(Observable):
         """
         for o1, o2 in itertools.combinations(self.obs, r=2):
             shares = qml.wires.Wires.shared_wires([o1.wires, o2.wires])
-            if shared and shared!=o1.wires:
+            if shared and shared != o1.wires:
                 raise qml.wires.WireError(
                     "The matrix for Tensors of Tensors/Observables with partially "
                     "overlapping wires is not supported."

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -1415,7 +1415,7 @@ class Tensor(Observable):
         U_list = []
         key = lambda x: x.wires.labels
         obs = sorted(self.obs, key=key)
-        for _, g in itertools.groupby(self.obs, key):
+        for _, g in itertools.groupby(obs, key):
             # extract the matrices of each diagonalizing gate
             mats = [i.matrix for i in g]
 
@@ -1445,8 +1445,9 @@ class Tensor(Observable):
             well-defined and implemented for this scenario.
         """
         for o1, o2 in itertools.combinations(self.obs, r=2):
-            shares = qml.wires.Wires.shared_wires([o1.wires, o2.wires])
-            if shared and shared != o1.wires:
+            shared = qml.wires.Wires.shared_wires([o1.wires, o2.wires])
+            print(shared)
+            if shared and (shared != o1.wires or shared != o2.wires):
                 raise qml.wires.WireError(
                     "The matrix for Tensors of Tensors/Observables with partially "
                     "overlapping wires is not supported."

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -15,7 +15,7 @@
 Unit tests for :mod:`pennylane.operation`.
 """
 import itertools
-import functools
+from functools import reduce
 
 import pytest
 import numpy as np
@@ -670,7 +670,7 @@ class TestTensor:
         # since the test is assuming consecutive wires for each observable
         # in the tensor product, it is sufficient to Kronecker product
         # the entire list.
-        U = functools.reduce(np.kron, U_list)
+        U = reduce(np.kron, U_list)
 
         res = U @ O_mat @ U.conj().T
         expected = np.diag(O.eigvals)
@@ -686,18 +686,59 @@ class TestTensor:
         O = qml.PauliX(0) @ qml.PauliY(1) @ qml.Hermitian(H, [2, 3])
 
         res = O.matrix
-        expected = np.kron(qml.PauliY._matrix(), H)
-        expected = np.kron(qml.PauliX._matrix(), expected)
+        expected = reduce(np.kron, [qml.PauliX._matrix(), qml.PauliY._matrix(), H])
 
         assert np.allclose(res, expected, atol=tol, rtol=0)
 
-    def test_multiplication_matrix(self, tol):
-        """If using the ``@`` operator on two observables acting on the
-        same wire, the tensor class should treat this as matrix multiplication."""
-        O = qml.PauliX(0) @ qml.PauliX(0)
+    def test_tensor_matrix_unsorted(self, tol):
+        """Test that the tensor product matrix method returns
+        the correct result if the observables are added unsorted
+        with respect to a canonical wire ordering."""
+        H = np.diag([1, 2, 3, 4])
+        O = qml.PauliX(0) @ qml.Hermitian(H, [2, 3]) @ qml.PauliY(1)
 
         res = O.matrix
-        expected = qml.PauliX._matrix() @ qml.PauliX._matrix()
+        expected = reduce(np.kron, [qml.PauliX._matrix(), qml.PauliY._matrix(), H])
+
+        assert np.allclose(res, expected, atol=tol, rtol=0)
+
+    def test_tensor_matrix_partial_wires_overlap_error(self, tol):
+        """Test that the tensor product matrix method returns
+        the correct result if the observables are added unsorted
+        with respect to a canonical wire ordering."""
+        H = np.diag([1, 2, 3, 4])
+        O1 = qml.PauliX(0) @ qml.Hermitian(H, [0, 1])
+        O2 = qml.Hermitian(H, [0, 1]) @ qml.PauliY(1)
+
+        for O in (O1, O2):
+            with pytest.raises(qml.wires.WireError, match="partially overlapping"):
+                O.matrix
+
+    @pytest.mark.parametrize("classes", [(qml.PauliX, qml.PauliX), (qml.PauliZ, qml.PauliX)])
+    def test_multiplication_matrix(self, tol, classes):
+        """If using the ``@`` operator on two observables acting on the
+        same wire, the tensor class should treat this as matrix multiplication."""
+        c1, c2 = classes
+        O = c1(0) @ c2(0)
+
+        res = O.matrix
+        expected = c1._matrix() @ c2._matrix()
+
+        assert np.allclose(res, expected, atol=tol, rtol=0)
+
+    @pytest.mark.parametrize("classes", [(qml.PauliX, qml.PauliX), (qml.PauliZ, qml.PauliX)])
+    def test_multiplication_matrix_among_obs(self, tol, classes):
+        """If using the ``@`` operator on two observables acting on the
+        same wire, the tensor class should treat this as matrix multiplication
+        even if there are other observables in the Tensor that act on different
+        wires."""
+        c1, c2 = classes
+        O = c1(1) @ qml.PauliZ(0) @ qml.PauliY(2) @ c2(1)
+
+        res = O.matrix
+        expected = reduce(
+            np.kron, [qml.PauliZ._matrix(), c1._matrix() @ c2._matrix(), qml.PauliY._matrix()]
+        )
 
         assert np.allclose(res, expected, atol=tol, rtol=0)
 


### PR DESCRIPTION
**Context:**
This PR implements the changes suggested [here](https://github.com/PennyLaneAI/pennylane/issues/715#issuecomment-990952362). 

**Description of the Change:**
1. Before using `itertools.groupby` to find observables that act on the same wires (that is on the same total set of wires, not just any partial overlapping wires) within `Tensor.matrix`, a `sorted` call is introduced. As mentioned in the referenced comment, `itertools.groupby` in general assumes that this is done by users, otherwise the grouping simply does not work as expected.
2. Also within `Tensor.matrix`, a check is performed that no pair of observables in `Tensor.obs` has a partial overlap w.r.t their wires. That is, full overlaps are covered by the change above, implementing matrix multiplication, but for example `qml.PauliX(1) @ qml.Hermitian(A, [0, 1, 2])` (for a 8x8 matrix `A`) will not have a computable matrix, but the `matrix` method will raise a `qml.wires.WireError`. This additional check costs N^2/2 checks whether a wires object is empty and N^2 checks whether two wires objects are the same, where N is the number of objects in `Tensor.obs`.

**Benefits:**
Effects of 1.: Observables in a `Tensor` acting on the same set of wires are multiplied together via standard matrix multiplication, independently from their order in the `Tensor.obs`, when calling `Tensor.matrix` (not symbolically, though). A particular benefit is that the output matrix is not augmented compared to the size one would expect based on `Tensor.wires`.
Also, the matrix respects the "generic" ordering or wires, which in particular includes integers and strings (Note that wires sets for a single observable that do _not_ respect this ordering themselves, like `qml.CNOT([3,0])` might cause strange effects here).
This means that the tensor `qml.PauliZ(4) @ qml.PauliX(1)` has the same output for `matrix` as `qml.PauliX(1) @ qml.PauliZ(4)`, namely `np.kron(qml.PauliX._matrix(), qml.PauliZ._matrix())`.
Effects of 2.: Together with 1, `Tensor.matrix` will not produce outputs that mismatch the shape expected based on the wires of the `Tensor`. Scenarios that trigger the implemented error are those for which additional, potentially expensive, padding of identities, followed by augmented matrix multiplications would be required, which we actively avoid with this check. As an example, consider a large Hermitian matrix tensored with a Pauli on one of its wires: `qml.Hermitian(A, wires=list(range(20))) @ qml.PauliX(2)`. Calling `matrix` on this without obtaining a wrongly-shaped output would require us to compute
```python
op1 = reduce(np.kron, [qml.Identity(0), qml.Identity(1), qml.PauliX._matrix()]+[qml.Identity(w) for w in range(3, 20)])
matrix = qml.Hermitian(A, wires=list(range(20))) @ op1
```
which is quite expensive and might escalate quickly if there are many observables with small overlaps in their wires.

**Possible Drawbacks:**
All calls to `Tensor.matrix` are affected by the two changes, incurring an overhead of O(N log(N))+O(N^2)=O(N^2) for the sorting operations and overlap checks. As the operations are quite basic, I expect this overhead to be small, but for many calls to the matrix, it might accumulate.
An alternative method would be to carry out the sorting and the overlap checks on the symbolic level, say in `__init__`. This would avoid repeating these operations for one given Tensor, but would incur the overhead even if `matrix` is not called, and in particular avoid Tensor objects with observables that have partial wires overlap.

**Related GitHub Issues:**
#715 
