### PR TITLE
Clean up `QuantumScript._par_info`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -139,6 +139,8 @@ keyword argument when using `GellMann`, which determines which of the 8 Gell-Man
   
 <h3>Breaking changes</h3>
 
+* `QuantumTape._par_info` is now a list of dictionaries, instead of a dictionary whose keys are integers starting from zero.
+
 * `QueuingContext` is renamed `QueuingManager`.
   [(#3061)](https://github.com/PennyLaneAI/pennylane/pull/3061)
 

--- a/pennylane/circuit_graph.py
+++ b/pennylane/circuit_graph.py
@@ -85,9 +85,8 @@ class CircuitGraph:
         ops (Iterable[.Operator]): quantum operators constituting the circuit, in temporal order
         obs (Iterable[.MeasurementProcess]): terminal measurements, in temporal order
         wires (.Wires): The addressable wire registers of the device that will be executing this graph
-        par_info (dict[int, dict[str, .Operation or int]]): Parameter information. Keys are
-            parameter indices (in the order they appear on the tape), and values are a
-            dictionary containing the corresponding operation and operation parameter index.
+        par_info (list[dict]): Parameter information. For each index, the entry is a dictionary containing an operation
+        and an index into that operation's parameters.
         trainable_params (set[int]): A set containing the indices of parameters that support
             differentiability. The indices provided match the order of appearence in the
             quantum circuit.
@@ -420,7 +419,7 @@ class CircuitGraph:
         current = Layer([], [])
         layers = [current]
 
-        for idx, info in self.par_info.items():
+        for idx, info in enumerate(self.par_info):
             if idx in self.trainable_params:
                 op = info["op"]
 

--- a/pennylane/gradients/gradient_transform.py
+++ b/pennylane/gradients/gradient_transform.py
@@ -53,7 +53,7 @@ def gradient_analysis(tape, use_graph=True, grad_fn=None):
     if grad_fn is not None:
         tape._gradient_fn = grad_fn
 
-    for idx, info in tape._par_info.items():
+    for idx, info in enumerate(tape._par_info):
 
         if idx not in tape.trainable_params:
             # non-trainable parameters do not require a grad_method
@@ -101,7 +101,7 @@ def grad_method_validation(method, tape):
 
     diff_methods = {
         idx: info["grad_method"]
-        for idx, info in tape._par_info.items()  # pylint: disable=protected-access
+        for idx, info in enumerate(tape._par_info)  # pylint: disable=protected-access
         if idx in tape.trainable_params
     }
 

--- a/pennylane/gradients/parameter_shift_cv.py
+++ b/pennylane/gradients/parameter_shift_cv.py
@@ -129,7 +129,7 @@ def _gradient_analysis_cv(tape):
 
     tape._gradient_fn = param_shift_cv
 
-    for idx, info in tape._par_info.items():
+    for idx, info in enumerate(tape._par_info):
         info["grad_method"] = _grad_method(tape, idx)
 
 

--- a/pennylane/tape/tape.py
+++ b/pennylane/tape/tape.py
@@ -499,7 +499,8 @@ class QuantumTape(QuantumScript, AnnotatedQueue):
 
         # map the params
         self.trainable_params = [parameter_mapping[i] for i in self.trainable_params]
-        self._par_info = {parameter_mapping[k]: v for k, v in self._par_info.items()}
+        _par_info_dict = {parameter_mapping[k]: v for k, v in enumerate(self._par_info)}
+        self._par_info = [_par_info_dict[i] for i in range(len(_par_info_dict))]
 
         for idx, op in enumerate(self._ops):
             self._ops[idx] = qml.adjoint(op, lazy=False)

--- a/tests/tape/test_qscript.py
+++ b/tests/tape/test_qscript.py
@@ -46,7 +46,7 @@ class TestInitialization:
         assert qs._ops == []
         assert qs._prep == []
         assert qs._measurements == []
-        assert qs._par_info == {}
+        assert qs._par_info == []
         assert qs._trainable_params == []
         assert qs._graph is None
         assert qs._specs is None

--- a/tests/tape/test_tape.py
+++ b/tests/tape/test_tape.py
@@ -772,7 +772,7 @@ class TestParameters:
 
         tape.set_parameters(new_params)
 
-        for pinfo, pval in zip(tape._par_info.values(), new_params):
+        for pinfo, pval in zip(tape._par_info, new_params):
             assert pinfo["op"].data[pinfo["p_idx"]] == pval
 
         assert tape.get_parameters() == new_params
@@ -780,7 +780,7 @@ class TestParameters:
         new_params = [0.1, -0.2, 1, 5, 0]
         tape.data = new_params
 
-        for pinfo, pval in zip(tape._par_info.values(), new_params):
+        for pinfo, pval in zip(tape._par_info, new_params):
             assert pinfo["op"].data[pinfo["p_idx"]] == pval
 
         assert tape.get_parameters() == new_params
@@ -794,7 +794,7 @@ class TestParameters:
         tape.set_parameters(new_params)
 
         count = 0
-        for idx, pinfo in tape._par_info.items():
+        for idx, pinfo in enumerate(tape._par_info):
             if idx in tape.trainable_params:
                 assert pinfo["op"].data[pinfo["p_idx"]] == new_params[count]
                 count += 1
@@ -835,7 +835,7 @@ class TestParameters:
         tape.trainable_params = [1, 3]
         tape.set_parameters(new_params, trainable_only=False)
 
-        for pinfo, pval in zip(tape._par_info.values(), new_params):
+        for pinfo, pval in zip(tape._par_info, new_params):
             assert pinfo["op"].data[pinfo["p_idx"]] == pval
 
         assert tape.get_parameters(trainable_only=False) == new_params


### PR DESCRIPTION
Note that PR branches off of #3097 and must be merged after it.

The `QuantumTape._par_info` (now `QuantumScript._par_info`) was a dictionary mapping from integers starting at zero to a dictionary.  This modifies that data structure to be a simple list instead.