### PR TITLE
Restore install for make and git in qchem.dockerfile

### DIFF
--- a/docker/qchem.dockerfile
+++ b/docker/qchem.dockerfile
@@ -17,6 +17,7 @@ FROM pennylane/base:latest
 # Update and install Qchem
 RUN DEBIAN_FRONTEND="noninteractive" apt-get install tzdata # need to perform this again
 RUN apt-get update \
+    && apt-get -y install --no-install-recommends make git \
     && rm -rf /var/lib/apt/lists/*
 
 # Setup and Build Qchem


### PR DESCRIPTION
**Context:**
This PR restores a change in `qchem.dockerfile` that was made while removing the openbabel dependency in qchem [here](https://github.com/PennyLaneAI/pennylane/pull/2415).

**Description of the Change:**
The following line is added back to the dockerfile:
`&& apt-get -y install --no-install-recommends make git \`