### PR TITLE
Support `qml.probs()`. Raise error when `qml.probs(wires=[])`.

### DIFF
--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -760,8 +760,9 @@ class QubitDevice(Device):
             elif obs.return_type is Probability:
                 # Appends a result of shape (2**len(obs.wires), num_bins,)
                 # if bin_size is not None else (2**len(obs.wires),)
+                wires = obs.wires or self.wires
                 results.append(
-                    self.probability(wires=obs.wires, shot_range=shot_range, bin_size=bin_size)
+                    self.probability(wires=wires, shot_range=shot_range, bin_size=bin_size)
                 )
 
             elif obs.return_type is State:

--- a/pennylane/measurements/measurements.py
+++ b/pennylane/measurements/measurements.py
@@ -148,7 +148,7 @@ class MeasurementProcess:
             if obs is not None:
                 raise ValueError("Cannot set the wires if an observable is provided.")
 
-        self._wires = wires or Wires([])
+        self._wires = wires
         self._eigvals = None
 
         if eigvals is not None:
@@ -528,7 +528,9 @@ class MeasurementProcess:
         if self.obs is not None:
             return self.obs.wires
 
-        return Wires.all_wires(self._wires) if isinstance(self._wires, list) else self._wires
+        wires = self._wires or Wires([])
+
+        return Wires.all_wires(wires) if isinstance(wires, list) else wires
 
     @property
     def raw_wires(self):

--- a/pennylane/measurements/measurements.py
+++ b/pennylane/measurements/measurements.py
@@ -142,8 +142,11 @@ class MeasurementProcess:
         self.id = id
         self.log_base = log_base
 
-        if wires is not None and obs is not None:
-            raise ValueError("Cannot set the wires if an observable is provided.")
+        if wires is not None:
+            if len(wires) == 0:
+                raise ValueError("Cannot set an empty list of wires.")
+            if obs is not None:
+                raise ValueError("Cannot set the wires if an observable is provided.")
 
         self._wires = wires or Wires([])
         self._eigvals = None

--- a/pennylane/measurements/probs.py
+++ b/pennylane/measurements/probs.py
@@ -34,6 +34,9 @@ def probs(wires=None, op=None):
     the wires to a subset of the full system; the size of the
     returned array will be ``[2**len(wires)]``.
 
+    .. Note::
+        If no wires nor observable are given, the probabilities of all wires is returned.
+
     **Example:**
 
     .. code-block:: python3
@@ -84,11 +87,6 @@ def probs(wires=None, op=None):
     """
     # pylint: disable=protected-access
 
-    if wires is None and op is None:
-        raise qml.QuantumFunctionError(
-            "qml.probs requires either the wires or the observable to be passed."
-        )
-
     if isinstance(op, qml.Hamiltonian):
         raise qml.QuantumFunctionError("Hamiltonians are not supported for rotating probabilities.")
 
@@ -108,5 +106,6 @@ def probs(wires=None, op=None):
                 "Cannot specify the wires to probs if an observable is "
                 "provided. The wires for probs will be determined directly from the observable."
             )
-        return MeasurementProcess(Probability, wires=qml.wires.Wires(wires))
-    return MeasurementProcess(Probability, obs=op)
+        wires = qml.wires.Wires(wires)
+
+    return MeasurementProcess(Probability, obs=op, wires=wires)

--- a/tests/measurements/test_counts.py
+++ b/tests/measurements/test_counts.py
@@ -411,3 +411,20 @@ class TestCounts:
         assert len(res[0]) == 10
         assert res[1] == {"00": 10}
         assert res[2] == {"00": 10, "01": 0, "10": 0, "11": 0}
+
+    def test_counts_empty_wires(self):
+        """Test that using ``qml.counts`` with an empty wire list raises an error."""
+        with pytest.raises(ValueError, match="Cannot set an empty list of wires."):
+            qml.counts(wires=[])
+
+    def test_counts_no_arguments(self):
+        """Test that using ``qml.counts`` with no arguments returns the counts of all wires."""
+        dev = qml.device("default.qubit", wires=3, shots=100)
+
+        @qml.qnode(dev)
+        def circuit():
+            return qml.counts()
+
+        res = circuit()
+
+        assert qml.math.allequal(res, {"000": 100})

--- a/tests/measurements/test_probs.py
+++ b/tests/measurements/test_probs.py
@@ -69,3 +69,20 @@ class TestProbs:
         meas_proc = q.queue[0]
         assert isinstance(meas_proc, MeasurementProcess)
         assert meas_proc.return_type == Probability
+
+    def test_probs_empty_wires(self):
+        """Test that using ``qml.probs`` with an empty wire list raises an error."""
+        with pytest.raises(ValueError, match="Cannot set an empty list of wires."):
+            qml.probs(wires=[])
+
+    def test_probs_no_arguments(self):
+        """Test that using ``qml.probs`` with no arguments returns the probabilities of all wires."""
+        dev = qml.device("default.qubit", wires=3)
+
+        @qml.qnode(dev)
+        def circuit():
+            return qml.probs()
+
+        res = circuit()
+
+        assert qml.math.allequal(res, [1, 0, 0, 0, 0, 0, 0, 0])

--- a/tests/measurements/test_sample.py
+++ b/tests/measurements/test_sample.py
@@ -289,3 +289,20 @@ class TestSample:
         assert isinstance(binned_samples, tuple)
         assert len(binned_samples) == len(shot_vec)
         assert binned_samples[0].shape == (shot_vec[0],)
+
+    def test_counts_empty_wires(self):
+        """Test that using ``qml.sample`` with an empty wire list raises an error."""
+        with pytest.raises(ValueError, match="Cannot set an empty list of wires."):
+            qml.sample(wires=[])
+
+    def test_counts_no_arguments(self):
+        """Test that using ``qml.sample`` with no arguments returns the counts of all wires."""
+        dev = qml.device("default.qubit", wires=3, shots=100)
+
+        @qml.qnode(dev)
+        def circuit():
+            return qml.sample()
+
+        res = circuit()
+
+        assert res.shape == (100, 3)


### PR DESCRIPTION
Nothing else to add :)