### PR TITLE
Adds tests for the `experimental.Device` abstract base class

### DIFF
--- a/pennylane/devices/experimental/default_qubit_2.py
+++ b/pennylane/devices/experimental/default_qubit_2.py
@@ -93,7 +93,7 @@ class DefaultQubit2(Device):
 
     def supports_derivatives(
         self,
-        execution_config: ExecutionConfig,
+        execution_config: Optional[ExecutionConfig] = None,
         circuit: Optional[QuantumTape] = None,
     ) -> bool:
         """Check whether or not derivatives are available for a given configuration and circuit.
@@ -109,6 +109,8 @@ class DefaultQubit2(Device):
             Bool: Whether or not a derivative can be calculated provided the given information
 
         """
+        if execution_config is None:
+            return True
         # backpropagation currently supported for all supported circuits
         # will later need to add logic if backprop requested with finite shots
         # do once device accepts finite shots

--- a/pennylane/devices/experimental/device_api.py
+++ b/pennylane/devices/experimental/device_api.py
@@ -20,7 +20,7 @@ import abc
 from numbers import Number
 from typing import Callable, Union, Sequence, Tuple, Optional
 
-from pennylane.tape import QuantumTape
+from pennylane.tape import QuantumTape, QuantumScript
 from pennylane import Tracker
 
 from .execution_config import ExecutionConfig, DefaultExecutionConfig
@@ -185,7 +185,7 @@ class Device(abc.ABC):
             """
             return res
 
-        circuit_batch = (circuits,) if isinstance(circuits, QuantumTape) else circuits
+        circuit_batch = (circuits,) if isinstance(circuits, QuantumScript) else circuits
         return circuit_batch, blank_postprocessing_fn, execution_config
 
     @abc.abstractmethod
@@ -266,7 +266,7 @@ class Device(abc.ABC):
 
     def supports_derivatives(
         self,
-        execution_config: ExecutionConfig,
+        execution_config: Optional[ExecutionConfig] = None,
         circuit: Optional[QuantumTape] = None,
     ) -> bool:
         """Determine whether or not a device provided derivative is potentially available.
@@ -341,12 +341,12 @@ class Device(abc.ABC):
 
         """
         if execution_config is None:
-            return self.compute_derivatives != Device.compute_derivatives
+            return type(self).compute_derivatives != Device.compute_derivatives
 
         if execution_config.gradient_method != "device" or execution_config.derivative_order != 1:
             return False
 
-        return self.compute_derivatives != Device.compute_derivatives
+        return type(self).compute_derivatives != Device.compute_derivatives
 
     def compute_derivatives(
         self,
@@ -466,7 +466,9 @@ class Device(abc.ABC):
         )
 
     def supports_jvp(
-        self, execution_config: ExecutionConfig, circuit: Optional[QuantumTape] = None
+        self,
+        execution_config: Optional[ExecutionConfig] = None,
+        circuit: Optional[QuantumTape] = None,
     ) -> bool:
         """Whether or not a given device defines a custom jacobian vector product.
 
@@ -542,7 +544,9 @@ class Device(abc.ABC):
         )
 
     def supports_vjp(
-        self, execution_config: ExecutionConfig, circuit: Optional[QuantumTape] = None
+        self,
+        execution_config: Optional[ExecutionConfig] = None,
+        circuit: Optional[QuantumTape] = None,
     ) -> bool:
         """Whether or not a given device defines a custom vector jacobian product.
 

--- a/tests/devices/experimental/test_default_qubit_2.py
+++ b/tests/devices/experimental/test_default_qubit_2.py
@@ -134,6 +134,8 @@ class TestSupportsDerivatives:
     def test_supports_backprop(self):
         """Test that DefaultQubit2 says that it supports backpropagation."""
         dev = DefaultQubit2()
+        assert dev.supports_derivatives() is True
+
         config = ExecutionConfig(gradient_method="backprop")
         assert dev.supports_derivatives(config) is True
 

--- a/tests/devices/experimental/test_device_api.py
+++ b/tests/devices/experimental/test_device_api.py
@@ -49,12 +49,12 @@ class TestMinimalDevice:
         assert self.dev.name == "MinimalDevice"
 
     def test_tracker_set_on_initialization(self):
-        """Test that a new tracker instance is intiailized with the class."""
+        """Test that a new tracker instance is initialized with the class."""
         assert isinstance(self.dev.tracker, qml.Tracker)
         assert self.dev.tracker is not self.MinimalDevice.tracker
 
     def test_preprocess_single_circuit(self):
-        """Test that preprocessing wraps a circuit circuit into a batch."""
+        """Test that preprocessing wraps a circuit into a batch."""
 
         circuit1 = qml.tape.QuantumScript()
         batch, fn, config = self.dev.preprocess(circuit1)
@@ -80,7 +80,7 @@ class TestMinimalDevice:
         assert fn(a) is a
 
     def test_supports_derivatives_default(self):
-        """Test that the defualt behavir of supports derivatives is false."""
+        """Test that the default behavior of supports derivatives is false."""
 
         assert not self.dev.supports_derivatives()
         assert not self.dev.supports_derivatives(ExecutionConfig())

--- a/tests/devices/experimental/test_device_api.py
+++ b/tests/devices/experimental/test_device_api.py
@@ -14,6 +14,7 @@
 """
 Tests for the basic default behavior of the Device API.
 """
+# pylint:disable=unused-argument
 import pytest
 
 import pennylane as qml
@@ -23,6 +24,7 @@ from pennylane.devices.experimental import Device, ExecutionConfig, DefaultExecu
 def test_execute_method_abstract():
     """Test that a device can't be instantiated without an execute method."""
 
+    # pylint: disable=too-few-public-methods
     class BadDevice(Device):
         """A bad device"""
 
@@ -139,6 +141,7 @@ class TestProvidingDerivatives:
         assert dev.supports_derivatives()
         assert not dev.supports_derivatives(ExecutionConfig(derivative_order=2))
         assert not dev.supports_derivatives(ExecutionConfig(gradient_method="backprop"))
+        assert dev.supports_derivatives(ExecutionConfig(gradient_method="device"))
 
         out = dev.execute_and_compute_derivatives(qml.tape.QuantumScript())
         assert out[0] == "a"

--- a/tests/devices/experimental/test_device_api.py
+++ b/tests/devices/experimental/test_device_api.py
@@ -35,7 +35,6 @@ def test_execute_method_abstract():
 class TestMinimalDevice:
     """Tests for a device with only a minimal execute provided."""
 
-
     # pylint: disable=too-few-public-methods
     class MinimalDevice(Device):
         """A device with only a dummy execute method provided."""

--- a/tests/devices/experimental/test_device_api.py
+++ b/tests/devices/experimental/test_device_api.py
@@ -26,7 +26,7 @@ def test_execute_method_abstract():
     class BadDevice(Device):
         """A bad device"""
 
-    with pytest.raises(TypeError, match=r"with abstract method execute"):
+    with pytest.raises(TypeError, match=r"instantiate abstract class BadDevice"):
         BadDevice()  # pylint: disable=abstract-class-instantiated
 
 

--- a/tests/devices/experimental/test_device_api.py
+++ b/tests/devices/experimental/test_device_api.py
@@ -35,6 +35,8 @@ def test_execute_method_abstract():
 class TestMinimalDevice:
     """Tests for a device with only a minimal execute provided."""
 
+
+    # pylint: disable=too-few-public-methods
     class MinimalDevice(Device):
         """A device with only a dummy execute method provided."""
 

--- a/tests/devices/experimental/test_device_api.py
+++ b/tests/devices/experimental/test_device_api.py
@@ -1,0 +1,192 @@
+# Copyright 2018-2023 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Tests for the basic default behavior of the Device API.
+"""
+import pytest
+
+import pennylane as qml
+from pennylane.devices.experimental import Device, ExecutionConfig, DefaultExecutionConfig
+
+
+def test_execute_method_abstract():
+    """Test that a device can't be instantiated without an execute method."""
+
+    class BadDevice(Device):
+        """A bad device"""
+
+    with pytest.raises(TypeError, match=r"with abstract method execute"):
+        BadDevice()  # pylint: disable=abstract-class-instantiated
+
+
+class TestMinimalDevice:
+    """Tests for a device with only a minimal execute provided."""
+
+    class MinimalDevice(Device):
+        """A device with only a dummy execute method provided."""
+
+        # pylint:disable=unused-argnument
+        def execute(self, circuits, execution_config=DefaultExecutionConfig):
+            return (0,)
+
+    dev = MinimalDevice()
+
+    def test_device_name(self):
+        """Test the default name is the name of the class"""
+        assert self.dev.name == "MinimalDevice"
+
+    def test_tracker_set_on_initialization(self):
+        """Test that a new tracker instance is intiailized with the class."""
+        assert isinstance(self.dev.tracker, qml.Tracker)
+        assert self.dev.tracker is not self.MinimalDevice.tracker
+
+    def test_preprocess_single_circuit(self):
+        """Test that preprocessing wraps a circuit circuit into a batch."""
+
+        circuit1 = qml.tape.QuantumScript()
+        batch, fn, config = self.dev.preprocess(circuit1)
+        assert isinstance(batch, tuple)
+        assert len(batch) == 1
+        assert batch[0] is circuit1
+        assert callable(fn)
+
+        a = (1, 2)
+        assert fn(a) is a
+        assert config is qml.devices.experimental.DefaultExecutionConfig
+
+    def test_preprocess_batch_circuits(self):
+        """Test that preprocessing a batch doesn't do anything."""
+
+        circuit = qml.tape.QuantumScript()
+        in_config = ExecutionConfig()
+        in_batch = (circuit, circuit)
+        batch, fn, config = self.dev.preprocess(in_batch, in_config)
+        assert batch is in_batch
+        assert config is in_config
+        a = (1, 2)
+        assert fn(a) is a
+
+    def test_supports_derivatives_default(self):
+        """Test that the defualt behavir of supports derivatives is false."""
+
+        assert not self.dev.supports_derivatives()
+        assert not self.dev.supports_derivatives(ExecutionConfig())
+
+    def test_compute_derivatives_notimplemented(self):
+        """Test that compute derivatives raises a notimplementederror."""
+
+        with pytest.raises(NotImplementedError):
+            self.dev.compute_derivatives(qml.tape.QuantumScript())
+
+        with pytest.raises(NotImplementedError):
+            self.dev.execute_and_compute_derivatives(qml.tape.QuantumScript())
+
+    def test_supports_jvp_default(self):
+        """Test that the default behaviour of supports_jvp is false."""
+        assert not self.dev.supports_jvp()
+
+    def test_compute_jvp_not_implemented(self):
+        """Test that compute_jvp is not implemented by default."""
+        with pytest.raises(NotImplementedError):
+            self.dev.compute_jvp(qml.tape.QuantumScript(), (0.1,))
+
+        with pytest.raises(NotImplementedError):
+            self.dev.execute_and_compute_jvp(qml.tape.QuantumScript(), (0.1,))
+
+    def test_supports_vjp_default(self):
+        """Test that the default behavior of supports_jvp is false."""
+        assert not self.dev.supports_vjp()
+
+    def test_compute_vjp_not_implemented(self):
+        """Test that compute_vjp is not implemented by default."""
+        with pytest.raises(NotImplementedError):
+            self.dev.compute_vjp(qml.tape.QuantumScript(), (0.1,))
+
+        with pytest.raises(NotImplementedError):
+            self.dev.execute_and_compute_vjp(qml.tape.QuantumScript(), (0.1,))
+
+
+class TestProvidingDerivatives:
+    """Tests logic when derivatives, vjp, or jvp are overridden."""
+
+    def test_provided_derivative(self):
+        """Tests default logic for a device with a derivative provided."""
+
+        class WithDerivative(Device):
+            """A device with a derivative."""
+
+            # pylint: disable=unused-argument
+            def execute(self, circuits, execution_config: ExecutionConfig = DefaultExecutionConfig):
+                return "a"
+
+            def compute_derivatives(
+                self, circuits, execution_config: ExecutionConfig = DefaultExecutionConfig
+            ):
+                return ("b",)
+
+        dev = WithDerivative()
+        assert dev.supports_derivatives()
+        assert not dev.supports_derivatives(ExecutionConfig(derivative_order=2))
+        assert not dev.supports_derivatives(ExecutionConfig(gradient_method="backprop"))
+
+        out = dev.execute_and_compute_derivatives(qml.tape.QuantumScript())
+        assert out[0] == "a"
+        assert out[1] == ("b",)
+
+    def test_provided_jvp(self):
+        """Tests default logic for a device with a jvp provided."""
+
+        # pylint: disable=unused-argnument
+        class WithJvp(Device):
+            """A device with a jvp."""
+
+            def execute(self, circuits, execution_config: ExecutionConfig = DefaultExecutionConfig):
+                return "a"
+
+            def compute_jvp(
+                self, circuits, tangents, execution_config: ExecutionConfig = DefaultExecutionConfig
+            ):
+                return ("c",)
+
+        dev = WithJvp()
+        assert dev.supports_jvp()
+
+        out = dev.execute_and_compute_jvp(qml.tape.QuantumScript(), (1.0,))
+        assert out[0] == "a"
+        assert out[1] == ("c",)
+
+    def test_provided_vjp(self):
+        """Tests default logic for a device with a vjp provided."""
+
+        # pylint: disable=unused-argnument
+        class WithVjp(Device):
+            """A device with a vjp."""
+
+            def execute(self, circuits, execution_config: ExecutionConfig = DefaultExecutionConfig):
+                return "a"
+
+            def compute_vjp(
+                self,
+                circuits,
+                cotangents,
+                execution_config: ExecutionConfig = DefaultExecutionConfig,
+            ):
+                return ("c",)
+
+        dev = WithVjp()
+        assert dev.supports_vjp()
+
+        out = dev.execute_and_compute_vjp(qml.tape.QuantumScript(), (1.0,))
+        assert out[0] == "a"
+        assert out[1] == ("c",)


### PR DESCRIPTION
I initially didn't add tests for the `experimental.Device` interface, as any class that implements this interface should test the behaviour of all methods.

But at the end of the day, it doesn't hurt to test the "default" behavior of the interface.

This even allowed me to find some minor changes that needed to be made, such as:
*  changing the `isisntance` check to `QuantumScript` instead of `QuantumTape`
* defaulting the `execution_config` to `None` instead of `DefaultExecutionConfig` for the `supports_*` methods

Mostly, this will keep us from getting code coverage complaints every time we tweak the `device_api.py` file.