### PR TITLE
Add SPSA `gradient_transform`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -4,6 +4,25 @@
 
 <h3>New features since last release</h3>
 
+* New gradient transform `qml.gradients.spsa` based on the idea of SPSA.
+  [#3xxx](https://github.com/PennyLaneAI/pennylane/pull/3xxx)
+
+  This new transform allows to compute a single estimate of a quantum gradient
+  using simultaneous perturbation of parameters and a stochastic approximation.
+  Given some QNode `circuit` that takes, say, an argument `x`, the approximate
+  gradient can be computed via
+
+  >>> grad_fn = qml.gradients.spsa(circuit, h=0.1, num_samples=1
+  >>> grad = grad_fn(x)
+
+  The argument `num_samples` determines how many directions of simultaneous
+  perturbation are used and therefore the number of circuit evaluations, up
+  to a prefactor. See the
+  [spsa gradient transform documentation](
+  https://docs.pennylane.ai/en/stable/code/api/pennylane.gradients.spsa.html
+  ) for details.
+  Note: The full SPSA optimization method already is available as `SPSAOptimizer`.
+
 * New basis sets, `6-311g` and `CC-PVDZ`, are added to the qchem basis set repo.
   [#3279](https://github.com/PennyLaneAI/pennylane/pull/3279)
 
@@ -24,3 +43,5 @@
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):
+
+David Wierichs

--- a/pennylane/gradients/__init__.py
+++ b/pennylane/gradients/__init__.py
@@ -315,6 +315,7 @@ from . import parameter_shift
 from . import parameter_shift_cv
 from . import parameter_shift_hessian
 from . import finite_difference
+from . import spsa
 
 from .gradient_transform import gradient_transform
 from .hessian_transform import hessian_transform
@@ -324,6 +325,7 @@ from .parameter_shift_cv import param_shift_cv
 from .parameter_shift_hessian import param_shift_hessian
 from .vjp import compute_vjp, batch_vjp, vjp, compute_vjp_multi_new, compute_vjp_single_new
 from .jvp import batch_jvp, jvp, compute_jvp_multi, compute_jvp_single
+from .spsa import spsa
 
 from .hamiltonian_grad import hamiltonian_grad
 from .general_shift_rules import (

--- a/pennylane/gradients/gradient_transform.py
+++ b/pennylane/gradients/gradient_transform.py
@@ -46,11 +46,11 @@ def gradient_analysis(tape, use_graph=True, grad_fn=None):
             the cached gradient analysis will be used.
     """
     # pylint:disable=protected-access
-    if grad_fn is not None and getattr(tape, "_gradient_fn", None) is grad_fn:
-        # gradient analysis has already been performed on this tape
-        return
-
     if grad_fn is not None:
+        if getattr(tape, "_gradient_fn", None) is grad_fn:
+            # gradient analysis has already been performed on this tape
+            return
+
         tape._gradient_fn = grad_fn
 
     for idx, info in enumerate(tape._par_info):


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      test directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `doc/releases/changelog-dev.md` file, summarizing the
      change, and including a link back to the PR.

- [x] The PennyLane source code conforms to
      [PEP8 standards](https://www.python.org/dev/peps/pep-0008/).
      We check all of our code against [Pylint](https://www.pylint.org/).
      To lint modified files, simply `pip install pylint`, and then
      run `pylint pennylane/path/to/file.py`.

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
PennyLane has the `SPSAOptimizer`, but no separate method to compute the gradient alone based on the SPSA idea.

**Description of the Change:**
This PR adds the differentiation method SPSA, i.e a single estimation of a gradient via simultaneous perturbation of all parameters and stochastic approximation.

**Benefits:**
New differentiation method without having to use `SPSAOptimizer`.

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
N/A