### PR TITLE
Pin Lightning `>=0.22`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,7 +65,6 @@ jobs:
           pip install -r requirements-ci.txt
           python setup.py bdist_wheel
           pip install dist/PennyLane*.whl
-          pip install --upgrade --pre -i https://test.pypi.org/simple/ PennyLane-Lightning==0.22.0.dev16
 
       - name: Run tests
         run: python -m pytest tests --cov=pennylane $COVERAGE_FLAGS

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ requirements = [
     "semantic_version==2.6",
     "autoray",
     "cachetools",
-    "pennylane-lightning>=0.21",
+    "pennylane-lightning>=0.22",
 ]
 
 info = {


### PR DESCRIPTION
Pins to Lightning `>=0.22` in the `setup.py` file such that the most recent released version of PennyLane-Lightning is being pulled when installing PennyLane in a clean environment.