### PR TITLE
Update development guide to explain `dev.stopping.condition`

### DIFF
--- a/doc/development/adding_operators.rst
+++ b/doc/development/adding_operators.rst
@@ -213,16 +213,23 @@ FlipAndRotate(0.1, wires=['q3', 'q1'])
 >>> op.adjoint()
 FlipAndRotate(-0.1, wires=['q3', 'q1'])
 
-The new gate can be used with PennyLane devices. PennyLane checks with the device
-whether it supports operations using the operation name.
+The new gate can be used with PennyLane devices. Device support for an operation can be checked via
+``dev.stopping_condition(op)``.  If ``True``, then the device supports the matrix.
+
+``DefaultQubit`` first checks if the operator has a matrix using the :attr:`~.Operator.has_matrix` property.
+If the Operator doesn't have a matrix, the device then checks if the name of the Operator is explicitly specified in 
+:attr:`~DefaultQubit.operations` or :attr:`~DefaultQubit.observables`.
+
+Other devices that do not inherit from ``DefaultQubit`` only check if the name is explicitly specified in the ``operations``
+property.
 
 - If the device registers support for an operation with the same name,
   PennyLane leaves the gate implementation up to the device. The device
   might have a hardcoded implementation, *or* it may refer to one of the
   numerical representations of the operator (such as :meth:`.Operator.matrix`).
   
-- If the device does not register support for an operation with the same
-  name, PennyLane will automatically decompose the gate using :meth:`.Operator.decomposition`.
+- If the device does not support for an operation, PennyLane will automatically
+  decompose the gate using :meth:`.Operator.decomposition`.
 
 .. code-block:: python
 

--- a/doc/development/adding_operators.rst
+++ b/doc/development/adding_operators.rst
@@ -214,7 +214,7 @@ FlipAndRotate(0.1, wires=['q3', 'q1'])
 FlipAndRotate(-0.1, wires=['q3', 'q1'])
 
 The new gate can be used with PennyLane devices. Device support for an operation can be checked via
-``dev.stopping_condition(op)``.  If ``True``, then the device supports the matrix.
+``dev.stopping_condition(op)``.  If ``True``, then the device supports the operation.
 
 ``DefaultQubit`` first checks if the operator has a matrix using the :attr:`~.Operator.has_matrix` property.
 If the Operator doesn't have a matrix, the device then checks if the name of the Operator is explicitly specified in 

--- a/doc/development/adding_operators.rst
+++ b/doc/development/adding_operators.rst
@@ -228,7 +228,7 @@ property.
   might have a hardcoded implementation, *or* it may refer to one of the
   numerical representations of the operator (such as :meth:`.Operator.matrix`).
   
-- If the device does not support for an operation, PennyLane will automatically
+- If the device does not support an operation, PennyLane will automatically
   decompose the gate using :meth:`.Operator.decomposition`.
 
 .. code-block:: python

--- a/doc/development/plugins.rst
+++ b/doc/development/plugins.rst
@@ -85,11 +85,14 @@ Device capabilities
 You must further tell PennyLane about the operations that your device supports, 
 as well as potential further capabilities, by providing the following class attributes/properties:
 
-* :attr:`.Device.operations`: a set of the supported PennyLane operations as strings, e.g.,
+* :attr:`.Device.stopping_condition`: This :class:`~.BooleanFn` should return ``True`` for supported
+  operations and measurement processes, and ``False`` otherwise.  Note that this function is called on
+  **both** ``Operator`` and ``MeasurementProcess`` classes.
 
-  .. code-block:: python
-
-    operations = {"CNOT", "PauliX"}
+  If the device does *not* inherit from :class:`~.DefaultQubit`, then supported operations can be determined
+  by the :attr:`.Device.operations` property.  This property is a list of string names for supported operations.
+  :class:`~.DefaultQubit` supports any operation with a matrix, even if it's name isn't specifically enumerated
+  in :attr:`.Device.operations`.
 
   See :doc:`/introduction/operations` for a full list of operations
   supported by PennyLane.

--- a/doc/development/plugins.rst
+++ b/doc/development/plugins.rst
@@ -87,12 +87,25 @@ as well as potential further capabilities, by providing the following class attr
 
 * :attr:`.Device.stopping_condition`: This :class:`~.BooleanFn` should return ``True`` for supported
   operations and measurement processes, and ``False`` otherwise.  Note that this function is called on
-  **both** ``Operator`` and ``MeasurementProcess`` classes.
+  **both** ``Operator`` and ``MeasurementProcess`` classes. Though this function must accept both ``Operator``
+  and ``MeasurementProcess`` classes, it does not affect whether or not a ``MeasurementProcess`` is supported.
+
+  .. code-block:: python
+
+      @property
+      def stopping_condition(self):
+          def accepts_obj(obj):
+              return obj.name in {'CNOT', 'PauliX', 'PauliY', 'PauliZ'}
+          return qml.BooleanFn(accepts_obj)
 
   If the device does *not* inherit from :class:`~.DefaultQubit`, then supported operations can be determined
   by the :attr:`.Device.operations` property.  This property is a list of string names for supported operations.
   :class:`~.DefaultQubit` supports any operation with a matrix, even if it's name isn't specifically enumerated
   in :attr:`.Device.operations`.
+
+  .. code-block:: python
+
+      operations = {"CNOT", "PauliX"}
 
   See :doc:`/introduction/operations` for a full list of operations
   supported by PennyLane.


### PR DESCRIPTION
Now that we rely on `dev.stopping_condition` instead of purely `dev.operations` to determine whether or not an operation is supported, we need to update the developer guide to reflect this change.