### PR TITLE
Remove get paramter shift

### DIFF
--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -132,3 +132,9 @@ Completed deprecation cycles
 
   - Deprecated in v0.24
   - Removed in v0.27
+
+* The ``qml.Operation.get_parameter_shift`` method is deprecated. Use the methods of the ``gradients`` module
+  for general parameter-shift rules instead.
+
+  - Deprecated in v0.22
+  - Removed in v0.28

--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -133,7 +133,7 @@ Completed deprecation cycles
   - Deprecated in v0.24
   - Removed in v0.27
 
-* The ``qml.Operation.get_parameter_shift`` method is deprecated. Use the methods of the ``gradients`` module
+* The ``qml.Operation.get_parameter_shift`` method is removed. Use the methods of the ``gradients`` module
   for general parameter-shift rules instead.
 
   - Deprecated in v0.22

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -212,6 +212,10 @@
   class which inherits from `AnnotatedQueue`.
   [(#3401)](https://github.com/PennyLaneAI/pennylane/pull/3401)
 
+* The method `qml.Operation.get_parameter_shift` is removed. The `gradients` module should be used
+  for general parameter-shift rules instead.
+  [(#3419)](https://github.com/PennyLaneAI/pennylane/pull/3419)
+
 <h3>Deprecations</h3>
 
 Deprecations cycles are tracked at [doc/developement/deprecations.rst](https://docs.pennylane.ai/en/latest/development/deprecations.html).

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -1286,35 +1286,6 @@ class Operation(Operator):
         """
         raise NotImplementedError
 
-    def get_parameter_shift(self, idx):
-        r"""Multiplier and shift for the given parameter, based on its gradient recipe.
-
-        Args:
-            idx (int): parameter index within the operation
-
-        Returns:
-            list[[float, float, float]]: list of multiplier, coefficient, shift for each term in the gradient recipe
-
-        Note that the default value for ``shift`` is None, which is replaced by the
-        default shift :math:`\pi/2`.
-        """
-        warnings.warn(
-            "The method get_parameter_shift is deprecated. Use the methods of "
-            "the gradients module for general parameter-shift rules instead.",
-            UserWarning,
-        )
-        # get the gradient recipe for this parameter
-        recipe = self.grad_recipe[idx]
-        if recipe is not None:
-            return recipe
-
-        # We no longer assume any default parameter-shift rule to apply.
-        raise OperatorPropertyUndefined(
-            f"The operation {self.name} does not have a parameter-shift recipe defined."
-            " This error might occur if previously the two-term shift rule was assumed"
-            " silently. In this case, consider adding it explicitly to the operation."
-        )
-
     @property
     def parameter_frequencies(self):
         r"""Returns the frequencies for each operator parameter with respect

--- a/pennylane/ops/op_math/adjoint_class.py
+++ b/pennylane/ops/op_math/adjoint_class.py
@@ -85,9 +85,6 @@ class AdjointOperation(Operation):
     def grad_recipe(self):
         return self.base.grad_recipe
 
-    def get_parameter_shift(self, idx):
-        return self.base.get_parameter_shift(idx)
-
     @property
     def parameter_frequencies(self):
         return self.base.parameter_frequencies

--- a/tests/ops/op_math/test_adjoint_op.py
+++ b/tests/ops/op_math/test_adjoint_op.py
@@ -549,12 +549,6 @@ class TestAdjointOperationDiffInfo:
         """Test that the grad_recipe of the Adjoint is the same as the grad_recipe of the base."""
         assert Adjoint(base).grad_recipe == base.grad_recipe
 
-    def test_get_parameter_shift(self):
-        """Test `get_parameter_shift` for an operation where it still doesn't raise warnings and errors."""
-        base = qml.Rotation(1.234, wires=0)
-        with pytest.warns(UserWarning, match=r"get_parameter_shift is deprecated."):
-            assert Adjoint(base).get_parameter_shift(0) == base.get_parameter_shift(0)
-
     @pytest.mark.parametrize(
         "base",
         (qml.RX(1.23, wires=0), qml.Rot(1.23, 2.345, 3.456, wires=0), qml.CRX(1.234, wires=(0, 1))),

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -539,38 +539,6 @@ class TestOperationConstruction:
         op = DummyOp(x, wires=0)
         assert op.grad_recipe == ([[1.0, 1.0, x], [1.0, 0.0, -x]],)
 
-    def test_warning_get_parameter_shift(self):
-        """Test that ``get_parameter_shift`` issues a deprecation
-        warning."""
-
-        class DummyOp(qml.operation.Operation):
-            r"""Dummy custom operation"""
-            num_wires = 1
-            num_params = 1
-            grad_recipe = ("Dummy recipe",)
-
-        op = DummyOp(0.1, wires=0)
-        with pytest.warns(UserWarning, match="get_parameter_shift is deprecated"):
-            assert op.get_parameter_shift(0) == "Dummy recipe"
-
-    @pytest.mark.filterwarnings("ignore:The method get_parameter_shift is deprecated")
-    def test_error_get_parameter_shift_no_recipe(self):
-        """Test that ``get_parameter_shift`` raises an Error if no grad_recipe
-        is available, as we no longer assume the two-term rule by default."""
-
-        class DummyOp(qml.operation.Operation):
-            r"""Dummy custom operation"""
-            num_wires = 1
-            num_params = 1
-            grad_recipe = (None,)
-
-        op = DummyOp(0.1, wires=0)
-        with pytest.raises(
-            qml.operation.OperatorPropertyUndefined,
-            match="The operation DummyOp does not have a parameter-shift recipe",
-        ):
-            op.get_parameter_shift(0)
-
     def test_default_grad_method_with_frequencies(self):
         """Test that the correct ``grad_method`` is returned by default
         if ``parameter_frequencies`` are present.


### PR DESCRIPTION
Remove `qml.Operation.get_parameter_shift` (deprecated in v0.22)