### PR TITLE
Update `test_returns_state` in the device test suite

### DIFF
--- a/pennylane/devices/tests/test_properties.py
+++ b/pennylane/devices/tests/test_properties.py
@@ -221,25 +221,24 @@ class TestCapabilities:
         dev = qml.device(**device_kwargs)
         cap = dev.capabilities()
 
-        if "returns_state" not in cap:
-            pytest.skip("No returns_state capability specified by device.")
-
         @qml.qnode(dev)
         def circuit():
             qml.PauliX(wires=0)
             return qml.state()
 
-        circuit()
+        if not cap.get("returns_state"):
+            with pytest.raises(qml.QuantumFunctionError):
+                circuit()
 
-        if cap["returns_state"]:
-            assert dev.state is not None
-        else:
             try:
                 state = dev.state
             except AttributeError:
                 state = None
 
             assert state is None
+        else:
+            circuit()
+            assert dev.state is not None
 
     def test_returns_probs(self, device_kwargs):
         """Tests that the device reports correctly whether it supports reversible differentiation."""


### PR DESCRIPTION
**Context**
The `test_returns_state` test case from the device test suite contains logic that would fail if a device has `returns_state=False` set explicitly. This issue hasn't arisen before because we don't have such qubit devices in our ecosystem (as the devices would simply not set the define the `returns_state` key in their `capabilities`.

**Changes**

Changes `test_returns_state`.

**Checking this PR**

The `temp_state_false` branch in PennyLane-Qiskit contains a small modification of the Aer device that sets `returns_state=False`.

Checking out the branch for this PR and the `temp_state_false` branch in PennyLane-Qiskit allows running
`pl-device-test --device=qiskit.aer --tb=short --skip-ops --shots=None -k 'test_returns_state'` for a check to the correctness of this PR.