### PR TITLE
Update ScalarSymbolicOps and trainability

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -148,8 +148,9 @@
 * `retworkx` has been renamed to `rustworkx` to accomodate the change in name for the package.
   [(#3975)](https://github.com/PennyLaneAI/pennylane/pull/3975)
 
-* `Sum`, `Prod`, and `SProd` operator data is now a flat list, instead of nested.
+* `Exp`, `Sum`, `Prod`, and `SProd` operator data is now a flat list, instead of nested.
   [(#3958)](https://github.com/PennyLaneAI/pennylane/pull/3958)
+  [(#3983)](https://github.com/PennyLaneAI/pennylane/pull/3983)
 
 * `qml.operation.WiresEnum.AllWires` is now -2 instead of 0 to avoid the
   ambiguity between `op.num_wires = 0` and `op.num_wires = AllWires`.
@@ -181,8 +182,9 @@
   For example, you can no longer create `StateMP(qml.PauliX(0))` or `PurityMP(eigvals=(-1,1), wires=Wires(0))`.
   [(#3898)](https://github.com/PennyLaneAI/pennylane/pull/3898)
 
-* `Sum`, `Prod`, and `SProd` operator data is now a flat list, instead of nested.
+* `Exp`, `Sum`, `Prod`, and `SProd` operator data is now a flat list, instead of nested.
   [(#3958)](https://github.com/PennyLaneAI/pennylane/pull/3958)
+  [(#3983)](https://github.com/PennyLaneAI/pennylane/pull/3983)
 
 <h3>Deprecations</h3>
 

--- a/pennylane/ops/op_math/evolution.py
+++ b/pennylane/ops/op_math/evolution.py
@@ -15,6 +15,7 @@
 This submodule defines the Evolution class.
 """
 import warnings
+from copy import copy
 from warnings import warn
 
 import pennylane as qml
@@ -94,6 +95,14 @@ class Evolution(Exp):
         )
 
     @property
+    def data(self):
+        return self._data
+
+    @data.setter
+    def data(self, new_data):
+        self._data = new_data
+
+    @property
     def param(self):
         """A real coefficient with ``1j`` factored out."""
         return self.data[0]
@@ -145,3 +154,8 @@ class Evolution(Exp):
                 f"The generator is not defined."
             )
         return self.base
+
+    def __copy__(self):
+        copied = super().__copy__()
+        copied._data = copy(self._data)
+        return copied

--- a/pennylane/ops/op_math/exp.py
+++ b/pennylane/ops/op_math/exp.py
@@ -209,6 +209,10 @@ class Exp(ScalarSymbolicOp, Operation):
     def data(self):
         return self._data
 
+    @data.setter
+    def data(self, new_data):
+        self._data = new_data
+
     @property
     def coeff(self):
         """The numerical coefficient of the operator in the exponent."""

--- a/pennylane/ops/op_math/exp.py
+++ b/pennylane/ops/op_math/exp.py
@@ -212,6 +212,8 @@ class Exp(ScalarSymbolicOp, Operation):
     @data.setter
     def data(self, new_data):
         self._data = new_data
+        self.scalar = new_data[0]
+        self.base.data = new_data[1:]
 
     @property
     def coeff(self):

--- a/pennylane/ops/op_math/exp.py
+++ b/pennylane/ops/op_math/exp.py
@@ -14,7 +14,6 @@
 """
 This submodule defines the symbolic operation that stands for an exponential of an operator.
 """
-from copy import copy
 from typing import List
 from warnings import warn
 
@@ -173,7 +172,6 @@ class Exp(ScalarSymbolicOp, Operation):
     # pylint: disable=too-many-arguments
     def __init__(self, base, coeff=1, num_steps=None, do_queue=True, id=None):
         super().__init__(base, scalar=coeff, do_queue=do_queue, id=id)
-        self._data = [coeff, *self.base.data]
         self.grad_recipe = [None]
         self.num_steps = num_steps
 
@@ -184,36 +182,9 @@ class Exp(ScalarSymbolicOp, Operation):
             else f"Exp({self.coeff} {self.base.name})"
         )
 
-    # pylint: disable=attribute-defined-outside-init
-    def __copy__(self):
-        # this method needs to be overwritten because the base must be copied too.
-        copied_op = object.__new__(type(self))
-        # copied_op must maintain inheritance structure of self
-        # Relevant for symbolic ops that mix in operation-specific components.
-
-        for attr, value in vars(self).items():
-            if attr not in {"_hyperparameters"}:
-                setattr(copied_op, attr, value)
-
-        copied_op._hyperparameters = copy(self.hyperparameters)
-        copied_op.hyperparameters["base"] = copy(self.base)
-        copied_op._data = copy(self._data)
-
-        return copied_op
-
     @property
     def hash(self):
         return hash((str(self.name), self.base.hash, str(self.coeff)))
-
-    @property
-    def data(self):
-        return self._data
-
-    @data.setter
-    def data(self, new_data):
-        self._data = new_data
-        self.scalar = new_data[0]
-        self.base.data = new_data[1:]
 
     @property
     def coeff(self):

--- a/pennylane/ops/op_math/exp.py
+++ b/pennylane/ops/op_math/exp.py
@@ -173,7 +173,7 @@ class Exp(ScalarSymbolicOp, Operation):
     # pylint: disable=too-many-arguments
     def __init__(self, base, coeff=1, num_steps=None, do_queue=True, id=None):
         super().__init__(base, scalar=coeff, do_queue=do_queue, id=id)
-        self._data = [[coeff], self.base.data]
+        self._data = [coeff, *self.base.data]
         self.grad_recipe = [None]
         self.num_steps = num_steps
 

--- a/pennylane/ops/op_math/pow.py
+++ b/pennylane/ops/op_math/pow.py
@@ -236,6 +236,15 @@ class Pow(ScalarSymbolicOp):
     def ndim_params(self):
         return self.base.ndim_params
 
+    @property
+    def data(self):
+        """The trainable parameters"""
+        return self.base.data
+
+    @data.setter
+    def data(self, new_data):
+        self.base.data = new_data
+
     def label(self, decimals=None, base_label=None, cache=None):
         z_string = format(self.z).translate(_superscript)
         base_label = self.base.label(decimals, base_label, cache=cache)

--- a/pennylane/ops/op_math/sprod.py
+++ b/pennylane/ops/op_math/sprod.py
@@ -164,17 +164,6 @@ class SProd(ScalarSymbolicOp):
         return base_label or f"{scalar_val}*{self.base.label(decimals=decimals, cache=cache)}"
 
     @property
-    def data(self):
-        """The trainable parameters"""
-        return [self.scalar, *self.base.data]
-
-    @data.setter
-    def data(self, new_data):
-        self.scalar = new_data[0]
-        if len(new_data) > 1:
-            self.base.data = new_data[1:]
-
-    @property
     def num_params(self):
         """Number of trainable parameters that the operator depends on.
         Usually 1 + the number of trainable parameters for the base op.

--- a/pennylane/ops/op_math/symbolicop.py
+++ b/pennylane/ops/op_math/symbolicop.py
@@ -164,11 +164,22 @@ class ScalarSymbolicOp(SymbolicOp):
     def __init__(self, base, scalar: float, do_queue=True, id=None):
         self.scalar = np.array(scalar) if isinstance(scalar, list) else scalar
         super().__init__(base, do_queue=do_queue, id=id)
+        self._data = [self.scalar, *base.data]
         self._batch_size = self._check_and_compute_batch_size(scalar)
 
     @property
     def batch_size(self):
         return self._batch_size
+
+    @property
+    def data(self):
+        return self._data
+
+    @data.setter
+    def data(self, new_data):
+        self._data = new_data
+        self.scalar = new_data[0]
+        self.base.data = new_data[1:]
 
     def _check_and_compute_batch_size(self, scalar):
         batched_scalar = qml.math.ndim(scalar) > 0
@@ -249,3 +260,8 @@ class ScalarSymbolicOp(SymbolicOp):
             mat = self._matrix(self.scalar, base_matrix)
 
         return qml.math.expand_matrix(mat, wires=self.wires, wire_order=wire_order)
+
+    def __copy__(self):
+        copied = super().__copy__()
+        copied._data = copy(self._data)
+        return copied

--- a/pennylane/ops/op_math/symbolicop.py
+++ b/pennylane/ops/op_math/symbolicop.py
@@ -164,7 +164,6 @@ class ScalarSymbolicOp(SymbolicOp):
     def __init__(self, base, scalar: float, do_queue=True, id=None):
         self.scalar = np.array(scalar) if isinstance(scalar, list) else scalar
         super().__init__(base, do_queue=do_queue, id=id)
-        self._data = [self.scalar, *base.data]
         self._batch_size = self._check_and_compute_batch_size(scalar)
 
     @property
@@ -173,11 +172,10 @@ class ScalarSymbolicOp(SymbolicOp):
 
     @property
     def data(self):
-        return self._data
+        return [self.scalar, *self.base.data]
 
     @data.setter
     def data(self, new_data):
-        self._data = new_data
         self.scalar = new_data[0]
         self.base.data = new_data[1:]
 
@@ -260,8 +258,3 @@ class ScalarSymbolicOp(SymbolicOp):
             mat = self._matrix(self.scalar, base_matrix)
 
         return qml.math.expand_matrix(mat, wires=self.wires, wire_order=wire_order)
-
-    def __copy__(self):
-        copied = super().__copy__()
-        copied._data = copy(self._data)
-        return copied

--- a/tests/ops/op_math/test_evolution.py
+++ b/tests/ops/op_math/test_evolution.py
@@ -83,6 +83,13 @@ class TestEvolution:
         assert op.coeff == 1j * op.data[0]
         assert op.param == op.data[0]
 
+        new_param = np.array(2.345)
+        op.data = [new_param]
+
+        assert op.data == [new_param]
+        assert op.coeff == 1j * op.data[0]
+        assert op.data == op.data[0]
+
     def test_repr_paulix(self):
         """Test the __repr__ method when the base is a simple observable."""
         op = Evolution(qml.PauliX(0), 3)

--- a/tests/ops/op_math/test_exp.py
+++ b/tests/ops/op_math/test_exp.py
@@ -115,9 +115,11 @@ class TestProperties:
 
         new_phi = np.array(0.1234)
         new_coeff = np.array(3.456)
-        op.data = [new_phi, new_coeff]
+        op.data = [new_coeff, new_phi]
 
-        assert op.data == [new_phi, new_coeff]
+        assert op.data == [new_coeff, new_phi]
+        assert op.base.data == [new_phi]
+        assert op.scalar == new_coeff
 
     # pylint: disable=protected-access
     def test_queue_category_ops(self):

--- a/tests/ops/op_math/test_exp.py
+++ b/tests/ops/op_math/test_exp.py
@@ -941,3 +941,16 @@ class TestDifferentiation:
             op1.parameter_frequencies()
 
         assert op2.parameter_frequencies == [(4.0,)]
+
+    def test_params_can_be_considered_trainable(self):
+        """Tests that the parameters of an Exp are considered trainable."""
+        dev = qml.device("default.qubit", wires=1)
+
+        @qml.qnode(dev)
+        def circuit(x, coeff):
+            Exp(qml.RX(x, 0), coeff)
+            return qml.expval(qml.PauliZ(0))
+
+        with pytest.warns(UserWarning):
+            circuit(np.array(2.0), np.array(0.5))
+        assert circuit.tape.trainable_params == [0, 1]

--- a/tests/ops/op_math/test_exp.py
+++ b/tests/ops/op_math/test_exp.py
@@ -44,8 +44,8 @@ class TestInitialization:
         assert op.id == "something"
 
         assert op.num_params == 1
-        assert op.parameters == [[1], []]
-        assert op.data == [[1], []]
+        assert op.parameters == [1]
+        assert op.data == [1]
 
         assert op.wires == qml.wires.Wires("a")
 
@@ -63,8 +63,8 @@ class TestInitialization:
         assert op.name == "Exp"
 
         assert op.num_params == 1
-        assert op.parameters == [[coeff], []]
-        assert op.data == [[coeff], []]
+        assert op.parameters == [coeff]
+        assert op.data == [coeff]
 
         assert op.wires == qml.wires.Wires(("b", "c"))
 
@@ -82,7 +82,7 @@ class TestInitialization:
         assert op.name == "Exp"
 
         assert op.num_params == 2
-        assert op.data == [coeff, [base_coeff]]
+        assert op.data == [coeff, base_coeff]
 
         assert op.wires == qml.wires.Wires(5)
 
@@ -111,7 +111,7 @@ class TestProperties:
         base = qml.RX(phi, wires=0)
         op = Exp(base, coeff)
 
-        assert op.data == [[coeff], [phi]]
+        assert op.data == [coeff, phi]
 
     # pylint: disable=protected-access
     def test_queue_category_ops(self):

--- a/tests/ops/op_math/test_exp.py
+++ b/tests/ops/op_math/test_exp.py
@@ -113,6 +113,12 @@ class TestProperties:
 
         assert op.data == [coeff, phi]
 
+        new_phi = np.array(0.1234)
+        new_coeff = np.array(3.456)
+        op.data = [new_phi, new_coeff]
+
+        assert op.data == [new_phi, new_coeff]
+
     # pylint: disable=protected-access
     def test_queue_category_ops(self):
         """Test the _queue_category property."""

--- a/tests/ops/op_math/test_prod.py
+++ b/tests/ops/op_math/test_prod.py
@@ -1300,6 +1300,18 @@ class TestIntegration:
         res2 = batched_no_prod(x, y)
         assert qml.math.allclose(res1, res2)
 
+    def test_params_can_be_considered_trainable(self):
+        """Tests that the parameters of a Prod are considered trainable."""
+        dev = qml.device("default.qubit", wires=2)
+
+        @qml.qnode(dev)
+        def circuit():
+            return qml.expval(qml.prod(qml.RX(1.1, 0), qml.RY(qnp.array(2.2), 1)))
+
+        with pytest.warns(UserWarning):
+            circuit()
+        assert circuit.tape.trainable_params == [1]
+
 
 class TestSortWires:
     """Tests for the wire sorting algorithm."""

--- a/tests/ops/op_math/test_sum.py
+++ b/tests/ops/op_math/test_sum.py
@@ -1076,6 +1076,18 @@ class TestIntegration:
         with pytest.warns(UserWarning, match="Sum might not be hermitian."):
             my_circ()
 
+    def test_params_can_be_considered_trainable(self):
+        """Tests that the parameters of a Sum are considered trainable."""
+        dev = qml.device("default.qubit", wires=2)
+
+        @qml.qnode(dev)
+        def circuit():
+            return qml.expval(Sum(qml.RX(1.1, 0), qml.RY(qnp.array(2.2), 0)))
+
+        with pytest.warns(UserWarning):
+            circuit()
+        assert circuit.tape.trainable_params == [1]
+
 
 # pylint: disable=too-few-public-methods
 class TestArithmetic:

--- a/tests/ops/op_math/test_symbolic_op.py
+++ b/tests/ops/op_math/test_symbolic_op.py
@@ -18,12 +18,17 @@ import pytest
 
 import pennylane as qml
 from pennylane import numpy as np
-from pennylane.ops.op_math import SymbolicOp
+from pennylane.ops.op_math import SymbolicOp, ScalarSymbolicOp
 from pennylane.wires import Wires
 
 
 class TempOperator(qml.operation.Operator):
     num_wires = 1
+
+
+class TempScalar(ScalarSymbolicOp):
+    def _matrix(scalar, mat):
+        pass
 
 
 def test_intialization():
@@ -199,3 +204,41 @@ class TestQueuing:
             op = SymbolicOp(base, do_queue=False)
 
         assert len(q) == 0
+
+
+class TestScalarSymbolicOp:
+    """Tests for the ScalarSymbolicOp class."""
+
+    def test_init(self):
+        base = TempOperator(1.1, wires=[0])
+        scalar = 2.2
+        op = TempScalar(base, scalar)
+        assert isinstance(op.scalar, float)
+        assert op.scalar == 2.2
+        assert op.data == [2.2, 1.1]
+
+        base = TempOperator(1.1, wires=[0])
+        scalar = [2.2, 3.3]
+        op = TempScalar(base, scalar)
+        assert isinstance(op.scalar, np.ndarray)
+        assert np.all(op.scalar == [2.2, 3.3])
+        assert np.all(op.data[0] == op.scalar)
+        assert op.data[1] == 1.1
+
+    def test_data(self):
+        """Tests the data property."""
+        op = TempScalar(TempOperator(1.1, wires=[0]), 2.2)
+        assert op.scalar == 2.2
+        assert op.data == [2.2, 1.1]
+
+        # check setting through ScalarSymbolicOp
+        op.data = [3.3, 4.4]
+        assert op.data == [3.3, 4.4]
+        assert op.scalar == 3.3
+        assert op.base.data == [4.4]
+
+        # check setting through base
+        op.base.data = [5.5]
+        assert op.data == [3.3, 5.5]
+        assert op.scalar == 3.3
+        assert op.base.data == [5.5]


### PR DESCRIPTION
**Context:**
We want all operator data to be as flat as possible. Also, I had previously done this for Sum and Prod, but didn't test the consequential result which is that their data can now be considered trainable.

**Description of the Change:**
1. Move identical data logic from SProd and Exp to the parent class, ScalarSymbolicOp. Note that while doing this, I also made the data for `Exp` flat.
2. Add a custom `data` property definition to Pow so it keeps its old behaviour of treating `z` as a hyperparameter (eg. excluded from `op.data`)
3. The `copy` dunder for Exp was moved to the parent class so its siblings can have it too : )
4. Add tests to ensure Exp, Sum and Prod data is trainable (there was already an SProd test that actually measures the gradient)

**Benefits:**
- It is easier to detect trainability of flat data, and more consistent with the rest of PennyLane
- Less copied code
- The new tape converter integration can move forward thanks to the addition of a data setter to all ScalarSymbolicOps

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
#3958, #3899, fixes #3916