### PR TITLE
Minor fixes for v0.29 release

### DIFF
--- a/doc/releases/changelog-0.29.0.md
+++ b/doc/releases/changelog-0.29.0.md
@@ -140,8 +140,8 @@
 
 * The Hadamard test gradient tranform is now available via `qml.gradients.hadamard_grad`. The gradient transform 
   `qml.gradients.hadamard_grad` is now registered as a differentiation method for `QNode`s.
-  [#3625](https://github.com/PennyLaneAI/pennylane/pull/3625)
-  [#3736](https://github.com/PennyLaneAI/pennylane/pull/3736)
+  [(#3625)](https://github.com/PennyLaneAI/pennylane/pull/3625)
+  [(#3736)](https://github.com/PennyLaneAI/pennylane/pull/3736)
 
   `qml.gradients.hadamard_grad` is a hardware-compatible transform that calculates the
   gradient of a quantum circuit using the Hadamard test. Note that the device requires an
@@ -695,11 +695,11 @@
   (Array(-0.09983341, dtype=float32, weak_type=True), Array(0.01983384, dtype=float32, weak_type=True))
   ```
 
-  It comes with the fact that the interface is determined during the `QNode` call instead of the
+  It comes with the catch that the interface is determined during the `QNode` call instead of the
   initialization. It means that the `gradient_fn` and `gradient_kwargs` are only defined on the QNode at the beginning
-  of the call. As well, without specifying the interface it is not possible to guarantee that the device will not be changed
-  during the call if you are using backprop(`default.qubit` to `default.qubit,jax`e.g.) whereas before it was happening at
-  initialization, therefore you should not try to track the device without specifying the interface.
+  of the call. Moreover, without specifying the interface it is not possible to guarantee that the device will not be changed
+  during the call if you are using backprop (`default.qubit` to `default.qubit,jax`e.g.), whereas before it was happening at
+  initialization. Therefore you should not try to track the device without specifying the interface.
 
 * The tape method `get_operation` can also now return the operation index in the tape, and it can be
   activated by setting the `return_op_index` to `True`: `get_operation(idx, return_op_index=True)`. It will become

--- a/doc/releases/changelog-0.29.0.md
+++ b/doc/releases/changelog-0.29.0.md
@@ -728,7 +728,7 @@
   Instead, they can be accesses via `op.base.wires` or `op.target_wires`.
   [(#3450)](https://github.com/PennyLaneAI/pennylane/pull/3450)
 
-* The tape constructed by a QNode is no longer queued to surrounding contexts.
+* The tape constructed by a `QNode` is no longer queued to surrounding contexts.
   [(#3509)](https://github.com/PennyLaneAI/pennylane/pull/3509)
 
 * Nested operators like `Tensor`, `Hamiltonian`, and `Adjoint` now remove their owned operators

--- a/doc/releases/changelog-0.29.0.md
+++ b/doc/releases/changelog-0.29.0.md
@@ -179,7 +179,7 @@
 
 * The gradient transform `qml.gradients.spsa_grad` is now registered as a
   differentiation method for `QNode`s.
-  [#3440](https://github.com/PennyLaneAI/pennylane/pull/3440)
+  [(#3440)](https://github.com/PennyLaneAI/pennylane/pull/3440)
 
   The SPSA gradient transform can now also be used implicitly by marking a `QNode`
   as differentiable with SPSA. It can be selected via

--- a/pennylane/math/quantum.py
+++ b/pennylane/math/quantum.py
@@ -1060,15 +1060,15 @@ def max_entropy(state, indices, base=None, check_state=False, c_dtype="complex12
     >>> max_entropy(x, indices=[0])
     0.6931472
 
-    The logarithm base can be switched to 2 for example.
+    The logarithm base can be changed. For example:
 
     >>> max_entropy(x, indices=[0], base=2)
     1.0
 
-    The maximum entropy can be obtained by providing a quantum state as a density matrix, for example:
+    The maximum entropy can be obtained by providing a quantum state as a density matrix. For example:
 
     >>> y = [[1/2, 0, 0, 1/2], [0, 0, 0, 0], [0, 0, 0, 0], [1/2, 0, 0, 1/2]]
-    >>> max_entropy(x, indices=[0])
+    >>> max_entropy(y, indices=[0])
     0.6931472
 
     The maximum entropy is always greater or equal to the Von Neumann entropy. In this maximally

--- a/pennylane/ops/qubit/parametric_ops.py
+++ b/pennylane/ops/qubit/parametric_ops.py
@@ -3422,7 +3422,7 @@ class IsingZZ(Operation):
 
         **Example:**
 
-        >>> qml.IsingZZ.compute_decomposition(1.23, wires=[0,1])
+        >>> qml.IsingZZ.compute_decomposition(1.23, wires=[0, 1])
         [CNOT(wires=[0, 1]), RZ(1.23, wires=[1]), CNOT(wires=[0, 1])]
 
         """

--- a/pennylane/qnode.py
+++ b/pennylane/qnode.py
@@ -821,7 +821,7 @@ class QNode:
             self.interface = qml.math.get_interface(*args, *list(kwargs.values()))
             if self.device is not self._original_device:
                 warnings.warn(
-                    "The device was switched during the call of the QNode, to avoid this behaviour define"
+                    "The device was switched during the call of the QNode, to avoid this behaviour define "
                     "an interface argument instead of auto."
                 )
 

--- a/pennylane/tape/qscript.py
+++ b/pennylane/tape/qscript.py
@@ -347,11 +347,12 @@ class QuantumScript:
         """
         rotation_gates = []
 
-        for observable in self.observables:
-            # some observables do not have diagonalizing gates,
-            # in which case we just don't append any
-            with contextlib.suppress(qml.operation.DiagGatesUndefinedError):
-                rotation_gates.extend(observable.diagonalizing_gates())
+        with qml.queuing.QueuingManager.stop_recording():
+            for observable in self.observables:
+                # some observables do not have diagonalizing gates,
+                # in which case we just don't append any
+                with contextlib.suppress(qml.operation.DiagGatesUndefinedError):
+                    rotation_gates.extend(observable.diagonalizing_gates())
         return rotation_gates
 
     ##### Update METHODS ###############

--- a/tests/tape/test_qscript.py
+++ b/tests/tape/test_qscript.py
@@ -975,3 +975,16 @@ class TestFromQueue:
             x = qml.PauliZ(0)
 
         assert child.from_queue(q).operations == [x]
+
+    def test_diagonalizing_gates_not_queued(self):
+        """Test that diagonalizing gates don't get added to an active queue when
+        requested."""
+        qscript = QuantumScript(ops=[qml.PauliZ(0)], measurements=[qml.expval(qml.PauliX(0))])
+
+        with qml.queuing.AnnotatedQueue() as q:
+            diag_ops = qscript.diagonalizing_gates
+
+        assert len(diag_ops) == 1
+        # Hadamard is the diagonalizing gate for PauliX
+        assert qml.equal(diag_ops[0], qml.Hadamard(0))
+        assert q.queue == []

--- a/tests/test_qnode.py
+++ b/tests/test_qnode.py
@@ -1222,8 +1222,8 @@ class TestIntegration:
 
         @qml.qnode(dev)
         def qnode():
-            qml.PauliX(0)
-            return qml.expval(qml.PauliZ(0))
+            qml.PauliZ(0)
+            return qml.expval(qml.PauliX(0))
 
         with qml.queuing.AnnotatedQueue() as q:
             qnode()


### PR DESCRIPTION
* Fixed some docs (see changes)
* Fixed issue where calling a qnode within an `AnnotatedQueue` would add diagonalizing gates for the measurements to the queue.