### PR TITLE
Proposal for performance improvements in the Tape and Wires classes

### DIFF
--- a/pennylane/tape/tape.py
+++ b/pennylane/tape/tape.py
@@ -523,9 +523,9 @@ class QuantumTape(AnnotatedQueue):
         )
         self.num_wires = len(self.wires)
 
-        self.is_sampled = any(m.return_type is Sample for m in self.measurements)
-        self.all_sampled = all(m.return_type is Sample for m in self.measurements)
-        self.is_sampled = any(m.return_type is Sample for m in self.measurements)
+        return_types = [m.return_type is Sample for m in self.measurements]
+        self.is_sampled = any(return_types)
+        self.all_sampled = all(return_types)
 
     def _update_observables(self):
         """Update information about observables, including the wires that are acted upon and
@@ -1557,7 +1557,21 @@ class QuantumTape(AnnotatedQueue):
             tape._ops = self._ops.copy()
             tape._measurements = self._measurements.copy()
 
-        tape._update()
+        tape._graph = None
+        tape._specs = None
+        tape._depth = None
+
+        tape.wires = copy.copy(self.wires)
+        tape.num_wires = self.num_wires
+        tape.is_sampled = self.is_sampled
+        tape.all_sampled = self.all_sampled
+
+        tape._update_par_info()
+
+        tape._update_trainable_params()
+        tape._obs_sharing_wires = [copy.copy(shared_wires) for shared_wires in self._obs_sharing_wires]
+        tape._obs_sharing_wires_id = [copy.copy(wire_id) for wire_id in self._obs_sharing_wires_id]
+
         tape.trainable_params = self.trainable_params.copy()
         tape._output_dim = self.output_dim
 

--- a/pennylane/wires.py
+++ b/pennylane/wires.py
@@ -412,15 +412,7 @@ class Wires(Sequence):
         >>> Wires.all_wires(list_of_wires)
         <Wires = [4, 0, 1, 3, 5]>
         """
-        combined = []
-        seen_labels = set()
-        for wires in list_of_wires:
-            if not isinstance(wires, Wires):
-                raise WireError(f"Expected a Wires object; got {wires} of type {type(wires)}")
-
-            extension = [label for label in wires.labels if label not in seen_labels]
-            combined.extend(extension)
-            seen_labels.update(extension)
+        combined = list(dict.fromkeys(sum([wires.tolist() if isinstance(wires, Wires) else Wires(wires).tolist() for wires in list_of_wires], [])))
 
         if sort:
             if all(isinstance(w, int) for w in combined):

--- a/tests/test_wires.py
+++ b/tests/test_wires.py
@@ -318,8 +318,7 @@ class TestWires:
         new_wires = Wires.all_wires([wires1, wires2, wires3], sort=True)
         assert new_wires.labels == (1, 2, 3, 4, 5, 6)
 
-        with pytest.raises(WireError, match="Expected a Wires object"):
-            Wires.all_wires([[3, 4], [8, 5]])
+        assert Wires.all_wires([[3, 4], [8, 5]]).labels == (3, 4, 8, 5)
 
     def test_shared_wires_method(self):
         """Tests the ``shared_wires()`` method."""


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      test directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `doc/releases/changelog-dev.md` file, summarizing the
      change, and including a link back to the PR.

- [ ] The PennyLane source code conforms to
      [PEP8 standards](https://www.python.org/dev/peps/pep-0008/).
      We check all of our code against [Pylint](https://www.pylint.org/).
      To lint modified files, simply `pip install pylint`, and then
      run `pylint pennylane/path/to/file.py`.

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**

This is not really a PR that is meant to be merged as is, but I am submitting these proposed code changes as suggestions after discussing them with @josh146 . The motivation for these changes is the profiling done as part of #2430

**Description of the Change:**

The changes are meant to improve performance of the most frequently run parts of the Wires and Tape classes.

**Benefits:**

Quite noticeable speedups, especially when computing parameter-shift gradients. 

**Possible Drawbacks:**

`all_wires()` no longer raises an exception if it is not passed a `Wires` object but tries to cast to `Wires`. Not sure this is a drawback...

**Related GitHub Issues:**

#2430