### PR TITLE
Partition the Pauli group into qubit-wise commuting terms

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -24,6 +24,42 @@
 
 <h3>Improvements</h3>
 
+* Added a new `partition_pauli_group` function to the `grouping` module for
+  efficiently measuring the `N`-qubit Pauli group with `3 ** N`
+  qubit-wise commuting terms.
+  [(#2185)](https://github.com/PennyLaneAI/pennylane/pull/2185)
+  
+  ```pycon
+  >>> qml.grouping.partition_pauli_group(3)
+  [['III', 'IIZ', 'IZI', 'IZZ', 'ZII', 'ZIZ', 'ZZI', 'ZZZ'],
+   ['IIX', 'IZX', 'ZIX', 'ZZX'],
+   ['IIY', 'IZY', 'ZIY', 'ZZY'],
+   ['IXI', 'IXZ', 'ZXI', 'ZXZ'],
+   ['IXX', 'ZXX'],
+   ['IXY', 'ZXY'],
+   ['IYI', 'IYZ', 'ZYI', 'ZYZ'],
+   ['IYX', 'ZYX'],
+   ['IYY', 'ZYY'],
+   ['XII', 'XIZ', 'XZI', 'XZZ'],
+   ['XIX', 'XZX'],
+   ['XIY', 'XZY'],
+   ['XXI', 'XXZ'],
+   ['XXX'],
+   ['XXY'],
+   ['XYI', 'XYZ'],
+   ['XYX'],
+   ['XYY'],
+   ['YII', 'YIZ', 'YZI', 'YZZ'],
+   ['YIX', 'YZX'],
+   ['YIY', 'YZY'],
+   ['YXI', 'YXZ'],
+   ['YXX'],
+   ['YXY'],
+   ['YYI', 'YYZ'],
+   ['YYX'],
+   ['YYY']]
+  ```
+
 <h3>Breaking changes</h3>
 
 * The `MultiControlledX` operation now accepts a single `wires` keyword argument for both `control_wires` and `wires`.

--- a/pennylane/grouping/__init__.py
+++ b/pennylane/grouping/__init__.py
@@ -38,4 +38,4 @@ from .utils import (
     observables_to_binary_matrix,
     qwc_complement_adj_matrix,
 )
-from .pauli import pauli_group, pauli_mult, pauli_mult_with_phase
+from .pauli import pauli_group, pauli_mult, pauli_mult_with_phase, partition_pauli_group

--- a/pennylane/grouping/pauli.py
+++ b/pennylane/grouping/pauli.py
@@ -300,9 +300,17 @@ def partition_pauli_group(n_qubits: int) -> List[List[str]]:
      ['YYX'],
      ['YYY']]
     """
-    strings = set()
+    strings = set()  # tracks all the strings that have already been grouped
     groups = []
 
+    # We know that I and Z always commute on a given qubit. The following generates all product
+    # sequences of len(n_qubits) over "FXYZ", with F indicating a free slot that can be swapped for
+    # the product over I and Z, and all other terms fixed to the given X/Y/Z. For example, if
+    # ``n_qubits = 3`` our first value for ``string`` will be ``('F', 'F', 'F')``. We then expand
+    # the product of I and Z over the three free slots, giving
+    # ``['III', 'IIZ', 'IZI', 'IZZ', 'ZII', 'ZIZ', 'ZZI', 'ZZZ']``, which is our first group. The
+    # next element of ``string`` will be ``('F', 'F', 'X')`` which we use to generate our second
+    # group ``['IIX', 'IZX', 'ZIX', 'ZZX']``.
     for string in itertools.product("FXYZ", repeat=n_qubits):
         if string not in strings:
             num_free_slots = string.count("F")
@@ -314,7 +322,7 @@ def partition_pauli_group(n_qubits: int) -> List[List[str]]:
                 commuting_string = list(commuting_string)
                 new_string = tuple(commuting_string.pop(0) if s == "F" else s for s in string)
 
-                if new_string not in strings:
+                if new_string not in strings:  # only add if string has not already been grouped
                     group.append("".join(new_string))
                     strings |= {new_string}
 

--- a/pennylane/grouping/pauli.py
+++ b/pennylane/grouping/pauli.py
@@ -15,19 +15,19 @@
 Functions for constructing the :math:`n`-qubit Pauli group, and performing the
 group operation (multiplication).
 """
-from functools import lru_cache
 import itertools
+from functools import lru_cache
 from typing import List
 
 import numpy as np
 
 from pennylane import Identity
 from pennylane.grouping.utils import (
+    _wire_map_from_pauli_pair,
+    are_identical_pauli_words,
     binary_to_pauli,
     pauli_to_binary,
     pauli_word_to_string,
-    are_identical_pauli_words,
-    _wire_map_from_pauli_pair,
 )
 
 

--- a/pennylane/grouping/pauli.py
+++ b/pennylane/grouping/pauli.py
@@ -267,7 +267,7 @@ def partition_pauli_group(n_qubits: int) -> List[List[str]]:
 
     Returns:
         List[List[str]]: A collection of qubit-wise commuting groups containing Pauli words as
-        simple strings
+        strings
 
     **Example**
 

--- a/pennylane/grouping/pauli.py
+++ b/pennylane/grouping/pauli.py
@@ -300,6 +300,18 @@ def partition_pauli_group(n_qubits: int) -> List[List[str]]:
      ['YYX'],
      ['YYY']]
     """
+    # Cover the case where n_qubits may be passed as a float
+    if isinstance(n_qubits, float):
+        if n_qubits.is_integer():
+            n_qubits = int(n_qubits)
+
+    # If not an int, or a float representing a int, raise an error
+    if not isinstance(n_qubits, int):
+        raise TypeError("Must specify an integer number of qubits.")
+
+    if n_qubits <= 0:
+        raise ValueError("Number of qubits must be at least 1.")
+
     strings = set()  # tracks all the strings that have already been grouped
     groups = []
 

--- a/tests/grouping/test_pauli_group.py
+++ b/tests/grouping/test_pauli_group.py
@@ -238,7 +238,7 @@ class TestPartitionPauliGroup:
             ["YYX"],
             ["YYY"],
         ]
-        assert expected == partition_pauli_group(3)
+        assert expected == partition_pauli_group(3.0)
 
     @pytest.mark.parametrize("n", range(1, 9))
     def test_scaling(self, n):
@@ -257,3 +257,11 @@ class TestPartitionPauliGroup:
                     w1 = string_to_pauli_word(s1)
                     w2 = string_to_pauli_word(s2)
                     assert is_commuting(w1, w2)
+
+    def test_pauli_group_invalid_input(self):
+        """Test that invalid inputs to the Pauli group are handled correctly."""
+        with pytest.raises(TypeError, match="Must specify an integer number"):
+            partition_pauli_group("3")
+
+        with pytest.raises(ValueError, match="Number of qubits must be at least 1"):
+            partition_pauli_group(-1)

--- a/tests/grouping/test_pauli_group.py
+++ b/tests/grouping/test_pauli_group.py
@@ -15,15 +15,15 @@
 Unit tests for the :mod:`pauli_group`  functions in ``grouping/pauli.py``.
 """
 import pytest
-from pennylane import Identity, PauliX, PauliY, PauliZ
 
+from pennylane import Identity, PauliX, PauliY, PauliZ
+from pennylane.grouping import is_commuting, string_to_pauli_word
 from pennylane.grouping.pauli import (
+    partition_pauli_group,
     pauli_group,
     pauli_mult,
     pauli_mult_with_phase,
-    partition_pauli_group,
 )
-from pennylane.grouping import string_to_pauli_word, is_commuting
 
 
 class TestPauliGroup:

--- a/tests/grouping/test_pauli_group.py
+++ b/tests/grouping/test_pauli_group.py
@@ -258,8 +258,8 @@ class TestPartitionPauliGroup:
                     w2 = string_to_pauli_word(s2)
                     assert is_commuting(w1, w2)
 
-    def test_pauli_group_invalid_input(self):
-        """Test that invalid inputs to the Pauli group are handled correctly."""
+    def test_invalid_input(self):
+        """Test that invalid inputs are handled correctly."""
         with pytest.raises(TypeError, match="Must specify an integer number"):
             partition_pauli_group("3")
 

--- a/tests/grouping/test_pauli_group.py
+++ b/tests/grouping/test_pauli_group.py
@@ -17,7 +17,13 @@ Unit tests for the :mod:`pauli_group`  functions in ``grouping/pauli.py``.
 import pytest
 from pennylane import Identity, PauliX, PauliY, PauliZ
 
-from pennylane.grouping.pauli import pauli_group, pauli_mult, pauli_mult_with_phase
+from pennylane.grouping.pauli import (
+    pauli_group,
+    pauli_mult,
+    pauli_mult_with_phase,
+    partition_pauli_group,
+)
+from pennylane.grouping import string_to_pauli_word, is_commuting
 
 
 class TestPauliGroup:
@@ -196,3 +202,58 @@ class TestPauliGroup:
         """Test that multiplication including phases works as expected."""
         _, obtained_phase = pauli_mult_with_phase(pauli_word_1, pauli_word_2, wire_map=wire_map)
         assert obtained_phase == expected_phase
+
+
+class TestPartitionPauliGroup:
+    """Tests for the partition_pauli_group function"""
+
+    def test_expected_answer(self):
+        """Test if we get the expected answer for 3 qubits"""
+        expected = [
+            ["III", "IIZ", "IZI", "IZZ", "ZII", "ZIZ", "ZZI", "ZZZ"],
+            ["IIX", "IZX", "ZIX", "ZZX"],
+            ["IIY", "IZY", "ZIY", "ZZY"],
+            ["IXI", "IXZ", "ZXI", "ZXZ"],
+            ["IXX", "ZXX"],
+            ["IXY", "ZXY"],
+            ["IYI", "IYZ", "ZYI", "ZYZ"],
+            ["IYX", "ZYX"],
+            ["IYY", "ZYY"],
+            ["XII", "XIZ", "XZI", "XZZ"],
+            ["XIX", "XZX"],
+            ["XIY", "XZY"],
+            ["XXI", "XXZ"],
+            ["XXX"],
+            ["XXY"],
+            ["XYI", "XYZ"],
+            ["XYX"],
+            ["XYY"],
+            ["YII", "YIZ", "YZI", "YZZ"],
+            ["YIX", "YZX"],
+            ["YIY", "YZY"],
+            ["YXI", "YXZ"],
+            ["YXX"],
+            ["YXY"],
+            ["YYI", "YYZ"],
+            ["YYX"],
+            ["YYY"],
+        ]
+        assert expected == partition_pauli_group(3)
+
+    @pytest.mark.parametrize("n", range(1, 9))
+    def test_scaling(self, n):
+        """Test if the number of groups is equal to 3**n"""
+        assert len(partition_pauli_group(n)) == 3**n
+
+    @pytest.mark.parametrize("n", range(1, 6))
+    def test_is_qwc(self, n):
+        """Test if each group contains only qubit-wise commuting terms"""
+        for group in partition_pauli_group(n):
+            size = len(group)
+            for i in range(size):
+                for j in range(i, size):
+                    s1 = group[i]
+                    s2 = group[j]
+                    w1 = string_to_pauli_word(s1)
+                    w2 = string_to_pauli_word(s2)
+                    assert is_commuting(w1, w2)


### PR DESCRIPTION
**Context:**

As part of the QCut module, we need to efficiently measure over the full N-qubit Pauli group. Although there are `4^N` terms, we can measure only `3^N` groups.

**Description of the Change:**

Added the `partition_pauli_group` function to the `grouping` module.

**Possible Drawbacks:**

The function returns Pauli words expressed as simple strings. This is sufficient for the QCut module's needs but some users may prefer the Pauli words as PL observables/tensors. Since the current implementation is sufficient for now, I propose to leave returning PL observables/tensors as a follow up addition.

Example:
```pycon
>>> qml.grouping.partition_pauli_group(3)
[['III', 'IIZ', 'IZI', 'IZZ', 'ZII', 'ZIZ', 'ZZI', 'ZZZ'],
 ['IIX', 'IZX', 'ZIX', 'ZZX'],
 ['IIY', 'IZY', 'ZIY', 'ZZY'],
 ['IXI', 'IXZ', 'ZXI', 'ZXZ'],
 ['IXX', 'ZXX'],
 ['IXY', 'ZXY'],
 ['IYI', 'IYZ', 'ZYI', 'ZYZ'],
 ['IYX', 'ZYX'],
 ['IYY', 'ZYY'],
 ['XII', 'XIZ', 'XZI', 'XZZ'],
 ['XIX', 'XZX'],
 ['XIY', 'XZY'],
 ['XXI', 'XXZ'],
 ['XXX'],
 ['XXY'],
 ['XYI', 'XYZ'],
 ['XYX'],
 ['XYY'],
 ['YII', 'YIZ', 'YZI', 'YZZ'],
 ['YIX', 'YZX'],
 ['YIY', 'YZY'],
 ['YXI', 'YXZ'],
 ['YXX'],
 ['YXY'],
 ['YYI', 'YYZ'],
 ['YYX'],
 ['YYY']]
```