### PR TITLE
batch transform occurs with the correct number of shots

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -23,6 +23,7 @@
 
 * If the device originally has no shots but finite shots are dynamically specified, Hamiltonian
   expansion now occurs.
+  [(#3369)](https://github.com/PennyLaneAI/pennylane/pull/3369)
 
 <h3>Contributors</h3>
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -21,6 +21,11 @@
   attributes were modified.
   [#3292](https://github.com/PennyLaneAI/pennylane/pull/3292)
 
+* If the device originally has no shots but finite shots are dynamically specified, Hamiltonian
+  expansion now occurs.
+
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):
+
+Christina Lee

--- a/pennylane/interfaces/execution.py
+++ b/pennylane/interfaces/execution.py
@@ -351,7 +351,8 @@ def _execute_new(
     gradient_kwargs = gradient_kwargs or {}
 
     if device_batch_transform:
-        tapes, batch_fn = qml.transforms.map_batch_transform(device.batch_transform, tapes)
+        dev_batch_transform = set_shots(device, override_shots)(device.batch_transform)
+        tapes, batch_fn = qml.transforms.map_batch_transform(dev_batch_transform, tapes)
     else:
         batch_fn = lambda res: res  # pragma: no cover
 
@@ -610,7 +611,8 @@ def execute(
     gradient_kwargs = gradient_kwargs or {}
 
     if device_batch_transform:
-        tapes, batch_fn = qml.transforms.map_batch_transform(device.batch_transform, tapes)
+        dev_batch_transform = set_shots(device, override_shots)(device.batch_transform)
+        tapes, batch_fn = qml.transforms.map_batch_transform(dev_batch_transform, tapes)
     else:
         batch_fn = lambda res: res
 

--- a/pennylane/interfaces/execution.py
+++ b/pennylane/interfaces/execution.py
@@ -238,7 +238,7 @@ def _execute_new(
     cache=True,
     cachesize=10000,
     max_diff=1,
-    override_shots=False,
+    override_shots: int = False,
     expand_fn="device",
     max_expansion=10,
     device_batch_transform=True,
@@ -271,6 +271,8 @@ def _execute_new(
             the maximum number of derivatives to support. Increasing this value allows
             for higher order derivatives to be extracted, at the cost of additional
             (classical) computational overhead during the backwards pass.
+        override_shots (int): The number of shots to use for the execution. If ``False``, then the
+            number of shots on the device is used.
         expand_fn (function): Tape expansion function to be called prior to device execution.
             Must have signature of the form ``expand_fn(tape, max_expansion)``, and return a
             single :class:`~.QuantumTape`. If not provided, by default :meth:`Device.expand_fn`
@@ -482,7 +484,7 @@ def execute(
     cache=True,
     cachesize=10000,
     max_diff=1,
-    override_shots=False,
+    override_shots: int = False,
     expand_fn="device",
     max_expansion=10,
     device_batch_transform=True,
@@ -514,6 +516,8 @@ def execute(
             the maximum number of derivatives to support. Increasing this value allows
             for higher order derivatives to be extracted, at the cost of additional
             (classical) computational overhead during the backwards pass.
+        override_shots (int): The number of shots to use for the execution. If ``False``, then the
+            number of shots on the device is used.
         expand_fn (function): Tape expansion function to be called prior to device execution.
             Must have signature of the form ``expand_fn(tape, max_expansion)``, and return a
             single :class:`~.QuantumTape`. If not provided, by default :meth:`Device.expand_fn`

--- a/tests/interfaces/test_autograd.py
+++ b/tests/interfaces/test_autograd.py
@@ -16,7 +16,6 @@ import sys
 
 import autograd
 import pytest
-import numpy as onp
 
 import pennylane as qml
 from pennylane import numpy as np

--- a/tests/interfaces/test_autograd.py
+++ b/tests/interfaces/test_autograd.py
@@ -16,6 +16,7 @@ import sys
 
 import autograd
 import pytest
+import numpy as onp
 
 import pennylane as qml
 from pennylane import numpy as np
@@ -209,6 +210,15 @@ class TestBatchTransformExecution:
         res = qml.execute([tape], dev, None, device_batch_transform=True)
         spy.assert_called()
         assert np.allclose(res[0], np.cos(y), atol=0.1)
+
+    def test_batch_transform_dynamic_shots(self):
+        """Tests that the batch transform considers the number of shots for the execution, not those
+        statically on the device."""
+        dev = qml.device("default.qubit", wires=1)
+        H = 2.0 * qml.PauliZ(0)
+        qscript = qml.tape.QuantumScript(measurements=[qml.expval(H)])
+        res = qml.execute([qscript], dev, interface=None, override_shots=10)
+        assert res == [2.0]
 
 
 class TestCaching:

--- a/tests/returntypes/test_autograd_new.py
+++ b/tests/returntypes/test_autograd_new.py
@@ -205,6 +205,15 @@ class TestBatchTransformExecution:
         assert isinstance(res[0], float)
         assert np.allclose(res[0], np.cos(y), atol=0.1)
 
+    def test_batch_transform_dynamic_shots(self):
+        """Tests that the batch transform considers the number of shots for the execution, not those
+        statically on the device."""
+        dev = qml.device("default.qubit", wires=1)
+        H = 2.0 * qml.PauliZ(0)
+        qscript = qml.tape.QuantumScript(measurements=[qml.expval(H)])
+        res = qml.execute([qscript], dev, interface=None, override_shots=10)
+        assert res == [2.0]
+
 
 class TestCaching:
     """Test for caching behaviour"""


### PR DESCRIPTION
Fixes #3368 .

Currently, device batch transformations occur with the number of shots originally specified on the device, not the number of shots used for the execution.  In the cases where the device has no shots but the execution does, this leads to errors if we are taking the expectation value of a Hamiltonian.

```python
@qml.qnode(qml.device('default.qubit', wires=2), diff_method=None)
def circuit():
    return qml.expval(2.0 * qml.PauliX(0))

circuit(shots=20)
```

This quick fix merely overrides the device shots for the duration of `batch_transform`.

This bug highlights the need to:
* Remove the shots specification and move it to some sort of "execution config" data class
* Make device preprocessing depend on the execution config data class