### PR TITLE
Performance: use in-place matrix operations

### DIFF
--- a/pennylane/ops/op_math/prod.py
+++ b/pennylane/ops/op_math/prod.py
@@ -214,8 +214,12 @@ class Prod(CompositeOp):
                 for op in self
             )
 
+            def idot(mat1, mat2):
+                mat1 @= mat2
+                return mat1
+
             reduced_mat, prod_wires = math.reduce_matrices(
-                mats_and_wires_gen=mats_and_wires_gen, reduce_func=math.dot
+                mats_and_wires_gen=mats_and_wires_gen, reduce_func=idot
             )
 
             wire_order = wire_order or self.wires
@@ -232,8 +236,12 @@ class Prod(CompositeOp):
         if self.has_overlapping_wires:
             mats_and_wires_gen = ((op.sparse_matrix(), op.wires) for op in self)
 
+            def idot(mat1, mat2):
+                mat1 @= mat2
+                return mat1
+
             reduced_mat, prod_wires = math.reduce_matrices(
-                mats_and_wires_gen=mats_and_wires_gen, reduce_func=math.dot
+                mats_and_wires_gen=mats_and_wires_gen, reduce_func=idot
             )
 
             wire_order = wire_order or self.wires

--- a/pennylane/ops/op_math/sum.py
+++ b/pennylane/ops/op_math/sum.py
@@ -185,8 +185,12 @@ class Sum(CompositeOp):
             for op in self
         )
 
+        def iadd(mat1, mat2):
+            mat1 += mat2
+            return mat1
+
         reduced_mat, sum_wires = math.reduce_matrices(
-            mats_and_wires_gen=mats_and_wires_gen, reduce_func=math.add
+            mats_and_wires_gen=mats_and_wires_gen, reduce_func=iadd
         )
 
         wire_order = wire_order or self.wires
@@ -197,8 +201,12 @@ class Sum(CompositeOp):
         """Compute the sparse matrix representation of the Sum op in csr representation."""
         mats_and_wires_gen = ((op.sparse_matrix(), op.wires) for op in self)
 
+        def iadd(mat1, mat2):
+            mat1 += mat2
+            return mat1
+
         reduced_mat, sum_wires = math.reduce_matrices(
-            mats_and_wires_gen=mats_and_wires_gen, reduce_func=math.add
+            mats_and_wires_gen=mats_and_wires_gen, reduce_func=iadd
         )
 
         wire_order = wire_order or self.wires

--- a/pennylane/ops/qubit/non_parametric_ops.py
+++ b/pennylane/ops/qubit/non_parametric_ops.py
@@ -76,7 +76,7 @@ class Hadamard(Observable, Operation):
         [[ 0.70710678  0.70710678]
          [ 0.70710678 -0.70710678]]
         """
-        return np.array([[INV_SQRT2, INV_SQRT2], [INV_SQRT2, -INV_SQRT2]])
+        return np.array([[INV_SQRT2, INV_SQRT2], [INV_SQRT2, -INV_SQRT2]], dtype=np.complex128)
 
     @staticmethod
     def compute_sparse_matrix(*params, **hyperparams):
@@ -219,7 +219,7 @@ class PauliX(Observable, Operation):
         [[0 1]
          [1 0]]
         """
-        return np.array([[0, 1], [1, 0]])
+        return np.array([[0, 1], [1, 0]], dtype=np.complex128)
 
     @staticmethod
     def compute_sparse_matrix(*params, **hyperparams):
@@ -367,7 +367,7 @@ class PauliY(Observable, Operation):
         [[ 0.+0.j -0.-1.j]
          [ 0.+1.j  0.+0.j]]
         """
-        return np.array([[0, -1j], [1j, 0]])
+        return np.array([[0, -1j], [1j, 0]], dtype=np.complex128)
 
     @staticmethod
     def compute_sparse_matrix(*params, **hyperparams):
@@ -513,7 +513,7 @@ class PauliZ(Observable, Operation):
         [[ 1  0]
          [ 0 -1]]
         """
-        return np.array([[1, 0], [0, -1]])
+        return np.array([[1, 0], [0, -1]], dtype=np.complex128)
 
     @staticmethod
     def compute_sparse_matrix(*params, **hyperparams):
@@ -996,7 +996,9 @@ class CNOT(Operation):
          [0 0 0 1]
          [0 0 1 0]]
         """
-        return np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]])
+        return np.array(
+            [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]], dtype=np.complex128
+        )
 
     def adjoint(self):
         return CNOT(wires=self.wires)


### PR DESCRIPTION
For manipulations involving large matrices, we want to cut down on memory allocation whenever possible. One way to do that is by using in-place manipulations instead.

```pycon
>>> mat1 += mat2
>>> mat1 @= mat2
```

One downside to using in-place operations is that we can't perform type conversions.  The original `mat1` must have an equal or more-precise type to `mat2`.  Therefore, we would need to standardize `Operator.matrix` to return `complex128`. or perform type casting manually.

For the example:
```
H = qml.op_sum(
    qml.s_prod(0.5, qml.PauliX(0)),
    qml.s_prod(1.2, qml.prod(qml.PauliY(1), qml.PauliX(0))),
    qml.s_prod(3.4, qml.prod(qml.PauliZ(3), qml.PauliZ(2), qml.PauliY(0))),
    qml.s_prod(2.3, qml.prod(qml.PauliZ(4), qml.PauliY(5)))
)
```

And timing `H.matrix()`, I am getting `947 µs ± 106 µs per loop` for this branch and `1.26 ms ± 497 µs per loop` for master.

For comparison: `qml.utils.sparse_hamiltonian(H_old).todense()` takes `1.19 ms ± 4.86 µs per loop `.

There may be other downsides to this that I am not yet aware of.