### PR TITLE
[WIP] Update operator `matrix()` to use `_pauli_rep` (Pauli Integration#2)

### DIFF
--- a/pennylane/ops/op_math/pow.py
+++ b/pennylane/ops/op_math/pow.py
@@ -244,6 +244,13 @@ class Pow(SymbolicOp):
         )
 
     def matrix(self, wire_order=None):
+        try:
+            pr = self._pauli_rep
+            wires = wire_order or self.wires.tolist()
+            return pr.to_mat(wire_order=wires)
+        except NotImplementedError:
+            pass
+
         if isinstance(self.base, qml.Hamiltonian):
             base_matrix = qml.matrix(self.base)
         else:
@@ -266,6 +273,22 @@ class Pow(SymbolicOp):
             base_matrix = base.compute_sparse_matrix(*params, **base.hyperparameters)
             return base_matrix**z
         raise SparseMatrixUndefinedError
+
+    def sparse_matrix(self, wire_order=None):
+        try:
+            pr = self._pauli_rep
+            wires = wire_order or self.wires.tolist()
+            return pr.to_mat(wire_order=wires, format="csr")
+        except NotImplementedError:
+            pass
+
+        canonical_sparse_matrix = self.compute_sparse_matrix(
+            *self.parameters, **self.hyperparameters
+        )
+
+        return qmlmath.expand_matrix(
+            canonical_sparse_matrix, wires=self.wires, wire_order=wire_order
+        )
 
     # pylint: disable=arguments-renamed, invalid-overridden-method
     @property

--- a/pennylane/ops/op_math/prod.py
+++ b/pennylane/ops/op_math/prod.py
@@ -231,6 +231,12 @@ class Prod(CompositeOp):
 
     def matrix(self, wire_order=None):
         """Representation of the operator as a matrix in the computational basis."""
+        try:
+            pr = self._pauli_rep
+            wires = wire_order or self.wires.tolist()
+            return pr.to_mat(wire_order=wires)
+        except NotImplementedError:
+            pass
 
         def mats_gen():
             for ops in self.overlapping_ops:
@@ -259,6 +265,13 @@ class Prod(CompositeOp):
         return math.expand_matrix(full_mat, self.wires, wire_order=wire_order)
 
     def sparse_matrix(self, wire_order=None):
+        try:
+            pr = self._pauli_rep
+            wires = wire_order or self.wires.tolist()
+            return pr.to_mat(wire_order=wires, format="csr")
+        except NotImplementedError:
+            pass
+
         if self.has_overlapping_wires or self.num_wires > MAX_NUM_WIRES_KRON_PRODUCT:
             mats_and_wires_gen = ((op.sparse_matrix(), op.wires) for op in self)
 

--- a/pennylane/ops/op_math/sprod.py
+++ b/pennylane/ops/op_math/sprod.py
@@ -198,6 +198,13 @@ class SProd(SymbolicOp):
         return self.scalar * self.base.eigvals()
 
     def sparse_matrix(self, wire_order=None):
+        try:
+            pr = self._pauli_rep
+            wires = wire_order or self.wires.tolist()
+            return pr.to_mat(wire_order=wires, format="csr")
+        except NotImplementedError:
+            pass
+
         return self.scalar * self.base.sparse_matrix(wire_order=wire_order)
 
     @property
@@ -225,6 +232,13 @@ class SProd(SymbolicOp):
         Returns:
             tensor_like: matrix representation
         """
+        try:
+            pr = self._pauli_rep
+            wires = wire_order or self.wires.tolist()
+            return pr.to_mat(wire_order=wires)
+        except NotImplementedError:
+            pass
+
         if isinstance(self.base, qml.Hamiltonian):
             return self.scalar * qml.matrix(self.base, wire_order=wire_order)
         return self.scalar * self.base.matrix(wire_order=wire_order)

--- a/pennylane/ops/op_math/sum.py
+++ b/pennylane/ops/op_math/sum.py
@@ -163,6 +163,12 @@ class Sum(CompositeOp):
         Returns:
             tensor_like: matrix representation
         """
+        try:
+            pr = self._pauli_rep
+            return pr.to_mat(wire_order=wire_order)
+        except NotImplementedError:
+            pass
+
         mats_and_wires_gen = (
             (qml.matrix(op) if isinstance(op, qml.Hamiltonian) else op.matrix(), op.wires)
             for op in self


### PR DESCRIPTION
**Context:**
We can now make use of the `PauliSentence` and `PauliWord` classes to quickly and efficiently compute the matrix of a given operator! 

**Related GitHub Issues:**
https://github.com/PennyLaneAI/pennylane/pull/3443
