### PR TITLE
Fix bug when using `for` loops with custom decompositions

### DIFF
--- a/pennylane/transforms/tape_expand.py
+++ b/pennylane/transforms/tape_expand.py
@@ -223,7 +223,7 @@ def _custom_decomp_context(custom_decomps):
         if isinstance(obj, str):
             obj = getattr(qml, obj)
 
-        original_decomp_method = obj.decomposition
+        original_decomp_method = obj.compute_decomposition
 
         try:
             # Explicitly set the new compute_decomposition method

--- a/tests/transforms/test_tape_expand.py
+++ b/tests/transforms/test_tape_expand.py
@@ -737,10 +737,10 @@ class TestCreateCustomDecompExpandFn:
         res = []
         for i in range(2):
 
-            custom_decomps={'MultiRZ': qml.MultiRZ.compute_decomposition}
-            dev = qml.device('lightning.qubit', wires=2, custom_decomps=custom_decomps)
+            custom_decomps = {"MultiRZ": qml.MultiRZ.compute_decomposition}
+            dev = qml.device("lightning.qubit", wires=2, custom_decomps=custom_decomps)
 
-            @qml.qnode(dev, diff_method='adjoint')
+            @qml.qnode(dev, diff_method="adjoint")
             def cost(theta):
                 qml.Hadamard(wires=0)
                 qml.Hadamard(wires=1)

--- a/tests/transforms/test_tape_expand.py
+++ b/tests/transforms/test_tape_expand.py
@@ -730,3 +730,24 @@ class TestCreateCustomDecompExpandFn:
         assert len(circuit.qtape.operations) == 1
         assert circuit.qtape.operations[0].name == "CNOT"
         assert dev.custom_expand_fn is None
+
+    def test_custom_decomp_used_twice(self):
+        """Test that creating a custom decomposition includes overwriting the
+        correct method under the hood and produces expected results."""
+        res = []
+        for i in range(2):
+
+            custom_decomps={'MultiRZ': qml.MultiRZ.compute_decomposition}
+            dev = qml.device('lightning.qubit', wires=2, custom_decomps=custom_decomps)
+
+            @qml.qnode(dev, diff_method='adjoint')
+            def cost(theta):
+                qml.Hadamard(wires=0)
+                qml.Hadamard(wires=1)
+                qml.MultiRZ(theta, wires=[1, 0])
+                return qml.expval(qml.PauliX(1))
+
+            x = np.array(0.5)
+            res.append(cost(x))
+
+        assert res[0] == res[1]


### PR DESCRIPTION
**Context:**

Attempting to apply a custom decomposition inside a for loop would cause an error:

```python
for i in range(2):

    custom_decomps={'MultiRZ': qml.MultiRZ.compute_decomposition}
    dev = qml.device('lightning.qubit', wires=2, custom_decomps=custom_decomps)

    @qml.qnode(dev, diff_method='adjoint')
    def cost(theta):
        qml.Hadamard(wires=0)
        qml.Hadamard(wires=1)
        qml.MultiRZ(theta, wires=[1, 0])
        return qml.expval(qml.PauliX(1))

    x = np.array(0.5, requires_grad=True)
    cost(x)
```

```
Traceback (most recent call last):
  File "/home/josh/xanadu/pennylane/pennylane/operation.py", line 1098, in expand
    self.decomposition()
  File "/home/josh/xanadu/pennylane/pennylane/operation.py", line 991, in decomposition
    return self.compute_decomposition(
TypeError: decomposition() got an unexpected keyword argument 'wires'
```

For some reason, the for loop is important here. Replacing it with simply the same block repeated does not cause the error.

**Description of the Change:** Fixes a typo in `custom_decomposition`, where the wrong `decomposition` method was being overwritten when the method exits.

**Benefits:** Fixes the bug above. The changelog was not edited, as this bug was introduced into `master`.

**Possible Drawbacks:** n/a

**Related GitHub Issues:** n/a
