### PR TITLE
add purity to quickstart for measurements

### DIFF
--- a/doc/introduction/measurements.rst
+++ b/doc/introduction/measurements.rst
@@ -38,6 +38,7 @@ The available measurement functions are
     ~pennylane.density_matrix
     ~pennylane.vn_entropy
     ~pennylane.mutual_info
+    ~pennylane.purity
     ~pennylane.classical_shadow
     ~pennylane.shadow_expval
 


### PR DESCRIPTION
`qml.purity` was missing from the quickstart.