### PR TITLE
[OpRefractor] remove `string_for_inverse`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -22,6 +22,7 @@
 The Operator class has undergone a major refactor with the following changes:
 
 * The `string_for_inverse` attribute is removed.
+  [(#2021)](https://github.com/PennyLaneAI/pennylane/pull/2021)
 
 <h3>Contributors</h3>
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -17,6 +17,12 @@
 
 <h3>Documentation</h3>
 
+<h3>Operator class refactor</h3>
+
+The Operator class has undergone a major refactor with the following changes:
+
+* The `string_for_inverse` attribute is removed.
+
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -815,8 +815,8 @@ class Device(abc.ABC):
             return operation.__name__ in self.operations
         if isinstance(operation, str):
 
-            if operation.endswith(Operation.string_for_inverse):
-                in_ops = operation[: -len(Operation.string_for_inverse)] in self.operations
+            if operation.endswith(".inv"):
+                in_ops = operation[: -4] in self.operations
                 # TODO: update when all capabilities keys changed to "supports_inverse_operations"
                 supports_inv = self.capabilities().get(
                     "supports_inverse_operations", False
@@ -847,8 +847,8 @@ class Device(abc.ABC):
         if isinstance(observable, str):
 
             # This check regards observables that are also operations
-            if observable.endswith(Operation.string_for_inverse):
-                return self.supports_operation(observable[: -len(Operation.string_for_inverse)])
+            if observable.endswith(".inv"):
+                return self.supports_operation(observable[: -4])
 
             return observable in self.observables
 

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -816,7 +816,7 @@ class Device(abc.ABC):
         if isinstance(operation, str):
 
             if operation.endswith(".inv"):
-                in_ops = operation[: -4] in self.operations
+                in_ops = operation[:-4] in self.operations
                 # TODO: update when all capabilities keys changed to "supports_inverse_operations"
                 supports_inv = self.capabilities().get(
                     "supports_inverse_operations", False
@@ -848,7 +848,7 @@ class Device(abc.ABC):
 
             # This check regards observables that are also operations
             if observable.endswith(".inv"):
-                return self.supports_operation(observable[: -4])
+                return self.supports_operation(observable[:-4])
 
             return observable in self.observables
 

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -599,8 +599,6 @@ class Operation(Operator):
             This flag is useful if there is some reason to run an Operation
             outside of a BaseQNode context.
     """
-    # pylint: disable=abstract-method
-    string_for_inverse = ".inv"
 
     @property
     def grad_method(self):
@@ -802,7 +800,7 @@ class Operation(Operator):
     @property
     def name(self):
         """Get and set the name of the operator."""
-        return self._name + Operation.string_for_inverse if self.inverse else self._name
+        return self._name + ".inv" if self.inverse else self._name
 
     def label(self, decimals=None, base_label=None):
         if self.inverse:


### PR DESCRIPTION
The `string_for_inverse` attribute was used in only place, and that place could easily just use `".inv"` directly instead.  Therefore the attribute is removed.