### PR TITLE
Update  `MeasureNode` and `PrepareNode`operation identifiers 

### DIFF
--- a/tests/transforms/test_qcut.py
+++ b/tests/transforms/test_qcut.py
@@ -165,15 +165,14 @@ def test_node_ids(monkeypatch):
     """
     Tests that the `MeasureNode` and `PrepareNode` return the correct id
     """
+    with monkeypatch.context() as m:
+        m.setattr("uuid.uuid4", lambda: "some_string")
 
-    monkeypatch.setattr(qcut.MeasureNode, "id", "measure_id_string")
-    monkeypatch.setattr(qcut.PrepareNode, "id", "prepare_id_string")
+        mn = qcut.MeasureNode(wires=0)
+        pn = qcut.PrepareNode(wires=0)
 
-    mn = qcut.MeasureNode(wires=0)
-    pn = qcut.PrepareNode(wires=0)
-
-    assert mn.id == "measure_id_string"
-    assert pn.id == "prepare_id_string"
+        assert mn.id == "some_string"
+        assert pn.id == "some_string"
 
 
 class TestTapeToGraph:

--- a/tests/transforms/test_qcut.py
+++ b/tests/transforms/test_qcut.py
@@ -1311,9 +1311,9 @@ class TestContractTensors:
 
     t = [np.arange(4), np.arange(4, 8)]
     # make copies of nodes to ensure id comparisons work correctly
-    m = [[copy.copy(qcut.MeasureNode(wires=0))], []]
-    p = [[], [copy.copy(qcut.PrepareNode(wires=0))]]
-    edge_dict = {"pair": (m[0][0], p[1][0])}
+    m = [[qcut.MeasureNode(wires=0)], []]
+    p = [[], [qcut.PrepareNode(wires=0)]]
+    edge_dict = {"pair": (copy.copy(m)[0][0], copy.copy(p)[1][0])}
     g = MultiDiGraph([(0, 1, edge_dict)])
     expected_result = np.dot(*t)
 


### PR DESCRIPTION
**Context:**
In the circuit cutting workflow we have `MeasureNode` and `PrepareNode` operations to indicate where physical measurements and state preparations should occur.  These nodes are copied in the cutting workflow so as not to mutate the original circuit. This can later lead to problems with comparing node instances.

**Description of the Change:**
The operation classes of each have been update to provide an `id` attribute which an be used to compare 

**Benefits:**
Allows for comparison of node operations that isn't reliant on memory locations.
