### PR TITLE
Integrate new device derivatives into `qml.execute`

### DIFF
--- a/pennylane/devices/experimental/default_qubit_2.py
+++ b/pennylane/devices/experimental/default_qubit_2.py
@@ -207,6 +207,10 @@ class DefaultQubit2(Device):
             is_single_circuit = True
             circuits = [circuits]
 
+        if self.tracker.active:
+            self.tracker.update(derivative_batches=1, derivatives=len(circuits))
+            self.tracker.record()
+
         if execution_config.gradient_method == "adjoint":
             res = tuple(adjoint_jacobian(circuit) for circuit in circuits)
             return res[0] if is_single_circuit else res

--- a/pennylane/devices/experimental/execution_config.py
+++ b/pennylane/devices/experimental/execution_config.py
@@ -27,6 +27,7 @@ SUPPORTED_GRADIENT_METHODS = [
     "finite-diff",
     "device",
     "adjoint",
+    "gradient-transform",
 ]
 
 

--- a/pennylane/devices/qubit/preprocess.py
+++ b/pennylane/devices/qubit/preprocess.py
@@ -61,11 +61,16 @@ def _accepted_operator(op: qml.operation.Operator) -> bool:
     return op.has_matrix
 
 
+def _accepted_adjoint_operator(op: qml.operation.Operator) -> bool:
+    """Specify whether or not an Oeprator is supported by adjoint differentiation."""
+    return op.num_params <= 1
+
+
 def _operator_decomposition_gen(
-    op: qml.operation.Operator,
+    op: qml.operation.Operator, acceptance_function: Callable[[qml.operation.Operator], bool]
 ) -> Generator[qml.operation.Operator, None, None]:
     """A generator that yields the next operation that is accepted by DefaultQubit2."""
-    if _accepted_operator(op):
+    if acceptance_function(op):
         yield op
     else:
         try:
@@ -76,7 +81,7 @@ def _operator_decomposition_gen(
             ) from e
 
         for sub_op in decomp:
-            yield from _operator_decomposition_gen(sub_op)
+            yield from _operator_decomposition_gen(sub_op, acceptance_function)
 
 
 #######################
@@ -95,34 +100,18 @@ def validate_and_expand_adjoint(
         Union[.QuantumTape, .DeviceError]: The expanded tape, such that it is supported by adjoint differentiation.
         If the circuit is invalid for adjoint differentiation, a DeviceError with an explanation is returned instead.
     """
-    # Check validity of measurements
-    measurements = []
-    for m in circuit.measurements:
-        if not isinstance(m, ExpectationMP):
-            return DeviceError(
-                "Adjoint differentiation method does not support "
-                f"measurement {m.__class__.__name__}."
-            )
 
-        if not m.obs.has_matrix:
-            return DeviceError(
-                f"Adjoint differentiation method does not support observable {m.obs.name}."
-            )
-
-        measurements.append(m)
-
-    expanded_ops = []
-    for op in circuit._ops:
-        if op.num_params > 1:
-            if not isinstance(op, qml.Rot):
-                return DeviceError(
-                    f"The {op} operation is not supported using "
-                    'the "adjoint" differentiation method.'
-                )
-            ops = op.decomposition()
-            expanded_ops.extend(ops)
-        elif not isinstance(op, qml.operation.StatePrep):
-            expanded_ops.append(op)
+    try:
+        new_ops = [
+            final_op
+            for op in circuit._ops
+            for final_op in _operator_decomposition_gen(op, _accepted_adjoint_operator)
+        ]
+    except RecursionError as e:
+        raise DeviceError(
+            "Reached recursion limit trying to decompose operations. "
+            "Operator decomposition may have entered an infinite loop."
+        ) from e
 
     prep = circuit._prep[:1]
 
@@ -141,7 +130,23 @@ def validate_and_expand_adjoint(
         else:
             trainable_params.append(k)
 
-    expanded_tape = qml.tape.QuantumScript(expanded_ops, measurements, prep, circuit.shots)
+    # Check validity of measurements
+    measurements = []
+    for m in circuit.measurements:
+        if not isinstance(m, ExpectationMP):
+            return DeviceError(
+                "Adjoint differentiation method does not support "
+                f"measurement {m.__class__.__name__}."
+            )
+
+        if not m.obs.has_matrix:
+            return DeviceError(
+                f"Adjoint differentiation method does not support observable {m.obs.name}."
+            )
+
+        measurements.append(m)
+
+    expanded_tape = qml.tape.QuantumScript(new_ops, measurements, prep, circuit.shots)
     expanded_tape.trainable_params = trainable_params
 
     return expanded_tape
@@ -209,7 +214,9 @@ def expand_fn(circuit: qml.tape.QuantumScript) -> qml.tape.QuantumScript:
     if not all(_accepted_operator(op) for op in circuit._ops):
         try:
             new_ops = [
-                final_op for op in circuit._ops for final_op in _operator_decomposition_gen(op)
+                final_op
+                for op in circuit._ops
+                for final_op in _operator_decomposition_gen(op, _accepted_operator)
             ]
         except RecursionError as e:
             raise DeviceError(

--- a/pennylane/interfaces/autograd.py
+++ b/pennylane/interfaces/autograd.py
@@ -511,7 +511,7 @@ def vjp(
                 unwrapped_tapes = tuple(convert_to_numpy_parameters(t) for t in tapes)
                 jacs = gradient_fn(unwrapped_tapes, **gradient_kwargs)
 
-                vjps = _compute_vjps_autograd(jacs, dy, multi_measurements, device.shot_vector)
+                vjps = _compute_vjps_autograd(jacs, dy, multi_measurements, shot_vector)
 
         return_vjps = [
             qml.math.to_numpy(v, max_depth=_n) if isinstance(v, ArrayBox) else v for v in vjps

--- a/pennylane/interfaces/execution.py
+++ b/pennylane/interfaces/execution.py
@@ -21,7 +21,7 @@ devices with autodifferentiation support.
 
 # pylint: disable=import-outside-toplevel,too-many-arguments,too-many-branches,not-callable
 # pylint: disable=unused-argument,unnecessary-lambda-assignment,inconsistent-return-statements,
-# pylint: disable=too-many-statements, invalid-unary-operand-type
+# pylint: disable=too-many-statements, invalid-unary-operand-type, function-redefined
 
 import inspect
 import warnings
@@ -455,7 +455,17 @@ def execute(
         interface = qml.math.get_interface(*params)
 
     new_device_interface = isinstance(device, qml.devices.experimental.Device)
-    config = qml.devices.experimental.ExecutionConfig(interface=interface)
+    if gradient_fn is None:
+        _gradient_method = None
+    elif isinstance(gradient_fn, str):
+        _gradient_method = gradient_fn
+    else:
+        _gradient_method = "gradient-transform"
+    config = qml.devices.experimental.ExecutionConfig(
+        interface=interface,
+        gradient_method=_gradient_method,
+        grad_on_execution=None if grad_on_execution == "best" else grad_on_execution,
+    )
     gradient_kwargs = gradient_kwargs or {}
 
     if isinstance(cache, bool) and cache:
@@ -506,19 +516,54 @@ def execute(
 
     _grad_on_execution = False
 
-    if gradient_fn == "device":
+    if config.use_device_gradient:
+        # must be new device if this is specified as true
+        _grad_on_execution = config.grad_on_execution
+
+        if config.grad_on_execution:
+
+            def execute_fn(internal_tapes):
+                """A partial function that wraps the execute_and_compute_derivatives method of the device.
+
+                Closure Variables:
+                    device: The device to execute on
+                    config: the ExecutionConfig that specifies how to perform the simulations.
+                """
+                return device.execute_and_compute_derivatives(internal_tapes, config)
+
+            gradient_fn = None
+
+        else:
+
+            def execute_fn(internal_tapes) -> Tuple[ResultBatch, Tuple]:
+                """A wrapper around device.execute that adds an empty tuple instead of derivatives.
+
+                Closure Variables:
+                    device: the device to execute on
+                    config: the ExecutionConfig that specifies how to perform the simulations.
+                """
+                return (device.execute(internal_tapes, config), tuple())
+
+            def gradient_fn(internal_tapes):
+                """A partial function that wraps compute_derivatives method of the device.
+
+                Closure Variables:
+                    device: the device to execute on
+                    config: the ExecutionConfig that specifies how to take the derivative.
+                """
+                return device.compute_derivatives(internal_tapes, config)
+
+    elif gradient_fn == "device":
         # gradient function is a device method
 
         # Expand all tapes as per the device's expand function here.
         # We must do this now, prior to the interface, to ensure that
         # decompositions with parameter processing is tracked by the
         # autodiff frameworks.
-        for i, tape in enumerate(tapes):
-            tapes[i] = expand_fn(tape)
+        tapes = tuple(expand_fn(t) for t in tapes)
 
         if gradient_kwargs.get("method", "") == "adjoint_jacobian":
-            mode = "forward" if grad_on_execution else "backward"
-            tapes = _adjoint_jacobian_expansion(tapes, mode, interface, max_expansion)
+            tapes = _adjoint_jacobian_expansion(tapes, grad_on_execution, interface, max_expansion)
 
         # grad on execution or best was chosen
         if grad_on_execution is True or grad_on_execution == "best":

--- a/tests/interfaces/default_qubit_2_integration/test_autograd_default_qubit_2.py
+++ b/tests/interfaces/default_qubit_2_integration/test_autograd_default_qubit_2.py
@@ -105,7 +105,8 @@ test_matrix = [
     ({"gradient_fn": param_shift}, 100000, DefaultQubit2(seed=42)),
     ({"gradient_fn": param_shift}, None, DefaultQubit2()),
     ({"gradient_fn": "backprop"}, None, DefaultQubit2()),
-    # no device gradient yet
+    ({"gradient_fn": "adjoint", "grad_on_execution": True}, None, DefaultQubit2()),
+    ({"gradient_fn": "adjoint", "grad_on_execution": False}, None, DefaultQubit2()),
 ]
 
 
@@ -196,7 +197,7 @@ class TestAutogradExecuteIntegration:
         """Test that a tape with no parameters is correctly
         ignored during the gradient computation"""
 
-        if execute_kwargs["gradient_fn"] == "device":
+        if execute_kwargs["gradient_fn"] == "adjoint":
             pytest.skip("Adjoint differentiation does not yet support probabilities")
 
         def cost(params):
@@ -448,6 +449,9 @@ class TestAutogradExecuteIntegration:
         """Tests correct output shape and evaluation for a tape
         with prob outputs"""
 
+        if execute_kwargs["gradient_fn"] == "adjoint":
+            pytest.skip("adjoint differentiation does not suppport probabilities.")
+
         def cost(x, y):
             ops = [qml.RX(x, 0), qml.RY(y, 1), qml.CNOT((0, 1))]
             m = [qml.probs(wires=0), qml.probs(wires=1)]
@@ -500,7 +504,7 @@ class TestAutogradExecuteIntegration:
     def test_ragged_differentiation(self, execute_kwargs, device, shots):
         """Tests correct output shape and evaluation for a tape
         with prob and expval outputs"""
-        if execute_kwargs["gradient_fn"] == "device":
+        if execute_kwargs["gradient_fn"] == "adjoint":
             pytest.skip("Adjoint differentiation does not yet support probabilities")
 
         def cost(x, y):
@@ -612,20 +616,25 @@ class TestHigherOrderDerivatives:
 
 
 @pytest.mark.parametrize("execute_kwargs, shots, device", test_matrix)
+@pytest.mark.parametrize("use_new_op_math", (True, False))
 class TestHamiltonianWorkflows:
     """Test that tapes ending with expectations
     of Hamiltonians provide correct results and gradients"""
 
     @pytest.fixture
-    def cost_fn(self, execute_kwargs, shots, device):
+    def cost_fn(self, execute_kwargs, shots, device, use_new_op_math):
         """Cost function for gradient tests"""
 
         def _cost_fn(weights, coeffs1, coeffs2):
             obs1 = [qml.PauliZ(0), qml.PauliZ(0) @ qml.PauliX(1), qml.PauliY(0)]
             H1 = qml.Hamiltonian(coeffs1, obs1)
+            if use_new_op_math:
+                H1 = qml.pauli.pauli_sentence(H1).operation()
 
             obs2 = [qml.PauliZ(0)]
             H2 = qml.Hamiltonian(coeffs2, obs2)
+            if use_new_op_math:
+                H2 = qml.pauli.pauli_sentence(H2).operation()
 
             with qml.queuing.AnnotatedQueue() as q:
                 qml.RX(weights[0], wires=0)
@@ -667,8 +676,13 @@ class TestHamiltonianWorkflows:
             ]
         )
 
-    def test_multiple_hamiltonians_not_trainable(self, cost_fn, shots):
+    def test_multiple_hamiltonians_not_trainable(
+        self, execute_kwargs, cost_fn, shots, use_new_op_math
+    ):
         """Test hamiltonian with no trainable parameters."""
+
+        if execute_kwargs["gradient_fn"] == "adjoint" and not use_new_op_math:
+            pytest.skip("adjoint differentiation does not suppport hamiltonians.")
 
         coeffs1 = np.array([0.1, 0.2, 0.3], requires_grad=False)
         coeffs2 = np.array([0.7], requires_grad=False)
@@ -682,8 +696,11 @@ class TestHamiltonianWorkflows:
         expected = self.cost_fn_jacobian(weights, coeffs1, coeffs2)[:, :2]
         assert np.allclose(res, expected, atol=atol_for_shots(shots), rtol=0)
 
-    def test_multiple_hamiltonians_trainable(self, cost_fn, shots):
+    def test_multiple_hamiltonians_trainable(self, execute_kwargs, cost_fn, shots, use_new_op_math):
         """Test hamiltonian with trainable parameters."""
+        if execute_kwargs["gradient_fn"] == "adjoint" and not use_new_op_math:
+            pytest.skip("adjoint differentiation does not suppport hamiltonians.")
+
         coeffs1 = np.array([0.1, 0.2, 0.3], requires_grad=True)
         coeffs2 = np.array([0.7], requires_grad=True)
         weights = np.array([0.4, 0.5], requires_grad=True)


### PR DESCRIPTION
This PR integrates device derivatives coming from the experimental device with `qml.execute`.

In doing so, I also updated `DefaultQubit2.preprocess` so that it expands operations that aren't supported by adjoint differentiation if it is requested.

I also added a possible key `"gradient-transform"` to `ExecutionConfig.gradient_method` to correspond to a callable gradient transform. We could consider adding an optional `gradient_transform` key to the `ExecutionConfig` for when the gradient method is a gradient transform.