### PR TITLE
Change `QubitDevice.statistics` signature

### DIFF
--- a/doc/development/plugins.rst
+++ b/doc/development/plugins.rst
@@ -270,7 +270,7 @@ your plugin which, by default, performs the following process:
         self._samples = self.generate_samples()
 
     # compute the required statistics
-    results = self.statistics(circuit.observables)
+    results = self.statistics(circuit)
 
     return self._asarray(results)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -5,6 +5,7 @@
 <h3>New features since last release</h3>
 
 * Add the controlled Hadamard gate.
+
   ```pycon
   >>> ch = qml.CH(wires=[0, 1])
   >>> matrix = ch.compute_matrix()
@@ -13,6 +14,7 @@
    [ 0.          0.          0.70710678  0.70710678]
    [ 0.          0.          0.70710678 -0.70710678]]
   ```
+
   [#3408](https://github.com/PennyLaneAI/pennylane/pull/3408)
   
 * Support custom measurement processes:
@@ -149,6 +151,7 @@
   [#3374](https://github.com/PennyLaneAI/pennylane/pull/3374)
 
   Example with a single measurement:
+
   ```python
   dev = qml.device("default.qubit", wires=1, shots=[1000, 2000, 3000])
 
@@ -161,7 +164,8 @@
   def cost(a):
       return qml.math.stack(circuit(a))
   ```
-  ```
+
+  ```pycon
   >>> qml.enable_return()
   >>> a = np.array(0.4)
   >>> circuit(a)
@@ -171,7 +175,9 @@
   >>> qml.jacobian(cost)(a)
   array([-0.391     , -0.389     , -0.38433333])
   ```
+
   Example with multiple measurements:
+
   ```python
   dev = qml.device("default.qubit", wires=2, shots=[1000, 2000, 3000])
 
@@ -186,7 +192,8 @@
       res = circuit(a)
       return qml.math.stack([qml.math.hstack(r) for r in res])
   ```
-  ```
+
+  ```pycon
   >>> circuit(a)
   ((array(0.904), array([0.952, 0.   , 0.   , 0.048])),
    (array(0.915), array([0.9575, 0.    , 0.    , 0.0425])),
@@ -201,7 +208,6 @@
          [-0.37133333, -0.18566667,  0.        ,  0.        ,  0.18566667]])
   ```
 
-
 <h3>Breaking changes</h3>
 
 * The `log_base` attribute has been moved from `MeasurementProcess` to the new `_VnEntropy` and
@@ -215,6 +221,20 @@
   `OrderedDict` and encapsulates the queue. Consequentially, this also applies to the `QuantumTape`
   class which inherits from `AnnotatedQueue`.
   [(#3401)](https://github.com/PennyLaneAI/pennylane/pull/3401)
+
+* Changed the signature of the `QubitDevice.statistics` method from
+
+  ```python
+  def statistics(self, observables, shot_range=None, bin_size=None, circuit=None):
+  ```
+
+  to
+
+  ```python
+  def statistics(self, circuit: QuantumScript, shot_range=None, bin_size=None):
+  ```
+
+  [#3421](https://github.com/PennyLaneAI/pennylane/pull/3421)
 
 <h3>Deprecations</h3>
 

--- a/tests/test_qutrit_device.py
+++ b/tests/test_qutrit_device.py
@@ -14,20 +14,27 @@
 """
 Unit tests for the :mod:`pennylane` :class:`QutritDevice` class.
 """
-import pytest
-import numpy as np
 from random import random
+
+import numpy as np
+import pytest
 from scipy.stats import unitary_group
 
 import pennylane as qml
+from pennylane import DeviceError, QubitDevice, QutritDevice
 from pennylane import numpy as pnp
-from pennylane import QutritDevice, DeviceError, QuantumFunctionError, QubitDevice
-from pennylane.devices import DefaultQubit
-from pennylane.measurements import Sample, Variance, Expectation, Probability, State, Counts
-from pennylane.circuit_graph import CircuitGraph
+from pennylane.measurements import (
+    Counts,
+    Expectation,
+    MeasurementProcess,
+    Probability,
+    Sample,
+    State,
+    Variance,
+    state,
+)
+from pennylane.tape import QuantumScript
 from pennylane.wires import Wires
-from pennylane.tape import QuantumTape
-from pennylane.measurements import state
 
 
 @pytest.fixture(scope="function")
@@ -291,42 +298,36 @@ class TestExtractStatistics:
     def test_results_created(self, mock_qutrit_device_extract_stats, monkeypatch, returntype):
         """Tests that the statistics method simply builds a results list without any side-effects"""
 
-        class SomeObservable(qml.operation.Observable):
-            num_wires = 1
-            return_type = returntype
-
-        obs = SomeObservable(wires=0)
+        qscript = QuantumScript(measurements=[MeasurementProcess(returntype)])
 
         with monkeypatch.context() as m:
             dev = mock_qutrit_device_extract_stats()
-            results = dev.statistics([obs])
+            results = dev.statistics(qscript)
 
         assert results == [0]
 
     def test_results_no_state(self, mock_qutrit_device, monkeypatch):
         """Tests that the statistics method raises an AttributeError when a State return type is
         requested when QutritDevice does not have a state attribute"""
+        qscript = QuantumScript(measurements=[qml.state()])
+
         with monkeypatch.context() as m:
             dev = mock_qutrit_device()
             m.delattr(QubitDevice, "state")
             with pytest.raises(
                 qml.QuantumFunctionError, match="The state is not available in the current"
             ):
-                dev.statistics([qml.state()])
+                dev.statistics(qscript)
 
     @pytest.mark.parametrize("returntype", [None])
     def test_results_created_empty(self, mock_qutrit_device_extract_stats, monkeypatch, returntype):
         """Tests that the statistics method returns an empty list if the return type is None"""
 
-        class SomeObservable(qml.operation.Observable):
-            num_wires = 1
-            return_type = returntype
-
-        obs = SomeObservable(wires=0)
+        qscript = QuantumScript(measurements=[MeasurementProcess(returntype)])
 
         with monkeypatch.context() as m:
             dev = mock_qutrit_device_extract_stats()
-            results = dev.statistics([obs])
+            results = dev.statistics(qscript)
 
         assert results == []
 
@@ -338,15 +339,11 @@ class TestExtractStatistics:
 
         assert returntype not in [Expectation, Variance, Sample, Probability, State, Counts, None]
 
-        class SomeObservable(qml.operation.Observable):
-            num_wires = 1
-            return_type = returntype
-
-        obs = SomeObservable(wires=0)
+        qscript = QuantumScript(measurements=[MeasurementProcess(returntype)])
 
         dev = mock_qutrit_device_extract_stats()
         with pytest.raises(qml.QuantumFunctionError, match="Unsupported return type"):
-            dev.statistics([obs])
+            dev.statistics(qscript)
 
     def test_return_state_with_multiple_observables(self, mock_qutrit_device_extract_stats):
         """Checks that an error is raised if multiple observables are being returned


### PR DESCRIPTION
From:
```python
def statistics(self, observables, shot_range=None, bin_size=None, circuit=None):
```
To:
```python
def statistics(self, circuit: QuantumScript, shot_range=None, bin_size=None):
```

For this breaking change, we will need to update the following plugins:
1. `pennylane-lightning-gpu`: https://github.com/PennyLaneAI/pennylane-lightning-gpu/pull/78
2. `pennylane-qiskit`: https://github.com/PennyLaneAI/pennylane-qiskit/pull/236
3. `pennylane-honeywell`: https://github.com/PennyLaneAI/pennylane-honeywell/pull/35

**Note:** `observables` can still be accessed inside the `statistics` method by using `circuit.observables`.