### PR TITLE
Add useful error message on empty batch transform

### DIFF
--- a/pennylane/templates/embeddings/basis.py
+++ b/pennylane/templates/embeddings/basis.py
@@ -33,7 +33,7 @@ class BasisEmbedding(Operation):
         gradients with respect to the argument cannot be computed by PennyLane.
 
     Args:
-        features (tensor-like): binary input of shape ``(n, )``
+        features (tensor_like): binary input of shape ``(n, )``
         wires (Iterable): wires that the template acts on
 
     Example:

--- a/pennylane/templates/state_preparations/basis.py
+++ b/pennylane/templates/state_preparations/basis.py
@@ -43,7 +43,7 @@ class BasisStatePreparation(Operation):
         print(circuit(basis_state)) # [ 1. -1. -1.  1.]
 
     Args:
-        basis_state (array): Input array of shape ``(n,)``, where n is the number of wires
+        basis_state (tensor_like): Input of shape ``(n,)``, where n is the number of wires
             the state preparation acts on.
         wires (Iterable): wires that the template acts on
     """

--- a/pennylane/transforms/batch_params.py
+++ b/pennylane/transforms/batch_params.py
@@ -110,6 +110,11 @@ def batch_params(tape, all_operations=False):
     -0.30262974103192636
     """
     params = tape.get_parameters(trainable_only=not all_operations)
+    if not params:
+        raise ValueError(
+            "There are no operations to transform. Either add trainable parameters, "
+            "or specify `all_operations=True`."
+        )
     output_tapes = []
 
     try:


### PR DESCRIPTION
**Context:** When a batch transform collects an empty `params` list, it currently
raises an IndexError. For example with:

```py
@qml.batch_params
@qml.qnode(qml.device("default.qubit", wires=1))
def circuit(x):
    qml.RY(x, wires=0)
    return qml.expval(qml.PauliZ(0))

x = np.linspace(0.2, 0.6, 3)
circuit(x)
```

**Description of the Change:**

This fix adds a check to raise a useful error message in cases were there are no trainable parameters and `all_operations` was not set to True.

Also fixes some template argument types in docstrings.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
