### PR TITLE
Addition of operators and scalars + extra dunder methods

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -179,7 +179,7 @@
          [1., 5.]])
   ```
 
-* A `SProd` symbolic class is added that allows users to represent the scalar product 
+* A `SProd` symbolic class is added that allows users to represent the scalar product
 of operators. [(#2622)](https://github.com/PennyLaneAI/pennylane/pull/2622)
 
   We can get the matrix, eigenvalues, terms, diagonalizing gates and more.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -168,6 +168,7 @@
   >>> exp_op = qml.RZ(1.0, wires=0) ** 2
   >>> exp_op
   RZ**2(1.0, wires=[0])
+  ```
 
 * Add support for addition of operators and scalars. [(#2849)](https://github.com/PennyLaneAI/pennylane/pull/2849)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -170,13 +170,22 @@
   RZ**2(1.0, wires=[0])
   ```
 
-* Add support for addition of operators and scalars. [(#2849)](https://github.com/PennyLaneAI/pennylane/pull/2849)
+* Added support for addition of operators and scalars. [(#2849)](https://github.com/PennyLaneAI/pennylane/pull/2849)
 
   ```pycon
   >>> sum_op = 5 + qml.PauliX(0)
   >>> sum_op.matrix()
   array([[5., 1.],
          [1., 5.]])
+  ```
+
+  Added `__neg__` and `__sub__` dunder methods to the `qml.operation.Operator` class so that users
+  can negate and substract operators more naturally.
+
+  ```pycon
+  >>> -(-qml.PauliZ(0) + qml.PauliX(0)).matrix()
+  array([[ 1, -1],
+        [-1, -1]])
   ```
 
 * A `SProd` symbolic class is added that allows users to represent the scalar product

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -168,6 +168,14 @@
   >>> exp_op = qml.RZ(1.0, wires=0) ** 2
   >>> exp_op
   RZ**2(1.0, wires=[0])
+
+* Add support for addition of operators and scalars. [(#2849)](https://github.com/PennyLaneAI/pennylane/pull/2849)
+
+  ```pycon
+  >>> sum_op = 5 + qml.PauliX(0)
+  >>> sum_op.matrix()
+  array([[5., 1.],
+         [1., 5.]])
   ```
 
 * New FlipSign operator that flips the sign for a given basic state. [(#2780)](https://github.com/PennyLaneAI/pennylane/pull/2780)

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -106,6 +106,7 @@ from numpy.linalg import multi_dot
 from scipy.sparse import coo_matrix, eye, kron
 
 import pennylane as qml
+from pennylane.ops import SProd, Sum
 from pennylane.wires import Wires
 
 from .utils import pauli_eigs
@@ -1210,11 +1211,9 @@ class Operator(abc.ABC):
         if isinstance(other, numbers.Number):
             if other == 0:
                 return self
-            return qml.ops.Sum(  # pylint: disable=no-member
-                self, qml.s_prod(scalar=other, operator=qml.Identity(wires=self.wires))
-            )
+            return Sum(self, SProd(scalar=other, base=qml.Identity(wires=self.wires)))
         if isinstance(other, Operator):
-            return qml.ops.Sum(self, other)  # pylint: disable=no-member
+            return Sum(self, other)
         raise ValueError(f"Cannot add Operator and {type(other)}")
 
     __radd__ = __add__
@@ -1231,7 +1230,7 @@ class Operator(abc.ABC):
 
     def __neg__(self):
         """The negation operation of an Operator object."""
-        return qml.s_prod(scalar=-1, operator=self)
+        return SProd(scalar=-1, base=self)
 
     def __pow__(self, other):
         r"""The power operation of an Operator object."""

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -1206,18 +1206,30 @@ class Operator(abc.ABC):
         return tape
 
     def __add__(self, other):
-        r"""The addition operation between Operator objects."""
+        """The addition operation of Operator-Operator objects and Operator-scalar."""
         if isinstance(other, numbers.Number):
             if other == 0:
                 return self
             return qml.ops.Sum(  # pylint: disable=no-member
-                self, other * qml.Identity(wires=self.wires)  # TODO: Use ScalarProd when available
+                self, other * qml.Identity(wires=self.wires)  # TODO: Use SProd when available
             )
         if isinstance(other, Operator):
             return qml.ops.Sum(self, other)  # pylint: disable=no-member
         raise ValueError(f"Cannot add Operator and {type(other)}")
 
     __radd__ = __add__
+
+    def __sub__(self, other):
+        """The substraction operation of Operator-Operator objects and Operator-scalar."""
+        return self + (-other)
+
+    def __rsub__(self, other):
+        """The reverse substraction operation of Operator-Operator objects and Operator-scalar."""
+        return -self + other
+
+    def __neg__(self):
+        """The negation operation of an Operator object."""
+        return -1 * self  # TODO: Use SProd when available
 
     def __pow__(self, other):
         r"""The power operation of an Operator object."""

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -1719,7 +1719,10 @@ class Observable(Operator):
         r"""The subtraction operation between Observables/Tensors/qml.Hamiltonian objects."""
         if isinstance(other, (Observable, Tensor, qml.Hamiltonian)):
             return self.__add__(other.__mul__(-1))
-        raise ValueError(f"Cannot subtract {type(other)} from Observable")
+        try:
+            return super().__sub__(other=other)
+        except ValueError as e:
+            raise ValueError(f"Cannot subtract {type(other)} from Observable") from e
 
 
 class Tensor(Observable):

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -1221,7 +1221,9 @@ class Operator(abc.ABC):
 
     def __sub__(self, other):
         """The substraction operation of Operator-Operator objects and Operator-scalar."""
-        return self + (-other)
+        if isinstance(other, (Operator, numbers.Number)):
+            return self + (-other)
+        raise ValueError(f"Cannot substract {type(other)} from Operator.")
 
     def __rsub__(self, other):
         """The reverse substraction operation of Operator-Operator objects and Operator-scalar."""

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -1207,8 +1207,12 @@ class Operator(abc.ABC):
 
     def __add__(self, other):
         r"""The addition operation between Operator objects."""
-        if isinstance(other, numbers.Number) and other == 0:
-            return self
+        if isinstance(other, numbers.Number):
+            if other == 0:
+                return self
+            return qml.ops.Sum(  # pylint: disable=no-member
+                self, other * qml.Identity(wires=self.wires)
+            )
         if isinstance(other, Operator):
             return qml.ops.Sum(self, other)  # pylint: disable=no-member
         raise ValueError(f"Cannot add Operator and {type(other)}")
@@ -1678,8 +1682,6 @@ class Observable(Operator):
 
     def __add__(self, other):
         r"""The addition operation between Observables/Tensors/qml.Hamiltonian objects."""
-        if isinstance(other, numbers.Number) and other == 0:
-            return self
         if isinstance(other, qml.Hamiltonian):
             return other + self
         if isinstance(other, (Observable, Tensor)):

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -106,7 +106,6 @@ from numpy.linalg import multi_dot
 from scipy.sparse import coo_matrix, eye, kron
 
 import pennylane as qml
-from pennylane.ops import SProd, Sum
 from pennylane.wires import Wires
 
 from .utils import pauli_eigs
@@ -1211,9 +1210,14 @@ class Operator(abc.ABC):
         if isinstance(other, numbers.Number):
             if other == 0:
                 return self
-            return Sum(self, SProd(scalar=other, base=qml.Identity(wires=self.wires)))
+            return qml.ops.Sum(  # pylint: disable=no-member
+                self,
+                qml.ops.SProd(  # pylint: disable=no-member
+                    scalar=other, base=qml.Identity(wires=self.wires)
+                ),
+            )
         if isinstance(other, Operator):
-            return Sum(self, other)
+            return qml.ops.Sum(self, other)  # pylint: disable=no-member
         raise ValueError(f"Cannot add Operator and {type(other)}")
 
     __radd__ = __add__
@@ -1230,7 +1234,7 @@ class Operator(abc.ABC):
 
     def __neg__(self):
         """The negation operation of an Operator object."""
-        return SProd(scalar=-1, base=self)
+        return qml.ops.SProd(scalar=-1, base=self)  # pylint: disable=no-member
 
     def __pow__(self, other):
         r"""The power operation of an Operator object."""

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -1211,7 +1211,7 @@ class Operator(abc.ABC):
             if other == 0:
                 return self
             return qml.ops.Sum(  # pylint: disable=no-member
-                self, other * qml.Identity(wires=self.wires)  # TODO: Use SProd when available
+                self, qml.s_prod(scalar=other, operator=qml.Identity(wires=self.wires))
             )
         if isinstance(other, Operator):
             return qml.ops.Sum(self, other)  # pylint: disable=no-member
@@ -1231,7 +1231,7 @@ class Operator(abc.ABC):
 
     def __neg__(self):
         """The negation operation of an Operator object."""
-        return -1 * self  # TODO: Use SProd when available
+        return qml.s_prod(scalar=-1, operator=self)
 
     def __pow__(self, other):
         r"""The power operation of an Operator object."""

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -1211,7 +1211,7 @@ class Operator(abc.ABC):
             if other == 0:
                 return self
             return qml.ops.Sum(  # pylint: disable=no-member
-                self, other * qml.Identity(wires=self.wires)
+                self, other * qml.Identity(wires=self.wires)  # TODO: Use ScalarProd when available
             )
         if isinstance(other, Operator):
             return qml.ops.Sum(self, other)  # pylint: disable=no-member

--- a/pennylane/ops/qubit/hamiltonian.py
+++ b/pennylane/ops/qubit/hamiltonian.py
@@ -400,8 +400,9 @@ class Hamiltonian(Observable):
         self._grouping_indices = None
 
     def __str__(self):
-        # Lambda function that formats the wires
-        wires_print = lambda ob: ",".join(map(str, ob.wires.tolist()))
+        def wires_print(ob: Observable):
+            """Function that formats the wires."""
+            return ",".join(map(str, ob.wires.tolist()))
 
         list_of_coeffs = self.data  # list of scalar tensors
         paired_coeff_obs = list(zip(list_of_coeffs, self.ops))
@@ -589,8 +590,10 @@ class Hamiltonian(Observable):
             )
             ops.append(H)
             return qml.Hamiltonian(coeffs, ops, simplify=True)
-
-        raise ValueError(f"Cannot add Hamiltonian and {type(H)}")
+        try:
+            return super().__add__(other=H)
+        except ValueError as e:
+            raise ValueError(f"Cannot add Hamiltonian and {type(H)}") from e
 
     __radd__ = __add__
 

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -780,8 +780,8 @@ class TestOperatorIntegration:
     def test_sum_with_scalar(self):
         """Test the __sum__ dunder method with a scalar value."""
         sum_op = 5 + qml.PauliX(0)
-        final_op = qml.ops.Sum(5 * qml.Identity(0), qml.PauliX(0))
-        assert qml.equal(sum_op, final_op)
+        final_op = qml.ops.Sum(qml.ops.s_prod(5, qml.Identity(0)), qml.PauliX(0))
+        assert np.allclose(sum_op.matrix(), final_op.matrix(), rtol=0)
 
     def test_dunder_methods(self):
         """Test the __sub__, __rsub__ and __neg__ dunder methods."""

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -781,6 +781,7 @@ class TestOperatorIntegration:
         """Test the __sum__ dunder method with a scalar value."""
         sum_op = 5 + qml.PauliX(0)
         final_op = qml.ops.Sum(qml.ops.s_prod(5, qml.Identity(0)), qml.PauliX(0))
+        # TODO: Use qml.equal when fixed.
         assert np.allclose(sum_op.matrix(), final_op.matrix(), rtol=0)
 
     def test_dunder_methods(self):

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -786,8 +786,11 @@ class TestOperatorIntegration:
     def test_dunder_methods(self):
         """Test the __sub__, __rsub__ and __neg__ dunder methods."""
         sum_op = qml.PauliX(0) - 5
-        sum_op2 = 5 - qml.PauliX(0)
-        assert qml.equal(op1=sum_op, op2=-sum_op2)
+        sum_op_2 = -(5 - qml.PauliX(0))
+        assert np.allclose(a=sum_op.matrix(), b=np.array([[-5, 1], [1, -5]]), rtol=0)
+        assert np.allclose(a=sum_op.matrix(), b=sum_op_2.matrix(), rtol=0)
+        neg_op = -qml.PauliX(0)
+        assert np.allclose(a=neg_op.matrix(), b=np.array([[0, -1], [-1, 0]]), rtol=0)
 
 
 class TestInverse:

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -777,6 +777,12 @@ class TestOperatorIntegration:
         with pytest.raises(ValueError, match="Cannot raise an Operator"):
             _ = DummyOp(wires=[0]) ** DummyOp(wires=[0])
 
+    def test_sum_with_scalar(self):
+        """Test the __sum__ dunder method with a scalar value."""
+        sum_op = 5 + qml.PauliX(0)
+        final_op = qml.ops.Sum(5 * qml.Identity(0), qml.PauliX(0))
+        assert qml.equal(sum_op, final_op)
+
 
 class TestInverse:
     """Test inverse of operations"""

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -783,6 +783,12 @@ class TestOperatorIntegration:
         final_op = qml.ops.Sum(5 * qml.Identity(0), qml.PauliX(0))
         assert qml.equal(sum_op, final_op)
 
+    def test_dunder_methods(self):
+        """Test the __sub__, __rsub__ and __neg__ dunder methods."""
+        sum_op = qml.PauliX(0) - 5
+        sum_op2 = 5 - qml.PauliX(0)
+        assert qml.equal(op1=sum_op, op2=-sum_op2)
+
 
 class TestInverse:
     """Test inverse of operations"""


### PR DESCRIPTION
Add support to addition of operators and scalars.

Example:

```python
import pennylane as qml
sum_op = 5 + qml.PauliX(0)
print(sum_op)
```
Prints:
```
PauliX(wires=[0]) + 5*(Identity(wires=[0]))
```

Add `__sub__`, `__rsub__` and `__neg__` dunder methods to the `Operator` class.