### PR TITLE
Modify JAX test to pass with JAX version 0.3.1

### DIFF
--- a/tests/math/test_is_abstract.py
+++ b/tests/math/test_is_abstract.py
@@ -150,9 +150,13 @@ class TestJAX:
         res = cost(x, w)
         assert res == 0.26
 
-        # since we only specify argnums=0, w will not be abstract
-        grad = jax.grad(cost, argnums=0)(x, w, w_is_abstract=False)
-        assert np.allclose(grad, 2 * x)
+        # NOTE: As of JAX 0.3.1, JAX will trace non-differentiated arguments.
+        # As a result, it is no longer possible to assume that non-differentiated
+        # arguments will not be abstract.
+
+        # # since we only specify argnums=0, w will not be abstract
+        # grad = jax.grad(cost, argnums=0)(x, w, w_is_abstract=False)
+        # assert np.allclose(grad, 2 * x)
 
         # Otherwise, w will be abstract
         grad = jax.grad(cost, argnums=[0, 1])(x, w, w_is_abstract=True)


### PR DESCRIPTION
**Context:** As of JAX 0.3.1, JAX will trace non-differentiated arguments. As a result, it is no longer possible to assume that non-differentiated arguments will not be abstract.

**Description of the Change:** Modify the test to add a note, and comment out an assertion that will no longer work with JAX 0.3.1

**Benefits:** Tests will pass with the latest JAX. No functionality in PL is dependent on this, so there is no 'breaking change' to report.

**Possible Drawbacks:** While this is not a 'breaking change', it is unfortunate. It means that the ability to inspect tensor values (e.g., during transforms or compilation) will not work with JAX even if it is a non-differentiated argument.

**Related GitHub Issues:** n/a
