### PR TITLE
introduce StatePrepInterface for state-prep ops

### DIFF
--- a/pennylane/ops/qubit/state_preparation.py
+++ b/pennylane/ops/qubit/state_preparation.py
@@ -15,11 +15,32 @@
 This submodule contains the discrete-variable quantum operations concerned
 with preparing a certain state on the device.
 """
-# pylint:disable=abstract-method,arguments-differ,protected-access,no-member
+# pylint:disable=arguments-differ
+from abc import ABC, abstractmethod
+
 from pennylane.operation import AnyWires, Operation
 from pennylane.templates.state_preparations import BasisStatePreparation, MottonenStatePreparation
 
 state_prep_ops = {"BasisState", "QubitStateVector", "QubitDensityMatrix"}
+
+
+class StatePrepInterface(ABC):  # pylint:disable=too-few-public-methods
+    """An interface for state-prep operations."""
+
+    @abstractmethod
+    def state_vector(self, wire_order=None, interface="autograd"):
+        """
+        Returns a vector to be used as an initial state for a circuit.
+
+        Args:
+            wire_order (Iterable): global wire order, must contain all wire labels
+                from the operator's wires
+            interface (str): The name of the machine learning framework to use.
+                Will be determined automatically if not provided
+
+        Returns:
+            array: A state vector for all wires in a circuit
+        """
 
 
 class BasisState(Operation):

--- a/tests/ops/qubit/test_state_prep.py
+++ b/tests/ops/qubit/test_state_prep.py
@@ -77,6 +77,17 @@ class TestStatePrepInterface:
         prep_op = DefaultPrep([1, 0], wires=[0])
         assert np.array_equal(prep_op.state_vector(), [1, 0])
 
+    def test_child_must_implement_state_vector(self):
+        """Tests that a child class that does not implement state_vector fails."""
+
+        class NoStatePrepOp(Operation, qml.ops.qubit.StatePrepInterface):
+            """A dummy class that assumes it was given a state vector."""
+
+            num_wires = AllWires
+
+        with pytest.raises(TypeError, match="Can't instantiate abstract class"):
+            NoStatePrepOp(wires=[0])
+
 
 class TestDecomposition:
     def test_BasisState_decomposition(self):

--- a/tests/ops/qubit/test_state_prep.py
+++ b/tests/ops/qubit/test_state_prep.py
@@ -18,7 +18,7 @@ import pytest
 
 import pennylane as qml
 from pennylane import numpy as np
-from pennylane.wires import Wires
+from pennylane.operation import Operation, AllWires
 
 
 densitymat0 = np.array([[1.0, 0.0], [0.0, 0.0]])
@@ -51,12 +51,31 @@ def test_labelling_matrix_cache(op, mat, base):
     assert op.label() == base
 
     cache = {"matrices": []}
-    assert op.label(cache=cache) == base + "(M0)"
+    assert op.label(cache=cache) == f"{base}(M0)"
     assert qml.math.allclose(cache["matrices"][0], mat)
 
     cache = {"matrices": [0, mat, 0]}
-    assert op.label(cache=cache) == base + "(M1)"
+    assert op.label(cache=cache) == f"{base}(M1)"
     assert len(cache["matrices"]) == 3
+
+
+class TestStatePrepInterface:
+    """Test the StatePrepInterface class."""
+
+    # pylint:disable=unused-argument,too-few-public-methods
+    def test_basic_stateprep(self):
+        """Tests a basic implementation of the StatePrepInterface."""
+
+        class DefaultPrep(Operation, qml.ops.qubit.StatePrepInterface):
+            """A dummy class that assumes it was given a state vector."""
+
+            num_wires = AllWires
+
+            def state_vector(self, wire_order=None, interface="autograd"):
+                return self.parameters[0]
+
+        prep_op = DefaultPrep([1, 0], wires=[0])
+        assert np.array_equal(prep_op.state_vector(), [1, 0])
 
 
 class TestDecomposition:


### PR DESCRIPTION
**Context:**
StatePrep operators are special in that their intended use is to create a state-vector, rather than a matrix representation. This interface should exist so that state-prep operators can inherit it and gain some typing benefits. There was some discussion in which we called this a mixin, but it's more of an interface. The difference is semantic and nit-picky but I figured I should be as accurate as I can. Then again, "interface" means something else in PennyLane...

**Description of the Change:**
Introduces the `StatePrepInterface` class for state-prep operators to inherit from. The class is an interface that requires child classes to implement the `state_vector` method.

**Benefits:**
State-prep operators will be identifiable by their type, and will follow a standardized interface for returning a state-vector.

**Possible Drawbacks:**
More abstract code? It's a small change, I think it will bring value.

**Related GitHub Issues:**
Open PRs that will need updating once this is in: #3633, #3635 