### PR TITLE
[prototype] prototype for resource estimation

### DIFF
--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -381,9 +381,9 @@ class QubitDevice(Device):
         # increment counter for number of executions of qubit device
         self._num_executions += 1
 
-        if self.tracker.active:
-            self.tracker.update(executions=1, shots=self._shots, results=results)
-            self.tracker.record()
+        #if self.tracker.active:
+        #    self.tracker.update(executions=1, shots=self._shots, results=results)
+        #    self.tracker.record()
 
         return results
 

--- a/pennylane/circuit_graph.py
+++ b/pennylane/circuit_graph.py
@@ -469,8 +469,19 @@ class CircuitGraph:
                 self._operation_graph = self._graph.subgraph(
                     list(self._graph.nodes().index(node) for node in self.operations)
                 )
-                self._depth = rx.dag_longest_path_length(self._operation_graph) + 1
+                # Add a weight function to account for the depth of custom operations.
+                # This is a quick hack. A more robust treatments is needed.
+                self._depth = rx.dag_longest_path_length(self._operation_graph, self.weight_fn) + 1
         return self._depth
+
+    def weight_fn(self, i, j, c):
+        r"""Return the depth of a custom operation as the edge weight to compute the longest path in
+        the DAG."""
+        if hasattr(self.operations[i], "resources"):
+            w = self.operations[i].resources().depth
+            return w
+
+        return 1
 
     def has_path(self, a, b):
         """Checks if a path exists between the two given nodes.

--- a/pennylane/interfaces/execution.py
+++ b/pennylane/interfaces/execution.py
@@ -636,6 +636,13 @@ def execute(
     if expand_fn == "device":
         expand_fn = lambda tape: device.expand_fn(tape, max_expansion=max_expansion)
 
+    # added to return resource information
+    if device.short_name == "null.qubit":
+        res = qml.interfaces.cache_execute(
+            batch_execute, cache, return_tuple=False, expand_fn=expand_fn
+        )(tapes)
+        return res
+
     if gradient_fn is None:
         # don't unwrap if it's an interface device
         if "passthru_interface" in device.capabilities():

--- a/pennylane/resource/__init__.py
+++ b/pennylane/resource/__init__.py
@@ -18,3 +18,4 @@ logical qubits required to implement advanced quantum algorithms.
 from .first_quantization import FirstQuantization
 from .second_quantization import DoubleFactorization
 from .measurement import estimate_error, estimate_shots
+from estimation import estimate_resources_tape, estimate_resources_qnode, estimate_resources_op

--- a/pennylane/resource/estimation.py
+++ b/pennylane/resource/estimation.py
@@ -1,0 +1,203 @@
+# Copyright 2018-2022 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+This module contains the functions needed for resource estimation.
+"""
+
+from collections import defaultdict
+import pennylane as qml
+from pennylane import numpy as np
+from pennylane.operation import AnyWires, Operation
+
+
+class Resource:
+    r"""Create a resource object for storing quantum resource information."""
+
+    def __init__(self):
+        self.num_wires = 0
+        self.num_gates = 0
+        self.gate_types = defaultdict(int)
+        self.depth = 0
+        self.shots = 0
+
+    def __str__(self):
+        keys = ["wires", "gates", "depth", "shots", "gate_types"]
+        vals = [self.num_wires, self.num_gates, self.depth, self.shots, self.gate_types]
+        items = "\n".join([str(i) for i in zip(keys, vals)])
+        items = items.replace("('", "")
+        items = items.replace("',", ":")
+        items = items.replace(")", "")
+        items = items.replace("defaultdict(<class 'int'>, ", "\n")
+        return items
+
+    def __repr__(self):
+        return f"<Resource: wires={self.num_wires}, gates={self.num_gates}, depth={self.depth}, shots={self.shots}, gate_types={self.gate_types}>"
+
+    def _ipython_display_(self):
+        """Displays __str__ in ipython instead of __repr__"""
+        print(str(self))
+
+
+class CustomOperation(qml.DoubleExcitation):
+    num_wires = 4
+
+    def resources(self):
+        resource = Resource()
+        resource.num_gates = 11
+        resource.gate_types = {"T": 5, "CNOT": 6}
+        resource.depth = 11
+        return resource
+
+
+def estimate_resources_tape(tape):
+    r"""Return resource estimation for a quantum tape.
+
+    Args:
+        tape (qml.QuantumTape): quantum tape
+
+    Returns:
+        qml.resource.Resource: resource information
+
+    .. details::
+        :title: Usage Details
+
+        The followng example shows estimating resource for a quantum tape constructed with PennyLane
+        gates and a custom gate:
+
+        .. code-block:: python3
+
+            with qml.tape.QuantumTape() as tape:
+                qml.SingleExcitation(0.1, wires=[0, 1])
+                qml.DoubleExcitation(0.2, wires=[0, 1, 2, 3])
+                CustomOperation(wires=range(6))
+
+        >>> resources = estimate_resources_tape(tape)()
+        >>> print(resources)
+        wires: 6
+        gates: 42
+        depth: 0
+        shots: 0
+        gate_types:
+        {'CNOT': 22, 'CRY': 1, 'Hadamard': 6, 'RY': 8, 'T': 5}
+    """
+
+    def _estimate():
+        resource = Resource()
+        resource.num_wires = len(tape.wires)
+        for op in tape.operations:
+            if not hasattr(op, "resources"):
+                # gate_types
+                decomp = op.decomposition()
+                for d in decomp:
+                    resource.gate_types[d.name] += 1
+                # num_gates
+                resource.num_gates += len(decomp)
+            if hasattr(op, "resources"):
+                op_resource = op.resources()
+                # gate_types
+                for d in op_resource.gate_types:
+                    resource.gate_types[d] += op_resource.gate_types[d]
+                # num_gates
+                resource.num_gates += sum(op_resource.gate_types.values())
+
+                # user-defined resource - be careful with allowing this
+                # for item in vars(op_resource).keys():
+                #     resource_value = getattr(op_resource, item)
+                #     if not hasattr(resource, item):
+                #         setattr(resource, item, resource_value)
+        return resource
+
+    return _estimate
+
+
+def estimate_resources_qnode(qnode):
+    r"""Return resource estimation for a qnode.
+
+    Args:
+        qnode (qml.QNode): quantum node
+
+    Returns:
+        qml.resource.Resource: resource information
+
+    .. details::
+        :title: Usage Details
+
+        The followng example shows estimating resource for a VQE workflow:
+
+        .. code-block:: python3
+
+            symbols  = ['Li', 'H']
+            geometry = np.array([[0.0, 0.0, -0.69434785],
+                                 [0.0, 0.0,  0.69434785]], requires_grad = False)
+            electrons = 4
+            ham, qubits = qml.qchem.molecular_hamiltonian(symbols, geometry)
+            hf_state = qml.qchem.hf_state(electrons, qubits)
+            singles, doubles = qml.qchem.excitations(electrons, qubits)
+            excitations = singles + doubles
+            wires = range(qubits)
+
+            dev = qml.device("default.qubit", wires=qubits)
+
+            @qml.qnode(dev)
+            def circuit(params):
+                qml.BasisStatePreparation(hf_state, wires=range(qubits))
+                for i, excitation in enumerate(excitations):
+                    if len(excitation) == 4:
+                        qml.DoubleExcitation(params[i], wires=excitation)
+                    else:
+                        qml.SingleExcitation(params[i], wires=excitation)
+                return qml.expval(ham)
+
+            params = np.zeros(len(excitations))
+
+            energy = circuit(params)
+
+        >>> resources = estimate_resources_qnode(circuit)()
+        >>> print(resources)
+        wires: 12
+        gates: 2180
+        depth: 0
+        shots: None
+        gate_types:
+        {'PauliX': 4, 'CNOT': 1096, 'CRY': 16, 'Hadamard': 456, 'RY': 608}
+    """
+
+    def _estimate():
+
+        tape = qnode.tape
+        resource = Resource()
+        resource.num_wires = len(tape.wires)
+        resource.shots = qnode.device.shots
+
+        for op in tape.operations:
+
+            if not hasattr(op, "resources"):
+                # gate_types
+                decomp = op.decomposition()
+                for d in decomp:
+                    resource.gate_types[d.name] += 1
+                # num_gates
+                resource.num_gates += len(decomp)
+
+            if hasattr(op, "resources"):
+                op_resource = op.resources()
+                # gate_types
+                for d in op_resource.gate_types:
+                    resource.gate_types[d] += op_resource.gate_types[d]
+                # num_gates
+                resource.num_gates += sum(op_resource.gate_types.values())
+
+        return resource
+
+    return _estimate

--- a/pennylane/resource/estimation.py
+++ b/pennylane/resource/estimation.py
@@ -279,8 +279,7 @@ def estimate_resources_batch(qnode):
         .. code-block:: python3
 
             symbols  = ['H', 'H']
-            geometry = np.array([[0.0, 0.0, -0.69434785],
-                                 [0.0, 0.0,  0.69434785]], requires_grad = False)
+            geometry = np.array([[0.0, 0.0, -0.69434785], [0.0, 0.0,  0.69434785]], requires_grad = False)
             electrons = 2
             ham, qubits = qml.qchem.molecular_hamiltonian(symbols, geometry, grouping_type='qwc')
             hf_state = qml.qchem.hf_state(electrons, qubits)

--- a/pennylane/resource/estimation.py
+++ b/pennylane/resource/estimation.py
@@ -279,7 +279,8 @@ def estimate_resources_batch(qnode):
         .. code-block:: python3
 
             symbols  = ['H', 'H']
-            geometry = np.array([[0.0, 0.0, -0.69434785], [0.0, 0.0,  0.69434785]], requires_grad = False)
+            geometry = np.array([[0.0, 0.0, -0.69434785],
+                                 [0.0, 0.0,  0.69434785]], requires_grad = False)
             electrons = 2
             ham, qubits = qml.qchem.molecular_hamiltonian(symbols, geometry, grouping_type='qwc')
             hf_state = qml.qchem.hf_state(electrons, qubits)

--- a/pennylane/resource/estimation.py
+++ b/pennylane/resource/estimation.py
@@ -69,6 +69,34 @@ expectation value of a Hamiltonian with its terms grouped by the 'qwc' method.
              <Resource: wires=10, gates=132, depth=0, shots=100, gate_types=defaultdict(<class 'int'>, {'PhaseShift': 4, 'RX': 2, 'CNOT': 64, 'CRY': 1, 'Hadamard': 24, 'RY': 32, 'T': 5})>,
              <Resource: wires=10, gates=132, depth=0, shots=100, gate_types=defaultdict(<class 'int'>, {'PhaseShift': 4, 'RX': 2, 'CNOT': 64, 'CRY': 1, 'Hadamard': 24, 'RY': 32, 'T': 5})>,
              <Resource: wires=10, gates=132, depth=0, shots=100, gate_types=defaultdict(<class 'int'>, {'PhaseShift': 4, 'RX': 2, 'CNOT': 64, 'CRY': 1, 'Hadamard': 24, 'RY': 32, 'T': 5})>]
+
+The resource information can be also collected in the device tracker. The `batch_execute` and
+`_batch_execute_new` functions in `_qubit_device` are modified to add resource information to
+tracker. This example shows how to access resource information:
+
+        .. code-block:: python3
+
+            dev = qml.device('default.qubit', wires = 10, shots = None)
+            @qml.qnode(dev, diff_method='parameter-shift')
+            def circuit(params):
+                qml.BasisState(np.array([1, 1, 0, 0, 0, 0, 0, 0, 0, 0]), wires = range(10))
+                qml.SingleExcitation(params[0], wires=[0, 1])
+                qml.DoubleExcitation(params[1],wires=[0, 1, 2, 3])
+                qml.DoubleExcitation(params[1],wires=[0, 1, 4, 5])
+                qml.DoubleExcitation(params[1],wires=[0, 1, 6, 7])
+                qml.DoubleExcitation(params[1],wires=[0, 1, 8, 9])
+                # CustomOperation(wires=range(6))
+                return qml.expval(ham)
+            params = np.array([0.1, 0.2])
+
+            >>> with qml.Tracker(dev) as tracker:
+            ...    qml.grad(circuit)(params)
+            >>> tracker.history['resources']
+             [[<Resource: wires=10, gates=125, depth=0, shots=None, gate_types=defaultdict(<class 'int'>, {'PhaseShift': 4, 'RX': 4, 'CNOT': 58, 'CRY': 1, 'Hadamard': 24, 'RY': 34})>,
+             ...
+
+
+
 """
 
 from collections import defaultdict


### PR DESCRIPTION
**Context:**
Contains a prototype for extending resource estimation.

**Use Cases:**
1. A full VQE workflow (apply gates, template, compute expval, optimise circuit)
2. A complicated algorithm given as a single black box (QPE with double-factorized Hamiltonian)
3. A complicated algorithm given as a composed of black-box operations with known estimates (PREP and SEL to block-encode a matrix, then using as part of QSVT)

**Issues:**
1. Unable to create a qnode with n_wires > 30
2. How to compute depth?
3. How to obtain decomposition of nested operations?
4. How to use dataclass with dict?
5. Modify qml.CircuitGraph to account for custom operations and node [weights](https://cs.stackexchange.com/questions/79437/given-dag-gv-e-and-weight-on-the-vertices-find-the-heaviest-path-that-starts).