### PR TITLE
bugfix in broadcast

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -292,12 +292,15 @@ the `decimals` and `show_matrices` keywords are added. `qml.drawer.tape_text(tap
   ```
   [(#2276)](https://github.com/PennyLaneAI/pennylane/pull/2276)
 
+* Fixes a bug in `broadcast` described in issue [#2402](https://github.com/PennyLaneAI/pennylane/issues/2402)
+  [(#2403)](https://github.com/PennyLaneAI/pennylane/pull/2403)
+
 <h3>Documentation</h3>
 
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):
 
-Karim Alaa El-Din, Guillermo Alonso-Linaje, Juan Miguel Arrazola, Thomas Bromley, Alain Delgado,
+Jack Y. Araz, Karim Alaa El-Din, Guillermo Alonso-Linaje, Juan Miguel Arrazola, Thomas Bromley, Alain Delgado,
 Olivia Di Matteo, Anthony Hayes, David Ittah, Josh Izaac, Soran Jahangiri, Christina Lee, Romain Moyard, Zeyue Niu,
 Jay Soni, Antal Száva, Maurice Weber.

--- a/pennylane/templates/broadcast.py
+++ b/pennylane/templates/broadcast.py
@@ -564,4 +564,4 @@ def broadcast(unitary, wires, pattern, parameters=None, kwargs=None):
             unitary(wires=wire_sequence[i], **kwargs)
     else:
         for i in range(len(wire_sequence)):
-            unitary(*parameters[i], wires=wire_sequence[i], **kwargs)
+            unitary(parameters[i], wires=wire_sequence[i], **kwargs)


### PR DESCRIPTION
**Context:**
Very simple bugfix in broadcast see issue #2402 

e.g.
```python
w = np.random.uniform(0,1,(2,15,))
qml.broadcast(qml.templates.ArbitraryUnitary, 4, [[0,3], [1,2]], w)
```
