### PR TITLE
Pin networkx < 3.0

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -153,6 +153,9 @@
 
 <h3>Bug fixes</h3>
 
+* Pins networkx version <3.0 till a bug with tensorflow-jit, networkx, and qcut is resolved.
+  [(#3609)](https://github.com/PennyLaneAI/pennylane/pull/3609)
+
 * Fixed the wires for the Y decomposition in the ZX calculus transform.
   [(#3598)](https://github.com/PennyLaneAI/pennylane/pull/3598)
 * 

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,6 +1,6 @@
 numpy
 scipy
-networkx
+networkx<3.0
 retworkx
 autograd
 toml

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,6 +1,6 @@
 numpy
 scipy
-networkx<3.0
+networkx
 retworkx
 autograd
 toml

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ with open("pennylane/_version.py") as f:
 requirements = [
     "numpy<1.24",
     "scipy",
-    "networkx",
+    "networkx<3.0",
     "retworkx",
     "autograd",
     "toml",


### PR DESCRIPTION
We are currently getting errors in circuit cutting tests, see https://github.com/PennyLaneAI/pennylane/actions/runs/3872906008/jobs/6602308449

This PR attempts to fix that problem by pinning `networkx` to be less than 3.0. 