### PR TITLE
Various gradient-related fixups with the new return system

### DIFF
--- a/pennylane/gradients/parameter_shift_hessian.py
+++ b/pennylane/gradients/parameter_shift_hessian.py
@@ -475,8 +475,9 @@ def _expval_hessian_param_shift_tuple(
     return hessian_tapes, processing_fn
 
 
-@hessian_transform
-def param_shift_hessian(tape, argnum=None, diagonal_shifts=None, off_diagonal_shifts=None, f0=None):
+def _param_shift_hessian_legacy(
+    tape, argnum=None, diagonal_shifts=None, off_diagonal_shifts=None, f0=None
+):
     r"""Transform a QNode to compute the parameter-shift Hessian with respect to its trainable
     parameters.
 
@@ -621,15 +622,6 @@ def param_shift_hessian(tape, argnum=None, diagonal_shifts=None, off_diagonal_sh
                [0.        , 0.05998862]])
 
     """
-    if qml.active_return():
-        return _param_shift_hessian_tuple(
-            tape,
-            argnum=argnum,
-            diagonal_shifts=diagonal_shifts,
-            off_diagonal_shifts=off_diagonal_shifts,
-            f0=f0,
-        )
-
     # Perform input validation before generating tapes.
     if any(isinstance(m, StateMP) for m in tape.measurements):
         raise ValueError(
@@ -699,9 +691,8 @@ def param_shift_hessian(tape, argnum=None, diagonal_shifts=None, off_diagonal_sh
     )
 
 
-def _param_shift_hessian_tuple(
-    tape, argnum=None, diagonal_shifts=None, off_diagonal_shifts=None, f0=None
-):
+@hessian_transform
+def param_shift_hessian(tape, argnum=None, diagonal_shifts=None, off_diagonal_shifts=None, f0=None):
     r"""Transform a QNode to compute the parameter-shift Hessian with respect to its trainable
     parameters. This is the Hessian transform to replace the old one in the new return types system
 
@@ -844,6 +835,14 @@ def _param_shift_hessian_tuple(
         ((array(0.), array(0.)), (array(0.), array(0.05998862)))
 
     """
+    if not qml.active_return():
+        return _param_shift_hessian_legacy(
+            tape,
+            argnum=argnum,
+            diagonal_shifts=diagonal_shifts,
+            off_diagonal_shifts=off_diagonal_shifts,
+            f0=f0,
+        )
 
     # Perform input validation before generating tapes.
     if any(isinstance(m, StateMP) for m in tape.measurements):

--- a/pennylane/gradients/pulse_gradient.py
+++ b/pennylane/gradients/pulse_gradient.py
@@ -504,13 +504,6 @@ def _expval_stoch_pulse_grad(tape, argnum, num_split_times, key, shots):
         tapes.extend(this_tapes)
 
     def processing_fn(results):
-        # pylint: disable=protected-access
-        scalar_qfunc_output = tape._qfunc_output is not None and not isinstance(
-            tape._qfunc_output, Sequence
-        )
-        if scalar_qfunc_output:
-            results = [qml.math.squeeze(res) for res in results]
-
         num_measurements = len(tape.measurements)
         single_measure = num_measurements == 1
         shot_vector = isinstance(shots, Sequence)

--- a/pennylane/tape/qscript.py
+++ b/pennylane/tape/qscript.py
@@ -1029,6 +1029,7 @@ class QuantumScript:
         new_qscript._obs_sharing_wires_id = self._obs_sharing_wires_id
         new_qscript._batch_size = self.batch_size
         new_qscript._output_dim = self.output_dim
+        new_qscript._qfunc_output = copy.copy(self._qfunc_output)
 
         return new_qscript
 

--- a/tests/tape/test_qscript.py
+++ b/tests/tape/test_qscript.py
@@ -568,6 +568,7 @@ class TestScriptCopying:
         ops = [qml.RY(0.5, wires=1), qml.CNOT((0, 1))]
         m = [qml.expval(qml.PauliZ(0) @ qml.PauliY(1))]
         qs = QuantumScript(ops, m, prep=prep)
+        qs._qfunc_output = np.array(123)
 
         copied_qs = qs.copy()
 
@@ -587,6 +588,8 @@ class TestScriptCopying:
         assert qs.get_parameters() == copied_qs.get_parameters()
         assert qs.wires == copied_qs.wires
         assert qs.data == copied_qs.data
+        assert qs._qfunc_output == copied_qs._qfunc_output
+        assert qs._qfunc_output is not copied_qs._qfunc_output
 
         # check that the output dim is identical
         assert qs.output_dim == copied_qs.output_dim


### PR DESCRIPTION
**Context:**
`tape._qfunc_output` has become a sneaky part of the tape API, and it causes some hiccups. This PR tries to address them.

**Description of the Change:**
1. Copy `_qfunc_output` when copying tapes
2. Stop trying to squeeze the results in pulse_gradient (because we don't have to)
3. Re-arrange the `parameter_shift_hessian` methods to match the new format (`fn_name` and `_fn_name_legacy`)

**Benefits:**
1. `_qfunc_output` results don't just disappear after tape copying (though the value of their existence is currently in question)
2. Future devs won't be confused about this seemingly unnecessary line
3. It will make it easier to remove legacy code once its deprecation window is over

**Possible Drawbacks:**
Maybe something depended on `tape._qfunc_output` disappearing on copy? If tests pass here, I'm satisfied.

**Related GitHub Issues:**
Caused headaches working on #3899