### PR TITLE
Fix QChem documentation

### DIFF
--- a/doc/code/qml_qchem.rst
+++ b/doc/code/qml_qchem.rst
@@ -10,26 +10,10 @@ number observables.
 
 .. currentmodule:: pennylane.qchem
 
-.. rubric:: Modules
-
-.. autosummary::
-    :toctree: api
-
-    basis_data
-    basis_set
-    convert
-    dipole
-    hamiltonian
-    hartree_fock
-    integrals
-    matrices
-    molecule
-    number
-    observable_hf
-    openfermion_obs
-    spin
-    structure
-    tapering
+.. automodapi:: pennylane.qchem
+    :no-heading:
+    :include-all-objects:
+    :no-inheritance-diagram:
 
 Differentiable Hartree-Fock
 ---------------------------

--- a/pennylane/qchem/openfermion_obs.py
+++ b/pennylane/qchem/openfermion_obs.py
@@ -816,9 +816,6 @@ def molecular_hamiltonian(
     This function drives the construction of the second-quantized electronic Hamiltonian
     of a molecule and its transformation to the basis of Pauli matrices.
 
-    The `method` can be either "dhf", which uses an in-built differentiable Hartree-Fock solver, or
-    "pyscf", which uses the OpenFermion-PySCF plugin.
-
     The net charge of the molecule can be given to simulate cationic/anionic systems. Also, the
     spin multiplicity can be input to determine the number of unpaired electrons occupying the HF
     orbitals as illustrated in the left panel of the figure below.
@@ -828,9 +825,6 @@ def molecular_hamiltonian(
 
     An active space can be defined for a given number of *active electrons* occupying a reduced set
     of *active orbitals* as sketched in the right panel of the figure below.
-
-    The atomic coordinates must be in atomic units and could be given as a 1D array of
-    size ``3*N`` or a 2D array of shape ``(N, 3)`` where ``N`` is the number of atoms.
 
     |
 
@@ -842,7 +836,9 @@ def molecular_hamiltonian(
 
     Args:
         symbols (list[str]): symbols of the atomic species in the molecule
-        coordinates (array[float]): atomic positions in Cartesian coordinates and in atomic units
+        coordinates (array[float]): atomic positions in Cartesian coordinates.
+            The atomic coordinates must be in atomic units and can be given as either a 1D array of
+            size ``3*N``, or a 2D array of shape ``(N, 3)`` where ``N`` is the number of atoms.
         name (str): name of the molecule
         charge (int): Net charge of the molecule. If not specified a neutral system is assumed.
         mult (int): Spin multiplicity :math:`\mathrm{mult}=N_\mathrm{unpaired} + 1`
@@ -850,8 +846,10 @@ def molecular_hamiltonian(
             Possible values of ``mult`` are :math:`1, 2, 3, \ldots`. If not specified,
             a closed-shell HF state is assumed.
         basis (str): atomic basis set used to represent the molecular orbitals
-        method (str): quantum chemistry method used to solve the
-            mean field electronic structure problem
+        method (str): Quantum chemistry method used to solve the
+            mean field electronic structure problem. Available options are ``method="dhf"``
+            to specify the built-in differentiable Hartree-Fock solver, or ``method="pyscf"``
+            to use the OpenFermion-PySCF plugin (this requires that ``openfermionpyscf`` be installed).
         active_electrons (int): Number of active electrons. If not specified, all electrons
             are considered to be active.
         active_orbitals (int): Number of active orbitals. If not specified, all orbitals
@@ -859,7 +857,7 @@ def molecular_hamiltonian(
         mapping (str): transformation used to map the fermionic Hamiltonian to the qubit Hamiltonian
         outpath (str): path to the directory containing output files
         wires (Wires, list, tuple, dict): Custom wire mapping for connecting to Pennylane ansatz.
-            For types Wires/list/tuple, each item in the iterable represents a wire label
+            For types ``Wires``/``list``/``tuple``, each item in the iterable represents a wire label
             corresponding to the qubit number equal to its index.
             For type dict, only int-keyed dict (for qubit-to-wire conversion) is accepted for
             partial mapping. If None, will use identity map.


### PR DESCRIPTION
**Context:** The new qchem API page was not correctly listing available functions. The `molecular_hamiltonian` function also had a few rendering errors.

**Description of the Change:** Modifies the `qchem.rst` so that it lists available functions according to import location.

**Benefits:** Easier to navigate the documentation.

**Possible Drawbacks:** Not sure if anything is being listed that we don't want to appear in the documentation. If this is the case, we should not be importing these functions/classes into `pennylane/qchem/__init__.py`.

Alternatively, if you want to organize these functions, you could replace the `automodapi` with `autosummary`, and manually list which functions to document.

@soranjh one more question: the function to import operators, `qml.qchem.import_operator`. I thought it was originally going to be accessible top-level in PL?

**Related GitHub Issues:** n/a.
