### PR TITLE
Treat identities as equivalent in `pauli.are_identical_pauli_words`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -170,6 +170,7 @@
 
 * `qml.pauli.are_identical_pauli_words` now treats all identities as equal. Identity terms on Hamiltonians with non-standard
   wire orders are no longer eliminated.
+  [(#4161)](https://github.com/PennyLaneAI/pennylane/pull/4161)
 
 <h3>Contributors ✍️</h3>
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -168,6 +168,9 @@
 * Removes a patch in `interfaces/autograd.py` that checks for the `strawberryfields.gbs` device.  That device
   is pinned to PennyLane <= v0.29.0, so that patch is no longer necessary.
 
+* `qml.pauli.are_identical_pauli_words` now treats all identities as equal. Identity terms on Hamiltonians with non-standard
+  wire orders are no longer eliminated.
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane/pauli/utils.py
+++ b/pennylane/pauli/utils.py
@@ -148,6 +148,9 @@ def are_identical_pauli_words(pauli_1, pauli_2):
     pauli_1 = getattr(pauli_1, "prune", lambda: pauli_1)()
     pauli_2 = getattr(pauli_2, "prune", lambda: pauli_2)()
 
+    if isinstance(pauli_1, qml.Identity) and isinstance(pauli_2, qml.Identity):
+        return True
+
     if isinstance(pauli_1, paulis_with_identity) and isinstance(pauli_2, paulis_with_identity):
         return (pauli_1.wires, pauli_1.name) == (pauli_2.wires, pauli_2.name)
 

--- a/tests/ops/qubit/test_hamiltonian.py
+++ b/tests/ops/qubit/test_hamiltonian.py
@@ -1479,6 +1479,14 @@ class TestHamiltonianArithmeticJax:
 class TestGrouping:
     """Tests for the grouping functionality"""
 
+    def test_indentities_preserved(self):
+        """Tests that the grouping indices do not drop identity terms when the wire order is nonstandard."""
+
+        obs = [qml.PauliZ(1), qml.PauliZ(0), qml.Identity(0)]
+
+        H = qml.Hamiltonian([1.0, 1.0, 1.0], obs, grouping_type="qwc")
+        assert H.grouping_indices == [[0, 1, 2]]
+
     def test_grouping_is_correct_kwarg(self):
         """Basic test checking that grouping with a kwarg works as expected"""
         a = qml.PauliX(0)

--- a/tests/pauli/test_pauli_utils.py
+++ b/tests/pauli/test_pauli_utils.py
@@ -309,6 +309,11 @@ class TestGroupingUtils:
         assert not are_identical_pauli_words(pauli_word_1, pauli_word_4)
         assert not are_identical_pauli_words(pauli_word_3, pauli_word_4)
 
+    def test_identities_always_pauli_words(self):
+        """Tests that identity terms are always identical."""
+        assert are_identical_pauli_words(qml.Identity(0), qml.Identity("a"))
+        assert are_identical_pauli_words(qml.Identity((-2, -3)), qml.Identity("wire"))
+
     @pytest.mark.parametrize("non_pauli_word", non_pauli_words)
     def test_are_identical_pauli_words_non_pauli_word_catch(self, non_pauli_word):
         """Tests TypeError raise for when non-Pauli word Pennylane operators/operations are given


### PR DESCRIPTION
Fixes #4155 

```
>>> binary_repr = qml.pauli.pauli_to_binary(qml.Identity("b"), wire_map={"a": 0, "b": 1})
>>> qml.pauli.binary_to_pauli(binary_repr, wire_map={"a": 0, "b": 1})
Identity(wires=['a'])
```

Converting an `Identity` to a binary form and back removes the wires it was originally on.  This causes problems when computing the grouping indices on a Hamiltonian because the original operation and the returned operation are no longer the same.

This problem can be circumvented by making all identities identical:
```
>>> qml.pauli.are_identical_pauli_words(qml.Identity("a"), qml.Identity("b"))
True
```

Given the two terms do inherently represent the same thing, this decision should be fine.