### PR TITLE
OpenFermion version < 1.4.0 is not compatible with Cirq 1.0.0

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -13,3 +13,4 @@ dask[delayed]
 autoray
 matplotlib
 opt_einsum
+openfermion==1.4.0


### PR DESCRIPTION
**Context:**
New Cirq release (v1.0.0) is incompatible with Openfermion (v<1.3.0). 

**Description of the Change:**
Pin openfermion==1.4.0
