### PR TITLE
Bugfix for Nesterov Momentum Optimier

### DIFF
--- a/doc/releases/changelog-0.23.0.md
+++ b/doc/releases/changelog-0.23.0.md
@@ -485,6 +485,7 @@ the `decimals` and `show_matrices` keywords are added. `qml.drawer.tape_text(tap
 
 * Fixes a bug where non-trainable arguments were shifted in the `NesterovMomentumOptimizer`
   if a trainable argument was after it in the argument list.
+  [(#2466)](https://github.com/PennyLaneAI/pennylane/pull/2466)
 
 * Fixes a bug where `qml.DiagonalQubitUnitary` did not support `@jax.jit`
   and `@tf.function`.

--- a/doc/releases/changelog-0.23.0.md
+++ b/doc/releases/changelog-0.23.0.md
@@ -483,6 +483,9 @@ the `decimals` and `show_matrices` keywords are added. `qml.drawer.tape_text(tap
 
 <h3>Bug fixes</h3>
 
+* Fixes a bug where non-trainable arguments were shifted in the `NesterovMomentumOptimizer`
+  if a trainable argument was after it in the argument list.
+
 * Fixes a bug where `qml.DiagonalQubitUnitary` did not support `@jax.jit`
   and `@tf.function`.
   [(#2445)](https://github.com/PennyLaneAI/pennylane/pull/2445)

--- a/pennylane/optimize/nesterov_momentum.py
+++ b/pennylane/optimize/nesterov_momentum.py
@@ -59,7 +59,9 @@ class NesterovMomentumOptimizer(MomentumOptimizer):
         """
         shifted_args = list(args)
 
-        trainable_indices = [i for i, arg in enumerate(args) if getattr(arg, "requires_grad", False)]
+        trainable_indices = [
+            i for i, arg in enumerate(args) if getattr(arg, "requires_grad", False)
+        ]
 
         if self.accumulation:
             for index in trainable_indices:

--- a/pennylane/optimize/nesterov_momentum.py
+++ b/pennylane/optimize/nesterov_momentum.py
@@ -59,18 +59,15 @@ class NesterovMomentumOptimizer(MomentumOptimizer):
         """
         shifted_args = list(args)
 
-        trainable_args = []
-        for arg in args:
-            if getattr(arg, "requires_grad", False):
-                trainable_args.append(arg)
+        trainable_indices = [i for i, arg in enumerate(args) if getattr(arg, "requires_grad", False)]
 
         if self.accumulation:
-            for index, arg in enumerate(trainable_args):
-                shifted_args[index] = arg - self.momentum * self.accumulation[index]
+            for index in trainable_indices:
+                shifted_args[index] = args[index] - self.momentum * self.accumulation[index]
 
         g = get_gradient(objective_fn) if grad_fn is None else grad_fn
         grad = g(*shifted_args, **kwargs)
         forward = getattr(g, "forward", None)
 
-        grad = (grad,) if len(trainable_args) == 1 else grad
+        grad = (grad,) if len(trainable_indices) == 1 else grad
         return grad, forward

--- a/tests/optimize/test_optimize.py
+++ b/tests/optimize/test_optimize.py
@@ -115,17 +115,21 @@ class TestOverOpts:
         """Check non-trainable argument does not get updated"""
 
         def func(a, b, c, d):
+            if not qml.math.allclose(b, 1.0):
+                # Tests Nesterov momentum optimizer only shifts arguments of the trainable parameters
+                raise ValueError("Only accepts a b of 1.0.")
             return a * b * c * d
 
-        a = np.array(1.0, requires_grad=True)
+        a = np.array(0.1, requires_grad=True)
         b = np.array(1.0, requires_grad=False)
         c = 1.0
-        d = np.array(1.0, requires_grad=True)
+        d = np.array(0.2, requires_grad=True)
 
-        args_new = opt.step(func, a, b, c, d)
+        args1 = opt.step(func, a, b, c, d)
+        args2 = opt.step(func, *args1)
 
-        assert args_new[1] is b
-        assert args_new[2] == 1.0
+        assert args2[1] is b
+        assert args2[2] == 1.0
 
     def test_steps_the_same(self, opt, tol):
         """Tests whether separating the args into different inputs affects their

--- a/tests/optimize/test_optimize.py
+++ b/tests/optimize/test_optimize.py
@@ -115,9 +115,7 @@ class TestOverOpts:
         """Check non-trainable argument does not get updated"""
 
         def func(a, b, c, d):
-            if not qml.math.allclose(b, 1.0):
-                # Tests Nesterov momentum optimizer only shifts arguments of the trainable parameters
-                raise ValueError("Only accepts a b of 1.0.")
+            assert qml.math.allclose(b, 1.0)
             return a * b * c * d
 
         a = np.array(0.1, requires_grad=True)


### PR DESCRIPTION
This bug was discovered through [the "Variational Classifier" demo](https://github.com/PennyLaneAI/qml/runs/6085549063?check_suite_focus=true#step:8:2432).

In the Nesterov Momentum Optimizer, there was confusion between the index of an argument in the total arguments list and the index in the *trainable-only* arguments list.  Non-trainable arguments were shifted using the gradient of a trainable argument after them in the list. Since `BasisState` has to have zero and one only, this shifting caused execution to fail.