### PR TITLE
Raise a deprecation warning if `Operator.decomposition` is a staticmethod

### DIFF
--- a/pennylane/gradients/gradient_transform.py
+++ b/pennylane/gradients/gradient_transform.py
@@ -47,7 +47,7 @@ def grad_method_validation(method, tape):
 
     diff_methods = {
         idx: info["grad_method"]
-        for idx, info in tape._par_info.items()
+        for idx, info in tape._par_info.items()  # pylint: disable=protected-access
         if idx in tape.trainable_params
     }
 

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -1263,7 +1263,22 @@ class Operation(Operator):
         tape = qml.tape.QuantumTape(do_queue=False)
 
         with tape:
-            self.decomposition()
+
+            try:
+                self.decomposition()
+
+            except TypeError:
+                if self.num_params == 0:
+                    self.decomposition(wires=self.wires)
+                else:
+                    self.decomposition(*self.parameters, wires=self.wires)
+
+                warnings.warn(
+                    "Operator.decomposition() is now an instance method, and no longer accepts parameters. "
+                    "Either define the static method 'compute_decomposition' instead, or use "
+                    "'self.wires' and 'self.parameters'.",
+                    UserWarning,
+                )
 
         if not self.data:
             # original operation has no trainable parameters

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -16,6 +16,7 @@ Unit tests for :mod:`pennylane.operation`.
 """
 import itertools
 from functools import reduce
+import warnings
 
 import pytest
 import numpy as np
@@ -1845,3 +1846,46 @@ class TestDeprecationWarnings:
             m1 = op.eigvals
 
         assert np.allclose(m1, op.get_eigvals())
+
+    def test_decomposition_deprecation(self):
+        """Test that old-style staticmethod decompositions raise a warning"""
+        dev = qml.device("default.qubit", wires=1)
+
+        class MyOp(Operation):
+            num_wires = 1
+            num_params = 2
+
+            @staticmethod
+            def decomposition(*params, wires):
+                qml.RY(params[0], wires=wires[0])
+                qml.PauliZ(wires=wires[0])
+                qml.RX(params[1], wires=wires[0])
+
+        @qml.qnode(dev)
+        def qnode(*params):
+            MyOp(*params, wires=0)
+            return qml.state()
+
+        with pytest.warns(UserWarning, match="is now an instance method"):
+            print(qnode(0.1, 0.2))
+
+        # using an instance method will not raise a deprecation warning
+
+        class MyOp(Operation):
+            num_wires = 1
+            num_params = 2
+
+            def decomposition(self):
+                qml.RY(self.parameters[0], wires=self.wires[0])
+                qml.PauliZ(wires=self.wires[0])
+                qml.RX(self.parameters[1], wires=self.wires[0])
+
+        @qml.qnode(dev)
+        def qnode(*params):
+            MyOp(*params, wires=0)
+            return qml.state()
+
+        with warnings.catch_warnings():
+            # any warnings emitted will be raised as errors
+            warnings.simplefilter("error")
+            print(qnode(0.1, 0.2))

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -1867,7 +1867,7 @@ class TestDeprecationWarnings:
             return qml.state()
 
         with pytest.warns(UserWarning, match="is now an instance method"):
-            print(qnode(0.1, 0.2))
+            result1 = qnode(0.1, 0.2)
 
         # using an instance method will not raise a deprecation warning
 
@@ -1888,4 +1888,6 @@ class TestDeprecationWarnings:
         with warnings.catch_warnings():
             # any warnings emitted will be raised as errors
             warnings.simplefilter("error")
-            print(qnode(0.1, 0.2))
+            result2 = qnode(0.1, 0.2)
+
+        assert np.allclose(result1, result2)


### PR DESCRIPTION
**Context:** As part of the recent operator refactor, the static method `Operator.decomposition` was renamed to `Operator.compute_decomposition`. The new `Operator.decomposition` is now an instance method.

**Description of the Change:** Adds a deprecation warning to alert developers to this change.

**Benefits:** As above.

**Possible Drawbacks:** n/a

**Related GitHub Issues:** Closes #2210 
