### PR TITLE
[WIP] `Operator.hash` considers global phases

### DIFF
--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -252,10 +252,8 @@ def _process_data(op):
     # Use qml.math.real to take the real part. We may get complex inputs for
     # example when differentiating holomorphic functions with JAX: a complex
     # valued QNode (one that returns qml.state) requires complex typed inputs.
-    if op.name in ("RX", "RY", "RZ", "PhaseShift", "Rot"):
-        return str([qml.math.round(qml.math.real(d) % (2 * np.pi), 10) for d in op.data])
 
-    if op.name in ("CRX", "CRY", "CRZ", "CRot"):
+    if op.name in ("CRX", "CRY", "CRZ", "CRot", "RX", "RY", "RZ", "PhaseShift", "Rot"):
         return str([qml.math.round(qml.math.real(d) % (4 * np.pi), 10) for d in op.data])
 
     return str(op.data)


### PR DESCRIPTION
`Operator.hash` considers rotation parameters mod `2 pi`. Therefore, it treats `RX(x, 0)` and `RX(x+2*pi,0)` identically.

But these operators are not different, as they differ by a global phase.  This phase will show up when measuring the statevector and when performing the operation in conjunction with something else.  In my case, it was breaking parameter-shift gradients for controlled operations in #2990 .