### PR TITLE
Update `qml.math.allclose` to work for trainable Torch tensors (motivated by `qml.equal`)

### DIFF
--- a/pennylane/math/utils.py
+++ b/pennylane/math/utils.py
@@ -59,7 +59,7 @@ def allclose(a, b, rtol=1e-05, atol=1e-08, **kwargs):
         # Some frameworks may provide their own allclose implementation.
         # Try and use it if available.
         res = np.allclose(a, b, rtol=rtol, atol=atol, **kwargs)
-    except (TypeError, AttributeError, ImportError):
+    except (TypeError, AttributeError, ImportError, RuntimeError):
         # Otherwise, convert the input to NumPy arrays.
         #
         # TODO: replace this with a bespoke, framework agnostic

--- a/pennylane/ops/functions/equal.py
+++ b/pennylane/ops/functions/equal.py
@@ -32,13 +32,13 @@ def equal(
     Args:
         op1 (.Operator): First operator to compare
         op2 (.Operator): Second operator to compare
-        check_interface (bool, optional): Whether to compare interfaces. Default: `True`
-        check_trainability (bool, optional): Whether to compare trainability status. Default: `True`
+        check_interface (bool, optional): Whether to compare interfaces. Default: ``True``
+        check_trainability (bool, optional): Whether to compare trainability status. Default: ``True``
         rtol (float, optional): Relative tolerance for parameters
         atol (float, optional): Absolute tolerance for parameters
 
     Returns:
-        bool: `True` if the operators are equal, else `False`
+        bool: ``True`` if the operators are equal, else ``False``
 
     **Example**
 

--- a/tests/math/test_functions.py
+++ b/tests/math/test_functions.py
@@ -1076,7 +1076,8 @@ class TestRequiresGrad:
         assert not fn.requires_grad(t)
 
     def test_tf(self):
-        """TensorFlow tensors will True *if* they are being watched by a gradient tape"""
+        """TensorFlow tensors will True *if* they are being watched by a
+        gradient tape or if they have a trainable attribute set to True"""
         t1 = tf.Variable([1.0, 2.0])
         t2 = tf.constant([1.0, 2.0])
         assert not fn.requires_grad(t1)
@@ -1093,6 +1094,9 @@ class TestRequiresGrad:
             tape.watch([t1, t2])
             assert fn.requires_grad(t1)
             assert fn.requires_grad(t2)
+
+        t3 = tf.Variable([1.0, 2.0], trainable=True)
+        assert fn.requires_grad(t3)
 
     def test_unknown_interface(self):
         """Test that an error is raised if the interface is unknown"""

--- a/tests/math/test_functions.py
+++ b/tests/math/test_functions.py
@@ -150,7 +150,12 @@ def test_allequal(t1, t2):
     assert res == expected
 
 
-@pytest.mark.parametrize("t1,t2", list(itertools.combinations(test_data, r=2)))
+@pytest.mark.parametrize(
+    "t1,t2",
+    list(
+        itertools.combinations(test_data + [torch.tensor([1.0, 2.0, 3.0], requires_grad=True)], r=2)
+    ),
+)
 def test_allclose(t1, t2):
     """Test that the allclose function works for a variety of inputs."""
     res = fn.allclose(t1, t2)

--- a/tests/math/test_functions.py
+++ b/tests/math/test_functions.py
@@ -1076,8 +1076,7 @@ class TestRequiresGrad:
         assert not fn.requires_grad(t)
 
     def test_tf(self):
-        """TensorFlow tensors will True *if* they are being watched by a
-        gradient tape or if they have a trainable attribute set to True"""
+        """TensorFlow tensors will True *if* they are being watched by a gradient tape"""
         t1 = tf.Variable([1.0, 2.0])
         t2 = tf.constant([1.0, 2.0])
         assert not fn.requires_grad(t1)
@@ -1094,9 +1093,6 @@ class TestRequiresGrad:
             tape.watch([t1, t2])
             assert fn.requires_grad(t1)
             assert fn.requires_grad(t2)
-
-        t3 = tf.Variable([1.0, 2.0], trainable=True)
-        assert fn.requires_grad(t3)
 
     def test_unknown_interface(self):
         """Test that an error is raised if the interface is unknown"""

--- a/tests/ops/functions/test_equal.py
+++ b/tests/ops/functions/test_equal.py
@@ -858,8 +858,7 @@ class TestEqual:
         wire = 0
 
         pl_tensor = qml.numpy.array(0.3, requires_grad=True)
-        jax_array = jax.core.Tracer(0.3)
-        tf_tensor = tf.Variable(0.3, trainable=True)
+        tf_tensor = tf.Variable(0.3)
         torch_tensor = torch.tensor(0.3, requires_grad=True)
 
         non_jax_tensors = [pl_tensor, tf_tensor, torch_tensor]
@@ -869,15 +868,23 @@ class TestEqual:
         # qml.math.requires_grad returns True for a Tracer with JAX, the
         # assertion involves using a JAX function that transforms a JAX NumPy
         # array into a Tracer
-        def jax_assertion_func(x, y):
-            op1 = qml.RY(jax.numpy.array(x), wires=1)
-            op2 = qml.RY(torch.tensor(y, requires_grad=True), wires=1)
-            assert qml.equal(op1, op2, check_interface=False, check_trainability=True)
+        def jax_assertion_func(x, other_tensor):
+            operation1 = op1(jax.numpy.array(x), wires=1)
+            operation2 = op1(other_tensor, wires=1)
+            if isinstance(other_tensor, tf.Variable):
+                with tf.GradientTape() as tape:
+                    assert qml.equal(
+                        operation1, operation2, check_interface=False, check_trainability=True
+                    )
+            else:
+                assert qml.equal(
+                    operation1, operation2, check_interface=False, check_trainability=True
+                )
             return x
 
         par = 0.3
         for tensor in non_jax_tensors:
-            jax.grad(jax_assertion_func, argnums=0)(par, par)
+            jax.grad(jax_assertion_func, argnums=0)(par, tensor)
 
         # TF and Autograd
         # ------------------
@@ -901,13 +908,16 @@ class TestEqual:
 
         # Autograd and Torch
         # ------------------
-        with tf.GradientTape() as tape:
-            assert qml.equal(
-                op1(pl_tensor, wires=wire),
-                op1(torch_tensor, wires=wire),
-                check_trainability=True,
-                check_interface=False,
-            )
+        assert qml.equal(
+            op1(pl_tensor, wires=wire),
+            op1(torch_tensor, wires=wire),
+            check_trainability=True,
+            check_interface=False,
+        )
+
+    def test_equal_with_different_arithmetic_depth(self):
+        """Test equal method with two operators with different arithmetic depth."""
+        assert not qml.equal(qml.adjoint(qml.PauliX(0)), qml.adjoint(qml.adjoint(qml.PauliX(0))))
 
     def test_equal_with_nested_operators_raises_error(self):
         """Test that the equal method with two operators with the same arithmetic depth (>0) raises


### PR DESCRIPTION
**Context:**
```py
pl_tensor = qml.numpy.array(0.3, requires_grad=True)
torch_tensor = torch.tensor(0.3, requires_grad=True)
qml.math.allclose(pl_tensor, torch_tensor)
```
Raises
```py
RuntimeError: Can't call numpy() on Tensor that requires grad. Use tensor.detach().numpy() instead.
```
**Description of the Change:**
Updates `qml.math.allclose` to catch `RuntimeError`. This way trainable Torch tensors are correctly converted to NumPy.

**Benefits:**
`qml.math.allclose` works with Torch Tensors that have `requires_grad=True` set.

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
N/A