### PR TITLE
Support various channels with interfaces

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -120,6 +120,9 @@
 
 <h3>Improvements</h3>
 
+* Most channels in are now fully differentiable in all interfaces.
+  [(#3612)](https://github.com/PennyLaneAI/pennylane/pull/3612)
+
 * Extended the `qml.equal` function to compare `Prod` and `Sum` operators.
   [(#3516)](https://github.com/PennyLaneAI/pennylane/pull/3516)
 
@@ -190,3 +193,4 @@ Albert Mitjans Coma
 Romain Moyard
 Matthew Silverman
 Antal Száva
+David Wierichs

--- a/pennylane/ops/channel.py
+++ b/pennylane/ops/channel.py
@@ -616,7 +616,7 @@ class PauliError(Channel):
         interface = np.get_interface(p)
         if interface == "tensorflow" or "Y" in operators:
             if interface == "numpy":
-                p *= 1 + 0j
+                p = (1 + 0j) * p
             else:
                 p = np.cast_like(p, 1j)
 

--- a/pennylane/ops/channel.py
+++ b/pennylane/ops/channel.py
@@ -83,7 +83,9 @@ class AmplitudeDamping(Channel):
             raise ValueError("gamma must be in the interval [0,1].")
 
         K0 = np.diag([1, np.sqrt(1 - gamma + np.eps)])
-        K1 = np.sqrt(gamma + np.eps) * np.convert_like(np.cast_like(np.array([[0, 1], [0, 0]]), gamma), gamma)
+        K1 = np.sqrt(gamma + np.eps) * np.convert_like(
+            np.cast_like(np.array([[0, 1], [0, 0]]), gamma), gamma
+        )
         return [K0, K1]
 
 
@@ -167,9 +169,17 @@ class GeneralizedAmplitudeDamping(Channel):
             raise ValueError("p must be in the interval [0,1].")
 
         K0 = np.sqrt(p + np.eps) * np.diag([1, np.sqrt(1 - gamma + np.eps)])
-        K1 = np.sqrt(p + np.eps) * np.sqrt(gamma) * np.convert_like(np.cast_like(np.array([[0, 1], [0, 0]]), gamma), gamma)
+        K1 = (
+            np.sqrt(p + np.eps)
+            * np.sqrt(gamma)
+            * np.convert_like(np.cast_like(np.array([[0, 1], [0, 0]]), gamma), gamma)
+        )
         K2 = np.sqrt(1 - p + np.eps) * np.diag([np.sqrt(1 - gamma + np.eps), 1])
-        K3 = np.sqrt(1 - p + np.eps) * np.sqrt(gamma) * np.convert_like(np.cast_like(np.array([[0, 0], [1, 0]]), gamma), gamma)
+        K3 = (
+            np.sqrt(1 - p + np.eps)
+            * np.sqrt(gamma)
+            * np.convert_like(np.cast_like(np.array([[0, 0], [1, 0]]), gamma), gamma)
+        )
         return [K0, K1, K2, K3]
 
 
@@ -325,8 +335,12 @@ class DepolarizingChannel(Channel):
 
         K0 = np.sqrt(1 - p + np.eps) * np.convert_like(np.eye(2, dtype=complex), p)
         K1 = np.sqrt(p / 3 + np.eps) * np.convert_like(np.array([[0, 1], [1, 0]], dtype=complex), p)
-        K2 = np.sqrt(p / 3 + np.eps) * np.convert_like(np.array([[0, -1j], [1j, 0]], dtype=complex), p)
-        K3 = np.sqrt(p / 3 + np.eps) * np.convert_like(np.array([[1, 0], [0, -1]], dtype=complex), p)
+        K2 = np.sqrt(p / 3 + np.eps) * np.convert_like(
+            np.array([[0, -1j], [1j, 0]], dtype=complex), p
+        )
+        K3 = np.sqrt(p / 3 + np.eps) * np.convert_like(
+            np.array([[1, 0], [0, -1]], dtype=complex), p
+        )
         return [K0, K1, K2, K3]
 
 
@@ -485,10 +499,18 @@ class ResetError(Channel):
         interface = np.get_interface([p_0, p_1])
         p_0, p_1 = np.coerce([p_0, p_1], like=interface)
         K0 = np.sqrt(1 - p_0 - p_1 + np.eps) * np.convert_like(np.cast_like(np.eye(2), p_0), p_0)
-        K1 = np.sqrt(p_0 + np.eps) * np.convert_like(np.cast_like(np.array([[1, 0], [0, 0]]), p_0), p_0)
-        K2 = np.sqrt(p_0 + np.eps) * np.convert_like(np.cast_like(np.array([[0, 1], [0, 0]]), p_0), p_0)
-        K3 = np.sqrt(p_1 + np.eps) * np.convert_like(np.cast_like(np.array([[0, 0], [1, 0]]), p_0), p_0)
-        K4 = np.sqrt(p_1 + np.eps) * np.convert_like(np.cast_like(np.array([[0, 0], [0, 1]]), p_0), p_0)
+        K1 = np.sqrt(p_0 + np.eps) * np.convert_like(
+            np.cast_like(np.array([[1, 0], [0, 0]]), p_0), p_0
+        )
+        K2 = np.sqrt(p_0 + np.eps) * np.convert_like(
+            np.cast_like(np.array([[0, 1], [0, 0]]), p_0), p_0
+        )
+        K3 = np.sqrt(p_1 + np.eps) * np.convert_like(
+            np.cast_like(np.array([[0, 0], [1, 0]]), p_0), p_0
+        )
+        K4 = np.sqrt(p_1 + np.eps) * np.convert_like(
+            np.cast_like(np.array([[0, 0], [0, 1]]), p_0), p_0
+        )
 
         return [K0, K1, K2, K3, K4]
 
@@ -592,9 +614,9 @@ class PauliError(Channel):
         K0 = np.sqrt(1 - p + np.eps) * np.convert_like(np.cast_like(np.eye(2**nq), p), p)
 
         interface = np.get_interface(p)
-        if interface=="tensorflow" or "Y" in operators:
-            if interface=='numpy':
-                p *= 1+0j
+        if interface == "tensorflow" or "Y" in operators:
+            if interface == "numpy":
+                p *= 1 + 0j
             else:
                 p = np.cast_like(p, 1j)
 

--- a/pennylane/ops/channel.py
+++ b/pennylane/ops/channel.py
@@ -83,7 +83,7 @@ class AmplitudeDamping(Channel):
             raise ValueError("gamma must be in the interval [0,1].")
 
         K0 = np.diag([1, np.sqrt(1 - gamma + np.eps)])
-        K1 = np.sqrt(gamma + np.eps) * np.array([[0, 1], [0, 0]])
+        K1 = np.sqrt(gamma + np.eps) * np.convert_like(np.cast_like(np.array([[0, 1], [0, 0]]), gamma), gamma)
         return [K0, K1]
 
 
@@ -167,9 +167,9 @@ class GeneralizedAmplitudeDamping(Channel):
             raise ValueError("p must be in the interval [0,1].")
 
         K0 = np.sqrt(p + np.eps) * np.diag([1, np.sqrt(1 - gamma + np.eps)])
-        K1 = np.sqrt(p + np.eps) * np.sqrt(gamma) * np.array([[0, 1], [0, 0]])
+        K1 = np.sqrt(p + np.eps) * np.sqrt(gamma) * np.convert_like(np.cast_like(np.array([[0, 1], [0, 0]]), gamma), gamma)
         K2 = np.sqrt(1 - p + np.eps) * np.diag([np.sqrt(1 - gamma + np.eps), 1])
-        K3 = np.sqrt(1 - p + np.eps) * np.sqrt(gamma) * np.array([[0, 0], [1, 0]])
+        K3 = np.sqrt(1 - p + np.eps) * np.sqrt(gamma) * np.convert_like(np.cast_like(np.array([[0, 0], [1, 0]]), gamma), gamma)
         return [K0, K1, K2, K3]
 
 
@@ -320,10 +320,13 @@ class DepolarizingChannel(Channel):
         if not np.is_abstract(p) and not 0.0 <= p <= 1.0:
             raise ValueError("p must be in the interval [0,1]")
 
-        K0 = np.sqrt(1 - p + np.eps) * np.eye(2)
-        K1 = np.sqrt(p / 3 + np.eps) * np.array([[0, 1], [1, 0]])
-        K2 = np.sqrt(p / 3 + np.eps) * np.array([[0, -1j], [1j, 0]])
-        K3 = np.sqrt(p / 3 + np.eps) * np.array([[1, 0], [0, -1]])
+        if np.get_interface(p) == "tensorflow":
+            p = np.cast_like(p, 1j)
+
+        K0 = np.sqrt(1 - p + np.eps) * np.convert_like(np.eye(2, dtype=complex), p)
+        K1 = np.sqrt(p / 3 + np.eps) * np.convert_like(np.array([[0, 1], [1, 0]], dtype=complex), p)
+        K2 = np.sqrt(p / 3 + np.eps) * np.convert_like(np.array([[0, -1j], [1j, 0]], dtype=complex), p)
+        K3 = np.sqrt(p / 3 + np.eps) * np.convert_like(np.array([[1, 0], [0, -1]], dtype=complex), p)
         return [K0, K1, K2, K3]
 
 
@@ -386,8 +389,8 @@ class BitFlip(Channel):
         if not np.is_abstract(p) and not 0.0 <= p <= 1.0:
             raise ValueError("p must be in the interval [0,1]")
 
-        K0 = np.sqrt(1 - p + np.eps) * np.eye(2)
-        K1 = np.sqrt(p + np.eps) * np.array([[0, 1], [1, 0]])
+        K0 = np.sqrt(1 - p + np.eps) * np.convert_like(np.cast_like(np.eye(2), p), p)
+        K1 = np.sqrt(p + np.eps) * np.convert_like(np.cast_like(np.array([[0, 1], [1, 0]]), p), p)
         return [K0, K1]
 
 
@@ -479,11 +482,13 @@ class ResetError(Channel):
         if not np.is_abstract(p_0 + p_1) and not 0.0 <= p_0 + p_1 <= 1.0:
             raise ValueError("p_0 + p_1 must be in the interval [0,1]")
 
-        K0 = np.sqrt(1 - p_0 - p_1 + np.eps) * np.eye(2)
-        K1 = np.sqrt(p_0 + np.eps) * np.array([[1, 0], [0, 0]])
-        K2 = np.sqrt(p_0 + np.eps) * np.array([[0, 1], [0, 0]])
-        K3 = np.sqrt(p_1 + np.eps) * np.array([[0, 0], [1, 0]])
-        K4 = np.sqrt(p_1 + np.eps) * np.array([[0, 0], [0, 1]])
+        interface = np.get_interface([p_0, p_1])
+        p_0, p_1 = np.coerce([p_0, p_1], like=interface)
+        K0 = np.sqrt(1 - p_0 - p_1 + np.eps) * np.convert_like(np.cast_like(np.eye(2), p_0), p_0)
+        K1 = np.sqrt(p_0 + np.eps) * np.convert_like(np.cast_like(np.array([[1, 0], [0, 0]]), p_0), p_0)
+        K2 = np.sqrt(p_0 + np.eps) * np.convert_like(np.cast_like(np.array([[0, 1], [0, 0]]), p_0), p_0)
+        K3 = np.sqrt(p_1 + np.eps) * np.convert_like(np.cast_like(np.array([[0, 0], [1, 0]]), p_0), p_0)
+        K4 = np.sqrt(p_1 + np.eps) * np.convert_like(np.cast_like(np.array([[0, 0], [0, 1]]), p_0), p_0)
 
         return [K0, K1, K2, K3, K4]
 
@@ -584,16 +589,23 @@ class PauliError(Channel):
         nq = len(operators)
 
         # K0 is sqrt(1-p) * Identity
-        K0 = np.sqrt(1 - p + np.eps) * np.eye(2**nq)
+        K0 = np.sqrt(1 - p + np.eps) * np.convert_like(np.cast_like(np.eye(2**nq), p), p)
+
+        interface = np.get_interface(p)
+        if interface=="tensorflow" or "Y" in operators:
+            if interface=='numpy':
+                p *= 1+0j
+            else:
+                p = np.cast_like(p, 1j)
 
         ops = {
-            "X": np.array([[0, 1], [1, 0]]),
-            "Y": np.array([[0, -1j], [1j, 0]]),
-            "Z": np.array([[1, 0], [0, -1]]),
+            "X": np.convert_like(np.cast_like(np.array([[0, 1], [1, 0]]), p), p),
+            "Y": np.convert_like(np.cast_like(np.array([[0, -1j], [1j, 0]]), p), p),
+            "Z": np.convert_like(np.cast_like(np.array([[1, 0], [0, -1]]), p), p),
         }
 
         # K1 is composed by Kraus matrices of operators
-        K1 = np.sqrt(p + np.eps) * np.array([[1]])
+        K1 = np.sqrt(p + np.eps) * np.convert_like(np.cast_like(np.eye(1), p), p)
         for op in operators[::-1]:
             K1 = np.multi_dispatch()(np.kron)(ops[op], K1)
 
@@ -659,8 +671,8 @@ class PhaseFlip(Channel):
         if not np.is_abstract(p) and not 0.0 <= p <= 1.0:
             raise ValueError("p must be in the interval [0,1]")
 
-        K0 = np.sqrt(1 - p + np.eps) * np.eye(2)
-        K1 = np.sqrt(p + np.eps) * np.array([[1, 0], [0, -1]])
+        K0 = np.sqrt(1 - p + np.eps) * np.convert_like(np.cast_like(np.eye(2), p), p)
+        K1 = np.sqrt(p + np.eps) * np.convert_like(np.cast_like(np.diag([1, -1]), p), p)
         return [K0, K1]
 
 

--- a/tests/ops/test_channel_ops.py
+++ b/tests/ops/test_channel_ops.py
@@ -41,17 +41,18 @@ ch_list = [
 class TestChannels:
     """Tests for the quantum channels"""
 
-    @pytest.mark.parametrize("interface", 
+    @pytest.mark.parametrize(
+        "interface",
         [
             None,
             pytest.param("autograd", marks=pytest.mark.autograd),
             pytest.param("tensorflow", marks=pytest.mark.tf),
             pytest.param("jax", marks=pytest.mark.jax),
             pytest.param("torch", marks=pytest.mark.torch),
-        ]
+        ],
     )
     @pytest.mark.parametrize("op", ch_list)
-    @pytest.mark.parametrize("p", [0., 0.1, 1.])
+    @pytest.mark.parametrize("p", [0.0, 0.1, 1.0])
     @pytest.mark.parametrize("tr_args", [[100e-6, 100e-6, 20e-9], [100e-6, 120e-6, 20e-9]])
     def test_kraus_matrices_sum_identity(self, op, p, tr_args, interface, tol):
         """Test channels are trace-preserving"""
@@ -96,7 +97,7 @@ class TestAmplitudeDamping:
             channel.AmplitudeDamping(1.5, wires=0).kraus_matrices()
 
     expected_jac_fn = lambda self, gamma: [
-        qml.math.array([[0, 0], [0, -1 / (2 * qml.math.sqrt(1-gamma))]]),
+        qml.math.array([[0, 0], [0, -1 / (2 * qml.math.sqrt(1 - gamma))]]),
         qml.math.array([[0, 1 / (2 * qml.math.sqrt(gamma))], [0, 0]]),
     ]
 
@@ -137,6 +138,7 @@ class TestAmplitudeDamping:
         jac = jac_fn(gamma)
         assert qml.math.allclose(jac, self.expected_jac_fn(gamma))
 
+
 class TestGeneralizedAmplitudeDamping:
     """Tests for the quantum channel GeneralizedAmplitudeDamping"""
 
@@ -170,15 +172,18 @@ class TestGeneralizedAmplitudeDamping:
 
     expected_jac_fn = lambda self, gamma, p: (
         [
-            qml.math.sqrt(p) * qml.math.array([[0, 0], [0, -1 / (2 * qml.math.sqrt(1-gamma))]]),
+            qml.math.sqrt(p) * qml.math.array([[0, 0], [0, -1 / (2 * qml.math.sqrt(1 - gamma))]]),
             qml.math.sqrt(p) * qml.math.array([[0, 1 / (2 * qml.math.sqrt(gamma))], [0, 0]]),
-            qml.math.sqrt(1 - p) * qml.math.array([[-1 / (2 * qml.math.sqrt(1-gamma)), 0], [0, 0]]),
+            qml.math.sqrt(1 - p)
+            * qml.math.array([[-1 / (2 * qml.math.sqrt(1 - gamma)), 0], [0, 0]]),
             qml.math.sqrt(1 - p) * qml.math.array([[0, 0], [1 / (2 * qml.math.sqrt(gamma)), 0]]),
         ],
         [
-            1 / (2 * qml.math.sqrt(p)) * qml.math.array([[1, 0], [0, qml.math.sqrt(1-gamma)]]),
+            1 / (2 * qml.math.sqrt(p)) * qml.math.array([[1, 0], [0, qml.math.sqrt(1 - gamma)]]),
             1 / (2 * qml.math.sqrt(p)) * qml.math.array([[0, qml.math.sqrt(gamma)], [0, 0]]),
-            -1 / (2 * qml.math.sqrt(1 - p)) * qml.math.array([[qml.math.sqrt(1-gamma), 0], [0, 1]]),
+            -1
+            / (2 * qml.math.sqrt(1 - p))
+            * qml.math.array([[qml.math.sqrt(1 - gamma), 0], [0, 1]]),
             -1 / (2 * qml.math.sqrt(1 - p)) * qml.math.array([[0, 0], [qml.math.sqrt(gamma), 0]]),
         ],
     )
@@ -187,7 +192,9 @@ class TestGeneralizedAmplitudeDamping:
     def test_kraus_jac_autograd(self):
         gamma = pnp.array(0.43, requires_grad=True)
         p = pnp.array(0.3, requires_grad=True)
-        fn = lambda gamma, p: qml.math.stack(channel.GeneralizedAmplitudeDamping(gamma, p, wires=0).kraus_matrices())
+        fn = lambda gamma, p: qml.math.stack(
+            channel.GeneralizedAmplitudeDamping(gamma, p, wires=0).kraus_matrices()
+        )
         jac_fn = qml.jacobian(fn)
         jac = jac_fn(gamma, p)
         assert qml.math.allclose(jac, self.expected_jac_fn(gamma, p))
@@ -198,7 +205,9 @@ class TestGeneralizedAmplitudeDamping:
 
         gamma = torch.tensor(0.43, requires_grad=True)
         p = torch.tensor(0.3, requires_grad=True)
-        fn = lambda gamma, p: qml.math.stack(channel.GeneralizedAmplitudeDamping(gamma, p, wires=0).kraus_matrices())
+        fn = lambda gamma, p: qml.math.stack(
+            channel.GeneralizedAmplitudeDamping(gamma, p, wires=0).kraus_matrices()
+        )
         jac = torch.autograd.functional.jacobian(fn, (gamma, p))
         exp_jac = self.expected_jac_fn(gamma.detach().numpy(), p.detach().numpy())
         assert len(jac) == len(exp_jac) == 2
@@ -212,7 +221,9 @@ class TestGeneralizedAmplitudeDamping:
         gamma = tf.Variable(0.43)
         p = tf.Variable(0.3)
         with tf.GradientTape() as tape:
-            out = qml.math.stack(channel.GeneralizedAmplitudeDamping(gamma, p, wires=0).kraus_matrices())
+            out = qml.math.stack(
+                channel.GeneralizedAmplitudeDamping(gamma, p, wires=0).kraus_matrices()
+            )
         jac = tape.jacobian(out, (gamma, p))
         assert qml.math.allclose(jac, self.expected_jac_fn(gamma, p))
 
@@ -222,7 +233,9 @@ class TestGeneralizedAmplitudeDamping:
 
         gamma = jax.numpy.array(0.43)
         p = jax.numpy.array(0.3)
-        fn = lambda gamma, p: qml.math.stack(channel.GeneralizedAmplitudeDamping(gamma, p, wires=0).kraus_matrices())
+        fn = lambda gamma, p: qml.math.stack(
+            channel.GeneralizedAmplitudeDamping(gamma, p, wires=0).kraus_matrices()
+        )
         jac_fn = jax.jacobian(fn, argnums=[0, 1])
         jac = jac_fn(gamma, p)
         assert qml.math.allclose(jac, self.expected_jac_fn(gamma, p))
@@ -251,7 +264,7 @@ class TestPhaseDamping:
             channel.PhaseDamping(1.5, wires=0).kraus_matrices()
 
     expected_jac_fn = lambda self, gamma: [
-        qml.math.array([[0, 0], [0, -1 / (2 * qml.math.sqrt(1-gamma))]]),
+        qml.math.array([[0, 0], [0, -1 / (2 * qml.math.sqrt(1 - gamma))]]),
         qml.math.array([[0, 0], [0, 1 / (2 * qml.math.sqrt(gamma))]]),
     ]
 
@@ -293,7 +306,6 @@ class TestPhaseDamping:
         assert qml.math.allclose(jac, self.expected_jac_fn(gamma))
 
 
-
 class TestBitFlip:
     """Tests for the quantum channel BitFlipChannel"""
 
@@ -331,7 +343,7 @@ class TestBitFlip:
             channel.BitFlip(1.5, wires=0).kraus_matrices()
 
     expected_jac_fn = lambda self, p: [
-        -1 / (2 * qml.math.sqrt(1-p)) * qml.math.eye(2),
+        -1 / (2 * qml.math.sqrt(1 - p)) * qml.math.eye(2),
         1 / (2 * qml.math.sqrt(p)) * qml.math.array([[0, 1], [1, 0]]),
     ]
 
@@ -410,7 +422,7 @@ class TestPhaseFlip:
             channel.PhaseFlip(1.5, wires=0).kraus_matrices()
 
     expected_jac_fn = lambda self, p: [
-        -1 / (2 * qml.math.sqrt(1-p)) * qml.math.eye(2),
+        -1 / (2 * qml.math.sqrt(1 - p)) * qml.math.eye(2),
         1 / (2 * qml.math.sqrt(p)) * qml.math.diag([1, -1]),
     ]
 
@@ -491,7 +503,7 @@ class TestDepolarizingChannel:
             qml.DepolarizingChannel(1.5, wires=0).kraus_matrices()
 
     expected_jac_fn = lambda self, p: [
-        -1 / (2 * qml.math.sqrt(1-p)) * qml.math.eye(2),
+        -1 / (2 * qml.math.sqrt(1 - p)) * qml.math.eye(2),
         1 / (6 * qml.math.sqrt(p / 3)) * qml.math.array([[0, 1], [1, 0]]),
         1 / (6 * qml.math.sqrt(p / 3)) * qml.math.array([[0, -1j], [1j, 0]]),
         1 / (6 * qml.math.sqrt(p / 3)) * qml.math.diag([1, -1]),
@@ -500,8 +512,12 @@ class TestDepolarizingChannel:
     @pytest.mark.autograd
     def test_kraus_jac_autograd(self):
         p = pnp.array(0.43, requires_grad=True)
-        fn_real = lambda x: qml.math.real(qml.math.stack(channel.DepolarizingChannel(x, wires=0).kraus_matrices()))
-        fn_imag = lambda x: qml.math.imag(qml.math.stack(channel.DepolarizingChannel(x, wires=0).kraus_matrices()))
+        fn_real = lambda x: qml.math.real(
+            qml.math.stack(channel.DepolarizingChannel(x, wires=0).kraus_matrices())
+        )
+        fn_imag = lambda x: qml.math.imag(
+            qml.math.stack(channel.DepolarizingChannel(x, wires=0).kraus_matrices())
+        )
         jac_fn_real = qml.jacobian(fn_real)
         jac_fn_imag = qml.jacobian(fn_imag)
         jac = jac_fn_real(p) + 1j * jac_fn_imag(p)
@@ -512,11 +528,15 @@ class TestDepolarizingChannel:
         import torch
 
         p = torch.tensor(0.43, requires_grad=True)
-        fn_real = lambda x: qml.math.real(qml.math.stack(channel.DepolarizingChannel(x, wires=0).kraus_matrices()))
-        fn_imag = lambda x: qml.math.imag(qml.math.stack(channel.DepolarizingChannel(x, wires=0).kraus_matrices()))
+        fn_real = lambda x: qml.math.real(
+            qml.math.stack(channel.DepolarizingChannel(x, wires=0).kraus_matrices())
+        )
+        fn_imag = lambda x: qml.math.imag(
+            qml.math.stack(channel.DepolarizingChannel(x, wires=0).kraus_matrices())
+        )
         jac_real = torch.autograd.functional.jacobian(fn_real, p).detach().numpy()
         jac_imag = torch.autograd.functional.jacobian(fn_imag, p).detach().numpy()
-        assert qml.math.allclose(jac_real+1j*jac_imag, self.expected_jac_fn(p.detach().numpy()))
+        assert qml.math.allclose(jac_real + 1j * jac_imag, self.expected_jac_fn(p.detach().numpy()))
 
     @pytest.mark.tf
     def test_kraus_jac_tf(self):
@@ -770,11 +790,11 @@ class TestPauliError:
 
     expected_jac_fn = {
         "X": lambda p: [
-            -1 / (2 * qml.math.sqrt(1-p)) * qml.math.eye(2),
+            -1 / (2 * qml.math.sqrt(1 - p)) * qml.math.eye(2),
             1 / (2 * qml.math.sqrt(p)) * qml.math.array([[0, 1], [1, 0]]),
         ],
         "XY": lambda p: [
-            -1 / (2 * qml.math.sqrt(1-p)) * qml.math.eye(4),
+            -1 / (2 * qml.math.sqrt(1 - p)) * qml.math.eye(4),
             1 / (2 * qml.math.sqrt(p)) * (qml.math.diag([1j, -1j, 1j, -1j])[::-1]),
         ],
     }
@@ -784,8 +804,12 @@ class TestPauliError:
     def test_kraus_jac_autograd(self, ops):
         p = pnp.array(0.43, requires_grad=True)
         wires = list(range(len(ops)))
-        fn_real = lambda x: qml.math.real(qml.math.stack(channel.PauliError(ops, x, wires=wires).kraus_matrices()))
-        fn_imag = lambda x: qml.math.imag(qml.math.stack(channel.PauliError(ops, x, wires=wires).kraus_matrices()))
+        fn_real = lambda x: qml.math.real(
+            qml.math.stack(channel.PauliError(ops, x, wires=wires).kraus_matrices())
+        )
+        fn_imag = lambda x: qml.math.imag(
+            qml.math.stack(channel.PauliError(ops, x, wires=wires).kraus_matrices())
+        )
         jac_fn_real = qml.jacobian(fn_real)
         jac_fn_imag = qml.jacobian(fn_imag)
         jac = jac_fn_real(p) + 1j * jac_fn_imag(p)
@@ -798,11 +822,17 @@ class TestPauliError:
 
         p = torch.tensor(0.43, requires_grad=True)
         wires = list(range(len(ops)))
-        fn_real = lambda x: qml.math.real(qml.math.stack(channel.PauliError(ops, x, wires=wires).kraus_matrices()))
-        fn_imag = lambda x: qml.math.imag(qml.math.stack(channel.PauliError(ops, x, wires=wires).kraus_matrices()))
+        fn_real = lambda x: qml.math.real(
+            qml.math.stack(channel.PauliError(ops, x, wires=wires).kraus_matrices())
+        )
+        fn_imag = lambda x: qml.math.imag(
+            qml.math.stack(channel.PauliError(ops, x, wires=wires).kraus_matrices())
+        )
         jac_real = torch.autograd.functional.jacobian(fn_real, p).detach().numpy()
         jac_imag = torch.autograd.functional.jacobian(fn_imag, p).detach().numpy()
-        assert qml.math.allclose(jac_real+1j*jac_imag, self.expected_jac_fn[ops](p.detach().numpy()))
+        assert qml.math.allclose(
+            jac_real + 1j * jac_imag, self.expected_jac_fn[ops](p.detach().numpy())
+        )
 
     @pytest.mark.parametrize("ops", ["X", "XY"])
     @pytest.mark.tf

--- a/tests/ops/test_channel_ops.py
+++ b/tests/ops/test_channel_ops.py
@@ -41,26 +41,36 @@ ch_list = [
 class TestChannels:
     """Tests for the quantum channels"""
 
-    @pytest.mark.parametrize("ops", ch_list)
-    @pytest.mark.parametrize("p", [0, 0.1, 1])
+    @pytest.mark.parametrize("interface", 
+        [
+            None,
+            pytest.param("autograd", marks=pytest.mark.autograd),
+            pytest.param("tensorflow", marks=pytest.mark.tf),
+            pytest.param("jax", marks=pytest.mark.jax),
+            pytest.param("torch", marks=pytest.mark.torch),
+        ]
+    )
+    @pytest.mark.parametrize("op", ch_list)
+    @pytest.mark.parametrize("p", [0., 0.1, 1.])
     @pytest.mark.parametrize("tr_args", [[100e-6, 100e-6, 20e-9], [100e-6, 120e-6, 20e-9]])
-    def test_kraus_matrices_sum_identity(self, ops, p, tr_args, tol):
+    def test_kraus_matrices_sum_identity(self, op, p, tr_args, interface, tol):
         """Test channels are trace-preserving"""
-        if ops.__name__ == "GeneralizedAmplitudeDamping":
-            op = [ops(p, p, wires=0)]
-        elif ops.__name__ == "ResetError":
-            op = [ops(p / 2, p / 3, wires=0)]
-        elif ops.__name__ == "PauliError":
-            op = [ops("X", p, wires=0), ops("XX", p, wires=[0, 1])]
-        elif ops.__name__ == "ThermalRelaxationError":
-            op = [ops(p, *tr_args, wires=0)]
+        p = qml.math.array(p, like=interface)
+        if op.__name__ == "GeneralizedAmplitudeDamping":
+            ops = [op(p, p, wires=0)]
+        elif op.__name__ == "ResetError":
+            ops = [op(p / 2, p / 3, wires=0)]
+        elif op.__name__ == "PauliError":
+            ops = [op("X", p, wires=0), op("XX", p, wires=[0, 1])]
+        elif op.__name__ == "ThermalRelaxationError":
+            ops = [op(p, *tr_args, wires=0)]
         else:
-            op = [ops(p, wires=0)]
-        for operation in op:
+            ops = [op(p, wires=0)]
+        for operation in ops:
             K_list = operation.kraus_matrices()
-            K_arr = np.array(K_list)
-            Kraus_sum = np.einsum("ajk,ajl->kl", K_arr.conj(), K_arr)
-            assert np.allclose(Kraus_sum, np.eye(K_list[0].shape[0]), atol=tol, rtol=0)
+            K_arr = qml.math.stack(K_list)
+            Kraus_sum = qml.math.einsum("ajk,ajl->kl", qml.math.conj(K_arr), K_arr)
+            assert qml.math.allclose(Kraus_sum, np.eye(K_list[0].shape[0]), atol=tol, rtol=0)
 
 
 class TestAmplitudeDamping:
@@ -85,6 +95,47 @@ class TestAmplitudeDamping:
         with pytest.raises(ValueError, match="gamma must be in the interval"):
             channel.AmplitudeDamping(1.5, wires=0).kraus_matrices()
 
+    expected_jac_fn = lambda self, gamma: [
+        qml.math.array([[0, 0], [0, -1 / (2 * qml.math.sqrt(1-gamma))]]),
+        qml.math.array([[0, 1 / (2 * qml.math.sqrt(gamma))], [0, 0]]),
+    ]
+
+    @pytest.mark.autograd
+    def test_kraus_jac_autograd(self):
+        gamma = pnp.array(0.43, requires_grad=True)
+        fn = lambda x: qml.math.stack(channel.AmplitudeDamping(x, wires=0).kraus_matrices())
+        jac_fn = qml.jacobian(fn)
+        jac = jac_fn(gamma)
+        assert qml.math.allclose(jac, self.expected_jac_fn(gamma))
+
+    @pytest.mark.torch
+    def test_kraus_jac_torch(self):
+        import torch
+
+        gamma = torch.tensor(0.43, requires_grad=True)
+        fn = lambda x: qml.math.stack(channel.AmplitudeDamping(x, wires=0).kraus_matrices())
+        jac = torch.autograd.functional.jacobian(fn, gamma)
+        assert qml.math.allclose(jac.detach().numpy(), self.expected_jac_fn(gamma.detach().numpy()))
+
+    @pytest.mark.tf
+    def test_kraus_jac_tf(self):
+        import tensorflow as tf
+
+        gamma = tf.Variable(0.43)
+        with tf.GradientTape() as tape:
+            out = qml.math.stack(channel.AmplitudeDamping(gamma, wires=0).kraus_matrices())
+        jac = tape.jacobian(out, gamma)
+        assert qml.math.allclose(jac, self.expected_jac_fn(gamma))
+
+    @pytest.mark.jax
+    def test_kraus_jac_jax(self):
+        import jax
+
+        gamma = jax.numpy.array(0.43)
+        fn = lambda x: qml.math.stack(channel.AmplitudeDamping(x, wires=0).kraus_matrices())
+        jac_fn = jax.jacobian(fn)
+        jac = jac_fn(gamma)
+        assert qml.math.allclose(jac, self.expected_jac_fn(gamma))
 
 class TestGeneralizedAmplitudeDamping:
     """Tests for the quantum channel GeneralizedAmplitudeDamping"""
@@ -117,6 +168,65 @@ class TestGeneralizedAmplitudeDamping:
         with pytest.raises(ValueError, match="p must be in the interval"):
             channel.GeneralizedAmplitudeDamping(0.0, 1.5, wires=0).kraus_matrices()
 
+    expected_jac_fn = lambda self, gamma, p: (
+        [
+            qml.math.sqrt(p) * qml.math.array([[0, 0], [0, -1 / (2 * qml.math.sqrt(1-gamma))]]),
+            qml.math.sqrt(p) * qml.math.array([[0, 1 / (2 * qml.math.sqrt(gamma))], [0, 0]]),
+            qml.math.sqrt(1 - p) * qml.math.array([[-1 / (2 * qml.math.sqrt(1-gamma)), 0], [0, 0]]),
+            qml.math.sqrt(1 - p) * qml.math.array([[0, 0], [1 / (2 * qml.math.sqrt(gamma)), 0]]),
+        ],
+        [
+            1 / (2 * qml.math.sqrt(p)) * qml.math.array([[1, 0], [0, qml.math.sqrt(1-gamma)]]),
+            1 / (2 * qml.math.sqrt(p)) * qml.math.array([[0, qml.math.sqrt(gamma)], [0, 0]]),
+            -1 / (2 * qml.math.sqrt(1 - p)) * qml.math.array([[qml.math.sqrt(1-gamma), 0], [0, 1]]),
+            -1 / (2 * qml.math.sqrt(1 - p)) * qml.math.array([[0, 0], [qml.math.sqrt(gamma), 0]]),
+        ],
+    )
+
+    @pytest.mark.autograd
+    def test_kraus_jac_autograd(self):
+        gamma = pnp.array(0.43, requires_grad=True)
+        p = pnp.array(0.3, requires_grad=True)
+        fn = lambda gamma, p: qml.math.stack(channel.GeneralizedAmplitudeDamping(gamma, p, wires=0).kraus_matrices())
+        jac_fn = qml.jacobian(fn)
+        jac = jac_fn(gamma, p)
+        assert qml.math.allclose(jac, self.expected_jac_fn(gamma, p))
+
+    @pytest.mark.torch
+    def test_kraus_jac_torch(self):
+        import torch
+
+        gamma = torch.tensor(0.43, requires_grad=True)
+        p = torch.tensor(0.3, requires_grad=True)
+        fn = lambda gamma, p: qml.math.stack(channel.GeneralizedAmplitudeDamping(gamma, p, wires=0).kraus_matrices())
+        jac = torch.autograd.functional.jacobian(fn, (gamma, p))
+        exp_jac = self.expected_jac_fn(gamma.detach().numpy(), p.detach().numpy())
+        assert len(jac) == len(exp_jac) == 2
+        for j, exp_j in zip(jac, exp_jac):
+            assert qml.math.allclose(j.detach().numpy(), exp_j)
+
+    @pytest.mark.tf
+    def test_kraus_jac_tf(self):
+        import tensorflow as tf
+
+        gamma = tf.Variable(0.43)
+        p = tf.Variable(0.3)
+        with tf.GradientTape() as tape:
+            out = qml.math.stack(channel.GeneralizedAmplitudeDamping(gamma, p, wires=0).kraus_matrices())
+        jac = tape.jacobian(out, (gamma, p))
+        assert qml.math.allclose(jac, self.expected_jac_fn(gamma, p))
+
+    @pytest.mark.jax
+    def test_kraus_jac_jax(self):
+        import jax
+
+        gamma = jax.numpy.array(0.43)
+        p = jax.numpy.array(0.3)
+        fn = lambda gamma, p: qml.math.stack(channel.GeneralizedAmplitudeDamping(gamma, p, wires=0).kraus_matrices())
+        jac_fn = jax.jacobian(fn, argnums=[0, 1])
+        jac = jac_fn(gamma, p)
+        assert qml.math.allclose(jac, self.expected_jac_fn(gamma, p))
+
 
 class TestPhaseDamping:
     """Tests for the quantum channel PhaseDamping"""
@@ -139,6 +249,49 @@ class TestPhaseDamping:
     def test_gamma_invalid_parameter(self):
         with pytest.raises(ValueError, match="gamma must be in the interval"):
             channel.PhaseDamping(1.5, wires=0).kraus_matrices()
+
+    expected_jac_fn = lambda self, gamma: [
+        qml.math.array([[0, 0], [0, -1 / (2 * qml.math.sqrt(1-gamma))]]),
+        qml.math.array([[0, 0], [0, 1 / (2 * qml.math.sqrt(gamma))]]),
+    ]
+
+    @pytest.mark.autograd
+    def test_kraus_jac_autograd(self):
+        gamma = pnp.array(0.43, requires_grad=True)
+        fn = lambda x: qml.math.stack(channel.PhaseDamping(x, wires=0).kraus_matrices())
+        jac_fn = qml.jacobian(fn)
+        jac = jac_fn(gamma)
+        assert qml.math.allclose(jac, self.expected_jac_fn(gamma))
+
+    @pytest.mark.torch
+    def test_kraus_jac_torch(self):
+        import torch
+
+        gamma = torch.tensor(0.43, requires_grad=True)
+        fn = lambda x: qml.math.stack(channel.PhaseDamping(x, wires=0).kraus_matrices())
+        jac = torch.autograd.functional.jacobian(fn, gamma)
+        assert qml.math.allclose(jac.detach().numpy(), self.expected_jac_fn(gamma.detach().numpy()))
+
+    @pytest.mark.tf
+    def test_kraus_jac_tf(self):
+        import tensorflow as tf
+
+        gamma = tf.Variable(0.43)
+        with tf.GradientTape() as tape:
+            out = qml.math.stack(channel.PhaseDamping(gamma, wires=0).kraus_matrices())
+        jac = tape.jacobian(out, gamma)
+        assert qml.math.allclose(jac, self.expected_jac_fn(gamma))
+
+    @pytest.mark.jax
+    def test_kraus_jac_jax(self):
+        import jax
+
+        gamma = jax.numpy.array(0.43)
+        fn = lambda x: qml.math.stack(channel.PhaseDamping(x, wires=0).kraus_matrices())
+        jac_fn = jax.jacobian(fn)
+        jac = jac_fn(gamma)
+        assert qml.math.allclose(jac, self.expected_jac_fn(gamma))
+
 
 
 class TestBitFlip:
@@ -177,6 +330,48 @@ class TestBitFlip:
         with pytest.raises(ValueError, match="p must be in the interval"):
             channel.BitFlip(1.5, wires=0).kraus_matrices()
 
+    expected_jac_fn = lambda self, p: [
+        -1 / (2 * qml.math.sqrt(1-p)) * qml.math.eye(2),
+        1 / (2 * qml.math.sqrt(p)) * qml.math.array([[0, 1], [1, 0]]),
+    ]
+
+    @pytest.mark.autograd
+    def test_kraus_jac_autograd(self):
+        p = pnp.array(0.43, requires_grad=True)
+        fn = lambda x: qml.math.stack(channel.BitFlip(x, wires=0).kraus_matrices())
+        jac_fn = qml.jacobian(fn)
+        jac = jac_fn(p)
+        assert qml.math.allclose(jac, self.expected_jac_fn(p))
+
+    @pytest.mark.torch
+    def test_kraus_jac_torch(self):
+        import torch
+
+        p = torch.tensor(0.43, requires_grad=True)
+        fn = lambda x: qml.math.stack(channel.BitFlip(x, wires=0).kraus_matrices())
+        jac = torch.autograd.functional.jacobian(fn, p)
+        assert qml.math.allclose(jac.detach().numpy(), self.expected_jac_fn(p.detach().numpy()))
+
+    @pytest.mark.tf
+    def test_kraus_jac_tf(self):
+        import tensorflow as tf
+
+        p = tf.Variable(0.43)
+        with tf.GradientTape() as tape:
+            out = qml.math.stack(channel.BitFlip(p, wires=0).kraus_matrices())
+        jac = tape.jacobian(out, p)
+        assert qml.math.allclose(jac, self.expected_jac_fn(p))
+
+    @pytest.mark.jax
+    def test_kraus_jac_jax(self):
+        import jax
+
+        p = jax.numpy.array(0.43)
+        fn = lambda x: qml.math.stack(channel.BitFlip(x, wires=0).kraus_matrices())
+        jac_fn = jax.jacobian(fn)
+        jac = jac_fn(p)
+        assert qml.math.allclose(jac, self.expected_jac_fn(p))
+
 
 class TestPhaseFlip:
     """Test that various values of p give correct Kraus matrices"""
@@ -214,20 +409,62 @@ class TestPhaseFlip:
         with pytest.raises(ValueError, match="p must be in the interval"):
             channel.PhaseFlip(1.5, wires=0).kraus_matrices()
 
+    expected_jac_fn = lambda self, p: [
+        -1 / (2 * qml.math.sqrt(1-p)) * qml.math.eye(2),
+        1 / (2 * qml.math.sqrt(p)) * qml.math.diag([1, -1]),
+    ]
+
+    @pytest.mark.autograd
+    def test_kraus_jac_autograd(self):
+        p = pnp.array(0.43, requires_grad=True)
+        fn = lambda x: qml.math.stack(channel.PhaseFlip(x, wires=0).kraus_matrices())
+        jac_fn = qml.jacobian(fn)
+        jac = jac_fn(p)
+        assert qml.math.allclose(jac, self.expected_jac_fn(p))
+
+    @pytest.mark.torch
+    def test_kraus_jac_torch(self):
+        import torch
+
+        p = torch.tensor(0.43, requires_grad=True)
+        fn = lambda x: qml.math.stack(channel.PhaseFlip(x, wires=0).kraus_matrices())
+        jac = torch.autograd.functional.jacobian(fn, p)
+        assert qml.math.allclose(jac.detach().numpy(), self.expected_jac_fn(p.detach().numpy()))
+
+    @pytest.mark.tf
+    def test_kraus_jac_tf(self):
+        import tensorflow as tf
+
+        p = tf.Variable(0.43)
+        with tf.GradientTape() as tape:
+            out = qml.math.stack(channel.PhaseFlip(p, wires=0).kraus_matrices())
+        jac = tape.jacobian(out, p)
+        assert qml.math.allclose(jac, self.expected_jac_fn(p))
+
+    @pytest.mark.jax
+    def test_kraus_jac_jax(self):
+        import jax
+
+        p = jax.numpy.array(0.43)
+        fn = lambda x: qml.math.stack(channel.PhaseFlip(x, wires=0).kraus_matrices())
+        jac_fn = jax.jacobian(fn)
+        jac = jac_fn(p)
+        assert qml.math.allclose(jac, self.expected_jac_fn(p))
+
 
 class TestDepolarizingChannel:
     """Tests for the quantum channel DepolarizingChannel"""
 
     def test_p_zero(self, tol):
         """Test p=0 gives correct Kraus matrices"""
-        op = channel.DepolarizingChannel
+        op = qml.DepolarizingChannel
         assert np.allclose(op(0, wires=0).kraus_matrices()[0], np.eye(2), atol=tol, rtol=0)
         assert np.allclose(op(0, wires=0).kraus_matrices()[1], np.zeros((2, 2)), atol=tol, rtol=0)
 
     def test_p_arbitrary(self, tol):
         """Test p=0.1 gives correct Kraus matrices"""
         p = 0.1
-        op = channel.DepolarizingChannel
+        op = qml.DepolarizingChannel
         expected = np.sqrt(p / 3) * X
         assert np.allclose(op(0.1, wires=0).kraus_matrices()[1], expected, atol=tol, rtol=0)
 
@@ -251,7 +488,57 @@ class TestDepolarizingChannel:
 
     def test_p_invalid_parameter(self):
         with pytest.raises(ValueError, match="p must be in the interval"):
-            channel.DepolarizingChannel(1.5, wires=0).kraus_matrices()
+            qml.DepolarizingChannel(1.5, wires=0).kraus_matrices()
+
+    expected_jac_fn = lambda self, p: [
+        -1 / (2 * qml.math.sqrt(1-p)) * qml.math.eye(2),
+        1 / (6 * qml.math.sqrt(p / 3)) * qml.math.array([[0, 1], [1, 0]]),
+        1 / (6 * qml.math.sqrt(p / 3)) * qml.math.array([[0, -1j], [1j, 0]]),
+        1 / (6 * qml.math.sqrt(p / 3)) * qml.math.diag([1, -1]),
+    ]
+
+    @pytest.mark.autograd
+    def test_kraus_jac_autograd(self):
+        p = pnp.array(0.43, requires_grad=True)
+        fn_real = lambda x: qml.math.real(qml.math.stack(channel.DepolarizingChannel(x, wires=0).kraus_matrices()))
+        fn_imag = lambda x: qml.math.imag(qml.math.stack(channel.DepolarizingChannel(x, wires=0).kraus_matrices()))
+        jac_fn_real = qml.jacobian(fn_real)
+        jac_fn_imag = qml.jacobian(fn_imag)
+        jac = jac_fn_real(p) + 1j * jac_fn_imag(p)
+        assert qml.math.allclose(jac, self.expected_jac_fn(p))
+
+    @pytest.mark.torch
+    def test_kraus_jac_torch(self):
+        import torch
+
+        p = torch.tensor(0.43, requires_grad=True)
+        fn_real = lambda x: qml.math.real(qml.math.stack(channel.DepolarizingChannel(x, wires=0).kraus_matrices()))
+        fn_imag = lambda x: qml.math.imag(qml.math.stack(channel.DepolarizingChannel(x, wires=0).kraus_matrices()))
+        jac_real = torch.autograd.functional.jacobian(fn_real, p).detach().numpy()
+        jac_imag = torch.autograd.functional.jacobian(fn_imag, p).detach().numpy()
+        assert qml.math.allclose(jac_real+1j*jac_imag, self.expected_jac_fn(p.detach().numpy()))
+
+    @pytest.mark.tf
+    def test_kraus_jac_tf(self):
+        import tensorflow as tf
+
+        p = tf.Variable(0.43)
+        with tf.GradientTape() as tape:
+            out = qml.math.stack(channel.DepolarizingChannel(p, wires=0).kraus_matrices())
+        jac = tape.jacobian(out, p)
+        assert qml.math.allclose(jac, self.expected_jac_fn(p))
+
+    @pytest.mark.jax
+    def test_kraus_jac_jax(self):
+        import jax
+
+        jax.config.update("jax_enable_x64", True)
+
+        p = jax.numpy.array(0.43, dtype=jax.numpy.complex128)
+        fn = lambda x: qml.math.stack(channel.DepolarizingChannel(x, wires=0).kraus_matrices())
+        jac_fn = jax.jacobian(fn, holomorphic=True)
+        jac = jac_fn(p)
+        assert qml.math.allclose(jac, self.expected_jac_fn(p))
 
 
 class TestResetError:
@@ -322,6 +609,68 @@ class TestResetError:
                 ]
             ),
         )
+
+    expected_jac_fn = lambda self, p0, p1: (
+        [
+            -1 / (2 * qml.math.sqrt(1 - p0 - p1)) * qml.math.eye(2),
+            1 / (2 * qml.math.sqrt(p0)) * qml.math.array([[1, 0], [0, 0]]),
+            1 / (2 * qml.math.sqrt(p0)) * qml.math.array([[0, 1], [0, 0]]),
+            qml.math.zeros((2, 2)),
+            qml.math.zeros((2, 2)),
+        ],
+        [
+            -1 / (2 * qml.math.sqrt(1 - p0 - p1)) * qml.math.eye(2),
+            qml.math.zeros((2, 2)),
+            qml.math.zeros((2, 2)),
+            1 / (2 * qml.math.sqrt(p1)) * qml.math.array([[0, 0], [1, 0]]),
+            1 / (2 * qml.math.sqrt(p1)) * qml.math.array([[0, 0], [0, 1]]),
+        ],
+    )
+
+    @pytest.mark.autograd
+    def test_kraus_jac_autograd(self):
+        p0 = pnp.array(0.43, requires_grad=True)
+        p1 = pnp.array(0.12, requires_grad=True)
+
+        fn = lambda p0, p1: qml.math.stack(channel.ResetError(p0, p1, wires=0).kraus_matrices())
+        jac_fn = qml.jacobian(fn)
+        jac = jac_fn(p0, p1)
+        assert qml.math.allclose(jac, self.expected_jac_fn(p0, p1))
+
+    @pytest.mark.torch
+    def test_kraus_jac_torch(self):
+        import torch
+
+        p0 = torch.tensor(0.43, requires_grad=True)
+        p1 = torch.tensor(0.12, requires_grad=True)
+        fn = lambda p0, p1: qml.math.stack(channel.ResetError(p0, p1, wires=0).kraus_matrices())
+        jac = torch.autograd.functional.jacobian(fn, (p0, p1))
+        exp_jac = self.expected_jac_fn(p0.detach().numpy(), p1.detach().numpy())
+        assert len(jac) == len(exp_jac) == 2
+        for j, exp_j in zip(jac, exp_jac):
+            assert qml.math.allclose(j.detach().numpy(), exp_j)
+
+    @pytest.mark.tf
+    def test_kraus_jac_tf(self):
+        import tensorflow as tf
+
+        p0 = tf.Variable(0.43)
+        p1 = tf.Variable(0.12)
+        with tf.GradientTape() as tape:
+            out = qml.math.stack(channel.ResetError(p0, p1, wires=0).kraus_matrices())
+        jac = tape.jacobian(out, (p0, p1))
+        assert qml.math.allclose(jac, self.expected_jac_fn(p0, p1))
+
+    @pytest.mark.jax
+    def test_kraus_jac_jax(self):
+        import jax
+
+        p0 = jax.numpy.array(0.43)
+        p1 = jax.numpy.array(0.12)
+        fn = lambda p0, p1: qml.math.stack(channel.ResetError(p0, p1, wires=0).kraus_matrices())
+        jac_fn = jax.jacobian(fn, argnums=[0, 1])
+        jac = jac_fn(p0, p1)
+        assert qml.math.allclose(jac, self.expected_jac_fn(p0, p1))
 
 
 class TestPauliError:
@@ -418,6 +767,66 @@ class TestPauliError:
         c = channel.PauliError(operators, 0.5, wires=wires)
 
         assert np.allclose(c.kraus_matrices(), expected_Ks, atol=tol, rtol=0)
+
+    expected_jac_fn = {
+        "X": lambda p: [
+            -1 / (2 * qml.math.sqrt(1-p)) * qml.math.eye(2),
+            1 / (2 * qml.math.sqrt(p)) * qml.math.array([[0, 1], [1, 0]]),
+        ],
+        "XY": lambda p: [
+            -1 / (2 * qml.math.sqrt(1-p)) * qml.math.eye(4),
+            1 / (2 * qml.math.sqrt(p)) * (qml.math.diag([1j, -1j, 1j, -1j])[::-1]),
+        ],
+    }
+
+    @pytest.mark.parametrize("ops", ["X", "XY"])
+    @pytest.mark.autograd
+    def test_kraus_jac_autograd(self, ops):
+        p = pnp.array(0.43, requires_grad=True)
+        wires = list(range(len(ops)))
+        fn_real = lambda x: qml.math.real(qml.math.stack(channel.PauliError(ops, x, wires=wires).kraus_matrices()))
+        fn_imag = lambda x: qml.math.imag(qml.math.stack(channel.PauliError(ops, x, wires=wires).kraus_matrices()))
+        jac_fn_real = qml.jacobian(fn_real)
+        jac_fn_imag = qml.jacobian(fn_imag)
+        jac = jac_fn_real(p) + 1j * jac_fn_imag(p)
+        assert qml.math.allclose(jac, self.expected_jac_fn[ops](p))
+
+    @pytest.mark.parametrize("ops", ["X", "XY"])
+    @pytest.mark.torch
+    def test_kraus_jac_torch(self, ops):
+        import torch
+
+        p = torch.tensor(0.43, requires_grad=True)
+        wires = list(range(len(ops)))
+        fn_real = lambda x: qml.math.real(qml.math.stack(channel.PauliError(ops, x, wires=wires).kraus_matrices()))
+        fn_imag = lambda x: qml.math.imag(qml.math.stack(channel.PauliError(ops, x, wires=wires).kraus_matrices()))
+        jac_real = torch.autograd.functional.jacobian(fn_real, p).detach().numpy()
+        jac_imag = torch.autograd.functional.jacobian(fn_imag, p).detach().numpy()
+        assert qml.math.allclose(jac_real+1j*jac_imag, self.expected_jac_fn[ops](p.detach().numpy()))
+
+    @pytest.mark.parametrize("ops", ["X", "XY"])
+    @pytest.mark.tf
+    def test_kraus_jac_tf(self, ops):
+        import tensorflow as tf
+
+        p = tf.Variable(0.43)
+        wires = list(range(len(ops)))
+        with tf.GradientTape() as tape:
+            out = qml.math.stack(channel.PauliError(ops, p, wires=wires).kraus_matrices())
+        jac = tape.jacobian(out, p)
+        assert qml.math.allclose(jac, self.expected_jac_fn[ops](p))
+
+    @pytest.mark.parametrize("ops", ["X", "XY"])
+    @pytest.mark.jax
+    def test_kraus_jac_jax(self, ops):
+        import jax
+
+        p = jax.numpy.array(0.43, dtype=jax.numpy.complex128)
+        wires = list(range(len(ops)))
+        fn = lambda x: qml.math.stack(channel.PauliError(ops, x, wires=wires).kraus_matrices())
+        jac_fn = jax.jacobian(fn, holomorphic=True)
+        jac = jac_fn(p)
+        assert qml.math.allclose(jac, self.expected_jac_fn[ops](p))
 
 
 class TestQubitChannel:

--- a/tests/ops/test_channel_ops.py
+++ b/tests/ops/test_channel_ops.py
@@ -67,6 +67,7 @@ class TestChannels:
             ops = [op(p, *tr_args, wires=0)]
         else:
             ops = [op(p, wires=0)]
+
         for operation in ops:
             K_list = operation.kraus_matrices()
             K_arr = qml.math.stack(K_list)


### PR DESCRIPTION
**Context:**
The non-unitary channels in PennyLane have some incompatibilities with the interfaces.

**Description of the Change:**
This PR fixes differentiability of the Kraus matrices of all channels, except for `QubitChannel` and `ThermalRelaxationChannel`.
It also introduces tests for all fixed channels.

**Benefits:**
Differentiability support.

**Possible Drawbacks:**
Code complexity and performance reductions, as usual for interface support.

**Related GitHub Issues:**
Fixes #3608 

Blocks newly added tests in #3584