### PR TITLE
Jax marker in metric tensor tests & fix docker build

### DIFF
--- a/tests/returntypes/transforms/test_metric_tensor_new.py
+++ b/tests/returntypes/transforms/test_metric_tensor_new.py
@@ -1191,6 +1191,7 @@ class TestFullMetricTensor:
         else:
             assert qml.math.allclose(mt, expected)
 
+    @pytest.mark.jax
     @pytest.mark.parametrize("ansatz, params", zip(fubini_ansatze, fubini_params))
     @pytest.mark.parametrize("interface", ["auto", "jax"])
     def test_correct_output_jax(self, ansatz, params, interface):
@@ -1221,6 +1222,7 @@ class TestFullMetricTensor:
         else:
             assert qml.math.allclose(mt, expected)
 
+    @pytest.mark.jax
     @pytest.mark.parametrize("ansatz, params", zip(fubini_ansatze, fubini_params))
     @pytest.mark.parametrize("interface", ["auto", "jax"])
     def test_correct_output_jax_argnum_warning(self, ansatz, params, interface):


### PR DESCRIPTION
**Description of the Change:**

Two markers were forgotten in `test_metric_tensor_new`
