### PR TITLE
`SparseHamiltonian` uses `AnyWires

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -57,6 +57,9 @@
   to be set as trainable), and therefore the derivatives are computed more efficiently.
   [(#3697)](https://github.com/PennyLaneAI/pennylane/pull/3697)
 
+* `qml.SparseHamiltonian` now applies to any number of wires rather than all wires present in a circuit.
+  [(#3888)](https://github.com/PennyLaneAI/pennylane/pull/3888)
+
 
 <h3>Breaking changes</h3>
 

--- a/pennylane/ops/qubit/observables.py
+++ b/pennylane/ops/qubit/observables.py
@@ -23,7 +23,7 @@ import numpy as np
 from scipy.sparse import csr_matrix
 
 import pennylane as qml
-from pennylane.operation import AllWires, AnyWires, Observable
+from pennylane.operation import AnyWires, Observable
 from pennylane.wires import Wires
 
 from .matrix_ops import QubitUnitary
@@ -215,7 +215,7 @@ class SparseHamiltonian(Observable):
 
     **Details:**
 
-    * Number of wires: All
+    * Number of wires: Any
     * Number of parameters: 1
     * Gradient recipe: None
 
@@ -242,7 +242,7 @@ class SparseHamiltonian(Observable):
     >>> Hmat = H.sparse_matrix()
     >>> H_sparse = qml.SparseHamiltonian(Hmat, wires)
     """
-    num_wires = AllWires
+    num_wires = AnyWires
     num_params = 1
     """int: Number of trainable parameters that the operator depends on."""
 

--- a/pennylane/ops/qubit/observables.py
+++ b/pennylane/ops/qubit/observables.py
@@ -209,10 +209,6 @@ class SparseHamiltonian(Observable):
         ``SparseHamiltonian`` observables can only be used to return expectation values.
         Variances and samples are not supported.
 
-    .. note::
-
-        Note that the ``SparseHamiltonian`` observable should not be used with a subset of wires.
-
     **Details:**
 
     * Number of wires: Any


### PR DESCRIPTION
Updated `SparseHamiltonian` to use `AnyWires` instead of `AllWires`.