### PR TITLE
Add pickle warning to datasets

### DIFF
--- a/doc/introduction/data.rst
+++ b/doc/introduction/data.rst
@@ -16,11 +16,11 @@ where the quantum dataset is a collection of `quantum data` obtained from variou
 
 .. warning::
     
-        PennyLane datasets use the ``pickle`` module to compress, store, and read data. Here, we 
-        reproduce an important warning from the ``pickle`` module: it is possible
-        to construct malicious pickle data which will execute arbitrary code during unpickling.
-        Never unpickle data that could have come from an untrusted source, or that could have been 
-        tampered with.
+        PennyLane datasets use the ``dill`` module to compress, store, and read data. Since ``dill``
+        is built on the ``pickle`` module, we reproduce an important warning from the ``pickle``
+        module: it is possible to construct malicious pickle data which will execute arbitrary code
+        during unpickling. Never unpickle data that could have come from an untrusted source, or
+        that could have been tampered with.
 
 Loading Datasets in PennyLane
 -----------------------------

--- a/doc/introduction/data.rst
+++ b/doc/introduction/data.rst
@@ -14,6 +14,13 @@ where the quantum dataset is a collection of `quantum data` obtained from variou
     The packages ``zstd`` and ``dill`` are required to use the :mod:`~pennylane.data` module. 
     These can be installed with ``pip install zstd dill``.
 
+.. warning::
+    
+        PennyLane datasets use the ``pickle`` module to compress, store, and read data. Here, we reproduce
+        and important warning from the ``pickle`` module: it is possible
+        to construct malicious pickle data which will execute arbitrary code during unpickling.
+        Never unpickle data that could have come from an untrusted source, or that could have been 
+        tampered with.
 
 Loading Datasets in PennyLane
 -----------------------------

--- a/doc/introduction/data.rst
+++ b/doc/introduction/data.rst
@@ -16,8 +16,8 @@ where the quantum dataset is a collection of `quantum data` obtained from variou
 
 .. warning::
     
-        PennyLane datasets use the ``pickle`` module to compress, store, and read data. Here, we reproduce
-        and important warning from the ``pickle`` module: it is possible
+        PennyLane datasets use the ``pickle`` module to compress, store, and read data. Here, we 
+        reproduce an important warning from the ``pickle`` module: it is possible
         to construct malicious pickle data which will execute arbitrary code during unpickling.
         Never unpickle data that could have come from an untrusted source, or that could have been 
         tampered with.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -585,6 +585,9 @@ Deprecations cycles are tracked at [doc/developement/deprecations.rst](https://d
   $U^{\dagger} | \psi \rangle$ the actual state being measured in the $Z$-basis.
   [(#3409)](https://github.com/PennyLaneAI/pennylane/pull/3409)
 
+* Adds warnings about using ``dill`` to pickle and unpickle datasets. 
+  [#3505](https://github.com/PennyLaneAI/pennylane/pull/3505)
+
 <h3>Bug fixes</h3>
 
 * Fixed a bug where `hamiltonian_expand` didn't preserve the type of the inputted results in its output.

--- a/pennylane/data/data_manager.py
+++ b/pennylane/data/data_manager.py
@@ -227,13 +227,11 @@ def load(
 
     .. warning::
 
-        PennyLane datasets use the ``pickle`` module to compress, store, and read data. Here, we
-        reproduce an important warning from the ``pickle`` module: it is possible
-        to construct malicious pickle data which will execute arbitrary code during unpickling.
-        Never unpickle data that could have come from an untrusted source, or that could have been
-        tampered with.
-
-
+        PennyLane datasets use the ``dill`` module to compress, store, and read data. Since ``dill``
+        is built on the ``pickle`` module, we reproduce an important warning from the ``pickle``
+        module: it is possible to construct malicious pickle data which will execute arbitrary code
+        during unpickling. Never unpickle data that could have come from an untrusted source, or
+        that could have been tampered with.
     """
 
     _ = lazy

--- a/pennylane/data/data_manager.py
+++ b/pennylane/data/data_manager.py
@@ -208,7 +208,9 @@ def _generate_folders(node, folders):
 def load(
     data_name, attributes=None, lazy=False, folder_path="", force=False, num_threads=50, **params
 ):
-    r"""Downloads the data if it is not already present in the directory and return it to user as a :class:`~pennylane.data.Dataset` object.
+    r"""Downloads the data if it is not already present in the directory and return it to user as a 
+    :class:`~pennylane.data.Dataset` object. For the full list of available datasets, please see the
+    `datasets website <https://pennylane.ai/qml/datasets.html>`_.
 
     Args:
         data_name (str)   : A string representing the type of data required such as `qchem`, `qpsin`, etc.
@@ -222,6 +224,16 @@ def load(
 
     Returns:
         list[:class:`~pennylane.data.Dataset`]
+
+    .. warning::
+    
+        PennyLane datasets use the ``pickle`` module to compress, store, and read data. Here, we reproduce
+        and important warning from the ``pickle`` module: it is possible
+        to construct malicious pickle data which will execute arbitrary code during unpickling.
+        Never unpickle data that could have come from an untrusted source, or that could have been 
+        tampered with.
+
+
     """
 
     _ = lazy

--- a/pennylane/data/data_manager.py
+++ b/pennylane/data/data_manager.py
@@ -208,7 +208,7 @@ def _generate_folders(node, folders):
 def load(
     data_name, attributes=None, lazy=False, folder_path="", force=False, num_threads=50, **params
 ):
-    r"""Downloads the data if it is not already present in the directory and return it to user as a 
+    r"""Downloads the data if it is not already present in the directory and return it to user as a
     :class:`~pennylane.data.Dataset` object. For the full list of available datasets, please see the
     `datasets website <https://pennylane.ai/qml/datasets.html>`_.
 
@@ -226,11 +226,11 @@ def load(
         list[:class:`~pennylane.data.Dataset`]
 
     .. warning::
-    
+
         PennyLane datasets use the ``pickle`` module to compress, store, and read data. Here, we reproduce
         and important warning from the ``pickle`` module: it is possible
         to construct malicious pickle data which will execute arbitrary code during unpickling.
-        Never unpickle data that could have come from an untrusted source, or that could have been 
+        Never unpickle data that could have come from an untrusted source, or that could have been
         tampered with.
 
 

--- a/pennylane/data/data_manager.py
+++ b/pennylane/data/data_manager.py
@@ -227,8 +227,8 @@ def load(
 
     .. warning::
 
-        PennyLane datasets use the ``pickle`` module to compress, store, and read data. Here, we reproduce
-        and important warning from the ``pickle`` module: it is possible
+        PennyLane datasets use the ``pickle`` module to compress, store, and read data. Here, we
+        reproduce an important warning from the ``pickle`` module: it is possible
         to construct malicious pickle data which will execute arbitrary code during unpickling.
         Never unpickle data that could have come from an untrusted source, or that could have been
         tampered with.


### PR DESCRIPTION
**Context:**
Pickled files can execute malicious code while unpickling. We use the pickle module to handle storage and compression/decompression of PennyLane datasets and plan to allow users to upload their own data in the future. Therefore it is important to give a warning about the potential for malicious code.

**Description of the Change:**
Added a warning to the documentation for `qml.data.load`.

**Benefits:**
Users become aware of the dangers of pickled files and are more careful in the future when user-uploaded datasets become available.

**Possible Drawbacks:**
Users think that downloading a dataset from PennyLane is unsafe. This can be solved by transitioning to another form of storage and compression in the future.
