### PR TITLE
Add `qml.generator(op)` backwards compatibility

### DIFF
--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -1291,9 +1291,10 @@ class Operation(Operator):
         >>> op = qml.ControlledPhaseShift(0.1, wires=[0, 1])
         >>> op.parameter_frequencies
         [(1,)]
-        >>> gen_eigvals = tuple(np.linalg.eigvals(op.generator[0] * op.generator[1]))
-        >>> qml.gradients.eigvals_to_frequencies(gen_eigvals)
-        (tensor(1., requires_grad=True),)
+        >>> gen = qml.generator(op, format="observable")
+        >>> gen_eigvals = qml.eigvals(gen)
+        >>> qml.gradients.eigvals_to_frequencies(tuple(gen_eigvals))
+        (1.0,)
 
         For more details on this relationship, see :func:`.eigvals_to_frequencies`.
         """

--- a/pennylane/ops/functions/generator.py
+++ b/pennylane/ops/functions/generator.py
@@ -115,12 +115,12 @@ def _generator_backcompatibility(op):
     gen = op.generator
 
     if inspect.isclass(gen[0]):
-        gen = gen[1] * gen[0](wires=op.wires)
+        return gen[1] * gen[0](wires=op.wires)
 
-    elif isinstance(gen[0], np.ndarray):
-        gen = gen[1] * qml.Hermitian(gen[0], wires=op.wires)
+    if isinstance(gen[0], np.ndarray) and len(gen[0].shape) == 2:
+        return gen[1] * qml.Hermitian(gen[0], wires=op.wires)
 
-    return gen
+    raise qml.operation.GeneratorUndefinedError
 
 
 @qml.op_transform

--- a/tests/ops/functions/test_generator.py
+++ b/tests/ops/functions/test_generator.py
@@ -136,6 +136,47 @@ class TestValidation:
             qml.generator(qml.RX, format=None)(0.5, wires=0)
 
 
+class TestBackwardsCompatibility:
+    """Test that operators that provide the old style generator property
+    continue to work with a deprecation warning."""
+
+    def test_return_class(self):
+        """Test that an old-style Operator that has a generator property,
+        and that returns a list containing (a) operator class and (b) prefactor,
+        continues to work but also raises a deprecation warning."""
+
+        class DeprecatedClassOp(CustomOp):
+            generator = [qml.PauliX, -0.6]
+
+        op = DeprecatedClassOp(0.5, wires="a")
+
+        with pytest.warns(UserWarning, match=r"The Operator\.generator property is deprecated"):
+            gen, prefactor = qml.generator(op)
+
+        assert isinstance(gen, qml.operation.Operator)
+        assert prefactor == -0.6
+        assert gen.name == "PauliX"
+        assert gen.wires.tolist() == ["a"]
+
+    def test_return_array(self):
+        """Test that an old-style Operator that has a generator property,
+        and that returns a list containing (a) array and (b) prefactor,
+        continues to work but also raises a deprecation warning."""
+
+        class DeprecatedClassOp(CustomOp):
+            generator = [np.diag([0, 1]), -0.6]
+
+        op = DeprecatedClassOp(0.5, wires="a")
+
+        with pytest.warns(UserWarning, match=r"The Operator\.generator property is deprecated"):
+            gen, prefactor = qml.generator(op)
+
+        assert isinstance(gen, qml.operation.Operator)
+        assert prefactor == -0.6
+        assert gen.name == "Hermitian"
+        assert gen.wires.tolist() == ["a"]
+
+
 class TestPrefactorReturn:
     """Tests for format="prefactor". This format attempts to isolate a prefactor
     (if possible) from the generator, which is useful if the generator is a Pauli word."""


### PR DESCRIPTION
**Context:** 

- In previous versions of PennyLane, `Operator.generator` was a property, that returned a list of the form `[type, float]` or `[array, float]`.

- In the current master, this has been changed. `Operator.generator` is now a _method_, and it returns an Operator _instance_.

- In #2256, a high-level `qml.generator()` function was added, intended to be the user-facing interface to `Operator.generator()`.

**Description of the Change:** A small modification to `qml.generator()` has been made, to ensure it continues to work with old-style operators that define the `Operator.generator` property. In addition, a deprecation warning is raised.

**Benefits:** `qml.generator()` should work with old-style operators.

**Possible Drawbacks:** This backwards compatibility is constrained, in that it requires developers start using `qml.generator`, a new function!

**Related GitHub Issues:** n/a
