### PR TITLE
Preparation for release candidate `v0.26.0`

### DIFF
--- a/doc/development/release_notes.md
+++ b/doc/development/release_notes.md
@@ -3,7 +3,9 @@ Release notes
 
 This page contains the release notes for PennyLane.
 
-.. mdinclude:: ../releases/changelog-dev.md
+.. mdinclude:: ../releases/changelog-0.26.0.md
+
+.. mdinclude:: ../releases/changelog-0.25.1.md
 
 .. mdinclude:: ../releases/changelog-0.25.0.md
 

--- a/doc/releases/changelog-0.25.1.md
+++ b/doc/releases/changelog-0.25.1.md
@@ -1,6 +1,6 @@
 :orphan:
 
-# Release 0.25.1 (current release)
+# Release 0.25.1
 
 <h3>Bug fixes</h3>
 

--- a/doc/releases/changelog-0.26.0.md
+++ b/doc/releases/changelog-0.26.0.md
@@ -1,6 +1,6 @@
 :orphan:
 
-# Release 0.26.0-dev (development release)
+# Release 0.26.0-dev (current release)
 
 <h3>New features since last release</h3>
 

--- a/pennylane/_version.py
+++ b/pennylane/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.26.0-dev"
+__version__ = "0.26.0"


### PR DESCRIPTION
Updates PennyLane as we're entering a new development version (release of v0.25.0 coming up):

Preparation of release candidate:
* Rename changelog-dev.md to changelog-0.26.0.md
* Increments version from 0.26.0-dev to 0.26.0
* Change changelog-dev reference to changelog-0.26 reference in release_notes.md


```
rc    master
|     |
|     - add changelog-dev.md, add changelog-dev reference to release_notes.md, bump version to 0.26.0-dev
|    /
|   /
|  /
| /
|/
- (**THIS PR**) rename changelog-dev.md to changelog-0.26.0.md, change changelog-dev reference to changelog-0.26 reference in release_notes.md, move "current release" label from changelog-0.25.1 to changelog-0.26, change version from 0.26.0-dev to 0.26.0
|
| 
```