### PR TITLE
Minor gradient fixes

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -397,6 +397,10 @@
   the four-term parameter shift rule. The correct eight-term rule will now be used when
   using the parameter-shift rule.
   [(#2180)](https://github.com/PennyLaneAI/pennylane/pull/2180)
+  
+* Fixes a bug where `qml.gradients.param_shift_hessian` would produce an
+  error whenever all elements of the Hessian are known in advance to be 0.
+  [(#2299)](https://github.com/PennyLaneAI/pennylane/pull/2299)
 
 <h3>Documentation</h3>
 

--- a/pennylane/gradients/finite_difference.py
+++ b/pennylane/gradients/finite_difference.py
@@ -302,7 +302,7 @@ def finite_diff(
             "If this is unintended, please mark trainable parameters in accordance with the "
             "chosen auto differentiation framework, or via the 'tape.trainable_params' property."
         )
-        return [], lambda _: np.zeros([tape.output_dim, len(tape.trainable_params)])
+        return [], lambda _: ()
 
     if validate_params:
         if "grad_method" not in tape._par_info[0]:

--- a/pennylane/gradients/param_shift_hessian.py
+++ b/pennylane/gradients/param_shift_hessian.py
@@ -343,4 +343,9 @@ def param_shift_hessian(tape, f0=None):
     _gradient_analysis(tape)
     diff_methods = grad_method_validation("analytic", tape)
 
+    if all(g == "0" for g in diff_methods):
+        return [], lambda _: np.zeros(
+            [tape.output_dim, len(tape.trainable_params), len(tape.trainable_params)]
+        )
+
     return compute_hessian_tapes(tape, diff_methods, f0)

--- a/pennylane/gradients/param_shift_hessian.py
+++ b/pennylane/gradients/param_shift_hessian.py
@@ -170,21 +170,20 @@ def compute_hessian_tapes(tape, diff_methods, f0=None):
             # Compute the elements of the Hessian as the linear combination of
             # results and coefficients, barring optimization cases.
             if j < i:
-                g = hessian[j * h_dim + i]
+                hess = hessian[j * h_dim + i]
             elif s == 0:
-                g = qml.math.zeros(out_dim)
+                hess = qml.math.zeros(out_dim)
             else:
                 res = qml.math.stack(res)
-                hess = qml.math.convert_like(hessian_coeffs[k], res)
-                hess = qml.math.cast(hess, res.dtype)
-                g = qml.math.tensordot(res, hess, [[0], [0]])
+                coeffs = qml.math.cast(qml.math.convert_like(hessian_coeffs[k], res), res.dtype)
+                hess = qml.math.tensordot(res, coeffs, [[0], [0]])
                 if (i, j) in unshifted_coeffs:
-                    g += unshifted_coeffs[(i, j)] * r0
+                    hess = hess + unshifted_coeffs[(i, j)] * r0
 
-            hessian.append(g)
+            hessian.append(hess)
 
         # Reshape the Hessian to have the dimensions of the QNode output on the outside, that is:
-        #         (h_dim, h_dim, out_dim) -> (out_dim, h_dim, h_dim)
+        #     (h_dim*h_dim, out_dim) -> (h_dim, h_dim, out_dim) -> (out_dim, h_dim, h_dim)
         hessian = qml.math.reshape(qml.math.stack(hessian), (h_dim, h_dim) + out_dim)
         reordered_axes = list(range(2, len(out_dim) + 2)) + [0, 1]
         hessian = qml.math.transpose(hessian, axes=reordered_axes)

--- a/pennylane/gradients/parameter_shift.py
+++ b/pennylane/gradients/parameter_shift.py
@@ -611,7 +611,7 @@ def param_shift(
             "If this is unintended, please mark trainable parameters in accordance with the "
             "chosen auto differentiation framework, or via the 'tape.trainable_params' property."
         )
-        return [], lambda _: np.zeros([tape.output_dim, len(tape.trainable_params)])
+        return [], lambda _: ()
 
     _gradient_analysis(tape)
     method = "analytic" if fallback_fn is None else "best"

--- a/pennylane/gradients/parameter_shift_cv.py
+++ b/pennylane/gradients/parameter_shift_cv.py
@@ -660,7 +660,7 @@ def param_shift_cv(
             "If this is unintended, please mark trainable parameters in accordance with the "
             "chosen auto differentiation framework, or via the 'tape.trainable_params' property."
         )
-        return gradient_tapes, lambda _: np.zeros([tape.output_dim, len(tape.trainable_params)])
+        return gradient_tapes, lambda _: ()
 
     def _update(data):
         """Utility function to update the list of gradient tapes,

--- a/tests/gradients/test_finite_difference.py
+++ b/tests/gradients/test_finite_difference.py
@@ -221,6 +221,24 @@ class TestFiniteDiff:
         assert g_tapes == []
         assert res == ()
 
+    def test_all_zero_diff_methods(self):
+        """Test that the transform works correctly when the diff method for every parameter is
+        identified to be 0, and that no tapes were generated."""
+        dev = qml.device("default.qubit", wires=4)
+
+        @qml.qnode(dev)
+        def circuit(params):
+            qml.Rot(*params, wires=0)
+            return qml.probs([2, 3])
+
+        params = np.array([0.5, 0.5, 0.5], requires_grad=True)
+
+        result = qml.gradients.finite_diff(circuit)(params)
+        assert np.allclose(result, np.zeros((4, 3)), atol=0, rtol=0)
+
+        tapes, _ = qml.gradients.finite_diff(circuit.tape)
+        assert tapes == []
+
     def test_y0(self, mocker):
         """Test that if first order finite differences is used, then
         the tape is executed only once using the current parameter

--- a/tests/gradients/test_finite_difference.py
+++ b/tests/gradients/test_finite_difference.py
@@ -219,8 +219,7 @@ class TestFiniteDiff:
         res = post_processing(qml.execute(g_tapes, dev, None))
 
         assert g_tapes == []
-        assert res.size == 0
-        assert np.all(res == np.array([[]]))
+        assert res == ()
 
     def test_y0(self, mocker):
         """Test that if first order finite differences is used, then

--- a/tests/gradients/test_param_shift_hessian.py
+++ b/tests/gradients/test_param_shift_hessian.py
@@ -542,6 +542,24 @@ class TestParameterShiftHessian:
         assert h_tapes == []
         assert res == ()
 
+    def test_all_zero_diff_methods(self):
+        """Test that the transform works correctly when the diff method for every parameter is
+        identified to be 0, and that no tapes were generated."""
+        dev = qml.device("default.qubit", wires=4)
+
+        @qml.qnode(dev)
+        def circuit(params):
+            qml.Rot(*params, wires=0)
+            return qml.probs([2, 3])
+
+        params = np.array([0.5, 0.5, 0.5], requires_grad=True)
+
+        result = qml.gradients.param_shift_hessian(circuit)(params)
+        assert np.allclose(result, np.zeros((4, 3, 3)), atol=0, rtol=0)
+
+        tapes, _ = qml.gradients.param_shift_hessian(circuit.tape)
+        assert tapes == []
+
     def test_f0_argument(self):
         """Test that we can provide the results of a QNode to save on quantum invocations"""
 

--- a/tests/gradients/test_parameter_shift.py
+++ b/tests/gradients/test_parameter_shift.py
@@ -236,8 +236,7 @@ class TestParamShift:
         res = post_processing(qml.execute(g_tapes, dev, None))
 
         assert g_tapes == []
-        assert res.size == 0
-        assert np.all(res == np.array([[]]))
+        assert res == ()
 
     def test_y0(self):
         """Test that if the gradient recipe has a zero-shift component, then

--- a/tests/gradients/test_parameter_shift.py
+++ b/tests/gradients/test_parameter_shift.py
@@ -238,6 +238,24 @@ class TestParamShift:
         assert g_tapes == []
         assert res == ()
 
+    def test_all_zero_diff_methods(self):
+        """Test that the transform works correctly when the diff method for every parameter is
+        identified to be 0, and that no tapes were generated."""
+        dev = qml.device("default.qubit", wires=4)
+
+        @qml.qnode(dev)
+        def circuit(params):
+            qml.Rot(*params, wires=0)
+            return qml.probs([2, 3])
+
+        params = np.array([0.5, 0.5, 0.5], requires_grad=True)
+
+        result = qml.gradients.param_shift(circuit)(params)
+        assert np.allclose(result, np.zeros((4, 3)), atol=0, rtol=0)
+
+        tapes, _ = qml.gradients.param_shift(circuit.tape)
+        assert tapes == []
+
     def test_y0(self):
         """Test that if the gradient recipe has a zero-shift component, then
         the tape is executed only once using the current parameter

--- a/tests/gradients/test_parameter_shift_cv.py
+++ b/tests/gradients/test_parameter_shift_cv.py
@@ -310,8 +310,7 @@ class TestParameterShiftLogic:
         res = post_processing(qml.execute(g_tapes, dev, None))
 
         assert g_tapes == []
-        assert res.size == 0
-        assert np.all(res == np.array([[]]))
+        assert res == ()
 
     def test_state_non_differentiable_error(self):
         """Test error raised if attempting to differentiate with

--- a/tests/gradients/test_parameter_shift_cv.py
+++ b/tests/gradients/test_parameter_shift_cv.py
@@ -312,6 +312,24 @@ class TestParameterShiftLogic:
         assert g_tapes == []
         assert res == ()
 
+    def test_all_zero_diff_methods(self):
+        """Test that the transform works correctly when the diff method for every parameter is
+        identified to be 0, and that no tapes were generated."""
+        dev = qml.device("default.gaussian", wires=2)
+
+        @qml.qnode(dev)
+        def circuit(params):
+            qml.Rotation(params[0], wires=0)
+            return qml.expval(qml.X(1))
+
+        params = np.array([0.5, 0.5, 0.5], requires_grad=True)
+
+        result = qml.gradients.param_shift_cv(circuit, dev)(params)
+        assert np.allclose(result, np.zeros((2, 3)), atol=0, rtol=0)
+
+        tapes, _ = qml.gradients.param_shift_cv(circuit.tape, dev)
+        assert tapes == []
+
     def test_state_non_differentiable_error(self):
         """Test error raised if attempting to differentiate with
         respect to a state"""

--- a/tests/test_quantum_gradients.py
+++ b/tests/test_quantum_gradients.py
@@ -237,7 +237,7 @@ class TestCVGradient:
 
     def test_cv_gradients_parameters_inside_array(self, gaussian_dev, tol):
         "Tests that free parameters inside an array passed to an Operation yield correct gradients."
-        par = [0.4, 1.3]
+        par = anp.array([0.4, 1.3], requires_grad=True)
 
         def qf(x, y):
             qml.Displacement(0.5, 0, wires=[0])


### PR DESCRIPTION
Fixes a bug in `qml.gradients.param_shift_hessian` which errors when the diff methods are zero for all parameters. For example in the following scenario:

```py
dev = qml.device('default.qubit', wires=4)
@qml.qnode(dev)
def circuit(params):
    qml.Rot(*params, wires=0)
    return qml.probs([2,3])

params = np.array([0.5, 0.5, 0.5], requires_grad=True)
qml.gradients.param_shift_hessian(circuit)(params)
```
```py
>>> ValueError: need at least one array to stack
```

Both `param_shift` and `param_shift_hessian` assume that the `results` value passed to their post-processing functions (from batched tape execution) has at least one element. Thus, scenarios which do not generate any tapes need to be checked for beforehand:

https://github.com/PennyLaneAI/pennylane/blob/e1b15d27cc5a4a882b552c936580dd903fe3b988/pennylane/gradients/parameter_shift.py#L597-L598

---

In the absence of trainable parameters, some gradient transforms did not produce an empty tuple yet like the rest of our functions. This has been updated.

---

Minor reformatting on the parameter shift hessian transform.

---

Fix missing `requires_grad` attribute on a test, as well as catch expected warning on another test.