### PR TITLE
Warn upon import of an `ObservableReturnType` from operation instead of measurements

### DIFF
--- a/pennylane/__init__.py
+++ b/pennylane/__init__.py
@@ -28,6 +28,7 @@ from pennylane.queuing import apply, QueuingContext
 import pennylane.fourier
 import pennylane.kernels
 import pennylane.math
+import pennylane.measurements
 import pennylane.operation
 import pennylane.qnn
 import pennylane.templates

--- a/pennylane/measurements.py
+++ b/pennylane/measurements.py
@@ -28,7 +28,6 @@ from typing import Generic, TypeVar
 import numpy as np
 
 import pennylane as qml
-from pennylane.operation import Observable
 from pennylane.wires import Wires
 
 # =============================================================================
@@ -494,7 +493,7 @@ def expval(op):
     Raises:
         QuantumFunctionError: `op` is not an instance of :class:`~.Observable`
     """
-    if not isinstance(op, (Observable, qml.Hamiltonian)):
+    if not isinstance(op, (qml.operation.Observable, qml.Hamiltonian)):
         raise qml.QuantumFunctionError(
             f"{op.name} is not an observable: cannot be used with expval"
         )
@@ -529,7 +528,7 @@ def var(op):
     Raises:
         QuantumFunctionError: `op` is not an instance of :class:`~.Observable`
     """
-    if not isinstance(op, Observable):
+    if not isinstance(op, qml.operation.Observable):
         raise qml.QuantumFunctionError(f"{op.name} is not an observable: cannot be used with var")
 
     return MeasurementProcess(Variance, obs=op, shape=(1,), numeric_type=float)
@@ -607,7 +606,7 @@ def sample(op=None, wires=None):
         case ``qml.sample(obs)`` is interpreted as a single-shot expectation value of the
         observable ``obs``.
     """
-    if not isinstance(op, Observable) and op is not None:  # None type is also allowed for op
+    if not isinstance(op, qml.operation.Observable) and op is not None:  # None type is also allowed for op
         raise qml.QuantumFunctionError(
             f"{op.name} is not an observable: cannot be used with sample"
         )

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -109,6 +109,18 @@ from pennylane.wires import Wires
 
 from .utils import pauli_eigs
 
+def __getattr__(name):
+    warning_names = {"Sample", "Variance", "Expectation", "Probability", "State", "MidMeasure"}
+    if name in warning_names:
+        obj = getattr(qml.measurements, name)
+        warning_string = f"qml.operation.{name} is deprecated. Please import from qml.measurements.{name} instead"
+        warnings.warn(warning_string, UserWarning)
+        return obj
+    try:
+        return globals()[name]
+    except KeyError as e:
+        raise AttributeError from e 
+
 
 def expand_matrix(base_matrix, wires, wire_order):
     """Re-express a base matrix acting on a subspace defined by a set of wire labels

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -33,6 +33,15 @@ from pennylane.wires import Wires
 # pylint: disable=no-self-use, no-member, protected-access, pointless-statement
 
 
+@pytest.mark.parametrize(
+    "return_type", ("Sample", "Variance", "Expectation", "Probability", "State", "MidMeasure")
+)
+def test_obersvablereturntypes_import_warnings(return_type):
+
+    with pytest.warns(UserWarning, match=r"is deprecated"):
+        getattr(qml.operation, return_type)
+
+
 class TestOperatorConstruction:
     """Test custom operators construction."""
 


### PR DESCRIPTION
This last release cycle moved `Sample`, `Variance`, `Expectation`, `Probability`, `State`, and `MidMeasure` to the `measurements` module instead of the `operation` module.

As some plugins rely on these objects, we are adding a deprecation cycle with `UserWarning`'s to aid the transition. Now, if someone calls something like `qml.operation.Sample`, a user warning is raised.