### PR TITLE
Avoid ragged arrays when unwrapping nested parameters

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -86,6 +86,7 @@ keyword argument when using `GellMann`, which determines which of the 8 Gell-Man
   [(#3126)](https://github.com/PennyLaneAI/pennylane/pull/3126)
 
 * `qml.math.unwrap` no longer creates ragged arrays. Lists remain lists.
+  [(#3163)](https://github.com/PennyLaneAI/pennylane/pull/3163)
 
 <h3>Breaking changes</h3>
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -85,6 +85,8 @@ keyword argument when using `GellMann`, which determines which of the 8 Gell-Man
 * Add details to the output of `Exp.label()`.
   [(#3126)](https://github.com/PennyLaneAI/pennylane/pull/3126)
 
+* `qml.math.unwrap` no longer creates ragged arrays. Lists remain lists.
+
 <h3>Breaking changes</h3>
 
 * `QueuingContext` is renamed `QueuingManager`.

--- a/pennylane/math/multi_dispatch.py
+++ b/pennylane/math/multi_dispatch.py
@@ -749,12 +749,7 @@ def unwrap(values, max_depth=None):
         new_val = (
             np.to_numpy(val, max_depth=max_depth) if isinstance(val, ArrayBox) else np.to_numpy(val)
         )
-
-        if not new_val.shape:
-            # is a scalar
-            new_val = new_val.tolist()
-
-        return new_val
+        return new_val.tolist() if isinstance(new_val, ndarray) and not new_val.shape else new_val
 
     return [convert(val) for val in values]
 

--- a/pennylane/math/multi_dispatch.py
+++ b/pennylane/math/multi_dispatch.py
@@ -750,7 +750,7 @@ def unwrap(values, max_depth=None):
             np.to_numpy(val, max_depth=max_depth) if isinstance(val, ArrayBox) else np.to_numpy(val)
         )
 
-        if isinstance(new_val, ndarray) and not new_val.shape:
+        if not new_val.shape:
             # is a scalar
             new_val = new_val.tolist()
 

--- a/pennylane/math/multi_dispatch.py
+++ b/pennylane/math/multi_dispatch.py
@@ -742,21 +742,21 @@ def unwrap(values, max_depth=None):
     >>> print(grad)
     [0.99500417 0.98006658 0.95533649]
     """
-    res = []
 
-    for t in values:
-        if isinstance(t, ArrayBox):
-            a = np.to_numpy(t, max_depth=max_depth)
-        else:
-            a = np.to_numpy(t)
+    def convert(val):
+        if isinstance(val, list):
+            return unwrap(val)
+        new_val = (
+            np.to_numpy(val, max_depth=max_depth) if isinstance(val, ArrayBox) else np.to_numpy(val)
+        )
 
-        if isinstance(a, ndarray) and not a.shape:
-            # if NumPy array is scalar, convert to a Python float
-            res.append(a.tolist())
-        else:
-            res.append(a)
+        if isinstance(new_val, ndarray) and not new_val.shape:
+            # is a scalar
+            new_val = new_val.tolist()
 
-    return res
+        return new_val
+
+    return [convert(val) for val in values]
 
 
 def add(*args, **kwargs):

--- a/tests/math/test_multi_dispatch.py
+++ b/tests/math/test_multi_dispatch.py
@@ -123,3 +123,35 @@ def test_multi_dispatch_decorate_non_dispatch(values):
         return coefficient * np.sum([fn.dot(v, v) for v in values])
 
     assert fn.allequal(custom_function(values), 700)
+
+
+@pytest.mark.all_interfaces
+def test_unwrap():
+    """Test that unwrap converts lists to lists and interface variables to numpy."""
+    import torch
+    import tensorflow as tf
+    from jax import numpy as jnp
+
+    params = [
+        [torch.tensor(2)],
+        [[3, 4], torch.tensor([5, 6])],
+        tf.Variable([-1.0, -2.0]),
+        [jnp.array(0.5), jnp.array([6, 7])],
+        torch.tensor(0.5),
+    ]
+
+    out = fn.unwrap(params)
+
+    assert out[0] == [2]
+    assert out[1][0] == [3, 4]
+    assert fn.allclose(out[1][1], np.array([5, 6]))
+    assert fn.get_interface(out[1][1]) == "numpy"
+
+    assert fn.allclose(out[2], np.array([-1.0, -2.0]))
+    assert fn.get_interface(out[2]) == "numpy"
+
+    assert out[3][0] == 0.5
+    assert fn.allclose(out[3][1], np.array([6, 7]))
+    assert fn.get_interface(out[3][1]) == "numpy"
+
+    assert out[4] == 0.5


### PR DESCRIPTION
Contains just part of #3021 , but that PR was also going to fix batching for operator arithmetic.  Operator arithmetic batching will take more PR's and thought.

The following code:
```
import warnings
warnings.simplefilter("error")

with qml.tape.QuantumTape() as tape:
    obs = qml.op_sum(qml.s_prod(torch.tensor(1.2), qml.PauliX(0)), qml.PauliZ(0))
    qml.expval(obs)

with qml.tape.Unwrap(tape):
    print(tape.get_parameters())
    print(obs.parameters)
```
Will still raise errors, but that will be because of batching and not because of unwrapping.  So there will be one less warning.

The warning raised by unwrapping the nested data will no longer exist.