### PR TITLE
Basis state implement stateprep

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -371,6 +371,8 @@
 * The `StatePrep` class has been added as an interface that state-prep operators must implement.
   [(#3654)](https://github.com/PennyLaneAI/pennylane/pull/3654)
 
+* `BasisState` now implements the `StatePrep` interface.
+
 <h3>Breaking changes</h3>
 
 * The tape method `get_operation` can also now return the operation index in the tape, and it can be

--- a/pennylane/ops/qubit/state_preparation.py
+++ b/pennylane/ops/qubit/state_preparation.py
@@ -88,21 +88,25 @@ class BasisState(StatePrep):
 
     def state_vector(self, wire_order=None):
         """Returns a state-vector of shape ``(2,) * num_wires``."""
+        state = self.parameters[0]
+        if any(i not in [0, 1] for i in state):
+            raise ValueError("BasisState parameter must consist of 0 or 1 integers.")
+
         if wire_order is None:
             num_wires = len(self.wires)
-            indices = self.parameters[0]
+            indices = state
         else:
             new_wires = Wires(wire_order)
             if not new_wires.contains_wires(self.wires):
                 raise WireError("Custom wire_order must contain all BasisState wires")
             num_wires = len(new_wires)
             indices = [0] * num_wires
-            for base_wire_label, value in zip(self.wires, self.parameters[0]):
+            for base_wire_label, value in zip(self.wires, state):
                 indices[new_wires.index(base_wire_label)] = value
 
         ket = np.zeros((2,) * num_wires)
         ket[tuple(indices)] = 1
-        return convert_like(ket, self.parameters[0])
+        return convert_like(ket, state)
 
 
 class QubitStateVector(Operation):

--- a/pennylane/ops/qubit/state_preparation.py
+++ b/pennylane/ops/qubit/state_preparation.py
@@ -87,10 +87,10 @@ class BasisState(StatePrep):
         return [BasisStatePreparation(n, wires)]
 
     def state_vector(self, wire_order=None):
-        """Returns a ket vector representing the state being created."""
+        """Returns a state-vector of shape ``(2,) * num_wires``."""
         if wire_order is None:
             num_wires = len(self.wires)
-            indices = list(self.parameters[0])
+            indices = self.parameters[0]
         else:
             new_wires = Wires(wire_order)
             if not new_wires.contains_wires(self.wires):
@@ -100,8 +100,8 @@ class BasisState(StatePrep):
             for base_wire_label, value in zip(self.wires, self.parameters[0]):
                 indices[new_wires.index(base_wire_label)] = value
 
-        ket = np.zeros(2**num_wires)
-        ket[np.ravel_multi_index(indices, [2] * num_wires)] = 1
+        ket = np.zeros((2,) * num_wires)
+        ket[tuple(indices)] = 1
         return convert_like(ket, self.parameters[0])
 
 

--- a/tests/ops/qubit/test_state_prep.py
+++ b/tests/ops/qubit/test_state_prep.py
@@ -132,3 +132,11 @@ class TestStateVector:
         basis_op = qml.BasisState([0, 1], wires=[0, 1])
         with pytest.raises(WireError, match="wire_order must contain all BasisState wires"):
             basis_op.state_vector(wire_order=[1, 2])
+
+    def test_BasisState_explicitly_checks_0_1(self):
+        """Tests that BasisState gives a clear error if a value other than 0 or 1 is given."""
+        op = qml.BasisState([2, 1], wires=[0, 1])
+        with pytest.raises(
+            ValueError, match="BasisState parameter must consist of 0 or 1 integers."
+        ):
+            _ = op.state_vector()

--- a/tests/ops/qubit/test_state_prep.py
+++ b/tests/ops/qubit/test_state_prep.py
@@ -101,21 +101,23 @@ class TestStateVector:
     @pytest.mark.parametrize(
         "num_wires,wire_order,one_position",
         [
-            (2, None, 1),
-            (2, [1, 2], 1),
-            (3, [0, 1, 2], 1),
-            (3, ["a", 1, 2], 1),
-            (3, [1, 2, 0], 2),
-            (3, [1, 2, "a"], 2),
+            (2, None, (0, 1)),
+            (2, [1, 2], (0, 1)),
+            (2, [2, 1], (1, 0)),
+            (3, [0, 1, 2], (0, 0, 1)),
+            (3, ["a", 1, 2], (0, 0, 1)),
+            (3, [1, 2, 0], (0, 1, 0)),
+            (3, [1, 2, "a"], (0, 1, 0)),
         ],
     )
     def test_BasisState_state_vector(self, num_wires, wire_order, one_position):
         """Tests that BasisState state_vector returns kets as expected."""
         basis_op = qml.BasisState([0, 1], wires=[1, 2])
         ket = basis_op.state_vector(wire_order=wire_order)
+        assert qml.math.shape(ket) == (2,) * num_wires
         assert ket[one_position] == 1
         ket[one_position] = 0  # everything else should be zero, as we assert below
-        assert np.allclose(np.zeros(2**num_wires), ket)
+        assert np.allclose(np.zeros((2,) * num_wires), ket)
 
     @pytest.mark.all_interfaces
     @pytest.mark.parametrize("interface", ["numpy", "jax", "torch", "tensorflow"])

--- a/tests/tests_passing_pylint.txt
+++ b/tests/tests_passing_pylint.txt
@@ -9,3 +9,4 @@ tests/ops/functions/test_evolve.py
 tests/ops/qutrit/test_qutrit_observables.py
 tests/test_operation.py
 tests/pulse/**
+tests/ops/qubit/test_state_prep.py


### PR DESCRIPTION
Replaces #3633 

**Context:**
State-prep methods should implement (aka inherit from) the new `StatePrep` interface, so this PR does that.

**Description of the Change:**
BasisState inherits from StatePrep, and implements the `state_vector` method. It essentially just calls `zeros` then sets the result to 1 at the index of the operator parameter, expanding over wires as needed, then reshapes the result from flat to `(2,) * num_wires`

**Benefits:**
BasisState will be usable to prepare a state in the new python simulator device (once #3683 is done)

**Related GitHub Issues:**
I first attempted something to a similar effect in #3626, but this approach makes more sense.

From my similar PR for QubitStateVector (#3685):
> Question for reviewers that I'm now realizing: The wire expansion thing might be common, and should maybe follow the existing `matrix/compute_matrix` pattern so the parent StatePrep class can do the expansion, and the child classes will be simpler. Should I make that change? I'm thinking yes.

^ I still think yes, but I think I'll do it _after_ this PR.