### PR TITLE
[WIP] remove initial state flipping in the UCCSD template

### DIFF
--- a/pennylane/templates/subroutines/uccsd.py
+++ b/pennylane/templates/subroutines/uccsd.py
@@ -132,10 +132,6 @@ class UCCSD(Operation):
             # Define the qnode
             @qml.qnode(dev)
             def circuit(params, wires, s_wires, d_wires, hf_state):
-
-                # Flip the HF state
-                hf_state = np.flip(hf_state)
-
                 qml.UCCSD(params, wires, s_wires, d_wires, hf_state)
                 return qml.expval(H)
 
@@ -233,9 +229,7 @@ class UCCSD(Operation):
         """
         op_list = []
 
-        init_state_flipped = np.flip(init_state)
-
-        op_list.append(BasisState(init_state_flipped, wires=wires))
+        op_list.append(BasisState(init_state, wires=wires))
 
         for i, (w1, w2) in enumerate(d_wires):
             op_list.append(

--- a/pennylane/templates/subroutines/uccsd.py
+++ b/pennylane/templates/subroutines/uccsd.py
@@ -204,9 +204,9 @@ class UCCSD(Operation):
         """
         op_list = []
 
-        # init_state_flipped = np.flip(init_state)
+        init_state_flipped = np.flip(init_state)
 
-        op_list.append(BasisState(init_state, wires=wires))
+        op_list.append(BasisState(init_state_flipped, wires=wires))
 
         for i, (w1, w2) in enumerate(d_wires):
             op_list.append(

--- a/pennylane/templates/subroutines/uccsd.py
+++ b/pennylane/templates/subroutines/uccsd.py
@@ -204,9 +204,9 @@ class UCCSD(Operation):
         """
         op_list = []
 
-        init_state_flipped = np.flip(init_state)
+        # init_state_flipped = np.flip(init_state)
 
-        op_list.append(BasisState(init_state_flipped, wires=wires))
+        op_list.append(BasisState(init_state, wires=wires))
 
         for i, (w1, w2) in enumerate(d_wires):
             op_list.append(

--- a/tests/qchem/test_structure.py
+++ b/tests/qchem/test_structure.py
@@ -193,7 +193,7 @@ def test_excitations_to_wires_exceptions(singles, doubles, wires, message_match)
             np.array([3.90575761, -1.89772083, -1.36689032]),
             [[0, 2], [1, 3]],
             [[0, 1, 2, 3]],
-            [-0.14619406, -0.06502792, 0.14619406, 0.06502792],
+            [0.14619406, 0.06502792, -0.14619406, -0.06502792],  # computed with AllSinglesDoubles
         )
     ],
 )

--- a/tests/qchem/test_structure.py
+++ b/tests/qchem/test_structure.py
@@ -201,14 +201,14 @@ def test_excitation_integration_with_uccsd(weights, singles, doubles, expected):
     """Test integration with the UCCSD template"""
 
     s_wires, d_wires = qchem.excitations_to_wires(singles, doubles)
-    N = 4
-    wires = range(N)
-    dev = qml.device("default.qubit", wires=N)
+    n = 4
+    wires = range(n)
+    dev = qml.device("default.qubit", wires=n)
 
     @qml.qnode(dev)
     def circuit(weights):
         UCCSD(weights, wires, s_wires=s_wires, d_wires=d_wires, init_state=np.array([1, 1, 0, 0]))
-        return [qml.expval(qml.PauliZ(w)) for w in range(N)]
+        return [qml.expval(qml.PauliZ(w)) for w in range(n)]
 
     res = circuit(weights)
     assert np.allclose(res, np.array(expected))

--- a/tests/templates/test_subroutines/test_uccsd.py
+++ b/tests/templates/test_subroutines/test_uccsd.py
@@ -31,7 +31,7 @@ class TestDecomposition:
                 [],
                 np.array([3.815]),
                 [
-                    [0, qml.BasisState, [0, 1, 2, 3, 4, 5], [np.array([0, 0, 0, 0, 1, 1])]],
+                    [0, qml.BasisState, [0, 1, 2, 3, 4, 5], [np.array([1, 1, 0, 0, 0, 0])]],
                     [1, qml.RX, [0], [-np.pi / 2]],
                     [5, qml.RZ, [2], [1.9075]],
                     [6, qml.CNOT, [1, 2], []],
@@ -286,7 +286,7 @@ def circuit_template(weights):
         wires=range(4),
         s_wires=[[0, 1]],
         d_wires=[[[0, 1], [2, 3]]],
-        init_state=np.array([0, 0, 0, 1]),
+        init_state=np.array([1, 0, 0, 0]),
     )
     return qml.expval(qml.PauliZ(0))
 


### PR DESCRIPTION
**Context:**
The UCCSD template [flips](https://github.com/PennyLaneAI/pennylane/blob/07140375176c0791a50beac5e9aa0d9159026f8b/pennylane/templates/subroutines/uccsd.py#L207) the order of qubits in the initial state with:

`init_state_flipped = np.flip(init_state)`

This requires the initial state defined by the user, before passing it to the UCCSD template, to be flipped as well which is not consistent with the format in the other templates and the general convention we have in the rest of `qchem`. This unnecessary redundant flipping of the initial state could be avoided by simply removing `init_state_flipped = np.flip(init_state)` from the `compute_decomposition` function.

**Description of the Change:**
- The line `init_state_flipped = np.flip(init_state)` is removed from the `compute_decomposition` function.
- The reference values in `test_excitation_integration_with_uccsd` are corrected. 
- The reference states are un-flipped in `test_subroutines/test_uccsd.py`.

**Benefits:**
The change prevents any confusion about defining the correct initial state when the UCCSD template is used.

**Possible Drawbacks:**

**Related GitHub Issues:**
https://github.com/PennyLaneAI/pennylane/issues/3147