### PR TITLE
Allow flexible parameter shapes and multi-dimensional tape return shape in custom JVP

### DIFF
--- a/pennylane/interfaces/jax.py
+++ b/pennylane/interfaces/jax.py
@@ -164,12 +164,6 @@ def _execute(
     """The main interface execution function where jacobians of the execute
     function are computed by the registered backward function."""
 
-    # Copy a given tape with operations and set parameters
-    def cp_tape(t, a):
-        tc = t.copy(copy_operations=True)
-        tc.set_parameters(a)
-        return tc
-
     def array_if_not_counts(tape, r):
         """Auxiliary function to convert the result of a tape to an array,
         unless the tape had Counts measurements that are represented with
@@ -178,7 +172,7 @@ def _execute(
 
     @jax.custom_vjp
     def wrapped_exec(params):
-        new_tapes = [cp_tape(t, a) for t, a in zip(tapes, params)]
+        new_tapes = [_copy_tape(t, a) for t, a in zip(tapes, params)]
         with qml.tape.Unwrap(*new_tapes):
             res, _ = execute_fn(new_tapes, **gradient_kwargs)
 
@@ -199,7 +193,7 @@ def _execute(
             p = args[:-1]
             dy = args[-1]
 
-            new_tapes = [cp_tape(t, a) for t, a in zip(tapes, p)]
+            new_tapes = [_copy_tape(t, a) for t, a in zip(tapes, p)]
             with qml.tape.Unwrap(*new_tapes):
                 vjp_tapes, processing_fn = qml.gradients.batch_vjp(
                     new_tapes,
@@ -457,27 +451,24 @@ def _execute_bwd_new(
         new_tapes = [_copy_tape(t, a) for t, a in zip(tapes, primals[0])]
 
         if isinstance(gradient_fn, qml.gradients.gradient_transform):
+            _args = (
+                new_tapes,
+                tangents[0],
+                gradient_fn,
+                device.shot_vector,
+            )
+            _kwargs = {
+                "reduction": "append",
+                "gradient_kwargs": gradient_kwargs,
+            }
             if _n == max_diff:
+                print(f"_n==max_diff")
                 with qml.tape.Unwrap(*new_tapes):
-                    jvp_tapes, processing_fn = qml.gradients.batch_jvp(
-                        new_tapes,
-                        tangents[0],
-                        gradient_fn,
-                        device.shot_vector,
-                        reduction="append",
-                        gradient_kwargs=gradient_kwargs,
-                    )
+                    jvp_tapes, processing_fn = qml.gradients.batch_jvp(*_args, **_kwargs)
                     jvps = processing_fn(execute_fn(jvp_tapes)[0])
 
             else:
-                jvp_tapes, processing_fn = qml.gradients.batch_jvp(
-                    new_tapes,
-                    tangents[0],
-                    gradient_fn,
-                    device.shot_vector,
-                    reduction="append",
-                    gradient_kwargs=gradient_kwargs,
-                )
+                jvp_tapes, processing_fn = qml.gradients.batch_jvp(*_args, **_kwargs)
 
                 jvps = processing_fn(
                     execute_new(


### PR DESCRIPTION
**Context:**
The custom JVP rule in `gradients/jvp.py` assumes tape parameters to be scalars, and allows for a single axis of tape return types.

**Description of the Change:**
This PR updates `compute_jvp_single` to allow for flexible parameter shapes and multi-dimensional tape return shapes.
It also boils down some code bits to be a bit more concise.

**Benefits:**
More flexible JVPs. In particular, the option to differentiate with the interfaces while using non-scalar differentiable tape parameters, and when using multi-dimensional tape returns like e.g. broadcasted `probs`

**Possible Drawbacks:**
Code complexity.
Also, we should do a benchmark, although I think the previously supported cases should not be touched too much in their essence.

**Related GitHub Issues:**
TBD
