### PR TITLE
Fix bug where the new QNode was not correctly expanding QWC observables

### DIFF
--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -620,9 +620,7 @@ class Device(abc.ABC):
             .QuantumTape: The expanded/decomposed circuit, such that the device
             will natively support all operations.
         """
-        obs_on_same_wire = len(
-            circuit._obs_sharing_wires  # pylint: disable=protected-access
-        ) > 0 and not self.supports_observable("Hamiltonian")
+        obs_on_same_wire = len(circuit._obs_sharing_wires) > 0  # pylint: disable=protected-access
 
         ops_not_supported = not all(self.stopping_condition(op) for op in circuit.operations)
 

--- a/pennylane/measure.py
+++ b/pennylane/measure.py
@@ -185,6 +185,7 @@ class MeasurementProcess:
             self.obs.diagonalizing_gates()
             MeasurementProcess(self.return_type, wires=self.obs.wires, eigvals=self.obs.eigvals)
 
+        print(tape)
         return tape
 
     def queue(self, context=qml.QueuingContext):


### PR DESCRIPTION
**Context:** In #2095 it was noticed that PL v0.19 and above was no longer returning the correct result for QNodes with multiple measurements. It turns out that `Device.default_expand_fn` was not correctly diagonalizing the QWC Pauli terms due to an errant if condition.

**Description of the Change:**

- Fixes the `if` condition in `Device.default_expand_fn` so that multiple QWC observables are correctly expanded.

- Adds a test to ensure this edge case passes.

**Benefits:** As above.

**Possible Drawbacks:** n/a

**Related GitHub Issues:** Closes #2095
