### PR TITLE
Better integrating `QuantumScript`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -92,6 +92,10 @@ keyword argument when using `GellMann`, which determines which of the 8 Gell-Man
   should continue to rely on `QNode`s.
   [(#3097)](https://github.com/PennyLaneAI/pennylane/pull/3097)
 
+* `qml.simplify`, `op_tranform`'s like `qml.matrix`, `batch_transform`, `hamiltonian_expand` and `split_non_commuting` now work with
+  `QuantumScript` as well as `QuantumTape`.
+  [(#3209)](https://github.com/PennyLaneAI/pennylane/pull/3209)
+
 * The UCCSD and kUpCCGSD template are modified to remove a redundant flipping of the initial state.
   [(#3148)](https://github.com/PennyLaneAI/pennylane/pull/3148)
 

--- a/pennylane/transforms/batch_transform.py
+++ b/pennylane/transforms/batch_transform.py
@@ -325,7 +325,7 @@ class batch_transform:
             # dev = some_transform(dev, *transform_args)
             return self._device_wrapper(*targs, **tkwargs)(qnode)
 
-        if isinstance(qnode, qml.tape.QuantumTape):
+        if isinstance(qnode, qml.tape.QuantumScript):
             # Input is a quantum tape.
             # tapes, fn = some_transform(tape, *transform_args)
             return self._tape_wrapper(*targs, **tkwargs)(qnode)
@@ -387,7 +387,7 @@ class batch_transform:
         """Applies the batch tape transform to an input tape.
 
         Args:
-            tape (.QuantumTape): the tape to be transformed
+            tape (.QuantumScript): the tape to be transformed
             *args: positional arguments to pass to the tape transform
             **kwargs: keyword arguments to pass to the tape transform
 
@@ -427,7 +427,7 @@ def map_batch_transform(transform, tapes):
     Args:
         transform (.batch_transform): the batch transform
             to be mapped
-        tapes (Sequence[QuantumTape]): The sequence of tapes the batch
+        tapes (Sequence[QuantumScript]): The sequence of tapes the batch
             transform should be applied to. Each tape in the sequence
             is transformed by the batch transform.
 

--- a/pennylane/transforms/batch_transform.py
+++ b/pennylane/transforms/batch_transform.py
@@ -365,7 +365,7 @@ class batch_transform:
                 if isinstance(qnode, qml.Device):
                     return self._device_wrapper(*targs, **tkwargs)(qnode)
 
-                if isinstance(qnode, qml.tape.QuantumTape):
+                if isinstance(qnode, qml.tape.QuantumScript):
                     return self._tape_wrapper(*targs, **tkwargs)(qnode)
 
                 _wrapper = self.qnode_wrapper(qnode, targs, tkwargs)

--- a/pennylane/transforms/hamiltonian_expand.py
+++ b/pennylane/transforms/hamiltonian_expand.py
@@ -170,7 +170,8 @@ def hamiltonian_expand(tape, group=True):
     # make one tape per observable
     tapes = []
     for o in hamiltonian.ops:
-        new_tape = tape.__class__(tape.operations, [qml.expval(o)])
+        # pylint: disable=protected-access
+        new_tape = tape.__class__(tape._ops, [qml.expval(o)], tape._prep)
         tapes.append(new_tape)
 
     # pylint: disable=function-redefined

--- a/pennylane/transforms/hamiltonian_expand.py
+++ b/pennylane/transforms/hamiltonian_expand.py
@@ -170,11 +170,7 @@ def hamiltonian_expand(tape, group=True):
     # make one tape per observable
     tapes = []
     for o in hamiltonian.ops:
-        with tape.__class__() as new_tape:
-            for op in tape.operations:
-                op.queue()
-            qml.expval(o)
-
+        new_tape = tape.__class__(tape.operations, [qml.expval(o)])
         tapes.append(new_tape)
 
     # pylint: disable=function-redefined

--- a/pennylane/transforms/hamiltonian_expand.py
+++ b/pennylane/transforms/hamiltonian_expand.py
@@ -151,13 +151,7 @@ def hamiltonian_expand(tape, group=True):
         # observables in that grouping
         tapes = []
         for obs in obs_groupings:
-
-            with tape.__class__() as new_tape:
-                for op in tape.operations:
-                    op.queue()
-
-                for o in obs:
-                    qml.expval(o)
+            new_tape = tape.__class__(tape._ops, (qml.expval(o) for o in obs), tape._prep)
 
             new_tape = new_tape.expand(stop_at=lambda obj: True)
             tapes.append(new_tape)

--- a/pennylane/transforms/op_transforms.py
+++ b/pennylane/transforms/op_transforms.py
@@ -209,7 +209,7 @@ class op_transform:
             # is the object we wish to transform
             obj, *targs = targs
 
-        if isinstance(obj, (qml.operation.Operator, qml.tape.QuantumTape)) or callable(obj):
+        if isinstance(obj, (qml.operation.Operator, qml.tape.QuantumScript)) or callable(obj):
             return self._create_wrapper(obj, *targs, **tkwargs)
 
         # Input is not an operator nor a QNode nor a quantum tape nor a qfunc.
@@ -411,7 +411,7 @@ class op_transform:
 
             wrapper = self.fn(obj, *targs, **tkwargs)
 
-        elif isinstance(obj, qml.tape.QuantumTape):
+        elif isinstance(obj, qml.tape.QuantumScript):
             # Input is a quantum tape. Get the quantum tape.
             tape, verified_wire_order = self._make_tape(obj, wire_order)
 
@@ -482,7 +482,7 @@ class op_transform:
             tape = obj.qtape
             wires = obj.device.wires
 
-        elif isinstance(obj, qml.tape.QuantumTape):
+        elif isinstance(obj, qml.tape.QuantumScript):
             # user passed a tape
             tape = obj
             wires = tape.wires

--- a/pennylane/transforms/split_non_commuting.py
+++ b/pennylane/transforms/split_non_commuting.py
@@ -160,12 +160,9 @@ def split_non_commuting(tape):
         # make one tape per commuting group
         tapes = []
         for group in groups:
-            with qml.tape.QuantumTape() as new_tape:
-                for op in tape.operations:
-                    qml.apply(op)
-
-                for type, o in zip(return_types, group):
-                    obs_fn[type](o)
+            new_tape = tape.__class__(
+                tape._ops, (obs_fn[type](o) for type, o in zip(return_types, group)), tape._prep
+            )
 
             tapes.append(new_tape)
 

--- a/tests/ops/functions/test_matrix.py
+++ b/tests/ops/functions/test_matrix.py
@@ -165,6 +165,11 @@ class TestMultipleOperations:
         expected_matrix = I_CNOT @ X_S_H
         assert np.allclose(matrix, expected_matrix)
 
+        qs = qml.tape.QuantumScript(tape.operations)
+        qs_matrix = qml.matrix(tape, wire_order)
+
+        assert np.allclose(qs_matrix, expected_matrix)
+
     def test_multiple_operations_qfunc(self):
         """Check the total matrix for a qfunc containing multiple gates"""
         wire_order = ["a", "b", "c"]
@@ -212,6 +217,10 @@ class TestWithParameterBroadcasting:
         matrix = qml.matrix(tape, wire_order)
         expected_matrix = [I_CNOT @ I_S_H, -1j * I_CNOT @ X_S_H, I_CNOT @ np.kron(RX(0.7), S_H)]
         assert np.allclose(matrix, expected_matrix)
+
+        qs = qml.tape.QuantumScript(tape.operations)
+        qs_matrix = qml.matrix(qs, wire_order)
+        assert np.allclose(qs_matrix, expected_matrix)
 
     def test_multiple_operations_tape_leading_broadcasted_op(self):
         """Check the total matrix for a tape containing multiple gates

--- a/tests/transforms/test_batch_transform.py
+++ b/tests/transforms/test_batch_transform.py
@@ -112,6 +112,10 @@ class TestBatchTransform:
         tapes, fn = my_transform(tape)
         assert fn(5) == 5
 
+        qs = qml.tape.QuantumScript(tape.operations, tape.measurements)
+        tapes, fn = my_transform(qs)
+        assert fn(5) == 5
+
     def test_not_differentiable(self):
         """Test that a non-differentiable transform cannot be differentiated"""
 

--- a/tests/transforms/test_hamiltonian_expand.py
+++ b/tests/transforms/test_hamiltonian_expand.py
@@ -87,12 +87,26 @@ class TestHamiltonianExpand:
 
         assert np.isclose(output, expval)
 
+        qs = qml.tape.QuantumScript(tape.operations, tape.measurements)
+        tapes, fn = qml.transforms.hamiltonian_expand(qs)
+        results = dev.batch_execute(tapes)
+        expval = fn(results)
+
+        assert np.isclose(output, expval)
+
     @pytest.mark.parametrize(("tape", "output"), zip(TAPES, OUTPUTS))
     def test_hamiltonians_no_grouping(self, tape, output):
         """Tests that the hamiltonian_expand transform returns the correct value
         if we switch grouping off"""
 
         tapes, fn = qml.transforms.hamiltonian_expand(tape, group=False)
+        results = dev.batch_execute(tapes)
+        expval = fn(results)
+
+        assert np.isclose(output, expval)
+
+        qs = qml.tape.QuantumScript(tape.operations, tape.measurements)
+        tapes, fn = qml.transforms.hamiltonian_expand(qs, group=False)
         results = dev.batch_execute(tapes)
         expval = fn(results)
 
@@ -114,6 +128,10 @@ class TestHamiltonianExpand:
         tapes, fn = qml.transforms.hamiltonian_expand(tape, group=False)
         assert len(tapes) == 2
 
+        qs = qml.tape.QuantumScript(tape.operations, tape.measurements)
+        tapes, fn = qml.transforms.hamiltonian_expand(qs, group=False)
+        assert len(tapes) == 2
+
     def test_number_of_tapes(self):
         """Tests that the the correct number of tapes is produced"""
 
@@ -129,6 +147,13 @@ class TestHamiltonianExpand:
         assert len(tapes) == 3
 
         tapes, fn = qml.transforms.hamiltonian_expand(tape, group=True)
+        assert len(tapes) == 2
+
+        qs = qml.tape.QuantumScript(tape.operations, tape.measurements)
+        tapes, fn = qml.transforms.hamiltonian_expand(qs, group=False)
+        assert len(tapes) == 3
+
+        tapes, fn = qml.transforms.hamiltonian_expand(qs, group=True)
         assert len(tapes) == 2
 
     def test_hamiltonian_error(self):

--- a/tests/transforms/test_hamiltonian_expand.py
+++ b/tests/transforms/test_hamiltonian_expand.py
@@ -149,7 +149,12 @@ class TestHamiltonianExpand:
         tapes, fn = qml.transforms.hamiltonian_expand(tape, group=True)
         assert len(tapes) == 2
 
-        qs = qml.tape.QuantumScript(tape.operations, tape.measurements)
+    def test_number_of_qscripts(self):
+        """Tests the correct number of quantum scripts are produced."""
+
+        H = qml.Hamiltonian([1.0, 2.0, 3.0], [qml.PauliZ(0), qml.PauliX(1), qml.PauliX(0)])
+        qs = qml.tape.QuantumScript(measurements=[qml.expval(H)])
+
         tapes, fn = qml.transforms.hamiltonian_expand(qs, group=False)
         assert len(tapes) == 3
 

--- a/tests/transforms/test_op_transform.py
+++ b/tests/transforms/test_op_transform.py
@@ -155,6 +155,10 @@ class TestUI:
         # check default wire order
         assert spy.spy_return[1].tolist() == [0, "a"]
 
+        qs = qml.tape.QuantumScript(tape.operations)
+        res_qs = my_transform(qs)
+        assert res_qs == ["RX", "RY"]
+
     def test_multiple_operator_qfunc(self, mocker):
         """Test that a transform can be applied to a quantum function
         with multiple operations as long as it is registered _how_
@@ -528,6 +532,10 @@ class TestWireOrder:
         expected = np.kron(np.eye(2), np.diag([1, -1]))
         assert np.allclose(res, expected)
         assert spy.spy_return[1].tolist() == ["a", 0]
+
+        qs = qml.tape.QuantumScript(tape.operations)
+        res_qs = matrix(qs, wire_order=["a", 0])
+        assert np.allclose(res_qs, expected)
 
     def test_inconsistent_wires_tape(self, mocker):
         """Test that an exception is raised if the wire order and tape wires are inconsistent"""


### PR DESCRIPTION
Now that `QuantumTape` inherits from `QuantumScript`, many locations only really need the parent `QuantumScript` and not the queuing part of the object.

This PR begins by switching `isinstance` checks and changing dispatch behaviour in some transforms.

With this PR, we will now be able to do things like:

```pycon
>>> qs = qml.tape.QuantumScript([qml.S(0), qml.T(0)])
>>> qml.matrix(qs)
array([[ 1.        +0.j        ,  0.        +0.j        ],
       [ 0.        +0.j        , -0.70710678+0.70710678j]])
>>> qs2 = qml.tape.QuantumScript(measurements=[qml.expval(qml.PauliX(0) + qml.PauliY(0))])
>>> scripts, fn = qml.transforms.hamiltonian_expand(qs2)
>>> scripts[0].circuit, scripts[1].circuit
([expval(PauliX(wires=[0]))], [expval(PauliY(wires=[0]))])
```