### PR TITLE
[OpRefactor] add temporary hyperparameter attribute

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -17,6 +17,13 @@
 
 <h3>Documentation</h3>
 
+<h3>Operator class refactor</h3>
+
+The Operator class has undergone a major refactor with the following changes:
+
+* A `hyperparameters` attribute was added to the operator class.
+  [(#2017)](https://github.com/PennyLaneAI/pennylane/pull/2017)
+
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -537,8 +537,7 @@ class Operator(abc.ABC):
 
     @property
     def hyperparameters(self):
-        """Non-trainable variables that define this operation.
-        """
+        """Non-trainable variables that define this operation."""
         # TODO [Maria/Josh]: this is a placeholder; in future we want to
         # define hyperparameters for all ops, even if they overwrite init
         if hasattr(self, "_hyperparameters"):

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -538,8 +538,6 @@ class Operator(abc.ABC):
     @property
     def hyperparameters(self):
         """Non-trainable variables that define this operation."""
-        # TODO [Maria/Josh]: this is a placeholder; in future we want to
-        # define hyperparameters for all ops, even if they overwrite init
         if hasattr(self, "_hyperparameters"):
             return self._hyperparameters
         return {}

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -537,7 +537,7 @@ class Operator(abc.ABC):
 
     @property
     def hyperparameters(self):
-        """Non-trainable variables that define this operation."""
+        """dict: Dictionary of non-trainable variables that define this operation."""
         if hasattr(self, "_hyperparameters"):
             return self._hyperparameters
         return {}

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -464,6 +464,7 @@ class Operator(abc.ABC):
         self._name = self.__class__.__name__  #: str: name of the operator
         self._id = id
         self.queue_idx = None  #: int, None: index of the Operator in the circuit queue, or None if not in a queue
+        self._hyperparameters = {}
 
         if wires is None:
             raise ValueError(f"Must specify the wires that {self.name} acts on")
@@ -533,6 +534,16 @@ class Operator(abc.ABC):
     def parameters(self):
         """Current parameter values."""
         return self.data.copy()
+
+    @property
+    def hyperparameters(self):
+        """Non-trainable variables that define this operation.
+        """
+        # TODO [Maria/Josh]: this is a placeholder; in future we want to
+        # define hyperparameters for all ops, even if they overwrite init
+        if hasattr(self, "_hyperparameters"):
+            return self._hyperparameters
+        return {}
 
     @staticmethod
     def decomposition(*params, wires):

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -540,7 +540,8 @@ class Operator(abc.ABC):
         """dict: Dictionary of non-trainable variables that define this operation."""
         if hasattr(self, "_hyperparameters"):
             return self._hyperparameters
-        return {}
+        self._hyperparameters = {}
+        return self._hyperparameters
 
     @staticmethod
     def decomposition(*params, wires):

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -98,10 +98,16 @@ class TestOperatorConstruction:
         class MyOp(qml.operation.Operation):
             num_wires = 1
 
+        class MyOpOverwriteInit(qml.operation.Operation):
+            num_wires = 1
+
             def __init__(self, wires):
-                super().__init__(wires=wires)
+                pass
 
         op = MyOp(wires=0)
+        assert op.hyperparameters == {}
+
+        op = MyOpOverwriteInit(wires=0)
         assert op.hyperparameters == {}
 
 

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -110,6 +110,18 @@ class TestOperatorConstruction:
         op = MyOpOverwriteInit(wires=0)
         assert op.hyperparameters == {}
 
+    def test_custom_hyperparams(self):
+        """Tests that an operation can add custom hyperparams."""
+
+        class MyOp(qml.operation.Operation):
+            num_wires = 1
+
+            def __init__(self, wires, basis_state=None):
+                self._hyperparameters = {"basis_state": basis_state}
+
+        state = [0, 1, 0]
+        assert MyOp(wires=1, basis_state=state).hyperparameters["basis_state"] == state
+
 
 class TestOperationConstruction:
     """Test custom operations construction."""

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -92,6 +92,18 @@ class TestOperatorConstruction:
         op.name = "MyOp"
         assert op.name == "MyOp"
 
+    def test_default_hyperparams(self):
+        """Tests that the hyperparams attribute is defined for all operations."""
+
+        class MyOp(qml.operation.Operation):
+            num_wires = 1
+
+            def __init__(self, wires):
+                super().__init__(wires=wires)
+
+        op = MyOp(wires=0)
+        assert op.hyperparameters == {}
+
 
 class TestOperationConstruction:
     """Test custom operations construction."""


### PR DESCRIPTION
**Context:**

We decided to move towards a system where an operators trainable parameters are stored as `op.parameters` and the non-trainable ones (like `control_wires`, `basis_state`, `features`) as a dictionary `op.hyperparameters`.

This PR introduces a dummy version to enable PRs to be build on this attribute, even though the details will be worked out moving forward.

**Description of the Change:**

Add a simple test and attribute.

