### PR TITLE
Fix shape of `ShadowMeasurementProcess`

### DIFF
--- a/pennylane/measurements.py
+++ b/pennylane/measurements.py
@@ -597,7 +597,7 @@ class ShadowMeasurementProcess(MeasurementProcess):
         """
         # the return value of expval is always a scalar
         if self.return_type is ShadowExpval:
-            return ()
+            return (1,)
 
         # otherwise, the return type requires a device
         if device is None:
@@ -608,7 +608,7 @@ class ShadowMeasurementProcess(MeasurementProcess):
 
         # the first entry of the tensor represents the measured bits,
         # and the second indicate the indices of the unitaries used
-        return (2, device.shots, len(self.wires))
+        return (1, 2, device.shots, len(self.wires))
 
     @property
     def wires(self):

--- a/tests/shadow/test_shadow_expval.py
+++ b/tests/shadow/test_shadow_expval.py
@@ -75,8 +75,23 @@ class TestExpvalMeasurement:
         dev = qml.device("default.qubit", wires=wires, shots=shots)
         H = qml.PauliZ(0)
         res = qml.shadow_expval(H)
-        assert res.shape() == ()
-        assert res.shape(dev) == ()
+        assert res.shape() == (1,)
+        assert res.shape(dev) == (1,)
+
+    def test_shape_matches(self):
+        """Test that the shape of the MeasurementProcess matches the shape
+        of the tape execution"""
+        wires = 2
+        shots = 100
+        H = qml.PauliZ(0)
+
+        circuit = hadamard_circuit(wires, shots)
+        circuit.construct((H,), {})
+
+        res = qml.execute([circuit.tape], circuit.device, None)[0]
+        expected_shape = qml.shadow_expval(H).shape()
+
+        assert res.shape == expected_shape
 
     def test_measurement_process_copy(self):
         """Test that the attributes of the MeasurementProcess instance are

--- a/tests/shadow/test_shadow_measurement.py
+++ b/tests/shadow/test_shadow_measurement.py
@@ -129,12 +129,25 @@ class TestShadowMeasurement:
         """Test that the shape of the MeasurementProcess instance is correct"""
         dev = qml.device("default.qubit", wires=wires, shots=shots)
         res = qml.classical_shadow(wires=range(wires), seed_recipes=seed)
-        assert res.shape(device=dev) == (2, shots, wires)
+        assert res.shape(device=dev) == (1, 2, shots, wires)
 
         # test an error is raised when device is None
         msg = "The device argument is required to obtain the shape of a classical shadow measurement process"
         with pytest.raises(qml.measurements.MeasurementShapeError, match=msg):
             res.shape(device=None)
+
+    def test_shape_matches(self, wires):
+        """Test that the shape of the MeasurementProcess matches the shape
+        of the tape execution"""
+        shots = 100
+
+        circuit = get_circuit(wires, shots, True)
+        circuit.construct((), {})
+
+        res = qml.execute([circuit.tape], circuit.device, None)[0]
+        expected_shape = qml.classical_shadow(wires=range(wires)).shape(device=circuit.device)
+
+        assert res.shape == expected_shape
 
     @pytest.mark.parametrize("seed", seed_recipes_list)
     def test_measurement_process_copy(self, wires, seed):


### PR DESCRIPTION
**Context:**
The shape of `ShadowMeasurementProcess` returns the wrong shape.

**Description of the Change:**
Fix the shape of `ShadowMeasurementProcess` to match the output shape of the tape execution.