### PR TITLE
Make `QuantumTape.hash` JIT-compatible

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -522,6 +522,10 @@ of operators. [(#2622)](https://github.com/PennyLaneAI/pennylane/pull/2622)
 
 <h3>Bug fixes</h3>
 
+* Parameter-broadcasted tapes now yield the correct output when executed with JAX and JIT
+  in backpropagation mode and while using a cache.
+  [(#2888)](https://github.com/PennyLaneAI/pennylane/pull/2888)
+
 * Updated IsingXY gate doc-string.
   [(#2858)](https://github.com/PennyLaneAI/pennylane/pull/2858)
 

--- a/pennylane/tape/tape.py
+++ b/pennylane/tape/tape.py
@@ -1571,7 +1571,7 @@ class QuantumTape(AnnotatedQueue):
     @property
     def hash(self):
         """int: returns an integer hash uniquely representing the quantum tape"""
-        fingerprint = []
+        fingerprint = [hash(self)]
         fingerprint.extend(op.hash for op in self.operations)
         fingerprint.extend(m.hash for m in self.measurements)
         fingerprint.extend(self.trainable_params)

--- a/tests/interfaces/test_jax_qnode.py
+++ b/tests/interfaces/test_jax_qnode.py
@@ -230,6 +230,7 @@ def test_broadcasting_jit_compatibility():
     res = circuit(x)
     jit_res = jax.jit(circuit)(x)
     assert not qml.math.isclose(res[0], res[1])
+    assert not qml.math.isclose(jit_res[0], jit_res[1])
     assert qml.math.allclose(res, jnp.cos(x))
     assert qml.math.allclose(jit_res, jnp.cos(x))
 

--- a/tests/interfaces/test_jax_qnode.py
+++ b/tests/interfaces/test_jax_qnode.py
@@ -213,6 +213,7 @@ class TestQNode:
         )
         assert np.allclose(res, expected, atol=tol, rtol=0)
 
+
 def test_broadcasting_jit_compatibility():
     """Test that cache-executing a parameter-broadcasted circuit with JAX and JIT
     works as expected and does not wrongly cache different tapes as one."""


### PR DESCRIPTION
This PR modifies `qml.tape.QuantumTape.hash` to include `hash(tape)` itself, so that cache-executing tapes with JAX+JIT is possible in backpropagation mode.


**Related issues**

Fixes  #2762.