### PR TITLE
Add check for auto interface and device that do not support backprop

### DIFF
--- a/pennylane/qnode.py
+++ b/pennylane/qnode.py
@@ -460,16 +460,15 @@ class QNode:
             self.gradient_fn = None
             self.gradient_kwargs = {}
             return
-        if self.interface == "auto":
+        if self.interface == "auto" and self.diff_method == "backprop":
             # Check that the device has the capabilities to support backprop
-            if self.diff_method == "backprop":
-                backprop_devices = self.device.capabilities().get("passthru_devices", None)
-                if backprop_devices is None:
-                    raise qml.QuantumFunctionError(
-                        f"The {self.device.short_name} device does not support native computations with "
-                        "autodifferentiation frameworks."
-                    )
-                return
+            backprop_devices = self.device.capabilities().get("passthru_devices", None)
+            if backprop_devices is None:
+                raise qml.QuantumFunctionError(
+                    f"The {self.device.short_name} device does not support native computations with "
+                    "autodifferentiation frameworks."
+                )
+            return
 
         self.gradient_fn, self.gradient_kwargs, self.device = self.get_gradient_fn(
             self._original_device, self.interface, self.diff_method

--- a/pennylane/qnode.py
+++ b/pennylane/qnode.py
@@ -469,7 +469,7 @@ class QNode:
                         f"The {self.device.short_name} device does not support native computations with "
                         "autodifferentiation frameworks."
                     )
-            return
+                return
 
         self.gradient_fn, self.gradient_kwargs, self.device = self.get_gradient_fn(
             self._original_device, self.interface, self.diff_method

--- a/pennylane/qnode.py
+++ b/pennylane/qnode.py
@@ -460,14 +460,15 @@ class QNode:
             self.gradient_fn = None
             self.gradient_kwargs = {}
             return
-        if self.interface == "auto" and self.diff_method == "backprop":
-            # Check that the device has the capabilities to support backprop
-            backprop_devices = self.device.capabilities().get("passthru_devices", None)
-            if backprop_devices is None:
-                raise qml.QuantumFunctionError(
-                    f"The {self.device.short_name} device does not support native computations with "
-                    "autodifferentiation frameworks."
-                )
+        if self.interface == "auto" and self.diff_method in ["backprop", "best"]:
+            if self.diff_method == "backprop":
+                # Check that the device has the capabilities to support backprop
+                backprop_devices = self.device.capabilities().get("passthru_devices", None)
+                if backprop_devices is None:
+                    raise qml.QuantumFunctionError(
+                        f"The {self.device.short_name} device does not support native computations with "
+                        "autodifferentiation frameworks."
+                    )
             return
 
         self.gradient_fn, self.gradient_kwargs, self.device = self.get_gradient_fn(

--- a/pennylane/qnode.py
+++ b/pennylane/qnode.py
@@ -461,6 +461,14 @@ class QNode:
             self.gradient_kwargs = {}
             return
         if self.interface == "auto":
+            # Check that the device has the capabilities to support backprop
+            if self.diff_method == "backprop":
+                backprop_devices = self.device.capabilities().get("passthru_devices", None)
+                if backprop_devices is None:
+                    raise qml.QuantumFunctionError(
+                        f"The {self.device.short_name} device does not support native computations with "
+                        "autodifferentiation frameworks."
+                    )
             return
 
         self.gradient_fn, self.gradient_kwargs, self.device = self.get_gradient_fn(

--- a/tests/devices/test_lightning_qubit.py
+++ b/tests/devices/test_lightning_qubit.py
@@ -42,6 +42,24 @@ def test_integration():
     assert np.allclose(qml.grad(qn_l)(weights), qml.grad(qn_d)(weights))
 
 
+def test_no_backprop_auto_interface():
+    """Test that lightning.qubit does not support the backprop
+    differentiation method."""
+
+    dev = qml.device("lightning.qubit", wires=2)
+
+    def circuit():
+        """Simple quantum function."""
+        return qml.expval(qml.PauliZ(0))
+
+    with pytest.raises(
+        qml.QuantumFunctionError,
+        match="The lightning.qubit device does not support native "
+        "computations with autodifferentiation frameworks.",
+    ):
+        qml.QNode(circuit, dev, diff_method="backprop")
+
+
 class TestDtypePreserved:
     """Test that the user-defined dtype of the device is preserved for QNode
     evaluation"""

--- a/tests/devices/test_lightning_qubit.py
+++ b/tests/devices/test_lightning_qubit.py
@@ -60,6 +60,23 @@ def test_no_backprop_auto_interface():
         qml.QNode(circuit, dev, diff_method="backprop")
 
 
+def test_finite_shots_adjoint():
+    """Test that that shots and adjoint diff raises an error."""
+
+    dev = qml.device("lightning.qubit", wires=2, shots=2)
+
+    def circuit():
+        """Simple quantum function."""
+        return qml.expval(qml.PauliZ(0))
+
+    with pytest.warns(
+        UserWarning,
+        match="Requested adjoint differentiation to be computed with finite shots. Adjoint differentiation always "
+        "calculated exactly.",
+    ):
+        qml.QNode(circuit, dev, diff_method="adjoint")
+
+
 class TestDtypePreserved:
     """Test that the user-defined dtype of the device is preserved for QNode
     evaluation"""

--- a/tests/devices/test_lightning_qubit.py
+++ b/tests/devices/test_lightning_qubit.py
@@ -61,7 +61,7 @@ def test_no_backprop_auto_interface():
 
 
 def test_finite_shots_adjoint():
-    """Test that that shots and adjoint diff raises an error."""
+    """Test that shots and adjoint diff raises an error."""
 
     dev = qml.device("lightning.qubit", wires=2, shots=2)
 

--- a/tests/test_qnode.py
+++ b/tests/test_qnode.py
@@ -361,16 +361,15 @@ class TestValidation:
 
         qn = QNode(dummyfunc, dev, diff_method="device")
         assert qn.diff_method == "device"
-        assert qn.gradient_fn is None
+        assert qn.gradient_fn == "device"
 
         qn = QNode(dummyfunc, dev, interface="autograd", diff_method="device")
         assert qn.diff_method == "device"
         assert qn.gradient_fn == "device"
-        mock_device.assert_called_once()
 
         qn = QNode(dummyfunc, dev, diff_method="finite-diff")
         assert qn.diff_method == "finite-diff"
-        assert qn.gradient_fn is None
+        assert qn.gradient_fn is qml.gradients.finite_diff
 
         qn = QNode(dummyfunc, dev, interface="autograd", diff_method="finite-diff")
         assert qn.diff_method == "finite-diff"
@@ -378,7 +377,7 @@ class TestValidation:
 
         qn = QNode(dummyfunc, dev, diff_method="spsa")
         assert qn.diff_method == "spsa"
-        assert qn.gradient_fn is None
+        assert qn.gradient_fn is qml.gradients.spsa_grad
 
         qn = QNode(dummyfunc, dev, interface="autograd", diff_method="spsa")
         assert qn.diff_method == "spsa"
@@ -386,7 +385,7 @@ class TestValidation:
 
         qn = QNode(dummyfunc, dev, diff_method="parameter-shift")
         assert qn.diff_method == "parameter-shift"
-        assert qn.gradient_fn is None
+        assert qn.gradient_fn is qml.gradients.param_shift
 
         qn = QNode(dummyfunc, dev, interface="autograd", diff_method="parameter-shift")
         assert qn.diff_method == "parameter-shift"


### PR DESCRIPTION
**Description of the Change:**

With the "auto" interface raises an error at initialization of QNode if the device does not support backprop.

It allows checks for all diff_method expect `best` and `backprop` as they require the interface.