### PR TITLE
`qml.equal` considers in-place inversion.

### DIFF
--- a/doc/releases/changelog-0.25.0.md
+++ b/doc/releases/changelog-0.25.0.md
@@ -710,6 +710,7 @@ of operators.
 <h3>Bug fixes 🐞</h3>
 
 * Fixes `qml.equal` so that operators with different inverse properties are not equal.
+  [(#2947)](https://github.com/PennyLaneAI/pennylane/pull/2947)
 
 * Cleans up interactions between operator arithmetic and batching by
   testing supported cases and adding errors when batching is not supported.

--- a/doc/releases/changelog-0.25.0.md
+++ b/doc/releases/changelog-0.25.0.md
@@ -709,6 +709,8 @@ of operators.
 
 <h3>Bug fixes 🐞</h3>
 
+* Fixes `qml.equal` so that operators with different inverse properties are not equal.
+
 * Cleans up interactions between operator arithmetic and batching by
   testing supported cases and adding errors when batching is not supported.
   [(#2900)](https://github.com/PennyLaneAI/pennylane/pull/2900)

--- a/pennylane/ops/functions/equal.py
+++ b/pennylane/ops/functions/equal.py
@@ -98,4 +98,4 @@ def equal(
             if qml.math.get_interface(params_1) != qml.math.get_interface(params_2):
                 return False
 
-    return True
+    return getattr(op1, "inverse", False) == getattr(op2, "inverse", False)

--- a/tests/ops/functions/test_equal.py
+++ b/tests/ops/functions/test_equal.py
@@ -847,3 +847,15 @@ class TestEqual:
             + " depth larger than 0 is not yet implemented.",
         ):
             qml.equal(qml.adjoint(qml.PauliX(0)), qml.adjoint(qml.PauliX(0)))
+
+    def test_equal_same_inversion(self):
+        """Test operations are equal if they are both inverted."""
+        op1 = qml.RX(1.2, wires=0).inv()
+        op2 = qml.RX(1.2, wires=0).inv()
+        assert qml.equal(op1, op2)
+
+    def test_not_equal_different_inversion(self):
+        """Test operations are not equal if one is inverted and the other is not."""
+        op1 = qml.PauliX(0)
+        op2 = qml.PauliX(0).inv()
+        assert not qml.equal(op1, op2)


### PR DESCRIPTION
Fixes #2945 

Now we have 
```
>>> qml.equal(qml.RX(1.0, wires=0), qml.RX(1.0, wires=0).inv())
False
```