### PR TITLE
Move pauli word logic from `qml.grouping.utils.is_commuting` to `qml.is_commuting`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -389,9 +389,6 @@
 * `qml.grouping.is_pauli_word` now returns `False` for operators that don't inherit from `qml.Observable`, instead of raising an error.
   [(#3039)](https://github.com/PennyLaneAI/pennylane/pull/3039)
 
-* `qml.grouping.utils.is_commuting` is removed, and its Pauli word logic is now part of `qml.is_commuting`.
-  [(#3033)](https://github.com/PennyLaneAI/pennylane/pull/3033)
-
 <h3>Breaking changes</h3>
 
 * Measuring an operator that might not be hermitian as an observable now raises a warning instead of an
@@ -409,6 +406,9 @@
 * The `expand_matrix()` has been moved from `~/operation.py` to
   `~/math/matrix_manipulation.py`
   [(#3008)](https://github.com/PennyLaneAI/pennylane/pull/3008)
+
+* `qml.grouping.utils.is_commuting` is removed, and its Pauli word logic is now part of `qml.is_commuting`.
+  [(#3033)](https://github.com/PennyLaneAI/pennylane/pull/3033)
 
 <h3>Deprecations</h3>
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -333,6 +333,9 @@
 * `qml.grouping.is_pauli_word` now returns `False` for operators that don't inherit from `qml.Observable`, instead of raising an error.
   [(#3039)](https://github.com/PennyLaneAI/pennylane/pull/3039)
 
+* `qml.grouping.utils.is_commuting` is removed, and its Pauli word logic is now part of `qml.is_commuting`.
+  [(#3033)](https://github.com/PennyLaneAI/pennylane/pull/3033)
+
 <h3>Breaking changes</h3>
 
 * Measuring an operator that might not be hermitian as an observable now raises a warning instead of an

--- a/pennylane/grouping/__init__.py
+++ b/pennylane/grouping/__init__.py
@@ -33,7 +33,6 @@ from .utils import (
     pauli_word_to_string,
     string_to_pauli_word,
     pauli_word_to_matrix,
-    is_commuting,
     is_qwc,
     are_pauli_words_qwc,
     observables_to_binary_matrix,

--- a/pennylane/grouping/utils.py
+++ b/pennylane/grouping/utils.py
@@ -532,56 +532,6 @@ def pauli_word_to_matrix(pauli_word, wire_map=None):
     return reduce(np.kron, pauli_mats)
 
 
-def is_commuting(pauli_word_1, pauli_word_2, wire_map=None):
-    r"""Checks if two Pauli words commute.
-
-    To determine if two Pauli words commute, we can check the value of the
-    symplectic inner product of their binary vector representations.
-    For two binary vectors representing Pauli words, :math:`p_1 = [x_1, z_1]`
-    and :math:`p_2 = [x_2, z_2],` the symplectic inner product is defined as
-    :math:`\langle p_1, p_2 \rangle_{symp} = z_1 x_2^T + z_2 x_1^T`. If the symplectic
-    product is :math:`0` they commute, while if it is :math:`1`, they don't commute.
-
-    Args:
-        pauli_word_1 (Observable): first Pauli word in commutator
-        pauli_word_2 (Observable): second Pauli word in commutator
-        wire_map (dict[Union[str, int], int]): dictionary containing all wire labels used in
-            the Pauli word as keys, and unique integer labels as their values
-
-    Returns:
-        bool: returns True if the input Pauli commute, False otherwise
-
-    Raises:
-        TypeError: if either of the Pauli words is not valid.
-
-    **Example**
-
-    >>> wire_map = {'a' : 0, 'b' : 1, 'c' : 2}
-    >>> pauli_word_1 = qml.PauliX('a') @ qml.PauliY('b')
-    >>> pauli_word_2 = qml.PauliZ('a') @ qml.PauliZ('c')
-    >>> is_commuting(pauli_word_1, pauli_word_2, wire_map=wire_map)
-    False
-    """
-
-    if not (is_pauli_word(pauli_word_1) and is_pauli_word(pauli_word_2)):
-        raise TypeError(
-            f"Expected Pauli word observables, instead got {pauli_word_1} and {pauli_word_2}"
-        )
-
-    if wire_map is None:
-        wire_map = _wire_map_from_pauli_pair(pauli_word_1, pauli_word_2)
-
-    n_qubits = len(wire_map)
-
-    pauli_vec_1 = pauli_to_binary(pauli_word_1, n_qubits=n_qubits, wire_map=wire_map)
-    pauli_vec_2 = pauli_to_binary(pauli_word_2, n_qubits=n_qubits, wire_map=wire_map)
-
-    x1, z1 = pauli_vec_1[:n_qubits], pauli_vec_1[n_qubits:]
-    x2, z2 = pauli_vec_2[:n_qubits], pauli_vec_2[n_qubits:]
-
-    return (np.dot(z1, x2) + np.dot(z2, x1)) % 2 == 0
-
-
 def is_qwc(pauli_vec_1, pauli_vec_2):
     """Checks if two Pauli words in the binary vector representation are qubit-wise commutative.
 

--- a/pennylane/grouping/utils.py
+++ b/pennylane/grouping/utils.py
@@ -60,9 +60,6 @@ def is_pauli_word(observable):
     Returns:
         bool: true if the input observable is a Pauli word, false otherwise.
 
-    Raises:
-        TypeError: if input observable is not an Observable instance.
-
     **Example**
 
     >>> is_pauli_word(qml.Identity(0))

--- a/pennylane/ops/functions/is_commuting.py
+++ b/pennylane/ops/functions/is_commuting.py
@@ -39,9 +39,6 @@ def _pword_is_commuting(pauli_word_1, pauli_word_2, wire_map=None):
     Returns:
         bool: returns True if the input Pauli commute, False otherwise
 
-    Raises:
-        TypeError: if either of the Pauli words is not valid.
-
     **Example**
 
     >>> wire_map = {'a' : 0, 'b' : 1, 'c' : 2}

--- a/pennylane/ops/functions/is_commuting.py
+++ b/pennylane/ops/functions/is_commuting.py
@@ -17,6 +17,57 @@ Defines `is_commuting`, an function for determining if two functions commute.
 
 import pennylane as qml
 from pennylane import numpy as np
+from pennylane.grouping.utils import is_pauli_word, pauli_to_binary, _wire_map_from_pauli_pair
+
+
+def _pword_is_commuting(pauli_word_1, pauli_word_2, wire_map=None):
+    r"""Checks if two Pauli words commute.
+
+    To determine if two Pauli words commute, we can check the value of the
+    symplectic inner product of their binary vector representations.
+    For two binary vectors representing Pauli words, :math:`p_1 = [x_1, z_1]`
+    and :math:`p_2 = [x_2, z_2],` the symplectic inner product is defined as
+    :math:`\langle p_1, p_2 \rangle_{symp} = z_1 x_2^T + z_2 x_1^T`. If the symplectic
+    product is :math:`0` they commute, while if it is :math:`1`, they don't commute.
+
+    Args:
+        pauli_word_1 (Observable): first Pauli word in commutator
+        pauli_word_2 (Observable): second Pauli word in commutator
+        wire_map (dict[Union[str, int], int]): dictionary containing all wire labels used in
+            the Pauli word as keys, and unique integer labels as their values
+
+    Returns:
+        bool: returns True if the input Pauli commute, False otherwise
+
+    Raises:
+        TypeError: if either of the Pauli words is not valid.
+
+    **Example**
+
+    >>> wire_map = {'a' : 0, 'b' : 1, 'c' : 2}
+    >>> pauli_word_1 = qml.PauliX('a') @ qml.PauliY('b')
+    >>> pauli_word_2 = qml.PauliZ('a') @ qml.PauliZ('c')
+    >>> is_commuting(pauli_word_1, pauli_word_2, wire_map=wire_map)
+    False
+    """
+
+    if not (is_pauli_word(pauli_word_1) and is_pauli_word(pauli_word_2)):
+        raise TypeError(
+            f"Expected Pauli word observables, instead got {pauli_word_1} and {pauli_word_2}"
+        )
+
+    if wire_map is None:
+        wire_map = _wire_map_from_pauli_pair(pauli_word_1, pauli_word_2)
+
+    n_qubits = len(wire_map)
+
+    pauli_vec_1 = pauli_to_binary(pauli_word_1, n_qubits=n_qubits, wire_map=wire_map)
+    pauli_vec_2 = pauli_to_binary(pauli_word_2, n_qubits=n_qubits, wire_map=wire_map)
+
+    x1, z1 = pauli_vec_1[:n_qubits], pauli_vec_1[n_qubits:]
+    x2, z2 = pauli_vec_2[:n_qubits], pauli_vec_2[n_qubits:]
+
+    return (np.dot(z1, x2) + np.dot(z2, x1)) % 2 == 0
 
 
 def _get_target_name(op):
@@ -213,6 +264,8 @@ unsupported_operations = [
     "CommutingEvolution",
     "DisplacementEmbedding",
     "SqueezingEmbedding",
+    "Prod",
+    "Sum",
 ]
 non_commuting_operations = [
     # State Prep
@@ -261,7 +314,7 @@ non_commuting_operations = [
 ]
 
 
-def is_commuting(operation1, operation2):
+def is_commuting(operation1, operation2, wire_map=None):
     r"""Check if two operations are commuting using a lookup table.
 
     A lookup table is used to check the commutation between the
@@ -281,6 +334,8 @@ def is_commuting(operation1, operation2):
     Args:
         operation1 (.Operation): A first quantum operation.
         operation2 (.Operation): A second quantum operation.
+        wire_map (dict[Union[str, int], int]): dictionary for Pauli word commutation containing all
+            wire labels used in the Pauli word as keys, and unique integer labels as their values
 
     Returns:
          bool: True if the operations commute, False otherwise.
@@ -309,7 +364,16 @@ def is_commuting(operation1, operation2):
     if operation2.name == "ControlledOperation" and operation2.control_base == "MultipleTargets":
         raise qml.QuantumFunctionError(f"{operation2.control_base} controlled is not supported.")
 
-    # Case 1 operations are disjoints
+    try:
+        return _pword_is_commuting(operation1, operation2, wire_map)
+    except TypeError:  # aside from Pauli words, Tensor commutation evaluation is not supported
+        if isinstance(operation1, qml.operation.Tensor) or isinstance(
+            operation2, qml.operation.Tensor
+        ):
+            # pylint: disable=raise-missing-from
+            raise qml.QuantumFunctionError("Tensor operations are not supported.")
+
+    # operations are disjoints
     if not intersection(operation1.wires, operation2.wires):
         return True
 

--- a/pennylane/ops/functions/is_commuting.py
+++ b/pennylane/ops/functions/is_commuting.py
@@ -51,11 +51,6 @@ def _pword_is_commuting(pauli_word_1, pauli_word_2, wire_map=None):
     False
     """
 
-    if not (is_pauli_word(pauli_word_1) and is_pauli_word(pauli_word_2)):
-        raise TypeError(
-            f"Expected Pauli word observables, instead got {pauli_word_1} and {pauli_word_2}"
-        )
-
     if wire_map is None:
         wire_map = _wire_map_from_pauli_pair(pauli_word_1, pauli_word_2)
 
@@ -364,14 +359,13 @@ def is_commuting(operation1, operation2, wire_map=None):
     if operation2.name == "ControlledOperation" and operation2.control_base == "MultipleTargets":
         raise qml.QuantumFunctionError(f"{operation2.control_base} controlled is not supported.")
 
-    try:
+    if is_pauli_word(operation1) and is_pauli_word(operation2):
         return _pword_is_commuting(operation1, operation2, wire_map)
-    except TypeError:  # aside from Pauli words, Tensor commutation evaluation is not supported
-        if isinstance(operation1, qml.operation.Tensor) or isinstance(
-            operation2, qml.operation.Tensor
-        ):
-            # pylint: disable=raise-missing-from
-            raise qml.QuantumFunctionError("Tensor operations are not supported.")
+
+    # aside from Pauli words, Tensor commutation evaluation is not supported
+    if isinstance(operation1, qml.operation.Tensor) or isinstance(operation2, qml.operation.Tensor):
+        # pylint: disable=raise-missing-from
+        raise qml.QuantumFunctionError("Tensor operations are not supported.")
 
     # operations are disjoints
     if not intersection(operation1.wires, operation2.wires):

--- a/tests/grouping/test_grouping_utils.py
+++ b/tests/grouping/test_grouping_utils.py
@@ -28,7 +28,6 @@ from pennylane.grouping.utils import (
     pauli_word_to_string,
     string_to_pauli_word,
     pauli_word_to_matrix,
-    is_commuting,
     is_qwc,
     are_pauli_words_qwc,
     observables_to_binary_matrix,
@@ -469,38 +468,3 @@ class TestGroupingUtils:
         """Ensure invalid inputs are handled properly when converting Pauli words to matrices."""
         with pytest.raises(TypeError):
             pauli_word_to_matrix(non_pauli_word)
-
-    @pytest.mark.parametrize(
-        "pauli_word_1,pauli_word_2,wire_map,commute_status",
-        [
-            (Identity(0), PauliZ(0), {0: 0}, True),
-            (PauliY(0), PauliZ(0), {0: 0}, False),
-            (PauliX(0), PauliX(1), {0: 0, 1: 1}, True),
-            (PauliY("x"), PauliX("y"), None, True),
-            (
-                PauliZ("a") @ PauliY("b") @ PauliZ("d"),
-                PauliX("a") @ PauliZ("c") @ PauliY("d"),
-                {"a": 0, "b": 1, "c": 2, "d": 3},
-                True,
-            ),
-            (
-                PauliX("a") @ PauliY("b") @ PauliZ("d"),
-                PauliX("a") @ PauliZ("c") @ PauliY("d"),
-                {"a": 0, "b": 1, "c": 2, "d": 3},
-                False,
-            ),
-        ],
-    )
-    def test_is_commuting(self, pauli_word_1, pauli_word_2, wire_map, commute_status):
-        """Test that (non)-commuting Pauli words are correctly identified."""
-        do_they_commute = is_commuting(pauli_word_1, pauli_word_2, wire_map=wire_map)
-        assert do_they_commute == commute_status
-
-    @pytest.mark.parametrize(
-        "pauli_word_1,pauli_word_2",
-        [(non_pauli_words[0], PauliX(0) @ PauliY(2)), (PauliX(0) @ PauliY(2), non_pauli_words[0])],
-    )
-    def test_is_commuting_invalid_input(self, pauli_word_1, pauli_word_2):
-        """Ensure invalid inputs are handled properly when determining commutativity."""
-        with pytest.raises(TypeError):
-            is_commuting(pauli_word_1, pauli_word_2)

--- a/tests/grouping/test_pauli_group.py
+++ b/tests/grouping/test_pauli_group.py
@@ -16,8 +16,8 @@ Unit tests for the :mod:`pauli_group`  functions in ``grouping/pauli.py``.
 """
 import pytest
 
-from pennylane import Identity, PauliX, PauliY, PauliZ
-from pennylane.grouping import is_commuting, string_to_pauli_word
+from pennylane import Identity, PauliX, PauliY, PauliZ, is_commuting
+from pennylane.grouping import string_to_pauli_word
 from pennylane.grouping.pauli import (
     partition_pauli_group,
     pauli_group,

--- a/tests/ops/functions/test_is_commuting.py
+++ b/tests/ops/functions/test_is_commuting.py
@@ -21,7 +21,6 @@ import pennylane as qml
 from pennylane.ops.functions.is_commuting import (
     _get_target_name,
     _check_mat_commutation,
-    is_commuting,
 )
 
 control_base_map_data = [
@@ -828,7 +827,7 @@ class TestCommutingFunction:
             ([[0], [1]], True),
         ],
     )
-    def test_u3_identity_barrier(self, wires, res):
+    def test_barrier_u3_identity(self, wires, res):
         """Commutation between Barrier and U3(0.0, 0.0, 0.0)."""
         commutation = qml.is_commuting(
             qml.Barrier(wires=wires[1]), qml.U3(0.0, 0.0, 0.0, wires=wires[0])
@@ -856,7 +855,7 @@ class TestCommutingFunction:
             ),
         ],
     )
-    def test_is_commuting(self, pauli_word_1, pauli_word_2, wire_map, commute_status):
+    def test_pauli_words(self, pauli_word_1, pauli_word_2, wire_map, commute_status):
         """Test that (non)-commuting Pauli words are correctly identified."""
         do_they_commute = qml.is_commuting(pauli_word_1, pauli_word_2, wire_map=wire_map)
         assert do_they_commute == commute_status
@@ -868,7 +867,7 @@ class TestCommutingFunction:
             (qml.PauliX(0) @ qml.PauliY(2), qml.PauliX(0) @ qml.Hadamard(1) @ qml.Identity(2)),
         ],
     )
-    def test_is_commuting_invalid_input(self, pauli_word_1, pauli_word_2):
+    def test_non_pauli_word_tensors_not_supported(self, pauli_word_1, pauli_word_2):
         """Ensure invalid inputs are handled properly when determining commutativity."""
         with pytest.raises(qml.QuantumFunctionError, match="Tensor operations are not supported."):
             qml.is_commuting(pauli_word_1, pauli_word_2)

--- a/tests/test_qaoa.py
+++ b/tests/test_qaoa.py
@@ -163,10 +163,7 @@ class TestMixerHamiltonians:
         mixer_hamiltonian = qaoa.x_mixer(wires)
 
         # check that all observables commute
-        assert all(
-            qml.grouping.is_commuting(o, mixer_hamiltonian.ops[0])
-            for o in mixer_hamiltonian.ops[1:]
-        )
+        assert all(qml.is_commuting(o, mixer_hamiltonian.ops[0]) for o in mixer_hamiltonian.ops[1:])
         # check that the 1-group grouping information was set
         assert mixer_hamiltonian.grouping_indices is not None
         assert mixer_hamiltonian.grouping_indices == [[0, 1, 2, 3]]
@@ -974,7 +971,7 @@ class TestCostHamiltonians:
         cost_h, _ = qaoa.maxcut(graph)
 
         # check that all observables commute
-        assert all(qml.grouping.is_commuting(o, cost_h.ops[0]) for o in cost_h.ops[1:])
+        assert all(qml.is_commuting(o, cost_h.ops[0]) for o in cost_h.ops[1:])
         # check that the 1-group grouping information was set
         assert cost_h.grouping_indices is not None
         assert cost_h.grouping_indices == [list(range(len(cost_h.ops)))]
@@ -996,7 +993,7 @@ class TestCostHamiltonians:
         cost_h, _ = qaoa.max_independent_set(graph)
 
         # check that all observables commute
-        assert all(qml.grouping.is_commuting(o, cost_h.ops[0]) for o in cost_h.ops[1:])
+        assert all(qml.is_commuting(o, cost_h.ops[0]) for o in cost_h.ops[1:])
         # check that the 1-group grouping information was set
         assert cost_h.grouping_indices is not None
         assert cost_h.grouping_indices == [list(range(len(cost_h.ops)))]
@@ -1018,7 +1015,7 @@ class TestCostHamiltonians:
         cost_h, _ = qaoa.min_vertex_cover(graph)
 
         # check that all observables commute
-        assert all(qml.grouping.is_commuting(o, cost_h.ops[0]) for o in cost_h.ops[1:])
+        assert all(qml.is_commuting(o, cost_h.ops[0]) for o in cost_h.ops[1:])
         # check that the 1-group grouping information was set
         assert cost_h.grouping_indices is not None
         assert cost_h.grouping_indices == [list(range(len(cost_h.ops)))]
@@ -1042,7 +1039,7 @@ class TestCostHamiltonians:
         cost_h, _ = qaoa.max_clique(graph)
 
         # check that all observables commute
-        assert all(qml.grouping.is_commuting(o, cost_h.ops[0]) for o in cost_h.ops[1:])
+        assert all(qml.is_commuting(o, cost_h.ops[0]) for o in cost_h.ops[1:])
         # check that the 1-group grouping information was set
         assert cost_h.grouping_indices is not None
         assert cost_h.grouping_indices == [list(range(len(cost_h.ops)))]
@@ -1077,7 +1074,7 @@ class TestCostHamiltonians:
         cost_h, _, _ = qaoa.max_weight_cycle(graph)
 
         # check that all observables commute
-        assert all(qml.grouping.is_commuting(o, cost_h.ops[0]) for o in cost_h.ops[1:])
+        assert all(qml.is_commuting(o, cost_h.ops[0]) for o in cost_h.ops[1:])
         # check that the 1-group grouping information was set
         assert cost_h.grouping_indices is not None
         assert cost_h.grouping_indices == [list(range(len(cost_h.ops)))]


### PR DESCRIPTION
**Context:**
There are currently two different implementations of `is_commuting()`: one at the top-level for a variety of operators, and another in `pennylane/grouping/utils.py` specifically for Pauli words. These should be in the same place to avoid drift, give a simpler user interface and ease future development, so I'm putting them in the same place (`qml.is_commuting`)

**Description of the Change:**
- Move the Pauli word is_commuting logic to `qml.is_commuting()` (thereby removing `qml.grouping.utils.is_commuting()`), and try to check this before other checks
- If it deems one or both operators to not be Pauli words, check if either are Tensors
  - If they are, raise an exception
  - Else, carry on
- Explicitly remove support for Prod and Sum classes (as well as Tensors) since we do not yet have an implementation to support them

**Benefits:**
- Single method for users to check if two operators commute. Distinguishing logic for Pauli words vs. other operators is hidden away.
- Explicitly removes support for (non-Pauli word) Tensors, as well as composite operators

**Possible Drawbacks:**
- `qml.is_commuting()` is becoming large and messy (as hinted by our pylint disabled features 😄 ). Hopefully this gets some love in the future. The code is still organized and legible, just a warning.

**Related GitHub Issues:**
Fixes #3007 