### PR TITLE
Copy one-electron integrals inside `_chemist_transform`

### DIFF
--- a/pennylane/qchem/factorization.py
+++ b/pennylane/qchem/factorization.py
@@ -390,7 +390,7 @@ def _chemist_transform(one_body_tensor=None, two_body_tensor=None, spatial_basis
     chemist_two_body_coeffs, chemist_one_body_coeffs = None, None
 
     if one_body_tensor is not None:
-        chemist_one_body_coeffs = one_body_tensor
+        chemist_one_body_coeffs = one_body_tensor.copy()
 
     if two_body_tensor is not None:
         chemist_two_body_coeffs = np.swapaxes(two_body_tensor, 1, 3)

--- a/tests/qchem/test_factorization.py
+++ b/tests/qchem/test_factorization.py
@@ -710,3 +710,10 @@ def test_chemist_transform(
         one_body_tensor=one_body_correction, spatial_basis=spatial_basis
     )
     assert np.allclose(chemist_one_body, one_body_correction)
+
+    chemist_one_body, chemist_two_body = qml.qchem.factorization._chemist_transform(
+        one_body_tensor=one_body_correction,
+        two_body_tensor=two_body_tensor, spatial_basis=spatial_basis
+    )
+
+    assert np.allclose(one_body_corr, one_body_correction)

--- a/tests/qchem/test_factorization.py
+++ b/tests/qchem/test_factorization.py
@@ -713,7 +713,8 @@ def test_chemist_transform(
 
     chemist_one_body, chemist_two_body = qml.qchem.factorization._chemist_transform(
         one_body_tensor=one_body_correction,
-        two_body_tensor=two_body_tensor, spatial_basis=spatial_basis
+        two_body_tensor=two_body_tensor,
+        spatial_basis=spatial_basis,
     )
 
     assert np.allclose(one_body_corr, one_body_correction)


### PR DESCRIPTION
**Context:** one-body tensor wasn't being copied in `qml.qchem._chemist_transform`, which lead to it being changed (in place) whenever `qml.basis_rotation` was being called.

**Description of the Change:** added `.copy()`, when building the `chemist_one_body_coeffs` when one-body tensors are provided. 

**Benefits:** in-place manipulation of one-body tensors wouldn't happen.

**Possible Drawbacks:**

**Related GitHub Issues:**
