### PR TITLE
Stop using `qml.dot` inside `ParametrizedHamiltonian`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -71,8 +71,8 @@
 * The Hadamard test gradient tranform is now available via `qml.gradients.hadamard_grad`.
   [#3625](https://github.com/PennyLaneAI/pennylane/pull/3625)
 
-  `qml.gradients.hadamard_grad` is a hardware-compatible transform that calculates the 
-  gradient of a quantum circuit using the Hadamard test. Note that the device requires an 
+  `qml.gradients.hadamard_grad` is a hardware-compatible transform that calculates the
+  gradient of a quantum circuit using the Hadamard test. Note that the device requires an
   auxiliary wire to calculate the gradient.
 
   ```pycon
@@ -387,9 +387,6 @@
 
 * `Sum` and `Prod` operations now have broadcasted operands.
   [(#3611)](https://github.com/PennyLaneAI/pennylane/pull/3611)
-
-* `qml.dot` is now compatible with JAX-JIT.
-  [(#3636)](https://github.com/PennyLaneAI/pennylane/pull/3636)
 
 * All dunder methods now return `NotImplemented`, allowing the right dunder method (e.g. `__radd__`)
   of the other class to be called.

--- a/pennylane/ops/functions/dot.py
+++ b/pennylane/ops/functions/dot.py
@@ -77,7 +77,7 @@ def dot(coeffs: Sequence[float], ops: Sequence[Operator], pauli=False):
     if pauli:
         return _pauli_dot(coeffs, ops)
 
-    operands = [qml.s_prod(coeff, op) for coeff, op in zip(coeffs, ops)]
+    operands = [op if coeff == 1 else qml.s_prod(coeff, op) for coeff, op in zip(coeffs, ops)]
     return qml.sum(*operands) if len(operands) > 1 else operands[0]
 
 

--- a/pennylane/pulse/parametrized_hamiltonian.py
+++ b/pennylane/pulse/parametrized_hamiltonian.py
@@ -154,7 +154,9 @@ class ParametrizedHamiltonian:
         """The fixed term(s) of the ``ParametrizedHamiltonian``. Returns a ``Sum`` operator of ``SProd``
         operators (or a single ``SProd`` operator in the event that there is only one term in ``H_fixed``).
         """
-        return qml.dot(self.coeffs_fixed, self.ops_fixed) if self.coeffs_fixed else 0
+        if self.coeffs_fixed:
+            return sum(qml.s_prod(c, o) for c, o in zip(self.coeffs_fixed, self.ops_fixed))
+        return 0
 
     def H_parametrized(self, params, t):
         """The parametrized terms of the Hamiltonian for the specified parameters and time.
@@ -167,7 +169,7 @@ class ParametrizedHamiltonian:
         ``~SProd`` operator in the event that there is only one term in ``H_parametrized``)."""
 
         coeffs = [f(param, t) for f, param in zip(self.coeffs_parametrized, params)]
-        return qml.dot(coeffs, self.ops_parametrized) if coeffs else 0
+        return sum(qml.s_prod(c, o) for c, o in zip(coeffs, self.ops_parametrized)) if coeffs else 0
 
     @property
     def coeffs(self):

--- a/tests/ops/functions/test_dot.py
+++ b/tests/ops/functions/test_dot.py
@@ -38,8 +38,11 @@ class TestDotSum:
         S = qml.dot(coeffs=c, ops=o)
         assert isinstance(S, Sum)
         for summand, coeff in zip(S.operands, c):
-            assert isinstance(summand, SProd)
-            assert summand.scalar == coeff
+            if coeff == 1:
+                assert isinstance(summand, qml.PauliX)
+            else:
+                assert isinstance(summand, SProd)
+                assert summand.scalar == coeff
 
     def test_dot_returns_sprod(self):
         """Test that the dot function returns a SProd operator when only one operator is input."""
@@ -73,7 +76,7 @@ class TestDotSum:
         o = [qml.PauliX(0), qml.PauliY(1), qml.PauliZ(2)]
         op_sum = qml.dot(c, o)
         op_sum_2 = Sum(
-            SProd(qml.numpy.array(1.0, dtype=dtype), qml.PauliX(0)),
+            qml.PauliX(0),
             SProd(qml.numpy.array(2.0, dtype=dtype), qml.PauliY(1)),
             SProd(qml.numpy.array(3.0, dtype=dtype), qml.PauliZ(2)),
         )
@@ -89,7 +92,7 @@ class TestDotSum:
         o = [qml.PauliX(0), qml.PauliY(1), qml.PauliZ(2)]
         op_sum = qml.dot(c, o)
         op_sum_2 = Sum(
-            SProd(tf.constant(1.0, dtype=getattr(tf, dtype)), qml.PauliX(0)),
+            qml.PauliX(0),
             SProd(tf.constant(2.0, dtype=getattr(tf, dtype)), qml.PauliY(1)),
             SProd(tf.constant(3.0, dtype=getattr(tf, dtype)), qml.PauliZ(2)),
         )
@@ -105,7 +108,7 @@ class TestDotSum:
         o = [qml.PauliX(0), qml.PauliY(1), qml.PauliZ(2)]
         op_sum = qml.dot(c, o)
         op_sum_2 = Sum(
-            SProd(torch.tensor(1.0, dtype=getattr(torch, dtype)), qml.PauliX(0)),
+            qml.PauliX(0),
             SProd(torch.tensor(2.0, dtype=getattr(torch, dtype)), qml.PauliY(1)),
             SProd(torch.tensor(3.0, dtype=getattr(torch, dtype)), qml.PauliZ(2)),
         )
@@ -121,31 +124,11 @@ class TestDotSum:
         o = [qml.PauliX(0), qml.PauliY(1), qml.PauliZ(2)]
         op_sum = qml.dot(c, o)
         op_sum_2 = Sum(
-            SProd(jax.numpy.array(1.0, dtype=dtype), qml.PauliX(0)),
+            qml.PauliX(0),
             SProd(jax.numpy.array(2.0, dtype=dtype), qml.PauliY(1)),
             SProd(jax.numpy.array(3.0, dtype=dtype), qml.PauliZ(2)),
         )
         assert qml.equal(op_sum, op_sum_2)
-
-    @pytest.mark.jax
-    @pytest.mark.parametrize("dtype", (float, complex))
-    def test_dot_is_jittable(self, dtype):
-        """Test that the dot function is jittable."""
-        import jax
-
-        @jax.jit
-        def jittable_func():
-            c = jax.numpy.array([1.0, 2.0, 3.0], dtype=dtype)
-            o = [qml.PauliX(0), qml.PauliY(1), qml.PauliZ(2)]
-            return qml.matrix(qml.dot(c, o))
-
-        op_mat = jittable_func()
-        op_sum_2 = Sum(
-            SProd(jax.numpy.array(1.0, dtype=dtype), qml.PauliX(0)),
-            SProd(jax.numpy.array(2.0, dtype=dtype), qml.PauliY(1)),
-            SProd(jax.numpy.array(3.0, dtype=dtype), qml.PauliZ(2)),
-        )
-        assert qml.math.allequal(op_mat, op_sum_2.matrix())
 
 
 coeffs = [0.12345, 1.2345, 12.345, 123.45, 1234.5, 12345]


### PR DESCRIPTION
The use of `qml.dot` inside `ParametrizedHamiltonian` adds the restriction that `qml.dot` must be jittable.

This restricts us to improve this function by adding, for example, conditional results.