### PR TITLE
Amend PCPhase operator to support RZ convention

### DIFF
--- a/pennylane/ops/qubit/parametric_ops_multi_qubit.py
+++ b/pennylane/ops/qubit/parametric_ops_multi_qubit.py
@@ -617,9 +617,8 @@ class PCPhase(Operation):
 
         if qml.math.get_interface(phi) == "tensorflow":
             phase = qml.math.exp(1j * qml.math.cast_like(phi, 1j))
-            return stack_last(
-                [phase if index < d else qml.math.ones_like(phase) for index in range(t)]
-            )
+            minus_phase = qml.math.exp(-1j * qml.math.cast_like(phi, 1j))
+            return stack_last([phase if index < d else minus_phase for index in range(t)])
 
         arg = 1j * phi
         prefactors = qml.math.array([1 if index < d else -1 for index in range(t)], like=phi)

--- a/pennylane/ops/qubit/parametric_ops_multi_qubit.py
+++ b/pennylane/ops/qubit/parametric_ops_multi_qubit.py
@@ -514,18 +514,20 @@ class PCPhase(Operation):
     A projector-controlled phase gate.
 
     This gate applies a complex phase :math:`\phi` to first :math:`dim`
-    basis vectors of the input state. This is equivalent to applying a constant
-    phase shift to the subspace spanned by those vectors. Consider the 2 qubit
+    basis vectors of the input state while applying a complex phase :math:`- \phi`
+    to the remaining basis vectors. This is equivalent to applying a constant
+    phase shift to the subspace spanned by those :math:`dim` vectors. Consider the 2 qubit
     case where :math:`dim = 2`.
 
     .. math:: \Pi_{\phi}(\phi, dim=2, wires=[0,1]) = \begin{bmatrix}
                 e^{i\phi} & 0 & 0 & 0 \\
                 0 & e^{i\phi} & 0 & 0 \\
-                0 & 0 & 1 & 0 \\
-                0 & 0 & 0 & 1
+                0 & 0 & e^{-i\phi} & 0 \\
+                0 & 0 & 0 & e^{-i\phi}
             \end{bmatrix}.
 
-    This applies a phase shift to the subspace spanned by :math:`\lbrace | 00 \rangle , | 01 \rangle \rbrace`.
+    This is effectively applying a :math:`2*\phi` phase shift to the subspace spanned by
+    :math:`\lbrace | 00 \rangle , | 01 \rangle \rbrace` excluding global phase.
 
     **Details:**
 
@@ -548,7 +550,7 @@ class PCPhase(Operation):
     array([[0.33423773+0.9424888j, 0.        +0.j       , 0.        +0.j       , 0.        +0.j       ],
            [0.        +0.j       , 0.33423773+0.9424888j, 0.        +0.j       , 0.        +0.j       ],
            [0.        +0.j       , 0.        +0.j       , 0.33423773+0.9424888j, 0.        +0.j       ],
-           [0.        +0.j       , 0.        +0.j       , 0.        +0.j       , 1.        +0.j       ]])
+           [0.        +0.j       , 0.        +0.j       , 0.        +0.j       , 0.33423773-0.9424888j]])
     """
     num_wires = AnyWires
     num_params = 1

--- a/pennylane/ops/qubit/parametric_ops_multi_qubit.py
+++ b/pennylane/ops/qubit/parametric_ops_multi_qubit.py
@@ -561,7 +561,7 @@ class PCPhase(Operation):
     parameter_frequencies = [(2,)]
 
     def generator(self):
-        r"""The hermitian matrix, which when exponentiated and scaled (i :math:`\phi`), produces
+        r"""The Hermitian matrix, which, when exponentiated and scaled (i :math:`\phi`), produces
         the PCPhase unitary."""
         dim, shape = self.hyperparameters["dimension"]
         mat = np.diag([1 if index < dim else -1 for index in range(shape)])

--- a/pennylane/ops/qubit/parametric_ops_multi_qubit.py
+++ b/pennylane/ops/qubit/parametric_ops_multi_qubit.py
@@ -558,13 +558,13 @@ class PCPhase(Operation):
 
     basis = "Z"
     grad_method = "A"
-    parameter_frequencies = [(1,)]
+    parameter_frequencies = [(2,)]
 
     def generator(self):
         r"""The hermitian matrix, which when exponentiated and scaled (i :math:`\phi`), produces
         the PCPhase unitary."""
         dim, shape = self.hyperparameters["dimension"]
-        mat = np.diag([1 if index < dim else 0 for index in range(shape)])
+        mat = np.diag([1 if index < dim else -1 for index in range(shape)])
         return qml.Hermitian(mat, wires=self.wires)
 
     def __init__(self, phi, dim, wires, do_queue=True, id=None):
@@ -587,7 +587,7 @@ class PCPhase(Operation):
 
         if qml.math.get_interface(phi) == "tensorflow":
             p = qml.math.exp(1j * qml.math.cast_like(phi, 1j))
-            ones = qml.math.ones_like(p)
+            minus_p = qml.math.exp(-1j * qml.math.cast_like(phi, 1j))
             zeros = qml.math.zeros_like(p)
 
             columns = []
@@ -595,13 +595,13 @@ class PCPhase(Operation):
                 columns.append(
                     [p if j == i else zeros for j in range(t)]
                     if i < d
-                    else [ones if j == i else zeros for j in range(t)]
+                    else [minus_p if j == i else zeros for j in range(t)]
                 )
             r = qml.math.stack(columns, like="tensorflow", axis=-2)
             return r
 
         arg = 1j * phi
-        prefactors = qml.math.array([1 if index < d else 0 for index in range(t)], like=phi)
+        prefactors = qml.math.array([1 if index < d else -1 for index in range(t)], like=phi)
 
         if qml.math.ndim(arg) == 0:
             return qml.math.diag(qml.math.exp(arg * prefactors))
@@ -622,7 +622,7 @@ class PCPhase(Operation):
             )
 
         arg = 1j * phi
-        prefactors = qml.math.array([1 if index < d else 0 for index in range(t)], like=phi)
+        prefactors = qml.math.array([1 if index < d else -1 for index in range(t)], like=phi)
 
         if qml.math.ndim(phi) == 0:
             product = arg * prefactors
@@ -654,23 +654,30 @@ class PCPhase(Operation):
         phi = params[0]
         k, n = hyperparams["dimension"]
 
-        def _get_base_ops(theta, wire):
-            return PauliX(wire) @ PhaseShift(theta, wire) @ PauliX(wire), PhaseShift(theta, wire)
-
         def _get_op_from_binary_rep(binary_rep, theta, wires):
             if len(binary_rep) == 1:
-                op = _get_base_ops(theta, wire=wires[0])[int(binary_rep)]
+                op = (
+                    PhaseShift(theta, wires[0]) if int(binary_rep)
+                    else PauliX(wires[0]) @ PhaseShift(theta, wires[0]) @ PauliX(wires[0])
+                )
             else:
-                base_op = _get_base_ops(theta, wire=wires[-1])[int(binary_rep[-1])]
+                base_op = (
+                    PhaseShift(theta, wires[-1]) if int(binary_rep[-1])
+                    else PauliX(wires[-1]) @ PhaseShift(theta, wires[-1]) @ PauliX(wires[-1])
+                )
                 op = qml.ctrl(
                     base_op, control=wires[:-1], control_values=[int(i) for i in binary_rep[:-1]]
                 )
             return op
 
         n_log2 = int(np.log2(n))
-        binary_reps = [bin(_k)[2:].zfill(n_log2) for _k in range(k)]
+        positive_binary_reps = [bin(_k)[2:].zfill(n_log2) for _k in range(k)]
+        negative_binary_reps = [bin(_k)[2:].zfill(n_log2) for _k in range(k, n)]
 
-        return [_get_op_from_binary_rep(br, phi, wires=wires) for br in binary_reps]
+        positive_ops = [_get_op_from_binary_rep(br, phi, wires=wires) for br in positive_binary_reps]
+        negative_ops = [_get_op_from_binary_rep(br, -1*phi, wires=wires) for br in negative_binary_reps]
+
+        return positive_ops + negative_ops
 
     def adjoint(self):
         """Computes the adjoint of the operator."""

--- a/pennylane/ops/qubit/parametric_ops_multi_qubit.py
+++ b/pennylane/ops/qubit/parametric_ops_multi_qubit.py
@@ -657,12 +657,14 @@ class PCPhase(Operation):
         def _get_op_from_binary_rep(binary_rep, theta, wires):
             if len(binary_rep) == 1:
                 op = (
-                    PhaseShift(theta, wires[0]) if int(binary_rep)
+                    PhaseShift(theta, wires[0])
+                    if int(binary_rep)
                     else PauliX(wires[0]) @ PhaseShift(theta, wires[0]) @ PauliX(wires[0])
                 )
             else:
                 base_op = (
-                    PhaseShift(theta, wires[-1]) if int(binary_rep[-1])
+                    PhaseShift(theta, wires[-1])
+                    if int(binary_rep[-1])
                     else PauliX(wires[-1]) @ PhaseShift(theta, wires[-1]) @ PauliX(wires[-1])
                 )
                 op = qml.ctrl(
@@ -674,8 +676,12 @@ class PCPhase(Operation):
         positive_binary_reps = [bin(_k)[2:].zfill(n_log2) for _k in range(k)]
         negative_binary_reps = [bin(_k)[2:].zfill(n_log2) for _k in range(k, n)]
 
-        positive_ops = [_get_op_from_binary_rep(br, phi, wires=wires) for br in positive_binary_reps]
-        negative_ops = [_get_op_from_binary_rep(br, -1*phi, wires=wires) for br in negative_binary_reps]
+        positive_ops = [
+            _get_op_from_binary_rep(br, phi, wires=wires) for br in positive_binary_reps
+        ]
+        negative_ops = [
+            _get_op_from_binary_rep(br, -1 * phi, wires=wires) for br in negative_binary_reps
+        ]
 
         return positive_ops + negative_ops
 

--- a/tests/ops/qubit/test_attributes.py
+++ b/tests/ops/qubit/test_attributes.py
@@ -465,7 +465,7 @@ class TestSupportsBroadcasting:
         mat2 = op.compute_matrix(*op.parameters, **op.hyperparameters)
 
         mats = [
-            np.diag([np.exp(1j * phi) if i < dim else 1.0 for i in range(size)])
+            np.diag([np.exp(1j * phi) if i < dim else np.exp(-1j * phi) for i in range(size)])
             for phi in broadcasted_phi
         ]
         expected_mat = np.array(mats)

--- a/tests/ops/qubit/test_parametric_ops.py
+++ b/tests/ops/qubit/test_parametric_ops.py
@@ -171,7 +171,13 @@ class TestOperations:
             return qml.state()
 
         def _get_expected_state(phase, dim, size):
-            return np.array([np.exp(1j * phase) if i < dim else np.exp(-1j * phase) for i in range(size)]) * 1 / 2
+            return (
+                np.array(
+                    [np.exp(1j * phase) if i < dim else np.exp(-1j * phase) for i in range(size)]
+                )
+                * 1
+                / 2
+            )
 
         assert np.allclose(circuit(theta, d), _get_expected_state(theta, d, 4))
 
@@ -1017,7 +1023,9 @@ class TestMatrix:
         mat2 = op.compute_matrix(*op.parameters, **op.hyperparameters)
 
         expected_mat = tf.Variable(
-            np.diag([np.exp(1j * phi) if i < dim else np.exp(-1j * phi) for i in range(2**num_wires)])
+            np.diag(
+                [np.exp(1j * phi) if i < dim else np.exp(-1j * phi) for i in range(2**num_wires)]
+            )
         )
 
         assert np.allclose(mat1, expected_mat)
@@ -1038,7 +1046,9 @@ class TestMatrix:
         mat2 = op.compute_matrix(*op.parameters, **op.hyperparameters)
 
         expected_mat = torch.tensor(
-            np.diag([np.exp(1j * phi) if i < dim else np.exp(-1j * phi) for i in range(2**num_wires)])
+            np.diag(
+                [np.exp(1j * phi) if i < dim else np.exp(-1j * phi) for i in range(2**num_wires)]
+            )
         )
 
         assert np.allclose(mat1, expected_mat)
@@ -1061,7 +1071,9 @@ class TestMatrix:
         mat2 = op.compute_matrix(*op.parameters, **op.hyperparameters)
 
         expected_mat = jnp.diag(
-            jnp.array([jnp.exp(1j * phi) if i < dim else np.exp(-1j * phi) for i in range(2**num_wires)])
+            jnp.array(
+                [jnp.exp(1j * phi) if i < dim else np.exp(-1j * phi) for i in range(2**num_wires)]
+            )
         )
 
         assert np.allclose(mat1, expected_mat)
@@ -2105,13 +2117,17 @@ class TestEigvals:
         # test arbitrary phase shift
         phi = 0.5432
         op = qml.PCPhase(phi, dim=2, wires=[0, 1])
-        expected = np.array([np.exp(1j * phi), np.exp(1j * phi), np.exp(-1j * phi), np.exp(-1j * phi)])
+        expected = np.array(
+            [np.exp(1j * phi), np.exp(1j * phi), np.exp(-1j * phi), np.exp(-1j * phi)]
+        )
         assert np.allclose(op.eigvals(), expected)
 
         # test arbitrary broadcasted phase shift
         phi = np.array([0.5, 0.4, 0.3])
         op = qml.PCPhase(phi, dim=2, wires=[0, 1])
-        expected = np.array([[np.exp(1j * p), np.exp(1j * p), np.exp(-1j * p), np.exp(-1j * p)] for p in phi])
+        expected = np.array(
+            [[np.exp(1j * p), np.exp(1j * p), np.exp(-1j * p), np.exp(-1j * p)] for p in phi]
+        )
         assert np.allclose(op.eigvals(), expected)
 
     def test_crz_eigvals(self, tol):
@@ -2832,9 +2848,7 @@ class TestGrad:
         import tensorflow as tf
 
         dev = qml.device(dev_name, wires=[0, 1])
-        expected_grad = tf.Variable(
-            -4 * npp.cos(phi) * npp.sin(phi)
-        )  # computed by hand
+        expected_grad = tf.Variable(-4 * npp.cos(phi) * npp.sin(phi))  # computed by hand
         phi = tf.Variable(phi)
 
         @qml.qnode(dev, diff_method=diff_method)
@@ -2864,9 +2878,7 @@ class TestGrad:
         import torch
 
         dev = qml.device(dev_name, wires=[0, 1])
-        expected_grad = torch.tensor(
-            -4 * npp.cos(phi) * npp.sin(phi)
-        )  # computed by hand
+        expected_grad = torch.tensor(-4 * npp.cos(phi) * npp.sin(phi))  # computed by hand
         phi = torch.tensor(phi, requires_grad=True)
 
         @qml.qnode(dev, diff_method=diff_method)
@@ -2895,9 +2907,7 @@ class TestGrad:
         import jax.numpy as jnp
 
         dev = qml.device(dev_name, wires=[0, 1])
-        expected_grad = jnp.array(
-            -4 * npp.cos(phi) * npp.sin(phi)
-        )  # computed by hand
+        expected_grad = jnp.array(-4 * npp.cos(phi) * npp.sin(phi))  # computed by hand
         phi = jnp.array(phi)
 
         @qml.qnode(dev, diff_method=diff_method)


### PR DESCRIPTION
**Context:**
PCPhase gates were designed to be primarily used in the QSVT workflow. Swapping to this convention will allow them to be more directly applied to the workflow without having to keep track of additional global phases.

**Description of the Change:**
In the previous implementation of `PCPhase(phi, dim, wires)`, the first `dim` number of entries along the diagonal in the matrix were phase shifted by `e^(i * phi)` while the remaining `2**n - dim` entries of the diagonal were left alone (set to 1). 

This convention is swapped to one in which the remaining `2**n - dim` entries of the diagonal were set to `e^(-i * phi)`. Note, these two conventions only differ by a global phase. 

**Benefits:**
By absorbing the global phase into the representation, we get a cleaner implementation of QSVT which doesn't have to track the global phase as strictly when converting between representations. This convention is also identical when using trained QSP angles which use RZ rotations as their projector controlled phase gates. 
