### PR TITLE
Incrementing the version number to `v0.24.0-dev`

### DIFF
--- a/doc/development/release_notes.md
+++ b/doc/development/release_notes.md
@@ -6,6 +6,8 @@ This page contains the release notes for PennyLane.
 
 .. mdinclude:: ../releases/changelog-dev.md
 
+.. mdinclude:: ../releases/changelog-0.23.0.md
+
 .. mdinclude:: ../releases/changelog-0.22.2.md
 
 .. mdinclude:: ../releases/changelog-0.22.1.md

--- a/doc/releases/changelog-0.22.2.md
+++ b/doc/releases/changelog-0.22.2.md
@@ -1,6 +1,6 @@
 :orphan:
 
-# Release 0.22.2 (current release)
+# Release 0.22.2
 
 <h3>Bug fixes</h3>
 

--- a/doc/releases/changelog-0.23.0.md
+++ b/doc/releases/changelog-0.23.0.md
@@ -1,6 +1,6 @@
 :orphan:
 
-# Release 0.23.0-dev (development release)
+# Release 0.23.0 (current release)
 
 <h3>New features since last release</h3>
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1,0 +1,17 @@
+:orphan:
+
+# Release 0.24.0-dev (development release)
+
+<h3>New features since last release</h3>
+
+<h3>Improvements</h3>
+
+<h3>Breaking changes</h3>
+
+<h3>Deprecations</h3>
+
+<h3>Documentation</h3>
+
+<h3>Contributors</h3>
+
+This release contains contributions from (in alphabetical order):

--- a/pennylane/_version.py
+++ b/pennylane/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.23.0-dev"
+__version__ = "0.24.0-dev"


### PR DESCRIPTION
Updates PennyLane as we're entering a new development version (release of v0.23.0 coming up):

* Moves the v0.23.0 changelog into a separate file
* Updates the dev changelog file to have empty sections
* Increments the version number to v0.24.0-dev

Note: QChem is not being released, what's more, the subpackage is being deprecated.

See the same PR for the [v0.23.0 bump](https://github.com/PennyLaneAI/pennylane/pull/2295).