### PR TITLE
Added the `process_shifts` utility function to docs

### DIFF
--- a/pennylane/gradients/__init__.py
+++ b/pennylane/gradients/__init__.py
@@ -62,6 +62,7 @@ Utility functions
 .. autosummary::
     :toctree: api
 
+    process_shifts
     finite_diff_coeffs
     generate_shifted_tapes
     generate_shift_rule

--- a/pennylane/gradients/general_shift_rules.py
+++ b/pennylane/gradients/general_shift_rules.py
@@ -21,7 +21,7 @@ import pennylane as qml
 
 
 def process_shifts(rule, tol=1e-10, check_duplicates=True):
-    """Utility function to process gradient rules.
+    r"""Utility function to process gradient rules.
 
     Args:
         rule (array): a ``(2, M)`` array corresponding to ``M`` terms


### PR DESCRIPTION
The `process_shifts` function introduced in PR [2182](https://github.com/PennyLaneAI/pennylane/pull/2182) does not show up in the docs. This was addressed by adding it to the `__init__.py` file comments. 