### PR TITLE
Extend the interfaces description page

### DIFF
--- a/doc/introduction/interfaces.rst
+++ b/doc/introduction/interfaces.rst
@@ -141,7 +141,7 @@ The bridge between the quantum and classical worlds is provided in PennyLane via
 Currently, there are four built-in interfaces: :doc:`NumPy <interfaces/numpy>`, :doc:`PyTorch
 <interfaces/torch>`, :doc:`JAX <interfaces/jax>`, and :doc:`TensorFlow <interfaces/tf>`. These
 interfaces make each of these libraries quantum-aware, allowing quantum circuits to be treated just
-like any other operation. Each interface can be chosen with any device.
+like any other operation. Any interface can be chosen with any device.
 
 In PennyLane, an interface is declared when creating a :class:`QNode <pennylane.QNode>`, e.g.,
 

--- a/doc/introduction/interfaces.rst
+++ b/doc/introduction/interfaces.rst
@@ -141,7 +141,7 @@ The bridge between the quantum and classical worlds is provided in PennyLane via
 Currently, there are four built-in interfaces: :doc:`NumPy <interfaces/numpy>`, :doc:`PyTorch
 <interfaces/torch>`, :doc:`JAX <interfaces/jax>`, and :doc:`TensorFlow <interfaces/tf>`. These
 interfaces make each of these libraries quantum-aware, allowing quantum circuits to be treated just
-like any other operation.
+like any other operation. Each interface can be chosen with any device.
 
 In PennyLane, an interface is declared when creating a :class:`QNode <pennylane.QNode>`, e.g.,
 
@@ -159,6 +159,11 @@ This will allow native numerical objects of the specified library (NumPy arrays,
 or TensorFlow Tensors) to be passed as parameters to the quantum circuit. It also makes
 the gradients of the quantum circuit accessible to the classical library, enabling the
 optimization of arbitrary hybrid circuits.
+
+When specifying an interface, the objects of the chosen framework are converted
+into NumPy objects and are passed to a device in most cases. Exceptions include
+cases when the devices support end-to-end computations in a framework. Such
+devices may be referred to as backpropagation or passthru devices.
 
 See the links below for walkthroughs of each specific interface:
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -22,8 +22,12 @@
 
 <h3>Documentation</h3>
 
+* Extended the interfaces description page to explicitly mention device
+  compatibility.
+  [(#2031)](https://github.com/PennyLaneAI/pennylane/pull/2031)
+
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):
 
-Olivia Di Matteo, David Wierichs
+Olivia Di Matteo, Antal Száva, David Wierichs


### PR DESCRIPTION
The [page for interfaces](https://pennylane.readthedocs.io/en/stable/introduction/interfaces.html) doesn't seem to explicitly mention that support for every interface applies to using any device.

This PR adds a bit more context.