### PR TITLE
Fix sign errors in `qml.DoubleExcitation` documentation.

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -186,6 +186,9 @@
 
 <h3>Documentation</h3>
 
+* Fixes an error in the signs of equations in the `DoubleExcitation` page.
+  [(#2072)](https://github.com/PennyLaneAI/pennylane/pull/2072)
+
 * Extended the interfaces description page to explicitly mention device
   compatibility.
   [(#2031)](https://github.com/PennyLaneAI/pennylane/pull/2031)

--- a/pennylane/ops/qubit/qchem_ops.py
+++ b/pennylane/ops/qubit/qchem_ops.py
@@ -278,8 +278,8 @@ class DoubleExcitation(Operation):
 
     .. math::
 
-        &|0011\rangle \rightarrow \cos(\phi/2) |0011\rangle - \sin(\phi/2) |1100\rangle\\
-        &|1100\rangle \rightarrow \cos(\phi/2) |1100\rangle + \sin(\phi/2) |0011\rangle,
+        &|0011\rangle \rightarrow \cos(\phi/2) |0011\rangle + \sin(\phi/2) |1100\rangle\\
+        &|1100\rangle \rightarrow \cos(\phi/2) |1100\rangle - \sin(\phi/2) |0011\rangle,
 
     while leaving all other basis states unchanged.
 
@@ -301,7 +301,7 @@ class DoubleExcitation(Operation):
     **Example**
 
     The following circuit performs the transformation :math:`|1100\rangle\rightarrow \cos(
-    \phi/2)|1100\rangle +\sin(\phi/2)|0011\rangle)`:
+    \phi/2)|1100\rangle - \sin(\phi/2)|0011\rangle)`:
 
     .. code-block::
 


### PR DESCRIPTION
**Context:** There is an error in the signs of the basis state transforms in the `DoubleExcitation` documentation; it does not match the actual transformation that is being performed.

**Description of the Change:** Fixes the signs in relevant places in the docs.

The existing example given is:
```python
dev = qml.device('default.qubit', wires=4)

@qml.qnode(dev)
def circuit(phi):
    qml.PauliX(wires=0)
    qml.PauliX(wires=1)
    qml.DoubleExcitation(phi, wires=[0, 1, 2, 3])
    return qml.state()

>>> circuit(0.1)
tensor([ 0.        +0.j,  0.        +0.j,  0.        +0.j,
        -0.04997917+0.j,  0.        +0.j,  0.        +0.j,
         0.        +0.j,  0.        +0.j,  0.        +0.j,
         0.        +0.j,  0.        +0.j,  0.        +0.j,
         0.99875026+0.j,  0.        +0.j,  0.        +0.j,
         0.        +0.j], requires_grad=True)
```
If you run this, it produces the state `-sin(phi/2)|0011> + cos(phi/2) |1100>`, whereas the original documentation displayed both signs as a `+`.

**Benefits:** ^ the above :tada:

**Possible Drawbacks:** None

**Related GitHub Issues:** None
