### PR TITLE
Deprecate `qml.finite_diff`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -124,6 +124,7 @@
   [(#2121)](https://github.com/PennyLaneAI/pennylane/pull/2121)
 
 <h3>Deprecations</h3>
+
 * A deprecation warning has been added to the `qml.finite_diff()` method.
   [#2212](https://github.com/PennyLaneAI/pennylane/pull/2212)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -124,6 +124,8 @@
   [(#2121)](https://github.com/PennyLaneAI/pennylane/pull/2121)
 
 <h3>Deprecations</h3>
+* A deprecation warning has been added to the `qml.finite_diff()` method.
+  [#2212](https://github.com/PennyLaneAI/pennylane/pull/2212)
 
 <h3>Bug fixes</h3>
 

--- a/pennylane/_grad.py
+++ b/pennylane/_grad.py
@@ -527,7 +527,7 @@ def finite_diff(f, N=1, argnum=0, idx=None, delta=0.01):
     warnings.warn(
         "The black-box finite_diff function will be deprecated, users can "
         "instead use qml.gradients.finite_diff to compute the gradient of "
-        "tapes or qnodes. Otherwise a manually implementation is required.",
+        "tapes or QNodes. Otherwise, manual implementation is required.",
         UserWarning,
     )
 

--- a/pennylane/_grad.py
+++ b/pennylane/_grad.py
@@ -524,6 +524,12 @@ def finite_diff(f, N=1, argnum=0, idx=None, delta=0.01):
     >>> print(second_derivative(x, y))
     -0.372062798810191
     """
+    warnings.warn(
+        "The black-box finite_diff function will be deprecated, users can "
+        "instead use qml.gradients.finite_diff to compute the gradient of "
+        "tapes or qnodes. Otherwise a manually implementation is required.",
+        UserWarning,
+    )
 
     if not callable(f):
         error_message = f"{type(f)} object is not callable. \n'f' should be a callable function"

--- a/tests/test_finite_diff.py
+++ b/tests/test_finite_diff.py
@@ -24,6 +24,14 @@ grad3 = np.array(
 )
 
 
+def catch_warn_finite_diff(f, N=1, argnum=0, idx=None, delta=0.01):
+    """Computes the finite diff and catches the initial deprecation warning."""
+
+    with pytest.warns(UserWarning, match="The black-box finite_diff function will be deprecated,"):
+        res = qml.finite_diff(f, N, argnum, idx, delta)
+    return res
+
+
 @pytest.mark.parametrize(
     ("x", "y", "argnum", "idx", "delta", "exp_grad"),
     [
@@ -47,7 +55,7 @@ def test_first_finit_diff(x, y, argnum, idx, delta, exp_grad):
     def f(x, y):
         return np.sin(x) / x**4 + y**-3
 
-    grad = qml.finite_diff(f, argnum=argnum, idx=idx, delta=delta)(x, y)
+    grad = catch_warn_finite_diff(f, argnum=argnum, idx=idx, delta=delta)(x, y)
 
     if grad.ndim != 0:
         idx = list(np.ndindex(*grad.shape))
@@ -86,7 +94,7 @@ def test_second_order_finite_diff(x, y, argnum, idx, delta, exp_deriv2):
     def f(x, y):
         return np.sin(x) / x**4 + y**-3
 
-    deriv2 = qml.finite_diff(f, N=2, argnum=argnum, idx=idx, delta=delta)(x, y)
+    deriv2 = catch_warn_finite_diff(f, N=2, argnum=argnum, idx=idx, delta=delta)(x, y)
 
     assert np.allclose(deriv2, exp_deriv2)
 
@@ -108,10 +116,10 @@ def test_exceptions_finite_diff(N, delta, func, msg_match):
 
     if N != 0:
         with pytest.raises(ValueError, match=msg_match):
-            qml.finite_diff(f, N=N, delta=delta)
+            catch_warn_finite_diff(f, N=N, delta=delta)
     elif N == 0:
         with pytest.raises(TypeError, match=msg_match):
-            qml.finite_diff(f(0.5), N=N, delta=delta)
+            catch_warn_finite_diff(f(0.5), N=N, delta=delta)
 
 
 @pytest.mark.parametrize(
@@ -140,11 +148,11 @@ def test_exceptions(which, argnum, idx, msg_match):
 
     if which == "both":
         with pytest.raises(ValueError, match=msg_match):
-            qml.finite_diff(f, argnum=argnum, idx=idx)(x, y)
+            catch_warn_finite_diff(f, argnum=argnum, idx=idx)(x, y)
 
         with pytest.raises(ValueError, match=msg_match):
-            qml.finite_diff(f, N=2, argnum=argnum, idx=idx)(x, y)
+            catch_warn_finite_diff(f, N=2, argnum=argnum, idx=idx)(x, y)
 
     if which == "second":
         with pytest.raises(ValueError, match=msg_match):
-            qml.finite_diff(f, N=2, argnum=argnum, idx=idx)(x, y)
+            catch_warn_finite_diff(f, N=2, argnum=argnum, idx=idx)(x, y)


### PR DESCRIPTION
**Context:**
Adding a deprecation warning for `qml.finite_diff` which will be removed in the next release. Users will be directed to use `qml.gradients.finite_diff`. 

**Description of the Change:**
Running the following code yields the following warning: 

```
>>> def f(x, y):
    ...     return np.sin(y[0])*np.sin(y[1]) - x**-3
    ...
>>>
>>> (x, y) = (0.376, np.array([1.975, 0.33, -0.4]))
>>>
>>> gradient = qml.finite_diff(f, argnum=1)

UserWarning: The black-box finite_diff function will be deprecated, 
users can instead use qml.gradients.finite_diff to compute the gradient 
of tapes or qnodes. Otherwise a manually implementation is required.

>>>
>>> print(gradient(x, y))

[-0.12744129189670161 0.8698027233702277]

>>>
```