### PR TITLE
add support for windows filepaths in dataset module

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -621,6 +621,9 @@ Deprecations cycles are tracked at [doc/developement/deprecations.rst](https://d
   run on a device defined with a shot vector.
   [(#3422)](https://github.com/PennyLaneAI/pennylane/pull/3422)
 
+* The `qml.data` module now works as expected on Windows.
+  [(#3504)](https://github.com/PennyLaneAI/pennylane/pull/3504)
+
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane/data/dataset.py
+++ b/pennylane/data/dataset.py
@@ -106,7 +106,7 @@ class Dataset(ABC):
     def __std_init__(self, data_name, folder, attr_prefix, docstring):
         """Constructor for standardized datasets."""
         self._dtype = data_name
-        self._folder = folder.rstrip("/")
+        self._folder = folder.rstrip(os.path.sep)
         self._prefix = os.path.join(self._folder, attr_prefix) + "_{}.dat"
         self._prefix_len = len(attr_prefix) + 1
         self._description = os.path.join(data_name, self._folder.split(data_name)[-1][1:])
@@ -116,7 +116,7 @@ class Dataset(ABC):
         if not os.path.exists(self._fullfile):
             self._fullfile = None
 
-        for f in glob(self._folder + "/*.dat"):
+        for f in glob(f"{self._folder}{os.path.sep}*.dat"):
             self.read(f, lazy=True)
 
     def __base_init__(self, **kwargs):
@@ -144,8 +144,9 @@ class Dataset(ABC):
         attr_str = (
             str(list(self.attrs))
             if len(self.attrs) < 3
-            else str(list(self.attrs)[:2])[:-1] + ", ...]"
+            else f"{str(list(self.attrs)[:2])[:-1]}, ...]"
         )
+
         std_str = f"description: {self._description}, " if self._is_standard else ""
         return f"<Dataset = {std_str}attributes: {attr_str}>"
 
@@ -241,7 +242,7 @@ class Dataset(ABC):
 
     # The methods below are intended for use only by standard Dataset objects
     def __get_filename_for_attribute(self, attribute):
-        return self._fullfile if self._fullfile else self._prefix.format(attribute)
+        return self._fullfile or self._prefix.format(attribute)
 
     def __get_attribute_from_filename(self, filename):
         return os.path.basename(filename)[self._prefix_len : -4]


### PR DESCRIPTION
**Context:**
Windows uses `\` as a path separator. Unfortunately, the datasets module matches local paths to S3 bucket paths and doesn't expect local paths to use anything other than `/`.

**Description of the Change:**
Convert windows paths to unix-like paths before sending requests to S3.

**Benefits:**
The dataset module will work as expected on Windows

**Possible Drawbacks:**
N/A (well.. encouraging people to continue development on Windows is a grey area but I digress 😄 )

**Related GitHub Issues:**
N/A