### PR TITLE
Allow setting data on `qml.Hamiltonian` to update coefficients

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -378,6 +378,9 @@
 * Set `Tensor.has_matrix` to `True`.
   [(#3647)](https://github.com/PennyLaneAI/pennylane/pull/3647)
 
+* Fixed a bug in `qml.Hamiltonian` where setting the `data` attribute didn't update the Hamiltonian coefficients.
+  [(#)]()
+
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -379,7 +379,7 @@
   [(#3647)](https://github.com/PennyLaneAI/pennylane/pull/3647)
 
 * Fixed a bug in `qml.Hamiltonian` where setting the `data` attribute didn't update the Hamiltonian coefficients.
-  [(#)]()
+  [(#3668)](https://github.com/PennyLaneAI/pennylane/pull/3668)
 
 <h3>Contributors</h3>
 

--- a/pennylane/ops/qubit/hamiltonian.py
+++ b/pennylane/ops/qubit/hamiltonian.py
@@ -220,6 +220,27 @@ class Hamiltonian(Observable):
         return super().label(decimals=decimals, base_label=base_label or "𝓗", cache=cache)
 
     @property
+    def data(self):
+        """Return the operator data
+
+        Returns:
+            List[float]: coefficients in the Hamiltonian expression as a list
+        """
+        return self._data
+
+    @data.setter
+    def data(self, data):
+        """Set the operator data, and update the coefficients accordingly.
+
+        Raises:
+        ValueError: if the number of coefficients does not match the number of observables
+        """
+        if qml.math.shape(data)[0] != qml.math.shape(self._ops)[0]:
+            raise ValueError("The number of coefficients and operators does not match.")
+        self._data = list(data)
+        self._coeffs = qml.math.stack(data) if data else []
+
+    @property
     def coeffs(self):
         """Return the coefficients defining the Hamiltonian.
 
@@ -383,7 +404,7 @@ class Hamiltonian(Observable):
 
         # hotfix: We `self.data`, since `self.parameters` returns a copy of the data and is now returned in
         # self.terms(). To be improved soon.
-        self.data = new_coeffs
+        self._data = new_coeffs
         # hotfix: We overwrite the hyperparameter entry, which is now returned in self.terms().
         # To be improved soon.
         self.hyperparameters["ops"] = new_ops

--- a/pennylane/ops/qubit/hamiltonian.py
+++ b/pennylane/ops/qubit/hamiltonian.py
@@ -235,7 +235,7 @@ class Hamiltonian(Observable):
         Raises:
         ValueError: if the number of coefficients does not match the number of observables
         """
-        if qml.math.shape(data)[0] != qml.math.shape(self._ops)[0]:
+        if qml.math.shape(data)[0] != qml.math.shape(self.ops)[0]:
             raise ValueError("The number of coefficients and operators does not match.")
         self._data = list(data)
         self._coeffs = qml.math.stack(data) if data else []

--- a/tests/ops/qubit/test_hamiltonian.py
+++ b/tests/ops/qubit/test_hamiltonian.py
@@ -686,6 +686,21 @@ class TestHamiltonian:
         assert H.label() == "𝓗"
         assert H.label(decimals=2) == "𝓗"
 
+    @pytest.mark.parametrize("data", [(1.5, -2.0, 0.3), (1.0,), (0.5, -1.0, 1.4, 0.3)])
+    def test_data_setter(self, data):
+        """Tests that data and coefficients are set correctly when data is updated."""
+        H = qml.Hamiltonian((0.1, 0.2, 0.3), (qml.PauliZ(0), qml.PauliX(1), qml.PauliX(0)))
+        if len(data) != 3:
+            with pytest.raises(
+                ValueError, match="The number of coefficients and operators does not match"
+            ):
+                H.data = data
+
+        else:
+            H.data = data
+            assert H.data == list(data)
+            assert H.coeffs == list(data)
+
     @pytest.mark.parametrize("terms, string", zip(valid_hamiltonians, valid_hamiltonians_str))
     def test_hamiltonian_str(self, terms, string):
         """Tests that the __str__ function for printing is correct"""


### PR DESCRIPTION
**Context:**
Fixing a bug where updating the `data` attribute of a `qml.Hamiltonian` object didn't update its `coeffs` attribute.

**Description of the Change:**
Updated `qml.Hamiltonian` to use `data` as a property so that a setter can be used to update `data` and `coeffs` simultaneously.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
