### PR TITLE
fix `devices.qubit.apply_operation` with large tf states

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -83,6 +83,7 @@
   
 * `qml.devices.qubit.apply_operation` catches the `tf.errors.UnimplementedError` that occurs when `PauliZ` or `CNOT` gates
   are applied to a large (>8 wires) tensorflow state. When that occurs, the logic falls back to the tensordot logic instead.
+  [(#3884)](https://github.com/PennyLaneAI/pennylane/pull/3884/)
 
 <h3>Contributors</h3>
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -74,7 +74,9 @@
 
 * Made `qml.OrbitalRotation` and consequently `qml.GateFabric` consistent with the interleaved Jordan-Wigner ordering.
   [(#3861)](https://github.com/PennyLaneAI/pennylane/pull/3861)
-
+  
+* `qml.devices.qubit.apply_operation` catches the `tf.errors.UnimplementedError` that occurs when `PauliZ` or `CNOT` gates
+  are applied to a large (>8 wires) tensorflow state. When that occurs, the logic falls back to the tensordot logic instead.
 
 <h3>Contributors</h3>
 

--- a/pennylane/devices/qubit/apply_operation.py
+++ b/pennylane/devices/qubit/apply_operation.py
@@ -211,7 +211,7 @@ def apply_pauliz(op: qml.PauliZ, state, is_state_batched: bool = False):
     sl_1 = _get_slice(1, axis, n_dim)
 
     try:
-        state1 = math.multiply(shift, state[sl_1])
+        state1 = math.multiply(-1, state[sl_1])
     except Exception as e:
         # slicing fails with tensorflow and states with more than 8 wires.
         # Instead of checking checking for this case all the time, we just fallback

--- a/pennylane/devices/qubit/apply_operation.py
+++ b/pennylane/devices/qubit/apply_operation.py
@@ -205,7 +205,6 @@ def apply_pauliz(op: qml.PauliZ, state, is_state_batched: bool = False):
     axis = op.wires[0] + is_state_batched
     n_dim = math.ndim(state)
 
-    n_dim = math.ndim(state)
     if n_dim >= 9 and math.get_interface(state) == "tensorflow":
         return apply_operation_tensordot(op, state)
 

--- a/pennylane/devices/qubit/apply_operation.py
+++ b/pennylane/devices/qubit/apply_operation.py
@@ -224,7 +224,6 @@ def apply_cnot(op: qml.CNOT, state, is_state_batched: bool = False):
     control_axes = op.wires[0] + is_state_batched
     n_dim = math.ndim(state)
 
-    n_dim = math.ndim(state)
     if n_dim >= 9 and math.get_interface(state) == "tensorflow":
         return apply_operation_tensordot(op, state)
 

--- a/pennylane/devices/qubit/apply_operation.py
+++ b/pennylane/devices/qubit/apply_operation.py
@@ -211,7 +211,8 @@ def apply_pauliz(op: qml.PauliZ, state, is_state_batched: bool = False):
     sl_1 = _get_slice(1, axis, n_dim)
 
     try:
-        state1 = math.multiply(-1, state[sl_1])
+        # must be first state and then -1 because it breaks otherwise
+        state1 = math.multiply(state[sl_1], -1)
     except Exception as e:
         # slicing fails with tensorflow and states with more than 8 wires.
         # Instead of checking checking for this case all the time, we just fallback

--- a/tests/devices/qubit/test_apply_operation.py
+++ b/tests/devices/qubit/test_apply_operation.py
@@ -378,3 +378,18 @@ class TestLargerOperations:
             state_v2 = method(d_op, state_v2)
 
         assert qml.math.allclose(state_v1, state_v2)
+
+
+@pytest.mark.tf
+@pytest.mark.parametrize("op", (qml.PauliZ(8), qml.CNOT((5, 6))))
+def test_tf_large_state(op):
+    """ "Tests that custom kernels that use slicing fall back to a different method when
+    the state has a large number of wires."""
+    import tensorflow as tf
+
+    state = np.zeros([2] * 10)
+    state = tf.Variable(state)
+    new_state = apply_operation(op, state)
+
+    # still all zeros.  Mostly just making sure error not raised
+    assert qml.math.allclose(state, new_state)


### PR DESCRIPTION
Tensorflow doesn't support slicing on states with more than 8 dimensions. So if we try and run the code:

```
state = create_initial_state(range(10), like='tensorflow')
apply_operation(qml.PauliZ(9), state)
```

We get:
```
---------------------------------------------------------------------------
UnimplementedError                        Traceback (most recent call last)
Cell In[7], line 2
      1 state = create_initial_state(range(10), like='tensorflow')
----> 2 apply_operation(qml.PauliZ(9), state)

File Python.framework/Versions/3.10/lib/python3.10/functools.py:889, in singledispatch.<locals>.wrapper(*args, **kw)
    885 if not args:
    886     raise TypeError(f'{funcname} requires at least '
    887                     '1 positional argument')
--> 889 return dispatch(args[0].__class__)(*args, **kw)

File pennylane/pennylane/devices/qubit/apply_operation.py:183, in apply_pauliz(op, state)
    180 sl_0 = _get_slice(0, op.wires[0], n_wires)
    181 sl_1 = _get_slice(1, op.wires[0], n_wires)
--> 183 state1 = math.multiply(state[sl_1], -1)
    184 return math.stack([state[sl_0], state1], axis=op.wires[0])

File /lib/python3.10/site-packages/tensorflow/python/util/traceback_utils.py:153, in filter_traceback.<locals>.error_handler(*args, **kwargs)
    151 except Exception as e:
    152   filtered_tb = _process_traceback_frames(e.__traceback__)
--> 153   raise e.with_traceback(filtered_tb) from None
    154 finally:
    155   del filtered_tb

File lib/python3.10/site-packages/tensorflow/python/framework/ops.py:7215, in raise_from_not_ok_status(e, name)
   7213 def raise_from_not_ok_status(e, name):
   7214   e.message += (" name: " + name if name is not None else "")
-> 7215   raise core._status_to_exception(e) from None

UnimplementedError: {{function_node __wrapped__StridedSlice_device_/job:localhost/replica:0/task:0/device:CPU:0}} Unhandled input dimensions 10 [Op:StridedSlice] name: strided_slice
```

 Since this case is exceptional, and we do not want to slow down the standard logical slow, I implemented fallback logic using try-except blocks.

If the error is a `tf.errors.UnimplementedError`, we fall back to `apply_operation_tensordot`.

This will probably have performance implications for applying PauliZ and CNOT on large states, but at least it won't affect the performance in cases where the error does not occur.

Blocks testing for #3862 