### PR TITLE
Fix openqasm test

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -147,6 +147,10 @@
 
 <h3>Improvements</h3>
 
+* A precision argument has been added to the tape's ``to_openqasm`` function 
+  to control the precision of parameters.
+  [(#XXX)](https://github.com/PennyLaneAI/pennylane/pull/XXX)
+
 * Insert transform now supports adding operation after or before certain specific gates.
   [(#1980)](https://github.com/PennyLaneAI/pennylane/pull/1980)
 

--- a/pennylane/tape/tape.py
+++ b/pennylane/tape/tape.py
@@ -1130,7 +1130,7 @@ class QuantumTape(AnnotatedQueue):
             max_length=max_length,
         )
 
-    def to_openqasm(self, wires=None, rotations=True, measure_all=True):
+    def to_openqasm(self, wires=None, rotations=True, measure_all=True, precision=None):
         """Serialize the circuit as an OpenQASM 2.0 program.
 
         Measurements are assumed to be performed on all qubits in the computational basis. An
@@ -1150,6 +1150,7 @@ class QuantumTape(AnnotatedQueue):
                 measured wires such that they are in the eigenbasis of the circuit observables.
             measure_all (bool): whether to perform a computational basis measurement on all qubits
                 or just those specified in the tape
+            precision (int): decimal digits to display for parameters
 
         Returns:
             str: OpenQASM serialization of the circuit
@@ -1200,7 +1201,11 @@ class QuantumTape(AnnotatedQueue):
             if op.num_params > 0:
                 # If the operation takes parameters, construct a string
                 # with parameter values.
-                params = "(" + ",".join([str(p) for p in op.parameters]) + ")"
+                if precision is not None:
+                    params = "(" + ",".join([f'{p:.{precision}}' for p in op.parameters]) + ")"
+                else:
+                    # use default precision
+                    params = "(" + ",".join([str(p) for p in op.parameters]) + ")"
 
             qasm_str += f"{gate}{params} {wire_labels};\n"
 

--- a/pennylane/tape/tape.py
+++ b/pennylane/tape/tape.py
@@ -1202,7 +1202,7 @@ class QuantumTape(AnnotatedQueue):
                 # If the operation takes parameters, construct a string
                 # with parameter values.
                 if precision is not None:
-                    params = "(" + ",".join([f'{p:.{precision}}' for p in op.parameters]) + ")"
+                    params = "(" + ",".join([f"{p:.{precision}}" for p in op.parameters]) + ")"
                 else:
                     # use default precision
                     params = "(" + ",".join([str(p) for p in op.parameters]) + ")"

--- a/tests/circuit_graph/test_qasm.py
+++ b/tests/circuit_graph/test_qasm.py
@@ -162,12 +162,12 @@ class TestToQasmUnitTests:
         with qml.tape.QuantumTape() as circuit1:
             qml.QubitStateVector(psi, wires=[0, 1])
 
-        qasm1 = circuit1.to_openqasm()
+        qasm1 = circuit1.to_openqasm(precision=11)
 
         with qml.tape.QuantumTape() as circuit2:
             qml.QubitStateVector.decomposition(psi, wires=[0, 1])
 
-        qasm2 = circuit2.to_openqasm(wires=Wires([0, 1]))
+        qasm2 = circuit2.to_openqasm(wires=Wires([0, 1]), precision=11)
 
         expected = dedent(
             """\
@@ -175,18 +175,19 @@ class TestToQasmUnitTests:
             include "qelib1.inc";
             qreg q[2];
             creg c[2];
-            ry(1.5707963267948968) q[0];
-            ry(1.5707963267948968) q[1];
+            ry(1.5707963268) q[0];
+            ry(1.5707963268) q[1];
             cx q[0],q[1];
             cx q[0],q[1];
             cx q[0],q[1];
-            rz(3.141592653589793) q[1];
+            rz(3.1415926536) q[1];
             cx q[0],q[1];
             measure q[0] -> c[0];
             measure q[1] -> c[1];
             """
         )
 
+        # different
         assert qasm1 == expected
         assert qasm1 == qasm2
 
@@ -694,6 +695,31 @@ class TestQNodeQasmIntegrationTests:
             measure q[0] -> c[0];
             measure q[1] -> c[1];
             measure q[2] -> c[2];
+            """
+        )
+
+        assert res == expected
+
+    def test_precision(self):
+        """Test that the QASM serializer takes into account the desired precision."""
+        dev = qml.device("default.qubit", wires=["a"])
+
+        @qml.qnode(dev)
+        def qnode():
+            qml.RX(np.pi, wires="a")
+            return qml.expval(qml.PauliZ("a"))
+
+        qnode()
+        res = qnode.qtape.to_openqasm(precision=4)
+
+        expected = dedent(
+            """\
+            OPENQASM 2.0;
+            include "qelib1.inc";
+            qreg q[1];
+            creg c[1];
+            rx(3.142) q[0];
+            measure q[0] -> c[0];
             """
         )
 

--- a/tests/circuit_graph/test_qasm.py
+++ b/tests/circuit_graph/test_qasm.py
@@ -558,7 +558,7 @@ class TestQNodeQasmIntegrationTests:
 
         # construct the qnode circuit
         qnode(state=np.array([1, -1, -1, 1]) / np.sqrt(4))
-        res = qnode.qtape.to_openqasm()
+        res = qnode.qtape.to_openqasm(precision=11)
 
         expected = dedent(
             """\
@@ -566,12 +566,12 @@ class TestQNodeQasmIntegrationTests:
             include "qelib1.inc";
             qreg q[2];
             creg c[2];
-            ry(1.5707963267948968) q[0];
-            ry(1.5707963267948968) q[1];
+            ry(1.5707963268) q[0];
+            ry(1.5707963268) q[1];
             cx q[0],q[1];
             cx q[0],q[1];
             cx q[0],q[1];
-            rz(3.141592653589793) q[1];
+            rz(3.1415926536) q[1];
             cx q[0],q[1];
             measure q[0] -> c[0];
             measure q[1] -> c[1];


### PR DESCRIPTION
Presumably due to a change in precision handling of a dependency, a qasm test started failing because of a different string representation of a 15th digit.

This PR adds a precision argument to the `to_openqasm` method, and uses it in the test. A test for the argument is also added.