### PR TITLE
silence pylint issue

### DIFF
--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -530,7 +530,7 @@ class Operator(abc.ABC):
         """
         raise MatrixUndefinedError
 
-    # pylint: disable=no-self-argument
+    # pylint: disable=no-self-argument, comparison-with-callable
     @classproperty
     def has_matrix(cls):
         r"""Bool: Whether or not the Operator returns a defined matrix.


### PR DESCRIPTION
The recent PR introducing the `has_matrix` property also introduced a linting error.  This silences that error.