### PR TITLE
Add improved decomposition for `qml.SingleExcitation`

### DIFF
--- a/pennylane/ops/qubit/qchem_ops.py
+++ b/pennylane/ops/qubit/qchem_ops.py
@@ -227,9 +227,22 @@ class SingleExcitation(Operation):
 
         """
         decomp_ops = [
-            qml.CNOT(wires=[wires[0], wires[1]]),
-            qml.CRY(phi, wires=[wires[1], wires[0]]),
-            qml.CNOT(wires=[wires[0], wires[1]]),
+            qml.adjoint(qml.T)(wires=wires[0]),
+            qml.Hadamard(wires=wires[0]),
+            qml.S(wires=wires[0]),
+            qml.adjoint(qml.T)(wires=wires[1]),
+            qml.adjoint(qml.S)(wires=wires[1]),
+            qml.Hadamard(wires=wires[1]),
+            qml.CNOT(wires=[wires[1], wires[0]]),
+            qml.RZ(-phi/2, wires=wires[0]),
+            qml.RY(phi/2, wires=wires[1]),
+            qml.CNOT(wires=[wires[1], wires[0]]),
+            qml.adjoint(qml.S)(wires=wires[0]),
+            qml.Hadamard(wires=wires[0]),
+            qml.T(wires=wires[0]),
+            qml.Hadamard(wires=wires[1]),
+            qml.S(wires=wires[1]),
+            qml.T(wires=wires[1])
         ]
         return decomp_ops
 

--- a/tests/ops/qubit/test_qchem_ops.py
+++ b/tests/ops/qubit/test_qchem_ops.py
@@ -173,30 +173,16 @@ class TestSingleExcitation:
 
     @pytest.mark.parametrize("phi", [-0.1, 0.2, np.pi / 4])
     def test_single_excitation_decomp(self, phi):
-        """Tests that the SingleExcitation operation calculates the correct decomposition.
-
-        Need to consider the matrix of CRY separately, as the control is wire 1
-        and the target is wire 0 in the decomposition."""
+        """Tests that the SingleExcitation operation calculates the correct decomposition."""
         decomp1 = qml.SingleExcitation(phi, wires=[0, 1]).decomposition()
         decomp2 = qml.SingleExcitation.compute_decomposition(phi, wires=[0, 1])
 
         for decomp in [decomp1, decomp2]:
-            mats = []
-            for i in reversed(decomp):
-                if i.wires.tolist() == [1, 0] and isinstance(i, qml.CRY):
-                    new_mat = np.array(
-                        [
-                            [1, 0, 0, 0],
-                            [0, np.cos(phi / 2), 0, -np.sin(phi / 2)],
-                            [0, 0, 1, 0],
-                            [0, np.sin(phi / 2), 0, np.cos(phi / 2)],
-                        ]
-                    )
-                    mats.append(new_mat)
-                else:
-                    mats.append(i.matrix())
+            with qml.tape.QuantumTape() as tape:
+                for op in decomp:
+                    qml.apply(op)
 
-            decomposed_matrix = np.linalg.multi_dot(mats)
+            decomposed_matrix = qml.matrix(tape, wire_order=[0, 1])
             exp = SingleExcitation(phi)
 
             assert np.allclose(decomposed_matrix, exp)


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      test directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `doc/releases/changelog-dev.md` file, summarizing the
      change, and including a link back to the PR.

- [ ] The PennyLane source code conforms to
      [PEP8 standards](https://www.python.org/dev/peps/pep-0008/).
      We check all of our code against [Pylint](https://www.pylint.org/).
      To lint modified files, simply `pip install pylint`, and then
      run `pylint pennylane/path/to/file.py`.

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:** Any two-qubit operation can be decomposed into a sequence of operations involving at most 3 CNOTs. The current decomposition for `qml.SingleExcitation` used two CNOTs and a controlled Y rotation, which when decomposed, would total 4 CNOTs.

**Description of the Change:** Implemented a new decomposition for `qml.SingleExcitation` that requires only 2 CNOTs, at the cost of some additional single-qubit operations.

**Benefits:** More efficient decomposition, esp. for running on hardware as it halves the number of CNOTs. No change to the number of circuit evaluations for gradient computation.

**Possible Drawbacks:** Number of single-qubit operations is increased.

**Related GitHub Issues:** N/A
