### PR TITLE
Use token with Codecov uploader

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -367,4 +367,6 @@ jobs:
         - name: Download reports from tests
           uses: actions/download-artifact@v2
         - name: Upload to Codecov
-          uses: codecov/codecov-action@v3.3.0
+          uses: codecov/codecov-action@v3
+          with:
+            token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -367,4 +367,4 @@ jobs:
         - name: Download reports from tests
           uses: actions/download-artifact@v2
         - name: Upload to Codecov
-          uses: codecov/codecov-action@v3
+          uses: codecov/codecov-action@v3.3.0


### PR DESCRIPTION
**Context:**
We've been experiencing failures with Codecov.

**Description of the Change:**

Adds token usage for the Codecov uploader. Tokenless uploads seem to be limited with Codecov and may hit issues making it fail intermittently.