### PR TITLE
Fix plugin test matrix

### DIFF
--- a/pennylane/devices/tests/test_measurements.py
+++ b/pennylane/devices/tests/test_measurements.py
@@ -1562,6 +1562,9 @@ class TestStateMeasurement:
         """Test the execution of a custom state measurement."""
         dev = device(2)
 
+        if dev.shots is not None:
+            pytest.skip("Some plugins don't update state information when shots is not None.")
+
         class MyMeasurement(StateMeasurement):
             """Dummy state measurement."""
 

--- a/pennylane/devices/tests/test_measurements.py
+++ b/pennylane/devices/tests/test_measurements.py
@@ -1508,7 +1508,8 @@ class TestSampleMeasurement:
             qml.PauliX(0)
             return MyMeasurement(wires=[0]), MyMeasurement(wires=[1])
 
-        assert qml.math.allequal(circuit(), [1, 1])
+        res = circuit()
+        assert qml.math.allequal(res, [1, 1])
 
     def test_sample_measurement_without_shots(self, device):
         """Test that executing a sampled measurement with ``shots=None`` raises an error."""

--- a/pennylane/devices/tests/test_measurements.py
+++ b/pennylane/devices/tests/test_measurements.py
@@ -1501,14 +1501,14 @@ class TestSampleMeasurement:
             """Dummy sampled measurement."""
 
             def process_samples(self, samples, wire_order, shot_range=None, bin_size=None):
-                return qml.math.sum(samples[..., self.wires])
+                return 1
 
         @qml.qnode(dev)
         def circuit():
             qml.PauliX(0)
             return MyMeasurement(wires=[0]), MyMeasurement(wires=[1])
 
-        assert qml.math.allequal(circuit(), [dev.shots, 0])
+        assert circuit() == 1
 
     def test_sample_measurement_without_shots(self, device):
         """Test that executing a sampled measurement with ``shots=None`` raises an error."""
@@ -1521,7 +1521,7 @@ class TestSampleMeasurement:
             """Dummy sampled measurement."""
 
             def process_samples(self, samples, wire_order, shot_range=None, bin_size=None):
-                return qml.math.sum(samples[..., self.wires])
+                return 1
 
         @qml.qnode(dev)
         def circuit():
@@ -1565,7 +1565,7 @@ class TestStateMeasurement:
             """Dummy state measurement."""
 
             def process_state(self, state, wire_order):
-                return qml.math.sum(state)
+                return 1
 
         @qml.qnode(dev)
         def circuit():
@@ -1584,7 +1584,7 @@ class TestStateMeasurement:
             """Dummy state measurement."""
 
             def process_state(self, state, wire_order):
-                return qml.math.sum(state)
+                return 1
 
         @qml.qnode(dev)
         def circuit():
@@ -1622,13 +1622,13 @@ class TestCustomMeasurement:
             """Dummy measurement transform."""
 
             def process(self, qscript, device):
-                return {device.shots: len(qscript)}
+                return 1
 
         @qml.qnode(dev)
         def circuit():
             return MyMeasurement()
 
-        assert circuit() == {dev.shots: len(circuit.tape)}
+        assert circuit() == 1
 
     def test_method_overriden_by_device(self, device):
         """Test that the device can override a measurement process."""

--- a/pennylane/devices/tests/test_measurements.py
+++ b/pennylane/devices/tests/test_measurements.py
@@ -1508,7 +1508,7 @@ class TestSampleMeasurement:
             qml.PauliX(0)
             return MyMeasurement(wires=[0]), MyMeasurement(wires=[1])
 
-        assert circuit() == 1
+        assert qml.math.allequal(circuit(), [1, 1])
 
     def test_sample_measurement_without_shots(self, device):
         """Test that executing a sampled measurement with ``shots=None`` raises an error."""

--- a/pennylane/devices/tests/test_measurements.py
+++ b/pennylane/devices/tests/test_measurements.py
@@ -1570,6 +1570,7 @@ class TestStateMeasurement:
 
         @qml.qnode(dev)
         def circuit():
+            qml.PauliX(0)
             return MyMeasurement()
 
         assert circuit() == 1
@@ -1589,6 +1590,7 @@ class TestStateMeasurement:
 
         @qml.qnode(dev)
         def circuit():
+            qml.PauliX(0)
             return MyMeasurement()
 
         with pytest.warns(
@@ -1627,6 +1629,7 @@ class TestCustomMeasurement:
 
         @qml.qnode(dev)
         def circuit():
+            qml.PauliX(0)
             return MyMeasurement()
 
         assert circuit() == 1
@@ -1643,6 +1646,7 @@ class TestCustomMeasurement:
 
         @qml.qnode(dev)
         def circuit():
+            qml.PauliX(0)
             return qml.classical_shadow(wires=0)
 
         circuit.device.measurement_map[ClassicalShadowMP] = "test_method"


### PR DESCRIPTION
Stop using `samples` and `state` in tests to make tests more generic.

Add operations to all circuits (cirq crashes if circuit has no operations).

Skip test if shots is not None.