### PR TITLE
Fix sign expand

### DIFF
--- a/pennylane/transforms/sign_expand/sign_expand.py
+++ b/pennylane/transforms/sign_expand/sign_expand.py
@@ -233,7 +233,28 @@ def sign_expand(  # pylint: disable=too-many-arguments
 
         H = qml.PauliZ(0) + 0.5 * qml.PauliZ(2) + qml.PauliZ(1)
 
-    and a circuit of the form,
+    a device with auxiliary qubits,
+
+    .. code-block:: python3
+
+        dev = qml.device("default.qubit", wires=[0,1,2,'Hadamard','Target'])
+
+    and a circuit of the form, with the transform as decorator.
+
+    .. code-block:: python3
+
+        @qml.transforms.sign_expand
+        @qml.qnode(dev)
+        def circuit():
+            qml.Hadamard(wires=0)
+            qml.CNOT(wires=[0, 1])
+            qml.PauliX(wires=2)
+            return qml.expval(H)
+
+    >>> circuit()
+    -0.4999999999999999
+
+    You can also work directly on tapes:
 
     .. code-block:: python3
 

--- a/pennylane/transforms/sign_expand/sign_expand.py
+++ b/pennylane/transforms/sign_expand/sign_expand.py
@@ -324,13 +324,13 @@ def sign_expand(  # pylint: disable=too-many-arguments
     # make one tape per observable
     tapes = []
     for proj in projs:
-        with tape.__class__() as new_tape:
-            for op in tape.operations:
-                op.queue()
-            if tape.measurements[0].return_type == qml.measurements.Expectation:
-                qml.expval(qml.Hermitian(proj, wires=wires))
-            else:
-                qml.var(qml.Hermitian(proj, wires=wires))
+
+        if tape.measurements[0].return_type == qml.measurements.Expectation:
+            measurements = [qml.expval(qml.Hermitian(proj, wires=wires))]
+        else:
+            measurements = [qml.var(qml.Hermitian(proj, wires=wires))]
+
+        new_tape = qml.tape.QuantumScript(tape.operations, measurements)
 
         tapes.append(new_tape)
 

--- a/pennylane/transforms/sign_expand/sign_expand.py
+++ b/pennylane/transforms/sign_expand/sign_expand.py
@@ -260,7 +260,7 @@ def sign_expand(  # pylint: disable=too-many-arguments
 
             operations = [qml.Hadamard(wires=0), qml.CNOT(wires=[0, 1]), qml.PauliX(wires=2)]
             measurements = [qml.expval(H)]
-            tape = qml.tape.QuantumScript(operations, measurements)
+            tape = qml.tape.QuantumTape(operations, measurements)
 
     We can use the ``sign_expand`` transform to generate new tapes and a classical
     post-processing function for computing the expectation value of the Hamiltonian in these new decompositions
@@ -285,15 +285,15 @@ def sign_expand(  # pylint: disable=too-many-arguments
     -0.24999999999999994
 
 
-    As a last thing, as the paper is about variance minimizing one can also calculate the variance of the estimator by
-    changing the tape
+    Lastly, as the paper is about minimizing variance, one can also calculate the variance of the estimator by
+    changing the tape:
 
 
     .. code-block:: python3
 
             operations = [qml.Hadamard(wires=0), qml.CNOT(wires=[0, 1]), qml.PauliX(wires=2)]
             measurements = [qml.var(H)]
-            tape = qml.tape.QuantumScript(operations, measurements)
+            tape = qml.tape.QuantumTape(operations, measurements)
 
     >>> tapes, fn = qml.transforms.sign_expand(tape, circuit=True, J=20, delta=0)
     >>> dev = qml.device("default.qubit", wires=[0,1,2,'Hadamard','Target'])

--- a/pennylane/transforms/sign_expand/sign_expand.py
+++ b/pennylane/transforms/sign_expand/sign_expand.py
@@ -71,7 +71,7 @@ def evolve_under(ops, coeffs, time, controls):
     """
     ops_temp = []
     for op, coeff in zip(ops, coeffs):
-        pauli_word = qml.grouping.pauli_word_to_string(op)
+        pauli_word = qml.pauli.pauli_word_to_string(op)
         ops_temp.append(
             controlled_pauli_evolution(
                 coeff * time,

--- a/pennylane/transforms/sign_expand/sign_expand.py
+++ b/pennylane/transforms/sign_expand/sign_expand.py
@@ -288,7 +288,6 @@ def sign_expand(  # pylint: disable=too-many-arguments
     As a last thing, as the paper is about variance minimizing one can also calculate the variance of the estimator by
     changing the tape
 
-    .. code-block:: python3
 
     .. code-block:: python3
 


### PR DESCRIPTION
**Context:**
The transform `sign_expand` was not compatible with Qnodes.

**Description of the Change:**

This PR makes the `sign_expand` compatible with QNodes and also fix the documentation.
