### PR TITLE
Sphinx: do NOT add an inheritance diagram by default

### DIFF
--- a/doc/code/qml.rst
+++ b/doc/code/qml.rst
@@ -6,5 +6,4 @@ qml
 .. automodapi:: pennylane
     :no-heading:
     :include-all-objects:
-    :no-inheritance-diagram:
     :skip: iter_entry_points, Version, SimpleSpec, plugin_devices, plugin_converters, default_config, reload

--- a/doc/code/qml.rst
+++ b/doc/code/qml.rst
@@ -6,4 +6,5 @@ qml
 .. automodapi:: pennylane
     :no-heading:
     :include-all-objects:
+    :no-inheritance-diagram:
     :skip: iter_entry_points, Version, SimpleSpec, plugin_devices, plugin_converters, default_config, reload

--- a/doc/code/qml_data.rst
+++ b/doc/code/qml_data.rst
@@ -5,5 +5,4 @@ qml.data
 
 .. automodapi:: pennylane.data
     :no-heading:
-    :no-inheritance-diagram:
     :no-inherited-members:

--- a/doc/code/qml_drawer.rst
+++ b/doc/code/qml_drawer.rst
@@ -8,7 +8,6 @@ of circuits.
 
 .. automodapi:: pennylane.drawer
     :no-heading:
-    :no-inheritance-diagram:
     :no-inherited-members:
     :skip: available_styles
     :skip: use_style

--- a/doc/code/qml_fourier.rst
+++ b/doc/code/qml_fourier.rst
@@ -7,7 +7,6 @@ Overview
 .. automodapi:: pennylane.fourier
     :no-heading:
     :include-all-objects:
-    :no-inheritance-diagram:
     :no-inherited-members:
 
 Visualization

--- a/doc/code/qml_kernels.rst
+++ b/doc/code/qml_kernels.rst
@@ -16,7 +16,6 @@ matrices which can be used to mitigate device noise and sampling errors.
     :no-heading:
     :no-main-docstr:
     :include-all-objects:
-    :no-inheritance-diagram:
 
 
 Description

--- a/doc/code/qml_math.rst
+++ b/doc/code/qml_math.rst
@@ -5,5 +5,4 @@ qml.math
 
 .. automodapi:: pennylane.math
     :no-heading:
-    :no-inheritance-diagram:
     :no-inherited-members:

--- a/doc/code/qml_operation.rst
+++ b/doc/code/qml_operation.rst
@@ -14,6 +14,7 @@ qml.operation
 .. automodapi:: pennylane.operation
     :no-heading:
     :include-all-objects:
+    :inheritance-diagram:
     :skip: IntEnum, ClassPropertyDescriptor, multi_dot, pauli_eigs, Wires, eye, kron, coo_matrix, expand_matrix, QueuingManager
 
 

--- a/doc/code/qml_pauli.rst
+++ b/doc/code/qml_pauli.rst
@@ -13,7 +13,6 @@ for Pauli-word partitioning functionality used in measurement optimization.
 .. automodapi:: pennylane.pauli
     :no-heading:
     :no-main-docstr:
-    :no-inheritance-diagram:
     :no-inherited-members:
 
 PauliWord and PauliSentence
@@ -81,7 +80,6 @@ Graph colouring
 
 .. automodapi:: pennylane.pauli.grouping.graph_colouring
     :no-heading:
-    :no-inheritance-diagram:
     :no-inherited-members:
 
 

--- a/doc/code/qml_qaoa.rst
+++ b/doc/code/qml_qaoa.rst
@@ -14,7 +14,6 @@ Mixer Hamiltonians
 
 .. automodapi:: pennylane.qaoa.mixers
     :no-heading:
-    :no-inheritance-diagram:
     :no-inherited-members:
 
 Cost Hamiltonians
@@ -22,7 +21,6 @@ Cost Hamiltonians
 
 .. automodapi:: pennylane.qaoa.cost
     :no-heading:
-    :no-inheritance-diagram:
     :no-inherited-members:
 
 QAOA Layers
@@ -30,7 +28,6 @@ QAOA Layers
 
 .. automodapi:: pennylane.qaoa.layers
     :no-heading:
-    :no-inheritance-diagram:
     :no-inherited-members:
 
 Cycle Optimization

--- a/doc/code/qml_qchem.rst
+++ b/doc/code/qml_qchem.rst
@@ -13,7 +13,6 @@ number observables.
 .. automodapi:: pennylane.qchem
     :no-heading:
     :include-all-objects:
-    :no-inheritance-diagram:
     :skip: taper, symmetry_generators, paulix_ops, import_operator
 
 Differentiable Hartree-Fock

--- a/doc/code/qml_qinfo.rst
+++ b/doc/code/qml_qinfo.rst
@@ -14,7 +14,6 @@ Transforms
 
 .. automodapi:: pennylane.qinfo.transforms
     :no-heading:
-    :no-inheritance-diagram:
     :no-inherited-members:
     :skip: metric_tensor
     :skip: adjoint_metric_tensor

--- a/doc/code/qml_queuing.rst
+++ b/doc/code/qml_queuing.rst
@@ -14,6 +14,5 @@ Overview
 .. automodapi:: pennylane.queuing
     :no-heading:
     :include-all-objects:
-    :no-inheritance-diagram:
     :no-inherited-members:
     :skip: contextmanager, OrderedDict

--- a/doc/code/qml_resource.rst
+++ b/doc/code/qml_resource.rst
@@ -9,5 +9,4 @@ Overview
 .. automodapi:: pennylane.resource
     :no-heading:
     :include-all-objects:
-    :no-inheritance-diagram:
     :no-inherited-members:

--- a/doc/code/qml_tape.rst
+++ b/doc/code/qml_tape.rst
@@ -21,3 +21,4 @@ TensorFlow, and PyTorch.
 .. automodapi:: pennylane.tape
     :no-main-docstr:
     :include-all-objects:
+    :inheritance-diagram:

--- a/doc/code/qml_utils.rst
+++ b/doc/code/qml_utils.rst
@@ -11,5 +11,4 @@ qml.utils
 .. automodapi:: pennylane.utils
     :no-heading:
     :include-all-objects:
-    :no-inheritance-diagram:
     :skip: Iterable

--- a/doc/code/qml_wires.rst
+++ b/doc/code/qml_wires.rst
@@ -10,5 +10,4 @@ qml.wires
 
 .. automodapi:: pennylane.wires
     :no-heading:
-    :no-inheritance-diagram:
     :skip: Sequence, Iterable

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -12,7 +12,9 @@
 #
 # All configuration values have a default; values that are commented out
 # serve to show the default.
-import sys, os, re
+import os
+import re
+import sys
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -51,6 +53,7 @@ os.environ["SPHINX_BUILD"] = "1"
 autosummary_generate = True
 autosummary_imported_members = False
 automodapi_toctreedirnm = "code/api"
+automodapi_inheritance_diagram = False
 automodsumm_inherited_members = True
 
 # Hot fix for the error: 'You must configure the bibtex_bibfiles setting'
@@ -231,7 +234,7 @@ html_theme_options = {
     "extra_copyrights": [
         "TensorFlow, the TensorFlow logo, and any related marks are trademarks " "of Google Inc."
     ],
-    "google_analytics_tracking_id": "UA-130507810-1"
+    "google_analytics_tracking_id": "UA-130507810-1",
 }
 
 edit_on_github_project = "PennyLaneAI/pennylane"


### PR DESCRIPTION
1. Add `automodapi_inheritance_diagram = False` sphinx variable to avoid calling `:no-inheritance-diagram:` in every doc page.
2. Remove `:no-inheritance-diagram:` where used and add `:inheritance-diagram:` where needed.
3. Remove the inheritance diagram from `qml.rst` because it is incomprehensible: [see here](https://docs.pennylane.ai/en/stable/code/qml.html#class-inheritance-diagram)
