### PR TITLE
Adds a cutoff for Hamiltonian `_ipython_display`

### DIFF
--- a/pennylane/ops/qubit/hamiltonian.py
+++ b/pennylane/ops/qubit/hamiltonian.py
@@ -432,7 +432,7 @@ class Hamiltonian(Observable):
         """
         if len(self.ops) < 15:
             print(str(self))
-        else:
+        else:  # pragma: no-cover
             print(repr(self))
 
     def _obs_data(self):

--- a/pennylane/ops/qubit/hamiltonian.py
+++ b/pennylane/ops/qubit/hamiltonian.py
@@ -430,7 +430,10 @@ class Hamiltonian(Observable):
         """Displays __str__ in ipython instead of __repr__
         See https://ipython.readthedocs.io/en/stable/config/integrating.html
         """
-        print(self.__str__())
+        if len(self.ops) < 15:
+            print(str(self))
+        else:
+            print(repr(self))
 
     def _obs_data(self):
         r"""Extracts the data from a Hamiltonian and serializes it in an order-independent fashion.

--- a/tests/ops/qubit/test_hamiltonian.py
+++ b/tests/ops/qubit/test_hamiltonian.py
@@ -645,11 +645,18 @@ class TestHamiltonian:
         assert H.__str__() == string
 
     @patch("builtins.print")
-    def test_hamiltonian_ipython_display(self, mock_print):
+    def test_small_hamiltonian_ipython_display(self, mock_print):
         """Test that the ipython_dipslay method prints __str__."""
         H = 1.0 * qml.PauliX(0)
         H._ipython_display_()
         mock_print.assert_called_with(str(H))
+
+    @patch("builtins.print")
+    def test_big_hamiltonian_ipython_display(self, mock_print):
+        """Test that the ipython_dipslay method prints __repr__ when H has more than 15 terms."""
+        H = qml.Hamiltonian([1] * 16, [qml.PauliX(i) for i in range(16)])
+        H._ipython_display_()
+        mock_print.assert_called_with(repr(H))
 
     @pytest.mark.parametrize("terms, string", zip(valid_hamiltonians, valid_hamiltonians_repr))
     def test_hamiltonian_repr(self, terms, string):

--- a/tests/ops/qubit/test_hamiltonian.py
+++ b/tests/ops/qubit/test_hamiltonian.py
@@ -653,7 +653,7 @@ class TestHamiltonian:
 
     @patch("builtins.print")
     def test_big_hamiltonian_ipython_display(self, mock_print):
-        """Test that the ipython_dipslay method prints __repr__ when H has more than 15 terms."""
+        """Test that the ipython_display method prints __repr__ when H has more than 15 terms."""
         H = qml.Hamiltonian([1] * 16, [qml.PauliX(i) for i in range(16)])
         H._ipython_display_()
         mock_print.assert_called_with(repr(H))


### PR DESCRIPTION
This PR adds a cutoff of 15 terms to the `_ipython_display_` of Hamiltonians.  If the Hamiltonian has 15 or above terms, IPython will merely display the `repr` instead of the `str`.