### PR TITLE
Improve efficiency of matrix calculation when operator is symmetric over wires #3565

### DIFF
--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -604,7 +604,7 @@ class Operator(abc.ABC):
         """
         canonical_matrix = self.compute_matrix(*self.parameters, **self.hyperparameters)
 
-        if wire_order is None or self.wires == Wires(wire_order):
+        if wire_order is None or self.wires == Wires(wire_order) or self.name in qml.ops.qubit.attributes.symmetric_over_all_wires:
             return canonical_matrix
 
         return expand_matrix(canonical_matrix, wires=self.wires, wire_order=wire_order)

--- a/pennylane/ops/qubit/attributes.py
+++ b/pennylane/ops/qubit/attributes.py
@@ -160,7 +160,7 @@ self_inverses = Attribute(
 """Attribute: Operations that are their own inverses."""
 
 
-symmetric_over_all_wires = Attribute(["CZ", "CCZ", "SWAP"])
+symmetric_over_all_wires = Attribute(["CZ", "CCZ", "SWAP", "IsingXX", "Identity", "ISWAP", "SISWAP","SQISW", "MultiRZ", "PauliRot", "IsingXY", "IsingYY", "IsingZZ", "PSWAP"])
 """Attribute: Operations that are the same if you exchange the order of wires.
 
 For example, ``qml.CZ(wires=[0, 1])`` has the same effect as ``qml.CZ(wires=[1,


### PR DESCRIPTION
[**Context:**](https://github.com/PennyLaneAI/pennylane/issues/3565)

**Description of the Change:**
update `qml.ops.qubit.attributes.symmetric_over_all_wires`
let `Operator.matrix`  check the attribute `qml.ops.qubit.attributes.symmetric_over_all_wires`:
    ```
def matrix(self, wire_order=None):
        canonical_matrix = self.compute_matrix(*self.parameters, **self.hyperparameters)

        if wire_order is None or wire_order == self.wires or self.name in qml.ops.qubit.attributes.symmetric_over_all_wires:
            return canonical_matrix

        return expand_matrix(canonical_matrix, wires=self.wires, wire_order=wire_order)
```
**Benefits:** speed up calculating matrix when the operator is symmetric over wires

**Possible Drawbacks:**

**Related GitHub Issues:**
