### PR TITLE
Ensure Lightning test wheels are used in docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-  pull_request:
 
 jobs:
   base-tests:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,23 @@
+name: Docker builds
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  base-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.4.1
+        with:
+          access_token: ${{ github.token }}
+
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+
+      - name: Build & test PennyLane
+        run: make -f docker/Makefile build-base

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -289,6 +289,9 @@ the `decimals` and `show_matrices` keywords are added. `qml.drawer.tape_text(tap
 
 <h3>Bug fixes</h3>
 
+* PennyLane Lightning version in Docker container is pulled from latest wheel-builds.
+  [(#2416)](https://github.com/PennyLaneAI/pennylane/pull/2416)
+
 * Optimizers only consider a variable trainable if they have `requires_grad = True`.
   [(#2381)](https://github.com/PennyLaneAI/pennylane/pull/2381)
 

--- a/docker/pennylane.dockerfile
+++ b/docker/pennylane.dockerfile
@@ -43,6 +43,7 @@ RUN git submodule update --init --recursive \
     && pip install wheel && pip install -r requirements.txt \
     && python3 setup.py install \
     && pip install pytest pytest-cov pytest-mock flaky \
+    && pip install -i https://test.pypi.org/simple/ pennylane-lightning --pre --upgrade \
     && make test
 
 # create Second small build.

--- a/docker/pennylane.dockerfile
+++ b/docker/pennylane.dockerfile
@@ -44,7 +44,7 @@ RUN git submodule update --init --recursive \
     && python3 setup.py install \
     && pip install pytest pytest-cov pytest-mock flaky \
     && pip install -i https://test.pypi.org/simple/ pennylane-lightning --pre --upgrade \
-    && make test
+    && make test && make coverage
 
 # create Second small build.
 FROM ubuntu:latest

--- a/docker/qchem.dockerfile
+++ b/docker/qchem.dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-From pennylane/base:latest
+FROM pennylane/base:latest
 
 # Update and install Qchem
 RUN DEBIAN_FRONTEND="noninteractive" apt-get install tzdata # need to perform this again
@@ -25,6 +25,7 @@ WORKDIR /opt/pennylane/qchem
 RUN git submodule update --init --recursive
 RUN pip install wheel && pip install openfermionpyscf && pip install -r requirements.txt \
     && python3 setup.py install \
+    && pip install -i https://test.pypi.org/simple/ pennylane-lightning --pre --upgrade \
     && make test
 
 # Image build completed.

--- a/docker/qchem.dockerfile
+++ b/docker/qchem.dockerfile
@@ -26,7 +26,7 @@ RUN git submodule update --init --recursive
 RUN pip install wheel && pip install openfermionpyscf && pip install -r requirements.txt \
     && python3 setup.py install \
     && pip install -i https://test.pypi.org/simple/ pennylane-lightning --pre --upgrade \
-    && make test
+    && make test && make coverage
 
 # Image build completed.
 CMD echo "Successfully built Docker image"


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      test directory!

- [x] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `doc/releases/changelog-dev.md` file, summarizing the
      change, and including a link back to the PR.

- [x] The PennyLane source code conforms to
      [PEP8 standards](https://www.python.org/dev/peps/pep-0008/).
      We check all of our code against [Pylint](https://www.pylint.org/).
      To lint modified files, simply `pip install pylint`, and then
      run `pylint pennylane/path/to/file.py`.

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:** The docker build on PennyLane can fail tests due to the released version of Lightning being pulled in. As both repositories require synchronized changes, building a docker image from PennyLane master should also use the latest version of Lightning.

**Description of the Change:** Ensure the Lightning wheel is a pre-release from the latest master.

**Benefits:** Allows previously failing docker tests to pass.

**Possible Drawbacks:** Docker builds require the master version of PennyLane to be in sync.

**Related GitHub Issues:**
