### PR TITLE
Add adjoint method to Barrier

### DIFF
--- a/pennylane/ops/qubit/non_parametric_ops.py
+++ b/pennylane/ops/qubit/non_parametric_ops.py
@@ -1186,3 +1186,6 @@ class Barrier(Operation):
 
     def label(self, decimals=None):
         return "||"
+
+    def adjoint(self):
+        return Barrier(wires=self.wires)


### PR DESCRIPTION
**Context:**
`Barrier` was missing `adjoint` method. 
**Description of the Change:**
Add `adjoint` method
**Benefits:**
Adjointed circuits now correctly have the `Barrier` at the right place.
**Possible Drawbacks:**
None
**Related GitHub Issues:**
