### PR TITLE
Shots #5: Distribute shots over tapes

### DIFF
--- a/pennylane/gradients/finite_difference.py
+++ b/pennylane/gradients/finite_difference.py
@@ -25,13 +25,13 @@ from scipy.special import factorial
 
 import pennylane as qml
 
-from .gradient_transform import (
-    gradient_transform,
-    grad_method_validation,
-    choose_grad_methods,
-    gradient_analysis,
-)
 from .general_shift_rules import generate_shifted_tapes
+from .gradient_transform import (
+    choose_grad_methods,
+    grad_method_validation,
+    gradient_analysis,
+    gradient_transform,
+)
 
 
 @functools.lru_cache(maxsize=None)
@@ -299,7 +299,7 @@ def _finite_diff_new(
             shapes.append(0)
             continue
 
-        g_tapes = generate_shifted_tapes(tape, i, shifts * h)
+        g_tapes = generate_shifted_tapes(tape, coeffs, i, shifts * h)
         gradient_tapes.extend(g_tapes)
         shapes.append(len(g_tapes))
 
@@ -567,7 +567,7 @@ def finite_diff(
             shapes.append(0)
             continue
 
-        g_tapes = generate_shifted_tapes(tape, i, shifts * h)
+        g_tapes = generate_shifted_tapes(tape, coeffs, i, shifts * h)
         gradient_tapes.extend(g_tapes)
         shapes.append(len(g_tapes))
 

--- a/pennylane/gradients/general_shift_rules.py
+++ b/pennylane/gradients/general_shift_rules.py
@@ -417,7 +417,7 @@ def generate_shifted_tapes(
     """
 
     total_shots = tape.shots
-    M = np.sum(np.abs(coeffs))
+    M = qml.math.sum(qml.math.abs(coeffs))
 
     def _copy_and_shift_params(tape: QuantumTape, params, idx, shift, mult, coeff):
         """Create a copy of a tape and of parameters, and set the new tape to the parameters
@@ -429,8 +429,8 @@ def generate_shifted_tapes(
 
         shifted_tape = tape.copy(copy_operations=True)
         if tape.distribute_shots and total_shots is not None:
-            shots = np.floor(total_shots * (np.abs(coeff) / M))
-            shots = [int(shot) for shot in shots] if np.shape(shots) != () else int(shots)
+            shots = qml.math.floor(total_shots * (qml.math.abs(coeff) / M))
+            shots = [int(shot) for shot in shots] if qml.math.shape(shots) != () else int(shots)
             shifted_tape.shots = shots
         shifted_tape.set_parameters(new_params)
         return shifted_tape

--- a/pennylane/gradients/parameter_shift.py
+++ b/pennylane/gradients/parameter_shift.py
@@ -23,8 +23,9 @@ import numpy as np
 
 import pennylane as qml
 from pennylane.measurements import MutualInfo, State, VnEntropy
+from pennylane.tape import QuantumTape
 
-from .finite_difference import finite_diff, _all_zero_grad_new, _no_trainable_grad_new
+from .finite_difference import _all_zero_grad_new, _no_trainable_grad_new, finite_diff
 from .general_shift_rules import (
     _iterate_shift_rule,
     frequencies_to_period,
@@ -169,7 +170,7 @@ def _multi_meas_grad(res, coeffs, r0, unshifted_coeff, num_measurements):
     return tuple(g)
 
 
-def _evaluate_gradient_new(tape, res, data, r0, shots):
+def _evaluate_gradient_new(tape: QuantumTape, res, data, r0, shots):
     """Use shifted tape evaluations and parameter-shift rule coefficients
     to evaluate a gradient result.
 
@@ -256,7 +257,7 @@ def _evaluate_gradient(res, data, broadcast, r0, scalar_qfunc_output):
     return g
 
 
-def _get_operation_recipe(tape, t_idx, shifts, order=1):
+def _get_operation_recipe(tape: QuantumTape, t_idx, shifts, order=1):
     """Utility function to return the parameter-shift rule
     of the operation corresponding to trainable parameter
     t_idx on tape.
@@ -424,7 +425,13 @@ def _reorder_grad_axes_multi_measure(
 
 
 def _expval_param_shift_tuple(
-    tape, argnum=None, shifts=None, gradient_recipes=None, f0=None, broadcast=False, shots=None
+    tape: QuantumTape,
+    argnum=None,
+    shifts=None,
+    gradient_recipes=None,
+    f0=None,
+    broadcast=False,
+    shots=None,
 ):
     r"""Generate the parameter-shift tapes and postprocessing methods required
         to compute the gradient of a gate parameter with respect to an
@@ -499,7 +506,7 @@ def _expval_param_shift_tuple(
         )
         coeffs, multipliers, op_shifts = recipe.T
 
-        g_tapes = generate_shifted_tapes(tape, idx, op_shifts, multipliers, broadcast)
+        g_tapes = generate_shifted_tapes(tape, coeffs, idx, op_shifts, multipliers, broadcast)
         gradient_tapes.extend(g_tapes)
         # If broadcast=True, g_tapes only contains one tape. If broadcast=False, all returned
         # tapes will have the same batch_size=None. Thus we only use g_tapes[0].batch_size here.
@@ -570,7 +577,13 @@ def _expval_param_shift_tuple(
 
 
 def expval_param_shift(
-    tape, argnum=None, shifts=None, gradient_recipes=None, f0=None, broadcast=False, shots=None
+    tape: QuantumTape,
+    argnum=None,
+    shifts=None,
+    gradient_recipes=None,
+    f0=None,
+    broadcast=False,
+    shots=None,
 ):
     r"""Generate the parameter-shift tapes and postprocessing methods required
     to compute the gradient of a gate parameter with respect to an
@@ -659,7 +672,7 @@ def expval_param_shift(
         #
         # Note: this is an issue both with the existing and the new return type system
 
-        g_tapes = generate_shifted_tapes(tape, idx, op_shifts, multipliers, broadcast)
+        g_tapes = generate_shifted_tapes(tape, coeffs, idx, op_shifts, multipliers, broadcast)
         gradient_tapes.extend(g_tapes)
 
         # If broadcast=True, g_tapes only contains one tape. If broadcast=False, all returned
@@ -894,7 +907,13 @@ def _create_variance_proc_fn(
 
 
 def _var_param_shift_tuple(
-    tape, argnum, shifts=None, gradient_recipes=None, f0=None, broadcast=False, shots=None
+    tape: QuantumTape,
+    argnum,
+    shifts=None,
+    gradient_recipes=None,
+    f0=None,
+    broadcast=False,
+    shots=None,
 ):
     r"""Generate the parameter-shift tapes and postprocessing methods required
     to compute the gradient of a gate parameter with respect to a
@@ -1003,7 +1022,13 @@ def _var_param_shift_tuple(
 
 
 def var_param_shift(
-    tape, argnum, shifts=None, gradient_recipes=None, f0=None, broadcast=False, shots=None
+    tape: QuantumTape,
+    argnum,
+    shifts=None,
+    gradient_recipes=None,
+    f0=None,
+    broadcast=False,
+    shots=None,
 ):
     r"""Generate the parameter-shift tapes and postprocessing methods required
     to compute the gradient of a gate parameter with respect to a
@@ -1161,7 +1186,7 @@ def var_param_shift(
 # TODO: docstrings & mention shots arg
 @gradient_transform
 def _param_shift_new(
-    tape,
+    tape: QuantumTape,
     argnum=None,
     shifts=None,
     gradient_recipes=None,
@@ -1510,7 +1535,7 @@ def _param_shift_new(
 
 @gradient_transform
 def param_shift(
-    tape,
+    tape: QuantumTape,
     argnum=None,
     shifts=None,
     gradient_recipes=None,

--- a/pennylane/gradients/parameter_shift_cv.py
+++ b/pennylane/gradients/parameter_shift_cv.py
@@ -24,14 +24,10 @@ import numpy as np
 
 import pennylane as qml
 
-from .gradient_transform import (
-    gradient_transform,
-    grad_method_validation,
-    choose_grad_methods,
-)
 from .finite_difference import finite_diff
-from .parameter_shift import expval_param_shift, _get_operation_recipe
-from .general_shift_rules import process_shifts, generate_shifted_tapes
+from .general_shift_rules import generate_shifted_tapes, process_shifts
+from .gradient_transform import choose_grad_methods, grad_method_validation, gradient_transform
+from .parameter_shift import _get_operation_recipe, expval_param_shift
 
 
 def _grad_method(tape, idx):
@@ -351,7 +347,7 @@ def second_order_param_shift(tape, dev_wires, argnum=None, shifts=None, gradient
                 "gradient recipe of more than two terms."
             )
 
-        shifted_tapes = generate_shifted_tapes(tape, idx, op_shifts, multipliers)
+        shifted_tapes = generate_shifted_tapes(tape, coeffs, idx, op_shifts, multipliers)
 
         # evaluate transformed observables at the original parameter point
         # first build the Heisenberg picture transformation matrix Z

--- a/pennylane/gradients/parameter_shift_hessian.py
+++ b/pennylane/gradients/parameter_shift_hessian.py
@@ -15,24 +15,21 @@
 This module contains functions for computing the parameter-shift hessian
 of a qubit-based quantum tape.
 """
-import warnings
 import itertools as it
+import warnings
 from collections.abc import Sequence
 
 import pennylane as qml
 from pennylane import numpy as np
 
-from .gradient_transform import (
-    gradient_analysis,
-    grad_method_validation,
-)
-from .hessian_transform import hessian_transform
-from .parameter_shift import _get_operation_recipe
 from .general_shift_rules import (
     _combine_shift_rules,
-    generate_shifted_tapes,
     generate_multishifted_tapes,
+    generate_shifted_tapes,
 )
+from .gradient_transform import grad_method_validation, gradient_analysis
+from .hessian_transform import hessian_transform
+from .parameter_shift import _get_operation_recipe
 
 
 def _process_argnum(argnum, tape):
@@ -174,7 +171,7 @@ def _generate_diag_tapes(tape, idx, diag_recipes, add_unshifted, tapes, coeffs):
         unshifted_coeff = None
 
     # Create the shifted tapes for the diagonal entry and store them along with coefficients
-    new_tapes = generate_shifted_tapes(tape, idx, s, m)
+    new_tapes = generate_shifted_tapes(tape, c, idx, s, m)
     tapes.extend(new_tapes)
     coeffs.append(c)
 

--- a/pennylane/qnode.py
+++ b/pennylane/qnode.py
@@ -168,6 +168,7 @@ class QNode:
         cache=True,
         cachesize=10000,
         max_diff=1,
+        distribute_shots=False,
         **gradient_kwargs,
     ):
         if interface not in SUPPORTED_INTERFACES:
@@ -213,7 +214,7 @@ class QNode:
             self.execute_kwargs["expand_fn"] = None
 
         # internal data attributes
-        self._tape = QuantumTape(shots=device.raw_shots)
+        self._tape = QuantumTape(shots=device.raw_shots, distribute_shots=distribute_shots)
         self._qfunc_output = None
         self._user_gradient_kwargs = gradient_kwargs
         self._original_device = device
@@ -566,7 +567,7 @@ class QNode:
     def construct(self, args, kwargs):
         """Call the quantum function with a tape context, ensuring the operations get queued."""
 
-        self._tape = QuantumTape(shots=self.raw_shots)
+        self._tape = QuantumTape(shots=self.raw_shots, distribute_shots=self.tape.distribute_shots)
 
         with self.tape:
             self._qfunc_output = self.func(*args, **kwargs)
@@ -654,7 +655,9 @@ class QNode:
 
                 # pylint: disable=not-callable
                 # update the gradient function
-                self._tape = QuantumTape(shots=override_shots)
+                self._tape = QuantumTape(
+                    shots=override_shots, distribute_shots=self.tape.distribute_shots
+                )
                 self._update_gradient_fn()
 
         # construct the tape

--- a/pennylane/tape/qscript.py
+++ b/pennylane/tape/qscript.py
@@ -213,13 +213,21 @@ class QuantumScript:
     True for its child Quantum Tape."""
 
     def __init__(
-        self, ops=None, measurements=None, prep=None, shots=None, name=None, _update=True
+        self,
+        ops=None,
+        measurements=None,
+        prep=None,
+        shots=None,
+        name=None,
+        _update=True,
+        distribute_shots=False,
     ):  # pylint: disable=too-many-arguments
         self.name = name
         self.shots = shots
         self._prep = [] if prep is None else list(prep)
         self._ops = [] if ops is None else list(ops)
         self._measurements = [] if measurements is None else list(measurements)
+        self.distribute_shots = distribute_shots
 
         self._par_info = {}
         """dict[int, dict[str, Operator or int]]: Parameter information. Keys are

--- a/pennylane/tape/tape.py
+++ b/pennylane/tape/tape.py
@@ -336,10 +336,16 @@ class QuantumTape(QuantumScript, AnnotatedQueue):
         distribute_shots=False,
     ):
         self.do_queue = do_queue
-        self.distribute_shots = distribute_shots
         AnnotatedQueue.__init__(self)
         QuantumScript.__init__(
-            self, ops, measurements, prep, shots=shots, name=name, _update=_update
+            self,
+            ops,
+            measurements,
+            prep,
+            shots=shots,
+            name=name,
+            _update=_update,
+            distribute_shots=distribute_shots,
         )
 
     def __enter__(self):

--- a/pennylane/tape/tape.py
+++ b/pennylane/tape/tape.py
@@ -333,8 +333,10 @@ class QuantumTape(QuantumScript, AnnotatedQueue):
         name=None,
         do_queue=True,
         _update=True,
+        distribute_shots=False,
     ):
         self.do_queue = do_queue
+        self.distribute_shots = distribute_shots
         AnnotatedQueue.__init__(self)
         QuantumScript.__init__(
             self, ops, measurements, prep, shots=shots, name=name, _update=_update

--- a/pennylane/transforms/hamiltonian_expand.py
+++ b/pennylane/transforms/hamiltonian_expand.py
@@ -15,8 +15,6 @@
 Contains the hamiltonian expand tape transform
 """
 # pylint: disable=protected-access
-import numpy as np
-
 import pennylane as qml
 from pennylane.tape import QuantumTape
 
@@ -151,7 +149,8 @@ def hamiltonian_expand(tape: QuantumTape, group=True):
         ]
 
         total_shots = tape.shots
-        M = sum(np.abs(coeff_groupings))
+        if tape.distribute_shots:
+            M = sum(qml.math.abs(coeff_groupings))
 
         # make one tape per grouping, measuring the
         # observables in that grouping
@@ -159,7 +158,7 @@ def hamiltonian_expand(tape: QuantumTape, group=True):
         for obs, coeff in zip(obs_groupings, coeff_groupings):
 
             shots = (
-                int(np.floor(total_shots * np.abs(coeff) / M))
+                int(qml.math.floor(total_shots * qml.math.abs(coeff) / M))
                 if tape.distribute_shots
                 else total_shots
             )

--- a/tests/gradients/test_finite_difference.py
+++ b/tests/gradients/test_finite_difference.py
@@ -16,12 +16,11 @@ Tests for the gradients.finite_difference module.
 """
 import pytest
 
-from pennylane import numpy as np
-
 import pennylane as qml
-from pennylane.gradients import finite_diff, finite_diff_coeffs, generate_shifted_tapes
+from pennylane import numpy as np
 from pennylane.devices import DefaultQubit
-from pennylane.operation import Observable, AnyWires
+from pennylane.gradients import finite_diff, finite_diff_coeffs
+from pennylane.operation import AnyWires, Observable
 
 
 class TestCoeffs:
@@ -138,7 +137,8 @@ class TestFiniteDiff:
         assert len(spy.call_args_list) == 1
 
         # only called for parameter 0
-        assert spy.call_args[0][0:2] == (tape, 0)
+        assert spy.call_args[0][0] == tape
+        assert spy.call_args[0][2] == 0
 
     @pytest.mark.autograd
     def test_no_trainable_params_qnode_autograd(self):

--- a/tests/gradients/test_general_shift_rules.py
+++ b/tests/gradients/test_general_shift_rules.py
@@ -12,20 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Tests for the gradients.general_shift_rules module."""
+import numpy as np
 import pytest
 
-import numpy as np
 import pennylane as qml
-
 from pennylane.gradients.general_shift_rules import (
+    _get_shift_rule,
+    _iterate_shift_rule_with_multipliers,
     eigvals_to_frequencies,
     frequencies_to_period,
-    generate_shift_rule,
-    _get_shift_rule,
     generate_multi_shift_rule,
-    generate_shifted_tapes,
     generate_multishifted_tapes,
-    _iterate_shift_rule_with_multipliers,
+    generate_shift_rule,
+    generate_shifted_tapes,
 )
 
 
@@ -407,7 +406,8 @@ class TestGenerateShiftedTapes:
 
         tape.trainable_params = {0, 2}
         shifts = [0.1, -0.2, 1.6]
-        res = generate_shifted_tapes(tape, 1, shifts)
+        coeffs = [1, 1, 1]
+        res = generate_shifted_tapes(tape, coeffs, 1, shifts)
 
         assert len(res) == len(shifts)
         assert res[0].get_parameters(trainable_only=False) == [1.0, 2.0, 3.1, 4.0]
@@ -427,7 +427,8 @@ class TestGenerateShiftedTapes:
         tape.trainable_params = {0, 2}
         shifts = [0.3, 0.6]
         multipliers = [0.2, 0.5]
-        res = generate_shifted_tapes(tape, 0, shifts, multipliers)
+        coeffs = [1, 1]
+        res = generate_shifted_tapes(tape, coeffs, 0, shifts, multipliers)
 
         assert len(res) == 2
         assert res[0].get_parameters(trainable_only=False) == [0.2 * 1.0 + 0.3, 2.0, 3.0, 4.0]

--- a/tests/gradients/test_parameter_shift.py
+++ b/tests/gradients/test_parameter_shift.py
@@ -12,16 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Tests for the gradients.parameter_shift module."""
-from collections.abc import Sequence
-
 import pytest
+from collections.abc import Sequence
 
 import pennylane as qml
 from pennylane import numpy as np
-from pennylane.devices import DefaultQubit
 from pennylane.gradients import param_shift
 from pennylane.gradients.parameter_shift import _get_operation_recipe
-from pennylane.operation import AnyWires, Observable
+from pennylane.devices import DefaultQubit
+from pennylane.operation import Observable, AnyWires
 
 
 class TestGetOperationRecipe:
@@ -492,7 +491,7 @@ class TestParamShiftBroadcast:
         during the Jacobian computation."""
         spy = mocker.spy(qml.gradients.parameter_shift, "expval_param_shift")
 
-        with qml.tape.QuantumTape(distribute_shots=True, shots=1000) as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(0.543, wires=[0])
             qml.RY(-0.654, wires=[1])  # does not have any impact on the expval
             qml.expval(qml.PauliZ(0))
@@ -506,8 +505,7 @@ class TestParamShiftBroadcast:
         assert res.shape == (1, 2)
 
         # only called for parameter 0
-        assert spy.call_args[0][0] == tape
-        assert spy.call_args[0][0] == [0]
+        assert spy.call_args[0][0:2] == (tape, [0])
 
     def test_with_gradient_recipes(self):
         """Test that the function behaves as expected"""

--- a/tests/returntypes/test_finite_difference_new.py
+++ b/tests/returntypes/test_finite_difference_new.py
@@ -17,16 +17,11 @@ Tests for the gradients.finite_difference module.
 import numpy
 import pytest
 
-from pennylane import numpy as np
-
 import pennylane as qml
-from pennylane.gradients import (
-    finite_diff,
-    finite_diff_coeffs,
-    generate_shifted_tapes,
-)
+from pennylane import numpy as np
 from pennylane.devices import DefaultQubit
-from pennylane.operation import Observable, AnyWires
+from pennylane.gradients import finite_diff, finite_diff_coeffs, generate_shifted_tapes
+from pennylane.operation import AnyWires, Observable
 
 
 class TestCoeffs:
@@ -151,7 +146,8 @@ class TestFiniteDiff:
         assert len(spy.call_args_list) == 1
 
         # only called for parameter 0
-        assert spy.call_args[0][0:2] == (tape, 0)
+        assert spy.call_args[0][0] == tape
+        assert spy.call_args[0][2] == 0
 
     def test_no_trainable_params_tape(self):
         """Test that the correct ouput and warning is generated in the absence of any trainable


### PR DESCRIPTION
Distribute shots over generated tapes in the following functions:
- `hamiltonian_expand`
- `param_shift`
- `finite_diff`

By default the shots are NOT distributed (to maintain the previous behaviour), however a distribute_shots keyword argument (which defaults to False) has been added to the QNode, QuantumTape and QuantumScript classes. The UI looks like the following:

QuantumTape:

```pycon
>>> x = np.array(0.654, requires_grad=True)
>>> with qml.tape.QuantumTape(shots=1000, distribute_shots=True) as tape:
...     qml.RX(x, wires=0)
...     qml.expval(qml.PauliZ(0))
>>> tapes, fn = qml.gradients.param_shift(tape)
>>> for tape in tapes:
...     print(tape.shots)
500
500
```
QNode:

```pycon
>>> x = np.array(0.654, requires_grad=True)
>>> # we need to add the shots below because the Device class is not fully refactored
>>> device = qml.device("default.qubit", wires=1, shots=1000)  
>>> @qml.qnode(device, shots=1000, distribute_shots=True)
... def circuit():
...     return qml.counts(qml.PauliX(0))
>>> qml.gradients.param_shift(circuit)(x)
-0.0004
```