### PR TITLE
add trainable_params setter; use in interfaces

### DIFF
--- a/pennylane/interfaces/autograd.py
+++ b/pennylane/interfaces/autograd.py
@@ -15,7 +15,7 @@
 This module contains functions for adding the Autograd interface
 to a PennyLane Device class.
 """
-# pylint: disable=too-many-arguments
+# pylint: disable=too-many-arguments,no-member
 from collections.abc import Sequence
 
 import autograd
@@ -66,14 +66,10 @@ def execute(tapes, device, execute_fn, gradient_fn, gradient_kwargs, _n=1, max_d
             mode=mode,
         )
 
-    # pylint: disable=unused-argument
     for tape in tapes:
-        # set the trainable parameters
-        params = tape.get_parameters(trainable_only=False)
-        tape.trainable_params = qml.math.get_trainable_indices(params)
+        tape.update_trainable_parameters()
 
     # pylint misidentifies autograd.builtins as a dict
-    # pylint: disable=no-member
     parameters = autograd.builtins.tuple(
         [autograd.builtins.list(t.get_parameters()) for t in tapes]
     )
@@ -287,7 +283,7 @@ autograd.extend.defvjp(_execute, vjp, argnums=[0])
 
 def _execute_new(
     tapes, device, execute_fn, gradient_fn, gradient_kwargs, _n=1, max_diff=2, mode=None
-):
+):  # pylint: disable=unused-argument
     """Execute a batch of tapes with Autograd parameters on a device.
 
     Args:
@@ -315,14 +311,10 @@ def _execute_new(
         list[list[float]]: A nested list of tape results. Each element in
         the returned list corresponds in order to the provided tapes.
     """
-    # pylint: disable=unused-argument
     for tape in tapes:
-        # set the trainable parameters
-        params = tape.get_parameters(trainable_only=False)
-        tape.trainable_params = qml.math.get_trainable_indices(params)
+        tape.update_trainable_parameters()
 
     # pylint misidentifies autograd.builtins as a dict
-    # pylint: disable=no-member
     parameters = autograd.builtins.tuple(
         [autograd.builtins.list(t.get_parameters()) for t in tapes]
     )

--- a/pennylane/interfaces/jax.py
+++ b/pennylane/interfaces/jax.py
@@ -97,9 +97,7 @@ def execute(tapes, device, execute_fn, gradient_fn, gradient_kwargs, _n=1, max_d
 
     if _n == 1:
         for tape in tapes:
-            # set the trainable parameters
-            params = tape.get_parameters(trainable_only=False)
-            tape.trainable_params = qml.math.get_trainable_indices(params)
+            tape.update_trainable_parameters()
 
     parameters = tuple(list(t.get_parameters()) for t in tapes)
 
@@ -388,11 +386,9 @@ def execute_new(tapes, device, execute_fn, gradient_fn, gradient_kwargs, _n=1, m
         list[list[float]]: A nested list of tape results. Each element in
         the returned list corresponds in order to the provided tapes.
     """
-    # Set the trainable parameters
     if _n == 1:
         for tape in tapes:
-            params = tape.get_parameters(trainable_only=False)
-            tape.trainable_params = qml.math.get_trainable_indices(params)
+            tape.update_trainable_parameters()
 
     parameters = tuple(list(t.get_parameters()) for t in tapes)
 
@@ -442,11 +438,7 @@ def _execute_bwd_new(
         with qml.tape.Unwrap(*new_tapes):
             res, _ = execute_fn(new_tapes, **gradient_kwargs)
 
-        if device.shot_vector:
-            res = _to_jax_shot_vector(res)
-        else:
-            res = _to_jax(res)
-
+        res = _to_jax_shot_vector(res) if device.shot_vector else _to_jax(res)
         return res
 
     @execute_wrapper.defjvp

--- a/pennylane/interfaces/jax_jit.py
+++ b/pennylane/interfaces/jax_jit.py
@@ -79,10 +79,11 @@ def execute(tapes, device, execute_fn, gradient_fn, gradient_kwargs, _n=1, max_d
         for tape in tapes:
             # set the jitted parameters
             params = tape.get_parameters(trainable_only=False)
-            trainable_params = set()
-            for idx, p in enumerate(params):
-                if isinstance(p, jax.core.Tracer) or qml.math.requires_grad(p):
-                    trainable_params.add(idx)
+            trainable_params = {
+                idx
+                for idx, p in enumerate(params)
+                if isinstance(p, jax.core.Tracer) or qml.math.requires_grad(p)
+            }
             tape.trainable_params = trainable_params
 
     parameters = tuple(list(t.get_parameters()) for t in tapes)

--- a/pennylane/interfaces/jax_jit_tuple.py
+++ b/pennylane/interfaces/jax_jit_tuple.py
@@ -162,9 +162,7 @@ def execute_tuple(tapes, device, execute_fn, gradient_fn, gradient_kwargs, _n=1,
 
     if _n == 1:
         for tape in tapes:
-            # set the trainable parameters
-            params = tape.get_parameters(trainable_only=False)
-            tape.trainable_params = qml.math.get_trainable_indices(params)
+            tape.update_trainable_parameters()
 
     parameters = tuple(list(t.get_parameters(trainable_only=False)) for t in tapes)
 

--- a/pennylane/interfaces/tensorflow_autograph.py
+++ b/pennylane/interfaces/tensorflow_autograph.py
@@ -38,10 +38,11 @@ def _flatten_nested_list(x):
     """
     Recursively flatten the list
     """
-    if not isinstance(x, (tuple, list)):
-        return [x]
-
-    return reduce(lambda a, y: a + _flatten_nested_list(y), x, [])
+    return (
+        reduce(lambda a, y: a + _flatten_nested_list(y), x, [])
+        if isinstance(x, (tuple, list))
+        else [x]
+    )
 
 
 def execute(tapes, device, execute_fn, gradient_fn, gradient_kwargs, _n=1, max_diff=2, mode=None):
@@ -261,7 +262,7 @@ def execute(tapes, device, execute_fn, gradient_fn, gradient_kwargs, _n=1, max_d
             vjps = iter(vjps)
             vjps = [next(vjps) if x in trainable else None for x in range(len(all_params))]
 
-            variables = tfkwargs.get("variables", None)
+            variables = tfkwargs.get("variables")
             return (vjps, variables) if variables is not None else vjps
 
         return res, grad_fn
@@ -520,7 +521,7 @@ def _execute_new(
             vjps = iter(vjps)
             vjps = [next(vjps) if x in trainable else None for x in range(len(all_params))]
 
-            variables = tfkwargs.get("variables", None)
+            variables = tfkwargs.get("variables")
             return (vjps, variables) if variables is not None else vjps
 
         return res, grad_fn

--- a/tests/tape/test_qscript.py
+++ b/tests/tape/test_qscript.py
@@ -401,6 +401,20 @@ class TestUpdate:
         qs = QuantumScript(ops, m)
         assert qs.output_dim == output_dim * factor
 
+    def test_update_trainable_parameters(self):
+        """Test update_trainable_parameters works as expected."""
+        qs = QuantumScript(
+            [
+                qml.RX(1.1, 0),
+                qml.RY(np.array(1.1), 1),
+                qml.Rot(0.1, np.array(0.2), 0.3, 0),
+            ],
+            [qml.expval(qml.Hermitian(np.array([[1, 0], [0, -1]]), 0))],
+        )
+        assert qs.trainable_params == list(range(6))
+        qs.update_trainable_parameters()
+        assert qs.trainable_params == [1, 3, 5]
+
 
 class TestIteration:
     """Test the capabilities related to iterating over quantum script."""


### PR DESCRIPTION
**Context:**
While working on lightning upgrades, I discovered that we spend far too much time in `tape.get_parameters`. The reason is the nested indexing combined with deep operators. I benchmark this by comparing a Hamiltonian with ~900 terms to an equivalent Sum operator:
![image](https://user-images.githubusercontent.com/23283972/225404493-a740843f-3879-44b2-8c4a-769bd739d5e4.png)

As you can see from the first timings (Hamiltonian vs. Sum, using new setter), the Sum is 4x slower than Hamiltonian. But in the second timings (using old setter), Sum is ~1300x slower than Hamiltonian. So this is a 300x speedup in this example.

**Description of the Change:**
1. Add a new method to QuantumScript, `update_trainable_parameters`, which updates the accurate trainable indices of a tape when called
2. Set `QNode.construct()` and relevant interfaces to use this new method when possible.

**Benefits:**
Big speedup.

**Possible Drawbacks:**
- Even more methods in the QuantumScript class?
- Inconsistent parameter-checking from interface to interface. I couldn't update tensorflow because it uses all parameters anyway. This makes me thing `get_parameters()` itself can be optimized, but I'll investigate that in another PR.

**Related GitHub Issues:**
Tried something more extreme in #3906, but don't mind that :p