### PR TITLE
Allow non-hermitian observables

### DIFF
--- a/pennylane/measurements.py
+++ b/pennylane/measurements.py
@@ -21,6 +21,7 @@ and measurement samples using AnnotatedQueues.
 import copy
 import functools
 import uuid
+import warnings
 from enum import Enum
 from typing import Generic, TypeVar
 
@@ -546,9 +547,7 @@ def expval(op):
         QuantumFunctionError: `op` is not an instance of :class:`~.Observable`
     """
     if not op.is_hermitian:
-        raise qml.QuantumFunctionError(
-            f"{op.name} is not an observable: cannot be used with expval"
-        )
+        warnings.warn(f"{op.name} might not be an observable.")
 
     return MeasurementProcess(Expectation, obs=op)
 
@@ -581,8 +580,7 @@ def var(op):
         QuantumFunctionError: `op` is not an instance of :class:`~.Observable`
     """
     if not op.is_hermitian:
-        raise qml.QuantumFunctionError(f"{op.name} is not an observable: cannot be used with var")
-
+        warnings.warn(f"{op.name} might not be an observable.")
     return MeasurementProcess(Variance, obs=op)
 
 
@@ -660,12 +658,7 @@ def sample(op=None, wires=None):
         observable ``obs``.
     """
     if op is not None and not op.is_hermitian:  # None type is also allowed for op
-        raise qml.QuantumFunctionError(
-            f"{op.name} is not an observable: cannot be used with sample"
-        )
-
-    if isinstance(op, (qml.ops.Sum, qml.ops.SProd, qml.ops.Prod)):  # pylint: disable=no-member
-        raise qml.QuantumFunctionError("Symbolic Operations are not supported for sampling yet.")
+        warnings.warn(f"{op.name} might not be an observable.")
 
     if wires is not None:
         if op is not None:
@@ -749,12 +742,7 @@ def counts(op=None, wires=None):
         observable ``obs``.
     """
     if op is not None and not op.is_hermitian:  # None type is also allowed for op
-        raise qml.QuantumFunctionError(
-            f"{op.name} is not an observable: cannot be used with counts"
-        )
-
-    if isinstance(op, (qml.ops.Sum, qml.ops.SProd, qml.ops.Prod)):  # pylint: disable=no-member
-        raise qml.QuantumFunctionError("Symbolic Operations are not supported for sampling yet.")
+        warnings.warn(f"{op.name} might not be an observable.")
 
     if wires is not None:
         if op is not None:

--- a/tests/test_measurements.py
+++ b/tests/test_measurements.py
@@ -114,16 +114,16 @@ class TestExpval:
         assert res.dtype == r_dtype
 
     def test_not_an_observable(self):
-        """Test that a qml.QuantumFunctionError is raised if the provided
-        argument is not an observable"""
+        """Test that a warning is raised if the provided
+        argument might not be an observable."""
         dev = qml.device("default.qubit", wires=2)
 
         @qml.qnode(dev)
         def circuit():
             qml.RX(0.52, wires=0)
-            return qml.expval(qml.CNOT(wires=[0, 1]))
+            return qml.expval(qml.prod(qml.PauliX(0), qml.PauliZ(0)))
 
-        with pytest.raises(qml.QuantumFunctionError, match="CNOT is not an observable"):
+        with pytest.warns(UserWarning, match="Prod might not be an observable."):
             res = circuit()
 
     def test_observable_return_type_is_expectation(self):
@@ -190,16 +190,16 @@ class TestVar:
         assert res.dtype == r_dtype
 
     def test_not_an_observable(self):
-        """Test that a qml.QuantumFunctionError is raised if the provided
-        argument is not an observable"""
+        """Test that a UserWarning is raised if the provided
+        argument might not be an observable."""
         dev = qml.device("default.qubit", wires=2)
 
         @qml.qnode(dev)
         def circuit():
             qml.RX(0.52, wires=0)
-            return qml.var(qml.CNOT(wires=[0, 1]))
+            return qml.var(qml.prod(qml.PauliX(0), qml.PauliZ(0)))
 
-        with pytest.raises(qml.QuantumFunctionError, match="CNOT is not an observable"):
+        with pytest.warns(UserWarning, match="Prod might not be an observable."):
             res = circuit()
 
     def test_observable_return_type_is_variance(self):
@@ -378,16 +378,16 @@ class TestSample:
         assert np.array_equal(result[2].shape, (n_sample,))
 
     def test_not_an_observable(self):
-        """Test that a qml.QuantumFunctionError is raised if the provided
-        argument is not an observable"""
-        dev = qml.device("default.qubit", wires=2)
+        """Test that a UserWarning is raised if the provided
+        argument might not be an observable."""
+        dev = qml.device("default.qubit", wires=2, shots=10)
 
         @qml.qnode(dev)
         def circuit():
             qml.RX(0.52, wires=0)
-            return qml.sample(qml.CNOT(wires=[0, 1]))
+            return qml.sample(qml.prod(qml.PauliX(0), qml.PauliZ(0)))
 
-        with pytest.raises(qml.QuantumFunctionError, match="CNOT is not an observable"):
+        with pytest.warns(UserWarning, match="Prod might not be an observable."):
             sample = circuit()
 
     def test_observable_return_type_is_sample(self):
@@ -575,16 +575,16 @@ class TestCounts:
             res = circuit()
 
     def test_not_an_observable(self):
-        """Test that a qml.QuantumFunctionError is raised if the provided
-        argument is not an observable"""
-        dev = qml.device("default.qubit", wires=2)
+        """Test that a UserWarning is raised if the provided
+        argument might not be an observable."""
+        dev = qml.device("default.qubit", wires=2, shots=10)
 
         @qml.qnode(dev)
         def circuit():
             qml.RX(0.52, wires=0)
-            return qml.counts(qml.CNOT(wires=[0, 1]))
+            return qml.counts(qml.prod(qml.PauliX(0), qml.PauliZ(0)))
 
-        with pytest.raises(qml.QuantumFunctionError, match="CNOT is not an observable"):
+        with pytest.warns(UserWarning, match="Prod might not be an observable."):
             sample = circuit()
 
     def test_counts_dimension(self, tol):
@@ -1041,16 +1041,19 @@ class TestBetaStatisticsError:
     """Tests for errors arising for the beta statistics functions"""
 
     def test_not_an_observable(self, stat_func):
-        """Test that a qml.QuantumFunctionError is raised if the provided
-        argument is not an observable"""
+        """Test that a UserWarning is raised if the provided
+        argument might not be an observable."""
+        if stat_func is sample:
+            pytest.skip("Sampling is not yet supported with symbolic operators.")
+
         dev = qml.device("default.qubit", wires=2)
 
         @qml.qnode(dev)
         def circuit():
             qml.RX(0.52, wires=0)
-            return stat_func(qml.CNOT(wires=[0, 1]))
+            return stat_func(qml.prod(qml.PauliX(0), qml.PauliZ(0)))
 
-        with pytest.raises(qml.QuantumFunctionError, match="CNOT is not an observable"):
+        with pytest.warns(UserWarning, match="Prod might not be an observable."):
             res = circuit()
 
 


### PR DESCRIPTION
Raise warning when using non-hermitian observables.