### PR TITLE
Introduce operator input parameter `ndim_params` and `batch_size` attributes

### DIFF
--- a/pennylane/math/single_dispatch.py
+++ b/pennylane/math/single_dispatch.py
@@ -168,7 +168,6 @@ ar.autoray._SUBMODULE_ALIASES["tensorflow", "moveaxis"] = "tensorflow.experiment
 ar.autoray._SUBMODULE_ALIASES["tensorflow", "sinc"] = "tensorflow.experimental.numpy"
 ar.autoray._SUBMODULE_ALIASES["tensorflow", "isclose"] = "tensorflow.experimental.numpy"
 ar.autoray._SUBMODULE_ALIASES["tensorflow", "atleast_1d"] = "tensorflow.experimental.numpy"
-ar.autoray._SUBMODULE_ALIASES["tensorflow", "ndim"] = "tensorflow.experimental.numpy"
 
 
 ar.autoray._FUNC_ALIASES["tensorflow", "arcsin"] = "asin"
@@ -198,6 +197,16 @@ def _round_tf(tensor, decimals=0):
 
 
 ar.register_function("tensorflow", "round", _round_tf)
+
+
+def _ndim_tf(tensor):
+    try:
+        return _i("tf").experimental.numpy.ndim(tensor)
+    except AttributeError:
+        return len(tensor.shape)
+
+
+ar.register_function("tensorflow", "ndim", _ndim_tf)
 
 
 def _take_tf(tensor, indices, axis=None):

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -484,7 +484,7 @@ class Operator(abc.ABC):
     -0.9999987318946099
 
     """
-    # pylint: disable=too-many-public-methods
+    # pylint: disable=too-many-public-methods, too-many-instance-attributes
 
     def __copy__(self):
         cls = self.__class__

--- a/pennylane/ops/channel.py
+++ b/pennylane/ops/channel.py
@@ -700,6 +700,11 @@ class QubitChannel(Channel):
         if not np.allclose(Kraus_sum, np.eye(K_list[0].shape[0])):
             raise ValueError("Only trace preserving channels can be applied.")
 
+    def _check_batching(self, params):
+        """Treat the Kraus matrices as independent parameters when checking for a
+        batch dimension."""
+        super()._check_batching(*params)
+
     @staticmethod
     def compute_kraus_matrices(K_list):  # pylint:disable=arguments-differ
         """Kraus matrices representing the QubitChannel channel.

--- a/pennylane/tape/tape.py
+++ b/pennylane/tape/tape.py
@@ -487,7 +487,10 @@ class QuantumTape(AnnotatedQueue):
             if op_batch_size is None:
                 continue
             if candidate and op_batch_size != candidate:
-                raise ValueError(f"The batch sizes of the tape operations do not match.")
+                raise ValueError(
+                    "The batch sizes of the tape operations do not match, they include "
+                    f"{candidate} and {op_batch_size}."
+                )
             candidate = candidate or op_batch_size
 
         self._batch_size = candidate


### PR DESCRIPTION
This PR implements the first part of parameter broadcasting, including the operator attributes `ndim_params` and `batch_size` (which is based on `_batch_size`) as well as the tape attribute `batch_size` which is inferred from the batch sizes of the tape operations.
These attributes will be used to determine if an operator or a tape is batched, which will be used by devices at execution.