### PR TITLE
Remove `MeasurementProcess._permute_wires` method.

### DIFF
--- a/pennylane/measurements/expval.py
+++ b/pennylane/measurements/expval.py
@@ -129,12 +129,8 @@ class ExpectationMP(SampleMeasurement, StateMeasurement):
             return probs[idx]
         eigvals = qml.math.asarray(self.obs.eigvals(), dtype="float64")
 
-        # the probability vector must be permuted to account for the permuted
-        # wire order of the observable
-        permuted_wires = self._permute_wires(wire_order)
-
         # we use ``self.wires`` instead of ``self.obs`` because the observable was
         # already applied to the state
-        prob = qml.probs(wires=permuted_wires).process_state(state=state, wire_order=wire_order)
+        prob = qml.probs(wires=self.wires).process_state(state=state, wire_order=wire_order)
         # In case of broadcasting, `prob` has two axes and this is a matrix-vector product
         return qml.math.dot(prob, eigvals)

--- a/pennylane/measurements/expval.py
+++ b/pennylane/measurements/expval.py
@@ -131,7 +131,7 @@ class ExpectationMP(SampleMeasurement, StateMeasurement):
 
         # the probability vector must be permuted to account for the permuted
         # wire order of the observable
-        permuted_wires = self._permute_wires(self.obs.wires)
+        permuted_wires = self._permute_wires(wire_order)
 
         # we use ``self.wires`` instead of ``self.obs`` because the observable was
         # already applied to the state

--- a/pennylane/measurements/measurements.py
+++ b/pennylane/measurements/measurements.py
@@ -479,55 +479,56 @@ class MeasurementProcess(ABC):
             new_measurement._wires = Wires([wire_map.get(wire, wire) for wire in self.wires])
         return new_measurement
 
-    def _permute_wires(self, wires: Wires):
-        r"""Given an observable which acts on multiple wires, permute the wires to
-          be consistent with the device wire order.
+    def _permute_wires(self, device_wire_order: Wires):
+        r"""Returns a permutation of the measurement's wires that is consistent with the given device
+        wire order.
 
-          Suppose we are given an observable :math:`\hat{O} = \Identity \otimes \Identity \otimes \hat{Z}`.
-          This observable can be represented in many ways:
-
-        .. code-block:: python
-
-              O_1 = qml.Identity(wires=0) @ qml.Identity(wires=1) @ qml.PauliZ(wires=2)
-              O_2 = qml.PauliZ(wires=2) @ qml.Identity(wires=0) @ qml.Identity(wires=1)
-
-          Notice that while the explicit tensor product matrix representation of :code:`O_1` and :code:`O_2` is
-          different, the underlying operator is identical due to the wire labelling (assuming the labels in
-          ascending order are {0,1,2}). If we wish to compute the expectation value of such an observable, we must
-          ensure it is identical in both cases. To facilitate this, we permute the wires in our state vector such
-          that they are consistent with this swapping of order in the tensor observable.
+        Suppose we define a measurement with an observable
+        :math:`\hat{O} = \Identity \otimes \Identity \otimes \hat{Z}`. This observable can be
+        represented in many ways:
 
         .. code-block:: python
 
-              >>> print(O_1.wires)
-              <Wires = [0, 1, 2]>
-              >>> print(O_2.wires)
-              <Wires = [2, 0, 1]>
+            O_1 = qml.Identity(wires=0) @ qml.Identity(wires=1) @ qml.PauliZ(wires=2)
+            O_2 = qml.PauliZ(wires=2) @ qml.Identity(wires=0) @ qml.Identity(wires=1)
 
-          We might naively think that we must permute our state vector to match the wire order of our tensor observable.
-          We must be careful and realize that the wire order of the terms in the tensor observable DOES NOT match the
-          permutation of the terms themselves. As an example we directly compare :code:`O_1` and :code:`O_2`:
+        Notice that while the explicit tensor product matrix representation of :code:`O_1` and :code:`O_2` is
+        different, the underlying operator is identical due to the wire labelling (assuming the labels in
+        ascending order are {0,1,2}). If we wish to compute the expectation value of such an observable, we must
+        ensure it is identical in both cases. To facilitate this, we permute the wires in our state vector such
+        that they are consistent with this swapping of order in the tensor observable.
 
-          The first term in :code:`O_1` (:code:`qml.Identity(wires=0)`) became the second term in :code:`O_2`.
-          By similar comparison we see that each term in the tensor product was shifted one position forward
-          (i.e 0 --> 1, 1 --> 2, 2 --> 0). The wires in our permuted quantum state should follow their respective
-          terms in the tensor product observable.
+        .. code-block:: python
 
-          Thus, the correct wire ordering should be :code:`permuted_wires = <Wires = [1, 2, 0]>`. But if we had
-          taken the naive approach we would have permuted our state according to
-          :code:`permuted_wires = <Wires = [2, 0, 1]>` which is NOT correct.
+            >>> print(O_1.wires)
+            <Wires = [0, 1, 2]>
+            >>> print(O_2.wires)
+            <Wires = [2, 0, 1]>
 
-          This function uses the observable wires and the global device wire ordering in order to determine the
-          permutation of the wires in the observable required such that if our quantum state vector is
-          permuted accordingly then the amplitudes of the state will match the matrix representation of the observable.
+        We might naively think that we must permute our state vector to match the wire order of our tensor observable.
+        We must be careful and realize that the wire order of the terms in the tensor observable DOES NOT match the
+        permutation of the terms themselves. As an example we directly compare :code:`O_1` and :code:`O_2`:
 
-          Args:
-              observable (Observable): the observable whose wires are to be permuted.
+        The first term in :code:`O_1` (:code:`qml.Identity(wires=0)`) became the second term in :code:`O_2`.
+        By similar comparison we see that each term in the tensor product was shifted one position forward
+        (i.e 0 --> 1, 1 --> 2, 2 --> 0). The wires in our permuted quantum state should follow their respective
+        terms in the tensor product observable.
 
-          Returns:
-              permuted_wires (Wires): permuted wires object
+        Thus, the correct wire ordering should be :code:`permuted_wires = <Wires = [1, 2, 0]>`. But if we had
+        taken the naive approach we would have permuted our state according to
+        :code:`permuted_wires = <Wires = [2, 0, 1]>` which is NOT correct.
+
+        This function uses the measurement's wires and the global device wire ordering in order to determine the
+        permutation of the wires in the observable required such that if our quantum state vector is
+        permuted accordingly then the amplitudes of the state will match the matrix representation of the observable.
+
+        Args:
+            device_wires_order (Wires): the wires of the device used to compute the measurement
+
+        Returns:
+            permuted_wires (Wires): the measurement's permuted wires
         """
-        wire_map = dict(zip(wires, range(len(wires))))
+        wire_map = dict(zip(device_wire_order, range(len(device_wire_order))))
         ordered_obs_wire_lst = sorted(self.wires.tolist(), key=lambda label: wire_map[label])
         mapped_wires = [wire_map[w] for w in self.wires]
         permutation = qml.math.argsort(mapped_wires)  # extract permutation via argsort

--- a/pennylane/measurements/measurements.py
+++ b/pennylane/measurements/measurements.py
@@ -479,61 +479,6 @@ class MeasurementProcess(ABC):
             new_measurement._wires = Wires([wire_map.get(wire, wire) for wire in self.wires])
         return new_measurement
 
-    def _permute_wires(self, device_wire_order: Wires):
-        r"""Returns a permutation of the measurement's wires that is consistent with the given device
-        wire order.
-
-        Suppose we define a measurement with an observable
-        :math:`\hat{O} = \Identity \otimes \Identity \otimes \hat{Z}`. This observable can be
-        represented in many ways:
-
-        .. code-block:: python
-
-            O_1 = qml.Identity(wires=0) @ qml.Identity(wires=1) @ qml.PauliZ(wires=2)
-            O_2 = qml.PauliZ(wires=2) @ qml.Identity(wires=0) @ qml.Identity(wires=1)
-
-        Notice that while the explicit tensor product matrix representation of :code:`O_1` and :code:`O_2` is
-        different, the underlying operator is identical due to the wire labelling (assuming the labels in
-        ascending order are {0,1,2}). If we wish to compute the expectation value of such an observable, we must
-        ensure it is identical in both cases. To facilitate this, we permute the wires in our state vector such
-        that they are consistent with this swapping of order in the tensor observable.
-
-        .. code-block:: python
-
-            >>> print(O_1.wires)
-            <Wires = [0, 1, 2]>
-            >>> print(O_2.wires)
-            <Wires = [2, 0, 1]>
-
-        We might naively think that we must permute our state vector to match the wire order of our tensor observable.
-        We must be careful and realize that the wire order of the terms in the tensor observable DOES NOT match the
-        permutation of the terms themselves. As an example we directly compare :code:`O_1` and :code:`O_2`:
-
-        The first term in :code:`O_1` (:code:`qml.Identity(wires=0)`) became the second term in :code:`O_2`.
-        By similar comparison we see that each term in the tensor product was shifted one position forward
-        (i.e 0 --> 1, 1 --> 2, 2 --> 0). The wires in our permuted quantum state should follow their respective
-        terms in the tensor product observable.
-
-        Thus, the correct wire ordering should be :code:`permuted_wires = <Wires = [1, 2, 0]>`. But if we had
-        taken the naive approach we would have permuted our state according to
-        :code:`permuted_wires = <Wires = [2, 0, 1]>` which is NOT correct.
-
-        This function uses the measurement's wires and the global device wire ordering in order to determine the
-        permutation of the wires in the observable required such that if our quantum state vector is
-        permuted accordingly then the amplitudes of the state will match the matrix representation of the observable.
-
-        Args:
-            device_wires_order (Wires): the wires of the device used to compute the measurement
-
-        Returns:
-            permuted_wires (Wires): the measurement's permuted wires
-        """
-        wire_map = dict(zip(device_wire_order, range(len(device_wire_order))))
-        ordered_obs_wire_lst = sorted(self.wires.tolist(), key=lambda label: wire_map[label])
-        mapped_wires = [wire_map[w] for w in self.wires]
-        permutation = qml.math.argsort(mapped_wires)  # extract permutation via argsort
-        return Wires([ordered_obs_wire_lst[index] for index in permutation])
-
 
 class SampleMeasurement(MeasurementProcess):
     """Sample-based measurement process.

--- a/pennylane/measurements/var.py
+++ b/pennylane/measurements/var.py
@@ -136,7 +136,7 @@ class VarianceMP(SampleMeasurement, StateMeasurement):
         eigvals = qml.math.asarray(self.obs.eigvals(), dtype=float)
 
         # the probability vector must be permuted to account for the permuted wire order of the observable
-        new_obs_wires = self._permute_wires(self.obs.wires)
+        new_obs_wires = self._permute_wires(wire_order)
         # we use ``wires`` instead of ``op`` because the observable was
         # already applied to the state
         prob = qml.probs(wires=new_obs_wires).process_state(state=state, wire_order=wire_order)

--- a/pennylane/measurements/var.py
+++ b/pennylane/measurements/var.py
@@ -135,10 +135,8 @@ class VarianceMP(SampleMeasurement, StateMeasurement):
 
         eigvals = qml.math.asarray(self.obs.eigvals(), dtype=float)
 
-        # the probability vector must be permuted to account for the permuted wire order of the observable
-        new_obs_wires = self._permute_wires(wire_order)
         # we use ``wires`` instead of ``op`` because the observable was
         # already applied to the state
-        prob = qml.probs(wires=new_obs_wires).process_state(state=state, wire_order=wire_order)
+        prob = qml.probs(wires=self.wires).process_state(state=state, wire_order=wire_order)
         # In case of broadcasting, `prob` has two axes and these are a matrix-vector products
         return qml.math.dot(prob, (eigvals**2)) - qml.math.dot(prob, eigvals) ** 2

--- a/tests/measurements/test_expval.py
+++ b/tests/measurements/test_expval.py
@@ -42,7 +42,7 @@ def custom_measurement_process(device, spy):
             new_res = meas.process_samples(
                 samples=samples, wire_order=device.wires, shot_range=shot_range, bin_size=bin_size
             )
-        assert qml.math.allequal(old_res, new_res)
+        assert qml.math.allclose(old_res, new_res)
 
 
 class TestExpval:
@@ -161,3 +161,28 @@ class TestExpval:
         assert np.allclose(res, expected, atol=0.02, rtol=0.02)
 
         custom_measurement_process(new_dev, spy)
+
+    def test_permuted_wires(self, mocker):
+        """Test that the expectation value of an operator with permuted wires is the same."""
+        obs = qml.prod(qml.PauliZ(8), qml.s_prod(2, qml.PauliZ(10)), qml.s_prod(3, qml.PauliZ("h")))
+        obs_2 = qml.prod(
+            qml.s_prod(3, qml.PauliZ("h")), qml.PauliZ(8), qml.s_prod(2, qml.PauliZ(10))
+        )
+
+        dev = qml.device("default.qubit", wires=["h", 8, 10])
+        spy = mocker.spy(qml.QubitDevice, "expval")
+
+        @qml.qnode(dev)
+        def circuit():
+            qml.RX(1.23, wires=["h"])
+            qml.RY(2.34, wires=[8])
+            return qml.expval(obs)
+
+        @qml.qnode(dev)
+        def circuit2():
+            qml.RX(1.23, wires=["h"])
+            qml.RY(2.34, wires=[8])
+            return qml.expval(obs_2)
+
+        assert circuit() == circuit2()
+        custom_measurement_process(dev, spy)

--- a/tests/measurements/test_var.py
+++ b/tests/measurements/test_var.py
@@ -40,7 +40,7 @@ def custom_measurement_process(device, spy):
             )
         else:
             new_res = meas.process_state(state=state, wire_order=device.wires)
-        assert qml.math.allequal(old_res, new_res)
+        assert qml.math.allclose(old_res, new_res)
 
 
 class TestVar:
@@ -148,4 +148,29 @@ class TestVar:
 
         assert np.allclose(res, expected, atol=0.02, rtol=0.02)
 
+        custom_measurement_process(dev, spy)
+
+    def test_permuted_wires(self, mocker):
+        """Test that the expectation value of an operator with permuted wires is the same."""
+        obs = qml.prod(qml.PauliZ(8), qml.s_prod(2, qml.PauliZ(10)), qml.s_prod(3, qml.PauliZ("h")))
+        obs_2 = qml.prod(
+            qml.s_prod(3, qml.PauliZ("h")), qml.PauliZ(8), qml.s_prod(2, qml.PauliZ(10))
+        )
+
+        dev = qml.device("default.qubit", wires=["h", 8, 10])
+        spy = mocker.spy(qml.QubitDevice, "var")
+
+        @qml.qnode(dev)
+        def circuit():
+            qml.RX(1.23, wires=["h"])
+            qml.RY(2.34, wires=[8])
+            return qml.var(obs)
+
+        @qml.qnode(dev)
+        def circuit2():
+            qml.RX(1.23, wires=["h"])
+            qml.RY(2.34, wires=[8])
+            return qml.var(obs_2)
+
+        assert circuit() == circuit2()
         custom_measurement_process(dev, spy)

--- a/tests/measurements/test_var.py
+++ b/tests/measurements/test_var.py
@@ -151,7 +151,7 @@ class TestVar:
         custom_measurement_process(dev, spy)
 
     def test_permuted_wires(self, mocker):
-        """Test that the expectation value of an operator with permuted wires is the same."""
+        """Test that the variance of an operator with permuted wires is the same."""
         obs = qml.prod(qml.PauliZ(8), qml.s_prod(2, qml.PauliZ(10)), qml.s_prod(3, qml.PauliZ("h")))
         obs_2 = qml.prod(
             qml.s_prod(3, qml.PauliZ("h")), qml.PauliZ(8), qml.s_prod(2, qml.PauliZ(10))


### PR DESCRIPTION
- Remove useless usage of `_permute_wires` (`qml.probs` already does permutation).
- Remove `_permute_wires` from `MP`.