### PR TITLE
Add warning for `get_operation`

### DIFF
--- a/pennylane/tape/qscript.py
+++ b/pennylane/tape/qscript.py
@@ -17,6 +17,7 @@ executed by a device.
 """
 # pylint: disable=too-many-instance-attributes, protected-access, too-many-public-methods
 
+import warnings
 import contextlib
 import copy
 from collections import Counter, defaultdict
@@ -550,18 +551,26 @@ class QuantumScript:
 
         self._trainable_params = sorted(set(param_indices))
 
-    def get_operation(self, idx):
+    def get_operation(self, idx, return_op_index=False):
         """Returns the trainable operation, and the corresponding operation argument
         index, for a specified trainable parameter index.
 
         Args:
             idx (int): the trainable parameter index
-
+            return_op_index (bool): the trainable parameter index
         Returns:
             tuple[.Operation, int]: tuple containing the corresponding
             operation, and an integer representing the argument index,
             for the provided trainable parameter.
         """
+        if not return_op_index:
+            warnings.warn(
+                "The get_operation will soon be updated to also return the index of the trainable operation in the tape."
+                "If you want to switch to the new behavior, you can pass `return_op_index==True`"
+            )
+        else:
+            return self._get_operation(idx)
+
         # get the index of the parameter in the script
         t_idx = self.trainable_params[idx]
 

--- a/pennylane/tape/qscript.py
+++ b/pennylane/tape/qscript.py
@@ -563,13 +563,12 @@ class QuantumScript:
             operation, and an integer representing the argument index,
             for the provided trainable parameter.
         """
-        if not return_op_index:
-            warnings.warn(
-                "The get_operation will soon be updated to also return the index of the trainable operation in the tape."
-                "If you want to switch to the new behavior, you can pass `return_op_index==True`"
-            )
-        else:
+        if return_op_index:
             return self._get_operation(idx)
+        warnings.warn(
+            "The get_operation will soon be updated to also return the index of the trainable operation in the tape."
+            "If you want to switch to the new behavior, you can pass `return_op_index=True`"
+        )
 
         # get the index of the parameter in the script
         t_idx = self.trainable_params[idx]

--- a/tests/tape/test_qscript.py
+++ b/tests/tape/test_qscript.py
@@ -233,29 +233,69 @@ class TestUpdate:
         m = [qml.expval(qml.Hermitian(2 * np.eye(2), wires=0))]
         qs = QuantumScript(ops, m)
 
-        op_0, p_id_0 = qs.get_operation(0)
-        assert op_0 == ops[0] and p_id_0 == 0
+        with pytest.warns(
+            UserWarning,
+            match="The get_operation will soon be updated to also return the index of the trainable operation in the tape.",
+        ):
+            op_0, p_id_0 = qs.get_operation(0)
+            assert op_0 == ops[0] and p_id_0 == 0
 
-        op_1, p_id_1 = qs.get_operation(1)
-        assert op_1 == ops[1] and p_id_1 == 0
+            op_1, p_id_1 = qs.get_operation(1)
+            assert op_1 == ops[1] and p_id_1 == 0
 
-        op_2, p_id_2 = qs.get_operation(2)
-        assert op_2 == ops[1] and p_id_2 == 1
+            op_2, p_id_2 = qs.get_operation(2)
+            assert op_2 == ops[1] and p_id_2 == 1
 
-        op_3, p_id_3 = qs.get_operation(3)
-        assert op_3 == ops[1] and p_id_3 == 2
+            op_3, p_id_3 = qs.get_operation(3)
+            assert op_3 == ops[1] and p_id_3 == 2
 
-        op_4, p_id_4 = qs.get_operation(4)
-        assert op_4 == ops[3] and p_id_4 == 0
+            op_4, p_id_4 = qs.get_operation(4)
+            assert op_4 == ops[3] and p_id_4 == 0
 
-        op_5, p_id_5 = qs.get_operation(5)
-        assert op_5 == ops[4] and p_id_5 == 0
+            op_5, p_id_5 = qs.get_operation(5)
+            assert op_5 == ops[4] and p_id_5 == 0
 
-        op_6, p_id_6 = qs.get_operation(6)
-        assert op_6 == ops[4] and p_id_6 == 1
+            op_6, p_id_6 = qs.get_operation(6)
+            assert op_6 == ops[4] and p_id_6 == 1
 
-        _, p_id_0 = qs.get_operation(7)
+            _, p_id_0 = qs.get_operation(7)
         assert p_id_0 == 0
+
+    def test_get_operation_return_index(self):
+        """Tests the tape method get_operation"""
+        ops = [
+            qml.RX(1.2, wires=0),
+            qml.Rot(2.3, 3.4, 5.6, wires=0),
+            qml.PauliX(wires=0),
+            qml.QubitUnitary(np.eye(2), wires=0),
+            qml.U2(-1, -2, wires=0),
+        ]
+        m = [qml.expval(qml.Hermitian(2 * np.eye(2), wires=0))]
+        qs = QuantumScript(ops, m)
+
+        op_0, op_id_0, p_id_0 = qs.get_operation(0, True)
+        assert op_0 == ops[0] and op_id_0 == 0 and p_id_0 == 0
+
+        op_1, op_id_1, p_id_1 = qs.get_operation(1, True)
+        assert op_1 == ops[1] and op_id_1 == 1 and p_id_1 == 0
+
+        op_2, op_id_2, p_id_2 = qs.get_operation(2, True)
+        assert op_2 == ops[1] and op_id_2 == 1 and p_id_2 == 1
+
+        op_3, op_id_3, p_id_3 = qs.get_operation(3, True)
+        assert op_3 == ops[1] and op_id_3 == 1 and p_id_3 == 2
+
+        op_4, op_id_4, p_id_4 = qs.get_operation(4, True)
+        assert op_4 == ops[3] and op_id_4 == 3 and p_id_4 == 0
+
+        op_5, op_id_5, p_id_5 = qs.get_operation(5, True)
+        assert op_5 == ops[4] and op_id_5 == 4 and p_id_5 == 0
+
+        op_6, op_id_6, p_id_6 = qs.get_operation(6, True)
+        assert op_6 == ops[4] and op_id_6 == 4 and p_id_6 == 1
+
+        _, obs_id_0, p_id_0 = qs.get_operation(7, True)
+        assert obs_id_0 == 0 and p_id_0 == 0
 
     def test_get_operation_(self):
         """Tests the tape method _get_operation"""
@@ -292,7 +332,6 @@ class TestUpdate:
 
         _, obs_id_0, p_id_0 = qs._get_operation(7)
         assert obs_id_0 == 0 and p_id_0 == 0
-
 
     def test_update_observables(self):
         """This method needs to be more thoroughly tested, and probably even reconsidered in

--- a/tests/tape/test_qscript.py
+++ b/tests/tape/test_qscript.py
@@ -262,7 +262,7 @@ class TestUpdate:
         assert p_id_0 == 0
 
     def test_get_operation_return_index(self):
-        """Tests the tape method get_operation"""
+        """Tests the tape method get_operation with `return_op_index` bool."""
         ops = [
             qml.RX(1.2, wires=0),
             qml.Rot(2.3, 3.4, 5.6, wires=0),


### PR DESCRIPTION
**Context:**

Following this PR https://github.com/PennyLaneAI/pennylane/pull/3667

**Description of the Change:**

This PR adds a warning for the `get_operation` tape method, it also let the user to turn on the new behavior.

**Benefits:**

It allows to integrate the changes of `_par_info`.

**Possible Drawbacks:**

-

**Related GitHub Issues:**
