### PR TITLE
Allow devices to specify if they want to disregard grouping

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -271,6 +271,9 @@
 * Replace (almost) all instances of `with QuantumTape()` with `QuantumScript` construction.
   [(#3454)](https://github.com/PennyLaneAI/pennylane/pull/3454)
 
+* Adds support for devices disregarding observable grouping indices in Hamiltonians through
+  the optional `use_grouping` attribute.
+  [(#3456)](https://github.com/PennyLaneAI/pennylane/pull/3456)
 
 <h4>Return types project</h4>
 
@@ -539,6 +542,7 @@ Astral Cai
 Isaac De Vlugt
 Pieter Eendebak
 Lillian M. A. Frederiksen
+Katharine Hyatt
 Soran Jahangiri
 Edward Jiang
 Christina Lee

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -731,6 +731,7 @@ class Device(abc.ABC):
             for obs in circuit.observables
             if obs.name == "Hamiltonian"
         )
+        # device property present in braket plugin
         use_grouping = getattr(self, "use_grouping", True)
 
         hamiltonian_in_obs = "Hamiltonian" in [obs.name for obs in circuit.observables]

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -731,17 +731,16 @@ class Device(abc.ABC):
             for obs in circuit.observables
             if obs.name == "Hamiltonian"
         )
-        use_grouping = getattr(self, 'use_grouping', True)
+        use_grouping = getattr(self, "use_grouping", True)
 
         hamiltonian_in_obs = "Hamiltonian" in [obs.name for obs in circuit.observables]
 
         return_types = [m.return_type for m in circuit.observables]
 
         is_shadow = ShadowExpval in return_types
+        hamiltonian_usable = not supports_hamiltonian or (finite_shots and not is_shadow)
 
-        if hamiltonian_in_obs and (
-            (not supports_hamiltonian or (finite_shots and not is_shadow)) or (use_grouping and grouping_known)
-        ):
+        if hamiltonian_in_obs and (hamiltonian_usable or (use_grouping and grouping_known)):
             # If the observable contains a Hamiltonian and the device does not
             # support Hamiltonians, or if the simulation uses finite shots, or
             # if the Hamiltonian explicitly specifies an observable grouping,

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -731,6 +731,7 @@ class Device(abc.ABC):
             for obs in circuit.observables
             if obs.name == "Hamiltonian"
         )
+        use_grouping = getattr(self, 'use_grouping', True)
 
         hamiltonian_in_obs = "Hamiltonian" in [obs.name for obs in circuit.observables]
 
@@ -739,7 +740,7 @@ class Device(abc.ABC):
         is_shadow = ShadowExpval in return_types
 
         if hamiltonian_in_obs and (
-            (not supports_hamiltonian or (finite_shots and not is_shadow)) or grouping_known
+            (not supports_hamiltonian or (finite_shots and not is_shadow)) or (use_grouping and grouping_known)
         ):
             # If the observable contains a Hamiltonian and the device does not
             # support Hamiltonians, or if the simulation uses finite shots, or

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -739,9 +739,9 @@ class Device(abc.ABC):
         return_types = [m.return_type for m in circuit.observables]
 
         is_shadow = ShadowExpval in return_types
-        hamiltonian_usable = not supports_hamiltonian or (finite_shots and not is_shadow)
+        hamiltonian_unusable = not supports_hamiltonian or (finite_shots and not is_shadow)
 
-        if hamiltonian_in_obs and (hamiltonian_usable or (use_grouping and grouping_known)):
+        if hamiltonian_in_obs and (hamiltonian_unusable or (use_grouping and grouping_known)):
             # If the observable contains a Hamiltonian and the device does not
             # support Hamiltonians, or if the simulation uses finite shots, or
             # if the Hamiltonian explicitly specifies an observable grouping,

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -125,7 +125,7 @@ class Device(abc.ABC):
     """
 
     # pylint: disable=too-many-public-methods,too-many-instance-attributes
-    _capabilities = {"model": None, "supports_broadcasting": False, "use_grouping": True}
+    _capabilities = {"model": None, "supports_broadcasting": False}
     """The capabilities dictionary stores the properties of a device. Devices can add their
     own custom properties and overwrite existing ones by overriding the ``capabilities()`` method."""
 

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -125,7 +125,7 @@ class Device(abc.ABC):
     """
 
     # pylint: disable=too-many-public-methods,too-many-instance-attributes
-    _capabilities = {"model": None, "supports_broadcasting": False}
+    _capabilities = {"model": None, "supports_broadcasting": False, "use_grouping": True}
     """The capabilities dictionary stores the properties of a device. Devices can add their
     own custom properties and overwrite existing ones by overriding the ``capabilities()`` method."""
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1023,14 +1023,17 @@ class TestBatchExecution:
             res[0], dev.execute(empty_tape.operations, empty_tape.observables), rtol=tol, atol=0
         )
 
+
 class TestGrouping:
     """Tests for the use_grouping option for devices."""
+
     @pytest.mark.parametrize("use_grouping", (True, False))
     def test_batch_transform_checks_use_grouping_property(use_grouping):
         """If the device specifies `use_grouping=False`, the batch transform
         method won't expand the hamiltonian when the measured hamiltonian has
         grouping indices.
         """
+
         class TestDevice(qml.Device):
             name = ""
             short_name = ""
@@ -1044,7 +1047,7 @@ class TestGrouping:
             reset = lambda *args, **kwargs: 0
             supports_observable = lambda *args, **kwargs: True
 
-        H = qml.Hamiltonian([1.0, 1.0], [qml.PauliX(0), qml.PauliY(0)], grouping_type='qwc')
+        H = qml.Hamiltonian([1.0, 1.0], [qml.PauliX(0), qml.PauliY(0)], grouping_type="qwc")
         qs = qml.tape.QuantumScript(measurements=[qml.expval(H)])
 
         dev = TestDevice()

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1028,7 +1028,7 @@ class TestGrouping:
     """Tests for the use_grouping option for devices."""
 
     @pytest.mark.parametrize("use_grouping", (True, False))
-    def test_batch_transform_checks_use_grouping_property(use_grouping):
+    def test_batch_transform_checks_use_grouping_property(self, use_grouping):
         """If the device specifies `use_grouping=False`, the batch transform
         method won't expand the hamiltonian when the measured hamiltonian has
         grouping indices.

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1022,3 +1022,37 @@ class TestBatchExecution:
         assert np.allclose(
             res[0], dev.execute(empty_tape.operations, empty_tape.observables), rtol=tol, atol=0
         )
+
+class TestGrouping:
+    """Tests for the use_grouping option for devices."""
+    @pytest.mark.parametrize("use_grouping", (True, False))
+    def test_batch_transform_checks_use_grouping_property(use_grouping):
+        """If the device specifies `use_grouping=False`, the batch transform
+        method won't expand the hamiltonian when the measured hamiltonian has
+        grouping indices.
+        """
+        class TestDevice(qml.Device):
+            name = ""
+            short_name = ""
+            pennylane_requires = ""
+            version = ""
+            author = ""
+            operations = ""
+            observables = ""
+            apply = lambda *args, **kwargs: 0
+            expval = lambda *args, **kwargs: 0
+            reset = lambda *args, **kwargs: 0
+            supports_observable = lambda *args, **kwargs: True
+
+        H = qml.Hamiltonian([1.0, 1.0], [qml.PauliX(0), qml.PauliY(0)], grouping_type='qwc')
+        qs = qml.tape.QuantumScript(measurements=[qml.expval(H)])
+
+        dev = TestDevice()
+        dev.shots = None
+        dev.use_grouping = use_grouping
+        new_qscripts, post_proc_fn = dev.batch_transform(qs)
+
+        if use_grouping:
+            assert len(new_qscripts) == 2
+        else:
+            assert len(new_qscripts) == 1


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      test directory!

- [x] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `doc/releases/changelog-dev.md` file, summarizing the
      change, and including a link back to the PR.

- [x] The PennyLane source code conforms to
      [PEP8 standards](https://www.python.org/dev/peps/pep-0008/).
      We check all of our code against [Pylint](https://www.pylint.org/).
      To lint modified files, simply `pip install pylint`, and then
      run `pylint pennylane/path/to/file.py`.

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**

Add variable in `execute` to allow devices to request that Hamiltonians **not** be expanded using grouped indices, even if they are known.

**Description of the Change:**

Default behaviour is unchanged. If a device does have a `use_grouping` attr, it can specify that grouping not be used.

**Benefits:**

Allows devices to control whether one expectation value or many are calculated. Avoids unexpected conversion of one observable (a Hamiltonian) into a list of observables.

**Possible Drawbacks:**

Degraded performance if device developers choose badly when setting the default for their device.

**Related GitHub Issues:**
