### PR TITLE
fix strings that wrap around without a space

### DIFF
--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -760,8 +760,8 @@ class QubitDevice(Device):
             elif obs.return_type is State:
                 if len(measurements) > 1:
                     raise qml.QuantumFunctionError(
-                        "The state or density matrix cannot be returned in combination"
-                        " with other return types"
+                        "The state or density matrix cannot be returned in combination "
+                        "with other return types"
                     )
 
                 if self.shots is not None:
@@ -824,16 +824,16 @@ class QubitDevice(Device):
             elif obs.return_type is Shadow:
                 if len(measurements) > 1:
                     raise qml.QuantumFunctionError(
-                        "Classical shadows cannot be returned in combination"
-                        " with other return types"
+                        "Classical shadows cannot be returned in combination "
+                        "with other return types"
                     )
                 results.append(self.classical_shadow(obs, circuit))
 
             elif obs.return_type is ShadowExpval:
                 if len(measurements) > 1:
                     raise qml.QuantumFunctionError(
-                        "Classical shadows cannot be returned in combination"
-                        " with other return types"
+                        "Classical shadows cannot be returned in combination "
+                        "with other return types"
                     )
                 results.append(self.shadow_expval(obs, circuit=circuit))
 
@@ -976,8 +976,8 @@ class QubitDevice(Device):
             elif isinstance(m, StateMP):
                 if len(measurements) > 1:
                     raise qml.QuantumFunctionError(
-                        "The state or density matrix cannot be returned in combination"
-                        " with other return types"
+                        "The state or density matrix cannot be returned in combination "
+                        "with other return types"
                     )
 
                 if self.shots is not None:
@@ -1039,16 +1039,16 @@ class QubitDevice(Device):
             elif isinstance(m, ClassicalShadowMP):
                 if len(measurements) > 1:
                     raise qml.QuantumFunctionError(
-                        "Classical shadows cannot be returned in combination"
-                        " with other return types"
+                        "Classical shadows cannot be returned in combination "
+                        "with other return types"
                     )
                 result = self.classical_shadow(obs, circuit)
 
             elif isinstance(m, ShadowExpvalMP):
                 if len(measurements) > 1:
                     raise qml.QuantumFunctionError(
-                        "Classical shadows cannot be returned in combination"
-                        " with other return types"
+                        "Classical shadows cannot be returned in combination "
+                        "with other return types"
                     )
                 result = self.shadow_expval(obs, circuit=circuit)
 
@@ -1907,8 +1907,8 @@ class QubitDevice(Device):
 
         if self.shots is not None:
             warnings.warn(
-                "Requested adjoint differentiation to be computed with finite shots."
-                " The derivative is always exact when using the adjoint differentiation method.",
+                "Requested adjoint differentiation to be computed with finite shots. "
+                "The derivative is always exact when using the adjoint differentiation method.",
                 UserWarning,
             )
 

--- a/pennylane/data/dataset.py
+++ b/pennylane/data/dataset.py
@@ -32,8 +32,8 @@ def _import_zstd_dill():
         import zstd, dill
     except ImportError as Error:
         raise ImportError(
-            "This feature requires zstd and dill."
-            " They can be installed with:\n\n pip install zstd dill."
+            "This feature requires zstd and dill. "
+            "They can be installed with:\n\n pip install zstd dill."
         ) from Error
 
     return zstd, dill

--- a/pennylane/data/dataset.py
+++ b/pennylane/data/dataset.py
@@ -33,7 +33,7 @@ def _import_zstd_dill():
     except ImportError as Error:
         raise ImportError(
             "This feature requires zstd and dill."
-            "They can be installed with:\n\n pip install zstd dill."
+            " They can be installed with:\n\n pip install zstd dill."
         ) from Error
 
     return zstd, dill

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -286,8 +286,8 @@ class DefaultQubit(QubitDevice):
             operation (ParametrizedEvolution): operation to apply on the state
         """
         raise NotImplementedError(
-            f"The device {self.short_name} cannot execute a ParametrizedEvolution operation."
-            " Please use the jax interface."
+            f"The device {self.short_name} cannot execute a ParametrizedEvolution operation. "
+            "Please use the jax interface."
         )
 
     def _apply_operation(self, state, operation):

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -287,7 +287,7 @@ class DefaultQubit(QubitDevice):
         """
         raise NotImplementedError(
             f"The device {self.short_name} cannot execute a ParametrizedEvolution operation."
-            "Please use the jax  interface."
+            " Please use the jax interface."
         )
 
     def _apply_operation(self, state, operation):

--- a/pennylane/devices/default_qubit_jax.py
+++ b/pennylane/devices/default_qubit_jax.py
@@ -38,7 +38,7 @@ def _validate_jax_version():
     if jax.__version__ == "0.4.4":
         raise RuntimeError(
             "\nYour installed version of JAX is 0.4.4 but Pennylane is incompatible with it.\n\n"
-            "You can either downgrade JAX to version 0.4.3 or update to a more recent version if available."
+            "You can either downgrade JAX to version 0.4.3 or update to a more recent version if available.\n"
             "If you downgrade, you will also need to downgrade JAXLIB to version 0.4.3 or earlier.\n"
             "If you are using pip to manage your packages, you can run the following command:\n\n"
             "\tpip install 'jax==0.4.3' 'jaxlib==0.4.3'\n\n"

--- a/pennylane/drawer/style.py
+++ b/pennylane/drawer/style.py
@@ -38,7 +38,7 @@ def _needs_mpl(func):
         if not _has_mpl:  # pragma: no cover
             raise ImportError(
                 "The drawer style module requires matplotlib."
-                "You can install matplotlib via \n\n   pip install matplotlib"
+                " You can install matplotlib via \n\n   pip install matplotlib"
             )
         func()
 

--- a/pennylane/drawer/style.py
+++ b/pennylane/drawer/style.py
@@ -37,8 +37,8 @@ def _needs_mpl(func):
     def wrapper():
         if not _has_mpl:  # pragma: no cover
             raise ImportError(
-                "The drawer style module requires matplotlib."
-                " You can install matplotlib via \n\n   pip install matplotlib"
+                "The drawer style module requires matplotlib. "
+                "You can install matplotlib via \n\n   pip install matplotlib"
             )
         func()
 

--- a/pennylane/gradients/parameter_shift.py
+++ b/pennylane/gradients/parameter_shift.py
@@ -1598,11 +1598,11 @@ def _param_shift_new(
             res = fn(results)
         except (ValueError, TypeError) as e:
             raise e.__class__(
-                "The processing function of the gradient transform ran into errors"
-                " while the new return type system was turned on. Make sure to"
-                " pass the device shots to the param_shift gradient transform"
-                " using the shots argument or disable the new return type"
-                " system by calling the qml.disable_return function."
+                "The processing function of the gradient transform ran into errors "
+                "while the new return type system was turned on. Make sure to "
+                "pass the device shots to the param_shift gradient transform "
+                "using the shots argument or disable the new return type "
+                "system by calling the qml.disable_return function."
             ) from e
         return res
 

--- a/pennylane/math/is_independent.py
+++ b/pennylane/math/is_independent.py
@@ -373,9 +373,9 @@ def is_independent(
 
     if interface == "torch":
         warnings.warn(
-            "The function is_independent is only available numerically for the PyTorch interface."
-            " Make sure that sampling positions and evaluating the function at these positions"
-            " is a sufficient test, or change the interface."
+            "The function is_independent is only available numerically for the PyTorch interface. "
+            "Make sure that sampling positions and evaluating the function at these positions "
+            "is a sufficient test, or change the interface."
         )
 
     return _is_indep_numerical(func, interface, args, kwargs, num_pos, seed, atol, rtol, bounds)

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -1919,8 +1919,8 @@ class Tensor(Observable):
         if base_label is not None:
             if len(base_label) != len(self.obs):
                 raise ValueError(
-                    "Tensor label requires ``base_label`` keyword to be same length"
-                    " as tensor components."
+                    "Tensor label requires ``base_label`` keyword to be same length "
+                    "as tensor components."
                 )
             return "@".join(
                 ob.label(decimals=decimals, base_label=lbl) for ob, lbl in zip(self.obs, base_label)

--- a/pennylane/ops/functions/eigvals.py
+++ b/pennylane/ops/functions/eigvals.py
@@ -107,7 +107,7 @@ def eigvals(op, k=1, which="SA"):
     if isinstance(op, qml.Hamiltonian):
         warnings.warn(
             "For Hamiltonians, the eigenvalues will be computed numerically. "
-            "This may be computationally intensive for a large number of wires."
+            "This may be computationally intensive for a large number of wires. "
             "Consider using a sparse representation of the Hamiltonian with qml.SparseHamiltonian.",
             UserWarning,
         )

--- a/pennylane/ops/op_math/controlled.py
+++ b/pennylane/ops/op_math/controlled.py
@@ -635,6 +635,6 @@ class ControlledOp(Controlled, operation.Operation):
             return [qml.gradients.eigvals_to_frequencies(processed_gen_eigvals)]
         raise operation.ParameterFrequenciesUndefinedError(
             f"Operation {self.name} does not have parameter frequencies defined, "
-            "and parameter frequencies can not be computed via generator for more than one"
+            "and parameter frequencies can not be computed via generator for more than one "
             "parameter."
         )

--- a/pennylane/ops/qubit/matrix_ops.py
+++ b/pennylane/ops/qubit/matrix_ops.py
@@ -100,7 +100,7 @@ class QubitUnitary(Operation):
             )
         ):
             warnings.warn(
-                f"Operator {U}\n may not be unitary."
+                f"Operator {U}\n may not be unitary. "
                 "Verify unitarity of operation, or use a datatype with increased precision.",
                 UserWarning,
             )

--- a/pennylane/ops/qubit/parametric_ops.py
+++ b/pennylane/ops/qubit/parametric_ops.py
@@ -1674,8 +1674,8 @@ class PauliRot(Operation):
 
         if not PauliRot._check_pauli_word(pauli_word):
             raise ValueError(
-                f'The given Pauli word "{pauli_word}" contains characters that are not allowed.'
-                " Allowed characters are I, X, Y and Z"
+                f'The given Pauli word "{pauli_word}" contains characters that are not allowed. '
+                "Allowed characters are I, X, Y and Z"
             )
 
         num_wires = 1 if isinstance(wires, int) else len(wires)
@@ -1760,8 +1760,8 @@ class PauliRot(Operation):
         """
         if not PauliRot._check_pauli_word(pauli_word):
             raise ValueError(
-                f'The given Pauli word "{pauli_word}" contains characters that are not allowed.'
-                " Allowed characters are I, X, Y and Z"
+                f'The given Pauli word "{pauli_word}" contains characters that are not allowed. '
+                "Allowed characters are I, X, Y and Z"
             )
 
         interface = qml.math.get_interface(theta)

--- a/pennylane/ops/qutrit/matrix_ops.py
+++ b/pennylane/ops/qutrit/matrix_ops.py
@@ -88,7 +88,7 @@ class QutritUnitary(Operation):
                 )
             ):
                 warnings.warn(
-                    f"Operator {U}\n may not be unitary."
+                    f"Operator {U}\n may not be unitary. "
                     "Verify unitarity of operation, or use a datatype with increased precision.",
                     UserWarning,
                 )

--- a/pennylane/qchem/convert.py
+++ b/pennylane/qchem/convert.py
@@ -209,8 +209,8 @@ def _pennylane_to_openfermion(coeffs, ops, wires=None):
         import openfermion
     except ImportError as Error:
         raise ImportError(
-            "This feature requires openfermion."
-            " It can be installed with: pip install openfermion"
+            "This feature requires openfermion. "
+            "It can be installed with: pip install openfermion"
         ) from Error
 
     all_wires = Wires.all_wires([op.wires for op in ops], sort=True)

--- a/pennylane/qchem/molecule.py
+++ b/pennylane/qchem/molecule.py
@@ -81,9 +81,9 @@ class Molecule:
             "cc-pvdz",
         ]:
             raise ValueError(
-                "Currently, the only supported basis sets are 'sto-3g', '6-31g', '6-311g' and"
-                " 'cc-pvdz'. Please consider using `load_data=True` to download the basis set from"
-                " an external library that can be installed with: pip install basis-set-exchange."
+                "Currently, the only supported basis sets are 'sto-3g', '6-31g', '6-311g' and "
+                "'cc-pvdz'. Please consider using `load_data=True` to download the basis set from "
+                "an external library that can be installed with: pip install basis-set-exchange."
             )
 
         if set(symbols) - set(atomic_numbers):
@@ -103,8 +103,8 @@ class Molecule:
 
         if self.n_electrons % 2 == 1 or self.mult != 1:
             raise ValueError(
-                "Openshell systems are not supported. Change the charge or spin"
-                " multiplicity of the molecule."
+                "Openshell systems are not supported. Change the charge or spin "
+                "multiplicity of the molecule."
             )
 
         if l is None:

--- a/pennylane/qnode.py
+++ b/pennylane/qnode.py
@@ -702,8 +702,8 @@ class QNode:
 
         if device.shots is not None:
             warnings.warn(
-                "Requested adjoint differentiation to be computed with finite shots."
-                " Adjoint differentiation always calculated exactly.",
+                "Requested adjoint differentiation to be computed with finite shots. "
+                "Adjoint differentiation always calculated exactly.",
                 UserWarning,
             )
         return "device", {"use_device_state": True, "method": "adjoint_jacobian"}, device
@@ -788,8 +788,8 @@ class QNode:
             # pylint: disable=no-member
             if isinstance(obj, qml.ops.qubit.SparseHamiltonian) and self.gradient_fn == "backprop":
                 raise qml.QuantumFunctionError(
-                    "SparseHamiltonian observable must be used with the parameter-shift"
-                    " differentiation method"
+                    "SparseHamiltonian observable must be used with the parameter-shift "
+                    "differentiation method"
                 )
 
         # Apply the deferred measurement principle if the device doesn't

--- a/pennylane/tape/qscript.py
+++ b/pennylane/tape/qscript.py
@@ -567,7 +567,7 @@ class QuantumScript:
         if return_op_index:
             return self._get_operation(idx)
         warnings.warn(
-            "The get_operation will soon be updated to also return the index of the trainable operation in the tape."
+            "The get_operation will soon be updated to also return the index of the trainable operation in the tape. "
             "If you want to switch to the new behavior, you can pass `return_op_index=True`"
         )
 

--- a/pennylane/templates/embeddings/amplitude.py
+++ b/pennylane/templates/embeddings/amplitude.py
@@ -225,7 +225,7 @@ class AmplitudeEmbedding(Operation):
                     feature_set = feature_set / qml.math.sqrt(norm)
                 else:
                     raise ValueError(
-                        f"Features must be a vector of norm 1.0; got norm {norm}."
+                        f"Features must be a vector of norm 1.0; got norm {norm}. "
                         "Use 'normalize=True' to automatically normalize."
                     )
 

--- a/pennylane/templates/subroutines/qmc.py
+++ b/pennylane/templates/subroutines/qmc.py
@@ -60,7 +60,7 @@ def probs_to_unitary(probs):
     ):  # skip check and error if jitting to avoid JAX tracer errors
         if not qml.math.allclose(sum(probs), 1) or min(probs) < 0:
             raise ValueError(
-                "A valid probability distribution of non-negative numbers that sum to one"
+                "A valid probability distribution of non-negative numbers that sum to one "
                 "must be input"
             )
 

--- a/pennylane/transforms/qcut/tapes.py
+++ b/pennylane/transforms/qcut/tapes.py
@@ -391,8 +391,8 @@ def _qcut_expand_fn(
 
     if not (auto_cutter is True or callable(auto_cutter)):
         raise ValueError(
-            "No WireCut operations found in the circuit. Consider increasing the max_depth value if"
-            " operations or nested tapes contain WireCut operations."
+            "No WireCut operations found in the circuit. Consider increasing the max_depth value if "
+            "operations or nested tapes contain WireCut operations."
         )
 
     return tape


### PR DESCRIPTION
as title says. the new line in python code is not reflected as a new line or a space in printed strings, so these should be added. I basically searched the regex `[^\s]["']$\n\s*['"][^\s]` (non-whitespace, then a close-quote, then a new line, optional leading white-space, an open-quote, then another non-whitespace character) after seeing it a few times and manually picked out the troublesome ones. Manually "filtered out" the escape sequences and docstrings that matched my search, but there weren't too many.