### PR TITLE
[WIP] [QIM-6] Classical Fisher Information

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -77,6 +77,9 @@
   method for a provided device and interface, in human-readable format.
   [(#2533)](https://github.com/PennyLaneAI/pennylane/pull/2533)
 
+* Allow `qml.expval()` to accept lists of non-commuting observables by splitting the tape into commuting groups.
+  [(#2587)](https://github.com/PennyLaneAI/pennylane/pull/2587)
+
 <h3>Breaking changes</h3>
 
 * The module `qml.gradients.param_shift_hessian` has been renamed to
@@ -148,4 +151,4 @@
 This release contains contributions from (in alphabetical order):
 
 Guillermo Alonso-Linaje, Mikhail Andrenkov, Juan Miguel Arrazola, Utkarsh Azad, Christian Gogolin,
-Soran Jahangiri, Edward Jiang, Christina Lee, Chae-Yeun Park, Maria Schuld, Jay Soni
+Soran Jahangiri, Edward Jiang, Korbinian Kottmann, Christina Lee, Chae-Yeun Park, Maria Schuld, Jay Soni

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -763,7 +763,7 @@ class Device(abc.ABC):
                     circuits.append(new_circuit)
 
                 def reorder_fn(res):
-                    print(res, group_coeffs)
+                    """ re-ordering the output the same way observables where input """
                     return qml.math.concatenate(res)[qml.math.concatenate(group_coeffs)]
 
                 return circuits, reorder_fn

--- a/pennylane/quantum_info/classical_fisher.py
+++ b/pennylane/quantum_info/classical_fisher.py
@@ -1,0 +1,21 @@
+# Copyright 2022 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Differentiable classical fisher information"""
+# pylint: disable=import-outside-toplevel
+
+import pennylane as qml
+
+from .batch_transform import batch_transform
+
+# placeholder


### PR DESCRIPTION
**Context:**
Would be nice to add the classical fisher information matrix (CFIM) eq. (14-15) in [2103.15191](https://arxiv.org/pdf/2103.15191.pdf). 

![image](https://user-images.githubusercontent.com/43949391/171045547-5a6ed38c-33be-419a-9380-f7ad20bc9544.png)

There are some design questions that we should address first though.  

The idea is to have it as a transform such that it can be used in a similar fashion as `qml.metric_tensor()`, i.e. `qml.classical_fisher(qnode)(params)` outputs the `(num_params, num_params)` CFIM at `params`.

Now as far as I understand people are usually interested in the CFIM with respect to a parametrized **state** rather than a measurement, i.e. the measurement set M being simply all basis states.

In the context of tape transforms, I could just take the operations of the input tape and ignore the measurements. Then create a new tape with those operations and let it output the probabilities. This can then be differentiated and we should in principle have all elements necessary to compute the CFIM.
