### PR TITLE
Deprecate transforms.measurement_grouping

### DIFF
--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -62,6 +62,7 @@ Pending deprecations
   Don't use:
 
   .. code-block:: python
+
     with qml.tape.QuantumTape() as tape:
       qml.RX(0.1, wires=0)
       qml.RX(0.2, wires=1)
@@ -74,6 +75,7 @@ Pending deprecations
   Instead, use:
 
   .. code-block:: python
+
     obs = [qml.PauliZ(0), qml.PauliX(1)]
     coeffs = [2.0, 1.0]
     H = qml.Hamiltonian(coeffs, obs)

--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -54,6 +54,37 @@ Pending deprecations
         some_qfunc(params)
         return qml.expval(Hamiltonian)
 
+* ``qml.transforms.measurement_grouping`` has been deprecated, and usage will now raise a warning.
+
+  - Deprecated in v0.28
+  - Will be removed in v0.29
+
+  Don't use:
+
+  .. code-block:: python
+    with qml.tape.QuantumTape() as tape:
+      qml.RX(0.1, wires=0)
+      qml.RX(0.2, wires=1)
+
+    obs = [qml.PauliZ(0), qml.PauliX(1)]
+    coeffs = [2.0, 1.0]
+
+    tapes, fn = qml.transforms.measurement_grouping(tape, obs, coeffs)
+
+  Instead, use:
+
+  .. code-block:: python
+    obs = [qml.PauliZ(0), qml.PauliX(1)]
+    coeffs = [2.0, 1.0]
+    H = qml.Hamiltonian(coeffs, obs)
+
+    with qml.tape.QuantumTape() as tape:
+      qml.RX(0.1, wires=0)
+      qml.RX(0.2, wires=1)
+      qml.expval(H)
+
+    tapes, fn = qml.transforms.hamiltonian_expand(tape)
+
 Completed deprecation cycles
 ----------------------------
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -209,6 +209,8 @@ Deprecations cycles are tracked at [doc/developement/deprecations.rst](https://d
   * `qml.tape.QuantumTape.stop_recording()`: Use `qml.QueuingManager.stop_recording()`
   * `qml.QueuingContext` is now `qml.QueuingManager`
   * `QueuingManager.safe_update_info` and `AnnotatedQueue.safe_update_info`: Use plain `update_info`
+  
+* `qml.transforms.measurement_grouping` has been deprecated. Use `qml.transforms.hamiltonian_expand` instead.
 
 <h3>Documentation</h3>
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -211,6 +211,7 @@ Deprecations cycles are tracked at [doc/developement/deprecations.rst](https://d
   * `QueuingManager.safe_update_info` and `AnnotatedQueue.safe_update_info`: Use plain `update_info`
   
 * `qml.transforms.measurement_grouping` has been deprecated. Use `qml.transforms.hamiltonian_expand` instead.
+  [(#3417)](https://github.com/PennyLaneAI/pennylane/pull/3417)
 
 <h3>Documentation</h3>
 

--- a/pennylane/transforms/measurement_grouping.py
+++ b/pennylane/transforms/measurement_grouping.py
@@ -14,6 +14,7 @@
 """
 Contains the measurement grouping transform
 """
+import warnings
 import pennylane as qml
 
 
@@ -73,6 +74,12 @@ def measurement_grouping(tape, obs_list, coeffs_list):
     >>> print(res)
     2.0007186031172046
     """
+
+    warnings.warn(
+        "qml.transforms.measurement_grouping is deprecated. Instead, use qml.transforms.hamiltonian_expand",
+        UserWarning,
+    )
+
     obs_groupings, coeffs_groupings = qml.pauli.group_observables(obs_list, coeffs_list)
     tapes = []
 

--- a/tests/transforms/test_measurement_grouping.py
+++ b/tests/transforms/test_measurement_grouping.py
@@ -35,3 +35,19 @@ def test_measurement_grouping():
     dev = qml.device("default.qubit", wires=3)
     res = fn(dev.batch_execute(tapes))
     assert np.isclose(res, 2.0007186)
+
+
+def test_deprecation_warning_measurement_grouping():
+    """Tests that a deprecation warning is raised when using measurement_grouping."""
+
+    with qml.tape.QuantumTape() as tape:
+        qml.RX(0.1, wires=0)
+        qml.RX(0.2, wires=1)
+        qml.CNOT(wires=[0, 1])
+        qml.CNOT(wires=[1, 2])
+
+    obs = [qml.PauliZ(0), qml.PauliX(0) @ qml.PauliZ(1), qml.PauliX(2)]
+    coeffs = [2.0, -0.54, 0.1]
+
+    with pytest.warns(UserWarning, match="is deprecated"):
+        _, _ = qml.transforms.measurement_grouping(tape, obs, coeffs)


### PR DESCRIPTION
**Description of the Change:**
Deprecate `qml.transforms.measurement_grouping` in favour of `qml.transforms.hamiltonian_expand`