### PR TITLE
Set `Tensor._batch_size` to None

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -231,7 +231,7 @@
 * `Dataset.write()` now ensures that any lazy-loaded values are loaded before they are written to a file.
   [(#3605)](https://github.com/PennyLaneAI/pennylane/pull/3605)
 
-* Set `Tensor._batch_size` to None during initialization..
+* Set `Tensor._batch_size` to None during initialization.
   [(#3642)](https://github.com/PennyLaneAI/pennylane/pull/3642)
 
 <h3>Contributors</h3>

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -231,6 +231,9 @@
 * `Dataset.write()` now ensures that any lazy-loaded values are loaded before they are written to a file.
   [(#3605)](https://github.com/PennyLaneAI/pennylane/pull/3605)
 
+* Set `Tensor._batch_size` to None during initialization..
+  [(#3642)](https://github.com/PennyLaneAI/pennylane/pull/3642)
+
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -1823,6 +1823,7 @@ class Tensor(Observable):
         self._eigvals_cache = None
         self.obs: List[Observable] = []
         self._args = args
+        self._batch_size = None
         self.queue(init=True)
 
     def label(self, decimals=None, base_label=None, cache=None):

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -1278,6 +1278,13 @@ class TestTensor:
         t = Tensor(X, Y)
         assert t.name == [X.name, Y.name]
 
+    def test_batch_size(self):
+        """Test that the batch_size attribute of the Tensor is initialized as None."""
+        X = qml.PauliX(0)
+        Y = qml.PauliY(2)
+        t = Tensor(X, Y)
+        assert t.batch_size is None
+
     def test_num_wires(self):
         """Test that the correct number of wires is returned"""
         p = np.eye(4)


### PR DESCRIPTION
Set `Tensor._batch_size` to None in `__init__` to avoid getting an error when calling this attribute.
