### PR TITLE
Make the Pauli display nice

### DIFF
--- a/pennylane/pauli/pauli_arithmetic.py
+++ b/pennylane/pauli/pauli_arithmetic.py
@@ -143,7 +143,7 @@ class PauliWord(dict):
     def __str__(self):
         """String representation of a PauliWord."""
         if len(self) == 0:
-            return "()"
+            return "I"
         return " @ ".join(f"{op}({w})" for w, op in self.items())
 
     def __repr__(self):

--- a/pennylane/pauli/pauli_arithmetic.py
+++ b/pennylane/pauli/pauli_arithmetic.py
@@ -224,6 +224,8 @@ class PauliSentence(dict):
 
     def __str__(self):
         """String representation of the PauliSentence."""
+        if len(self) == 0:
+            return "I"
         return "\n+ ".join(f"{coeff} * {str(pw)}" for pw, coeff in self.items())
 
     def __repr__(self):

--- a/tests/pauli/test_pauli_arithmetic.py
+++ b/tests/pauli/test_pauli_arithmetic.py
@@ -187,6 +187,7 @@ class TestPauliSentence:
         ),
         (ps3, "-0.5 * Z(0) @ Z(b) @ Z(c)\n" "+ 1 * I"),
         (ps4, "1 * I"),
+        (ps5, "I"),
     )
 
     @pytest.mark.parametrize("ps, str_rep", tup_ps_str)

--- a/tests/pauli/test_pauli_arithmetic.py
+++ b/tests/pauli/test_pauli_arithmetic.py
@@ -96,7 +96,7 @@ class TestPauliWord:
         (pw1, "X(1) @ Y(2)"),
         (pw2, "X(a) @ X(b) @ Z(c)"),
         (pw3, "Z(0) @ Z(b) @ Z(c)"),
-        (pw4, "()"),
+        (pw4, "I"),
     )
 
     @pytest.mark.parametrize("pw, str_rep", tup_pw_str)
@@ -185,8 +185,8 @@ class TestPauliSentence:
             ps2,
             "-1.23 * X(1) @ Y(2)\n" "+ (-0-4j) * X(a) @ X(b) @ Z(c)\n" "+ 0.5 * Z(0) @ Z(b) @ Z(c)",
         ),
-        (ps3, "-0.5 * Z(0) @ Z(b) @ Z(c)\n" "+ 1 * ()"),
-        (ps4, "1 * ()"),
+        (ps3, "-0.5 * Z(0) @ Z(b) @ Z(c)\n" "+ 1 * I"),
+        (ps4, "1 * I"),
     )
 
     @pytest.mark.parametrize("ps, str_rep", tup_ps_str)


### PR DESCRIPTION
Update the display of an empty PauliWord from `()` to `I`, as it functionally behaves like Identity.