### PR TITLE
Change `Operator.num_wires` to `AnyWires`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -81,7 +81,7 @@
   [(#3851)](https://github.com/PennyLaneAI/pennylane/pull/3851)
 
 * Changed `Operator.num_wires` from an abstract value to `AnyWires`.
-  [(#3918)](https://github.com/PennyLaneAI/pennylane/pull/3918)
+  [(#3919)](https://github.com/PennyLaneAI/pennylane/pull/3919)
 
 <h3>Breaking changes</h3>
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -80,6 +80,9 @@
   `ops.op_math.ctrl_decomp_bisect`.
   [(#3851)](https://github.com/PennyLaneAI/pennylane/pull/3851)
 
+* Changed `Operator.num_wires` from an abstract value to `AnyWires`.
+  [(#3918)](https://github.com/PennyLaneAI/pennylane/pull/3918)
+
 <h3>Breaking changes</h3>
 
 * Both JIT interfaces are not compatible with Jax `>0.4.3`, we raise an error for those versions.

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -842,10 +842,8 @@ class Operator(abc.ABC):
         """
         raise TermsUndefinedError
 
-    @property
-    @abc.abstractmethod
-    def num_wires(self):
-        """Number of wires the operator acts on."""
+    num_wires = AnyWires
+    """Number of wires the operator acts on."""
 
     @property
     def name(self):

--- a/pennylane/ops/op_math/composite.py
+++ b/pennylane/ops/op_math/composite.py
@@ -122,6 +122,7 @@ class CompositeOp(Operator):
 
     @property
     def num_wires(self):
+        """Number of wires the operator acts on."""
         return len(self.wires)
 
     @property

--- a/pennylane/ops/op_math/symbolicop.py
+++ b/pennylane/ops/op_math/symbolicop.py
@@ -103,6 +103,7 @@ class SymbolicOp(Operator):
 
     @property
     def num_wires(self):
+        """Number of wires the operator acts on."""
         return len(self.wires)
 
     # pylint: disable=arguments-renamed, invalid-overridden-method

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -78,6 +78,7 @@ class TestOperatorConstruction:
             r"""Dummy custom operator"""
 
         assert DummyOp.num_wires == qml.operation.AnyWires
+        assert Operator.num_wires == qml.operation.AnyWires
 
     def test_incorrect_num_params(self):
         """Test that an exception is raised if called with wrong number of parameters"""

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -71,6 +71,14 @@ class TestOperatorConstruction:
         with pytest.raises(qml.wires.WireError, match="Wires must be unique"):
             DummyOp(0.5, wires=[1, 1], do_queue=False)
 
+    def test_num_wires_default_any_wires(self):
+        """Test that num_wires is `AnyWires` by default."""
+
+        class DummyOp(qml.operation.Operator):
+            r"""Dummy custom operator"""
+
+        assert DummyOp.num_wires == qml.operation.AnyWires
+
     def test_incorrect_num_params(self):
         """Test that an exception is raised if called with wrong number of parameters"""
 


### PR DESCRIPTION
Change `Operator.num_wires` from an abstract value to `AnyWires`. This will make adding new operators slightly easier if the operator acts on arbitrary wires.