### PR TITLE
Define dedicated `QubitDevice.sample` docstring

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -248,6 +248,9 @@
 
 <h3>Documentation</h3>
 
+* Added a dedicated docstring for the `QubitDevice.sample` method.
+  [(#2812)](https://github.com/PennyLaneAI/pennylane/pull/2812)
+
 * Optimization examples of using JAXopt and Optax with the JAX interface have
   been added.
   [(#2769)](https://github.com/PennyLaneAI/pennylane/pull/2769)

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -973,6 +973,26 @@ class QubitDevice(Device):
         return np.squeeze(np.var(samples, axis=0))
 
     def sample(self, observable, shot_range=None, bin_size=None, counts=False):
+        """Return samples of an observable.
+
+        Args:
+            observable (Observable): the observable to sample
+            shot_range (tuple[int]): 2-tuple of integers specifying the range of samples
+                to use. If not specified, all samples are used.
+            bin_size (int): Divides the shot range into bins of size ``bin_size``, and
+                returns the measurement statistic separately over each bin. If not
+                provided, the entire shot range is treated as a single bin.
+            counts (bool): whether counts (``True``) or raw samples (``False``)
+                should be returned
+
+        Raises:
+            EigvalsUndefinedError: if no information is available about the
+                eigenvalues of the observable
+
+        Returns:
+            Union[array[float], dict, list[dict]]: samples in an array of
+            dimension ``(shots,)`` or counts
+        """
         def _samples_to_counts(samples, no_observable_provided):
             """Group the obtained samples into a dictionary.
 

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -993,6 +993,7 @@ class QubitDevice(Device):
             Union[array[float], dict, list[dict]]: samples in an array of
             dimension ``(shots,)`` or counts
         """
+
         def _samples_to_counts(samples, no_observable_provided):
             """Group the obtained samples into a dictionary.
 


### PR DESCRIPTION
The `QubitDevice.sample` method differs from `Device.sample`. Yet, they have the same docstring.

This PR creates a custom `QubitDevice.sample` docstring.

Closes #2811