### PR TITLE
Make `AmplitudeEmbedding` JIT-compatible

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -148,7 +148,7 @@ keyword argument when using `GellMann`, which determines which of the 8 Gell-Man
 <h3>Bug fixes</h3>
 
 * Fixed a bug that made `qml.AmplitudeEmbedding` incompatible with JITting.
-  [(#31xx)](https://github.com/PennyLaneAI/pennylane/pull/31xx)
+  [(#3166)](https://github.com/PennyLaneAI/pennylane/pull/3166)
 
 * Fixed the `qml.transforms.transpile` transform to work correctly for all two-qubit operations.
   [(#3104)](https://github.com/PennyLaneAI/pennylane/pull/3104)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -147,6 +147,9 @@ keyword argument when using `GellMann`, which determines which of the 8 Gell-Man
 
 <h3>Bug fixes</h3>
 
+* Fixed a bug that made `qml.AmplitudeEmbedding` incompatible with JITting.
+  [(#31xx)](https://github.com/PennyLaneAI/pennylane/pull/31xx)
+
 * Fixed the `qml.transforms.transpile` transform to work correctly for all two-qubit operations.
   [(#3104)](https://github.com/PennyLaneAI/pennylane/pull/3104)
 

--- a/pennylane/templates/embeddings/amplitude.py
+++ b/pennylane/templates/embeddings/amplitude.py
@@ -218,7 +218,7 @@ class AmplitudeEmbedding(Operation):
                         dat_type = type(feature_set)
                         padding = dat_type(padding).to(feature_set.device)
 
-                    feature_set = qml.math.concatenate([feature_set, padding], axis=0)
+                    feature_set = qml.math.hstack([feature_set, padding])
 
             # normalize
             norm = qml.math.sum(qml.math.abs(feature_set) ** 2)

--- a/tests/templates/test_embeddings/test_amplitude.py
+++ b/tests/templates/test_embeddings/test_amplitude.py
@@ -401,7 +401,9 @@ class TestInterfaces:
         @qml.qnode(dev, interface="jax")
         def circuit_decomposed(features):
             # need to cast to complex tensor, which is implicitly done in the template
-            state = qml.math.cast(qml.math.hstack([features, qml.math.zeros_like(features)]), np.complex128)
+            state = qml.math.cast(
+                qml.math.hstack([features, qml.math.zeros_like(features)]), np.complex128
+            )
             qml.QubitStateVector(state, wires=range(4))
             return qml.state()
 


### PR DESCRIPTION
This PR fixes #3165 by replacing `qml.math.concatenate` by `qml.math.hstack`.
A test that fails on master because it uses `pad_with` like the example in #3165 is added.