### PR TITLE
Add testing for cv state prep operations and update documentation

### DIFF
--- a/pennylane/ops/cv.py
+++ b/pennylane/ops/cv.py
@@ -100,7 +100,7 @@ class Rotation(CVOperation):
 
     Args:
         phi (float): the rotation angle
-        wires (Sequence[int] or int): the wire the operation acts on
+        wires (Sequence[Any] or Any): the wire the operation acts on
         do_queue (bool): Indicates whether the operator should be
             immediately pushed into the Operator queue (optional)
         id (str or None): String representing the operation (optional)
@@ -151,7 +151,7 @@ class Squeezing(CVOperation):
     Args:
         r (float): squeezing amount
         phi (float): squeezing phase angle :math:`\phi`
-        wires (Sequence[int] or int): the wire the operation acts on
+        wires (Sequence[Any] or Any): the wire the operation acts on
         do_queue (bool): Indicates whether the operator should be
             immediately pushed into the Operator queue (optional)
         id (str or None): String representing the operation (optional)
@@ -208,7 +208,7 @@ class Displacement(CVOperation):
     Args:
         a (float): displacement magnitude :math:`a=|\alpha|`
         phi (float): phase angle :math:`\phi`
-        wires (Sequence[int] or int): the wire the operation acts on
+        wires (Sequence[Any] or Any): the wire the operation acts on
         do_queue (bool): Indicates whether the operator should be
             immediately pushed into the Operator queue (optional)
         id (str or None): String representing the operation (optional)
@@ -271,7 +271,7 @@ class Beamsplitter(CVOperation):
         phi (float): Phase angle :math:`\phi`. The reflection amplitude of the
             beamsplitter is :math:`r = e^{i\phi}\sin(\theta)`.
             The value :math:`\phi = \pi/2` gives the symmetric beamsplitter.
-        wires (Sequence[int] or int): the wire the operation acts on
+        wires (Sequence[Any]): the wire the operation acts on
         do_queue (bool): Indicates whether the operator should be
             immediately pushed into the Operator queue (optional)
         id (str or None): String representing the operation (optional)
@@ -335,7 +335,7 @@ class TwoModeSqueezing(CVOperation):
     Args:
         r (float): squeezing amount
         phi (float): squeezing phase angle :math:`\phi`
-        wires (Sequence[int] or int): the wire the operation acts on
+        wires (Sequence[Any]): the wire the operation acts on
         do_queue (bool): Indicates whether the operator should be
             immediately pushed into the Operator queue (optional)
         id (str or None): String representing the operation (optional)
@@ -399,7 +399,7 @@ class QuadraticPhase(CVOperation):
 
     Args:
         s (float): parameter
-        wires (Sequence[int] or int): the wire the operation acts on
+        wires (Sequence[Any] or Any): the wire the operation acts on
         do_queue (bool): Indicates whether the operator should be
             immediately pushed into the Operator queue (optional)
         id (str or None): String representing the operation (optional)
@@ -455,7 +455,7 @@ class ControlledAddition(CVOperation):
 
     Args:
         s (float): addition multiplier
-        wires (Sequence[int] or int): the wire the operation acts on
+        wires (Sequence[Any]): the wire the operation acts on
         do_queue (bool): Indicates whether the operator should be
             immediately pushed into the Operator queue (optional)
         id (str or None): String representing the operation (optional)
@@ -514,7 +514,7 @@ class ControlledPhase(CVOperation):
 
     Args:
         s (float):  phase shift multiplier
-        wires (Sequence[int] or int): the wire the operation acts on
+        wires (Sequence[Any]): the wire the operation acts on
         do_queue (bool): Indicates whether the operator should be
             immediately pushed into the Operator queue (optional)
         id (str or None): String representing the operation (optional)
@@ -560,7 +560,7 @@ class Kerr(CVOperation):
 
     Args:
         kappa (float): parameter
-        wires (Sequence[int] or int): the wire the operation acts on
+        wires (Sequence[Any] or Any): the wire the operation acts on
         do_queue (bool): Indicates whether the operator should be
             immediately pushed into the Operator queue (optional)
         id (str or None): String representing the operation (optional)
@@ -591,7 +591,7 @@ class CrossKerr(CVOperation):
 
     Args:
         kappa (float): parameter
-        wires (Sequence[int] or int): the wire the operation acts on
+        wires (Sequence[Any]): the wire the operation acts on
         do_queue (bool): Indicates whether the operator should be
             immediately pushed into the Operator queue (optional)
         id (str or None): String representing the operation (optional)
@@ -622,7 +622,7 @@ class CubicPhase(CVOperation):
 
     Args:
         gamma (float): parameter
-        wires (Sequence[int] or int): the wire the operation acts on
+        wires (Sequence[Any] or Any): the wire the operation acts on
         do_queue (bool): Indicates whether the operator should be
             immediately pushed into the Operator queue (optional)
         id (str or None): String representing the operation (optional)
@@ -673,7 +673,7 @@ class InterferometerUnitary(CVOperation):
 
     Args:
         U (array): A shape ``(len(wires), len(wires))`` complex unitary matrix
-        wires (Sequence[int] or int): the wires the operation acts on
+        wires (Sequence[Any] or Any): the wires the operation acts on
         do_queue (bool): Indicates whether the operator should be
             immediately pushed into the Operator queue (optional)
         id (str or None): String representing the operation (optional)
@@ -729,7 +729,7 @@ class CoherentState(CVOperation):
     Args:
         a (float): displacement magnitude :math:`r=|\alpha|`
         phi (float): phase angle :math:`\phi`
-        wires (Sequence[int] or int): the wire the operation acts on
+        wires (Sequence[Any] or Any): the wire the operation acts on
         do_queue (bool): Indicates whether the operator should be
             immediately pushed into the Operator queue (optional)
         id (str or None): String representing the operation (optional)
@@ -755,7 +755,7 @@ class SqueezedState(CVOperation):
     Args:
         r (float): squeezing magnitude
         phi (float): squeezing angle :math:`\phi`
-        wires (Sequence[int] or int): the wire the operation acts on
+        wires (Sequence[Any] or Any): the wire the operation acts on
         do_queue (bool): Indicates whether the operator should be
             immediately pushed into the Operator queue (optional)
         id (str or None): String representing the operation (optional)
@@ -791,7 +791,7 @@ class DisplacedSqueezedState(CVOperation):
         phi_a (float): displacement angle :math:`\phi_a`
         r (float): squeezing magnitude :math:`r=|z|`
         phi_r (float): squeezing angle :math:`\phi_r`
-        wires (Sequence[int] or int): the wire the operation acts on
+        wires (Sequence[Any] or Any): the wire the operation acts on
         do_queue (bool): Indicates whether the operator should be
             immediately pushed into the Operator queue (optional)
         id (str or None): String representing the operation (optional)
@@ -816,7 +816,7 @@ class ThermalState(CVOperation):
 
     Args:
         nbar (float): mean thermal population of the mode
-        wires (Sequence[int] or int): the wire the operation acts on
+        wires (Sequence[Any] or Any): the wire the operation acts on
         do_queue (bool): Indicates whether the operator should be
             immediately pushed into the Operator queue (optional)
         id (str or None): String representing the operation (optional)
@@ -846,7 +846,7 @@ class GaussianState(CVOperation):
         V (array): the :math:`2N\times 2N` (real and positive definite) covariance matrix
         r (array): a length :math:`2N` vector of means, of the
             form :math:`(\x_0,\dots,\x_{N-1},\p_0,\dots,\p_{N-1})`
-        wires (Sequence[int] or int): the wire the operation acts on
+        wires (Sequence[Any] or Any): the wire the operation acts on
         do_queue (bool): Indicates whether the operator should be
             immediately pushed into the Operator queue (optional)
         id (str or None): String representing the operation (optional)
@@ -874,7 +874,7 @@ class FockState(CVOperation):
 
     Args:
         n (int): Fock state to prepare
-        wires (Sequence[int] or int): the wire the operation acts on
+        wires (Sequence[Any] or Any): the wire the operation acts on
         do_queue (bool): Indicates whether the operator should be
             immediately pushed into the Operator queue (optional)
         id (str or None): String representing the operation (optional)
@@ -926,7 +926,7 @@ class FockStateVector(CVOperation):
     Args:
         state (array): a single ket vector, for single mode state preparation,
             or a multimode ket, with one array dimension per mode
-        wires (Sequence[int] or int): the wire the operation acts on
+        wires (Sequence[Any] or Any): the wire the operation acts on
         do_queue (bool): Indicates whether the operator should be
             immediately pushed into the Operator queue (optional)
         id (str or None): String representing the operation (optional)
@@ -1016,7 +1016,7 @@ class FockDensityMatrix(CVOperation):
     Args:
         state (array): a single mode matrix :math:`\rho_{ij}`, or
             a multimode tensor :math:`\rho_{ij,kl,\dots,mn}`, with two indices per mode
-        wires (Sequence[int] or int): the wire the operation acts on
+        wires (Sequence[Any] or Any): the wire the operation acts on
         do_queue (bool): Indicates whether the operator should be
             immediately pushed into the Operator queue (optional)
         id (str or None): String representing the operation (optional)
@@ -1053,7 +1053,7 @@ class CatState(CVOperation):
         phi (float): displacement angle :math:`\phi`
         p (float): parity, where :math:`p=0` corresponds to an even
             cat state, and :math:`p=1` an odd cat state.
-        wires (Sequence[int] or int): the wire the operation acts on
+        wires (Sequence[Any] or Any): the wire the operation acts on
         do_queue (bool): Indicates whether the operator should be
             immediately pushed into the Operator queue (optional)
         id (str or None): String representing the operation (optional)
@@ -1095,7 +1095,7 @@ class NumberOperator(CVObservable):
         \end{bmatrix}
 
     Args:
-        wires (Sequence[int] or int): the wire the operation acts on
+        wires (Sequence[Any] or Any): the wire the operation acts on
     """
     num_params = 0
     num_wires = 1
@@ -1131,7 +1131,7 @@ class TensorN(CVObservable):
     * Number of parameters: 0
 
     Args:
-        wires (Sequence[int] or int): the wire the operation acts on
+        wires (Sequence[Any] or Any): the wire the operation acts on
 
     .. UsageDetails::
 
@@ -1191,7 +1191,7 @@ class X(CVObservable):
       .. math:: d = [0, 1, 0]
 
     Args:
-        wires (Sequence[int] or int): the wire the operation acts on
+        wires (Sequence[Any] or Any): the wire the operation acts on
     """
     num_params = 0
     num_wires = 1
@@ -1224,7 +1224,7 @@ class P(CVObservable):
       .. math:: d = [0, 0, 1]
 
     Args:
-        wires (Sequence[int] or int): the wire the operation acts on
+        wires (Sequence[Any] or Any): the wire the operation acts on
     """
     num_params = 0
     num_wires = 1
@@ -1259,7 +1259,7 @@ class QuadOperator(CVObservable):
     Args:
         phi (float): axis in the phase space at which to calculate
             the generalized quadrature observable
-        wires (Sequence[int] or int): the wire the operation acts on
+        wires (Sequence[Any] or Any): the wire the operation acts on
         do_queue (bool): Indicates whether the operator should be
             immediately pushed into the Operator queue (optional)
         id (str or None): String representing the operation (optional)
@@ -1338,7 +1338,7 @@ class PolyXP(CVObservable):
 
     Args:
         q (array[float]): expansion coefficients
-        wires (Sequence[int] or int): the wire the operation acts on
+        wires (Sequence[Any] or Any): the wire the operation acts on
         do_queue (bool): Indicates whether the operator should be
             immediately pushed into the Operator queue (optional)
         id (str or None): String representing the operation (optional)
@@ -1399,7 +1399,7 @@ class FockStateProjector(CVObservable):
 
             Note that ``len(n)==len(wires)``, and that ``len(n)`` cannot exceed the
             total number of wires in the QNode.
-        wires (Sequence[int] or int): the wire the operation acts on
+        wires (Sequence[Any] or Any): the wire the operation acts on
         do_queue (bool): Indicates whether the operator should be
             immediately pushed into the Operator queue (optional)
         id (str or None): String representing the operation (optional)

--- a/tests/ops/test_cv_ops.py
+++ b/tests/ops/test_cv_ops.py
@@ -19,8 +19,8 @@ Unit tests for the :mod:`pennylane.plugin.DefaultGaussian` device.
 from scipy.linalg import block_diag
 import pytest
 
-import pennylane
 from pennylane import numpy as np
+from pennylane.operation import AnyWires
 import numpy.testing as np_testing
 from pennylane.ops import cv
 from pennylane.wires import Wires
@@ -212,6 +212,26 @@ class TestNonGaussian:
         with pytest.raises(RuntimeError):
             op.heisenberg_tr(Wires(range(op.num_wires)))
 
+
+state_prep_data = [
+    (cv.CoherentState(0.1, 0.2, wires=0), 2,1, "F"),
+    (cv.SqueezedState(0.1, 0.2, wires=0), 2, 1, "F"),
+    (cv.DisplacedSqueezedState(0.1, 0.2, 0.3, 0.4, wires=0), 4,1,"F"),
+    (cv.ThermalState(0.1, wires=0), 1,1, "F"),
+    (cv.GaussianState(0.1, 0.2, wires=(0,1,2,3,4)), 2, AnyWires, "F"),
+    (cv.FockState(1, wires=0), 1, 1, None),
+    (cv.FockStateVector([0,0,1,0], wires=0), 1, AnyWires, "F"),
+    (cv.FockDensityMatrix(np.eye(2), wires=0), 1, AnyWires, "F"),
+    (cv.CatState(0.1, 0.2, 0.3, wires=0), 3, 1, "F")
+]
+
+@pytest.mark.parametrize("op, num_params, num_wires, grad_method", state_prep_data)
+def test_state_prep_operations(op, num_params, num_wires, grad_method):
+    """Test initialization of state preperation operations."""
+
+    assert op.num_params == num_params
+    assert op.num_wires == num_wires
+    assert op.grad_method == grad_method
 
 label_data = [
     (cv.Rotation(1.2345, wires=0), "R", "R\n(1.23)", "R⁻¹\n(1)"),

--- a/tests/ops/test_cv_ops.py
+++ b/tests/ops/test_cv_ops.py
@@ -214,16 +214,17 @@ class TestNonGaussian:
 
 
 state_prep_data = [
-    (cv.CoherentState(0.1, 0.2, wires=0), 2,1, "F"),
+    (cv.CoherentState(0.1, 0.2, wires=0), 2, 1, "F"),
     (cv.SqueezedState(0.1, 0.2, wires=0), 2, 1, "F"),
-    (cv.DisplacedSqueezedState(0.1, 0.2, 0.3, 0.4, wires=0), 4,1,"F"),
-    (cv.ThermalState(0.1, wires=0), 1,1, "F"),
-    (cv.GaussianState(0.1, 0.2, wires=(0,1,2,3,4)), 2, AnyWires, "F"),
+    (cv.DisplacedSqueezedState(0.1, 0.2, 0.3, 0.4, wires=0), 4, 1, "F"),
+    (cv.ThermalState(0.1, wires=0), 1, 1, "F"),
+    (cv.GaussianState(0.1, 0.2, wires=(0, 1, 2, 3, 4)), 2, AnyWires, "F"),
     (cv.FockState(1, wires=0), 1, 1, None),
-    (cv.FockStateVector([0,0,1,0], wires=0), 1, AnyWires, "F"),
+    (cv.FockStateVector([0, 0, 1, 0], wires=0), 1, AnyWires, "F"),
     (cv.FockDensityMatrix(np.eye(2), wires=0), 1, AnyWires, "F"),
-    (cv.CatState(0.1, 0.2, 0.3, wires=0), 3, 1, "F")
+    (cv.CatState(0.1, 0.2, 0.3, wires=0), 3, 1, "F"),
 ]
+
 
 @pytest.mark.parametrize("op, num_params, num_wires, grad_method", state_prep_data)
 def test_state_prep_operations(op, num_params, num_wires, grad_method):
@@ -232,6 +233,7 @@ def test_state_prep_operations(op, num_params, num_wires, grad_method):
     assert op.num_params == num_params
     assert op.num_wires == num_wires
     assert op.grad_method == grad_method
+
 
 label_data = [
     (cv.Rotation(1.2345, wires=0), "R", "R\n(1.23)", "R⁻¹\n(1)"),


### PR DESCRIPTION
Upon trying to delete the old text circuit drawing infrastructure, I learned that the cv state preparation operations have no individual testing.

This PR adds testing of initialization and class properties.

It also changes the documentation for `wires` type to reflect the fact we support arbitrary wire labels, not just integers.