### PR TITLE
Allow `DefaultQubit2` to be initialized with a random seed

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -56,6 +56,7 @@
 * Support for sample-based measurements has been added to the `DefaultQubit2` device.
   [(#4105)](https://github.com/PennyLaneAI/pennylane/pull/4105)
   [(#4114)](https://github.com/PennyLaneAI/pennylane/pull/4114)
+  [(#4120)](https://github.com/PennyLaneAI/pennylane/pull/4120)
 
 * Added a `dense` keyword to `ParametrizedEvolution` that allows forcing dense or sparse matrices.
   [(#4079)](https://github.com/PennyLaneAI/pennylane/pull/4079)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -59,6 +59,8 @@
 * Support for sample-based measurements has been added to the `DefaultQubit2` device.
   [(#4105)](https://github.com/PennyLaneAI/pennylane/pull/4105)
   [(#4114)](https://github.com/PennyLaneAI/pennylane/pull/4114)
+
+* Added a keyword argument `seed` to the `DefaultQubit2` device.
   [(#4120)](https://github.com/PennyLaneAI/pennylane/pull/4120)
 
 * Added a `dense` keyword to `ParametrizedEvolution` that allows forcing dense or sparse matrices.

--- a/pennylane/devices/experimental/default_qubit_2.py
+++ b/pennylane/devices/experimental/default_qubit_2.py
@@ -17,6 +17,7 @@ This module contains the next generation successor to default qubit
 
 from typing import Union, Callable, Tuple, Optional, Sequence
 
+import pennylane.numpy as np
 from pennylane.resource import Resources
 from pennylane.measurements import Shots
 from pennylane.tape import QuantumTape, QuantumScript
@@ -34,7 +35,10 @@ QuantumTape_or_Batch = Union[QuantumTape, QuantumTapeBatch]
 class DefaultQubit2(Device):
     """A PennyLane device written in Python and capable of backpropagation derivatives.
 
-    This class currently has no arguments.
+    Args:
+        seed (Union[None, int, array_like[int], SeedSequence, BitGenerator, Generator]): A
+            seed-like parameter matching that of ``seed`` for ``numpy.random.default_rng``.
+            If no value is provided, a default RNG will be used.
 
     **Example:**
 
@@ -92,6 +96,11 @@ class DefaultQubit2(Device):
     def name(self):
         """The name of the device."""
         return "default.qubit.2"
+
+    def __init__(self, seed=None) -> None:
+        super().__init__()
+
+        self._rng = np.random.default_rng(seed)
 
     def supports_derivatives(
         self,
@@ -191,7 +200,7 @@ class DefaultQubit2(Device):
             self.tracker.update(batches=1, executions=len(circuits))
             self.tracker.record()
 
-        results = tuple(simulate(c) for c in circuits)
+        results = tuple(simulate(c, rng=self._rng) for c in circuits)
         return results[0] if is_single_circuit else results
 
     def compute_derivatives(

--- a/tests/devices/experimental/test_default_qubit_2.py
+++ b/tests/devices/experimental/test_default_qubit_2.py
@@ -995,13 +995,13 @@ class TestRandomSeed:
         different results (with almost certainty)"""
         qs = qml.tape.QuantumScript([qml.Hadamard(0)], measurements, shots=1000)
 
-        dev1 = DefaultQubit2(seed=123)
+        dev1 = DefaultQubit2(seed=None)
         result1 = dev1.execute(qs)
 
-        dev2 = DefaultQubit2(seed=456)
+        dev2 = DefaultQubit2(seed=123)
         result2 = dev2.execute(qs)
 
-        dev3 = DefaultQubit2(seed=None)
+        dev3 = DefaultQubit2(seed=456)
         result3 = dev3.execute(qs)
 
         if len(measurements) == 1:

--- a/tests/devices/experimental/test_default_qubit_2.py
+++ b/tests/devices/experimental/test_default_qubit_2.py
@@ -1009,6 +1009,28 @@ class TestRandomSeed:
             [qml.sample(wires=0), qml.expval(qml.PauliZ(0)), qml.probs(wires=0)],
         ],
     )
+    def test_different_executions(self, measurements):
+        """Test that the same device will produce different results every execution"""
+        qs = qml.tape.QuantumScript([qml.Hadamard(0)], measurements, shots=1000)
+
+        dev = DefaultQubit2(seed=123)
+        result1 = dev.execute(qs)
+        result2 = dev.execute(qs)
+
+        if len(measurements) == 1:
+            result1, result2 = [result1], [result2]
+
+        assert all(np.any(res1 != res2) for res1, res2 in zip(result1, result2))
+
+    @pytest.mark.parametrize(
+        "measurements",
+        [
+            [qml.sample(wires=0)],
+            [qml.expval(qml.PauliZ(0))],
+            [qml.probs(wires=0)],
+            [qml.sample(wires=0), qml.expval(qml.PauliZ(0)), qml.probs(wires=0)],
+        ],
+    )
     def test_global_seed(self, measurements):
         """Test that a global seed does not affect the result of devices
         provided with a seed"""

--- a/tests/devices/experimental/test_default_qubit_2.py
+++ b/tests/devices/experimental/test_default_qubit_2.py
@@ -981,19 +981,10 @@ class TestRandomSeed:
 
         assert all(np.all(res1 == res2) for res1, res2 in zip(result1, result2))
 
-    @pytest.mark.parametrize(
-        "measurements",
-        [
-            [qml.sample(wires=0)],
-            [qml.expval(qml.PauliZ(0))],
-            [qml.probs(wires=0)],
-            [qml.sample(wires=0), qml.expval(qml.PauliZ(0)), qml.probs(wires=0)],
-        ],
-    )
-    def test_different_seed(self, measurements):
+    def test_different_seed(self):
         """Test that different devices given different random seeds will produce
         different results (with almost certainty)"""
-        qs = qml.tape.QuantumScript([qml.Hadamard(0)], measurements, shots=1000)
+        qs = qml.tape.QuantumScript([qml.Hadamard(0)], [qml.sample(wires=0)], shots=1000)
 
         dev1 = DefaultQubit2(seed=None)
         result1 = dev1.execute(qs)
@@ -1004,13 +995,10 @@ class TestRandomSeed:
         dev3 = DefaultQubit2(seed=456)
         result3 = dev3.execute(qs)
 
-        if len(measurements) == 1:
-            result1, result2, result3 = [result1], [result2], [result3]
-
         # assert results are pairwise different
-        assert all(np.any(res1 != res2) for res1, res2 in zip(result1, result2))
-        assert all(np.any(res1 != res3) for res1, res3 in zip(result1, result3))
-        assert all(np.any(res2 != res3) for res2, res3 in zip(result2, result3))
+        assert np.any(result1 != result2)
+        assert np.any(result1 != result3)
+        assert np.any(result2 != result3)
 
     @pytest.mark.parametrize(
         "measurements",


### PR DESCRIPTION
**Context:**
Part of the effort to integrate the new device API. Support for sample-based measurements was recently added 🎉, and the API allowed for passing in a `np.Generator` object.

**Description of the Change:**
Add a `seed` keyword argument to the `__init__` method of `DefaultQubit2`. This is used to create a `np.Generator` object within the device upon initialization. This generator would then be passed to downstream calls of `simulate`.

**Benefits:**
Allows the user to seed the random number generator at the device level 🎉 

**Possible Drawbacks:**
None