### PR TITLE
Issue a warning about repeated cached executions with shot noise

### DIFF
--- a/doc/releases/changelog-0.23.0.md
+++ b/doc/releases/changelog-0.23.0.md
@@ -444,6 +444,9 @@
   accessed via the top-level `qml` namespace.
   [(#2396)](https://github.com/PennyLaneAI/pennylane/pull/2396)
 
+* Raise a warning where caching produces identical shot noise on execution results with finite shots.
+  [(#2478)](https://github.com/PennyLaneAI/pennylane/pull/2478)
+
 <h3>Deprecations</h3>
 
 <h3>Breaking changes</h3>

--- a/pennylane/interfaces/execution.py
+++ b/pennylane/interfaces/execution.py
@@ -21,8 +21,8 @@ devices with autodifferentiation support.
 # pylint: disable=import-outside-toplevel,too-many-arguments,too-many-branches,not-callable
 from functools import wraps
 import itertools
-from cachetools import LRUCache
 import warnings
+from cachetools import LRUCache
 
 import pennylane as qml
 

--- a/pennylane/interfaces/execution.py
+++ b/pennylane/interfaces/execution.py
@@ -124,13 +124,13 @@ def cache_execute(fn, cache, pass_kwargs=False, return_tuple=True, expand_fn=Non
                 cached_results[i] = cache[hashes[i]]
                 # Introspect the set_shots decorator of the input function:
                 # warn the user in case of finite shots with cached results
-                finite_shots=False
+                finite_shots = False
                 for var in fn.__closure__:  # retrieve captured context manager instance
                     if isinstance(var.cell_contents, contextlib._GeneratorContextManager):
                         # retrieve device instance from set_shots arguments
                         for arg in var.cell_contents.args:
                             if isinstance(arg, Device):
-                                finite_shots=isinstance(arg.shots, int)
+                                finite_shots = isinstance(arg.shots, int)
                 if finite_shots:
                     warnings.warn(
                         "Cached execution with finite shots detected: note that the shot noise "

--- a/pennylane/interfaces/execution.py
+++ b/pennylane/interfaces/execution.py
@@ -122,8 +122,10 @@ def cache_execute(fn, cache, pass_kwargs=False, return_tuple=True, expand_fn=Non
             if hashes[i] in cache:
                 # Tape exists within the cache, store the cached result
                 cached_results[i] = cache[hashes[i]]
+
                 # Introspect the set_shots decorator of the input function:
-                # warn the user in case of finite shots with cached results
+                #   warn the user in case of finite shots with cached results
+                # pylint: disable=protected-access
                 finite_shots = False
                 for var in fn.__closure__:  # retrieve captured context manager instance
                     if isinstance(var.cell_contents, contextlib._GeneratorContextManager):

--- a/pennylane/interfaces/execution.py
+++ b/pennylane/interfaces/execution.py
@@ -141,8 +141,12 @@ def cache_execute(fn, cache, pass_kwargs=False, return_tuple=True, expand_fn=Non
 
                 if finite_shots:
                     warnings.warn(
-                        "Cached execution with finite shots detected: note that the shot noise "
-                        "will be the same on all results from executions with identical arguments.",
+                        "Cached execution with finite shots detected!\n"
+                        "Note that samples as well as all noisy quantities computed via sampling "
+                        "will be identical across executions. This situation arises where tapes "
+                        "are executed with identical operations, measurements, and parameters.\n"
+                        "To avoid this behavior, provide 'cache=False' to the QNode or execution "
+                        "function.",
                         UserWarning,
                     )
             else:

--- a/pennylane/interfaces/execution.py
+++ b/pennylane/interfaces/execution.py
@@ -317,18 +317,12 @@ def execute(
         if "passthru_interface" in device.capabilities():
             return batch_fn(
                 qml.interfaces.cache_execute(
-                    batch_execute,
-                    cache,
-                    return_tuple=False,
-                    expand_fn=expand_fn,
+                    batch_execute, cache, return_tuple=False, expand_fn=expand_fn
                 )(tapes)
             )
         with qml.tape.Unwrap(*tapes):
             res = qml.interfaces.cache_execute(
-                batch_execute,
-                cache,
-                return_tuple=False,
-                expand_fn=expand_fn,
+                batch_execute, cache, return_tuple=False, expand_fn=expand_fn
             )(tapes)
 
         return batch_fn(res)
@@ -336,10 +330,7 @@ def execute(
     if gradient_fn == "backprop" or interface is None:
         return batch_fn(
             qml.interfaces.cache_execute(
-                batch_execute,
-                cache,
-                return_tuple=False,
-                expand_fn=expand_fn,
+                batch_execute, cache, return_tuple=False, expand_fn=expand_fn
             )(tapes)
         )
 

--- a/tests/test_qnode.py
+++ b/tests/test_qnode.py
@@ -14,6 +14,7 @@
 """Unit tests for the QNode"""
 from collections import defaultdict
 import pytest
+import warnings
 import numpy as np
 from scipy.sparse import coo_matrix
 
@@ -1091,6 +1092,34 @@ class TestShots:
         res = circuit(0.8, shots=2)
         assert len(res) == 2
         assert dev.shots == 3
+
+    def test_warning_finite_shots_dev(self):
+        """Tests that a warning is raised when caching is used with finite shots."""
+        dev = qml.device("default.qubit", wires=2, shots=5)
+
+        @qml.qnode(dev, cache={})
+        def circuit(x):
+            qml.RZ(x, wires=0)
+            return qml.expval(qml.PauliZ(0))
+
+        # no warning on the first execution
+        circuit(0.3)
+        with pytest.warns(UserWarning, match="Cached execution with finite shots detected"):
+            circuit(0.3)
+
+    def test_warning_finite_shots_override(self):
+        """Tests that a warning is raised when caching is used with finite shots."""
+        dev = qml.device("default.qubit", wires=2)
+
+        @qml.qnode(dev, cache={})
+        def circuit(x):
+            qml.RZ(x, wires=0)
+            return qml.expval(qml.PauliZ(0))
+
+        # no warning on the first execution
+        circuit(0.3)
+        with pytest.warns(UserWarning, match="Cached execution with finite shots detected"):
+            circuit(0.3, shots=5)
 
 
 @pytest.mark.xfail


### PR DESCRIPTION
Closes #2150

Raises the following warning when a QNode is executed repeatedly with caching turned on and shot noise enabled: 

```
UserWarning: Cached execution with finite shots detected: note that the shot noise will be the same on all results from executions with identical arguments.
```

Example:

```py
import pennylane as qml
from pennylane import numpy as np

params = np.random.randn(2, 2, 3)
observable_as_array = np.array([[ 1. +0.j,  0. +0.j,  0. +0.j,  0. +0.j],
                                [ 0. +0.j,  0.4+0.j, 21.6+0.j,  0. +0.j],
                                [ 0. +0.j, 21.6+0.j, -0.4+0.j,  0. +0.j],
                                [ 0. +0.j,  0. +0.j,  0. +0.j, -1. +0.j]])

dev = qml.device('default.qubit', wires=2, shots=42)
@qml.qnode(dev, diff_method='parameter-shift', cache={})
def circuit(params):
    qml.templates.layers.StronglyEntanglingLayers(params, wires=range(dev.num_wires))
    return qml.expval(qml.Hermitian(observable_as_array, wires=range(dev.num_wires)))

print(circuit(params))  # no warning on first execution
print(circuit(params))  # emit warning
```
