### PR TITLE
bump lightning version to 0.30

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ requirements = [
     "semantic-version>=2.7",
     "autoray>=0.3.1",
     "cachetools",
-    "pennylane-lightning>=0.28",
+    "pennylane-lightning>=0.30",
     "requests",
 ]
 


### PR DESCRIPTION
This PR bumps the required lightning version to v0.30.

This will not work until the lightning wheels have been uploaded to PyPI. Once that happens, this PR can be merged.  Then we can create the PL release.