### PR TITLE
`Operator` converts `tuple` to `np.ndarray`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -289,6 +289,8 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* `Operator` now casts `tuple` to `np.ndarray` as well as `list`. 
+
 * Fixes a bug where `qml.ctrl` for parametric gates were incompatible with PyTorch tensors on the GPU.
   [(#4002)](https://github.com/PennyLaneAI/pennylane/pull/4002)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -290,6 +290,7 @@
 <h3>Bug fixes 🐛</h3>
 
 * `Operator` now casts `tuple` to `np.ndarray` as well as `list`. 
+  [(#4022)](https://github.com/PennyLaneAI/pennylane/pull/4022)
 
 * Fixes a bug where `qml.ctrl` for parametric gates were incompatible with PyTorch tensors on the GPU.
   [(#4002)](https://github.com/PennyLaneAI/pennylane/pull/4002)

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -1001,7 +1001,7 @@ class Operator(abc.ABC):
 
         self._check_batching(params)
 
-        self.data = [np.array(p) if isinstance(p, list) else p for p in params]
+        self.data = [np.array(p) if isinstance(p, (list, tuple)) else p for p in params]
 
         if do_queue:
             self.queue()

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -190,7 +190,7 @@ class TestOperatorConstruction:
         assert isinstance(op.data[0], np.ndarray)
 
         op2 = DummyOp((1, 2, 3), wires=0)
-        assert isinstance(op.data[0], np.ndarray)
+        assert isinstance(op2.data[0], np.ndarray)
 
     def test_wires_by_final_argument(self):
         """Test that wires can be passed as the final positional argument."""


### PR DESCRIPTION
Currently, `Operator` converts tuples to `np.ndarray`  upon initialization:

```
>>> op = qml.BasisState([1,0], wires=(0,1))
>>> op.data
[array([1, 0])]
```

But it does not do the same thing with tuples. Somehow previously, operators like `BasisState` could accept tuples as their parameters, and at some point (we think in `Unwrap`), they got converted to the expected `np.ndarray`.  Since this no longer happens in `Unwrap`, we now explicitly convert tuples to numpy arrays as well.

Lightning tests used tuples, and thus expected this behaviour to still exist. Instead of changing those tests, I think it makes to continue accept tuples in addition to just lists.


Note: I moved some things around in `test_operation.py` so the tests would be a little bit better organized.