### PR TITLE
Add support for JIT when using `DiagonalQubitUnitary`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -411,7 +411,7 @@ the `decimals` and `show_matrices` keywords are added. `qml.drawer.tape_text(tap
 
 * Fixes a bug where `qml.DiagonalQubitUnitary` did not support `@jax.jit`
   and `@tf.function`.
-  [(#)]()
+  [(#2445)](https://github.com/PennyLaneAI/pennylane/pull/2445)
 
 * Fixes a bug in the `qml.PauliRot` operation, where computing the generator was not taking into
   account the operation wires.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -409,6 +409,10 @@ the `decimals` and `show_matrices` keywords are added. `qml.drawer.tape_text(tap
 
 <h3>Bug fixes</h3>
 
+* Fixes a bug where `qml.DiagonalQubitUnitary` did not support `@jax.jit`
+  and `@tf.function`.
+  [(#)]()
+
 * Fixes a bug in the `qml.PauliRot` operation, where computing the generator was not taking into
   account the operation wires.
   [(#2442)](https://github.com/PennyLaneAI/pennylane/pull/2442)

--- a/pennylane/ops/qubit/matrix_ops.py
+++ b/pennylane/ops/qubit/matrix_ops.py
@@ -403,7 +403,9 @@ class DiagonalQubitUnitary(Operation):
         """
         D = qml.math.asarray(D)
 
-        if not qml.math.allclose(D * qml.math.conj(D), qml.math.ones_like(D)):
+        if not qml.math.is_abstract(D) and not qml.math.allclose(
+            D * qml.math.conj(D), qml.math.ones_like(D)
+        ):
             raise ValueError("Operator must be unitary.")
 
         return D

--- a/tests/ops/qubit/test_matrix_ops.py
+++ b/tests/ops/qubit/test_matrix_ops.py
@@ -267,7 +267,7 @@ class TestDiagonalQubitUnitary:
         expected = -jnp.sin(x)
         assert np.allclose(grad, expected)
 
-    @pytest.mark.slow # test takes 12 seconds due to tf.function
+    @pytest.mark.slow  # test takes 12 seconds due to tf.function
     def test_tf_function(self):
         """Test that the diagonal matrix unitary operation works
         within a QNode that uses TensorFlow autograph"""

--- a/tests/ops/qubit/test_matrix_ops.py
+++ b/tests/ops/qubit/test_matrix_ops.py
@@ -246,6 +246,53 @@ class TestDiagonalQubitUnitary:
         with pytest.raises(ValueError, match="Operator must be unitary"):
             qml.DiagonalQubitUnitary.compute_matrix(np.array([1, 2]))
 
+    def test_jax_jit(self):
+        """Test that the diagonal matrix unitary operation works
+        within a QNode that uses the JAX JIT"""
+        jax = pytest.importorskip("jax")
+        jnp = jax.numpy
+
+        dev = qml.device("default.qubit", wires=1, shots=None)
+
+        @jax.jit
+        @qml.qnode(dev, interface="jax")
+        def circuit(x):
+            diag = jnp.exp(1j * x * jnp.array([1, -1]) / 2)
+            qml.Hadamard(wires=0)
+            qml.DiagonalQubitUnitary(diag, wires=0)
+            return qml.expval(qml.PauliX(0))
+
+        x = 0.654
+        grad = jax.grad(circuit)(x)
+        expected = -jnp.sin(x)
+        assert np.allclose(grad, expected)
+
+    @pytest.mark.slow # test takes 12 seconds due to tf.function
+    def test_tf_function(self):
+        """Test that the diagonal matrix unitary operation works
+        within a QNode that uses TensorFlow autograph"""
+        tf = pytest.importorskip("tensorflow")
+
+        dev = qml.device("default.qubit", wires=1, shots=None)
+
+        @tf.function
+        @qml.qnode(dev, interface="tf")
+        def circuit(x):
+            x = tf.cast(x, tf.complex128)
+            diag = tf.math.exp(1j * x * tf.constant([1.0 + 0j, -1.0 + 0j]) / 2)
+            qml.Hadamard(wires=0)
+            qml.DiagonalQubitUnitary(diag, wires=0)
+            return qml.expval(qml.PauliX(0))
+
+        x = tf.Variable(0.452)
+
+        with tf.GradientTape() as tape:
+            loss = circuit(x)
+
+        grad = tape.gradient(loss, x)
+        expected = -tf.math.sin(x)
+        assert np.allclose(grad, expected)
+
 
 X = np.array([[0, 1], [1, 0]])
 


### PR DESCRIPTION
**Context:** Due to a unitarity check, `qml.DiagonalQubitUnitary` did not work with `@jax.jit` and `@tf.function`.

**Description of the Change:** Uses `qml.math.is_abstract` to avoid the unitarity check if a JIT is detected.

**Benefits:** The operation now works with JIT compilation.

**Possible Drawbacks:** TensorFlow is very slow to compile, so the test added to ensure that `@tf.function` works takes 12 seconds :( Should we remove it?

**Related GitHub Issues:** n/a
