### PR TITLE
modified `__add__` for `Observable` and `Hamiltonian` to support adding '0'

### DIFF
--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -97,6 +97,7 @@ import abc
 import copy
 import itertools
 import functools
+import numbers
 import warnings
 from enum import IntEnum
 from scipy.sparse import kron, eye, coo_matrix
@@ -1560,11 +1561,15 @@ class Observable(Operator):
 
     def __add__(self, other):
         r"""The addition operation between Observables/Tensors/qml.Hamiltonian objects."""
+        if isinstance(other, numbers.Number) and other == 0:
+            return self
         if isinstance(other, qml.Hamiltonian):
             return other + self
         if isinstance(other, (Observable, Tensor)):
             return qml.Hamiltonian([1, 1], [self, other], simplify=True)
         raise ValueError(f"Cannot add Observable and {type(other)}")
+
+    __radd__ = __add__
 
     def __mul__(self, a):
         r"""The scalar multiplication operation between a scalar and an Observable/Tensor."""

--- a/pennylane/ops/qubit/hamiltonian.py
+++ b/pennylane/ops/qubit/hamiltonian.py
@@ -17,6 +17,7 @@ arithmetic operations on their input states.
 """
 # pylint: disable=too-many-arguments,too-many-instance-attributes
 import itertools
+import numbers
 from copy import copy
 from collections.abc import Iterable
 
@@ -566,6 +567,9 @@ class Hamiltonian(Observable):
         ops = self.ops.copy()
         self_coeffs = copy(self.coeffs)
 
+        if isinstance(H, numbers.Number) and H == 0:
+            return self
+
         if isinstance(H, Hamiltonian):
             coeffs = qml.math.concatenate([self_coeffs, copy(H.coeffs)], axis=0)
             ops.extend(H.ops.copy())
@@ -579,6 +583,8 @@ class Hamiltonian(Observable):
             return qml.Hamiltonian(coeffs, ops, simplify=True)
 
         raise ValueError(f"Cannot add Hamiltonian and {type(H)}")
+
+    __radd__ = __add__
 
     def __mul__(self, a):
         r"""The scalar multiplication operation between a scalar and a Hamiltonian."""

--- a/tests/ops/qubit/test_hamiltonian.py
+++ b/tests/ops/qubit/test_hamiltonian.py
@@ -266,6 +266,14 @@ add_hamiltonians = [
     ),
 ]
 
+add_zero_hamiltonians = [
+    qml.Hamiltonian([1, 1.2, 0.1], [qml.PauliX(0), qml.PauliZ(1), qml.PauliX(2)]),
+    qml.Hamiltonian([1, 1], [qml.PauliX(0), qml.Hermitian(np.array([[1, 0], [0, -1]]), 0)]),
+    qml.Hamiltonian(
+            [1.5, 1.2, 1.1, 0.3], [qml.PauliX(0), qml.PauliZ(1), qml.PauliX(2), qml.PauliX(1)]
+        )
+]
+
 sub_hamiltonians = [
     (
         qml.Hamiltonian([1, 1.2, 0.1], [qml.PauliX(0), qml.PauliZ(1), qml.PauliX(2)]),
@@ -713,6 +721,12 @@ class TestHamiltonian:
     def test_hamiltonian_add(self, H1, H2, H):
         """Tests that Hamiltonians are added correctly"""
         assert H.compare(H1 + H2)
+
+    @pytest.mark.parametrize("H", add_zero_hamiltonians)
+    def test_hamiltonian_add_zero(self, H):
+        """Tests that Hamiltonians can be added to zero"""
+        assert H.compare(H + 0)
+        assert H.compare(0 + H)
 
     @pytest.mark.parametrize(("coeff", "H", "res"), mul_hamiltonians)
     def test_hamiltonian_mul(self, coeff, H, res):

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -1199,6 +1199,13 @@ add_obs = [
     ),
 ]
 
+add_zero_obs = [
+    qml.PauliX(0),
+    qml.Identity(1),
+    qml.Hermitian(np.array([[1, 0], [0, -1]]), 1.2),
+    qml.PauliX(0) @ qml.Hadamard(2)
+]
+
 mul_obs = [
     (qml.PauliZ(0), 3, qml.Hamiltonian([3], [qml.PauliZ(0)])),
     (qml.PauliZ(0) @ qml.Identity(1), 3, qml.Hamiltonian([3], [qml.PauliZ(0)])),
@@ -1300,6 +1307,12 @@ class TestTensorObservableOperations:
     def test_addition(self, obs1, obs2, obs):
         """Tests addition between Tensors and Observables"""
         assert obs.compare(obs1 + obs2)
+
+    @pytest.mark.parametrize("obs", add_zero_obs)
+    def test_add_zero(self, obs):
+        """Tests adding Tensors and Observables to zero"""
+        assert obs.compare(obs + 0)
+        assert obs.compare(0 + obs)
 
     @pytest.mark.parametrize(("coeff", "obs", "res_obs"), mul_obs)
     def test_scalar_multiplication(self, coeff, obs, res_obs):


### PR DESCRIPTION
**Context:**

We would like to be able to sum a list of observables as follows:
```
H = sum([qml.PauliX(i) for i in range(10)])
```
Since `sum` starts at integer `0` by default, we need to define addition between observables and `0`.

**Description of the Change:**

We modified the `__add__` method for `Observable` and `Hamiltonian` classes, so that integer `0` can be added to `Observable` and `Hamiltonian` objects, either from the left side or the right side. Unit tests were added for this feature.

**Benefits:**

Now we can directly `sum` a list of observables in an elegant way.

**Possible Drawbacks:**

None.

**Related GitHub Issues:**

Closes #2423.
