### PR TITLE
Use default.qubit.jax instead of default.qubit

### DIFF
--- a/doc/releases/changelog-0.29.0.md
+++ b/doc/releases/changelog-0.29.0.md
@@ -57,7 +57,7 @@
 
   ```pycon
   >>> dev = qml.device("default.qubit.jax", wires=2)
-  >>> qnode = qml.QNode(pulse_circuit, dev, interface="jax")
+  >>> qnode = qml.QNode(pulse_circuit, dev)
   >>> params = (p1, p2)
   >>> qnode(params, time=0.5)
   Array(0.72153819, dtype=float64)

--- a/doc/releases/changelog-0.29.0.md
+++ b/doc/releases/changelog-0.29.0.md
@@ -57,7 +57,7 @@
 
   ```pycon
   >>> dev = qml.device("default.qubit.jax", wires=2)
-  >>> qnode = qml.QNode(pulse_circuit, dev)
+  >>> qnode = qml.QNode(pulse_circuit, dev, interface="jax")
   >>> params = (p1, p2)
   >>> qnode(params, time=0.5)
   Array(0.72153819, dtype=float64)

--- a/doc/releases/changelog-0.29.0.md
+++ b/doc/releases/changelog-0.29.0.md
@@ -52,11 +52,11 @@
       return qml.expval(qml.PauliX(0) @ qml.PauliY(1))
   ```
 
-  Pulse-based circuits can be executed and differentiated on the `default.qubit` simulator using JAX
-  as an interface:
+  Pulse-based circuits can be executed and differentiated on the `default.qubit.jax` simulator using
+  JAX as an interface:
 
   ```pycon
-  >>> dev = qml.device("default.qubit", wires=2)
+  >>> dev = qml.device("default.qubit.jax", wires=2)
   >>> qnode = qml.QNode(pulse_circuit, dev, interface="jax")
   >>> params = (p1, p2)
   >>> qnode(params, time=0.5)

--- a/pennylane/ops/functions/evolve.py
+++ b/pennylane/ops/functions/evolve.py
@@ -140,7 +140,7 @@ def evolve(*args, **kwargs):  # pylint: disable=unused-argument
 
         dev = qml.device("default.qubit.jax", wires=4)
         @jax.jit
-        @qml.qnode(dev)
+        @qml.qnode(dev, interface="jax")
         def circuit(params):
             qml.evolve(H)(params, t=[0, 10])
             return qml.expval(qml.PauliZ(0))

--- a/pennylane/ops/functions/evolve.py
+++ b/pennylane/ops/functions/evolve.py
@@ -140,7 +140,7 @@ def evolve(*args, **kwargs):  # pylint: disable=unused-argument
 
         dev = qml.device("default.qubit.jax", wires=4)
         @jax.jit
-        @qml.qnode(dev, interface="jax")
+        @qml.qnode(dev)
         def circuit(params):
             qml.evolve(H)(params, t=[0, 10])
             return qml.expval(qml.PauliZ(0))

--- a/pennylane/ops/functions/evolve.py
+++ b/pennylane/ops/functions/evolve.py
@@ -138,7 +138,7 @@ def evolve(*args, **kwargs):  # pylint: disable=unused-argument
 
         import jax
 
-        dev = qml.device("default.qubit", wires=4)
+        dev = qml.device("default.qubit.jax", wires=4)
         @jax.jit
         @qml.qnode(dev, interface="jax")
         def circuit(params):

--- a/pennylane/pulse/__init__.py
+++ b/pennylane/pulse/__init__.py
@@ -212,7 +212,7 @@ Now we can execute the evolution of this Hamiltonian in a QNode and compute its 
 
     import jax
 
-    dev = qml.device("default.qubit", wires=1)
+    dev = qml.device("default.qubit.jax", wires=1)
 
     @jax.jit
     @qml.qnode(dev, interface="jax")

--- a/pennylane/pulse/__init__.py
+++ b/pennylane/pulse/__init__.py
@@ -215,7 +215,7 @@ Now we can execute the evolution of this Hamiltonian in a QNode and compute its 
     dev = qml.device("default.qubit.jax", wires=1)
 
     @jax.jit
-    @qml.qnode(dev)
+    @qml.qnode(dev, interface="jax")
     def circuit(params):
         qml.evolve(H)(params, t=[0, 10])
         return qml.expval(qml.PauliZ(0))

--- a/pennylane/pulse/__init__.py
+++ b/pennylane/pulse/__init__.py
@@ -215,7 +215,7 @@ Now we can execute the evolution of this Hamiltonian in a QNode and compute its 
     dev = qml.device("default.qubit.jax", wires=1)
 
     @jax.jit
-    @qml.qnode(dev, interface="jax")
+    @qml.qnode(dev)
     def circuit(params):
         qml.evolve(H)(params, t=[0, 10])
         return qml.expval(qml.PauliZ(0))

--- a/pennylane/pulse/convenience_functions.py
+++ b/pennylane/pulse/convenience_functions.py
@@ -57,7 +57,7 @@ def constant(scalar, time):
 
     .. code-block:: python
 
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.jax", wires=1)
         @qml.qnode(dev, interface="jax")
         def circuit(params):
             qml.evolve(H)(params, t=2)

--- a/pennylane/pulse/convenience_functions.py
+++ b/pennylane/pulse/convenience_functions.py
@@ -58,7 +58,7 @@ def constant(scalar, time):
     .. code-block:: python
 
         dev = qml.device("default.qubit.jax", wires=1)
-        @qml.qnode(dev)
+        @qml.qnode(dev, interface="jax")
         def circuit(params):
             qml.evolve(H)(params, t=2)
             return qml.expval(qml.PauliZ(0))

--- a/pennylane/pulse/convenience_functions.py
+++ b/pennylane/pulse/convenience_functions.py
@@ -58,7 +58,7 @@ def constant(scalar, time):
     .. code-block:: python
 
         dev = qml.device("default.qubit.jax", wires=1)
-        @qml.qnode(dev, interface="jax")
+        @qml.qnode(dev)
         def circuit(params):
             qml.evolve(H)(params, t=2)
             return qml.expval(qml.PauliZ(0))

--- a/pennylane/pulse/parametrized_evolution.py
+++ b/pennylane/pulse/parametrized_evolution.py
@@ -114,7 +114,7 @@ class ParametrizedEvolution(Operation):
 
         import jax
 
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.jax", wires=1)
         @jax.jit
         @qml.qnode(dev, interface="jax")
         def circuit(params):
@@ -195,7 +195,7 @@ class ParametrizedEvolution(Operation):
 
         .. code-block:: python
 
-            dev = qml.device("default.qubit", wires=3)
+            dev = qml.device("default.qubit.jax", wires=3)
 
             @qml.qnode(dev, interface="jax")
             def circuit1(params):

--- a/pennylane/pulse/parametrized_evolution.py
+++ b/pennylane/pulse/parametrized_evolution.py
@@ -116,7 +116,7 @@ class ParametrizedEvolution(Operation):
 
         dev = qml.device("default.qubit.jax", wires=1)
         @jax.jit
-        @qml.qnode(dev, interface="jax")
+        @qml.qnode(dev)
         def circuit(params):
             qml.evolve(H)(params, t=[0, 10])
             return qml.expval(qml.PauliZ(0))
@@ -197,7 +197,7 @@ class ParametrizedEvolution(Operation):
 
             dev = qml.device("default.qubit.jax", wires=3)
 
-            @qml.qnode(dev, interface="jax")
+            @qml.qnode(dev)
             def circuit1(params):
                 qml.evolve(H1)(params, t=[0, 10])
                 qml.evolve(H2)(params, t=[0, 10])

--- a/pennylane/pulse/parametrized_evolution.py
+++ b/pennylane/pulse/parametrized_evolution.py
@@ -116,7 +116,7 @@ class ParametrizedEvolution(Operation):
 
         dev = qml.device("default.qubit.jax", wires=1)
         @jax.jit
-        @qml.qnode(dev)
+        @qml.qnode(dev, interface="jax")
         def circuit(params):
             qml.evolve(H)(params, t=[0, 10])
             return qml.expval(qml.PauliZ(0))
@@ -197,7 +197,7 @@ class ParametrizedEvolution(Operation):
 
             dev = qml.device("default.qubit.jax", wires=3)
 
-            @qml.qnode(dev)
+            @qml.qnode(dev, interface="jax")
             def circuit1(params):
                 qml.evolve(H1)(params, t=[0, 10])
                 qml.evolve(H2)(params, t=[0, 10])


### PR DESCRIPTION
Ensures users can execute with finite shots (though differentiation is not supported)