### PR TITLE
Add crucial information to the SparseHamiltonian doc string

### DIFF
--- a/pennylane/ops/qubit/observables.py
+++ b/pennylane/ops/qubit/observables.py
@@ -197,6 +197,18 @@ class SparseHamiltonian(Observable):
         do_queue (bool): Indicates whether the operator should be
             immediately pushed into the Operator queue (optional)
         id (str or None): String representing the operation (optional)
+
+    **Example:**
+        You can construct your Hamiltonian as usual using :class:`~.Hamiltonian` and then utilize
+        the utility function :func:`~.utils.sparse_hamiltonian` to construct the sparse matrix that serves as the input
+        to ``SparseHamiltonian``:
+
+        >>> wires = 20
+        >>> coeffs = [1 for _ in range(wires)]
+        >>> observables = [qml.PauliZ(0) for _ in range(wires)]
+        >>> H = qml.Hamiltonian(coeffs, observables)
+        >>> Hmat = qml.utils.sparse_hamiltonian(H)
+        >>> H_sparse = qml.SparseHamiltonian(Hmat, wires=wires)
     """
     num_wires = AllWires
     num_params = 1


### PR DESCRIPTION
**Context:**

Added reference to `qml.utils.sparse_hamiltonian` to `qml.SparseHamiltonian` class and a use-case example.

**Description of the Change:**

Just changed the doc-string

**Benefits:**

Now it should be clear to the user how to construct sparse Hamiltonians using PennyLane.

**Possible Drawbacks:**

**Related GitHub Issues:**
