### PR TITLE
Make Pauli Word pickleable

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -127,6 +127,7 @@
 <h3>Bug fixes</h3>
 
 * `qml.pauli.PauliWord` is now pickle-able.
+  [(#3588)](https://github.com/PennyLaneAI/pennylane/pull/3588)
 
 * Child classes of `QuantumScript` now return their own type when using `SomeChildClass.from_queue`.
   [(#3501)](https://github.com/PennyLaneAI/pennylane/pull/3501)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -126,6 +126,8 @@
 
 <h3>Bug fixes</h3>
 
+* `qml.pauli.PauliWord` is now pickle-able.
+
 * Child classes of `QuantumScript` now return their own type when using `SomeChildClass.from_queue`.
   [(#3501)](https://github.com/PennyLaneAI/pennylane/pull/3501)
 
@@ -141,6 +143,7 @@ Utkarsh Azad
 Astral Cai
 Lillian M. A. Frederiksen
 Soran Jahangiri
+Christina Lee
 Albert Mitjans Coma
 Romain Moyard
 Matthew Silverman

--- a/pennylane/pauli/pauli_arithmetic.py
+++ b/pennylane/pauli/pauli_arithmetic.py
@@ -117,11 +117,10 @@ class PauliWord(dict):
         super().__init__(mapping)
 
     def __reduce__(self):
-        """Defining this method allows PauliWord to be pickle-able. Otherwise, un-pickling
+        """Defines how to pickle and unpickle a PauliWord. Otherwise, un-pickling
         would cause __setitem__ to be called, which is forbidden on PauliWord.
-
+        
         For more information, see: https://docs.python.org/3/library/pickle.html#object.__reduce__
-
         """
         return (PauliWord, (dict(self),))
 

--- a/pennylane/pauli/pauli_arithmetic.py
+++ b/pennylane/pauli/pauli_arithmetic.py
@@ -119,7 +119,6 @@ class PauliWord(dict):
     def __reduce__(self):
         """Defines how to pickle and unpickle a PauliWord. Otherwise, un-pickling
         would cause __setitem__ to be called, which is forbidden on PauliWord.
-        
         For more information, see: https://docs.python.org/3/library/pickle.html#object.__reduce__
         """
         return (PauliWord, (dict(self),))

--- a/pennylane/pauli/pauli_arithmetic.py
+++ b/pennylane/pauli/pauli_arithmetic.py
@@ -116,6 +116,15 @@ class PauliWord(dict):
                 del mapping[wire]
         super().__init__(mapping)
 
+    def __reduce__(self):
+        """Defining this method allows PauliWord to be pickle-able. Otherwise, un-pickling
+        would cause __setitem__ to be called, which is forbidden on PauliWord.
+
+        For more information, see: https://docs.python.org/3/library/pickle.html#object.__reduce__
+
+        """
+        return (PauliWord, (dict(self),))
+
     def __copy__(self):
         """Copy the PauliWord instance."""
         return PauliWord(dict(self.items()))

--- a/tests/pauli/test_pauli_arithmetic.py
+++ b/tests/pauli/test_pauli_arithmetic.py
@@ -543,7 +543,7 @@ class TestPauliSentence:
             ps5.hamiltonian()
 
     def test_pickling(self):
-        """Check that pauliwords can be pickled and unpickled."""
+        """Check that paulisentences can be pickled and unpickled."""
         pw1 = PauliWord({2: "X", 3: "Y", 4: "Z"})
         pw2 = PauliWord({2: "Y", 3: "Z"})
         ps = PauliSentence({pw1: 1.5, pw2: -0.5})

--- a/tests/pauli/test_pauli_arithmetic.py
+++ b/tests/pauli/test_pauli_arithmetic.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Unit Tests for the PauliWord and PauliSentence classes"""
+import pickle
 import pytest
 from copy import copy, deepcopy
 
@@ -217,6 +218,13 @@ class TestPauliWord:
         cast to a Hamiltonian."""
         with pytest.raises(ValueError, match="Can't get the Hamiltonian for an empty PauliWord."):
             pw4.hamiltonian()
+
+    def test_pickling(self):
+        """Check that pauliwords can be pickled and unpickled."""
+        pw = PauliWord({2: "X", 3: "Y", 4: "Z"})
+        serialization = pickle.dumps(pw)
+        new_pw = pickle.loads(serialization)
+        assert pw == new_pw
 
 
 class TestPauliSentence:
@@ -533,3 +541,13 @@ class TestPauliSentence:
             ValueError, match="Can't get the Hamiltonian for an empty PauliSentence."
         ):
             ps5.hamiltonian()
+
+    def test_pickling(self):
+        """Check that pauliwords can be pickled and unpickled."""
+        pw1 = PauliWord({2: "X", 3: "Y", 4: "Z"})
+        pw2 = PauliWord({2: "Y", 3: "Z"})
+        ps = PauliSentence({pw1: 1.5, pw2: -0.5})
+
+        serialization = pickle.dumps(ps)
+        new_ps = pickle.loads(serialization)
+        assert ps == new_ps


### PR DESCRIPTION
By default, unpickling a dictionary calls `__setitem__`.

```python
import pennylane as qml
import pickle

op = qml.PauliX(0)
pic = pickle.dumps(op)
pickle.loads(pic)
```
```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In [4], line 1
----> 1 pickle.loads(pic)

File pennylane/pennylane/pauli/pauli_arithmetic.py:130, in PauliWord.__setitem__(self, key, item)
    128 def __setitem__(self, key, item):
    129     """Restrict setting items after instantiation."""
--> 130     raise TypeError("PauliWord object does not support assignment")

TypeError: PauliWord object does not support assignment
```

To avoid this, `PauliWord` will now define `__reduce__()`.  See https://docs.python.org/3/library/pickle.html#object.__reduce__ for more information.

While the documentation does warn "Although powerful, implementing `__reduce__()` directly in your classes is error prone.", I can't find a better option. While normally custom pickling can be defined through `__getstate__` and `__setstate__`, dictionaries (and thus things that inherit from a dictionary) have special logic that prevented this from working.

At least the solution uses the minimal form of `__reduce__`: a callable object and a tuple of  arguments for the callable object.

