### PR TITLE
Skip identities in default.mixed

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -49,7 +49,7 @@
 
 <h3>Improvements</h3>
 
-* `"default.qubit"` and `"default.mixed"` now skip over identity operators instead of performing matrix multiplication
+* `default.qubit` and `default.mixed` now skip over identity operators instead of performing matrix multiplication
   with the identity.
   [(#2356)](https://github.com/PennyLaneAI/pennylane/pull/2356)
   [(#2365)](https://github.com/PennyLaneAI/pennylane/pull/2365)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -52,6 +52,7 @@
 * `"default.qubit"` and `"default.mixed"` now skip over identity operators instead of performing matrix multiplication
   with the identity.
   [(#2356)](https://github.com/PennyLaneAI/pennylane/pull/2356)
+  [(#2365)](https://github.com/PennyLaneAI/pennylane/pull/2365)
 
 * `QuantumTape` objects are now iterable and accessing the
   operations and measurements of the underlying quantum circuit is more

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -49,7 +49,7 @@
 
 <h3>Improvements</h3>
 
-* `"default.qubit"` now skips over identity operators instead performing matrix multiplication
+* `"default.qubit"` and `"default.mixed"` now skip over identity operators instead of performing matrix multiplication
   with the identity.
   [(#2356)](https://github.com/PennyLaneAI/pennylane/pull/2356)
 

--- a/pennylane/devices/default_mixed.py
+++ b/pennylane/devices/default_mixed.py
@@ -459,6 +459,8 @@ class DefaultMixed(QubitDevice):
             operation (.Operation): operation to apply on the device
         """
         wires = operation.wires
+        if operation.base_name == "Identity":
+            return
 
         if isinstance(operation, QubitStateVector):
             self._apply_state_vector(operation.parameters[0], wires)

--- a/tests/devices/test_default_mixed.py
+++ b/tests/devices/test_default_mixed.py
@@ -808,6 +808,24 @@ class TestApplyOperation:
         spy_diag.assert_not_called()
         spy_channel.assert_called_once()
 
+    def test_identity_skipped(self, mocker):
+        """Test that applying the identity does not perform any additional computations."""
+
+        op = qml.Identity(0)
+        dev = qml.device("default.mixed", wires=1)
+
+        spy_diagonal_unitary = mocker.spy(dev, "_apply_diagonal_unitary")
+        spy_apply_channel = mocker.spy(dev, "_apply_channel")
+
+        initialstate = dev.state.__copy__()
+
+        dev._apply_operation(op)
+
+        assert qml.math.allclose(dev.state, initialstate)
+
+        spy_diagonal_unitary.assert_not_called()
+        spy_apply_channel.assert_not_called()
+
 
 class TestApply:
     """Unit tests for the main method `apply()`. We check that lists of operations are applied

--- a/tests/devices/test_default_qubit.py
+++ b/tests/devices/test_default_qubit.py
@@ -2342,7 +2342,7 @@ class TestApplyOperationUnit:
             assert np.allclose(res_wires, wires)
 
     def test_identity_skipped(self, mocker):
-        """Test identity operation does not perform additional computations."""
+        """Test that applying the identity operation does not perform any additional computations."""
         dev = qml.device("default.qubit", wires=1)
 
         starting_state = np.array([1, 0])


### PR DESCRIPTION
Following #2356 , this PR makes `"default.mixed"` skip identities as well.