### PR TITLE
Reverse operation order in QSVT compute_matrix, update tests

### DIFF
--- a/pennylane/templates/subroutines/qsvt.py
+++ b/pennylane/templates/subroutines/qsvt.py
@@ -371,7 +371,7 @@ class QSVT(Operation):
                     op_list.append(adjoint(UA_copy))
 
             op_list.append(projectors[-1])
-            mat = qml.matrix(qml.prod(*tuple(op_list)))
+            mat = qml.matrix(qml.prod(*tuple(op_list[::-1])))
 
         return mat
 

--- a/tests/templates/test_subroutines/test_qsvt.py
+++ b/tests/templates/test_subroutines/test_qsvt.py
@@ -316,20 +316,20 @@ class Testqsvt:
                 [0.2, 0.3],
                 [0, 1],
                 # mathematical order of gates:
-                qml.matrix(qml.PCPhase(0.2, dim=2, wires=[0, 1]))@\
-                qml.matrix(qml.BlockEncode([[0.1, 0.2], [0.3, 0.4]], wires=[0, 1]))@\
-                qml.matrix(qml.PCPhase(0.3, dim=2, wires=[0, 1]))
+                qml.matrix(qml.PCPhase(0.2, dim=2, wires=[0, 1]))
+                @ qml.matrix(qml.BlockEncode([[0.1, 0.2], [0.3, 0.4]], wires=[0, 1]))
+                @ qml.matrix(qml.PCPhase(0.3, dim=2, wires=[0, 1])),
             ),
             (
                 [[0.3, 0.1], [0.2, 0.9]],
                 [0.1, 0.2, 0.3],
                 [0, 1],
                 # mathematical order of gates:
-                qml.matrix(qml.PCPhase(0.1, dim=2, wires=[0, 1]))@\
-                qml.matrix(qml.adjoint(qml.BlockEncode([[0.3, 0.1], [0.2, 0.9]], wires=[0, 1])))@\
-                qml.matrix(qml.PCPhase(0.2, dim=2, wires=[0, 1]))@\
-                qml.matrix(qml.BlockEncode([[0.3, 0.1], [0.2, 0.9]], wires=[0, 1]))@\
-                qml.matrix(qml.PCPhase(0.3, dim=2, wires=[0, 1]))
+                qml.matrix(qml.PCPhase(0.1, dim=2, wires=[0, 1]))
+                @ qml.matrix(qml.adjoint(qml.BlockEncode([[0.3, 0.1], [0.2, 0.9]], wires=[0, 1])))
+                @ qml.matrix(qml.PCPhase(0.2, dim=2, wires=[0, 1]))
+                @ qml.matrix(qml.BlockEncode([[0.3, 0.1], [0.2, 0.9]], wires=[0, 1]))
+                @ qml.matrix(qml.PCPhase(0.3, dim=2, wires=[0, 1])),
             ),
         ],
     )
@@ -441,7 +441,7 @@ class Testqsvt:
             qml.qsvt(
                 A,
                 phis,
-                wires=[0,1],
+                wires=[0, 1],
             )
             return qml.expval(qml.PauliZ(wires=0))
 


### PR DESCRIPTION
**Context:**
Calling `qml.matrix(qml.qsvt(*args))` gave the incorrect matrix.

**Description of the Change:**
Updated `qml.QSVT.compute_matrix` to use the equation operation order when computing the matrix.

**Benefits:**
QSVT now gives the correct matrix