### PR TITLE
Have `test_single_argument_step` use `flaky`

### DIFF
--- a/tests/optimize/test_optimize_shot_adapative.py
+++ b/tests/optimize/test_optimize_shot_adapative.py
@@ -127,6 +127,7 @@ class TestSingleShotGradientIntegration:
         qml.RX(x, wires=0)
         return qml.expval(qml.PauliZ(0))
 
+    @flaky(max_runs=3)
     @pytest.mark.parametrize("cost_fn", [qnode, expval_cost])
     def test_single_argument_step(self, cost_fn, mocker, monkeypatch):
         """Test that a simple QNode with a single argument correctly performs an optimization step,


### PR DESCRIPTION
**Context:**

The `test_single_argument_step` test fails stochastically, e.g., [see log here](https://github.com/PennyLaneAI/pennylane/actions/runs/3044307643/jobs/4904553461#step:11:207).

**Description of the Change:**

Have it use `flaky`.