### PR TITLE
QNGOptimizer_Hamiltonian 

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -35,6 +35,12 @@
   
 <h3>Breaking changes</h3>
 
+<h3>Bug fixes</h3>
+
+* `QNGOptimizer` did not work with operators whose generator was a Hamiltonian.
+  [(#2524)](https://github.com/PennyLaneAI/pennylane/pull/2524)
+
+
 <h3>Deprecations</h3>
 
 <h3>Documentation</h3>
@@ -43,4 +49,4 @@
 
 This release contains contributions from (in alphabetical order):
 
-Christian Gogolin, Christina Lee
+Guillermo Alonso-Linaje, Christian Gogolin, Christina Lee

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -40,7 +40,8 @@
 
 <h3>Bug fixes</h3>
 
-* `QNGOptimizer` did not work with operators whose generator was a Hamiltonian.
+* Fixed a bug where `QNGOptimizer` did not work with operators
+  whose generator was a Hamiltonian.
   [(#2524)](https://github.com/PennyLaneAI/pennylane/pull/2524)
 
 

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -2490,7 +2490,7 @@ def gen_is_multi_term_hamiltonian(obj):
     except (AttributeError, OperatorPropertyUndefined, GeneratorUndefinedError):
         return False
 
-    if type(o) == qml.Hamiltonian:
+    if isinstance(o, qml.Hamiltonian):
         if len(o.coeffs) > 1:
             return True
     return False

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -2478,3 +2478,14 @@ def defines_diagonalizing_gates(obj):
         except DiagGatesUndefinedError:
             return False
         return True
+
+
+@qml.BooleanFn
+def gen_is_hamiltonian(obj):
+    """Returns ``True`` if an operator has a generator defined and it is a Hamiltonian."""
+    try:
+        o = obj.generator()
+    except (AttributeError, OperatorPropertyUndefined, GeneratorUndefinedError):
+        return False
+
+    return type(o) == qml.Hamiltonian

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -2481,7 +2481,7 @@ def defines_diagonalizing_gates(obj):
 
 
 @qml.BooleanFn
-def gen_is_hamiltonian(obj):
+def gen_is_multi_term_hamiltonian(obj):
     """Returns ``True`` if an operator has a generator defined and it is a Hamiltonian
     with more than one term."""
 

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -2482,10 +2482,15 @@ def defines_diagonalizing_gates(obj):
 
 @qml.BooleanFn
 def gen_is_hamiltonian(obj):
-    """Returns ``True`` if an operator has a generator defined and it is a Hamiltonian."""
+    """Returns ``True`` if an operator has a generator defined and it is a Hamiltonian
+    with more than one term."""
+
     try:
         o = obj.generator()
     except (AttributeError, OperatorPropertyUndefined, GeneratorUndefinedError):
         return False
 
-    return type(o) == qml.Hamiltonian
+    if type(o) == qml.Hamiltonian:
+        if len(o.coeffs) > 1:
+            return True
+    return False

--- a/pennylane/transforms/tape_expand.py
+++ b/pennylane/transforms/tape_expand.py
@@ -188,10 +188,7 @@ Returns:
 
 expand_nonunitary_gen = create_expand_fn(
     depth=10,
-    stop_at=not_tape
-    | is_measurement
-    | has_nopar
-    | (has_gen & has_unitary_gen),
+    stop_at=not_tape | is_measurement | has_nopar | (has_gen & has_unitary_gen),
     docstring=_expand_nonunitary_gen_doc,
 )
 

--- a/pennylane/transforms/tape_expand.py
+++ b/pennylane/transforms/tape_expand.py
@@ -19,7 +19,7 @@ import contextlib
 import pennylane as qml
 from pennylane.operation import (
     has_gen,
-    gen_is_hamiltonian,
+    gen_is_multi_term_hamiltonian,
     has_grad_method,
     has_nopar,
     has_unitary_gen,
@@ -137,7 +137,7 @@ Returns:
 
 expand_multipar = create_expand_fn(
     depth=10,
-    stop_at=not_tape | is_measurement | has_nopar | (has_gen & ~gen_is_hamiltonian),
+    stop_at=not_tape | is_measurement | has_nopar | (has_gen & ~gen_is_multi_term_hamiltonian),
     docstring=_expand_multipar_doc,
 )
 
@@ -164,7 +164,7 @@ expand_trainable_multipar = create_expand_fn(
     | is_measurement
     | has_nopar
     | (~is_trainable)
-    | (has_gen & ~gen_is_hamiltonian),
+    | (has_gen & ~gen_is_multi_term_hamiltonian),
     docstring=_expand_trainable_multipar_doc,
 )
 

--- a/pennylane/transforms/tape_expand.py
+++ b/pennylane/transforms/tape_expand.py
@@ -19,6 +19,7 @@ import contextlib
 import pennylane as qml
 from pennylane.operation import (
     has_gen,
+    gen_is_hamiltonian,
     has_grad_method,
     has_nopar,
     has_unitary_gen,
@@ -136,7 +137,7 @@ Returns:
 
 expand_multipar = create_expand_fn(
     depth=10,
-    stop_at=not_tape | is_measurement | has_nopar | has_gen,
+    stop_at=not_tape | is_measurement | has_nopar | (has_gen & ~gen_is_hamiltonian),
     docstring=_expand_multipar_doc,
 )
 
@@ -159,7 +160,11 @@ Returns:
 
 expand_trainable_multipar = create_expand_fn(
     depth=10,
-    stop_at=not_tape | is_measurement | has_nopar | (~is_trainable) | has_gen,
+    stop_at=not_tape
+    | is_measurement
+    | has_nopar
+    | (~is_trainable)
+    | (has_gen & ~gen_is_hamiltonian),
     docstring=_expand_trainable_multipar_doc,
 )
 
@@ -183,7 +188,10 @@ Returns:
 
 expand_nonunitary_gen = create_expand_fn(
     depth=10,
-    stop_at=not_tape | is_measurement | has_nopar | (has_gen & has_unitary_gen),
+    stop_at=not_tape
+    | is_measurement
+    | has_nopar
+    | ((has_gen & ~gen_is_hamiltonian) & has_unitary_gen),
     docstring=_expand_nonunitary_gen_doc,
 )
 

--- a/pennylane/transforms/tape_expand.py
+++ b/pennylane/transforms/tape_expand.py
@@ -191,7 +191,7 @@ expand_nonunitary_gen = create_expand_fn(
     stop_at=not_tape
     | is_measurement
     | has_nopar
-    | ((has_gen & ~gen_is_hamiltonian) & has_unitary_gen),
+    | (has_gen & has_unitary_gen),
     docstring=_expand_nonunitary_gen_doc,
 )
 

--- a/tests/optimize/test_qng.py
+++ b/tests/optimize/test_qng.py
@@ -72,6 +72,31 @@ class TestOptimize:
         assert np.allclose(step1, expected_step)
         assert np.allclose(step2, expected_step)
 
+    def test_step_and_cost_autograd_with_gen_hamiltonian(self, tol):
+        """Test that the correct cost and step is returned via the
+        step_and_cost method for the QNG optimizer when the generator
+        of an operator is a Hamiltonian"""
+
+        dev = qml.device("default.qubit", wires=4)
+
+        @qml.qnode(dev)
+        def circuit(params):
+            qml.DoubleExcitation(params[0], wires=[0, 1, 2, 3])
+            qml.RY(params[1], wires=0)
+            return qml.expval(qml.PauliZ(0))
+
+        var = np.array([0.011, 0.012])
+        opt = qml.QNGOptimizer(stepsize=0.01)
+
+        step1, res = opt.step_and_cost(circuit, var)
+        step2 = opt.step(circuit, var)
+
+        expected = circuit(var)
+        expected_step = var - opt.stepsize * 4 * qml.grad(circuit)(var)
+        assert np.all(res == expected)
+        assert np.allclose(step1, expected_step)
+        assert np.allclose(step2, expected_step)
+
     def test_step_and_cost_with_grad_fn_grouped_input(self, tol):
         """Test that the correct cost and update is returned via the step_and_cost
         method for the QNG optimizer when providing an explicit grad_fn.

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -1531,6 +1531,7 @@ class TestCVOperation:
 
 
 class TestCriteria:
+    doubleExcitation = qml.DoubleExcitation(0.1, wires=[0, 1, 2, 3])
     rx = qml.RX(qml.numpy.array(0.3, requires_grad=True), wires=1)
     stiff_rx = qml.RX(0.3, wires=1)
     cnot = qml.CNOT(wires=[1, 0])
@@ -1554,6 +1555,13 @@ class TestCriteria:
         assert qml.operation.has_grad_method(self.rx)
         assert qml.operation.has_grad_method(self.rot)
         assert not qml.operation.has_grad_method(self.cnot)
+
+    def test_gen_is_hamiltonian(self):
+        """Test gen_is_hamiltonian criterion."""
+        assert qml.operation.gen_is_hamiltonian(self.doubleExcitation)
+        assert not qml.operation.gen_is_hamiltonian(self.cnot)
+        assert not qml.operation.gen_is_hamiltonian(self.rot)
+        assert not qml.operation.gen_is_hamiltonian(self.exp)
 
     def test_has_multipar(self):
         """Test has_multipar criterion."""

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -1556,12 +1556,12 @@ class TestCriteria:
         assert qml.operation.has_grad_method(self.rot)
         assert not qml.operation.has_grad_method(self.cnot)
 
-    def test_gen_is_hamiltonian(self):
-        """Test gen_is_hamiltonian criterion."""
-        assert qml.operation.gen_is_hamiltonian(self.doubleExcitation)
-        assert not qml.operation.gen_is_hamiltonian(self.cnot)
-        assert not qml.operation.gen_is_hamiltonian(self.rot)
-        assert not qml.operation.gen_is_hamiltonian(self.exp)
+    def test_gen_is_multi_term_hamiltonian(self):
+        """Test gen_is_multi_term_hamiltonian criterion."""
+        assert qml.operation.gen_is_multi_term_hamiltonian(self.doubleExcitation)
+        assert not qml.operation.gen_is_multi_term_hamiltonian(self.cnot)
+        assert not qml.operation.gen_is_multi_term_hamiltonian(self.rot)
+        assert not qml.operation.gen_is_multi_term_hamiltonian(self.exp)
 
     def test_has_multipar(self):
         """Test has_multipar criterion."""


### PR DESCRIPTION

------------------------------------------------------------------------------------------------------------

**Context:**

When using `QNGOptimizer` with `DoubleExcitation` an error occurred because the `DoubleExcitation` generator is a Hamiltonian and there is no diagonalization method.

**Description of the Change:**

A function has been added to check if the generator is a Hamiltonian with more than one term (since if it has only one term it can be treated as a simple operator). If it is a Hamiltonian, we expand the operation.

**Benefits:**

QNGOptimizer can now be used with more gates

**Possible Drawbacks:**

Perhaps in other cases it is better not to expand (?)

**Related GitHub Issues:**

#2502 
