### PR TITLE
Introduce a Dataset repr

### DIFF
--- a/doc/introduction/data.rst
+++ b/doc/introduction/data.rst
@@ -28,7 +28,7 @@ The :func:`~pennylane.data.load` function returns a ``list`` with the desired da
 
 >>> H2datasets = qml.data.load("qchem", molname="H2", basis="STO-3G", bondlength=1.1)
 >>> print(H2datasets)
-[<pennylane.data.dataset.Dataset object at 0x7f14e4369640>]
+[<Dataset = data name: qchem, description: H2/STO-3G/1.1, attributes: ['molecule', 'hamiltonian', ...]>]
 >>> H2data = H2datasets[0]
 
 When we only want to download portions of a large dataset, we can specify the desired properties  (referred to as `attributes`).

--- a/doc/introduction/data.rst
+++ b/doc/introduction/data.rst
@@ -28,7 +28,7 @@ The :func:`~pennylane.data.load` function returns a ``list`` with the desired da
 
 >>> H2datasets = qml.data.load("qchem", molname="H2", basis="STO-3G", bondlength=1.1)
 >>> print(H2datasets)
-[<Dataset = data name: qchem, description: H2/STO-3G/1.1, attributes: ['molecule', 'hamiltonian', ...]>]
+[<Dataset = description: qchem/H2/STO-3G/1.1, attributes: ['molecule', 'hamiltonian', ...]>]
 >>> H2data = H2datasets[0]
 
 We can load multiple parameter values at once by providing a list of values instead of only a single value.
@@ -36,10 +36,10 @@ To load all possible values, use the special keyword "full".
 
 >>> H2datasets = qml.data.load("qchem", molname="H2", basis="full", bondlength=[0.5, 1.1])
 >>> print(H2datasets)
-[<Dataset = data name: qchem, description: H2/6-31G/0.5, attributes: ['molecule', 'hamiltonian', ...]>,
- <Dataset = data name: qchem, description: H2/6-31G/1.1, attributes: ['molecule', 'hamiltonian', ...]>,
- <Dataset = data name: qchem, description: H2/STO-3G/0.5, attributes: ['molecule', 'hamiltonian', ...]>,
- <Dataset = data name: qchem, description: H2/STO-3G/1.1, attributes: ['molecule', 'hamiltonian', ...]>]
+[<Dataset = description: qchem/H2/6-31G/0.5, attributes: ['molecule', 'hamiltonian', ...]>,
+ <Dataset = description: qchem/H2/6-31G/1.1, attributes: ['molecule', 'hamiltonian', ...]>,
+ <Dataset = description: qchem/H2/STO-3G/0.5, attributes: ['molecule', 'hamiltonian', ...]>,
+ <Dataset = description: qchem/H2/STO-3G/1.1, attributes: ['molecule', 'hamiltonian', ...]>]
 
 When we only want to download portions of a large dataset, we can specify the desired properties  (referred to as `attributes`).
 For example, we can download or load only the molecule and energy of a dataset as follows:

--- a/doc/introduction/data.rst
+++ b/doc/introduction/data.rst
@@ -31,7 +31,7 @@ The :func:`~pennylane.data.load` function returns a ``list`` with the desired da
 [<Dataset = description: qchem/H2/STO-3G/1.1, attributes: ['molecule', 'hamiltonian', ...]>]
 >>> H2data = H2datasets[0]
 
-We can load multiple parameter values at once by providing a list of values instead of only a single value.
+We can load datasets for multiple parameter values by providing a list of values instead of a single value.
 To load all possible values, use the special keyword "full".
 
 >>> multiple_datasets = qml.data.load("qchem", molname="H2", basis="full", bondlength=[0.5, 1.1])

--- a/doc/introduction/data.rst
+++ b/doc/introduction/data.rst
@@ -34,8 +34,8 @@ The :func:`~pennylane.data.load` function returns a ``list`` with the desired da
 We can load datasets for multiple parameter values by providing a list of values instead of a single value.
 To load all possible values, use the special keyword "full".
 
->>> multiple_datasets = qml.data.load("qchem", molname="H2", basis="full", bondlength=[0.5, 1.1])
->>> print(multiple_datasets)
+>>> H2datasets = qml.data.load("qchem", molname="H2", basis="full", bondlength=[0.5, 1.1])
+>>> print(H2datasets)
 [<Dataset = description: qchem/H2/6-31G/0.5, attributes: ['molecule', 'hamiltonian', ...]>,
  <Dataset = description: qchem/H2/6-31G/1.1, attributes: ['molecule', 'hamiltonian', ...]>,
  <Dataset = description: qchem/H2/STO-3G/0.5, attributes: ['molecule', 'hamiltonian', ...]>,

--- a/doc/introduction/data.rst
+++ b/doc/introduction/data.rst
@@ -31,6 +31,16 @@ The :func:`~pennylane.data.load` function returns a ``list`` with the desired da
 [<Dataset = data name: qchem, description: H2/STO-3G/1.1, attributes: ['molecule', 'hamiltonian', ...]>]
 >>> H2data = H2datasets[0]
 
+We can load multiple parameter values at once by providing a list of values instead of only a single value.
+To load all possible values, use the special keyword "full".
+
+>>> H2datasets = qml.data.load("qchem", molname="H2", basis="full", bondlength=[0.5, 1.1])
+>>> print(H2datasets)
+[<Dataset = data name: qchem, description: H2/6-31G/0.5, attributes: ['molecule', 'hamiltonian', ...]>,
+ <Dataset = data name: qchem, description: H2/6-31G/1.1, attributes: ['molecule', 'hamiltonian', ...]>,
+ <Dataset = data name: qchem, description: H2/STO-3G/0.5, attributes: ['molecule', 'hamiltonian', ...]>,
+ <Dataset = data name: qchem, description: H2/STO-3G/1.1, attributes: ['molecule', 'hamiltonian', ...]>]
+
 When we only want to download portions of a large dataset, we can specify the desired properties  (referred to as `attributes`).
 For example, we can download or load only the molecule and energy of a dataset as follows:
 
@@ -50,6 +60,10 @@ To determine what attributes are available for a type of dataset, we can use the
 ...
 "tapered_hamiltonian",
 "full"]
+
+.. note::
+
+    "full" is the default value for ``attributes``, and it means that all available attributes for the Dataset will be downloaded.
 
 Using Datasets in PennyLane
 ---------------------------

--- a/doc/introduction/data.rst
+++ b/doc/introduction/data.rst
@@ -34,8 +34,8 @@ The :func:`~pennylane.data.load` function returns a ``list`` with the desired da
 We can load multiple parameter values at once by providing a list of values instead of only a single value.
 To load all possible values, use the special keyword "full".
 
->>> H2datasets = qml.data.load("qchem", molname="H2", basis="full", bondlength=[0.5, 1.1])
->>> print(H2datasets)
+>>> multiple_datasets = qml.data.load("qchem", molname="H2", basis="full", bondlength=[0.5, 1.1])
+>>> print(multiple_datasets)
 [<Dataset = description: qchem/H2/6-31G/0.5, attributes: ['molecule', 'hamiltonian', ...]>,
  <Dataset = description: qchem/H2/6-31G/1.1, attributes: ['molecule', 'hamiltonian', ...]>,
  <Dataset = description: qchem/H2/STO-3G/0.5, attributes: ['molecule', 'hamiltonian', ...]>,
@@ -70,9 +70,9 @@ Using Datasets in PennyLane
 
 Once loaded, one can access properties of the datasets:
 
->>> H2_dataset.molecule
+>>> H2data.molecule
 <pennylane.qchem.molecule.Molecule object at 0x7f890b409280>
->>> print(H2_dataset.hf_state)
+>>> print(H2data.hf_state)
 [1 1 0 0]
 
 The loaded data items are fully compatible with PennyLane. We can therefore
@@ -81,10 +81,10 @@ use them directly in a PennyLane circuits as follows:
 >>> dev = qml.device("default.qubit",wires=4)
 >>> @qml.qnode(dev)
 ... def circuit():
-...     qml.BasisState(H2_dataset.hf_state, wires = [0, 1, 2, 3])
-...     for op in H2_dataset.vqe_gates:
+...     qml.BasisState(H2data.hf_state, wires = [0, 1, 2, 3])
+...     for op in H2data.vqe_gates:
 ...         qml.apply(op)
-...     return qml.expval(H2_dataset.hamiltonian)
+...     return qml.expval(H2data.hamiltonian)
 >>> print(circuit())
 -1.0791430411076344
 

--- a/doc/releases/changelog-0.27.0.md
+++ b/doc/releases/changelog-0.27.0.md
@@ -327,10 +327,10 @@
   >>> dev = qml.device("default.qubit",wires=4)
   >>> @qml.qnode(dev)
   ... def circuit():
-  ...     qml.BasisState(H2_dataset.hf_state, wires = [0, 1, 2, 3])
-  ...     for op in H2_dataset.vqe_gates:
+  ...     qml.BasisState(H2data.hf_state, wires = [0, 1, 2, 3])
+  ...     for op in H2data.vqe_gates:
   ...         qml.apply(op)
-  ...     return qml.expval(H2_dataset.hamiltonian)
+  ...     return qml.expval(H2data.hamiltonian)
   >>> print(circuit())
   -1.0791430411076344
   ```

--- a/doc/releases/changelog-0.27.0.md
+++ b/doc/releases/changelog-0.27.0.md
@@ -250,7 +250,7 @@
   ```pycon
   >>> H2datasets = qml.data.load("qchem", molname="H2", basis="STO-3G", bondlength=1.1)
   >>> print(H2datasets)
-  [<Dataset = description: qchem/H2/STO-3G/1.1, attributes: ['molecule', 'hamiltonian', ...]>]
+  [<pennylane.data.dataset.Dataset object at 0x7f14e4369640>]
   >>> H2data = H2datasets[0]
   ```
 
@@ -318,7 +318,7 @@
           force: False
           dest folder: /Users/jovyan/Downloads/datasets
           Would you like to continue? (Default is yes) [Y/n]:
-          <Dataset = description: qspin/Ising/open/rectangular/4x4, attributes: ['parameters', 'ground_states']>
+          <pennylane.data.dataset.Dataset object at 0x10157ab50>
     ```
 
 * Once loaded, properties of a dataset can be accessed easily as follows:
@@ -327,10 +327,10 @@
   >>> dev = qml.device("default.qubit",wires=4)
   >>> @qml.qnode(dev)
   ... def circuit():
-  ...     qml.BasisState(H2data.hf_state, wires = [0, 1, 2, 3])
-  ...     for op in H2data.vqe_gates:
+  ...     qml.BasisState(H2_dataset.hf_state, wires = [0, 1, 2, 3])
+  ...     for op in H2_dataset.vqe_gates:
   ...         qml.apply(op)
-  ...     return qml.expval(H2data.hamiltonian)
+  ...     return qml.expval(H2_dataset.hamiltonian)
   >>> print(circuit())
   -1.0791430411076344
   ```

--- a/doc/releases/changelog-0.27.0.md
+++ b/doc/releases/changelog-0.27.0.md
@@ -250,7 +250,7 @@
   ```pycon
   >>> H2datasets = qml.data.load("qchem", molname="H2", basis="STO-3G", bondlength=1.1)
   >>> print(H2datasets)
-  [<pennylane.data.dataset.Dataset object at 0x7f14e4369640>]
+  [<Dataset = data name: qchem, description: H2/STO-3G/1.1, attributes: ['molecule', 'hamiltonian', ...]>]
   >>> H2data = H2datasets[0]
   ```
 
@@ -318,7 +318,7 @@
           force: False
           dest folder: /Users/jovyan/Downloads/datasets
           Would you like to continue? (Default is yes) [Y/n]:
-          <pennylane.data.dataset.Dataset object at 0x10157ab50>
+          <Dataset = data name: qspin, description: Ising/open/rectangular/4x4, attributes: ['parameters', 'ground_states']>
     ```
 
 * Once loaded, properties of a dataset can be accessed easily as follows:

--- a/doc/releases/changelog-0.27.0.md
+++ b/doc/releases/changelog-0.27.0.md
@@ -250,7 +250,7 @@
   ```pycon
   >>> H2datasets = qml.data.load("qchem", molname="H2", basis="STO-3G", bondlength=1.1)
   >>> print(H2datasets)
-  [<Dataset = data name: qchem, description: H2/STO-3G/1.1, attributes: ['molecule', 'hamiltonian', ...]>]
+  [<Dataset = description: qchem/H2/STO-3G/1.1, attributes: ['molecule', 'hamiltonian', ...]>]
   >>> H2data = H2datasets[0]
   ```
 
@@ -318,7 +318,7 @@
           force: False
           dest folder: /Users/jovyan/Downloads/datasets
           Would you like to continue? (Default is yes) [Y/n]:
-          <Dataset = data name: qspin, description: Ising/open/rectangular/4x4, attributes: ['parameters', 'ground_states']>
+          <Dataset = description: qspin/Ising/open/rectangular/4x4, attributes: ['parameters', 'ground_states']>
     ```
 
 * Once loaded, properties of a dataset can be accessed easily as follows:

--- a/pennylane/data/data_manager.py
+++ b/pennylane/data/data_manager.py
@@ -392,7 +392,7 @@ def load_interactive():
         force: False
         dest folder: /Users/jovyan/Downloads/datasets
         Would you like to continue? (Default is yes) [Y/n]:
-        <Dataset = data name: qspin, description: Ising/open/rectangular/4x4, attributes: ['parameters', 'ground_states']>
+        <Dataset = description: qspin/Ising/open/rectangular/4x4, attributes: ['parameters', 'ground_states']>
     """
 
     _refresh_foldermap()

--- a/pennylane/data/data_manager.py
+++ b/pennylane/data/data_manager.py
@@ -392,7 +392,7 @@ def load_interactive():
         force: False
         dest folder: /Users/jovyan/Downloads/datasets
         Would you like to continue? (Default is yes) [Y/n]:
-        <pennylane.data.dataset.Dataset object at 0x10157ab50>
+        <Dataset = data name: qspin, description: Ising/open/rectangular/4x4, attributes: ['parameters', 'ground_states']>
     """
 
     _refresh_foldermap()

--- a/pennylane/data/dataset.py
+++ b/pennylane/data/dataset.py
@@ -109,7 +109,7 @@ class Dataset(ABC):
         self._folder = folder.rstrip("/")
         self._prefix = os.path.join(self._folder, attr_prefix) + "_{}.dat"
         self._prefix_len = len(attr_prefix) + 1
-        self._description = self._folder.split(data_name)[-1][1:]
+        self._description = os.path.join(data_name, self._folder.split(data_name)[-1][1:])
         self.__doc__ = docstring
 
         self._fullfile = self._prefix.format("full")
@@ -146,11 +146,7 @@ class Dataset(ABC):
             if len(self.attrs) < 3
             else str(list(self.attrs)[:2])[:-1] + ", ...]"
         )
-        std_str = (
-            f"data name: {self._dtype}, description: {self._description}, "
-            if self._is_standard
-            else ""
-        )
+        std_str = f"description: {self._description}, " if self._is_standard else ""
         return f"<Dataset = {std_str}attributes: {attr_str}>"
 
     @property

--- a/pennylane/data/dataset.py
+++ b/pennylane/data/dataset.py
@@ -37,6 +37,7 @@ def _import_zstd_dill():
     return zstd, dill
 
 
+# pylint: disable=too-many-instance-attributes
 class Dataset(ABC):
     """Create a dataset object to store a collection of information describing
     a physical system and its evolution. For example, a dataset for an arbitrary
@@ -140,8 +141,16 @@ class Dataset(ABC):
             self.__base_init__(**kwargs)
 
     def __repr__(self):
-        attr_str = str(list(self.attrs)) if len(self.attrs) < 3 else str(list(self.attrs)[:2])[:-1] + ", ...]"
-        std_str = f"data name: {self._dtype}, description: {self._description}, " if self._is_standard else ""
+        attr_str = (
+            str(list(self.attrs))
+            if len(self.attrs) < 3
+            else str(list(self.attrs)[:2])[:-1] + ", ...]"
+        )
+        std_str = (
+            f"data name: {self._dtype}, description: {self._description}, "
+            if self._is_standard
+            else ""
+        )
         return f"<Dataset = {std_str}attributes: {attr_str}>"
 
     @property

--- a/pennylane/data/dataset.py
+++ b/pennylane/data/dataset.py
@@ -108,6 +108,7 @@ class Dataset(ABC):
         self._folder = folder.rstrip("/")
         self._prefix = os.path.join(self._folder, attr_prefix) + "_{}.dat"
         self._prefix_len = len(attr_prefix) + 1
+        self._description = self._folder.split(data_name)[-1][1:]
         self.__doc__ = docstring
 
         self._fullfile = self._prefix.format("full")
@@ -137,6 +138,11 @@ class Dataset(ABC):
         else:
             self._is_standard = False
             self.__base_init__(**kwargs)
+
+    def __repr__(self):
+        attr_str = str(list(self.attrs)) if len(self.attrs) < 3 else str(list(self.attrs)[:2])[:-1] + ", ...]"
+        std_str = f"data name: {self._dtype}, description: {self._description}, " if self._is_standard else ""
+        return f"<Dataset = {std_str}attributes: {attr_str}>"
 
     @property
     def attrs(self):

--- a/tests/data/test_dataset.py
+++ b/tests/data/test_dataset.py
@@ -222,13 +222,13 @@ def test_repr_standard(tmp_path):
     dataset = qml.data.Dataset("qchem", str(folder), "H2_STO-3G_1.02", "", standard=True)
     assert (
         repr(dataset)
-        == "<Dataset = data name: qchem, description: H2/STO-3G/1.02, attributes: ['molecule', 'hf_state']>"
+        == "<Dataset = description: qchem/H2/STO-3G/1.02, attributes: ['molecule', 'hf_state']>"
     )
 
     dataset.vqe_energy = 1.1
     assert (
         repr(dataset)
-        == "<Dataset = data name: qchem, description: H2/STO-3G/1.02, attributes: ['molecule', 'hf_state', ...]>"
+        == "<Dataset = description: qchem/H2/STO-3G/1.02, attributes: ['molecule', 'hf_state', ...]>"
     )
 
 

--- a/tests/data/test_dataset.py
+++ b/tests/data/test_dataset.py
@@ -215,13 +215,22 @@ def test_repr_standard(tmp_path):
     """Test that __repr__ for standard Datasets look as expected."""
     folder = tmp_path / "qchem" / "H2" / "STO-3G" / "1.02"
     os.makedirs(folder)
-    qml.data.Dataset._write_file({"molecule": 1, "hf_state": 2}, str(folder / "H2_STO-3G_1.02_full.dat"))
+    qml.data.Dataset._write_file(
+        {"molecule": 1, "hf_state": 2}, str(folder / "H2_STO-3G_1.02_full.dat")
+    )
 
     dataset = qml.data.Dataset("qchem", str(folder), "H2_STO-3G_1.02", "", standard=True)
-    assert repr(dataset) == "<Dataset = data name: qchem, description: H2/STO-3G/1.02, attributes: ['molecule', 'hf_state']>"
+    assert (
+        repr(dataset)
+        == "<Dataset = data name: qchem, description: H2/STO-3G/1.02, attributes: ['molecule', 'hf_state']>"
+    )
 
     dataset.vqe_energy = 1.1
-    assert repr(dataset) == "<Dataset = data name: qchem, description: H2/STO-3G/1.02, attributes: ['molecule', 'hf_state', ...]>"
+    assert (
+        repr(dataset)
+        == "<Dataset = data name: qchem, description: H2/STO-3G/1.02, attributes: ['molecule', 'hf_state', ...]>"
+    )
+
 
 def test_repr_non_standard():
     """Test that __repr__ for non-standard Datasets look as expected."""

--- a/tests/data/test_dataset.py
+++ b/tests/data/test_dataset.py
@@ -209,3 +209,24 @@ def test_import_zstd_dill(monkeypatch):
 
         with pytest.raises(ImportError, match="This feature requires zstd and dill"):
             qml.data.dataset._import_zstd_dill()
+
+
+def test_repr_standard(tmp_path):
+    """Test that __repr__ for standard Datasets look as expected."""
+    folder = tmp_path / "qchem" / "H2" / "STO-3G" / "1.02"
+    os.makedirs(folder)
+    qml.data.Dataset._write_file({"molecule": 1, "hf_state": 2}, str(folder / "H2_STO-3G_1.02_full.dat"))
+
+    dataset = qml.data.Dataset("qchem", str(folder), "H2_STO-3G_1.02", "", standard=True)
+    assert repr(dataset) == "<Dataset = data name: qchem, description: H2/STO-3G/1.02, attributes: ['molecule', 'hf_state']>"
+
+    dataset.vqe_energy = 1.1
+    assert repr(dataset) == "<Dataset = data name: qchem, description: H2/STO-3G/1.02, attributes: ['molecule', 'hf_state', ...]>"
+
+def test_repr_non_standard():
+    """Test that __repr__ for non-standard Datasets look as expected."""
+    dataset = qml.data.Dataset(foo=1, bar=2)
+    assert repr(dataset) == "<Dataset = attributes: ['foo', 'bar']>"
+
+    dataset.baz = 3
+    assert repr(dataset) == "<Dataset = attributes: ['foo', 'bar', ...]>"


### PR DESCRIPTION
**Context:**
The Dataset class is the core of the new data module being introduced in 0.27. While it is functional and complete, the repr is rather ugly. It will be heavily featured in documentation, so it should be improved before we announce this new offering.

**Description of the Change:**
Introduce a `__repr__` for the Dataset class. Below are example standard and non-standard reprs:
```pycon
>>> qml.data.load('qchem', molname='H2', basis='STO-3G', bondlength=0.74)[0]
<Dataset = data name: qchem, description: H2/STO-3G/0.74, attributes: ['molecule', 'hamiltonian', ...]>
>>> qml.data.Dataset(foo=3, bar=4, baz=5)
<Dataset = attributes: ['foo', 'bar', ...]>
```

**Benefits:**
- The return value from `qml.data.load` and `qml.data.Dataset` will be beautiful
- The docs/demos for the datasets project will be beautiful

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
N/A