### PR TITLE
make fidelity of vectors differentiable

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -118,6 +118,9 @@ keyword argument when using `GellMann`, which determines which of the 8 Gell-Man
 * Fixed a bug with the control values of a controlled version of a `ControlledQubitUnitary`.
   [(#3119)](https://github.com/PennyLaneAI/pennylane/pull/3119)
 
+* Fixed a bug where `qml.math.fidelity(non_trainable_state, trainable_state)` failed unexpectedly.
+  [(#3160)](https://github.com/PennyLaneAI/pennylane/pull/3160)
+
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane/math/quantum.py
+++ b/pennylane/math/quantum.py
@@ -717,7 +717,7 @@ def fidelity(state0, state1, check_state=False, c_dtype="complex128"):
     # Two pure states, squared overlap
     if state1.shape == (len_state1,) and state0.shape == (len_state0,):
         overlap = np.tensordot(state0, np.transpose(np.conj(state1)), axes=1)
-        overlap = np.linalg.norm(overlap) ** 2
+        overlap = np.abs(overlap) ** 2
         return overlap
     # First state mixed, second state pure
     if state1.shape == (len_state1,) and state0.shape != (len_state0,):

--- a/tests/qinfo/test_fidelity.py
+++ b/tests/qinfo/test_fidelity.py
@@ -425,29 +425,6 @@ class TestFidelityQnode:
         fid_grad = tape.gradient(entropy, param)
         assert qml.math.allclose(fid_grad, expected_fid)
 
-    @pytest.mark.tf
-    @pytest.mark.parametrize("param", parameters)
-    @pytest.mark.parametrize("wire", wires)
-    def test_fidelity_qnodes_rx_tworx_tf_grad(self, param, wire):
-        """Test the gradient of the fidelity between two trainable circuits with Tensorflow."""
-        import tensorflow as tf
-
-        dev = qml.device("default.qubit", wires=wire)
-
-        @qml.qnode(dev, interface="tf")
-        def circuit(x):
-            qml.RX(x, wires=0)
-            return qml.state()
-
-        expected = expected_grad_fidelity_rx_pauliz(param)
-        expected_fid = [-expected, expected]
-        params = (tf.Variable(param), tf.Variable(2 * param))
-        with tf.GradientTape() as tape:
-            entropy = qml.qinfo.fidelity(circuit, circuit, wires0=[0], wires1=[0])(*params)
-
-        fid_grad = tape.gradient(entropy, params)
-        assert qml.math.allclose(fid_grad, expected_fid)
-
     @pytest.mark.jax
     @pytest.mark.parametrize("device", devices)
     @pytest.mark.parametrize("param", parameters)

--- a/tests/qinfo/test_fidelity.py
+++ b/tests/qinfo/test_fidelity.py
@@ -612,7 +612,9 @@ class TestFidelityQnode:
             qml.RX(x, wires=0)
             return qml.state()
 
-        fid_grad = jax.grad(qml.qinfo.fidelity(circuit, circuit, wires0=[0], wires1=[0]), argnums=[0,1])(
+        fid_grad = jax.grad(
+            qml.qinfo.fidelity(circuit, circuit, wires0=[0], wires1=[0]), argnums=[0, 1]
+        )(
             (jax.numpy.array(param)),
             (jax.numpy.array(2 * param)),
         )
@@ -633,9 +635,9 @@ class TestFidelityQnode:
             qml.RX(x, wires=0)
             return qml.state()
 
-        fid_grad = jax.jit(jax.grad(qml.qinfo.fidelity(circuit, circuit, wires0=[0], wires1=[0]), argnums=[0,1]))(
-            (jax.numpy.array(param)), (jax.numpy.array(2 * param))
-        )
+        fid_grad = jax.jit(
+            jax.grad(qml.qinfo.fidelity(circuit, circuit, wires0=[0], wires1=[0]), argnums=[0, 1])
+        )((jax.numpy.array(param)), (jax.numpy.array(2 * param)))
         expected = expected_grad_fidelity_rx_pauliz(param)
         expected_fid = [-expected, expected]
         assert qml.math.allclose(fid_grad, expected_fid, rtol=1e-04, atol=1e-03)

--- a/tests/qinfo/test_fidelity.py
+++ b/tests/qinfo/test_fidelity.py
@@ -445,7 +445,7 @@ class TestFidelityQnode:
         with tf.GradientTape() as tape:
             entropy = qml.qinfo.fidelity(circuit, circuit, wires0=[0], wires1=[0])(*params)
 
-        fid_grad = [tape.gradient(e, p) for e, p in zip(entropy, params)]
+        fid_grad = tape.gradient(entropy, params)
         assert qml.math.allclose(fid_grad, expected_fid)
 
     @pytest.mark.jax

--- a/tests/qinfo/test_fidelity.py
+++ b/tests/qinfo/test_fidelity.py
@@ -754,7 +754,7 @@ class TestFidelityQnode:
             qml.qinfo.fidelity(circuit0, circuit1, wires0=[0], wires1=[0]), argnums=[0, 1]
         )((jax.numpy.array(param)), (jax.numpy.array(2.0)))
         expected_fid_grad = expected_grad_fidelity_rx_pauliz(param)
-        assert qml.math.allclose(fid_grad, (expected_fid_grad, 0.0), rtol=1e-02, atol=1e-04)
+        assert qml.math.allclose(fid_grad, (expected_fid_grad, 0.0), rtol=1e-03, atol=1e-04)
 
     @pytest.mark.jax
     @pytest.mark.parametrize("param", parameters)
@@ -781,4 +781,4 @@ class TestFidelityQnode:
             jax.grad(qml.qinfo.fidelity(circuit0, circuit1, wires0=[0], wires1=[0]), argnums=[0, 1])
         )((jax.numpy.array(param)), (jax.numpy.array(2.0)))
         expected_fid_grad = expected_grad_fidelity_rx_pauliz(param)
-        assert qml.math.allclose(fid_grad, (expected_fid_grad, 0.0), rtol=1e-02, atol=1e-04)
+        assert qml.math.allclose(fid_grad, (expected_fid_grad, 0.0), rtol=1e-03, atol=1e-04)

--- a/tests/qinfo/test_fidelity.py
+++ b/tests/qinfo/test_fidelity.py
@@ -219,8 +219,7 @@ class TestFidelityQnode:
             return qml.state()
 
         fid_grad = qml.grad(qml.qinfo.fidelity(circuit0, circuit1, wires0=[0], wires1=[0]))(
-            None,
-            (qml.numpy.array(param, requires_grad=True))
+            None, (qml.numpy.array(param, requires_grad=True))
         )
         expected_fid = expected_grad_fidelity_rx_pauliz(param)
         assert qml.math.allclose(fid_grad, expected_fid)
@@ -239,7 +238,7 @@ class TestFidelityQnode:
 
         fid_grad = qml.grad(qml.qinfo.fidelity(circuit, circuit, wires0=[0], wires1=[0]))(
             (qml.numpy.array(param, requires_grad=True)),
-            (qml.numpy.array(2*param, requires_grad=True))
+            (qml.numpy.array(2 * param, requires_grad=True)),
         )
         expected = expected_grad_fidelity_rx_pauliz(param)
         expected_fid = [-expected, expected]
@@ -588,4 +587,3 @@ class TestFidelityQnode:
         )((jax.numpy.array(param)), (jax.numpy.array(2.0)))
         expected_fid_grad = expected_grad_fidelity_rx_pauliz(param)
         assert qml.math.allclose(fid_grad, (expected_fid_grad, 0.0), rtol=1e-02, atol=1e-04)
-


### PR DESCRIPTION
**Context:**
While testing PLCC, I ultimately avoided using `qml.math.fidelity` because it wasn't working for trainable states with autograd. Turns out, this is only true if you do `fidelity(non_trainable, trainable)`. Any other combo seems to work fine. Anyway, the reason was `np.linalg.norm` not getting along nicely with an intermediate 1D-ArrayBox while calculating the overlap in `fidelity()`.

**Description of the Change:**
Replace `np.linalg.norm` with `np.abs` in `qml.math.fidelity` for the case where both states are 2D (pure) vectors

**Benefits:**
The user will no longer see an error when doing `qml.math.fidelity(non_trainable_state, trainable_state)`

**Possible Drawbacks:**
None. But there may be more weird edge-cases not considered in the fidelity method. We'll fix those as they come (if they do).