### PR TITLE
Fix gradient transform output shape for 2D QNode outputs

### DIFF
--- a/pennylane/gradients/finite_difference.py
+++ b/pennylane/gradients/finite_difference.py
@@ -382,6 +382,8 @@ def finite_diff(
             if hasattr(g, "dtype") and g.dtype is np.dtype("object"):
                 grads[i] = qml.math.hstack(g)
 
-        return qml.math.T(qml.math.stack(grads))
+        grads = qml.math.stack(grads)
+        new_shape = qml.math.shape(grads)[1:] + (qml.math.shape(grads)[0],)
+        return qml.math.reshape(qml.math.T(grads), new_shape)
 
     return gradient_tapes, processing_fn

--- a/pennylane/gradients/parameter_shift.py
+++ b/pennylane/gradients/parameter_shift.py
@@ -274,7 +274,9 @@ def expval_param_shift(tape, argnum=None, shifts=None, gradient_recipes=None, f0
             if hasattr(g, "dtype") and g.dtype is np.dtype("object"):
                 grads[i] = qml.math.hstack(g)
 
-        return qml.math.T(qml.math.stack(grads))
+        grads = qml.math.stack(grads)
+        new_shape = qml.math.shape(grads)[1:] + (qml.math.shape(grads)[0],)
+        return qml.math.reshape(qml.math.T(grads), new_shape)
 
     return gradient_tapes, processing_fn
 

--- a/pennylane/gradients/parameter_shift_cv.py
+++ b/pennylane/gradients/parameter_shift_cv.py
@@ -465,7 +465,9 @@ def second_order_param_shift(tape, dev_wires, argnum=None, shifts=None, gradient
             if hasattr(g, "dtype") and g.dtype is np.dtype("object"):
                 grads[i] = qml.math.hstack(g)
 
-        return qml.math.T(qml.math.stack(grads))
+        grads = qml.math.stack(grads)
+        new_shape = qml.math.shape(grads)[1:] + (qml.math.shape(grads)[0],)
+        return qml.math.reshape(qml.math.T(grads), new_shape)
 
     return gradient_tapes, processing_fn
 

--- a/tests/gradients/test_finite_difference.py
+++ b/tests/gradients/test_finite_difference.py
@@ -285,6 +285,19 @@ class TestFiniteDiff:
         assert np.allclose(j1, [exp, 0])
         assert np.allclose(j2, [0, exp])
 
+    def test_correct_2d_output_shape(self):
+        """Test that the finite diff transform does not swap QNode output dimensions."""
+        dev = qml.device("default.qubit", wires=4)
+
+        @qml.qnode(dev)
+        def circuit(params):
+            qml.Rot(*params, wires=0)
+            return [qml.probs([0, 1]), qml.probs([2, 3])]
+
+        params = np.array([0.5, 0.5, 0.5], requires_grad=True)
+        result = qml.gradients.finite_diff(circuit)(params)
+        assert result.shape == (2, 4, len(params))
+
 
 @pytest.mark.parametrize("approx_order", [2, 4])
 @pytest.mark.parametrize("strategy", ["forward", "backward", "center"])

--- a/tests/gradients/test_parameter_shift.py
+++ b/tests/gradients/test_parameter_shift.py
@@ -372,6 +372,19 @@ class TestParamShift:
         grad = fn(dev.batch_execute(tapes))
         assert np.allclose(grad, -np.sin(x))
 
+    def test_correct_2d_output_shape(self):
+        """Test that the parameter shift transform does not swap QNode output dimensions."""
+        dev = qml.device("default.qubit", wires=4)
+
+        @qml.qnode(dev)
+        def circuit(params):
+            qml.Rot(*params, wires=0)
+            return [qml.probs([0, 1]), qml.probs([2, 3])]
+
+        params = np.array([0.5, 0.5, 0.5], requires_grad=True)
+        result = qml.gradients.param_shift(circuit)(params)
+        assert result.shape == (2, 4, len(params))
+
 
 class TestParameterShiftRule:
     """Tests for the parameter shift implementation"""


### PR DESCRIPTION
Fixes a bug in `qml.gradients.param_shift` that transposes the QNode output dimensions in the returned tensor:

https://github.com/PennyLaneAI/pennylane/blob/e1b15d27cc5a4a882b552c936580dd903fe3b988/pennylane/gradients/parameter_shift.py#L277

The following example demonstrates the issue:

```py
dev = qml.device('default.qubit', wires=4)
@qml.qnode(dev)
def circuit(params):
    qml.Rot(*params, wires=0)
    return [qml.probs([0,1]), qml.probs([2,3])]

params = np.array([0.5, 0.5, 0.5], requires_grad=True)
qml.gradients.param_shift(circuit)(params).shape
```
```py
>>> (4, 2, 3)
```
where the QNode output dimensions are `(4, 2)` instead of `(2, 4)`.

---

~~Also fixes a bug in `qml.gradients.param_shift_hessian` [...]~~

Edit: 2nd fix has been moved to #2299
