### PR TITLE
Make `Rotosolve._validate inputs` static

### DIFF
--- a/pennylane/optimize/rotosolve.py
+++ b/pennylane/optimize/rotosolve.py
@@ -300,7 +300,8 @@ class RotosolveOptimizer:
         else:
             self.substep_optimizer = substep_optimizer
 
-    def _validate_inputs(self, requires_grad, args, nums_frequency, spectra):
+    @staticmethod
+    def _validate_inputs(requires_grad, args, nums_frequency, spectra):
         """Checks that for each trainable argument either the number of
         frequencies or the frequency spectrum is given."""
 


### PR DESCRIPTION
Fixes a no `self` use issue that Codefactor is raising.

![Screenshot from 2022-01-13 10-43-41](https://user-images.githubusercontent.com/24476053/149361874-ca5e8577-0bbb-47de-8267-de88b3e769c0.png)
