### PR TITLE
Promote warning about vanilla version of NumPy to RST warning.

### DIFF
--- a/doc/introduction/interfaces/numpy.rst
+++ b/doc/introduction/interfaces/numpy.rst
@@ -21,7 +21,7 @@ provided by PennyLane alongside with the PennyLane library:
     import pennylane as qml
     from pennylane import numpy as np
 
-This is powered via `autograd <https://github.com/HIPS/autograd>`_, and enables
+This is powered via `Autograd <https://github.com/HIPS/autograd>`_, and enables
 automatic differentiation and backpropagation of classical computations using familiar
 NumPy functions and modules (such as ``np.sin``, ``np.cos``, ``np.exp``, ``np.linalg``,
 ``np.fft``), as well as standard Python constructs, such as ``if`` statements, and ``for``
@@ -289,21 +289,22 @@ the partial derivative of the first/second expectation value with respect to the
 Advanced Autograd usage
 -----------------------
 
-The PennyLane NumPy interface leverages the Python library `autograd
+The PennyLane NumPy interface leverages the Python library `Autograd
 <https://github.com/HIPS/autograd>`_ to enable automatic differentiation of NumPy code, and extends
 it to provide gradients of quantum circuit functions encapsulated in QNodes. In order to make NumPy
 code differentiable, Autograd provides a wrapped version of NumPy (exposed in PennyLane as
 :code:`pennylane.numpy`).
 
-As stated in other sections, using this interface, any hybrid computation should be coded using the
-wrapped version of NumPy provided by PennyLane. **If you accidentally import the vanilla version of
-NumPy, your code will not be automatically differentiable.**
+.. warning::
+    As stated in other sections, using this interface, any hybrid computation should be coded using the
+    wrapped version of NumPy provided by PennyLane. If you accidentally import the vanilla version of
+    NumPy, your code will not be automatically differentiable.
 
-Because of the way autograd wraps NumPy, the PennyLane NumPy interface allows standard NumPy
+Because of the way Autograd wraps NumPy, the PennyLane NumPy interface allows standard NumPy
 functions and basic Python control statements (``if`` statements, loops, etc.) for declaring
 differentiable classical computations.
 
-That being said, autograd's coverage of NumPy is not complete. It is best to consult the `autograd
+That being said, Autograd's coverage of NumPy is not complete. It is best to consult the `Autograd
 docs <https://github.com/HIPS/autograd/blob/master/docs/tutorial.md>`_ for a more complete overview
 of supported and unsupported features. We highlight a few of the major 'gotchas' here.
 

--- a/doc/releases/changelog-0.29.0.md
+++ b/doc/releases/changelog-0.29.0.md
@@ -844,6 +844,9 @@
   
 <h3>Documentation</h3>
 
+* Make warning about vanilla version of NumPy for differentiation more prominent.
+  [(#3838)](https://github.com/PennyLaneAI/pennylane/pull/3838)
+
 * The documentation for `qml.operation` has been improved.
   [(#3664)](https://github.com/PennyLaneAI/pennylane/pull/3664)
 


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      test directory!

- [x] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `doc/releases/changelog-dev.md` file, summarizing the
      change, and including a link back to the PR.

- [x] The PennyLane source code conforms to
      [PEP8 standards](https://www.python.org/dev/peps/pep-0008/).
      We check all of our code against [Pylint](https://www.pylint.org/).
      To lint modified files, simply `pip install pylint`, and then
      run `pylint pennylane/path/to/file.py`.

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
NumPy interface doc includes an important warning about which version of NumPy to use with Autograd.

**Description of the Change:**
Promote bold format sentence to RST warning. Make Autograd name case uniform throughout document.

**Benefits:**
Increase use awareness.

**Possible Drawbacks:**

**Related GitHub Issues:**
