### PR TITLE
Fix `qml.counts` measurement in new device

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -85,6 +85,7 @@
   [(#4105)](https://github.com/PennyLaneAI/pennylane/pull/4105)
   [(#4114)](https://github.com/PennyLaneAI/pennylane/pull/4114)
   [(#4133)](https://github.com/PennyLaneAI/pennylane/pull/4133)
+  [(#4172)](https://github.com/PennyLaneAI/pennylane/pull/4172)
 
 * Added a keyword argument `seed` to the `DefaultQubit2` device.
   [(#4120)](https://github.com/PennyLaneAI/pennylane/pull/4120)

--- a/pennylane/devices/qubit/sampling.py
+++ b/pennylane/devices/qubit/sampling.py
@@ -89,12 +89,20 @@ def _measure_with_samples_diagonalizing_gates(
             # better to call sample_state just once with total_shots, then use
             # the shot_range keyword argument
             samples = sample_state(pre_rotated_state, shots=s, wires=wires, rng=rng)
-            processed_samples.append(qml.math.squeeze(mp.process_samples(samples, wires)))
+
+            if not isinstance(processed := mp.process_samples(samples, wires), dict):
+                processed = qml.math.squeeze(processed)
+
+            processed_samples.append(processed)
 
         return tuple(processed_samples)
 
     samples = sample_state(pre_rotated_state, shots=shots.total_shots, wires=wires, rng=rng)
-    return qml.math.squeeze(mp.process_samples(samples, wires))
+
+    if not isinstance(processed := mp.process_samples(samples, wires), dict):
+        processed = qml.math.squeeze(processed)
+
+    return processed
 
 
 def sample_state(state, shots: int, wires=None, rng=None) -> np.ndarray:

--- a/pennylane/measurements/counts.py
+++ b/pennylane/measurements/counts.py
@@ -281,6 +281,7 @@ class CountsMP(SampleMeasurement):
 
         if self.obs is None:
             # convert samples and outcomes (if using) from arrays to str for dict keys
+            samples = qml.math.cast_like(samples, qml.math.int8(0))
             samples = qml.math.apply_along_axis(_sample_to_str, -1, samples)
             batched_ndims = 3  # no observable was provided, batched samples will have shape (batch_size, shots, len(wires))
             if self.all_outcomes:
@@ -299,9 +300,10 @@ class CountsMP(SampleMeasurement):
         base_dict = {k: qml.math.int64(0) for k in outcomes}
         outcome_dicts = [base_dict.copy() for _ in range(shape[0])]
         results = [qml.math.unique(batch, return_counts=True) for batch in samples]
+
         for result, outcome_dict in zip(results, outcome_dicts):
             states, _counts = result
-            for state, count in zip(states, _counts):
+            for state, count in zip(qml.math.unwrap(states), _counts):
                 outcome_dict[state] = count
 
         return outcome_dicts if batched else outcome_dicts[0]

--- a/tests/devices/experimental/test_default_qubit_2.py
+++ b/tests/devices/experimental/test_default_qubit_2.py
@@ -551,6 +551,41 @@ class TestSampleMeasurements:
         assert results[0].shape == (100, 2)
         assert results[1].shape == (50,)
 
+    def test_counts_wires(self):
+        """Test that a Counts measurement with wires works as expected"""
+        x = np.array(np.pi / 2)
+        qs = qml.tape.QuantumScript([qml.RY(x, wires=0)], [qml.counts(wires=[0, 1])], shots=10000)
+
+        dev = DefaultQubit2(seed=123)
+        result = dev.execute(qs)
+
+        assert isinstance(result, dict)
+        assert set(result.keys()) == {"00", "10"}
+
+        # check that the count values match the expected
+        values = list(result.values())
+        assert np.allclose(values[0] / (values[0] + values[1]), 0.5, atol=0.01)
+
+    @pytest.mark.parametrize("all_outcomes", [False, True])
+    def test_counts_obs(self, all_outcomes):
+        """Test that a Counts measurement with an observable works as expected"""
+        x = np.array(np.pi / 2)
+        qs = qml.tape.QuantumScript(
+            [qml.RY(x, wires=0)],
+            [qml.counts(qml.PauliZ(0), all_outcomes=all_outcomes)],
+            shots=10000,
+        )
+
+        dev = DefaultQubit2(seed=123)
+        result = dev.execute(qs)
+
+        assert isinstance(result, dict)
+        assert set(result.keys()) == {1, -1}
+
+        # check that the count values match the expected
+        values = list(result.values())
+        assert np.allclose(values[0] / (values[0] + values[1]), 0.5, atol=0.01)
+
 
 class TestExecutingBatches:
     """Tests involving executing multiple circuits at the same time."""

--- a/tests/measurements/test_counts.py
+++ b/tests/measurements/test_counts.py
@@ -117,6 +117,97 @@ class TestCounts:
         assert repr(m3) == "CountsMP(eigvals=[-1  1], wires=[], all_outcomes=False)"
 
 
+class TestProcessSamples:
+    """Unit tests for the counts.process_samples method"""
+
+    def test_counts_shape_single_wires(self):
+        """Test that the counts output is correct for single wires"""
+        shots = 1000
+        samples = np.random.choice([0, 1], size=(shots, 2)).astype(np.bool8)
+
+        result = qml.counts(wires=0).process_samples(samples, wire_order=[0])
+
+        assert len(result) == 2
+        assert set(result.keys()) == {"0", "1"}
+        assert result["0"] == np.count_nonzero(samples[:, 0] == 0)
+        assert result["1"] == np.count_nonzero(samples[:, 0] == 1)
+
+    def test_counts_shape_multi_wires(self):
+        """Test that the counts function outputs counts of the right size
+        for multiple wires"""
+        shots = 1000
+        samples = np.random.choice([0, 1], size=(shots, 2)).astype(np.bool8)
+
+        result = qml.counts(wires=[0, 1]).process_samples(samples, wire_order=[0, 1])
+
+        assert len(result) == 4
+        assert set(result.keys()) == {"00", "01", "10", "11"}
+        assert result["00"] == np.count_nonzero(
+            np.logical_and(samples[:, 0] == 0, samples[:, 1] == 0)
+        )
+        assert result["01"] == np.count_nonzero(
+            np.logical_and(samples[:, 0] == 0, samples[:, 1] == 1)
+        )
+        assert result["10"] == np.count_nonzero(
+            np.logical_and(samples[:, 0] == 1, samples[:, 1] == 0)
+        )
+        assert result["11"] == np.count_nonzero(
+            np.logical_and(samples[:, 0] == 1, samples[:, 1] == 1)
+        )
+
+    def test_counts_obs(self):
+        """Test that the counts function outputs counts of the right size for observables"""
+        shots = 1000
+        samples = np.random.choice([0, 1], size=(shots, 2)).astype(np.bool8)
+
+        result = qml.counts(qml.PauliZ(0)).process_samples(samples, wire_order=[0])
+
+        assert len(result) == 2
+        assert set(result.keys()) == {1, -1}
+        assert result[1] == np.count_nonzero(samples[:, 0] == 0)
+        assert result[-1] == np.count_nonzero(samples[:, 0] == 1)
+
+    def test_counts_all_outcomes_wires(self):
+        """Test that the counts output is correct when all_outcomes is passed"""
+        shots = 1000
+        samples = np.zeros((shots, 2)).astype(np.bool8)
+
+        result1 = qml.counts(wires=0, all_outcomes=False).process_samples(samples, wire_order=[0])
+
+        assert len(result1) == 1
+        assert set(result1.keys()) == {"0"}
+        assert result1["0"] == shots
+
+        result2 = qml.counts(wires=0, all_outcomes=True).process_samples(samples, wire_order=[0])
+
+        assert len(result2) == 2
+        assert set(result2.keys()) == {"0", "1"}
+        assert result2["0"] == shots
+        assert result2["1"] == 0
+
+    def test_counts_all_outcomes_obs(self):
+        """Test that the counts output is correct when all_outcomes is passed"""
+        shots = 1000
+        samples = np.zeros((shots, 2)).astype(np.bool8)
+
+        result1 = qml.counts(qml.PauliZ(0), all_outcomes=False).process_samples(
+            samples, wire_order=[0]
+        )
+
+        assert len(result1) == 1
+        assert set(result1.keys()) == {1}
+        assert result1[1] == shots
+
+        result2 = qml.counts(qml.PauliZ(0), all_outcomes=True).process_samples(
+            samples, wire_order=[0]
+        )
+
+        assert len(result2) == 2
+        assert set(result2.keys()) == {1, -1}
+        assert result2[1] == shots
+        assert result2[-1] == 0
+
+
 class TestCountsIntegration:
     # pylint:disable=too-many-public-methods
 


### PR DESCRIPTION
**Context:**
Part of the effort to integrate the new device API. Most measurements are supported with only a few weird edge cases (including counts).

**Description of the Change:**
Previous behaviour:
```
>>> dev = DefaultQubit2()
>>> qs1 = qml.tape.QuantumScript([qml.RY(1.4, wires=0)], [qml.counts(wires=[0, 1])], shots=15)
>>> dev.execute(qs1)
{'FalseFalse': 9, 'TrueFalse': 6}
>>> qs2 = qml.tape.QuantumScript([qml.RY(1.4, wires=0)], [qml.counts(qml.PauliZ(0))], shots=15)
>>> dev.execute(qs2)
{tensor(-1, requires_grad=True): 10, tensor(1, requires_grad=True): 5}
```

New behaviour:
```
>>> dev = DefaultQubit2()
>>> qs1 = qml.tape.QuantumScript([qml.RY(1.4, wires=0)], [qml.counts(wires=[0, 1])], shots=15)
>>> dev.execute(qs1)
{'00': 9, '10': 6}
>>> qs2 = qml.tape.QuantumScript([qml.RY(1.4, wires=0)], [qml.counts(qml.PauliZ(0))], shots=15)
>>> dev.execute(qs2)
{-1,: 10, 1: 5}
```
