### PR TITLE
PauliRot decomposes to single Pauli roatations and IsingZZ

### DIFF
--- a/pennylane/ops/qubit/parametric_ops.py
+++ b/pennylane/ops/qubit/parametric_ops.py
@@ -735,7 +735,16 @@ class PauliRot(Operation):
         return MultiRZ._eigvals(theta, len(pauli_word))
 
     @staticmethod
-    def conjugate_tape(wires, pauli_word):
+    def _conjugate_tape(wires, pauli_word):
+        """For a given Pauli word, return a tape that diagonalizes it
+
+        Args:
+            pauli_word (str): Pauli word we want to diagonalize
+
+        Returns:
+            qml.tape: A tape of operations U that UDU^\dagger = P, where P
+            is the Pauli word.
+        """
         with qml.tape.OperationRecorder() as tape:
             for wire, gate in zip(wires, pauli_word):
                 if gate == "X":
@@ -766,9 +775,9 @@ class PauliRot(Operation):
             if pauli_word == "Z":
                 return [qml.RZ(theta, wires=active_wires)]
         
-        conjuate_tape = PauliRot.conjugate_tape(active_wires, active_gates)
+        conjuate_tape = PauliRot._conjugate_tape(active_wires, active_gates)
         conjuate_tape_inv = conjuate_tape.copy()
-        conjuate_tape_inv.inv() # inversion in place
+        conjuate_tape_inv.inv() # inverse in place
         with qml.tape.OperationRecorder() as rec:
             rec.append(conjuate_tape)
             if len(active_wires) == 2:

--- a/pennylane/ops/qubit/parametric_ops.py
+++ b/pennylane/ops/qubit/parametric_ops.py
@@ -753,8 +753,12 @@ class PauliRot(Operation):
                     Hadamard(wires=[wire])
                 elif gate == "Y":
                     RX(np.pi / 2, wires=[wire])
-
-            MultiRZ(theta, wires=list(active_wires))
+            if len(active_wires) == 1:
+                RZ(theta, wires = active_wires[0])
+            elif len(active_wires) == 2:
+                IsingZZ(theta, wires = list(active_wires))
+            else:
+                MultiRZ(theta, wires=list(active_wires))
 
             for wire, gate in zip(active_wires, active_gates):
                 if gate == "X":

--- a/tests/ops/qubit/test_parametric_ops.py
+++ b/tests/ops/qubit/test_parametric_ops.py
@@ -1053,7 +1053,7 @@ class TestPauliRot:
 
         assert len(decomp_ops) == 1
 
-        assert decomp_ops[0].name == "MultiRZ"
+        assert decomp_ops[0].name == "RZ"
 
         assert decomp_ops[0].wires == Wires([0])
         assert decomp_ops[0].data[0] == theta

--- a/tests/ops/qubit/test_parametric_ops.py
+++ b/tests/ops/qubit/test_parametric_ops.py
@@ -1088,7 +1088,7 @@ class TestPauliRot:
 
         assert len(decomp_ops) == 1
 
-        assert decomp_ops[0].name == "MultiRZ"
+        assert decomp_ops[0].name == "IsingZZ"
 
         assert decomp_ops[0].wires == Wires([0, 1])
         assert decomp_ops[0].data[0] == theta
@@ -1110,7 +1110,7 @@ class TestPauliRot:
         assert decomp_ops[1].wires == Wires([1])
         assert decomp_ops[1].data[0] == np.pi / 2
 
-        assert decomp_ops[2].name == "MultiRZ"
+        assert decomp_ops[2].name == "IsingZZ"
         assert decomp_ops[2].wires == Wires([0, 1])
         assert decomp_ops[2].data[0] == theta
 

--- a/tests/transforms/test_draw.py
+++ b/tests/transforms/test_draw.py
@@ -586,8 +586,8 @@ class TestOpsIntegration:
 
         res = qml.draw(circuit, expansion_strategy="device")(0.5)
         expected = [
-            " 0: ──H────────RZ(0.5)──H──H──╭RZ(0.25)──H──H────────RZ(0.5)──H──H──╭RZ(0.25)──H──┤ Probs \n",
-            " 1: ──RZ(0.5)──H──────────────╰RZ(0.25)──H──RZ(0.5)──H──────────────╰RZ(0.25)──H──┤       \n",
+            " 0: ──RX(0.5)──H──╭IsingZZ(0.25)──H──RX(0.5)──H──╭IsingZZ(0.25)──H──┤ Probs \n"
+            " 1: ──RZ(0.5)──H──╰IsingZZ(0.25)──H──RZ(0.5)──H──╰IsingZZ(0.25)──H──┤       \n"
         ]
 
         assert res == "".join(expected)


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      test directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `doc/releases/changelog-dev.md` file, summarizing the
      change, and including a link back to the PR.

- [ ] The PennyLane source code conforms to
      [PEP8 standards](https://www.python.org/dev/peps/pep-0008/).
      We check all of our code against [Pylint](https://www.pylint.org/).
      To lint modified files, simply `pip install pylint`, and then
      run `pylint pennylane/path/to/file.py`.

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:** In the current implementation, `PauliRot` always decomposes into `MultiRZ` with additional conjugate operations to diagonalize it. Thus even when the given Pauli word is single X or Y, it returns length 3 decompositions instead of single `RX` or `RY`. In addition, as `RZ`, `IsingZZ` must be faster than `MultiRZ` in most of the plugins, it is also more reasonable to use them when the number of wires is 1 or 2.

**Description of the Change:** `decomposition` method of `PauliRot` is specialized when the number of wires is 1 or 2.

**Benefits:** As the current QAOA template returns approximate Hamiltonian evolution, which uses the `PauliRot` gate, I expect that it becomes also faster.

**Possible Drawbacks:** Maybe slightly slower `decomposition` method.

**Related GitHub Issues:**
