### PR TITLE
put back QuantumTape naming in split_qscript

### DIFF
--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -98,7 +98,7 @@ Pending deprecations
       qml.RX(0.2, wires=1)
       qml.expval(H)
 
-    tapes, fn = qml.transforms.split_qscript(tape)
+    tapes, fn = qml.transforms.split_tape(tape)
 
 * ``qml.transforms.make_tape`` has been deprecated, and usage will now raise a warning.
   Instead, use ``qml.tape.make_qscript``.
@@ -107,7 +107,7 @@ Pending deprecations
   - Will be removed in v0.29
 
 * ``qml.transforms.hamiltonian_expand`` has been deprecated. Users are redirected to the new
-  ``qml.transforms.split_qscript`` function.
+  ``qml.transforms.split_tape`` function.
 
   - Deprecated in v0.28
   - Will be removed in v0.29

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -752,7 +752,7 @@ class Device(abc.ABC):
             # support Hamiltonians, or if the simulation uses finite shots, or
             # if the Hamiltonian explicitly specifies an observable grouping,
             # split tape into multiple tapes of diagonalizable known observables.
-            circuits, hamiltonian_fn = qml.transforms.split_qscript(circuit, group=True)
+            circuits, hamiltonian_fn = qml.transforms.split_tape(circuit, group=True)
 
         elif (
             len(circuit._obs_sharing_wires) > 0
@@ -785,7 +785,7 @@ class Device(abc.ABC):
 
         # Chain the postprocessing functions of the broadcasted-tape expansions and the Hamiltonian
         # expansion. Note that the application order is reversed compared to the expansion order,
-        # i.e. while we first applied `split_qscript` to the tape, we need to process the
+        # i.e. while we first applied `split_tape` to the tape, we need to process the
         # results from the broadcast expansion first.
         def total_processing(results):
             return hamiltonian_fn(expanded_fn(results))

--- a/pennylane/transforms/__init__.py
+++ b/pennylane/transforms/__init__.py
@@ -148,7 +148,7 @@ more tapes as well as a classical processing function.
 
     ~transforms.broadcast_expand
     ~transforms.measurement_grouping
-    ~transforms.split_qscript
+    ~transforms.split_tape
 
 Decorators and utility functions
 --------------------------------
@@ -197,7 +197,7 @@ from .condition import cond, Conditional
 from .compile import compile
 from .decompositions import zyz_decomposition, two_qubit_decomposition
 from .defer_measurements import defer_measurements
-from .split_qscript import split_qscript
+from .split_tape import split_tape
 from .split_non_commuting import split_non_commuting
 from .measurement_grouping import measurement_grouping
 from .metric_tensor import metric_tensor
@@ -244,9 +244,9 @@ def __getattr__(name):
     syntax for one release."""
     if name == "hamiltonian_expand":
         warnings.warn(
-            "The hamiltonian_expand function is deprecated, please use split_qscript instead.",
+            "The hamiltonian_expand function is deprecated, please use split_tape instead.",
             UserWarning,
         )
-        return split_qscript
+        return split_tape
 
     raise AttributeError(f"Module {__name__} has no attribute {name}")  # pragma: no cover

--- a/pennylane/transforms/batch_transform.py
+++ b/pennylane/transforms/batch_transform.py
@@ -455,7 +455,7 @@ def map_batch_transform(transform, tapes):
     batch transform across both of the these tapes in such a way
     that allows us to submit a single job for execution:
 
-    >>> tapes, fn = map_batch_transform(qml.transforms.split_qscript, [tape1, tape2])
+    >>> tapes, fn = map_batch_transform(qml.transforms.split_tape, [tape1, tape2])
     >>> dev = qml.device("default.qubit", wires=2)
     >>> fn(qml.execute(tapes, dev, qml.gradients.param_shift))
     [0.9950041652780257, 0.8150893013179248]

--- a/pennylane/transforms/measurement_grouping.py
+++ b/pennylane/transforms/measurement_grouping.py
@@ -76,7 +76,7 @@ def measurement_grouping(tape, obs_list, coeffs_list):
     """
 
     warnings.warn(
-        "qml.transforms.measurement_grouping is deprecated. Instead, use qml.transforms.split_qscript",
+        "qml.transforms.measurement_grouping is deprecated. Instead, use qml.transforms.split_tape",
         UserWarning,
     )
 

--- a/tests/interfaces/test_autograd_qnode.py
+++ b/tests/interfaces/test_autograd_qnode.py
@@ -1389,7 +1389,7 @@ class TestTapeExpansion:
             pytest.skip("The adjoint and backprop methods do not yet support sampling")
 
         dev = qml.device(dev_name, wires=3, shots=50000)
-        spy = mocker.spy(qml.transforms, "split_qscript")
+        spy = mocker.spy(qml.transforms, "split_tape")
         obs = [qml.PauliX(0), qml.PauliX(0) @ qml.PauliZ(1), qml.PauliZ(0) @ qml.PauliZ(1)]
 
         @qnode(dev, diff_method=diff_method, mode=mode, max_diff=max_diff)

--- a/tests/interfaces/test_jax_qnode.py
+++ b/tests/interfaces/test_jax_qnode.py
@@ -1278,7 +1278,7 @@ class TestTapeExpansion:
             pytest.skip("JAX only supports first derivatives")
 
         dev = qml.device(dev_name, wires=3, shots=None)
-        spy = mocker.spy(qml.transforms, "split_qscript")
+        spy = mocker.spy(qml.transforms, "split_tape")
         obs = [qml.PauliX(0), qml.PauliX(0) @ qml.PauliZ(1), qml.PauliZ(0) @ qml.PauliZ(1)]
 
         @qnode(dev, interface=interface, diff_method=diff_method, mode=mode, max_diff=max_diff)
@@ -1337,7 +1337,7 @@ class TestTapeExpansion:
             pytest.skip("JAX only supports first derivatives")
 
         dev = qml.device(dev_name, wires=3, shots=50000)
-        spy = mocker.spy(qml.transforms, "split_qscript")
+        spy = mocker.spy(qml.transforms, "split_tape")
         obs = [qml.PauliX(0), qml.PauliX(0) @ qml.PauliZ(1), qml.PauliZ(0) @ qml.PauliZ(1)]
 
         @qnode(dev, interface=interface, diff_method=diff_method, mode=mode, max_diff=max_diff)

--- a/tests/interfaces/test_tensorflow_qnode.py
+++ b/tests/interfaces/test_tensorflow_qnode.py
@@ -1201,7 +1201,7 @@ class TestTapeExpansion:
             pytest.skip("The adjoint and backprop methods do not yet support sampling")
 
         dev = qml.device(dev_name, wires=3, shots=50000)
-        spy = mocker.spy(qml.transforms, "split_qscript")
+        spy = mocker.spy(qml.transforms, "split_tape")
         obs = [qml.PauliX(0), qml.PauliX(0) @ qml.PauliZ(1), qml.PauliZ(0) @ qml.PauliZ(1)]
 
         @qnode(dev, diff_method=diff_method, mode=mode, max_diff=max_diff, interface="tf")

--- a/tests/interfaces/test_torch_qnode.py
+++ b/tests/interfaces/test_torch_qnode.py
@@ -1232,7 +1232,7 @@ class TestTapeExpansion:
             pytest.skip("The adjoint and backprop methods do not yet support sampling")
 
         dev = qml.device(dev_name, wires=3, shots=50000)
-        spy = mocker.spy(qml.transforms, "split_qscript")
+        spy = mocker.spy(qml.transforms, "split_tape")
         obs = [qml.PauliX(0), qml.PauliX(0) @ qml.PauliZ(1), qml.PauliZ(0) @ qml.PauliZ(1)]
 
         @qnode(dev, diff_method=diff_method, mode=mode, max_diff=max_diff, interface="torch")

--- a/tests/returntypes/autograd/test_autograd_qnode_new.py
+++ b/tests/returntypes/autograd/test_autograd_qnode_new.py
@@ -1485,7 +1485,7 @@ class TestTapeExpansion:
             pytest.skip("The adjoint and backprop methods do not yet support sampling")
 
         dev = qml.device(dev_name, wires=3, shots=50000)
-        spy = mocker.spy(qml.transforms, "split_qscript")
+        spy = mocker.spy(qml.transforms, "split_tape")
         obs = [qml.PauliX(0), qml.PauliX(0) @ qml.PauliZ(1), qml.PauliZ(0) @ qml.PauliZ(1)]
 
         @qnode(dev, diff_method=diff_method, mode=mode, max_diff=max_diff)

--- a/tests/returntypes/jax/test_jax_jit_qnode_new.py
+++ b/tests/returntypes/jax/test_jax_jit_qnode_new.py
@@ -1315,7 +1315,7 @@ class TestTapeExpansion:
             pytest.skip("TODO: add Hessian support to JAX-JIT.")
 
         dev = qml.device(dev_name, wires=3, shots=None)
-        spy = mocker.spy(qml.transforms, "split_qscript")
+        spy = mocker.spy(qml.transforms, "split_tape")
         obs = [qml.PauliX(0), qml.PauliX(0) @ qml.PauliZ(1), qml.PauliZ(0) @ qml.PauliZ(1)]
 
         @qnode(dev, interface=interface, diff_method=diff_method, mode=mode, max_diff=max_diff)
@@ -1373,7 +1373,7 @@ class TestTapeExpansion:
             pytest.skip("TODO: add Hessian support to JAX-JIT.")
 
         dev = qml.device(dev_name, wires=3, shots=50000)
-        spy = mocker.spy(qml.transforms, "split_qscript")
+        spy = mocker.spy(qml.transforms, "split_tape")
         obs = [qml.PauliX(0), qml.PauliX(0) @ qml.PauliZ(1), qml.PauliZ(0) @ qml.PauliZ(1)]
 
         @qnode(dev, interface=interface, diff_method=diff_method, mode=mode, max_diff=max_diff)

--- a/tests/returntypes/jax/test_jax_qnode_new.py
+++ b/tests/returntypes/jax/test_jax_qnode_new.py
@@ -1290,7 +1290,7 @@ class TestTapeExpansion:
             pytest.skip("The adjoint method does not yet support Hamiltonians")
 
         dev = qml.device(dev_name, wires=3, shots=None)
-        spy = mocker.spy(qml.transforms, "split_qscript")
+        spy = mocker.spy(qml.transforms, "split_tape")
         obs = [qml.PauliX(0), qml.PauliX(0) @ qml.PauliZ(1), qml.PauliZ(0) @ qml.PauliZ(1)]
 
         @qnode(dev, interface=interface, diff_method=diff_method, mode=mode, max_diff=max_diff)
@@ -1345,7 +1345,7 @@ class TestTapeExpansion:
             pytest.skip("The adjoint and backprop methods do not yet support sampling")
 
         dev = qml.device(dev_name, wires=3, shots=50000)
-        spy = mocker.spy(qml.transforms, "split_qscript")
+        spy = mocker.spy(qml.transforms, "split_tape")
         obs = [qml.PauliX(0), qml.PauliX(0) @ qml.PauliZ(1), qml.PauliZ(0) @ qml.PauliZ(1)]
 
         @qnode(dev, interface=interface, diff_method=diff_method, mode=mode, max_diff=max_diff)

--- a/tests/returntypes/tf/test_tensorflow_qnode_new.py
+++ b/tests/returntypes/tf/test_tensorflow_qnode_new.py
@@ -1200,7 +1200,7 @@ class TestTapeExpansion:
             pytest.skip("The adjoint and backprop methods do not yet support sampling")
 
         dev = qml.device(dev_name, wires=3, shots=50000)
-        spy = mocker.spy(qml.transforms, "split_qscript")
+        spy = mocker.spy(qml.transforms, "split_tape")
         obs = [qml.PauliX(0), qml.PauliX(0) @ qml.PauliZ(1), qml.PauliZ(0) @ qml.PauliZ(1)]
 
         @qnode(dev, diff_method=diff_method, mode=mode, max_diff=max_diff, interface="tf")

--- a/tests/returntypes/torch/test_torch_qnode_new.py
+++ b/tests/returntypes/torch/test_torch_qnode_new.py
@@ -1301,7 +1301,7 @@ class TestTapeExpansion:
             pytest.skip("The adjoint and backprop methods do not yet support sampling")
 
         dev = qml.device(dev_name, wires=3, shots=50000)
-        spy = mocker.spy(qml.transforms, "split_qscript")
+        spy = mocker.spy(qml.transforms, "split_tape")
         obs = [qml.PauliX(0), qml.PauliX(0) @ qml.PauliZ(1), qml.PauliZ(0) @ qml.PauliZ(1)]
 
         @qnode(dev, diff_method=diff_method, mode=mode, max_diff=max_diff, interface="torch")

--- a/tests/test_qnode.py
+++ b/tests/test_qnode.py
@@ -1511,7 +1511,7 @@ class TestTapeExpansion:
         def circuit():
             return qml.expval(H)
 
-        spy = mocker.spy(qml.transforms, "split_qscript")
+        spy = mocker.spy(qml.transforms, "split_tape")
         res = circuit()
         assert np.allclose(res, c[2], atol=0.1)
 

--- a/tests/transforms/test_batch_transform.py
+++ b/tests/transforms/test_batch_transform.py
@@ -688,8 +688,8 @@ class TestMapBatchTransform:
             qml.expval(H + 0.5 * qml.PauliY(0))
 
         tape2 = qml.tape.QuantumScript.from_queue(q2)
-        spy = mocker.spy(qml.transforms, "split_qscript")
-        tapes, fn = qml.transforms.map_batch_transform(qml.transforms.split_qscript, [tape1, tape2])
+        spy = mocker.spy(qml.transforms, "split_tape")
+        tapes, fn = qml.transforms.map_batch_transform(qml.transforms.split_tape, [tape1, tape2])
 
         spy.assert_called()
         assert len(tapes) == 5
@@ -722,7 +722,7 @@ class TestMapBatchTransform:
 
             tape2 = qml.tape.QuantumScript.from_queue(q2)
             tapes, fn = qml.transforms.map_batch_transform(
-                qml.transforms.split_qscript, [tape1, tape2]
+                qml.transforms.split_tape, [tape1, tape2]
             )
             res = qml.execute(tapes, dev, qml.gradients.param_shift, device_batch_transform=False)
             return np.sum(fn(res))


### PR DESCRIPTION
I'm righting my wrongs that are coming up in #3264 