### PR TITLE
[WIP] Decompositions for arbitrary controlled operations

### DIFF
--- a/pennylane/ops/op_math/ctrl_decompositions.py
+++ b/pennylane/ops/op_math/ctrl_decompositions.py
@@ -1,0 +1,66 @@
+# Copyright 2018-2022 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+This file defines how to decompose arbitrary controlled operations.
+"""
+import pennylane as qml
+
+
+def _grey_code(n):
+    """Returns the grey code of order n."""
+    if n == 1:
+        return [[0], [1]]
+    previous = _grey_code(n - 1)
+    code = [[0] + old for old in previous]
+    code += [[1] + old for old in reversed(previous)]
+    return code
+
+
+def ctrl_decomposition1(op, control):
+    """Uses section 7 to decompose the controlled operation.
+
+    https://arxiv.org/pdf/quant-ph/9503016.pdf
+
+    Args:
+        op: The target operation
+        control (Iterable[Any]): The control wires
+
+    Returns:
+        list[Operator]: The decomposition
+
+    """
+
+    n_control = len(control)
+
+    target_op = qml.pow(op, 2 ** (1 - n_control), lazy=False, do_queue=False)
+    adj_target = qml.adjoint(target_op)
+    active_pairs = set()
+
+    gates = []
+
+    for code in _grey_code(n_control)[1:]:
+
+        active_wires = [cwire for cwire, codei in zip(control, code) if codei == 1]
+        target_wire = active_wires[0]
+
+        new_active_pairs = {(w, target_wire) for w in active_wires[1:]}
+        changed_active_pairs = active_pairs.symmetric_difference(new_active_pairs)
+
+        gates += [qml.CNOT(pair) for pair in changed_active_pairs]
+
+        _target = target_op if sum(code) % 2 == 0 else adj_target
+        gates.append(qml.ctrl(_target, target_wire))
+        active_pairs = new_active_pairs
+
+    return gates


### PR DESCRIPTION
This PR adds an implementation of [Section 7 of "Elementary Gates for Quantum Computation" by Barenco et al](https://arxiv.org/pdf/quant-ph/9503016.pdf).

This decomposition requires no work wires, and is optimal for lower numbers of control wires. It works with any target operation.

It only depends on the ability to:
* Implement a single controlled version
* Take arbitrary roots of the gate
* Take the adjoint

For example, a triply controlled X can be implemented as:

![image](https://user-images.githubusercontent.com/6364575/192565169-b9131b79-b9fd-43c3-a8ab-db07c94f6d8b.png)

The decomposition scales as $2^{n-1}$, compared to the linear scaling of the decomposition for `MultiControlledX`. 

The below numbers are for expansion till we only have singly controlled gates.  The threshold between when one is more efficient than the other is highly dependent on the decomposition of a Toffoli gate.  If the Toffoli gate decomposes using controlled-SX, the existing `MultiControlledX` decomposition becomes much more efficient.

![image](https://user-images.githubusercontent.com/6364575/192564444-3ddea4d8-5d80-4766-b3c9-65e0127bad4d.png)

While this comparison is for a `MultiControlledX`, the new decomposition works for any target operation, not just `PauliX`.

```python
from pennylane.ops.op_math.ctrl_decompositions import ctrl_decomposition1

op = qml.PauliX("a")

with qml.tape.QuantumTape() as tape:
    ops = ctrl_decomposition1(op, (0,1,2))
```