### PR TITLE
Update test markers in qcut

### DIFF
--- a/tests/transforms/test_qcut.py
+++ b/tests/transforms/test_qcut.py
@@ -2732,6 +2732,7 @@ class TestContractTensors:
     )
     expected_grad = np.array([expected_grad_0, expected_grad_1])
 
+    @pytest.mark.autograd
     @pytest.mark.parametrize("use_opt_einsum", [True, False])
     def test_basic_grad_autograd(self, use_opt_einsum):
         """Test if the basic contraction is differentiable using the autograd interface"""
@@ -2750,6 +2751,7 @@ class TestContractTensors:
 
         assert np.allclose(grad, self.expected_grad)
 
+    @pytest.mark.torch
     @pytest.mark.parametrize("use_opt_einsum", [True, False])
     def test_basic_grad_torch(self, use_opt_einsum):
         """Test if the basic contraction is differentiable using the torch interface"""
@@ -2769,6 +2771,7 @@ class TestContractTensors:
 
         assert np.allclose(grad, self.expected_grad)
 
+    @pytest.mark.tf
     @pytest.mark.parametrize("use_opt_einsum", [True, False])
     def test_basic_grad_tf(self, use_opt_einsum):
         """Test if the basic contraction is differentiable using the tf interface"""
@@ -2788,6 +2791,7 @@ class TestContractTensors:
 
         assert np.allclose(grad, self.expected_grad)
 
+    @pytest.mark.jax
     @pytest.mark.parametrize("use_opt_einsum", [True, False])
     def test_basic_grad_jax(self, use_opt_einsum):
         """Test if the basic contraction is differentiable using the jax interface"""


### PR DESCRIPTION
**Description of the Change:**

There is some failing test if you run `pytest tests/` and some interfaces are not installed. We add corresponding markers to those tests.