### PR TITLE
add matrix to BasisState operation

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -166,6 +166,9 @@
   keyword argument to specify that the contents of the file being read should be directly assigned to an attribute.
   [(#3605)](https://github.com/PennyLaneAI/pennylane/pull/3605)
 
+* Added the `matrix()` method to `qml.BasisState`.
+  [(#3633)](https://github.com/PennyLaneAI/pennylane/pull/3633)
+
 <h3>Breaking changes</h3>
 
 * The target wires of the unitary for `ControlledQubitUnitary` are no longer available via `op.hyperparameters["u_wires"]`. 

--- a/pennylane/ops/qubit/state_preparation.py
+++ b/pennylane/ops/qubit/state_preparation.py
@@ -96,17 +96,17 @@ class BasisState(Operation):
         """Returns a ket vector representing the state being created."""
         if wire_order is None:
             num_wires = len(self.wires)
-            indices = np.array(self.parameters[0])
+            indices = list(self.parameters[0])
         else:
-            wires = Wires(wire_order)
-            if not wires.contains_wires(self.wires):
+            new_wires = Wires(wire_order)
+            if not new_wires.contains_wires(self.wires):
                 raise WireError("Custom wire_order must contain all BasisState wires")
-            num_wires = len(wires)
+            num_wires = len(new_wires)
             indices = [0] * num_wires
-            for wire_idx, value in zip(self.wires, self.parameters[0]):
-                indices[wires.index(wire_idx)] = value
+            for base_wire_label, value in zip(self.wires, self.parameters[0]):
+                indices[new_wires.index(base_wire_label)] = value
 
-        ket = np.zeros(2**num_wires, dtype="complex128")
+        ket = np.zeros(2**num_wires)
         ket[np.ravel_multi_index(indices, [2] * num_wires)] = 1
         return convert_like(ket, self.parameters[0])
 

--- a/pennylane/ops/qubit/state_preparation.py
+++ b/pennylane/ops/qubit/state_preparation.py
@@ -56,6 +56,7 @@ class BasisState(Operation):
     >>> print(example_circuit())
     [0.+0.j 0.+0.j 0.+0.j 1.+0.j]
     """
+    has_matrix = True
     num_wires = AnyWires
     num_params = 1
     """int: Number of trainable parameters that the operator depends on."""
@@ -89,11 +90,6 @@ class BasisState(Operation):
 
         """
         return [BasisStatePreparation(n, wires)]
-
-    # pylint:disable=arguments-renamed,invalid-overridden-method
-    @property
-    def has_matrix(self):
-        return True
 
     def matrix(self, wire_order=None):
         """Returns a ket vector representing the state being created."""

--- a/pennylane/ops/qubit/state_preparation.py
+++ b/pennylane/ops/qubit/state_preparation.py
@@ -90,7 +90,7 @@ class BasisState(Operation):
         """
         return [BasisStatePreparation(n, wires)]
 
-    # pylint:disable=invalid-overridden-method
+    # pylint:disable=arguments-renamed,invalid-overridden-method
     @property
     def has_matrix(self):
         return True

--- a/pennylane/ops/qubit/state_preparation.py
+++ b/pennylane/ops/qubit/state_preparation.py
@@ -17,6 +17,7 @@ with preparing a certain state on the device.
 """
 # pylint:disable=abstract-method,arguments-differ,protected-access,no-member
 from pennylane import numpy as np
+from pennylane.math import convert_like
 from pennylane.operation import AnyWires, Operation
 from pennylane.templates.state_preparations import BasisStatePreparation, MottonenStatePreparation
 from pennylane.wires import Wires, WireError
@@ -95,7 +96,7 @@ class BasisState(Operation):
         """Returns a ket vector representing the state being created."""
         if wire_order is None:
             num_wires = len(self.wires)
-            indices = self.parameters[0]
+            indices = np.array(self.parameters[0])
         else:
             wires = Wires(wire_order)
             if not wires.contains_wires(self.wires):
@@ -107,7 +108,7 @@ class BasisState(Operation):
 
         ket = np.zeros(2**num_wires, dtype="complex128")
         ket[np.ravel_multi_index(indices, [2] * num_wires)] = 1
-        return ket
+        return convert_like(ket, self.parameters[0])
 
 
 class QubitStateVector(Operation):

--- a/tests/ops/qubit/test_state_prep.py
+++ b/tests/ops/qubit/test_state_prep.py
@@ -18,7 +18,7 @@ import pytest
 
 import pennylane as qml
 from pennylane import numpy as np
-from pennylane.wires import Wires, WireError
+from pennylane.wires import WireError
 
 
 densitymat0 = np.array([[1.0, 0.0], [0.0, 0.0]])
@@ -125,4 +125,4 @@ class TestMatrix:
 
     def test_has_matrix(self):
         """Tests that has_matrix is always True for BasisState."""
-        assert qml.BasisState([0, 1], wires=[0, 1]).has_matrix is True
+        assert qml.BasisState.has_matrix is True

--- a/tests/ops/qubit/test_state_prep.py
+++ b/tests/ops/qubit/test_state_prep.py
@@ -117,13 +117,13 @@ class TestMatrix:
         ket[one_position] = 0  # everything else should be zero, as we assert below
         assert np.allclose(np.zeros(2**num_wires), ket)
 
-    def test_BasisState_preserves_parameter_type(self):
-        """Tests that given a Torch tensor, the result is also a Torch tensor."""
-        import torch
-
-        basis_op = qml.BasisState(torch.tensor([0, 1]), wires=[1, 2])
-        assert isinstance(basis_op.matrix(), torch.Tensor)
-        assert isinstance(basis_op.matrix(wire_order=[0, 1, 2]), torch.Tensor)
+    @pytest.mark.all_interfaces
+    @pytest.mark.parametrize("interface", ["numpy", "jax", "torch", "tensorflow"])
+    def test_BasisState_preserves_parameter_type(self, interface):
+        """Tests that given an array of some type, the resulting matrix is also that type."""
+        basis_op = qml.BasisState(qml.math.array([0, 1], like=interface), wires=[1, 2])
+        assert qml.math.get_interface(basis_op.matrix()) == interface
+        assert qml.math.get_interface(basis_op.matrix(wire_order=[0, 1, 2])) == interface
 
     def test_BasisState_matrix_bad_wire_order(self):
         """Tests that the provided wire_order must contain the wires in the operation."""

--- a/tests/ops/qubit/test_state_prep.py
+++ b/tests/ops/qubit/test_state_prep.py
@@ -51,11 +51,11 @@ def test_labelling_matrix_cache(op, mat, base):
     assert op.label() == base
 
     cache = {"matrices": []}
-    assert op.label(cache=cache) == base + "(M0)"
+    assert op.label(cache=cache) == f"{base}(M0)"
     assert qml.math.allclose(cache["matrices"][0], mat)
 
     cache = {"matrices": [0, mat, 0]}
-    assert op.label(cache=cache) == base + "(M1)"
+    assert op.label(cache=cache) == f"{base}(M1)"
     assert len(cache["matrices"]) == 3
 
 
@@ -116,6 +116,14 @@ class TestMatrix:
         assert ket[one_position] == 1
         ket[one_position] = 0  # everything else should be zero, as we assert below
         assert np.allclose(np.zeros(2**num_wires), ket)
+
+    def test_BasisState_preserves_parameter_type(self):
+        """Tests that given a Torch tensor, the result is also a Torch tensor."""
+        import torch
+
+        basis_op = qml.BasisState(torch.tensor([0, 1]), wires=[1, 2])
+        assert isinstance(basis_op.matrix(), torch.Tensor)
+        assert isinstance(basis_op.matrix(wire_order=[0, 1, 2]), torch.Tensor)
 
     def test_BasisState_matrix_bad_wire_order(self):
         """Tests that the provided wire_order must contain the wires in the operation."""

--- a/tests/ops/qubit/test_state_prep.py
+++ b/tests/ops/qubit/test_state_prep.py
@@ -18,7 +18,7 @@ import pytest
 
 import pennylane as qml
 from pennylane import numpy as np
-from pennylane.wires import Wires
+from pennylane.wires import Wires, WireError
 
 
 densitymat0 = np.array([[1.0, 0.0], [0.0, 0.0]])
@@ -93,3 +93,36 @@ class TestDecomposition:
 
         op = qml.QubitStateVector(U, wires=wires)
         assert op.batch_size == 3
+
+
+class TestMatrix:
+    """Test the matrix() method of various state-prep operations."""
+
+    @pytest.mark.parametrize(
+        "num_wires,wire_order,one_position",
+        [
+            (2, None, 1),
+            (2, [1, 2], 1),
+            (3, [0, 1, 2], 1),
+            (3, ["a", 1, 2], 1),
+            (3, [1, 2, 0], 2),
+            (3, [1, 2, "a"], 2),
+        ],
+    )
+    def test_BasisState_matrix(self, num_wires, wire_order, one_position):
+        """Tests that BasisState matrix returns kets as expected."""
+        basis_op = qml.BasisState([0, 1], wires=[1, 2])
+        ket = basis_op.matrix(wire_order=wire_order)
+        assert ket[one_position] == 1
+        ket[one_position] = 0  # everything else should be zero, as we assert below
+        assert np.allclose(np.zeros(2**num_wires), ket)
+
+    def test_BasisState_matrix_bad_wire_order(self):
+        """Tests that the provided wire_order must contain the wires in the operation."""
+        basis_op = qml.BasisState([0, 1], wires=[0, 1])
+        with pytest.raises(WireError, match="wire_order must contain all BasisState wires"):
+            basis_op.matrix(wire_order=[1, 2])
+
+    def test_has_matrix(self):
+        """Tests that has_matrix is always True for BasisState."""
+        assert qml.BasisState([0, 1], wires=[0, 1]).has_matrix is True


### PR DESCRIPTION
**Context:**
Prep operations should have a matrix representation that is a ket vector.

**Description of the Change:**
Adds `matrix()` and `has_matrix` to `qml.BasisState`

**Benefits:**
The `BasisState` operation can be used in matrix multiplication during computations. This is primarily for use by simulators, and should be useful for any simulator.

**Related GitHub Issues:**
I first attempted something to a similar effect in #3626, but this approach makes more sense.