### PR TITLE
Fix issue template for bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -62,6 +62,7 @@ body:
   - type: checkboxes
     id: terms
     attributes:
-      label: I have searched existing GitHub issues to make sure the issue does not already exist.
+      label: Existing GitHub issues
       options:
+        - label: I have searched existing GitHub issues to make sure the issue does not already exist.
           required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -62,6 +62,6 @@ body:
   - type: checkboxes
     id: terms
     attributes:
+      label: I have searched existing GitHub issues to make sure the issue does not already exist.
       options:
-        - label: I have searched existing GitHub issues to make sure the issue does not already exist.
           required: true


### PR DESCRIPTION
The bug report template raises an error (see [here]()):
![Screenshot from 2022-01-13 14-02-19](https://user-images.githubusercontent.com/20772922/149335137-c1b4c457-fe36-4e7e-add7-4bca278de058.png)

As the error message is saying, the eights (zero-based indexing) entry of the `body`, which is the very last entry in the `body`, requires the mandatory `key` called `label`. While the `options` of this entry do have a `label`, the entry itself does not.

This PR includes a dummy value for this `key`. (According to the documentation, an empty or whitespace-only string is not accepted for values of mandatory fields.) 