### PR TITLE
Remove `qml.queuing.Queue` class

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -79,6 +79,9 @@
 
 <h3>Breaking changes</h3>
 
+* The `qml.queuing.Queue` class is now removed.
+  [(#2599)](https://github.com/PennyLaneAI/pennylane/pull/2599)
+
 * The unused keyword argument `do_queue` for `Operation.adjoint` is now fully removed.
   [(#2583)](https://github.com/PennyLaneAI/pennylane/pull/2583)
 

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -1746,8 +1746,6 @@ class Tensor(Observable):
             except qml.queuing.QueuingError:
                 o.queue(context=context)
                 context.update_info(o, owner=self)
-            except NotImplementedError:
-                pass
 
         context.append(self, owns=tuple(constituents))
         return self
@@ -2014,7 +2012,9 @@ class Tensor(Observable):
                 return 1
         return 0
 
-    def sparse_matrix(self, wires=None, format="csr"):  # pylint:disable=arguments-renamed
+    def sparse_matrix(
+        self, wires=None, format="csr"
+    ):  # pylint:disable=arguments-renamed, arguments-differ
         r"""Computes, by default, a `scipy.sparse.csr_matrix` representation of this Tensor.
 
         This is useful for larger qubit numbers, where the dense matrix becomes very large, while

--- a/pennylane/queuing.py
+++ b/pennylane/queuing.py
@@ -209,25 +209,6 @@ class QueuingContext(abc.ABC):
         raise NotImplementedError
 
 
-class Queue(QueuingContext):
-    """Lightweight class that maintains a basic queue of objects."""
-
-    def __init__(self):
-        self.queue = []
-
-    def _append(self, obj, **kwargs):
-        self.queue.append(obj)
-
-    def _remove(self, obj):
-        self.queue.remove(obj)
-
-    # Overwrite the inherited class methods, so that if queue.append is called,
-    # it is appended to the instantiated queue (rather than being added to the
-    # currently active queuing context, which may be a different queue).
-    append = _append
-    remove = _remove
-
-
 class AnnotatedQueue(QueuingContext):
     """Lightweight class that maintains a basic queue of operations, in addition
     to metadata annotations."""

--- a/pennylane/queuing.py
+++ b/pennylane/queuing.py
@@ -185,9 +185,9 @@ class QueuingContext(abc.ABC):
         if cls.recording():
             cls.active_context()._update_info(obj, **kwargs)  # pylint: disable=protected-access
 
+    @abc.abstractmethod
     def _update_info(self, obj, **kwargs):
         """Updates information of an object in the queue instance."""
-        raise NotImplementedError
 
     @classmethod
     def get_info(cls, obj):
@@ -204,9 +204,9 @@ class QueuingContext(abc.ABC):
 
         return None
 
+    @abc.abstractmethod
     def _get_info(self, obj):
         """Retrieves information of an object in the queue instance."""
-        raise NotImplementedError
 
 
 class AnnotatedQueue(QueuingContext):

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -662,7 +662,7 @@ class TestTensor:
         ):
             Tensor(T, qml.CNOT(wires=[0, 1]))
 
-    def test_queuing(self):
+    def test_queuing_defined_outside(self):
         """Test the queuing of a Tensor object."""
 
         op1 = qml.PauliX(0)
@@ -671,6 +671,23 @@ class TestTensor:
 
         with qml.tape.QuantumTape() as tape:
             T.queue()
+
+        assert len(tape.queue) == 3
+        assert tape.queue[0] is op1
+        assert tape.queue[1] is op2
+        assert tape.queue[2] is T
+
+        assert tape._queue[op1] == {"owner": T}
+        assert tape._queue[op2] == {"owner": T}
+        assert tape._queue[T] == {"owns": (op1, op2)}
+
+    def test_queuing(self):
+        """Test the queuing of a Tensor object."""
+
+        with qml.tape.QuantumTape() as tape:
+            op1 = qml.PauliX(0)
+            op2 = qml.PauliY(1)
+            T = Tensor(op1, op2)
 
         assert len(tape.queue) == 3
         assert tape.queue[0] is op1

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -713,6 +713,19 @@ class TestTensor:
         assert tape._queue[op2] == {"owner": T}
         assert tape._queue[T] == {"owns": (op1, op2)}
 
+    def test_queuing_matmul(self):
+        """Test queuing when tensor constructed with matmul."""
+
+        with qml.tape.QuantumTape() as tape:
+            op1 = qml.PauliX(0)
+            op2 = qml.PauliY(1)
+            t = op1 @ op2
+
+        assert len(tape.queue) == 3
+        assert tape._queue[op1] == {"owner": t}
+        assert tape._queue[op2] == {"owner": t}
+        assert tape._queue[t] == {"owns": (op1, op2)}
+
     def test_name(self):
         """Test that the names of the observables are
         returned as expected"""

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -662,6 +662,25 @@ class TestTensor:
         ):
             Tensor(T, qml.CNOT(wires=[0, 1]))
 
+    def test_queuing(self):
+        """Test the queuing of a Tensor object."""
+
+        op1 = qml.PauliX(0)
+        op2 = qml.PauliY(1)
+        T = Tensor(op1, op2)
+
+        with qml.tape.QuantumTape() as tape:
+            T.queue()
+
+        assert len(tape.queue) == 3
+        assert tape.queue[0] is op1
+        assert tape.queue[1] is op2
+        assert tape.queue[2] is T
+
+        assert tape._queue[op1] == {"owner": T}
+        assert tape._queue[op2] == {"owner": T}
+        assert tape._queue[T] == {"owns": (op1, op2)}
+
     def test_name(self):
         """Test that the names of the observables are
         returned as expected"""

--- a/tests/test_queuing.py
+++ b/tests/test_queuing.py
@@ -20,7 +20,7 @@ import pytest
 import pennylane as qml
 import numpy as np
 
-from pennylane.queuing import AnnotatedQueue, AnnotatedQueue, Queue, QueuingContext, QueuingError
+from pennylane.queuing import AnnotatedQueue, AnnotatedQueue, QueuingContext, QueuingError
 from pennylane.tape import OperationRecorder
 
 
@@ -112,88 +112,6 @@ class TestQueuingContext:
     def test_no_active_context(self, mock_queuing_context):
         """Test that if there are no active contexts, active_context() returns None"""
         assert mock_queuing_context.active_context() is None
-
-
-class TestQueue:
-    """Test the Queue class."""
-
-    def test_arbitrary_obj(self):
-        """Tests that arbitrary objects can be appended to and removed from the queue."""
-
-        objs = [5, "hi", 1.2, np.einsum, lambda x: x + 1]
-        with Queue() as q:
-            for obj in objs:
-                q.append(obj)
-        assert q.queue == objs
-
-        with q:
-            for _ in range(len(objs)):
-                obj = objs.pop()
-                q.remove(obj)
-                assert q.queue == objs
-
-    def test_remove_not_in_queue(self):
-        """Test that remove fails when the object to be removed is not in the queue."""
-
-        with Queue() as q1:
-            op1 = qml.PauliZ(0)
-            op2 = qml.PauliZ(1)
-            q1.append(op1)
-            q1.append(op2)
-
-        with Queue() as q2:
-            q2.append(op1)
-
-            with pytest.raises(ValueError, match="not in list"):
-                q2.remove(op2)
-
-    def test_append_qubit_gates(self):
-        """Test that gates are successfully appended to the queue."""
-        with Queue() as q:
-            ops = [
-                qml.RX(0.5, wires=0),
-                qml.RY(-10.1, wires=1),
-                qml.CNOT(wires=[0, 1]),
-                qml.PhaseShift(-1.1, wires=18),
-                qml.T(wires=99),
-            ]
-        assert q.queue == ops
-
-    def test_append_qubit_observables(self):
-        """Test that ops that are also observables are successfully
-        appended to the queue."""
-        with Queue() as q:
-            # wire repetition is deliberate, Queue contains no checks/logic
-            # for circuits
-            ops = [
-                qml.Hadamard(wires=0),
-                qml.PauliX(wires=1),
-                qml.PauliY(wires=1),
-                qml.Hermitian(np.ones([2, 2]), wires=7),
-            ]
-        assert q.queue == ops
-
-    def test_append_tensor_ops(self):
-        """Test that ops which are used as inputs to `Tensor`
-        are successfully added to the queue, as well as the `Tensor` object."""
-
-        with Queue() as q:
-            A = qml.PauliZ(0)
-            B = qml.PauliY(1)
-            tensor_op = qml.operation.Tensor(A, B)
-        assert q.queue == [A, B, tensor_op]
-        assert tensor_op.obs == [A, B]
-
-    def test_append_tensor_ops_overloaded(self):
-        """Test that Tensor ops created using `@`
-        are successfully added to the queue, as well as the `Tensor` object."""
-
-        with Queue() as q:
-            A = qml.PauliZ(0)
-            B = qml.PauliY(1)
-            tensor_op = A @ B
-        assert q.queue == [A, B, tensor_op]
-        assert tensor_op.obs == [A, B]
 
 
 class TestAnnotatedQueue:


### PR DESCRIPTION
The `qml.queuing.Queue` class is a vestigial holdover from the early implementation that never ended up being used in anything.  This PR removes this object and it's unit tests.