### PR TITLE
Matrix incompatible for `Hamiltonian` objects in Arithmetic Operators

### DIFF
--- a/doc/releases/changelog-0.25.0.md
+++ b/doc/releases/changelog-0.25.0.md
@@ -765,6 +765,9 @@
   with another non-commuting observable.
   [(#2928)](https://github.com/PennyLaneAI/pennylane/pull/2928)
 
+* Operator Arithmetic now allows `Hamiltonian` objects to be used and produces correct matrices.
+  [(#2957)](https://github.com/PennyLaneAI/pennylane/pull/2957)
+
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane/ops/op_math/adjoint_class.py
+++ b/pennylane/ops/op_math/adjoint_class.py
@@ -214,7 +214,10 @@ class Adjoint(SymbolicOp):
     def matrix(self, wire_order=None):
         if self.base.batch_size is not None:
             raise qml.operation.MatrixUndefinedError
-        base_matrix = qml.matrix(self.base, wire_order=wire_order)
+        if isinstance(self.base, qml.Hamiltonian):
+            base_matrix = qml.matrix(self.base, wire_order=wire_order)
+        else:
+            base_matrix = self.base.matrix(wire_order=wire_order)
         return transpose(conj(base_matrix))
 
     def decomposition(self):

--- a/pennylane/ops/op_math/adjoint_class.py
+++ b/pennylane/ops/op_math/adjoint_class.py
@@ -214,7 +214,7 @@ class Adjoint(SymbolicOp):
     def matrix(self, wire_order=None):
         if self.base.batch_size is not None:
             raise qml.operation.MatrixUndefinedError
-        base_matrix = self.base.matrix(wire_order=wire_order)
+        base_matrix = qml.matrix(self.base, wire_order=wire_order)
         return transpose(conj(base_matrix))
 
     def decomposition(self):

--- a/pennylane/ops/op_math/pow_class.py
+++ b/pennylane/ops/op_math/pow_class.py
@@ -174,7 +174,10 @@ class Pow(SymbolicOp):
         return self.base.label(decimals, base_label, cache=cache) + z_string
 
     def matrix(self, wire_order=None):
-        base_matrix = qml.matrix(self.base)
+        if isinstance(self.base, qml.Hamiltonian):
+            base_matrix = qml.matrix(self.base)
+        else:
+            base_matrix = self.base.matrix()
 
         if isinstance(self.z, int):
             mat = qmlmath.linalg.matrix_power(base_matrix, self.z)

--- a/pennylane/ops/op_math/pow_class.py
+++ b/pennylane/ops/op_math/pow_class.py
@@ -174,7 +174,7 @@ class Pow(SymbolicOp):
         return self.base.label(decimals, base_label, cache=cache) + z_string
 
     def matrix(self, wire_order=None):
-        base_matrix = self.base.matrix()
+        base_matrix = qml.matrix(self.base)
 
         if isinstance(self.z, int):
             mat = qmlmath.linalg.matrix_power(base_matrix, self.z)

--- a/pennylane/ops/op_math/prod.py
+++ b/pennylane/ops/op_math/prod.py
@@ -292,7 +292,9 @@ class Prod(Operator):
         if wire_order is None:
             wire_order = self.wires
 
-        mats = (expand_matrix(op.matrix(), op.wires, wire_order=wire_order) for op in self.factors)
+        mats = (
+            expand_matrix(qml.matrix(op), op.wires, wire_order=wire_order) for op in self.factors
+        )
         return reduce(math.dot, mats)
 
     # pylint: disable=protected-access

--- a/pennylane/ops/op_math/prod.py
+++ b/pennylane/ops/op_math/prod.py
@@ -293,8 +293,10 @@ class Prod(Operator):
             wire_order = self.wires
 
         mats = (
-            expand_matrix(op.matrix(), op.wires, wire_order=wire_order) if not isinstance(op, qml.Hamiltonian)
-            else expand_matrix(qml.matrix(op), op.wires, wire_order=wire_order) for op in self.factors
+            expand_matrix(op.matrix(), op.wires, wire_order=wire_order)
+            if not isinstance(op, qml.Hamiltonian)
+            else expand_matrix(qml.matrix(op), op.wires, wire_order=wire_order)
+            for op in self.factors
         )
         return reduce(math.dot, mats)
 

--- a/pennylane/ops/op_math/prod.py
+++ b/pennylane/ops/op_math/prod.py
@@ -293,7 +293,8 @@ class Prod(Operator):
             wire_order = self.wires
 
         mats = (
-            expand_matrix(qml.matrix(op), op.wires, wire_order=wire_order) for op in self.factors
+            expand_matrix(op.matrix(), op.wires, wire_order=wire_order) if not isinstance(op, qml.Hamiltonian)
+            else expand_matrix(qml.matrix(op), op.wires, wire_order=wire_order) for op in self.factors
         )
         return reduce(math.dot, mats)
 

--- a/pennylane/ops/op_math/sprod.py
+++ b/pennylane/ops/op_math/sprod.py
@@ -210,7 +210,7 @@ class SProd(SymbolicOp):
         Returns:
             tensor_like: matrix representation
         """
-        return self.scalar * self.base.matrix(wire_order=wire_order)
+        return self.scalar * qml.matrix(self.base, wire_order=wire_order)
 
     @property
     def _queue_category(self):  # don't queue scalar prods as they might not be Unitary!

--- a/pennylane/ops/op_math/sprod.py
+++ b/pennylane/ops/op_math/sprod.py
@@ -210,7 +210,9 @@ class SProd(SymbolicOp):
         Returns:
             tensor_like: matrix representation
         """
-        return self.scalar * qml.matrix(self.base, wire_order=wire_order)
+        if isinstance(self.base, qml.Hamiltonian):
+            return self.scalar * qml.matrix(self.base, wire_order=wire_order)
+        return self.scalar * self.base.matrix(wire_order=wire_order)
 
     @property
     def _queue_category(self):  # don't queue scalar prods as they might not be Unitary!

--- a/pennylane/ops/op_math/sum.py
+++ b/pennylane/ops/op_math/sum.py
@@ -295,7 +295,10 @@ class Sum(Operator):
         def matrix_gen(summands, wire_order=None):
             """Helper function to construct a generator of matrices"""
             for op in summands:
-                yield qml.matrix(op, wire_order=wire_order)
+                if isinstance(op, qml.Hamiltonian):
+                    yield qml.matrix(op, wire_order=wire_order)
+                else:
+                    yield op.matrix(wire_order=wire_order)
 
         if wire_order is None:
             wire_order = self.wires

--- a/pennylane/ops/op_math/sum.py
+++ b/pennylane/ops/op_math/sum.py
@@ -295,7 +295,7 @@ class Sum(Operator):
         def matrix_gen(summands, wire_order=None):
             """Helper function to construct a generator of matrices"""
             for op in summands:
-                yield op.matrix(wire_order=wire_order)
+                yield qml.matrix(op, wire_order=wire_order)
 
         if wire_order is None:
             wire_order = self.wires

--- a/tests/ops/op_math/test_adjoint_op.py
+++ b/tests/ops/op_math/test_adjoint_op.py
@@ -559,6 +559,15 @@ class TestMatrix:
         with pytest.raises(qml.operation.MatrixUndefinedError):
             Adjoint(base).matrix()
 
+    def test_adj_hamiltonian(self):
+        """Test that a we can take the adjoint of a hamiltonian."""
+        U = qml.Hamiltonian([1.0], [qml.PauliX(wires=0) @ qml.PauliZ(wires=1)])
+        adj_op = Adjoint(base=U)  # hamiltonian = hermitian = self-adjoint
+        mat = adj_op.matrix()
+
+        true_mat = qml.matrix(U)
+        assert np.allclose(mat, true_mat)
+
 
 def test_sparse_matrix():
     """Test that the spare_matrix method returns the adjoint of the base sparse matrix."""

--- a/tests/ops/op_math/test_pow_op.py
+++ b/tests/ops/op_math/test_pow_op.py
@@ -529,6 +529,15 @@ class TestMatrix:
 
         assert qml.math.allclose(op_mat, compare_mat)
 
+    def test_pow_hamiltonian(self):
+        """Test that a hamiltonian object can be exponentiated."""
+        U = qml.Hamiltonian([1.0], [qml.PauliX(wires=0)])
+        pow_op = Pow(base=U, z=2)
+        mat = pow_op.matrix()
+
+        true_mat = [[1, 0], [0, 1]]
+        assert np.allclose(mat, true_mat)
+
 
 class TestSparseMatrix:
     """Tests involving the sparse matrix method."""

--- a/tests/ops/op_math/test_prod.py
+++ b/tests/ops/op_math/test_prod.py
@@ -414,6 +414,20 @@ class TestMatrix:
         true_mat = qnp.kron(U, qnp.eye(2)) @ qnp.eye(4)
         assert np.allclose(mat, true_mat)
 
+    def test_prod_hamiltonian(self):
+        """Test that a hamiltonian object can be composed."""
+        U = qml.Hamiltonian([0.5], [qml.PauliX(wires=1)])
+        prod_op = Prod(qml.PauliZ(wires=0), U)
+        mat = prod_op.matrix()
+
+        true_mat = [
+            [0.0, 0.5, 0.0, 0.0],
+            [0.5, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, -0.5],
+            [0.0, 0.0, -0.5, 0.0],
+        ]
+        assert np.allclose(mat, true_mat)
+
     # Add interface tests for each interface !
 
     @pytest.mark.jax

--- a/tests/ops/op_math/test_sprod.py
+++ b/tests/ops/op_math/test_sprod.py
@@ -326,6 +326,15 @@ class TestMatrix:
 
         assert np.allclose(sparse_matrix.todense(), expected_sparse_matrix.todense())
 
+    def test_sprod_hamiltonian(self):
+        """Test that a hamiltonian object can be scaled."""
+        U = qml.Hamiltonian([0.5], [qml.PauliX(wires=0)])
+        sprod_op = SProd(-4, U)
+        mat = sprod_op.matrix()
+
+        true_mat = [[0, -2], [-2, 0]]
+        assert np.allclose(mat, true_mat)
+
     # Add interface tests for each interface !
 
     @pytest.mark.jax

--- a/tests/ops/op_math/test_sum.py
+++ b/tests/ops/op_math/test_sum.py
@@ -447,11 +447,12 @@ class TestMatrix:
 
     def test_sum_hamiltonian(self):
         """Test that a hamiltonian object can be summed."""
-        U = 0.5 * (qml.PauliX(wires=0) @ qml.PauliZ(wires=0))
+        U = 0.5 * (qml.PauliX(wires=0) @ qml.PauliZ(wires=1))
         sum_op = Sum(U, qml.PauliX(wires=0))
         mat = sum_op.matrix()
 
-        true_mat = [[0, 0.5], [1.5, 0]]
+        true_mat = [[0, 0, 1.5, 0], [0, 0, 0, 0.5], [1.5, 0, 0, 0], [0, 0.5, 0, 0]]
+
         assert np.allclose(mat, true_mat)
 
     # Add interface tests for each interface !

--- a/tests/ops/op_math/test_sum.py
+++ b/tests/ops/op_math/test_sum.py
@@ -445,6 +445,15 @@ class TestMatrix:
         true_mat = qnp.kron(U, qnp.eye(2)) + qnp.eye(4)
         assert np.allclose(mat, true_mat)
 
+    def test_sum_hamiltonian(self):
+        """Test that a hamiltonian object can be summed."""
+        U = 0.5 * (qml.PauliX(wires=0) @ qml.PauliZ(wires=0))
+        sum_op = Sum(U, qml.PauliX(wires=0))
+        mat = sum_op.matrix()
+
+        true_mat = [[0, 0.5], [1.5, 0]]
+        assert np.allclose(mat, true_mat)
+
     # Add interface tests for each interface !
 
     @pytest.mark.jax


### PR DESCRIPTION
**Context:**
`qml.matrix()` was not compatible with some arithmetic operators and instances of the `Hamiltonian` class.

**Description of the Change:**
Update the `matrix()` class method for the arithmetic operator classes to use the top level `qml.matrix()` method.
