### PR TITLE
Raise an error when we return `sample()` or `counts()` with observables that are not diagonal! 

### DIFF
--- a/doc/releases/changelog-0.25.0.md
+++ b/doc/releases/changelog-0.25.0.md
@@ -758,6 +758,11 @@ of operators.
 * Calling `qml.equal` with nested operators now raises a NotImplementedError.
   [(#2877)](https://github.com/PennyLaneAI/pennylane/pull/2877)
 
+* Returning `qml.sample()` or `qml.counts()` with other non-commuting measurements of observables
+  now raises a QuantumFunctionError. (eg. `return qml.expval(PauliX(wires=0)), qml.sample()` 
+  now raises an error)
+  [(#2924)](https://github.com/PennyLaneAI/pennylane/pull/2924)
+
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/doc/releases/changelog-0.25.0.md
+++ b/doc/releases/changelog-0.25.0.md
@@ -758,9 +758,9 @@ of operators.
 * Calling `qml.equal` with nested operators now raises a NotImplementedError.
   [(#2877)](https://github.com/PennyLaneAI/pennylane/pull/2877)
 
-* Returning `qml.sample()` or `qml.counts()` with other non-commuting measurements of observables
-  now raises a QuantumFunctionError. (eg. `return qml.expval(PauliX(wires=0)), qml.sample()` 
-  now raises an error)
+* Returning `qml.sample()` or `qml.counts()` with other measurements of non-commuting observables
+  now raises a QuantumFunctionError (e.g., `return qml.expval(PauliX(wires=0)), qml.sample()` 
+  now raises an error).
   [(#2924)](https://github.com/PennyLaneAI/pennylane/pull/2924)
 
 <h3>Contributors</h3>

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -321,6 +321,7 @@ class QubitDevice(Device):
                 if o.return_type in (qml.measurements.Sample, qml.measurements.Counts) and o.obs is None:
                     raw_sampled_ops = True
                     break
+
             if raw_sampled_ops and circuit.diagonalizing_gates:
                 raise qml.QuantumFunctionError(
                     f"Computational basis measurements do not commute with some of the "
@@ -412,12 +413,12 @@ class QubitDevice(Device):
         if self.shots is not None:
             self._samples = self.generate_samples()
 
-            sampled_obs = []
+            raw_sampled_ops = False
             for o in circuit.measurements:
-                if o.return_type in (qml.measurements.Sample, qml.measurements.Counts):
-                    sampled_obs.append(o)
+                if o.return_type in (qml.measurements.Sample, qml.measurements.Counts) and o.obs is None:
+                    raw_sampled_ops = True
+                    break
 
-            raw_sampled_ops = any(o.obs is None for o in sampled_obs)
             if raw_sampled_ops and circuit.diagonalizing_gates:
                 raise qml.QuantumFunctionError(
                     f"Computational basis measurements do not commute with some of the "

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -316,9 +316,11 @@ class QubitDevice(Device):
         if self.shots is not None or circuit.is_sampled:
             self._samples = self.generate_samples()
 
-            sampled_obs = [
-                o for o in circuit.measurements if o.return_type in (qml.measurements.Sample, qml.measurements.Counts)
-            ]
+            sampled_obs = []
+            for o in circuit.measurements:
+                if o.return_type in (qml.measurements.Sample, qml.measurements.Counts):
+                    sampled_obs.append(o)
+
             raw_sampled_ops = any(o.obs is None for o in sampled_obs)
             if raw_sampled_ops and circuit.diagonalizing_gates:
                 raise qml.QuantumFunctionError(
@@ -411,9 +413,11 @@ class QubitDevice(Device):
         if self.shots is not None:
             self._samples = self.generate_samples()
 
-            sampled_obs = [
-                o for o in circuit.measurements if o.return_type in (qml.measurements.Sample, qml.measurements.Counts)
-            ]
+            sampled_obs = []
+            for o in circuit.measurements:
+                if o.return_type in (qml.measurements.Sample, qml.measurements.Counts):
+                    sampled_obs.append(o)
+
             raw_sampled_ops = any(o.obs is None for o in sampled_obs)
             if raw_sampled_ops and circuit.diagonalizing_gates:
                 raise qml.QuantumFunctionError(

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -316,12 +316,11 @@ class QubitDevice(Device):
         if self.shots is not None or circuit.is_sampled:
             self._samples = self.generate_samples()
 
-            sampled_obs = []
+            raw_sampled_ops = False
             for o in circuit.measurements:
-                if o.return_type in (qml.measurements.Sample, qml.measurements.Counts):
-                    sampled_obs.append(o)
-
-            raw_sampled_ops = any(o.obs is None for o in sampled_obs)
+                if o.return_type in (qml.measurements.Sample, qml.measurements.Counts) and o.obs is None:
+                    raw_sampled_ops = True
+                    break
             if raw_sampled_ops and circuit.diagonalizing_gates:
                 raise qml.QuantumFunctionError(
                     f"Computational basis measurements do not commute with some of the "

--- a/tests/test_qubit_device.py
+++ b/tests/test_qubit_device.py
@@ -753,6 +753,28 @@ class TestSample:
         with pytest.raises(qml.operation.EigvalsUndefinedError, match="Cannot compute samples"):
             dev.sample(qml.Hamiltonian([1.0], [qml.PauliX(0)]))
 
+    def test_no_error_measuring__commuting_ops_in_sample(self):
+        """Test that no error is raised when computational basis samples are
+        taken with other commuting measurements."""
+        dev = qml.device("default.qubit", wires=1, shots=10)
+
+        @qml.qnode(dev)
+        def circuit():
+            return qml.expval(qml.PauliZ(wires=0)), qml.sample()
+
+        _ = circuit()
+
+    def test_no_error_measuring__commuting_ops_in_counts(self):
+        """Test that no error is raised when computational basis samples are
+        taken with other commuting measurements."""
+        dev = qml.device("default.qubit", wires=1, shots=10)
+
+        @qml.qnode(dev)
+        def circuit():
+            return qml.expval(qml.PauliZ(wires=0)), qml.counts()
+
+        _ = circuit()
+
 
 class TestSampleWithBroadcasting:
     """Test the sample method when broadcasting is used"""
@@ -1150,6 +1172,32 @@ class TestExecution:
         for _ in range(num_evals_3):
             node_3(0.432, 0.12)
         assert dev_1.num_executions == num_evals_1 + num_evals_3
+
+    def test_raise_error_measuring_non_commuting_ops_in_sample(self):
+        """Test that an error is raised in the execution method when
+        computational basis samples are taken and other non-commuting
+        measurements are present"""
+        dev = qml.device("default.qubit", wires=2, shots=10)
+
+        @qml.qnode(dev)
+        def circuit():
+            return qml.expval(qml.PauliZ(0) @ qml.PauliX(1)), qml.sample()
+
+        with pytest.raises(qml.QuantumFunctionError, match="Computational basis measurements do not commute"):
+            _ = circuit()
+
+    def test_raise_error_measuring_non_commuting_ops_in_counts(self):
+        """Test that an error is raised in the execution method when
+        computational basis samples are taken and other non-commuting
+        measurements are present"""
+        dev = qml.device("default.qubit", wires=2, shots=10)
+
+        @qml.qnode(dev)
+        def circuit():
+            return qml.expval(qml.PauliZ(0) @ qml.PauliX(1)), qml.counts()
+
+        with pytest.raises(qml.QuantumFunctionError, match="Computational basis measurements do not commute"):
+            _ = circuit()
 
 
 class TestExecutionBroadcasted:

--- a/tests/test_qubit_device.py
+++ b/tests/test_qubit_device.py
@@ -773,7 +773,7 @@ class TestSample:
         def circuit():
             return qml.expval(qml.PauliZ(wires=0)), qml.counts()
 
-        _ = circuit()
+        circuit()
 
 
 class TestSampleWithBroadcasting:
@@ -1186,7 +1186,7 @@ class TestExecution:
         with pytest.raises(
             qml.QuantumFunctionError, match="Computational basis measurements do not commute"
         ):
-            _ = circuit()
+            circuit()
 
     def test_raise_error_measuring_non_commuting_ops_in_counts(self):
         """Test that an error is raised in the execution method when
@@ -1201,7 +1201,7 @@ class TestExecution:
         with pytest.raises(
             qml.QuantumFunctionError, match="Computational basis measurements do not commute"
         ):
-            _ = circuit()
+            circuit()
 
 
 class TestExecutionBroadcasted:

--- a/tests/test_qubit_device.py
+++ b/tests/test_qubit_device.py
@@ -1183,7 +1183,9 @@ class TestExecution:
         def circuit():
             return qml.expval(qml.PauliZ(0) @ qml.PauliX(1)), qml.sample()
 
-        with pytest.raises(qml.QuantumFunctionError, match="Computational basis measurements do not commute"):
+        with pytest.raises(
+            qml.QuantumFunctionError, match="Computational basis measurements do not commute"
+        ):
             _ = circuit()
 
     def test_raise_error_measuring_non_commuting_ops_in_counts(self):
@@ -1196,7 +1198,9 @@ class TestExecution:
         def circuit():
             return qml.expval(qml.PauliZ(0) @ qml.PauliX(1)), qml.counts()
 
-        with pytest.raises(qml.QuantumFunctionError, match="Computational basis measurements do not commute"):
+        with pytest.raises(
+            qml.QuantumFunctionError, match="Computational basis measurements do not commute"
+        ):
             _ = circuit()
 
 


### PR DESCRIPTION
**Context:**
sample and counts are measurement processes which admit a special syntax: `sample()`, `counts()`. We interpret this syntax to mean "return computational basis samples or counts". However, this measurement is not commutative with other measurements which are not diagonal in the computational basis. Thus they are not allowed to be performed simultaneously. 

We now raise an error when the user tries to measure these simultaneously with other non-commuting measurements. 

**Description of the Change:**
Add check in `execute()` to determine if there are any diagonalizing gates and if we are also asking for computational basis samples. 

**Related GitHub Issues:**
https://github.com/PennyLaneAI/pennylane/issues/2863
