### PR TITLE
Fix `qml.sample` for shot vectors

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -29,7 +29,7 @@
    [ 0.          0.          0.70710678 -0.70710678]]
   ```
   [#3408](https://github.com/PennyLaneAI/pennylane/pull/3408)
-  
+
 * Support custom measurement processes:
   * `SampleMeasurement` and `StateMeasurement` classes have been added. They contain an abstract
     method to process samples/quantum state.
@@ -81,10 +81,10 @@
 
 * New basis sets, `6-311g` and `CC-PVDZ`, are added to the qchem basis set repo.
   [#3279](https://github.com/PennyLaneAI/pennylane/pull/3279)
-  
+
 * New parametric qubit ops `qml.CPhaseShift00`, `qml.CPhaseShift01` and `qml.CPhaseShift10` which perform a phaseshift, similar to `qml.ControlledPhaseShift` but on different positions of the state vector.
   [(#2715)](https://github.com/PennyLaneAI/pennylane/pull/2715)
-  
+
 * Support for purity computation is added. The `qml.math.purity` function computes the purity from a state vector or a density matrix:
 
   [#3290](https://github.com/PennyLaneAI/pennylane/pull/3290)
@@ -95,7 +95,7 @@
   1.0
   >>> qml.math.purity(x, [0])
   0.5
-    
+
   >>> x = [[1 / 2, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 1 / 2]]
   >>> qml.math.purity(x, [0, 1])
   0.5
@@ -153,7 +153,7 @@
 
 * Remove private `_wires` setter from the `Controlled.map_wires` method.
   [3405](https://github.com/PennyLaneAI/pennylane/pull/3405)
-  
+
 * `QuantumTape._process_queue` has been moved to `qml.queuing.process_queue` to disentangle
   its functionality from the `QuantumTape` class.
   [(#3401)](https://github.com/PennyLaneAI/pennylane/pull/3401)
@@ -245,7 +245,7 @@ Deprecations cycles are tracked at [doc/developement/deprecations.rst](https://d
   * `qml.tape.QuantumTape.stop_recording()`: Use `qml.QueuingManager.stop_recording()`
   * `qml.QueuingContext` is now `qml.QueuingManager`
   * `QueuingManager.safe_update_info` and `AnnotatedQueue.safe_update_info`: Use plain `update_info`
-  
+
 * `qml.transforms.measurement_grouping` has been deprecated. Use `qml.transforms.hamiltonian_expand` instead.
   [(#3417)](https://github.com/PennyLaneAI/pennylane/pull/3417)
 
@@ -292,6 +292,10 @@ Deprecations cycles are tracked at [doc/developement/deprecations.rst](https://d
 * The `pad_with` argument in the `AmplitudeEmbedding` template is now compatible
   with all interfaces
   [(#3392)](https://github.com/PennyLaneAI/pennylane/pull/3392)
+
+* Fixed a bug where a QNode returning `qml.sample` would produce incorrect results when
+  run on a device defined with a shot vector.
+  [#3422](https://github.com/PennyLaneAI/pennylane/pull/3422)
 
 <h3>Contributors</h3>
 

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -1754,7 +1754,7 @@ class QubitDevice(Device):
             ]
 
         return (
-            samples.reshape((num_wires, bin_size, -1))
+            samples.T.reshape((num_wires, bin_size, -1))
             if no_observable_provided
             else samples.reshape((bin_size, -1))
         )

--- a/pennylane/measurements/counts.py
+++ b/pennylane/measurements/counts.py
@@ -178,9 +178,13 @@ class _Counts(SampleMeasurement):
             return self._samples_to_counts(samples)
 
         num_wires = len(self.wires) if self.wires else len(wire_order)
-        shape = (-1, bin_size, num_wires) if self.obs is None else (-1, bin_size)
+        samples = (
+            samples.reshape((num_wires, -1)).T.reshape(-1, bin_size, num_wires)
+            if self.obs is None
+            else samples.reshape((-1, bin_size))
+        )
 
-        return [self._samples_to_counts(bin_sample) for bin_sample in samples.reshape(shape)]
+        return [self._samples_to_counts(bin_sample) for bin_sample in samples]
 
     def _samples_to_counts(self, samples):
         """Groups the samples into a dictionary showing number of occurences for

--- a/pennylane/measurements/sample.py
+++ b/pennylane/measurements/sample.py
@@ -141,7 +141,7 @@ class _Sample(SampleMeasurement):
 
         if self.obs is None:
             # if no observable was provided then return the raw samples
-            return samples if bin_size is None else samples.reshape(num_wires, bin_size, -1)
+            return samples if bin_size is None else samples.T.reshape(num_wires, bin_size, -1)
 
         if name in {"PauliX", "PauliY", "PauliZ", "Hadamard"}:
             # Process samples for observables with eigenvalues {1, -1}

--- a/tests/measurements/test_sample.py
+++ b/tests/measurements/test_sample.py
@@ -230,15 +230,21 @@ class TestSample:
         @qml.qnode(dev)
         def circuit():
             qml.Hadamard(wires=0)
+            qml.CNOT(wires=[0, 1])
             return qml.sample()
 
         res = circuit()
 
         assert isinstance(res, tuple)
 
-        expected_shapes = [(num_wires,), (num_wires, shots2), (num_wires, shots3)]
+        expected_shapes = [(num_wires,), (shots2, num_wires), (shots3, num_wires)]
         assert len(res) == len(expected_shapes)
-        assert (r.shape == exp_shape for r, exp_shape in zip(res, expected_shapes))
+        assert all(r.shape == exp_shape for r, exp_shape in zip(res, expected_shapes))
+
+        # assert first wire is always the same as second
+        assert np.all(res[0][0] == res[0][1])
+        assert np.all(res[1][:, 0] == res[1][:, 1])
+        assert np.all(res[2][:, 0] == res[2][:, 1])
 
         custom_measurement_process(dev, spy)
 


### PR DESCRIPTION
**Context:**
Previously `qml.sample` produced incorrect results when shot vectors are used:
```python3
dev = qml.device("default.qubit", wires=2, shots=(5, 10))

@qml.qnode(dev)
def circuit():
    qml.Hadamard(wires=0)
    qml.CNOT(wires=[0, 1])
    return qml.sample(wires=[0, 1])
```
```
>>> circuit()
(tensor([[0, 0],
        [0, 1],
        [0, 1],
        [0, 1],
        [0, 1]], dtype=int64, requires_grad=True), tensor([[1, 0],
        [1, 0],
        [1, 0],
        [1, 0],
        [0, 0],
        [0, 0],
        [1, 0],
        [1, 0],
        [1, 1],
        [1, 1]], dtype=int64, requires_grad=True))
```

**Description of the Change:**
The reshape logic in the qubit device was missing a transpose. This PR adds the transpose. Also fixed a broken test that would have failed on master.

**Related GitHub Issues:**
https://github.com/PennyLaneAI/pennylane/issues/3412
