### PR TITLE
Fix Contolled.map_wires

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -24,7 +24,7 @@
 * Functionality for fetching symbols and geometry of a compound from the PubChem Database using `qchem.mol_data`.
   [(#3289)](https://github.com/PennyLaneAI/pennylane/pull/3289)
   [(#3378)](https://github.com/PennyLaneAI/pennylane/pull/3378)
- 
+
   ```pycon
   >>> mol_data("BeH2")
   (['Be', 'H', 'H'],
@@ -57,6 +57,9 @@
 
 * A representation has been added to the `Molecule` class.
   [#3364](https://github.com/PennyLaneAI/pennylane/pull/3364)
+
+* Remove private `_wires` setter from the `Controlled.map_wires` method.
+  [3405](https://github.com/PennyLaneAI/pennylane/pull/3405)
 
 <h3>Breaking changes</h3>
 

--- a/pennylane/ops/op_math/controlled_class.py
+++ b/pennylane/ops/op_math/controlled_class.py
@@ -274,19 +274,16 @@ class Controlled(SymbolicOp):
         return self.control_wires + self.target_wires + self.work_wires
 
     def map_wires(self, wire_map: dict):
-        new_op = copy(self)
+        new_base = self.base.map_wires(wire_map=wire_map)
+        new_control_wires = Wires([wire_map.get(wire, wire) for wire in self.control_wires])
+        new_work_wires = Wires([wire_map.get(wire, wire) for wire in self.work_wires])
 
-        new_op.hyperparameters["control_wires"] = Wires(
-            [wire_map.get(wire, wire) for wire in self.control_wires]
+        return Controlled(
+            base=new_base,
+            control_wires=new_control_wires,
+            control_values=self.control_values,
+            work_wires=new_work_wires,
         )
-
-        new_op.base._wires = Wires([wire_map.get(wire, wire) for wire in self.base.wires])
-
-        new_op.hyperparameters["work_wires"] = Wires(
-            [wire_map.get(wire, wire) for wire in self.work_wires]
-        )
-
-        return new_op
 
     # Methods ##########################################
 


### PR DESCRIPTION
Remove private `_wires` setter. Use `map_wires` instead.

This fix assumes that the `Controlled` class is immutable: two instances that are instantiated with the same arguments will always be equal.
