### PR TITLE
Get parameter shift gradients with the new `Evolution` operator

### DIFF
--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -1335,7 +1335,7 @@ class Operation(Operator):
                 eigvals = qml.eigvals(gen)
 
             eigvals = tuple(np.round(eigvals, 8))
-            return qml.gradients.eigvals_to_frequencies(eigvals)
+            return [qml.gradients.eigvals_to_frequencies(eigvals)]
 
         raise ParameterFrequenciesUndefinedError(
             f"Operation {self.name} does not have parameter frequencies defined, "

--- a/pennylane/ops/op_math/exp.py
+++ b/pennylane/ops/op_math/exp.py
@@ -165,7 +165,7 @@ class Exp(SymbolicOp, Operation):
 
     @property
     def hash(self):
-        return hash((str(self.name), self.base.hash, tuple(self.data)))
+        return hash((str(self.name), self.base.hash, self.coeff))
 
     @property
     def data(self):

--- a/pennylane/ops/op_math/exp.py
+++ b/pennylane/ops/op_math/exp.py
@@ -165,7 +165,7 @@ class Exp(SymbolicOp, Operation):
 
     @property
     def hash(self):
-        return hash((str(self.name), self.base.hash, self.coeff))
+        return hash((str(self.name), self.base.hash, str(self.coeff)))
 
     @property
     def data(self):

--- a/pennylane/ops/qubit/hamiltonian.py
+++ b/pennylane/ops/qubit/hamiltonian.py
@@ -393,6 +393,7 @@ class Hamiltonian(Observable):
         self._wires = qml.wires.Wires.all_wires([op.wires for op in self.ops], sort=True)
         # reset grouping, since the indices refer to the old observables and coefficients
         self._grouping_indices = None
+        return self
 
     def __str__(self):
         def wires_print(ob: Observable):

--- a/tests/ops/op_math/test_exp.py
+++ b/tests/ops/op_math/test_exp.py
@@ -99,7 +99,7 @@ class TestProperties:
     """Test of the properties of the Exp class."""
 
     def test_data(self):
-        """Test accessing and setting the data property."""
+        """Test intializaing and accessing the data property."""
 
         phi = np.array(1.234)
         coeff = np.array(2.345)
@@ -108,13 +108,6 @@ class TestProperties:
         op = Exp(base, coeff)
 
         assert op.data == [[coeff], [phi]]
-
-        new_data = [[-2.1], [-3.4]]
-        op.data = new_data
-
-        assert op.data == new_data
-        assert op.coeff == -2.1
-        assert base.data == [-3.4]
 
     def test_queue_category_ops(self):
         """Test the _queue_category property."""
@@ -631,7 +624,7 @@ class TestDifferentiation:
     def test_parameter_frequencies(self):
         """Test parameter_frequencies property"""
         op = Exp(qml.PauliZ(1), 1j)
-        assert op.parameter_frequencies == (2,)
+        assert op.parameter_frequencies == [(2,)]
 
     def test_parameter_frequencies_raises_error(self):
         """Test that parameter_frequencies raises an error if the op.generator() is undefined"""
@@ -652,7 +645,7 @@ class TestDifferentiation:
         with pytest.raises(ParameterFrequenciesUndefinedError):
             op1.parameter_frequencies()
 
-        assert op2.parameter_frequencies == (4.0,)
+        assert op2.parameter_frequencies == [(4.0,)]
 
 
 class TestEvolution:
@@ -695,7 +688,7 @@ class TestEvolution:
         assert op.num_params == 1
 
     def test_data(self):
-        """Test accessing and setting the data property."""
+        """Test initializing and accessing the data property."""
 
         param = np.array(1.234)
 
@@ -703,11 +696,6 @@ class TestEvolution:
         op = Evolution(base, param)
 
         assert op.data == [param]
-
-        new_data = [2.345]
-        op.data = new_data
-
-        assert op.data == new_data
         assert op.coeff == 1j * op.data[0]
         assert op.param == op.data[0]
 

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -625,7 +625,7 @@ class TestOperationConstruction:
 
         x = 0.654
         op = DummyOp(x, wires=0)
-        assert op.parameter_frequencies == (0.4,)
+        assert op.parameter_frequencies == [(0.4,)]
 
     def test_frequencies_default_multi_param(self):
         """Test that an operation with default parameter frequencies and multiple


### PR DESCRIPTION
We had a couple of problems to fix to get `Evolution` working with parameter shift gradients.

First, the shape of `RX.parameter_frequencies` is different from that in the default `Operator.parameter_frequencies` definition.  This PR adds a layer of nesting to `Operator.parameter_frequencies` so it matches that returned by classes like `RX`.

Second, now `Hamiltonian.simplify` returns an instance of itself and adheres to the stated interface for that method. This was causing problems with decomposing the exponential operator. I'm unsure if it was affecting the gradients, but it was giving me errors.

As for changes to `Exp`, it now has `Exp.__copy__` and `Exp.hash`.

I also make `coeff` and `param` properties dynamically inferred from the data.

@lillian542 Feel free to merge this into your PR if you are happy with it.

This allows us to do:
```
op.data[0] = new_param
```
and have the parameter updated.

In the long term, we need official getter and setters for the parameters.