### PR TITLE
`ParametrizedEvolution`: Use `params` in `super` call

### DIFF
--- a/pennylane/pulse/parametrized_evolution.py
+++ b/pennylane/pulse/parametrized_evolution.py
@@ -172,30 +172,32 @@ class ParametrizedEvolution(Operation):
             raise ValueError(
                 "All operators inside the parametrized hamiltonian must have a matrix defined."
             )
+        self._has_matrix = params is not None and t is not None
         self.H = H
-        self.params = params
         self.odeint_kwargs = odeint_kwargs
         if t is None:
             self.t = None
         else:
             self.t = jnp.array([0, t] if qml.math.ndim(t) == 0 else t, dtype=float)
-        super().__init__(wires=H.wires, do_queue=do_queue, id=id)
+        params = [] if params is None else params
+        super().__init__(*params, wires=H.wires, do_queue=do_queue, id=id)
 
     def __call__(self, params, t, **odeint_kwargs):
-        self.params = params
+        self.data = [jnp.array(p) if isinstance(p, list) else p for p in params]
         self.t = jnp.array([0, t] if qml.math.ndim(t) == 0 else t, dtype=float)
         if odeint_kwargs:
             self.odeint_kwargs.update(odeint_kwargs)
+        self._has_matrix = True
         return self
 
     # pylint: disable=arguments-renamed, invalid-overridden-method
     @property
     def has_matrix(self):
-        return True
+        return self._has_matrix
 
     # pylint: disable=import-outside-toplevel
     def matrix(self, wire_order=None):
-        if self.params is None or self.t is None:
+        if not self.has_matrix:
             raise ValueError(
                 "The parameters and the time window are required to compute the matrix. "
                 "You can update its values by calling the class: EV(params, t)."
@@ -204,7 +206,7 @@ class ParametrizedEvolution(Operation):
 
         def fun(y, t):
             """dy/dt = -i H(t) y"""
-            return -1j * qml.matrix(self.H(self.params, t=t)) @ y
+            return -1j * qml.matrix(self.H(self.data, t=t)) @ y
 
         result = odeint(fun, y0, self.t, **self.odeint_kwargs)
         mat = result[-1]

--- a/tests/ops/qubit/test_matrix_ops.py
+++ b/tests/ops/qubit/test_matrix_ops.py
@@ -518,7 +518,7 @@ class TestDiagonalQubitUnitary:
             loss = circuit(x)
 
         grad = tape.gradient(loss, x)
-        expected = -tf.math.sin(x)
+        expected = -tf.math.sin(x)  # pylint: disable=invalid-unary-operand-type
         assert np.allclose(grad, expected)
 
 

--- a/tests/pulse/test_parametrized_evolution.py
+++ b/tests/pulse/test_parametrized_evolution.py
@@ -89,7 +89,6 @@ class TestInitialization:
 
         assert ev.H is H
         assert qml.math.allequal(ev.t, [0, 2])
-        assert qml.math.allequal(ev.params, [1, 2])
 
         assert ev.wires == H.wires
         assert ev.num_wires == AnyWires
@@ -97,9 +96,9 @@ class TestInitialization:
         assert ev.id is None
         assert ev.queue_idx is None
 
-        assert ev.data == []
-        assert ev.parameters == []
-        assert ev.num_params == 0
+        assert qml.math.allequal(ev.data, [1, 2])
+        assert qml.math.allequal(ev.parameters, [1, 2])
+        assert ev.num_params == 2
 
     def test_odeint_kwargs(self):
         """Test the initialization with odeint kwargs."""
@@ -117,14 +116,14 @@ class TestInitialization:
         H = ParametrizedHamiltonian(coeffs, ops)
         ev = ParametrizedEvolution(H=H, mxstep=10)
 
-        assert ev.params is None
+        assert ev.parameters == []
         assert ev.t is None
         assert ev.odeint_kwargs == {"mxstep": 10}
         params = [1, 2, 3]
         t = 6
         ev(params, t, atol=1e-6, rtol=1e-4)
 
-        assert qml.math.allequal(ev.params, params)
+        assert qml.math.allequal(ev.parameters, params)
         assert qml.math.allequal(ev.t, [0, 6])
         assert ev.odeint_kwargs == {"mxstep": 10, "atol": 1e-6, "rtol": 1e-4}
 


### PR DESCRIPTION
Use `params` in `super().__init__` call to update the `num_params` attribute.