### PR TITLE
Allow circuit drawing with `KerasLayer` and `TorchLayer`

### DIFF
--- a/pennylane/qnn/torch.py
+++ b/pennylane/qnn/torch.py
@@ -435,6 +435,43 @@ class TorchLayer(Module):
 
         return torch.hstack(res).type(x.dtype)
 
+    def construct(self, args, kwargs):
+        """Constructs the wrapped QNode on input data using the initialized weights.
+
+        This method was added to match the QNode interface. The provided args
+        must contain a single item, which is the input to the layer. The provided
+        kwargs is unused.
+
+        Args:
+            args (tuple): A tuple containing one entry that is the input to this layer
+            kwargs (dict): Unused
+        """
+        x = args[0]
+        kwargs = {
+            self.input_arg: x,
+            **{arg: weight.to(x) for arg, weight in self.qnode_weights.items()},
+        }
+        self.qnode.construct((), kwargs)
+
+    @property
+    def qtape(self):
+        """Get the quantum tape executed by the wrapped QNode"""
+        return self.qnode.qtape
+
+    @property
+    def device(self):
+        """Get the device of the wrapped QNode"""
+        return self.qnode.device
+
+    @property
+    def expansion_strategy(self):
+        """Get the expansion strategy of the wrapped QNode"""
+        return self.qnode.expansion_strategy
+
+    @expansion_strategy.setter
+    def expansion_strategy(self, value):
+        self.qnode.expansion_strategy = value
+
     def _init_weights(
         self,
         weight_shapes: Dict[str, tuple],

--- a/tests/qnn/test_keras.py
+++ b/tests/qnn/test_keras.py
@@ -708,3 +708,74 @@ def test_batch_input_multi_measure():
     for x_, r in zip(x, res):
         exp = tf.experimental.numpy.hstack(circuit(x_, layer.qnode_weights["weights"]))
         assert qml.math.allclose(r, exp)
+
+
+@pytest.mark.tf
+def test_draw():
+    """Test that a KerasLayer can be drawn using qml.draw"""
+
+    dev = qml.device("default.qubit", wires=2)
+    weight_shapes = {"w1": 1, "w2": (3, 2, 3)}
+
+    @qml.qnode(dev, interface="tensorflow")
+    def circuit(inputs, w1, w2):
+        qml.templates.AngleEmbedding(inputs, wires=[0, 1])
+        qml.RX(w1, wires=0)
+        qml.templates.StronglyEntanglingLayers(w2, wires=[0, 1])
+        return qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliZ(1))
+
+    qlayer = KerasLayer(circuit, weight_shapes, output_dim=2)
+
+    # make the rotation angle positive to prevent the extra minus sign messing up the alignment
+    qlayer.qnode_weights["w1"] = tf.abs(qlayer.qnode_weights["w1"])
+
+    batch_size = 5
+    x = tf.constant(np.random.uniform(0, 1, (batch_size, 2)))
+
+    actual = qml.draw(qlayer)(x)
+
+    w1 = f"{qlayer.qnode_weights['w1'].numpy():.2f}"
+    m1 = f"{qlayer.qnode_weights['w2'].numpy()}"
+    expected = (
+        f"0: ─╭AngleEmbedding(M0)──RX({w1})─╭StronglyEntanglingLayers(M1)─┤  <Z>\n"
+        f"1: ─╰AngleEmbedding(M0)───────────╰StronglyEntanglingLayers(M1)─┤  <Z>\n"
+        f"M0 = \n{x}\n"
+        f"M1 = \n{m1}"
+    )
+
+    assert actual == expected
+
+
+@pytest.mark.tf
+def test_draw_mpl():
+    """Test that a KerasLayer can be drawn using qml.draw_mpl"""
+
+    dev = qml.device("default.qubit", wires=2)
+    weight_shapes = {"w1": 1, "w2": (3, 2, 3)}
+
+    @qml.qnode(dev, interface="tensorflow")
+    def circuit(inputs, w1, w2):
+        qml.templates.AngleEmbedding(inputs, wires=[0, 1])
+        qml.RX(w1, wires=0)
+        qml.templates.StronglyEntanglingLayers(w2, wires=[0, 1])
+        return qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliZ(1))
+
+    qlayer = KerasLayer(circuit, weight_shapes, output_dim=2)
+
+    # make the rotation angle positive to prevent the extra minus sign messing up the alignment
+    qlayer.qnode_weights["w1"] = tf.abs(qlayer.qnode_weights["w1"])
+
+    batch_size = 5
+    x = tf.constant(np.random.uniform(0, 1, (batch_size, 2)))
+
+    _, ax = qml.draw_mpl(qlayer)(x)
+
+    assert len(ax.patches) == 9  # 3 boxes, 3 patches for each measure
+    assert len(ax.lines) == 2  # 2 wires
+    assert len(ax.texts) == 5  # 2 wire labels, 3 box labels
+
+    assert ax.texts[0].get_text() == "0"
+    assert ax.texts[1].get_text() == "1"
+    assert ax.texts[2].get_text() == "AngleEmbedding"
+    assert ax.texts[3].get_text() == "RX"
+    assert ax.texts[4].get_text() == "StronglyEntanglingLayers"

--- a/tests/qnn/test_qnn_torch.py
+++ b/tests/qnn/test_qnn_torch.py
@@ -733,3 +733,74 @@ def test_batch_input_multi_measure():
     for x_, r in zip(x, res):
         exp = torch.hstack(circuit(x_, layer.qnode_weights["weights"]))
         assert qml.math.allclose(r, exp)
+
+
+@pytest.mark.torch
+def test_draw():
+    """Test that a TorchLayer can be drawn using qml.draw"""
+
+    dev = qml.device("default.qubit", wires=2)
+    weight_shapes = {"w1": 1, "w2": (3, 2, 3)}
+
+    @qml.qnode(dev, interface="torch")
+    def circuit(inputs, w1, w2):
+        qml.templates.AngleEmbedding(inputs, wires=[0, 1])
+        qml.RX(w1, wires=0)
+        qml.templates.StronglyEntanglingLayers(w2, wires=[0, 1])
+        return qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliZ(1))
+
+    qlayer = TorchLayer(circuit, weight_shapes)
+
+    # make the rotation angle positive to prevent the extra minus sign messing up the alignment
+    qlayer.qnode_weights["w1"] = torch.abs(qlayer.qnode_weights["w1"])
+
+    batch_size = 5
+    x = torch.Tensor(np.random.uniform(0, 1, (batch_size, 2)))
+
+    actual = qml.draw(qlayer)(x)
+
+    w1 = f"{qlayer.qnode_weights['w1'].detach().numpy():.2f}"
+    m1 = f"{qlayer.qnode_weights['w2']}"
+    expected = (
+        f"0: ─╭AngleEmbedding(M0)──RX({w1})─╭StronglyEntanglingLayers(M1)─┤  <Z>\n"
+        f"1: ─╰AngleEmbedding(M0)───────────╰StronglyEntanglingLayers(M1)─┤  <Z>\n"
+        f"M0 = \n{x}\n"
+        f"M1 = \n{m1}"
+    )
+
+    assert actual == expected
+
+
+@pytest.mark.torch
+def test_draw_mpl():
+    """Test that a TorchLayer can be drawn using qml.draw_mpl"""
+
+    dev = qml.device("default.qubit", wires=2)
+    weight_shapes = {"w1": 1, "w2": (3, 2, 3)}
+
+    @qml.qnode(dev, interface="torch")
+    def circuit(inputs, w1, w2):
+        qml.templates.AngleEmbedding(inputs, wires=[0, 1])
+        qml.RX(w1, wires=0)
+        qml.templates.StronglyEntanglingLayers(w2, wires=[0, 1])
+        return qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliZ(1))
+
+    qlayer = TorchLayer(circuit, weight_shapes)
+
+    # make the rotation angle positive to prevent the extra minus sign messing up the alignment
+    qlayer.qnode_weights["w1"] = torch.abs(qlayer.qnode_weights["w1"])
+
+    batch_size = 5
+    x = torch.Tensor(np.random.uniform(0, 1, (batch_size, 2)))
+
+    _, ax = qml.draw_mpl(qlayer)(x)
+
+    assert len(ax.patches) == 9  # 3 boxes, 3 patches for each measure
+    assert len(ax.lines) == 2  # 2 wires
+    assert len(ax.texts) == 5  # 2 wire labels, 3 box labels
+
+    assert ax.texts[0].get_text() == "0"
+    assert ax.texts[1].get_text() == "1"
+    assert ax.texts[2].get_text() == "AngleEmbedding"
+    assert ax.texts[3].get_text() == "RX"
+    assert ax.texts[4].get_text() == "StronglyEntanglingLayers"


### PR DESCRIPTION
**Context:**
Part of the ongoing effort to make the `qml.qnn` module more feature-rich for users.

**Description of the Change:**
Allow `KerasLayer` and `TorchLayer` to be used in `qml.draw` and `qml.draw_mpl`. The layer classes automatically handle passing in the trainable parameters to the QNode.

Example with `qml.draw`:
```python
def make_qlayer():
    dev = qml.device("default.qubit", wires=2)
    weight_shapes = {"w1": 1, "w2": (3, 2, 3)}

    @qml.qnode(dev, interface="tensorflow")
    def circuit(inputs, w1, w2):
        qml.templates.AngleEmbedding(inputs, wires=[0, 1])
        qml.RX(w1, wires=0)
        qml.templates.StronglyEntanglingLayers(w2, wires=[0, 1])
        return qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliZ(1))

    return qml.qnn.KerasLayer(circuit, weight_shapes={"w1": 1, "w2": (3, 2, 3)}, output_dim=2)
```
```
>>> qlayer = make_qlayer()
>>> x = tf.constant(np.random.uniform(0, 1, (4, 2)))
>>> qml.draw(qlayer, show_matrices=False)(x)
0: ─╭AngleEmbedding(M0)──RX(-0.71)─╭StronglyEntanglingLayers(M1)─┤  <Z>
1: ─╰AngleEmbedding(M0)────────────╰StronglyEntanglingLayers(M1)─┤  <Z>
>>> qml.draw(qlayer, expansion_strategy="device")(x)
0: ──RX(M0)──RX(-0.71)──────────────Rot(0.40,0.22,0.01)─╭●─╭X──Rot(-0.51,0.51,0.32)─╭●─╭X───Rot(0.34,0.23,-0.22)─╭●─╭X─┤  <Z>
1: ──RX(M1)──Rot(0.29,-0.21,-0.11)──────────────────────╰X─╰●──Rot(0.46,-0.34,0.32)─╰X─╰●───Rot(-0.25,0.09,0.59)─╰X─╰●─┤  <Z>
M0 =
[0.35571893 0.65128189 0.19363715 0.21534807]
M1 =
[0.80472787 0.71840111 0.71478832 0.97561509]
```
Example with `qml.draw_mpl`:
```
>>> qml.draw_mpl(qlayer, expansion_strategy="device")(x)
>>> plt.show()
```
![Figure_1](https://github.com/PennyLaneAI/pennylane/assets/34989448/26dbabab-9a1d-4418-be43-b9e57a2fd70b)
