### PR TITLE
remove the pylint test pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,14 +13,6 @@ repos:
           "--rcfile=.pylintrc", # Link to your config file
         ]
       exclude: ^(doc/|tests/)
-- repo: local
-  hooks:
-    - id: pylint-tests
-      name: pylint whitelisted tests
-      language: system
-      types: [python]
-      entry: bash -c 'pylint --rcfile tests/.pylintrc $(cat tests/tests_passing_pylint.txt | tr "\n" " ")'
-      files: ^tests/
 -   repo: https://github.com/psf/black
     rev: 22.3.0
     hooks:


### PR DESCRIPTION
It sucks as is. CI will still fail if you violate our test linting requirements, but this doesn't happen often enough to merit enduring this pre-commit hook. Making a better hook is non-trivial as it stands, so we can look into this later. I'll open a draft PR once this is merged and see what I can do, but for now, we should disable it