### PR TITLE
[Op. Arithm.] Improve performance #4 (Matrix Caching)

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -275,6 +275,9 @@
   depth greater than 0. The `__repr__` for `Controlled` show `control_wires` instead of `wires`.
   [(#3013)](https://github.com/PennyLaneAI/pennylane/pull/3013)
 
+* `Prod` and `Sum` now support caching their matrix representation.
+  [(#????)](insert link here)
+
 <h3>Breaking changes</h3>
 
 * Measuring an operator that might not be hermitian as an observable now raises a warning instead of an

--- a/pennylane/ops/op_math/prod.py
+++ b/pennylane/ops/op_math/prod.py
@@ -26,6 +26,7 @@ import numpy as np
 import pennylane as qml
 from pennylane import math
 from pennylane.operation import Operator
+from pennylane.wires import Wires
 from pennylane.ops.op_math.pow_class import Pow
 from pennylane.ops.op_math.sprod import SProd
 from pennylane.ops.op_math.sum import Sum
@@ -295,6 +296,8 @@ class Prod(Operator):
     def matrix(self, wire_order=None):
         """Representation of the operator as a matrix in the computational basis."""
         wire_order = wire_order or self.wires
+        if not isinstance(wire_order, Wires):
+            wire_order = Wires(wire_order)
         if wire_order in self._mat_cache:
             return self._mat_cache[wire_order]
 

--- a/pennylane/ops/op_math/prod.py
+++ b/pennylane/ops/op_math/prod.py
@@ -160,6 +160,7 @@ class Prod(Operator):
         """Initialize a Prod instance"""
         self._id = id
         self.queue_idx = None
+        self._mat_cache = {}
 
         if len(factors) < 2:
             raise ValueError(f"Require at least two operators to multiply; got {len(factors)}")
@@ -294,6 +295,9 @@ class Prod(Operator):
     def matrix(self, wire_order=None):
         """Representation of the operator as a matrix in the computational basis."""
         wire_order = wire_order or self.wires
+        if wire_order in self._mat_cache:
+            return self._mat_cache[wire_order]
+
         mats = (
             math.expand_matrix(qml.matrix(op), op.wires, wire_order=wire_order)
             if isinstance(op, qml.Hamiltonian)
@@ -301,7 +305,9 @@ class Prod(Operator):
             for op in self.factors
         )
 
-        return reduce(math.dot, mats)
+        mat = reduce(math.dot, mats)
+        self._mat_cache[wire_order] = mat
+        return mat
 
     def label(self, decimals=None, base_label=None, cache=None):
         r"""How the product is represented in diagrams and drawings.

--- a/pennylane/ops/op_math/sum.py
+++ b/pennylane/ops/op_math/sum.py
@@ -153,6 +153,7 @@ class Sum(Operator):
         self._name = "Sum"
         self._id = id
         self.queue_idx = None
+        self._mat_cache = {}
 
         if len(summands) < 2:
             raise ValueError(f"Require at least two operators to sum; got {len(summands)}")
@@ -301,10 +302,13 @@ class Sum(Operator):
                 else:
                     yield op.matrix(wire_order=wire_order)
 
-        if wire_order is None:
-            wire_order = self.wires
+        wire_order = wire_order or self.wires
+        if wire_order in self._mat_cache:
+            return self._mat_cache[wire_order]
 
-        return _sum(matrix_gen(self.summands, wire_order))
+        mat = _sum(matrix_gen(self.summands, wire_order))
+        self._mat_cache[wire_order] = mat
+        return mat
 
     def label(self, decimals=None, base_label=None, cache=None):
         r"""How the sum is represented in diagrams and drawings.

--- a/pennylane/ops/op_math/sum.py
+++ b/pennylane/ops/op_math/sum.py
@@ -24,6 +24,7 @@ import numpy as np
 import pennylane as qml
 from pennylane import math
 from pennylane.operation import Operator
+from pennylane.wires import Wires
 
 
 def op_sum(*summands, do_queue=True, id=None):
@@ -303,6 +304,8 @@ class Sum(Operator):
                     yield op.matrix(wire_order=wire_order)
 
         wire_order = wire_order or self.wires
+        if not isinstance(wire_order, Wires):
+            wire_order = Wires(wire_order)
         if wire_order in self._mat_cache:
             return self._mat_cache[wire_order]
 

--- a/tests/ops/op_math/test_prod.py
+++ b/tests/ops/op_math/test_prod.py
@@ -437,6 +437,17 @@ class TestMatrix:
         true_mat = qnp.kron(U, qnp.eye(2)) @ qnp.eye(4)
         assert np.allclose(mat, true_mat)
 
+    def test_cache_mat(self):
+        """Test that the matrix gets cached into the instance attribute"""
+        wire_order1, wire_order2 = ([0, 1], [1, 0])
+        prod_op = qml.prod(qml.PauliX(wires=0), qml.RZ(1.23, wires=1))
+
+        mat1 = qml.matrix(prod_op, wire_order=wire_order1)
+        mat2 = qml.matrix(prod_op, wire_order=wire_order2)
+
+        assert (prod_op._mat_cache[Wires(wire_order1)] == mat1).all()
+        assert (prod_op._mat_cache[Wires(wire_order2)] == mat2).all()
+
     def test_prod_hamiltonian(self):
         """Test that a hamiltonian object can be composed."""
         U = qml.Hamiltonian([0.5], [qml.PauliX(wires=1)])

--- a/tests/ops/op_math/test_sum.py
+++ b/tests/ops/op_math/test_sum.py
@@ -468,6 +468,17 @@ class TestMatrix:
         true_mat = qnp.kron(U, qnp.eye(2)) + qnp.eye(4)
         assert np.allclose(mat, true_mat)
 
+    def test_cache_mat(self):
+        """Test that the matrix gets cached into the instance attribute"""
+        wire_order1, wire_order2 = ([0, 1], [1, 0])
+        sum_op = qml.op_sum(qml.PauliX(wires=0), qml.RZ(1.23, wires=1))
+
+        mat1 = qml.matrix(sum_op, wire_order=wire_order1)
+        mat2 = qml.matrix(sum_op, wire_order=wire_order2)
+
+        assert (sum_op._mat_cache[Wires(wire_order1)] == mat1).all()
+        assert (sum_op._mat_cache[Wires(wire_order2)] == mat2).all()
+
     def test_sum_hamiltonian(self):
         """Test that a hamiltonian object can be summed."""
         U = 0.5 * (qml.PauliX(wires=0) @ qml.PauliZ(wires=1))


### PR DESCRIPTION
**Context:**
When composing operations, sums and products of operators can get very big (lots of summands and factors). Computing the matrix of such composite operators will be very time consuming. We can save some computation time by caching the result of the matrix for re-use on subsequent calls. 

**Description of the Change:**
Add a property to the class which is a dictionary storing the matrix representation for a given wire order. 

**Benefits:**
No longer have to re-compute the matrix multiple times. 

**Possible Drawbacks:**
If there are many possible wire permutations, the matrix for which is required, then the cache could grow very large.
