### PR TITLE
Add documentation and tests for `TorchLayer` saving

### DIFF
--- a/pennylane/qnn/torch.py
+++ b/pennylane/qnn/torch.py
@@ -152,11 +152,11 @@ class TorchLayer(Module):
 
         **Model saving**
 
-        Instances of ``TorchLayer`` can be saved using the usual ``torch.save()`` utility":
+        Instances of ``TorchLayer`` can be saved using the usual ``torch.save()`` utility:
 
         .. code-block::
 
-            qlayer = qml.qnn.TorchLayer(qnode, weight_shapes=weight_shapes, init_method=init_method)
+            qlayer = qml.qnn.TorchLayer(qnode, weight_shapes=weight_shapes)
             torch.save(qlayer.state_dict(), SAVE_PATH)
 
         To load the model, an instance of the class must be created first before calling ``torch.load()``,
@@ -164,7 +164,7 @@ class TorchLayer(Module):
 
         .. code-block::
 
-            qlayer = qml.qnn.TorchLayer(qnode, weight_shapes=weight_shapes, init_method=init_method)
+            qlayer = qml.qnn.TorchLayer(qnode, weight_shapes=weight_shapes)
             qlayer.load_state_dict(torch.load(SAVE_PATH))
             qlayer.eval()
 

--- a/pennylane/qnn/torch.py
+++ b/pennylane/qnn/torch.py
@@ -150,6 +150,30 @@ class TorchLayer(Module):
 
             qlayer = qml.qnn.TorchLayer(qnode, weight_shapes=weight_shapes, init_method=init_method)
 
+        **Model saving**
+
+        Instances of ``TorchLayer`` can be saved using the usual ``torch.save()`` utility":
+
+        .. code-block::
+
+            qlayer = qml.qnn.TorchLayer(qnode, weight_shapes=weight_shapes, init_method=init_method)
+            torch.save(qlayer.state_dict(), SAVE_PATH)
+
+        To load the model, an instance of the class must be created first before calling ``torch.load()``,
+        as required by PyTorch:
+
+        .. code-block::
+
+            qlayer = qml.qnn.TorchLayer(qnode, weight_shapes=weight_shapes, init_method=init_method)
+            qlayer.load_state_dict(torch.load(SAVE_PATH))
+            qlayer.eval()
+
+        .. note::
+
+            Currently ``TorchLayer`` objects cannot be saved using the ``torch.save(qlayer, SAVE_PATH)``
+            syntax. In order to save a ``TorchLayer`` object, the object's ``state_dict`` should be
+            saved instead.
+
         **Full code example**
 
         The code block below shows how a circuit composed of templates from the

--- a/pennylane/qnn/torch.py
+++ b/pennylane/qnn/torch.py
@@ -174,6 +174,27 @@ class TorchLayer(Module):
             syntax. In order to save a ``TorchLayer`` object, the object's ``state_dict`` should be
             saved instead.
 
+        PyTorch modules that contain ``TorchLayer`` objects can also be saved and loaded.
+
+        Saving:
+
+        .. code-block::
+
+            qlayer = qml.qnn.TorchLayer(qnode, weight_shapes=weight_shapes)
+            clayer = torch.nn.Linear(2, 2)
+            model = torch.nn.Sequential(qlayer, clayer)
+            torch.save(model.state_dict(), SAVE_PATH)
+
+        Loading:
+
+        .. code-block::
+
+            qlayer = qml.qnn.TorchLayer(qnode, weight_shapes=weight_shapes)
+            clayer = torch.nn.Linear(2, 2)
+            model = torch.nn.Sequential(qlayer, clayer)
+            model.load_state_dict(torch.load(SAVE_PATH))
+            model.eval()
+
         **Full code example**
 
         The code block below shows how a circuit composed of templates from the

--- a/pennylane/qnn/torch.py
+++ b/pennylane/qnn/torch.py
@@ -159,7 +159,7 @@ class TorchLayer(Module):
             qlayer = qml.qnn.TorchLayer(qnode, weight_shapes=weight_shapes)
             torch.save(qlayer.state_dict(), SAVE_PATH)
 
-        To load the model, an instance of the class must be created first before calling ``torch.load()``,
+        To load the layer again, an instance of the class must be created first before calling ``torch.load()``,
         as required by PyTorch:
 
         .. code-block::

--- a/tests/legacy/qnn/test_qnn_torch_old.py
+++ b/tests/legacy/qnn/test_qnn_torch_old.py
@@ -568,12 +568,16 @@ class TestTorchLayerIntegration:
     @pytest.mark.parametrize("n_qubits, output_dim", indices_up_to(2))
     def test_save_model(self, get_circuit, n_qubits, output_dim):
         """Test if the model can be saved and loaded"""
-        model = TorchLayer(*get_circuit)
+        qlayer = TorchLayer(*get_circuit)
+        clayer = torch.nn.Linear(output_dim, 2)
+        model = torch.nn.Sequential(qlayer, clayer)
 
         saved_state_dict = model.state_dict()
         torch.save(saved_state_dict, "dummy.pt")
 
-        new_model = TorchLayer(*get_circuit)
+        new_qlayer = TorchLayer(*get_circuit)
+        new_clayer = torch.nn.Linear(output_dim, 2)
+        new_model = torch.nn.Sequential(new_qlayer, new_clayer)
         new_state_dict = new_model.state_dict()
 
         assert list(saved_state_dict.keys()) == list(new_state_dict.keys())

--- a/tests/legacy/qnn/test_qnn_torch_old.py
+++ b/tests/legacy/qnn/test_qnn_torch_old.py
@@ -565,6 +565,34 @@ class TestTorchLayerIntegration:
         assert dict_keys == all_params
         assert len(dict_keys) == len(all_params)
 
+    @pytest.mark.parametrize("n_qubits, output_dim", indices_up_to(2))
+    def test_save_model(self, get_circuit, n_qubits, output_dim):
+        """Test if the model can be saved and loaded"""
+        model = TorchLayer(*get_circuit)
+
+        saved_state_dict = model.state_dict()
+        torch.save(saved_state_dict, "dummy.pt")
+
+        new_model = TorchLayer(*get_circuit)
+        new_state_dict = new_model.state_dict()
+
+        assert list(saved_state_dict.keys()) == list(new_state_dict.keys())
+
+        # test that the new model's weights are different
+        assert all(
+            torch.any(saved_state_dict[k] != new_state_dict[k]) for k in saved_state_dict.keys()
+        )
+
+        new_model.load_state_dict(torch.load("dummy.pt"))
+        new_state_dict = new_model.state_dict()
+
+        assert list(saved_state_dict.keys()) == list(new_state_dict.keys())
+
+        # test that the new model's weights are now the same
+        assert all(
+            torch.all(saved_state_dict[k] == new_state_dict[k]) for k in saved_state_dict.keys()
+        )
+
 
 @pytest.mark.torch
 def test_vjp_is_unwrapped_for_param_shift():

--- a/tests/qnn/test_qnn_torch.py
+++ b/tests/qnn/test_qnn_torch.py
@@ -602,12 +602,16 @@ class TestTorchLayerIntegration:
     @pytest.mark.parametrize("n_qubits, output_dim", indices_up_to(2))
     def test_save_model(self, get_circuit, n_qubits, output_dim):
         """Test if the model can be saved and loaded"""
-        model = TorchLayer(*get_circuit)
+        qlayer = TorchLayer(*get_circuit)
+        clayer = torch.nn.Linear(output_dim, 2)
+        model = torch.nn.Sequential(qlayer, clayer)
 
         saved_state_dict = model.state_dict()
         torch.save(saved_state_dict, "dummy.pt")
 
-        new_model = TorchLayer(*get_circuit)
+        new_qlayer = TorchLayer(*get_circuit)
+        new_clayer = torch.nn.Linear(output_dim, 2)
+        new_model = torch.nn.Sequential(new_qlayer, new_clayer)
         new_state_dict = new_model.state_dict()
 
         assert list(saved_state_dict.keys()) == list(new_state_dict.keys())

--- a/tests/qnn/test_qnn_torch.py
+++ b/tests/qnn/test_qnn_torch.py
@@ -599,6 +599,34 @@ class TestTorchLayerIntegration:
         assert dict_keys == all_params
         assert len(dict_keys) == len(all_params)
 
+    @pytest.mark.parametrize("n_qubits, output_dim", indices_up_to(2))
+    def test_save_model(self, get_circuit, n_qubits, output_dim):
+        """Test if the model can be saved and loaded"""
+        model = TorchLayer(*get_circuit)
+
+        saved_state_dict = model.state_dict()
+        torch.save(saved_state_dict, "dummy.pt")
+
+        new_model = TorchLayer(*get_circuit)
+        new_state_dict = new_model.state_dict()
+
+        assert list(saved_state_dict.keys()) == list(new_state_dict.keys())
+
+        # test that the new model's weights are different
+        assert all(
+            torch.any(saved_state_dict[k] != new_state_dict[k]) for k in saved_state_dict.keys()
+        )
+
+        new_model.load_state_dict(torch.load("dummy.pt"))
+        new_state_dict = new_model.state_dict()
+
+        assert list(saved_state_dict.keys()) == list(new_state_dict.keys())
+
+        # test that the new model's weights are now the same
+        assert all(
+            torch.all(saved_state_dict[k] == new_state_dict[k]) for k in saved_state_dict.keys()
+        )
+
 
 @pytest.mark.torch
 def test_vjp_is_unwrapped_for_param_shift():


### PR DESCRIPTION
**Context:**
`TorchLayer` is already able to be saved using the usual PyTorch syntax.

**Description of the Change:**
Add documentation on how to do it. Also add tests in case it breaks in the future.