### PR TITLE
Add information to errors due to `qml.jacobian`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -207,6 +207,9 @@
 
 <h3>Bug fixes</h3>
 
+* A more informative error message is raised in `qml.jacobian` to explain potential
+  problems with the new return types specification.
+
 * Fixed a bug where calling `Evolution.generator` with `coeff` being a complex ArrayBox raised an error.
   [(#3796)](https://github.com/PennyLaneAI/pennylane/pull/3796)
   

--- a/pennylane/_grad.py
+++ b/pennylane/_grad.py
@@ -112,7 +112,7 @@ class grad:
             self._forward = self._fun(*args, **kwargs)
             return ()
 
-        grad_value, ans = grad_fn(*args, **kwargs)
+        grad_value, ans = grad_fn(*args, **kwargs)  # pylint: disable=not-callable
         self._forward = ans
 
         return grad_value
@@ -324,7 +324,16 @@ def jacobian(func, argnum=None):
                 "If this is unintended, please add trainable parameters via the "
                 "'requires_grad' attribute or 'argnum' keyword."
             )
-        jac = tuple(_jacobian(func, arg)(*args, **kwargs) for arg in _argnum)
+        try:
+            jac = tuple(_jacobian(func, arg)(*args, **kwargs) for arg in _argnum)
+        except Exception as e:
+            raise ValueError(
+                "PennyLane has a new return shape specification that"
+                " may not work well with autograd and more than one measurement. That may"
+                " be the source of the error. \n\n"
+                "Try wrapping your output in a autograd numpy array,"
+                " using qml.disable_return, or using a different interface."
+            ) from e
 
         return jac[0] if unpack else jac
 

--- a/tests/test_grad.py
+++ b/tests/test_grad.py
@@ -1,0 +1,34 @@
+# Copyright 2018-2023 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Unittests for the _grad module.
+"""
+import pytest
+
+import pennylane as qml
+
+
+def test_return_types_error_caught():
+    """Test that an informative error message is raised if an error occurs
+    inside qml.jacobian."""
+    dev = qml.device("default.qubit", wires=2)
+
+    @qml.qnode(dev)
+    def circuit(x):
+        qml.RX(x, 0)
+        return qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliZ(1))
+
+    x = qml.numpy.array(0.1)
+    with pytest.raises(ValueError, match=r"PennyLane has a new return shape specification"):
+        qml.jacobian(circuit)(x)

--- a/tests/tests_passing_pylint.txt
+++ b/tests/tests_passing_pylint.txt
@@ -3,6 +3,7 @@ tests/devices/experimental/**
 tests/drawer/test_tape_mpl.py
 tests/drawer/test_draw_mpl.py
 tests/drawer/test_drawer_utils.py
+tests/test_grad.py
 tests/measurements/test_counts.py
 tests/measurements/test_probs.py
 tests/measurements/test_shots.py


### PR DESCRIPTION
[sc-37074]

Errors like that #3992 that happen on the backward pass for the new return type specification with autograd can be very difficult to interpret, especially for users that are unfamiliar with the change in return type specification.

This PR adds a try-except block in `qml.jacobian` that will catch such errors and add information and suggestions.


For example,
```
dev = qml.device('default.qubit', wires=3)

@qml.qnode(dev, diff_method="parameter-shift")
def circuit(x):
    qml.RX(x[0], 0)
    return qml.expval(qml.PauliZ(0) ), qml.expval(qml.PauliZ(1))

qml.jacobian(circuit)(x)
```

Will now state:
```
ValueError: PennyLane has a new return shape specification that may not work well with autograd and more than one measurement. That may be the source of the error. 

Try wrapping your output in a autograd numpy array, using qml.disable_return, or using a different interface.
```
Instead of just:
```
TypeError: 'ArrayVSpace' object cannot be interpreted as an integer
```