### PR TITLE
clean up after catching errors within a stop_recording context

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -202,6 +202,9 @@ keyword argument when using `GellMann`, which determines which of the 8 Gell-Man
 * Fixed a bug where `qml.math.fidelity(non_trainable_state, trainable_state)` failed unexpectedly.
   [(#3160)](https://github.com/PennyLaneAI/pennylane/pull/3160)
 
+* Fixed a bug where `qml.QueuingManager.stop_recording` did not clean up if yielded code raises an exception.
+  [(#3182)](https://github.com/PennyLaneAI/pennylane/pull/3182)
+
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane/queuing.py
+++ b/pennylane/queuing.py
@@ -145,7 +145,11 @@ class QueuingManager:
         """
         previously_active_contexts = cls._active_contexts
         cls._active_contexts = []
-        yield
+        try:
+            yield
+        except Exception as e:
+            cls._active_contexts = previously_active_contexts
+            raise e
         cls._active_contexts = previously_active_contexts
 
     @classmethod

--- a/tests/tape/test_tape.py
+++ b/tests/tape/test_tape.py
@@ -1658,6 +1658,21 @@ class TestStopRecording:
         assert len(temp_tape.operations) == 1
         assert temp_tape.operations[0] == op1
 
+    @pytest.mark.parametrize("ret", [expval, var])
+    def test_stop_recording_within_tape_cleans_up(self, ret):
+        """Test if some error is raised within a stop_recording context, the previously
+        active contexts are still returned to avoid popping from an empty deque"""
+        @qml.transforms.insert(qml.RY, 0.1)
+        def circuit():
+            qml.RX(0.3, wires=0)
+            qml.RY(0.4, wires=1)
+            qml.expval(qml.PauliX(0)) # non-commuting, will raise error
+            ret(op=qml.PauliZ(0))
+
+        with pytest.raises(qml.QuantumFunctionError, match="Only observables that are qubit-wise"):
+            with QuantumTape() as tape:
+                circuit()
+
 
 def test_get_active_tape():
     """Test that the get_active_tape() function returns the currently

--- a/tests/tape/test_tape.py
+++ b/tests/tape/test_tape.py
@@ -1658,22 +1658,14 @@ class TestStopRecording:
         assert len(temp_tape.operations) == 1
         assert temp_tape.operations[0] == op1
 
-    @pytest.mark.parametrize("ret", [expval, var])
-    def test_stop_recording_within_tape_cleans_up(self, ret):
+    def test_stop_recording_within_tape_cleans_up(self):
         """Test if some error is raised within a stop_recording context, the previously
         active contexts are still returned to avoid popping from an empty deque"""
 
-        @qml.transforms.insert(qml.RY, 0.1)
-        def circuit():
-            qml.RX(0.3, wires=0)
-            qml.RY(0.4, wires=1)
-            qml.expval(qml.PauliX(0))  # non-commuting, will raise error
-            ret(op=qml.PauliZ(0))
-
-        with pytest.raises(qml.QuantumFunctionError, match="Only observables that are qubit-wise"):
-            with QuantumTape() as tape:
-                circuit()
-
+        with pytest.raises(ValueError):
+            with qml.queuing.AnnotatedQueue() as q:
+                with qml.QueuingManager.stop_recording():
+                    raise ValueError
 
 def test_get_active_tape():
     """Test that the get_active_tape() function returns the currently

--- a/tests/tape/test_tape.py
+++ b/tests/tape/test_tape.py
@@ -1662,11 +1662,12 @@ class TestStopRecording:
     def test_stop_recording_within_tape_cleans_up(self, ret):
         """Test if some error is raised within a stop_recording context, the previously
         active contexts are still returned to avoid popping from an empty deque"""
+
         @qml.transforms.insert(qml.RY, 0.1)
         def circuit():
             qml.RX(0.3, wires=0)
             qml.RY(0.4, wires=1)
-            qml.expval(qml.PauliX(0)) # non-commuting, will raise error
+            qml.expval(qml.PauliX(0))  # non-commuting, will raise error
             ret(op=qml.PauliZ(0))
 
         with pytest.raises(qml.QuantumFunctionError, match="Only observables that are qubit-wise"):

--- a/tests/tape/test_tape.py
+++ b/tests/tape/test_tape.py
@@ -1667,6 +1667,7 @@ class TestStopRecording:
                 with qml.QueuingManager.stop_recording():
                     raise ValueError
 
+
 def test_get_active_tape():
     """Test that the get_active_tape() function returns the currently
     recording tape, or None if no tape is recording"""


### PR DESCRIPTION
**Context:**
A bug was reported which demonstrated a scenario where `QueuingManager.stop_recording` called from within a tape raises an unexpected error (when some expected error is raised within the `stop_recording` block). If you `yield` in python, and the code you yielded to raises an exception, the rest of your code doesn't run. We had some cleanup code after `yield` in `stop_recording` that *must* be run before exiting a tape.

**Description of the Change:**
Restore previously active contexts after a `stop_recording` context even when the yielded block raises some error.

**Benefits:**
A bug will be squashed.

**Possible Drawbacks:**
None.

**Related GitHub Issues:**
Fixes #3103