### PR TITLE
Raise an error if jitting `Counts` or `Sample`

### DIFF
--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -1783,6 +1783,10 @@ class QubitDevice(Device):
             Union[array[float], dict, list[dict]]: samples in an array of
             dimension ``(shots,)`` or counts
         """
+        # Check if counts are being returned while jitting
+        if qml.math.is_abstract(self._state):
+            if counts:
+                raise DeviceError("Can't JIT a quantum function that returns counts.")
 
         # translate to wire labels used by device
         device_wires = self.map_wires(observable.wires)


### PR DESCRIPTION
This PR updates PennyLane to throw an error explicitly if a user tries to jit a QNode that returns `counts` or a QNode with trainable parameters that returns `samples`.
* Update `QubitDevice.sample` to raise an error if jitting is enabled and `counts` are being returned.
* Update `CountsMP.process_samples` to raise an error if jitting is enabled.