### PR TITLE
ensure provided order of dataset parameters is preserved

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -36,6 +36,9 @@
 
 <h3>Bug fixes</h3>
 
+* Ensure that `qml.data.load` returns datasets in a stable and expected order.
+  [(#3856)](https://github.com/PennyLaneAI/pennylane/pull/3856)
+
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane/data/data_manager.py
+++ b/pennylane/data/data_manager.py
@@ -197,7 +197,11 @@ def _generate_folders(node, folders):
     """
 
     next_folders = folders[1:]
-    folders = set(node) if folders[0] == ["full"] else set(folders[0]).intersection(set(node))
+    if folders[0] == ["full"]:
+        folders = node
+    else:
+        values_for_this_node = set(folders[0]).intersection(set(node))
+        folders = [f for f in folders[0] if f in values_for_this_node]
     return (
         [
             os.path.join(folder, child)

--- a/tests/data/test_dataset_access.py
+++ b/tests/data/test_dataset_access.py
@@ -304,7 +304,7 @@ class TestLoadHelpers:
                     "HeH": {"STO-3G": ["0.50"]},
                 },
                 [["full"], ["full"], ["0.48", "0.50"]],
-                ["H2/6-31G/0.50", "H2/STO-3G/0.48", "H2/STO-3G/0.50", "HeH/STO-3G/0.50"],
+                ["H2/STO-3G/0.48", "H2/STO-3G/0.50", "H2/6-31G/0.50", "HeH/STO-3G/0.50"],
             ),
             (
                 {
@@ -318,7 +318,7 @@ class TestLoadHelpers:
     )
     def test_generate_folders(self, node, folders, output):
         """Test the _generate_folders helper function."""
-        assert sorted(qml.data.data_manager._generate_folders(node, folders)) == output
+        assert qml.data.data_manager._generate_folders(node, folders) == output
 
     @patch("concurrent.futures.ThreadPoolExecutor.submit", return_value=True)
     @patch("pennylane.data.data_manager.wait", return_value=MagicMock(done=[]))

--- a/tests/data/test_dataset_access.py
+++ b/tests/data/test_dataset_access.py
@@ -314,6 +314,14 @@ class TestLoadHelpers:
                 [["full"], ["STO-3G"], ["0.50"]],
                 [],
             ),
+            (
+                {
+                    "H2": {"STO-3G": ["0.46", "0.48", "0.50"], "6-31G": ["0.46", "0.50"]},
+                    "HeH": {"STO-3G": ["0.50"]},
+                },
+                [["HeH", "H2"], ["STO-3G"], ["0.50", "0.46"]],
+                ["HeH/STO-3G/0.50", "H2/STO-3G/0.50", "H2/STO-3G/0.46"],
+            ),
         ],
     )
     def test_generate_folders(self, node, folders, output):

--- a/tests/data/test_dataset_access.py
+++ b/tests/data/test_dataset_access.py
@@ -492,11 +492,25 @@ class TestLoad:
             "qchem", molname="H2", basis="6-31G", bondlength="full", folder_path=str(tmp_path)
         )
         assert len(datasets) == 3
-        assert sorted([d.molecule for d in datasets]) == [
+        assert [d.molecule for d in datasets] == [
             "H2_6-31G_0.46_full",
-            "H2_6-31G_1.0_full",
             "H2_6-31G_1.16_full",
+            "H2_6-31G_1.0_full",
         ]
+
+    def test_stable_load_order(self, tmp_path):
+        """Test that the order of returned datasets is stable and sorted."""
+        lengths = [1.0, 1.16, 0.46]
+        path = str(tmp_path)
+        for _ in range(5):  # 5 subsequent calls to suggest stability
+            data = qml.data.load(
+                "qchem", molname="H2", basis="6-31G", bondlength=lengths, folder_path=path
+            )
+            assert [d.molecule for d in data] == [
+                "H2_6-31G_1.0_full",
+                "H2_6-31G_1.16_full",
+                "H2_6-31G_0.46_full",
+            ]
 
     @pytest.mark.parametrize(
         ("attributes", "fullfile"),


### PR DESCRIPTION
**Context:**
I used sets to ensure that we only request files that exist, but this potentially shuffles the order of generated datasets. This is unexpected for the user.

**Description of the Change:**
After using sets to determine which datasets actually exist on S3, use a list comprehension to sort the parameter according to the list provided by the user.

**Benefits:**
The ordering of datasets will now be stable in subsequent calls, and have some expected order. Note that it will go in order of parameters saved in S3 metadata, _not_ in order of kwargs provided by user. This means that if a user gives `load(bondlength=[1,2], molname=[y, x])`, it will first sort by `molname` and not by `bondlength` (because `molname` comes before `bondlength` in the stored metadata).

**Possible Drawbacks:**
N/A. The extra microsecond needed to generate the ordered list?

**Related GitHub Issues:**
Fixes #3855 