### PR TITLE
Add shot vector support to sample measurements

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -57,6 +57,7 @@ This release contains contributions from (in alphabetical order):
 
 Isaac De Vlugt,
 Soran Jahangiri,
+Edward Jiang,
 Christina Lee,
 Romain Moyard,
 Mudit Pandey,

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -35,6 +35,7 @@
 
 * Added a function `measure_with_samples` that returns a sample-based measurement result given a state
   [(#4083)](https://github.com/PennyLaneAI/pennylane/pull/4083)
+  [(#4093)](https://github.com/PennyLaneAI/pennylane/pull/4093)
 
 * Support for adjoint differentiation has been added to the `DefaultQubit2` device.
   [(#4037)](https://github.com/PennyLaneAI/pennylane/pull/4037)

--- a/pennylane/devices/qubit/sampling.py
+++ b/pennylane/devices/qubit/sampling.py
@@ -42,15 +42,17 @@ def measure_with_samples(
     for op in mp.diagonalizing_gates():
         pre_rotated_state = apply_operation(op, pre_rotated_state)
 
-    # we don't need to worry about shot vectors for now
-    # if shots.has_partitioned_shots:
-    #     processed_samples = []
-    #     for shot_copies in shots.shot_vector:
-    #         for _ in range(shot_copies.copies):
-    #             samples = sample_state(pre_rotated_state, shot_copies.shots, rng=rng)
-    #             processed_samples.append(mp.process_samples(samples, wire_order))
+    # if there is a shot vector, build a list containing results for each shot entry
+    if shots.has_partitioned_shots:
+        samples = sample_state(pre_rotated_state, shots=shots.total_shots, wires=mp.wires, rng=rng)
+        processed_samples = []
+        start = 0
+        for shot_copies in shots.shot_vector:
+            for _ in range(shot_copies.copies):
+                processed_samples.append(mp.process_samples(samples, mp.wires, shot_range=(start, start + shot_copies.shots)))
+                start += shot_copies.shots
 
-    #     return tuple(processed_samples)
+        return tuple(processed_samples)
 
     samples = sample_state(pre_rotated_state, shots=shots.total_shots, wires=mp.wires, rng=rng)
     return mp.process_samples(samples, mp.wires)

--- a/pennylane/devices/qubit/sampling.py
+++ b/pennylane/devices/qubit/sampling.py
@@ -25,6 +25,8 @@ def measure_with_samples(
 ) -> TensorLike:
     """
     Returns the samples of the measurement process performed on the given state.
+    This function assumes that the user-defined wire labels in the measurement process
+    have already been mapped to integer wires used in the device.
 
     Args:
         mp (~.measurements.SampleMeasurement): The sample measurement to perform

--- a/pennylane/devices/qubit/sampling.py
+++ b/pennylane/devices/qubit/sampling.py
@@ -44,13 +44,10 @@ def measure_with_samples(
 
     # if there is a shot vector, build a list containing results for each shot entry
     if shots.has_partitioned_shots:
-        samples = sample_state(pre_rotated_state, shots=shots.total_shots, wires=mp.wires, rng=rng)
         processed_samples = []
-        start = 0
-        for shot_copies in shots.shot_vector:
-            for _ in range(shot_copies.copies):
-                processed_samples.append(mp.process_samples(samples, mp.wires, shot_range=(start, start + shot_copies.shots)))
-                start += shot_copies.shots
+        for s in shots:
+            samples = sample_state(pre_rotated_state, shots=s, wires=mp.wires, rng=rng)
+            processed_samples.append(mp.process_samples(samples, mp.wires))
 
         return tuple(processed_samples)
 

--- a/pennylane/devices/qubit/sampling.py
+++ b/pennylane/devices/qubit/sampling.py
@@ -42,17 +42,19 @@ def measure_with_samples(
     for op in mp.diagonalizing_gates():
         pre_rotated_state = apply_operation(op, pre_rotated_state)
 
+    wires = qml.wires.Wires(range(len(state.shape)))
+
     # if there is a shot vector, build a list containing results for each shot entry
     if shots.has_partitioned_shots:
         processed_samples = []
         for s in shots:
-            samples = sample_state(pre_rotated_state, shots=s, wires=mp.wires, rng=rng)
-            processed_samples.append(mp.process_samples(samples, mp.wires))
+            samples = sample_state(pre_rotated_state, shots=s, wires=wires, rng=rng)
+            processed_samples.append(mp.process_samples(samples, wires))
 
         return tuple(processed_samples)
 
-    samples = sample_state(pre_rotated_state, shots=shots.total_shots, wires=mp.wires, rng=rng)
-    return mp.process_samples(samples, mp.wires)
+    samples = sample_state(pre_rotated_state, shots=shots.total_shots, wires=wires, rng=rng)
+    return mp.process_samples(samples, wires)
 
 
 def sample_state(state, shots: int, wires=None, rng=None) -> np.ndarray:

--- a/pennylane/devices/qubit/sampling.py
+++ b/pennylane/devices/qubit/sampling.py
@@ -50,6 +50,9 @@ def measure_with_samples(
     if shots.has_partitioned_shots:
         processed_samples = []
         for s in shots:
+            # currently we call sample_state for each shot entry, but it may be
+            # better to call sample_state just once with total_shots, then use
+            # the shot_range keyword argument
             samples = sample_state(pre_rotated_state, shots=s, wires=wires, rng=rng)
             processed_samples.append(mp.process_samples(samples, wires))
 

--- a/pennylane/measurements/shots.py
+++ b/pennylane/measurements/shots.py
@@ -161,6 +161,11 @@ class Shots:
         memo[id(self)] = self
         return self
 
+    def __iter__(self):
+        for shot_copy in self.shot_vector:
+            for _ in range(shot_copy.copies):
+                yield shot_copy.shots
+
     def __all_tuple_init__(self, shots: Sequence[Tuple]):
         res = []
         total_shots = 0

--- a/tests/devices/qubit/test_sampling.py
+++ b/tests/devices/qubit/test_sampling.py
@@ -252,3 +252,29 @@ class TestMeasureSamples:
 
         assert result != 0
         assert np.allclose(result, 0, atol=0.03)
+
+    @pytest.mark.parametrize("shots, total_copies", [
+        [(100,), 1],
+        [((100, 1),), 1],
+        [((100, 2),), 2],
+        [(100, 100), 2],
+        [(100, 200), 2],
+        [(100, 100, 200), 3],
+        [(200, (100, 2)), 3]
+    ])
+    def test_sample_measure_shot_vector(self, shots, total_copies):
+        """Test that a sample measurement with shot vectors works as expected"""
+        state = qml.math.array(two_qubit_state)
+        shots_obj = qml.measurements.Shots(shots)
+        mp = qml.sample(wires=range(2))
+
+        result = measure_with_samples(mp, state, shots=shots_obj)
+
+        if total_copies == 1:
+            assert isinstance(result, np.ndarray)
+            result = (result,)
+
+        assert isinstance(result, tuple)
+        assert len(result) == total_copies
+
+

--- a/tests/devices/qubit/test_sampling.py
+++ b/tests/devices/qubit/test_sampling.py
@@ -219,6 +219,33 @@ class TestMeasureSamples:
         assert result0 == 1
         assert result1 == -1
 
+    def test_var_measure(self):
+        """Test that a variance measurement works as expected"""
+        state = qml.math.array(two_qubit_state)
+        shots = qml.measurements.Shots(100)
+        mp = qml.var(qml.prod(qml.PauliX(0), qml.PauliY(1)))
+
+        result = measure_with_samples(mp, state, shots=shots)
+
+        assert result.shape == ()
+        assert result == 0
+
+    def test_var_measure_single_wire(self):
+        """Test that a variance measurement on a single wire works as expected"""
+        state = np.array([[1, -1j], [0, 0]]) / np.sqrt(2)
+        shots = qml.measurements.Shots(100)
+
+        mp0 = qml.var(qml.PauliZ(0))
+        mp1 = qml.var(qml.PauliY(1))
+
+        result0 = measure_with_samples(mp0, state, shots=shots)
+        result1 = measure_with_samples(mp1, state, shots=shots)
+
+        assert result0.shape == ()
+        assert result1.shape == ()
+        assert result0 == 0
+        assert result1 == 0
+
     def test_approximate_sample_measure(self):
         """Test that a sample measurement returns approximately the correct distribution"""
         state = qml.math.array(two_qubit_state)
@@ -228,7 +255,7 @@ class TestMeasureSamples:
         result = measure_with_samples(mp, state, shots=shots)
 
         one_prob = np.count_nonzero(result[:, 0]) / result.shape[0]
-        assert np.allclose(one_prob, 0.5, atol=0.03)
+        assert np.allclose(one_prob, 0.5, atol=0.05)
 
     def test_approximate_prob_measure(self):
         """Test that a probability measurement works as expected"""
@@ -238,8 +265,8 @@ class TestMeasureSamples:
 
         result = measure_with_samples(mp, state, shots=shots)
 
-        assert np.allclose(result[1], 0.5, atol=0.03)
-        assert np.allclose(result[2], 0.5, atol=0.03)
+        assert np.allclose(result[1], 0.5, atol=0.05)
+        assert np.allclose(result[2], 0.5, atol=0.05)
         assert result[1] + result[2] == 1
 
     def test_approximate_expval_measure(self):
@@ -251,7 +278,18 @@ class TestMeasureSamples:
         result = measure_with_samples(mp, state, shots=shots)
 
         assert result != 0
-        assert np.allclose(result, 0, atol=0.03)
+        assert np.allclose(result, 0, atol=0.05)
+
+    def test_approximate_var_measure(self):
+        """Test that a variance measurement works as expected"""
+        state = qml.math.array(two_qubit_state)
+        shots = qml.measurements.Shots(10000)
+        mp = qml.var(qml.prod(qml.PauliX(0), qml.PauliX(1)))
+
+        result = measure_with_samples(mp, state, shots=shots)
+
+        assert result != 1
+        assert np.allclose(result, 1, atol=0.05)
 
     @pytest.mark.parametrize(
         "shots, total_copies",
@@ -348,3 +386,34 @@ class TestMeasureSamples:
         for res in result:
             assert res.shape == ()
             assert res == -1
+
+    @pytest.mark.parametrize(
+        "shots, total_copies",
+        [
+            [(100,), 1],
+            [((100, 1),), 1],
+            [((100, 2),), 2],
+            [(100, 100), 2],
+            [(100, 200), 2],
+            [(100, 100, 200), 3],
+            [(200, (100, 2)), 3],
+        ],
+    )
+    def test_var_measure_shot_vector(self, shots, total_copies):
+        """Test that a variance measurement with shot vectors works as expected"""
+        state = qml.math.array(two_qubit_state)
+        shots = qml.measurements.Shots(shots)
+        mp = qml.var(qml.prod(qml.PauliX(0), qml.PauliY(1)))
+
+        result = measure_with_samples(mp, state, shots=shots)
+
+        if total_copies == 1:
+            assert isinstance(result, np.float64)
+            result = (result,)
+
+        assert isinstance(result, tuple)
+        assert len(result) == total_copies
+
+        for res in result:
+            assert res.shape == ()
+            assert res == 0

--- a/tests/devices/qubit/test_sampling.py
+++ b/tests/devices/qubit/test_sampling.py
@@ -252,7 +252,7 @@ class TestMeasureSamples:
         shots = qml.measurements.Shots(10000)
         mp = qml.sample(wires=range(2))
 
-        result = measure_with_samples(mp, state, shots=shots)
+        result = measure_with_samples(mp, state, shots=shots, rng=123)
 
         one_prob = np.count_nonzero(result[:, 0]) / result.shape[0]
         assert np.allclose(one_prob, 0.5, atol=0.05)
@@ -263,7 +263,7 @@ class TestMeasureSamples:
         shots = qml.measurements.Shots(10000)
         mp = qml.probs(wires=range(2))
 
-        result = measure_with_samples(mp, state, shots=shots)
+        result = measure_with_samples(mp, state, shots=shots, rng=123)
 
         assert np.allclose(result[1], 0.5, atol=0.05)
         assert np.allclose(result[2], 0.5, atol=0.05)
@@ -275,7 +275,7 @@ class TestMeasureSamples:
         shots = qml.measurements.Shots(10000)
         mp = qml.expval(qml.prod(qml.PauliX(0), qml.PauliX(1)))
 
-        result = measure_with_samples(mp, state, shots=shots)
+        result = measure_with_samples(mp, state, shots=shots, rng=123)
 
         assert result != 0
         assert np.allclose(result, 0, atol=0.05)
@@ -286,7 +286,7 @@ class TestMeasureSamples:
         shots = qml.measurements.Shots(10000)
         mp = qml.var(qml.prod(qml.PauliX(0), qml.PauliX(1)))
 
-        result = measure_with_samples(mp, state, shots=shots)
+        result = measure_with_samples(mp, state, shots=shots, rng=123)
 
         assert result != 1
         assert np.allclose(result, 1, atol=0.05)

--- a/tests/measurements/test_shots.py
+++ b/tests/measurements/test_shots.py
@@ -158,12 +158,8 @@ class TestShotsConstruction:
     )
     def test_iter(self, shots, expected):
         """Test that iteration over Shots works correctly"""
-        actual = []
-        for s in Shots(shots):
-            actual.append(s)
-
-        assert len(actual) == len(expected)
-        assert all(act == exp for act, exp in zip(actual, expected))
+        actual = [s for s in Shots(shots)]
+        assert actual == expected
 
     def test_sequence_all_tuple(self):
         """Tests that a sequence of tuples is allowed."""

--- a/tests/measurements/test_shots.py
+++ b/tests/measurements/test_shots.py
@@ -145,6 +145,26 @@ class TestShotsConstruction:
             assert hash_s == hash(copy.copy(s))
             assert hash_s == hash(Shots(s.shot_vector if s.shot_vector else None))
 
+    @pytest.mark.parametrize(
+        "shots, expected",
+        [
+            (100, [100]),
+            ([(100, 1)], [100]),
+            ([(100, 2)], [100, 100]),
+            ([100, 200], [100, 200]),
+            ([(100, 2), 200], [100, 100, 200]),
+            ([(100, 3), 200, (300, 2)], [100, 100, 100, 200, 300, 300]),
+        ],
+    )
+    def test_iter(self, shots, expected):
+        """Test that iteration over Shots works correctly"""
+        actual = []
+        for s in Shots(shots):
+            actual.append(s)
+
+        assert len(actual) == len(expected)
+        assert all(act == exp for act, exp in zip(actual, expected))
+
     def test_sequence_all_tuple(self):
         """Tests that a sequence of tuples is allowed."""
         shots = Shots([(1, 2), (1, 5), (3, 4)])

--- a/tests/measurements/test_shots.py
+++ b/tests/measurements/test_shots.py
@@ -158,7 +158,7 @@ class TestShotsConstruction:
     )
     def test_iter(self, shots, expected):
         """Test that iteration over Shots works correctly"""
-        actual = [s for s in Shots(shots)]
+        actual = list(Shots(shots))
         assert actual == expected
 
     def test_sequence_all_tuple(self):


### PR DESCRIPTION
**Context:**
Part of the effort to integrate the new device API.

**Description of the Change:**
Add shot-vector support to `measure_with_samples` in `devices/qubit/sampling.py`.

**Benefits:**
This function can now be called from `simulate()` with shot vectors.

**Possible Drawbacks:**
None