### PR TITLE
add back parametric_ops file for backwards pickle support

### DIFF
--- a/pennylane/ops/qubit/parametric_ops.py
+++ b/pennylane/ops/qubit/parametric_ops.py
@@ -1,0 +1,26 @@
+# Copyright 2018-2023 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# pylint: disable=too-many-arguments
+"""
+This file exists to support backwards compatibility for datasets pickled with
+pennylane.ops.qubit.parametric_ops (i.e. from before the file splitting).
+
+All new parametric operators should go into the more precisely named files.
+"""
+
+# pylint:disable=wildcard-import,unused-wildcard-import
+
+from .parametric_ops_controlled import *
+from .parametric_ops_multi_qubit import *
+from .parametric_ops_single_qubit import *

--- a/tests/ops/qubit/test_parametric_ops.py
+++ b/tests/ops/qubit/test_parametric_ops.py
@@ -23,6 +23,11 @@ from gate_data import ControlledPhaseShift, CPhaseShift00, CPhaseShift01, CPhase
 
 import pennylane as qml
 from pennylane import numpy as npp
+from pennylane.ops.qubit.parametric_ops import (
+    RX as old_loc_RX,
+    ControlledPhaseShift as old_loc_ControlledPhaseShift,
+    MultiRZ as old_loc_MultiRZ,
+)
 from pennylane.wires import Wires
 
 PARAMETRIZED_OPERATIONS = [
@@ -3994,3 +3999,12 @@ control_value_data = [
 def test_control_values(op, control_values):
     """Test the ``control_values`` attribute for parametrized operations."""
     assert op.control_values == control_values
+
+
+def test_op_aliases_are_valid():
+    """Tests that ops in new files can still be accessed from the old parametric_ops module."""
+    assert (
+        qml.ops.qubit.parametric_ops_controlled.ControlledPhaseShift is old_loc_ControlledPhaseShift
+    )
+    assert qml.ops.qubit.parametric_ops_multi_qubit.MultiRZ is old_loc_MultiRZ
+    assert qml.ops.qubit.parametric_ops_single_qubit.RX is old_loc_RX


### PR DESCRIPTION
**Context:**
Our datasets were created using `pickle` and PennyLane, but an older version of it (ie. before this past Monday). As a result, the parametric ops are namespaced in `pennylane.ops.qubit.parametric_ops`, but that module no longer exists as of #3789. So, unpickling those datasets fails:
```pycon
>>> import pennylane as qml
>>> nh3 = qml.data.load("qchem", molname="NH3", basis="STO-3G", bondlength=1.49)[0]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/matthews/src/github.com/PennyLaneAI/pennylane/pennylane/data/data_manager.py", line 272, in load
    Dataset(data_name, real_folder, folder.replace(pathsep, "_"), docstring, standard=True)
  File "/Users/matthews/src/github.com/PennyLaneAI/pennylane/pennylane/data/dataset.py", line 148, in __init__
    self.__std_init__(*args)
  File "/Users/matthews/src/github.com/PennyLaneAI/pennylane/pennylane/data/dataset.py", line 122, in __std_init__
    self.read(self._fullfile, lazy=True)
  File "/Users/matthews/src/github.com/PennyLaneAI/pennylane/pennylane/data/dataset.py", line 206, in read
    data = self._read_file(filepath)
  File "/Users/matthews/src/github.com/PennyLaneAI/pennylane/pennylane/data/dataset.py", line 181, in _read_file
    return dill.loads(depressed_pickle)
  File "/Users/matthews/.pyenv/versions/pl/lib/python3.9/site-packages/dill/_dill.py", line 286, in loads
    return load(file, ignore, **kwds)
  File "/Users/matthews/.pyenv/versions/pl/lib/python3.9/site-packages/dill/_dill.py", line 272, in load
    return Unpickler(file, ignore=ignore, **kwds).load()
  File "/Users/matthews/.pyenv/versions/pl/lib/python3.9/site-packages/dill/_dill.py", line 419, in load
    obj = StockUnpickler.load(self)
  File "/Users/matthews/.pyenv/versions/pl/lib/python3.9/site-packages/dill/_dill.py", line 409, in find_class
    return StockUnpickler.find_class(self, module, name)
ModuleNotFoundError: No module named 'pennylane.ops.qubit.parametric_ops'
```

**Description of the Change:**
Add back `parametric_ops.py` as an alias for the contents of the now-split-up files.

**Benefits:**
Datasets will be loadable again.

**Possible Drawbacks:**
This file only exists for backwards compatibility and its existence might confuse people, and contribute to overall repo messiness.

**Related GitHub Issues:**
#3789

Note: I didn't add a changelog entry because I'm hoping to remove this before the release