### PR TITLE
Improve Quickstart: Op section

### DIFF
--- a/doc/introduction/operations.rst
+++ b/doc/introduction/operations.rst
@@ -33,7 +33,7 @@ This quantum function uses the :class:`RZ <pennylane.RZ>`,
 Functions applied to operators extract information (such as the matrix representation) or
 transform operators (like turning a gate into a controlled gate).
 
-Below is a list of all quantum operations and operation functions supported by PennyLane.
+Below is a list of all quantum operators and operator functions supported by PennyLane.
 
 Operator functions
 ------------------
@@ -72,7 +72,7 @@ In the functional form, they are usually differentiable with respect to gate arg
 >>> x.grad
 tensor(-0.5910)
 
-Some operator transform can also act on multiple operations, by passing
+Some operator transform can also act on multiple operators, by passing
 quantum functions, QNodes or tapes:
 
 >>> def circuit(theta):
@@ -87,7 +87,7 @@ array([[ 0.92387953+0.j,  0.+0.j ,  0.-0.38268343j,  0.+0.j],
 
 .. _intro_ref_ops_qubit:
 
-Qubit operations
+Qubit operators
 ----------------
 
 .. _intro_ref_ops_qgates:
@@ -301,7 +301,7 @@ solving the minimum clique cover problem, and auxiliary functions, refer to the
 
 .. _intro_ref_ops_cv:
 
-Continuous-Variable (CV) operations
+Continuous-Variable (CV) operators
 -----------------------------------
 
 If you would like to learn more about the CV model of quantum computing, check out the

--- a/doc/introduction/operations.rst
+++ b/doc/introduction/operations.rst
@@ -3,13 +3,13 @@
 
 .. _intro_ref_ops:
 
-Quantum operations
-==================
+Quantum operators
+=================
 
 .. currentmodule:: pennylane.ops
 
-PennyLane supports a wide variety of quantum operations---such as gates, noisy channels, state preparations and measurements.
-These operations can be used exclusively in quantum functions, like shown in the following example:
+PennyLane supports a wide variety of quantum operators---such as gates, noisy channels, state preparations and measurements.
+These operators can be used in quantum functions, like shown in the following example:
 
 .. code-block:: python
 
@@ -29,6 +29,9 @@ This quantum function uses the :class:`RZ <pennylane.RZ>`,
 :class:`AmplitudeDamping <pennylane.AmplitudeDamping>`
 :ref:`noisy channel <intro_ref_ops_channels>` as well as the
 :class:`PauliZ <pennylane.PauliZ>` :ref:`observable <intro_ref_ops_qobs>`.
+
+Functions applied to operators extract information (such as the matrix representation) or
+transform operators (like turning a gate into a controlled gate).
 
 Below is a list of all quantum operations and operation functions supported by PennyLane.
 
@@ -62,7 +65,7 @@ Operator functions can also be used in a functional form:
 tensor([[0.9553+0.0000j, 0.0000-0.2955j],
       [0.0000-0.2955j, 0.9553+0.0000j]], grad_fn=<AddBackward0>)
 
-In its functional form, most are fully differentiable with respect to gate arguments:
+In the functional form, they are usually differentiable with respect to gate arguments:
 
 >>> loss = torch.real(torch.trace(matrix_fn(x, wires=0)))
 >>> loss.backward()
@@ -70,7 +73,7 @@ In its functional form, most are fully differentiable with respect to gate argum
 tensor(-0.5910)
 
 Some operator transform can also act on multiple operations, by passing
-quantum functions, qnodes or tapes:
+quantum functions, QNodes or tapes:
 
 >>> def circuit(theta):
 ...     qml.RX(theta, wires=1)

--- a/doc/introduction/operations.rst
+++ b/doc/introduction/operations.rst
@@ -25,15 +25,37 @@ These operators can be used in quantum functions, like shown in the following ex
 
 This quantum function uses the :class:`RZ <pennylane.RZ>`,
 :class:`CNOT <pennylane.CNOT>`,
-:class:`RY <pennylane.RY>` :ref:`gates <intro_ref_ops_qgates>`, the
+:class:`RY <pennylane.RY>` gates, the
 :class:`AmplitudeDamping <pennylane.AmplitudeDamping>`
-:ref:`noisy channel <intro_ref_ops_channels>` as well as the
-:class:`PauliZ <pennylane.PauliZ>` :ref:`observable <intro_ref_ops_qobs>`.
+noisy channel as well as the
+:class:`PauliZ <pennylane.PauliZ>` observable.
 
 Functions applied to operators extract information (such as the matrix representation) or
 transform operators (like turning a gate into a controlled gate).
 
-Below is a list of all quantum operators and operator functions supported by PennyLane.
+PennyLane supports the following operators and operator functions:
+
+:ref:`intro_ref_ops_funcs`
+
+:ref:`intro_ref_ops_qubit`:
+
+* :ref:`intro_ref_ops_nonparam`
+* :ref:`intro_ref_ops_qparam`
+* :ref:`intro_ref_ops_qchem`
+* :ref:`intro_ref_ops_matrix`
+* :ref:`intro_ref_ops_arithm`
+* :ref:`intro_ref_ops_qstateprep`
+* :ref:`intro_ref_ops_channels`
+* :ref:`intro_ref_ops_qobs`
+
+:ref:`intro_ref_ops_cv`:
+
+* :ref:`intro_ref_ops_cvgates`
+* :ref:`intro_ref_ops_cvstateprep`
+* :ref:`intro_ref_ops_cvobs`
+
+
+.. _intro_ref_ops_funcs:
 
 Operator functions
 ------------------
@@ -88,12 +110,12 @@ array([[ 0.92387953+0.j,  0.+0.j ,  0.-0.38268343j,  0.+0.j],
 .. _intro_ref_ops_qubit:
 
 Qubit operators
-----------------
+---------------
 
-.. _intro_ref_ops_qgates:
+.. _intro_ref_ops_nonparam:
 
-Non-parametric Ops
-^^^^^^^^^^^^^^^^^^
+Non-parametrized gates
+^^^^^^^^^^^^^^^^^^^^^^
 
 
 :html:`<div class="summary-table">`
@@ -124,9 +146,10 @@ Non-parametric Ops
 
 :html:`</div>`
 
+.. _intro_ref_ops_qparam:
 
-Parametric Ops
-^^^^^^^^^^^^^^
+Parametrized gates
+^^^^^^^^^^^^^^^^^^
 
 
 :html:`<div class="summary-table">`
@@ -156,9 +179,10 @@ Parametric Ops
 
 :html:`</div>`
 
+.. _intro_ref_ops_qchem:
 
-Quantum Chemistry Ops
-^^^^^^^^^^^^^^^^^^^^^
+Quantum chemistry gates
+^^^^^^^^^^^^^^^^^^^^^^^
 
 
 :html:`<div class="summary-table">`
@@ -180,9 +204,10 @@ Electronic Hamiltonians built independently using
 `OpenFermion <https://github.com/quantumlib/OpenFermion>`_ tools can be readily converted to a
 PennyLane observable using the :func:`~.pennylane.import_operator` function.
 
+.. _intro_ref_ops_matrix:
 
-Matrix Ops
-^^^^^^^^^^
+Gates constructed from a matrix
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 :html:`<div class="summary-table">`
@@ -196,9 +221,10 @@ Matrix Ops
 
 :html:`</div>`
 
+.. _intro_ref_ops_arithm:
 
-Arithmetic Ops
-^^^^^^^^^^^^^^
+Gates performing arithmetics
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 :html:`<div class="summary-table">`
@@ -211,9 +237,10 @@ Arithmetic Ops
 
 :html:`</div>`
 
+.. _intro_ref_ops_qstateprep:
 
-Qubit state preparation
-^^^^^^^^^^^^^^^^^^^^^^^
+State preparation
+^^^^^^^^^^^^^^^^^
 
 
 :html:`<div class="summary-table">`
@@ -255,8 +282,8 @@ Noisy channels
 
 .. _intro_ref_ops_qobs:
 
-Qubit observables
-^^^^^^^^^^^^^^^^^
+Observables
+^^^^^^^^^^^
 
 :html:`<div class="summary-table">`
 
@@ -275,30 +302,6 @@ Qubit observables
 
 :html:`</div>`
 
-Grouping Pauli words
-^^^^^^^^^^^^^^^^^^^^
-
-Grouping Pauli words can be used for the optimizing the measurement of qubit
-Hamiltonians. Along with groups of observables, post-measurement rotations can
-also be obtained using :func:`~.optimize_measurements`:
-
-.. code-block:: python
-
-    >>> obs = [qml.PauliY(0), qml.PauliX(0) @ qml.PauliX(1), qml.PauliZ(1)]
-    >>> coeffs = [1.43, 4.21, 0.97]
-    >>> post_rotations, diagonalized_groupings, grouped_coeffs = optimize_measurements(obs, coeffs)
-    >>> post_rotations
-    [[RY(-1.5707963267948966, wires=[0]), RY(-1.5707963267948966, wires=[1])],
-     [RX(1.5707963267948966, wires=[0])]]
-
-The post-measurement rotations can be used to diagonalize the partitions of
-observables found.
-
-For further details on measurement optimization, grouping observables through
-solving the minimum clique cover problem, and auxiliary functions, refer to the
-:doc:`/code/qml_grouping` subpackage.
-
-
 .. _intro_ref_ops_cv:
 
 Continuous-Variable (CV) operators
@@ -310,7 +313,7 @@ page of the `Strawberry Fields <https://strawberryfields.ai/>`__ documentation.
 
 .. _intro_ref_ops_cvgates:
 
-CV Gates
+CV gates
 ^^^^^^^^
 
 :html:`<div class="summary-table">`
@@ -334,6 +337,7 @@ CV Gates
 
 :html:`</div>`
 
+.. _intro_ref_ops_cvstateprep:
 
 CV state preparation
 ^^^^^^^^^^^^^^^^^^^^

--- a/doc/introduction/operations.rst
+++ b/doc/introduction/operations.rst
@@ -35,25 +35,6 @@ transform operators (like turning a gate into a controlled gate).
 
 PennyLane supports the following operators and operator functions:
 
-:ref:`intro_ref_ops_funcs`
-
-:ref:`intro_ref_ops_qubit`:
-
-* :ref:`intro_ref_ops_nonparam`
-* :ref:`intro_ref_ops_qparam`
-* :ref:`intro_ref_ops_qchem`
-* :ref:`intro_ref_ops_matrix`
-* :ref:`intro_ref_ops_arithm`
-* :ref:`intro_ref_ops_qstateprep`
-* :ref:`intro_ref_ops_channels`
-* :ref:`intro_ref_ops_qobs`
-
-:ref:`intro_ref_ops_cv`:
-
-* :ref:`intro_ref_ops_cvgates`
-* :ref:`intro_ref_ops_cvstateprep`
-* :ref:`intro_ref_ops_cvobs`
-
 
 .. _intro_ref_ops_funcs:
 


### PR DESCRIPTION
Added explanation of what an op function is.

Changed "operation" to "operator" everywhere.

Added quicklinks to top

Removed section on pauli grouping, which will appear in new Quickstart section added in a follow-up PR