### PR TITLE
[bugfix] adjoint of adjoint expands queues base operation

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -54,6 +54,10 @@
 
 <h3>Documentation</h3>
 
+<h3>Bug fixes</h3>
+
+* The adjoint of an adjoint has correct `expand` result.
+
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -56,7 +56,8 @@
 
 <h3>Bug fixes</h3>
 
-* The adjoint of an adjoint has correct `expand` result.
+* The adjoint of an adjoint has a correct `expand` result.
+  [(#2766)](https://github.com/PennyLaneAI/pennylane/pull/2766)
 
 <h3>Contributors</h3>
 

--- a/pennylane/ops/op_math/adjoint_class.py
+++ b/pennylane/ops/op_math/adjoint_class.py
@@ -310,7 +310,7 @@ class Adjoint(Operator):
         return self.base.has_matrix
 
     def adjoint(self):
-        return self.base
+        return self.base.queue()
 
     @property
     def _queue_category(self):

--- a/tests/ops/op_math/test_adjoint_op.py
+++ b/tests/ops/op_math/test_adjoint_op.py
@@ -608,6 +608,18 @@ class TestDecompositionExpand:
         with pytest.raises(qml.operation.DecompositionUndefinedError):
             Adjoint(base).decomposition()
 
+    def test_adjoint_of_adjoint(self):
+        """Test that the adjoint an adjoint returns the base operator through both decomposition and expand."""
+
+        base = qml.PauliX(0)
+        adj1 = Adjoint(base)
+        adj2 = Adjoint(adj1)
+
+        assert adj2.decomposition()[0] is base
+
+        tape = adj2.expand()
+        assert tape.circuit[0] is base
+
 
 class TestIntegration:
     """Test the integration of the Adjoint class with qnodes and gradients."""


### PR DESCRIPTION
Fixes #2765 

```pycon
>>> base = qml.PauliX(0)
>>> adj1 = qml.adjoint(base)
>>> adj2 = qml.adjoint(adj1)
>>> adj2.expand().circuit
[PauliX(wires=[0])]
```