### PR TITLE
Add measurement validation to `preprocess.py`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -52,6 +52,7 @@
 
 * Support for sample-based measurements has been added to the `DefaultQubit2` device.
   [(#4105)](https://github.com/PennyLaneAI/pennylane/pull/4105)
+  [(#4114)](https://github.com/PennyLaneAI/pennylane/pull/4114)
 
 * Added a `dense` keyword to `ParametrizedEvolution` that allows forcing dense or sparse matrices.
   [(#4079)](https://github.com/PennyLaneAI/pennylane/pull/4079)

--- a/pennylane/devices/qubit/preprocess.py
+++ b/pennylane/devices/qubit/preprocess.py
@@ -22,7 +22,7 @@ import warnings
 import pennylane as qml
 
 from pennylane.operation import Tensor
-from pennylane.measurements import MidMeasureMP, StateMeasurement, ExpectationMP
+from pennylane.measurements import MidMeasureMP, StateMeasurement, SampleMeasurement, ExpectationMP
 from pennylane import DeviceError
 
 from ..experimental import ExecutionConfig, DefaultExecutionConfig
@@ -144,6 +144,29 @@ def validate_and_expand_adjoint(
     return expanded_tape
 
 
+def validate_measurements(circuit: qml.tape.QuantumTape):
+    """Check that the circuit contains a valid set of measurements. A valid
+    set of measurements is defined as:
+
+    1. If circuit.shots is None (i.e., the execution is analytic), then
+       the circuit must only contain ``StateMeasurements``.
+    2. If circuit.shots is not None, then the circuit must only contain
+       ``SampleMeasurements``.
+
+    If the circuit has an invalid set of measurements, then an error is raised.
+    """
+    if circuit.shots.total_shots is None:
+        for m in circuit.measurements:
+            if not isinstance(m, StateMeasurement):
+                raise DeviceError(f"Analytic circuits must only contain StateMeasurements; got {m}")
+    else:
+        for m in circuit.measurements:
+            if not isinstance(m, SampleMeasurement):
+                raise DeviceError(
+                    f"Circuits with finite shots must only contain SampleMeasurements; got {m}"
+                )
+
+
 def expand_fn(circuit: qml.tape.QuantumScript) -> qml.tape.QuantumScript:
     """Method for expanding or decomposing an input circuit.
 
@@ -177,7 +200,7 @@ def expand_fn(circuit: qml.tape.QuantumScript) -> qml.tape.QuantumScript:
                 "Operator decomposition may have entered an infinite loop."
             ) from e
         circuit = qml.tape.QuantumScript(
-            new_ops, circuit.measurements, circuit._prep, circuit.shots
+            new_ops, circuit.measurements, circuit._prep, shots=circuit.shots
         )
 
     for observable in circuit.observables:
@@ -186,11 +209,6 @@ def expand_fn(circuit: qml.tape.QuantumScript) -> qml.tape.QuantumScript:
                 raise DeviceError(f"Observable {observable} not supported on DefaultQubit2")
         elif observable.name not in _observables:
             raise DeviceError(f"Observable {observable} not supported on DefaultQubit2")
-
-    # change this once shots are supported
-    for m in circuit.measurements:
-        if not isinstance(m, StateMeasurement):
-            raise DeviceError(f"Measurement process {m} is only useable with finite shots.")
 
     return circuit
 
@@ -278,6 +296,8 @@ def preprocess(
         Tuple[QuantumTape], Callable, ExecutionConfig: QuantumTapes that the device can natively execute,
         a postprocessing function to be called after execution, and a configuration with originally unset specifications filled in.
     """
+    for c in circuits:
+        validate_measurements(c)
 
     circuits = tuple(expand_fn(c) for c in circuits)
     if execution_config.gradient_method == "adjoint":

--- a/tests/devices/qubit/test_preprocess.py
+++ b/tests/devices/qubit/test_preprocess.py
@@ -28,6 +28,7 @@ from pennylane.devices.qubit.preprocess import (
     validate_and_expand_adjoint,
     validate_measurements,
 )
+from pennylane.devices.experimental import ExecutionConfig
 from pennylane.measurements import MidMeasureMP, MeasurementValue
 from pennylane.tape import QuantumScript
 from pennylane import DeviceError
@@ -311,6 +312,19 @@ class TestValidateMeasurements:
         msg = "Circuits with finite shots must only contain SampleMeasurements"
         with pytest.raises(DeviceError, match=msg):
             validate_measurements(tape)
+
+    @pytest.mark.parametrize("diff_method", ["adjoint", "backprop"])
+    def test_finite_shots_analytic_diff_method(self, diff_method):
+        """Test that a circuit with finite shots executed with diff_method "adjoint"
+        or "backprop" raises an error"""
+        tape = QuantumScript([], [qml.expval(qml.PauliZ(0))], shots=100)
+
+        execution_config = ExecutionConfig()
+        execution_config.gradient_method = diff_method
+
+        msg = "Circuits with finite shots must be executed with non-analytic gradient methods"
+        with pytest.raises(DeviceError, match=msg):
+            validate_measurements(tape, execution_config)
 
 
 class TestBatchTransform:


### PR DESCRIPTION
**Context:**
Part of the effort to integrate the new device API. Support for sample-based measurements was recently added 🎉

**Description of the Change:**
Add a new validation check to `preprocess.py`. This checks if analytic executions only contains `StateMeasurements` and finite-shot executions only contains `SampleMeasurements`.

**Benefits:**
Feedback is provided to the user if an invalid set of measurements (e.g. state and sample) is executed.

**Possible Drawbacks:**
Might be slightly slower, but this is a one-time check at the start of the execution. 
