### PR TITLE
Use `qml.eigvals` in `qml.transforms.transpile` to have no deprecation warning

### DIFF
--- a/pennylane/transforms/transpile.py
+++ b/pennylane/transforms/transpile.py
@@ -4,6 +4,7 @@ Contains the transpiler transform.
 from typing import Union, List
 import networkx as nx
 
+import pennylane as qml
 from pennylane import apply, Hamiltonian
 from pennylane.ops.qubit import SWAP
 from pennylane.operation import Tensor
@@ -172,7 +173,7 @@ def _adjust_mmt_indices(_m, _map_wires):
 
     # change wires of observable
     if _m.obs is None:
-        return type(_m)(return_type=_m.return_type, eigvals=_m.eigvals, wires=_new_wires)
+        return type(_m)(return_type=_m.return_type, eigvals=qml.eigvals(_m), wires=_new_wires)
 
     _new_obs = type(_m.obs)(wires=_new_wires, id=_m.obs.id)
     return type(_m)(return_type=_m.return_type, obs=_new_obs)


### PR DESCRIPTION
Use `qml.eigvals` because `MeasurementProcess.eigvals` is being deprecated and a warning is raised when the transpile transform is used.

```py
  dev = qml.device('default.qubit', wires=4)

  @qml.qnode(dev)
  @qml.transforms.transpile(coupling_map=[(0, 1), (1, 2), (2, 3)])
  def circuit(param):
      qml.CNOT(wires=[0, 1])
      qml.CNOT(wires=[0, 2])
      qml.CNOT(wires=[0, 3])
      qml.PhaseShift(param, wires=0)
      return qml.probs(wires=[0, 1, 2, 3])
```
![image](https://user-images.githubusercontent.com/24476053/164547506-0f399c40-60e0-4504-8da5-21149f2ad7e8.png)