### PR TITLE
Wires were not being updated for a hamiltonian when using in place addition

### DIFF
--- a/pennylane/ops/qubit/hamiltonian.py
+++ b/pennylane/ops/qubit/hamiltonian.py
@@ -396,6 +396,7 @@ class Hamiltonian(Observable):
 
         self._coeffs = qml.math.stack(new_coeffs) if new_coeffs else []
         self._ops = new_ops
+        self._wires = self._wires = qml.wires.Wires.all_wires([op.wires for op in self.ops], sort=True)
         # reset grouping, since the indices refer to the old observables and coefficients
         self._grouping_indices = None
 
@@ -619,18 +620,19 @@ class Hamiltonian(Observable):
         if isinstance(H, Hamiltonian):
             self._coeffs = qml.math.concatenate([self._coeffs, H.coeffs], axis=0)
             self._ops.extend(H.ops.copy())
-            self.simplify()
-            return self
 
-        if isinstance(H, (Tensor, Observable)):
+        elif isinstance(H, (Tensor, Observable)):
             self._coeffs = qml.math.concatenate(
                 [self._coeffs, qml.math.cast_like([1.0], self._coeffs)], axis=0
             )
             self._ops.append(H)
-            self.simplify()
-            return self
 
-        raise ValueError(f"Cannot add Hamiltonian and {type(H)}")
+        else:
+            raise ValueError(f"Cannot add Hamiltonian and {type(H)}")
+
+        self._wires = qml.wires.Wires.all_wires([op.wires for op in self.ops], sort=True)
+        self.simplify()
+        return self
 
     def __imul__(self, a):
         r"""The inplace scalar multiplication operation between a scalar and a Hamiltonian."""

--- a/tests/ops/qubit/test_hamiltonian.py
+++ b/tests/ops/qubit/test_hamiltonian.py
@@ -266,6 +266,12 @@ add_hamiltonians = [
             np.array([qml.PauliX(0), qml.PauliZ(1), qml.PauliX(2), qml.PauliX(1)]),
         ),
     ),
+    # Case where the first Hamiltonian does not cover all wires
+    (
+        qml.Hamiltonian([1.23, -4.56], [qml.PauliZ(0), qml.Identity(2)]),
+        qml.Hamiltonian([3.14, 1.0], [qml.PauliZ(0), qml.PauliX(1)]),
+        qml.Hamiltonian([4.37, 1.0, -4.56], [qml.PauliZ(0), qml.PauliX(1), qml.Identity(2)]),
+    ),
 ]
 
 add_zero_hamiltonians = [
@@ -808,16 +814,20 @@ class TestHamiltonian:
         """Tests that Hamiltonians are added inline correctly"""
         H1 += H2
         assert H.compare(H1)
+        assert H.wires == H1.wires
 
     @pytest.mark.parametrize(("H1", "H2"), iadd_zero_hamiltonians)
     def test_hamiltonian_iadd_zero(self, H1, H2):
         """Tests in-place addition between Hamiltonians and zero"""
         H1 += 0
         assert H1.compare(H2)
+        assert H2.wires == H1.wires
         H1 += 0.0
         assert H1.compare(H2)
+        assert H2.wires == H1.wires
         H1 += 0e1
         assert H1.compare(H2)
+        assert H2.wires == H1.wires
 
     @pytest.mark.parametrize(("coeff", "H", "res"), mul_hamiltonians)
     def test_hamiltonian_imul(self, coeff, H, res):
@@ -830,6 +840,7 @@ class TestHamiltonian:
         """Tests that Hamiltonians are subtracted inline correctly"""
         H1 -= H2
         assert H.compare(H1)
+        assert H.wires == H1.wires
 
     def test_arithmetic_errors(self):
         """Tests that the arithmetic operations thrown the correct errors"""


### PR DESCRIPTION
**Context:**
Given a hamiltonian object, if one were to perform in-place addition, the `h.wires` attribute was not updated to consider new wires from the added hamiltonian. 

eg. 

```
>>> H = qml.Hamiltonian([1., 2.], [qml.PauliX(0), qml.PauliY(1)])
>>> H2 = qml.Hamiltonian([1.], [qml.PauliZ(2)])
>>>
>>> H += H2 
>>> print(H.wires)
<Wires = [0, 1]>  
>>> # should be <Wires = [0, 1, 2]>
```

**Description of the Change:**
Added logic which updates `H.wires` once an in place addition has occurred. 
