### PR TITLE
Rotosolve warning no trainables

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -249,6 +249,10 @@
 
 <h3>Improvements</h3>
 
+* The `RotosolveOptimizer` now raises an error if no trainable arguments are
+  detected, instead of silently skipping update steps for all arguments.
+  [(#2109)](https://github.com/PennyLaneAI/pennylane/pull/2109)
+
 * The function `qml.math.safe_squeeze` is introduced and `gradient_transform` allows
   for QNode argument axes of size `1`.
   [(#2080)](https://github.com/PennyLaneAI/pennylane/pull/2080)

--- a/pennylane/optimize/rotosolve.py
+++ b/pennylane/optimize/rotosolve.py
@@ -50,6 +50,11 @@ def _validate_inputs(requires_grad, args, nums_frequency, spectra):
     """Checks that for each trainable argument either the number of
     frequencies or the frequency spectrum is given."""
 
+    if not any(requires_grad.values()):
+        raise ValueError(
+            "Found no parameters to optimize. The parameters to optimize "
+            "have to be marked as trainable."
+        )
     for arg, (arg_name, _requires_grad) in zip(args, requires_grad.items()):
         if _requires_grad:
             _nums_frequency = nums_frequency.get(arg_name, {})
@@ -396,7 +401,7 @@ class RotosolveOptimizer:
         .. warning::
 
             ``RotosolveOptimizer`` will only update parameters that are *explicitly*
-            markes as trainable. Either via ``requires_grad`` if using Autograd or PyTorch,
+            marked as trainable. Either via ``requires_grad`` if using Autograd or PyTorch,
             or by using `tf.Variable` tensors inside a `GradientTape` if using TensorFlow.
 
         """
@@ -561,7 +566,7 @@ class RotosolveOptimizer:
         .. warning::
 
             ``RotosolveOptimizer`` will only update parameters that are *explicitly*
-            markes as trainable. Either via ``requires_grad`` if using Autograd or PyTorch,
+            marked as trainable. Either via ``requires_grad`` if using Autograd or PyTorch,
             or by using `tf.Variable` tensors inside a `GradientTape` if using TensorFlow.
         """
         x_new, _, *y_output = self.step_and_cost(

--- a/pennylane/optimize/rotosolve.py
+++ b/pennylane/optimize/rotosolve.py
@@ -174,6 +174,13 @@ class RotosolveOptimizer:
     and the reconstruction method used for more general operations is described in
     `Wierichs et al. (2021) <https://arxiv.org/abs/2107.12390>`_.
 
+    .. warning::
+
+        ``RotosolveOptimizer`` will only update parameters that are *explicitly*
+        marked as trainable. This can be done via ``requires_grad`` if using Autograd
+        or PyTorch. ``RotosolveOptimizer`` is not yet implemented to work in a stable
+        manner with TensorFlow or JAX.
+
     **Example:**
 
     Initialize the optimizer and set the number of steps to optimize over.
@@ -241,12 +248,6 @@ class RotosolveOptimizer:
     gradient-based optimizers when using Autograd or Torch.
     With TensorFlow, a ``tf.Variable`` inside a ``tf.GradientTape`` may be used to
     mark variables as trainable.
-
-    .. warning::
-
-        ``RotosolveOptimizer`` will only update parameters that are *explicitly*
-        marked as trainable. Either via ``requires_grad`` if using Autograd or PyTorch,
-        or by using `tf.Variable` tensors inside a `GradientTape` if using TensorFlow.
 
     Now we carry out the optimization.
     The minimized cost of the intermediate univariate reconstructions can

--- a/pennylane/optimize/rotosolve.py
+++ b/pennylane/optimize/rotosolve.py
@@ -242,6 +242,12 @@ class RotosolveOptimizer:
     With TensorFlow, a ``tf.Variable`` inside a ``tf.GradientTape`` may be used to
     mark variables as trainable.
 
+    .. warning::
+
+        ``RotosolveOptimizer`` will only update parameters that are *explicitly*
+        marked as trainable. Either via ``requires_grad`` if using Autograd or PyTorch,
+        or by using `tf.Variable` tensors inside a `GradientTape` if using TensorFlow.
+
     Now we carry out the optimization.
     The minimized cost of the intermediate univariate reconstructions can
     be read out via ``full_output``, including the cost *after* the full Rotosolve step:
@@ -397,12 +403,6 @@ class RotosolveOptimizer:
             about each parameter that is to be trained with ``RotosolveOptimizer``.
             For each univariate reconstruction, the data in ``nums_frequency`` takes
             precedence over the information in ``spectra``.
-
-        .. warning::
-
-            ``RotosolveOptimizer`` will only update parameters that are *explicitly*
-            marked as trainable. Either via ``requires_grad`` if using Autograd or PyTorch,
-            or by using `tf.Variable` tensors inside a `GradientTape` if using TensorFlow.
 
         """
         # todo: does this signature call cover all cases?

--- a/pennylane/optimize/rotosolve.py
+++ b/pennylane/optimize/rotosolve.py
@@ -563,11 +563,6 @@ class RotosolveOptimizer:
             For each univariate reconstruction, the data in ``nums_frequency`` takes
             precedence over the information in ``spectra``.
 
-        .. warning::
-
-            ``RotosolveOptimizer`` will only update parameters that are *explicitly*
-            marked as trainable. Either via ``requires_grad`` if using Autograd or PyTorch,
-            or by using `tf.Variable` tensors inside a `GradientTape` if using TensorFlow.
         """
         x_new, _, *y_output = self.step_and_cost(
             objective_fn,

--- a/tests/optimize/test_rotosolve.py
+++ b/tests/optimize/test_rotosolve.py
@@ -92,6 +92,20 @@ def test_error_missing_frequency_info_single_par():
     with pytest.raises(ValueError, match=r"was provided for the entry \(3,\)"):
         opt.step(fun, x, nums_frequency=nums_frequency, spectra=spectra)
 
+def test_error_no_trainable_args():
+    """Test that an error is raised if none of the arguments is trainable."""
+
+    opt = RotosolveOptimizer()
+    fun = lambda x, y, z: 1.
+    x = np.arange(4, requires_grad=False)
+    y = np.arange(2, requires_grad=False)
+    z = [1.2, -0.4, -9.1]
+    #nums_frequency = {"x": {(0,): 1, (1,): 1}}
+    #spectra = {"x": {(0,): [0.0, 1.0], (2,): [0.0, 1.0]}}
+
+    with pytest.raises(ValueError, match="Found no parameters to optimize."):
+        opt.step(fun, x, nums_frequency=None, spectra=None)
+
 
 classical_functions = [
     lambda x: np.sin(x + 0.124) * 2.5123,
@@ -189,10 +203,13 @@ class TestWithClassicalFunction:
             return fun(*args, **kwargs)
 
         opt = RotosolveOptimizer(substep_optimizer, substep_kwargs)
-
-        # Parameters are not marked as trainable -> Expect only one execution for f0
+        
+        # Make only the first argument trainable
+        param = (np.array(param[0], requires_grad=True),) + param[1:]
+        # Only one argument is marked as trainable -> Expect only the executions for that arg
         new_param = opt.step(_fun, *param, nums_frequency=nums_freq)
-        assert num_calls == 1
+        exp_num_calls_single_trainable = sum(2*num+1 for num in nums_freq["x"].values())
+        assert num_calls == exp_num_calls_single_trainable
         num_calls = 0
 
         # Parameters are now marked as trainable -> Expect full number of executions
@@ -207,7 +224,9 @@ class TestWithClassicalFunction:
         Includes testing of the parameter output shape and the old cost when using step_and_cost."""
         opt = RotosolveOptimizer(substep_optimizer, substep_kwargs)
 
-        # Without trainable parameters, param should not be changed
+        # Make only the first argument trainable
+        param = (np.array(param[0], requires_grad=True),) + param[1:]
+        # Only one argument is marked as trainable -> All other arguments have to stay fixed
         new_param_step = opt.step(
             fun,
             *param,
@@ -217,11 +236,7 @@ class TestWithClassicalFunction:
         if len(param) == 1:
             new_param_step = (new_param_step,)
 
-        assert np.allclose(
-            np.fromiter(_flatten(param), dtype=float),
-            np.fromiter(_flatten(new_param_step), dtype=float),
-            atol=1e-5,
-        )
+        assert all(np.allclose(p, new_p) for p, new_p in zip(param[1:], new_param_step[1:]))
 
         # With trainable parameters, training should happen
         param = tuple(np.array(p, requires_grad=True) for p in param)
@@ -320,17 +335,14 @@ def test_multiple_steps(fun, x_min, param, num_freq):
 
 
 classical_functions_deact = [
-    lambda x: np.sin(x + 0.124) * 2.5123,
     lambda x, y: -np.cos(x + 0.12) * 0.872 + np.sin(y[0] - 2.01) - np.cos(y[1] - 1.35) * 0.111,
     lambda x, y, z: -np.cos(x + 0.12) * 0.872 + np.sin(y - 2.01) - np.cos(z - 1.35) * 0.111,
 ]
 classical_minima_deact = [
-    (0.24,),
     (-0.12, [0.8, 0.1]),
     (-0.12, 0.2, 1.35),
 ]
 classical_params_deact = [
-    (np.array(0.24, requires_grad=False),),
     (np.array(0.3, requires_grad=True), np.array([0.8, 0.1], requires_grad=False)),
     (
         np.array(0.1, requires_grad=True),
@@ -339,7 +351,6 @@ classical_params_deact = [
     ),
 ]
 classical_nums_frequency_deact = [
-    {"x": {(): 1}},
     {"x": {(): 1}, "y": {(0,): 1, (1,): 1}},
     {"x": {(): 1}, "y": {(): 1}, "z": {(): 1}},
 ]

--- a/tests/optimize/test_rotosolve.py
+++ b/tests/optimize/test_rotosolve.py
@@ -92,16 +92,17 @@ def test_error_missing_frequency_info_single_par():
     with pytest.raises(ValueError, match=r"was provided for the entry \(3,\)"):
         opt.step(fun, x, nums_frequency=nums_frequency, spectra=spectra)
 
+
 def test_error_no_trainable_args():
     """Test that an error is raised if none of the arguments is trainable."""
 
     opt = RotosolveOptimizer()
-    fun = lambda x, y, z: 1.
+    fun = lambda x, y, z: 1.0
     x = np.arange(4, requires_grad=False)
     y = np.arange(2, requires_grad=False)
     z = [1.2, -0.4, -9.1]
-    #nums_frequency = {"x": {(0,): 1, (1,): 1}}
-    #spectra = {"x": {(0,): [0.0, 1.0], (2,): [0.0, 1.0]}}
+    # nums_frequency = {"x": {(0,): 1, (1,): 1}}
+    # spectra = {"x": {(0,): [0.0, 1.0], (2,): [0.0, 1.0]}}
 
     with pytest.raises(ValueError, match="Found no parameters to optimize."):
         opt.step(fun, x, nums_frequency=None, spectra=None)
@@ -203,12 +204,12 @@ class TestWithClassicalFunction:
             return fun(*args, **kwargs)
 
         opt = RotosolveOptimizer(substep_optimizer, substep_kwargs)
-        
+
         # Make only the first argument trainable
         param = (np.array(param[0], requires_grad=True),) + param[1:]
         # Only one argument is marked as trainable -> Expect only the executions for that arg
         new_param = opt.step(_fun, *param, nums_frequency=nums_freq)
-        exp_num_calls_single_trainable = sum(2*num+1 for num in nums_freq["x"].values())
+        exp_num_calls_single_trainable = sum(2 * num + 1 for num in nums_freq["x"].values())
         assert num_calls == exp_num_calls_single_trainable
         num_calls = 0
 

--- a/tests/optimize/test_rotosolve.py
+++ b/tests/optimize/test_rotosolve.py
@@ -101,8 +101,6 @@ def test_error_no_trainable_args():
     x = np.arange(4, requires_grad=False)
     y = np.arange(2, requires_grad=False)
     z = [1.2, -0.4, -9.1]
-    # nums_frequency = {"x": {(0,): 1, (1,): 1}}
-    # spectra = {"x": {(0,): [0.0, 1.0], (2,): [0.0, 1.0]}}
 
     with pytest.raises(ValueError, match="Found no parameters to optimize."):
         opt.step(fun, x, nums_frequency=None, spectra=None)


### PR DESCRIPTION
**Context:**
As discussed in #2100 , the warning that `RotosolveOptimizer` will only update arguments marked as trainable is made more visible in this PR. Additionally, a warning is raised if no trainable arguments are found.

**Description of the Change:**
Doc string improvement (enhance visibility of existing warning regarding training).
Introduce a warning for use cases in which the optimizer would not do anything.

**Benefits:**
UI improvement

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
#2100 