### PR TITLE
simplify `Barriers` to the `Identity` if `only_visual=True`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -221,6 +221,9 @@
 * `Controlled` operators now work with `qml.is_commuting`.
   [(#2994)](https://github.com/PennyLaneAI/pennylane/pull/2994)
 
+* `qml.Barrier` with `only_visual=True` now simplifies, via `op.simplify()` to the identity
+  or a product of identities.
+
 <h3>Breaking changes</h3>
 
 * Measuring an operator that might not be hermitian as an observable now raises a warning instead of an

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -223,6 +223,7 @@
 
 * `qml.Barrier` with `only_visual=True` now simplifies, via `op.simplify()` to the identity
   or a product of identities.
+  [(#3016)](https://github.com/PennyLaneAI/pennylane/pull/3016)
 
 <h3>Breaking changes</h3>
 

--- a/pennylane/ops/qubit/non_parametric_ops.py
+++ b/pennylane/ops/qubit/non_parametric_ops.py
@@ -2306,6 +2306,13 @@ class Barrier(Operation):
     def pow(self, z):
         return [copy(self)]
 
+    def simplify(self):
+        if self.only_visual:
+            if len(self.wires) == 1:
+                return qml.Identity(self.wires[0])
+            return qml.prod(*(qml.Identity(w) for w in self.wires))
+        return self
+
 
 class WireCut(Operation):
     r"""WireCut(wires)

--- a/tests/ops/qubit/test_non_parametric_ops.py
+++ b/tests/ops/qubit/test_non_parametric_ops.py
@@ -479,7 +479,7 @@ class TestEigenval:
 
 
 class TestBarrier:
-    """Tests that the Barrier gate is correct"""
+    """Tests that the Barrier gate is correct."""
 
     def test_use_barrier(self):
         r"""Test that the barrier influences compilation."""
@@ -603,6 +603,25 @@ class TestBarrier:
         """Test that barrier does not raise an error when instantiated with wires=[]."""
         barrier = qml.Barrier(wires=[])
         assert isinstance(barrier, qml.Barrier)
+
+    def test_simplify_only_visual_one_wire(self):
+        """Test that if `only_visual=True`, the operation simplifies to the identity."""
+        op = qml.Barrier(wires="a", only_visual=True)
+        simplified = op.simplify()
+        assert qml.equal(simplified, qml.Identity("a"))
+
+    def test_simplify_only_visual_multiple_wires(self):
+        """Test that if `only_visual=True`, the operation simplifies to a product of identities."""
+        op = qml.Barrier(wires=(0, 1, 2), only_visual=True)
+        simplified = op.simplify()
+        assert isinstance(simplified, qml.ops.op_math.Prod)
+        for i, op in enumerate(simplified.factors):
+            assert qml.equal(op, qml.Identity(i))
+
+    def test_simplify_only_visual_False(self):
+        """Test that no simplification occurs if only_visual is False."""
+        op = qml.Barrier(wires=(0, 1, 2, 3), only_visual=False)
+        assert op.simplify() is op
 
 
 class TestWireCut:


### PR DESCRIPTION
In our compilation functions, only Barriers where `only_visual=False` affect the output of the compilation.  If `only_visual=True`, the Barriers are removed prior to compilation.

We should mimic this behaviour with the `qml.simplify` pipeline. With this PR and #2982 , we get:

```python
>>> qml.simplify( qml.S(0) @ qml.Barrier(0, only_visual=True) @ qml.S(0) )
PauliX(wires=[0])
>>> qml.simplify( qml.S(0) @ qml.Barrier(0, only_visual=False) @ qml.S(0) )
S(wires=[0]) @ Barrier(wires=[0]) @ S(wires=[0])
```