### PR TITLE
Return `NotImplemented` in dunder methods

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -132,11 +132,11 @@
 * Extended the `qml.equal` function to compare `Prod` and `Sum` operators.
   [(#3516)](https://github.com/PennyLaneAI/pennylane/pull/3516)
 
-* Reorganize `ControlledQubitUnitary` to inherit from `ControlledOp`. The class methods 
+* Reorganize `ControlledQubitUnitary` to inherit from `ControlledOp`. The class methods
   `decomposition`, `expand`, and `sparse_matrix` are now defined rather than raising an error.
   [(#3450)](https://github.com/PennyLaneAI/pennylane/pull/3450)
 
-* Parameter broadcasting support is added for the `Controlled` class if the base operator supports 
+* Parameter broadcasting support is added for the `Controlled` class if the base operator supports
   broadcasting.
   [(#3450)](https://github.com/PennyLaneAI/pennylane/pull/3450)
 
@@ -166,9 +166,13 @@
   keyword argument to specify that the contents of the file being read should be directly assigned to an attribute.
   [(#3605)](https://github.com/PennyLaneAI/pennylane/pull/3605)
 
+* All dunder methods now return `NotImplemented`, allowing the right dunder method (e.g. `__radd__`)
+  of the other class to be called.
+  [(#3631)](https://github.com/PennyLaneAI/pennylane/pull/3631)
+
 <h3>Breaking changes</h3>
 
-* The target wires of the unitary for `ControlledQubitUnitary` are no longer available via `op.hyperparameters["u_wires"]`. 
+* The target wires of the unitary for `ControlledQubitUnitary` are no longer available via `op.hyperparameters["u_wires"]`.
   Instead, they can be accesses via `op.base.wires` or `op.target_wires`.
   [(#3450)](https://github.com/PennyLaneAI/pennylane/pull/3450)
 

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -1783,7 +1783,7 @@ class Observable(Operator):
     def __sub__(self, other):
         r"""The subtraction operation between Observables/Tensors/qml.Hamiltonian objects."""
         if isinstance(other, (Observable, Tensor, qml.Hamiltonian)):
-            return self.__add__(other.__mul__(-1))
+            return self + (-1 * other)
         return super().__sub__(other=other)
 
 

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -1293,8 +1293,8 @@ class Operator(abc.ABC):
             return self
         try:
             return qml.op_sum(self, qml.s_prod(scalar=other, operator=qml.Identity(self.wires)))
-        except ValueError as e:
-            raise ValueError(f"Cannot add Operator and {type(other)}") from e
+        except ValueError:
+            return NotImplemented
 
     __radd__ = __add__
 
@@ -1302,22 +1302,20 @@ class Operator(abc.ABC):
         """The scalar multiplication between scalars and Operators."""
         try:
             return qml.s_prod(scalar=other, operator=self)
-        except ValueError as e:
-            raise ValueError(f"Cannot multiply Operator and {type(other)}.") from e
+        except ValueError:
+            return NotImplemented
 
     __rmul__ = __mul__
 
     def __matmul__(self, other):
         """The product operation between Operator objects."""
-        if isinstance(other, Operator):
-            return qml.prod(self, other)
-        raise ValueError("Can only perform tensor products between operators.")
+        return qml.prod(self, other) if isinstance(other, Operator) else NotImplemented
 
     def __sub__(self, other):
         """The subtraction operation of Operator-Operator objects and Operator-scalar."""
         if isinstance(other, (Operator, numbers.Number)):
             return self + (-other)
-        raise ValueError(f"Cannot subtract {type(other)} from Operator.")
+        return NotImplemented
 
     def __rsub__(self, other):
         """The reverse subtraction operation of Operator-Operator objects and Operator-scalar."""
@@ -1331,7 +1329,7 @@ class Operator(abc.ABC):
         r"""The power operation of an Operator object."""
         if isinstance(other, numbers.Number):
             return qml.pow(self, z=other)
-        raise ValueError(f"Cannot raise an Operator with an exponent of type {type(other)}")
+        return NotImplemented
 
 
 # =============================================================================
@@ -1700,10 +1698,7 @@ class Observable(Operator):
         if isinstance(other, Observable):
             return Tensor(self, other)
 
-        try:
-            return super().__matmul__(other=other)
-        except ValueError as e:
-            raise ValueError("Can only perform tensor products between operators.") from e
+        return super().__matmul__(other=other)
 
     def _obs_data(self):
         r"""Extracts the data from a Observable or Tensor and serializes it in an order-independent fashion.
@@ -1771,10 +1766,8 @@ class Observable(Operator):
             return other + self
         if isinstance(other, (Observable, Tensor)):
             return qml.Hamiltonian([1, 1], [self, other], simplify=True)
-        try:
-            return super().__add__(other=other)
-        except ValueError as e:
-            raise ValueError(f"Cannot add Observable and {type(other)}") from e
+
+        return super().__add__(other=other)
 
     __radd__ = __add__
 
@@ -1782,10 +1775,8 @@ class Observable(Operator):
         r"""The scalar multiplication operation between a scalar and an Observable/Tensor."""
         if isinstance(a, (int, float)):
             return qml.Hamiltonian([a], [self], simplify=True)
-        try:
-            return super().__mul__(other=a)
-        except ValueError as e:
-            raise ValueError(f"Cannot multiply Observable by {type(a)}") from e
+
+        return super().__mul__(other=a)
 
     __rmul__ = __mul__
 
@@ -1793,10 +1784,7 @@ class Observable(Operator):
         r"""The subtraction operation between Observables/Tensors/qml.Hamiltonian objects."""
         if isinstance(other, (Observable, Tensor, qml.Hamiltonian)):
             return self.__add__(other.__mul__(-1))
-        try:
-            return super().__sub__(other=other)
-        except ValueError as e:
-            raise ValueError(f"Cannot subtract {type(other)} from Observable") from e
+        return super().__sub__(other=other)
 
 
 class Tensor(Observable):
@@ -1986,7 +1974,7 @@ class Tensor(Observable):
             self.obs.append(other)
 
         else:
-            raise ValueError("Can only perform tensor products between observables.")
+            return NotImplemented
 
         wires = [op.wires for op in self.obs]
         if len(wires) != len(set(wires)):
@@ -2008,7 +1996,7 @@ class Tensor(Observable):
             QueuingManager.remove(other)
             return self
 
-        raise ValueError("Can only perform tensor products between observables.")
+        return NotImplemented
 
     __imatmul__ = __matmul__
 

--- a/pennylane/ops/qubit/hamiltonian.py
+++ b/pennylane/ops/qubit/hamiltonian.py
@@ -546,7 +546,7 @@ class Hamiltonian(Observable):
 
             return qml.Hamiltonian(coeffs1, terms, simplify=True)
 
-        raise ValueError(f"Cannot tensor product Hamiltonian and {type(H)}")
+        return NotImplemented
 
     def __rmatmul__(self, H):
         r"""The tensor product operation (from the right) between a Hamiltonian and
@@ -563,7 +563,7 @@ class Hamiltonian(Observable):
 
             return qml.Hamiltonian(coeffs1, terms, simplify=True)
 
-        raise ValueError(f"Cannot tensor product Hamiltonian and {type(H)}")
+        return NotImplemented
 
     def __add__(self, H):
         r"""The addition operation between a Hamiltonian and a Hamiltonian/Tensor/Observable."""
@@ -585,7 +585,7 @@ class Hamiltonian(Observable):
             ops.append(H)
             return qml.Hamiltonian(coeffs, ops, simplify=True)
 
-        raise ValueError(f"Cannot add Hamiltonian and {type(H)}")
+        return NotImplemented
 
     __radd__ = __add__
 
@@ -596,7 +596,7 @@ class Hamiltonian(Observable):
             coeffs = qml.math.multiply(a, self_coeffs)
             return qml.Hamiltonian(coeffs, self.ops.copy())
 
-        raise ValueError(f"Cannot multiply Hamiltonian by {type(a)}")
+        return NotImplemented
 
     __rmul__ = __mul__
 
@@ -604,7 +604,7 @@ class Hamiltonian(Observable):
         r"""The subtraction operation between a Hamiltonian and a Hamiltonian/Tensor/Observable."""
         if isinstance(H, (Hamiltonian, Tensor, Observable)):
             return self.__add__(H.__mul__(-1))
-        raise ValueError(f"Cannot subtract {type(H)} from Hamiltonian")
+        return NotImplemented
 
     def __iadd__(self, H):
         r"""The inplace addition operation between a Hamiltonian and a Hamiltonian/Tensor/Observable."""
@@ -625,7 +625,7 @@ class Hamiltonian(Observable):
             self.simplify()
             return self
 
-        raise ValueError(f"Cannot add Hamiltonian and {type(H)}")
+        return NotImplemented
 
     def __imul__(self, a):
         r"""The inplace scalar multiplication operation between a scalar and a Hamiltonian."""
@@ -633,14 +633,14 @@ class Hamiltonian(Observable):
             self._coeffs = qml.math.multiply(a, self._coeffs)
             return self
 
-        raise ValueError(f"Cannot multiply Hamiltonian by {type(a)}")
+        return NotImplemented
 
     def __isub__(self, H):
         r"""The inplace subtraction operation between a Hamiltonian and a Hamiltonian/Tensor/Observable."""
         if isinstance(H, (Hamiltonian, Tensor, Observable)):
             self.__iadd__(H.__mul__(-1))
             return self
-        raise ValueError(f"Cannot subtract {type(H)} from Hamiltonian")
+        return NotImplemented
 
     def queue(self, context=qml.QueuingManager):
         """Queues a qml.Hamiltonian instance"""

--- a/pennylane/ops/qubit/hamiltonian.py
+++ b/pennylane/ops/qubit/hamiltonian.py
@@ -603,7 +603,7 @@ class Hamiltonian(Observable):
     def __sub__(self, H):
         r"""The subtraction operation between a Hamiltonian and a Hamiltonian/Tensor/Observable."""
         if isinstance(H, (Hamiltonian, Tensor, Observable)):
-            return self.__add__(H.__mul__(-1))
+            return self + (-1 * H)
         return NotImplemented
 
     def __iadd__(self, H):

--- a/tests/ops/qubit/test_hamiltonian.py
+++ b/tests/ops/qubit/test_hamiltonian.py
@@ -14,6 +14,7 @@
 """
 Tests for the Hamiltonian class.
 """
+from collections.abc import Iterable
 from unittest.mock import patch
 
 import numpy as np
@@ -22,7 +23,6 @@ import pytest
 import pennylane as qml
 from pennylane import numpy as pnp
 from pennylane.wires import Wires
-from collections.abc import Iterable
 
 # Make test data in different interfaces, if installed
 COEFFS_PARAM_INTERFACE = [
@@ -857,21 +857,21 @@ class TestHamiltonian:
         """Tests that the arithmetic operations thrown the correct errors"""
         H = qml.Hamiltonian([1], [qml.PauliZ(0)])
         A = [[1, 0], [0, -1]]
-        with pytest.raises(ValueError, match="Cannot tensor product Hamiltonian"):
-            H @ A
-        with pytest.raises(ValueError, match="Cannot tensor product Hamiltonian"):
-            H.__rmatmul__(A)
-        with pytest.raises(ValueError, match="Cannot add Hamiltonian"):
-            H + A
-        with pytest.raises(ValueError, match="Cannot multiply Hamiltonian"):
-            H * A
-        with pytest.raises(ValueError, match="Cannot subtract"):
-            H - A
-        with pytest.raises(ValueError, match="Cannot add Hamiltonian"):
+        with pytest.raises(TypeError, match="unsupported operand type"):
+            _ = H @ A
+        with pytest.raises(TypeError, match="unsupported operand type"):
+            _ = A @ H
+        with pytest.raises(TypeError, match="unsupported operand type"):
+            _ = H + A
+        with pytest.raises(TypeError, match="can't multiply sequence by non-int"):
+            _ = H * A
+        with pytest.raises(TypeError, match="unsupported operand type"):
+            _ = H - A
+        with pytest.raises(TypeError, match="unsupported operand type"):
             H += A
-        with pytest.raises(ValueError, match="Cannot multiply Hamiltonian"):
+        with pytest.raises(TypeError, match="unsupported operand type"):
             H *= A
-        with pytest.raises(ValueError, match="Cannot subtract"):
+        with pytest.raises(TypeError, match="unsupported operand type"):
             H -= A
 
     def test_hamiltonian_queue_outside(self):

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -876,7 +876,7 @@ class TestOperatorIntegration:
             r"""Dummy custom operator"""
             num_wires = 1
 
-        with pytest.raises(ValueError, match="Cannot raise an Operator"):
+        with pytest.raises(TypeError, match="unsupported operand type"):
             _ = DummyOp(wires=[0]) ** DummyOp(wires=[0])
 
     def test_sum_with_operator(self):
@@ -1027,12 +1027,12 @@ class TestOperatorIntegration:
 
     def test_mul_with_not_supported_object_raises_error(self):
         """Test that the __mul__ dunder method raises an error when using a non-supported object."""
-        with pytest.raises(ValueError, match="Cannot multiply Observable by"):
+        with pytest.raises(TypeError, match="can't multiply sequence by non-int of type 'PauliX'"):
             _ = "dummy" * qml.PauliX(0)
 
     def test_matmul_with_not_supported_object_raises_error(self):
         """Test that the __matmul__ dunder method raises an error when using a non-supported object."""
-        with pytest.raises(ValueError, match="Can only perform tensor products between operators."):
+        with pytest.raises(TypeError, match="unsupported operand type"):
             _ = qml.PauliX(0) @ "dummy"
 
 
@@ -1382,15 +1382,11 @@ class TestTensor:
         Y = qml.CNOT(wires=[0, 1])
         Z = qml.PauliZ(0)
 
-        with pytest.raises(
-            ValueError, match="Can only perform tensor products between observables"
-        ):
+        with pytest.raises(TypeError, match="unsupported operand type"):
             T = X @ Z
             T @ Y
 
-        with pytest.raises(
-            ValueError, match="Can only perform tensor products between observables"
-        ):
+        with pytest.raises(TypeError, match="unsupported operand type"):
             T = X @ Z
             4 @ T
 
@@ -1894,14 +1890,17 @@ class TestTensorObservableOperations:
         obs = qml.PauliZ(0)
         tensor = qml.PauliZ(0) @ qml.PauliX(1)
         A = [[1, 0], [0, -1]]
-        with pytest.raises(ValueError, match="Cannot add Observable"):
+        with pytest.raises(TypeError, match="unsupported operand type"):
             obs + A
+        with pytest.raises(TypeError, match="unsupported operand type"):
             tensor + A
-        with pytest.raises(ValueError, match="Cannot multiply Observable"):
+        with pytest.raises(TypeError, match="can't multiply sequence by non-int of type 'PauliZ'"):
             obs * A
+        with pytest.raises(TypeError, match="can't multiply sequence by non-int of type 'Tensor'"):
             A * tensor
-        with pytest.raises(ValueError, match="Cannot subtract"):
+        with pytest.raises(TypeError, match="unsupported operand type"):
             obs - A
+        with pytest.raises(TypeError, match="unsupported operand type"):
             tensor - A
 
 

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -984,6 +984,30 @@ class TestOperatorIntegration:
         assert isinstance(prod_op, SProd)
         assert prod_op.scalar is scalar
 
+    def test_dunder_method_with_new_class(self):
+        """Test that when calling any Operator dunder method with a non-supported class that
+        has its right dunder method defined, the class' right dunder method is called."""
+
+        class Dummy:
+            def __radd__(self, other):
+                return True
+
+            def __rsub__(self, other):
+                return True
+
+            def __rmul__(self, other):
+                return True
+
+            def __rmatmul__(self, other):
+                return True
+
+        op = qml.PauliX(0)
+        dummy = Dummy()
+        assert op + dummy is True
+        assert op - dummy is True
+        assert op * dummy is True
+        assert op @ dummy is True
+
     @pytest.mark.torch
     def test_mul_scalar_torch_tensor(self):
         """Test the __mul__ dunder method with a scalar torch tensor."""

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -15,12 +15,11 @@
 Unit tests for :mod:`pennylane.operation`.
 """
 import itertools
-import warnings
 from functools import reduce
 
 import numpy as np
 import pytest
-from gate_data import CNOT, II, SWAP, TADD, TSWAP, I, Toffoli, X
+from gate_data import CNOT, I, Toffoli, X
 from numpy.linalg import multi_dot
 
 import pennylane as qml
@@ -29,7 +28,7 @@ from pennylane.operation import Operation, Operator, Tensor, operation_derivativ
 from pennylane.ops import Prod, SProd, Sum, cv
 from pennylane.wires import Wires
 
-# pylint: disable=no-self-use, no-member, protected-access, pointless-statement
+# pylint: disable=no-self-use, no-member, protected-access, redefined-outer-name, too-few-public-methods, too-many-public-methods, unused-argument
 
 Toffoli_broadcasted = np.tensordot([0.1, -4.2j], Toffoli, axes=0)
 CNOT_broadcasted = np.tensordot([1.4], CNOT, axes=0)
@@ -187,7 +186,7 @@ class TestOperatorConstruction:
 
     @pytest.mark.autograd
     @pytest.mark.parametrize("params, exp_batch_size", broadcasted_params_test_data)
-    def test_broadcasted_params(self, params, exp_batch_size):
+    def test_broadcasted_params_autograd(self, params, exp_batch_size):
         r"""Test that initialization of an operator with broadcasted parameters
         works and sets the ``batch_size`` correctly with Autograd parameters."""
 
@@ -203,7 +202,7 @@ class TestOperatorConstruction:
 
     @pytest.mark.jax
     @pytest.mark.parametrize("params, exp_batch_size", broadcasted_params_test_data)
-    def test_broadcasted_params(self, params, exp_batch_size):
+    def test_broadcasted_params_jax(self, params, exp_batch_size):
         r"""Test that initialization of an operator with broadcasted parameters
         works and sets the ``batch_size`` correctly with JAX parameters."""
         import jax
@@ -220,7 +219,7 @@ class TestOperatorConstruction:
 
     @pytest.mark.tf
     @pytest.mark.parametrize("params, exp_batch_size", broadcasted_params_test_data)
-    def test_broadcasted_params(self, params, exp_batch_size):
+    def test_broadcasted_params_tf(self, params, exp_batch_size):
         r"""Test that initialization of an operator with broadcasted parameters
         works and sets the ``batch_size`` correctly with TensorFlow parameters."""
         import tensorflow as tf
@@ -237,7 +236,7 @@ class TestOperatorConstruction:
 
     @pytest.mark.torch
     @pytest.mark.parametrize("params, exp_batch_size", broadcasted_params_test_data)
-    def test_broadcasted_params(self, params, exp_batch_size):
+    def test_broadcasted_params_torch(self, params, exp_batch_size):
         r"""Test that initialization of an operator with broadcasted parameters
         works and sets the ``batch_size`` correctly with Torch parameters."""
         import torch
@@ -290,7 +289,7 @@ class TestOperatorConstruction:
             num_wires = 1
 
         op = DummyOp(wires=0)
-        op.name = "MyOp"
+        op.name = "MyOp"  # pylint: disable=attribute-defined-outside-init
         assert op.name == "MyOp"
 
     def test_default_hyperparams(self):
@@ -463,8 +462,8 @@ class TestOperatorConstruction:
                 return self._ndim_params
 
         def fun(x):
-            op0 = qml.RX(x, 0)
-            op1 = MyRX(x, 0)
+            _ = qml.RX(x, 0)
+            _ = MyRX(x, 0)
 
         # No kwargs
         fun0 = tf.function(fun)
@@ -652,7 +651,7 @@ class TestOperationConstruction:
         with pytest.raises(
             qml.operation.OperatorPropertyUndefined, match="DummyOp does not have parameter"
         ):
-            op.parameter_frequencies
+            _ = op.parameter_frequencies
 
     @pytest.mark.parametrize("num_param", [1, 2])
     def test_frequencies_parameter_dependent(self, num_param):
@@ -1075,7 +1074,7 @@ class TestInverse:
                 op = DummyOp(wires=[0]).inv()
             assert op.inverse is True
 
-        tape = qml.tape.QuantumScript.from_queue(q)
+        _ = qml.tape.QuantumScript.from_queue(q)
         assert op.inverse is True
 
     def test_inverse_integration(self):
@@ -1165,7 +1164,7 @@ class TestTensor:
             Tensor(X, Y)
 
         with pytest.warns(UserWarning, match="Tensor object acts on overlapping wires"):
-            op @ qml.PauliZ(1)
+            _ = op @ qml.PauliZ(1)
 
     def test_queuing_defined_outside(self):
         """Test the queuing of a Tensor object."""
@@ -1384,11 +1383,11 @@ class TestTensor:
 
         with pytest.raises(TypeError, match="unsupported operand type"):
             T = X @ Z
-            T @ Y
+            _ = T @ Y
 
         with pytest.raises(TypeError, match="unsupported operand type"):
             T = X @ Z
-            4 @ T
+            _ = 4 @ T
 
     def test_eigvals(self):
         """Test that the correct eigenvalues are returned for the Tensor"""
@@ -1521,7 +1520,7 @@ class TestTensor:
         with pytest.raises(NotImplementedError, match="wire_order"):
             O.matrix(wire_order=[1, 0])
 
-    def test_tensor_matrix_partial_wires_overlap_warning(self, tol):
+    def test_tensor_matrix_partial_wires_overlap_warning(self):
         """Tests that a warning is raised if the wires the factors in
         the tensor product act on have partial overlaps."""
         H = np.diag([1, 2, 3, 4])
@@ -1532,7 +1531,7 @@ class TestTensor:
             with pytest.warns(UserWarning, match="partially overlapping"):
                 O.matrix()
 
-    def test_tensor_matrix_too_large_warning(self, tol):
+    def test_tensor_matrix_too_large_warning(self):
         """Tests that a warning is raised if wires occur in multiple of the
         factors in the tensor product, leading to a wrongly-sized matrix."""
         O = qml.PauliX(0) @ qml.PauliX(1) @ qml.PauliX(0)
@@ -1580,7 +1579,7 @@ class TestTensor:
 
         O = tensor_observable
         for idx, obs in enumerate(O.non_identity_obs):
-            assert type(obs) == type(expected[idx])
+            assert isinstance(obs, type(expected[idx]))
             assert obs.wires == expected[idx].wires
 
     tensor_obs_pruning = [
@@ -1609,10 +1608,9 @@ class TestTensor:
     def test_prune(self, tensor_observable, expected):
         """Tests that the prune method returns the expected Tensor or single non-Tensor Observable."""
         O = tensor_observable
-        O_expected = expected
 
         O_pruned = O.prune()
-        assert type(O_pruned) == type(expected)
+        assert isinstance(O_pruned, type(expected))
         assert O_pruned.wires == expected.wires
 
     def test_prune_while_queuing_return_tensor(self):
@@ -1891,17 +1889,17 @@ class TestTensorObservableOperations:
         tensor = qml.PauliZ(0) @ qml.PauliX(1)
         A = [[1, 0], [0, -1]]
         with pytest.raises(TypeError, match="unsupported operand type"):
-            obs + A
+            _ = obs + A
         with pytest.raises(TypeError, match="unsupported operand type"):
-            tensor + A
+            _ = tensor + A
         with pytest.raises(TypeError, match="can't multiply sequence by non-int of type 'PauliZ'"):
-            obs * A
+            _ = obs * A
         with pytest.raises(TypeError, match="can't multiply sequence by non-int of type 'Tensor'"):
-            A * tensor
+            _ = A * tensor
         with pytest.raises(TypeError, match="unsupported operand type"):
-            obs - A
+            _ = obs - A
         with pytest.raises(TypeError, match="unsupported operand type"):
-            tensor - A
+            _ = tensor - A
 
 
 # Dummy class inheriting from Operator
@@ -2254,13 +2252,12 @@ def test_docstring_example_of_operator_class(tol):
     Operator class docstring, as well as in the 'adding_operators'
     page in the developer guide."""
 
-    import pennylane as qml
-
     class FlipAndRotate(qml.operation.Operation):
 
         num_wires = qml.operation.AnyWires
         grad_method = "A"
 
+        # pylint: disable=too-many-arguments
         def __init__(self, angle, wire_rot, wire_flip=None, do_flip=False, do_queue=True, id=None):
 
             if do_flip and wire_flip is None:

--- a/tests/tests_passing_pylint.txt
+++ b/tests/tests_passing_pylint.txt
@@ -2,3 +2,4 @@ tests/data/test_dataset.py
 tests/data/test_dataset_access.py
 tests/ops/op_math/test_controlled_ops.py
 tests/ops/op_math/test_controlled.py
+tests/test_operation.py


### PR DESCRIPTION
**Context:**
If we have two objects with both the `__add__` and `__radd__` method, when summing A + B , `B.__radd__` is ONLY called if `A.__add__` returns `NotImplemented`

**Description of the Change:**
Return `NotImplemented` in all dunder methods. This allows for `B.__radd__` to be called.

Fixes https://github.com/PennyLaneAI/pennylane/issues/3627
