### PR TITLE
Allow scalar to be a 0d JAX array when calling `s_prod.sparse_matrix`

### DIFF
--- a/pennylane/ops/op_math/sprod.py
+++ b/pennylane/ops/op_math/sprod.py
@@ -227,7 +227,7 @@ class SProd(ScalarSymbolicOp):
         return self.scalar * self.base.eigvals()
 
     def sparse_matrix(self, wire_order=None):
-        return self.scalar * self.base.sparse_matrix(wire_order=wire_order)
+        return self.base.sparse_matrix(wire_order=wire_order).multiply(self.scalar)
 
     @property
     def has_matrix(self):


### PR DESCRIPTION
**Context:**
`qml.s_prod(jnp.array(1.0), qml.PauliX(0)).sparse_matrix()` fails because `scalar` is a `jnp.array` and `jnp.array * scipy.sparse_matrix` is not supported.

**Description of the Change:**
Use `scipy.sparse_matrix.multiply(scalar)` instead

**Related GitHub Issues:**
#3762 
