### PR TITLE
fix get interface doc string

### DIFF
--- a/doc/releases/changelog-0.27.0.md
+++ b/doc/releases/changelog-0.27.0.md
@@ -553,6 +553,15 @@
   'torch'
   ```
 
+  Note that when passing lists or tuples of without unpacking them, ``get_interface`` will always default to ``"numpy"``.
+
+  ```pycon
+  >>> qml.math.get_interface([torch_scalar, torch_tensor, numpy_tensor])
+  'numpy'
+  ```
+  
+
+
 * `qml.drawer.draw.draw_mpl` now accepts a `style` kwarg to select a style for plotting, rather than calling
   `qml.drawer.use_style(style)` before plotting. Setting a style for `draw_mpl` does not change the global
   configuration for matplotlib plotting. If no `style` is passed, the function defaults

--- a/doc/releases/changelog-0.27.0.md
+++ b/doc/releases/changelog-0.27.0.md
@@ -675,7 +675,7 @@ Lillian M. A. Frederiksen,
 Diego Guala,
 Soran Jahangiri,
 Edward Jiang,
-Korbinian Kottmann
+Korbinian Kottmann,
 Christina Lee,
 Lee J. O'Riordan,
 Mudit Pandey,

--- a/doc/releases/changelog-0.27.0.md
+++ b/doc/releases/changelog-0.27.0.md
@@ -675,6 +675,7 @@ Lillian M. A. Frederiksen,
 Diego Guala,
 Soran Jahangiri,
 Edward Jiang,
+Korbinian Kottmann
 Christina Lee,
 Lee J. O'Riordan,
 Mudit Pandey,

--- a/doc/releases/changelog-0.27.0.md
+++ b/doc/releases/changelog-0.27.0.md
@@ -553,7 +553,7 @@
   'torch'
   ```
 
-  Note that when passing lists or tuples of without unpacking them, ``get_interface`` will always default to ``"numpy"``.
+  Note that when passing lists or tuples without unpacking them, ``get_interface`` will always default to ``"numpy"``.
 
   ```pycon
   >>> qml.math.get_interface([torch_scalar, torch_tensor, numpy_tensor])

--- a/pennylane/math/utils.py
+++ b/pennylane/math/utils.py
@@ -196,7 +196,7 @@ def get_interface(*values):
     * Vanilla NumPy arrays and SciPy sparse matrices can be used alongside other tensor objects;
       they will always be treated as non-differentiable constants.
 
-    .. warning:: 
+    .. warning::
         ``get_interface`` defaults to ``"numpy"`` whenever Python built-in objects are passed.
         I.e. a list or tuple of ``torch`` tensors will be identified as ``"numpy"``:
 

--- a/pennylane/math/utils.py
+++ b/pennylane/math/utils.py
@@ -196,13 +196,15 @@ def get_interface(*values):
     * Vanilla NumPy arrays and SciPy sparse matrices can be used alongside other tensor objects;
       they will always be treated as non-differentiable constants.
 
-    .. warning: ``get_interface`` defaults to ``"numpy"`` whenever Python built-in objects are passed.
+    .. warning:: 
+        ``get_interface`` defaults to ``"numpy"`` whenever Python built-in objects are passed.
         I.e. a list or tuple of ``torch`` tensors will be identified as ``"numpy"``:
 
         >>> get_interface([torch.tensor([1]), torch.tensor([1])])
         "numpy"
 
         The correct usage in that case is to unpack the arguments ``get_interface(*[torch.tensor([1]), torch.tensor([1])])``.
+
     """
 
     if len(values) == 1:

--- a/pennylane/math/utils.py
+++ b/pennylane/math/utils.py
@@ -195,6 +195,14 @@ def get_interface(*values):
 
     * Vanilla NumPy arrays and SciPy sparse matrices can be used alongside other tensor objects;
       they will always be treated as non-differentiable constants.
+
+    .. warning: ``get_interface`` defaults to ``"numpy"`` whenever Python built-in objects are passed.
+        I.e. a list or tuple of ``torch`` tensors will be identified as ``"numpy"``: 
+        
+        >>> get_interface([torch.tensor([1]), torch.tensor([1])])
+        "numpy"
+
+        The correct usage in that case is to unpack the arguments ``get_interface(*[torch.tensor([1]), torch.tensor([1])])``.
     """
 
     if len(values) == 1:

--- a/pennylane/math/utils.py
+++ b/pennylane/math/utils.py
@@ -197,8 +197,8 @@ def get_interface(*values):
       they will always be treated as non-differentiable constants.
 
     .. warning: ``get_interface`` defaults to ``"numpy"`` whenever Python built-in objects are passed.
-        I.e. a list or tuple of ``torch`` tensors will be identified as ``"numpy"``: 
-        
+        I.e. a list or tuple of ``torch`` tensors will be identified as ``"numpy"``:
+
         >>> get_interface([torch.tensor([1]), torch.tensor([1])])
         "numpy"
 


### PR DESCRIPTION
Just a small fix. I think this is actually not new to `v0.27` but `get_interface` has been added extensively in https://github.com/PennyLaneAI/pennylane/pull/3136 so it is worth highlighting this behavior.