### PR TITLE
Use `access_state` device test

### DIFF
--- a/pennylane/devices/tests/test_properties.py
+++ b/pennylane/devices/tests/test_properties.py
@@ -227,8 +227,11 @@ class TestCapabilities:
             return qml.state()
 
         if not cap.get("returns_state"):
+
+            # If the device is not defined to return state then the
+            # access_state method should raise
             with pytest.raises(qml.QuantumFunctionError):
-                circuit()
+                dev.access_state()
 
             try:
                 state = dev.state


### PR DESCRIPTION
Another update to the `returns_state` functionality test (prev. in #2671). Some plugins may have custom circuit validation when evaluating a QNode that has not been accounted for in the device test (e.g., Braket). Therefore, the test case now calls on the `access_state` method of `QubitDevice`.

Tested locally via:
```bash
pl-device-test --device=braket.local.qubit --tb=short --skip-ops --shots=20000 -k 'returns_state'
pl-device-test --device=braket.local.qubit --tb=short --skip-ops -k 'returns_state'
pl-device-test --device=cirq.simulator --tb=short --skip-ops --shots=None -k 'returns_state'
pl-device-test --device=cirq.simulator --tb=short --skip-ops --shots=20000 -k 'returns_state'
pl-device-test --device=cirq.mixedsimulator --tb=short --skip-ops --shots=None -k 'returns_state'
pl-device-test --device=cirq.mixedsimulator --tb=short --skip-ops --shots=20000 -k 'returns_state'
pl-device-test --device=cirq.qsim --tb=short --skip-ops --analytic=False --shots=20000 -k 'returns_state'
pl-device-test --device=forest.numpy_wavefunction --tb=short --skip-ops --shots=None -k 'returns_state'
pl-device-test --device=forest.wavefunction --tb=short --skip-ops --shots=20000 -k 'returns_state'
pl-device-test --device=forest.numpy_wavefunction --tb=short --skip-ops --shots=None -k 'returns_state'
pl-device-test --device=forest.wavefunction --tb=short --skip-ops --shots=20000 -k 'returns_state'
pl-device-test --device=qiskit.basicaer --tb=short --skip-ops --shots=20000 --device-kwargs backend=qasm_simulator -k 'returns_state'
pl-device-test --device=qiskit.aer --tb=short --skip-ops --shots=20000 -k 'returns_state'
pl-device-test --device=qiskit.basicaer --tb=short --skip-ops --shots=None --device-kwargs backend=statevector_simulator -k 'returns_state'
pl-device-test --device=qiskit.aer --tb=short --skip-ops --shots=None --device-kwargs backend=aer_simulator_unitary -k 'returns_state'
pl-device-test --device=ionq.simulator --tb=short --skip-ops --shots=10000 -k 'returns_state'
```