### PR TITLE
Statistics deprecation

### DIFF
--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -7,7 +7,8 @@ Pending deprecations
 --------------------
 
 * The ``observables`` argument in ``QubitDevice.statistics`` is deprecated. Please use ``circuit``
-  instead.
+  instead. Using a list of observables in ``QubitDevice.statistics`` is deprecated. Please use a
+  ``QuantumTape`` instead.
 
   - Still accessible in v0.28
   - Will be removed in v0.29

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -722,10 +722,10 @@ class QubitDevice(Device):
     # pylint: disable=too-many-statements
     def statistics(
         self,
-        circuit: QuantumTape = None,
+        observables=None,
         shot_range=None,
         bin_size=None,
-        observables=None,
+        circuit: QuantumTape = None,
     ):
         """Process measurement results from circuit execution and return statistics.
 
@@ -773,23 +773,18 @@ class QubitDevice(Device):
               ``shot_range=[35, 135]``, ``bin_size=100``.
         """
         if observables is not None:
-            warnings.warn(
-                message="The ``observables`` argument in ``QubitDevice.statistics`` is deprecated. "
-                "Please use ``circuit`` instead.",
-                category=UserWarning,
-            )
             circuit = observables
         elif circuit is None:
             raise ValueError("Please provide a circuit into the statistics method.")
         if isinstance(circuit, QuantumScript):
             measurements = circuit.measurements
         else:
-            if observables is None:
-                warnings.warn(
-                    message="Using a list of observables in ``QubitDevice.statistics`` is "
-                    "deprecated. Please use a ``QuantumTape`` instead.",
-                    category=UserWarning,
-                )
+            warnings.warn(
+                message="Using a list of observables in ``QubitDevice.statistics`` is deprecated. Please use a "
+                "``QuantumTape`` instead. This should be passed to ``circuit``, as the ``observables`` "
+                "argument is also deprecated.",
+                category=UserWarning,
+            )
             measurements = circuit
 
         results = []

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -784,11 +784,12 @@ class QubitDevice(Device):
         if isinstance(circuit, QuantumScript):
             measurements = circuit.measurements
         else:
-            warnings.warn(
-                message="Using a list of observables in ``QubitDevice.statistics`` is "
-                "deprecated. Please use a ``QuantumTape`` instead.",
-                category=UserWarning,
-            )
+            if observables is None:
+                warnings.warn(
+                    message="Using a list of observables in ``QubitDevice.statistics`` is "
+                    "deprecated. Please use a ``QuantumTape`` instead.",
+                    category=UserWarning,
+                )
             measurements = circuit
 
         results = []

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -773,19 +773,21 @@ class QubitDevice(Device):
               ``shot_range=[35, 135]``, ``bin_size=100``.
         """
         if observables is not None:
-            circuit = observables
-        elif circuit is None:
-            raise ValueError("Please provide a circuit into the statistics method.")
-        if isinstance(circuit, QuantumScript):
+            if isinstance(observables, QuantumScript):
+                circuit = observables
+                measurements = circuit.measurements
+            else:
+                warnings.warn(
+                    message="Using a list of observables in ``QubitDevice.statistics`` is deprecated. "
+                    "Please use a ``QuantumTape`` instead. This should be passed to ``circuit``, "
+                    "as the ``observables`` argument is also deprecated.",
+                    category=UserWarning,
+                )
+                measurements = observables
+        elif circuit is not None:
             measurements = circuit.measurements
         else:
-            warnings.warn(
-                message="Using a list of observables in ``QubitDevice.statistics`` is deprecated. Please use a "
-                "``QuantumTape`` instead. This should be passed to ``circuit``, as the ``observables`` "
-                "argument is also deprecated.",
-                category=UserWarning,
-            )
-            measurements = circuit
+            raise ValueError("Please provide a circuit into the statistics method.")
 
         results = []
 

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -721,7 +721,11 @@ class QubitDevice(Device):
 
     # pylint: disable=too-many-statements
     def statistics(
-        self, observables=None, shot_range=None, bin_size=None, circuit: QuantumTape = None
+        self,
+        circuit: QuantumTape = None,
+        shot_range=None,
+        bin_size=None,
+        observables=None,
     ):
         """Process measurement results from circuit execution and return statistics.
 
@@ -769,20 +773,23 @@ class QubitDevice(Device):
               ``shot_range=[35, 135]``, ``bin_size=100``.
         """
         if observables is not None:
-            if isinstance(observables, QuantumScript):
-                circuit = observables
-                measurements = circuit.measurements
-            else:
-                warnings.warn(
-                    message="Using a list of observables in ``QubitDevice.statistics`` is "
-                    "deprecated. Please use a ``QuantumTape`` instead.",
-                    category=UserWarning,
-                )
-                measurements = observables
-        elif circuit is not None:
+            warnings.warn(
+                message="The ``observables`` argument in ``QubitDevice.statistics`` is deprecated. "
+                "Please use ``circuit`` instead.",
+                category=UserWarning,
+            )
+            circuit = observables
+        elif circuit is None:
+            raise ValueError("Please provide a circuit into the statistics method.")
+        if isinstance(circuit, QuantumScript):
             measurements = circuit.measurements
         else:
-            raise ValueError("Please provide a circuit into the statistics method.")
+            warnings.warn(
+                message="Using a list of observables in ``QubitDevice.statistics`` is "
+                "deprecated. Please use a ``QuantumTape`` instead.",
+                category=UserWarning,
+            )
+            measurements = circuit
 
         results = []
 

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -721,11 +721,7 @@ class QubitDevice(Device):
 
     # pylint: disable=too-many-statements
     def statistics(
-        self,
-        observables=None,
-        shot_range=None,
-        bin_size=None,
-        circuit: QuantumTape = None,
+        self, observables=None, shot_range=None, bin_size=None, circuit: QuantumTape = None
     ):
         """Process measurement results from circuit execution and return statistics.
 

--- a/tests/test_qubit_device.py
+++ b/tests/test_qubit_device.py
@@ -336,12 +336,6 @@ class TestExtractStatistics:
         ):
             dev.statistics(observables=[])
 
-        with pytest.warns(
-            UserWarning,
-            match="Using a list of observables in ``QubitDevice.statistics`` is",
-        ):
-            dev.statistics(circuit=[])
-
     def test_no_observables_or_circuit_raises_error(
         self, mock_qubit_device_extract_stats, monkeypatch
     ):

--- a/tests/test_qubit_device.py
+++ b/tests/test_qubit_device.py
@@ -326,29 +326,21 @@ class TestParameters:
 class TestExtractStatistics:
     """Test the statistics method"""
 
-    def test_list_of_observables_deprecated(self, mock_qubit_device_extract_stats, monkeypatch):
+    def test_statistics_deprecation_warning(self, mock_qubit_device_extract_stats, monkeypatch):
         """Test that using a list of observables as an argument is deprecated."""
         dev = mock_qubit_device_extract_stats()
+
         with pytest.warns(
             UserWarning,
             match="Using a list of observables in ``QubitDevice.statistics`` is",
         ):
-            dev.statistics([])
-
-    def test_observables_kwarg_deprecated(self, mock_qubit_device_extract_stats, monkeypatch):
-        """Test that using observables instead of circuit is deprecated."""
-        dev = mock_qubit_device_extract_stats()
-        with pytest.warns(
-            UserWarning,
-            match="The ``observables`` argument in ``QubitDevice.statistics`` is deprecated. ",
-        ):
             dev.statistics(observables=[])
-        qscript = QuantumScript()
+
         with pytest.warns(
             UserWarning,
-            match="The ``observables`` argument in ``QubitDevice.statistics`` is deprecated. ",
+            match="Using a list of observables in ``QubitDevice.statistics`` is",
         ):
-            dev.statistics([], observables=qscript)
+            dev.statistics(circuit=[])
 
     def test_no_observables_or_circuit_raises_error(
         self, mock_qubit_device_extract_stats, monkeypatch

--- a/tests/test_qubit_device.py
+++ b/tests/test_qubit_device.py
@@ -326,22 +326,30 @@ class TestParameters:
 class TestExtractStatistics:
     """Test the statistics method"""
 
-    def test_statistics_deprecation_warning(self, mock_qubit_device_extract_stats, monkeypatch):
+    def test_observables_deprecated(self, mock_qubit_device_extract_stats, monkeypatch):
         """Test that using a list of observables as an argument is deprecated."""
-        dev = mock_qubit_device_extract_stats()
-
-        with pytest.warns(
-            UserWarning,
-            match="Using a list of observables in ``QubitDevice.statistics`` is",
-        ):
-            dev.statistics(observables=[])
-
-    def test_no_observables_or_circuit_raises_error(
-        self, mock_qubit_device_extract_stats, monkeypatch
-    ):
-        dev = mock_qubit_device_extract_stats()
-        with pytest.raises(ValueError, match="Please provide a circuit into the statistics method"):
-            dev.statistics()
+        with monkeypatch.context() as m:
+            dev = mock_qubit_device_extract_stats()
+            with pytest.warns(
+                UserWarning,
+                match="Using a list of observables in ``QubitDevice.statistics`` is",
+            ):
+                dev.statistics([])
+            with pytest.warns(
+                UserWarning,
+                match="Using a list of observables in ``QubitDevice.statistics`` is",
+            ):
+                dev.statistics(observables=[])
+            qscript = QuantumScript()
+            with pytest.warns(
+                UserWarning,
+                match="Using a list of observables in ``QubitDevice.statistics`` is",
+            ):
+                dev.statistics([], circuit=qscript)
+            with pytest.raises(
+                ValueError, match="Please provide a circuit into the statistics method"
+            ):
+                dev.statistics()
 
     @pytest.mark.parametrize(
         "measurement", [ExpectationMP, VarianceMP, SampleMP, ProbabilityMP, StateMP]

--- a/tests/test_qubit_device.py
+++ b/tests/test_qubit_device.py
@@ -334,11 +334,6 @@ class TestExtractStatistics:
             match="Using a list of observables in ``QubitDevice.statistics`` is",
         ):
             dev.statistics([])
-        with pytest.warns(
-            UserWarning,
-            match="Using a list of observables in ``QubitDevice.statistics`` is",
-        ):
-            dev.statistics(observables=[])
 
     def test_observables_kwarg_deprecated(self, mock_qubit_device_extract_stats, monkeypatch):
         """Test that using observables instead of circuit is deprecated."""

--- a/tests/test_qubit_device.py
+++ b/tests/test_qubit_device.py
@@ -326,30 +326,41 @@ class TestParameters:
 class TestExtractStatistics:
     """Test the statistics method"""
 
-    def test_observables_deprecated(self, mock_qubit_device_extract_stats, monkeypatch):
+    def test_list_of_observables_deprecated(self, mock_qubit_device_extract_stats, monkeypatch):
         """Test that using a list of observables as an argument is deprecated."""
-        with monkeypatch.context() as m:
-            dev = mock_qubit_device_extract_stats()
-            with pytest.warns(
-                UserWarning,
-                match="Using a list of observables in ``QubitDevice.statistics`` is",
-            ):
-                dev.statistics([])
-            with pytest.warns(
-                UserWarning,
-                match="Using a list of observables in ``QubitDevice.statistics`` is",
-            ):
-                dev.statistics(observables=[])
-            qscript = QuantumScript()
-            with pytest.warns(
-                UserWarning,
-                match="Using a list of observables in ``QubitDevice.statistics`` is",
-            ):
-                dev.statistics([], circuit=qscript)
-            with pytest.raises(
-                ValueError, match="Please provide a circuit into the statistics method"
-            ):
-                dev.statistics()
+        dev = mock_qubit_device_extract_stats()
+        with pytest.warns(
+            UserWarning,
+            match="Using a list of observables in ``QubitDevice.statistics`` is",
+        ):
+            dev.statistics([])
+        with pytest.warns(
+            UserWarning,
+            match="Using a list of observables in ``QubitDevice.statistics`` is",
+        ):
+            dev.statistics(observables=[])
+
+    def test_observables_kwarg_deprecated(self, mock_qubit_device_extract_stats, monkeypatch):
+        """Test that using observables instead of circuit is deprecated."""
+        dev = mock_qubit_device_extract_stats()
+        with pytest.warns(
+            UserWarning,
+            match="The ``observables`` argument in ``QubitDevice.statistics`` is deprecated. ",
+        ):
+            dev.statistics(observables=[])
+        qscript = QuantumScript()
+        with pytest.warns(
+            UserWarning,
+            match="The ``observables`` argument in ``QubitDevice.statistics`` is deprecated. ",
+        ):
+            dev.statistics([], observables=qscript)
+
+    def test_no_observables_or_circuit_raises_error(
+        self, mock_qubit_device_extract_stats, monkeypatch
+    ):
+        dev = mock_qubit_device_extract_stats()
+        with pytest.raises(ValueError, match="Please provide a circuit into the statistics method"):
+            dev.statistics()
 
     @pytest.mark.parametrize(
         "measurement", [ExpectationMP, VarianceMP, SampleMP, ProbabilityMP, StateMP]


### PR DESCRIPTION
User warning warns not to pass a list to `dev.statistics`, but instead to pass a `QuantumTape`.

Deprecations document warns users not to use the `observables` kwarg, but instead to use `circuit`.

This PR updates the user warning to also warn about the deprecation of the `observables` kwarg, and the `deprecations.rst` file to also mention deprecation of passing a list instead of a tape.