### PR TITLE
change qscript to tape in public facing content

### DIFF
--- a/doc/releases/changelog-0.28.0.md
+++ b/doc/releases/changelog-0.28.0.md
@@ -193,7 +193,7 @@
 
 * Support custom measurement processes:
   - `SampleMeasurement`, `StateMeasurement` and `CustomMeasurement` classes have been added.
-    They contain an abstract method to process samples/quantum states/quantum scripts. These classes
+    They contain an abstract method to process samples/quantum states/quantum tapes. These classes
     make it easier for users to define their own `MeasurementProcess` by compartmentalizing the different
     types of measurements into three simple categories. 
 
@@ -732,7 +732,7 @@
   to
 
   ```python
-  def statistics(self, circuit: QuantumScript, shot_range=None, bin_size=None):
+  def statistics(self, circuit: QuantumTape, shot_range=None, bin_size=None):
   ```
 
   [(#3421)](https://github.com/PennyLaneAI/pennylane/pull/3421)

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -40,7 +40,7 @@ from pennylane.measurements import (
 )
 from pennylane.operation import Observable, Operation, Tensor
 from pennylane.ops import Hamiltonian, Sum
-from pennylane.tape import QuantumScript
+from pennylane.tape import QuantumScript, QuantumTape
 from pennylane.wires import WireError, Wires
 
 ShotTuple = namedtuple("ShotTuple", ["shots", "copies"])
@@ -604,8 +604,7 @@ class Device(abc.ABC):
         function accepts a queuable object (including a PennyLane operation
         and observable) and returns ``True`` if supported by the device."""
         return qml.BooleanFn(
-            lambda obj: not isinstance(obj, qml.tape.QuantumScript)
-            and self.supports_operation(obj.name)
+            lambda obj: not isinstance(obj, QuantumScript) and self.supports_operation(obj.name)
         )
 
     def custom_expand(self, fn):
@@ -699,7 +698,7 @@ class Device(abc.ABC):
 
         return self.default_expand_fn(circuit, max_expansion=max_expansion)
 
-    def batch_transform(self, circuit: QuantumScript):
+    def batch_transform(self, circuit: QuantumTape):
         """Apply a differentiable batch transform for preprocessing a circuit
         prior to execution. This method is called directly by the QNode, and
         should be overwritten if the device requires a transform that

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -232,7 +232,7 @@ class QubitDevice(Device):
         When overriding the logic of a :class:`~pennylane.measurements.MeasurementTransform`, the
         method defined by the device should only have a single argument:
 
-        * qscript: quantum script to transform
+        * tape: quantum tape to transform
 
     **Example:**
 
@@ -796,7 +796,7 @@ class QubitDevice(Device):
             # Check if there is an overriden version of the measurement process
             if method := getattr(self, self.measurement_map[type(m)], False):
                 if isinstance(m, MeasurementTransform):
-                    results.append(method(qscript=circuit))
+                    results.append(method(tape=circuit))
                 else:
                     results.append(method(m, shot_range=shot_range, bin_size=bin_size))
             # TODO: Remove return_type when `observables` argument is removed from this method
@@ -908,7 +908,7 @@ class QubitDevice(Device):
                 results.append(self.shadow_expval(obs, circuit=circuit))
 
             elif isinstance(m, MeasurementTransform):
-                results.append(m.process(qscript=circuit, device=self))
+                results.append(m.process(tape=circuit, device=self))
 
             elif isinstance(m, (SampleMeasurement, StateMeasurement)):
                 results.append(self._measure(m, shot_range=shot_range, bin_size=bin_size))
@@ -1022,7 +1022,7 @@ class QubitDevice(Device):
             # Check if there is an overriden version of the measurement process
             if method := getattr(self, self.measurement_map[type(m)], False):
                 if isinstance(m, MeasurementTransform):
-                    result = method(qscript=circuit)
+                    result = method(tape=circuit)
                 else:
                     result = method(m, shot_range=shot_range, bin_size=bin_size)
             # 1. Based on the measurement type, compute statistics
@@ -1123,7 +1123,7 @@ class QubitDevice(Device):
                 result = self.shadow_expval(obs, circuit=circuit)
 
             elif isinstance(m, MeasurementTransform):
-                result = m.process(qscript=circuit, device=self)
+                result = m.process(tape=circuit, device=self)
 
             elif isinstance(m, (SampleMeasurement, StateMeasurement)):
                 result = self._measure(m, shot_range=shot_range, bin_size=bin_size)

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -61,7 +61,7 @@ from pennylane.measurements import (
     VnEntropyMP,
 )
 from pennylane.operation import operation_derivative
-from pennylane.tape import QuantumScript
+from pennylane.tape import QuantumScript, QuantumTape
 from pennylane.wires import Wires
 
 
@@ -397,7 +397,7 @@ class QubitDevice(Device):
 
         return results
 
-    def execute(self, circuit: QuantumScript, **kwargs):
+    def execute(self, circuit: QuantumTape, **kwargs):
         """Execute a queue of quantum operations on the device and then
         measure the given observables.
 
@@ -478,7 +478,7 @@ class QubitDevice(Device):
 
         return results
 
-    def shot_vec_statistics(self, circuit: QuantumScript):
+    def shot_vec_statistics(self, circuit: QuantumTape):
         """Process measurement results from circuit execution using a device
         with a shot vector and return statistics.
 
@@ -556,7 +556,7 @@ class QubitDevice(Device):
 
         return tuple(results)
 
-    def _multi_meas_with_counts_shot_vec(self, circuit: QuantumScript, shot_tuple, r):
+    def _multi_meas_with_counts_shot_vec(self, circuit: QuantumTape, shot_tuple, r):
         """Auxiliary function of the shot_vec_statistics and execute_new
         functions for post-processing the results of multiple measurements at
         least one of which was a counts measurement.
@@ -721,7 +721,7 @@ class QubitDevice(Device):
 
     # pylint: disable=too-many-statements
     def statistics(
-        self, observables=None, shot_range=None, bin_size=None, circuit: QuantumScript = None
+        self, observables=None, shot_range=None, bin_size=None, circuit: QuantumTape = None
     ):
         """Process measurement results from circuit execution and return statistics.
 
@@ -729,7 +729,7 @@ class QubitDevice(Device):
         density matrices.
 
         Args:
-            circuit (~.tape.QuantumScript): the quantum script currently being executed
+            circuit (~.tape.QuantumTape): the quantum tape currently being executed
             shot_range (tuple[int]): 2-tuple of integers specifying the range of samples
                 to use. If not specified, all samples are used.
             bin_size (int): Divides the shot range into bins of size ``bin_size``, and
@@ -775,7 +775,7 @@ class QubitDevice(Device):
             else:
                 warnings.warn(
                     message="Using a list of observables in ``QubitDevice.statistics`` is "
-                    "deprecated. Please use a ``QuantumScript`` instead.",
+                    "deprecated. Please use a ``QuantumTape`` instead.",
                     category=UserWarning,
                 )
                 measurements = observables
@@ -963,14 +963,14 @@ class QubitDevice(Device):
             samples=self._samples, wire_order=self.wires, shot_range=shot_range, bin_size=bin_size
         )
 
-    def _statistics_new(self, circuit: QuantumScript, shot_range=None, bin_size=None):
+    def _statistics_new(self, circuit: QuantumTape, shot_range=None, bin_size=None):
         """Process measurement results from circuit execution and return statistics.
 
         This includes returning expectation values, variance, samples, probabilities, states, and
         density matrices.
 
         Args:
-            circuit (~.tape.QuantumScript): the quantum script currently being executed
+            circuit (~.tape.QuantumTape): the quantum tape currently being executed
             shot_range (tuple[int]): 2-tuple of integers specifying the range of samples
                 to use. If not specified, all samples are used.
             bin_size (int): Divides the shot range into bins of size ``bin_size``, and
@@ -1931,7 +1931,7 @@ class QubitDevice(Device):
         )
 
     def adjoint_jacobian(
-        self, tape: QuantumScript, starting_state=None, use_device_state=False
+        self, tape: QuantumTape, starting_state=None, use_device_state=False
     ):  # pylint: disable=too-many-statements
         """Implements the adjoint method outlined in
         `Jones and Gacon <https://arxiv.org/abs/2009.02823>`__ to differentiate an input tape.
@@ -1951,7 +1951,7 @@ class QubitDevice(Device):
               :class:`~.Hamiltonian` or :class:`~.Hermitian`.
 
         Args:
-            tape (.QuantumScript): circuit that the function takes the gradient of
+            tape (.QuantumTape): circuit that the function takes the gradient of
 
         Keyword Args:
             starting_state (tensor_like): post-forward pass state to start execution with. It should be

--- a/pennylane/devices/tests/test_measurements.py
+++ b/pennylane/devices/tests/test_measurements.py
@@ -1627,7 +1627,7 @@ class TestCustomMeasurement:
         class MyMeasurement(MeasurementTransform):
             """Dummy measurement transform."""
 
-            def process(self, qscript, device):
+            def process(self, tape, device):
                 return 1
 
         @qml.qnode(dev)
@@ -1653,6 +1653,6 @@ class TestCustomMeasurement:
             return qml.classical_shadow(wires=0)
 
         circuit.device.measurement_map[ClassicalShadowMP] = "test_method"
-        circuit.device.test_method = lambda qscript: 2
+        circuit.device.test_method = lambda tape: 2
 
         assert circuit() == 2

--- a/pennylane/measurements/__init__.py
+++ b/pennylane/measurements/__init__.py
@@ -49,11 +49,11 @@ classes. These classes are subclassed to implement measurements in PennyLane.
 
 * Each :class:`MeasurementTransform` subclass represents a measurement process that requires
   the application of a batch transform, which contains a :meth:`MeasurementTransform.process` method
-  that converts the given quantum script into a batch of quantum scripts and executes them using the
+  that converts the given quantum tape into a batch of quantum tapes and executes them using the
   device. This method should always have the same arguments:
 
-  * qscript (QuantumScript): quantum script to transform
-  * device (Device): device used to transform the quantum script
+  * tape (QuantumTape): quantum tape to transform
+  * device (Device): device used to transform the quantum tape
 
   The main difference between a :class:`MeasurementTransform` and a
   :func:`~pennylane.batch_transform` is that a batch transform is tracked by the gradient transform,

--- a/pennylane/measurements/classical_shadow.py
+++ b/pennylane/measurements/classical_shadow.py
@@ -237,7 +237,7 @@ class ClassicalShadowMP(MeasurementTransform):
         self.seed = seed
         super().__init__(*args, **kwargs)
 
-    def process(self, qscript, device):
+    def process(self, tape, device):
         """
         Returns the measured bits and recipes in the classical shadow protocol.
 
@@ -257,14 +257,14 @@ class ClassicalShadowMP(MeasurementTransform):
         Pauli measurements have shape ``(T, n)``.
 
         This implementation is device-agnostic and works by executing single-shot
-        quantum scripts containing randomized Pauli observables. Devices should override this
+        quantum tapes containing randomized Pauli observables. Devices should override this
         if they can offer cleaner or faster implementations.
 
         .. seealso:: :func:`~pennylane.classical_shadow`
 
         Args:
-            qscript (QuantumScript): the quantum script to be processed
-            device (Device): the device used to process the quantum script
+            tape (QuantumTape): the quantum tape to be processed
+            device (Device): the device used to process the quantum tape
 
         Returns:
             tensor_like[int]: A tensor with shape ``(2, T, n)``, where the first row represents
@@ -298,7 +298,7 @@ class ClassicalShadowMP(MeasurementTransform):
                 ]
 
                 device.reset()
-                device.apply(qscript.operations, rotations=qscript.diagonalizing_gates + rotations)
+                device.apply(tape.operations, rotations=tape.diagonalizing_gates + rotations)
 
                 outcomes[t] = device.generate_samples()[0][mapped_wires]
 
@@ -354,10 +354,8 @@ class ShadowExpvalMP(MeasurementTransform):
         self.k = k
         super().__init__(*args, **kwargs)
 
-    def process(self, qscript, device):
-        bits, recipes = qml.classical_shadow(wires=self.wires, seed=self.seed).process(
-            qscript, device
-        )
+    def process(self, tape, device):
+        bits, recipes = qml.classical_shadow(wires=self.wires, seed=self.seed).process(tape, device)
         shadow = qml.shadows.ClassicalShadow(bits, recipes, wire_map=self.wires.tolist())
         return shadow.expval(self.H, self.k)
 

--- a/pennylane/measurements/measurements.py
+++ b/pennylane/measurements/measurements.py
@@ -375,7 +375,7 @@ class MeasurementProcess(ABC):
         rotation and a measurement in the computational basis.
 
         Returns:
-            .QuantumScript: a quantum script containing the operations
+            .QuantumTape: a quantum tape containing the operations
             required to diagonalize the observable
 
         **Example:**
@@ -389,18 +389,18 @@ class MeasurementProcess(ABC):
 
         Expanding this out:
 
-        >>> qscript = m.expand()
+        >>> tape = m.expand()
 
-        We can see that the resulting script has the qubit unitary applied,
+        We can see that the resulting tape has the qubit unitary applied,
         and a measurement process with no observable, but the eigenvalues
         specified:
 
-        >>> print(qscript.operations)
+        >>> print(tape.operations)
         [QubitUnitary(array([[-0.89442719,  0.4472136 ],
               [ 0.4472136 ,  0.89442719]]), wires=['a'])]
-        >>> print(qscript.measurements[0].eigvals())
+        >>> print(tape.measurements[0].eigvals())
         [0. 5.]
-        >>> print(qscript.measurements[0].obs)
+        >>> print(tape.measurements[0].obs)
         None
         """
         if self.obs is None:
@@ -633,21 +633,21 @@ class StateMeasurement(MeasurementProcess):
 
 
 class MeasurementTransform(MeasurementProcess):
-    """Measurement process that applies a transform into the given quantum script. This transform
+    """Measurement process that applies a transform into the given quantum tape. This transform
     is carried out inside the gradient black box, thus is not tracked by the gradient transform.
 
     Any class inheriting from ``MeasurementTransform`` should define its own ``process`` method,
     which should have the following arguments:
 
-    * qscript (QuantumScript): quantum script to transform
-    * device (Device): device used to transform the quantum script
+    * tape (QuantumTape): quantum tape to transform
+    * device (Device): device used to transform the quantum tape
     """
 
     @abstractmethod
-    def process(self, qscript, device):
-        """Process the given quantum script.
+    def process(self, tape, device):
+        """Process the given quantum tape.
 
         Args:
-            qscript (QuantumScript): quantum script to transform
-            device (Device): device used to transform the quantum script
+            tape (QuantumTape): quantum tape to transform
+            device (Device): device used to transform the quantum tape
         """

--- a/pennylane/ops/functions/map_wires.py
+++ b/pennylane/ops/functions/map_wires.py
@@ -22,11 +22,11 @@ from pennylane.measurements import MeasurementProcess
 from pennylane.operation import Operator
 from pennylane.qnode import QNode
 from pennylane.queuing import QueuingManager
-from pennylane.tape import QuantumScript, make_qscript
+from pennylane.tape import QuantumScript, make_qscript, QuantumTape
 
 
 def map_wires(
-    input: Union[Operator, MeasurementProcess, QuantumScript, QNode, Callable],
+    input: Union[Operator, MeasurementProcess, QuantumTape, QNode, Callable],
     wire_map: dict,
     queue=False,
     replace=False,
@@ -35,15 +35,15 @@ def map_wires(
     wire map.
 
     Args:
-        input (.Operator, pennylane.QNode, .QuantumScript, or Callable): an operator, quantum node,
-            quantum script, or function that applies quantum operations
+        input (.Operator, pennylane.QNode, .QuantumTape, or Callable): an operator, quantum node,
+            quantum tape, or function that applies quantum operations
         wire_map (dict): dictionary containing the old wires as keys and the new wires as values
         queue (bool): Whether or not to queue the object when recording. Defaults to False.
         replace (bool): When ``queue=True``, if ``replace=True`` the input operators will be
             replaced by its mapped version. Defaults to False.
 
     Returns:
-        (.Operator, pennylane.QNode, .QuantumScript, or Callable): input with changed wires
+        (.Operator, pennylane.QNode, .QuantumTape, or Callable): input with changed wires
 
     .. note::
 
@@ -103,7 +103,7 @@ def map_wires(
         measurements = [qml.map_wires(m, wire_map) for m in input.measurements]
         prep = [qml.map_wires(p, wire_map) for p in input._prep]  # pylint: disable=protected-access
 
-        return QuantumScript(ops=ops, measurements=measurements, prep=prep)
+        return input.__class__(ops=ops, measurements=measurements, prep=prep)
 
     if callable(input):
 

--- a/pennylane/ops/functions/simplify.py
+++ b/pennylane/ops/functions/simplify.py
@@ -23,19 +23,19 @@ from pennylane.measurements import MeasurementProcess
 from pennylane.operation import Operator
 from pennylane.qnode import QNode
 from pennylane.queuing import QueuingManager
-from pennylane.tape import QuantumScript, make_qscript
+from pennylane.tape import QuantumScript, make_qscript, QuantumTape
 
 
-def simplify(input: Union[Operator, MeasurementProcess, QuantumScript, QNode, Callable]):
+def simplify(input: Union[Operator, MeasurementProcess, QuantumTape, QNode, Callable]):
     """Simplifies an operator, tape, qnode or quantum function by reducing its arithmetic depth
     or number of rotation parameters.
 
     Args:
-        input (.Operator, pennylane.QNode, .QuantumScript, or Callable): an operator, quantum node,
+        input (.Operator, pennylane.QNode, .QuantumTape, or Callable): an operator, quantum node,
             tape or function that applies quantum operations
 
     Returns:
-        (.Operator, pennylane.QNode, .QuantumScript, or Callable): Simplified input.
+        (.Operator, pennylane.QNode, .QuantumTape, or Callable): Simplified input.
 
     **Example**
 
@@ -91,7 +91,7 @@ def simplify(input: Union[Operator, MeasurementProcess, QuantumScript, QNode, Ca
 
     if isinstance(input, QuantumScript):
         # pylint: disable=protected-access
-        return QuantumScript(
+        return input.__class__(
             [op.simplify() for op in input._ops],
             [m.simplify() for m in input.measurements],
             [op.simplify() for op in input._prep],

--- a/pennylane/qnode.py
+++ b/pennylane/qnode.py
@@ -26,7 +26,7 @@ import pennylane as qml
 from pennylane import Device
 from pennylane.interfaces import INTERFACE_MAP, SUPPORTED_INTERFACES, set_shots
 from pennylane.measurements import ClassicalShadowMP, CountsMP, MidMeasureMP
-from pennylane.tape import QuantumScript, make_qscript
+from pennylane.tape import QuantumTape, make_qscript
 
 
 class QNode:
@@ -36,7 +36,7 @@ class QNode:
     (corresponding to a :ref:`variational circuit <glossary_variational_circuit>`)
     and the computational device it is executed on.
 
-    The QNode calls the quantum function to construct a :class:`~.QuantumScript` instance representing
+    The QNode calls the quantum function to construct a :class:`~.QuantumTape` instance representing
     the quantum circuit.
 
     Args:
@@ -699,7 +699,7 @@ class QNode:
         )
 
     @property
-    def tape(self) -> QuantumScript:
+    def tape(self) -> QuantumTape:
         """The quantum tape"""
         return self._tape
 

--- a/pennylane/shadows/transforms.py
+++ b/pennylane/shadows/transforms.py
@@ -20,11 +20,11 @@ from itertools import product
 import pennylane as qml
 import pennylane.numpy as np
 from pennylane.measurements import ClassicalShadowMP
-from pennylane.tape import QuantumScript
+from pennylane.tape import QuantumScript, QuantumTape
 
 
 @qml.batch_transform
-def _replace_obs(tape: QuantumScript, obs, *args, **kwargs):
+def _replace_obs(tape: QuantumTape, obs, *args, **kwargs):
     """
     Tape transform to replace the measurement processes with the given one
     """
@@ -42,7 +42,7 @@ def _replace_obs(tape: QuantumScript, obs, *args, **kwargs):
 
         # queue the new observable
         obs(*args, **kwargs)
-    qscript = qml.tape.QuantumScript.from_queue(q)
+    qscript = QuantumScript.from_queue(q)
 
     def processing_fn(res):
         if qml.active_return():

--- a/pennylane/transforms/adjoint_metric_tensor.py
+++ b/pennylane/transforms/adjoint_metric_tensor.py
@@ -99,7 +99,7 @@ def adjoint_metric_tensor(circuit, device=None, hybrid=True):
           Note also that this makes the metric tensor strictly real-valued.
 
     Args:
-        circuit (.QuantumScript or .QNode): Circuit to compute the metric tensor of
+        circuit (.QuantumTape or .QNode): Circuit to compute the metric tensor of
         device (.Device): Device to use for the adjoint method
         hybrid (bool): Whether to take classical preprocessing into account. Ignored if
             ``circuit`` is a tape.
@@ -161,7 +161,7 @@ def adjoint_metric_tensor(circuit, device=None, hybrid=True):
     if isinstance(circuit, (qml.QNode, qml.ExpvalCost)):
         return _adjoint_metric_tensor_qnode(circuit, device, hybrid)
 
-    raise qml.QuantumFunctionError("The passed object is not a QuantumScript or QNode.")
+    raise qml.QuantumFunctionError("The passed object is not a QuantumTape or QNode.")
 
 
 def _adjoint_metric_tensor_tape(tape, device):

--- a/pennylane/transforms/batch_transform.py
+++ b/pennylane/transforms/batch_transform.py
@@ -387,7 +387,7 @@ class batch_transform:
         """Applies the batch tape transform to an input tape.
 
         Args:
-            tape (.QuantumScript): the tape to be transformed
+            tape (.QuantumTape): the tape to be transformed
             *args: positional arguments to pass to the tape transform
             **kwargs: keyword arguments to pass to the tape transform
 
@@ -427,7 +427,7 @@ def map_batch_transform(transform, tapes):
     Args:
         transform (.batch_transform): the batch transform
             to be mapped
-        tapes (Sequence[QuantumScript]): The sequence of tapes the batch
+        tapes (Sequence[QuantumTape]): The sequence of tapes the batch
             transform should be applied to. Each tape in the sequence
             is transformed by the batch transform.
 

--- a/pennylane/transforms/commutation_dag.py
+++ b/pennylane/transforms/commutation_dag.py
@@ -22,7 +22,7 @@ import networkx as nx
 from networkx.drawing.nx_pydot import to_pydot
 
 import pennylane as qml
-from pennylane.tape import QuantumScript, make_qscript
+from pennylane.tape import QuantumScript, make_qscript, QuantumTape
 from pennylane.wires import Wires
 
 
@@ -212,7 +212,7 @@ class CommutationDAG:
 
     """
 
-    def __init__(self, tape: QuantumScript):
+    def __init__(self, tape: QuantumTape):
 
         self.num_wires = len(tape.wires)
         self.node_id = -1

--- a/pennylane/transforms/condition.py
+++ b/pennylane/transforms/condition.py
@@ -43,7 +43,7 @@ class Conditional(Operation):
         expr (MeasurementValue): the measurement outcome value to consider
         then_op (Operation): the PennyLane operation to apply conditionally
         do_queue (bool): indicates whether the operator should be
-            recorded when created in a qscript context
+            recorded when created in a tape context
         id (str): custom label given to an operator instance,
             can be useful for some applications where the instance has to be identified
     """

--- a/pennylane/transforms/hamiltonian_expand.py
+++ b/pennylane/transforms/hamiltonian_expand.py
@@ -20,10 +20,10 @@ from typing import List
 import pennylane as qml
 from pennylane.measurements import ExpectationMP, MeasurementProcess
 from pennylane.ops import SProd, Sum
-from pennylane.tape import QuantumScript
+from pennylane.tape import QuantumScript, QuantumTape
 
 
-def hamiltonian_expand(tape: QuantumScript, group=True):
+def hamiltonian_expand(tape: QuantumTape, group=True):
     r"""
     Splits a tape measuring a Hamiltonian expectation into mutliple tapes of Pauli expectations,
     and provides a function to recombine the results.
@@ -204,20 +204,20 @@ def hamiltonian_expand(tape: QuantumScript, group=True):
 
 
 # pylint: disable=too-many-branches, too-many-statements
-def sum_expand(qscript: QuantumScript, group=True):
-    """Splits a quantum script measuring a Sum expectation into multiple scripts of summand
+def sum_expand(tape: QuantumTape, group=True):
+    """Splits a quantum tape measuring a Sum expectation into multiple tapes of summand
     expectations, and provides a function to recombine the results.
 
     Args:
-        qscript (.QuantumScript): the quantum script used when calculating the expectation value
+        tape (.QuantumTape): the quantum tape used when calculating the expectation value
             of the Hamiltonian
         group (bool): Whether to compute disjoint groups of Pauli observables acting on different
             wires, leading to fewer tapes.
 
     Returns:
-        tuple[list[.QuantumScript], function]: Returns a tuple containing a list of
-        quantum scripts to be evaluated, and a function to be applied to these
-        script executions to compute the expectation value.
+        tuple[list[.QuantumTape], function]: Returns a tuple containing a list of
+        quantum tapes to be evaluated, and a function to be applied to these
+        tape executions to compute the expectation value.
 
     **Example**
 
@@ -290,12 +290,12 @@ def sum_expand(qscript: QuantumScript, group=True):
     [expval(PauliX(wires=[0]))]
     """
     # Populate these 2 dictionaries with the unique measurement objects, the index of the
-    # initial measurement on the qscript and the coefficient
+    # initial measurement on the tape and the coefficient
     # NOTE: expval(Sum) is expanded into the expectation of each summand
     # NOTE: expval(SProd) is transformed into expval(SProd.base) and the coeff is updated
     measurements_dict = {}  # {m_hash: measurement}
     idxs_coeffs_dict = {}  # {m_hash: [(location_idx, coeff)]}
-    for idx, m in enumerate(qscript.measurements):
+    for idx, m in enumerate(tape.measurements):
         obs = m.obs
         if isinstance(obs, Sum) and isinstance(m, ExpectationMP):
             for summand in obs.operands:
@@ -326,7 +326,7 @@ def sum_expand(qscript: QuantumScript, group=True):
     measurements = list(measurements_dict.values())
     idxs_coeffs = list(idxs_coeffs_dict.values())
 
-    # Create the qscripts, group observables if group==True
+    # Create the tapes, group observables if group==True
     if group:
         m_groups = _group_measurements(measurements)
         # Update ``idxs_coeffs`` list such that it tracks the new ``m_groups`` list of lists
@@ -338,13 +338,12 @@ def sum_expand(qscript: QuantumScript, group=True):
                 tmp_idxs.append([idxs_coeffs[measurements.index(m)] for m in m_group])
         idxs_coeffs = tmp_idxs
         qscripts = [
-            QuantumScript(ops=qscript._ops, measurements=m_group, prep=qscript._prep)
+            QuantumScript(ops=tape._ops, measurements=m_group, prep=tape._prep)
             for m_group in m_groups
         ]
     else:
         qscripts = [
-            QuantumScript(ops=qscript._ops, measurements=[m], prep=qscript._prep)
-            for m in measurements
+            QuantumScript(ops=tape._ops, measurements=[m], prep=tape._prep) for m in measurements
         ]
 
     def processing_fn(expanded_results):

--- a/pennylane/transforms/insert_ops.py
+++ b/pennylane/transforms/insert_ops.py
@@ -90,7 +90,7 @@ def insert(
         device which will transform circuits before execution
 
     Raises:
-        QuantumFunctionError: if some observables in the qscript are not qubit-wise commuting
+        QuantumFunctionError: if some observables in the tape are not qubit-wise commuting
         ValueError: if a single operation acting on multiple wires is passed to ``op``
         ValueError: if the requested ``position`` argument is not ``'start'``, ``'end'`` or
             ``'all'`` OR PennyLane Operation

--- a/pennylane/transforms/metric_tensor.py
+++ b/pennylane/transforms/metric_tensor.py
@@ -502,10 +502,10 @@ def _get_first_term_tapes(layer_i, layer_j, allow_nonunitary, aux_wire):
             control the controlled-generator operations
 
     Returns:
-        list[pennylane.tape.QuantumScript]: Transformed qscripts that compute the
+        list[pennylane.tape.QuantumTape]: Transformed tapes that compute the
             first term of the metric tensor for the off-diagonal block belonging
             to the input layers
-        list[tuple[int]]: 2-tuple indices assigning the qscripts to metric tensor
+        list[tuple[int]]: 2-tuple indices assigning the tapes to metric tensor
             entries
     """
 

--- a/pennylane/transforms/qcut/tapes.py
+++ b/pennylane/transforms/qcut/tapes.py
@@ -123,7 +123,7 @@ def graph_to_tape(graph: MultiDiGraph) -> QuantumTape:
         graph (nx.MultiDiGraph): directed multigraph to be converted to a tape
 
     Returns:
-        QuantumTape: the quantum script corresponding to the input graph
+        QuantumTape: the quantum tape corresponding to the input graph
 
     **Example**
 

--- a/pennylane/transforms/qfunc_transforms.py
+++ b/pennylane/transforms/qfunc_transforms.py
@@ -148,7 +148,7 @@ class single_tape_transform:
     def __call__(self, tape, *args, **kwargs):
         with qml.queuing.AnnotatedQueue() as q:
             self.transform_fn(tape, *args, **kwargs)
-        qs = qml.tape.QuantumScript(*qml.queuing.process_queue(q))
+        qs = qml.tape.QuantumScript.from_queue(q)
         for obj, info in q.items():
             qml.queuing.QueuingManager.append(obj, **info)
         return qs
@@ -337,15 +337,15 @@ def qfunc_transform(tape_transform):
 
             def transform(old_qfunc, params):
                 def new_qfunc(*args, **kwargs):
-                    # 1. extract the QuantumScript from the old qfunc, being
+                    # 1. extract the QuantumTape from the old qfunc, being
                     # careful *not* to have it queued.
-                    qscript = make_qscript(old_qfunc)(*args, **kwargs)
+                    tape = make_qscript(old_qfunc)(*args, **kwargs)
 
-                    # 2. transform the qscript
-                    new_script = tape_transform(qscript, params)
+                    # 2. transform the tape
+                    new_tape = tape_transform(tape, params)
 
-                    # 3. queue the *new* qscript to the active queuing context
-                    new_script.queue()
+                    # 3. queue the *new* tape to the active queuing context
+                    new_tape.queue()
                 return new_qfunc
 
         *Note: this is pseudocode; the actual implementation is significantly more complicated!*

--- a/tests/measurements/test_measurements.py
+++ b/tests/measurements/test_measurements.py
@@ -564,8 +564,8 @@ class TestMeasurementTransform:
         switch_return()
 
         class MyMeasurement(MeasurementTransform):
-            def process(self, qscript, device):
-                return {device.shots: len(qscript)}
+            def process(self, tape, device):
+                return {device.shots: len(tape)}
 
         dev = qml.device("default.qubit", wires=2, shots=1000)
 
@@ -586,6 +586,6 @@ class TestMeasurementTransform:
             return qml.classical_shadow(wires=0)
 
         circuit.device.measurement_map[ClassicalShadowMP] = "test_method"
-        circuit.device.test_method = lambda qscript: 2
+        circuit.device.test_method = lambda tape: 2
 
         assert circuit() == 2

--- a/tests/transforms/test_zx.py
+++ b/tests/transforms/test_zx.py
@@ -487,7 +487,7 @@ class TestConvertersZX:
         qscript = QuantumScript(operations, [], [])
         with pytest.raises(
             qml.QuantumFunctionError,
-            match="The expansion of the quantum script failed, PyZX does not support",
+            match="The expansion of the quantum tape failed, PyZX does not support",
         ):
             qml.transforms.to_zx(qscript)
 


### PR DESCRIPTION
## 🚨 Going into the RC branch 🚨 

we're planning to rename QuantumScript back to QuantumTape in two releases (first we need to deprecate `with QuantumTape()`), so we shouldn't start advertising QuantumScript only for it to disappear in two releases.

Do I need a changelog entry for this?