### PR TITLE
Add CH to the list of operations

### DIFF
--- a/doc/introduction/operations.rst
+++ b/doc/introduction/operations.rst
@@ -163,6 +163,7 @@ Non-parametrized gates
     ~pennylane.CNOT
     ~pennylane.CZ
     ~pennylane.CY
+    ~pennylane.CH
     ~pennylane.SWAP
     ~pennylane.ISWAP
     ~pennylane.ECR


### PR DESCRIPTION
As the title says, `qml.CH` was missing from the list of operations on the "operations" page.