### PR TITLE
IPython displays a `Hamiltonian`'s `str` representation instead of `repr`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -75,6 +75,9 @@
 
 <h3>Improvements</h3>
 
+* IPython displays the `str` representation of a `Hamiltonian`, rather than the `repr`. This displays
+  more information about the object.
+
 * The qchem openfermion-dependent tests are localized and collected in `tests.qchem.of_tests`. The
   new module `test_structure` is created to collect the tests of the `qchem.structure` module in
   one place and remove their dependency to openfermion.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -77,6 +77,7 @@
 
 * IPython displays the `str` representation of a `Hamiltonian`, rather than the `repr`. This displays
   more information about the object.
+  [(#2648)](https://github.com/PennyLaneAI/pennylane/pull/2648)
 
 * The qchem openfermion-dependent tests are localized and collected in `tests.qchem.of_tests`. The
   new module `test_structure` is created to collect the tests of the `qchem.structure` module in

--- a/pennylane/ops/qubit/hamiltonian.py
+++ b/pennylane/ops/qubit/hamiltonian.py
@@ -426,6 +426,11 @@ class Hamiltonian(Observable):
         # Constructor-call-like representation
         return f"<Hamiltonian: terms={qml.math.shape(self.coeffs)[0]}, wires={self.wires.tolist()}>"
 
+    def _ipython_display_(self):
+        # See https://ipython.readthedocs.io/en/stable/config/integrating.html
+        # Displays __str__ in ipython instead of __repr__
+        print(self.__str__())
+
     def _obs_data(self):
         r"""Extracts the data from a Hamiltonian and serializes it in an order-independent fashion.
 

--- a/pennylane/ops/qubit/hamiltonian.py
+++ b/pennylane/ops/qubit/hamiltonian.py
@@ -426,9 +426,10 @@ class Hamiltonian(Observable):
         # Constructor-call-like representation
         return f"<Hamiltonian: terms={qml.math.shape(self.coeffs)[0]}, wires={self.wires.tolist()}>"
 
-    def _ipython_display_(self): # pragma: no-cover
-        # See https://ipython.readthedocs.io/en/stable/config/integrating.html
-        # Displays __str__ in ipython instead of __repr__
+    def _ipython_display_(self):  # pragma: no-cover
+        """Displays __str__ in ipython instead of __repr__
+        See https://ipython.readthedocs.io/en/stable/config/integrating.html
+        """
         print(self.__str__())
 
     def _obs_data(self):

--- a/pennylane/ops/qubit/hamiltonian.py
+++ b/pennylane/ops/qubit/hamiltonian.py
@@ -426,7 +426,7 @@ class Hamiltonian(Observable):
         # Constructor-call-like representation
         return f"<Hamiltonian: terms={qml.math.shape(self.coeffs)[0]}, wires={self.wires.tolist()}>"
 
-    def _ipython_display_(self):
+    def _ipython_display_(self): # pragma: no-cover
         # See https://ipython.readthedocs.io/en/stable/config/integrating.html
         # Displays __str__ in ipython instead of __repr__
         print(self.__str__())

--- a/tests/ops/qubit/test_hamiltonian.py
+++ b/tests/ops/qubit/test_hamiltonian.py
@@ -17,6 +17,8 @@ Tests for the Hamiltonian class.
 import numpy as np
 import pytest
 
+from unittest.mock import patch
+
 import pennylane as qml
 from pennylane import numpy as pnp
 
@@ -641,6 +643,13 @@ class TestHamiltonian:
         """Tests that the __str__ function for printing is correct"""
         H = qml.Hamiltonian(*terms)
         assert H.__str__() == string
+
+    @patch("builtins.print")
+    def test_hamiltonian_ipython_display(self, mock_print):
+        """Test that the ipython_dipslay method prints __str__."""
+        H = 1.0 * qml.PauliX(0)
+        H._ipython_display_()
+        mock_print.assert_called_with(str(H))
 
     @pytest.mark.parametrize("terms, string", zip(valid_hamiltonians, valid_hamiltonians_repr))
     def test_hamiltonian_repr(self, terms, string):


### PR DESCRIPTION
Currently, IPython displays Hamiltonians via their `repr` representation:

```
>>> 1.0 * qml.PauliX(0)
<Hamiltonian: terms=1, wires=[0]>
```

This doesn't tell us much about what's actually in the Hamiltonian, so I find myself always having to use `print(H)` instead of simply `H` when playing around with Hamiltonians in the REPL.

This PR defines the `_ipython_display` method for Hamiltonians, so now it prints out the full `str` representation.

```
>>> 1.0 * qml.PauliX(0)
  (1.0) [X0]
```