### PR TITLE
Documentation fixes for the v0.23.0 release

### DIFF
--- a/doc/introduction/measurements.rst
+++ b/doc/introduction/measurements.rst
@@ -77,7 +77,7 @@ by a ``Hadamard`` and ``CNOT`` gate.
     import pennylane as qml
     from pennylane import numpy as np
 
-    dev = qml.device("default.qubit", wires=2)
+    dev = qml.device("default.qubit", wires=2, shots=1)
 
     @qml.qnode(dev)
     def circuit():
@@ -130,7 +130,7 @@ Probability
 
 You can also train QNodes on computational basis probabilities, by using
 the :func:`~.pennylane.probs` measurement function. The function can
-accept either specified ``wires`` or an observable that rotates the 
+accept either specified ``wires`` or an observable that rotates the
 computational basis.
 
 .. code-block:: python3

--- a/doc/introduction/measurements.rst
+++ b/doc/introduction/measurements.rst
@@ -77,7 +77,7 @@ by a ``Hadamard`` and ``CNOT`` gate.
     import pennylane as qml
     from pennylane import numpy as np
 
-    dev = qml.device("default.qubit", wires=2, shots=1)
+    dev = qml.device("default.qubit", wires=2, shots=1000)
 
     @qml.qnode(dev)
     def circuit():

--- a/pennylane/transforms/control.py
+++ b/pennylane/transforms/control.py
@@ -189,7 +189,7 @@ def ctrl(fn, control, control_values=None):
         fn (function): Any python function that applies pennylane operations.
         control (Wires): The control wire(s).
         control_values (int or list[int]): The value(s) the control wire(s) should take.
-            Integers other than x=0 or x=1 will treated as int(bool(x)).
+            Integers other than 0 or 1 will be treated as ``int(bool(x))``.
 
     Returns:
         function: A new function that applies the controlled equivalent of ``fn``. The returned

--- a/pennylane/transforms/control.py
+++ b/pennylane/transforms/control.py
@@ -188,7 +188,7 @@ def ctrl(fn, control, control_values=None):
     Args:
         fn (function): Any python function that applies pennylane operations.
         control (Wires): The control wire(s).
-        control_values (list[int]): The values the control wire(s) should take.
+        control_values (int or list[int]): The value(s) the control wire(s) should take.
 
     Returns:
         function: A new function that applies the controlled equivalent of ``fn``. The returned
@@ -240,7 +240,7 @@ def ctrl(fn, control, control_values=None):
 
     .. Note::
 
-        Some devices are able to take advantage of the inherient sparsity of a
+        Some devices are able to take advantage of the inherent sparsity of a
         controlled operation. In those cases, it may be more efficient to use
         this transform rather than adding controls by hand. For devices that don't
         have special control support, the operation is expanded to add control wires
@@ -255,8 +255,8 @@ def ctrl(fn, control, control_values=None):
         .. code-block:: python3
 
             # These two ops are equivalent.
-            op1 = qml.ctrl(qml.ctrl(my_ops, 1), 2)
-            op2 = qml.ctrl(my_ops, [2, 1])
+            op1 = qml.ctrl(qml.ctrl(ops, 1), 2)
+            op2 = qml.ctrl(ops, [2, 1])
 
         **Control Value Assignment**
 
@@ -264,16 +264,16 @@ def ctrl(fn, control, control_values=None):
 
         .. code-block:: python3
 
-            op = qml.ctrl(qml.ctrl(my_ops, 1), 2, control_values=0)
-            op()
+            op = qml.ctrl(ops, 2, control_values=0)
+            op(params=[0.1, 0.2])
 
         This is equivalent to the following.
 
         .. code-block:: python3
 
             qml.PauliX(wires=2)
-            op = qml.ctrl(qml.ctrl(my_ops, 1), 2)
-            op()
+            op = qml.ctrl(ops, 2)
+            op(params=[0.1, 0.2])
             qml.PauliX(wires=2)
 
     """

--- a/pennylane/transforms/control.py
+++ b/pennylane/transforms/control.py
@@ -189,6 +189,7 @@ def ctrl(fn, control, control_values=None):
         fn (function): Any python function that applies pennylane operations.
         control (Wires): The control wire(s).
         control_values (int or list[int]): The value(s) the control wire(s) should take.
+            Integers other than x=0 or x=1 will treated as int(bool(x)).
 
     Returns:
         function: A new function that applies the controlled equivalent of ``fn``. The returned

--- a/pennylane/transforms/qcut.py
+++ b/pennylane/transforms/qcut.py
@@ -1092,6 +1092,7 @@ def cut_circuit_mc(
         Consider the circuit below:
 
         .. code-block:: python
+
             np.random.seed(42)
 
             with qml.tape.QuantumTape() as tape:

--- a/pennylane/transforms/qcut.py
+++ b/pennylane/transforms/qcut.py
@@ -967,7 +967,7 @@ def cut_circuit_mc(
     Args:
         tape (QuantumTape): the tape of the full circuit to be cut
         classical_processing_fn (callable): A classical postprocessing function to be applied to
-            the reconstructed bitstrings. The expected input is a bitstring; a flat array of length ``wires``.
+            the reconstructed bitstrings. The expected input is a bitstring; a flat array of length ``wires``,
             and the output should be a single number within the interval :math:`[-1, 1]`.
             If not supplied, the transform will output samples.
         auto_cutter (Union[bool, Callable]): Toggle for enabling automatic cutting with the default
@@ -1092,6 +1092,7 @@ def cut_circuit_mc(
         Consider the circuit below:
 
         .. code-block:: python
+            np.random.seed(42)
 
             with qml.tape.QuantumTape() as tape:
                 qml.Hadamard(wires=0)
@@ -1126,9 +1127,9 @@ def cut_circuit_mc(
                 qml.sample(wires=[0, 1, 2])
 
         >>> cut_graph = qml.transforms.qcut.find_and_place_cuts(
-                graph=qml.transforms.qcut.tape_to_graph(uncut_tape),
-                cut_strategy=qml.transforms.qcut.CutStrategy(max_free_wires=2),
-            )
+        ...     graph=qml.transforms.qcut.tape_to_graph(uncut_tape),
+        ...     cut_strategy=qml.transforms.qcut.CutStrategy(max_free_wires=2),
+        ... )
         >>> print(qml.transforms.qcut.graph_to_tape(cut_graph).draw())
          0: ──H─╭C───────────┤  Sample[|1⟩⟨1|]
          1: ────╰X──//──X─╭C─┤  Sample[|1⟩⟨1|]
@@ -1187,11 +1188,11 @@ def cut_circuit_mc(
 
         >>> shots = 3
         >>> configurations, settings = qml.transforms.qcut.expand_fragment_tapes_mc(
-        ...        fragment_tapes, communication_graph, shots=shots
-        ...    )
+        ...     fragment_tapes, communication_graph, shots=shots
+        ... )
         >>> tapes = tuple(tape for c in configurations for tape in c)
         >>> settings
-        tensor([[0, 4, 7]], requires_grad=True)
+        tensor([[6, 3, 4]], requires_grad=True)
 
         Each configuration is drawn below:
 
@@ -1202,21 +1203,21 @@ def cut_circuit_mc(
         .. code-block::
 
             0: ──H─╭C────┤  Sample[|1⟩⟨1|]
-            1: ────╰X──X─┤  Sample[I]
+            1: ────╰X──X─┤  Sample[Z]
+
+            0: ──H─╭C────┤  Sample[|1⟩⟨1|]
+            1: ────╰X──X─┤  Sample[X]
 
             0: ──H─╭C────┤  Sample[|1⟩⟨1|]
             1: ────╰X──X─┤  Sample[Y]
 
-            0: ──H─╭C────┤  Sample[|1⟩⟨1|]
-            1: ────╰X──X─┤  Sample[Z]
-
             0: ──I─╭C─┤  Sample[|1⟩⟨1|]
             1: ────╰X─┤  Sample[|1⟩⟨1|]
 
-            0: ──H──S─╭C─┤  Sample[|1⟩⟨1|]
+            0: ──X──S─╭C─┤  Sample[|1⟩⟨1|]
             1: ───────╰X─┤  Sample[|1⟩⟨1|]
 
-            0: ──X─╭C─┤  Sample[|1⟩⟨1|]
+            0: ──H─╭C─┤  Sample[|1⟩⟨1|]
             1: ────╰X─┤  Sample[|1⟩⟨1|]
 
         The last step is to execute the tapes and postprocess the results using
@@ -1229,9 +1230,9 @@ def cut_circuit_mc(
         ...     communication_graph,
         ...     shots=shots,
         ... )
-        [array([[1., 0., 0.],
-                [0., 0., 0.],
-                [1., 1., 1.]])]
+        [array([[0., 0., 0.],
+                [1., 0., 0.],
+                [1., 0., 0.]])]
 
         Alternatively, it is possible to calculate an expectation value if a classical
         processing function is provided that will accept the reconstructed circuit bitstrings
@@ -1252,7 +1253,7 @@ def cut_circuit_mc(
         ...     shots,
         ...     fn
         ... )
-        array(4.)
+        array(-4.)
     """
     # pylint: disable=unused-argument, too-many-arguments
 


### PR DESCRIPTION
Contains fixes for:
- `qml.ctrl` docstring: non-existent variable, type declaration, spelling
- Bell example on [measurements page](https://pennylane.readthedocs.io/en/stable/introduction/measurements.html#combined-measurements) (fixes #2455)