### PR TITLE
Dont convert variables to numpy if on interface-specific device

### DIFF
--- a/pennylane/interfaces/batch/__init__.py
+++ b/pennylane/interfaces/batch/__init__.py
@@ -325,6 +325,11 @@ def execute(
         expand_fn = lambda tape: device.expand_fn(tape, max_expansion=max_expansion)
 
     if gradient_fn is None:
+        # don't unwrap if it's an interface device
+        if "passthru_interface" in device.capabilities():
+            return batch_fn(
+                cache_execute(batch_execute, cache, return_tuple=False, expand_fn=expand_fn)(tapes)
+            )
         with qml.tape.Unwrap(*tapes):
             res = cache_execute(batch_execute, cache, return_tuple=False, expand_fn=expand_fn)(
                 tapes

--- a/tests/interfaces/test_batch_jax.py
+++ b/tests/interfaces/test_batch_jax.py
@@ -834,3 +834,19 @@ class TestVectorValued:
 
         with pytest.raises(InterfaceUnsupportedError):
             jax.jacobian(cost)(params, cache=None)
+
+
+def test_diff_method_None_jit():
+    """Test that jitted execution works when `gradient_fn=None`."""
+
+    dev = qml.device("default.qubit.jax", wires=1, shots=10)
+
+    @jax.jit
+    def wrapper(x):
+        with qml.tape.QuantumTape() as tape:
+            qml.RX(x, wires=0)
+            qml.expval(qml.PauliZ(0))
+
+        return qml.execute([tape], dev, gradient_fn=None)
+
+    assert jnp.allclose(wrapper(jnp.array(0.0))[0], 1.0)

--- a/tests/interfaces/test_batch_jax_qnode.py
+++ b/tests/interfaces/test_batch_jax_qnode.py
@@ -366,6 +366,18 @@ class TestShotsIntegration:
     """Test that the QNode correctly changes shot value, and
     remains differentiable."""
 
+    def test_diff_method_None(self, interface):
+        """Test jax device works with diff_method=None."""
+        dev = qml.device("default.qubit.jax", wires=1, shots=10)
+
+        @jax.jit
+        @qml.qnode(dev, diff_method=None, interface=interface)
+        def circuit(x):
+            qml.RX(x, wires=0)
+            return qml.expval(qml.PauliZ(0))
+
+        assert jnp.allclose(circuit(jnp.array(0.0)), 1)
+
     def test_changing_shots(self, interface, mocker, tol):
         """Test that changing shots works on execution"""
         dev = qml.device("default.qubit", wires=2, shots=None)


### PR DESCRIPTION
Same https://github.com/PennyLaneAI/pennylane/pull/2136/, just targetting `master`.