### PR TITLE
Decompose `Exp` into `PauliRot` if possible

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -235,6 +235,7 @@ Users can specify the control wires as well as the values to control the operati
 
 * The `Exp` class decomposes into a `PauliRot` class if the coefficient is imaginary and 
   the base operator is a Pauli Word.
+  [(#3249)](https://github.com/PennyLaneAI/pennylane/pull/3249)
 
 * Added the `samples_computational_basis` attribute to the `MeasurementProcess` and `QuantumScript` classes to track
   if computational basis samples are being generated.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -233,6 +233,9 @@ Users can specify the control wires as well as the values to control the operati
 
 <h3>Improvements</h3>
 
+* The `Exp` class decomposes into a `PauliRot` class if the coefficient is imaginary and 
+  the base operator is a Pauli Word.
+
 * Added the `samples_computational_basis` attribute to the `MeasurementProcess` and `QuantumScript` classes to track
   if computational basis samples are being generated.
   [(#3207)](https://github.com/PennyLaneAI/pennylane/pull/3207)

--- a/pennylane/ops/op_math/exp.py
+++ b/pennylane/ops/op_math/exp.py
@@ -173,6 +173,17 @@ class Exp(SymbolicOp):
         return math.real(self.coeff) == 0 and is_pauli_word(self.base)
 
     def decomposition(self):
+        r"""Representation of the operator as a product of other operators. Decomposes into
+        :class:`~.PauliRot` if the coefficient is imaginary and the base is a Pauli Word.
+
+        .. math:: O = O_1 O_2 \dots O_n
+
+        A ``DecompositionUndefinedError`` is raised if the coefficient is not imaginary or the base
+        is not a Pauli Word.
+
+        Returns:
+            list[PauliRot]: decomposition of the operator
+        """
         if math.real(self.coeff) != 0 or not is_pauli_word(self.base):
             raise DecompositionUndefinedError
         new_coeff = math.real(2j * self.coeff)

--- a/pennylane/ops/qubit/parametric_ops.py
+++ b/pennylane/ops/qubit/parametric_ops.py
@@ -1147,6 +1147,9 @@ class PauliRot(Operation):
                 f"{num_wires} was expected for wires {wires}"
             )
 
+    def __repr__(self):
+        return f"PauliRot({self.data[0]}, {self.hyperparameters['pauli_word']}, wires={self.wires.tolist()})"
+
     def label(self, decimals=None, base_label=None, cache=None):
         r"""A customizable string representation of the operator.
 

--- a/tests/ops/op_math/test_exp.py
+++ b/tests/ops/op_math/test_exp.py
@@ -17,6 +17,7 @@ from copy import copy
 
 import pennylane as qml
 from pennylane import numpy as np
+from pennylane.operation import DecompositionUndefinedError
 from pennylane.ops.op_math import Exp
 
 
@@ -273,6 +274,42 @@ class TestMatrix:
 
         with pytest.raises(NotImplementedError):
             op.sparse_matrix(wire_order=[0, 1])
+
+
+class TestDecomposition:
+    @pytest.mark.parametrize("coeff", (1, 1 + 0.5j))
+    def test_non_imag_no_decomposition(self, coeff):
+        """Tests that the decomposition doesn't exist if the coefficient has a real component."""
+        op = Exp(coeff, qml.PauliX(0))
+        assert not op.has_decomposition
+        with pytest.raises(DecompositionUndefinedError):
+            op.decomposition()
+
+    def test_non_pauli_word_base_no_decomposition(self):
+        """Tests that the decomposition doesn't exist if the base is not a pauli word."""
+        op = Exp(-0.5j, qml.S(0))
+        assert not op.has_decomposition
+        with pytest.raises(DecompositionUndefinedError):
+            op.decomposition()
+
+    @pytest.mark.parametrize(
+        "base, base_string",
+        (
+            (qml.PauliX(0), "X"),
+            (qml.PauliZ(0) @ qml.PauliY(1), "ZY"),
+            (qml.PauliY(0) @ qml.Identity(1) @ qml.PauliZ(2), "YIZ"),
+        ),
+    )
+    def test_pauli_word_decompositioni(self, base, base_string):
+        """Check that Exp decomposes into PauliRot if possible."""
+        theta = 3.21
+        op = Exp(base, -0.5j * theta)
+
+        assert op.has_decomposition
+        pr = op.decomposition()[0]
+        assert pr.data[0] == 3.21
+        assert pr.hyperparameters["pauli_word"] == base_string
+        assert pr.wires == base.wires
 
 
 class TestMiscMethods:

--- a/tests/ops/op_math/test_exp.py
+++ b/tests/ops/op_math/test_exp.py
@@ -307,9 +307,7 @@ class TestDecomposition:
 
         assert op.has_decomposition
         pr = op.decomposition()[0]
-        assert pr.data[0] == 3.21
-        assert pr.hyperparameters["pauli_word"] == base_string
-        assert pr.wires == base.wires
+        assert qml.equal(pr, qml.PauliRot(3.21, base_string, base.wires))
 
 
 class TestMiscMethods:

--- a/tests/ops/qubit/test_parametric_ops.py
+++ b/tests/ops/qubit/test_parametric_ops.py
@@ -2566,6 +2566,10 @@ PAULI_ROT_MATRIX_TEST_DATA = [
 class TestPauliRot:
     """Test the PauliRot operation."""
 
+    def test_paulirot_repr(self):
+        op = qml.PauliRot(1.234, "XYX", wires=(0, 1, 2))
+        assert repr(op) == "PauliRot(1.234, XYX, wires=[0, 1, 2])"
+
     @pytest.mark.parametrize("theta", np.linspace(0, 2 * np.pi, 7))
     @pytest.mark.parametrize(
         "pauli_word,expected_matrix",


### PR DESCRIPTION
Right now, the `Exp` class doesn't have a decomposition.

This PR decomposes `Exp` into `PauliRot` if:
* The coefficient is purely imaginary
* The base operator is a pauli word

For example:

```pycon
>>> op = qml.exp(qml.PauliX(0) @ qml.PauliY(1), -0.5j * 1.234)
>>> op.decomposition()
[PauliRot(-1.234, XY, wires=[0, 1])]
```

It also updates the repr method for `PauliRot`, because it was missing crucial information.