### PR TITLE
Remove mentions of `"reversible"` method

### DIFF
--- a/doc/introduction/interfaces.rst
+++ b/doc/introduction/interfaces.rst
@@ -53,13 +53,6 @@ accumulators such as the parameter-shift rule and finite-differences. For more d
   forward pass by iteratively applying the inverse (adjoint) gate. This method is similar to
   ``"backprop"``, but has significantly lower memory usage and a similar runtime.
 
-* ``"reversible"``: Use a form of backpropagation that takes advantage of the unitary or reversible
-  nature of quantum computation.
-
-  This method is similar to the ``adjoint`` method, but has a slightly larger time overhead and a similar
-  memory overhead. Compared to the parameter-shift rule, the reversible method can be faster or slower,
-  depending on the density and location of parametrized gates in a circuit.
-
 Hardware-compatible differentiation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -170,6 +170,10 @@
 
 <h3>Bug fixes</h3>
 
+* The available `diff_method`s for QNodes given in an error message and the
+  documentation have been corrected.
+  [(#2078)](https://github.com/PennyLaneAI/pennylane/pull/2078)
+
 * Fixes a bug in `DefaultQubit` where the second derivative of QNodes at 
   positions corresponding to vanishing state vector amplitudes is wrong.
   [(#2057)](https://github.com/PennyLaneAI/pennylane/pull/2057)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -209,8 +209,8 @@
 
 <h3>Bug fixes</h3>
 
-* The available `diff_method`s for QNodes given in an error message and the
-  documentation have been corrected.
+* The available `diff_method` options for QNodes has been corrected in both the
+  error messages and the documentation.
   [(#2078)](https://github.com/PennyLaneAI/pennylane/pull/2078)
 
 * Fixes a bug in `DefaultQubit` where the second derivative of QNodes at 

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -845,8 +845,7 @@ class QubitDevice(Device):
         `Jones and Gacon <https://arxiv.org/abs/2009.02823>`__ to differentiate an input tape.
 
         After a forward pass, the circuit is reversed by iteratively applying inverse (adjoint)
-        gates to scan backwards through the circuit. This method is similar to the reversible
-        method, but has a lower time overhead and a similar memory overhead.
+        gates to scan backwards through the circuit.
 
         .. note::
             The adjoint differentiation method has the following restrictions:

--- a/pennylane/qnode.py
+++ b/pennylane/qnode.py
@@ -313,7 +313,7 @@ class QNode:
         if isinstance(diff_method, str):
             raise qml.QuantumFunctionError(
                 f"Differentiation method {diff_method} not recognized. Allowed "
-                "options are ('best', 'parameter-shift', 'backprop', 'finite-diff', 'device', 'reversible', 'adjoint')."
+                "options are ('best', 'parameter-shift', 'backprop', 'finite-diff', 'device', 'adjoint')."
             )
 
         if isinstance(diff_method, qml.gradients.gradient_transform):
@@ -421,10 +421,9 @@ class QNode:
         # need to inspect the circuit measurements to ensure only expectation values are taken. This
         # cannot be done here since we don't yet know the composition of the circuit.
 
-        supported_device = hasattr(device, "_apply_operation")
-        supported_device = supported_device and hasattr(device, "_apply_unitary")
+        required_attrs = ["_apply_operation", "_apply_unitary", "adjoint_jacobian"]
+        supported_device = all(hasattr(device, attr) for attr in required_attrs)
         supported_device = supported_device and device.capabilities().get("returns_state")
-        supported_device = supported_device and hasattr(device, "adjoint_jacobian")
 
         if not supported_device:
             raise ValueError(

--- a/tests/devices/test_default_qubit_torch.py
+++ b/tests/devices/test_default_qubit_torch.py
@@ -1540,7 +1540,7 @@ class TestPassthruIntegration:
             assert qml.qnode(dev, diff_method="autograd", interface=interface)(circuit)
         assert (
             str(e.value)
-            == "Differentiation method autograd not recognized. Allowed options are ('best', 'parameter-shift', 'backprop', 'finite-diff', 'device', 'reversible', 'adjoint')."
+            == "Differentiation method autograd not recognized. Allowed options are ('best', 'parameter-shift', 'backprop', 'finite-diff', 'device', 'adjoint')."
         )
 
 

--- a/tests/ops/qubit/test_hamiltonian.py
+++ b/tests/ops/qubit/test_hamiltonian.py
@@ -1646,29 +1646,3 @@ class TestHamiltonianDifferentiation:
             match="Adjoint differentiation method does not support Hamiltonian observables",
         ):
             grad_fn(coeffs, param)
-
-    @pytest.mark.xfail
-    def test_not_supported_by_reverse_differentiation(self):
-        """Test that error is raised when attempting the reverse differentiation method."""
-        dev = qml.device("default.qubit", wires=2)
-
-        coeffs = pnp.array([-0.05, 0.17], requires_grad=True)
-        param = pnp.array(1.7, requires_grad=True)
-
-        @qml.qnode(dev, diff_method="reversible")
-        def circuit(coeffs, param):
-            qml.RX(param, wires=0)
-            qml.RY(param, wires=0)
-            return qml.expval(
-                qml.Hamiltonian(
-                    coeffs,
-                    [qml.PauliX(0), qml.PauliZ(0)],
-                )
-            )
-
-        grad_fn = qml.grad(circuit)
-        with pytest.raises(
-            qml.QuantumFunctionError,
-            match="Reverse differentiation method does not support Hamiltonian observables",
-        ):
-            grad_fn(coeffs, param)


### PR DESCRIPTION
Fixes #2077 and removes the comparison of the adjoint method to the reversible method in the doc string of `adjoint_jacobian` as it is not visible to users unless they use the old QNode.

Unrelated: Made the capability check for the adjoint diff method a tiny bit more readable.

Related issues:
#2077