### PR TITLE
update is_pauli_word docstring

### DIFF
--- a/pennylane/pauli/utils.py
+++ b/pennylane/pauli/utils.py
@@ -62,7 +62,7 @@ def is_pauli_word(observable):
         This function will only confirm that all operators are Pauli or Identity operators,
         and not whether the Observable is mathematically a Pauli word.
         If an Observable consists of multiple Pauli operators targeting the same wire, the
-        function will return `True` regardless of any complex coeffients.
+        function will return ``True`` regardless of any complex coefficients.
 
 
     Args:

--- a/pennylane/pauli/utils.py
+++ b/pennylane/pauli/utils.py
@@ -55,7 +55,15 @@ def _wire_map_from_pauli_pair(pauli_word_1, pauli_word_2):
 
 def is_pauli_word(observable):
     """
-    Checks if an observable instance is a Pauli word.
+    Checks if an observable instance consists only of Pauli and Identity Operators.
+
+    .. Warning::
+
+        This function will only confirm that all operators are Pauli or Identity operators,
+        and not whether the Observable is mathematically a Pauli word.
+        If an Observable consists of multiple Pauli operators targeting the same wire, the
+        function will return `True` regardless of any complex coeffients.
+
 
     Args:
         observable (Observable): an observable, either a :class:`~.Tensor` instance or


### PR DESCRIPTION
**Context:**
is_pauli_word sounds like it checks if something is a Pauli word, but technically it just checks if all the operators are Pauli operators or Identity. 

**Description of the Change:**
Add a note in the docstring mentioning that this doesn't do what it sounds like it does.

**Related GitHub Issues:**
#3334
