### PR TITLE
Create limited `devices.qubit.simulate` internal function

### DIFF
--- a/pennylane/devices/qubit/__init__.py
+++ b/pennylane/devices/qubit/__init__.py
@@ -22,7 +22,9 @@ at your own discretion.
     :toctree: api
     create_initial_state
     apply_operaiton
+    simulate
 """
 
 from .apply_operation import apply_operation
 from .initialize_state import create_initial_state
+from .simulate import simulate

--- a/pennylane/devices/qubit/simulate.py
+++ b/pennylane/devices/qubit/simulate.py
@@ -1,0 +1,77 @@
+# Copyright 2018-2023 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Simulate a quantum script."""
+
+# pylint: disable=protected-access
+import pennylane as qml
+from pennylane.wires import Wires
+from pennylane.measurements import StateMeasurement
+
+from .initialize_state import create_initial_state
+from .apply_operation import apply_operation
+
+
+def measure_state_diagonalizing_gates(state, measurementprocess: StateMeasurement):
+    """Measure ``state`` using ``measurementprocess`` if measurement process is state based
+    and has an observable that provides diagonalizing gates.."""
+    total_indices = len(state.shape)
+    wires = Wires(range(total_indices))
+
+    for op in measurementprocess.obs.diagonalizing_gates():
+        state = apply_operation(op, state)
+
+    return measurementprocess.process_state(state.flatten(), wires)
+
+
+def measure(mp: StateMeasurement, state):
+    """Measure ``mp`` on the ``state``."""
+    if isinstance(mp, StateMeasurement):
+
+        if mp.obs is None:
+            # no need to apply diagonalizing gates
+            total_indices = len(state.shape)
+            wires = Wires(range(total_indices))
+            return mp.process_state(state.flatten(), wires)
+
+        if mp.obs.has_diagonalizing_gates:
+            return measure_state_diagonalizing_gates(state, mp)
+
+    raise NotImplementedError
+
+
+def simulate(circuit: qml.tape.QuantumScript):
+    """Simulate a single quantum script.
+
+    This is an internal function that will be called by the to-be-created ``PythonDevice``.
+
+    Args:
+        circuit: The single circuit to simulate
+
+    Returns:
+        tuple(ndarray): The results of the simulation
+
+    This function assummes that wire labels denote indices and all operations provide matrices.
+
+    >>> qs = qml.tape.QuantumScript([qml.RX(1.2, wires=0)], [qml.expval(qml.PauliZ(0)), qml.probs(wires=(0,1))])
+    >>> simulate(qs)
+    (0.36235775447667357,
+    tensor([0.68117888, 0.        , 0.31882112, 0.        ], requires_grad=True))
+
+    """
+    state = create_initial_state(circuit.wires, circuit._prep[0] if circuit._prep else None)
+
+    for op in circuit._ops:
+        state = apply_operation(op, state)
+
+    return tuple(measure(mp, state) for mp in circuit.measurements)


### PR DESCRIPTION
Depends on #3683

This will be an internal function used by the next-generation Python device. The logic is extracted from the device to allow easy simulation of batches and the ability to distribute multiple simulations across different threads.

This first iteration will only support state-based measurement of observables with diagonalizing gates.  Later PR's will add state-based measurements of observables with sparse or dense matrices and sample-based measurements.

This function will allow simultaneous measurement of non-commuting observables.