### PR TITLE
Clarify `(Diagonal)QubitUnitary` docstrings regarding trainability

### DIFF
--- a/doc/releases/changelog-0.30.0.md
+++ b/doc/releases/changelog-0.30.0.md
@@ -341,6 +341,10 @@
 
 <h3>Documentation 📝</h3>
 
+* The documentation of `QubitUnitary` and `DiagonalQubitUnitary` was clarified regarding the
+  parameters of the operations.
+  [(#4031)](https://github.com/PennyLaneAI/pennylane/pull/4031)
+
 * A typo was corrected in the documentation for introduction to `inspecting_circuits` and `chemistry`.
   [(#3844)](https://github.com/PennyLaneAI/pennylane/pull/3844)
 

--- a/pennylane/ops/qubit/matrix_ops.py
+++ b/pennylane/ops/qubit/matrix_ops.py
@@ -76,15 +76,12 @@ class QubitUnitary(Operation):
     def __init__(
         self, U, wires, do_queue=True, id=None, unitary_check=False
     ):  # pylint: disable=too-many-arguments
-        # For pure QubitUnitary operations (not controlled), check that the number
-        # of wires fits the dimensions of the matrix
-
         wires = Wires(wires)
-
         U_shape = qml.math.shape(U)
-
         dim = 2 ** len(wires)
 
+        # For pure QubitUnitary operations (not controlled), check that the number
+        # of wires fits the dimensions of the matrix
         if len(U_shape) not in {2, 3} or U_shape[-2:] != (dim, dim):
             raise ValueError(
                 f"Input unitary must be of shape {(dim, dim)} or (batch_size, {dim}, {dim}) "

--- a/pennylane/ops/qubit/matrix_ops.py
+++ b/pennylane/ops/qubit/matrix_ops.py
@@ -29,7 +29,7 @@ from pennylane.wires import Wires
 
 class QubitUnitary(Operation):
     r"""QubitUnitary(U, wires)
-    Apply an arbitrary fixed unitary matrix.
+    Apply an arbitrary unitary matrix with a dimension that is a power of two.
 
     **Details:**
 
@@ -200,7 +200,7 @@ class QubitUnitary(Operation):
 
 class DiagonalQubitUnitary(Operation):
     r"""DiagonalQubitUnitary(D, wires)
-    Apply an arbitrary fixed diagonal unitary matrix.
+    Apply an arbitrary diagonal unitary matrix with a dimension that is a power of two.
 
     **Details:**
 


### PR DESCRIPTION
This PR slightly modifies the initial lines of the docstrings of `DiagonalQubitUnitary` and `QubitUnitary` in order to clarify that their inputs actually are trainable, and not fixed.