### PR TITLE
Fix the include pattern for `black` in `pyproject.toml`

### DIFF
--- a/doc/_static/draw_mpl/draw_mpl_examples.py
+++ b/doc/_static/draw_mpl/draw_mpl_examples.py
@@ -26,6 +26,7 @@ from pennylane import draw_mpl
 
 folder = pathlib.Path(__file__).parent
 
+
 def main_example(circuit):
 
     fig, ax = draw_mpl(circuit)(1.2345, 1.2345)
@@ -33,89 +34,103 @@ def main_example(circuit):
     plt.savefig(folder / "main_example.png")
     plt.close()
 
+
 def decimals(dev):
-    
     @qml.qnode(dev)
     def circuit2(x, y):
         qml.RX(x, wires=0)
         qml.Rot(*y, wires=0)
         return qml.expval(qml.PauliZ(0))
 
-    fig, ax = draw_mpl(circuit2, decimals=2)(1.23456, [1.2345,2.3456,3.456])
+    fig, ax = draw_mpl(circuit2, decimals=2)(1.23456, [1.2345, 2.3456, 3.456])
 
     plt.savefig(folder / "decimals.png")
 
+
 def wire_order(circuit):
-    fig, ax = draw_mpl(circuit, wire_order=[3,2,1,0])(1.2345,1.2345)
+    fig, ax = draw_mpl(circuit, wire_order=[3, 2, 1, 0])(1.2345, 1.2345)
     plt.savefig(folder / "wire_order.png")
     plt.close()
 
+
 def show_all_wires(circuit):
-    fig, ax = draw_mpl(circuit, wire_order=["aux"], show_all_wires=True)(1.2345,1.2345)
+    fig, ax = draw_mpl(circuit, wire_order=["aux"], show_all_wires=True)(1.2345, 1.2345)
 
     plt.savefig(folder / "show_all_wires.png")
     plt.close()
 
+
 def postprocessing(circuit):
-    fig, ax = draw_mpl(circuit)(1.2345,1.2345)
+    fig, ax = draw_mpl(circuit)(1.2345, 1.2345)
     fig.suptitle("My Circuit", fontsize="xx-large")
 
-    options = {'facecolor': "white", 'edgecolor': "#f57e7e", "linewidth": 6, "zorder": -1}
+    options = {"facecolor": "white", "edgecolor": "#f57e7e", "linewidth": 6, "zorder": -1}
     box1 = plt.Rectangle((-0.5, -0.5), width=3.0, height=4.0, **options)
     ax.add_patch(box1)
 
-    ax.annotate("CSWAP", xy=(3, 2.5), xycoords='data', xytext=(3.8,1.5), textcoords='data',
-                arrowprops={'facecolor': 'black'}, fontsize=14)
+    ax.annotate(
+        "CSWAP",
+        xy=(3, 2.5),
+        xycoords="data",
+        xytext=(3.8, 1.5),
+        textcoords="data",
+        arrowprops={"facecolor": "black"},
+        fontsize=14,
+    )
 
     plt.savefig(folder / "postprocessing.png")
     plt.close()
 
+
 def rcparams(circuit):
-    plt.rcParams['patch.facecolor'] = 'mistyrose'
-    plt.rcParams['patch.edgecolor'] = 'maroon'
-    plt.rcParams['text.color'] = 'maroon'
-    plt.rcParams['font.weight'] = 'bold'
-    plt.rcParams['patch.linewidth'] = 4
-    plt.rcParams['patch.force_edgecolor'] = True
-    plt.rcParams['lines.color'] = 'indigo'
-    plt.rcParams['lines.linewidth'] = 5
-    plt.rcParams['figure.facecolor'] = 'ghostwhite'
+    plt.rcParams["patch.facecolor"] = "mistyrose"
+    plt.rcParams["patch.edgecolor"] = "maroon"
+    plt.rcParams["text.color"] = "maroon"
+    plt.rcParams["font.weight"] = "bold"
+    plt.rcParams["patch.linewidth"] = 4
+    plt.rcParams["patch.force_edgecolor"] = True
+    plt.rcParams["lines.color"] = "indigo"
+    plt.rcParams["lines.linewidth"] = 5
+    plt.rcParams["figure.facecolor"] = "ghostwhite"
 
-
-    fig, ax = qml.draw_mpl(circuit)(1.2345,1.2345)
+    fig, ax = qml.draw_mpl(circuit)(1.2345, 1.2345)
 
     plt.savefig(folder / "rcparams.png")
     plt.close()
-    plt.style.use('default')
+    plt.style.use("default")
+
 
 def use_style(circuit):
 
-    qml.drawer.use_style('black_white')
+    qml.drawer.use_style("black_white")
 
-    fig, ax = qml.draw_mpl(circuit)(1.2345,1.2345)
+    fig, ax = qml.draw_mpl(circuit)(1.2345, 1.2345)
 
     plt.savefig(folder / "black_white_style.png")
     plt.close()
-    plt.style.use('default')
+    plt.style.use("default")
+
 
 def wires_labels(circuit):
-    fig, ax = draw_mpl(circuit, wire_options={'color':'black', 'linewidth': 5},
-                label_options={'size': 20})(1.2345,1.2345)
+    fig, ax = draw_mpl(
+        circuit, wire_options={"color": "black", "linewidth": 5}, label_options={"size": 20}
+    )(1.2345, 1.2345)
     plt.savefig(folder / "wires_labels.png")
     plt.close()
 
+
 if __name__ == "__main__":
 
-    dev = qml.device('lightning.qubit', wires=(0,1,2,3))
+    dev = qml.device("lightning.qubit", wires=(0, 1, 2, 3))
 
     @qml.qnode(dev)
     def circuit(x, z):
-        qml.QFT(wires=(0,1,2,3))
-        qml.IsingXX(1.234, wires=(0,2))
-        qml.Toffoli(wires=(0,1,2))
-        qml.CSWAP(wires=(0,2,3))
+        qml.QFT(wires=(0, 1, 2, 3))
+        qml.IsingXX(1.234, wires=(0, 2))
+        qml.Toffoli(wires=(0, 1, 2))
+        qml.CSWAP(wires=(0, 2, 3))
         qml.RX(x, wires=0)
-        qml.CRZ(z, wires=(3,0))
+        qml.CRZ(z, wires=(3, 0))
         return qml.expval(qml.PauliZ(0))
 
     main_example(circuit)

--- a/doc/_static/drawer/mpldrawer_examples.py
+++ b/doc/_static/drawer/mpldrawer_examples.py
@@ -115,12 +115,13 @@ def measure(savefile="measure.png"):
     drawer = MPLDrawer(n_wires=2, n_layers=1)
     drawer.measure(layer=0, wires=0)
 
-    measure_box = {'facecolor': 'white', 'edgecolor': 'indigo'}
-    measure_lines = {'edgecolor': 'indigo', 'facecolor': 'plum', 'linewidth': 2}
+    measure_box = {"facecolor": "white", "edgecolor": "indigo"}
+    measure_lines = {"edgecolor": "indigo", "facecolor": "plum", "linewidth": 2}
     drawer.measure(layer=0, wires=1, box_options=measure_box, lines_options=measure_lines)
 
     plt.savefig(folder / savefile)
     plt.close()
+
 
 def integration(style="default", savefile="example_basic.png"):
     use_style(style)
@@ -133,7 +134,7 @@ def integration(style="default", savefile="example_basic.png"):
 
     drawer.box_gate(1, 4, "Z")
 
-    drawer.SWAP(2, (3,4))
+    drawer.SWAP(2, (3, 4))
     drawer.CNOT(2, (0, 2))
 
     drawer.ctrl(3, [1, 3], control_values=[True, False])
@@ -152,15 +153,15 @@ def integration(style="default", savefile="example_basic.png"):
 
 
 def integration_rcParams(savefile="example_rcParams.png"):
-    plt.rcParams['patch.facecolor'] = 'mistyrose'
-    plt.rcParams['patch.edgecolor'] = 'maroon'
-    plt.rcParams['text.color'] = 'maroon'
-    plt.rcParams['font.weight'] = 'bold'
-    plt.rcParams['patch.linewidth'] = 4
-    plt.rcParams['patch.force_edgecolor'] = True
-    plt.rcParams['lines.color'] = 'indigo'
-    plt.rcParams['lines.linewidth'] = 5
-    plt.rcParams['figure.facecolor'] = 'ghostwhite'
+    plt.rcParams["patch.facecolor"] = "mistyrose"
+    plt.rcParams["patch.edgecolor"] = "maroon"
+    plt.rcParams["text.color"] = "maroon"
+    plt.rcParams["font.weight"] = "bold"
+    plt.rcParams["patch.linewidth"] = 4
+    plt.rcParams["patch.force_edgecolor"] = True
+    plt.rcParams["lines.color"] = "indigo"
+    plt.rcParams["lines.linewidth"] = 5
+    plt.rcParams["figure.facecolor"] = "ghostwhite"
 
     drawer = MPLDrawer(n_wires=5, n_layers=5)
 
@@ -173,7 +174,7 @@ def integration_rcParams(savefile="example_rcParams.png"):
 
     drawer.box_gate(1, 4, "Z")
 
-    drawer.SWAP(2, (3,4))
+    drawer.SWAP(2, (3, 4))
     drawer.CNOT(2, (0, 2))
 
     drawer.ctrl(3, [1, 3], control_values=[True, False])

--- a/doc/_static/style/style_examples.py
+++ b/doc/_static/style/style_examples.py
@@ -25,28 +25,30 @@ import matplotlib.pyplot as plt
 
 folder = pathlib.Path(__file__).parent
 
+
 def make_imag(circuit, style):
     qml.drawer.use_style(style)
 
-    fig, ax = qml.draw_mpl(circuit)(1.2345,1.2345)
-    fig.suptitle(style, fontsize='xx-large')
+    fig, ax = qml.draw_mpl(circuit)(1.2345, 1.2345)
+    fig.suptitle(style, fontsize="xx-large")
 
     plt.savefig(folder / (style + "_style.png"))
     plt.close()
-    qml.drawer.use_style('default')
+    qml.drawer.use_style("default")
+
 
 if __name__ == "__main__":
 
-    dev = qml.device('lightning.qubit', wires=(0,1,2,3))
+    dev = qml.device("lightning.qubit", wires=(0, 1, 2, 3))
+
     @qml.qnode(dev)
     def circuit(x, z):
-        qml.QFT(wires=(0,1,2,3))
-        qml.Toffoli(wires=(0,1,2))
-        qml.CSWAP(wires=(0,2,3))
+        qml.QFT(wires=(0, 1, 2, 3))
+        qml.Toffoli(wires=(0, 1, 2))
+        qml.CSWAP(wires=(0, 2, 3))
         qml.RX(x, wires=0)
-        qml.CRZ(z, wires=(3,0))
+        qml.CRZ(z, wires=(3, 0))
         return qml.expval(qml.PauliZ(0))
 
     for style in qml.drawer.available_styles():
         make_imag(circuit, style)
-

--- a/doc/_static/tape_mpl/tape_mpl_examples.py
+++ b/doc/_static/tape_mpl/tape_mpl_examples.py
@@ -28,6 +28,7 @@ from pennylane.drawer import tape_mpl
 
 folder = pathlib.Path(__file__).parent
 
+
 def default(tape):
 
     fig, ax = tape_mpl(tape)
@@ -35,23 +36,26 @@ def default(tape):
     plt.savefig(folder / "default.png")
     plt.close()
 
+
 def decimals():
 
     with qml.tape.QuantumTape() as tape2:
         qml.RX(1.23456, wires=0)
-        qml.Rot(1.2345,2.3456,3.456, wires=0)
+        qml.Rot(1.2345, 2.3456, 3.456, wires=0)
         qml.expval(qml.PauliZ(0))
 
     fig, ax = tape_mpl(tape2, decimals=2)
     plt.savefig(folder / "decimals.png")
     plt.close()
 
+
 def wire_order(tape):
 
-    fig, ax = tape_mpl(tape, wire_order=[3,2,1,0])
+    fig, ax = tape_mpl(tape, wire_order=[3, 2, 1, 0])
 
     plt.savefig(folder / "wire_order.png")
     plt.close()
+
 
 def show_all_wires(tape):
 
@@ -59,66 +63,79 @@ def show_all_wires(tape):
     plt.savefig(folder / "show_all_wires.png")
     plt.close()
 
+
 def rcparams(tape):
 
-    plt.rcParams['patch.facecolor'] = 'mistyrose'
-    plt.rcParams['patch.edgecolor'] = 'maroon'
-    plt.rcParams['text.color'] = 'maroon'
-    plt.rcParams['font.weight'] = 'bold'
-    plt.rcParams['patch.linewidth'] = 4
-    plt.rcParams['patch.force_edgecolor'] = True
-    plt.rcParams['lines.color'] = 'indigo'
-    plt.rcParams['lines.linewidth'] = 5
-    plt.rcParams['figure.facecolor'] = 'ghostwhite'
+    plt.rcParams["patch.facecolor"] = "mistyrose"
+    plt.rcParams["patch.edgecolor"] = "maroon"
+    plt.rcParams["text.color"] = "maroon"
+    plt.rcParams["font.weight"] = "bold"
+    plt.rcParams["patch.linewidth"] = 4
+    plt.rcParams["patch.force_edgecolor"] = True
+    plt.rcParams["lines.color"] = "indigo"
+    plt.rcParams["lines.linewidth"] = 5
+    plt.rcParams["figure.facecolor"] = "ghostwhite"
 
     fig, ax = tape_mpl(tape)
 
     plt.savefig(folder / "rcparams.png")
     plt.close()
-    plt.style.use('default')
+    plt.style.use("default")
+
 
 def use_style(tape):
 
-    qml.drawer.use_style('black_white')
+    qml.drawer.use_style("black_white")
 
     fig, ax = tape_mpl(tape)
 
     plt.savefig(folder / "black_white_style.png")
     plt.close()
-    plt.style.use('default')
+    plt.style.use("default")
+
 
 def wires_and_labels(tape):
 
-    fig, ax = tape_mpl(tape, wire_options={'color':'black', 'linewidth': 5},
-                  label_options={'size': 20})
+    fig, ax = tape_mpl(
+        tape, wire_options={"color": "black", "linewidth": 5}, label_options={"size": 20}
+    )
 
     plt.savefig(folder / "wires_labels.png")
     plt.close()
+
 
 def postprocessing(tape):
 
     fig, ax = tape_mpl(tape)
     fig.suptitle("My Circuit", fontsize="xx-large")
 
-    options = {'facecolor': "white", 'edgecolor': "#f57e7e", "linewidth": 6, "zorder": -1}
+    options = {"facecolor": "white", "edgecolor": "#f57e7e", "linewidth": 6, "zorder": -1}
     box1 = plt.Rectangle((-0.5, -0.5), width=3.0, height=4.0, **options)
     ax.add_patch(box1)
 
-    ax.annotate("CSWAP", xy=(3, 2.5), xycoords='data', xytext=(3.8,1.5), textcoords='data',
-                arrowprops={'facecolor': 'black'}, fontsize=14)
+    ax.annotate(
+        "CSWAP",
+        xy=(3, 2.5),
+        xycoords="data",
+        xytext=(3.8, 1.5),
+        textcoords="data",
+        arrowprops={"facecolor": "black"},
+        fontsize=14,
+    )
 
     plt.savefig(folder / "postprocessing.png")
     plt.close()
 
+
 if __name__ == "__main__":
 
     with qml.tape.QuantumTape() as tape:
-        qml.QFT(wires=(0,1,2,3))
-        qml.IsingXX(1.234, wires=(0,2))
-        qml.Toffoli(wires=(0,1,2))
-        qml.CSWAP(wires=(0,2,3))
+        qml.QFT(wires=(0, 1, 2, 3))
+        qml.IsingXX(1.234, wires=(0, 2))
+        qml.Toffoli(wires=(0, 1, 2))
+        qml.CSWAP(wires=(0, 2, 3))
         qml.RX(1.2345, wires=0)
-        qml.CRZ(1.2345, wires=(3,0))
+        qml.CRZ(1.2345, wires=(3, 0))
         qml.expval(qml.PauliZ(0))
 
     default(tape)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -43,7 +43,7 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx_automodapi.automodapi",
     "sphinx_copybutton",
-    "m2r2"
+    "m2r2",
 ]
 
 os.environ["SPHINX_BUILD"] = "1"
@@ -57,7 +57,9 @@ copybutton_prompt_text = r">>> |\.\.\. |\$ |In \[\d*\]: | {2,5}\.\.\.: | {5,8}: 
 copybutton_prompt_is_regexp = True
 
 intersphinx_mapping = {"https://pennylane.ai/qml/": None}
-mathjax_path = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_CHTML"
+mathjax_path = (
+    "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_CHTML"
+)
 ignore_warnings = [("code/api/qml_transforms*", "no module named pennylane.transforms")]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -125,20 +127,20 @@ todo_include_todos = False
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-#html_theme_options = {}
+# html_theme_options = {}
 
 # Add any paths that contain custom themes here, relative to this directory.
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-#html_title = None
+# html_title = None
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
-#html_short_title = None
+# html_short_title = None
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
-#html_logo = None
+# html_logo = None
 
 # The name of an image file (relative to this directory) to use as a favicon of
 # the docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
@@ -153,20 +155,20 @@ html_static_path = ["_static"]
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
 # directly to the root of the documentation.
-#html_extra_path = []
+# html_extra_path = []
 
 # If not "", a "Last updated on:" timestamp is inserted at every page bottom,
 # using the given strftime format.
-#html_last_updated_fmt = "%b %d, %Y"
+# html_last_updated_fmt = "%b %d, %Y"
 
 # If true, SmartyPants will be used to convert quotes and dashes to
 # typographically correct entities.
-#html_use_smartypants = True
+# html_use_smartypants = True
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.
 html_sidebars = {
-    "**" : [
+    "**": [
         "searchbox.html",
         "globaltoc.html",
     ]
@@ -174,47 +176,47 @@ html_sidebars = {
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.
-#html_additional_pages = {}
+# html_additional_pages = {}
 
 # If false, no module index is generated.
-#html_domain_indices = True
+# html_domain_indices = True
 
 # If false, no index is generated.
-#html_use_index = True
+# html_use_index = True
 
 # If true, the index is split into individual pages for each letter.
-#html_split_index = False
+# html_split_index = False
 
 # If true, links to the reST sources are added to the pages.
-#html_show_sourcelink = True
+# html_show_sourcelink = True
 
 # If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
-#html_show_sphinx = True
+# html_show_sphinx = True
 
 # If true, "(C) Copyright ..." is shown in the HTML footer. Default is True.
-#html_show_copyright = True
+# html_show_copyright = True
 
 # If true, an OpenSearch description file will be output, and all pages will
 # contain a <link> tag referring to it.  The value of this option must be the
 # base URL from which the finished HTML is served.
-#html_use_opensearch = ""
+# html_use_opensearch = ""
 
 # This is the file name suffix for HTML files (e.g., ".xhtml").
-#html_file_suffix = None
+# html_file_suffix = None
 
 # Language to be used for generating the HTML full-text search index.
 # Sphinx supports the following languages:
 #   "da", "de", "en", "es", "fi", "fr", "h", "it", "ja"
 #   "nl", "no", "pt", "ro", "r", "sv", "tr"
-#html_search_language = "en"
+# html_search_language = "en"
 
 # A dictionary with options for the search language support, empty by default.
 # Now only "ja" uses this config value
-#html_search_options = {"type": "default"}
+# html_search_options = {"type": "default"}
 
 # The name of a javascript file (relative to the configuration directory) that
 # implements a search results scorer. If empty, the default will be used.
-#html_search_scorer = "scorer.js"
+# html_search_scorer = "scorer.js"
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = "PennyLanedoc"
@@ -227,9 +229,7 @@ html_theme_options = {
     "navbar_wordmark_path": "_static/pl_wordmark.png",
     # Specifying #19b37b is more correct but does not match the other PL websites.
     "navbar_logo_colour": "#2d7c7f",
-
     "navbar_home_link": "https://pennylane.ai",
-
     "navbar_left_links": [
         {
             "name": "Quantum machine learning",
@@ -255,9 +255,8 @@ html_theme_options = {
         {
             "name": "Blog",
             "href": "https://pennylane.ai/blog/",
-        }
+        },
     ],
-
     "navbar_right_links": [
         {
             "name": "FAQ",
@@ -273,16 +272,12 @@ html_theme_options = {
             "name": "GitHub",
             "href": "https://github.com/PennyLaneAI/pennylane",
             "icon": "fab fa-github",
-        }
+        },
     ],
-
     "extra_copyrights": [
-        "TensorFlow, the TensorFlow logo, and any related marks are trademarks "
-        "of Google Inc."
+        "TensorFlow, the TensorFlow logo, and any related marks are trademarks " "of Google Inc."
     ],
-
     "google_analytics_tracking_id": "UA-130507810-2",
-
     "border_colour": "#19b37b",
     "prev_next_button_colour": "#19b37b",
     "prev_next_button_hover_colour": "#0e714d",
@@ -300,15 +295,12 @@ latex_elements = {
     # The paper size ("letterpaper" or "a4paper").
     #
     # "papersize": "letterpaper",
-
     # The font size ("10pt", "11pt" or "12pt").
     #
     # "pointsize": "10pt",
-
     # Additional stuff for the LaTeX preamble.
     #
     # "preamble": "",
-
     # Latex figure (float) alignment
     #
     # "figure_align": "htbp",
@@ -320,8 +312,7 @@ latex_additional_files = ["macros.tex"]
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, "PennyLane.tex", "PennyLane Documentation",
-     "Xanadu Inc.", "manual"),
+    (master_doc, "PennyLane.tex", "PennyLane Documentation", "Xanadu Inc.", "manual"),
 ]
 
 
@@ -329,10 +320,7 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [
-    (master_doc, "pennylane", "PennyLane Documentation",
-     [author], 1)
-]
+man_pages = [(master_doc, "pennylane", "PennyLane Documentation", [author], 1)]
 
 
 # -- Options for Texinfo output -------------------------------------------
@@ -341,13 +329,19 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, "PennyLane", "PennyLane Documentation",
-     author, "PennyLane", "Xanadu quantum machine learning library.",
-     "Miscellaneous"),
+    (
+        master_doc,
+        "PennyLane",
+        "PennyLane Documentation",
+        author,
+        "PennyLane",
+        "Xanadu quantum machine learning library.",
+        "Miscellaneous",
+    ),
 ]
 
 
-#============================================================
+# ============================================================
 
 # the order in which autodoc lists the documented members
 autodoc_member_order = "bysource"

--- a/pennylane/gradients/parameter_shift_hessian.py
+++ b/pennylane/gradients/parameter_shift_hessian.py
@@ -489,7 +489,7 @@ def param_shift_hessian(tape, argnum=None, diagonal_shifts=None, off_diagonal_sh
     for i, g in enumerate(diff_methods):
         if g == "0":
             bool_argnum[i] = bool_argnum[:, i] = False
-    if qml.math.all(~bool_argnum): # pylint: disable=invalid-unary-operand-type
+    if qml.math.all(~bool_argnum):  # pylint: disable=invalid-unary-operand-type
         par_dim = len(tape.trainable_params)
         return [], lambda _: qml.math.zeros([tape.output_dim, par_dim, par_dim])
 

--- a/pennylane/measurements.py
+++ b/pennylane/measurements.py
@@ -576,9 +576,7 @@ def sample(op=None, wires=None):
         case ``qml.sample(obs)`` is interpreted as a single-shot expectation value of the
         observable ``obs``.
     """
-    if (
-        op is not None and not op.is_hermitian
-    ):  # None type is also allowed for op
+    if op is not None and not op.is_hermitian:  # None type is also allowed for op
         raise qml.QuantumFunctionError(
             f"{op.name} is not an observable: cannot be used with sample"
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [tool.black]
 line-length = 100
-include = 'pennylane\.pyi?$, tests\.pyi?$'
+include = '\.pyi?$'

--- a/tests/templates/test_embeddings/test_basis.py
+++ b/tests/templates/test_embeddings/test_basis.py
@@ -77,12 +77,12 @@ class TestInputs:
     """Test inputs and pre-processing."""
 
     @pytest.mark.parametrize(
-        ("feat","wires","expected"),
+        ("feat", "wires", "expected"),
         [(7, range(3), [1, 1, 1]), (2, range(4), [0, 0, 1, 0]), (8, range(5), [0, 1, 0, 0, 0])],
     )
     def test_features_as_int_conversion(self, feat, wires, expected):
         """checks conversion from features as int to a list of binary digits
-           with length = len(wires)"""
+        with length = len(wires)"""
 
         assert (
             qml.BasisEmbedding(features=feat, wires=wires).hyperparameters["basis_state"]


### PR DESCRIPTION
**Context:**
Running black from the main `pennylane` folder results in:

`No Python files are present to be formatted. Nothing to do` :sleeping:


**Description of the Change:**

* Updates the `include` pattern in `pyproject.toml`;
* Runs black on `pennylane` and `tests`;
* Runs `black .` that formats some Python files in the `doc` folder too.

**Benefits:**

`black` can be run again.

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
N/A