### PR TITLE
Process `Operators` into `tape._ops`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -28,6 +28,8 @@
 * Circuit cutting now performs expansion to search for wire cuts in contained operations or tapes.
   [(#2340)](https://github.com/PennyLaneAI/pennylane/pull/2340)
 
+* The `QuantumTape` now processes all `Operator` objects into `_ops` list, instead of just `Operation` objects.
+
 <h3>Deprecations</h3>
 
 <h3>Breaking changes</h3>
@@ -63,8 +65,6 @@ the `decimals` and `show_matrices` keywords are added. `qml.drawer.tape_text(tap
 * The deprecated tape subclasses `QubitParamShiftTape`, `JacobianTape`, `CVParamShiftTape`, and
   `ReversibleTape` have been removed.
   [(#2336)](https://github.com/PennyLaneAI/pennylane/pull/2336)
-
-<h3>Bug fixes</h3>
 
 <h3>Bug fixes</h3>
 

--- a/pennylane/tape/tape.py
+++ b/pennylane/tape/tape.py
@@ -406,7 +406,7 @@ class QuantumTape(AnnotatedQueue):
             if isinstance(obj, QuantumTape):
                 self._ops.append(obj)
 
-            elif isinstance(obj, qml.operation.Operation) and not info.get("owner", False):
+            elif isinstance(obj, qml.operation.Operator) and not info.get("owner", False):
                 # operation objects with no owners
 
                 if self._measurements:
@@ -415,7 +415,8 @@ class QuantumTape(AnnotatedQueue):
                     )
 
                 # invert the operation if required
-                obj.inverse = info.get("inverse", obj.inverse)
+                if isinstance(obj, qml.operation.Operation):
+                    obj.inverse = info.get("inverse", obj.inverse)
 
                 if isinstance(obj, STATE_PREP_OPS):
                     if self._ops:


### PR DESCRIPTION
Currently, only objects inheriting from `Operation` are processed into from a tape queue into `tape._ops`.  

This was necessary in the past, as `Observables` denoted how to perform measurements. Now that we have `MeasurementProcess` objects to denote measurements, `Operator` objects will never be put into the `_measurements` list.

This change will be necessary if the upcoming Operator Modifiers/ Wrappers inherit from `Operator` instead of from `Operation`.