### PR TITLE
Iteratively unwrap nested parameters

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -257,6 +257,10 @@
   or a product of identities.
   [(#3016)](https://github.com/PennyLaneAI/pennylane/pull/3016)
 
+* `qml.math.unwrap` and `op._check_batching` no longer create ragged NumPy arrays when used in conjunction
+  with operator arithmetic.
+  [(#3021)](https://github.com/PennyLaneAI/pennylane/pull/3021)
+
 <h3>Breaking changes</h3>
 
 * Measuring an operator that might not be hermitian as an observable now raises a warning instead of an

--- a/pennylane/math/multi_dispatch.py
+++ b/pennylane/math/multi_dispatch.py
@@ -801,21 +801,21 @@ def unwrap(values, max_depth=None):
     >>> print(grad)
     [0.99500417 0.98006658 0.95533649]
     """
-    res = []
 
-    for t in values:
-        if isinstance(t, ArrayBox):
-            a = np.to_numpy(t, max_depth=max_depth)
-        else:
-            a = np.to_numpy(t)
+    def convert(val):
+        if isinstance(val, list):
+            return unwrap(val)
+        new_val = (
+            np.to_numpy(val, max_depth=max_depth) if isinstance(val, ArrayBox) else np.to_numpy(val)
+        )
 
-        if isinstance(a, ndarray) and not a.shape:
-            # if NumPy array is scalar, convert to a Python float
-            res.append(a.tolist())
-        else:
-            res.append(a)
+        if isinstance(new_val, ndarray) and not new_val.shape:
+            # is a scalar
+            new_val = new_val.tolist()
 
-    return res
+        return new_val
+
+    return [convert(val) for val in values]
 
 
 def add(*args, **kwargs):

--- a/pennylane/ops/op_math/prod.py
+++ b/pennylane/ops/op_math/prod.py
@@ -182,6 +182,9 @@ class Prod(Operator):
 
         return copied_op
 
+    def _check_batching(self, params):
+        pass
+
     def terms(self):  # is this method necessary for this class?
         return [1.0], [self]
 

--- a/pennylane/ops/op_math/prod.py
+++ b/pennylane/ops/op_math/prod.py
@@ -182,8 +182,10 @@ class Prod(Operator):
 
         return copied_op
 
+    # pylint: disable=protected-access
     def _check_batching(self, params):
-        pass
+        for param, op in zip(params, self.factors):
+            op._check_batching(param)
 
     def terms(self):  # is this method necessary for this class?
         return [1.0], [self]

--- a/pennylane/ops/op_math/sum.py
+++ b/pennylane/ops/op_math/sum.py
@@ -177,8 +177,10 @@ class Sum(Operator):
 
         return copied_op
 
+    # pylint: disable=protected-access
     def _check_batching(self, params):
-        pass
+        for param, op in zip(params, self.summands):
+            op._check_batching(param)
 
     @property
     def data(self):

--- a/pennylane/ops/op_math/sum.py
+++ b/pennylane/ops/op_math/sum.py
@@ -177,6 +177,9 @@ class Sum(Operator):
 
         return copied_op
 
+    def _check_batching(self, params):
+        pass
+
     @property
     def data(self):
         """Create data property"""

--- a/pennylane/ops/op_math/symbolicop.py
+++ b/pennylane/ops/op_math/symbolicop.py
@@ -127,3 +127,6 @@ class SymbolicOp(Operator):
     @property
     def arithmetic_depth(self) -> int:
         return 1 + self.base.arithmetic_depth
+
+    def _check_batching(self, params):
+        pass

--- a/pennylane/ops/op_math/symbolicop.py
+++ b/pennylane/ops/op_math/symbolicop.py
@@ -128,5 +128,6 @@ class SymbolicOp(Operator):
     def arithmetic_depth(self) -> int:
         return 1 + self.base.arithmetic_depth
 
+    # pylint: disable=protected-access
     def _check_batching(self, params):
-        pass
+        return self.base._check_batching(params)

--- a/tests/math/test_multi_dispatch.py
+++ b/tests/math/test_multi_dispatch.py
@@ -123,3 +123,32 @@ def test_multi_dispatch_decorate_non_dispatch(values):
         return coefficient * np.sum([fn.dot(v, v) for v in values])
 
     assert fn.allequal(custom_function(values), 700)
+
+
+@pytest.mark.all_interfaces
+def test_unwrap():
+    """Test that unwrap converts lists to lists and interface variables to numpy."""
+    import torch
+    import tensorflow as tf
+    from jax import numpy as jnp
+
+    params = [
+        [torch.tensor(2)],
+        [[3, 4], torch.tensor([5, 6])],
+        tf.Variable([-1.0, -2.0]),
+        [jnp.array(0.5), jnp.array([6, 7])],
+    ]
+
+    out = fn.unwrap(params)
+
+    assert out[0] == [2]
+    assert out[1][0] == [3, 4]
+    assert fn.allclose(out[1][1], np.array([5, 6]))
+    assert fn.get_interface(out[1][1]) == "numpy"
+
+    assert fn.allclose(out[2], np.array([-1.0, -2.0]))
+    assert fn.get_interface(out[2]) == "numpy"
+
+    assert out[3][0] == 0.5
+    assert fn.allclose(out[3][1], np.array([6, 7]))
+    assert fn.get_interface(out[3][1]) == "numpy"

--- a/tests/ops/op_math/test_prod.py
+++ b/tests/ops/op_math/test_prod.py
@@ -231,7 +231,7 @@ class TestInitialization:
 
 
 class TestMscMethods:
-    """Test dunder methods."""
+    """Test dunder and other miscellaneous small methods."""
 
     @pytest.mark.parametrize("ops_lst, ops_rep", tuple((i, j) for i, j in zip(ops, ops_rep)))
     def test_repr(self, ops_lst, ops_rep):
@@ -252,6 +252,18 @@ class TestMscMethods:
         for f1, f2 in zip(prod_op.factors, copied_op.factors):
             assert qml.equal(f1, f2)
             assert f1 is not f2
+
+    def test_check_batching(self):
+        """Test that _check_batching runs check batching on all constituents."""
+
+        base1 = qml.RX(1.2, wires=0)
+        base2 = qml.RZ(2.3, wires=0)
+
+        prod = Prod(base1, base2)
+        prod.data = [[np.array([1.2, 2.3])], [np.array([3.4, 4.5])]]
+        prod._check_batching(prod.data)
+        assert base1.batch_size == 2
+        assert base2.batch_size == 2
 
 
 class TestMatrix:

--- a/tests/ops/op_math/test_sum.py
+++ b/tests/ops/op_math/test_sum.py
@@ -278,6 +278,18 @@ class TestMscMethods:
             assert s1.wires == s2.wires
             assert s1.data == s2.data
 
+    def test_check_batching(self):
+        """Test that _check_batching runs check batching on all constituents."""
+
+        base1 = qml.RX(1.2, wires=0)
+        base2 = qml.RZ(2.3, wires=0)
+
+        op = Sum(base1, base2)
+        op.data = [[np.array([1.2, 2.3])], [np.array([3.4, 4.5])]]
+        op._check_batching(op.data)
+        assert base1.batch_size == 2
+        assert base2.batch_size == 2
+
 
 class TestMatrix:
     """Test matrix-related methods."""

--- a/tests/ops/op_math/test_symbolic_op.py
+++ b/tests/ops/op_math/test_symbolic_op.py
@@ -58,7 +58,7 @@ def test_check_batching():
 
     base = qml.RX(1.2, wires=0)
     op = SymbolicOp(base)
-    op.data = [np.array(2.3, 4.5)]
+    op.data = [np.array([2.3, 4.5])]
     op._check_batching(op.data)
     assert base.batch_size == 2
 

--- a/tests/ops/op_math/test_symbolic_op.py
+++ b/tests/ops/op_math/test_symbolic_op.py
@@ -53,6 +53,16 @@ def test_copy():
     assert op.data == [param1]
 
 
+def test_check_batching():
+    """Test that calling _check_batching on a symbolic op runs it on the base operation."""
+
+    base = qml.RX(1.2, wires=0)
+    op = SymbolicOp(base)
+    op.data = [np.array(2.3, 4.5)]
+    op._check_batching(op.data)
+    assert base.batch_size == 2
+
+
 class TestProperties:
     """Test the properties of the symbolic op."""
 


### PR DESCRIPTION
Currently, unwrapping operator arithmetic data can cause a multitude of `VisibleDeprecationWarnings` from ragged arrays:
```
import warnings
warnings.simplefilter("error")

with qml.tape.QuantumTape() as tape:
    obs = qml.op_sum(qml.s_prod(torch.tensor(1.2), qml.PauliX(0)), qml.PauliZ(0))
    qml.expval(obs)

with qml.tape.Unwrap(tape):
    print(tape.get_parameters())
    print(obs.parameters)
```

This PR makes it so those warnings are avoided.  Parameters that are lists are iteratively unwrapped, rather than casted to numpy.

Unfortunately upon returning the parameters to normal `op._check_batching` is called. In `_check_batching`, `qml.math.ndim` is called, which also casts parameters to numpy arrays.  By deferring the `_check_batching` method of composite and decorator operators to their components, we are no longer calling `qml.math.ndim` on ragged arrays.

 
