### PR TITLE
Remove auto warning and swtich tracker

### DIFF
--- a/pennylane/qnode.py
+++ b/pennylane/qnode.py
@@ -819,11 +819,7 @@ class QNode:
 
         if old_interface == "auto":
             self.interface = qml.math.get_interface(*args, *list(kwargs.values()))
-            if self.device is not self._original_device:
-                warnings.warn(
-                    "The device was switched during the call of the QNode, to avoid this behaviour define "
-                    "an interface argument instead of auto."
-                )
+            self.device.tracker = self._original_device.tracker
 
         if not self._qfunc_uses_shots_arg:
             # If shots specified in call but not in qfunc signature,

--- a/tests/test_qnode.py
+++ b/tests/test_qnode.py
@@ -560,9 +560,8 @@ class TestValidation:
         assert "Use diff_method instead" in str(w[0].message)
         assert "Use diff_method instead" in str(w[1].message)
 
-    def test_auto_interface_device_switched_warning(self):
-        """Test that checks that a warning is raised if the device is switched during the QNode call due to auto
-        interface."""
+    def test_auto_interface_tracker_device_switched(self):
+        """Test that checks that the tracker is switched to the new device."""
         dev = qml.device("default.qubit", wires=1)
 
         @qml.qnode(dev)
@@ -570,11 +569,17 @@ class TestValidation:
             qml.RX(params, wires=0)
             return qml.expval(qml.PauliZ(0))
 
-        with pytest.warns(
-            UserWarning,
-            match="The device was switched during the call of the QNode",
-        ):
+        with qml.Tracker(dev) as tracker:
             circuit(qml.numpy.array(0.1, requires_grad=True))
+
+        assert tracker.totals == {"executions": 1, "batches": 1, "batch_len": 1}
+        assert np.allclose(tracker.history.pop("results")[0], 0.99500417)
+        assert tracker.history == {
+            "executions": [1],
+            "shots": [None],
+            "batches": [1],
+            "batch_len": [1],
+        }
 
     def test_autograd_interface_device_switched_no_warnings(self):
         """Test that checks that no warning is raised for device switch when you define an interface."""


### PR DESCRIPTION
**Context:**

We added a warning when the device is switched in QNode call.

**Description of the Change:**

This PR removes the warning and set the tracker from the old device to the new device.


**Benefits:**

Tracker is still working.

**Possible Drawbacks:**

The device is still switched, creating potential issues.
