### PR TITLE
add fragment configurations method, add test, update docs

### DIFF
--- a/pennylane/transforms/__init__.py
+++ b/pennylane/transforms/__init__.py
@@ -95,6 +95,7 @@ Utility function to assist with the circuit cutting transform
     ~transforms.replace_wire_cut_nodes
     ~transforms.fragment_graph
     ~transforms.graph_to_tape
+    ~transforms.expand_fragment_tapes
 
 Transforms that act on tapes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -173,4 +174,5 @@ from .qcut import (
     replace_wire_cut_nodes,
     fragment_graph,
     graph_to_tape,
+    expand_fragment_tapes,
 )


### PR DESCRIPTION
**Context:**
In the circuit cutting pipeline, once the graph representing the circuit has been partitioned into [subgraphs](https://github.com/PennyLaneAI/pennylane/pull/2153) and the subgraphs have been [converted to tapes](https://github.com/PennyLaneAI/pennylane/pull/2165) representing circuit fragments, it is necessary to implement the physical measurements and state preparations that will allow us to execute the individual fragments and recombine the output. This is achieved here through use of the Paul basis.

**Description of the Change:**
A method has been added to expand a fragment tape into a tape for each configuration.

**Benefits:**
Facilitates the circuit cutting compiler.

**Possible Drawbacks:**
Only supports expectation values and Pauli basis.