### PR TITLE
Clarify usage of `substep_optimizer` in the docstring of `RotosolveOptimizer`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -584,6 +584,10 @@
 
 <h3>Documentation</h3>
 
+* Improves the documentation of `RotosolveOptimizer` regarding the
+  usage of the passed `substep_optimizer` and its keyword arguments.
+  [(#2160)](https://github.com/PennyLaneAI/pennylane/pull/2160)
+
 * Fixes an error in the signs of equations in the `DoubleExcitation` page.
   [(#2072)](https://github.com/PennyLaneAI/pennylane/pull/2072)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -586,7 +586,7 @@
 
 * Improves the documentation of `RotosolveOptimizer` regarding the
   usage of the passed `substep_optimizer` and its keyword arguments.
-  [(#2160)](https://github.com/PennyLaneAI/pennylane/pull/2160)
+  [(#2161)](https://github.com/PennyLaneAI/pennylane/pull/2161)
 
 * Fixes an error in the signs of equations in the `DoubleExcitation` page.
   [(#2072)](https://github.com/PennyLaneAI/pennylane/pull/2072)

--- a/pennylane/optimize/rotosolve.py
+++ b/pennylane/optimize/rotosolve.py
@@ -113,6 +113,7 @@ class RotosolveOptimizer:
     Args:
         substep_optimizer (str or callable): Optimizer to use for the substeps of Rotosolve
             that carries out a univariate (i.e., single-parameter) global optimization.
+            *Only used if there are more than one frequency for a given parameter.*
             It must take as inputs:
 
             - A function ``fn`` that maps scalars to scalars,
@@ -142,11 +143,14 @@ class RotosolveOptimizer:
             callable. For ``substep_optimizer="shgo"``, the original keyword arguments of
             the SciPy implementation are available, for ``substep_optimizer="brute"`` the
             keyword arguments ``ranges``, ``Ns`` and ``num_steps`` are useful.
+            *Only used if there are more than one frequency for a given parameter.*
 
     For each parameter, a purely classical one-dimensional global optimization over the
-    interval :math:`(-\pi,\pi]` is performed, which is replaced by a closed-form expression for
-    the optimal value if the :math:`d\text{th}` parametrized gate has only two eigenvalues. In this
-    case, the optimal value :math:`\theta^*_d` is given by
+    interval :math:`(-\pi,\pi]` is performed, which is replaced automatically by a
+    closed-form expression for the optimal value if the :math:`d\text{th}` parametrized
+    gate has only two eigenvalues. This means that ``substep_optimizer`` and
+    ``substep_kwargs`` will not be used for these parameters.
+    In this case, the optimal value :math:`\theta^*_d` is given analytically by
 
     .. math::
 
@@ -158,12 +162,13 @@ class RotosolveOptimizer:
     where :math:`\left<H\right>_{\theta_d}` is the expectation value of the objective function
     restricted to only depend on the parameter :math:`\theta_d`.
 
-    .. warning ::
+    .. warning::
 
         The built-in one-dimensional optimizers ``"brute"`` and ``"shgo"`` for the substeps
         of a Rotosolve optimization step use the interval :math:`(-\pi,\pi]`, rescaled with
         the inverse smallest frequency as default domain to optimize over. For complicated
-        cost functions, this domain might not be suitable for the substep optimization.
+        cost functions, this domain might not be suitable for the substep optimization and
+        an appropriate range should be passed via ``bounds`` in ``substep_kwargs``.
 
     The algorithm is described in further detail in
     `Vidal and Theis (2018) <https://arxiv.org/abs/1812.06323>`_,

--- a/pennylane/transforms/adjoint_metric_tensor.py
+++ b/pennylane/transforms/adjoint_metric_tensor.py
@@ -140,7 +140,7 @@ def adjoint_metric_tensor(circuit, device=None, hybrid=True):
 
     .. code-block:: python
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit", wires=3)
 
         @qml.qnode(dev, interface="autograd")
         def circuit(weights):

--- a/tests/transforms/test_metric_tensor.py
+++ b/tests/transforms/test_metric_tensor.py
@@ -77,10 +77,10 @@ class TestMetricTensor:
 
     @pytest.mark.parametrize("diff_method", ["parameter-shift", "backprop"])
     def test_parameter_fan_out(self, diff_method):
-        """The metric tensor is always with respect to the quantum circuit. Any
-        classical processing is not taken into account. As a result, if there is
+        """The metric tensor is with respect to the quantum circuit and ignores
+        classical processing if ``hybrid=False``. As a result, if there is
         parameter fan-out, the returned metric tensor will be larger than
-        expected.
+        ``(len(args), len(args))`` if hybrid computation is deactivated.
         """
         dev = qml.device("default.qubit", wires=2)
 


### PR DESCRIPTION
This PR changes the doc string of the RotosolveOptimizer in order to make clear that the
analytical 1D minimization for parameters that enter a QNode with a single frequency does not have to be chosen
manually via substep_optimizer, but that this is taken care of automatically, and substep_optimizer is simply ignored
for such parameters.

Thanks to @cvjjm for pointing out that this should be improved :)

This PR also fixes a single docstring in `test_metric_tensor.py` which is too small for a separate PR.

(This is a copy of #2160 for technical reasons.)