### PR TITLE
always install cvxpy/cvxopt in test CI now that there are 3.11 wheels

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,10 +43,6 @@ jobs:
           pip install -r requirements-dev.txt --upgrade
           pip install torch==$TORCH_VERSION -f https://download.pytorch.org/whl/torch_stable.html
 
-      - name: Conditionally install cvxpy and cvxopt
-        if: matrix.python-version != '3.11'
-        run: python -m pip install cvxpy cvxopt
-
       - name: Install PennyLane
         run: |
           python setup.py bdist_wheel
@@ -93,10 +89,6 @@ jobs:
           python -m pip install --upgrade pip && pip install wheel --upgrade
           pip install -r requirements-ci.txt --upgrade
           pip install -r requirements-dev.txt --upgrade
-
-      - name: Conditionally install cvxpy and cvxopt
-        if: matrix.python-version != '3.11'
-        run: python -m pip install cvxpy cvxopt
 
       - name: Install PennyLane
         run: |
@@ -145,7 +137,7 @@ jobs:
           python -m pip install --upgrade pip && pip install wheel --upgrade
           pip install -r requirements-ci.txt --upgrade
           pip install -r requirements-dev.txt --upgrade
-          pip install pytest-split cvxpy cvxopt tensorflow~=$TF_VERSION keras~=$TF_VERSION
+          pip install pytest-split tensorflow~=$TF_VERSION keras~=$TF_VERSION
 
       - name: Install PennyLane
         run: |
@@ -196,10 +188,6 @@ jobs:
           pip install -r requirements-dev.txt --upgrade
           pip install pytest-split jax==$JAX_VERSION jaxlib==$JAX_VERSION
 
-      - name: Conditionally install cvxpy and cvxopt
-        if: matrix.python-version != '3.11'
-        run: python -m pip install cvxpy cvxopt
-
       - name: Install PennyLane
         run: |
           python setup.py bdist_wheel
@@ -248,10 +236,6 @@ jobs:
           pip install -r requirements-ci.txt --upgrade
           pip install -r requirements-dev.txt --upgrade
           pip install pytest-split
-
-      - name: Conditionally install cvxpy and cvxopt
-        if: matrix.python-version != '3.11'
-        run: python -m pip install cvxpy cvxopt
 
       - name: Install PennyLane
         run: |

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,5 +1,7 @@
 numpy
 scipy
+cvxpy
+cvxopt
 networkx
 rustworkx
 autograd


### PR DESCRIPTION
This was added in #3276 to allow for 3.11 support, but now the wheels exist (cvxopt/cvxopt#228)! I'm just un-doing the changes done in that python upgrade PR.