### PR TITLE
Fix queuing unexpected operators with `qml.measure`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -23,7 +23,7 @@
   
 <h3>Breaking changes</h3>
 
-<h3>Bug fixed</h3>
+<h3>Bug fixes</h3>
 
 * The conditional measurement added gates that were not defined.
   [(#2328)](https://github.com/PennyLaneAI/pennylane/pull/2328)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -23,6 +23,11 @@
   
 <h3>Breaking changes</h3>
 
+<h3>Bug fixed</h3>
+
+* The conditional measurement added gates that were not defined.
+  [(#2328)](https://github.com/PennyLaneAI/pennylane/pull/2328)
+
 <h3>Deprecations</h3>
 
 <h3>Documentation</h3>
@@ -31,4 +36,4 @@
 
 This release contains contributions from (in alphabetical order):
 
-Karim Alaa El-Din, Anthony Hayes
+Karim Alaa El-Din, Guillermo Alonso-Linaje, Anthony Hayes

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -25,7 +25,8 @@
 
 <h3>Bug fixes</h3>
 
-* The conditional measurement added gates that were not defined.
+* Fixes cases with `qml.measure` where unexpected operations were added to the
+  circuit.
   [(#2328)](https://github.com/PennyLaneAI/pennylane/pull/2328)
 
 <h3>Deprecations</h3>

--- a/pennylane/transforms/defer_measurements.py
+++ b/pennylane/transforms/defer_measurements.py
@@ -90,7 +90,7 @@ def defer_measurements(tape):
     ):
         raise ValueError("Continuous variable operations and observables are not supported.")
 
-    for op in tape.queue:
+    for op in tape.operations + tape.measurements:
         op_wires_measured = set(wire for wire in op.wires if wire in measured_wires.values())
         if len(op_wires_measured) > 0:
             raise ValueError(

--- a/pennylane/transforms/defer_measurements.py
+++ b/pennylane/transforms/defer_measurements.py
@@ -85,9 +85,17 @@ def defer_measurements(tape):
     """
     measured_wires = {}
 
-    if any(
-        isinstance(op, (qml.operation.CVOperation, qml.operation.CVObservable)) for op in tape.queue
-    ):
+    cv_op = any(
+        isinstance(op, (qml.operation.CVOperation, qml.operation.CVObservable))
+        for op in tape.operations
+    )
+    cv_obs = any(
+        isinstance(
+            getattr(op, "obs", None), (qml.operation.CVOperation, qml.operation.CVObservable)
+        )
+        for op in tape.measurements
+    )
+    if cv_op or cv_obs:
         raise ValueError("Continuous variable operations and observables are not supported.")
 
     for op in tape.operations + tape.measurements:

--- a/pennylane/transforms/defer_measurements.py
+++ b/pennylane/transforms/defer_measurements.py
@@ -47,10 +47,10 @@ def defer_measurements(tape):
     .. note::
 
         When applying the transform on a quantum function that returns
-        :func:`~measurements.state` as the terminal measurement or contains
-        :class:`~.Snapshot` instruction, state vector information the
-        transformed circuit will be obtained. No post-measurement states are
-        considered.
+        :func:`~.state` as the terminal measurement or contains the
+        :class:`~.Snapshot` instruction, state information corresponding to
+        simulating the transformed circuit will be obtained. No
+        post-measurement states are considered.
 
     Args:
         qfunc (function): a quantum function

--- a/pennylane/transforms/defer_measurements.py
+++ b/pennylane/transforms/defer_measurements.py
@@ -85,17 +85,10 @@ def defer_measurements(tape):
     """
     measured_wires = {}
 
-    cv_op = any(
-        isinstance(op, (qml.operation.CVOperation, qml.operation.CVObservable))
-        for op in tape.operations
-    )
-    cv_obs = any(
-        isinstance(
-            getattr(op, "obs", None), (qml.operation.CVOperation, qml.operation.CVObservable)
-        )
-        for op in tape.measurements
-    )
-    if cv_op or cv_obs:
+    cv_types = (qml.operation.CVOperation, qml.operation.CVObservable)
+    ops_cv = any(isinstance(op, cv_types) for op in tape.operations)
+    obs_cv = any(isinstance(getattr(op, "obs", None), cv_types) for op in tape.measurements)
+    if ops_cv or obs_cv:
         raise ValueError("Continuous variable operations and observables are not supported.")
 
     for op in tape.operations + tape.measurements:

--- a/pennylane/transforms/defer_measurements.py
+++ b/pennylane/transforms/defer_measurements.py
@@ -44,6 +44,14 @@ def defer_measurements(tape):
         This transform does not change the list of terminal measurements returned by
         the quantum function.
 
+    .. note::
+
+        When applying the transform on a quantum function that returns
+        :func:`~measurements.state` as the terminal measurement or contains
+        :class:`~.Snapshot` instruction, state vector information the
+        transformed circuit will be obtained. No post-measurement states are
+        considered.
+
     Args:
         qfunc (function): a quantum function
 
@@ -75,13 +83,6 @@ def defer_measurements(tape):
 
     >>> qml.grad(qnode)(par)
     -0.9924450321351936
-
-    .. note::
-
-        When applying the transform on a quantum function that returns
-        :func:`~measurements.state` as the terminal measurement, the state vector corresponding
-        to the pre-measurement state of the transformed circuit will be
-        obtained. No post-measurement states are considered.
     """
     measured_wires = {}
 

--- a/tests/transforms/test_condition.py
+++ b/tests/transforms/test_condition.py
@@ -31,13 +31,14 @@ import pennylane as qml
 from pennylane.transforms.condition import ConditionalTransformError
 
 terminal_meas = [
-qml.probs(wires=[1, 0]),
-qml.expval(qml.PauliZ(0)),
-qml.expval(qml.PauliZ('a') @ qml.PauliZ(3) @ qml.PauliZ(-1)),
-qml.var(qml.PauliX('b')),
-qml.state(),
-qml.density_matrix(wires=[2,3])
+    qml.probs(wires=[1, 0]),
+    qml.expval(qml.PauliZ(0)),
+    qml.expval(qml.PauliZ("a") @ qml.PauliZ(3) @ qml.PauliZ(-1)),
+    qml.var(qml.PauliX("b")),
+    qml.state(),
+    qml.density_matrix(wires=[2, 3]),
 ]
+
 
 @pytest.mark.parametrize("terminal_measurement", terminal_meas)
 class TestCond:

--- a/tests/transforms/test_condition.py
+++ b/tests/transforms/test_condition.py
@@ -30,12 +30,21 @@ from pennylane import numpy as np
 import pennylane as qml
 from pennylane.transforms.condition import ConditionalTransformError
 
+terminal_meas = [
+qml.probs(wires=[1, 0]),
+qml.expval(qml.PauliZ(0)),
+qml.expval(qml.PauliZ('a') @ qml.PauliZ(3) @ qml.PauliZ(-1)),
+qml.var(qml.PauliX('b')),
+qml.state(),
+qml.density_matrix(wires=[2,3])
+]
 
+@pytest.mark.parametrize("terminal_measurement", terminal_meas)
 class TestCond:
     """Tests that verify that the cond transform works as expect."""
 
-    def test_cond_queues(self):
-        """Test that qml.cond queues Conditional operations as expected."""
+    def test_cond_ops(self, terminal_measurement):
+        """Test that qml.cond creates conditional operations as expected."""
         r = 1.234
 
         def f(x):
@@ -46,12 +55,12 @@ class TestCond:
         with qml.tape.QuantumTape() as tape:
             m_0 = qml.measure(0)
             qml.cond(m_0, f)(r)
-            qml.probs(wires=1)
+            qml.apply(terminal_measurement)
 
-        ops = tape.queue
+        ops = tape.operations
         target_wire = qml.wires.Wires(1)
 
-        assert len(ops) == 5
+        assert len(ops) == 4
         assert ops[0].return_type == qml.operation.MidMeasure
 
         assert isinstance(ops[1], qml.transforms.condition.Conditional)
@@ -67,31 +76,32 @@ class TestCond:
         assert isinstance(ops[3].then_op, qml.PauliZ)
         assert ops[3].then_op.wires == target_wire
 
-        assert ops[4].return_type == qml.operation.Probability
+        assert len(tape.measurements) == 1
+        assert tape.measurements[0] is terminal_measurement
 
-    def tape_with_else(f, g, r):
+    def tape_with_else(f, g, r, meas):
         """Tape that uses cond by passing both a true and false func."""
         with qml.tape.QuantumTape() as tape:
             m_0 = qml.measure(0)
             qml.cond(m_0, f, g)(r)
-            qml.probs(wires=1)
+            qml.apply(meas)
 
         return tape
 
-    def tape_uses_cond_twice(f, g, r):
+    def tape_uses_cond_twice(f, g, r, meas):
         """Tape that uses cond twice such that it's equivalent to using cond
         with two functions being passed (tape_with_else)."""
         with qml.tape.QuantumTape() as tape:
             m_0 = qml.measure(0)
             qml.cond(m_0, f)(r)
             qml.cond(~m_0, g)(r)
-            qml.probs(wires=1)
+            qml.apply(meas)
 
         return tape
 
     @pytest.mark.parametrize("tape", [tape_with_else, tape_uses_cond_twice])
-    def test_cond_queues_with_else(self, tape):
-        """Test that qml.cond queues Conditional operations as expected in two cases:
+    def test_cond_operationss_with_else(self, tape, terminal_measurement):
+        """Test that qml.cond operationss Conditional operations as expected in two cases:
         1. When an else qfunc is provided;
         2. When qml.cond is used twice equivalent to using an else qfunc.
         """
@@ -105,11 +115,11 @@ class TestCond:
         def g(x):
             qml.PauliY(1)
 
-        tape = tape(f, g, r)
-        ops = tape.queue
+        tape = tape(f, g, r, terminal_measurement)
+        ops = tape.operations
         target_wire = qml.wires.Wires(1)
 
-        assert len(ops) == 6
+        assert len(ops) == 5
 
         assert ops[0].return_type == qml.operation.MidMeasure
 
@@ -137,14 +147,15 @@ class TestCond:
         # However, it is not the same for the false_fn
         assert ops[3].meas_val is not ops[4].meas_val
 
-        assert ops[5].return_type == qml.operation.Probability
+        assert len(tape.measurements) == 1
+        assert tape.measurements[0] is terminal_measurement
 
-    def test_cond_error(self):
+    def test_cond_error(self, terminal_measurement):
         """Test that an error is raised when the qfunc has a measurement."""
         dev = qml.device("default.qubit", wires=3)
 
         def f():
-            return qml.state()
+            return qml.apply(terminal_measurement)
 
         with pytest.raises(
             ConditionalTransformError, match="contain no measurements can be applied conditionally"
@@ -152,7 +163,7 @@ class TestCond:
             m_0 = qml.measure(1)
             qml.cond(m_0, f)()
 
-    def test_cond_error_else(self):
+    def test_cond_error_else(self, terminal_measurement):
         """Test that an error is raised when one of the qfuncs has a
         measurement."""
         dev = qml.device("default.qubit", wires=3)
@@ -161,7 +172,7 @@ class TestCond:
             qml.PauliX(0)
 
         def g():
-            return qml.state()
+            return qml.apply(terminal_measurement)
 
         with pytest.raises(
             ConditionalTransformError, match="contain no measurements can be applied conditionally"
@@ -176,7 +187,7 @@ class TestCond:
             qml.cond(m_0, g, f)()  # Check that the same error is raised when f and g are swapped
 
     @pytest.mark.parametrize("inp", [1, "string", qml.PauliZ(0)])
-    def test_cond_error_unrecognized_input(self, inp):
+    def test_cond_error_unrecognized_input(self, inp, terminal_measurement):
         """Test that an error is raised when the input is not recognized."""
         dev = qml.device("default.qubit", wires=3)
 
@@ -188,23 +199,24 @@ class TestCond:
             qml.cond(m_0, inp)()
 
 
+@pytest.mark.parametrize("terminal_measurement", terminal_meas)
 class TestOtherTransforms:
     """Tests that qml.cond works correctly with other transforms."""
 
-    def test_cond_queues_with_adjoint(self):
-        """Test that qml.cond queues Conditional operations as expected with
+    def test_cond_operationss_with_adjoint(self, terminal_measurement):
+        """Test that qml.cond operationss Conditional operations as expected with
         qml.adjoint."""
         r = 1.234
 
         with qml.tape.QuantumTape() as tape:
             m_0 = qml.measure(0)
             qml.cond(m_0, qml.adjoint(qml.RX), qml.RX)(r, wires=1)
-            qml.probs(wires=1)
+            qml.apply(terminal_measurement)
 
-        ops = tape.queue
+        ops = tape.operations
         target_wire = qml.wires.Wires(1)
 
-        assert len(ops) == 4
+        assert len(ops) == 3
         assert ops[0].return_type == qml.operation.MidMeasure
 
         assert isinstance(ops[1], qml.transforms.condition.Conditional)
@@ -217,29 +229,30 @@ class TestOtherTransforms:
         assert ops[2].then_op.data == [r]
         assert ops[2].then_op.wires == target_wire
 
-        assert ops[3].return_type == qml.operation.Probability
+        assert len(tape.measurements) == 1
+        assert tape.measurements[0] is terminal_measurement
 
-    def test_cond_queues_with_ctrl(self):
-        """Test that qml.cond queues Conditional operations as expected with
+    def test_cond_operationss_with_ctrl(self, terminal_measurement):
+        """Test that qml.cond operationss Conditional operations as expected with
         qml.ctrl."""
         r = 1.234
 
         with qml.tape.QuantumTape() as tape:
             m_0 = qml.measure(0)
             qml.cond(m_0, qml.ctrl(qml.RX, 1), qml.ctrl(qml.RY, 1))(r, wires=2)
-            qml.probs(wires=[1, 2])
+            qml.apply(terminal_measurement)
 
-        ops = tape.queue
+        ops = tape.operations
         target_wire = qml.wires.Wires(2)
 
-        assert len(ops) == 4
+        assert len(ops) == 3
         assert ops[0].return_type == qml.operation.MidMeasure
 
         assert isinstance(ops[1], qml.transforms.condition.Conditional)
         assert isinstance(ops[1].then_op, qml.transforms.control.ControlledOperation)
 
-        assert len(ops[1].then_op.subtape.queue) == 1
-        controlled_op = ops[1].then_op.subtape.queue[0]
+        assert len(ops[1].then_op.subtape.operations) == 1
+        controlled_op = ops[1].then_op.subtape.operations[0]
         assert isinstance(controlled_op, qml.RX)
         assert controlled_op.data == [r]
         assert controlled_op.wires == target_wire
@@ -247,41 +260,43 @@ class TestOtherTransforms:
         assert isinstance(ops[2], qml.transforms.condition.Conditional)
         assert isinstance(ops[2].then_op, qml.transforms.control.ControlledOperation)
 
-        assert len(ops[2].then_op.subtape.queue) == 1
-        controlled_op = ops[2].then_op.subtape.queue[0]
+        assert len(ops[2].then_op.subtape.operations) == 1
+        controlled_op = ops[2].then_op.subtape.operations[0]
         assert isinstance(controlled_op, qml.RY)
         assert controlled_op.data == [r]
         assert controlled_op.wires == target_wire
 
-        assert ops[3].return_type == qml.operation.Probability
+        assert len(tape.measurements) == 1
+        assert tape.measurements[0] is terminal_measurement
 
-    def test_ctrl_queues_with_cond(self):
-        """Test that qml.cond queues Conditional operations as expected with
+    def test_ctrl_operationss_with_cond(self, terminal_measurement):
+        """Test that qml.cond operationss Conditional operations as expected with
         qml.ctrl."""
         r = 1.234
 
         with qml.tape.QuantumTape() as tape:
             m_0 = qml.measure(0)
             qml.ctrl(qml.cond(m_0, qml.RX, qml.RY), 1)(r, wires=0)
-            qml.probs(wires=[1, 2])
+            qml.apply(terminal_measurement)
 
-        ops = tape.queue
+        ops = tape.operations
         target_wire = qml.wires.Wires(2)
 
-        assert len(ops) == 3
+        assert len(ops) == 2
         assert ops[0].return_type == qml.operation.MidMeasure
 
         assert isinstance(ops[1], qml.transforms.control.ControlledOperation)
-        assert len(ops[1].subtape.queue) == 2
+        assert len(ops[1].subtape.operations) == 2
 
-        op1 = ops[1].subtape.queue[0]
+        op1 = ops[1].subtape.operations[0]
         assert isinstance(op1, qml.transforms.condition.Conditional)
         assert isinstance(op1.then_op, qml.RX)
         assert op1.then_op.data == [r]
 
-        op2 = ops[1].subtape.queue[1]
+        op2 = ops[1].subtape.operations[1]
         assert isinstance(op2, qml.transforms.condition.Conditional)
         assert isinstance(op2.then_op, qml.RY)
         assert op1.then_op.data == [r]
 
-        assert ops[2].return_type == qml.operation.Probability
+        assert len(tape.measurements) == 1
+        assert tape.measurements[0] is terminal_measurement

--- a/tests/transforms/test_defer_measurements.py
+++ b/tests/transforms/test_defer_measurements.py
@@ -648,7 +648,6 @@ class TestConditionalOperations:
         assert np.allclose(qml.matrix(normal_circuit)(x, y), qml.matrix(cond_qnode)(x, y))
 
 
-
 class TestTemplates:
     """Tests templates being conditioned on mid-circuit measurement outcomes."""
 

--- a/tests/transforms/test_defer_measurements.py
+++ b/tests/transforms/test_defer_measurements.py
@@ -611,7 +611,7 @@ class TestConditionalOperations:
     def test_cond_qfunc_with_else(self, device):
         """Test that a qfunc can also used with qml.cond even when an else
         qfunc is provided."""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device(device, wires=2)
 
         x = 0.3
         y = 3.123
@@ -645,6 +645,8 @@ class TestConditionalOperations:
             return qml.probs(wires=[0])
 
         assert np.allclose(normal_circuit(x, y), cond_qnode(x, y))
+        assert np.allclose(qml.matrix(normal_circuit)(x, y), qml.matrix(cond_qnode)(x, y))
+
 
 
 class TestTemplates:

--- a/tests/transforms/test_defer_measurements.py
+++ b/tests/transforms/test_defer_measurements.py
@@ -677,6 +677,16 @@ class TestTemplates:
 
         assert np.allclose(qnode1(), qnode2())
 
+        # Check the operations
+        for op1, op2 in zip(qnode1.qtape.operations, qnode2.qtape.operations):
+            assert type(op1) == type(op2)
+            assert np.allclose(op1.data, op2.data)
+
+        # Check the measurements
+        for op1, op2 in zip(qnode1.qtape.measurements, qnode2.qtape.measurements):
+            assert type(op1) == type(op2)
+            assert np.allclose(op1.data, op2.data)
+
     def test_angle_embedding(self):
         """Test the angle embedding template conditioned on mid-circuit
         measurement outcomes."""
@@ -705,6 +715,16 @@ class TestTemplates:
 
         assert np.allclose(res1, res2)
 
+        # Check the operations
+        for op1, op2 in zip(qnode1.qtape.operations, qnode2.qtape.operations):
+            assert type(op1) == type(op2)
+            assert np.allclose(op1.data, op2.data)
+
+        # Check the measurements
+        for op1, op2 in zip(qnode1.qtape.measurements, qnode2.qtape.measurements):
+            assert type(op1) == type(op2)
+            assert np.allclose(op1.data, op2.data)
+
     @pytest.mark.parametrize("template", [qml.StronglyEntanglingLayers, qml.BasicEntanglerLayers])
     def test_layers(self, template):
         """Test layers conditioned on mid-circuit measurement outcomes."""
@@ -730,6 +750,16 @@ class TestTemplates:
         weights = np.random.random(size=shape)
 
         assert np.allclose(qnode1(weights), qnode2(weights))
+
+        # Check the operations
+        for op1, op2 in zip(qnode1.qtape.operations, qnode2.qtape.operations):
+            assert type(op1) == type(op2)
+            assert np.allclose(op1.data, op2.data)
+
+        # Check the measurements
+        for op1, op2 in zip(qnode1.qtape.measurements, qnode2.qtape.measurements):
+            assert type(op1) == type(op2)
+            assert np.allclose(op1.data, op2.data)
 
 
 class TestDrawing:

--- a/tests/transforms/test_defer_measurements.py
+++ b/tests/transforms/test_defer_measurements.py
@@ -148,14 +148,28 @@ class TestQNode:
         with pytest.raises(ValueError, match="Cannot apply operations"):
             qnode()
 
-    def test_cv_error(self):
+    def test_cv_op_error(self):
         """Test that CV operations are not supported."""
         dev = qml.device("default.gaussian", wires=3)
 
         @qml.qnode(dev)
         @qml.defer_measurements
         def qnode():
-            qml.X(0)
+            qml.Rotation(0.123, wires=[0])
+            return qml.expval(qml.NumberOperator(1))
+
+        with pytest.raises(
+            ValueError, match="Continuous variable operations and observables are not supported"
+        ):
+            qnode()
+
+    def test_cv_obs_error(self):
+        """Test that CV observables are not supported."""
+        dev = qml.device("default.gaussian", wires=3)
+
+        @qml.qnode(dev)
+        @qml.defer_measurements
+        def qnode():
             return qml.expval(qml.NumberOperator(1))
 
         with pytest.raises(


### PR DESCRIPTION
**Context:**
The conditional measurement added gates that were not defined.

**Description of the Change:**
Following the @antalszava 's suggestion I just changed `tape.queue` for `tape.operations + tape.measurements`. The issue originally was that `tape.queue` contains the underlying annotated queue that doesn't describe the circuit itself. Instead, a circuit would have to be iterated using `tape.operations + tape.measurements`.

**Related GitHub Issues:**
[(#2327)](https://github.com/PennyLaneAI/pennylane/issues/2327)
