### PR TITLE
[Docs fix Pauli words]

### DIFF
--- a/pennylane/ops/functions/equal.py
+++ b/pennylane/ops/functions/equal.py
@@ -52,7 +52,7 @@ def equal(
 
         The kwargs ``check_interface`` and ``check_trainability`` can only be set when
         comparing ``Operation`` objects. Comparisons of ``MeasurementProcess``
-        or ``Observable`` objects will use the defualt value of ``True`` for both, regardless
+        or ``Observable`` objects will use the default value of ``True`` for both, regardless
         of what the user specifies when calling the function. For subclasses of ``SymbolicOp``
         with an ``Operation`` as a base, the kwargs will be applied to the base comparison.
 

--- a/pennylane/pauli/pauli_arithmetic.py
+++ b/pennylane/pauli/pauli_arithmetic.py
@@ -352,7 +352,7 @@ class PauliSentence(dict):
         return math.expand_matrix(reduced_mat, result_wire_order, wire_order=wire_order)
 
     def operation(self, wire_order=None):
-        """Returns a native PennyLane``~.Operator`` representing the PauliSentence."""
+        """Returns a native PennyLane :class:`~pennylane.Operation` representing the PauliSentence."""
         if len(self) == 0:
             if wire_order in (None, [], wires.Wires([])):
                 raise ValueError("Can't get the operation for an empty PauliSentence.")
@@ -364,7 +364,7 @@ class PauliSentence(dict):
         return summands[0] if len(summands) == 1 else op_sum(*summands)
 
     def hamiltonian(self, wire_order=None):
-        """Returns a native PennyLane ~.Hamiltonian representing the PauliSentence."""
+        """Returns a native PennyLane :class:`~pennylane.Hamiltonian` representing the PauliSentence."""
         if len(self) == 0:
             if wire_order in (None, [], wires.Wires([])):
                 raise ValueError("Can't get the Hamiltonian for an empty PauliSentence.")

--- a/pennylane/pauli/pauli_arithmetic.py
+++ b/pennylane/pauli/pauli_arithmetic.py
@@ -210,7 +210,7 @@ class PauliWord(dict):
         return reduce(kron, (matrix_map[self[w]] for w in wire_order))
 
     def operation(self, wire_order=None):
-        """Returns a native PennyLane :class:`~pennylane.Operator` representing the PauliWord."""
+        """Returns a native PennyLane :class:`~pennylane.operation.Operation` representing the PauliWord."""
         if len(self) == 0:
             if wire_order in (None, [], wires.Wires([])):
                 raise ValueError("Can't get the operation for an empty PauliWord.")
@@ -352,7 +352,7 @@ class PauliSentence(dict):
         return math.expand_matrix(reduced_mat, result_wire_order, wire_order=wire_order)
 
     def operation(self, wire_order=None):
-        """Returns a native PennyLane :class:`~pennylane.Operation` representing the PauliSentence."""
+        """Returns a native PennyLane :class:`~pennylane.operation.Operation` representing the PauliSentence."""
         if len(self) == 0:
             if wire_order in (None, [], wires.Wires([])):
                 raise ValueError("Can't get the operation for an empty PauliSentence.")

--- a/pennylane/pauli/pauli_arithmetic.py
+++ b/pennylane/pauli/pauli_arithmetic.py
@@ -210,7 +210,7 @@ class PauliWord(dict):
         return reduce(kron, (matrix_map[self[w]] for w in wire_order))
 
     def operation(self, wire_order=None):
-        """Returns a native PennyLane``~.Operator`` representing the PauliWord."""
+        """Returns a native PennyLane :class:`~pennylane.Operator` representing the PauliWord."""
         if len(self) == 0:
             if wire_order in (None, [], wires.Wires([])):
                 raise ValueError("Can't get the operation for an empty PauliWord.")
@@ -220,7 +220,7 @@ class PauliWord(dict):
         return factors[0] if len(factors) == 1 else prod(*factors)
 
     def hamiltonian(self, wire_order=None):
-        """Return ~.Hamiltonian representing the PauliWord"""
+        """Return :class:`~pennylane.Hamiltonian` representing the PauliWord"""
         if len(self) == 0:
             if wire_order in (None, [], wires.Wires([])):
                 raise ValueError("Can't get the Hamiltonian for an empty PauliWord.")


### PR DESCRIPTION
Small fixes to links in the PauliWord methods

The hyperlinks dont work. Is this behavior new?
![image](https://user-images.githubusercontent.com/43949391/208078018-61d4ec77-696c-4071-a958-baad0fd33b37.png)
