### PR TITLE
ControlledQubitUnitary should raise `DecompositionUndefinedError`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -462,6 +462,7 @@ The Operator class has undergone a major refactor with the following changes:
   decomposition does not exist, the code now raises a custom `NoDecompositionError`
   instead of `NotImplementedError`.
   [(#2024)](https://github.com/PennyLaneAI/pennylane/pull/2024)
+  [(#2320)](https://github.com/PennyLaneAI/pennylane/pull/2320)
 
 * The `diagonalizing_gates()` representation has been moved to the highest-level
   `Operator` class and is therefore available to all subclasses. A condition

--- a/pennylane/ops/qubit/matrix_ops.py
+++ b/pennylane/ops/qubit/matrix_ops.py
@@ -20,7 +20,7 @@ import warnings
 import numpy as np
 
 import pennylane as qml
-from pennylane.operation import AnyWires, Operation
+from pennylane.operation import AnyWires, Operation, DecompositionUndefinedError
 from pennylane.wires import Wires
 
 
@@ -240,6 +240,10 @@ class ControlledQubitUnitary(QubitUnitary):
 
         total_wires = control_wires + wires
         super().__init__(*params, wires=total_wires, do_queue=do_queue)
+
+    @staticmethod
+    def compute_decomposition(*params, wires=None, **hyperparameters):
+        raise DecompositionUndefinedError
 
     @staticmethod
     def compute_matrix(

--- a/tests/ops/qubit/test_matrix_ops.py
+++ b/tests/ops/qubit/test_matrix_ops.py
@@ -454,7 +454,7 @@ class TestControlledQubitUnitary:
         assert np.allclose(res_dynamic, expected, atol=tol)
 
     def test_no_decomp(self):
-        """Test ControlledQubitUnitary raises a decomposition undefined
+        """Test that ControlledQubitUnitary raises a decomposition undefined
         error."""
         mat = qml.PauliX(0).get_matrix()
         with pytest.raises(qml.operation.DecompositionUndefinedError):

--- a/tests/ops/qubit/test_matrix_ops.py
+++ b/tests/ops/qubit/test_matrix_ops.py
@@ -453,6 +453,13 @@ class TestControlledQubitUnitary:
         assert np.allclose(res_static, expected, atol=tol)
         assert np.allclose(res_dynamic, expected, atol=tol)
 
+    def test_no_decomp(self):
+        """Test ControlledQubitUnitary raises a decomposition undefined
+        error."""
+        mat = qml.PauliX(0).get_matrix()
+        with pytest.raises(qml.operation.DecompositionUndefinedError):
+            qml.ControlledQubitUnitary(mat, wires=0, control_wires=1).decomposition()
+
 
 label_data = [
     (X, qml.QubitUnitary(X, wires=0)),


### PR DESCRIPTION
**Context**
By default, operations don't have a decomposition defined and raise `DecompositionUndefinedError` with the changes in https://github.com/PennyLaneAI/pennylane/pull/2024. Operations can, however, define there own decompositions.

`qml.QubitUnitary` has a custom decomposition defined. Its controlled version, `qml.ControlledQubitUnitary` inherits from `qml.QubitUnitary`, but doesn't have a decomposition defined. This, however, breaks examples because `qml.QubitUnitary`'s `compute_decomposition` is being called when a decomposition of `qml.ControlledQubitUnitary` is attempted (see related issue).

**Changes**

Explicitly defines the `qml.ControlledQubitUnitary.compute_decomposition` method as is in the `Operator` class to raise `DecompositionUndefinedError`.

**Related issue**
Closes https://github.com/PennyLaneAI/pennylane/issues/2219.