### PR TITLE
[Bug] `Operation.has_matrix` incorrect when no matrix

### DIFF
--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -537,9 +537,7 @@ class Operator(abc.ABC):
 
         Note: Child classes may have this as an instance property instead of as a class property.
         """
-        return (cls.compute_matrix != Operator.compute_matrix) or (
-            cls.get_matrix != Operator.get_matrix
-        )
+        return cls.compute_matrix != Operator.compute_matrix
 
     @property
     def matrix(self):

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -161,18 +161,6 @@ class TestOperatorConstruction:
         assert MyOp.has_matrix
         assert MyOp(wires=0).has_matrix
 
-    def test_has_matrix_true_get_matrix(self):
-        """Test has_matrix property also detects overriding of `get_matrix` method."""
-
-        class MyOp(qml.operation.Operator):
-            num_wires = 1
-
-            def get_matrix(self):
-                return np.eye(2)
-
-        assert MyOp.has_matrix
-        assert MyOp(wires=0).has_matrix
-
     def test_has_matrix_false(self):
         """Test has_matrix property defaults to false if `compute_matrix` not overwritten."""
 
@@ -181,6 +169,16 @@ class TestOperatorConstruction:
 
         assert not MyOp.has_matrix
         assert not MyOp(wires=0).has_matrix
+
+    def test_has_matrix_false_concrete_template(self):
+        """Test has_matrix with a concrete operation (StronglyEntanglingLayers)
+        that does not have a matrix defined."""
+
+        rng = qml.numpy.random.default_rng(seed=42)
+        shape = qml.StronglyEntanglingLayers.shape(n_layers=2, n_wires=2)
+        params = rng.random(shape)
+        op = qml.StronglyEntanglingLayers(params, wires=range(2))
+        assert not op.has_matrix
 
 
 class TestOperationConstruction:


### PR DESCRIPTION
Currently, `Operator.has_matrix` detects whether or not either `compute_matrix` or `get_matrix` is overridden from the `Operator` version.  As `Operation` itself overrides `compute_matrix`, everything inheriting from `Operation` seemed to have a matrix defined.  This led to incorrect results for a number of templates.