### PR TITLE
fixes test due to positional argument `use_opt_einsum`

### DIFF
--- a/tests/transforms/test_qcut.py
+++ b/tests/transforms/test_qcut.py
@@ -3559,8 +3559,12 @@ class TestCutCircuitTransform:
         dev_2 = qml.device("default.qubit", wires=["Alice", 3.14, "Bob"])
 
         uncut_circuit = qml.QNode(circuit, dev_uncut)
-        cut_circuit_1 = qml.transforms.cut_circuit(qml.QNode(circuit, dev_1), use_opt_einsum)
-        cut_circuit_2 = qml.transforms.cut_circuit(qml.QNode(circuit, dev_2), use_opt_einsum)
+        cut_circuit_1 = qml.transforms.cut_circuit(
+            qml.QNode(circuit, dev_1), use_opt_einsum=use_opt_einsum
+        )
+        cut_circuit_2 = qml.transforms.cut_circuit(
+            qml.QNode(circuit, dev_2), use_opt_einsum=use_opt_einsum
+        )
 
         res_expected = uncut_circuit()
         res_1 = cut_circuit_1()


### PR DESCRIPTION
**Context:**
In test `tests/transforms/test_qcut.py::test_device_wires`, the argument `use_opt_einsum` was provided as a positional argument to `cut_circuit` which now gets interpreted as the `auto_cutter` argument due to argument order change in PR #2428. This caused kahypar to be called, leading to an import error in the test.

**Description of the Change:**
Passing `use_opt_einsum` as keyword argument.

**Benefits:**
fixes test in master branch

**Possible Drawbacks:**

**Related GitHub Issues:**
