### PR TITLE
Update grouping warning from `DeprecationWarning` to `UserWarning`

### DIFF
--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -9,8 +9,8 @@ Pending deprecations
 * The ``grouping`` module is deprecated. The functionality has been moved and
   reorganized in the new ``pauli`` module under ``pauli/utils.py`` or ``pauli/grouping/``.
 
-  - Still accessible in v0.27
-  - Will be removed in v0.28
+  - Still accessible in v0.27, v0.28
+  - Will be removed in v0.29
 
   The functions from ``grouping/pauli.py``, ``grouping/transformations.py`` and
   ``grouping/utils.py`` have been moved to ``pauli/utils.py``. The remaining functions

--- a/pennylane/__init__.py
+++ b/pennylane/__init__.py
@@ -348,7 +348,7 @@ def __getattr__(name):
     if name == "grouping":
         warnings.warn(
             "The qml.grouping module is deprecated, please use qml.pauli instead.",
-            DeprecationWarning,
+            UserWarning,
         )
         import pennylane.grouping as grouping  # pylint:disable=import-outside-toplevel,consider-using-from-import
 


### PR DESCRIPTION
**Context:**
Grouping module is now deprecated, we used to raise a `DeprecationWarning`, but this gets ignored by default, resulting in no error message being displayed. 

**Description of the Change:**
Raise `UserWarning` instead so that it is raised correctly.