### PR TITLE
More specific representation for GellMann ops

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -180,6 +180,9 @@
   of the other class to be called.
   [(#3631)](https://github.com/PennyLaneAI/pennylane/pull/3631)
 
+* The GellMann operators now include their index in the displayed representation.
+  [(#3641)](https://github.com/PennyLaneAI/pennylane/pull/3641)
+
 <h3>Breaking changes</h3>
 
 * The target wires of the unitary for `ControlledQubitUnitary` are no longer available via `op.hyperparameters["u_wires"]`.

--- a/pennylane/ops/qutrit/observables.py
+++ b/pennylane/ops/qutrit/observables.py
@@ -216,7 +216,7 @@ class GellMann(Observable):
         super().__init__(wires=wires, do_queue=do_queue, id=id)
 
     def label(self, decimals=None, base_label=None, cache=None):
-        return base_label or "GellMann(" + str(self.hyperparameters["index"]) + ")"
+        return base_label or f"GellMann({self.hyperparameters['index']})"
 
     def __repr__(self):
         return f"GellMann{self.hyperparameters['index']}(wires=[{self.wires[0]}])"

--- a/pennylane/ops/qutrit/observables.py
+++ b/pennylane/ops/qutrit/observables.py
@@ -218,6 +218,9 @@ class GellMann(Observable):
     def label(self, decimals=None, base_label=None, cache=None):
         return base_label or "GellMann(" + str(self.hyperparameters["index"]) + ")"
 
+    def __repr__(self):
+        return f"GellMann{self.hyperparameters['index']}(wires=[{self.wires[0]}])"
+
     _eigvecs = {
         1: np.array(
             [[1 / np.sqrt(2), -1 / np.sqrt(2), 0], [1 / np.sqrt(2), 1 / np.sqrt(2), 0], [0, 0, 1]],

--- a/tests/ops/qutrit/test_qutrit_observables.py
+++ b/tests/ops/qutrit/test_qutrit_observables.py
@@ -392,7 +392,7 @@ class TestGellMann:
 
     @pytest.mark.parametrize("index", list(range(1, 9)))
     def test_repr(self, index):
-        """Test that the __repr__ method si correct"""
+        """Test that the __repr__ method is correct"""
 
         rep = f"GellMann{index}(wires=[0])"
         obs = qml.GellMann(wires=0, index=index)

--- a/tests/ops/qutrit/test_qutrit_observables.py
+++ b/tests/ops/qutrit/test_qutrit_observables.py
@@ -389,3 +389,12 @@ class TestGellMann:
 
         assert obs.label() == label
         assert obs.label(decimals=2) == label
+
+    @pytest.mark.parametrize("index", list(range(1, 9)))
+    def test_repr(self, index):
+        """Test that the __repr__ method si correct"""
+
+        rep = f"GellMann{index}(wires=[0])"
+        obs = qml.GellMann(wires=0, index=index)
+
+        assert repr(obs) == rep

--- a/tests/ops/qutrit/test_qutrit_observables.py
+++ b/tests/ops/qutrit/test_qutrit_observables.py
@@ -14,12 +14,13 @@
 """Unit tests for qutrit observables."""
 import functools
 from unittest.mock import PropertyMock, patch
-
 import pytest
-import pennylane as qml
 import numpy as np
 from gate_data import GELL_MANN
 
+import pennylane as qml
+
+# pylint: disable=protected-access, unused-argument
 
 # Hermitian matrices, their corresponding eigenvalues and eigenvectors.
 EIGVALS_TEST_DATA = [
@@ -72,7 +73,7 @@ class TestTHermitian:
 
     def setup_method(self):
         """Patch the _eigs class attribute of the Hermitian class before every test."""
-        self.patched_eigs = patch(
+        self.patched_eigs = patch(  # pylint: disable=attribute-defined-outside-init
             "pennylane.ops.qutrit.observables.THermitian._eigs", PropertyMock(return_value={})
         )
         self.patched_eigs.start()

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -28,7 +28,8 @@ from pennylane.operation import Operation, Operator, Tensor, operation_derivativ
 from pennylane.ops import Prod, SProd, Sum, cv
 from pennylane.wires import Wires
 
-# pylint: disable=no-self-use, no-member, protected-access, redefined-outer-name, too-few-public-methods, too-many-public-methods, unused-argument
+# pylint: disable=no-self-use, no-member, protected-access, redefined-outer-name, too-few-public-methods
+# pylint: disable=too-many-public-methods, unused-argument, unnecessary-lambda-assignment
 
 Toffoli_broadcasted = np.tensordot([0.1, -4.2j], Toffoli, axes=0)
 CNOT_broadcasted = np.tensordot([1.4], CNOT, axes=0)

--- a/tests/tests_passing_pylint.txt
+++ b/tests/tests_passing_pylint.txt
@@ -4,3 +4,4 @@ tests/ops/op_math/test_controlled_ops.py
 tests/ops/op_math/test_controlled.py
 tests/ops/op_math/test_dot.py
 tests/test_operation.py
+tests/ops/qutrit/test_qutrit_observables.py


### PR DESCRIPTION
**Context:**
Currently, when initializing GellMann operators, the representation that is displayed does not include the index of the GellMann operator, so it is unclear what operation is being performed.  

```
coeffs = [2, f1]
obs = [qml.GellMann(wires=0, index=1), qml.GellMann(wires=0, index=2)]
H = ParametrizedHamiltonian(coeffs, obs)
H(2, 4)
>>>(2*(GellMann(wires=[0]))) + (10*(GellMann(wires=[0])))
```

**Description of the Change:**
A `__repr__` method is added to specify how to display the operators. The behaviour is now:

```
H(2, 4)
>>>(2*(GellMann1(wires=[0]))) + (10*(GellMann2(wires=[0])))
```
