### PR TITLE
Default qubit support for any operation that provides a matrix

### DIFF
--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -198,19 +198,13 @@ class DefaultQubit(QubitDevice):
         wire_map = zip(wires, consecutive_wires)
         return dict(wire_map)
 
-    @property
-    def stopping_condition(self):
-        def f(obj):
-            if isinstance(obj, qml.tape.QuantumTape):
-                return False
-            if isinstance(obj, qml.operation.Operation):
-                return obj.has_matrix
-            if isinstance(obj, qml.measurements.MeasurementProcess):
-                if obj.obs is not None:
-                    return self.supports_observable(obj.obs)
-                return True
-            return False
-        return qml.BooleanFn(f)
+    def supports_operation(self, operation):
+        if operation.__class__.__name__ in {"Snapshot",
+        "BasisState",
+        "QubitStateVector",
+        "QubitUnitary"}:
+            return True
+        return operation.has_matrix
 
     # pylint: disable=arguments-differ
     def apply(self, operations, rotations=None, **kwargs):

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -198,6 +198,20 @@ class DefaultQubit(QubitDevice):
         wire_map = zip(wires, consecutive_wires)
         return dict(wire_map)
 
+    @property
+    def stopping_condition(self):
+        def f(obj):
+            if isinstance(obj, qml.tape.QuantumTape):
+                return False
+            if isinstance(obj, qml.operation.Operation):
+                return obj.has_matrix
+            if isinstance(obj, qml.measurements.MeasurementProcess):
+                if obj.obs is not None:
+                    return self.supports_observable(obj.obs)
+                return True
+            return False
+        return qml.BooleanFn(f)
+
     # pylint: disable=arguments-differ
     def apply(self, operations, rotations=None, **kwargs):
         rotations = rotations or []

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -537,9 +537,7 @@ class Operator(abc.ABC):
 
         Note: Child classes may have this as an instance property instead of as a class property.
         """
-        return (cls.compute_matrix != Operator.compute_matrix) or (
-            cls.get_matrix != Operator.get_matrix
-        )
+        return (cls.compute_matrix != Operator.compute_matrix)
 
     @property
     def matrix(self):
@@ -1847,6 +1845,10 @@ class Tensor(Observable):
             diag_gates.extend(o.diagonalizing_gates())
 
         return diag_gates
+
+    @property
+    def has_matrix(self):
+        return all(ob.has_matrix for ob in self.obs)
 
     def get_matrix(self, wire_order=None):
         r"""Matrix representation of the Tensor operator

--- a/tests/interfaces/test_autograd.py
+++ b/tests/interfaces/test_autograd.py
@@ -643,7 +643,7 @@ class TestAutogradExecuteIntegration:
                 U3(*p, wires=0)
                 qml.expval(qml.PauliX(0))
 
-            tape = tape.expand(stop_at=lambda obj: device.supports_operation(obj.name))
+            tape = tape.expand(stop_at=lambda obj: device.supports_operation(obj))
             return execute([tape], device, **execute_kwargs)[0]
 
         a = np.array(0.1, requires_grad=False)

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -161,18 +161,6 @@ class TestOperatorConstruction:
         assert MyOp.has_matrix
         assert MyOp(wires=0).has_matrix
 
-    def test_has_matrix_true_get_matrix(self):
-        """Test has_matrix property also detects overriding of `get_matrix` method."""
-
-        class MyOp(qml.operation.Operator):
-            num_wires = 1
-
-            def get_matrix(self):
-                return np.eye(2)
-
-        assert MyOp.has_matrix
-        assert MyOp(wires=0).has_matrix
-
     def test_has_matrix_false(self):
         """Test has_matrix property defaults to false if `compute_matrix` not overwritten."""
 


### PR DESCRIPTION
Currently, `"default.qubit"` requires explicitly writing out the class names for every operation it supports.

This is difficult to maintain, and currently `GroverOperator` and `PauliRot` both provide a matrix and aren't explicitly supported.  This leads to these operations being decomposed when we don't need to decompose them, and us performing more operations than necessary.

This PR attempts to change how we determine device support for `"default.qubit"`.  Instead, we will support any operation that provides a matrix, see the recently added `has_matrix` Operator attribute.

To do so, we need to test support on an instance-basis, instead of a class-basis.  Some operations may provide matrices in some situations but not others.  This requires changing `Device.supports_operation` and `Device.supports_observable` to accept operator instances instead of strings or class types.'

While execution is fine, many tests are failing because they rely on the particulars of how we test device support.

This PR will try to be as non-invasive as possible, but I highly recommend completely overhauling the system, as it is overly complex yet extremely delicate. We need to standardize what interacts with the rest of PennyLane and what is an internal implementation choice for each device type.