### PR TITLE
[WIP] Equals with Observables

### DIFF
--- a/pennylane/ops/functions/equal.py
+++ b/pennylane/ops/functions/equal.py
@@ -42,7 +42,7 @@ def equal(
         linear combination of Hermitians.
         To do so would require the matrix form of Hamiltonians and Tensors
         be calculated, which would drastically increase runtime.
-        The function will only recognize Hermitians as equal if they are **exactly** the same.
+        The function will only recognize Hermitians as equal if they are exactly the same.
 
     Args:
         op1 (.Operator, .MeasurementProcess, or .ShadowMeasurementProcess): First object to compare
@@ -137,6 +137,7 @@ def equal_operation(
     atol: float = 1e-9,
 ):
     """Determine whether two Operations objects are equal"""
+
     if [op1.name, op1.wires] != [op2.name, op2.wires]:
         return False
 
@@ -167,6 +168,8 @@ def equal_symbolicop(
     op2,
 ):
     """Determine whether two SymbolicOps objects are equal"""
+    if not isinstance(op2, SymbolicOp):
+        return False
     raise NotImplementedError(
         f"Comparison between SymbolicOps not implemented. Received {op1} and {op2}."
     )
@@ -175,6 +178,8 @@ def equal_symbolicop(
 @equal.register
 def equal_compositeop(op1: CompositeOp, op2):
     """Determine whether two CompositeOps objects are equal"""
+    if not isinstance(op2, CompositeOp):
+        return False
     raise NotImplementedError(
         f"Comparison between CompositeOps not implemented. Received {op1} and {op2}."
     )
@@ -188,6 +193,8 @@ def equal_observable(op1: Observable, op2):
         # compared as two Operations, but singledispatch selects a function to execute based on op1
         # and considers the Pauli operators Observables
         return equal_operation(op1, op2)
+    if not isinstance(op2, Observable):
+        raise NotImplementedError(f"Comparison between Observable and {type(op2)} not implemented.")
     return _obs_comparison_data(op1) == _obs_comparison_data(op2)
 
 

--- a/pennylane/ops/functions/equal.py
+++ b/pennylane/ops/functions/equal.py
@@ -100,7 +100,7 @@ def _obs_comparison_data(obs):
 @equal.register
 def equal_operation(
     op1: Operation,
-    op2: Operation,
+    op2,
     check_interface: bool = True,
     check_trainability: bool = True,
     rtol: float = 1e-5,
@@ -134,7 +134,7 @@ def equal_operation(
 @equal.register
 def equal_symbolicop(
     op1: SymbolicOp,
-    op2: SymbolicOp,
+    op2,
 ):
     """Determine whether two SymbolicOps objects are equal"""
     raise NotImplementedError(
@@ -145,7 +145,7 @@ def equal_symbolicop(
 @equal.register
 def equal_compositeop(
     op1: CompositeOp,
-    op2: CompositeOp,
+    op2,
 ):
     """Determine whether two CompositeOps objects are equal"""
     raise NotImplementedError(
@@ -154,13 +154,17 @@ def equal_compositeop(
 
 
 @equal.register
-def equal_observable(op1: Observable, op2: Observable):
+def equal_observable(op1: Observable, op2):
     """Determine whether two Observables objects are equal"""
+    if isinstance(op2, Operation):
+        # if op1 is a Pauli observable, and it is being compared to an Operation, they should be
+        # compared as two Operations, but singledispatch selects a function to execute based on op1
+        return equal_operation(op1, op2)
     return _obs_comparison_data(op1) == _obs_comparison_data(op2)
 
 
 @equal.register
-def equal_measurements(op1: MeasurementProcess, op2: MeasurementProcess):
+def equal_measurements(op1: MeasurementProcess, op2):
     """Determine whether two MeasurementProcess objects are equal"""
     return_types_match = op1.return_type == op2.return_type
     if op1.obs is not None and op2.obs is not None:
@@ -182,7 +186,7 @@ def equal_measurements(op1: MeasurementProcess, op2: MeasurementProcess):
 
 
 @equal.register
-def equal_shadow_measurements(op1: ShadowMeasurementProcess, op2: ShadowMeasurementProcess):
+def equal_shadow_measurements(op1: ShadowMeasurementProcess, op2):
     """Determine whether two ShadowMeasurementProcess objects are equal"""
     return_types_match = op1.return_type == op2.return_type
     wires_match = op1.wires == op2.wires

--- a/pennylane/ops/functions/equal.py
+++ b/pennylane/ops/functions/equal.py
@@ -107,17 +107,8 @@ def equal_operation(
     atol: float = 1e-9,
 ):
     """Determine whether two Operations objects are equal"""
-    if [op1.name, op1.arithmetic_depth, op1.wires] != [
-        op2.name,
-        op2.arithmetic_depth,
-        op2.wires,
-    ]:
+    if [op1.name, op1.wires] != [op2.name, op2.wires]:
         return False
-
-    if op1.arithmetic_depth > 0:
-        raise NotImplementedError(
-            "Comparison of Operations with an arithmetic depth larger than 0 is not yet implemented."
-        )
 
     if not all(
         qml.math.allclose(d1, d2, rtol=rtol, atol=atol) for d1, d2 in zip(op1.data, op2.data)

--- a/pennylane/ops/functions/equal.py
+++ b/pennylane/ops/functions/equal.py
@@ -21,6 +21,8 @@ from functools import singledispatch
 import pennylane as qml
 from pennylane.measurements import MeasurementProcess, ShadowMeasurementProcess
 from pennylane.operation import Operator, Operation, Observable
+from pennylane.ops.op_math.symbolicop import SymbolicOp
+from pennylane.ops.op_math.composite import CompositeOp
 from pennylane.ops.qubit.hamiltonian import Hamiltonian
 
 
@@ -136,6 +138,28 @@ def equal_operation(
                 return False
 
     return getattr(op1, "inverse", False) == getattr(op2, "inverse", False)
+
+
+@equal.register
+def equal_symbolicop(
+    op1: SymbolicOp,
+    op2: SymbolicOp,
+):
+    """Determine whether two SymbolicOps objects are equal"""
+    raise NotImplementedError(
+        f"Comparison between SymbolicOps not implemented. Received {op1} and {op2}."
+    )
+
+
+@equal.register
+def equal_compositeop(
+    op1: CompositeOp,
+    op2: CompositeOp,
+):
+    """Determine whether two CompositeOps objects are equal"""
+    raise NotImplementedError(
+        f"Comparison between CompositeOps not implemented. Received {op1} and {op2}."
+    )
 
 
 @equal.register

--- a/pennylane/ops/functions/equal.py
+++ b/pennylane/ops/functions/equal.py
@@ -28,7 +28,7 @@ from pennylane.ops.qubit.hamiltonian import Hamiltonian
 def equal(
     op1: Union[Operator, MeasurementProcess, ShadowMeasurementProcess],
     op2: Union[Operator, MeasurementProcess, ShadowMeasurementProcess],
-    **kwargs
+    **kwargs,
 ):
     r"""Function for determining operator or measurement equality.
 
@@ -83,7 +83,7 @@ def equal(
         >>> qml.equal(op3, op4, check_trainability=False)
         True
     """
-    raise NotImplementedError("Cannot compare {type(op1)} and {type(op2)}")
+    raise NotImplementedError(f"Cannot compare {type(op1)} and {type(op2)}")
 
 
 def _obs_comparison_data(obs):
@@ -96,7 +96,7 @@ def _obs_comparison_data(obs):
 
 
 @equal.register
-def equal_operator(
+def equal_operation(
     op1: Operation,
     op2: Operation,
     check_interface: bool = True,
@@ -141,7 +141,7 @@ def equal_operator(
 @equal.register
 def equal_observable(op1: Observable, op2: Observable):
     """Determine whether two Observables objects are equal"""
-    return _obs_comparison_data(op1) != _obs_comparison_data(op2)
+    return _obs_comparison_data(op1) == _obs_comparison_data(op2)
 
 
 @equal.register

--- a/pennylane/ops/functions/equal.py
+++ b/pennylane/ops/functions/equal.py
@@ -74,9 +74,9 @@ def equal(
 
     Two Observables of different types can also be compared, for example a Hamiltonian and a Tensor:
 
-    >>>H = qml.Hamiltonian([0.5, 0.5], [qml.PauliZ(0) @ qml.PauliY(1), qml.PauliY(1) @ qml.PauliZ(0) @ qml.Identity("a")])
-    >>>obs = qml.PauliZ(0) @ qml.PauliY(1)
-    >>>qml.equal(H1, obs)
+    >>> H = qml.Hamiltonian([0.5, 0.5], [qml.PauliZ(0) @ qml.PauliY(1), qml.PauliY(1) @ qml.PauliZ(0) @ qml.Identity("a")])
+    >>> obs = qml.PauliZ(0) @ qml.PauliY(1)
+    >>> qml.equal(H1, obs)
     True
 
     Observables of the type Hermitian are, however, only comparable to other Hermitians, and must be identical to
@@ -84,11 +84,9 @@ def equal(
 
     >>> A = np.array([[1, 0], [0, -1]])
     >>> B = np.array([[1., 0], [0, -1.]])
-
     >>> H1 = qml.Hermitian(A, 0)
     >>> H2 = qml.Hermitian(A, 0)
     >>> H3 = qml.Hermitian(B, 0)
-
     >>> qml.equal(H1, H2), qml.equal(H1, H3)
     (True, False)
 

--- a/tests/ops/functions/test_equal.py
+++ b/tests/ops/functions/test_equal.py
@@ -969,9 +969,13 @@ class TestEqual:
             check_interface=False,
         )
 
-    def test_equal_with_different_arithmetic_depth(self):
-        """Test equal method with two operators with different arithmetic depth."""
-        assert not qml.equal(qml.adjoint(qml.PauliX(0)), qml.adjoint(qml.adjoint(qml.PauliX(0))))
+    def test_equal_with_symbolicops_raises_error(self):
+        """Test equal method comparing two SymbolicOps raises an error."""
+        with pytest.raises(
+            NotImplementedError,
+            match="Comparison between SymbolicOps not implemented. Received Adjoint(PauliX(wires=[0])) and Adjoint(PauliX(wires=[0])).",
+        ):
+            qml.equal(qml.adjoint(qml.PauliX(0)), qml.adjoint(qml.adjoint(qml.PauliX(0))))
 
     def test_equal_with_nested_operators_raises_error(self):
         """Test that the equal method with two operators with the same arithmetic depth (>0) raises


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      test directory!

- [x] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `doc/releases/changelog-dev.md` file, summarizing the
      change, and including a link back to the PR.

- [x] The PennyLane source code conforms to
      [PEP8 standards](https://www.python.org/dev/peps/pep-0008/).
      We check all of our code against [Pylint](https://www.pylint.org/).
      To lint modified files, simply `pip install pylint`, and then
      run `pylint pennylane/path/to/file.py`.

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**

**Description of the Change:**

- Rearrange qml.equal to use `singledispatch` to replace conditional logic
- Add comparison between Observables/Tensors/Hamiltonians, based on Hamiltonian.compare function

**Benefits:**

- Moves some nested/conditional logic out of the function and into singledispatch
- Enables qml.equal to compare Observables - comparing Hamiltonians, comparing a Hamiltonian to a Tensor, etc.

**Possible Drawbacks:**

- using `singledispatch` makes the green function box at the top of the docs page ugly
- The `functools singledispatch` only looks at the type of one argument. This is almost always fine, because generally we want to compare things where `op1` and `op2` are of the same type, but specifically for comparing `PauliX`, `PauliY`, and `PauliZ`, this adds a slight complication. We want these operators to be treated as `Operations` when comparing to an `Operation`, and `Observable` when comparing to an `Observable`.
- Comparison between SymbolicOps or CompositeOps are not implemented.
- There's a bit of asymmetry in what options are available depending on what the user is comparing. The inconsistencies in how closely the same function compares different objects could create some confusion.
    - For example: you can specify that you want to ignore trainability or interface when comparing Operations, but not when comparing Observables. 
    - Another example: it is much better able to compare Hamiltonians in different forms than Hermitians in different forms:
    
```
>>>H = qml.Hamiltonian( [0.5, 0.5], [qml.PauliZ(0) @ qml.PauliY(1), qml.PauliY(1) @ qml.PauliZ(0) @ qml.Identity("a")])
>>>obs = qml.PauliZ(0) @ qml.PauliY(1)
>>>qml.equal(H1, obs)
True

>>>A = np.array([[1, 0], [0, -1]])
>>>B = np.array([[1., 0], [0, -1.]])
>>>qml.equal(qml.Hermitian(A, 0), qml.Hermitian(B, 0)
False
```


**Related GitHub Issues:**
