### PR TITLE
Jax jit interface vesrion validation Windows

### DIFF
--- a/pennylane/interfaces/jax_jit.py
+++ b/pennylane/interfaces/jax_jit.py
@@ -38,19 +38,20 @@ def _validate_jax_version():
     and JAX lib.
     """
 
-    if platform.system() == "Windows":
-        jax_version_to_check = "<0.3.24"
-        jax_lib_version_to_check = "<0.3.22"
+    platform_used = platform.system()
+    if platform_used == "Windows":
+        jax_version_to_check = "0.3.24"
+        jax_lib_version_to_check = "0.3.22"
     else:
-        jax_version_to_check = "<0.3.17"
-        jax_lib_version_to_check = "<0.3.15"
+        jax_version_to_check = "0.3.17"
+        jax_lib_version_to_check = "0.3.15"
 
-    if semantic_version.match(jax_version_to_check, jax.__version__) or semantic_version.match(
-        jax_lib_version_to_check, jax.lib.__version__
-    ):
+    if semantic_version.match(
+        "<" + jax_version_to_check, jax.__version__
+    ) or semantic_version.match("<" + jax_lib_version_to_check, jax.lib.__version__):
         msg = (
-            "The JAX JIT interface of PennyLane requires version 0.3.17 or higher for JAX "
-            "and 0.3.15 or higher JAX lib. Please upgrade these packages."
+            f"The JAX JIT interface of PennyLane requires version {jax_version_to_check} or higher for JAX "
+            f"and {jax_lib_version_to_check} or higher JAX lib on {platform_used}. Please upgrade these packages."
         )
         raise InterfaceUnsupportedError(msg)
 

--- a/pennylane/interfaces/jax_jit.py
+++ b/pennylane/interfaces/jax_jit.py
@@ -16,12 +16,14 @@ This module contains functions for adding the JAX interface
 to a PennyLane Device class.
 """
 
+import platform
+
 # pylint: disable=too-many-arguments
 import jax
 import jax.numpy as jnp
-
 import numpy as np
 import semantic_version
+
 import pennylane as qml
 from pennylane.interfaces import InterfaceUnsupportedError
 from pennylane.interfaces.jax import _raise_vector_valued_fwd
@@ -30,8 +32,21 @@ dtype = jnp.float64
 
 
 def _validate_jax_version():
-    if semantic_version.match("<0.3.17", jax.__version__) or semantic_version.match(
-        "<0.3.15", jax.lib.__version__
+    """Validate the JAX version used.
+
+    The jax.pure_callback feature requires at least JAX version >=0.3.17. Windows requires even higher versions for JAX
+    and JAX lib.
+    """
+
+    if platform.system() == "Windows":
+        jax_version_to_check = "<0.3.24"
+        jax_lib_version_to_check = "<0.3.22"
+    else:
+        jax_version_to_check = "<0.3.17"
+        jax_lib_version_to_check = "<0.3.15"
+
+    if semantic_version.match(jax_version_to_check, jax.__version__) or semantic_version.match(
+        jax_lib_version_to_check, jax.lib.__version__
     ):
         msg = (
             "The JAX JIT interface of PennyLane requires version 0.3.17 or higher for JAX "


### PR DESCRIPTION
This PR extends the version validation of JAX and JAX lib because Windows seems to require higher version numbers for those packages.

```
error: 'mhlo.broadcast_in_dim' op requires the same element type for all operands and results
    return wrapped_exec(params)
```

Using
```
>>> import jax
>>> jax.__version__
'0.3.17'
>>> import jaxlib
>>> jaxlib.__version__
'0.3.17'
```
on Windows raises the above error.

Note that `platform.system()` was picked to gather the platform used (as [per this comment](https://stackoverflow.com/a/58071295/12899253)).