### PR TITLE
Restructure `param_shift` and fix bug in unshifted term bookkeeping

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -277,8 +277,9 @@
 
 <h3>Bug fixes</h3>
 
-* Fixes a bug where the parameter-shift gradient breaks when using
-  custom `grad_recipe`'s that contain unshifted terms with those that do not.
+* Fixes a bug where the parameter-shift gradient breaks when using both
+  custom `grad_recipe`s that contain unshifted terms and recipes that
+  do not contains any unshifted terms.
   [(#2834)](https://github.com/PennyLaneAI/pennylane/pull/2834)
 
 * Fixes a bug where the parameter-shift Hessian of circuits with untrainable

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -277,6 +277,10 @@
 
 <h3>Bug fixes</h3>
 
+* Fixes a bug where the parameter-shift gradient breaks when using
+  custom `grad_recipe`'s that contain unshifted terms with those that do not.
+  [(#2834)](https://github.com/PennyLaneAI/pennylane/pull/2834)
+
 * Fixes a bug where the parameter-shift Hessian of circuits with untrainable
   parameters might be computed with respect to the wrong parameters or
   might raise an error.

--- a/pennylane/gradients/parameter_shift.py
+++ b/pennylane/gradients/parameter_shift.py
@@ -217,6 +217,8 @@ def expval_param_shift(tape, argnum=None, shifts=None, gradient_recipes=None, f0
     # Each entry for gradient_data will be a tuple with content
     # (num_tapes, coeffs, fn, unshifted_coeff)
     gradient_data = []
+    # Keep track of whether there is at least one unshifted
+    # term in the parameter-shift rules of all parameters
     at_least_one_unshifted = False
 
     for idx, _ in enumerate(tape.trainable_params):

--- a/pennylane/gradients/parameter_shift.py
+++ b/pennylane/gradients/parameter_shift.py
@@ -72,6 +72,7 @@ def _square_observable(obs):
 
     return NONINVOLUTORY_OBS[obs.name](obs)
 
+
 def _process_op_recipe(op, p_idx, order):
     """Process an existing recipe of an operation."""
     recipe = op.grad_recipe[p_idx]
@@ -203,7 +204,7 @@ def expval_param_shift(tape, argnum=None, shifts=None, gradient_recipes=None, f0
                     "Can only differentiate Hamiltonian "
                     f"coefficients for expectations, not {op.return_type.value}"
                 )
-            
+
             g_tapes, h_fn = qml.gradients.hamiltonian_grad(tape, idx)
             # hamiltonian_grad always returns a list with a single tape
             gradient_tapes.extend(g_tapes)

--- a/pennylane/gradients/parameter_shift.py
+++ b/pennylane/gradients/parameter_shift.py
@@ -77,7 +77,7 @@ def _process_op_recipe(op, p_idx, order):
     """Process an existing recipe of an operation."""
     recipe = op.grad_recipe[p_idx]
     if recipe is None:
-        return
+        return None
 
     recipe = qml.math.array(recipe)
     if order == 1:
@@ -113,7 +113,6 @@ def _choose_recipe(argnum, idx, gradient_recipes, shifts, tape):
 
 def _extract_unshifted(recipe, at_least_one_unshifted, f0, gradient_tapes, tape):
     first_c, first_m, first_s = recipe[0]
-    coeffs, multipliers, op_shifts = recipe.T
     # Extract zero-shift term if present (if so, it will always be the first)
     if first_s == 0 and first_m == 1:
         # Gradient recipe includes a term with zero shift.

--- a/tests/gradients/test_parameter_shift.py
+++ b/tests/gradients/test_parameter_shift.py
@@ -309,7 +309,8 @@ class TestParamShift:
         # two tapes per parameter that doesn't use a custom recipe,
         # one tape per parameter that uses custom recipe,
         # plus one global call if at least one uses the custom recipe
-        assert len(tapes) == 2 * tape.num_params + 1 - len(ops_with_custom_recipe)
+        num_ops_standard_recipe = tape.num_params - len(ops_with_custom_recipe)
+        assert len(tapes) == 2 * num_ops_standard_recipe + len(ops_with_custom_recipe) + 1
         # Test that executing the tapes and the postprocessing function works
         grad = fn(qml.execute(tapes, dev, None))
         assert qml.math.allclose(grad, -np.sin(x[0] + x[1]), atol=1e-5)

--- a/tests/gradients/test_parameter_shift.py
+++ b/tests/gradients/test_parameter_shift.py
@@ -300,13 +300,12 @@ class TestParamShift:
             qml.expval(qml.PauliZ(0))
 
         gradient_recipes = tuple(
-            [[-1e7, 1, 0], [1e7, 1, 1e7]] if i in ops_with_custom_recipe else None
-            for i in range(2)
+            [[-1e7, 1, 0], [1e7, 1, 1e7]] if i in ops_with_custom_recipe else None for i in range(2)
         )
         tapes, fn = qml.gradients.param_shift(tape, gradient_recipes=gradient_recipes)
 
         # two tapes per parameter that doesn't use a custom recipe,
-        # one tape per parameter that uses custom recipe, 
+        # one tape per parameter that uses custom recipe,
         # plus one global call if at least one uses the custom recipe
         assert len(tapes) == 2 * tape.num_params + 1 - len(ops_with_custom_recipe)
 
@@ -338,6 +337,7 @@ class TestParamShift:
 
         class RX(qml.RX):
             """RX operation with an additional (wrong) term in the grad recipe."""
+
             grad_recipe = ([[0.5, 1, np.pi / 2], [-0.5, 1, -np.pi / 2], [0.2, 1, 0]],)
 
         x = np.array([-0.361, 0.654], requires_grad=True)
@@ -360,7 +360,9 @@ class TestParamShift:
             assert tape.operations[1].data[0] == x[1] + expected[1]
 
         grad = fn(dev.batch_execute(tapes))
-        assert np.allclose(grad, [-np.sin(x[0]+x[1]), -np.sin(x[0]+x[1]) + 0.2 * np.cos(x[0]+x[1])])
+        assert np.allclose(
+            grad, [-np.sin(x[0] + x[1]), -np.sin(x[0] + x[1]) + 0.2 * np.cos(x[0] + x[1])]
+        )
 
     def test_independent_parameters_analytic(self):
         """Test the case where expectation values are independent of some parameters. For those

--- a/tests/gradients/test_parameter_shift.py
+++ b/tests/gradients/test_parameter_shift.py
@@ -346,6 +346,7 @@ class TestParamShift:
             The grad_recipe no longer yields the derivative, but we account for this.
             For this test, the presence of the unshifted term (with non-vanishing coefficient)
             is essential."""
+
             grad_recipe = ([[0.5, 1, s], [-0.5, 1, -s], [0.2, 1, 0]],)
 
         x = np.array([-0.361, 0.654], requires_grad=True)

--- a/tests/gradients/test_parameter_shift.py
+++ b/tests/gradients/test_parameter_shift.py
@@ -300,7 +300,8 @@ class TestParamShift:
             qml.expval(qml.PauliZ(0))
 
         gradient_recipes = tuple(
-            [[-1e7, 1, 0], [1e7, 1, 1e-7]] if i in ops_with_custom_recipe else None for i in range(2)
+            [[-1e7, 1, 0], [1e7, 1, 1e-7]] if i in ops_with_custom_recipe else None
+            for i in range(2)
         )
         tapes, fn = qml.gradients.param_shift(tape, gradient_recipes=gradient_recipes)
 


### PR DESCRIPTION
This PR restructures `param_shift`. In particular, it introduces additional helper methods, trying to modularize the main for loop of `expval_param_shift`.
In addition, this restructuring fixed #2833, as this bug was caused by flawed bookkeeping of unshifted coefficients (It worked for second order derivatives because usually then all operations require the unshifted tape.

Related issue: #2833 