### PR TITLE
call pip with subprocess instead of _internal

### DIFF
--- a/pennylane/about.py
+++ b/pennylane/about.py
@@ -16,18 +16,11 @@ This module contains the :func:`about` function to display all the details of th
 e.g., OS, version, `Numpy` and `Scipy` versions, installation method.
 """
 import platform
-import importlib
 import sys
+from subprocess import check_output
 from pkg_resources import iter_entry_points
 import numpy
 import scipy
-
-# The following if/else block enables support for pip versions 19.3.x
-_parent_module = importlib.util.find_spec("pip._internal.main") or importlib.util.find_spec(
-    "pip._internal"
-)
-_internal_main = importlib.util.module_from_spec(_parent_module)
-_parent_module.loader.exec_module(_internal_main)
 
 
 def about():
@@ -35,7 +28,7 @@ def about():
     Prints the information for pennylane installation.
     """
     plugin_devices = iter_entry_points("pennylane.plugins")
-    _internal_main.main(["show", "pennylane"])
+    print(check_output([sys.executable, "-m", "pip", "show", "pennylane"]).decode())
     print(f"Platform info:           {platform.platform(aliased=True)}")
     print(
         f"Python version:          {sys.version_info[0]}.{sys.version_info[1]}.{sys.version_info[2]}"


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      test directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `doc/releases/changelog-dev.md` file, summarizing the
      change, and including a link back to the PR.

- [x] The PennyLane source code conforms to
      [PEP8 standards](https://www.python.org/dev/peps/pep-0008/).
      We check all of our code against [Pylint](https://www.pylint.org/).
      To lint modified files, simply `pip install pylint`, and then
      run `pylint pennylane/path/to/file.py`.

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
I work on PennyLane Cloud, and we don't love seeing the same warning constantly. Whenever someone imports pennylane, they see the following:
```bash
/opt/conda/envs/pennylane/lib/python3.8/site-packages/_distutils_hack/__init__.py:30: UserWarning: Setuptools is replacing distutils.
  warnings.warn("Setuptools is replacing distutils.")
```

I poked around, got a more detailed trace of the warning and found that it was because this file imports pip's internal library directly. The [pip docs](https://pip.pypa.io/en/latest/user_guide/#using-pip-from-your-program) recommend using `subprocess.check_call()` instead, so I'm kinda doing that (The test captures stdout using contextlib and it appears that subprocess output doesn't get captured there, so I instead capture using `subprocess.check_output` then I call `print`. I can change this if we don't love the details of it). Furthermore, calling `pennylane.about()` itself would give another warning:
```
WARNING: pip is being invoked by an old script wrapper. This will fail in a future version of pip.
Please see https://github.com/pypa/pip/issues/5599 for advice on fixing the underlying issue.
To avoid this problem you can invoke Python with '-m pip' instead of running pip directly.
```
This feels like an artifact of using `pip._internal` from python code, but anyway, it disappears when using subprocess 😄 

**Description of the Change:**

No longer import `pip._internal` to call `pip show pennylane` in `pennylane/about.py`. Instead, call `pip` directly in a subprocess as advised by pip docs.

**Benefits:**
Warnings are no longer outputted when importing pennylane or when running `pennylane.about()`, and the code would be following pip's recommended practices.

**Possible Drawbacks:**
None as far as I can see. Maybe some OS will not like `str.decode()`? I tried specifying `sys.stdout.encoding` as an argument but again, the contextlib usage in `test_about.py` didn't like that (it was `None`).

**Related GitHub Issues:**
N/A