### PR TITLE
remove old entry in changelog about broadcasting

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -302,13 +302,6 @@
   0.9905158135644924
   ```
   
-
-* Operators have new attributes `ndim_params` and `batch_size`, and `QuantumTapes` have the new
-  attribute `batch_size`.
-  - `Operator.ndim_params` contains the expected number of dimensions per parameter of the operator,
-  - `Operator.batch_size` contains the size of an additional parameter broadcasting axis, if present,
-  - `QuantumTape.batch_size` contains the `batch_size` of its operations (see below).
-  
 * New `solarized_light` and `solarized_dark` styles available for drawing circuit diagram graphics. 
   [(#2662)](https://github.com/PennyLaneAI/pennylane/pull/2662)
   
@@ -321,7 +314,6 @@
   ```
 
 * Parameter broadcasting within operations and tapes was introduced.
-
   [(#2575)](https://github.com/PennyLaneAI/pennylane/pull/2575)
   [(#2590)](https://github.com/PennyLaneAI/pennylane/pull/2590)
   [(#2609)](https://github.com/PennyLaneAI/pennylane/pull/2609)


### PR DESCRIPTION
Removes an excess entry in the changelog that by accident was not removed during a merge.

@antalszava It seems that currently your name is the only one not sorted in the contributors list according to first name, if I'm not mistaken. Is this intentional? :)

Also, @WingCode is entered with the GitHub handle instead of the full name. Is this intentional? :)