### PR TITLE
Fix `_batch_size` of copies and wire mappings of `Tensor`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -341,8 +341,9 @@
 * `Dataset.write()` now ensures that any lazy-loaded values are loaded before they are written to a file.
   [(#3605)](https://github.com/PennyLaneAI/pennylane/pull/3605)
 
-* Set `Tensor._batch_size` to None during initialization.
+* Set `Tensor._batch_size` to None during initialization, copying and `map_wires`.
   [(#3642)](https://github.com/PennyLaneAI/pennylane/pull/3642)
+  [(#3661)](https://github.com/PennyLaneAI/pennylane/pull/3661)
 
 * Set `Tensor.has_matrix` to `True`.
   [(#3647)](https://github.com/PennyLaneAI/pennylane/pull/3647)

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -1860,6 +1860,7 @@ class Tensor(Observable):
         copied_op = cls.__new__(cls)  # pylint: disable=no-value-for-parameter
         copied_op.obs = self.obs.copy()
         copied_op._eigvals_cache = self._eigvals_cache
+        copied_op._batch_size = self._batch_size
         return copied_op
 
     def __repr__(self):
@@ -2254,6 +2255,7 @@ class Tensor(Observable):
         new_op = cls.__new__(cls)  # pylint: disable=no-value-for-parameter
         new_op.obs = [obs.map_wires(wire_map) for obs in self.obs]
         new_op._eigvals_cache = self._eigvals_cache
+        new_op._batch_size = self._batch_size
         return new_op
 
 

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -16,6 +16,7 @@ Unit tests for :mod:`pennylane.operation`.
 """
 import itertools
 from functools import reduce
+import copy
 
 import numpy as np
 import pytest
@@ -1621,6 +1622,18 @@ class TestTensor:
         with pytest.raises(ValueError, match="Can only compute"):
             t.sparse_matrix()
 
+    def test_copy(self):
+        """Test copying of a Tensor."""
+        tensor = Tensor(qml.PauliX(0), qml.PauliY(1), qml.PauliZ(2))
+        copied_tensor = copy.copy(tensor)
+        copied_tensor1 = tensor.__copy__()
+        for c in [copied_tensor, copied_tensor1]:
+            assert c is not tensor
+            assert c.wires == Wires([0, 1, 2])
+            assert c.batch_size == tensor.batch_size == None
+            for obs1, obs2 in zip(c.obs, tensor.obs):
+                assert qml.equal(obs1, obs2)
+
     def test_map_wires(self):
         """Test the map_wires method."""
         tensor = Tensor(qml.PauliX(0), qml.PauliY(1), qml.PauliZ(2))
@@ -1630,6 +1643,7 @@ class TestTensor:
         assert tensor is not mapped_tensor
         assert tensor.wires == Wires([0, 1, 2])
         assert mapped_tensor.wires == Wires([10, 11, 12])
+        assert mapped_tensor.batch_size == tensor.batch_size
         for obs1, obs2 in zip(mapped_tensor.obs, final_obs):
             assert qml.equal(obs1, obs2)
 


### PR DESCRIPTION
**Context:**
The `_batch_size` attribute of `Tensor` was not copied properly when using `Tensor.map_wires` or `Tensor.__copy__`

**Description of the Change:**
Change that.

**Benefits:**
The following works:
```pycon
>>> op = copy.copy(qml.PauliZ(0) @ qml.PauliX(1))
>>> op.batch_size
None
```

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
#3660
