### PR TITLE
Fix tensors multiplying Hamiltonians

### DIFF
--- a/doc/releases/changelog-0.30.0.md
+++ b/doc/releases/changelog-0.30.0.md
@@ -430,6 +430,7 @@
   [(#3985)](https://github.com/PennyLaneAI/pennylane/pull/3985)
 
 * Fixes a bug when a Tensor is multiplied by a Hamiltonian or a Hamiltonian is multipled by a Tensor.
+  [(#4036)](https://github.com/PennyLaneAI/pennylane/pull/4036)
 
 <h3>Contributors ✍️</h3>
 

--- a/doc/releases/changelog-0.30.0.md
+++ b/doc/releases/changelog-0.30.0.md
@@ -429,6 +429,8 @@
   it in their respective `map_wires` methods if they have a Pauli rep.
   [(#3985)](https://github.com/PennyLaneAI/pennylane/pull/3985)
 
+* Fixes a bug when a Tensor is multiplied by a Hamiltonian or a Hamiltonian is multipled by a Tensor.
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -2094,6 +2094,9 @@ class Tensor(Observable):
         return 1 + max(o.arithmetic_depth for o in self.obs)
 
     def __matmul__(self, other):
+        if isinstance(other, qml.Hamiltonian):
+            return other.__rmatmul__(self)
+
         if isinstance(other, Tensor):
             self.obs.extend(other.obs)
 

--- a/pennylane/ops/qubit/hamiltonian.py
+++ b/pennylane/ops/qubit/hamiltonian.py
@@ -633,7 +633,7 @@ class Hamiltonian(Observable):
             return qml.Hamiltonian(coeffs, terms, simplify=True)
 
         if isinstance(H, (Tensor, Observable)):
-            terms = [op @ H for op in ops1]
+            terms = [op @ copy(H) for op in ops1]
 
             return qml.Hamiltonian(coeffs1, terms, simplify=True)
 
@@ -650,7 +650,7 @@ class Hamiltonian(Observable):
         ops1 = self.ops.copy()
 
         if isinstance(H, (Tensor, Observable)):
-            terms = [H @ op for op in ops1]
+            terms = [copy(H) @ op for op in ops1]
 
             return qml.Hamiltonian(coeffs1, terms, simplify=True)
 

--- a/tests/ops/qubit/test_hamiltonian.py
+++ b/tests/ops/qubit/test_hamiltonian.py
@@ -806,7 +806,7 @@ class TestHamiltonian:
         """Tests that Hamiltonians are subtracted correctly"""
         assert H.compare(H1 - H2)
 
-    def test_hamiltonian_tenosr_matmul(self):
+    def test_hamiltonian_tensor_matmul(self):
         """Tests that a hamiltonian can be multiplied by a tensor."""
         H = qml.PauliX(0) + qml.PauliY(0)
         t = qml.PauliZ(1) @ qml.PauliZ(2)

--- a/tests/ops/qubit/test_hamiltonian.py
+++ b/tests/ops/qubit/test_hamiltonian.py
@@ -806,6 +806,21 @@ class TestHamiltonian:
         """Tests that Hamiltonians are subtracted correctly"""
         assert H.compare(H1 - H2)
 
+    def test_hamiltonian_tenosr_matmul(self):
+        """Tests that a hamiltonian can be multiplied by a tensor."""
+        H = qml.PauliX(0) + qml.PauliY(0)
+        t = qml.PauliZ(1) @ qml.PauliZ(2)
+        out = H @ t
+
+        expected = qml.Hamiltonian(
+            [1, 1],
+            [
+                qml.PauliX(0) @ qml.PauliZ(1) @ qml.PauliZ(2),
+                qml.PauliY(0) @ qml.PauliZ(1) @ qml.PauliZ(2),
+            ],
+        )
+        assert qml.equal(out, expected)
+
     @pytest.mark.parametrize(("H1", "H2", "H"), matmul_hamiltonians)
     def test_hamiltonian_matmul(self, H1, H2, H):
         """Tests that Hamiltonians are tensored correctly"""

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -1424,6 +1424,21 @@ class TestTensor:
         assert isinstance(t, Tensor)
         assert t.obs == [Z, H, X, Y]
 
+    def test_multiply_tensor_hamiltonian(self):
+        """Test that a tensor can be multiplied by a hamiltonian."""
+        H = qml.PauliX(0) + qml.PauliY(0)
+        t = qml.PauliZ(1) @ qml.PauliZ(2)
+        out = t @ H
+
+        expected = qml.Hamiltonian(
+            [1, 1],
+            [
+                qml.PauliZ(1) @ qml.PauliZ(2) @ qml.PauliX(0),
+                qml.PauliZ(1) @ qml.PauliZ(2) @ qml.PauliY(0),
+            ],
+        )
+        assert qml.equal(out, expected)
+
     def test_multiply_tensor_in_place(self):
         """Test that multiplying a tensor in-place
         produces a tensor"""


### PR DESCRIPTION
Currently we have:
```
>>> H = qml.PauliX(0) + qml.PauliY(0)
>>> t = qml.PauliZ(1) @ qml.PauliZ(2)
>>> H @ t
 (2) [Y0 X0 Z1 Z2]
>>> t @ H
PauliY(wires=[0]) @ PauliX(wires=[0]) @ PauliZ(wires=[1]) @ PauliZ(wires=[2]) @ <Hamiltonian: terms=2, wires=[0]>
```

Which are both wrong. 

This PR makes it so the above will be correct. The lightning tests were expecting to be able to multiply tensors and hamiltonians, so this PR is necessary to get their tests passing.