### PR TITLE
Updated GPU Tests workflow file to only run if the pull_request is in open state

### DIFF
--- a/.github/workflows/tests-gpu.yml
+++ b/.github/workflows/tests-gpu.yml
@@ -24,7 +24,15 @@ jobs:
       - ubuntu-22.04
       - gpu
 
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'gpu'))
+    if: >-
+      ${{
+        github.event_name == 'push' ||
+        (
+          github.event_name == 'pull_request' &&
+          contains(github.event.pull_request.labels.*.name, 'gpu') &&
+          github.event.pull_request.state == 'open'
+        )
+      }}
 
     strategy:
       max-parallel: 2

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -101,6 +101,7 @@ Olivia Di Matteo,
 Josh Izaac,
 Edward Jiang,
 Korbinian Kottmann,
+Rashid N H M,
 Zeyue Niu,
 Mudit Pandey,
 Antal Száva


### PR DESCRIPTION
**Context:** Currently the GPU tests run on the `labeled` event with the `gpu` label being added even if the PR the label is being added to is Closed/Merged. This is wasteful since the number of GPU runners we have are limited.

**Description of the Change:** This PR updates the conditional check for the GPU tests running on only run on open PRs.

**Benefits:** Better utilization of self-hosted runners

**Possible Drawbacks:** 
None. Unless we have a new situation where we'd like GPU tests to run on already merged PRs, but do not see that as being the case.

**Related GitHub Issues:**
None.