### PR TITLE
Fix non updated _obs_sharing_wires

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -20,6 +20,7 @@
 
 * Functionality for fetching symbols and geometry of a compound from the PubChem Database using `qchem.mol_data`.
   [(#3289)](https://github.com/PennyLaneAI/pennylane/pull/3289)
+  [(#3378)](https://github.com/PennyLaneAI/pennylane/pull/3378)
  
   ```pycon
   >>> mol_data("BeH2")

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -77,6 +77,9 @@ Deprecations cycles are tracked at [doc/developement/deprecations.rst](https://d
 
 <h3>Bug fixes</h3>
 
+* Original tape `_obs_sharing_wires` is updated during its expansion.
+  [#3293](https://github.com/PennyLaneAI/pennylane/pull/3293)
+  
 * Small fix of `MeasurementProcess.map_wires`, where both the `self.obs` and `self._wires`
   attributes were modified.
   [#3292](https://github.com/PennyLaneAI/pennylane/pull/3292)
@@ -104,3 +107,4 @@ Lillian M. A. Frederiksen
 Soran Jahangiri
 Christina Lee
 Albert Mitjans Coma
+Romain Moyard

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -77,7 +77,7 @@ Deprecations cycles are tracked at [doc/developement/deprecations.rst](https://d
 
 <h3>Bug fixes</h3>
 
-* Original tape `_obs_sharing_wires` is updated during its expansion.
+* Original tape `_obs_sharing_wires` attribute is updated during its expansion.
   [#3293](https://github.com/PennyLaneAI/pennylane/pull/3293)
   
 * Small fix of `MeasurementProcess.map_wires`, where both the `self.obs` and `self._wires`

--- a/pennylane/tape/tape.py
+++ b/pennylane/tape/tape.py
@@ -153,6 +153,7 @@ def expand_tape(qscript, depth=1, stop_at=None, expand_measurements=False):
                 rotations, diag_obs = qml.pauli.diagonalize_qwc_pauli_words(
                     qscript._obs_sharing_wires
                 )
+                qscript._obs_sharing_wires = diag_obs
             except (TypeError, ValueError) as e:
                 if any(
                     m.return_type in (Probability, Sample, Counts, AllCounts)

--- a/tests/tape/test_tape.py
+++ b/tests/tape/test_tape.py
@@ -1172,6 +1172,26 @@ class TestExpand:
         with pytest.raises(qml.QuantumFunctionError, match=expected_error_msg):
             tape.expand(expand_measurements=True)
 
+    def test_multiple_expand_no_change_original_tape(self):
+        """Test that the original tape is not changed multiple time after maximal expansion."""
+        with QuantumTape() as tape:
+            qml.RX(0.1, wires=[0])
+            qml.RY(0.2, wires=[1])
+            qml.CNOT(wires=[0, 1])
+            qml.expval(qml.PauliZ(0) @ qml.PauliX(1))
+            qml.expval(qml.PauliZ(0))
+
+        expand_tape = tape.expand()
+        circuit_after_first_expand = tape.operations
+        twice_expand_tape = tape.expand()
+        circuit_after_second_expand = tape.operations
+        assert all(
+            [
+                qml.equal(op1, op2)
+                for op1, op2 in zip(circuit_after_first_expand, circuit_after_second_expand)
+            ]
+        )
+
     def test_is_sampled_reserved_after_expansion(self, monkeypatch, mocker):
         """Test that the is_sampled property is correctly set when tape
         expansion happens."""


### PR DESCRIPTION
**Description of the Change:**

The _obs_sharing_wires value is not updated after expansion in the original, therefore rotations are added each you call expansion.

**Example:**
```
  with QuantumTape() as tape:
      qml.RX(0.1, wires=[0])
      qml.RY(0.2, wires=[1])
      qml.CNOT(wires=[0, 1])
      qml.expval(qml.PauliZ(0) @ qml.PauliX(1))
      qml.expval(qml.PauliZ(0))

  expand_tape = tape.expand()
  print(tape.circuit)
  expand_tape = tape.expand()
  print(tape.circuit)
```
Before changes:
```
[RX(0.1, wires=[0]), RY(0.2, wires=[1]), CNOT(wires=[0, 1]), RY(-1.5707963267948966, wires=[1]), expval(PauliZ(wires=[0]) @ PauliZ(wires=[1])), expval(PauliZ(wires=[0]))]
[RX(0.1, wires=[0]), RY(0.2, wires=[1]), CNOT(wires=[0, 1]), RY(-1.5707963267948966, wires=[1]), RY(-1.5707963267948966, wires=[1]), expval(PauliZ(wires=[0]) @ PauliZ(wires=[1])), expval(PauliZ(wires=[0]))]
```
After changes:
```
[RX(0.1, wires=[0]), RY(0.2, wires=[1]), CNOT(wires=[0, 1]), RY(-1.5707963267948966, wires=[1]), expval(PauliZ(wires=[0]) @ PauliZ(wires=[1])), expval(PauliZ(wires=[0]))]
[RX(0.1, wires=[0]), RY(0.2, wires=[1]), CNOT(wires=[0, 1]), RY(-1.5707963267948966, wires=[1]), expval(PauliZ(wires=[0]) @ PauliZ(wires=[1])), expval(PauliZ(wires=[0]))]
````
**Related GitHub Issues:**

Closes https://github.com/PennyLaneAI/pennylane/issues/3395