### PR TITLE
Add `qml.math.expm` for matrix exponentiation

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -475,6 +475,7 @@ of operators. [(#2622)](https://github.com/PennyLaneAI/pennylane/pull/2622)
   [(#2767)](https://github.com/PennyLaneAI/pennylane/pull/2767)
 
 * Adds `expm` to the `pennylane.math` module for matrix exponentiation.
+  [(#2890)](https://github.com/PennyLaneAI/pennylane/pull/2890)
 
 <h3>Deprecations</h3>
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -474,6 +474,8 @@ of operators. [(#2622)](https://github.com/PennyLaneAI/pennylane/pull/2622)
   [(#2744)](https://github.com/PennyLaneAI/pennylane/pull/2744)
   [(#2767)](https://github.com/PennyLaneAI/pennylane/pull/2767)
 
+* Adds `expm` to the `pennylane.math` module for matrix exponentiation.
+
 <h3>Deprecations</h3>
 
 <h3>Documentation</h3>

--- a/pennylane/math/__init__.py
+++ b/pennylane/math/__init__.py
@@ -52,6 +52,7 @@ from .multi_dispatch import (
     where,
     add,
     iscomplex,
+    expm,
 )
 
 from .quantum import cov_matrix, marginal_prob

--- a/pennylane/math/multi_dispatch.py
+++ b/pennylane/math/multi_dispatch.py
@@ -813,3 +813,26 @@ def iscomplex(tensor, like=None):
         return False
 
     return np.iscomplex(tensor)
+
+
+@multi_dispatch()
+def expm(tensor, like=None):
+    """Compute the matrix exponential of an array :math:`e^{X}`.
+
+    ..note::
+        This function is not differentiable with Autograd, as it
+        relies on the scipy implementation.
+    """
+    if like == "torch":
+        return tensor.matrix_exp()
+    if like == "jax":
+        from jax.scipy.linalg import expm as jax_expm
+
+        return jax_expm(tensor)
+    if like == "tensorflow":
+        import tensorflow as tf
+
+        return tf.linalg.expm(tensor)
+    from scipy.linalg import expm as scipy_expm
+
+    return scipy_expm(tensor)


### PR DESCRIPTION
The exponential wrapper #2799 creating `Exp(op, coeff)` requires matrix exponentiation for its matrix.  This PR adds `expm` to the `math` module that dispatches to the different versions in the different interfaces.

Numpy and autograd do not have their own version of matrix exponentiation. Instead, these types of matrices will rely on SciPy's function. Therefore, `expm` will not be autograd-differentiable.