### PR TITLE
Update functions in qchem to support operator arithmetic

### DIFF
--- a/tests/qchem/test_hamiltonians.py
+++ b/tests/qchem/test_hamiltonians.py
@@ -20,6 +20,7 @@ import pennylane as qml
 from pennylane import Identity, PauliX, PauliY, PauliZ
 from pennylane import numpy as np
 from pennylane import qchem
+from pennylane.operation import enable_new_opmath, disable_new_opmath
 
 
 @pytest.mark.parametrize(
@@ -273,6 +274,17 @@ def test_diff_hamiltonian(symbols, geometry, h_ref_data):
     assert np.allclose(h.terms()[0], h_ref.terms()[0])
     assert qml.Hamiltonian(np.ones(len(h.terms()[0])), h.terms()[1]).compare(
         qml.Hamiltonian(np.ones(len(h_ref.terms()[0])), h_ref.terms()[1])
+    )
+
+    enable_new_opmath()
+    h_pl_op = qchem.diff_hamiltonian(mol)(*args)
+    disable_new_opmath()
+
+    wire_order = h_ref.wires
+    assert not isinstance(h_pl_op, qml.Hamiltonian)
+    assert np.allclose(
+        qml.matrix(h_pl_op, wire_order=wire_order),
+        qml.matrix(h_ref, wire_order=wire_order),
     )
 
 

--- a/tests/qchem/test_particle_number.py
+++ b/tests/qchem/test_particle_number.py
@@ -20,6 +20,7 @@ import pennylane as qml
 from pennylane import Identity, PauliZ
 from pennylane import numpy as np
 from pennylane import qchem
+from pennylane.operation import enable_new_opmath, disable_new_opmath
 
 
 @pytest.mark.parametrize(
@@ -57,8 +58,18 @@ def test_particle_number(orbitals, coeffs_ref, ops_ref):
     """
     n = qchem.particle_number(orbitals)
     n_ref = qml.Hamiltonian(coeffs_ref, ops_ref)
-
     assert n.compare(n_ref)
+
+    enable_new_opmath()
+    n_pl_op = qchem.particle_number(orbitals)
+    disable_new_opmath()
+
+    wire_order = n_ref.wires
+    assert not isinstance(n_pl_op, qml.Hamiltonian)
+    assert np.allclose(
+        qml.matrix(n_pl_op, wire_order=wire_order),
+        qml.matrix(n_ref, wire_order=wire_order),
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/qchem/test_spin.py
+++ b/tests/qchem/test_spin.py
@@ -20,6 +20,7 @@ import pennylane as qml
 from pennylane import Identity, PauliX, PauliY, PauliZ
 from pennylane import numpy as np
 from pennylane import qchem
+from pennylane.operation import enable_new_opmath, disable_new_opmath
 
 
 @pytest.mark.parametrize(
@@ -173,8 +174,18 @@ def test_spin2(electrons, orbitals, coeffs_ref, ops_ref):
     """
     s2 = qchem.spin.spin2(electrons, orbitals)
     s2_ref = qml.Hamiltonian(coeffs_ref, ops_ref)
-
     assert s2.compare(s2_ref)
+
+    enable_new_opmath()
+    s2_pl_op = qchem.spin.spin2(electrons, orbitals)
+    disable_new_opmath()
+
+    wire_order = s2_ref.wires
+    assert not isinstance(s2_pl_op, qml.Hamiltonian)
+    assert np.allclose(
+        qml.matrix(s2_pl_op, wire_order=wire_order),
+        qml.matrix(s2_ref, wire_order=wire_order),
+    )
 
 
 @pytest.mark.parametrize(
@@ -222,8 +233,19 @@ def test_spinz(orbitals, coeffs_ref, ops_ref):
     """
     sz = qchem.spin.spinz(orbitals)
     sz_ref = qml.Hamiltonian(coeffs_ref, ops_ref)
-
     assert sz.compare(sz_ref)
+
+    enable_new_opmath()
+    sz_pl_op = qchem.spin.spinz(orbitals)
+    disable_new_opmath()
+    sz_ref_pl_op = qml.dot(coeffs_ref, ops_ref)
+
+    wire_order = sz_ref_pl_op.wires
+    assert not isinstance(sz_pl_op, qml.Hamiltonian)
+    assert np.allclose(
+        qml.matrix(sz_pl_op, wire_order=wire_order),
+        qml.matrix(sz_ref_pl_op, wire_order=wire_order),
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
**Context:**
Now that the new operator arithmetic machinery is integrated with pennylane (via enable_new_opmath()), we want to start making use of it across the codebase, specifically in the qchem module.

**Description of the Change:**
Update tests for the following functions as they now return arithmetic operators when `active_new_opmath()` is `True`:
- `particle_number()` in `number.py`
- `diff_hamiltonian()` in `hamiltonian.py`
- `spin2()`, `spins()` in `spin.py`

**Benefits:**
We are slowly moving away from `Hamiltonian` and adopting the new machinery we have! 
