### PR TITLE
Add link to CV model page in StrawberryFields docs

### DIFF
--- a/doc/introduction/operations.rst
+++ b/doc/introduction/operations.rst
@@ -254,7 +254,7 @@ Continuous-Variable (CV) operations
 
 If you would like to learn more about the CV model of quantum computing, check out the
 `quantum photonics <https://strawberryfields.ai/photonics/concepts/photonics.html>`_
-page of the [Strawberry Fields](https://strawberryfields.ai/) documentation.
+page of the `Strawberry Fields <https://strawberryfields.ai/>`__ documentation.
 
 .. _intro_ref_ops_cvgates:
 

--- a/doc/introduction/operations.rst
+++ b/doc/introduction/operations.rst
@@ -252,6 +252,10 @@ solving the minimum clique cover problem, and auxiliary functions, refer to the
 Continuous-variable (CV) operations
 -----------------------------------
 
+If you would like to learn more about the CV model of quantum computing, check out the
+`quantum photonics <https://strawberryfields.ai/photonics/concepts/photonics.html>`_
+page of the strawberry fields documentation.
+
 .. _intro_ref_ops_cvgates:
 
 CV Gates

--- a/doc/introduction/operations.rst
+++ b/doc/introduction/operations.rst
@@ -249,12 +249,12 @@ solving the minimum clique cover problem, and auxiliary functions, refer to the
 
 .. _intro_ref_ops_cv:
 
-Continuous-variable (CV) operations
+Continuous-Variable (CV) operations
 -----------------------------------
 
 If you would like to learn more about the CV model of quantum computing, check out the
 `quantum photonics <https://strawberryfields.ai/photonics/concepts/photonics.html>`_
-page of the strawberry fields documentation.
+page of the [Strawberry Fields](https://strawberryfields.ai/) documentation.
 
 .. _intro_ref_ops_cvgates:
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -228,6 +228,9 @@
 
 <h3>Documentation</h3>
 
+* Link to the strawberry fields docs for information on the CV model.
+  [(#2259)](https://github.com/PennyLaneAI/pennylane/pull/2259)
+
 * Fixes the example for `qml.QFT`.
   [(#2232)](https://github.com/PennyLaneAI/pennylane/pull/2232)
 


### PR DESCRIPTION
**Context:**
The PennyLane documentation currently does not contain or link to information about the CV model of quantum computing, making it difficult for users unfamiliar with the model to use PennyLane's CV capabilities.

**Description of the Change:**
Link to the Strawberry Fields documentation which explains the difference between the CV and qubit model.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
