### PR TITLE
Make visual changes for 0 and 1 control values [unitaryhack]

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -375,6 +375,10 @@
   is now used to style the Sphinx documentation.
   [(#2450)](https://github.com/PennyLaneAI/pennylane/pull/2450)
 
+* Added reference to `qml.utils.sparse_hamiltonian` in `qml.SparseHamiltonian` to clarify
+  how to construct sparse Hamiltonians in PennyLane.
+  [(2572)](https://github.com/PennyLaneAI/pennylane/pull/2572)
+
 * Added a new section in the [Gradients and Training](https://pennylane.readthedocs.io/en/stable/introduction/interfaces.html)
   page that summarizes the supported device configurations and provides justification. Also
   added [code examples](https://pennylane.readthedocs.io/en/stable/introduction/unsupported.html)
@@ -386,5 +390,5 @@
 This release contains contributions from (in alphabetical order):
 
 Amintor Dusko, Chae-Yeun Park, Christian Gogolin, Christina Lee, David Wierichs, Edward Jiang, Guillermo Alonso-Linaje,
-Jay Soni, Juan Miguel Arrazola, Maria Schuld, Mikhail Andrenkov, Romain Moyard, Qi Hu, Samuel Banning, Soran Jahangiri, 
+Jay Soni, Juan Miguel Arrazola, Korbinian, Kottmann, Maria Schuld, Mikhail Andrenkov, Romain Moyard, Qi Hu, Samuel Banning, Soran Jahangiri, 
 Utkarsh Azad, WingCode

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -305,9 +305,7 @@
 * The performance of building sparse Hamiltonians has been improved by accumulating the sparse representation of coefficient-operator pairs in a temporary storage and by eliminating unnecessary `kron` operations on identity matrices. 
   [(#2630)](https://github.com/PennyLaneAI/pennylane/pull/2630)
 
-* Drawing a circuit with custom control values now has distinct symbols for 0 and 1 control state.
-  Also adds support for `qml.ControlledQubitUnitary` in the mpl drawer which allows it to also display control
-  values distinctly.
+* Control values are now displayed distinctly in text and mpl drawings of circuits.
   [(#2668)](https://github.com/PennyLaneAI/pennylane/pull/2668)
 
 <h3>Breaking changes</h3>

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -304,6 +304,11 @@
 * The performance of building sparse Hamiltonians has been improved by accumulating the sparse representation of coefficient-operator pairs in a temporary storage and by eliminating unnecessary `kron` operations on identity matrices. 
   [(#2630)](https://github.com/PennyLaneAI/pennylane/pull/2630)
 
+* Drawing a circuit with custom control values now has distinct symbols for 0 and 1 control state.
+  Also adds support for `qml.ControlledQubitUnitary` in the mpl drawer which allows it to also display control
+  values distinctly.
+  [(#2668)](https://github.com/PennyLaneAI/pennylane/pull/2668)
+
 <h3>Breaking changes</h3>
 
 * The `qml.queuing.Queue` class is now removed.

--- a/pennylane/drawer/tape_mpl.py
+++ b/pennylane/drawer/tape_mpl.py
@@ -53,6 +53,15 @@ def _add_multicontrolledx(drawer, layer, mapped_wires, op):
     drawer.CNOT(layer, mapped_wires, control_values=control_values)
 
 
+def _add_controlledqubitunitary(drawer, layer, mapped_wires, op):
+    # convert control values
+    control_values = [(i == "1") for i in op.hyperparameters["control_values"]]
+    drawer.box_gate(layer, mapped_wires[-1], text="U")
+    drawer.ctrl(
+        layer, wires=mapped_wires[:-1], wires_target=mapped_wires[-1], control_values=control_values
+    )
+
+
 # pylint: disable=unused-argument
 def _add_cz(drawer, layer, mapped_wires, op):
     drawer.ctrl(layer, mapped_wires)
@@ -83,6 +92,7 @@ special_cases = {
     ops.CZ: _add_cz,
     ops.Barrier: _add_barrier,
     ops.WireCut: _add_wirecut,
+    ops.ControlledQubitUnitary: _add_controlledqubitunitary,
 }
 """Dictionary mapping special case classes to functions for drawing them."""
 

--- a/pennylane/drawer/tape_mpl.py
+++ b/pennylane/drawer/tape_mpl.py
@@ -86,7 +86,7 @@ special_cases = {
 }
 """Dictionary mapping special case classes to functions for drawing them."""
 
-
+# pylint: disable=too-many-branches
 def tape_mpl(tape, wire_order=None, show_all_wires=False, decimals=None, **kwargs):
     """Produces a matplotlib graphic from a tape.
 

--- a/pennylane/drawer/tape_mpl.py
+++ b/pennylane/drawer/tape_mpl.py
@@ -56,10 +56,10 @@ def _add_multicontrolledx(drawer, layer, mapped_wires, op):
 def _add_controlledqubitunitary(drawer, layer, mapped_wires, op):
     # convert control values
     control_values = [(i == "1") for i in op.hyperparameters["control_values"]]
-    drawer.box_gate(layer, mapped_wires[-1], text="U")
     drawer.ctrl(
         layer, wires=mapped_wires[:-1], wires_target=mapped_wires[-1], control_values=control_values
     )
+    drawer.box_gate(layer, mapped_wires[-1], text="U")
 
 
 # pylint: disable=unused-argument

--- a/pennylane/drawer/tape_text.py
+++ b/pennylane/drawer/tape_text.py
@@ -42,14 +42,12 @@ def _add_op(op, layer_str, wire_map, decimals, cache):
 
     control_wires = op.control_wires
     control_values = op.hyperparameters.get("control_values", None)
-    for i, w in enumerate(control_wires):
-        if control_values:
-            if control_values[i] == "1":
-                layer_str[wire_map[w]] += "C"
-            elif control_values[i] == "0":
-                layer_str[wire_map[w]] += "O"
-        else:
-            layer_str[wire_map[w]] += "C"
+    if control_values:
+        for w, val in zip(control_wires, control_values):
+            layer_str[wire_map[w]] += "●" if val == "1" else "○"
+    else:
+        for w in control_wires:
+            layer_str[wire_map[w]] += "●"
 
     label = op.label(decimals=decimals, cache=cache).replace("\n", "")
     if len(op.wires) == 0:  # operation (e.g. barrier, snapshot) across all wires

--- a/pennylane/drawer/tape_text.py
+++ b/pennylane/drawer/tape_text.py
@@ -41,8 +41,15 @@ def _add_op(op, layer_str, wire_map, decimals, cache):
     layer_str = _add_grouping_symbols(op, layer_str, wire_map)
 
     control_wires = op.control_wires
-    for w in control_wires:
-        layer_str[wire_map[w]] += "C"
+    control_values = op.hyperparameters.get("control_values", None)
+    for i, w in enumerate(control_wires):
+        if control_values:
+            if control_values[i] == "1":
+                layer_str[wire_map[w]] += "C"
+            elif control_values[i] == "0":
+                layer_str[wire_map[w]] += "O"
+        else:
+            layer_str[wire_map[w]] += "C"
 
     label = op.label(decimals=decimals, cache=cache).replace("\n", "")
     if len(op.wires) == 0:  # operation (e.g. barrier, snapshot) across all wires

--- a/pennylane/ops/qubit/observables.py
+++ b/pennylane/ops/qubit/observables.py
@@ -197,6 +197,21 @@ class SparseHamiltonian(Observable):
         do_queue (bool): Indicates whether the operator should be
             immediately pushed into the Operator queue (optional)
         id (str or None): String representing the operation (optional)
+
+    **Example**
+
+    Sparse Hamiltonians can be constructed directly with a SciPy-compatible sparse matrix.
+
+    Alternatively, you can construct your Hamiltonian as usual using :class:`~.Hamiltonian`, and then use
+    the utility function :func:`~.utils.sparse_hamiltonian` to construct the sparse matrix that serves as the input
+    to ``SparseHamiltonian``:
+
+    >>> wires = 20
+    >>> coeffs = [1 for _ in range(wires)]
+    >>> observables = [qml.PauliZ(i) for _ in range(wires)]
+    >>> H = qml.Hamiltonian(coeffs, observables)
+    >>> Hmat = qml.utils.sparse_hamiltonian(H)
+    >>> H_sparse = qml.SparseHamiltonian(Hmat, wires=wires)
     """
     num_wires = AllWires
     num_params = 1

--- a/tests/drawer/test_tape_mpl.py
+++ b/tests/drawer/test_tape_mpl.py
@@ -251,6 +251,33 @@ class TestSpecialGates:
         assert len(ax.lines) == 5
         plt.close()
 
+    def test_ControlledQubitUnitary(self):
+        """Test ControlledQubitUnitary gets a special call."""
+
+        with QuantumTape() as tape:
+            qml.ControlledQubitUnitary(
+                qml.matrix(qml.RX)(0, 0),
+                control_wires=[0, 1, 2, 3],
+                wires=[4],
+                control_values="1010",
+            )
+
+        _, ax = tape_mpl(tape)
+        layer = 0
+
+        assert len(ax.patches) == 5
+        assert ax.patches[0].center == (layer, 0)
+        assert ax.patches[1].center == (layer, 1)
+        assert ax.patches[2].center == (layer, 2)
+        assert ax.patches[3].center == (layer, 3)
+
+        # five wires, one control line
+        assert len(ax.lines) == 6
+        control_line = ax.lines[5]
+        assert control_line.get_data() == ((layer, layer), (0, 4))
+
+        plt.close()
+
     def test_Toffoli(self):
         """Test Toffoli gets a special call."""
 

--- a/tests/drawer/test_tape_mpl.py
+++ b/tests/drawer/test_tape_mpl.py
@@ -252,7 +252,7 @@ class TestSpecialGates:
         plt.close()
 
     def test_ControlledQubitUnitary(self):
-        """Test ControlledQubitUnitary gets a special call."""
+        """Test ControlledQubitUnitary"""
 
         with QuantumTape() as tape:
             qml.ControlledQubitUnitary(
@@ -267,9 +267,13 @@ class TestSpecialGates:
 
         assert len(ax.patches) == 5
         assert ax.patches[0].center == (layer, 0)
+        assert ax.patches[0].get_facecolor() == mpl.colors.to_rgba(plt.rcParams["lines.color"])
         assert ax.patches[1].center == (layer, 1)
+        assert ax.patches[1].get_facecolor() == mpl.colors.to_rgba(plt.rcParams["axes.facecolor"])
         assert ax.patches[2].center == (layer, 2)
+        assert ax.patches[2].get_facecolor() == mpl.colors.to_rgba(plt.rcParams["lines.color"])
         assert ax.patches[3].center == (layer, 3)
+        assert ax.patches[3].get_facecolor() == mpl.colors.to_rgba(plt.rcParams["axes.facecolor"])
 
         # five wires, one control line
         assert len(ax.lines) == 6

--- a/tests/drawer/test_tape_mpl.py
+++ b/tests/drawer/test_tape_mpl.py
@@ -251,37 +251,6 @@ class TestSpecialGates:
         assert len(ax.lines) == 5
         plt.close()
 
-    def test_ControlledQubitUnitary(self):
-        """Test ControlledQubitUnitary"""
-
-        with QuantumTape() as tape:
-            qml.ControlledQubitUnitary(
-                qml.matrix(qml.RX)(0, 0),
-                control_wires=[0, 1, 2, 3],
-                wires=[4],
-                control_values="1010",
-            )
-
-        _, ax = tape_mpl(tape)
-        layer = 0
-
-        assert len(ax.patches) == 5
-        assert ax.patches[0].center == (layer, 0)
-        assert ax.patches[0].get_facecolor() == mpl.colors.to_rgba(plt.rcParams["lines.color"])
-        assert ax.patches[1].center == (layer, 1)
-        assert ax.patches[1].get_facecolor() == mpl.colors.to_rgba(plt.rcParams["axes.facecolor"])
-        assert ax.patches[2].center == (layer, 2)
-        assert ax.patches[2].get_facecolor() == mpl.colors.to_rgba(plt.rcParams["lines.color"])
-        assert ax.patches[3].center == (layer, 3)
-        assert ax.patches[3].get_facecolor() == mpl.colors.to_rgba(plt.rcParams["axes.facecolor"])
-
-        # five wires, one control line
-        assert len(ax.lines) == 6
-        control_line = ax.lines[5]
-        assert control_line.get_data() == ((layer, layer), (0, 4))
-
-        plt.close()
-
     def test_Toffoli(self):
         """Test Toffoli gets a special call."""
 
@@ -441,6 +410,40 @@ class TestControlledGates:
 
         # two wire labels, so CRX is third text object
         assert ax.texts[2].get_text() == "RX\n(1.23)"
+        plt.close()
+
+    def test_control_values(self):
+        """Test control values get displayed correctly"""
+
+        with QuantumTape() as tape:
+            qml.ControlledQubitUnitary(
+                qml.matrix(qml.RX)(0, 0),
+                control_wires=[0, 1, 2, 3],
+                wires=[4],
+                control_values="1010",
+            )
+
+        _, ax = tape_mpl(tape)
+        layer = 0
+
+        # 5 wires -> 4 control, 1 target
+        assert len(ax.patches) == 5
+        # Circle for control values are positioned correctly
+        # Circle color matched according to the control value
+        assert ax.patches[0].center == (layer, 0)
+        assert ax.patches[0].get_facecolor() == mpl.colors.to_rgba(plt.rcParams["lines.color"])
+        assert ax.patches[1].center == (layer, 1)
+        assert ax.patches[1].get_facecolor() == mpl.colors.to_rgba(plt.rcParams["axes.facecolor"])
+        assert ax.patches[2].center == (layer, 2)
+        assert ax.patches[2].get_facecolor() == mpl.colors.to_rgba(plt.rcParams["lines.color"])
+        assert ax.patches[3].center == (layer, 3)
+        assert ax.patches[3].get_facecolor() == mpl.colors.to_rgba(plt.rcParams["axes.facecolor"])
+
+        # five wires, one control line
+        assert len(ax.lines) == 6
+        control_line = ax.lines[5]
+        assert control_line.get_data() == ((layer, layer), (0, 4))
+
         plt.close()
 
 

--- a/tests/drawer/test_tape_text.py
+++ b/tests/drawer/test_tape_text.py
@@ -73,8 +73,8 @@ class TestHelperFunctions:
         "op, out",
         [
             (qml.PauliX(0), ["─X", "─", "─", "─"]),
-            (qml.CNOT(wires=(0, 2)), ["╭C", "│", "╰X", "─"]),
-            (qml.Toffoli(wires=(0, 1, 3)), ["╭C", "├C", "│", "╰X"]),
+            (qml.CNOT(wires=(0, 2)), ["╭●", "│", "╰X", "─"]),
+            (qml.Toffoli(wires=(0, 1, 3)), ["╭●", "├●", "│", "╰X"]),
             (qml.IsingXX(1.23, wires=(0, 2)), ["╭IsingXX", "│", "╰IsingXX", "─"]),
             (qml.Snapshot(), ["─|S|", "─|S|", "─|S|", "─|S|"]),
             (qml.Barrier(), ["─||", "─||", "─||", "─||"]),
@@ -88,8 +88,8 @@ class TestHelperFunctions:
         "op, out",
         [
             (qml.PauliY(1), ["─X", "─Y", "─", "─"]),
-            (qml.CNOT(wires=(1, 2)), ["─X", "╭C", "╰X", "─"]),
-            (qml.CRX(1.23, wires=(2, 3)), ["─X", "─", "╭C", "╰RX"]),
+            (qml.CNOT(wires=(1, 2)), ["─X", "╭●", "╰X", "─"]),
+            (qml.CRX(1.23, wires=(2, 3)), ["─X", "─", "╭●", "╰RX"]),
         ],
     )
     def test_add_second_op(self, op, out):
@@ -242,10 +242,10 @@ class TestMaxLength:
 
 
 single_op_tests_data = [
-    (qml.CNOT(wires=(0, 1)), "0: ─╭C─┤  \n1: ─╰X─┤  "),
-    (qml.Toffoli(wires=(0, 1, 2)), "0: ─╭C─┤  \n1: ─├C─┤  \n2: ─╰X─┤  "),
+    (qml.CNOT(wires=(0, 1)), "0: ─╭●─┤  \n1: ─╰X─┤  "),
+    (qml.Toffoli(wires=(0, 1, 2)), "0: ─╭●─┤  \n1: ─├●─┤  \n2: ─╰X─┤  "),
     (qml.Barrier(wires=(0, 1, 2)), "0: ─╭||─┤  \n1: ─├||─┤  \n2: ─╰||─┤  "),
-    (qml.CSWAP(wires=(0, 1, 2)), "0: ─╭C────┤  \n1: ─├SWAP─┤  \n2: ─╰SWAP─┤  "),
+    (qml.CSWAP(wires=(0, 1, 2)), "0: ─╭●────┤  \n1: ─├SWAP─┤  \n2: ─╰SWAP─┤  "),
     (
         qml.DoubleExcitationPlus(1.23, wires=(0, 1, 2, 3)),
         "0: ─╭G²₊(1.23)─┤  \n1: ─├G²₊(1.23)─┤  \n2: ─├G²₊(1.23)─┤  \n3: ─╰G²₊(1.23)─┤  ",

--- a/tests/drawer/test_tape_text.py
+++ b/tests/drawer/test_tape_text.py
@@ -242,6 +242,7 @@ class TestMaxLength:
 
 
 single_op_tests_data = [
+    (qml.MultiControlledX([0, 1, 2], 3, '010'), "0: ─╭○─┤  \n1: ─├●─┤  \n2: ─├○─┤  \n3: ─╰X─┤  "),
     (qml.CNOT(wires=(0, 1)), "0: ─╭●─┤  \n1: ─╰X─┤  "),
     (qml.Toffoli(wires=(0, 1, 2)), "0: ─╭●─┤  \n1: ─├●─┤  \n2: ─╰X─┤  "),
     (qml.Barrier(wires=(0, 1, 2)), "0: ─╭||─┤  \n1: ─├||─┤  \n2: ─╰||─┤  "),

--- a/tests/drawer/test_tape_text.py
+++ b/tests/drawer/test_tape_text.py
@@ -242,7 +242,7 @@ class TestMaxLength:
 
 
 single_op_tests_data = [
-    (qml.MultiControlledX([0, 1, 2], 3, '010'), "0: ─╭○─┤  \n1: ─├●─┤  \n2: ─├○─┤  \n3: ─╰X─┤  "),
+    (qml.MultiControlledX([0, 1, 2], 3, "010"), "0: ─╭○─┤  \n1: ─├●─┤  \n2: ─├○─┤  \n3: ─╰X─┤  "),
     (qml.CNOT(wires=(0, 1)), "0: ─╭●─┤  \n1: ─╰X─┤  "),
     (qml.Toffoli(wires=(0, 1, 2)), "0: ─╭●─┤  \n1: ─├●─┤  \n2: ─╰X─┤  "),
     (qml.Barrier(wires=(0, 1, 2)), "0: ─╭||─┤  \n1: ─├||─┤  \n2: ─╰||─┤  "),

--- a/tests/interfaces/test_tensorflow_qnode.py
+++ b/tests/interfaces/test_tensorflow_qnode.py
@@ -126,7 +126,7 @@ class TestQNode:
             return qml.state()
 
         result = qml.draw(circuit)(p1=x, p3=z)
-        expected = "0: ──RX(0.10)──RX(0.40)─╭C─┤  State\n" "1: ──RY(0.06)───────────╰X─┤  State"
+        expected = "0: ──RX(0.10)──RX(0.40)─╭●─┤  State\n" "1: ──RY(0.06)───────────╰X─┤  State"
         assert result == expected
 
     def test_jacobian(self, dev_name, diff_method, mode, mocker, tol):

--- a/tests/interfaces/test_torch_qnode.py
+++ b/tests/interfaces/test_torch_qnode.py
@@ -120,7 +120,7 @@ class TestQNode:
         circuit(p1=x, p3=z)
 
         result = qml.draw(circuit)(p1=x, p3=z)
-        expected = "0: ──RX(0.10)──RX(0.40)─╭C─┤  <Z>\n" "1: ──RY(0.06)───────────╰X─┤  <Z>"
+        expected = "0: ──RX(0.10)──RX(0.40)─╭●─┤  <Z>\n" "1: ──RY(0.06)───────────╰X─┤  <Z>"
 
         assert result == expected
 

--- a/tests/transforms/test_defer_measurements.py
+++ b/tests/transforms/test_defer_measurements.py
@@ -804,8 +804,8 @@ class TestDrawing:
         transformed_qnode = qml.QNode(transformed_qfunc, dev)
 
         expected = (
-            "0: ─╭C────────────────────────────────────────────────────┤     \n"
+            "0: ─╭●────────────────────────────────────────────────────┤     \n"
             "1: ─╰ControlledOperation(0.31)─╭ControlledOperation(0.31)─┤  <Z>\n"
-            "2: ────────────────────────────╰C─────────────────────────┤     "
+            "2: ────────────────────────────╰●─────────────────────────┤     "
         )
         assert qml.draw(transformed_qnode)() == expected


### PR DESCRIPTION
**Context:**
Text drawing had no difference between 0 and 1 control values. Similarly, mpl drawer was missing `ControlledQubitUnitary` in its special cases
**Description of the Change:**
Changes text drawer to have different symbols for 0 and 1 control values. ~~Also, add `ControlledQubitUnitary` as a special case in mpl drawer.~~ Adds logic in mpl drawer to consider `control_values`
**Benefits:**
Better visual circuits.
**Possible Drawbacks:**

**Related GitHub Issues:**
Closes #2660 