### PR TITLE
Move the `ObservableReturnTypes` to `measurements`

### DIFF
--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -28,13 +28,9 @@ import pennylane as qml
 from pennylane.operation import (
     Operation,
     Observable,
-    Sample,
-    State,
-    Variance,
-    Expectation,
-    Probability,
     Tensor,
 )
+from pennylane.measurements import Sample, State, Variance, Expectation, Probability
 from pennylane.wires import Wires, WireError
 
 
@@ -880,7 +876,7 @@ class Device(abc.ABC):
 
             if getattr(
                 o, "return_type", None
-            ) == qml.operation.MidMeasure and not self.capabilities().get(
+            ) == qml.measurements.MidMeasure and not self.capabilities().get(
                 "supports_mid_measure", False
             ):
                 raise DeviceError(

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -26,14 +26,8 @@ import warnings
 import numpy as np
 
 import pennylane as qml
-from pennylane.operation import (
-    Sample,
-    Variance,
-    Expectation,
-    Probability,
-    State,
-    operation_derivative,
-)
+from pennylane.operation import operation_derivative
+from pennylane.measurements import Sample, Variance, Expectation, Probability, State
 from pennylane import Device
 from pennylane.math import sum as qmlsum
 from pennylane.wires import Wires

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -889,7 +889,7 @@ class QubitDevice(Device):
         dot_product_real = lambda b, k: self._real(qmlsum(self._conj(b) * k, axis=sum_axes))
 
         for m in tape.measurements:
-            if m.return_type is not qml.operation.Expectation:
+            if m.return_type is not qml.measurements.Expectation:
                 raise qml.QuantumFunctionError(
                     "Adjoint differentiation method does not support"
                     f" measurement {m.return_type.value}"

--- a/pennylane/circuit_graph.py
+++ b/pennylane/circuit_graph.py
@@ -147,15 +147,15 @@ class CircuitGraph:
             op.queue_idx = k  # store the queue index in the Operator
 
             if hasattr(op, "return_type"):
-                if op.return_type is qml.operation.State:
+                if op.return_type is qml.measurements.State:
                     # State measurements contain no wires by default, but wires are
                     # required for the circuit drawer, so we recreate the state
                     # measurement with all wires
-                    op = qml.measurements.MeasurementProcess(qml.operation.State, wires=wires)
+                    op = qml.measurements.MeasurementProcess(qml.measurements.State, wires=wires)
 
-                elif op.return_type is qml.operation.Sample and op.wires == Wires([]):
+                elif op.return_type is qml.measurements.Sample and op.wires == Wires([]):
                     # Sampling without specifying wires is treated as sampling all wires
-                    op = qml.measurements.MeasurementProcess(qml.operation.Sample, wires=wires)
+                    op = qml.measurements.MeasurementProcess(qml.measurements.Sample, wires=wires)
 
                 op.queue_idx = k
 

--- a/pennylane/drawer/representation_resolver.py
+++ b/pennylane/drawer/representation_resolver.py
@@ -474,23 +474,23 @@ class RepresentationResolver:
             str: String representation of the Observable
         """
         # pylint: disable=inconsistent-return-statements
-        if obs.return_type == qml.operation.Expectation:
+        if obs.return_type == qml.measurements.Expectation:
             return (
                 self.charset.LANGLE
                 + f"{self.operator_representation(obs, wire)}"
                 + self.charset.RANGLE
             )
 
-        if obs.return_type == qml.operation.Variance:
+        if obs.return_type == qml.measurements.Variance:
             return f"Var[{self.operator_representation(obs, wire)}]"
 
-        if obs.return_type == qml.operation.Sample:
+        if obs.return_type == qml.measurements.Sample:
             return f"Sample[{self.operator_representation(obs, wire)}]"
 
-        if obs.return_type == qml.operation.Probability:
+        if obs.return_type == qml.measurements.Probability:
             return "Probs"
 
-        if obs.return_type == qml.operation.State:
+        if obs.return_type == qml.measurements.State:
             return "State"
 
         # Unknown return_type

--- a/pennylane/drawer/tape_text.py
+++ b/pennylane/drawer/tape_text.py
@@ -16,7 +16,7 @@ This module contains logic for the text based circuit drawer through the ``tape_
 """
 
 import pennylane as qml
-from pennylane.operation import Expectation, Probability, Sample, Variance, State
+from pennylane.measurements import Expectation, Probability, Sample, Variance, State
 
 from .drawable_layers import drawable_layers
 from .utils import convert_wire_order

--- a/pennylane/fourier/qnode_spectrum.py
+++ b/pennylane/fourier/qnode_spectrum.py
@@ -394,7 +394,7 @@ def qnode_spectrum(qnode, encoding_args=None, argnum=None, decimals=8, validatio
         # After construction, check whether invalid operations (for a spectrum)
         # are present in the QNode
         for m in qnode.qtape.measurements:
-            if m.return_type not in {qml.operation.Expectation, qml.operation.Probability}:
+            if m.return_type not in {qml.measurements.Expectation, qml.measurements.Probability}:
                 raise ValueError(
                     f"The return_type {m.return_type.value} is not supported as it likely does "
                     "not admit a Fourier spectrum."

--- a/pennylane/gradients/gradient_transform.py
+++ b/pennylane/gradients/gradient_transform.py
@@ -214,7 +214,7 @@ class gradient_transform(qml.batch_transform):
 
             qjac = _wrapper(*args, **kwargs)
 
-            if any(m.return_type is qml.operation.Probability for m in qnode.qtape.measurements):
+            if any(m.return_type is qml.measurements.Probability for m in qnode.qtape.measurements):
                 qjac = qml.math.safe_squeeze(qjac, exclude_axis=-1)
 
             if not hybrid:

--- a/pennylane/gradients/hessian_transform.py
+++ b/pennylane/gradients/hessian_transform.py
@@ -124,7 +124,7 @@ class hessian_transform(qml.batch_transform):
 
             qhess = _wrapper(*args, **kwargs)
 
-            if any(m.return_type is qml.operation.Probability for m in qnode.qtape.measurements):
+            if any(m.return_type is qml.measurements.Probability for m in qnode.qtape.measurements):
                 qhess = qml.math.squeeze(qhess)
 
             if not hybrid:

--- a/pennylane/gradients/param_shift_hessian.py
+++ b/pennylane/gradients/param_shift_hessian.py
@@ -293,13 +293,13 @@ def param_shift_hessian(tape, f0=None):
     """
 
     # Perform input validation before generating tapes.
-    if any(m.return_type is qml.operation.State for m in tape.measurements):
+    if any(m.return_type is qml.measurements.State for m in tape.measurements):
         raise ValueError(
             "Computing the Hessian of circuits that return the state is not supported."
         )
 
     # The parameter-shift Hessian implementation currently doesn't support variance measurements.
-    if any(m.return_type is qml.operation.Variance for m in tape.measurements):
+    if any(m.return_type is qml.measurements.Variance for m in tape.measurements):
         raise ValueError(
             "Computing the Hessian of circuits that return variances is currently not supported."
         )

--- a/pennylane/gradients/parameter_shift.py
+++ b/pennylane/gradients/parameter_shift.py
@@ -306,7 +306,7 @@ def var_param_shift(tape, argnum, shifts=None, gradient_recipes=None, f0=None):
     argnum = argnum or tape.trainable_params
 
     # Determine the locations of any variance measurements in the measurement queue.
-    var_mask = [m.return_type is qml.operation.Variance for m in tape.measurements]
+    var_mask = [m.return_type is qml.measurements.Variance for m in tape.measurements]
     var_idx = np.where(var_mask)[0]
 
     # Get <A>, the expectation value of the tape with unshifted parameters.
@@ -316,7 +316,7 @@ def var_param_shift(tape, argnum, shifts=None, gradient_recipes=None, f0=None):
     for i in var_idx:
         obs = expval_tape._measurements[i].obs
         expval_tape._measurements[i] = qml.measurements.MeasurementProcess(
-            qml.operation.Expectation, obs=obs
+            qml.measurements.Expectation, obs=obs
         )
 
     gradient_tapes = [expval_tape]
@@ -356,7 +356,7 @@ def var_param_shift(tape, argnum, shifts=None, gradient_recipes=None, f0=None):
             # involutory observables A in the queue with A^2.
             obs = _square_observable(expval_sq_tape._measurements[i].obs)
             expval_sq_tape._measurements[i] = qml.measurements.MeasurementProcess(
-                qml.operation.Expectation, obs=obs
+                qml.measurements.Expectation, obs=obs
             )
 
         # Non-involutory observables are present; the partial derivative of <A^2>
@@ -600,7 +600,7 @@ def param_shift(
          [ 0.69916862  0.34072424  0.69202359]]
     """
 
-    if any(m.return_type is qml.operation.State for m in tape.measurements):
+    if any(m.return_type is qml.measurements.State for m in tape.measurements):
         raise ValueError(
             "Computing the gradient of circuits that return the state is not supported."
         )
@@ -643,7 +643,7 @@ def param_shift(
     if gradient_recipes is None:
         gradient_recipes = [None] * len(argnum)
 
-    if any(m.return_type is qml.operation.Variance for m in tape.measurements):
+    if any(m.return_type is qml.measurements.Variance for m in tape.measurements):
         g_tapes, fn = var_param_shift(tape, argnum, shifts, gradient_recipes, f0)
     else:
         g_tapes, fn = expval_param_shift(tape, argnum, shifts, gradient_recipes, f0)

--- a/pennylane/gradients/parameter_shift.py
+++ b/pennylane/gradients/parameter_shift.py
@@ -188,7 +188,7 @@ def expval_param_shift(tape, argnum=None, shifts=None, gradient_recipes=None, f0
 
         if op.name == "Hamiltonian":
             # operation is a Hamiltonian
-            if op.return_type is not qml.operation.Expectation:
+            if op.return_type is not qml.measurements.Expectation:
                 raise ValueError(
                     "Can only differentiate Hamiltonian "
                     f"coefficients for expectations, not {op.return_type.value}"

--- a/pennylane/interfaces/batch/tensorflow_autograph.py
+++ b/pennylane/interfaces/batch/tensorflow_autograph.py
@@ -72,7 +72,7 @@ def execute(tapes, device, execute_fn, gradient_fn, gradient_kwargs, _n=1, max_d
 
         if tape.all_sampled:
             output_types.append(tf.int64)
-        elif tape.measurements[0].return_type is qml.operation.State:
+        elif tape.measurements[0].return_type is qml.measurements.State:
             output_types.append(tf.complex128)
         else:
             output_types.append(tf.float64)

--- a/pennylane/interfaces/jax.py
+++ b/pennylane/interfaces/jax.py
@@ -20,7 +20,7 @@ import jax
 from jax.experimental import host_callback
 import jax.numpy as jnp
 from pennylane.queuing import AnnotatedQueue
-from pennylane.operation import Variance, Expectation
+from pennylane.measurements import Variance, Expectation
 
 
 class JAXInterface(AnnotatedQueue):

--- a/pennylane/measurements.py
+++ b/pennylane/measurements.py
@@ -20,21 +20,56 @@ and measurement samples using AnnotatedQueues.
 import copy
 import uuid
 import warnings
+from enum import Enum
 from typing import Generic, TypeVar
 
 import numpy as np
 
 import pennylane as qml
-from pennylane.operation import (
-    Expectation,
-    MidMeasure,
-    Observable,
-    Probability,
-    Sample,
-    State,
-    Variance,
-)
+from pennylane.operation import Observable
 from pennylane.wires import Wires
+
+# =============================================================================
+# ObservableReturnTypes types
+# =============================================================================
+
+
+class ObservableReturnTypes(Enum):
+    """Enumeration class to represent the return types of an observable."""
+
+    Sample = "sample"
+    Variance = "var"
+    Expectation = "expval"
+    Probability = "probs"
+    State = "state"
+    MidMeasure = "measure"
+
+    def __repr__(self):
+        """String representation of the return types."""
+        return str(self.value)
+
+
+Sample = ObservableReturnTypes.Sample
+"""Enum: An enumeration which represents sampling an observable."""
+
+Variance = ObservableReturnTypes.Variance
+"""Enum: An enumeration which represents returning the variance of
+an observable on specified wires."""
+
+Expectation = ObservableReturnTypes.Expectation
+"""Enum: An enumeration which represents returning the expectation
+value of an observable on specified wires."""
+
+Probability = ObservableReturnTypes.Probability
+"""Enum: An enumeration which represents returning probabilities
+of all computational basis states."""
+
+State = ObservableReturnTypes.State
+"""Enum: An enumeration which represents returning the state in the computational basis."""
+
+MidMeasure = ObservableReturnTypes.MidMeasure
+"""Enum: An enumeration which represents returning sampling the computational
+basis in the middle of the circuit."""
 
 
 class MeasurementProcess:

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -1481,7 +1481,7 @@ class Observable(Operator):
         if self.return_type is None:
             return temp
 
-        if self.return_type is Probability:
+        if self.return_type is qml.measurements.Probability:
             return repr(self.return_type) + f"(wires={self.wires.tolist()})"
 
         return repr(self.return_type) + "(" + temp + ")"
@@ -1685,7 +1685,7 @@ class Tensor(Observable):
         if self.return_type is None:
             return s
 
-        if self.return_type is Probability:
+        if self.return_type is qml.measurements.Probability:
             return repr(self.return_type) + f"(wires={self.wires.tolist()})"
 
         return repr(self.return_type) + "(" + s + ")"

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -275,48 +275,6 @@ subsystem. It is equivalent to an integer with value -1."""
 
 
 # =============================================================================
-# ObservableReturnTypes types
-# =============================================================================
-
-
-class ObservableReturnTypes(Enum):
-    """Enumeration class to represent the return types of an observable."""
-
-    Sample = "sample"
-    Variance = "var"
-    Expectation = "expval"
-    Probability = "probs"
-    State = "state"
-    MidMeasure = "measure"
-
-    def __repr__(self):
-        """String representation of the return types."""
-        return str(self.value)
-
-
-Sample = ObservableReturnTypes.Sample
-"""Enum: An enumeration which represents sampling an observable."""
-
-Variance = ObservableReturnTypes.Variance
-"""Enum: An enumeration which represents returning the variance of
-an observable on specified wires."""
-
-Expectation = ObservableReturnTypes.Expectation
-"""Enum: An enumeration which represents returning the expectation
-value of an observable on specified wires."""
-
-Probability = ObservableReturnTypes.Probability
-"""Enum: An enumeration which represents returning probabilities
-of all computational basis states."""
-
-State = ObservableReturnTypes.State
-"""Enum: An enumeration which represents returning the state in the computational basis."""
-
-MidMeasure = ObservableReturnTypes.MidMeasure
-"""Enum: An enumeration which represents returning sampling the computational
-basis in the middle of the circuit."""
-
-# =============================================================================
 # Class property
 # =============================================================================
 

--- a/pennylane/qnode.py
+++ b/pennylane/qnode.py
@@ -504,7 +504,7 @@ class QNode:
             )
 
         terminal_measurements = [
-            m for m in self.tape.measurements if m.return_type != qml.operation.MidMeasure
+            m for m in self.tape.measurements if m.return_type != qml.measurements.MidMeasure
         ]
         if not all(ret == m for ret, m in zip(measurement_processes, terminal_measurements)):
             raise qml.QuantumFunctionError(
@@ -532,7 +532,7 @@ class QNode:
         # 2. Move this expansion to Device (e.g., default_expand_fn or
         # batch_transform method)
         if any(
-            getattr(obs, "return_type", None) == qml.operation.MidMeasure
+            getattr(obs, "return_type", None) == qml.measurements.MidMeasure
             for obs in self.tape.operations
         ):
             self._tape = qml.defer_measurements(self._tape)

--- a/pennylane/qnode_old.py
+++ b/pennylane/qnode_old.py
@@ -26,7 +26,7 @@ import numpy as np
 import pennylane as qml
 from pennylane import Device
 
-from pennylane.operation import State
+from pennylane.measurements import State
 
 from pennylane.interfaces.autograd import AutogradInterface, np as anp
 from pennylane.tape import (

--- a/pennylane/tape/cv_param_shift.py
+++ b/pennylane/tape/cv_param_shift.py
@@ -123,7 +123,7 @@ class CVParamShiftTape(QubitParamShiftTape):
 
         for m in self.measurements:
 
-            if (m.return_type is qml.operation.Probability) or (m.obs.ev_order not in (1, 2)):
+            if (m.return_type is qml.measurements.Probability) or (m.obs.ev_order not in (1, 2)):
                 # Higher-order observables (including probability) only support finite differences.
                 best.append("F")
                 continue
@@ -148,12 +148,12 @@ class CVParamShiftTape(QubitParamShiftTape):
 
             elif m.obs.ev_order == 2:
 
-                if m.return_type is qml.operation.Expectation:
+                if m.return_type is qml.measurements.Expectation:
                     # If the observable is second order, we must use the second order
                     # CV parameter shift rule
                     best_method = "A2"
 
-                elif m.return_type is qml.operation.Variance:
+                elif m.return_type is qml.measurements.Variance:
                     # we only support analytic variance gradients for
                     # first order observables
                     best_method = "F"
@@ -348,7 +348,7 @@ class CVParamShiftTape(QubitParamShiftTape):
             idx = self.observables.index(obs)
             transformed_obs_idx.append(idx)
             tape._measurements[idx] = MeasurementProcess(
-                qml.operation.Expectation, self._transform_observable(obs, Z, dev_wires)
+                qml.measurements.Expectation, self._transform_observable(obs, Z, dev_wires)
             )
 
         tapes = [tape]
@@ -474,7 +474,7 @@ class CVParamShiftTape(QubitParamShiftTape):
         # Temporarily convert all variance measurements on the tape into expectation values
         for i in self.var_idx:
             obs = evA_tape._measurements[i].obs
-            evA_tape._measurements[i] = MeasurementProcess(qml.operation.Expectation, obs=obs)
+            evA_tape._measurements[i] = MeasurementProcess(qml.measurements.Expectation, obs=obs)
 
         # evaluate the analytic derivative of <A>
         pdA_tapes, pdA_fn = evA_tape.parameter_shift_first_order(idx, params, **options)
@@ -497,7 +497,7 @@ class CVParamShiftTape(QubitParamShiftTape):
             # with itself, to get a square symmetric matrix representing
             # the square of the observable
             obs = qml.PolyXP(np.outer(A, A), wires=obs.wires, do_queue=False)
-            pdA2_tape._measurements[i] = MeasurementProcess(qml.operation.Expectation, obs=obs)
+            pdA2_tape._measurements[i] = MeasurementProcess(qml.measurements.Expectation, obs=obs)
 
         # Here, we calculate the analytic derivatives of the <A^2> observables.
         pdA2_tapes, pdA2_fn = pdA2_tape.parameter_shift_second_order(idx, params, **options)

--- a/pennylane/tape/jacobian_tape.py
+++ b/pennylane/tape/jacobian_tape.py
@@ -23,7 +23,7 @@ import warnings
 import numpy as np
 
 import pennylane as qml
-from pennylane.operation import State
+from pennylane.measurements import State
 from pennylane.tape import QuantumTape
 
 # CV ops still need to support state preparation operations prior to any

--- a/pennylane/tape/qubit_param_shift.py
+++ b/pennylane/tape/qubit_param_shift.py
@@ -145,7 +145,7 @@ class QubitParamShiftTape(JacobianTape):
         self.analytic_pd = self.parameter_shift
 
         # check if the quantum tape contains any variance measurements
-        self.var_mask = [m.return_type is qml.operation.Variance for m in self.measurements]
+        self.var_mask = [m.return_type is qml.measurements.Variance for m in self.measurements]
 
         # Make a copy of the original measurements; we will be mutating them
         # during the parameter shift method.
@@ -263,7 +263,7 @@ class QubitParamShiftTape(JacobianTape):
         # Convert all variance measurements on the tape into expectation values
         for i in self.var_idx:
             obs = evA_tape._measurements[i].obs
-            evA_tape._measurements[i] = MeasurementProcess(qml.operation.Expectation, obs=obs)
+            evA_tape._measurements[i] = MeasurementProcess(qml.measurements.Expectation, obs=obs)
 
         # evaluate the analytic derivative of <A>
         pdA_tapes, pdA_fn = evA_tape.parameter_shift(idx, params, **options)
@@ -286,7 +286,7 @@ class QubitParamShiftTape(JacobianTape):
                 A = obs.get_matrix()
 
                 obs = qml.Hermitian(A @ A, wires=obs.wires, do_queue=False)
-                pdA2_tape._measurements[i] = MeasurementProcess(qml.operation.Expectation, obs=obs)
+                pdA2_tape._measurements[i] = MeasurementProcess(qml.measurements.Expectation, obs=obs)
 
             # Non-involutory observables are present; the partial derivative of <A^2>
             # may be non-zero. Here, we calculate the analytic derivatives of the <A^2>
@@ -472,7 +472,7 @@ class QubitParamShiftTape(JacobianTape):
 
         info = super().specs
 
-        if any(m.return_type is qml.operation.State for m in self.measurements):
+        if any(m.return_type is qml.measurements.State for m in self.measurements):
             return info
 
         if len(self._par_info) > 0:

--- a/pennylane/tape/reversible.py
+++ b/pennylane/tape/reversible.py
@@ -141,8 +141,8 @@ class ReversibleTape(JacobianTape):
         # expectation values of observables for now.
         for m in self.measurements:
             if (
-                m.return_type is qml.operation.Variance
-                or m.return_type is qml.operation.Probability
+                m.return_type is qml.measurements.Variance
+                or m.return_type is qml.measurements.Probability
             ):
                 raise ValueError(
                     f"{m.return_type} is not supported with the reversible gradient method"

--- a/pennylane/tape/tape.py
+++ b/pennylane/tape/tape.py
@@ -24,7 +24,8 @@ import numpy as np
 
 import pennylane as qml
 from pennylane.queuing import AnnotatedQueue, QueuingContext, QueuingError
-from pennylane.operation import DecompositionUndefinedError, Sample
+from pennylane.operation import DecompositionUndefinedError
+from pennylane.measurements import Sample
 
 from .unwrap import UnwrapTape
 
@@ -436,7 +437,7 @@ class QuantumTape(AnnotatedQueue):
 
             elif isinstance(obj, qml.measurements.MeasurementProcess):
 
-                if obj.return_type == qml.operation.MidMeasure:
+                if obj.return_type == qml.measurements.MidMeasure:
 
                     # TODO: for now, consider mid-circuit measurements as tape
                     # operations such that the order of the operators in the
@@ -449,15 +450,15 @@ class QuantumTape(AnnotatedQueue):
                     self._measurements.append(obj)
 
                     # attempt to infer the output dimension
-                    if obj.return_type is qml.operation.Probability:
+                    if obj.return_type is qml.measurements.Probability:
                         self._output_dim += 2 ** len(obj.wires)
-                    elif obj.return_type is qml.operation.State:
+                    elif obj.return_type is qml.measurements.State:
                         continue  # the output_dim is worked out automatically
                     else:
                         self._output_dim += 1
 
                     # check if any sampling is occuring
-                    if obj.return_type is qml.operation.Sample:
+                    if obj.return_type is qml.measurements.Sample:
                         self.is_sampled = True
 
         self._update()

--- a/pennylane/transforms/defer_measurements.py
+++ b/pennylane/transforms/defer_measurements.py
@@ -99,7 +99,7 @@ def defer_measurements(tape):
 
         if (
             isinstance(op, qml.measurements.MeasurementProcess)
-            and op.return_type == qml.operation.MidMeasure
+            and op.return_type == qml.measurements.MidMeasure
         ):
             measured_wires[op.id] = op.wires[0]
 

--- a/pennylane/transforms/qcut.py
+++ b/pennylane/transforms/qcut.py
@@ -30,8 +30,8 @@ from networkx import MultiDiGraph, weakly_connected_components, has_path
 import pennylane as qml
 from pennylane import apply, expval
 from pennylane.grouping import string_to_pauli_word
-from pennylane.measurements import MeasurementProcess
-from pennylane.operation import Expectation, Operation, Operator, Tensor
+from pennylane.measurements import MeasurementProcess, Expectation
+from pennylane.operation import Operation, Operator, Tensor
 from pennylane.ops.qubit.non_parametric_ops import WireCut
 from pennylane.tape import QuantumTape
 from pennylane.wires import Wires

--- a/tests/collections/test_collections.py
+++ b/tests/collections/test_collections.py
@@ -151,13 +151,13 @@ class TestMap:
         assert len(queue) == 2
         assert queue[0].name == "RX"
         assert queue[1].name == "PauliX"
-        assert queue[1].return_type == qml.operation.Expectation
+        assert queue[1].return_type == qml.measurements.Expectation
 
         queue = qc[1].qtape.operations + qc[1].qtape.observables
         assert len(queue) == 2
         assert queue[0].name == "RX"
         assert queue[1].name == "PauliY"
-        assert queue[1].return_type == qml.operation.Variance
+        assert queue[1].return_type == qml.measurements.Variance
 
     def test_invalid_observable(self):
         """Test that an invalid observable raises an exception"""

--- a/tests/tape/test_tape.py
+++ b/tests/tape/test_tape.py
@@ -88,22 +88,22 @@ class TestConstruction:
 
         # test that the internal tape._measurements list is created properly
         assert isinstance(tape._measurements[0], MeasurementProcess)
-        assert tape._measurements[0].return_type == qml.operation.Expectation
+        assert tape._measurements[0].return_type == qml.measurements.Expectation
         assert tape._measurements[0].obs == obs[0]
 
         assert isinstance(tape._measurements[1], MeasurementProcess)
-        assert tape._measurements[1].return_type == qml.operation.Probability
+        assert tape._measurements[1].return_type == qml.measurements.Probability
 
         # test the public observables property
         assert len(tape.observables) == 2
         assert tape.observables[0].name == "PauliX"
-        assert tape.observables[1].return_type == qml.operation.Probability
+        assert tape.observables[1].return_type == qml.measurements.Probability
 
         # test the public measurements property
         assert len(tape.measurements) == 2
         assert all(isinstance(m, MeasurementProcess) for m in tape.measurements)
-        assert tape.observables[0].return_type == qml.operation.Expectation
-        assert tape.observables[1].return_type == qml.operation.Probability
+        assert tape.observables[0].return_type == qml.measurements.Expectation
+        assert tape.observables[1].return_type == qml.measurements.Probability
 
     def test_tensor_observables_matmul(self):
         """Test that tensor observables are correctly processed from the annotated
@@ -117,7 +117,7 @@ class TestConstruction:
 
         assert tape.operations == [op]
         assert tape.observables == [t_obs2]
-        assert tape.measurements[0].return_type is qml.operation.Expectation
+        assert tape.measurements[0].return_type is qml.measurements.Expectation
         assert tape.measurements[0].obs is t_obs2
 
     def test_tensor_observables_rmatmul(self):
@@ -133,7 +133,7 @@ class TestConstruction:
 
         assert tape.operations == [op]
         assert tape.observables == [t_obs2]
-        assert tape.measurements[0].return_type is qml.operation.Expectation
+        assert tape.measurements[0].return_type is qml.measurements.Expectation
         assert tape.measurements[0].obs is t_obs2
 
     def test_tensor_observables_tensor_init(self):
@@ -149,7 +149,7 @@ class TestConstruction:
 
         assert tape.operations == [op]
         assert tape.observables == [t_obs2]
-        assert tape.measurements[0].return_type is qml.operation.Expectation
+        assert tape.measurements[0].return_type is qml.measurements.Expectation
         assert tape.measurements[0].obs is t_obs2
 
     def test_tensor_observables_tensor_matmul(self):
@@ -166,7 +166,7 @@ class TestConstruction:
 
         assert tape.operations == [op]
         assert tape.observables == [t_obs]
-        assert tape.measurements[0].return_type is qml.operation.Variance
+        assert tape.measurements[0].return_type is qml.measurements.Variance
         assert tape.measurements[0].obs is t_obs
 
     def test_qubit_diagonalization(self, make_tape):
@@ -862,7 +862,7 @@ class TestExpand:
 
         assert len(new_tape.operations) == 5
 
-        expected = [qml.operation.Probability, qml.operation.Expectation, qml.operation.Variance]
+        expected = [qml.measurements.Probability, qml.measurements.Expectation, qml.measurements.Variance]
         assert [m.return_type is r for m, r in zip(new_tape.measurements, expected)]
 
         expected = [None, None, None]

--- a/tests/test_qubit_device.py
+++ b/tests/test_qubit_device.py
@@ -21,7 +21,7 @@ from random import random
 import pennylane as qml
 from pennylane import numpy as pnp
 from pennylane import QubitDevice, DeviceError, QuantumFunctionError
-from pennylane.operation import Sample, Variance, Expectation, Probability, State
+from pennylane.measurements import Sample, Variance, Expectation, Probability, State
 from pennylane.circuit_graph import CircuitGraph
 from pennylane.wires import Wires
 from pennylane.tape import QuantumTape

--- a/tests/transforms/test_condition.py
+++ b/tests/transforms/test_condition.py
@@ -52,7 +52,7 @@ class TestCond:
         target_wire = qml.wires.Wires(1)
 
         assert len(ops) == 5
-        assert ops[0].return_type == qml.operation.MidMeasure
+        assert ops[0].return_type == qml.measurements.MidMeasure
 
         assert isinstance(ops[1], qml.transforms.condition.Conditional)
         assert isinstance(ops[1].then_op, qml.PauliX)
@@ -67,7 +67,7 @@ class TestCond:
         assert isinstance(ops[3].then_op, qml.PauliZ)
         assert ops[3].then_op.wires == target_wire
 
-        assert ops[4].return_type == qml.operation.Probability
+        assert ops[4].return_type == qml.measurements.Probability
 
     def test_cond_queues_with_else(self):
         """Test that qml.cond queues Conditional operations as expected when an
@@ -92,7 +92,7 @@ class TestCond:
 
         assert len(ops) == 6
 
-        assert ops[0].return_type == qml.operation.MidMeasure
+        assert ops[0].return_type == qml.measurements.MidMeasure
 
         assert isinstance(ops[1], qml.transforms.condition.Conditional)
         assert isinstance(ops[1].then_op, qml.PauliX)
@@ -111,7 +111,7 @@ class TestCond:
         assert isinstance(ops[4].then_op, qml.PauliY)
         assert ops[4].then_op.wires == target_wire
 
-        assert ops[5].return_type == qml.operation.Probability
+        assert ops[5].return_type == qml.measurements.Probability
 
     def test_cond_error(self):
         """Test that an error is raised when the qfunc has a measurement."""
@@ -179,7 +179,7 @@ class TestOtherTransforms:
         target_wire = qml.wires.Wires(1)
 
         assert len(ops) == 4
-        assert ops[0].return_type == qml.operation.MidMeasure
+        assert ops[0].return_type == qml.measurements.MidMeasure
 
         assert isinstance(ops[1], qml.transforms.condition.Conditional)
         assert isinstance(ops[1].then_op, qml.RX)
@@ -191,7 +191,7 @@ class TestOtherTransforms:
         assert ops[2].then_op.data == [r]
         assert ops[2].then_op.wires == target_wire
 
-        assert ops[3].return_type == qml.operation.Probability
+        assert ops[3].return_type == qml.measurements.Probability
 
     def test_cond_queues_with_ctrl(self):
         """Test that qml.cond queues Conditional operations as expected with
@@ -207,7 +207,7 @@ class TestOtherTransforms:
         target_wire = qml.wires.Wires(2)
 
         assert len(ops) == 4
-        assert ops[0].return_type == qml.operation.MidMeasure
+        assert ops[0].return_type == qml.measurements.MidMeasure
 
         assert isinstance(ops[1], qml.transforms.condition.Conditional)
         assert isinstance(ops[1].then_op, qml.transforms.control.ControlledOperation)
@@ -227,7 +227,7 @@ class TestOtherTransforms:
         assert controlled_op.data == [r]
         assert controlled_op.wires == target_wire
 
-        assert ops[3].return_type == qml.operation.Probability
+        assert ops[3].return_type == qml.measurements.Probability
 
     def test_ctrl_queues_with_cond(self):
         """Test that qml.cond queues Conditional operations as expected with
@@ -243,7 +243,7 @@ class TestOtherTransforms:
         target_wire = qml.wires.Wires(2)
 
         assert len(ops) == 3
-        assert ops[0].return_type == qml.operation.MidMeasure
+        assert ops[0].return_type == qml.measurements.MidMeasure
 
         assert isinstance(ops[1], qml.transforms.control.ControlledOperation)
         assert len(ops[1].subtape.queue) == 2
@@ -258,4 +258,4 @@ class TestOtherTransforms:
         assert isinstance(op2.then_op, qml.RY)
         assert op1.then_op.data == [r]
 
-        assert ops[2].return_type == qml.operation.Probability
+        assert ops[2].return_type == qml.measurements.Probability

--- a/tests/transforms/test_insert_ops.py
+++ b/tests/transforms/test_insert_ops.py
@@ -21,7 +21,7 @@ import pytest
 
 import pennylane as qml
 import pennylane.transforms.insert_ops
-from pennylane.operation import Expectation
+from pennylane.measurements import Expectation
 from pennylane.tape import QuantumTape
 from pennylane.transforms.insert_ops import insert
 


### PR DESCRIPTION
Currently, the `ObservableReturnTypes`:
* `Sample`
* `Variance`
* `Expectation`
* `Probability`
* `State`
* `MidMeasure`

are currently located in the `operation.py` file, even though they indicate information about measurements.

Since they are part of how we denote measurements, they are moved to the `measurements` file.

This creates many places where we have to update the path.  The plugins will probably need to be updated with this change as well.