### PR TITLE
Add simplify method to parametric ops

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -116,7 +116,7 @@
   print(qnode(x, H), qml.grad(qnode)(x, H))
   ```
 
-* `qml.exp` exponentiates an Operator.  An optional scalar coefficient can multiply the 
+* `qml.exp` exponentiates an Operator.  An optional scalar coefficient can multiply the
   Operator before exponentiation. Internally, this constructor functions creates the new
   class `qml.ops.op_math.Exp`.
   [(#2799)](https://github.com/PennyLaneAI/pennylane/pull/2799)
@@ -150,6 +150,18 @@
 
 * Added `PSWAP` operator.
   [(#2667)](https://github.com/PennyLaneAI/pennylane/pull/2667)
+
+* The `qml.simplify` method can now simplify parametrized operations.
+  [(#3012)](https://github.com/PennyLaneAI/pennylane/pull/3012)
+
+  ```pycon
+  >>> op1 = qml.RX(30.0, wires=0)
+  >>> qml.simplify(op1)
+  RX(4.867258771281655, wires=[0])
+  >>> op2 = qml.Rot(np.pi / 2, 5.0, -np.pi / 2, wires=0)
+  >>> qml.simplify(op2)
+  RX(5.0, wires=[0])
+  ```
 
 * The `qml.simplify` method now can compute the adjoint and power of specific operators.
   [(#2922)](https://github.com/PennyLaneAI/pennylane/pull/2922)
@@ -216,7 +228,7 @@
   the new `circuit` keyword argument.
   [(#2820)](https://github.com/PennyLaneAI/pennylane/pull/2820)
 
-* The `expand_matrix()` has been moved from `~/operation.py` to 
+* The `expand_matrix()` has been moved from `~/operation.py` to
   `~/math/matrix_manipulation.py`
   [(#3008)](https://github.com/PennyLaneAI/pennylane/pull/3008)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -115,8 +115,8 @@
 
   print(qnode(x, H), qml.grad(qnode)(x, H))
   ```
-  
-* `expand_matrix()` method now allows the sparse matrix representation of an operator to be extended to 
+
+* `expand_matrix()` method now allows the sparse matrix representation of an operator to be extended to
   a larger hilbert space.
   [(#2998)](https://github.com/PennyLaneAI/pennylane/pull/2998)
 
@@ -180,6 +180,9 @@
   >>> op2 = qml.Rot(np.pi / 2, 5.0, -np.pi / 2, wires=0)
   >>> qml.simplify(op2)
   RX(5.0, wires=[0])
+  >>> op3 = qml.RX(4 * np.pi, wires=0)
+  >>> qml.simplify(op3)
+  Identity(wires=[0])
   ```
 
 * The `qml.simplify` method now can compute the adjoint and power of specific operators.

--- a/pennylane/math/single_dispatch.py
+++ b/pennylane/math/single_dispatch.py
@@ -197,7 +197,6 @@ ar.autoray._SUBMODULE_ALIASES["tensorflow", "arctan"] = "tensorflow.math"
 ar.autoray._SUBMODULE_ALIASES["tensorflow", "arctan2"] = "tensorflow.math"
 ar.autoray._SUBMODULE_ALIASES["tensorflow", "diag"] = "tensorflow.linalg"
 ar.autoray._SUBMODULE_ALIASES["tensorflow", "kron"] = "tensorflow.experimental.numpy"
-ar.autoray._SUBMODULE_ALIASES["tensorflow", "mod"] = "tensorflow.experimental.numpy"
 ar.autoray._SUBMODULE_ALIASES["tensorflow", "moveaxis"] = "tensorflow.experimental.numpy"
 ar.autoray._SUBMODULE_ALIASES["tensorflow", "sinc"] = "tensorflow.experimental.numpy"
 ar.autoray._SUBMODULE_ALIASES["tensorflow", "isclose"] = "tensorflow.experimental.numpy"
@@ -450,7 +449,6 @@ ar.register_function("torch", "expand_dims", lambda x, axis: _i("torch").unsquee
 ar.register_function("torch", "shape", lambda x: tuple(x.shape))
 ar.register_function("torch", "gather", lambda x, indices: x[indices])
 ar.register_function("torch", "equal", lambda x, y: _i("torch").eq(x, y))
-ar.register_function("torch", "mod", lambda x, y: _i("torch").remainder(x, y))
 
 ar.register_function(
     "torch",

--- a/pennylane/math/single_dispatch.py
+++ b/pennylane/math/single_dispatch.py
@@ -197,6 +197,7 @@ ar.autoray._SUBMODULE_ALIASES["tensorflow", "arctan"] = "tensorflow.math"
 ar.autoray._SUBMODULE_ALIASES["tensorflow", "arctan2"] = "tensorflow.math"
 ar.autoray._SUBMODULE_ALIASES["tensorflow", "diag"] = "tensorflow.linalg"
 ar.autoray._SUBMODULE_ALIASES["tensorflow", "kron"] = "tensorflow.experimental.numpy"
+ar.autoray._SUBMODULE_ALIASES["tensorflow", "mod"] = "tensorflow.experimental.numpy"
 ar.autoray._SUBMODULE_ALIASES["tensorflow", "moveaxis"] = "tensorflow.experimental.numpy"
 ar.autoray._SUBMODULE_ALIASES["tensorflow", "sinc"] = "tensorflow.experimental.numpy"
 ar.autoray._SUBMODULE_ALIASES["tensorflow", "isclose"] = "tensorflow.experimental.numpy"
@@ -449,6 +450,7 @@ ar.register_function("torch", "expand_dims", lambda x, axis: _i("torch").unsquee
 ar.register_function("torch", "shape", lambda x: tuple(x.shape))
 ar.register_function("torch", "gather", lambda x, indices: x[indices])
 ar.register_function("torch", "equal", lambda x, y: _i("torch").eq(x, y))
+ar.register_function("torch", "mod", lambda x, y: _i("torch").remainder(x, y))
 
 ar.register_function(
     "torch",

--- a/pennylane/ops/functions/is_commuting.py
+++ b/pennylane/ops/functions/is_commuting.py
@@ -341,15 +341,8 @@ def is_commuting(operation1, operation2):
     if operation1.name == "CRot" and operation2.name == "CRot":
         return check_commutation_two_non_simplified_crot(operation1, operation2)
 
-    # Parametric operation might implement the identity operator
-    commutation_identity_simplification_1 = check_simplify_identity_commutation(operation1)
-    if commutation_identity_simplification_1 is not None:
-        return commutation_identity_simplification_1
-
-    # pylint:disable=arguments-out-of-order
-    commutation_identity_simplification_2 = check_simplify_identity_commutation(operation2)
-    if commutation_identity_simplification_2 is not None:
-        return commutation_identity_simplification_2
+    if "Identity" in (operation1.name, operation2.name):
+        return True
 
     # Check if operations are non simplified rotations and return commutation if it is the case.
     op_set = {"U2", "U3", "Rot", "CRot"}

--- a/pennylane/ops/functions/is_commuting.py
+++ b/pennylane/ops/functions/is_commuting.py
@@ -168,21 +168,6 @@ def check_commutation_two_non_simplified_crot(operation1, operation2):
     return False
 
 
-def check_simplify_identity_commutation(op):
-    r"""Check that a parametric operation can be simplified to the identity operator.
-    If simplification is not possible, it returns None.
-
-    Args:
-        op (pennylane.Operation): First operation.
-
-    Returns:
-        Bool, None: True if op can be simplified to the identity, None otherwise.
-    """
-    return (
-        True if op.data and op.name != "U2" and np.allclose(np.mod(op.data, 2 * np.pi), 0) else None
-    )
-
-
 def check_commutation_two_non_simplified_rotations(operation1, operation2):
     r"""Check that the operations are two non simplified operations. If it is the case, then it checks commutation
     for two rotations that were not simplified.

--- a/pennylane/ops/qubit/parametric_ops.py
+++ b/pennylane/ops/qubit/parametric_ops.py
@@ -879,18 +879,18 @@ class Rot(Operation):
         """
         p0, p1, p2 = [p % (4 * np.pi) for p in self.data]
 
-        if qml.math.allclose(p0 % (2 * np.pi), np.pi / 2) and qml.math.allclose(
-            p2 % (2 * np.pi), 3 * np.pi / 2
-        ):
+        if qml.math.allclose(p0, 0) and qml.math.allclose(p1, 0) and qml.math.allclose(p2, 0):
+            return qml.Identity(wires=self.wires)
+        if qml.math.allclose(p0, np.pi / 2) and qml.math.allclose(p2, 7 * np.pi / 2):
             return qml.RX(p1, wires=self.wires)
-        if qml.math.allclose(p0 % (2 * np.pi), 0) and qml.math.allclose(p2 % (2 * np.pi), 0):
+        if qml.math.allclose(p0, 0) and qml.math.allclose(p2, 0):
             return qml.RY(p1, wires=self.wires)
-        if qml.math.allclose(p1 % (2 * np.pi), 0):
-            return qml.RZ((p0 + p2) % (2 * np.pi), wires=self.wires)
+        if qml.math.allclose(p1, 0):
+            return qml.RZ((p0 + p2) % (4 * np.pi), wires=self.wires)
         if (
-            qml.math.allclose(p0 % (2 * np.pi), np.pi)
-            and qml.math.allclose(p1 % (2 * np.pi), np.pi / 2)
-            and qml.math.allclose(p2 % (2 * np.pi), 0)
+            qml.math.allclose(p0, np.pi)
+            and qml.math.allclose(p1, np.pi / 2)
+            and qml.math.allclose(p2, 0)
         ):
             return qml.Hadamard(wires=self.wires)
 
@@ -2084,18 +2084,18 @@ class CRot(Operation):
 
         p0, p1, p2 = [p % (4 * np.pi) for p in params]
 
-        if qml.math.allclose(p0 % (2 * np.pi), np.pi / 2) and qml.math.allclose(
-            p2 % (2 * np.pi), 3 * np.pi / 2
-        ):
+        if qml.math.allclose(p0, 0) and qml.math.allclose(p1, 0) and qml.math.allclose(p2, 0):
+            return qml.Identity(wires=wires[0])
+        if qml.math.allclose(p0, np.pi / 2) and qml.math.allclose(p2, 7 * np.pi / 2):
             return qml.CRX(p1, wires=wires)
-        if qml.math.allclose(p0 % (2 * np.pi), 0) and qml.math.allclose(p2 % (2 * np.pi), 0):
+        if qml.math.allclose(p0, 0) and qml.math.allclose(p2, 0):
             return qml.CRY(p1, wires=wires)
-        if qml.math.allclose(p1 % (2 * np.pi), 0):
-            return qml.CRZ((p0 + p2) % (2 * np.pi), wires=wires)
+        if qml.math.allclose(p1, 0):
+            return qml.CRZ((p0 + p2) % (4 * np.pi), wires=wires)
         if (
-            qml.math.allclose(p0 % (2 * np.pi), np.pi)
-            and qml.math.allclose(p1 % (2 * np.pi), np.pi / 2)
-            and qml.math.allclose(p2 % (2 * np.pi), 0)
+            qml.math.allclose(p0, np.pi)
+            and qml.math.allclose(p1, np.pi / 2)
+            and qml.math.allclose(p2, 0)
         ):
             hadamard = qml.Hadamard
             return qml.ctrl(hadamard, control=self.control_wires)(wires=target_wires)
@@ -2520,6 +2520,8 @@ class U3(Operation):
         p0 = params[0] % (4 * np.pi)
         p1, p2 = [p % (2 * np.pi) for p in params[1:]]
 
+        if qml.math.allclose(p0, 0) and qml.math.allclose(p1, 0) and qml.math.allclose(p2, 0):
+            return qml.Identity(wires=wires)
         if qml.math.allclose(p0, 0) and not qml.math.allclose(p1, 0) and qml.math.allclose(p2, 0):
             return qml.PhaseShift(p1, wires=wires)
         if (

--- a/pennylane/ops/qubit/parametric_ops.py
+++ b/pennylane/ops/qubit/parametric_ops.py
@@ -2312,6 +2312,8 @@ class U2(Operation):
             return qml.RY(np.pi / 2, wires=wires)
         if qml.math.allclose(delta, np.pi / 2) and qml.math.allclose(phi, 3 * np.pi / 2):
             return qml.RX(np.pi / 2, wires=wires)
+        if qml.math.allclose(delta, 3 * np.pi / 2) and qml.math.allclose(phi, np.pi / 2):
+            return qml.RX(3 * np.pi / 2, wires=wires)
 
         return U2(phi, delta, wires=wires)
 

--- a/pennylane/ops/qubit/parametric_ops.py
+++ b/pennylane/ops/qubit/parametric_ops.py
@@ -120,7 +120,7 @@ class RX(Operation):
         return new_op.inv() if self.inverse else new_op
 
     def simplify(self):
-        theta = qml.math.mod(self.data[0], 4 * np.pi)
+        theta = self.data[0] % (4 * np.pi)
         return RX(theta, wires=self.wires)
 
     def single_qubit_rot_angles(self):
@@ -214,7 +214,7 @@ class RY(Operation):
         return new_op.inv() if self.inverse else new_op
 
     def simplify(self):
-        theta = qml.math.mod(self.data[0], 4 * np.pi)
+        theta = self.data[0] % (4 * np.pi)
         return RY(theta, wires=self.wires)
 
     def single_qubit_rot_angles(self):
@@ -348,7 +348,7 @@ class RZ(Operation):
         return new_op.inv() if self.inverse else new_op
 
     def simplify(self):
-        theta = qml.math.mod(self.data[0], 4 * np.pi)
+        theta = self.data[0] % (4 * np.pi)
         return RZ(theta, wires=self.wires)
 
     def single_qubit_rot_angles(self):
@@ -511,7 +511,7 @@ class PhaseShift(Operation):
         return new_op.inv() if self.inverse else new_op
 
     def simplify(self):
-        phi = qml.math.mod(self.data[0], 2 * np.pi)
+        phi = self.data[0] % (2 * np.pi)
         return PhaseShift(phi, wires=self.wires)
 
     def single_qubit_rot_angles(self):
@@ -690,7 +690,7 @@ class ControlledPhaseShift(Operation):
         return [ControlledPhaseShift(self.data[0] * z, wires=self.wires)]
 
     def simplify(self):
-        phi = qml.math.mod(self.data[0], 2 * np.pi)
+        phi = self.data[0] % (2 * np.pi)
         return ControlledPhaseShift(phi, wires=self.wires)
 
     @property
@@ -857,14 +857,14 @@ class Rot(Operation):
         Hadamard(wires=[0])
 
         """
-        p0, p1, p2 = qml.math.mod(self.data, 2 * np.pi)
+        p0, p1, p2 = [p % (2 * np.pi) for p in self.data]
 
-        if np.allclose(p0, np.pi / 2) and np.allclose(np.mod(self.data[2], -2 * np.pi), -np.pi / 2):
-            return qml.RX(self.data[1], wires=self.wires)
+        if np.allclose(p0, np.pi / 2) and np.allclose(p2, 3 * np.pi / 2):
+            return qml.RX(p1, wires=self.wires)
         if np.allclose(p0, 0) and np.allclose(p2, 0):
-            return qml.RY(self.data[1], wires=self.wires)
+            return qml.RY(p1, wires=self.wires)
         if np.allclose(p1, 0):
-            return qml.RZ(qml.math.mod(self.data[0] + self.data[2], 2 * np.pi), wires=self.wires)
+            return qml.RZ((self.data[0] + self.data[2]) % (2 * np.pi), wires=self.wires)
         if np.allclose(p0, np.pi) and np.allclose(p1, np.pi / 2) and np.allclose(p2, 0):
             return qml.Hadamard(wires=self.wires)
 
@@ -1032,7 +1032,7 @@ class MultiRZ(Operation):
         return [MultiRZ(self.data[0] * z, wires=self.wires)]
 
     def simplify(self):
-        theta = qml.math.mod(self.data[0], 4 * np.pi)
+        theta = self.data[0] % (4 * np.pi)
         return MultiRZ(theta, wires=self.wires)
 
 
@@ -1498,7 +1498,7 @@ class CRX(Operation):
         return [CRX(self.data[0] * z, wires=self.wires)]
 
     def simplify(self):
-        phi = qml.math.mod(self.data[0], 4 * np.pi)
+        phi = self.data[0] % (4 * np.pi)
         return CRX(phi, wires=self.wires)
 
     @property
@@ -1654,7 +1654,7 @@ class CRY(Operation):
         return [CRY(self.data[0] * z, wires=self.wires)]
 
     def simplify(self):
-        phi = qml.math.mod(self.data[0], 4 * np.pi)
+        phi = self.data[0] % (4 * np.pi)
         return CRY(phi, wires=self.wires)
 
     @property
@@ -1846,7 +1846,7 @@ class CRZ(Operation):
         return [CRZ(self.data[0] * z, wires=self.wires)]
 
     def simplify(self):
-        phi = qml.math.mod(self.data[0], 4 * np.pi)
+        phi = self.data[0] % (4 * np.pi)
         return CRZ(phi, wires=self.wires)
 
     @property
@@ -2040,14 +2040,14 @@ class CRot(Operation):
         wires = self.wires
         params = self.parameters
 
-        p0, p1, p2 = qml.math.mod(params, 2 * np.pi)
+        p0, p1, p2 = [p % (2 * np.pi) for p in params]
 
-        if np.allclose(p0, np.pi / 2) and np.allclose(np.mod(self.data[2], -2 * np.pi), -np.pi / 2):
-            return qml.CRX(self.data[1], wires=wires)
+        if np.allclose(p0, np.pi / 2) and np.allclose(p2, 3 * np.pi / 2):
+            return qml.CRX(p1, wires=wires)
         if np.allclose(p0, 0) and np.allclose(p2, 0):
-            return qml.CRY(self.data[1], wires=wires)
+            return qml.CRY(p1, wires=wires)
         if np.allclose(p1, 0):
-            return qml.CRZ(qml.math.mod(self.data[0] + self.data[2], 2 * np.pi), wires=wires)
+            return qml.CRZ((self.data[0] + self.data[2]) % (2 * np.pi), wires=wires)
         if np.allclose(p0, np.pi) and np.allclose(p1, np.pi / 2) and np.allclose(p2, 0):
             hadamard = qml.Hadamard
             return qml.ctrl(hadamard, control=self.control_wires)(wires=target_wires)
@@ -2164,7 +2164,7 @@ class U1(Operation):
         return [U1(self.data[0] * z, wires=self.wires)]
 
     def simplify(self):
-        phi = qml.math.mod(self.data[0], 2 * np.pi)
+        phi = self.data[0] % (2 * np.pi)
         return U1(phi, wires=self.wires)
 
 
@@ -2298,14 +2298,12 @@ class U2(Operation):
         """Simplifies the gate into RX or RY gates if possible."""
         wires = self.wires
 
-        phi, delta = qml.math.mod(self.data, 2 * np.pi)
+        phi, delta = [p % (2 * np.pi) for p in self.data]
 
-        if np.allclose(delta, 0) and np.allclose(np.mod(phi + delta, 2 * np.pi), 0):
+        if np.allclose(delta, 0) and np.allclose(phi, 0):
             return qml.RY(np.pi / 2, wires=wires)
-        if np.allclose(np.mod(self.data[1], np.pi / 2), 0) and np.allclose(
-            np.mod(phi + delta, 2 * np.pi), 0
-        ):
-            return qml.RX(delta, wires=wires)
+        if np.allclose(delta, np.pi / 2) and np.allclose(phi, 3 * np.pi / 2):
+            return qml.RX(np.pi / 2, wires=wires)
 
         return U2(phi, delta, wires=wires)
 
@@ -2463,16 +2461,12 @@ class U3(Operation):
         wires = self.wires
         params = self.parameters
 
-        p0 = qml.math.mod(params[0], 4 * np.pi)
-        p1, p2 = qml.math.mod(params[1:], 2 * np.pi)
+        p0 = params[0] % (4 * np.pi)
+        p1, p2 = [p % (2 * np.pi) for p in params[1:]]
 
         if np.allclose(p0, 0) and not np.allclose(p1, 0) and np.allclose(p2, 0):
             return qml.PhaseShift(p1, wires=wires)
-        if (
-            np.allclose(p2, np.pi / 2)
-            and np.allclose(np.mod(self.data[1] + self.data[2], 2 * np.pi), 0)
-            and not np.allclose(p0, 0)
-        ):
+        if np.allclose(p2, np.pi / 2) and np.allclose(p1, 3 * np.pi / 2) and not np.allclose(p0, 0):
             return qml.RX(p0, wires=wires)
         if not np.allclose(p0, 0) and np.allclose(p1, 0) and np.allclose(p2, 0):
             return qml.RY(p0, wires=wires)
@@ -2609,7 +2603,7 @@ class IsingXX(Operation):
         return [IsingXX(self.data[0] * z, wires=self.wires)]
 
     def simplify(self):
-        phi = qml.math.mod(self.data[0], 4 * np.pi)
+        phi = self.data[0] % (4 * np.pi)
         return IsingXX(phi, wires=self.wires)
 
 
@@ -2748,7 +2742,7 @@ class IsingYY(Operation):
         return [IsingYY(self.data[0] * z, wires=self.wires)]
 
     def simplify(self):
-        phi = qml.math.mod(self.data[0], 4 * np.pi)
+        phi = self.data[0] % (4 * np.pi)
         return IsingYY(phi, wires=self.wires)
 
 
@@ -2918,7 +2912,7 @@ class IsingZZ(Operation):
         return [IsingZZ(self.data[0] * z, wires=self.wires)]
 
     def simplify(self):
-        phi = qml.math.mod(self.data[0], 4 * np.pi)
+        phi = self.data[0] % (4 * np.pi)
         return IsingZZ(phi, wires=self.wires)
 
 
@@ -3099,7 +3093,7 @@ class IsingXY(Operation):
         return [IsingXY(self.data[0] * z, wires=self.wires)]
 
     def simplify(self):
-        phi = qml.math.mod(self.data[0], 4 * np.pi)
+        phi = self.data[0] % (4 * np.pi)
         return IsingXY(phi, wires=self.wires)
 
 
@@ -3244,5 +3238,5 @@ class PSWAP(Operation):
         return PSWAP(-phi, wires=self.wires)
 
     def simplify(self):
-        phi = qml.math.mod(self.data[0], 2 * np.pi)
+        phi = self.data[0] % (2 * np.pi)
         return PSWAP(phi, wires=self.wires)

--- a/pennylane/ops/qubit/parametric_ops.py
+++ b/pennylane/ops/qubit/parametric_ops.py
@@ -40,7 +40,7 @@ def can_replace(x, y):
     Convenience function that returns if x is close to y and if
     x does not require grad
     """
-    return qml.math.allclose(x, y) and not qml.math.requires_grad(x)
+    return (not qml.math.requires_grad(x)) and qml.math.allclose(x, y)
 
 
 class RX(Operation):

--- a/pennylane/ops/qubit/parametric_ops.py
+++ b/pennylane/ops/qubit/parametric_ops.py
@@ -35,7 +35,7 @@ INV_SQRT2 = 1 / math.sqrt(2)
 stack_last = functools.partial(qml.math.stack, axis=-1)
 
 
-def can_replace(x, y):
+def _can_replace(x, y):
     """
     Convenience function that returns true if x is close to y and if
     x does not require grad
@@ -130,7 +130,7 @@ class RX(Operation):
     def simplify(self):
         theta = self.data[0] % (4 * np.pi)
 
-        if can_replace(theta, 0):
+        if _can_replace(theta, 0):
             return qml.Identity(wires=self.wires)
 
         return RX(theta, wires=self.wires)
@@ -228,7 +228,7 @@ class RY(Operation):
     def simplify(self):
         theta = self.data[0] % (4 * np.pi)
 
-        if can_replace(theta, 0):
+        if _can_replace(theta, 0):
             return qml.Identity(wires=self.wires)
 
         return RY(theta, wires=self.wires)
@@ -366,7 +366,7 @@ class RZ(Operation):
     def simplify(self):
         theta = self.data[0] % (4 * np.pi)
 
-        if can_replace(theta, 0):
+        if _can_replace(theta, 0):
             return qml.Identity(wires=self.wires)
 
         return RZ(theta, wires=self.wires)
@@ -533,7 +533,7 @@ class PhaseShift(Operation):
     def simplify(self):
         phi = self.data[0] % (2 * np.pi)
 
-        if can_replace(phi, 0):
+        if _can_replace(phi, 0):
             return qml.Identity(wires=self.wires)
 
         return PhaseShift(phi, wires=self.wires)
@@ -716,7 +716,7 @@ class ControlledPhaseShift(Operation):
     def simplify(self):
         phi = self.data[0] % (2 * np.pi)
 
-        if can_replace(phi, 0):
+        if _can_replace(phi, 0):
             return qml.Identity(wires=self.wires[0])
 
         return ControlledPhaseShift(phi, wires=self.wires)
@@ -887,15 +887,15 @@ class Rot(Operation):
         """
         p0, p1, p2 = [p % (4 * np.pi) for p in self.data]
 
-        if can_replace(p0, 0) and can_replace(p1, 0) and can_replace(p2, 0):
+        if _can_replace(p0, 0) and _can_replace(p1, 0) and _can_replace(p2, 0):
             return qml.Identity(wires=self.wires)
-        if can_replace(p0, np.pi / 2) and can_replace(p2, 7 * np.pi / 2):
+        if _can_replace(p0, np.pi / 2) and _can_replace(p2, 7 * np.pi / 2):
             return qml.RX(p1, wires=self.wires)
-        if can_replace(p0, 0) and can_replace(p2, 0):
+        if _can_replace(p0, 0) and _can_replace(p2, 0):
             return qml.RY(p1, wires=self.wires)
-        if can_replace(p1, 0):
+        if _can_replace(p1, 0):
             return qml.RZ((p0 + p2) % (4 * np.pi), wires=self.wires)
-        if can_replace(p0, np.pi) and can_replace(p1, np.pi / 2) and can_replace(p2, 0):
+        if _can_replace(p0, np.pi) and _can_replace(p1, np.pi / 2) and _can_replace(p2, 0):
             return qml.Hadamard(wires=self.wires)
 
         return Rot(p0, p1, p2, wires=self.wires)
@@ -1064,7 +1064,7 @@ class MultiRZ(Operation):
     def simplify(self):
         theta = self.data[0] % (4 * np.pi)
 
-        if can_replace(theta, 0):
+        if _can_replace(theta, 0):
             return qml.Identity(wires=self.wires[0])
 
         return MultiRZ(theta, wires=self.wires)
@@ -1534,7 +1534,7 @@ class CRX(Operation):
     def simplify(self):
         phi = self.data[0] % (4 * np.pi)
 
-        if can_replace(phi, 0):
+        if _can_replace(phi, 0):
             return qml.Identity(wires=self.wires[0])
 
         return CRX(phi, wires=self.wires)
@@ -1694,7 +1694,7 @@ class CRY(Operation):
     def simplify(self):
         phi = self.data[0] % (4 * np.pi)
 
-        if can_replace(phi, 0):
+        if _can_replace(phi, 0):
             return qml.Identity(wires=self.wires[0])
 
         return CRY(phi, wires=self.wires)
@@ -1890,7 +1890,7 @@ class CRZ(Operation):
     def simplify(self):
         phi = self.data[0] % (4 * np.pi)
 
-        if can_replace(phi, 0):
+        if _can_replace(phi, 0):
             return qml.Identity(wires=self.wires[0])
 
         return CRZ(phi, wires=self.wires)
@@ -2088,15 +2088,15 @@ class CRot(Operation):
 
         p0, p1, p2 = [p % (4 * np.pi) for p in params]
 
-        if can_replace(p0, 0) and can_replace(p1, 0) and can_replace(p2, 0):
+        if _can_replace(p0, 0) and _can_replace(p1, 0) and _can_replace(p2, 0):
             return qml.Identity(wires=wires[0])
-        if can_replace(p0, np.pi / 2) and can_replace(p2, 7 * np.pi / 2):
+        if _can_replace(p0, np.pi / 2) and _can_replace(p2, 7 * np.pi / 2):
             return qml.CRX(p1, wires=wires)
-        if can_replace(p0, 0) and can_replace(p2, 0):
+        if _can_replace(p0, 0) and _can_replace(p2, 0):
             return qml.CRY(p1, wires=wires)
-        if can_replace(p1, 0):
+        if _can_replace(p1, 0):
             return qml.CRZ((p0 + p2) % (4 * np.pi), wires=wires)
-        if can_replace(p0, np.pi) and can_replace(p1, np.pi / 2) and can_replace(p2, 0):
+        if _can_replace(p0, np.pi) and _can_replace(p1, np.pi / 2) and _can_replace(p2, 0):
             hadamard = qml.Hadamard
             return qml.ctrl(hadamard, control=self.control_wires)(wires=target_wires)
 
@@ -2216,7 +2216,7 @@ class U1(Operation):
     def simplify(self):
         phi = self.data[0] % (2 * np.pi)
 
-        if can_replace(phi, 0):
+        if _can_replace(phi, 0):
             return qml.Identity(wires=self.wires)
 
         return U1(phi, wires=self.wires)
@@ -2354,11 +2354,11 @@ class U2(Operation):
 
         phi, delta = [p % (2 * np.pi) for p in self.data]
 
-        if can_replace(delta, 0) and can_replace(phi, 0):
+        if _can_replace(delta, 0) and _can_replace(phi, 0):
             return qml.RY(np.pi / 2, wires=wires)
-        if can_replace(delta, np.pi / 2) and can_replace(phi, 3 * np.pi / 2):
+        if _can_replace(delta, np.pi / 2) and _can_replace(phi, 3 * np.pi / 2):
             return qml.RX(np.pi / 2, wires=wires)
-        if can_replace(delta, 3 * np.pi / 2) and can_replace(phi, np.pi / 2):
+        if _can_replace(delta, 3 * np.pi / 2) and _can_replace(phi, np.pi / 2):
             return qml.RX(3 * np.pi / 2, wires=wires)
 
         return U2(phi, delta, wires=wires)
@@ -2520,13 +2520,17 @@ class U3(Operation):
         p0 = params[0] % (4 * np.pi)
         p1, p2 = [p % (2 * np.pi) for p in params[1:]]
 
-        if can_replace(p0, 0) and can_replace(p1, 0) and can_replace(p2, 0):
+        if _can_replace(p0, 0) and _can_replace(p1, 0) and _can_replace(p2, 0):
             return qml.Identity(wires=wires)
-        if can_replace(p0, 0) and not can_replace(p1, 0) and can_replace(p2, 0):
+        if _can_replace(p0, 0) and not _can_replace(p1, 0) and _can_replace(p2, 0):
             return qml.PhaseShift(p1, wires=wires)
-        if can_replace(p2, np.pi / 2) and can_replace(p1, 3 * np.pi / 2) and not can_replace(p0, 0):
+        if (
+            _can_replace(p2, np.pi / 2)
+            and _can_replace(p1, 3 * np.pi / 2)
+            and not _can_replace(p0, 0)
+        ):
             return qml.RX(p0, wires=wires)
-        if not can_replace(p0, 0) and can_replace(p1, 0) and can_replace(p2, 0):
+        if not _can_replace(p0, 0) and _can_replace(p1, 0) and _can_replace(p2, 0):
             return qml.RY(p0, wires=wires)
 
         return U3(p0, p1, p2, wires=wires)
@@ -2663,7 +2667,7 @@ class IsingXX(Operation):
     def simplify(self):
         phi = self.data[0] % (4 * np.pi)
 
-        if can_replace(phi, 0):
+        if _can_replace(phi, 0):
             return qml.Identity(wires=self.wires[0])
 
         return IsingXX(phi, wires=self.wires)
@@ -2806,7 +2810,7 @@ class IsingYY(Operation):
     def simplify(self):
         phi = self.data[0] % (4 * np.pi)
 
-        if can_replace(phi, 0):
+        if _can_replace(phi, 0):
             return qml.Identity(wires=self.wires[0])
 
         return IsingYY(phi, wires=self.wires)
@@ -2980,7 +2984,7 @@ class IsingZZ(Operation):
     def simplify(self):
         phi = self.data[0] % (4 * np.pi)
 
-        if can_replace(phi, 0):
+        if _can_replace(phi, 0):
             return qml.Identity(wires=self.wires[0])
 
         return IsingZZ(phi, wires=self.wires)
@@ -3177,7 +3181,7 @@ class IsingXY(Operation):
     def simplify(self):
         phi = self.data[0] % (4 * np.pi)
 
-        if can_replace(phi, 0):
+        if _can_replace(phi, 0):
             return qml.Identity(wires=self.wires[0])
 
         return IsingXY(phi, wires=self.wires)
@@ -3326,7 +3330,7 @@ class PSWAP(Operation):
     def simplify(self):
         phi = self.data[0] % (2 * np.pi)
 
-        if can_replace(phi, 0):
+        if _can_replace(phi, 0):
             return qml.SWAP(wires=self.wires)
 
         return PSWAP(phi, wires=self.wires)

--- a/pennylane/ops/qubit/parametric_ops.py
+++ b/pennylane/ops/qubit/parametric_ops.py
@@ -35,6 +35,14 @@ INV_SQRT2 = 1 / math.sqrt(2)
 stack_last = functools.partial(qml.math.stack, axis=-1)
 
 
+def can_replace(x, y):
+    """
+    Convenience function that returns if x is close to y and if
+    x does not require grad
+    """
+    return qml.math.allclose(x, y) and not qml.math.requires_grad(x)
+
+
 class RX(Operation):
     r"""
     The single qubit X rotation
@@ -122,7 +130,7 @@ class RX(Operation):
     def simplify(self):
         theta = self.data[0] % (4 * np.pi)
 
-        if not qml.math.requires_grad(theta) and qml.math.allclose(theta, 0):
+        if can_replace(theta, 0):
             return qml.Identity(wires=self.wires)
 
         return RX(theta, wires=self.wires)
@@ -220,7 +228,7 @@ class RY(Operation):
     def simplify(self):
         theta = self.data[0] % (4 * np.pi)
 
-        if not qml.math.requires_grad(theta) and qml.math.allclose(theta, 0):
+        if can_replace(theta, 0):
             return qml.Identity(wires=self.wires)
 
         return RY(theta, wires=self.wires)
@@ -358,7 +366,7 @@ class RZ(Operation):
     def simplify(self):
         theta = self.data[0] % (4 * np.pi)
 
-        if not qml.math.requires_grad(theta) and qml.math.allclose(theta, 0):
+        if can_replace(theta, 0):
             return qml.Identity(wires=self.wires)
 
         return RZ(theta, wires=self.wires)
@@ -525,7 +533,7 @@ class PhaseShift(Operation):
     def simplify(self):
         phi = self.data[0] % (2 * np.pi)
 
-        if not qml.math.requires_grad(phi) and qml.math.allclose(phi, 0):
+        if can_replace(phi, 0):
             return qml.Identity(wires=self.wires)
 
         return PhaseShift(phi, wires=self.wires)
@@ -708,7 +716,7 @@ class ControlledPhaseShift(Operation):
     def simplify(self):
         phi = self.data[0] % (2 * np.pi)
 
-        if not qml.math.requires_grad(phi) and qml.math.allclose(phi, 0):
+        if can_replace(phi, 0):
             return qml.Identity(wires=self.wires[0])
 
         return ControlledPhaseShift(phi, wires=self.wires)
@@ -879,19 +887,15 @@ class Rot(Operation):
         """
         p0, p1, p2 = [p % (4 * np.pi) for p in self.data]
 
-        if qml.math.allclose(p0, 0) and qml.math.allclose(p1, 0) and qml.math.allclose(p2, 0):
+        if can_replace(p0, 0) and can_replace(p1, 0) and can_replace(p2, 0):
             return qml.Identity(wires=self.wires)
-        if qml.math.allclose(p0, np.pi / 2) and qml.math.allclose(p2, 7 * np.pi / 2):
+        if can_replace(p0, np.pi / 2) and can_replace(p2, 7 * np.pi / 2):
             return qml.RX(p1, wires=self.wires)
-        if qml.math.allclose(p0, 0) and qml.math.allclose(p2, 0):
+        if can_replace(p0, 0) and can_replace(p2, 0):
             return qml.RY(p1, wires=self.wires)
-        if qml.math.allclose(p1, 0):
+        if can_replace(p1, 0):
             return qml.RZ((p0 + p2) % (4 * np.pi), wires=self.wires)
-        if (
-            qml.math.allclose(p0, np.pi)
-            and qml.math.allclose(p1, np.pi / 2)
-            and qml.math.allclose(p2, 0)
-        ):
+        if can_replace(p0, np.pi) and can_replace(p1, np.pi / 2) and can_replace(p2, 0):
             return qml.Hadamard(wires=self.wires)
 
         return Rot(p0, p1, p2, wires=self.wires)
@@ -1060,7 +1064,7 @@ class MultiRZ(Operation):
     def simplify(self):
         theta = self.data[0] % (4 * np.pi)
 
-        if not qml.math.requires_grad(theta) and qml.math.allclose(theta, 0):
+        if can_replace(theta, 0):
             return qml.Identity(wires=self.wires[0])
 
         return MultiRZ(theta, wires=self.wires)
@@ -1530,7 +1534,7 @@ class CRX(Operation):
     def simplify(self):
         phi = self.data[0] % (4 * np.pi)
 
-        if not qml.math.requires_grad(phi) and qml.math.allclose(phi, 0):
+        if can_replace(phi, 0):
             return qml.Identity(wires=self.wires[0])
 
         return CRX(phi, wires=self.wires)
@@ -1690,7 +1694,7 @@ class CRY(Operation):
     def simplify(self):
         phi = self.data[0] % (4 * np.pi)
 
-        if not qml.math.requires_grad(phi) and qml.math.allclose(phi, 0):
+        if can_replace(phi, 0):
             return qml.Identity(wires=self.wires[0])
 
         return CRY(phi, wires=self.wires)
@@ -1886,7 +1890,7 @@ class CRZ(Operation):
     def simplify(self):
         phi = self.data[0] % (4 * np.pi)
 
-        if not qml.math.requires_grad(phi) and qml.math.allclose(phi, 0):
+        if can_replace(phi, 0):
             return qml.Identity(wires=self.wires[0])
 
         return CRZ(phi, wires=self.wires)
@@ -2084,19 +2088,15 @@ class CRot(Operation):
 
         p0, p1, p2 = [p % (4 * np.pi) for p in params]
 
-        if qml.math.allclose(p0, 0) and qml.math.allclose(p1, 0) and qml.math.allclose(p2, 0):
+        if can_replace(p0, 0) and can_replace(p1, 0) and can_replace(p2, 0):
             return qml.Identity(wires=wires[0])
-        if qml.math.allclose(p0, np.pi / 2) and qml.math.allclose(p2, 7 * np.pi / 2):
+        if can_replace(p0, np.pi / 2) and can_replace(p2, 7 * np.pi / 2):
             return qml.CRX(p1, wires=wires)
-        if qml.math.allclose(p0, 0) and qml.math.allclose(p2, 0):
+        if can_replace(p0, 0) and can_replace(p2, 0):
             return qml.CRY(p1, wires=wires)
-        if qml.math.allclose(p1, 0):
+        if can_replace(p1, 0):
             return qml.CRZ((p0 + p2) % (4 * np.pi), wires=wires)
-        if (
-            qml.math.allclose(p0, np.pi)
-            and qml.math.allclose(p1, np.pi / 2)
-            and qml.math.allclose(p2, 0)
-        ):
+        if can_replace(p0, np.pi) and can_replace(p1, np.pi / 2) and can_replace(p2, 0):
             hadamard = qml.Hadamard
             return qml.ctrl(hadamard, control=self.control_wires)(wires=target_wires)
 
@@ -2216,7 +2216,7 @@ class U1(Operation):
     def simplify(self):
         phi = self.data[0] % (2 * np.pi)
 
-        if not qml.math.requires_grad(phi) and qml.math.allclose(phi, 0):
+        if can_replace(phi, 0):
             return qml.Identity(wires=self.wires)
 
         return U1(phi, wires=self.wires)
@@ -2354,11 +2354,11 @@ class U2(Operation):
 
         phi, delta = [p % (2 * np.pi) for p in self.data]
 
-        if qml.math.allclose(delta, 0) and qml.math.allclose(phi, 0):
+        if can_replace(delta, 0) and can_replace(phi, 0):
             return qml.RY(np.pi / 2, wires=wires)
-        if qml.math.allclose(delta, np.pi / 2) and qml.math.allclose(phi, 3 * np.pi / 2):
+        if can_replace(delta, np.pi / 2) and can_replace(phi, 3 * np.pi / 2):
             return qml.RX(np.pi / 2, wires=wires)
-        if qml.math.allclose(delta, 3 * np.pi / 2) and qml.math.allclose(phi, np.pi / 2):
+        if can_replace(delta, 3 * np.pi / 2) and can_replace(phi, np.pi / 2):
             return qml.RX(3 * np.pi / 2, wires=wires)
 
         return U2(phi, delta, wires=wires)
@@ -2520,17 +2520,13 @@ class U3(Operation):
         p0 = params[0] % (4 * np.pi)
         p1, p2 = [p % (2 * np.pi) for p in params[1:]]
 
-        if qml.math.allclose(p0, 0) and qml.math.allclose(p1, 0) and qml.math.allclose(p2, 0):
+        if can_replace(p0, 0) and can_replace(p1, 0) and can_replace(p2, 0):
             return qml.Identity(wires=wires)
-        if qml.math.allclose(p0, 0) and not qml.math.allclose(p1, 0) and qml.math.allclose(p2, 0):
+        if can_replace(p0, 0) and not can_replace(p1, 0) and can_replace(p2, 0):
             return qml.PhaseShift(p1, wires=wires)
-        if (
-            qml.math.allclose(p2, np.pi / 2)
-            and qml.math.allclose(p1, 3 * np.pi / 2)
-            and not qml.math.allclose(p0, 0)
-        ):
+        if can_replace(p2, np.pi / 2) and can_replace(p1, 3 * np.pi / 2) and not can_replace(p0, 0):
             return qml.RX(p0, wires=wires)
-        if not qml.math.allclose(p0, 0) and qml.math.allclose(p1, 0) and qml.math.allclose(p2, 0):
+        if not can_replace(p0, 0) and can_replace(p1, 0) and can_replace(p2, 0):
             return qml.RY(p0, wires=wires)
 
         return U3(p0, p1, p2, wires=wires)
@@ -2667,7 +2663,7 @@ class IsingXX(Operation):
     def simplify(self):
         phi = self.data[0] % (4 * np.pi)
 
-        if not qml.math.requires_grad(phi) and qml.math.allclose(phi, 0):
+        if can_replace(phi, 0):
             return qml.Identity(wires=self.wires[0])
 
         return IsingXX(phi, wires=self.wires)
@@ -2810,7 +2806,7 @@ class IsingYY(Operation):
     def simplify(self):
         phi = self.data[0] % (4 * np.pi)
 
-        if not qml.math.requires_grad(phi) and qml.math.allclose(phi, 0):
+        if can_replace(phi, 0):
             return qml.Identity(wires=self.wires[0])
 
         return IsingYY(phi, wires=self.wires)
@@ -2984,7 +2980,7 @@ class IsingZZ(Operation):
     def simplify(self):
         phi = self.data[0] % (4 * np.pi)
 
-        if not qml.math.requires_grad(phi) and qml.math.allclose(phi, 0):
+        if can_replace(phi, 0):
             return qml.Identity(wires=self.wires[0])
 
         return IsingZZ(phi, wires=self.wires)
@@ -3181,7 +3177,7 @@ class IsingXY(Operation):
     def simplify(self):
         phi = self.data[0] % (4 * np.pi)
 
-        if not qml.math.requires_grad(phi) and qml.math.allclose(phi, 0):
+        if can_replace(phi, 0):
             return qml.Identity(wires=self.wires[0])
 
         return IsingXY(phi, wires=self.wires)
@@ -3330,7 +3326,7 @@ class PSWAP(Operation):
     def simplify(self):
         phi = self.data[0] % (2 * np.pi)
 
-        if not qml.math.requires_grad(phi) and qml.math.allclose(phi, 0):
+        if can_replace(phi, 0):
             return qml.SWAP(wires=self.wires)
 
         return PSWAP(phi, wires=self.wires)

--- a/pennylane/ops/qubit/parametric_ops.py
+++ b/pennylane/ops/qubit/parametric_ops.py
@@ -121,6 +121,10 @@ class RX(Operation):
 
     def simplify(self):
         theta = self.data[0] % (4 * np.pi)
+
+        if not qml.math.requires_grad(theta) and qml.math.allclose(theta, 0):
+            return qml.Identity(wires=self.wires)
+
         return RX(theta, wires=self.wires)
 
     def single_qubit_rot_angles(self):
@@ -215,6 +219,10 @@ class RY(Operation):
 
     def simplify(self):
         theta = self.data[0] % (4 * np.pi)
+
+        if not qml.math.requires_grad(theta) and qml.math.allclose(theta, 0):
+            return qml.Identity(wires=self.wires)
+
         return RY(theta, wires=self.wires)
 
     def single_qubit_rot_angles(self):
@@ -349,6 +357,10 @@ class RZ(Operation):
 
     def simplify(self):
         theta = self.data[0] % (4 * np.pi)
+
+        if not qml.math.requires_grad(theta) and qml.math.allclose(theta, 0):
+            return qml.Identity(wires=self.wires)
+
         return RZ(theta, wires=self.wires)
 
     def single_qubit_rot_angles(self):
@@ -512,6 +524,10 @@ class PhaseShift(Operation):
 
     def simplify(self):
         phi = self.data[0] % (2 * np.pi)
+
+        if not qml.math.requires_grad(phi) and qml.math.allclose(phi, 0):
+            return qml.Identity(wires=self.wires)
+
         return PhaseShift(phi, wires=self.wires)
 
     def single_qubit_rot_angles(self):
@@ -691,6 +707,10 @@ class ControlledPhaseShift(Operation):
 
     def simplify(self):
         phi = self.data[0] % (2 * np.pi)
+
+        if not qml.math.requires_grad(phi) and qml.math.allclose(phi, 0):
+            return qml.Identity(wires=self.wires)
+
         return ControlledPhaseShift(phi, wires=self.wires)
 
     @property
@@ -1039,6 +1059,10 @@ class MultiRZ(Operation):
 
     def simplify(self):
         theta = self.data[0] % (4 * np.pi)
+
+        if not qml.math.requires_grad(theta) and qml.math.allclose(theta, 0):
+            return qml.Identity(wires=self.wires)
+
         return MultiRZ(theta, wires=self.wires)
 
 
@@ -1505,6 +1529,10 @@ class CRX(Operation):
 
     def simplify(self):
         phi = self.data[0] % (4 * np.pi)
+
+        if not qml.math.requires_grad(phi) and qml.math.allclose(phi, 0):
+            return qml.Identity(wires=self.wires)
+
         return CRX(phi, wires=self.wires)
 
     @property
@@ -1661,6 +1689,10 @@ class CRY(Operation):
 
     def simplify(self):
         phi = self.data[0] % (4 * np.pi)
+
+        if not qml.math.requires_grad(phi) and qml.math.allclose(phi, 0):
+            return qml.Identity(wires=self.wires)
+
         return CRY(phi, wires=self.wires)
 
     @property
@@ -1853,6 +1885,10 @@ class CRZ(Operation):
 
     def simplify(self):
         phi = self.data[0] % (4 * np.pi)
+
+        if not qml.math.requires_grad(phi) and qml.math.allclose(phi, 0):
+            return qml.Identity(wires=self.wires)
+
         return CRZ(phi, wires=self.wires)
 
     @property
@@ -2177,6 +2213,10 @@ class U1(Operation):
 
     def simplify(self):
         phi = self.data[0] % (2 * np.pi)
+
+        if not qml.math.requires_grad(phi) and qml.math.allclose(phi, 0):
+            return qml.Identity(wires=self.wires)
+
         return U1(phi, wires=self.wires)
 
 
@@ -2622,6 +2662,10 @@ class IsingXX(Operation):
 
     def simplify(self):
         phi = self.data[0] % (4 * np.pi)
+
+        if not qml.math.requires_grad(phi) and qml.math.allclose(phi, 0):
+            return qml.Identity(wires=self.wires)
+
         return IsingXX(phi, wires=self.wires)
 
 
@@ -2761,6 +2805,10 @@ class IsingYY(Operation):
 
     def simplify(self):
         phi = self.data[0] % (4 * np.pi)
+
+        if not qml.math.requires_grad(phi) and qml.math.allclose(phi, 0):
+            return qml.Identity(wires=self.wires)
+
         return IsingYY(phi, wires=self.wires)
 
 
@@ -2931,6 +2979,10 @@ class IsingZZ(Operation):
 
     def simplify(self):
         phi = self.data[0] % (4 * np.pi)
+
+        if not qml.math.requires_grad(phi) and qml.math.allclose(phi, 0):
+            return qml.Identity(wires=self.wires)
+
         return IsingZZ(phi, wires=self.wires)
 
 
@@ -3112,6 +3164,10 @@ class IsingXY(Operation):
 
     def simplify(self):
         phi = self.data[0] % (4 * np.pi)
+
+        if not qml.math.requires_grad(phi) and qml.math.allclose(phi, 0):
+            return qml.Identity(wires=self.wires)
+
         return IsingXY(phi, wires=self.wires)
 
 
@@ -3257,4 +3313,8 @@ class PSWAP(Operation):
 
     def simplify(self):
         phi = self.data[0] % (2 * np.pi)
+
+        if not qml.math.requires_grad(phi) and qml.math.allclose(phi, 0):
+            return qml.SWAP(wires=self.wires)
+
         return PSWAP(phi, wires=self.wires)

--- a/pennylane/ops/qubit/parametric_ops.py
+++ b/pennylane/ops/qubit/parametric_ops.py
@@ -2174,6 +2174,8 @@ class U1(Operation):
         else:
             fac = np.array([0, 1])
 
+        fac = qml.math.convert_like(fac, phi)
+
         arg = 1j * phi
         if qml.math.ndim(arg) == 0:
             return qml.math.diag(qml.math.exp(arg * fac))
@@ -3112,12 +3114,24 @@ class IsingXY(Operation):
             s = qml.math.cast_like(s, 1j)
 
         js = 1j * s
+        off_diag = qml.math.cast_like(
+            qml.math.array(
+                [
+                    [0.0, 0.0, 0.0, 0.0],
+                    [0.0, 0.0, 1.0, 0.0],
+                    [0.0, 1.0, 0.0, 0.0],
+                    [0.0, 0.0, 0.0, 0.0],
+                ],
+                like=js,
+            ),
+            1j,
+        )
         if qml.math.ndim(phi) == 0:
-            return qml.math.diag([1, c, c, 1]) + qml.math.diag([0, js, js, 0])[::-1]
+            return qml.math.diag([1, c, c, 1]) + js * off_diag
 
         ones = qml.math.ones_like(c)
         diags = stack_last([ones, c, c, ones])[:, :, np.newaxis]
-        return diags * np.eye(4) + qml.math.tensordot(js, np.diag([0, 1, 1, 0])[::-1], axes=0)
+        return diags * np.eye(4) + qml.math.tensordot(js, off_diag, axes=0)
 
     @staticmethod
     def compute_eigvals(phi):  # pylint: disable=arguments-differ

--- a/pennylane/ops/qubit/parametric_ops.py
+++ b/pennylane/ops/qubit/parametric_ops.py
@@ -709,7 +709,7 @@ class ControlledPhaseShift(Operation):
         phi = self.data[0] % (2 * np.pi)
 
         if not qml.math.requires_grad(phi) and qml.math.allclose(phi, 0):
-            return qml.Identity(wires=self.wires)
+            return qml.Identity(wires=self.wires[0])
 
         return ControlledPhaseShift(phi, wires=self.wires)
 
@@ -1061,7 +1061,7 @@ class MultiRZ(Operation):
         theta = self.data[0] % (4 * np.pi)
 
         if not qml.math.requires_grad(theta) and qml.math.allclose(theta, 0):
-            return qml.Identity(wires=self.wires)
+            return qml.Identity(wires=self.wires[0])
 
         return MultiRZ(theta, wires=self.wires)
 
@@ -1531,7 +1531,7 @@ class CRX(Operation):
         phi = self.data[0] % (4 * np.pi)
 
         if not qml.math.requires_grad(phi) and qml.math.allclose(phi, 0):
-            return qml.Identity(wires=self.wires)
+            return qml.Identity(wires=self.wires[0])
 
         return CRX(phi, wires=self.wires)
 
@@ -1691,7 +1691,7 @@ class CRY(Operation):
         phi = self.data[0] % (4 * np.pi)
 
         if not qml.math.requires_grad(phi) and qml.math.allclose(phi, 0):
-            return qml.Identity(wires=self.wires)
+            return qml.Identity(wires=self.wires[0])
 
         return CRY(phi, wires=self.wires)
 
@@ -1887,7 +1887,7 @@ class CRZ(Operation):
         phi = self.data[0] % (4 * np.pi)
 
         if not qml.math.requires_grad(phi) and qml.math.allclose(phi, 0):
-            return qml.Identity(wires=self.wires)
+            return qml.Identity(wires=self.wires[0])
 
         return CRZ(phi, wires=self.wires)
 
@@ -2664,7 +2664,7 @@ class IsingXX(Operation):
         phi = self.data[0] % (4 * np.pi)
 
         if not qml.math.requires_grad(phi) and qml.math.allclose(phi, 0):
-            return qml.Identity(wires=self.wires)
+            return qml.Identity(wires=self.wires[0])
 
         return IsingXX(phi, wires=self.wires)
 
@@ -2807,7 +2807,7 @@ class IsingYY(Operation):
         phi = self.data[0] % (4 * np.pi)
 
         if not qml.math.requires_grad(phi) and qml.math.allclose(phi, 0):
-            return qml.Identity(wires=self.wires)
+            return qml.Identity(wires=self.wires[0])
 
         return IsingYY(phi, wires=self.wires)
 
@@ -2981,7 +2981,7 @@ class IsingZZ(Operation):
         phi = self.data[0] % (4 * np.pi)
 
         if not qml.math.requires_grad(phi) and qml.math.allclose(phi, 0):
-            return qml.Identity(wires=self.wires)
+            return qml.Identity(wires=self.wires[0])
 
         return IsingZZ(phi, wires=self.wires)
 
@@ -3166,7 +3166,7 @@ class IsingXY(Operation):
         phi = self.data[0] % (4 * np.pi)
 
         if not qml.math.requires_grad(phi) and qml.math.allclose(phi, 0):
-            return qml.Identity(wires=self.wires)
+            return qml.Identity(wires=self.wires[0])
 
         return IsingXY(phi, wires=self.wires)
 

--- a/pennylane/ops/qubit/parametric_ops.py
+++ b/pennylane/ops/qubit/parametric_ops.py
@@ -857,18 +857,20 @@ class Rot(Operation):
         Hadamard(wires=[0])
 
         """
-        p0, p1, p2 = [p % (2 * np.pi) for p in self.data]
+        p0, p1, p2 = [p % (4 * np.pi) for p in self.data]
 
-        if qml.math.allclose(p0, np.pi / 2) and qml.math.allclose(p2, 3 * np.pi / 2):
+        if qml.math.allclose(p0 % (2 * np.pi), np.pi / 2) and qml.math.allclose(
+            p2 % (2 * np.pi), 3 * np.pi / 2
+        ):
             return qml.RX(p1, wires=self.wires)
-        if qml.math.allclose(p0, 0) and qml.math.allclose(p2, 0):
+        if qml.math.allclose(p0 % (2 * np.pi), 0) and qml.math.allclose(p2 % (2 * np.pi), 0):
             return qml.RY(p1, wires=self.wires)
-        if qml.math.allclose(p1, 0):
-            return qml.RZ((self.data[0] + self.data[2]) % (2 * np.pi), wires=self.wires)
+        if qml.math.allclose(p1 % (2 * np.pi), 0):
+            return qml.RZ((p0 + p2) % (2 * np.pi), wires=self.wires)
         if (
-            qml.math.allclose(p0, np.pi)
-            and qml.math.allclose(p1, np.pi / 2)
-            and qml.math.allclose(p2, 0)
+            qml.math.allclose(p0 % (2 * np.pi), np.pi)
+            and qml.math.allclose(p1 % (2 * np.pi), np.pi / 2)
+            and qml.math.allclose(p2 % (2 * np.pi), 0)
         ):
             return qml.Hadamard(wires=self.wires)
 
@@ -2044,18 +2046,20 @@ class CRot(Operation):
         wires = self.wires
         params = self.parameters
 
-        p0, p1, p2 = [p % (2 * np.pi) for p in params]
+        p0, p1, p2 = [p % (4 * np.pi) for p in params]
 
-        if qml.math.allclose(p0, np.pi / 2) and qml.math.allclose(p2, 3 * np.pi / 2):
+        if qml.math.allclose(p0 % (2 * np.pi), np.pi / 2) and qml.math.allclose(
+            p2 % (2 * np.pi), 3 * np.pi / 2
+        ):
             return qml.CRX(p1, wires=wires)
-        if qml.math.allclose(p0, 0) and qml.math.allclose(p2, 0):
+        if qml.math.allclose(p0 % (2 * np.pi), 0) and qml.math.allclose(p2 % (2 * np.pi), 0):
             return qml.CRY(p1, wires=wires)
-        if qml.math.allclose(p1, 0):
-            return qml.CRZ((self.data[0] + self.data[2]) % (2 * np.pi), wires=wires)
+        if qml.math.allclose(p1 % (2 * np.pi), 0):
+            return qml.CRZ((p0 + p2) % (2 * np.pi), wires=wires)
         if (
-            qml.math.allclose(p0, np.pi)
-            and qml.math.allclose(p1, np.pi / 2)
-            and qml.math.allclose(p2, 0)
+            qml.math.allclose(p0 % (2 * np.pi), np.pi)
+            and qml.math.allclose(p1 % (2 * np.pi), np.pi / 2)
+            and qml.math.allclose(p2 % (2 * np.pi), 0)
         ):
             hadamard = qml.Hadamard
             return qml.ctrl(hadamard, control=self.control_wires)(wires=target_wires)

--- a/pennylane/ops/qubit/parametric_ops.py
+++ b/pennylane/ops/qubit/parametric_ops.py
@@ -859,13 +859,17 @@ class Rot(Operation):
         """
         p0, p1, p2 = [p % (2 * np.pi) for p in self.data]
 
-        if np.allclose(p0, np.pi / 2) and np.allclose(p2, 3 * np.pi / 2):
+        if qml.math.allclose(p0, np.pi / 2) and qml.math.allclose(p2, 3 * np.pi / 2):
             return qml.RX(p1, wires=self.wires)
-        if np.allclose(p0, 0) and np.allclose(p2, 0):
+        if qml.math.allclose(p0, 0) and qml.math.allclose(p2, 0):
             return qml.RY(p1, wires=self.wires)
-        if np.allclose(p1, 0):
+        if qml.math.allclose(p1, 0):
             return qml.RZ((self.data[0] + self.data[2]) % (2 * np.pi), wires=self.wires)
-        if np.allclose(p0, np.pi) and np.allclose(p1, np.pi / 2) and np.allclose(p2, 0):
+        if (
+            qml.math.allclose(p0, np.pi)
+            and qml.math.allclose(p1, np.pi / 2)
+            and qml.math.allclose(p2, 0)
+        ):
             return qml.Hadamard(wires=self.wires)
 
         return Rot(p0, p1, p2, wires=self.wires)
@@ -2042,13 +2046,17 @@ class CRot(Operation):
 
         p0, p1, p2 = [p % (2 * np.pi) for p in params]
 
-        if np.allclose(p0, np.pi / 2) and np.allclose(p2, 3 * np.pi / 2):
+        if qml.math.allclose(p0, np.pi / 2) and qml.math.allclose(p2, 3 * np.pi / 2):
             return qml.CRX(p1, wires=wires)
-        if np.allclose(p0, 0) and np.allclose(p2, 0):
+        if qml.math.allclose(p0, 0) and qml.math.allclose(p2, 0):
             return qml.CRY(p1, wires=wires)
-        if np.allclose(p1, 0):
+        if qml.math.allclose(p1, 0):
             return qml.CRZ((self.data[0] + self.data[2]) % (2 * np.pi), wires=wires)
-        if np.allclose(p0, np.pi) and np.allclose(p1, np.pi / 2) and np.allclose(p2, 0):
+        if (
+            qml.math.allclose(p0, np.pi)
+            and qml.math.allclose(p1, np.pi / 2)
+            and qml.math.allclose(p2, 0)
+        ):
             hadamard = qml.Hadamard
             return qml.ctrl(hadamard, control=self.control_wires)(wires=target_wires)
 
@@ -2300,9 +2308,9 @@ class U2(Operation):
 
         phi, delta = [p % (2 * np.pi) for p in self.data]
 
-        if np.allclose(delta, 0) and np.allclose(phi, 0):
+        if qml.math.allclose(delta, 0) and qml.math.allclose(phi, 0):
             return qml.RY(np.pi / 2, wires=wires)
-        if np.allclose(delta, np.pi / 2) and np.allclose(phi, 3 * np.pi / 2):
+        if qml.math.allclose(delta, np.pi / 2) and qml.math.allclose(phi, 3 * np.pi / 2):
             return qml.RX(np.pi / 2, wires=wires)
 
         return U2(phi, delta, wires=wires)
@@ -2464,11 +2472,15 @@ class U3(Operation):
         p0 = params[0] % (4 * np.pi)
         p1, p2 = [p % (2 * np.pi) for p in params[1:]]
 
-        if np.allclose(p0, 0) and not np.allclose(p1, 0) and np.allclose(p2, 0):
+        if qml.math.allclose(p0, 0) and not qml.math.allclose(p1, 0) and qml.math.allclose(p2, 0):
             return qml.PhaseShift(p1, wires=wires)
-        if np.allclose(p2, np.pi / 2) and np.allclose(p1, 3 * np.pi / 2) and not np.allclose(p0, 0):
+        if (
+            qml.math.allclose(p2, np.pi / 2)
+            and qml.math.allclose(p1, 3 * np.pi / 2)
+            and not qml.math.allclose(p0, 0)
+        ):
             return qml.RX(p0, wires=wires)
-        if not np.allclose(p0, 0) and np.allclose(p1, 0) and np.allclose(p2, 0):
+        if not qml.math.allclose(p0, 0) and qml.math.allclose(p1, 0) and qml.math.allclose(p2, 0):
             return qml.RY(p0, wires=wires)
 
         return U3(p0, p1, p2, wires=wires)

--- a/pennylane/ops/qubit/parametric_ops.py
+++ b/pennylane/ops/qubit/parametric_ops.py
@@ -37,7 +37,7 @@ stack_last = functools.partial(qml.math.stack, axis=-1)
 
 def can_replace(x, y):
     """
-    Convenience function that returns if x is close to y and if
+    Convenience function that returns true if x is close to y and if
     x does not require grad
     """
     return (not qml.math.requires_grad(x)) and qml.math.allclose(x, y)

--- a/tests/ops/functions/test_simplify.py
+++ b/tests/ops/functions/test_simplify.py
@@ -34,7 +34,13 @@ def build_op():
     )
 
 
-simplified_op = qml.prod(qml.RX(-1, 0), qml.RZ(-1, 0), qml.PauliX(0), qml.RY(-1, 0), qml.RX(-1, 0))
+simplified_op = qml.prod(
+    qml.RX(4 * np.pi - 1, 0),
+    qml.RZ(4 * np.pi - 1, 0),
+    qml.PauliX(0),
+    qml.RY(4 * np.pi - 1, 0),
+    qml.RX(4 * np.pi - 1, 0),
+)
 
 
 @pytest.mark.parametrize(

--- a/tests/ops/functions/test_simplify.py
+++ b/tests/ops/functions/test_simplify.py
@@ -91,6 +91,7 @@ class TestSimplifyRotations:
         simplified_op = qml.simplify(unsimplified_op)
 
         assert qml.math.allclose(qml.matrix(unsimplified_op), qml.matrix(simplified_op))
+        assert all((p >= 0).all() and (p < 4 * np.pi).all() for p in simplified_op.data)
         assert unsimplified_op.wires == simplified_op.wires
 
 

--- a/tests/ops/functions/test_simplify.py
+++ b/tests/ops/functions/test_simplify.py
@@ -75,11 +75,11 @@ class TestSimplifyRotations:
 
         # construct the parameters of the op
         if op.num_params == 1:
-            params = np.array([[-3.0, 3.0, 8.0]])
+            params = np.array([[-50.0, 3.0, 50.0]])
         elif op.num_params == 2:
-            params = np.array([[-3.0, 3.0, 8.0], [3.0, 8.0, -3]])
+            params = np.array([[-50.0, 3.0, 50.0], [3.0, 50.0, -50.0]])
         else:
-            params = np.array([[-3.0, 3.0, 8.0], [3.0, 8.0, -3], [8.0, -3.0, 3]])
+            params = np.array([[-50.0, 3.0, 50.0], [3.0, 50.0, -50.0], [50.0, -50.0, 3.0]])
 
         # construct the wires
         if op.num_wires == 1:

--- a/tests/ops/functions/test_simplify.py
+++ b/tests/ops/functions/test_simplify.py
@@ -43,58 +43,6 @@ simplified_op = qml.prod(
 )
 
 
-@pytest.mark.parametrize(
-    "op",
-    [
-        qml.RX,
-        qml.RY,
-        qml.RZ,
-        qml.PhaseShift,
-        qml.ControlledPhaseShift,
-        qml.Rot,
-        qml.MultiRZ,
-        qml.CRX,
-        qml.CRY,
-        qml.CRZ,
-        qml.CRot,
-        qml.U1,
-        qml.U2,
-        qml.U3,
-        qml.IsingXX,
-        qml.IsingYY,
-        qml.IsingZZ,
-        qml.IsingXY,
-        qml.PSWAP,
-    ],
-)
-class TestSimplifyRotations:
-    """Test for the qml.simplify function for single-qubit parametric ops"""
-
-    def test_simplify_rotations(self, op):
-        """Test that the matrices and wires are the same after simplification"""
-
-        # construct the parameters of the op
-        if op.num_params == 1:
-            params = np.array([[-50.0, 3.0, 50.0]])
-        elif op.num_params == 2:
-            params = np.array([[-50.0, 3.0, 50.0], [3.0, 50.0, -50.0]])
-        else:
-            params = np.array([[-50.0, 3.0, 50.0], [3.0, 50.0, -50.0], [50.0, -50.0, 3.0]])
-
-        # construct the wires
-        if op.num_wires == 1:
-            wires = 0
-        else:
-            wires = [0, 1]
-
-        unsimplified_op = op(*params, wires)
-        simplified_op = qml.simplify(unsimplified_op)
-
-        assert qml.math.allclose(qml.matrix(unsimplified_op), qml.matrix(simplified_op))
-        assert all((p >= 0).all() and (p < 4 * np.pi).all() for p in simplified_op.data)
-        assert unsimplified_op.wires == simplified_op.wires
-
-
 class TestSimplifyOperators:
     """Tests for the qml.simplify method used with operators."""
 

--- a/tests/ops/functions/test_simplify.py
+++ b/tests/ops/functions/test_simplify.py
@@ -17,6 +17,7 @@ Unit tests for the qml.simplify function
 import pytest
 
 import pennylane as qml
+from pennylane import numpy as np
 from pennylane.tape import QuantumTape
 
 
@@ -34,6 +35,57 @@ def build_op():
 
 
 simplified_op = qml.prod(qml.RX(-1, 0), qml.RZ(-1, 0), qml.PauliX(0), qml.RY(-1, 0), qml.RX(-1, 0))
+
+
+@pytest.mark.parametrize(
+    "op",
+    [
+        qml.RX,
+        qml.RY,
+        qml.RZ,
+        qml.PhaseShift,
+        qml.ControlledPhaseShift,
+        qml.Rot,
+        qml.MultiRZ,
+        qml.CRX,
+        qml.CRY,
+        qml.CRZ,
+        qml.CRot,
+        qml.U1,
+        qml.U2,
+        qml.U3,
+        qml.IsingXX,
+        qml.IsingYY,
+        qml.IsingZZ,
+        qml.IsingXY,
+        qml.PSWAP,
+    ],
+)
+class TestSimplifyRotations:
+    """Test for the qml.simplify function for single-qubit parametric ops"""
+
+    def test_simplify_rotations(self, op):
+        """Test that the matrices and wires are the same after simplification"""
+
+        # construct the parameters of the op
+        if op.num_params == 1:
+            params = np.array([[-3.0, 3.0, 8.0]])
+        elif op.num_params == 2:
+            params = np.array([[-3.0, 3.0, 8.0], [3.0, 8.0, -3]])
+        else:
+            params = np.array([[-3.0, 3.0, 8.0], [3.0, 8.0, -3], [8.0, -3.0, 3]])
+
+        # construct the wires
+        if op.num_wires == 1:
+            wires = 0
+        else:
+            wires = [0, 1]
+
+        unsimplified_op = op(*params, wires)
+        simplified_op = qml.simplify(unsimplified_op)
+
+        assert qml.math.allclose(qml.matrix(unsimplified_op), qml.matrix(simplified_op))
+        assert unsimplified_op.wires == simplified_op.wires
 
 
 class TestSimplifyOperators:

--- a/tests/ops/op_math/test_adjoint_op.py
+++ b/tests/ops/op_math/test_adjoint_op.py
@@ -245,7 +245,7 @@ class TestSimplify:
     def test_simplify_method(self):
         """Test that the simplify method reduces complexity to the minimum."""
         adj_op = Adjoint(Adjoint(Adjoint(qml.RZ(1.32, wires=0))))
-        final_op = qml.RZ(-1.32, wires=0)
+        final_op = qml.RZ(4 * np.pi - 1.32, wires=0)
         simplified_op = adj_op.simplify()
 
         # TODO: Use qml.equal when supported for nested operators
@@ -258,7 +258,9 @@ class TestSimplify:
     def test_simplify_adj_of_sums(self):
         """Test that the simplify methods converts an adjoint of sums to a sum of adjoints."""
         adj_op = Adjoint(qml.op_sum(qml.RX(1, 0), qml.RY(1, 0), qml.RZ(1, 0)))
-        sum_op = qml.op_sum(qml.RX(-1, 0), qml.RY(-1, 0), qml.RZ(-1, 0))
+        sum_op = qml.op_sum(
+            qml.RX(4 * np.pi - 1, 0), qml.RY(4 * np.pi - 1, 0), qml.RZ(4 * np.pi - 1, 0)
+        )
         simplified_op = adj_op.simplify()
 
         # TODO: Use qml.equal when supported for nested operators
@@ -278,7 +280,9 @@ class TestSimplify:
         """Test that the simplify method converts an adjoint of products to a (reverse) product
         of adjoints."""
         adj_op = Adjoint(qml.prod(qml.RX(1, 0), qml.RY(1, 0), qml.RZ(1, 0)))
-        final_op = qml.prod(qml.RZ(-1, 0), qml.RY(-1, 0), qml.RX(-1, 0))
+        final_op = qml.prod(
+            qml.RZ(4 * np.pi - 1, 0), qml.RY(4 * np.pi - 1, 0), qml.RX(4 * np.pi - 1, 0)
+        )
         simplified_op = adj_op.simplify()
 
         assert isinstance(simplified_op, qml.ops.Prod)

--- a/tests/ops/op_math/test_prod.py
+++ b/tests/ops/op_math/test_prod.py
@@ -715,7 +715,7 @@ class TestSimplify:
     def test_simplify_with_nested_prod_and_adjoints(self):
         """Test simplify method with nested product and adjoint operators."""
         prod_op = Prod(qml.adjoint(Prod(qml.RX(1, 0), qml.RY(1, 0))), qml.RZ(1, 0))
-        final_op = Prod(qml.RY(-1, 0), qml.RX(-1, 0), qml.RZ(1, 0))
+        final_op = Prod(qml.RY(4 * np.pi - 1, 0), qml.RX(4 * np.pi - 1, 0), qml.RZ(1, 0))
         simplified_op = prod_op.simplify()
 
         # TODO: Use qml.equal when supported for nested operators
@@ -747,9 +747,9 @@ class TestSimplify:
             Prod(qml.PauliX(0), qml.PauliX(1)),
             qml.PauliX(0) @ (5 * qml.RX(1, 1)),
             qml.PauliX(0) @ qml.s_prod(5, qml.PauliX(1)),
-            Prod(qml.RX(-1, 0), qml.PauliX(0), qml.PauliX(1)),
-            Prod(qml.RX(-1, 0), qml.PauliX(0), 5 * qml.RX(1, 1)),
-            Prod(qml.RX(-1, 0), qml.PauliX(0), qml.s_prod(5, qml.PauliX(1))),
+            Prod(qml.RX(4 * np.pi - 1, 0), qml.PauliX(0), qml.PauliX(1)),
+            Prod(qml.RX(4 * np.pi - 1, 0), qml.PauliX(0), 5 * qml.RX(1, 1)),
+            Prod(qml.RX(4 * np.pi - 1, 0), qml.PauliX(0), qml.s_prod(5, qml.PauliX(1))),
             Prod(qml.PauliX(0), qml.PauliX(0), qml.PauliX(1)),
             Prod(qml.PauliX(0), qml.PauliX(0), 5 * qml.RX(1, 1)),
             Prod(qml.PauliX(0), qml.PauliX(0), qml.s_prod(5, qml.PauliX(1))),

--- a/tests/ops/qubit/test_parametric_ops.py
+++ b/tests/ops/qubit/test_parametric_ops.py
@@ -3186,20 +3186,21 @@ class TestSimplify:
         unsimplified_op = self.get_unsimplified_op(op)
         params, wires = unsimplified_op.data, unsimplified_op.wires
 
-        params = [p[0] for p in params]
+        for i in range(params[0].shape[0]):
+            parameters = [p[i] for p in params]
 
-        unsimplified_res = circuit(False, wires, *params)
-        simplified_res = circuit(True, wires, *params)
+            unsimplified_res = circuit(False, wires, *parameters)
+            simplified_res = circuit(True, wires, *parameters)
 
-        unsimplified_grad = qml.grad(circuit, argnum=list(range(2, 2 + len(params))))(
-            False, wires, *params
-        )
-        simplified_grad = qml.grad(circuit, argnum=list(range(2, 2 + len(params))))(
-            True, wires, *params
-        )
+            unsimplified_grad = qml.grad(circuit, argnum=list(range(2, 2 + len(parameters))))(
+                False, wires, *parameters
+            )
+            simplified_grad = qml.grad(circuit, argnum=list(range(2, 2 + len(parameters))))(
+                True, wires, *parameters
+            )
 
-        assert qml.math.allclose(unsimplified_res, simplified_res)
-        assert qml.math.allclose(unsimplified_grad, simplified_grad)
+            assert qml.math.allclose(unsimplified_res, simplified_res)
+            assert qml.math.allclose(unsimplified_grad, simplified_grad)
 
     @pytest.mark.tf
     @pytest.mark.parametrize("op", rotations)
@@ -3221,20 +3222,21 @@ class TestSimplify:
         unsimplified_op = self.get_unsimplified_op(op)
         params, wires = unsimplified_op.data, unsimplified_op.wires
 
-        params = [tf.Variable(p[0]) for p in params]
+        for i in range(params[0].shape[0]):
+            parameters = [tf.Variable(p[i]) for p in params]
 
-        with tf.GradientTape() as unsimplified_tape:
-            unsimplified_res = circuit(False, wires, *params)
+            with tf.GradientTape() as unsimplified_tape:
+                unsimplified_res = circuit(False, wires, *parameters)
 
-        unsimplified_grad = unsimplified_tape.gradient(unsimplified_res, params)
+            unsimplified_grad = unsimplified_tape.gradient(unsimplified_res, parameters)
 
-        with tf.GradientTape() as simplified_tape:
-            simplified_res = circuit(False, wires, *params)
+            with tf.GradientTape() as simplified_tape:
+                simplified_res = circuit(False, wires, *parameters)
 
-        simplified_grad = simplified_tape.gradient(simplified_res, params)
+            simplified_grad = simplified_tape.gradient(simplified_res, parameters)
 
-        assert qml.math.allclose(unsimplified_res, simplified_res)
-        assert qml.math.allclose(unsimplified_grad, simplified_grad)
+            assert qml.math.allclose(unsimplified_res, simplified_res)
+            assert qml.math.allclose(unsimplified_grad, simplified_grad)
 
     @pytest.mark.tf
     def test_simplify_rotations_grad_tf_function(self):
@@ -3259,20 +3261,21 @@ class TestSimplify:
         unsimplified_op = self.get_unsimplified_op(op)
         params, wires = unsimplified_op.data, unsimplified_op.wires
 
-        params = [tf.Variable(p[0]) for p in params]
+        for i in range(params[0].shape[0]):
+            parameters = [tf.Variable(p[i]) for p in params]
 
-        with tf.GradientTape() as unsimplified_tape:
-            unsimplified_res = circuit(False, wires, *params)
+            with tf.GradientTape() as unsimplified_tape:
+                unsimplified_res = circuit(False, wires, *parameters)
 
-        unsimplified_grad = unsimplified_tape.gradient(unsimplified_res, params)
+            unsimplified_grad = unsimplified_tape.gradient(unsimplified_res, parameters)
 
-        with tf.GradientTape() as simplified_tape:
-            simplified_res = circuit(True, wires, *params)
+            with tf.GradientTape() as simplified_tape:
+                simplified_res = circuit(True, wires, *parameters)
 
-        simplified_grad = simplified_tape.gradient(simplified_res, params)
+            simplified_grad = simplified_tape.gradient(simplified_res, parameters)
 
-        assert qml.math.allclose(unsimplified_res, simplified_res)
-        assert qml.math.allclose(unsimplified_grad, simplified_grad)
+            assert qml.math.allclose(unsimplified_res, simplified_res)
+            assert qml.math.allclose(unsimplified_grad, simplified_grad)
 
     @pytest.mark.torch
     @pytest.mark.parametrize("op", rotations)
@@ -3294,18 +3297,19 @@ class TestSimplify:
         unsimplified_op = self.get_unsimplified_op(op)
         params, wires = unsimplified_op.data, unsimplified_op.wires
 
-        params = [torch.tensor(p[0], requires_grad=True) for p in params]
+        for i in range(params[0].shape[0]):
+            parameters = [torch.tensor(p[i], requires_grad=True) for p in params]
 
-        unsimplified_res = circuit(False, wires, *params)
-        unsimplified_res.backward()
-        unsimplified_grad = [p.grad for p in params]
+            unsimplified_res = circuit(False, wires, *parameters)
+            unsimplified_res.backward()
+            unsimplified_grad = [p.grad for p in parameters]
 
-        simplified_res = circuit(True, wires, *params)
-        simplified_res.backward()
-        simplified_grad = [p.grad for p in params]
+            simplified_res = circuit(True, wires, *parameters)
+            simplified_res.backward()
+            simplified_grad = [p.grad for p in parameters]
 
-        assert qml.math.allclose(unsimplified_res, simplified_res)
-        assert qml.math.allclose(unsimplified_grad, simplified_grad)
+            assert qml.math.allclose(unsimplified_res, simplified_res)
+            assert qml.math.allclose(unsimplified_grad, simplified_grad)
 
     @pytest.mark.jax
     @pytest.mark.parametrize("op", rotations)
@@ -3328,20 +3332,21 @@ class TestSimplify:
         unsimplified_op = self.get_unsimplified_op(op)
         params, wires = unsimplified_op.data, unsimplified_op.wires
 
-        params = [jnp.array(p[0]) for p in params]
+        for i in range(params[0].shape[0]):
+            parameters = [jnp.array(p[i]) for p in params]
 
-        unsimplified_res = circuit(False, wires, *params)
-        simplified_res = circuit(True, wires, *params)
+            unsimplified_res = circuit(False, wires, *parameters)
+            simplified_res = circuit(True, wires, *parameters)
 
-        unsimplified_grad = jax.grad(circuit, argnums=list(range(2, 2 + len(params))))(
-            False, wires, *params
-        )
-        simplified_grad = jax.grad(circuit, argnums=list(range(2, 2 + len(params))))(
-            True, wires, *params
-        )
+            unsimplified_grad = jax.grad(circuit, argnums=list(range(2, 2 + len(parameters))))(
+                False, wires, *parameters
+            )
+            simplified_grad = jax.grad(circuit, argnums=list(range(2, 2 + len(parameters))))(
+                True, wires, *parameters
+            )
 
-        assert qml.math.allclose(unsimplified_res, simplified_res, atol=1e-6)
-        assert qml.math.allclose(unsimplified_grad, simplified_grad, atol=1e-6)
+            assert qml.math.allclose(unsimplified_res, simplified_res, atol=1e-6)
+            assert qml.math.allclose(unsimplified_grad, simplified_grad, atol=1e-6)
 
     @pytest.mark.jax
     def test_simplify_rotations_grad_jax_jit(self):
@@ -3370,18 +3375,21 @@ class TestSimplify:
         unsimplified_op = self.get_unsimplified_op(op)
         params = unsimplified_op.data
 
-        params = [jnp.array(p[0]) for p in params]
+        for i in range(params[0].shape[0]):
+            parameters = [jnp.array(p[i]) for p in params]
 
-        unsimplified_res = unsimplified_circuit(*params)
-        simplified_res = simplified_circuit(*params)
+            unsimplified_res = unsimplified_circuit(*parameters)
+            simplified_res = simplified_circuit(*parameters)
 
-        unsimplified_grad = jax.grad(unsimplified_circuit, argnums=list(range(len(params))))(
-            *params
-        )
-        simplified_grad = jax.grad(simplified_circuit, argnums=list(range(len(params))))(*params)
+            unsimplified_grad = jax.grad(
+                unsimplified_circuit, argnums=list(range(len(parameters)))
+            )(*parameters)
+            simplified_grad = jax.grad(simplified_circuit, argnums=list(range(len(parameters))))(
+                *parameters
+            )
 
-        assert qml.math.allclose(unsimplified_res, simplified_res, atol=1e-6)
-        assert qml.math.allclose(unsimplified_grad, simplified_grad, atol=1e-6)
+            assert qml.math.allclose(unsimplified_res, simplified_res, atol=1e-6)
+            assert qml.math.allclose(unsimplified_grad, simplified_grad, atol=1e-6)
 
     @pytest.mark.parametrize("op", rotations)
     def test_simplify_to_identity(self, op):


### PR DESCRIPTION
**Context:**
Part of the new `simplify` pipeline for operator arithmetic

**Description of the Change:**
Overwrite the default `Operation.simplify` method for most parametric operations. These simplify methods take the rotation angles and mods them by `2 * np.pi`. 
