### PR TITLE
[Prototype] Conditional Measurement Ops using MeasurementProcess 

### DIFF
--- a/pennylane/__init__.py
+++ b/pennylane/__init__.py
@@ -41,7 +41,7 @@ from pennylane.circuit_graph import CircuitGraph
 from pennylane.configuration import Configuration
 from pennylane.tracker import Tracker
 from pennylane.io import *
-from pennylane.measure import density_matrix, expval, probs, sample, state, var, measure
+from pennylane.measure import density_matrix, expval, probs, sample, state, var, mc_measure
 from pennylane.ops import *
 from pennylane.ops.qml_if import If
 from pennylane.templates import broadcast, layer

--- a/pennylane/__init__.py
+++ b/pennylane/__init__.py
@@ -41,8 +41,9 @@ from pennylane.circuit_graph import CircuitGraph
 from pennylane.configuration import Configuration
 from pennylane.tracker import Tracker
 from pennylane.io import *
-from pennylane.measure import density_matrix, expval, probs, sample, state, var
+from pennylane.measure import density_matrix, expval, probs, sample, state, var, measure
 from pennylane.ops import *
+from pennylane.ops.qml_if import If
 from pennylane.templates import broadcast, layer
 from pennylane.templates.embeddings import *
 from pennylane.templates.layers import *

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -877,21 +877,28 @@ class Device(abc.ABC):
 
             operation_name = o.name
 
-            if o.inverse:
-                # TODO: update when all capabilities keys changed to "supports_inverse_operations"
-                supports_inv = self.capabilities().get(
-                    "supports_inverse_operations", False
-                ) or self.capabilities().get("inverse_operations", False)
-                if not supports_inv:
+            if isinstance(o, qml.measure.MidCircuitMP):
+                if not self.supports_observable(operation_name):
                     raise DeviceError(
-                        f"The inverse of gates are not supported on device {self.short_name}"
+                        f"Mid-circuit measurement {operation_name} is not supported on device {self.short_name}"
                     )
-                operation_name = o.base_name
 
-            if not self.supports_operation(operation_name):
-                raise DeviceError(
-                    f"Gate {operation_name} not supported on device {self.short_name}"
-                )
+            else:
+                if o.inverse:
+                    # TODO: update when all capabilities keys changed to "supports_inverse_operations"
+                    supports_inv = self.capabilities().get(
+                        "supports_inverse_operations", False
+                    ) or self.capabilities().get("inverse_operations", False)
+                    if not supports_inv:
+                        raise DeviceError(
+                            f"The inverse of gates are not supported on device {self.short_name}"
+                        )
+                    operation_name = o.base_name
+
+                if not self.supports_operation(operation_name):
+                    raise DeviceError(
+                        f"Gate {operation_name} not supported on device {self.short_name}"
+                    )
 
         for o in observables:
             if isinstance(o, qml.measure.MeasurementProcess) and o.obs is not None:

--- a/pennylane/measure.py
+++ b/pennylane/measure.py
@@ -22,7 +22,7 @@ import copy
 import numpy as np
 
 import pennylane as qml
-from pennylane.operation import Expectation, Observable, Probability, Sample, State, Variance
+from pennylane.operation import Expectation, Observable, Probability, Sample, State, Variance, MCMeasure
 from pennylane.wires import Wires
 
 
@@ -221,6 +221,22 @@ class MeasurementProcess:
             )
 
         return hash(fingerprint)
+
+
+class MidCircuitMP(MeasurementProcess):
+    """This class handles measurement processes which occur during
+     the middle of a circuit. The idea is to provide functionality which
+     stores mid circuit results and apply projective operations"""
+
+    def __init__(self, return_type, obs=None, wires=None, eigvals=None):
+        self._run_time_value = None
+        self.measured = False  # keeps track of if the measurement has taken place or not
+        super().__init__(self, return_type, obs=None, wires=wires, eigvals=eigvals)
+
+
+def measure(wires):
+    """Measures the wires in the computational basis"""
+    return MidCircuitMP(MCMeasure, wires=qml.wires.Wires(wires))
 
 
 def expval(op):

--- a/pennylane/measure.py
+++ b/pennylane/measure.py
@@ -47,7 +47,6 @@ class MeasurementProcess:
     def __init__(self, return_type, obs=None, wires=None, eigvals=None):
         self.return_type = return_type
         self.obs = obs
-
         if wires is not None and obs is not None:
             raise ValueError("Cannot set the wires if an observable is provided.")
 
@@ -228,13 +227,12 @@ class MidCircuitMP(MeasurementProcess):
      the middle of a circuit. The idea is to provide functionality which
      stores mid circuit results and apply projective operations"""
 
-    def __init__(self, return_type, obs=None, wires=None, eigvals=None):
-        self._run_time_value = None
-        self.measured = False  # keeps track of if the measurement has taken place or not
-        super().__init__(self, return_type, obs=None, wires=wires, eigvals=eigvals)
+    def __init__(self, return_type, **kwargs):
+        self.run_time_value = None
+        super().__init__(return_type, **kwargs)
 
 
-def measure(wires):
+def mc_measure(wires):
     """Measures the wires in the computational basis"""
     return MidCircuitMP(MCMeasure, wires=qml.wires.Wires(wires))
 

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -165,6 +165,7 @@ class ObservableReturnTypes(Enum):
     Expectation = "expval"
     Probability = "probs"
     State = "state"
+    MCMeasure = "measure"
 
     def __repr__(self):
         """String representation of the return types."""
@@ -188,6 +189,10 @@ of all computational basis states."""
 
 State = ObservableReturnTypes.State
 """Enum: An enumeration which represents returning the state in the computational basis."""
+
+MCMeasure = ObservableReturnTypes.MCMeasure
+"""Enum: An enumeration which represents returning the result of a mid circuit measurement
+of some observable on some or all of the wires in the circuit."""
 
 # =============================================================================
 # Class property

--- a/pennylane/ops/__init__.py
+++ b/pennylane/ops/__init__.py
@@ -21,6 +21,7 @@ such as gates, state preparations and observables.
 from .cv import *
 from .qubit import *
 from .channel import *
+# from .qml_if import *
 
 from .cv import __all__ as _cv__all__
 from .cv import ops as _cv__ops__

--- a/pennylane/ops/qml_if.py
+++ b/pennylane/ops/qml_if.py
@@ -9,5 +9,5 @@ class If(Operation):
         self.m_val = m_val
         self.then_op = then_op
         self.else_op = else_op
-        wires = list({m_val.wire} | set(then_op.wires) | set(getattr(else_op, "wires", [])))
+        wires = list({m_val.wires} | set(then_op.wires) | set(getattr(else_op, "wires", [])))
         super().__init__(wires=wires)

--- a/pennylane/ops/qml_if.py
+++ b/pennylane/ops/qml_if.py
@@ -1,0 +1,13 @@
+from pennylane.operation import AnyWires, Operation
+
+
+class If(Operation):
+    """Condition operations on measurement results using this """
+    num_wires = AnyWires
+
+    def __init__(self, m_val, then_op, else_op=None):
+        self.m_val = m_val
+        self.then_op = then_op
+        self.else_op = else_op
+        wires = list({m_val.wire} | set(then_op.wires) | set(getattr(else_op, "wires", [])))
+        super().__init__(wires=wires)

--- a/pennylane/qnode.py
+++ b/pennylane/qnode.py
@@ -490,6 +490,7 @@ class QNode:
         params = self.tape.get_parameters(trainable_only=False)
         self.tape.trainable_params = qml.math.get_trainable_indices(params)
 
+        print(self._qfunc_output)
         if not isinstance(self._qfunc_output, Sequence):
             measurement_processes = (self._qfunc_output,)
         else:


### PR DESCRIPTION
Prototype for supporting conditional Operations using the measurement process class

These changes support the following example: 

```python 
dev = qml.device("default.qubit", wires=3)

@qml.qnode(dev)
def circuit():
    qml.Hadamard(wires=0)
    qml.CNOT(wires=[0, 1])

    m = qml.mc_measure(wires=0)

    qml.If(m, qml.PauliX(wires=2, do_queue=False))

    return m, qml.state()
```

```
>>> print(circuit())
(0, tensor([[1.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j]], requires_grad=True))
>>>
>>>  # or
>>>
>>> print(circuit())
(1, tensor([[0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 1.+0.j]], requires_grad=True))
```