### PR TITLE
Update ExpvalCost removal to v0.31

### DIFF
--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -39,7 +39,7 @@ Pending deprecations
 * ``qml.ExpvalCost`` has been deprecated, and usage will now raise a warning.
   
   - Deprecated in v0.24
-  - Will be removed in v0.30
+  - Will be removed in v0.31
 
   Instead, it is recommended to simply
   pass Hamiltonians to the ``qml.expval`` function inside QNodes:


### PR DESCRIPTION
See above.

(I also didn't realize `ExpvalCost` had been deprecated since v0.24. Definitely shouldn't get pushed back beyond v0.31)
