### PR TITLE
Amend docstring examples for `compute_matrix` and `compute_eigvals`

### DIFF
--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -138,30 +138,30 @@ def expand_matrix(base_matrix, wires, wire_order):
     ...                         [9, 10, 11, 12],
     ...                         [13, 14, 15, 16]])
     >>> expand_matrix(base_matrix, wires=[0, 2], wire_order=[0, 2])
-    array([[ 1  2  3  4]
+    [[ 1  2  3  4]
      [ 5  6  7  8]
      [ 9 10 11 12]
-     [13 14 15 16]])
+     [13 14 15 16]]
 
     If the wire order is a permutation of ``wires``, the entries of the base matrix get permuted:
 
     >>> expand_matrix(base_matrix, wires=[0, 2], wire_order=[2, 0])
-    array([[ 1  3  2  4]
+    [[ 1  3  2  4]
      [ 9 11 10 12]
      [ 5  7  6  8]
-     [13 15 14 16]])
+     [13 15 14 16]]
 
     If the wire order contains wire labels not found in ``wires``, the matrix gets expanded:
 
     >>> expand_matrix(base_matrix, wires=[0, 2], wire_order=[0, 1, 2])
-    array([[ 1  2  0  0  3  4  0  0]
+    [[ 1  2  0  0  3  4  0  0]
      [ 5  6  0  0  7  8  0  0]
      [ 0  0  1  2  0  0  3  4]
      [ 0  0  5  6  0  0  7  8]
      [ 9 10  0  0 11 12  0  0]
      [13 14  0  0 15 16  0  0]
      [ 0  0  9 10  0  0 11 12]
-     [ 0  0 13 14  0  0 15 16]])
+     [ 0  0 13 14  0  0 15 16]]
 
     The method works with tensors from all autodifferentiation frameworks, for example:
 

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -138,30 +138,30 @@ def expand_matrix(base_matrix, wires, wire_order):
     ...                         [9, 10, 11, 12],
     ...                         [13, 14, 15, 16]])
     >>> expand_matrix(base_matrix, wires=[0, 2], wire_order=[0, 2])
-    [[ 1  2  3  4]
+    array([[ 1  2  3  4]
      [ 5  6  7  8]
      [ 9 10 11 12]
-     [13 14 15 16]]
+     [13 14 15 16]])
 
     If the wire order is a permutation of ``wires``, the entries of the base matrix get permuted:
 
     >>> expand_matrix(base_matrix, wires=[0, 2], wire_order=[2, 0])
-    [[ 1  3  2  4]
+    array([[ 1  3  2  4]
      [ 9 11 10 12]
      [ 5  7  6  8]
-     [13 15 14 16]]
+     [13 15 14 16]])
 
     If the wire order contains wire labels not found in ``wires``, the matrix gets expanded:
 
     >>> expand_matrix(base_matrix, wires=[0, 2], wire_order=[0, 1, 2])
-    [[ 1  2  0  0  3  4  0  0]
+    array([[ 1  2  0  0  3  4  0  0]
      [ 5  6  0  0  7  8  0  0]
      [ 0  0  1  2  0  0  3  4]
      [ 0  0  5  6  0  0  7  8]
      [ 9 10  0  0 11 12  0  0]
      [13 14  0  0 15 16  0  0]
      [ 0  0  9 10  0  0 11 12]
-     [ 0  0 13 14  0  0 15 16]]
+     [ 0  0 13 14  0  0 15 16]])
 
     The method works with tensors from all autodifferentiation frameworks, for example:
 

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -137,7 +137,7 @@ def expand_matrix(base_matrix, wires, wire_order):
     ...                         [5, 6, 7, 8],
     ...                         [9, 10, 11, 12],
     ...                         [13, 14, 15, 16]])
-    >>> expand_matrix(base_matrix, wires=[0, 2], wire_order=[0, 2])
+    >>> print(expand_matrix(base_matrix, wires=[0, 2], wire_order=[0, 2]))
     [[ 1  2  3  4]
      [ 5  6  7  8]
      [ 9 10 11 12]
@@ -145,7 +145,7 @@ def expand_matrix(base_matrix, wires, wire_order):
 
     If the wire order is a permutation of ``wires``, the entries of the base matrix get permuted:
 
-    >>> expand_matrix(base_matrix, wires=[0, 2], wire_order=[2, 0])
+    >>> print(expand_matrix(base_matrix, wires=[0, 2], wire_order=[2, 0]))
     [[ 1  3  2  4]
      [ 9 11 10 12]
      [ 5  7  6  8]
@@ -153,7 +153,7 @@ def expand_matrix(base_matrix, wires, wire_order):
 
     If the wire order contains wire labels not found in ``wires``, the matrix gets expanded:
 
-    >>> expand_matrix(base_matrix, wires=[0, 2], wire_order=[0, 1, 2])
+    >>> print(expand_matrix(base_matrix, wires=[0, 2], wire_order=[0, 1, 2]))
     [[ 1  2  0  0  3  4  0  0]
      [ 5  6  0  0  7  8  0  0]
      [ 0  0  1  2  0  0  3  4]

--- a/pennylane/ops/identity.py
+++ b/pennylane/ops/identity.py
@@ -64,7 +64,7 @@ class Identity(CVObservable, Operation):
 
         **Example**
 
-        >>> qml.Identity.compute_eigvals()
+        >>> print(qml.Identity.compute_eigvals())
         [ 1 1]
         """
         return np.array([1, 1])
@@ -83,7 +83,7 @@ class Identity(CVObservable, Operation):
 
         **Example**
 
-        >>> qml.Identity.compute_matrix()
+        >>> print(qml.Identity.compute_matrix())
         [[1. 0.]
          [0. 1.]]
         """

--- a/pennylane/ops/qubit/arithmetic_ops.py
+++ b/pennylane/ops/qubit/arithmetic_ops.py
@@ -107,7 +107,7 @@ class QubitCarry(Operation):
 
         **Example**
 
-        >>> qml.QubitCarry.compute_matrix()
+        >>> print(qml.QubitCarry.compute_matrix())
         [[1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]
          [0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0]
          [0 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0]
@@ -254,7 +254,7 @@ class QubitSum(Operation):
 
         **Example**
 
-        >>> qml.QubitSum.compute_matrix()
+        >>> print(qml.QubitSum.compute_matrix())
         [[1 0 0 0 0 0 0 0]
          [0 1 0 0 0 0 0 0]
          [0 0 0 1 0 0 0 0]

--- a/pennylane/ops/qubit/non_parametric_ops.py
+++ b/pennylane/ops/qubit/non_parametric_ops.py
@@ -66,7 +66,7 @@ class Hadamard(Observable, Operation):
 
         **Example**
 
-        >>> qml.Hadamard.compute_matrix()
+        >>> print(qml.Hadamard.compute_matrix())
         [[ 0.70710678  0.70710678]
          [ 0.70710678 -0.70710678]]
         """
@@ -92,7 +92,7 @@ class Hadamard(Observable, Operation):
 
         **Example**
 
-        >>> qml.Hadamard.compute_eigvals()
+        >>> print(qml.Hadamard.compute_eigvals())
         [ 1 -1]
         """
         return pauli_eigs(1)
@@ -117,7 +117,7 @@ class Hadamard(Observable, Operation):
 
         **Example**
 
-        >>> qml.Hadamard.compute_diagonalizing_gates(wires=[0])
+        >>> print(qml.Hadamard.compute_diagonalizing_gates(wires=[0]))
         [RY(-0.7853981633974483, wires=[0])]
         """
         return [qml.RY(-np.pi / 4, wires=wires)]
@@ -138,7 +138,7 @@ class Hadamard(Observable, Operation):
 
         **Example:**
 
-        >>> qml.Hadamard.compute_decomposition(0)
+        >>> print(qml.Hadamard.compute_decomposition(0))
         [PhaseShift(1.5707963267948966, wires=[0]),
         RX(1.5707963267948966, wires=[0]),
         PhaseShift(1.5707963267948966, wires=[0])]
@@ -199,7 +199,7 @@ class PauliX(Observable, Operation):
 
         **Example**
 
-        >>> qml.PauliX.compute_matrix()
+        >>> print(qml.PauliX.compute_matrix())
         [[0 1]
          [1 0]]
         """
@@ -225,7 +225,7 @@ class PauliX(Observable, Operation):
 
         **Example**
 
-        >>> qml.PauliX.compute_eigvals()
+        >>> print(qml.PauliX.compute_eigvals())
         [ 1 -1]
         """
         return pauli_eigs(1)
@@ -250,7 +250,7 @@ class PauliX(Observable, Operation):
 
         **Example**
 
-        >>> qml.PauliX.compute_diagonalizing_gates(wires=[0])
+        >>> print(qml.PauliX.compute_diagonalizing_gates(wires=[0]))
         [Hadamard(wires=[0])]
         """
         return [Hadamard(wires=wires)]
@@ -272,7 +272,7 @@ class PauliX(Observable, Operation):
 
         **Example:**
 
-        >>> qml.PauliX.compute_decomposition(0)
+        >>> print(qml.PauliX.compute_decomposition(0))
         [PhaseShift(1.5707963267948966, wires=[0]),
         RX(3.141592653589793, wires=[0]),
         PhaseShift(1.5707963267948966, wires=[0])]
@@ -335,7 +335,7 @@ class PauliY(Observable, Operation):
 
         **Example**
 
-        >>> qml.PauliY.compute_matrix()
+        >>> print(qml.PauliY.compute_matrix())
         [[ 0.+0.j -0.-1.j]
          [ 0.+1.j  0.+0.j]]
         """
@@ -361,7 +361,7 @@ class PauliY(Observable, Operation):
 
         **Example**
 
-        >>> qml.PauliY.compute_eigvals()
+        >>> print(qml.PauliY.compute_eigvals())
         [ 1 -1]
         """
         return pauli_eigs(1)
@@ -386,7 +386,7 @@ class PauliY(Observable, Operation):
 
         **Example**
 
-        >>> qml.PauliY.compute_diagonalizing_gates(wires=[0])
+        >>> print(qml.PauliY.compute_diagonalizing_gates(wires=[0]))
         [PauliZ(wires=[0]), S(wires=[0]), Hadamard(wires=[0])]
         """
         return [
@@ -411,7 +411,7 @@ class PauliY(Observable, Operation):
 
         **Example:**
 
-        >>> qml.PauliY.compute_decomposition(0)
+        >>> print(qml.PauliY.compute_decomposition(0))
         [PhaseShift(1.5707963267948966, wires=[0]),
         RY(3.141592653589793, wires=[0]),
         PhaseShift(1.5707963267948966, wires=[0])]
@@ -472,7 +472,7 @@ class PauliZ(Observable, Operation):
 
         **Example**
 
-        >>> qml.PauliZ.compute_matrix()
+        >>> print(qml.PauliZ.compute_matrix())
         [[ 1  0]
          [ 0 -1]]
         """
@@ -498,7 +498,7 @@ class PauliZ(Observable, Operation):
 
         **Example**
 
-        >>> qml.PauliZ.compute_eigvals()
+        >>> print(qml.PauliZ.compute_eigvals())
         [ 1 -1]
         """
         return pauli_eigs(1)
@@ -524,7 +524,7 @@ class PauliZ(Observable, Operation):
 
         **Example**
 
-        >>> qml.PauliZ.compute_diagonalizing_gates(wires=[0])
+        >>> print(qml.PauliZ.compute_diagonalizing_gates(wires=[0]))
         []
         """
         return []
@@ -545,7 +545,7 @@ class PauliZ(Observable, Operation):
 
         **Example:**
 
-        >>> qml.PauliZ.compute_decomposition(0)
+        >>> print(qml.PauliZ.compute_decomposition(0))
         [PhaseShift(3.141592653589793, wires=[0])]
 
         """
@@ -599,7 +599,7 @@ class S(Operation):
 
         **Example**
 
-        >>> qml.S.compute_matrix()
+        >>> print(qml.S.compute_matrix())
         [[1.+0.j 0.+0.j]
          [0.+0.j 0.+1.j]]
         """
@@ -625,7 +625,7 @@ class S(Operation):
 
         **Example**
 
-        >>> qml.S.compute_eigvals()
+        >>> print(qml.S.compute_eigvals())
         [1.+0.j 0.+1.j]
         """
         return np.array([1, 1j])
@@ -647,7 +647,7 @@ class S(Operation):
 
         **Example:**
 
-        >>> qml.S.compute_decomposition(0)
+        >>> print(qml.S.compute_decomposition(0))
         [PhaseShift(1.5707963267948966, wires=[0])]
 
         """
@@ -700,7 +700,7 @@ class T(Operation):
 
         **Example**
 
-        >>> qml.T.compute_matrix()
+        >>> print(qml.T.compute_matrix())
         [[1.+0.j         0.        +0.j        ]
          [0.+0.j         0.70710678+0.70710678j]]
         """
@@ -726,7 +726,7 @@ class T(Operation):
 
         **Example**
 
-        >>> qml.T.compute_eigvals()
+        >>> print(qml.T.compute_eigvals())
         [1.+0.j 0.70710678+0.70710678j]
         """
         return np.array([1, cmath.exp(1j * np.pi / 4)])
@@ -748,7 +748,7 @@ class T(Operation):
 
         **Example:**
 
-        >>> qml.T.compute_decomposition(0)
+        >>> print(qml.T.compute_decomposition(0))
         [PhaseShift(0.7853981633974483, wires=[0])]
 
         """
@@ -801,7 +801,7 @@ class SX(Operation):
 
         **Example**
 
-        >>> qml.SX.compute_matrix()
+        >>> print(qml.SX.compute_matrix())
         [[0.5+0.5j 0.5-0.5j]
          [0.5-0.5j 0.5+0.5j]]
         """
@@ -828,7 +828,7 @@ class SX(Operation):
 
         **Example**
 
-        >>> qml.SX.compute_eigvals()
+        >>> print(qml.SX.compute_eigvals())
         [1.+0.j 0.+1.j]
         """
         return np.array([1, 1j])
@@ -850,7 +850,7 @@ class SX(Operation):
 
         **Example:**
 
-        >>> qml.SX.compute_decomposition(0)
+        >>> print(qml.SX.compute_decomposition(0))
         [RZ(1.5707963267948966, wires=[0]),
         RY(1.5707963267948966, wires=[0]),
         RZ(-3.141592653589793, wires=[0]),
@@ -920,7 +920,7 @@ class CNOT(Operation):
 
         **Example**
 
-        >>> qml.CNOT.compute_matrix()
+        >>> print(qml.CNOT.compute_matrix())
         [[1 0 0 0]
          [0 1 0 0]
          [0 0 0 1]
@@ -983,7 +983,7 @@ class CZ(Operation):
 
         **Example**
 
-        >>> qml.CZ.compute_matrix()
+        >>> print(qml.CZ.compute_matrix())
         [[ 1  0  0  0]
          [ 0  1  0  0]
          [ 0  0  1  0]
@@ -1012,7 +1012,7 @@ class CZ(Operation):
 
         **Example**
 
-        >>> qml.CZ.compute_eigvals()
+        >>> print(qml.CZ.compute_eigvals())
         [1, 1, 1, -1]
         """
         return np.array([1, 1, 1, -1])
@@ -1070,7 +1070,7 @@ class CY(Operation):
 
         **Example**
 
-        >>> qml.CY.compute_matrix()
+        >>> print(qml.CY.compute_matrix())
         [[ 1.+0.j  0.+0.j  0.+0.j  0.+0.j]
          [ 0.+0.j  1.+0.j  0.+0.j  0.+0.j]
          [ 0.+0.j  0.+0.j  0.+0.j -0.-1.j]
@@ -1103,7 +1103,7 @@ class CY(Operation):
 
         **Example:**
 
-        >>> qml.CY.compute_decomposition(0)
+        >>> print(qml.CY.compute_decomposition(0))
         [CRY(3.141592653589793, wires=[0, 1]), S(wires=[0])]
 
         """
@@ -1154,7 +1154,7 @@ class SWAP(Operation):
 
         **Example**
 
-        >>> qml.SWAP.compute_matrix()
+        >>> print(qml.SWAP.compute_matrix())
         [[1 0 0 0]
          [0 0 1 0]
          [0 1 0 0]
@@ -1179,7 +1179,7 @@ class SWAP(Operation):
 
         **Example:**
 
-        >>> qml.SWAP.compute_decomposition((0,1))
+        >>> print(qml.SWAP.compute_decomposition((0,1)))
         [CNOT(wires=[0, 1]), CNOT(wires=[1, 0]), CNOT(wires=[0, 1])]
 
         """
@@ -1234,7 +1234,7 @@ class ISWAP(Operation):
 
         **Example**
 
-        >>> qml.ISWAP.compute_matrix()
+        >>> print(qml.ISWAP.compute_matrix())
         [[1.+0.j 0.+0.j 0.+0.j 0.+0.j]
          [0.+0.j 0.+0.j 0.+1.j 0.+0.j]
          [0.+0.j 0.+1.j 0.+0.j 0.+0.j]
@@ -1263,7 +1263,7 @@ class ISWAP(Operation):
 
         **Example**
 
-        >>> qml.ISWAP.compute_eigvals()
+        >>> print(qml.ISWAP.compute_eigvals())
         [1j, -1j, 1, 1]
         """
         return np.array([1j, -1j, 1, 1])
@@ -1285,7 +1285,7 @@ class ISWAP(Operation):
 
         **Example:**
 
-        >>> qml.ISWAP.compute_decomposition((0,1))
+        >>> print(qml.ISWAP.compute_decomposition((0,1)))
         [S(wires=[0]),
         S(wires=[1]),
         Hadamard(wires=[0]),
@@ -1348,7 +1348,7 @@ class SISWAP(Operation):
 
         **Example**
 
-        >>> qml.SISWAP.compute_matrix()
+        >>> print(qml.SISWAP.compute_matrix())
         [[1.+0.j          0.+0.j          0.+0.j  0.+0.j]
          [0.+0.j  0.70710678+0.j  0.+0.70710678j  0.+0.j]
          [0.+0.j  0.+0.70710678j  0.70710678+0.j  0.+0.j]
@@ -1384,7 +1384,7 @@ class SISWAP(Operation):
 
         **Example**
 
-        >>> qml.SISWAP.compute_eigvals()
+        >>> print(qml.SISWAP.compute_eigvals())
         [0.70710678+0.70710678j 0.70710678-0.70710678j 1.+0.j 1.+0.j]
         """
         return np.array([INV_SQRT2 * (1 + 1j), INV_SQRT2 * (1 - 1j), 1, 1])
@@ -1406,7 +1406,7 @@ class SISWAP(Operation):
 
         **Example:**
 
-        >>> qml.SISWAP.compute_decomposition((0,1))
+        >>> print(qml.SISWAP.compute_decomposition((0,1)))
         [SX(wires=[0]),
         RZ(1.5707963267948966, wires=[0]),
         CNOT(wires=[0, 1]),
@@ -1493,7 +1493,7 @@ class CSWAP(Operation):
 
         **Example**
 
-        >>> qml.CSWAP.compute_matrix()
+        >>> print(qml.CSWAP.compute_matrix())
         [[1 0 0 0 0 0 0 0]
          [0 1 0 0 0 0 0 0]
          [0 0 1 0 0 0 0 0]
@@ -1533,7 +1533,7 @@ class CSWAP(Operation):
 
         **Example:**
 
-        >>> qml.CSWAP.compute_decomposition((0,1,2))
+        >>> print(qml.CSWAP.compute_decomposition((0,1,2)))
         [Toffoli(wires=[0, 2, 1]), Toffoli(wires=[0, 1, 2]), Toffoli(wires=[0, 2, 1])]
 
         """
@@ -1602,7 +1602,7 @@ class Toffoli(Operation):
 
         **Example**
 
-        >>> qml.Toffoli.compute_matrix()
+        >>> print(qml.Toffoli.compute_matrix())
         [[1 0 0 0 0 0 0 0]
          [0 1 0 0 0 0 0 0]
          [0 0 1 0 0 0 0 0]
@@ -1642,7 +1642,7 @@ class Toffoli(Operation):
 
         **Example:**
 
-        >>> qml.Toffoli.compute_decomposition((0,1,2))
+        >>> print(qml.Toffoli.compute_decomposition((0,1,2)))
         [Hadamard(wires=[2]),
         CNOT(wires=[1, 2]),
         T.inv(wires=[2]),
@@ -1812,12 +1812,12 @@ class MultiControlledX(Operation):
 
         **Example**
 
-        >>> qml.MultiControlledX.compute_matrix([0], '1')
+        >>> print(qml.MultiControlledX.compute_matrix([0], '1'))
         [[1. 0. 0. 0.]
          [0. 1. 0. 0.]
          [0. 0. 0. 1.]
          [0. 0. 1. 0.]]
-        >>> qml.MultiControlledX.compute_matrix([1], '0')
+        >>> print(qml.MultiControlledX.compute_matrix([1], '0'))
         [[0. 1. 0. 0.]
          [1. 0. 0. 0.]
          [0. 0. 1. 0.]
@@ -1875,7 +1875,7 @@ class MultiControlledX(Operation):
 
         **Example:**
 
-        >>> qml.MultiControlledX.compute_decomposition(wires=[0,1,2,3],control_values="111", work_wires=qml.wires.Wires("aux"))
+        >>> print(qml.MultiControlledX.compute_decomposition(wires=[0,1,2,3],control_values="111", work_wires=qml.wires.Wires("aux")))
         [Toffoli(wires=[2, 'aux', 3]),
         Toffoli(wires=[0, 1, 'aux']),
         Toffoli(wires=[2, 'aux', 3]),
@@ -2041,7 +2041,7 @@ class Barrier(Operation):
 
         **Example:**
 
-        >>> qml.Barrier.compute_decomposition(0)
+        >>> print(qml.Barrier.compute_decomposition(0))
         []
 
         """
@@ -2089,7 +2089,7 @@ class WireCut(Operation):
 
         **Example:**
 
-        >>> qml.WireCut.compute_decomposition(0)
+        >>> print(qml.WireCut.compute_decomposition(0))
         []
 
         """


### PR DESCRIPTION
Amend docstring examples for `compute_matrix` and `compute_eigvals` to get the correct formatting in the output.

This is meant to avoid confusion that users might have if they don't get the same output as in the docs.