### PR TITLE
update jax par-ham test

### DIFF
--- a/pennylane/devices/default_qubit_jax.py
+++ b/pennylane/devices/default_qubit_jax.py
@@ -196,6 +196,7 @@ class DefaultQubitJax(DefaultQubit):
         del self._apply_ops["PauliY"]
         del self._apply_ops["Hadamard"]
         del self._apply_ops["CZ"]
+        self.operations = self.operations.copy()
         self.operations.add("ParametrizedEvolution")
         self._prng_key = prng_key
 

--- a/tests/devices/test_default_qubit.py
+++ b/tests/devices/test_default_qubit.py
@@ -2079,6 +2079,13 @@ class TestApplyOps:
             return qml.expval(qml.PauliZ(0))
 
         with pytest.raises(
+            DeviceError,
+            match="Gate ParametrizedEvolution not supported on device default.qubit.autograd",
+        ):
+            circuit()
+
+        self.dev.operations.add("ParametrizedEvolution")
+        with pytest.raises(
             NotImplementedError,
             match="The device default.qubit.autograd cannot execute a ParametrizedEvolution operation",
         ):

--- a/tests/devices/test_default_qubit.py
+++ b/tests/devices/test_default_qubit.py
@@ -2066,15 +2066,14 @@ class TestApplyOps:
     @pytest.mark.jax
     def test_apply_parametrized_evolution_raises_error(self):
         """Test that applying a ParametrizedEvolution raises an error."""
-        ev_dev = qml.device("default.qubit", wires=1)
         param_ev = qml.evolve(ParametrizedHamiltonian([1], [qml.PauliX(0)]))
         with pytest.raises(
             NotImplementedError,
             match="The device default.qubit cannot execute a ParametrizedEvolution operation",
         ):
-            ev_dev._apply_parametrized_evolution(state=self.state, operation=param_ev)
+            self.dev._apply_parametrized_evolution(state=self.state, operation=param_ev)
 
-        @qml.qnode(ev_dev)
+        @qml.qnode(self.dev)
         def circuit():
             qml.apply(param_ev)
             return qml.expval(qml.PauliZ(0))
@@ -2085,7 +2084,7 @@ class TestApplyOps:
         ):
             circuit()
 
-        ev_dev.operations.add("ParametrizedEvolution")
+        self.dev.operations.add("ParametrizedEvolution")
         with pytest.raises(
             NotImplementedError,
             match="The device default.qubit.autograd cannot execute a ParametrizedEvolution operation",

--- a/tests/devices/test_default_qubit.py
+++ b/tests/devices/test_default_qubit.py
@@ -2066,14 +2066,15 @@ class TestApplyOps:
     @pytest.mark.jax
     def test_apply_parametrized_evolution_raises_error(self):
         """Test that applying a ParametrizedEvolution raises an error."""
+        ev_dev = qml.device("default.qubit", wires=1)
         param_ev = qml.evolve(ParametrizedHamiltonian([1], [qml.PauliX(0)]))
         with pytest.raises(
             NotImplementedError,
             match="The device default.qubit cannot execute a ParametrizedEvolution operation",
         ):
-            self.dev._apply_parametrized_evolution(state=self.state, operation=param_ev)
+            ev_dev._apply_parametrized_evolution(state=self.state, operation=param_ev)
 
-        @qml.qnode(self.dev)
+        @qml.qnode(ev_dev)
         def circuit():
             qml.apply(param_ev)
             return qml.expval(qml.PauliZ(0))
@@ -2084,7 +2085,7 @@ class TestApplyOps:
         ):
             circuit()
 
-        self.dev.operations.add("ParametrizedEvolution")
+        ev_dev.operations.add("ParametrizedEvolution")
         with pytest.raises(
             NotImplementedError,
             match="The device default.qubit.autograd cannot execute a ParametrizedEvolution operation",


### PR DESCRIPTION
**Context:**
`default.qubit.jax` added to `self.operations` in its init method, but it didn't copy it first. So, it updated the class-level definition, `DefaultQubit.operations`! This meant that other devices (including `default.qubit.autograd`) also thought they supported `ParametrizedEvolution` when they in fact did not.

This test was failing locally when run on its own, but if you run it with some other test that involves jax locally, then it passes. Very strange.

**Description of the Change:**
Update the test to check that it fails in the validation stage when the operation is not supported (the default). Then add `ParametrizedEvolution` to the list of supported operations on the device, and see that applying the operation fails as the test was checking before (with operator validation passing).

**Benefits:**
Non-jax `default.qubit` devices no longer think they support `ParametrizedEvolution`, allowing them to fail in the validation stage if one is present (like they're supposed to).

**Possible Drawbacks:**
N/A. Although, I feel like the last part of the test isn't super necessary because users would never manually add an operation to a device's op list.

**Related GitHub Issues:**
Found this while trying to split up tests in #3964. That PR literally changed nothing except for the `tests.yml` config file, and boom. Test failed.