### PR TITLE
[Proposal] Set trainable parameters on tape construction

### DIFF
--- a/pennylane/interfaces/autograd.py
+++ b/pennylane/interfaces/autograd.py
@@ -15,7 +15,7 @@
 This module contains functions for adding the Autograd interface
 to a PennyLane Device class.
 """
-# pylint: disable=too-many-arguments
+# pylint: disable=too-many-arguments,no-member
 from collections.abc import Sequence
 
 import autograd
@@ -66,17 +66,10 @@ def execute(tapes, device, execute_fn, gradient_fn, gradient_kwargs, _n=1, max_d
             mode=mode,
         )
 
-    # pylint: disable=unused-argument
-    for tape in tapes:
-        # set the trainable parameters
-        params = tape.get_parameters(trainable_only=False)
-        tape.trainable_params = qml.math.get_trainable_indices(params)
-
     # pylint misidentifies autograd.builtins as a dict
-    # pylint: disable=no-member
     parameters = autograd.builtins.tuple(
         [autograd.builtins.list(t.get_parameters()) for t in tapes]
-    )
+    )  # pylint: disable=no-member
 
     return _execute(
         parameters,
@@ -287,7 +280,7 @@ autograd.extend.defvjp(_execute, vjp, argnums=[0])
 
 def _execute_new(
     tapes, device, execute_fn, gradient_fn, gradient_kwargs, _n=1, max_diff=2, mode=None
-):
+):  # pylint:disable=unused-argument
     """Execute a batch of tapes with Autograd parameters on a device.
 
     Args:
@@ -315,17 +308,11 @@ def _execute_new(
         list[list[float]]: A nested list of tape results. Each element in
         the returned list corresponds in order to the provided tapes.
     """
-    # pylint: disable=unused-argument
-    for tape in tapes:
-        # set the trainable parameters
-        params = tape.get_parameters(trainable_only=False)
-        tape.trainable_params = qml.math.get_trainable_indices(params)
-
     # pylint misidentifies autograd.builtins as a dict
-    # pylint: disable=no-member
     parameters = autograd.builtins.tuple(
         [autograd.builtins.list(t.get_parameters()) for t in tapes]
-    )
+    )  # pylint: disable=no-member
+
     return __execute_new(
         parameters,
         tapes=tapes,

--- a/pennylane/interfaces/jax.py
+++ b/pennylane/interfaces/jax.py
@@ -95,12 +95,6 @@ def execute(tapes, device, execute_fn, gradient_fn, gradient_kwargs, _n=1, max_d
 
     _validate_tapes(tapes)
 
-    if _n == 1:
-        for tape in tapes:
-            # set the trainable parameters
-            params = tape.get_parameters(trainable_only=False)
-            tape.trainable_params = qml.math.get_trainable_indices(params)
-
     parameters = tuple(list(t.get_parameters()) for t in tapes)
 
     if gradient_fn is None:
@@ -388,12 +382,6 @@ def execute_new(tapes, device, execute_fn, gradient_fn, gradient_kwargs, _n=1, m
         list[list[float]]: A nested list of tape results. Each element in
         the returned list corresponds in order to the provided tapes.
     """
-    # Set the trainable parameters
-    if _n == 1:
-        for tape in tapes:
-            params = tape.get_parameters(trainable_only=False)
-            tape.trainable_params = qml.math.get_trainable_indices(params)
-
     parameters = tuple(list(t.get_parameters()) for t in tapes)
 
     if gradient_fn is None:

--- a/pennylane/interfaces/jax_jit_tuple.py
+++ b/pennylane/interfaces/jax_jit_tuple.py
@@ -160,12 +160,6 @@ def execute_tuple(tapes, device, execute_fn, gradient_fn, gradient_kwargs, _n=1,
         # not implemeneted and is required for the callback logic
         raise NotImplementedError("The JAX-JIT interface doesn't support qml.counts.")
 
-    if _n == 1:
-        for tape in tapes:
-            # set the trainable parameters
-            params = tape.get_parameters(trainable_only=False)
-            tape.trainable_params = qml.math.get_trainable_indices(params)
-
     parameters = tuple(list(t.get_parameters(trainable_only=False)) for t in tapes)
 
     if gradient_fn is None:

--- a/pennylane/interfaces/tensorflow.py
+++ b/pennylane/interfaces/tensorflow.py
@@ -179,10 +179,7 @@ def execute(tapes, device, execute_fn, gradient_fn, gradient_kwargs, _n=1, max_d
     params_unwrapped = []
 
     for i, tape in enumerate(tapes):
-        # store the trainable parameters
         params = tape.get_parameters(trainable_only=False)
-        tape.trainable_params = qml.math.get_trainable_indices(params)
-
         parameters += [p for i, p in enumerate(params) if i in tape.trainable_params]
 
         # store all unwrapped parameters
@@ -325,10 +322,7 @@ def _execute_new(tapes, device, execute_fn, gradient_fn, gradient_kwargs, _n=1, 
     params_unwrapped = []
 
     for i, tape in enumerate(tapes):
-        # store the trainable parameters
         params = tape.get_parameters(trainable_only=False)
-        tape.trainable_params = qml.math.get_trainable_indices(params)
-
         parameters += [p for i, p in enumerate(params) if i in tape.trainable_params]
 
         # store all unwrapped parameters

--- a/pennylane/interfaces/tensorflow_autograph.py
+++ b/pennylane/interfaces/tensorflow_autograph.py
@@ -93,10 +93,7 @@ def execute(tapes, device, execute_fn, gradient_fn, gradient_kwargs, _n=1, max_d
     output_types = []
 
     for tape in tapes:
-        # store the trainable parameters
         params = tape.get_parameters(trainable_only=False)
-        tape.trainable_params = qml.math.get_trainable_indices(params)
-
         parameters += [p for i, p in enumerate(params) if i in tape.trainable_params]
         all_params += params
         trainable += (np.array(list(tape.trainable_params)) + sum(lens)).tolist()
@@ -314,10 +311,7 @@ def _execute_new(
     num_shot_copies = _get_num_copies(device.shot_vector) if device.shot_vector else 1
 
     for tape in tapes:
-        # store the trainable parameters
         params = tape.get_parameters(trainable_only=False)
-        tape.trainable_params = qml.math.get_trainable_indices(params)
-
         parameters += [p for i, p in enumerate(params) if i in tape.trainable_params]
         all_params += params
         trainable += (np.array(list(tape.trainable_params)) + sum(lens)).tolist()

--- a/pennylane/interfaces/torch.py
+++ b/pennylane/interfaces/torch.py
@@ -241,9 +241,6 @@ def execute(tapes, device, execute_fn, gradient_fn, gradient_kwargs, _n=1, max_d
 
     parameters = []
     for tape in tapes:
-        # set the trainable parameters
-        params = tape.get_parameters(trainable_only=False)
-        tape.trainable_params = qml.math.get_trainable_indices(params)
         parameters.extend(tape.get_parameters())
 
     kwargs = {
@@ -479,12 +476,8 @@ def _execute_new(tapes, device, execute_fn, gradient_fn, gradient_kwargs, _n=1, 
         list[list[torch.Tensor]]: A nested list of tape results. Each element in
         the returned list corresponds in order to the provided tapes.
     """
-    # pylint: disable=unused-argument
     parameters = []
     for tape in tapes:
-        # set the trainable parameters
-        params = tape.get_parameters(trainable_only=False)
-        tape.trainable_params = qml.math.get_trainable_indices(params)
         parameters.extend(tape.get_parameters())
 
     kwargs = {

--- a/pennylane/qnode.py
+++ b/pennylane/qnode.py
@@ -751,9 +751,6 @@ class QNode:
         self._tape = make_qscript(self.func)(*args, **kwargs)
         self._qfunc_output = self.tape._qfunc_output
 
-        params = self.tape.get_parameters(trainable_only=False)
-        self.tape.trainable_params = qml.math.get_trainable_indices(params)
-
         if isinstance(self._qfunc_output, qml.numpy.ndarray):
             measurement_processes = tuple(self.tape.measurements)
         elif not isinstance(self._qfunc_output, Sequence):

--- a/pennylane/transforms/tape_expand.py
+++ b/pennylane/transforms/tape_expand.py
@@ -29,11 +29,6 @@ from pennylane.operation import (
 )
 
 
-def _update_trainable_params(tape):
-    params = tape.get_parameters(trainable_only=False)
-    tape.trainable_params = qml.math.get_trainable_indices(params)
-
-
 def create_expand_fn(depth, stop_at=None, device=None, docstring=None):
     """Create a function for expanding a tape to a given depth, and
     with a specific stopping criterion. This is a wrapper around
@@ -100,8 +95,6 @@ def create_expand_fn(depth, stop_at=None, device=None, docstring=None):
                 tape = tape.expand(depth=depth, stop_at=stop_at)
             else:
                 return tape
-
-            _update_trainable_params(tape)
 
         return tape
 

--- a/tests/interfaces/test_jax.py
+++ b/tests/interfaces/test_jax.py
@@ -478,7 +478,7 @@ class TestJaxExecuteIntegration:
             qml.expval(qml.PauliZ(0))
 
         tape = qml.tape.QuantumScript.from_queue(q)
-        assert tape.trainable_params == [0, 1]
+        assert tape.trainable_params == []
 
         def cost(a, b):
             # An explicit call to _update() is required here to update the
@@ -488,6 +488,7 @@ class TestJaxExecuteIntegration:
             # number of provided parameters fails in the tape: (len(params) !=
             # required_length) and the tape produces incorrect results.
             tape._update()
+            tape.trainable_params = [0, 1]
             tape.set_parameters([a, b])
             return execute([tape], dev, interface=interface, **execute_kwargs)[0][0]
 

--- a/tests/interfaces/test_tensorflow.py
+++ b/tests/interfaces/test_tensorflow.py
@@ -475,6 +475,8 @@ class TestTensorFlowExecuteIntegration:
             qml.expval(qml.PauliY(1))
 
         tape = qml.tape.QuantumScript.from_queue(q)
+        # must explicitly define trainable_params, tape defined outside tf.GradientTape context
+        tape.trainable_params = [0, 1]
         with tf.GradientTape() as t:
             tape.set_parameters([a, b])
             assert tape.trainable_params == [0, 1]

--- a/tests/tape/test_qscript.py
+++ b/tests/tape/test_qscript.py
@@ -172,7 +172,7 @@ class TestUpdate:
         assert qs.samples_computational_basis is False
 
     def test_update_par_info_update_trainable_params(self):
-        """Tests setting the parameter info dictionary.  Makes sure to include operations with
+        """Tests setting the parameter info dictionary. Makes sure to include operations with
         multiple parameters, operations with matrix parameters, and measurement of observables with
         parameters."""
         ops = [
@@ -195,7 +195,7 @@ class TestUpdate:
         assert p_i[6] == {"op": ops[3], "op_idx": 3, "p_idx": 1}
         assert p_i[7] == {"op": m[0].obs, "op_idx": 0, "p_idx": 0}
 
-        assert qs._trainable_params == list(range(8))
+        assert qs._trainable_params == [4, 7]
 
     def test_get_operation(self):
         """Tests the tape method get_operation"""
@@ -204,7 +204,7 @@ class TestUpdate:
             qml.Rot(2.3, 3.4, 5.6, wires=0),
             qml.PauliX(wires=0),
             qml.QubitUnitary(np.eye(2), wires=0),
-            qml.U2(-1, -2, wires=0),
+            qml.U2(-1, np.array(-2), wires=0),
         ]
         m = [qml.expval(qml.Hermitian(2 * np.eye(2), wires=0))]
         qs = QuantumScript(ops, m)
@@ -213,56 +213,21 @@ class TestUpdate:
             UserWarning,
             match="The get_operation will soon be updated to also return the index of the trainable operation in the tape.",
         ):
-            op_0, p_id_0 = qs.get_operation(0)
-            assert op_0 == ops[0] and p_id_0 == 0
-
-        with pytest.warns(
-            UserWarning,
-            match="The get_operation will soon be updated to also return the index of the trainable operation in the tape.",
-        ):
-            op_1, p_id_1 = qs.get_operation(1)
-            assert op_1 == ops[1] and p_id_1 == 0
-
-        with pytest.warns(
-            UserWarning,
-            match="The get_operation will soon be updated to also return the index of the trainable operation in the tape.",
-        ):
-            op_2, p_id_2 = qs.get_operation(2)
-            assert op_2 == ops[1] and p_id_2 == 1
-
-        with pytest.warns(
-            UserWarning,
-            match="The get_operation will soon be updated to also return the index of the trainable operation in the tape.",
-        ):
-            op_3, p_id_3 = qs.get_operation(3)
-            assert op_3 == ops[1] and p_id_3 == 2
-
-        with pytest.warns(
-            UserWarning,
-            match="The get_operation will soon be updated to also return the index of the trainable operation in the tape.",
-        ):
-            op_4, p_id_4 = qs.get_operation(4)
+            op_4, p_id_4 = qs.get_operation(0)
             assert op_4 == ops[3] and p_id_4 == 0
 
         with pytest.warns(
             UserWarning,
             match="The get_operation will soon be updated to also return the index of the trainable operation in the tape.",
         ):
-            op_5, p_id_5 = qs.get_operation(5)
-            assert op_5 == ops[4] and p_id_5 == 0
-
-        with pytest.warns(
-            UserWarning,
-            match="The get_operation will soon be updated to also return the index of the trainable operation in the tape.",
-        ):
-            op_6, p_id_6 = qs.get_operation(6)
+            op_6, p_id_6 = qs.get_operation(1)
             assert op_6 == ops[4] and p_id_6 == 1
 
         with pytest.warns(
             UserWarning,
             match="The get_operation will soon be updated to also return the index of the trainable operation in the tape.",
         ):
-            _, p_id_0 = qs.get_operation(7)
+            _, p_id_0 = qs.get_operation(2)
             assert p_id_0 == 0
 
     def test_get_operation_return_index(self):
@@ -272,33 +237,18 @@ class TestUpdate:
             qml.Rot(2.3, 3.4, 5.6, wires=0),
             qml.PauliX(wires=0),
             qml.QubitUnitary(np.eye(2), wires=0),
-            qml.U2(-1, -2, wires=0),
+            qml.U2(-1, np.array(-2), wires=0),
         ]
         m = [qml.expval(qml.Hermitian(2 * np.eye(2), wires=0))]
         qs = QuantumScript(ops, m)
 
-        op_0, op_id_0, p_id_0 = qs.get_operation(0, True)
-        assert op_0 == ops[0] and op_id_0 == 0 and p_id_0 == 0
-
-        op_1, op_id_1, p_id_1 = qs.get_operation(1, True)
-        assert op_1 == ops[1] and op_id_1 == 1 and p_id_1 == 0
-
-        op_2, op_id_2, p_id_2 = qs.get_operation(2, True)
-        assert op_2 == ops[1] and op_id_2 == 1 and p_id_2 == 1
-
-        op_3, op_id_3, p_id_3 = qs.get_operation(3, True)
-        assert op_3 == ops[1] and op_id_3 == 1 and p_id_3 == 2
-
-        op_4, op_id_4, p_id_4 = qs.get_operation(4, True)
+        op_4, op_id_4, p_id_4 = qs.get_operation(0, True)
         assert op_4 == ops[3] and op_id_4 == 3 and p_id_4 == 0
 
-        op_5, op_id_5, p_id_5 = qs.get_operation(5, True)
-        assert op_5 == ops[4] and op_id_5 == 4 and p_id_5 == 0
-
-        op_6, op_id_6, p_id_6 = qs.get_operation(6, True)
+        op_6, op_id_6, p_id_6 = qs.get_operation(1, True)
         assert op_6 == ops[4] and op_id_6 == 4 and p_id_6 == 1
 
-        _, obs_id_0, p_id_0 = qs.get_operation(7, True)
+        _, obs_id_0, p_id_0 = qs.get_operation(2, True)
         assert obs_id_0 == 0 and p_id_0 == 0
 
     def test_get_operation_private(self):
@@ -308,33 +258,18 @@ class TestUpdate:
             qml.Rot(2.3, 3.4, 5.6, wires=0),
             qml.PauliX(wires=0),
             qml.QubitUnitary(np.eye(2), wires=0),
-            qml.U2(-1, -2, wires=0),
+            qml.U2(-1, np.array(-2), wires=0),
         ]
         m = [qml.expval(qml.Hermitian(2 * np.eye(2), wires=0))]
         qs = QuantumScript(ops, m)
 
-        op_0, op_id_0, p_id_0 = qs._get_operation(0)
-        assert op_0 == ops[0] and op_id_0 == 0 and p_id_0 == 0
-
-        op_1, op_id_1, p_id_1 = qs._get_operation(1)
-        assert op_1 == ops[1] and op_id_1 == 1 and p_id_1 == 0
-
-        op_2, op_id_2, p_id_2 = qs._get_operation(2)
-        assert op_2 == ops[1] and op_id_2 == 1 and p_id_2 == 1
-
-        op_3, op_id_3, p_id_3 = qs._get_operation(3)
-        assert op_3 == ops[1] and op_id_3 == 1 and p_id_3 == 2
-
-        op_4, op_id_4, p_id_4 = qs._get_operation(4)
+        op_4, op_id_4, p_id_4 = qs._get_operation(0)
         assert op_4 == ops[3] and op_id_4 == 3 and p_id_4 == 0
 
-        op_5, op_id_5, p_id_5 = qs._get_operation(5)
-        assert op_5 == ops[4] and op_id_5 == 4 and p_id_5 == 0
-
-        op_6, op_id_6, p_id_6 = qs._get_operation(6)
+        op_6, op_id_6, p_id_6 = qs._get_operation(1)
         assert op_6 == ops[4] and op_id_6 == 4 and p_id_6 == 1
 
-        _, obs_id_0, p_id_0 = qs._get_operation(7)
+        _, obs_id_0, p_id_0 = qs._get_operation(2)
         assert obs_id_0 == 0 and p_id_0 == 0
 
     def test_update_observables(self):
@@ -506,7 +441,7 @@ class TestInfomationProperties:
             qml.RX(-0.543, wires=0),
             qml.Rot(-4.3, 4.69, 1.2, wires=0),
             qml.CNOT(wires=[0, "a"]),
-            qml.RX(0.54, wires=4),
+            qml.RX(np.array(0.54), wires=4),
         ]
         m = [qml.expval(qml.PauliX(wires="a")), qml.probs(wires=[0, "a"])]
 
@@ -561,7 +496,7 @@ class TestInfomationProperties:
         assert specs["num_observables"] == 2
         assert specs["num_diagonalizing_gates"] == 1
         assert specs["num_used_wires"] == 3
-        assert specs["num_trainable_params"] == 5
+        assert specs["num_trainable_params"] == 1
         assert specs["depth"] == 3
 
 
@@ -572,7 +507,7 @@ class TestScriptCopying:
         """Test that shallow copying of a script results in all
         contained data being shared between the original tape and the copy"""
         prep = [qml.BasisState(np.array([1, 0]), wires=(0, 1))]
-        ops = [qml.RY(0.5, wires=1), qml.CNOT((0, 1))]
+        ops = [qml.RY(np.array(0.5), wires=1), qml.CNOT((0, 1))]
         m = [qml.expval(qml.PauliZ(0) @ qml.PauliY(1))]
         qs = QuantumScript(ops, m, prep=prep)
 
@@ -618,7 +553,7 @@ class TestScriptCopying:
         parameters to be set independently"""
 
         prep = [qml.BasisState(np.array([1, 0]), wires=(0, 1))]
-        ops = [qml.RY(0.5, wires=1), qml.CNOT((0, 1))]
+        ops = [qml.RY(np.array(0.5), wires=1), qml.CNOT((0, 1))]
         m = [qml.expval(qml.PauliZ(0) @ qml.PauliY(1))]
         qs = QuantumScript(ops, m, prep=prep)
 
@@ -756,7 +691,12 @@ class TestHashing:
         b = 0.2
 
         qs1 = QuantumScript([qml.RX(a, 0), qml.RY(b, 1)])
-        qs2 = QuantumScript([qml.RX(np.array(a), 0), qml.RY(np.array(b), 1)])
+        qs2 = QuantumScript(
+            [
+                qml.RX(np.array(a, requires_grad=False), 0),
+                qml.RY(np.array(b, requires_grad=False), 1),
+            ]
+        )
 
         assert qs1.hash == qs2.hash
 


### PR DESCRIPTION
**Context:**
Setting trainable parameters is manually done in a much slower manner on qnode construction, and every time a tape is executed. The performance impact of this is harsh, and the inconsistency from before and after tape execution can be surprising.

**Description of the Change:**
Define trainable parameters using on tape construction, rather than execution (and on qnode construction). This may be considered a breaking change, as `tape.trainable_params` used to be all parameters before being executed, but is now set correctly right from the get-go. In my opinion (esp. based on the tests that broke), the main thing this breaks is if a user did `tape = ...; tape.set_parameters(...)`, but I don't believe this is a common practice in general.

**Benefits:**
Significant performance improvements, as well as cleaner code with more expected results.

**Possible Drawbacks:**
Users may have grown to expect this all-parameters-are-trainable-until-executed behaviour, and of course might now depend on it.

I'll add details on performance differences soon.