### PR TITLE
deprecate make_tape

### DIFF
--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -100,6 +100,12 @@ Pending deprecations
 
     tapes, fn = qml.transforms.hamiltonian_expand(tape)
 
+* ``qml.transforms.make_tape`` has been deprecated, and usage will now raise a warning.
+  Instead, use ``qml.tape.make_qscript``.
+
+  - Deprecated in v0.28
+  - Will be removed in v0.29
+
 Completed deprecation cycles
 ----------------------------
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -511,6 +511,9 @@ Deprecations cycles are tracked at [doc/developement/deprecations.rst](https://d
   wanted seed.
   [(#3388)](https://github.com/PennyLaneAI/pennylane/pull/3388)
 
+* `make_tape` is deprecated. Please use `qml.tape.make_qscript` instead.
+  [(#3478)](https://github.com/PennyLaneAI/pennylane/pull/3478)
+
 <h3>Documentation</h3>
 
 * Adds developer documentation for the queuing module.

--- a/pennylane/transforms/qfunc_transforms.py
+++ b/pennylane/transforms/qfunc_transforms.py
@@ -65,6 +65,8 @@ def make_tape(fn):
     [RY(1.0, wires=[0])]
     """
 
+    warnings.warn("``make_tape`` is deprecated in favor of ``qml.tape.make_qscript``", UserWarning)
+
     def wrapper(*args, **kwargs):
         with qml.QueuingManager.stop_recording(), qml.tape.QuantumTape() as new_tape:
             fn(*args, **kwargs)

--- a/tests/transforms/test_qfunc_transform.py
+++ b/tests/transforms/test_qfunc_transform.py
@@ -323,6 +323,15 @@ class TestQFuncTransforms:
 
         assert original_fn is decorated_transform
 
+    def test_make_tape_is_deprecated(self):
+        """Test that make_tape is deprecated and points users to make_qscript."""
+
+        def circuit(x):
+            qml.RX(x, wires=0)
+
+        with pytest.warns(UserWarning, match="qml.tape.make_qscript"):
+            tape = qml.transforms.make_tape(circuit)(0.1)
+
 
 ############################################
 # Test transform, ansatz, and qfunc function


### PR DESCRIPTION
**Context:**
It's not used anywhere in the codebase anymore, and we don't want any new code to use it

**Description of the Change:**
Add a deprecation warning when `make_tape` is used.

**Benefits:**
People will know to use `make_qscript` instead.

**Possible Drawbacks:**
N/A