### PR TITLE
Modify resource docs

### DIFF
--- a/doc/releases/changelog-0.25.0.md
+++ b/doc/releases/changelog-0.25.0.md
@@ -17,6 +17,7 @@
   [(#2796)](https://github.com/PennyLaneAI/pennylane/pull/2796)
   [(#2797)](https://github.com/PennyLaneAI/pennylane/pull/2797)
   [(#2874)](https://github.com/PennyLaneAI/pennylane/pull/2874)
+  [(#2944)](https://github.com/PennyLaneAI/pennylane/pull/2944)
   [(#2644)](https://github.com/PennyLaneAI/pennylane/pull/2644)
 
   The new [`qml.resource`](https://pennylane.readthedocs.io/en/stable/code/qml_resource.html) module allows you to estimate the number of 

--- a/pennylane/resource/first_quantization.py
+++ b/pennylane/resource/first_quantization.py
@@ -30,29 +30,7 @@ class FirstQuantization(Operation):
     the number of electrons and the unit cell volume need to be defined. The costs can then be
     computed using the functions :func:`~.pennylane.resource.FirstQuantization.gate_cost` and
     :func:`~.pennylane.resource.FirstQuantization.qubit_cost` with a target error that has the default
-    value of 0.0016 Ha (chemical accuracy).
-
-    Following `PRX Quantum 2, 040332 (2021) <https://link.aps.org/doi/10.1103/PRXQuantum.2.040332>`_
-    , the target algorithm error, :math:`\epsilon`, is distributed among four different sources of
-    error using Eq. (131)
-
-    .. math::
-        \epsilon^2 \geq \epsilon_{qpe}^2 + (\epsilon_{\mathcal{M}} + \epsilon_R + \epsilon_T)^2,
-
-    where :math:`\epsilon_{qpe}` is the quantum phase estimation error and
-    :math:`\epsilon_{\mathcal{M}}`, :math:`\epsilon_R`, and :math:`\epsilon_T` are defined in Eqs.
-    (132-134).
-
-    Here, we fix :math:`\epsilon_{\mathcal{M}} = \epsilon_R = \epsilon_T = \alpha \epsilon` with
-    a default value of :math:`\alpha = 0.01` and obtain
-
-    .. math::
-        \epsilon_{qpe} = \sqrt{\epsilon^2 [1 - (3 \alpha)^2]}.
-
-    Note that the user only needs to define the target algorithm error :math:`\epsilon`. The error
-    distribution takes place inside the functions.
-
-    Atomic units are used throughout the class.
+    value of 0.0016 Ha (chemical accuracy). Atomic units are used throughout the class.
 
     Args:
         n (int): number of plane waves
@@ -62,28 +40,40 @@ class FirstQuantization(Operation):
         charge (int): total electric charge of the system
         br (int): number of bits for ancilla qubit rotation
 
+    **Example**
+
+    >>> n = 100000
+    >>> eta = 156
+    >>> omega = 1145.166
+    >>> algo = FirstQuantization(n, eta, omega)
+    >>> print(algo.lamb,  # the 1-Norm of the Hamiltonian
+    >>>       algo.gates, # estimated number of non-Clifford gates
+    >>>       algo.qubits # estimated number of logical qubits
+    >>>       )
+    649912.4801542697 1.10e+13 4416
+
     .. details::
-        :title: Usage Details
+        :title: Theory
 
-        .. code-block:: python
+        Following `PRX Quantum 2, 040332 (2021) <https://link.aps.org/doi/10.1103/PRXQuantum.2.040332>`_
+        , the target algorithm error, :math:`\epsilon`, is distributed among four different sources
+        of error using Eq. (131)
 
-            import pennylane as qml
-            from pennylane import numpy as np
+        .. math::
+            \epsilon^2 \geq \epsilon_{qpe}^2 + (\epsilon_{\mathcal{M}} + \epsilon_R + \epsilon_T)^2,
 
-            n = 100000
-            eta = 156
-            omega = 1145.166
+        where :math:`\epsilon_{qpe}` is the quantum phase estimation error and
+        :math:`\epsilon_{\mathcal{M}}`, :math:`\epsilon_R`, and :math:`\epsilon_T` are defined in
+        Eqs. (132-134).
 
-            algo = FirstQuantization(n, eta, omega)
+        Here, we fix :math:`\epsilon_{\mathcal{M}} = \epsilon_R = \epsilon_T = \alpha \epsilon` with
+        a default value of :math:`\alpha = 0.01` and obtain
 
-        >>> algo.lamb  # the 1-Norm of the Hamiltonian
-        649912.4801542697
+        .. math::
+            \epsilon_{qpe} = \sqrt{\epsilon^2 [1 - (3 \alpha)^2]}.
 
-        >>> algo.gates  # estimated number of non-Clifford gates
-        1.10e+13
-
-        >>> algo.qubits  # estimated number of logical qubits
-        4416
+        Note that the user only needs to define the target algorithm error :math:`\epsilon`. The
+        error distribution takes place inside the functions.
     """
 
     num_wires = AnyWires

--- a/pennylane/resource/second_quantization.py
+++ b/pennylane/resource/second_quantization.py
@@ -26,33 +26,6 @@ class DoubleFactorization(Operation):
     r"""Estimate the number of non-Clifford gates and logical qubits for a quantum phase estimation
     algorithm in second quantization with a double-factorized Hamiltonian.
 
-    To estimate the gate and qubit costs for implementing this method, the Hamiltonian needs to be
-    factorized using the :func:`~.pennylane.qchem.factorize` function following
-    [`PRX Quantum 2, 030305 (2021) <https://journals.aps.org/prxquantum/abstract/10.1103/PRXQuantum.2.030305>`_].
-    The objective of the factorization is to find a set of symmetric matrices, :math:`L^{(r)}`,
-    such that the two-electron integral tensor in
-    `chemist notation <http://vergil.chemistry.gatech.edu/notes/permsymm/permsymm.pdf>`_,
-    :math:`V`, can be computed as
-
-    .. math::
-
-           V_{ijkl} = \sum_r^R L_{ij}^{(r)} L_{kl}^{(r) T},
-
-    with the rank :math:`R \leq n^2`, where :math:`n` is the number of molecular orbitals. The
-    matrices :math:`L^{(r)}` are diagonalized and for each matrix the eigenvalues that are
-    smaller than a given threshold (and their corresponding eigenvectors) are discarded. The
-    average number of the retained eigenvalues, :math:`M`, determines the rank of the second
-    factorization step. The 1-norm of the Hamiltonian can then be computed using the
-    :func:`~.pennylane.resource.DoubleFactorization.norm` function from the electron integrals and
-    the eigenvalues of the matrices :math:`L^{(r)}`.
-
-    The total number of gates and qubits for implementing the quantum phase estimation algorithm
-    for the given Hamiltonian can then be computed using the functions
-    :func:`~.pennylane.resource.DoubleFactorization.gate_cost` and
-    :func:`~.pennylane.resource.DoubleFactorization.qubit_cost` with a target error that has the
-    default value of 0.0016 Ha (chemical accuracy). The costs are computed using Eqs. (C39-C40)
-    of [`PRX Quantum 2, 030305 (2021) <https://journals.aps.org/prxquantum/abstract/10.1103/PRXQuantum.2.030305>`_].
-
     Atomic units are used throughout the class.
 
     Args:
@@ -68,32 +41,50 @@ class DoubleFactorization(Operation):
         beta (int): number of bits for the rotation angles
         chemist_notation (bool): if True, the two-electron integrals need to be in chemist notation
 
+    **Example**
+
+    >>> symbols  = ['O', 'H', 'H']
+    >>> geometry = np.array([[0.00000000,  0.00000000,  0.28377432],
+    >>>                      [0.00000000,  1.45278171, -1.00662237],
+    >>>                      [0.00000000, -1.45278171, -1.00662237]], requires_grad = False)
+    >>> mol = qml.qchem.Molecule(symbols, geometry, basis_name='sto-3g')
+    >>> core, one, two = qml.qchem.electron_integrals(mol)()
+    >>> algo = DoubleFactorization(one, two)
+    >>> print(algo.lamb,  # the 1-Norm of the Hamiltonian
+    >>>       algo.gates, # estimated number of non-Clifford gates
+    >>>       algo.qubits # estimated number of logical qubits
+    >>>       )
+    >>> 53.62085493277858 103969925 290
+
     .. details::
-        :title: Usage Details
+        :title: Theory
 
-        .. code-block:: python
+        To estimate the gate and qubit costs for implementing this method, the Hamiltonian needs to
+        be factorized using the :func:`~.pennylane.qchem.factorize` function following
+        [`PRX Quantum 2, 030305 (2021) <https://journals.aps.org/prxquantum/abstract/10.1103/PRXQuantum.2.030305>`_].
+        The objective of the factorization is to find a set of symmetric matrices, :math:`L^{(r)}`,
+        such that the two-electron integral tensor in
+        `chemist notation <http://vergil.chemistry.gatech.edu/notes/permsymm/permsymm.pdf>`_,
+        :math:`V`, can be computed as
 
-            import pennylane as qml
-            from pennylane import numpy as np
+        .. math::
 
-            symbols  = ['O', 'H', 'H']
-            geometry = np.array([[0.00000000,  0.00000000,  0.28377432],
-                                 [0.00000000,  1.45278171, -1.00662237],
-                                 [0.00000000, -1.45278171, -1.00662237]], requires_grad = False)
+               V_{ijkl} = \sum_r^R L_{ij}^{(r)} L_{kl}^{(r) T},
 
-            mol = qml.qchem.Molecule(symbols, geometry, basis_name='sto-3g')
+        with the rank :math:`R \leq n^2`, where :math:`n` is the number of molecular orbitals. The
+        matrices :math:`L^{(r)}` are diagonalized and for each matrix the eigenvalues that are
+        smaller than a given threshold (and their corresponding eigenvectors) are discarded. The
+        average number of the retained eigenvalues, :math:`M`, determines the rank of the second
+        factorization step. The 1-norm of the Hamiltonian can then be computed using the
+        :func:`~.pennylane.resource.DoubleFactorization.norm` function from the electron integrals
+        and the eigenvalues of the matrices :math:`L^{(r)}`.
 
-            core, one, two = qml.qchem.electron_integrals(mol)()
-            algo = DoubleFactorization(one, two)
-
-        >>> algo.lamb  # the 1-Norm of the Hamiltonian
-        53.62085493277858
-
-        >>> algo.gates  # estimated number of non-Clifford gates
-        103969925
-
-        >>> algo.qubits  # estimated number of logical qubits
-        290
+        The total number of gates and qubits for implementing the quantum phase estimation algorithm
+        for the given Hamiltonian can then be computed using the functions
+        :func:`~.pennylane.resource.DoubleFactorization.gate_cost` and
+        :func:`~.pennylane.resource.DoubleFactorization.qubit_cost` with a target error that has the
+        default value of 0.0016 Ha (chemical accuracy). The costs are computed using Eqs. (C39-C40)
+        of [`PRX Quantum 2, 030305 (2021) <https://journals.aps.org/prxquantum/abstract/10.1103/PRXQuantum.2.030305>`_].
     """
     num_wires = AnyWires
     grad_method = None

--- a/pennylane/resource/second_quantization.py
+++ b/pennylane/resource/second_quantization.py
@@ -54,7 +54,7 @@ class DoubleFactorization(Operation):
     >>>       algo.gates, # estimated number of non-Clifford gates
     >>>       algo.qubits # estimated number of logical qubits
     >>>       )
-    >>> 53.62085493277858 103969925 290
+    53.62085493277858 103969925 290
 
     .. details::
         :title: Theory


### PR DESCRIPTION
**Context:**
This PR reorganises the docstrings of `DoubleFactorization` and `FirstQuantization`  classes in `resource` module. 

**Description of the Change:**
- The Usage Details section is converted to Examples.
- The theoretical details are brought to a new Theory section.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
