### PR TITLE
Update operation.py

### DIFF
--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -788,7 +788,7 @@ class Operator(abc.ABC):
 
         Returns:
             tuple[list[tensor_like or float], list[.Operation]]: list of coefficients :math:`c_i`
-                and list of operations :math:`O_i`
+            and list of operations :math:`O_i`
         """
         return self.compute_terms(*self.parameters, **self.hyperparameters)
 


### PR DESCRIPTION
**Context:** indentation of return statement caused the docs to display incorrectly
![image](https://user-images.githubusercontent.com/7213358/157727699-a4831cb0-d954-4d07-b9d0-e9ed07ef2069.png)


**Description of the Change:** revises indentation

**Benefits:** cleaner docs

**Possible Drawbacks:** none

**Related GitHub Issues:**
