### PR TITLE
Empty hamiltonians are compatible with `qml.pauli_sentence()`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -182,7 +182,7 @@
   wire orders are no longer eliminated.
   [(#4161)](https://github.com/PennyLaneAI/pennylane/pull/4161)
 
-* `qml.pauli_sentence()` is now compatible with empty hamiltonians `qml.Hamiltonian([], [])`.
+* `qml.pauli_sentence()` is now compatible with empty Hamiltonians `qml.Hamiltonian([], [])`.
   [(#4171)](https://github.com/PennyLaneAI/pennylane/pull/4171)
 
 <h3>Contributors ✍️</h3>

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -182,6 +182,9 @@
   wire orders are no longer eliminated.
   [(#4161)](https://github.com/PennyLaneAI/pennylane/pull/4161)
 
+* `qml.pauli_sentence()` is now compatible with empty hamiltonians `qml.Hamiltonian([], [])`.
+  [(#4171)](https://github.com/PennyLaneAI/pennylane/pull/4171)
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane/pauli/conversion.py
+++ b/pennylane/pauli/conversion.py
@@ -214,7 +214,7 @@ def _(op: Hamiltonian):
             ps[pw] = coeff * sub_coeff
         summands.append(ps)
 
-    return reduce(lambda a, b: a + b, summands)
+    return reduce(lambda a, b: a + b, summands) if len(summands) > 0 else PauliSentence()
 
 
 @pauli_sentence.register

--- a/pennylane/pauli/pauli_arithmetic.py
+++ b/pennylane/pauli/pauli_arithmetic.py
@@ -307,7 +307,7 @@ class PauliSentence(dict):
     def __str__(self):
         """String representation of the PauliSentence."""
         if len(self) == 0:
-            return "I"
+            return "0 * I"
         return "\n+ ".join(f"{coeff} * {str(pw)}" for pw, coeff in self.items())
 
     def __repr__(self):

--- a/tests/pauli/test_conversion.py
+++ b/tests/pauli/test_conversion.py
@@ -185,6 +185,10 @@ class TestPauliSentence:
 
     hamiltonian_ps = (
         (
+            qml.Hamiltonian([], []),
+            PauliSentence(),
+        ),
+        (
             qml.Hamiltonian([2], [qml.PauliZ(wires=0)]),
             PauliSentence({PauliWord({0: "Z"}): 2}),
         ),

--- a/tests/pauli/test_pauli_arithmetic.py
+++ b/tests/pauli/test_pauli_arithmetic.py
@@ -277,7 +277,7 @@ class TestPauliSentence:
         ),
         (ps3, "-0.5 * Z(0) @ Z(b) @ Z(c)\n" "+ 1 * I"),
         (ps4, "1 * I"),
-        (ps5, "I"),
+        (ps5, "0 * I"),
     )
 
     @pytest.mark.parametrize("ps, str_rep", tup_ps_str)


### PR DESCRIPTION
**Context:**
Fixes an issue where empty hamiltonians `qml.Hamiltonian([], [])` could not be converted to PauliSentences via `qml.pauli_sentence()`. 

**Description of the Change:**
- Add check for empty hamiltonian and return empty PauliSentence (PS)
- Fix print for empty PS, "I" --> "0 * I". Since an empty PS is the null operator.

**Related GitHub Issues:**
Fixes https://github.com/PennyLaneAI/pennylane/issues/4134
