### PR TITLE
[Prototype] Deferred measurement principle transform

### DIFF
--- a/pennylane/__init__.py
+++ b/pennylane/__init__.py
@@ -63,6 +63,7 @@ from pennylane.transforms import (
     ControlledOperation,
     compile,
     ctrl,
+    defer_measurements,
     measurement_grouping,
     metric_tensor,
     specs,

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -848,6 +848,7 @@ class DefaultQubit(QubitDevice):
         # init the state vector to |00..0>
         self._state = self._create_basis_state(0)
         self._pre_rotated_state = self._state
+        self._measured = []
 
     def analytic_probability(self, wires=None):
 

--- a/pennylane/ops/mid_circuit_measure.py
+++ b/pennylane/ops/mid_circuit_measure.py
@@ -107,6 +107,11 @@ class MeasurementDependantValue(Generic[T]):
             return [self._depends_on, *self._zero_case.measurements]
         return [self._depends_on]
 
+    def logical_not(self):
+        """Perform a logical not on the MeasurementDependantValue.
+        """
+        return apply_to_measurement_dependant_values(lambda x: not x)(self)
+
     # define all mathematical __dunder__ methods https://docs.python.org/3/library/operator.html
     def __add__(self, other: Any):
         return apply_to_measurement_dependant_values(lambda x, y: x + y)(self, other)
@@ -125,6 +130,12 @@ class MeasurementDependantValue(Generic[T]):
 
     def __rand__(self, other: Any):
         return apply_to_measurement_dependant_values(lambda x, y: y and x)(self, other)
+
+    def __or__(self, other: Any):
+        return apply_to_measurement_dependant_values(lambda x, y: x or y)(self, other)
+
+    def __ror__(self, other: Any):
+        return apply_to_measurement_dependant_values(lambda x, y: y or x)(self, other)
 
     def __str__(self):
         measurements = self.measurements

--- a/pennylane/ops/mid_circuit_measure.py
+++ b/pennylane/ops/mid_circuit_measure.py
@@ -252,15 +252,8 @@ def if_then(expr: MeasurementDependantValue[bool], then_op: Type[Operation]):
         measured_qubit = expr
 
         def __init__(self, *args, **kwargs):
-            self.then_op = then_op
-            self.args = args
-            self.kwargs = kwargs
-            # self.then_op = then_op(*args, do_queue=False, **kwargs)
+            self.then_op = then_op(*args, do_queue=False, **kwargs)
             super().__init__(*args, **kwargs)
-
-
-        def construct_op(self):
-            return self.then_op(*self.args, **self.kwargs)
 
     return _IfOp
 

--- a/pennylane/ops/mid_circuit_measure.py
+++ b/pennylane/ops/mid_circuit_measure.py
@@ -254,6 +254,7 @@ def if_then(expr: MeasurementDependantValue[bool], then_op: Type[Operation]):
         op: Type[Operation] = then_op
         branches = expr.branches
         dependant_measurements = expr.measurements
+        measured_qubit = expr
 
         def __init__(self, *args, **kwargs):
             self.then_op = then_op(*args, do_queue=False, **kwargs)

--- a/pennylane/ops/mid_circuit_measure.py
+++ b/pennylane/ops/mid_circuit_measure.py
@@ -120,6 +120,12 @@ class MeasurementDependantValue(Generic[T]):
     def __rmul__(self, other: Any):
         return apply_to_measurement_dependant_values(lambda x, y: y * x)(self, other)
 
+    def __and__(self, other: Any):
+        return apply_to_measurement_dependant_values(lambda x, y: x and y)(self, other)
+
+    def __rand__(self, other: Any):
+        return apply_to_measurement_dependant_values(lambda x, y: y and x)(self, other)
+
     def __str__(self):
         measurements = self.measurements
         lines = []
@@ -246,8 +252,15 @@ def if_then(expr: MeasurementDependantValue[bool], then_op: Type[Operation]):
         measured_qubit = expr
 
         def __init__(self, *args, **kwargs):
-            self.then_op = then_op(*args, do_queue=False, **kwargs)
+            self.then_op = then_op
+            self.args = args
+            self.kwargs = kwargs
+            # self.then_op = then_op(*args, do_queue=False, **kwargs)
             super().__init__(*args, **kwargs)
+
+
+        def construct_op(self):
+            return self.then_op(*self.args, **self.kwargs)
 
     return _IfOp
 

--- a/pennylane/ops/mid_circuit_measure.py
+++ b/pennylane/ops/mid_circuit_measure.py
@@ -260,7 +260,6 @@ def if_then(expr: MeasurementDependantValue[bool], then_op: Type[Operation]):
         op: Type[Operation] = then_op
         branches = expr.branches
         dependant_measurements = expr.measurements
-        measured_qubit = expr
 
         def __init__(self, *args, **kwargs):
             self.then_op = then_op(*args, do_queue=False, **kwargs)

--- a/pennylane/transforms/__init__.py
+++ b/pennylane/transforms/__init__.py
@@ -123,6 +123,7 @@ from .classical_jacobian import classical_jacobian
 from .compile import compile
 from .control import ControlledOperation, ctrl
 from .decompositions import zyz_decomposition, two_qubit_decomposition
+from .defer_measurements import defer_measurements
 from .draw import draw, draw_mpl
 from .hamiltonian_expand import hamiltonian_expand
 from .measurement_grouping import measurement_grouping

--- a/pennylane/transforms/defer_measurements.py
+++ b/pennylane/transforms/defer_measurements.py
@@ -35,7 +35,7 @@ def defer_measurements(tape):
                         for i, wire_val in enumerate(branch):
                             if wire_val and flipped[i] or not wire_val and not flipped[i]:
                                 qml.RZ(math.pi, wires=control[i])
-                        ctrl(op.construct_op, control=control)()
+                        ctrl(lambda: apply(op.then_op), control=control)()
                 for i, flip in enumerate(flipped):
                     if flip:
                         qml.RZ(math.pi, wires=control[i])
@@ -43,11 +43,11 @@ def defer_measurements(tape):
             elif op.__class__.__name__ == "_ConditionOp":
                 control = op.dependant_measurements
                 flipped = [False] * len(control)
-                for branch, value in op.branches.items():
+                for branch, branch_op in op.branches.items():
                     for i, wire_val in enumerate(branch):
                         if wire_val and flipped[i] or not wire_val and not flipped[i]:
                             qml.RZ(math.pi, wires=control[i])
-                    ctrl(lambda: new_tape.append(value), control=control)()
+                    ctrl(lambda: apply(branch_op), control=control)()
                 flip_wires = []
                 for i, flip in enumerate(flipped):
                     if flip:

--- a/pennylane/transforms/defer_measurements.py
+++ b/pennylane/transforms/defer_measurements.py
@@ -32,37 +32,27 @@ def defer_measurements(tape):
                 flipped = [False] * len(control)
                 for branch, value in op.branches.items():
                     if value:
-                        flip_wires = []
                         for i, wire_val in enumerate(branch):
                             if wire_val and flipped[i] or not wire_val and not flipped[i]:
-                                flip_wires.append(control[i])
-                        if flip_wires:
-                            qml.RZ(math.pi, wires=flip_wires)
+                                qml.RZ(math.pi, wires=control[i])
                         ctrl(op.construct_op, control=control)()
-                flip_wires = []
                 for i, flip in enumerate(flipped):
                     if flip:
-                        flip_wires.append(control[i])
-                if flip_wires:
-                    qml.RZ(math.pi, wires=flip_wires)
+                        qml.RZ(math.pi, wires=control[i])
 
             elif op.__class__.__name__ == "_ConditionOp":
                 control = op.dependant_measurements
                 flipped = [False] * len(control)
                 for branch, value in op.branches.items():
-                    flip_wires = []
                     for i, wire_val in enumerate(branch):
                         if wire_val and flipped[i] or not wire_val and not flipped[i]:
-                            flip_wires.append(control[i])
-                    if flip_wires:
-                        qml.RZ(math.pi, wires=flip_wires)
+                            qml.RZ(math.pi, wires=control[i])
                     ctrl(lambda: new_tape.append(value), control=control)()
                 flip_wires = []
                 for i, flip in enumerate(flipped):
                     if flip:
                         flip_wires.append(control[i])
-                if flip_wires:
-                    qml.RZ(math.pi, wires=flip_wires)
+                        qml.RZ(math.pi, wires=control[i])
 
 
             else:

--- a/pennylane/transforms/defer_measurements.py
+++ b/pennylane/transforms/defer_measurements.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Code for the tape transform implementing the deferred measurement principle."""
-import math
-
 import pennylane as qml
 from pennylane.transforms import qfunc_transform, ctrl
 from pennylane.queuing import apply
@@ -38,11 +36,11 @@ def defer_measurements(tape):
                     if value:
                         for i, wire_val in enumerate(branch):
                             if wire_val and flipped[i] or not wire_val and not flipped[i]:
-                                qml.RZ(math.pi, wires=control[i])
+                                qml.PauliX(wires=control[i])
                         ctrl(lambda: apply(op.then_op), control=control)()
                 for i, flip in enumerate(flipped):
                     if flip:
-                        qml.RZ(math.pi, wires=control[i])
+                        qml.PauliX(wires=control[i])
 
             elif op.__class__.__name__ == "_ConditionOp":
                 control = op.dependant_measurements
@@ -50,11 +48,11 @@ def defer_measurements(tape):
                 for branch, branch_op in op.branches.items():
                     for i, wire_val in enumerate(branch):
                         if wire_val and flipped[i] or not wire_val and not flipped[i]:
-                            qml.RZ(math.pi, wires=control[i])
+                            qml.PauliX(wires=control[i])
                     ctrl(lambda: apply(branch_op), control=control)()
                 for i, flip in enumerate(flipped):
                     if flip:
-                        qml.RZ(math.pi, wires=control[i])
+                        qml.PauliX(wires=control[i])
 
             else:
                 apply(op)

--- a/pennylane/transforms/defer_measurements.py
+++ b/pennylane/transforms/defer_measurements.py
@@ -26,13 +26,14 @@ def defer_measurements(tape):
                 pass
 
             elif op.__class__.__name__ == "_IfOp":
-                control = op.measured_qubit._dependent_on
-                op_class = op.then_op.__class__
-                if op.data:
-                    controlled_op = ctrl(op_class, control=control)(*op.data, wires=op.wires)
+                control = op.dependent_on
+                for branch in op.branch:
+                    op_class = op.then_op.__class__
+                    if op.data:
+                        controlled_op = ctrl(op_class, control=control)(*op.data, wires=op.wires)
 
-                else:
-                    controlled_op = ctrl(op_class, control=control)(wires=op.wires)
+                    else:
+                        controlled_op = ctrl(op_class, control=control)(wires=op.wires)
             else:
                 apply(op)
 

--- a/pennylane/transforms/defer_measurements.py
+++ b/pennylane/transforms/defer_measurements.py
@@ -48,12 +48,9 @@ def defer_measurements(tape):
                         if wire_val and flipped[i] or not wire_val and not flipped[i]:
                             qml.RZ(math.pi, wires=control[i])
                     ctrl(lambda: apply(branch_op), control=control)()
-                flip_wires = []
                 for i, flip in enumerate(flipped):
                     if flip:
-                        flip_wires.append(control[i])
                         qml.RZ(math.pi, wires=control[i])
-
 
             else:
                 apply(op)

--- a/pennylane/transforms/defer_measurements.py
+++ b/pennylane/transforms/defer_measurements.py
@@ -46,6 +46,25 @@ def defer_measurements(tape):
                 if flip_wires:
                     qml.RZ(math.pi, wires=flip_wires)
 
+            elif op.__class__.__name__ == "_ConditionOp":
+                control = op.dependant_measurements
+                flipped = [False] * len(control)
+                for branch, value in op.branches.items():
+                    flip_wires = []
+                    for i, wire_val in enumerate(branch):
+                        if wire_val and flipped[i] or not wire_val and not flipped[i]:
+                            flip_wires.append(control[i])
+                    if flip_wires:
+                        qml.RZ(math.pi, wires=flip_wires)
+                    ctrl(lambda: new_tape.append(value), control=control)()
+                flip_wires = []
+                for i, flip in enumerate(flipped):
+                    if flip:
+                        flip_wires.append(control[i])
+                if flip_wires:
+                    qml.RZ(math.pi, wires=flip_wires)
+
+
             else:
                 apply(op)
 

--- a/pennylane/transforms/defer_measurements.py
+++ b/pennylane/transforms/defer_measurements.py
@@ -1,0 +1,41 @@
+# Copyright 2018-2022 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Code for the tape transform implementing the deferred measurement principle."""
+import pennylane as qml
+
+@qml.qfunc_transform
+def defer_measurements(tape):
+    new_tape_ops = []
+    
+    for op in tape.queue:
+        if isinstance(op, qml.ops.mid_circuit_measure._MidCircuitMeasure):
+            pass
+
+        elif op.__class__.__name__ == "_IfOp":
+            control = op.measured_qubit._dependent_on
+            op_class = op.then_op.__class__
+            if op.data:
+                controlled_op = qml.ctrl(op_class, control=control)(*op.data, wires=op.wires)
+                
+            else:
+                controlled_op = qml.ctrl(op_class, control=control)(wires=op.wires)
+            new_tape_ops.append(controlled_op)
+        else:
+            new_tape_ops.append(op)
+        
+    with qml.tape.QuantumTape() as new_tape:
+        for op in new_tape_ops:
+            qml.apply(op)
+            
+    return new_tape

--- a/pennylane/transforms/defer_measurements.py
+++ b/pennylane/transforms/defer_measurements.py
@@ -13,8 +13,11 @@
 # limitations under the License.
 """Code for the tape transform implementing the deferred measurement principle."""
 import pennylane as qml
+from pennylane.transforms import qfunc_transform, ctrl
+from pennylane.queuing import apply
+from pennylane.tape import QuantumTape
 
-@qml.qfunc_transform
+@qfunc_transform
 def defer_measurements(tape):
     new_tape_ops = []
     
@@ -26,16 +29,16 @@ def defer_measurements(tape):
             control = op.measured_qubit._dependent_on
             op_class = op.then_op.__class__
             if op.data:
-                controlled_op = qml.ctrl(op_class, control=control)(*op.data, wires=op.wires)
+                controlled_op = ctrl(op_class, control=control)(*op.data, wires=op.wires)
                 
             else:
-                controlled_op = qml.ctrl(op_class, control=control)(wires=op.wires)
+                controlled_op = ctrl(op_class, control=control)(wires=op.wires)
             new_tape_ops.append(controlled_op)
         else:
             new_tape_ops.append(op)
         
-    with qml.tape.QuantumTape() as new_tape:
+    with QuantumTape() as new_tape:
         for op in new_tape_ops:
-            qml.apply(op)
+            apply(op)
             
     return new_tape

--- a/pennylane/transforms/defer_measurements.py
+++ b/pennylane/transforms/defer_measurements.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Code for the tape transform implementing the deferred measurement principle."""
+import math
+
 import pennylane as qml
 from pennylane.transforms import qfunc_transform, ctrl
 from pennylane.queuing import apply
@@ -26,14 +28,29 @@ def defer_measurements(tape):
                 pass
 
             elif op.__class__.__name__ == "_IfOp":
-                control = op.dependent_on
-                for branch in op.branch:
-                    op_class = op.then_op.__class__
-                    if op.data:
-                        controlled_op = ctrl(op_class, control=control)(*op.data, wires=op.wires)
+                control = op.dependant_measurements
+                flipped = [False] * len(control)
+                for branch, value in op.branches.items():
+                    if value:
+                        flip_wires = []
+                        for i, wire_val in enumerate(branch):
+                            if wire_val and flipped[i] or not wire_val and not flipped[i]:
+                                flip_wires.append(control[i])
+                        if flip_wires:
+                            qml.RZ(math.pi, wires=flip_wires)
+                        op_class = op.then_op.__class__
+                        if op.data:
+                            controlled_op = ctrl(op_class, control=control)(*op.data, wires=op.wires)
 
-                    else:
-                        controlled_op = ctrl(op_class, control=control)(wires=op.wires)
+                        else:
+                            controlled_op = ctrl(op_class, control=control)(wires=op.wires)
+                flip_wires = []
+                for i, flip in enumerate(flipped):
+                    if flip:
+                        flip_wires.append(control[i])
+                if flip_wires:
+                    qml.RZ(math.pi, wires=flip_wires)
+
             else:
                 apply(op)
 

--- a/pennylane/transforms/defer_measurements.py
+++ b/pennylane/transforms/defer_measurements.py
@@ -23,9 +23,13 @@ from pennylane.tape import QuantumTape
 def defer_measurements(tape):
 
     with QuantumTape() as new_tape:
+        measured_wires = []
         for op in tape.queue:
+            if any([wire in measured_wires for wire in op.wires]):
+                raise ValueError("cannot reuse measured wires.")
+
             if isinstance(op, qml.ops.mid_circuit_measure._MidCircuitMeasure):
-                pass
+                measured_wires.append(op.measured_wire)
 
             elif op.__class__.__name__ == "_IfOp":
                 control = op.dependant_measurements

--- a/pennylane/transforms/defer_measurements.py
+++ b/pennylane/transforms/defer_measurements.py
@@ -19,26 +19,21 @@ from pennylane.tape import QuantumTape
 
 @qfunc_transform
 def defer_measurements(tape):
-    new_tape_ops = []
-    
-    for op in tape.queue:
-        if isinstance(op, qml.ops.mid_circuit_measure._MidCircuitMeasure):
-            pass
 
-        elif op.__class__.__name__ == "_IfOp":
-            control = op.measured_qubit._dependent_on
-            op_class = op.then_op.__class__
-            if op.data:
-                controlled_op = ctrl(op_class, control=control)(*op.data, wires=op.wires)
-                
-            else:
-                controlled_op = ctrl(op_class, control=control)(wires=op.wires)
-            new_tape_ops.append(controlled_op)
-        else:
-            new_tape_ops.append(op)
-        
     with QuantumTape() as new_tape:
-        for op in new_tape_ops:
-            apply(op)
-            
+        for op in tape.queue:
+            if isinstance(op, qml.ops.mid_circuit_measure._MidCircuitMeasure):
+                pass
+
+            elif op.__class__.__name__ == "_IfOp":
+                control = op.measured_qubit._dependent_on
+                op_class = op.then_op.__class__
+                if op.data:
+                    controlled_op = ctrl(op_class, control=control)(*op.data, wires=op.wires)
+
+                else:
+                    controlled_op = ctrl(op_class, control=control)(wires=op.wires)
+            else:
+                apply(op)
+
     return new_tape

--- a/pennylane/transforms/defer_measurements.py
+++ b/pennylane/transforms/defer_measurements.py
@@ -38,7 +38,7 @@ def defer_measurements(tape):
                                 flip_wires.append(control[i])
                         if flip_wires:
                             qml.RZ(math.pi, wires=flip_wires)
-                        controlled_op = ctrl(op.construct_op, control=control)()
+                        ctrl(op.construct_op, control=control)()
                 flip_wires = []
                 for i, flip in enumerate(flipped):
                     if flip:

--- a/pennylane/transforms/defer_measurements.py
+++ b/pennylane/transforms/defer_measurements.py
@@ -38,12 +38,7 @@ def defer_measurements(tape):
                                 flip_wires.append(control[i])
                         if flip_wires:
                             qml.RZ(math.pi, wires=flip_wires)
-                        op_class = op.then_op.__class__
-                        if op.data:
-                            controlled_op = ctrl(op_class, control=control)(*op.data, wires=op.wires)
-
-                        else:
-                            controlled_op = ctrl(op_class, control=control)(wires=op.wires)
+                        controlled_op = ctrl(op.construct_op, control=control)()
                 flip_wires = []
                 for i, flip in enumerate(flipped):
                     if flip:

--- a/tests/ops/test_mid_circuit_measurements.py
+++ b/tests/ops/test_mid_circuit_measurements.py
@@ -19,6 +19,7 @@ class TestMidCircuitMeasurements:
             return qml.probs(wires=0)
 
         @qml.qnode(dev)
+        @qml.defer_measurements
         def teleportation_circuit(rads):
 
             # Create Alice's secret qubit state
@@ -54,6 +55,7 @@ class TestMidCircuitMeasurements:
         dev = qml.device("default.qubit", wires=2)
 
         @qml.qnode(dev)
+        @qml.defer_measurements
         def runtime_circuit():
             qml.Hadamard(wires=0)
             m0 = qml.mid_measure(0)
@@ -69,6 +71,7 @@ class TestMidCircuitMeasurements:
         dev = qml.device("default.qubit", wires=4)
 
         @qml.qnode(dev)
+        @qml.defer_measurements
         def runtime_circuit():
             qml.Hadamard(wires=0)
             qml.Hadamard(wires=1)

--- a/tests/transforms/test_defer_measurements.py
+++ b/tests/transforms/test_defer_measurements.py
@@ -1,0 +1,52 @@
+import pytest
+import math
+
+import pennylane as qml
+import pennylane.numpy as np
+
+class TestMidCircuitMeasurements:
+    """Tests mid circuit measurements"""
+
+    @pytest.mark.parametrize("r", np.linspace(0.0, 1.6, 10))
+    @pytest.mark.parametrize("device", ["default.qubit", "default.mixed"])
+    def test_quantum_teleportation(self, device, r):
+        dev = qml.device(device, wires=3)
+
+        @qml.qnode(dev)
+        def normal_circuit(rads):
+            qml.RY(rads, wires=0)
+
+            return qml.probs(wires=0)
+
+        @qml.qnode(dev)
+        @qml.defer_measurements
+        def teleportation_circuit(rads):
+
+            # Create Alice's secret qubit state
+            qml.RY(rads, wires=0)
+
+            # create an EPR pair with wires 1 and 2. 1 is held by Alice and 2 held by Bob
+            qml.Hadamard(wires=1)
+            qml.CNOT(wires=[1, 2])
+
+            # Alice sends her qubits through a CNOT gate.
+            qml.CNOT(wires=[0, 1])
+
+            # Alice then sends the first qubit through a Hadamard gate.
+            qml.Hadamard(wires=0)
+
+            # Alice measures her qubits, obtaining one of four results, and sends this information to Bob.
+            m_0 = qml.mid_measure(0)
+            m_1 = qml.mid_measure(1)
+
+            # Given Alice's measurements, Bob performs one of four operations on his half of the EPR pair and
+            # recovers the original quantum state.
+            qml.if_then(m_1, qml.RX)(math.pi, wires=2)
+            qml.if_then(m_0, qml.RZ)(math.pi, wires=2)
+
+            return qml.probs(wires=2)
+
+        normal_probs = normal_circuit(r)
+        teleported_probs = teleportation_circuit(r)
+
+        assert np.linalg.norm(normal_probs - teleported_probs) < 0.01


### PR DESCRIPTION
Targets the branch used in https://github.com/PennyLaneAI/pennylane/pull/2134/ to showcase the diff.

Example
```python
        @qml.qnode(dev)
        @qml.defer_measurements
        def teleportation_circuit(rads):

            # Create Alice's secret qubit state
            qml.RY(rads, wires=0)

            # create an EPR pair with wires 1 and 2. 1 is held by Alice and 2 held by Bob
            qml.Hadamard(wires=1)
            qml.CNOT(wires=[1, 2])

            # Alice sends her qubits through a CNOT gate.
            qml.CNOT(wires=[0, 1])

            # Alice then sends the first qubit through a Hadamard gate.
            qml.Hadamard(wires=0)

            # Alice measures her qubits, obtaining one of four results, and sends this information to Bob.
            m_0 = qml.mid_measure(0)
            m_1 = qml.mid_measure(1)

            # Given Alice's measurements, Bob performs one of four operations on his half of the EPR pair and
            # recovers the original quantum state.
            qml.if_then(m_1, qml.RX)(math.pi, wires=2)
            qml.if_then(m_0, qml.RZ)(math.pi, wires=2)

            return qml.probs(wires=2)
```