### PR TITLE
Change `eigh` to `eig` to support computing the eigenvalues of non-hermitian observables

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -219,6 +219,10 @@ keyword argument when using `GellMann`, which determines which of the 8 Gell-Man
 * Fixed a bug where `qml.QueuingManager.stop_recording` did not clean up if yielded code raises an exception.
   [(#3182)](https://github.com/PennyLaneAI/pennylane/pull/3182)
 
+* Fixed a bug where `op.eigvals()` would return an incorrect result if the operator was a non-hermitian 
+  composite operator.
+  [(#3204)](https://github.com/PennyLaneAI/pennylane/pull/3204)
+
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane/ops/op_math/composite.py
+++ b/pennylane/ops/op_math/composite.py
@@ -155,12 +155,12 @@ class CompositeOp(Operator):
             dict[str, array]: dictionary containing the eigenvalues and the
                 eigenvectors of the operator.
         """
+        eigen_func = np.linalg.eigh if self.is_hermitian else np.linalg.eig
+
         if self.hash not in self._eigs:
-            mat = (
-                self.matrix()
-            )  # we no longer check for hermiticity and allow "anything" on simulator
+            mat = self.matrix()
             mat = math.to_numpy(mat)
-            w, U = np.linalg.eig(mat)
+            w, U = eigen_func(mat)
             self._eigs[self.hash] = {"eigvec": U, "eigval": w}
 
         return self._eigs[self.hash]

--- a/pennylane/ops/op_math/composite.py
+++ b/pennylane/ops/op_math/composite.py
@@ -156,9 +156,9 @@ class CompositeOp(Operator):
                 eigenvectors of the operator.
         """
         if self.hash not in self._eigs:
-            Hmat = self.matrix()
-            Hmat = math.to_numpy(Hmat)
-            w, U = np.linalg.eigh(Hmat)
+            mat = self.matrix()  # we no longer check for hermiticity and allow "anything" on simulator
+            mat = math.to_numpy(mat)
+            w, U = np.linalg.eig(mat)
             self._eigs[self.hash] = {"eigvec": U, "eigval": w}
 
         return self._eigs[self.hash]

--- a/pennylane/ops/op_math/composite.py
+++ b/pennylane/ops/op_math/composite.py
@@ -156,7 +156,9 @@ class CompositeOp(Operator):
                 eigenvectors of the operator.
         """
         if self.hash not in self._eigs:
-            mat = self.matrix()  # we no longer check for hermiticity and allow "anything" on simulator
+            mat = (
+                self.matrix()
+            )  # we no longer check for hermiticity and allow "anything" on simulator
             mat = math.to_numpy(mat)
             w, U = np.linalg.eig(mat)
             self._eigs[self.hash] = {"eigvec": U, "eigval": w}

--- a/tests/ops/functions/test_eigvals.py
+++ b/tests/ops/functions/test_eigvals.py
@@ -312,6 +312,18 @@ class TestCompositeOperations:
 
         assert np.allclose(mat_eigvals, prod_eigvals)
 
+    def test_composite_eigvals(self):
+        """Test that an arithmetic op with non-hermitian base ops produces the correct eigen-values."""
+        op = qml.prod(qml.PauliX(0), qml.adjoint(qml.PauliY(0)))
+        op_adj = qml.adjoint(op)
+        imag_op = -0.5j * (op - op_adj)
+        op_eigvals = qml.eigvals(imag_op)
+
+        mat_rep = np.array([[1.0, 0.0], [0.0, -1.0]])
+        mat_eigvals = np.linalg.eig(mat_rep)[0]
+
+        assert np.allclose(mat_eigvals, op_eigvals)
+
 
 class TestTemplates:
     """These tests are useful as they test operators that might not have

--- a/tests/ops/functions/test_eigvals.py
+++ b/tests/ops/functions/test_eigvals.py
@@ -287,6 +287,32 @@ class TestMultipleOperations:
         assert np.allclose(res, expected)
 
 
+class TestCompositeOperations:
+    """Composite Operations use math.linalg.eig instead of math.linalg.eigh since the operators
+    may not be hermitian."""
+
+    def test_sum_eigvals(self):
+        """Test that a sum op returns the correct eigvals."""
+        sum_op = qml.op_sum(qml.s_prod(1j, qml.PauliZ(wires=0)), qml.Identity(wires=0))
+        sum_eigvals = qml.eigvals(sum_op)
+
+        mat_rep = np.array([[1 + 1j, 0], [0, 1 - 1j]])
+        mat_eigvals = np.linalg.eig(mat_rep)[0]
+
+        assert np.allclose(mat_eigvals, sum_eigvals)
+
+    def test_prod_eigvals(self):
+        """Test that a prod op returns the correct eigvals."""
+
+        prod_op = qml.prod(qml.s_prod(1j, qml.PauliZ(wires=0)), qml.Identity(wires=1))
+        prod_eigvals = qml.eigvals(prod_op)
+
+        mat_rep = np.array([[1j, 0, 0, 0], [0, 1j, 0, 0], [0, 0, -1j, 0], [0, 0, 0, -1j]])
+        mat_eigvals = np.linalg.eig(mat_rep)[0]
+
+        assert np.allclose(mat_eigvals, prod_eigvals)
+
+
 class TestTemplates:
     """These tests are useful as they test operators that might not have
     matrix forms defined, requiring decomposition."""

--- a/tests/ops/op_math/test_prod.py
+++ b/tests/ops/op_math/test_prod.py
@@ -696,15 +696,15 @@ class TestProperties:
         eig_vals = eig_decomp["eigval"]
 
         true_eigvecs = qnp.tensor(
-            [  # the eigvecs ordered according to eigvals ordered smallest --> largest
-                [0.0, 0.0, 1.0, 0.0],
+            [
                 [1.0, 0.0, 0.0, 0.0],
                 [0.0, 1.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0, 0.0],
                 [0.0, 0.0, 0.0, 1.0],
             ]
         )
 
-        true_eigvals = qnp.tensor([-1.0, -1.0, 1.0, 1.0])
+        true_eigvals = qnp.tensor([1.0, -1.0, -1.0, 1.0])
 
         assert np.allclose(eig_vals, true_eigvals)
         assert np.allclose(eig_vecs, true_eigvecs)

--- a/tests/ops/op_math/test_prod.py
+++ b/tests/ops/op_math/test_prod.py
@@ -697,14 +697,14 @@ class TestProperties:
 
         true_eigvecs = qnp.tensor(
             [
+                [0.0, 0.0, 1.0, 0.0],
                 [1.0, 0.0, 0.0, 0.0],
                 [0.0, 1.0, 0.0, 0.0],
-                [0.0, 0.0, 1.0, 0.0],
                 [0.0, 0.0, 0.0, 1.0],
             ]
         )
 
-        true_eigvals = qnp.tensor([1.0, -1.0, -1.0, 1.0])
+        true_eigvals = qnp.tensor([-1.0, -1.0, 1.0, 1.0])
 
         assert np.allclose(eig_vals, true_eigvals)
         assert np.allclose(eig_vecs, true_eigvecs)

--- a/tests/ops/op_math/test_sum.py
+++ b/tests/ops/op_math/test_sum.py
@@ -497,14 +497,14 @@ class TestProperties:
 
         true_eigvecs = qnp.tensor(
             [
-                [1.0, 0.0, 0.0, 0.0],
-                [0.0, 1.0, 0.0, 0.0],
                 [0.0, 0.0, 1.0, 0.0],
                 [0.0, 0.0, 0.0, 1.0],
+                [1.0, 0.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0, 0.0],
             ]
         )
 
-        true_eigvals = qnp.tensor([2.0, 2.0, 0.0, 0.0])
+        true_eigvals = qnp.tensor([0.0, 0.0, 2.0, 2.0])
 
         assert np.allclose(eig_vals, true_eigvals)
         assert np.allclose(eig_vecs, true_eigvecs)

--- a/tests/ops/op_math/test_sum.py
+++ b/tests/ops/op_math/test_sum.py
@@ -497,14 +497,14 @@ class TestProperties:
 
         true_eigvecs = qnp.tensor(
             [
-                [0.0, 0.0, 1.0, 0.0],
-                [0.0, 0.0, 0.0, 1.0],
                 [1.0, 0.0, 0.0, 0.0],
                 [0.0, 1.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0, 0.0],
+                [0.0, 0.0, 0.0, 1.0],
             ]
         )
 
-        true_eigvals = qnp.tensor([0.0, 0.0, 2.0, 2.0])
+        true_eigvals = qnp.tensor([2.0, 2.0, 0.0, 0.0])
 
         assert np.allclose(eig_vals, true_eigvals)
         assert np.allclose(eig_vecs, true_eigvecs)
@@ -782,7 +782,7 @@ class TestIntegration:
         results = my_circ()
 
         assert len(results) == 20
-        assert (results == 2).all()
+        assert np.allclose(results, qnp.tensor([2.0] * 20, requires_grad=True))
 
     def test_measurement_process_count(self):
         """Test Sum class instance in counts measurement process."""
@@ -797,8 +797,9 @@ class TestIntegration:
         results = my_circ()
 
         assert sum(results.values()) == 20
-        assert 2 in results
-        assert -2 not in results
+        assert np.allclose(
+            2, list(results.keys())[0]
+        )  # rounding errors due to float type of measurement outcome
 
     def test_differentiable_measurement_process(self):
         """Test that the gradient can be computed with a Sum op in the measurement process."""


### PR DESCRIPTION
**Context:**
When working with linear combinations of operations. If the expressions are not fully simplified, then there may be sub-operators which are not hermitian. When asking for the eigenvalues of such operators, the default pipeline assumes hermiticity and will automatically cast to `float` types (losing information about the complex parts). 

We update the pipeline to support complex eigenvalues here. 

**Related Issues:** 
[issue 3198](https://github.com/PennyLaneAI/pennylane/issues/3198)

[sc-28321]