### PR TITLE
[WIP] `qml.expval()` with non-commuting operators

### DIFF
--- a/doc/releases/changelog-0.23.1.md
+++ b/doc/releases/changelog-0.23.1.md
@@ -7,11 +7,8 @@
 * Fixed a bug enabling PennyLane to work with the latest version of Autoray.
   [(#2548)](https://github.com/PennyLaneAI/pennylane/pull/2548)
 
-* Deprecating ExpvalCost by adding a UserWarning.
-  [(#2571)](https://github.com/PennyLaneAI/pennylane/pull/2571)
-
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):
 
-Josh Izaac, Korbinian Kottmann
+Josh Izaac

--- a/doc/releases/changelog-0.23.1.md
+++ b/doc/releases/changelog-0.23.1.md
@@ -7,8 +7,11 @@
 * Fixed a bug enabling PennyLane to work with the latest version of Autoray.
   [(#2548)](https://github.com/PennyLaneAI/pennylane/pull/2548)
 
+* Deprecating ExpvalCost by adding a UserWarning.
+  [(#2571)](https://github.com/PennyLaneAI/pennylane/pull/2571)
+
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):
 
-Josh Izaac
+Josh Izaac, Korbinian Kottmann

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -117,6 +117,9 @@
 
 <h3>Deprecations</h3>
 
+* Deprecating ExpvalCost by adding a UserWarning.
+  [(#2571)](https://github.com/PennyLaneAI/pennylane/pull/2571)
+
 <h3>Bug fixes</h3>
 
 * Fixes a bug in `DiagonalQubitUnitary._controlled` where an invalid operation was queued
@@ -133,5 +136,5 @@
 
 This release contains contributions from (in alphabetical order):
 
-Guillermo Alonso-Linaje, Mikhail Andrenkov, Utkarsh Azad, Christian Gogolin, Edward Jiang, Christina Lee,
+Guillermo Alonso-Linaje, Mikhail Andrenkov, Utkarsh Azad, Christian Gogolin, Edward Jiang, Korbinian Kottmann, Christina Lee,
 Chae-Yeun Park, Maria Schuld

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -729,43 +729,43 @@ class Device(abc.ABC):
                     "Can only return the expectation of a single Hamiltonian observable"
                 ) from e
 
-        # Check for case of non-commuting terms outside of Hamiltonians
-        measurements = circuit.measurements
+        if len(circuit._obs_sharing_wires) > 0 and not hamiltonian_in_obs:
+            # Check for case of non-commuting terms outside of Hamiltonians
+            measurements = circuit.measurements
 
-        obs_list = []
-        # get the observables from the measurements
-        # TO DO: This loop should become superfluous when the reworked operator classes are implemented
-        for i,measurement in enumerate(measurements):
-            if hasattr(measurement.obs, "obs"):
-                # this loop re-creates multi-qubit observables, e.g. PauliZ(0) @ PauliZ(1)
-                _list = measurement.obs.obs # the list of individual observables before composition
-                obs = _list[0]
-                for ob_i in _list[1:]:
-                    obs @= ob_i # I am sure there must be a better way to do this?
-            else:
-                obs = measurement.obs
-            obs_list.append(obs)
-        n_obs = len(obs_list)
+            obs_list = []
+            # get the observables from the measurements
+            # TO DO: This loop should become superfluous when the reworked operator classes are implemented
+            for i, measurement in enumerate(measurements):
+                if hasattr(measurement.obs, "obs"):
+                    # this loop re-creates multi-qubit observables, e.g. PauliZ(0) @ PauliZ(1)
+                    _list = (
+                        measurement.obs.obs
+                    )  # the list of individual observables before composition
+                    obs = _list[0]
+                    for ob_i in _list[1:]:
+                        obs @= ob_i  # I am sure there must be a better way to do this?
+                else:
+                    obs = measurement.obs
+                obs_list.append(obs)
+            n_obs = len(obs_list)
 
-        # If there is more than one group of commuting observables, split tapes
-        groups, group_coeffs = qml.grouping.group_observables(obs_list, range(len(obs_list)))
-        if len(groups) > 1:
-            # make one tape per commuting group
-            circuits = []
-            for group in groups:
-                with circuit.__class__() as new_circuit:
-                    [op.queue() for op in circuit.operations]
-                    [qml.expval(o) for o in group]
+            # If there is more than one group of commuting observables, split tapes
+            groups, group_coeffs = qml.grouping.group_observables(obs_list, range(len(obs_list)))
+            if len(groups) > 1:
+                # make one tape per commuting group
+                circuits = []
+                for group in groups:
+                    with circuit.__class__() as new_circuit:
+                        [op.queue() for op in circuit.operations]
+                        [qml.expval(o) for o in group]
 
-                circuits.append(new_circuit)
+                    circuits.append(new_circuit)
 
-            def reorder_fn(res):
-                # re-ordering the output accordingly to how it was input
-                reorder = np.zeros(n_obs) # numpy array for fancy indexing
-                for i,indxs in enumerate(group_coeffs):
-                    reorder[indxs] = res[i] # using fancy indexing
-                return reorder
-            return circuits, reorder_fn
+                def reorder_fn(res):
+                    return qml.math.concatenate(res)[qml.math.concatenate(group_coeffs)]
+
+                return circuits, reorder_fn
 
         # otherwise, return an identity transform
         return [circuit], lambda res: res[0]

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -729,6 +729,44 @@ class Device(abc.ABC):
                     "Can only return the expectation of a single Hamiltonian observable"
                 ) from e
 
+        # Check for case of non-commuting terms outside of Hamiltonians
+        measurements = circuit.measurements
+
+        obs_list = []
+        # get the observables from the measurements
+        # TO DO: This loop should become superfluous when the reworked operator classes are implemented
+        for i,measurement in enumerate(measurements):
+            if hasattr(measurement.obs, "obs"):
+                # this loop re-creates multi-qubit observables, e.g. PauliZ(0) @ PauliZ(1)
+                _list = measurement.obs.obs # the list of individual observables before composition
+                obs = _list[0]
+                for ob_i in _list[1:]:
+                    obs @= ob_i # I am sure there must be a better way to do this?
+            else:
+                obs = measurement.obs
+            obs_list.append(obs)
+        n_obs = len(obs_list)
+
+        # If there is more than one group of commuting observables, split tapes
+        groups, group_coeffs = qml.grouping.group_observables(obs_list, range(len(obs_list)))
+        if len(groups) > 1:
+            # make one tape per commuting group
+            circuits = []
+            for group in groups:
+                with circuit.__class__() as new_circuit:
+                    [op.queue() for op in circuit.operations]
+                    [qml.expval(o) for o in group]
+
+                circuits.append(new_circuit)
+
+            def reorder_fn(res):
+                # re-ordering the output accordingly to how it was input
+                reorder = np.zeros(n_obs) # numpy array for fancy indexing
+                for i,indxs in enumerate(group_coeffs):
+                    reorder[indxs] = res[i] # using fancy indexing
+                return reorder
+            return circuits, reorder_fn
+
         # otherwise, return an identity transform
         return [circuit], lambda res: res[0]
 

--- a/pennylane/vqe/vqe.py
+++ b/pennylane/vqe/vqe.py
@@ -26,8 +26,8 @@ from pennylane import numpy as np
 class ExpvalCost:
     """
     .. warning::
-        `qml.ExpvalCost()` will soon be deprecated, use :class:`~.QNode` and ``qml.expval()`` instead.
-        For example, use:
+        ``ExpvalCost`` is deprecated. Instead, it is recommended to simply
+        pass Hamiltonians to the :func:`~.expval` function inside QNodes.
 
         .. code-block:: python
 

--- a/pennylane/vqe/vqe.py
+++ b/pennylane/vqe/vqe.py
@@ -24,7 +24,21 @@ from pennylane import numpy as np
 
 
 class ExpvalCost:
-    """Create a cost function that gives the expectation value of an input Hamiltonian.
+    """
+    .. warning::
+        `qml.ExpvalCost()` will soon be deprecated, use :class:`~.QNode` and ``qml.expval()`` instead.
+        For example, use:
+
+        .. code-block:: python
+
+            qml.qnode(dev)
+            def ansatz(params):
+                some_qfunc(params)
+                return qml.expval(Hamiltonian)
+
+        In order to optimize the Hamiltonian evaluation taking into account commuting terms, use the `grouping_type` keyword in :class:`~.Hamiltonian`
+
+    Create a cost function that gives the expectation value of an input Hamiltonian.
 
     This cost function is useful for a range of problems including VQE and QAOA.
 

--- a/pennylane/vqe/vqe.py
+++ b/pennylane/vqe/vqe.py
@@ -151,7 +151,7 @@ class ExpvalCost:
         **kwargs,
     ):
         warnings.warn(
-            "qml.ExpvalCost() will be deprecated, use qml.expval() instead. "
+            "ExpvalCost is deprecated, use qml.expval() instead. "
             "For optimizing Hamiltonian measurements with measuring commuting "
             "terms in parallel, use the grouping_type keyword in qml.Hamiltonian.",
             UserWarning,

--- a/pennylane/vqe/vqe.py
+++ b/pennylane/vqe/vqe.py
@@ -31,7 +31,7 @@ class ExpvalCost:
 
         .. code-block:: python
 
-            qml.qnode(dev)
+            @qml.qnode(dev)
             def ansatz(params):
                 some_qfunc(params)
                 return qml.expval(Hamiltonian)

--- a/pennylane/vqe/vqe.py
+++ b/pennylane/vqe/vqe.py
@@ -36,7 +36,7 @@ class ExpvalCost:
                 some_qfunc(params)
                 return qml.expval(Hamiltonian)
 
-        In order to optimize the Hamiltonian evaluation taking into account commuting terms, use the `grouping_type` keyword in :class:`~.Hamiltonian`
+        In order to optimize the Hamiltonian evaluation taking into account commuting terms, use the ``grouping_type`` keyword in :class:`~.Hamiltonian`.
 
     Create a cost function that gives the expectation value of an input Hamiltonian.
 

--- a/pennylane/vqe/vqe.py
+++ b/pennylane/vqe/vqe.py
@@ -136,6 +136,13 @@ class ExpvalCost:
         optimize=False,
         **kwargs,
     ):
+        warnings.warn(
+            "qml.ExpvalCost() will be deprecated, use qml.expval() instead. "
+            "For optimizing Hamiltonian measurements with measuring commuting "
+            "terms in parallel, use the grouping_type keyword in qml.Hamiltonian.",
+            UserWarning,
+        )
+
         if kwargs.get("measure", "expval") != "expval":
             raise ValueError("ExpvalCost can only be used to construct sums of expectation values.")
 

--- a/tests/optimize/test_optimize_shot_adapative.py
+++ b/tests/optimize/test_optimize_shot_adapative.py
@@ -22,7 +22,8 @@ from pennylane import numpy as np
 def catch_warn_ExpvalCost(ansatz, hamiltonian, device, **kwargs):
     """Computes the ExpvalCost and catches the initial deprecation warning."""
 
-    with pytest.warns(UserWarning, match="will be deprecated,"):
+    with pytest.warns(UserWarning, match="is deprecated,"):
+
         res = qml.ExpvalCost(ansatz, hamiltonian, device, **kwargs)
     return res
 

--- a/tests/optimize/test_optimize_shot_adapative.py
+++ b/tests/optimize/test_optimize_shot_adapative.py
@@ -19,6 +19,14 @@ import pennylane as qml
 from pennylane import numpy as np
 
 
+def catch_warn_ExpvalCost(ansatz, hamiltonian, device, **kwargs):
+    """Computes the ExpvalCost and catches the initial deprecation warning."""
+
+    with pytest.warns(UserWarning, match="will be deprecated,"):
+        res = qml.ExpvalCost(ansatz, hamiltonian, device, **kwargs)
+    return res
+
+
 class TestExceptions:
     """Test exceptions are raised for incorrect usage"""
 
@@ -30,7 +38,7 @@ class TestExceptions:
         def ansatz(x, **kwargs):
             qml.RX(x, wires=0)
 
-        expval_cost = qml.ExpvalCost(ansatz, H, dev)
+        expval_cost = catch_warn_ExpvalCost(ansatz, H, dev)
 
         opt = qml.ShotAdaptiveOptimizer(min_shots=10)
 
@@ -54,7 +62,7 @@ class TestExceptions:
         def ansatz(x, **kwargs):
             qml.RX(x, wires=0)
 
-        expval_cost = qml.ExpvalCost(ansatz, H, dev)
+        expval_cost = catch_warn_ExpvalCost(ansatz, H, dev)
 
         opt = qml.ShotAdaptiveOptimizer(min_shots=10, stepsize=100.0)
 
@@ -110,7 +118,7 @@ class TestSingleShotGradientIntegration:
     def ansatz(x, **kwargs):
         qml.RX(x, wires=0)
 
-    expval_cost = qml.ExpvalCost(ansatz, H, dev)
+    expval_cost = catch_warn_ExpvalCost(ansatz, H, dev)
 
     @qml.qnode(dev)
     def qnode(x):
@@ -182,7 +190,7 @@ class TestSingleShotGradientIntegration:
         qml.RY(x[1, 1], wires=0)
         qml.RZ(x[1, 2], wires=0)
 
-    expval_cost = qml.ExpvalCost(ansatz, H, dev)
+    expval_cost = catch_warn_ExpvalCost(ansatz, H, dev)
     qnode = expval_cost.qnodes[0]
 
     @pytest.mark.parametrize("cost_fn", [qnode, expval_cost])
@@ -408,7 +416,7 @@ class TestWeightedRandomSampling:
         dev = qml.device("default.qubit", wires=2, shots=100)
         H = qml.Hamiltonian(coeffs, [qml.PauliZ(0), qml.PauliZ(0) @ qml.PauliZ(1)])
 
-        expval_cost = qml.ExpvalCost(qml.templates.StronglyEntanglingLayers, H, dev)
+        expval_cost = catch_warn_ExpvalCost(qml.templates.StronglyEntanglingLayers, H, dev)
         weights = np.random.random(qml.templates.StronglyEntanglingLayers.shape(3, 2))
 
         opt = qml.ShotAdaptiveOptimizer(min_shots=10)
@@ -428,7 +436,7 @@ class TestWeightedRandomSampling:
         dev = qml.device("default.qubit", wires=2, shots=100)
         H = qml.Hamiltonian(coeffs, [qml.PauliZ(0), qml.PauliZ(0) @ qml.PauliZ(1)])
 
-        expval_cost = qml.ExpvalCost(qml.templates.StronglyEntanglingLayers, H, dev)
+        expval_cost = catch_warn_ExpvalCost(qml.templates.StronglyEntanglingLayers, H, dev)
         weights = np.random.random(qml.templates.StronglyEntanglingLayers.shape(3, 2))
 
         opt = qml.ShotAdaptiveOptimizer(min_shots=10, term_sampling=None)
@@ -443,7 +451,7 @@ class TestWeightedRandomSampling:
         dev = qml.device("default.qubit", wires=2, shots=100)
         H = qml.Hamiltonian(coeffs, [qml.PauliZ(0), qml.PauliZ(0) @ qml.PauliZ(1)])
 
-        expval_cost = qml.ExpvalCost(qml.templates.StronglyEntanglingLayers, H, dev)
+        expval_cost = catch_warn_ExpvalCost(qml.templates.StronglyEntanglingLayers, H, dev)
         weights = np.random.random(qml.templates.StronglyEntanglingLayers.shape(3, 2))
 
         opt = qml.ShotAdaptiveOptimizer(min_shots=10, term_sampling="uniform_random_sampling")
@@ -458,7 +466,7 @@ class TestWeightedRandomSampling:
         dev = qml.device("default.qubit", wires=2, shots=100)
         H = qml.Hamiltonian(coeffs, [qml.PauliZ(0), qml.PauliX(1), qml.PauliZ(0) @ qml.PauliZ(1)])
 
-        expval_cost = qml.ExpvalCost(qml.templates.StronglyEntanglingLayers, H, dev)
+        expval_cost = catch_warn_ExpvalCost(qml.templates.StronglyEntanglingLayers, H, dev)
         weights = np.random.random(qml.templates.StronglyEntanglingLayers.shape(3, 2))
 
         opt = qml.ShotAdaptiveOptimizer(min_shots=10)
@@ -479,7 +487,7 @@ class TestWeightedRandomSampling:
         dev = qml.device("default.qubit", wires=2, shots=100)
         H = qml.Hamiltonian(coeffs, [qml.PauliZ(0), qml.PauliX(1), qml.PauliZ(0) @ qml.PauliZ(1)])
 
-        expval_cost = qml.ExpvalCost(qml.templates.StronglyEntanglingLayers, H, dev)
+        expval_cost = catch_warn_ExpvalCost(qml.templates.StronglyEntanglingLayers, H, dev)
         weights = np.random.random(qml.templates.StronglyEntanglingLayers.shape(3, 2))
 
         opt = qml.ShotAdaptiveOptimizer(min_shots=10)
@@ -544,7 +552,7 @@ class TestOptimization:
             qml.Rot(*x[3], wires=1)
             qml.CNOT(wires=[0, 1])
 
-        cost = qml.ExpvalCost(ansatz, H, dev)
+        cost = catch_warn_ExpvalCost(ansatz, H, dev)
         params = np.random.random((4, 3), requires_grad=True)
         initial_loss = cost(params)
 
@@ -594,7 +602,7 @@ class TestStepAndCost:
             qml.RY(x[1], wires=0)
 
         H = qml.Hamiltonian([1.0], [qml.PauliZ(0)])
-        circuit = qml.ExpvalCost(ansatz, H, dev)
+        circuit = catch_warn_ExpvalCost(ansatz, H, dev)
         params = np.array([0.1, 0.3], requires_grad=True)
         opt = qml.ShotAdaptiveOptimizer(min_shots=10)
 

--- a/tests/optimize/test_qng.py
+++ b/tests/optimize/test_qng.py
@@ -269,7 +269,7 @@ class TestOptimize:
         obs_list = [qml.PauliX(0), qml.PauliZ(0)]
 
         h = qml.Hamiltonian(coeffs=coeffs, observables=obs_list)
-        with pytest.warns(UserWarning, match="will be deprecated,"):
+        with pytest.warns(UserWarning, match="is deprecated,"):
             cost_fn = qml.ExpvalCost(ansatz=circuit, hamiltonian=h, device=dev)
 
         def gradient(params):

--- a/tests/optimize/test_qng.py
+++ b/tests/optimize/test_qng.py
@@ -269,8 +269,8 @@ class TestOptimize:
         obs_list = [qml.PauliX(0), qml.PauliZ(0)]
 
         h = qml.Hamiltonian(coeffs=coeffs, observables=obs_list)
-
-        cost_fn = qml.ExpvalCost(ansatz=circuit, hamiltonian=h, device=dev)
+        with pytest.warns(UserWarning, match="will be deprecated,"):
+            cost_fn = qml.ExpvalCost(ansatz=circuit, hamiltonian=h, device=dev)
 
         def gradient(params):
             """Returns the gradient"""

--- a/tests/qchem/of_tests/test_convert.py
+++ b/tests/qchem/of_tests/test_convert.py
@@ -29,6 +29,14 @@ openfermion = pytest.importorskip("openfermion")
 openfermionpyscf = pytest.importorskip("openfermionpyscf")
 
 
+def catch_warn_ExpvalCost(ansatz, hamiltonian, device, **kwargs):
+    """Computes the ExpvalCost and catches the initial deprecation warning."""
+
+    with pytest.warns(UserWarning, match="will be deprecated,"):
+        res = qml.ExpvalCost(ansatz, hamiltonian, device, **kwargs)
+    return res
+
+
 @pytest.fixture(
     scope="module",
     params=[
@@ -556,7 +564,7 @@ def test_integration_observable_to_vqe_cost(
         for phi, w in zip(phis, wires):
             qml.RX(phi, wires=w)
 
-    dummy_cost = qml.ExpvalCost(dummy_ansatz, vqe_observable, dev)
+    dummy_cost = catch_warn_ExpvalCost(dummy_ansatz, vqe_observable, dev)
     params = [0.1 * i for i in range(num_qubits)]
     res = dummy_cost(params)
 
@@ -666,7 +674,7 @@ def test_integration_mol_file_to_vqe_cost(
 
     phis = np.load(os.path.join(ref_dir, "dummy_ansatz_parameters.npy"))
 
-    dummy_cost = qml.ExpvalCost(dummy_ansatz, vqe_hamiltonian, dev)
+    dummy_cost = catch_warn_ExpvalCost(dummy_ansatz, vqe_hamiltonian, dev)
     res = dummy_cost(phis)
 
     assert np.abs(res - expected_cost) < tol["atol"]

--- a/tests/qchem/of_tests/test_convert.py
+++ b/tests/qchem/of_tests/test_convert.py
@@ -32,7 +32,7 @@ openfermionpyscf = pytest.importorskip("openfermionpyscf")
 def catch_warn_ExpvalCost(ansatz, hamiltonian, device, **kwargs):
     """Computes the ExpvalCost and catches the initial deprecation warning."""
 
-    with pytest.warns(UserWarning, match="will be deprecated,"):
+    with pytest.warns(UserWarning, match="is deprecated,"):
         res = qml.ExpvalCost(ansatz, hamiltonian, device, **kwargs)
     return res
 

--- a/tests/qchem/of_tests/test_dipole_of.py
+++ b/tests/qchem/of_tests/test_dipole_of.py
@@ -239,7 +239,8 @@ def test_dipole(symbols, coords, charge, hf_state, exp_dipole, tol, tmpdir):
     def circuit(param, wires):
         qml.BasisState(hf_state, wires=wires)
 
-    dipole = np.array([qml.ExpvalCost(circuit, obs, dev)(0.0) for obs in dip_obs])
+    with pytest.warns(UserWarning, match="will be deprecated,"):
+        dipole = np.array([qml.ExpvalCost(circuit, obs, dev)(0.0) for obs in dip_obs])
 
     assert np.allclose(dipole, exp_dipole, **tol)
 

--- a/tests/qchem/of_tests/test_dipole_of.py
+++ b/tests/qchem/of_tests/test_dipole_of.py
@@ -239,7 +239,7 @@ def test_dipole(symbols, coords, charge, hf_state, exp_dipole, tol, tmpdir):
     def circuit(param, wires):
         qml.BasisState(hf_state, wires=wires)
 
-    with pytest.warns(UserWarning, match="will be deprecated,"):
+    with pytest.warns(UserWarning, match="is deprecated,"):
         dipole = np.array([qml.ExpvalCost(circuit, obs, dev)(0.0) for obs in dip_obs])
 
     assert np.allclose(dipole, exp_dipole, **tol)

--- a/tests/test_qaoa.py
+++ b/tests/test_qaoa.py
@@ -76,7 +76,7 @@ b_rx.add_edges_from([(0, 1, ""), (1, 2, ""), (0, 2, "")])
 def catch_warn_ExpvalCost(ansatz, hamiltonian, device, **kwargs):
     """Computes the ExpvalCost and catches the initial deprecation warning."""
 
-    with pytest.warns(UserWarning, match="will be deprecated,"):
+    with pytest.warns(UserWarning, match="is deprecated,"):
         res = qml.ExpvalCost(ansatz, hamiltonian, device, **kwargs)
     return res
 

--- a/tests/test_qaoa.py
+++ b/tests/test_qaoa.py
@@ -73,6 +73,14 @@ b_rx.add_nodes_from(["b", 1, 0.3])
 b_rx.add_edges_from([(0, 1, ""), (1, 2, ""), (0, 2, "")])
 
 
+def catch_warn_ExpvalCost(ansatz, hamiltonian, device, **kwargs):
+    """Computes the ExpvalCost and catches the initial deprecation warning."""
+
+    with pytest.warns(UserWarning, match="will be deprecated,"):
+        res = qml.ExpvalCost(ansatz, hamiltonian, device, **kwargs)
+    return res
+
+
 def decompose_hamiltonian(hamiltonian):
     coeffs = list(qml.math.toarray(hamiltonian.coeffs))
     ops = [i.name for i in hamiltonian.ops]
@@ -1208,7 +1216,7 @@ class TestIntegration:
 
         # Defines the device and the QAOA cost function
         dev = qml.device("default.qubit", wires=len(wires))
-        cost_function = qml.ExpvalCost(circuit, cost_h, dev)
+        cost_function = catch_warn_ExpvalCost(circuit, cost_h, dev)
 
         res = cost_function([[1, 1], [1, 1]])
         expected = -1.8260274380964299
@@ -1242,7 +1250,7 @@ class TestIntegration:
 
         # Defines the device and the QAOA cost function
         dev = qml.device("default.qubit", wires=len(wires))
-        cost_function = qml.ExpvalCost(circuit, cost_h, dev)
+        cost_function = catch_warn_ExpvalCost(circuit, cost_h, dev)
 
         res = cost_function([[1, 1], [1, 1]])
         expected = -1.8260274380964299
@@ -1862,7 +1870,7 @@ class TestCycles:
         def states(basis_state, **kwargs):
             qml.BasisState(basis_state, wires=range(wires))
 
-        cost = qml.ExpvalCost(states, h, dev, optimize=True)
+        cost = catch_warn_ExpvalCost(states, h, dev, optimize=True)
 
         # Calculate the set of all bitstrings
         bitstrings = itertools.product([0, 1], repeat=wires)
@@ -1915,7 +1923,7 @@ class TestCycles:
         def energy(basis_state, **kwargs):
             qml.BasisState(basis_state, wires=range(wires))
 
-        cost = qml.ExpvalCost(energy, h, dev, optimize=True)
+        cost = catch_warn_ExpvalCost(energy, h, dev, optimize=True)
 
         # Calculate the set of all bitstrings
         states = itertools.product([0, 1], repeat=wires)
@@ -1977,7 +1985,7 @@ class TestCycles:
         def states(basis_state, **kwargs):
             qml.BasisState(basis_state, wires=range(wires))
 
-        cost = qml.ExpvalCost(states, h, dev, optimize=True)
+        cost = catch_warn_ExpvalCost(states, h, dev, optimize=True)
 
         # Calculate the set of all bitstrings
         bitstrings = itertools.product([0, 1], repeat=wires)

--- a/tests/test_vqe.py
+++ b/tests/test_vqe.py
@@ -29,6 +29,14 @@ def seed():
     np.random.seed(0)
 
 
+def catch_warn_ExpvalCost(ansatz, hamiltonian, device, **kwargs):
+    """Computes the ExpvalCost and catches the initial deprecation warning."""
+
+    with pytest.warns(UserWarning, match="will be deprecated,"):
+        res = qml.ExpvalCost(ansatz, hamiltonian, device, **kwargs)
+    return res
+
+
 #####################################################
 # Hamiltonians
 
@@ -317,7 +325,7 @@ class TestVQE:
         """Tests that the cost function evaluates properly"""
         hamiltonian = qml.Hamiltonian(coeffs, observables)
         dev = qml.device("default.qubit", wires=3)
-        expval = qml.ExpvalCost(ansatz, hamiltonian, dev)
+        expval = catch_warn_ExpvalCost(ansatz, hamiltonian, dev)
         assert type(expval(params)) == np.float64
         assert np.shape(expval(params)) == ()  # expval should be scalar
 
@@ -328,7 +336,7 @@ class TestVQE:
         """Tests that the cost function returns correct expectation values"""
         dev = qml.device("default.qubit", wires=2)
         hamiltonian = qml.Hamiltonian(coeffs, observables)
-        cost = qml.ExpvalCost(lambda params, **kwargs: None, hamiltonian, dev)
+        cost = catch_warn_ExpvalCost(lambda params, **kwargs: None, hamiltonian, dev)
         assert cost([]) == sum(expected)
 
     @pytest.mark.parametrize("ansatz", JUNK_INPUTS)
@@ -336,7 +344,7 @@ class TestVQE:
         """Tests that the cost function raises an exception if the ansatz is not valid"""
         hamiltonian = qml.Hamiltonian((1.0,), [qml.PauliZ(0)])
         with pytest.raises(ValueError, match="not a callable function."):
-            cost = qml.ExpvalCost(4, hamiltonian, mock_device())
+            cost = catch_warn_ExpvalCost(4, hamiltonian, mock_device())
 
     @pytest.mark.autograd
     @pytest.mark.parametrize("coeffs, observables, expected", hamiltonians_with_expvals)
@@ -346,7 +354,9 @@ class TestVQE:
         keyword arguments."""
         dev = qml.device("default.qubit", wires=2)
         hamiltonian = qml.Hamiltonian(coeffs, observables)
-        cost = qml.ExpvalCost(lambda params, **kwargs: None, hamiltonian, dev, h=123, order=2)
+        cost = catch_warn_ExpvalCost(
+            lambda params, **kwargs: None, hamiltonian, dev, h=123, order=2
+        )
 
         # Checking that the qnodes contain the step size and order
         for qnode in cost.qnodes:
@@ -364,7 +374,7 @@ class TestVQE:
         dev = qml.device("default.qubit", wires=4, shots=shots)
         hamiltonian = big_hamiltonian
 
-        cost = qml.ExpvalCost(
+        cost = catch_warn_ExpvalCost(
             qml.templates.StronglyEntanglingLayers,
             hamiltonian,
             dev,
@@ -372,7 +382,7 @@ class TestVQE:
             interface="torch",
             diff_method="parameter-shift",
         )
-        cost2 = qml.ExpvalCost(
+        cost2 = catch_warn_ExpvalCost(
             qml.templates.StronglyEntanglingLayers,
             hamiltonian,
             dev,
@@ -407,7 +417,7 @@ class TestVQE:
         dev = qml.device("default.qubit", wires=4, shots=shots)
         hamiltonian = big_hamiltonian
 
-        cost = qml.ExpvalCost(
+        cost = catch_warn_ExpvalCost(
             qml.templates.StronglyEntanglingLayers,
             hamiltonian,
             dev,
@@ -415,7 +425,7 @@ class TestVQE:
             interface="tf",
             diff_method="parameter-shift",
         )
-        cost2 = qml.ExpvalCost(
+        cost2 = catch_warn_ExpvalCost(
             qml.templates.StronglyEntanglingLayers,
             hamiltonian,
             dev,
@@ -450,7 +460,7 @@ class TestVQE:
         dev = qml.device("default.qubit", wires=4, shots=shots)
         hamiltonian = big_hamiltonian
 
-        cost = qml.ExpvalCost(
+        cost = catch_warn_ExpvalCost(
             qml.templates.StronglyEntanglingLayers,
             hamiltonian,
             dev,
@@ -458,7 +468,7 @@ class TestVQE:
             interface="autograd",
             diff_method="parameter-shift",
         )
-        cost2 = qml.ExpvalCost(
+        cost2 = catch_warn_ExpvalCost(
             qml.templates.StronglyEntanglingLayers,
             hamiltonian,
             dev,
@@ -504,7 +514,7 @@ class TestVQE:
         coefs = (np.random.rand(len(obs)) - 0.5) * 2
         hamiltonian = qml.Hamiltonian(coefs, obs)
 
-        cost = qml.ExpvalCost(
+        cost = catch_warn_ExpvalCost(
             qml.templates.StronglyEntanglingLayers,
             hamiltonian,
             dev,
@@ -512,7 +522,7 @@ class TestVQE:
             interface="autograd",
             diff_method="parameter-shift",
         )
-        cost2 = qml.ExpvalCost(
+        cost2 = catch_warn_ExpvalCost(
             qml.templates.StronglyEntanglingLayers,
             hamiltonian,
             dev,
@@ -558,7 +568,7 @@ class TestVQE:
         coefs = (np.random.rand(len(obs)) - 0.5) * 2
         hamiltonian = qml.Hamiltonian(coefs, obs)
 
-        cost = qml.ExpvalCost(
+        cost = catch_warn_ExpvalCost(
             qml.templates.StronglyEntanglingLayers,
             hamiltonian,
             dev,
@@ -566,7 +576,7 @@ class TestVQE:
             interface="torch",
             diff_method="parameter-shift",
         )
-        cost2 = qml.ExpvalCost(
+        cost2 = catch_warn_ExpvalCost(
             qml.templates.StronglyEntanglingLayers,
             hamiltonian,
             dev,
@@ -612,7 +622,7 @@ class TestVQE:
         coefs = (np.random.rand(len(obs)) - 0.5) * 2
         hamiltonian = qml.Hamiltonian(coefs, obs)
 
-        cost = qml.ExpvalCost(
+        cost = catch_warn_ExpvalCost(
             qml.templates.StronglyEntanglingLayers,
             hamiltonian,
             dev,
@@ -620,7 +630,7 @@ class TestVQE:
             interface="tf",
             diff_method="parameter-shift",
         )
-        cost2 = qml.ExpvalCost(
+        cost2 = catch_warn_ExpvalCost(
             qml.templates.StronglyEntanglingLayers,
             hamiltonian,
             dev,
@@ -652,14 +662,14 @@ class TestVQE:
         dev = qml.device("default.qubit", wires=4)
         hamiltonian = big_hamiltonian
 
-        cost = qml.ExpvalCost(
+        cost = catch_warn_ExpvalCost(
             qml.templates.StronglyEntanglingLayers,
             hamiltonian,
             dev,
             optimize=True,
             diff_method="parameter-shift",
         )
-        cost2 = qml.ExpvalCost(
+        cost2 = catch_warn_ExpvalCost(
             qml.templates.StronglyEntanglingLayers,
             hamiltonian,
             dev,
@@ -690,7 +700,7 @@ class TestVQE:
         dev = qml.device("default.qubit", wires=4)
         hamiltonian = qml.Hamiltonian([0], [qml.PauliX(0)])
 
-        cost = qml.ExpvalCost(
+        cost = catch_warn_ExpvalCost(
             qml.templates.StronglyEntanglingLayers,
             hamiltonian,
             dev,
@@ -716,7 +726,7 @@ class TestVQE:
         dev = qml.device("default.qubit", wires=4)
         hamiltonian = big_hamiltonian
 
-        cost = qml.ExpvalCost(
+        cost = catch_warn_ExpvalCost(
             qml.templates.StronglyEntanglingLayers,
             hamiltonian,
             dev,
@@ -745,7 +755,7 @@ class TestVQE:
         dev = qml.device("default.qubit", wires=4)
         hamiltonian = big_hamiltonian
 
-        cost = qml.ExpvalCost(
+        cost = catch_warn_ExpvalCost(
             qml.templates.StronglyEntanglingLayers, hamiltonian, dev, optimize=True, interface="tf"
         )
 
@@ -775,7 +785,7 @@ class TestVQE:
             qml.PhaseShift(params[2], wires=1)
 
         h = qml.Hamiltonian([1, 1], [qml.PauliZ(0), qml.PauliZ(1)])
-        qnodes = qml.ExpvalCost(ansatz, h, dev)
+        qnodes = catch_warn_ExpvalCost(ansatz, h, dev)
         mt = qml.metric_tensor(qnodes, approx=approx)(p)
         assert mt.shape == (3, 3)
         assert isinstance(mt, pnp.ndarray)
@@ -790,7 +800,7 @@ class TestVQE:
         obs = [qml.PauliZ(0), qml.PauliZ(1)]
         h = qml.Hamiltonian([1, 1], obs)
 
-        qnodes = qml.ExpvalCost(qml.templates.BasicEntanglerLayers, h, dev)
+        qnodes = catch_warn_ExpvalCost(qml.templates.BasicEntanglerLayers, h, dev)
         np.random.seed(1967)
         w = np.random.random(qml.templates.BasicEntanglerLayers.shape(n_layers=3, n_wires=2))
         w = pnp.array(w, requires_grad=True)
@@ -815,7 +825,7 @@ class TestVQE:
         h = qml.Hamiltonian([1, 1], [qml.PauliZ(0), qml.PauliZ(1)])
 
         with pytest.raises(ValueError, match="Using multiple devices is not supported when"):
-            qml.ExpvalCost(qml.templates.StronglyEntanglingLayers, h, dev, optimize=True)
+            catch_warn_ExpvalCost(qml.templates.StronglyEntanglingLayers, h, dev, optimize=True)
 
     def test_variance_error(self):
         """Test that an error is raised if attempting to use ExpvalCost to measure
@@ -824,7 +834,9 @@ class TestVQE:
         hamiltonian = big_hamiltonian
 
         with pytest.raises(ValueError, match="sums of expectation values"):
-            qml.ExpvalCost(qml.templates.StronglyEntanglingLayers, hamiltonian, dev, measure="var")
+            catch_warn_ExpvalCost(
+                qml.templates.StronglyEntanglingLayers, hamiltonian, dev, measure="var"
+            )
 
 
 # Test data
@@ -1153,7 +1165,7 @@ class TestAutogradInterface:
         a, b = 0.54, 0.123
         params = np.array([a, b])
 
-        cost = qml.ExpvalCost(ansatz, H, dev, interface=interface)
+        cost = catch_warn_ExpvalCost(ansatz, H, dev, interface=interface)
         dcost = qml.grad(cost, argnum=[0])
         res = dcost(params)
 
@@ -1199,7 +1211,7 @@ class TestTorchInterface:
         a, b = 0.54, 0.123
         params = torch.autograd.Variable(torch.tensor([a, b]), requires_grad=True)
 
-        cost = qml.ExpvalCost(ansatz, H, dev, interface="torch")
+        cost = catch_warn_ExpvalCost(ansatz, H, dev, interface="torch")
         loss = cost(params)
         loss.backward()
 
@@ -1249,7 +1261,7 @@ class TestTFInterface:
         H = qml.Hamiltonian(coeffs, observables)
         a, b = 0.54, 0.123
         params = tf.Variable([a, b], dtype=tf.float64)
-        cost = qml.ExpvalCost(ansatz, H, dev, interface="tf")
+        cost = catch_warn_ExpvalCost(ansatz, H, dev, interface="tf")
 
         with tf.GradientTape() as tape:
             loss = cost(params)
@@ -1288,7 +1300,7 @@ class TestMultipleInterfaceIntegration:
         w = tf.Variable(params)
         ansatz = qml.templates.layers.StronglyEntanglingLayers
 
-        cost = qml.ExpvalCost(ansatz, H, dev, interface="tf")
+        cost = catch_warn_ExpvalCost(ansatz, H, dev, interface="tf")
 
         with tf.GradientTape() as tape:
             loss = cost(w)
@@ -1299,7 +1311,7 @@ class TestMultipleInterfaceIntegration:
         w = torch.autograd.Variable(w, requires_grad=True)
         ansatz = qml.templates.layers.StronglyEntanglingLayers
 
-        cost = qml.ExpvalCost(ansatz, H, dev, interface="torch")
+        cost = catch_warn_ExpvalCost(ansatz, H, dev, interface="torch")
         loss = cost(w)
         loss.backward()
         res_torch = w.grad.numpy()
@@ -1307,7 +1319,7 @@ class TestMultipleInterfaceIntegration:
         # NumPy interface
         w = params
         ansatz = qml.templates.layers.StronglyEntanglingLayers
-        cost = qml.ExpvalCost(ansatz, H, dev, interface="autograd")
+        cost = catch_warn_ExpvalCost(ansatz, H, dev, interface="autograd")
         dcost = qml.grad(cost, argnum=[0])
         res = dcost(w)
 

--- a/tests/test_vqe.py
+++ b/tests/test_vqe.py
@@ -32,7 +32,7 @@ def seed():
 def catch_warn_ExpvalCost(ansatz, hamiltonian, device, **kwargs):
     """Computes the ExpvalCost and catches the initial deprecation warning."""
 
-    with pytest.warns(UserWarning, match="will be deprecated,"):
+    with pytest.warns(UserWarning, match="is deprecated,"):
         res = qml.ExpvalCost(ansatz, hamiltonian, device, **kwargs)
     return res
 

--- a/tests/transforms/test_adjoint_metric_tensor.py
+++ b/tests/transforms/test_adjoint_metric_tensor.py
@@ -857,7 +857,7 @@ class TestErrors:
         def ansatz(x, wires):
             qml.RX(x, wires=0)
 
-        with pytest.warns(UserWarning, match="will be deprecated,"):
+        with pytest.warns(UserWarning, match="is deprecated,"):
             cost = qml.ExpvalCost(ansatz, H, [dev1, dev2])
         with pytest.warns(UserWarning, match="ExpvalCost was instantiated"):
             mt = qml.adjoint_metric_tensor(cost)

--- a/tests/transforms/test_adjoint_metric_tensor.py
+++ b/tests/transforms/test_adjoint_metric_tensor.py
@@ -857,6 +857,7 @@ class TestErrors:
         def ansatz(x, wires):
             qml.RX(x, wires=0)
 
-        cost = qml.ExpvalCost(ansatz, H, [dev1, dev2])
+        with pytest.warns(UserWarning, match="will be deprecated,"):
+            cost = qml.ExpvalCost(ansatz, H, [dev1, dev2])
         with pytest.warns(UserWarning, match="ExpvalCost was instantiated"):
             mt = qml.adjoint_metric_tensor(cost)


### PR DESCRIPTION
**Context:**

Currently, `qml.expval()` does not allow for lists of operators that are not commuting. I.e. the following code

```python
import pennylane as qml
with qml.tape.QuantumTape() as tape:
    qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
    qml.expval(qml.PauliY(0))
qml.tape.tape.expand_tape(tape)
```
produces an error message as the observables do not commute.

**Description of the Change:**

The idea is to split the tape into groups of commuting observables, compute those, and recombine them.  
We want to do this in the device class on the call of batch_transform() in a similar way as Hamiltonians are expanded.  

For this we first need the list of observables, which in the current state of the operator and observable classes is a bit cumbersome. This should be easier once those classes are updated.
Now this list of observables is grouped into commuting groups using `qml.groupings.group_observables()`. We keep track of the indices by also passing a list of dummy coefficients.

Then a new tape for each of those groups is generated and passed. In the end we recombine all results into a single list with the same order as the observables have been initially given.

**Re-structuring after grouping**

We want the user not to know that this grouping has taken place internally and output the same shape and order as the input of expectation values. For this we need to pass a non-trivial classical processing function. I decided to go with the following:
```python
def reorder_fn(res):
    return qml.math.concatenate(res)[qml.math.concatenate(group_coeffs)]
```
`res` is a list of results for each commuting group. So the first step, concatenating those results produces a list of the original size. The second step is re-ordering the results according to the original input. An example for the following circuit
```python
import pennylane as qml
dev = qml.device("default.qubit", wires=5)
@qml.qnode(dev)
def circ():
    return [qml.expval(qml.PauliZ(0) @ qml.PauliZ(1)),
    qml.expval(qml.PauliY(0)),
    qml.expval(qml.PauliZ(1)),
    qml.expval(qml.PauliX(1) @ qml.PauliX(4)),
    qml.expval(qml.PauliX(3))]
```
Here the we would internally have `res = [tensor([1., 1., 0.], requires_grad=True), tensor([0., 0.], requires_grad=True)]` and `group_coeffs = [array([0, 2, 4]), array([1, 3])]`. So `reorder_fn` computes
```python
reorder_fn(res) = tensor([1., 1., 0., 0., 0.,], requires_grad=True)[array(0,2,4,1,3)] = tensor([1., 0., 0., 1., 0.], requires_grad=True)
```

**Status at initial WIP PR**

With the current changes, cases like the following work:
```python
import pennylane as qml
dev = qml.device("default.qubit", wires=5)
@qml.qnode(dev)
def circ():
    return [qml.expval(qml.PauliZ(0) @ qml.PauliZ(1)),
    qml.expval(qml.PauliY(0)),
    qml.expval(qml.PauliZ(1)),
    qml.expval(qml.PauliX(1) @ qml.PauliX(4)),
    qml.expval(qml.PauliX(3))]
circ()
```

```python
import pennylane as qml
dev = qml.device("default.qubit", wires=2)
@qml.qnode(dev)
def circ():
    qml.QubitStateVector([0.+0.j, 0.+0.j, 0.+1.j, 0.+0.j], wires=range(2))
    return [qml.expval(qml.PauliZ(0) @ qml.PauliZ(1)),
    qml.expval(qml.PauliY(0)),
    qml.expval(qml.PauliZ(1))]
circ()
```

```python
import pennylane as qml
dev = qml.device("default.qubit", wires=2)
@qml.qnode(dev)
def circ():
    qml.PauliY(0)
    return [qml.expval(qml.PauliZ(0) @ qml.PauliZ(1)),
    qml.expval(qml.PauliY(0)),
    qml.expval(qml.PauliZ(1))]
circ()
```

```python
import pennylane as qml
dev = qml.device("default.qubit", wires=2)
H = qml.Hamiltonian([0.5,0.5],[qml.PauliZ(0), qml.PauliZ(1)])
@qml.qnode(dev)
def circ():
    qml.PauliY(0)
    return qml.expval(H), qml.expval(H)
circ()
```

However, some of the tests in the test suite still fail, so I need to figure out why that is and make changes accordingly.


**Possible Drawbacks:**

Statevector devies can compute non-commuting observables straight away so they should be treated as a special case for speed ups in a separate PR.

**Related GitHub Issues:**
