### PR TITLE
Update the documentation with the latest changes in parameter differentiability

### DIFF
--- a/doc/introduction/interfaces.rst
+++ b/doc/introduction/interfaces.rst
@@ -122,8 +122,8 @@ tensor([[-0.04673668, -0.09442394, -0.14409127],
 Note that, while gradient transforms allow quantum gradient rules to be applied directly to QNodes,
 this is not a replacement --- and should not be used instead of --- standard training workflows (for example,
 ``qml.grad()`` if using Autograd, ``loss.backward()`` for PyTorch, or ``tape.gradient()`` for TensorFlow).
-This is because gradient transforms do not take into account classical processing, and only support
-gradients of quantum components.
+This is because gradient transforms do not take into account classical computation nodes, and only
+support gradients of QNodes.
 For more details on available gradient transforms, as well as learning how to define your own
 gradient transform, please see the :mod:`qml.gradients <pennylane.gradients>` documentation.
 

--- a/doc/introduction/interfaces/numpy.rst
+++ b/doc/introduction/interfaces/numpy.rst
@@ -125,21 +125,19 @@ How does PennyLane know which arguments of a quantum function to differentiate, 
 For example, you may want to pass arguments to a QNode but *not* have
 PennyLane consider them when computing gradients.
 
-All positional arguments provided to the QNode are assumed to be differentiable
-by default, but this behaviour is deprecated. In a future release, only arguments explicitly
-marked as trainable or marked using the `argnum` keyword argument will be treated as trainable. Not explicitly marking arguments currently raises a 
-deprecation warning.
-
-For now, arguments are internally turned into arrays from the PennyLane NumPy module,
-which have a special flag ``requires_grad`` specifying whether they are trainable or not:
+Regular positional arguments provided to the QNode are not assumed to be differentiable
+by default. This includes arguments in the form of built-in Python data types, and arrays from
+the original NumPy module. Thus, arguments need to be explicitly marked as trainable or selected
+using the `argnum` keyword. To mark an argument as trainable, a special flag ``requires_grad``
+has been added to arrays from PennyLane's NumPy module:
 
 >>> from pennylane import numpy as np
 >>> np.array([0.1, 0.2], requires_grad=True)
 tensor([0.1, 0.2], requires_grad=True)
 
-If you would like to provide explicit non-differentiable arguments to the
-QNode or gradient function, make sure to use a NumPy array that specifies
-``requires_grad=False``:
+When omitted, the value for this flag is ``True``, so if you would like to provide a
+non-differentiable PennyLane NumPy array to the QNode or gradient function, make sure
+to specify ``requires_grad=False``:
 
 >>> from pennylane import numpy as np
 >>> np.array([0.1, 0.2], requires_grad=False)
@@ -150,67 +148,34 @@ tensor([0.1, 0.2], requires_grad=False)
     The ``requires_grad`` argument can be passed to any NumPy function provided by PennyLane,
     including NumPy functions that create arrays like ``np.random.random``, ``np.zeros``, etc.
 
-An alternative way to avoid having positional arguments turned into differentiable PennyLane NumPy arrays is to
-use a keyword argument syntax when the QNode is evaluated or when its gradient is computed.
-
-For example, consider the following QNode that accepts one trainable argument ``weights``,
-and two non-differentiable arguments ``data`` and ``wires``:
+On the other hand, keyword arguments (whether they have a default value or not), are always
+considered non-trainable, no matter their data type or flags they may have. For example, consider
+the following QNode that accepts two arguments ``data`` and ``weights``:
 
 .. code-block:: python
 
     dev = qml.device('default.qubit', wires=5)
 
     @qml.qnode(dev)
-    def circuit(weights, data, wires):
-        qml.AmplitudeEmbedding(data, wires=wires, normalize=True)
-        qml.RX(weights[0], wires=wires[0])
-        qml.RY(weights[1], wires=wires[1])
-        qml.RZ(weights[2], wires=wires[2])
-        qml.CNOT(wires=[wires[0], wires[1]])
-        qml.CNOT(wires=[wires[0], wires[2]])
-        return qml.expval(qml.PauliZ(wires[0]))
+    def circuit(data, weights):
+        qml.AmplitudeEmbedding(data, wires=[0, 1, 2], normalize=True)
+        qml.RX(weights[0], wires=0)
+        qml.RY(weights[1], wires=1)
+        qml.RZ(weights[2], wires=2)
+        qml.CNOT(wires=[0, 1])
+        qml.CNOT(wires=[0, 2])
+        return qml.expval(qml.PauliZ(0))
 
+    rng = np.random.default_rng(seed=42)  # make the results reproducable
+    data = rng.random([2**3], requires_grad=True)
+    weights = np.array([0.1, 0.2, 0.3], requires_grad=False)
 
-For ``data``, which is a PennyLane NumPy array, we can simply specify ``requires_grad=False``:
+When we compute the derivative, arguments with ``requires_grad=False`` as well as arguments
+passed as keyword arguments are ignored by :func:`~.grad`, which in this case means no gradient
+is computed at all:
 
->>> rng = np.random.default_rng(seed=42)  # make the results reproducable
->>> data = rng.random([2**3], requires_grad=False)
-
-But ``wires`` is a list in this example, and if we turn it into a PennyLane NumPy array we would have to
-create a device that understands custom wire labels of this type.
-It is much easier to use the second option laid out above, and pass ``wires`` to the
-QNode using keyword argument syntax:
-
->>> wires = [2, 0, 1]
->>> weights = np.array([0.1, 0.2, 0.3])
->>> circuit(weights, data, wires=wires)
-tensor(-0.03404945, requires_grad=True)
-
-When we compute the derivative, arguments with ``requires_grad=False`` as well as arguments passed as
-keyword arguments are ignored by :func:`~.grad`:
-
->>> grad_fn = qml.grad(circuit)
->>> grad_fn(weights, data, wires=wires)
-array([ 3.41633993e-03,  8.23993651e-18, -6.93889390e-18])
-
-.. note::
-
-    **Keyword arguments**
-
-    The :func:`~.grad` function does not differentiate keyword arguments. A QNode may be defined
-    using arguments with default values; for example
-
-    .. code-block:: python
-
-        @qml.qnode(dev)
-        def circuit(weights, data=None):
-
-    These arguments must always be passed using ``keyword=value`` syntax:
-
-    >>> circuit(weights, data=[0.34, 0.1])
-
-    These arguments will always be treated as non-differentiable by the QNode and :func:`~.grad`
-    function.
+>>> qml.grad(circuit)(data, weights=weights)
+()
 
 Optimization
 ------------
@@ -376,8 +341,8 @@ to the ``scipy.minimize`` function:
 
 Some of the SciPy minimization methods require information about the gradient
 of the cost function via the ``jac`` keyword argument. This is easy to include; we
-can simply create a function that computes the gradient using ``qml.grad``.  Since
-``minimize`` does not use our wrapped version of numpy, we need to explicitly 
+can simply create a function that computes the gradient using ``qml.grad``. Since
+``minimize`` does not use our wrapped version of numpy, we need to explicitly
 specify which arguments are trainable via the ``argnum`` keyword.
 
 >>> minimize(cost, params, method='BFGS', jac=qml.grad(cost, argnum=0))

--- a/doc/introduction/interfaces/numpy.rst
+++ b/doc/introduction/interfaces/numpy.rst
@@ -128,7 +128,7 @@ PennyLane consider them when computing gradients.
 Regular positional arguments provided to the QNode are not assumed to be differentiable
 by default. This includes arguments in the form of built-in Python data types, and arrays from
 the original NumPy module. Thus, arguments need to be explicitly marked as trainable or selected
-using the `argnum` keyword. To mark an argument as trainable, a special flag ``requires_grad``
+using the ``argnum`` keyword. To mark an argument as trainable, a special flag ``requires_grad``
 has been added to arrays from PennyLane's NumPy module:
 
 >>> from pennylane import numpy as np
@@ -167,7 +167,7 @@ the following QNode that accepts two arguments ``data`` and ``weights``:
         return qml.expval(qml.PauliZ(0))
 
     rng = np.random.default_rng(seed=42)  # make the results reproducable
-    data = rng.random([2**3], requires_grad=True)
+    data = rng.random([2 ** 3], requires_grad=True)
     weights = np.array([0.1, 0.2, 0.3], requires_grad=False)
 
 When we compute the derivative, arguments with ``requires_grad=False`` as well as arguments

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -433,6 +433,7 @@
   it should be instantiated via PennyLane's NumPy wrapper using the `requires_grad=True`
   attribute. The previous behaviour was deprecated in version v0.19.0 of PennyLane.
   [(#2116)](https://github.com/PennyLaneAI/pennylane/pull/2116)
+  [(#2125)](https://github.com/PennyLaneAI/pennylane/pull/2125)
 
   ```python
   from pennylane import numpy as np

--- a/pennylane/_grad.py
+++ b/pennylane/_grad.py
@@ -29,9 +29,12 @@ make_vjp = unary_to_nary(_make_vjp)
 class grad:
     """Returns the gradient as a callable function of (functions of) QNodes.
 
-    Function arguments with the property ``requires_grad`` set to ``False``
-    will automatically be excluded from the gradient computation, unless
-    the ``argnum`` keyword argument is passed.
+    By default, gradients are computed for arguments which contain the property
+    ``requires_grad=True``. Alternatively, the ``argnum`` keyword argument can
+    be specified to compute gradients for function arguments without this property,
+    such as scalars, lists, tuples, dicts, or vanilla NumPy arrays. Setting
+    ``argnum`` to the index of an argument with ``requires_grad=False`` will raise
+    a ``NonDifferentiableError``.
 
     When the output gradient function is executed, both the forward pass
     *and* the backward pass will be performed in order to
@@ -145,6 +148,10 @@ def jacobian(func, argnum=None):
     Returns:
         function: the function that returns the Jacobian of the input
         function with respect to the arguments in argnum
+
+    .. note::
+        Due to a limitation in Autograd, this function can only differentiate built-in scalar
+        or NumPy array arguments.
 
     For ``argnum=None``, the trainable arguments are inferred dynamically from the arguments
     passed to the function. The returned function takes the same arguments as the original

--- a/pennylane/qnn/keras.py
+++ b/pennylane/qnn/keras.py
@@ -217,7 +217,7 @@ class KerasLayer(Layer):
         dtype = tf.float32 if tf.keras.backend.floatx() == tf.float32 else tf.float64
 
         try:
-            # TODO: remove once the beta QNode is default
+            # TODO: remove when the old QNode is removed
             if self.qnode.diff_method != "backprop" or self.qnode.diff_method_change:
                 self.qnode.to_tf(dtype=dtype)
         except AttributeError:

--- a/pennylane/qnn/torch.py
+++ b/pennylane/qnn/torch.py
@@ -217,7 +217,7 @@ class TorchLayer(Module):
         self.qnode = qnode
 
         try:
-            # TODO: remove once the beta QNode is default
+            # TODO: remove when the old QNode is removed
             self.qnode.to_torch()
         except AttributeError:
             self.qnode.interface = "torch"

--- a/pennylane/qnode.py
+++ b/pennylane/qnode.py
@@ -45,7 +45,7 @@ class QNode:
 
             * ``"autograd"``: Allows autograd to backpropagate
               through the QNode. The QNode accepts default Python types
-              (floats, ints, lists) as well as NumPy array arguments,
+              (floats, ints, lists, tuples, dicts) as well as NumPy array arguments,
               and returns NumPy arrays.
 
             * ``"torch"``: Allows PyTorch to backpropogate
@@ -60,7 +60,7 @@ class QNode:
               JAX ``DeviceArray`` objects.
 
             * ``None``: The QNode accepts default Python types
-              (floats, ints, lists) as well as NumPy array arguments,
+              (floats, ints, lists, tuples, dicts) as well as NumPy array arguments,
               and returns NumPy arrays. It does not connect to any
               machine learning library automatically for backpropagation.
 


### PR DESCRIPTION
**Context:** This PR updates various points in the documentation regarding which data types can be differentiated in autograd, and what the defaults for parameter trainability are.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
