### PR TITLE
use Shots class in gradients module

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -123,6 +123,9 @@
 * The construction of the pauli representation for the `Sum` class is now faster.
   [(#4142)](https://github.com/PennyLaneAI/pennylane/pull/4142)
 
+* Updated the `gradients` module to use the new `Shots` object internally.
+  [(#4152)](https://github.com/PennyLaneAI/pennylane/pull/4152)
+
 <h3>Breaking changes 💔</h3>
 
 * All drawing methods changed their default value for the keyword argument `show_matrices` to `True`.

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -83,7 +83,7 @@ def _process_shot_sequence(shot_list):
         else:
             # Iterate through the shots, and group consecutive identical shots
             split_at_repeated = np.split(shot_list, np.diff(shot_list).nonzero()[0] + 1)
-            shot_vector = [ShotTuple(shots=i[0], copies=len(i)) for i in split_at_repeated]
+            shot_vector = [ShotTuple(shots=int(i[0]), copies=len(i)) for i in split_at_repeated]
 
     elif all(isinstance(s, (int, tuple)) for s in shot_list):
         # shot list contains tuples; assume it is already in a sparse representation

--- a/pennylane/gradients/finite_difference.py
+++ b/pennylane/gradients/finite_difference.py
@@ -23,7 +23,7 @@ import numpy as np
 from scipy.special import factorial
 
 import pennylane as qml
-from pennylane.measurements import ProbabilityMP
+from pennylane.measurements import ProbabilityMP, Shots
 
 from .general_shift_rules import generate_shifted_tapes
 from .gradient_transform import (
@@ -156,7 +156,7 @@ def finite_diff_coeffs(n, approx_order, strategy):
     return coeffs_and_shifts
 
 
-def _processing_fn(results, shots=qml.measurements.Shots(None), single_shot_batch_fn=None):
+def _processing_fn(results, shots: Shots = Shots(None), single_shot_batch_fn=None):
     if not shots.has_partitioned_shots:
         return single_shot_batch_fn(results)
     grads_tuple = []
@@ -338,7 +338,7 @@ def finite_diff(
             validate_params=validate_params,
             shots=shots,
         )
-    shots = qml.measurements.Shots(shots)
+    shots = Shots(shots)
     if argnum is None and not tape.trainable_params:
         return _no_trainable_grad(tape, shots)
 

--- a/pennylane/gradients/finite_difference.py
+++ b/pennylane/gradients/finite_difference.py
@@ -23,7 +23,6 @@ import numpy as np
 from scipy.special import factorial
 
 import pennylane as qml
-from pennylane._device import _get_num_copies
 from pennylane.measurements import ProbabilityMP
 
 from .general_shift_rules import generate_shifted_tapes
@@ -157,21 +156,15 @@ def finite_diff_coeffs(n, approx_order, strategy):
     return coeffs_and_shifts
 
 
-def _processing_fn(results, shots=None, single_shot_batch_fn=None):
-    shot_vector = isinstance(shots, Sequence)
-
-    if not shot_vector:
-        grads_tuple = single_shot_batch_fn(results)
-    else:
-        grads_tuple = []
-        len_shot_vec = _get_num_copies(shots)
-        for idx in range(len_shot_vec):
-            res = [tape_res[idx] for tape_res in results]
-            g_tuple = single_shot_batch_fn(res)
-            grads_tuple.append(g_tuple)
-        grads_tuple = tuple(grads_tuple)
-
-    return grads_tuple
+def _processing_fn(results, shots=qml.measurements.Shots(None), single_shot_batch_fn=None):
+    if not shots.has_partitioned_shots:
+        return single_shot_batch_fn(results)
+    grads_tuple = []
+    for idx in range(shots.num_copies):
+        res = [tape_res[idx] for tape_res in results]
+        g_tuple = single_shot_batch_fn(res)
+        grads_tuple.append(g_tuple)
+    return tuple(grads_tuple)
 
 
 @gradient_transform
@@ -345,6 +338,7 @@ def finite_diff(
             validate_params=validate_params,
             shots=shots,
         )
+    shots = qml.measurements.Shots(shots)
     if argnum is None and not tape.trainable_params:
         return _no_trainable_grad(tape, shots)
 

--- a/pennylane/gradients/hadamard_gradient.py
+++ b/pennylane/gradients/hadamard_gradient.py
@@ -186,6 +186,7 @@ def _hadamard_grad(
     assert_active_return(transform_name)
     assert_no_state_returns(tape.measurements, transform_name)
     assert_no_variance(tape.measurements, transform_name)
+    shots = qml.measurements.Shots(shots)
 
     if argnum is None and not tape.trainable_params:
         return _no_trainable_grad(tape, shots)

--- a/pennylane/gradients/jvp.py
+++ b/pennylane/gradients/jvp.py
@@ -15,8 +15,6 @@
 This module contains functions for computing the Jacobian vector product
 of tapes.
 """
-from collections.abc import Sequence
-
 import numpy as np
 
 import pennylane as qml
@@ -302,9 +300,6 @@ def jvp(tape, tangent, gradient_fn, shots=None, gradient_kwargs=None):
         return [], lambda _, num=None: None
 
     multi_m = len(tape.measurements) > 1
-    # pylint:disable=protected-access
-    if isinstance(shots, Sequence) and all(isinstance(s, qml._device.ShotTuple) for s in shots):
-        shots = list(map(tuple, shots))
     shots = qml.measurements.Shots(shots)
 
     try:

--- a/pennylane/gradients/jvp.py
+++ b/pennylane/gradients/jvp.py
@@ -18,7 +18,7 @@ of tapes.
 import numpy as np
 
 import pennylane as qml
-from pennylane.measurements import ProbabilityMP
+from pennylane.measurements import ProbabilityMP, Shots
 
 
 def compute_jvp_single(tangent, jac):
@@ -300,7 +300,7 @@ def jvp(tape, tangent, gradient_fn, shots=None, gradient_kwargs=None):
         return [], lambda _, num=None: None
 
     multi_m = len(tape.measurements) > 1
-    shots = qml.measurements.Shots(shots)
+    shots = Shots(shots)
 
     try:
         # if qml.math.allclose(qml.math.stack(tangent), 0):

--- a/pennylane/gradients/parameter_shift.py
+++ b/pennylane/gradients/parameter_shift.py
@@ -22,8 +22,7 @@ from functools import partial
 import numpy as np
 
 import pennylane as qml
-from pennylane._device import _get_num_copies
-from pennylane.measurements import VarianceMP
+from pennylane.measurements import VarianceMP, Shots
 
 from .finite_difference import finite_diff
 from .general_shift_rules import (
@@ -185,15 +184,13 @@ def _multi_meas_grad(res, coeffs, r0, unshifted_coeff, num_measurements):
     return tuple(g)
 
 
-def _evaluate_gradient(tape, res, data, r0, shots):
+def _evaluate_gradient(tape, res, data, r0, shots: Shots):
     """Use shifted tape evaluations and parameter-shift rule coefficients to evaluate
     a gradient result. If res is an empty list, ``r0`` and ``data[3]``, which is the
     coefficient for the unshifted term, must be given and not None.
     """
 
     _, coeffs, fn, unshifted_coeff, _ = data
-
-    shot_vector = isinstance(shots, Sequence)
 
     # individual post-processing of e.g. Hamiltonian grad tapes
     if fn is not None:
@@ -202,10 +199,10 @@ def _evaluate_gradient(tape, res, data, r0, shots):
     num_measurements = len(tape.measurements)
 
     if num_measurements == 1:
-        if not shot_vector:
+        if not shots.has_partitioned_shots:
             return _single_meas_grad(res, coeffs, unshifted_coeff, r0)
         g = []
-        len_shot_vec = _get_num_copies(shots)
+        len_shot_vec = shots.num_copies
         # Res has order of axes:
         # 1. Number of parameters
         # 2. Shot vector
@@ -218,15 +215,14 @@ def _evaluate_gradient(tape, res, data, r0, shots):
         return tuple(g)
 
     g = []
-    if not shot_vector:
+    if not shots.has_partitioned_shots:
         return _multi_meas_grad(res, coeffs, r0, unshifted_coeff, num_measurements)
 
-    len_shot_vec = _get_num_copies(shots)
     # Res has order of axes:
     # 1. Number of parameters
     # 2. Shot vector
     # 3. Number of measurements
-    for idx_shot_comp in range(len_shot_vec):
+    for idx_shot_comp in range(shots.num_copies):
         single_shot_component_result = [
             result_for_each_param[idx_shot_comp] for result_for_each_param in res
         ]
@@ -330,14 +326,14 @@ def _get_operation_recipe(tape, t_idx, shifts, order=1):
     return qml.math.stack([coeffs, mults, shifts]).T
 
 
-def _make_zero_rep(g, single_measure, shot_vector):
+def _make_zero_rep(g, single_measure, partitioned_shots):
     """Create a zero-valued gradient entry adapted to the measurements and shot_vector
     of a gradient computation, where g is a previously computed non-zero gradient entry."""
-    if single_measure and not shot_vector:
+    if single_measure and not partitioned_shots:
         zero_rep = qml.math.zeros_like(g)
     elif single_measure:
         zero_rep = tuple(qml.math.zeros_like(shot_comp_g) for shot_comp_g in g)
-    elif not shot_vector:
+    elif not partitioned_shots:
         zero_rep = tuple(qml.math.zeros_like(meas_g) for meas_g in g)
     else:
         zero_rep = tuple(
@@ -437,8 +433,8 @@ def expval_param_shift(
     num_measurements = len(tape.measurements)
     single_measure = num_measurements == 1
     num_params = len(tape.trainable_params)
-    shot_vector = isinstance(shots, Sequence)
-    tape_specs = (single_measure, num_params, num_measurements, shot_vector, shots)
+    shots = Shots(shots)
+    tape_specs = (single_measure, num_params, num_measurements, shots)
 
     def processing_fn(results):
         start, r0 = (1, results[0]) if at_least_one_unshifted and f0 is None else (0, f0)
@@ -464,7 +460,7 @@ def expval_param_shift(
 
         # g will have been defined at least once (because otherwise all gradients would have
         # been zero), providing a representative for a zero gradient to emulate its type/shape.
-        zero_rep = _make_zero_rep(g, single_measure, shot_vector)
+        zero_rep = _make_zero_rep(g, single_measure, shots.has_partitioned_shots)
 
         # Fill in zero-valued gradients
         grads = [zero_rep if g is None else g for g in grads]
@@ -671,7 +667,7 @@ def _put_zeros_in_pdA2_involutory(tape, pdA2, involutory_indices):
     return tuple(new_pdA2)
 
 
-def _get_pdA2(results, tape, pdA2_fn, non_involutory_indices, var_indices, shot_vector):
+def _get_pdA2(results, tape, pdA2_fn, non_involutory_indices, var_indices, partitioned_shots):
     """The main auxiliary function to get the partial derivative of <A^2>."""
     pdA2 = 0
 
@@ -680,10 +676,8 @@ def _get_pdA2(results, tape, pdA2_fn, non_involutory_indices, var_indices, shot_
         pdA2 = pdA2_fn(results)
 
         # For involutory observables (A^2 = I) we have d<A^2>/dp = 0.
-        involutory = set(var_indices) - set(non_involutory_indices)
-
-        if involutory:
-            if shot_vector:
+        if involutory := set(var_indices) - set(non_involutory_indices):
+            if partitioned_shots:
                 pdA2 = tuple(
                     _put_zeros_in_pdA2_involutory(tape, pdA2_shot_comp, involutory)
                     for pdA2_shot_comp in pdA2
@@ -765,36 +759,40 @@ def _create_variance_proc_fn(
             determine the number of results to post-process later
         non_involutory_indices (list): the indices in the measurement queue of all non-involutory
             observables
-        shots (None, int, list[int]): The device shots that will be used to execute the tapes outputted by this
+        shots (.Shots): The device shots that will be used to execute the tapes outputted by this
             the param-shift transform.
     """
 
     def processing_fn(results):
         f0 = results[0]
 
-        shot_vector = isinstance(shots, Sequence)
+        partitioned_shots = shots.has_partitioned_shots
 
         # analytic derivative of <A>
         pdA = pdA_fn(results[int(not pdA_fn.first_result_unshifted) : tape_boundary])
 
         # analytic derivative of <A^2>
         pdA2 = _get_pdA2(
-            results[tape_boundary:], tape, pdA2_fn, non_involutory_indices, var_indices, shot_vector
+            results[tape_boundary:],
+            tape,
+            pdA2_fn,
+            non_involutory_indices,
+            var_indices,
+            partitioned_shots,
         )
 
         # The logic follows:
         # variances (var_mask==True): return d(var(A))/dp = d<A^2>/dp -2 * <A> * d<A>/dp
         # plain expectations (var_mask==False): return d<A>/dp
         # Note: if pdA2 != 0, then len(pdA2) == len(pdA)
-        if shot_vector:
+        if partitioned_shots:
             final_res = []
-            len_shot_vec = _get_num_copies(shots)
-            for idx_shot_comp in range(len_shot_vec):
+            for idx_shot_comp in range(shots.num_copies):
                 f0_comp = f0[idx_shot_comp]
 
                 pdA_comp = pdA[idx_shot_comp]
 
-                pdA2_comp = pdA2[idx_shot_comp] if not isinstance(pdA2, int) else pdA2
+                pdA2_comp = pdA2 if isinstance(pdA2, int) else pdA2[idx_shot_comp]
                 r = _single_variance_gradient(tape, var_mask, pdA2_comp, f0_comp, pdA_comp)
                 final_res.append(r)
 
@@ -845,6 +843,7 @@ def var_param_shift(
         return _var_param_shift_legacy(tape, argnum, shifts, gradient_recipes, f0, broadcast, shots)
 
     argnum = argnum or tape.trainable_params
+    shots = Shots(shots)
 
     # Determine the locations of any variance measurements in the measurement queue.
     var_mask = [isinstance(m, VarianceMP) for m in tape.measurements]
@@ -1367,6 +1366,7 @@ def param_shift(
         )
 
     transform_name = "parameter-shift rule"
+    shots = Shots(shots)
     assert_no_state_returns(tape.measurements, transform_name)
     assert_multimeasure_not_broadcasted(tape.measurements, broadcast)
 
@@ -1389,7 +1389,7 @@ def param_shift(
     if unsupported_params:
         # If shots were provided, assume that the fallback function also takes that arg
 
-        fallback_fn = fallback_fn if shots is None else partial(fallback_fn, shots=shots)
+        fallback_fn = partial(fallback_fn, shots=shots) if shots.total_shots else fallback_fn
         if not argnum:
             return fallback_fn(tape)
 
@@ -1449,19 +1449,16 @@ def param_shift(
             unsupported_res = results[:fallback_len]
             supported_res = results[fallback_len:]
 
-            shot_vector = isinstance(shots, Sequence)
-            if not shot_vector:
+            if not shots.has_partitioned_shots:
                 unsupported_grads = fallback_proc_fn(unsupported_res)
                 supported_grads = fn(supported_res)
                 return _single_shot_batch_grad(unsupported_grads, supported_grads)
-
-            len_shot_vec = _get_num_copies(shots)
 
             supported_grads = fn(supported_res)
             unsupported_grads = fallback_proc_fn(unsupported_res)
 
             final_grad = []
-            for idx in range(len_shot_vec):
+            for idx in range(shots.num_copies):
                 u_grads = unsupported_grads[idx]
                 sup = supported_grads[idx]
                 final_grad.append(_single_shot_batch_grad(u_grads, sup))

--- a/pennylane/gradients/pulse_gradient.py
+++ b/pennylane/gradients/pulse_gradient.py
@@ -599,7 +599,7 @@ def _expval_stoch_pulse_grad(tape, argnum, num_split_times, key, shots, use_broa
     num_measurements = len(tape.measurements)
     single_measure = num_measurements == 1
     num_params = len(tape.trainable_params)
-    partitioned_shots = shots.has_partitioned_shots
+    has_partitioned_shots = shots.has_partitioned_shots
     tape_specs = (single_measure, num_params, num_measurements, shots)
 
     def processing_fn(results):
@@ -614,13 +614,13 @@ def _expval_stoch_pulse_grad(tape, argnum, num_split_times, key, shots, use_broa
             # Apply the postprocessing of the parameter-shift rule and contract
             # with classical Jacobian, effectively computing the integral approximation
             g = _parshift_and_integrate(
-                res, cjacs, avg_prefactor, single_measure, partitioned_shots, use_broadcasting
+                res, cjacs, avg_prefactor, single_measure, has_partitioned_shots, use_broadcasting
             )
             grads.append(g)
 
         # g will have been defined at least once (because otherwise all gradients would have
         # been zero), providing a representative for a zero gradient to emulate its type/shape.
-        zero_rep = _make_zero_rep(g, single_measure, partitioned_shots)
+        zero_rep = _make_zero_rep(g, single_measure, has_partitioned_shots)
 
         # Fill in zero-valued gradients
         grads = [zero_rep if g is None else g for g in grads]

--- a/pennylane/gradients/spsa_gradient.py
+++ b/pennylane/gradients/spsa_gradient.py
@@ -275,6 +275,7 @@ def spsa_grad(
             sampler_seed=sampler_seed,
         )
 
+    shots = qml.measurements.Shots(shots)
     if argnum is None and not tape.trainable_params:
         return _no_trainable_grad(tape, shots)
 

--- a/pennylane/gradients/vjp.py
+++ b/pennylane/gradients/vjp.py
@@ -16,7 +16,6 @@ This module contains functions for computing the vector-Jacobian product
 of tapes.
 """
 # pylint: disable=no-member, too-many-branches
-from collections.abc import Sequence
 import numpy as np
 import autograd
 
@@ -359,8 +358,6 @@ def vjp(tape, dy, gradient_fn, shots=None, gradient_kwargs=None):
         return [], lambda _, num=None: None
 
     # pylint:disable=protected-access
-    if isinstance(shots, Sequence) and all(isinstance(s, qml._device.ShotTuple) for s in shots):
-        shots = list(map(tuple, shots))
     shots = qml.measurements.Shots(shots)
 
     try:

--- a/pennylane/gradients/vjp.py
+++ b/pennylane/gradients/vjp.py
@@ -388,13 +388,12 @@ def vjp(tape, dy, gradient_fn, shots=None, gradient_kwargs=None):
     def processing_fn(results, num=None):
         # postprocess results to compute the Jacobian
         jac = fn(results)
-        shot_vector = isinstance(shots, Sequence)
 
         if qml.active_return():
             multi = len(tape.measurements) > 1
             comp_vjp_fn = compute_vjp_multi if multi else compute_vjp_single
 
-            if not shot_vector:
+            if not shots.has_partitioned_shots:
                 return comp_vjp_fn(dy, jac, num=num)
 
             vjp_ = [comp_vjp_fn(dy_, jac_, num=num) for dy_, jac_ in zip(dy, jac)]

--- a/pennylane/gradients/vjp.py
+++ b/pennylane/gradients/vjp.py
@@ -358,6 +358,11 @@ def vjp(tape, dy, gradient_fn, shots=None, gradient_kwargs=None):
         # is simply none.
         return [], lambda _, num=None: None
 
+    # pylint:disable=protected-access
+    if isinstance(shots, Sequence) and all(isinstance(s, qml._device.ShotTuple) for s in shots):
+        shots = list(map(tuple, shots))
+    shots = qml.measurements.Shots(shots)
+
     try:
         if _all_close_to_zero(dy):
             # If the dy vector is zero, then the

--- a/pennylane/gradients/vjp.py
+++ b/pennylane/gradients/vjp.py
@@ -357,7 +357,6 @@ def vjp(tape, dy, gradient_fn, shots=None, gradient_kwargs=None):
         # is simply none.
         return [], lambda _, num=None: None
 
-    # pylint:disable=protected-access
     shots = qml.measurements.Shots(shots)
 
     try:

--- a/pennylane/measurements/shots.py
+++ b/pennylane/measurements/shots.py
@@ -223,3 +223,8 @@ class Shots:
         if self.total_shots is None:
             return False
         return len(self.shot_vector) > 1 or self.shot_vector[0].copies > 1
+
+    @property
+    def num_copies(self):
+        """The total number of copies of any shot quantity."""
+        return sum(s.copies for s in self.shot_vector)

--- a/pennylane/optimize/shot_adaptive.py
+++ b/pennylane/optimize/shot_adaptive.py
@@ -242,11 +242,11 @@ class ShotAdaptiveOptimizer(GradientDescentOptimizer):
                 continue
 
             # set the QNode device shots
-            h.device.shots = [(1, int(s))]
+            h.device.shots = 1 if s == 1 else [(1, int(s))]
 
             jacs = []
             for i in argnums:
-                if qml.active_return():
+                if qml.active_return() and s > 1:
 
                     def cost(*args, **kwargs):
                         # pylint: disable=cell-var-from-loop
@@ -257,7 +257,7 @@ class ShotAdaptiveOptimizer(GradientDescentOptimizer):
 
                 j = qml.jacobian(cost, argnum=i)(*args, **kwargs)
 
-                if s == 1 and not qml.active_return():
+                if s == 1:
                     j = np.expand_dims(j, 0)
                 # Divide each term by the probability per shot. This is
                 # because we are sampling one at a time.

--- a/tests/measurements/test_shots.py
+++ b/tests/measurements/test_shots.py
@@ -226,6 +226,8 @@ class TestShotsConstruction:
             (10, 1),
             ([10, 10], 2),
             ([10, 10, 20], 3),
+            ([100, (10, 3)], 4),
+            ([(10, 3), (20, 2)], 5),
         ],
     )
     def test_num_copies(self, shots, expected):

--- a/tests/measurements/test_shots.py
+++ b/tests/measurements/test_shots.py
@@ -218,3 +218,15 @@ class TestShotsConstruction:
     def test_has_partitioned_shots(self, shots, expected):
         """Tests the has_partitioned_shots method."""
         assert Shots(shots).has_partitioned_shots is expected
+
+    @pytest.mark.parametrize(
+        "shots, expected",
+        [
+            (None, 0),
+            (10, 1),
+            ([10, 10], 2),
+            ([10, 10, 20], 3),
+        ],
+    )
+    def test_num_copies(self, shots, expected):
+        assert Shots(shots).num_copies == expected


### PR DESCRIPTION
**Context:**
The gradients module needs updating to the new Shots class, so this does that. Once the interfaces module does this as well, we'll be near rid of any old Shots usage internally.

**Description of the Change:**
- Add a `num_copies` property to the `Shots` class, as various gradient methods were computing it on their own before
- Update all gradients to use the new `Shots` type internally. The outward-facing functions (eg. `qml.gradients.param_shift`) accept vanilla python types and cast to a `Shots` object for you so the user doesn't need to know, but the private functions across the module now expect a strongly-type `Shots` object
- Little fix-up to `shot_adaptive` for the case where it set `device.shot_tuple = [(1, 1)]`. The old shots "API" considered this to be partitioned shots, but the new `Shots` class disagreed, and it caused a test to fail while computing results of varying shapes

**Benefits:**
We are closer to removing shots from the device, and we can now use pretty, well-defined class properties/methods in the gradients module when working with shots

**Possible Drawbacks:**
Might be a touch difficult to fully clean out the old stuff in the future, and maybe the occasional unnecessary casting to `Shots` (luckily, the constructor just returns `self` in that case!)