### PR TITLE
Fix wires for PauliY and RY in the `to_zx` function

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -150,6 +150,9 @@
 
 <h3>Bug fixes</h3>
 
+* Fixed the wires for the Y decomposition in the ZX calculus transform.
+  [(#3598)](https://github.com/PennyLaneAI/pennylane/pull/3598)
+* 
 * `qml.pauli.PauliWord` is now pickle-able.
   [(#3588)](https://github.com/PennyLaneAI/pennylane/pull/3588)
 

--- a/pennylane/transforms/zx/converter.py
+++ b/pennylane/transforms/zx/converter.py
@@ -314,10 +314,10 @@ def _to_zx(tape, expand_measurements=False):
         if op.name == "RY":
             theta = op.data[0]
             decomp = [
-                qml.RX(np.pi / 2, wires=0),
-                qml.RZ(theta + np.pi, wires=0),
-                qml.RX(np.pi / 2, wires=0),
-                qml.RZ(3 * np.pi, wires=0),
+                qml.RX(np.pi / 2, wires=op.wires),
+                qml.RZ(theta + np.pi, wires=op.wires),
+                qml.RX(np.pi / 2, wires=op.wires),
+                qml.RZ(3 * np.pi, wires=op.wires),
             ]
             expanded_operations.extend(decomp)
         else:

--- a/tests/transforms/test_zx.py
+++ b/tests/transforms/test_zx.py
@@ -218,8 +218,9 @@ class TestConvertersZX:
         I = qml.math.eye(2**2)
 
         operations = [
-            qml.RZ(5 / 4 * np.pi, wires=1),
+            qml.RZ(5 / 4 * np.pi, wires=0),
             qml.RZ(3 / 4 * np.pi, wires=1),
+            qml.PauliY(wires=1),
             qml.RX(0.1, wires=0),
             qml.PauliZ(wires=0),
             qml.RZ(0.3, wires=1),

--- a/tests/transforms/test_zx.py
+++ b/tests/transforms/test_zx.py
@@ -223,6 +223,7 @@ class TestConvertersZX:
             qml.PauliY(wires=1),
             qml.RX(0.1, wires=0),
             qml.PauliZ(wires=0),
+            qml.RY(0.2, wires=1),
             qml.RZ(0.3, wires=1),
             qml.PauliX(wires=1),
             qml.CNOT(wires=[0, 1]),


### PR DESCRIPTION
**Context:**

The wires for the Y decomposition was always assumed to be 0.

**Description of the Change:**

It changes the wires to be `op.wires`