### PR TITLE
Speed up diagonalize_qwc_pauli_words()

### DIFF
--- a/pennylane/grouping/transformations.py
+++ b/pennylane/grouping/transformations.py
@@ -135,18 +135,31 @@ def diagonalize_qwc_pauli_words(qwc_grouping):
       PauliZ(wires=[0]) @ PauliZ(wires=[3]),
       PauliZ(wires=[1]) @ PauliZ(wires=[3])])
     """
-    m_paulis = len(qwc_grouping)
-    all_wires = Wires.all_wires([pauli_word.wires for pauli_word in qwc_grouping])
-    wire_map = {label: ind for ind, label in enumerate(all_wires)}
-    for i in range(m_paulis):
-        for j in range(i + 1, m_paulis):
-            if not is_qwc(
-                pauli_to_binary(qwc_grouping[i], wire_map=wire_map),
-                pauli_to_binary(qwc_grouping[j], wire_map=wire_map),
-            ):
-                raise ValueError(
-                    f"{qwc_grouping[i]} and {qwc_grouping[j]} are not qubit-wise commuting."
-                )
+    # If all Paulis are the same kind they are naturally QWC and we
+    # don't need to do the expensive quadratic scalig check
+    first_pauli_name = qwc_grouping[0].name
+    if isinstance(first_pauli_name, list):
+        first_pauli_name = first_pauli_name[0]
+    all_paulis_same_kind = all([all([first_pauli_name == sub_word_name for sub_word_name in pauli_word.name]) if isinstance(pauli_word.name, list) else first_pauli_name == pauli_word.name for pauli_word in qwc_grouping])
+    if not all_paulis_same_kind:
+        m_paulis = len(qwc_grouping)
+        all_wires = Wires.all_wires([pauli_word.wires for pauli_word in qwc_grouping])
+        wire_map = {label: ind for ind, label in enumerate(all_wires)}
+        pauli_binaries = [
+            pauli_to_binary(
+                qwc_grouping[i],
+                wire_map=wire_map,
+                check_is_pauli_word=False,
+            ) for i in range(m_paulis)]
+        for i in range(m_paulis):
+            for j in range(i + 1, m_paulis):
+                if not is_qwc(
+                        pauli_binaries[i],
+                        pauli_binaries[j],
+                ):
+                    raise ValueError(
+                        f"{qwc_grouping[i]} and {qwc_grouping[j]} are not qubit-wise commuting."
+                    )
 
     pauli_operators = []
     diag_terms = []

--- a/pennylane/grouping/utils.py
+++ b/pennylane/grouping/utils.py
@@ -253,8 +253,8 @@ def pauli_to_binary(pauli_word, n_qubits=None, wire_map=None, check_is_pauli_wor
         elif name == "PauliZ":
             binary_pauli[n_qubits + wire] = 1
 
-        else:
-            raise ValueError()
+        elif name != "Identity":
+            raise ValueError("name {}".format(name))
 
     return binary_pauli
 

--- a/pennylane/grouping/utils.py
+++ b/pennylane/grouping/utils.py
@@ -134,7 +134,7 @@ def are_identical_pauli_words(pauli_1, pauli_2):
     return set(zip(pauli_1.wires, pauli_1.name)) == set(zip(pauli_2.wires, pauli_2.name))
 
 
-def pauli_to_binary(pauli_word, n_qubits=None, wire_map=None):
+def pauli_to_binary(pauli_word, n_qubits=None, wire_map=None, check_is_pauli_word=True):
     """Converts a Pauli word to the binary vector representation.
 
     This functions follows convention that the first half of binary vector components specify
@@ -214,7 +214,7 @@ def pauli_to_binary(pauli_word, n_qubits=None, wire_map=None):
     array([1., 0., 0., 0., 0., 1., 0., 0., 0., 0., 0., 0.])
     """
 
-    if not is_pauli_word(pauli_word):
+    if check_is_pauli_word and not is_pauli_word(pauli_word):
         raise TypeError(f"Expected a Pauli word Observable instance, instead got {pauli_word}.")
 
     if wire_map is None:
@@ -252,6 +252,9 @@ def pauli_to_binary(pauli_word, n_qubits=None, wire_map=None):
 
         elif name == "PauliZ":
             binary_pauli[n_qubits + wire] = 1
+
+        else:
+            raise ValueError()
 
     return binary_pauli
 


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      test directory!

- [x] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `doc/releases/changelog-dev.md` file, summarizing the
      change, and including a link back to the PR.

- [x] The PennyLane source code conforms to
      [PEP8 standards](https://www.python.org/dev/peps/pep-0008/).
      We check all of our code against [Pylint](https://www.pylint.org/).
      To lint modified files, simply `pip install pylint`, and then
      run `pylint pennylane/path/to/file.py`.

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**

I ran into a case where measuring quadratically many commuting Paulis, even with +10 qubits, 90% of the simulation time was spent in `diagonalize_qwc_pauli_words()`

**Description of the Change:**

This PR makes the quadratic check for QWC more efficient by pre-computing the expensive binary representations of Paulis and avoids the quadratic scaling altogether in the special case that all Paulis are of the same kind.

**Benefits:**

Massive speedups when many commuting Paulis are measured.

**Possible Drawbacks:**

If the Paulis are QWC but not all identical, then an additional linear scaling check is run.

**Related GitHub Issues:**

None.