### PR TITLE
[WIP] add norm for second quantized Hamiltonian

### DIFF
--- a/doc/code/qml_resources.rst
+++ b/doc/code/qml_resources.rst
@@ -1,0 +1,15 @@
+qml.resources
+￼=============
+￼
+￼Overview
+￼--------
+￼
+￼The resources module provides the functionality to estimate the cost of implementing quantum
+￼algorithms.
+￼
+￼.. currentmodule:: pennylane.resources
+￼
+￼.. automodapi:: pennylane.resources
+￼    :no-heading:
+￼    :include-all-objects:
+￼    :no-inheritance-diagram:

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -189,6 +189,7 @@ PennyLane is **free** and **open source**, released under the Apache License, Ve
    code/qml_hf
    code/qml_qchem
    code/qml_qnn
+   code/qml_resources
    code/qml_tape
    code/qml_transforms
    code/qml_drawer

--- a/pennylane/__init__.py
+++ b/pennylane/__init__.py
@@ -30,6 +30,7 @@ import pennylane.kernels
 import pennylane.math
 import pennylane.operation
 import pennylane.qnn
+import pennylane.resources
 import pennylane.templates
 import pennylane.hf
 import pennylane.qchem

--- a/pennylane/resources/__init__.py
+++ b/pennylane/resources/__init__.py
@@ -14,3 +14,4 @@
 """
 This subpackage provides the functionality for algorithm resource estimation.
 """
+from .df import norm

--- a/pennylane/resources/df.py
+++ b/pennylane/resources/df.py
@@ -69,10 +69,10 @@ def norm(one, two, eigvals):
      >>> l, w, v = factorize(two, 1e-5)
      >>> print(norm(one, two, w))
      52.98762043980203
-     """
+    """
     lambda_one = 0.25 * np.sum([np.sum(abs(val)) ** 2 for val in eigvals])
 
-    t_mat = one - 0.5 * np.einsum('illj', two) + np.einsum('llij', two)
+    t_mat = one - 0.5 * np.einsum("illj", two) + np.einsum("llij", two)
 
     val, vec = np.linalg.eigh(t_mat)
 

--- a/pennylane/resources/double_factorization.py
+++ b/pennylane/resources/double_factorization.py
@@ -19,15 +19,40 @@ from pennylane import numpy as np
 
 
 def norm(one, two, eigvals):
-    r"""Return the 1-norm of a molecular Hamiltonian from the one- and two-electron and factorized
-    two-electron integrals.
+    r"""Return the 1-norm of a molecular Hamiltonian from the one- and two-electron integrals and
+    eigenvalues of the factorized two-electron integral tensor.
+
+    The 1-norm of a double-factorized molecular Hamiltonian is computed as
+    [`arXiv:2007.14460 <https://arxiv.org/abs/2007.14460>`_]
+
+    .. math::
+
+        \lambda = ||T|| + \frac{1}{4} \sum_r ||L^{(r)}||^2,
+
+    where the Schatten norm, :math:`||L||`, is defined as
+
+    .. math::
+
+        ||L|| = \sum_k |\text{eigvals}[L]_k|.
+
+    The matrices :math:`L^{(r)}` are obtained from a rank-r factorizing the two-electron integral
+    tensor :math:`h`, arranged in the chemist notation, such that
+
+    .. math::
+
+        h_{ijkl} = \sum_r L_{ij}^{(r)} L_{kl}^{(r) T}.
+
+    The matrix :math:`T` is constructed from the one-and two electron integrals as
+
+    .. math::
+
+        T = h_{ij} - \frac{1}{2} \sum_l h_{illj} + \sum_l h_{llij}.
 
      Args:
          one (array[array[float]]): one-electron integrals
          two (array[array[float]]): two-electron integrals
          eigvals (array[float]): eigenvalues of the matrices obtained from factorizing the
              two-electron integral tensor
-
 
      Returns:
          array[float]: 1-norm of the Hamiltonian
@@ -47,9 +72,9 @@ def norm(one, two, eigvals):
      """
     lambda_one = 0.25 * np.sum([np.sum(abs(val)) ** 2 for val in eigvals])
 
-    l_inv = one - 0.5 * np.einsum('illj', two) + np.einsum('llij', two)
+    t_mat = one - 0.5 * np.einsum('illj', two) + np.einsum('llij', two)
 
-    val, vec = np.linalg.eigh(l_inv)
+    val, vec = np.linalg.eigh(t_mat)
 
     lambda_two = np.sum(abs(val))
 

--- a/pennylane/resources/double_factorization.py
+++ b/pennylane/resources/double_factorization.py
@@ -1,0 +1,56 @@
+# Copyright 2018-2022 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+This module contains the functions needed for resource estimation with double factorization method.
+"""
+
+from pennylane import numpy as np
+
+
+def norm(one, two, eigvals):
+    r"""Return the 1-norm of a molecular Hamiltonian from the one- and two-electron and factorized
+    two-electron integrals.
+
+     Args:
+         one (array[array[float]]): one-electron integrals
+         two (array[array[float]]): two-electron integrals
+         eigvals (array[float]): eigenvalues of the matrices obtained from factorizing the
+             two-electron integral tensor
+
+
+     Returns:
+         array[float]: 1-norm of the Hamiltonian
+
+     **Example**
+
+     >>> symbols  = ['H', 'H', 'O']
+     >>> geometry = np.array([[0.0,  0.000000000,  0.150166845],
+     >>>                      [0.0,  0.768778665, -0.532681406],
+     >>>                      [0.0, -0.768778665, -0.532681406]], requires_grad = False) / 0.529177
+     >>> mol = qml.qchem.Molecule(symbols, geometry, basis_name='sto-3g')
+     >>> core, one, two = qml.qchem.electron_integrals(mol)()
+     >>> two = np.swapaxes(two, 1, 3) # convert to the chemists notation
+     >>> l, w, v = factorize(two, 1e-5)
+     >>> print(norm(one, two, w))
+     52.98762043980203
+     """
+    lambda_one = 0.25 * np.sum([np.sum(abs(val)) ** 2 for val in eigvals])
+
+    l_inv = one - 0.5 * np.einsum('illj', two) + np.einsum('llij', two)
+
+    val, vec = np.linalg.eigh(l_inv)
+
+    lambda_two = np.sum(abs(val))
+
+    return lambda_one + lambda_two

--- a/tests/resources/test_df.py
+++ b/tests/resources/test_df.py
@@ -1,0 +1,51 @@
+# Copyright 2018-2021 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Unit tests for functions needed for resource estimation with double factorization method.
+"""
+import pytest
+import pennylane as qml
+from pennylane import numpy as np
+
+
+@pytest.mark.parametrize(
+    ("one", "two", "eigvals", "lamb_ref"),
+    [
+        (
+            np.array([[-1.25330961e00, 4.01900735e-14], [4.01900735e-14, -4.75069041e-01]]),
+            # two-electron integral is arranged in the chemist notation [11|22]
+            np.array(
+                [
+                    [
+                        [[6.74755872e-01, -4.60742555e-14], [-4.60742555e-14, 6.63711349e-01]],
+                        [[-4.61020111e-14, 1.81210478e-01], [1.81210478e-01, -4.26325641e-14]],
+                    ],
+                    [
+                        [[-4.60464999e-14, 1.81210478e-01], [1.81210478e-01, -4.25215418e-14]],
+                        [[6.63711349e-01, -4.28546088e-14], [-4.24105195e-14, 6.97651447e-01]],
+                    ],
+                ]
+            ),
+            np.tensor(
+                [[-0.10489852, 0.10672343], [-0.42568824, 0.42568824], [-0.82864211, -0.81447282]]
+            ),
+            1.6570518796336895,  # lambda value obtained from openfermion
+        )
+    ],
+)
+def test_df_norm(one, two, eigvals, lamb_ref):
+    r"""Test that the norm function returns the correct 1-norm."""
+    lamb = qml.resources.norm(one, two, eigvals)
+
+    assert np.allclose(lamb, lamb_ref)


### PR DESCRIPTION
**Context:**
This PR adds functions for computing  the 1-norm of a molecular Hamiltonian from the one- and two-electron integrals and eigenvalues of the factorized two-electron integral tensor.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
