### PR TITLE
Update QAOA test because of NumPy version 1.23.0

### DIFF
--- a/tests/test_qaoa.py
+++ b/tests/test_qaoa.py
@@ -1058,7 +1058,15 @@ class TestCostHamiltonians:
         cost_h, mixer_h, m = qaoa.max_weight_cycle(graph, constrained=constrained)
 
         assert mapping == m
-        assert decompose_hamiltonian(cost_hamiltonian) == decompose_hamiltonian(cost_h)
+
+        c1, t1, w1 = decompose_hamiltonian(cost_hamiltonian)
+        c2, t2, w2 = decompose_hamiltonian(cost_h)
+
+        # There may be a very small numeric difference in the coeffs
+        assert np.allclose(c1, c2)
+        assert t1 == t2
+        assert w1 == w2
+
         assert decompose_hamiltonian(mixer_hamiltonian) == decompose_hamiltonian(mixer_h)
 
     @pytest.mark.parametrize("constrained", [True, False])


### PR DESCRIPTION
One test case is failing with `numpy==1.23.0` due to a freshly failing equality check. The failure is due to potentially small differences in Hamiltonian coefficients ([see log here](https://github.com/PennyLaneAI/pennylane/runs/7015030142?check_suite_focus=true#step:11:246)), part of the error output:
```
E     Full diff:
E       [
E        -6.693147180559945,
E        -6.0,
E        -5.594534891891835,
E        -5.306852819440055,
E        -5.083709268125845,
E     -  -4.901387711331891,
E     ?                   -
E     +  -4.90138771133189,
E        54.0,
E        12.0,
E        -12.0,
E        -6.0,
E        -6.0,
E        -12.0,
E        6.0,
E        12.0,
E        -6.0,
E        -6.0,
E        -12.0,
E        6.0,
E        12.0,
E        -6.0,
E        -6.0,
E        6.0,
E       ]
```