### PR TITLE
Parameter-shift rule with unshifted evaluations

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -176,6 +176,10 @@ keyword argument when using `GellMann`, which determines which of the 8 Gell-Man
 
 <h3>Bug fixes</h3>
 
+* Fixed a bug that made `gradients.param_shift` raise an error when used with unshifted terms only
+  in a custom recipe, or with a recipe that does not use evaluations.
+  [(#31xx)](https://github.com/PennyLaneAI/pennylane/pull/31xx)
+
 * Fixed a bug that made `qml.AmplitudeEmbedding` incompatible with JITting.
   [(#3166)](https://github.com/PennyLaneAI/pennylane/pull/3166)
 

--- a/pennylane/gradients/parameter_shift.py
+++ b/pennylane/gradients/parameter_shift.py
@@ -352,7 +352,9 @@ def _expval_param_shift_tuple(
         gradient_tapes.extend(g_tapes)
         # If broadcast=True, g_tapes only contains one tape. If broadcast=False, all returned
         # tapes will have the same batch_size=None. Thus we only use g_tapes[0].batch_size here.
-        gradient_data.append((len(g_tapes), coeffs, None, unshifted_coeff, g_tapes[0].batch_size))
+        # If no gradient tapes are returned (e.g. only unshifted term in recipe), batch_size=None
+        batch_size = g_tapes[0].batch_size if g_tapes else None
+        gradient_data.append((len(g_tapes), coeffs, None, unshifted_coeff, batch_size))
 
     def processing_fn(results):
         grads = []
@@ -488,7 +490,9 @@ def expval_param_shift(
         gradient_tapes.extend(g_tapes)
         # If broadcast=True, g_tapes only contains one tape. If broadcast=False, all returned
         # tapes will have the same batch_size=None. Thus we only use g_tapes[0].batch_size here.
-        gradient_data.append((len(g_tapes), coeffs, None, unshifted_coeff, g_tapes[0].batch_size))
+        # If no gradient tapes are returned (e.g. only unshifted term in recipe), batch_size=None
+        batch_size = g_tapes[0].batch_size if g_tapes else None
+        gradient_data.append((len(g_tapes), coeffs, None, unshifted_coeff, batch_size))
 
     def processing_fn(results):
         # Apply the same squeezing as in qml.QNode to make the transform output consistent.

--- a/pennylane/gradients/parameter_shift.py
+++ b/pennylane/gradients/parameter_shift.py
@@ -163,7 +163,7 @@ def _evaluate_gradient_new(tape, res, data, r0):
         res = fn(res)
 
     multi_measure = len(tape.measurements) > 1
-    if isinstance(res, list) and len(res)==0:
+    if isinstance(res, list) and len(res) == 0:
         # No shifted evaluations are present, just the unshifted one.
         if not multi_measure:
             return unshifted_coeff * r0
@@ -203,7 +203,7 @@ def _evaluate_gradient(res, data, broadcast, r0, scalar_qfunc_output):
 
     _, coeffs, fn, unshifted_coeff, batch_size = data
 
-    if isinstance(res, list) and len(res)==0:
+    if isinstance(res, list) and len(res) == 0:
         # No shifted evaluations are present, just the unshifted one.
         return unshifted_coeff * r0
 

--- a/tests/gradients/test_parameter_shift.py
+++ b/tests/gradients/test_parameter_shift.py
@@ -328,6 +328,34 @@ class TestParamShift:
         grad = fn(qml.execute(tapes, dev, None))
         assert qml.math.allclose(grad, -np.sin(x[0] + x[1]), atol=1e-5)
 
+    @pytest.mark.parametrize("ops_with_custom_recipe", [[0], [1], [0, 1]])
+    def test_custom_recipe_unshifted_only(self, ops_with_custom_recipe):
+        """Test that if the gradient recipe has a zero-shift component, then
+        the tape is executed only once using the current parameter
+        values."""
+        dev = qml.device("default.qubit", wires=2)
+        x = [0.543, -0.654]
+
+        with qml.tape.QuantumTape() as tape:
+            qml.RX(x[0], wires=[0])
+            qml.RX(x[1], wires=[0])
+            qml.expval(qml.PauliZ(0))
+
+        gradient_recipes = tuple(
+            [[-1e7, 1, 0], [1e7, 1, 0]] if i in ops_with_custom_recipe else None
+            for i in range(2)
+        )
+        tapes, fn = qml.gradients.param_shift(tape, gradient_recipes=gradient_recipes)
+
+        # two tapes per parameter that doesn't use a custom recipe,
+        # plus one global (unshifted) call if at least one uses the custom recipe
+        num_ops_standard_recipe = tape.num_params - len(ops_with_custom_recipe)
+        assert len(tapes) == 2 * num_ops_standard_recipe + int(tape.num_params!=num_ops_standard_recipe)
+        # Test that executing the tapes and the postprocessing function works
+        grad = fn(qml.execute(tapes, dev, None))
+        expected = [-np.sin(x[0] + x[1]) if i not in ops_with_custom_recipe else 0 for i in range(2)]
+        assert qml.math.allclose(grad, expected, atol=1e-5)
+
     @pytest.mark.parametrize("y_wire", [0, 1])
     def test_f0_provided(self, y_wire):
         """Test that if the original tape output is provided, then

--- a/tests/gradients/test_parameter_shift.py
+++ b/tests/gradients/test_parameter_shift.py
@@ -342,18 +342,21 @@ class TestParamShift:
             qml.expval(qml.PauliZ(0))
 
         gradient_recipes = tuple(
-            [[-1e7, 1, 0], [1e7, 1, 0]] if i in ops_with_custom_recipe else None
-            for i in range(2)
+            [[-1e7, 1, 0], [1e7, 1, 0]] if i in ops_with_custom_recipe else None for i in range(2)
         )
         tapes, fn = qml.gradients.param_shift(tape, gradient_recipes=gradient_recipes)
 
         # two tapes per parameter that doesn't use a custom recipe,
         # plus one global (unshifted) call if at least one uses the custom recipe
         num_ops_standard_recipe = tape.num_params - len(ops_with_custom_recipe)
-        assert len(tapes) == 2 * num_ops_standard_recipe + int(tape.num_params!=num_ops_standard_recipe)
+        assert len(tapes) == 2 * num_ops_standard_recipe + int(
+            tape.num_params != num_ops_standard_recipe
+        )
         # Test that executing the tapes and the postprocessing function works
         grad = fn(qml.execute(tapes, dev, None))
-        expected = [-np.sin(x[0] + x[1]) if i not in ops_with_custom_recipe else 0 for i in range(2)]
+        expected = [
+            -np.sin(x[0] + x[1]) if i not in ops_with_custom_recipe else 0 for i in range(2)
+        ]
         assert qml.math.allclose(grad, expected, atol=1e-5)
 
     @pytest.mark.parametrize("y_wire", [0, 1])

--- a/tests/returntypes/test_parameter_shift_new.py
+++ b/tests/returntypes/test_parameter_shift_new.py
@@ -442,6 +442,34 @@ class TestParamShift:
         grad = fn(qml.execute(tapes, dev, None))
         assert qml.math.allclose(grad, -np.sin(x[0] + x[1]), atol=1e-5)
 
+    @pytest.mark.parametrize("ops_with_custom_recipe", [[0], [1], [0, 1]])
+    def test_custom_recipe_unshifted_only(self, ops_with_custom_recipe):
+        """Test that if the gradient recipe has a zero-shift component, then
+        the tape is executed only once using the current parameter
+        values."""
+        dev = qml.device("default.qubit", wires=2)
+        x = [0.543, -0.654]
+
+        with qml.tape.QuantumTape() as tape:
+            qml.RX(x[0], wires=[0])
+            qml.RX(x[1], wires=[0])
+            qml.expval(qml.PauliZ(0))
+
+        gradient_recipes = tuple(
+            [[-1e7, 1, 0], [1e7, 1, 0]] if i in ops_with_custom_recipe else None
+            for i in range(2)
+        )
+        tapes, fn = qml.gradients.param_shift(tape, gradient_recipes=gradient_recipes)
+
+        # two tapes per parameter that doesn't use a custom recipe,
+        # plus one global (unshifted) call if at least one uses the custom recipe
+        num_ops_standard_recipe = tape.num_params - len(ops_with_custom_recipe)
+        assert len(tapes) == 2 * num_ops_standard_recipe + int(tape.num_params!=num_ops_standard_recipe)
+        # Test that executing the tapes and the postprocessing function works
+        grad = fn(qml.execute(tapes, dev, None))
+        expected = [-np.sin(x[0] + x[1]) if i not in ops_with_custom_recipe else 0 for i in range(2)]
+        assert qml.math.allclose(grad, expected, atol=1e-5)
+
     @pytest.mark.parametrize("y_wire", [0, 1])
     def test_f0_provided(self, y_wire):
         """Test that if the original tape output is provided, then

--- a/tests/returntypes/test_parameter_shift_new.py
+++ b/tests/returntypes/test_parameter_shift_new.py
@@ -456,18 +456,21 @@ class TestParamShift:
             qml.expval(qml.PauliZ(0))
 
         gradient_recipes = tuple(
-            [[-1e7, 1, 0], [1e7, 1, 0]] if i in ops_with_custom_recipe else None
-            for i in range(2)
+            [[-1e7, 1, 0], [1e7, 1, 0]] if i in ops_with_custom_recipe else None for i in range(2)
         )
         tapes, fn = qml.gradients.param_shift(tape, gradient_recipes=gradient_recipes)
 
         # two tapes per parameter that doesn't use a custom recipe,
         # plus one global (unshifted) call if at least one uses the custom recipe
         num_ops_standard_recipe = tape.num_params - len(ops_with_custom_recipe)
-        assert len(tapes) == 2 * num_ops_standard_recipe + int(tape.num_params!=num_ops_standard_recipe)
+        assert len(tapes) == 2 * num_ops_standard_recipe + int(
+            tape.num_params != num_ops_standard_recipe
+        )
         # Test that executing the tapes and the postprocessing function works
         grad = fn(qml.execute(tapes, dev, None))
-        expected = [-np.sin(x[0] + x[1]) if i not in ops_with_custom_recipe else 0 for i in range(2)]
+        expected = [
+            -np.sin(x[0] + x[1]) if i not in ops_with_custom_recipe else 0 for i in range(2)
+        ]
         assert qml.math.allclose(grad, expected, atol=1e-5)
 
     @pytest.mark.parametrize("y_wire", [0, 1])


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      test directory!

- [x] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `doc/releases/changelog-dev.md` file, summarizing the
      change, and including a link back to the PR.

- [x] The PennyLane source code conforms to
      [PEP8 standards](https://www.python.org/dev/peps/pep-0008/).
      We check all of our code against [Pylint](https://www.pylint.org/).
      To lint modified files, simply `pip install pylint`, and then
      run `pylint pennylane/path/to/file.py`.

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
This PR fixes #3174, which is sensitive to a custom gradient recipe having unshifted terms _exclusively_.
It also fixes a bug where unshifted term raised an error when using the new return type system.

**Description of the Change:**
Custom recipes with unshifted terms only are supported now, and the new return type system variant is now compatible with
unshifted terms at all.

**Benefits:**
More custom recipes can be handles by `param_shift` and the new corresponding function.

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
#3174 
