### PR TITLE
Use custom `states_to_binary` method in `QubitDevice`'s

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -252,6 +252,10 @@
 
 <h3>Bug fixes</h3>
 
+* Fixes a bug where custom implementations of devices' `states_to_binary`
+  method was not used.
+  [(#27xx)](https://github.com/PennyLaneAI/pennylane/pull/27xx)
+  
 * `qml.grouping.group_observables` now works when individual wire
   labels are iterable.
   [(#2752)](https://github.com/PennyLaneAI/pennylane/pull/2752)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -254,7 +254,7 @@
 
 * Fixes a bug where custom implementations of devices' `states_to_binary`
   method was not used.
-  [(#27xx)](https://github.com/PennyLaneAI/pennylane/pull/27xx)
+  [(#2809)](https://github.com/PennyLaneAI/pennylane/pull/2809)
   
 * `qml.grouping.group_observables` now works when individual wire
   labels are iterable.
@@ -267,5 +267,6 @@
 
 This release contains contributions from (in alphabetical order):
 
-David Ittah, Edward Jiang, Ankit Khandelwal, Christina Lee, Sergio Martínez-Losa, Ixchel Meza Chavez, 
-Lee James O'Riordan, Mudit Pandey, Bogdan Reznychenko, Jay Soni, Antal Száva, Moritz Willmann
+David Ittah, Edward Jiang, Ankit Khandelwal, Christina Lee, Sergio Martínez-Losa,
+Ixchel Meza Chavez, Lee James O'Riordan, Mudit Pandey, Bogdan Reznychenko,
+Jay Soni, Antal Száva, David Wierichs, Moritz Willmann

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -254,7 +254,7 @@
 
 <h3>Bug fixes</h3>
 
-* Fixes a bug where custom implementations of devices' `states_to_binary`
+* Fixes a bug where the custom implementation of the `states_to_binary` device
   method was not used.
   [(#2809)](https://github.com/PennyLaneAI/pennylane/pull/2809)
   

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -605,7 +605,6 @@ class QubitDevice(Device):
         basis_states = np.arange(number_of_states)
         return np.random.choice(basis_states, shots, p=state_probability)
 
-    # @staticmethod
     def generate_basis_states(self, num_wires, dtype=np.uint32):
         """
         Generates basis states in binary representation according to the number

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -605,7 +605,7 @@ class QubitDevice(Device):
         basis_states = np.arange(number_of_states)
         return np.random.choice(basis_states, shots, p=state_probability)
 
-    #@staticmethod
+    # @staticmethod
     def generate_basis_states(self, num_wires, dtype=np.uint32):
         """
         Generates basis states in binary representation according to the number

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -579,7 +579,7 @@ class QubitDevice(Device):
         rotated_prob = self.analytic_probability()
 
         samples = self.sample_basis_states(number_of_states, rotated_prob)
-        return QubitDevice.states_to_binary(samples, self.num_wires)
+        return self.states_to_binary(samples, self.num_wires)
 
     def sample_basis_states(self, number_of_states, state_probability):
         """Sample from the computational basis states based on the state
@@ -605,8 +605,8 @@ class QubitDevice(Device):
         basis_states = np.arange(number_of_states)
         return np.random.choice(basis_states, shots, p=state_probability)
 
-    @staticmethod
-    def generate_basis_states(num_wires, dtype=np.uint32):
+    #@staticmethod
+    def generate_basis_states(self, num_wires, dtype=np.uint32):
         """
         Generates basis states in binary representation according to the number
         of wires specified.
@@ -634,7 +634,7 @@ class QubitDevice(Device):
         """
         if 2 < num_wires < 32:
             states_base_ten = np.arange(2**num_wires, dtype=dtype)
-            return QubitDevice.states_to_binary(states_base_ten, num_wires, dtype=dtype)
+            return self.states_to_binary(states_base_ten, num_wires, dtype=dtype)
 
         # A slower, but less memory intensive method
         basis_states_generator = itertools.product((0, 1), repeat=num_wires)

--- a/pennylane/_qutrit_device.py
+++ b/pennylane/_qutrit_device.py
@@ -104,10 +104,9 @@ class QutritDevice(QubitDevice):  # pylint: disable=too-many-public-methods
         rotated_prob = self.analytic_probability()
 
         samples = self.sample_basis_states(number_of_states, rotated_prob)
-        return QutritDevice.states_to_ternary(samples, self.num_wires)
+        return self.states_to_ternary(samples, self.num_wires)
 
-    @staticmethod
-    def generate_basis_states(num_wires, dtype=np.uint32):
+    def generate_basis_states(self, num_wires, dtype=np.uint32):
         """Generates basis states in ternary representation according to the number
         of wires specified.
 

--- a/tests/test_qubit_device.py
+++ b/tests/test_qubit_device.py
@@ -370,7 +370,7 @@ class TestGenerateSamples:
         with monkeypatch.context() as m:
             # Mock the auxiliary methods such that they return the expected values
             m.setattr(QubitDevice, "sample_basis_states", lambda self, wires, b: wires)
-            m.setattr(QubitDevice, "states_to_binary", lambda a, b: (a, b))
+            m.setattr(QubitDevice, "states_to_binary", staticmethod(lambda a, b: (a, b)))
             m.setattr(QubitDevice, "analytic_probability", lambda *args: None)
             m.setattr(QubitDevice, "shots", 1000)
             dev._samples = dev.generate_samples()

--- a/tests/test_qutrit_device.py
+++ b/tests/test_qutrit_device.py
@@ -340,7 +340,7 @@ class TestGenerateSamples:
         with monkeypatch.context() as m:
             # Mock the auxiliary methods such that they return the expected values
             m.setattr(QutritDevice, "sample_basis_states", lambda self, wires, b: wires)
-            m.setattr(QutritDevice, "states_to_ternary", lambda a, b: (a, b))
+            m.setattr(QutritDevice, "states_to_ternary", staticmethod(lambda a, b: (a, b)))
             m.setattr(QutritDevice, "analytic_probability", lambda *args: None)
             m.setattr(QutritDevice, "shots", 1000)
             dev._samples = dev.generate_samples()


### PR DESCRIPTION
This PR changes `QubitDevice.generate_samples` and `QubitDevice.generate_basis_states` to use `self.states_to_binary` instead of `QubitDevice.states_to_binary`.