### PR TITLE
Fixrectdoc

### DIFF
--- a/pennylane/pulse/convenience_functions.py
+++ b/pennylane/pulse/convenience_functions.py
@@ -91,7 +91,10 @@ def rect(x: Union[float, Callable], windows: Union[Tuple[float], List[Tuple[floa
         ``windows``, and otherwise returns 0.
 
     .. note::
-        If ``x`` is a function, it must accept two arguments: the trainable parameters and time.
+        If ``x`` is a function, it must accept two arguments: the trainable parameters and time. The primary use
+        of ``rect`` is for numerical simulations via :class:`ParametrizedEvolution`, which assumes ``t`` to be a single scalar
+        argument. If you need to efficiently compute multiple times, you need to broadcast over ``t`` via 
+        `jax.vmap <https://jax.readthedocs.io/en/latest/_autosummary/jax.vmap.html>`_ (see examples below).
 
     **Example**
 

--- a/pennylane/pulse/convenience_functions.py
+++ b/pennylane/pulse/convenience_functions.py
@@ -123,7 +123,10 @@ def rect(x: Union[float, Callable], windows: Union[Tuple[float], List[Tuple[floa
             :width: 60%
             :target: javascript:void(0);
 
-    This can be used to create a :class:`~.ParametrizedHamiltonian` in the following way:
+    Note that in order to efficiently create ``y2``, we broadcasted ``windowed_f`` over the
+    time argument using `jax.vmap <https://jax.readthedocs.io/en/latest/_autosummary/jax.vmap.html>`_.
+
+    ``rect`` can be used to create a :class:`~.ParametrizedHamiltonian` in the following way:
 
     >>> H = qml.pulse.rect(jnp.polyval, windows=[(1, 7)]) * qml.PauliX(0)
 

--- a/pennylane/pulse/convenience_functions.py
+++ b/pennylane/pulse/convenience_functions.py
@@ -107,8 +107,10 @@ def rect(x: Union[float, Callable], windows: Union[Tuple[float], List[Tuple[floa
         time = jnp.linspace(0, 10, 1000)
         windows = [(1, 7)]
 
+        windowed_f = qml.pulse.rect(f, windows=windows)
+
         y1 = f(p, time)
-        y2 = [qml.pulse.rect(f, windows=windows)(p, t) for t in time]
+        y2 = jax.vmap(windowed_f, (None, 0))(p, time)
 
         plt.plot(time, y1, label=f"polyval(p={p}, t)")
         plt.plot(time, y2, label=f"rect(polyval, windows={windows})(p={p}, t)")


### PR DESCRIPTION
There can be some unexpected behavior using `pulse.rect` when one wants to compute multiple time values. This is not better explained in the docs.

Ideally we would want this behavior by default, or at least not have the broadcasting work but give wrong results.

**Expected behavior**

```
def amp0(p, t):
    f = p[0] * jnp.exp(-(t-p[1])**2/(2*p[2]**2))
    return qml.pulse.rect(f, windows=[0.1, 1.7])(p, t)

amp = jax.vmap(amp0, (None, 0))

p = [2.5, 0.9, 0.3]
t = jnp.linspace(0, 0.2 , 100)
plt.plot(t, amp(p, t),"x-")
plt.show()
```
![image](https://user-images.githubusercontent.com/43949391/227506890-390935d3-fda1-4550-8e00-0870eab527c4.png)


**Actual behavior**

```python3
def amp(p, t):
    f = p[0] * jnp.exp(-(t-p[1])**2/(2*p[2]**2))
    return qml.pulse.rect(f, windows=[0.1, 1.7])(p, t)

p = [2.5, 0.9, 0.3]
t = jnp.linspace(0, 0.2 , 100)
print(amp(p, 0.05)) #(yields 0)
plt.plot(t, amp(p, t),"x-")
plt.show()
```
![image](https://user-images.githubusercontent.com/43949391/227498408-47ec0047-6c64-4855-8b29-c0eb9db87248.png)
