### PR TITLE
Remove numpy version limit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy<1.24
+numpy~=1.24
 scipy~=1.8
 cvxpy~=1.2
 cvxopt~=1.3.0

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open("pennylane/_version.py") as f:
     version = f.readlines()[-1].split()[-1].strip("\"'")
 
 requirements = [
-    "numpy<1.24",
+    "numpy",
     "scipy",
     "networkx",
     "retworkx",


### PR DESCRIPTION
**Context:** This PR is now closed. The numpy version needs to stay limited because numpy removed support for ragged arrays.

**Description of the Change:** Remove the numpy version limit.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
