### PR TITLE
Snapshot: remove temporary fixes for lightning device

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,6 +65,7 @@ jobs:
           pip install -r requirements-ci.txt
           python setup.py bdist_wheel
           pip install dist/PennyLane*.whl
+          pip install --upgrade --pre -i https://test.pypi.org/simple/ PennyLane-Lightning
 
       - name: Run tests
         run: python -m pytest tests --cov=pennylane $COVERAGE_FLAGS

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -9,12 +9,13 @@
   execution, such as the quantum state vector and density matrix in the qubit case, or the
   covariance matrix and vector of means in the continuous variable case. The saved states can be
   retrieved in the form of a dictionary via the top-level `qml.snapshots` function.
-  [(#2233)](https://github.com/PennyLaneAI/pennylane/pull/2233) 
+  [(#2233)](https://github.com/PennyLaneAI/pennylane/pull/2233)
   [(#2289)](https://github.com/PennyLaneAI/pennylane/pull/2289)
+  [(#2291)](https://github.com/PennyLaneAI/pennylane/pull/2291)
 
   ```py
   dev = qml.device("default.qubit", wires=2)
-  
+
   @qml.qnode(dev, interface=None)
   def circuit():
       qml.Snapshot()

--- a/pennylane/debugging.py
+++ b/pennylane/debugging.py
@@ -28,7 +28,7 @@ class _Debugger:
     """
 
     def __init__(self, dev):
-        if dev.short_name == "lightning.qubit" or not hasattr(dev, "_debugger"):
+        if "Snapshot" not in dev.operations:
             raise DeviceError("Device does not support snapshots.")
 
         self.snapshots = {}

--- a/pennylane/ops/snapshot.py
+++ b/pennylane/ops/snapshot.py
@@ -15,8 +15,6 @@
 This module contains the Snapshot (pseudo) operation that is common to both
 cv and qubit computing paradigms in PennyLane.
 """
-import numpy as np
-
 from pennylane.operation import AnyWires, Operation
 
 
@@ -50,8 +48,3 @@ class Snapshot(Operation):
     @staticmethod
     def compute_decomposition(*params, wires=None, **hyperparameters):
         return []
-
-    # TODO: remove once pennylane-lightning#242 is resolved
-    @staticmethod
-    def compute_matrix(*params, **hyperparams):
-        return np.eye(2)

--- a/tests/test_debugging.py
+++ b/tests/test_debugging.py
@@ -22,11 +22,12 @@ import pennylane as qml
 class TestSnapshot:
     """Test the Snapshot instruction for simulators."""
 
-    def test_default_qubit(self):
+    @pytest.mark.parametrize("method", [None, "backprop", "parameter-shift", "adjoint"])
+    def test_default_qubit(self, method):
         """Test that multiple snapshots are returned correctly on the state-vector simulator."""
         dev = qml.device("default.qubit", wires=2)
 
-        @qml.qnode(dev)
+        @qml.qnode(dev, diff_method=method)
         def circuit():
             qml.Snapshot()
             qml.Hadamard(wires=0)
@@ -49,11 +50,12 @@ class TestSnapshot:
         assert all(k1 == k2 for k1, k2 in zip(result.keys(), expected.keys()))
         assert all(np.allclose(v1, v2) for v1, v2 in zip(result.values(), expected.values()))
 
-    def test_default_mixed(self):
+    @pytest.mark.parametrize("method", [None, "parameter-shift"])
+    def test_default_mixed(self, method):
         """Test that multiple snapshots are returned correctly on the density-matrix simulator."""
         dev = qml.device("default.mixed", wires=2)
 
-        @qml.qnode(dev)
+        @qml.qnode(dev, diff_method=method)
         def circuit():
             qml.Snapshot()
             qml.Hadamard(wires=0)
@@ -78,11 +80,12 @@ class TestSnapshot:
         assert all(k1 == k2 for k1, k2 in zip(result.keys(), expected.keys()))
         assert all(np.allclose(v1, v2) for v1, v2 in zip(result.values(), expected.values()))
 
-    def test_default_gaussian(self):
+    @pytest.mark.parametrize("method", [None, "parameter-shift"])
+    def test_default_gaussian(self, method):
         """Test that multiple snapshots are returned correctly on the CV simulator."""
         dev = qml.device("default.gaussian", wires=2)
 
-        @qml.qnode(dev)
+        @qml.qnode(dev, diff_method=method)
         def circuit():
             qml.Snapshot()
             qml.Displacement(0.5, 0, wires=0)
@@ -124,11 +127,12 @@ class TestSnapshot:
             for v1, v2 in zip(result.values(), expected.values())
         )
 
-    def test_lightning_qubit(self):
+    @pytest.mark.parametrize("method", [None, "parameter-shift", "adjoint"])
+    def test_lightning_qubit(self, method):
         """Test that an error is (currently) raised on the lightning simulator."""
         dev = qml.device("lightning.qubit", wires=2)
 
-        @qml.qnode(dev)
+        @qml.qnode(dev, diff_method=method)
         def circuit():
             qml.Snapshot()
             qml.Hadamard(wires=0)
@@ -252,28 +256,3 @@ class TestSnapshot:
 
         if m == "state":
             assert np.allclose(result[2], result["execution_results"])
-
-    @pytest.mark.parametrize("method", [None, "backprop", "parameter-shift", "adjoint"])
-    def test_different_diff_methods(self, method):
-        """Test that snapshots work with different differentiation methods."""
-        dev = qml.device("default.qubit", wires=2)
-
-        @qml.qnode(dev, diff_method=method)
-        def circuit():
-            qml.Snapshot()
-            qml.Hadamard(wires=0)
-            qml.Snapshot("very_important_state")
-            qml.CNOT(wires=[0, 1])
-            qml.Snapshot()
-            return qml.expval(qml.PauliZ(0))
-
-        result = qml.snapshots(circuit)()
-        expected = {
-            0: np.array([1, 0, 0, 0]),
-            "very_important_state": np.array([1 / np.sqrt(2), 0, 1 / np.sqrt(2), 0]),
-            2: np.array([1 / np.sqrt(2), 0, 0, 1 / np.sqrt(2)]),
-            "execution_results": np.array(0),
-        }
-
-        assert all(k1 == k2 for k1, k2 in zip(result.keys(), expected.keys()))
-        assert all(np.allclose(v1, v2) for v1, v2 in zip(result.values(), expected.values()))


### PR DESCRIPTION
Now that https://github.com/PennyLaneAI/pennylane-lightning/issues/242 is resolved, the temporary fixes to make snapshot not break lightning can be removed.