### PR TITLE
Adjoint diff now uses adjoint instead of in-place inversion

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -253,7 +253,8 @@
   with many commuting terms.
   [(#2789)](https://github.com/PennyLaneAI/pennylane/pull/2798)
 
-* Adjoint differention now uses the adjoint symbolic wrapper instead of in-place inversion.
+* Adjoint differentiation now uses the adjoint symbolic wrapper instead of in-place inversion.
+  [(#2855)](https://github.com/PennyLaneAI/pennylane/pull/2855)
 
 <h3>Breaking changes</h3>
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -253,6 +253,8 @@
   with many commuting terms.
   [(#2789)](https://github.com/PennyLaneAI/pennylane/pull/2798)
 
+* Adjoint differention now uses the adjoint symbolic wrapper instead of in-place inversion.
+
 <h3>Breaking changes</h3>
 
 * The deprecated `qml.hf` module is removed. The `qml.hf` functionality is fully supported by

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -1180,16 +1180,12 @@ class QubitDevice(Device):
         trainable_param_number = len(trainable_params) - 1
         for op in expanded_ops:
 
-            if (op.grad_method is not None) and (param_number in trainable_params):
-                d_op_matrix = operation_derivative(op)
-
-            op.inv()
-            # Ideally use use op.adjoint() here
-            # then we don't have to re-invert the operation at the end
-            ket = self._apply_operation(ket, op)
+            adj_op = qml.adjoint(op)
+            ket = self._apply_operation(ket, adj_op)
 
             if op.grad_method is not None:
                 if param_number in trainable_params:
+                    d_op_matrix = operation_derivative(op)
                     ket_temp = self._apply_unitary(ket, d_op_matrix, op.wires)
 
                     jac[:, trainable_param_number] = 2 * dot_product_real(bras, ket_temp)
@@ -1198,7 +1194,6 @@ class QubitDevice(Device):
                 param_number -= 1
 
             for kk in range(n_obs):
-                bras[kk, ...] = self._apply_operation(bras[kk, ...], op)
-            op.inv()
+                bras[kk, ...] = self._apply_operation(bras[kk, ...], adj_op)
 
         return jac


### PR DESCRIPTION
Now that we have the `Adjoint` symbolic op and can represent the adjoint of an operation in all cases without relying on in-place modification, we can go back and tidy the `QubitDevice.adjoint_jacobian` method.