### PR TITLE
New `OrbitalRotation` decomposition

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -49,6 +49,8 @@ keyword argument when using `GellMann`, which determines which of the 8 Gell-Man
 
 <h3>Improvements</h3>
 
+* `OrbitalRotation` is now decomposed into two `SingleExcitation` operators for faster execution and a more efficient parameter-shift gradient calculation.
+
 * Added the `Operator` attributes `has_decomposition` and `has_adjoint` that indicate
   whether a corresponding `decomposition` or `adjoint` method is available.
   [(#2986)](https://github.com/PennyLaneAI/pennylane/pull/2986)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -50,6 +50,7 @@ keyword argument when using `GellMann`, which determines which of the 8 Gell-Man
 <h3>Improvements</h3>
 
 * `OrbitalRotation` is now decomposed into two `SingleExcitation` operators for faster execution and a more efficient parameter-shift gradient calculation.
+  [(#3171)](https://github.com/PennyLaneAI/pennylane/pull/3171)
 
 * Added the `Operator` attributes `has_decomposition` and `has_adjoint` that indicate
   whether a corresponding `decomposition` or `adjoint` method is available.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -49,7 +49,7 @@ keyword argument when using `GellMann`, which determines which of the 8 Gell-Man
 
 <h3>Improvements</h3>
 
-* `OrbitalRotation` is now decomposed into two `SingleExcitation` operators for faster execution and a more efficient parameter-shift gradient calculation.
+* `OrbitalRotation` is now decomposed into two `SingleExcitation` operations for faster execution and more efficient parameter-shift gradient calculations on devices that natively support `SingleExcitation`.
   [(#3171)](https://github.com/PennyLaneAI/pennylane/pull/3171)
 
 * Added the `Operator` attributes `has_decomposition` and `has_adjoint` that indicate

--- a/pennylane/ops/qubit/qchem_ops.py
+++ b/pennylane/ops/qubit/qchem_ops.py
@@ -1029,7 +1029,8 @@ class OrbitalRotation(Operation):
 
         .. seealso:: :meth:`~.OrbitalRotation.decomposition`.
 
-        For the source of this decomposition, see page 18 of
+        This operator is decomposed into two :class:`~.SingleExcitation` gates. For a decomposition
+        into more elementary gates, see page 18 of
         `"Local, Expressive, Quantum-Number-Preserving VQE Ansatze for Fermionic Systems" <https://doi.org/10.1088/1367-2630/ac2cb3>`_ .
 
         Args:
@@ -1041,43 +1042,15 @@ class OrbitalRotation(Operation):
 
         **Example:**
 
-        >>> qml.OrbitalRotation.compute_decomposition(1.23, wires=(0,1,2,3))
-        [Hadamard(wires=[3]),
-        Hadamard(wires=[2]),
-        CNOT(wires=[3, 1]),
-        CNOT(wires=[2, 0]),
-        RY(0.615, wires=[3]),
-        RY(0.615, wires=[2]),
-        RY(0.615, wires=[1]),
-        RY(0.615, wires=[0]),
-        CNOT(wires=[3, 1]),
-        CNOT(wires=[2, 0]),
-        Hadamard(wires=[3]),
-        Hadamard(wires=[2])]
+        >>> qml.OrbitalRotation.compute_decomposition(1.2, wires=[0, 1, 2, 3])
+        [SingleExcitation(1.2, wires=[0, 2]), SingleExcitation(1.2, wires=[1, 3])]
 
         """
 
-        decomp_ops = [
+        return [
             qml.SingleExcitation(phi, wires=[wires[0], wires[2]]),
             qml.SingleExcitation(phi, wires=[wires[1], wires[3]]),
         ]
-
-        # This decomposition is the "upside down" version of that on p18 of https://arxiv.org/abs/2104.05695
-        # decomp_ops = [
-        #    qml.Hadamard(wires=wires[3]),
-        #    qml.Hadamard(wires=wires[2]),
-        #    qml.CNOT(wires=[wires[3], wires[1]]),
-        #    qml.CNOT(wires=[wires[2], wires[0]]),
-        #    qml.RY(phi / 2, wires=wires[3]),
-        #    qml.RY(phi / 2, wires=wires[2]),
-        #    qml.RY(phi / 2, wires=wires[1]),
-        #    qml.RY(phi / 2, wires=wires[0]),
-        #    qml.CNOT(wires=[wires[3], wires[1]]),
-        #    qml.CNOT(wires=[wires[2], wires[0]]),
-        #    qml.Hadamard(wires=wires[3]),
-        #    qml.Hadamard(wires=wires[2]),
-        # ]
-        return decomp_ops
 
     def adjoint(self):
         (phi,) = self.parameters

--- a/pennylane/ops/qubit/qchem_ops.py
+++ b/pennylane/ops/qubit/qchem_ops.py
@@ -1056,21 +1056,27 @@ class OrbitalRotation(Operation):
         Hadamard(wires=[2])]
 
         """
-        # This decomposition is the "upside down" version of that on p18 of https://arxiv.org/abs/2104.05695
+
         decomp_ops = [
-            qml.Hadamard(wires=wires[3]),
-            qml.Hadamard(wires=wires[2]),
-            qml.CNOT(wires=[wires[3], wires[1]]),
-            qml.CNOT(wires=[wires[2], wires[0]]),
-            qml.RY(phi / 2, wires=wires[3]),
-            qml.RY(phi / 2, wires=wires[2]),
-            qml.RY(phi / 2, wires=wires[1]),
-            qml.RY(phi / 2, wires=wires[0]),
-            qml.CNOT(wires=[wires[3], wires[1]]),
-            qml.CNOT(wires=[wires[2], wires[0]]),
-            qml.Hadamard(wires=wires[3]),
-            qml.Hadamard(wires=wires[2]),
+            qml.SingleExcitation(phi, wires=[wires[0], wires[2]]),
+            qml.SingleExcitation(phi, wires=[wires[1], wires[3]]),
         ]
+
+        # This decomposition is the "upside down" version of that on p18 of https://arxiv.org/abs/2104.05695
+        # decomp_ops = [
+        #    qml.Hadamard(wires=wires[3]),
+        #    qml.Hadamard(wires=wires[2]),
+        #    qml.CNOT(wires=[wires[3], wires[1]]),
+        #    qml.CNOT(wires=[wires[2], wires[0]]),
+        #    qml.RY(phi / 2, wires=wires[3]),
+        #    qml.RY(phi / 2, wires=wires[2]),
+        #    qml.RY(phi / 2, wires=wires[1]),
+        #    qml.RY(phi / 2, wires=wires[0]),
+        #    qml.CNOT(wires=[wires[3], wires[1]]),
+        #    qml.CNOT(wires=[wires[2], wires[0]]),
+        #    qml.Hadamard(wires=wires[3]),
+        #    qml.Hadamard(wires=wires[2]),
+        # ]
         return decomp_ops
 
     def adjoint(self):

--- a/tests/ops/qubit/test_qchem_ops.py
+++ b/tests/ops/qubit/test_qchem_ops.py
@@ -767,50 +767,21 @@ class TestOrbitalRotation:
     def test_orbital_rotation_decomp(self, phi):
         """Tests that the OrbitalRotation operation calculates the correct decomposition.
 
-        The decomposition has already been expressed in terms of single-qubit rotations
-        and CNOTs. For each term in the decomposition we need to construct the appropriate
-        four-qubit tensor product matrix and then multiply them together.
+        The decomposition is expressed in terms of two SingleExcitation gates. 
         """
         decomp1 = qml.OrbitalRotation(phi, wires=[0, 1, 2, 3]).decomposition()
         decomp2 = qml.OrbitalRotation.compute_decomposition(phi, wires=[0, 1, 2, 3])
 
-        from functools import reduce
+        op = qml.OrbitalRotation(phi, wires=[0, 1, 2, 3])
+        res1 = op.decomposition()
+        res2 = qml.OrbitalRotation.compute_decomposition(phi, wires=[0, 1, 2, 3])
 
-        # To compute the matrix for CX on an arbitrary number of qubits, use the fact that
-        # CU  = |0><0| \otimes I + |1><1| \otimes U
-        def cnot_four_qubits(wires):
-            proj_0_term = [StateZeroProjector if idx == wires[0] else np.eye(2) for idx in range(4)]
-
-            proj_1_term = [np.eye(2) for idx in range(4)]
-            proj_1_term[wires[0]] = StateOneProjector
-            proj_1_term[wires[1]] = X
-
-            proj_0_kron = reduce(np.kron, proj_0_term)
-            proj_1_kron = reduce(np.kron, proj_1_term)
-
-            return proj_0_kron + proj_1_kron
-
-        # Inserts a single-qubit matrix into a four-qubit matrix at the right place
-        def single_mat_four_qubits(mat, wire):
-            individual_mats = [mat if idx == wire else np.eye(2) for idx in range(4)]
-            return reduce(np.kron, individual_mats)
-
-        for decomp in [decomp1, decomp2]:
-            mats = []
-            for i in reversed(decomp):
-                # Single-qubit gate
-                if len(i.wires.tolist()) == 1:
-                    mat = single_mat_four_qubits(i.matrix(), i.wires.tolist()[0])
-                    mats.append(mat)
-                # Two-qubit gate
-                else:
-                    mat = cnot_four_qubits(i.wires.tolist())
-                    mats.append(mat)
-
-            decomposed_matrix = np.linalg.multi_dot(mats)
-            exp = OrbitalRotation(phi)
-
-            assert np.allclose(decomposed_matrix, exp)
+        decomposed_matrix = qml.matrix(
+            qml.SingleExcitation(phi, [0, 2]) @ qml.SingleExcitation(phi, [1, 3]),
+            wire_order=[0, 1, 2, 3],
+        )
+        for res in [res1, res2]:
+            assert np.equal(decomposed_matrix.all(), op.matrix().all())
 
     def test_adjoint(self):
         """Test adjoint method for adjoint op decomposition."""

--- a/tests/ops/qubit/test_qchem_ops.py
+++ b/tests/ops/qubit/test_qchem_ops.py
@@ -774,7 +774,7 @@ class TestOrbitalRotation:
             qml.SingleExcitation(phi, [0, 2]) @ qml.SingleExcitation(phi, [1, 3]),
             wire_order=[0, 1, 2, 3],
         )
-        assert np.equal(decomposed_matrix.all(), op.matrix().all())
+        assert np.array_equal(decomposed_matrix, op.matrix())
 
     def test_adjoint(self):
         """Test adjoint method for adjoint op decomposition."""

--- a/tests/ops/qubit/test_qchem_ops.py
+++ b/tests/ops/qubit/test_qchem_ops.py
@@ -767,21 +767,14 @@ class TestOrbitalRotation:
     def test_orbital_rotation_decomp(self, phi):
         """Tests that the OrbitalRotation operation calculates the correct decomposition.
 
-        The decomposition is expressed in terms of two SingleExcitation gates. 
+        The decomposition is expressed in terms of two SingleExcitation gates.
         """
-        decomp1 = qml.OrbitalRotation(phi, wires=[0, 1, 2, 3]).decomposition()
-        decomp2 = qml.OrbitalRotation.compute_decomposition(phi, wires=[0, 1, 2, 3])
-
         op = qml.OrbitalRotation(phi, wires=[0, 1, 2, 3])
-        res1 = op.decomposition()
-        res2 = qml.OrbitalRotation.compute_decomposition(phi, wires=[0, 1, 2, 3])
-
         decomposed_matrix = qml.matrix(
             qml.SingleExcitation(phi, [0, 2]) @ qml.SingleExcitation(phi, [1, 3]),
             wire_order=[0, 1, 2, 3],
         )
-        for res in [res1, res2]:
-            assert np.equal(decomposed_matrix.all(), op.matrix().all())
+        assert np.equal(decomposed_matrix.all(), op.matrix().all())
 
     def test_adjoint(self):
         """Test adjoint method for adjoint op decomposition."""


### PR DESCRIPTION
**Context:** New decomposition for `OrbitalDecomposition`.

**Description of the Change:** Decomposes into `SingleExcitation` gates instead of more elementary gates (e.g. control gates, `Hadamard`, etc.)

**Benefits:** 

There are two really big advantages to decomposing down into SingleExcitation gates:
- `default.qubit` and `lightning` natively support `SingleExcitation`, so the execution will be faster
- `SingleExcitation` has a parameter-shift rule defined, so less circuits will be executed to get the gradient

**Related GitHub Issues:** https://github.com/PennyLaneAI/pennylane/issues/3169
