### PR TITLE
Document the `max_diff` arg more in the docs to explain higher-order derivatives

### DIFF
--- a/doc/introduction/interfaces.rst
+++ b/doc/introduction/interfaces.rst
@@ -293,6 +293,58 @@ support gradients of QNodes.
 For more details on available gradient transforms, as well as learning how to define your own
 gradient transform, please see the :mod:`qml.gradients <pennylane.gradients>` documentation.
 
+
+Differentiating gradient transforms and higher-order derivatives
+----------------------------------------------------------------
+
+Gradient transforms are themselves differentiable, allowing higher-order
+gradients to be computed:
+
+.. code-block:: python
+
+    dev = qml.device("default.qubit", wires=2)
+
+    @qml.qnode(dev)
+    def circuit(weights):
+        qml.RX(weights[0], wires=0)
+        qml.RY(weights[1], wires=1)
+        qml.CNOT(wires=[0, 1])
+        qml.RX(weights[2], wires=1)
+        return qml.expval(qml.PauliZ(1))
+
+>>> weights = np.array([0.1, 0.2, 0.3], requires_grad=True)
+>>> circuit(weights)
+tensor(0.9316158, requires_grad=True)
+>>> qml.gradients.param_shift(circuit)(weights)  # gradient
+array([[-0.09347337, -0.18884787, -0.28818254]])
+>>> qml.jacobian(qml.gradients.param_shift(circuit))(weights)  # hessian
+array([[[-0.9316158 ,  0.01894799,  0.0289147 ],
+        [ 0.01894799, -0.9316158 ,  0.05841749],
+        [ 0.0289147 ,  0.05841749, -0.9316158 ]]])
+
+Another way to compute higher-order derivatives is by passing the ``max_diff`` and
+``diff_method`` arguments to the QNode and by successive differentiation:
+
+.. code-block:: python
+
+    @qml.qnode(dev, diff_method="parameter-shift", max_diff=2)
+    def circuit(weights):
+        qml.RX(weights[0], wires=0)
+        qml.RY(weights[1], wires=1)
+        qml.CNOT(wires=[0, 1])
+        qml.RX(weights[2], wires=1)
+        return qml.expval(qml.PauliZ(1))
+
+>>> weights = np.array([0.1, 0.2, 0.3], requires_grad=True)
+>>> qml.jacobian(qml.jacobian(circuit))(weights)  # hessian
+array([[-0.9316158 ,  0.01894799,  0.0289147 ],
+       [ 0.01894799, -0.9316158 ,  0.05841749],
+       [ 0.0289147 ,  0.05841749, -0.9316158 ]])
+
+Note that the ``max_diff`` argument only applies to gradient transforms and that its default value is ``1``; failing to
+set its value correctly may yield incorrect results for higher-order derivatives. Also, passing
+``diff_method="parameter-shift"`` is equivalent to passing ``diff_method=qml.gradients.param_shift``.
+
 Supported configurations
 ------------------------
 

--- a/pennylane/gradients/__init__.py
+++ b/pennylane/gradients/__init__.py
@@ -186,8 +186,8 @@ tensor([[-0.04673668, -0.09442394, -0.14409127],
     >>> qml.gradients.param_shift(circuit, hybrid=False)(weights)
 
 
-Differentiating gradient transforms
------------------------------------
+Differentiating gradient transforms and higher-order derivatives
+----------------------------------------------------------------
 
 Gradient transforms are themselves differentiable, allowing higher-order
 gradients to be computed:
@@ -214,6 +214,28 @@ array([[[-0.9316158 ,  0.01894799,  0.0289147 ],
         [ 0.01894799, -0.9316158 ,  0.05841749],
         [ 0.0289147 ,  0.05841749, -0.9316158 ]]])
 
+Another way to compute higher-order derivatives is by passing the ``max_diff`` and
+``diff_method`` arguments to the QNode and by successive differentiation:
+
+.. code-block:: python
+
+    @qml.qnode(dev, diff_method="parameter-shift", max_diff=2)
+    def circuit(weights):
+        qml.RX(weights[0], wires=0)
+        qml.RY(weights[1], wires=1)
+        qml.CNOT(wires=[0, 1])
+        qml.RX(weights[2], wires=1)
+        return qml.expval(qml.PauliZ(1))
+
+>>> weights = np.array([0.1, 0.2, 0.3], requires_grad=True)
+>>> qml.jacobian(qml.jacobian(circuit))(weights)  # hessian
+array([[-0.9316158 ,  0.01894799,  0.0289147 ],
+       [ 0.01894799, -0.9316158 ,  0.05841749],
+       [ 0.0289147 ,  0.05841749, -0.9316158 ]])
+
+Note that the default value of ``max_diff`` is ``1``; failing to set its value correctly may yield incorrect results for
+higher-order derivatives. Also, passing ``diff_method="parameter-shift"`` is equivalent to passing
+``diff_method=qml.gradients.param_shift``.
 
 Transforming tapes
 ------------------

--- a/pennylane/gradients/__init__.py
+++ b/pennylane/gradients/__init__.py
@@ -233,9 +233,9 @@ array([[-0.9316158 ,  0.01894799,  0.0289147 ],
        [ 0.01894799, -0.9316158 ,  0.05841749],
        [ 0.0289147 ,  0.05841749, -0.9316158 ]])
 
-Note that the default value of ``max_diff`` is ``1``; failing to set its value correctly may yield incorrect results for
-higher-order derivatives. Also, passing ``diff_method="parameter-shift"`` is equivalent to passing
-``diff_method=qml.gradients.param_shift``.
+Note that the ``max_diff`` argument only applies to gradient transforms and that its default value is ``1``; failing to
+set its value correctly may yield incorrect results for higher-order derivatives. Also, passing
+``diff_method="parameter-shift"`` is equivalent to passing ``diff_method=qml.gradients.param_shift``.
 
 Transforming tapes
 ------------------


### PR DESCRIPTION
Explains the usage of the `max_diff` arg more in the docs to explain higher-order derivatives with an example.