### PR TITLE
Remove use of in place inversion

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -85,6 +85,8 @@
   RX(-1, wires=[0])
   ```
 
+* Internal use of in-place inversion is eliminated in preparation of its deprecation.
+
 <h3>Breaking changes</h3>
 
 <h3>Deprecations</h3>

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -85,7 +85,8 @@
   RX(-1, wires=[0])
   ```
 
-* Internal use of in-place inversion is eliminated in preparation of its deprecation.
+* Internal use of in-place inversion is eliminated in preparation for its deprecation.
+  [(#2965)](https://github.com/PennyLaneAI/pennylane/pull/2965)
 
 <h3>Breaking changes</h3>
 

--- a/pennylane/ops/qubit/non_parametric_ops.py
+++ b/pennylane/ops/qubit/non_parametric_ops.py
@@ -1835,42 +1835,41 @@ class Toffoli(Operation):
 
         **Example:**
 
-        >>> print(qml.Toffoli.compute_decomposition((0,1,2)))
+        >>> qml.Toffoli.compute_decomposition((0,1,2))
         [Hadamard(wires=[2]),
         CNOT(wires=[1, 2]),
-        T.inv(wires=[2]),
+        Adjoint(T)(wires=[2]),
         CNOT(wires=[0, 2]),
         T(wires=[2]),
         CNOT(wires=[1, 2]),
-        T.inv(wires=[2]),
+        Adjoint(T)(wires=[2]),
         CNOT(wires=[0, 2]),
         T(wires=[2]),
         T(wires=[1]),
         CNOT(wires=[0, 1]),
         Hadamard(wires=[2]),
         T(wires=[0]),
-        T.inv(wires=[1]),
+        Adjoint(T)(wires=[1]),
         CNOT(wires=[0, 1])]
 
         """
-        decomp_ops = [
+        return [
             Hadamard(wires=wires[2]),
             CNOT(wires=[wires[1], wires[2]]),
-            T(wires=wires[2]).inv(),
+            qml.adjoint(T(wires=wires[2])),
             CNOT(wires=[wires[0], wires[2]]),
             T(wires=wires[2]),
             CNOT(wires=[wires[1], wires[2]]),
-            T(wires=wires[2]).inv(),
+            qml.adjoint(T(wires=wires[2])),
             CNOT(wires=[wires[0], wires[2]]),
             T(wires=wires[2]),
             T(wires=wires[1]),
             CNOT(wires=[wires[0], wires[1]]),
             Hadamard(wires=wires[2]),
             T(wires=wires[0]),
-            T(wires=wires[1]).inv(),
+            qml.adjoint(T(wires=wires[1])),
             CNOT(wires=[wires[0], wires[1]]),
         ]
-        return decomp_ops
 
     def adjoint(self):
         return Toffoli(wires=self.wires)

--- a/pennylane/tape/tape.py
+++ b/pennylane/tape/tape.py
@@ -703,10 +703,7 @@ class QuantumTape(AnnotatedQueue):
         self._par_info = {parameter_mapping[k]: v for k, v in self._par_info.items()}
 
         for idx, op in enumerate(self._ops):
-            try:
-                self._ops[idx] = op.adjoint()
-            except qml.operation.AdjointUndefinedError:
-                op.inverse = not op.inverse
+            self._ops[idx] = qml.adjoint(op, lazy=False)
 
         self._ops = list(reversed(self._ops))
 

--- a/pennylane/templates/subroutines/qpe.py
+++ b/pennylane/templates/subroutines/qpe.py
@@ -167,6 +167,6 @@ class QuantumPhaseEstimation(Operation):
                 ControlledQubitUnitary(unitary_powers.pop(), control_wires=wire, wires=target_wires)
             )
 
-        op_list.append(qml.templates.QFT(wires=estimation_wires).inv())
+        op_list.append(qml.adjoint(qml.templates.QFT(wires=estimation_wires)))
 
         return op_list

--- a/pennylane/transforms/adjoint_metric_tensor.py
+++ b/pennylane/transforms/adjoint_metric_tensor.py
@@ -51,11 +51,8 @@ def _apply_operations(state, op, device, invert=False):
         device._apply_basis_state(op.parameters[0], op.wires)
         return device._state
 
-    if invert:
-        op.inv()
-    state = device._apply_operation(state, op)
-    if invert:
-        op.inv()
+    apply_op = qml.adjoint(op) if invert else op
+    state = device._apply_operation(state, apply_op)
 
     return state
 

--- a/pennylane/transforms/qmc.py
+++ b/pennylane/transforms/qmc.py
@@ -352,6 +352,6 @@ def quantum_monte_carlo(fn, wires, target_wire, estimation_wires):
             for _ in range(n_reps):
                 q(*args, **kwargs)
 
-        QFT(wires=estimation_wires).inv()
+        adjoint(QFT(wires=estimation_wires))
 
     return wrapper

--- a/tests/templates/test_subroutines/test_qpe.py
+++ b/tests/templates/test_subroutines/test_qpe.py
@@ -33,11 +33,15 @@ class TestDecomposition:
             qml.ControlledQubitUnitary(m @ m, control_wires=[1], wires=[0]),
             qml.Hadamard(2),
             qml.ControlledQubitUnitary(m, control_wires=[2], wires=[0]),
-            qml.QFT(wires=[1, 2]).inv()
+            qml.adjoint(qml.QFT(wires=[1, 2]))
 
         assert len(tape2.queue) == len(tape.queue)
-        assert all([op1.name == op2.name for op1, op2 in zip(tape.queue, tape2.queue)])
-        assert all([op1.wires == op2.wires for op1, op2 in zip(tape.queue, tape2.queue)])
+        for op1, op2 in zip(tape.queue[:-1], tape2.queue[:-1]):
+            assert qml.equal(op1, op2)
+
+        assert isinstance(tape[-1], qml.ops.op_math.Adjoint)
+        assert qml.equal(tape[-1].base, qml.QFT(wires=(1, 2)))
+
         assert np.allclose(tape.queue[1].matrix(), tape2.queue[1].matrix())
         assert np.allclose(tape.queue[3].matrix(), tape2.queue[3].matrix())
 

--- a/tests/templates/test_subroutines/test_qpe.py
+++ b/tests/templates/test_subroutines/test_qpe.py
@@ -36,6 +36,7 @@ class TestDecomposition:
             qml.adjoint(qml.QFT(wires=[1, 2]))
 
         assert len(tape2.queue) == len(tape.queue)
+        # qml.equal doesn't work for Adjoint op yet, so we stop before we get to it.
         for op1, op2 in zip(tape.queue[:-1], tape2.queue[:-1]):
             assert qml.equal(op1, op2)
 


### PR DESCRIPTION
In preparation for deprecating in-place inversion with `Operation.inv`, this PR eliminates its use internally in PennyLane.