### PR TITLE
Raise an error for `AnyWires` if empty list was passed as `wires`

### DIFF
--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -923,7 +923,11 @@ class Operator(abc.ABC):
                 f"{len(self._wires)} wires given, {self.num_wires} expected."
             )
 
-        if self.num_wires is AnyWires and len(self._wires) == 0:
+        if (
+            self.num_wires is AnyWires
+            and not getattr(self, "no_wires_ok", False)
+            and len(self._wires) == 0
+        ):
             raise ValueError(
                 f"{self.name}: wrong number of wires. " f"At least one wire has to be given."
             )

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -923,6 +923,11 @@ class Operator(abc.ABC):
                 f"{len(self._wires)} wires given, {self.num_wires} expected."
             )
 
+        if self.num_wires is AnyWires and len(self._wires) == 0:
+            raise ValueError(
+                f"{self.name}: wrong number of wires. " f"At least one wire has to be given."
+            )
+
         self.data = list(params)  #: list[Any]: parameters of the operator
 
         if do_queue:
@@ -1114,8 +1119,10 @@ class Operator(abc.ABC):
 
             except TypeError:
                 if self.num_params == 0:
+                    # pylint:disable=unexpected-keyword-arg
                     self.decomposition(wires=self.wires)
                 else:
+                    # pylint:disable=unexpected-keyword-arg
                     self.decomposition(*self.parameters, wires=self.wires)
 
                 warnings.warn(
@@ -1129,6 +1136,7 @@ class Operator(abc.ABC):
             # original operation has no trainable parameters
             tape.trainable_params = {}
 
+        # pylint:disable=no-member
         if self.inverse:
             tape.inv()
 
@@ -2447,6 +2455,7 @@ def has_nopar(obj):
 def has_unitary_gen(obj):
     """Returns ``True`` if an operator has a unitary_generator
     according to the ``has_unitary_generator`` flag."""
+    # pylint:disable=no-member
     return obj in qml.ops.qubit.attributes.has_unitary_generator
 
 

--- a/pennylane/ops/qubit/hamiltonian.py
+++ b/pennylane/ops/qubit/hamiltonian.py
@@ -160,6 +160,7 @@ class Hamiltonian(Observable):
     """
 
     num_wires = qml.operation.AnyWires
+    no_wires_valid = True
     grad_method = "A"  # supports analytic gradients
 
     def __init__(

--- a/pennylane/ops/qubit/non_parametric_ops.py
+++ b/pennylane/ops/qubit/non_parametric_ops.py
@@ -2016,9 +2016,10 @@ class Barrier(Operation):
     num_wires = AnyWires
     par_domain = None
 
-    def __init__(self, only_visual=False, wires=Wires([]), do_queue=True, id=None):
+    def __init__(self, wires=Wires([]), only_visual=False, do_queue=True, id=None):
         self.only_visual = only_visual
         self.hyperparameters["only_visual"] = only_visual
+
         super().__init__(wires=wires, do_queue=do_queue, id=id)
 
     @staticmethod

--- a/pennylane/ops/snapshot.py
+++ b/pennylane/ops/snapshot.py
@@ -58,6 +58,7 @@ class Snapshot(Operation):
     .. seealso:: :func:`~.snapshots`
     """
     num_wires = AnyWires
+    no_wires_valid = True
     num_params = 0
     grad_method = None
 


### PR DESCRIPTION
**Context:**

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**

Closes #2496