### PR TITLE
test to show noise transform fails properly

### DIFF
--- a/tests/transforms/test_insert_ops.py
+++ b/tests/transforms/test_insert_ops.py
@@ -490,7 +490,7 @@ def test_insert_decorator_doesnt_cause_index_error():
         return qml.expval(qml.PauliX(0)), qml.expval(qml.PauliY(0)), qml.expval(qml.PauliZ(0))
 
     # This tape's expansion fails, but shouldn't cause a downstream IndexError. See issue #3103
-    with pytest.raises(Exception) as e:
+    with pytest.raises(Exception, match="Only observables that are qubit-wise commuting") as e:
         noisy_circuit(0.4)
     assert e.type != IndexError
     assert e.type == qml.QuantumFunctionError

--- a/tests/transforms/test_insert_ops.py
+++ b/tests/transforms/test_insert_ops.py
@@ -472,7 +472,7 @@ def test_insert_template():
     assert np.allclose(f1(w1, w2), f2(w1, w2))
 
 
-def test_insert_decorator_doesnt_cause_deque_error():
+def test_insert_decorator_doesnt_cause_index_error():
     """Test that the insert transform catches and reports errors from the enclosed function."""
 
     def noise(noise_param, wires):
@@ -489,10 +489,8 @@ def test_insert_decorator_doesnt_cause_deque_error():
         qml.T(wires=0)
         return qml.expval(qml.PauliX(0)), qml.expval(qml.PauliY(0)), qml.expval(qml.PauliZ(0))
 
-    try:
+    # This tape's expansion fails, but shouldn't cause a downstream IndexError. See issue #3103
+    with pytest.raises(Exception) as e:
         noisy_circuit(0.4)
-        assert False
-    except Exception as e:
-        # This tape's expansion fails, but shouldn't cause a downstream IndexError. See issue #3103
-        assert not isinstance(e, IndexError)
-        assert isinstance(e, qml.QuantumFunctionError)
+    assert e.type != IndexError
+    assert e.type == qml.QuantumFunctionError


### PR DESCRIPTION
Issue #3103 was closed automatically, but let's add one more test as per Antal's request in the closing PR.

This test demonstrates that the reported bug specifically has been fixed.

Note that if (when?) we support non-commuting observables, this will no longer raise an error and the test will fail (it will hit the `assert False` line). If we don't want this to happen, we can leave the tests as is (because the other PR more generally tests what happens when a downstream error occurs). I'm of the opinion that this is still a value-add, because we can simply remove this test when this circuit no longer raises an error!