### PR TITLE
Update `MultiControlledX` call in `GroverOperator`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -249,6 +249,7 @@
 * The `MultiControlledX` operation now accepts a single `wires` keyword argument for both `control_wires` and `wires`.
   The single `wires` keyword should be all the control wires followed by a single target wire. 
   [(#2121)](https://github.com/PennyLaneAI/pennylane/pull/2121)
+  [(#2278)](https://github.com/PennyLaneAI/pennylane/pull/2278)
 
 <h3>Deprecations</h3>
 

--- a/pennylane/templates/subroutines/grover.py
+++ b/pennylane/templates/subroutines/grover.py
@@ -142,8 +142,7 @@ class GroverOperator(Operation):
         op_list.append(
             MultiControlledX(
                 control_values=ctrl_str,
-                control_wires=wires[:-1],
-                wires=wires[-1],
+                wires=wires,
                 work_wires=work_wires,
             )
         )

--- a/tests/templates/test_subroutines/test_grover.py
+++ b/tests/templates/test_subroutines/test_grover.py
@@ -112,8 +112,7 @@ def test_grover_diffusion_matrix(n_wires):
     ctrl_str = "0" * (n_wires - 1)
     CX = MultiControlledX(
         control_values=ctrl_str,
-        control_wires=wires[:-1],
-        wires=wires[-1],
+        wires=wires,
         work_wires=None,
     ).get_matrix()
 
@@ -186,7 +185,7 @@ def test_expand(wires):
 
 def test_findstate():
     """Asserts can find state marked by oracle."""
-    wires = range(6)
+    wires = list(range(6))
 
     dev = qml.device("default.qubit", wires=wires)
 
@@ -197,7 +196,7 @@ def test_findstate():
 
         for _ in range(5):
             qml.Hadamard(wires[0])
-            qml.MultiControlledX(wires=wires[0], control_wires=wires[1:])
+            qml.MultiControlledX(wires=wires[1:] + wires[0:1])
             qml.Hadamard(wires[0])
             qml.GroverOperator(wires=wires)
 


### PR DESCRIPTION
As of PR #2121 , `qml.MultiControlledX` prefers a single wires keyword argument of the form control_wires+target_wire. If passed a separate `control_wires` keyword argument, it raises a warning but still works.  This PR changes the syntax for creating a `MultiControlledX` in the decomposition for the `GroverOperator`.  Now it will no longer raise a warning.