### PR TITLE
set AllWires to be non-zero

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -151,6 +151,10 @@
 * `Sum`, `Prod`, and `SProd` operator data is now a flat list, instead of nested.
   [(#3958)](https://github.com/PennyLaneAI/pennylane/pull/3958)
 
+* `qml.operation.WiresEnum.AllWires` is now -2 instead of 0 to avoid the
+  ambiguity between `op.num_wires = 0` and `op.num_wires = AllWires`.
+  [(#3978)](https://github.com/PennyLaneAI/pennylane/pull/3978)
+
 <h3>Breaking changes</h3>
 
 * Both JIT interfaces are not compatible with Jax `>0.4.3`, we raise an error for those versions.

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -297,7 +297,7 @@ class WiresEnum(IntEnum):
     an operation acts on"""
 
     AnyWires = -1
-    AllWires = 0
+    AllWires = -2
 
 
 AllWires = WiresEnum.AllWires


### PR DESCRIPTION
One-line PR!

**Context:**
If someone checks `op.num_wires == 0` and it is `AllWires`, they will get a false positive. We want to avoid this, because they are not logically the same:
```pycon
>>> AllWires == 0
True
```

**Description of the Change:**
Now it's -2.
```pycon
>>> AllWires == 0, AllWires == -2
(False, True)
```

**Benefits:**
Although `num_wires = 0` doesn't _really_ make sense, `num_wires = -2` _reaaaally_ doesn't make sense, so there will be no ambiguity.

**Possible Drawbacks:**
Maybe some external user manually checks for `0` assuming it means `AllWires`? It's kinda against the spirit of enums, but you never know. I added this in the "Improvements" section of the changelog and not the "Breaking Changes" section to avoid thinking of this as "breaking" for that reason.