### PR TITLE
map_wires in expval(H) to ensure device wires used

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -649,6 +649,10 @@ Users can specify the control wires as well as the values to control the operati
   composite operator.
   [(#3204)](https://github.com/PennyLaneAI/pennylane/pull/3204)
 
+* Fixed a bug where `qml.expval(qml.Hamiltonian())` would not raise an error
+  if the Hamiltonian involved some wires that are not present on the device.
+  [(#3266)](https://github.com/PennyLaneAI/pennylane/pull/3266)
+
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -533,6 +533,7 @@ class DefaultQubit(QubitDevice):
         if observable.name in ("Hamiltonian", "SparseHamiltonian"):
             assert self.shots is None, f"{observable.name} must be used with shots=None"
 
+            self.map_wires(observable.wires)
             backprop_mode = (
                 not isinstance(self.state, np.ndarray)
                 or any(not isinstance(d, (float, np.ndarray)) for d in observable.data)

--- a/tests/devices/test_default_qubit.py
+++ b/tests/devices/test_default_qubit.py
@@ -79,8 +79,6 @@ U_cswap = np.array(
     ]
 )
 
-H = np.array([[1.02789352, 1.61296440 - 0.3498192j], [1.61296440 + 0.3498192j, 1.23920938 + 0j]])
-
 THETA = np.linspace(0.11, 1, 3)
 PHI = np.linspace(0.32, 1, 3)
 VARPHI = np.linspace(0.02, 1, 3)
@@ -2544,6 +2542,17 @@ class TestHamiltonianSupport:
         H = qml.Hamiltonian([0.1, 0.2], [qml.PauliX(0), qml.PauliZ(1)])
 
         with pytest.raises(AssertionError, match="Hamiltonian must be used with shots=None"):
+            dev.expval(H)
+
+    def test_error_hamiltonian_expval_wrong_wires(self):
+        """Tests that expval fails if Hamiltonian uses non-device wires."""
+        dev = qml.device("default.qubit", wires=2, shots=None)
+        H = qml.Hamiltonian([0.1, 0.2, 0.3], [qml.PauliX(0), qml.PauliZ(1), qml.PauliY(2)])
+
+        with pytest.raises(
+            WireError,
+            match=r"Did not find some of the wires \(0, 1, 2\) on device with wires \(0, 1\).",
+        ):
             dev.expval(H)
 
 


### PR DESCRIPTION
**Context:**
See #3228. default.qubit wouldn't ensure Hamiltonian wires existed on the device before measuring the expectation value of it.

**Description of the Change:**
Try to map the Hamiltonian's wires to the device's wires on `default.qubit` when `shots=None` upon measuring expval.

**Benefits:**
`expval` will raise a WireError as expected when the device doesn't have the wires expected by the Hamiltonian.

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
Fixes #3228