### PR TITLE
Extend `qcut.tape_to_graph` to support sampling measurements

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -4,6 +4,12 @@
 
 <h3>New features since last release</h3>
 
+* Development of a circuit-cutting compiler extension to circuits with sampling
+  measurements has begun:
+
+  - The existing `qcut.tape_to_graph()` method has been extended to convert a
+    sample measurements over all circuit wires to distinct sample nodes for each wire
+
 <h3>Improvements</h3>
 
 <h3>Breaking changes</h3>
@@ -15,3 +21,5 @@
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):
+
+Anthony Hayes

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -9,6 +9,7 @@
 
   - The existing `qcut.tape_to_graph()` method has been extended to convert a
     sample measurements over all circuit wires to distinct sample nodes for each wire
+    [(#2313)](https://github.com/PennyLaneAI/pennylane/pull/2313)
 
 <h3>Improvements</h3>
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -8,7 +8,8 @@
   measurements has begun:
 
   - The existing `qcut.tape_to_graph()` method has been extended to convert a
-    sample measurements over all circuit wires to distinct sample nodes for each wire
+    sample measurement without an observable specified to multiple single-qubit sample
+    nodes.
     [(#2313)](https://github.com/PennyLaneAI/pennylane/pull/2313)
 
 <h3>Improvements</h3>

--- a/pennylane/transforms/qcut.py
+++ b/pennylane/transforms/qcut.py
@@ -30,7 +30,7 @@ import pennylane as qml
 from pennylane import apply, expval
 from pennylane.grouping import string_to_pauli_word
 from pennylane.measurements import MeasurementProcess
-from pennylane.operation import Expectation, Operation, Operator, Tensor
+from pennylane.operation import Expectation, Operation, Operator, Sample, Tensor
 from pennylane.ops.qubit.non_parametric_ops import WireCut
 from pennylane.tape import QuantumTape
 from pennylane.wires import Wires
@@ -235,6 +235,11 @@ def tape_to_graph(tape: QuantumTape) -> MultiDiGraph:
     for m in tape.measurements:
         obs = getattr(m, "obs", None)
         if obs is not None and isinstance(obs, Tensor):
+            if m.return_type is Sample:
+                raise ValueError(
+                    "Sampling from tensor products of observables "
+                    "is not supported in circuit cutting"
+                )
             for o in obs.obs:
                 m_ = MeasurementProcess(m.return_type, obs=o)
 

--- a/pennylane/transforms/qcut.py
+++ b/pennylane/transforms/qcut.py
@@ -24,7 +24,7 @@ from functools import partial
 from itertools import product
 from typing import Any, Callable, ClassVar, Dict, List, Optional, Sequence, Tuple, Union
 
-from networkx import MultiDiGraph, weakly_connected_components, has_path
+from networkx import MultiDiGraph, has_path, weakly_connected_components
 
 import pennylane as qml
 from pennylane import apply, expval
@@ -239,7 +239,10 @@ def tape_to_graph(tape: QuantumTape) -> MultiDiGraph:
                 m_ = MeasurementProcess(m.return_type, obs=o)
 
                 _add_operator_node(graph, m_, order, wire_latest_node)
-
+        elif m.return_type.name == "Sample":
+            for w in m.wires.tolist():
+                s_ = qml.sample(qml.Projector([1], wires=w))
+                _add_operator_node(graph, s_, order, wire_latest_node)
         else:
             _add_operator_node(graph, m, order, wire_latest_node)
             order += 1

--- a/pennylane/transforms/qcut.py
+++ b/pennylane/transforms/qcut.py
@@ -239,8 +239,8 @@ def tape_to_graph(tape: QuantumTape) -> MultiDiGraph:
                 m_ = MeasurementProcess(m.return_type, obs=o)
 
                 _add_operator_node(graph, m_, order, wire_latest_node)
-        elif m.return_type.name == "Sample":
-            for w in m.wires.tolist():
+        elif m.return_type is Sample and obs is None:
+            for w in m.wires:
                 s_ = qml.sample(qml.Projector([1], wires=w))
                 _add_operator_node(graph, s_, order, wire_latest_node)
         else:

--- a/tests/transforms/test_qcut.py
+++ b/tests/transforms/test_qcut.py
@@ -384,7 +384,7 @@ class TestTapeToGraph:
 
     def test_split_sample_measurement(self):
         """
-        Test that a circuit with single sample measurement over all wires is
+        Test that a circuit with a single sample measurement over all wires is
         correctly converted to a graph with a distinct node for each wire sampled
         """
 
@@ -409,9 +409,13 @@ class TestTapeToGraph:
             qml.sample(qml.Projector([1], wires=[2])),
         ]
 
-        for node, expected_node in zip(list(g.nodes), expected_nodes):
+        for node, expected_node in zip(g.nodes, expected_nodes):
             assert node.name == expected_node.name
             assert node.wires == expected_node.wires
+
+            if getattr(node, "obs", None) is not None:
+                assert node.return_type is qml.operation.Sample
+                assert node.obs.name == expected_node.obs.name
 
     def test_sample_tensor_obs(self):
         """
@@ -428,7 +432,7 @@ class TestTapeToGraph:
             qml.sample(qml.PauliX(0) @ qml.PauliY(1))
 
         with pytest.raises(ValueError, match="Sampling from tensor products of observables "):
-            g = qcut.tape_to_graph(tape)
+            qcut.tape_to_graph(tape)
 
     def test_multiple_obs_samples(self):
         """
@@ -459,9 +463,13 @@ class TestTapeToGraph:
             qml.sample(qml.PauliZ(wires=[2])),
         ]
 
-        for node, expected_node in zip(list(g.nodes), expected_nodes):
+        for node, expected_node in zip(g.nodes, expected_nodes):
             assert node.name == expected_node.name
             assert node.wires == expected_node.wires
+
+            if getattr(node, "obs", None) is not None:
+                assert node.return_type is qml.operation.Sample
+                assert node.obs.name == expected_node.obs.name
 
 
 class TestReplaceWireCut:

--- a/tests/transforms/test_qcut.py
+++ b/tests/transforms/test_qcut.py
@@ -413,6 +413,23 @@ class TestTapeToGraph:
             assert node.name == expected_node.name
             assert node.wires == expected_node.wires
 
+    def test_sample_tensor_obs(self):
+        """
+        Test that a circuit with a sample measurement of a tensor product of
+        observables raises the correct error.
+        """
+
+        with qml.tape.QuantumTape() as tape:
+            qml.Hadamard(wires=0)
+            qml.CNOT(wires=[0, 1])
+            qml.PauliX(wires=1)
+            qml.WireCut(wires=1)
+            qml.CNOT(wires=[1, 2])
+            qml.sample(qml.PauliX(0) @ qml.PauliY(1))
+
+        with pytest.raises(ValueError, match="Sampling from tensor products of observables "):
+            g = qcut.tape_to_graph(tape)
+
 
 class TestReplaceWireCut:
     """

--- a/tests/transforms/test_qcut.py
+++ b/tests/transforms/test_qcut.py
@@ -430,6 +430,39 @@ class TestTapeToGraph:
         with pytest.raises(ValueError, match="Sampling from tensor products of observables "):
             g = qcut.tape_to_graph(tape)
 
+    def test_multiple_obs_samples(self):
+        """
+        Test that a circuit with multiple sample measurements of observables
+        over individual wires is supported.
+        """
+
+        with qml.tape.QuantumTape() as tape:
+            qml.Hadamard(wires=0)
+            qml.CNOT(wires=[0, 1])
+            qml.PauliX(wires=1)
+            qml.WireCut(wires=1)
+            qml.CNOT(wires=[1, 2])
+            qml.sample(qml.PauliZ(0))
+            qml.sample(qml.PauliZ(1))
+            qml.sample(qml.PauliZ(2))
+
+        g = qcut.tape_to_graph(tape)
+
+        expected_nodes = [
+            qml.Hadamard(wires=[0]),
+            qml.CNOT(wires=[0, 1]),
+            qml.PauliX(wires=[1]),
+            qml.WireCut(wires=[1]),
+            qml.CNOT(wires=[1, 2]),
+            qml.sample(qml.PauliZ(wires=[0])),
+            qml.sample(qml.PauliZ(wires=[1])),
+            qml.sample(qml.PauliZ(wires=[2])),
+        ]
+
+        for node, expected_node in zip(list(g.nodes), expected_nodes):
+            assert node.name == expected_node.name
+            assert node.wires == expected_node.wires
+
 
 class TestReplaceWireCut:
     """


### PR DESCRIPTION
**Context:**
Many practical applications of quantum circuits require sampling measurements. Here we begin extending the existing manual circuit cutting pipeline to support sampling measurements.

**Description of the Change:**
The existing `qcut.tape_to_graph` method has been extended to convert a sampling in the computational basis over all wires in a circuit. The single sampling measurement is converted into distinct nodes in the computational graph; one for each wire. 

**Benefits:**
First step toward supporting cutting circuit with sampling measurements.

**Possible Drawbacks:**
~~Does not support sample measurements containing observables.~~

**Related GitHub Issues:**
#2297 sampling with and without observables in a single circuit causes an error. As such, the sample nodes added to the graph contain an explicit projection measurement equivalent to sampling in the computational basis. This is required for later steps in the cutting pipeline when converting subgraphs to fragment tapes.  