### PR TITLE
Lint `identity.py`

### DIFF
--- a/pennylane/ops/identity.py
+++ b/pennylane/ops/identity.py
@@ -149,5 +149,5 @@ class Identity(CVObservable, Operation):
     def adjoint(self):  # pylint:disable=arguments-differ
         return Identity(wires=self.wires)
 
-    def pow(self, n):
+    def pow(self, _):
         return [Identity(wires=self.wires)]


### PR DESCRIPTION
Lints the `identity.py` file after #2225 due to new CodeFactor issues:
![image](https://user-images.githubusercontent.com/24476053/168658970-1d574d92-ecec-4d65-8e3e-d57d0f04f088.png)
