### PR TITLE
Remove some test skips now that `default.mixed` supports backprop

### DIFF
--- a/tests/test_measurements.py
+++ b/tests/test_measurements.py
@@ -1217,9 +1217,6 @@ class TestDensityMatrix:
     @pytest.mark.parametrize("diff_method", [None, "backprop"])
     def test_correct_density_matrix_torch(self, dev_name, diff_method):
         """Test that the correct density matrix is returned using torch interface."""
-        if dev_name == "default.mixed" and diff_method == "backprop":
-            pytest.skip("Mixed device does not support backprop.")
-
         dev = qml.device(dev_name, wires=2)
 
         @qml.qnode(dev, interface="torch")
@@ -1238,9 +1235,6 @@ class TestDensityMatrix:
     @pytest.mark.parametrize("diff_method", [None, "backprop"])
     def test_correct_density_matrix_jax(self, dev_name, diff_method):
         """Test that the correct density matrix is returned using JAX interface."""
-        if dev_name == "default.mixed" and diff_method == "backprop":
-            pytest.skip("Mixed device does not support backprop.")
-
         dev = qml.device(dev_name, wires=2)
 
         @qml.qnode(dev, interface="jax", diff_method=diff_method)
@@ -1259,9 +1253,6 @@ class TestDensityMatrix:
     @pytest.mark.parametrize("diff_method", [None, "backprop"])
     def test_correct_density_matrix_tf(self, dev_name, diff_method):
         """Test that the correct density matrix is returned using the TensorFlow interface."""
-        if dev_name == "default.mixed" and diff_method == "backprop":
-            pytest.skip("Mixed device does not support backprop.")
-
         dev = qml.device(dev_name, wires=2)
 
         @qml.qnode(dev, interface="tf")


### PR DESCRIPTION
Not entirely sure why, but some tests set backprop for the forward pass with `default.mixed` and have been skipped before. Now we can allow these cases to work too.