### PR TITLE
`qml.grouping.is_pauli_word` returns false for non-observables

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -296,7 +296,7 @@
   and the diagonalising gates using the factors/summands instead of using the full matrix.
   [(#3022)](https://github.com/PennyLaneAI/pennylane/pull/3022)
 
-* `qml.grouping.is_pauli_word` now returns `False` for non-Observables, instead of raising an error.
+* `qml.grouping.is_pauli_word` now returns `False` for operators that don't inherit from `qml.Observable`, instead of raising an error.
   [(#3039)](https://github.com/PennyLaneAI/pennylane/pull/3039)
 
 <h3>Breaking changes</h3>

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -296,6 +296,8 @@
   and the diagonalising gates using the factors/summands instead of using the full matrix.
   [(#3022)](https://github.com/PennyLaneAI/pennylane/pull/3022)
 
+* `qml.grouping.is_pauli_word` now returns `False` for non-Observables, instead of raising an error.
+
 <h3>Breaking changes</h3>
 
 * Measuring an operator that might not be hermitian as an observable now raises a warning instead of an

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -297,6 +297,7 @@
   [(#3022)](https://github.com/PennyLaneAI/pennylane/pull/3022)
 
 * `qml.grouping.is_pauli_word` now returns `False` for non-Observables, instead of raising an error.
+  [(#3039)](https://github.com/PennyLaneAI/pennylane/pull/3039)
 
 <h3>Breaking changes</h3>
 

--- a/pennylane/grouping/utils.py
+++ b/pennylane/grouping/utils.py
@@ -74,7 +74,7 @@ def is_pauli_word(observable):
     """
 
     if not isinstance(observable, Observable):
-        raise TypeError(f"Expected {Observable} instance, instead got {type(observable)} instance.")
+        return False
 
     pauli_word_names = ["Identity", "PauliX", "PauliY", "PauliZ"]
     if isinstance(observable, Tensor):

--- a/tests/grouping/test_grouping_utils.py
+++ b/tests/grouping/test_grouping_utils.py
@@ -256,6 +256,14 @@ class TestGroupingUtils:
         assert not is_pauli_word(observable_3)
         assert not is_pauli_word(observable_4)
 
+    def test_is_pauli_word_non_observable(self):
+        """Test that non-observables are not Pauli Words."""
+
+        class DummyOp(qml.operation.Operator):
+            num_wires = 1
+
+        assert not is_pauli_word(DummyOp(1))
+
     def test_are_identical_pauli_words(self):
         """Tests for determining if two Pauli words have the same ``wires`` and ``name`` attributes."""
 


### PR DESCRIPTION
For [PennyLane Lightning PR #349](https://github.com/PennyLaneAI/pennylane-lightning/pull/349), I am trying to get adjoint differentiation working with operator arithmetic observables.

On that PR branch, I try:
```
dev = qml.device('lightning.qubit', wires=2)

@qml.qnode(dev, diff_method="adjoint")
def circuit(x):
    qml.RX(x, wires=0)
    return qml.expval(qml.s_prod(2.0, qml.PauliZ(0)))

x = qml.numpy.array(1.0)

circuit(x)
```
Only to get the error (tail end of traceback only):
```
File ~/Prog/pennylane-lightning/pennylane_lightning/_serialize.py:66, in _obs_has_kernel(ob)
     57 def _obs_has_kernel(ob: Observable) -> bool:
     58     """Returns True if the input observable has a supported kernel in the C++ backend.
     59 
     60     Args:
   (...)
     64         bool: indicating whether ``obs`` has a dedicated kernel in the backend
     65     """
---> 66     if is_pauli_word(ob):
     67         return True
     68     if isinstance(ob, (Hadamard, Projector)):

File ~/Prog/pennylane/pennylane/grouping/utils.py:77, in is_pauli_word(observable)
     53 """
     54 Checks if an observable instance is a Pauli word.
     55 
   (...)
     73 False
     74 """
     76 if not isinstance(observable, Observable):
---> 77     raise TypeError(f"Expected {Observable} instance, instead got {type(observable)} instance.")
     79 pauli_word_names = ["Identity", "PauliX", "PauliY", "PauliZ"]
     80 if isinstance(observable, Tensor):

TypeError: Expected <class 'pennylane.operation.Observable'> instance, instead got <class 'pennylane.ops.op_math.sprod.SProd'> instance.
```

This occurs because we no longer only measure observables.  `Sum`, `Prod`, and `SProd` are only plain `Operator`'s.

So we simply return `False` if the provided object is not a Pauli Word.  Non-observables are obviously not Pauli Words.

This may also improve PR #3033 .