### PR TITLE
Pin jinja2 for CI checks to `3.0.3`

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -21,3 +21,4 @@ tensornetwork==0.3
 toml
 torch==1.9.0+cpu
 torchvision==0.10.0+cpu
+jinja2==3.0.3

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -13,4 +13,3 @@ dask[delayed]
 autoray
 matplotlib
 opt_einsum
-jinja2==3.0.3

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -13,3 +13,4 @@ dask[delayed]
 autoray
 matplotlib
 opt_einsum
+jinja2==3.0.3


### PR DESCRIPTION
**Context:**

Installation part of the CI checks for documentation is failing because of `jinja2` version `3.1.0` that was released today. 

**Description of the Change:**

This PR pins `jinja2` to version `3.0.3` 
