### PR TITLE
[OpRefactor] Update eigenvalue representations

### DIFF
--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -762,7 +762,7 @@ class QubitDevice(Device):
         # exact expectation value
         if self.shots is None:
             try:
-                eigvals = self._asarray(observable.eigvals, dtype=self.R_DTYPE)
+                eigvals = self._asarray(observable.eigvals(), dtype=self.R_DTYPE)
             except NotImplementedError as e:
                 raise ValueError(
                     f"Cannot compute analytic expectations of {observable.name}."
@@ -788,7 +788,7 @@ class QubitDevice(Device):
         # exact variance value
         if self.shots is None:
             try:
-                eigvals = self._asarray(observable.eigvals, dtype=self.R_DTYPE)
+                eigvals = self._asarray(observable.eigvals(), dtype=self.R_DTYPE)
             except NotImplementedError as e:
                 # if observable has no info on eigenvalues, we cannot return this measurement
                 raise ValueError(f"Cannot compute analytic variance of {observable.name}.") from e
@@ -830,7 +830,7 @@ class QubitDevice(Device):
             powers_of_two = 2 ** np.arange(samples.shape[-1])[::-1]
             indices = samples @ powers_of_two
             try:
-                samples = observable.eigvals[indices]
+                samples = observable.eigvals()[indices]
             except NotImplementedError as e:
                 # if observable has no info on eigenvalues, we cannot return this measurement
                 raise ValueError(f"Cannot compute samples of {observable.name}.") from e

--- a/pennylane/devices/default_mixed.py
+++ b/pennylane/devices/default_mixed.py
@@ -214,7 +214,7 @@ class DefaultMixed(QubitDevice):
             unitary, returns a 1D array representing the matrix diagonal.
         """
         if operation in diagonal_in_z_basis:
-            return operation.eigvals
+            return operation.eigvals()
 
         if isinstance(operation, Channel):
             return operation.kraus_matrices

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -543,7 +543,7 @@ class DefaultQubit(QubitDevice):
             a 1D array representing the matrix diagonal.
         """
         if unitary in diagonal_in_z_basis:
-            return unitary.eigvals
+            return unitary.eigvals()
 
         return unitary.matrix()
 

--- a/pennylane/devices/default_qubit_torch.py
+++ b/pennylane/devices/default_qubit_torch.py
@@ -297,7 +297,7 @@ class DefaultQubitTorch(DefaultQubit):
             a 1D array representing the matrix diagonal.
         """
         if unitary in diagonal_in_z_basis:
-            return self._asarray(unitary.eigvals, dtype=self.C_DTYPE)
+            return self._asarray(unitary.eigvals(), dtype=self.C_DTYPE)
         return self._asarray(unitary.matrix(), dtype=self.C_DTYPE)
 
     def sample_basis_states(self, number_of_states, state_probability):

--- a/pennylane/math/quantum.py
+++ b/pennylane/math/quantum.py
@@ -89,7 +89,7 @@ def cov_matrix(prob, obs, wires=None, diag_approx=False):
 
     # diagonal variances
     for i, o in enumerate(obs):
-        l = cast(o.eigvals, dtype=float64)
+        l = cast(o.eigvals(), dtype=float64)
         w = o.wires.labels if wires is None else wires.indices(o.wires)
         p = marginal_prob(prob, w)
 
@@ -109,8 +109,8 @@ def cov_matrix(prob, obs, wires=None, diag_approx=False):
         o2wires = o2.wires.labels if wires is None else wires.indices(o2.wires)
         shared_wires = set(o1wires + o2wires)
 
-        l1 = cast(o1.eigvals, dtype=float64)
-        l2 = cast(o2.eigvals, dtype=float64)
+        l1 = cast(o1.eigvals(), dtype=float64)
+        l2 = cast(o2.eigvals(), dtype=float64)
         l12 = cast(np.kron(l1, l2), dtype=float64)
 
         p1 = marginal_prob(prob, o1wires)

--- a/pennylane/measure.py
+++ b/pennylane/measure.py
@@ -114,7 +114,6 @@ class MeasurementProcess:
             return self.obs.wires
         return self._wires
 
-    @property
     def eigvals(self):
         r"""Eigenvalues associated with the measurement process.
 
@@ -129,7 +128,7 @@ class MeasurementProcess:
         **Example:**
 
         >>> m = MeasurementProcess(Expectation, obs=qml.PauliX(wires=1))
-        >>> m.eigvals
+        >>> m.eigvals()
         array([1, -1])
 
         Returns:
@@ -137,7 +136,7 @@ class MeasurementProcess:
         """
         if self.obs is not None:
             try:
-                return self.obs.eigvals
+                return self.obs.eigvals()
             except NotImplementedError:
                 pass
 
@@ -171,7 +170,7 @@ class MeasurementProcess:
         >>> print(tape.operations)
         [QubitUnitary(array([[-0.89442719,  0.4472136 ],
               [ 0.4472136 ,  0.89442719]]), wires=['a'])]
-        >>> print(tape.measurements[0].eigvals)
+        >>> print(tape.measurements[0].eigvals())
         [0. 5.]
         >>> print(tape.measurements[0].obs)
         None
@@ -183,7 +182,7 @@ class MeasurementProcess:
 
         with JacobianTape() as tape:
             self.obs.diagonalizing_gates()
-            MeasurementProcess(self.return_type, wires=self.obs.wires, eigvals=self.obs.eigvals)
+            MeasurementProcess(self.return_type, wires=self.obs.wires, eigvals=self.obs.eigvals())
 
         return tape
 

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -491,8 +491,8 @@ class Operator(abc.ABC):
         directly without instantiating the operator first.
 
         The default implementation relies on the presence of the
-        :attr:`~.Operator.compute_matrix` method. To return the eigenvalues of *instantiated* operators,
-        please use the :attr:`~.Operator.eigvals()` method instead.
+        :meth:`~.Operator.compute_matrix` method. To return the eigenvalues of *instantiated* operators,
+        please use the :meth:`~.Operator.eigvals()` method instead.
 
         If :attr:`diagonalizing_gates` are specified, the order of the
         eigenvalues matches the order of
@@ -1189,7 +1189,7 @@ class Channel(Operation, abc.ABC):
         [0.        , 0.        ]])]
 
         To return the Kraus matrices of an *instantiated* channel,
-        please use the :attr:`~.Operator.kraus_matrices` property instead.
+        please use the :meth:`~.Operator.kraus_matrices` property instead.
 
         Returns:
             list(array): list of Kraus matrices

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -482,7 +482,10 @@ class Operator(abc.ABC):
 
     @classmethod
     def compute_eigvals(cls, *params, **hyperparams):
-        """Eigenvalues of the operator.
+        """Canonical eigenvalues of the operator in the computational basis.
+
+        The canonical eigenvalues refer to the textbook matrix representation that does not consider wires.
+        Implicitly, this assumes that the wires of the operator correspond to the global wire order.
 
         This class method allows eigenvalues to be computed
         directly without instantiating the operator first.

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -518,7 +518,7 @@ class Operator(abc.ABC):
         >>> qml.PauliX.compute_eigvals()
         array([1, -1])
         """
-        return NotImplementedError
+        raise NotImplementedError
 
     def eigvals(self):
         r"""Eigenvalues of the operator.
@@ -554,7 +554,7 @@ class Operator(abc.ABC):
         except NotImplementedError:
             # By default, compute the eigenvalues from the matrix representation.
             # This will raise a NotImplementedError if the matrix is undefined.
-            return np.linalg.eigvals(self.compute_matrix(*self.parameters, **self.hyperparameters))
+            return np.linalg.eigvals(self.matrix())
 
     @staticmethod
     def compute_terms(*params, **hyperparams):  # pylint: disable=unused-argument

--- a/pennylane/ops/identity.py
+++ b/pennylane/ops/identity.py
@@ -36,7 +36,6 @@ class Identity(CVObservable, Operation):
     grad_method = None
 
     ev_order = 1
-    eigvals = np.array([1, 1])
 
     @property
     def num_params(self):
@@ -46,8 +45,18 @@ class Identity(CVObservable, Operation):
         return base_label or "I"
 
     @classmethod
-    def _eigvals(cls, *params):
-        return cls.eigvals
+    def compute_eigvals(cls):  # pylint: disable=unused-argument,arguments-differ
+        """Eigenvalues of the Identity operator.
+
+        Returns:
+            array: eigenvalues
+
+        **Example**
+
+        >>> qml.Identity.compute_eigvals()
+        [ 1 1]
+        """
+        return np.array([1, 1])
 
     @staticmethod
     def compute_matrix():  # pylint: disable=arguments-differ

--- a/pennylane/ops/identity.py
+++ b/pennylane/ops/identity.py
@@ -44,8 +44,8 @@ class Identity(CVObservable, Operation):
     def label(self, decimals=None, base_label=None):
         return base_label or "I"
 
-    @classmethod
-    def compute_eigvals(cls):  # pylint: disable=unused-argument,arguments-differ
+    @staticmethod
+    def compute_eigvals():  # pylint: disable=,arguments-differ
         """Eigenvalues of the Identity operator.
 
         Returns:

--- a/pennylane/ops/qubit/matrix_ops.py
+++ b/pennylane/ops/qubit/matrix_ops.py
@@ -329,8 +329,8 @@ class DiagonalQubitUnitary(Operation):
 
         return qml.math.diag(D)
 
-    @classmethod
-    def compute_eigvals(cls, D):  # pylint: disable=unused-argument,arguments-differ
+    @staticmethod
+    def compute_eigvals(D):  # pylint: disable=,arguments-differ
         """Eigenvalues of the DiagonalQubitUnitary operator.
 
         Args:

--- a/pennylane/ops/qubit/matrix_ops.py
+++ b/pennylane/ops/qubit/matrix_ops.py
@@ -330,7 +330,7 @@ class DiagonalQubitUnitary(Operation):
         return qml.math.diag(D)
 
     @classmethod
-    def compute_eigvals(cls, D):  # pylint: disable=arguments-differ
+    def compute_eigvals(cls, D):  # pylint: disable=unused-argument,arguments-differ
         """Eigenvalues of the DiagonalQubitUnitary operator.
 
         Args:

--- a/pennylane/ops/qubit/matrix_ops.py
+++ b/pennylane/ops/qubit/matrix_ops.py
@@ -318,9 +318,9 @@ class DiagonalQubitUnitary(Operation):
 
         **Example**
 
-        >>> qml.DiagonalQubitUnitary.compute_matrix(np.array([1, -1]))
-        [[ 1  0]
-         [ 0 -1]]
+        >>> qml.DiagonalQubitUnitary.compute_matrix(torch.tensor([1, -1]))
+        tensor([[ 1,  0],
+                [ 0, -1]])
         """
         D = qml.math.asarray(D)
 
@@ -330,8 +330,21 @@ class DiagonalQubitUnitary(Operation):
         return qml.math.diag(D)
 
     @classmethod
-    def _eigvals(cls, *params):
-        D = qml.math.asarray(params[0])
+    def compute_eigvals(cls, D):  # pylint: disable=arguments-differ
+        """Eigenvalues of the DiagonalQubitUnitary operator.
+
+        Args:
+            D (tensor_like): diagonal of the matrix
+
+        Returns:
+            tensor_like: eigenvalues
+
+        **Example**
+
+        >>> qml.DiagonalQubitUnitary.compute_eigvals(torch.tensor([1, -1]))
+        tensor([ 1, -1])
+        """
+        D = qml.math.asarray(D)
 
         if not qml.math.allclose(D * qml.math.conj(D), qml.math.ones_like(D)):
             raise ValueError("Operator must be unitary.")

--- a/pennylane/ops/qubit/non_parametric_ops.py
+++ b/pennylane/ops/qubit/non_parametric_ops.py
@@ -43,7 +43,6 @@ class Hadamard(Observable, Operation):
         wires (Sequence[int] or int): the wire the operation acts on
     """
     num_wires = 1
-    eigvals = pauli_eigs(1)
 
     @property
     def num_params(self):
@@ -68,8 +67,18 @@ class Hadamard(Observable, Operation):
         return np.array([[INV_SQRT2, INV_SQRT2], [INV_SQRT2, -INV_SQRT2]])
 
     @classmethod
-    def _eigvals(cls, *params):
-        return cls.eigvals
+    def compute_eigvals(cls):  # pylint: disable=unused-argument,arguments-differ
+        """Eigenvalues of the Hadamard operator.
+
+        Returns:
+            array: eigenvalues
+
+        **Example**
+
+        >>> qml.Hadamard.compute_eigvals()
+        [ 1 -1]
+        """
+        return pauli_eigs(1)
 
     @staticmethod
     def compute_diagonalizing_gates(wires):
@@ -128,7 +137,6 @@ class PauliX(Observable, Operation):
     """
     num_wires = 1
     basis = "X"
-    eigvals = pauli_eigs(1)
 
     @property
     def num_params(self):
@@ -153,8 +161,18 @@ class PauliX(Observable, Operation):
         return np.array([[0, 1], [1, 0]])
 
     @classmethod
-    def _eigvals(cls, *params):
-        return cls.eigvals
+    def compute_eigvals(cls):  # pylint: disable=unused-argument,arguments-differ
+        """Eigenvalues of the PauliX operator.
+
+        Returns:
+            array: eigenvalues
+
+        **Example**
+
+        >>> qml.PauliX.compute_eigvals()
+        [ 1 -1]
+        """
+        return pauli_eigs(1)
 
     @staticmethod
     def compute_diagonalizing_gates(wires):
@@ -214,7 +232,6 @@ class PauliY(Observable, Operation):
     """
     num_wires = 1
     basis = "Y"
-    eigvals = pauli_eigs(1)
 
     @property
     def num_params(self):
@@ -239,8 +256,18 @@ class PauliY(Observable, Operation):
         return np.array([[0, -1j], [1j, 0]])
 
     @classmethod
-    def _eigvals(cls, *params):
-        return cls.eigvals
+    def compute_eigvals(cls):  # pylint: disable=unused-argument,arguments-differ
+        """Eigenvalues of the PauliY operator.
+
+        Returns:
+            array: eigenvalues
+
+        **Example**
+
+        >>> qml.PauliY.compute_eigvals()
+        [ 1 -1]
+        """
+        return pauli_eigs(1)
 
     @staticmethod
     def compute_diagonalizing_gates(wires):
@@ -306,7 +333,6 @@ class PauliZ(Observable, Operation):
     """
     num_wires = 1
     basis = "Z"
-    eigvals = pauli_eigs(1)
 
     @property
     def num_params(self):
@@ -331,8 +357,18 @@ class PauliZ(Observable, Operation):
         return np.array([[1, 0], [0, -1]])
 
     @classmethod
-    def _eigvals(cls, *params):
-        return cls.eigvals
+    def compute_eigvals(cls):  # pylint: disable=unused-argument,arguments-differ
+        """Eigenvalues of the PauliZ operator.
+
+        Returns:
+            array: eigenvalues
+
+        **Example**
+
+        >>> qml.PauliZ.compute_eigvals()
+        [ 1 -1]
+        """
+        return pauli_eigs(1)
 
     @staticmethod
     def compute_diagonalizing_gates(wires):  # pylint: disable=unused-argument
@@ -386,7 +422,6 @@ class S(Operation):
     """
     num_wires = 1
     basis = "Z"
-    op_eigvals = np.array([1, 1j])
 
     @property
     def num_params(self):
@@ -408,8 +443,18 @@ class S(Operation):
         return np.array([[1, 0], [0, 1j]])
 
     @classmethod
-    def _eigvals(cls, *params):
-        return cls.op_eigvals
+    def compute_eigvals(cls):  # pylint: disable=unused-argument,arguments-differ
+        """Eigenvalues of the S operator.
+
+        Returns:
+            array: eigenvalues
+
+        **Example**
+
+        >>> qml.S.compute_eigvals()
+        [1.+0.j 0.+1.j]
+        """
+        return np.array([1, 1j])
 
     @staticmethod
     def decomposition(wires):
@@ -443,7 +488,6 @@ class T(Operation):
     """
     num_wires = 1
     basis = "Z"
-    op_eigvals = np.array([1, cmath.exp(1j * np.pi / 4)])
 
     @property
     def num_params(self):
@@ -465,8 +509,18 @@ class T(Operation):
         return np.array([[1, 0], [0, cmath.exp(1j * np.pi / 4)]])
 
     @classmethod
-    def _eigvals(cls, *params):
-        return cls.op_eigvals
+    def compute_eigvals(cls):  # pylint: disable=unused-argument,arguments-differ
+        """Eigenvalues of the T operator.
+
+        Returns:
+            array: eigenvalues
+
+        **Example**
+
+        >>> qml.T.compute_eigvals()
+        [1.+0.j 0.70710678+0.70710678j]
+        """
+        return np.array([1, cmath.exp(1j * np.pi / 4)])
 
     @staticmethod
     def decomposition(wires):
@@ -500,7 +554,6 @@ class SX(Operation):
     """
     num_wires = 1
     basis = "X"
-    op_eigvals = np.array([1, 1j])
 
     @property
     def num_params(self):
@@ -522,8 +575,18 @@ class SX(Operation):
         return 0.5 * np.array([[1 + 1j, 1 - 1j], [1 - 1j, 1 + 1j]])
 
     @classmethod
-    def _eigvals(cls, *params):
-        return cls.op_eigvals
+    def compute_eigvals(cls):  # pylint: disable=unused-argument,arguments-differ
+        """Eigenvalues of the SX operator.
+
+        Returns:
+            array: eigenvalues
+
+        **Example**
+
+        >>> qml.SX.compute_eigvals()
+        [1.+0.j 0.+1.j]
+        """
+        return np.array([1, 1j])
 
     @staticmethod
     def decomposition(wires):
@@ -625,7 +688,6 @@ class CZ(Operation):
     """
     num_wires = 2
     basis = "Z"
-    eigvals = np.array([1, 1, 1, -1])
 
     @property
     def num_params(self):
@@ -652,8 +714,18 @@ class CZ(Operation):
         return np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, -1]])
 
     @classmethod
-    def _eigvals(cls, *params):
-        return cls.eigvals
+    def compute_eigvals(cls):  # pylint: disable=unused-argument,arguments-differ
+        """Eigenvalues of the CZ operator.
+
+        Returns:
+            array: eigenvalues
+
+        **Example**
+
+        >>> qml.CZ.compute_eigvals()
+        [1, 1, 1, -1]
+        """
+        return np.array([1, 1, 1, -1])
 
     def adjoint(self):
         return CZ(wires=self.wires)
@@ -810,7 +882,6 @@ class ISWAP(Operation):
         wires (Sequence[int]): the wires the operation acts on
     """
     num_wires = 2
-    op_eigvals = np.array([1j, -1j, 1, 1])
 
     @property
     def num_params(self):
@@ -834,8 +905,18 @@ class ISWAP(Operation):
         return np.array([[1, 0, 0, 0], [0, 0, 1j, 0], [0, 1j, 0, 0], [0, 0, 0, 1]])
 
     @classmethod
-    def _eigvals(cls, *params):
-        return cls.op_eigvals
+    def compute_eigvals(cls):  # pylint: disable=unused-argument,arguments-differ
+        """Eigenvalues of the ISWAP operator.
+
+        Returns:
+            array: eigenvalues
+
+        **Example**
+
+        >>> qml.ISWAP.compute_eigvals()
+        [1j, -1j, 1, 1]
+        """
+        return np.array([1j, -1j, 1, 1])
 
     @staticmethod
     def decomposition(wires):
@@ -904,8 +985,18 @@ class SISWAP(Operation):
         )
 
     @classmethod
-    def _eigvals(cls, *params):
-        return cls.op_eigvals
+    def compute_eigvals(cls):  # pylint: disable=unused-argument,arguments-differ
+        """Eigenvalues of the SISWAP operator.
+
+        Returns:
+            array: eigenvalues
+
+        **Example**
+
+        >>> qml.SISWAP.compute_eigvals()
+        [0.70710678+0.70710678j 0.70710678-0.70710678j 1.+0.j 1.+0.j]
+        """
+        return np.array([INV_SQRT2 * (1 + 1j), INV_SQRT2 * (1 - 1j), 1, 1])
 
     @staticmethod
     def decomposition(wires):

--- a/pennylane/ops/qubit/non_parametric_ops.py
+++ b/pennylane/ops/qubit/non_parametric_ops.py
@@ -66,8 +66,8 @@ class Hadamard(Observable, Operation):
         """
         return np.array([[INV_SQRT2, INV_SQRT2], [INV_SQRT2, -INV_SQRT2]])
 
-    @classmethod
-    def compute_eigvals(cls):  # pylint: disable=unused-argument,arguments-differ
+    @staticmethod
+    def compute_eigvals():  # pylint: disable=,arguments-differ
         """Eigenvalues of the Hadamard operator.
 
         Returns:
@@ -160,8 +160,8 @@ class PauliX(Observable, Operation):
         """
         return np.array([[0, 1], [1, 0]])
 
-    @classmethod
-    def compute_eigvals(cls):  # pylint: disable=unused-argument,arguments-differ
+    @staticmethod
+    def compute_eigvals():  # pylint: disable=,arguments-differ
         """Eigenvalues of the PauliX operator.
 
         Returns:
@@ -255,8 +255,8 @@ class PauliY(Observable, Operation):
         """
         return np.array([[0, -1j], [1j, 0]])
 
-    @classmethod
-    def compute_eigvals(cls):  # pylint: disable=unused-argument,arguments-differ
+    @staticmethod
+    def compute_eigvals():  # pylint: disable=,arguments-differ
         """Eigenvalues of the PauliY operator.
 
         Returns:
@@ -356,8 +356,8 @@ class PauliZ(Observable, Operation):
         """
         return np.array([[1, 0], [0, -1]])
 
-    @classmethod
-    def compute_eigvals(cls):  # pylint: disable=unused-argument,arguments-differ
+    @staticmethod
+    def compute_eigvals():  # pylint: disable=,arguments-differ
         """Eigenvalues of the PauliZ operator.
 
         Returns:
@@ -442,8 +442,8 @@ class S(Operation):
         """
         return np.array([[1, 0], [0, 1j]])
 
-    @classmethod
-    def compute_eigvals(cls):  # pylint: disable=unused-argument,arguments-differ
+    @staticmethod
+    def compute_eigvals():  # pylint: disable=,arguments-differ
         """Eigenvalues of the S operator.
 
         Returns:
@@ -508,8 +508,8 @@ class T(Operation):
         """
         return np.array([[1, 0], [0, cmath.exp(1j * np.pi / 4)]])
 
-    @classmethod
-    def compute_eigvals(cls):  # pylint: disable=unused-argument,arguments-differ
+    @staticmethod
+    def compute_eigvals():  # pylint: disable=,arguments-differ
         """Eigenvalues of the T operator.
 
         Returns:
@@ -574,8 +574,8 @@ class SX(Operation):
         """
         return 0.5 * np.array([[1 + 1j, 1 - 1j], [1 - 1j, 1 + 1j]])
 
-    @classmethod
-    def compute_eigvals(cls):  # pylint: disable=unused-argument,arguments-differ
+    @staticmethod
+    def compute_eigvals():  # pylint: disable=,arguments-differ
         """Eigenvalues of the SX operator.
 
         Returns:
@@ -713,8 +713,8 @@ class CZ(Operation):
         """
         return np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, -1]])
 
-    @classmethod
-    def compute_eigvals(cls):  # pylint: disable=unused-argument,arguments-differ
+    @staticmethod
+    def compute_eigvals():  # pylint: disable=,arguments-differ
         """Eigenvalues of the CZ operator.
 
         Returns:
@@ -904,8 +904,8 @@ class ISWAP(Operation):
         """
         return np.array([[1, 0, 0, 0], [0, 0, 1j, 0], [0, 1j, 0, 0], [0, 0, 0, 1]])
 
-    @classmethod
-    def compute_eigvals(cls):  # pylint: disable=unused-argument,arguments-differ
+    @staticmethod
+    def compute_eigvals():  # pylint: disable=,arguments-differ
         """Eigenvalues of the ISWAP operator.
 
         Returns:
@@ -984,8 +984,8 @@ class SISWAP(Operation):
             ]
         )
 
-    @classmethod
-    def compute_eigvals(cls):  # pylint: disable=unused-argument,arguments-differ
+    @staticmethod
+    def compute_eigvals():  # pylint: disable=,arguments-differ
         """Eigenvalues of the SISWAP operator.
 
         Returns:

--- a/pennylane/ops/qubit/observables.py
+++ b/pennylane/ops/qubit/observables.py
@@ -109,7 +109,6 @@ class Hermitian(Observable):
 
         return Hermitian._eigs[Hkey]
 
-    @property
     def eigvals(self):
         """Return the eigenvalues of the specified Hermitian observable.
 
@@ -315,24 +314,24 @@ class Projector(Observable):
         return m
 
     @classmethod
-    def _eigvals(cls, *params):
-        """Eigenvalues of the specific projector operator.
+    def compute_eigvals(cls, basis_state):  # pylint: disable=unused-argument,arguments-differ
+        """Eigenvalues of the Projector operator.
+
+        Args:
+            basis_state (Iterable): basis state to project on
 
         Returns:
-            array: eigenvalues of the projector observable in the computational basis
+            array: eigenvalues
+
+        **Example**
+
+        >>> qml.Projector.compute_eigvals([0, 1])
+        [0. 1. 0. 0.]
         """
-        w = np.zeros(2 ** len(params[0]))
-        idx = int("".join(str(i) for i in params[0]), 2)
+        w = np.zeros(2 ** len(basis_state))
+        idx = int("".join(str(i) for i in basis_state), 2)
         w[idx] = 1
         return w
-
-    @classmethod
-    def _matrix(cls, *params):
-        basis_state = params[0]
-        m = np.zeros((2 ** len(basis_state), 2 ** len(basis_state)))
-        idx = int("".join(str(i) for i in basis_state), 2)
-        m[idx, idx] = 1
-        return m
 
     @staticmethod
     def compute_diagonalizing_gates(

--- a/pennylane/ops/qubit/observables.py
+++ b/pennylane/ops/qubit/observables.py
@@ -313,8 +313,8 @@ class Projector(Observable):
         m[idx, idx] = 1
         return m
 
-    @classmethod
-    def compute_eigvals(cls, basis_state):  # pylint: disable=unused-argument,arguments-differ
+    @staticmethod
+    def compute_eigvals(basis_state):  # pylint: disable=,arguments-differ
         """Eigenvalues of the Projector operator.
 
         Args:

--- a/pennylane/ops/qubit/parametric_ops.py
+++ b/pennylane/ops/qubit/parametric_ops.py
@@ -225,7 +225,7 @@ class RZ(Operation):
 
     @staticmethod
     def compute_eigvals(theta):  # pylint: disable=,arguments-differ
-        """Canonical eigenvalues of the RZ operator.
+        """Eigenvalues of the RZ operator.
 
         Args:
             theta (tensor_like or float): rotation angle
@@ -316,7 +316,7 @@ class PhaseShift(Operation):
 
     @staticmethod
     def compute_eigvals(phi):  # pylint: disable=,arguments-differ
-        """Canonical eigenvalues of the PhaseShift operator.
+        """Eigenvalues of the PhaseShift operator.
 
         Args:
             phi (tensor_like or float): phase shift
@@ -417,7 +417,7 @@ class ControlledPhaseShift(Operation):
 
     @staticmethod
     def compute_eigvals(phi):  # pylint: disable=,arguments-differ
-        """Canonical eigenvalues of the ControlledPhaseShift operator.
+        """Eigenvalues of the ControlledPhaseShift operator.
 
         Args:
             phi (tensor_like or float): phase shift

--- a/pennylane/ops/qubit/parametric_ops.py
+++ b/pennylane/ops/qubit/parametric_ops.py
@@ -224,7 +224,7 @@ class RZ(Operation):
         return qml.math.diag([p, qml.math.conj(p)])
 
     @classmethod
-    def compute_eigvals(cls, theta):  # pylint: disable=arguments-differ
+    def compute_eigvals(cls, theta):  # pylint: disable=unused-argument,arguments-differ
         """Canonical eigenvalues of the RZ operator.
 
         Args:
@@ -315,7 +315,7 @@ class PhaseShift(Operation):
         return qml.math.diag([1, exp_part])
 
     @classmethod
-    def compute_eigvals(cls, phi):  # pylint: disable=arguments-differ
+    def compute_eigvals(cls, phi):  # pylint: disable=unused-argument,arguments-differ
         """Canonical eigenvalues of the PhaseShift operator.
 
         Args:
@@ -416,7 +416,7 @@ class ControlledPhaseShift(Operation):
         return qml.math.diag([1, 1, 1, exp_part])
 
     @classmethod
-    def compute_eigvals(cls, phi):  # pylint: disable=arguments-differ
+    def compute_eigvals(cls, phi):  # pylint: disable=unused-argument,arguments-differ
         """Canonical eigenvalues of the ControlledPhaseShift operator.
 
         Args:
@@ -631,7 +631,7 @@ class MultiRZ(Operation):
         return -0.5 * functools.reduce(matmul, [qml.PauliZ(w) for w in self.wires])
 
     @classmethod
-    def compute_eigvals(cls, theta, n_wires):  # pylint: disable=arguments-differ
+    def compute_eigvals(cls, theta, n_wires):  # pylint: disable=unused-argument,arguments-differ
         """Eigenvalues of the MultiRZ operator.
 
         Args:
@@ -1213,7 +1213,7 @@ class CRZ(Operation):
         return qml.math.diag([1, 1, exp_part, qml.math.conj(exp_part)])
 
     @classmethod
-    def compute_eigvals(cls, theta):  # pylint: disable=arguments-differ
+    def compute_eigvals(cls, theta):  # pylint: disable=unused-argument,arguments-differ
         """Eigenvalues of the CRZ operator.
 
         Args:

--- a/pennylane/ops/qubit/parametric_ops.py
+++ b/pennylane/ops/qubit/parametric_ops.py
@@ -1212,8 +1212,8 @@ class CRZ(Operation):
 
         return qml.math.diag([1, 1, exp_part, qml.math.conj(exp_part)])
 
-    @classmethod
-    def compute_eigvals(cls, theta):  # pylint: disable=,arguments-differ
+    @staticmethod
+    def compute_eigvals(theta):  # pylint: disable=arguments-differ
         """Eigenvalues of the CRZ operator.
 
         Args:

--- a/pennylane/ops/qubit/parametric_ops.py
+++ b/pennylane/ops/qubit/parametric_ops.py
@@ -223,8 +223,8 @@ class RZ(Operation):
 
         return qml.math.diag([p, qml.math.conj(p)])
 
-    @classmethod
-    def compute_eigvals(cls, theta):  # pylint: disable=unused-argument,arguments-differ
+    @staticmethod
+    def compute_eigvals(theta):  # pylint: disable=,arguments-differ
         """Canonical eigenvalues of the RZ operator.
 
         Args:
@@ -314,8 +314,8 @@ class PhaseShift(Operation):
 
         return qml.math.diag([1, exp_part])
 
-    @classmethod
-    def compute_eigvals(cls, phi):  # pylint: disable=unused-argument,arguments-differ
+    @staticmethod
+    def compute_eigvals(phi):  # pylint: disable=,arguments-differ
         """Canonical eigenvalues of the PhaseShift operator.
 
         Args:
@@ -415,8 +415,8 @@ class ControlledPhaseShift(Operation):
 
         return qml.math.diag([1, 1, 1, exp_part])
 
-    @classmethod
-    def compute_eigvals(cls, phi):  # pylint: disable=unused-argument,arguments-differ
+    @staticmethod
+    def compute_eigvals(phi):  # pylint: disable=,arguments-differ
         """Canonical eigenvalues of the ControlledPhaseShift operator.
 
         Args:
@@ -630,8 +630,8 @@ class MultiRZ(Operation):
     def generator(self):
         return -0.5 * functools.reduce(matmul, [qml.PauliZ(w) for w in self.wires])
 
-    @classmethod
-    def compute_eigvals(cls, theta, n_wires):  # pylint: disable=unused-argument,arguments-differ
+    @staticmethod
+    def compute_eigvals(theta, n_wires):  # pylint: disable=,arguments-differ
         """Eigenvalues of the MultiRZ operator.
 
         Args:
@@ -851,8 +851,8 @@ class PauliRot(Operation):
         pauli_word = self.parameters[1]
         return -0.5 * qml.grouping.string_to_pauli_word(pauli_word)
 
-    @classmethod
-    def compute_eigvals(cls, theta, pauli_word):  # pylint: disable=unused-argument,arguments-differ
+    @staticmethod
+    def compute_eigvals(theta, pauli_word):  # pylint: disable=,arguments-differ
         """Eigenvalues of the PauliRot operator.
 
         Returns:
@@ -1213,7 +1213,7 @@ class CRZ(Operation):
         return qml.math.diag([1, 1, exp_part, qml.math.conj(exp_part)])
 
     @classmethod
-    def compute_eigvals(cls, theta):  # pylint: disable=unused-argument,arguments-differ
+    def compute_eigvals(cls, theta):  # pylint: disable=,arguments-differ
         """Eigenvalues of the CRZ operator.
 
         Args:

--- a/pennylane/ops/qubit/parametric_ops.py
+++ b/pennylane/ops/qubit/parametric_ops.py
@@ -224,8 +224,20 @@ class RZ(Operation):
         return qml.math.diag([p, qml.math.conj(p)])
 
     @classmethod
-    def _eigvals(cls, *params):
-        theta = params[0]
+    def compute_eigvals(cls, theta):  # pylint: disable=arguments-differ
+        """Canonical eigenvalues of the RZ operator.
+
+        Args:
+            theta (tensor_like or float): rotation angle
+
+        Returns:
+            tensor_like: eigenvalues
+
+        **Example**
+
+        >>> qml.RZ.compute_eigvals(torch.tensor(0.5))
+        tensor([0.9689-0.2474j, 0.9689+0.2474j])
+        """
 
         if qml.math.get_interface(theta) == "tensorflow":
             theta = qml.math.cast_like(theta, 1j)
@@ -303,9 +315,20 @@ class PhaseShift(Operation):
         return qml.math.diag([1, exp_part])
 
     @classmethod
-    def _eigvals(cls, *params):
-        phi = params[0]
+    def compute_eigvals(cls, phi):  # pylint: disable=arguments-differ
+        """Canonical eigenvalues of the PhaseShift operator.
 
+        Args:
+            phi (tensor_like or float): phase shift
+
+        Returns:
+            tensor_like: eigenvalues
+
+        **Example**
+
+        >>> qml.PhaseShift.compute_eigvals(torch.tensor(0.5))
+        tensor([1.0000+0.0000j, 0.8776+0.4794j])
+        """
         if qml.math.get_interface(phi) == "tensorflow":
             phi = qml.math.cast_like(phi, 1j)
 
@@ -393,9 +416,20 @@ class ControlledPhaseShift(Operation):
         return qml.math.diag([1, 1, 1, exp_part])
 
     @classmethod
-    def _eigvals(cls, *params):
-        phi = params[0]
+    def compute_eigvals(cls, phi):  # pylint: disable=arguments-differ
+        """Canonical eigenvalues of the ControlledPhaseShift operator.
 
+        Args:
+            phi (tensor_like or float): phase shift
+
+        Returns:
+            tensor_like: eigenvalues
+
+        **Example**
+
+        >>> qml.ControlledPhaseShift.compute_eigvals(torch.tensor(0.5))
+        tensor([1.0000+0.0000j, 1.0000+0.0000j, 1.0000+0.0000j, 0.8776+0.4794j])
+        """
         if qml.math.get_interface(phi) == "tensorflow":
             phi = qml.math.cast_like(phi, 1j)
 
@@ -550,7 +584,7 @@ class MultiRZ(Operation):
         will decompose the gate using :class:`~.RZ` and :class:`~.CNOT` gates.
 
     Args:
-        theta (float): rotation angle :math:`\theta`
+        theta (tensor_like or float): rotation angle :math:`\theta`
         wires (Sequence[int] or int): the wires the operation acts on
     """
     num_wires = AnyWires
@@ -570,8 +604,8 @@ class MultiRZ(Operation):
         """Canonical matrix representation of the MultiRZ operator.
 
         Args:
-            theta (tensor_like or float): Rotation angle.
-            n_wires (int): Number of wires the rotation acts on.
+            theta (tensor_like or float): rotation angle
+            n_wires (int): number of wires the rotation acts on
 
         Returns:
             tensor_like: canonical matrix
@@ -597,22 +631,29 @@ class MultiRZ(Operation):
         return -0.5 * functools.reduce(matmul, [qml.PauliZ(w) for w in self.wires])
 
     @classmethod
-    def _eigvals(cls, theta, n):
-        eigs = qml.math.convert_like(pauli_eigs(n), theta)
+    def compute_eigvals(cls, theta, n_wires):  # pylint: disable=arguments-differ
+        """Eigenvalues of the MultiRZ operator.
+
+        Args:
+            theta (tensor_like or float): rotation angle
+            n_wires (int): number of wires the rotation acts on
+
+        Returns:
+            tensor_like: eigenvalues
+
+        **Example**
+
+        >>> qml.MultiRZ.compute_eigvals(torch.tensor(0.5), 3)
+        tensor([0.9689-0.2474j, 0.9689+0.2474j, 0.9689+0.2474j, 0.9689-0.2474j,
+                0.9689+0.2474j, 0.9689-0.2474j, 0.9689-0.2474j, 0.9689+0.2474j])
+        """
+        eigs = qml.math.convert_like(pauli_eigs(n_wires), theta)
 
         if qml.math.get_interface(theta) == "tensorflow":
             theta = qml.math.cast_like(theta, 1j)
             eigs = qml.math.cast_like(eigs, 1j)
 
         return qml.math.exp(-1j * theta / 2 * eigs)
-
-    @property
-    def eigvals(self):
-        # Redefine the property here to pass additionally the number of wires to the ``_eigvals`` method
-        if self.inverse:
-            return qml.math.conj(self._eigvals(*self.parameters, len(self.wires)))
-
-        return self._eigvals(*self.parameters, len(self.wires))
 
     @staticmethod
     def decomposition(theta, wires):
@@ -811,7 +852,17 @@ class PauliRot(Operation):
         return -0.5 * qml.grouping.string_to_pauli_word(pauli_word)
 
     @classmethod
-    def _eigvals(cls, theta, pauli_word):
+    def compute_eigvals(cls, theta, pauli_word):  # pylint: disable=unused-argument,arguments-differ
+        """Eigenvalues of the PauliRot operator.
+
+        Returns:
+            tensor_like: eigenvalues
+
+        **Example**
+
+        >>> qml.PauliRot.compute_eigvals(torch.tensor(0.5), "X")
+        tensor([0.9689-0.2474j, 0.9689+0.2474j])
+        """
         if qml.math.get_interface(theta) == "tensorflow":
             theta = qml.math.cast_like(theta, 1j)
 
@@ -819,7 +870,7 @@ class PauliRot(Operation):
         if pauli_word == "I" * len(pauli_word):
             return qml.math.exp(-1j * theta / 2) * qml.math.ones(2 ** len(pauli_word))
 
-        return MultiRZ._eigvals(theta, len(pauli_word))
+        return MultiRZ.compute_eigvals(theta, len(pauli_word))
 
     @staticmethod
     def decomposition(theta, pauli_word, wires):
@@ -1162,8 +1213,21 @@ class CRZ(Operation):
         return qml.math.diag([1, 1, exp_part, qml.math.conj(exp_part)])
 
     @classmethod
-    def _eigvals(cls, *params):
-        theta = qml.math.flatten(qml.math.stack([params[0]]))[0]
+    def compute_eigvals(cls, theta):  # pylint: disable=arguments-differ
+        """Eigenvalues of the CRZ operator.
+
+        Args:
+            theta (tensor_like or float): rotation angle
+
+        Returns:
+            tensor_like: eigenvalues
+
+        **Example**
+
+        >>> qml.CRZ.compute_eigvals(torch.tensor(0.5))
+        tensor([1.0000+0.0000j, 1.0000+0.0000j, 0.9689-0.2474j, 0.9689+0.2474j])
+        """
+        theta = qml.math.flatten(qml.math.stack([theta]))[0]
 
         if qml.math.get_interface(theta) == "tensorflow":
             theta = qml.math.cast_like(theta, 1j)

--- a/pennylane/transforms/metric_tensor.py
+++ b/pennylane/transforms/metric_tensor.py
@@ -631,7 +631,7 @@ def _metric_tensor_hadamard(tape, allow_nonunitary, aux_wire, device_wires):
         idx = 0
         for prob, obs in zip(diag_res, obs_list):
             for o in obs:
-                l = qml.math.cast(o.eigvals, dtype=np.float64)
+                l = qml.math.cast(o.eigvals(), dtype=np.float64)
                 w = tape.wires.indices(o.wires)
                 p = qml.math.marginal_prob(prob, w)
                 expvals = qml.math.scatter_element_add(expvals, (idx,), qml.math.dot(l, p))

--- a/tests/devices/test_default_mixed.py
+++ b/tests/devices/test_default_mixed.py
@@ -475,7 +475,7 @@ class TestApplyChannel:
 class TestApplyDiagonal:
     """Unit tests for the method `_apply_diagonal_unitary()`"""
 
-    x_apply_diag_init = [[1, PauliZ, basis_state(0, 1)], [2, CZ, basis_state(0, 2)]]
+    x_apply_diag_init = [[1, PauliZ(0), basis_state(0, 1)], [2, CZ(wires=[0, 1]), basis_state(0, 2)]]
 
     @pytest.mark.parametrize("x", x_apply_diag_init)
     def test_diag_init(self, x, tol):
@@ -485,14 +485,14 @@ class TestApplyDiagonal:
         target_state = np.reshape(x[2], [2] * 2 * nr_wires)
         dev = qml.device("default.mixed", wires=nr_wires)
         kraus = dev._get_kraus(op)
-        if op == CZ:
+        if op.name == "CZ":
             dev._apply_diagonal_unitary(kraus, wires=Wires([0, 1]))
         else:
             dev._apply_diagonal_unitary(kraus, wires=Wires(0))
 
         assert np.allclose(dev._state, target_state, atol=tol, rtol=0)
 
-    x_apply_diag_mixed = [[1, PauliZ, max_mixed_state(1)], [2, CZ, max_mixed_state(2)]]
+    x_apply_diag_mixed = [[1, PauliZ(0), max_mixed_state(1)], [2, CZ(wires=[0, 1]), max_mixed_state(2)]]
 
     @pytest.mark.parametrize("x", x_apply_diag_mixed)
     def test_diag_mixed(self, x, tol):
@@ -504,7 +504,7 @@ class TestApplyDiagonal:
         max_mixed = np.reshape(max_mixed_state(nr_wires), [2] * 2 * nr_wires)
         dev._state = max_mixed
         kraus = dev._get_kraus(op)
-        if op == CZ:
+        if op.name == "CZ":
             dev._apply_diagonal_unitary(kraus, wires=Wires([0, 1]))
         else:
             dev._apply_diagonal_unitary(kraus, wires=Wires(0))
@@ -512,10 +512,10 @@ class TestApplyDiagonal:
         assert np.allclose(dev._state, target_state, atol=tol, rtol=0)
 
     x_apply_diag_root = [
-        [1, PauliZ, np.array([[0.5, 0.5], [0.5, 0.5]])],
+        [1, PauliZ(0), np.array([[0.5, 0.5], [0.5, 0.5]])],
         [
             2,
-            CZ,
+            CZ(wires=[0, 1]),
             np.array(
                 [
                     [0.25, -0.25j, -0.25, -0.25j],
@@ -537,7 +537,7 @@ class TestApplyDiagonal:
         root = np.reshape(root_state(nr_wires), [2] * 2 * nr_wires)
         dev._state = root
         kraus = dev._get_kraus(op)
-        if op == CZ:
+        if op.name == "CZ":
             dev._apply_diagonal_unitary(kraus, wires=Wires([0, 1]))
         else:
             dev._apply_diagonal_unitary(kraus, wires=Wires(0))

--- a/tests/devices/test_default_mixed.py
+++ b/tests/devices/test_default_mixed.py
@@ -475,7 +475,10 @@ class TestApplyChannel:
 class TestApplyDiagonal:
     """Unit tests for the method `_apply_diagonal_unitary()`"""
 
-    x_apply_diag_init = [[1, PauliZ(0), basis_state(0, 1)], [2, CZ(wires=[0, 1]), basis_state(0, 2)]]
+    x_apply_diag_init = [
+        [1, PauliZ(0), basis_state(0, 1)],
+        [2, CZ(wires=[0, 1]), basis_state(0, 2)],
+    ]
 
     @pytest.mark.parametrize("x", x_apply_diag_init)
     def test_diag_init(self, x, tol):
@@ -492,7 +495,10 @@ class TestApplyDiagonal:
 
         assert np.allclose(dev._state, target_state, atol=tol, rtol=0)
 
-    x_apply_diag_mixed = [[1, PauliZ(0), max_mixed_state(1)], [2, CZ(wires=[0, 1]), max_mixed_state(2)]]
+    x_apply_diag_mixed = [
+        [1, PauliZ(0), max_mixed_state(1)],
+        [2, CZ(wires=[0, 1]), max_mixed_state(2)],
+    ]
 
     @pytest.mark.parametrize("x", x_apply_diag_mixed)
     def test_diag_mixed(self, x, tol):

--- a/tests/devices/test_default_qubit.py
+++ b/tests/devices/test_default_qubit.py
@@ -1699,7 +1699,7 @@ class TestTensorSample:
         dev._samples = dev.generate_samples()
         dev.sample(obs)
 
-        s1 = obs.eigvals
+        s1 = obs.eigvals()
         p = dev.probability(wires=dev.map_wires(obs.wires))
 
         # s1 should only contain 1 and -1
@@ -1739,7 +1739,7 @@ class TestTensorSample:
         dev._samples = dev.generate_samples()
         dev.sample(obs)
 
-        s1 = obs.eigvals
+        s1 = obs.eigvals()
         p = dev.marginal_prob(dev.probability(), wires=obs.wires)
 
         # s1 should only contain 1 and -1
@@ -1787,7 +1787,7 @@ class TestTensorSample:
         dev._samples = dev.generate_samples()
         dev.sample(obs)
 
-        s1 = obs.eigvals
+        s1 = obs.eigvals()
         p = dev.marginal_prob(dev.probability(), wires=obs.wires)
 
         # s1 should only contain the eigenvalues of

--- a/tests/devices/test_default_qubit_tf.py
+++ b/tests/devices/test_default_qubit_tf.py
@@ -177,11 +177,11 @@ class TestTFMatrix:
     def test_pauli_rot_tf_(self, param, pauli, wires):
         op = qml.PauliRot(param, pauli, wires=wires)
         expected_mat = op.matrix()
-        expected_eigvals = op.eigvals
+        expected_eigvals = op.eigvals()
 
         tf_op = qml.PauliRot(tf.Variable(param), pauli, wires=wires)
         obtained_mat = tf_op.matrix()
-        obtained_eigvals = tf_op.eigvals
+        obtained_eigvals = tf_op.eigvals()
 
         assert qml.math.get_interface(obtained_mat) == "tensorflow"
         assert qml.math.get_interface(obtained_eigvals) == "tensorflow"

--- a/tests/ops/qubit/test_non_parametric_ops.py
+++ b/tests/ops/qubit/test_non_parametric_ops.py
@@ -419,6 +419,7 @@ class TestDecompositions:
 
 
 class TestEigenval:
+
     def test_iswap_eigenval(self):
         """Tests that the ISWAP eigenvalue matches the numpy eigenvalues of the ISWAP matrix"""
         op = qml.ISWAP(wires=[0, 1])
@@ -434,6 +435,11 @@ class TestEigenval:
         res = op.eigvals()
         assert np.allclose(res, exp)
 
+    def test_sx_eigenvals(self):
+        """Tests that the SX eigenvalues are correct."""
+        evals = qml.SX(wires=0).eigvals()
+        expected = np.linalg.eigvals(qml.SX(wires=0).matrix())
+        assert np.allclose(evals, expected)
 
 class TestBarrier:
     """Tests that the Barrier gate is correct"""

--- a/tests/ops/qubit/test_non_parametric_ops.py
+++ b/tests/ops/qubit/test_non_parametric_ops.py
@@ -423,7 +423,7 @@ class TestEigenval:
         """Tests that the ISWAP eigenvalue matches the numpy eigenvalues of the ISWAP matrix"""
         op = qml.ISWAP(wires=[0, 1])
         exp = np.linalg.eigvals(op.matrix())
-        res = op.eigvals
+        res = op.eigvals()
         assert np.allclose(res, exp)
 
     @pytest.mark.parametrize("siswap_op", [qml.SISWAP, qml.SQISW])
@@ -431,7 +431,7 @@ class TestEigenval:
         """Tests that the ISWAP eigenvalue matches the numpy eigenvalues of the ISWAP matrix"""
         op = siswap_op(wires=[0, 1])
         exp = np.linalg.eigvals(op.matrix())
-        res = op.eigvals
+        res = op.eigvals()
         assert np.allclose(res, exp)
 
 

--- a/tests/ops/qubit/test_non_parametric_ops.py
+++ b/tests/ops/qubit/test_non_parametric_ops.py
@@ -419,7 +419,6 @@ class TestDecompositions:
 
 
 class TestEigenval:
-
     def test_iswap_eigenval(self):
         """Tests that the ISWAP eigenvalue matches the numpy eigenvalues of the ISWAP matrix"""
         op = qml.ISWAP(wires=[0, 1])
@@ -440,6 +439,7 @@ class TestEigenval:
         evals = qml.SX(wires=0).eigvals()
         expected = np.linalg.eigvals(qml.SX(wires=0).matrix())
         assert np.allclose(evals, expected)
+
 
 class TestBarrier:
     """Tests that the Barrier gate is correct"""

--- a/tests/ops/qubit/test_observables.py
+++ b/tests/ops/qubit/test_observables.py
@@ -130,7 +130,7 @@ class TestSimpleObservables:
     def test_eigvals(self, obs, mat, eigs, tol):
         """Test eigenvalues of standard observables are correct"""
         obs = obs(wires=0)
-        res = obs.eigvals
+        res = obs.eigvals()
         assert np.allclose(res, eigs, atol=tol, rtol=0)
 
     @pytest.mark.parametrize("obs, mat, eigs", OBSERVABLES)
@@ -190,7 +190,7 @@ class TestHermitian:
 
         key = tuple(observable_1.flatten().tolist())
 
-        qml.Hermitian(observable_1, 0).eigvals
+        qml.Hermitian(observable_1, 0).eigvals()
         assert np.allclose(
             qml.Hermitian._eigs[key]["eigval"], observable_1_eigvals, atol=tol, rtol=0
         )
@@ -205,7 +205,7 @@ class TestHermitian:
 
         key_2 = tuple(observable_2.flatten().tolist())
 
-        qml.Hermitian(observable_2, 0).eigvals
+        qml.Hermitian(observable_2, 0).eigvals()
         assert np.allclose(
             qml.Hermitian._eigs[key_2]["eigval"], observable_2_eigvals, atol=tol, rtol=0
         )
@@ -221,12 +221,12 @@ class TestHermitian:
         """Tests that the eigvals method of the Hermitian class keeps the same dictionary entries upon multiple calls."""
         key = tuple(observable.flatten().tolist())
 
-        qml.Hermitian(observable, 0).eigvals
+        qml.Hermitian(observable, 0).eigvals()
         assert np.allclose(qml.Hermitian._eigs[key]["eigval"], eigvals, atol=tol, rtol=0)
         assert np.allclose(qml.Hermitian._eigs[key]["eigvec"], eigvecs, atol=tol, rtol=0)
         assert len(qml.Hermitian._eigs) == 1
 
-        qml.Hermitian(observable, 0).eigvals
+        qml.Hermitian(observable, 0).eigvals()
         assert np.allclose(qml.Hermitian._eigs[key]["eigval"], eigvals, atol=tol, rtol=0)
         assert np.allclose(qml.Hermitian._eigs[key]["eigvec"], eigvecs, atol=tol, rtol=0)
         assert len(qml.Hermitian._eigs) == 1
@@ -373,7 +373,7 @@ class TestProjector:
     def test_projector_eigvals(self, basis_state, tol):
         """Tests that the eigvals property of the Projector class returns the correct results."""
         num_wires = len(basis_state)
-        eigvals = qml.Projector(basis_state, wires=range(num_wires)).eigvals
+        eigvals = qml.Projector(basis_state, wires=range(num_wires)).eigvals()
 
         if basis_state[0] == 0:
             observable = np.array([[1, 0], [0, 0]])

--- a/tests/ops/qubit/test_parametric_ops.py
+++ b/tests/ops/qubit/test_parametric_ops.py
@@ -558,7 +558,7 @@ class TestMatrix:
         exp = ControlledPhaseShift(phi)
         assert np.allclose(res, exp)
 
-        res = op.eigvals
+        res = op.eigvals()
         assert np.allclose(res, np.diag(exp))
 
 
@@ -1071,7 +1071,7 @@ class TestPauliRot:
         op = qml.PauliRot(theta, "Z", wires=0)
         decomp_ops = op.decompose()
 
-        assert np.allclose(op.eigvals, np.array([np.exp(-1j * theta / 2), np.exp(1j * theta / 2)]))
+        assert np.allclose(op.eigvals(), np.array([np.exp(-1j * theta / 2), np.exp(1j * theta / 2)]))
         assert np.allclose(op.matrix(), np.diag([np.exp(-1j * theta / 2), np.exp(1j * theta / 2)]))
 
         assert len(decomp_ops) == 1
@@ -1088,7 +1088,7 @@ class TestPauliRot:
         op = qml.PauliRot(theta, "II", wires=[0, 1])
         decomp_ops = op.decompose()
 
-        assert np.allclose(op.eigvals, np.exp(-1j * theta / 2) * np.ones(4))
+        assert np.allclose(op.eigvals(), np.exp(-1j * theta / 2) * np.ones(4))
         assert np.allclose(op.matrix() / op.matrix()[0, 0], np.eye(4))
 
         assert len(decomp_ops) == 0

--- a/tests/ops/qubit/test_parametric_ops.py
+++ b/tests/ops/qubit/test_parametric_ops.py
@@ -1071,7 +1071,9 @@ class TestPauliRot:
         op = qml.PauliRot(theta, "Z", wires=0)
         decomp_ops = op.decompose()
 
-        assert np.allclose(op.eigvals(), np.array([np.exp(-1j * theta / 2), np.exp(1j * theta / 2)]))
+        assert np.allclose(
+            op.eigvals(), np.array([np.exp(-1j * theta / 2), np.exp(1j * theta / 2)])
+        )
         assert np.allclose(op.matrix(), np.diag([np.exp(-1j * theta / 2), np.exp(1j * theta / 2)]))
 
         assert len(decomp_ops) == 1

--- a/tests/ops/test_identity.py
+++ b/tests/ops/test_identity.py
@@ -18,7 +18,7 @@ import numpy as np
 
 def test_identity_eigvals(tol):
     """Test identity eigenvalues are correct"""
-    res = qml.Identity._eigvals()
+    res = qml.Identity.compute_eigvals()
     expected = np.array([1, 1])
     assert np.allclose(res, expected, atol=tol, rtol=0)
 

--- a/tests/tape/test_tape.py
+++ b/tests/tape/test_tape.py
@@ -859,7 +859,7 @@ class TestExpand:
         assert [m.obs is r for m, r in zip(new_tape.measurements, expected)]
 
         expected = [None, [1, -1, -1, 1], [0, 5]]
-        assert [m.eigvals is r for m, r in zip(new_tape.measurements, expected)]
+        assert [m.eigvals() is r for m, r in zip(new_tape.measurements, expected)]
 
     def test_expand_tape_multiple_wires(self):
         """Test the expand() method when measurements with more than one observable on the same

--- a/tests/test_measure.py
+++ b/tests/test_measure.py
@@ -476,8 +476,7 @@ class TestProperties:
 
     def test_observable_with_no_eigvals(self):
         """An observable with no eigenvalues defined should cause
-        the eigvals property on the associated measurement process
-        to be None"""
+        the eigvals method to return a NotImplementedError"""
         obs = qml.NumberOperator(wires=0)
         m = MeasurementProcess(Expectation, obs=obs)
         assert m.eigvals() is None

--- a/tests/test_measure.py
+++ b/tests/test_measure.py
@@ -452,11 +452,11 @@ class TestProperties:
         obs = qml.Hermitian(np.diag([1, 2, 3]), wires=[0, 1, 2])
         m = MeasurementProcess(Expectation, obs=obs)
 
-        assert np.all(m.eigvals == np.array([1, 2, 3]))
+        assert np.all(m.eigvals() == np.array([1, 2, 3]))
 
         # changing the observable data should be reflected
         obs.data = [np.diag([5, 6, 7])]
-        assert np.all(m.eigvals == np.array([5, 6, 7]))
+        assert np.all(m.eigvals() == np.array([5, 6, 7]))
 
     def test_error_obs_and_eigvals(self):
         """Test that providing both eigenvalues and an observable
@@ -480,7 +480,7 @@ class TestProperties:
         to be None"""
         obs = qml.NumberOperator(wires=0)
         m = MeasurementProcess(Expectation, obs=obs)
-        assert m.eigvals is None
+        assert m.eigvals() is None
 
     def test_repr(self):
         """Test the string representation of a MeasurementProcess."""
@@ -517,7 +517,7 @@ class TestExpansion:
         assert len(tape.measurements) == 1
         assert tape.measurements[0].return_type is Expectation
         assert tape.measurements[0].wires.tolist() == [0, 1]
-        assert np.all(tape.measurements[0].eigvals == np.array([1, -1, -1, 1]))
+        assert np.all(tape.measurements[0].eigvals() == np.array([1, -1, -1, 1]))
 
     def test_expand_hermitian(self, tol):
         """Test the expansion of an hermitian observable"""
@@ -541,7 +541,7 @@ class TestExpansion:
         assert len(tape.measurements) == 1
         assert tape.measurements[0].return_type is Expectation
         assert tape.measurements[0].wires.tolist() == ["a"]
-        assert np.all(tape.measurements[0].eigvals == np.array([0, 5]))
+        assert np.all(tape.measurements[0].eigvals() == np.array([0, 5]))
 
     def test_expand_no_observable(self):
         """Check that an exception is raised if the measurement to

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -600,10 +600,10 @@ class TestTensor:
         X = qml.PauliX(0)
         Y = qml.PauliY(2)
         t = Tensor(X, Y)
-        assert np.array_equal(t.eigvals, np.kron([1, -1], [1, -1]))
+        assert np.array_equal(t.eigvals(), np.kron([1, -1], [1, -1]))
 
         # test that the eigvals are now cached and not recalculated
-        assert np.array_equal(t._eigvals_cache, t.eigvals)
+        assert np.array_equal(t._eigvals_cache, t.eigvals())
 
     @pytest.mark.usefixtures("tear_down_hermitian")
     def test_eigvals_hermitian(self, tol):
@@ -613,7 +613,7 @@ class TestTensor:
         Herm = qml.Hermitian(hamiltonian, wires=[1, 2])
         t = Tensor(X, Herm)
         d = np.kron(np.array([1.0, -1.0]), np.array([-1.0, 1.0, 1.0, 1.0]))
-        t = t.eigvals
+        t = t.eigvals()
         assert np.allclose(t, d, atol=tol, rtol=0)
 
     def test_eigvals_identity(self, tol):
@@ -622,7 +622,7 @@ class TestTensor:
         Iden = qml.Identity(1)
         t = Tensor(X, Iden)
         d = np.kron(np.array([1.0, -1.0]), np.array([1.0, 1.0]))
-        t = t.eigvals
+        t = t.eigvals()
         assert np.allclose(t, d, atol=tol, rtol=0)
 
     def test_eigvals_identity_and_hermitian(self, tol):
@@ -630,7 +630,7 @@ class TestTensor:
         multiple types of observables"""
         H = np.diag([1, 2, 3, 4])
         O = qml.PauliX(0) @ qml.Identity(2) @ qml.Hermitian(H, wires=[4, 5])
-        res = O.eigvals
+        res = O.eigvals()
         expected = np.kron(np.array([1.0, -1.0]), np.kron(np.array([1.0, 1.0]), np.arange(1, 5)))
         assert np.allclose(res, expected, atol=tol, rtol=0)
 
@@ -703,7 +703,7 @@ class TestTensor:
         U = functools.reduce(np.kron, U_list)
 
         res = U @ O_mat @ U.conj().T
-        expected = np.diag(O.eigvals)
+        expected = np.diag(O.eigvals())
 
         # once diagonalized by U, the result should be a diagonal
         # matrix of the eigenvalues.

--- a/tests/test_qubit_device.py
+++ b/tests/test_qubit_device.py
@@ -474,7 +474,7 @@ class TestExpval:
             m.setattr(QubitDevice, "probability", lambda self, wires=None: probs)
             res = dev.expval(obs)
 
-        assert res == (obs.eigvals @ probs).real
+        assert res == (obs.eigvals() @ probs).real
 
     def test_non_analytic_expval(self, mock_qubit_device_with_original_statistics, monkeypatch):
         """Tests that expval method when the analytic attribute is False
@@ -506,7 +506,6 @@ class TestExpval:
         class MyObs(qml.operation.Observable):
             num_wires = 1
 
-            @property
             def eigvals(self):
                 raise NotImplementedError
 
@@ -537,7 +536,7 @@ class TestVar:
             m.setattr(QubitDevice, "probability", lambda self, wires=None: probs)
             res = dev.var(obs)
 
-        assert res == (obs.eigvals ** 2) @ probs - (obs.eigvals @ probs).real ** 2
+        assert res == (obs.eigvals() ** 2) @ probs - (obs.eigvals() @ probs).real ** 2
 
     def test_non_analytic_var(self, mock_qubit_device_with_original_statistics, monkeypatch):
         """Tests that var method when the analytic attribute is False
@@ -568,7 +567,6 @@ class TestVar:
         class MyObs(qml.operation.Observable):
             num_wires = 1
 
-            @property
             def eigvals(self):
                 raise NotImplementedError
 


### PR DESCRIPTION

**Context:**

Applies the new design to eigenvalues.

**Description of the Change:**

Renaming, make `eigvals` a proper method, add some docstrings and examples.

**Possible Drawbacks:**

Didn't add tests. We should probably do this, but in interest of time I just rely on the old tests.