### PR TITLE
Update tape transforms to copy `shots` attribute

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -25,6 +25,7 @@
   [(#4067)](https://github.com/PennyLaneAI/pennylane/pull/4067)
   [(#4103)](https://github.com/PennyLaneAI/pennylane/pull/4103)
   [(#4106)](https://github.com/PennyLaneAI/pennylane/pull/4106)
+  [(#4112)](https://github.com/PennyLaneAI/pennylane/pull/4112)
 
 * `qml.specs` is compatible with custom operations that have `depth` bigger than 1.
   [(#4033)](https://github.com/PennyLaneAI/pennylane/pull/4033)

--- a/pennylane/devices/qubit/preprocess.py
+++ b/pennylane/devices/qubit/preprocess.py
@@ -137,7 +137,7 @@ def validate_and_expand_adjoint(
         else:
             trainable_params.append(k)
 
-    expanded_tape = qml.tape.QuantumScript(expanded_ops, measurements, prep)
+    expanded_tape = qml.tape.QuantumScript(expanded_ops, measurements, prep, circuit.shots)
     expanded_tape.trainable_params = trainable_params
 
     return expanded_tape
@@ -175,7 +175,9 @@ def expand_fn(circuit: qml.tape.QuantumScript) -> qml.tape.QuantumScript:
                 "Reached recursion limit trying to decompose operations. "
                 "Operator decomposition may have entered an infinite loop."
             ) from e
-        circuit = qml.tape.QuantumScript(new_ops, circuit.measurements, circuit._prep)
+        circuit = qml.tape.QuantumScript(
+            new_ops, circuit.measurements, circuit._prep, circuit.shots
+        )
 
     for observable in circuit.observables:
         if isinstance(observable, Tensor):

--- a/pennylane/gradients/hadamard_gradient.py
+++ b/pennylane/gradients/hadamard_gradient.py
@@ -302,7 +302,7 @@ def _expval_hadamard_grad(tape, argnum, aux_wire):
                 else:
                     measurements.append(qml.probs(op=obs_new))
 
-            new_tape = qml.tape.QuantumScript(ops=ops, measurements=measurements)
+            new_tape = qml.tape.QuantumScript(ops=ops, measurements=measurements, shots=tape.shots)
 
             _rotations, _measurements = qml.tape.tape.rotations_and_diagonal_measurements(new_tape)
             # pylint: disable=protected-access

--- a/pennylane/gradients/pulse_gradient.py
+++ b/pennylane/gradients/pulse_gradient.py
@@ -110,7 +110,7 @@ def _split_evol_tapes(tape, split_evolve_ops, op_idx):
     ops_pre = tape.operations[:op_idx]
     ops_post = tape.operations[op_idx + 1 :]
     return [
-        qml.tape.QuantumScript(ops_pre + split + ops_post, tape.measurements)
+        qml.tape.QuantumScript(ops_pre + split + ops_post, tape.measurements, shots=tape.shots)
         for split in split_evolve_ops
     ]
 

--- a/pennylane/ops/functions/simplify.py
+++ b/pennylane/ops/functions/simplify.py
@@ -95,6 +95,7 @@ def simplify(input: Union[Operator, MeasurementProcess, QuantumTape, QNode, Call
             [op.simplify() for op in input._ops],
             [m.simplify() for m in input.measurements],
             [op.simplify() for op in input._prep],
+            shots=input.shots,
         )
 
     if callable(input):

--- a/pennylane/qinfo/transforms.py
+++ b/pennylane/qinfo/transforms.py
@@ -306,7 +306,9 @@ def _compute_cfim(p, dp):
 def _make_probs(tape, wires=None, post_processing_fn=None):
     """Ignores the return types of the provided circuit and creates a new one
     that outputs probabilities"""
-    qscript = qml.tape.QuantumScript(tape.operations, [qml.probs(wires=wires or tape.wires)])
+    qscript = qml.tape.QuantumScript(
+        tape.operations, [qml.probs(wires=wires or tape.wires)], shots=tape.shots
+    )
 
     if post_processing_fn is None:
 

--- a/pennylane/shadows/transforms.py
+++ b/pennylane/shadows/transforms.py
@@ -42,7 +42,7 @@ def _replace_obs(tape: QuantumTape, obs, *args, **kwargs):
 
         # queue the new observable
         obs(*args, **kwargs)
-    qscript = QuantumScript.from_queue(q)
+    qscript = QuantumScript.from_queue(q, shots=tape.shots)
 
     def processing_fn(res):
         if qml.active_return():

--- a/pennylane/transforms/convert_to_numpy_parameters.py
+++ b/pennylane/transforms/convert_to_numpy_parameters.py
@@ -86,7 +86,7 @@ def convert_to_numpy_parameters(circuit: QuantumScript) -> QuantumScript:
     new_prep = (_convert_op_to_numpy_data(op) for op in circuit._prep)
     new_ops = (_convert_op_to_numpy_data(op) for op in circuit._ops)
     new_measurements = (_convert_measurement_to_numpy_data(m) for m in circuit.measurements)
-    new_circuit = circuit.__class__(new_ops, new_measurements, new_prep)
+    new_circuit = circuit.__class__(new_ops, new_measurements, new_prep, shots=circuit.shots)
     # must preserve trainable params as we lose information about the machine learning interface
     new_circuit.trainable_params = circuit.trainable_params
     new_circuit._qfunc_output = circuit._qfunc_output

--- a/pennylane/transforms/hamiltonian_expand.py
+++ b/pennylane/transforms/hamiltonian_expand.py
@@ -158,7 +158,9 @@ def hamiltonian_expand(tape: QuantumTape, group=True):
         # observables in that grouping
         tapes = []
         for obs in obs_groupings:
-            new_tape = tape.__class__(tape._ops, (qml.expval(o) for o in obs), tape._prep)
+            new_tape = tape.__class__(
+                tape._ops, (qml.expval(o) for o in obs), tape._prep, shots=tape.shots
+            )
 
             new_tape = new_tape.expand(stop_at=lambda obj: True)
             tapes.append(new_tape)
@@ -195,7 +197,7 @@ def hamiltonian_expand(tape: QuantumTape, group=True):
     tapes = []
     for o in hamiltonian.ops:
         # pylint: disable=protected-access
-        new_tape = tape.__class__(tape._ops, [qml.expval(o)], tape._prep)
+        new_tape = tape.__class__(tape._ops, [qml.expval(o)], tape._prep, shots=tape.shots)
         tapes.append(new_tape)
 
     # pylint: disable=function-redefined
@@ -353,12 +355,13 @@ def sum_expand(tape: QuantumTape, group=True):
                 tmp_idxs.append([idxs_coeffs[measurements.index(m)] for m in m_group])
         idxs_coeffs = tmp_idxs
         qscripts = [
-            QuantumScript(ops=tape._ops, measurements=m_group, prep=tape._prep)
+            QuantumScript(ops=tape._ops, measurements=m_group, prep=tape._prep, shots=tape.shots)
             for m_group in m_groups
         ]
     else:
         qscripts = [
-            QuantumScript(ops=tape._ops, measurements=[m], prep=tape._prep) for m in measurements
+            QuantumScript(ops=tape._ops, measurements=[m], prep=tape._prep, shots=tape.shots)
+            for m in measurements
         ]
 
     def processing_fn(expanded_results):

--- a/pennylane/transforms/qfunc_transforms.py
+++ b/pennylane/transforms/qfunc_transforms.py
@@ -145,7 +145,7 @@ class single_tape_transform:
     def __call__(self, tape, *args, **kwargs):
         with qml.queuing.AnnotatedQueue() as q:
             self.transform_fn(tape, *args, **kwargs)
-        qs = qml.tape.QuantumScript.from_queue(q)
+        qs = qml.tape.QuantumScript.from_queue(q, shots=tape.shots)
         for obj, info in q.items():
             qml.queuing.QueuingManager.append(obj, **info)
         return qs

--- a/pennylane/transforms/sign_expand/sign_expand.py
+++ b/pennylane/transforms/sign_expand/sign_expand.py
@@ -188,7 +188,7 @@ def construct_sgn_circuit(  # pylint: disable=too-many-arguments
         else:
             measurements = [qml.var(qml.PauliZ(controls[0]))]
 
-        new_tape = qml.tape.QuantumScript(operations, measurements)
+        new_tape = qml.tape.QuantumScript(operations, measurements, shots=tape.shots)
 
         tapes.append(new_tape)
     return tapes
@@ -353,7 +353,7 @@ def sign_expand(  # pylint: disable=too-many-arguments
         else:
             measurements = [qml.var(qml.Hermitian(proj, wires=wires))]
 
-        new_tape = qml.tape.QuantumScript(tape.operations, measurements)
+        new_tape = qml.tape.QuantumScript(tape.operations, measurements, shots=tape.shots)
 
         tapes.append(new_tape)
 

--- a/tests/gradients/core/test_hadamard_gradient.py
+++ b/tests/gradients/core/test_hadamard_gradient.py
@@ -520,6 +520,24 @@ class TestHadamardGrad:
 
         assert len(record) == 0
 
+    @pytest.mark.parametrize("shots", [None, 100])
+    def test_shots_attribute(self, shots):
+        """Tests that the shots attribute is copied to the new tapes"""
+        dev = qml.device("default.qubit", wires=3)
+        x = 0.543
+        y = -0.654
+
+        with qml.queuing.AnnotatedQueue() as q:
+            qml.RX(x, wires=[0])
+            qml.RY(y, wires=[1])
+            qml.CNOT(wires=[0, 1])
+            qml.expval(qml.PauliZ(0) @ qml.PauliX(1))
+
+        tape = qml.tape.QuantumScript.from_queue(q, shots=shots)
+        _, tapes = grad_fn(tape, dev)
+
+        assert all(new_tape.shots == tape.shots for new_tape in tapes)
+
 
 class TestHadamardGradEdgeCases:
     """Test the Hadamard gradient transform and edge cases such as non diff parameters, auxiliary wires, etc..."""

--- a/tests/gradients/core/test_pulse_gradient.py
+++ b/tests/gradients/core/test_pulse_gradient.py
@@ -644,6 +644,14 @@ class TestStochPulseGrad:
         res_jit = jax.jit(fun)(params)
         assert qml.math.isclose(res, res_jit)
 
+    @pytest.mark.parametrize("shots", [None, 100])
+    def test_shots_attribute(self, shots):
+        """Tests that the shots attribute is copied to the new tapes"""
+        tape = qml.tape.QuantumTape([], [qml.expval(qml.PauliZ(0)), qml.probs([1, 2])], shots=shots)
+        tapes, _ = stoch_pulse_grad(tape)
+
+        assert all(new_tape.shots == tape.shots for new_tape in tapes)
+
 
 @pytest.mark.jax
 class TestStochPulseGradQNodeIntegration:

--- a/tests/ops/functions/test_simplify.py
+++ b/tests/ops/functions/test_simplify.py
@@ -74,12 +74,13 @@ class TestSimplifyOperators:
 class TestSimplifyTapes:
     """Tests for the qml.simplify method used with tapes."""
 
-    def test_simplify_tape(self):
+    @pytest.mark.parametrize("shots", [None, 100])
+    def test_simplify_tape(self, shots):
         """Test the simplify method with a tape."""
         with qml.queuing.AnnotatedQueue() as q_tape:
             build_op()
 
-        tape = QuantumScript.from_queue(q_tape)
+        tape = QuantumScript.from_queue(q_tape, shots=shots)
         s_tape = qml.simplify(tape)
         assert len(s_tape) == 1
         s_op = s_tape[0]
@@ -87,6 +88,7 @@ class TestSimplifyTapes:
         assert s_op.data == simplified_op.data
         assert s_op.wires == simplified_op.wires
         assert s_op.arithmetic_depth == simplified_op.arithmetic_depth
+        assert tape.shots == s_tape.shots
 
     def test_execute_simplified_tape(self):
         """Test the execution of a simplified tape."""

--- a/tests/qinfo/test_fisher.py
+++ b/tests/qinfo/test_fisher.py
@@ -44,16 +44,18 @@ class TestMakeProbs:
         tape, _ = new_qnode.construct(x, {})
         assert tape[0].observables[0].return_type == qml.measurements.Probability
 
-    def test_make_probs(self):
+    @pytest.mark.parametrize("shots", [None, 100])
+    def test_make_probs(self, shots):
         """Testing the private _make_probs transform"""
         with qml.queuing.AnnotatedQueue() as q:
             qml.PauliX(0)
             qml.PauliZ(1)
             qml.PauliY(2)
-        tape = qml.tape.QuantumScript.from_queue(q)
+        tape = qml.tape.QuantumScript.from_queue(q, shots=shots)
         new_tape, fn = _make_probs(tape)
         assert len(new_tape) == 1
         assert np.isclose(fn([1]), 1)
+        assert new_tape[0].shots == tape.shots
 
 
 class TestComputeclassicalFisher:

--- a/tests/transforms/test_convert_to_numpy_parameters.py
+++ b/tests/transforms/test_convert_to_numpy_parameters.py
@@ -33,7 +33,8 @@ ml_frameworks_list = [
 
 
 @pytest.mark.parametrize("framework", ml_frameworks_list)
-def test_convert_arrays_to_numpy(framework):
+@pytest.mark.parametrize("shots", [None, 100])
+def test_convert_arrays_to_numpy(framework, shots):
     """Tests that convert_to_numpy_parameters works with autograd arrays."""
 
     x = qml.math.asarray(np.array(1.234), like=framework)
@@ -47,7 +48,7 @@ def test_convert_arrays_to_numpy(framework):
     m = [qml.state(), qml.expval(qml.Hermitian(M, 0))]
     prep = [qml.QubitStateVector(state, 0)]
 
-    qs = qml.tape.QuantumScript(ops, m, prep)
+    qs = qml.tape.QuantumScript(ops, m, prep, shots=shots)
     new_qs = convert_to_numpy_parameters(qs)
 
     # check ops that should be unaltered
@@ -58,6 +59,9 @@ def test_convert_arrays_to_numpy(framework):
     for ind in (0, 1, 2, 6):
         assert qml.equal(new_qs[ind], qs[ind], check_interface=False, check_trainability=False)
         assert qml.math.get_interface(*new_qs[ind].data) == "numpy"
+
+    # check shots attribute matches
+    assert new_qs.shots == qs.shots
 
 
 @pytest.mark.autograd

--- a/tests/transforms/test_hamiltonian_expand.py
+++ b/tests/transforms/test_hamiltonian_expand.py
@@ -179,6 +179,23 @@ class TestHamiltonianExpand:
         tapes, fn = hamiltonian_expand(qs, group=True)
         assert len(tapes) == 2
 
+    @pytest.mark.parametrize("shots", [None, 100])
+    @pytest.mark.parametrize("group", [True, False])
+    def test_shots_attribute(self, shots, group):
+        """Tests that the shots attribute is copied to the new tapes"""
+        H = qml.Hamiltonian([1.0, 2.0, 3.0], [qml.PauliZ(0), qml.PauliX(1), qml.PauliX(0)])
+
+        with AnnotatedQueue() as q:
+            qml.Hadamard(wires=0)
+            qml.CNOT(wires=[0, 1])
+            qml.PauliX(wires=2)
+            qml.expval(H)
+
+        tape = QuantumScript.from_queue(q, shots=shots)
+        new_tapes, _ = hamiltonian_expand(tape, group=group)
+
+        assert all(new_tape.shots == tape.shots for new_tape in new_tapes)
+
     def test_hamiltonian_error(self):
         """Tests that the script passed to hamiltonian_expand must end with a hamiltonian."""
         qscript = QuantumScript(measurements=[qml.expval(qml.PauliZ(0))])
@@ -430,6 +447,23 @@ class TestSumExpand:
 
         tapes, fn = sum_expand(qs, group=True)
         assert len(tapes) == 2
+
+    @pytest.mark.parametrize("shots", [None, 100])
+    @pytest.mark.parametrize("group", [True, False])
+    def test_shots_attribute(self, shots, group):
+        """Tests that the shots attribute is copied to the new tapes"""
+        H = qml.Hamiltonian([1.0, 2.0, 3.0], [qml.PauliZ(0), qml.PauliX(1), qml.PauliX(0)])
+
+        with AnnotatedQueue() as q:
+            qml.Hadamard(wires=0)
+            qml.CNOT(wires=[0, 1])
+            qml.PauliX(wires=2)
+            qml.expval(H)
+
+        tape = QuantumScript.from_queue(q, shots=shots)
+        new_tapes, _ = sum_expand(tape, group=group)
+
+        assert all(new_tape.shots == tape.shots for new_tape in new_tapes)
 
     def test_non_sum_tape(self):
         """Test that the ``sum_expand`` function returns the input tape if it does not

--- a/tests/transforms/test_qfunc_transform.py
+++ b/tests/transforms/test_qfunc_transform.py
@@ -31,7 +31,8 @@ class TestSingleTapeTransform:
         with pytest.raises(ValueError, match="does not appear to be a valid Python function"):
             qml.single_tape_transform(5)
 
-    def test_parametrized_transform(self):
+    @pytest.mark.parametrize("shots", [None, 100])
+    def test_parametrized_transform(self, shots):
         """Test that a parametrized transform can be applied
         to a tape"""
 
@@ -55,8 +56,10 @@ class TestSingleTapeTransform:
             qml.Hadamard(wires=0)
             qml.CRX(x, wires=[0, 1])
 
-        tape = qml.tape.QuantumScript.from_queue(q)
-        ops = my_transform(tape, a, b).operations
+        tape = qml.tape.QuantumScript.from_queue(q, shots=shots)
+        new_tape = my_transform(tape, a, b)
+        ops = new_tape.operations
+
         assert len(ops) == 4
         assert ops[0].name == "Hadamard"
 
@@ -67,6 +70,8 @@ class TestSingleTapeTransform:
         assert ops[2].parameters == [np.sum(b) * x / 2]
 
         assert ops[3].name == "CZ"
+
+        assert new_tape.shots == tape.shots
 
 
 class TestQFuncTransforms:

--- a/tests/transforms/test_sign_expand.py
+++ b/tests/transforms/test_sign_expand.py
@@ -114,6 +114,20 @@ class TestSignExpand:
         assert np.isclose(output, expval, 1e-2)
         # as these are approximations, these are only correct up to finite precision
 
+    @pytest.mark.parametrize("shots", [None, 100])
+    @pytest.mark.parametrize("circuit", [True, False])
+    def test_shots_attribute(self, shots, circuit):
+        """Tests that the shots attribute is copied to the new tapes"""
+        with qml.queuing.AnnotatedQueue() as q:
+            qml.PauliX(0)
+            H1 = qml.Hamiltonian([1.5], [qml.PauliZ(0) @ qml.PauliZ(1)])
+            qml.expval(H1)
+
+        tape = qml.tape.QuantumScript.from_queue(q, shots=shots)
+        new_tapes, _ = qml.transforms.sign_expand(tape, circuit=circuit)
+
+        assert all(new_tape.shots == tape.shots for new_tape in new_tapes)
+
     def test_hamiltonian_error(self):
         """Tests if wrong observables get caught in the test"""
 

--- a/tests/transforms/test_sign_expand.py
+++ b/tests/transforms/test_sign_expand.py
@@ -120,7 +120,6 @@ class TestSignExpand:
         """Tests that the shots attribute is copied to the new tapes"""
         with qml.queuing.AnnotatedQueue() as q:
             qml.PauliX(0)
-            H1 = qml.Hamiltonian([1.5], [qml.PauliZ(0) @ qml.PauliZ(1)])
             qml.expval(H1)
 
         tape = qml.tape.QuantumScript.from_queue(q, shots=shots)


### PR DESCRIPTION
**Context:**
Recently the `shots` attribute was put onto the `QuantumScript` class. Most of the transforms in the PennyLane repo have yet to be updated for this change.

**Description of the Change:**
Update the tape transforms to copy the `shots` attribute when creating a new tape.

**Benefits:**
Tape transforms now work fully with the new location of `shots`.

**Possible Drawbacks:**
None