### PR TITLE
v0.20.0 Lightning required

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -10,6 +10,11 @@
 
 <h3>Bug fixes</h3>
 
+* Fixes a bug where PennyLane didn't require v0.20.0 of PennyLane-Lightning,
+  but raised an error with versions of Lightning earlier than v0.20.0 due to
+  the new batch execution pipeline.
+  [(#2033)](https://github.com/PennyLaneAI/pennylane/pull/2033)
+
 * Fixes a bug in `classical_jacobian` when used with Torch, where the
   Jacobian of the preprocessing was also computed for non-trainable
   parameters.

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ requirements = [
     "semantic_version==2.6",
     "autoray",
     "cachetools",
-    "pennylane-lightning>=0.18",
+    "pennylane-lightning>=0.20",
 ]
 
 info = {


### PR DESCRIPTION
Increases the version of PennyLane-Lightning required such that no errors would arise from using earlier versions that do not support the new batch execution pipeline in PennyLane.