### PR TITLE
Fix `qml.math.dot` for autograd

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -268,6 +268,9 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Fixes a bug where `qml.math.dot` returned a numpy array instead of an autograd array, breaking autograd derivatives
+  in certain circumstances.
+
 * Fixes a bug where `qml.ctrl` for parametric gates were incompatible with PyTorch tensors on the GPU.
   [(#4002)](https://github.com/PennyLaneAI/pennylane/pull/4002)
 

--- a/pennylane/math/multi_dispatch.py
+++ b/pennylane/math/multi_dispatch.py
@@ -341,24 +341,20 @@ def dot(tensor1, tensor2, like=None):
 
         return np.tensordot(x, y, axes=[[-1], [-2]], like=like)
 
-    if like == "tensorflow":
-        if len(np.shape(x)) == 0 and len(np.shape(y)) == 0:
+    if like in {"tensorflow", "autograd"}:
+        shape_y = len(np.shape(y))
+        shape_x = len(np.shape(x))
+        if shape_x == 0 and shape_y == 0:
             return x * y
 
-        if len(np.shape(y)) == 1:
+        if shape_y == 1:
             return np.tensordot(x, y, axes=[[-1], [0]], like=like)
 
-        if len(np.shape(x)) == 2 and len(np.shape(y)) == 2:
+        if shape_x == 2 and shape_y == 2:
             return x @ y
 
         return np.tensordot(x, y, axes=[[-1], [-2]], like=like)
 
-    # pylint: disable=protected-access
-    if like == "autograd":
-        out = np.dot(x, y, like=like)
-        if hasattr(out, "_value"):
-            out._value = ar.numpy.asarray(out._value, like="autograd")
-        return out
     return np.dot(x, y, like=like)
 
 

--- a/pennylane/math/multi_dispatch.py
+++ b/pennylane/math/multi_dispatch.py
@@ -353,6 +353,12 @@ def dot(tensor1, tensor2, like=None):
 
         return np.tensordot(x, y, axes=[[-1], [-2]], like=like)
 
+    # pylint: disable=protected-access
+    if like == "autograd":
+        out = np.dot(x, y, like=like)
+        if hasattr(out, "_value"):
+            out._value = ar.numpy.asarray(out._value, like="autograd")
+        return out
     return np.dot(x, y, like=like)
 
 

--- a/pennylane/math/single_dispatch.py
+++ b/pennylane/math/single_dispatch.py
@@ -471,6 +471,7 @@ def _asarray_torch(x, dtype=None, **kwargs):
         np.float64: torch.float64,
         np.complex64: torch.complex64,
         np.complex128: torch.complex128,
+        "float64": torch.float64,
     }
 
     if dtype in dtype_map:

--- a/pennylane/measurements/expval.py
+++ b/pennylane/measurements/expval.py
@@ -127,7 +127,7 @@ class ExpectationMP(SampleMeasurement, StateMeasurement):
             idx = int("".join(str(i) for i in self.obs.parameters[0]), 2)
             probs = qml.probs(wires=self.wires).process_state(state=state, wire_order=wire_order)
             return probs[idx]
-        eigvals = qml.math.asarray(self.obs.eigvals())
+        eigvals = qml.math.asarray(self.obs.eigvals(), dtype="float64")
         # we use ``self.wires`` instead of ``self.obs`` because the observable was
         # already applied to the state
         prob = qml.probs(wires=self.wires).process_state(state=state, wire_order=wire_order)

--- a/pennylane/measurements/expval.py
+++ b/pennylane/measurements/expval.py
@@ -127,8 +127,7 @@ class ExpectationMP(SampleMeasurement, StateMeasurement):
             idx = int("".join(str(i) for i in self.obs.parameters[0]), 2)
             probs = qml.probs(wires=self.wires).process_state(state=state, wire_order=wire_order)
             return probs[idx]
-        eigvals = qml.math.asarray(self.obs.eigvals(), dtype="float64")
-
+        eigvals = qml.math.asarray(self.obs.eigvals())
         # we use ``self.wires`` instead of ``self.obs`` because the observable was
         # already applied to the state
         prob = qml.probs(wires=self.wires).process_state(state=state, wire_order=wire_order)

--- a/tests/devices/qubit/test_measure.py
+++ b/tests/devices/qubit/test_measure.py
@@ -223,8 +223,8 @@ class TestSumOfTermsDifferentiability:
         config.update("jax_enable_x64", True)  # otherwise output is too noisy
 
         x = jax.numpy.array(0.52, dtype=jax.numpy.float64)
-        coeffs = [jax.numpy.array(5.2), jax.numpy.array(9.67)]
-        f = jax.jit(self.f, static_argnums=(1, 2, 3)) if use_jit else self.f
+        coeffs = (5.2, 6.7)
+        f = jax.jit(self.f, static_argnums=(1, 2, 3, 4)) if use_jit else self.f
 
         out = f(x, coeffs, convert_to_hamiltonian=convert_to_hamiltonian)
         expected_out = self.expected(x, coeffs)
@@ -240,10 +240,13 @@ class TestSumOfTermsDifferentiability:
         """Test that backpropagation derivatives work with torch with hamiltonians and large sums."""
         import torch
 
-        coeffs = [torch.tensor(9.2, requires_grad=False), torch.tensor(6.2, requires_grad=False)]
+        coeffs = [
+            torch.tensor(9.2, requires_grad=False, dtype=torch.float64),
+            torch.tensor(6.2, requires_grad=False, dtype=torch.float64),
+        ]
 
-        x = torch.tensor(-0.289, requires_grad=True)
-        x2 = torch.tensor(-0.289, requires_grad=True)
+        x = torch.tensor(-0.289, requires_grad=True, dtype=torch.float64)
+        x2 = torch.tensor(-0.289, requires_grad=True, dtype=torch.float64)
         out = self.f(x, coeffs, convert_to_hamiltonian=convert_to_hamiltonian)
         expected_out = self.expected(x2, coeffs, like="torch")
         assert qml.math.allclose(out, expected_out)

--- a/tests/devices/qubit/test_measure.py
+++ b/tests/devices/qubit/test_measure.py
@@ -167,35 +167,49 @@ class TestMeasurements:
 
 class TestSumOfTermsDifferentiability:
     @staticmethod
-    def f(scale, n_wires=10, offset=0.1, convert_to_hamiltonian=False):
+    def f(scale, coeffs, n_wires=10, offset=0.1, convert_to_hamiltonian=False):
         ops = [qml.RX(offset + scale * i, wires=i) for i in range(n_wires)]
 
-        t1 = 2.5 * qml.prod(*(qml.PauliZ(i) for i in range(n_wires)))
-        t2 = 6.2 * qml.prod(*(qml.PauliY(i) for i in range(n_wires)))
-        H = t1 + t2
         if convert_to_hamiltonian:
-            H = H._pauli_rep.hamiltonian()  # pylint: disable=protected-access
+            H = qml.Hamiltonian(
+                coeffs,
+                [
+                    qml.operation.Tensor(*(qml.PauliZ(i) for i in range(n_wires))),
+                    qml.operation.Tensor(*(qml.PauliY(i) for i in range(n_wires))),
+                ],
+            )
+        else:
+            t1 = qml.s_prod(coeffs[0], qml.prod(*(qml.PauliZ(i) for i in range(n_wires))))
+            t2 = qml.s_prod(coeffs[1], qml.prod(*(qml.PauliY(i) for i in range(n_wires))))
+            H = t1 + t2
         qs = qml.tape.QuantumScript(ops, [qml.expval(H)])
         return simulate(qs)
 
     @staticmethod
-    def expected(scale, n_wires=10, offset=0.1, like="numpy"):
+    def expected(scale, coeffs, n_wires=10, offset=0.1, like="numpy"):
         phase = offset + scale * qml.math.asarray(range(n_wires), like=like)
         cosines = qml.math.cos(phase)
         sines = qml.math.sin(phase)
-        return 2.5 * qml.math.prod(cosines) + 6.2 * qml.math.prod(sines)
+        return coeffs[0] * qml.math.prod(cosines) + coeffs[1] * qml.math.prod(sines)
 
     @pytest.mark.autograd
     @pytest.mark.parametrize("convert_to_hamiltonian", (True, False))
-    def test_autograd_backprop(self, convert_to_hamiltonian):
+    @pytest.mark.parametrize(
+        "coeffs",
+        [
+            (qml.numpy.array(2.5), qml.numpy.array(6.2)),
+            (qml.numpy.array(2.5, requires_grad=False), qml.numpy.array(6.2, requires_grad=False)),
+        ],
+    )
+    def test_autograd_backprop(self, convert_to_hamiltonian, coeffs):
         """Test that backpropagation derivatives work in autograd with hamiltonians and large sums."""
         x = qml.numpy.array(0.52)
-        out = self.f(x, convert_to_hamiltonian=convert_to_hamiltonian)
-        expected_out = self.expected(x)
+        out = self.f(x, coeffs, convert_to_hamiltonian=convert_to_hamiltonian)
+        expected_out = self.expected(x, coeffs)
         assert qml.math.allclose(out, expected_out)
 
-        g = qml.grad(self.f)(x, convert_to_hamiltonian=convert_to_hamiltonian)
-        expected_g = qml.grad(self.expected)(x)
+        g = qml.grad(self.f)(x, coeffs, convert_to_hamiltonian=convert_to_hamiltonian)
+        expected_g = qml.grad(self.expected)(x, coeffs)
         assert qml.math.allclose(g, expected_g)
 
     @pytest.mark.jax
@@ -209,14 +223,15 @@ class TestSumOfTermsDifferentiability:
         config.update("jax_enable_x64", True)  # otherwise output is too noisy
 
         x = jax.numpy.array(0.52, dtype=jax.numpy.float64)
+        coeffs = [jax.numpy.array(5.2), jax.numpy.array(9.67)]
         f = jax.jit(self.f, static_argnums=(1, 2, 3)) if use_jit else self.f
 
-        out = f(x, convert_to_hamiltonian=convert_to_hamiltonian)
-        expected_out = self.expected(x)
+        out = f(x, coeffs, convert_to_hamiltonian=convert_to_hamiltonian)
+        expected_out = self.expected(x, coeffs)
         assert qml.math.allclose(out, expected_out)
 
-        g = jax.grad(f)(x, convert_to_hamiltonian=convert_to_hamiltonian)
-        expected_g = jax.grad(self.expected)(x)
+        g = jax.grad(f)(x, coeffs, convert_to_hamiltonian=convert_to_hamiltonian)
+        expected_g = jax.grad(self.expected)(x, coeffs)
         assert qml.math.allclose(g, expected_g)
 
     @pytest.mark.torch
@@ -225,10 +240,12 @@ class TestSumOfTermsDifferentiability:
         """Test that backpropagation derivatives work with torch with hamiltonians and large sums."""
         import torch
 
+        coeffs = [torch.tensor(9.2, requires_grad=False), torch.tensor(6.2, requires_grad=False)]
+
         x = torch.tensor(-0.289, requires_grad=True)
         x2 = torch.tensor(-0.289, requires_grad=True)
-        out = self.f(x, convert_to_hamiltonian=convert_to_hamiltonian)
-        expected_out = self.expected(x2, like="torch")
+        out = self.f(x, coeffs, convert_to_hamiltonian=convert_to_hamiltonian)
+        expected_out = self.expected(x2, coeffs, like="torch")
         assert qml.math.allclose(out, expected_out)
 
         out.backward()
@@ -242,12 +259,13 @@ class TestSumOfTermsDifferentiability:
         import tensorflow as tf
 
         x = tf.Variable(0.5)
+        coeffs = [8.3, 5.7]
 
         with tf.GradientTape() as tape1:
-            out = self.f(x, convert_to_hamiltonian=convert_to_hamiltonian)
+            out = self.f(x, coeffs, convert_to_hamiltonian=convert_to_hamiltonian)
 
         with tf.GradientTape() as tape2:
-            expected_out = self.expected(x)
+            expected_out = self.expected(x, coeffs)
 
         assert qml.math.allclose(out, expected_out)
         g1 = tape1.gradient(out, x)

--- a/tests/math/test_multi_dispatch.py
+++ b/tests/math/test_multi_dispatch.py
@@ -201,7 +201,6 @@ def test_gammainc(n, t, gamma_ref):
 
 
 def test_dot_autograd():
-
     x = np.array([1.0, 2.0], requires_grad=False)
     y = np.array([2.0, 3.0], requires_grad=True)
 

--- a/tests/math/test_multi_dispatch.py
+++ b/tests/math/test_multi_dispatch.py
@@ -22,6 +22,8 @@ from autoray import numpy as anp
 from pennylane import math as fn
 from pennylane import numpy as np
 
+from pennylane import grad as qml_grad
+
 pytestmark = pytest.mark.all_interfaces
 
 tf = pytest.importorskip("tensorflow", minversion="2.1")
@@ -196,6 +198,19 @@ def test_gammainc(n, t, gamma_ref):
     gamma = fn.gammainc(n, t)
 
     assert np.allclose(gamma, gamma_ref)
+
+
+def test_dot_autograd():
+
+    x = np.array([1.0, 2.0], requires_grad=False)
+    y = np.array([2.0, 3.0], requires_grad=True)
+
+    res = fn.dot(x, y)
+    assert isinstance(res, np.tensor)
+    assert res.requires_grad
+    assert fn.allclose(res, 8)
+
+    assert fn.allclose(qml_grad(fn.dot)(x, y), x)
 
 
 class TestMatmul:


### PR DESCRIPTION
In PR #3903 I was enocuntering problems with differentiating the result of measuring a Hamiltonian when coefficients were marked with `requires_grad=False`.

The source of the problem was `qml.math.dot`. Even when the inputs were autograd arrays or array boxes, the output would be a numpy array, not an autograd array. This would then confuse autograd downstream of that operation. This fixes that problem and unblocks #3903 .