### PR TITLE
Fix `MeasurementProcess.hash` and `CompositeOp.hash`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -97,6 +97,10 @@
 
 <h3>Bug fixes</h3>
 
+* `MeasurementProcess.hash` now uses the hash property of the observable. `Sum.hash` and `Prod.hash` are slightly changed
+  to work with non-numeric wire labels.  `sum_expand` should now return correct results and not treat some products as the same
+  operation.
+
 * Fixed bug where the coefficients where not ordered correctly when summing a `ParametrizedHamiltonian`
   with other operators.
   [(#3749)](https://github.com/PennyLaneAI/pennylane/pull/3749)

--- a/pennylane/measurements/measurements.py
+++ b/pennylane/measurements/measurements.py
@@ -442,13 +442,9 @@ class MeasurementProcess(ABC):
                 self.__class__.__name__,
             )
         else:
-            fingerprint = (
-                str(self.obs.name),
-                tuple(self.wires.tolist()),
-                str(self.obs.data),
-                self.__class__.__name__,
-            )
+            fingerprint = (self.__class__.__name__, self.obs.hash)
 
+        print(fingerprint)
         return hash(fingerprint)
 
     def simplify(self):

--- a/pennylane/ops/op_math/prod.py
+++ b/pennylane/ops/op_math/prod.py
@@ -422,7 +422,8 @@ def _swappable_ops(op1, op2, wire_map: dict = None) -> bool:
         wires2 = wires2.map(wire_map)
     wires1 = set(wires1)
     wires2 = set(wires2)
-    return False if wires1 & wires2 else wires1.pop() > wires2.pop()
+    # compare strings of wire labels so that we can compare arbitrary wire labels like 0 and "a"
+    return False if wires1 & wires2 else str(wires1.pop()) > str(wires2.pop())
 
 
 class _ProductFactorsGrouping:

--- a/pennylane/ops/op_math/sum.py
+++ b/pennylane/ops/op_math/sum.py
@@ -179,6 +179,11 @@ class Sum(CompositeOp):
     _math_op = math.sum
 
     @property
+    def hash(self):
+        # Since addition is always commutative, we do not need to sort
+        return hash(("Sum", frozenset(o.hash for o in self.operands)))
+
+    @property
     def is_hermitian(self):
         """If all of the terms in the sum are hermitian, then the Sum is hermitian."""
         return all(s.is_hermitian for s in self)

--- a/pennylane/transforms/hamiltonian_expand.py
+++ b/pennylane/transforms/hamiltonian_expand.py
@@ -334,6 +334,8 @@ def sum_expand(tape: QuantumTape, group=True):
         else:
             idxs_coeffs_dict[m.hash].append((idx, coeff))
 
+    print(measurements_dict)
+    print(idxs_coeffs_dict)
     # Cast the dictionaries into lists (we don't need the hashed anymore)
     measurements = list(measurements_dict.values())
     idxs_coeffs = list(idxs_coeffs_dict.values())


### PR DESCRIPTION
Solves #3891 

[sc-34965]

`sum_expand` was treating measurement processes as equal when they were not actually equal.  The problem was due to `MeasurementProcess.hash`. Now if the measurement has an observable, it uses the observables hash.

This change uncovered problems with `Sum.hash` and `Prod.hash`. The hash was first sorting the operations, so that would be the same even if the terms where in a different order, as long as the terms commuted. Sorting was failing when when the wires had mixed types, like `0` and `"a"`.  

Since the terms in a `Sum` are always commutative, we use a frozen set instead of sorting.

`Prod` now compares the string version of the wire labels, as strings can always be compared with `<`.  This will fail is the operator has both `0` and `"0"` as wire labels, but if someone does that they are just asking for trouble.

