### PR TITLE
Add warnings for the gradient transforms when there are no trainable parameters

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -494,6 +494,7 @@
   [(#2125)](https://github.com/PennyLaneAI/pennylane/pull/2125)
   [(#2139)](https://github.com/PennyLaneAI/pennylane/pull/2139)
   [(#2148)](https://github.com/PennyLaneAI/pennylane/pull/2148)
+  [(#2156)](https://github.com/PennyLaneAI/pennylane/pull/2156)
 
   ```python
   from pennylane import numpy as np

--- a/pennylane/gradients/gradient_transform.py
+++ b/pennylane/gradients/gradient_transform.py
@@ -123,7 +123,7 @@ class gradient_transform(qml.batch_transform):
                 warnings.warn(
                     "Attempted to compute the gradient of a QNode with no trainable parameters. "
                     "If this is unintended, please add trainable parameters in accordance with "
-                    "your autodiff framework."
+                    "the chosen auto differentiation framework."
                 )
                 return ()
 

--- a/pennylane/gradients/gradient_transform.py
+++ b/pennylane/gradients/gradient_transform.py
@@ -14,6 +14,8 @@
 """This module contains utilities for defining custom gradient transforms,
 including a decorator for specifying gradient expansions."""
 # pylint: disable=too-few-public-methods
+import warnings
+
 import pennylane as qml
 from pennylane.transforms.tape_expand import expand_invalid_trainable
 
@@ -117,6 +119,14 @@ class gradient_transform(qml.batch_transform):
         cjac_fn = qml.transforms.classical_jacobian(qnode, expand_fn=expand_invalid_trainable)
 
         def jacobian_wrapper(*args, **kwargs):
+            if not qml.math.get_trainable_indices(args):
+                warnings.warn(
+                    "Attempted to compute the gradient of a QNode with no trainable parameters. "
+                    "If this is unintended, please add trainable parameters in accordance with "
+                    "your autodiff framework."
+                )
+                return ()
+
             qjac = _wrapper(*args, **kwargs)
 
             if any(m.return_type is qml.operation.Probability for m in qnode.qtape.measurements):

--- a/pennylane/gradients/hessian_transform.py
+++ b/pennylane/gradients/hessian_transform.py
@@ -118,7 +118,7 @@ class hessian_transform(qml.batch_transform):
                 warnings.warn(
                     "Attempted to compute the hessian of a QNode with no trainable parameters. "
                     "If this is unintended, please add trainable parameters in accordance with "
-                    "your autodiff framework."
+                    "the chosen auto differentiation framework."
                 )
                 return ()
 

--- a/pennylane/gradients/hessian_transform.py
+++ b/pennylane/gradients/hessian_transform.py
@@ -13,8 +13,9 @@
 # limitations under the License.
 """This module contains utilities for defining custom Hessian transforms,
 including a decorator for specifying Hessian expansions."""
-import pennylane as qml
+import warnings
 
+import pennylane as qml
 from pennylane.transforms.tape_expand import expand_invalid_trainable
 
 
@@ -113,6 +114,14 @@ class hessian_transform(qml.batch_transform):
         cjac_fn = qml.transforms.classical_jacobian(qnode, expand_fn=self.expand_fn)
 
         def hessian_wrapper(*args, **kwargs):
+            if not qml.math.get_trainable_indices(args):
+                warnings.warn(
+                    "Attempted to compute the hessian of a QNode with no trainable parameters. "
+                    "If this is unintended, please add trainable parameters in accordance with "
+                    "your autodiff framework."
+                )
+                return ()
+
             qhess = _wrapper(*args, **kwargs)
 
             if any(m.return_type is qml.operation.Probability for m in qnode.qtape.measurements):

--- a/pennylane/gradients/param_shift_hessian.py
+++ b/pennylane/gradients/param_shift_hessian.py
@@ -305,8 +305,8 @@ def param_shift_hessian(tape, f0=None):
     if not tape.trainable_params:
         warnings.warn(
             "Attempted to compute the hessian of a tape with no trainable parameters. "
-            "If this is unintended, please mark trainable parameters in accordance with your "
-            "autodiff framework, or via the 'tape.trainable_params' property."
+            "If this is unintended, please mark trainable parameters in accordance with the "
+            "chosen auto differentiation framework, or via the 'tape.trainable_params' property."
         )
         return [], lambda _: ()
 

--- a/pennylane/gradients/param_shift_hessian.py
+++ b/pennylane/gradients/param_shift_hessian.py
@@ -15,6 +15,7 @@
 This module contains functions for computing the parameter-shift hessian
 of a qubit-based quantum tape.
 """
+import warnings
 import numpy as np
 
 import pennylane as qml
@@ -302,7 +303,12 @@ def param_shift_hessian(tape, f0=None):
         )
 
     if not tape.trainable_params:
-        return [], lambda _: []
+        warnings.warn(
+            "Attempted to compute the hessian of a tape with no trainable parameters. "
+            "If this is unintended, please mark trainable parameters in accordance with your "
+            "autodiff framework, or via the 'tape.trainable_params' property."
+        )
+        return [], lambda _: ()
 
     # The parameter-shift Hessian implementation currently only supports
     # the two-term parameter-shift rule. Raise an error for unsupported operations.

--- a/pennylane/gradients/parameter_shift.py
+++ b/pennylane/gradients/parameter_shift.py
@@ -549,8 +549,9 @@ def param_shift(
     if argnum is None and not tape.trainable_params:
         warnings.warn(
             "Attempted to compute the gradient of a tape with no trainable parameters. "
-            "If this is unintended, please mark trainable parameters in accordance with your "
-            "autodiff framework, or via the 'tape.trainable_params' property."
+            "If this is unintended, please mark trainable parameters in accordance with the "
+            "chosen auto differentiation framework, or via the 'tape.trainable_params' property."
+
         )
         return gradient_tapes, lambda _: np.zeros([tape.output_dim, len(tape.trainable_params)])
 

--- a/pennylane/gradients/parameter_shift.py
+++ b/pennylane/gradients/parameter_shift.py
@@ -551,7 +551,6 @@ def param_shift(
             "Attempted to compute the gradient of a tape with no trainable parameters. "
             "If this is unintended, please mark trainable parameters in accordance with the "
             "chosen auto differentiation framework, or via the 'tape.trainable_params' property."
-
         )
         return gradient_tapes, lambda _: np.zeros([tape.output_dim, len(tape.trainable_params)])
 

--- a/pennylane/gradients/parameter_shift.py
+++ b/pennylane/gradients/parameter_shift.py
@@ -16,6 +16,7 @@ This module contains functions for computing the parameter-shift gradient
 of a qubit-based quantum tape.
 """
 # pylint: disable=protected-access,too-many-arguments,too-many-statements
+import warnings
 import numpy as np
 
 import pennylane as qml
@@ -546,6 +547,11 @@ def param_shift(
     gradient_tapes = []
 
     if argnum is None and not tape.trainable_params:
+        warnings.warn(
+            "Attempted to compute the gradient of a tape with no trainable parameters. "
+            "If this is unintended, please mark trainable parameters in accordance with your "
+            "autodiff framework, or via the 'tape.trainable_params' property."
+        )
         return gradient_tapes, lambda _: np.zeros([tape.output_dim, len(tape.trainable_params)])
 
     # TODO: replace the JacobianTape._grad_method_validation

--- a/pennylane/gradients/parameter_shift_cv.py
+++ b/pennylane/gradients/parameter_shift_cv.py
@@ -646,6 +646,14 @@ def param_shift_cv(
     shapes = []
     fns = []
 
+    if argnum is None and not tape.trainable_params:
+        warnings.warn(
+            "Attempted to compute the gradient of a tape with no trainable parameters. "
+            "If this is unintended, please mark trainable parameters in accordance with your "
+            "autodiff framework, or via the 'tape.trainable_params' property."
+        )
+        return gradient_tapes, lambda _: np.zeros([tape.output_dim, len(tape.trainable_params)])
+
     def _update(data):
         """Utility function to update the list of gradient tapes,
         the corresponding number of gradient tapes, and the processing functions"""
@@ -657,8 +665,7 @@ def param_shift_cv(
     # functionality before deprecation.
     diff_methods = tape._grad_method_validation("analytic" if fallback_fn is None else "best")
     all_params_grad_method_zero = all(g == "0" for g in diff_methods)
-
-    if not tape.trainable_params or all_params_grad_method_zero:
+    if all_params_grad_method_zero:
         return gradient_tapes, lambda _: np.zeros([tape.output_dim, len(tape.trainable_params)])
 
     # TODO: replace the JacobianTape._choose_params_with_methods

--- a/pennylane/gradients/parameter_shift_cv.py
+++ b/pennylane/gradients/parameter_shift_cv.py
@@ -649,8 +649,9 @@ def param_shift_cv(
     if argnum is None and not tape.trainable_params:
         warnings.warn(
             "Attempted to compute the gradient of a tape with no trainable parameters. "
-            "If this is unintended, please mark trainable parameters in accordance with your "
-            "autodiff framework, or via the 'tape.trainable_params' property."
+            "If this is unintended, please mark trainable parameters in accordance with the "
+            "chosen auto differentiation framework, or via the 'tape.trainable_params' property."
+
         )
         return gradient_tapes, lambda _: np.zeros([tape.output_dim, len(tape.trainable_params)])
 

--- a/pennylane/gradients/parameter_shift_cv.py
+++ b/pennylane/gradients/parameter_shift_cv.py
@@ -651,7 +651,6 @@ def param_shift_cv(
             "Attempted to compute the gradient of a tape with no trainable parameters. "
             "If this is unintended, please mark trainable parameters in accordance with the "
             "chosen auto differentiation framework, or via the 'tape.trainable_params' property."
-
         )
         return gradient_tapes, lambda _: np.zeros([tape.output_dim, len(tape.trainable_params)])
 

--- a/pennylane/transforms/metric_tensor.py
+++ b/pennylane/transforms/metric_tensor.py
@@ -247,8 +247,9 @@ def metric_tensor(tape, approx=None, allow_nonunitary=True, aux_wire=None, devic
     if not tape.trainable_params:
         warnings.warn(
             "Attempted to compute the metric tensor of a tape with no trainable parameters. "
-            "If this is unintended, please mark trainable parameters in accordance with your "
-            "autodiff framework, or via the 'tape.trainable_params' property."
+            "If this is unintended, please mark trainable parameters in accordance with the "
+            "chosen auto differentiation framework, or via the 'tape.trainable_params' property."
+
         )
         return [], lambda _: ()
 
@@ -334,8 +335,9 @@ def qnode_execution_wrapper(self, qnode, targs, tkwargs):
         if not qml.math.get_trainable_indices(args):
             warnings.warn(
                 "Attempted to compute the metric tensor of a QNode with no trainable parameters. "
-                "If this is unintended, please add trainable parameters in accordance with your "
-                "autodiff framework."
+                "If this is unintended, please add trainable parameters in accordance with the "
+                "chosen auto differentiation framework."
+
             )
             return ()
 

--- a/pennylane/transforms/metric_tensor.py
+++ b/pennylane/transforms/metric_tensor.py
@@ -248,9 +248,9 @@ def metric_tensor(tape, approx=None, allow_nonunitary=True, aux_wire=None, devic
         warnings.warn(
             "Attempted to compute the metric tensor of a tape with no trainable parameters. "
             "If this is unintended, please mark trainable parameters in accordance with your "
-            "autodiff framework, or via the tape's 'trainable_params' property."
+            "autodiff framework, or via the 'tape.trainable_params' property."
         )
-        return [], None
+        return [], lambda _: ()
 
     # pylint: disable=too-many-arguments
     if approx in {"diag", "block-diag"}:

--- a/pennylane/transforms/metric_tensor.py
+++ b/pennylane/transforms/metric_tensor.py
@@ -247,8 +247,8 @@ def metric_tensor(tape, approx=None, allow_nonunitary=True, aux_wire=None, devic
     if not tape.trainable_params:
         warnings.warn(
             "Attempted to compute the metric tensor of a tape with no trainable parameters. "
-            "If this is unintended, please mark trainable parameters via the 'requires_grad' "
-            "attribute or 'trainable_params' property."
+            "If this is unintended, please mark trainable parameters in accordance with your "
+            "autodiff framework, or via the tape's 'trainable_params' property."
         )
         return [], None
 
@@ -334,8 +334,8 @@ def qnode_execution_wrapper(self, qnode, targs, tkwargs):
         if not qml.math.get_trainable_indices(args):
             warnings.warn(
                 "Attempted to compute the metric tensor of a QNode with no trainable parameters. "
-                "If this is unintended, please add trainable parameters via the 'requires_grad' "
-                "attribute."
+                "If this is unintended, please add trainable parameters in accordance with your "
+                "autodiff framework."
             )
             return ()
 

--- a/pennylane/transforms/metric_tensor.py
+++ b/pennylane/transforms/metric_tensor.py
@@ -244,6 +244,14 @@ def metric_tensor(tape, approx=None, allow_nonunitary=True, aux_wire=None, devic
         This means that in total only the tapes for the first terms of the off block-diagonal
         are required in addition to the circuits for the block diagonal.
     """
+    if not tape.trainable_params:
+        warnings.warn(
+            "Attempted to compute the metric tensor of a tape with no trainable parameters. "
+            "If this is unintended, please mark trainable parameters via the 'requires_grad' "
+            "attribute or 'trainable_params' property."
+        )
+        return [], None
+
     # pylint: disable=too-many-arguments
     if approx in {"diag", "block-diag"}:
         # Only require covariance matrix based transform
@@ -323,6 +331,14 @@ def qnode_execution_wrapper(self, qnode, targs, tkwargs):
     cjac_fn = qml.transforms.classical_jacobian(qnode, expand_fn=_expand_fn)
 
     def wrapper(*args, **kwargs):
+        if not qml.math.get_trainable_indices(args):
+            warnings.warn(
+                "Attempted to compute the metric tensor of a QNode with no trainable parameters. "
+                "If this is unintended, please add trainable parameters via the 'requires_grad' "
+                "attribute."
+            )
+            return ()
+
         try:
             mt = mt_fn(*args, **kwargs)
         except qml.wires.WireError as e:

--- a/pennylane/transforms/metric_tensor.py
+++ b/pennylane/transforms/metric_tensor.py
@@ -249,7 +249,6 @@ def metric_tensor(tape, approx=None, allow_nonunitary=True, aux_wire=None, devic
             "Attempted to compute the metric tensor of a tape with no trainable parameters. "
             "If this is unintended, please mark trainable parameters in accordance with the "
             "chosen auto differentiation framework, or via the 'tape.trainable_params' property."
-
         )
         return [], lambda _: ()
 
@@ -337,7 +336,6 @@ def qnode_execution_wrapper(self, qnode, targs, tkwargs):
                 "Attempted to compute the metric tensor of a QNode with no trainable parameters. "
                 "If this is unintended, please add trainable parameters in accordance with the "
                 "chosen auto differentiation framework."
-
             )
             return ()
 

--- a/tests/gradients/test_finite_difference.py
+++ b/tests/gradients/test_finite_difference.py
@@ -180,26 +180,45 @@ class TestFiniteDiff:
         # only called for parameter 0
         assert spy.call_args[0][0:2] == (tape, 0)
 
-    def test_no_trainable_parameters(self, mocker):
-        """Test that if the tape has no trainable parameters, no
-        subroutines are called and the returned Jacobian is empty"""
-        spy = mocker.spy(qml.gradients.finite_difference, "generate_shifted_tapes")
-
-        with qml.tape.JacobianTape() as tape:
-            qml.RX(0.543, wires=[0])
-            qml.RY(-0.654, wires=[1])
-            qml.expval(qml.PauliZ(0))
-
+    @pytest.mark.parametrize("interface", ["autograd", "jax", "torch", "tf"])
+    def test_no_trainable_params_qnode(self, interface):
+        """Test that the correct ouput and warning is generated in the absence of any trainable
+        parameters"""
         dev = qml.device("default.qubit", wires=2)
-        tape.trainable_params = {}
 
-        tapes, fn = finite_diff(tape)
-        res = fn(dev.batch_execute(tapes))
+        @qml.qnode(dev, interface=interface)
+        def circuit(weights):
+            qml.RX(weights[0], wires=0)
+            qml.RY(weights[1], wires=0)
+            return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
+
+        weights = [0.1, 0.2]
+        with pytest.warns(UserWarning, match="gradient of a QNode with no trainable parameters"):
+            res = qml.gradients.finite_diff(circuit)(weights)
+
+        assert res == ()
+
+    def test_no_trainable_params_tape(self):
+        """Test that the correct ouput and warning is generated in the absence of any trainable
+        parameters"""
+        dev = qml.device("default.qubit", wires=2)
+
+        weights = [0.1, 0.2]
+        with qml.tape.QuantumTape() as tape:
+            qml.RX(weights[0], wires=0)
+            qml.RY(weights[1], wires=0)
+            qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
+
+        # TODO: remove once #2155 is resolved
+        tape.trainable_params = []
+
+        with pytest.warns(UserWarning, match="gradient of a tape with no trainable parameters"):
+            g_tapes, post_processing = qml.gradients.finite_diff(tape)
+        res = post_processing(qml.execute(g_tapes, dev, None))
+
+        assert g_tapes == []
         assert res.size == 0
         assert np.all(res == np.array([[]]))
-
-        spy.assert_not_called()
-        assert len(tapes) == 0
 
     def test_y0(self, mocker):
         """Test that if first order finite differences is used, then

--- a/tests/gradients/test_finite_difference.py
+++ b/tests/gradients/test_finite_difference.py
@@ -180,10 +180,12 @@ class TestFiniteDiff:
         # only called for parameter 0
         assert spy.call_args[0][0:2] == (tape, 0)
 
-    @pytest.mark.parametrize("interface", ["autograd", "jax", "torch", "tf"])
+    @pytest.mark.parametrize("interface", ["autograd", "jax", "torch", "tensorflow"])
     def test_no_trainable_params_qnode(self, interface):
         """Test that the correct ouput and warning is generated in the absence of any trainable
         parameters"""
+        if interface != "autograd":
+            pytest.importorskip(interface)
         dev = qml.device("default.qubit", wires=2)
 
         @qml.qnode(dev, interface=interface)

--- a/tests/gradients/test_gradient_transform.py
+++ b/tests/gradients/test_gradient_transform.py
@@ -395,15 +395,15 @@ class TestGradientTransformIntegration:
         """Raise an exception if shots is used within the QNode"""
         dev = qml.device("default.qubit", wires=1, shots=1000)
 
-        @qml.qnode(dev)
         def circuit(x, shots):
             qml.RX(x, wires=0)
             return qml.expval(qml.PauliZ(0))
 
-        with pytest.raises(
-            ValueError, match="'shots' argument name is reserved for overriding the number of shots"
-        ):
-            qml.gradients.param_shift(circuit)(0.2, shots=100)
+        with pytest.warns(UserWarning, match="Detected 'shots' as an argument to the given"):
+            qnode = qml.QNode(circuit, dev)
+
+        with pytest.raises(ValueError, match="Detected 'shots' as an argument of the quantum"):
+            qml.gradients.param_shift(qnode)(0.2, shots=100)
 
 
 class TestInterfaceIntegration:

--- a/tests/gradients/test_param_shift_hessian.py
+++ b/tests/gradients/test_param_shift_hessian.py
@@ -536,7 +536,8 @@ class TestParameterShiftHessian:
             h_tapes, post_processing = qml.gradients.param_shift_hessian(tape)
         res = post_processing(qml.execute(h_tapes, dev, None))
 
-        assert h_tapes == [] and res == ()
+        assert h_tapes == []
+        assert res == ()
 
     def test_f0_argument(self):
         """Test that we can provide the results of a QNode to save on quantum invocations"""

--- a/tests/gradients/test_param_shift_hessian.py
+++ b/tests/gradients/test_param_shift_hessian.py
@@ -501,25 +501,42 @@ class TestParameterShiftHessian:
 
         qml.gradients.param_shift_hessian(circuit)(x, y, z)
 
-    def test_no_trainable_parameters(self):
-        """Test that the correct ouput is generated in the absence of any trainable parameters"""
-
+    def test_no_trainable_params_qnode(self):
+        """Test that the correct ouput and warning is generated in the absence of any trainable
+        parameters"""
         dev = qml.device("default.qubit", wires=2)
 
-        @qml.qnode(dev, diff_method="parameter-shift", max_diff=2)
-        def circuit(x):
-            qml.RX(x[0], wires=0)
-            qml.RY(x[1], wires=0)
-            qml.CRZ(x[2], wires=[0, 1])
-            return qml.probs(wires=1)
+        @qml.qnode(dev)
+        def circuit(weights):
+            qml.RX(weights[0], wires=0)
+            qml.RY(weights[1], wires=0)
+            return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
-        x = np.array([0.1, 0.2, 0.3], requires_grad=False)
+        weights = [0.1, 0.2]
+        with pytest.warns(UserWarning, match="hessian of a QNode with no trainable parameters"):
+            res = qml.gradients.param_shift_hessian(circuit)(weights)
 
-        with pytest.warns(UserWarning, match="Attempted to differentiate a function with no"):
-            expected = qml.jacobian(qml.jacobian(circuit))(x)
-            hessian = qml.gradients.param_shift_hessian(circuit)(x)
+        assert res == ()
 
-        assert np.allclose(expected, hessian)
+    def test_no_trainable_params_tape(self):
+        """Test that the correct ouput and warning is generated in the absence of any trainable
+        parameters"""
+        dev = qml.device("default.qubit", wires=2)
+
+        weights = [0.1, 0.2]
+        with qml.tape.QuantumTape() as tape:
+            qml.RX(weights[0], wires=0)
+            qml.RY(weights[1], wires=0)
+            qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
+
+        # TODO: remove once #2155 is resolved
+        tape.trainable_params = []
+
+        with pytest.warns(UserWarning, match="hessian of a tape with no trainable parameters"):
+            h_tapes, post_processing = qml.gradients.param_shift_hessian(tape)
+        res = post_processing(qml.execute(h_tapes, dev, None))
+
+        assert h_tapes == [] and res == ()
 
     def test_f0_argument(self):
         """Test that we can provide the results of a QNode to save on quantum invocations"""

--- a/tests/gradients/test_param_shift_hessian.py
+++ b/tests/gradients/test_param_shift_hessian.py
@@ -501,12 +501,13 @@ class TestParameterShiftHessian:
 
         qml.gradients.param_shift_hessian(circuit)(x, y, z)
 
-    def test_no_trainable_params_qnode(self):
+    @pytest.mark.parametrize("interface", ["autograd", "jax", "torch", "tf"])
+    def test_no_trainable_params_qnode(self, interface):
         """Test that the correct ouput and warning is generated in the absence of any trainable
         parameters"""
         dev = qml.device("default.qubit", wires=2)
 
-        @qml.qnode(dev)
+        @qml.qnode(dev, interface=interface)
         def circuit(weights):
             qml.RX(weights[0], wires=0)
             qml.RY(weights[1], wires=0)

--- a/tests/gradients/test_param_shift_hessian.py
+++ b/tests/gradients/test_param_shift_hessian.py
@@ -501,10 +501,12 @@ class TestParameterShiftHessian:
 
         qml.gradients.param_shift_hessian(circuit)(x, y, z)
 
-    @pytest.mark.parametrize("interface", ["autograd", "jax", "torch", "tf"])
+    @pytest.mark.parametrize("interface", ["autograd", "jax", "torch", "tensorflow"])
     def test_no_trainable_params_qnode(self, interface):
         """Test that the correct ouput and warning is generated in the absence of any trainable
         parameters"""
+        if interface != "autograd":
+            pytest.importorskip(interface)
         dev = qml.device("default.qubit", wires=2)
 
         @qml.qnode(dev, interface=interface)

--- a/tests/gradients/test_parameter_shift.py
+++ b/tests/gradients/test_parameter_shift.py
@@ -233,7 +233,9 @@ class TestParamShift:
             g_tapes, post_processing = qml.gradients.param_shift(tape)
         res = post_processing(qml.execute(g_tapes, dev, None))
 
-        assert g_tapes == [] and res.size == 0 and np.all(res == np.array([[]]))
+        assert g_tapes == []
+        assert res.size == 0
+        assert np.all(res == np.array([[]]))
 
     def test_y0(self, mocker):
         """Test that if the gradient recipe has a zero-shift component, then

--- a/tests/gradients/test_parameter_shift.py
+++ b/tests/gradients/test_parameter_shift.py
@@ -197,10 +197,12 @@ class TestParamShift:
         # only called for parameter 0
         assert spy.call_args[0][0:2] == (tape, [0])
 
-    @pytest.mark.parametrize("interface", ["autograd", "jax", "torch", "tf"])
+    @pytest.mark.parametrize("interface", ["autograd", "jax", "torch", "tensorflow"])
     def test_no_trainable_params_qnode(self, interface):
         """Test that the correct ouput and warning is generated in the absence of any trainable
         parameters"""
+        if interface != "autograd":
+            pytest.importorskip(interface)
         dev = qml.device("default.qubit", wires=2)
 
         @qml.qnode(dev, interface=interface)

--- a/tests/gradients/test_parameter_shift.py
+++ b/tests/gradients/test_parameter_shift.py
@@ -197,12 +197,13 @@ class TestParamShift:
         # only called for parameter 0
         assert spy.call_args[0][0:2] == (tape, [0])
 
-    def test_no_trainable_params_qnode(self):
+    @pytest.mark.parametrize("interface", ["autograd", "jax", "torch", "tf"])
+    def test_no_trainable_params_qnode(self, interface):
         """Test that the correct ouput and warning is generated in the absence of any trainable
         parameters"""
         dev = qml.device("default.qubit", wires=2)
 
-        @qml.qnode(dev)
+        @qml.qnode(dev, interface=interface)
         def circuit(weights):
             qml.RX(weights[0], wires=0)
             qml.RY(weights[1], wires=0)

--- a/tests/gradients/test_parameter_shift.py
+++ b/tests/gradients/test_parameter_shift.py
@@ -151,7 +151,8 @@ class TestParamShift:
         with qml.tape.JacobianTape() as tape:
             qml.expval(qml.PauliZ(0))
 
-        tapes, _ = qml.gradients.param_shift(tape)
+        with pytest.warns(UserWarning, match="gradient of a tape with no trainable parameters"):
+            tapes, _ = qml.gradients.param_shift(tape)
         assert not tapes
 
     def test_all_parameters_independent(self):
@@ -196,23 +197,42 @@ class TestParamShift:
         # only called for parameter 0
         assert spy.call_args[0][0:2] == (tape, [0])
 
-    def test_no_trainable_parameters(self):
-        """Test that if the tape has no trainable parameters, no
-        subroutines are called and the returned Jacobian is empty"""
-        with qml.tape.JacobianTape() as tape:
-            qml.RX(0.543, wires=[0])
-            qml.RY(-0.654, wires=[1])
-            qml.expval(qml.PauliZ(0))
-
+    def test_no_trainable_params_qnode(self):
+        """Test that the correct ouput and warning is generated in the absence of any trainable
+        parameters"""
         dev = qml.device("default.qubit", wires=2)
-        tape.trainable_params = {}
 
-        tapes, fn = qml.gradients.param_shift(tape)
-        assert len(tapes) == 0
+        @qml.qnode(dev)
+        def circuit(weights):
+            qml.RX(weights[0], wires=0)
+            qml.RY(weights[1], wires=0)
+            return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
-        res = fn(dev.batch_execute(tapes))
-        assert res.size == 0
-        assert np.all(res == np.array([[]]))
+        weights = [0.1, 0.2]
+        with pytest.warns(UserWarning, match="gradient of a QNode with no trainable parameters"):
+            res = qml.gradients.param_shift(circuit)(weights)
+
+        assert res == ()
+
+    def test_no_trainable_params_tape(self):
+        """Test that the correct ouput and warning is generated in the absence of any trainable
+        parameters"""
+        dev = qml.device("default.qubit", wires=2)
+
+        weights = [0.1, 0.2]
+        with qml.tape.QuantumTape() as tape:
+            qml.RX(weights[0], wires=0)
+            qml.RY(weights[1], wires=0)
+            qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
+
+        # TODO: remove once #2155 is resolved
+        tape.trainable_params = []
+
+        with pytest.warns(UserWarning, match="gradient of a tape with no trainable parameters"):
+            g_tapes, post_processing = qml.gradients.param_shift(tape)
+        res = post_processing(qml.execute(g_tapes, dev, None))
+
+        assert g_tapes == [] and res.size == 0 and np.all(res == np.array([[]]))
 
     def test_y0(self, mocker):
         """Test that if the gradient recipe has a zero-shift component, then

--- a/tests/gradients/test_parameter_shift_cv.py
+++ b/tests/gradients/test_parameter_shift_cv.py
@@ -307,7 +307,9 @@ class TestParameterShiftLogic:
             g_tapes, post_processing = qml.gradients.param_shift_cv(tape, dev)
         res = post_processing(qml.execute(g_tapes, dev, None))
 
-        assert g_tapes == [] and res.size == 0 and np.all(res == np.array([[]]))
+        assert g_tapes == []
+        assert res.size == 0
+        assert np.all(res == np.array([[]]))
 
     def test_state_non_differentiable_error(self):
         """Test error raised if attempting to differentiate with

--- a/tests/gradients/test_parameter_shift_cv.py
+++ b/tests/gradients/test_parameter_shift_cv.py
@@ -271,6 +271,43 @@ class TestTransformObservable:
 class TestParameterShiftLogic:
     """Test for the dispatching logic of the parameter shift method"""
 
+    def test_no_trainable_params_qnode(self):
+        """Test that the correct ouput and warning is generated in the absence of any trainable
+        parameters"""
+        dev = qml.device("default.gaussian", wires=2)
+
+        @qml.qnode(dev)
+        def circuit(weights):
+            qml.Displacement(weights[0], 0.0, wires=[0])
+            qml.Rotation(weights[1], wires=[0])
+            return qml.expval(qml.X(0))
+
+        weights = [0.1, 0.2]
+        with pytest.warns(UserWarning, match="gradient of a QNode with no trainable parameters"):
+            res = qml.gradients.param_shift_cv(circuit)(weights)
+
+        assert res == ()
+
+    def test_no_trainable_params_tape(self):
+        """Test that the correct ouput and warning is generated in the absence of any trainable
+        parameters"""
+        dev = qml.device("default.gaussian", wires=2)
+
+        weights = [0.1, 0.2]
+        with qml.tape.JacobianTape() as tape:
+            qml.Displacement(weights[0], 0.0, wires=[0])
+            qml.Rotation(weights[1], wires=[0])
+            qml.expval(qml.X(0))
+
+        # TODO: remove once #2155 is resolved
+        tape.trainable_params = []
+
+        with pytest.warns(UserWarning, match="gradient of a tape with no trainable parameters"):
+            g_tapes, post_processing = qml.gradients.param_shift_cv(tape, dev)
+        res = post_processing(qml.execute(g_tapes, dev, None))
+
+        assert g_tapes == [] and res.size == 0 and np.all(res == np.array([[]]))
+
     def test_state_non_differentiable_error(self):
         """Test error raised if attempting to differentiate with
         respect to a state"""

--- a/tests/gradients/test_parameter_shift_cv.py
+++ b/tests/gradients/test_parameter_shift_cv.py
@@ -271,10 +271,12 @@ class TestTransformObservable:
 class TestParameterShiftLogic:
     """Test for the dispatching logic of the parameter shift method"""
 
-    @pytest.mark.parametrize("interface", ["autograd", "jax", "torch", "tf"])
+    @pytest.mark.parametrize("interface", ["autograd", "jax", "torch", "tensorflow"])
     def test_no_trainable_params_qnode(self, interface):
         """Test that the correct ouput and warning is generated in the absence of any trainable
         parameters"""
+        if interface != "autograd":
+            pytest.importorskip(interface)
         dev = qml.device("default.gaussian", wires=2)
 
         @qml.qnode(dev, interface=interface)

--- a/tests/gradients/test_parameter_shift_cv.py
+++ b/tests/gradients/test_parameter_shift_cv.py
@@ -271,12 +271,13 @@ class TestTransformObservable:
 class TestParameterShiftLogic:
     """Test for the dispatching logic of the parameter shift method"""
 
-    def test_no_trainable_params_qnode(self):
+    @pytest.mark.parametrize("interface", ["autograd", "jax", "torch", "tf"])
+    def test_no_trainable_params_qnode(self, interface):
         """Test that the correct ouput and warning is generated in the absence of any trainable
         parameters"""
         dev = qml.device("default.gaussian", wires=2)
 
-        @qml.qnode(dev)
+        @qml.qnode(dev, interface=interface)
         def circuit(weights):
             qml.Displacement(weights[0], 0.0, wires=[0])
             qml.Rotation(weights[1], wires=[0])

--- a/tests/transforms/test_metric_tensor.py
+++ b/tests/transforms/test_metric_tensor.py
@@ -635,7 +635,8 @@ class TestMetricTensor:
             mt_tapes, post_processing = qml.metric_tensor(tape)
         res = post_processing(qml.execute(mt_tapes, dev, None))
 
-        assert mt_tapes == [] and res == ()
+        assert mt_tapes == []
+        assert res == ()
 
 
 fixed_pars = np.array([-0.2, 0.2, 0.5, 0.3, 0.7], requires_grad=False)

--- a/tests/transforms/test_metric_tensor.py
+++ b/tests/transforms/test_metric_tensor.py
@@ -600,8 +600,9 @@ class TestMetricTensor:
         ]
         assert [[type(op) for op in tape.operations] for tape in tapes] == expected_ops
 
-
     def test_no_trainable_params_qnode(self):
+        """Test that the correct ouput and warning is generated in the absence of any trainable
+        parameters"""
         dev = qml.device("default.qubit", wires=3)
 
         @qml.qnode(dev)
@@ -617,6 +618,8 @@ class TestMetricTensor:
         assert res == ()
 
     def test_no_trainable_params_tape(self):
+        """Test that the correct ouput and warning is generated in the absence of any trainable
+        parameters"""
         dev = qml.device("default.qubit", wires=3)
 
         weights = [0.1, 0.2]
@@ -632,7 +635,8 @@ class TestMetricTensor:
             mt_tapes, post_processing = qml.metric_tensor(tape)
         res = post_processing(qml.execute(mt_tapes, dev, None))
 
-        assert mt_tapes == [] and res == []
+        assert mt_tapes == [] and res == ()
+
 
 fixed_pars = np.array([-0.2, 0.2, 0.5, 0.3, 0.7], requires_grad=False)
 

--- a/tests/transforms/test_metric_tensor.py
+++ b/tests/transforms/test_metric_tensor.py
@@ -600,12 +600,13 @@ class TestMetricTensor:
         ]
         assert [[type(op) for op in tape.operations] for tape in tapes] == expected_ops
 
-    def test_no_trainable_params_qnode(self):
+    @pytest.mark.parametrize("interface", ["autograd", "jax", "torch", "tf"])
+    def test_no_trainable_params_qnode(self, interface):
         """Test that the correct ouput and warning is generated in the absence of any trainable
         parameters"""
         dev = qml.device("default.qubit", wires=3)
 
-        @qml.qnode(dev)
+        @qml.qnode(dev, interface=interface)
         def circuit(weights):
             qml.RX(weights[0], wires=0)
             qml.RY(weights[1], wires=0)

--- a/tests/transforms/test_metric_tensor.py
+++ b/tests/transforms/test_metric_tensor.py
@@ -600,10 +600,12 @@ class TestMetricTensor:
         ]
         assert [[type(op) for op in tape.operations] for tape in tapes] == expected_ops
 
-    @pytest.mark.parametrize("interface", ["autograd", "jax", "torch", "tf"])
+    @pytest.mark.parametrize("interface", ["autograd", "jax", "torch", "tensorflow"])
     def test_no_trainable_params_qnode(self, interface):
         """Test that the correct ouput and warning is generated in the absence of any trainable
         parameters"""
+        if interface != "autograd":
+            pytest.importorskip(interface)
         dev = qml.device("default.qubit", wires=3)
 
         @qml.qnode(dev, interface=interface)


### PR DESCRIPTION
Similar to the previous changes in #2148 and #2139, we'd like to provide a warning or useful error message when a user attempts to compute metric tensor even though there are no trainable parameters, such as in the following example:

```py
dev = qml.device("default.qubit", wires=3)

@qml.qnode(dev)
def circuit(weights):
    qml.RX(weights[0], wires=0)
    qml.RY(weights[1], wires=0)
    return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))

weights = [0.1, 0.2]
qml.metric_tensor(circuit)(weights)
```

Most or all gradient transforms actually throw an error at the moment when this is attempted, unless the `hybrid` parameter is set to False:

```
ValueError: need at least one array to stack
```

so this change will also resolve this bug.

With the proposed changes, a warning is raised and a default value returned instead, in both the QNode and tape execution case:

```
UserWarning: Attempted to compute the metric tensor of a QNode with no trainable parameters. If this is unintended, please add trainable parameters via the 'requires_grad' attribute.
  warnings.warn(
()
```