### PR TITLE
Move expand function from Operation to Operator

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -293,6 +293,8 @@ The Operator class has undergone a major refactor with the following changes:
   for developers.
   [(#2064)](https://github.com/PennyLaneAI/pennylane/pull/2064)
 
+* Moved ``expand()`` from ``Operation`` to ``Operator``.
+  [(#2239)](https://github.com/PennyLaneAI/pennylane/pull/2239)
 
 <h3>Contributors</h3>
 


### PR DESCRIPTION
**possible drawbacks**: I could not find any logic that relies on the expand function identifying Operations (as opposed to Observables) and hope this is safe. In any case, this _should_ not be logic that is used! 