### PR TITLE
Add `expansion_strategy` to `specs` transform

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -129,6 +129,8 @@
 
 <h3>Improvements</h3>
 
+* The `qml.specs` transform now accepts an `expansion_strategy` keyword argument.
+
 * `default.qubit` and `default.mixed` now skip over identity operators instead of performing matrix multiplication
   with the identity.
   [(#2356)](https://github.com/PennyLaneAI/pennylane/pull/2356)

--- a/pennylane/transforms/specs.py
+++ b/pennylane/transforms/specs.py
@@ -107,7 +107,6 @@ def specs(qnode, max_expansion=None, expansion_strategy=None):
         """
         initial_max_expansion = qnode.max_expansion
         initial_expansion_strategy = getattr(qnode, "expansion_strategy", None)
-        
 
         try:
             qnode.max_expansion = initial_max_expansion if max_expansion is None else max_expansion

--- a/pennylane/transforms/specs.py
+++ b/pennylane/transforms/specs.py
@@ -21,7 +21,7 @@ def _get_absolute_import_path(fn):
     return f"{inspect.getmodule(fn).__name__}.{fn.__name__}"
 
 
-def specs(qnode, max_expansion=None):
+def specs(qnode, max_expansion=None, expansion_strategy=None):
     """Resource information about a quantum circuit.
 
     This transform converts a QNode into a callable that provides resource information
@@ -33,6 +33,15 @@ def specs(qnode, max_expansion=None):
     Keyword Args:
         max_expansion (int): The number of times the internal circuit should be expanded when
             calculating the specification. Defaults to ``qnode.max_expansion``.
+        expansion_strategy (str): The strategy to use when circuit expansions or decompositions
+            are required.
+
+            - ``gradient``: The QNode will attempt to decompose
+              the internal circuit such that all circuit operations are supported by the gradient
+              method.
+
+            - ``device``: The QNode will attempt to decompose the internal circuit
+              such that all circuit operations are natively supported by the device.
 
     Returns:
         A function that has the same argument signature as ``qnode``. This function
@@ -97,12 +106,16 @@ def specs(qnode, max_expansion=None):
             dict[str, Union[defaultdict,int]]: dictionaries that contain QNode specifications
         """
         initial_max_expansion = qnode.max_expansion
-        qnode.max_expansion = initial_max_expansion if max_expansion is None else max_expansion
+        initial_expansion_strategy = getattr(qnode, "expansion_strategy", None)
+        
 
         try:
+            qnode.max_expansion = initial_max_expansion if max_expansion is None else max_expansion
+            qnode.expansion_strategy = expansion_strategy or initial_expansion_strategy
             qnode.construct(args, kwargs)
         finally:
             qnode.max_expansion = initial_max_expansion
+            qnode.expansion_strategy = initial_expansion_strategy
 
         info = qnode.qtape.specs.copy()
 

--- a/tests/transforms/test_specs.py
+++ b/tests/transforms/test_specs.py
@@ -129,23 +129,29 @@ class TestSpecsTransform:
         assert info["num_observables"] == 1
         assert info["num_diagonalizing_gates"] == 0
 
-    def test_max_expansion(self):
-        """Test that a user can calculation specifications for a different max
-        expansion parameter."""
-
+    def make_qnode_and_params(self, initial_expansion_strategy):
+        """Generates a qnode and params for use in other tests"""
         n_layers = 2
         n_wires = 5
 
         dev = qml.device("default.qubit", wires=n_wires)
 
-        @qml.qnode(dev)
+        @qml.qnode(dev, expansion_strategy=initial_expansion_strategy)
         def circuit(params):
-            qml.templates.BasicEntanglerLayers(params, wires=range(n_wires))
+            qml.BasicEntanglerLayers(params, wires=range(n_wires))
             return qml.expval(qml.PauliZ(0))
 
-        params_shape = qml.templates.BasicEntanglerLayers.shape(n_layers=n_layers, n_wires=n_wires)
+        params_shape = qml.BasicEntanglerLayers.shape(n_layers=n_layers, n_wires=n_wires)
         rng = np.random.default_rng(seed=10)
         params = rng.standard_normal(params_shape)
+
+        return circuit, params
+
+    def test_max_expansion(self):
+        """Test that a user can calculation specifications for a different max
+        expansion parameter."""
+
+        circuit, params = self.make_qnode_and_params("device")
 
         assert circuit.max_expansion == 10
         info = qml.specs(circuit, max_expansion=0)(params)
@@ -163,6 +169,20 @@ class TestSpecsTransform:
         assert info["device_name"] == "default.qubit.autograd"
         assert info["diff_method"] == "best"
         assert info["gradient_fn"] == "backprop"
+
+    def test_expansion_strategy(self):
+        """Test that a user can calculate specs for different expansion strategies."""
+        circuit, params = self.make_qnode_and_params("gradient")
+
+        assert circuit.expansion_strategy == "gradient"
+        info = qml.specs(circuit, expansion_strategy="device")(params)
+        assert circuit.expansion_strategy == "gradient"
+
+        assert len(info) == 15
+
+        assert info["gate_sizes"] == defaultdict(int, {1:10, 2: 10})
+        assert info["gate_types"] == defaultdict(int, {"RX": 10, "CNOT": 10})
+        assert info["num_operations"] == 20
 
     def test_gradient_transform(self):
         """Test that a gradient transform is properly labelled"""

--- a/tests/transforms/test_specs.py
+++ b/tests/transforms/test_specs.py
@@ -180,7 +180,7 @@ class TestSpecsTransform:
 
         assert len(info) == 15
 
-        assert info["gate_sizes"] == defaultdict(int, {1:10, 2: 10})
+        assert info["gate_sizes"] == defaultdict(int, {1: 10, 2: 10})
         assert info["gate_types"] == defaultdict(int, {"RX": 10, "CNOT": 10})
         assert info["num_operations"] == 20
 


### PR DESCRIPTION
Fixes #2393 

This PR adds the `expansion_strategy` keyword argument to the `qml.specs` transform.  Using this keyword, users can calculate the specifications of the circuit that will actually be executed by the device using `expansion_strategy="device"`.