### PR TITLE
Trial performance improvements to sparse Hamiltonian building

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -298,6 +298,9 @@
 * Added separate requirements_dev.txt for separation of concerns for code development and just using PennyLane.
   [(#2635)](https://github.com/PennyLaneAI/pennylane/pull/2635)
 
+* Performance improvements to building sparse Hamiltonians. Accumulate sparse representations of coefficient-operator pairs in a temporary storage then sum them every 100 coefficient-operator pairs, rather than adding them into the overall Hamiltonian sparse matrix at every iteration. Also improve performance of generating each pair's sparse representation by eliminating unnecessary `kron` operations on identity matrices.
+  [(#2630)](https://github.com/PennyLaneAI/pennylane/pull/2630)
+
 <h3>Breaking changes</h3>
 
 * The `qml.queuing.Queue` class is now removed.
@@ -329,9 +332,6 @@
   >>> dev.C_DTYPE
   <class 'numpy.complex64'>
   ```
-
-* Performance improvements to building sparse Hamiltonians.
-  [(#2630)](https://github.com/PennyLaneAI/pennylane/pull/2630)
 
 <h3>Bug fixes</h3>
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -298,7 +298,7 @@
 * Added separate requirements_dev.txt for separation of concerns for code development and just using PennyLane.
   [(#2635)](https://github.com/PennyLaneAI/pennylane/pull/2635)
 
-* Performance improvements to building sparse Hamiltonians. Accumulate sparse representations of coefficient-operator pairs in a temporary storage then sum them every 100 coefficient-operator pairs, rather than adding them into the overall Hamiltonian sparse matrix at every iteration. Also improve performance of generating each pair's sparse representation by eliminating unnecessary `kron` operations on identity matrices.
+* The performance of building sparse Hamiltonians has been improved by accumulating the sparse representation of coefficient-operator pairs in a temporary storage and by eliminating unnecessary `kron` operations on identity matrices. 
   [(#2630)](https://github.com/PennyLaneAI/pennylane/pull/2630)
 
 <h3>Breaking changes</h3>

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -330,6 +330,9 @@
   <class 'numpy.complex64'>
   ```
 
+* Performance improvements to building sparse Hamiltonians.
+  [(#2630)](https://github.com/PennyLaneAI/pennylane/pull/2630)
+
 <h3>Bug fixes</h3>
 
 * Fixed a bug where returning `qml.density_matrix` using the PyTorch interface would return a density matrix with wrong shape.
@@ -390,5 +393,5 @@
 This release contains contributions from (in alphabetical order):
 
 Amintor Dusko, Chae-Yeun Park, Christian Gogolin, Christina Lee, David Wierichs, Edward Jiang, Guillermo Alonso-Linaje,
-Jay Soni, Juan Miguel Arrazola, Korbinian, Kottmann, Maria Schuld, Mikhail Andrenkov, Romain Moyard, Qi Hu, Samuel Banning, Soran Jahangiri, 
-Utkarsh Azad, WingCode
+Jay Soni, Juan Miguel Arrazola, Katharine Hyatt, Korbinian, Kottmann, Maria Schuld, Mikhail Andrenkov, Romain Moyard,
+Qi Hu, Samuel Banning, Soran Jahangiri, Utkarsh Azad, WingCode

--- a/pennylane/utils.py
+++ b/pennylane/utils.py
@@ -168,13 +168,14 @@ def sparse_hamiltonian(H, wires=None):
 
         mat = []
         i_count = 0
-        for wire in range(len(wires)):
-            if wire in op.wires:
+        for (wire, wire_lab) in enumerate(wires):
+            if wire_lab in op.wires:
                 if i_count > 0:
                     mat.append(scipy.sparse.eye(2**i_count, format="coo"))
                 i_count = 0
-                idx = op.wires.index(wire)
-                mat.append(scipy.sparse.coo_matrix(obs[idx]))
+                idx = op.wires.index(wire_lab)
+                sp_obs = scipy.sparse.coo_matrix(obs[idx])
+                mat.append(sp_obs)
             else:
                 i_count += 1
 

--- a/pennylane/utils.py
+++ b/pennylane/utils.py
@@ -174,7 +174,7 @@ def sparse_hamiltonian(H, wires=None):
                     mat.append(scipy.sparse.eye(2**i_count, format="coo"))
                 i_count = 0
                 idx = op.wires.index(wire)
-                mat.append(obs[idx])
+                mat.append(scipy.sparse.coo_matrix(obs[idx]))
             else:
                 i_count += 1
 

--- a/pennylane/utils.py
+++ b/pennylane/utils.py
@@ -168,7 +168,7 @@ def sparse_hamiltonian(H, wires=None):
 
         mat = []
         i_count = 0
-        for (wire, wire_lab) in enumerate(wires):
+        for wire_lab in wires:
             if wire_lab in op.wires:
                 if i_count > 0:
                     mat.append(scipy.sparse.eye(2**i_count, format="coo"))


### PR DESCRIPTION
cc @mlxd 

**Context:**

Currently the `sparse_hamiltonian` generation code is pretty slow for large Hamiltonians. For example, for a 24 qubit Hamiltonian representing a CO2 molecule, generation of *each* coeff-op pair takes about 10s. This is problematic when there are 6000+ such pairs. Some timing I did suggests that most of the time is spent adding the temporary sparse matrices representing coeff-op pairs into the "overall" Hamiltonian `matrix`. There is also some performance lost by unnecessarily `kron`-ing identity matrices, when we know that `I_m kron I_n = I_{m+n}`. 


**Description of the Change:**

There are a few changes made here:
- coeff-op matrices are accumulated in a list until there are about 100 of them and then added together, and then this object is added into the overall `matrix`. This appears to lower the per-pair construction and addition time, partly because adding two sparser matrices is faster than adding a very sparse matrix to a matrix with much higher nnz.
- The code now detects when a series of identity matrices will appear in the operator string and just builds the larger identity matrix representing the sequence. This lowers time spent `kron`-ing for short chains (only one or two non-identity ops) from ~2s to ~0.5s. Again this can have a noticeable impact when there are many hundreds/thousands of such operators.
- The initial matrix is now in `csr` format, as SciPy converts to `csr` internally anyway and `csr` addition is much faster than for `coo`.

**Benefits:**
- Should deliver some performance gains for `sparse_hamiltonian` especially for very large Hamiltonians.

**Possible Drawbacks:**

- It's possible this approach is slower for smaller qubit counts/when the total operator count is lower
- 100 may not be a good cutoff for how long to make `temp_mats`. Probably this is machine dependent.

**Related GitHub Issues:**
