### PR TITLE
Link pulse demo in module description

### DIFF
--- a/pennylane/pulse/__init__.py
+++ b/pennylane/pulse/__init__.py
@@ -29,6 +29,9 @@ The :mod:`~.pulse` module is written for ``jax`` and will not work with other ma
 typically encountered in PennyLane. It requires separate installation, see
 `jax.readthedocs.io <https://jax.readthedocs.io/en/latest/>`_.
 
+For a demo of the basic pulse functionality in PennyLane and running a ctrl-VQE example, see our demo on
+`differentiable pulse programming <https://pennylane.ai/qml/demos/tutorial_pulse_programming101.html>`_.
+
 Overview
 --------
 


### PR DESCRIPTION
Quick PR linking the [pulse demo](https://pennylane.ai/qml/demos/tutorial_pulse_programming101.html) in the [pulse docs](https://docs.pennylane.ai/en/stable/code/qml_pulse.html).