### PR TITLE
Bump the version for Sphinx

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -12,7 +12,7 @@ pygments-github-lexers
 semantic_version==2.6
 scipy
 docutils==0.16
-sphinx==3.5.3
+sphinx==4.4.0
 sphinx-automodapi==0.13
 sphinx-copybutton
 sphinxcontrib-bibtex==0.4.2


### PR DESCRIPTION
The documentation CI checks have started failing with the new Jinja2 release.

This PR 