### PR TITLE
Remove `hf` dependency in qubit tapering

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -32,6 +32,9 @@
   This is a temporary fix that will disappear in the future. 
   [(#2408)](https://github.com/PennyLaneAI/pennylane/pull/2408)
 
+* The `qml.taper` function can now be used to consistently taper any additional observables such as dipole moment,
+  particle number, and spin operators using the symmetries obtained from the Hamiltonian.
+  [(#2510)](https://github.com/PennyLaneAI/pennylane/pull/2510)
   
 <h3>Breaking changes</h3>
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -46,4 +46,4 @@
 
 This release contains contributions from (in alphabetical order):
 
-Christian Gogolin, Christina Lee
+Utkarsh Azad, Christian Gogolin, Christina Lee

--- a/pennylane/qchem/observable_hf.py
+++ b/pennylane/qchem/observable_hf.py
@@ -138,7 +138,7 @@ def jordan_wigner(op):
     >>> f  = [0, 0]
     >>> q = jordan_wigner(f)
     >>> q
-    ([(0.5+0j), (-0.5+0j)], [[], [(0, 'Z')]]) # corresponds to :math:`\frac{1}{2}(I_0 - Z_0)`
+    ([(0.5+0j), (-0.5+0j)], [Identity(wires=[0]), PauliZ(wires=[0])]) # corresponds to :math:`\frac{1}{2}(I_0 - Z_0)`
     """
     if len(op) == 1:
         op = [((op[0], 1),)]

--- a/tests/qchem/hf_tests/test_tapering.py
+++ b/tests/qchem/hf_tests/test_tapering.py
@@ -589,17 +589,15 @@ def test_transform_hf(generators, paulixops, paulix_sector, num_electrons, num_w
         ),
     ],
 )
-def test_hf_energy(symbols, geometry, charge):
-    r"""Test that HF energy obtained from the tapered Hamiltonian and tapered Hartree Fock state
-    is consistent."""
+def test_taper_obs(symbols, geometry, charge):
+    r"""Test that values obtained from the tapered observables and tapered Hartree Fock state
+    are consistent."""
     mol = qml.qchem.Molecule(symbols, geometry, charge)
     hamiltonian = qml.qchem.diff_hamiltonian(mol)(geometry)
     hf_state = np.where(np.arange(len(hamiltonian.wires)) < mol.n_electrons, 1, 0)
     generators = qml.symmetry_generators(hamiltonian)
     paulixops = qml.paulix_ops(generators, len(hamiltonian.wires))
     paulix_sector = optimal_sector(hamiltonian, generators, mol.n_electrons)
-
-    hamiltonian_tapered = qml.taper(hamiltonian, generators, paulixops, paulix_sector)
     hf_state_tapered = taper_hf(
         generators, paulixops, paulix_sector, mol.n_electrons, len(hamiltonian.wires)
     )
@@ -612,15 +610,22 @@ def test_hf_energy(symbols, geometry, charge):
         lambda i, j: np.kron(i, j), [l if s else o for s in hf_state_tapered]
     )
 
-    energy = (
-        scipy.sparse.coo_matrix(state)
-        @ qml.utils.sparse_hamiltonian(hamiltonian)
-        @ scipy.sparse.coo_matrix(state).T
-    ).toarray()
-    energy_tapered = (
-        scipy.sparse.coo_matrix(state_tapered)
-        @ qml.utils.sparse_hamiltonian(hamiltonian_tapered)
-        @ scipy.sparse.coo_matrix(state_tapered).T
-    ).toarray()
-
-    assert np.isclose(energy, energy_tapered)
+    observables = [
+        hamiltonian,
+        qml.qchem.particle_number(len(hamiltonian.wires)),
+        qml.qchem.spin2(mol.n_electrons, len(hamiltonian.wires)),
+        qml.qchem.spinz(len(hamiltonian.wires)),
+    ]
+    for observable in observables:
+        tapered_obs = qml.taper(observable, generators, paulixops, paulix_sector)
+        obs_val = (
+            scipy.sparse.coo_matrix(state)
+            @ qml.utils.sparse_hamiltonian(observable)
+            @ scipy.sparse.coo_matrix(state).T
+        ).toarray()
+        obs_val_tapered = (
+            scipy.sparse.coo_matrix(state_tapered)
+            @ qml.utils.sparse_hamiltonian(tapered_obs)
+            @ scipy.sparse.coo_matrix(state_tapered).T
+        ).toarray()
+        assert np.isclose(obs_val, obs_val_tapered)

--- a/tests/qchem/hf_tests/test_tapering.py
+++ b/tests/qchem/hf_tests/test_tapering.py
@@ -590,8 +590,8 @@ def test_transform_hf(generators, paulixops, paulix_sector, num_electrons, num_w
     ],
 )
 def test_taper_obs(symbols, geometry, charge):
-    r"""Test that values obtained from the tapered observables and tapered Hartree Fock state
-    are consistent."""
+    r"""Test that the expectation values of tapered observables with respect to the
+    tapered Hartree Fock state (:math:`\langle HF|obs|HF \rangle`) are consistent."""
     mol = qml.qchem.Molecule(symbols, geometry, charge)
     hamiltonian = qml.qchem.diff_hamiltonian(mol)(geometry)
     hf_state = np.where(np.arange(len(hamiltonian.wires)) < mol.n_electrons, 1, 0)

--- a/tests/qchem/hf_tests/test_tapering.py
+++ b/tests/qchem/hf_tests/test_tapering.py
@@ -591,7 +591,7 @@ def test_transform_hf(generators, paulixops, paulix_sector, num_electrons, num_w
 )
 def test_taper_obs(symbols, geometry, charge):
     r"""Test that the expectation values of tapered observables with respect to the
-    tapered Hartree Fock state (:math:`\langle HF|obs|HF \rangle`) are consistent."""
+    tapered Hartree-Fock state (:math:`\langle HF|obs|HF \rangle`) are consistent."""
     mol = qml.qchem.Molecule(symbols, geometry, charge)
     hamiltonian = qml.qchem.diff_hamiltonian(mol)(geometry)
     hf_state = np.where(np.arange(len(hamiltonian.wires)) < mol.n_electrons, 1, 0)


### PR DESCRIPTION
**Context:**
This PR removes the dependency of `_generate_qubit_operator` from the `hf` module. It also adds a consistency check to manually add wires to the tapered observable if some go missing due to the `simplify()` routine. 

**Description of the Change:**
1. Replaces `_generate_qubit_operator` from `hf` module with the `jordan_wigner` from unified `qchem` module.
2. Adds consistency check for tapered wires in`qml.taper`. This allows us to return consistent observables in the case of tapering of non-Hamiltonian observables. 
3. Replaced the `test_hf_energy` unittest with a newer `test_taper_obs` unittest that uses the above consistency check.
4. Fix a minor documentation issue with `jordan_wigner`.

**Benefits:**
Removes dependency for the deprecated `hf` module and addresses wires consistency issue with empty simplified tapered observables.

**Possible Drawbacks:**
None.

**Related GitHub Issues:**
None.