### PR TITLE
`QubitUnitary`: Cast input matrix to tensor.

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -184,8 +184,8 @@
           [ 0.   +0.j   ,  0.   +0.j   ,  0.   +0.j   , -0.438+0.899j]])
   ```
   
-* Added `ParametrizedHamiltonian`, a callable that holds information representing a linear combination of operators 
-  with parametrized coefficents. The `ParametrizedHamiltonian` can be passed parameters to create the `Operator` for 
+* Added `ParametrizedHamiltonian`, a callable that holds information representing a linear combination of operators
+  with parametrized coefficents. The `ParametrizedHamiltonian` can be passed parameters to create the `Operator` for
   the specified parameters.
   [(#3617)](https://github.com/PennyLaneAI/pennylane/pull/3617)
   
@@ -199,6 +199,7 @@
 
   H =  2 * XX + f1 * YY + f2 * ZZ
   ```
+
   ```pycon
   >>> H
   ParametrizedHamiltonian: terms=3
@@ -206,6 +207,7 @@
   >>> H(params, t=0.5)
   (2*(PauliX(wires=[1]) @ PauliX(wires=[1]))) + ((-0.2876553535461426*(PauliY(wires=[0]) @ PauliY(wires=[0]))) + (1.5179612636566162*(PauliZ(wires=[0]) @ PauliZ(wires=[1]))))
   ```
+
   The same `ParametrizedHamiltonian` can also be constructed via a list of coefficients and operators:
 
   ```pycon
@@ -281,7 +283,7 @@
 * `Operator.inv()` and the `Operator.inverse` setter are removed. Please use `qml.adjoint` or `qml.pow` instead.
   [(#3618)](https://github.com/PennyLaneAI/pennylane/pull/3618)
   
-  Instead of 
+  Instead of
   
   >>> qml.PauliX(0).inv()
   
@@ -346,6 +348,9 @@
 
 * Set `Tensor.has_matrix` to `True`.
   [(#3647)](https://github.com/PennyLaneAI/pennylane/pull/3647)
+
+* Cast the input matrix `U` of `QubitUnitary` to a tensor using `qml.math.array`.
+  [(#3658)](https://github.com/PennyLaneAI/pennylane/pull/3658)
 
 <h3>Contributors</h3>
 

--- a/pennylane/ops/qubit/matrix_ops.py
+++ b/pennylane/ops/qubit/matrix_ops.py
@@ -104,7 +104,7 @@ class QubitUnitary(Operation):
                 UserWarning,
             )
 
-        U = qml.math.array(U)  # cast U to a tensor
+        U = np.array(U)  # cast U to a tensor
 
         super().__init__(U, wires=wires, do_queue=do_queue, id=id)
 

--- a/pennylane/ops/qubit/matrix_ops.py
+++ b/pennylane/ops/qubit/matrix_ops.py
@@ -104,7 +104,8 @@ class QubitUnitary(Operation):
                 UserWarning,
             )
 
-        U = np.array(U)  # cast U to a tensor
+        if isinstance(U, list):
+            U = np.array(U)  # cast U to a tensor
 
         super().__init__(U, wires=wires, do_queue=do_queue, id=id)
 

--- a/pennylane/ops/qubit/matrix_ops.py
+++ b/pennylane/ops/qubit/matrix_ops.py
@@ -104,6 +104,8 @@ class QubitUnitary(Operation):
                 UserWarning,
             )
 
+        U = qml.math.array(U)  # cast U to a tensor
+
         super().__init__(U, wires=wires, do_queue=do_queue, id=id)
 
     @staticmethod

--- a/tests/ops/qubit/test_matrix_ops.py
+++ b/tests/ops/qubit/test_matrix_ops.py
@@ -174,7 +174,7 @@ class TestQubitUnitary:
         out = qml.QubitUnitary(U, wires=range(num_wires)).matrix()
 
         # verify output type
-        assert isinstance(out, tf.Tensor)
+        assert isinstance(out, tf.Variable)
 
         # verify equivalent to input state
         assert qml.math.allclose(out, U)

--- a/tests/ops/qubit/test_matrix_ops.py
+++ b/tests/ops/qubit/test_matrix_ops.py
@@ -91,6 +91,14 @@ class TestQubitUnitary:
 
         assert qml.math.allclose(mat_to_pow, new_mat)
 
+    def test_qubit_unitary_input_casted_to_array(self):
+        """Test that the matrix passed to ``QubitUnitary`` is casted to a numpy array."""
+        U = [[1, 0], [0, 1]]
+        unitary = qml.QubitUnitary(U, wires=0)
+
+        assert isinstance(unitary.parameters[0], np.ndarray)
+        assert isinstance(unitary.matrix(), np.ndarray)
+
     @pytest.mark.autograd
     @pytest.mark.parametrize(
         "U,num_wires", [(H, 1), (np.kron(H, H), 2), (np.tensordot([1j, -1, 1], H, axes=0), 1)]
@@ -166,7 +174,7 @@ class TestQubitUnitary:
         out = qml.QubitUnitary(U, wires=range(num_wires)).matrix()
 
         # verify output type
-        assert isinstance(out, tf.Variable)
+        assert isinstance(out, tf.Tensor)
 
         # verify equivalent to input state
         assert qml.math.allclose(out, U)


### PR DESCRIPTION
Use `qml.math.array` to cast the input matrix to a tensor.

Fixes https://github.com/PennyLaneAI/pennylane/issues/3653