### PR TITLE
Fix PennyLane to work with Autoray 0.3.1

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -78,6 +78,9 @@
 * Fixes a bug with the decomposition of `qml.CommutingEvolution`.
   [(#2542)](https://github.com/PennyLaneAI/pennylane/pull/2542)
 
+* Fixed a bug enabling PennyLane to work with the latest version of Autoray.
+  [(#)](https://github.com/PennyLaneAI/pennylane/pull/)
+
 <h3>Deprecations</h3>
 
 <h3>Bug fixes</h3>

--- a/pennylane/math/multi_dispatch.py
+++ b/pennylane/math/multi_dispatch.py
@@ -574,7 +574,13 @@ def where(condition, x=None, y=None):
         interface = _multi_dispatch([condition])
         return np.where(condition, like=interface)
 
-    return np.where(condition, x, y, like=_multi_dispatch([condition, x, y]))
+    interface = _multi_dispatch([condition, x, y])
+    res = np.where(condition, x, y, like=interface)
+
+    if interface == "tensorflow":
+        return np.transpose(np.stack(res))
+
+    return res
 
 
 @multi_dispatch(argnum=[0, 1])

--- a/pennylane/math/single_dispatch.py
+++ b/pennylane/math/single_dispatch.py
@@ -321,17 +321,6 @@ ar.register_function("torch", "expand_dims", lambda x, axis: _i("torch").unsquee
 ar.register_function("torch", "shape", lambda x: tuple(x.shape))
 ar.register_function("torch", "gather", lambda x, indices: x[indices])
 
-try:
-    if semantic_version.match(">=1.10", _i("torch").__version__):
-        # Autoray uses the deprecated torch.symeig as an alias for eigh, however this has
-        # been deprecated in favour of torch.linalg.eigh.
-        # autoray.py:84: UserWarning: torch.symeig is deprecated in favor of torch.linalg.eigh
-        # and will be removed in a future PyTorch release.
-        del ar.autoray._FUNCS["torch", "linalg.eigh"]
-except ImportError:
-    pass
-
-
 ar.register_function(
     "torch",
     "sqrt",

--- a/pennylane/math/utils.py
+++ b/pennylane/math/utils.py
@@ -59,7 +59,7 @@ def allclose(a, b, rtol=1e-05, atol=1e-08, **kwargs):
         # Some frameworks may provide their own allclose implementation.
         # Try and use it if available.
         res = np.allclose(a, b, rtol=rtol, atol=atol, **kwargs)
-    except (TypeError, AttributeError):
+    except (TypeError, AttributeError, ImportError):
         # Otherwise, convert the input to NumPy arrays.
         #
         # TODO: replace this with a bespoke, framework agnostic
@@ -111,7 +111,7 @@ def cast(tensor, dtype):
     if not isinstance(dtype, str):
         try:
             dtype = np.dtype(dtype).name
-        except (AttributeError, TypeError):
+        except (AttributeError, TypeError, ImportError):
             dtype = getattr(dtype, "name", dtype)
 
     return ar.astype(tensor, ar.to_backend_dtype(dtype, like=ar.infer_backend(tensor)))

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ toml~=0.10
 appdirs~=1.4
 semantic_version~=2.6
 dask[delayed]~=2022.4.1
-autoray>=0.2.5
+autoray==0.3.1
 matplotlib~=3.5
 black>=21
 opt_einsum~=3.3

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ requirements = [
     "toml",
     "appdirs",
     "semantic_version==2.6",
-    "autoray",
+    "autoray>=0.3.1",
     "cachetools",
     "pennylane-lightning>=0.23",
 ]

--- a/tests/math/test_functions.py
+++ b/tests/math/test_functions.py
@@ -1414,8 +1414,6 @@ def test_where(interface, t):
         [0, 0, 1, 1, 2, 0, 0, 2, 2],
         [0, 1, 0, 1, 1, 0, 1, 0, 1],
     )
-    if interface == "tf":
-        expected = qml.math.T(expected)
     assert all(fn.allclose(_res, _exp) for _res, _exp in zip(res, expected))
 
 


### PR DESCRIPTION
**Context:** Autoray 0.3.1 was introduced, with breaking changes.

**Description of the Change:** Updates PennyLane to work with Autoray 0.3.1

**Benefits:** As above.

**Possible Drawbacks:** PennyLane will no longer work with version 0.2.5

**Related GitHub Issues:** n/a
