### PR TITLE
[Bugfix] Interface name variations dispatch to correct backprop device

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -114,6 +114,7 @@
 * `QNode`'s now map variations on interface names to the proper backpropagation device instead of
   reverting to other differentiation methods.
   [(#2591)](https://github.com/PennyLaneAI/pennylane/pull/2591)
+
 * Fixed a bug for `diff_method="adjoint"` where incorrect gradients were
   computed for QNodes with parametrized observables (e.g., `qml.Hermitian`).
   [(#2543)](https://github.com/PennyLaneAI/pennylane/pull/2543)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -108,6 +108,9 @@
 
 <h3>Bug fixes</h3>
 
+* `QNode`'s now map variations on interface names to the proper backpropagation device instead of
+  reverting to other differentiation methods.
+
 * Fixed a bug for `diff_method="adjoint"` where incorrect gradients were
   computed for QNodes with parametrized observables (e.g., `qml.Hermitian`).
   [(#2543)](https://github.com/PennyLaneAI/pennylane/pull/2543)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -111,8 +111,7 @@
 
 <h3>Bug fixes</h3>
 
-* `QNode`'s now map variations on interface names to the proper backpropagation device instead of
-  reverting to other differentiation methods.
+* `QNode`'s now can interpret variations on the interface name, like `"tensorflow"` or `"jax-jit"`, when requesting backpropagation. 
   [(#2591)](https://github.com/PennyLaneAI/pennylane/pull/2591)
 
 * Fixed a bug for `diff_method="adjoint"` where incorrect gradients were

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -113,7 +113,7 @@
 
 * `QNode`'s now map variations on interface names to the proper backpropagation device instead of
   reverting to other differentiation methods.
-
+  [(#2591)](https://github.com/PennyLaneAI/pennylane/pull/2591)
 * Fixed a bug for `diff_method="adjoint"` where incorrect gradients were
   computed for QNodes with parametrized observables (e.g., `qml.Hermitian`).
   [(#2543)](https://github.com/PennyLaneAI/pennylane/pull/2543)

--- a/pennylane/interfaces/__init__.py
+++ b/pennylane/interfaces/__init__.py
@@ -41,7 +41,7 @@ Supported interfaces
     ~interfaces.torch
 
 """
-from .execution import cache_execute, execute, INTERFACE_NAMES, SUPPORTED_INTERFACES
+from .execution import cache_execute, execute, INTERFACE_MAP, SUPPORTED_INTERFACES
 from .set_shots import set_shots
 
 

--- a/pennylane/qnode.py
+++ b/pennylane/qnode.py
@@ -406,7 +406,7 @@ class QNode:
         if device.shots is not None:
             raise qml.QuantumFunctionError("Backpropagation is only supported when shots=None.")
 
-        mapped_interface = INTERFACE_MAP[interface]
+        mapped_interface = INTERFACE_MAP.get(interface, interface)
 
         # determine if the device supports backpropagation
         backprop_interface = device.capabilities().get("passthru_interface", None)

--- a/pennylane/qnode.py
+++ b/pennylane/qnode.py
@@ -24,7 +24,7 @@ import autograd
 
 import pennylane as qml
 from pennylane import Device
-from pennylane.interfaces import set_shots, SUPPORTED_INTERFACES
+from pennylane.interfaces import set_shots, SUPPORTED_INTERFACES, INTERFACE_MAP
 
 
 class QNode:
@@ -41,7 +41,8 @@ class QNode:
         func (callable): a quantum function
         device (~.Device): a PennyLane-compatible device
         interface (str): The interface that will be used for classical backpropagation.
-            This affects the types of objects that can be passed to/returned from the QNode:
+            This affects the types of objects that can be passed to/returned from the QNode. See
+            ``qml.interfaces.SUPPORTED_INTERFACES`` for a list of all accepted strings.
 
             * ``"autograd"``: Allows autograd to backpropagate
               through the QNode. The QNode accepts default Python types
@@ -402,19 +403,18 @@ class QNode:
 
     @staticmethod
     def _validate_backprop_method(device, interface):
-        # determine if the device supports backpropagation
-        backprop_interface = device.capabilities().get("passthru_interface", None)
-
-        # determine if the device has any child devices that support backpropagation
-        backprop_devices = device.capabilities().get("passthru_devices", None)
-
         if device.shots is not None:
             raise qml.QuantumFunctionError("Backpropagation is only supported when shots=None.")
+
+        mapped_interface = INTERFACE_MAP[interface]
+
+        # determine if the device supports backpropagation
+        backprop_interface = device.capabilities().get("passthru_interface", None)
 
         if backprop_interface is not None:
             # device supports backpropagation natively
 
-            if interface == backprop_interface:
+            if mapped_interface == backprop_interface:
                 return "backprop", {}, device
 
             raise qml.QuantumFunctionError(
@@ -422,17 +422,20 @@ class QNode:
                 f"{backprop_interface} interface."
             )
 
+        # determine if the device has any child devices that support backpropagation
+        backprop_devices = device.capabilities().get("passthru_devices", None)
+
         if backprop_devices is not None:
             # device is analytic and has child devices that support backpropagation natively
 
-            if interface in backprop_devices:
+            if mapped_interface in backprop_devices:
                 # TODO: need a better way of passing existing device init options
                 # to a new device?
                 expand_fn = device.expand_fn
                 batch_transform = device.batch_transform
 
                 device = qml.device(
-                    backprop_devices[interface],
+                    backprop_devices[mapped_interface],
                     wires=device.wires,
                     shots=device.shots,
                 )

--- a/tests/interfaces/test_autograd.py
+++ b/tests/interfaces/test_autograd.py
@@ -49,8 +49,8 @@ class TestAutogradExecuteUnitTests:
 
         with pytest.raises(
             qml.QuantumFunctionError,
-            match="Autograd not found. Please install the latest version "
-            "of Autograd to enable the 'autograd' interface",
+            match="autograd not found. Please install the latest version "
+            "of autograd to enable the 'autograd' interface",
         ):
             qml.execute([tape], dev, gradient_fn=param_shift, interface="autograd")
 

--- a/tests/test_qnode.py
+++ b/tests/test_qnode.py
@@ -129,6 +129,20 @@ class TestValidation:
         assert method == "backprop"
         assert device is dev
 
+    @pytest.mark.all_interfaces
+    @pytest.mark.parametrize("accepted_name, official_name", qml.interfaces.INTERFACE_MAP.items())
+    def test_validate_backprop_method_all_interface_names(self, accepted_name, official_name):
+        """Test that backprop devices are mapped for all possible interface names."""
+        if accepted_name is None:
+            pytest.skip("None is not a backprop interface.")
+
+        dev = qml.device("default.qubit", wires=1)
+
+        diff_method, _, new_dev = QNode._validate_backprop_method(dev, accepted_name)
+
+        assert diff_method == "backprop"
+        assert new_dev.capabilities().get("passthru_interface") == official_name
+
     def test_validate_backprop_child_method(self, monkeypatch):
         """Test that the method for validating the backprop diff method
         tape works as expected if a child device supports backprop"""


### PR DESCRIPTION
Fixes #2546 

Now if you specify QNodes like:
```
qml.QNode(qfunc, qml.device('default.qubit', wires=1), interface="tensorflow", diff_method="backprop")
```

It will map the device to `default.qubit.tf` and using backpropagation instead of silently switching to a different `diff_method`.

In solving this bug, I substituted `qml.interfaces.INTERFACE_MAP` for `qml.interfaces.INTERFACE_NAMES`, which maps in the opposite direction.  This allowed from some readability improvements. `qml.interfaces.INTERFACE_MAP` maps provided name to canonical name, instead of canonical name to list of acceptable provided names.