### PR TITLE
Fix bug to allow `qml.ctrl` to work with gradient transforms

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -147,7 +147,7 @@
 
 * The ``qml.ctrl`` transform now works correctly with gradient transforms
   such as the parameter-shift rule.
-  [(#)](https://github.com/PennyLaneAI/pennylane/pull/)
+  [(#2238)](https://github.com/PennyLaneAI/pennylane/pull/2238)
 
 * Fixes a bug in which passing required arguments into operations as
   keyword arguments would throw an error because the documented call

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -145,6 +145,10 @@
 
 <h3>Bug fixes</h3>
 
+* The ``qml.ctrl`` transform now works correctly with gradient transforms
+  such as the parameter-shift rule.
+  [(#)](https://github.com/PennyLaneAI/pennylane/pull/)
+
 * Fixes a bug in which passing required arguments into operations as
   keyword arguments would throw an error because the documented call
   signature didn't match the function definition.

--- a/pennylane/transforms/control.py
+++ b/pennylane/transforms/control.py
@@ -83,6 +83,7 @@ class ControlledOperation(Operation):
         control_wires: A wire or set of wires.
     """
 
+    grad_method = None
     num_wires = AnyWires
 
     def __init__(self, tape, control_wires, do_queue=True):
@@ -105,8 +106,11 @@ class ControlledOperation(Operation):
 
     def expand(self):
         tape = self.subtape
+        tape.set_parameters(self.data)
+
         for wire in self.control_wires:
             tape = expand_with_control(tape, wire)
+
         return tape
 
     def adjoint(self):

--- a/tests/transforms/test_control.py
+++ b/tests/transforms/test_control.py
@@ -311,7 +311,7 @@ def test_controlled_template_and_operations():
     assert all(o.name in {"CNOT", "CRX", "Toffoli"} for o in tape.operations)
 
 
-@pytest.mark.parametrize("diff_method", ["backprop", "parameter-shift"])
+@pytest.mark.parametrize("diff_method", ["backprop", "parameter-shift", "finite-diff"])
 class TestDifferentiation:
     """Tests for differentiation"""
 

--- a/tests/transforms/test_control.py
+++ b/tests/transforms/test_control.py
@@ -309,3 +309,92 @@ def test_controlled_template_and_operations():
     tape = expand_tape(tape)
     assert len(tape.operations) == 10
     assert all(o.name in {"CNOT", "CRX", "Toffoli"} for o in tape.operations)
+
+
+@pytest.mark.parametrize("diff_method", ["backprop", "parameter-shift"])
+class TestDifferentiation:
+    """Tests for differentiation"""
+
+    def test_autograd(self, diff_method):
+        """Test differentiation using autograd"""
+        from pennylane import numpy as pnp
+
+        dev = qml.device("default.qubit", wires=2)
+        init_state = pnp.array([1.0, -1.0], requires_grad=False) / np.sqrt(2)
+
+        @qml.qnode(dev, diff_method=diff_method)
+        def circuit(b):
+            qml.QubitStateVector(init_state, wires=0)
+            qml.ctrl(qml.RY, control=0)(b, wires=[1])
+            return qml.expval(qml.PauliX(0))
+
+        b = pnp.array(0.123, requires_grad=True)
+        res = qml.grad(circuit)(b)
+        expected = np.sin(b / 2) / 2
+
+        assert np.allclose(res, expected)
+
+    def test_torch(self, diff_method):
+        """Test differentiation using torch"""
+        torch = pytest.importorskip("torch")
+
+        dev = qml.device("default.qubit", wires=2)
+        init_state = torch.tensor([1.0, -1.0], requires_grad=False) / np.sqrt(2)
+
+        @qml.qnode(dev, diff_method=diff_method, interface="torch")
+        def circuit(b):
+            qml.QubitStateVector(init_state, wires=0)
+            qml.ctrl(qml.RY, control=0)(b, wires=[1])
+            return qml.expval(qml.PauliX(0))
+
+        b = torch.tensor(0.123, requires_grad=True)
+        loss = circuit(b)
+        loss.backward()
+
+        res = b.grad.detach()
+        expected = np.sin(b.detach() / 2) / 2
+
+        assert np.allclose(res, expected)
+
+    def test_jax(self, diff_method):
+        """Test differentiation using JAX"""
+        jax = pytest.importorskip("jax")
+        jnp = jax.numpy
+
+        dev = qml.device("default.qubit", wires=2)
+
+        @qml.qnode(dev, diff_method=diff_method, interface="jax")
+        def circuit(b):
+            init_state = np.array([1.0, -1.0]) / np.sqrt(2)
+            qml.QubitStateVector(init_state, wires=0)
+            qml.ctrl(qml.RY, control=0)(b, wires=[1])
+            return qml.expval(qml.PauliX(0))
+
+        b = jnp.array(0.123)
+        res = jax.grad(circuit)(b)
+        expected = np.sin(b / 2) / 2
+
+        assert np.allclose(res, expected)
+
+    def test_tf(self, diff_method):
+        """Test differentiation using TF"""
+        tf = pytest.importorskip("tensorflow")
+
+        dev = qml.device("default.qubit", wires=2)
+        init_state = tf.constant([1.0, -1.0], dtype=tf.complex128) / np.sqrt(2)
+
+        @qml.qnode(dev, diff_method=diff_method, interface="tf")
+        def circuit(b):
+            qml.QubitStateVector(init_state, wires=0)
+            qml.ctrl(qml.RY, control=0)(b, wires=[1])
+            return qml.expval(qml.PauliX(0))
+
+        b = tf.Variable(0.123, dtype=tf.float64)
+
+        with tf.GradientTape() as tape:
+            loss = circuit(b)
+
+        res = tape.gradient(loss, b)
+        expected = np.sin(b / 2) / 2
+
+        assert np.allclose(res, expected)

--- a/tests/transforms/test_control.py
+++ b/tests/transforms/test_control.py
@@ -356,14 +356,19 @@ class TestDifferentiation:
 
         assert np.allclose(res, expected)
 
-    def test_jax(self, diff_method):
+    @pytest.mark.parametrize("jax_interface", ["jax", "jax-python", "jax-jit"])
+    def test_jax(self, diff_method, jax_interface):
         """Test differentiation using JAX"""
+
+        if diff_method == "backprop" and jax_interface != "jax":
+            pytest.skip("The backprop case only accepts interface='jax'")
+
         jax = pytest.importorskip("jax")
         jnp = jax.numpy
 
         dev = qml.device("default.qubit", wires=2)
 
-        @qml.qnode(dev, diff_method=diff_method, interface="jax")
+        @qml.qnode(dev, diff_method=diff_method, interface=jax_interface)
         def circuit(b):
             init_state = np.array([1.0, -1.0]) / np.sqrt(2)
             qml.QubitStateVector(init_state, wires=0)


### PR DESCRIPTION
**Context:** As per #2237, the `qml.ctrl` transform was not working with gradient transforms such as the parameter-shift rule. It does however work with backprop.

**Description of the Change:**

- Ensures that the tape parameters are up to date prior to expansion
- Sets `grad_method=None` to enforce decomposition if using the parameter-shift rule
- Adds tests

**Benefits:** Gradient transforms now work with `qml.ctrl`.

**Possible Drawbacks:** n/a

**Related GitHub Issues:** Fixes #2237
