### PR TITLE
Fix relevant typo regarding broadcasting in changelog

### DIFF
--- a/doc/releases/changelog-0.25.0.md
+++ b/doc/releases/changelog-0.25.0.md
@@ -624,7 +624,7 @@ of operators.
   1. The custom device inherits from `DefaultQubit`, not `QubitDevice`.
   2. The device implements custom methods in the simulation pipeline that are incompatible
      with broadcasting (for example `expval`, `apply_operation` or `analytic_probability`).
-  3. The custom device maintains the flag `"supports_broadcasting": False` in its `capabilities`
+  3. The custom device maintains the flag `"supports_broadcasting": True` in its `capabilities`
      dictionary *or* it overwrites `Device.batch_transform` without applying `broadcast_expand`
      (or both).
 


### PR DESCRIPTION
In the translation of [this comment](https://github.com/PennyLaneAI/pennylane/pull/2627/#issuecomment-1177240093) into the changelog entry in #2868 I made a logical mistake, which is fixed here. It is a mere flip of the Boolean `supports_broadcasting` in the capabilities dictionary, and the original statement was that

>  The device does not explicitly update the `_capabilities` dictionary of the class to contain `supports_broadcasting: False`

is problematic. In the changelog, I wrote that 

> The custom device maintains the flag `"supports_broadcasting": False` in its capabilities dictionary

is problematic, which is the opposite.