### PR TITLE
Update gather dispatch functions, use in marginal_probs

### DIFF
--- a/pennylane/math/single_dispatch.py
+++ b/pennylane/math/single_dispatch.py
@@ -51,7 +51,11 @@ ar.register_function("numpy", "flatten", lambda x: x.flatten())
 ar.register_function("numpy", "coerce", lambda x: x)
 ar.register_function("numpy", "block_diag", lambda x: _scipy_block_diag(*x))
 ar.register_function("builtins", "block_diag", lambda x: _scipy_block_diag(*x))
-ar.register_function("numpy", "gather", lambda x, indices: x[np.array(indices)])
+ar.register_function(
+    "numpy",
+    "gather",
+    lambda x, indices, axis=0: x[:, np.array(indices)] if axis == 1 else x[np.array(indices)],
+)
 ar.register_function("numpy", "unstack", list)
 
 ar.register_function("builtins", "unstack", list)
@@ -105,7 +109,11 @@ ar.autoray._MODULE_ALIASES["autograd"] = "pennylane.numpy"
 
 ar.register_function("autograd", "flatten", lambda x: x.flatten())
 ar.register_function("autograd", "coerce", lambda x: x)
-ar.register_function("autograd", "gather", lambda x, indices: x[np.array(indices)])
+ar.register_function(
+    "autograd",
+    "gather",
+    lambda x, indices, axis=0: x[:, np.array(indices)] if axis == 1 else x[np.array(indices)],
+)
 ar.register_function("autograd", "unstack", list)
 
 
@@ -476,7 +484,9 @@ ar.register_function("torch", "asarray", _asarray_torch)
 ar.register_function("torch", "diag", lambda x, k=0: _i("torch").diag(x, diagonal=k))
 ar.register_function("torch", "expand_dims", lambda x, axis: _i("torch").unsqueeze(x, dim=axis))
 ar.register_function("torch", "shape", lambda x: tuple(x.shape))
-ar.register_function("torch", "gather", lambda x, indices: x[indices])
+ar.register_function(
+    "torch", "gather", lambda x, indices, axis=0: x[:, indices] if axis == 1 else x[indices]
+)
 ar.register_function("torch", "equal", lambda x, y: _i("torch").eq(x, y))
 
 ar.register_function(
@@ -697,7 +707,11 @@ ar.register_function(
 ar.register_function("jax", "coerce", lambda x: x)
 ar.register_function("jax", "to_numpy", _to_numpy_jax)
 ar.register_function("jax", "block_diag", lambda x: _i("jax").scipy.linalg.block_diag(*x))
-ar.register_function("jax", "gather", lambda x, indices: x[np.array(indices)])
+ar.register_function(
+    "jax",
+    "gather",
+    lambda x, indices, axis=0: x[:, np.array(indices)] if axis == 1 else x[np.array(indices)],
+)
 
 
 def _ndim_jax(x):

--- a/pennylane/measurements/probs.py
+++ b/pennylane/measurements/probs.py
@@ -318,4 +318,5 @@ class ProbabilityMP(SampleMeasurement, StateMeasurement):
 
         powers_of_two = 2 ** qml.math.arange(num_wires)[::-1]
         perm = basis_states @ powers_of_two
-        return prob[:, perm] if batch_size is not None else prob[perm]
+        gather_axis = 0 if batch_size is None else 1
+        return qml.math.gather(prob, indices=perm, axis=gather_axis)

--- a/tests/measurements/test_probs.py
+++ b/tests/measurements/test_probs.py
@@ -232,6 +232,27 @@ class TestProbs:
         assert subset_probs.shape == (len(expected),)
         assert qml.math.allclose(subset_probs, expected)
 
+    @pytest.mark.all_interfaces
+    @pytest.mark.parametrize("interface", ["numpy", "jax", "torch", "tensorflow"])
+    @pytest.mark.parametrize(
+        "subset_wires,expected",
+        [
+            ([1, 2], [[0.5, 0, 0.5, 0], [0, 0.5, 0, 0.5]]),
+            ([2, 0], [[0.5, 0.5, 0, 0], [0, 0, 0.5, 0.5]]),
+            (
+                [1, 2, 0],
+                [[0.25, 0.25, 0.25, 0.25, 0, 0, 0, 0], [0, 0, 0, 0, 0.25, 0.25, 0.25, 0.25]],
+            ),
+        ],
+    )
+    def test_process_state_batched(self, interface, subset_wires, expected):
+        """Tests that process_state functions as expected with all interfaces with batching."""
+        states = qml.math.array([[1 / 2, 0] * 4, [0, 1 / 2] * 4], like=interface)
+        wires = qml.wires.Wires(range(3))
+        subset_probs = qml.probs(wires=subset_wires).process_state(states, wires)
+        assert subset_probs.shape == qml.math.shape(expected)
+        assert qml.math.allclose(subset_probs, expected)
+
     def test_integration(self, tol, mocker):
         """Test the probability is correct for a known state preparation."""
         dev = qml.device("default.qubit", wires=2)

--- a/tests/measurements/test_probs.py
+++ b/tests/measurements/test_probs.py
@@ -211,6 +211,27 @@ class TestProbs:
 
         custom_measurement_process(dev, spy_probs)
 
+    @pytest.mark.all_interfaces
+    @pytest.mark.parametrize("interface", ["numpy", "jax", "torch", "tensorflow"])
+    @pytest.mark.parametrize(
+        "subset_wires,expected",
+        [
+            ([0, 1], [0.25, 0.25, 0.25, 0.25]),
+            ([1, 2], [0.5, 0, 0.5, 0]),
+            ([0, 2], [0.5, 0, 0.5, 0]),
+            ([2, 0], [0.5, 0.5, 0, 0]),
+            ([2, 1], [0.5, 0.5, 0, 0]),
+            ([1, 2, 0], [0.25, 0.25, 0.25, 0.25, 0, 0, 0, 0]),
+        ],
+    )
+    def test_process_state(self, interface, subset_wires, expected):
+        """Tests that process_state functions as expected with all interfaces."""
+        state = qml.math.array([1 / 2, 0] * 4, like=interface)
+        wires = qml.wires.Wires(range(3))
+        subset_probs = qml.probs(wires=subset_wires).process_state(state, wires)
+        assert subset_probs.shape == (len(expected),)
+        assert qml.math.allclose(subset_probs, expected)
+
     def test_integration(self, tol, mocker):
         """Test the probability is correct for a known state preparation."""
         dev = qml.device("default.qubit", wires=2)


### PR DESCRIPTION
**Context:**
I was working on #3720 and @albi3ro pointed out that I could just use `ProbabilityMP.process_state` rather than re-invent the wheel. I love that, but there was a compatibility issue with `process_state(some_tf_tensor)`. The tensorflow way is to use `tf.gather`, but our dispatch to other interfaces doesn't accept an axis argument so that can't be updated easily for all interfaces.

**Description of the Change:**
- Update the `gather` dispatch method for all interfaces to accept an `axis` attribute
- Use `qml.math.gather` in `ProbabilityMP.marginal_probs` so it works with tensorflow

**Benefits:**
- `qml.probs().process_state()` will work with all interfaces
- My sample_state PR will be unblocked

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
#3720 