### PR TITLE
`op.inv()` method only updates itself and not the queue

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -79,6 +79,7 @@
 
 * Using `Operation.inv()` in a queuing environment no longer updates the queue's metadata, but merely updates
   the operation in place.
+  [(#2596)](https://github.com/PennyLaneAI/pennylane/pull/2596)
 
 <h3>Breaking changes</h3>
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -77,6 +77,9 @@
   method for a provided device and interface, in human-readable format.
   [(#2533)](https://github.com/PennyLaneAI/pennylane/pull/2533)
 
+* Using `Operation.inv()` in a queuing environment no longer updates the queue's metadata, but merely updates
+  the operation in place.
+
 <h3>Breaking changes</h3>
 
 * The unused keyword argument `do_queue` for `Operation.adjoint` is now fully removed.

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -1318,11 +1318,7 @@ class Operation(Operator):
         Returns:
             :class:`Operator`: operation to be inverted
         """
-        if qml.QueuingContext.recording():
-            current_inv = qml.QueuingContext.get_info(self).get("inverse", False)
-            qml.QueuingContext.update_info(self, inverse=not current_inv)
-        else:
-            self.inverse = not self._inverse
+        self.inverse = not self._inverse
         return self
 
     def matrix(self, wire_order=None):

--- a/pennylane/tape/tape.py
+++ b/pennylane/tape/tape.py
@@ -463,9 +463,6 @@ class QuantumTape(AnnotatedQueue):
                     )
                 getattr(self, obj._queue_category).append(obj)
 
-                if hasattr(obj, "inverse"):
-                    obj.inverse = info.get("inverse", obj.inverse)
-
         self._update()
 
     def _update_circuit_info(self):
@@ -1442,9 +1439,6 @@ class QuantumTape(AnnotatedQueue):
         with QuantumTape() as tape:
             for op in operations:
                 op.queue()
-
-                if op.inverse:
-                    op.inv()
 
         # decompose the queue
         # pylint: disable=no-member

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -596,7 +596,7 @@ class TestInverse:
             num_wires = 1
 
         with qml.tape.QuantumTape() as tape:
-            op = DummyOp(wires=[0])
+            op = DummyOp(wires=[0]).inv()
             assert op.inverse is True
 
         assert op.inverse is True

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -588,18 +588,33 @@ class TestInverse:
         assert dummy_op.inv().name == dummy_op_class_name
         assert not dummy_op.inverse
 
-    def test_inverse_of_operation(self):
-        """Test the inverse of an operation"""
+    def test_inv_queuing(self):
+        """Test that inv updates the inverse property in place during queuing."""
+
+        class DummyOp(qml.operation.Operation):
+            r"""Dummy custom Operation"""
+            num_wires = 1
+
+        with qml.tape.QuantumTape() as tape:
+            op = DummyOp(wires=[0])
+            assert op.inverse is True
+
+        assert op.inverse is True
+
+    def test_inverse_integration(self):
+        """Test that the inv integrates with qnode execution. An operation followed by the inverse
+        operation should leave the state unchanged.
+        """
 
         dev1 = qml.device("default.qubit", wires=2)
 
         @qml.qnode(dev1)
         def circuit():
-            qml.PauliZ(wires=[0])
-            qml.PauliZ(wires=[0]).inv()
-            return qml.expval(qml.PauliZ(0))
+            qml.RX(1.234, wires=0)
+            qml.RX(1.234, wires=0).inv()
+            return qml.state()
 
-        assert circuit() == 1
+        assert qml.math.allclose(circuit()[0], 1)
 
     def test_inverse_operations_not_supported(self):
         """Test that the inverse of operations is not currently


### PR DESCRIPTION
I decided to make this change because the current behaviour was causing problems for a different PR I was working on. Also, this behaviour has always confused and annoyed me.

The problem I was encountering dealt with something like this situation:

```
>>> with qml.tape.QuantumTape() as tape:
        ob = qml.PauliX(0).inv() @ qml.PauliY(1)
>>> ob
PauliX(wires=[0]) @ PauliY(wires=[1])
```
Because the `PauliX` gate was "owned" by the tensor, it never gets inverted when the queue is being processed.  This was so far an invisible bug because tensors and Hamiltonians tend to contain `Operation`'s that are self-inverses.

I can't figure out why we are using the queue metadata in this situation, and removing this behaviour does not cause any tests to fail.

So this is just a tiny bit of cleaning.