### PR TITLE
Improve pauli utils

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -11,8 +11,8 @@
 * Parameterized Hamiltonians can now be created with the addition of `ParametrizedHamiltonian`.
   [(#3617)](https://github.com/PennyLaneAI/pennylane/pull/3617)
 
-  A `ParametrizedHamiltonian` holds information representing a linear combination of operators 
-  with parametrized coefficents. The `ParametrizedHamiltonian` can be passed parameters to create the operator for 
+  A `ParametrizedHamiltonian` holds information representing a linear combination of operators
+  with parametrized coefficents. The `ParametrizedHamiltonian` can be passed parameters to create the operator for
   the specified parameters.
   
   ```pycon
@@ -25,6 +25,7 @@
 
   H =  2 * XX + f1 * YY + f2 * ZZ
   ```
+
   ```pycon
   >>> H
   ParametrizedHamiltonian: terms=3
@@ -59,6 +60,7 @@
   1.1 * X(0)
   + 2.2 * Y(0)
   ```
+
   [(#3586)](https://github.com/PennyLaneAI/pennylane/pull/3586)
 
 <h4>Always differentiable 📈</h4>
@@ -241,10 +243,9 @@
   4: ─────────────────╰RY(0.81)─╰SWAP─────────────────╰RY(0.06)─╰SWAP─────────────────┤  State
   ```
 
-  
 * Added `pwc` as a convenience function for defining a `ParametrizedHamiltonian`.
-  This function can be used to create a callable coefficient by setting 
-  the timespan over which the function should be non-zero. The resulting callable 
+  This function can be used to create a callable coefficient by setting
+  the timespan over which the function should be non-zero. The resulting callable
   can be passed an array of parameters and a time.
   [(#3645)](https://github.com/PennyLaneAI/pennylane/pull/3645)
 
@@ -253,8 +254,9 @@
   >>> f = pwc(timespan)
   >>> f * qml.PauliX(0)
   ParametrizedHamiltonian: terms=1
-  ``` 
-  The `params` array will be used as bin values evenly distributed over the timespan, 
+  ```
+
+  The `params` array will be used as bin values evenly distributed over the timespan,
   and the parameter `t` will determine which of the bins is returned.
 
   ```pycon
@@ -266,7 +268,7 @@
   
 * Added `pwc_from_function` as a decorator for defining a `ParametrizedHamiltonian`.
   This function can be used to decorate a function and create a piecewise constant
-  approximation of it. 
+  approximation of it.
   [(#3645)](https://github.com/PennyLaneAI/pennylane/pull/3645)
   
   ```pycon
@@ -274,7 +276,8 @@
   ... def f1(p, t):
   ...     return p * t
   ```
-  The resulting function approximates the same of `p**2 * t` on the interval `t=(2, 4)` 
+
+  The resulting function approximates the same of `p**2 * t` on the interval `t=(2, 4)`
   in 10 bins, and returns zero outside the interval.
   
   ```pycon
@@ -289,7 +292,6 @@
   DeviceArray(0., dtype=float32)
   ```
   
-
 <h3>Improvements</h3>
 
 * `qml.purity` is added as a measurement process for purity
@@ -346,8 +348,8 @@
 * Lazy-loading in the `Dataset.read()` method is more universally supported.
   [(#3605)](https://github.com/PennyLaneAI/pennylane/pull/3605)
 
-* Implemented the XYX single-qubit unitary decomposition. 
-  [(#3628)](https://github.com/PennyLaneAI/pennylane/pull/3628) 
+* Implemented the XYX single-qubit unitary decomposition.
+  [(#3628)](https://github.com/PennyLaneAI/pennylane/pull/3628)
 
 * `Sum` and `Prod` operations now have broadcasted operands.
   [(#3611)](https://github.com/PennyLaneAI/pennylane/pull/3611)
@@ -371,6 +373,9 @@
 * The `StatePrep` class has been added as an interface that state-prep operators must implement.
   [(#3654)](https://github.com/PennyLaneAI/pennylane/pull/3654)
 
+* `qml.pauli.is_pauli_word` now accepts `Prod` operators, and it returns `False` when a `Hamiltonian` contains more than one term.
+  [(#3692)](https://github.com/PennyLaneAI/pennylane/pull/3692)
+
 <h3>Breaking changes</h3>
 
 * The tape method `get_operation` can also now return the operation index in the tape, and it can be
@@ -381,7 +386,7 @@
 * `Operator.inv()` and the `Operator.inverse` setter have been removed. Please use `qml.adjoint` or `qml.pow` instead.
   [(#3618)](https://github.com/PennyLaneAI/pennylane/pull/3618)
   
-  For example, instead of 
+  For example, instead of
   
   ```pycon
   >>> qml.PauliX(0).inv()

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -373,7 +373,11 @@
 * The `StatePrep` class has been added as an interface that state-prep operators must implement.
   [(#3654)](https://github.com/PennyLaneAI/pennylane/pull/3654)
 
-* `qml.pauli.is_pauli_word` now accepts `Prod` operators, and it returns `False` when a `Hamiltonian` contains more than one term.
+* `qml.pauli.is_pauli_word` now supports `Prod` and `SProd` operators, and it returns `False` when a
+  `Hamiltonian` contains more than one term.
+  [(#3692)](https://github.com/PennyLaneAI/pennylane/pull/3692)
+
+* `qml.pauli.pauli_word_to_string` now supports `Prod`, `SProd` and `Hamiltonian` operators.
   [(#3692)](https://github.com/PennyLaneAI/pennylane/pull/3692)
 
 <h3>Breaking changes</h3>

--- a/pennylane/pauli/conversion.py
+++ b/pennylane/pauli/conversion.py
@@ -204,7 +204,7 @@ def _(op: SProd):
 
 @pauli_sentence.register
 def _(op: Hamiltonian):
-    if not is_pauli_word(op):
+    if not all(is_pauli_word(o) for o in op.ops):
         raise ValueError(f"Op must be a linear combination of Pauli operators only, got: {op}")
 
     summands = []

--- a/pennylane/pauli/utils.py
+++ b/pennylane/pauli/utils.py
@@ -379,7 +379,7 @@ def pauli_word_to_string(pauli_word, wire_map=None):
 
     A Pauli word can be either:
 
-    * A single pauli operator (see :class:`~.PauliX for an example).
+    * A single pauli operator (see :class:`~.PauliX` for an example).
 
     * A :class:`Tensor` instance containing Pauli operators.
 

--- a/pennylane/pauli/utils.py
+++ b/pennylane/pauli/utils.py
@@ -392,6 +392,14 @@ def pauli_word_to_string(pauli_word, wire_map=None):
         >>> qml.pauli.pauli_word_to_string(3 * qml.PauliX(0) @ qml.PauliY(1))
         'XY'
 
+    .. warning::
+
+        This method assumes all Pauli operators are acting on different wires, ignoring
+        any extra operators:
+
+        >>> qml.pauli.pauli_word_to_string(qml.PauliX(0) @ qml.PauliY(0) @ qml.PauliY(0))
+        'X'
+
     Args:
         pauli_word (Observable): an observable, either a :class:`~.Tensor` instance or
             single-qubit observable representing a Pauli group element.

--- a/pennylane/pauli/utils.py
+++ b/pennylane/pauli/utils.py
@@ -57,7 +57,7 @@ def is_pauli_word(observable):
 
     A Pauli word can be either:
 
-    * A single pauli operator (see :class:`~.PauliX for an example).
+    * A single pauli operator (see :class:`~.PauliX` for an example).
 
     * A :class:`Tensor` instance containing Pauli operators.
 

--- a/pennylane/pauli/utils.py
+++ b/pennylane/pauli/utils.py
@@ -28,8 +28,7 @@ import numpy as np
 
 import pennylane as qml
 from pennylane.operation import Tensor
-from pennylane.ops import Identity, PauliX, PauliY, PauliZ, Prod
-from pennylane.ops.qubit.hamiltonian import Hamiltonian
+from pennylane.ops import Hamiltonian, Identity, PauliX, PauliY, PauliZ, Prod, SProd
 from pennylane.tape import OperationRecorder
 from pennylane.wires import Wires
 
@@ -49,13 +48,20 @@ def _wire_map_from_pauli_pair(pauli_word_1, pauli_word_2):
         in the Pauli word as keys, and unique integer labels as their values.
     """
     wire_labels = Wires.all_wires([pauli_word_1.wires, pauli_word_2.wires]).labels
-    wire_map = {label: i for i, label in enumerate(wire_labels)}
-    return wire_map
+    return {label: i for i, label in enumerate(wire_labels)}
 
 
 def is_pauli_word(observable):
     """
     Checks if an observable instance consists only of Pauli and Identity Operators.
+
+    A Pauli word can be either:
+
+    * A single pauli operator (see :class:`~.PauliX for an example).
+    * A :class:`Tensor` instance containing Pauli operators.
+    * A :class:`Prod` instance containing Pauli operators.
+    * A :class:`SProd` instance containing a Pauli operator.
+    * A :class:`Hamiltonian` instance with only one term.
 
     .. Warning::
 
@@ -66,7 +72,7 @@ def is_pauli_word(observable):
 
 
     Args:
-        observable (~.Observable): the operator to be examined
+        observable (~.Operator): the operator to be examined
 
     Returns:
         bool: true if the input observable is a Pauli word, false otherwise.
@@ -79,6 +85,8 @@ def is_pauli_word(observable):
     True
     >>> is_pauli_word(qml.PauliZ(0) @ qml.Hadamard(1))
     False
+    >>> is_pauli_word(4 * qml.PauliX(0) @ qml.PauliZ(0))
+    True
     """
     pauli_word_names = ["Identity", "PauliX", "PauliY", "PauliZ"]
     if isinstance(observable, Tensor):
@@ -89,6 +97,9 @@ def is_pauli_word(observable):
 
     if isinstance(observable, Prod):
         return all(is_pauli_word(op) for op in observable)
+
+    if isinstance(observable, SProd):
+        return is_pauli_word(observable.base)
 
     return observable.name in pauli_word_names
 
@@ -360,11 +371,26 @@ def binary_to_pauli(binary_vector, wire_map=None):  # pylint: disable=too-many-b
 
 
 def pauli_word_to_string(pauli_word, wire_map=None):
-    """Convert a Pauli word from a tensor to a string.
+    """Convert a Pauli word to a string.
+
+    A Pauli word can be either:
+
+    * A single pauli operator (see :class:`~.PauliX for an example).
+    * A :class:`Tensor` instance containing Pauli operators.
+    * A :class:`Prod` instance containing Pauli operators.
+    * A :class:`SProd` instance containing a Pauli operator.
+    * A :class:`Hamiltonian` instance with only one term.
 
     Given a Pauli in observable form, convert it into string of
     characters from ``['I', 'X', 'Y', 'Z']``. This representation is required for
     functions such as :class:`.PauliRot`.
+
+    .. warning::
+
+        This method ignores any potential coefficient multiplying the Pauli word:
+
+        >>> qml.pauli.pauli_word_to_string(3 * qml.PauliX(0) @ qml.PauliY(1))
+        'XY'
 
     Args:
         pauli_word (Observable): an observable, either a :class:`~.Tensor` instance or
@@ -389,6 +415,13 @@ def pauli_word_to_string(pauli_word, wire_map=None):
 
     if not is_pauli_word(pauli_word):
         raise TypeError(f"Expected Pauli word observables, instead got {pauli_word}")
+    if isinstance(pauli_word, Hamiltonian):
+        # hamiltonian contains only one term
+        pauli_word = pauli_word.ops[0]
+    elif isinstance(pauli_word, Prod):
+        pauli_word = Tensor(*pauli_word.operands)
+    elif isinstance(pauli_word, SProd):
+        pauli_word = pauli_word.base
 
     character_map = {"Identity": "I", "PauliX": "X", "PauliY": "Y", "PauliZ": "Z"}
 

--- a/pennylane/pauli/utils.py
+++ b/pennylane/pauli/utils.py
@@ -63,7 +63,7 @@ def is_pauli_word(observable):
 
     * A :class:`Prod` instance containing Pauli operators.
 
-    * A :class:`SProd` instance containing a Pauli operator.
+    * A :class:`SProd` instance containing a valid Pauli word.
 
     * A :class:`Hamiltonian` instance with only one term.
 

--- a/pennylane/pauli/utils.py
+++ b/pennylane/pauli/utils.py
@@ -58,9 +58,13 @@ def is_pauli_word(observable):
     A Pauli word can be either:
 
     * A single pauli operator (see :class:`~.PauliX for an example).
+
     * A :class:`Tensor` instance containing Pauli operators.
+
     * A :class:`Prod` instance containing Pauli operators.
+
     * A :class:`SProd` instance containing a Pauli operator.
+
     * A :class:`Hamiltonian` instance with only one term.
 
     .. Warning::
@@ -376,9 +380,13 @@ def pauli_word_to_string(pauli_word, wire_map=None):
     A Pauli word can be either:
 
     * A single pauli operator (see :class:`~.PauliX for an example).
+
     * A :class:`Tensor` instance containing Pauli operators.
+
     * A :class:`Prod` instance containing Pauli operators.
+
     * A :class:`SProd` instance containing a Pauli operator.
+
     * A :class:`Hamiltonian` instance with only one term.
 
     Given a Pauli in observable form, convert it into string of

--- a/pennylane/pauli/utils.py
+++ b/pennylane/pauli/utils.py
@@ -82,17 +82,14 @@ def is_pauli_word(observable):
     """
     pauli_word_names = ["Identity", "PauliX", "PauliY", "PauliZ"]
     if isinstance(observable, Tensor):
-        return set(observable.name).issubset(pauli_word_names) and len(observable.obs) == len(
-            observable.wires
-        )
+        return set(observable.name).issubset(pauli_word_names)
 
     if isinstance(observable, Hamiltonian):
         return False if len(observable.ops) > 1 else is_pauli_word(observable.ops[0])
 
     if isinstance(observable, Prod):
-        return all(is_pauli_word(op) for op in observable) and len(observable) == len(
-            observable.wires
-        )
+        return all(is_pauli_word(op) for op in observable)
+
     return observable.name in pauli_word_names
 
 

--- a/tests/pauli/test_pauli_utils.py
+++ b/tests/pauli/test_pauli_utils.py
@@ -374,6 +374,10 @@ class TestGroupingUtils:
             (PauliZ("a") @ PauliY("b") @ PauliZ("d"), {"a": 0, "b": 1, "c": 2, "d": 3}, "ZYIZ"),
             (PauliZ("a") @ PauliY("b") @ PauliZ("d"), None, "ZYZ"),
             (PauliX("a") @ PauliY("b") @ PauliZ("d"), {"d": 0, "c": 1, "b": 2, "a": 3}, "ZIYX"),
+            (4.5 * PauliX(0), {0: 0}, "X"),
+            (qml.prod(PauliX(0), PauliY(1)), {0: 0, 1: 1}, "XY"),
+            (PauliX(0) @ PauliZ(0), {0: 0}, "X"),  # second operator is ignored!!
+            (3 * PauliZ(0) @ PauliY(3), {0: 0, 3: 1}, "ZY"),
         ],
     )
     def test_pauli_word_to_string(self, pauli_word, wire_map, expected_string):

--- a/tests/pauli/test_pauli_utils.py
+++ b/tests/pauli/test_pauli_utils.py
@@ -14,45 +14,45 @@
 """
 Unit tests for the :mod:`pauli` utility functions in ``pauli/utils.py``.
 """
-import pytest
 import numpy as np
+import pytest
+
 import pennylane as qml
 from pennylane import (
+    RX,
+    RY,
+    U3,
+    Hadamard,
     Hamiltonian,
+    Hermitian,
     Identity,
     PauliX,
     PauliY,
     PauliZ,
-    Hadamard,
-    Hermitian,
-    U3,
     is_commuting,
-    RX,
-    RY,
 )
 from pennylane.operation import Tensor
 from pennylane.pauli import (
-    is_pauli_word,
     are_identical_pauli_words,
-    pauli_to_binary,
-    binary_to_pauli,
-    pauli_word_to_string,
-    string_to_pauli_word,
-    pauli_word_to_matrix,
-    is_qwc,
     are_pauli_words_qwc,
+    binary_to_pauli,
+    diagonalize_pauli_word,
+    diagonalize_qwc_pauli_words,
+    is_pauli_word,
+    is_qwc,
     observables_to_binary_matrix,
-    qwc_complement_adj_matrix,
     partition_pauli_group,
     pauli_group,
     pauli_mult,
     pauli_mult_with_phase,
+    pauli_to_binary,
+    pauli_word_to_matrix,
+    pauli_word_to_string,
+    qwc_complement_adj_matrix,
     qwc_rotation,
-    diagonalize_pauli_word,
-    diagonalize_qwc_pauli_words,
     simplify,
+    string_to_pauli_word,
 )
-
 
 non_pauli_words = [
     PauliX(0) @ Hadamard(1) @ Identity(2),
@@ -266,8 +266,13 @@ class TestGroupingUtils:
         (PauliZ(1) @ PauliX(2) @ PauliZ(4), True),
         (PauliX(1) @ Hadamard(4), False),
         (Hadamard(0), False),
+        (Hamiltonian([0.5], [PauliZ(1) @ PauliX(2)]), True),
+        (Hamiltonian([0.5], [PauliZ(1) @ PauliX(1)]), True),
+        (Hamiltonian([1.0], [Hadamard(0)]), False),
         (Hamiltonian([1.0, 0.5], [PauliX(0), PauliZ(1) @ PauliX(2)]), True),
-        (Hamiltonian([1.0, 0.5], [Hadamard(0), PauliZ(1) @ PauliX(2)]), False),
+        (qml.prod(qml.PauliX(0), qml.PauliY(0)), False),
+        (qml.prod(qml.PauliX(0), qml.PauliY(1)), True),
+        (qml.prod(qml.PauliX(0), qml.Hadamard(1)), False),
     )
 
     @pytest.mark.parametrize("ob, is_pw", obs_pw_status)

--- a/tests/pauli/test_pauli_utils.py
+++ b/tests/pauli/test_pauli_utils.py
@@ -273,6 +273,8 @@ class TestGroupingUtils:
         (qml.prod(qml.PauliX(0), qml.PauliY(0)), True),
         (qml.prod(qml.PauliX(0), qml.PauliY(1)), True),
         (qml.prod(qml.PauliX(0), qml.Hadamard(1)), False),
+        (qml.s_prod(5, qml.PauliX(0) @ qml.PauliZ(1)), True),
+        (qml.s_prod(5, qml.Hadamard(0)), False),
     )
 
     @pytest.mark.parametrize("ob, is_pw", obs_pw_status)
@@ -378,6 +380,8 @@ class TestGroupingUtils:
             (qml.prod(PauliX(0), PauliY(1)), {0: 0, 1: 1}, "XY"),
             (PauliX(0) @ PauliZ(0), {0: 0}, "X"),  # second operator is ignored!!
             (3 * PauliZ(0) @ PauliY(3), {0: 0, 3: 1}, "ZY"),
+            (qml.s_prod(8, qml.PauliX(0) @ qml.PauliZ(1)), {0: 0, 1: 1}, "XZ"),
+            (qml.Hamiltonian([4], [qml.PauliX(0) @ qml.PauliZ(1)]), {0: 0, 1: 1}, "XZ"),
         ],
     )
     def test_pauli_word_to_string(self, pauli_word, wire_map, expected_string):

--- a/tests/pauli/test_pauli_utils.py
+++ b/tests/pauli/test_pauli_utils.py
@@ -269,8 +269,8 @@ class TestGroupingUtils:
         (Hamiltonian([0.5], [PauliZ(1) @ PauliX(2)]), True),
         (Hamiltonian([0.5], [PauliZ(1) @ PauliX(1)]), True),
         (Hamiltonian([1.0], [Hadamard(0)]), False),
-        (Hamiltonian([1.0, 0.5], [PauliX(0), PauliZ(1) @ PauliX(2)]), True),
-        (qml.prod(qml.PauliX(0), qml.PauliY(0)), False),
+        (Hamiltonian([1.0, 0.5], [PauliX(0), PauliZ(1) @ PauliX(2)]), False),
+        (qml.prod(qml.PauliX(0), qml.PauliY(0)), True),
         (qml.prod(qml.PauliX(0), qml.PauliY(1)), True),
         (qml.prod(qml.PauliX(0), qml.Hadamard(1)), False),
     )


### PR DESCRIPTION
- Add support for `Prod`, `SProd` and `Hamiltonian` in `is_pauli_word` and `pauli_word_to_string`.
- Return `False` if given a `Hamiltonian` with more than one term.