### PR TITLE
do the same in jax as in jax-jit for getting results in execute_fwd

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -220,6 +220,7 @@
   [(#4171)](https://github.com/PennyLaneAI/pennylane/pull/4171)
 
 * Fixes a bug with Jax where executing multiple tapes with `gradient_fn="device"` would fail.
+  [(#4190)](https://github.com/PennyLaneAI/pennylane/pull/4190)
 
 <h3>Contributors ✍️</h3>
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -219,6 +219,8 @@
 * `qml.pauli_sentence()` is now compatible with empty Hamiltonians `qml.Hamiltonian([], [])`.
   [(#4171)](https://github.com/PennyLaneAI/pennylane/pull/4171)
 
+* Fixes a bug with Jax where executing multiple tapes with `gradient_fn="device"` would fail.
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane/interfaces/jax.py
+++ b/pennylane/interfaces/jax.py
@@ -532,25 +532,9 @@ def _execute_fwd(
         multi_measurements = [len(tape.measurements) > 1 for tape in tapes]
 
         jvps = _compute_jvps(jacs, tangents[0], multi_measurements)
-        return res, jvps
+        return (res, jacs), (jvps, jacs)
 
-    res = execute_wrapper(params)
-
-    tracing = []
-    for i, tape in enumerate(tapes):
-        if len(tape.measurements) == 1:
-            tracing.append(isinstance(res[i], jax.interpreters.ad.JVPTracer))
-        else:
-            tracing.extend([isinstance(r, jax.interpreters.ad.JVPTracer) for r in res[i]])
-
-    tracing = any(tracing)
-
-    # When there are no tracers (not differentiating), we have the result of
-    # the forward pass and the jacobian, but only need the result of the
-    # forward pass
-    if len(res) == 2 and not tracing:
-        res = res[0]
-
+    res, _jacs = execute_wrapper(params)
     return res
 
 

--- a/pennylane/interfaces/jax_jit_tuple.py
+++ b/pennylane/interfaces/jax_jit_tuple.py
@@ -435,6 +435,6 @@ def _execute_fwd(
 
         return (res, updated_jacs), (jvps, updated_jacs)
 
-    res = execute_wrapper(params)
+    res, _jacs = execute_wrapper(params)
 
-    return res[0]
+    return res

--- a/tests/interfaces/test_jax.py
+++ b/tests/interfaces/test_jax.py
@@ -157,7 +157,6 @@ class TestJaxExecuteUnitTests:
 
         a = jax.numpy.array([0.1, 0.2])
         res = cost(a)
-        print(res)
 
         x, y = a
         assert np.allclose(res[0][0], np.cos(x) * np.cos(y))


### PR DESCRIPTION
**Context:**
The jax code was wrongly iterating over `[[res1, res2, ...], jacs]` instead of `[res1, res2, ...]` but it slipped by undetected because you'd need 3 or more tapes to be executed to hit an IndexError.

**Description of the Change:**
Remove the unnecessary tracing stuff and match what jax-jit does.

**Benefits:**
Code now works as expected

**Possible Drawbacks:**
It's a bit hacky, but it gets the job done.