### PR TITLE
Add convenience functionality to `SpecialUnitary` for sparse input parameters

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -9,6 +9,7 @@
 * A new operation `SpecialUnitary` was added, providing access to an arbitrary
   unitary gate via a parametrization in the Pauli basis.
   [(#3650)](https://github.com/PennyLaneAI/pennylane/pull/3650)
+  [(#3677)](https://github.com/PennyLaneAI/pennylane/pull/3677)
  
   The new operation takes a single argument, a one-dimensional `tensor_like`
   of length `4**num_wires-1`, where `num_wires` is the number of wires the unitary acts on.
@@ -42,6 +43,17 @@
   >>> rx = qml.RX(-2 * x, 0) # RX introduces a prefactor -0.5 that has to be compensated
   >>> qml.math.allclose(su.matrix(), rx.matrix())
   True
+  ```
+
+  Alternatively, it is possible to pass the parameters for specific Pauli words and
+  indicate the selection and order of words with the optional argument `words`:
+
+  ```pycon
+  >>> x = [0.2, 0.4]
+  >>> words = ["IX", "YY"] # The first parameter will be used for IX, the second for YY
+  >>> qml.SpecialUnitary(x, wires=[0, 1], words=words)
+  SpecialUnitary(array([0.2, 0. , 0. , 0. , 0. , 0. , 0. , 0. , 0. , 0.4, 0. , 0. , 0. ,
+          0. , 0. ]), wires=[0, 1])
   ```
   
   This operation supports parameter broadcasting/batching.


### PR DESCRIPTION
**Context:**
#3650 adds `SpecialUnitary`. In order to initialize this operation, users have to pass an input vector of size $4^n-1$, which quickly becomes inconvenient. In particular, there might be applications in which those Pauli words are known to which the input parameters belong.

**Description of the Change:**
This PR adds an internal convenience function and a keyword argument to `SpecialUnitary`, allowing for re-interpretation of the input parameters as coefficients for selected Pauli words:

```pycon
>>> x = [0.2, 0.4]
>>> words = ["IX", "YY"]
>>> qml.SpecialUnitary(x, wires=[0, 1], words=words)
SpecialUnitary(array([0.2, 0. , 0. , 0. , 0. , 0. , 0. , 0. , 0. , 0.4, 0. , 0. , 0. ,
       0. , 0. ]), wires=[0, 1])
```
This convenience feature does not break differentiability or broadcasting support.

**Benefits:**
Convenience when using `SpecialUnitary`

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
N/A