### PR TITLE
Fix `classical_jacobian` with untrainable arguments when used with Torch

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -10,6 +10,11 @@
 
 <h3>Bug fixes</h3>
 
+* Fixes a bug in `classical_jacobian` when used with Torch, where the
+  Jacobian of the preprocessing was also computed for non-trainable
+  parameters.
+  [(#20xx)](https://github.com/PennyLaneAI/pennylane/pull/20xx)
+
 * Fixes a bug in queueing of the `two_qubit_decomposition` method that
   originally led to circuits with >3 two-qubit unitaries failing when passed
   through the `unitary_to_rot` optimization transform.
@@ -21,4 +26,4 @@
 
 This release contains contributions from (in alphabetical order):
 
-Olivia Di Matteo
+Olivia Di Matteo, David Wierichs

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -13,7 +13,7 @@
 * Fixes a bug in `classical_jacobian` when used with Torch, where the
   Jacobian of the preprocessing was also computed for non-trainable
   parameters.
-  [(#20xx)](https://github.com/PennyLaneAI/pennylane/pull/20xx)
+  [(#2020)](https://github.com/PennyLaneAI/pennylane/pull/2020)
 
 * Fixes a bug in queueing of the `two_qubit_decomposition` method that
   originally led to circuits with >3 two-qubit unitaries failing when passed

--- a/pennylane/transforms/classical_jacobian.py
+++ b/pennylane/transforms/classical_jacobian.py
@@ -172,16 +172,13 @@ def classical_jacobian(qnode, argnum=None, expand_fn=None, trainable_only=True):
         import torch
 
         def _jacobian(*args, **kwargs):  # pylint: disable=unused-argument
-            nonlocal argnum
-
             jac = torch.autograd.functional.jacobian(classical_preprocessing, args)
 
-            if argnum is None:
-                argnum = qml.math.get_trainable_indices(args)
-            if np.isscalar(argnum):
-                jac = jac[argnum]
+            torch_argnum = argnum if argnum is not None else qml.math.get_trainable_indices(args)
+            if np.isscalar(torch_argnum):
+                jac = jac[torch_argnum]
             else:
-                jac = tuple((jac[idx] for idx in argnum))
+                jac = tuple((jac[idx] for idx in torch_argnum))
             return jac
 
         return _jacobian

--- a/pennylane/transforms/classical_jacobian.py
+++ b/pennylane/transforms/classical_jacobian.py
@@ -172,12 +172,16 @@ def classical_jacobian(qnode, argnum=None, expand_fn=None, trainable_only=True):
         import torch
 
         def _jacobian(*args, **kwargs):  # pylint: disable=unused-argument
+            nonlocal argnum
+
             jac = torch.autograd.functional.jacobian(classical_preprocessing, args)
-            if argnum is not None:
-                if np.isscalar(argnum):
-                    jac = jac[argnum]
-                else:
-                    jac = tuple((jac[idx] for idx in argnum))
+
+            if argnum is None:
+                argnum = qml.math.get_trainable_indices(args)
+            if np.isscalar(argnum):
+                jac = jac[argnum]
+            else:
+                jac = tuple((jac[idx] for idx in argnum))
             return jac
 
         return _jacobian


### PR DESCRIPTION
**Context:**
This implements the fix proposed in [this comment](https://github.com/PennyLaneAI/pennylane/issues/2018#issuecomment-992598533) on issue 2018.

**Description of the Change:**
For `argnum=None` and `interface="torch"`, `argnum` is now determined based on the `requires_grad` property of the arguments passed to `classical_jacobian`. This is implemented via `qml.math.get_trainable_indices`. When `argnum` is passed by the user, it of course takes precedence over this default behaviour (like before).

**Benefits:**
Fixes #2018

**Possible Drawbacks:**
n/a

**Related GitHub Issues:**
#2018