### PR TITLE
[WIP] support qutrit state prep

### DIFF
--- a/pennylane/ops/qutrit/__init__.py
+++ b/pennylane/ops/qutrit/__init__.py
@@ -25,10 +25,12 @@ from .observables import *
 from .non_parametric_ops import *
 from .parametric_ops import *
 from ..identity import Identity
+from .state_preparation import *
 
 # TODO: Change `qml.Identity` for qutrit support or add `qml.TIdentity` for qutrits
 ops = {
     "Identity",
+    "QutritBasisState",
     "QutritUnitary",
     "ControlledQutritUnitary",
     "TShift",

--- a/pennylane/ops/qutrit/state_preparation.py
+++ b/pennylane/ops/qutrit/state_preparation.py
@@ -1,0 +1,108 @@
+# Copyright 2018-2021 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+This submodule contains the discrete-variable quantum operations concerned
+with preparing a certain state on the device.
+"""
+# pylint:disable=abstract-method,arguments-differ,protected-access,no-member
+from pennylane import numpy as np
+from pennylane import math
+from pennylane.operation import AnyWires, Operation, StatePrep
+from pennylane.templates.state_preparations import QutritBasisStatePreparation
+from pennylane.wires import Wires, WireError
+
+state_prep_ops = {"QutritBasisState"}
+
+
+class QutritBasisState(StatePrep):
+    r"""QutritBasisState(n, wires)
+    Prepares a single computational basis state.
+
+    **Details:**
+
+    * Number of wires: Any (the operation can act on any number of wires)
+    * Number of parameters: 1
+    * Gradient recipe: None (integer parameters not supported)
+
+
+    Args:
+        n (array): prepares the basis state :math:`\ket{n}`, where ``n`` is an
+            array of integers from the set :math:`\{0, 1\}`, i.e.,
+            if ``n = np.array([0, 1, 0])``, prepares the state :math:`|010\rangle`.
+        wires (Sequence[int] or int): the wire(s) the operation acts on
+
+    **Example**
+
+    >>> dev = qml.device('default.qutrit', wires=2)
+    >>> @qml.qnode(dev)
+    ... def example_circuit():
+    ...     qml.QutritBasisState(np.array([1, 2]), wires=range(2))
+    ...     return qml.state()
+    >>> print(example_circuit())
+    [0.+0.j 0.+0.j 0.+0.j 0.+0.j 1.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0j]
+    """
+    num_wires = AnyWires
+    num_params = 1
+    """int: Number of trainable parameters that the operator depends on."""
+
+    ndim_params = (1,)
+    """int: Number of dimensions per trainable parameter of the operator."""
+
+    @staticmethod
+    def compute_decomposition(n, wires):
+        r"""Representation of the operator as a product of other operators (static method). :
+
+        .. math:: O = O_1 O_2 \dots O_n.
+
+
+        .. seealso:: :meth:`~.BasisState.decomposition`.
+
+        Args:
+            n (array): prepares the basis state :math:`\ket{n}`, where ``n`` is an
+                array of integers from the set :math:`\{0, 1\}`
+            wires (Iterable, Wires): the wire(s) the operation acts on
+
+        Returns:
+            list[Operator]: decomposition into lower level operations
+
+        **Example:**
+
+        >>> qml.BasisState.compute_decomposition([1,0], wires=(0,1))
+        [BasisStatePreparation([1, 0], wires=[0, 1])]
+
+        """
+        return [QutritBasisStatePreparation(n, wires)]
+
+    def state_vector(self, wire_order=None):
+        """Returns a state-vector of shape ``(3,) * num_wires``."""
+        prep_vals = self.parameters[0]
+        if any(i not in [0, 1, 2] for i in prep_vals):
+            raise ValueError("QutritBasisState parameter must consist of 0, 1 or 2 integers.")
+
+        if (num_wires := len(self.wires)) != len(prep_vals):
+            raise ValueError("QutritBasisState parameter and wires must be of equal length.")
+
+        if wire_order is None:
+            indices = prep_vals
+        else:
+            if not Wires(wire_order).contains_wires(self.wires):
+                raise WireError("Custom wire_order must contain all QutritBasisState wires")
+            num_wires = len(wire_order)
+            indices = [0] * num_wires
+            for base_wire_label, value in zip(self.wires, prep_vals):
+                indices[wire_order.index(base_wire_label)] = value
+
+        ket = np.zeros((3,) * num_wires)
+        ket[tuple(indices)] = 1
+        return math.convert_like(ket, prep_vals)

--- a/pennylane/ops/qutrit/state_preparation.py
+++ b/pennylane/ops/qutrit/state_preparation.py
@@ -38,7 +38,7 @@ class QutritBasisState(StatePrep):
 
     Args:
         n (array): prepares the basis state :math:`\ket{n}`, where ``n`` is an
-            array of integers from the set :math:`\{0, 1\}`, i.e.,
+            array of integers from the set :math:`\{0, 1, 2\}`, i.e.,
             if ``n = np.array([0, 1, 0])``, prepares the state :math:`|010\rangle`.
         wires (Sequence[int] or int): the wire(s) the operation acts on
 
@@ -66,11 +66,11 @@ class QutritBasisState(StatePrep):
         .. math:: O = O_1 O_2 \dots O_n.
 
 
-        .. seealso:: :meth:`~.BasisState.decomposition`.
+        .. seealso:: :meth:`~.QutritBasisState.decomposition`.
 
         Args:
             n (array): prepares the basis state :math:`\ket{n}`, where ``n`` is an
-                array of integers from the set :math:`\{0, 1\}`
+                array of integers from the set :math:`\{0, 1, 2\}`
             wires (Iterable, Wires): the wire(s) the operation acts on
 
         Returns:
@@ -78,8 +78,8 @@ class QutritBasisState(StatePrep):
 
         **Example:**
 
-        >>> qml.BasisState.compute_decomposition([1,0], wires=(0,1))
-        [BasisStatePreparation([1, 0], wires=[0, 1])]
+        >>> qml.QutritBasisState.compute_decomposition([1,0], wires=(0,1))
+        [QutritBasisStatePreparation([1, 0], wires=[0, 1])]
 
         """
         return [QutritBasisStatePreparation(n, wires)]

--- a/pennylane/templates/state_preparations/__init__.py
+++ b/pennylane/templates/state_preparations/__init__.py
@@ -18,4 +18,5 @@ by decomposing it into elementary operations.
 
 from .mottonen import MottonenStatePreparation
 from .basis import BasisStatePreparation
+from .qutritbasis import QutritBasisStatePreparation
 from .arbitrary_state_preparation import ArbitraryStatePreparation

--- a/pennylane/templates/state_preparations/qutritbasis.py
+++ b/pennylane/templates/state_preparations/qutritbasis.py
@@ -34,19 +34,19 @@ class QutritBasisStatePreparation(Operation):
             the state preparation acts on.
         wires (Iterable): wires that the template acts on
 
-    **Example**
+    # **Example**
 
-    .. code-block:: python
+    # .. code-block:: python
 
-        dev = qml.device("default.qubit", wires=4)
+    #     dev = qml.device("default.qutrit", wires=4)
 
-        @qml.qnode(dev)
-        def circuit(basis_state):
-            qml.QutritBasisStatePreparation(basis_state, wires=range(4))
-            return [qml.expval(qml.TShift(wires=i)) for i in range(4)]
+    #     @qml.qnode(dev)
+    #     def circuit(basis_state):
+    #         qml.QutritBasisStatePreparation(basis_state, wires=range(4))
+    #         return [qml.expval(qml.TShift(wires=i)) for i in range(4)]
 
-        basis_state = [0, 1, 1, 0]
-        print(circuit(basis_state)) # [ 1. -1. -1.  1.]
+    #     basis_state = [0, 1, 1, 0]
+    #     print(circuit(basis_state)) # [ 1. -1. -1.  1.] #TODO: calculate this for qutrit.
     """
     num_params = 1
     num_wires = AnyWires
@@ -102,9 +102,9 @@ class QutritBasisStatePreparation(Operation):
 
         **Example**
 
-        >>> qml.BasisStatePreparation.compute_decomposition(basis_state=[1, 1], wires=["a", "b"])
-        [PauliX(wires=['a']),
-        PauliX(wires=['b'])]
+        >>> qml.QutritBasisStatePreparation.compute_decomposition(basis_state=[1, 1], wires=["a", "b"])
+        [TShift(wires=['a']),
+        TShift(wires=['b'])]
         """
         if not qml.math.is_abstract(basis_state):
             op_list = []

--- a/pennylane/templates/state_preparations/qutritbasis.py
+++ b/pennylane/templates/state_preparations/qutritbasis.py
@@ -1,0 +1,125 @@
+# Copyright 2018-2021 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+r"""
+Contains the QutritBasisStatePreparation template.
+"""
+
+import pennylane as qml
+import pennylane.numpy as np
+from pennylane.operation import Operation, AnyWires
+
+
+class QutritBasisStatePreparation(Operation):
+    r"""
+    Prepares a basis state on the given wires using a sequence of TShift gates.
+
+    .. warning::
+
+        ``basis_state`` influences the circuit architecture and is therefore incompatible with
+        gradient computations.
+
+    Args:
+        basis_state (array): Input array of shape ``(n,)``, where n is the number of wires
+            the state preparation acts on.
+        wires (Iterable): wires that the template acts on
+
+    **Example**
+
+    .. code-block:: python
+
+        dev = qml.device("default.qubit", wires=4)
+
+        @qml.qnode(dev)
+        def circuit(basis_state):
+            qml.QutritBasisStatePreparation(basis_state, wires=range(4))
+            return [qml.expval(qml.TShift(wires=i)) for i in range(4)]
+
+        basis_state = [0, 1, 1, 0]
+        print(circuit(basis_state)) # [ 1. -1. -1.  1.]
+    """
+    num_params = 1
+    num_wires = AnyWires
+    grad_method = None
+
+    def __init__(self, basis_state, wires, do_queue=True, id=None):
+        basis_state = qml.math.stack(basis_state)
+
+        # check if the `basis_state` param is batched
+        batched = len(qml.math.shape(basis_state)) > 1
+
+        state_batch = basis_state if batched else [basis_state]
+
+        for i, state in enumerate(state_batch):
+            shape = qml.math.shape(state)
+
+            if len(shape) != 1:
+                raise ValueError(
+                    f"Basis states must be one-dimensional; state {i} has shape {shape}."
+                )
+
+            n_bits = shape[0]
+            if n_bits != len(wires):
+                raise ValueError(
+                    f"Basis states must be of length {len(wires)}; state {i} has length {n_bits}."
+                )
+
+            if not qml.math.is_abstract(state):
+                if any(bit not in [0, 1, 2] for bit in state):
+                    raise ValueError(
+                        f"Basis states must only consist of 0s, 1s and 2s; state {i} is {state}"
+                    )
+
+        # TODO: basis_state should be a hyperparameter, not a trainable parameter.
+        # However, this breaks a test that ensures compatibility with batch_transform.
+        # The transform should be rewritten to support hyperparameters as well.
+        super().__init__(basis_state, wires=wires, do_queue=do_queue, id=id)
+
+    @staticmethod
+    def compute_decomposition(basis_state, wires):  # pylint: disable=arguments-differ
+        r"""Representation of the operator as a product of other operators.
+
+        .. math:: O = O_1 O_2 \dots O_n.
+
+        .. seealso:: :meth:`~.BasisStatePreparation.decomposition`.
+
+        Args:
+            basis_state (array): Input array of shape ``(len(wires),)``
+            wires (Any or Iterable[Any]): wires that the operator acts on
+
+        Returns:
+            list[.Operator]: decomposition of the operator
+
+        **Example**
+
+        >>> qml.BasisStatePreparation.compute_decomposition(basis_state=[1, 1], wires=["a", "b"])
+        [PauliX(wires=['a']),
+        PauliX(wires=['b'])]
+        """
+        if not qml.math.is_abstract(basis_state):
+            op_list = []
+            for wire, state in zip(wires, basis_state):
+                if state == 1:
+                    op_list.append(qml.TShift(wire))
+                elif state == 2:
+                    op_list.append(qml.TShift(wire))
+                    op_list.append(qml.TShift(wire))
+            return op_list
+
+        # op_list = []
+        # for wire, state in zip(wires, basis_state):
+        #     op_list.append(qml.PhaseShift(state * np.pi / 2, wire))
+        #     op_list.append(qml.RX(state * np.pi, wire))
+        #     op_list.append(qml.PhaseShift(state * np.pi / 2, wire))
+
+        # return op_list


### PR DESCRIPTION
**Context:**
close #4122 as part of UnitaryHack 2023 (I've written the function, but need to implement unit tests and want to check in and get thoughts on my approach :)

**Description of the Change:**
Added a `QutritBasisState` class analogous to `BasisState` in `pennylane.ops.qutrit.state_preparation.py`, as specified in the above issue. To support this, I also added a `QutritBasisStatePreparation` template in `pennylane.templates.state_preparations.qutritbasis.py`.

**Benefits:**
Supports state preparation for qutrits.

**Possible Drawbacks:**
Unit tests not implemented yet - I'm looking for feedback or confirmation that I'm going in the right direction.
So far, the tests I've done by building in a Jupyter notebook show that it's working correctly. 

<img width="514" alt="Screen Shot 2023-05-28 at 11 42 21 PM" src="https://github.com/PennyLaneAI/pennylane/assets/74874354/fb5864d2-366d-4f8e-82a7-f8ed370a38fc">

**Related GitHub Issues:**
#4122 
