### PR TITLE
Deprecate jacobian tape

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -364,14 +364,14 @@
 
 * Executing tapes using `tape.execute(dev)` is deprecated.
   Please use the `qml.execute([tape], dev)` function instead.
-  [(#)]()
+  [(#2306)](https://github.com/PennyLaneAI/pennylane/pull/2306)
 
 * The subclasses of the quantum tape, including `JacobianTape`, `QubitParamShiftTape`,
   `CVParamShiftTape`, and `ReversibleTape` are deprecated. Instead of calling
   `JacobianTape.jacobian()` and `JacobianTape.hessian()`,
   please use a standard `QuantumTape`, and apply gradient transforms using
   the `qml.gradients` module.
-  [(#)]()
+  [(#2306)](https://github.com/PennyLaneAI/pennylane/pull/2306)
 
 * The `qml.operation.Operation.get_parameter_shift` method has been deprecated
   and will be removed in a future release.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -364,6 +364,14 @@
 
 * Executing tapes using `tape.execute(dev)` is deprecated.
   Please use the `qml.execute([tape], dev)` function instead.
+  [(#)]()
+
+* The subclasses of the quantum tape, including `JacobianTape`, `QubitParamShiftTape`,
+  `CVParamShiftTape`, and `ReversibleTape` are deprecated. Instead of calling
+  `JacobianTape.jacobian()` and `JacobianTape.hessian()`,
+  please use a standard `QuantumTape`, and apply gradient transforms using
+  the `qml.gradients` module.
+  [(#)]()
 
 * The `qml.operation.Operation.get_parameter_shift` method has been deprecated
   and will be removed in a future release.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -362,6 +362,9 @@
 
 <h3>Deprecations</h3>
 
+* Executing tapes using `tape.execute(dev)` is deprecated.
+  Please use the `qml.execute([tape], dev)` function instead.
+
 * The `qml.operation.Operation.get_parameter_shift` method has been deprecated
   and will be removed in a future release.
   [#2227](https://github.com/PennyLaneAI/pennylane/pull/2227)

--- a/pennylane/gradients/__init__.py
+++ b/pennylane/gradients/__init__.py
@@ -238,12 +238,12 @@ define the gradient:
 
 >>> gradient_tapes, fn = qml.gradients.param_shift(tape)
 >>> gradient_tapes
-[<JacobianTape: wires=[0, 1], params=3>,
- <JacobianTape: wires=[0, 1], params=3>,
- <JacobianTape: wires=[0, 1], params=3>,
- <JacobianTape: wires=[0, 1], params=3>,
- <JacobianTape: wires=[0, 1], params=3>,
- <JacobianTape: wires=[0, 1], params=3>]
+[<QuantumTape: wires=[0, 1], params=3>,
+ <QuantumTape: wires=[0, 1], params=3>,
+ <QuantumTape: wires=[0, 1], params=3>,
+ <QuantumTape: wires=[0, 1], params=3>,
+ <QuantumTape: wires=[0, 1], params=3>,
+ <QuantumTape: wires=[0, 1], params=3>]
 
 This can be useful if the underlying circuits representing the gradient
 computation need to be analyzed.

--- a/pennylane/gradients/finite_difference.py
+++ b/pennylane/gradients/finite_difference.py
@@ -28,6 +28,7 @@ from .gradient_transform import (
     gradient_transform,
     grad_method_validation,
     choose_grad_methods,
+    gradient_analysis,
 )
 
 
@@ -272,7 +273,7 @@ def finite_diff(
         device evaluation. Instead, the processed tapes, and post-processing
         function, which together define the gradient are directly returned:
 
-        >>> with qml.tape.JacobianTape() as tape:
+        >>> with qml.tape.QuantumTape() as tape:
         ...     qml.RX(params[0], wires=0)
         ...     qml.RY(params[1], wires=0)
         ...     qml.RX(params[2], wires=0)
@@ -280,10 +281,10 @@ def finite_diff(
         ...     qml.var(qml.PauliZ(0))
         >>> gradient_tapes, fn = qml.gradients.finite_diff(tape)
         >>> gradient_tapes
-        [<JacobianTape: wires=[0, 1], params=3>,
-         <JacobianTape: wires=[0, 1], params=3>,
-         <JacobianTape: wires=[0, 1], params=3>,
-         <JacobianTape: wires=[0, 1], params=3>]
+        [<QuantumTape: wires=[0], params=3>,
+         <QuantumTape: wires=[0], params=3>,
+         <QuantumTape: wires=[0], params=3>,
+         <QuantumTape: wires=[0], params=3>]
 
         This can be useful if the underlying circuits representing the gradient
         computation need to be analyzed.
@@ -306,7 +307,7 @@ def finite_diff(
 
     if validate_params:
         if "grad_method" not in tape._par_info[0]:
-            tape._update_gradient_info()
+            gradient_analysis(tape, grad_fn=finite_diff)
         diff_methods = grad_method_validation("numeric", tape)
     else:
         diff_methods = ["F" for i in tape.trainable_params]

--- a/pennylane/gradients/gradient_transform.py
+++ b/pennylane/gradients/gradient_transform.py
@@ -23,8 +23,7 @@ from pennylane.transforms.tape_expand import expand_invalid_trainable
 def gradient_analysis(tape, use_graph=True, grad_fn=None):
     """Update the parameter information dictionary of the tape with
     gradient information of each parameter."""
-
-    if getattr(tape, "_gradient_fn", None) is grad_fn:
+    if grad_fn is not None and getattr(tape, "_gradient_fn", None) is grad_fn:
         # gradient analysis has already been performed on this tape
         return
 

--- a/pennylane/gradients/gradient_transform.py
+++ b/pennylane/gradients/gradient_transform.py
@@ -22,7 +22,30 @@ from pennylane.transforms.tape_expand import expand_invalid_trainable
 
 def gradient_analysis(tape, use_graph=True, grad_fn=None):
     """Update the parameter information dictionary of the tape with
-    gradient information of each parameter."""
+    gradient information of each parameter.
+
+    Parameter gradient methods include:
+
+    * ``None``: the parameter does not support differentiation.
+
+    * ``"0"``: the variational circuit output does not depend on this
+      parameter (the partial derivative is zero).
+
+    In addition, the operator might define its own grad method
+    via :attr:`.Operator.grad_method`.
+
+    Note that this function modifies the input tape in-place.
+
+    Args:
+        tape (.QuantumTape): the quantum tape to analyze
+        use_graph (bool): whether to use a directed-acyclic graph to determine
+            if the parameter has a gradient of 0
+        grad_fn (None or callable): The gradient transform performing the analysis.
+            This is an optional argument; if provided, and the tape has already
+            been analyzed for the gradient information by the same gradient transform,
+            the cached gradient analysis will be used.
+    """
+    # pylint:disable=protected-access
     if grad_fn is not None and getattr(tape, "_gradient_fn", None) is grad_fn:
         # gradient analysis has already been performed on this tape
         return

--- a/pennylane/gradients/param_shift_hessian.py
+++ b/pennylane/gradients/param_shift_hessian.py
@@ -20,8 +20,7 @@ import numpy as np
 
 import pennylane as qml
 
-from .parameter_shift import _gradient_analysis
-from .gradient_transform import grad_method_validation
+from .gradient_transform import gradient_analysis, grad_method_validation
 from .hessian_transform import hessian_transform
 
 
@@ -265,13 +264,13 @@ def param_shift_hessian(tape, f0=None):
         >>> tape = circuit.qtape
         >>> hessian_tapes, postproc_fn = qml.gradients.param_shift_hessian(tape)
         >>> hessian_tapes
-        [<JacobianTape: wires=[0], params=2>,
-            <JacobianTape: wires=[0], params=2>,
-            <JacobianTape: wires=[0], params=2>,
-            <JacobianTape: wires=[0], params=2>,
-            <JacobianTape: wires=[0], params=2>,
-            <JacobianTape: wires=[0], params=2>,
-            <JacobianTape: wires=[0], params=2>]
+        [<QuantumTape: wires=[0], params=2>,
+         <QuantumTape: wires=[0], params=2>,
+         <QuantumTape: wires=[0], params=2>,
+         <QuantumTape: wires=[0], params=2>,
+         <QuantumTape: wires=[0], params=2>,
+         <QuantumTape: wires=[0], params=2>,
+         <QuantumTape: wires=[0], params=2>]
         >>> postproc_fn(qml.execute(hessian_tapes, dev, None))
         array([[-0.97517033,  0.01983384],
                 [ 0.01983384, -0.97517033]])
@@ -340,7 +339,7 @@ def param_shift_hessian(tape, f0=None):
                 f"Hessian. Only two-term parameter shift rules are currently supported."
             )
 
-    _gradient_analysis(tape)
+    gradient_analysis(tape, grad_fn=qml.gradients.param_shift)
     diff_methods = grad_method_validation("analytic", tape)
 
     if all(g == "0" for g in diff_methods):

--- a/pennylane/gradients/parameter_shift_cv.py
+++ b/pennylane/gradients/parameter_shift_cv.py
@@ -593,7 +593,7 @@ def param_shift_cv(
     to use during autodifferentiation:
 
     >>> dev = qml.device("default.gaussian", wires=2)
-    >>> @qml.qnode(dev, gradient_fn=qml.gradients.param_shift_cv)
+    >>> @qml.qnode(dev, diff_method="parameter-shift")
     ... def circuit(params):
     ...     qml.Squeezing(params[0], params[1], wires=[0])
     ...     qml.Squeezing(params[2], params[3], wires=[0])
@@ -621,16 +621,16 @@ def param_shift_cv(
         function, which together define the gradient are directly returned:
 
         >>> r0, phi0, r1, phi1 = [0.4, -0.3, -0.7, 0.2]
-        >>> with qml.tape.JacobianTape() as tape:
+        >>> with qml.tape.QuantumTape() as tape:
         ...     qml.Squeezing(r0, phi0, wires=[0])
         ...     qml.Squeezing(r1, phi1, wires=[0])
         ...     qml.expval(qml.NumberOperator(0))  # second-order
         >>> gradient_tapes, fn = qml.gradients.param_shift_cv(tape, dev)
         >>> gradient_tapes
-        [<JacobianTape: wires=[0], params=4>,
-         <JacobianTape: wires=[0], params=4>,
-         <JacobianTape: wires=[0], params=4>,
-         <JacobianTape: wires=[0], params=4>]
+        [<QuantumTape: wires=[0], params=4>,
+         <QuantumTape: wires=[0], params=4>,
+         <QuantumTape: wires=[0], params=4>,
+         <QuantumTape: wires=[0], params=4>]
 
         This can be useful if the underlying circuits representing the gradient
         computation need to be analyzed.

--- a/pennylane/interfaces/batch/__init__.py
+++ b/pennylane/interfaces/batch/__init__.py
@@ -263,12 +263,12 @@ def execute(
         dev = qml.device("lightning.qubit", wires=2)
 
         def cost_fn(params, x):
-            with qml.tape.JacobianTape() as tape1:
+            with qml.tape.QuantumTape() as tape1:
                 qml.RX(params[0], wires=0)
                 qml.RY(params[1], wires=0)
                 qml.expval(qml.PauliZ(0))
 
-            with qml.tape.JacobianTape() as tape2:
+            with qml.tape.QuantumTape() as tape2:
                 qml.RX(params[2], wires=0)
                 qml.RY(x[0], wires=1)
                 qml.CNOT(wires=[0, 1])
@@ -277,7 +277,7 @@ def execute(
             tapes = [tape1, tape2]
 
             # execute both tapes in a batch on the given device
-            res = execute(tapes, dev, qml.gradients.param_shift)
+            res = qml.execute(tapes, dev, qml.gradients.param_shift, max_diff=2)
 
             return res[0][0] + res[1][0, 0] - res[1][0, 1]
 
@@ -291,7 +291,7 @@ def execute(
     >>> params = np.array([0.1, 0.2, 0.3], requires_grad=True)
     >>> x = np.array([0.5], requires_grad=True)
     >>> cost_fn(params, x)
-    1.9305068163274222
+    tensor(1.93050682, requires_grad=True)
 
     Since the ``execute`` function is differentiable, we can
     also compute the gradient:

--- a/pennylane/measurements.py
+++ b/pennylane/measurements.py
@@ -193,7 +193,7 @@ class MeasurementProcess:
         rotation and a measurement in the computational basis.
 
         Returns:
-            .JacobianTape: a quantum tape containing the operations
+            .QuantumTape: a quantum tape containing the operations
             required to diagonalize the observable
 
         **Example**
@@ -224,9 +224,7 @@ class MeasurementProcess:
         if self.obs is None:
             raise qml.operation.DecompositionUndefinedError
 
-        from pennylane.tape import JacobianTape  # pylint: disable=import-outside-toplevel
-
-        with JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             self.obs.diagonalizing_gates()
             MeasurementProcess(
                 self.return_type, wires=self.obs.wires, eigvals=self.obs.get_eigvals()

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -1098,7 +1098,7 @@ class Operator(abc.ABC):
         """Returns a tape that has recorded the decomposition of the operator.
 
         Returns:
-            .JacobianTape: quantum tape
+            .QuantumTape: quantum tape
         """
         tape = qml.tape.QuantumTape(do_queue=False)
 

--- a/pennylane/optimize/lie_algebra.py
+++ b/pennylane/optimize/lie_algebra.py
@@ -90,8 +90,8 @@ def algebra_commutator(tape, observables, lie_algebra_basis_names, nqubits):
     for obs in observables:
         for o in obs:
             # create a list of tapes for the plus and minus shifted circuits
-            tapes_plus = [qml.tape.JacobianTape(p + "_p") for p in lie_algebra_basis_names]
-            tapes_min = [qml.tape.JacobianTape(p + "_m") for p in lie_algebra_basis_names]
+            tapes_plus = [qml.tape.QuantumTape(p + "_p") for p in lie_algebra_basis_names]
+            tapes_min = [qml.tape.QuantumTape(p + "_m") for p in lie_algebra_basis_names]
 
             # loop through all operations on the input tape
             for op in tape.operations:

--- a/pennylane/qnode.py
+++ b/pennylane/qnode.py
@@ -482,7 +482,7 @@ class QNode:
     def construct(self, args, kwargs):
         """Call the quantum function with a tape context, ensuring the operations get queued."""
 
-        self._tape = qml.tape.JacobianTape()
+        self._tape = qml.tape.QuantumTape()
 
         with self.tape:
             self._qfunc_output = self.func(*args, **kwargs)

--- a/pennylane/qnode_old.py
+++ b/pennylane/qnode_old.py
@@ -40,6 +40,11 @@ from pennylane.tape import (
 class QNode:
     """Represents a quantum node in the hybrid computational graph.
 
+    .. warning::
+
+        This QNode is deprecated and due to be removed in an upcoming
+        release. Please use :class:`qml.QNode <.pennylane.QNode>` instead.
+
     A *quantum node* contains a :ref:`quantum function <intro_vcirc_qfunc>`
     (corresponding to a :ref:`variational circuit <glossary_variational_circuit>`)
     and the computational device it is executed on.
@@ -163,6 +168,11 @@ class QNode:
         argnum=None,
         **kwargs,
     ):
+        warnings.warn(
+            "qml.qnode_old.QNode is deprecated, and will be removed in an "
+            "upcoming release. Please use qml.QNode instead.",
+            UserWarning,
+        )
 
         if diff_method is None:
             # TODO: update this behaviour once the new differentiable pipeline is the default

--- a/pennylane/tape/cv_param_shift.py
+++ b/pennylane/tape/cv_param_shift.py
@@ -33,6 +33,12 @@ from .qubit_param_shift import QubitParamShiftTape, _get_operation_recipe
 class CVParamShiftTape(QubitParamShiftTape):
     r"""Quantum tape for CV parameter-shift analytic differentiation method.
 
+    .. warning::
+
+        The ``CVParamShiftTape`` is deprecated.
+        Please use a standard :class:`~.QuantumTape`, and apply gradient transforms using
+        the :mod:`.gradients` module to compute parameter-shift gradients.
+
     This class extends the :class:`~.jacobian` method of the quantum tape
     to support analytic gradients of Gaussian CV operations using the parameter-shift rule.
     This gradient method returns *exact* gradients, and can be computed directly

--- a/pennylane/tape/jacobian_tape.py
+++ b/pennylane/tape/jacobian_tape.py
@@ -51,6 +51,12 @@ class JacobianTape(QuantumTape):
 
         See :mod:`pennylane.tape` for more details.
 
+    .. warning::
+
+        The ``JacobianTape`` as well as the ``JacobianTape.jacobian()`` method is deprecated.
+        Please use a standard :class:`~.QuantumTape`, and apply gradient transforms using
+        the :mod:`.gradients` module to compute Jacobians.
+
     Args:
         name (str): a name given to the quantum tape
         do_queue (bool): Whether to queue this tape in a parent tape context.
@@ -439,6 +445,12 @@ class JacobianTape(QuantumTape):
     def jacobian(self, device, params=None, **options):
         r"""Compute the Jacobian of the parametrized quantum circuit recorded by the quantum tape.
 
+        .. warning::
+
+            The ``JacobianTape`` as well as the ``JacobianTape.jacobian()`` method is deprecated.
+            Please use a standard :class:`~.QuantumTape`, and apply gradient transforms using
+            the :mod:`.gradients` module to compute Jacobians.
+
         The quantum tape can be interpreted as a simple :math:`\mathbb{R}^m \to \mathbb{R}^n` function,
         mapping :math:`m` (trainable) gate parameters to :math:`n` measurement statistics,
         such as expectation values or probabilities.
@@ -543,6 +555,13 @@ class JacobianTape(QuantumTape):
         array([], shape=(4, 0), dtype=float64)
         """
         # pylint: disable=too-many-statements
+
+        warnings.warn(
+            "Differentiating tapes using JacobianTape.jacobian() is deprecated. "
+            "Please use ta standard QuantumTape with gradient transforms from "
+            "the qml.gradients module instead."
+        )
+
         if any(m.return_type is State for m in self.measurements):
             raise ValueError("The jacobian method does not support circuits that return the state")
 
@@ -665,6 +684,12 @@ class JacobianTape(QuantumTape):
     def hessian(self, device, params=None, **options):
         r"""Compute the Hessian of the parametrized quantum circuit recorded by the quantum tape.
 
+        .. warning::
+
+            The ``JacobianTape`` as well as the ``JacobianTape.hessian()`` method is deprecated.
+            Please use a standard :class:`~.QuantumTape`, and apply gradient transforms using
+            the :mod:`.gradients` module to compute Hessians.
+
         The quantum tape can be interpreted as a simple :math:`\mathbb{R}^m \to \mathbb{R}^n` function,
         mapping :math:`m` (trainable) gate parameters to :math:`n` measurement statistics,
         such as expectation values or probabilities.
@@ -738,6 +763,12 @@ class JacobianTape(QuantumTape):
         >>> tape.hessian(dev)
         array([], shape=(0, 0), dtype=float64)
         """
+        warnings.warn(
+            "Differentiating tapes using JacobianTape.hessian() is deprecated. "
+            "Please use ta standard QuantumTape with gradient transforms from "
+            "the qml.gradients module instead."
+        )
+
         if any(m.return_type is State for m in self.measurements):
             raise ValueError("The Hessian method does not support circuits that return the state")
 

--- a/pennylane/tape/qubit_param_shift.py
+++ b/pennylane/tape/qubit_param_shift.py
@@ -82,6 +82,12 @@ def _get_operation_recipe(op, p_idx, shifts):
 class QubitParamShiftTape(JacobianTape):
     r"""Quantum tape for qubit parameter-shift analytic differentiation method.
 
+    .. warning::
+
+        The ``QubitParamShiftTape`` is deprecated.
+        Please use a standard :class:`~.QuantumTape`, and apply gradient transforms using
+        the :mod:`.gradients` module to compute parameter-shift gradients.
+
     This class extends the :class:`~.jacobian` method of the quantum tape
     to support analytic gradients of qubit operations using the parameter-shift rule.
     This gradient method returns *exact* gradients, and can be computed directly

--- a/pennylane/tape/reversible.py
+++ b/pennylane/tape/reversible.py
@@ -34,6 +34,12 @@ ABC_ARRAY = np.array(list(ABC))
 class ReversibleTape(JacobianTape):
     r"""Quantum tape for computing gradients via reversible analytic differentiation.
 
+    .. warning::
+
+        The ``ReversibleTape`` is deprecated.
+        Instead, create a standard ``QuantumTape``, and use devices that support
+        native adjoint differentiation methods, such as ``default.qubit`` and ``lightning.qubit``.
+
     .. note::
 
         The reversible analytic differentiation method has the following restrictions:

--- a/pennylane/tape/tape.py
+++ b/pennylane/tape/tape.py
@@ -1361,6 +1361,11 @@ class QuantumTape(AnnotatedQueue):
 
         For more details on differentiable tape execution, see :meth:`~.execute`.
 
+        .. warning::
+
+            Executing tapes using ``tape.execute(dev)`` is deprecated.
+            Please use the :func:`~.execute` function instead.
+
         Args:
             device (~.Device): a PennyLane device
                 that can execute quantum operations and return measurement statistics

--- a/pennylane/tape/tape.py
+++ b/pennylane/tape/tape.py
@@ -118,10 +118,10 @@ def expand_tape(tape, depth=1, stop_at=None, expand_measurements=False):
 
     .. code-block:: python
 
-        with JacobianTape() as tape:
+        with QuantumTape() as tape:
             qml.BasisState(np.array([1, 1]), wires=[0, 'a'])
 
-            with JacobianTape() as tape2:
+            with QuantumTape() as tape2:
                 qml.Rot(0.543, 0.1, 0.4, wires=0)
 
             qml.CNOT(wires=[0, 'a'])
@@ -132,7 +132,7 @@ def expand_tape(tape, depth=1, stop_at=None, expand_measurements=False):
 
     >>> tape.operations
     [BasisState(array([1, 1]), wires=[0, 'a']),
-     <JacobianTape: wires=[0], params=3>,
+     <QuantumTape: wires=[0], params=3>,
      CNOT(wires=[0, 'a']),
      RY(0.2, wires=['a'])]
 
@@ -539,10 +539,10 @@ class QuantumTape(AnnotatedQueue):
 
         .. code-block:: python
 
-            with JacobianTape() as tape:
+            with QuantumTape() as tape:
                 qml.BasisState(np.array([1, 1]), wires=[0, 'a'])
 
-                with JacobianTape() as tape2:
+                with QuantumTape() as tape2:
                     qml.Rot(0.543, 0.1, 0.4, wires=0)
 
                 qml.CNOT(wires=[0, 'a'])
@@ -553,7 +553,7 @@ class QuantumTape(AnnotatedQueue):
 
         >>> tape.operations
         [BasisState(array([1, 1]), wires=[0, 'a']),
-         <JacobianTape: wires=[0], params=3>,
+         <QuantumTape: wires=[0], params=3>,
          CNOT(wires=[0, 'a']),
          RY(0.2, wires=['a'])]
 
@@ -590,7 +590,7 @@ class QuantumTape(AnnotatedQueue):
 
         .. code-block:: python
 
-            with JacobianTape() as tape:
+            with QuantumTape() as tape:
                 qml.BasisState(np.array([1, 1]), wires=[0, 'a'])
                 qml.RX(0.432, wires=0)
                 qml.Rot(0.543, 0.1, 0.4, wires=0).inv()
@@ -709,21 +709,20 @@ class QuantumTape(AnnotatedQueue):
         automatically excluded from the Jacobian computation.
 
         The number of trainable parameters determines the number of parameters passed to
-        :meth:`~.set_parameters`, :meth:`~.execute`, and :meth:`~.JacobianTape.jacobian`,
-        and changes the default output size of methods :meth:`~.JacobianTape.jacobian` and
-        :meth:`~.get_parameters()`.
+        :meth:`~.set_parameters`, and changes the default output size of method :meth:`~.get_parameters()`.
 
         .. note::
 
-            Since the :meth:`~.JacobianTape.jacobian` method is not called for devices that support
-            native backpropagation (such as ``default.qubit.tf`` and ``default.qubit.autograd``),
-            this property contains no relevant information when using backpropagation to compute gradients.
+            For devices that support native backpropagation (such as
+            ``default.qubit.tf`` and ``default.qubit.autograd``), this
+            property contains no relevant information when using
+            backpropagation to compute gradients.
 
         **Example**
 
         .. code-block:: python
 
-            with JacobianTape() as tape:
+            with QuantumTape() as tape:
                 qml.RX(0.432, wires=0)
                 qml.RY(0.543, wires=0)
                 qml.CNOT(wires=[0, 'a'])
@@ -792,7 +791,7 @@ class QuantumTape(AnnotatedQueue):
 
         .. code-block:: python
 
-            with JacobianTape() as tape:
+            with QuantumTape() as tape:
                 qml.RX(0.432, wires=0)
                 qml.RY(0.543, wires=0)
                 qml.CNOT(wires=[0, 'a'])
@@ -839,7 +838,7 @@ class QuantumTape(AnnotatedQueue):
 
         .. code-block:: python
 
-            with JacobianTape() as tape:
+            with QuantumTape() as tape:
                 qml.RX(0.432, wires=0)
                 qml.RY(0.543, wires=0)
                 qml.CNOT(wires=[0, 'a'])
@@ -926,7 +925,7 @@ class QuantumTape(AnnotatedQueue):
 
         .. code-block:: python
 
-            with JacobianTape() as tape:
+            with QuantumTape() as tape:
                 qml.RX(0.432, wires=0)
                 qml.RY(0.543, wires=0)
                 qml.CNOT(wires=[0, 'a'])
@@ -949,7 +948,7 @@ class QuantumTape(AnnotatedQueue):
 
         .. code-block:: python
 
-            with JacobianTape() as tape:
+            with QuantumTape() as tape:
                 qml.RX(0.432, wires=0)
                 qml.RY(0.543, wires=0)
                 qml.CNOT(wires=[0, 'a'])
@@ -984,7 +983,7 @@ class QuantumTape(AnnotatedQueue):
 
         .. code-block:: python
 
-            with JacobianTape() as tape:
+            with QuantumTape() as tape:
                 qml.RX(0.432, wires=0)
                 qml.RY(0.543, wires=0)
                 qml.CNOT(wires=[0, 'a'])
@@ -1305,6 +1304,11 @@ class QuantumTape(AnnotatedQueue):
     def execute(self, device, params=None):
         """Execute the tape on a quantum device.
 
+        .. warning::
+
+            Executing tapes using ``tape.execute(dev)`` is deprecated.
+            Please use the :func:`~.execute` function instead.
+
         Args:
             device (.Device): a PennyLane device
                 that can execute quantum operations and return measurement statistics
@@ -1315,7 +1319,7 @@ class QuantumTape(AnnotatedQueue):
 
         .. code-block:: python
 
-            with JacobianTape() as tape:
+            with QuantumTape() as tape:
                 qml.RX(0.432, wires=0)
                 qml.RY(0.543, wires=0)
                 qml.CNOT(wires=[0, 'a'])
@@ -1339,6 +1343,11 @@ class QuantumTape(AnnotatedQueue):
         >>> tape.get_parameters()
         [0.432, 0.543, 0.133]
         """
+        warnings.warn(
+            "Executing tapes using tape.execute(dev) is deprecated. "
+            "Please use the qml.execute([tape], dev) function instead."
+        )
+
         if params is None:
             params = self.get_parameters()
 

--- a/pennylane/tape/tape.py
+++ b/pennylane/tape/tape.py
@@ -19,6 +19,7 @@ from collections import Counter, deque, defaultdict
 import contextlib
 import copy
 from threading import RLock
+import warnings
 
 import numpy as np
 
@@ -254,19 +255,10 @@ class QuantumTape(AnnotatedQueue):
     <pennylane.circuit_graph.CircuitGraph object at 0x7fcc0433a690>
 
     Once constructed, the quantum tape can be executed directly on a supported
-    device:
+    device via the :func:`~.execute` function:
 
     >>> dev = qml.device("default.qubit", wires=[0, 'a'])
-
-    Execution can take place either using the in-place constructed parameters,
-
-    >>> tape.execute(dev)
-    [0.77750694]
-
-    or by providing parameters at run time:
-
-    >>> tape.execute(dev, params=[0.1, 0.1, 0.1])
-    [0.99003329]
+    >>> qml.execute([tape], dev, gradient_fn=None)
 
     The trainable parameters of the tape can be explicitly set, and the values of
     the parameters modified in-place:

--- a/pennylane/tape/tape.py
+++ b/pennylane/tape/tape.py
@@ -259,6 +259,7 @@ class QuantumTape(AnnotatedQueue):
 
     >>> dev = qml.device("default.qubit", wires=[0, 'a'])
     >>> qml.execute([tape], dev, gradient_fn=None)
+    [array([0.77750694])]
 
     The trainable parameters of the tape can be explicitly set, and the values of
     the parameters modified in-place:

--- a/pennylane/transforms/batch_transform.py
+++ b/pennylane/transforms/batch_transform.py
@@ -76,8 +76,8 @@ class batch_transform:
             '''Generates two tapes, one with all RX replaced with RY,
             and the other with all RX replaced with RZ.'''
 
-            tape1 = qml.tape.JacobianTape()
-            tape2 = qml.tape.JacobianTape()
+            tape1 = qml.tape.QuantumTape()
+            tape2 = qml.tape.QuantumTape()
 
             # loop through all operations on the input tape
             for op in tape.operations + tape.measurements:
@@ -102,7 +102,7 @@ class batch_transform:
 
     We can apply this transform to a quantum tape:
 
-    >>> with qml.tape.JacobianTape() as tape:
+    >>> with qml.tape.QuantumTape() as tape:
     ...     qml.Hadamard(wires=0)
     ...     qml.RX(-0.5, wires=0)
     ...     qml.expval(qml.PauliX(0))

--- a/pennylane/transforms/qfunc_transforms.py
+++ b/pennylane/transforms/qfunc_transforms.py
@@ -139,7 +139,7 @@ class single_tape_transform:
 
     We can apply this transform to a quantum tape:
 
-    >>> with qml.tape.JacobianTape() as tape:
+    >>> with qml.tape.QuantumTape() as tape:
     ...     qml.Hadamard(wires=0)
     ...     qml.CRX(-0.5, wires=[0, 1])
     >>> new_tape = my_transform(tape, 1., 2.)

--- a/pennylane/transforms/tape_expand.py
+++ b/pennylane/transforms/tape_expand.py
@@ -74,7 +74,7 @@ def create_expand_fn(depth, stop_at=None, device=None, docstring=None):
 
     .. code-block:: python
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(0.2, wires=0)
             qml.RX(qml.numpy.array(-2.4, requires_grad=True), wires=1)
             qml.Rot(1.7, 0.92, -1.1, wires=0)

--- a/tests/gradients/test_finite_difference.py
+++ b/tests/gradients/test_finite_difference.py
@@ -111,7 +111,7 @@ class TestShiftedTapes:
     def test_multipliers(self):
         """Test that the function behaves as expected when multipliers are used"""
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.PauliZ(0)
             qml.RX(1.0, wires=0)
             qml.CNOT(wires=[0, 2])
@@ -136,7 +136,7 @@ class TestFiniteDiff:
         respect to a non-differentiable argument"""
         psi = np.array([1, 0, 1, 0], requires_grad=False) / np.sqrt(2)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.QubitStateVector(psi, wires=[0, 1])
             qml.RX(0.543, wires=[0])
             qml.RY(-0.654, wires=[1])
@@ -165,7 +165,7 @@ class TestFiniteDiff:
         during the Jacobian computation."""
         spy = mocker.spy(qml.gradients.finite_difference, "generate_shifted_tapes")
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(0.543, wires=[0])
             qml.RY(-0.654, wires=[1])
             qml.expval(qml.PauliZ(0))
@@ -245,7 +245,7 @@ class TestFiniteDiff:
         values."""
         dev = qml.device("default.qubit", wires=2)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(0.543, wires=[0])
             qml.RY(-0.654, wires=[0])
             qml.expval(qml.PauliZ(0))
@@ -262,7 +262,7 @@ class TestFiniteDiff:
         values."""
         dev = qml.device("default.qubit", wires=2)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(0.543, wires=[0])
             qml.RY(-0.654, wires=[0])
             qml.expval(qml.PauliZ(0))
@@ -278,12 +278,12 @@ class TestFiniteDiff:
         parameters, the gradient should be evaluated to zero without executing the device."""
         dev = qml.device("default.qubit", wires=2)
 
-        with qml.tape.JacobianTape() as tape1:
+        with qml.tape.QuantumTape() as tape1:
             qml.RX(1, wires=[0])
             qml.RX(1, wires=[1])
             qml.expval(qml.PauliZ(0))
 
-        with qml.tape.JacobianTape() as tape2:
+        with qml.tape.QuantumTape() as tape2:
             qml.RX(1, wires=[0])
             qml.RX(1, wires=[1])
             qml.expval(qml.PauliZ(1))
@@ -314,7 +314,7 @@ class TestFiniteDiffIntegration:
         dev = qml.device("default.qubit", wires=3)
         params = [1.0, 1.0, 1.0]
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(params[0], wires=[0])
             qml.RY(params[1], wires=[1])
             qml.RZ(params[2], wires=[2])
@@ -333,7 +333,7 @@ class TestFiniteDiffIntegration:
         x = 0.543
         y = -0.654
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(x, wires=[0])
             qml.RY(y, wires=[1])
             qml.CNOT(wires=[0, 1])
@@ -354,7 +354,7 @@ class TestFiniteDiffIntegration:
         x = 0.543
         y = -0.654
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(x, wires=[0])
             qml.RY(y, wires=[1])
             qml.CNOT(wires=[0, 1])
@@ -380,7 +380,7 @@ class TestFiniteDiffIntegration:
         x = 0.543
         y = -0.654
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(x, wires=[0])
             qml.RY(y, wires=[1])
             qml.CNOT(wires=[0, 1])
@@ -404,7 +404,7 @@ class TestFiniteDiffIntegration:
         x = 0.543
         y = -0.654
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(x, wires=[0])
             qml.RY(y, wires=[1])
             qml.CNOT(wires=[0, 1])
@@ -425,7 +425,7 @@ class TestFiniteDiffIntegration:
         x = 0.543
         y = -0.654
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(x, wires=[0])
             qml.RY(y, wires=[1])
             qml.CNOT(wires=[0, 1])
@@ -446,7 +446,7 @@ class TestFiniteDiffIntegration:
         x = 0.543
         y = -0.654
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(x, wires=[0])
             qml.RY(y, wires=[1])
             qml.CNOT(wires=[0, 1])
@@ -497,7 +497,7 @@ class TestFiniteDiffGradients:
         params = np.array([0.543, -0.654], requires_grad=True)
 
         def cost_fn(x):
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RX(x[0], wires=[0])
                 qml.RY(x[1], wires=[1])
                 qml.CNOT(wires=[0, 1])
@@ -525,7 +525,7 @@ class TestFiniteDiffGradients:
         params = np.array([0.543, -0.654], requires_grad=True)
 
         def cost_fn(x):
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RX(x[0], wires=[0])
                 qml.RY(x[1], wires=[1])
                 qml.CNOT(wires=[0, 1])
@@ -552,7 +552,7 @@ class TestFiniteDiffGradients:
         params = tf.Variable([0.543, -0.654], dtype=tf.float64)
 
         with tf.GradientTape() as t:
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RX(params[0], wires=[0])
                 qml.RY(params[1], wires=[1])
                 qml.CNOT(wires=[0, 1])
@@ -584,7 +584,7 @@ class TestFiniteDiffGradients:
         params = tf.Variable([0.543, -0.654], dtype=tf.float64)
 
         with tf.GradientTape() as t:
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RX(params[0], wires=[0])
                 qml.RY(params[1], wires=[1])
                 qml.CNOT(wires=[0, 1])
@@ -608,7 +608,7 @@ class TestFiniteDiffGradients:
         dev = qml.device("default.qubit.torch", wires=2)
         params = torch.tensor([0.543, -0.654], dtype=torch.float64, requires_grad=True)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(params[0], wires=[0])
             qml.RY(params[1], wires=[1])
             qml.CNOT(wires=[0, 1])
@@ -646,7 +646,7 @@ class TestFiniteDiffGradients:
         params = jnp.array([0.543, -0.654])
 
         def cost_fn(x):
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RX(x[0], wires=[0])
                 qml.RY(x[1], wires=[1])
                 qml.CNOT(wires=[0, 1])

--- a/tests/gradients/test_gradient_transform.py
+++ b/tests/gradients/test_gradient_transform.py
@@ -24,14 +24,13 @@ from pennylane.gradients.gradient_transform import (
 
 
 class TestGradMethodValidation:
-    """Test the helper function grad_method_validation, which is a
-    reduced copy of the eponymous method of ``JacobianTape``."""
+    """Test the helper function grad_method_validation."""
 
     @pytest.mark.parametrize("method", ["analytic", "best"])
     def test_with_nondiff_parameters(self, method):
         """Test that trainable parameters without grad_method
         are detected correctly, raising an exception."""
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(np.array(0.1, requires_grad=True), wires=0)
             qml.RX(np.array(0.1, requires_grad=True), wires=0)
             qml.expval(qml.PauliZ(0))
@@ -43,7 +42,7 @@ class TestGradMethodValidation:
     def test_with_numdiff_parameters_and_analytic(self):
         """Test that trainable parameters with numerical grad_method ``"F"``
         together with ``method="analytic"`` raises an exception."""
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(np.array(0.1, requires_grad=True), wires=0)
             qml.RX(np.array(0.1, requires_grad=True), wires=0)
             qml.expval(qml.PauliZ(0))
@@ -54,8 +53,7 @@ class TestGradMethodValidation:
 
 
 class TestChooseGradMethods:
-    """Test the helper function choose_grad_methods, which is a
-    reduced copy of the eponymous method of ``JacobianTape``."""
+    """Test the helper function choose_grad_methods"""
 
     all_diff_methods = [
         ["A"] * 2,

--- a/tests/gradients/test_hamiltonian_gradient.py
+++ b/tests/gradients/test_hamiltonian_gradient.py
@@ -21,7 +21,7 @@ def test_behaviour():
 
     dev = qml.device("default.qubit", wires=2)
 
-    with qml.tape.JacobianTape() as tape:
+    with qml.tape.QuantumTape() as tape:
         qml.RY(0.3, wires=0)
         qml.RX(0.5, wires=1)
         qml.CNOT(wires=[0, 1])
@@ -34,13 +34,13 @@ def test_behaviour():
     tapes, processing_fn = hamiltonian_grad(tape, idx=1)
     res2 = processing_fn(dev.batch_execute(tapes))
 
-    with qml.tape.JacobianTape() as tape1:
+    with qml.tape.QuantumTape() as tape1:
         qml.RY(0.3, wires=0)
         qml.RX(0.5, wires=1)
         qml.CNOT(wires=[0, 1])
         qml.expval(qml.PauliZ(0))
 
-    with qml.tape.JacobianTape() as tape2:
+    with qml.tape.QuantumTape() as tape2:
         qml.RY(0.3, wires=0)
         qml.RX(0.5, wires=1)
         qml.CNOT(wires=[0, 1])

--- a/tests/gradients/test_parameter_shift.py
+++ b/tests/gradients/test_parameter_shift.py
@@ -17,7 +17,7 @@ import pytest
 import pennylane as qml
 from pennylane import numpy as np
 from pennylane.gradients import param_shift
-from pennylane.gradients.parameter_shift import _gradient_analysis
+from pennylane.gradients.gradient_transform import gradient_analysis
 
 
 class TestGradAnalysis:
@@ -35,7 +35,7 @@ class TestGradAnalysis:
             qml.CNOT(wires=[0, 1])
             qml.probs(wires=[0, 1])
 
-        _gradient_analysis(tape)
+        gradient_analysis(tape)
 
         assert tape._par_info[0]["grad_method"] is None
         assert tape._par_info[1]["grad_method"] == "A"
@@ -53,7 +53,7 @@ class TestGradAnalysis:
             qml.probs(wires=[0, 1])
 
         spy = mocker.spy(qml.operation, "has_grad_method")
-        _gradient_analysis(tape)
+        gradient_analysis(tape)
         spy.assert_called()
 
         assert tape._par_info[0]["grad_method"] is None
@@ -61,7 +61,7 @@ class TestGradAnalysis:
         assert tape._par_info[2]["grad_method"] == "A"
 
         spy = mocker.spy(qml.operation, "has_grad_method")
-        _gradient_analysis(tape)
+        gradient_analysis(tape)
         spy.assert_not_called()
 
     def test_independent(self):
@@ -73,7 +73,7 @@ class TestGradAnalysis:
             qml.RY(-0.654, wires=[1])
             qml.expval(qml.PauliY(0))
 
-        _gradient_analysis(tape)
+        gradient_analysis(tape)
 
         assert tape._par_info[0]["grad_method"] == "A"
         assert tape._par_info[1]["grad_method"] == "0"
@@ -87,7 +87,7 @@ class TestGradAnalysis:
             qml.RY(-0.654, wires=[1])
             qml.expval(qml.PauliY(0))
 
-        _gradient_analysis(tape, use_graph=False)
+        gradient_analysis(tape, use_graph=False)
 
         assert tape._par_info[0]["grad_method"] == "A"
         assert tape._par_info[1]["grad_method"] == "A"
@@ -105,7 +105,7 @@ class TestGradAnalysis:
             qml.CNOT(wires=[0, 1])
             qml.probs(wires=[0, 1])
 
-        _gradient_analysis(tape)
+        gradient_analysis(tape)
 
         assert tape._par_info[0]["grad_method"] is None
         assert tape._par_info[1]["grad_method"] == "F"

--- a/tests/gradients/test_parameter_shift.py
+++ b/tests/gradients/test_parameter_shift.py
@@ -28,7 +28,7 @@ class TestGradAnalysis:
         correctly marked"""
         psi = np.array([1, 0, 1, 0]) / np.sqrt(2)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.QubitStateVector(psi, wires=[0, 1])
             qml.RX(0.543, wires=[0])
             qml.RY(-0.654, wires=[1])
@@ -42,10 +42,11 @@ class TestGradAnalysis:
         assert tape._par_info[2]["grad_method"] == "A"
 
     def test_analysis_caching(self, mocker):
-        """Test that the gradient analysis is only executed once per tape"""
+        """Test that the gradient analysis is only executed once per tape
+        if grad_fn is set an unchanged."""
         psi = np.array([1, 0, 1, 0]) / np.sqrt(2)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.QubitStateVector(psi, wires=[0, 1])
             qml.RX(0.543, wires=[0])
             qml.RY(-0.654, wires=[1])
@@ -53,7 +54,7 @@ class TestGradAnalysis:
             qml.probs(wires=[0, 1])
 
         spy = mocker.spy(qml.operation, "has_grad_method")
-        gradient_analysis(tape)
+        gradient_analysis(tape, grad_fn=5)
         spy.assert_called()
 
         assert tape._par_info[0]["grad_method"] is None
@@ -61,14 +62,14 @@ class TestGradAnalysis:
         assert tape._par_info[2]["grad_method"] == "A"
 
         spy = mocker.spy(qml.operation, "has_grad_method")
-        gradient_analysis(tape)
+        gradient_analysis(tape, grad_fn=5)
         spy.assert_not_called()
 
     def test_independent(self):
         """Test that an independent variable is properly marked
         as having a zero gradient"""
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(0.543, wires=[0])
             qml.RY(-0.654, wires=[1])
             qml.expval(qml.PauliY(0))
@@ -82,7 +83,7 @@ class TestGradAnalysis:
         """In non-graph mode, it is impossible to determine
         if a parameter is independent or not"""
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(0.543, wires=[0])
             qml.RY(-0.654, wires=[1])
             qml.expval(qml.PauliY(0))
@@ -98,7 +99,7 @@ class TestGradAnalysis:
 
         psi = np.array([1, 0, 1, 0]) / np.sqrt(2)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.QubitStateVector(psi, wires=[0, 1])
             qml.RX(0.543, wires=[0])
             qml.RY(-0.654, wires=[1])
@@ -124,7 +125,7 @@ class TestShiftedTapes:
     def test_behaviour(self):
         """Test that the function behaves as expected"""
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.PauliZ(0)
             qml.RX(1.0, wires=0)
             qml.CNOT(wires=[0, 2])
@@ -148,7 +149,7 @@ class TestParamShift:
 
     def test_empty_circuit(self):
         """Test that an empty circuit works correctly"""
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.expval(qml.PauliZ(0))
 
         with pytest.warns(UserWarning, match="gradient of a tape with no trainable parameters"):
@@ -157,7 +158,7 @@ class TestParamShift:
 
     def test_all_parameters_independent(self):
         """Test that a circuit where all parameters do not affect the output"""
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(0.4, wires=0)
             qml.expval(qml.PauliZ(1))
 
@@ -169,7 +170,7 @@ class TestParamShift:
         respect to a state"""
         psi = np.array([1, 0, 1, 0]) / np.sqrt(2)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(0.543, wires=[0])
             qml.RY(-0.654, wires=[1])
             qml.state()
@@ -182,7 +183,7 @@ class TestParamShift:
         during the Jacobian computation."""
         spy = mocker.spy(qml.gradients.parameter_shift, "expval_param_shift")
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(0.543, wires=[0])
             qml.RY(-0.654, wires=[1])
             qml.expval(qml.PauliZ(0))
@@ -262,7 +263,7 @@ class TestParamShift:
         values."""
         dev = qml.device("default.qubit", wires=2)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(0.543, wires=[0])
             qml.RY(-0.654, wires=[0])
             qml.expval(qml.PauliZ(0))
@@ -279,7 +280,7 @@ class TestParamShift:
         values."""
         dev = qml.device("default.qubit", wires=2)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(0.543, wires=[0])
             qml.RY(-0.654, wires=[0])
             qml.expval(qml.PauliZ(0))
@@ -298,12 +299,12 @@ class TestParamShift:
         parameters, the gradient should be evaluated to zero without executing the device."""
         dev = qml.device("default.qubit", wires=2)
 
-        with qml.tape.JacobianTape() as tape1:
+        with qml.tape.QuantumTape() as tape1:
             qml.RX(1, wires=[0])
             qml.RX(1, wires=[1])
             qml.expval(qml.PauliZ(0))
 
-        with qml.tape.JacobianTape() as tape2:
+        with qml.tape.QuantumTape() as tape2:
             qml.RX(1, wires=[0])
             qml.RX(1, wires=[1])
             qml.expval(qml.PauliZ(1))
@@ -345,7 +346,7 @@ class TestParamShift:
         x = np.array(0.654, requires_grad=True)
         dev = qml.device("default.qubit", wires=2)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             RX(x, wires=0)
             qml.expval(qml.PauliZ(0))
 
@@ -382,7 +383,7 @@ class TestParamShift:
         dev = qml.device("default.qubit", wires=2)
 
         for op in [RX, NewOp]:
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 op(x, wires=0)
                 qml.expval(qml.PauliZ(0))
 
@@ -403,7 +404,7 @@ class TestParameterShiftRule:
         spy = mocker.spy(qml.gradients.parameter_shift, "_get_operation_recipe")
         dev = qml.device("default.qubit", wires=1)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.QubitStateVector(np.array([1.0, -1.0], requires_grad=False) / np.sqrt(2), wires=0)
             G(theta, wires=[0])
             qml.expval(qml.PauliZ(0))
@@ -414,10 +415,12 @@ class TestParameterShiftRule:
         assert len(tapes) == 2
 
         autograd_val = fn(dev.batch_execute(tapes))
-        manualgrad_val = (
-            tape.execute(dev, params=[theta + np.pi / 2])
-            - tape.execute(dev, params=[theta - np.pi / 2])
-        ) / 2
+
+        tape_fwd, tape_bwd = tape.copy(copy_operations=True), tape.copy(copy_operations=True)
+        tape_fwd.set_parameters([theta + np.pi / 2])
+        tape_bwd.set_parameters([theta - np.pi / 2])
+
+        manualgrad_val = np.subtract(*dev.batch_execute([tape_fwd, tape_bwd])) / 2
         assert np.allclose(autograd_val, manualgrad_val, atol=tol, rtol=0)
 
         assert spy.call_args[1]["shifts"] == (shift,)
@@ -435,7 +438,7 @@ class TestParameterShiftRule:
         dev = qml.device("default.qubit", wires=1)
         params = np.array([theta, theta**3, np.sqrt(2) * theta])
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.QubitStateVector(np.array([1.0, -1.0], requires_grad=False) / np.sqrt(2), wires=0)
             qml.Rot(*params, wires=[0])
             qml.expval(qml.PauliZ(0))
@@ -452,8 +455,11 @@ class TestParameterShiftRule:
             s = np.zeros_like(params)
             s[idx] += np.pi / 2
 
-            forward = tape.execute(dev, params=params + s)
-            backward = tape.execute(dev, params=params - s)
+            tape.set_parameters(params + s)
+            forward = dev.execute(tape)
+
+            tape.set_parameters(params - s)
+            backward = dev.execute(tape)
 
             manualgrad_val[0, idx] = (forward - backward) / 2
 
@@ -471,14 +477,14 @@ class TestParameterShiftRule:
         dev = qml.device("default.qubit", wires=2)
         b = 0.123
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.QubitStateVector(np.array([1.0, -1.0], requires_grad=False) / np.sqrt(2), wires=0)
             G(b, wires=[0, 1])
             qml.expval(qml.PauliX(0))
 
         tape.trainable_params = {1}
 
-        res = tape.execute(dev)
+        res = dev.execute(tape)
         assert np.allclose(res, -np.cos(b / 2), atol=tol, rtol=0)
 
         tapes, fn = qml.gradients.param_shift(tape)
@@ -498,14 +504,14 @@ class TestParameterShiftRule:
         dev = qml.device("default.qubit", wires=2)
         a, b, c = np.array([theta, theta**3, np.sqrt(2) * theta])
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.QubitStateVector(np.array([1.0, -1.0], requires_grad=False) / np.sqrt(2), wires=0)
             qml.CRot(a, b, c, wires=[0, 1])
             qml.expval(qml.PauliX(0))
 
         tape.trainable_params = {1, 2, 3}
 
-        res = tape.execute(dev)
+        res = dev.execute(tape)
         expected = -np.cos(b / 2) * np.cos(0.5 * (a + c))
         assert np.allclose(res, expected, atol=tol, rtol=0)
 
@@ -534,7 +540,7 @@ class TestParameterShiftRule:
         order finite differences"""
         params = np.array([0.1, -1.6, np.pi / 5])
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(params[0], wires=[0])
             qml.CNOT(wires=[0, 1])
             qml.RY(-1.6, wires=[0])
@@ -562,7 +568,7 @@ class TestParameterShiftRule:
         order finite differences"""
         params = np.array([0.1, -1.6, np.pi / 5])
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(params[0], wires=[0])
             qml.CNOT(wires=[0, 1])
             qml.RY(-1.6, wires=[0])
@@ -598,7 +604,7 @@ class TestParameterShiftRule:
             grad_method = "F"
 
         def cost_fn(params):
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RX(params[0], wires=[0])
                 RY(params[1], wires=[1])
                 qml.CNOT(wires=[0, 1])
@@ -643,7 +649,7 @@ class TestParameterShiftRule:
         class RX(qml.RX):
             grad_method = "F"
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             RX(x, wires=[0])
             RY(y, wires=[1])
             qml.CNOT(wires=[0, 1])
@@ -669,7 +675,7 @@ class TestParameterShiftRule:
         x = 0.543
         y = -0.654
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(x, wires=[0])
             qml.RY(y, wires=[1])
             qml.CNOT(wires=[0, 1])
@@ -691,7 +697,7 @@ class TestParameterShiftRule:
         x = 0.543
         y = -0.654
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(x, wires=[0])
             qml.RY(y, wires=[1])
             qml.CNOT(wires=[0, 1])
@@ -714,7 +720,7 @@ class TestParameterShiftRule:
         x = 0.543
         y = -0.654
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(x, wires=[0])
             qml.RY(y, wires=[1])
             qml.CNOT(wires=[0, 1])
@@ -737,7 +743,7 @@ class TestParameterShiftRule:
         x = 0.543
         y = -0.654
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(x, wires=[0])
             qml.RY(y, wires=[1])
             qml.CNOT(wires=[0, 1])
@@ -782,11 +788,11 @@ class TestParameterShiftRule:
         dev = qml.device("default.qubit", wires=1)
         a = 0.54
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(a, wires=0)
             qml.var(qml.PauliZ(0))
 
-        res = tape.execute(dev)
+        res = dev.execute(tape)
         expected = 1 - np.cos(a) ** 2
         assert np.allclose(res, expected, atol=tol, rtol=0)
 
@@ -810,13 +816,13 @@ class TestParameterShiftRule:
         A = np.array([[4, -1 + 6j], [-1 - 6j, 2]])
         a = 0.54
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(a, wires=0)
             qml.var(qml.Hermitian(A, 0))
 
         tape.trainable_params = {0}
 
-        res = tape.execute(dev)
+        res = dev.execute(tape)
         expected = (39 / 2) - 6 * np.sin(2 * a) + (35 / 2) * np.cos(2 * a)
         assert np.allclose(res, expected, atol=tol, rtol=0)
 
@@ -840,7 +846,7 @@ class TestParameterShiftRule:
         A = np.array([[4, -1 + 6j], [-1 - 6j, 2]])
         a = 0.54
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(a, wires=0)
             qml.RX(a, wires=1)
             qml.var(qml.PauliZ(0))
@@ -848,7 +854,7 @@ class TestParameterShiftRule:
 
         tape.trainable_params = {0, 1}
 
-        res = tape.execute(dev)
+        res = dev.execute(tape)
         expected = [1 - np.cos(a) ** 2, (39 / 2) - 6 * np.sin(2 * a) + (35 / 2) * np.cos(2 * a)]
         assert np.allclose(res, expected, atol=tol, rtol=0)
 
@@ -874,7 +880,7 @@ class TestParameterShiftRule:
         b = -0.423
         c = 0.123
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(a, wires=0)
             qml.RY(b, wires=1)
             qml.CNOT(wires=[1, 2])
@@ -884,7 +890,7 @@ class TestParameterShiftRule:
             qml.expval(qml.PauliZ(1))
             qml.var(qml.PauliZ(2))
 
-        res = tape.execute(dev)
+        res = dev.execute(tape)
         expected = np.array(
             [
                 np.sin(a) ** 2,
@@ -921,7 +927,7 @@ class TestParameterShiftRule:
         P = np.array([1])
         x, y = 0.765, -0.654
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(x, wires=0)
             qml.RY(y, wires=1)
             qml.CNOT(wires=[0, 1])
@@ -929,7 +935,7 @@ class TestParameterShiftRule:
 
         tape.trainable_params = {0, 1}
 
-        res = tape.execute(dev)
+        res = dev.execute(tape)
         expected = 0.25 * np.sin(x / 2) ** 2 * (3 + np.cos(2 * y) + 2 * np.cos(x) * np.sin(y) ** 2)
         assert np.allclose(res, expected, atol=tol, rtol=0)
 
@@ -962,7 +968,7 @@ class TestParamShiftGradients:
         params = np.array([0.543, -0.654], requires_grad=True)
 
         def cost_fn(x):
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RX(x[0], wires=[0])
                 qml.RY(x[1], wires=[1])
                 qml.CNOT(wires=[0, 1])
@@ -993,7 +999,7 @@ class TestParamShiftGradients:
         params = tf.Variable([0.543, -0.654], dtype=tf.float64)
 
         with tf.GradientTape() as t:
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RX(params[0], wires=[0])
                 qml.RY(params[1], wires=[1])
                 qml.CNOT(wires=[0, 1])
@@ -1025,7 +1031,7 @@ class TestParamShiftGradients:
         dev = qml.device("default.qubit.torch", wires=2)
         params = torch.tensor([0.543, -0.654], dtype=torch.float64, requires_grad=True)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(params[0], wires=[0])
             qml.RY(params[1], wires=[1])
             qml.CNOT(wires=[0, 1])
@@ -1058,7 +1064,7 @@ class TestParamShiftGradients:
         params = jnp.array([0.543, -0.654])
 
         def cost_fn(x):
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RX(x[0], wires=[0])
                 qml.RY(x[1], wires=[1])
                 qml.CNOT(wires=[0, 1])
@@ -1095,7 +1101,7 @@ class TestHamiltonianExpvalGradients:
 
         weights = np.array([0.4, 0.5])
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(weights[0], wires=0)
             qml.RY(weights[1], wires=1)
             qml.CNOT(wires=[0, 1])
@@ -1117,7 +1123,7 @@ class TestHamiltonianExpvalGradients:
 
         weights = np.array([0.4, 0.5])
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(weights[0], wires=0)
             qml.RY(weights[1], wires=1)
             qml.CNOT(wires=[0, 1])
@@ -1156,7 +1162,7 @@ class TestHamiltonianExpvalGradients:
 
         weights = np.array([0.4, 0.5])
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(weights[0], wires=0)
             qml.RY(weights[1], wires=1)
             qml.CNOT(wires=[0, 1])
@@ -1204,7 +1210,7 @@ class TestHamiltonianExpvalGradients:
         weights = np.array([0.4, 0.5])
         x, y = weights
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(weights[0], wires=0)
             qml.RY(weights[1], wires=1)
             qml.CNOT(wires=[0, 1])
@@ -1247,7 +1253,7 @@ class TestHamiltonianExpvalGradients:
         obs2 = [qml.PauliZ(0)]
         H2 = qml.Hamiltonian(coeffs2, obs2)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(weights[0], wires=0)
             qml.RY(weights[1], wires=1)
             qml.CNOT(wires=[0, 1])

--- a/tests/gradients/test_parameter_shift_cv.py
+++ b/tests/gradients/test_parameter_shift_cv.py
@@ -34,7 +34,7 @@ class TestGradAnalysis:
         """Test that a non-differentiable parameter is
         correctly marked"""
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.FockState(1, wires=0)
             qml.Displacement(0.543, 0, wires=[1])
             qml.Beamsplitter(0, 0, wires=[0, 1])
@@ -60,7 +60,7 @@ class TestGradAnalysis:
         """Test that an independent variable is properly marked
         as having a zero gradient"""
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.Rotation(0.543, wires=[0])
             qml.Rotation(-0.654, wires=[1])
             qml.expval(qml.P(0))
@@ -75,10 +75,10 @@ class TestGradAnalysis:
 
     def test_finite_diff(self, monkeypatch):
         """If an op has grad_method=F, this should be respected
-        by the qml.tape.JacobianTape"""
+        by the qml.tape.QuantumTape"""
         monkeypatch.setattr(qml.Rotation, "grad_method", "F")
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.Rotation(0.543, wires=[0])
             qml.Squeezing(0.543, 0, wires=[0])
             qml.expval(qml.P(0))
@@ -92,7 +92,7 @@ class TestGradAnalysis:
         a differentiable Gaussian operation results in
         numeric differentiation."""
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.Rotation(1.0, wires=[0])
             qml.Rotation(1.0, wires=[1])
             # Non-Gaussian
@@ -107,7 +107,7 @@ class TestGradAnalysis:
         # Kerr gate does not support the parameter-shift rule
         assert _grad_method(tape, 2) == "F"
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.Rotation(1.0, wires=[0])
             qml.Rotation(1.0, wires=[1])
             # entangle the modes
@@ -127,7 +127,7 @@ class TestGradAnalysis:
         """Probability is the expectation value of a
         higher order observable, and thus only supports numerical
         differentiation"""
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.Rotation(0.543, wires=[0])
             qml.Squeezing(0.543, 0, wires=[0])
             qml.probs(wires=0)
@@ -141,19 +141,19 @@ class TestGradAnalysis:
         parameter-shift is supported. If the observable is second order,
         however, only finite-differences is supported."""
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.Rotation(1.0, wires=[0])
             qml.var(qml.P(0))  # first order
 
         assert _grad_method(tape, 0) == "A"
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.Rotation(1.0, wires=[0])
             qml.var(qml.NumberOperator(0))  # second order
 
         assert _grad_method(tape, 0) == "F"
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.Rotation(1.0, wires=[0])
             qml.Rotation(1.0, wires=[1])
             qml.Beamsplitter(0.5, 0.0, wires=[0, 1])
@@ -169,7 +169,7 @@ class TestGradAnalysis:
         """Test that the expectation of a second-order observable forces
         the gradient method to use the second-order parameter-shift rule"""
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.Rotation(1.0, wires=[0])
             qml.expval(qml.NumberOperator(0))  # second order
 
@@ -181,7 +181,7 @@ class TestGradAnalysis:
         doesn't recognize"""
         monkeypatch.setattr(qml.Rotation, "grad_method", "B")
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.Rotation(1.0, wires=0)
             qml.expval(qml.X(0))
 
@@ -297,7 +297,7 @@ class TestParameterShiftLogic:
         dev = qml.device("default.gaussian", wires=2)
 
         weights = [0.1, 0.2]
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.Displacement(weights[0], 0.0, wires=[0])
             qml.Rotation(weights[1], wires=[0])
             qml.expval(qml.X(0))
@@ -333,7 +333,7 @@ class TestParameterShiftLogic:
     def test_state_non_differentiable_error(self):
         """Test error raised if attempting to differentiate with
         respect to a state"""
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.state()
 
         with pytest.raises(ValueError, match=r"return the state is not supported"):
@@ -346,7 +346,7 @@ class TestParameterShiftLogic:
 
         dev = qml.device("default.gaussian", wires=1)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.Displacement(1.0, 0.0, wires=[0])
             qml.Rotation(2.0, wires=[0])
             qml.expval(qml.X(0))
@@ -369,7 +369,7 @@ class TestParameterShiftLogic:
 
         monkeypatch.delitem(dev._observable_map, "PolyXP")
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.Rotation(1.0, wires=[0])
             qml.expval(qml.NumberOperator(0))
 
@@ -389,7 +389,7 @@ class TestParameterShiftLogic:
 
         monkeypatch.delitem(dev._observable_map, "PolyXP")
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.Rotation(1.0, wires=[0])
             qml.var(qml.X(0))
 
@@ -405,7 +405,7 @@ class TestParameterShiftLogic:
         parameters, the gradient should be evaluated to zero without executing the device."""
         dev = qml.device("default.gaussian", wires=2)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.Displacement(1, 0, wires=[1])
             qml.Displacement(1, 0, wires=[0])
             qml.expval(qml.X(0))
@@ -434,7 +434,7 @@ class TestParameterShiftLogic:
         """Test the case where expectation values are independent of all parameters."""
         dev = qml.device("default.gaussian", wires=2)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.Displacement(1, 0, wires=[1])
             qml.Displacement(1, 0, wires=[1])
             qml.expval(qml.X(0))
@@ -462,7 +462,7 @@ class TestExpectationQuantumGradients:
         alpha = 0.5643
         theta = 0.23354
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.Displacement(alpha, 0.0, wires=[0])
             qml.Rotation(theta, wires=[0])
             qml.expval(qml.X(0))
@@ -490,7 +490,7 @@ class TestExpectationQuantumGradients:
         alpha = 0.5643
         theta = 0.23354
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.Displacement(alpha, 0.0, wires=[0])
             qml.Beamsplitter(theta, 0.0, wires=[0, 1])
             qml.expval(qml.X(0))
@@ -518,7 +518,7 @@ class TestExpectationQuantumGradients:
         r = 0.5643
         phi = 0.23354
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.Displacement(r, phi, wires=[0])
             qml.expval(qml.X(0))
 
@@ -555,7 +555,7 @@ class TestExpectationQuantumGradients:
         alpha = 0.5643
         r = 0.23354
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.Displacement(alpha, 0.0, wires=[0])
             qml.Squeezing(r, 0.0, wires=[0])
 
@@ -589,7 +589,7 @@ class TestExpectationQuantumGradients:
 
         r = 0.23354
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.Squeezing(r, 0.0, wires=[0])
             # the fock state projector is a 'non-Gaussian' observable
             qml.expval(qml.FockStateProjector(np.array([2, 0]), wires=[0, 1]))
@@ -615,7 +615,7 @@ class TestExpectationQuantumGradients:
 
         r0, phi0, r1, phi1 = [0.4, -0.3, -0.7, 0.2]
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.Squeezing(r0, phi0, wires=[0])
             qml.Squeezing(r1, phi1, wires=[0])
             qml.expval(qml.NumberOperator(0))  # second order
@@ -646,7 +646,7 @@ class TestExpectationQuantumGradients:
         r = [0.4, -0.7, 0.1, 0.2]
         p = [0.1, 0.2, 0.3, 0.4]
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.Squeezing(r[0], p[0], wires=[0])
             qml.Squeezing(r[1], p[1], wires=[0])
             qml.Squeezing(r[2], p[2], wires=[1])
@@ -688,7 +688,7 @@ class TestExpectationQuantumGradients:
         finite difference and analytic methods."""
         tol = 1e-2
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.Displacement(0.5, 0, wires=0)
             qml.apply(op)
             qml.Beamsplitter(1.3, -2.3, wires=[0, 1])
@@ -698,7 +698,7 @@ class TestExpectationQuantumGradients:
             qml.expval(obs(wires=0))
 
         dev = qml.device("default.gaussian", wires=2)
-        res = tape.execute(dev)
+        res = qml.execute([tape], dev, None)
 
         tape.trainable_params = set(range(2, 2 + op.num_params))
 
@@ -768,7 +768,7 @@ class TestExpectationQuantumGradients:
             requires_grad=False,
         )
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.Displacement(0.543, 0, wires=0)
             qml.InterferometerUnitary(U, wires=[0, 1])
             qml.expval(qml.X(0))
@@ -805,14 +805,14 @@ class TestVarianceQuantumGradients:
         r = 0.543
         phi = -0.654
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.Squeezing(r, 0, wires=0)
             qml.Rotation(phi, wires=0)
             qml.var(qml.X(0))
 
         tape.trainable_params = {0, 2}
 
-        res = tape.execute(dev)
+        res = qml.execute([tape], dev, None)
         expected = np.exp(2 * r) * np.sin(phi) ** 2 + np.exp(-2 * r) * np.cos(phi) ** 2
         assert np.allclose(res, expected, atol=tol, rtol=0)
 
@@ -841,14 +841,14 @@ class TestVarianceQuantumGradients:
         n = 0.12
         a = 0.765
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.ThermalState(n, wires=0)
             qml.Displacement(a, 0, wires=0)
             qml.var(qml.NumberOperator(0))
 
         tape.trainable_params = {0, 1}
 
-        res = tape.execute(dev)
+        res = qml.execute([tape], dev, None)
         expected = n**2 + n + np.abs(a) ** 2 * (1 + 2 * n)
         assert np.allclose(res, expected, atol=tol, rtol=0)
 
@@ -866,7 +866,7 @@ class TestVarianceQuantumGradients:
 
         a, b = [0.54, -0.423]
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.Displacement(0.5, 0, wires=0)
             qml.Squeezing(a, 0, wires=0)
             qml.Squeezing(b, 0, wires=1)
@@ -893,7 +893,7 @@ class TestVarianceQuantumGradients:
         order observable to compute the variance derivative analytically"""
         dev = qml.device("default.gaussian", wires=1)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.Displacement(1.0, 0, wires=0)
             qml.var(qml.NumberOperator(0))
 
@@ -917,7 +917,7 @@ class TestVarianceQuantumGradients:
 
         dev.operations.add(DummyOp)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             DummyOp(1, wires=[0])
             qml.expval(qml.X(0))
 
@@ -939,7 +939,7 @@ class TestVarianceQuantumGradients:
         finite difference and analytic methods."""
         tol = 1e-2
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.Displacement(0.5, 0, wires=0)
             qml.apply(op)
             qml.Beamsplitter(1.3, -2.3, wires=[0, 1])
@@ -949,7 +949,7 @@ class TestVarianceQuantumGradients:
             qml.var(obs(wires=0))
 
         dev = qml.device("default.gaussian", wires=2)
-        res = tape.execute(dev)
+        res = qml.execute([tape], dev, None)
 
         tape.trainable_params = set(range(2, 2 + op.num_params))
 
@@ -978,7 +978,7 @@ class TestVarianceQuantumGradients:
         r = 0.12
         phi = 0.105
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.Squeezing(r, 0, wires=0)
             qml.Rotation(phi, wires=0)
             qml.var(qml.X(wires=[0]))
@@ -1001,7 +1001,7 @@ class TestVarianceQuantumGradients:
         n = 0.12
         a = 0.105
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.ThermalState(n, wires=0)
             qml.Displacement(a, 0, wires=0)
             qml.var(qml.TensorN(wires=[0]))
@@ -1025,7 +1025,7 @@ class TestParamShiftInterfaces:
         phi = 0.105
 
         def cost_fn(x):
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.Squeezing(x[0], 0, wires=0)
                 qml.Rotation(x[1], wires=0)
                 qml.var(qml.X(wires=[0]))
@@ -1050,7 +1050,7 @@ class TestParamShiftInterfaces:
         params = tf.Variable([0.543, -0.654], dtype=tf.float64)
 
         with tf.GradientTape() as t:
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.Squeezing(params[0], 0, wires=0)
                 qml.Rotation(params[1], wires=0)
                 qml.var(qml.X(wires=[0]))
@@ -1088,7 +1088,7 @@ class TestParamShiftInterfaces:
         dev = qml.device("default.gaussian", wires=1)
         params = torch.tensor([0.543, -0.654], dtype=torch.float64, requires_grad=True)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.Squeezing(params[0], 0, wires=0)
             qml.Rotation(params[1], wires=0)
             qml.var(qml.X(wires=[0]))
@@ -1130,7 +1130,7 @@ class TestParamShiftInterfaces:
         params = jnp.array([0.543, -0.654])
 
         def cost_fn(x):
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.Squeezing(params[0], 0, wires=0)
                 qml.Rotation(params[1], wires=0)
                 qml.var(qml.X(wires=[0]))

--- a/tests/gradients/test_vjp.py
+++ b/tests/gradients/test_vjp.py
@@ -140,7 +140,7 @@ class TestVJP:
         x = 0.543
         y = -0.654
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(x, wires=[0])
             qml.RY(y, wires=[1])
             qml.CNOT(wires=[0, 1])
@@ -165,7 +165,7 @@ class TestVJP:
         x = 0.543
         y = -0.654
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(x, wires=[0])
             qml.RY(y, wires=[1])
             qml.CNOT(wires=[0, 1])
@@ -191,7 +191,7 @@ class TestVJP:
         x = 0.543
         y = -0.654
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(x, wires=[0])
             qml.RY(y, wires=[1])
             qml.CNOT(wires=[0, 1])
@@ -240,7 +240,7 @@ class TestVJP:
         zero-like."""
         x = np.array([0.1], dtype=np.float64)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(x[0], wires=0)
             qml.expval(qml.PauliZ(0))
 
@@ -280,7 +280,7 @@ class TestVJPGradients:
         params = np.array([0.543, -0.654], requires_grad=True)
 
         def cost_fn(x, dy):
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 ansatz(x[0], x[1])
 
             tape.trainable_params = {0, 1}
@@ -306,7 +306,7 @@ class TestVJPGradients:
         params = torch.tensor(params_np, requires_grad=True, dtype=torch.float64)
         dy = torch.tensor([-1.0, 0.0, 0.0, 1.0], dtype=torch.float64)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             ansatz(params[0], params[1])
 
         tape.trainable_params = {0, 1}
@@ -334,7 +334,7 @@ class TestVJPGradients:
         dy = tf.constant([-1.0, 0.0, 0.0, 1.0], dtype=tf.float64)
 
         with tf.GradientTape() as t:
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 ansatz(params[0], params[1])
 
             tape.trainable_params = {0, 1}
@@ -393,7 +393,7 @@ class TestVJPGradients:
 
         @partial(jax.jit, static_argnums=1)
         def cost_fn(x, dy):
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 ansatz(x[0], x[1])
 
             tape.trainable_params = {0, 1}
@@ -422,7 +422,7 @@ class TestBatchVJP:
             qml.CNOT(wires=[0, 1])
             qml.expval(qml.PauliZ(0))
 
-        with qml.tape.JacobianTape() as tape2:
+        with qml.tape.QuantumTape() as tape2:
             qml.RX(0.4, wires=0)
             qml.RX(0.6, wires=0)
             qml.CNOT(wires=[0, 1])
@@ -478,7 +478,7 @@ class TestBatchVJP:
             qml.CNOT(wires=[0, 1])
             qml.expval(qml.PauliZ(0))
 
-        with qml.tape.JacobianTape() as tape2:
+        with qml.tape.QuantumTape() as tape2:
             qml.RX(0.4, wires=0)
             qml.RX(0.6, wires=0)
             qml.CNOT(wires=[0, 1])
@@ -502,12 +502,12 @@ class TestBatchVJP:
         """Test the 'append' reduction strategy"""
         dev = qml.device("default.qubit", wires=2)
 
-        with qml.tape.JacobianTape() as tape1:
+        with qml.tape.QuantumTape() as tape1:
             qml.RX(0.4, wires=0)
             qml.CNOT(wires=[0, 1])
             qml.expval(qml.PauliZ(0))
 
-        with qml.tape.JacobianTape() as tape2:
+        with qml.tape.QuantumTape() as tape2:
             qml.RX(0.4, wires=0)
             qml.RX(0.6, wires=0)
             qml.CNOT(wires=[0, 1])
@@ -531,12 +531,12 @@ class TestBatchVJP:
         """Test the 'extend' reduction strategy"""
         dev = qml.device("default.qubit", wires=2)
 
-        with qml.tape.JacobianTape() as tape1:
+        with qml.tape.QuantumTape() as tape1:
             qml.RX(0.4, wires=0)
             qml.CNOT(wires=[0, 1])
             qml.expval(qml.PauliZ(0))
 
-        with qml.tape.JacobianTape() as tape2:
+        with qml.tape.QuantumTape() as tape2:
             qml.RX(0.4, wires=0)
             qml.RX(0.6, wires=0)
             qml.CNOT(wires=[0, 1])

--- a/tests/interfaces/test_batch_autograd.py
+++ b/tests/interfaces/test_batch_autograd.py
@@ -41,7 +41,7 @@ class TestAutogradExecuteUnitTests:
 
         dev = qml.device("default.qubit", wires=2, shots=None)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.expval(qml.PauliY(1))
 
         with pytest.raises(
@@ -60,7 +60,7 @@ class TestAutogradExecuteUnitTests:
         dev = qml.device("default.qubit", wires=1)
 
         def cost(a, device):
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RY(a[0], wires=0)
                 qml.RX(a[1], wires=0)
                 qml.expval(qml.PauliZ(0))
@@ -85,7 +85,7 @@ class TestAutogradExecuteUnitTests:
         dev = qml.device("default.qubit", wires=1)
 
         def cost(a, device):
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RY(a[0], wires=0)
                 qml.RX(a[1], wires=0)
                 qml.expval(qml.PauliZ(0))
@@ -104,7 +104,7 @@ class TestAutogradExecuteUnitTests:
         dev = qml.device("default.qubit", wires=1)
 
         def cost(a, device):
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RY(a[0], wires=0)
                 qml.RX(a[1], wires=0)
                 qml.expval(qml.PauliZ(0))
@@ -120,7 +120,7 @@ class TestAutogradExecuteUnitTests:
         spy = mocker.spy(dev, "execute_and_gradients")
 
         def cost(a):
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RY(a[0], wires=0)
                 qml.RX(a[1], wires=0)
                 qml.expval(qml.PauliZ(0))
@@ -146,7 +146,7 @@ class TestAutogradExecuteUnitTests:
         spy_gradients = mocker.spy(qml.devices.DefaultQubit, "gradients")
 
         def cost(a):
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RY(a[0], wires=0)
                 qml.RX(a[1], wires=0)
                 qml.expval(qml.PauliZ(0))
@@ -182,7 +182,7 @@ class TestBatchTransformExecution:
         x = 0.6
         y = 0.2
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(x, wires=0)
             qml.RY(y, wires=1)
             qml.CNOT(wires=[0, 1])
@@ -209,7 +209,7 @@ class TestCaching:
         spy = mocker.spy(qml.interfaces.batch, "cache_execute")
 
         def cost(a, cachesize):
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RY(a[0], wires=0)
                 qml.RX(a[1], wires=0)
                 qml.probs(wires=0)
@@ -230,7 +230,7 @@ class TestCaching:
         spy = mocker.spy(qml.interfaces.batch, "cache_execute")
 
         def cost(a, cache):
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RY(a[0], wires=0)
                 qml.RX(a[1], wires=0)
                 qml.probs(wires=0)
@@ -250,7 +250,7 @@ class TestCaching:
         dev = qml.device("default.qubit", wires=1)
 
         def cost(a, cache):
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RY(a[0], wires=0)
                 qml.RX(a[1], wires=0)
                 qml.probs(wires=0)
@@ -294,7 +294,7 @@ class TestCaching:
         N = len(params)
 
         def cost(x, cache):
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RX(x[0], wires=[0])
                 qml.RY(x[1], wires=[1])
 
@@ -345,7 +345,7 @@ class TestCaching:
         params = np.array([0.1, 0.2, 0.3])
 
         def cost(a, cache):
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RY(a[0], wires=0)
                 qml.RX(a[1], wires=0)
                 qml.RY(a[2], wires=0)
@@ -400,12 +400,12 @@ class TestAutogradExecuteIntegration:
         dev = qml.device("default.qubit", wires=1)
 
         def cost(a, b):
-            with qml.tape.JacobianTape() as tape1:
+            with qml.tape.QuantumTape() as tape1:
                 qml.RY(a, wires=0)
                 qml.RX(b, wires=0)
                 qml.expval(qml.PauliZ(0))
 
-            with qml.tape.JacobianTape() as tape2:
+            with qml.tape.QuantumTape() as tape2:
                 qml.RY(a, wires=0)
                 qml.RX(b, wires=0)
                 qml.expval(qml.PauliZ(0))
@@ -426,7 +426,7 @@ class TestAutogradExecuteIntegration:
         dev = qml.device("default.qubit", wires=2)
 
         def cost(a):
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RY(a, wires=0)
                 qml.expval(qml.PauliZ(0))
             return execute([tape], dev, **execute_kwargs)[0]
@@ -435,7 +435,7 @@ class TestAutogradExecuteIntegration:
         assert res.shape == (1,)
 
         # compare to standard tape jacobian
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RY(a, wires=0)
             qml.expval(qml.PauliZ(0))
 
@@ -452,7 +452,7 @@ class TestAutogradExecuteIntegration:
         b = np.array(0.2, requires_grad=True)
 
         def cost(a, b, device):
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RY(a, wires=0)
                 qml.RX(b, wires=1)
                 qml.CNOT(wires=[0, 1])
@@ -480,15 +480,15 @@ class TestAutogradExecuteIntegration:
         dev = qml.device("default.qubit", wires=1)
 
         def cost(params):
-            with qml.tape.JacobianTape() as tape1:
+            with qml.tape.QuantumTape() as tape1:
                 qml.Hadamard(0)
                 qml.expval(qml.PauliX(0))
 
-            with qml.tape.JacobianTape() as tape2:
+            with qml.tape.QuantumTape() as tape2:
                 qml.RY(np.array(0.5, requires_grad=False), wires=0)
                 qml.expval(qml.PauliZ(0))
 
-            with qml.tape.JacobianTape() as tape3:
+            with qml.tape.QuantumTape() as tape3:
                 qml.RY(params[0], wires=0)
                 qml.RX(params[1], wires=0)
                 qml.expval(qml.PauliZ(0))
@@ -513,7 +513,7 @@ class TestAutogradExecuteIntegration:
 
         dev = qml.device("default.qubit", wires=2)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RY(a, wires=0)
             qml.RX(b, wires=1)
             qml.CNOT(wires=[0, 1])
@@ -554,7 +554,7 @@ class TestAutogradExecuteIntegration:
         c = np.array(0.3, requires_grad=True)
 
         def cost(a, b, c, device):
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RY(a * c, wires=0)
                 qml.RZ(b, wires=0)
                 qml.RX(c + c**2 + np.sin(a), wires=0)
@@ -575,7 +575,7 @@ class TestAutogradExecuteIntegration:
         b = np.array(0.2, requires_grad=False)
 
         def cost(a, b, device):
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RY(a, wires=0)
                 qml.RX(b, wires=0)
                 qml.CNOT(wires=[0, 1])
@@ -606,7 +606,7 @@ class TestAutogradExecuteIntegration:
         a = np.array(0.1, requires_grad=True)
 
         def cost(a, U, device):
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.QubitUnitary(U, wires=0)
                 qml.RY(a, wires=0)
                 qml.expval(qml.PauliZ(0))
@@ -626,7 +626,7 @@ class TestAutogradExecuteIntegration:
 
         class U3(qml.U3):
             def expand(self):
-                tape = qml.tape.JacobianTape()
+                tape = qml.tape.QuantumTape()
                 theta, phi, lam = self.data
                 wires = self.wires
                 tape._ops += [
@@ -636,7 +636,7 @@ class TestAutogradExecuteIntegration:
                 return tape
 
         def cost_fn(a, p, device):
-            tape = qml.tape.JacobianTape()
+            tape = qml.tape.QuantumTape()
 
             with tape:
                 qml.RX(a, wires=0)
@@ -678,7 +678,7 @@ class TestAutogradExecuteIntegration:
             pytest.skip("Adjoint differentiation does not yet support probabilities")
 
         def cost(x, y, device):
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RX(x, wires=[0])
                 qml.RY(y, wires=[1])
                 qml.CNOT(wires=[0, 1])
@@ -731,7 +731,7 @@ class TestAutogradExecuteIntegration:
             pytest.skip("Adjoint differentiation does not yet support probabilities")
 
         def cost(x, y, device):
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RX(x, wires=[0])
                 qml.RY(y, wires=[1])
                 qml.CNOT(wires=[0, 1])
@@ -769,7 +769,7 @@ class TestAutogradExecuteIntegration:
             pytest.skip("Adjoint differentiation does not support samples")
 
         def cost(x, device):
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.Hadamard(wires=[0])
                 qml.CNOT(wires=[0, 1])
                 qml.sample(qml.PauliZ(0))
@@ -801,13 +801,13 @@ class TestHigherOrderDerivatives:
         params = np.array([0.543, -0.654], requires_grad=True)
 
         def cost_fn(x):
-            with qml.tape.JacobianTape() as tape1:
+            with qml.tape.QuantumTape() as tape1:
                 qml.RX(x[0], wires=[0])
                 qml.RY(x[1], wires=[1])
                 qml.CNOT(wires=[0, 1])
                 qml.var(qml.PauliZ(0) @ qml.PauliX(1))
 
-            with qml.tape.JacobianTape() as tape2:
+            with qml.tape.QuantumTape() as tape2:
                 qml.RX(x[0], wires=0)
                 qml.RY(x[0], wires=1)
                 qml.CNOT(wires=[0, 1])
@@ -847,7 +847,7 @@ class TestHigherOrderDerivatives:
         params = np.array([0.543, -0.654], requires_grad=True)
 
         def cost_fn(x):
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RX(x[0], wires=[0])
                 qml.RY(x[1], wires=[1])
                 qml.CNOT(wires=[0, 1])
@@ -876,13 +876,13 @@ class TestHigherOrderDerivatives:
         params = np.array([0.543, -0.654], requires_grad=True)
 
         def cost_fn(x):
-            with qml.tape.JacobianTape() as tape1:
+            with qml.tape.QuantumTape() as tape1:
                 qml.RX(x[0], wires=[0])
                 qml.RY(x[1], wires=[1])
                 qml.CNOT(wires=[0, 1])
                 qml.var(qml.PauliZ(0) @ qml.PauliX(1))
 
-            with qml.tape.JacobianTape() as tape2:
+            with qml.tape.QuantumTape() as tape2:
                 qml.RX(x[0], wires=0)
                 qml.RY(x[0], wires=1)
                 qml.CNOT(wires=[0, 1])
@@ -917,7 +917,7 @@ class TestOverridingShots:
         dev = qml.device("default.qubit", wires=2, shots=None)
         a, b = np.array([0.543, -0.654], requires_grad=True)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RY(a, wires=0)
             qml.RX(b, wires=1)
             qml.CNOT(wires=[0, 1])
@@ -947,7 +947,7 @@ class TestOverridingShots:
         dev = qml.device("default.qubit", wires=2, shots=123)
         a, b = np.array([0.543, -0.654], requires_grad=True)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RY(a, wires=0)
             qml.RX(b, wires=1)
             qml.CNOT(wires=[0, 1])
@@ -980,7 +980,7 @@ class TestOverridingShots:
 
         a, b = np.array([0.543, -0.654], requires_grad=True)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RY(a, wires=0)
             qml.RX(b, wires=1)
             qml.CNOT(wires=[0, 1])
@@ -1003,7 +1003,7 @@ class TestOverridingShots:
         a, b = np.array([0.543, -0.654], requires_grad=True)
 
         def cost_fn(a, b, shots):
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RY(a, wires=0)
                 qml.RX(b, wires=1)
                 qml.CNOT(wires=[0, 1])
@@ -1045,7 +1045,7 @@ class TestHamiltonianWorkflows:
             obs2 = [qml.PauliZ(0)]
             H2 = qml.Hamiltonian(coeffs2, obs2)
 
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RX(weights[0], wires=0)
                 qml.RY(weights[1], wires=1)
                 qml.CNOT(wires=[0, 1])

--- a/tests/interfaces/test_batch_autograd_qnode.py
+++ b/tests/interfaces/test_batch_autograd_qnode.py
@@ -17,7 +17,7 @@ from pennylane import numpy as np
 
 import pennylane as qml
 from pennylane import qnode, QNode
-from pennylane.tape import JacobianTape
+from pennylane.tape import QuantumTape
 
 qubit_device_and_diff_method = [
     ["default.qubit", "finite-diff", "backward"],
@@ -394,7 +394,7 @@ class TestQNode:
                 theta, phi, lam = self.data
                 wires = self.wires
 
-                with JacobianTape() as tape:
+                with QuantumTape() as tape:
                     qml.Rot(lam, theta, -lam, wires=wires)
                     qml.PhaseShift(phi + lam, wires=wires)
 

--- a/tests/interfaces/test_batch_jax.py
+++ b/tests/interfaces/test_batch_jax.py
@@ -39,7 +39,7 @@ class TestJaxExecuteUnitTests:
         dev = qml.device("default.qubit", wires=1)
 
         def cost(a, device):
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RY(a[0], wires=0)
                 qml.RX(a[1], wires=0)
                 qml.expval(qml.PauliZ(0))
@@ -65,7 +65,7 @@ class TestJaxExecuteUnitTests:
         dev = qml.device("default.qubit", wires=1)
 
         def cost(a, device):
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RY(a[0], wires=0)
                 qml.RX(a[1], wires=0)
                 qml.expval(qml.PauliZ(0))
@@ -90,7 +90,7 @@ class TestJaxExecuteUnitTests:
         dev = qml.device("default.qubit", wires=1)
 
         def cost(a, device):
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RY(a[0], wires=0)
                 qml.RX(a[1], wires=0)
                 qml.expval(qml.PauliZ(0))
@@ -111,7 +111,7 @@ class TestJaxExecuteUnitTests:
         spy = mocker.spy(dev, "execute_and_gradients")
 
         def cost(a):
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RY(a[0], wires=0)
                 qml.RX(a[1], wires=0)
                 qml.expval(qml.PauliZ(0))
@@ -141,7 +141,7 @@ class TestJaxExecuteUnitTests:
         spy_gradients = mocker.spy(qml.devices.DefaultQubit, "gradients")
 
         def cost(a):
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RY(a[0], wires=0)
                 qml.RX(a[1], wires=0)
                 qml.expval(qml.PauliZ(0))
@@ -176,7 +176,7 @@ class TestJaxExecuteUnitTests:
             InterfaceUnsupportedError,
             match="The JAX interface only supports first order derivatives.",
         ):
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RY(a[0], wires=0)
                 qml.RX(a[1], wires=0)
                 qml.expval(qml.PauliZ(0))
@@ -201,7 +201,7 @@ class TestCaching:
         spy = mocker.spy(qml.interfaces.batch, "cache_execute")
 
         def cost(a, cachesize):
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RY(a[0], wires=0)
                 qml.RX(a[1], wires=0)
                 qml.expval(qml.PauliZ(0))
@@ -228,7 +228,7 @@ class TestCaching:
         spy = mocker.spy(qml.interfaces.batch, "cache_execute")
 
         def cost(a, cache):
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RY(a[0], wires=0)
                 qml.RX(a[1], wires=0)
                 qml.expval(qml.PauliZ(0))
@@ -253,12 +253,12 @@ class TestCaching:
         b = jnp.array(0.2)
 
         def cost(a, b, cache):
-            with qml.tape.JacobianTape() as tape1:
+            with qml.tape.QuantumTape() as tape1:
                 qml.RY(a, wires=0)
                 qml.RX(b, wires=0)
                 qml.expval(qml.PauliZ(0))
 
-            with qml.tape.JacobianTape() as tape2:
+            with qml.tape.QuantumTape() as tape2:
                 qml.RY(a, wires=0)
                 qml.RX(b, wires=0)
                 qml.expval(qml.PauliZ(0))
@@ -284,7 +284,7 @@ class TestCaching:
         dev = qml.device("default.qubit", wires=1)
 
         def cost(a, cache):
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RY(a[0], wires=0)
                 qml.RX(a[1], wires=0)
                 qml.expval(qml.PauliZ(0))
@@ -326,7 +326,7 @@ class TestCaching:
         params = jnp.array([0.1, 0.2, 0.3])
 
         def cost(a, cache):
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RY(a[0], wires=0)
                 qml.RX(a[1], wires=0)
                 qml.RY(a[2], wires=0)
@@ -382,12 +382,12 @@ class TestJaxExecuteIntegration:
         dev = qml.device("default.qubit", wires=1)
 
         def cost(a, b):
-            with qml.tape.JacobianTape() as tape1:
+            with qml.tape.QuantumTape() as tape1:
                 qml.RY(a, wires=0)
                 qml.RX(b, wires=0)
                 qml.expval(qml.PauliZ(0))
 
-            with qml.tape.JacobianTape() as tape2:
+            with qml.tape.QuantumTape() as tape2:
                 qml.RY(a, wires=0)
                 qml.RX(b, wires=0)
                 qml.expval(qml.PauliZ(0))
@@ -408,7 +408,7 @@ class TestJaxExecuteIntegration:
         dev = qml.device("default.qubit", wires=2)
 
         def cost(a):
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RY(a, wires=0)
                 qml.expval(qml.PauliZ(0))
             return execute([tape], dev, interface=interface, **execute_kwargs)[0][0]
@@ -417,7 +417,7 @@ class TestJaxExecuteIntegration:
         assert res.shape == ()
 
         # compare to standard tape jacobian
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RY(a, wires=0)
             qml.expval(qml.PauliZ(0))
 
@@ -435,7 +435,7 @@ class TestJaxExecuteIntegration:
 
         dev = qml.device("default.qubit", wires=2)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RY(a, wires=0)
             qml.RX(b, wires=1)
             qml.CNOT(wires=[0, 1])
@@ -479,7 +479,7 @@ class TestJaxExecuteIntegration:
         c = jnp.array(0.3)
 
         def cost(a, b, c, device):
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RY(a * c, wires=0)
                 qml.RZ(b, wires=0)
                 qml.RX(c + c**2 + jnp.sin(a), wires=0)
@@ -498,13 +498,13 @@ class TestJaxExecuteIntegration:
         params = jax.numpy.array([0.3, 0.2])
 
         def cost_fn(x):
-            with qml.tape.JacobianTape() as tape1:
+            with qml.tape.QuantumTape() as tape1:
                 qml.Hadamard(0)
                 qml.RY(x[0], wires=[0])
                 qml.CNOT(wires=[0, 1])
                 qml.expval(qml.PauliZ(0))
 
-            with qml.tape.JacobianTape() as tape2:
+            with qml.tape.QuantumTape() as tape2:
                 qml.Hadamard(0)
                 qml.CRX(2 * x[0] * x[1], wires=[0, 1])
                 qml.RX(2 * x[1], wires=[1])
@@ -524,13 +524,13 @@ class TestJaxExecuteIntegration:
         params = jax.numpy.array([0.3, 0.2])
 
         def cost_fn(x):
-            with qml.tape.JacobianTape() as tape1:
+            with qml.tape.QuantumTape() as tape1:
                 qml.Hadamard(0)
                 qml.RY(x[0], wires=[0])
                 qml.CNOT(wires=[0, 1])
                 qml.expval(qml.PauliZ(0))
 
-            with qml.tape.JacobianTape() as tape2:
+            with qml.tape.QuantumTape() as tape2:
                 qml.Hadamard(0)
                 qml.CRX(2 * x[0] * x[1], wires=[0, 1])
                 qml.RX(2 * x[1], wires=[1])
@@ -551,7 +551,7 @@ class TestJaxExecuteIntegration:
         U = qml.RY(a, wires=0).get_matrix()
 
         def cost(U, device):
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.PauliX(0)
                 qml.QubitUnitary(U, wires=0)
                 qml.expval(qml.PauliZ(0))
@@ -573,7 +573,7 @@ class TestJaxExecuteIntegration:
 
         class U3(qml.U3):
             def expand(self):
-                tape = qml.tape.JacobianTape()
+                tape = qml.tape.QuantumTape()
                 theta, phi, lam = self.data
                 wires = self.wires
                 tape._ops += [
@@ -583,7 +583,7 @@ class TestJaxExecuteIntegration:
                 return tape
 
         def cost_fn(a, p, device):
-            tape = qml.tape.JacobianTape()
+            tape = qml.tape.QuantumTape()
 
             with tape:
                 qml.RX(a, wires=0)
@@ -624,7 +624,7 @@ class TestJaxExecuteIntegration:
         params = jnp.array([0.1, 0.2, 0.3])
 
         def cost(a, cache):
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RY(a[0], wires=0)
                 qml.RX(a[1], wires=0)
                 qml.RY(a[2], wires=0)
@@ -652,7 +652,7 @@ class TestJaxExecuteIntegration:
         params = jnp.array([0.1, 0.2, 0.3])
 
         def cost(a, cache):
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RY(a[0], wires=0)
                 qml.RX(a[1], wires=0)
                 qml.RY(a[2], wires=0)
@@ -686,7 +686,7 @@ class TestVectorValued:
         params = jnp.array([0.1, 0.2, 0.3])
 
         def cost(a, cache):
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RY(a[0], wires=0)
                 qml.RX(a[1], wires=0)
                 qml.RY(a[2], wires=0)
@@ -712,7 +712,7 @@ class TestVectorValued:
         params = jnp.array([0.1])
 
         def cost(a, cache):
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RY(a[0], wires=0)
                 qml.expval(qml.PauliZ(0))
                 qml.expval(qml.PauliZ(1))
@@ -732,14 +732,14 @@ class TestVectorValued:
             pytest.skip("The forward mode is tested separately as it should raise an error.")
 
         def cost(x, y, device, interface, ek):
-            with qml.tape.JacobianTape() as tape1:
+            with qml.tape.QuantumTape() as tape1:
                 qml.RX(x, wires=[0])
                 qml.RY(y, wires=[1])
                 qml.CNOT(wires=[0, 1])
                 qml.expval(qml.PauliZ(0))
                 qml.expval(qml.PauliZ(1))
 
-            with qml.tape.JacobianTape() as tape2:
+            with qml.tape.QuantumTape() as tape2:
                 qml.RX(x, wires=[0])
                 qml.RY(y, wires=[1])
                 qml.CNOT(wires=[0, 1])
@@ -777,14 +777,14 @@ class TestVectorValued:
             pytest.skip("The adjoint diff method doesn't support probabilities.")
 
         def cost(x, y, device, interface, ek):
-            with qml.tape.JacobianTape() as tape1:
+            with qml.tape.QuantumTape() as tape1:
                 qml.RX(x, wires=[0])
                 qml.RY(y, wires=[1])
                 qml.CNOT(wires=[0, 1])
                 qml.expval(qml.PauliZ(0))
                 qml.expval(qml.PauliZ(1))
 
-            with qml.tape.JacobianTape() as tape2:
+            with qml.tape.QuantumTape() as tape2:
                 qml.RX(x, wires=[0])
                 qml.RY(y, wires=[1])
                 qml.CNOT(wires=[0, 1])
@@ -820,7 +820,7 @@ class TestVectorValued:
         params = jnp.array([0.1, 0.2, 0.3])
 
         def cost(a, cache):
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RY(a[0], wires=0)
                 qml.RX(a[1], wires=0)
                 qml.RY(a[2], wires=0)

--- a/tests/interfaces/test_batch_jax_qnode.py
+++ b/tests/interfaces/test_batch_jax_qnode.py
@@ -18,7 +18,7 @@ from pennylane import numpy as np
 
 import pennylane as qml
 from pennylane import qnode, QNode
-from pennylane.tape import JacobianTape
+from pennylane.tape import QuantumTape
 from pennylane.interfaces.batch import InterfaceUnsupportedError
 
 qubit_device_and_diff_method = [
@@ -176,7 +176,7 @@ class TestQNode:
                 theta, phi, lam = self.data
                 wires = self.wires
 
-                with JacobianTape() as tape:
+                with QuantumTape() as tape:
                     qml.Rot(lam, theta, -lam, wires=wires)
                     qml.PhaseShift(phi + lam, wires=wires)
 

--- a/tests/interfaces/test_batch_tensorflow.py
+++ b/tests/interfaces/test_batch_tensorflow.py
@@ -37,7 +37,7 @@ class TestTensorFlowExecuteUnitTests:
         dev = qml.device("default.qubit", wires=1)
 
         with tf.GradientTape() as t:
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RY(a[0], wires=0)
                 qml.RX(a[1], wires=0)
                 qml.expval(qml.PauliZ(0))
@@ -63,7 +63,7 @@ class TestTensorFlowExecuteUnitTests:
         dev = qml.device("default.qubit", wires=1)
 
         with tf.GradientTape() as t:
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RY(a[0], wires=0)
                 qml.RX(a[1], wires=0)
                 qml.expval(qml.PauliZ(0))
@@ -80,7 +80,7 @@ class TestTensorFlowExecuteUnitTests:
         spy = mocker.spy(dev, "execute_and_gradients")
 
         with tf.GradientTape() as t:
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RY(a[0], wires=0)
                 qml.RX(a[1], wires=0)
                 qml.expval(qml.PauliZ(0))
@@ -105,7 +105,7 @@ class TestTensorFlowExecuteUnitTests:
         a = tf.Variable([0.1, 0.2])
 
         with tf.GradientTape() as t:
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RY(a[0], wires=0)
                 qml.RX(a[1], wires=0)
                 qml.expval(qml.PauliZ(0))
@@ -137,7 +137,7 @@ class TestCaching:
         a = tf.Variable([0.1, 0.2])
 
         with tf.GradientTape() as t:
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RY(a[0], wires=0)
                 qml.RX(a[1], wires=0)
                 qml.probs(wires=0)
@@ -159,7 +159,7 @@ class TestCaching:
         custom_cache = {}
 
         with tf.GradientTape() as t:
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RY(a[0], wires=0)
                 qml.RX(a[1], wires=0)
                 qml.probs(wires=0)
@@ -180,7 +180,7 @@ class TestCaching:
         a = tf.Variable([0.1, 0.2], dtype=tf.float64)
 
         def cost(a, cache):
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RY(a[0], wires=0)
                 qml.RX(a[1], wires=0)
                 qml.probs(wires=0)
@@ -221,7 +221,7 @@ class TestCaching:
         N = params.shape[0]
 
         def cost(x, cache):
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RX(x[0], wires=[0])
                 qml.RY(x[1], wires=[1])
 
@@ -302,12 +302,12 @@ class TestTensorFlowExecuteIntegration:
         b = tf.Variable(0.2)
 
         with tf.GradientTape() as t:
-            with qml.tape.JacobianTape() as tape1:
+            with qml.tape.QuantumTape() as tape1:
                 qml.RY(a, wires=0)
                 qml.RX(b, wires=0)
                 qml.expval(qml.PauliZ(0))
 
-            with qml.tape.JacobianTape() as tape2:
+            with qml.tape.QuantumTape() as tape2:
                 qml.RY(a, wires=0)
                 qml.RX(b, wires=0)
                 qml.expval(qml.PauliZ(0))
@@ -324,7 +324,7 @@ class TestTensorFlowExecuteIntegration:
         dev = qml.device("default.qubit", wires=2)
 
         with tf.GradientTape() as t:
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RY(a, wires=0)
                 qml.expval(qml.PauliZ(0))
             res = execute([tape], dev, **execute_kwargs)[0]
@@ -333,7 +333,7 @@ class TestTensorFlowExecuteIntegration:
         assert res.shape == (1,)
 
         # compare to standard tape jacobian
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RY(a, wires=0)
             qml.expval(qml.PauliZ(0))
 
@@ -351,7 +351,7 @@ class TestTensorFlowExecuteIntegration:
         dev = qml.device("default.qubit", wires=2)
 
         with tf.GradientTape() as t:
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RY(a, wires=0)
                 qml.RX(b, wires=1)
                 qml.CNOT(wires=[0, 1])
@@ -377,15 +377,15 @@ class TestTensorFlowExecuteIntegration:
         x, y = 1.0 * params
 
         with tf.GradientTape() as t:
-            with qml.tape.JacobianTape() as tape1:
+            with qml.tape.QuantumTape() as tape1:
                 qml.Hadamard(0)
                 qml.expval(qml.PauliX(0))
 
-            with qml.tape.JacobianTape() as tape2:
+            with qml.tape.QuantumTape() as tape2:
                 qml.RY(0.5, wires=0)
                 qml.expval(qml.PauliZ(0))
 
-            with qml.tape.JacobianTape() as tape3:
+            with qml.tape.QuantumTape() as tape3:
                 qml.RY(params[0], wires=0)
                 qml.RX(params[1], wires=0)
                 qml.expval(qml.PauliZ(0))
@@ -407,7 +407,7 @@ class TestTensorFlowExecuteIntegration:
         dev = qml.device("default.qubit", wires=2)
 
         with tf.GradientTape() as t:
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RY(a, wires=0)
                 qml.RX(b, wires=1)
                 qml.CNOT(wires=[0, 1])
@@ -446,7 +446,7 @@ class TestTensorFlowExecuteIntegration:
 
         dev = qml.device("default.qubit", wires=2)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RY(a, wires=0)
             qml.RX(b, wires=1)
             qml.CNOT(wires=[0, 1])
@@ -486,7 +486,7 @@ class TestTensorFlowExecuteIntegration:
         dev = qml.device("default.qubit", wires=1)
 
         with tf.GradientTape() as t:
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RY(a * c, wires=0)
                 qml.RZ(b, wires=0)
                 qml.RX(c + c**2 + tf.sin(a), wires=0)
@@ -507,7 +507,7 @@ class TestTensorFlowExecuteIntegration:
         dev = qml.device("default.qubit", wires=2)
 
         with tf.GradientTape() as t:
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RY(0.2, wires=0)
                 qml.RX(b, wires=0)
                 qml.CNOT(wires=[0, 1])
@@ -533,7 +533,7 @@ class TestTensorFlowExecuteIntegration:
 
         with tf.GradientTape() as t:
 
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.QubitUnitary(U, wires=0)
                 qml.RY(a, wires=0)
                 qml.expval(qml.PauliZ(0))
@@ -552,7 +552,7 @@ class TestTensorFlowExecuteIntegration:
 
         class U3(qml.U3):
             def expand(self):
-                tape = qml.tape.JacobianTape()
+                tape = qml.tape.QuantumTape()
                 theta, phi, lam = self.data
                 wires = self.wires
                 tape._ops += [
@@ -561,7 +561,7 @@ class TestTensorFlowExecuteIntegration:
                 ]
                 return tape
 
-        qtape = qml.tape.JacobianTape()
+        qtape = qml.tape.QuantumTape()
 
         dev = qml.device("default.qubit", wires=1)
         a = np.array(0.1)
@@ -611,7 +611,7 @@ class TestTensorFlowExecuteIntegration:
         y = tf.Variable(-0.654, dtype=tf.float64)
 
         with tf.GradientTape() as t:
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RX(x, wires=[0])
                 qml.RY(y, wires=[1])
                 qml.CNOT(wires=[0, 1])
@@ -654,7 +654,7 @@ class TestTensorFlowExecuteIntegration:
         y = tf.Variable(-0.654, dtype=tf.float64)
 
         with tf.GradientTape() as t:
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RX(x, wires=[0])
                 qml.RY(y, wires=[1])
                 qml.CNOT(wires=[0, 1])
@@ -685,7 +685,7 @@ class TestTensorFlowExecuteIntegration:
         dev = qml.device("default.qubit", wires=2, shots=10)
 
         with tf.GradientTape() as t:
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.Hadamard(wires=[0])
                 qml.CNOT(wires=[0, 1])
                 qml.sample(qml.PauliZ(0))
@@ -718,13 +718,13 @@ class TestHigherOrderDerivatives:
 
         with tf.GradientTape() as t2:
             with tf.GradientTape() as t1:
-                with qml.tape.JacobianTape() as tape1:
+                with qml.tape.QuantumTape() as tape1:
                     qml.RX(params[0], wires=[0])
                     qml.RY(params[1], wires=[1])
                     qml.CNOT(wires=[0, 1])
                     qml.var(qml.PauliZ(0) @ qml.PauliX(1))
 
-                with qml.tape.JacobianTape() as tape2:
+                with qml.tape.QuantumTape() as tape2:
                     qml.RX(params[0], wires=0)
                     qml.RY(params[0], wires=1)
                     qml.CNOT(wires=[0, 1])
@@ -760,7 +760,7 @@ class TestHigherOrderDerivatives:
 
         with tf.GradientTape() as t2:
             with tf.GradientTape(persistent=True) as t1:
-                with qml.tape.JacobianTape() as tape:
+                with qml.tape.QuantumTape() as tape:
                     qml.RY(params[0], wires=0)
                     qml.RX(params[1], wires=0)
                     qml.probs(wires=0)
@@ -807,7 +807,7 @@ class TestHigherOrderDerivatives:
 
         with tf.GradientTape() as t2:
             with tf.GradientTape() as t1:
-                with qml.tape.JacobianTape() as tape:
+                with qml.tape.QuantumTape() as tape:
                     qml.RX(params[0], wires=[0])
                     qml.RY(params[1], wires=[1])
                     qml.CNOT(wires=[0, 1])
@@ -836,13 +836,13 @@ class TestHigherOrderDerivatives:
 
         with tf.GradientTape() as t2:
             with tf.GradientTape() as t1:
-                with qml.tape.JacobianTape() as tape1:
+                with qml.tape.QuantumTape() as tape1:
                     qml.RX(params[0], wires=[0])
                     qml.RY(params[1], wires=[1])
                     qml.CNOT(wires=[0, 1])
                     qml.var(qml.PauliZ(0) @ qml.PauliX(1))
 
-                with qml.tape.JacobianTape() as tape2:
+                with qml.tape.QuantumTape() as tape2:
                     qml.RX(params[0], wires=0)
                     qml.RY(params[0], wires=1)
                     qml.CNOT(wires=[0, 1])
@@ -889,7 +889,7 @@ class TestHamiltonianWorkflows:
             obs2 = [qml.PauliZ(0)]
             H2 = qml.Hamiltonian(coeffs2, obs2)
 
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RX(weights[0], wires=0)
                 qml.RY(weights[1], wires=1)
                 qml.CNOT(wires=[0, 1])

--- a/tests/interfaces/test_batch_tensorflow_qnode.py
+++ b/tests/interfaces/test_batch_tensorflow_qnode.py
@@ -19,7 +19,7 @@ tf = pytest.importorskip("tensorflow")
 
 import pennylane as qml
 from pennylane import qnode, QNode
-from pennylane.tape import JacobianTape
+from pennylane.tape import QuantumTape
 
 
 qubit_device_and_diff_method = [
@@ -369,7 +369,7 @@ class TestQNode:
                 theta, phi, lam = self.data
                 wires = self.wires
 
-                with JacobianTape() as tape:
+                with QuantumTape() as tape:
                     qml.Rot(lam, theta, -lam, wires=wires)
                     qml.PhaseShift(phi + lam, wires=wires)
 

--- a/tests/interfaces/test_batch_torch.py
+++ b/tests/interfaces/test_batch_torch.py
@@ -35,7 +35,7 @@ class TestTorchExecuteUnitTests:
 
         dev = qml.device("default.qubit", wires=1)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RY(a[0], wires=0)
             qml.RX(a[1], wires=0)
             qml.expval(qml.PauliZ(0))
@@ -60,7 +60,7 @@ class TestTorchExecuteUnitTests:
 
         dev = qml.device("default.qubit", wires=1)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RY(a[0], wires=0)
             qml.RX(a[1], wires=0)
             qml.expval(qml.PauliZ(0))
@@ -78,7 +78,7 @@ class TestTorchExecuteUnitTests:
 
         a = torch.tensor([0.1, 0.2], requires_grad=True)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RY(a[0], wires=0)
             qml.RX(a[1], wires=0)
             qml.expval(qml.PauliZ(0))
@@ -102,7 +102,7 @@ class TestTorchExecuteUnitTests:
 
         a = torch.tensor([0.1, 0.2], requires_grad=True)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RY(a[0], wires=0)
             qml.RX(a[1], wires=0)
             qml.expval(qml.PauliZ(0))
@@ -127,7 +127,7 @@ class TestTorchExecuteUnitTests:
 
         a = torch.tensor([0.1, 0.2], requires_grad=True)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RY(a[0], wires=0)
             qml.RX(a[1], wires=0)
             qml.expval(qml.PauliZ(0))
@@ -158,7 +158,7 @@ class TestCaching:
         spy = mocker.spy(qml.interfaces.batch, "cache_execute")
 
         def cost(a, cachesize):
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RY(a[0], wires=0)
                 qml.RX(a[1], wires=0)
                 qml.probs(wires=0)
@@ -182,7 +182,7 @@ class TestCaching:
         spy = mocker.spy(qml.interfaces.batch, "cache_execute")
 
         def cost(a, cache):
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RY(a[0], wires=0)
                 qml.RX(a[1], wires=0)
                 qml.probs(wires=0)
@@ -205,7 +205,7 @@ class TestCaching:
         dev = qml.device("default.qubit", wires=1)
 
         def cost(a, cache):
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RY(a[0], wires=0)
                 qml.RX(a[1], wires=0)
                 qml.probs(wires=0)
@@ -237,7 +237,7 @@ class TestCaching:
         N = len(params)
 
         def cost(x, cache):
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RX(x[0], wires=[0])
                 qml.RY(x[1], wires=[1])
 
@@ -290,7 +290,7 @@ class TestCaching:
         params = torch.tensor([0.1, 0.2, 0.3])
 
         def cost(a, cache):
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RY(a[0], wires=0)
                 qml.RX(a[1], wires=0)
                 qml.RY(a[2], wires=0)
@@ -362,12 +362,12 @@ class TestTorchExecuteIntegration:
         a = torch.tensor(0.1, requires_grad=True, device=torch_device)
         b = torch.tensor(0.2, requires_grad=False, device=torch_device)
 
-        with qml.tape.JacobianTape() as tape1:
+        with qml.tape.QuantumTape() as tape1:
             qml.RY(a, wires=0)
             qml.RX(b, wires=0)
             qml.expval(qml.PauliZ(0))
 
-        with qml.tape.JacobianTape() as tape2:
+        with qml.tape.QuantumTape() as tape2:
             qml.RY(a, wires=0)
             qml.RX(b, wires=0)
             qml.expval(qml.PauliZ(0))
@@ -383,7 +383,7 @@ class TestTorchExecuteIntegration:
         a = torch.tensor(0.1, requires_grad=True, dtype=torch.float64, device=torch_device)
         dev = qml.device("default.qubit", wires=2)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RY(a, wires=0)
             qml.expval(qml.PauliZ(0))
 
@@ -412,7 +412,7 @@ class TestTorchExecuteIntegration:
 
         dev = qml.device("default.qubit", wires=2)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RZ(torch.tensor(0.543, device=torch_device), wires=0)
             qml.RY(a, wires=0)
             qml.RX(b, wires=1)
@@ -449,15 +449,15 @@ class TestTorchExecuteIntegration:
         params = torch.tensor([0.1, 0.2], requires_grad=True, device=torch_device)
         x, y = params.detach()
 
-        with qml.tape.JacobianTape() as tape1:
+        with qml.tape.QuantumTape() as tape1:
             qml.Hadamard(0)
             qml.expval(qml.PauliX(0))
 
-        with qml.tape.JacobianTape() as tape2:
+        with qml.tape.QuantumTape() as tape2:
             qml.RY(0.5, wires=0)
             qml.expval(qml.PauliZ(0))
 
-        with qml.tape.JacobianTape() as tape3:
+        with qml.tape.QuantumTape() as tape3:
             qml.RY(params[0], wires=0)
             qml.RX(params[1], wires=0)
             qml.expval(qml.PauliZ(0))
@@ -484,7 +484,7 @@ class TestTorchExecuteIntegration:
 
         dev = qml.device("default.qubit", wires=2)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RY(a, wires=0)
             qml.RX(b, wires=1)
             qml.CNOT(wires=[0, 1])
@@ -534,7 +534,7 @@ class TestTorchExecuteIntegration:
 
         dev = qml.device("default.qubit", wires=1)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RY(params[0] * params[1], wires=0)
             qml.RZ(0.2, wires=0)
             qml.RX(params[1] + params[1] ** 2 + torch.sin(params[0]), wires=0)
@@ -567,7 +567,7 @@ class TestTorchExecuteIntegration:
         """Test evaluation and Jacobian if there are no trainable parameters"""
         dev = qml.device("default.qubit", wires=2)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RY(0.2, wires=0)
             qml.RX(torch.tensor(0.1, device=torch_device), wires=0)
             qml.CNOT(wires=[0, 1])
@@ -600,7 +600,7 @@ class TestTorchExecuteIntegration:
 
         dev = qml.device("default.qubit", wires=2)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.QubitUnitary(U, wires=0)
             qml.RY(a, wires=0)
             qml.expval(qml.PauliZ(0))
@@ -621,7 +621,7 @@ class TestTorchExecuteIntegration:
 
         class U3(qml.U3):
             def expand(self):
-                tape = qml.tape.JacobianTape()
+                tape = qml.tape.QuantumTape()
                 theta, phi, lam = self.data
                 wires = self.wires
                 tape._ops += [
@@ -630,7 +630,7 @@ class TestTorchExecuteIntegration:
                 ]
                 return tape
 
-        tape = qml.tape.JacobianTape()
+        tape = qml.tape.QuantumTape()
 
         dev = qml.device("default.qubit", wires=1)
         a = np.array(0.1)
@@ -698,7 +698,7 @@ class TestTorchExecuteIntegration:
         x = torch.tensor(x_val, requires_grad=True, device=torch_device)
         y = torch.tensor(y_val, requires_grad=True, device=torch_device)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(x, wires=[0])
             qml.RY(y, wires=[1])
             qml.CNOT(wires=[0, 1])
@@ -745,7 +745,7 @@ class TestTorchExecuteIntegration:
         x = torch.tensor(x_val, requires_grad=True, device=torch_device)
         y = torch.tensor(y_val, requires_grad=True, device=torch_device)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(x, wires=[0])
             qml.RY(y, wires=[1])
             qml.CNOT(wires=[0, 1])
@@ -787,7 +787,7 @@ class TestTorchExecuteIntegration:
 
         dev = qml.device("default.qubit", wires=2, shots=10)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.Hadamard(wires=[0])
             qml.CNOT(wires=[0, 1])
             qml.sample(qml.PauliZ(0))
@@ -805,7 +805,7 @@ class TestTorchExecuteIntegration:
 
         dev = qml.device("default.qubit", wires=2, shots=10)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.Hadamard(wires=[0])
             qml.CNOT(wires=[0, 1])
             qml.sample(qml.PauliZ(0))
@@ -828,7 +828,7 @@ class TestTorchExecuteIntegration:
 
         x = torch.tensor(0.65, requires_grad=True)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(x, wires=[0])
             qml.sample(qml.PauliZ(0))
 
@@ -848,7 +848,7 @@ class TestTorchExecuteIntegration:
 
         weights = torch.ones((3,))
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.U3(*weights, wires=0)
             qml.expval(qml.PauliZ(wires=0))
 
@@ -875,13 +875,13 @@ class TestHigherOrderDerivatives:
         params = torch.tensor([0.543, -0.654], requires_grad=True, dtype=torch.float64)
 
         def cost_fn(x):
-            with qml.tape.JacobianTape() as tape1:
+            with qml.tape.QuantumTape() as tape1:
                 qml.RX(x[0], wires=[0])
                 qml.RY(x[1], wires=[1])
                 qml.CNOT(wires=[0, 1])
                 qml.var(qml.PauliZ(0) @ qml.PauliX(1))
 
-            with qml.tape.JacobianTape() as tape2:
+            with qml.tape.QuantumTape() as tape2:
                 qml.RX(x[0], wires=0)
                 qml.RY(x[0], wires=1)
                 qml.CNOT(wires=[0, 1])
@@ -917,7 +917,7 @@ class TestHigherOrderDerivatives:
         dev = qml.device("default.qubit", wires=1)
 
         def circuit(x):
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RY(x[0], wires=0)
                 qml.RX(x[1], wires=0)
                 qml.probs(wires=0)
@@ -985,7 +985,7 @@ class TestHigherOrderDerivatives:
         )
 
         def cost_fn(x):
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RX(x[0], wires=[0])
                 qml.RY(x[1], wires=[1])
                 qml.CNOT(wires=[0, 1])
@@ -1010,13 +1010,13 @@ class TestHigherOrderDerivatives:
         params = torch.tensor([0.543, -0.654], requires_grad=True, dtype=torch.float64)
 
         def cost_fn(x):
-            with qml.tape.JacobianTape() as tape1:
+            with qml.tape.QuantumTape() as tape1:
                 qml.RX(x[0], wires=[0])
                 qml.RY(x[1], wires=[1])
                 qml.CNOT(wires=[0, 1])
                 qml.var(qml.PauliZ(0) @ qml.PauliX(1))
 
-            with qml.tape.JacobianTape() as tape2:
+            with qml.tape.QuantumTape() as tape2:
                 qml.RX(x[0], wires=0)
                 qml.RY(x[0], wires=1)
                 qml.CNOT(wires=[0, 1])
@@ -1067,7 +1067,7 @@ class TestHamiltonianWorkflows:
             obs2 = [qml.PauliZ(0)]
             H2 = qml.Hamiltonian(coeffs2, obs2)
 
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 qml.RX(weights[0], wires=0)
                 qml.RY(weights[1], wires=1)
                 qml.CNOT(wires=[0, 1])

--- a/tests/interfaces/test_batch_torch_qnode.py
+++ b/tests/interfaces/test_batch_torch_qnode.py
@@ -20,7 +20,7 @@ from torch.autograd.functional import hessian, jacobian
 
 import pennylane as qml
 from pennylane import qnode, QNode
-from pennylane.tape import JacobianTape
+from pennylane.tape import QuantumTape
 
 
 qubit_device_and_diff_method = [
@@ -385,7 +385,7 @@ class TestQNode:
                 theta, phi, lam = self.data
                 wires = self.wires
 
-                with JacobianTape() as tape:
+                with QuantumTape() as tape:
                     qml.Rot(lam, theta, -lam, wires=wires)
                     qml.PhaseShift(phi + lam, wires=wires)
 

--- a/tests/qnn/test_keras.py
+++ b/tests/qnn/test_keras.py
@@ -479,7 +479,7 @@ class TestKerasLayer:
         with tf.GradientTape() as tape:
             out = tf.reduce_sum(qlayer(inputs))
 
-        spy = mocker.spy(qml.tape.QubitParamShiftTape, "jacobian")
+        spy = mocker.spy(qml.gradients, "param_shift")
 
         grad = tape.gradient(out, qlayer.trainable_weights)
         assert grad is not None

--- a/tests/tape/test_qnode_old.py
+++ b/tests/tape/test_qnode_old.py
@@ -606,6 +606,11 @@ class TestValidation:
         )
 
         expected_warnings = {
+            (
+                UserWarning,
+                f"qml.qnode_old.QNode is deprecated, and will be removed in an "
+                "upcoming release. Please use qml.QNode instead.",
+            ),
             (UserWarning, f"'{unrecognized_one}'{warning_text}"),
             (UserWarning, f"'{unrecognized_two}'{warning_text}"),
         }
@@ -632,6 +637,11 @@ class TestValidation:
         )
 
         expected_warnings = {
+            (
+                UserWarning,
+                f"qml.qnode_old.QNode is deprecated, and will be removed in an "
+                "upcoming release. Please use qml.QNode instead.",
+            ),
             (UserWarning, f"'{unrecognized_one}'{warning_text}"),
             (UserWarning, f"'{unrecognized_two}'{warning_text}"),
         }

--- a/tests/templates/test_subroutines/test_approx_time_evolution.py
+++ b/tests/templates/test_subroutines/test_approx_time_evolution.py
@@ -374,7 +374,7 @@ def test_trainable_hamiltonian(dev_name, diff_method):
     def create_tape(coeffs, t):
         H = qml.Hamiltonian(coeffs, obs)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.templates.ApproxTimeEvolution(H, t, 2)
             qml.expval(qml.PauliZ(0))
 

--- a/tests/templates/test_subroutines/test_qpe.py
+++ b/tests/templates/test_subroutines/test_qpe.py
@@ -64,7 +64,7 @@ class TestDecomposition:
 
             tape = tape.expand(depth=2, stop_at=lambda obj: obj.name in dev.operations)
 
-            res = tape.execute(dev).flatten()
+            res = dev.execute(tape).flatten()
             initial_estimate = np.argmax(res) / 2 ** (wires - 1)
 
             # We need to rescale because RX is exp(- i theta X / 2) and we expect a unitary of the
@@ -112,7 +112,7 @@ class TestDecomposition:
                 qml.probs(estimation_wires)
 
             tape = tape.expand(depth=2, stop_at=lambda obj: obj.name in dev.operations)
-            res = tape.execute(dev).flatten()
+            res = dev.execute(tape).flatten()
 
             if phase < 0:
                 estimate = np.argmax(res) / 2 ** (wires - 2) - 1

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -918,7 +918,7 @@ class TestBatchExecution:
         qml.PauliX(wires=0)
         qml.expval(qml.PauliZ(wires=0)), qml.expval(qml.PauliZ(wires=1))
 
-    with qml.tape.JacobianTape() as tape2:
+    with qml.tape.QuantumTape() as tape2:
         qml.PauliX(wires=0)
         qml.expval(qml.PauliZ(wires=0))
 

--- a/tests/test_qnode.py
+++ b/tests/test_qnode.py
@@ -21,7 +21,7 @@ import pennylane as qml
 from pennylane import numpy as pnp
 from pennylane import qnode, QNode
 from pennylane.transforms import draw
-from pennylane.tape import JacobianTape
+from pennylane.tape import QuantumTape
 
 
 def dummyfunc():
@@ -408,12 +408,12 @@ class TestTapeConstruction:
 
         res = qn(x, y)
 
-        assert isinstance(qn.qtape, JacobianTape)
+        assert isinstance(qn.qtape, QuantumTape)
         assert len(qn.qtape.operations) == 3
         assert len(qn.qtape.observables) == 1
         assert qn.qtape.num_params == 2
 
-        expected = qn.qtape.execute(dev)
+        expected = qml.execute([qn.tape], dev, None)
         assert np.allclose(res, expected, atol=tol, rtol=0)
 
         # when called, a new quantum tape is constructed
@@ -614,12 +614,12 @@ class TestDecorator:
 
         res = func(x, y)
 
-        assert isinstance(func.qtape, JacobianTape)
+        assert isinstance(func.qtape, QuantumTape)
         assert len(func.qtape.operations) == 3
         assert len(func.qtape.observables) == 1
         assert func.qtape.num_params == 2
 
-        expected = func.qtape.execute(dev)
+        expected = qml.execute([func.tape], dev, None)
         assert np.allclose(res, expected, atol=tol, rtol=0)
 
         # when called, a new quantum tape is constructed

--- a/tests/test_qubit_device.py
+++ b/tests/test_qubit_device.py
@@ -832,7 +832,7 @@ class TestBatchExecution:
         qml.PauliX(wires=0)
         qml.expval(qml.PauliZ(wires=0)), qml.expval(qml.PauliZ(wires=1))
 
-    with qml.tape.JacobianTape() as tape2:
+    with qml.tape.QuantumTape() as tape2:
         qml.PauliX(wires=0)
         qml.expval(qml.PauliZ(wires=0))
 

--- a/tests/test_qubit_device_adjoint_jacobian.py
+++ b/tests/test_qubit_device_adjoint_jacobian.py
@@ -220,7 +220,7 @@ class TestAdjointJacobian:
 
         dM1 = dev.adjoint_jacobian(tape)
 
-        tape.execute(dev)
+        qml.execute([tape], dev, None)
         dM2 = dev.adjoint_jacobian(tape, use_device_state=True)
 
         assert np.allclose(dM1, dM2, atol=tol, rtol=0)
@@ -239,7 +239,7 @@ class TestAdjointJacobian:
 
         dM1 = dev.adjoint_jacobian(tape)
 
-        tape.execute(dev)
+        qml.execute([tape], dev, None)
         dM2 = dev.adjoint_jacobian(tape, starting_state=dev._pre_rotated_state)
 
         assert np.allclose(dM1, dM2, atol=tol, rtol=0)

--- a/tests/test_qubit_device_adjoint_jacobian.py
+++ b/tests/test_qubit_device_adjoint_jacobian.py
@@ -32,7 +32,7 @@ class TestAdjointJacobian:
         """Test if a QuantumFunctionError is raised for a tape with measurements that are not
         expectation values"""
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(0.1, wires=0)
             qml.var(qml.PauliZ(0))
 
@@ -44,7 +44,7 @@ class TestAdjointJacobian:
 
         dev = qml.device("default.qubit", wires=1, shots=1)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.expval(qml.PauliZ(0))
 
         with pytest.warns(
@@ -56,7 +56,7 @@ class TestAdjointJacobian:
         """Test if a QuantumFunctionError is raised for an unsupported operation, i.e.,
         multi-parameter operations that are not qml.Rot"""
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.CRot(0.1, 0.2, 0.3, wires=[0, 1])
             qml.expval(qml.PauliZ(0))
 
@@ -68,7 +68,7 @@ class TestAdjointJacobian:
     def test_pauli_rotation_gradient(self, G, theta, tol, dev):
         """Tests that the automatic gradients of Pauli rotations are correct."""
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.QubitStateVector(np.array([1.0, -1.0], requires_grad=False) / np.sqrt(2), wires=0)
             G(theta, wires=[0])
             qml.expval(qml.PauliZ(0))
@@ -88,7 +88,7 @@ class TestAdjointJacobian:
         correct."""
         params = np.array([theta, theta**3, np.sqrt(2) * theta])
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.QubitStateVector(np.array([1.0, -1.0], requires_grad=False) / np.sqrt(2), wires=0)
             qml.Rot(*params, wires=[0])
             qml.expval(qml.PauliZ(0))
@@ -106,7 +106,7 @@ class TestAdjointJacobian:
     def test_ry_gradient(self, par, tol, dev):
         """Test that the gradient of the RY gate matches the exact analytic formula."""
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RY(par, wires=[0])
             qml.expval(qml.PauliX(0))
 
@@ -125,7 +125,7 @@ class TestAdjointJacobian:
         """Test that the gradient of the RX gate matches the known formula."""
         a = 0.7418
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(a, wires=0)
             qml.expval(qml.PauliZ(0))
 
@@ -139,7 +139,7 @@ class TestAdjointJacobian:
         dev = qml.device("default.qubit", wires=3)
         params = np.array([np.pi, np.pi / 2, np.pi / 3])
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(params[0], wires=0)
             qml.RX(params[1], wires=1)
             qml.RX(params[2], wires=2)
@@ -162,7 +162,7 @@ class TestAdjointJacobian:
         """Tests that the gradients of circuits match between the finite difference and device
         methods."""
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.Hadamard(wires=0)
             qml.RX(0.543, wires=0)
             qml.CNOT(wires=[0, 1])
@@ -188,7 +188,7 @@ class TestAdjointJacobian:
         """Tests that gates with multiple free parameters yield correct gradients."""
         x, y, z = [0.5, 0.3, -0.7]
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(0.4, wires=[0])
             qml.Rot(x, y, z, wires=[0])
             qml.RY(-0.2, wires=[0])
@@ -210,7 +210,7 @@ class TestAdjointJacobian:
 
         x, y, z = [0.5, 0.3, -0.7]
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(0.4, wires=[0])
             qml.Rot(x, y, z, wires=[0])
             qml.RY(-0.2, wires=[0])
@@ -229,7 +229,7 @@ class TestAdjointJacobian:
         """Tests provides correct answer when provided starting state."""
         x, y, z = [0.5, 0.3, -0.7]
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(0.4, wires=[0])
             qml.Rot(x, y, z, wires=[0])
             qml.RY(-0.2, wires=[0])

--- a/tests/transforms/test_adjoint.py
+++ b/tests/transforms/test_adjoint.py
@@ -134,7 +134,7 @@ def test_nested_adjoint_on_function():
     )
 
 
-with qml.tape.JacobianTape() as tape:
+with qml.tape.QuantumTape() as tape:
     qml.PauliX(0)
     qml.Hadamard(1)
 

--- a/tests/transforms/test_adjoint_metric_tensor.py
+++ b/tests/transforms/test_adjoint_metric_tensor.py
@@ -819,7 +819,7 @@ class TestErrors:
 
     def test_error_finite_shots(self):
         """Test that an error is raised if the device has a finite number of shots set."""
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(0.2, wires=0)
             qml.RY(1.9, wires=1)
         dev = qml.device("default.qubit", wires=2, shots=1)

--- a/tests/transforms/test_batch_transform.py
+++ b/tests/transforms/test_batch_transform.py
@@ -493,8 +493,8 @@ class TestBatchTransformGradients:
         """Generates two tapes, one with all RX replaced with RY,
         and the other with all RX replaced with RZ."""
 
-        tape1 = qml.tape.JacobianTape()
-        tape2 = qml.tape.JacobianTape()
+        tape1 = qml.tape.QuantumTape()
+        tape2 = qml.tape.QuantumTape()
 
         # loop through all operations on the input tape
         for op in tape.operations + tape.measurements:
@@ -650,13 +650,13 @@ class TestMapBatchTransform:
         x = 0.6
         y = 0.7
 
-        with qml.tape.JacobianTape() as tape1:
+        with qml.tape.QuantumTape() as tape1:
             qml.RX(x, wires=0)
             qml.RY(y, wires=1)
             qml.CNOT(wires=[0, 1])
             qml.expval(H)
 
-        with qml.tape.JacobianTape() as tape2:
+        with qml.tape.QuantumTape() as tape2:
             qml.Hadamard(wires=0)
             qml.CRX(x, wires=[0, 1])
             qml.CNOT(wires=[0, 1])
@@ -683,13 +683,13 @@ class TestMapBatchTransform:
         weights = np.array([0.6, 0.8], requires_grad=True)
 
         def cost(weights):
-            with qml.tape.JacobianTape() as tape1:
+            with qml.tape.QuantumTape() as tape1:
                 qml.RX(weights[0], wires=0)
                 qml.RY(weights[1], wires=1)
                 qml.CNOT(wires=[0, 1])
                 qml.expval(H)
 
-            with qml.tape.JacobianTape() as tape2:
+            with qml.tape.QuantumTape() as tape2:
                 qml.Hadamard(wires=0)
                 qml.CRX(weights[0], wires=[0, 1])
                 qml.CNOT(wires=[0, 1])

--- a/tests/transforms/test_hamiltonian_expand.py
+++ b/tests/transforms/test_hamiltonian_expand.py
@@ -160,7 +160,7 @@ class TestHamiltonianExpval:
             0.64123,
         ]
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             for i in range(2):
                 qml.RX(np.array(0), wires=0)
                 qml.RX(np.array(0), wires=1)
@@ -204,7 +204,7 @@ class TestHamiltonianExpval:
         ]
 
         with tf.GradientTape() as gtape:
-            with qml.tape.JacobianTape() as tape:
+            with qml.tape.QuantumTape() as tape:
                 for i in range(2):
                     qml.RX(var[i, 0], wires=0)
                     qml.RX(var[i, 1], wires=1)

--- a/tests/transforms/test_metric_tensor.py
+++ b/tests/transforms/test_metric_tensor.py
@@ -580,7 +580,7 @@ class TestMetricTensor:
         """Test that a tape with Ising gates has the correct metric tensor tapes."""
 
         dev = qml.device("default.qubit", wires=3)
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.Hadamard(0)
             qml.Hadamard(2)
             qml.IsingXX(0.2, wires=[0, 1])
@@ -1353,7 +1353,7 @@ def aux_wire_ansatz_1(x, y):
 def test_get_aux_wire(aux_wire, ansatz):
     """Test ``_get_aux_wire`` without device_wires."""
     x, y = np.array([0.2, 0.1], requires_grad=True)
-    with qml.tape.JacobianTape() as tape:
+    with qml.tape.QuantumTape() as tape:
         ansatz(x, y)
     out = _get_aux_wire(aux_wire, tape, None)
 
@@ -1366,7 +1366,7 @@ def test_get_aux_wire(aux_wire, ansatz):
 def test_get_aux_wire_with_device_wires():
     """Test ``_get_aux_wire`` with device_wires."""
     x, y = np.array([0.2, 0.1], requires_grad=True)
-    with qml.tape.JacobianTape() as tape:
+    with qml.tape.QuantumTape() as tape:
         qml.RX(x, wires=0)
         qml.RX(x, wires="one")
 

--- a/tests/transforms/test_optimization/test_undo_swaps.py
+++ b/tests/transforms/test_optimization/test_undo_swaps.py
@@ -36,7 +36,7 @@ class TestUndoSwaps:
         transformed_qfunc = undo_swaps(qfunc)
 
         tape = qml.transforms.make_tape(transformed_qfunc)()
-        res = tape.execute(qml.device("default.qubit", wires=2))
+        res = qml.device("default.qubit", wires=2).execute(tape)
         assert len(tape.operations) == 2
         assert np.allclose(res[0][0], 0.5)
 
@@ -52,7 +52,7 @@ class TestUndoSwaps:
         transformed_qfunc = undo_swaps(qfunc)
 
         tape = qml.transforms.make_tape(transformed_qfunc)()
-        res = tape.execute(qml.device("default.qubit", wires=2))
+        res = qml.device("default.qubit", wires=2).execute(tape)
         assert len(tape.operations) == 2
         assert np.allclose(res[0][2], 1.0)
 
@@ -75,10 +75,10 @@ class TestUndoSwaps:
         transformed_qfunc = undo_swaps(qfunc1)
 
         tape1 = qml.transforms.make_tape(transformed_qfunc)()
-        res1 = tape1.execute(qml.device("default.qubit", wires=3))
+        res1 = qml.device("default.qubit", wires=3).execute(tape1)
 
         tape2 = qml.transforms.make_tape(qfunc2)()
-        res2 = tape2.execute(qml.device("default.qubit", wires=3))
+        res2 = qml.device("default.qubit", wires=3).execute(tape2)
 
         assert np.allclose(res1, res2)
 
@@ -102,10 +102,10 @@ class TestUndoSwaps:
         transformed_qfunc = undo_swaps(qfunc1)
 
         tape1 = qml.transforms.make_tape(transformed_qfunc)()
-        res1 = tape1.execute(qml.device("default.qubit", wires=3))
+        res1 = qml.device("default.qubit", wires=3).execute(tape1)
 
         tape2 = qml.transforms.make_tape(qfunc2)()
-        res2 = tape2.execute(qml.device("default.qubit", wires=3))
+        res2 = qml.device("default.qubit", wires=3).execute(tape2)
 
         assert np.allclose(res1, res2)
 

--- a/tests/transforms/test_tape_expand.py
+++ b/tests/transforms/test_tape_expand.py
@@ -25,7 +25,7 @@ class TestCreateExpandFn:
 
     crit_0 = (~qml.operation.is_trainable) | (qml.operation.has_gen & qml.operation.is_trainable)
     doc_0 = "Test docstring."
-    with qml.tape.JacobianTape() as tape:
+    with qml.tape.QuantumTape() as tape:
         qml.RX(0.2, wires=0)
         qml.RY(qml.numpy.array(2.1, requires_grad=True), wires=1)
         qml.Rot(*qml.numpy.array([0.5, 0.2, -0.1], requires_grad=True), wires=0)
@@ -63,7 +63,7 @@ class TestCreateExpandFn:
         dev = qml.device("default.qubit", wires=1)
         expand_fn = qml.transforms.create_expand_fn(device=dev, depth=10, stop_at=self.crit_0)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.U1(0.2, wires=0)
             qml.Rot(*qml.numpy.array([0.5, 0.2, -0.1], requires_grad=True), wires=0)
 
@@ -80,7 +80,7 @@ class TestCreateExpandFn:
         dev = qml.device("default.qubit", wires=1)
         expand_fn = qml.transforms.create_expand_fn(device=dev, depth=10)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.U1(0.2, wires=0)
             qml.Rot(*qml.numpy.array([0.5, 0.2, -0.1], requires_grad=True), wires=0)
 
@@ -96,7 +96,7 @@ class TestCreateExpandFn:
         """Test that passing a depth simply expands to that depth"""
         dev = qml.device("default.qubit", wires=0)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(0.2, wires=0)
             qml.RY(qml.numpy.array(2.1, requires_grad=True), wires=1)
             qml.Rot(*qml.numpy.array([0.5, 0.2, -0.1], requires_grad=True), wires=0)
@@ -169,7 +169,7 @@ class TestExpandNonunitaryGen:
     def test_do_not_expand(self):
         """Test that a tape with single-parameter operations with
         unitary generators and non-parametric operations is not touched."""
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(0.2, wires=0)
             qml.Hadamard(0)
             qml.PauliRot(0.9, "XY", wires=[0, 1])
@@ -182,7 +182,7 @@ class TestExpandNonunitaryGen:
     def test_expand_multi_par(self):
         """Test that a tape with single-parameter operations with
         unitary generators and non-parametric operations is not touched."""
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(0.2, wires=0)
             qml.Hadamard(0)
             qml.Rot(0.9, 1.2, -0.6, wires=0)
@@ -209,7 +209,7 @@ class TestExpandNonunitaryGen:
             def generator(self):
                 return None
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(0.2, wires=0)
             qml.Hadamard(0)
             _PhaseShift(2.1, wires=1)
@@ -225,7 +225,7 @@ class TestExpandNonunitaryGen:
         """Test that a tape with single-parameter operations with
         unitary generators and non-parametric operations is not touched."""
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(0.2, wires=0)
             qml.Hadamard(0)
             qml.PhaseShift(2.1, wires=1)


### PR DESCRIPTION
**Context:** The tape subclasses and `tape.execute()` are no longer used by PennyLane, and ready for a deprecation cycle.

**Description of the Change:** All tape subclasses and execution methods have been marked as deprecated.

**Benefits:** n/a

**Possible Drawbacks:** n/a

**Related GitHub Issues:** n/a
