### PR TITLE
Fix two-qubit decomp to consider arbitrary number of unitaries

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -8,9 +8,17 @@
 
 <h3>Breaking changes</h3>
 
+<h3>Bug fixes</h3>
+
+* Fixes a bug in queueing of the `two_qubit_decomposition` method that
+  originally led to circuits with >3 two-qubit unitaries failing when passed
+  through the `unitary_to_rot` optimization transform.
+  [(#2015)](https://github.com/PennyLaneAI/pennylane/pull/2015)
+
 <h3>Documentation</h3>
 
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):
 
+Olivia Di Matteo

--- a/pennylane/transforms/decompositions/two_qubit_unitary.py
+++ b/pennylane/transforms/decompositions/two_qubit_unitary.py
@@ -611,9 +611,8 @@ def two_qubit_decomposition(U, wires):
     # If there is an active tape, queue the decomposition so that expand works
     current_tape = qml.tape.get_active_tape()
 
-    if current_tape:
-        with current_tape:
-            for op in decomp:
-                qml.apply(op)
+    if current_tape is not None:
+        for op in decomp:
+            qml.apply(op, context=current_tape)
 
     return decomp


### PR DESCRIPTION
**Context:** Circuits with >3 two-qubit unitaries were yielding a `RecursionError` when put through the `unitary_to_rot` transform.

**Description of the Change:** Fixes the queuing in the `two_qubit_decomposition` method and adds a relevant unit test.

**Benefits:** Arbitrary number of two-qubit unitaries can now be decomposed.

**Possible Drawbacks:** None; although, I'm admittedly not sure why this fixed the problem.

**Related GitHub Issues:** #2014 
