### PR TITLE
Adding batching support for symbolic operators

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -185,7 +185,7 @@
 * The adjoint transform `adjoint` can now accept either a single instantiated operator or
   a quantum function. It returns an entity of the same type/ call signature as what it was given:
   [(#2222)](https://github.com/PennyLaneAI/pennylane/pull/2222)
-
+  [(#2672)](https://github.com/PennyLaneAI/pennylane/pull/2672)
   ```pycon
   >>> qml.adjoint(qml.PauliX(0))
   Adjoint(PauliX)(wires=[0])

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -186,6 +186,7 @@
   a quantum function. It returns an entity of the same type/ call signature as what it was given:
   [(#2222)](https://github.com/PennyLaneAI/pennylane/pull/2222)
   [(#2672)](https://github.com/PennyLaneAI/pennylane/pull/2672)
+
   ```pycon
   >>> qml.adjoint(qml.PauliX(0))
   Adjoint(PauliX)(wires=[0])

--- a/pennylane/ops/op_math/adjoint_class.py
+++ b/pennylane/ops/op_math/adjoint_class.py
@@ -257,6 +257,18 @@ class Adjoint(Operator):
     def num_wires(self):
         return self.base.num_wires
 
+    @property
+    def batch_size(self):
+        return self.base.batch_size
+
+    @property
+    def ndim_params(self):
+        return self.base.ndim_params
+
+    @property
+    def is_hermitian(self):
+        return self.base.is_hermitian
+
     def queue(self, context=QueuingContext):
         context.safe_update_info(self.base, owner=self)
         context.append(self, owns=self.base)

--- a/pennylane/ops/op_math/pow_class.py
+++ b/pennylane/ops/op_math/pow_class.py
@@ -217,6 +217,14 @@ class Pow(Operator):
         self.base._wires = new_wires
 
     @property
+    def batch_size(self):
+        return self.base.batch_size
+
+    @property
+    def ndim_params(self):
+        return self.base.ndim_params
+
+    @property
     def num_wires(self):
         return len(self.wires)
 

--- a/tests/ops/op_math/test_adjoint_op.py
+++ b/tests/ops/op_math/test_adjoint_op.py
@@ -223,6 +223,33 @@ class TestProperties:
         op._wires = wire1
         assert op._wires == base._wires == wire1
 
+    @pytest.mark.parametrize("value", (True, False))
+    def test_is_hermitian(self, value):
+        """Test `is_hermitian` property mirrors that of the base."""
+
+        class DummyOp(qml.operation.Operator):
+            num_wires = 1
+            is_hermitian = value
+
+        op = Adjoint(DummyOp(0))
+        assert op.is_hermitian == value
+
+    def test_batching_properties(self):
+        """Test that Adjoint batching behavior mirrors that of the base."""
+
+        class DummyOp(qml.operation.Operator):
+            ndim_params = (0, 2)
+            num_wires = 1
+
+        param1 = [0.3] * 3
+        param2 = [[[0.3, 1.2]]] * 3
+
+        base = DummyOp(param1, param2, wires=0)
+        op = Adjoint(base)
+
+        assert op.ndim_params == (0, 2)
+        assert op.batch_size == 3
+
 
 class TestMiscMethods:
     """Test miscellaneous small methods on the Adjoint class."""


### PR DESCRIPTION
This PR updates the `Adjoint` and `Pow` symbolic operators to also have the new `ndim_params` and `batch_size` properties added recently in #2575.  It also adds the `is_hermitian` property to the `Adjoint` symbolic operator.

This PR should fix the failing build for the `tutorial_classical_kernels.py` demo.