### PR TITLE
Data manager fixups

### DIFF
--- a/pennylane/data/__init__.py
+++ b/pennylane/data/__init__.py
@@ -16,4 +16,4 @@ The data module provides functionality to load and manage datasets.
 """
 
 from .dataset import Dataset
-from .data_manager import load, list_datasets
+from .data_manager import load, load_interactive, list_datasets

--- a/pennylane/data/__init__.py
+++ b/pennylane/data/__init__.py
@@ -16,4 +16,4 @@ The data module provides functionality to load and manage datasets.
 """
 
 from .dataset import Dataset
-from .data_manager import load, load_interactive, list_datasets
+from .data_manager import load, load_interactive, list_datasets, list_attributes

--- a/pennylane/data/data_manager.py
+++ b/pennylane/data/data_manager.py
@@ -15,6 +15,7 @@
 Contains the Dataset utility functions.
 """
 # pylint:disable=too-many-arguments,global-statement
+from collections.abc import Iterable
 from concurrent.futures import ThreadPoolExecutor, wait, FIRST_EXCEPTION
 import os
 
@@ -27,6 +28,19 @@ DATA_STRUCT_URL = os.path.join(S3_URL, "data_struct.json")
 
 _foldermap = {}
 _data_struct = {}
+
+
+def _format_detail(param, detail):
+    if isinstance(detail, str):
+        return detail
+    if param == "layout" and isinstance(detail, Iterable):
+        return "x".join(map(str, detail))
+    if param == "bondlength":
+        if isinstance(detail, float):
+            return str(detail)
+        if isinstance(detail, int):
+            return f"{detail:.1f}"
+    raise TypeError(f"Invalid type '{type(detail).__name__}' for parameter '{param}'")
 
 
 def _validate_params(data_name, description, attributes):
@@ -57,8 +71,8 @@ def _validate_params(data_name, description, attributes):
         """Recursively validates that all values in `description` exist in the dataset."""
         param = params_left[0]
         params_left = params_left[1:]
-        details = description[param]
-        for detail in details:
+        for detail in description[param]:
+            detail = _format_detail(param, detail)
             if detail == "full":
                 if not params_left:
                     return

--- a/pennylane/data/data_manager.py
+++ b/pennylane/data/data_manager.py
@@ -25,7 +25,7 @@ from pennylane.data.dataset import Dataset
 
 S3_URL = "https://xanadu-quantum-datasets-test.s3.amazonaws.com"
 FOLDERMAP_URL = os.path.join(S3_URL, "foldermap.json")
-DATA_STRUCT_URL = os.path.join(S3_URL, "data_struct.json")
+DATA_STRUCT_URL = os.path.join(S3_URL, "data_struct_new.json")
 
 _foldermap = {}
 _data_struct = {}
@@ -240,15 +240,7 @@ def load(
     _s3_download(data_name, all_folders, attributes, directory_path, force, num_threads)
 
     data_files = []
-    docstring = f"{data['docstr']}\n\nArgs:\n"
-    for arg, argtype, argdoc in zip(
-        data["attributes"], data["attribute_types"], data["docstrings"]
-    ):
-        if arg == "full":
-            continue
-        docstring += f"\t{arg} ({argtype}): {argdoc}\n"
-    docstring += f"\nReturns:\n\tDataset({data_name})"
-
+    docstring = data["docstr"]
     for folder in all_folders:
         real_folder = os.path.join(directory_path, data_name, folder)
         data_files.append(

--- a/pennylane/data/data_manager.py
+++ b/pennylane/data/data_manager.py
@@ -15,7 +15,7 @@
 Contains the Dataset utility functions.
 """
 # pylint:disable=too-many-arguments,global-statement
-from concurrent.futures import ThreadPoolExecutor, wait
+from concurrent.futures import ThreadPoolExecutor, wait, FIRST_EXCEPTION
 import os
 
 import requests
@@ -135,7 +135,10 @@ def _s3_download(data_name, folders, attributes, dest_folder, force, num_threads
 
     with ThreadPoolExecutor(num_threads) as pool:
         futures = [pool.submit(_fetch_and_save, f, dest_folder) for f in files]
-        wait(futures)
+        results = wait(futures, return_when=FIRST_EXCEPTION)
+        for result in results.done:
+            if result.exception():
+                raise result.exception()
 
 
 def _generate_folders(node, folders):

--- a/pennylane/data/data_manager.py
+++ b/pennylane/data/data_manager.py
@@ -243,9 +243,15 @@ def list_datasets(path=None):
         >>> qml.qdata.list_datasets()
         {
             'qchem': {
-                'H2': {'STO3G': ['0.8']},
-                'LiH': {'STO3G': ['1.1']},
-                'NH3': {'STO3G': ['1.8']}
+                'H2': {
+                    '6-31G': ['0.46', '1.16', '0.58'],
+                    'STO-3G': ['0.46', '1.05']
+                },
+                'HeH': {'STO-3G': ['0.9', '0.74', '0.6', '0.8']}
+            },
+            'qspin': {
+                'Heisenberg': {'closed': {'chain': ['1x4']}},
+                'Ising': {'open': {'chain': ['1x8']}}
             }
         }
     """

--- a/pennylane/data/data_manager.py
+++ b/pennylane/data/data_manager.py
@@ -99,7 +99,7 @@ def _validate_params(data_name, description, attributes):
                     validate_structure(child, params_left)
             elif detail not in node:
                 # TODO: shorten this limit without permanently changing it
-                # sys.tracebacklimit = 0  # the recursive stack is disorienting
+                # sys.tracebacklimit = 0 # the recursive stack is disorienting
                 raise ValueError(
                     f"{param} value of '{detail}' is not available. Available values are {list(node)}"
                 )

--- a/pennylane/data/data_manager.py
+++ b/pennylane/data/data_manager.py
@@ -208,15 +208,20 @@ def load(
     _s3_download(data_name, all_folders, attributes, directory_path, force, num_threads)
 
     data_files = []
+    docstring = f"{data['docstr']}\n\nArgs:\n"
+    for arg, argtype, argdoc in zip(
+        data["attributes"], data["attribute_types"], data["docstrings"]
+    ):
+        if arg == "full":
+            continue
+        docstring += f"\t{arg} ({argtype}): {argdoc}\n"
+    docstring += f"\nReturns:\n\tDataset({data_name})"
+
     for folder in all_folders:
         real_folder = os.path.join(directory_path, data_name, folder)
-        obj = Dataset(data_name, real_folder, folder.replace("/", "_"), standard=True)
-        doc_attrs = obj.list_attributes()
-        doc_vals = [type(getattr(obj, attr)) for attr in doc_attrs]
-        args_idx = [data["attributes"].index(x) for x in doc_attrs]
-        argsdocs = [data["docstrings"][x] for x in args_idx]
-        obj.setdocstr(data["docstr"], doc_attrs, doc_vals, argsdocs)
-        data_files.append(obj)
+        data_files.append(
+            Dataset(data_name, real_folder, folder.replace("/", "_"), docstring, standard=True)
+        )
 
     return data_files
 

--- a/pennylane/data/data_manager.py
+++ b/pennylane/data/data_manager.py
@@ -280,7 +280,7 @@ def list_datasets(path=None):
                     '6-31G': ['0.46', '1.16', '0.58'],
                     'STO-3G': ['0.46', '1.05']
                 },
-                'HeH': {'STO-3G': ['0.9', '0.74', '0.6', '0.8']}
+                'HeH+': {'STO-3G': ['0.9', '0.74', '0.6', '0.8']}
             },
             'qspin': {
                 'Heisenberg': {'closed': {'chain': ['1x4']}},
@@ -337,32 +337,35 @@ def load_interactive():
 
     **Example**
 
-    qml.data.load_interactive()
-    Please select a data name:
+    .. code-block :: pycon
+
+        >>> qml.data.load_interactive()
+        Please select a data name:
             1) qspin
             2) qchem
-    Choice [1-2]: 1
-    Please select a sysname:
-        ...
-    Please select a periodicity:
-        ...
-    Please select a lattice:
-        ...
-    Please select a layout:
-        ...
-    Please select attributes:
-        ...
-    Force download files? (Default is no) [y/N]: N
-    Folder to download to? (Default is pwd, will download to /datasets subdirectory): /Users/jovyan/Downloads
+        Choice [1-2]: 1
+        Please select a sysname:
+            ...
+        Please select a periodicity:
+            ...
+        Please select a lattice:
+            ...
+        Please select a layout:
+            ...
+        Please select attributes:
+            ...
+        Force download files? (Default is no) [y/N]: N
+        Folder to download to? (Default is pwd, will download to /datasets subdirectory): /Users/jovyan/Downloads
 
-    Please confirm your choices:
-    dataset: qspin/Ising/open/rectangular/4x4
-    attributes: ['parameters', 'ground_states']
-    force: False
-    dest folder: /Users/jovyan/Downloads/datasets
-    Would you like to continue? (Default is yes) [Y/n]:
-    <pennylane.data.dataset.Dataset object at 0x10157ab50>
+        Please confirm your choices:
+        dataset: qspin/Ising/open/rectangular/4x4
+        attributes: ['parameters', 'ground_states']
+        force: False
+        dest folder: /Users/jovyan/Downloads/datasets
+        Would you like to continue? (Default is yes) [Y/n]:
+        <pennylane.data.dataset.Dataset object at 0x10157ab50>
     """
+
     if not _foldermap:
         _refresh_foldermap()
     if not _data_struct:

--- a/pennylane/data/data_manager.py
+++ b/pennylane/data/data_manager.py
@@ -394,7 +394,7 @@ def load_interactive():
 
     approve = input("Would you like to continue? (Default is yes) [Y/n]: ")
     if approve not in ["Y", "", "y"]:
-        print("not downloading.")
+        print("Aborting and not downloading!")
         return None
     return load(
         data_name, attributes=attributes, folder_path=dest_folder, force=force, **description

--- a/pennylane/data/data_manager.py
+++ b/pennylane/data/data_manager.py
@@ -18,6 +18,7 @@ Contains the Dataset utility functions.
 from collections.abc import Iterable
 from concurrent.futures import ThreadPoolExecutor, wait, FIRST_EXCEPTION
 import os
+from urllib.parse import quote
 
 import requests
 from pennylane.data.dataset import Dataset
@@ -110,7 +111,7 @@ def _refresh_data_struct():
 
 def _fetch_and_save(filename, dest_folder):
     """Download a single file from S3 and save it locally."""
-    response = requests.get(os.path.join(S3_URL, filename), timeout=5.0)
+    response = requests.get(os.path.join(S3_URL, quote(filename)), timeout=5.0)
     response.raise_for_status()
     with open(os.path.join(dest_folder, filename), "wb") as f:
         f.write(response.content)

--- a/pennylane/data/data_manager.py
+++ b/pennylane/data/data_manager.py
@@ -26,7 +26,7 @@ from pennylane.data.dataset import Dataset
 
 S3_URL = "https://xanadu-quantum-datasets-test.s3.amazonaws.com"
 FOLDERMAP_URL = os.path.join(S3_URL, "foldermap.json")
-DATA_STRUCT_URL = os.path.join(S3_URL, "data_struct_new.json")
+DATA_STRUCT_URL = os.path.join(S3_URL, "data_struct.json")
 
 _foldermap = {}
 _data_struct = {}

--- a/pennylane/data/dataset.py
+++ b/pennylane/data/dataset.py
@@ -83,15 +83,15 @@ class Dataset(ABC):
         + (1) [Z1]
     """
 
-    _standard_argnames = ["data_name", "data_folder", "attr_prefix"]
+    _standard_argnames = ["data_name", "data_folder", "attr_prefix", "docstring"]
 
-    def __std_init__(self, data_name, folder, attr_prefix):
+    def __std_init__(self, data_name, folder, attr_prefix, docstring):
         """Constructor for standardized datasets."""
         self._dtype = data_name
         self._folder = folder.rstrip("/")
         self._prefix = os.path.join(self._folder, attr_prefix) + "_{}.dat"
         self._prefix_len = len(attr_prefix) + 1
-        self.__doc__ = ""
+        self.__doc__ = docstring
 
         self._fullfile = self._prefix.format("full")
         if not os.path.exists(self._fullfile):
@@ -236,13 +236,3 @@ class Dataset(ABC):
                 return value
             # TODO: download the file here?
             raise
-
-    def setdocstr(self, docstr, args=None, argtypes=None, argsdocs=None):
-        """Build the docstring for the Dataset class"""
-        docstring = f"{docstr}\n\n"
-        if args and argsdocs and argtypes:
-            docstring += "Args:\n"
-            for arg, argdoc, argtype in zip(args, argsdocs, argtypes):
-                docstring += f"\t{arg} ({argtype}): {argdoc}\n"
-            docstring += f"\nReturns:\n\tDataset({self._dtype})"
-        self.__doc__ = docstring  # pylint:disable=attribute-defined-outside-init

--- a/pennylane/data/dataset.py
+++ b/pennylane/data/dataset.py
@@ -83,11 +83,11 @@ class Dataset(ABC):
         + (1) [Z1]
     """
 
-    _standard_argnames = ["data_type", "data_folder", "attr_prefix"]
+    _standard_argnames = ["data_name", "data_folder", "attr_prefix"]
 
-    def __std_init__(self, data_type, folder, attr_prefix):
+    def __std_init__(self, data_name, folder, attr_prefix):
         """Constructor for standardized datasets."""
-        self._dtype = data_type
+        self._dtype = data_name
         self._folder = folder.rstrip("/")
         self._prefix = os.path.join(self._folder, attr_prefix) + "_{}.dat"
         self._prefix_len = len(attr_prefix) + 1

--- a/pennylane/data/dataset.py
+++ b/pennylane/data/dataset.py
@@ -229,6 +229,8 @@ class Dataset(ABC):
             if os.path.exists(filepath):
                 value = self._read_file(filepath)
                 if filepath == self._fullfile:
+                    if name not in value:
+                        raise
                     value = value[name]
                 setattr(self, name, value)
                 return value

--- a/pennylane/data/dataset.py
+++ b/pennylane/data/dataset.py
@@ -163,6 +163,7 @@ class Dataset(ABC):
 
     @staticmethod
     def _write_file(data, filepath, protocol=4):
+        """General method to write data to a file."""
         pickled_data = dill.dumps(data, protocol=protocol)
         compressed_pickle = zstd.compress(pickled_data)
         with open(filepath, "wb") as f:

--- a/pennylane/data/dataset.py
+++ b/pennylane/data/dataset.py
@@ -187,6 +187,7 @@ class Dataset(ABC):
         """List the attributes saved on the Dataset"""
         return list(self.attrs)
 
+    # pylint: disable=attribute-defined-outside-init
     def __copy__(self):
         cls = self.__class__
 

--- a/pennylane/data/dataset.py
+++ b/pennylane/data/dataset.py
@@ -187,26 +187,24 @@ class Dataset(ABC):
         """List the attributes saved on the Dataset"""
         return list(self.attrs)
 
-    @classmethod
-    def from_dataset(cls, dataset):
-        """Builds a dataset from another dataset. Copies the data from another :class:`~pennylane.data.Dataset`.
+    def __copy__(self):
+        cls = self.__class__
 
-        Args:
-            dataset (Dataset): the dataset to copy
+        if not self._is_standard:
+            return cls(**self.attrs)
 
-        Returns:
-            Dataset: a new dataset containing the same keys and values as the original
+        copied = cls.__new__(cls)
+        copied._is_standard = True
+        copied._dtype = self._dtype
+        copied._folder = self._folder
+        copied._prefix = self._prefix
+        copied._prefix_len = self._prefix_len
+        copied._fullfile = self._fullfile
+        copied.__doc__ = self.__doc__
+        for key, val in self.attrs.items():
+            setattr(copied, f"{key}", val)
 
-        **Example**
-
-            >>> original_dataset = qml.data.Dataset(kw1 = 1, kw2 = '2', kw3 = [3])
-            >>> new_dataset = qml.data.Dataset.from_dataset(original_dataset)
-            >>> print(vars(original_dataset))
-            {'dtype': None, '__doc__': '', 'kw1': 1, 'kw2': '2', 'kw3': [3]}
-            >>> print(vars(new_dataset))
-            {'dtype': None, '__doc__': '', 'kw1': 1, 'kw2': '2', 'kw3': [3]}
-        """
-        return cls(**dataset.attrs)
+        return copied
 
     # The methods below are intended for use only by standard Dataset objects
     def __get_filename_for_attribute(self, attribute):

--- a/tests/data/test_dataset.py
+++ b/tests/data/test_dataset.py
@@ -73,7 +73,7 @@ def test_copy_standard(tmp_path):
     """Test that standard datasets can be built from other standard datasets."""
     filepath = tmp_path / "myset_full.dat"
     qml.data.Dataset._write_file({"molecule": 1, "hf_state": 2}, str(filepath))
-    test_dataset = qml.data.Dataset("qchem", str(tmp_path), "myset", standard=True)
+    test_dataset = qml.data.Dataset("qchem", str(tmp_path), "myset", "", standard=True)
     new_dataset = copy(test_dataset)
 
     assert new_dataset._is_standard == test_dataset._is_standard
@@ -94,12 +94,12 @@ def test_invalid_init():
     """Test that __init__ fails with invalid arguments."""
     with pytest.raises(
         TypeError,
-        match=r"Standard datasets expect 3 arguments: \['data_name', 'data_folder', 'attr_prefix'\]",
+        match=r"Standard datasets expect 4 arguments: \['data_name', 'data_folder', 'attr_prefix', 'docstring'\]",
     ):
         qml.data.Dataset("first", "second", standard=True)
 
     with pytest.raises(ValueError, match="Expected data_name to be a str, got int"):
-        qml.data.Dataset(1, "some_folder", "some_prefix", standard=True)
+        qml.data.Dataset(1, "some_folder", "some_prefix", "some_docstr", standard=True)
 
 
 def test_getattribute_dunder_non_full(tmp_path):
@@ -111,7 +111,7 @@ def test_getattribute_dunder_non_full(tmp_path):
     folder = tmp_path / "datasets" / "myset"
 
     # would not usually be done by users, bypassing qml.data.load
-    standard_dataset = qml.data.Dataset("qchem", str(folder), "myset", standard=True)
+    standard_dataset = qml.data.Dataset("qchem", str(folder), "myset", "", standard=True)
 
     # no hf_state file exists (yet!)
     with pytest.raises(AttributeError):
@@ -131,7 +131,7 @@ def test_getattribute_dunder_full(tmp_path):
     qml.data.Dataset._write_file({"hf_state": 2}, str(folder / "myset_full.dat"))
 
     # this getattribute will read from the above created file
-    dataset = qml.data.Dataset("qchem", str(folder), "myset", standard=True)
+    dataset = qml.data.Dataset("qchem", str(folder), "myset", "", standard=True)
     assert dataset.hf_state == 2
     with pytest.raises(AttributeError):
         _ = dataset.molecule
@@ -142,7 +142,7 @@ def test_none_attribute_value(tmp_path):
     non_standard_dataset = qml.data.Dataset(molecule=None)
     assert non_standard_dataset.molecule is None
 
-    standard_dataset = qml.data.Dataset("qchem", str(tmp_path), "myset", standard=True)
+    standard_dataset = qml.data.Dataset("qchem", str(tmp_path), "myset", "", standard=True)
     standard_dataset.molecule = None  # wouldn't usually happen
     with pytest.raises(
         AttributeError,
@@ -155,7 +155,7 @@ def test_lazy_load_until_access_non_full(tmp_path):
     """Test that Datasets do not load values until accessed with non-full files."""
     filename = str(tmp_path / "myset_hf_state.dat")
     qml.data.Dataset._write_file(2, filename)
-    dataset = qml.data.Dataset("qchem", str(tmp_path), "myset", standard=True)
+    dataset = qml.data.Dataset("qchem", str(tmp_path), "myset", "", standard=True)
     assert dataset.attrs == {"hf_state": None}
     assert dataset.hf_state == 2
     assert dataset.attrs == {"hf_state": 2}
@@ -165,7 +165,7 @@ def test_lazy_load_until_access_full(tmp_path):
     """Test that Datasets do not load values until accessed with full files."""
     filename = str(tmp_path / "myset_full.dat")
     qml.data.Dataset._write_file({"molecule": 1, "hf_state": 2}, filename)
-    dataset = qml.data.Dataset("qchem", str(tmp_path), "myset", standard=True)
+    dataset = qml.data.Dataset("qchem", str(tmp_path), "myset", "", standard=True)
     assert dataset.attrs == {"molecule": None, "hf_state": None}
     assert dataset.molecule == 1
     assert dataset.attrs == {"molecule": 1, "hf_state": None}

--- a/tests/data/test_dataset.py
+++ b/tests/data/test_dataset.py
@@ -90,11 +90,11 @@ def test_invalid_init():
     """Test that __init__ fails with invalid arguments."""
     with pytest.raises(
         TypeError,
-        match=r"Standard datasets expect 3 arguments: \['data_type', 'data_folder', 'attr_prefix'\]",
+        match=r"Standard datasets expect 3 arguments: \['data_name', 'data_folder', 'attr_prefix'\]",
     ):
         qml.data.Dataset("first", "second", standard=True)
 
-    with pytest.raises(ValueError, match="Expected data_type to be a str, got int"):
+    with pytest.raises(ValueError, match="Expected data_name to be a str, got int"):
         qml.data.Dataset(1, "some_folder", "some_prefix", standard=True)
 
 

--- a/tests/data/test_dataset.py
+++ b/tests/data/test_dataset.py
@@ -36,7 +36,6 @@ def test_write_dataset(tmp_path):
     """Test that datasets are saved correctly."""
     test_dataset = qml.data.Dataset(kw1=1, kw2="2", kw3=[3])
     d = tmp_path / "sub"
-    d.mkdir()
     p = d / "test_dataset"
     test_dataset.write(p)
 
@@ -45,7 +44,6 @@ def test_read_dataset(tmp_path):
     """Test that datasets are loaded correctly."""
     test_dataset = qml.data.Dataset(kw1=1, kw2="2", kw3=[3])
     d = tmp_path / "sub"
-    d.mkdir()
     p = d / "test_dataset"
     test_dataset.write(p)
 
@@ -55,6 +53,12 @@ def test_read_dataset(tmp_path):
     assert test_dataset.kw1 == 1
     assert test_dataset.kw2 == "2"
     assert test_dataset.kw3 == [3]
+
+
+def test_list_attributes():
+    """Test the list_attributes method."""
+    test_dataset = qml.data.Dataset(kw1=1)
+    assert test_dataset.list_attributes() == ["kw1"]
 
 
 def test_copy_non_standard():
@@ -129,7 +133,7 @@ def test_getattribute_dunder_full(tmp_path):
     # this getattribute will read from the above created file
     dataset = qml.data.Dataset("qchem", str(folder), "myset", standard=True)
     assert dataset.hf_state == 2
-    with pytest.raises(KeyError):
+    with pytest.raises(AttributeError):
         _ = dataset.molecule
 
 

--- a/tests/data/test_dataset.py
+++ b/tests/data/test_dataset.py
@@ -64,80 +64,82 @@ def test_from_dataset():
     assert new_dataset.attrs == test_dataset.attrs
 
 
-class TestStandardDataset:
-    """Tests focused on Datasets initialized with standard=True."""
+def test_invalid_init():
+    """Test that __init__ fails with invalid arguments."""
+    with pytest.raises(
+        TypeError,
+        match=r"Standard datasets expect 3 arguments: \['data_type', 'data_folder', 'attr_prefix'\]",
+    ):
+        qml.data.Dataset("first", "second", standard=True)
 
-    def test_invalid_init(self):
-        """Test that __init__ fails with invalid arguments."""
-        with pytest.raises(
-            TypeError,
-            match=r"Standard datasets expect 3 arguments: \['data_type', 'data_folder', 'attr_prefix'\]",
-        ):
-            qml.data.Dataset("first", "second", standard=True)
+    with pytest.raises(ValueError, match="Expected data_type to be a str, got int"):
+        qml.data.Dataset(1, "some_folder", "some_prefix", standard=True)
 
-        with pytest.raises(ValueError, match="Expected data_type to be a str, got int"):
-            qml.data.Dataset(1, "some_folder", "some_prefix", standard=True)
 
-    def test_getattribute_dunder_non_full(self, tmp_path):
-        """Test the getattribute override."""
-        non_standard_dataset = qml.data.Dataset(foo="bar")
-        with pytest.raises(AttributeError):
-            _ = non_standard_dataset.baz
+def test_getattribute_dunder_non_full(tmp_path):
+    """Test the getattribute override."""
+    non_standard_dataset = qml.data.Dataset(foo="bar")
+    with pytest.raises(AttributeError):
+        _ = non_standard_dataset.baz
 
-        folder = tmp_path / "datasets" / "myset"
+    folder = tmp_path / "datasets" / "myset"
 
-        # would not usually be done by users, bypassing qml.data.load
-        standard_dataset = qml.data.Dataset("qchem", str(folder), "myset", standard=True)
+    # would not usually be done by users, bypassing qml.data.load
+    standard_dataset = qml.data.Dataset("qchem", str(folder), "myset", standard=True)
 
-        # no hf_state file exists (yet!)
-        with pytest.raises(AttributeError):
-            _ = standard_dataset.hf_state
-        # create an hf_state file
-        os.makedirs(folder)
-        qml.data.Dataset._write_file(2, str(folder / "myset_hf_state.dat"))
-        # this getattribute will read from the above created file
-        assert standard_dataset.hf_state == 2
-        assert standard_dataset._fullfile is None
+    # no hf_state file exists (yet!)
+    with pytest.raises(AttributeError):
+        _ = standard_dataset.hf_state
+    # create an hf_state file
+    os.makedirs(folder)
+    qml.data.Dataset._write_file(2, str(folder / "myset_hf_state.dat"))
+    # this getattribute will read from the above created file
+    assert standard_dataset.hf_state == 2
+    assert standard_dataset._fullfile is None
 
-    def test_getattribute_dunder_full(self, tmp_path):
-        """Test the getattribute behaviour when a fullfile is set."""
-        folder = tmp_path / "datasets" / "myset"
-        os.makedirs(folder)
-        qml.data.Dataset._write_file({"hf_state": 2}, str(folder / "myset_full.dat"))
 
-        # this getattribute will read from the above created file
-        dataset = qml.data.Dataset("qchem", str(folder), "myset", standard=True)
-        assert dataset.hf_state == 2
-        with pytest.raises(KeyError):
-            _ = dataset.molecule
+def test_getattribute_dunder_full(tmp_path):
+    """Test the getattribute behaviour when a fullfile is set."""
+    folder = tmp_path / "datasets" / "myset"
+    os.makedirs(folder)
+    qml.data.Dataset._write_file({"hf_state": 2}, str(folder / "myset_full.dat"))
 
-    def test_none_attribute_value(self, tmp_path):
-        """Test that non-standard datasets return None while standard datasets raise an error."""
-        non_standard_dataset = qml.data.Dataset(molecule=None)
-        assert non_standard_dataset.molecule is None
+    # this getattribute will read from the above created file
+    dataset = qml.data.Dataset("qchem", str(folder), "myset", standard=True)
+    assert dataset.hf_state == 2
+    with pytest.raises(KeyError):
+        _ = dataset.molecule
 
-        standard_dataset = qml.data.Dataset("qchem", str(tmp_path), "myset", standard=True)
-        standard_dataset.molecule = None  # wouldn't usually happen
-        with pytest.raises(
-            AttributeError,
-            match="Dataset has a 'molecule' attribute, but it is None and no data file was found",
-        ):
-            _ = standard_dataset.molecule
 
-    def test_lazy_load_until_access_non_full(self, tmp_path):
-        """Test that Datasets do not load values until accessed with non-full files."""
-        filename = str(tmp_path / "myset_hf_state.dat")
-        qml.data.Dataset._write_file(2, filename)
-        dataset = qml.data.Dataset("qchem", str(tmp_path), "myset", standard=True)
-        assert dataset.attrs == {"hf_state": None}
-        assert dataset.hf_state == 2
-        assert dataset.attrs == {"hf_state": 2}
+def test_none_attribute_value(tmp_path):
+    """Test that non-standard datasets return None while standard datasets raise an error."""
+    non_standard_dataset = qml.data.Dataset(molecule=None)
+    assert non_standard_dataset.molecule is None
 
-    def test_lazy_load_until_access_full(self, tmp_path):
-        """Test that Datasets do not load values until accessed with full files."""
-        filename = str(tmp_path / "myset_full.dat")
-        qml.data.Dataset._write_file({"hf_state": 2}, filename)
-        dataset = qml.data.Dataset("qchem", str(tmp_path), "myset", standard=True)
-        assert dataset.attrs == {"hf_state": None}
-        assert dataset.hf_state == 2
-        assert dataset.attrs == {"hf_state": 2}
+    standard_dataset = qml.data.Dataset("qchem", str(tmp_path), "myset", standard=True)
+    standard_dataset.molecule = None  # wouldn't usually happen
+    with pytest.raises(
+        AttributeError,
+        match="Dataset has a 'molecule' attribute, but it is None and no data file was found",
+    ):
+        _ = standard_dataset.molecule
+
+
+def test_lazy_load_until_access_non_full(tmp_path):
+    """Test that Datasets do not load values until accessed with non-full files."""
+    filename = str(tmp_path / "myset_hf_state.dat")
+    qml.data.Dataset._write_file(2, filename)
+    dataset = qml.data.Dataset("qchem", str(tmp_path), "myset", standard=True)
+    assert dataset.attrs == {"hf_state": None}
+    assert dataset.hf_state == 2
+    assert dataset.attrs == {"hf_state": 2}
+
+
+def test_lazy_load_until_access_full(tmp_path):
+    """Test that Datasets do not load values until accessed with full files."""
+    filename = str(tmp_path / "myset_full.dat")
+    qml.data.Dataset._write_file({"hf_state": 2}, filename)
+    dataset = qml.data.Dataset("qchem", str(tmp_path), "myset", standard=True)
+    assert dataset.attrs == {"hf_state": None}
+    assert dataset.hf_state == 2
+    assert dataset.attrs == {"hf_state": 2}

--- a/tests/data/test_dataset.py
+++ b/tests/data/test_dataset.py
@@ -62,7 +62,7 @@ def test_copy_non_standard():
     test_dataset = qml.data.Dataset(dtype="test_data", kw1=1, kw2="2", kw3=[3])
     new_dataset = copy(test_dataset)
     assert new_dataset.attrs == test_dataset.attrs
-    assert new_dataset._is_standard == False
+    assert new_dataset._is_standard is False
 
 
 def test_copy_standard(tmp_path):

--- a/tests/data/test_dataset_access.py
+++ b/tests/data/test_dataset_access.py
@@ -33,27 +33,12 @@ _data_struct = {
     "qchem": {
         "docstr": "Quantum chemistry dataset.",
         "params": ["molname", "basis", "bondlength"],
-        "docstrings": [
-            "Molecule object describing the chemical system",
-            "Hamiltonian of the system using Jordan-Wigner mapping",
-            "Sparse Hamiltonian of the system",
-            "Hartree-Fock state for the system",
-            "Contains all the attributes related to the quantum chemistry datatset",
-        ],
         "attributes": ["molecule", "hamiltonian", "sparse_hamiltonian", "hf_state", "full"],
-        "attribute_types": ["Molecule", "dict", "csr_matrix", "tensor", "dict"],
     },
     "qspin": {
         "docstr": "Quantum many-body spin system dataset.",
         "params": ["sysname", "periodicity", "lattice", "layout"],
-        "docstrings": [
-            "Parameters describing the spin system",
-            "Hamiltonians for the spin systems with different parameter values",
-            "Ground states for the spin systems with different parameter values",
-            "Contains all the attributes related to the quantum spin datatset",
-        ],
         "attributes": ["parameters", "hamiltonians", "ground_states", "full"],
-        "attribute_types": ["ndarray", "list", "ndarray", "dict"],
     },
 }
 
@@ -556,7 +541,7 @@ class TestLoad:
             os.path.join(dest, "datasets/qchem/H2/6-31G/1.16/H2_6-31G_1.16_full.dat"),
         ]
 
-    def test_docstr_generated_correctly(self, tmp_path):
+    def test_docstr_is_added_to_loaded_dataset(self, tmp_path):
         """Test that a docstring describing all attributes on a Dataset is set."""
         dest = str(tmp_path)
         data = qml.data.load(
@@ -567,19 +552,7 @@ class TestLoad:
             attributes=["molecule"],
             folder_path=dest,
         )[0]
-        print(data.__doc__.split("\n"))
-        assert data.__doc__.split("\n") == [
-            "Quantum chemistry dataset.",
-            "",
-            "Args:",
-            "\tmolecule (Molecule): Molecule object describing the chemical system",
-            "\thamiltonian (dict): Hamiltonian of the system using Jordan-Wigner mapping",
-            "\tsparse_hamiltonian (csr_matrix): Sparse Hamiltonian of the system",
-            "\thf_state (tensor): Hartree-Fock state for the system",
-            "",
-            "Returns:",
-            "\tDataset(qchem)",
-        ]
+        assert data.__doc__ == "Quantum chemistry dataset."
 
 
 @patch.object(requests, "get", get_mock)

--- a/tests/data/test_dataset_access.py
+++ b/tests/data/test_dataset_access.py
@@ -83,8 +83,8 @@ def submit_download_mock(_self, _fetch_and_save, filename, dest_folder):
 class TestValidateParams:
     """Test the _validate_params function."""
 
-    def test_data_type_error(self):
-        """Test that _validate_params fails when an unknown data_type is passed in."""
+    def test_data_name_error(self):
+        """Test that _validate_params fails when an unknown data_name is passed in."""
         with pytest.raises(ValueError, match="Currently the hosted datasets are of types"):
             qml.data.data_manager._validate_params("qspn", {}, [])
 
@@ -163,7 +163,7 @@ class TestValidateParams:
             )
 
     @pytest.mark.parametrize(
-        ("data_type", "description", "attributes"),
+        ("data_name", "description", "attributes"),
         [
             (
                 "qchem",
@@ -197,9 +197,9 @@ class TestValidateParams:
             ),
         ],
     )
-    def test_validate_params_successes(self, data_type, description, attributes):
+    def test_validate_params_successes(self, data_name, description, attributes):
         """Test that the _validate_params method passes with valid parameters."""
-        qml.data.data_manager._validate_params(data_type, description, attributes)
+        qml.data.data_manager._validate_params(data_name, description, attributes)
 
 
 class TestLoadHelpers:

--- a/tests/data/test_dataset_access.py
+++ b/tests/data/test_dataset_access.py
@@ -19,8 +19,6 @@ from concurrent.futures import ThreadPoolExecutor
 from unittest.mock import MagicMock, patch
 from glob import glob
 import os
-import dill
-import zstd
 
 import pytest
 import requests
@@ -76,10 +74,7 @@ def submit_download_mock(_self, _fetch_and_save, filename, dest_folder):
     content = os.path.splitext(os.path.basename(filename))[0]
     if content.split("_")[-1] == "full":
         content = {"molecule": content}
-    pickled_data = dill.dumps(content, protocol=4)
-    compressed_pickle = zstd.compress(pickled_data)
-    with open(os.path.join(dest_folder, filename), "wb") as f:
-        f.write(compressed_pickle)
+    qml.data.Dataset._write_file(content, os.path.join(dest_folder, filename))
 
 
 @patch.object(qml.data.data_manager, "_foldermap", _folder_map)


### PR DESCRIPTION
Two notes for reviewers:
- I made a comment below, please lmk what you think
- I think this PR is easiest to review one commit at a time, because each commit does one logical thing. You can filter by commit in the "Files changed" tab. I'd also shift-click the first two to view them together to make the diff nicer.

Does a handful of things:
- Lazy init, non-lazy `__getattribute__` (requires care with standard vs. non-standard)
- `from_dataset` turned into copy constructor
- Better `list_datasets()` docstring example
- Rename `data_type` to `data_name`
- Description type check/format
  - `layout` can be an iterable, so (1,2) -> "1x2"
  - `bondlength` can be a number, so `0.46` is accepted, as well as `"0.46"`. `1` will become `"1.0"`
  - Everything else must be a string
- Provide a separate interactive load prompt
- Always set a full docstring on standard Datasets
- Added the `list_attributes` method to get all attributes available for a given data name

After discussing, will not do the following:
- Change “full” to “*” (will keep things consistent because "full" is essentially an attribute/file suffix)
- Don’t return a list if only one dataset generated from `load()` (better to keep the method's return type consistent)