### PR TITLE
Docs update - change qnode kwarg to diff_method

### DIFF
--- a/pennylane/gradients/__init__.py
+++ b/pennylane/gradients/__init__.py
@@ -111,7 +111,7 @@ creating the QNode:
 
 .. code-block:: python
 
-    @qml.qnode(dev, gradient_fn=qml.gradients.param_shift)
+    @qml.qnode(dev, diff_method=qml.gradients.param_shift)
     def circuit(weights):
         ...
 

--- a/pennylane/gradients/finite_difference.py
+++ b/pennylane/gradients/finite_difference.py
@@ -586,7 +586,7 @@ def finite_diff(
     to use during autodifferentiation:
 
     >>> dev = qml.device("default.qubit", wires=2)
-    >>> @qml.qnode(dev, gradient_fn=qml.gradients.finite_diff)
+    >>> @qml.qnode(dev, diff_method=qml.gradients.finite_diff)
     ... def circuit(params):
     ...     qml.RX(params[0], wires=0)
     ...     qml.RY(params[1], wires=0)

--- a/pennylane/gradients/parameter_shift.py
+++ b/pennylane/gradients/parameter_shift.py
@@ -1740,7 +1740,7 @@ def param_shift(
     to use during autodifferentiation:
 
     >>> dev = qml.device("default.qubit", wires=2)
-    >>> @qml.qnode(dev, gradient_fn=qml.gradients.param_shift)
+    >>> @qml.qnode(dev, diff_method=qml.gradients.param_shift)
     ... def circuit(params):
     ...     qml.RX(params[0], wires=0)
     ...     qml.RY(params[1], wires=0)

--- a/pennylane/ops/op_math/sprod.py
+++ b/pennylane/ops/op_math/sprod.py
@@ -97,7 +97,7 @@ class SProd(SymbolicOp):
 
             dev = qml.device("default.qubit", wires=1)
 
-            @qml.qnode(dev, grad_method="best")
+            @qml.qnode(dev, diff_method="best")
             def circuit(scalar, theta):
                 qml.RX(theta, wires=0)
                 return qml.expval(qml.s_prod(scalar, qml.Hadamard(wires=0)))

--- a/pennylane/ops/op_math/sum.py
+++ b/pennylane/ops/op_math/sum.py
@@ -107,7 +107,7 @@ class Sum(CompositeOp):
             sum_op = Sum(qml.PauliX(0), qml.PauliZ(1))
             dev = qml.device("default.qubit", wires=2)
 
-            @qml.qnode(dev, grad_method="best")
+            @qml.qnode(dev, diff_method="best")
             def circuit(weights):
                 qml.RX(weights[0], wires=0)
                 qml.RY(weights[1], wires=1)

--- a/tests/ops/op_math/test_sprod.py
+++ b/tests/ops/op_math/test_sprod.py
@@ -703,7 +703,7 @@ class TestIntegration:
         is used in the measurement process."""
         dev = qml.device("default.qubit", wires=1)
 
-        @qml.qnode(dev, grad_method="best")
+        @qml.qnode(dev, diff_method="best")
         def circuit(scalar):
             qml.PauliX(wires=0)
             return qml.expval(SProd(scalar, qml.Hadamard(wires=0)))
@@ -719,7 +719,7 @@ class TestIntegration:
         sprod_op = SProd(100, qml.Hadamard(0))
         dev = qml.device("default.qubit", wires=1)
 
-        @qml.qnode(dev, grad_method="best")
+        @qml.qnode(dev, diff_method="best")
         def circuit(weights):
             qml.RX(weights[0], wires=0)
             return qml.expval(sprod_op)

--- a/tests/ops/op_math/test_sum.py
+++ b/tests/ops/op_math/test_sum.py
@@ -806,7 +806,7 @@ class TestIntegration:
         sum_op = Sum(qml.PauliX(0), qml.PauliZ(1))
         dev = qml.device("default.qubit", wires=2)
 
-        @qml.qnode(dev, grad_method="best")
+        @qml.qnode(dev, diff_method="best")
         def circuit(weights):
             qml.RX(weights[0], wires=0)
             qml.RY(weights[1], wires=1)


### PR DESCRIPTION
**Context:**
Examples in docstrings and a couple of tests use `gradient_fn` or `grad_method` kwarg in the qnode. These don't work, the kwarg the qnode expects is `diff_method`.

**Description of the Change:**
Changed to `diff_method`.

**Benefits:**
Not inaccurate.

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
#3499
