### PR TITLE
Add DefaultPulse device

### DIFF
--- a/pennylane/devices/__init__.py
+++ b/pennylane/devices/__init__.py
@@ -30,6 +30,7 @@ to verify and test quantum gradient computations.
     default_gaussian
     default_mixed
     default_qutrit
+    default_pulse
     tests
 """
 # DefaultQubitTF and DefaultQubitAutograd not imported here since this
@@ -38,4 +39,5 @@ to verify and test quantum gradient computations.
 from .default_qubit import DefaultQubit
 from .default_gaussian import DefaultGaussian
 from .default_mixed import DefaultMixed
+from .default_pulse import DefaultPulse
 from .null_qubit import NullQubit

--- a/pennylane/devices/default_pulse.py
+++ b/pennylane/devices/default_pulse.py
@@ -1,0 +1,54 @@
+# Copyright 2018-2023 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+r"""
+The default.pulse device builds on PennyLane's standard qubit-based device, adding support for
+pulse-based circuits.
+"""
+import numpy as np
+
+from .._version import __version__
+from .default_qubit import DefaultQubit
+
+
+class DefaultPulse(DefaultQubit):
+    """Default pulses device for PennyLane.
+
+    Args:
+        wires (int, Iterable[Number, str]): Number of subsystems represented by the device,
+            or iterable that contains unique labels for the subsystems as numbers (i.e., ``[-1, 0, 2]``)
+            or strings (``['ancilla', 'q1', 'q2']``). Default 1 if not specified.
+        shots (None, int): How many times the circuit should be evaluated (or sampled) to estimate
+            the expectation values. Defaults to ``None`` if not specified, which means that the device
+            returns analytical results.
+        dt (float): the time step used by the differential equation solver to evolve the
+             time-dependent Hamiltonian.
+        dim (int): dimensions of the system (2 for qubits, 3 for qutrits, etc)
+        drift(Operator): optional Hamiltonian term representing a constant drift term for the system Hamiltonian
+    """
+
+    name = "Default PennyLane plugin for pulses"
+    short_name = "default.pulse"
+    pennylane_requires = __version__
+    version = __version__
+    author = "Xanadu Inc."
+
+    def __init__(self, wires, *, shots=None, analytic=None, dt=1e-5, dim=2, drift=None):
+        r_dtype = np.float64
+        c_dtype = np.complex128
+
+        self.dt = dt
+        self.dim = dim
+        self.drift = drift
+
+        super().__init__(wires, shots=shots, r_dtype=r_dtype, c_dtype=c_dtype, analytic=analytic)

--- a/pennylane/devices/default_pulse.py
+++ b/pennylane/devices/default_pulse.py
@@ -15,7 +15,6 @@ r"""
 The default.pulse device builds on PennyLane's standard qubit-based device, adding support for
 pulse-based circuits.
 """
-import numpy as np
 
 from .._version import __version__
 from .default_qubit_jax import DefaultQubitJax

--- a/pennylane/devices/default_pulse.py
+++ b/pennylane/devices/default_pulse.py
@@ -21,7 +21,7 @@ from .._version import __version__
 from .default_qubit import DefaultQubit
 
 
-class DefaultPulse(DefaultQubit):
+class DefaultPulse(DefaultQubitJax):
     """Default pulses device for PennyLane.
 
     Args:

--- a/pennylane/devices/default_pulse.py
+++ b/pennylane/devices/default_pulse.py
@@ -18,7 +18,7 @@ pulse-based circuits.
 import numpy as np
 
 from .._version import __version__
-from .default_qubit import DefaultQubit
+from .default_qubit_jax import DefaultQubitJax
 
 
 class DefaultPulse(DefaultQubitJax):

--- a/pennylane/devices/default_pulse.py
+++ b/pennylane/devices/default_pulse.py
@@ -44,11 +44,9 @@ class DefaultPulse(DefaultQubitJax):
     author = "Xanadu Inc."
 
     def __init__(self, wires, *, shots=None, analytic=None, dt=1e-5, dim=2, drift=None):
-        r_dtype = np.float64
-        c_dtype = np.complex128
 
         self.dt = dt
         self.dim = dim
         self.drift = drift
 
-        super().__init__(wires, shots=shots, r_dtype=r_dtype, c_dtype=c_dtype, analytic=analytic)
+        super().__init__(wires, shots=shots, analytic=analytic)

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# pylint: disable=missing-module-docstring
+# pylint: disable=unspecified-encoding
+# pylint: disable=consider-using-with
+# pylint: disable=unspecific-encoding
+
 from setuptools import setup, find_packages
 
 with open("pennylane/_version.py") as f:
@@ -53,6 +58,7 @@ info = {
             "default.mixed = pennylane.devices.default_mixed:DefaultMixed",
             "null.qubit = pennylane.devices.null_qubit:NullQubit",
             "default.qutrit = pennylane.devices.default_qutrit:DefaultQutrit",
+            "default.pulse = pennylane.devices.default_pulse:DefaultPulse",
         ],
         "console_scripts": ["pl-device-test=pennylane.devices.tests:cli"],
     },

--- a/tests/devices/test_default_pulse.py
+++ b/tests/devices/test_default_pulse.py
@@ -1,0 +1,33 @@
+# Copyright 2018-2023 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Unit tests for the :mod:`pennylane.plugin.PulseQubit` device.
+"""
+
+import pytest
+import numpy as np
+import pennylane as qml
+
+
+def test_initialization():
+    device = qml.DefaultPulse(
+        wires=[0, 1], shots=1000, dt=1e-3, dim=3, drift=2 * qml.PauliX(0) + qml.PauliY(1)
+    )
+    assert device.shots == 1000
+    assert device.dt == 1e-3
+    assert device.dim == 3
+    assert qml.equal(device.drift, 2 * qml.PauliX(0) + qml.PauliY(1))
+
+    assert device.r_dtype == np.float64
+    assert device.c_dtype == np.complex128


### PR DESCRIPTION
Set up dummy device (currently default.qubit with addition of `dt`, `dim` and `drift` attributes) as first step in a device to support pulse programming