### PR TITLE
Fix commutativity of `Hamiltonian` and `Observable` in tensor product

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -118,13 +118,14 @@
 * Fixed a bug enabling PennyLane to work with the latest version of Autoray.
   [(#2549)](https://github.com/PennyLaneAI/pennylane/pull/2549)
 
-<h3>Deprecations</h3>
-
-<h3>Bug fixes</h3>
+* Fixed a bug which caused different behaviour for `Hamiltonian @ Observable` and `Observable @ Hamiltonian`.
+  [(#2570)](https://github.com/PennyLaneAI/pennylane/pull/2570)
 
 * Fixes a bug in `DiagonalQubitUnitary._controlled` where an invalid operation was queued
   instead of the controlled version of the diagonal unitary.
   [(#2525)](https://github.com/PennyLaneAI/pennylane/pull/2525)
+
+<h3>Deprecations</h3>
 
 <h3>Documentation</h3>
 
@@ -137,4 +138,4 @@
 This release contains contributions from (in alphabetical order):
 
 Guillermo Alonso-Linaje, Mikhail Andrenkov, Juan Miguel Arrazola, Utkarsh Azad, Christian Gogolin,
-Soran Jahangiri, Edward Jiang, Christina Lee, Chae-Yeun Park, Maria Schuld
+Soran Jahangiri, Edward Jiang, Christina Lee, Chae-Yeun Park, Maria Schuld, Jay Soni

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -1471,7 +1471,7 @@ class Observable(Operator):
         return repr(self.return_type) + "(" + temp + ")"
 
     def __matmul__(self, other):
-        if isinstance(other, Tensor):
+        if isinstance(other, (Tensor, qml.Hamiltonian)):
             return other.__rmatmul__(self)
 
         if isinstance(other, Observable):

--- a/pennylane/ops/qubit/hamiltonian.py
+++ b/pennylane/ops/qubit/hamiltonian.py
@@ -547,7 +547,7 @@ class Hamiltonian(Observable):
     def __rmatmul__(self, H):
         r"""The tensor product operation from the right) between a Hamiltonian and
         a Hamiltonian/Tensor/Observable (ie. Hamiltonian.__rmul__(H) = H @ Hamiltonian).
-         """
+        """
         coeffs1 = copy(self.coeffs)
         ops1 = self.ops.copy()
 

--- a/pennylane/ops/qubit/hamiltonian.py
+++ b/pennylane/ops/qubit/hamiltonian.py
@@ -544,6 +544,20 @@ class Hamiltonian(Observable):
 
         raise ValueError(f"Cannot tensor product Hamiltonian and {type(H)}")
 
+    def __rmatmul__(self, H):
+        r"""The tensor product operation from the right) between a Hamiltonian and
+        a Hamiltonian/Tensor/Observable (ie. Hamiltonian.__rmul__(H) = H @ Hamiltonian).
+         """
+        coeffs1 = copy(self.coeffs)
+        ops1 = self.ops.copy()
+
+        if isinstance(H, (Tensor, Observable)):
+            terms = [H @ op for op in ops1]
+
+            return qml.Hamiltonian(coeffs1, terms, simplify=True)
+
+        raise ValueError(f"Cannot tensor product Hamiltonian and {type(H)}")
+
     def __add__(self, H):
         r"""The addition operation between a Hamiltonian and a Hamiltonian/Tensor/Observable."""
         ops = self.ops.copy()

--- a/pennylane/ops/qubit/hamiltonian.py
+++ b/pennylane/ops/qubit/hamiltonian.py
@@ -545,7 +545,7 @@ class Hamiltonian(Observable):
         raise ValueError(f"Cannot tensor product Hamiltonian and {type(H)}")
 
     def __rmatmul__(self, H):
-        r"""The tensor product operation from the right) between a Hamiltonian and
+        r"""The tensor product operation (from the right) between a Hamiltonian and
         a Hamiltonian/Tensor/Observable (ie. Hamiltonian.__rmul__(H) = H @ Hamiltonian).
         """
         if isinstance(H, Hamiltonian):  # can't be accessed by '@'

--- a/pennylane/ops/qubit/hamiltonian.py
+++ b/pennylane/ops/qubit/hamiltonian.py
@@ -548,6 +548,9 @@ class Hamiltonian(Observable):
         r"""The tensor product operation from the right) between a Hamiltonian and
         a Hamiltonian/Tensor/Observable (ie. Hamiltonian.__rmul__(H) = H @ Hamiltonian).
         """
+        if isinstance(H, Hamiltonian):  # can't be accessed by '@'
+            return H.__matmul__(self)
+
         coeffs1 = copy(self.coeffs)
         ops1 = self.ops.copy()
 

--- a/tests/ops/qubit/test_hamiltonian.py
+++ b/tests/ops/qubit/test_hamiltonian.py
@@ -773,6 +773,8 @@ class TestHamiltonian:
         A = [[1, 0], [0, -1]]
         with pytest.raises(ValueError, match="Cannot tensor product Hamiltonian"):
             H @ A
+        with pytest.raises(ValueError, match="Cannot tensor product Hamiltonian"):
+            H.__rmatmul__(A)
         with pytest.raises(ValueError, match="Cannot add Hamiltonian"):
             H + A
         with pytest.raises(ValueError, match="Cannot multiply Hamiltonian"):

--- a/tests/ops/qubit/test_hamiltonian.py
+++ b/tests/ops/qubit/test_hamiltonian.py
@@ -444,6 +444,69 @@ matmul_hamiltonians = [
     ),
 ]
 
+rmatmul_hamiltonians = [
+    (
+        qml.Hamiltonian([0.5, 0.5], [qml.PauliZ(2), qml.PauliZ(3)]),
+        qml.Hamiltonian([1, 1], [qml.PauliX(0), qml.PauliZ(1)]),
+        qml.Hamiltonian(
+            [0.5, 0.5, 0.5, 0.5],
+            [
+                qml.PauliX(0) @ qml.PauliZ(2),
+                qml.PauliX(0) @ qml.PauliZ(3),
+                qml.PauliZ(1) @ qml.PauliZ(2),
+                qml.PauliZ(1) @ qml.PauliZ(3),
+            ],
+        ),
+    ),
+    (
+        qml.Hamiltonian([1, 1], [qml.PauliX(3) @ qml.PauliZ(2), qml.PauliZ(2)]),
+        qml.Hamiltonian([0.5, 0.25], [qml.PauliX(0) @ qml.PauliX(1), qml.PauliZ(0)]),
+        qml.Hamiltonian(
+            [0.5, 0.5, 0.25, 0.25],
+            [
+                qml.PauliX(0) @ qml.PauliX(1) @ qml.PauliX(3) @ qml.PauliZ(2),
+                qml.PauliX(0) @ qml.PauliX(1) @ qml.PauliZ(2),
+                qml.PauliZ(0) @ qml.PauliX(3) @ qml.PauliZ(2),
+                qml.PauliZ(0) @ qml.PauliZ(2),
+            ],
+        ),
+    ),
+    (
+        qml.Hamiltonian([2, 2], [qml.PauliZ(1.2), qml.PauliY("c")]),
+        qml.Hamiltonian([1, 1], [qml.PauliX("b"), qml.Hermitian(np.array([[1, 0], [0, -1]]), 0)]),
+        qml.Hamiltonian(
+            [2, 2, 2, 2],
+            [
+                qml.PauliX("b") @ qml.PauliZ(1.2),
+                qml.PauliX("b") @ qml.PauliY("c"),
+                qml.Hermitian(np.array([[1, 0], [0, -1]]), 0) @ qml.PauliZ(1.2),
+                qml.Hermitian(np.array([[1, 0], [0, -1]]), 0) @ qml.PauliY("c"),
+            ],
+        ),
+    ),
+    (
+        qml.Hamiltonian([1, 1], [qml.PauliX(0), qml.PauliZ(1)]),
+        qml.PauliX(2),
+        qml.Hamiltonian([1, 1], [qml.PauliX(2) @ qml.PauliX(0), qml.PauliX(2) @ qml.PauliZ(1)]),
+    ),
+    # Case where arguments coeffs and ops to the Hamiltonian are iterables other than lists
+    (
+        qml.Hamiltonian(np.array([0.5, 0.5]), np.array([qml.PauliZ(2), qml.PauliZ(3)])),
+        qml.Hamiltonian((1, 1), (qml.PauliX(0), qml.PauliZ(1))),
+        qml.Hamiltonian(
+            (0.5, 0.5, 0.5, 0.5),
+            np.array(
+                [
+                    qml.PauliX(0) @ qml.PauliZ(2),
+                    qml.PauliX(0) @ qml.PauliZ(3),
+                    qml.PauliZ(1) @ qml.PauliZ(2),
+                    qml.PauliZ(1) @ qml.PauliZ(3),
+                ]
+            ),
+        ),
+    ),
+]
+
 big_hamiltonian_coeffs = np.array(
     [
         -0.04207898,
@@ -672,6 +735,11 @@ class TestHamiltonian:
     def test_hamiltonian_matmul(self, H1, H2, H):
         """Tests that Hamiltonians are tensored correctly"""
         assert H.compare(H1 @ H2)
+
+    @pytest.mark.parametrize(("H1", "H2", "H"), rmatmul_hamiltonians)
+    def test_hamiltonian_matmul(self, H1, H2, H):
+        """Tests that Hamiltonians are tensored correctly when using __rmatmul__"""
+        assert H.compare(H1.__rmatmul__(H2))
 
     def test_hamiltonian_same_wires(self):
         """Test if a ValueError is raised when multiplication between Hamiltonians acting on the

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -1195,6 +1195,20 @@ mul_obs = [
     ),
 ]
 
+matmul_obs = [
+    (qml.PauliX(0), qml.PauliZ(1), Tensor(qml.PauliX(0), qml.PauliZ(1))),  # obs @ obs
+    (
+        qml.PauliX(0),
+        qml.PauliZ(1) @ qml.PauliY(2),
+        Tensor(qml.PauliX(0), qml.PauliZ(1), qml.PauliY(2)),
+    ),  # obs @ tensor
+    (
+        qml.PauliX(0),
+        qml.Hamiltonian([1.0], [qml.PauliY(1)]),
+        qml.Hamiltonian([1.0], [qml.PauliX(0) @ qml.PauliY(1)]),
+    ),  # obs @ hamiltonian
+]
+
 sub_obs = [
     (qml.PauliZ(0) @ qml.Identity(1), qml.PauliZ(0), qml.Hamiltonian([], [])),
     (
@@ -1282,6 +1296,11 @@ class TestTensorObservableOperations:
     def test_subtraction(self, obs1, obs2, obs):
         """Tests subtraction between Tensors and Observables"""
         assert obs.compare(obs1 - obs2)
+
+    @pytest.mark.parametrize(("obs1", "obs2", "res"), matmul_obs)
+    def test_tensor_product(self, obs1, obs2, res):
+        """Tests the tensor product between Observables"""
+        assert res.compare(obs1 @ obs2)
 
     def test_arithmetic_errors(self):
         """Tests that the arithmetic operations throw the correct errors"""


### PR DESCRIPTION
**Context:**
Given a Hamiltonian object `H` and an observable object (eg. `qml.PauliX(0)`), the tensor product: 

```python 
dev = qml.device("default.qubit", wires=3)

@qml.qnode(dev)
def circ(op):
    qml.Hadamard(0)
    qml.CNOT(wires=[0,1]) 
    return qml.expval(op)
```

```
>>> op1 = H @ qml.PauliX(0)
>>> op2 = qml.PauliX(0) @ H   
>>>
>>> circ(op1)  # works as expected 
>>> circ(op2) # fails due to an error accessing the EigenValues of a tensor observable
```

**Description of the Change:**
The `__matmul__` method in the `Observable` class checks if the other object is an instance of `Hamiltonian`. In this case it will differ the matrix multiplication to the `Hamiltonian` classes implementation. Also a `__rmatmul__` method is implemented for the `Hamiltonian` class to allow for the above. 

**Related GitHub Issues:**
User reported [bug](https://github.com/PennyLaneAI/pennylane/issues/2557)
