### PR TITLE
Use `qml.math.cast` after `qml.math.convert_like` in `qml.gradients` to copy `dtype`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -426,6 +426,10 @@
 
 <h3>Bug fixes</h3>
 
+* Fixes a bug for the TensorFlow interface where the dtype of input tensors was
+  not cast.
+  [(#2120)](https://github.com/PennyLaneAI/pennylane/pull/2120)
+
 * Fixes a bug where batch transformed QNodes would fail to apply batch transforms
   provided by the underlying device.
   [(#2111)](https://github.com/PennyLaneAI/pennylane/pull/2111)

--- a/pennylane/gradients/param_shift_hessian.py
+++ b/pennylane/gradients/param_shift_hessian.py
@@ -60,7 +60,9 @@ def generate_multishifted_tapes(tape, idx, shifts):
         shifted_tape = tape.copy(copy_operations=True)
 
         for id_, s in zip(idx, shift):
-            new_params[id_] = new_params[id_] + qml.math.cast_like(s, new_params[id_])
+            dtype = new_params[id_].dtype
+            new_params[id_] = new_params[id_] + qml.math.convert_like(s, new_params[id_])
+            new_params[id_] = qml.math.cast(new_params[id_], dtype)
 
         shifted_tape.set_parameters(new_params)
         tapes.append(shifted_tape)
@@ -171,8 +173,10 @@ def compute_hessian_tapes(tape, diff_methods, f0=None):
                 g = qml.math.zeros(out_dim)
             else:
                 res = qml.math.stack(res)
+                hess = qml.math.convert_like(hessian_coeffs[k], res)
+                hess = qml.math.cast(hess, res.dtype)
                 g = qml.math.tensordot(
-                    res, qml.math.cast_like(hessian_coeffs[k], res), [[0], [0]]
+                    res, hess, [[0], [0]]
                 )
                 if (i, j) in unshifted_coeffs:
                     g += unshifted_coeffs[(i, j)] * r0

--- a/pennylane/gradients/param_shift_hessian.py
+++ b/pennylane/gradients/param_shift_hessian.py
@@ -175,9 +175,7 @@ def compute_hessian_tapes(tape, diff_methods, f0=None):
                 res = qml.math.stack(res)
                 hess = qml.math.convert_like(hessian_coeffs[k], res)
                 hess = qml.math.cast(hess, res.dtype)
-                g = qml.math.tensordot(
-                    res, hess, [[0], [0]]
-                )
+                g = qml.math.tensordot(res, hess, [[0], [0]])
                 if (i, j) in unshifted_coeffs:
                     g += unshifted_coeffs[(i, j)] * r0
 

--- a/pennylane/gradients/param_shift_hessian.py
+++ b/pennylane/gradients/param_shift_hessian.py
@@ -60,7 +60,7 @@ def generate_multishifted_tapes(tape, idx, shifts):
         shifted_tape = tape.copy(copy_operations=True)
 
         for id_, s in zip(idx, shift):
-            new_params[id_] = new_params[id_] + qml.math.convert_like(s, new_params[id_])
+            new_params[id_] = new_params[id_] + qml.math.cast_like(s, new_params[id_])
 
         shifted_tape.set_parameters(new_params)
         tapes.append(shifted_tape)
@@ -172,7 +172,7 @@ def compute_hessian_tapes(tape, diff_methods, f0=None):
             else:
                 res = qml.math.stack(res)
                 g = qml.math.tensordot(
-                    res, qml.math.convert_like(hessian_coeffs[k], res), [[0], [0]]
+                    res, qml.math.cast_like(hessian_coeffs[k], res), [[0], [0]]
                 )
                 if (i, j) in unshifted_coeffs:
                     g += unshifted_coeffs[(i, j)] * r0

--- a/pennylane/gradients/vjp.py
+++ b/pennylane/gradients/vjp.py
@@ -45,7 +45,8 @@ def compute_vjp(dy, jac, num=None):
         num = math.shape(dy_row)[0]
 
     if not isinstance(dy_row, np.ndarray):
-        jac = math.cast_like(jac, dy_row)
+        jac = math.convert_like(jac, dy_row)
+        jac = math.cast(jac, dy_row.dtype)
 
     jac = math.reshape(jac, [num, -1])
 
@@ -54,7 +55,8 @@ def compute_vjp(dy, jac, num=None):
             # If the dy vector is zero, then the
             # corresponding element of the VJP will be zero.
             num_params = jac.shape[1]
-            return math.cast_like(np.zeros([num_params]), dy)
+            res = math.convert_like(np.zeros([num_params]), dy)
+            return math.cast(res, dy.dtype)
     except (AttributeError, TypeError):
         pass
 
@@ -169,7 +171,12 @@ def vjp(tape, dy, gradient_fn, gradient_kwargs=None):
             # If the dy vector is zero, then the
             # corresponding element of the VJP will be zero,
             # and we can avoid a quantum computation.
-            return [], lambda _, num=None: math.cast_like(np.zeros([num_params]), dy)
+
+            def func(_, num=None):
+                res = math.convert_like(np.zeros([num_params]), dy)
+                return math.cast(res, dy.dtype)
+
+            return [], func
     except (AttributeError, TypeError):
         pass
 

--- a/pennylane/gradients/vjp.py
+++ b/pennylane/gradients/vjp.py
@@ -45,7 +45,7 @@ def compute_vjp(dy, jac, num=None):
         num = math.shape(dy_row)[0]
 
     if not isinstance(dy_row, np.ndarray):
-        jac = math.convert_like(jac, dy_row)
+        jac = math.cast_like(jac, dy_row)
 
     jac = math.reshape(jac, [num, -1])
 
@@ -54,7 +54,7 @@ def compute_vjp(dy, jac, num=None):
             # If the dy vector is zero, then the
             # corresponding element of the VJP will be zero.
             num_params = jac.shape[1]
-            return math.convert_like(np.zeros([num_params]), dy)
+            return math.cast_like(np.zeros([num_params]), dy)
     except (AttributeError, TypeError):
         pass
 
@@ -169,7 +169,7 @@ def vjp(tape, dy, gradient_fn, gradient_kwargs=None):
             # If the dy vector is zero, then the
             # corresponding element of the VJP will be zero,
             # and we can avoid a quantum computation.
-            return [], lambda _, num=None: math.convert_like(np.zeros([num_params]), dy)
+            return [], lambda _, num=None: math.cast_like(np.zeros([num_params]), dy)
     except (AttributeError, TypeError):
         pass
 

--- a/pennylane/gradients/vjp.py
+++ b/pennylane/gradients/vjp.py
@@ -172,7 +172,7 @@ def vjp(tape, dy, gradient_fn, gradient_kwargs=None):
             # corresponding element of the VJP will be zero,
             # and we can avoid a quantum computation.
 
-            def func(_, num=None):
+            def func(_, num=None): # pylint: disable=unused-argument
                 res = math.convert_like(np.zeros([num_params]), dy)
                 return math.cast(res, dy.dtype)
 

--- a/pennylane/gradients/vjp.py
+++ b/pennylane/gradients/vjp.py
@@ -172,7 +172,7 @@ def vjp(tape, dy, gradient_fn, gradient_kwargs=None):
             # corresponding element of the VJP will be zero,
             # and we can avoid a quantum computation.
 
-            def func(_, num=None): # pylint: disable=unused-argument
+            def func(_, num=None):  # pylint: disable=unused-argument
                 res = math.convert_like(np.zeros([num_params]), dy)
                 return math.cast(res, dy.dtype)
 

--- a/pennylane/math/utils.py
+++ b/pennylane/math/utils.py
@@ -135,7 +135,16 @@ def cast_like(tensor1, tensor2):
     >>> cast_like(x, y)
     tensor([1., 2.])
     """
-    dtype = ar.to_numpy(tensor2).dtype.type
+    try:
+        dtype = ar.to_numpy(tensor2).dtype.type
+    except AttributeError:
+
+        interface = get_interface(tensor2)
+        if interface == "tensorflow":
+            # If the attribute error was raised than tf.function was turned on
+            # and converting to NumPy is not an option
+            dtype = tensor2.dtype
+
     return cast(tensor1, dtype)
 
 

--- a/pennylane/math/utils.py
+++ b/pennylane/math/utils.py
@@ -136,7 +136,6 @@ def cast_like(tensor1, tensor2):
     tensor([1., 2.])
     """
     dtype = ar.to_numpy(tensor2).dtype.type
-
     return cast(tensor1, dtype)
 
 

--- a/pennylane/math/utils.py
+++ b/pennylane/math/utils.py
@@ -135,15 +135,7 @@ def cast_like(tensor1, tensor2):
     >>> cast_like(x, y)
     tensor([1., 2.])
     """
-    try:
-        dtype = ar.to_numpy(tensor2).dtype.type
-    except AttributeError:
-
-        interface = get_interface(tensor2)
-        if interface == "tensorflow":
-            # If the attribute error was raised than tf.function was turned on
-            # and converting to NumPy is not an option
-            dtype = tensor2.dtype
+    dtype = ar.to_numpy(tensor2).dtype.type
 
     return cast(tensor1, dtype)
 

--- a/tests/gradients/test_vjp.py
+++ b/tests/gradients/test_vjp.py
@@ -52,6 +52,51 @@ class TestComputeVJP:
         vjp = qml.gradients.compute_vjp(dy, jac)
         assert np.all(vjp == np.zeros([3]))
 
+    @pytest.mark.parametrize("dtype1,dtype2", [("float32","float64"), ("float64","float32")])
+    def test_dtype_torch(self, dtype1, dtype2):
+        """Test that using the Torch interface the dtype of the result is
+        determined by the dtype of the dy."""
+        torch = pytest.importorskip("torch")
+
+        dtype1 = getattr(torch, dtype1)
+        dtype2 = getattr(torch, dtype2)
+
+        dy = torch.ones(4, dtype=dtype1)
+        jac = torch.ones((4,4), dtype=dtype2)
+
+        assert qml.gradients.compute_vjp(dy, jac).dtype == dtype1
+
+    @pytest.mark.parametrize("dtype1,dtype2", [("float32","float64"), ("float64","float32")])
+    def test_dtype_tf(self, dtype1, dtype2):
+        """Test that using the TensorFlow interface the dtype of the result is
+        determined by the dtype of the dy."""
+        tf = pytest.importorskip("tensorflow")
+
+        dtype1 = getattr(tf, dtype1)
+        dtype2 = getattr(tf, dtype2)
+
+        dy = tf.ones(4, dtype=dtype1)
+        jac = tf.ones((4,4), dtype=dtype2)
+
+        assert qml.gradients.compute_vjp(dy, jac).dtype == dtype1
+
+    @pytest.mark.parametrize("dtype1,dtype2", [("float32","float64"), ("float64","float32")])
+    def test_dtype_jax(self, dtype1, dtype2):
+        """Test that using the JAX interface the dtype of the result is
+        determined by the dtype of the dy."""
+        jax = pytest.importorskip("jax")
+        from jax import numpy as jnp
+        from jax.config import config
+
+        config.update("jax_enable_x64", True)
+
+        dtype1 = getattr(jax.numpy, dtype1)
+        dtype2 = getattr(jax.numpy, dtype2)
+
+        dy = jax.numpy.array([0,1], dtype=dtype1)
+        jac = jax.numpy.array([[0,1],[2,3]], dtype=dtype2)
+
+        assert qml.gradients.compute_vjp(dy, jac).dtype == dtype1
 
 class TestVJP:
     """Tests for the vjp function"""

--- a/tests/gradients/test_vjp.py
+++ b/tests/gradients/test_vjp.py
@@ -294,7 +294,7 @@ class TestVJPGradients:
         dev.C_DTYPE = vanilla_numpy.complex64
         dev.R_DTYPE = vanilla_numpy.float32
 
-        @qml.qnode(dev, interface='tf', diff_method='adjoint')
+        @qml.qnode(dev, interface="tf", diff_method="adjoint")
         def circuit(weights, features):
             for i in range(nwires):
                 qml.RX(features[i], wires=i)
@@ -304,12 +304,12 @@ class TestVJPGradients:
         vanilla_numpy.random.seed(42)
 
         ndata = 100
-        data = [vanilla_numpy.random.randn(nwires).astype('float32') for _ in range(ndata)]
-        label = [vanilla_numpy.random.choice([1, 0]).astype('int') for _ in range(ndata)]
+        data = [vanilla_numpy.random.randn(nwires).astype("float32") for _ in range(ndata)]
+        label = [vanilla_numpy.random.choice([1, 0]).astype("int") for _ in range(ndata)]
 
         loss = tf.losses.SparseCategoricalCrossentropy()
 
-        params = tf.Variable(vanilla_numpy.random.randn(nwires).astype('float32'), trainable=True)
+        params = tf.Variable(vanilla_numpy.random.randn(nwires).astype("float32"), trainable=True)
         with tf.GradientTape() as tape:
             probs = [circuit(params, d) for d in data]
             loss_value = loss(label, probs)

--- a/tests/gradients/test_vjp.py
+++ b/tests/gradients/test_vjp.py
@@ -52,7 +52,7 @@ class TestComputeVJP:
         vjp = qml.gradients.compute_vjp(dy, jac)
         assert np.all(vjp == np.zeros([3]))
 
-    @pytest.mark.parametrize("dtype1,dtype2", [("float32","float64"), ("float64","float32")])
+    @pytest.mark.parametrize("dtype1,dtype2", [("float32", "float64"), ("float64", "float32")])
     def test_dtype_torch(self, dtype1, dtype2):
         """Test that using the Torch interface the dtype of the result is
         determined by the dtype of the dy."""
@@ -62,11 +62,11 @@ class TestComputeVJP:
         dtype2 = getattr(torch, dtype2)
 
         dy = torch.ones(4, dtype=dtype1)
-        jac = torch.ones((4,4), dtype=dtype2)
+        jac = torch.ones((4, 4), dtype=dtype2)
 
         assert qml.gradients.compute_vjp(dy, jac).dtype == dtype1
 
-    @pytest.mark.parametrize("dtype1,dtype2", [("float32","float64"), ("float64","float32")])
+    @pytest.mark.parametrize("dtype1,dtype2", [("float32", "float64"), ("float64", "float32")])
     def test_dtype_tf(self, dtype1, dtype2):
         """Test that using the TensorFlow interface the dtype of the result is
         determined by the dtype of the dy."""
@@ -76,11 +76,11 @@ class TestComputeVJP:
         dtype2 = getattr(tf, dtype2)
 
         dy = tf.ones(4, dtype=dtype1)
-        jac = tf.ones((4,4), dtype=dtype2)
+        jac = tf.ones((4, 4), dtype=dtype2)
 
         assert qml.gradients.compute_vjp(dy, jac).dtype == dtype1
 
-    @pytest.mark.parametrize("dtype1,dtype2", [("float32","float64"), ("float64","float32")])
+    @pytest.mark.parametrize("dtype1,dtype2", [("float32", "float64"), ("float64", "float32")])
     def test_dtype_jax(self, dtype1, dtype2):
         """Test that using the JAX interface the dtype of the result is
         determined by the dtype of the dy."""
@@ -93,10 +93,11 @@ class TestComputeVJP:
         dtype1 = getattr(jax.numpy, dtype1)
         dtype2 = getattr(jax.numpy, dtype2)
 
-        dy = jax.numpy.array([0,1], dtype=dtype1)
-        jac = jax.numpy.array([[0,1],[2,3]], dtype=dtype2)
+        dy = jax.numpy.array([0, 1], dtype=dtype1)
+        jac = jax.numpy.array([[0, 1], [2, 3]], dtype=dtype2)
 
         assert qml.gradients.compute_vjp(dy, jac).dtype == dtype1
+
 
 class TestVJP:
     """Tests for the vjp function"""
@@ -232,6 +233,21 @@ class TestVJP:
         )
 
         assert np.allclose(res, dy @ expected, atol=tol, rtol=0)
+
+    @pytest.mark.parametrize("dtype", [np.float32, np.float64])
+    def test_dtype_matches_dy(self, dtype):
+        """Tests that the vjp function matches the dtype of dy when dy is
+        zero-like."""
+        x = np.array([0.1], dtype=np.float64)
+
+        with qml.tape.JacobianTape() as tape:
+            qml.RX(x[0], wires=0)
+            qml.expval(qml.PauliZ(0))
+
+        dy = np.zeros(3, dtype=dtype)
+        _, func = qml.gradients.vjp(tape, dy, qml.gradients.param_shift)
+
+        assert func([]).dtype == dtype
 
 
 def expected(params):


### PR DESCRIPTION
**Context:**
`qml.math.cast_like` attempts to copy the dtype of a tensor whereas `qml.math.convert_like` only uses the type of the tensors during conversion

The `qml.gradients` module uses `qml.math.convert_like`. There may, however, be cases where the dtype would need to be copied, otherwise unexpected behaviour arises.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
#2105 