### PR TITLE
Fix import error and (some) warnings in the test suite

### DIFF
--- a/pennylane/transforms/qmc.py
+++ b/pennylane/transforms/qmc.py
@@ -46,8 +46,7 @@ def _apply_controlled_z(wires, control_wire, work_wires):
     control_values = "0" * (len(wires) - 1) + "1"
     control_wires = wires[1:] + control_wire
     MultiControlledX(
-        control_wires=control_wires,
-        wires=target_wire,
+        wires=[*control_wires, target_wire],
         control_values=control_values,
         work_wires=work_wires,
     )

--- a/tests/drawer/test_tape_mpl.py
+++ b/tests/drawer/test_tape_mpl.py
@@ -274,7 +274,7 @@ class TestSpecialGates:
         """Test MultiControlledX gets a special call."""
 
         with QuantumTape() as tape:
-            qml.MultiControlledX(control_wires=[0, 1, 2, 3], wires=4)
+            qml.MultiControlledX(wires=[0, 1, 2, 3, 4])
 
         _, ax = tape_mpl(tape)
         layer = 0
@@ -294,7 +294,7 @@ class TestSpecialGates:
         """Test MultiControlledX special call with provided control values."""
 
         with QuantumTape() as tape:
-            qml.MultiControlledX(control_wires=[0, 1, 2, 3], wires=4, control_values="0101")
+            qml.MultiControlledX(wires=[0, 1, 2, 3, 4], control_values="0101")
 
         _, ax = tape_mpl(tape)
 

--- a/tests/gradients/test_general_shift_rules.py
+++ b/tests/gradients/test_general_shift_rules.py
@@ -170,15 +170,8 @@ class TestGenerateShiftRule:
 
         frequencies = (1, 2, 3, 4, 5, 67)
 
-        with pytest.warns(None) as warnings:
+        with pytest.warns(UserWarning, match="Solving linear problem with near zero determinant"):
             generate_shift_rule(frequencies)
-
-        raised_warning = False
-        for warning in warnings:
-            if "Solving linear problem with near zero determinant" in str(warning):
-                raised_warning = True
-
-        assert raised_warning
 
     def test_second_order_two_term_shift_rule(self):
         """Test that the second order shift rule is correct and

--- a/tests/grouping/test_group_observables.py
+++ b/tests/grouping/test_group_observables.py
@@ -375,7 +375,7 @@ class TestDifferentiable:
 
     def test_differentiation_tf(self, tol):
         """Test that grouping is differentiable with tf tensors as coefficient"""
-        tf = pytest.importorskip("tf")
+        tf = pytest.importorskip("tensorflow")
         obs = [PauliX(wires=0), PauliX(wires=1), PauliZ(wires=1)]
 
         def group(coeffs, select=None):

--- a/tests/optimize/test_gradient_descent.py
+++ b/tests/optimize/test_gradient_descent.py
@@ -226,15 +226,9 @@ class TestGradientDescentOptimizer:
         assert opt.stepsize == eta
 
         eta2 = 0.1
-        opt.update_stepsize(eta2)
+        with pytest.warns(UserWarning, match="'update_stepsize' is deprecated. Stepsize value can"):
+            opt.update_stepsize(eta2)
         assert opt.stepsize == eta2
-
-        with pytest.warns(
-            UserWarning,
-            match="'update_stepsize' is deprecated. Stepsize value can be updated using "
-            "the 'stepsize' attribute.",
-        ):
-            opt.update_stepsize(eta)
 
     def test_private_stepsize(self):
         """
@@ -243,18 +237,10 @@ class TestGradientDescentOptimizer:
         """
         eta = 0.5
         opt = GradientDescentOptimizer(eta)
-        assert opt._stepsize == eta
-
-        with pytest.warns(
-            UserWarning, match="'_stepsize' is deprecated. Please use 'stepsize' instead."
-        ):
-            opt._stepsize
+        with pytest.warns(UserWarning, match="'_stepsize' is deprecated. Please use 'stepsize'"):
+            assert opt._stepsize == eta
 
         eta2 = 0.1
-        opt._stepsize = eta2
-        assert opt.stepsize == eta2
-
-        with pytest.warns(
-            UserWarning, match="'_stepsize' is deprecated. Please use 'stepsize' instead."
-        ):
+        with pytest.warns(UserWarning, match="'_stepsize' is deprecated. Please use 'stepsize'"):
             opt._stepsize = eta2
+        assert opt.stepsize == eta2

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -218,6 +218,7 @@ class TestOperationConstruction:
         with pytest.warns(UserWarning, match="get_parameter_shift is deprecated"):
             assert op.get_parameter_shift(0) == "Dummy recipe"
 
+    @pytest.mark.filterwarnings("ignore:The method get_parameter_shift is deprecated")
     def test_error_get_parameter_shift_no_recipe(self):
         """Test that ``get_parameter_shift`` raises an Error if no grad_recipe
         is available, as we no longer assume the two-term rule by default."""

--- a/tests/test_prob.py
+++ b/tests/test_prob.py
@@ -177,7 +177,7 @@ def test_prob_generalize_param_one_qubit(hermitian, init_state, tol):
         qml.Hermitian(hermitian, wires=0).diagonalizing_gates()
 
     state = np.array([1, 0])
-    matrix = qml.transforms.get_unitary_matrix(circuit_rotated)(0.56)
+    matrix = qml.matrix(circuit_rotated)(0.56)
     state = np.dot(matrix, state)
     expected = np.reshape(np.abs(state) ** 2, [2] * 1)
     expected = expected.flatten()
@@ -208,7 +208,7 @@ def test_prob_generalize_param(hermitian, init_state, tol):
         qml.Hermitian(hermitian, wires=0).diagonalizing_gates()
 
     state = np.array([1, 0, 0, 0, 0, 0, 0, 0])
-    matrix = qml.transforms.get_unitary_matrix(circuit_rotated)(0.56, 0.1)
+    matrix = qml.matrix(circuit_rotated)(0.56, 0.1)
     state = np.dot(matrix, state)
     expected = np.reshape(np.abs(state) ** 2, [2] * 3)
     expected = np.einsum("ijk->i", expected).flatten()
@@ -243,7 +243,7 @@ def test_prob_generalize_param_multiple(hermitian, init_state, tol):
         qml.Hermitian(hermitian, wires=0).diagonalizing_gates()
 
     state = np.array([1, 0, 0, 0, 0, 0, 0, 0])
-    matrix = qml.transforms.get_unitary_matrix(circuit_rotated)(0.56, 0.1)
+    matrix = qml.matrix(circuit_rotated)(0.56, 0.1)
     state = np.dot(matrix, state)
 
     expected = np.reshape(np.abs(state) ** 2, [2] * 3)
@@ -281,7 +281,7 @@ def test_prob_generalize_initial_state(hermitian, wire, init_state, tol):
         qml.PauliX(wires=3)
         qml.Hermitian(hermitian, wires=wire).diagonalizing_gates()
 
-    matrix = qml.transforms.get_unitary_matrix(circuit_rotated)()
+    matrix = qml.matrix(circuit_rotated)()
     state = np.dot(matrix, state)
     expected = np.reshape(np.abs(state) ** 2, [2] * 4)
 
@@ -322,7 +322,7 @@ def test_operation_prob(operation, wire, init_state, tol):
         qml.PauliZ(wires=3)
         operation(wires=wire).diagonalizing_gates()
 
-    matrix = qml.transforms.get_unitary_matrix(circuit_rotated)()
+    matrix = qml.matrix(circuit_rotated)()
     state = np.dot(matrix, state)
     expected = np.reshape(np.abs(state) ** 2, [2] * 4)
 
@@ -363,7 +363,7 @@ def test_operation_prob(operation, wire, init_state, tol):
         qml.PauliZ(wires=3)
         operation(wires=wire).diagonalizing_gates()
 
-    matrix = qml.transforms.get_unitary_matrix(circuit_rotated)()
+    matrix = qml.matrix(circuit_rotated)()
     state = np.dot(matrix, state)
     expected = np.reshape(np.abs(state) ** 2, [2] * 4)
 
@@ -404,7 +404,7 @@ def test_observable_tensor_prob(observable, init_state, tol):
         observable[0](wires=0).diagonalizing_gates()
         observable[1](wires=1).diagonalizing_gates()
 
-    matrix = qml.transforms.get_unitary_matrix(circuit_rotated)()
+    matrix = qml.matrix(circuit_rotated)()
     state = np.dot(matrix, state)
     expected = np.reshape(np.abs(state) ** 2, [2] * 4)
 

--- a/tests/test_qnode.py
+++ b/tests/test_qnode.py
@@ -657,7 +657,7 @@ class TestIntegration:
 
     def test_correct_number_of_executions_tf(self):
         """Test that number of executions are tracked in the tf interface."""
-        tf = pytest.importorskip("tf")
+        tf = pytest.importorskip("tensorflow")
 
         def func():
             qml.Hadamard(wires=0)

--- a/tests/transforms/test_commutation_dag.py
+++ b/tests/transforms/test_commutation_dag.py
@@ -443,9 +443,7 @@ class TestCommutingFunction:
         """Commutation between CNOT and MultiControlledX."""
         commutation = qml.is_commuting(
             qml.CNOT(wires=wires[0]),
-            qml.MultiControlledX(
-                control_wires=wires[1][0:3], wires=wires[1][-1], control_values="111"
-            ),
+            qml.MultiControlledX(wires=wires[1], control_values="111"),
         )
         assert commutation == res
 

--- a/tests/transforms/test_decompositions.py
+++ b/tests/transforms/test_decompositions.py
@@ -21,7 +21,6 @@ import pennylane as qml
 from pennylane import numpy as np
 
 from pennylane.wires import Wires
-from pennylane.transforms.get_unitary_matrix import get_unitary_matrix
 
 from pennylane.transforms.decompositions import zyz_decomposition
 from pennylane.transforms.decompositions import two_qubit_decomposition
@@ -677,7 +676,7 @@ class TestTwoQubitUnitaryDecomposition:
             for op in obtained_decomposition:
                 qml.apply(op)
 
-        obtained_matrix = get_unitary_matrix(tape, wire_order=wires)()
+        obtained_matrix = qml.matrix(tape, wire_order=wires)
 
         # We check with a slightly great tolerance threshold here simply because the
         # test matrices were copied in here with reduced precision.
@@ -698,7 +697,7 @@ class TestTwoQubitUnitaryDecomposition:
             for op in obtained_decomposition:
                 qml.apply(op)
 
-        obtained_matrix = get_unitary_matrix(tape, wire_order=wires)()
+        obtained_matrix = qml.matrix(tape, wire_order=wires)
 
         assert check_matrix_equivalence(U, obtained_matrix, atol=1e-7)
 
@@ -717,7 +716,7 @@ class TestTwoQubitUnitaryDecomposition:
             for op in obtained_decomposition:
                 qml.apply(op)
 
-        obtained_matrix = get_unitary_matrix(tape, wire_order=wires)()
+        obtained_matrix = qml.matrix(tape, wire_order=wires)
 
         assert check_matrix_equivalence(U, obtained_matrix, atol=1e-7)
 
@@ -736,7 +735,7 @@ class TestTwoQubitUnitaryDecomposition:
             for op in obtained_decomposition:
                 qml.apply(op)
 
-        obtained_matrix = get_unitary_matrix(tape, wire_order=wires)()
+        obtained_matrix = qml.matrix(tape, wire_order=wires)
 
         assert check_matrix_equivalence(U, obtained_matrix, atol=1e-7)
 
@@ -758,7 +757,7 @@ class TestTwoQubitUnitaryDecompositionInterfaces:
             for op in obtained_decomposition:
                 qml.apply(op)
 
-        obtained_matrix = get_unitary_matrix(tape, wire_order=wires)()
+        obtained_matrix = qml.matrix(tape, wire_order=wires)
 
         assert check_matrix_equivalence(U, obtained_matrix, atol=1e-7)
 
@@ -778,7 +777,7 @@ class TestTwoQubitUnitaryDecompositionInterfaces:
             for op in obtained_decomposition:
                 qml.apply(op)
 
-        obtained_matrix = get_unitary_matrix(tape, wire_order=wires)()
+        obtained_matrix = qml.matrix(tape, wire_order=wires)
 
         assert check_matrix_equivalence(U, obtained_matrix, atol=1e-7)
 
@@ -796,7 +795,7 @@ class TestTwoQubitUnitaryDecompositionInterfaces:
             for op in obtained_decomposition:
                 qml.apply(op)
 
-        obtained_matrix = get_unitary_matrix(tape, wire_order=wires)()
+        obtained_matrix = qml.matrix(tape, wire_order=wires)
 
         assert check_matrix_equivalence(U, obtained_matrix, atol=1e-7)
 
@@ -816,7 +815,7 @@ class TestTwoQubitUnitaryDecompositionInterfaces:
             for op in obtained_decomposition:
                 qml.apply(op)
 
-        obtained_matrix = get_unitary_matrix(tape, wire_order=wires)()
+        obtained_matrix = qml.matrix(tape, wire_order=wires)
 
         assert check_matrix_equivalence(U, obtained_matrix, atol=1e-7)
 
@@ -839,7 +838,7 @@ class TestTwoQubitUnitaryDecompositionInterfaces:
             for op in obtained_decomposition:
                 qml.apply(op)
 
-        obtained_matrix = get_unitary_matrix(tape, wire_order=wires)()
+        obtained_matrix = qml.matrix(tape, wire_order=wires)
 
         assert check_matrix_equivalence(U, obtained_matrix, atol=1e-7)
 
@@ -864,6 +863,6 @@ class TestTwoQubitUnitaryDecompositionInterfaces:
             for op in obtained_decomposition:
                 qml.apply(op)
 
-        obtained_matrix = get_unitary_matrix(tape, wire_order=wires)()
+        obtained_matrix = qml.matrix(tape, wire_order=wires)
 
         assert check_matrix_equivalence(U, obtained_matrix, atol=1e-7)

--- a/tests/transforms/test_get_unitary_matrix.py
+++ b/tests/transforms/test_get_unitary_matrix.py
@@ -163,7 +163,7 @@ def test_get_unitary_matrix_MultiControlledX():
     wires = [0, 1, 2, 3, 4, 5]
 
     def testcircuit():
-        qml.MultiControlledX(control_wires=[0, 2, 4, 5], wires=3)
+        qml.MultiControlledX(wires=[0, 2, 4, 5, 3])
 
     state0 = [1, 0]
     state1 = [0, 1]

--- a/tests/transforms/test_optimization/test_commute_controlled.py
+++ b/tests/transforms/test_optimization/test_commute_controlled.py
@@ -18,7 +18,6 @@ import pennylane as qml
 from pennylane.wires import Wires
 
 from pennylane.transforms.optimization import commute_controlled
-from pennylane.transforms.get_unitary_matrix import get_unitary_matrix
 from utils import (
     compare_operation_lists,
     check_matrix_equivalence,
@@ -294,10 +293,10 @@ class TestCommuteControlled:
         assert len(original_ops) == len(transformed_ops)
 
         # Compare matrices
-        compute_matrix = get_unitary_matrix(qfunc, [0, 1])
+        compute_matrix = qml.matrix(qfunc, [0, 1])
         matrix_expected = compute_matrix()
 
-        compute_transformed_matrix = get_unitary_matrix(transformed_qfunc, [0, 1])
+        compute_transformed_matrix = qml.matrix(transformed_qfunc, [0, 1])
         matrix_obtained = compute_transformed_matrix()
 
         assert check_matrix_equivalence(matrix_expected, matrix_obtained)

--- a/tests/transforms/test_optimization/test_optimization_utils.py
+++ b/tests/transforms/test_optimization/test_optimization_utils.py
@@ -22,7 +22,6 @@ from pennylane.transforms.optimization.optimization_utils import (
 )
 
 from utils import check_matrix_equivalence
-from pennylane.transforms.get_unitary_matrix import get_unitary_matrix
 
 
 sample_op_list = [
@@ -66,8 +65,7 @@ class TestRotGateFusion:
             qml.RZ(angles[1], wires=0),
             qml.RY(angles[2], wires=0),
 
-        compute_matrix = get_unitary_matrix(original_ops, [0])
-        product_yzy = compute_matrix()
+        product_yzy = qml.matrix(original_ops, [0])()
 
         z1, y, z2 = _yzy_to_zyz(angles)
 
@@ -76,8 +74,7 @@ class TestRotGateFusion:
             qml.RY(y, wires=0)
             qml.RZ(z2, wires=0)
 
-        compute_transformed_matrix = get_unitary_matrix(transformed_ops, [0])
-        product_zyz = compute_transformed_matrix()
+        product_zyz = qml.matrix(transformed_ops, [0])()
 
         assert check_matrix_equivalence(product_yzy, product_zyz)
 
@@ -107,8 +104,7 @@ class TestRotGateFusion:
             qml.Rot(*angles_1, wires=0)
             qml.Rot(*angles_2, wires=0)
 
-        compute_matrix = get_unitary_matrix(original_ops, [0])
-        matrix_expected = compute_matrix()
+        matrix_expected = qml.matrix(original_ops, [0])()
 
         fused_angles = fuse_rot_angles(angles_1, angles_2)
         matrix_obtained = qml.Rot(*fused_angles, wires=0).get_matrix()

--- a/tests/transforms/test_optimization/test_single_qubit_fusion.py
+++ b/tests/transforms/test_optimization/test_single_qubit_fusion.py
@@ -18,7 +18,6 @@ from pennylane import numpy as np
 import pennylane as qml
 from pennylane.wires import Wires
 from pennylane.transforms.optimization import single_qubit_fusion
-from pennylane.transforms.get_unitary_matrix import get_unitary_matrix
 
 from utils import *
 
@@ -41,11 +40,9 @@ class TestSingleQubitFusion:
         transformed_qfunc = single_qubit_fusion()(qfunc)
 
         # Compare matrices
-        compute_matrix = get_unitary_matrix(qfunc, [0])
-        matrix_expected = compute_matrix()
+        matrix_expected = qml.matrix(qfunc, [0])()
 
-        compute_transformed_matrix = get_unitary_matrix(transformed_qfunc, [0])
-        matrix_obtained = compute_transformed_matrix()
+        matrix_obtained = qml.matrix(transformed_qfunc, [0])()
         assert check_matrix_equivalence(matrix_expected, matrix_obtained)
 
     def test_single_qubit_fusion_no_gates_after(self):
@@ -126,11 +123,9 @@ class TestSingleQubitFusion:
         compare_operation_lists(transformed_ops, names_expected, wires_expected)
 
         # Compare matrices
-        compute_matrix = get_unitary_matrix(qfunc, [0, 1])
-        matrix_expected = compute_matrix()
+        matrix_expected = qml.matrix(qfunc, [0, 1])()
 
-        compute_transformed_matrix = get_unitary_matrix(transformed_qfunc, [0, 1])
-        matrix_obtained = compute_transformed_matrix()
+        matrix_obtained = qml.matrix(transformed_qfunc, [0, 1])()
         assert check_matrix_equivalence(matrix_expected, matrix_obtained)
 
     def test_single_qubit_fusion_multiple_qubits(self):
@@ -156,11 +151,9 @@ class TestSingleQubitFusion:
         compare_operation_lists(transformed_ops, names_expected, wires_expected)
 
         # Check matrix representation
-        compute_matrix = get_unitary_matrix(qfunc, ["a", "b"])
-        matrix_expected = compute_matrix()
+        matrix_expected = qml.matrix(qfunc, ["a", "b"])()
 
-        compute_transformed_matrix = get_unitary_matrix(transformed_qfunc, ["a", "b"])
-        matrix_obtained = compute_transformed_matrix()
+        matrix_obtained = qml.matrix(transformed_qfunc, ["a", "b"])()
 
         assert check_matrix_equivalence(matrix_expected, matrix_obtained)
 

--- a/tests/transforms/test_unitary_to_rot.py
+++ b/tests/transforms/test_unitary_to_rot.py
@@ -461,8 +461,8 @@ def test_unitary_to_rot_multiple_two_qubit(num_reps):
     original_qnode = qml.QNode(my_circuit, dev)
     transformed_qnode = qml.QNode(unitary_to_rot(my_circuit), dev)
 
-    original_matrix = qml.transforms.get_unitary_matrix(original_qnode)()
-    transformed_matrix = qml.transforms.get_unitary_matrix(transformed_qnode)()
+    original_matrix = qml.matrix(original_qnode)()
+    transformed_matrix = qml.matrix(transformed_qnode)()
 
     assert check_matrix_equivalence(original_matrix, transformed_matrix, atol=1e-7)
 


### PR DESCRIPTION
The following bug during import has been fixed which resulted in skipped tests:

```py
pytest.importskip("tf")
```

The following warnings have been eliminated from the PennyLane tests:

- `UserWarning: The control_wires keyword will be removed soon. Use wires = (control_wires, target_wire) instead. See the documentation for more information.`
- `UserWarning: The method get_parameter_shift is deprecated. Use the methods of the gradients module for general parameter-shift rules instead.`
- `UserWarning: get_unitary_matrix is deprecated, and will be removed in an upcoming release. For extracting matrices of operations and quantum functions, please use qml.matrix().`
- `PytestRemovedIn8Warning: Passing None has been deprecated.`
- `UserWarning: 'update_stepsize' is deprecated. Stepsize value can be updated using the 'stepsize' attribute.`
- `UserWarning: '_stepsize' is deprecated. Please use 'stepsize' instead.`

Warnings from the deprecated functions/tests themselves have not been removed.

No changelog required since it only applies to tests.