### PR TITLE
remove debugging prints in tests

### DIFF
--- a/tests/returntypes/test_jax_new.py
+++ b/tests/returntypes/test_jax_new.py
@@ -551,7 +551,6 @@ class TestJaxExecuteIntegration:
             result = execute(
                 tapes=[tape1, tape2], device=dev, interface=interface, **execute_kwargs
             )
-            print(result)
             return result[0] + result[1] - 7 * result[1]
 
         res = jax.grad(cost_fn)(params)
@@ -578,7 +577,6 @@ class TestJaxExecuteIntegration:
             return execute(tapes=[tape1, tape2], device=dev, interface=interface, **execute_kwargs)
 
         res = cost_fn(params)
-        print(res)
         assert isinstance(res, list)
         assert all(isinstance(r, jnp.ndarray) for r in res)
         assert all(r.shape == () for r in res)
@@ -670,7 +668,6 @@ class TestJaxExecuteIntegration:
                 qml.expval(qml.PauliZ(1))
 
             res = execute([tape], dev, cache=cache, interface=interface, **execute_kwargs)
-            print(res)
             return res[0]
 
         res = jax.grad(cost)(params, cache=None)

--- a/tests/returntypes/test_parameter_shift_shot_vec_new.py
+++ b/tests/returntypes/test_parameter_shift_shot_vec_new.py
@@ -2524,7 +2524,6 @@ class TestReturn:
     def test_1_1(self, shot_vec, meas, shape, op_wires):
         """Test one param one measurement case"""
         dev = qml.device("default.qubit", wires=3, shots=shot_vec)
-        print(dev._shot_vector, dev.shots)
         x = 0.543
 
         with qml.tape.QuantumTape() as tape:


### PR DESCRIPTION
Found a `print` statement in https://github.com/PennyLaneAI/pennylane/pull/3267/ that looks like a debugging relic.

Checked through search and found more print statements from new return types project, also fixed here.