### PR TITLE
Address `default.qubit.jax` tracer errors when using PRNGKey

### DIFF
--- a/pennylane/devices/default_qubit_jax.py
+++ b/pennylane/devices/default_qubit_jax.py
@@ -276,7 +276,7 @@ class DefaultQubitJax(DefaultQubit):
         return jax.random.choice(key, number_of_states, shape=(shots,), p=state_probability)
 
     @staticmethod
-    def states_to_binary(samples, num_wires, dtype=jnp.int32):
+    def states_to_binary(samples, num_wires, dtype=jnp.int64):
         """Convert basis states from base 10 to binary representation.
 
         This is an auxiliary method to the generate_samples method.


### PR DESCRIPTION
This Draft shows how to solve the issue of jax tracer errors with the jax device when using shots/prngkeys.

The solution is a bit hacky but is reliable.

The script that this fixes is the following (one should do the same change also for the gradient rule..)

```python
import jax
import jax.numpy as jnp
import pennylane as qml

# Let's create our circuit with randomness and compile it with jax.jit.
@jax.jit
def circuit(key, param):
    # Notice how the device construction now happens within the jitted method.
    # Also note the added '.jax' to the device path.
    dev = qml.device("default.qubit.jax", wires=2, shots=10, prng_key=key)

    # Now we can create our qnode within the circuit function.
    @qml.qnode(dev, interface="jax", diff_method="finite-diff")
    def my_circuit():
        qml.RX(param, wires=0)
        qml.CNOT(wires=[0, 1])
        return qml.sample(qml.PauliZ(0))
    return my_circuit()

key1 = jax.random.PRNGKey(0)
key2 = jax.random.PRNGKey(1)

# Notice that the first two runs return exactly the same results,
print(f"key1: {circuit(key1, jnp.pi/2)}")
print(f"key1: {circuit(key1, jnp.pi/2)}")

# The second run has different results.
print(f"key2: {circuit(key2, jnp.pi/2)}")
```