### PR TITLE
Support `pad_with` argument in `AmplitudeEmbedding` for all interfaces

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -20,7 +20,7 @@
 
 * Functionality for fetching symbols and geometry of a compound from the PubChem Database using `qchem.mol_data`.
   [(#3289)](https://github.com/PennyLaneAI/pennylane/pull/3289)
- 
+
   ```pycon
   >>> mol_data("BeH2")
   (['Be', 'H', 'H'],
@@ -81,7 +81,7 @@ Deprecations cycles are tracked at [doc/developement/deprecations.rst](https://d
   [#3292](https://github.com/PennyLaneAI/pennylane/pull/3292)
 
 * An issue with `drain=False` in the adaptive optimizer is fixed. Before the fix, the operator pool
-  needed to be re-constructed inside the optimization pool when `drain=False`. With the new fix, 
+  needed to be re-constructed inside the optimization pool when `drain=False`. With the new fix,
   this reconstruction is not needed.
   [#3361](https://github.com/PennyLaneAI/pennylane/pull/3361)
 
@@ -91,6 +91,10 @@ Deprecations cycles are tracked at [doc/developement/deprecations.rst](https://d
 
 * `qml.matrix(op)` now fails if the operator truly has no matrix (eg. `Barrier`) to match `op.matrix()`
   [(#3386)](https://github.com/PennyLaneAI/pennylane/pull/3386)
+
+* The `pad_with` argument in the `AmplitudeEmbedding` template is now compatible
+  with all interfaces
+  [(#3392)](https://github.com/PennyLaneAI/pennylane/pull/3392)
 
 
 <h3>Contributors</h3>

--- a/pennylane/templates/embeddings/amplitude.py
+++ b/pennylane/templates/embeddings/amplitude.py
@@ -211,13 +211,7 @@ class AmplitudeEmbedding(Operation):
                 # pad
                 if n_features < dim:
                     padding = [pad_with] * (dim - n_features)
-                    if (
-                        hasattr(feature_set, "device") and feature_set.device.type == "cuda"
-                    ):  # pragma: no cover
-                        ## Torch tensor, send to same GPU
-                        dat_type = type(feature_set)
-                        padding = dat_type(padding).to(feature_set.device)
-
+                    padding = qml.math.convert_like(padding, feature_set)
                     feature_set = qml.math.hstack([feature_set, padding])
 
             # normalize

--- a/tests/templates/test_embeddings/test_amplitude.py
+++ b/tests/templates/test_embeddings/test_amplitude.py
@@ -345,6 +345,34 @@ class TestInterfaces:
 
         assert qml.math.allclose(res, res2, atol=tol, rtol=0)
 
+    @pytest.mark.autograd
+    @pytest.mark.parametrize("features", all_features)
+    def test_autograd_pad_with(self, tol, features):
+        """Tests autograd tensors and pad_with."""
+
+        features = pnp.array(features)
+
+        dev = qml.device("default.qubit", wires=4)
+
+        @qml.qnode(dev, interface="autograd")
+        def circuit_decomposed(features):
+            # need to cast to complex tensor, which is implicitly done in the template
+            state = qml.math.cast(
+                qml.math.hstack([features, qml.math.zeros_like(features)]), np.complex128
+            )
+            qml.QubitStateVector(state, wires=range(4))
+            return qml.state()
+
+        @qml.qnode(dev, interface="autograd")
+        def circuit(x=None):
+            qml.AmplitudeEmbedding(x, list(range(4)), pad_with=0.0)
+            return qml.state()
+
+        res = circuit(features)
+        res2 = circuit_decomposed(features)
+
+        assert qml.math.allclose(res, res2, atol=tol, rtol=0)
+
     @pytest.mark.jax
     @pytest.mark.parametrize("features", all_features)
     def test_jax(self, tol, features):
@@ -437,6 +465,35 @@ class TestInterfaces:
         assert qml.math.allclose(res, res2, atol=tol, rtol=0)
 
     @pytest.mark.tf
+    @pytest.mark.parametrize("features", all_features)
+    def test_tf_pad_with(self, tol, features):
+        """Tests tf tensors and pad_with."""
+        import tensorflow as tf
+
+        features = tf.Variable(all_features[0])
+
+        dev = qml.device("default.qubit", wires=4)
+
+        @qml.qnode(dev, interface="tf")
+        def circuit_decomposed(features):
+            # need to cast to complex tensor, which is implicitly done in the template
+            state = qml.math.cast(
+                qml.math.hstack([features, qml.math.zeros_like(features)]), tf.complex128
+            )
+            qml.QubitStateVector(state, wires=range(4))
+            return qml.state()
+
+        @qml.qnode(dev, interface="tf")
+        def circuit(x=None):
+            qml.AmplitudeEmbedding(x, list(range(4)), pad_with=0.0)
+            return qml.state()
+
+        res = circuit(features)
+        res2 = circuit_decomposed(features)
+
+        assert qml.math.allclose(res, res2, atol=tol, rtol=0)
+
+    @pytest.mark.tf
     def test_tf_error_when_batching(self, tol):
         """Tests batched tf tensors raising an error."""
 
@@ -485,5 +542,34 @@ class TestInterfaces:
 
         res = circuit(features)
         res2 = circuit2(features)
+
+        assert qml.math.allclose(res, res2, atol=tol, rtol=0)
+
+    @pytest.mark.torch
+    @pytest.mark.parametrize("features", all_features)
+    def test_autograd_pad_with(self, tol, features):
+        """Tests torch tensors and pad_with."""
+        import torch
+
+        features = torch.tensor(features, requires_grad=True)
+
+        dev = qml.device("default.qubit", wires=4)
+
+        @qml.qnode(dev, interface="torch")
+        def circuit_decomposed(features):
+            # need to cast to complex tensor, which is implicitly done in the template
+            state = qml.math.cast(
+                qml.math.hstack([features, qml.math.zeros_like(features)]), torch.complex128
+            )
+            qml.QubitStateVector(state, wires=range(4))
+            return qml.state()
+
+        @qml.qnode(dev, interface="torch")
+        def circuit(x=None):
+            qml.AmplitudeEmbedding(x, list(range(4)), pad_with=0.0)
+            return qml.state()
+
+        res = circuit(features)
+        res2 = circuit_decomposed(features)
 
         assert qml.math.allclose(res, res2, atol=tol, rtol=0)

--- a/tests/templates/test_embeddings/test_amplitude.py
+++ b/tests/templates/test_embeddings/test_amplitude.py
@@ -547,7 +547,7 @@ class TestInterfaces:
 
     @pytest.mark.torch
     @pytest.mark.parametrize("features", all_features)
-    def test_autograd_pad_with(self, tol, features):
+    def test_torch_pad_with(self, tol, features):
         """Tests torch tensors and pad_with."""
         import torch
 


### PR DESCRIPTION
**Context:**
The `AmplitudeEmbedding` template has an optional argument `pad_with` that pads the input features if the shape is smaller than the dimension of the feature space. Passing a value for this argument is incompatible with some interfaces if the input features  is an interface-specific tensor.

**Description of the Change:**
Allow passing in `pad_with` argument even if `features` is a tensor. Add tests for `pad_with` for all interfaces.

**Related GitHub Issues:**
https://github.com/PennyLaneAI/pennylane/issues/3379
