### PR TITLE
Exclude `changelog-dev.md` in the rc sync process

### DIFF
--- a/.github/workflows/rc_sync.yml
+++ b/.github/workflows/rc_sync.yml
@@ -53,6 +53,7 @@ jobs:
           # Exclude some files known to be divergent during the release process from the PR
           git checkout master -- pennylane/_version.py
           git checkout master -- doc/development/release_notes.md
+          git checkout master -- doc/releases/changelog-dev.md
           git config user.name "GitHub Actions Bot"
           git config user.email "<>"
           git commit -m "exclude files from pr"


### PR DESCRIPTION
The daily sync PRs merging rc to `master` may update the `changelog-dev.md` file in a way that's not desirable.

See the following commit for example: https://github.com/PennyLaneAI/pennylane/pull/2713/commits/38b3242d664b2b274d07080634d9c191e6b789f8

This PR excludes the `changelog-dev.md` file from the synced files.