### PR TITLE
Docfix/architecture typo

### DIFF
--- a/doc/development/guide/architecture.rst
+++ b/doc/development/guide/architecture.rst
@@ -266,7 +266,7 @@ In other words, these steps can invoke differentiable classical computations, su
 
 There are some devices where the execution of the quantum circuit is also tracked by the
 autodifferentiation framework. This is possible if the device is a simulator that is
-coded entiely in the framework's language (such as a TensorFlow quantum simulator).
+coded entirely in the framework's language (such as a TensorFlow quantum simulator).
 
 |
 

--- a/doc/development/guide/tests.rst
+++ b/doc/development/guide/tests.rst
@@ -20,7 +20,7 @@ Creating a test
 Every test has to be added to the PennyLane `test folder <https://github.com/PennyLaneAI/pennylane/tree/master/tests>`__.
 The test folder follows the structure of the PennyLane module folder. Therefore, tests needs to be added to the corresponding subfolder of the functionality they are testing.
 
-Most tests typcally will not require the use of an interface or autodifferentiation framework (such as Autograd, Torch, TensorFlow and Jax). Tests without an interface will be marked
+Most tests typically will not require the use of an interface or autodifferentiation framework (such as Autograd, Torch, TensorFlow and Jax). Tests without an interface will be marked
 as a ``core`` test automatically by pytest (the functionality for this is located in ``conftest.py``). For such general tests, you can follow the structure of the example below,
 where it is recommended that you follow general `pytest guidelines <https://docs.pytest.org/>`__:
 


### PR DESCRIPTION
**Context:**
I found a couple typos in the documentation whilst reading it.

**Description of the Change:**
Fixed the typos.

**Benefits:**
Typos fixed.

**Possible Drawbacks:**
None.

**Related GitHub Issues:**
None.