### PR TITLE
Fix bug related to labeling of nested controlled operations in drawer

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -608,6 +608,10 @@
 
 <h3>Bug fixes</h3>
 
+* Fixed a bug in the drawer where nested controlled operations would output
+  the label of the operation being controlled, rather than the control values.
+  [(#)](https://github.com/PennyLaneAI/pennylane/pull/)
+
 * Fixed a bug in `qml.transforms.metric_tensor` where prefactors of operation generators were taken
   into account multiple times, leading to wrong outputs for non-standard operations.
   [(#3579)](https://github.com/PennyLaneAI/pennylane/pull/3579)
@@ -664,6 +668,7 @@ Utkarsh Azad
 Cristian Boghiu
 Astral Cai
 Isaac De Vlugt
+Olivia Di Matteo
 Lillian M. A. Frederiksen
 Soran Jahangiri
 Christina Lee

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -610,7 +610,7 @@
 
 * Fixed a bug in the drawer where nested controlled operations would output
   the label of the operation being controlled, rather than the control values.
-  [(#)](https://github.com/PennyLaneAI/pennylane/pull/)
+  [(#3745)](https://github.com/PennyLaneAI/pennylane/pull/3745)
 
 * Fixed a bug in `qml.transforms.metric_tensor` where prefactors of operation generators were taken
   into account multiple times, leading to wrong outputs for non-standard operations.

--- a/pennylane/drawer/tape_mpl.py
+++ b/pennylane/drawer/tape_mpl.py
@@ -23,7 +23,7 @@ from pennylane import ops
 from pennylane.wires import Wires
 from .mpldrawer import MPLDrawer
 from .drawable_layers import drawable_layers
-from .utils import convert_wire_order
+from .utils import convert_wire_order, unwrap_controls
 from .style import use_style
 
 has_mpl = True
@@ -131,15 +131,14 @@ def _tape_mpl(tape, wire_order=None, show_all_wires=False, decimals=None, **kwar
                 specialfunc(drawer, layer, mapped_wires, op)
 
             else:
-                op_control_wires = getattr(op, "control_wires", [])
+                op_control_wires, control_values = unwrap_controls(op)
+
                 control_wires = [wire_map[w] for w in op_control_wires]
                 target_wires = (
                     [wire_map[w] for w in op.wires if w not in op_control_wires]
                     if len(op.wires) != 0
                     else wire_map.values()
                 )
-                # It is assumed that if `op.wires == 0`, `op` acts on all wires
-                control_values = op.hyperparameters.get("control_values", None)
 
                 if control_values is None:
                     control_values = [True for _ in control_wires]

--- a/pennylane/drawer/tape_text.py
+++ b/pennylane/drawer/tape_text.py
@@ -17,6 +17,7 @@ This module contains logic for the text based circuit drawer through the ``tape_
 
 import pennylane as qml
 from pennylane.measurements import Expectation, Probability, Sample, Variance, State
+from pennylane.ops import ControlledOp
 
 from .drawable_layers import drawable_layers
 from .utils import convert_wire_order
@@ -51,7 +52,7 @@ def _add_op(op, layer_str, wire_map, decimals, cache):
     # Controlled operations may themselves contain controlled operations; check
     # for any nesting of operators when drawing so that we correctly identify
     # and label _all_ control and target qubits
-    if isinstance(op, qml.ops.ControlledOp):
+    if isinstance(op, ControlledOp):
         next_ctrl = op
 
         while hasattr(next_ctrl, "base"):

--- a/pennylane/drawer/utils.py
+++ b/pennylane/drawer/utils.py
@@ -14,7 +14,7 @@
 """
 This module contains some useful utility functions for circuit drawing.
 """
-from pennylane.ops import ControlledOp
+from pennylane.ops import Controlled
 
 
 def default_wire_map(tape):
@@ -77,7 +77,7 @@ def unwrap_controls(op):
     control_wires = getattr(op, "control_wires", [])
     control_values = op.hyperparameters.get("control_values", None)
 
-    if isinstance(op, ControlledOp):
+    if isinstance(op, Controlled):
         next_ctrl = op
 
         while hasattr(next_ctrl, "base"):

--- a/pennylane/drawer/utils.py
+++ b/pennylane/drawer/utils.py
@@ -74,11 +74,11 @@ def unwrap_controls(op):
         Wires, List: The control wires of the operation, along with any associated
         control values.
     """
-    control_wires = getattr(op, "control_wires", [])
-
     # Get wires and control values of base operation; need to make a copy of
     # control values, otherwise it will modify the list in the operation itself.
+    control_wires = getattr(op, "control_wires", [])
     control_values = op.hyperparameters.get("control_values", None)
+
     if isinstance(control_values, list):
         control_values = control_values.copy()
 

--- a/pennylane/drawer/utils.py
+++ b/pennylane/drawer/utils.py
@@ -75,7 +75,12 @@ def unwrap_controls(op):
         control values.
     """
     control_wires = getattr(op, "control_wires", [])
+
+    # Get wires and control values of base operation; need to make a copy of
+    # control values, otherwise it will modify the list in the operation itself.
     control_values = op.hyperparameters.get("control_values", None)
+    if isinstance(control_values, list):
+        control_values = control_values.copy()
 
     if isinstance(op, Controlled):
         next_ctrl = op

--- a/tests/drawer/test_drawer_utils.py
+++ b/tests/drawer/test_drawer_utils.py
@@ -17,7 +17,8 @@ Unit tests for the pennylane.drawer.utils` module.
 
 import pytest
 import pennylane as qml
-from pennylane.drawer.utils import default_wire_map, convert_wire_order
+from pennylane.drawer.utils import default_wire_map, convert_wire_order, unwrap_controls
+from pennylane.wires import Wires
 
 
 class TestDefaultWireMap:
@@ -93,3 +94,55 @@ class TestConvertWireOrder:
 
         wire_map = convert_wire_order(ops, wire_order, show_all_wires=True)
         assert wire_map == {"a": 0, "b": 1, "c": 2, "d": 3}
+
+
+class TestUnwrapControls:
+    """Tests the ``unwrap_controls`` utility function."""
+
+    @pytest.mark.parametrize(
+        "op,expected_control_wires,expected_control_values",
+        [
+            (qml.PauliX(wires="a"), Wires([]), None),
+            (qml.CNOT(wires=["a", "b"]), Wires("a"), None),
+            (qml.ctrl(qml.PauliX(wires="b"), control="a"), Wires("a"), [True]),
+            (
+                qml.ctrl(qml.PauliX(wires="b"), control=["a", "c", "d"]),
+                Wires(["a", "c", "d"]),
+                [True, True, True],
+            ),
+            (
+                qml.ctrl(qml.PauliZ(wires="c"), control=["a", "d"], control_values=[True, False]),
+                Wires(["a", "d"]),
+                [True, False],
+            ),
+            (
+                qml.ctrl(qml.CNOT(wires=["c", "d"]), control=["a", "b"]),
+                Wires(["a", "b", "c"]),
+                [True, True, True],
+            ),
+            (
+                qml.ctrl(qml.ctrl(qml.CNOT(wires=["c", "d"]), control=["a", "b"]), control=["e"]),
+                Wires(["e", "a", "b", "c"]),
+                [True, True, True, True],
+            ),
+            (
+                qml.ctrl(
+                    qml.ctrl(
+                        qml.CNOT(wires=["c", "d"]), control=["a", "b"], control_values=[False, True]
+                    ),
+                    control=["e"],
+                    control_values=[False],
+                ),
+                Wires(["e", "a", "b", "c"]),
+                [False, False, True, True],
+            ),
+        ],
+    )
+    def test_multi_defined_control_values(
+        self, op, expected_control_wires, expected_control_values
+    ):
+        """Test a multi-controlled single-qubit operation with defined control values."""
+        control_wires, control_values = unwrap_controls(op)
+
+        assert control_wires == expected_control_wires
+        assert control_values == expected_control_values

--- a/tests/drawer/test_drawer_utils.py
+++ b/tests/drawer/test_drawer_utils.py
@@ -116,6 +116,15 @@ class TestUnwrapControls:
                 [True, False],
             ),
             (
+                qml.ctrl(
+                    qml.CRX(0.3, wires=["c", "e"]),
+                    control=["a", "b", "d"],
+                    control_values=[True, False, False],
+                ),
+                Wires(["a", "b", "d", "c"]),
+                [True, False, False, True],
+            ),
+            (
                 qml.ctrl(qml.CNOT(wires=["c", "d"]), control=["a", "b"]),
                 Wires(["a", "b", "c"]),
                 [True, True, True],

--- a/tests/drawer/test_tape_mpl.py
+++ b/tests/drawer/test_tape_mpl.py
@@ -463,6 +463,20 @@ class TestControlledGates:
         tape = QuantumScript.from_queue(q_tape)
         self.check_tape_controlled_qubit_unitary(tape)
 
+    def test_nested_control_values_bool(self):
+        """Test control_values get displayed correctly for nested controlled operations
+        when they are provided as a list of bools."""
+
+        with qml.queuing.AnnotatedQueue() as q_tape:
+            qml.ctrl(
+                qml.ctrl(qml.PauliX(wires=4), control=[2, 3], control_values=[1, 0]),
+                control=[0, 1],
+                control_values=[1, 0],
+            )
+
+        tape = QuantumScript.from_queue(q_tape)
+        self.check_tape_controlled_qubit_unitary(tape)
+
     def check_tape_controlled_qubit_unitary(self, tape):
         """Checks the control symbols for a tape with some version of a controlled qubit unitary."""
         _, ax = tape_mpl(tape, style=None)  # set style to None to use plt.rcParams values

--- a/tests/drawer/test_tape_text.py
+++ b/tests/drawer/test_tape_text.py
@@ -298,6 +298,25 @@ single_op_tests_data = [
         ),
         "0: ───┤ ╭<𝓗>\n1: ───┤ ╰<𝓗>",
     ),
+    # Operations (both regular and controlled) and nested multi-valued controls
+    (qml.ctrl(qml.PauliX(wires=2), control=[0, 1]), "0: ─╭●─┤  \n1: ─├●─┤  \n2: ─╰X─┤  "),
+    (qml.ctrl(qml.CNOT(wires=[1, 2]), control=0), "0: ─╭●─┤  \n1: ─├●─┤  \n2: ─╰X─┤  "),
+    (
+        qml.ctrl(qml.CRZ(0.2, wires=[1, 2]), control=[3, 0]),
+        "3: ─╭●────────┤  \n0: ─├●────────┤  \n1: ─├●────────┤  \n2: ─╰RZ(0.20)─┤  ",
+    ),
+    (
+        qml.ctrl(qml.CH(wires=[0, 3]), control=[2, 1], control_values=[False, True]),
+        "2: ─╭○─┤  \n1: ─├●─┤  \n0: ─├●─┤  \n3: ─╰H─┤  ",
+    ),
+    (
+        qml.ctrl(
+            qml.ctrl(qml.CY(wires=[3, 4]), control=[1, 2], control_values=[True, False]),
+            control=0,
+            control_values=[False],
+        ),
+        "0: ─╭○─┤  \n1: ─├●─┤  \n2: ─├○─┤  \n3: ─├●─┤  \n4: ─╰Y─┤  ",
+    ),
 ]
 
 


### PR DESCRIPTION
**Context:** When drawing operations where controls are nested (e.g., a controlled controlled operation, or nested use of `qml.ctrl`, not all the control wires were identified as such, and would be drawn using the label of the operation being applied under the control.

**Description of the Change:** Updates the tape text drawer to handle the special case of controlled operations when drawing

**Benefits:** Tapes are now drawn correctly :tada:

**Possible Drawbacks:** Matplotlib case was also affected; have visually inspected that the results are now correct, but not sure how to write the tests.

**Related GitHub Issues:** #3702 
