### PR TITLE
Remove fancy ctrl decomps

### DIFF
--- a/doc/releases/changelog-0.30.0.md
+++ b/doc/releases/changelog-0.30.0.md
@@ -220,7 +220,7 @@
       with qml.QueuingManager.stop_recording():
           # the decomposition does not un-queue the target
           target = qml.RX(np.pi/2, wires=0)
-      qml.ops.ctrl_decomp_bisect(target, (1,2,3,4,5))
+      qml.ops.ctrl_decomp_bisect(target, (1, 2, 3, 4, 5))
       return qml.state()
 
   print(qml.draw(circuit, expansion_strategy="device")())
@@ -630,6 +630,7 @@ Nothing for this release!
 
 * `ctrl_decomp_bisect` and `ctrl_decomp_zyz` are no longer used by default when decomposing
   controlled operations due to the presence of a global phase difference in the zyz decomposition of some target operators.
+  [(#4065)](https://github.com/PennyLaneAI/pennylane/pull/4065)
 
 * Fixed a bug where `qml.math.dot` returned a numpy array instead of an autograd array, breaking autograd derivatives
   in certain circumstances.

--- a/doc/releases/changelog-0.30.0.md
+++ b/doc/releases/changelog-0.30.0.md
@@ -635,6 +635,9 @@ Nothing for this release!
 
 <h3>Bug fixes 🐛</h3>
 
+* `ctrl_decomp_bisect` and `ctrl_decomp_zyz` are no longer used by default when decomposing
+  controlled operations due to the presence of a global phase difference in the zyz decomposition of some target operators.
+
 * Fixed a bug where `qml.math.dot` returned a numpy array instead of an autograd array, breaking autograd derivatives
   in certain circumstances.
   [(#4019)](https://github.com/PennyLaneAI/pennylane/pull/4019)

--- a/pennylane/ops/op_math/controlled.py
+++ b/pennylane/ops/op_math/controlled.py
@@ -30,10 +30,6 @@ from pennylane.operation import Operator
 from pennylane.wires import Wires
 
 from .symbolicop import SymbolicOp
-from .controlled_decompositions import (
-    ctrl_decomp_zyz,
-    ctrl_decomp_bisect,
-)
 
 
 def ctrl(op, control, control_values=None, work_wires=None):
@@ -478,8 +474,8 @@ class Controlled(SymbolicOp):
             return True
         if isinstance(self.base, qml.PauliX):
             return True
-        if len(self.base.wires) == 1 and getattr(self.base, "has_matrix", False):
-            return True
+        # if len(self.base.wires) == 1 and getattr(self.base, "has_matrix", False):
+        #    return True
         if self.base.has_decomposition:
             return True
 
@@ -572,16 +568,16 @@ def _decompose_no_control_values(op: "operation.Operator") -> List["operation.Op
     if isinstance(op.base, qml.PauliX):
         # has some special case handling of its own for further decomposition
         return [qml.MultiControlledX(wires=op.active_wires, work_wires=op.work_wires)]
-    if (
-        len(op.base.wires) == 1
-        and len(op.control_wires) >= 2
-        and getattr(op.base, "has_matrix", False)
-        and qmlmath.get_interface(*op.data) == "numpy"  # as implemented, not differentiable
-    ):
-        # Bisect algorithms use CNOTs and single qubit unitary
-        return ctrl_decomp_bisect(op.base, op.control_wires)
-    if len(op.base.wires) == 1 and getattr(op.base, "has_matrix", False):
-        return ctrl_decomp_zyz(op.base, op.control_wires)
+    # if (
+    #    len(op.base.wires) == 1
+    #    and len(op.control_wires) >= 2
+    #    and getattr(op.base, "has_matrix", False)
+    #    and qmlmath.get_interface(*op.data) == "numpy"  # as implemented, not differentiable
+    # ):
+    # Bisect algorithms use CNOTs and single qubit unitary
+    #    return ctrl_decomp_bisect(op.base, op.control_wires)
+    # if len(op.base.wires) == 1 and getattr(op.base, "has_matrix", False):
+    #    return ctrl_decomp_zyz(op.base, op.control_wires)
 
     if not op.base.has_decomposition:
         return None

--- a/tests/ops/op_math/test_controlled.py
+++ b/tests/ops/op_math/test_controlled.py
@@ -1520,6 +1520,7 @@ def test_qubit_unitary(M):
     assert not equal_list(list(tape), expected)
 
 
+@pytest.mark.xfail
 @pytest.mark.parametrize(
     "M",
     [

--- a/tests/ops/op_math/test_controlled_decompositions.py
+++ b/tests/ops/op_math/test_controlled_decompositions.py
@@ -201,6 +201,7 @@ class TestControlledDecompositionZYZ:
         assert len(decomp) == 5
         assert all(qml.equal(o, e) for o, e in zip(decomp, expected))
 
+    @pytest.mark.xfail
     @pytest.mark.parametrize("test_expand", [False, True])
     def test_zyz_decomp_no_control_values(self, test_expand):
         """Test that the ZYZ decomposition is used for single qubit target operations
@@ -225,6 +226,7 @@ class TestControlledDecompositionZYZ:
         expected = qml.ops.ctrl_decomp_zyz(base, (0,))
         assert equal_list(decomp, expected)
 
+    @pytest.mark.xfail
     @pytest.mark.parametrize("test_expand", [False, True])
     def test_zyz_decomp_control_values(self, test_expand):
         """Test that the ZYZ decomposition is used for single qubit target operations
@@ -627,6 +629,7 @@ class TestControlledBisectGeneral:
         expected = expected_circuit()
         assert np.allclose(res, expected, atol=tol, rtol=tol)
 
+    @pytest.mark.xfail
     @pytest.mark.parametrize("op", zip(gen_ops, gen_ops_best))
     @pytest.mark.parametrize("control_wires", cw5)
     @pytest.mark.parametrize("all_the_way_from_ctrl", [False, True])


### PR DESCRIPTION
Due to a problem found by @KetpuntoG in comparing default qubit and lightning:
```
import pennylane as qml

dev = qml.device("lightning.qubit", wires = 2)

@qml.qnode(dev)
def circuit():
  qml.Hadamard(wires = 0)
  qml.QuantumPhaseEstimation(qml.matrix(qml.Hadamard)(wires = 0), [0], [1])
  return qml.probs(wires = [0,1])

circuit()
```

We discovered that the global phase ignored by the new decompositions does in fact change the results in certain situations.

Therefore as a quick fix before the release, we are turning off the fancy decompositions. When we have a way to handle the global phase, we can add it back in.