### PR TITLE
Fix `dev.num_executions` bug with QNode caching

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -525,6 +525,10 @@
 
 <h3>Bug fixes</h3>
 
+* Fixes a bug where the number of executions recorded by the QNode is incorrect
+  e.g., for `diff_method="backprop"`.
+  [(#XXX)](https://github.com/PennyLaneAI/pennylane/pull/XXX)
+
 * Fixes a bug where the `default.qubit.jax` device can't be used with `diff_method=None` and jitting.
   [(#2136)](https://github.com/PennyLaneAI/pennylane/pull/2136)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -527,7 +527,7 @@
 
 * Fixes a bug where the number of executions recorded by the QNode is incorrect
   e.g., for `diff_method="backprop"`.
-  [(#XXX)](https://github.com/PennyLaneAI/pennylane/pull/XXX)
+  [(#2171)](https://github.com/PennyLaneAI/pennylane/pull/2171)
 
 * Fixes a bug where the `default.qubit.jax` device can't be used with `diff_method=None` and jitting.
   [(#2136)](https://github.com/PennyLaneAI/pennylane/pull/2136)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -526,7 +526,7 @@
 <h3>Bug fixes</h3>
 
 * Fixes a bug where an incorrect number of executions are recorded by
-  a QNode using a custom cache e.g., for `diff_method="backprop"`.
+  a QNode using a custom cache with `diff_method="backprop"`.
   [(#2171)](https://github.com/PennyLaneAI/pennylane/pull/2171)
 
 * Fixes a bug where the `default.qubit.jax` device can't be used with `diff_method=None` and jitting.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -525,8 +525,8 @@
 
 <h3>Bug fixes</h3>
 
-* Fixes a bug where the number of executions recorded by the QNode is incorrect
-  e.g., for `diff_method="backprop"`.
+* Fixes a bug where an incorrect number of executions are recorded by
+  a QNode using a custom cache e.g., for `diff_method="backprop"`.
   [(#2171)](https://github.com/PennyLaneAI/pennylane/pull/2171)
 
 * Fixes a bug where the `default.qubit.jax` device can't be used with `diff_method=None` and jitting.

--- a/pennylane/qnode.py
+++ b/pennylane/qnode.py
@@ -265,7 +265,10 @@ class QNode:
         # of the user's device before and after executing the tape.
 
         if self.device is not self._original_device:
-            self._original_device._num_executions += 1  # pylint: disable=protected-access
+
+            # Use the number of executions on the original device as we may
+            # have used the cache
+            self._original_device._num_executions = self.device._num_executions # pylint: disable=protected-access
 
             # Update for state vector simulators that have the _pre_rotated_state attribute
             if hasattr(self._original_device, "_pre_rotated_state"):

--- a/pennylane/qnode.py
+++ b/pennylane/qnode.py
@@ -271,7 +271,7 @@ class QNode:
             # have used the cache
 
             if not self._tape_cached:
-                self._original_device._num_executions += 1 # pylint: disable=protected-access
+                self._original_device._num_executions += 1  # pylint: disable=protected-access
 
             # Update for state vector simulators that have the _pre_rotated_state attribute
             if hasattr(self._original_device, "_pre_rotated_state"):
@@ -553,7 +553,11 @@ class QNode:
         self.construct(args, kwargs)
 
         cache = self.execute_kwargs.get("cache", False)
-        using_custom_cache = hasattr(cache, "__getitem__") and hasattr(cache, "__setitem__") and hasattr(cache, "__delitem__")
+        using_custom_cache = (
+            hasattr(cache, "__getitem__")
+            and hasattr(cache, "__setitem__")
+            and hasattr(cache, "__delitem__")
+        )
         self._tape_cached = using_custom_cache and self.tape.hash in cache
 
         res = qml.execute(

--- a/pennylane/qnode.py
+++ b/pennylane/qnode.py
@@ -217,6 +217,7 @@ class QNode:
         self._original_device = device
         self.gradient_fn = None
         self.gradient_kwargs = None
+        self._tape_cached = False
 
         self._update_gradient_fn()
         functools.update_wrapper(self, func)
@@ -268,9 +269,9 @@ class QNode:
 
             # Use the number of executions on the original device as we may
             # have used the cache
-            self._original_device._num_executions = (
-                self.device._num_executions
-            )  # pylint: disable=protected-access
+
+            if not self._tape_cached:
+                self._original_device._num_executions += 1 # pylint: disable=protected-access
 
             # Update for state vector simulators that have the _pre_rotated_state attribute
             if hasattr(self._original_device, "_pre_rotated_state"):
@@ -550,6 +551,10 @@ class QNode:
 
         # construct the tape
         self.construct(args, kwargs)
+
+        cache = self.execute_kwargs.get("cache", False)
+        using_custom_cache = hasattr(cache, "__getitem__") and hasattr(cache, "__setitem__") and hasattr(cache, "__delitem__")
+        self._tape_cached = using_custom_cache and self.tape.hash in cache
 
         res = qml.execute(
             [self.tape],

--- a/pennylane/qnode.py
+++ b/pennylane/qnode.py
@@ -268,7 +268,9 @@ class QNode:
 
             # Use the number of executions on the original device as we may
             # have used the cache
-            self._original_device._num_executions = self.device._num_executions # pylint: disable=protected-access
+            self._original_device._num_executions = (
+                self.device._num_executions
+            )  # pylint: disable=protected-access
 
             # Update for state vector simulators that have the _pre_rotated_state attribute
             if hasattr(self._original_device, "_pre_rotated_state"):

--- a/pennylane/qnode.py
+++ b/pennylane/qnode.py
@@ -267,9 +267,6 @@ class QNode:
 
         if self.device is not self._original_device:
 
-            # Use the number of executions on the original device as we may
-            # have used the cache
-
             if not self._tape_cached:
                 self._original_device._num_executions += 1  # pylint: disable=protected-access
 

--- a/tests/test_qnode.py
+++ b/tests/test_qnode.py
@@ -715,7 +715,7 @@ class TestIntegration:
         """Tests that if we swapped the original device (e.g., when
         diff_method='backprop') then the number of executions recorded is
         correct."""
-        dev = qml.device('default.qubit', wires=2)
+        dev = qml.device("default.qubit", wires=2)
 
         cache = {}
 

--- a/tests/test_qnode.py
+++ b/tests/test_qnode.py
@@ -736,7 +736,7 @@ class TestIntegration:
         """Tests that if we swapped the original device (e.g., when
         diff_method='backprop') then the number of executions recorded is
         correct even with multiple QNode evaluations."""
-        dev = qml.device('default.qubit', wires=2)
+        dev = qml.device("default.qubit", wires=2)
 
         cache = {}
 
@@ -755,7 +755,6 @@ class TestIntegration:
 
         for _ in range(15):
             circuit()
-
 
         # Although we've evaluated the QNode several times, due to caching,
         # there were two device executions recorded

--- a/tests/test_qnode.py
+++ b/tests/test_qnode.py
@@ -711,6 +711,27 @@ class TestIntegration:
 
         assert dev.num_executions == 6
 
+    def test_num_exec_caching_device_swap(self):
+        """Tests that if we swapped the original device (e.g., when
+        diff_method='backprop') then the number of executions recorded is
+        correct."""
+        dev = qml.device('default.qubit', wires=2)
+
+        cache = {}
+
+        @qml.qnode(dev, diff_method="backprop", cache=cache)
+        def circuit():
+            qml.RY(0.345, wires=0)
+            return qml.expval(qml.PauliZ(0))
+
+        for _ in range(15):
+            circuit()
+
+        # Although we've evaluated the QNode more than once, due to caching,
+        # there was one device execution recorded
+        assert dev.num_executions == 1
+        assert cache != {}
+
     @pytest.mark.parametrize("diff_method", ["parameter-shift", "finite-diff"])
     def test_single_expectation_value_with_argnum_one(self, diff_method, tol):
         """Tests correct output shape and evaluation for a QNode


### PR DESCRIPTION
**Context:**
See linked issue https://github.com/PennyLaneAI/pennylane/issues/2170. The issue arises when swapping the underlying device in the QNode (e.g., when having `diff_method="backprop"`).

**Description of the Change:**

Instead of incrementing the number of executions, we set the number of executions using the number of executions from the device used.

**Benefits:**

`dev.num_executions` is recorded correctly.

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
Closes https://github.com/PennyLaneAI/pennylane/issues/2170