### PR TITLE
Hilbert schmidt make qscript

### DIFF
--- a/pennylane/templates/subroutines/hilbert_schmidt.py
+++ b/pennylane/templates/subroutines/hilbert_schmidt.py
@@ -15,6 +15,8 @@
 This submodule contains the templates for the Hilbert-Schmidt tests.
 """
 # pylint: disable-msg=too-many-arguments
+import warnings
+
 import pennylane as qml
 from pennylane.operation import AnyWires, Operation
 
@@ -95,7 +97,15 @@ class HilbertSchmidt(Operation):
     num_wires = AnyWires
     grad_method = None
 
-    def __init__(self, *params, v_function, v_wires, u_script, do_queue=True, id=None):
+    def __init__(self, *params, v_function, v_wires, u_script=None, do_queue=True, id=None, u_tape=None):
+
+        if u_script is None:
+            if u_tape is None:
+                raise TypeError("__init__() missing 1 required keyword-only argument: 'u_script'")
+            warnings.warn("The u_tape keyword is deprecated. Please use u_script instead.", UserWarning)
+            u_script = u_tape
+        elif u_tape is not None:
+            raise ValueError("Only u_script should be used. The u_tape keyword is deprecated.")
 
         self._num_params = len(params)
 

--- a/pennylane/templates/subroutines/hilbert_schmidt.py
+++ b/pennylane/templates/subroutines/hilbert_schmidt.py
@@ -44,14 +44,14 @@ class HilbertSchmidt(Operation):
         params (array): Parameters for the quantum function `V`.
         v_function (callable): Quantum function that represents the approximate compiled unitary `V`.
         v_wires (int or Iterable[Number, str]]): The wire(s) the approximate compiled unitary act on.
-        u_tape (.QuantumTape): `U`, the unitary to be compiled as a ``qml.tape.QuantumTape``.
+        u_script (.QuantumScript): `U`, the unitary to be compiled as a ``qml.tape.QuantumScript``.
 
     Raises:
-        QuantumFunctionError: The argument ``u_tape`` must be a ``QuantumTape``.
+        QuantumFunctionError: The argument ``u_script`` must be a ``QuantumScript``.
         QuantumFunctionError: ``v_function`` is not a valid quantum function.
         QuantumFunctionError: ``U`` and ``V`` do not have the same number of wires.
         QuantumFunctionError: The wires ``v_wires`` are a subset of ``V`` wires.
-        QuantumFunctionError: ``u_tape`` and ``v_tape`` must act on distinct wires.
+        QuantumFunctionError: ``u_script`` and ``v_script`` must act on distinct wires.
 
     **Reference**
 
@@ -71,8 +71,7 @@ class HilbertSchmidt(Operation):
 
         .. code-block:: python
 
-            with qml.tape.QuantumTape(do_queue=False) as u_tape:
-                qml.Hadamard(wires=0)
+            u_script = qml.tape.QuantumScript([qml.Hadamard(wires=0)])
 
             def v_function(params):
                 qml.RZ(params[0], wires=1)
@@ -80,31 +79,31 @@ class HilbertSchmidt(Operation):
             dev = qml.device("default.qubit", wires=2)
 
             @qml.qnode(dev)
-            def hilbert_test(v_params, v_function, v_wires, u_tape):
-                qml.HilbertSchmidt(v_params, v_function=v_function, v_wires=v_wires, u_tape=u_tape)
-                return qml.probs(u_tape.wires + v_wires)
+            def hilbert_test(v_params, v_function, v_wires, u_script):
+                qml.HilbertSchmidt(v_params, v_function=v_function, v_wires=v_wires, u_script=u_script)
+                return qml.probs(u_script.wires + v_wires)
 
-            def cost_hst(parameters, v_function, v_wires, u_tape):
-                return (1 - hilbert_test(v_params=parameters, v_function=v_function, v_wires=v_wires, u_tape=u_tape)[0])
+            def cost_hst(parameters, v_function, v_wires, u_script):
+                return (1 - hilbert_test(v_params=parameters, v_function=v_function, v_wires=v_wires, u_script=u_script)[0])
 
         Now that the cost function has been defined it can be called for specific parameters:
 
-        >>> cost_hst([0], v_function = v_function, v_wires = [1], u_tape = u_tape)
+        >>> cost_hst([0], v_function = v_function, v_wires = [1], u_script = u_script)
         1
 
     """
     num_wires = AnyWires
     grad_method = None
 
-    def __init__(self, *params, v_function, v_wires, u_tape, do_queue=True, id=None):
+    def __init__(self, *params, v_function, v_wires, u_script, do_queue=True, id=None):
 
         self._num_params = len(params)
 
-        if not isinstance(u_tape, qml.tape.QuantumTape):
-            raise qml.QuantumFunctionError("The argument u_tape must be a QuantumTape.")
+        if not isinstance(u_script, qml.tape.QuantumScript):
+            raise qml.QuantumFunctionError("The argument u_script must be a QuantumScript.")
 
-        u_wires = u_tape.wires
-        self.hyperparameters["u_tape"] = u_tape
+        u_wires = u_script.wires
+        self.hyperparameters["u_script"] = u_script
 
         if not callable(v_function):
             raise qml.QuantumFunctionError(
@@ -113,19 +112,19 @@ class HilbertSchmidt(Operation):
 
         self.hyperparameters["v_function"] = v_function
 
-        v_tape = qml.transforms.make_tape(v_function)(*params)
-        self.hyperparameters["v_tape"] = v_tape
-        self.hyperparameters["v_wires"] = v_tape.wires
+        v_script = qml.tape.make_qscript(v_function)(*params)
+        self.hyperparameters["v_script"] = v_script
+        self.hyperparameters["v_wires"] = v_script.wires
 
         if len(u_wires) != len(v_wires):
             raise qml.QuantumFunctionError("U and V must have the same number of wires.")
 
-        if not qml.wires.Wires(v_wires).contains_wires(v_tape.wires):
-            raise qml.QuantumFunctionError("All wires in v_tape must be in v_wires.")
+        if not qml.wires.Wires(v_wires).contains_wires(v_script.wires):
+            raise qml.QuantumFunctionError("All wires in v_script must be in v_wires.")
 
         # Intersection of wires
-        if len(qml.wires.Wires.shared_wires([u_tape.wires, v_tape.wires])) != 0:
-            raise qml.QuantumFunctionError("u_tape and v_tape must act on distinct wires.")
+        if len(qml.wires.Wires.shared_wires([u_script.wires, v_script.wires])) != 0:
+            raise qml.QuantumFunctionError("u_script and v_script must act on distinct wires.")
 
         wires = qml.wires.Wires(u_wires + v_wires)
 
@@ -137,10 +136,10 @@ class HilbertSchmidt(Operation):
 
     @staticmethod
     def compute_decomposition(
-        params, wires, u_tape, v_tape, v_function=None, v_wires=None
+        params, wires, u_script, v_script, v_function=None, v_wires=None
     ):  # pylint: disable=arguments-differ,unused-argument
         r"""Representation of the operator as a product of other operators."""
-        n_wires = len(u_tape.wires + v_tape.wires)
+        n_wires = len(u_script.wires + v_script.wires)
         decomp_ops = []
 
         first_range = range(0, int(n_wires / 2))
@@ -155,13 +154,13 @@ class HilbertSchmidt(Operation):
             decomp_ops.append(qml.CNOT(wires=[wires[i], wires[j]]))
 
         # Unitary U
-        for op_u in u_tape.operations:
+        for op_u in u_script.operations:
             # The operation has been defined outside of this function, to queue it we call qml.apply.
             qml.apply(op_u)
             decomp_ops.append(op_u)
 
         # Unitary V conjugate
-        for op_v in v_tape.operations:
+        for op_v in v_script.operations:
             decomp_ops.append(qml.adjoint(op_v, lazy=False))
 
         # CNOT second layer
@@ -190,14 +189,14 @@ class LocalHilbertSchmidt(HilbertSchmidt):
         params (array): Parameters for the quantum function `V`.
         v_function (Callable): Quantum function that represents the approximate compiled unitary `V`.
         v_wires (int or Iterable[Number, str]]): the wire(s) the approximate compiled unitary act on.
-        u_tape (.QuantumTape): `U`, the unitary to be compiled as a ``qml.tape.QuantumTape``.
+        u_script (.QuantumScript): `U`, the unitary to be compiled as a ``qml.tape.QuantumScript``.
 
     Raises:
-        QuantumFunctionError: The argument u_tape must be a QuantumTape
+        QuantumFunctionError: The argument u_script must be a QuantumScript
         QuantumFunctionError: ``v_function`` is not a valid Quantum function.
         QuantumFunctionError: `U` and `V` do not have the same number of wires.
         QuantumFunctionError: The wires ``v_wires`` are a subset of `V` wires.
-        QuantumFunctionError: u_tape and v_tape must act on distinct wires.
+        QuantumFunctionError: u_script and v_script must act on distinct wires.
 
     **Reference**
 
@@ -219,8 +218,7 @@ class LocalHilbertSchmidt(HilbertSchmidt):
 
             import numpy as np
 
-            with qml.tape.QuantumTape(do_queue=False) as u_tape:
-                qml.CZ(wires=[0,1])
+            u_script = qml.tape.QuantumScript([qml.CZ(wires=[0,1])])
 
             def v_function(params):
                 qml.RZ(params[0], wires=2)
@@ -232,26 +230,26 @@ class LocalHilbertSchmidt(HilbertSchmidt):
             dev = qml.device("default.qubit", wires=4)
 
             @qml.qnode(dev)
-            def local_hilbert_test(v_params, v_function, v_wires, u_tape):
-                qml.LocalHilbertSchmidt(v_params, v_function=v_function, v_wires=v_wires, u_tape=u_tape)
-                return qml.probs(u_tape.wires + v_wires)
+            def local_hilbert_test(v_params, v_function, v_wires, u_script):
+                qml.LocalHilbertSchmidt(v_params, v_function=v_function, v_wires=v_wires, u_script=u_script)
+                return qml.probs(u_script.wires + v_wires)
 
-            def cost_lhst(parameters, v_function, v_wires, u_tape):
-                return (1 - local_hilbert_test(v_params=parameters, v_function=v_function, v_wires=v_wires, u_tape=u_tape)[0])
+            def cost_lhst(parameters, v_function, v_wires, u_script):
+                return (1 - local_hilbert_test(v_params=parameters, v_function=v_function, v_wires=v_wires, u_script=u_script)[0])
 
         Now that the cost function has been defined it can be called for specific parameters:
 
-        >>> cost_lhst([3*np.pi/2, 3*np.pi/2, np.pi/2], v_function = v_function, v_wires = [1], u_tape = u_tape)
+        >>> cost_lhst([3*np.pi/2, 3*np.pi/2, np.pi/2], v_function = v_function, v_wires = [1], u_script = u_script)
         0.5
     """
 
     @staticmethod
     def compute_decomposition(
-        params, wires, u_tape, v_tape, v_function=None, v_wires=None
+        params, wires, u_script, v_script, v_function=None, v_wires=None
     ):  # pylint: disable=arguments-differ,unused-argument
         r"""Representation of the operator as a product of other operators (static method)."""
         decomp_ops = []
-        n_wires = len(u_tape.wires + v_tape.wires)
+        n_wires = len(u_script.wires + v_script.wires)
         first_range = range(0, int(n_wires / 2))
         second_range = range(int(n_wires / 2), n_wires)
 
@@ -264,12 +262,12 @@ class LocalHilbertSchmidt(HilbertSchmidt):
             decomp_ops.append(qml.CNOT(wires=[wires[i], wires[j]]))
 
         # Unitary U
-        for op_u in u_tape.operations:
+        for op_u in u_script.operations:
             qml.apply(op_u)
             decomp_ops.append(op_u)
 
         # Unitary V conjugate
-        for op_v in v_tape.operations:
+        for op_v in v_script.operations:
             decomp_ops.append(qml.adjoint(qml.apply, lazy=False)(op_v))
 
         # Only one CNOT

--- a/tests/templates/test_subroutines/test_hilbert_schmidt.py
+++ b/tests/templates/test_subroutines/test_hilbert_schmidt.py
@@ -17,6 +17,7 @@ Unit tests for the Hilbert-Schmidt templates.
 import pytest
 
 import pennylane as qml
+from pennylane.tape import QuantumScript, make_qscript
 
 
 class TestHilbertSchmidt:
@@ -24,16 +25,14 @@ class TestHilbertSchmidt:
 
     def test_hs_decomposition_1_qubit(self):
         """Test if the HS operation is correctly decomposed for a 1 qubit unitary."""
-        with qml.tape.QuantumTape(do_queue=False) as U:
-            qml.Hadamard(wires=0)
+        U = QuantumScript([qml.Hadamard(wires=0)])
 
         def v_circuit(params):
             qml.RZ(params[0], wires=1)
 
-        op = qml.HilbertSchmidt([0.1], v_function=v_circuit, v_wires=[1], u_tape=U)
+        op = qml.HilbertSchmidt([0.1], v_function=v_circuit, v_wires=[1], u_script=U)
 
-        with qml.tape.QuantumTape() as tape_dec:
-            op.decomposition()
+        script_dec = make_qscript(op.decomposition)()
 
         expected_operations = [
             qml.Hadamard(wires=[0]),
@@ -43,24 +42,22 @@ class TestHilbertSchmidt:
             qml.CNOT(wires=[0, 1]),
             qml.Hadamard(wires=[0]),
         ]
-        for i, j in zip(tape_dec.operations, expected_operations):
+        for i, j in zip(script_dec.operations, expected_operations):
             assert i.name == j.name
             assert i.data == j.data
             assert i.wires == j.wires
 
     def test_hs_decomposition_2_qubits(self):
         """Test if the HS operation is correctly decomposed for 2 qubits."""
-        with qml.tape.QuantumTape(do_queue=False) as U:
-            qml.SWAP(wires=[0, 1])
+        U = QuantumScript([qml.SWAP(wires=[0, 1])])
 
         def v_circuit(params):
             qml.RZ(params[0], wires=2)
             qml.CNOT(wires=[2, 3])
 
-        op = qml.HilbertSchmidt([0.1], v_function=v_circuit, v_wires=[2, 3], u_tape=U)
+        op = qml.HilbertSchmidt([0.1], v_function=v_circuit, v_wires=[2, 3], u_script=U)
 
-        with qml.tape.QuantumTape() as tape_dec:
-            op.decomposition()
+        script_dec = make_qscript(op.decomposition)()
 
         expected_operations = [
             qml.Hadamard(wires=[0]),
@@ -76,24 +73,22 @@ class TestHilbertSchmidt:
             qml.Hadamard(wires=[1]),
         ]
 
-        for i, j in zip(tape_dec.operations, expected_operations):
+        for i, j in zip(script_dec.operations, expected_operations):
             assert i.name == j.name
             assert i.data == j.data
             assert i.wires == j.wires
 
     def test_hs_decomposition_2_qubits_custom_wires(self):
         """Test if the HS operation is correctly decomposed for 2 qubits with custom wires."""
-        with qml.tape.QuantumTape(do_queue=False) as U:
-            qml.SWAP(wires=["a", "b"])
+        U = QuantumScript([qml.SWAP(wires=["a", "b"])])
 
         def v_circuit(params):
             qml.RZ(params[0], wires="c")
             qml.CNOT(wires=["c", "d"])
 
-        op = qml.HilbertSchmidt([0.1], v_function=v_circuit, v_wires=["c", "d"], u_tape=U)
+        op = qml.HilbertSchmidt([0.1], v_function=v_circuit, v_wires=["c", "d"], u_script=U)
 
-        with qml.tape.QuantumTape() as tape_dec:
-            op.decomposition()
+        script_dec = make_qscript(op.decomposition)()
 
         expected_operations = [
             qml.Hadamard(wires=["a"]),
@@ -109,7 +104,7 @@ class TestHilbertSchmidt:
             qml.Hadamard(wires=["b"]),
         ]
 
-        for i, j in zip(tape_dec.operations, expected_operations):
+        for i, j in zip(script_dec.operations, expected_operations):
             assert i.name == j.name
             assert i.data == j.data
             assert i.wires == j.wires
@@ -117,23 +112,19 @@ class TestHilbertSchmidt:
     def test_v_not_quantum_function(self):
         """Test that we cannot pass a non quantum function to the HS operation"""
 
-        with qml.tape.QuantumTape(do_queue=False) as U:
-            qml.Hadamard(wires=0)
-
-        with qml.tape.QuantumTape(do_queue=False) as v_circuit:
-            qml.RZ(0.1, wires=1)
+        U = QuantumScript([qml.Hadamard(wires=0)])
+        v_circuit = QuantumScript([qml.RZ(0.1, wires=1)])
 
         with pytest.raises(
             qml.QuantumFunctionError,
             match="The argument v_function must be a callable quantum " "function.",
         ):
-            qml.HilbertSchmidt([0.1], v_function=v_circuit, v_wires=[1], u_tape=U)
+            qml.HilbertSchmidt([0.1], v_function=v_circuit, v_wires=[1], u_script=U)
 
     def test_u_v_same_number_of_wires(self):
         """Test that U and V must have the same number of wires."""
 
-        with qml.tape.QuantumTape(do_queue=False) as U:
-            qml.CNOT(wires=[0, 1])
+        U = QuantumScript([qml.CNOT(wires=[0, 1])])
 
         def v_circuit(params):
             qml.RZ(params[0], wires=1)
@@ -141,10 +132,10 @@ class TestHilbertSchmidt:
         with pytest.raises(
             qml.QuantumFunctionError, match="U and V must have the same number of wires."
         ):
-            qml.HilbertSchmidt([0.1], v_function=v_circuit, v_wires=[2], u_tape=U)
+            qml.HilbertSchmidt([0.1], v_function=v_circuit, v_wires=[2], u_script=U)
 
-    def test_u_quantum_tape(self):
-        """Test that U must be a quantum tape."""
+    def test_u_quantum_script(self):
+        """Test that U must be a quantum script."""
 
         def u_circuit():
             qml.CNOT(wires=[0, 1])
@@ -153,37 +144,35 @@ class TestHilbertSchmidt:
             qml.RZ(params[0], wires=1)
 
         with pytest.raises(
-            qml.QuantumFunctionError, match="The argument u_tape must be a QuantumTape."
+            qml.QuantumFunctionError, match="The argument u_script must be a QuantumScript."
         ):
-            qml.HilbertSchmidt([0.1], v_function=v_circuit, v_wires=[1], u_tape=u_circuit)
+            qml.HilbertSchmidt([0.1], v_function=v_circuit, v_wires=[1], u_script=u_circuit)
 
     def test_v_wires(self):
         """Test that all wires in V are also in v_wires."""
 
-        with qml.tape.QuantumTape(do_queue=False) as U:
-            qml.Hadamard(wires=0)
+        U = QuantumScript([qml.Hadamard(wires=0)])
 
         def v_circuit(params):
             qml.RZ(params[0], wires=2)
 
         with pytest.raises(
-            qml.QuantumFunctionError, match="All wires in v_tape must be in v_wires."
+            qml.QuantumFunctionError, match="All wires in v_script must be in v_wires."
         ):
-            qml.HilbertSchmidt([0.1], v_function=v_circuit, v_wires=[1], u_tape=U)
+            qml.HilbertSchmidt([0.1], v_function=v_circuit, v_wires=[1], u_script=U)
 
     def test_distinct_wires(self):
         """Test that U and V have distinct wires."""
 
-        with qml.tape.QuantumTape(do_queue=False) as U:
-            qml.Hadamard(wires=0)
+        U = QuantumScript([qml.Hadamard(wires=0)])
 
         def v_circuit(params):
             qml.RZ(params[0], wires=0)
 
         with pytest.raises(
-            qml.QuantumFunctionError, match="u_tape and v_tape must act on distinct wires."
+            qml.QuantumFunctionError, match="u_script and v_script must act on distinct wires."
         ):
-            qml.HilbertSchmidt([0.1], v_function=v_circuit, v_wires=[0], u_tape=U)
+            qml.HilbertSchmidt([0.1], v_function=v_circuit, v_wires=[0], u_script=U)
 
 
 class TestLocalHilbertSchmidt:
@@ -191,16 +180,14 @@ class TestLocalHilbertSchmidt:
 
     def test_lhs_decomposition_1_qubit(self):
         """Test if the LHS operation is correctly decomposed"""
-        with qml.tape.QuantumTape(do_queue=False) as U:
-            qml.Hadamard(wires=0)
+        U = QuantumScript([qml.Hadamard(wires=0)])
 
         def v_circuit(params):
             qml.RZ(params[0], wires=1)
 
-        op = qml.LocalHilbertSchmidt([0.1], v_function=v_circuit, v_wires=[1], u_tape=U)
+        op = qml.LocalHilbertSchmidt([0.1], v_function=v_circuit, v_wires=[1], u_script=U)
 
-        with qml.tape.QuantumTape() as tape_dec:
-            op.decomposition()
+        script_dec = make_qscript(op.decomposition)()
 
         expected_operations = [
             qml.Hadamard(wires=[0]),
@@ -211,23 +198,21 @@ class TestLocalHilbertSchmidt:
             qml.Hadamard(wires=[0]),
         ]
 
-        for i, j in zip(tape_dec.operations, expected_operations):
+        for i, j in zip(script_dec.operations, expected_operations):
             assert i.name == j.name
             assert i.data == j.data
             assert i.wires == j.wires
 
     def test_lhs_decomposition_1_qubit_custom_wires(self):
         """Test if the LHS operation is correctly decomposed with custom wires."""
-        with qml.tape.QuantumTape(do_queue=False) as U:
-            qml.Hadamard(wires="a")
+        U = QuantumScript([qml.Hadamard(wires="a")])
 
         def v_circuit(params):
             qml.RZ(params[0], wires="b")
 
-        op = qml.LocalHilbertSchmidt([0.1], v_function=v_circuit, v_wires=["b"], u_tape=U)
+        op = qml.LocalHilbertSchmidt([0.1], v_function=v_circuit, v_wires=["b"], u_script=U)
 
-        with qml.tape.QuantumTape() as tape_dec:
-            op.decomposition()
+        script_dec = make_qscript(op.decomposition)()
 
         expected_operations = [
             qml.Hadamard(wires=["a"]),
@@ -238,24 +223,22 @@ class TestLocalHilbertSchmidt:
             qml.Hadamard(wires=["a"]),
         ]
 
-        for i, j in zip(tape_dec.operations, expected_operations):
+        for i, j in zip(script_dec.operations, expected_operations):
             assert i.name == j.name
             assert i.data == j.data
             assert i.wires == j.wires
 
     def test_lhs_decomposition_2_qubits(self):
         """Test if the LHS operation is correctly decomposed for 2 qubits."""
-        with qml.tape.QuantumTape(do_queue=False) as U:
-            qml.SWAP(wires=[0, 1])
+        U = QuantumScript([qml.SWAP(wires=[0, 1])])
 
         def v_circuit(params):
             qml.RZ(params[0], wires=2)
             qml.CNOT(wires=[2, 3])
 
-        op = qml.LocalHilbertSchmidt([0.1], v_function=v_circuit, v_wires=[2, 3], u_tape=U)
+        op = qml.LocalHilbertSchmidt([0.1], v_function=v_circuit, v_wires=[2, 3], u_script=U)
 
-        with qml.tape.QuantumTape() as tape_dec:
-            op.decomposition()
+        script_dec = make_qscript(op.decomposition)()
 
         expected_operations = [
             qml.Hadamard(wires=[0]),
@@ -269,7 +252,7 @@ class TestLocalHilbertSchmidt:
             qml.Hadamard(wires=[0]),
         ]
 
-        for i, j in zip(tape_dec.operations, expected_operations):
+        for i, j in zip(script_dec.operations, expected_operations):
             assert i.name == j.name
             assert i.data == j.data
             assert i.wires == j.wires
@@ -277,23 +260,19 @@ class TestLocalHilbertSchmidt:
     def test_v_not_quantum_function(self):
         """Test that we cannot pass a non quantum function to the HS operation"""
 
-        with qml.tape.QuantumTape(do_queue=False) as U:
-            qml.Hadamard(wires=0)
-
-        with qml.tape.QuantumTape(do_queue=False) as v_circuit:
-            qml.RZ(0.1, wires=1)
+        U = QuantumScript([qml.Hadamard(wires=0)])
+        v_circuit = QuantumScript([qml.RZ(0.1, wires=1)])
 
         with pytest.raises(
             qml.QuantumFunctionError,
             match="The argument v_function must be a callable quantum " "function.",
         ):
-            qml.LocalHilbertSchmidt([0.1], v_function=v_circuit, v_wires=[1], u_tape=U)
+            qml.LocalHilbertSchmidt([0.1], v_function=v_circuit, v_wires=[1], u_script=U)
 
     def test_u_v_same_number_of_wires(self):
         """Test that U and V must have the same number of wires."""
 
-        with qml.tape.QuantumTape(do_queue=False) as U:
-            qml.CNOT(wires=[0, 1])
+        U = QuantumScript([qml.CNOT(wires=[0, 1])])
 
         def v_circuit(params):
             qml.RZ(params[0], wires=1)
@@ -301,10 +280,10 @@ class TestLocalHilbertSchmidt:
         with pytest.raises(
             qml.QuantumFunctionError, match="U and V must have the same number of wires."
         ):
-            qml.LocalHilbertSchmidt([0.1], v_function=v_circuit, v_wires=[2], u_tape=U)
+            qml.LocalHilbertSchmidt([0.1], v_function=v_circuit, v_wires=[2], u_script=U)
 
-    def test_u_quantum_tape(self):
-        """Test that U must be a quantum tape."""
+    def test_u_quantum_script(self):
+        """Test that U must be a quantum script."""
 
         def u_circuit():
             qml.CNOT(wires=[0, 1])
@@ -313,34 +292,32 @@ class TestLocalHilbertSchmidt:
             qml.RZ(params[0], wires=1)
 
         with pytest.raises(
-            qml.QuantumFunctionError, match="The argument u_tape must be a QuantumTape."
+            qml.QuantumFunctionError, match="The argument u_script must be a QuantumScript."
         ):
-            qml.LocalHilbertSchmidt([0.1], v_function=v_circuit, v_wires=[1], u_tape=u_circuit)
+            qml.LocalHilbertSchmidt([0.1], v_function=v_circuit, v_wires=[1], u_script=u_circuit)
 
     def test_v_wires(self):
         """Test that all wires in V are also in v_wires."""
 
-        with qml.tape.QuantumTape(do_queue=False) as U:
-            qml.Hadamard(wires=0)
+        U = QuantumScript([qml.Hadamard(wires=0)])
 
         def v_circuit(params):
             qml.RZ(params[0], wires=2)
 
         with pytest.raises(
-            qml.QuantumFunctionError, match="All wires in v_tape must be in v_wires."
+            qml.QuantumFunctionError, match="All wires in v_script must be in v_wires."
         ):
-            qml.LocalHilbertSchmidt([0.1], v_function=v_circuit, v_wires=[1], u_tape=U)
+            qml.LocalHilbertSchmidt([0.1], v_function=v_circuit, v_wires=[1], u_script=U)
 
     def test_distinct_wires(self):
         """Test that U and V have distinct wires."""
 
-        with qml.tape.QuantumTape(do_queue=False) as U:
-            qml.Hadamard(wires=0)
+        U = QuantumScript([qml.Hadamard(wires=0)])
 
         def v_circuit(params):
             qml.RZ(params[0], wires=0)
 
         with pytest.raises(
-            qml.QuantumFunctionError, match="u_tape and v_tape must act on distinct wires."
+            qml.QuantumFunctionError, match="u_script and v_script must act on distinct wires."
         ):
-            qml.LocalHilbertSchmidt([0.1], v_function=v_circuit, v_wires=[0], u_tape=U)
+            qml.LocalHilbertSchmidt([0.1], v_function=v_circuit, v_wires=[0], u_script=U)


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      test directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `doc/releases/changelog-dev.md` file, summarizing the
      change, and including a link back to the PR.

- [ ] The PennyLane source code conforms to
      [PEP8 standards](https://www.python.org/dev/peps/pep-0008/).
      We check all of our code against [Pylint](https://www.pylint.org/).
      To lint modified files, simply `pip install pylint`, and then
      run `pylint pennylane/path/to/file.py`.

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**

<details><summary>Example init outputs</summary>

```pycon
### prep
>>> U = qml.tape.QuantumScript([qml.Hadamard(wires=0)])
>>> def v_func(params):
...     qml.RZ(params[0], wires=1)
... 

### the (newly) correct way

>>> qml.HilbertSchmidt([0], v_function=v_func, v_wires=[1], u_script=U)
HilbertSchmidt([0], wires=[0, 1])

### the deprecated way

>>> qml.HilbertSchmidt([0], v_function=v_func, v_wires=[1], u_tape=U)
/Users/matthews/src/github.com/PennyLaneAI/pennylane/pennylane/templates/subroutines/hilbert_schmidt.py:105: UserWarning: The u_tape keyword is deprecated. Please use u_script instead.
  warnings.warn("The u_tape keyword is deprecated. Please use u_script instead.", UserWarning)
HilbertSchmidt([0], wires=[0, 1])

### Using both old and new - not allowed

>>> qml.HilbertSchmidt([0], v_function=v_func, v_wires=[1], u_script=U, u_tape=U)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/matthews/src/github.com/PennyLaneAI/pennylane/pennylane/templates/subroutines/hilbert_schmidt.py", line 108, in __init__
    raise ValueError("Only u_script should be used. The u_tape keyword is deprecated.")
ValueError: Only u_script should be used. The u_tape keyword is deprecated.

### Using neither - not allowed, would be TypeError with base python

>>> qml.HilbertSchmidt([0], v_function=v_func, v_wires=[1])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/matthews/src/github.com/PennyLaneAI/pennylane/pennylane/templates/subroutines/hilbert_schmidt.py", line 104, in __init__
    raise TypeError("HilbertSchmidt missing 1 required keyword-only argument: 'u_script'")
TypeError: __init__() missing 1 required keyword-only argument: 'u_script'
```
</details>
