### PR TITLE
add locking to operationrecorder to match old state

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -526,6 +526,7 @@
 
 * Update `OperationRecorder` to inherit from `AnnotatedQueue` and `QuantumScript` instead of `QuantumTape`.
   [(#3496)](https://github.com/PennyLaneAI/pennylane/pull/3496)
+  [(#3510)](https://github.com/PennyLaneAI/pennylane/pull/3510)
 
 <h3>Breaking changes</h3>
 


### PR DESCRIPTION
Should have been part of #3496 to keep things the same as they were before. not adding to changelog

code should match [QuantumTape's enter/exit dunders](https://github.com/PennyLaneAI/pennylane/blob/6f94ad8dc7765e3c30ffcc23b2c07515bad7ba5d/pennylane/tape/tape.py#L356-L376), which it used to inherit from.