### PR TITLE
Move summary line of ExpvalCost docstring

### DIFF
--- a/pennylane/vqe/vqe.py
+++ b/pennylane/vqe/vqe.py
@@ -25,6 +25,10 @@ from pennylane import numpy as np
 
 class ExpvalCost:
     """
+    Create a cost function that gives the expectation value of an input Hamiltonian.
+
+    This cost function is useful for a range of problems including VQE and QAOA.
+
     .. warning::
         ``ExpvalCost`` is deprecated. Instead, it is recommended to simply
         pass Hamiltonians to the :func:`~.expval` function inside QNodes.
@@ -37,10 +41,6 @@ class ExpvalCost:
                 return qml.expval(Hamiltonian)
 
         In order to optimize the Hamiltonian evaluation taking into account commuting terms, use the ``grouping_type`` keyword in :class:`~.Hamiltonian`.
-
-    Create a cost function that gives the expectation value of an input Hamiltonian.
-
-    This cost function is useful for a range of problems including VQE and QAOA.
 
     Args:
         ansatz (callable): The ansatz for the circuit before the final measurement step.


### PR DESCRIPTION
**Context:**
The "one sentence" summary of `ExpvalCost` is no longer showing up at on the main page of the docs.

**Description of the Change:**
Move the summary before the deprecation warning.