### PR TITLE
Preparation for release candidate 0.29

### DIFF
--- a/doc/development/release_notes.md
+++ b/doc/development/release_notes.md
@@ -3,7 +3,7 @@ Release notes
 
 This page contains the release notes for PennyLane.
 
-.. mdinclude:: ../releases/changelog-dev.md
+.. mdinclude:: ../releases/changelog-0.25.0.md
 
 .. mdinclude:: ../releases/changelog-0.28.0.md
 

--- a/doc/releases/changelog-0.28.0.md
+++ b/doc/releases/changelog-0.28.0.md
@@ -1,6 +1,6 @@
 :orphan:
 
-# Release 0.28.0 (current release)
+# Release 0.28.0
 
 <h3>New features since last release</h3>
 

--- a/doc/releases/changelog-0.29.0.md
+++ b/doc/releases/changelog-0.29.0.md
@@ -1,6 +1,6 @@
 :orphan:
 
-# Release 0.29.0-dev (development release)
+# Release 0.29.0 (current release)
 
 <h3>New features since last release</h3>
 

--- a/pennylane/_version.py
+++ b/pennylane/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.29.0-dev"
+__version__ = "0.29.0"


### PR DESCRIPTION
Preparation of the release candidate:

* Rename `changelog-dev.md` to `changelog-0.29.0.md`.
* Increments the version number to v0.29.0
* Change changelog-dev reference to changelog-0.20 reference
* Add (current release) to top of v0.29 changelog
* Remove (current release) from top of v0.28 changelog