### PR TITLE
Update Error message non commuting ops are measured

### DIFF
--- a/doc/releases/changelog-0.26.0.md
+++ b/doc/releases/changelog-0.26.0.md
@@ -511,7 +511,7 @@
 
 * Added a more descriptive error message when measuring non-commuting observables at the end of a circuit with
   `probs`, `samples`, `counts` and `allcounts`.
-  [(#????)](link)
+  [(#3065](https://github.com/PennyLaneAI/pennylane/pull/3065)
 
 <h3>Contributors</h3>
 

--- a/doc/releases/changelog-0.26.0.md
+++ b/doc/releases/changelog-0.26.0.md
@@ -509,6 +509,10 @@
 * Fixed a bug where printing `qml.Hamiltonian` with complex coefficients raises `TypeError` in some cases.
   [(#3005)](https://github.com/PennyLaneAI/pennylane/pull/3004)
 
+* Added a more descriptive error message when measuring non-commuting observables at the end of a circuit with
+  `probs`, `samples`, `counts` and `allcounts`.
+  [(#????)](link)
+
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane/tape/tape.py
+++ b/pennylane/tape/tape.py
@@ -158,7 +158,10 @@ def expand_tape(tape, depth=1, stop_at=None, expand_measurements=False):
                     tape._obs_sharing_wires
                 )
             except (TypeError, ValueError) as e:
-                if any(m.return_type in (Probability, Sample, Counts, AllCounts) for m in tape.measurements):
+                if any(
+                    m.return_type in (Probability, Sample, Counts, AllCounts)
+                    for m in tape.measurements
+                ):
                     raise qml.QuantumFunctionError(
                         "Only observables that are qubit-wise commuting "
                         "Pauli words can be returned on the same wire.\n"

--- a/pennylane/tape/tape.py
+++ b/pennylane/tape/tape.py
@@ -166,7 +166,8 @@ def expand_tape(tape, depth=1, stop_at=None, expand_measurements=False):
                         "Only observables that are qubit-wise commuting "
                         "Pauli words can be returned on the same wire.\n"
                         "Try removing all probability, sample and counts measurements "
-                        "to allow for separate measurements of each observable."
+                        "this will allow for splitting of execution and separate measurements "
+                        "for each non-commuting observable."
                     ) from e
 
                 raise qml.QuantumFunctionError(

--- a/tests/tape/test_tape.py
+++ b/tests/tape/test_tape.py
@@ -1188,7 +1188,8 @@ class TestExpand:
             "Only observables that are qubit-wise commuting "
             "Pauli words can be returned on the same wire.\n"
             "Try removing all probability, sample and counts measurements "
-            "to allow for separate measurements of each observable."
+            "this will allow for splitting of execution and separate measurements "
+            "for each non-commuting observable."
         )
 
         with pytest.raises(qml.QuantumFunctionError, match=expected_error_msg):

--- a/tests/tape/test_tape.py
+++ b/tests/tape/test_tape.py
@@ -29,6 +29,7 @@ from pennylane.measurements import (
     expval,
     sample,
     var,
+    probs,
 )
 from pennylane.tape import QuantumTape, TapeError
 
@@ -1160,7 +1161,7 @@ class TestExpand:
 
         assert tape1_exp.graph.hash == tape2.graph.hash
 
-    @pytest.mark.parametrize("ret", [expval, var, sample, counts])
+    @pytest.mark.parametrize("ret", [expval, var, sample, counts, probs])
     def test_expand_tape_multiple_wires_non_commuting(self, ret):
         """Test if a QuantumFunctionError is raised during tape expansion if non-commuting
         observables are on the same wire"""
@@ -1168,7 +1169,7 @@ class TestExpand:
             qml.RX(0.3, wires=0)
             qml.RY(0.4, wires=1)
             qml.expval(qml.PauliX(0))
-            ret(qml.PauliZ(0))
+            ret(op=qml.PauliZ(0))
 
         with pytest.raises(qml.QuantumFunctionError, match="Only observables that are qubit-wise"):
             tape.expand(expand_measurements=True)


### PR DESCRIPTION
**Context:**
When measuring non-commuting observables in a tape we raise an error. This error is not very descriptive relative to the many cases in which it could be raised

**Description of the Change:**
Update the error message raised, based on if we measure samples, probs, counts, etc. 

**Related GitHub Issues:**
[Issue](https://github.com/PennyLaneAI/pennylane/issues/3051)