### PR TITLE
Remove `seed_recipes` argument from `classical_shadow` and `shadow_expval`

### DIFF
--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -19,13 +19,6 @@ Pending deprecations
   - Still accessible in v0.28, v0.29
   - Will be removed in v0.30
 
-* The ``seed_recipes`` argument in ``qml.classical_shadow`` and ``qml.shadow_expval`` is deprecated.
-  A new argument ``seed`` has been added, which defaults to ``None`` and can contain an integer with the 
-  wanted seed.
-
-  - Still accessible in v0.28, v0.29
-  - Will be removed in v0.30
-
 * The ``grouping`` module is deprecated. The functionality has been moved and
   reorganized in the new ``pauli`` module under ``pauli/utils.py`` or ``pauli/grouping/``.
 
@@ -74,6 +67,12 @@ Pending deprecations
 
 Completed deprecation cycles
 ----------------------------
+
+* The ``seed_recipes`` argument in ``qml.classical_shadow`` and ``qml.shadow_expval`` has been removed.
+  An argument ``seed`` which defaults to ``None`` can contain an integer with the wanted seed.
+
+  - Still accessible in v0.28, v0.29
+  - Removed in v0.30
 
 * The ``get_operation`` tape method is updated to return the operation index as well, changing its signature.
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -235,9 +235,11 @@
 
 <h3>Breaking changes 💔</h3>
 
+* The `seed_recipes` argument has been removed from `qml.classical_shadow` and `qml.shadow_expval`.
+  [(#4020)](https://github.com/PennyLaneAI/pennylane/pull/4020)
+
 * The tape method `get_operation` has an updated signature.
   [(#3998)](https://github.com/PennyLaneAI/pennylane/pull/3998)
-
 
 * Both JIT interfaces are not compatible with JAX `>0.4.3`, we raise an error for those versions.
   [(#3877)](https://github.com/PennyLaneAI/pennylane/pull/3877)

--- a/pennylane/measurements/classical_shadow.py
+++ b/pennylane/measurements/classical_shadow.py
@@ -28,7 +28,7 @@ from pennylane.wires import Wires
 from .measurements import MeasurementShapeError, MeasurementTransform, Shadow, ShadowExpval
 
 
-def shadow_expval(H, k=1, seed=None, seed_recipes=True):
+def shadow_expval(H, k=1, seed=None):
     r"""Compute expectation values using classical shadows in a differentiable manner.
 
     The canonical way of computing expectation values is to simply average the expectation values for each local snapshot, :math:`\langle O \rangle = \sum_t \text{tr}(\rho^{(t)}O) / T`.
@@ -85,16 +85,11 @@ def shadow_expval(H, k=1, seed=None, seed_recipes=True):
     >>> qml.jacobian(circuit)(x, Hs)
     [-0.48312, -0.00198, -0.00375,  0.00168]
     """
-    if seed_recipes is False:
-        warnings.warn(
-            "Using ``seed_recipes`` is deprecated. Please use ``seed`` instead.",
-            UserWarning,
-        )
     seed = seed or np.random.randint(2**30)
     return ShadowExpvalMP(H=H, seed=seed, k=k)
 
 
-def classical_shadow(wires, seed=None, seed_recipes=True):
+def classical_shadow(wires, seed=None):
     """
     The classical shadow measurement protocol.
 
@@ -186,37 +181,37 @@ def classical_shadow(wires, seed=None, seed_recipes=True):
                 qml.CNOT(wires=[0, 1])
                 qml.classical_shadow(wires=[0, 1])
 
-        >>> bits1, recipes1 = qml.execute([tape], device=dev, gradient_fn=None)[0][0]
-        >>> bits2, recipes2 = qml.execute([tape], device=dev, gradient_fn=None)[0][0]
+        >>> bits1, recipes1 = qml.execute([tape], device=dev, gradient_fn=None)[0]
+        >>> bits2, recipes2 = qml.execute([tape], device=dev, gradient_fn=None)[0]
         >>> np.all(recipes1 == recipes2)
         True
         >>> np.all(bits1 == bits2)
         False
 
         If using different Pauli recipes is desired for the :class:`~.tape.QuantumTape` interface,
-        the ``seed_recipes`` flag should be explicitly set to ``False``:
+        different seeds should be used for the classical shadow:
 
         .. code-block:: python3
 
             dev = qml.device("default.qubit", wires=2, shots=5)
 
-            with qml.tape.QuantumTape() as tape:
+            with qml.tape.QuantumTape() as tape1:
                 qml.Hadamard(wires=0)
                 qml.CNOT(wires=[0, 1])
-                qml.classical_shadow(wires=[0, 1], seed_recipes=False)
+                qml.classical_shadow(wires=[0, 1], seed=10)
 
-        >>> bits1, recipes1 = qml.execute([tape], device=dev, gradient_fn=None)[0][0]
-        >>> bits2, recipes2 = qml.execute([tape], device=dev, gradient_fn=None)[0][0]
+            with qml.tape.QuantumTape() as tape2:
+                qml.Hadamard(wires=0)
+                qml.CNOT(wires=[0, 1])
+                qml.classical_shadow(wires=[0, 1], seed=15)
+
+        >>> bits1, recipes1 = qml.execute([tape1], device=dev, gradient_fn=None)[0]
+        >>> bits2, recipes2 = qml.execute([tape2], device=dev, gradient_fn=None)[0]
         >>> np.all(recipes1 == recipes2)
         False
         >>> np.all(bits1 == bits2)
         False
     """
-    if seed_recipes is False:
-        warnings.warn(
-            "Using ``seed_recipes`` is deprecated. Please use ``seed`` instead.",
-            UserWarning,
-        )
     wires = Wires(wires)
     seed = seed or np.random.randint(2**30)
     return ClassicalShadowMP(wires=wires, seed=seed)

--- a/pennylane/measurements/classical_shadow.py
+++ b/pennylane/measurements/classical_shadow.py
@@ -15,7 +15,6 @@
 This module contains the qml.classical_shadow measurement.
 """
 import copy
-import warnings
 from collections.abc import Iterable
 from typing import Optional, Union, Sequence
 

--- a/tests/measurements/test_classical_shadow.py
+++ b/tests/measurements/test_classical_shadow.py
@@ -272,14 +272,6 @@ class TestClassicalShadow:
         with pytest.raises(qml.QuantumFunctionError, match=msg):
             circuit()
 
-    def test_seed_recipes_deprecated(self, wires):
-        """Test that using the ``seed_recipes`` argument is deprecated."""
-        with pytest.warns(
-            UserWarning,
-            match="Using ``seed_recipes`` is deprecated. Please use ``seed`` instead",
-        ):
-            qml.classical_shadow(wires=wires, seed_recipes=False)
-
 
 def hadamard_circuit(wires, shots=10000, interface="autograd"):
     dev = qml.device("default.qubit", wires=wires, shots=shots)
@@ -403,14 +395,6 @@ class TestExpvalMeasurement:
         assert tape.operations[0].name == "PauliY"
         assert len(tape.measurements) == 1
         assert isinstance(tape.measurements[0], ShadowExpvalMP)
-
-    def test_seed_recipes_deprecated(self):
-        """Test that using the ``seed_recipes`` argument is deprecated."""
-        with pytest.warns(
-            UserWarning,
-            match="Using ``seed_recipes`` is deprecated. Please use ``seed`` instead",
-        ):
-            qml.shadow_expval(H=qml.PauliX(0), seed_recipes=False)
 
 
 obs_hadamard = [


### PR DESCRIPTION
**Context:**
The `seed_recipes` argument has been deprecated since v0.28 and was scheduled to be removed in v0.30

**Description of the Change:**
* Removed `seed_recipes` argument from `classical_shadow` and `shadow_expval`

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
