### PR TITLE
Add gamma functions to the math module

### DIFF
--- a/pennylane/math/single_dispatch.py
+++ b/pennylane/math/single_dispatch.py
@@ -87,6 +87,14 @@ def _cond(pred, true_fn, false_fn, args):
 ar.register_function("numpy", "cond", _cond)
 ar.register_function("builtins", "cond", _cond)
 
+ar.register_function("numpy", "gamma", lambda x: _i("autograd").scipy.special.gamma(x))
+ar.register_function("numpy", "gammainc", lambda x, y: _i("autograd").scipy.special.gammainc(x, y))
+
+ar.register_function("builtins", "gamma", lambda x: _i("autograd").scipy.special.gamma(x))
+ar.register_function(
+    "builtins", "gammainc", lambda x, y: _i("autograd").scipy.special.gammainc(x, y)
+)
+
 # -------------------------------- Autograd --------------------------------- #
 
 
@@ -185,6 +193,11 @@ ar.register_function(
 
 ar.register_function("autograd", "diagonal", lambda x, *args: _i("qml").numpy.diag(x))
 ar.register_function("autograd", "cond", _cond)
+
+ar.register_function(
+    "autograd", "gammainc", lambda x, y: _i("autograd").scipy.special.gammainc(x, y)
+)
+ar.register_function("autograd", "gamma", lambda x: _i("autograd").scipy.special.gamma(x))
 
 
 # -------------------------------- TensorFlow --------------------------------- #
@@ -679,4 +692,9 @@ ar.register_function(
     "jax",
     "cond",
     lambda pred, true_fn, false_fn, args: _i("jax").lax.cond(pred, true_fn, false_fn, *args),
+)
+
+ar.register_function("jax", "gammainc", lambda x, y: _i("jax").scipy.special.gammainc(x, y))
+ar.register_function(
+    "jax", "gamma", lambda x: _i("jax").numpy.exp(_i("jax").scipy.special.gammaln(x))
 )

--- a/pennylane/qchem/integrals.py
+++ b/pennylane/qchem/integrals.py
@@ -711,11 +711,11 @@ def _boys(n, t):
     Returns:
         (array[float]): value of the Boys function
     """
-    return np.where(
+    return qml.math.where(
         t == 0.0,
         1 / (2 * n + 1),
-        asp.special.gammainc(n + 0.5, t + (t == 0.0))
-        * asp.special.gamma(n + 0.5)
+        qml.math.gammainc(n + 0.5, t + (t == 0.0))
+        * qml.math.gamma(n + 0.5)
         / (2 * (t + (t == 0.0)) ** (n + 0.5)),
     )  # (t == 0.0) is added to avoid divide by zero
 


### PR DESCRIPTION
**Context:**
The PR adds the gamma function and the incomplete gamma function needed for computing the Boys function to `qml.math`.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
