### PR TITLE
Shots #4: Use shot information from `QuantumTape` instead of `Device`

### DIFF
--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -35,6 +35,7 @@ from pennylane.measurements import (
     Variance,
 )
 from pennylane.operation import Observable, Operation, Tensor
+from pennylane.tape import QuantumTape
 from pennylane.wires import WireError, Wires
 
 ShotTuple = namedtuple("ShotTuple", ["shots", "copies"])
@@ -210,9 +211,7 @@ class Device(abc.ABC):
     @property
     def analytic(self):
         """Whether shots is None or not. Kept for backwards compatability."""
-        if self._shots is None:
-            return True
-        return False
+        return self._shots is None
 
     @property
     def wires(self):
@@ -681,7 +680,7 @@ class Device(abc.ABC):
 
         return self.default_expand_fn(circuit, max_expansion=max_expansion)
 
-    def batch_transform(self, circuit):
+    def batch_transform(self, circuit: QuantumTape):
         """Apply a differentiable batch transform for preprocessing a circuit
         prior to execution. This method is called directly by the QNode, and
         should be overwritten if the device requires a transform that
@@ -708,7 +707,7 @@ class Device(abc.ABC):
             to be applied to the list of evaluated circuit results.
         """
         supports_hamiltonian = self.supports_observable("Hamiltonian")
-        finite_shots = self.shots is not None
+        finite_shots = circuit.shots is not None
         grouping_known = all(
             obs.grouping_indices is not None
             for obs in circuit.observables

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -657,7 +657,7 @@ class Device(abc.ABC):
 
         return circuit
 
-    def expand_fn(self, circuit, max_expansion=10):
+    def expand_fn(self, circuit: QuantumTape, max_expansion=10):
         """Method for expanding or decomposing an input circuit.
         Can be the default or a custom expansion method, see
         :meth:`.Device.default_expand_fn` and :meth:`.Device.custom_expand` for more

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -35,7 +35,7 @@ from pennylane.measurements import (
     Variance,
 )
 from pennylane.operation import Observable, Operation, Tensor
-from pennylane.tape import QuantumScript, QuantumTape
+from pennylane.tape import QuantumTape
 from pennylane.wires import WireError, Wires
 
 ShotTuple = namedtuple("ShotTuple", ["shots", "copies"])
@@ -398,7 +398,7 @@ class Device(abc.ABC):
         return cls._capabilities
 
     # pylint: disable=too-many-branches,unused-argument
-    def execute(self, queue: QuantumScript, observables, parameters=None, **kwargs):
+    def execute(self, queue, observables, parameters=None, **kwargs):
         """Execute a queue of quantum operations on the device and then measure the given observables.
 
         For plugin developers: Instead of overwriting this, consider implementing a suitable subset of
@@ -406,7 +406,7 @@ class Device(abc.ABC):
         :meth:`expval`, :meth:`var`, :meth:`sample`, :meth:`post_measure`, and :meth:`execution_context`.
 
         Args:
-            queue (Iterable[~.tape.QuantumScript]): operations to execute on the device
+            queue (Iterable[~.operation.Operation]): operations to execute on the device
             observables (Iterable[~.operation.Observable]): observables to measure and return
             parameters (dict[int, list[ParameterDependency]]): Mapping from free parameter index to the list of
                 :class:`Operations <pennylane.operation.Operation>` (in the queue) that depend on it.
@@ -421,8 +421,6 @@ class Device(abc.ABC):
         Returns:
             array[float]: measured value(s)
         """
-        if queue.shots is None and self.shots is not None:
-            queue.shots = self.raw_shots
         self.check_validity(queue, observables)
         self._op_queue = queue
         self._obs_queue = observables

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -35,7 +35,7 @@ from pennylane.measurements import (
     Variance,
 )
 from pennylane.operation import Observable, Operation, Tensor
-from pennylane.tape import QuantumTape
+from pennylane.tape import QuantumScript, QuantumTape
 from pennylane.wires import WireError, Wires
 
 ShotTuple = namedtuple("ShotTuple", ["shots", "copies"])
@@ -398,7 +398,7 @@ class Device(abc.ABC):
         return cls._capabilities
 
     # pylint: disable=too-many-branches,unused-argument
-    def execute(self, queue, observables, parameters=None, **kwargs):
+    def execute(self, queue: QuantumScript, observables, parameters=None, **kwargs):
         """Execute a queue of quantum operations on the device and then measure the given observables.
 
         For plugin developers: Instead of overwriting this, consider implementing a suitable subset of
@@ -406,7 +406,7 @@ class Device(abc.ABC):
         :meth:`expval`, :meth:`var`, :meth:`sample`, :meth:`post_measure`, and :meth:`execution_context`.
 
         Args:
-            queue (Iterable[~.operation.Operation]): operations to execute on the device
+            queue (Iterable[~.tape.QuantumScript]): operations to execute on the device
             observables (Iterable[~.operation.Observable]): observables to measure and return
             parameters (dict[int, list[ParameterDependency]]): Mapping from free parameter index to the list of
                 :class:`Operations <pennylane.operation.Operation>` (in the queue) that depend on it.
@@ -421,6 +421,8 @@ class Device(abc.ABC):
         Returns:
             array[float]: measured value(s)
         """
+        if queue.shots is None and self.shots is not None:
+            queue.shots = self.raw_shots
         self.check_validity(queue, observables)
         self._op_queue = queue
         self._obs_queue = observables

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -277,7 +277,7 @@ class QubitDevice(Device):
 
             s1 = s2
 
-        multiple_sampled_jobs = circuit.is_sampled and self._has_partitioned_shots()
+        multiple_sampled_jobs = circuit.is_sampled and circuit.has_partitioned_shots()
         if not multiple_sampled_jobs and not counts_exist:
             # Can only stack single element outputs
             results = self._stack(results)
@@ -415,7 +415,7 @@ class QubitDevice(Device):
                 # all the other cases except any counts
                 results = self._asarray(results)
 
-        elif circuit.all_sampled and not self._has_partitioned_shots() and not counts_exist:
+        elif circuit.all_sampled and not circuit.has_partitioned_shots() and not counts_exist:
             results = self._asarray(results)
         else:
             results = tuple(
@@ -950,7 +950,7 @@ class QubitDevice(Device):
                     )
 
                 # TODO: qml.execute shot vec support required with new return types
-                # if self._shot_vector is not None:
+                # if circuit.shot_vector is not None:
                 #     raise NotImplementedError(
                 #         "Returning the Von Neumann entropy is not supported with shot vectors."
                 #     )
@@ -971,7 +971,7 @@ class QubitDevice(Device):
                     )
 
                 # TODO: qml.execute shot vec support required with new return types
-                # if self._shot_vector is not None:
+                # if circuit.shot_vector is not None:
                 #     raise NotImplementedError(
                 #         "Returning the mutual information is not supported with shot vectors."
                 #     )

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -311,6 +311,9 @@ class QubitDevice(Device):
         Returns:
             array[float]: measured value(s)
         """
+        if circuit.shots is None and self.shots is not None:
+            circuit.shots = self.raw_shots
+
         self.check_validity(circuit.operations, circuit.observables)
 
         # apply all circuit operations
@@ -389,7 +392,7 @@ class QubitDevice(Device):
         )
 
         # compute the required statistics
-        if not self.analytic and circuit.shot_vector is not None:
+        if circuit.shot_vector is not None:
             results = self._collect_shotvector_results(circuit, counts_exist)
         else:
             results = self.statistics(circuit=circuit)

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -389,7 +389,7 @@ class QubitDevice(Device):
         )
 
         # compute the required statistics
-        if not circuit.analytic and circuit.shot_vector is not None:
+        if not self.analytic and circuit.shot_vector is not None:
             results = self._collect_shotvector_results(circuit, counts_exist)
         else:
             results = self.statistics(circuit=circuit)

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -389,7 +389,7 @@ class QubitDevice(Device):
         )
 
         # compute the required statistics
-        if not self.analytic and circuit.shot_vector is not None:
+        if not circuit.analytic and circuit.shot_vector is not None:
             results = self._collect_shotvector_results(circuit, counts_exist)
         else:
             results = self.statistics(circuit=circuit)

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -17,7 +17,7 @@ This module contains the :class:`QubitDevice` abstract base class.
 
 # For now, arguments may be different from the signatures provided in Device
 # e.g. instead of expval(self, observable, wires, par) have expval(self, observable)
-# pylint: disable=arguments-differ, abstract-method, no-value-for-parameter,too-many-instance-attributes,too-many-branches, no-member, bad-option-value, arguments-renamed
+# pylint: disable=arguments-differ, abstract-method, no-value-for-parameter,too-many-instance-attributes,too-many-branches,no-member,bad-option-value,arguments-renamed,too-many-statements
 import abc
 import itertools
 import warnings
@@ -368,6 +368,9 @@ class QubitDevice(Device):
         Returns:
             array[float]: measured value(s)
         """
+        if circuit.shots is None and self.shots is not None:
+            circuit.shots = self.raw_shots  # update tape shots with device.shots
+
         if qml.active_return():
             return self._execute_new(circuit, **kwargs)
 
@@ -1819,6 +1822,9 @@ class QubitDevice(Device):
             QuantumFunctionError: if the input tape has measurements that are not expectation values
                 or contains a multi-parameter operation aside from :class:`~.Rot`
         """
+        if tape.shots is None:
+            # Update tape shots with device.shots
+            tape.shots = self.raw_shots
         # broadcasted inner product not summing over first dimension of b
         sum_axes = tuple(range(1, self.num_wires + 1))
         # pylint: disable=unnecessary-lambda-assignment)

--- a/pennylane/collections/qnode_collection.py
+++ b/pennylane/collections/qnode_collection.py
@@ -14,9 +14,13 @@
 """
 Contains the QNodeCollection class.
 """
+import warnings
+
 # pylint: disable=too-many-arguments,import-outside-toplevel
 from collections.abc import Sequence
-import warnings
+from typing import List
+
+from pennylane.qnode import QNode
 
 
 class QNodeCollection(Sequence):
@@ -159,7 +163,7 @@ class QNodeCollection(Sequence):
     """
 
     def __init__(self, qnodes=None):
-        self.qnodes = []
+        self.qnodes: List[QNode] = []
         self.extend(qnodes or [])
 
     @property

--- a/pennylane/interfaces/execution.py
+++ b/pennylane/interfaces/execution.py
@@ -566,6 +566,16 @@ def execute(
            [ 0.01983384, -0.97517033,  0.        ],
            [ 0.        ,  0.        , -0.95533649]])
     """
+    tapes = list(tapes)
+    for i, tape in enumerate(tapes):
+        if override_shots is not False:
+            # Always create a new class when overriding shots
+            new_tape = tape.copy()
+            new_tape.shots = override_shots
+            tapes[i] = new_tape
+        elif tape.shots is None:
+            tape.shots = device.raw_shots
+
     if qml.active_return():
         return _execute_new(
             tapes,

--- a/pennylane/interfaces/set_shots.py
+++ b/pennylane/interfaces/set_shots.py
@@ -18,9 +18,11 @@ to be temporarily modified.
 # pylint: disable=protected-access
 import contextlib
 
+from pennylane import Device
+
 
 @contextlib.contextmanager
-def set_shots(device, shots):
+def set_shots(device: Device, shots):
     """Context manager to temporarily change the shots
     of a device.
 

--- a/pennylane/optimize/shot_adaptive.py
+++ b/pennylane/optimize/shot_adaptive.py
@@ -13,11 +13,14 @@
 # limitations under the License.
 """Shot adaptive optimizer"""
 # pylint: disable=too-many-instance-attributes,too-many-arguments,too-many-branches
+from typing import Sequence
+
 from scipy.stats import multinomial
 
 import pennylane as qml
 from pennylane import numpy as np
-
+from pennylane.qnode import QNode
+from pennylane.vqe import ExpvalCost
 
 from .gradient_descent import GradientDescentOptimizer
 
@@ -206,7 +209,14 @@ class ShotAdaptiveOptimizer(GradientDescentOptimizer):
         super().__init__(stepsize=stepsize)
 
     @staticmethod
-    def weighted_random_sampling(qnodes, coeffs, shots, argnums, *args, **kwargs):
+    def weighted_random_sampling(
+        qnodes: Sequence[QNode],
+        coeffs: Sequence[float],
+        shots: int,
+        argnums: Sequence[int],
+        *args,
+        **kwargs,
+    ):
         """Returns an array of length ``shots`` containing single-shot estimates
         of the Hamiltonian gradient. The shots are distributed randomly over
         the terms in the Hamiltonian, as per a multinomial distribution.
@@ -244,7 +254,7 @@ class ShotAdaptiveOptimizer(GradientDescentOptimizer):
                 continue
 
             # set the QNode device shots
-            h.device.shots = [(1, s)]
+            h.shots = [(1, s)]
 
             jacs = []
             for i in argnums:
@@ -293,7 +303,7 @@ class ShotAdaptiveOptimizer(GradientDescentOptimizer):
         if self.stepsize > 2 / self.lipschitz:
             raise ValueError(f"The learning rate must be less than {2 / self.lipschitz}")
 
-    def _single_shot_expval_gradients(self, expval_cost, args, kwargs):
+    def _single_shot_expval_gradients(self, expval_cost: ExpvalCost, args, kwargs):
         """Compute the single shot gradients of an ExpvalCost object"""
 
         qnodes = expval_cost.qnodes
@@ -301,7 +311,7 @@ class ShotAdaptiveOptimizer(GradientDescentOptimizer):
         device = qnodes[0].device
 
         self.check_device(device)
-        original_shots = device.shots
+        original_shots = [qnode.shots for qnode in qnodes]
 
         if self.lipschitz is None:
             self.check_learning_rate(coeffs)
@@ -312,7 +322,8 @@ class ShotAdaptiveOptimizer(GradientDescentOptimizer):
                     qnodes, coeffs, self.max_shots, self.trainable_args, *args, **kwargs
                 )
             elif self.term_sampling is None:
-                device.shots = [(1, self.max_shots)]
+                for qnode in qnodes:
+                    qnode.shots = [(1, self.max_shots)]
                 # We iterate over each trainable argument, rather than using
                 # qml.jacobian(expval_cost), to take into account the edge case where
                 # different arguments have different shapes and cannot be stacked.
@@ -327,25 +338,24 @@ class ShotAdaptiveOptimizer(GradientDescentOptimizer):
                     "term_sampling=None currently supported."
                 )
         finally:
-            device.shots = original_shots
+            for qnode, init_shots in zip(qnodes, original_shots):
+                qnode.shots = init_shots
 
         return grads
 
-    def _single_shot_qnode_gradients(self, qnode, args, kwargs):
+    def _single_shot_qnode_gradients(self, qnode: QNode, args, kwargs):
         """Compute the single shot gradients of a QNode."""
-        device = qnode.device
-
         self.check_device(qnode.device)
-        original_shots = device.shots
+        original_shots = qnode.shots
 
         if self.lipschitz is None:
             self.check_learning_rate(1)
 
         try:
-            device.shots = [(1, self.max_shots)]
+            qnode.shots = [(1, self.max_shots)]
             grads = [qml.jacobian(qnode, argnum=i)(*args, **kwargs) for i in self.trainable_args]
         finally:
-            device.shots = original_shots
+            qnode.shots = original_shots
 
         return grads
 
@@ -366,8 +376,10 @@ class ShotAdaptiveOptimizer(GradientDescentOptimizer):
         """
         if isinstance(objective_fn, qml.ExpvalCost):
             grads = self._single_shot_expval_gradients(objective_fn, args, kwargs)
-        elif isinstance(objective_fn, qml.QNode) or hasattr(objective_fn, "device"):
+        elif isinstance(objective_fn, qml.QNode):
             grads = self._single_shot_qnode_gradients(objective_fn, args, kwargs)
+        elif hasattr(objective_fn, "qnode"):
+            grads = self._single_shot_qnode_gradients(objective_fn.qnode, args, kwargs)
         else:
             raise ValueError(
                 "The objective function must either be encoded as a single QNode or "
@@ -502,16 +514,18 @@ class ShotAdaptiveOptimizer(GradientDescentOptimizer):
         new_args = self.step(objective_fn, *args, **kwargs)
 
         if isinstance(objective_fn, qml.ExpvalCost):
-            device = objective_fn.qnodes[0].device
-        elif isinstance(objective_fn, qml.QNode) or hasattr(objective_fn, "device"):
-            device = objective_fn.device
+            qnodes = objective_fn.qnodes
+        elif isinstance(objective_fn, qml.QNode) or hasattr(objective_fn, "qnode"):
+            qnodes = [objective_fn]
 
-        original_shots = device.shots
+        original_shots = [qnode.shots for qnode in qnodes]
 
         try:
-            device.shots = int(self.max_shots)
+            for qnode in qnodes:
+                qnode.shots = int(self.max_shots)
             forward = objective_fn(*args, **kwargs)
         finally:
-            device.shots = original_shots
+            for qnode, init_shots in zip(qnodes, original_shots):
+                qnode.shots = init_shots
 
         return new_args, forward

--- a/pennylane/qinfo/transforms.py
+++ b/pennylane/qinfo/transforms.py
@@ -17,6 +17,7 @@ import functools
 
 import pennylane as qml
 from pennylane.devices import DefaultQubit
+from pennylane.qnode import QNode
 from pennylane.tape import QuantumTape
 from pennylane.transforms import adjoint_metric_tensor, batch_transform, metric_tensor
 
@@ -434,7 +435,7 @@ def classical_fisher(qnode, argnums=0):
     return wrapper
 
 
-def quantum_fisher(qnode, *args, **kwargs):
+def quantum_fisher(qnode: QNode, *args, **kwargs):
     r"""Returns a function that computes the quantum fisher information matrix (QFIM) of a given :class:`.QNode`.
 
     Given a parametrized quantum state :math:`|\psi(\bm{\theta})\rangle`, the quantum fisher information matrix (QFIM) quantifies how changes to the parameters :math:`\bm{\theta}`
@@ -519,7 +520,7 @@ def quantum_fisher(qnode, *args, **kwargs):
 
     """
 
-    if qnode.device.shots is not None and isinstance(qnode.device, DefaultQubit):
+    if qnode.shots is not None and isinstance(qnode.device, DefaultQubit):
 
         def wrapper(*args0, **kwargs0):
             return 4 * metric_tensor(qnode, *args, **kwargs)(*args0, **kwargs0)

--- a/pennylane/qnode.py
+++ b/pennylane/qnode.py
@@ -675,7 +675,7 @@ class QNode:
                 gradient_fn=self.gradient_fn,
                 interface=self.interface,
                 gradient_kwargs=self.gradient_kwargs,
-                override_shots=override_shots,
+                override_shots=override_shots,  # TODO: Remove this line when using tape.shots
                 **self.execute_kwargs,
             )
 
@@ -713,7 +713,7 @@ class QNode:
             gradient_fn=self.gradient_fn,
             interface=self.interface,
             gradient_kwargs=self.gradient_kwargs,
-            override_shots=override_shots,
+            override_shots=override_shots,  # TODO: Remove this line when using tape.shots
             **self.execute_kwargs,
         )
 

--- a/pennylane/tape/qscript.py
+++ b/pennylane/tape/qscript.py
@@ -892,6 +892,9 @@ class QuantumScript:
             >>> qs.shape(dev)
             (1, 4)
         """
+        if self.shots is None and device.shots is not None:
+            self.shots = device.raw_shots
+
         if qml.active_return():
             return self._shape_new(device)
 

--- a/pennylane/tape/qscript.py
+++ b/pennylane/tape/qscript.py
@@ -749,8 +749,7 @@ class QuantumScript:
         """
         return measurement_process.shape(device)
 
-    @staticmethod
-    def _multi_homogenous_measurement_shape(mps, device):
+    def _multi_homogenous_measurement_shape(self, mps, device):
         """Auxiliary function of shape that determines the output
         shape of a quantum script with multiple homogenous measurements.
 
@@ -781,7 +780,7 @@ class QuantumScript:
                 "Getting the output shape of a quantum script with multiple state measurements is not supported."
             )
 
-        shot_vector = device._shot_vector
+        shot_vector = self.shot_vector
         if shot_vector is None:
             if ret_type in (qml.measurements.Expectation, qml.measurements.Variance):
 
@@ -806,17 +805,16 @@ class QuantumScript:
 
             elif ret_type == qml.measurements.Sample:
 
-                shape = (len(mps), device.shots)
+                shape = (len(mps), self.shots)
 
             # No other measurement type to check
 
         else:
-            shape = QuantumScript._shape_shot_vector_multi_homogenous(mps, device)
+            shape = self._shape_shot_vector_multi_homogenous(mps, device)
 
         return shape
 
-    @staticmethod
-    def _shape_shot_vector_multi_homogenous(mps, device):
+    def _shape_shot_vector_multi_homogenous(self, mps, device):
         """Auxiliary function for determining the output shape of the quantum script for
         multiple homogenous measurements for a device with a shot vector.
 
@@ -826,7 +824,7 @@ class QuantumScript:
         shape = tuple()
 
         ret_type = mps[0].return_type
-        shot_vector = device._shot_vector
+        shot_vector = self.shot_vector
 
         # Shot vector was defined
         if ret_type in (qml.measurements.Expectation, qml.measurements.Variance):
@@ -857,7 +855,7 @@ class QuantumScript:
 
         elif ret_type == qml.measurements.Sample:
             shape = []
-            for shot_val in device.shot_vector:
+            for shot_val in self.shot_vector:
                 shots = shot_val.shots
                 if shots != 1:
                     shape.extend((shots, len(mps)) for _ in range(shot_val.copies))
@@ -946,7 +944,7 @@ class QuantumScript:
         if len(shapes) == 1:
             return shapes[0]
 
-        if device.shot_vector is not None:
+        if self.shot_vector is not None:
             # put the shot vector axis before the measurement axis
             shapes = tuple(zip(*shapes))
 
@@ -1040,7 +1038,9 @@ class QuantumScript:
             _ops = self._ops.copy()
             _measurements = self._measurements.copy()
 
-        new_qscript = self.__class__(ops=_ops, measurements=_measurements, prep=_prep)
+        new_qscript = self.__class__(
+            ops=_ops, measurements=_measurements, prep=_prep, shots=self.raw_shots
+        )
         new_qscript._graph = None if copy_operations else self._graph
         new_qscript._specs = None
         new_qscript.wires = copy.copy(self.wires)

--- a/pennylane/tape/tape.py
+++ b/pennylane/tape/tape.py
@@ -57,7 +57,7 @@ def get_active_tape():
 
 
 # TODO: move this function to its own file and rename
-def expand_tape(qscript, depth=1, stop_at=None, expand_measurements=False):
+def expand_tape(qscript: QuantumScript, depth=1, stop_at=None, expand_measurements=False):
     """Expand all objects in a tape to a specific depth.
 
     Args:
@@ -193,7 +193,9 @@ def expand_tape(qscript, depth=1, stop_at=None, expand_measurements=False):
 
     # preserves inheritance structure
     # if qscript is a QuantumTape, returned object will be a quantum tape
-    new_qscript = qscript.__class__(new_ops, new_measurements, new_prep, _update=False)
+    new_qscript = qscript.__class__(
+        new_ops, new_measurements, new_prep, shots=qscript.raw_shots, _update=False
+    )
 
     # Update circuit info
     new_qscript.wires = copy.copy(qscript.wires)

--- a/pennylane/transforms/adjoint_metric_tensor.py
+++ b/pennylane/transforms/adjoint_metric_tensor.py
@@ -16,9 +16,12 @@ Contains the adjoint_metric_tensor.
 """
 import warnings
 from itertools import chain
+from typing import Union
 
 import pennylane as qml
+from pennylane import Device
 from pennylane import numpy as np
+from pennylane.qnode import QNode
 from pennylane.tape import QuantumTape
 
 # pylint: disable=protected-access
@@ -81,7 +84,9 @@ def _group_operations(tape):
     return trainable_operations, group_after_trainable_op
 
 
-def adjoint_metric_tensor(circuit, device=None, hybrid=True):
+def adjoint_metric_tensor(
+    circuit: Union[QNode, QuantumTape], device: Union[None, Device] = None, hybrid=True
+):
     r"""Implements the adjoint method outlined in
     `Jones <https://arxiv.org/abs/2011.02991>`__ to compute the metric tensor.
 
@@ -157,6 +162,8 @@ def adjoint_metric_tensor(circuit, device=None, hybrid=True):
     The drawback of the adjoint method is that it is only available on simulators and without
     shot simulations.
     """
+    if circuit.shots is None and device is not None and device.shots is not None:
+        circuit.shots = device.raw_shots
     if isinstance(circuit, qml.tape.QuantumTape):
         return _adjoint_metric_tensor_tape(circuit, device)
     if isinstance(circuit, (qml.QNode, qml.ExpvalCost)):

--- a/pennylane/transforms/adjoint_metric_tensor.py
+++ b/pennylane/transforms/adjoint_metric_tensor.py
@@ -16,9 +16,10 @@ Contains the adjoint_metric_tensor.
 """
 import warnings
 from itertools import chain
-from pennylane import numpy as np
 
 import pennylane as qml
+from pennylane import numpy as np
+from pennylane.tape import QuantumTape
 
 # pylint: disable=protected-access
 from pennylane.transforms.metric_tensor import _contract_metric_tensor_with_cjac
@@ -164,10 +165,10 @@ def adjoint_metric_tensor(circuit, device=None, hybrid=True):
     raise qml.QuantumFunctionError("The passed object is not a QuantumTape or QNode.")
 
 
-def _adjoint_metric_tensor_tape(tape, device):
+def _adjoint_metric_tensor_tape(tape: QuantumTape, device):
     """Computes the metric tensor of a tape using the adjoint method and a given device."""
     # pylint: disable=protected-access
-    if device.shots is not None:
+    if tape.shots is not None:
         raise ValueError(
             "The adjoint method for the metric tensor is only implemented for shots=None"
         )

--- a/pennylane/transforms/adjoint_metric_tensor.py
+++ b/pennylane/transforms/adjoint_metric_tensor.py
@@ -162,7 +162,11 @@ def adjoint_metric_tensor(
     The drawback of the adjoint method is that it is only available on simulators and without
     shot simulations.
     """
-    if circuit.shots is None and device is not None and device.shots is not None:
+    if (
+        isinstance(device, qml.Device)
+        and getattr(circuit, "shots", False) is None
+        and device.shots is not None
+    ):
         circuit.shots = device.raw_shots
     if isinstance(circuit, qml.tape.QuantumTape):
         return _adjoint_metric_tensor_tape(circuit, device)

--- a/pennylane/transforms/qcut.py
+++ b/pennylane/transforms/qcut.py
@@ -36,6 +36,7 @@ from pennylane.grouping import string_to_pauli_word
 from pennylane.measurements import Expectation, MeasurementProcess, Sample
 from pennylane.operation import Operation, Operator, Tensor
 from pennylane.ops.qubit.non_parametric_ops import WireCut
+from pennylane.qnode import QNode
 from pennylane.tape import QuantumTape
 from pennylane.wires import Wires
 
@@ -1355,7 +1356,7 @@ def cut_circuit_mc(
 
 
 @cut_circuit_mc.custom_qnode_wrapper
-def qnode_execution_wrapper_mc(self, qnode, targs, tkwargs):
+def qnode_execution_wrapper_mc(self, qnode: QNode, targs, tkwargs):
     """Here, we overwrite the QNode execution wrapper in order
     to replace execution variables"""
 
@@ -1378,7 +1379,7 @@ def qnode_execution_wrapper_mc(self, qnode, targs, tkwargs):
             )
 
         shots = kwargs.pop("shots", False)
-        shots = shots or qnode.device.shots
+        shots = shots or qnode.shots
 
         if shots is None:
             raise ValueError(

--- a/pennylane/vqe/vqe.py
+++ b/pennylane/vqe/vqe.py
@@ -189,8 +189,7 @@ class ExpvalCost:
                 raise ValueError("Using multiple devices is not supported when optimize=True")
 
             obs_groupings, coeffs_groupings = qml.grouping.group_observables(observables, coeffs)
-            d = device[0] if self._multiple_devices else device
-            w = d.wires.tolist()
+            w = device.wires.tolist()
 
             @qml.qnode(device, interface=interface, diff_method=diff_method, **kwargs)
             def circuit(*qnode_args, obs, **qnode_kwargs):
@@ -200,8 +199,8 @@ class ExpvalCost:
 
             def cost_fn(*qnode_args, **qnode_kwargs):
                 """Combine results from grouped QNode executions with grouped coefficients"""
-                if device.shot_vector:
-                    shots_batch = sum(i[1] for i in device.shot_vector)
+                if circuit.shot_vector:
+                    shots_batch = sum(i[1] for i in circuit.shot_vector)
 
                     total = [0] * shots_batch
 

--- a/tests/interfaces/test_autograd.py
+++ b/tests/interfaces/test_autograd.py
@@ -25,6 +25,7 @@ from pennylane.devices import DefaultQubit
 from pennylane.gradients import finite_diff, param_shift
 from pennylane.interfaces import execute
 from pennylane.operation import AnyWires, Observable
+from pennylane.tape import QuantumScript
 
 pytestmark = pytest.mark.autograd
 
@@ -949,6 +950,39 @@ class TestOverridingShots:
         res = execute([tape], dev, gradient_fn=param_shift)
         assert np.allclose(res, -np.cos(a) * np.sin(b), atol=tol, rtol=0)
         spy.assert_not_called()
+
+    def test_overriding_shots_with_same_value(self, mocker):
+        """Overriding shots with the same value as the device will have no effect"""
+        dev = qml.device("default.qubit", wires=2, shots=123)
+        a, b = np.array([0.543, -0.654], requires_grad=True)
+
+        with qml.tape.QuantumTape() as tape:
+            qml.RY(a, wires=0)
+            qml.RX(b, wires=1)
+            qml.CNOT(wires=[0, 1])
+            qml.expval(qml.PauliY(1))
+
+        spy = mocker.Mock(wraps=QuantumScript.shots.fset)
+        mock_property = QuantumScript.shots.setter(spy)
+        mocker.patch.object(QuantumScript, "shots", mock_property)
+
+        res = execute([tape], dev, gradient_fn=param_shift, override_shots=123)
+        # overriden shots is the same, no change
+        spy.assert_called()
+
+        res = execute([tape], dev, gradient_fn=param_shift, override_shots=100)
+        # overriden shots is not the same, shots were changed
+        spy.assert_called()
+
+        assert len(spy.call_args_list) == 4
+        # initial tape shots (None) are copied into new tape
+        assert spy.call_args_list[0][0][1] is None
+        # shots are overriden
+        assert spy.call_args_list[1][0][1] == 123
+        # initial tape shots (None) are copied into new tape
+        assert spy.call_args_list[2][0][1] is None
+        # shots are overriden
+        assert spy.call_args_list[3][0][1] == 100
 
     def test_overriding_device_with_shot_vector(self):
         """Overriding a device that has a batch of shots set

--- a/tests/optimize/test_optimize_shot_adapative.py
+++ b/tests/optimize/test_optimize_shot_adapative.py
@@ -14,7 +14,6 @@
 """Tests for the shot adaptive optimizer"""
 import pytest
 from flaky import flaky
-from scipy.stats import multinomial
 
 import pennylane as qml
 from pennylane import numpy as np

--- a/tests/optimize/test_optimize_shot_adapative.py
+++ b/tests/optimize/test_optimize_shot_adapative.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 """Tests for the shot adaptive optimizer"""
 import pytest
-from scipy.stats import multinomial
 from flaky import flaky
+from scipy.stats import multinomial
 
 import pennylane as qml
 from pennylane import numpy as np
@@ -104,7 +104,7 @@ class TestExceptions:
             opt.step(cost, np.array(0.5, requires_grad=True))
 
         # defining the device attribute allows it to proceed
-        cost.device = circuit.device
+        cost.qnode = circuit
         new_x = opt.step(cost, np.array(0.5, requires_grad=True))
 
         assert isinstance(new_x, np.tensor)

--- a/tests/returntypes/test_adjoint_diff_new.py
+++ b/tests/returntypes/test_adjoint_diff_new.py
@@ -43,7 +43,7 @@ class TestAdjointJacobian:
 
         dev = qml.device("default.qubit", wires=1, shots=10)
 
-        with qml.tape.QuantumTape() as tape:
+        with qml.tape.QuantumTape(shots=10) as tape:
             qml.expval(qml.PauliZ(0))
 
         with pytest.warns(

--- a/tests/returntypes/test_adjoint_diff_new.py
+++ b/tests/returntypes/test_adjoint_diff_new.py
@@ -43,7 +43,7 @@ class TestAdjointJacobian:
 
         dev = qml.device("default.qubit", wires=1, shots=10)
 
-        with qml.tape.QuantumTape(shots=10) as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.expval(qml.PauliZ(0))
 
         with pytest.warns(

--- a/tests/tape/test_tape.py
+++ b/tests/tape/test_tape.py
@@ -1364,7 +1364,7 @@ class TestExecution:
         x = 0.543
         y = -0.654
 
-        with QuantumTape() as tape:
+        with QuantumTape(shots=10) as tape:
             qml.RX(x, wires=[0])
             qml.RY(y, wires=[1])
             qml.CNOT(wires=[0, 1])
@@ -1380,7 +1380,7 @@ class TestExecution:
         x = 0.543
         y = -0.654
 
-        with QuantumTape() as tape:
+        with QuantumTape(shots=10) as tape:
             qml.RX(x, wires=[0])
             qml.RY(y, wires=[1])
             qml.CNOT(wires=[0, 1])
@@ -1397,7 +1397,7 @@ class TestExecution:
         x = 0.543
         y = -0.654
 
-        with QuantumTape() as tape:
+        with QuantumTape(shots=10) as tape:
             qml.RX(x, wires=[0])
             qml.RY(y, wires=[1])
             qml.CNOT(wires=[0, 1])
@@ -1967,7 +1967,7 @@ class TestOutputShape:
         a = np.array(0.1)
         b = np.array(0.2)
 
-        with qml.tape.QuantumTape() as tape:
+        with qml.tape.QuantumTape(shots=shots) as tape:
             qml.RY(a, wires=0)
             qml.RX(b, wires=0)
             qml.apply(measurement)
@@ -2010,7 +2010,7 @@ class TestOutputShape:
         a = np.array(0.1)
         b = np.array(0.2)
 
-        with qml.tape.QuantumTape() as tape:
+        with qml.tape.QuantumTape(shots=shots) as tape:
             qml.RY(a, wires=0)
             qml.RX(b, wires=0)
             qml.apply(measurement)
@@ -2089,7 +2089,7 @@ class TestOutputShape:
         a = np.array(0.1)
         b = np.array(0.2)
 
-        with qml.tape.QuantumTape() as tape:
+        with qml.tape.QuantumTape(shots=shots) as tape:
             qml.RY(a, wires=0)
             qml.RX(b, wires=0)
             for m in measurements:
@@ -2125,7 +2125,7 @@ class TestOutputShape:
         a = np.array(0.1)
         b = np.array(0.2)
 
-        with qml.tape.QuantumTape() as tape:
+        with qml.tape.QuantumTape(shots=shots) as tape:
             qml.RY(a, wires=0)
             qml.RX(b, wires=0)
             for m in measurements:
@@ -2155,7 +2155,7 @@ class TestOutputShape:
         b = np.array(0.2)
 
         num_samples = 3
-        with qml.tape.QuantumTape() as tape:
+        with qml.tape.QuantumTape(shots=shots) as tape:
             qml.RY(a, wires=0)
             qml.RX(b, wires=0)
             for i in range(num_samples):
@@ -2181,7 +2181,7 @@ class TestOutputShape:
         b = np.array(0.2)
 
         num_samples = 3
-        with qml.tape.QuantumTape() as tape:
+        with qml.tape.QuantumTape(shots=shots) as tape:
             qml.RY(a, wires=0)
             qml.RX(b, wires=0)
             for i in range(num_samples):
@@ -2206,7 +2206,7 @@ class TestOutputShape:
         using a device with a shot vector."""
         dev = qml.device("default.qubit", wires=3, shots=(1, 2, 3))
 
-        with qml.tape.QuantumTape() as tape:
+        with qml.tape.QuantumTape(shots=(1, 2, 3)) as tape:
             qml.probs(wires=[0])
             qml.probs(wires=[1, 2])
 
@@ -2249,7 +2249,7 @@ class TestOutputShape:
         along with a device with a shot vector raises an error."""
         dev = qml.device("default.qubit", wires=3, shots=(1, 2, 3))
 
-        with qml.tape.QuantumTape() as tape:
+        with qml.tape.QuantumTape(shots=(1, 2, 3)) as tape:
             qml.RY(0.3, wires=0)
             qml.RX(0.2, wires=0)
             qml.sample()
@@ -2265,7 +2265,7 @@ class TestOutputShape:
         along with a device with a shot vector raises an error."""
         dev = qml.device("default.qubit", wires=3, shots=(1, 2, 3))
 
-        with qml.tape.QuantumTape() as tape:
+        with qml.tape.QuantumTape(shots=(1, 2, 3)) as tape:
             qml.RY(0.3, wires=0)
             qml.RX(0.2, wires=0)
             qml.sample()

--- a/tests/tape/test_tape.py
+++ b/tests/tape/test_tape.py
@@ -1364,7 +1364,7 @@ class TestExecution:
         x = 0.543
         y = -0.654
 
-        with QuantumTape(shots=10) as tape:
+        with QuantumTape() as tape:
             qml.RX(x, wires=[0])
             qml.RY(y, wires=[1])
             qml.CNOT(wires=[0, 1])
@@ -1380,7 +1380,7 @@ class TestExecution:
         x = 0.543
         y = -0.654
 
-        with QuantumTape(shots=10) as tape:
+        with QuantumTape() as tape:
             qml.RX(x, wires=[0])
             qml.RY(y, wires=[1])
             qml.CNOT(wires=[0, 1])
@@ -1397,7 +1397,7 @@ class TestExecution:
         x = 0.543
         y = -0.654
 
-        with QuantumTape(shots=10) as tape:
+        with QuantumTape() as tape:
             qml.RX(x, wires=[0])
             qml.RY(y, wires=[1])
             qml.CNOT(wires=[0, 1])
@@ -1967,7 +1967,7 @@ class TestOutputShape:
         a = np.array(0.1)
         b = np.array(0.2)
 
-        with qml.tape.QuantumTape(shots=shots) as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RY(a, wires=0)
             qml.RX(b, wires=0)
             qml.apply(measurement)
@@ -2010,7 +2010,7 @@ class TestOutputShape:
         a = np.array(0.1)
         b = np.array(0.2)
 
-        with qml.tape.QuantumTape(shots=shots) as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RY(a, wires=0)
             qml.RX(b, wires=0)
             qml.apply(measurement)
@@ -2089,7 +2089,7 @@ class TestOutputShape:
         a = np.array(0.1)
         b = np.array(0.2)
 
-        with qml.tape.QuantumTape(shots=shots) as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RY(a, wires=0)
             qml.RX(b, wires=0)
             for m in measurements:
@@ -2125,7 +2125,7 @@ class TestOutputShape:
         a = np.array(0.1)
         b = np.array(0.2)
 
-        with qml.tape.QuantumTape(shots=shots) as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RY(a, wires=0)
             qml.RX(b, wires=0)
             for m in measurements:
@@ -2155,7 +2155,7 @@ class TestOutputShape:
         b = np.array(0.2)
 
         num_samples = 3
-        with qml.tape.QuantumTape(shots=shots) as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RY(a, wires=0)
             qml.RX(b, wires=0)
             for i in range(num_samples):
@@ -2181,7 +2181,7 @@ class TestOutputShape:
         b = np.array(0.2)
 
         num_samples = 3
-        with qml.tape.QuantumTape(shots=shots) as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RY(a, wires=0)
             qml.RX(b, wires=0)
             for i in range(num_samples):
@@ -2206,7 +2206,7 @@ class TestOutputShape:
         using a device with a shot vector."""
         dev = qml.device("default.qubit", wires=3, shots=(1, 2, 3))
 
-        with qml.tape.QuantumTape(shots=(1, 2, 3)) as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.probs(wires=[0])
             qml.probs(wires=[1, 2])
 
@@ -2249,7 +2249,7 @@ class TestOutputShape:
         along with a device with a shot vector raises an error."""
         dev = qml.device("default.qubit", wires=3, shots=(1, 2, 3))
 
-        with qml.tape.QuantumTape(shots=(1, 2, 3)) as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RY(0.3, wires=0)
             qml.RX(0.2, wires=0)
             qml.sample()
@@ -2265,7 +2265,7 @@ class TestOutputShape:
         along with a device with a shot vector raises an error."""
         dev = qml.device("default.qubit", wires=3, shots=(1, 2, 3))
 
-        with qml.tape.QuantumTape(shots=(1, 2, 3)) as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RY(0.3, wires=0)
             qml.RX(0.2, wires=0)
             qml.sample()

--- a/tests/test_debugging.py
+++ b/tests/test_debugging.py
@@ -14,8 +14,9 @@
 """
 Unit tests for the debugging module.
 """
-import pytest
 import numpy as np
+import pytest
+
 import pennylane as qml
 
 
@@ -189,16 +190,18 @@ class TestSnapshot:
 
         assert result == expected
 
-    @pytest.mark.parametrize("shots", [None, 0, 1, 100])
+    @pytest.mark.parametrize("shots", [None, 1, 100])
     def test_different_shots(self, shots):
         """Test that snapshots are returned correctly with different QNode shot values."""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit", wires=2, shots=shots)
 
         @qml.qnode(dev, shots=shots)
         def circuit():
             qml.Snapshot()
             qml.Hadamard(wires=0)
             qml.Snapshot("very_important_state")
+            qml.CNOT(wires=[0, 1])
+            qml.Snapshot()
             qml.CNOT(wires=[0, 1])
             qml.Snapshot()
             return qml.expval(qml.PauliX(0))
@@ -208,7 +211,8 @@ class TestSnapshot:
             0: np.array([1, 0, 0, 0]),
             "very_important_state": np.array([1 / np.sqrt(2), 0, 1 / np.sqrt(2), 0]),
             2: np.array([1 / np.sqrt(2), 0, 0, 1 / np.sqrt(2)]),
-            "execution_results": np.array(0),
+            3: np.array([1 / np.sqrt(2), 0, 1 / np.sqrt(2), 0]),
+            "execution_results": np.array(1),
         }
 
         assert all(k1 == k2 for k1, k2 in zip(result.keys(), expected.keys()))

--- a/tests/test_qubit_device.py
+++ b/tests/test_qubit_device.py
@@ -14,18 +14,18 @@
 """
 Unit tests for the :mod:`pennylane` :class:`QubitDevice` class.
 """
-import pytest
-import numpy as np
 from random import random
 
+import numpy as np
+import pytest
+
 import pennylane as qml
+from pennylane import DeviceError, QuantumFunctionError, QubitDevice
 from pennylane import numpy as pnp
-from pennylane import QubitDevice, DeviceError, QuantumFunctionError
-from pennylane.measurements import Sample, Variance, Expectation, Probability, State
 from pennylane.circuit_graph import CircuitGraph
-from pennylane.wires import Wires
+from pennylane.measurements import Expectation, Probability, Sample, State, Variance, state
 from pennylane.tape import QuantumTape
-from pennylane.measurements import state
+from pennylane.wires import Wires
 
 mock_qubit_device_paulis = ["PauliX", "PauliY", "PauliZ"]
 mock_qubit_device_rotations = ["RX", "RY", "RZ"]
@@ -314,11 +314,12 @@ class TestExtractStatistics:
             num_wires = 1
             return_type = returntype
 
-        obs = SomeObservable(wires=0)
+        with QuantumTape() as tape:
+            return SomeObservable(wires=0)
 
         with monkeypatch.context() as m:
             dev = mock_qubit_device_extract_stats()
-            results = dev.statistics([obs])
+            results = dev.statistics(tape)
 
         assert results == [0]
 
@@ -328,10 +329,14 @@ class TestExtractStatistics:
         with monkeypatch.context():
             dev = mock_qubit_device_extract_stats()
             delattr(dev.__class__, "state")
+
+            with QuantumTape() as tape:
+                return state()
+
             with pytest.raises(
                 qml.QuantumFunctionError, match="The state is not available in the current"
             ):
-                dev.statistics([state()])
+                dev.statistics(tape)
 
     @pytest.mark.parametrize("returntype", [None])
     def test_results_created_empty(self, mock_qubit_device_extract_stats, monkeypatch, returntype):
@@ -341,11 +346,12 @@ class TestExtractStatistics:
             num_wires = 1
             return_type = returntype
 
-        obs = SomeObservable(wires=0)
+        with QuantumTape() as tape:
+            return SomeObservable(wires=0)
 
         with monkeypatch.context() as m:
             dev = mock_qubit_device_extract_stats()
-            results = dev.statistics([obs])
+            results = dev.statistics(tape)
 
         assert results == []
 
@@ -359,11 +365,12 @@ class TestExtractStatistics:
             num_wires = 1
             return_type = returntype
 
-        obs = SomeObservable(wires=0)
+        with QuantumTape() as tape:
+            return SomeObservable(wires=0)
 
         with pytest.raises(qml.QuantumFunctionError, match="Unsupported return type"):
             dev = mock_qubit_device_extract_stats()
-            dev.statistics([obs])
+            dev.statistics(tape)
 
 
 class TestGenerateSamples:

--- a/tests/test_qubit_device_adjoint_jacobian.py
+++ b/tests/test_qubit_device_adjoint_jacobian.py
@@ -17,8 +17,9 @@ Tests for the ``adjoint_jacobian`` method of the :mod:`pennylane` :class:`QubitD
 import pytest
 
 import pennylane as qml
+from pennylane import QNode
 from pennylane import numpy as np
-from pennylane import QNode, qnode
+from pennylane import qnode
 
 
 class TestAdjointJacobian:
@@ -44,7 +45,7 @@ class TestAdjointJacobian:
 
         dev = qml.device("default.qubit", wires=1, shots=1)
 
-        with qml.tape.QuantumTape() as tape:
+        with qml.tape.QuantumTape(shots=1) as tape:
             qml.expval(qml.PauliZ(0))
 
         with pytest.warns(
@@ -366,7 +367,9 @@ class TestAdjointJacobianQNode:
         """Tests that the correct gradient is computed for qnodes which
         use the same parameter in multiple gates."""
 
-        from gate_data import Rotx as Rx, Roty as Ry, Rotz as Rz
+        from gate_data import Rotx as Rx
+        from gate_data import Roty as Ry
+        from gate_data import Rotz as Rz
 
         def expZ(state):
             return np.abs(state[0]) ** 2 - np.abs(state[1]) ** 2

--- a/tests/test_qubit_device_adjoint_jacobian.py
+++ b/tests/test_qubit_device_adjoint_jacobian.py
@@ -45,7 +45,7 @@ class TestAdjointJacobian:
 
         dev = qml.device("default.qubit", wires=1, shots=1)
 
-        with qml.tape.QuantumTape(shots=1) as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.expval(qml.PauliZ(0))
 
         with pytest.warns(

--- a/tests/test_qutrit_device.py
+++ b/tests/test_qutrit_device.py
@@ -14,20 +14,20 @@
 """
 Unit tests for the :mod:`pennylane` :class:`QutritDevice` class.
 """
-import pytest
-import numpy as np
 from random import random
+
+import numpy as np
+import pytest
 from scipy.stats import unitary_group
 
 import pennylane as qml
+from pennylane import DeviceError, QuantumFunctionError, QubitDevice, QutritDevice
 from pennylane import numpy as pnp
-from pennylane import QutritDevice, DeviceError, QuantumFunctionError, QubitDevice
-from pennylane.devices import DefaultQubit
-from pennylane.measurements import Sample, Variance, Expectation, Probability, State, Counts
 from pennylane.circuit_graph import CircuitGraph
-from pennylane.wires import Wires
+from pennylane.devices import DefaultQubit
+from pennylane.measurements import Counts, Expectation, Probability, Sample, State, Variance, state
 from pennylane.tape import QuantumTape
-from pennylane.measurements import state
+from pennylane.wires import Wires
 
 
 @pytest.fixture(scope="function")
@@ -295,11 +295,12 @@ class TestExtractStatistics:
             num_wires = 1
             return_type = returntype
 
-        obs = SomeObservable(wires=0)
+        with QuantumTape() as tape:
+            return SomeObservable(wires=0)
 
         with monkeypatch.context() as m:
             dev = mock_qutrit_device_extract_stats()
-            results = dev.statistics([obs])
+            results = dev.statistics(tape)
 
         assert results == [0]
 
@@ -309,10 +310,12 @@ class TestExtractStatistics:
         with monkeypatch.context() as m:
             dev = mock_qutrit_device()
             m.delattr(QubitDevice, "state")
+            with QuantumTape() as tape:
+                return qml.state()
             with pytest.raises(
                 qml.QuantumFunctionError, match="The state is not available in the current"
             ):
-                dev.statistics([qml.state()])
+                dev.statistics(tape)
 
     @pytest.mark.parametrize("returntype", [None])
     def test_results_created_empty(self, mock_qutrit_device_extract_stats, monkeypatch, returntype):
@@ -322,11 +325,12 @@ class TestExtractStatistics:
             num_wires = 1
             return_type = returntype
 
-        obs = SomeObservable(wires=0)
+        with QuantumTape() as tape:
+            return SomeObservable(wires=0)
 
         with monkeypatch.context() as m:
             dev = mock_qutrit_device_extract_stats()
-            results = dev.statistics([obs])
+            results = dev.statistics(tape)
 
         assert results == []
 
@@ -342,11 +346,12 @@ class TestExtractStatistics:
             num_wires = 1
             return_type = returntype
 
-        obs = SomeObservable(wires=0)
+        with QuantumTape() as tape:
+            return SomeObservable(wires=0)
 
         dev = mock_qutrit_device_extract_stats()
         with pytest.raises(qml.QuantumFunctionError, match="Unsupported return type"):
-            dev.statistics([obs])
+            dev.statistics(tape)
 
     def test_return_state_with_multiple_observables(self, mock_qutrit_device_extract_stats):
         """Checks that an error is raised if multiple observables are being returned


### PR DESCRIPTION
Use `tape.shots`, `tape.shot_vector` instead of `device.shots`, `device.shot_vector`...