### PR TITLE
Pauli map wires

### DIFF
--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -1394,6 +1394,8 @@ class Operator(abc.ABC):
         """
         new_op = copy.copy(self)
         new_op._wires = Wires([wire_map.get(wire, wire) for wire in self.wires])
+        if (p_rep := new_op._pauli_rep) is not None:
+            new_op._pauli_rep = p_rep.map_wires(wire_map)
         return new_op
 
     def simplify(self) -> "Operator":  # pylint: disable=unused-argument

--- a/pennylane/ops/op_math/composite.py
+++ b/pennylane/ops/op_math/composite.py
@@ -336,16 +336,17 @@ class CompositeOp(Operator):
         """The function used when combining the operands of the composite operator"""
 
     def map_wires(self, wire_map: dict):
+        # pylint:disable=protected-access
         cls = self.__class__
         new_op = cls.__new__(cls)
         new_op.operands = tuple(op.map_wires(wire_map=wire_map) for op in self)
-        new_op._wires = Wires(  # pylint: disable=protected-access
-            [wire_map.get(wire, wire) for wire in self.wires]
-        )
+        new_op._wires = Wires([wire_map.get(wire, wire) for wire in self.wires])
         new_op.data = self.data.copy()
         for attr, value in vars(self).items():
             if attr not in {"data", "operands", "_wires"}:
                 setattr(new_op, attr, value)
+        if (p_rep := new_op._pauli_rep) is not None:
+            new_op._pauli_rep = p_rep.map_wires(wire_map)
 
         return new_op
 

--- a/pennylane/ops/op_math/symbolicop.py
+++ b/pennylane/ops/op_math/symbolicop.py
@@ -138,8 +138,11 @@ class SymbolicOp(Operator):
         )
 
     def map_wires(self, wire_map: dict):
+        # pylint:disable=protected-access
         new_op = copy(self)
         new_op.hyperparameters["base"] = self.base.map_wires(wire_map=wire_map)
+        if (p_rep := new_op._pauli_rep) is not None:
+            new_op._pauli_rep = p_rep.map_wires(wire_map)
         return new_op
 
 

--- a/pennylane/pauli/pauli_arithmetic.py
+++ b/pennylane/pauli/pauli_arithmetic.py
@@ -242,7 +242,7 @@ class PauliWord(dict):
 
     def map_wires(self, wire_map: dict) -> "PauliWord":
         """Return a new PauliWord with the wires mapped."""
-        return self.__class__({wire_map[w]: op for w, op in self.items()})
+        return self.__class__({wire_map.get(w, w): op for w, op in self.items()})
 
 
 class PauliSentence(dict):

--- a/pennylane/pauli/pauli_arithmetic.py
+++ b/pennylane/pauli/pauli_arithmetic.py
@@ -240,6 +240,10 @@ class PauliWord(dict):
         obs = [op_map[op](wire) for wire, op in self.items()]
         return Hamiltonian([1], [obs[0] if len(obs) == 1 else Tensor(*obs)])
 
+    def map_wires(self, wire_map: dict) -> "PauliWord":
+        """Return a new PauliWord with the wires mapped."""
+        return self.__class__({wire_map[w]: op for w, op in self.items()})
+
 
 class PauliSentence(dict):
     """Dictionary representing a linear combination of Pauli words, with the keys
@@ -397,3 +401,7 @@ class PauliSentence(dict):
         for pw, coeff in items:
             if abs(coeff) <= tol:
                 del self[pw]
+
+    def map_wires(self, wire_map: dict) -> "PauliSentence":
+        """Return a new PauliSentence with the wires mapped."""
+        return self.__class__({pw.map_wires(wire_map): coeff for pw, coeff in self.items()})

--- a/tests/ops/op_math/test_composite.py
+++ b/tests/ops/op_math/test_composite.py
@@ -188,12 +188,18 @@ class TestConstruction:
     def test_map_wires(self):
         """Test the map_wires method."""
         diag_op = ValidOp(*self.simple_operands)
+        diag_op._pauli_rep = qml.pauli.PauliSentence({qml.pauli.PauliWord({0: "X", 1: "Y"}): 1})
+
         wire_map = {0: 5, 1: 7, 2: 9, 3: 11}
         mapped_op = diag_op.map_wires(wire_map=wire_map)
 
         assert mapped_op.wires == Wires([5, 7])
         assert mapped_op[0].wires == Wires(5)
         assert mapped_op[1].wires == Wires(7)
+        assert mapped_op._pauli_rep is not diag_op._pauli_rep
+        assert mapped_op._pauli_rep == qml.pauli.PauliSentence(
+            {qml.pauli.PauliWord({5: "X", 7: "Y"}): 1}
+        )
 
     def test_build_pauli_rep(self):
         """Test the build_pauli_rep"""

--- a/tests/ops/op_math/test_symbolic_op.py
+++ b/tests/ops/op_math/test_symbolic_op.py
@@ -59,12 +59,16 @@ def test_map_wires():
     """Test the map_wires method."""
     base = TempOperator("a")
     op = SymbolicOp(base, id="something")
+    # pylint:disable=attribute-defined-outside-init
+    op._pauli_rep = qml.pauli.PauliSentence({qml.pauli.PauliWord({"a": "X"}): 1})
     wire_map = {"a": 5}
     mapped_op = op.map_wires(wire_map=wire_map)
     assert op.wires == Wires("a")
     assert op.base.wires == Wires("a")
     assert mapped_op.wires == Wires(5)
     assert mapped_op.base.wires == Wires(5)
+    assert mapped_op._pauli_rep is not op._pauli_rep
+    assert mapped_op._pauli_rep == qml.pauli.PauliSentence({qml.pauli.PauliWord({5: "X"}): 1})
 
 
 class TestProperties:

--- a/tests/pauli/test_pauli_arithmetic.py
+++ b/tests/pauli/test_pauli_arithmetic.py
@@ -235,6 +235,7 @@ class TestPauliWord:
         "word,wire_map,expected",
         [
             (PauliWord({0: X, 1: Y}), {0: "a", 1: "b"}, PauliWord({"a": X, "b": Y})),
+            (PauliWord({0: X, 1: Y}), {1: "b"}, PauliWord({0: X, "b": Y})),
             (PauliWord({0: X, 1: Y}), {0: 1, 1: 0}, PauliWord({0: Y, 1: X})),
             (PauliWord({"a": X, 0: Y}), {"a": 2, 0: 1, "c": "C"}, PauliWord({2: X, 1: Y})),
         ],
@@ -601,10 +602,10 @@ class TestPauliSentence:
 
     def test_map_wires(self):
         """Test the map_wires conversion method."""
-        assert ps1.map_wires({0: "t", 1: "u", 2: "v", "a": 1, "b": 2, "c": 3}) == PauliSentence(
+        assert ps1.map_wires({1: "u", 2: "v", "a": 1, "b": 2, "c": 3}) == PauliSentence(
             {
                 PauliWord({"u": X, "v": Y}): 1.23,
                 PauliWord({1: X, 2: X, 3: Z}): 4j,
-                PauliWord({"t": Z, 2: Z, 3: Z}): -0.5,
+                PauliWord({0: Z, 2: Z, 3: Z}): -0.5,
             }
         )

--- a/tests/pauli/test_pauli_arithmetic.py
+++ b/tests/pauli/test_pauli_arithmetic.py
@@ -231,6 +231,18 @@ class TestPauliWord:
         new_pw = pickle.loads(serialization)
         assert pw == new_pw
 
+    @pytest.mark.parametrize(
+        "word,wire_map,expected",
+        [
+            (PauliWord({0: X, 1: Y}), {0: "a", 1: "b"}, PauliWord({"a": X, "b": Y})),
+            (PauliWord({0: X, 1: Y}), {0: 1, 1: 0}, PauliWord({0: Y, 1: X})),
+            (PauliWord({"a": X, 0: Y}), {"a": 2, 0: 1, "c": "C"}, PauliWord({2: X, 1: Y})),
+        ],
+    )
+    def test_map_wires(self, word, wire_map, expected):
+        """Test the map_wires conversion method."""
+        assert word.map_wires(wire_map) == expected
+
 
 class TestPauliSentence:
     def test_missing(self):
@@ -586,3 +598,13 @@ class TestPauliSentence:
         serialization = pickle.dumps(ps)
         new_ps = pickle.loads(serialization)
         assert ps == new_ps
+
+    def test_map_wires(self):
+        """Test the map_wires conversion method."""
+        assert ps1.map_wires({0: "t", 1: "u", 2: "v", "a": 1, "b": 2, "c": 3}) == PauliSentence(
+            {
+                PauliWord({"u": X, "v": Y}): 1.23,
+                PauliWord({1: X, 2: X, 3: Z}): 4j,
+                PauliWord({"t": Z, 2: Z, 3: Z}): -0.5,
+            }
+        )

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -542,11 +542,24 @@ class TestOperatorConstruction:
             num_wires = 3
 
         op = DummyOp(wires=[0, 1, 2])
+        op._pauli_rep = qml.pauli.PauliSentence(  # pylint:disable=attribute-defined-outside-init
+            {
+                qml.pauli.PauliWord({0: "X", 1: "Y", 2: "Z"}): 1.1,
+                qml.pauli.PauliWord({0: "Z", 1: "X", 2: "Y"}): 2.2,
+            }
+        )
         wire_map = {0: 10, 1: 11, 2: 12}
         mapped_op = op.map_wires(wire_map=wire_map)
         assert op is not mapped_op
         assert op.wires == Wires([0, 1, 2])
         assert mapped_op.wires == Wires([10, 11, 12])
+        assert mapped_op._pauli_rep is not op._pauli_rep
+        assert mapped_op._pauli_rep == qml.pauli.PauliSentence(
+            {
+                qml.pauli.PauliWord({10: "X", 11: "Y", 12: "Z"}): 1.1,
+                qml.pauli.PauliWord({10: "Z", 11: "X", 12: "Y"}): 2.2,
+            }
+        )
 
     def test_map_wires_uncomplete_wire_map(self):
         """Test that the map_wires method doesn't change wires that are not present in the wire


### PR DESCRIPTION
**Context:**
When using `op.map_wires`, the pauli rep would not also map wires, as reported in bug #3967

**Description of the Change:**
- Add `map_wires` methods to PauliWord and PauliSentence
- Update the `map_wires` methods of `Operator`, `CompositeOp` and `SymbolicOp` to map their pauli reps if they have one. This will include child classes like Exp, SProd, Prod, Sum, etc.

**Benefits:**
- Users can map the wires of Pauli objects
- The `_pauli_rep` of operators created from mapping wires will be correct

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
Fixes #3967