### PR TITLE
Update `qcut` to stop relying on operator hash

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -27,6 +27,9 @@
   $\hat{c}_1 c_0 \hat{c}_2 c_3$.
   [(#4191)](https://github.com/PennyLaneAI/pennylane/pull/4191)
 
+* Added the `FermiSentence` class to represent a linear combination of fermionic operators.
+  [(#4195)](https://github.com/PennyLaneAI/pennylane/pull/4195)
+
 <h3>Improvements 🛠</h3>
 
 * The stochastic parameter-shift gradient transform for pulses, `stoch_pulse_grad`, now

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -230,8 +230,8 @@
 
 * `pennylane.collections`, `pennylane.op_sum`, and `pennylane.utils.sparse_hamiltonian` are removed.
 
-* The `pennylane.transforms.qcut` module now uses `(op, id(op))` as nodes in directed multigraphs instead of `op`.
-  This change removes the dependency of the module on the hash of operators.
+* The `pennylane.transforms.qcut` module now uses `(op, id(op))` as nodes in directed multigraphs that are used within
+  the circuit cutting workflow instead of `op`. This change removes the dependency of the module on the hash of operators.
   [(#4224)](https://github.com/PennyLaneAI/pennylane/pull/4224)
 
 <h3>Deprecations 👋</h3>

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -268,6 +268,9 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Fixes adjoint jacobian results with `grad_on_execution=False` in the JAX-JIT interface.
+  [(4217)](https://github.com/PennyLaneAI/pennylane/pull/4217)
+
 * Fixes a bug where `stoch_pulse_grad` would ignore prefactors of rescaled Pauli words in the
   generating terms of a pulse Hamiltonian.
   [(4156)](https://github.com/PennyLaneAI/pennylane/pull/4156)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -230,6 +230,10 @@
 
 * `pennylane.collections`, `pennylane.op_sum`, and `pennylane.utils.sparse_hamiltonian` are removed.
 
+* The `pennylane.transforms.qcut` module now uses `(op, id(op))` as nodes in directed multigraphs instead of `op`.
+  This change removes the dependency of the module on the hash of operators.
+  [(#4224)](https://github.com/PennyLaneAI/pennylane/pull/4224)
+
 <h3>Deprecations 👋</h3>
 
 * `LieAlgebraOptimizer` is renamed. Please use `RiemannianGradientOptimizer` instead.

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -13,7 +13,7 @@ available-interfaces:
 
 available-plugins:
 	@echo "The following plugins are available for PennyLane:"
-	@echo "1.qiskit 2.amazon-braket 3.sf 4.cirq 5.qulacs 6.aqt"
+	@echo "1.qiskit 2.amazon-braket 3.quantuminspire 4.cirq 5.qulacs 6.aqt"
 	@echo "7.honeywell 8.pq 9.qsharp 10.forest 11.orquestra 12.ionq"
 
 build-base:

--- a/docker/interfaces/install-interface-gpu.sh
+++ b/docker/interfaces/install-interface-gpu.sh
@@ -22,17 +22,17 @@ case $INTERFACE_NAME in
 # Build Jax GPU interface
   "jax")
   echo "##########-Installing" "$INTERFACE_NAME" "GPU INTERFACE-##########"
-	pip3 install jax==0.2.14 jaxlib==0.1.67+cuda111 -f https://storage.googleapis.com/jax-releases/jax_releases.html
+	pip3 install jax==0.4.10 jaxlib==0.4.10+cuda111 -f https://storage.googleapis.com/jax-releases/jax_releases.html
   ;;
 # Build Torch GPU interface
   "torch")
   echo "##########-Installing" "$INTERFACE_NAME" "GPU INTERFACE-##########"
-  pip3 install torch==1.8.1
+  pip3 install torch==2.0.0
   ;;
 # Build Tensorflow GPU interface
   "tensorflow")
   echo "##########-Installing" "$INTERFACE_NAME" "GPU INTERFACE-##########"
-  pip3 install tensorflow==2.5.0
+  pip3 install tensorflow==2.12.0
   ;;
 	*)
   echo "##########-No-GPU-Interface-Installed-##########"

--- a/docker/interfaces/install-interface.sh
+++ b/docker/interfaces/install-interface.sh
@@ -27,12 +27,12 @@ case $INTERFACE_NAME in
 # Build Torch interface
   "torch")
   echo "##########-Installing" "$INTERFACE_NAME" "INTERFACE-##########"
-  pip3 install torch==1.8.1
+  pip3 install torch==2.0.0
   ;;
 # Build Tensorflow interface
   "tensorflow")
   echo "##########-Installing" "$INTERFACE_NAME" "INTERFACE-##########"
-  pip3 install tensorflow==2.5.0
+  pip3 install tensorflow==2.12.0
   ;;
 	*)
   echo "##########-No-Interface-Installed-##########"

--- a/docker/plugins/install-plugin.sh
+++ b/docker/plugins/install-plugin.sh
@@ -29,10 +29,10 @@ case $PLUGIN_NAME in
   echo "##########-Installing" "$PLUGIN_NAME" "Plugin-##########"
   pip3 install amazon-braket-pennylane-plugin
   ;;
- # Build SF Plugin
-  "sf")
+ # Build QuantumInspire Plugin
+  "quantuminspire")
   echo "##########-Installing" "$PLUGIN_NAME" "Plugin-##########"
-  pip3 install pennylane-sf
+  pip3 install pennylane-quantuminspire
   ;;
 # Build Cirq Plugin
   "cirq")

--- a/pennylane/fermi/__init__.py
+++ b/pennylane/fermi/__init__.py
@@ -14,4 +14,4 @@
 """A module containing utility functions and reduced representation classes for working with
 Fermionic operators. """
 
-from .fermionic import FermiWord
+from .fermionic import FermiWord, FermiSentence

--- a/pennylane/fermi/fermionic.py
+++ b/pennylane/fermi/fermionic.py
@@ -158,9 +158,87 @@ class FermiWord(dict):
 
         return operator
 
+    # TODO: create __add__ and __iadd__ method when FermiSentence is merged.
+    # TODO: create __sub__ and __isub__ method when FermiSentence is merged.
+    # TODO: create __imul__ method.
+    # TODO: support multiply by number in __mul__ when FermiSentence is merged.
+    # TODO: create mapping method when the jordan_wigner function is added.
+    # TODO: allow multiplication of a FermiWord with a FermiSentence and vice versa
 
-# TODO: create __add__ and __iadd__ method when FermiSentence is merged.
-# TODO: create __sub__ and __isub__ method when FermiSentence is merged.
-# TODO: create __imul__ method.
-# TODO: support multiply by number in __mul__ when FermiiSentence is merged.
-# TODO: create mapping method when the jordan_wigner function is added.
+
+class FermiSentence(dict):
+    r"""Immutable dictionary used to represent a Fermi sentence, a linear combination of Fermi words, with the keys
+    as FermiWord instances and the values correspond to coefficients.
+
+    >>> w1 = FermiWord({(0, 0) : '+', (1, 1) : '-'})
+    >>> w2 = FermiWord({(0, 1) : '+', (1, 2) : '-'})
+    >>> s = FermiSentence({w1 : 1.2, w2: 3.1})
+    >>> s
+    1.2 * '0+ 1-'
+    + 3.1 * '1+ 2-'
+    """
+
+    @property
+    def wires(self):
+        r"""Return wires of the FermiSentence."""
+        return set().union(*(fw.wires for fw in self.keys()))
+
+    def __str__(self):
+        r"""String representation of a FermiSentence."""
+        if len(self) == 0:
+            return "0 * 'I'"
+        return "\n+ ".join(f"{coeff} * '{fw.to_string()}'" for fw, coeff in self.items())
+
+    def __repr__(self):
+        r"""Terminal representation for FermiSentence."""
+        return str(self)
+
+    def __missing__(self, key):
+        r"""If the FermiSentence does not contain a FermiWord then the associated value will be 0."""
+        return 0.0
+
+    def __add__(self, other):
+        r"""Add two Fermi sentence together by iterating over the smaller one and adding its terms
+        to the larger one."""
+        smaller_fs, larger_fs = (
+            (self, copy(other)) if len(self) < len(other) else (other, copy(self))
+        )
+        for key in smaller_fs:
+            larger_fs[key] += smaller_fs[key]
+
+        return larger_fs
+
+    def __mul__(self, other):
+        r"""Multiply two Fermi sentences by iterating over each sentence and multiplying the Fermi
+        words pair-wise"""
+        # an empty FermiSentence represents the Null operator
+        if (len(self) == 0) or (len(other) == 0):
+            return FermiSentence({FermiWord({}): 0})
+
+        product = FermiSentence({})
+
+        for fw1, coeff1 in self.items():
+            for fw2, coeff2 in other.items():
+                product[fw1 * fw2] += coeff1 * coeff2
+
+        return product
+
+    def __pow__(self, value):
+        r"""Exponentiate a Fermi sentence to an integer power."""
+        if value < 0 or not isinstance(value, int):
+            raise ValueError("The exponent must be a positive integer.")
+
+        operator = FermiSentence({FermiWord({}): 1})  # 1 times Identity
+
+        for _ in range(value):
+            operator *= self
+
+        return operator
+
+    def simplify(self, tol=1e-8):
+        r"""Remove any FermiWords in the FermiSentence with coefficients less than the threshold
+        tolerance."""
+        items = list(self.items())
+        for fw, coeff in items:
+            if abs(coeff) <= tol:
+                del self[fw]

--- a/pennylane/interfaces/execution.py
+++ b/pennylane/interfaces/execution.py
@@ -587,6 +587,20 @@ def execute(
                 pass_kwargs=True,
                 return_tuple=False,
             )
+
+            # Adjoint Jacobian with backward pass and jitting needs the original circuit output state which
+            # can not be reused from the device if `grad_on_execution is False`.
+
+            interface_jax = interface
+            if interface == "jax":
+                from .jax import get_jax_interface_name
+
+                interface_jax = get_jax_interface_name(tapes)
+            if interface_jax == "jax-jit":
+                use_device_state = gradient_kwargs.get("use_device_state", None)
+                if use_device_state:
+                    gradient_kwargs["use_device_state"] = False
+
     elif grad_on_execution is True:
         # In "forward" mode, gradients are automatically handled
         # within execute_and_gradients, so providing a gradient_fn

--- a/pennylane/interfaces/jax_jit_tuple.py
+++ b/pennylane/interfaces/jax_jit_tuple.py
@@ -222,7 +222,7 @@ def _execute_bwd(
 
         multi_measurements = [len(tape.measurements) > 1 for tape in tapes]
 
-        # Execution: execute the function first
+        # Execution: execute the function first (execution on the device does not happen)
         evaluation_results = execute_wrapper(params)
 
         # Backward: branch off based on the gradient function is a device method.

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -1495,6 +1495,12 @@ class Operator(abc.ABC):
             return qml.pow(self, z=other)
         return NotImplemented
 
+    def __eq__(self, other):
+        return qml.equal(self, other)
+
+    def __hash__(self):
+        return self.hash
+
 
 # =============================================================================
 # Base Operation class

--- a/pennylane/transforms/qcut/cutstrategy.py
+++ b/pennylane/transforms/qcut/cutstrategy.py
@@ -196,8 +196,8 @@ class CutStrategy:
         wire_depths = {}
         for g in tape_dag.nodes:
             if not isinstance(g[0], WireCut):
-                for w in g.wires:
-                    wire_depths[w] = wire_depths.get(w, 0) + 1 / len(g.wires)
+                for w in g[0].wires:
+                    wire_depths[w] = wire_depths.get(w, 0) + 1 / len(g[0].wires)
         self._validate_input(max_wires_by_fragment, max_gates_by_fragment)
 
         probed_cuts = self._infer_probed_cuts(

--- a/pennylane/transforms/qcut/cutstrategy.py
+++ b/pennylane/transforms/qcut/cutstrategy.py
@@ -195,7 +195,7 @@ class CutStrategy:
         """
         wire_depths = {}
         for g in tape_dag.nodes:
-            if not isinstance(g, WireCut):
+            if not isinstance(g[0], WireCut):
                 for w in g.wires:
                     wire_depths[w] = wire_depths.get(w, 0) + 1 / len(g.wires)
         self._validate_input(max_wires_by_fragment, max_gates_by_fragment)

--- a/pennylane/transforms/qcut/kahypar.py
+++ b/pennylane/transforms/qcut/kahypar.py
@@ -42,59 +42,62 @@ def kahypar_cut(
     verbose: bool = False,
 ) -> List[Tuple[Operation, Operation, Any]]:
     """Calls `KaHyPar <https://kahypar.org/>`__ to partition a graph.
+    +
 
-    .. warning::
-        Requires KaHyPar to be installed separately. For Linux and Mac users,
-        KaHyPar can be installed using ``pip install kahypar``. Windows users
-        can follow the instructions
-        `here <https://kahypar.org>`__ to compile from source.
 
-    Args:
-        graph (nx.MultiDiGraph): The graph to be partitioned.
-        num_fragments (int): Desired number of fragments.
-        imbalance (int): Imbalance factor of the partitioning. Defaults to KaHyPar's determination.
-        edge_weights (List[Union[int, float]]): Weights for edges. Defaults to unit-weighted edges.
-        node_weights (List[Union[int, float]]): Weights for nodes. Defaults to unit-weighted nodes.
-        fragment_weights (List[Union[int, float]]): Maximum size constraints by fragment. Defaults
-            to no such constraints, with ``imbalance`` the only parameter affecting fragment sizes.
-        hyperwire_weight (int): Weight on the artificially appended hyperedges representing wires.
-            Setting it to 0 leads to no such insertion. If greater than 0, hyperedges will be
-            appended with the provided weight, to encourage the resulting fragments to cluster gates
-            on the same wire together. Defaults to 1.
-        seed (int): KaHyPar's seed. Defaults to the seed in the config file which defaults to -1,
-            i.e. unfixed seed.
-        config_path (str): KaHyPar's ``.ini`` config file path. Defaults to its SEA20 paper config.
-        trial (int): trial id for summary label creation. Defaults to ``None``.
-        verbose (bool): Flag for printing KaHyPar's output summary. Defaults to ``False``.
 
-    Returns:
-        List[Union[int, Any]]: List of cut edges.
+        .. warning::
+            Requires KaHyPar to be installed separately. For Linux and Mac users,
+            KaHyPar can be installed using ``pip install kahypar``. Windows users
+            can follow the instructions
+            `here <https://kahypar.org>`__ to compile from source.
 
-    **Example**
+        Args:
+            graph (nx.MultiDiGraph): The graph to be partitioned.
+            num_fragments (int): Desired number of fragments.
+            imbalance (int): Imbalance factor of the partitioning. Defaults to KaHyPar's determination.
+            edge_weights (List[Union[int, float]]): Weights for edges. Defaults to unit-weighted edges.
+            node_weights (List[Union[int, float]]): Weights for nodes. Defaults to unit-weighted nodes.
+            fragment_weights (List[Union[int, float]]): Maximum size constraints by fragment. Defaults
+                to no such constraints, with ``imbalance`` the only parameter affecting fragment sizes.
+            hyperwire_weight (int): Weight on the artificially appended hyperedges representing wires.
+                Setting it to 0 leads to no such insertion. If greater than 0, hyperedges will be
+                appended with the provided weight, to encourage the resulting fragments to cluster gates
+                on the same wire together. Defaults to 1.
+            seed (int): KaHyPar's seed. Defaults to the seed in the config file which defaults to -1,
+                i.e. unfixed seed.
+            config_path (str): KaHyPar's ``.ini`` config file path. Defaults to its SEA20 paper config.
+            trial (int): trial id for summary label creation. Defaults to ``None``.
+            verbose (bool): Flag for printing KaHyPar's output summary. Defaults to ``False``.
 
-    Consider the following 2-wire circuit with one CNOT gate connecting the wires:
+        Returns:
+            List[Union[int, Any]]: List of cut edges.
 
-    .. code-block:: python
+        **Example**
 
-        with qml.tape.QuantumTape() as tape:
-            qml.RX(0.432, wires=0)
-            qml.RY(0.543, wires="a")
-            qml.CNOT(wires=[0, "a"])
-            qml.RZ(0.240, wires=0)
-            qml.RZ(0.133, wires="a")
-            qml.RX(0.432, wires=0)
-            qml.RY(0.543, wires="a")
-            qml.expval(qml.PauliZ(wires=[0]))
+        Consider the following 2-wire circuit with one CNOT gate connecting the wires:
 
-    We can let KaHyPar automatically find the optimal edges to place cuts:
+        .. code-block:: python
 
-    >>> graph = qml.transforms.qcut.tape_to_graph(tape)
-    >>> cut_edges = qml.transforms.qcut.kahypar_cut(
-            graph=graph,
-            num_fragments=2,
-        )
-    >>> cut_edges
-    [(CNOT(wires=[0, 'a']), RZ(0.24, wires=[0]), 0)]
+            with qml.tape.QuantumTape() as tape:
+                qml.RX(0.432, wires=0)
+                qml.RY(0.543, wires="a")
+                qml.CNOT(wires=[0, "a"])
+                qml.RZ(0.240, wires=0)
+                qml.RZ(0.133, wires="a")
+                qml.RX(0.432, wires=0)
+                qml.RY(0.543, wires="a")
+                qml.expval(qml.PauliZ(wires=[0]))
+
+        We can let KaHyPar automatically find the optimal edges to place cuts:
+
+        >>> graph = qml.transforms.qcut.tape_to_graph(tape)
+        >>> cut_edges = qml.transforms.qcut.kahypar_cut(
+                graph=graph,
+                num_fragments=2,
+            )
+        >>> cut_edges
+        [(CNOT(wires=[0, 'a']), RZ(0.24, wires=[0]), 0)]
     """
     # pylint: disable=too-many-arguments, import-outside-toplevel
     try:

--- a/pennylane/transforms/qcut/montecarlo.py
+++ b/pennylane/transforms/qcut/montecarlo.py
@@ -678,8 +678,8 @@ def expand_fragment_tapes_mc(
     pairs = [e[-1] for e in communication_graph.edges.data("pair")]
     settings = np.random.choice(range(8), size=(len(pairs), shots), replace=True)
 
-    meas_settings = {pair[0].id: setting for pair, setting in zip(pairs, settings)}
-    prep_settings = {pair[1].id: setting for pair, setting in zip(pairs, settings)}
+    meas_settings = {pair[0][0].id: setting for pair, setting in zip(pairs, settings)}
+    prep_settings = {pair[1][0].id: setting for pair, setting in zip(pairs, settings)}
 
     all_configs = []
     for tape in tapes:

--- a/pennylane/transforms/qcut/processing.py
+++ b/pennylane/transforms/qcut/processing.py
@@ -325,7 +325,7 @@ def contract_tensors(
                 for pred_edge in pred_edges.values():
                     meas_op, prep_op = pred_edge["pair"]
 
-                    if p.id is prep_op.id:
+                    if p.id is prep_op[0].id:
                         symb = get_symbol(ctr)
                         ctr += 1
                         tensor_indxs[i] += symb
@@ -339,7 +339,7 @@ def contract_tensors(
                 for succ_edge in succ_edges.values():
                     meas_op, _ = succ_edge["pair"]
 
-                    if m.id is meas_op.id:
+                    if m.id is meas_op[0].id:
                         symb = meas_map[meas_op]
                         tensor_indxs[i] += symb
 

--- a/tests/fermi/test_fermionic.py
+++ b/tests/fermi/test_fermionic.py
@@ -17,7 +17,7 @@ from copy import copy, deepcopy
 
 import pytest
 
-from pennylane.fermi.fermionic import FermiWord
+from pennylane.fermi.fermionic import FermiSentence, FermiWord
 
 fw1 = FermiWord({(0, 0): "+", (1, 1): "-"})
 fw2 = FermiWord({(0, 0): "+", (1, 0): "-"})
@@ -171,3 +171,235 @@ class TestFermiWord:
         """Test that an error is raised if the operator orders are not correct."""
         with pytest.raises(ValueError, match="The operator indices must belong to the set"):
             FermiWord(operator)
+
+
+fs1 = FermiSentence({fw1: 1.23, fw2: 4j, fw3: -0.5})
+fs2 = FermiSentence({fw1: -1.23, fw2: -4j, fw3: 0.5})
+fs1_hamiltonian = FermiSentence({fw1: 1.23, fw2: 4, fw3: -0.5})
+fs2_hamiltonian = FermiSentence({fw1: -1.23, fw2: -4, fw3: 0.5})
+fs3 = FermiSentence({fw3: -0.5, fw4: 1})
+fs4 = FermiSentence({fw4: 1})
+fs5 = FermiSentence({})
+
+fs1_x_fs2 = FermiSentence(  # fs1 * fs1, computed by hand
+    {
+        FermiWord({(0, 0): "+", (1, 1): "-", (2, 0): "+", (3, 1): "-"}): 1.5129,
+        FermiWord({(0, 0): "+", (1, 1): "-", (2, 0): "+", (3, 0): "-"}): 4.92j,
+        FermiWord(
+            {
+                (0, 0): "+",
+                (1, 1): "-",
+                (2, 0): "+",
+                (3, 3): "-",
+                (4, 0): "+",
+                (5, 4): "-",
+            }
+        ): -0.615,
+        FermiWord({(0, 0): "+", (1, 0): "-", (2, 0): "+", (3, 1): "-"}): 4.92j,
+        FermiWord({(0, 0): "+", (1, 0): "-", (2, 0): "+", (3, 0): "-"}): -16,
+        FermiWord(
+            {
+                (0, 0): "+",
+                (1, 0): "-",
+                (2, 0): "+",
+                (3, 3): "-",
+                (4, 0): "+",
+                (5, 4): "-",
+            }
+        ): (-0 - 2j),
+        FermiWord(
+            {
+                (0, 0): "+",
+                (1, 3): "-",
+                (2, 0): "+",
+                (3, 4): "-",
+                (4, 0): "+",
+                (5, 1): "-",
+            }
+        ): -0.615,
+        FermiWord(
+            {
+                (0, 0): "+",
+                (1, 3): "-",
+                (2, 0): "+",
+                (3, 4): "-",
+                (4, 0): "+",
+                (5, 0): "-",
+            }
+        ): (-0 - 2j),
+        FermiWord(
+            {
+                (0, 0): "+",
+                (1, 3): "-",
+                (2, 0): "+",
+                (3, 4): "-",
+                (4, 0): "+",
+                (5, 3): "-",
+                (6, 0): "+",
+                (7, 4): "-",
+            }
+        ): 0.25,
+    }
+)
+
+
+class TestFermiSentence:
+    def test_missing(self):
+        """Test the result when a missing key is indexed."""
+        fw = FermiWord({(0, 0): "+", (1, 1): "-"})
+        new_fw = FermiWord({(0, 2): "+", (1, 3): "-"})
+        fs = FermiSentence({fw: 1.0})
+
+        assert new_fw not in fs.keys()
+        assert fs[new_fw] == 0.0
+
+    def test_set_items(self):
+        """Test that we can add to a FermiSentence."""
+        fw = FermiWord({(0, 0): "+", (1, 1): "-"})
+        fs = FermiSentence({fw: 1.0})
+
+        new_fw = FermiWord({(0, 2): "+", (1, 3): "-"})
+        assert new_fw not in fs.keys()
+
+        fs[new_fw] = 3.45
+        assert new_fw in fs.keys() and fs[new_fw] == 3.45
+
+    tup_fs_str = (
+        (fs1, "1.23 * '0+ 1-'\n" + "+ 4j * '0+ 0-'\n" + "+ -0.5 * '0+ 3- 0+ 4-'"),
+        (fs2, "-1.23 * '0+ 1-'\n" + "+ (-0-4j) * '0+ 0-'\n" + "+ 0.5 * '0+ 3- 0+ 4-'"),
+        (fs3, "-0.5 * '0+ 3- 0+ 4-'\n" + "+ 1 * 'I'"),
+        (fs4, "1 * 'I'"),
+        (fs5, "0 * 'I'"),
+    )
+
+    @pytest.mark.parametrize("fs, str_rep", tup_fs_str)
+    def test_str(self, fs, str_rep):
+        """Test the string representation of the FermiSentence."""
+        print(str(fs))
+        assert str(fs) == str_rep
+        assert repr(fs) == str_rep
+
+    tup_fs_wires = (
+        (fs1, {0, 1, 3, 4}),
+        (fs2, {0, 1, 3, 4}),
+        (fs3, {0, 3, 4}),
+        (fs4, set()),
+    )
+
+    @pytest.mark.parametrize("fs, wires", tup_fs_wires)
+    def test_wires(self, fs, wires):
+        """Test the correct wires are given for the FermiSentence."""
+        assert fs.wires == wires
+
+    @pytest.mark.parametrize("fs", (fs1, fs2, fs3, fs4))
+    def test_copy(self, fs):
+        """Test that the copy is identical to the original."""
+        copy_fs = copy(fs)
+        deep_copy_fs = deepcopy(fs)
+
+        assert copy_fs == fs
+        assert deep_copy_fs == fs
+        assert copy_fs is not fs
+        assert deep_copy_fs is not fs
+
+    tup_fs_mult = (  # computed by hand
+        (
+            fs1,
+            fs1,
+            fs1_x_fs2,
+        ),
+        (
+            fs3,
+            fs4,
+            fs3,
+        ),
+        (
+            fs4,
+            fs4,
+            FermiSentence(
+                {
+                    FermiWord({}): 1,
+                }
+            ),
+        ),
+        (fs5, fs3, fs5),
+        (fs3, fs5, fs5),
+        (fs4, fs3, fs3),
+        (fs3, fs4, fs3),
+        (
+            FermiSentence({fw2: 1, fw3: 1, fw4: 1}),
+            FermiSentence({fw4: 1, fw2: 1}),
+            FermiSentence({fw2: 2, fw3: 1, fw4: 1, fw2 * fw2: 1, fw3 * fw2: 1}),
+        ),
+    )
+
+    @pytest.mark.parametrize("f1, f2, result", tup_fs_mult)
+    def test_mul(self, f1, f2, result):
+        """Test that the correct result of multiplication is produced."""
+        simplified_product = f1 * f2
+        simplified_product.simplify()
+
+        assert simplified_product == result
+
+    tup_fs_add = (  # computed by hand
+        (fs1, fs1, FermiSentence({fw1: 2.46, fw2: 8j, fw3: -1})),
+        (fs1, fs2, FermiSentence({})),
+        (fs1, fs3, FermiSentence({fw1: 1.23, fw2: 4j, fw3: -1, fw4: 1})),
+        (fs2, fs5, fs2),
+    )
+
+    @pytest.mark.parametrize("f1, f2, result", tup_fs_add)
+    def test_add(self, f1, f2, result):
+        """Test that the correct result of addition is produced."""
+
+        simplified_product = f1 + f2
+        simplified_product.simplify()
+
+        assert simplified_product == result
+
+    def test_simplify(self):
+        """Test that simplify removes terms in the FermiSentence with coefficient less than the
+        threshold."""
+        un_simplified_fs = FermiSentence({fw1: 0.001, fw2: 0.05, fw3: 1})
+
+        expected_simplified_fs0 = FermiSentence({fw1: 0.001, fw2: 0.05, fw3: 1})
+        expected_simplified_fs1 = FermiSentence({fw2: 0.05, fw3: 1})
+        expected_simplified_fs2 = FermiSentence({fw3: 1})
+
+        un_simplified_fs.simplify()
+        assert un_simplified_fs == expected_simplified_fs0  # default tol = 1e-8
+        un_simplified_fs.simplify(tol=1e-2)
+        assert un_simplified_fs == expected_simplified_fs1
+        un_simplified_fs.simplify(tol=1e-1)
+        assert un_simplified_fs == expected_simplified_fs2
+
+    def test_pickling(self):
+        """Check that FermiSentences can be pickled and unpickled."""
+        f1 = FermiWord({(0, 0): "+", (1, 1): "-"})
+        f2 = FermiWord({(0, 0): "+", (1, 3): "-", (2, 0): "+", (3, 4): "-"})
+        fs = FermiSentence({f1: 1.5, f2: -0.5})
+
+        serialization = pickle.dumps(fs)
+        new_fs = pickle.loads(serialization)
+        assert fs == new_fs
+
+    tup_fs_pow = (
+        (fs1, 0, FermiSentence({FermiWord({}): 1})),
+        (fs1, 1, fs1),
+        (fs1, 2, fs1_x_fs2),
+        (fs3, 0, FermiSentence({FermiWord({}): 1})),
+        (fs3, 1, fs3),
+        (fs4, 0, FermiSentence({FermiWord({}): 1})),
+        (fs4, 3, fs4),
+    )
+
+    @pytest.mark.parametrize("f1, pow, result", tup_fs_pow)
+    def test_pow(self, f1, pow, result):
+        assert f1**pow == result
+
+    tup_fs_pow_error = ((fs1, -1), (fs3, 1.5))
+
+    @pytest.mark.parametrize("f1, pow", tup_fs_pow_error)
+    def test_pow_error(self, f1, pow):
+        with pytest.raises(ValueError, match="The exponent must be a positive integer."):
+            f1**pow  # pylint: disable=pointless-statement

--- a/tests/interfaces/test_jax_jit_qnode.py
+++ b/tests/interfaces/test_jax_jit_qnode.py
@@ -403,12 +403,7 @@ class TestVectorValuedQNode:
             qml.CNOT(wires=[0, 1])
             return qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliY(1))
 
-        if diff_method == "adjoint" and not grad_on_execution:
-            # TODO: jit here too when the following issue is resolved:
-            # https://github.com/PennyLaneAI/pennylane/issues/3475
-            jac_fn = jax.jacobian(circuit, argnums=[0, 1])
-        else:
-            jac_fn = jax.jit(jax.jacobian(circuit, argnums=[0, 1]))
+        jac_fn = jax.jit(jax.jacobian(circuit, argnums=[0, 1]))
 
         res = jac_fn(a, b)
 
@@ -2854,9 +2849,6 @@ class TestSubsetArgnums:
     ):
         """Test single measurement with different diff methods with argnums."""
 
-        if diff_method == "adjoint" and not grad_on_execution:
-            pytest.skip("Adjoint and backward pass do not work because of issue #3475")
-
         dev = qml.device(dev_name, wires=3)
 
         @qml.qnode(
@@ -2906,9 +2898,6 @@ class TestSubsetArgnums:
     ):
         """Test multiple measurements with different diff methods with argnums."""
         dev = qml.device(dev_name, wires=3)
-
-        if diff_method == "adjoint" and not grad_on_execution:
-            pytest.skip("Adjoint and backward pass do not work because of issue #3475")
 
         @qml.qnode(
             dev, interface=interface, diff_method=diff_method, grad_on_execution=grad_on_execution

--- a/tests/transforms/test_qcut.py
+++ b/tests/transforms/test_qcut.py
@@ -152,10 +152,10 @@ with qml.queuing.AnnotatedQueue() as q1:
 
 frag1 = qml.tape.QuantumScript.from_queue(q1)
 frag_edge_data = [
-    (0, 1, {"pair": (frag0.operations[4], frag1.operations[0])}),
-    (1, 0, {"pair": (frag1.operations[2], frag0.operations[5])}),
-    (0, 1, {"pair": (frag0.operations[8], frag1.operations[4])}),
-    (1, 0, {"pair": (frag1.operations[6], frag0.operations[9])}),
+    (0, 1, {"pair": ((frag0.operations[4], id(frag0.operations[4])), (frag1.operations[0], id(frag1.operations[0])))}),
+    (1, 0, {"pair": ((frag1.operations[2], id(frag1.operations[2])), (frag0.operations[5], id(frag0.operations[5])))}),
+    (0, 1, {"pair": ((frag0.operations[8], id(frag0.operations[8])), (frag1.operations[4], id(frag1.operations[4])))}),
+    (1, 0, {"pair": ((frag1.operations[6], id(frag1.operations[6])), (frag0.operations[9], id(frag0.operations[9])))}),
 ]
 
 
@@ -163,10 +163,10 @@ def compare_nodes(nodes, expected_wires, expected_names):
     """Helper function to compare nodes of directed multigraph"""
 
     for node, exp_wire in zip(nodes, expected_wires):
-        assert node.wires.tolist() == exp_wire
+        assert node[0].wires.tolist() == exp_wire
 
     for node, exp_name in zip(nodes, expected_names):
-        assert node.name == exp_name
+        assert node[0].name == exp_name
 
 
 def compare_fragment_nodes(node_data, expected_data):
@@ -176,7 +176,7 @@ def compare_fragment_nodes(node_data, expected_data):
 
     for data in node_data:
         # The exact ordering of node_data varies on each call
-        assert (data[0].name, data[0].wires, data[1]) in expected
+        assert (data[0][0].name, data[0][0].wires, data[1]) in expected
 
 
 def compare_fragment_edges(edge_data, expected_data):
@@ -186,7 +186,7 @@ def compare_fragment_edges(edge_data, expected_data):
 
     for data in edge_data:
         # The exact ordering of edge_data varies on each call
-        assert (data[0].name, data[1].name, data[2]) in expected
+        assert (data[0][0].name, data[1][0].name, data[2]) in expected
 
 
 def compare_tapes(tape, expected_tape):
@@ -256,8 +256,8 @@ class TestTapeToGraph:
 
         assert len(nodes) == len(ops) + len(tape.observables)
         for op, node in zip(ops, nodes[:-1]):
-            assert op == node
-        assert tape.observables[0] == nodes[-1].obs
+            assert op == node[0]
+        assert tape.observables[0] == nodes[-1][0].obs
 
     def test_converted_graph_edges(self):
         """
@@ -273,13 +273,13 @@ class TestTapeToGraph:
         ops = tape.operations
 
         expected_edge_connections = [
-            (ops[0], ops[2], 0),
-            (ops[1], ops[2], 0),
-            (ops[2], ops[3], 0),
-            (ops[2], ops[3], 1),
-            (ops[3], ops[4], 0),
-            (ops[3], ops[5], 0),
-            (ops[4], tape.measurements[0], 0),
+            ((ops[0], id(ops[0])), (ops[2], id(ops[2])), 0),
+            ((ops[1], id(ops[1])), (ops[2], id(ops[2])), 0),
+            ((ops[2], id(ops[2])), (ops[3], id(ops[3])), 0),
+            ((ops[2], id(ops[2])), (ops[3], id(ops[3])), 1),
+            ((ops[3], id(ops[3])), (ops[4], id(ops[4])), 0),
+            ((ops[3], id(ops[3])), (ops[5], id(ops[5])), 0),
+            ((ops[4], id(ops[4])), (tape.measurements[0], id(tape.measurements[0])), 0),
         ]
 
         for edge, expected_edge in zip(edges, expected_edge_connections):
@@ -410,7 +410,7 @@ class TestTapeToGraph:
         g = qcut.tape_to_graph(tape)
         nodes = list(g.nodes)
 
-        node_observables = [node for node in nodes if hasattr(node, "return_type")]
+        node_observables = [node[0] for node in nodes if hasattr(node[0], "return_type")]
 
         assert node_observables[0].return_type.name == expected_measurement
 
@@ -474,12 +474,12 @@ class TestTapeToGraph:
         ]
 
         for node, expected_node in zip(g.nodes, expected_nodes):
-            assert node.name == expected_node.name
-            assert node.wires == expected_node.wires
+            assert node[0].name == expected_node.name
+            assert node[0].wires == expected_node.wires
 
-            if getattr(node, "obs", None) is not None:
-                assert node.return_type is qml.measurements.Sample
-                assert node.obs.name == expected_node.obs.name
+            if getattr(node[0], "obs", None) is not None:
+                assert node[0].return_type is qml.measurements.Sample
+                assert node[0].obs.name == expected_node.obs.name
 
     def test_sample_tensor_obs(self):
         """
@@ -530,12 +530,12 @@ class TestTapeToGraph:
         ]
 
         for node, expected_node in zip(g.nodes, expected_nodes):
-            assert node.name == expected_node.name
-            assert node.wires == expected_node.wires
+            assert node[0].name == expected_node.name
+            assert node[0].wires == expected_node.wires
 
-            if getattr(node, "obs", None) is not None:
-                assert node.return_type is qml.measurements.Sample
-                assert node.obs.name == expected_node.obs.name
+            if getattr(node[0], "obs", None) is not None:
+                assert node[0].return_type is qml.measurements.Sample
+                assert node[0].obs.name == expected_node.obs.name
 
 
 class TestReplaceWireCut:
@@ -572,18 +572,18 @@ class TestReplaceWireCut:
 
         qcut.replace_wire_cut_nodes(g)
         new_node_data = list(g.nodes(data=True))
-        op_names = [op.name for op, order in new_node_data]
+        op_names = [op[0].name for op, order in new_node_data]
 
         assert "WireCut" not in op_names
         assert "MeasureNode" in op_names
         assert "PrepareNode" in op_names
 
         for op, order in new_node_data:
-            if op.name == "MeasureNode":
-                assert op.wires.tolist() == [wire_cut_num]
+            if op[0].name == "MeasureNode":
+                assert op[0].wires.tolist() == [wire_cut_num]
                 assert order == wire_cut_order
-            elif op.name == "PrepareNode":
-                assert op.wires.tolist() == [wire_cut_num]
+            elif op[0].name == "PrepareNode":
+                assert op[0].wires.tolist() == [wire_cut_num]
                 assert order == wire_cut_order
 
     def test_multiple_wire_cuts_replaced(self):
@@ -617,11 +617,11 @@ class TestReplaceWireCut:
         g = qcut.tape_to_graph(tape)
         node_data = list(g.nodes(data=True))
 
-        wire_cut_order = [order for op, order in node_data if op.name == "WireCut"]
+        wire_cut_order = [order for op, order in node_data if op[0].name == "WireCut"]
 
         qcut.replace_wire_cut_nodes(g)
         new_node_data = list(g.nodes(data=True))
-        op_names = [op.name for op, order in new_node_data]
+        op_names = [op[0].name for op, order in new_node_data]
 
         assert "WireCut" not in op_names
         assert op_names.count("MeasureNode") == 3
@@ -630,12 +630,12 @@ class TestReplaceWireCut:
         measure_counter = prepare_counter = 0
 
         for op, order in new_node_data:
-            if op.name == "MeasureNode":
-                assert op.wires.tolist() == [wire_cut_num[measure_counter]]
+            if op[0].name == "MeasureNode":
+                assert op[0].wires.tolist() == [wire_cut_num[measure_counter]]
                 assert order == wire_cut_order[measure_counter]
                 measure_counter += 1
-            elif op.name == "PrepareNode":
-                assert op.wires.tolist() == [wire_cut_num[prepare_counter]]
+            elif op[0].name == "PrepareNode":
+                assert op[0].wires.tolist() == [wire_cut_num[prepare_counter]]
                 assert order == wire_cut_order[prepare_counter]
                 prepare_counter += 1
 
@@ -662,16 +662,16 @@ class TestReplaceWireCut:
         nodes = list(g.nodes)
 
         for node in nodes:
-            if node.name == "MeasureNode":
+            if node[0].name == "MeasureNode":
                 succ = list(g.succ[node])[0]
                 pred = list(g.pred[node])[0]
-                assert succ.name == "PrepareNode"
-                assert pred.name == "RZ"
-            if node.name == "PrepareNode":
+                assert succ[0].name == "PrepareNode"
+                assert pred[0].name == "RZ"
+            if node[0].name == "PrepareNode":
                 succ = list(g.succ[node])[0]
                 pred = list(g.pred[node])[0]
-                assert succ.name == "CNOT"
-                assert pred.name == "MeasureNode"
+                assert succ[0].name == "CNOT"
+                assert pred[0].name == "MeasureNode"
 
     def test_wirecut_has_no_predecessor(self):
         """
@@ -694,18 +694,18 @@ class TestReplaceWireCut:
 
         qcut.replace_wire_cut_nodes(g)
         new_node_data = list(g.nodes(data=True))
-        op_names = [op.name for op, order in new_node_data]
+        op_names = [op[0].name for op, order in new_node_data]
 
         assert "WireCut" not in op_names
         assert "MeasureNode" in op_names
         assert "PrepareNode" in op_names
 
         for op, order in new_node_data:
-            if op.name == "MeasureNode":
+            if op[0].name == "MeasureNode":
                 assert order == {"order": 0}
                 pred = list(g.pred[op])
                 assert pred == []
-            elif op.name == "PrepareNode":
+            elif op[0].name == "PrepareNode":
                 assert order == {"order": 0}
 
     def test_wirecut_has_no_successor(self):
@@ -728,16 +728,16 @@ class TestReplaceWireCut:
 
         qcut.replace_wire_cut_nodes(g)
         new_node_data = list(g.nodes(data=True))
-        op_names = [op.name for op, order in new_node_data]
+        op_names = [op[0].name for op, order in new_node_data]
 
         assert "WireCut" not in op_names
         assert "MeasureNode" in op_names
         assert "PrepareNode" in op_names
 
         for op, order in new_node_data:
-            if op.name == "MeasureNode":
+            if op[0].name == "MeasureNode":
                 assert order == {"order": 3}
-            elif op.name == "PrepareNode":
+            elif op[0].name == "PrepareNode":
                 assert order == {"order": 3}
                 succ = list(g.succ[op])
                 assert succ == []
@@ -761,8 +761,8 @@ class TestReplaceWireCut:
         qcut.replace_wire_cut_nodes(g)
 
         nodes = list(g.nodes)
-        measure_nodes = [node for node in nodes if node.name == "MeasureNode"]
-        prepare_nodes = [node for node in nodes if node.name == "PrepareNode"]
+        measure_nodes = [node for node in nodes if node[0].name == "MeasureNode"]
+        prepare_nodes = [node for node in nodes if node[0].name == "PrepareNode"]
 
         assert len(measure_nodes) == len(prepare_nodes) == 3
 
@@ -800,7 +800,7 @@ class TestReplaceWireCut:
             _, _, wire_label_in = in_edges[0]
             _, _, wire_label_out = out_edges[0]
 
-            assert wire_label_in == wire_label_out == node.wires.tolist()[0]
+            assert wire_label_in == wire_label_out == node[0].wires.tolist()[0]
 
 
 class TestFragmentGraph:
@@ -978,8 +978,8 @@ class TestFragmentGraph:
             assert edge[1] == exp_edge[1]
 
             for node, exp_node in zip(edge[2]["pair"], exp_edge[2]["pair"]):
-                assert node.name == exp_node.name
-                assert node.wires.tolist() == exp_node.wires.tolist()
+                assert node[0].name == exp_node.name
+                assert node[0].wires.tolist() == exp_node.wires.tolist()
 
     def test_fragment_wirecut_first_and_last(self):
         """
@@ -1855,7 +1855,7 @@ class TestExpandFragmentTapesMC:
         tape1 = qml.tape.QuantumScript.from_queue(q1)
         tapes = [tape0, tape1]
 
-        edge_data = {"pair": (tape0.operations[2], tape1.operations[0])}
+        edge_data = {"pair": ((tape0.operations[2], id(tape0.operations[2])), (tape1.operations[0], id(tape1.operations[0])))}
         communication_graph = MultiDiGraph([(0, 1, edge_data)])
 
         fixed_choice = np.array([[4, 0, 1]])
@@ -3210,7 +3210,8 @@ class TestContractTensors:
     # make copies of nodes to ensure id comparisons work correctly
     m = [[qcut.MeasureNode(wires=0)], []]
     p = [[], [qcut.PrepareNode(wires=0)]]
-    edge_dict = {"pair": (copy.copy(m)[0][0], copy.copy(p)[1][0])}
+    m_copy, p_copy = copy.copy(m), copy.copy(p)
+    edge_dict = {"pair": ((m_copy[0][0], id(m_copy[0][0])), (p_copy[1][0], id(p_copy[1][0])))}
     g = MultiDiGraph([(0, 1, edge_dict)])
     expected_result = np.dot(*t)
 
@@ -3399,13 +3400,13 @@ class TestContractTensors:
             ],
         ]
         edges = [
-            (0, 0, 0, {"pair": (m[0][0], p[0][2])}),
-            (0, 1, 0, {"pair": (m[0][1], p[1][0])}),
-            (0, 1, 1, {"pair": (m[0][2], p[1][1])}),
-            (0, 2, 0, {"pair": (m[0][4], p[2][0])}),
-            (0, 2, 1, {"pair": (m[0][3], p[2][1])}),
-            (1, 0, 0, {"pair": (m[1][0], p[0][0])}),
-            (1, 0, 1, {"pair": (m[1][1], p[0][1])}),
+            (0, 0, 0, {"pair": ((m[0][0], id(m[0][0])), (p[0][2], id(p[0][2])))}),
+            (0, 1, 0, {"pair": ((m[0][1], id(m[0][1])), (p[1][0], id(p[1][0])))}),
+            (0, 1, 1, {"pair": ((m[0][2], id(m[0][2])), (p[1][1], id(p[1][1])))}),
+            (0, 2, 0, {"pair": ((m[0][4], id(m[0][4])), (p[2][0], id(p[2][0])))}),
+            (0, 2, 1, {"pair": ((m[0][3], id(m[0][3])), (p[2][1], id(p[2][1])))}),
+            (1, 0, 0, {"pair": ((m[1][0], id(m[1][0])), (p[0][0], id(p[0][0])))}),
+            (1, 0, 1, {"pair": ((m[1][1], id(m[1][1])), (p[0][1], id(p[0][1])))}),
         ]
         g = MultiDiGraph(edges)
 
@@ -3694,8 +3695,8 @@ class TestQCutProcessingFn:
         m = [[qcut.MeasureNode(wires=0)], [qcut.MeasureNode(wires=0)], []]
 
         edges = [
-            (0, 1, 0, {"pair": (m[0][0], p[1][0])}),
-            (1, 2, 0, {"pair": (m[1][0], p[2][0])}),
+            (0, 1, 0, {"pair": ((m[0][0], id(m[0][0])), (p[1][0], id(p[1][0])))}),
+            (1, 2, 0, {"pair": ((m[1][0], id(m[1][0])), (p[2][0], id(p[2][0])))}),
         ]
         g = MultiDiGraph(edges)
 
@@ -3722,8 +3723,8 @@ class TestQCutProcessingFn:
             m = [[qcut.MeasureNode(wires=0)], [qcut.MeasureNode(wires=0)], []]
 
             edges = [
-                (0, 1, 0, {"pair": (m[0][0], p[1][0])}),
-                (1, 2, 0, {"pair": (m[1][0], p[2][0])}),
+                (0, 1, 0, {"pair": ((m[0][0], id(m[0][0])), (p[1][0], id(p[1][0])))}),
+                (1, 2, 0, {"pair": ((m[1][0], id(m[1][0])), (p[2][0], id(p[2][0])))}),
             ]
             g = MultiDiGraph(edges)
 
@@ -3759,8 +3760,8 @@ class TestQCutProcessingFn:
             m = [[qcut.MeasureNode(wires=0)], [qcut.MeasureNode(wires=0)], []]
 
             edges = [
-                (0, 1, 0, {"pair": (m[0][0], p[1][0])}),
-                (1, 2, 0, {"pair": (m[1][0], p[2][0])}),
+                (0, 1, 0, {"pair": ((m[0][0], id(m[0][0])), (p[1][0], id(p[1][0])))}),
+                (1, 2, 0, {"pair": ((m[1][0], id(m[1][0])), (p[2][0], id(p[2][0])))}),
             ]
             g = MultiDiGraph(edges)
 
@@ -3797,8 +3798,8 @@ class TestQCutProcessingFn:
             m = [[qcut.MeasureNode(wires=0)], [qcut.MeasureNode(wires=0)], []]
 
             edges = [
-                (0, 1, 0, {"pair": (m[0][0], p[1][0])}),
-                (1, 2, 0, {"pair": (m[1][0], p[2][0])}),
+                (0, 1, 0, {"pair": ((m[0][0], id(m[0][0])), (p[1][0], id(p[1][0])))}),
+                (1, 2, 0, {"pair": ((m[1][0], id(m[1][0])), (p[2][0], id(p[2][0])))}),
             ]
             g = MultiDiGraph(edges)
 
@@ -3838,8 +3839,8 @@ class TestQCutProcessingFn:
             m = [[qcut.MeasureNode(wires=0)], [qcut.MeasureNode(wires=0)], []]
 
             edges = [
-                (0, 1, 0, {"pair": (m[0][0], p[1][0])}),
-                (1, 2, 0, {"pair": (m[1][0], p[2][0])}),
+                (0, 1, 0, {"pair": ((m[0][0], id(m[0][0])), (p[1][0], id(p[1][0])))}),
+                (1, 2, 0, {"pair": ((m[1][0], id(m[1][0])), (p[2][0], id(p[2][0])))}),
             ]
             g = MultiDiGraph(edges)
 
@@ -4785,7 +4786,7 @@ class TestCutStrategy:
                 else {num_fragments_probed}
             )
         elif exhaustive:
-            num_tape_gates = sum(not isinstance(n, qml.WireCut) for n in tape_dag.nodes)
+            num_tape_gates = sum(not isinstance(n[0], qml.WireCut) for n in tape_dag.nodes)
             assert {v["num_fragments"] for v in all_cut_kwargs} == set(range(2, num_tape_gates + 1))
 
     @pytest.mark.parametrize(
@@ -5039,7 +5040,7 @@ class TestKaHyPar:
                 [
                     n
                     for n in graph.nodes
-                    if isinstance(n, (qml.WireCut, qcut.MeasureNode, qcut.PrepareNode))
+                    if isinstance(n[0], (qml.WireCut, qcut.MeasureNode, qcut.PrepareNode))
                 ]
             )
             == dangling_measure
@@ -5058,17 +5059,17 @@ class TestKaHyPar:
         tape = qml.tape.QuantumScript.from_queue(q)
         graph = qcut.tape_to_graph(tape)
         op0, op1, op2 = tape.operations[0], tape.operations[1], tape.operations[2]
-        cut_edges = [e for e in graph.edges if e[0] is op0 and e[1] is op1]
-        cut_edges += [e for e in graph.edges if e[0] is op1 and e[1] is op2]
+        cut_edges = [e for e in graph.edges if e[0][0] is op0 and e[1][0] is op1]
+        cut_edges += [e for e in graph.edges if e[0][0] is op1 and e[1][0] is op2]
 
         cut_graph = qcut.place_wire_cuts(graph=graph, cut_edges=cut_edges)
-        wire_cuts = [n for n in cut_graph.nodes if isinstance(n, qml.WireCut)]
+        wire_cuts = [n for n in cut_graph.nodes if isinstance(n[0], qml.WireCut)]
 
         assert len(wire_cuts) == len(cut_edges)
-        assert list(cut_graph.pred[wire_cuts[0]]) == [op0]
-        assert list(cut_graph.succ[wire_cuts[0]]) == [op1]
-        assert list(cut_graph.pred[wire_cuts[1]]) == [op1]
-        assert list(cut_graph.succ[wire_cuts[1]]) == [op2]
+        assert list(cut_graph.pred[wire_cuts[0]]) == [(op0, id(op0))]
+        assert list(cut_graph.succ[wire_cuts[0]]) == [(op1, id(op1))]
+        assert list(cut_graph.pred[wire_cuts[1]]) == [(op1, id(op1))]
+        assert list(cut_graph.succ[wire_cuts[1]]) == [(op2, id(op2))]
 
         # check if order is unique and also if there's enough nodes.
         assert list({i for _, i in cut_graph.nodes.data("order")}) == list(

--- a/tests/transforms/test_qcut.py
+++ b/tests/transforms/test_qcut.py
@@ -152,10 +152,46 @@ with qml.queuing.AnnotatedQueue() as q1:
 
 frag1 = qml.tape.QuantumScript.from_queue(q1)
 frag_edge_data = [
-    (0, 1, {"pair": ((frag0.operations[4], id(frag0.operations[4])), (frag1.operations[0], id(frag1.operations[0])))}),
-    (1, 0, {"pair": ((frag1.operations[2], id(frag1.operations[2])), (frag0.operations[5], id(frag0.operations[5])))}),
-    (0, 1, {"pair": ((frag0.operations[8], id(frag0.operations[8])), (frag1.operations[4], id(frag1.operations[4])))}),
-    (1, 0, {"pair": ((frag1.operations[6], id(frag1.operations[6])), (frag0.operations[9], id(frag0.operations[9])))}),
+    (
+        0,
+        1,
+        {
+            "pair": (
+                (frag0.operations[4], id(frag0.operations[4])),
+                (frag1.operations[0], id(frag1.operations[0])),
+            )
+        },
+    ),
+    (
+        1,
+        0,
+        {
+            "pair": (
+                (frag1.operations[2], id(frag1.operations[2])),
+                (frag0.operations[5], id(frag0.operations[5])),
+            )
+        },
+    ),
+    (
+        0,
+        1,
+        {
+            "pair": (
+                (frag0.operations[8], id(frag0.operations[8])),
+                (frag1.operations[4], id(frag1.operations[4])),
+            )
+        },
+    ),
+    (
+        1,
+        0,
+        {
+            "pair": (
+                (frag1.operations[6], id(frag1.operations[6])),
+                (frag0.operations[9], id(frag0.operations[9])),
+            )
+        },
+    ),
 ]
 
 
@@ -1855,7 +1891,12 @@ class TestExpandFragmentTapesMC:
         tape1 = qml.tape.QuantumScript.from_queue(q1)
         tapes = [tape0, tape1]
 
-        edge_data = {"pair": ((tape0.operations[2], id(tape0.operations[2])), (tape1.operations[0], id(tape1.operations[0])))}
+        edge_data = {
+            "pair": (
+                (tape0.operations[2], id(tape0.operations[2])),
+                (tape1.operations[0], id(tape1.operations[0])),
+            )
+        }
         communication_graph = MultiDiGraph([(0, 1, edge_data)])
 
         fixed_choice = np.array([[4, 0, 1]])


### PR DESCRIPTION
**Context:**
Part of the effort to stop relying on operator hash and equality.

**Description of the Change:**
Updated the `qcut` module to use `(op, id(op))` as nodes in the directed multigraphs used in the circuit cutting workflow instead of `op`.

**Benefits:**
`qcut` no longer relies on operator hash, allowing us to update the operator `__hash__` and `__eq__` methods in the future.

**Possible Drawbacks:**
Breaking change. While likely not used by many users, there are public functions in `qcut` to create graphs from tapes.

**Related GitHub Issues:**
