### PR TITLE
Fix pure callback changelog & JAX version validation

### DIFF
--- a/doc/releases/changelog-0.27.0.md
+++ b/doc/releases/changelog-0.27.0.md
@@ -147,6 +147,8 @@
   [(#3261)](https://github.com/PennyLaneAI/pennylane/pull/3261)
 
   ```python
+  import jax
+  from jax import numpy as jnp
   from jax.config import config
   config.update("jax_enable_x64", True)
 

--- a/doc/releases/changelog-0.27.0.md
+++ b/doc/releases/changelog-0.27.0.md
@@ -147,6 +147,9 @@
   [(#3261)](https://github.com/PennyLaneAI/pennylane/pull/3261)
 
   ```python
+  from jax.config import config
+  config.update("jax_enable_x64", True)
+
   dev = qml.device("lightning.qubit", wires=2)
 
   @jax.jit
@@ -157,17 +160,17 @@
       qml.CNOT(wires=[0, 1])
       return qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliZ(1))
 
-  x = jnp.array(1.0, dtype=jnp.float32)
-  y = jnp.array(2.0, dtype=jnp.float32)
+  x = jnp.array(1.0)
+  y = jnp.array(2.0)
   ```
 
   ```pycon
   >>> jax.jacobian(circuit, argnums=[0, 1])(x, y)
-  (DeviceArray([-0.84147096,  0.3501755 ], dtype=float32),
-   DeviceArray([ 4.474455e-18, -4.912955e-01], dtype=float32))
+  (DeviceArray([-0.84147098,  0.35017549], dtype=float64, weak_type=True),
+   DeviceArray([ 4.47445479e-18, -4.91295496e-01], dtype=float64, weak_type=True))
   ```
 
-  Note that this change depends on `jax.pure_callback`, which requires `jax==0.3.17`.
+  Note that this change depends on `jax.pure_callback`, which requires `jax>=0.3.17`.
 
 * The `QNode` class now accepts an `auto` interface, which automatically detects the interface of the given input.
   [(#3132)](https://github.com/PennyLaneAI/pennylane/pull/3132)

--- a/pennylane/interfaces/jax_jit.py
+++ b/pennylane/interfaces/jax_jit.py
@@ -31,11 +31,11 @@ dtype = jnp.float64
 
 def _validate_jax_version():
     if semantic_version.match("<0.3.17", jax.__version__) or semantic_version.match(
-        "<0.3.17", jax.lib.__version__
+        "<0.3.15", jax.lib.__version__
     ):
         msg = (
-            "The JAX JIT interface of PennyLane requires version 0.3.17 or higher for JAX and JAX lib. "
-            "Please upgrade these packages."
+            "The JAX JIT interface of PennyLane requires version 0.3.17 or higher for JAX "
+            "and 0.3.15 or higher JAX lib. Please upgrade these packages."
         )
         raise InterfaceUnsupportedError(msg)
 

--- a/tests/interfaces/test_jax.py
+++ b/tests/interfaces/test_jax.py
@@ -33,9 +33,16 @@ from pennylane.interfaces.jax_jit import _execute_with_fwd
 
 
 @pytest.mark.parametrize(
-    "version, should_raise", [("0.3.16", True), ("0.3.17", False), ("0.3.18", False)]
+    "version, package, should_raise",
+    [
+        ("0.3.16", jax, True),
+        ("0.3.17", jax, False),
+        ("0.3.18", jax, False),
+        ("0.3.14", jax.lib, True),
+        ("0.3.15", jax.lib, False),
+        ("0.3.16", jax.lib, False),
+    ],
 )
-@pytest.mark.parametrize("package", [jax, jax.lib])
 def test_raise_version_error(package, version, should_raise, monkeypatch):
     """Test JAX version error"""
     a = jnp.array([0.1, 0.2])
@@ -49,7 +56,7 @@ def test_raise_version_error(package, version, should_raise, monkeypatch):
         m.setattr(package, "__version__", version)
 
         if should_raise:
-            msg = "requires version 0.3.17 or higher for JAX and JAX lib"
+            msg = "requires version 0.3.17 or higher for JAX and 0.3.15 or higher JAX lib"
             with pytest.raises(InterfaceUnsupportedError, match=msg):
                 execute([tape], dev, gradient_fn=param_shift, interface="jax-jit")
         else:


### PR DESCRIPTION
* Updates the changelog item to use double-precision;
* Lowers the required version of JAX lib because there's no 0.3.17 version available version on PyPi.