### PR TITLE
cast sample result with _asarray

### DIFF
--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -911,7 +911,7 @@ class QubitDevice(Device):
 
             elif obs.return_type is Sample:
                 samples = self.sample(obs, shot_range=shot_range, bin_size=bin_size, counts=False)
-                result = qml.math.squeeze(samples)
+                result = self._asarray(qml.math.squeeze(samples))
 
             elif obs.return_type in (Counts, AllCounts):
                 result = self.sample(obs, shot_range=shot_range, bin_size=bin_size, counts=True)

--- a/tests/returntypes/test_new_return_types_qnode.py
+++ b/tests/returntypes/test_new_return_types_qnode.py
@@ -417,7 +417,7 @@ class TestIntegrationSingleReturnTensorFlow:
         """Test the sample measurement."""
         import tensorflow as tf
 
-        if device == "default.mixed" or "default.qubit":
+        if device in ["default.mixed", "default.qubit"]:
             pytest.skip("Sample need to be rewritten for Tf.")
 
         dev = qml.device(device, wires=2, shots=shots)
@@ -631,7 +631,7 @@ class TestIntegrationSingleReturnTorch:
         """Test the sample measurement."""
         import torch
 
-        if device == "default.mixed" or "default.qubit":
+        if device in ["default.mixed", "default.qubit"]:
             pytest.skip("Sample need to be rewritten for Torch.")
 
         dev = qml.device(device, wires=2, shots=shots)
@@ -1290,7 +1290,7 @@ class TestIntegrationMultipleReturnsTensorflow:
         """Test the expval and sample measurements together."""
         import tensorflow as tf
 
-        if device == "default.mixed" or "default.qubit":
+        if device in ["default.mixed", "default.qubit"]:
             pytest.skip("Sample must be reworked with interfaces.")
 
         dev = qml.device(device, wires=2, shots=shots)
@@ -1553,7 +1553,7 @@ class TestIntegrationMultipleReturnsTorch:
         """Test the expval and sample measurements together."""
         import torch
 
-        if device == "default.mixed" or "default.qubit":
+        if device in ["default.mixed", "default.qubit"]:
             pytest.skip("Sample need to be rewritten for interfaces.")
 
         dev = qml.device(device, wires=2, shots=shots)


### PR DESCRIPTION
**Context:**
See related issue. The new return type system was not casting the result of `qml.sample` according to the device being used.

**Description of the Change:**
Cast the result of `qml.sample` to the return type of the interface being used in the new return-type system.

**Benefits:**
Device execution will return results in the expected data type, as opposed to blindly returning a numpy.array

**Possible Drawbacks:**
None... unless `sample()` sometimes returns a scalar value, and it gets blindly cast to an array-like?

**Related GitHub Issues:**
Fixes #2983

## Note on testing
I didn't add any tests, but instead made existing tests run that weren't otherwise running (and would have failed without this bugfix). The tests were checking things like:
```python
if "default.qubit.tf" == "default.mixed" or "default.qubit:"
    pytest.skip()
```
In Python, this evaluates as:
```python
if ("default.qubit.tf" == "default.mixed") or ("default.qubit")
# aka, if (False) or (True):
```
The condition in the first set of parentheses is obviously False, so it checks if the next "condition" ("default.qubit") is truthy, which it is (strings of non-zero length are truthy in Python). I fixed the syntax, the tests failed, then I added the bugfix, and the tests passed. List of previously failing tests:
- TestIntegrationSingleReturnTensorFlow::test_sample
- TestIntegrationSingleReturnTorch::test_sample
- TestIntegrationMultipleReturnsTensorflow::test_expval_sample
- TestIntegrationMultipleReturnsTorch::test_expval_sample

Jax samples were returning `jaxlib.xla_extension.DeviceArray` types without this fix, so there was no additional testing needed.