### PR TITLE
Ignore different arguments linting error (NesterovMomentum and ShotAdaptive optimizers)

### DIFF
--- a/pennylane/optimize/nesterov_momentum.py
+++ b/pennylane/optimize/nesterov_momentum.py
@@ -36,6 +36,7 @@ class NesterovMomentumOptimizer(MomentumOptimizer):
         momentum (float): user-defined hyperparameter :math:`m`
     """
 
+    # pylint: disable=arguments-renamed
     def compute_grad(self, objective_fn, args, kwargs, grad_fn=None):
         r"""Compute gradient of the objective function at at the shifted point :math:`(x -
         m\times\text{accumulation})` and return it along with the objective function forward pass

--- a/pennylane/optimize/shot_adaptive.py
+++ b/pennylane/optimize/shot_adaptive.py
@@ -350,7 +350,7 @@ class ShotAdaptiveOptimizer(GradientDescentOptimizer):
 
     def compute_grad(
         self, objective_fn, args, kwargs
-    ):  # pylint: disable=signature-differs,arguments-differ
+    ):  # pylint: disable=signature-differs,arguments-differ,arguments-renamed
         r"""Compute gradient of the objective function, as well as the variance of the gradient,
         at the given point.
 


### PR DESCRIPTION
Ignores the linting issues in `pennylane/optimize/nesterov_momentum.py` and `pennylane/optimize/shot_adaptive.py` that were "discovered" by Codefactor in https://github.com/PennyLaneAI/pennylane/pull/2363:

![image](https://user-images.githubusercontent.com/24476053/162813786-e147845e-ed87-42a4-b2a2-c0fe54d70971.png)
