### PR TITLE
Add test runners for Python 3.10 and update TF and PyTorch versions

### DIFF
--- a/.github/workflows/tests-gpu.yml
+++ b/.github/workflows/tests-gpu.yml
@@ -29,6 +29,7 @@ jobs:
         github.event_name == 'push' ||
         (
           github.event_name == 'pull_request' &&
+          contains(github.event.pull_request.labels.*.name, 'gpu') &&
           github.event.pull_request.state == 'open'
         )
       }}

--- a/.github/workflows/tests-gpu.yml
+++ b/.github/workflows/tests-gpu.yml
@@ -29,7 +29,6 @@ jobs:
         github.event_name == 'push' ||
         (
           github.event_name == 'pull_request' &&
-          contains(github.event.pull_request.labels.*.name, 'gpu') &&
           github.event.pull_request.state == 'open'
         )
       }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,8 +7,8 @@ on:
 
 
 env:
-  TF_VERSION: 2.6.0
-  TORCH_VERSION: 1.10.0+cpu
+  TF_VERSION: 2.10.0
+  TORCH_VERSION: 1.11.0+cpu
   COVERAGE_FLAGS: "--cov=pennylane --cov-report=term-missing --cov-report=xml --no-flaky-report -p no:warnings --tb=native"
 
 
@@ -22,8 +22,11 @@ jobs:
           - {python-version: 3.7, suite: 'torch'}
           - {python-version: 3.7, suite: 'tf'}
           - {python-version: 3.8, suite: 'tf'}
+          - {python-version: '3.10', suite: 'tf'}
           - {python-version: 3.8, suite: 'torch'}
+          - {python-version: '3.10', suite: 'torch'}
           - {python-version: 3.8, suite: 'jax'}
+          - {python-version: '3.10', suite: 'jax'}
           - {python-version: 3.7, suite: 'autograd'}
           - {python-version: 3.8, suite: 'autograd'}
           - {python-version: 3.9, suite: 'autograd'}

--- a/tests/qnn/test_keras.py
+++ b/tests/qnn/test_keras.py
@@ -549,12 +549,12 @@ class TestKerasLayerIntegration:
     def test_model_save_weights(self, model, n_qubits, tmpdir):
         """Test if the model can be successfully saved and reloaded using the get_weights()
         method"""
-        prediction = model.predict(np.ones(n_qubits))
+        prediction = model.predict(np.ones((1, n_qubits)))
         weights = model.get_weights()
         file = str(tmpdir) + "/model"
         model.save_weights(file)
         model.load_weights(file)
-        prediction_loaded = model.predict(np.ones(n_qubits))
+        prediction_loaded = model.predict(np.ones((1, n_qubits)))
         weights_loaded = model.get_weights()
 
         assert np.allclose(prediction, prediction_loaded)
@@ -601,12 +601,12 @@ class TestKerasLayerIntegrationDM:
         """Test if the model_dm can be successfully saved and reloaded using the get_weights()
         method"""
 
-        prediction = model_dm.predict(np.ones(n_qubits))
+        prediction = model_dm.predict(np.ones((1, n_qubits)))
         weights = model_dm.get_weights()
         file = str(tmpdir) + "/model"
         model_dm.save_weights(file)
         model_dm.load_weights(file)
-        prediction_loaded = model_dm.predict(np.ones(n_qubits))
+        prediction_loaded = model_dm.predict(np.ones((1, n_qubits)))
         weights_loaded = model_dm.get_weights()
 
         assert np.allclose(prediction, prediction_loaded)


### PR DESCRIPTION
**Context:**
Previously some tests were failing with a modern TF+Python installation.

**Description of the Change:**
Added test runners for Python 3.10. Updated the CI version of TF to 2.10.0 and PyTorch to 1.11.0. 
Also fixed the failing tests.
