### PR TITLE
Remove patch for the pennylane-sf plugin

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -35,6 +35,9 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Removes a patch in `interfaces/autograd.py` that checks for the `strawberryfields.gbs` device.  That device
+  is pinned to PennyLane <= v0.29.0, so that patch is no longer necessary.
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane/interfaces/autograd.py
+++ b/pennylane/interfaces/autograd.py
@@ -260,10 +260,6 @@ def _vjp_legacy(
         return_vjps = [
             qml.math.to_numpy(v, max_depth=_n) if isinstance(v, ArrayBox) else v for v in vjps
         ]
-        if device.short_name == "strawberryfields.gbs":  # pragma: no cover
-            # TODO: remove this exceptional case once the source of this issue
-            # https://github.com/PennyLaneAI/pennylane-sf/issues/89 is determined
-            return (return_vjps,)  # pragma: no cover
 
         return return_vjps
 
@@ -508,10 +504,6 @@ def vjp(
         return_vjps = [
             qml.math.to_numpy(v, max_depth=_n) if isinstance(v, ArrayBox) else v for v in vjps
         ]
-        if device.short_name == "strawberryfields.gbs":  # pragma: no cover
-            # TODO: remove this exceptional case once the source of this issue
-            # https://github.com/PennyLaneAI/pennylane-sf/issues/89 is determined
-            return (return_vjps,)  # pragma: no cover
 
         return return_vjps
 


### PR DESCRIPTION
This patch of code is for making PL compatible with the `pennylane-sf` plugin.  Given the plugin will not be supported by pennylane v0.30 and above, we no longer need this patch.