### PR TITLE
Make `qml.devices.qubit.measure` compatible with backprop derivatives for Hamiltonian and Sum

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -25,6 +25,9 @@
 * `AdaptiveOptimizer` is updated to use non-default user-defined qnode arguments.
   [(#3765)](https://github.com/PennyLaneAI/pennylane/pull/3765)
 
+* Adds logic to `qml.devices.qubit.measure` to compute the expectation values of `Hamiltonian` and `Sum `
+  in a backpropagation compatible way.
+
 <h3>Breaking changes</h3>
 
 <h3>Deprecations</h3>

--- a/pennylane/devices/qubit/__init__.py
+++ b/pennylane/devices/qubit/__init__.py
@@ -23,13 +23,16 @@ at your own discretion.
 
     create_initial_state
     apply_operation
+    measure
     sample_state
     preprocess
     simulate
 """
 
-from .apply_operation import apply_operation
 from .initialize_state import create_initial_state
+from .apply_operation import apply_operation
+from .measure import measure
 from .sampling import sample_state
+
 from .preprocess import preprocess
 from .simulate import simulate

--- a/pennylane/devices/qubit/measure.py
+++ b/pennylane/devices/qubit/measure.py
@@ -19,7 +19,7 @@ from typing import Callable
 from scipy.sparse import csr_matrix
 
 from pennylane import math
-from pennylane.ops import Sum
+from pennylane.ops import Sum, prod
 from pennylane.measurements import StateMeasurement, MeasurementProcess, ExpectationMP
 from pennylane.typing import TensorLike
 from pennylane.wires import Wires
@@ -71,6 +71,30 @@ def state_hamiltonian_expval(measurementprocess: ExpectationMP, state: TensorLik
     return math.real(math.squeeze(res))
 
 
+def state_hamiltonian_expval_backprop(
+    measurementprocess: ExpectationMP, state: TensorLike
+) -> TensorLike:
+    """Measure the expecation value of the state when the measured observable is a ``Hamiltonian`` or ``Sum``
+    and it must be backpropagation compatible.
+
+    Args:
+        measurementprocess (ExpectationMP): measurement process to apply to the state
+        state (TensorLike): the state to measure
+
+    Returns:
+        TensorLike: the result of the measurement
+    """
+    obs = measurementprocess.obs
+    if isinstance(obs, Sum):
+        terms_iterator = obs
+    else:
+        terms_iterator = [prod(*o.obs) * c for c, o in zip(*obs.terms())]
+
+    # Recursively call measure on each term, so that the best measurement method can
+    # be used for each term
+    return sum(measure(ExpectationMP(term), state) for term in terms_iterator)
+
+
 def state_measurement_process(
     measurementprocess: StateMeasurement, state: TensorLike
 ) -> TensorLike:
@@ -89,7 +113,7 @@ def state_measurement_process(
 
 
 def get_measurement_function(
-    measurementprocess: MeasurementProcess,
+    measurementprocess: MeasurementProcess, backprop_mode: bool = False
 ) -> Callable[[MeasurementProcess, TensorLike], TensorLike]:
     """Get the appropriate method for performing a measurement.
 
@@ -104,21 +128,20 @@ def get_measurement_function(
             # no need to apply diagonalizing gates
             return state_measurement_process
 
-        if isinstance(measurementprocess, ExpectationMP) and measurementprocess.obs.name in (
-            "Hamiltonian",
-            "SparseHamiltonian",
-        ):
-            return state_hamiltonian_expval
+        if isinstance(measurementprocess, ExpectationMP):
+            if measurementprocess.obs.name == "SparseHamiltonian":
+                return state_hamiltonian_expval
 
-        if (
-            isinstance(measurementprocess, ExpectationMP)
-            and isinstance(measurementprocess.obs, Sum)
-            and measurementprocess.obs.has_overlapping_wires
-            and len(measurementprocess.obs.wires) > 7
-        ):
-            # Use tensor contraction for `Sum` expectation values with non-commuting summands
-            # and 8 or more wires as it's faster than using eigenvalues.
-            return state_hamiltonian_expval
+            if measurementprocess.obs.name == "Hamiltonian" or (
+                isinstance(measurementprocess.obs, Sum)
+                and measurementprocess.obs.has_overlapping_wires
+                and len(measurementprocess.obs.wires) > 7
+            ):
+                # Use tensor contraction for `Sum` expectation values with non-commuting summands
+                # and 8 or more wires as it's faster than using eigenvalues.
+                return (
+                    state_hamiltonian_expval_backprop if backprop_mode else state_hamiltonian_expval
+                )
 
         if measurementprocess.obs.has_diagonalizing_gates:
             return state_diagonalizing_gates
@@ -136,4 +159,5 @@ def measure(measurementprocess: MeasurementProcess, state: TensorLike) -> Tensor
     Returns:
         Tensorlike: the result of the measurement
     """
-    return get_measurement_function(measurementprocess)(measurementprocess, state)
+    backprop_mode = math.get_interface(state) != "numpy"
+    return get_measurement_function(measurementprocess, backprop_mode)(measurementprocess, state)


### PR DESCRIPTION
Currently, `qml.devices.qubit.measure` handles large `Hamiltonian` and `Sum` objects by creating a csr matrix representation of the operator and performing inner products for <Psi | M |Psi>.

This was not compatible backpropagation, so I added method that calculates the expectation value to each term in the sum and then combines them.

Not only is this backpropagation compatible, early benchmarking shows it to be more efficient for at least a couple cases.

![Screenshot 2023-03-03 at 1 27 18 PM](https://user-images.githubusercontent.com/6364575/222798927-d3da74fa-ba77-4951-99d9-a735d8b9de3c.png)
