### PR TITLE
Fix codefactor issues

### DIFF
--- a/pennylane/templates/layers/cv_neural_net.py
+++ b/pennylane/templates/layers/cv_neural_net.py
@@ -14,7 +14,7 @@
 r"""
 Contains the CVNeuralNetLayers template.
 """
-# pylint: disable-msg=too-many-branches,too-many-arguments,protected-access
+# pylint: disable-msg=too-many-branches,too-many-arguments,protected-access,arguments-differ
 import pennylane as qml
 from pennylane.operation import Operation, AnyWires
 

--- a/pennylane/templates/subroutines/qpe.py
+++ b/pennylane/templates/subroutines/qpe.py
@@ -14,7 +14,7 @@
 """
 Contains the QuantumPhaseEstimation template.
 """
-# pylint: disable=too-many-arguments
+# pylint: disable=too-many-arguments,arguments-differ
 import pennylane as qml
 from pennylane.operation import AnyWires, Operation
 from pennylane.ops import Hadamard, ControlledQubitUnitary

--- a/pennylane/transforms/control.py
+++ b/pennylane/transforms/control.py
@@ -127,7 +127,7 @@ class ControlledOperation(Operation):
             # Not within a queuing context
             with QuantumTape() as new_tape:
                 # Execute all ops adjointed.
-                ops = adjoint(requeue_ops_in_tape)(self.subtape)  # is this needed?
+                adjoint(requeue_ops_in_tape)(self.subtape)
 
         return ControlledOperation(new_tape, self.control_wires)
 

--- a/pennylane/transforms/control.py
+++ b/pennylane/transforms/control.py
@@ -127,7 +127,7 @@ class ControlledOperation(Operation):
             # Not within a queuing context
             with QuantumTape() as new_tape:
                 # Execute all ops adjointed.
-                ops = adjoint(requeue_ops_in_tape)(self.subtape)
+                ops = adjoint(requeue_ops_in_tape)(self.subtape) # is this needed?
 
         return ControlledOperation(new_tape, self.control_wires)
 

--- a/pennylane/transforms/control.py
+++ b/pennylane/transforms/control.py
@@ -127,7 +127,7 @@ class ControlledOperation(Operation):
             # Not within a queuing context
             with QuantumTape() as new_tape:
                 # Execute all ops adjointed.
-                ops = adjoint(requeue_ops_in_tape)(self.subtape) # is this needed?
+                ops = adjoint(requeue_ops_in_tape)(self.subtape)  # is this needed?
 
         return ControlledOperation(new_tape, self.control_wires)
 


### PR DESCRIPTION
**Context:**
This PR fixes the following codefactor issues that seem to be appearing for the first time [here](https://github.com/PennyLaneAI/pennylane/pull/1973/files).

1. Line 205 in pennylane/templates/layers/cv_neural_net.py is missing `do_queue` argument which leads to an `arguments-differ` issue.

2. Line 149 in pennylane/templates/subroutines/qpe.py is missing `do_queue` argument which leads to an `arguments-differ` issue.

3. Line 130 in pennylane/transforms/control.py introduces `ops` which is not used anywhere and leads to an `unused-variable` issue. 

**Description of the Change:**

To fix issues 1 and 2, `pylint:disable=arguments-differ` is added to both files similar to what we have [here](https://github.com/PennyLaneAI/pennylane/blob/23b82a4d6b7c5a42d2a4a9e660ac7f61f2919e29/pennylane/ops/qubit/parametric_ops.py#L18).

The 3rd issue can be fixed similarly, but it is not clear if the variable `ops` is needed at all.

**Benefits:**
NA

**Possible Drawbacks:**
NA

**Related GitHub Issues:**
NA