### PR TITLE
Pauli rot bug fix

### DIFF
--- a/pennylane/ops/op_math/exp.py
+++ b/pennylane/ops/op_math/exp.py
@@ -23,6 +23,7 @@ from pennylane.operation import (
     DecompositionUndefinedError,
     expand_matrix,
     OperatorPropertyUndefined,
+    Tensor,
 )
 from pennylane.pauli import is_pauli_word, pauli_word_to_string
 from pennylane.wires import Wires
@@ -170,6 +171,14 @@ class Exp(SymbolicOp):
     # pylint: disable=arguments-renamed, invalid-overridden-method
     @property
     def has_decomposition(self):
+        if isinstance(self.base, Tensor):
+            all_wires = [obs.wires for obs in self.base.obs]
+            if len(all_wires) != len(set(all_wires)):
+                raise NotImplementedError(
+                    "Unable to determine if the exponential has a decomposition "
+                    "when the base operator is a Tensor object with overlapping wires. "
+                    f"Received base {self.base}."
+                )
         return math.real(self.coeff) == 0 and is_pauli_word(self.base)
 
     def decomposition(self):
@@ -184,7 +193,7 @@ class Exp(SymbolicOp):
         Returns:
             list[PauliRot]: decomposition of the operator
         """
-        if math.real(self.coeff) != 0 or not is_pauli_word(self.base):
+        if not self.has_decomposition:
             raise DecompositionUndefinedError
         new_coeff = math.real(2j * self.coeff)
         string_base = pauli_word_to_string(self.base)

--- a/tests/ops/op_math/test_exp.py
+++ b/tests/ops/op_math/test_exp.py
@@ -300,6 +300,8 @@ class TestDecomposition:
 
         with pytest.raises(NotImplementedError):
             op.has_decomposition()
+
+         with pytest.raises(NotImplementedError):
             op.decomposition()
 
     @pytest.mark.parametrize(

--- a/tests/ops/op_math/test_exp.py
+++ b/tests/ops/op_math/test_exp.py
@@ -280,16 +280,26 @@ class TestDecomposition:
     @pytest.mark.parametrize("coeff", (1, 1 + 0.5j))
     def test_non_imag_no_decomposition(self, coeff):
         """Tests that the decomposition doesn't exist if the coefficient has a real component."""
-        op = Exp(coeff, qml.PauliX(0))
+        op = Exp(qml.PauliX(0), coeff)
         assert not op.has_decomposition
         with pytest.raises(DecompositionUndefinedError):
             op.decomposition()
 
     def test_non_pauli_word_base_no_decomposition(self):
         """Tests that the decomposition doesn't exist if the base is not a pauli word."""
-        op = Exp(-0.5j, qml.S(0))
+        op = Exp(qml.S(0), -0.5j)
         assert not op.has_decomposition
         with pytest.raises(DecompositionUndefinedError):
+            op.decomposition()
+
+    def test_nontensor_tensor_raises_error(self):
+        """Checks that accessing the decomposition throws an error if the base is a Tensor
+        object that is not a mathematical tensor"""
+        base_op = qml.PauliX(0) @ qml.PauliZ(0)
+        op = Exp(base_op, 1j)
+
+        with pytest.raises(NotImplementedError):
+            op.has_decomposition()
             op.decomposition()
 
     @pytest.mark.parametrize(

--- a/tests/ops/op_math/test_exp.py
+++ b/tests/ops/op_math/test_exp.py
@@ -301,7 +301,7 @@ class TestDecomposition:
         with pytest.raises(NotImplementedError):
             op.has_decomposition()
 
-         with pytest.raises(NotImplementedError):
+        with pytest.raises(NotImplementedError):
             op.decomposition()
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
**Context:**
The `has_decomposition` and `decomposition` methods to decompose an `Exp` into `PauliRot` returns incorrect results if the base operator for the `Exp` is a Tensor object with multiple Pauli operators acting on the same wire, i.e. `qml.PauliX(0) @ qml.PauliY(0)`.

**Description of the Change:**
The `has_decomposition` method now includes a check for overlapping wires if the base observable is a Tensor object. It raises a NotImplementedError if there is overlap in the wires.