### PR TITLE
[WIP] Extend `qml.equal` to `MeasurementProcess` objects

### DIFF
--- a/pennylane/ops/functions/equal.py
+++ b/pennylane/ops/functions/equal.py
@@ -15,13 +15,15 @@
 This module contains the qml.equal function.
 """
 # pylint: disable=too-many-arguments,too-many-return-statements
+from typing import Union
 import pennylane as qml
+from pennylane.measurements import MeasurementProcess
 from pennylane.operation import Operator
 
 
 def equal(
-    op1: Operator,
-    op2: Operator,
+    op1: Union[Operator, MeasurementProcess],
+    op2: Union[Operator, MeasurementProcess],
     check_interface=True,
     check_trainability=True,
     rtol=1e-5,
@@ -30,8 +32,8 @@ def equal(
     r"""Function for determining operator equality.
 
     Args:
-        op1 (.Operator): First operator to compare
-        op2 (.Operator): Second operator to compare
+        op1 (.Operator or .MeasurementProcess): First operator or MeasurementProcess to compare
+        op2 (.Operator or .MeasurementProcess): Second operator or MeasurementProcess to compare
         check_interface (bool, optional): Whether to compare interfaces. Default: ``True``
         check_trainability (bool, optional): Whether to compare trainability status. Default: ``True``
         rtol (float, optional): Relative tolerance for parameters
@@ -42,17 +44,22 @@ def equal(
 
     **Example**
 
-    Given two operators, ``qml.equal`` determines their equality:
+    Given two operators or measurement processes, ``qml.equal`` determines their equality:
 
     >>> op1 = qml.RX(np.array(.12), wires=0)
     >>> op2 = qml.RY(np.array(1.23), wires=0)
     >>> qml.equal(op1, op1), qml.equal(op1, op2)
     True False
 
+    >>> qml.equal(qml.expval(qml.PauliX(0)), qml.expval(qml.PauliX(0)) )
+    >>> True
+    >>> qml.equal(qml.probs(wires=(0,1)), qml.probs(wires=(1,2)) )
+    >>> False
+
     .. details::
         :title: Usage Details
 
-        You can use the optional arguments to get more specific results.
+        You can use the optional arguments when comparing Operators to get more specific results.
 
         Consider the following comparisons:
 
@@ -72,8 +79,33 @@ def equal(
         >>> qml.equal(op3, op4, check_trainability=False)
         True
     """
-    if op1.__class__ is not op2.__class__ or op1.arithmetic_depth != op2.arithmetic_depth:
+
+    if op1.__class__ is not op2.__class__:
         return False
+
+    if op1.__class__ is MeasurementProcess:
+
+        if op1.return_type != op2.return_type:
+            return False
+
+        # Check the existence of m.obs, compare if exists for both
+        if op1.obs != op2.obs:
+            return False
+        elif op1.obs == op2.obs and op1.obs is not None:
+            return True
+
+        # Check wires
+        if op1.wires != op2.wires:
+            return False
+        else:
+            return True
+        
+        # TODO: consider that both obs and wires can be none
+        
+    # If operator:
+    if op1.arithmetic_depth != op2.arithmetic_depth:
+        return False
+
     if op1.arithmetic_depth > 0:
         raise NotImplementedError(
             "Comparison of operators with an arithmetic depth larger than 0 is not yet implemented."

--- a/tests/ops/functions/test_equal.py
+++ b/tests/ops/functions/test_equal.py
@@ -107,6 +107,44 @@ PARAMETRIZED_OPERATIONS_COMBINATIONS = list(
 )
 
 
+PARAMETRIZED_MEASUREMENTS_WIRES = [
+    qml.density_matrix,
+    qml.vn_entropy,
+    qml.measure,
+    qml.mutual_info,
+    qml.classical_shadow,
+
+    qml.shadow_expval, # porbably wires, or maybe obs since expval
+    qml.state, # probably has wires?
+]
+
+PARAMETRIZED_MEASUREMENTS_OBS = [
+    qml.var,
+    qml.expval
+]
+
+PARAMETRIZED_MEASUREMENTS_EITHER = [
+    qml.sample,
+    qml.counts,
+    qml.probs
+]
+
+
+PARAMETRIZED_MEASUREMENTS = [
+    qml.sample,
+    qml.counts,
+    qml.density_matrix,
+    qml.var,
+    qml.expval,
+    qml.probs,
+    qml.state,
+    qml.measure,
+    qml.vn_entropy,
+    qml.mutual_info,
+    qml.classical_shadow,
+    qml.shadow_expval
+]
+
 class TestEqual:
     @pytest.mark.parametrize("ops", PARAMETRIZED_OPERATIONS_COMBINATIONS)
     def test_equal_simple_diff_op(self, ops):
@@ -940,3 +978,15 @@ class TestEqual:
         op1 = qml.PauliX(0)
         op2 = qml.PauliX(0).inv()
         assert not qml.equal(op1, op2)
+
+    # Test cases
+    # 1. test not equal 2 MeasurementProcess with observables only
+    # 2. test equal 2 MeasurementProcess with observables only
+    # 3. test not equal 2 MeasurementProcess with wires only 
+    # 4. test equal 2 MeasurementProcess with wires only
+    # 5. test not equal MeasurementProcess with wires and Measurement Process with observable
+    # 6. test not equal MeasurementProcess and Operator
+    # 7. test state
+    # 8. test raises error when object type not MeasurementProcess or Operator
+
+        


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      test directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `doc/releases/changelog-dev.md` file, summarizing the
      change, and including a link back to the PR.

- [ ] The PennyLane source code conforms to
      [PEP8 standards](https://www.python.org/dev/peps/pep-0008/).
      We check all of our code against [Pylint](https://www.pylint.org/).
      To lint modified files, simply `pip install pylint`, and then
      run `pylint pennylane/path/to/file.py`.

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
`qml.equal` currently checks equality for Operator. This PR extends this functionality to objects of type MeasurementProcess.

**Description of the Change:**
Augment the qml.equal function with conditional statements to check the equality of MeasurementProcess objects.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**

------------------------------------------------------------------------------------------------------------
**Questions:**
I had a few questions that can help me move forward with this PR :
1. Do I need to consider that both observables and wires can be None? For example, `qml.state()` seems to not require wires or observables.
2. Would it be a good idea to create other functions in equal.py such as `check_measurement_equality()` and `check_operator_equality()`? I am finding the long function with many if statements harder to follow (also pylint doesn't like it :). If there is a plan to extend `qml.equal` to classes similar to `MeasurementProcess` in the future, then this function would grow into a massive function that can be hard to understand.
3. In measurements.py, there is a function `density_matrix()`, but there is no return type `density_matrix` in `ObservableReturnTypes` at the top of the file? Is `AllCounts` the associated return type for `density_matrix`?
4. Any feedback on my current direction would be greatly appreciated.

Thank you for the clarification
