### PR TITLE
Codecov: single upload for coverage reports

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -313,4 +313,4 @@ jobs:
         - name: Download reports from tests
           uses: actions/download-artifact@v2
         - name: Upload to Codecov
-          uses: codecov/codecov-action@v1
+          uses: codecov/codecov-action@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,7 +87,7 @@ jobs:
 
       - uses: actions/upload-artifact@v2
         with:
-          name: core-interfaces-coverage
+          name: core-interfaces-coverage-${{ matrix.config.suite }}-${{ matrix.config.python-version }}
           path: ./coverage.xml
 
   all-interfaces-tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -301,7 +301,7 @@ jobs:
 
       - uses: actions/upload-artifact@v2
         with:
-          name: devices-coverage
+          name: devices-coverage-${{ matrix.config.device }}-${{ matrix.config.shots }}
           path: ./coverage.xml
 
   upload-to-codecov:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -311,4 +311,6 @@ jobs:
         - name: Checkout
           uses: actions/checkout@v2
         - name: Download reports from tests
-          uses: codecov/codecov-action@v1
+          uses: actions/download-artifact@v2
+        - name: Upload to Codecov
+          uses: codecov/codecov-action@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -140,7 +140,7 @@ jobs:
           name: all-interfaces-coverage
           path: ./coverage.xml
 
-  qcut-tests:
+  qcut:
     runs-on: ubuntu-latest
 
     steps:
@@ -193,7 +193,7 @@ jobs:
           name: qcut-coverage
           path: ./coverage.xml
 
-  qchem-tests:
+  qchem:
     runs-on: ubuntu-latest
 
     steps:
@@ -305,10 +305,10 @@ jobs:
           path: ./coverage.xml
 
   upload-to-codecov:
-      needs: [core-and-interface-tests, all-interfaces-tests, qcut-tests, qchem-tests, device-tests]
+      needs: [core-and-interface-tests, all-interfaces-tests, qcut, qchem, device-tests]
       runs-on: ubuntu-latest
       steps:
         - name: Checkout
           uses: actions/checkout@v2
         - name: Download reports from tests
-          uses: codecov/codecov-action@v3
+          uses: codecov/codecov-action@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,10 +85,10 @@ jobs:
       - name: Adjust coverage file for Codecov
         run: bash <(sed -i 's/filename=\"/filename=\"pennylane\//g' coverage.xml)
 
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+      - uses: actions/upload-artifact@v2
         with:
-          file: ./coverage.xml
+          name: core-interfaces-coverage
+          path: ./coverage.xml
 
   all-interfaces-tests:
     runs-on: ubuntu-latest
@@ -135,12 +135,12 @@ jobs:
       - name: Adjust coverage file for Codecov
         run: bash <(sed -i 's/filename=\"/filename=\"pennylane\//g' coverage.xml)
 
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+      - uses: actions/upload-artifact@v2
         with:
-          file: ./coverage.xml
+          name: all-interfaces-coverage
+          path: ./coverage.xml
 
-  qcut:
+  qcut-tests:
     runs-on: ubuntu-latest
 
     steps:
@@ -188,12 +188,12 @@ jobs:
       - name: Adjust coverage file for Codecov
         run: bash <(sed -i 's/filename=\"/filename=\"pennylane\//g' coverage.xml)
 
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+      - uses: actions/upload-artifact@v2
         with:
-          file: ./coverage.xml
+          name: qcut-coverage
+          path: ./coverage.xml
 
-  qchem:
+  qchem-tests:
     runs-on: ubuntu-latest
 
     steps:
@@ -234,10 +234,10 @@ jobs:
       - name: Adjust coverage file for Codecov
         run: bash <(sed -i 's/filename=\"/filename=\"pennylane\//g' coverage.xml)
 
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+      - uses: actions/upload-artifact@v2
         with:
-          file: ./coverage.xml
+          name: qchem-coverage
+          path: ./coverage.xml
 
   device-tests:
     runs-on: ubuntu-latest
@@ -299,7 +299,18 @@ jobs:
       - name: Adjust coverage file for Codecov
         run: bash <(sed -i 's/filename=\"/filename=\"pennylane\//g' coverage.xml)
 
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+      - uses: actions/upload-artifact@v2
         with:
-          file: ./coverage.xml
+          name: devices-coverage
+          path: ./coverage.xml
+
+  upload-to-codecov:
+      needs: [core-and-interface-tests, all-interfaces-tests, qcut-tests, qchem-tests, device-tests]
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v2
+        - name: Download reports from tests
+          uses: actions/download-artifact@v2
+        - name: Upload to Codecov
+          uses: codecov/codecov-action@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -140,7 +140,7 @@ jobs:
           name: all-interfaces-coverage
           path: ./coverage.xml
 
-  qcut:
+  qcut-tests:
     runs-on: ubuntu-latest
 
     steps:
@@ -193,7 +193,7 @@ jobs:
           name: qcut-coverage
           path: ./coverage.xml
 
-  qchem:
+  qchem-tests:
     runs-on: ubuntu-latest
 
     steps:
@@ -305,7 +305,7 @@ jobs:
           path: ./coverage.xml
 
   upload-to-codecov:
-      needs: [core-and-interface-tests, all-interfaces-tests, qcut, qchem, device-tests]
+      needs: [core-and-interface-tests, all-interfaces-tests, qcut-tests, qchem-tests, device-tests]
       runs-on: ubuntu-latest
       steps:
         - name: Checkout

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -311,6 +311,4 @@ jobs:
         - name: Checkout
           uses: actions/checkout@v2
         - name: Download reports from tests
-          uses: actions/download-artifact@v2
-        - name: Upload to Codecov
           uses: codecov/codecov-action@v3

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,7 +3,7 @@ ignore:
 
 codecov:
   notify:
-    after_n_builds: 9
+    after_n_builds: 1
 
 comment:
-  after_n_builds: 9
+  after_n_builds: 1


### PR DESCRIPTION
**Context:**

Currently it upload the coverage report for every single job, creating temporary failed codecov action.

**Description of the Change:**

After each jobs create an artifact with the coverage report, at the end it creates a new job that is uploading the artifacts and it sends the coverages report to codecov all at once.