### PR TITLE
[Bug] Fix `qml.simplify` output shape differences

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -251,6 +251,7 @@
 <h3>Bug fixes</h3>
 
 * `jax.jit` now works with QNode when the quantum function was transformed by `qml.simplify`.
+  [(#3017)](https://github.com/PennyLaneAI/pennylane/pull/3017)
 
 * Operators that have `num_wires = AnyWires` or `num_wires = AnyWires` raise an error, with
   certain exceptions, when instantiated with `wires=[]`.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -250,7 +250,7 @@
 
 <h3>Bug fixes</h3>
 
-* `jax.jit` now works with QNode when the quantum function was transformed by `qml.simplify`.
+* Jax gradients now work with a QNode when the quantum function was transformed by `qml.simplify`.
   [(#3017)](https://github.com/PennyLaneAI/pennylane/pull/3017)
 
 * Operators that have `num_wires = AnyWires` or `num_wires = AnyWires` raise an error, with

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -250,6 +250,8 @@
 
 <h3>Bug fixes</h3>
 
+* `jax.jit` now works with QNode when the quantum function was transformed by `qml.simplify`.
+
 * Operators that have `num_wires = AnyWires` or `num_wires = AnyWires` raise an error, with
   certain exceptions, when instantiated with `wires=[]`.
   [(#2979)](https://github.com/PennyLaneAI/pennylane/pull/2979)

--- a/pennylane/ops/functions/simplify.py
+++ b/pennylane/ops/functions/simplify.py
@@ -106,7 +106,8 @@ def simplify(input: Union[Operator, MeasurementProcess, QuantumTape, QNode, Call
                 func(*args, **kwargs)
 
             _ = [qml.simplify(op) for op in tape.operations]
-            return tuple(qml.simplify(m) for m in tape.measurements)
+            m = tuple(qml.simplify(m) for m in tape.measurements)
+            return m[0] if len(m) == 1 else m
 
         if isinstance(input, QNode):
             return QNode(

--- a/tests/ops/functions/test_simplify.py
+++ b/tests/ops/functions/test_simplify.py
@@ -162,3 +162,24 @@ class TestSimplifyCallables:
         assert s_op.data == simplified_tape_op.data
         assert s_op.wires == simplified_tape_op.wires
         assert s_op.arithmetic_depth == simplified_tape_op.arithmetic_depth
+
+    @pytest.mark.jax
+    def test_jitting_simplified_qfunc(self):
+        """Test that we can jit qnodes that have a simplified quantum function."""
+
+        import jax
+
+        @jax.jit
+        @qml.qnode(qml.device("default.qubit.jax", wires=1), interface="jax")
+        @qml.simplify
+        def circuit(x):
+            qml.adjoint(qml.RX(x, wires=0))
+            qml.PauliX(0) ** 2
+            return qml.expval(qml.PauliY(0))
+
+        x = jax.numpy.array(4 * jax.numpy.pi + 0.1)
+        res = circuit(x)
+        assert qml.math.allclose(res, jax.numpy.sin(x))
+
+        grad = jax.grad(circuit)(x)
+        assert qml.math.allclose(grad, jax.numpy.cos(x))


### PR DESCRIPTION
In current master, if we try to take the gradient of a simplified qnode with jax:

```
@qml.qnode(qml.device('default.qubit.jax', wires=1), interface='jax')
@qml.simplify
def circuit(x):
    qml.adjoint(qml.RX(x, wires=0))
    return qml.expval(qml.PauliZ(0))

x = jax.numpy.array(0.1)
jax.grad(circuit)(x)
```
We get:
```
File /jax/_src/api.py:1091, in _check_scalar(x)
   1089 if isinstance(aval, ShapedArray):
   1090   if aval.shape != ():
-> 1091     raise TypeError(msg(f"had shape: {aval.shape}"))
   1092 else:
   1093   raise TypeError(msg(f"had abstract value {aval}"))

TypeError: Gradient only defined for scalar-output functions. Output had shape: (1,).
```

This is because `qml.simplify` returns a tuple of the simplified measurements.  We should return just the measurement itself if only one measurement exists.