### PR TITLE
[Prototype] `experimental.Device.preprocess` returns an execution config

### DIFF
--- a/pennylane/devices/experimental/device_api.py
+++ b/pennylane/devices/experimental/device_api.py
@@ -139,7 +139,7 @@ class Device(abc.ABC):
         self,
         circuits: QuantumTape_or_Batch,
         execution_config: ExecutionConfig = DefaultExecutionConfig,
-    ) -> Tuple[QuantumTapeBatch, Callable]:
+    ) -> Tuple[QuantumTapeBatch, Callable, ExecutionConfig]:
         """Device preprocessing function.
 
         .. warning::
@@ -157,8 +157,8 @@ class Device(abc.ABC):
                 the execution.
 
         Returns:
-            Sequence[QuantumTape], Callable: QuantumTapes that the device can natively execute
-            and a postprocessing function to be called after execution.
+            Tuple[QuantumTape], Callable, ExecutionConfig: QuantumTapes that the device can natively execute,
+            a postprocessing function to be called after execution, and a configuration with unset specifications filled in.
 
         Raises:
             Exception: An exception is raised if the input cannot be converted into a form supported by the device.
@@ -170,6 +170,12 @@ class Device(abc.ABC):
         * splitting circuits with batched parameters into multiple executions
         * gradient specific preprocessing, such as making sure trainable operators have generators
         * validation of configuration parameters
+
+        Certain configuration parameters may be unspecified in the input ``execution_config``. Preprocessing
+        should fill these unspecificied configuration parameters in with concrete values. Examples include:
+
+        * ``grad_on_execution``: A value of ``None`` indicates this value has not yet been set.
+        * ``gradient_method``: A value of ``"best"`` indicates this value has not yet been set.
 
         """
 
@@ -185,8 +191,8 @@ class Device(abc.ABC):
             """
             return res
 
-        circuit_batch = [circuits] if isinstance(circuits, QuantumTape) else circuits
-        return circuit_batch, blank_postprocessing_fn
+        circuit_batch = (circuits,) if isinstance(circuits, QuantumTape) else circuits
+        return circuit_batch, blank_postprocessing_fn, execution_config
 
     @abc.abstractmethod
     def execute(

--- a/pennylane/devices/experimental/execution_config.py
+++ b/pennylane/devices/experimental/execution_config.py
@@ -41,13 +41,16 @@ class ExecutionConfig:
     shots: Optional[Union[int, Tuple[int]]] = None
     """The number of shots for an execution"""
 
+    grad_on_execution: Union[bool, str] = "best"
+    """Whether or not to compute the gradient at the same time as the execution."""
+
     gradient_method: Optional[str] = None
     """The method used to compute the gradient of the quantum circuit being executed"""
 
-    gradient_keyword_arguments: dict = None
+    gradient_keyword_arguments: Optional[dict] = None
     """Arguments used to control a gradient transform"""
 
-    device_options: dict = None
+    device_options: Optional[dict] = None
     """Various options for the device executing a quantum circuit"""
 
     interface: str = "autograd"
@@ -65,6 +68,11 @@ class ExecutionConfig:
         if self.interface not in SUPPORTED_INTERFACES:
             raise ValueError(
                 f"interface must be in {SUPPORTED_INTERFACES}, got {self.interface} instead."
+            )
+
+        if self.grad_on_execution not in {True, False, "best"}:
+            raise ValueError(
+                f"grad_on_execution must be True, False, or 'best'. Got {self.grad_on_execution} instead."
             )
 
         if (

--- a/pennylane/devices/qubit/preprocess.py
+++ b/pennylane/devices/qubit/preprocess.py
@@ -17,6 +17,7 @@ that they are supported for execution by a device."""
 # pylint: disable=protected-access
 from typing import Generator, Callable, Tuple
 import warnings
+import dataclasses
 
 import pennylane as qml
 
@@ -239,7 +240,7 @@ def batch_transform(
 def preprocess(
     circuits: Tuple[qml.tape.QuantumScript],
     execution_config: ExecutionConfig = DefaultExecutionConfig,
-) -> Tuple[Tuple[qml.tape.QuantumScript], Callable]:
+) -> Tuple[Tuple[qml.tape.QuantumScript], Callable, ExecutionConfig]:
     """Preprocess a batch of :class:`~.QuantumTape` objects to make them ready for execution.
 
     This function validates a batch of :class:`~.QuantumTape` objects by transforming and expanding
@@ -250,10 +251,10 @@ def preprocess(
         execution_config (.ExecutionConfig): execution configuration with configurable
             options for the execution.
 
-    Returns:
-        Tuple[Sequence[.QuantumTape], callable]: Returns a tuple containing
-        the sequence of circuits to be executed, and a post-processing function
-        to be applied to the list of evaluated circuit results.
+        Returns:
+            Tuple[QuantumTape], Callable, ExecutionConfig: QuantumTapes that the device can natively execute,
+            a postprocessing function to be called after execution, and a configuration with unset specifications filled in.
+
     """
     if execution_config.shots is not None:
         # Finite shot support will be added later
@@ -265,4 +266,10 @@ def preprocess(
 
     circuits, batch_fn = qml.transforms.map_batch_transform(batch_transform, circuits)
 
-    return circuits, batch_fn
+    if execution_config.gradient_method == "best":
+        execution_config = dataclasses.replace(execution_config, gradient_method="backprop")
+
+    if execution_config.grad_on_execution == "best":
+        execution_config = dataclasses.replace(execution_config, grad_on_execution=True)
+
+    return circuits, batch_fn, execution_config

--- a/pennylane/interfaces/execution.py
+++ b/pennylane/interfaces/execution.py
@@ -21,13 +21,13 @@ devices with autodifferentiation support.
 
 # pylint: disable=import-outside-toplevel,too-many-arguments,too-many-branches,not-callable
 # pylint: disable=unused-argument,unnecessary-lambda-assignment,inconsistent-return-statements,
-# pylint: disable=too-many-statements, invalid-unary-operand-type
+# pylint: disable=too-many-statements, invalid-unary-operand-type, too-many-return-statements
 
 import inspect
 import warnings
 from contextlib import _GeneratorContextManager
 from functools import wraps, partial
-from typing import Callable, Sequence
+from typing import Callable, Sequence, Optional, Union
 
 from cachetools import LRUCache
 
@@ -137,7 +137,9 @@ def cache_execute(fn: Callable, cache, pass_kwargs=False, return_tuple=True, exp
         if cache is None or (isinstance(cache, bool) and not cache):
             # No caching. Simply execute the execution function
             # and return the results.
-            res = fn(tapes, **kwargs)
+
+            # must convert to list as new device interface returns tuples
+            res = list(fn(tapes, **kwargs))
             return (res, []) if return_tuple else res
 
         execution_tapes = {}
@@ -202,6 +204,8 @@ def cache_execute(fn: Callable, cache, pass_kwargs=False, return_tuple=True, exp
         else:
             # execute all unique tapes that do not exist in the cache
             res = fn(execution_tapes.values(), **kwargs)
+            # convert to list as new device interface returns a tuple
+            res = list(res)
 
         final_res = []
 
@@ -229,7 +233,7 @@ def cache_execute(fn: Callable, cache, pass_kwargs=False, return_tuple=True, exp
 def execute(
     tapes: Sequence[QuantumTape],
     device,
-    gradient_fn: Callable = None,
+    gradient_fn: Optional[Union[Callable, str]] = None,
     interface="auto",
     grad_on_execution="best",
     gradient_kwargs=None,
@@ -237,7 +241,7 @@ def execute(
     cachesize=10000,
     max_diff=1,
     override_shots: int = False,
-    expand_fn="device",
+    expand_fn="device",  # type: ignore
     max_expansion=10,
     device_batch_transform=True,
 ):
@@ -363,6 +367,11 @@ def execute(
             device_batch_transform=device_batch_transform,
         )
 
+    new_device_interface = isinstance(device, qml.devices.experimental.Device)
+    config = qml.devices.experimental.ExecutionConfig(
+        interface=interface, grad_on_execution=grad_on_execution, gradient_method=str(gradient_fn)
+    )
+
     if interface == "auto":
         params = []
         for tape in tapes:
@@ -371,7 +380,14 @@ def execute(
 
     gradient_kwargs = gradient_kwargs or {}
 
-    if device_batch_transform:
+    if new_device_interface:
+        if not device_batch_transform:
+            warnings.warn(
+                "device batch transforms cannot be turned off with the new device interface.",
+                UserWarning,
+            )
+        tapes, batch_fn, config = device.preprocess(tapes, config)
+    elif device_batch_transform:
         dev_batch_transform = set_shots(device, override_shots)(device.batch_transform)
         tapes, batch_fn = qml.transforms.map_batch_transform(dev_batch_transform, tapes)
     else:
@@ -382,12 +398,31 @@ def execute(
         cache = LRUCache(maxsize=cachesize)
         setattr(cache, "_persistent_cache", False)
 
-    batch_execute = set_shots(device, override_shots)(device.batch_execute)
+    if new_device_interface:
+        batch_execute = device.execute
+    else:
+        batch_execute = set_shots(device, override_shots)(device.batch_execute)
 
     if expand_fn == "device":
-        expand_fn = lambda tape: device.expand_fn(tape, max_expansion=max_expansion)
+        if new_device_interface:
+
+            def expand_fn(tape):  # pylint: disable=function-redefined
+                """A blank expansion function since the new device handles expansion in preprocessing."""
+                return tape
+
+        else:
+
+            def expand_fn(tape):  # pylint: disable=function-redefined
+                """A wrapper around the device ``expand_fn``."""
+                return device.expand_fn(tape, max_expansion=max_expansion)
 
     if gradient_fn is None:
+        if new_device_interface:
+            cached_execution = cache_execute(
+                device.execute, cache, return_tuple=False, pass_kwargs=True
+            )
+            results = cached_execution(tapes, execution_config=config)
+            return batch_fn(results)
         # don't unwrap if it's an interface device
         if "passthru_interface" in device.capabilities() or device.short_name == "default.mixed":
             return batch_fn(
@@ -403,6 +438,12 @@ def execute(
         return batch_fn(res)
 
     if gradient_fn == "backprop" or interface is None:
+        if new_device_interface:
+            cached_execution = cache_execute(
+                device.execute, cache, return_tuple=False, pass_kwargs=True
+            )
+            results = cached_execution(tapes, execution_config=config)
+            return batch_fn(results)
         return batch_fn(
             qml.interfaces.cache_execute(
                 batch_execute, cache, return_tuple=False, expand_fn=expand_fn
@@ -429,24 +470,41 @@ def execute(
             tapes = _adjoint_jacobian_expansion(tapes, mode, interface, max_expansion)
 
         # grad on execution or best was chosen
-        if grad_on_execution is True or grad_on_execution == "best":
-            # replace the forward execution function to return
-            # both results and gradients
-            execute_fn = set_shots(device, override_shots)(device.execute_and_gradients)
-            gradient_fn = None
-            _grad_on_execution = True
+        if new_device_interface:
+            if config.grad_on_execution is True:
+
+                # pylint: disable=function-redefined
+                def execute_fn(circuits):
+                    return device.execute_and_compute_derivatives(circuits, config)
+
+                gradient_fn = None
+                _grad_on_execution = True
+            else:
+                execute_fn = cache_execute(device.execute, cache=None)
+                gradient_fn = cache_execute(
+                    device.compute_derivatives, cache, pass_kwargs=True, return_tuple=False
+                )
+                _grad_on_execution = False
 
         else:
-            # disable caching on the forward pass
-            execute_fn = qml.interfaces.cache_execute(batch_execute, cache=None)
+            if grad_on_execution is True or grad_on_execution == "best":
+                # replace the forward execution function to return
+                # both results and gradients
+                execute_fn = set_shots(device, override_shots)(device.execute_and_gradients)
+                gradient_fn = None
+                _grad_on_execution = True
 
-            # replace the backward gradient computation
-            gradient_fn = qml.interfaces.cache_execute(
-                set_shots(device, override_shots)(device.gradients),
-                cache,
-                pass_kwargs=True,
-                return_tuple=False,
-            )
+            else:
+                # disable caching on the forward pass
+                execute_fn = cache_execute(batch_execute, cache=None)
+
+                # replace the backward gradient computation
+                gradient_fn = cache_execute(
+                    set_shots(device, override_shots)(device.gradients),
+                    cache,
+                    pass_kwargs=True,
+                    return_tuple=False,
+                )
     elif grad_on_execution is True:
         # In "forward" mode, gradients are automatically handled
         # within execute_and_gradients, so providing a gradient_fn
@@ -608,6 +666,10 @@ def _execute_legacy(
            [ 0.01983384, -0.97517033,  0.        ],
            [ 0.        ,  0.        , -0.95533649]])
     """
+
+    if isinstance(device, qml.devices.experimental.Device):
+        raise ValueError("New device interface only works with return types enabled.")
+
     if interface == "auto":
         params = []
         for tape in tapes:


### PR DESCRIPTION
In order for the device to select what "best" entails for an execution configuration, we need to allow the device to fill in "best" entries with concrete values.

In order to implement this with the new `devices.experimental.Device`, interface, we would need to modify the call signature for the `preprocess` method so that it also returns a configuration object.

This PR has several parts to it:

* Changing the call siganture for `Device.preprocess`
* Adding `grad_on_execution` to the device's `ExecutionConfig`
* Making `DefaultQubit2` implement this changed interface
* Adding adjoint differentiation support to `DefaultQubit2`
* Making the `interfaces` module rely on this new interface.

```
>>> config = ExecutionConfig(gradient_method="best", grad_on_execution="best")
>>> batch, post_processing_fn, config = DefaultQubit2().preprocess([qml.tape.QuantumTape()], config)
>>> pprint.pprint(config)
ExecutionConfig(shots=None,
                grad_on_execution=True,
                gradient_method='backprop',
                gradient_keyword_arguments={},
                device_options={},
                interface='autograd',
                derivative_order=1)
```


With this change, we would no longer assume devices always want to compute derivatives at the same time as executions.