### PR TITLE
Fix formatting issues for MERA template

### DIFF
--- a/pennylane/templates/tensornetworks/mera.py
+++ b/pennylane/templates/tensornetworks/mera.py
@@ -99,7 +99,7 @@ def compute_indices(wires, n_block_wires):
 class MERA(Operation):
     """The MERA template broadcasts an input circuit across many wires following the
     architecture of a multi-scale entanglement renormalization ansatz tensor network.
-    This architecture can be found in `arXiv:quant-ph/0610099 <https://arxiv.org/abs/quant-ph/0610099>`
+    This architecture can be found in `arXiv:quant-ph/0610099 <https://arxiv.org/abs/quant-ph/0610099>`_
     and closely resembles `quantum convolutional neural networks <https://arxiv.org/abs/1810.03787>`_.
 
     The argument ``block`` is a user-defined quantum circuit. Each ``block`` may depend on a different set of parameters.
@@ -157,7 +157,6 @@ class MERA(Operation):
         It may be necessary to reorder the wires to see the MERA architecture clearly:
 
         >>> print(qml.draw(circuit,expansion_strategy='device',wire_order=[2,0,1,3])(template_weights))
-
         2: ───────────────╭C──RY(0.10)──╭X──RY(-0.30)───────────────┤
         0: ─╭X──RY(-0.30)─│─────────────╰C──RY(0.10)──╭C──RY(0.10)──┤
         1: ─╰C──RY(0.10)──│─────────────╭X──RY(-0.30)─╰X──RY(-0.30)─┤  <Z>


### PR DESCRIPTION
In the documentation for the MERA template, a link wasn't rendering correctly and the output of the drawer had a extra blank line, removing code rendering for the output.