### PR TITLE
Update `qml.Flipsign` docs example

### DIFF
--- a/pennylane/templates/subroutines/flip_sign.py
+++ b/pennylane/templates/subroutines/flip_sign.py
@@ -47,12 +47,14 @@ class FlipSign(Operation):
 
             dev = qml.device("default.qubit", wires=2)
 
+
             @qml.qnode(dev)
             def circuit():
-               for wire in list(range(2)):
-                    qml.Hadamard(wires = wire)
-               qml.FlipSign(basis_state, wires = list(range(2)))
-               return qml.sample()
+                for wire in list(range(2)):
+                    qml.Hadamard(wires=wire)
+                qml.FlipSign(basis_state, wires=list(range(2)))
+                return qml.sample()
+
 
             circuit()
 

--- a/pennylane/templates/subroutines/flip_sign.py
+++ b/pennylane/templates/subroutines/flip_sign.py
@@ -53,7 +53,7 @@ class FlipSign(Operation):
                 for wire in list(range(2)):
                     qml.Hadamard(wires=wire)
                 qml.FlipSign(basis_state, wires=list(range(2)))
-                return qml.sample()
+                return qml.state()
 
 
             circuit()


### PR DESCRIPTION
Formats and corrects the `qml.Flipsign` docstring example.