### PR TITLE
Allow setting threshold in `rydberg_interaction` to remove negligible terms

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -57,6 +57,9 @@
   to be set as trainable), and therefore the derivatives are computed more efficiently.
   [(#3697)](https://github.com/PennyLaneAI/pennylane/pull/3697)
 
+* Added `threshold` keyword argument to `qml.pulse.rydberg_interaction` to allow removal of negligible interactions from
+  Rydberg Hamiltonians.
+  [(#3889)](https://github.com/PennyLaneAI/pennylane/pull/3889)
 
 <h3>Breaking changes</h3>
 

--- a/pennylane/pulse/rydberg_hamiltonian.py
+++ b/pennylane/pulse/rydberg_hamiltonian.py
@@ -25,7 +25,9 @@ from pennylane.wires import Wires
 from .parametrized_hamiltonian import ParametrizedHamiltonian
 
 
-def rydberg_interaction(register: list, wires=None, interaction_coeff: float = 862690):
+def rydberg_interaction(
+    register: list, wires=None, interaction_coeff: float = 862690, threshold: float = None
+):
     r"""Returns a :class:`ParametrizedHamiltonian` representing the interaction of an ensemble of
     Rydberg atoms due to the Rydberg blockade
 
@@ -58,6 +60,9 @@ def rydberg_interaction(register: list, wires=None, interaction_coeff: float = 8
         interaction_coeff (float): Rydberg interaction constant in units: :math:`\text{MHz} \times \mu \text{m}^6`.
             Defaults to :math:`862690 \text{ MHz} \times \mu \text{m}^6`. This value is based on an assumption that
             frequencies and energies in the Hamiltonian are provided in units of MHz.
+        threshold (float): Threshold for distance between Rydberg atoms beyond which their contribution to the interaction
+            term is negligible. For threshold :math:`\epsilon`, the van der Waals potential :math:`V_{ij}` between two atoms
+            :math:`i`, :math:`j` will be ignored if :math:`\frac{1}{R_{ij}^{6}} < \epsilon`.
 
     Returns:
         RydbergHamiltonian: a :class:`~.ParametrizedHamiltonian` representing the atom interaction
@@ -103,6 +108,9 @@ def rydberg_interaction(register: list, wires=None, interaction_coeff: float = 8
     for idx, (pos1, wire1) in enumerate(zip(register[:-1], wires[:-1])):
         for pos2, wire2 in zip(register[(idx + 1) :], wires[(idx + 1) :]):
             atom_distance = np.linalg.norm(qml.math.array(pos2) - pos1)
+            if threshold is not None and (1 / abs(atom_distance) ** 6) < threshold:
+                continue
+
             Vij = interaction_coeff / (abs(atom_distance) ** 6)  # van der Waals potential
             coeffs.append(Vij)
             observables.append(qml.prod(qml.Projector([1], wire1), qml.Projector([1], wire2)))


### PR DESCRIPTION
This PR adds a `threshold` keyword argument to `qml.pulse.rydberg_interaction` to allow users to remove ignore negligible interactions in the interaction term of a Rydberg atom system.

For two Rydberg atoms $i$, $j$ and threshold $\epsilon$, the van der Waals potential $V_{ij}$ is assumed to be negligible if $\frac{1}{R_{ij}^{6}} < \epsilon$, where $R_{ij}$ is the distance between $i$, $j$.