### PR TITLE
Make `drive` non user-facing

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -31,16 +31,15 @@
     the Hamiltonian of the interaction of all the Rydberg atoms.
   * A new user-facing `transmon_interaction` function is added, constructing
     the Hamiltonian that describes the circuit QED interaction Hamiltonian of superconducting transmon systems.
-  * A new user-facing `drive` function is added, which returns a `ParametrizedHamiltonian` (`HardwareHamiltonian`) containing
-    the Hamiltonian of the interaction between a driving electro-magnetic field and a group of qubits.
-  * A new user-facing `rydberg_drive` function is added, which returns a `ParametrizedHamiltonian` (`HardwareHamiltonian`) containing
-    the Hamiltonian of the interaction between a driving laser field and a group of Rydberg atoms.
+  * A new user-facing `rydberg_drive` function is added, which returns a `ParametrizedHamiltonian` (`HardwareHamiltonian`) containing the Hamiltonian of the interaction between a driving laser field and a group of Rydberg atoms.
   [(#3749)](https://github.com/PennyLaneAI/pennylane/pull/3749)
   [(#3911)](https://github.com/PennyLaneAI/pennylane/pull/3911)
   [(#3930)](https://github.com/PennyLaneAI/pennylane/pull/3930)
-  [(#3936)](https://github.com/PennyLaneAI/pennylane/pull/3936/)
+  [(#3936)](https://github.com/PennyLaneAI/pennylane/pull/3936)
   [(#3966)](https://github.com/PennyLaneAI/pennylane/pull/3966)
   [(#3987)](https://github.com/PennyLaneAI/pennylane/pull/3987)
+  [(#4021)](https://github.com/PennyLaneAI/pennylane/pull/4021)
+
   * A new keyword argument called `max_distance` has been added to `qml.pulse.rydberg_interaction` to allow for the removal of negligible contributions
     from atoms beyond `max_distance` from each other.
     [(#3889)](https://github.com/PennyLaneAI/pennylane/pull/3889)

--- a/pennylane/_version.py
+++ b/pennylane/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.30.0-dev"
+__version__ = "0.30.0"

--- a/pennylane/_version.py
+++ b/pennylane/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.30.0"
+__version__ = "0.30.0-dev"

--- a/pennylane/pulse/__init__.py
+++ b/pennylane/pulse/__init__.py
@@ -71,7 +71,6 @@ Hardware Compatible Hamiltonians
     ~rydberg_drive
     ~transmon_interaction
     ~transmon_drive
-    ~drive
 
 
 Creating a parametrized Hamiltonian

--- a/pennylane/pulse/transmon.py
+++ b/pennylane/pulse/transmon.py
@@ -249,11 +249,11 @@ def transmon_drive(amplitude, phase, freq, wires, d=2):
 
     .. note:: Currently only supports ``d=2`` with qudit support planned in the future. For ``d=2`` we have :math:`a:=\frac{1}{2}(\sigma^x + i \sigma^y)`.
 
-    .. note:: Due to convention in the respective fields, we ommit the factor :math:`\frac{1}{2}` present in the related constructors :func:`~.drive` and :func:`~.rydberg_drive`
+    .. note:: Due to convention in the respective fields, we ommit the factor :math:`\frac{1}{2}` present in the related constructors :func:`~.rydberg_drive`
 
     .. seealso::
 
-        :func:`~.drive`, :func:`~.rydberg_drive`, :func:`~.transmon_interaction`
+        :func:`~.rydberg_drive`, :func:`~.transmon_interaction`
 
     Args:
         amplitude (Union[float, callable]): The amplitude :math:`\Omega(t)` (in GHz).

--- a/pennylane/pulse/transmon.py
+++ b/pennylane/pulse/transmon.py
@@ -249,7 +249,7 @@ def transmon_drive(amplitude, phase, freq, wires, d=2):
 
     .. note:: Currently only supports ``d=2`` with qudit support planned in the future. For ``d=2`` we have :math:`a:=\frac{1}{2}(\sigma^x + i \sigma^y)`.
 
-    .. note:: Due to convention in the respective fields, we ommit the factor :math:`\frac{1}{2}` present in the related constructors :func:`~.rydberg_drive`
+    .. note:: Due to convention in the respective fields, we ommit the factor :math:`\frac{1}{2}` present in the related constructor :func:`~.rydberg_drive`
 
     .. seealso::
 

--- a/pennylane/pulse/transmon.py
+++ b/pennylane/pulse/transmon.py
@@ -249,7 +249,7 @@ def transmon_drive(amplitude, phase, freq, wires, d=2):
 
     .. note:: Currently only supports ``d=2`` with qudit support planned in the future. For ``d=2`` we have :math:`a:=\frac{1}{2}(\sigma^x + i \sigma^y)`.
 
-    .. note:: Due to convention in the respective fields, we ommit the factor :math:`\frac{1}{2}` present in the related constructor :func:`~.rydberg_drive`
+    .. note:: Due to convention in the respective fields, we omit the factor :math:`\frac{1}{2}` present in the related constructor :func:`~.rydberg_drive`
 
     .. seealso::
 


### PR DESCRIPTION
Making `drive` non user-facing.
Pro:
- functionality already provided by `rydberg_drive` or `transmon_drive(amp, phase, 0, wires)`
- less maintenance

Con:
- one off extra work: for code quality it would make sense to remove the function alltogether and just have `rydberg_drive`
- lose the nice "theoretical background page that relates the Hamiltonians for different conventions / fields (though could still keep/move those in `rydberg_drive` and `transmon_drive`

Background:
Originally thought we could unify all drives because they are doing the same. While this is indeed the case, it makes sense to have different functions for different physical systems because conventions are different. I.e. for Rydberg atoms where all qubits have the same energy gap, it makes more sense to talk about detuning from that uniform energy gap (/frequency). For transmons that is not the case, and different qubits have different resonance frequencies. Hence the drive frequency is used explicitly.