### PR TITLE
Add sample measurement function for new device API

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -21,6 +21,9 @@
 * `qml.prod` now accepts a single qfunc input for creating new `Prod` operators.
   [(#4011)](https://github.com/PennyLaneAI/pennylane/pull/4011)
 
+* Added a function `measure_with_samples` that returns a sample-based measurement result given a state
+  [(#4083)](https://github.com/PennyLaneAI/pennylane/pull/4083)
+
 <h3>Breaking changes 💔</h3>
 
 * `pennylane.collections`, `pennylane.op_sum`, and `pennylane.utils.sparse_hamiltonian` are removed.

--- a/pennylane/devices/qubit/__init__.py
+++ b/pennylane/devices/qubit/__init__.py
@@ -34,5 +34,5 @@ from .adjoint_jacobian import adjoint_jacobian
 from .initialize_state import create_initial_state
 from .measure import measure
 from .preprocess import preprocess
-from .sampling import sample_state
+from .sampling import sample_state, measure_with_samples
 from .simulate import simulate

--- a/pennylane/devices/qubit/sampling.py
+++ b/pennylane/devices/qubit/sampling.py
@@ -15,6 +15,34 @@
 
 import pennylane as qml
 from pennylane import numpy as np
+from pennylane.measurements import SampleMeasurement, Shots
+from pennylane.typing import TensorLike
+from .apply_operation import apply_operation
+
+
+def measure_with_samples(mp: SampleMeasurement,
+    state: np.ndarray,
+    shots: qml.measurements.Shots,
+    rng=None
+) -> TensorLike:
+
+    # apply diagonalizing gates
+    pre_rotated_state = state
+    for op in mp.diagonalizing_gates():
+        pre_rotated_state = apply_operation(op, pre_rotated_state)
+
+    # we don't need to worry about shot vectors for now
+    # if shots.has_partitioned_shots:
+    #     processed_samples = []
+    #     for shot_copies in shots.shot_vector:
+    #         for _ in range(shot_copies.copies):
+    #             samples = sample_state(pre_rotated_state, shot_copies.shots, rng=rng)
+    #             processed_samples.append(mp.process_samples(samples, wire_order))
+
+    #     return tuple(processed_samples)
+
+    samples = sample_state(pre_rotated_state, shots=shots, wires=mp.wires, rng=rng)
+    return mp.process_samples(samples, mp.wires)
 
 
 def sample_state(state, shots: int, wires=None, rng=None) -> np.ndarray:

--- a/pennylane/devices/qubit/sampling.py
+++ b/pennylane/devices/qubit/sampling.py
@@ -20,12 +20,9 @@ from pennylane.typing import TensorLike
 from .apply_operation import apply_operation
 
 
-def measure_with_samples(mp: SampleMeasurement,
-    state: np.ndarray,
-    shots: qml.measurements.Shots,
-    rng=None
+def measure_with_samples(
+    mp: SampleMeasurement, state: np.ndarray, shots: qml.measurements.Shots, rng=None
 ) -> TensorLike:
-
     # apply diagonalizing gates
     pre_rotated_state = state
     for op in mp.diagonalizing_gates():

--- a/pennylane/devices/qubit/sampling.py
+++ b/pennylane/devices/qubit/sampling.py
@@ -52,7 +52,7 @@ def measure_with_samples(
 
     #     return tuple(processed_samples)
 
-    samples = sample_state(pre_rotated_state, shots=shots, wires=mp.wires, rng=rng)
+    samples = sample_state(pre_rotated_state, shots=shots.total_shots, wires=mp.wires, rng=rng)
     return mp.process_samples(samples, mp.wires)
 
 

--- a/pennylane/devices/qubit/sampling.py
+++ b/pennylane/devices/qubit/sampling.py
@@ -21,8 +21,22 @@ from .apply_operation import apply_operation
 
 
 def measure_with_samples(
-    mp: SampleMeasurement, state: np.ndarray, shots: qml.measurements.Shots, rng=None
+    mp: SampleMeasurement, state: np.ndarray, shots: Shots, rng=None
 ) -> TensorLike:
+    """
+    Returns the samples of the measurement process performed on the given state.
+
+    Args:
+        mp (~.measurements.SampleMeasurement): The sample measurement to perform
+        state (np.ndarray[complex]): The state vector to sample from
+        shots (~.measurements.Shots): The number of samples to take
+        rng (Union[None, int, array_like[int], SeedSequence, BitGenerator, Generator]): A
+            seed-like parameter matching that of ``seed`` for ``numpy.random.default_rng``.
+            If no value is provided, a default RNG will be used.
+
+    Returns:
+        TensorLike[Any]: Sample measurement results
+    """
     # apply diagonalizing gates
     pre_rotated_state = state
     for op in mp.diagonalizing_gates():

--- a/tests/devices/qubit/test_sampling.py
+++ b/tests/devices/qubit/test_sampling.py
@@ -19,7 +19,6 @@ import pytest
 import pennylane as qml
 from pennylane import numpy as np
 from pennylane.devices.qubit import sample_state, measure_with_samples
-from pennylane.measurements import SampleMP, ProbabilityMP, ExpectationMP
 
 two_qubit_state = np.array([[0, 1j], [-1, 0]]) / np.sqrt(2)
 APPROX_ATOL = 0.01
@@ -39,6 +38,7 @@ def fixture_init_state():
 
 
 def samples_to_probs(samples, num_wires):
+    """Converts samples to probs"""
     samples_decimal = [np.ravel_multi_index(sample, [2] * num_wires) for sample in samples]
     counts = [0] * (2**num_wires)
 
@@ -132,7 +132,6 @@ class TestMeasureSamples:
         """Test that a sample measurement works as expected"""
         state = qml.math.array(two_qubit_state)
         shots = 100
-        wire_order = qml.wires.Wires(range(2))
         mp = qml.sample(wires=range(2))
 
         result = measure_with_samples(mp, state, shots=shots)
@@ -154,7 +153,7 @@ class TestMeasureSamples:
 
         assert result0.shape == (shots, 1)
         assert result0.dtype == np.bool8
-        assert np.all(result0 == False)
+        assert np.all(result0 == 0)
 
         assert result1.shape == (shots, 1)
         assert result1.dtype == np.bool8
@@ -164,7 +163,6 @@ class TestMeasureSamples:
         """Test that a probability measurement works as expected"""
         state = qml.math.array(two_qubit_state)
         shots = 100
-        wire_order = qml.wires.Wires(range(2))
         mp = qml.probs(wires=range(2))
 
         result = measure_with_samples(mp, state, shots=shots)
@@ -198,7 +196,6 @@ class TestMeasureSamples:
         """Test that an expval measurement works as expected"""
         state = qml.math.array(two_qubit_state)
         shots = 100
-        wire_order = qml.wires.Wires(range(2))
         mp = qml.expval(qml.prod(qml.PauliX(0), qml.PauliY(1)))
 
         result = measure_with_samples(mp, state, shots=shots)
@@ -226,7 +223,6 @@ class TestMeasureSamples:
         """Test that a sample measurement returns approximately the correct distribution"""
         state = qml.math.array(two_qubit_state)
         shots = 10000
-        wire_order = qml.wires.Wires(range(2))
         mp = qml.sample(wires=range(2))
 
         result = measure_with_samples(mp, state, shots=shots)
@@ -238,7 +234,6 @@ class TestMeasureSamples:
         """Test that a probability measurement works as expected"""
         state = qml.math.array(two_qubit_state)
         shots = 10000
-        wire_order = qml.wires.Wires(range(2))
         mp = qml.probs(wires=range(2))
 
         result = measure_with_samples(mp, state, shots=shots)
@@ -251,7 +246,6 @@ class TestMeasureSamples:
         """Test that an expval measurement works as expected"""
         state = qml.math.array(two_qubit_state)
         shots = 10000
-        wire_order = qml.wires.Wires(range(2))
         mp = qml.expval(qml.prod(qml.PauliX(0), qml.PauliX(1)))
 
         result = measure_with_samples(mp, state, shots=shots)

--- a/tests/devices/qubit/test_sampling.py
+++ b/tests/devices/qubit/test_sampling.py
@@ -131,7 +131,7 @@ class TestMeasureSamples:
     def test_sample_measure(self):
         """Test that a sample measurement works as expected"""
         state = qml.math.array(two_qubit_state)
-        shots = 100
+        shots = qml.measurements.Shots(100)
         mp = qml.sample(wires=range(2))
 
         result = measure_with_samples(mp, state, shots=shots)
@@ -143,7 +143,7 @@ class TestMeasureSamples:
     def test_sample_measure_single_wire(self):
         """Test that a sample measurement on a single wire works as expected"""
         state = np.array([[1, -1j], [0, 0]]) / np.sqrt(2)
-        shots = 100
+        shots = qml.measurements.Shots(100)
 
         mp0 = qml.sample(wires=0)
         mp1 = qml.sample(wires=1)
@@ -162,7 +162,7 @@ class TestMeasureSamples:
     def test_prob_measure(self):
         """Test that a probability measurement works as expected"""
         state = qml.math.array(two_qubit_state)
-        shots = 100
+        shots = qml.measurements.Shots(100)
         mp = qml.probs(wires=range(2))
 
         result = measure_with_samples(mp, state, shots=shots)
@@ -175,7 +175,7 @@ class TestMeasureSamples:
     def test_prob_measure_single_wire(self):
         """Test that a probability measurement on a single wire works as expected"""
         state = np.array([[1, -1j], [0, 0]]) / np.sqrt(2)
-        shots = 100
+        shots = qml.measurements.Shots(100)
 
         mp0 = qml.probs(wires=0)
         mp1 = qml.probs(wires=1)
@@ -195,7 +195,7 @@ class TestMeasureSamples:
     def test_expval_measure(self):
         """Test that an expval measurement works as expected"""
         state = qml.math.array(two_qubit_state)
-        shots = 100
+        shots = qml.measurements.Shots(100)
         mp = qml.expval(qml.prod(qml.PauliX(0), qml.PauliY(1)))
 
         result = measure_with_samples(mp, state, shots=shots)
@@ -206,7 +206,7 @@ class TestMeasureSamples:
     def test_expval_measure_single_wire(self):
         """Test that an expval measurement on a single wire works as expected"""
         state = np.array([[1, -1j], [0, 0]]) / np.sqrt(2)
-        shots = 100
+        shots = qml.measurements.Shots(100)
 
         mp0 = qml.expval(qml.PauliZ(0))
         mp1 = qml.expval(qml.PauliY(1))
@@ -222,7 +222,7 @@ class TestMeasureSamples:
     def test_approximate_sample_measure(self):
         """Test that a sample measurement returns approximately the correct distribution"""
         state = qml.math.array(two_qubit_state)
-        shots = 10000
+        shots = qml.measurements.Shots(10000)
         mp = qml.sample(wires=range(2))
 
         result = measure_with_samples(mp, state, shots=shots)
@@ -233,7 +233,7 @@ class TestMeasureSamples:
     def test_approximate_prob_measure(self):
         """Test that a probability measurement works as expected"""
         state = qml.math.array(two_qubit_state)
-        shots = 10000
+        shots = qml.measurements.Shots(10000)
         mp = qml.probs(wires=range(2))
 
         result = measure_with_samples(mp, state, shots=shots)
@@ -245,7 +245,7 @@ class TestMeasureSamples:
     def test_approximate_expval_measure(self):
         """Test that an expval measurement works as expected"""
         state = qml.math.array(two_qubit_state)
-        shots = 10000
+        shots = qml.measurements.Shots(10000)
         mp = qml.expval(qml.prod(qml.PauliX(0), qml.PauliX(1)))
 
         result = measure_with_samples(mp, state, shots=shots)

--- a/tests/devices/qubit/test_sampling.py
+++ b/tests/devices/qubit/test_sampling.py
@@ -142,7 +142,7 @@ class TestMeasureSamples:
         assert all(qml.math.allequal(s, [0, 1]) or qml.math.allequal(s, [1, 0]) for s in result)
 
     def test_sample_measure_single_wire(self):
-        """Test that a sample measurement on a single wire works as expected """
+        """Test that a sample measurement on a single wire works as expected"""
         state = np.array([[1, -1j], [0, 0]]) / np.sqrt(2)
         shots = 100
 

--- a/tests/devices/qubit/test_sampling.py
+++ b/tests/devices/qubit/test_sampling.py
@@ -18,7 +18,8 @@ import pytest
 
 import pennylane as qml
 from pennylane import numpy as np
-from pennylane.devices.qubit import sample_state
+from pennylane.devices.qubit import sample_state, measure_with_samples
+from pennylane.measurements import SampleMP, ProbabilityMP, ExpectationMP
 
 two_qubit_state = np.array([[0, 1j], [-1, 0]]) / np.sqrt(2)
 APPROX_ATOL = 0.01
@@ -47,80 +48,114 @@ def samples_to_probs(samples, num_wires):
     return np.array(counts, dtype=np.float64) / len(samples)
 
 
-@pytest.mark.all_interfaces
-@pytest.mark.parametrize("interface", ["numpy", "jax", "torch", "tensorflow"])
-def test_sample_state_basic(interface):
-    """Tests that the returned samples are as expected."""
-    state = qml.math.array(two_qubit_state, like=interface)
-    samples = sample_state(state, 10)
-    assert samples.shape == (10, 2)
-    assert samples.dtype == np.bool8
-    assert all(qml.math.allequal(s, [0, 1]) or qml.math.allequal(s, [1, 0]) for s in samples)
+class TestSampleState:
+    """Test that the sample_state function works as expected"""
+
+    @pytest.mark.all_interfaces
+    @pytest.mark.parametrize("interface", ["numpy", "jax", "torch", "tensorflow"])
+    def test_sample_state_basic(self, interface):
+        """Tests that the returned samples are as expected."""
+        state = qml.math.array(two_qubit_state, like=interface)
+        samples = sample_state(state, 10)
+        assert samples.shape == (10, 2)
+        assert samples.dtype == np.bool8
+        assert all(qml.math.allequal(s, [0, 1]) or qml.math.allequal(s, [1, 0]) for s in samples)
+
+    @pytest.mark.parametrize("wire_order", [[2], [2, 0], [0, 2, 1]])
+    def test_marginal_sample_state(self, wire_order):
+        """Tests that marginal states can be sampled as expected."""
+        state = np.zeros((2, 2, 2))
+        state[:, :, 1] = 0.5  # third wire is always 1
+        alltrue_axis = wire_order.index(2)
+
+        samples = sample_state(state, 20, wires=wire_order)
+        assert all(samples[:, alltrue_axis])
+
+    def test_sample_state_custom_rng(self):
+        """Tests that a custom RNG can be used with sample_state."""
+        custom_rng = np.random.default_rng(12345)
+        samples = sample_state(two_qubit_state, 4, rng=custom_rng)
+        expected = [[0, 1], [0, 1], [1, 0], [1, 0]]
+        assert qml.math.allequal(samples, expected)
+
+    def test_approximate_probs_from_samples(self, init_state):
+        """Tests that the generated samples are approximately as expected."""
+        n = 4
+        shots = 20000
+        state = init_state(n)
+
+        flat_state = state.flatten()
+        expected_probs = np.real(flat_state) ** 2 + np.imag(flat_state) ** 2
+
+        samples = sample_state(state, shots)
+        approx_probs = samples_to_probs(samples, n)
+        assert np.allclose(approx_probs, expected_probs, atol=APPROX_ATOL)
+
+    def test_entangled_qubit_samples_always_match(self):
+        """Tests that entangled qubits are always in the same state."""
+        bell_state = np.array([[1, 0], [0, 1]]) / np.sqrt(2)
+        samples = sample_state(bell_state, 1000)
+        assert samples.shape == (1000, 2)
+        assert not any(samples[:, 0] ^ samples[:, 1])  # all samples are entangled
+        assert not all(samples[:, 0])  # some samples are |00>
+        assert any(samples[:, 0])  # ...and some are |11>!
+
+    @pytest.mark.slow
+    @pytest.mark.parametrize("num_wires", [13, 14, 15, 16])
+    def test_sample_state_many_wires(self, num_wires):
+        """Tests that sample_state works as expected with many wires, and with re-ordering."""
+        shots = 10000
+        shape = (2,) * num_wires
+        flat_state = np.arange(1, 2**num_wires + 1, dtype=np.float64)
+        original_norm = np.linalg.norm(flat_state)
+        flat_state /= original_norm
+        state = flat_state.reshape(shape)
+        expected_probs = np.real(flat_state) ** 2 + np.imag(flat_state) ** 2
+
+        ordered_samples = sample_state(state, shots)
+        ordered_probs = samples_to_probs(ordered_samples, num_wires)
+        assert np.allclose(ordered_probs, expected_probs, atol=APPROX_ATOL)
+
+        random_wires = list(range(num_wires))
+        shuffle(random_wires)
+        random_samples = sample_state(state, shots, wires=random_wires)
+        random_probs = samples_to_probs(random_samples, num_wires)
+
+        reordered_probs = ordered_probs.reshape(shape).transpose(random_wires).flatten()
+        assert np.allclose(reordered_probs, random_probs, atol=APPROX_ATOL)
 
 
-@pytest.mark.parametrize("wire_order", [[2], [2, 0], [0, 2, 1]])
-def test_marginal_sample_state(wire_order):
-    """Tests that marginal states can be sampled as expected."""
-    state = np.zeros((2, 2, 2))
-    state[:, :, 1] = 0.5  # third wire is always 1
-    alltrue_axis = wire_order.index(2)
+class TestMeasureSamples:
+    """Test that the measure_with_samples function works as expected"""
 
-    samples = sample_state(state, 20, wires=wire_order)
-    assert all(samples[:, alltrue_axis])
+    def test_sample_measure(self):
+        """Test that a sample measurement works as expected"""
+        state = qml.math.array(two_qubit_state)
+        shots = 100
+        wire_order = qml.wires.Wires(range(2))
+        mp = qml.sample(wires=range(2))
 
+        result = measure_with_samples(mp, state, shots=shots)
 
-def test_sample_state_custom_rng():
-    """Tests that a custom RNG can be used with sample_state."""
-    custom_rng = np.random.default_rng(12345)
-    samples = sample_state(two_qubit_state, 4, rng=custom_rng)
-    expected = [[0, 1], [0, 1], [1, 0], [1, 0]]
-    assert qml.math.allequal(samples, expected)
+        assert result.shape == (shots, 2)
+        assert result.dtype == np.bool8
+        assert all(qml.math.allequal(s, [0, 1]) or qml.math.allequal(s, [1, 0]) for s in result)
 
+    def test_sample_measure_single_wire(self):
+        """Test that a sample measurement on a single wire works as expected """
+        state = np.array([[1, -1j], [0, 0]]) / np.sqrt(2)
+        shots = 100
 
-def test_approximate_probs_from_samples(init_state):
-    """Tests that the generated samples are approximately as expected."""
-    n = 4
-    shots = 20000
-    state = init_state(n)
+        mp0 = qml.sample(wires=0)
+        mp1 = qml.sample(wires=1)
 
-    flat_state = state.flatten()
-    expected_probs = np.real(flat_state) ** 2 + np.imag(flat_state) ** 2
+        result0 = measure_with_samples(mp0, state, shots=shots)
+        result1 = measure_with_samples(mp1, state, shots=shots)
 
-    samples = sample_state(state, shots)
-    approx_probs = samples_to_probs(samples, n)
-    assert np.allclose(approx_probs, expected_probs, atol=APPROX_ATOL)
+        assert result0.shape == (shots, 1)
+        assert result0.dtype == np.bool8
+        assert np.all(result0 == False)
 
-
-def test_entangled_qubit_samples_always_match():
-    """Tests that entangled qubits are always in the same state."""
-    bell_state = np.array([[1, 0], [0, 1]]) / np.sqrt(2)
-    samples = sample_state(bell_state, 1000)
-    assert samples.shape == (1000, 2)
-    assert not any(samples[:, 0] ^ samples[:, 1])  # all samples are entangled
-    assert not all(samples[:, 0])  # some samples are |00>
-    assert any(samples[:, 0])  # ...and some are |11>!
-
-
-@pytest.mark.slow
-@pytest.mark.parametrize("num_wires", [13, 14, 15, 16])
-def test_sample_state_many_wires(num_wires):
-    """Tests that sample_state works as expected with many wires, and with re-ordering."""
-    shots = 10000
-    shape = (2,) * num_wires
-    flat_state = np.arange(1, 2**num_wires + 1, dtype=np.float64)
-    original_norm = np.linalg.norm(flat_state)
-    flat_state /= original_norm
-    state = flat_state.reshape(shape)
-    expected_probs = np.real(flat_state) ** 2 + np.imag(flat_state) ** 2
-
-    ordered_samples = sample_state(state, shots)
-    ordered_probs = samples_to_probs(ordered_samples, num_wires)
-    assert np.allclose(ordered_probs, expected_probs, atol=APPROX_ATOL)
-
-    random_wires = list(range(num_wires))
-    shuffle(random_wires)
-    random_samples = sample_state(state, shots, wires=random_wires)
-    random_probs = samples_to_probs(random_samples, num_wires)
-
-    reordered_probs = ordered_probs.reshape(shape).transpose(random_wires).flatten()
-    assert np.allclose(reordered_probs, random_probs, atol=APPROX_ATOL)
+        assert result1.shape == (shots, 1)
+        assert result1.dtype == np.bool8
+        assert len(np.unique(result1)) == 2

--- a/tests/devices/qubit/test_sampling.py
+++ b/tests/devices/qubit/test_sampling.py
@@ -136,7 +136,7 @@ class TestMeasureSamples:
 
         result = measure_with_samples(mp, state, shots=shots)
 
-        assert result.shape == (shots, 2)
+        assert result.shape == (shots.total_shots, 2)
         assert result.dtype == np.bool8
         assert all(qml.math.allequal(s, [0, 1]) or qml.math.allequal(s, [1, 0]) for s in result)
 
@@ -151,11 +151,11 @@ class TestMeasureSamples:
         result0 = measure_with_samples(mp0, state, shots=shots)
         result1 = measure_with_samples(mp1, state, shots=shots)
 
-        assert result0.shape == (shots, 1)
+        assert result0.shape == (shots.total_shots, 1)
         assert result0.dtype == np.bool8
         assert np.all(result0 == 0)
 
-        assert result1.shape == (shots, 1)
+        assert result1.shape == (shots.total_shots, 1)
         assert result1.dtype == np.bool8
         assert len(np.unique(result1)) == 2
 


### PR DESCRIPTION
**Context:**
Part of the effort to integrate the new device API.

**Description of the Change:**
Add a new function in `devices/qubit/sampling.py` that takes as input a `SampleMeasurement` and a state, and returns the result of that measurement.

**Benefits:**
This function can be called from `simulate()` to get the sample measurement results.

**Possible Drawbacks:**
None
