### PR TITLE
Bump requests version

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -32,7 +32,7 @@ torchvision==0.12.0; sys_platform == "darwin" and python_version == "3.10"
 jinja2==3.0.3
 rustworkx==0.12.1
 networkx==2.6
-requests~=2.28.1
+requests~=2.30.0
 # we do not pin the sphinx theme, to allow the
 # navbar and header data to be updated at the source
 pennylane-sphinx-theme

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,4 +6,4 @@ pytest-xdist>=2.5.0
 flaky>=3.7.0
 pytest-forked>=1.4.0
 black>=21
-requests~=2.28.1
+requests~=2.30.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ dask[delayed]~=2022.4.1
 autoray==0.3.1
 matplotlib~=3.5
 opt_einsum~=3.3
-requests~=2.28.1
+requests~=2.30.0


### PR DESCRIPTION
**Context:**
The `requests` module recently had a release that fixes the issues with `urllib3`. 

**Description of the Change:**
Bump the pinned version of `requests`.