### PR TITLE
Upgrade Dask to `2021.10`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,6 @@ autograd==1.3
 toml==0.10
 appdirs==1.4
 semantic_version==2.6
-dask[delayed]==2021.08
+dask[delayed]==2021.10
 autoray>=0.2.5
 matplotlib==3.4


### PR DESCRIPTION
Updates the Dask version being used for security purposes.