### PR TITLE
Updated ReadTheDocs badge to new pennylane docs url

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
     <img src="https://img.shields.io/codecov/c/github/PennyLaneAI/pennylane/master.svg?logo=codecov&style=flat-square" />
   </a>
   <!-- ReadTheDocs -->
-  <a href="https://pennylane.readthedocs.io">
-    <img src="https://img.shields.io/readthedocs/pennylane.svg?logo=read-the-docs&style=flat-square" />
+  <a href="https://docs.pennylane.ai/en/latest">
+    <img src="https://readthedocs.com/projects/xanaduai-pennylane/badge/?version=latest&style=flat-square" />
   </a>
   <!-- PyPI -->
   <a href="https://pypi.org/project/PennyLane">


### PR DESCRIPTION
**Context:** New ReadTheDocs badge

**Description of the Change:**
The current RTD badge on the pennylane README uses https://shield.io, which unfortunately does not support the Business tier hosting of RTD. 

The new solution is to use the badge that RTD themselves generate for each project. 

This PR updates the RTD docs badge with the new links.

**Benefits:**
Old badge will go stale once the current community RTD builds are disabled. This new badge reflects the updated status.

**Possible Drawbacks:**
No logo available with the new badge

**Related GitHub Issues:**
None