### PR TITLE
[Bug] `qml.grouping.group_observables` support for utterable wire labels

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -54,6 +54,11 @@
 
 <h3>Documentation</h3>
 
+<h3>Bug fixes</h3>
+
+* `qml.grouping.group_observabeles` now works when individual wire
+  labels are iterable.
+
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane/grouping/utils.py
+++ b/pennylane/grouping/utils.py
@@ -289,7 +289,7 @@ def binary_to_pauli(binary_vector, wire_map=None):  # pylint: disable=too-many-b
 
     An arbitrary labelling can be assigned by using ``wire_map``:
 
-    >>> wire_map = {Wires('a'): 0, Wires('b'): 1, Wires('c'): 2}
+    >>> wire_map = {'a': 0, 'b': 1, 'c': 2}
     >>> binary_to_pauli([0,1,1,0,1,0], wire_map=wire_map)
     Tensor(PauliY(wires=['b']), PauliX(wires=['c']))
 
@@ -313,27 +313,27 @@ def binary_to_pauli(binary_vector, wire_map=None):  # pylint: disable=too-many-b
 
     n_qubits = len(binary_vector) // 2
 
-    if wire_map is not None:
+    if wire_map is None:
+        label_map = {i: i for i in range(n_qubits)}
+    else:
         if set(wire_map.values()) != set(range(n_qubits)):
             raise ValueError(
                 f"The values of wire_map must be integers 0 to N, for 2N-dimensional binary vector."
                 f" Instead got wire_map values: {wire_map.values()}"
             )
         label_map = {explicit_index: wire_label for wire_label, explicit_index in wire_map.items()}
-    else:
-        label_map = {i: Wires(i) for i in range(n_qubits)}
 
     pauli_word = None
     for i in range(n_qubits):
         operation = None
         if binary_vector[i] == 1 and binary_vector[n_qubits + i] == 0:
-            operation = PauliX(wires=label_map[i])
+            operation = PauliX(wires=Wires([label_map[i]]))
 
         elif binary_vector[i] == 1 and binary_vector[n_qubits + i] == 1:
-            operation = PauliY(wires=label_map[i])
+            operation = PauliY(wires=Wires([label_map[i]]))
 
         elif binary_vector[i] == 0 and binary_vector[n_qubits + i] == 1:
-            operation = PauliZ(wires=label_map[i])
+            operation = PauliZ(wires=Wires([label_map[i]]))
 
         if operation is not None:
             if pauli_word is None:

--- a/tests/grouping/test_group_observables.py
+++ b/tests/grouping/test_group_observables.py
@@ -144,6 +144,7 @@ observables_list = [
         PauliX("b") @ PauliZ("a"),
         PauliZ("a") @ PauliZ("b") @ PauliZ("c"),
     ],
+    [PauliX([(0, 0)]), PauliZ([(0, 0)])],
 ]
 
 qwc_sols = [
@@ -167,6 +168,7 @@ qwc_sols = [
         [PauliZ(wires=["a"]) @ PauliZ(wires=["b"]) @ PauliZ(wires=["c"])],
         [PauliX(wires=["a"]), PauliX(wires=["a"]) @ PauliZ(wires=["b"])],
     ],
+    [[PauliX([(0, 0)])], [PauliZ([(0, 0)])]],
 ]
 
 commuting_sols = [
@@ -190,6 +192,7 @@ commuting_sols = [
         [PauliX(wires=["a"]), PauliX(wires=["a"]) @ PauliZ(wires=["b"])],
         [PauliZ(wires=["a"]) @ PauliX(wires=["b"])],
     ],
+    [[PauliX([(0, 0)])], [PauliZ([(0, 0)])]],
 ]
 
 anticommuting_sols = [
@@ -215,6 +218,7 @@ anticommuting_sols = [
         ],
         [PauliX(wires=["a"]), PauliZ(wires=["a"]) @ PauliX(wires=["b"])],
     ],
+    [[PauliX([(0, 0)]), PauliZ([(0, 0)])]],
 ]
 
 
@@ -223,7 +227,7 @@ class TestGroupObservables:
     Tests for ``group_observables`` function using QWC, commuting, and anticommuting partitioning.
     """
 
-    qwc_tuples = [(obs, qwc_sols[i]) for i, obs in enumerate(observables_list)]
+    qwc_tuples = [(obs, sol) for obs, sol in zip(observables_list, qwc_sols)]
 
     @pytest.mark.parametrize("observables,qwc_partitions_sol", qwc_tuples)
     def test_qwc_partitioning(self, observables, qwc_partitions_sol):
@@ -242,7 +246,7 @@ class TestGroupObservables:
             for j, pauli in enumerate(partition):
                 assert are_identical_pauli_words(pauli, qwc_partitions_sol[i][j])
 
-    com_tuples = [(obs, commuting_sols[i]) for i, obs in enumerate(observables_list)]
+    com_tuples = [(obs, sol) for obs, sol in zip(observables_list, commuting_sols)]
 
     @pytest.mark.parametrize("observables,com_partitions_sol", com_tuples)
     def test_commuting_partitioning(self, observables, com_partitions_sol):
@@ -261,7 +265,7 @@ class TestGroupObservables:
             for j, pauli in enumerate(partition):
                 assert are_identical_pauli_words(pauli, com_partitions_sol[i][j])
 
-    anticom_tuples = [(obs, anticommuting_sols[i]) for i, obs in enumerate(observables_list)]
+    anticom_tuples = [(obs, sols) for obs, sols in zip(observables_list, anticommuting_sols)]
 
     @pytest.mark.parametrize("observables,anticom_partitions_sol", anticom_tuples)
     def test_anticommuting_partitioning(self, observables, anticom_partitions_sol):

--- a/tests/transforms/test_split_non_commuting.py
+++ b/tests/transforms/test_split_non_commuting.py
@@ -145,7 +145,6 @@ exp_grad = np.array(
 )
 
 
-@pytest.mark.all_interfaces
 class TestAutodiffSplitNonCommuting:
     """Autodiff tests for all frameworks"""
 


### PR DESCRIPTION
Solves #2748 

`qml.grouping.group_observables` now works when a wire label is an iterable, such as a tuple.

Such as in this code:
```
wires = [(0,0)]
dev = qml.device('default.qubit', wires=wires)

@qml.qnode(dev)
def circ():
    return qml.expval(qml.PauliZ([(0,0)])), qml.expval(qml.PauliX([(0,0)]))

circ()
```