### PR TITLE
Wires not updated for a hamiltonian with in-place addition

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -737,6 +737,9 @@
   gates within a template.
   [(#2704)](https://github.com/PennyLaneAI/pennylane/pull/2704)
 
+* `Hamiltonian.wires` is now properly updated after in place operations.
+  [(#2738)](https://github.com/PennyLaneAI/pennylane/pull/2738)
+
 <h3>Deprecations</h3>
 
 * Deprecating ExpvalCost by adding a UserWarning.

--- a/pennylane/ops/qubit/hamiltonian.py
+++ b/pennylane/ops/qubit/hamiltonian.py
@@ -396,6 +396,7 @@ class Hamiltonian(Observable):
 
         self._coeffs = qml.math.stack(new_coeffs) if new_coeffs else []
         self._ops = new_ops
+        self._wires = qml.wires.Wires.all_wires([op.wires for op in self.ops], sort=True)
         # reset grouping, since the indices refer to the old observables and coefficients
         self._grouping_indices = None
 

--- a/pennylane/vqe/vqe.py
+++ b/pennylane/vqe/vqe.py
@@ -25,6 +25,10 @@ from pennylane import numpy as np
 
 class ExpvalCost:
     """
+    Create a cost function that gives the expectation value of an input Hamiltonian.
+
+    This cost function is useful for a range of problems including VQE and QAOA.
+
     .. warning::
         ``ExpvalCost`` is deprecated. Instead, it is recommended to simply
         pass Hamiltonians to the :func:`~.expval` function inside QNodes.
@@ -37,10 +41,6 @@ class ExpvalCost:
                 return qml.expval(Hamiltonian)
 
         In order to optimize the Hamiltonian evaluation taking into account commuting terms, use the ``grouping_type`` keyword in :class:`~.Hamiltonian`.
-
-    Create a cost function that gives the expectation value of an input Hamiltonian.
-
-    This cost function is useful for a range of problems including VQE and QAOA.
 
     Args:
         ansatz (callable): The ansatz for the circuit before the final measurement step.

--- a/tests/ops/qubit/test_hamiltonian.py
+++ b/tests/ops/qubit/test_hamiltonian.py
@@ -266,6 +266,12 @@ add_hamiltonians = [
             np.array([qml.PauliX(0), qml.PauliZ(1), qml.PauliX(2), qml.PauliX(1)]),
         ),
     ),
+    # Case where the 1st hamiltonian doesn't contain all wires
+    (
+        qml.Hamiltonian([1.23, -3.45], [qml.PauliX(0), qml.PauliY(1)]),
+        qml.Hamiltonian([6.78], [qml.PauliZ(2)]),
+        qml.Hamiltonian([1.23, -3.45, 6.78], [qml.PauliX(0), qml.PauliY(1), qml.PauliZ(2)]),
+    ),
 ]
 
 add_zero_hamiltonians = [
@@ -360,6 +366,12 @@ sub_hamiltonians = [
             (0.5, 1.2, -1.5, -0.3),
             np.array([qml.PauliX(0), qml.PauliZ(1), qml.PauliX(2), qml.PauliX(1)]),
         ),
+    ),
+    # Case where the 1st hamiltonian doesn't contain all wires
+    (
+        qml.Hamiltonian([1.23, -3.45], [qml.PauliX(0), qml.PauliY(1)]),
+        qml.Hamiltonian([6.78], [qml.PauliZ(2)]),
+        qml.Hamiltonian([1.23, -3.45, -6.78], [qml.PauliX(0), qml.PauliY(1), qml.PauliZ(2)]),
     ),
 ]
 
@@ -808,6 +820,7 @@ class TestHamiltonian:
         """Tests that Hamiltonians are added inline correctly"""
         H1 += H2
         assert H.compare(H1)
+        assert H.wires == H1.wires
 
     @pytest.mark.parametrize(("H1", "H2"), iadd_zero_hamiltonians)
     def test_hamiltonian_iadd_zero(self, H1, H2):
@@ -830,6 +843,7 @@ class TestHamiltonian:
         """Tests that Hamiltonians are subtracted inline correctly"""
         H1 -= H2
         assert H.compare(H1)
+        assert H.wires == H1.wires
 
     def test_arithmetic_errors(self):
         """Tests that the arithmetic operations thrown the correct errors"""


### PR DESCRIPTION
**Context:**
Given a hamiltonian object, if one were to perform in-place addition, the `h.wires` attribute was not updated to consider new wires from the added hamiltonian. 

eg. 

```
>>> H = qml.Hamiltonian([1., 2.], [qml.PauliX(0), qml.PauliY(1)])
>>> H2 = qml.Hamiltonian([1.], [qml.PauliZ(2)])
>>>
>>> H += H2 
>>> print(H.wires)
<Wires = [0, 1]>  
>>> # should be <Wires = [0, 1, 2]>
```

**Description of the Change:**
Added logic which updates `H.wires` once an in place addition has occurred. 

**Related GitHub Issues:**
Based on this user reported [issue](https://github.com/PennyLaneAI/pennylane/issues/2706)