### PR TITLE
Adjoint batching support to `Adjoint` wrapper

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -49,6 +49,8 @@ keyword argument when using `GellMann`, which determines which of the 8 Gell-Man
 
 <h3>Improvements</h3>
 
+* `Adjoint` now supports batching if the base operation supports batching.
+
 * Added the `Operator` attributes `has_decomposition` and `has_adjoint` that indicate
   whether a corresponding `decomposition` or `adjoint` method is available.
   [(#2986)](https://github.com/PennyLaneAI/pennylane/pull/2986)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -50,6 +50,7 @@ keyword argument when using `GellMann`, which determines which of the 8 Gell-Man
 <h3>Improvements</h3>
 
 * `Adjoint` now supports batching if the base operation supports batching.
+  [(#3168)](https://github.com/PennyLaneAI/pennylane/pull/3168)
 
 * Added the `Operator` attributes `has_decomposition` and `has_adjoint` that indicate
   whether a corresponding `decomposition` or `adjoint` method is available.

--- a/pennylane/ops/op_math/adjoint_class.py
+++ b/pennylane/ops/op_math/adjoint_class.py
@@ -228,6 +228,7 @@ class Adjoint(SymbolicOp):
 
         return moveaxis(conj(base_matrix), -2, -1)
 
+    # pylint: disable=arguments-differ
     def sparse_matrix(self, wire_order=None, format="csr"):
         base_matrix = self.base.sparse_matrix(wire_order=wire_order)
         return transpose(conj(base_matrix)).asformat(format=format)

--- a/tests/ops/op_math/test_adjoint_op.py
+++ b/tests/ops/op_math/test_adjoint_op.py
@@ -723,6 +723,15 @@ class TestEigvals:
 
         assert qml.math.allclose(qml.math.conj(base_eigvals), adj_eigvals)
 
+    def test_batching_eigvals(self):
+        """Test that eigenvalues work with batched parameters."""
+        x = np.array([1.2, 2.3, 3.4])
+        base = qml.RX(x, 0)
+        adj = Adjoint(base)
+        compare = qml.RX(-x, 0)
+
+        assert qml.math.allclose(base.eigvals(), compare.eigvals())
+
     def test_no_matrix_defined_eigvals(self):
         """Test that if the base does not define eigvals, The Adjoint raises the same error."""
         base = qml.QubitStateVector([1, 0], wires=0)

--- a/tests/ops/op_math/test_adjoint_op.py
+++ b/tests/ops/op_math/test_adjoint_op.py
@@ -308,6 +308,17 @@ class TestProperties:
         op = Adjoint(DummyOp(0))
         assert op.is_hermitian == value
 
+    def test_batching_properties(self):
+        """Test the batching properties and methods."""
+
+        base = qml.RX(np.array([1.2, 2.3, 3.4]), 0)
+        op = Adjoint(base)
+        assert op.batch_size == 3
+        assert op.ndim_params == (0,)
+
+        op._check_batching([np.array([1.2, 2.3])])
+        assert op.batch_size == base.batch_size == 2
+
 
 class TestSimplify:
     """Test Adjoint simplify method and depth property."""
@@ -602,14 +613,16 @@ class TestQueueing:
 class TestMatrix:
     """Test the matrix method for a variety of interfaces."""
 
-    def test_batching_error(self):
-        """Test that a MatrixUndefinedError is raised if the base is batched."""
+    def test_batching_support(self):
+        """Test that adjoint matrix has batching support."""
         x = qml.numpy.array([0.1, 0.2, 0.3])
         base = qml.RX(x, wires=0)
         op = Adjoint(base)
+        mat = op.matrix()
+        compare = qml.RX(-x, wires=0)
 
-        with pytest.raises(qml.operation.MatrixUndefinedError):
-            op.matrix()
+        assert qml.math.allclose(mat, compare.matrix())
+        assert mat.shape == (3, 2, 2)
 
     def check_matrix(self, x, interface):
         """Compares matrices in a interface independent manner."""
@@ -671,7 +684,7 @@ class TestMatrix:
 
 def test_sparse_matrix():
     """Test that the spare_matrix method returns the adjoint of the base sparse matrix."""
-    from scipy.sparse import csr_matrix
+    from scipy.sparse import csr_matrix, coo_matrix
 
     H = np.array([[6 + 0j, 1 - 2j], [1 + 2j, -1]])
     H = csr_matrix(H)
@@ -684,6 +697,7 @@ def test_sparse_matrix():
     op_sparse_mat = op.sparse_matrix()
 
     assert isinstance(op_sparse_mat, csr_matrix)
+    assert isinstance(op.sparse_matrix(format="coo"), coo_matrix)
 
     assert qml.math.allclose(base_conj_T.toarray(), op_sparse_mat.toarray())
 


### PR DESCRIPTION
The matrix for adjoint now works with batched parameters:
```
>>> base = qml.RX(np.array([1.2, 2.3]), 0)
>>> op = qml.adjoint(base, lazy=True)
>>> op.matrix()
tensor([[[0.82533561-0.j        , 0.        +0.56464247j],
         [0.        +0.56464247j, 0.82533561-0.j        ]],

        [[0.40848744-0.j        , 0.        +0.91276394j],
         [0.        +0.91276394j, 0.40848744-0.j        ]]], requires_grad=True)
```