### PR TITLE
Avoid raising an error in `hamiltonian_expand` function

### DIFF
--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -727,7 +727,7 @@ class Device(abc.ABC):
         is_shadow = ShadowExpval in return_types
 
         if hamiltonian_in_obs and (
-            not supports_hamiltonian or (finite_shots and not is_shadow) or grouping_known
+            (not supports_hamiltonian or (finite_shots and not is_shadow)) or grouping_known
         ):
             # If the observable contains a Hamiltonian and the device does not
             # support Hamiltonians, or if the simulation uses finite shots, or

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -25,22 +25,17 @@ from functools import lru_cache
 import numpy as np
 
 import pennylane as qml
-from pennylane.operation import (
-    Operation,
-    Observable,
-    Tensor,
-)
 from pennylane.measurements import (
+    Expectation,
+    MidMeasure,
+    Probability,
     Sample,
+    ShadowExpval,
     State,
     Variance,
-    Expectation,
-    Probability,
-    MidMeasure,
-    ShadowExpval,
 )
-from pennylane.wires import Wires, WireError
-
+from pennylane.operation import Observable, Operation, Tensor
+from pennylane.wires import WireError, Wires
 
 ShotTuple = namedtuple("ShotTuple", ["shots", "copies"])
 """tuple[int, int]: Represents copies of a shot number."""
@@ -731,20 +726,17 @@ class Device(abc.ABC):
 
         is_shadow = ShadowExpval in return_types
 
-        if hamiltonian_in_obs and (
-            (not supports_hamiltonian or (finite_shots and not is_shadow)) or grouping_known
+        if (
+            hamiltonian_in_obs
+            and (not supports_hamiltonian or (finite_shots and not is_shadow))
+            or grouping_known
         ):
             # If the observable contains a Hamiltonian and the device does not
             # support Hamiltonians, or if the simulation uses finite shots, or
             # if the Hamiltonian explicitly specifies an observable grouping,
             # split tape into multiple tapes of diagonalizable known observables.
-            try:
-                circuits, hamiltonian_fn = qml.transforms.hamiltonian_expand(circuit, group=False)
+            circuits, hamiltonian_fn = qml.transforms.hamiltonian_expand(circuit, group=False)
 
-            except ValueError as e:
-                raise ValueError(
-                    "Can only return the expectation of a single Hamiltonian observable"
-                ) from e
         elif (
             len(circuit._obs_sharing_wires) > 0
             and not hamiltonian_in_obs

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -726,10 +726,8 @@ class Device(abc.ABC):
 
         is_shadow = ShadowExpval in return_types
 
-        if (
-            hamiltonian_in_obs
-            and (not supports_hamiltonian or (finite_shots and not is_shadow))
-            or grouping_known
+        if hamiltonian_in_obs and (
+            not supports_hamiltonian or (finite_shots and not is_shadow) or grouping_known
         ):
             # If the observable contains a Hamiltonian and the device does not
             # support Hamiltonians, or if the simulation uses finite shots, or

--- a/pennylane/transforms/hamiltonian_expand.py
+++ b/pennylane/transforms/hamiltonian_expand.py
@@ -21,8 +21,8 @@ import pennylane as qml
 def hamiltonian_expand(tape, group=True):
     r"""
     Splits a tape measuring a Hamiltonian expectation into mutliple tapes of Pauli expectations,
-    and provides a function to recombine the results. If the tape doesn't measure a single
-    Hamiltonian expectation it is returned unchanged.
+    and provides a function to recombine the results. The tape is returned unchanged if it doesn't
+    measure a single Hamiltonian expectation.
 
     Args:
         tape (.QuantumTape): the tape used when calculating the expectation value

--- a/pennylane/transforms/hamiltonian_expand.py
+++ b/pennylane/transforms/hamiltonian_expand.py
@@ -21,7 +21,8 @@ import pennylane as qml
 def hamiltonian_expand(tape, group=True):
     r"""
     Splits a tape measuring a Hamiltonian expectation into mutliple tapes of Pauli expectations,
-    and provides a function to recombine the results.
+    and provides a function to recombine the results. If the tape doesn't measure a single
+    Hamiltonian expectation it is returned unchanged.
 
     Args:
         tape (.QuantumTape): the tape used when calculating the expectation value
@@ -125,9 +126,7 @@ def hamiltonian_expand(tape, group=True):
         or len(tape.measurements) > 1
         or tape.measurements[0].return_type != qml.measurements.Expectation
     ):
-        raise ValueError(
-            "Passed tape must end in `qml.expval(H)`, where H is of type `qml.Hamiltonian`"
-        )
+        return [tape], lambda res: res[0]
 
     # note: for backward passes of some frameworks
     # it is crucial to use the hamiltonian.data attribute,

--- a/tests/test_qnode.py
+++ b/tests/test_qnode.py
@@ -1516,27 +1516,6 @@ class TestTapeExpansion:
 
         assert len(tapes) == 2
 
-    def test_invalid_hamiltonian_expansion_finite_shots(self, mocker):
-        """Test that an error is raised if multiple expectations are requested
-        when using finite shots"""
-        dev = qml.device("default.qubit", wires=3, shots=50000)
-
-        obs = [qml.PauliX(0), qml.PauliX(0) @ qml.PauliZ(1), qml.PauliZ(0) @ qml.PauliZ(1)]
-        c = np.array([-0.6543, 0.24, 0.54])
-        H = qml.Hamiltonian(c, obs)
-        H.compute_grouping()
-
-        assert len(H.grouping_indices) == 2
-
-        @qnode(dev)
-        def circuit():
-            return qml.expval(H), qml.expval(H)
-
-        with pytest.raises(
-            ValueError, match="Can only return the expectation of a single Hamiltonian"
-        ):
-            circuit()
-
     def test_device_expansion_strategy(self, mocker):
         """Test that the device expansion strategy performs the device
         decomposition at construction time, and not at execution time"""

--- a/tests/test_vqe.py
+++ b/tests/test_vqe.py
@@ -19,8 +19,8 @@ import pytest
 
 import pennylane as qml
 from pennylane import numpy as pnp
-from pennylane.wires import Wires
-from pennylane.devices import DefaultQubit, DefaultMixed
+from pennylane.devices import DefaultMixed, DefaultQubit
+from pennylane.operation import EigvalsUndefinedError
 
 
 @pytest.fixture(scope="function")
@@ -1015,7 +1015,7 @@ class TestNewVQE:
         def circuit():
             return qml.sample(H)
 
-        with pytest.raises(ValueError, match="Can only return the expectation of a single"):
+        with pytest.raises(EigvalsUndefinedError, match="Cannot compute samples of Hamiltonian."):
             circuit()
 
     @pytest.mark.autograd
@@ -1282,8 +1282,8 @@ class TestMultipleInterfaceIntegration:
 
     def test_all_interfaces_gradient_agree(self, tol):
         """Test the gradient agrees across all interfaces"""
-        import torch
         import tensorflow as tf
+        import torch
 
         dev = qml.device("default.qubit", wires=2)
 

--- a/tests/transforms/test_hamiltonian_expand.py
+++ b/tests/transforms/test_hamiltonian_expand.py
@@ -163,6 +163,8 @@ class TestHamiltonianExpand:
         assert len(tapes) == 2
 
     def test_non_hamiltonian_tape(self):
+        """Test that the ``hamiltonian_expand`` function returns the input tape if it does not
+        contain a single measurement with the expectation value of a Hamiltonian."""
 
         with pennylane.tape.QuantumTape() as tape:
             qml.expval(qml.PauliZ(0))

--- a/tests/transforms/test_hamiltonian_expand.py
+++ b/tests/transforms/test_hamiltonian_expand.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
 import numpy as np
+import pytest
+
 import pennylane as qml
 import pennylane.tape
 from pennylane import numpy as pnp
@@ -161,13 +162,15 @@ class TestHamiltonianExpand:
         tapes, fn = qml.transforms.hamiltonian_expand(qs, group=True)
         assert len(tapes) == 2
 
-    def test_hamiltonian_error(self):
+    def test_non_hamiltonian_tape(self):
 
         with pennylane.tape.QuantumTape() as tape:
             qml.expval(qml.PauliZ(0))
 
-        with pytest.raises(ValueError, match=r"Passed tape must end in"):
-            tapes, fn = qml.transforms.hamiltonian_expand(tape)
+        tapes, fn = qml.transforms.hamiltonian_expand(tape)
+
+        assert tapes[0] is tape
+        assert fn([1]) == 1
 
     @pytest.mark.autograd
     def test_hamiltonian_dif_autograd(self, tol):


### PR DESCRIPTION
Return the input tape and an identity transform instead of raising an error in the `hamiltonian_expand` function.
