### PR TITLE
[WIP] Experimental Jax-compatible, Immutable QuantumScript

### DIFF
--- a/interface_examples/execute_grad_jax.py
+++ b/interface_examples/execute_grad_jax.py
@@ -1,0 +1,52 @@
+import pennylane as qml
+import jax
+import jax.numpy as jnp
+
+dev = qml.device("default.qubit", wires=2)
+
+px = qml.PauliX(1)
+
+def raw_circuit(x, y):
+    qml.RX(x, wires=0)
+    qml.RY(y, wires=0)
+    qml.CNOT(wires=[0, 1])
+    qml.RX(0.133, wires=1)
+    return qml.expval(qml.PauliZ(wires=[0]))
+
+with qml.queuing.AnnotatedQueue() as queue:
+    qml.RX(0.432, wires=0)
+    qml.RY(0.543, wires=0)
+    qml.CNOT(wires=[0, 1])
+    qml.RX(0.133, wires=1)
+    qml.expval(qml.PauliZ(wires=[0]))
+
+with qml.queuing.AnnotatedQueue() as queue2:
+    qml.RX(0.432, wires=0)
+    qml.RY(0.543, wires=0)
+    qml.CNOT(wires=[0, 1])
+    qml.RX(0.133, wires=1)
+    qml.expval(qml.PauliZ(wires=[0]))
+
+tp=qml.tape.QuantumScript.from_queue(queue)
+tp2=qml.tape.QuantumScript.from_queue(queue2)
+
+#dev.execute(tp)
+#dev.execute(tp2)
+
+l, s = jax.tree_util.tree_flatten(tp)
+l2, s2 = jax.tree_util.tree_flatten(tp2)
+
+e1 = qml.expval(qml.PauliZ(wires=[0]))
+e2 = qml.expval(qml.PauliZ(wires=[0]))
+
+circuit = qml.qnode(device=dev, interface="jax", cache=False)(raw_circuit)
+circuit = qml.qnode(device=dev, cache=False)(raw_circuit)
+
+x = jnp.array(0.432)
+y = jnp.array(0.543)
+
+fun = jax.jit(circuit)
+gfun = jax.jit(jax.grad(fun))
+
+fun(x, y)
+gfun(x,y)

--- a/interface_examples/execute_jax.py
+++ b/interface_examples/execute_jax.py
@@ -1,0 +1,51 @@
+import pennylane as qml
+import jax
+import jax.numpy as jnp
+
+dev = qml.device("default.qubit", wires=2)
+
+px = qml.PauliX(1)
+
+def raw_circuit(x, y):
+    qml.RX(x, wires=0)
+    qml.RY(y, wires=0)
+    qml.CNOT(wires=[0, 1])
+    qml.RX(0.133, wires=1)
+    return qml.expval(qml.PauliZ(wires=[0]))
+
+with qml.queuing.AnnotatedQueue() as queue:
+    qml.RX(0.432, wires=0)
+    qml.RY(0.543, wires=0)
+    qml.CNOT(wires=[0, 1])
+    qml.RX(0.133, wires=1)
+    qml.expval(qml.PauliZ(wires=[0]))
+
+with qml.queuing.AnnotatedQueue() as queue2:
+    qml.RX(0.432, wires=0)
+    qml.RY(0.543, wires=0)
+    qml.CNOT(wires=[0, 1])
+    qml.RX(0.133, wires=1)
+    qml.expval(qml.PauliZ(wires=[0]))
+
+tp=qml.tape.QuantumScript.from_queue(queue)
+tp2=qml.tape.QuantumScript.from_queue(queue2)
+
+dev.execute(tp)
+dev.execute(tp2)
+
+l, s = jax.tree_util.tree_flatten(tp)
+l2, s2 = jax.tree_util.tree_flatten(tp2)
+
+e1 = qml.expval(qml.PauliZ(wires=[0]))
+e2 = qml.expval(qml.PauliZ(wires=[0]))
+
+circuit = qml.qnode(device=dev, interface="jax", cache=False)(raw_circuit)
+circuit = qml.qnode(device=dev, cache=False)(raw_circuit)
+
+x = jnp.array(0.432)
+y = jnp.array(0.543)
+
+jcircuit = jax.jit(circuit)
+
+circuit(x, y)
+jcircuit(x, y)

--- a/interface_examples/execute_jax_lightning.py
+++ b/interface_examples/execute_jax_lightning.py
@@ -1,0 +1,41 @@
+from jax.config import config
+
+config.update("jax_enable_x64", True)
+del config
+
+
+import pennylane as qml
+import jax
+import jax.numpy as jnp
+
+dev = qml.device("lightning.qubit", wires=2)
+
+px = qml.PauliX(1)
+
+def raw_circuit(x, y):
+    qml.RX(x, wires=0)
+    qml.RY(y, wires=0)
+    qml.CNOT(wires=[0, 1])
+    qml.RX(0.133, wires=1)
+    return qml.expval(qml.PauliZ(wires=[0]))
+
+#circuit = qml.qnode(device=dev, interface="jax", cache=False)(raw_circuit)
+vv = []
+circuit = qml.qnode(device=dev, cache=False)(raw_circuit)
+def rcircuit(x,y):
+    vv.append(x)
+    vv.append(y)
+    return circuit(x,y)
+
+x = jnp.array(0.432)
+y = jnp.array(0.543)
+
+fun = rcircuit
+
+gfun = jax.grad(rcircuit)
+
+print("=====")
+fun(x, y)
+print("ko")
+print("=====")
+#gfun(x,y)

--- a/pennylane/__init__.py
+++ b/pennylane/__init__.py
@@ -27,12 +27,14 @@ from semantic_version import SimpleSpec, Version
 from pennylane.boolean_fn import BooleanFn
 from pennylane.queuing import QueuingManager, apply
 
-import pennylane.fourier
-import pennylane.kernels
-import pennylane.math
-import pennylane.operation
-import pennylane.qnn
-import pennylane.templates
+from pennylane import fourier as fourier
+from pennylane import kernels as kernels
+from pennylane import math as math
+from pennylane import operation as operation
+from pennylane import qnn as qnn
+from pennylane import templates as qntemplatesn
+from pennylane import pauli as pauli
+
 import pennylane.pauli
 from pennylane.pauli import pauli_decompose
 import pennylane.resource

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -942,8 +942,7 @@ class QubitDevice(Device):
         for m in measurements:
             # TODO: Remove this when all overriden measurements support the `MeasurementProcess` class
             if m.obs is not None:
-                obs = m.obs
-                obs.return_type = m.return_type
+                obs = m.obs.replace(return_type=m.return_type)
             else:
                 obs = m
             # Check if there is an overriden version of the measurement process

--- a/pennylane/core/__init__.py
+++ b/pennylane/core/__init__.py
@@ -1,0 +1,1 @@
+from . import pytree

--- a/pennylane/core/pytree/__init__.py
+++ b/pennylane/core/pytree/__init__.py
@@ -1,0 +1,6 @@
+__version__ = "0.1.7"
+
+from .pytree import Pytree, field, static_field
+from .utils import property_cached
+
+__all__ = ["Pytree", "field", "static_field", "property_cached"]

--- a/pennylane/core/pytree/backends.py
+++ b/pennylane/core/pytree/backends.py
@@ -7,6 +7,6 @@ try:
 except ImportError:
 	pass
 
-def register_pytree_with_keys(cls, flatten_fun, unflatten_fun, static_fields):
+def register_pytree_with_keys(cls, flatten_fun, unflatten_fun, static_fields, cache_fields):
 	for backend in backends:
-		backend.register_pytree_with_keys(cls, flatten_fun, unflatten_fun, static_fields)
+		backend.register_pytree_with_keys(cls, flatten_fun, unflatten_fun, static_fields, cache_fields)

--- a/pennylane/core/pytree/backends.py
+++ b/pennylane/core/pytree/backends.py
@@ -1,0 +1,12 @@
+
+backends = []
+
+try:
+	from . import jax_backend
+	backends.append(jax_backend)
+except ImportError:
+	pass
+
+def register_pytree_with_keys(cls, flatten_fun, unflatten_fun, static_fields):
+	for backend in backends:
+		backend.register_pytree_with_keys(cls, flatten_fun, unflatten_fun, static_fields)

--- a/pennylane/core/pytree/jax_backend.py
+++ b/pennylane/core/pytree/jax_backend.py
@@ -3,13 +3,14 @@ from functools import partial
 import jax
 
 
-def register_pytree_with_keys(cls, flatten_fun, unflatten_fun, static_fields):
+def register_pytree_with_keys(cls, flatten_fun, unflatten_fun, static_fields, cache_fields):
     if hasattr(jax.tree_util, "register_pytree_with_keys"):
         jax.tree_util.register_pytree_with_keys(
             cls,
             partial(
                 flatten_fun,
                 static_fields,
+                cache_fields,
                 with_key_paths=True,
             ),
             unflatten_fun,
@@ -20,6 +21,7 @@ def register_pytree_with_keys(cls, flatten_fun, unflatten_fun, static_fields):
             partial(
                 flatten_fun,
                 static_fields,
+                cache_fields,
                 with_key_paths=False,
             ),
             unflatten_fun,

--- a/pennylane/core/pytree/jax_backend.py
+++ b/pennylane/core/pytree/jax_backend.py
@@ -1,0 +1,26 @@
+from functools import partial
+
+import jax
+
+
+def register_pytree_with_keys(cls, flatten_fun, unflatten_fun, static_fields):
+    if hasattr(jax.tree_util, "register_pytree_with_keys"):
+        jax.tree_util.register_pytree_with_keys(
+            cls,
+            partial(
+                flatten_fun,
+                static_fields,
+                with_key_paths=True,
+            ),
+            unflatten_fun,
+        )
+    else:
+        jax.tree_util.register_pytree_node(
+            cls,
+            partial(
+                flatten_fun,
+                static_fields,
+                with_key_paths=False,
+            ),
+            unflatten_fun,
+        )

--- a/pennylane/core/pytree/pytree.py
+++ b/pennylane/core/pytree/pytree.py
@@ -1,0 +1,315 @@
+import dataclasses
+import importlib.util
+import itertools
+import typing as tp
+from abc import ABCMeta
+from copy import copy
+from functools import partial
+
+from . import backends
+
+P = tp.TypeVar("P", bound="Pytree")
+
+
+def field(
+    default: tp.Any = dataclasses.MISSING,
+    *,
+    pytree_node: bool = True,
+    cache_node: bool = False,
+    default_factory: tp.Any = dataclasses.MISSING,
+    init: bool = True,
+    repr: bool = True,
+    hash: tp.Optional[bool] = None,
+    compare: bool = True,
+    metadata: tp.Optional[tp.Mapping[str, tp.Any]] = None,
+):
+    """Defines a field for a PyTree class, setting some behaviour flags.
+    
+    Most flags are inherited from dataclasses and have no effect unless the class is also
+    a dataclass. The most relevant ones are:
+    
+    Args:
+        default: The default value for this field unless set in the constructor.
+        pytree_node: If True, this field will be a data field in the PyTree. Only
+            PyTrees or array data should be contained in such field. If `pytree_node=False`
+            the field is some static, compile time data and it should be hashable, comparable
+            for equality, immutable and not contain any pytree_nodes such as arrays.
+        cache_node: If True, this field will be excluded from pytree travsersal. This
+            must be used for fields used to contain cached data.
+        
+    Args:
+        default (tp.Any, optional): _description_. Defaults to dataclasses.MISSING.
+        pytree_node (bool, optional): _description_. Defaults to True.
+        cache_node (bool, optional): _description_. Defaults to False.
+        default_factory (tp.Any, optional): _description_. Defaults to dataclasses.MISSING.
+        init (bool, optional): _description_. Defaults to True.
+        repr (bool, optional): _description_. Defaults to True.
+        hash (tp.Optional[bool], optional): _description_. Defaults to None.
+        compare (bool, optional): _description_. Defaults to True.
+        metadata (tp.Optional[tp.Mapping[str, tp.Any]], optional): _description_. Defaults to None.
+
+    Raises:
+        ValueError: _description_
+
+    Returns:
+        _type_: _description_
+    """
+    if metadata is None:
+        metadata = {}
+    else:
+        metadata = dict(metadata)
+
+    if "pytree_node" in metadata:
+        raise ValueError("'pytree_node' found in metadata")
+    
+    if cache_node:
+        metadata["cache_field"] = cache_node
+        pytree_node = False
+    metadata["pytree_node"] = pytree_node
+
+    return dataclasses.field(
+        default=default,
+        default_factory=default_factory,
+        init=init,
+        repr=repr,
+        hash=hash,
+        compare=compare,
+        metadata=metadata,
+    )
+
+
+def static_field(
+    default: tp.Any = dataclasses.MISSING,
+    *,
+    default_factory: tp.Any = dataclasses.MISSING,
+    init: bool = True,
+    repr: bool = True,
+    hash: tp.Optional[bool] = None,
+    compare: bool = True,
+    metadata: tp.Optional[tp.Mapping[str, tp.Any]] = None,
+):
+    return field(
+        default=default,
+        pytree_node=False,
+        default_factory=default_factory,
+        init=init,
+        repr=repr,
+        hash=hash,
+        compare=compare,
+        metadata=metadata,
+    )
+
+
+class PytreeMeta(ABCMeta):
+    def __call__(self: tp.Type[P], *args: tp.Any, **kwargs: tp.Any) -> P:
+        obj: P = self.__new__(self, *args, **kwargs)
+        obj.__dict__["_pytree__initializing"] = True
+
+        # set default values
+        if not dataclasses.is_dataclass(obj):
+            for f in obj._pytree__field_default_init:
+                ft = getattr(obj, f)
+                if ft.default is not dataclasses.MISSING:
+                    obj.__setattr__(f, ft.default)
+                else:
+                    obj.__setattr__(f, ft.default_factory())
+        try:
+            obj.__init__(*args, **kwargs)
+        finally:
+            del obj.__dict__["_pytree__initializing"]
+        return obj
+
+
+class Pytree(metaclass=PytreeMeta):
+    _pytree__initializing: bool
+    _pytree__class_is_mutable: bool
+    _pytree__static_fields: tp.FrozenSet[str]
+    _pytree__setter_descriptors: tp.FrozenSet[str]
+    _pytree__field_default_init: tp.FrozenSet[str]
+
+    def __init_subclass__(cls, mutable: bool = False):
+        super().__init_subclass__()
+
+        # gather class info
+        class_vars = vars(cls)
+        setter_descriptors = set()
+        static_fields = _inherited_static_fields(cls)
+        default_init_fields = _inherited_default_init_fields(cls)
+
+        for field, value in class_vars.items():
+            if isinstance(value, dataclasses.Field) and not value.metadata.get(
+                "pytree_node", True
+            ):
+                static_fields.add(field)
+
+            # add setter descriptors
+            if hasattr(value, "__set__"):
+                setter_descriptors.add(field)
+
+            # setter
+            if isinstance(value, dataclasses.Field):
+                if (value.default is not dataclasses.MISSING) or (value.default_factory is not dataclasses.MISSING):
+                    default_init_fields.add(field)
+
+        # init class variables
+        cls._pytree__initializing = False
+        cls._pytree__class_is_mutable = mutable
+        cls._pytree__static_fields = frozenset(static_fields)
+        cls._pytree__setter_descriptors = frozenset(setter_descriptors)
+        cls._pytree__field_default_init = frozenset(default_init_fields)
+
+        backends.register_pytree_with_keys(cls, cls._pytree__flatten, cls._pytree__unflatten, cls._pytree__static_fields)
+
+        # flax serialization support
+        if importlib.util.find_spec("flax") is not None:
+            from flax import serialization
+
+            serialization.register_serialization_state(
+                cls,
+                partial(cls._to_flax_state_dict, cls._pytree__static_fields),
+                partial(cls._from_flax_state_dict, cls._pytree__static_fields),
+            )
+
+    @classmethod
+    def _pytree__flatten(
+        cls,
+        static_field_names: tp.FrozenSet[str],
+        pytree: "Pytree",
+        *,
+        with_key_paths: bool,
+    ) -> tp.Tuple[
+        tp.List[tp.Any],
+        tp.Tuple[tp.List[str], tp.List[tp.Tuple[str, tp.Any]]],
+    ]:
+        static_fields = []
+        node_names = []
+        node_values = []
+        # sort to ensure deterministic order
+        for field in sorted(vars(pytree)):
+            value = getattr(pytree, field)
+            if field in static_field_names:
+                static_fields.append((field, value))
+            else:
+                if with_key_paths:
+                    import jax
+                    value = (jax.tree_util.GetAttrKey(field), value)
+                node_names.append(field)
+                node_values.append(value)
+
+        return node_values, (node_names, static_fields)
+
+    @classmethod
+    def _pytree__unflatten(
+        cls: tp.Type[P],
+        metadata: tp.Tuple[tp.List[str], tp.List[tp.Tuple[str, tp.Any]]],
+        node_values: tp.List[tp.Any],
+    ) -> P:
+        node_names, static_fields = metadata
+        node_fields = dict(zip(node_names, node_values))
+        pytree = object.__new__(cls)
+        pytree.__dict__.update(node_fields, **dict(static_fields))
+        return pytree
+
+    @classmethod
+    def _to_flax_state_dict(
+        cls, static_field_names: tp.FrozenSet[str], pytree: "Pytree"
+    ) -> tp.Dict[str, tp.Any]:
+        from flax import serialization
+
+        state_dict = {
+            name: serialization.to_state_dict(getattr(pytree, name))
+            for name in pytree.__dict__
+            if name not in static_field_names
+        }
+        return state_dict
+
+    @classmethod
+    def _from_flax_state_dict(
+        cls,
+        static_field_names: tp.FrozenSet[str],
+        pytree: P,
+        state: tp.Dict[str, tp.Any],
+    ) -> P:
+        """Restore the state of a data class."""
+        from flax import serialization
+
+        state = state.copy()  # copy the state so we can pop the restored fields.
+        updates = {}
+        for name in pytree.__dict__:
+            if name in static_field_names:
+                continue
+            if name not in state:
+                raise ValueError(
+                    f"Missing field {name} in state dict while restoring"
+                    f" an instance of {type(pytree).__name__},"
+                    f" at path {serialization.current_path()}"
+                )
+            value = getattr(pytree, name)
+            value_state = state.pop(name)
+            updates[name] = serialization.from_state_dict(value, value_state, name=name)
+        if state:
+            names = ",".join(state.keys())
+            raise ValueError(
+                f'Unknown field(s) "{names}" in state dict while'
+                f" restoring an instance of {type(pytree).__name__}"
+                f" at path {serialization.current_path()}"
+            )
+        return pytree.replace(**updates)
+
+    def replace(self: P, **kwargs: tp.Any) -> P:
+        """
+        Replace the values of the fields of the object with the values of the
+        keyword arguments. If the object is a dataclass, `dataclasses.replace`
+        will be used. Otherwise, a new object will be created with the same
+        type as the original object.
+        """
+        if dataclasses.is_dataclass(self):
+            return dataclasses.replace(self, **kwargs)
+
+        unknown_keys = set(kwargs) - set(vars(self))
+        if unknown_keys:
+            raise ValueError(
+                f"Trying to replace unknown fields {unknown_keys} "
+                f"for '{type(self).__name__}'"
+            )
+
+        pytree = copy(self)
+        pytree.__dict__.update(kwargs)
+        return pytree
+
+    if not tp.TYPE_CHECKING:
+
+        def __setattr__(self: P, field: str, value: tp.Any):
+            if (
+                not self._pytree__initializing
+                and not self._pytree__class_is_mutable
+                and field not in self._pytree__setter_descriptors
+            ):
+                raise AttributeError(
+                    f"{type(self)} is immutable, trying to update field {field}"
+                )
+
+            object.__setattr__(self, field, value)
+
+
+def _inherited_static_fields(cls: type) -> tp.Set[str]:
+    static_fields = set()
+    for parent_class in cls.mro():
+        if (
+            parent_class is not cls
+            and parent_class is not Pytree
+            and issubclass(parent_class, Pytree)
+        ):
+            static_fields.update(parent_class._pytree__static_fields)
+    return static_fields
+
+def _inherited_default_init_fields(cls: type) -> tp.Set[str]:
+    default_init_fields = set()
+    for parent_class in cls.mro():
+        if (
+            parent_class is not cls
+            and parent_class is not Pytree
+            and issubclass(parent_class, Pytree)
+        ):
+            default_init_fields.update(parent_class._pytree__field_default_init)
+    return default_init_fields

--- a/pennylane/core/pytree/utils.py
+++ b/pennylane/core/pytree/utils.py
@@ -1,0 +1,16 @@
+from functools import partial, wraps
+
+   
+def property_cached(fun):
+    """
+    Better implementation of cached_property from the standard library.
+    """
+    @wraps(fun)
+    def property_fun(self, *args, **kwargs):
+        property_name = f"__cached_{fun.__name__}"
+        if not hasattr(self, property_name):
+            value = fun(*args, **kwargs)
+            object.__setattr__(self, property_name, value)
+        return object.__getattribute__(self, property_name)
+
+    return property_fun

--- a/pennylane/core/tests/test_pytree.py
+++ b/pennylane/core/tests/test_pytree.py
@@ -1,0 +1,247 @@
+import dataclasses
+from typing import Generic, TypeVar
+
+import jax
+import pytest
+from flax import serialization
+
+from simple_pytree import Pytree, field, static_field
+
+
+class TestPytree:
+    def test_immutable_pytree(self):
+        class Foo(Pytree):
+            x: int = static_field()
+
+            def __init__(self, y) -> None:
+                self.x = 2
+                self.y = y
+
+        pytree = Foo(y=3)
+
+        leaves = jax.tree_util.tree_leaves(pytree)
+        assert leaves == [3]
+
+        pytree = jax.tree_map(lambda x: x * 2, pytree)
+        assert pytree.x == 2
+        assert pytree.y == 6
+
+        pytree = pytree.replace(x=3)
+        assert pytree.x == 3
+        assert pytree.y == 6
+
+        with pytest.raises(
+            AttributeError, match="is immutable, trying to update field"
+        ):
+            pytree.x = 4
+
+    def test_immutable_pytree_dataclass(self):
+        @dataclasses.dataclass(frozen=True)
+        class Foo(Pytree):
+            y: int = field()
+            x: int = static_field(2)
+
+        pytree = Foo(y=3)
+
+        leaves = jax.tree_util.tree_leaves(pytree)
+        assert leaves == [3]
+
+        pytree = jax.tree_map(lambda x: x * 2, pytree)
+        assert pytree.x == 2
+        assert pytree.y == 6
+
+        pytree = pytree.replace(x=3)
+        assert pytree.x == 3
+        assert pytree.y == 6
+
+        with pytest.raises(AttributeError, match="cannot assign to field"):
+            pytree.x = 4
+
+    def test_jit(self):
+        @dataclasses.dataclass
+        class Foo(Pytree):
+            a: int
+            b: int = static_field()
+
+        module = Foo(a=1, b=2)
+
+        @jax.jit
+        def f(m: Foo):
+            return m.a + m.b
+
+        assert f(module) == 3
+
+    def test_flax_serialization(self):
+        class Bar(Pytree):
+            a: int = static_field()
+
+            def __init__(self, a, b):
+                self.a = a
+                self.b = b
+
+        @dataclasses.dataclass
+        class Foo(Pytree):
+            bar: Bar
+            c: int
+            d: int = static_field()
+
+        foo: Foo = Foo(bar=Bar(a=1, b=2), c=3, d=4)
+
+        state_dict = serialization.to_state_dict(foo)
+
+        assert state_dict == {
+            "bar": {
+                "b": 2,
+            },
+            "c": 3,
+        }
+
+        state_dict["bar"]["b"] = 5
+
+        foo = serialization.from_state_dict(foo, state_dict)
+
+        assert foo.bar.b == 5
+
+        del state_dict["bar"]["b"]
+
+        with pytest.raises(ValueError, match="Missing field"):
+            serialization.from_state_dict(foo, state_dict)
+
+        state_dict["bar"]["b"] = 5
+
+        # add unknown field
+        state_dict["x"] = 6
+
+        with pytest.raises(ValueError, match="Unknown field"):
+            serialization.from_state_dict(foo, state_dict)
+
+    def test_generics(self):
+        T = TypeVar("T")
+
+        class MyClass(Pytree, Generic[T]):
+            def __init__(self, x: T):
+                self.x = x
+
+        MyClass[int]
+
+    def test_key_paths(self):
+        @dataclasses.dataclass
+        class Bar(Pytree):
+            a: int = 1
+            b: int = static_field(2)
+
+        @dataclasses.dataclass
+        class Foo(Pytree):
+            x: int = 3
+            y: int = static_field(4)
+            z: Bar = field(default_factory=Bar)
+
+        foo = Foo()
+
+        path_values, treedef = jax.tree_util.tree_flatten_with_path(foo)
+        path_values = [(list(map(str, path)), value) for path, value in path_values]
+
+        assert path_values[0] == ([".x"], 3)
+        assert path_values[1] == ([".z", ".a"], 1)
+
+    def test_setter_attribute_allowed(self):
+        n = None
+
+        class SetterDescriptor:
+            def __set__(self, _, value):
+                nonlocal n
+                n = value
+
+        class Foo(Pytree):
+            x = SetterDescriptor()
+
+        foo = Foo()
+        foo.x = 1
+
+        assert n == 1
+
+        with pytest.raises(AttributeError, match=r"<.*> is immutable"):
+            foo.y = 2
+
+    def test_replace_unknown_fields_error(self):
+        class Foo(Pytree):
+            pass
+
+        with pytest.raises(ValueError, match="Trying to replace unknown fields"):
+            Foo().replace(y=1)
+
+    def test_dataclass_inheritance(self):
+        @dataclasses.dataclass
+        class A(Pytree):
+            a: int = 1
+            b: int = static_field(2)
+
+        @dataclasses.dataclass
+        class B(A):
+            c: int = 3
+
+        pytree = B()
+        leaves = jax.tree_util.tree_leaves(pytree)
+        assert leaves == [1, 3]
+
+    def test_pytree_with_new(self):
+        class A(Pytree):
+            def __init__(self, a):
+                self.a = a
+
+            def __new__(cls, a):
+                return super().__new__(cls)
+
+        pytree = A(a=1)
+
+        pytree = jax.tree_map(lambda x: x * 2, pytree)
+
+
+class TestMutablePytree:
+    def test_pytree(self):
+        class Foo(Pytree, mutable=True):
+            x: int = static_field()
+
+            def __init__(self, y) -> None:
+                self.x = 2
+                self.y = y
+
+        pytree = Foo(y=3)
+
+        leaves = jax.tree_util.tree_leaves(pytree)
+        assert leaves == [3]
+
+        pytree = jax.tree_map(lambda x: x * 2, pytree)
+        assert pytree.x == 2
+        assert pytree.y == 6
+
+        pytree = pytree.replace(x=3)
+        assert pytree.x == 3
+        assert pytree.y == 6
+
+        # test mutation
+        pytree.x = 4
+        assert pytree.x == 4
+
+    def test_pytree_dataclass(self):
+        @dataclasses.dataclass
+        class Foo(Pytree, mutable=True):
+            y: int = field()
+            x: int = static_field(2)
+
+        pytree: Foo = Foo(y=3)
+
+        leaves = jax.tree_util.tree_leaves(pytree)
+        assert leaves == [3]
+
+        pytree = jax.tree_map(lambda x: x * 2, pytree)
+        assert pytree.x == 2
+        assert pytree.y == 6
+
+        pytree = pytree.replace(x=3)
+        assert pytree.x == 3
+        assert pytree.y == 6
+
+        # test mutation
+        pytree.x = 4
+        assert pytree.x == 4

--- a/pennylane/measurements/measurements.py
+++ b/pennylane/measurements/measurements.py
@@ -154,7 +154,7 @@ class MeasurementProcess(Pytree):
     # Below, we imitate an identity observable, so that the
     # device undertakes no action upon receiving this observable.
     name : str = "Identity"
-    data: List = []
+    data: List = ()
 
     # pylint: disable=too-many-arguments
     def __init__(
@@ -493,6 +493,18 @@ class MeasurementProcess(Pytree):
         else:
             new_measurement._wires = Wires([wire_map.get(wire, wire) for wire in self.wires])
         return new_measurement
+
+    @property
+    def _attrs(self):
+        return (self.name, self.id, self.obs, self._wires, self._eigvals, self.data)
+
+    def __eq__(self, o):
+        if type(self) is type(o):
+            return self._attrs == o._attrs
+        return False
+
+    def __hash__(self):
+        return hash(self._attrs)
 
 
 class SampleMeasurement(MeasurementProcess):

--- a/pennylane/measurements/measurements.py
+++ b/pennylane/measurements/measurements.py
@@ -319,17 +319,17 @@ class MeasurementProcess(Pytree):
 
         return f"{self.obs}"
 
-    def __copy__(self):
-        cls = self.__class__
-        copied_m = cls.__new__(cls)
-
-        for attr, value in vars(self).items():
-            setattr(copied_m, attr, value)
-
-        if self.obs is not None:
-            copied_m.obs = copy.copy(self.obs)
-
-        return copied_m
+    #def __copy__(self):
+    #    cls = self.__class__
+    #    copied_m = cls.__new__(cls)
+    #
+    #    for attr, value in vars(self).items():
+    #        setattr(copied_m, attr, value)
+    #
+    #    if self.obs is not None:
+    #        copied_m.obs = copy.copy(self.obs)
+    #
+    #    return copied_m
 
     @property
     def wires(self):

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -668,7 +668,7 @@ class Operator(Pytree, abc.ABC):
 
     @property
     def _attrs(self):
-        return (self.name, self.wires, str(self.hyperparameters.values()), _process_data(self))
+        return (self.name, self.wires)#, str(self.hyperparameters.values()), _process_data(self))
 
     def __hash__(self):
         return hash(self._attrs)

--- a/pennylane/ops/identity.py
+++ b/pennylane/ops/identity.py
@@ -48,7 +48,7 @@ class Identity(CVObservable, Operation):
 
     def __init__(self, *params, wires=None, do_queue=True, id=None):
         super().__init__(*params, wires=wires, do_queue=do_queue, id=id)
-        self._hyperparameters = {"n_wires": len(self.wires)}
+        self.hyperparameters = {"n_wires": len(self.wires)}
         self._pauli_rep = qml.pauli.PauliSentence({qml.pauli.PauliWord({}): 1.0})
 
     def label(self, decimals=None, base_label=None, cache=None):

--- a/pennylane/qnode.py
+++ b/pennylane/qnode.py
@@ -758,7 +758,8 @@ class QNode:
         self._qfunc_output = self.tape._qfunc_output
 
         params = self.tape.get_parameters(trainable_only=False)
-        self.tape.trainable_params = qml.math.get_trainable_indices(params)
+        #print(self.tape.trainable_params)
+        #self.tape.trainable_params = qml.math.get_trainable_indices(params)
 
         if any(isinstance(m, CountsMP) for m in self.tape.measurements) and any(
             qml.math.is_abstract(a) for a in args

--- a/pennylane/tape/qscript.py
+++ b/pennylane/tape/qscript.py
@@ -534,7 +534,10 @@ class QuantumScript(Pytree):
 
     @property
     def trainable_params(self):
-        return self._trainable_params
+        #return self._trainable_params
+        params = self.get_parameters(trainable_only=False)
+        return qml.math.get_trainable_indices(params)
+
 
     @trainable_params.setter
     def trainable_params(self, param_indices):

--- a/pennylane/tape/qscript.py
+++ b/pennylane/tape/qscript.py
@@ -176,9 +176,9 @@ class QuantumScript(Pytree):
 
     def __init__(self, ops=None, measurements=None, prep=None, name=None, _update=True):
         self.name = name
-        self._prep = [] if prep is None else list(prep)
-        self._ops = [] if ops is None else list(ops)
-        self._measurements = [] if measurements is None else list(measurements)
+        self._prep = tuple() if prep is None else tuple(prep)
+        self._ops = tuple() if ops is None else tuple(ops)
+        self._measurements = tuple() if measurements is None else tuple(measurements)
 
         #self._par_info = []
         """list[dict[str, Operator or int]]: Parameter information.
@@ -296,8 +296,7 @@ class QuantumScript(Pytree):
 
         for m in self.measurements:
             if m.obs is not None:
-                m.obs.return_type = m.return_type
-                obs.append(m.obs)
+                obs.append(m.obs.replace(return_type=m.return_type))
             else:
                 obs.append(m)
 
@@ -1354,6 +1353,19 @@ class QuantumScript(Pytree):
     def from_queue(cls, queue):
         """Construct a QuantumScript from an AnnotatedQueue."""
         return cls(*process_queue(queue))
+
+
+    @property
+    def _attrs(self):
+        return (self.name, self._prep, self._ops, self._measurements)
+
+    def __eq__(self, o):
+        if type(self) is type(o):
+            return self._attrs == o._attrs
+        return False
+
+    def __hash__(self):
+        return hash(self._attrs)
 
 
 def make_qscript(fn):

--- a/pennylane/wires.py
+++ b/pennylane/wires.py
@@ -150,9 +150,10 @@ class Wires(Sequence, Pytree):
 
     def __hash__(self):
         """Implements the hash function."""
-        if self._hash_cache is None:
-            object.__setattr__(self, "_hash_cache", hash(self._labels))
-        return self._hash_cache
+        #if self._hash_cache is None:
+        #    object.__setattr__(self, "_hash_cache", hash(self._labels))
+        #return self._hash_cache
+        return hash(self._labels)
 
     def __add__(self, other):
         """Defines the addition to return a Wires object containing all wires of the two terms.


### PR DESCRIPTION
This is a draft implementation of the ADR on PyTrees which makes operators and the QuantumScript immutable PyTrees, and integrates such capability in the execution interface that is considerably simplified (see changes in `interfaces/jax-jit`).

Some sample scripts that run without errors are stored in `/interface-examples`.

The PR does not support `trainable-hyperparameters` assuming that this is taken care by Jax.
