### PR TITLE
[WIP] Move no-jax-warning in ParametrizedEvolution

### DIFF
--- a/pennylane/pulse/parametrized_evolution.py
+++ b/pennylane/pulse/parametrized_evolution.py
@@ -263,11 +263,6 @@ class ParametrizedEvolution(Operation):
         id=None,
         **odeint_kwargs
     ):
-        if not has_jax:
-            raise ImportError(
-                "Module jax is required for the ``ParametrizedEvolution`` class. "
-                "You can install jax via: pip install jax"
-            )
         if not all(op.has_matrix or isinstance(op, qml.Hamiltonian) for op in H.ops):
             raise ValueError(
                 "All operators inside the parametrized hamiltonian must have a matrix defined."
@@ -283,6 +278,11 @@ class ParametrizedEvolution(Operation):
         super().__init__(*params, wires=H.wires, do_queue=do_queue, id=id)
 
     def __call__(self, params, t, **odeint_kwargs):
+        if not has_jax:
+            raise ImportError(
+                "Module jax is required for the ``ParametrizedEvolution`` class. "
+                "You can install jax via: pip install jax"
+            )
         # Need to cast all elements inside params to `jnp.arrays` to make sure they are not cast
         # to `np.arrays` inside `Operator.__init__`
         params = [jnp.array(p) for p in params]
@@ -301,6 +301,11 @@ class ParametrizedEvolution(Operation):
 
     # pylint: disable=import-outside-toplevel
     def matrix(self, wire_order=None):
+        if not has_jax:
+            raise ImportError(
+                "Module jax is required for the ``ParametrizedEvolution`` class. "
+                "You can install jax via: pip install jax"
+            )
         if not self.has_matrix:
             raise ValueError(
                 "The parameters and the time window are required to compute the matrix. "

--- a/tests/pulse/test_parametrized_evolution.py
+++ b/tests/pulse/test_parametrized_evolution.py
@@ -16,7 +16,6 @@ Unit tests for the ParametrizedEvolution class
 """
 # pylint: disable=unused-argument,too-few-public-methods,import-outside-toplevel
 from functools import reduce
-import importlib
 import numpy as np
 import pytest
 import pennylane as qml
@@ -66,31 +65,15 @@ def time_dependent_hamiltonian():
     return ParametrizedHamiltonian(coeffs, ops)
 
 
-@pytest.mark.skipif(
-    importlib.util.find_spec("jax") is not None, reason="should only pass when jax is not installed"
-)
 def test_error_raised_on_call_if_jax_not_installed():
     """Test that an error is raised if an ``Evolve`` operator is instantiated without jax installed"""
-    # try:
-    #     import jax  # pylint: disable=unused-import
-    #
-    #     pytest.skip()
-    # except ModuleNotFoundError:
     with pytest.raises(ImportError, match="Module jax is required"):
         ParametrizedEvolution(H=ParametrizedHamiltonian([1], [qml.PauliX(0)]))([], 2)
 
 
-@pytest.mark.skipif(
-    importlib.util.find_spec("jax") is not None, reason="should only pass when jax is not installed"
-)
 def test_error_raised_for_matrix_method_if_jax_not_installed():
     """Test that an error is raised if an ``Evolve`` operator is instantiated without jax installed"""
-    # try:
-    #     import jax  # pylint: disable=unused-import
-    #
-    #     pytest.skip()
-    # except ModuleNotFoundError:
-    with pytest.raises(ImportError, match="Sanity check"):
+    with pytest.raises(ImportError, match="Module jax is required"):
         ParametrizedEvolution(
             H=ParametrizedHamiltonian([1], [qml.PauliX(0)]), params=[], t=2
         ).matrix()

--- a/tests/pulse/test_parametrized_evolution.py
+++ b/tests/pulse/test_parametrized_evolution.py
@@ -65,7 +65,7 @@ def time_dependent_hamiltonian():
     return ParametrizedHamiltonian(coeffs, ops)
 
 
-def test_error_raised_if_jax_not_installed():
+def test_error_raised_on_call_if_jax_not_installed():
     """Test that an error is raised if an ``Evolve`` operator is instantiated without jax installed"""
     try:
         import jax  # pylint: disable=unused-import
@@ -73,7 +73,20 @@ def test_error_raised_if_jax_not_installed():
         pytest.skip()
     except ImportError:
         with pytest.raises(ImportError, match="Module jax is required"):
-            ParametrizedEvolution(H=ParametrizedHamiltonian([1], [qml.PauliX(0)]))
+            ParametrizedEvolution(H=ParametrizedHamiltonian([1], [qml.PauliX(0)]))([], 2)
+
+
+def test_error_raised_for_matrix_method_if_jax_not_installed():
+    """Test that an error is raised if an ``Evolve`` operator is instantiated without jax installed"""
+    try:
+        import jax  # pylint: disable=unused-import
+
+        pytest.skip()
+    except ImportError:
+        with pytest.raises(ImportError, match="Module jax is required"):
+            ParametrizedEvolution(
+                H=ParametrizedHamiltonian([1], [qml.PauliX(0)]), params=[], t=2
+            ).matrix()
 
 
 @pytest.mark.jax

--- a/tests/pulse/test_parametrized_evolution.py
+++ b/tests/pulse/test_parametrized_evolution.py
@@ -83,7 +83,7 @@ def test_error_raised_for_matrix_method_if_jax_not_installed():
 
         pytest.skip()
     except ModuleNotFoundError:
-        with pytest.raises(ImportError, match="Module jax is required"):
+        with pytest.raises(ImportError, match="Sanity check"):
             ParametrizedEvolution(
                 H=ParametrizedHamiltonian([1], [qml.PauliX(0)]), params=[], t=2
             ).matrix()

--- a/tests/pulse/test_parametrized_evolution.py
+++ b/tests/pulse/test_parametrized_evolution.py
@@ -16,6 +16,7 @@ Unit tests for the ParametrizedEvolution class
 """
 # pylint: disable=unused-argument,too-few-public-methods,import-outside-toplevel
 from functools import reduce
+import importlib
 import numpy as np
 import pytest
 import pennylane as qml
@@ -65,28 +66,30 @@ def time_dependent_hamiltonian():
     return ParametrizedHamiltonian(coeffs, ops)
 
 
+@pytest.mark.skipif(importlib.util.find_spec("jax") is not None)
 def test_error_raised_on_call_if_jax_not_installed():
     """Test that an error is raised if an ``Evolve`` operator is instantiated without jax installed"""
-    try:
-        import jax  # pylint: disable=unused-import
+    # try:
+    #     import jax  # pylint: disable=unused-import
+    #
+    #     pytest.skip()
+    # except ModuleNotFoundError:
+    with pytest.raises(ImportError, match="Module jax is required"):
+        ParametrizedEvolution(H=ParametrizedHamiltonian([1], [qml.PauliX(0)]))([], 2)
 
-        pytest.skip()
-    except ModuleNotFoundError:
-        with pytest.raises(ImportError, match="Module jax is required"):
-            ParametrizedEvolution(H=ParametrizedHamiltonian([1], [qml.PauliX(0)]))([], 2)
 
-
+@pytest.mark.skipif(importlib.util.find_spec("jax") is not None)
 def test_error_raised_for_matrix_method_if_jax_not_installed():
     """Test that an error is raised if an ``Evolve`` operator is instantiated without jax installed"""
-    try:
-        import jax  # pylint: disable=unused-import
-
-        pytest.skip()
-    except ModuleNotFoundError:
-        with pytest.raises(ImportError, match="Sanity check"):
-            ParametrizedEvolution(
-                H=ParametrizedHamiltonian([1], [qml.PauliX(0)]), params=[], t=2
-            ).matrix()
+    # try:
+    #     import jax  # pylint: disable=unused-import
+    #
+    #     pytest.skip()
+    # except ModuleNotFoundError:
+    with pytest.raises(ImportError, match="Sanity check"):
+        ParametrizedEvolution(
+            H=ParametrizedHamiltonian([1], [qml.PauliX(0)]), params=[], t=2
+        ).matrix()
 
 
 @pytest.mark.jax

--- a/tests/pulse/test_parametrized_evolution.py
+++ b/tests/pulse/test_parametrized_evolution.py
@@ -66,7 +66,9 @@ def time_dependent_hamiltonian():
     return ParametrizedHamiltonian(coeffs, ops)
 
 
-@pytest.mark.skipif(importlib.util.find_spec("jax") is not None)
+@pytest.mark.skipif(
+    importlib.util.find_spec("jax") is not None, reason="should only pass when jax is not installed"
+)
 def test_error_raised_on_call_if_jax_not_installed():
     """Test that an error is raised if an ``Evolve`` operator is instantiated without jax installed"""
     # try:
@@ -78,7 +80,9 @@ def test_error_raised_on_call_if_jax_not_installed():
         ParametrizedEvolution(H=ParametrizedHamiltonian([1], [qml.PauliX(0)]))([], 2)
 
 
-@pytest.mark.skipif(importlib.util.find_spec("jax") is not None)
+@pytest.mark.skipif(
+    importlib.util.find_spec("jax") is not None, reason="should only pass when jax is not installed"
+)
 def test_error_raised_for_matrix_method_if_jax_not_installed():
     """Test that an error is raised if an ``Evolve`` operator is instantiated without jax installed"""
     # try:

--- a/tests/pulse/test_parametrized_evolution.py
+++ b/tests/pulse/test_parametrized_evolution.py
@@ -71,7 +71,7 @@ def test_error_raised_on_call_if_jax_not_installed():
         import jax  # pylint: disable=unused-import
 
         pytest.skip()
-    except ImportError:
+    except ModuleNotFoundError:
         with pytest.raises(ImportError, match="Module jax is required"):
             ParametrizedEvolution(H=ParametrizedHamiltonian([1], [qml.PauliX(0)]))([], 2)
 
@@ -82,7 +82,7 @@ def test_error_raised_for_matrix_method_if_jax_not_installed():
         import jax  # pylint: disable=unused-import
 
         pytest.skip()
-    except ImportError:
+    except ModuleNotFoundError:
         with pytest.raises(ImportError, match="Module jax is required"):
             ParametrizedEvolution(
                 H=ParametrizedHamiltonian([1], [qml.PauliX(0)]), params=[], t=2


### PR DESCRIPTION
For hardware, we dont need jax as a requirement for `ParametrizedEvolution`

Works in principle but requires the user to use `qml.pulse.ParametrizedEvolution(H, params, t)` instead of `qml.evolve(H)(params, t)`