### PR TITLE
Remove analytic property from `Device` class

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -138,7 +138,7 @@ keyword argument when using `GellMann`, which determines which of the 8 Gell-Man
 * `qml.math.unwrap` no longer creates ragged arrays. Lists remain lists.
   [(#3163)](https://github.com/PennyLaneAI/pennylane/pull/3163)
 
-* New `null.qubit` device. The `null.qubit`performs no operations or memory allocations. 
+* New `null.qubit` device. The `null.qubit`performs no operations or memory allocations.
   [(#2589)](https://github.com/PennyLaneAI/pennylane/pull/2589)
 
 * `ControlledQubitUnitary` now has a `control_values` property.
@@ -195,6 +195,8 @@ keyword argument when using `GellMann`, which determines which of the 8 Gell-Man
 
 * `qml.tape.get_active_tape` is deprecated. Please use `qml.QueuingManager.active_context()` instead.
   [(#3068)](https://github.com/PennyLaneAI/pennylane/pull/3068)
+
+* The deprecated `Device.analytic` property has been removed.
 
 <h3>Documentation</h3>
 

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -25,22 +25,17 @@ from functools import lru_cache
 import numpy as np
 
 import pennylane as qml
-from pennylane.operation import (
-    Operation,
-    Observable,
-    Tensor,
-)
 from pennylane.measurements import (
+    Expectation,
+    MidMeasure,
+    Probability,
     Sample,
+    ShadowExpval,
     State,
     Variance,
-    Expectation,
-    Probability,
-    MidMeasure,
-    ShadowExpval,
 )
-from pennylane.wires import Wires, WireError
-
+from pennylane.operation import Observable, Operation, Tensor
+from pennylane.wires import WireError, Wires
 
 ShotTuple = namedtuple("ShotTuple", ["shots", "copies"])
 """tuple[int, int]: Represents copies of a shot number."""
@@ -123,14 +118,9 @@ class Device(abc.ABC):
     _circuits = {}  #: dict[str->Circuit]: circuit templates associated with this API class
     _asarray = staticmethod(np.asarray)
 
-    def __init__(self, wires=1, shots=1000, *, analytic=None):
+    def __init__(self, wires=1, shots=1000):
 
         self.shots = shots
-
-        if analytic is not None:
-            msg = "The analytic argument has been replaced by shots=None. "
-            msg += "Please use shots=None instead of analytic=True."
-            raise DeviceError(msg)
 
         if not isinstance(wires, Iterable):
             # interpret wires as the number of consecutive wires
@@ -211,13 +201,6 @@ class Device(abc.ABC):
         """Number of circuit evaluations/random samples used to estimate
         expectation values of observables"""
         return self._shots
-
-    @property
-    def analytic(self):
-        """Whether shots is None or not. Kept for backwards compatability."""
-        if self._shots is None:
-            return True
-        return False
 
     @property
     def wires(self):

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -198,10 +198,8 @@ class QubitDevice(Device):
         "Prod",
     }
 
-    def __init__(
-        self, wires=1, shots=None, *, r_dtype=np.float64, c_dtype=np.complex128, analytic=None
-    ):
-        super().__init__(wires=wires, shots=shots, analytic=analytic)
+    def __init__(self, wires=1, shots=None, *, r_dtype=np.float64, c_dtype=np.complex128):
+        super().__init__(wires=wires, shots=shots)
 
         if "float" not in str(r_dtype):
             raise DeviceError("Real datatype must be a floating point type.")
@@ -384,7 +382,7 @@ class QubitDevice(Device):
         )
 
         # compute the required statistics
-        if not self.analytic and self._shot_vector is not None:
+        if self._shot_vector is not None:
             results = self._collect_shotvector_results(circuit, counts_exist)
         else:
             results = self.statistics(circuit.observables, circuit=circuit)

--- a/pennylane/devices/default_gaussian.py
+++ b/pennylane/devices/default_gaussian.py
@@ -21,16 +21,18 @@ It implements the necessary :class:`~pennylane._device.Device` methods as well a
 :mod:`continuous-variable Gaussian operations <pennylane.ops.cv>`, and provides a very simple simulation of a
 Gaussian-based quantum circuit architecture.
 """
+import cmath
+
 # pylint: disable=attribute-defined-outside-init,too-many-arguments
 import math
-import cmath
-import numpy as np
 
+import numpy as np
 from scipy.special import factorial as fac
 
 import pennylane as qml
-from pennylane.ops import Identity
 from pennylane import Device
+from pennylane.ops import Identity
+
 from .._version import __version__
 
 # tolerance for numerical errors
@@ -686,8 +688,8 @@ class DefaultGaussian(Device):
 
     _circuits = {}
 
-    def __init__(self, wires, *, shots=None, hbar=2, analytic=None):
-        super().__init__(wires, shots, analytic=analytic)
+    def __init__(self, wires, *, shots=None, hbar=2):
+        super().__init__(wires, shots)
         self.eng = None
         self.hbar = hbar
         self._debugger = None

--- a/pennylane/devices/default_mixed.py
+++ b/pennylane/devices/default_mixed.py
@@ -34,7 +34,7 @@ from pennylane import (
     Snapshot,
 )
 from pennylane import numpy as np
-from pennylane.measurements import Counts, AllCounts, MutualInfo, Sample, State, VnEntropy
+from pennylane.measurements import AllCounts, Counts, MutualInfo, Sample, State, VnEntropy
 from pennylane.operation import Channel
 from pennylane.ops.qubit.attributes import diagonal_in_z_basis
 from pennylane.wires import Wires
@@ -160,14 +160,7 @@ class DefaultMixed(QubitDevice):
         return res
 
     def __init__(
-        self,
-        wires,
-        *,
-        r_dtype=np.float64,
-        c_dtype=np.complex128,
-        shots=None,
-        analytic=None,
-        readout_prob=None,
+        self, wires, *, r_dtype=np.float64, c_dtype=np.complex128, shots=None, readout_prob=None
     ):
         if isinstance(wires, int) and wires > 23:
             raise ValueError(
@@ -185,7 +178,7 @@ class DefaultMixed(QubitDevice):
                 raise ValueError("The readout error probability should be in the range [0,1].")
 
         # call QubitDevice init
-        super().__init__(wires, shots, r_dtype=r_dtype, c_dtype=c_dtype, analytic=analytic)
+        super().__init__(wires, shots, r_dtype=r_dtype, c_dtype=c_dtype)
         self._debugger = None
 
         # Create the initial state.

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -18,17 +18,18 @@ It implements the necessary :class:`~pennylane._device.Device` methods as well a
 :mod:`qubit operations <pennylane.ops.qubit>`, and provides a very simple pure state
 simulation of a qubit-based quantum circuit architecture.
 """
-import itertools
 import functools
+import itertools
 from string import ascii_letters as ABC
 
 import numpy as np
 from scipy.sparse import csr_matrix
 
 import pennylane as qml
-from pennylane import QubitDevice, DeviceError, QubitStateVector, BasisState, Snapshot
+from pennylane import BasisState, DeviceError, QubitDevice, QubitStateVector, Snapshot
 from pennylane.ops.qubit.attributes import diagonal_in_z_basis
 from pennylane.wires import WireError
+
 from .._version import __version__
 
 ABC_ARRAY = np.array(list(ABC))
@@ -163,10 +164,8 @@ class DefaultQubit(QubitDevice):
         "Exp",
     }
 
-    def __init__(
-        self, wires, *, r_dtype=np.float64, c_dtype=np.complex128, shots=None, analytic=None
-    ):
-        super().__init__(wires, shots, r_dtype=r_dtype, c_dtype=c_dtype, analytic=analytic)
+    def __init__(self, wires, *, r_dtype=np.float64, c_dtype=np.complex128, shots=None):
+        super().__init__(wires, shots, r_dtype=r_dtype, c_dtype=c_dtype)
         self._debugger = None
 
         # Create the initial state. Internally, we store the

--- a/pennylane/devices/default_qubit_autograd.py
+++ b/pennylane/devices/default_qubit_autograd.py
@@ -15,7 +15,6 @@
 reference plugin.
 """
 from pennylane import numpy as np
-
 from pennylane.devices import DefaultQubit
 
 
@@ -62,7 +61,7 @@ class DefaultQubitAutograd(DefaultQubit):
       used as the device backend.
 
     * Only exact expectation values, variances, and probabilities are differentiable.
-      When instantiating the device with ``analytic=False``, differentiating QNode
+      When instantiating the device with ``shots!=None``, differentiating QNode
       outputs will result in an error.
 
     Args:
@@ -109,10 +108,10 @@ class DefaultQubitAutograd(DefaultQubit):
     def _const_mul(constant, array):
         return constant * array
 
-    def __init__(self, wires, *, shots=None, analytic=None):
+    def __init__(self, wires, *, shots=None):
         r_dtype = np.float64
         c_dtype = np.complex128
-        super().__init__(wires, shots=shots, r_dtype=r_dtype, c_dtype=c_dtype, analytic=analytic)
+        super().__init__(wires, shots=shots, r_dtype=r_dtype, c_dtype=c_dtype)
 
         # prevent using special apply methods for these gates due to slowdown in Autograd
         # implementation

--- a/pennylane/devices/default_qubit_jax.py
+++ b/pennylane/devices/default_qubit_jax.py
@@ -20,8 +20,8 @@ import pennylane as qml
 from pennylane.devices import DefaultQubit
 
 try:
-    import jax.numpy as jnp
     import jax
+    import jax.numpy as jnp
     from jax.config import config as jax_config
 
 except ImportError as e:  # pragma: no cover
@@ -155,14 +155,14 @@ class DefaultQubitJax(DefaultQubit):
     _size = staticmethod(jnp.size)
     _ndim = staticmethod(jnp.ndim)
 
-    def __init__(self, wires, *, shots=None, prng_key=None, analytic=None):
+    def __init__(self, wires, *, shots=None, prng_key=None):
         if jax_config.read("jax_enable_x64"):
             c_dtype = jnp.complex128
             r_dtype = jnp.float64
         else:
             c_dtype = jnp.complex64
             r_dtype = jnp.float32
-        super().__init__(wires, r_dtype=r_dtype, c_dtype=c_dtype, shots=shots, analytic=analytic)
+        super().__init__(wires, r_dtype=r_dtype, c_dtype=c_dtype, shots=shots)
 
         # prevent using special apply methods for these gates due to slowdown in jax
         # implementation

--- a/pennylane/devices/default_qubit_tf.py
+++ b/pennylane/devices/default_qubit_tf.py
@@ -15,6 +15,7 @@
 reference plugin.
 """
 import itertools
+
 import numpy as np
 import semantic_version
 
@@ -35,6 +36,7 @@ except ImportError as e:
 
 
 from pennylane.math.single_dispatch import _ndim_tf
+
 from . import DefaultQubit
 from .default_qubit import tolerance
 
@@ -159,11 +161,11 @@ class DefaultQubitTF(DefaultQubit):
 
         return res
 
-    def __init__(self, wires, *, shots=None, analytic=None):
+    def __init__(self, wires, *, shots=None):
         r_dtype = tf.float64
         c_dtype = tf.complex128
 
-        super().__init__(wires, shots=shots, r_dtype=r_dtype, c_dtype=c_dtype, analytic=analytic)
+        super().__init__(wires, shots=shots, r_dtype=r_dtype, c_dtype=c_dtype)
 
         # prevent using special apply method for this gate due to slowdown in TF implementation
         del self._apply_ops["CZ"]

--- a/pennylane/devices/default_qubit_torch.py
+++ b/pennylane/devices/default_qubit_torch.py
@@ -15,6 +15,7 @@
 reference plugin.
 """
 import warnings
+
 import semantic_version
 
 try:
@@ -28,7 +29,9 @@ except ImportError as e:
     raise ImportError("default.qubit.torch device requires Torch>=1.8.1") from e
 
 import numpy as np
+
 from pennylane.ops.qubit.attributes import diagonal_in_z_basis
+
 from . import DefaultQubit
 
 
@@ -154,7 +157,7 @@ class DefaultQubitTorch(DefaultQubit):
     _size = staticmethod(torch.numel)
     _ndim = staticmethod(lambda tensor: tensor.ndim)
 
-    def __init__(self, wires, *, shots=None, analytic=None, torch_device=None):
+    def __init__(self, wires, *, shots=None, torch_device=None):
 
         # Store if the user specified a Torch device. Otherwise the execute
         # method attempts to infer the Torch device from the gate parameters.
@@ -164,7 +167,7 @@ class DefaultQubitTorch(DefaultQubit):
         r_dtype = torch.float64
         c_dtype = torch.complex128
 
-        super().__init__(wires, r_dtype=r_dtype, c_dtype=c_dtype, shots=shots, analytic=analytic)
+        super().__init__(wires, r_dtype=r_dtype, c_dtype=c_dtype, shots=shots)
 
         # Move state to torch device (e.g. CPU, GPU, XLA, ...)
         self._state.requires_grad = True

--- a/pennylane/devices/default_qutrit.py
+++ b/pennylane/devices/default_qutrit.py
@@ -19,12 +19,14 @@ It implements the :class:`~pennylane._device.Device` methods as well as some bui
 simulation of qutrit-based quantum computing.
 """
 import functools
+
 import numpy as np
 
 import pennylane as qml  # pylint: disable=unused-import
 from pennylane import QutritDevice
-from pennylane.wires import WireError
 from pennylane.devices.default_qubit import _get_slice
+from pennylane.wires import WireError
+
 from .._version import __version__
 
 # tolerance for numerical errors
@@ -69,16 +71,8 @@ class DefaultQutrit(QutritDevice):
         "Identity",
     }
 
-    def __init__(
-        self,
-        wires,
-        *,
-        r_dtype=np.float64,
-        c_dtype=np.complex128,
-        shots=None,
-        analytic=None,
-    ):
-        super().__init__(wires, shots, r_dtype=r_dtype, c_dtype=c_dtype, analytic=analytic)
+    def __init__(self, wires, *, r_dtype=np.float64, c_dtype=np.complex128, shots=None):
+        super().__init__(wires, shots, r_dtype=r_dtype, c_dtype=c_dtype)
         self._debugger = None
 
         # Create the initial state. Internally, we store the

--- a/pennylane/devices/null_qubit.py
+++ b/pennylane/devices/null_qubit.py
@@ -16,11 +16,12 @@ The null.qubit device is a no-op device for benchmarking PennyLane's auxiliary f
 """
 from collections import defaultdict
 
-from pennylane.ops.qubit.attributes import diagonal_in_z_basis
-
 from pennylane import QubitDevice
 from pennylane import numpy as np
+from pennylane.ops.qubit.attributes import diagonal_in_z_basis
+
 from .._version import __version__
+
 
 # pylint: disable=unused-argument, no-self-use
 class NullQubit(QubitDevice):
@@ -116,21 +117,12 @@ class NullQubit(QubitDevice):
     }
 
     def __init__(self, wires, *args, **kwargs):
-        defaultKwargs = {
-            "shots": None,
-            "analytic": None,
-            "r_dtype": np.float64,
-            "c_dtype": np.complex128,
-        }
-        kwargs = {**defaultKwargs, **kwargs}
+        defaultKwargs = {"shots": None, "r_dtype": np.float64, "c_dtype": np.complex128}
+        kwargs = defaultKwargs | kwargs
 
         self._operation_calls = defaultdict(int)
         super().__init__(
-            wires,
-            shots=kwargs["shots"],
-            r_dtype=kwargs["r_dtype"],
-            c_dtype=kwargs["c_dtype"],
-            analytic=kwargs["analytic"],
+            wires, shots=kwargs["shots"], r_dtype=kwargs["r_dtype"], c_dtype=kwargs["c_dtype"]
         )
         self._debugger = None
 

--- a/pennylane/devices/null_qubit.py
+++ b/pennylane/devices/null_qubit.py
@@ -118,8 +118,7 @@ class NullQubit(QubitDevice):
 
     def __init__(self, wires, *args, **kwargs):
         defaultKwargs = {"shots": None, "r_dtype": np.float64, "c_dtype": np.complex128}
-        kwargs = defaultKwargs | kwargs
-
+        kwargs = {**defaultKwargs, **kwargs}
         self._operation_calls = defaultdict(int)
         super().__init__(
             wires, shots=kwargs["shots"], r_dtype=kwargs["r_dtype"], c_dtype=kwargs["c_dtype"]

--- a/pennylane/optimize/shot_adaptive.py
+++ b/pennylane/optimize/shot_adaptive.py
@@ -18,7 +18,6 @@ from scipy.stats import multinomial
 import pennylane as qml
 from pennylane import numpy as np
 
-
 from .gradient_descent import GradientDescentOptimizer
 
 
@@ -271,7 +270,7 @@ class ShotAdaptiveOptimizer(GradientDescentOptimizer):
         Raises:
             ValueError: if the device is analytic
         """
-        if dev.analytic:
+        if dev.shots is None:
             raise ValueError(
                 "The Rosalin optimizer can only be used with devices "
                 "that estimate expectation values with a finite number of shots."

--- a/tests/devices/test_default_gaussian.py
+++ b/tests/devices/test_default_gaussian.py
@@ -104,18 +104,6 @@ def gaussian_device_3_wires():
 gaussian_dev = gaussian_device_2_wires  # alias
 
 
-def test_analytic_deprecation():
-    """Tests if the kwarg `analytic` is used and displays error message."""
-    msg = "The analytic argument has been replaced by shots=None. "
-    msg += "Please use shots=None instead of analytic=True."
-
-    with pytest.raises(
-        DeviceError,
-        match=msg,
-    ):
-        qml.device("default.gaussian", wires=1, shots=1, analytic=True)
-
-
 class TestExceptions:
     """Tests that default.gaussian throws the correct error messages"""
 

--- a/tests/devices/test_default_mixed.py
+++ b/tests/devices/test_default_mixed.py
@@ -15,25 +15,25 @@
 Unit tests for the :mod:`pennylane.devices.DefaultMixed` device.
 """
 
+import numpy as np
 import pytest
+
 import pennylane as qml
-from pennylane import QubitStateVector, BasisState, DeviceError
+from pennylane import BasisState, DeviceError, QubitStateVector
 from pennylane.devices import DefaultMixed
 from pennylane.ops import (
-    Identity,
-    PauliZ,
-    CZ,
-    PauliX,
-    Hadamard,
     CNOT,
+    CZ,
     AmplitudeDamping,
     DepolarizingChannel,
-    ResetError,
+    Hadamard,
+    Identity,
     PauliError,
+    PauliX,
+    PauliZ,
+    ResetError,
 )
 from pennylane.wires import Wires
-
-import numpy as np
 
 INV_SQRT2 = 1 / np.sqrt(2)
 
@@ -1137,14 +1137,3 @@ class TestInit:
         """Tests that an error is raised if the device is initialized with more than 23 wires"""
         with pytest.raises(ValueError, match="This device does not currently"):
             qml.device("default.mixed", wires=24)
-
-    def test_analytic_deprecation(self):
-        """Tests if the kwarg `analytic` is used and displays error message."""
-        msg = "The analytic argument has been replaced by shots=None. "
-        msg += "Please use shots=None instead of analytic=True."
-
-        with pytest.raises(
-            DeviceError,
-            match=msg,
-        ):
-            qml.device("default.mixed", wires=1, shots=1, analytic=True)

--- a/tests/devices/test_default_mixed_autograd.py
+++ b/tests/devices/test_default_mixed_autograd.py
@@ -24,19 +24,6 @@ from pennylane import DeviceError
 
 
 @pytest.mark.autograd
-def test_analytic_deprecation():
-    """Tests if the kwarg `analytic` is used and displays error message."""
-    msg = "The analytic argument has been replaced by shots=None. "
-    msg += "Please use shots=None instead of analytic=True."
-
-    with pytest.raises(
-        DeviceError,
-        match=msg,
-    ):
-        qml.device("default.mixed", wires=1, shots=1, analytic=True)
-
-
-@pytest.mark.autograd
 class TestQNodeIntegration:
     """Integration tests for default.mixed.autograd. This test ensures it integrates
     properly with the PennyLane UI, in particular the QNode."""

--- a/tests/devices/test_default_qubit.py
+++ b/tests/devices/test_default_qubit.py
@@ -86,18 +86,6 @@ PHI = np.linspace(0.32, 1, 3)
 VARPHI = np.linspace(0.02, 1, 3)
 
 
-def test_analytic_deprecation():
-    """Tests if the kwarg `analytic` is used and displays error message."""
-    msg = "The analytic argument has been replaced by shots=None. "
-    msg += "Please use shots=None instead of analytic=True."
-
-    with pytest.raises(
-        DeviceError,
-        match=msg,
-    ):
-        qml.device("default.qubit", wires=1, shots=1, analytic=True)
-
-
 def test_dtype_errors():
     """Test that if an incorrect dtype is provided to the device then an error is raised."""
     with pytest.raises(DeviceError, match="Real datatype must be a floating point type."):

--- a/tests/devices/test_default_qubit_autograd.py
+++ b/tests/devices/test_default_qubit_autograd.py
@@ -17,22 +17,9 @@ Integration tests for the ``default.qubit.autograd`` device.
 import pytest
 
 import pennylane as qml
+from pennylane import DeviceError
 from pennylane import numpy as np
 from pennylane.devices.default_qubit_autograd import DefaultQubitAutograd
-from pennylane import DeviceError
-
-
-@pytest.mark.autograd
-def test_analytic_deprecation():
-    """Tests if the kwarg `analytic` is used and displays error message."""
-    msg = "The analytic argument has been replaced by shots=None. "
-    msg += "Please use shots=None instead of analytic=True."
-
-    with pytest.raises(
-        DeviceError,
-        match=msg,
-    ):
-        qml.device("default.qubit.autograd", wires=1, shots=1, analytic=True)
 
 
 @pytest.mark.autograd

--- a/tests/devices/test_default_qubit_jax.py
+++ b/tests/devices/test_default_qubit_jax.py
@@ -24,19 +24,6 @@ from pennylane.devices.default_qubit_jax import DefaultQubitJax
 
 
 @pytest.mark.jax
-def test_analytic_deprecation():
-    """Tests if the kwarg `analytic` is used and displays error message."""
-    msg = "The analytic argument has been replaced by shots=None. "
-    msg += "Please use shots=None instead of analytic=True."
-
-    with pytest.raises(
-        DeviceError,
-        match=msg,
-    ):
-        qml.device("default.qubit.jax", wires=1, shots=1, analytic=True)
-
-
-@pytest.mark.jax
 class TestQNodeIntegration:
     """Integration tests for default.qubit.jax. This test ensures it integrates
     properly with the PennyLane UI, in particular the new QNode."""

--- a/tests/devices/test_default_qubit_tf.py
+++ b/tests/devices/test_default_qubit_tf.py
@@ -140,19 +140,6 @@ def broadcasted_init_state(scope="session"):
 #####################################################
 
 
-@pytest.mark.tf
-def test_analytic_deprecation():
-    """Tests if the kwarg `analytic` is used and displays error message."""
-    msg = "The analytic argument has been replaced by shots=None. "
-    msg += "Please use shots=None instead of analytic=True."
-
-    with pytest.raises(
-        DeviceError,
-        match=msg,
-    ):
-        qml.device("default.qubit.tf", wires=1, shots=1, analytic=True)
-
-
 #####################################################
 # Device-level matrix creation tests
 #####################################################

--- a/tests/devices/test_default_qubit_torch.py
+++ b/tests/devices/test_default_qubit_torch.py
@@ -184,16 +184,6 @@ def device(scope="function"):
 #####################################################
 
 
-@pytest.mark.torch
-def test_analytic_deprecation():
-    """Tests if the kwarg `analytic` is used and displays error message."""
-    msg = "The analytic argument has been replaced by shots=None. "
-    msg += "Please use shots=None instead of analytic=True."
-
-    with pytest.raises(DeviceError, match=msg):
-        qml.device("default.qubit.torch", wires=1, shots=1, analytic=True)
-
-
 #####################################################
 # Helper Method Test
 #####################################################

--- a/tests/devices/test_default_qutrit.py
+++ b/tests/devices/test_default_qutrit.py
@@ -17,13 +17,13 @@ Unit tests for the :mod:`pennylane.plugin.DefaultQutrit` device.
 import math
 
 import pytest
+from gate_data import GELL_MANN, OMEGA, TADD, TCLOCK, TSHIFT, TSWAP
+
 import pennylane as qml
-from pennylane import numpy as np, DeviceError
+from pennylane import DeviceError
+from pennylane import numpy as np
 from pennylane.devices.default_qutrit import DefaultQutrit
-from pennylane.wires import Wires, WireError
-
-from gate_data import OMEGA, TSHIFT, TCLOCK, TSWAP, TADD, GELL_MANN
-
+from pennylane.wires import WireError, Wires
 
 U_thadamard_01 = np.multiply(
     1 / np.sqrt(2),
@@ -35,18 +35,6 @@ U_thadamard_01 = np.multiply(
 U_x_02 = np.array([[0, 0, 1], [0, 1, 0], [1, 0, 0]], dtype=np.complex128)
 
 U_z_12 = np.array([[1, 0, 0], [0, 1, 0], [0, 0, -1]], dtype=np.complex128)
-
-
-def test_analytic_deprecation():
-    """Tests if the kwarg `analytic` is used and displays error message."""
-    msg = "The analytic argument has been replaced by shots=None. "
-    msg += "Please use shots=None instead of analytic=True."
-
-    with pytest.raises(
-        DeviceError,
-        match=msg,
-    ):
-        qml.device("default.qutrit", wires=1, shots=1, analytic=True)
 
 
 def test_dtype_errors():

--- a/tests/devices/test_null_qubit.py
+++ b/tests/devices/test_null_qubit.py
@@ -18,14 +18,14 @@ import cmath
 
 # pylint: disable=protected-access,cell-var-from-loop
 import math
+from collections import defaultdict
 
 import pytest
-import pennylane as qml
-from pennylane import numpy as np, DeviceError
-from pennylane.devices.null_qubit import NullQubit
-from pennylane import Tracker
 
-from collections import defaultdict
+import pennylane as qml
+from pennylane import DeviceError, Tracker
+from pennylane import numpy as np
+from pennylane.devices.null_qubit import NullQubit
 
 
 @pytest.fixture(scope="function", params=[(np.float32, np.complex64), (np.float64, np.complex128)])
@@ -36,18 +36,6 @@ def nullqubit_device(request):
         )
 
     return _device
-
-
-def test_analytic_deprecation():
-    """Tests if the kwarg `analytic` is used and displays error message."""
-    msg = "The analytic argument has been replaced by shots=None. "
-    msg += "Please use shots=None instead of analytic=True."
-
-    with pytest.raises(
-        DeviceError,
-        match=msg,
-    ):
-        qml.device("null.qubit", wires=1, shots=1, analytic=True)
 
 
 def test_dtype_errors():

--- a/tests/gradients/test_finite_difference.py
+++ b/tests/gradients/test_finite_difference.py
@@ -16,12 +16,11 @@ Tests for the gradients.finite_difference module.
 """
 import pytest
 
-from pennylane import numpy as np
-
 import pennylane as qml
-from pennylane.gradients import finite_diff, finite_diff_coeffs, generate_shifted_tapes
+from pennylane import numpy as np
 from pennylane.devices import DefaultQubit
-from pennylane.operation import Observable, AnyWires
+from pennylane.gradients import finite_diff, finite_diff_coeffs, generate_shifted_tapes
+from pennylane.operation import AnyWires, Observable
 
 
 class TestCoeffs:
@@ -399,7 +398,7 @@ class TestFiniteDiff:
                 self.R_DTYPE = SpecialObservable
 
             def expval(self, observable, **kwargs):
-                if self.analytic and isinstance(observable, SpecialObservable):
+                if self.shots is None and isinstance(observable, SpecialObservable):
                     val = super().expval(qml.PauliZ(wires=0), **kwargs)
                     return SpecialObject(val)
 

--- a/tests/gradients/test_parameter_shift.py
+++ b/tests/gradients/test_parameter_shift.py
@@ -12,15 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Tests for the gradients.parameter_shift module."""
-import pytest
 from collections.abc import Sequence
+
+import pytest
 
 import pennylane as qml
 from pennylane import numpy as np
+from pennylane.devices import DefaultQubit
 from pennylane.gradients import param_shift
 from pennylane.gradients.parameter_shift import _get_operation_recipe
-from pennylane.devices import DefaultQubit
-from pennylane.operation import Observable, AnyWires
+from pennylane.operation import AnyWires, Observable
 
 
 class TestGetOperationRecipe:
@@ -1289,7 +1290,7 @@ class TestParameterShiftRule:
                 self.R_DTYPE = SpecialObservable
 
             def expval(self, observable, **kwargs):
-                if self.analytic and isinstance(observable, SpecialObservable):
+                if self.shots is None and isinstance(observable, SpecialObservable):
                     val = super().expval(qml.PauliZ(wires=0), **kwargs)
                     return SpecialObject(val)
 

--- a/tests/interfaces/test_autograd.py
+++ b/tests/interfaces/test_autograd.py
@@ -18,13 +18,13 @@ import sys
 
 import autograd
 import pytest
-from pennylane import numpy as np
-from pennylane.operation import Observable, AnyWires
 
 import pennylane as qml
+from pennylane import numpy as np
 from pennylane.devices import DefaultQubit
 from pennylane.gradients import finite_diff, param_shift
 from pennylane.interfaces import execute
+from pennylane.operation import AnyWires, Observable
 
 pytestmark = pytest.mark.autograd
 
@@ -1243,7 +1243,7 @@ class DeviceSupportingSpecialObservable(DefaultQubit):
         return capabilities
 
     def expval(self, observable, **kwargs):
-        if self.analytic and isinstance(observable, SpecialObservable):
+        if self.shots is None and isinstance(observable, SpecialObservable):
             val = super().expval(qml.PauliZ(wires=0), **kwargs)
             return SpecialObject(val)
 

--- a/tests/returntypes/test_finite_difference_new.py
+++ b/tests/returntypes/test_finite_difference_new.py
@@ -17,16 +17,11 @@ Tests for the gradients.finite_difference module.
 import numpy
 import pytest
 
-from pennylane import numpy as np
-
 import pennylane as qml
-from pennylane.gradients import (
-    finite_diff,
-    finite_diff_coeffs,
-    generate_shifted_tapes,
-)
+from pennylane import numpy as np
 from pennylane.devices import DefaultQubit
-from pennylane.operation import Observable, AnyWires
+from pennylane.gradients import finite_diff, finite_diff_coeffs, generate_shifted_tapes
+from pennylane.operation import AnyWires, Observable
 
 
 class TestCoeffs:
@@ -493,7 +488,7 @@ class TestFiniteDiff:
     #             self.R_DTYPE = SpecialObservable
     #
     #         def expval(self, observable, **kwargs):
-    #             if self.analytic and isinstance(observable, SpecialObservable):
+    #             if self.shots is None and isinstance(observable, SpecialObservable):
     #                 val = super().expval(qml.PauliZ(wires=0), **kwargs)
     #                 return SpecialObject(val)
     #

--- a/tests/returntypes/test_parameter_shift_new.py
+++ b/tests/returntypes/test_parameter_shift_new.py
@@ -16,10 +16,10 @@ import pytest
 
 import pennylane as qml
 from pennylane import numpy as np
+from pennylane.devices import DefaultQubit
 from pennylane.gradients import param_shift
 from pennylane.gradients.parameter_shift import _get_operation_recipe, _put_zeros_in_pdA2_involutory
-from pennylane.devices import DefaultQubit
-from pennylane.operation import Observable, AnyWires
+from pennylane.operation import AnyWires, Observable
 
 
 class TestGetOperationRecipe:
@@ -1953,7 +1953,7 @@ class TestParameterShiftRule:
     #             self.R_DTYPE = SpecialObservable
 
     #         def expval(self, observable, **kwargs):
-    #             if self.analytic and isinstance(observable, SpecialObservable):
+    #             if self.shots is None and isinstance(observable, SpecialObservable):
     #                 val = super().expval(qml.PauliZ(wires=0), **kwargs)
     #                 return SpecialObject(val)
 

--- a/tests/returntypes/test_parameter_shift_shot_vec_new.py
+++ b/tests/returntypes/test_parameter_shift_shot_vec_new.py
@@ -16,11 +16,10 @@ import pytest
 
 import pennylane as qml
 from pennylane import numpy as np
+from pennylane.devices import DefaultQubit
 from pennylane.gradients import param_shift
 from pennylane.gradients.parameter_shift import _get_operation_recipe, _put_zeros_in_pdA2_involutory
-from pennylane.devices import DefaultQubit
-from pennylane.operation import Observable, AnyWires
-
+from pennylane.operation import AnyWires, Observable
 
 shot_vec_tol = 10e-3
 herm_shot_vec_tol = 0.5
@@ -2020,7 +2019,7 @@ class TestParameterShiftRule:
     #             self.R_DTYPE = SpecialObservable
 
     #         def expval(self, observable, **kwargs):
-    #             if self.analytic and isinstance(observable, SpecialObservable):
+    #             if self.shots is None and isinstance(observable, SpecialObservable):
     #                 val = super().expval(qml.PauliZ(wires=0), **kwargs)
     #                 return SpecialObject(val)
 


### PR DESCRIPTION
Remove deprecated `Device.analytic` property.

**Note:** Checked the following plugins to make sure none of them use the `analytic` property/kwarg:
- `pennylane-forest`
- `lightning-qubit`
- `pennylane-qiskit`
- `pennylane-cirq`
- `pennylane-pq`
- `pennylane-ionq`
- `pennylane-qulacs`
- `pennylane-qsharp`
- `pennylane-sf`: Created [PR](https://github.com/PennyLaneAI/pennylane-sf/pull/121) removing usage of `self.analytic` property.
- `pennylane-honeywell`: Created [PR](https://github.com/PennyLaneAI/pennylane-honeywell/pull/34) removing usage of `self.analytic` property.
- `pennylane-orquestra`: Created [PR](https://github.com/PennyLaneAI/pennylane-orquestra/pull/32) removing usage of `self.analytic` property.
- `pennylane-aqt`: Created [PR](https://github.com/PennyLaneAI/pennylane-aqt/pull/39) removing usage of `self.analytic` property.
- `amazon-braket-pennylane-plugin-python`: Created [PR](https://github.com/aws/amazon-braket-pennylane-plugin-python/pull/115) removing usage of `self.analytic` property.