### PR TITLE
Shot adapt test fix

### DIFF
--- a/tests/optimize/test_optimize_shot_adapative.py
+++ b/tests/optimize/test_optimize_shot_adapative.py
@@ -14,6 +14,7 @@
 """Tests for the shot adaptive optimizer"""
 import pytest
 from scipy.stats import multinomial
+from flaky import flaky
 
 import pennylane as qml
 from pennylane import numpy as np
@@ -593,9 +594,11 @@ class TestStepAndCost:
 
         assert np.allclose(res, -1, atol=tol, rtol=0)
 
+    @flaky(max_runs=3)
     def test_expval_cost(self, tol):
         """Test that the cost is correctly returned
         when using a QNode as the cost function"""
+        np.random.seed(0)
         dev = qml.device("default.qubit", wires=1, shots=10)
 
         def ansatz(x, **kwargs):


### PR DESCRIPTION
**Context:**

One of the tests for the Shot adaptive optimizer fails stochastically at times:
https://github.com/PennyLaneAI/pennylane/runs/7749282768?check_suite_focus=true#step:11:467

**Description of the Change:**
Adds a seed and uses flaky.

**Benefits:**
No stochastic CI test failures.

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
N/A