### PR TITLE
Allow broadcasting in the numerical representations of standard operations

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -29,6 +29,26 @@
   array([[[-0.09928388,  0.        ,  0.        ],
         [ 0.        , -0.27633945,  0.        ],
         [ 0.        ,  0.        , -0.09928388]]])
+* Many parametrized operations now allow arguments with a batch dimension
+  [(#2535)](https://github.com/PennyLaneAI/pennylane/pull/2535)
+
+  This feature is not usable as a stand-alone but a technical requirement
+  for future performance improvements.
+  Previously unsupported batched parameters are allowed for example in 
+  standard rotation gates. The batch dimension is the last dimension
+  of operator matrices, eigenvalues etc. Note that the batched parameter
+  has to be passed as an `array` but not as a python `list` or `tuple`.
+
+  ```pycon
+  >>> op = qml.RX(np.array([0.1, 0.2, 0.3], requires_grad=True), 0)
+  >>> np.round(op.matrix(), 4)
+  tensor([[[0.9988+0.j    , 0.995 +0.j    , 0.9888+0.j    ],
+             [0.    -0.05j  , 0.    -0.0998j, 0.    -0.1494j]],
+
+            [[0.    -0.05j  , 0.    -0.0998j, 0.    -0.1494j],
+             [0.9988+0.j    , 0.995 +0.j    , 0.9888+0.j    ]]], requires_grad=True)
+  >>> op.matrix().shape
+  (2, 2, 3)
   ```
 
 * Speed up measuring of commuting Pauli operators

--- a/pennylane/math/single_dispatch.py
+++ b/pennylane/math/single_dispatch.py
@@ -48,6 +48,7 @@ ar.register_function("builtins", "unstack", list)
 # qml.SparseHamiltonian are not automatically 'unwrapped' to dense NumPy arrays.
 ar.register_function("scipy", "to_numpy", lambda x: x)
 ar.register_function("scipy", "shape", np.shape)
+ar.register_function("scipy", "ndim", np.ndim)
 
 
 def _scatter_element_add_numpy(tensor, index, value):

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -190,29 +190,39 @@ def expand_matrix(base_matrix, wires, wire_order):
     # TODO[Maria]: In future we should consider making ``utils.expand`` differentiable and calling it here.
     wire_order = Wires(wire_order)
     n = len(wires)
-    interface = qml.math._multi_dispatch(base_matrix)  # pylint: disable=protected-access
+    shape = qml.math.shape(base_matrix)
+    batch_dim = shape[-1] if len(shape) == 3 else None
+    interface = qml.math.get_interface(base_matrix)  # pylint: disable=protected-access
 
     # operator's wire positions relative to wire ordering
     op_wire_pos = wire_order.indices(wires)
 
     identity = qml.math.reshape(
-        qml.math.eye(2 ** len(wire_order), like=interface), [2] * len(wire_order) * 2
+        qml.math.eye(2 ** len(wire_order), like=interface), [2] * (len(wire_order) * 2)
     )
     axes = (list(range(n, 2 * n)), op_wire_pos)
 
     # reshape op.matrix()
     op_matrix_interface = qml.math.convert_like(base_matrix, identity)
-    mat_op_reshaped = qml.math.reshape(op_matrix_interface, [2] * n * 2)
+    shape = [2] * (n * 2) + [batch_dim] if batch_dim else [2] * (n * 2)
+    mat_op_reshaped = qml.math.reshape(op_matrix_interface, shape)
     mat_tensordot = qml.math.tensordot(
         mat_op_reshaped, qml.math.cast_like(identity, mat_op_reshaped), axes
     )
+    if batch_dim:
+        mat_tensordot = qml.math.moveaxis(mat_tensordot, n, -1)
 
     unused_idxs = [idx for idx in range(len(wire_order)) if idx not in op_wire_pos]
     # permute matrix axes to match wire ordering
     perm = op_wire_pos + unused_idxs
-    mat = qml.math.moveaxis(mat_tensordot, wire_order.indices(wire_order), perm)
+    sources = wire_order.indices(wire_order)
+    if batch_dim:
+        perm = perm + [-1]
+        sources = sources + [-1]
 
-    mat = qml.math.reshape(mat, (2 ** len(wire_order), 2 ** len(wire_order)))
+    mat = qml.math.moveaxis(mat_tensordot, sources, perm)
+    shape = [2 ** len(wire_order)] * 2 + [batch_dim] if batch_dim else [2 ** len(wire_order)] * 2
+    mat = qml.math.reshape(mat, shape)
 
     return mat
 
@@ -688,7 +698,14 @@ class Operator(abc.ABC):
             # By default, compute the eigenvalues from the matrix representation.
             # This will raise a NotImplementedError if the matrix is undefined.
             try:
-                return qml.math.linalg.eigvals(self.matrix())
+                mat = self.get_matrix()
+                if len(qml.math.shape(mat)) == 3:
+                    # linalg.eigvals expects the last two dimensions to be the square dimension
+                    # so that we have to transpose before and after the calculation.
+                    return qml.math.transpose(
+                        qml.math.linalg.eigvals(qml.math.transpose(mat, (2, 0, 1))), (1, 0)
+                    )
+                return qml.math.linalg.eigvals(mat)
             except MatrixUndefinedError as e:
                 raise EigvalsUndefinedError from e
 
@@ -804,7 +821,9 @@ class Operator(abc.ABC):
 
         if len(qml.math.shape(params[0])) != 0:
             # assume that if the first parameter is matrix-valued, there is only a single parameter
-            # this holds true for all current operations and templates
+            # this holds true for all current operations and templates unless tensor-batching
+            # is used
+            # TODO[dwierichs]: Implement a proper label for tensor-batched operators
             if (
                 cache is None
                 or not isinstance(cache.get("matrices", None), list)
@@ -1404,7 +1423,7 @@ class Operation(Operator):
         canonical_matrix = self.compute_matrix(*self.parameters, **self.hyperparameters)
 
         if self.inverse:
-            canonical_matrix = qml.math.conj(qml.math.T(canonical_matrix))
+            canonical_matrix = qml.math.conj(qml.math.moveaxis(canonical_matrix, 0, 1))
 
         if wire_order is None or self.wires == Wires(wire_order):
             return canonical_matrix

--- a/pennylane/ops/functions/matrix.py
+++ b/pennylane/ops/functions/matrix.py
@@ -141,7 +141,6 @@ def _matrix(tape, wire_order=None):
 
     for op in tape.operations:
         U = matrix(op, wire_order=wire_order)
-        unitary_matrix = qml.math.tensordot(U, unitary_matrix, axes=[[1], [0]])
-        unitary_matrix = qml.math.moveaxis(unitary_matrix, 1, -1)
+        unitary_matrix = qml.math.tensordot(U, unitary_matrix, axes=[[-1], [-2]])
 
     return unitary_matrix

--- a/pennylane/ops/functions/matrix.py
+++ b/pennylane/ops/functions/matrix.py
@@ -141,6 +141,7 @@ def _matrix(tape, wire_order=None):
 
     for op in tape.operations:
         U = matrix(op, wire_order=wire_order)
-        unitary_matrix = qml.math.dot(U, unitary_matrix)
+        unitary_matrix = qml.math.tensordot(U, unitary_matrix, axes=[[1], [0]])
+        unitary_matrix = qml.math.moveaxis(unitary_matrix, 1, -1)
 
     return unitary_matrix

--- a/pennylane/ops/qubit/attributes.py
+++ b/pennylane/ops/qubit/attributes.py
@@ -199,3 +199,28 @@ The reason is that if this method is missing, eigenvalues are computed from the 
 representation using ``np.linalg.eigvals``, which fails for some tensor types that the matrix
 may be cast in on backpropagation devices.
 """
+
+supports_tensorbatching = Attribute(
+    [
+        "QubitUnitary",
+        "DiagonalQubitUnitary",
+        "RX",
+        "RY",
+        "RZ",
+        "PhaseShift",
+        "ControlledPhaseShift",
+        "Rot",
+        "MultiRZ",
+        "PauliRot",
+        "CRX",
+        "CRY",
+        "CRZ",
+        "CRot",
+        "U1",
+        "U2",
+        "U3",
+        "IsingXX",
+        "IsingYY",
+        "IsingZZ",
+    ]
+)

--- a/pennylane/ops/qubit/matrix_ops.py
+++ b/pennylane/ops/qubit/matrix_ops.py
@@ -32,6 +32,7 @@ class QubitUnitary(Operation):
 
     * Number of wires: Any (the operation can act on any number of wires)
     * Number of parameters: 1
+    * Number of dimensions per parameter: (2,)
     * Gradient recipe: None
 
     Args:
@@ -54,6 +55,9 @@ class QubitUnitary(Operation):
 
     num_params = 1
     """int: Number of trainable parameters that the operator depends on."""
+
+    ndim_params = (2,)
+    """tuple[int]: Number of dimensions per trainable parameter that the operator depends on."""
 
     grad_method = None
     """Gradient computation method."""
@@ -194,6 +198,7 @@ class ControlledQubitUnitary(QubitUnitary):
 
     * Number of wires: Any (the operation can act on any number of wires)
     * Number of parameters: 1
+    * Number of dimensions per parameter: (2,)
     * Gradient recipe: None
 
     Args:
@@ -229,6 +234,9 @@ class ControlledQubitUnitary(QubitUnitary):
 
     num_params = 1
     """int: Number of trainable parameters that the operator depends on."""
+
+    ndim_params = (2,)
+    """tuple[int]: Number of dimensions per trainable parameter that the operator depends on."""
 
     grad_method = None
     """Gradient computation method."""
@@ -367,6 +375,7 @@ class DiagonalQubitUnitary(Operation):
 
     * Number of wires: Any (the operation can act on any number of wires)
     * Number of parameters: 1
+    * Number of dimensions per parameter: (1,)
     * Gradient recipe: None
 
     Args:
@@ -378,6 +387,9 @@ class DiagonalQubitUnitary(Operation):
 
     num_params = 1
     """int: Number of trainable parameters that the operator depends on."""
+
+    ndim_params = (1,)
+    """tuple[int]: Number of dimensions per trainable parameter that the operator depends on."""
 
     grad_method = None
     """Gradient computation method."""

--- a/pennylane/ops/qubit/parametric_ops.py
+++ b/pennylane/ops/qubit/parametric_ops.py
@@ -32,6 +32,7 @@ from pennylane.wires import Wires
 
 INV_SQRT2 = 1 / math.sqrt(2)
 
+stack_last = functools.partial(qml.math.stack, axis=-1)
 
 class RX(Operation):
     r"""
@@ -46,6 +47,7 @@ class RX(Operation):
 
     * Number of wires: 1
     * Number of parameters: 1
+    * Number of dimensions per parameter: (0,)
     * Gradient recipe: :math:`\frac{d}{d\phi}f(R_x(\phi)) = \frac{1}{2}\left[f(R_x(\phi+\pi/2)) - f(R_x(\phi-\pi/2))\right]`
       where :math:`f` is an expectation value depending on :math:`R_x(\phi)`.
 
@@ -59,6 +61,9 @@ class RX(Operation):
     num_wires = 1
     num_params = 1
     """int: Number of trainable parameters that the operator depends on."""
+
+    ndim_params = (0,)
+    """tuple[int]: Number of dimensions per trainable parameter that the operator depends on."""
 
     basis = "X"
     grad_method = "A"
@@ -100,8 +105,7 @@ class RX(Operation):
 
         c = (1 + 0j) * c
         js = -1j * s
-        return qml.math.stack([qml.math.stack([c, js]), qml.math.stack([js, c])])
-        # return mat * qml.math.array([[1+0j, -1j], [-1j, 1+0j]], like=mat)
+        return qml.math.stack([stack_last([c, js]), stack_last([js, c])], axis=-2)
 
     def adjoint(self):
         return RX(-self.data[0], wires=self.wires)
@@ -131,6 +135,7 @@ class RY(Operation):
 
     * Number of wires: 1
     * Number of parameters: 1
+    * Number of dimensions per parameter: (0,)
     * Gradient recipe: :math:`\frac{d}{d\phi}f(R_y(\phi)) = \frac{1}{2}\left[f(R_y(\phi+\pi/2)) - f(R_y(\phi-\pi/2))\right]`
       where :math:`f` is an expectation value depending on :math:`R_y(\phi)`.
 
@@ -144,6 +149,9 @@ class RY(Operation):
     num_wires = 1
     num_params = 1
     """int: Number of trainable parameters that the operator depends on."""
+
+    ndim_params = (0,)
+    """tuple[int]: Number of dimensions per trainable parameter that the operator depends on."""
 
     basis = "Y"
     grad_method = "A"
@@ -185,7 +193,7 @@ class RY(Operation):
             s = qml.math.cast_like(s, 1j)
         c = (1 + 0j) * c
         s = (1 + 0j) * s
-        return qml.math.stack([qml.math.stack([c, -s]), qml.math.stack([s, c])])
+        return qml.math.stack([stack_last([c, -s]), stack_last([s, c])], axis=-2)
 
     def adjoint(self):
         return RY(-self.data[0], wires=self.wires)
@@ -214,6 +222,7 @@ class RZ(Operation):
 
     * Number of wires: 1
     * Number of parameters: 1
+    * Number of dimensions per parameter: (0,)
     * Gradient recipe: :math:`\frac{d}{d\phi}f(R_z(\phi)) = \frac{1}{2}\left[f(R_z(\phi+\pi/2)) - f(R_z(\phi-\pi/2))\right]`
       where :math:`f` is an expectation value depending on :math:`R_z(\phi)`.
 
@@ -227,6 +236,9 @@ class RZ(Operation):
     num_wires = 1
     num_params = 1
     """int: Number of trainable parameters that the operator depends on."""
+
+    ndim_params = (0,)
+    """tuple[int]: Number of dimensions per trainable parameter that the operator depends on."""
 
     basis = "Z"
     grad_method = "A"
@@ -265,7 +277,7 @@ class RZ(Operation):
         p = qml.math.exp(-0.5j * theta)
         z = qml.math.zeros_like(p)
 
-        return qml.math.stack([qml.math.stack([p, z]), qml.math.stack([z, qml.math.conj(p)])])
+        return qml.math.stack([stack_last([p, z]), stack_last([z, qml.math.conj(p)])], axis=-2)
 
     @staticmethod
     def compute_eigvals(theta):  # pylint: disable=arguments-differ
@@ -300,7 +312,7 @@ class RZ(Operation):
 
         p = qml.math.exp(-0.5j * theta)
 
-        return qml.math.stack([p, qml.math.conj(p)])
+        return stack_last([p, qml.math.conj(p)])
 
     def adjoint(self):
         return RZ(-self.data[0], wires=self.wires)
@@ -329,6 +341,7 @@ class PhaseShift(Operation):
 
     * Number of wires: 1
     * Number of parameters: 1
+    * Number of dimensions per parameter: (0,)
     * Gradient recipe: :math:`\frac{d}{d\phi}f(R_\phi(\phi)) = \frac{1}{2}\left[f(R_\phi(\phi+\pi/2)) - f(R_\phi(\phi-\pi/2))\right]`
       where :math:`f` is an expectation value depending on :math:`R_{\phi}(\phi)`.
 
@@ -342,6 +355,9 @@ class PhaseShift(Operation):
     num_wires = 1
     num_params = 1
     """int: Number of trainable parameters that the operator depends on."""
+
+    ndim_params = (0,)
+    """tuple[int]: Number of dimensions per trainable parameter that the operator depends on."""
 
     basis = "Z"
     grad_method = "A"
@@ -384,7 +400,7 @@ class PhaseShift(Operation):
         p = qml.math.exp(1j * phi)
         z = qml.math.zeros_like(p)
 
-        return qml.math.stack([qml.math.stack([qml.math.ones_like(p), z]), qml.math.stack([z, p])])
+        return qml.math.stack([stack_last([qml.math.ones_like(p), z]), stack_last([z, p])], axis=-2)
 
     @staticmethod
     def compute_eigvals(phi):  # pylint: disable=arguments-differ
@@ -418,7 +434,7 @@ class PhaseShift(Operation):
 
         p = qml.math.exp(1j * phi)
 
-        return qml.math.stack([qml.math.ones_like(p), p])
+        return stack_last([qml.math.ones_like(p), p])
 
     @staticmethod
     def compute_decomposition(phi, wires):
@@ -475,6 +491,7 @@ class ControlledPhaseShift(Operation):
 
     * Number of wires: 2
     * Number of parameters: 1
+    * Number of dimensions per parameter: (0,)
     * Gradient recipe: :math:`\frac{d}{d\phi}f(CR_\phi(\phi)) = \frac{1}{2}\left[f(CR_\phi(\phi+\pi/2)) - f(CR_\phi(\phi-\pi/2))\right]`
       where :math:`f` is an expectation value depending on :math:`CR_{\phi}(\phi)`.
 
@@ -488,6 +505,9 @@ class ControlledPhaseShift(Operation):
     num_wires = 2
     num_params = 1
     """int: Number of trainable parameters that the operator depends on."""
+
+    ndim_params = (0,)
+    """tuple[int]: Number of dimensions per trainable parameter that the operator depends on."""
 
     basis = "Z"
     grad_method = "A"
@@ -540,7 +560,7 @@ class ControlledPhaseShift(Operation):
                 [zeros, zeros, zeros, exp_part],
             ]
 
-            return qml.math.stack([qml.math.stack(row) for row in matrix])
+            return qml.math.stack([stack_last(row) for row in matrix], axis=-2)
 
         return qml.math.diag([1, 1, 1, exp_part])
 
@@ -576,7 +596,7 @@ class ControlledPhaseShift(Operation):
 
         exp_part = qml.math.exp(1j * phi)
         ones = qml.math.ones_like(exp_part)
-        return qml.math.stack([ones, ones, ones, exp_part])
+        return stack_last([ones, ones, ones, exp_part])
 
     @staticmethod
     def compute_decomposition(phi, wires):
@@ -643,6 +663,7 @@ class Rot(Operation):
 
     * Number of wires: 1
     * Number of parameters: 3
+    * Number of dimensions per parameter: (0, 0, 0)
     * Gradient recipe: :math:`\frac{d}{d\phi}f(R(\phi, \theta, \omega)) = \frac{1}{2}\left[f(R(\phi+\pi/2, \theta, \omega)) - f(R(\phi-\pi/2, \theta, \omega))\right]`
       where :math:`f` is an expectation value depending on :math:`R(\phi, \theta, \omega)`.
       This gradient recipe applies for each angle argument :math:`\{\phi, \theta, \omega\}`.
@@ -664,6 +685,9 @@ class Rot(Operation):
     num_wires = 1
     num_params = 3
     """int: Number of trainable parameters that the operator depends on."""
+
+    ndim_params = (0, 0, 0)
+    """tuple[int]: Number of dimensions per trainable parameter that the operator depends on."""
 
     grad_method = "A"
     parameter_frequencies = [(1,), (1,), (1,)]
@@ -700,9 +724,10 @@ class Rot(Operation):
         # Rot(0.2, 0.3, tf.Variable(0.5), wires=0)
         # So we need to make sure the matrix comes out having the right type
         interface = qml.math._multi_dispatch([phi, theta, omega])
+        one = qml.math.ones_like(phi) * qml.math.ones_like(theta) * qml.math.ones_like(omega)
 
-        c = qml.math.cos(theta / 2)
-        s = qml.math.sin(theta / 2)
+        c = qml.math.cos(theta / 2) * one
+        s = qml.math.sin(theta / 2) * one
 
         # If anything is not tensorflow, it has to be casted and then
         if interface == "tensorflow":
@@ -722,7 +747,7 @@ class Rot(Operation):
             ],
         ]
 
-        return qml.math.stack([qml.math.stack(row) for row in mat])
+        return qml.math.stack([stack_last(row) for row in mat], axis=-2)
 
     @staticmethod
     def compute_decomposition(phi, theta, omega, wires):
@@ -778,6 +803,7 @@ class MultiRZ(Operation):
 
     * Number of wires: Any
     * Number of parameters: 1
+    * Number of dimensions per parameter: (0,)
     * Gradient recipe: :math:`\frac{d}{d\theta}f(MultiRZ(\theta)) = \frac{1}{2}\left[f(MultiRZ(\theta +\pi/2)) - f(MultiRZ(\theta-\pi/2))\right]`
       where :math:`f` is an expectation value depending on :math:`MultiRZ(\theta)`.
 
@@ -796,6 +822,9 @@ class MultiRZ(Operation):
     num_wires = AnyWires
     num_params = 1
     """int: Number of trainable parameters that the operator depends on."""
+
+    ndim_params = (0,)
+    """tuple[int]: Number of dimensions per trainable parameter that the operator depends on."""
 
     grad_method = "A"
     parameter_frequencies = [(1,)]
@@ -836,12 +865,10 @@ class MultiRZ(Operation):
             eigs = qml.math.cast_like(eigs, 1j)
 
         shape = qml.math.shape(theta)
+        # TODO[dwierichs]: How to properly recycle _check_batching here?
         if len(shape) > 0:
-            eigvals = qml.math.exp(qml.math.tensordot(eigs, -0.5j * theta, axes=0))
-            dim = 2**num_wires
-            mat = qml.math.zeros(((dim, dim) + shape), like=eigvals, dtype=complex)
-            mat[np.diag_indices(dim, ndim=2)] = eigvals
-            return mat
+            eigvals = [qml.math.exp(-0.5j * t * eigs) for t in theta]
+            return qml.math.stack([qml.math.diag(eig) for eig in eigvals])
 
         eigvals = qml.math.exp(-0.5j * theta * eigs)
         return qml.math.diag(eigvals)
@@ -885,7 +912,7 @@ class MultiRZ(Operation):
             eigs = qml.math.cast_like(eigs, 1j)
 
         if len(qml.math.shape(theta)) > 0:
-            return qml.math.exp(qml.math.tensordot(eigs, -0.5j * theta, axes=0))
+            return qml.math.exp(qml.math.tensordot(-0.5j * theta, eigs, axes=0))
 
         return qml.math.exp(-0.5j * theta * eigs)
 
@@ -938,6 +965,7 @@ class PauliRot(Operation):
 
     * Number of wires: Any
     * Number of parameters: 1
+    * Number of dimensions per parameter: (0,)
     * Gradient recipe: :math:`\frac{d}{d\theta}f(RP(\theta)) = \frac{1}{2}\left[f(RP(\theta +\pi/2)) - f(RP(\theta-\pi/2))\right]`
       where :math:`f` is an expectation value depending on :math:`RP(\theta)`.
 
@@ -968,6 +996,9 @@ class PauliRot(Operation):
     num_wires = AnyWires
     num_params = 1
     """int: Number of trainable parameters that the operator depends on."""
+
+    ndim_params = (0,)
+    """tuple[int]: Number of dimensions per trainable parameter that the operator depends on."""
 
     do_check_domain = False
     grad_method = "A"
@@ -1029,7 +1060,7 @@ class PauliRot(Operation):
             op_label += "⁻¹"
 
         # TODO[dwierichs]: Implement a proper label for tensor-batched operators
-        if decimals is not None and qml.math.shape(self.parameters[0]) == ():
+        if decimals is not None and self.batch_size is None:
             param_string = f"\n({qml.math.asarray(self.parameters[0]):.{decimals}f})"
             op_label += param_string
 
@@ -1084,9 +1115,10 @@ class PauliRot(Operation):
         # Simplest case is if the Pauli is the identity matrix
         if set(pauli_word) == {"I"}:
 
+            # TODO[dwierichs]: how to recycle _check_batching properly here? Implement broadcasting
             if len(qml.math.shape(theta)) > 0:
                 raise NotImplementedError(
-                    "PauliRot with the identity matrix does not support tensor-batching."
+                    "PauliRot with the identity matrix does not support broadcasting."
                 )
             exp = qml.math.exp(-0.5j * theta)
             iden = qml.math.eye(2 ** len(pauli_word))
@@ -1117,8 +1149,8 @@ class PauliRot(Operation):
         # and the tensordot containing multi_Z_rot_matrix should decide about the interface
         return expand_matrix(
             qml.math.einsum(
-                "jk...,ij->i...k",
-                qml.math.tensordot(multi_Z_rot_matrix, conjugation_matrix, axes=[[1], [0]]),
+                "...jk,ij->...ik",
+                qml.math.tensordot(multi_Z_rot_matrix, conjugation_matrix, axes=[[-1], [0]]),
                 qml.math.conj(conjugation_matrix),
             ),
             non_identity_wires,
@@ -1159,9 +1191,10 @@ class PauliRot(Operation):
 
         # Identity must be treated specially because its eigenvalues are all the same
         if set(pauli_word) == {"I"}:
+            # TODO[dwierichs]: how to recycle _check_batching properly here? Implement broadcasting
             if len(qml.math.shape(theta)) > 0:
                 raise NotImplementedError(
-                    "PauliRot with the identity matrix does not support tensor-batching."
+                    "PauliRot with the identity matrix does not support broadcasting."
                 )
             return qml.math.exp(-0.5j * theta) * qml.math.ones(2 ** len(pauli_word))
 
@@ -1248,6 +1281,7 @@ class CRX(Operation):
 
     * Number of wires: 2
     * Number of parameters: 1
+    * Number of dimensions per parameter: (0,)
     * Gradient recipe: The controlled-RX operator satisfies a four-term parameter-shift rule
       (see Appendix F, https://doi.org/10.1088/1367-2630/ac2cb3):
 
@@ -1271,6 +1305,9 @@ class CRX(Operation):
     num_wires = 2
     num_params = 1
     """int: Number of trainable parameters that the operator depends on."""
+
+    ndim_params = (0,)
+    """tuple[int]: Number of dimensions per trainable parameter that the operator depends on."""
 
     basis = "X"
     grad_method = "A"
@@ -1328,7 +1365,7 @@ class CRX(Operation):
             [zeros, zeros, js, c],
         ]
 
-        return qml.math.stack([qml.math.stack(row) for row in matrix])
+        return qml.math.stack([stack_last(row) for row in matrix], axis=-2)
 
     @staticmethod
     def compute_decomposition(phi, wires):
@@ -1399,6 +1436,7 @@ class CRY(Operation):
 
     * Number of wires: 2
     * Number of parameters: 1
+    * Number of dimensions per parameter: (0,)
     * Gradient recipe: The controlled-RY operator satisfies a four-term parameter-shift rule
       (see Appendix F, https://doi.org/10.1088/1367-2630/ac2cb3):
 
@@ -1422,6 +1460,9 @@ class CRY(Operation):
     num_wires = 2
     num_params = 1
     """int: Number of trainable parameters that the operator depends on."""
+
+    ndim_params = (0,)
+    """tuple[int]: Number of dimensions per trainable parameter that the operator depends on."""
 
     basis = "Y"
     grad_method = "A"
@@ -1480,7 +1521,7 @@ class CRY(Operation):
             [zeros, zeros, s, c],
         ]
 
-        return qml.math.stack([qml.math.stack(row) for row in matrix])
+        return qml.math.stack([stack_last(row) for row in matrix], axis=-2)
 
     @staticmethod
     def compute_decomposition(phi, wires):
@@ -1549,6 +1590,7 @@ class CRZ(Operation):
 
     * Number of wires: 2
     * Number of parameters: 1
+    * Number of dimensions per parameter: (0,)
     * Gradient recipe: The controlled-RZ operator satisfies a four-term parameter-shift rule
       (see Appendix F, https://doi.org/10.1088/1367-2630/ac2cb3):
 
@@ -1572,6 +1614,9 @@ class CRZ(Operation):
     num_wires = 2
     num_params = 1
     """int: Number of trainable parameters that the operator depends on."""
+
+    ndim_params = (0,)
+    """tuple[int]: Number of dimensions per trainable parameter that the operator depends on."""
 
     basis = "Z"
     grad_method = "A"
@@ -1623,7 +1668,7 @@ class CRZ(Operation):
             [zeros, zeros, zeros, qml.math.conj(exp_part)],
         ]
 
-        return qml.math.stack([qml.math.stack(row) for row in matrix])
+        return qml.math.stack([stack_last(row) for row in matrix], axis=-2)
 
     @staticmethod
     def compute_eigvals(theta):  # pylint: disable=arguments-differ
@@ -1660,7 +1705,7 @@ class CRZ(Operation):
         exp_part = qml.math.exp(-0.5j * theta)
         o = qml.math.ones_like(exp_part)
 
-        return qml.math.stack([o, o, exp_part, qml.math.conj(exp_part)])
+        return stack_last([o, o, exp_part, qml.math.conj(exp_part)])
 
     @staticmethod
     def compute_decomposition(phi, wires):
@@ -1723,6 +1768,7 @@ class CRot(Operation):
 
     * Number of wires: 2
     * Number of parameters: 3
+    * Number of dimensions per parameter: (0, 0, 0)
     * Gradient recipe: The controlled-Rot operator satisfies a four-term parameter-shift rule
       (see Appendix F, https://doi.org/10.1088/1367-2630/ac2cb3):
 
@@ -1749,6 +1795,9 @@ class CRot(Operation):
     num_wires = 2
     num_params = 3
     """int: Number of trainable parameters that the operator depends on."""
+
+    ndim_params = (0, 0, 0)
+    """tuple[int]: Number of dimensions per trainable parameter that the operator depends on."""
 
     grad_method = "A"
     parameter_frequencies = [(0.5, 1.0), (0.5, 1.0), (0.5, 1.0)]
@@ -1786,12 +1835,13 @@ class CRot(Operation):
                 [ 0.0+0.0j,  0.0+0.0j,  0.0993+0.0100j,  0.9752+0.1977j]])
         """
         # It might be that they are in different interfaces, e.g.,
-        # Rot(0.2, 0.3, tf.Variable(0.5), wires=0)
+        # CRot(0.2, 0.3, tf.Variable(0.5), wires=0)
         # So we need to make sure the matrix comes out having the right type
         interface = qml.math._multi_dispatch([phi, theta, omega])
+        one = qml.math.ones_like(phi) * qml.math.ones_like(theta) * qml.math.ones_like(omega)
 
-        c = qml.math.cos(theta / 2)
-        s = qml.math.sin(theta / 2)
+        c = qml.math.cos(theta / 2) * one
+        s = qml.math.sin(theta / 2) * one
 
         # If anything is not tensorflow, it has to be casted
         if interface == "tensorflow":
@@ -1819,7 +1869,7 @@ class CRot(Operation):
             ],
         ]
 
-        return qml.math.stack([qml.math.stack(row) for row in mat])
+        return qml.math.stack([stack_last(row) for row in mat], axis=-2)
 
     @staticmethod
     def compute_decomposition(phi, theta, omega, wires):
@@ -1888,6 +1938,7 @@ class U1(Operation):
 
     * Number of wires: 1
     * Number of parameters: 1
+    * Number of dimensions per parameter: (0,)
     * Gradient recipe: :math:`\frac{d}{d\phi}f(U_1(\phi)) = \frac{1}{2}\left[f(U_1(\phi+\pi/2)) - f(U_1(\phi-\pi/2))\right]`
       where :math:`f` is an expectation value depending on :math:`U_1(\phi)`.
 
@@ -1901,6 +1952,9 @@ class U1(Operation):
     num_wires = 1
     num_params = 1
     """int: Number of trainable parameters that the operator depends on."""
+
+    ndim_params = (0,)
+    """tuple[int]: Number of dimensions per trainable parameter that the operator depends on."""
 
     grad_method = "A"
     parameter_frequencies = [(1,)]
@@ -1938,7 +1992,7 @@ class U1(Operation):
         p = qml.math.exp(1j * phi)
         z = qml.math.zeros_like(p)
 
-        return qml.math.stack([qml.math.stack([qml.math.ones_like(p), z]), qml.math.stack([z, p])])
+        return qml.math.stack([stack_last([qml.math.ones_like(p), z]), stack_last([z, p])], axis=-2)
 
     @staticmethod
     def compute_decomposition(phi, wires):
@@ -1996,6 +2050,7 @@ class U2(Operation):
 
     * Number of wires: 1
     * Number of parameters: 2
+    * Number of dimensions per parameter: (0, 0)
     * Gradient recipe: :math:`\frac{d}{d\phi}f(U_2(\phi, \delta)) = \frac{1}{2}\left[f(U_2(\phi+\pi/2, \delta)) - f(U_2(\phi-\pi/2, \delta))\right]`
       where :math:`f` is an expectation value depending on :math:`U_2(\phi, \delta)`.
       This gradient recipe applies for each angle argument :math:`\{\phi, \delta\}`.
@@ -2011,6 +2066,9 @@ class U2(Operation):
     num_wires = 1
     num_params = 2
     """int: Number of trainable parameters that the operator depends on."""
+
+    ndim_params = (0, 0)
+    """tuple[int]: Number of dimensions per trainable parameter that the operator depends on."""
 
     grad_method = "A"
     parameter_frequencies = [(1,), (1,)]
@@ -2041,6 +2099,7 @@ class U2(Operation):
                 [ 0.7036+0.0706j,  0.6755+0.2090j]])
         """
         interface = qml.math._multi_dispatch([phi, delta])
+        one = qml.math.ones_like(phi) * qml.math.ones_like(delta)
 
         # If anything is not tensorflow, it has to be casted and then
         if interface == "tensorflow":
@@ -2048,11 +2107,11 @@ class U2(Operation):
             delta = qml.math.cast_like(qml.math.asarray(delta, like=interface), 1j)
 
         mat = [
-            [qml.math.ones_like(phi), -qml.math.exp(1j * delta)],
-            [qml.math.exp(1j * phi), qml.math.exp(1j * (phi + delta))],
+            [one, -qml.math.exp(1j * delta) * one],
+            [qml.math.exp(1j * phi) * one, qml.math.exp(1j * (phi + delta))],
         ]
 
-        return INV_SQRT2 * qml.math.stack([qml.math.stack(row) for row in mat])
+        return INV_SQRT2 * qml.math.stack([stack_last(row) for row in mat], axis=-2)
 
     @staticmethod
     def compute_decomposition(phi, delta, wires):
@@ -2118,6 +2177,7 @@ class U3(Operation):
 
     * Number of wires: 1
     * Number of parameters: 3
+    * Number of dimensions per parameter: (0, 0, 0)
     * Gradient recipe: :math:`\frac{d}{d\phi}f(U_3(\theta, \phi, \delta)) = \frac{1}{2}\left[f(U_3(\theta+\pi/2, \phi, \delta)) - f(U_3(\theta-\pi/2, \phi, \delta))\right]`
       where :math:`f` is an expectation value depending on :math:`U_3(\theta, \phi, \delta)`.
       This gradient recipe applies for each angle argument :math:`\{\theta, \phi, \delta\}`.
@@ -2134,6 +2194,9 @@ class U3(Operation):
     num_wires = 1
     num_params = 3
     """int: Number of trainable parameters that the operator depends on."""
+
+    ndim_params = (0, 0, 0)
+    """tuple[int]: Number of dimensions per trainable parameter that the operator depends on."""
 
     grad_method = "A"
     parameter_frequencies = [(1,), (1,), (1,)]
@@ -2169,9 +2232,10 @@ class U3(Operation):
         # Rot(0.2, 0.3, tf.Variable(0.5), wires=0)
         # So we need to make sure the matrix comes out having the right type
         interface = qml.math._multi_dispatch([theta, phi, delta])
+        one = qml.math.ones_like(theta) * qml.math.ones_like(phi) * qml.math.ones_like(delta)
 
-        c = qml.math.cos(theta / 2)
-        s = qml.math.sin(theta / 2)
+        c = qml.math.cos(theta / 2) * one
+        s = qml.math.sin(theta / 2) * one
 
         # If anything is not tensorflow, it has to be casted and then
         if interface == "tensorflow":
@@ -2185,7 +2249,7 @@ class U3(Operation):
             [s * qml.math.exp(1j * phi), c * qml.math.exp(1j * (phi + delta))],
         ]
 
-        return qml.math.stack([qml.math.stack(row) for row in mat])
+        return qml.math.stack([stack_last(row) for row in mat], axis=-2)
 
     @staticmethod
     def compute_decomposition(theta, phi, delta, wires):
@@ -2242,6 +2306,7 @@ class IsingXX(Operation):
 
     * Number of wires: 2
     * Number of parameters: 1
+    * Number of dimensions per parameter: (0,)
     * Gradient recipe: :math:`\frac{d}{d\phi}f(XX(\phi)) = \frac{1}{2}\left[f(XX(\phi +\pi/2)) - f(XX(\phi-\pi/2))\right]`
       where :math:`f` is an expectation value depending on :math:`XX(\phi)`.
 
@@ -2255,6 +2320,9 @@ class IsingXX(Operation):
     num_wires = 2
     num_params = 1
     """int: Number of trainable parameters that the operator depends on."""
+
+    ndim_params = (0,)
+    """tuple[int]: Number of dimensions per trainable parameter that the operator depends on."""
 
     grad_method = "A"
     parameter_frequencies = [(1,)]
@@ -2306,7 +2374,7 @@ class IsingXX(Operation):
             [z, js, c, z],
             [js, z, z, c],
         ]
-        return qml.math.stack([qml.math.stack(row) for row in matrix])
+        return qml.math.stack([stack_last(row) for row in matrix], axis=-2)
 
     @staticmethod
     def compute_decomposition(phi, wires):
@@ -2360,6 +2428,7 @@ class IsingYY(Operation):
 
     * Number of wires: 2
     * Number of parameters: 1
+    * Number of dimensions per parameter: (0,)
     * Gradient recipe: :math:`\frac{d}{d\phi}f(YY(\phi)) = \frac{1}{2}\left[f(YY(\phi +\pi/2)) - f(YY(\phi-\pi/2))\right]`
       where :math:`f` is an expectation value depending on :math:`YY(\phi)`.
 
@@ -2373,6 +2442,9 @@ class IsingYY(Operation):
     num_wires = 2
     num_params = 1
     """int: Number of trainable parameters that the operator depends on."""
+
+    ndim_params = (0,)
+    """tuple[int]: Number of dimensions per trainable parameter that the operator depends on."""
 
     grad_method = "A"
     parameter_frequencies = [(1,)]
@@ -2452,7 +2524,7 @@ class IsingYY(Operation):
             [z, -js, c, z],
             [js, z, z, c],
         ]
-        return qml.math.stack([qml.math.stack(row) for row in matrix])
+        return qml.math.stack([stack_last(row) for row in matrix], axis=-2)
 
     def adjoint(self):
         (phi,) = self.parameters
@@ -2477,6 +2549,7 @@ class IsingZZ(Operation):
 
     * Number of wires: 2
     * Number of parameters: 1
+    * Number of dimensions per parameter: (0,)
     * Gradient recipe: :math:`\frac{d}{d\phi}f(ZZ(\phi)) = \frac{1}{2}\left[f(ZZ(\phi +\pi/2)) - f(ZZ(\phi-\pi/2))\right]`
       where :math:`f` is an expectation value depending on :math:`ZZ(\theta)`.
 
@@ -2490,6 +2563,9 @@ class IsingZZ(Operation):
     num_wires = 2
     num_params = 1
     """int: Number of trainable parameters that the operator depends on."""
+
+    ndim_params = (0,)
+    """tuple[int]: Number of dimensions per trainable parameter that the operator depends on."""
 
     grad_method = "A"
     parameter_frequencies = [(1,)]
@@ -2566,7 +2642,7 @@ class IsingZZ(Operation):
             [zeros, zeros, zeros, neg_phase],
         ]
 
-        return qml.math.stack([qml.math.stack(row) for row in matrix])
+        return qml.math.stack([stack_last(row) for row in matrix], axis=-2)
 
     @staticmethod
     def compute_eigvals(phi):  # pylint: disable=arguments-differ
@@ -2601,7 +2677,7 @@ class IsingZZ(Operation):
         pos_phase = qml.math.exp(1.0j * phi / 2)
         neg_phase = qml.math.exp(-1.0j * phi / 2)
 
-        return qml.math.stack([neg_phase, pos_phase, pos_phase, neg_phase])
+        return stack_last([neg_phase, pos_phase, pos_phase, neg_phase])
 
     def adjoint(self):
         (phi,) = self.parameters

--- a/tests/ops/qubit/test_matrix_ops.py
+++ b/tests/ops/qubit/test_matrix_ops.py
@@ -66,7 +66,7 @@ class TestQubitUnitary:
 
     @pytest.mark.autograd
     @pytest.mark.parametrize(
-        "U,num_wires", [(H, 1), (np.kron(H, H), 2), (np.tensordot(H, [1j, -1, 1], axes=0), 1)]
+        "U,num_wires", [(H, 1), (np.kron(H, H), 2), (np.tensordot([1j, -1, 1], H, axes=0), 1)]
     )
     def test_qubit_unitary_autograd(self, U, num_wires):
         """Test that the unitary operator produces the correct output and
@@ -82,10 +82,10 @@ class TestQubitUnitary:
 
         # test non-square matrix
         with pytest.raises(ValueError, match="must be of shape"):
-            qml.QubitUnitary(U[1:], wires=range(num_wires)).matrix()
+            qml.QubitUnitary(U[:, 1:], wires=range(num_wires)).matrix()
 
         if len(U.shape) == 2:
-            # test non-unitary matrix if it is not batched (not implemented yet for batching)
+            # test non-unitary matrix if it is not broadcasted (not implemented yet)
             U3 = U.copy()
             U3[0, 0] += 0.5
             with pytest.warns(UserWarning, match="may not be unitary"):
@@ -97,7 +97,7 @@ class TestQubitUnitary:
 
     @pytest.mark.torch
     @pytest.mark.parametrize(
-        "U,num_wires", [(H, 1), (np.kron(H, H), 2), (np.tensordot(H, [1j, -1, 1], axes=0), 1)]
+        "U,num_wires", [(H, 1), (np.kron(H, H), 2), (np.tensordot([1j, -1, 1], H, axes=0), 1)]
     )
     def test_qubit_unitary_torch(self, U, num_wires):
         """Test that the unitary operator produces the correct output and
@@ -115,10 +115,10 @@ class TestQubitUnitary:
 
         # test non-square matrix
         with pytest.raises(ValueError, match="must be of shape"):
-            qml.QubitUnitary(U[1:], wires=range(num_wires)).matrix()
+            qml.QubitUnitary(U[:, 1:], wires=range(num_wires)).matrix()
 
         if len(U.shape) == 2:
-            # test non-unitary matrix if it is not batched (not implemented yet for batching)
+            # test non-unitary matrix if it is not broadcasted (not implemented yet)
             U3 = U.detach().clone()
             U3[0, 0] += 0.5
             with pytest.warns(UserWarning, match="may not be unitary"):
@@ -130,7 +130,7 @@ class TestQubitUnitary:
 
     @pytest.mark.tf
     @pytest.mark.parametrize(
-        "U,num_wires", [(H, 1), (np.kron(H, H), 2), (np.tensordot(H, [1j, -1, 1], axes=0), 1)]
+        "U,num_wires", [(H, 1), (np.kron(H, H), 2), (np.tensordot([1j, -1, 1], H, axes=0), 1)]
     )
     def test_qubit_unitary_tf(self, U, num_wires):
         """Test that the unitary operator produces the correct output and
@@ -148,10 +148,10 @@ class TestQubitUnitary:
 
         # test non-square matrix
         with pytest.raises(ValueError, match="must be of shape"):
-            qml.QubitUnitary(U[1:], wires=range(num_wires)).matrix()
+            qml.QubitUnitary(U[:, 1:], wires=range(num_wires)).matrix()
 
         if len(U.shape) == 2:
-            # test non-unitary matrix if it is not batched (not implemented yet for batching)
+            # test non-unitary matrix if it is not broadcasted (not implemented yet)
             U3 = tf.Variable(U + 0.5)
             with pytest.warns(UserWarning, match="may not be unitary"):
                 qml.QubitUnitary(U3, wires=range(num_wires)).matrix()
@@ -162,7 +162,7 @@ class TestQubitUnitary:
 
     @pytest.mark.jax
     @pytest.mark.parametrize(
-        "U,num_wires", [(H, 1), (np.kron(H, H), 2), (np.tensordot(H, [1j, -1, 1], axes=0), 1)]
+        "U,num_wires", [(H, 1), (np.kron(H, H), 2), (np.tensordot([1j, -1, 1], H, axes=0), 1)]
     )
     def test_qubit_unitary_jax(self, U, num_wires):
         """Test that the unitary operator produces the correct output and
@@ -180,10 +180,10 @@ class TestQubitUnitary:
 
         # test non-square matrix
         with pytest.raises(ValueError, match="must be of shape"):
-            qml.QubitUnitary(U[1:], wires=range(num_wires)).matrix()
+            qml.QubitUnitary(U[:, 1:], wires=range(num_wires)).matrix()
 
         if len(U.shape) == 2:
-            # test non-unitary matrix if it is not batched (not implemented yet for batching)
+            # test non-unitary matrix if it is not broadcasted (not implemented yet)
             U3 = U + 0.5
             with pytest.warns(UserWarning, match="may not be unitary"):
                 qml.QubitUnitary(U3, wires=range(num_wires)).matrix()
@@ -194,7 +194,7 @@ class TestQubitUnitary:
 
     @pytest.mark.jax
     @pytest.mark.parametrize(
-        "U,num_wires", [(H, 1), (np.kron(H, H), 2), (np.tensordot(H, [1j, -1, 1], axes=0), 1)]
+        "U,num_wires", [(H, 1), (np.kron(H, H), 2), (np.tensordot([1j, -1, 1], H, axes=0), 1)]
     )
     def test_qubit_unitary_jax_jit(self, U, num_wires):
         """Tests that QubitUnitary works with jitting."""
@@ -247,8 +247,8 @@ class TestQubitUnitary:
         assert np.allclose(decomp2[0].parameters, expected_params, atol=1e-7)
 
     def test_error_qubit_unitary_decomposition_batched(self):
-        """Tests that single-qubit QubitUnitary decompositions are performed."""
-        U = np.ones((2, 2, 3))
+        """Tests that broadcasted QubitUnitary decompositions are not supported."""
+        U = np.ones((3, 2, 2))
         with pytest.raises(DecompositionUndefinedError, match="QubitUnitary does not support"):
             qml.QubitUnitary.compute_decomposition(U, wires=0)
         with pytest.raises(DecompositionUndefinedError, match="QubitUnitary does not support"):
@@ -277,7 +277,7 @@ class TestQubitUnitary:
         U = np.array(
             [[0.98877108 + 0.0j, 0.0 - 0.14943813j], [0.0 - 0.14943813j, 0.98877108 + 0.0j]]
         )
-        U = np.tensordot(U, [0.2, -0.1, 1.3], axes=0)
+        U = np.tensordot([0.2, -0.1, 1.3], U, axes=0)
         res_static = qml.QubitUnitary.compute_matrix(U)
         res_dynamic = qml.QubitUnitary(U, wires=0).matrix()
         expected = U
@@ -293,12 +293,9 @@ class TestDiagonalQubitUnitary:
         [
             ([1j, 1, 1, -1, -1j, 1j, 1, -1], 3, np.diag([1j, 1, 1, -1, -1j, 1j, 1, -1])),
             (
-                np.outer([1.0, -1.0, 1j, 1.0], [1.0, -1.0]),
+                np.outer([1.0, -1.0], [1.0, -1.0, 1j, 1.0]),
                 2,
-                np.transpose(
-                    np.stack([np.diag([1.0, -1.0, 1j, 1.0]), np.diag([-1.0, 1.0, -1j, -1.0])]),
-                    (1, 2, 0),
-                ),
+                np.stack([np.diag([1.0, -1.0, 1j, 1.0]), np.diag([-1.0, 1.0, -1j, -1.0])]),
             ),
         ],
     )
@@ -329,23 +326,33 @@ class TestDiagonalQubitUnitary:
     def test_controlled_batched(self):
         """Test that the correct controlled operation is created when
         controlling a qml.DiagonalQubitUnitary with a batched diagonal."""
-        D = np.array([[1j, 1], [1, -1], [-1j, 1j], [1, -1]])
+        D = np.array([[1j, 1, -1j, 1], [1, -1, 1j, -1]])
         op = qml.DiagonalQubitUnitary(D, wires=[1, 2])
         with qml.tape.QuantumTape() as tape:
             op._controlled(control=0)
         mat = qml.matrix(tape)
-        z = [0, 0]
-        o = [1, 1]
         expected = np.array(
             [
-                [o, z, z, z, z, z, z, z],
-                [z, o, z, z, z, z, z, z],
-                [z, z, o, z, z, z, z, z],
-                [z, z, z, o, z, z, z, z],
-                [z, z, z, z, [1j, 1], z, z, z],
-                [z, z, z, z, z, [1, -1], z, z],
-                [z, z, z, z, z, z, [-1j, 1j], z],
-                [z, z, z, z, z, z, z, [1, -1]],
+                [
+                    [1, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 1, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 1, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 1, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 1j, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 1, 0, 0],
+                    [0, 0, 0, 0, 0, 0, -1j, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 1],
+                ],
+                [
+                    [1, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 1, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 1, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 1, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 1, 0, 0, 0],
+                    [0, 0, 0, 0, 0, -1, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 1j, 0],
+                    [0, 0, 0, 0, 0, 0, 0, -1],
+                ],
             ]
         )
         assert qml.math.allclose(mat, expected)
@@ -372,10 +379,10 @@ class TestDiagonalQubitUnitary:
 
     def test_matrix_representation_batched(self, tol):
         """Test that the matrix representation is defined correctly for a batched diagonal."""
-        diag = np.array([[1, -1, 1j], [-1, -1, -1]])
+        diag = np.array([[1, -1], [1j, -1], [-1j, -1]])
         res_static = qml.DiagonalQubitUnitary.compute_matrix(diag)
         res_dynamic = qml.DiagonalQubitUnitary(diag, wires=0).matrix()
-        expected = np.array([[[1, -1, 1j], [0, 0, 0]], [[0, 0, 0], [-1, -1, -1]]])
+        expected = np.array([[[1, 0], [0, -1]], [[1j, 0], [0, -1]], [[-1j, 0], [0, -1]]])
         assert np.allclose(res_static, expected, atol=tol)
         assert np.allclose(res_dynamic, expected, atol=tol)
 
@@ -472,7 +479,7 @@ class TestControlledQubitUnitary:
     def test_error_batching(self):
         """Test if ControlledQubitUnitary raises a NotImplementedError when
         instantiated with a tensor-batched unitary."""
-        with pytest.raises(NotImplementedError, match=r"does not support tensor-batching"):
+        with pytest.raises(NotImplementedError, match=r"does not support broadcasting"):
             qml.ControlledQubitUnitary(np.ones((4, 4, 3)), control_wires=[0, 1], wires=2)
 
     @pytest.mark.parametrize("target_wire", range(3))

--- a/tests/ops/qubit/test_matrix_ops.py
+++ b/tests/ops/qubit/test_matrix_ops.py
@@ -20,6 +20,7 @@ from scipy.stats import unitary_group
 
 import pennylane as qml
 from pennylane.wires import Wires
+from pennylane.operation import DecompositionUndefinedError
 
 from gate_data import (
     I,
@@ -64,7 +65,9 @@ class TestQubitUnitary:
         assert qml.math.allclose(mat_to_pow, new_mat)
 
     @pytest.mark.autograd
-    @pytest.mark.parametrize("U,num_wires", [(H, 1), (np.kron(H, H), 2)])
+    @pytest.mark.parametrize(
+        "U,num_wires", [(H, 1), (np.kron(H, H), 2), (np.tensordot(H, [1j, -1, 1], axes=0), 1)]
+    )
     def test_qubit_unitary_autograd(self, U, num_wires):
         """Test that the unitary operator produces the correct output and
         catches incorrect input with autograd."""
@@ -81,18 +84,21 @@ class TestQubitUnitary:
         with pytest.raises(ValueError, match="must be of shape"):
             qml.QubitUnitary(U[1:], wires=range(num_wires)).matrix()
 
-        # test non-unitary matrix
-        U3 = U.copy()
-        U3[0, 0] += 0.5
-        with pytest.warns(UserWarning, match="may not be unitary"):
-            qml.QubitUnitary(U3, wires=range(num_wires)).matrix()
+        if len(U.shape) == 2:
+            # test non-unitary matrix if it is not batched (not implemented yet for batching)
+            U3 = U.copy()
+            U3[0, 0] += 0.5
+            with pytest.warns(UserWarning, match="may not be unitary"):
+                qml.QubitUnitary(U3, wires=range(num_wires)).matrix()
 
         # test an error is thrown when constructed with incorrect number of wires
         with pytest.raises(ValueError, match="must be of shape"):
             qml.QubitUnitary(U, wires=range(num_wires + 1)).matrix()
 
     @pytest.mark.torch
-    @pytest.mark.parametrize("U,num_wires", [(H, 1), (np.kron(H, H), 2)])
+    @pytest.mark.parametrize(
+        "U,num_wires", [(H, 1), (np.kron(H, H), 2), (np.tensordot(H, [1j, -1, 1], axes=0), 1)]
+    )
     def test_qubit_unitary_torch(self, U, num_wires):
         """Test that the unitary operator produces the correct output and
         catches incorrect input with torch."""
@@ -111,18 +117,21 @@ class TestQubitUnitary:
         with pytest.raises(ValueError, match="must be of shape"):
             qml.QubitUnitary(U[1:], wires=range(num_wires)).matrix()
 
-        # test non-unitary matrix
-        U3 = U.detach().clone()
-        U3[0, 0] += 0.5
-        with pytest.warns(UserWarning, match="may not be unitary"):
-            qml.QubitUnitary(U3, wires=range(num_wires)).matrix()
+        if len(U.shape) == 2:
+            # test non-unitary matrix if it is not batched (not implemented yet for batching)
+            U3 = U.detach().clone()
+            U3[0, 0] += 0.5
+            with pytest.warns(UserWarning, match="may not be unitary"):
+                qml.QubitUnitary(U3, wires=range(num_wires)).matrix()
 
         # test an error is thrown when constructed with incorrect number of wires
         with pytest.raises(ValueError, match="must be of shape"):
             qml.QubitUnitary(U, wires=range(num_wires + 1)).matrix()
 
     @pytest.mark.tf
-    @pytest.mark.parametrize("U,num_wires", [(H, 1), (np.kron(H, H), 2)])
+    @pytest.mark.parametrize(
+        "U,num_wires", [(H, 1), (np.kron(H, H), 2), (np.tensordot(H, [1j, -1, 1], axes=0), 1)]
+    )
     def test_qubit_unitary_tf(self, U, num_wires):
         """Test that the unitary operator produces the correct output and
         catches incorrect input with tensorflow."""
@@ -141,17 +150,20 @@ class TestQubitUnitary:
         with pytest.raises(ValueError, match="must be of shape"):
             qml.QubitUnitary(U[1:], wires=range(num_wires)).matrix()
 
-        # test non-unitary matrix
-        U3 = tf.Variable(U + 0.5)
-        with pytest.warns(UserWarning, match="may not be unitary"):
-            qml.QubitUnitary(U3, wires=range(num_wires)).matrix()
+        if len(U.shape) == 2:
+            # test non-unitary matrix if it is not batched (not implemented yet for batching)
+            U3 = tf.Variable(U + 0.5)
+            with pytest.warns(UserWarning, match="may not be unitary"):
+                qml.QubitUnitary(U3, wires=range(num_wires)).matrix()
 
         # test an error is thrown when constructed with incorrect number of wires
         with pytest.raises(ValueError, match="must be of shape"):
             qml.QubitUnitary(U, wires=range(num_wires + 1)).matrix()
 
     @pytest.mark.jax
-    @pytest.mark.parametrize("U,num_wires", [(H, 1), (np.kron(H, H), 2)])
+    @pytest.mark.parametrize(
+        "U,num_wires", [(H, 1), (np.kron(H, H), 2), (np.tensordot(H, [1j, -1, 1], axes=0), 1)]
+    )
     def test_qubit_unitary_jax(self, U, num_wires):
         """Test that the unitary operator produces the correct output and
         catches incorrect input with jax."""
@@ -170,18 +182,21 @@ class TestQubitUnitary:
         with pytest.raises(ValueError, match="must be of shape"):
             qml.QubitUnitary(U[1:], wires=range(num_wires)).matrix()
 
-        # test non-unitary matrix
-        U3 = U + 0.5
-        with pytest.warns(UserWarning, match="may not be unitary"):
-            qml.QubitUnitary(U3, wires=range(num_wires)).matrix()
+        if len(U.shape) == 2:
+            # test non-unitary matrix if it is not batched (not implemented yet for batching)
+            U3 = U + 0.5
+            with pytest.warns(UserWarning, match="may not be unitary"):
+                qml.QubitUnitary(U3, wires=range(num_wires)).matrix()
 
         # test an error is thrown when constructed with incorrect number of wires
         with pytest.raises(ValueError, match="must be of shape"):
             qml.QubitUnitary(U, wires=range(num_wires + 1)).matrix()
 
     @pytest.mark.jax
-    @pytest.mark.parametrize("U, num_wires", [(H, 1), (np.kron(H, H), 2)])
-    def test_qubit_unitary_jax(self, U, num_wires):
+    @pytest.mark.parametrize(
+        "U,num_wires", [(H, 1), (np.kron(H, H), 2), (np.tensordot(H, [1j, -1, 1], axes=0), 1)]
+    )
+    def test_qubit_unitary_jax_jit(self, U, num_wires):
         """Tests that QubitUnitary works with jitting."""
         import jax
         from jax import numpy as jnp
@@ -231,6 +246,14 @@ class TestQubitUnitary:
         assert isinstance(decomp2[0], expected_gate)
         assert np.allclose(decomp2[0].parameters, expected_params, atol=1e-7)
 
+    def test_error_qubit_unitary_decomposition_batched(self):
+        """Tests that single-qubit QubitUnitary decompositions are performed."""
+        U = np.ones((2, 2, 3))
+        with pytest.raises(DecompositionUndefinedError, match="QubitUnitary does not support"):
+            qml.QubitUnitary.compute_decomposition(U, wires=0)
+        with pytest.raises(DecompositionUndefinedError, match="QubitUnitary does not support"):
+            qml.QubitUnitary(U, wires=0).decomposition()
+
     def test_qubit_unitary_decomposition_multiqubit_invalid(self):
         """Test that QubitUnitary is not decomposed for more than two qubits."""
         U = qml.Toffoli(wires=[0, 1, 2]).matrix()
@@ -249,21 +272,48 @@ class TestQubitUnitary:
         assert np.allclose(res_static, expected, atol=tol)
         assert np.allclose(res_dynamic, expected, atol=tol)
 
+    def test_matrix_representation_batched(self, tol):
+        """Test that the matrix representation is defined correctly"""
+        U = np.array(
+            [[0.98877108 + 0.0j, 0.0 - 0.14943813j], [0.0 - 0.14943813j, 0.98877108 + 0.0j]]
+        )
+        U = np.tensordot(U, [0.2, -0.1, 1.3], axes=0)
+        res_static = qml.QubitUnitary.compute_matrix(U)
+        res_dynamic = qml.QubitUnitary(U, wires=0).matrix()
+        expected = U
+        assert np.allclose(res_static, expected, atol=tol)
+        assert np.allclose(res_dynamic, expected, atol=tol)
+
 
 class TestDiagonalQubitUnitary:
     """Test the DiagonalQubitUnitary operation."""
 
-    def test_decomposition(self):
+    @pytest.mark.parametrize(
+        "D, num_wires, expected_U",
+        [
+            ([1j, 1, 1, -1, -1j, 1j, 1, -1], 3, np.diag([1j, 1, 1, -1, -1j, 1j, 1, -1])),
+            (
+                np.outer([1.0, -1.0, 1j, 1.0], [1.0, -1.0]),
+                2,
+                np.transpose(
+                    np.stack([np.diag([1.0, -1.0, 1j, 1.0]), np.diag([-1.0, 1.0, -1j, -1.0])]),
+                    (1, 2, 0),
+                ),
+            ),
+        ],
+    )
+    def test_decomposition(self, D, num_wires, expected_U):
         """Test that DiagonalQubitUnitary falls back to QubitUnitary."""
-        D = np.array([1j, 1, 1, -1, -1j, 1j, 1, -1])
+        D = np.array(D)
 
-        decomp = qml.DiagonalQubitUnitary.compute_decomposition(D, [0, 1, 2])
-        decomp2 = qml.DiagonalQubitUnitary(D, wires=[0, 1, 2]).decomposition()
+        wires = list(range(num_wires))
+        decomp = qml.DiagonalQubitUnitary.compute_decomposition(D, wires)
+        decomp2 = qml.DiagonalQubitUnitary(D, wires=wires).decomposition()
 
         assert decomp[0].name == "QubitUnitary" == decomp2[0].name
-        assert decomp[0].wires == Wires([0, 1, 2]) == decomp2[0].wires
-        assert np.allclose(decomp[0].data[0], np.diag(D))
-        assert np.allclose(decomp2[0].data[0], np.diag(D))
+        assert decomp[0].wires == Wires(wires) == decomp2[0].wires
+        assert np.allclose(decomp[0].data[0], expected_U)
+        assert np.allclose(decomp2[0].data[0], expected_U)
 
     def test_controlled(self):
         """Test that the correct controlled operation is created when controlling a qml.DiagonalQubitUnitary."""
@@ -275,6 +325,30 @@ class TestDiagonalQubitUnitary:
         assert qml.math.allclose(
             mat, qml.math.diag(qml.math.append(qml.math.ones(8, dtype=complex), D))
         )
+
+    def test_controlled_batched(self):
+        """Test that the correct controlled operation is created when
+        controlling a qml.DiagonalQubitUnitary with a batched diagonal."""
+        D = np.array([[1j, 1], [1, -1], [-1j, 1j], [1, -1]])
+        op = qml.DiagonalQubitUnitary(D, wires=[1, 2])
+        with qml.tape.QuantumTape() as tape:
+            op._controlled(control=0)
+        mat = qml.matrix(tape)
+        z = [0, 0]
+        o = [1, 1]
+        expected = np.array(
+            [
+                [o, z, z, z, z, z, z, z],
+                [z, o, z, z, z, z, z, z],
+                [z, z, o, z, z, z, z, z],
+                [z, z, z, o, z, z, z, z],
+                [z, z, z, z, [1j, 1], z, z, z],
+                [z, z, z, z, z, [1, -1], z, z],
+                [z, z, z, z, z, z, [-1j, 1j], z],
+                [z, z, z, z, z, z, z, [1, -1]],
+            ]
+        )
+        assert qml.math.allclose(mat, expected)
 
     def test_matrix_representation(self, tol):
         """Test that the matrix representation is defined correctly"""
@@ -296,17 +370,32 @@ class TestDiagonalQubitUnitary:
         for x_op, x_pow in zip(op.data[0], pow_ops[0].data[0]):
             assert (x_op + 0.0j) ** n == x_pow
 
-    def test_error_matrix_not_unitary(self):
+    def test_matrix_representation_batched(self, tol):
+        """Test that the matrix representation is defined correctly for a batched diagonal."""
+        diag = np.array([[1, -1, 1j], [-1, -1, -1]])
+        res_static = qml.DiagonalQubitUnitary.compute_matrix(diag)
+        res_dynamic = qml.DiagonalQubitUnitary(diag, wires=0).matrix()
+        expected = np.array([[[1, -1, 1j], [0, 0, 0]], [[0, 0, 0], [-1, -1, -1]]])
+        assert np.allclose(res_static, expected, atol=tol)
+        assert np.allclose(res_dynamic, expected, atol=tol)
+
+    @pytest.mark.parametrize("D", [[1, 2], [[0.2, 1.0, -1.0], [1.0, -1j, 1j]]])
+    def test_error_matrix_not_unitary(self, D):
         """Tests that error is raised if diagonal by `compute_matrix` does not lead to a unitary"""
         with pytest.raises(ValueError, match="Operator must be unitary"):
-            qml.DiagonalQubitUnitary.compute_matrix(np.array([1, 2]))
-
-    @pytest.mark.jax
-    def test_error_eigvals_not_unitary(self):
-        """Tests that error is raised by `compute_eigvals` if diagonal does not lead to a unitary"""
+            qml.DiagonalQubitUnitary.compute_matrix(np.array(D))
         with pytest.raises(ValueError, match="Operator must be unitary"):
-            qml.DiagonalQubitUnitary.compute_eigvals(np.array([1, 2]))
+            qml.DiagonalQubitUnitary(np.array(D), wires=1).matrix()
 
+    @pytest.mark.parametrize("D", [[1, 2], [[0.2, 1.0, -1.0], [1.0, -1j, 1j]]])
+    def test_error_eigvals_not_unitary(self, D):
+        """Tests that error is raised if diagonal by `compute_matrix` does not lead to a unitary"""
+        with pytest.raises(ValueError, match="Operator must be unitary"):
+            qml.DiagonalQubitUnitary.compute_eigvals(np.array(D))
+        with pytest.raises(ValueError, match="Operator must be unitary"):
+            qml.DiagonalQubitUnitary(np.array(D), wires=0).eigvals()
+
+    # TODO[dwierichs]: Add a JIT test using tensor-batching once devices support it
     @pytest.mark.jax
     def test_jax_jit(self):
         """Test that the diagonal matrix unitary operation works
@@ -379,6 +468,12 @@ class TestControlledQubitUnitary:
         with wires is provided"""
         with pytest.raises(ValueError, match=r"Input unitary must be of shape \(2, 2\)"):
             qml.ControlledQubitUnitary(np.eye(4), control_wires=[0, 1], wires=2).matrix()
+
+    def test_error_batching(self):
+        """Test if ControlledQubitUnitary raises a NotImplementedError when
+        instantiated with a tensor-batched unitary."""
+        with pytest.raises(NotImplementedError, match=r"does not support tensor-batching"):
+            qml.ControlledQubitUnitary(np.ones((4, 4, 3)), control_wires=[0, 1], wires=2)
 
     @pytest.mark.parametrize("target_wire", range(3))
     def test_toffoli(self, target_wire):

--- a/tests/ops/qubit/test_parametric_ops.py
+++ b/tests/ops/qubit/test_parametric_ops.py
@@ -14,6 +14,7 @@
 """
 Unit tests for the available built-in parametric qubit operations.
 """
+from functools import reduce
 import pytest
 import copy
 import numpy as np
@@ -55,6 +56,41 @@ PARAMETRIZED_OPERATIONS = [
     qml.DoubleExcitationMinus(0.123, wires=[0, 1, 2, 3]),
 ]
 
+BATCHED_OPERATIONS = [
+    qml.RX(np.array([0.142, -0.61, 2.3]), wires=0),
+    qml.RY(np.array([1.291, -0.10, 5.2]), wires=0),
+    qml.RZ(np.array([4.239, -3.21, 1.1]), wires=0),
+    qml.PauliRot(np.array([0.142, -0.61, 2.3]), "Y", wires=0),
+    qml.IsingXX(np.array([0.142, -0.61, 2.3]), wires=[0, 1]),
+    qml.IsingYY(np.array([0.142, -0.61, 2.3]), wires=[0, 1]),
+    qml.IsingZZ(np.array([0.142, -0.61, 2.3]), wires=[0, 1]),
+    qml.Rot(np.array([0.142, -0.61, 2.3]), 0.456, 0.789, wires=0),
+    qml.PhaseShift(np.array([2.12, 0.21, -6.2]), wires=0),
+    qml.ControlledPhaseShift(np.array([1.777, -0.1, 5.29]), wires=[0, 2]),
+    qml.CPhase(np.array([1.777, -0.1, 5.29]), wires=[0, 2]),
+    qml.MultiRZ(np.array([1.124, -2.31, 0.112]), wires=[1, 2, 3]),
+    qml.CRX(np.array([0.836, 0.21, -3.57]), wires=[2, 3]),
+    qml.CRY(np.array([0.721, 2.31, 0.983]), wires=[2, 3]),
+    qml.CRZ(np.array([0.554, 1.11, 2.2]), wires=[2, 3]),
+    qml.U1(np.array([0.142, -0.61, 2.3]), wires=0),
+    qml.U2(np.array([9.23, 1.33, 3.556]), np.array([2.134, 1.2, 0.2]), wires=0),
+    qml.U3(
+        np.array([2.009, 1.33, 3.556]),
+        np.array([2.134, 1.2, 0.2]),
+        np.array([0.78, 0.48, 0.83]),
+        wires=0,
+    ),
+    qml.CRot(
+        np.array([0.142, -0.61, 2.3]),
+        np.array([9.82, 0.2, 0.53]),
+        np.array([0.12, 2.21, 0.789]),
+        wires=[0, 1],
+    ),
+    qml.QubitUnitary(1j * np.array([[[1, 0], [0, -1]], [[0, 1], [1, 0]]]), wires=0),
+    qml.DiagonalQubitUnitary(np.array([[1.0, 1.0j], [1.0j, 1.0j]]), wires=1),
+]
+
+
 NON_PARAMETRIZED_OPERATIONS = [
     qml.S(wires=0),
     qml.SX(wires=0),
@@ -78,9 +114,12 @@ NON_PARAMETRIZED_OPERATIONS = [
 
 ALL_OPERATIONS = NON_PARAMETRIZED_OPERATIONS + PARAMETRIZED_OPERATIONS
 
+dot_batched = lambda a, b: np.einsum("ij...,jk...->ik...", a, b)
+multi_dot_batched = lambda matrices: reduce(dot_batched, matrices)
+
 
 class TestOperations:
-    @pytest.mark.parametrize("op", ALL_OPERATIONS)
+    @pytest.mark.parametrize("op", ALL_OPERATIONS + BATCHED_OPERATIONS)
     def test_parametrized_op_copy(self, op, tol):
         """Tests that copied parametrized ops function as expected"""
         copied_op = copy.copy(op)
@@ -98,6 +137,16 @@ class TestOperations:
         res2 = np.dot(op_d.matrix(), op.matrix())
         np.testing.assert_allclose(res1, np.eye(2 ** len(op.wires)), atol=tol)
         np.testing.assert_allclose(res2, np.eye(2 ** len(op.wires)), atol=tol)
+        assert op.wires == op_d.wires
+
+    @pytest.mark.parametrize("op", BATCHED_OPERATIONS)
+    def test_adjoint_unitaries_batched(self, op, tol):
+        op_d = op.adjoint()
+        res1 = dot_batched(op.matrix(), op_d.matrix())
+        res2 = dot_batched(op_d.matrix(), op.matrix())
+        I = np.transpose(np.stack([np.eye(2 ** len(op.wires))] * op.matrix().shape[-1]), (1, 2, 0))
+        np.testing.assert_allclose(res1, I, atol=tol)
+        np.testing.assert_allclose(res2, I, atol=tol)
         assert op.wires == op_d.wires
 
 
@@ -128,9 +177,9 @@ class TestParameterFrequencies:
 
 
 class TestDecompositions:
-    def test_phase_decomposition(self, tol):
+    @pytest.mark.parametrize("phi", [0.3, np.array([0.4, 2.1])])
+    def test_phase_decomposition(self, phi, tol):
         """Tests that the decomposition of the Phase gate is correct"""
-        phi = 0.3
         op = qml.PhaseShift(phi, wires=0)
         res = op.decomposition()
 
@@ -139,19 +188,26 @@ class TestDecompositions:
         assert res[0].name == "RZ"
 
         assert res[0].wires == Wires([0])
-        assert res[0].data[0] == 0.3
+        assert np.allclose(res[0].data[0], phi)
 
         decomposed_matrix = res[0].matrix()
-        global_phase = (decomposed_matrix[op.matrix() != 0] / op.matrix()[op.matrix() != 0])[0]
+        phases = decomposed_matrix[op.matrix() != 0] / op.matrix()[op.matrix() != 0]
+        if isinstance(phi, float):
+            global_phase = phases[0]
+        else:
+            global_phase = phases[: len(phi)]
 
         assert np.allclose(decomposed_matrix, global_phase * op.matrix(), atol=tol, rtol=0)
 
-    def test_Rot_decomposition(self):
+    @pytest.mark.parametrize(
+        "phi, theta, omega",
+        [
+            (0.432, 0.654, -5.43),
+            (np.array([0.1, 2.1]), np.array([0.4, -0.2]), np.array([1.1, 0.2])),
+        ],
+    )
+    def test_Rot_decomposition(self, phi, theta, omega):
         """Test the decomposition of Rot."""
-        phi = 0.432
-        theta = 0.654
-        omega = -5.43
-
         ops1 = qml.Rot.compute_decomposition(phi, theta, omega, wires=0)
         ops2 = qml.Rot(phi, theta, omega, wires=0).decomposition()
 
@@ -163,12 +219,11 @@ class TestDecompositions:
         for ops in [ops1, ops2]:
             for c, p, op in zip(classes, params, ops):
                 assert isinstance(op, c)
-                assert op.parameters == p
+                assert np.allclose(op.parameters, p)
 
-    def test_CRX_decomposition(self):
+    @pytest.mark.parametrize("phi", [0.432, np.array([0.1, 2.1])])
+    def test_CRX_decomposition(self, phi):
         """Test the decomposition for CRX."""
-        phi = 0.432
-
         ops1 = qml.CRX.compute_decomposition(phi, wires=[0, 1])
         ops2 = qml.CRX(phi, wires=(0, 1)).decomposition()
 
@@ -179,13 +234,12 @@ class TestDecompositions:
         for ops in [ops1, ops2]:
             for op, c, p, w in zip(ops, classes, params, wires):
                 assert isinstance(op, c)
-                assert op.parameters == p
+                assert np.allclose(op.parameters, p)
                 assert op.wires == w
 
-    def test_CRY_decomposition(self):
+    @pytest.mark.parametrize("phi", [0.432, np.array([0.1, 2.1])])
+    def test_CRY_decomposition(self, phi):
         """Test the decomposition for CRY."""
-        phi = 0.432
-
         ops1 = qml.CRY.compute_decomposition(phi, wires=[0, 1])
         ops2 = qml.CRY(phi, wires=(0, 1)).decomposition()
 
@@ -196,13 +250,12 @@ class TestDecompositions:
         for ops in [ops1, ops2]:
             for op, c, p, w in zip(ops, classes, params, wires):
                 assert isinstance(op, c)
-                assert op.parameters == p
+                assert np.allclose(op.parameters, p)
                 assert op.wires == w
 
-    def test_CRZ_decomposition(self):
+    @pytest.mark.parametrize("phi", [0.432, np.array([0.1, 2.1])])
+    def test_CRZ_decomposition(self, phi):
         """Test the decomposition for CRZ."""
-        phi = 0.432
-
         ops1 = qml.CRZ.compute_decomposition(phi, wires=[0, 1])
         ops2 = qml.CRZ(phi, wires=(0, 1)).decomposition()
 
@@ -213,10 +266,17 @@ class TestDecompositions:
         for ops in [ops1, ops2]:
             for op, c, p, w in zip(ops, classes, params, wires):
                 assert isinstance(op, c)
-                assert op.parameters == p
+                assert np.allclose(op.parameters, p)
                 assert op.wires == w
 
-    @pytest.mark.parametrize("phi, theta, omega", [[0.5, 0.6, 0.7], [0.1, -0.4, 0.7], [-10, 5, -1]])
+    @pytest.mark.parametrize(
+        "phi, theta, omega",
+        [
+            [0.5, 0.6, 0.7],
+            [-10, 5, -1],
+            [np.array([0.1, 0.2]), np.array([-0.4, 2.19]), np.array([0.7, -0.7])],
+        ],
+    )
     def test_CRot_decomposition(self, tol, phi, theta, omega, monkeypatch):
         """Tests that the decomposition of the CRot gate is correct"""
         op = qml.CRot(phi, theta, omega, wires=[0, 1])
@@ -225,46 +285,52 @@ class TestDecompositions:
         mats = []
         for i in reversed(res):
             if len(i.wires) == 1:
-                mats.append(np.kron(np.eye(2), i.matrix()))
+                mat = i.matrix()
+                I = np.eye(2)[:, :, np.newaxis] if len(mat.shape) == 3 else np.eye(2)
+                mats.append(np.kron(I, mat))
             else:
                 mats.append(i.matrix())
 
-        decomposed_matrix = np.linalg.multi_dot(mats)
+        decomposed_matrix = multi_dot_batched(mats)
 
         assert np.allclose(decomposed_matrix, op.matrix(), atol=tol, rtol=0)
 
-    def test_U1_decomposition(self):
+    @pytest.mark.parametrize("phi", [0.432, np.array([0.1, 2.1])])
+    def test_U1_decomposition(self, phi):
         """Test the decomposition for U1."""
-        phi = 0.432
         res = qml.U1(phi, wires=0).decomposition()
         res2 = qml.U1.compute_decomposition(phi, wires=0)
 
         assert len(res) == len(res2) == 1
         assert res[0].name == res2[0].name == "PhaseShift"
-        assert res[0].parameters == res2[0].parameters == [phi]
+        assert np.allclose(res[0].parameters, [phi])
+        assert np.allclose(res2[0].parameters, [phi])
 
-    def test_U2_decomposition(self):
+    @pytest.mark.parametrize(
+        "phi, lam", [(0.432, 0.654), (np.array([0.1, 2.1]), np.array([1.2, 4.9]))]
+    )
+    def test_U2_decomposition(self, phi, lam):
         """Test the decomposition for U2."""
-        phi = 0.432
-        lam = 0.654
-
         ops1 = qml.U2.compute_decomposition(phi, lam, wires=0)
         ops2 = qml.U2(phi, lam, wires=0).decomposition()
 
         classes = [qml.Rot, qml.PhaseShift, qml.PhaseShift]
-        params = [[lam, np.pi / 2, -lam], [lam], [phi]]
+        params = [[lam, np.ones_like(lam) * np.pi / 2, -lam], [lam], [phi]]
 
         for ops in [ops1, ops2]:
             for op, c, p in zip(ops, classes, params):
                 assert isinstance(op, c)
-                assert op.parameters == p
+                assert np.allclose(op.parameters, p)
 
-    def test_U3_decomposition(self):
+    @pytest.mark.parametrize(
+        "theta, phi, lam",
+        [
+            (0.432, 0.654, 0.218),
+            (np.array([0.1, 2.1]), np.array([1.2, 4.9]), np.array([-1.7, 3.2])),
+        ],
+    )
+    def test_U3_decomposition(self, theta, phi, lam):
         """Test the decomposition for U3."""
-        theta = 0.654
-        phi = 0.432
-        lam = 0.654
-
         ops1 = qml.U3.compute_decomposition(theta, phi, lam, wires=0)
         ops2 = qml.U3(theta, phi, lam, wires=0).decomposition()
 
@@ -274,12 +340,12 @@ class TestDecompositions:
         for ops in [ops1, ops2]:
             for op, c, p in zip(ops, classes, params):
                 assert isinstance(op, c)
-                assert op.parameters == p
+                assert np.allclose(op.parameters, p)
 
-    def test_isingxx_decomposition(self, tol):
+    @pytest.mark.parametrize("phi", [0.1234, np.array([-0.1, 0.2, 0.5])])
+    def test_isingxx_decomposition(self, phi, tol):
         """Tests that the decomposition of the IsingXX gate is correct"""
-        param = 0.1234
-        op = qml.IsingXX(param, wires=[3, 2])
+        op = qml.IsingXX(phi, wires=[3, 2])
         res = op.decomposition()
 
         assert len(res) == 3
@@ -295,19 +361,21 @@ class TestDecompositions:
         mats = []
         for i in reversed(res):
             if i.wires == Wires([3]):
+                mat = i.matrix()
+                I = np.eye(2)[:, :, np.newaxis] if len(mat.shape) == 3 else np.eye(2)
                 # RX gate
-                mats.append(np.kron(i.matrix(), np.eye(2)))
+                mats.append(np.kron(mat, I))
             else:
                 mats.append(i.matrix())
 
-        decomposed_matrix = np.linalg.multi_dot(mats)
+        decomposed_matrix = multi_dot_batched(mats)
 
         assert np.allclose(decomposed_matrix, op.matrix(), atol=tol, rtol=0)
 
-    def test_isingyy_decomposition(self, tol):
+    @pytest.mark.parametrize("phi", [0.1234, np.array([-0.1, 0.2, 0.5])])
+    def test_isingyy_decomposition(self, phi, tol):
         """Tests that the decomposition of the IsingYY gate is correct"""
-        param = 0.1234
-        op = qml.IsingYY(param, wires=[3, 2])
+        op = qml.IsingYY(phi, wires=[3, 2])
         res = op.decomposition()
 
         assert len(res) == 3
@@ -323,19 +391,21 @@ class TestDecompositions:
         mats = []
         for i in reversed(res):
             if i.wires == Wires([3]):
+                mat = i.matrix()
+                I = np.eye(2)[:, :, np.newaxis] if len(mat.shape) == 3 else np.eye(2)
                 # RY gate
-                mats.append(np.kron(i.matrix(), np.eye(2)))
+                mats.append(np.kron(mat, I))
             else:
                 mats.append(i.matrix())
 
-        decomposed_matrix = np.linalg.multi_dot(mats)
+        decomposed_matrix = multi_dot_batched(mats)
 
         assert np.allclose(decomposed_matrix, op.matrix(), atol=tol, rtol=0)
 
-    def test_isingzz_decomposition(self, tol):
+    @pytest.mark.parametrize("phi", [0.1234, np.array([-0.1, 0.2, 0.5])])
+    def test_isingzz_decomposition(self, phi, tol):
         """Tests that the decomposition of the IsingZZ gate is correct"""
-        param = 0.1234
-        op = qml.IsingZZ(param, wires=[3, 2])
+        op = qml.IsingZZ(phi, wires=[3, 2])
         res = op.decomposition()
 
         assert len(res) == 3
@@ -351,16 +421,18 @@ class TestDecompositions:
         mats = []
         for i in reversed(res):
             if i.wires == Wires([2]):
+                mat = i.matrix()
+                I = np.eye(2)[:, :, np.newaxis] if len(mat.shape) == 3 else np.eye(2)
                 # RZ gate
-                mats.append(np.kron(np.eye(2), i.matrix()))
+                mats.append(np.kron(I, mat))
             else:
                 mats.append(i.matrix())
 
-        decomposed_matrix = np.linalg.multi_dot(mats)
+        decomposed_matrix = multi_dot_batched(mats)
 
         assert np.allclose(decomposed_matrix, op.matrix(), atol=tol, rtol=0)
 
-    @pytest.mark.parametrize("phi", [-0.1, 0.2, 0.5])
+    @pytest.mark.parametrize("phi", [-0.1, 0.5, np.array([0.2, -0.9])])
     @pytest.mark.parametrize("cphase_op", [qml.ControlledPhaseShift, qml.CPhase])
     def test_controlled_phase_shift_decomp(self, phi, cphase_op):
         """Tests that the ControlledPhaseShift and CPhase operation
@@ -368,44 +440,17 @@ class TestDecompositions:
         op = cphase_op(phi, wires=[0, 2])
         decomp = op.decomposition()
 
-        mats = []
-        for i in reversed(decomp):
-            if i.wires.tolist() == [0]:
-                mats.append(np.kron(i.matrix(), np.eye(4)))
-            elif i.wires.tolist() == [1]:
-                mats.append(np.kron(np.eye(2), np.kron(i.matrix(), np.eye(2))))
-            elif i.wires.tolist() == [2]:
-                mats.append(np.kron(np.eye(4), i.matrix()))
-            elif isinstance(i, qml.CNOT) and i.wires.tolist() == [0, 1]:
-                mats.append(np.kron(i.matrix(), np.eye(2)))
-            elif isinstance(i, qml.CNOT) and i.wires.tolist() == [0, 2]:
-                mats.append(
-                    np.array(
-                        [
-                            [1, 0, 0, 0, 0, 0, 0, 0],
-                            [0, 1, 0, 0, 0, 0, 0, 0],
-                            [0, 0, 1, 0, 0, 0, 0, 0],
-                            [0, 0, 0, 1, 0, 0, 0, 0],
-                            [0, 0, 0, 0, 0, 1, 0, 0],
-                            [0, 0, 0, 0, 1, 0, 0, 0],
-                            [0, 0, 0, 0, 0, 0, 0, 1],
-                            [0, 0, 0, 0, 0, 0, 1, 0],
-                        ]
-                    )
-                )
-
-        decomposed_matrix = np.linalg.multi_dot(mats)
+        mats = [op.matrix(wire_order=[0, 2]) for op in reversed(decomp)]
+        decomposed_matrix = multi_dot_batched(mats)
         lam = np.exp(1j * phi)
+        z = np.zeros_like(lam)
+        o = np.ones_like(lam)
         exp = np.array(
             [
-                [1, 0, 0, 0, 0, 0, 0, 0],
-                [0, 1, 0, 0, 0, 0, 0, 0],
-                [0, 0, 1, 0, 0, 0, 0, 0],
-                [0, 0, 0, 1, 0, 0, 0, 0],
-                [0, 0, 0, 0, 1, 0, 0, 0],
-                [0, 0, 0, 0, 0, lam, 0, 0],
-                [0, 0, 0, 0, 0, 0, 1, 0],
-                [0, 0, 0, 0, 0, 0, 0, lam],
+                [o, z, z, z],
+                [z, o, z, z],
+                [z, z, o, z],
+                [z, z, z, lam],
             ]
         )
 
@@ -418,11 +463,19 @@ class TestMatrix:
 
         # test identity for theta=0
         assert np.allclose(qml.PhaseShift.compute_matrix(0), np.identity(2), atol=tol, rtol=0)
+        assert np.allclose(qml.PhaseShift(0, wires=0).matrix(), np.identity(2), atol=tol, rtol=0)
         assert np.allclose(qml.U1.compute_matrix(0), np.identity(2), atol=tol, rtol=0)
 
         # test arbitrary phase shift
         phi = 0.5432
         expected = np.array([[1, 0], [0, np.exp(1j * phi)]])
+        assert np.allclose(qml.PhaseShift.compute_matrix(phi), expected, atol=tol, rtol=0)
+        assert np.allclose(qml.U1.compute_matrix(phi), expected, atol=tol, rtol=0)
+
+        # test arbitrary batched phase shift
+        phi = 0.5432
+        o, z = np.ones_like(phi), np.zeros_like(phi)
+        expected = np.array([[o, z], [z, np.exp(1j * phi)]])
         assert np.allclose(qml.PhaseShift.compute_matrix(phi), expected, atol=tol, rtol=0)
         assert np.allclose(qml.U1.compute_matrix(phi), expected, atol=tol, rtol=0)
 
@@ -437,6 +490,12 @@ class TestMatrix:
         expected = np.array([[1, -1j], [-1j, 1]]) / np.sqrt(2)
         assert np.allclose(qml.RX.compute_matrix(np.pi / 2), expected, atol=tol, rtol=0)
         assert np.allclose(qml.RX(np.pi / 2, wires=0).matrix(), expected, atol=tol, rtol=0)
+
+        # test identity for batched theta=pi/2
+        expected = np.tensordot(np.array([[1, -1j], [-1j, 1]]) / np.sqrt(2), [1, 1], axes=0)
+        pi_half = np.array([np.pi / 2, np.pi / 2])
+        assert np.allclose(qml.RX.compute_matrix(pi_half), expected, atol=tol, rtol=0)
+        assert np.allclose(qml.RX(pi_half, wires=0).matrix(), expected, atol=tol, rtol=0)
 
         # test identity for theta=pi
         expected = -1j * np.array([[0, 1], [1, 0]])
@@ -455,6 +514,12 @@ class TestMatrix:
         assert np.allclose(qml.RY.compute_matrix(np.pi / 2), expected, atol=tol, rtol=0)
         assert np.allclose(qml.RY(np.pi / 2, wires=0).matrix(), expected, atol=tol, rtol=0)
 
+        # test identity for batched theta=pi/2
+        expected = np.tensordot(np.array([[1, -1], [1, 1]]) / np.sqrt(2), [1, 1], axes=0)
+        pi_half = np.array([np.pi / 2, np.pi / 2])
+        assert np.allclose(qml.RY.compute_matrix(pi_half), expected, atol=tol, rtol=0)
+        assert np.allclose(qml.RY(pi_half, wires=0).matrix(), expected, atol=tol, rtol=0)
+
         # test identity for theta=pi
         expected = np.array([[0, -1], [1, 0]])
         assert np.allclose(qml.RY.compute_matrix(np.pi), expected, atol=tol, rtol=0)
@@ -472,6 +537,12 @@ class TestMatrix:
         assert np.allclose(qml.RZ.compute_matrix(np.pi / 2), expected, atol=tol, rtol=0)
         assert np.allclose(qml.RZ(np.pi / 2, wires=0).matrix(), expected, atol=tol, rtol=0)
 
+        # test identity for batched theta=pi/2
+        expected = np.tensordot(np.diag(np.exp([-1j * np.pi / 4, 1j * np.pi / 4])), [1, 1], axes=0)
+        pi_half = np.array([np.pi / 2, np.pi / 2])
+        assert np.allclose(qml.RZ.compute_matrix(pi_half), expected, atol=tol, rtol=0)
+        assert np.allclose(qml.RZ(pi_half, wires=0).matrix(), expected, atol=tol, rtol=0)
+
         # test identity for theta=pi
         assert np.allclose(qml.RZ.compute_matrix(np.pi), -1j * Z, atol=tol, rtol=0)
         assert np.allclose(qml.RZ(np.pi, wires=0).matrix(), -1j * Z, atol=tol, rtol=0)
@@ -482,15 +553,23 @@ class TestMatrix:
         assert np.allclose(qml.IsingXX(0, wires=[0, 1]).matrix(), np.identity(4), atol=tol, rtol=0)
 
         def get_expected(theta):
-            expected = np.array(np.diag([np.cos(theta / 2)] * 4), dtype=np.complex128)
+            if len(qml.math.shape(theta)) == 1:
+                expected = np.zeros((4, 4, qml.math.shape(theta)[0]), dtype=np.complex128)
+            else:
+                expected = np.zeros((4, 4), dtype=np.complex128)
+            cos_coeff = np.cos(theta / 2)
             sin_coeff = -1j * np.sin(theta / 2)
-            expected[3, 0] = sin_coeff
-            expected[2, 1] = sin_coeff
-            expected[1, 2] = sin_coeff
-            expected[0, 3] = sin_coeff
+            expected[0, 0] = expected[1, 1] = expected[2, 2] = expected[3, 3] = cos_coeff
+            expected[3, 0] = expected[2, 1] = expected[1, 2] = expected[0, 3] = sin_coeff
             return expected
 
         param = np.pi / 2
+        assert np.allclose(qml.IsingXX.compute_matrix(param), get_expected(param), atol=tol, rtol=0)
+        assert np.allclose(
+            qml.IsingXX(param, wires=[0, 1]).matrix(), get_expected(param), atol=tol, rtol=0
+        )
+
+        param = np.array([np.pi / 2, 0.213])
         assert np.allclose(qml.IsingXX.compute_matrix(param), get_expected(param), atol=tol, rtol=0)
         assert np.allclose(
             qml.IsingXX(param, wires=[0, 1]).matrix(), get_expected(param), atol=tol, rtol=0
@@ -511,11 +590,14 @@ class TestMatrix:
         )
 
         def get_expected(theta):
+            if len(qml.math.shape(theta)) == 1:
+                expected = np.zeros((4, 4, qml.math.shape(theta)[0]), dtype=np.complex128)
+            else:
+                expected = np.zeros((4, 4), dtype=np.complex128)
             neg_imag = np.exp(-1j * theta / 2)
-            plus_imag = np.exp(1j * theta / 2)
-            expected = np.array(
-                np.diag([neg_imag, plus_imag, plus_imag, neg_imag]), dtype=np.complex128
-            )
+            pos_imag = np.exp(1j * theta / 2)
+            expected[0, 0] = expected[3, 3] = neg_imag
+            expected[1, 1] = expected[2, 2] = pos_imag
             return expected
 
         param = np.pi / 2
@@ -525,6 +607,12 @@ class TestMatrix:
         )
         assert np.allclose(
             qml.IsingZZ.compute_eigvals(param), np.diagonal(get_expected(param)), atol=tol, rtol=0
+        )
+
+        param = np.array([np.pi / 2, 0.213])
+        assert np.allclose(qml.IsingZZ.compute_matrix(param), get_expected(param), atol=tol, rtol=0)
+        assert np.allclose(
+            qml.IsingZZ(param, wires=[0, 1]).matrix(), get_expected(param), atol=tol, rtol=0
         )
 
         param = np.pi
@@ -543,15 +631,24 @@ class TestMatrix:
         import tensorflow as tf
 
         def get_expected(theta):
+            if len(qml.math.shape(theta)) == 1:
+                expected = np.zeros((4, 4, qml.math.shape(theta)[0]), dtype=np.complex128)
+            else:
+                expected = np.zeros((4, 4), dtype=np.complex128)
             neg_imag = np.exp(-1j * theta / 2)
-            plus_imag = np.exp(1j * theta / 2)
-            expected = np.array(
-                np.diag([neg_imag, plus_imag, plus_imag, neg_imag]), dtype=np.complex128
-            )
+            pos_imag = np.exp(1j * theta / 2)
+            expected[0, 0] = expected[3, 3] = neg_imag
+            expected[1, 1] = expected[2, 2] = pos_imag
             return expected
 
         param = tf.Variable(np.pi)
         assert np.allclose(qml.IsingZZ.compute_matrix(param), get_expected(np.pi), atol=tol, rtol=0)
+
+        param = np.array([np.pi, 0.1242])
+        param_tf = tf.Variable(param)
+        assert np.allclose(
+            qml.IsingZZ.compute_matrix(param_tf), get_expected(param), atol=tol, rtol=0
+        )
 
     def test_Rot(self, tol):
         """Test arbitrary single qubit rotation is correct"""
@@ -580,7 +677,15 @@ class TestMatrix:
             qml.Rot(a, b, c, wires=0).matrix(), arbitrary_rotation(a, b, c), atol=tol, rtol=0
         )
 
-    def test_CRx(self, tol):
+        a, b, c = np.array([0.432, -0.124]), np.array([-0.152, 2.912]), np.array([0.9234, -9.2])
+        assert np.allclose(
+            qml.Rot.compute_matrix(a, b, c), arbitrary_rotation(a, b, c), atol=tol, rtol=0
+        )
+        assert np.allclose(
+            qml.Rot(a, b, c, wires=0).matrix(), arbitrary_rotation(a, b, c), atol=tol, rtol=0
+        )
+
+    def test_CRX(self, tol):
         """Test controlled x rotation is correct"""
 
         # test identity for theta=0
@@ -588,7 +693,7 @@ class TestMatrix:
         assert np.allclose(qml.CRX(0, wires=[0, 1]).matrix(), np.identity(4), atol=tol, rtol=0)
 
         # test identity for theta=pi/2
-        expected = np.array(
+        expected_pi_half = np.array(
             [
                 [1, 0, 0, 0],
                 [0, 1, 0, 0],
@@ -596,13 +701,20 @@ class TestMatrix:
                 [0, 0, -1j / np.sqrt(2), 1 / np.sqrt(2)],
             ]
         )
-        assert np.allclose(qml.CRX.compute_matrix(np.pi / 2), expected, atol=tol, rtol=0)
-        assert np.allclose(qml.CRX(np.pi / 2, wires=[0, 1]).matrix(), expected, atol=tol, rtol=0)
+        assert np.allclose(qml.CRX.compute_matrix(np.pi / 2), expected_pi_half, atol=tol, rtol=0)
+        assert np.allclose(
+            qml.CRX(np.pi / 2, wires=[0, 1]).matrix(), expected_pi_half, atol=tol, rtol=0
+        )
 
         # test identity for theta=pi
-        expected = np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, -1j], [0, 0, -1j, 0]])
-        assert np.allclose(qml.CRX.compute_matrix(np.pi), expected, atol=tol, rtol=0)
-        assert np.allclose(qml.CRX(np.pi, wires=[0, 1]).matrix(), expected, atol=tol, rtol=0)
+        expected_pi = np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, -1j], [0, 0, -1j, 0]])
+        assert np.allclose(qml.CRX.compute_matrix(np.pi), expected_pi, atol=tol, rtol=0)
+        assert np.allclose(qml.CRX(np.pi, wires=[0, 1]).matrix(), expected_pi, atol=tol, rtol=0)
+
+        param = np.array([np.pi / 2, np.pi])
+        expected = np.transpose(np.stack([expected_pi_half, expected_pi]), (1, 2, 0))
+        assert np.allclose(qml.CRX.compute_matrix(param), expected, atol=tol, rtol=0)
+        assert np.allclose(qml.CRX(param, wires=[0, 1]).matrix(), expected, atol=tol, rtol=0)
 
     def test_CRY(self, tol):
         """Test controlled y rotation is correct"""
@@ -612,7 +724,7 @@ class TestMatrix:
         assert np.allclose(qml.CRY(0, wires=[0, 1]).matrix(), np.identity(4), atol=tol, rtol=0)
 
         # test identity for theta=pi/2
-        expected = np.array(
+        expected_pi_half = np.array(
             [
                 [1, 0, 0, 0],
                 [0, 1, 0, 0],
@@ -620,13 +732,20 @@ class TestMatrix:
                 [0, 0, 1 / np.sqrt(2), 1 / np.sqrt(2)],
             ]
         )
-        assert np.allclose(qml.CRY.compute_matrix(np.pi / 2), expected, atol=tol, rtol=0)
-        assert np.allclose(qml.CRY(np.pi / 2, wires=[0, 1]).matrix(), expected, atol=tol, rtol=0)
+        assert np.allclose(qml.CRY.compute_matrix(np.pi / 2), expected_pi_half, atol=tol, rtol=0)
+        assert np.allclose(
+            qml.CRY(np.pi / 2, wires=[0, 1]).matrix(), expected_pi_half, atol=tol, rtol=0
+        )
 
         # test identity for theta=pi
-        expected = np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, -1], [0, 0, 1, 0]])
-        assert np.allclose(qml.CRY.compute_matrix(np.pi), expected, atol=tol, rtol=0)
-        assert np.allclose(qml.CRY(np.pi, wires=[0, 1]).matrix(), expected, atol=tol, rtol=0)
+        expected_pi = np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, -1], [0, 0, 1, 0]])
+        assert np.allclose(qml.CRY.compute_matrix(np.pi), expected_pi, atol=tol, rtol=0)
+        assert np.allclose(qml.CRY(np.pi, wires=[0, 1]).matrix(), expected_pi, atol=tol, rtol=0)
+
+        param = np.array([np.pi / 2, np.pi])
+        expected = np.transpose(np.stack([expected_pi_half, expected_pi]), (1, 2, 0))
+        assert np.allclose(qml.CRY.compute_matrix(param), expected, atol=tol, rtol=0)
+        assert np.allclose(qml.CRY(param, wires=[0, 1]).matrix(), expected, atol=tol, rtol=0)
 
     def test_CRZ(self, tol):
         """Test controlled z rotation is correct"""
@@ -636,7 +755,7 @@ class TestMatrix:
         assert np.allclose(qml.CRZ(0, wires=[0, 1]).matrix(), np.identity(4), atol=tol, rtol=0)
 
         # test identity for theta=pi/2
-        expected = np.array(
+        expected_pi_half = np.array(
             [
                 [1, 0, 0, 0],
                 [0, 1, 0, 0],
@@ -644,13 +763,20 @@ class TestMatrix:
                 [0, 0, 0, np.exp(1j * np.pi / 4)],
             ]
         )
-        assert np.allclose(qml.CRZ.compute_matrix(np.pi / 2), expected, atol=tol, rtol=0)
-        assert np.allclose(qml.CRZ(np.pi / 2, wires=[0, 1]).matrix(), expected, atol=tol, rtol=0)
+        assert np.allclose(qml.CRZ.compute_matrix(np.pi / 2), expected_pi_half, atol=tol, rtol=0)
+        assert np.allclose(
+            qml.CRZ(np.pi / 2, wires=[0, 1]).matrix(), expected_pi_half, atol=tol, rtol=0
+        )
 
         # test identity for theta=pi
-        expected = np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, -1j, 0], [0, 0, 0, 1j]])
-        assert np.allclose(qml.CRZ.compute_matrix(np.pi), expected, atol=tol, rtol=0)
-        assert np.allclose(qml.CRZ(np.pi, wires=[0, 1]).matrix(), expected, atol=tol, rtol=0)
+        expected_pi = np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, -1j, 0], [0, 0, 0, 1j]])
+        assert np.allclose(qml.CRZ.compute_matrix(np.pi), expected_pi, atol=tol, rtol=0)
+        assert np.allclose(qml.CRZ(np.pi, wires=[0, 1]).matrix(), expected_pi, atol=tol, rtol=0)
+
+        param = np.array([np.pi / 2, np.pi])
+        expected = np.transpose(np.stack([expected_pi_half, expected_pi]), (1, 2, 0))
+        assert np.allclose(qml.CRZ.compute_matrix(param), expected, atol=tol, rtol=0)
+        assert np.allclose(qml.CRZ(param, wires=[0, 1]).matrix(), expected, atol=tol, rtol=0)
 
     def test_CRot(self, tol):
         """Test controlled arbitrary rotation is correct"""
@@ -674,10 +800,10 @@ class TestMatrix:
             s = np.sin(y / 2)
             return np.array(
                 [
-                    [1, 0, 0, 0],
-                    [0, 1, 0, 0],
-                    [0, 0, np.exp(-0.5j * (x + z)) * c, -np.exp(0.5j * (x - z)) * s],
-                    [0, 0, np.exp(-0.5j * (x - z)) * s, np.exp(0.5j * (x + z)) * c],
+                    [s / s, 0 * s, 0 * s, 0 * s],
+                    [0 * s, s / s, 0 * s, 0 * s],
+                    [0 * s, 0 * s, np.exp(-0.5j * (x + z)) * c, -np.exp(0.5j * (x - z)) * s],
+                    [0 * s, 0 * s, np.exp(-0.5j * (x - z)) * s, np.exp(0.5j * (x + z)) * c],
                 ]
             )
 
@@ -692,22 +818,37 @@ class TestMatrix:
             rtol=0,
         )
 
-    def test_U2_gate(self, tol):
+        a, b, c = np.array([0.432, -0.124]), np.array([-0.152, 2.912]), np.array([0.9234, -9.2])
+        assert np.allclose(
+            qml.CRot.compute_matrix(a, b, c), arbitrary_Crotation(a, b, c), atol=tol, rtol=0
+        )
+        assert np.allclose(
+            qml.CRot(a, b, c, wires=[0, 1]).matrix(),
+            arbitrary_Crotation(a, b, c),
+            atol=tol,
+            rtol=0,
+        )
+
+    @pytest.mark.parametrize(
+        "phi, lam", [(0.432, 0.654), (np.array([0.1, 2.1]), np.array([1.2, 4.9]))]
+    )
+    def test_U2_gate(self, phi, lam, tol):
         """Test U2 gate matrix matches the documentation"""
-        phi = 0.432
-        lam = -0.12
         expected = np.array(
-            [[1, -np.exp(1j * lam)], [np.exp(1j * phi), np.exp(1j * (phi + lam))]]
+            [[lam / lam, -np.exp(1j * lam)], [np.exp(1j * phi), np.exp(1j * (phi + lam))]]
         ) / np.sqrt(2)
         assert np.allclose(qml.U2.compute_matrix(phi, lam), expected, atol=tol, rtol=0)
         assert np.allclose(qml.U2(phi, lam, wires=[0]).matrix(), expected, atol=tol, rtol=0)
 
-    def test_U3_gate(self, tol):
+    @pytest.mark.parametrize(
+        "theta, phi, lam",
+        [
+            (0.432, 0.654, 0.218),
+            (np.array([0.1, 2.1]), np.array([1.2, 4.9]), np.array([-1.7, 3.2])),
+        ],
+    )
+    def test_U3_gate(self, theta, phi, lam, tol):
         """Test U3 gate matrix matches the documentation"""
-        theta = 0.65
-        phi = 0.432
-        lam = -0.12
-
         expected = np.array(
             [
                 [np.cos(theta / 2), -np.exp(1j * lam) * np.sin(theta / 2)],
@@ -717,7 +858,6 @@ class TestMatrix:
                 ],
             ]
         )
-
         assert np.allclose(qml.U3.compute_matrix(theta, phi, lam), expected, atol=tol, rtol=0)
         assert np.allclose(qml.U3(theta, phi, lam, wires=[0]).matrix(), expected, atol=tol, rtol=0)
 
@@ -733,6 +873,22 @@ class TestMatrix:
 
         res = op.eigvals()
         assert np.allclose(res, np.diag(exp))
+
+    @pytest.mark.parametrize("cphase_op", [qml.ControlledPhaseShift, qml.CPhase])
+    def test_controlled_phase_shift_matrix_and_eigvals_batched(self, cphase_op):
+        """Tests that the ControlledPhaseShift and CPhase operation calculate the
+        correct matrix and eigenvalues for batched parameters"""
+        phi = np.array([0.2, np.pi / 2, -0.1])
+        op = cphase_op(phi, wires=[0, 1])
+        res = op.matrix()
+        o = np.ones_like(phi)
+        z = np.zeros_like(phi)
+        exp = np.array([[o, z, z, z], [z, o, z, z], [z, z, o, z], [z, z, z, np.exp(1j * phi)]])
+        assert np.allclose(res, exp)
+
+        res = op.eigvals()
+        exp_eigvals = np.array([o, o, o, np.exp(1j * phi)])
+        assert np.allclose(res, exp_eigvals)
 
 
 class TestGrad:
@@ -1212,6 +1368,11 @@ class TestPauliRot:
 
         assert np.allclose(res, expected, atol=tol, rtol=0)
 
+        res = qml.PauliRot.compute_matrix(np.ones(3) * theta, pauli_word)
+        expected = np.transpose(np.stack([expected_matrix(theta)] * 3), (1, 2, 0))
+
+        assert np.allclose(res, expected, atol=tol, rtol=0)
+
     @pytest.mark.parametrize(
         "theta,pauli_word,expected_matrix",
         PAULI_ROT_MATRIX_TEST_DATA,
@@ -1221,6 +1382,11 @@ class TestPauliRot:
 
         res = qml.PauliRot.compute_matrix(theta, pauli_word)
         expected = expected_matrix
+
+        assert np.allclose(res, expected, atol=tol, rtol=0)
+
+        res = qml.PauliRot.compute_matrix(np.ones(5) * theta, pauli_word)
+        expected = np.transpose(np.stack([expected_matrix] * 5), (1, 2, 0))
 
         assert np.allclose(res, expected, atol=tol, rtol=0)
 
@@ -1243,6 +1409,14 @@ class TestPauliRot:
         res = qml.PauliRot.compute_matrix(theta, pauli_word)
         expected = qml.utils.expand(
             qml.PauliRot.compute_matrix(theta, compressed_pauli_word), compressed_wires, wires
+        )
+
+        assert np.allclose(res, expected, atol=tol, rtol=0)
+
+        batch = np.ones(2) * theta
+        res = qml.PauliRot.compute_matrix(batch, pauli_word)
+        expected = qml.operation.expand_matrix(
+            qml.PauliRot.compute_matrix(batch, compressed_pauli_word), compressed_wires, wires
         )
 
         assert np.allclose(res, expected, atol=tol, rtol=0)
@@ -1278,10 +1452,17 @@ class TestPauliRot:
 
         assert len(decomp_ops) == 0
 
-    def test_PauliRot_decomposition_ZZ(self):
-        """Test that the decomposition for a ZZ rotation is correct."""
+    def test_error_PauliRot_all_Identity_batched(self):
+        """Test handling that tensor-batching is correctly reported as unsupported
+        with the all-identity Pauli."""
+        with pytest.raises(NotImplementedError, match="does not support tensor-batching"):
+            qml.PauliRot(np.ones(2), "II", wires=[0, 1]).matrix()
+        with pytest.raises(NotImplementedError, match="does not support tensor-batching"):
+            qml.PauliRot(np.ones(2), "II", wires=[0, 1]).eigvals()
 
-        theta = 0.4
+    @pytest.mark.parametrize("theta", [0.4, np.array([np.pi / 3, 0.1, -0.9])])
+    def test_PauliRot_decomposition_ZZ(self, theta):
+        """Test that the decomposition for a ZZ rotation is correct."""
         op = qml.PauliRot(theta, "ZZ", wires=[0, 1])
         decomp_ops = op.decomposition()
 
@@ -1290,12 +1471,12 @@ class TestPauliRot:
         assert decomp_ops[0].name == "MultiRZ"
 
         assert decomp_ops[0].wires == Wires([0, 1])
-        assert decomp_ops[0].data[0] == theta
+        assert np.allclose(decomp_ops[0].data[0], theta)
 
-    def test_PauliRot_decomposition_XY(self):
+    @pytest.mark.parametrize("theta", [0.4, np.array([np.pi / 3, 0.1, -0.9])])
+    def test_PauliRot_decomposition_XY(self, theta):
         """Test that the decomposition for a XY rotation is correct."""
 
-        theta = 0.4
         op = qml.PauliRot(theta, "XY", wires=[0, 1])
         decomp_ops = op.decomposition()
 
@@ -1305,26 +1486,24 @@ class TestPauliRot:
         assert decomp_ops[0].wires == Wires([0])
 
         assert decomp_ops[1].name == "RX"
-
         assert decomp_ops[1].wires == Wires([1])
         assert decomp_ops[1].data[0] == np.pi / 2
 
         assert decomp_ops[2].name == "MultiRZ"
         assert decomp_ops[2].wires == Wires([0, 1])
-        assert decomp_ops[2].data[0] == theta
+        assert np.allclose(decomp_ops[2].data[0], theta)
 
         assert decomp_ops[3].name == "Hadamard"
         assert decomp_ops[3].wires == Wires([0])
 
         assert decomp_ops[4].name == "RX"
-
         assert decomp_ops[4].wires == Wires([1])
         assert decomp_ops[4].data[0] == -np.pi / 2
 
-    def test_PauliRot_decomposition_XIYZ(self):
+    @pytest.mark.parametrize("theta", [0.4, np.array([np.pi / 3, 0.1, -0.9])])
+    def test_PauliRot_decomposition_XIYZ(self, theta):
         """Test that the decomposition for a XIYZ rotation is correct."""
 
-        theta = 0.4
         op = qml.PauliRot(theta, "XIYZ", wires=[0, 1, 2, 3])
         decomp_ops = op.decomposition()
 
@@ -1340,7 +1519,7 @@ class TestPauliRot:
 
         assert decomp_ops[2].name == "MultiRZ"
         assert decomp_ops[2].wires == Wires([0, 2, 3])
-        assert decomp_ops[2].data[0] == theta
+        assert np.allclose(decomp_ops[2].data[0], theta)
 
         assert decomp_ops[3].name == "Hadamard"
         assert decomp_ops[3].wires == Wires([0])
@@ -1361,13 +1540,36 @@ class TestPauliRot:
         def circuit(theta):
             qml.PauliRot(theta, pauli_word, wires=[0, 1])
 
-            return qml.expval(qml.PauliZ(0))
+            return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
         res = circuit(angle)
         gradient = np.squeeze(qml.grad(circuit)(angle))
 
         assert gradient == pytest.approx(
             0.5 * (circuit(angle + np.pi / 2) - circuit(angle - np.pi / 2)), abs=tol
+        )
+
+    # TODO[dwierichs]: Include this test using tensor-batching once devices support it
+    @pytest.mark.skip("QNodes/Devices do not support tensor-batching yet.")
+    @pytest.mark.parametrize("pauli_word", ["XX", "YY", "ZZ"])
+    def test_differentiability_batched(self, pauli_word, tol):
+        """Test that differentiation of PauliRot works with batched parameters."""
+
+        dev = qml.device("default.qubit", wires=2)
+
+        @qml.qnode(dev)
+        def circuit(theta):
+            qml.PauliRot(theta, pauli_word, wires=[0, 1])
+            return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
+
+        angle = npp.linspace(0, 2 * np.pi, 7, requires_grad=True)
+        res = circuit(angle)
+        jac = qml.jacobian(circuit)(angle)
+
+        assert np.allclose(
+            jac,
+            0.5 * (circuit(angle + np.pi / 2) - circuit(angle - np.pi / 2)),
+            atol=tol,
         )
 
     @pytest.mark.parametrize("angle", npp.linspace(0, 2 * np.pi, 7, requires_grad=True))
@@ -1522,25 +1724,24 @@ class TestMultiRZ:
         assert np.allclose(res_static, expected, atol=tol, rtol=0)
         assert np.allclose(res_dynamic, expected, atol=tol, rtol=0)
 
-    def test_MultiRZ_matrix_expand(self, tol):
-        """Test that the MultiRZ matrix respects the wire order."""
+    @pytest.mark.parametrize("num_wires", [1, 2, 3])
+    def test_MultiRZ_matrix_batched(self, num_wires, tol):
+        """Test that the MultiRZ matrix is correct for batched parameters."""
 
-        res = qml.MultiRZ(0.1, wires=[0, 1]).matrix(wire_order=[1, 0])
-        expected = np.array(
-            [
-                [0.99875026 - 0.04997917j, 0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j],
-                [0.0 + 0.0j, 0.99875026 + 0.04997917j, 0.0 + 0.0j, 0.0 + 0.0j],
-                [0.0 + 0.0j, 0.0 + 0.0j, 0.99875026 + 0.04997917j, 0.0 + 0.0j],
-                [0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j, 0.99875026 - 0.04997917j],
-            ]
-        )
+        theta = np.linspace(0, 2 * np.pi, 7)[:3]
+        res_static = qml.MultiRZ.compute_matrix(theta, num_wires)
+        res_dynamic = qml.MultiRZ(theta, wires=list(range(num_wires))).matrix()
+        signs = reduce(np.kron, [np.array([1, -1])] * num_wires) / 2
+        mats = [np.diag(np.exp(-1j * signs * p)) for p in theta]
+        expected = np.transpose(np.stack(mats), (1, 2, 0))
 
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        assert np.allclose(res_static, expected, atol=tol, rtol=0)
+        assert np.allclose(res_dynamic, expected, atol=tol, rtol=0)
 
-    def test_MultiRZ_decomposition_ZZ(self):
+    @pytest.mark.parametrize("theta", [0.4, np.array([np.pi / 3, 0.1, -0.9])])
+    def test_MultiRZ_decomposition_ZZ(self, theta):
         """Test that the decomposition for a ZZ rotation is correct."""
 
-        theta = 0.4
         op = qml.MultiRZ(theta, wires=[0, 1])
         decomp_ops = op.decomposition()
 
@@ -1550,15 +1751,15 @@ class TestMultiRZ:
         assert decomp_ops[1].name == "RZ"
 
         assert decomp_ops[1].wires == Wires([0])
-        assert decomp_ops[1].data[0] == theta
+        assert np.allclose(decomp_ops[1].data[0], theta)
 
         assert decomp_ops[2].name == "CNOT"
         assert decomp_ops[2].wires == Wires([1, 0])
 
-    def test_MultiRZ_decomposition_ZZZ(self):
+    @pytest.mark.parametrize("theta", [0.4, np.array([np.pi / 3, 0.1, -0.9])])
+    def test_MultiRZ_decomposition_ZZZ(self, theta):
         """Test that the decomposition for a ZZZ rotation is correct."""
 
-        theta = 0.4
         op = qml.MultiRZ(theta, wires=[0, 2, 3])
         decomp_ops = op.decomposition()
 
@@ -1571,7 +1772,7 @@ class TestMultiRZ:
         assert decomp_ops[2].name == "RZ"
 
         assert decomp_ops[2].wires == Wires([0])
-        assert decomp_ops[2].data[0] == theta
+        assert np.allclose(decomp_ops[2].data[0], theta)
 
         assert decomp_ops[3].name == "CNOT"
         assert decomp_ops[3].wires == Wires([2, 0])
@@ -1597,6 +1798,29 @@ class TestMultiRZ:
 
         assert gradient == pytest.approx(
             0.5 * (circuit(angle + np.pi / 2) - circuit(angle - np.pi / 2)), abs=tol
+        )
+
+    # TODO[dwierichs]: Include this test using tensor-batching once devices support it
+    @pytest.mark.skip("QNodes/Devices do not support tensor-batching yet.")
+    def test_differentiability_batched(self, tol):
+        """Test that differentiation of MultiRZ works."""
+
+        dev = qml.device("default.qubit", wires=2)
+
+        @qml.qnode(dev)
+        def circuit(theta):
+            qml.Hadamard(0)
+            qml.Hadamard(1)
+            qml.MultiRZ(theta, wires=[0, 1])
+
+            return qml.expval(qml.PauliX(0) @ qml.PauliX(1))
+
+        angle = npp.linspace(0, 2 * np.pi, 7, requires_grad=True)
+        res = circuit(angle)
+        jac = qml.jacobian(circuit)(angle)
+
+        assert np.allclose(
+            jac, 0.5 * (circuit(angle + np.pi / 2) - circuit(angle - np.pi / 2)), abs=tol
         )
 
     @pytest.mark.parametrize("angle", npp.linspace(0, 2 * np.pi, 7, requires_grad=True))
@@ -1638,6 +1862,28 @@ class TestMultiRZ:
 
         op.generator()
         spy.assert_not_called()
+
+    @pytest.mark.parametrize("theta", [0.4, np.array([np.pi / 3, 0.1, -0.9])])
+    def test_multirz_eigvals(self, theta, tol):
+        """Test that the eigenvalues of the MultiRZ gate are correct."""
+        op = qml.MultiRZ(theta, wires=range(3))
+
+        pos_phase = np.exp(1j * theta / 2)
+        neg_phase = np.exp(-1j * theta / 2)
+        expected = np.array(
+            [
+                neg_phase,
+                pos_phase,
+                pos_phase,
+                neg_phase,
+                pos_phase,
+                neg_phase,
+                neg_phase,
+                pos_phase,
+            ]
+        )
+        eigvals = op.eigvals()
+        assert np.allclose(eigvals, expected)
 
 
 label_data = [
@@ -1715,12 +1961,37 @@ label_data = [
     ),
 ]
 
+# labels with batched parameters are not implemented properly yet, the parameters are truncated
+label_data_batched = [
+    (qml.RX(np.array([1.23, 4.56]), wires=0), "RX", "RX", "RX", "RX⁻¹"),
+    (qml.PauliRot(np.array([1.23, 4.5]), "XYZ", wires=(0, 1, 2)), "RXYZ", "RXYZ", "RXYZ", "RXYZ⁻¹"),
+    (
+        qml.U3(np.array([0.1, 0.2]), np.array([-0.1, -0.2]), np.array([1.2, -0.1]), wires=0),
+        "U3",
+        "U3",
+        "U3",
+        "U3⁻¹",
+    ),
+]
+
 
 class TestLabel:
     """Test the label method on parametric ops"""
 
     @pytest.mark.parametrize("op, label1, label2, label3, label4", label_data)
     def test_label_method(self, op, label1, label2, label3, label4):
+        """Test label method with plain scalers."""
+
+        assert op.label() == label1
+        assert op.label(decimals=2) == label2
+        assert op.label(decimals=0) == label3
+
+        op.inv()
+        assert op.label(decimals=0) == label4
+        op.inv()
+
+    @pytest.mark.parametrize("op, label1, label2, label3, label4", label_data_batched)
+    def test_label_method_batched(self, op, label1, label2, label3, label4):
         """Test label method with plain scalers."""
 
         assert op.label() == label1
@@ -1786,6 +2057,24 @@ class TestLabel:
         op3 = qml.Rot("x", "y", "z", wires=0)
         assert op3.label(decimals=0) == "Rot\n(x,\ny,\nz)"
 
+    def test_string_parameter_batched(self):
+        """Test labelling works (i.e. does not raise an Error) if variable is a
+        string instead of a float."""
+
+        x = np.array(["x0", "x1", "x2"])
+        y = np.array(["y0", "y1", "y2"])
+        z = np.array(["z0", "z1", "z2"])
+
+        op1 = qml.RX(x, wires=0)
+        assert op1.label() == "RX"
+        assert op1.label(decimals=0) == "RX"
+
+        op2 = qml.CRX(y, wires=(0, 1))
+        assert op2.label(decimals=0) == "RX"
+
+        op3 = qml.Rot(x, y, z, wires=0)
+        assert op3.label(decimals=0) == "Rot"
+
 
 pow_parametric_ops = (
     qml.RX(1.234, wires=0),
@@ -1838,14 +2127,14 @@ control_data = [
     (qml.U2(1.234, 2.345, wires=0), Wires([])),
     (qml.U3(1.234, 2.345, 3.456, wires=0), Wires([])),
     (qml.IsingXX(1.234, wires=(0, 1)), Wires([])),
-    (qml.IsingYY(1.234, wires=(0, 1)), Wires([])),
+    (qml.IsingYY(np.array([-5.1, 0.219]), wires=(0, 1)), Wires([])),
     (qml.IsingZZ(1.234, wires=(0, 1)), Wires([])),
     ### Controlled Ops
     (qml.ControlledPhaseShift(1.234, wires=(0, 1)), Wires(0)),
     (qml.CPhase(1.234, wires=(0, 1)), Wires(0)),
     (qml.CRX(1.234, wires=(0, 1)), Wires(0)),
     (qml.CRY(1.234, wires=(0, 1)), Wires(0)),
-    (qml.CRZ(1.234, wires=(0, 1)), Wires(0)),
+    (qml.CRZ(np.array([1.234, 0.219]), wires=(0, 1)), Wires(0)),
     (qml.CRot(1.234, 2.2345, 3.456, wires=(0, 1)), Wires(0)),
 ]
 

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -26,11 +26,15 @@ from numpy.linalg import multi_dot
 import pennylane as qml
 from pennylane.operation import Tensor, operation_derivative, Operator, Operation
 
-from gate_data import I, X, CNOT
+from gate_data import I, X, CNOT, Toffoli, SWAP, II
 from pennylane.wires import Wires
 
 
 # pylint: disable=no-self-use, no-member, protected-access, pointless-statement
+
+Toffoli_batched = np.tensordot(Toffoli, [0.1, -4.2j], axes=0)
+CNOT_batched = np.tensordot(CNOT, [1.4], axes=0)
+I_batched = I[:, :, pnp.newaxis]
 
 
 @pytest.mark.parametrize(
@@ -1593,6 +1597,32 @@ class TestDefaultRepresentations:
         with pytest.raises(qml.operation.PowUndefinedError):
             gate.pow(1.234)
 
+class MyOpWithMat(Operator):
+    num_wires = 1
+
+    @staticmethod
+    def compute_matrix(theta):
+        return np.tensordot(np.array([[0.4, 1.2], [1.2, 0.4]]), theta, axes=0)
+
+
+class TestInheritedRepresentations:
+    """Tests that the default representations allow for
+    inheritance from other representations"""
+
+    def test_eigvals_from_matrix(self):
+        """Test that eigvals can be extracted when a matrix is defined."""
+        # Test with scalar parameter
+        theta = 0.3
+        op = MyOpWithMat(theta, wires=1)
+        eigvals = op.eigvals()
+        assert np.allclose(eigvals, [1.6 * theta, -0.8 * theta])
+
+        # Test with batched parameter
+        theta = np.array([0.3, 0.9, 1.2])
+        op = MyOpWithMat(theta, wires=1)
+        eigvals = op.eigvals()
+        assert np.allclose(eigvals, [1.6 * theta, -0.8 * theta])
+
 
 class TestChannel:
     """Unit tests for the Channel class"""
@@ -1831,99 +1861,185 @@ class TestCriteria:
 class TestExpandMatrix:
     """Tests for the expand_matrix helper function."""
 
+    base_matrix_1 = np.arange(1, 5).reshape((2, 2))
+    base_matrix_1_batched = np.arange(1, 13).reshape((2, 2, 3))
+    base_matrix_2 = np.arange(1, 17).reshape((4, 4))
+    base_matrix_2_batched = np.arange(1, 49).reshape((4, 4, 3))
+
     def test_no_expansion(self):
         """Tests the case where the original matrix is not changed"""
-        base_matrix = np.array([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]])
-        res = qml.operation.expand_matrix(base_matrix, wires=[0, 2], wire_order=[0, 2])
-        assert np.allclose(base_matrix, res)
+        res = qml.operation.expand_matrix(self.base_matrix_2, wires=[0, 2], wire_order=[0, 2])
+        assert np.allclose(self.base_matrix_2, res)
+
+    def test_no_expansion_batched(self):
+        """Tests the case where the batched original matrix is not changed"""
+        res = qml.operation.expand_matrix(
+            self.base_matrix_2_batched, wires=[0, 2], wire_order=[0, 2]
+        )
+        assert np.allclose(self.base_matrix_2_batched, res)
 
     def test_permutation(self):
         """Tests the case where the original matrix is permuted"""
-        base_matrix = np.array([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]])
-        res = qml.operation.expand_matrix(base_matrix, wires=[0, 2], wire_order=[2, 0])
+        res = qml.operation.expand_matrix(self.base_matrix_2, wires=[0, 2], wire_order=[2, 0])
 
         expected = np.array([[1, 3, 2, 4], [9, 11, 10, 12], [5, 7, 6, 8], [13, 15, 14, 16]])
         assert np.allclose(expected, res)
 
+    def test_permutation_batched(self):
+        """Tests the case where the batched original matrix is permuted"""
+        res = qml.operation.expand_matrix(
+            self.base_matrix_2_batched, wires=[0, 2], wire_order=[2, 0]
+        )
+
+        perm = [0, 2, 1, 3]
+        expected = self.base_matrix_2_batched[perm][:, perm]
+        assert np.allclose(expected, res)
+
     def test_expansion(self):
         """Tests the case where the original matrix is expanded"""
-        base_matrix = np.array([[0, 1], [1, 0]])
-        res = qml.operation.expand_matrix(base_matrix, wires=[2], wire_order=[0, 2])
-        expected = np.array([[0, 1, 0, 0], [1, 0, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]])
+        res = qml.operation.expand_matrix(self.base_matrix_1, wires=[2], wire_order=[0, 2])
+        expected = np.array([[1, 2, 0, 0], [3, 4, 0, 0], [0, 0, 1, 2], [0, 0, 3, 4]])
         assert np.allclose(expected, res)
 
-        res = qml.operation.expand_matrix(base_matrix, wires=[2], wire_order=[2, 0])
-        expected = np.array([[0, 0, 1, 0], [0, 0, 0, 1], [1, 0, 0, 0], [0, 1, 0, 0]])
+        res = qml.operation.expand_matrix(self.base_matrix_1, wires=[2], wire_order=[2, 0])
+        expected = np.array([[1, 0, 2, 0], [0, 1, 0, 2], [3, 0, 4, 0], [0, 3, 0, 4]])
         assert np.allclose(expected, res)
+
+    def test_expansion_batched(self):
+        """Tests the case where the batched original matrix is expanded"""
+        res = qml.operation.expand_matrix(self.base_matrix_1_batched, wires=[2], wire_order=[0, 2])
+        z = [0, 0, 0]
+        expected = np.array(
+            [
+                [[1, 2, 3], [4, 5, 6], z, z],
+                [[7, 8, 9], [10, 11, 12], z, z],
+                [z, z, [1, 2, 3], [4, 5, 6]],
+                [z, z, [7, 8, 9], [10, 11, 12]],
+            ]
+        )
+        assert np.allclose(expected, res)
+
+        res = qml.operation.expand_matrix(self.base_matrix_1_batched, wires=[2], wire_order=[2, 0])
+        expected = np.array(
+            [
+                [[1, 2, 3], z, [4, 5, 6], z],
+                [z, [1, 2, 3], z, [4, 5, 6]],
+                [[7, 8, 9], z, [10, 11, 12], z],
+                [z, [7, 8, 9], z, [10, 11, 12]],
+            ]
+        )
+        assert np.allclose(expected, res)
+
+    @staticmethod
+    def func_for_autodiff(mat):
+        """Expand a single-qubit matrix to two qubits where the
+        matrix acts on the latter qubit."""
+        return qml.operation.expand_matrix(mat, wires=[2], wire_order=[0, 2])
+
+    # the entries should be mapped by func_for_autodiff via
+    # source -> destinations
+    # (0, 0) -> (0, 0), (2, 2)
+    # (0, 1) -> (0, 1), (2, 3)
+    # (1, 0) -> (1, 0), (3, 2)
+    # (1, 1) -> (1, 1), (3, 3)
+    # so that the expected Jacobian is 0 everywhere except for the entries
+    # (dest, source) from the above list, where it is 1.
+    expected_autodiff_nobatch = np.zeros((4, 4, 2, 2), dtype=float)
+    indices = [
+        (0, 0, 0, 0),
+        (2, 2, 0, 0),
+        (0, 1, 0, 1),
+        (2, 3, 0, 1),
+        (1, 0, 1, 0),
+        (3, 2, 1, 0),
+        (1, 1, 1, 1),
+        (3, 3, 1, 1),
+    ]
+    for ind in indices:
+        expected_autodiff_nobatch[ind] = 1.0
+
+    # When using tensor-batching, the expected Jacobian
+    # of func_for_autodiff is diagonal in the dimensions 2 and 5
+    expected_autodiff_batched = np.zeros((4, 4, 3, 2, 2, 3), dtype=float)
+    for ind in indices:
+        expected_autodiff_batched[ind[0], ind[1], :, ind[2], ind[3], :] = np.eye(3)
+
+    expected_autodiff = [expected_autodiff_nobatch, expected_autodiff_batched]
 
     @pytest.mark.autograd
-    def test_autograd(self, tol):
-        """Tests differentiation in autograd by checking how a specific element of the expanded matrix depends on the
-        canonical matrix."""
+    @pytest.mark.parametrize(
+        "i, base_matrix",
+        [
+            (0, [[0.2, 1.1], [-1.3, 1.9]]),
+            (1, [[[0.2, 0.5, 1.2], [1.1, -0.3, -0.2]], [[-1.3, 1.9, 0.2], [0.1, 0.2, 0.7]]]),
+        ],
+    )
+    def test_autograd(self, i, base_matrix, tol):
+        """Tests differentiation in autograd by computing the Jacobian of
+        the expanded matrix with respect to the canonical matrix."""
 
-        def func(mat):
-            res = qml.operation.expand_matrix(mat, wires=[2], wire_order=[0, 2])
-            return res[0, 1]
+        base_matrix = pnp.array(base_matrix, requires_grad=True)
+        jac_fn = qml.jacobian(self.func_for_autodiff)
+        jac = jac_fn(base_matrix)
 
-        base_matrix = pnp.array([[0.0, 1.0], [1.0, 0.0]], requires_grad=True)
-        grad_fn = qml.grad(func)
-        gradient = grad_fn(base_matrix)
-
-        # the entry should propagate from position (0, 1) in the original tensor
-        expected = np.array([[0.0, 1.0], [0.0, 0.0]])
-        assert np.allclose(gradient, expected, atol=tol)
+        assert np.allclose(jac, self.expected_autodiff[i], atol=tol)
 
     @pytest.mark.torch
-    def test_torch(self, tol):
-        """Tests differentiation in torch by checking how a specific element of the expanded matrix depends on the
-        canonical matrix."""
+    @pytest.mark.parametrize(
+        "i, base_matrix",
+        [
+            (0, [[0.2, 1.1], [-1.3, 1.9]]),
+            (1, [[[0.2, 0.5, 1.2], [1.1, -0.3, -0.2]], [[-1.3, 1.9, 0.2], [0.1, 0.2, 0.7]]]),
+        ],
+    )
+    def test_torch(self, i, base_matrix, tol):
+        """Tests differentiation in torch by computing the Jacobian of
+        the expanded matrix with respect to the canonical matrix."""
         import torch
 
-        base_matrix = torch.tensor([[0.0, 1.0], [1.0, 0.0]], requires_grad=True)
-        res = qml.operation.expand_matrix(base_matrix, wires=[2], wire_order=[0, 2])
-        element = res[0, 1]
-        element.backward()
-        gradient = base_matrix.grad
+        base_matrix = torch.tensor(base_matrix, requires_grad=True)
+        jac = torch.autograd.functional.jacobian(self.func_for_autodiff, base_matrix)
 
-        # the entry should propagate from position (0, 1) in the original tensor
-        expected = torch.tensor([[0.0, 1.0], [0.0, 0.0]])
-        assert np.allclose(gradient, expected, atol=tol)
+        assert np.allclose(jac, self.expected_autodiff[i], atol=tol)
 
     @pytest.mark.jax
-    def test_jax(self, tol):
-        """Tests differentiation in jax by checking how a specific element of the expanded matrix depends on the
-        canonical matrix."""
+    @pytest.mark.parametrize(
+        "i, base_matrix",
+        [
+            (0, [[0.2, 1.1], [-1.3, 1.9]]),
+            (1, [[[0.2, 0.5, 1.2], [1.1, -0.3, -0.2]], [[-1.3, 1.9, 0.2], [0.1, 0.2, 0.7]]]),
+        ],
+    )
+    def test_jax(self, i, base_matrix, tol):
+        """Tests differentiation in jax by computing the Jacobian of
+        the expanded matrix with respect to the canonical matrix."""
         import jax
-        from jax import numpy as jnp
 
-        def func(mat):
-            res = qml.operation.expand_matrix(mat, wires=[2], wire_order=[0, 2])
-            return res[0, 1]
+        base_matrix = jax.numpy.array(base_matrix)
+        jac_fn = jax.jacobian(self.func_for_autodiff)
+        jac = jac_fn(base_matrix)
 
-        base_matrix = jnp.array([[0.0, 1.0], [1.0, 0.0]])
-        grad_fn = jax.grad(func)
-        gradient = grad_fn(base_matrix)
-
-        # the entry should propagate from position (0, 1) in the original tensor
-        expected = np.array([[0.0, 1.0], [0.0, 0.0]])
-        assert np.allclose(gradient, expected, atol=tol)
+        assert np.allclose(jac, self.expected_autodiff[i], atol=tol)
 
     @pytest.mark.tf
-    def test_tf(self, tol):
-        """Tests differentiation in TensorFlow by checking how a specific element of the expanded matrix depends on the
-        canonical matrix."""
+    @pytest.mark.parametrize(
+        "i, base_matrix",
+        [
+            (0, [[0.2, 1.1], [-1.3, 1.9]]),
+            (1, [[[0.2, 0.5, 1.2], [1.1, -0.3, -0.2]], [[-1.3, 1.9, 0.2], [0.1, 0.2, 0.7]]]),
+        ],
+    )
+    def test_tf(self, i, base_matrix, tol):
+        """Tests differentiation in TensorFlow by computing the Jacobian of
+        the expanded matrix with respect to the canonical matrix."""
         import tensorflow as tf
 
-        base_matrix = tf.Variable([[0.0, 1.0], [1.0, 0.0]])
+        base_matrix = tf.Variable(base_matrix)
         with tf.GradientTape() as tape:
-            res = qml.operation.expand_matrix(base_matrix, wires=[2], wire_order=[0, 2])
-            element = res[0, 1]
+            res = self.func_for_autodiff(base_matrix)
 
-        gradient = tape.gradient(element, base_matrix)
-
-        # the entry should propagate from position (0, 1) in the original tensor
-        expected = tf.constant([[0.0, 1.0], [0.0, 0.0]])
-        assert np.allclose(gradient, expected, atol=tol)
+        jac = tape.jacobian(res, base_matrix)
+        assert np.allclose(jac, self.expected_autodiff[i], atol=tol)
 
     def test_expand_one(self, tol):
         """Test that a 1 qubit gate correctly expands to 3 qubits."""
@@ -1948,6 +2064,31 @@ class TestExpandMatrix:
         expected = np.kron(np.kron(I, I), U)
         assert np.allclose(res, expected, atol=tol, rtol=0)
 
+    def test_expand_one_batched(self, tol):
+        """Test that a batched 1 qubit gate correctly expands to 3 qubits."""
+        U = np.array(
+            [
+                [0.83645892 - 0.40533293j, -0.20215326 + 0.30850569j],
+                [-0.23889780 - 0.28101519j, -0.88031770 - 0.29832709j],
+            ]
+        )
+        # outer product with batch vector
+        U = np.tensordot(U, [0.14, -0.23, 1.3j], axes=0)
+        # test applied to wire 0
+        res = qml.operation.expand_matrix(U, [0], [0, 4, 9])
+        expected = np.kron(np.kron(U, I_batched), I_batched)
+        assert np.allclose(res, expected, atol=tol, rtol=0)
+
+        # test applied to wire 4
+        res = qml.operation.expand_matrix(U, [4], [0, 4, 9])
+        expected = np.kron(np.kron(I_batched, U), I_batched)
+        assert np.allclose(res, expected, atol=tol, rtol=0)
+
+        # test applied to wire 9
+        res = qml.operation.expand_matrix(U, [9], [0, 4, 9])
+        expected = np.kron(np.kron(I_batched, I_batched), U)
+        assert np.allclose(res, expected, atol=tol, rtol=0)
+
     def test_expand_two_consecutive_wires(self, tol):
         """Test that a 2 qubit gate on consecutive wires correctly
         expands to 4 qubits."""
@@ -1968,6 +2109,27 @@ class TestExpandMatrix:
         expected = np.kron(np.kron(I, I), U2)
         assert np.allclose(res, expected, atol=tol, rtol=0)
 
+    def test_expand_two_consecutive_wires_batched(self, tol):
+        """Test that a batched 2 qubit gate on consecutive wires correctly
+        expands to 4 qubits."""
+        U2 = np.array([[0, 1, 1, 1], [1, 0, 1, -1], [1, -1, 0, 1], [1, 1, -1, 0]]) / np.sqrt(3)
+        U2 = np.tensordot(U2, [2.31, 1.53, 0.7 - 1.9j], axes=0)
+
+        # test applied to wire 0+1
+        res = qml.operation.expand_matrix(U2, [0, 1], [0, 1, 2, 3])
+        expected = np.kron(np.kron(U2, I_batched), I_batched)
+        assert np.allclose(res, expected, atol=tol, rtol=0)
+
+        # test applied to wire 1+2
+        res = qml.operation.expand_matrix(U2, [1, 2], [0, 1, 2, 3])
+        expected = np.kron(np.kron(I_batched, U2), I_batched)
+        assert np.allclose(res, expected, atol=tol, rtol=0)
+
+        # test applied to wire 2+3
+        res = qml.operation.expand_matrix(U2, [2, 3], [0, 1, 2, 3])
+        expected = np.kron(np.kron(I_batched, I_batched), U2)
+        assert np.allclose(res, expected, atol=tol, rtol=0)
+
     def test_expand_two_reversed_wires(self, tol):
         """Test that a 2 qubit gate on reversed consecutive wires correctly
         expands to 4 qubits."""
@@ -1977,74 +2139,135 @@ class TestExpandMatrix:
         expected = np.kron(np.kron(CNOT[:, rows][rows], I), I)
         assert np.allclose(res, expected, atol=tol, rtol=0)
 
+    def test_expand_two_reversed_wires_batched(self, tol):
+        """Test that a batched 2 qubit gate on reversed consecutive wires correctly
+        expands to 4 qubits."""
+        # CNOT with target on wire 1 and a batch dimension of size 1
+        res = qml.operation.expand_matrix(CNOT_batched, [1, 0], [0, 1, 2, 3])
+        rows = [0, 2, 1, 3]
+        expected = np.kron(np.kron(CNOT_batched[:, rows][rows], I_batched), I_batched)
+        assert np.allclose(res, expected, atol=tol, rtol=0)
+
     def test_expand_three_consecutive_wires(self, tol):
         """Test that a 3 qubit gate on consecutive
         wires correctly expands to 4 qubits."""
-        U_toffoli = np.diag([1 for i in range(8)])
-        U_toffoli[6:8, 6:8] = np.array([[0, 1], [1, 0]])
         # test applied to wire 0,1,2
-        res = qml.operation.expand_matrix(U_toffoli, [0, 1, 2], [0, 1, 2, 3])
-        expected = np.kron(U_toffoli, I)
+        res = qml.operation.expand_matrix(Toffoli, [0, 1, 2], [0, 1, 2, 3])
+        expected = np.kron(Toffoli, I)
         assert np.allclose(res, expected, atol=tol, rtol=0)
 
         # test applied to wire 1,2,3
-        res = qml.operation.expand_matrix(U_toffoli, [1, 2, 3], [0, 1, 2, 3])
-        expected = np.kron(I, U_toffoli)
+        res = qml.operation.expand_matrix(Toffoli, [1, 2, 3], [0, 1, 2, 3])
+        expected = np.kron(I, Toffoli)
+        assert np.allclose(res, expected, atol=tol, rtol=0)
+
+    def test_expand_three_consecutive_wires_batched(self, tol):
+        """Test that a batched 3 qubit gate on consecutive
+        wires correctly expands to 4 qubits."""
+        # test applied to wire 0,1,2
+        res = qml.operation.expand_matrix(Toffoli_batched, [0, 1, 2], [0, 1, 2, 3])
+        expected = np.kron(Toffoli_batched, I_batched)
+        assert np.allclose(res, expected, atol=tol, rtol=0)
+
+        # test applied to wire 1,2,3
+        res = qml.operation.expand_matrix(Toffoli_batched, [1, 2, 3], [0, 1, 2, 3])
+        expected = np.kron(I_batched, Toffoli_batched)
         assert np.allclose(res, expected, atol=tol, rtol=0)
 
     def test_expand_three_nonconsecutive_ascending_wires(self, tol):
         """Test that a 3 qubit gate on non-consecutive but ascending
         wires correctly expands to 4 qubits."""
-        U_toffoli = np.diag([1 for i in range(8)])
-        U_toffoli[6:8, 6:8] = np.array([[0, 1], [1, 0]])
         # test applied to wire 0,2,3
-        res = qml.operation.expand_matrix(U_toffoli, [0, 2, 3], [0, 1, 2, 3])
-        expected = (
-            np.kron(qml.SWAP.compute_matrix(), np.kron(I, I))
-            @ np.kron(I, U_toffoli)
-            @ np.kron(qml.SWAP.compute_matrix(), np.kron(I, I))
-        )
+        res = qml.operation.expand_matrix(Toffoli, [0, 2, 3], [0, 1, 2, 3])
+        expected = np.kron(SWAP, II) @ np.kron(I, Toffoli) @ np.kron(SWAP, II)
         assert np.allclose(res, expected, atol=tol, rtol=0)
 
         # test applied to wire 0,1,3
-        res = qml.operation.expand_matrix(U_toffoli, [0, 1, 3], [0, 1, 2, 3])
-        expected = (
-            np.kron(np.kron(I, I), qml.SWAP.compute_matrix())
-            @ np.kron(U_toffoli, I)
-            @ np.kron(np.kron(I, I), qml.SWAP.compute_matrix())
+        res = qml.operation.expand_matrix(Toffoli, [0, 1, 3], [0, 1, 2, 3])
+        expected = np.kron(II, SWAP) @ np.kron(Toffoli, I) @ np.kron(II, SWAP)
+        assert np.allclose(res, expected, atol=tol, rtol=0)
+
+    def test_expand_three_nonconsecutive_ascending_wires_batched(self, tol):
+        """Test that a batched 3 qubit gate on non-consecutive but ascending
+        wires correctly expands to 4 qubits."""
+        # test applied to wire 0,2,3
+        res = qml.operation.expand_matrix(Toffoli_batched[:, :, :1], [0, 2, 3], [0, 1, 2, 3])
+        expected = np.tensordot(
+            np.tensordot(
+                np.kron(SWAP, II),
+                np.kron(I_batched, Toffoli_batched[:, :, :1]),
+                axes=[[1], [0]],
+            ),
+            np.kron(SWAP, II),
+            axes=[[1], [0]],
         )
+        expected = np.moveaxis(expected, 1, -1)
+        assert np.allclose(res, expected, atol=tol, rtol=0)
+
+        # test applied to wire 0,1,3
+        res = qml.operation.expand_matrix(Toffoli_batched, [0, 1, 3], [0, 1, 2, 3])
+        _res = qml.operation.expand_matrix(Toffoli, [0, 1, 3], [0, 1, 2, 3])
+        expected = np.tensordot(
+            np.tensordot(
+                np.kron(II, SWAP),
+                np.kron(Toffoli_batched, I_batched),
+                axes=[[1], [0]],
+            ),
+            np.kron(II, SWAP),
+            axes=[[1], [0]],
+        )
+        expected = np.moveaxis(expected, 1, -1)
         assert np.allclose(res, expected, atol=tol, rtol=0)
 
     def test_expand_three_nonconsecutive_nonascending_wires(self, tol):
         """Test that a 3 qubit gate on non-consecutive non-ascending
         wires correctly expands to 4 qubits"""
-        U_toffoli = np.diag([1 for i in range(8)])
-        U_toffoli[6:8, 6:8] = np.array([[0, 1], [1, 0]])
         # test applied to wire 3, 1, 2
-        res = qml.operation.expand_matrix(U_toffoli, [3, 1, 2], [0, 1, 2, 3])
+        res = qml.operation.expand_matrix(Toffoli, [3, 1, 2], [0, 1, 2, 3])
         # change the control qubit on the Toffoli gate
-        rows = np.array([0, 4, 1, 5, 2, 6, 3, 7])
-        expected = np.kron(I, U_toffoli[:, rows][rows])
+        rows = [0, 4, 1, 5, 2, 6, 3, 7]
+        Toffoli_perm = Toffoli[:, rows][rows]
+        expected = np.kron(I, Toffoli_perm)
         assert np.allclose(res, expected, atol=tol, rtol=0)
 
         # test applied to wire 3, 0, 2
-        res = qml.operation.expand_matrix(U_toffoli, [3, 0, 2], [0, 1, 2, 3])
+        res = qml.operation.expand_matrix(Toffoli, [3, 0, 2], [0, 1, 2, 3])
         # change the control qubit on the Toffoli gate
-        rows = np.array([0, 4, 1, 5, 2, 6, 3, 7])
-        expected = (
-            np.kron(qml.SWAP.compute_matrix(), np.kron(I, I))
-            @ np.kron(I, U_toffoli[:, rows][rows])
-            @ np.kron(qml.SWAP.compute_matrix(), np.kron(I, I))
+        expected = np.kron(SWAP, II) @ np.kron(I, Toffoli_perm) @ np.kron(SWAP, II)
+        assert np.allclose(res, expected, atol=tol, rtol=0)
+
+    def test_expand_three_nonconsecutive_nonascending_wires_batched(self, tol):
+        """Test that a batched 3 qubit gate on non-consecutive non-ascending
+        wires correctly expands to 4 qubits"""
+        # test applied to wire 3, 1, 2
+        res = qml.operation.expand_matrix(Toffoli_batched, [3, 1, 2], [0, 1, 2, 3])
+        # change the control qubit on the Toffoli gate
+        rows = [0, 4, 1, 5, 2, 6, 3, 7]
+        Toffoli_batched_perm = Toffoli_batched[:, rows][rows]
+        expected = np.kron(I_batched, Toffoli_batched_perm)
+        assert np.allclose(res, expected, atol=tol, rtol=0)
+
+        # test applied to wire 3, 0, 2
+        res = qml.operation.expand_matrix(Toffoli_batched, [3, 0, 2], [0, 1, 2, 3])
+        # change the control qubit on the Toffoli gate
+        expected = np.tensordot(
+            np.tensordot(
+                np.kron(SWAP, II),
+                np.kron(I_batched, Toffoli_batched_perm),
+                axes=[[1], [0]],
+            ),
+            np.kron(SWAP, II),
+            axes=[[1], [0]],
         )
+        expected = np.moveaxis(expected, 1, -1)
         assert np.allclose(res, expected, atol=tol, rtol=0)
 
     def test_expand_matrix_usage_in_operator_class(self, tol):
         """Tests that the method is used correctly by defining a dummy operator and
         checking the permutation/expansion."""
 
-        base_matrix = np.array([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]])
-
-        permuted_matrix = np.array([[1, 3, 2, 4], [9, 11, 10, 12], [5, 7, 6, 8], [13, 15, 14, 16]])
+        perm = [0, 2, 1, 3]
+        permuted_matrix = self.base_matrix_2[perm][:, perm]
 
         expanded_matrix = np.array(
             [
@@ -2063,10 +2286,39 @@ class TestExpandMatrix:
             num_wires = 2
 
             def compute_matrix(*params, **hyperparams):
-                return base_matrix
+                return self.base_matrix_2
 
         op = DummyOp(wires=[0, 2])
-        assert np.allclose(op.matrix(), base_matrix, atol=tol)
+        assert np.allclose(op.matrix(), self.base_matrix_2, atol=tol)
+        assert np.allclose(op.matrix(wire_order=[2, 0]), permuted_matrix, atol=tol)
+        assert np.allclose(op.matrix(wire_order=[0, 1, 2]), expanded_matrix, atol=tol)
+
+    def test_expand_matrix_usage_in_operator_class_batched(self, tol):
+        """Tests that the method is used correctly with a batched matrix by defining
+        a dummy operator and checking the permutation/expansion."""
+
+        perm = [0, 2, 1, 3]
+        permuted_matrix = self.base_matrix_2_batched[perm][:, perm]
+
+        expanded_matrix = np.tensordot(
+            np.tensordot(
+                np.kron(SWAP, I),
+                np.kron(I_batched, self.base_matrix_2_batched),
+                axes=[[1], [0]],
+            ),
+            np.kron(SWAP, I),
+            axes=[[1], [0]],
+        )
+        expanded_matrix = np.moveaxis(expanded_matrix, 1, -1)
+
+        class DummyOp(qml.operation.Operator):
+            num_wires = 2
+
+            def compute_matrix(*params, **hyperparams):
+                return self.base_matrix_2_batched
+
+        op = DummyOp(wires=[0, 2])
+        assert np.allclose(op.matrix(), self.base_matrix_2_batched, atol=tol)
         assert np.allclose(op.matrix(wire_order=[2, 0]), permuted_matrix, atol=tol)
         assert np.allclose(op.matrix(wire_order=[0, 1, 2]), expanded_matrix, atol=tol)
 


### PR DESCRIPTION
This PR is a duplicate of #2535 that follows the conventions set up in #2575 and #2590 instead.
It sets the `ndim_params` attribute for many standard operations and allows for broadcasting in their numerical representations (mostly `compute_matrix` and `compute_eigvals`).