### PR TITLE
Fix qcut doc render

### DIFF
--- a/pennylane/transforms/qcut.py
+++ b/pennylane/transforms/qcut.py
@@ -763,7 +763,7 @@ def expand_fragment_tapes_mc(
 
         >>> configs, settings = qml.transforms.qcut.expand_fragment_tapes_mc(tapes, communication_graph, 3)
         >>> print(settings)
-        [[3 6 2]]
+        [[1 6 2]]
         >>> for i, (c1, c2) in enumerate(zip(configs[0], configs[1])):
         ...     print(f"config {i}:")
         ...     print(c1.draw())

--- a/pennylane/transforms/qcut.py
+++ b/pennylane/transforms/qcut.py
@@ -734,7 +734,7 @@ def expand_fragment_tapes_mc(
 
     Returns:
         Tuple[List[QuantumTape], np.ndarray]: the tapes corresponding to each configuration and the
-            settings that track each configuration pair
+        settings that track each configuration pair
 
     **Example**
 
@@ -763,7 +763,7 @@ def expand_fragment_tapes_mc(
 
         >>> configs, settings = qml.transforms.qcut.expand_fragment_tapes_mc(tapes, communication_graph, 3)
         >>> print(settings)
-        [[1 6 2]]
+        [[3 6 2]]
         >>> for i, (c1, c2) in enumerate(zip(configs[0], configs[1])):
         ...     print(f"config {i}:")
         ...     print(c1.draw())


### PR DESCRIPTION
**Context:**

Returns in one of the Qcut function does not render correctly, this PR fixes it.