### PR TITLE
Add shape validation to `SparseHamiltonian`

### DIFF
--- a/doc/releases/changelog-0.27.0.md
+++ b/doc/releases/changelog-0.27.0.md
@@ -593,6 +593,7 @@
 <h3>Bug fixes</h3>
 
 * `qml.SparseHamiltonian` now validates the size of the input matrix.
+  [(#3278)](https://github.com/PennyLaneAI/pennylane/pull/3278)
 
 * Fixed a bug where `qml.sample()` and `qml.counts()` would output incorrect results when mixed with measurements whose
   operators do not qubit-wise commute with computational basis projectors.

--- a/doc/releases/changelog-0.27.0.md
+++ b/doc/releases/changelog-0.27.0.md
@@ -591,6 +591,8 @@
 
 <h3>Bug fixes</h3>
 
+* `qml.SparseHamiltonian` now validates the size of the input matrix.
+
 * Fixed a bug where `qml.sample()` and `qml.counts()` would output incorrect results when mixed with measurements whose
   operators do not qubit-wise commute with computational basis projectors.
   [(#3207)](https://github.com/PennyLaneAI/pennylane/pull/3207)

--- a/pennylane/ops/qubit/observables.py
+++ b/pennylane/ops/qubit/observables.py
@@ -252,6 +252,11 @@ class SparseHamiltonian(Observable):
         if not isinstance(H, csr_matrix):
             raise TypeError("Observable must be a scipy sparse csr_matrix.")
         super().__init__(H, wires=wires, do_queue=do_queue, id=id)
+        mat_len = 2 ** len(self.wires)
+        if H.shape != (mat_len, mat_len):
+            raise ValueError(
+                f"Sparse Matrix must be of shape ({mat_len}, {mat_len}). Got {H.shape}."
+            )
 
     def label(self, decimals=None, base_label=None, cache=None):
         return super().label(decimals=decimals, base_label=base_label or "𝓗", cache=cache)

--- a/tests/ops/functions/test_eigvals.py
+++ b/tests/ops/functions/test_eigvals.py
@@ -203,23 +203,24 @@ class TestSingleOperation:
     )
     def test_sparse_hamiltonian(self, row, col, dat, val_ref):
         """Test that the eigenvalues of a sparse Hamiltonian are correctly returned"""
-        # N x N matrix with N = 20
-        h_sparse = scipy.sparse.csr_matrix((dat, (row, col)), shape=(len(row), len(col)))
-        h_sparse = qml.SparseHamiltonian(h_sparse, wires=all)
+        # N x N matrix with N = 16
+        h_mat = scipy.sparse.csr_matrix((dat, (row, col)), shape=(16, 16))
+        h_sparse = qml.SparseHamiltonian(h_mat, wires=range(4))
+
+        dense_mat = h_mat.todense()
+        dense_eigvals = np.sort(np.linalg.eigvals(dense_mat))
 
         # k = 1  (< N-1) scipy.sparse.linalg is used:
         val_groundstate = qml.eigvals(h_sparse, k=1)
-        # k = 18  (< N-1) scipy.sparse.linalg is used:
-        val_n_sparse = qml.eigvals(h_sparse, k=len(val_ref) - 2)
-        # k = 20 (> N-1) qml.math.linalg is used:
-        val_all = qml.eigvals(h_sparse, k=len(val_ref))
-        # k = 19 (= N-1) qml.math.linalg is used:
-        val_n_dense = qml.eigvals(h_sparse, k=len(val_ref) - 1)
+        assert np.allclose(val_groundstate, dense_eigvals[0])
 
-        assert np.allclose(val_groundstate, val_ref[0])
-        assert np.allclose(np.sort(val_n_sparse), val_ref[0:18])
-        assert np.allclose(np.sort(val_all), val_ref)
-        assert np.allclose(np.sort(val_n_dense), val_ref)
+        # k = 14  (< N-1) scipy.sparse.linalg is used:
+        val_n_sparse = np.sort(qml.eigvals(h_sparse, k=14))
+        assert np.allclose(val_n_sparse, dense_eigvals[0:-2])
+
+        # k = 16 (> N-1) qml.math.linalg is used:
+        val_all = np.sort(qml.eigvals(h_sparse, k=16))
+        assert np.allclose(val_all, dense_eigvals)
 
 
 class TestMultipleOperations:

--- a/tests/ops/qubit/test_sparse.py
+++ b/tests/ops/qubit/test_sparse.py
@@ -62,6 +62,14 @@ class TestSparse:
         H = qml.SparseHamiltonian(csr_matrix(np.array([[1, 0], [-1.5, 0]])), 1)
         assert H.label() == "𝓗"
 
+    def test_valueeror_shape(self):
+        """Test that iniatilization raises a ValueError if the shape is not correct for the number of wires."""
+        mat = csr_matrix([[1, 0], [0, 1]])
+        with pytest.raises(
+            ValueError, match=r"Sparse Matrix must be of shape \(4, 4\). Got \(2, 2\)."
+        ):
+            qml.SparseHamiltonian(mat, wires=(0, 1))
+
     @pytest.mark.parametrize("sparse_hamiltonian", SPARSE_HAMILTONIAN_TEST_DATA)
     def test_sparse_typeerror(self, sparse_hamiltonian):
         """Test that the SparseHamiltonian class raises a TypeError on incorrect inputs."""
@@ -69,12 +77,12 @@ class TestSparse:
         sparse_hamiltonian = coo_matrix(mat)
 
         with pytest.raises(TypeError, match="Observable must be a scipy sparse csr_matrix"):
-            qml.SparseHamiltonian(sparse_hamiltonian)
+            qml.SparseHamiltonian(sparse_hamiltonian, wires=0)
 
     @pytest.mark.parametrize("sparse_hamiltonian", SPARSE_HAMILTONIAN_TEST_DATA)
     def test_sparse_matrix(self, sparse_hamiltonian, tol):
         """Test that the matrix property of the SparseHamiltonian class returns the correct matrix."""
-        num_wires = len(sparse_hamiltonian[0])
+        num_wires = int(np.log2(len(sparse_hamiltonian[0])))
         sparse_hamiltonian_csr = csr_matrix(sparse_hamiltonian)
         res_dynamic = qml.SparseHamiltonian(
             sparse_hamiltonian_csr, range(num_wires)
@@ -88,7 +96,7 @@ class TestSparse:
     @pytest.mark.parametrize("sparse_hamiltonian", SPARSE_HAMILTONIAN_TEST_DATA)
     def test_matrix(self, sparse_hamiltonian, tol):
         """Test that the matrix property of the SparseHamiltonian class returns the correct matrix."""
-        num_wires = len(sparse_hamiltonian[0])
+        num_wires = int(np.log2(len(sparse_hamiltonian[0])))
         sparse_hamiltonian_csr = csr_matrix(sparse_hamiltonian)
         res_dynamic = qml.SparseHamiltonian(sparse_hamiltonian_csr, range(num_wires)).matrix()
         res_static = qml.SparseHamiltonian.compute_matrix(sparse_hamiltonian_csr)


### PR DESCRIPTION
Fixes #3272 .

Currently, `SparseHamiltonian` does not perform any validation on the shape of the matrix.  This leads to confusing errors downstream if the shape does not match the wires.

This PR just adds a simple check on the shape, and raises an error if the sparse matrix is not the right shape.

This is a rapid check, so I do not see any problems adding it in.