### PR TITLE
Adds initialize_state to devices/qubit

### DIFF
--- a/pennylane/devices/__init__.py
+++ b/pennylane/devices/__init__.py
@@ -39,3 +39,4 @@ from .default_qubit import DefaultQubit
 from .default_gaussian import DefaultGaussian
 from .default_mixed import DefaultMixed
 from .null_qubit import NullQubit
+from . import qubit

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -407,11 +407,7 @@ class DefaultQubit(QubitDevice):
         # to. If axes[1] is larger than axes[0], then we need to shift the target axis down by
         # one, otherwise we can leave as-is. For example: a state has [0, 1, 2, 3], control=1,
         # target=3. Then, state[sl_1] has 3 axes and target=3 now corresponds to the second axis.
-        if axes[1] > axes[0]:
-            target_axes = [axes[1] - 1]
-        else:
-            target_axes = [axes[1]]
-
+        target_axes = [axes[1] - 1] if axes[1] > axes[0] else [axes[1]]
         state_x = self._apply_x(state[sl_1], axes=target_axes)
         return self._stack([state[sl_0], state_x], axis=axes[0])
 
@@ -484,11 +480,7 @@ class DefaultQubit(QubitDevice):
         sl_0 = _get_slice(0, axes[0], ndim)
         sl_1 = _get_slice(1, axes[0], ndim)
 
-        if axes[1] > axes[0]:
-            target_axes = [axes[1] - 1]
-        else:
-            target_axes = [axes[1]]
-
+        target_axes = [axes[1] - 1] if axes[1] > axes[0] else [axes[1]]
         state_z = self._apply_z(state[sl_1], axes=target_axes)
         return self._stack([state[sl_0], state_z], axis=axes[0])
 
@@ -537,83 +529,84 @@ class DefaultQubit(QubitDevice):
         # intercept other Hamiltonians
         # TODO: Ideally, this logic should not live in the Device, but be moved
         # to a component that can be re-used by devices as needed.
-        if observable.name in ("Hamiltonian", "SparseHamiltonian"):
-            assert self.shots is None, f"{observable.name} must be used with shots=None"
+        if observable.name not in ("Hamiltonian", "SparseHamiltonian"):
+            return super().expval(observable, shot_range=shot_range, bin_size=bin_size)
 
-            self.map_wires(observable.wires)
-            backprop_mode = (
-                not isinstance(self.state, np.ndarray)
-                or any(not isinstance(d, (float, np.ndarray)) for d in observable.data)
-            ) and observable.name == "Hamiltonian"
+        if self.shots is not None:
+            raise ValueError(f"{observable.name} must be used with shots=None")
 
-            if backprop_mode:
-                # TODO[dwierichs]: This branch is not adapted to broadcasting yet
-                if self._ndim(self.state) == 2:
-                    raise NotImplementedError(
-                        "Expectation values of Hamiltonians for interface!=None are "
-                        "not supported together with parameter broadcasting yet"
-                    )
-                # We must compute the expectation value assuming that the Hamiltonian
-                # coefficients *and* the quantum states are tensor objects.
+        self.map_wires(observable.wires)
+        backprop_mode = (
+            not isinstance(self.state, np.ndarray)
+            or any(not isinstance(d, (float, np.ndarray)) for d in observable.data)
+        ) and observable.name == "Hamiltonian"
 
-                # Compute  <psi| H |psi> via sum_i coeff_i * <psi| PauliWord |psi> using a sparse
-                # representation of the Pauliword
-                res = qml.math.cast(qml.math.convert_like(0.0, observable.data), dtype=complex)
-                interface = qml.math.get_interface(self.state)
+        if backprop_mode:
+            # TODO[dwierichs]: This branch is not adapted to broadcasting yet
+            if self._ndim(self.state) == 2:
+                raise NotImplementedError(
+                    "Expectation values of Hamiltonians for interface!=None are "
+                    "not supported together with parameter broadcasting yet"
+                )
+            # We must compute the expectation value assuming that the Hamiltonian
+            # coefficients *and* the quantum states are tensor objects.
 
-                # Note: it is important that we use the Hamiltonian's data and not the coeffs
-                # attribute. This is because the .data attribute may be 'unwrapped' as required by
-                # the interfaces, whereas the .coeff attribute will always be the same input dtype
-                # that the user provided.
-                for op, coeff in zip(observable.ops, observable.data):
+            # Compute  <psi| H |psi> via sum_i coeff_i * <psi| PauliWord |psi> using a sparse
+            # representation of the Pauliword
+            res = qml.math.cast(qml.math.convert_like(0.0, observable.data), dtype=complex)
+            interface = qml.math.get_interface(self.state)
 
-                    # extract a scipy.sparse.coo_matrix representation of this Pauli word
-                    coo = qml.operation.Tensor(op).sparse_matrix(wires=self.wires, format="coo")
-                    Hmat = qml.math.cast(qml.math.convert_like(coo.data, self.state), self.C_DTYPE)
+            # Note: it is important that we use the Hamiltonian's data and not the coeffs
+            # attribute. This is because the .data attribute may be 'unwrapped' as required by
+            # the interfaces, whereas the .coeff attribute will always be the same input dtype
+            # that the user provided.
+            for op, coeff in zip(observable.ops, observable.data):
 
-                    product = (
-                        self._gather(self._conj(self.state), coo.row)
-                        * Hmat
-                        * self._gather(self.state, coo.col)
-                    )
-                    c = qml.math.convert_like(coeff, product)
+                # extract a scipy.sparse.coo_matrix representation of this Pauli word
+                coo = qml.operation.Tensor(op).sparse_matrix(wires=self.wires, format="coo")
+                Hmat = qml.math.cast(qml.math.convert_like(coo.data, self.state), self.C_DTYPE)
 
-                    if interface == "tensorflow":
-                        c = qml.math.cast(c, "complex128")
+                product = (
+                    self._gather(self._conj(self.state), coo.row)
+                    * Hmat
+                    * self._gather(self.state, coo.col)
+                )
+                c = qml.math.convert_like(coeff, product)
 
-                    res = qml.math.convert_like(res, product) + qml.math.sum(c * product)
+                if interface == "tensorflow":
+                    c = qml.math.cast(c, "complex128")
 
-            else:
-                # Coefficients and the state are not trainable, we can be more
-                # efficient in how we compute the Hamiltonian sparse matrix.
-                if observable.name == "Hamiltonian":
-                    Hmat = qml.utils.sparse_hamiltonian(observable, wires=self.wires)
-                elif observable.name == "SparseHamiltonian":
-                    Hmat = observable.sparse_matrix()
+                res = qml.math.convert_like(res, product) + qml.math.sum(c * product)
 
-                state = qml.math.toarray(self.state)
-                if self._ndim(state) == 2:
-                    res = qml.math.array(
-                        [
-                            csr_matrix.dot(
-                                csr_matrix(self._conj(_state)),
-                                csr_matrix.dot(Hmat, csr_matrix(_state[..., None])),
-                            ).toarray()[0]
-                            for _state in state
-                        ]
-                    )
-                else:
-                    res = csr_matrix.dot(
-                        csr_matrix(self._conj(state)),
-                        csr_matrix.dot(Hmat, csr_matrix(state[..., None])),
-                    ).toarray()[0]
-
+        else:
+            # Coefficients and the state are not trainable, we can be more
+            # efficient in how we compute the Hamiltonian sparse matrix.
             if observable.name == "Hamiltonian":
-                res = qml.math.squeeze(res)
+                Hmat = qml.utils.sparse_hamiltonian(observable, wires=self.wires)
+            elif observable.name == "SparseHamiltonian":
+                Hmat = observable.sparse_matrix()
 
-            return self._real(res)
+            state = qml.math.toarray(self.state)
+            if self._ndim(state) == 2:
+                res = qml.math.array(
+                    [
+                        csr_matrix.dot(
+                            csr_matrix(self._conj(_state)),
+                            csr_matrix.dot(Hmat, csr_matrix(_state[..., None])),
+                        ).toarray()[0]
+                        for _state in state
+                    ]
+                )
+            else:
+                res = csr_matrix.dot(
+                    csr_matrix(self._conj(state)),
+                    csr_matrix.dot(Hmat, csr_matrix(state[..., None])),
+                ).toarray()[0]
 
-        return super().expval(observable, shot_range=shot_range, bin_size=bin_size)
+        if observable.name == "Hamiltonian":
+            res = qml.math.squeeze(res)
+
+        return self._real(res)
 
     def _get_unitary_matrix(self, unitary):  # pylint: disable=no-self-use
         """Return the matrix representing a unitary operation.
@@ -693,7 +686,7 @@ class DefaultQubit(QubitDevice):
         if batch_size is not None:
             output_shape.insert(0, batch_size)
 
-        if not (state.shape in [(dim,), (batch_size, dim)]):
+        if state.shape not in [(dim,), (batch_size, dim)]:
             raise ValueError("State vector must have shape (2**wires,) or (batch_size, 2**wires).")
 
         if not qml.math.is_abstract(state):

--- a/pennylane/devices/qubit/__init__.py
+++ b/pennylane/devices/qubit/__init__.py
@@ -1,0 +1,16 @@
+# Copyright 2018-2023 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""The subpackage for various qubit devices and relevant common code."""
+
+from .initialize_state import initialize_state

--- a/pennylane/devices/qubit/initialize_state.py
+++ b/pennylane/devices/qubit/initialize_state.py
@@ -1,0 +1,90 @@
+# Copyright 2018-2023 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Functions to prepare a state."""
+
+from typing import List
+
+import pennylane as qml
+from pennylane import numpy as np
+from pennylane.interfaces import INTERFACE_MAP
+from pennylane.operation import Operator
+
+
+def _get_padded_wire_order(num_wires, operations):
+    """
+    Gets all distinct wires in ``operations``, and pads that list
+    with new labels if needed.
+
+    Args:
+        num_wires (int): The required number of wires in the returned wire_order
+        operations (List[Operator]): The inputted set of operations to extract wires from
+
+    Returns:
+        wire_order (List[int]): A wire order to use in computations to ensure consistency
+
+    Raises:
+        ValueError: If too many distinct wires are found in the provided list of operations
+    """
+    all_wires = qml.wires.Wires.all_wires([op.wires for op in operations])
+    num_prep_wires = len(all_wires)
+    if num_prep_wires > num_wires:
+        raise ValueError(
+            f"Expected no more than {num_wires} distinct wires across all prep_operations, got {all_wires}"
+        )
+    wire_order = all_wires.tolist()
+    if num_prep_wires < num_wires:  # pad `wire_order` to match `num_wires`
+        delta = num_wires - num_prep_wires
+        if int_wires := [w for w in wire_order if isinstance(w, int)]:
+            first_new_wire = max(int_wires) + 1
+            wire_order.extend(range(first_new_wire, first_new_wire + delta))
+        else:
+            wire_order.extend(range(delta))
+    return wire_order
+
+
+def initialize_state(
+    num_wires: int, prep_operations: List[Operator] = None, framework: str = "autograd"
+) -> np.ndarray:
+    """
+    Initialize a state vector given some preparation operations.
+
+    Args:
+        num_wires (int): The number of wires in the state being initialized
+        prep_operations (List[Operator]): A sequence of operations to apply to prepare an initial state
+        framework (str): The machine learning framework to use when preparing the initial state
+
+    Returns:
+        array[complex]: The initialized state vector
+
+    Raises:
+        QuantumFunctionError: If an unknown machine learning framework is provided
+        ValueError: If too many distinct wires are found in the provided list of prep operations
+    """
+    if framework not in INTERFACE_MAP:
+        raise qml.QuantumFunctionError(
+            f"Unknown framework {framework}. Interface must be one of {list(INTERFACE_MAP)}."
+        )
+    framework = INTERFACE_MAP[framework]
+    if framework == "tf":
+        framework = "tensorflow"
+
+    shape = (2,) * num_wires
+    state = qml.math.zeros(shape, dtype="complex128", like=framework)
+
+    if prep_operations:
+        wire_order = _get_padded_wire_order(num_wires, prep_operations)
+        for op in prep_operations:
+            state = qml.math.matmul(op.matrix(wire_order=wire_order), state, like=framework)
+
+    return qml.math.array(state, like=framework)

--- a/pennylane/devices/qubit/initialize_state.py
+++ b/pennylane/devices/qubit/initialize_state.py
@@ -20,6 +20,10 @@ from pennylane import numpy as np
 from pennylane.interfaces import INTERFACE_MAP
 from pennylane.operation import Operator
 
+INTERFACE_MAP = INTERFACE_MAP.copy()
+del INTERFACE_MAP[None]
+del INTERFACE_MAP["auto"]
+
 
 def _get_padded_wire_order(num_wires, operations):
     """
@@ -79,12 +83,12 @@ def initialize_state(
     if framework == "tf":
         framework = "tensorflow"
 
-    shape = (2,) * num_wires
-    state = qml.math.zeros(shape, dtype="complex128", like=framework)
+    state = np.zeros(2**num_wires, dtype="complex128")
+    state[0] = 1
 
     if prep_operations:
         wire_order = _get_padded_wire_order(num_wires, prep_operations)
         for op in prep_operations:
-            state = qml.math.matmul(op.matrix(wire_order=wire_order), state, like=framework)
+            state = qml.math.matmul(op.matrix(wire_order=wire_order), state)
 
-    return qml.math.array(state, like=framework)
+    return qml.math.reshape(qml.math.array(state, like=framework), (2,) * num_wires)

--- a/tests/devices/qubit/test_initialize_state.py
+++ b/tests/devices/qubit/test_initialize_state.py
@@ -1,0 +1,104 @@
+# Copyright 2018-2020 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Unit tests for the :func:`~pennylane.devices.qubit.initialize_state` function.
+"""
+
+import pytest
+
+import pennylane as qml
+from pennylane import numpy as np
+from pennylane.devices.qubit import initialize_state
+
+pytestmark = pytest.mark.all_interfaces
+
+tf = pytest.importorskip("tensorflow")
+torch = pytest.importorskip("torch")
+jax = pytest.importorskip("jax")
+
+SUPPORTED_INTERFACES_AND_TYPES = [
+    ("numpy", np.tensor),
+    ("scipy", np.ndarray),
+    ("jax", jax.numpy.DeviceArray),
+    ("torch", torch.Tensor),
+    ("tf", tf.Tensor),
+]
+SUPPORTED_INTERFACES = [i[0] for i in SUPPORTED_INTERFACES_AND_TYPES]
+
+
+@pytest.mark.parametrize("framework,dtype", SUPPORTED_INTERFACES_AND_TYPES)
+@pytest.mark.parametrize("num_wires", [1, 2, 3])
+def test_initialize_state_no_ops(framework, dtype, num_wires):
+    """Tests that initialize_state works without prep operations provided."""
+    actual = initialize_state(num_wires, framework=framework)
+    expected = np.zeros((2,) * num_wires)
+    expected[(0,) * num_wires] = 1
+    assert qml.math.allequal(expected, actual)
+    assert isinstance(actual, dtype)
+
+
+@pytest.mark.parametrize("framework,dtype", SUPPORTED_INTERFACES_AND_TYPES)
+def test_initialize_state_with_prep(framework, dtype):
+    """Tests that initialize_state handles prep operations correctly."""
+    ops = [qml.Hadamard(0), qml.CNOT([0, 1])]
+    actual = initialize_state(3, prep_operations=ops, framework=framework)
+    expected = np.zeros((2,) * 3)
+    expected[0][0][0] = 1 / np.sqrt(2)
+    expected[1][1][0] = 1 / np.sqrt(2)
+    assert qml.math.allequal(expected, actual)
+    assert isinstance(actual, dtype)
+
+
+def test_too_many_wires_in_prep():
+    """Tests that initialize_state fails when prep operations collectively have too many wires."""
+    ops = [qml.Hadamard(0), qml.CNOT([0, 1]), qml.PauliX(2)]
+    with pytest.raises(ValueError, match="Expected no more than 2 distinct wires"):
+        initialize_state(2, prep_operations=ops)
+
+
+def test_unknown_framework_fails():
+    """Tests that initialize_state fails when an unknown framework is provided."""
+    with pytest.raises(qml.QuantumFunctionError, match="Unknown framework"):
+        initialize_state(1, framework="nonsense")
+
+
+@pytest.mark.parametrize("framework", SUPPORTED_INTERFACES)
+def test_initialize_state_does_not_sort_wires(framework):
+    """Tests that initialize_state does not try to sort wires before computing."""
+    ops = [qml.Hadamard(0), qml.PauliX(2), qml.CNOT([0, 1])]
+    actual = initialize_state(3, prep_operations=ops, framework=framework)
+    expected = np.zeros((2,) * 3)
+    # because "2" was the second label spotted, the wire_order was (0,2,1) while computing
+    expected[0][1][0] = 1 / np.sqrt(2)
+    expected[1][1][1] = 1 / np.sqrt(2)
+    assert qml.math.allequal(expected, actual)
+
+
+@pytest.mark.parametrize("framework", SUPPORTED_INTERFACES)
+@pytest.mark.parametrize(
+    "wires",
+    [
+        (0, 1),
+        ("a", "b"),
+        ("a", 0),
+    ],
+)
+def test_wires_are_padded_in_calculation(framework, wires):
+    """Tests that initialize_state pads wires when calculating the state to match num_wires."""
+    ops = [qml.Hadamard(wires[0]), qml.CNOT([wires[0], wires[1]])]
+    actual = initialize_state(3, prep_operations=ops, framework=framework)
+    expected = np.zeros((2,) * 3)
+    expected[0][0][0] = 1 / np.sqrt(2)
+    expected[1][1][0] = 1 / np.sqrt(2)
+    assert qml.math.allequal(expected, actual)

--- a/tests/tests_passing_pylint.txt
+++ b/tests/tests_passing_pylint.txt
@@ -1,2 +1,2 @@
-tests/data/test_dataset.py
-tests/data/test_dataset_access.py
+tests/data/**
+tests/devices/qubit/**


### PR DESCRIPTION
**Context:**
With the new device API and the accompanying devices, it will be nice to have a way to generate an initial state-vector without tying that to any device.

**Description of the Change:**
Adds `initialize_state` to `devices/qubit` (a new submodule), which receives a series of prep operations and returns a state-vector.

**Benefits:**
There will be a generic way to create an initial state with no ties to any device

**Possible Drawbacks:**
This may have difficulties interacting with existing state-prep code, but that needs investigation.