### PR TITLE
Integrate sample-based measurement with `simulate`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -45,6 +45,9 @@
 * Support for adjoint differentiation has been added to the `DefaultQubit2` device.
   [(#4037)](https://github.com/PennyLaneAI/pennylane/pull/4037)
 
+* Support for sample-based measurements has been added to the `DefaultQubit2` device.
+  [(#4105)](https://github.com/PennyLaneAI/pennylane/pull/4105)
+
 * Added a `dense` keyword to `ParametrizedEvolution` that allows forcing dense or sparse matrices.
   [(#4079)](https://github.com/PennyLaneAI/pennylane/pull/4079)
   [(#4095)](https://github.com/PennyLaneAI/pennylane/pull/4095)

--- a/pennylane/devices/qubit/measure.py
+++ b/pennylane/devices/qubit/measure.py
@@ -93,18 +93,15 @@ def sum_of_terms_method(measurementprocess: ExpectationMP, state: TensorLike) ->
     if isinstance(measurementprocess.obs, Sum):
         # Recursively call measure on each term, so that the best measurement method can
         # be used for each term
-        return sum(
-            measure(ExpectationMP(term), state, Shots(None)) for term in measurementprocess.obs
-        )
+        return sum(measure(ExpectationMP(term), state) for term in measurementprocess.obs)
     # else hamiltonian
     return sum(
-        c * measure(ExpectationMP(t), state, Shots(None))
-        for c, t in zip(*measurementprocess.obs.terms())
+        c * measure(ExpectationMP(t), state) for c, t in zip(*measurementprocess.obs.terms())
     )
 
 
 def get_measurement_function(
-    measurementprocess: MeasurementProcess, state: TensorLike, shots: Shots
+    measurementprocess: MeasurementProcess, state: TensorLike, shots: Shots = None
 ) -> Callable[[MeasurementProcess, TensorLike], TensorLike]:
     """Get the appropriate method for performing a measurement.
 
@@ -118,7 +115,7 @@ def get_measurement_function(
     # use Shots to dispatch a SampleMeasurement; this is required because
     # some measurements (such as expval) are subclasses of both StateMeasurement
     # and SampleMeasurement, so we can't use isinstance checks to dispatch
-    if shots.total_shots is not None:
+    if shots is not None and shots.total_shots is not None:
         if isinstance(measurementprocess, SampleMeasurement):
             return functools.partial(qml.devices.qubit.measure_with_samples, shots=shots)
 
@@ -147,7 +144,9 @@ def get_measurement_function(
     raise NotImplementedError
 
 
-def measure(measurementprocess: MeasurementProcess, state: TensorLike, shots: Shots) -> TensorLike:
+def measure(
+    measurementprocess: MeasurementProcess, state: TensorLike, shots: Shots = None
+) -> TensorLike:
     """Apply a measurement process to a state.
 
     Args:

--- a/pennylane/devices/qubit/measure.py
+++ b/pennylane/devices/qubit/measure.py
@@ -93,10 +93,13 @@ def sum_of_terms_method(measurementprocess: ExpectationMP, state: TensorLike) ->
     if isinstance(measurementprocess.obs, Sum):
         # Recursively call measure on each term, so that the best measurement method can
         # be used for each term
-        return sum(measure(ExpectationMP(term), state) for term in measurementprocess.obs)
+        return sum(
+            measure(ExpectationMP(term), state, Shots(None)) for term in measurementprocess.obs
+        )
     # else hamiltonian
     return sum(
-        c * measure(ExpectationMP(t), state) for c, t in zip(*measurementprocess.obs.terms())
+        c * measure(ExpectationMP(t), state, Shots(None))
+        for c, t in zip(*measurementprocess.obs.terms())
     )
 
 
@@ -120,7 +123,6 @@ def get_measurement_function(
             return functools.partial(qml.devices.qubit.measure_with_samples, shots=shots)
 
         # TODO: raise error here?
-        pass
 
     if isinstance(measurementprocess, StateMeasurement):
         if isinstance(measurementprocess, ExpectationMP):

--- a/pennylane/devices/qubit/measure.py
+++ b/pennylane/devices/qubit/measure.py
@@ -14,21 +14,13 @@
 """
 Code relevant for performing measurements on a state.
 """
-import functools
 from typing import Callable
 
 from scipy.sparse import csr_matrix
 
-import pennylane as qml
 from pennylane import math
 from pennylane.ops import Sum, Hamiltonian
-from pennylane.measurements import (
-    Shots,
-    StateMeasurement,
-    SampleMeasurement,
-    MeasurementProcess,
-    ExpectationMP,
-)
+from pennylane.measurements import StateMeasurement, MeasurementProcess, ExpectationMP
 from pennylane.typing import TensorLike
 from pennylane.wires import Wires
 
@@ -101,7 +93,7 @@ def sum_of_terms_method(measurementprocess: ExpectationMP, state: TensorLike) ->
 
 
 def get_measurement_function(
-    measurementprocess: MeasurementProcess, state: TensorLike, shots: Shots = None
+    measurementprocess: MeasurementProcess, state: TensorLike
 ) -> Callable[[MeasurementProcess, TensorLike], TensorLike]:
     """Get the appropriate method for performing a measurement.
 
@@ -112,15 +104,6 @@ def get_measurement_function(
     Returns:
         Callable: function that returns the measurement result
     """
-    # use Shots to dispatch a SampleMeasurement; this is required because
-    # some measurements (such as expval) are subclasses of both StateMeasurement
-    # and SampleMeasurement, so we can't use isinstance checks to dispatch
-    if shots is not None and shots.total_shots is not None:
-        if isinstance(measurementprocess, SampleMeasurement):
-            return functools.partial(qml.devices.qubit.measure_with_samples, shots=shots)
-
-        # TODO: raise error here?
-
     if isinstance(measurementprocess, StateMeasurement):
         if isinstance(measurementprocess, ExpectationMP):
             if measurementprocess.obs.name == "SparseHamiltonian":
@@ -144,9 +127,7 @@ def get_measurement_function(
     raise NotImplementedError
 
 
-def measure(
-    measurementprocess: MeasurementProcess, state: TensorLike, shots: Shots = None
-) -> TensorLike:
+def measure(measurementprocess: MeasurementProcess, state: TensorLike) -> TensorLike:
     """Apply a measurement process to a state.
 
     Args:
@@ -156,4 +137,4 @@ def measure(
     Returns:
         Tensorlike: the result of the measurement
     """
-    return get_measurement_function(measurementprocess, state, shots)(measurementprocess, state)
+    return get_measurement_function(measurementprocess, state)(measurementprocess, state)

--- a/pennylane/devices/qubit/measure.py
+++ b/pennylane/devices/qubit/measure.py
@@ -14,13 +14,21 @@
 """
 Code relevant for performing measurements on a state.
 """
+import functools
 from typing import Callable
 
 from scipy.sparse import csr_matrix
 
+import pennylane as qml
 from pennylane import math
 from pennylane.ops import Sum, Hamiltonian
-from pennylane.measurements import StateMeasurement, MeasurementProcess, ExpectationMP
+from pennylane.measurements import (
+    Shots,
+    StateMeasurement,
+    SampleMeasurement,
+    MeasurementProcess,
+    ExpectationMP,
+)
 from pennylane.typing import TensorLike
 from pennylane.wires import Wires
 
@@ -93,7 +101,7 @@ def sum_of_terms_method(measurementprocess: ExpectationMP, state: TensorLike) ->
 
 
 def get_measurement_function(
-    measurementprocess: MeasurementProcess, state: TensorLike
+    measurementprocess: MeasurementProcess, state: TensorLike, shots: Shots
 ) -> Callable[[MeasurementProcess, TensorLike], TensorLike]:
     """Get the appropriate method for performing a measurement.
 
@@ -104,6 +112,16 @@ def get_measurement_function(
     Returns:
         Callable: function that returns the measurement result
     """
+    # use Shots to dispatch a SampleMeasurement; this is required because
+    # some measurements (such as expval) are subclasses of both StateMeasurement
+    # and SampleMeasurement, so we can't use isinstance checks to dispatch
+    if shots.total_shots is not None:
+        if isinstance(measurementprocess, SampleMeasurement):
+            return functools.partial(qml.devices.qubit.measure_with_samples, shots=shots)
+
+        # TODO: raise error here?
+        pass
+
     if isinstance(measurementprocess, StateMeasurement):
         if isinstance(measurementprocess, ExpectationMP):
             if measurementprocess.obs.name == "SparseHamiltonian":
@@ -127,7 +145,7 @@ def get_measurement_function(
     raise NotImplementedError
 
 
-def measure(measurementprocess: MeasurementProcess, state: TensorLike) -> TensorLike:
+def measure(measurementprocess: MeasurementProcess, state: TensorLike, shots: Shots) -> TensorLike:
     """Apply a measurement process to a state.
 
     Args:
@@ -137,4 +155,4 @@ def measure(measurementprocess: MeasurementProcess, state: TensorLike) -> Tensor
     Returns:
         Tensorlike: the result of the measurement
     """
-    return get_measurement_function(measurementprocess, state)(measurementprocess, state)
+    return get_measurement_function(measurementprocess, state, shots)(measurementprocess, state)

--- a/pennylane/devices/qubit/sampling.py
+++ b/pennylane/devices/qubit/sampling.py
@@ -54,12 +54,12 @@ def measure_with_samples(
             # better to call sample_state just once with total_shots, then use
             # the shot_range keyword argument
             samples = sample_state(pre_rotated_state, shots=s, wires=wires, rng=rng)
-            processed_samples.append(mp.process_samples(samples, wires))
+            processed_samples.append(qml.math.squeeze(mp.process_samples(samples, wires)))
 
         return tuple(processed_samples)
 
     samples = sample_state(pre_rotated_state, shots=shots.total_shots, wires=wires, rng=rng)
-    return mp.process_samples(samples, wires)
+    return qml.math.squeeze(mp.process_samples(samples, wires))
 
 
 def sample_state(state, shots: int, wires=None, rng=None) -> np.ndarray:

--- a/pennylane/devices/qubit/simulate.py
+++ b/pennylane/devices/qubit/simulate.py
@@ -56,5 +56,13 @@ def simulate(circuit: qml.tape.QuantumScript) -> Union[tuple, TensorLike]:
         state = apply_operation(op, state)
 
     if len(circuit.measurements) == 1:
-        return measure(circuit.measurements[0], state)
-    return tuple(measure(mp, state) for mp in circuit.measurements)
+        return measure(circuit.measurements[0], state, circuit.shots)
+
+    measurement_results = tuple(measure(mp, state, circuit.shots) for mp in circuit.measurements)
+
+    # no shot vector
+    if not circuit.shots.has_partitioned_shots:
+        return measurement_results
+
+    # shot vector case: move the shot vector axis before the measurement axis
+    return tuple(zip(*measurement_results))

--- a/pennylane/devices/qubit/simulate.py
+++ b/pennylane/devices/qubit/simulate.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Simulate a quantum script."""
-from typing import Union, Sequence
+from typing import Union
 
 # pylint: disable=protected-access
 import pennylane as qml
@@ -24,9 +24,7 @@ from .measure import measure
 from .sampling import measure_with_samples
 
 
-def simulate(
-    circuit: qml.tape.QuantumScript, rng: Union[None, int, Sequence[int]] = None
-) -> Union[tuple, TensorLike]:
+def simulate(circuit: qml.tape.QuantumScript, rng=None) -> Union[tuple, TensorLike]:
     """Simulate a single quantum script.
 
     This is an internal function that will be called by the successor to ``default.qubit``.

--- a/pennylane/devices/qubit/simulate.py
+++ b/pennylane/devices/qubit/simulate.py
@@ -16,6 +16,7 @@ from typing import Union
 
 # pylint: disable=protected-access
 import pennylane as qml
+import pennylane.numpy as np
 from pennylane.typing import TensorLike
 
 from .initialize_state import create_initial_state
@@ -72,6 +73,7 @@ def simulate(circuit: qml.tape.QuantumScript, rng=None) -> Union[tuple, TensorLi
     if len(circuit.measurements) == 1:
         return measure_with_samples(circuit.measurements[0], state, shots=circuit.shots, rng=rng)
 
+    rng = np.random.default_rng(rng)
     results = tuple(
         measure_with_samples(mp, state, shots=circuit.shots, rng=rng) for mp in circuit.measurements
     )

--- a/pennylane/devices/qubit/simulate.py
+++ b/pennylane/devices/qubit/simulate.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Simulate a quantum script."""
-from typing import Union
+from typing import Union, Sequence
 
 # pylint: disable=protected-access
 import pennylane as qml
@@ -24,13 +24,18 @@ from .measure import measure
 from .sampling import measure_with_samples
 
 
-def simulate(circuit: qml.tape.QuantumScript) -> Union[tuple, TensorLike]:
+def simulate(
+    circuit: qml.tape.QuantumScript, rng: Union[None, int, Sequence[int]] = None
+) -> Union[tuple, TensorLike]:
     """Simulate a single quantum script.
 
     This is an internal function that will be called by the successor to ``default.qubit``.
 
     Args:
         circuit (.QuantumScript): The single circuit to simulate
+        rng (Union[None, int, array_like[int], SeedSequence, BitGenerator, Generator]): A
+            seed-like parameter matching that of ``seed`` for ``numpy.random.default_rng``.
+            If no value is provided, a default RNG will be used.
 
     Returns:
         tuple(TensorLike): The results of the simulation
@@ -67,10 +72,10 @@ def simulate(circuit: qml.tape.QuantumScript) -> Union[tuple, TensorLike]:
     # finite-shot case
 
     if len(circuit.measurements) == 1:
-        return measure_with_samples(circuit.measurements[0], state, shots=circuit.shots)
+        return measure_with_samples(circuit.measurements[0], state, shots=circuit.shots, rng=rng)
 
     results = tuple(
-        measure_with_samples(mp, state, shots=circuit.shots) for mp in circuit.measurements
+        measure_with_samples(mp, state, shots=circuit.shots, rng=rng) for mp in circuit.measurements
     )
 
     # no shot vector

--- a/tests/devices/experimental/test_default_qubit_2.py
+++ b/tests/devices/experimental/test_default_qubit_2.py
@@ -293,7 +293,7 @@ class TestSampleMeasurements:
         x, y = np.array(0.732), np.array(0.488)
         qs = qml.tape.QuantumScript(
             [qml.RX(x, wires=0), qml.CNOT(wires=[0, 1]), qml.RY(y, wires=1)],
-            [qml.expval(qml.PauliZ(0)), qml.probs(wires=range(2)), qml.sample(wires=range(2))],
+            [qml.expval(qml.Hadamard(0)), qml.probs(wires=range(2)), qml.sample(wires=range(2))],
             shots=10000,
         )
 
@@ -306,7 +306,7 @@ class TestSampleMeasurements:
         assert all(isinstance(res, np.ndarray) for res in result)
 
         assert result[0].shape == ()
-        assert np.allclose(result[0], np.cos(x), atol=0.1)
+        assert np.allclose(result[0], np.cos(x) / np.sqrt(2), atol=0.1)
 
         assert result[1].shape == (4,)
         assert np.allclose(
@@ -395,7 +395,7 @@ class TestSampleMeasurements:
         shots = qml.measurements.Shots(shots)
         qs = qml.tape.QuantumScript(
             [qml.RX(x, wires=0), qml.CNOT(wires=[0, 1]), qml.RY(y, wires=1)],
-            [qml.expval(qml.PauliZ(0)), qml.probs(wires=range(2)), qml.sample(wires=range(2))],
+            [qml.expval(qml.Hadamard(0)), qml.probs(wires=range(2)), qml.sample(wires=range(2))],
             shots=shots,
         )
 
@@ -412,7 +412,7 @@ class TestSampleMeasurements:
             assert all(isinstance(meas_res, np.ndarray) for meas_res in shot_res)
 
             assert shot_res[0].shape == ()
-            assert np.allclose(shot_res[0], np.cos(x), atol=0.1)
+            assert np.allclose(shot_res[0], np.cos(x) / np.sqrt(2), atol=0.1)
 
             assert shot_res[1].shape == (4,)
             assert np.allclose(

--- a/tests/devices/experimental/test_default_qubit_2.py
+++ b/tests/devices/experimental/test_default_qubit_2.py
@@ -479,7 +479,7 @@ class TestSampleMeasurements:
         assert len(results) == 2
         assert all(isinstance(res, np.ndarray) for res in results)
         assert results[0].shape == (100, 2)
-        assert results[1].shape == (50, 1)
+        assert results[1].shape == (50,)
 
 
 class TestExecutingBatches:

--- a/tests/devices/experimental/test_default_qubit_2.py
+++ b/tests/devices/experimental/test_default_qubit_2.py
@@ -247,6 +247,226 @@ class TestBasicCircuit:
         assert qml.math.allclose(grad1[0], -tf.sin(phi))
 
 
+class TestSampleMeasurements:
+    """A copy of the `qubit.simulate` tests, but using the device"""
+
+    def test_single_expval(self):
+        """Test a simple circuit with a single expval measurement"""
+        x = np.array(0.732)
+        qs = qml.tape.QuantumScript([qml.RY(x, wires=0)], [qml.expval(qml.PauliZ(0))], shots=10000)
+
+        dev = DefaultQubit2()
+        result = dev.execute(qs)
+
+        assert isinstance(result, np.ndarray)
+        assert result.shape == ()
+        assert np.allclose(result, np.cos(x), atol=0.1)
+
+    def test_single_probs(self):
+        """Test a simple circuit with a single prob measurement"""
+        x = np.array(0.732)
+        qs = qml.tape.QuantumScript([qml.RY(x, wires=0)], [qml.probs(wires=0)], shots=10000)
+
+        dev = DefaultQubit2()
+        result = dev.execute(qs)
+
+        assert isinstance(result, np.ndarray)
+        assert result.shape == (2,)
+        assert np.allclose(result, [np.cos(x / 2) ** 2, np.sin(x / 2) ** 2], atol=0.1)
+
+    def test_single_sample(self):
+        """Test a simple circuit with a single sample measurement"""
+        x = np.array(0.732)
+        qs = qml.tape.QuantumScript([qml.RY(x, wires=0)], [qml.sample(wires=range(2))], shots=10000)
+
+        dev = DefaultQubit2()
+        result = dev.execute(qs)
+
+        assert isinstance(result, np.ndarray)
+        assert result.shape == (10000, 2)
+        assert np.allclose(
+            np.sum(result, axis=0).astype(np.float32) / 10000, [np.sin(x / 2) ** 2, 0], atol=0.1
+        )
+
+    def test_multi_measurements(self):
+        """Test a simple circuit containing multiple measurements"""
+        x, y = np.array(0.732), np.array(0.488)
+        qs = qml.tape.QuantumScript(
+            [qml.RX(x, wires=0), qml.CNOT(wires=[0, 1]), qml.RY(y, wires=1)],
+            [qml.expval(qml.PauliZ(0)), qml.probs(wires=range(2)), qml.sample(wires=range(2))],
+            shots=10000,
+        )
+
+        dev = DefaultQubit2()
+        result = dev.execute(qs)
+
+        assert isinstance(result, tuple)
+        assert len(result) == 3
+
+        assert all(isinstance(res, np.ndarray) for res in result)
+
+        assert result[0].shape == ()
+        assert np.allclose(result[0], np.cos(x), atol=0.1)
+
+        assert result[1].shape == (4,)
+        assert np.allclose(
+            result[1],
+            [
+                np.cos(x / 2) ** 2 * np.cos(y / 2) ** 2,
+                np.cos(x / 2) ** 2 * np.sin(y / 2) ** 2,
+                np.sin(x / 2) ** 2 * np.sin(y / 2) ** 2,
+                np.sin(x / 2) ** 2 * np.cos(y / 2) ** 2,
+            ],
+            atol=0.1,
+        )
+
+        assert result[2].shape == (10000, 2)
+
+    shots_data = [
+        [10000, 10000],
+        [(10000, 2)],
+        [10000, 20000],
+        [(10000, 2), 20000],
+        [(10000, 3), 20000, (30000, 2)],
+    ]
+
+    @pytest.mark.parametrize("shots", shots_data)
+    def test_expval_shot_vector(self, shots):
+        """Test a simple circuit with a single expval measurement for shot vectors"""
+        x = np.array(0.732)
+        shots = qml.measurements.Shots(shots)
+        qs = qml.tape.QuantumScript([qml.RY(x, wires=0)], [qml.expval(qml.PauliZ(0))], shots=shots)
+
+        dev = DefaultQubit2()
+        result = dev.execute(qs)
+
+        assert isinstance(result, tuple)
+        assert len(result) == len(list(shots))
+
+        assert all(isinstance(res, np.ndarray) for res in result)
+        assert all(res.shape == () for res in result)
+        assert all(np.allclose(res, np.cos(x), atol=0.1) for res in result)
+
+    @pytest.mark.parametrize("shots", shots_data)
+    def test_probs_shot_vector(self, shots):
+        """Test a simple circuit with a single prob measurement for shot vectors"""
+        x = np.array(0.732)
+        shots = qml.measurements.Shots(shots)
+        qs = qml.tape.QuantumScript([qml.RY(x, wires=0)], [qml.probs(wires=0)], shots=shots)
+
+        dev = DefaultQubit2()
+        result = dev.execute(qs)
+
+        assert isinstance(result, tuple)
+        assert len(result) == len(list(shots))
+
+        assert all(isinstance(res, np.ndarray) for res in result)
+        assert all(res.shape == (2,) for res in result)
+        assert all(
+            np.allclose(res, [np.cos(x / 2) ** 2, np.sin(x / 2) ** 2], atol=0.1) for res in result
+        )
+
+    @pytest.mark.parametrize("shots", shots_data)
+    def test_sample_shot_vector(self, shots):
+        """Test a simple circuit with a single sample measurement for shot vectors"""
+        x = np.array(0.732)
+        shots = qml.measurements.Shots(shots)
+        qs = qml.tape.QuantumScript([qml.RY(x, wires=0)], [qml.sample(wires=range(2))], shots=shots)
+
+        dev = DefaultQubit2()
+        result = dev.execute(qs)
+
+        assert isinstance(result, tuple)
+        assert len(result) == len(list(shots))
+
+        assert all(isinstance(res, np.ndarray) for res in result)
+        assert all(res.shape == (s, 2) for res, s in zip(result, shots))
+        assert all(
+            np.allclose(
+                np.sum(res, axis=0).astype(np.float32) / s, [np.sin(x / 2) ** 2, 0], atol=0.1
+            )
+            for res, s in zip(result, shots)
+        )
+
+    @pytest.mark.parametrize("shots", shots_data)
+    def test_multi_measurement_shot_vector(self, shots):
+        """Test a simple circuit containing multiple measurements for shot vectors"""
+        x, y = np.array(0.732), np.array(0.488)
+        shots = qml.measurements.Shots(shots)
+        qs = qml.tape.QuantumScript(
+            [qml.RX(x, wires=0), qml.CNOT(wires=[0, 1]), qml.RY(y, wires=1)],
+            [qml.expval(qml.PauliZ(0)), qml.probs(wires=range(2)), qml.sample(wires=range(2))],
+            shots=shots,
+        )
+
+        dev = DefaultQubit2()
+        result = dev.execute(qs)
+
+        assert isinstance(result, tuple)
+        assert len(result) == len(list(shots))
+
+        for shot_res, s in zip(result, shots):
+            assert isinstance(shot_res, tuple)
+            assert len(shot_res) == 3
+
+            assert all(isinstance(meas_res, np.ndarray) for meas_res in shot_res)
+
+            assert shot_res[0].shape == ()
+            assert np.allclose(shot_res[0], np.cos(x), atol=0.1)
+
+            assert shot_res[1].shape == (4,)
+            assert np.allclose(
+                shot_res[1],
+                [
+                    np.cos(x / 2) ** 2 * np.cos(y / 2) ** 2,
+                    np.cos(x / 2) ** 2 * np.sin(y / 2) ** 2,
+                    np.sin(x / 2) ** 2 * np.sin(y / 2) ** 2,
+                    np.sin(x / 2) ** 2 * np.cos(y / 2) ** 2,
+                ],
+                atol=0.1,
+            )
+
+            assert shot_res[2].shape == (s, 2)
+
+    def test_custom_wire_labels(self):
+        """Test that custom wire labels works as expected"""
+        x, y = np.array(0.732), np.array(0.488)
+        qs = qml.tape.QuantumScript(
+            [qml.RX(x, wires="b"), qml.CNOT(wires=["b", "a"]), qml.RY(y, wires="a")],
+            [
+                qml.expval(qml.PauliZ("b")),
+                qml.probs(wires=["a", "b"]),
+                qml.sample(wires=["b", "a"]),
+            ],
+            shots=10000,
+        )
+
+        dev = DefaultQubit2()
+        result = dev.execute(qs)
+
+        assert isinstance(result, tuple)
+        assert len(result) == 3
+
+        assert all(isinstance(res, np.ndarray) for res in result)
+
+        assert result[0].shape == ()
+        assert np.allclose(result[0], np.cos(x), atol=0.1)
+
+        assert result[1].shape == (4,)
+        assert np.allclose(
+            result[1],
+            [
+                np.cos(x / 2) ** 2 * np.cos(y / 2) ** 2,
+                np.sin(x / 2) ** 2 * np.sin(y / 2) ** 2,
+                np.cos(x / 2) ** 2 * np.sin(y / 2) ** 2,
+                np.sin(x / 2) ** 2 * np.cos(y / 2) ** 2,
+            ],
+            atol=0.1,
+        )
+
+        assert result[2].shape == (10000, 2)
+
+
 class TestExecutingBatches:
     @staticmethod
     def f(phi):

--- a/tests/devices/experimental/test_default_qubit_2.py
+++ b/tests/devices/experimental/test_default_qubit_2.py
@@ -466,6 +466,21 @@ class TestSampleMeasurements:
 
         assert result[2].shape == (10000, 2)
 
+    def test_batch_tapes(self):
+        """Test that a batch of tapes with sampling works as expected"""
+        x = np.array(0.732)
+        qs1 = qml.tape.QuantumScript([qml.RX(x, wires=0)], [qml.sample(wires=(0, 1))], shots=100)
+        qs2 = qml.tape.QuantumScript([qml.RX(x, wires=0)], [qml.sample(wires=1)], shots=50)
+
+        dev = DefaultQubit2()
+        results = dev.execute((qs1, qs2))
+
+        assert isinstance(results, tuple)
+        assert len(results) == 2
+        assert all(isinstance(res, np.ndarray) for res in results)
+        assert results[0].shape == (100, 2)
+        assert results[1].shape == (50, 1)
+
 
 class TestExecutingBatches:
     @staticmethod

--- a/tests/devices/qubit/test_sampling.py
+++ b/tests/devices/qubit/test_sampling.py
@@ -280,7 +280,6 @@ class TestMeasureSamples:
         assert result != 0
         assert np.allclose(result, 0, atol=0.05)
 
-<<<<<<< HEAD
     def test_approximate_var_measure(self):
         """Test that a variance measurement works as expected"""
         state = qml.math.array(two_qubit_state)
@@ -292,8 +291,6 @@ class TestMeasureSamples:
         assert result != 1
         assert np.allclose(result, 1, atol=0.05)
 
-=======
->>>>>>> e4fd474b7 (Add more tests)
     @pytest.mark.parametrize(
         "shots, total_copies",
         [

--- a/tests/devices/qubit/test_sampling.py
+++ b/tests/devices/qubit/test_sampling.py
@@ -280,6 +280,7 @@ class TestMeasureSamples:
         assert result != 0
         assert np.allclose(result, 0, atol=0.05)
 
+<<<<<<< HEAD
     def test_approximate_var_measure(self):
         """Test that a variance measurement works as expected"""
         state = qml.math.array(two_qubit_state)
@@ -291,6 +292,8 @@ class TestMeasureSamples:
         assert result != 1
         assert np.allclose(result, 1, atol=0.05)
 
+=======
+>>>>>>> e4fd474b7 (Add more tests)
     @pytest.mark.parametrize(
         "shots, total_copies",
         [

--- a/tests/devices/qubit/test_sampling.py
+++ b/tests/devices/qubit/test_sampling.py
@@ -151,11 +151,11 @@ class TestMeasureSamples:
         result0 = measure_with_samples(mp0, state, shots=shots)
         result1 = measure_with_samples(mp1, state, shots=shots)
 
-        assert result0.shape == (shots.total_shots, 1)
+        assert result0.shape == (shots.total_shots,)
         assert result0.dtype == np.bool8
         assert np.all(result0 == 0)
 
-        assert result1.shape == (shots.total_shots, 1)
+        assert result1.shape == (shots.total_shots,)
         assert result1.dtype == np.bool8
         assert len(np.unique(result1)) == 2
 

--- a/tests/devices/qubit/test_simulate.py
+++ b/tests/devices/qubit/test_simulate.py
@@ -335,6 +335,38 @@ class TestSampleMeasurements:
 
             assert shot_res[2].shape == (s, 2)
 
+    def test_custom_wire_labels(self):
+        """Test that custom wire labels works as expected"""
+        x, y = np.array(0.732), np.array(0.488)
+        qs = qml.tape.QuantumScript(
+            [qml.RX(x, wires='b'), qml.CNOT(wires=['b', 'a']), qml.RY(y, wires='a')],
+            [qml.expval(qml.PauliZ('b')), qml.probs(wires=['a', 'b']), qml.sample(wires=['b', 'a'])],
+            shots=10000,
+        )
+        result = simulate(qs)
+
+        assert isinstance(result, tuple)
+        assert len(result) == 3
+
+        assert all(isinstance(res, np.ndarray) for res in result)
+
+        assert result[0].shape == ()
+        assert np.allclose(result[0], np.cos(x), atol=0.1)
+
+        assert result[1].shape == (4,)
+        assert np.allclose(
+            result[1],
+            [
+                np.cos(x / 2) ** 2 * np.cos(y / 2) ** 2,
+                np.sin(x / 2) ** 2 * np.sin(y / 2) ** 2,
+                np.cos(x / 2) ** 2 * np.sin(y / 2) ** 2,
+                np.sin(x / 2) ** 2 * np.cos(y / 2) ** 2,
+            ],
+            atol=0.1,
+        )
+
+        assert result[2].shape == (10000, 2)
+
 
 class TestOperatorArithmetic:
     def test_numpy_op_arithmetic(self):

--- a/tests/devices/qubit/test_simulate.py
+++ b/tests/devices/qubit/test_simulate.py
@@ -339,8 +339,12 @@ class TestSampleMeasurements:
         """Test that custom wire labels works as expected"""
         x, y = np.array(0.732), np.array(0.488)
         qs = qml.tape.QuantumScript(
-            [qml.RX(x, wires='b'), qml.CNOT(wires=['b', 'a']), qml.RY(y, wires='a')],
-            [qml.expval(qml.PauliZ('b')), qml.probs(wires=['a', 'b']), qml.sample(wires=['b', 'a'])],
+            [qml.RX(x, wires="b"), qml.CNOT(wires=["b", "a"]), qml.RY(y, wires="a")],
+            [
+                qml.expval(qml.PauliZ("b")),
+                qml.probs(wires=["a", "b"]),
+                qml.sample(wires=["b", "a"]),
+            ],
             shots=10000,
         )
         result = simulate(qs)

--- a/tests/devices/qubit/test_simulate.py
+++ b/tests/devices/qubit/test_simulate.py
@@ -170,6 +170,19 @@ class TestBasicCircuit:
         assert qml.math.allclose(grad1[0], -tf.sin(phi))
 
 
+class TestSampleMeasurements:
+    """Tests circuits with sample-based measurements"""
+
+    def test_single_expval(self):
+        """Test a simple circuit with a single expval measurement"""
+        x = np.array(0.732)
+        qs = qml.tape.QuantumScript([qml.RY(x, wires=0)], [qml.expval(qml.PauliZ(0))], shots=10000)
+        result = simulate(qs)
+
+        assert isinstance(result, np.ndarray)
+        assert np.allclose(result, np.cos(x), atol=0.1)
+
+
 class TestOperatorArithmetic:
     def test_numpy_op_arithmetic(self):
         """Test an operator arithmetic circuit with non-integer wires with numpy."""


### PR DESCRIPTION
**Context:**
Part of the effort to integrate the new device API.

**Description of the Change:**
Update `simulate.py` to work with sample-based measurements.

**Benefits:**
Progress on integrating new device API 🎉 
