### PR TITLE
give flaky test more shots; mark slow test as such; linting

### DIFF
--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -552,80 +552,80 @@ class DefaultQubit(QubitDevice):
         # intercept other Hamiltonians
         # TODO: Ideally, this logic should not live in the Device, but be moved
         # to a component that can be re-used by devices as needed.
-        if observable.name in ("Hamiltonian", "SparseHamiltonian"):
-            assert self.shots is None, f"{observable.name} must be used with shots=None"
+        if observable.name not in ("Hamiltonian", "SparseHamiltonian"):
+            return super().expval(observable, shot_range=shot_range, bin_size=bin_size)
 
-            self.map_wires(observable.wires)
-            backprop_mode = (
-                not isinstance(self.state, np.ndarray)
-                or any(not isinstance(d, (float, np.ndarray)) for d in observable.data)
-            ) and observable.name == "Hamiltonian"
+        assert self.shots is None, f"{observable.name} must be used with shots=None"
 
-            if backprop_mode:
-                # TODO[dwierichs]: This branch is not adapted to broadcasting yet
-                if self._ndim(self.state) == 2:
-                    raise NotImplementedError(
-                        "Expectation values of Hamiltonians for interface!=None are "
-                        "not supported together with parameter broadcasting yet"
-                    )
-                # We must compute the expectation value assuming that the Hamiltonian
-                # coefficients *and* the quantum states are tensor objects.
+        self.map_wires(observable.wires)
+        backprop_mode = (
+            not isinstance(self.state, np.ndarray)
+            or any(not isinstance(d, (float, np.ndarray)) for d in observable.data)
+        ) and observable.name == "Hamiltonian"
 
-                # Compute  <psi| H |psi> via sum_i coeff_i * <psi| PauliWord |psi> using a sparse
-                # representation of the Pauliword
-                res = qml.math.cast(qml.math.convert_like(0.0, observable.data), dtype=complex)
-                interface = qml.math.get_interface(self.state)
+        if backprop_mode:
+            # TODO[dwierichs]: This branch is not adapted to broadcasting yet
+            if self._ndim(self.state) == 2:
+                raise NotImplementedError(
+                    "Expectation values of Hamiltonians for interface!=None are "
+                    "not supported together with parameter broadcasting yet"
+                )
+            # We must compute the expectation value assuming that the Hamiltonian
+            # coefficients *and* the quantum states are tensor objects.
 
-                # Note: it is important that we use the Hamiltonian's data and not the coeffs
-                # attribute. This is because the .data attribute may be 'unwrapped' as required by
-                # the interfaces, whereas the .coeff attribute will always be the same input dtype
-                # that the user provided.
-                for op, coeff in zip(observable.ops, observable.data):
-                    # extract a scipy.sparse.coo_matrix representation of this Pauli word
-                    coo = qml.operation.Tensor(op).sparse_matrix(wires=self.wires, format="coo")
-                    Hmat = qml.math.cast(qml.math.convert_like(coo.data, self.state), self.C_DTYPE)
+            # Compute  <psi| H |psi> via sum_i coeff_i * <psi| PauliWord |psi> using a sparse
+            # representation of the Pauliword
+            res = qml.math.cast(qml.math.convert_like(0.0, observable.data), dtype=complex)
+            interface = qml.math.get_interface(self.state)
 
-                    product = (
-                        self._gather(self._conj(self.state), coo.row)
-                        * Hmat
-                        * self._gather(self.state, coo.col)
-                    )
-                    c = qml.math.convert_like(coeff, product)
+            # Note: it is important that we use the Hamiltonian's data and not the coeffs
+            # attribute. This is because the .data attribute may be 'unwrapped' as required by
+            # the interfaces, whereas the .coeff attribute will always be the same input dtype
+            # that the user provided.
+            for op, coeff in zip(observable.ops, observable.data):
+                # extract a scipy.sparse.coo_matrix representation of this Pauli word
+                coo = qml.operation.Tensor(op).sparse_matrix(wires=self.wires, format="coo")
+                Hmat = qml.math.cast(qml.math.convert_like(coo.data, self.state), self.C_DTYPE)
 
-                    if interface == "tensorflow":
-                        c = qml.math.cast(c, "complex128")
+                product = (
+                    self._gather(self._conj(self.state), coo.row)
+                    * Hmat
+                    * self._gather(self.state, coo.col)
+                )
+                c = qml.math.convert_like(coeff, product)
 
-                    res = qml.math.convert_like(res, product) + qml.math.sum(c * product)
+                if interface == "tensorflow":
+                    c = qml.math.cast(c, "complex128")
 
+                res = qml.math.convert_like(res, product) + qml.math.sum(c * product)
+
+        else:
+            # Coefficients and the state are not trainable, we can be more
+            # efficient in how we compute the Hamiltonian sparse matrix.
+            if observable.name in {"Hamiltonian", "SparseHamiltonian"}:
+                Hmat = observable.sparse_matrix(wire_order=self.wires)
+
+            state = qml.math.toarray(self.state)
+            if self._ndim(state) == 2:
+                res = qml.math.array(
+                    [
+                        csr_matrix.dot(
+                            csr_matrix(self._conj(_state)),
+                            csr_matrix.dot(Hmat, csr_matrix(_state[..., None])),
+                        ).toarray()[0]
+                        for _state in state
+                    ]
+                )
             else:
-                # Coefficients and the state are not trainable, we can be more
-                # efficient in how we compute the Hamiltonian sparse matrix.
-                if observable.name in {"Hamiltonian", "SparseHamiltonian"}:
-                    Hmat = observable.sparse_matrix(wire_order=self.wires)
+                res = csr_matrix.dot(
+                    csr_matrix(self._conj(state)),
+                    csr_matrix.dot(Hmat, csr_matrix(state[..., None])),
+                ).toarray()[0]
 
-                state = qml.math.toarray(self.state)
-                if self._ndim(state) == 2:
-                    res = qml.math.array(
-                        [
-                            csr_matrix.dot(
-                                csr_matrix(self._conj(_state)),
-                                csr_matrix.dot(Hmat, csr_matrix(_state[..., None])),
-                            ).toarray()[0]
-                            for _state in state
-                        ]
-                    )
-                else:
-                    res = csr_matrix.dot(
-                        csr_matrix(self._conj(state)),
-                        csr_matrix.dot(Hmat, csr_matrix(state[..., None])),
-                    ).toarray()[0]
+        if observable.name == "Hamiltonian":
+            res = qml.math.squeeze(res)
 
-            if observable.name == "Hamiltonian":
-                res = qml.math.squeeze(res)
-
-            return self._real(res)
-
-        return super().expval(observable, shot_range=shot_range, bin_size=bin_size)
+        return self._real(res)
 
     def _get_unitary_matrix(self, unitary):  # pylint: disable=no-self-use
         """Return the matrix representing a unitary operation.

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -602,8 +602,7 @@ class DefaultQubit(QubitDevice):
         else:
             # Coefficients and the state are not trainable, we can be more
             # efficient in how we compute the Hamiltonian sparse matrix.
-            if observable.name in {"Hamiltonian", "SparseHamiltonian"}:
-                Hmat = observable.sparse_matrix(wire_order=self.wires)
+            Hmat = observable.sparse_matrix(wire_order=self.wires)
 
             state = qml.math.toarray(self.state)
             if self._ndim(state) == 2:

--- a/pennylane/ops/qubit/parametric_ops_multi_qubit.py
+++ b/pennylane/ops/qubit/parametric_ops_multi_qubit.py
@@ -265,8 +265,8 @@ class PauliRot(Operation):
 
         if not PauliRot._check_pauli_word(pauli_word):
             raise ValueError(
-                f'The given Pauli word "{pauli_word}" contains characters that are not allowed.'
-                " Allowed characters are I, X, Y and Z"
+                f'The given Pauli word "{pauli_word}" contains characters that are not allowed. '
+                "Allowed characters are I, X, Y and Z"
             )
 
         num_wires = 1 if isinstance(wires, int) else len(wires)
@@ -351,8 +351,8 @@ class PauliRot(Operation):
         """
         if not PauliRot._check_pauli_word(pauli_word):
             raise ValueError(
-                f'The given Pauli word "{pauli_word}" contains characters that are not allowed.'
-                " Allowed characters are I, X, Y and Z"
+                f'The given Pauli word "{pauli_word}" contains characters that are not allowed. '
+                "Allowed characters are I, X, Y and Z"
             )
 
         interface = qml.math.get_interface(theta)

--- a/tests/devices/qubit/test_sampling.py
+++ b/tests/devices/qubit/test_sampling.py
@@ -80,7 +80,7 @@ def test_sample_state_custom_rng():
 def test_approximate_probs_from_samples(init_state):
     """Tests that the generated samples are approximately as expected."""
     n = 4
-    shots = 10000
+    shots = 20000
     state = init_state(n)
 
     flat_state = state.flatten()
@@ -101,6 +101,7 @@ def test_entangled_qubit_samples_always_match():
     assert any(samples[:, 0])  # ...and some are |11>!
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("num_wires", [13, 14, 15, 16])
 def test_sample_state_many_wires(num_wires):
     """Tests that sample_state works as expected with many wires, and with re-ordering."""


### PR DESCRIPTION
**Context:**
The first sampling test would occasionally be off by a bit and fail, so I figured doubling the shots wouldn't hurt. The second one is just slow.

**Description of the Change:**
- Increase the number of shots in a test to reduce intermittent failures
- Mark a slow test as slow to help CI (it takes about 12 seconds)
- Reverse the indentation in DefaultQubit.expval because it was bugging me
- Re-do a whitespace fix that was accidentally un-done while splitting parametric_ops.py

**Benefits:**
- The test suite is better
- The code looks cleaner/more consistent

**Possible Drawbacks:**
N/A