### PR TITLE
Add python 3.11 classification

### DIFF
--- a/doc/releases/changelog-0.27.0.md
+++ b/doc/releases/changelog-0.27.0.md
@@ -370,6 +370,7 @@
 <h3>Improvements</h3>
 
 * Adds a Python 3.11 classification to the PennyLane package.
+  [(#3297)](https://github.com/PennyLaneAI/pennylane/pull/3297)
 
 * Added a `samples_computational_basis` attribute to the `MeasurementProcess` and `QuantumScript` classes to track if computational basis samples are being generated when `qml.sample` or `qml.counts` are called without specifying an observable.
   [(#3207)](https://github.com/PennyLaneAI/pennylane/pull/3207)

--- a/doc/releases/changelog-0.27.0.md
+++ b/doc/releases/changelog-0.27.0.md
@@ -369,6 +369,8 @@
 
 <h3>Improvements</h3>
 
+* Adds a Python 3.11 classification to the PennyLane package.
+
 * Added a `samples_computational_basis` attribute to the `MeasurementProcess` and `QuantumScript` classes to track if computational basis samples are being generated when `qml.sample` or `qml.counts` are called without specifying an observable.
   [(#3207)](https://github.com/PennyLaneAI/pennylane/pull/3207)
 

--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Scientific/Engineering :: Physics",
 ]


### PR DESCRIPTION
This PR merely adds the "Python 3.11" classification to the PennyLane package for the 0.27 release.  Adding CI checks to master will occur in #3276 .  This PR has not yet been merged due to optional requirements that do not have Python 3.11 support yet, like tensorflow, torch at the currently pinned version, and cvxpy. These should not be blockers for adding the classification to the core package.