### PR TITLE
add `expansion_strategy` keyword to `qml.draw_mpl`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -214,6 +214,8 @@
 
 <h3>Improvements</h3>
 
+* The `qml.draw_mpl` transform supports a `expansion_strategy` keyword argument.
+
 * The `qml.gradients` module has been streamlined and special-purpose functions
   moved closer to their use cases, while preserving existing behaviour.
   [(#2200)](https://github.com/PennyLaneAI/pennylane/pull/2200)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -215,6 +215,7 @@
 <h3>Improvements</h3>
 
 * The `qml.draw_mpl` transform supports a `expansion_strategy` keyword argument.
+  [(#2271)](https://github.com/PennyLaneAI/pennylane/pull/2271/)
 
 * The `qml.gradients` module has been streamlined and special-purpose functions
   moved closer to their use cases, while preserving existing behaviour.

--- a/pennylane/transforms/draw.py
+++ b/pennylane/transforms/draw.py
@@ -357,7 +357,9 @@ def draw(
     return wrapper
 
 
-def draw_mpl(qnode, wire_order=None, show_all_wires=False, decimals=None, **kwargs):
+def draw_mpl(
+    qnode, wire_order=None, show_all_wires=False, decimals=None, expansion_strategy=None, **kwargs
+):
     """Draw a qnode with matplotlib
 
     Args:
@@ -375,6 +377,16 @@ def draw_mpl(qnode, wire_order=None, show_all_wires=False, decimals=None, **kwar
         label_options (dict): matplotlib formatting options for the wire labels
         active_wire_notches (bool): whether or not to add notches indicating active wires.
             Defaults to ``True``.
+        expansion_strategy (str): The strategy to use when circuit expansions or decompositions
+            are required.
+
+            - ``gradient``: The QNode will attempt to decompose
+              the internal circuit such that all circuit operations are supported by the gradient
+              method.
+
+            - ``device``: The QNode will attempt to decompose the internal circuit
+              such that all circuit operations are natively supported by the device.
+
 
     Returns:
         A function that has the same argument signature as ``qnode``. When called,
@@ -540,7 +552,13 @@ def draw_mpl(qnode, wire_order=None, show_all_wires=False, decimals=None, **kwar
 
     @wraps(qnode)
     def wrapper(*args, **kwargs_qnode):
-        qnode.construct(args, kwargs_qnode)
+        original_expansion_strategy = getattr(qnode, "expansion_strategy", None)
+
+        try:
+            qnode.expansion_strategy = expansion_strategy or original_expansion_strategy
+            tapes = qnode.construct(args, kwargs_qnode)
+        finally:
+            qnode.expansion_strategy = original_expansion_strategy
 
         _wire_order = wire_order or qnode.device.wires
 

--- a/pennylane/transforms/draw.py
+++ b/pennylane/transforms/draw.py
@@ -556,7 +556,7 @@ def draw_mpl(
 
         try:
             qnode.expansion_strategy = expansion_strategy or original_expansion_strategy
-            tapes = qnode.construct(args, kwargs_qnode)
+            qnode.construct(args, kwargs_qnode)
         finally:
             qnode.expansion_strategy = original_expansion_strategy
 

--- a/tests/transforms/test_draw_mpl.py
+++ b/tests/transforms/test_draw_mpl.py
@@ -68,6 +68,21 @@ def test_standard_use():
     plt.close()
 
 
+@pytest.mark.parametrize(
+    "strategy, initial_strategy, n_patches", [("gradient", "device", 4), ("device", "gradient", 9)]
+)
+def test_expansion_strategy(strategy, initial_strategy, n_patches):
+    @qml.qnode(qml.device("default.qubit", wires=range(2)), expansion_strategy=initial_strategy)
+    def circuit():
+        qml.GroverOperator(wires=range(2))
+        return qml.expval(qml.PauliZ(0))
+
+    fig, ax = qml.draw_mpl(circuit, expansion_strategy=strategy)()
+
+    assert len(ax.patches) == n_patches
+    assert circuit.expansion_strategy == initial_strategy
+
+
 class TestKwargs:
     """Test various keywords arguments that can be passed to modify graphic."""
 


### PR DESCRIPTION
This PR adds the `expansion_strategy` keyword to `draw_mpl`.

![Screen Shot 2022-03-03 at 10 30 09 AM](https://user-images.githubusercontent.com/6364575/156596662-8d5c2b92-5905-478e-b9cd-a71d45543252.png)
