### PR TITLE
Add support for vmap and tf.function for channel ops

### DIFF
--- a/pennylane/math/single_dispatch.py
+++ b/pennylane/math/single_dispatch.py
@@ -77,6 +77,16 @@ ar.register_function("numpy", "eigvalsh", np.linalg.eigvalsh)
 ar.register_function("numpy", "entr", lambda x: -np.sum(x * np.log(x)))
 
 
+def _cond(pred, true_fn, false_fn, args):
+    if pred:
+        return true_fn(*args)
+    else:
+        return false_fn(*args)
+
+
+ar.register_function("numpy", "cond", _cond)
+
+
 # -------------------------------- Autograd --------------------------------- #
 
 
@@ -174,6 +184,7 @@ ar.register_function(
 )
 
 ar.register_function("autograd", "diagonal", lambda x, *args: _i("qml").numpy.diag(x))
+ar.register_function("autograd", "cond", _cond)
 
 
 # -------------------------------- TensorFlow --------------------------------- #
@@ -359,6 +370,29 @@ ar.register_function("tensorflow", "eigvalsh", _eigvalsh_tf)
 ar.register_function(
     "tensorflow", "entr", lambda x: -_i("tf").math.reduce_sum(x * _i("tf").math.log(x))
 )
+
+
+def _kron_tf(a, b):
+    import tensorflow as tf
+
+    a_shape = a.shape
+    b_shape = b.shape
+
+    a = a[:, tf.newaxis, :, tf.newaxis]
+    b = b[tf.newaxis, :, tf.newaxis, :]
+    return tf.reshape(a * b, (a_shape[0] * b_shape[0], a_shape[1] * b_shape[1]))
+
+
+ar.register_function("tensorflow", "kron", _kron_tf)
+
+
+def _cond_tf(pred, true_fn, false_fn, args):
+    import tensorflow as tf
+
+    return tf.cond(pred, lambda: true_fn(*args), lambda: false_fn(*args))
+
+
+ar.register_function("tensorflow", "cond", _cond_tf)
 
 
 # -------------------------------- Torch --------------------------------- #
@@ -577,6 +611,7 @@ def _sum_torch(tensor, axis=None, keepdims=False, dtype=None):
 
 
 ar.register_function("torch", "sum", _sum_torch)
+ar.register_function("torch", "cond", _cond)
 
 
 # -------------------------------- JAX --------------------------------- #
@@ -625,3 +660,9 @@ ar.register_function("jax", "unstack", list)
 # pylint: disable=unnecessary-lambda
 ar.register_function("jax", "eigvalsh", lambda x: _i("jax").numpy.linalg.eigvalsh(x))
 ar.register_function("jax", "entr", lambda x: _i("jax").numpy.sum(_i("jax").scipy.special.entr(x)))
+
+ar.register_function(
+    "jax",
+    "cond",
+    lambda pred, true_fn, false_fn, args: _i("jax").lax.cond(pred, true_fn, false_fn, *args),
+)

--- a/pennylane/math/utils.py
+++ b/pennylane/math/utils.py
@@ -135,7 +135,10 @@ def cast_like(tensor1, tensor2):
     >>> cast_like(x, y)
     tensor([1., 2.])
     """
-    dtype = ar.to_numpy(tensor2).dtype.type
+    if not is_abstract(tensor2):
+        dtype = ar.to_numpy(tensor2).dtype.type
+    else:
+        dtype = tensor2.dtype
     return cast(tensor1, dtype)
 
 

--- a/pennylane/ops/channel.py
+++ b/pennylane/ops/channel.py
@@ -79,7 +79,7 @@ class AmplitudeDamping(Channel):
         [array([[1., 0.], [0., 0.70710678]]),
          array([[0., 0.70710678], [0., 0.]])]
         """
-        if not 0.0 <= gamma <= 1.0:
+        if not np.is_abstract(gamma) and not 0.0 <= gamma <= 1.0:
             raise ValueError("gamma must be in the interval [0,1].")
 
         K0 = np.diag([1, np.sqrt(1 - gamma + np.eps)])
@@ -160,10 +160,10 @@ class GeneralizedAmplitudeDamping(Channel):
          array([[0.52915026, 0.        ], [0.        , 0.63245553]]),
          array([[0.        , 0.        ], [0.34641016, 0.        ]])]
         """
-        if not 0.0 <= gamma <= 1.0:
+        if not np.is_abstract(gamma) and not 0.0 <= gamma <= 1.0:
             raise ValueError("gamma must be in the interval [0,1].")
 
-        if not 0.0 <= p <= 1.0:
+        if not np.is_abstract(p) and not 0.0 <= p <= 1.0:
             raise ValueError("p must be in the interval [0,1].")
 
         K0 = np.sqrt(p + np.eps) * np.diag([1, np.sqrt(1 - gamma + np.eps)])
@@ -227,7 +227,7 @@ class PhaseDamping(Channel):
         [array([[1.        , 0.        ], [0.        , 0.70710678]]),
          array([[0.        , 0.        ], [0.        , 0.70710678]])]
         """
-        if not 0.0 <= gamma <= 1.0:
+        if not np.is_abstract(gamma) and not 0.0 <= gamma <= 1.0:
             raise ValueError("gamma must be in the interval [0,1].")
 
         K0 = np.diag([1, np.sqrt(1 - gamma + np.eps)])
@@ -317,7 +317,7 @@ class DepolarizingChannel(Channel):
          array([[0.+0.j        , 0.-0.40824829j], [0.+0.40824829j, 0.+0.j        ]]),
          array([[ 0.40824829,  0.        ], [ 0.        , -0.40824829]])]
         """
-        if not 0.0 <= p <= 1.0:
+        if not np.is_abstract(p) and not 0.0 <= p <= 1.0:
             raise ValueError("p must be in the interval [0,1]")
 
         K0 = np.sqrt(1 - p + np.eps) * np.eye(2)
@@ -383,7 +383,7 @@ class BitFlip(Channel):
         [array([[0.70710678, 0.        ], [0.        , 0.70710678]]),
          array([[0.        , 0.70710678], [0.70710678, 0.        ]])]
         """
-        if not 0.0 <= p <= 1.0:
+        if not np.is_abstract(p) and not 0.0 <= p <= 1.0:
             raise ValueError("p must be in the interval [0,1]")
 
         K0 = np.sqrt(1 - p + np.eps) * np.eye(2)
@@ -470,13 +470,13 @@ class ResetError(Channel):
          array([[0.        , 0.        ], [0.54772256, 0.        ]]),
          array([[0.        , 0.        ], [0.        , 0.54772256]])]
         """
-        if not 0.0 <= p_0 <= 1.0:
+        if not np.is_abstract(p_0) and not 0.0 <= p_0 <= 1.0:
             raise ValueError("p_0 must be in the interval [0,1]")
 
-        if not 0.0 <= p_1 <= 1.0:
+        if not np.is_abstract(p_1) and not 0.0 <= p_1 <= 1.0:
             raise ValueError("p_1 must be in the interval [0,1]")
 
-        if not 0.0 <= p_0 + p_1 <= 1.0:
+        if not np.is_abstract(p_0 + p_1) and not 0.0 <= p_0 + p_1 <= 1.0:
             raise ValueError("p_0 + p_1 must be in the interval [0,1]")
 
         K0 = np.sqrt(1 - p_0 - p_1 + np.eps) * np.eye(2)
@@ -550,7 +550,7 @@ class PauliError(Channel):
             raise ValueError("The specified operators need to be either of 'X', 'Y' or 'Z'")
 
         # check if probabilities are legal
-        if not 0.0 <= p <= 1.0:
+        if not np.is_abstract(p) and not 0.0 <= p <= 1.0:
             raise ValueError("p must be in the interval [0,1]")
 
         # check if the number of operators matches the number of wires
@@ -593,9 +593,9 @@ class PauliError(Channel):
         }
 
         # K1 is composed by Kraus matrices of operators
-        K1 = np.sqrt(p + np.eps) * np.array([1])
+        K1 = np.sqrt(p + np.eps) * np.array([[1]])
         for op in operators[::-1]:
-            K1 = np.kron(ops[op], K1)
+            K1 = np.multi_dispatch()(np.kron)(ops[op], K1)
 
         return [K0, K1]
 
@@ -656,7 +656,7 @@ class PhaseFlip(Channel):
         [array([[0.70710678, 0.        ], [0.        , 0.70710678]]),
          array([[ 0.70710678,  0.        ], [ 0.        , -0.70710678]])]
         """
-        if not 0.0 <= p <= 1.0:
+        if not np.is_abstract(p) and not 0.0 <= p <= 1.0:
             raise ValueError("p must be in the interval [0,1]")
 
         K0 = np.sqrt(1 - p + np.eps) * np.eye(2)
@@ -846,15 +846,15 @@ class ThermalRelaxationError(Channel):
          array([[-0.12718544,  0.        ], [ 0.        ,  0.13165421]]),
          array([[0.98784022, 0.        ], [0.        , 0.95430977]])]
         """
-        if not 0.0 <= pe <= 1.0:
+        if not np.is_abstract(pe) and not 0.0 <= pe <= 1.0:
             raise ValueError("pe must be between 0 and 1.")
-        if tg < 0:
+        if not np.is_abstract(tg) and tg < 0:
             raise ValueError(f"Invalid gate_time tg ({tg} < 0)")
-        if t1 <= 0:
+        if not np.is_abstract(t1) and t1 <= 0:
             raise ValueError("Invalid T_1 relaxation time parameter: T_1 <= 0.")
-        if t2 <= 0:
+        if not np.is_abstract(t2) and t2 <= 0:
             raise ValueError("Invalid T_2 relaxation time parameter: T_2 <= 0.")
-        if t2 - 2 * t1 > 0:
+        if not np.is_abstract(t2 - 2 * t1) and t2 - 2 * t1 > 0:
             raise ValueError("Invalid T_2 relaxation time parameter: T_2 greater than 2 * T_1.")
         # T1 relaxation rate
         eT1 = np.exp(-tg / t1)
@@ -862,7 +862,7 @@ class ThermalRelaxationError(Channel):
         # T2 dephasing rate
         eT2 = np.exp(-tg / t2)
 
-        if t2 <= t1:
+        def kraus_ops_small_t2():
             pz = (1 - p_reset) * (1 - eT2 / eT1) / 2
             pr0 = (1 - pe) * p_reset
             pr1 = pe * p_reset
@@ -875,8 +875,9 @@ class ThermalRelaxationError(Channel):
             K4 = np.sqrt(pr1 + np.eps) * np.array([[0, 0], [1, 0]])
             K5 = np.sqrt(pr1 + np.eps) * np.array([[0, 0], [0, 1]])
 
-            K = [K0, K1, K2, K3, K4, K5]
-        else:
+            return [K0, K1, K2, K3, K4, K5]
+
+        def kraus_ops_large_t2():
             e0 = p_reset * pe
             v0 = np.array([[0, 0], [1, 0]])
             K0 = np.sqrt(e0 + np.eps) * v0
@@ -892,14 +893,22 @@ class ThermalRelaxationError(Channel):
             )
             e2 = 1 - p_reset / 2 - common_term / 2
             term2 = 2 * eT2 / (2 * p_reset * pe - p_reset - common_term)
-            v2 = np.array([[term2, 0], [0, 1]]) / np.sqrt(term2**2 + 1)
+            v2 = (term2 * np.array([[1, 0], [0, 0]]) + np.array([[0, 0], [0, 1]])) / np.sqrt(
+                term2**2 + 1
+            )
             K2 = np.sqrt(e2 + np.eps) * v2
             term3 = 2 * eT2 / (2 * p_reset * pe - p_reset + common_term)
             e3 = 1 - p_reset / 2 + common_term / 2
-            v3 = np.array([[term3, 0], [0, 1]]) / np.sqrt(term3**2 + 1)
+            v3 = (term3 * np.array([[1, 0], [0, 0]]) + np.array([[0, 0], [0, 1]])) / np.sqrt(
+                term3**2 + 1
+            )
             K3 = np.sqrt(e3 + np.eps) * v3
+            K4 = np.cast_like(np.zeros((2, 2)), K1)
+            K5 = np.cast_like(np.zeros((2, 2)), K1)
 
-            K = [K0, K1, K2, K3]
+            return [K0, K1, K2, K3, K4, K5]
+
+        K = np.cond(t2 <= t1, kraus_ops_small_t2, kraus_ops_large_t2, ())
         return K
 
 

--- a/tests/devices/test_default_mixed_jax.py
+++ b/tests/devices/test_default_mixed_jax.py
@@ -640,3 +640,32 @@ class TestHighLevelIntegration:
 
         grad = jax.grad(cost)(weights)
         assert grad.shape == weights.shape
+
+    def test_vmap_channel_ops(self):
+        """Test that jax.vmap works for a QNode with channel ops"""
+        dev = qml.device("default.mixed", wires=1)
+
+        @qml.qnode(dev, diff_method="backprop", interface="jax")
+        def circuit(p):
+            qml.AmplitudeDamping(p, wires=0)
+            qml.GeneralizedAmplitudeDamping(p, p, wires=0)
+            qml.PhaseDamping(p, wires=0)
+            qml.DepolarizingChannel(p, wires=0)
+            qml.BitFlip(p, wires=0)
+            qml.ResetError(p, p, wires=0)
+            qml.PauliError("X", p, wires=0)
+            qml.PhaseFlip(p, wires=0)
+            qml.ThermalRelaxationError(p, p, p, 0.0001, wires=0)
+            return qml.expval(qml.PauliZ(0))
+
+        vcircuit = jax.vmap(circuit)
+
+        x = jnp.array([0.005, 0.01, 0.02, 0.05])
+        res = vcircuit(x)
+
+        # compare vmap results to results of individually executed circuits
+        expected = []
+        for x_indiv in x:
+            expected.append(circuit(x_indiv))
+
+        assert np.allclose(expected, res)


### PR DESCRIPTION
**Context:**
Part of the ongoing effort to extend functionality of the `default.mixed` device.

**Description of the Change:**
Now channel operations work with the `default.mixed` device for all QNodes, including those decorated with `jax.jit`, `jax.vmap`, and `tf.function`. 

Example with `jax.vmap`:
```python
dev = qml.device("default.mixed", wires=1)

@qml.qnode(dev, diff_method="backprop", interface="jax")
def circuit(p):
    qml.PauliX(wires=0)
    qml.ThermalRelaxationError(0.1, p, 1.4, 0.1, wires=0)
    return qml.expval(qml.PauliZ(0))
```
```pycon
>>> x = jnp.array([0.8, 1.0, 1.2])
>>> jax.vmap(circuit)(x)
DeviceArray([-0.78849435, -0.8287073 , -0.85608006], dtype=float32)
```

Example with `tf.function`:
```python
dev = qml.device("default.mixed", wires=1)

@qml.qnode(dev, diff_method="backprop", interface="tf")
def circuit(p):
    qml.PauliX(wires=0)
    qml.ThermalRelaxationError(0.1, p, 1.4, 0.1, wires=0)
    return qml.expval(qml.PauliZ(0))
```
```pycon
>>> x = tf.Variable(1.0)
>>> tf.function(circuit)(x)
<tf.Tensor: shape=(), dtype=float64, numpy=-0.8287073244190017>
```

**Benefits:**
Channel operations can now be used with `jax.jit`, `jax.vmap`, and `tf.function`.

**Possible Drawbacks:**

**Related GitHub Issues:**
Closes https://github.com/PennyLaneAI/pennylane/issues/1528
