### PR TITLE
Add raising an error if `qml.probs` called without wires or obs

### DIFF
--- a/pennylane/measurements.py
+++ b/pennylane/measurements.py
@@ -133,6 +133,7 @@ class MeasurementProcess:
             List[.Operation]: the operations that diagonalize the observables
         """
         try:
+            # pylint: disable=no-member
             return self.expand().operations
         except qml.operation.DecompositionUndefinedError:
             return []
@@ -517,6 +518,12 @@ def probs(wires=None, op=None):
          the computational basis
     """
     # pylint: disable=protected-access
+
+    if wires is None and op is None:
+        raise qml.QuantumFunctionError(
+            "qml.probs requires either the wires or the observable to be passed."
+        )
+
     if isinstance(op, qml.Hamiltonian):
         raise qml.QuantumFunctionError("Hamiltonians are not supported for rotating probabilities.")
 

--- a/tests/test_prob.py
+++ b/tests/test_prob.py
@@ -437,6 +437,24 @@ def test_hamiltonian_error(coeffs, obs, init_state, tol):
         circuit()
 
 
+def test_probs_no_wires_obs_raises():
+    "Test that an error is returned for hamiltonians."
+    num_wires = 1
+
+    dev = qml.device("default.qubit", wires=num_wires, shots=None)
+
+    @qml.qnode(dev)
+    def circuit_probs():
+        qml.RY(0.34, wires=0)
+        return qml.probs()
+
+    with pytest.raises(
+        qml.QuantumFunctionError,
+        match="qml.probs requires either the wires or the observable to be passed.",
+    ):
+        circuit_probs()
+
+
 @pytest.mark.parametrize(
     "operation", [qml.SingleExcitation, qml.SingleExcitationPlus, qml.SingleExcitationMinus]
 )


### PR DESCRIPTION
Closes #2401.