### PR TITLE
Add pytree version of `ParametrizedHamiltonian`

### DIFF
--- a/pennylane/devices/default_qubit_jax.py
+++ b/pennylane/devices/default_qubit_jax.py
@@ -218,7 +218,7 @@ class DefaultQubitJax(DefaultQubit):
 
         with jax.ensure_compile_time_eval():
             H_jax = ParametrizedHamiltonianPytree.from_hamiltonian(
-                operation.H, dense=len(self.wires) > 4, wire_order=self.wires
+                operation.H, dense=len(operation.wires) > 4, wire_order=self.wires
             )
 
         def fun(y, t):

--- a/pennylane/devices/default_qubit_jax.py
+++ b/pennylane/devices/default_qubit_jax.py
@@ -217,7 +217,7 @@ class DefaultQubitJax(DefaultQubit):
         state = self._flatten(state)
 
         with jax.ensure_compile_time_eval():
-            H_jax = ParametrizedHamiltonianPytree(
+            H_jax = ParametrizedHamiltonianPytree.from_hamiltonian(
                 operation.H, dense=len(self.wires) > 4, wire_order=self.wires
             )
 

--- a/pennylane/devices/default_qubit_jax.py
+++ b/pennylane/devices/default_qubit_jax.py
@@ -19,7 +19,7 @@ import numpy as np
 import pennylane as qml
 from pennylane.devices import DefaultQubit
 from pennylane.pulse import ParametrizedEvolution
-from pennylane.pulse.jax_utils import JaxParametrizedOperator
+from pennylane.pulse.parametrized_hamiltonian_pytree import ParametrizedHamiltonianPytree
 from pennylane.typing import TensorLike
 
 try:
@@ -217,7 +217,7 @@ class DefaultQubitJax(DefaultQubit):
         state = self._flatten(state)
 
         with jax.ensure_compile_time_eval():
-            H_jax = JaxParametrizedOperator.from_parametrized_hamiltonian(
+            H_jax = ParametrizedHamiltonianPytree(
                 operation.H, dense=len(self.wires) > 4, wire_order=self.wires
             )
 

--- a/pennylane/devices/default_qubit_jax.py
+++ b/pennylane/devices/default_qubit_jax.py
@@ -218,7 +218,7 @@ class DefaultQubitJax(DefaultQubit):
 
         with jax.ensure_compile_time_eval():
             H_jax = ParametrizedHamiltonianPytree.from_hamiltonian(
-                operation.H, dense=len(operation.wires) > 4, wire_order=self.wires
+                operation.H, dense=len(operation.wires) < 3, wire_order=self.wires
             )
 
         def fun(y, t):

--- a/pennylane/devices/default_qubit_jax.py
+++ b/pennylane/devices/default_qubit_jax.py
@@ -14,12 +14,12 @@
 """This module contains an jax implementation of the :class:`~.DefaultQubit`
 reference plugin.
 """
+# pylint: disable=ungrouped-imports
 import numpy as np
 
 import pennylane as qml
 from pennylane.devices import DefaultQubit
 from pennylane.pulse import ParametrizedEvolution
-from pennylane.pulse.parametrized_hamiltonian_pytree import ParametrizedHamiltonianPytree
 from pennylane.typing import TensorLike
 
 try:
@@ -27,6 +27,8 @@ try:
     import jax.numpy as jnp
     from jax.config import config as jax_config
     from jax.experimental.ode import odeint
+
+    from pennylane.pulse.parametrized_hamiltonian_pytree import ParametrizedHamiltonianPytree
 
 
 except ImportError as e:  # pragma: no cover
@@ -223,7 +225,7 @@ class DefaultQubitJax(DefaultQubit):
 
         def fun(y, t):
             """dy/dt = -i H(t) y"""
-            return -1j * (H_jax(operation.data, t=t) @ y)
+            return (-1j * H_jax(operation.data, t=t)) @ y
 
         result = odeint(fun, state, operation.t, **operation.odeint_kwargs)
         return self._reshape(result[-1], [2] * self.num_wires)

--- a/pennylane/devices/default_qubit_jax.py
+++ b/pennylane/devices/default_qubit_jax.py
@@ -32,7 +32,7 @@ try:
 
 
 except ImportError as e:  # pragma: no cover
-    raise ImportError("default.qubit.jax device requires installing jax>0.2.0") from e
+    raise ImportError("default.qubit.jax device requires installing jax>0.3.20") from e
 
 
 class DefaultQubitJax(DefaultQubit):

--- a/pennylane/pulse/jax_utils.py
+++ b/pennylane/pulse/jax_utils.py
@@ -15,8 +15,6 @@
 from dataclasses import dataclass, field
 from typing import Callable, Optional, Tuple
 
-import numpy as np
-
 import pennylane as qml
 
 from .parametrized_hamiltonian import ParametrizedHamiltonian
@@ -80,24 +78,6 @@ class JaxParametrizedOperator:
 
         return JaxParametrizedOperator(fixed_mat, parametrized_mat, tuple(H.coeffs_parametrized))
 
-    @property
-    def shape(self):
-        """Returns the shape of the matrix representation of the JaxParametrizedOperator.
-
-        Returns:
-            tuple: matrix shape
-        """
-        return self.O_fixed.shape
-
-    @property
-    def ndim(self):
-        """Returns the number of dimensions of the matrix representation of the JaxParametrizedOperator.
-
-        Returns:
-            int: number of dimensions
-        """
-        return self.O_fixed.ndim
-
     def tree_flatten(self):
         """Function used by ``jax`` to flatten the JaxParametrizedOperator.
 
@@ -133,35 +113,9 @@ class JaxLazyDot:
     coeffs: Tuple[complex, ...]
     ops: Tuple[sparse.CSR, ...]
 
-    def __array__(self, dtype=None):
-        res = 0
-        for c, o in zip(self.coeffs, self.ops):
-            if hasattr(o, "todense"):
-                o = o.todense()
-            res += c * o
-        return np.asarray(res, dtype=dtype)
-
     @jax.jit
     def __matmul__(self, v):
         return sum(c * (o @ v) for c, o in zip(self.coeffs, self.ops))
-
-    @property
-    def shape(self):
-        """Returns the shape of the matrix result of the operation.
-
-        Returns:
-            tuple: result shape
-        """
-        return self.ops[0].shape
-
-    @property
-    def ndim(self):
-        """Returns the number of dimensions of the matrix result of the operation.
-
-        Returns:
-            int: number of dimensions of the result
-        """
-        return self.ops[0].ndim
 
     def tree_flatten(self):
         """Function used by ``jax`` to flatten the JaxLazyDot operation.

--- a/pennylane/pulse/jax_utils.py
+++ b/pennylane/pulse/jax_utils.py
@@ -1,0 +1,188 @@
+# Copyright 2018-2021 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Module containing the ``JaxParametrizedOperator`` and ``JaxLazyDot`` classes."""
+from dataclasses import dataclass, field
+from typing import Callable, Optional, Tuple
+
+import numpy as np
+
+import pennylane as qml
+
+from .parametrized_hamiltonian import ParametrizedHamiltonian
+
+has_jax = True
+try:
+    import jax
+    import jax.numpy as jnp
+    from jax.experimental import sparse
+    from jax.tree_util import register_pytree_node_class
+except ImportError:
+    has_jax = False
+
+
+@register_pytree_node_class
+@dataclass
+class JaxParametrizedOperator:
+    """Jax pytree containing a parametrized operator."""
+
+    O_fixed: Optional[sparse.CSR]
+    O_parametrized: Tuple[sparse.CSR, ...]
+    coeff_parametrized: Tuple[
+        Callable[[float, float], complex], ...
+    ] = field()  # pytree_node=False)
+
+    def __call__(self, pars, t):
+        if self.O_fixed is not None:
+            ops = (self.O_fixed,)
+            coeffs = (1,)
+        else:
+            ops = ()
+            coeffs = ()
+        coeffs = coeffs + tuple(f(p, t) for f, p in zip(self.coeff_parametrized, pars))
+        return JaxLazyDot(coeffs, ops + self.O_parametrized)
+
+    @staticmethod
+    def from_parametrized_hamiltonian(
+        H: ParametrizedHamiltonian, dense: bool = False, wire_order=None
+    ):
+        """Construct a ``JaxParametrizedOperator`` from a ``ParametrizedHamiltonian``
+
+        Args:
+            H (ParametrizedHamiltonian): parametrized Hamiltonian to convert
+            dense (bool, optional): Decide wether a dense/sparse matrix is used. Defaults to False.
+            wire_order (list, optional): Wire order of the returned ``JaxParametrizedOperator``.
+                Defaults to None.
+
+        Returns:
+            JaxParametrizedOperator: jax-compatible parametrized operator
+        """
+        make_array = jnp.array if dense else sparse.CSR.fromdense
+
+        if len(H.ops_fixed) > 0:
+            fixed_mat = make_array(qml.matrix(H.H_fixed(), wire_order=wire_order))
+        else:
+            fixed_mat = None
+
+        parametrized_mat = tuple(
+            make_array(qml.matrix(op, wire_order=wire_order)) for op in H.ops_parametrized
+        )
+
+        return JaxParametrizedOperator(fixed_mat, parametrized_mat, tuple(H.coeffs_parametrized))
+
+    @property
+    def shape(self):
+        """Returns the shape of the matrix representation of the JaxParametrizedOperator.
+
+        Returns:
+            tuple: matrix shape
+        """
+        return self.O_fixed.shape
+
+    @property
+    def ndim(self):
+        """Returns the number of dimensions of the matrix representation of the JaxParametrizedOperator.
+
+        Returns:
+            int: number of dimensions
+        """
+        return self.O_fixed.ndim
+
+    def tree_flatten(self):
+        """Function used by ``jax`` to flatten the JaxParametrizedOperator.
+
+        Returns:
+            tuple: tuple containing the matrices and the parametrized coefficients defining the class
+        """
+        matrices = (
+            self.O_fixed,
+            self.O_parametrized,
+        )
+        param_coeffs = self.coeff_parametrized
+        return (matrices, param_coeffs)
+
+    @classmethod
+    def tree_unflatten(cls, param_coeffs: tuple, matrices: tuple):
+        """Function used by ``jax`` to unflatten the JaxParametrizedOperator.
+
+        Args:
+            param_coeffs (tuple): tuple containing the parametrized coefficients of the class
+            matrices (tuple): tuple containing the matrices of the class
+
+        Returns:
+            JaxParametrizedOperator: a JaxParametrizedOperator instance
+        """
+        return cls(*matrices, param_coeffs)
+
+
+@register_pytree_node_class
+@dataclass
+class JaxLazyDot:
+    """Jax pytree representing a lazy dot operation."""
+
+    coeffs: Tuple[complex, ...]
+    ops: Tuple[sparse.CSR, ...]
+
+    def __array__(self, dtype=None):
+        res = 0
+        for c, o in zip(self.coeffs, self.ops):
+            if hasattr(o, "todense"):
+                o = o.todense()
+            res += c * o
+        return np.asarray(res, dtype=dtype)
+
+    @jax.jit
+    def __matmul__(self, v):
+        return sum(c * (o @ v) for c, o in zip(self.coeffs, self.ops))
+
+    @property
+    def shape(self):
+        """Returns the shape of the matrix result of the operation.
+
+        Returns:
+            tuple: result shape
+        """
+        return self.ops[0].shape
+
+    @property
+    def ndim(self):
+        """Returns the number of dimensions of the matrix result of the operation.
+
+        Returns:
+            int: number of dimensions of the result
+        """
+        return self.ops[0].ndim
+
+    def tree_flatten(self):
+        """Function used by ``jax`` to flatten the JaxLazyDot operation.
+
+        Returns:
+            tuple: tuple containing children and the auxiliary data of the class
+        """
+        children = (self.coeffs, self.ops)
+        aux_data = None
+        return (children, aux_data)
+
+    # pylint: disable=unused-argument
+    @classmethod
+    def tree_unflatten(cls, aux_data, children):
+        """Function used by ``jax`` to unflatten the ``JaxLazyDot`` pytree.
+
+        Args:
+            aux_data (None): empty argument
+            children (tuple): tuple containing the coefficients and the matrices of the operation
+
+        Returns:
+            JaxLazyDot: JaxLazyDot instance
+        """
+        return cls(*children)

--- a/pennylane/pulse/parametrized_evolution.py
+++ b/pennylane/pulse/parametrized_evolution.py
@@ -24,13 +24,14 @@ import pennylane as qml
 from pennylane.operation import AnyWires, Operation
 
 from .parametrized_hamiltonian import ParametrizedHamiltonian
-from .parametrized_hamiltonian_pytree import ParametrizedHamiltonianPytree
 
 has_jax = True
 try:
     import jax
     import jax.numpy as jnp
     from jax.experimental.ode import odeint
+
+    from .parametrized_hamiltonian_pytree import ParametrizedHamiltonianPytree
 except ImportError as e:
     has_jax = False
 
@@ -314,7 +315,7 @@ class ParametrizedEvolution(Operation):
 
         def fun(y, t):
             """dy/dt = -i H(t) y"""
-            return -1j * (H_jax(self.data, t=t) @ y)
+            return (-1j * H_jax(self.data, t=t)) @ y
 
         result = odeint(fun, y0, self.t, **self.odeint_kwargs)
         mat = result[-1]

--- a/pennylane/pulse/parametrized_evolution.py
+++ b/pennylane/pulse/parametrized_evolution.py
@@ -308,7 +308,7 @@ class ParametrizedEvolution(Operation):
         y0 = jnp.eye(2 ** len(self.wires), dtype=complex)
 
         with jax.ensure_compile_time_eval():
-            H_jax = ParametrizedHamiltonianPytree(
+            H_jax = ParametrizedHamiltonianPytree.from_hamiltonian(
                 self.H, dense=len(self.wires) > 4, wire_order=self.wires
             )
 

--- a/pennylane/pulse/parametrized_evolution.py
+++ b/pennylane/pulse/parametrized_evolution.py
@@ -309,7 +309,7 @@ class ParametrizedEvolution(Operation):
 
         with jax.ensure_compile_time_eval():
             H_jax = ParametrizedHamiltonianPytree.from_hamiltonian(
-                self.H, dense=len(self.wires) > 4, wire_order=self.wires
+                self.H, dense=len(self.wires) < 3, wire_order=self.wires
             )
 
         def fun(y, t):

--- a/pennylane/pulse/parametrized_evolution.py
+++ b/pennylane/pulse/parametrized_evolution.py
@@ -22,9 +22,9 @@ from typing import List, Union
 
 import pennylane as qml
 from pennylane.operation import AnyWires, Operation
-from pennylane.pulse.jax_utils import JaxParametrizedOperator
 
 from .parametrized_hamiltonian import ParametrizedHamiltonian
+from .parametrized_hamiltonian_pytree import ParametrizedHamiltonianPytree
 
 has_jax = True
 try:
@@ -308,7 +308,7 @@ class ParametrizedEvolution(Operation):
         y0 = jnp.eye(2 ** len(self.wires), dtype=complex)
 
         with jax.ensure_compile_time_eval():
-            H_jax = JaxParametrizedOperator.from_parametrized_hamiltonian(
+            H_jax = ParametrizedHamiltonianPytree(
                 self.H, dense=len(self.wires) > 4, wire_order=self.wires
             )
 

--- a/pennylane/pulse/parametrized_hamiltonian_pytree.py
+++ b/pennylane/pulse/parametrized_hamiltonian_pytree.py
@@ -105,10 +105,12 @@ class LazyDotPytree:
     def __matmul__(self, other):
         return sum(c * (m @ other) for c, m in zip(self.coeffs, self.mats))
 
-    def __rmul__(self, other):
+    def __mul__(self, other):
         if jnp.array(other).ndim == 0:
             return LazyDotPytree(tuple(other * c for c in self.coeffs), self.mats)
         return NotImplemented
+
+    __rmul__ = __mul__
 
     def tree_flatten(self):
         """Function used by ``jax`` to flatten the JaxLazyDot operation.

--- a/pennylane/pulse/parametrized_hamiltonian_pytree.py
+++ b/pennylane/pulse/parametrized_hamiltonian_pytree.py
@@ -35,7 +35,7 @@ class ParametrizedHamiltonianPytree:
     coeffs_parametrized: Tuple[Callable]
 
     @staticmethod
-    def from_hamiltonian(H: ParametrizedHamiltonian, dense: bool = False, wire_order=None):
+    def from_hamiltonian(H: ParametrizedHamiltonian, *, dense: bool = False, wire_order=None):
         """Convert a ``ParametrizedHamiltonian`` into a jax pytree object.
 
         Args:

--- a/pennylane/pulse/parametrized_hamiltonian_pytree.py
+++ b/pennylane/pulse/parametrized_hamiltonian_pytree.py
@@ -113,7 +113,11 @@ class LazyDotPytree:
     @jax.jit
     def __matmul__(self, other):
         return sum(c * (m @ other) for c, m in zip(self.coeffs, self.mats))
-
+   def  __rmul__(self, other):
+        if jnp.array(other).ndim == 0:
+            return LazyDotPytree(tuple(other * c for c in self.coeffs), self.mats)
+        else:
+            return NotImplemented
     def tree_flatten(self):
         """Function used by ``jax`` to flatten the JaxLazyDot operation.
 

--- a/pennylane/pulse/parametrized_hamiltonian_pytree.py
+++ b/pennylane/pulse/parametrized_hamiltonian_pytree.py
@@ -41,6 +41,11 @@ class ParametrizedHamiltonianPytree:
     """
 
     def __init__(self, H: ParametrizedHamiltonian, dense: bool = False, wire_order=None):
+        if not has_jax:
+            raise ImportError(
+                "Module jax is required for the ``ParametrizedHamiltonianPytree`` class. "
+                "You can install jax via: pip install jax"
+            )
         make_array = jnp.array if dense else sparse.CSR.fromdense
 
         if len(H.ops_fixed) > 0:

--- a/pennylane/pulse/parametrized_hamiltonian_pytree.py
+++ b/pennylane/pulse/parametrized_hamiltonian_pytree.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Module containing the ``JaxParametrizedHamiltonian`` class."""
 from dataclasses import dataclass
-from typing import Callable, Tuple, Union
+from typing import Callable, Optional, Tuple, Union
 
 import pennylane as qml
 

--- a/pennylane/pulse/parametrized_hamiltonian_pytree.py
+++ b/pennylane/pulse/parametrized_hamiltonian_pytree.py
@@ -15,18 +15,14 @@
 from dataclasses import dataclass
 from typing import Callable, Optional, Tuple, Union
 
+import jax
+import jax.numpy as jnp
+from jax.experimental import sparse
+from jax.tree_util import register_pytree_node_class
+
 import pennylane as qml
 
 from .parametrized_hamiltonian import ParametrizedHamiltonian
-
-has_jax = True
-try:
-    import jax
-    import jax.numpy as jnp
-    from jax.experimental import sparse
-    from jax.tree_util import register_pytree_node_class
-except ImportError:
-    has_jax = False
 
 
 @register_pytree_node_class
@@ -51,11 +47,6 @@ class ParametrizedHamiltonianPytree:
         Returns:
             ParametrizedHamiltonianPytree: pytree object
         """
-        if not has_jax:
-            raise ImportError(
-                "Module jax is required for the ``ParametrizedHamiltonianPytree`` class. "
-                "You can install jax via: pip install jax"
-            )
         make_array = jnp.array if dense else sparse.CSR.fromdense
 
         if len(H.ops_fixed) > 0:

--- a/pennylane/pulse/parametrized_hamiltonian_pytree.py
+++ b/pennylane/pulse/parametrized_hamiltonian_pytree.py
@@ -113,11 +113,12 @@ class LazyDotPytree:
     @jax.jit
     def __matmul__(self, other):
         return sum(c * (m @ other) for c, m in zip(self.coeffs, self.mats))
-   def  __rmul__(self, other):
+
+    def __rmul__(self, other):
         if jnp.array(other).ndim == 0:
             return LazyDotPytree(tuple(other * c for c in self.coeffs), self.mats)
-        else:
-            return NotImplemented
+        return NotImplemented
+
     def tree_flatten(self):
         """Function used by ``jax`` to flatten the JaxLazyDot operation.
 

--- a/pennylane/pulse/parametrized_hamiltonian_pytree.py
+++ b/pennylane/pulse/parametrized_hamiltonian_pytree.py
@@ -108,7 +108,7 @@ class LazyDotPytree:
     """Jax pytree representing a lazy dot operation."""
 
     coeffs: Tuple[complex, ...]
-    mats: Tuple[sparse.CSR, ...]
+    mats: Tuple[Union[jnp.ndarray, sparse.CSR], ...]
 
     @jax.jit
     def __matmul__(self, other):

--- a/pennylane/pulse/parametrized_hamiltonian_pytree.py
+++ b/pennylane/pulse/parametrized_hamiltonian_pytree.py
@@ -34,7 +34,7 @@ except ImportError:
 class ParametrizedHamiltonianPytree:
     """Jax pytree class that represents a ``ParametrizedHamiltonian``."""
 
-    mat_fixed: Union[jnp.ndarray, sparse.CSR]
+    mat_fixed: Optional[Union[jnp.ndarray, sparse.CSR]]
     mats_parametrized: Tuple[Union[jnp.ndarray, sparse.CSR], ...]
     coeffs_parametrized: Tuple[Callable]
 

--- a/tests/pulse/test_parametrized_hamiltonian_pytree.py
+++ b/tests/pulse/test_parametrized_hamiltonian_pytree.py
@@ -15,12 +15,17 @@
 Unit tests for the ParametrizedHamiltonianPytree class
 """
 import numpy as np
+import pytest
 
 import pennylane as qml
-from pennylane.pulse.parametrized_hamiltonian_pytree import (
-    LazyDotPytree,
-    ParametrizedHamiltonianPytree,
-)
+
+try:
+    from pennylane.pulse.parametrized_hamiltonian_pytree import (
+        LazyDotPytree,
+        ParametrizedHamiltonianPytree,
+    )
+except ImportError:
+    pytestmark = pytest.mark.skip
 
 
 def f1(p, t):
@@ -36,6 +41,7 @@ params = [1.2, 2.3]
 H = qml.dot([1, 2, f1, f2], [qml.PauliX(0), qml.PauliY(1), qml.PauliZ(2), qml.Hadamard(3)])
 
 
+@pytest.mark.jax
 class TestParametrizedHamiltonianPytree:
     """Unit tests for the ParametrizedHamiltonianPytree class."""
 
@@ -93,6 +99,7 @@ class TestParametrizedHamiltonianPytree:
         assert new_H_pytree.coeffs_parametrized == H_pytree.coeffs_parametrized
 
 
+@pytest.mark.jax
 class TestLazyDotPytree:
     """Unit tests for the LazyDotPytree class."""
 

--- a/tests/pulse/test_parametrized_hamiltonian_pytree.py
+++ b/tests/pulse/test_parametrized_hamiltonian_pytree.py
@@ -1,0 +1,159 @@
+# Copyright 2018-2023 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Unit tests for the ParametrizedHamiltonianPytree class
+"""
+import numpy as np
+import pytest
+
+import pennylane as qml
+from pennylane.pulse import ParametrizedHamiltonian
+from pennylane.pulse.parametrized_hamiltonian_pytree import (
+    LazyDotPytree,
+    ParametrizedHamiltonianPytree,
+)
+
+
+def test_error_raised_if_jax_not_installed():
+    """Test that an error is raised if an ``Evolve`` operator is instantiated without jax installed"""
+    try:
+        import jax  # pylint: disable=unused-import
+
+        pytest.skip()
+    except ImportError:
+        ham = ParametrizedHamiltonian([], [])
+        with pytest.raises(ImportError, match="Module jax is required"):
+            ParametrizedHamiltonianPytree(ham)
+
+
+def f1(p, t):
+    return p * np.sin(t) * (t - 1)
+
+
+def f2(p, t):
+    return p * np.cos(t**2)
+
+
+params = [1.2, 2.3]
+
+H = qml.dot([1, 2, f1, f2], [qml.PauliX(0), qml.PauliY(1), qml.PauliZ(2), qml.Hadamard(3)])
+
+
+class TestParametrizedHamiltonianPytree:
+    """Unit tests for the ParametrizedHamiltonianPytree class."""
+
+    def test_attributes(self):
+        """Test that the attributes of the ParametrizedHamiltonianPytree class are initialized
+        correctly."""
+        from jax.experimental import sparse
+
+        H_pytree = ParametrizedHamiltonianPytree.from_hamiltonian(
+            H, dense=False, wire_order=[2, 3, 1, 0]
+        )
+
+        assert isinstance(H_pytree.mat_fixed, sparse.CSR)
+        assert isinstance(H_pytree.mats_parametrized, tuple)
+        assert H_pytree.coeffs_parametrized == [f1, f2]
+
+    def test_call_method(self):
+        """Test that the call method works correctly."""
+        H_pytree = ParametrizedHamiltonianPytree.from_hamiltonian(
+            H, dense=False, wire_order=[2, 3, 1, 0]
+        )
+
+        time = 4
+        res = H_pytree(params, t=time)
+
+        assert isinstance(res, LazyDotPytree)
+        assert qml.math.allclose(res.coeffs, (1, f1(params[0], time), f2(params[1], time)))
+
+    def test_flatten_method(self):
+        """Test the tree_flatten method."""
+        H_pytree = ParametrizedHamiltonianPytree.from_hamiltonian(
+            H, dense=False, wire_order=[2, 3, 1, 0]
+        )
+
+        flat_tree = H_pytree.tree_flatten()
+
+        assert isinstance(flat_tree, tuple)
+        assert flat_tree == (
+            (H_pytree.mat_fixed, H_pytree.mats_parametrized),
+            H_pytree.coeffs_parametrized,
+        )
+
+    def test_unflatten_method(self):
+        """Test the tree_unflatten method."""
+        H_pytree = ParametrizedHamiltonianPytree.from_hamiltonian(
+            H, dense=False, wire_order=[2, 3, 1, 0]
+        )
+
+        flat_tree = H_pytree.tree_flatten()
+
+        new_H_pytree = H_pytree.tree_unflatten(flat_tree[1], flat_tree[0])
+
+        assert new_H_pytree.mat_fixed == H_pytree.mat_fixed
+        assert new_H_pytree.mats_parametrized == H_pytree.mats_parametrized
+        assert new_H_pytree.coeffs_parametrized == H_pytree.coeffs_parametrized
+
+
+class TestLazyDotPytree:
+    """Unit tests for the LazyDotPytree class."""
+
+    def test_initialization(self):
+        coeffs = [1, 2, 3]
+        ops = [qml.PauliX(0), qml.PauliY(0), qml.PauliZ(0)]
+        mats = [qml.matrix(o) for o in ops]
+        D = LazyDotPytree(coeffs=coeffs, mats=mats)
+
+        assert D.coeffs == coeffs
+        assert D.mats == mats
+
+    def test_matmul(self):
+        """Test the __matmul__ method."""
+        coeffs = [1, 2, 3]
+        ops = [qml.PauliX(0), qml.PauliY(0), qml.PauliZ(0)]
+        mats = [qml.matrix(o) for o in ops]
+        D = LazyDotPytree(coeffs=coeffs, mats=mats)
+
+        another_matrix = qml.matrix(qml.PauliX(0))
+        res = D @ another_matrix
+
+        assert qml.math.allclose(res, qml.matrix(qml.dot(coeffs, ops)) @ another_matrix)
+
+    def test_flatten_method(self):
+        """Test the tree_flatten method."""
+        coeffs = [1, 2, 3]
+        ops = [qml.PauliX(0), qml.PauliY(0), qml.PauliZ(0)]
+        mats = [qml.matrix(o) for o in ops]
+        D = LazyDotPytree(coeffs=coeffs, mats=mats)
+
+        flat_tree = D.tree_flatten()
+
+        assert isinstance(flat_tree, tuple)
+        assert flat_tree[0] == (D.coeffs, D.mats)
+        assert flat_tree[1] is None
+
+    def test_unflatten_method(self):
+        """Test the tree_unflatten method."""
+        coeffs = [1, 2, 3]
+        ops = [qml.PauliX(0), qml.PauliY(0), qml.PauliZ(0)]
+        mats = [qml.matrix(o) for o in ops]
+        D = LazyDotPytree(coeffs=coeffs, mats=mats)
+
+        flat_tree = D.tree_flatten()
+
+        new_D = D.tree_unflatten(flat_tree[1], flat_tree[0])
+
+        assert new_D.coeffs == D.coeffs
+        assert new_D.mats == D.mats

--- a/tests/pulse/test_parametrized_hamiltonian_pytree.py
+++ b/tests/pulse/test_parametrized_hamiltonian_pytree.py
@@ -124,6 +124,21 @@ class TestLazyDotPytree:
 
         assert qml.math.allclose(res, qml.matrix(qml.dot(coeffs, ops)) @ another_matrix)
 
+    def test_rmul(self):
+        """Test the __rmul__ method"""
+        import jax.numpy as jnp
+
+        coeffs = [1, 2, 3]
+        ops = [qml.PauliX(0), qml.PauliY(0), qml.PauliZ(0)]
+        mats = [qml.matrix(o) for o in ops]
+        D = LazyDotPytree(coeffs=coeffs, mats=mats)
+
+        assert isinstance(3 * D, LazyDotPytree)
+        assert isinstance(D * 3, LazyDotPytree)
+
+        with pytest.raises(TypeError, match="unsupported operand type"):
+            _ = jnp.array([[1], [2]]) * D
+
     def test_flatten_method(self):
         """Test the tree_flatten method."""
         coeffs = [1, 2, 3]

--- a/tests/pulse/test_parametrized_hamiltonian_pytree.py
+++ b/tests/pulse/test_parametrized_hamiltonian_pytree.py
@@ -15,26 +15,12 @@
 Unit tests for the ParametrizedHamiltonianPytree class
 """
 import numpy as np
-import pytest
 
 import pennylane as qml
-from pennylane.pulse import ParametrizedHamiltonian
 from pennylane.pulse.parametrized_hamiltonian_pytree import (
     LazyDotPytree,
     ParametrizedHamiltonianPytree,
 )
-
-
-def test_error_raised_if_jax_not_installed():
-    """Test that an error is raised if an ``Evolve`` operator is instantiated without jax installed"""
-    try:
-        import jax  # pylint: disable=unused-import
-
-        pytest.skip()
-    except ImportError:
-        ham = ParametrizedHamiltonian([], [])
-        with pytest.raises(ImportError, match="Module jax is required"):
-            ParametrizedHamiltonianPytree(ham)
 
 
 def f1(p, t):


### PR DESCRIPTION
Copied over the code from https://github.com/PennyLaneAI/pennylane/pull/3763

This PR adds a jax pytree version of a `ParametrizedHamiltonian`, where the `dot` computation is delayed until the hamiltonian is multiplied with another matrix. This PR introduces a huge performance boost when simulating pulse programs.
