### PR TITLE
Move common methods to parent class.

### DIFF
--- a/pennylane/ops/op_math/adjoint.py
+++ b/pennylane/ops/op_math/adjoint.py
@@ -247,14 +247,6 @@ class Adjoint(SymbolicOp):
     def _check_batching(self, params):
         self.base._check_batching(params)
 
-    @property
-    def batch_size(self):
-        return self.base.batch_size
-
-    @property
-    def ndim_params(self):
-        return self.base.ndim_params
-
     def label(self, decimals=None, base_label=None, cache=None):
         base_label = self.base.label(decimals, base_label, cache=cache)
         return f"({base_label})†" if self.base.arithmetic_depth > 0 else f"{base_label}†"
@@ -286,11 +278,6 @@ class Adjoint(SymbolicOp):
     def eigvals(self):
         # Cannot define ``compute_eigvals`` because Hermitian only defines ``eigvals``
         return conj(self.base.eigvals())
-
-    # pylint: disable=arguments-renamed, invalid-overridden-method
-    @property
-    def has_diagonalizing_gates(self):
-        return self.base.has_diagonalizing_gates
 
     def diagonalizing_gates(self):
         return self.base.diagonalizing_gates()

--- a/pennylane/ops/op_math/adjoint.py
+++ b/pennylane/ops/op_math/adjoint.py
@@ -243,10 +243,6 @@ class Adjoint(SymbolicOp):
     def __repr__(self):
         return f"Adjoint({self.base})"
 
-    # pylint: disable=protected-access
-    def _check_batching(self, params):
-        self.base._check_batching(params)
-
     def label(self, decimals=None, base_label=None, cache=None):
         base_label = self.base.label(decimals, base_label, cache=cache)
         return f"({base_label})†" if self.base.arithmetic_depth > 0 else f"{base_label}†"

--- a/pennylane/ops/op_math/controlled.py
+++ b/pennylane/ops/op_math/controlled.py
@@ -438,10 +438,6 @@ class Controlled(SymbolicOp):
 
         return qmlmath.concatenate([ones, base_eigvals])
 
-    @property
-    def has_diagonalizing_gates(self):
-        return self.base.has_diagonalizing_gates
-
     def diagonalizing_gates(self):
         return self.base.diagonalizing_gates()
 

--- a/pennylane/ops/op_math/exp.py
+++ b/pennylane/ops/op_math/exp.py
@@ -290,11 +290,6 @@ class Exp(SymbolicOp, Operation):
 
         return sparse_expm(self.coeff * self.base.sparse_matrix().tocsc()).asformat(format)
 
-    # pylint: disable=arguments-renamed,invalid-overridden-method
-    @property
-    def has_diagonalizing_gates(self):
-        return self.base.has_diagonalizing_gates
-
     def diagonalizing_gates(self):
         return self.base.diagonalizing_gates()
 

--- a/pennylane/ops/op_math/pow.py
+++ b/pennylane/ops/op_math/pow.py
@@ -243,14 +243,6 @@ class Pow(SymbolicOp):
         """The exponent."""
         return self.hyperparameters["z"]
 
-    @property
-    def batch_size(self):
-        return self.base.batch_size
-
-    @property
-    def ndim_params(self):
-        return self.base.ndim_params
-
     def label(self, decimals=None, base_label=None, cache=None):
         z_string = format(self.z).translate(_superscript)
         base_label = self.base.label(decimals, base_label, cache=cache)

--- a/pennylane/ops/op_math/sprod.py
+++ b/pennylane/ops/op_math/sprod.py
@@ -181,11 +181,6 @@ class SProd(SymbolicOp):
         then the scalar product operator is hermitian."""
         return self.base.is_hermitian and not qml.math.iscomplex(self.scalar)
 
-    # pylint: disable=arguments-renamed,invalid-overridden-method
-    @property
-    def has_diagonalizing_gates(self):
-        return self.base.has_diagonalizing_gates
-
     def diagonalizing_gates(self):
         r"""Sequence of gates that diagonalize the operator in the computational basis.
 

--- a/pennylane/ops/op_math/symbolicop.py
+++ b/pennylane/ops/op_math/symbolicop.py
@@ -102,6 +102,10 @@ class SymbolicOp(Operator):
     def has_matrix(self):
         return self.base.has_matrix
 
+    # pylint: disable=protected-access
+    def _check_batching(self, params):
+        self.base._check_batching(params)
+
     # pylint: disable=arguments-renamed, invalid-overridden-method
     @property
     def has_diagonalizing_gates(self):

--- a/pennylane/ops/op_math/symbolicop.py
+++ b/pennylane/ops/op_math/symbolicop.py
@@ -102,6 +102,19 @@ class SymbolicOp(Operator):
     def has_matrix(self):
         return self.base.has_matrix
 
+    # pylint: disable=arguments-renamed, invalid-overridden-method
+    @property
+    def has_diagonalizing_gates(self):
+        return self.base.has_diagonalizing_gates
+
+    @property
+    def batch_size(self):
+        return self.base.batch_size
+
+    @property
+    def ndim_params(self):
+        return self.base.ndim_params
+
     @property
     def is_hermitian(self):
         return self.base.is_hermitian


### PR DESCRIPTION
Move duplicated methods to the parent `SymbolicOp` class