### PR TITLE
Fix expansion of fragments tapes containing no `MeasureNode`

### DIFF
--- a/pennylane/transforms/qcut.py
+++ b/pennylane/transforms/qcut.py
@@ -382,6 +382,11 @@ def _get_measurements(
         over ``group`` and ``obs`` is the observable composing the single measurement
         in ``measurements``
     """
+    if len(group) == 0:
+        # This ensures the measurements of the original tape are carried over to the
+        # following tape configurations in the absence of any MeasureNodes in the fragment
+        return measurements
+
     n_measurements = len(measurements)
     if n_measurements > 1:
         raise ValueError(
@@ -524,12 +529,7 @@ def expand_fragment_tapes(
                         apply(op)
 
                 with qml.tape.stop_recording():
-                    if len(group) > 0:
-                        measurements = _get_measurements(group, tape.measurements)
-                    # This ensures the measurements of the original tape are carried over to the
-                    # following tape configurations in the absence of any MeasureNodes in the fragment
-                    else:
-                        measurements = tape.measurements
+                    measurements = _get_measurements(group, tape.measurements)
                 for meas in measurements:
                     apply(meas)
 

--- a/pennylane/transforms/qcut.py
+++ b/pennylane/transforms/qcut.py
@@ -524,8 +524,12 @@ def expand_fragment_tapes(
                         apply(op)
 
                 with qml.tape.stop_recording():
-                    measurements = _get_measurements(group, tape.measurements)
-
+                    if len(group) > 0:
+                        measurements = _get_measurements(group, tape.measurements)
+                    # This ensures the measurements of the original tape are carried over to the
+                    # following tape configurations in the absence of any MeasureNodes in the fragment
+                    else:
+                        measurements = tape.measurements
                 for meas in measurements:
                     apply(meas)
 

--- a/tests/transforms/test_qcut.py
+++ b/tests/transforms/test_qcut.py
@@ -1211,6 +1211,59 @@ class TestExpandFragmentTapes:
             for wire3_prep_op, wire3_exp_op in zip(wire3_prep_ops, wire3_exp):
                 assert type(wire3_prep_op) == wire3_exp_op
 
+    def test_no_measure_node_observables(self):
+        """
+        Tests that a fragment with no MeasureNodes give the correct
+        configurations
+        """
+
+        with qml.tape.QuantumTape() as frag:
+            qml.RY(0.543, wires=[1])
+            qcut.PrepareNode(wires=[0])
+            qml.CNOT(wires=[0, 1])
+            qml.RZ(0.24, wires=[0])
+            qml.RZ(0.133, wires=[1])
+            qml.expval(qml.PauliZ(wires=[0]))
+
+        expanded_tapes, prep_nodes, meas_nodes = qcut.expand_fragment_tapes(frag)
+
+        ops = [
+            qml.CNOT(wires=[0, 1]),
+            qml.RZ(0.24, wires=[0]),
+            qml.RZ(0.133, wires=[1]),
+            qml.expval(qml.PauliZ(wires=[0])),
+        ]
+
+        with qml.tape.QuantumTape() as config1:
+            qml.RY(0.543, wires=[1])
+            qml.Identity(wires=[0])
+            for optr in ops:
+                qml.apply(optr)
+
+        with qml.tape.QuantumTape() as config2:
+            qml.RY(0.543, wires=[1])
+            qml.PauliX(wires=[0])
+            for optr in ops:
+                qml.apply(optr)
+
+        with qml.tape.QuantumTape() as config3:
+            qml.RY(0.543, wires=[1])
+            qml.Hadamard(wires=[0])
+            for optr in ops:
+                qml.apply(optr)
+
+        with qml.tape.QuantumTape() as config4:
+            qml.RY(0.543, wires=[1])
+            qml.Hadamard(wires=[0])
+            qml.S(wires=[0])
+            for optr in ops:
+                qml.apply(optr)
+
+        expected_configs = [config1, config2, config3, config4]
+
+        for tape, config in zip(expanded_tapes, expected_configs):
+            compare_tapes(tape, config)
+
 
 class TestContractTensors:
     """Tests for the contract_tensors function"""


### PR DESCRIPTION
**Context:**
Fragment tapes of cut circuit need to be expanded to multiple configurations in order to execute and recombine results. However, the observables of fragments tapes containing no `MeasureNode` were being lost. 

**Description of the Change:**
This PR fixes the logic so that measurements of such fragments persist across the following configurations 

**Benefits:**
Fixes broken pipeline for this specific case

**Related GitHub Issues:**
Blocker for #2216 