### PR TITLE
Add `measurement_map` attribute to `QubitDevice`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -72,7 +72,7 @@
     measurement processes in `QubitDevice`.
 
   * Add the `QubitDevice.measurement_map` attribute, which maps a measurement class to the name
-    of the device method that overrides the measurement process.
+    of a device method that will override the measurement process.
     [(#3286)](https://github.com/PennyLaneAI/pennylane/pull/3286)
     [(#3388)](https://github.com/PennyLaneAI/pennylane/pull/3388)
     [(#3343)](https://github.com/PennyLaneAI/pennylane/pull/3343)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -70,6 +70,9 @@
 
   * Allow the execution of `SampleMeasurement`, `StateMeasurement` and `MeasurementTransform`
     measurement processes in `QubitDevice`.
+
+  * Add the `QubitDevice.measurement_map` attribute, which maps a measurement class to the name
+    of the device method that overrides the measurement process.
     [(#3286)](https://github.com/PennyLaneAI/pennylane/pull/3286)
     [(#3388)](https://github.com/PennyLaneAI/pennylane/pull/3388)
     [(#3343)](https://github.com/PennyLaneAI/pennylane/pull/3343)
@@ -84,6 +87,7 @@
     [(#3388)](https://github.com/PennyLaneAI/pennylane/pull/3388)
     [(#3439)](https://github.com/PennyLaneAI/pennylane/pull/3439)
     [(#3466)](https://github.com/PennyLaneAI/pennylane/pull/3466)
+    [(#3503)](https://github.com/PennyLaneAI/pennylane/pull/3503)
 
 * Functionality for fetching symbols and geometry of a compound from the PubChem Database using `qchem.mol_data`.
   [(#3289)](https://github.com/PennyLaneAI/pennylane/pull/3289)
@@ -301,7 +305,6 @@
 
 * Improved the performance of executing circuits under the `jax.vmap` transformation, which can now leverage the batch-execution capabilities of some devices. [(#3452)](https://github.com/PennyLaneAI/pennylane/pull/3452)
   
-
 <h4>Return types project</h4>
 
 * The autograd interface for the new return types now supports devices with shot vectors.
@@ -422,6 +425,7 @@
          [-0.383     , -0.1915    ,  0.        ,  0.        ,  0.1915    ],
          [-0.38466667, -0.19233333,  0.        ,  0.        ,  0.19233333]])>
   ```
+
 * Thy PyTorch interface supports the new return system and users can use jacobian and hessian using custom differentiation
   methods (e.g., parameter-shift, finite difference or adjoint).
   [(#3416)](https://github.com/PennyLaneAI/pennylane/pull/3414)
@@ -436,6 +440,7 @@
       qml.CNOT(wires=[0, 1])>
       return qml.expval(qml.PauliZ(0)), qml.probs([0, 1])
   ```
+
   ```pycon
   >>> a = torch.tensor(0.1, requires_grad=True)
   >>> b = torch.tensor(0.2, requires_grad=True)
@@ -475,6 +480,7 @@
   (DeviceArray(5.55111512e-17, dtype=float64, weak_type=True),
   DeviceArray(0., dtype=float64, weak_type=True)))
   ```
+
 * Updated `qml.transforms.split_non_commuting` to support the new return types.
   [(#3414)](https://github.com/PennyLaneAI/pennylane/pull/3414)
 
@@ -491,7 +497,6 @@
 * Updated `qml.transforms.cut_circuit` and `qml.transforms.cut_circuit_mc` to
   support the new return types.
   [(#3346)](https://github.com/PennyLaneAI/pennylane/pull/3346)
-
 
 <h3>Breaking changes</h3>
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -69,10 +69,9 @@
     `VnEntropyMP`, `MutualInfoMP`, `ClassicalShadowMP` and `ShadowExpvalMP` classes.
 
   * Allow the execution of `SampleMeasurement`, `StateMeasurement` and `MeasurementTransform`
-    measurement processes in `QubitDevice`.
-
-  * Add the `QubitDevice.measurement_map` attribute, which maps a measurement class to the name
-    of a device method that will override the measurement process.
+    measurement processes in `QubitDevice`. Also allow devices to override measurement processes by
+    adding a `measurement_map` attribute, which should contain the measurement class as key and
+    the method name as value.
     [(#3286)](https://github.com/PennyLaneAI/pennylane/pull/3286)
     [(#3388)](https://github.com/PennyLaneAI/pennylane/pull/3388)
     [(#3343)](https://github.com/PennyLaneAI/pennylane/pull/3343)

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -239,6 +239,7 @@ class QubitDevice(Device):
     dictionary:
 
     .. code-block:: python
+
         class NewDevice(DefaultQubit):
             def __init__(self, wires, shots):
                 super().__init__(wires=wires, shots=shots)

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -218,35 +218,20 @@ class QubitDevice(Device):
     measurement_map = defaultdict(lambda: "")  # e.g. {SampleMP: "sample"}
     """Mapping used to override the logic of measurement processes. The dictionary maps a
     measurement class to a string containing the name of a device's method that overrides the
-    measurement process. The method defined by the device should have the following signature:
+    measurement process. The method defined by the device should have the following arguments:
 
-    .. code-block:: python
-
-        def custom_measurement(self, measurement: MeasurementProcess, shot_range=None, bin_size=None):
-            '''Device's custom measurement implementation.
-
-            Args:
-                measurement (MeasurementProcess): measurement to override
-                shot_range (tuple[int]): 2-tuple of integers specifying the range of samples
-                    to use. If not specified, all samples are used.
-                bin_size (int): Divides the shot range into bins of size ``bin_size``, and
-                    returns the measurement statistic separately over each bin. If not
-                    provided, the entire shot range is treated as a single bin.
-            '''
-
+    * measurement (MeasurementProcess): measurement to override
+    * shot_range (tuple[int]): 2-tuple of integers specifying the range of samples
+        to use. If not specified, all samples are used.
+    * bin_size (int): Divides the shot range into bins of size ``bin_size``, and
+        returns the measurement statistic separately over each bin. If not
+        provided, the entire shot range is treated as a single bin.
 
     .. note::
         When overriding the logic of a :class:`~pennylane.measurements.MeasurementTransform`, the
-        signature of the method defined by the device should have the following signature:
+        method defined by the device should only have a single argument:
 
-        .. code-block:: python
-
-            def custom_measurement(self, qscript: QuantumScript):
-                '''Device's custom measurement implementation.
-
-                Args:
-                    qscript: quantum script to transform
-                '''
+        * qscript: quantum script to transform
 
     **Example:**
     Let's create device that inherits from :class:`~pennylane.devices.DefaultQubit` and overrides the

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -235,6 +235,7 @@ class QubitDevice(Device):
         * qscript: quantum script to transform
 
     **Example:**
+
     Let's create device that inherits from :class:`~pennylane.devices.DefaultQubit` and overrides the
     logic of the `qml.sample` measurement. To do so we will need to update the ``measurement_map``
     dictionary:

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -228,6 +228,7 @@ class QubitDevice(Device):
         provided, the entire shot range is treated as a single bin.
 
     .. note::
+
         When overriding the logic of a :class:`~pennylane.measurements.MeasurementTransform`, the
         method defined by the device should only have a single argument:
 

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -23,6 +23,7 @@ import abc
 import contextlib
 import itertools
 import warnings
+from collections import defaultdict
 from typing import Union
 
 import numpy as np
@@ -213,6 +214,61 @@ class QubitDevice(Device):
         "Sprod",
         "Prod",
     }
+
+    measurement_map = defaultdict(lambda: "")  # e.g. {SampleMP: "sample"}
+    """Mapping used to override the logic of measurement processes. The dictionary maps a
+    measurement class to a string containing the name of a device's method that overrides the
+    measurement process. The method defined by the device should have the following signature:
+
+    .. code-block:: python
+
+        def custom_measurement(self, measurement: MeasurementProcess, shot_range=None, bin_size=None):
+            '''Device's custom measurement implementation.
+
+            Args:
+                measurement (MeasurementProcess): measurement to override
+                shot_range (tuple[int]): 2-tuple of integers specifying the range of samples
+                    to use. If not specified, all samples are used.
+                bin_size (int): Divides the shot range into bins of size ``bin_size``, and
+                    returns the measurement statistic separately over each bin. If not
+                    provided, the entire shot range is treated as a single bin.
+            '''
+
+
+    .. note::
+        When overriding the logic of a :class:`~pennylane.measurements.MeasurementTransform`, the
+        signature of the method defined by the device should have the following signature:
+
+        .. code-block:: python
+
+            def custom_measurement(self, qscript: QuantumScript):
+                '''Device's custom measurement implementation.
+
+                Args:
+                    qscript: quantum script to transform
+                '''
+
+    **Example:**
+    Let's create device that inherits from :class:`~pennylane.devices.DefaultQubit` and overrides the
+    logic of the `qml.sample` measurement. To do so we will need to update the ``measurement_map``
+    dictionary:
+
+    .. code-block:: python
+        class NewDevice(DefaultQubit):
+            def __init__(self, wires, shots):
+                super().__init__(wires=wires, shots=shots)
+                self.measurement_map[SampleMP] = "sample_measurement"
+
+            def sample_measurement(self, measurement, shot_range=None, bin_size=None):
+                return 2
+
+    >>> dev = NewDevice(wires=2, shots=1000)
+    >>> @qml.qnode(dev)
+    ... def circuit():
+    ...     return qml.sample()
+    >>> circuit()
+    tensor(2, requires_grad=True)
+    """
 
     def __init__(
         self, wires=1, shots=None, *, r_dtype=np.float64, c_dtype=np.complex128, analytic=None
@@ -749,9 +805,15 @@ class QubitDevice(Device):
                 obs.return_type = m.return_type
             else:
                 obs = m
+            # Check if there is an overriden version of the measurement process
+            if method := getattr(self, self.measurement_map[type(m)], False):
+                if isinstance(m, MeasurementTransform):
+                    results.append(method(qscript=circuit))
+                else:
+                    results.append(method(m, shot_range=shot_range, bin_size=bin_size))
             # TODO: Remove return_type when `observables` argument is removed from this method
             # Pass instances directly
-            if obs.return_type is Expectation:
+            elif obs.return_type is Expectation:
                 # Appends a result of shape (num_bins,) if bin_size is not None, else a scalar
                 results.append(self.expval(obs, shot_range=shot_range, bin_size=bin_size))
 
@@ -858,10 +920,7 @@ class QubitDevice(Device):
                 results.append(self.shadow_expval(obs, circuit=circuit))
 
             elif isinstance(m, MeasurementTransform):
-                if method := getattr(self, m.method_name, False):
-                    results.append(method(qscript=circuit))
-                else:
-                    results.append(m.process(qscript=circuit, device=self))
+                results.append(m.process(qscript=circuit, device=self))
 
             elif isinstance(m, (SampleMeasurement, StateMeasurement)):
                 results.append(self._measure(m, shot_range=shot_range, bin_size=bin_size))
@@ -896,8 +955,6 @@ class QubitDevice(Device):
         Returns:
             Union[float, dict, list[float]]: result of the measurement
         """
-        if method := getattr(self, measurement.method_name, False):
-            return method(measurement, shot_range=shot_range, bin_size=bin_size)
         if self.shots is None:
             if isinstance(measurement, StateMeasurement):
                 return measurement.process_state(state=self.state, wire_order=self.wires)
@@ -974,9 +1031,15 @@ class QubitDevice(Device):
                 obs.return_type = m.return_type
             else:
                 obs = m
+            # Check if there is an overriden version of the measurement process
+            if method := getattr(self, self.measurement_map[type(m)], False):
+                if isinstance(m, MeasurementTransform):
+                    result = method(qscript=circuit)
+                else:
+                    result = method(m, shot_range=shot_range, bin_size=bin_size)
             # 1. Based on the measurement type, compute statistics
             # Pass instances directly
-            if isinstance(m, ExpectationMP):
+            elif isinstance(m, ExpectationMP):
                 result = self.expval(obs, shot_range=shot_range, bin_size=bin_size)
 
             elif isinstance(m, VarianceMP):
@@ -1072,16 +1135,10 @@ class QubitDevice(Device):
                 result = self.shadow_expval(obs, circuit=circuit)
 
             elif isinstance(m, MeasurementTransform):
-                if method := getattr(self, m.method_name, False):
-                    result = method(qscript=circuit)
-                else:
-                    result = m.process(qscript=circuit, device=self)
+                result = m.process(qscript=circuit, device=self)
 
             elif isinstance(m, (SampleMeasurement, StateMeasurement)):
-                if method := getattr(self, m.method_name, False):
-                    result = method(obs, shot_range=shot_range, bin_size=bin_size)
-                else:
-                    result = self._measure(m, shot_range=shot_range, bin_size=bin_size)
+                result = self._measure(m, shot_range=shot_range, bin_size=bin_size)
 
             elif obs.return_type is not None:
                 raise qml.QuantumFunctionError(

--- a/pennylane/measurements/classical_shadow.py
+++ b/pennylane/measurements/classical_shadow.py
@@ -231,8 +231,6 @@ class ClassicalShadowMP(MeasurementTransform):
         kwargs (dict[Any, Any]): Additional keyword arguments passed to :class:`~.pennylane.measurements.MeasurementProcess`
     """
 
-    method_name = "classical_shadow"
-
     def __init__(self, *args, seed=None, **kwargs):
         self.seed = seed
         super().__init__(*args, **kwargs)
@@ -348,8 +346,6 @@ class ShadowExpvalMP(MeasurementTransform):
             ``k=1`` corresponds to simply taking the mean over all measurements.
         kwargs (dict[Any, Any]): Additional keyword arguments passed to :class:`~.pennylane.measurements.MeasurementProcess`
     """
-
-    method_name = "shadow_expval"
 
     def __init__(self, *args, H, seed=None, k=1, **kwargs):
         self.seed = seed

--- a/pennylane/measurements/counts.py
+++ b/pennylane/measurements/counts.py
@@ -147,8 +147,6 @@ class CountsMP(SampleMeasurement):
     """Measurement process that samples from the supplied observable and returns the number of
     counts for each sample."""
 
-    method_name = "counts"
-
     def __init__(
         self,
         obs: Union[Observable, None] = None,

--- a/pennylane/measurements/expval.py
+++ b/pennylane/measurements/expval.py
@@ -62,8 +62,6 @@ def expval(op: Operator):
 class ExpectationMP(SampleMeasurement, StateMeasurement):
     """Measurement process that computes the expectation value of the given operator."""
 
-    method_name = "expval"
-
     @property
     def return_type(self):
         return Expectation

--- a/pennylane/measurements/measurements.py
+++ b/pennylane/measurements/measurements.py
@@ -125,25 +125,6 @@ class MeasurementProcess(ABC):
         log_base (float): Base for the logarithm.
     """
 
-    method_name = ""
-    """Devices can override the logic of a measurement process by defining a method with the
-    name ``method_name`` of the corresponding class. The method should have the following signature:
-
-    .. code-block:: python
-
-        def method_name(self, measurement: MeasurementProcess, shot_range=None, bin_size=None):
-            '''Device's custom measurement implementation.
-
-            Args:
-                measurement (MeasurementProcess): measurement to override
-                shot_range (tuple[int]): 2-tuple of integers specifying the range of samples
-                    to use. If not specified, all samples are used.
-                bin_size (int): Divides the shot range into bins of size ``bin_size``, and
-                    returns the measurement statistic separately over each bin. If not
-                    provided, the entire shot range is treated as a single bin.
-            '''
-    """
-
     # pylint: disable=too-many-arguments
     def __init__(
         self,
@@ -599,48 +580,6 @@ class MeasurementTransform(MeasurementProcess):
 
     Any class inheriting from this class should define its own ``process`` method, which takes a
     device instance and a quantum script and returns the result of the measurement process.
-    """
-
-    method_name = ""
-    """Devices can override the logic of a measurement process by defining a method with the
-    name ``method_name`` of the corresponding class. The method should have the following signature:
-
-    .. code-block:: python
-
-        def method_name(self, qscript: QuantumScript):
-            '''Device's custom measurement implementation.
-
-            Args:
-                qscript: quantum script to transform
-            '''
-    """
-
-    method_name = ""
-    """Devices can override the logic of a measurement process by defining a method with the
-    name ``method_name`` of the corresponding class. The method should have the following signature:
-
-    .. code-block:: python
-
-        def method_name(self, qscript: QuantumScript):
-            '''Device's custom measurement implementation.
-
-            Args:
-                qscript: quantum script to transform
-            '''
-    """
-
-    method_name = ""
-    """Devices can override the logic of a measurement process by defining a method with the
-    name ``method_name`` of the corresponding class. The method should have the following signature:
-
-    .. code-block:: python
-
-        def method_name(self, qscript: QuantumScript):
-            '''Device's custom measurement implementation.
-
-            Args:
-                qscript: quantum script to transform
-            '''
     """
 
     @abstractmethod

--- a/pennylane/measurements/mutual_info.py
+++ b/pennylane/measurements/mutual_info.py
@@ -87,8 +87,6 @@ def mutual_info(wires0, wires1, log_base=None):
 class MutualInfoMP(StateMeasurement):
     """Measurement process that returns the mutual information between the provided wires."""
 
-    method_name = "mutual_info"
-
     # pylint: disable=too-many-arguments, unused-argument
     def __init__(
         self,

--- a/pennylane/measurements/probs.py
+++ b/pennylane/measurements/probs.py
@@ -116,8 +116,6 @@ def probs(wires=None, op=None):
 class ProbabilityMP(SampleMeasurement, StateMeasurement):
     """Measurement process that computes the probability of each computational basis state."""
 
-    method_name = "probability"
-
     @property
     def return_type(self):
         return Probability

--- a/pennylane/measurements/sample.py
+++ b/pennylane/measurements/sample.py
@@ -116,8 +116,6 @@ def sample(op: Union[Observable, None] = None, wires=None):
 class SampleMP(SampleMeasurement):
     """Measurement process that returns the samples of a given observable."""
 
-    method_name = "sample"
-
     @property
     def return_type(self):
         return Sample

--- a/pennylane/measurements/state.py
+++ b/pennylane/measurements/state.py
@@ -125,8 +125,6 @@ def density_matrix(wires):
 class StateMP(StateMeasurement):
     """Measurement process that returns the quantum state."""
 
-    method_name = "state"
-
     @property
     def return_type(self):
         return State

--- a/pennylane/measurements/var.py
+++ b/pennylane/measurements/var.py
@@ -61,8 +61,6 @@ def var(op: Operator):
 class VarianceMP(SampleMeasurement, StateMeasurement):
     """Measurement process that computes the variance of the supplied observable."""
 
-    method_name = "var"
-
     @property
     def return_type(self):
         return Variance

--- a/pennylane/measurements/vn_entropy.py
+++ b/pennylane/measurements/vn_entropy.py
@@ -72,8 +72,6 @@ def vn_entropy(wires, log_base=None):
 class VnEntropyMP(StateMeasurement):
     """Measurement process that returns the Von Neumann entropy of the system prior to measurement."""
 
-    method_name = "vn_entropy"
-
     # pylint: disable=too-many-arguments, unused-argument
     def __init__(
         self,

--- a/tests/measurements/test_measurements.py
+++ b/tests/measurements/test_measurements.py
@@ -486,19 +486,14 @@ class TestSampleMeasurement:
         """Test that the device can override a measurement process."""
         switch_return()
 
-        class MyMeasurement(SampleMeasurement):
-            method_name = "test_method"
-
-            def process_samples(self, samples, wire_order, shot_range, bin_size):
-                return qml.math.sum(samples[..., self.wires])
-
         dev = qml.device("default.qubit", wires=2, shots=1000)
 
         @qml.qnode(dev)
         def circuit():
             qml.PauliX(0)
-            return MyMeasurement(wires=[0]), MyMeasurement(wires=[1])
+            return qml.sample(wires=[0]), qml.sample(wires=[1])
 
+        circuit.device.measurement_map[SampleMP] = "test_method"
         circuit.device.test_method = lambda obs, shot_range=None, bin_size=None: 2
 
         assert qml.math.allequal(circuit(), [2, 2])
@@ -548,18 +543,13 @@ class TestStateMeasurement:
         """Test that the device can override a measurement process."""
         switch_return()
 
-        class MyMeasurement(StateMeasurement):
-            method_name = "test_method"
-
-            def process_state(self, state, wire_order):
-                return qml.math.sum(state)
-
         dev = qml.device("default.qubit", wires=2)
 
         @qml.qnode(dev)
         def circuit():
-            return MyMeasurement()
+            return qml.expval(op=qml.PauliX(0))
 
+        circuit.device.measurement_map[ExpectationMP] = "test_method"
         circuit.device.test_method = lambda obs, shot_range=None, bin_size=None: 2
 
         assert circuit() == 2
@@ -589,18 +579,13 @@ class TestMeasurementTransform:
         """Test that the device can override a measurement process."""
         switch_return()
 
-        class MyMeasurement(MeasurementTransform):
-            method_name = "test_method"
-
-            def process(self, qscript, device):
-                return {device.shots: len(qscript)}
-
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit", wires=2, shots=1000)
 
         @qml.qnode(dev)
         def circuit():
-            return MyMeasurement()
+            return qml.classical_shadow(wires=0)
 
+        circuit.device.measurement_map[ClassicalShadowMP] = "test_method"
         circuit.device.test_method = lambda qscript: 2
 
         assert circuit() == 2

--- a/tests/measurements/test_measurements.py
+++ b/tests/measurements/test_measurements.py
@@ -547,9 +547,9 @@ class TestStateMeasurement:
 
         @qml.qnode(dev)
         def circuit():
-            return qml.expval(op=qml.PauliX(0))
+            return qml.state()
 
-        circuit.device.measurement_map[ExpectationMP] = "test_method"
+        circuit.device.measurement_map[StateMP] = "test_method"
         circuit.device.test_method = lambda obs, shot_range=None, bin_size=None: 2
 
         assert circuit() == 2


### PR DESCRIPTION
- Remove `method_name` attribute from `MeasurementProcess` (it was added in this release cycle).
- Add `measurement_map` attribute to `QubitDevice`.

Devices can now define the name of the method used to override any measurement process:
```python
import pennylane as qml
from pennylane.devices import DefaultQubit
from pennylane.measurements import SampleMP

class NewDevice(DefaultQubit):
    def __init__(self, shots, wires):
        super().__init__(shots=shots, wires=wires)
        self.measurement_map[SampleMP] = "sample_measurement"

    def sample_measurement(self, measurement, shot_range=None, bin_size=None):
        return 2

dev = NewDevice(wires=2, shots=1000)

@qml.qnode(dev)
def circuit():
    return qml.sample()

print(circuit())
```
Returns
```
2
```