### PR TITLE
Remove unused `warnings` import

### DIFF
--- a/pennylane/gradients/hessian_transform.py
+++ b/pennylane/gradients/hessian_transform.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 """This module contains utilities for defining custom Hessian transforms,
 including a decorator for specifying Hessian expansions."""
-import warnings
-
 import pennylane as qml
 
 from pennylane.transforms.tape_expand import expand_invalid_trainable


### PR DESCRIPTION
Removes an unused `warnings` import that makes Codefactor fail.

![Screenshot from 2022-01-17 17-06-59](https://user-images.githubusercontent.com/24476053/149841960-37533720-004f-4b68-b9a5-d4dd3cc87d76.png)