### PR TITLE
Consistent docstring for Hadamard and other docs

### DIFF
--- a/doc/introduction/measurements.rst
+++ b/doc/introduction/measurements.rst
@@ -171,7 +171,7 @@ And the result is:
 >>> circuit()
 {'00': 495, '11': 505}
 
-Per default, only observed outcomes are included in the dictionary. The kwarg ``all_outcomes=True`` can 
+By default, only observed outcomes are included in the dictionary. The kwarg ``all_outcomes=True`` can
 be used to display all possible outcomes, including those that were observed ``0`` times in sampling.
 
 For example, we could run the previous circuit with ``all_outcomes=True``:

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -1648,7 +1648,6 @@ class QubitDevice(Device):
                     qml.RX(x, wires=0)
                     return qml.counts(all_outcomes=True)
 
-
         """
 
         outcomes = []

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -1607,7 +1607,7 @@ class QubitDevice(Device):
         each possible outcome.
 
         The format of the dictionary depends on obs.return_type, which is set when
-        calling measurements.counts by setting the kwarg all_outcomes (bool). Per default,
+        calling measurements.counts by setting the kwarg all_outcomes (bool). By default,
         the dictionary will only contain the observed outcomes. Optionally (all_outcomes=True)
         the dictionary will instead contain all possible outcomes, with a count of 0
         for those not observed. See example.
@@ -1629,7 +1629,7 @@ class QubitDevice(Device):
                     [0, 0],
                     [1, 0]], requires_grad=True)
 
-            Per default, this will return:
+            By default, this will return:
             >>> self._samples_to_counts(samples, obs, num_wires)
             {'00': 2, '10': 1}
 

--- a/pennylane/measurements.py
+++ b/pennylane/measurements.py
@@ -848,7 +848,7 @@ def counts(op=None, wires=None, all_outcomes=False):
     >>> circuit(0.5)
     {'00': 3, '01': 1}
 
-    Per default, outcomes that were not observed will not be included in the dictionary.
+    By default, outcomes that were not observed will not be included in the dictionary.
 
     .. code-block:: python3
 

--- a/pennylane/ops/qubit/non_parametric_ops.py
+++ b/pennylane/ops/qubit/non_parametric_ops.py
@@ -80,7 +80,6 @@ class Hadamard(Observable, Operation):
 
     @staticmethod
     def compute_sparse_matrix(*params, **hyperparams):
-        """Compute the sparse matrix representation"""
         return sparse.csr_matrix([[INV_SQRT2, INV_SQRT2], [INV_SQRT2, -INV_SQRT2]])
 
     @staticmethod


### PR DESCRIPTION
The other non_parametric_ops do not define a docstring for `compute_sparse_matrix`, so they inherit the more detailed (though maybe less relevant) docstring from the parent class. For consistency, I'm making Hadamard do the same. We can give them better docstrings later (or now!) if we prefer that.

Saw we changed "Per" to "By" in the changelog entry for the `all_outcomes` feature, so I'm doing it in the code as well.