### PR TITLE
skip some lightning tests if falling back to default.qubit

### DIFF
--- a/tests/devices/test_lightning_qubit.py
+++ b/tests/devices/test_lightning_qubit.py
@@ -47,6 +47,8 @@ def test_no_backprop_auto_interface():
     differentiation method."""
 
     dev = qml.device("lightning.qubit", wires=2)
+    if not dev._CPP_BINARY_AVAILABLE:
+        pytest.skip("lightning is falling back on default.qubit")
 
     def circuit():
         """Simple quantum function."""

--- a/tests/test_debugging.py
+++ b/tests/test_debugging.py
@@ -133,6 +133,8 @@ class TestSnapshot:
     def test_lightning_qubit(self, method):
         """Test that an error is (currently) raised on the lightning simulator."""
         dev = qml.device("lightning.qubit", wires=2)
+        if not dev._CPP_BINARY_AVAILABLE:
+            pytest.skip("lightning is falling back on default.qubit")
 
         @qml.qnode(dev, diff_method=method)
         def circuit():


### PR DESCRIPTION
CI fails occasionally because these tests expect lightning-specific failures, but lightning itself didn't install. It might be better to do some larger skip if we're falling back on default.qubit, but this will at least stop intermittent failures when lightning fails to build.

PS: should we not inspect this private attribute of the device? I figured it made sense, but we could do an `isinstance(dev, DefaultQubit)` check instead