### PR TITLE
Improve `Tensor` class

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -9,11 +9,11 @@
 * A new operation `SpecialUnitary` was added, providing access to an arbitrary
   unitary gate via a parametrization in the Pauli basis.
   [(#3650)](https://github.com/PennyLaneAI/pennylane/pull/3650)
- 
+
   The new operation takes a single argument, a one-dimensional `tensor_like`
   of length `4**num_wires-1`, where `num_wires` is the number of wires the unitary acts on.
 
-  The parameter `theta` refers to all Pauli words (except for the identity) in lexicographical 
+  The parameter `theta` refers to all Pauli words (except for the identity) in lexicographical
   order, which looks like the following for one and two qubits:
 
   ```pycon
@@ -368,7 +368,7 @@
 * The `create_initial_state` function is added to `devices/qubit` that returns an initial state for an execution.
   [(#3683)](https://github.com/PennyLaneAI/pennylane/pull/3683)
 
- * Added `qml.ops.ctrl_decomp_zyz` to compute the decomposition of a controlled single-qubit operation given
+* Added `qml.ops.ctrl_decomp_zyz` to compute the decomposition of a controlled single-qubit operation given
   a single-qubit operation and the control wires.
   [(#3681)](https://github.com/PennyLaneAI/pennylane/pull/3681)
 
@@ -575,6 +575,9 @@
 
 * Fixed a bug that made tapes/qnodes using `qml.Snapshot` incompatible with `qml.drawer.tape_mpl`.
   [(#3704)](https://github.com/PennyLaneAI/pennylane/pull/3704)
+
+* `Tensor._pauli_rep` is set to `None` during initialization. Add `Tensor.data` setter.
+  [(#3722)](https://github.com/PennyLaneAI/pennylane/pull/3722)
 
 <h3>Contributors</h3>
 

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -225,6 +225,7 @@ import autoray
 import numpy as np
 from numpy.linalg import multi_dot
 from scipy.sparse import coo_matrix, eye, kron
+
 import pennylane as qml
 from pennylane.math import expand_matrix
 from pennylane.queuing import QueuingManager
@@ -1927,6 +1928,7 @@ class Tensor(Observable):
         self.obs: List[Observable] = []
         self._args = args
         self._batch_size = None
+        self._pauli_rep = None
         self.queue(init=True)
 
     def label(self, decimals=None, base_label=None, cache=None):
@@ -2036,6 +2038,12 @@ class Tensor(Observable):
             list[Any]: flattened list containing all dependent parameters
         """
         return sum((o.data for o in self.obs), [])
+
+    @data.setter
+    def data(self, new_data):
+        """Set the data property"""
+        for new_entry, op in zip(new_data, self.obs):
+            op.data = new_entry
 
     @property
     def num_params(self):

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -2041,7 +2041,23 @@ class Tensor(Observable):
 
     @data.setter
     def data(self, new_data):
-        """Set the data property"""
+        """Setter used to set the parameters of all constituent observables in the tensor product.
+
+        The ``new_data`` argument should contain a list of elements, where each element corresponds
+        to a list containing the parameters of each observable (in order). If an observable doesn't
+        have any parameter, an empty list must be used.
+
+        **Example:**
+
+        >>> op = qml.PauliX(0) @ qml.Hermitian(np.eye(2), wires=1)
+        >>> op.data
+        [array([[1., 0.],
+        [0., 1.]])]
+        >>> op.data = [[], [np.eye(2) * 5]]
+        >>> op.data
+        [array([[5., 0.],
+        [0., 5.]])]
+        """
         for new_entry, op in zip(new_data, self.obs):
             op.data = new_entry
 

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -25,13 +25,7 @@ from numpy.linalg import multi_dot
 
 import pennylane as qml
 from pennylane import numpy as pnp
-from pennylane.operation import (
-    Operation,
-    Operator,
-    Tensor,
-    operation_derivative,
-    StatePrep,
-)
+from pennylane.operation import Operation, Operator, StatePrep, Tensor, operation_derivative
 from pennylane.ops import Prod, SProd, Sum, cv
 from pennylane.wires import Wires
 
@@ -1203,6 +1197,13 @@ class TestTensor:
         t = Tensor(X, Y)
         assert t.batch_size is None
 
+    def test_pauli_rep(self):
+        """Test that the _pauli_rep attribute of the Tensor is initialized as None."""
+        X = qml.PauliX(0)
+        Y = qml.PauliY(2)
+        t = Tensor(X, Y)
+        assert t._pauli_rep is None
+
     def test_has_matrix(self):
         """Test that the Tensor class has a ``has_matrix`` static attribute set to True."""
         assert Tensor.has_matrix is True
@@ -1230,6 +1231,17 @@ class TestTensor:
         Y = qml.Hermitian(p, wires=[1, 2])
         t = Tensor(X, Y)
         assert t.data == [p]
+
+    def test_data_setter(self):
+        """Test the data setter"""
+        p = np.eye(4)
+        X = qml.PauliX(0)
+        Y = qml.Hermitian(p, wires=[1, 2])
+        t = Tensor(X, Y)
+        assert t.data == [p]
+        new_data = np.eye(4) * 6
+        t.data = [[], [new_data]]
+        assert qml.math.allequal(t.data, [new_data])
 
     def test_num_params(self):
         """Test that the correct number of parameters is returned"""


### PR DESCRIPTION
- Set `self._pauli_rep` to `None`. (Fixes https://github.com/PennyLaneAI/pennylane/issues/3709)
- Add `Tensor.data` setter: some `map_wires` methods (such as `Composite.map_wires`) use data setters.