### PR TITLE
Update `upload.yml` to use same version of Torch as tests

### DIFF
--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -5,7 +5,7 @@ on:
 
 env:
   TF_VERSION: 2.10.0
-  TORCH_VERSION: 1.11.0+cpu
+  TORCH_VERSION: 1.13.0
 
 
 jobs:


### PR DESCRIPTION
**Context:**
Upload action failed to trigger for 0.28 release of PL due to another inconsistency between the .yml action files. Here we unify torch version between test and upload yml actions.

