### PR TITLE
Quantumfisher

### DIFF
--- a/pennylane/qinfo/__init__.py
+++ b/pennylane/qinfo/__init__.py
@@ -16,4 +16,4 @@
 
 from .utils import *
 from .entropies import *
-from .fisher import classical_fisher, _compute_cfim, _make_probs
+from .fisher import classical_fisher, quantum_fisher, _compute_cfim, _make_probs

--- a/pennylane/qinfo/fisher.py
+++ b/pennylane/qinfo/fisher.py
@@ -252,6 +252,9 @@ def quantum_fisher(*args, **kwargs):
     with short notation :math:`| \partial_j \psi(\bm{\theta}) \rangle := \frac{\partial}{\partial \theta_j}| \psi(\bm{\theta}) \rangle`.
 
     for :math:`N` qubits.
+
+    .. note::
+        ``quantum_fisher()`` is simply calling :func:`metric_tensor`, to which we refer for implementation details.
     """
     def wrapper(*args0, **kwargs0):
         return 4 * qml.metric_tensor(*args, **kwargs)(*args0, **kwargs0)

--- a/pennylane/qinfo/fisher.py
+++ b/pennylane/qinfo/fisher.py
@@ -251,11 +251,9 @@ def quantum_fisher(*args, **kwargs):
     
     with short notation :math:`| \partial_j \psi(\bm{\theta}) \rangle := \frac{\partial}{\partial \theta_j}| \psi(\bm{\theta}) \rangle`.
 
-    for :math:`N` qubits.
-
     .. note::
-        ``quantum_fisher()`` is simply calling :func:`metric_tensor`, to which we refer for implementation details.
+        ``quantum_fisher()`` is simply calling :func:`~.metric_tensor`, to which we refer for implementation details.
     """
     def wrapper(*args0, **kwargs0):
-        return 4 * qml.metric_tensor(*args, **kwargs)(*args0, **kwargs0)
+        return 4 * metric_tensor(*args, **kwargs)(*args0, **kwargs0)
     return wrapper

--- a/pennylane/transforms/metric_tensor.py
+++ b/pennylane/transforms/metric_tensor.py
@@ -37,6 +37,16 @@ def expand_fn(tape, approx=None, allow_nonunitary=True, aux_wire=None, device_wi
 def metric_tensor(tape, approx=None, allow_nonunitary=True, aux_wire=None, device_wires=None):
     r"""Returns a function that computes the metric tensor of a given QNode or quantum tape.
 
+    The metric tensor convention we employ here has the following form:
+
+    .. math::
+
+        \text{metric_tensor}_{i, j} = \text{Re}\left[ \langle \partial_i \psi(\bm{\theta}) | \partial_j \psi(\bm{\theta}) \rangle
+        - \langle \partial_i \psi(\bm{\theta}) | \psi(\bm{\theta}) \rangle \langle \psi(\bm{\theta}) | \partial_j \psi(\bm{\theta}) \rangle \right]
+    
+    with short notation :math:`| \partial_j \psi(\bm{\theta}) \rangle := \frac{\partial}{\partial \theta_j}| \psi(\bm{\theta}) \rangle`.
+    It is closely related to the quantum fisher information matrix, see :func:`~.qinfo.quantum_fisher` and eq. (26) in `arxiv:2103.15191 <https://arxiv.org/abs/2103.15191>`_.
+
     .. note::
 
         Only gates that have a single parameter and define a ``generator`` are supported.


### PR DESCRIPTION
**Context:**

Added a dummy function `qml.qinfo.quantum_fisher` that internally calls `qml.metric_tensor` and multiplies the result by 4 to have the same scaling factor as in eq. (27) in [2103.15191](https://arxiv.org/abs/2103.15191v3).

Additionally, I modified the doc-string of `qml.metric_tensor` accordingly.
