### PR TITLE
Support numpy integer type in resource estimation functions

### DIFF
--- a/pennylane/resource/first_quantization.py
+++ b/pennylane/resource/first_quantization.py
@@ -17,9 +17,7 @@ non-Clifford gates for quantum algorithms in first quantization using a plane-wa
 """
 # pylint: disable=no-self-use disable=too-many-arguments disable=too-many-instance-attributes
 import numpy
-
 from scipy import integrate
-
 from pennylane import numpy as np
 from pennylane.operation import AnyWires, Operation
 

--- a/pennylane/resource/first_quantization.py
+++ b/pennylane/resource/first_quantization.py
@@ -333,7 +333,7 @@ class FirstQuantization(Operation):
         >>> _cost_qrom(lz)
         21
         """
-        if lz <= 0 or not isinstance(lz, int):
+        if lz <= 0 or not isinstance(lz, (int, numpy.integer)):
             raise ValueError("The sum of the atomic numbers must be a positive integer.")
 
         k_f = np.floor(np.log2(lz) / 2)

--- a/pennylane/resource/first_quantization.py
+++ b/pennylane/resource/first_quantization.py
@@ -16,10 +16,12 @@ This module contains the functions needed for estimating the number of logical q
 non-Clifford gates for quantum algorithms in first quantization using a plane-wave basis.
 """
 # pylint: disable=no-self-use disable=too-many-arguments disable=too-many-instance-attributes
-from scipy import integrate
-from pennylane import numpy as np
-from pennylane.operation import Operation, AnyWires
 import numpy
+
+from scipy import integrate
+
+from pennylane import numpy as np
+from pennylane.operation import AnyWires, Operation
 
 
 class FirstQuantization(Operation):

--- a/pennylane/resource/first_quantization.py
+++ b/pennylane/resource/first_quantization.py
@@ -19,6 +19,7 @@ non-Clifford gates for quantum algorithms in first quantization using a plane-wa
 from scipy import integrate
 from pennylane import numpy as np
 from pennylane.operation import Operation, AnyWires
+import numpy
 
 
 class FirstQuantization(Operation):
@@ -244,7 +245,7 @@ class FirstQuantization(Operation):
         if n <= 0:
             raise ValueError("The number of plane waves must be a positive number.")
 
-        if eta <= 0 or not isinstance(eta, int):
+        if eta <= 0 or not isinstance(eta, (int, numpy.integer)):
             raise ValueError("The number of electrons must be a positive integer.")
 
         if omega <= 0:
@@ -374,7 +375,7 @@ class FirstQuantization(Operation):
         if n <= 0:
             raise ValueError("The number of plane waves must be a positive number.")
 
-        if eta <= 0 or not isinstance(eta, int):
+        if eta <= 0 or not isinstance(eta, (int, numpy.integer)):
             raise ValueError("The number of electrons must be a positive integer.")
 
         if omega <= 0:
@@ -498,7 +499,7 @@ class FirstQuantization(Operation):
         if n <= 0:
             raise ValueError("The number of plane waves must be a positive number.")
 
-        if eta <= 0 or not isinstance(eta, int):
+        if eta <= 0 or not isinstance(eta, (int, numpy.integer)):
             raise ValueError("The number of electrons must be a positive integer.")
 
         if omega <= 0:
@@ -549,7 +550,7 @@ class FirstQuantization(Operation):
         if n <= 0:
             raise ValueError("The number of plane waves must be a positive number.")
 
-        if eta <= 0 or not isinstance(eta, int):
+        if eta <= 0 or not isinstance(eta, (int, numpy.integer)):
             raise ValueError("The number of electrons must be a positive integer.")
 
         if omega <= 0:

--- a/pennylane/resource/second_quantization.py
+++ b/pennylane/resource/second_quantization.py
@@ -15,8 +15,8 @@
 This module contains the functions needed for resource estimation with the double factorization
 method.
 """
+# pylint: disable=no-self-use disable=too-many-arguments disable=too-many-instance-attributes
 import numpy
-
 from pennylane import numpy as np
 from pennylane.operation import AnyWires, Operation
 from pennylane.qchem import factorize

--- a/pennylane/resource/second_quantization.py
+++ b/pennylane/resource/second_quantization.py
@@ -15,13 +15,11 @@
 This module contains the functions needed for resource estimation with the double factorization
 method.
 """
-# pylint: disable=no-self-use disable=too-many-arguments disable=too-many-instance-attributes
+import numpy
+
 from pennylane import numpy as np
 from pennylane.operation import AnyWires, Operation
-
 from pennylane.qchem import factorize
-
-import numpy
 
 
 class DoubleFactorization(Operation):

--- a/pennylane/resource/second_quantization.py
+++ b/pennylane/resource/second_quantization.py
@@ -21,6 +21,8 @@ from pennylane.operation import AnyWires, Operation
 
 from pennylane.qchem import factorize
 
+import numpy
+
 
 class DoubleFactorization(Operation):
     r"""Estimate the number of non-Clifford gates and logical qubits for a quantum phase estimation
@@ -275,7 +277,7 @@ class DoubleFactorization(Operation):
         >>> unitary_cost(n, rank_r, rank_m, rank_max, br, alpha, beta)
         2007
         """
-        if n <= 0 or not isinstance(n, int) or n % 2 != 0:
+        if n <= 0 or not isinstance(n, (int, numpy.integer)) or n % 2 != 0:
             raise ValueError("The number of spin-orbitals must be a positive even integer.")
 
         if rank_r <= 0 or not isinstance(rank_r, int):
@@ -361,7 +363,7 @@ class DoubleFactorization(Operation):
         >>> gate_cost(n, lamb, error, rank_r, rank_m, rank_max, br, alpha, beta)
         167048631
         """
-        if n <= 0 or not isinstance(n, int) or n % 2 != 0:
+        if n <= 0 or not isinstance(n, (int, numpy.integer)) or n % 2 != 0:
             raise ValueError("The number of spin-orbitals must be a positive even integer.")
 
         if error <= 0.0:
@@ -430,7 +432,7 @@ class DoubleFactorization(Operation):
         >>> qubit_cost(n, lamb, error, rank_r, rank_m, rank_max, br, alpha, beta)
         292
         """
-        if n <= 0 or not isinstance(n, int) or n % 2 != 0:
+        if n <= 0 or not isinstance(n, (int, numpy.integer)) or n % 2 != 0:
             raise ValueError("The number of spin-orbitals must be a positive even integer.")
 
         if error <= 0.0:


### PR DESCRIPTION
**Context:**
This PR makes `numpy.integer` an accepted type for number of electrons and number of spin-orbitals.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
