### PR TITLE
Remove tapemethods from gradients

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -61,6 +61,11 @@
 
 <h3>Improvements</h3>
 
+* The `gradients` module has been streamlined and special-purpose functions
+  moved closer to their use cases. This does not change the behaviour for
+  users in any way.
+  [(#2200)](https://github.com/PennyLaneAI/pennylane/pull/2200)
+
 * Added a new `partition_pauli_group` function to the `grouping` module for
   efficiently measuring the `N`-qubit Pauli group with `3 ** N`
   qubit-wise commuting terms.

--- a/pennylane/gradients/finite_difference.py
+++ b/pennylane/gradients/finite_difference.py
@@ -24,7 +24,11 @@ from scipy.special import factorial
 
 import pennylane as qml
 
-from .gradient_transform import gradient_transform
+from .gradient_transform import (
+    gradient_transform,
+    _grad_method_validation,
+    _choose_params_with_methods,
+)
 
 
 @functools.lru_cache(maxsize=None)
@@ -300,10 +304,10 @@ def finite_diff(
         )
         return [], lambda _: np.zeros([tape.output_dim, len(tape.trainable_params)])
 
-    # TODO: replace the JacobianTape._grad_method_validation
-    # functionality before deprecation.
     if validate_params:
-        diff_methods = tape._grad_method_validation("numeric")
+        if "grad_method" not in tape._par_info[0]:
+            tape._update_gradient_info()
+        diff_methods = _grad_method_validation("numeric", tape)
     else:
         diff_methods = ["F" for i in tape.trainable_params]
 
@@ -330,9 +334,7 @@ def finite_diff(
         shifts = shifts[1:]
         coeffs = coeffs[1:]
 
-    # TODO: replace the JacobianTape._choose_params_with_methods
-    # functionality before deprecation.
-    method_map = dict(tape._choose_params_with_methods(diff_methods, argnum))
+    method_map = _choose_params_with_methods(diff_methods, argnum)
 
     for i, _ in enumerate(tape.trainable_params):
         if i not in method_map or method_map[i] == "0":

--- a/pennylane/gradients/gradient_transform.py
+++ b/pennylane/gradients/gradient_transform.py
@@ -19,6 +19,90 @@ import warnings
 import pennylane as qml
 from pennylane.transforms.tape_expand import expand_invalid_trainable
 
+def _grad_method_validation(method, tape):
+    """Validates if the gradient method requested is supported by the trainable
+    parameters of a tape, and returns the allowed parameter gradient methods.
+
+    This method will generate parameter gradient information for the given tape if it
+    has not already been generated, and then proceed to validate the gradient method.
+    In particular:
+
+    * An exception will be raised if there exist non-differentiable trainable
+      parameters on the tape.
+
+    * An exception will be raised if the Jacobian method is ``"analytic"`` but there
+      exist some trainable parameters on the tape that only support numeric differentiation.
+
+    If all validations pass, this method will return a tuple containing the allowed parameter
+    gradient methods for each trainable parameter.
+
+    Args:
+        method (str): the overall Jacobian differentiation method
+        tape (.JacobianTape): the tape with associated parameter information
+
+    Returns:
+        tuple[str, None]: the allowed parameter gradient methods for each trainable parameter
+    """
+
+    diff_methods = {
+        idx: info["grad_method"]
+        for idx, info in tape._par_info.items()
+        if idx in tape.trainable_params
+    }
+
+    # check and raise an error if any parameters are non-differentiable
+    nondiff_params = {idx for idx, g in diff_methods.items() if g is None}
+
+    if nondiff_params:
+        raise ValueError(f"Cannot differentiate with respect to parameter(s) {nondiff_params}")
+
+    numeric_params = {idx for idx, g in diff_methods.items() if g == "F"}
+
+    # If explicitly using analytic mode, ensure that all parameters
+    # support analytic differentiation.
+    if method == "analytic" and numeric_params:
+        raise ValueError(
+            f"The analytic gradient method cannot be used with the parameter(s) {numeric_params}."
+        )
+
+    return tuple(diff_methods.values())
+
+
+def _choose_params_with_methods(diff_methods, argnum):
+    """Chooses the trainable parameters to use for computing the Jacobian
+    by returning a map of their indices and differentiation methods.
+
+    When there are fewer parameters specified than the total number of
+    trainable parameters, the Jacobian is estimated by using the parameters
+    specified using the ``argnum`` keyword argument.
+
+    Args:
+        diff_methods (list): the ordered list of differentiation methods
+            for each parameter
+        argnum (int, list(int), None): Indices for argument(s) with respect
+            to which to compute the Jacobian.
+
+    Returns:
+        dict: map of the trainable parameter indices and
+        differentiation methods
+    """
+    if argnum is None:
+        return dict(enumerate(diff_methods))
+
+    if isinstance(argnum, int):
+        argnum = [argnum]
+
+    num_params = len(argnum)
+
+    if num_params == 0:
+        warnings.warn(
+            "No trainable parameters were specified for computing the Jacobian.",
+            UserWarning,
+        )
+        return {}
+
+    return {idx: diff_methods[idx] for idx in argnum}
+
 
 class gradient_transform(qml.batch_transform):
     """Decorator for defining quantum gradient transforms.

--- a/pennylane/gradients/gradient_transform.py
+++ b/pennylane/gradients/gradient_transform.py
@@ -19,6 +19,7 @@ import warnings
 import pennylane as qml
 from pennylane.transforms.tape_expand import expand_invalid_trainable
 
+
 def _grad_method_validation(method, tape):
     """Validates if the gradient method requested is supported by the trainable
     parameters of a tape, and returns the allowed parameter gradient methods.

--- a/pennylane/gradients/param_shift_hessian.py
+++ b/pennylane/gradients/param_shift_hessian.py
@@ -21,6 +21,7 @@ import numpy as np
 import pennylane as qml
 
 from .parameter_shift import _gradient_analysis
+from .gradient_transform import _grad_method_validation
 from .hessian_transform import hessian_transform
 
 
@@ -340,6 +341,6 @@ def param_shift_hessian(tape, f0=None):
             )
 
     _gradient_analysis(tape)
-    diff_methods = tape._grad_method_validation("analytic")  # pylint: disable=protected-access
+    diff_methods = _grad_method_validation("analytic", tape)
 
     return compute_hessian_tapes(tape, diff_methods, f0)

--- a/pennylane/gradients/parameter_shift.py
+++ b/pennylane/gradients/parameter_shift.py
@@ -21,7 +21,11 @@ import numpy as np
 
 import pennylane as qml
 
-from .gradient_transform import gradient_transform
+from .gradient_transform import (
+    gradient_transform,
+    _grad_method_validation,
+    _choose_params_with_methods,
+)
 from .finite_difference import finite_diff, generate_shifted_tapes
 from .general_shift_rules import _process_shifts
 
@@ -587,17 +591,12 @@ def param_shift(
 
     _gradient_analysis(tape)
     method = "analytic" if fallback_fn is None else "best"
-
-    # TODO: replace the JacobianTape._grad_method_validation
-    # functionality before deprecation.
-    diff_methods = tape._grad_method_validation(method)
+    diff_methods = _grad_method_validation(method, tape)
 
     if all(g == "0" for g in diff_methods):
         return [], lambda _: np.zeros([tape.output_dim, len(tape.trainable_params)])
 
-    # TODO: replace the JacobianTape._choose_params_with_methods
-    # functionality before deprecation.
-    method_map = dict(tape._choose_params_with_methods(diff_methods, argnum))
+    method_map = _choose_params_with_methods(diff_methods, argnum)
 
     # If there are unsupported operations, call the fallback gradient function
     gradient_tapes = []

--- a/pennylane/gradients/parameter_shift_cv.py
+++ b/pennylane/gradients/parameter_shift_cv.py
@@ -23,7 +23,11 @@ import numpy as np
 
 import pennylane as qml
 
-from .gradient_transform import gradient_transform
+from .gradient_transform import (
+    gradient_transform,
+    _grad_method_validation,
+    _choose_params_with_methods,
+)
 from .finite_difference import finite_diff, generate_shifted_tapes
 from .parameter_shift import expval_param_shift, _get_operation_recipe
 from .general_shift_rules import _process_shifts
@@ -646,7 +650,6 @@ def param_shift_cv(
         )
 
     _gradient_analysis(tape)
-
     gradient_tapes = []
     shapes = []
     fns = []
@@ -666,16 +669,13 @@ def param_shift_cv(
         shapes.append(len(data[0]))
         fns.append(data[1])
 
-    # TODO: replace the JacobianTape._grad_method_validation
-    # functionality before deprecation.
-    diff_methods = tape._grad_method_validation("analytic" if fallback_fn is None else "best")
+    method = "analytic" if fallback_fn is None else "best"
+    diff_methods = _grad_method_validation(method, tape)
     all_params_grad_method_zero = all(g == "0" for g in diff_methods)
     if all_params_grad_method_zero:
         return gradient_tapes, lambda _: np.zeros([tape.output_dim, len(tape.trainable_params)])
 
-    # TODO: replace the JacobianTape._choose_params_with_methods
-    # functionality before deprecation.
-    method_map = dict(tape._choose_params_with_methods(diff_methods, argnum))
+    method_map = _choose_params_with_methods(diff_methods, argnum)
     var_present = any(m.return_type is qml.operation.Variance for m in tape.measurements)
 
     unsupported_params = []

--- a/tests/gradients/test_gradient_transform.py
+++ b/tests/gradients/test_gradient_transform.py
@@ -16,7 +16,78 @@ import pytest
 
 import pennylane as qml
 from pennylane import numpy as np
-from pennylane.gradients.gradient_transform import gradient_transform
+from pennylane.gradients.gradient_transform import (
+    gradient_transform,
+    _choose_params_with_methods,
+    _grad_method_validation,
+)
+
+
+class TestGradMethodValidation:
+    """Test the helper function _grad_method_validation, which is a
+    reduced copy of the eponymous method of ``JacobianTape``."""
+
+    @pytest.mark.parametrize("method", ["analytic", "best"])
+    def test_with_nondiff_parameters(self, method):
+        """Test that trainable parameters without grad_method
+        are detected correctly, raising an exception."""
+        with qml.tape.JacobianTape() as tape:
+            qml.RX(np.array(0.1, requires_grad=True), wires=0)
+            qml.RX(np.array(0.1, requires_grad=True), wires=0)
+            qml.expval(qml.PauliZ(0))
+        tape._par_info[0]["grad_method"] = "A"
+        tape._par_info[1]["grad_method"] = None
+        with pytest.raises(ValueError, match="Cannot differentiate with respect"):
+            _grad_method_validation(method, tape)
+
+    def test_with_numdiff_parameters_and_analytic(self):
+        """Test that trainable parameters with numerical grad_method ``"F"``
+        together with ``method="analytic"`` raises an exception."""
+        with qml.tape.JacobianTape() as tape:
+            qml.RX(np.array(0.1, requires_grad=True), wires=0)
+            qml.RX(np.array(0.1, requires_grad=True), wires=0)
+            qml.expval(qml.PauliZ(0))
+        tape._par_info[0]["grad_method"] = "A"
+        tape._par_info[1]["grad_method"] = "F"
+        with pytest.raises(ValueError, match="The analytic gradient method cannot be used"):
+            _grad_method_validation("analytic", tape)
+
+
+class TestChooseParamsWithMethods:
+    """Test the helper function _choose_params_with_methods, which is a
+    reduced copy of the eponymous method of ``JacobianTape``."""
+
+    all_diff_methods = [
+        ["A"] * 2,
+        [None, "A", "F", "A"],
+        ["F"],
+        ["0", "A"],
+    ]
+
+    @pytest.mark.parametrize("diff_methods", all_diff_methods)
+    def test_without_argnum(self, diff_methods):
+        """Test that the method returns all diff_methods when
+        used with ``argnum=None``."""
+        chosen = _choose_params_with_methods(diff_methods, None)
+        assert chosen == dict(enumerate(diff_methods))
+
+    @pytest.mark.parametrize(
+        "diff_methods, argnum, expected",
+        zip(all_diff_methods, [1, 2, 0, 0], [{1: "A"}, {2: "F"}, {0: "F"}, {0: "0"}]),
+    )
+    def test_with_integer_argnum(self, diff_methods, argnum, expected):
+        """Test that the method returns the correct single diff_method when
+        used with an integer ``argnum``."""
+        chosen = _choose_params_with_methods(diff_methods, argnum)
+        assert chosen == expected
+
+    @pytest.mark.parametrize("diff_methods", all_diff_methods[:2] + [[]])
+    def test_warning_with_empty_argnum(self, diff_methods):
+        """Test that the method raises a warning when an empty iterable
+        is passed as ``argnum``."""
+        with pytest.warns(UserWarning, match="No trainable parameters were specified"):
+            chosen = _choose_params_with_methods(diff_methods, [])
+        assert chosen == {}
 
 
 class TestGradientTransformIntegration:

--- a/tests/gradients/test_parameter_shift_cv.py
+++ b/tests/gradients/test_parameter_shift_cv.py
@@ -882,7 +882,7 @@ class TestVarianceQuantumGradients:
 
         tape.trainable_params = {0}
 
-        with pytest.raises(ValueError, match=r"cannot be used with the argument\(s\) \{0\}"):
+        with pytest.raises(ValueError, match=r"cannot be used with the parameter\(s\) \{0\}"):
             param_shift_cv(tape, dev, fallback_fn=None)
 
     def test_error_unsupported_grad_recipe(self, monkeypatch):
@@ -904,15 +904,14 @@ class TestVarianceQuantumGradients:
             DummyOp(1, wires=[0])
             qml.expval(qml.X(0))
 
-        with monkeypatch.context() as m:
-            m.setattr(tape, "_grad_method_validation", lambda *args: ("A",))
-            tape._par_info[0]["grad_method"] = "A"
-            tape.trainable_params = {0}
+        tape._gradient_fn = param_shift_cv
+        tape._par_info[0]["grad_method"] = "A"
+        tape.trainable_params = {0}
 
-            with pytest.raises(
-                NotImplementedError, match=r"analytic gradient for order-2 operators is unsupported"
-            ):
-                param_shift_cv(tape, dev, force_order2=True)
+        with pytest.raises(
+            NotImplementedError, match=r"analytic gradient for order-2 operators is unsupported"
+        ):
+            param_shift_cv(tape, dev, force_order2=True)
 
     @pytest.mark.parametrize("obs", [qml.X, qml.NumberOperator])
     @pytest.mark.parametrize(


### PR DESCRIPTION
This is the third PR in a row, after #2180 and #2182.

In this PR, the private methods `_choose_params_with_methods` and `_grad_method_validation` are copied from the `JacobianTape` into the `gradients` module to keep the code closer together and avoid usage of private methods. The copies are slightly reduced in code length.

