### PR TITLE
Fix drawing of nested controlled ops.

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -473,6 +473,9 @@
 * `QubitStateVector` now implements the `StatePrep` interface.
   [(#3685)](https://github.com/PennyLaneAI/pennylane/pull/3685)
 
+* Nested `Controlled` operators are simplified during initialization.
+  [(#3737)](https://github.com/PennyLaneAI/pennylane/pull/3737)
+
 <h3>Breaking changes</h3>
 
 * The tape method `get_operation` can also now return the operation index in the tape, and it can be
@@ -588,6 +591,9 @@
 
 * Redirect `qml.math.ndim` to `jnp.ndim` when using it on a jax tensor.
   [(#3730)](https://github.com/PennyLaneAI/pennylane/pull/3730)
+
+* Fix bug where `qml.draw` didn't take into account the `control_wires` of nested controlled operators.
+  [(#3737)](https://github.com/PennyLaneAI/pennylane/pull/3737)
 
 <h3>Contributors</h3>
 

--- a/pennylane/drawer/tape_text.py
+++ b/pennylane/drawer/tape_text.py
@@ -16,7 +16,8 @@ This module contains logic for the text based circuit drawer through the ``tape_
 """
 
 import pennylane as qml
-from pennylane.measurements import Expectation, Probability, Sample, Variance, State
+from pennylane.measurements import Expectation, Probability, Sample, State, Variance
+from pennylane.ops import Controlled
 
 from .drawable_layers import drawable_layers
 from .utils import convert_wire_order
@@ -47,6 +48,11 @@ def _add_op(op, layer_str, wire_map, decimals, cache):
 
     control_wires = getattr(op, "control_wires", [])
     control_values = op.hyperparameters.get("control_values", None)
+
+    if isinstance(op, Controlled) and (base_control_wires := getattr(op.base, "control_wires", [])):
+        control_wires += base_control_wires
+        control_values += [1] * len(base_control_wires)
+
     if control_values:
         for w, val in zip(control_wires, control_values):
             layer_str[wire_map[w]] += "●" if _bool_control_value(val) else "○"

--- a/pennylane/ops/op_math/controlled.py
+++ b/pennylane/ops/op_math/controlled.py
@@ -533,14 +533,6 @@ class Controlled(SymbolicOp):
         ]
 
     def simplify(self) -> "Controlled":
-        if isinstance(self.base, Controlled):
-            base = self.base.base.simplify()
-            return self.__class__(
-                base,
-                control_wires=self.control_wires + self.base.control_wires,
-                control_values=self.control_values + self.base.control_values,
-                work_wires=self.work_wires + self.base.work_wires,
-            )
         return self.__class__(
             base=self.base.simplify(),
             control_wires=self.control_wires,

--- a/pennylane/ops/op_math/controlled.py
+++ b/pennylane/ops/op_math/controlled.py
@@ -274,6 +274,13 @@ class Controlled(SymbolicOp):
                 "Work wires must be different the control_wires and base operation wires."
             )
 
+        if isinstance(base, Controlled):
+            qml.QueuingManager.remove(base)
+            control_wires = control_wires + base.control_wires
+            work_wires = work_wires + base.work_wires
+            control_values = control_values + base.control_values
+            base = base.base
+
         self.hyperparameters["control_wires"] = control_wires
         self.hyperparameters["control_values"] = control_values
         self.hyperparameters["work_wires"] = work_wires

--- a/tests/drawer/test_tape_text.py
+++ b/tests/drawer/test_tape_text.py
@@ -82,6 +82,11 @@ class TestHelperFunctions:
             (qml.Snapshot(), ["─|Snap|", "─|Snap|", "─|Snap|", "─|Snap|"]),
             (qml.Barrier(), ["─||", "─||", "─||", "─||"]),
             (qml.S(0) @ qml.T(0), ["─S@T", "─", "─", "─"]),
+            (qml.ctrl(qml.CNOT(wires=(0, 2)), control=1), ["╭●", "├●", "╰X", "─"]),
+            (
+                qml.ctrl(qml.CNOT(wires=(0, 2)), control=1, control_values=[False]),
+                ["╭●", "├○", "╰X", "─"],
+            ),
         ],
     )
     def test_add_op(self, op, out):

--- a/tests/ops/op_math/test_controlled.py
+++ b/tests/ops/op_math/test_controlled.py
@@ -160,6 +160,17 @@ class TestInitialization:
         op = Controlled(self.temp_op, (0, 1, 2), control_values=["", None, 5])
         assert op.control_values == [False, False, True]
 
+    def test_nested_controlled_ops(self):
+        """Test that nested controlled operations are simplified during initialization."""
+        op = Controlled(self.temp_op, (0, 1, 2), control_values=[True, False, True])
+        op2 = Controlled(op, (3, 4, 5), control_values=[False, True, False])
+
+        final_op = Controlled(
+            self.temp_op, (3, 4, 5, 0, 1, 2), control_values=[False, True, False, True, False, True]
+        )
+
+        assert qml.equal(op2, final_op)
+
     def test_control_values_wrong_length(self):
         """Test checking control_values length error."""
         with pytest.raises(ValueError, match="control_values should be the same length"):
@@ -1381,7 +1392,7 @@ def test_nested_ctrl():
     assert len(tape.operations) == 1
     op = tape.operations[0]
     assert isinstance(op, Controlled)
-    new_tape = tape.expand(depth=2)
+    new_tape = tape.expand(depth=1)
     assert qml.equal(new_tape[0], qml.Toffoli(wires=[3, 7, 0]))
 
 

--- a/tests/ops/op_math/test_controlled_ops.py
+++ b/tests/ops/op_math/test_controlled_ops.py
@@ -20,9 +20,8 @@ import pytest
 from scipy.stats import unitary_group
 
 import pennylane as qml
-from pennylane.wires import Wires
 from pennylane.ops.qubit.matrix_ops import QubitUnitary
-
+from pennylane.wires import Wires
 
 X = np.array([[0, 1], [1, 0]])
 X_broadcasted = np.array([X] * 3)
@@ -228,8 +227,8 @@ class TestControlledQubitUnitary:
         U = unitary_group.rvs(2 ** len(target_wires), random_state=1967)
 
         # Pick random starting state for the control and target qubits
-        control_state_weights = np.random.normal(size=(2 ** (len(control_wires) + 1) - 2))
-        target_state_weights = np.random.normal(size=(2 ** (len(target_wires) + 1) - 2))
+        control_state_weights = np.random.normal(size=2 ** (len(control_wires) + 1) - 2)
+        target_state_weights = np.random.normal(size=2 ** (len(target_wires) + 1) - 2)
 
         @qml.qnode(dev)
         def circuit_mixed_polarity():


### PR DESCRIPTION
- Simplify nested `Controlled` ops during initialisation.
- Take into account nested controlled ops in drawer.

Fixes: https://github.com/PennyLaneAI/pennylane/issues/3702