### PR TITLE
Make QuantumScript.diagonalizing_gates a method; allow device to specify observables to skip

### DIFF
--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -159,7 +159,7 @@ class QubitDevice(Device):
         "Prod",
     }
 
-    observables_to_not_diagonalize = {}
+    observables_to_not_diagonalize = ()
     """Observables whose diagonalizing gates are not used when evaluating a circuit."""
 
     measurement_map = defaultdict(lambda: "")  # e.g. {SampleMP: "sample"}

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -314,7 +314,7 @@ class QubitDevice(Device):
         self.check_validity(circuit.operations, circuit.observables)
 
         # apply all circuit operations
-        self.apply(circuit.operations, rotations=circuit.diagonalizing_gates, **kwargs)
+        self.apply(circuit.operations, rotations=circuit.diagonalizing_gates(), **kwargs)
 
         # generate computational basis samples
         if self.shots is not None:
@@ -370,7 +370,7 @@ class QubitDevice(Device):
         self.check_validity(circuit.operations, circuit.observables)
 
         # apply all circuit operations
-        self.apply(circuit.operations, rotations=circuit.diagonalizing_gates, **kwargs)
+        self.apply(circuit.operations, rotations=circuit.diagonalizing_gates(), **kwargs)
 
         # generate computational basis samples
         if self.shots is not None or circuit.is_sampled:
@@ -1394,7 +1394,7 @@ class QubitDevice(Device):
                 ]
 
                 self.reset()
-                self.apply(circuit.operations, rotations=circuit.diagonalizing_gates + rotations)
+                self.apply(circuit.operations, rotations=circuit.diagonalizing_gates() + rotations)
 
                 outcomes[t] = self.generate_samples()[0][mapped_wires]
 

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -160,7 +160,7 @@ class QubitDevice(Device):
     }
 
     observables_to_not_diagonalize = ()
-    """Observables whose diagonalizing gates are not used when evaluating a circuit."""
+    """Tuple of Observables whose diagonalizing gates are not used when evaluating a circuit."""
 
     measurement_map = defaultdict(lambda: "")  # e.g. {SampleMP: "sample"}
     """Mapping used to override the logic of measurement processes. The dictionary maps a

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -159,6 +159,9 @@ class QubitDevice(Device):
         "Prod",
     }
 
+    observables_to_not_diagonalize = {}
+    """Observables whose diagonalizing gates are not used when evaluating a circuit."""
+
     measurement_map = defaultdict(lambda: "")  # e.g. {SampleMP: "sample"}
     """Mapping used to override the logic of measurement processes. The dictionary maps a
     measurement class to a string containing the name of a device's method that overrides the
@@ -314,7 +317,11 @@ class QubitDevice(Device):
         self.check_validity(circuit.operations, circuit.observables)
 
         # apply all circuit operations
-        self.apply(circuit.operations, rotations=circuit.diagonalizing_gates(), **kwargs)
+        self.apply(
+            circuit.operations,
+            rotations=circuit.diagonalizing_gates(skip=self.observables_to_not_diagonalize),
+            **kwargs,
+        )
 
         # generate computational basis samples
         if self.shots is not None:
@@ -370,7 +377,11 @@ class QubitDevice(Device):
         self.check_validity(circuit.operations, circuit.observables)
 
         # apply all circuit operations
-        self.apply(circuit.operations, rotations=circuit.diagonalizing_gates(), **kwargs)
+        self.apply(
+            circuit.operations,
+            rotations=circuit.diagonalizing_gates(skip=self.observables_to_not_diagonalize),
+            **kwargs,
+        )
 
         # generate computational basis samples
         if self.shots is not None or circuit.is_sampled:

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -173,7 +173,7 @@ class DefaultQubit(QubitDevice):
         "Evolution",
     }
 
-    observables_to_not_diagonalize = {"Sum", "Hamiltonian"}
+    observables_to_not_diagonalize = (qml.ops.Sum, qml.Hamiltonian)  # pylint:disable=no-member
 
     def __init__(
         self, wires, *, r_dtype=np.float64, c_dtype=np.complex128, shots=None, analytic=None

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -173,7 +173,7 @@ class DefaultQubit(QubitDevice):
         "Evolution",
     }
 
-    observables_to_not_diagonalize = (qml.ops.Sum, qml.Hamiltonian)  # pylint:disable=no-member
+    observables_to_not_diagonalize = (qml.Hamiltonian,)
 
     def __init__(
         self, wires, *, r_dtype=np.float64, c_dtype=np.complex128, shots=None, analytic=None

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -173,6 +173,8 @@ class DefaultQubit(QubitDevice):
         "Evolution",
     }
 
+    observables_to_not_diagonalize = {"Sum", "Hamiltonian"}
+
     def __init__(
         self, wires, *, r_dtype=np.float64, c_dtype=np.complex128, shots=None, analytic=None
     ):

--- a/pennylane/devices/null_qubit.py
+++ b/pennylane/devices/null_qubit.py
@@ -280,7 +280,7 @@ class NullQubit(QubitDevice):
         return self._operation_calls
 
     def execute(self, circuit, **kwargs):
-        self.apply(circuit.operations, rotations=circuit.diagonalizing_gates, **kwargs)
+        self.apply(circuit.operations, rotations=circuit.diagonalizing_gates(), **kwargs)
 
         if self.tracker.active:
             self.tracker.update(executions=1, shots=self._shots)

--- a/pennylane/measurements/classical_shadow.py
+++ b/pennylane/measurements/classical_shadow.py
@@ -314,7 +314,7 @@ class ClassicalShadowMP(MeasurementTransform):
                 ]
 
                 device.reset()
-                device.apply(tape.operations, rotations=tape.diagonalizing_gates + rotations)
+                device.apply(tape.operations, rotations=tape.diagonalizing_gates() + rotations)
 
                 outcomes[t] = device.generate_samples()[0][mapped_wires]
 

--- a/pennylane/tape/qscript.py
+++ b/pennylane/tape/qscript.py
@@ -348,7 +348,7 @@ class QuantumScript:
             List[~.Operation]: the operations that diagonalize the observables
         """
         rotation_gates = []
-        obs_to_skip = skip or set()
+        obs_to_skip = skip or ()
 
         with qml.queuing.QueuingManager.stop_recording():
             for observable in self.observables:

--- a/pennylane/tape/qscript.py
+++ b/pennylane/tape/qscript.py
@@ -337,7 +337,6 @@ class QuantumScript:
         """The (inferred) output dimension of the quantum script."""
         return self._output_dim
 
-    @property
     def diagonalizing_gates(self):
         """Returns the gates that diagonalize the measured wires such that they
         are in the eigenbasis of the circuit observables.
@@ -1188,7 +1187,7 @@ class QuantumScript:
 
             self._specs["num_operations"] = len(self.operations)
             self._specs["num_observables"] = len(self.observables)
-            self._specs["num_diagonalizing_gates"] = len(self.diagonalizing_gates)
+            self._specs["num_diagonalizing_gates"] = len(self.diagonalizing_gates())
             self._specs["num_used_wires"] = self.num_wires
             self._specs["depth"] = self.graph.get_depth()
             self._specs["num_trainable_params"] = self.num_params
@@ -1271,7 +1270,7 @@ class QuantumScript:
         if rotations:
             # if requested, append diagonalizing gates corresponding
             # to circuit observables
-            operations += self.diagonalizing_gates
+            operations += self.diagonalizing_gates()
 
         # decompose the queue
         # pylint: disable=no-member

--- a/pennylane/tape/qscript.py
+++ b/pennylane/tape/qscript.py
@@ -337,17 +337,22 @@ class QuantumScript:
         """The (inferred) output dimension of the quantum script."""
         return self._output_dim
 
-    def diagonalizing_gates(self):
+    def diagonalizing_gates(self, skip=None):
         """Returns the gates that diagonalize the measured wires such that they
         are in the eigenbasis of the circuit observables.
 
+        Args:
+            skip (Optional[set[str]]): The names of observables that do not need diagonalizing
         Returns:
             List[~.Operation]: the operations that diagonalize the observables
         """
         rotation_gates = []
+        obs_to_skip = skip or set()
 
         with qml.queuing.QueuingManager.stop_recording():
             for observable in self.observables:
+                if observable.name in obs_to_skip:
+                    continue
                 # some observables do not have diagonalizing gates,
                 # in which case we just don't append any
                 with contextlib.suppress(qml.operation.DiagGatesUndefinedError):

--- a/pennylane/tape/qscript.py
+++ b/pennylane/tape/qscript.py
@@ -342,7 +342,8 @@ class QuantumScript:
         are in the eigenbasis of the circuit observables.
 
         Args:
-            skip (Optional[set[str]]): The names of observables that do not need diagonalizing
+            skip (Optional[tuple[type]]): The types of observables that do not need diagonalizing
+
         Returns:
             List[~.Operation]: the operations that diagonalize the observables
         """
@@ -351,7 +352,7 @@ class QuantumScript:
 
         with qml.queuing.QueuingManager.stop_recording():
             for observable in self.observables:
-                if observable.name in obs_to_skip:
+                if isinstance(observable, obs_to_skip):
                     continue
                 # some observables do not have diagonalizing gates,
                 # in which case we just don't append any

--- a/tests/circuit_graph/test_qasm.py
+++ b/tests/circuit_graph/test_qasm.py
@@ -249,7 +249,7 @@ class TestToQasmUnitTests:
 
         assert res == expected
 
-        ops2 = circuit.operations + circuit.diagonalizing_gates
+        ops2 = circuit.operations + circuit.diagonalizing_gates()
 
         with qml.queuing.AnnotatedQueue() as q2:
             [o.queue() for o in ops2]

--- a/tests/tape/test_qscript.py
+++ b/tests/tape/test_qscript.py
@@ -982,7 +982,7 @@ class TestFromQueue:
         qscript = QuantumScript(ops=[qml.PauliZ(0)], measurements=[qml.expval(qml.PauliX(0))])
 
         with qml.queuing.AnnotatedQueue() as q:
-            diag_ops = qscript.diagonalizing_gates
+            diag_ops = qscript.diagonalizing_gates()
 
         assert len(diag_ops) == 1
         # Hadamard is the diagonalizing gate for PauliX

--- a/tests/tape/test_tape.py
+++ b/tests/tape/test_tape.py
@@ -185,7 +185,7 @@ class TestConstruction:
         obs_rotations = [o.diagonalizing_gates() for o in obs]
         obs_rotations = [item for sublist in obs_rotations for item in sublist]
 
-        for o1, o2 in zip(tape.diagonalizing_gates, obs_rotations):
+        for o1, o2 in zip(tape.diagonalizing_gates(), obs_rotations):
             assert isinstance(o1, o2.__class__)
             assert o1.wires == o2.wires
 


### PR DESCRIPTION
🚨 disclaimer 🚨 : *This feels like a fairly significant change, I'm happy to move completely away from this (see alternative in next section) if it's not what we want.*

**My motivation for this approach**
This do-I-diagonalize decision seems like something that needs to be made by the device. Currently, [we do it](https://github.com/PennyLaneAI/pennylane/blob/b583b174079d367211c8e8d103404f2e3cfeba1b/pennylane/_qubit_device.py#L373) when applying operations: `self.apply(circuit.operations, rotations=circuit.diagonalizing_gates, **kwargs)`, with `self` being the device. Because `diagonalizing_gates` is a _property_ of the circuit (which is de-coupled from the device), it can't know anything about the device requesting them. This change will allow such knowledge. Plus, it is a little confusing that it's a property while `Operator.diagonalizing_gates` is a method, but that is minor in the big-picture here (and makes this a breaking change!).

Alternative: `QubitDevice` can implement its own `diagonalizing_gates(circuit: QuantumScript)` method, putting logic in there.

**Context:**
See the discussion in [this PR comment](https://github.com/PennyLaneAI/pennylane-lightning/pull/424#issuecomment-1479686782). Basically, sometimes we compute the diagonalizing gates for an observable despite not needing them.

**Description of the Change:**
1. Make `QuantumScript.diagonalizing_gates` a method instead of a property
2. Update `QuantumScript.diagonalizing_gates` to accept an optional `skip` attribute, which is a list of observable types that should not have their diagonalizing gates computed
3. Set `observables_to_not_diagonalize` to be an empty tuple by default in `QubitDevice`, set it to be `(qml.Hamiltonian,)` for default.qubit.
4. In `QubitDevice.execute` (and `_execute_new`), pass the above-defined tuple to `circuit.diagonalizing_gates` as the skip value.

**Benefits:**
1. Unnecessary computation can be avoided
2. We will be able to add `Sum` to this list for Lightning, giving a massive speedup

**Possible Drawbacks:**
1. This is a breaking change for the `QuantumScript` API
2. Yet another property defined on a Device class
3. Unsure of this, but I think we only want to skip in certain circumstances, eg. when the measurement containing the observable is an expval. Would it be bad to exclude these rotations for other measurement processes?

**Related GitHub Issues:**
PennyLaneAI/pennylane-lightning#424

TODO: add tests