### PR TITLE
make docker builds work

### DIFF
--- a/docker/interfaces/gpu-cuda/build_interface_gpu.dockerfile
+++ b/docker/interfaces/gpu-cuda/build_interface_gpu.dockerfile
@@ -14,6 +14,10 @@
 
 FROM pennylane/cuda/base:latest
 ARG INTERFACE_NAME=tensorflow
+RUN . /opt/venv/bin/activate
+# the following packages need re-installation in this build stage to avoid bugs
+RUN pip uninstall -y numpy scipy rustworkx \
+    && pip install "numpy<1.24" "scipy~=1.8" "rustworkx==0.12.0"
 WORKDIR /opt/pennylane/docker/interfaces
 RUN chmod +x install-interface-gpu.sh && ./install-interface-gpu.sh $INTERFACE_NAME
 

--- a/docker/interfaces/gpu-cuda/cuda-base.dockerfile
+++ b/docker/interfaces/gpu-cuda/cuda-base.dockerfile
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM nvidia/cuda:11.1-base AS compile-image
+FROM nvidia/cuda:11.1.1-base AS compile-image
 
 # Setup and install Basic packages
+RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub
 RUN apt-get update && apt-get install -y apt-utils --no-install-recommends
 RUN DEBIAN_FRONTEND="noninteractive" apt-get install -y tzdata \
     build-essential \
@@ -54,6 +55,9 @@ COPY --from=compile-image /opt/pennylane /opt/pennylane
 ENV PATH="/opt/venv/bin:$PATH"
 RUN apt-get update \
     && apt-get install -y apt-utils \
-    --no-install-recommends python3 python3-pip python3-venv
+    --no-install-recommends python3 python3-venv \
+    && rm -rf /opt/venv/lib/python3.8/site-packages/pip* \
+    && python3 -m ensurepip
 # Image build completed.
+ENV PYTHONPATH="/opt/venv/lib/python3.8/site-packages"
 CMD echo "Successfully built Docker image for GPU"

--- a/docker/pennylane.dockerfile
+++ b/docker/pennylane.dockerfile
@@ -28,6 +28,8 @@ RUN DEBIAN_FRONTEND="noninteractive" apt-get install -y tzdata \
     python3-pip \
     python3-venv \
     libjpeg-dev \
+    libopenblas-dev \
+    libsuitesparse-dev \
     libpng-dev && \
     rm -rf /var/lib/apt/lists/* \
     && /usr/sbin/update-ccache-symlinks \
@@ -35,6 +37,8 @@ RUN DEBIAN_FRONTEND="noninteractive" apt-get install -y tzdata \
     && python3 -m venv /opt/venv
 # Activate VirtualENV
 ENV PATH="/opt/venv/bin:$PATH"
+# This flag (along with openblas and suitesparse above) are needed for cvxopt
+ENV CPPFLAGS="-I/usr/include/suitesparse"
 
 #Setup and Build pennylane
 WORKDIR /opt/pennylane


### PR DESCRIPTION
**Context:**
It has recently come to my attention that our docker builds don't work, so I'm making them work.

**Description of the Change:**
`cvxopt` failed to install for the CPU docker image because it depends on OpenBLAS being on the system, so I'm installing it. As for the GPU docker image...
1. the nvidia/cuda base image tag being used just didn't exist, so I'm using one that does
2. something was failing with signing keys for some cuda installation, so I followed [this forum post response](https://askubuntu.com/questions/1408016/the-following-signatures-couldnt-be-verified-because-the-public-key-is-not-avai) (had to use the manual one because `wget` isn't installed yet and this keeps things neater)
3. The installed version of `pip` was a mess because various parts of it were linked to files outside of `/opt/venv`, so I uninstalled it and re-installed it. Due to the sneaky moves being done to keep the image minimal, I opted to use `python3 -m ensurepip` as it's the most reliable in this case.
4. I wasn't able to import pennylane because various dependencies were busted from the minimal-image creation, so I am uninstalling and re-installing them

**Benefits:**
Our docker images build!

**Possible Drawbacks:**
- The `jax` GPU image definitely does not build. The link being followed doesn't seem to work, and it's too much effort to make it work. Perhaps we should make that fail explicitly until it's fixed.
- The `jax` CPU build is failing for a different, weird reason. I believe it's because the pip being installed doesn't support the `manylinux2014` distro tag (which [is being used](https://storage.googleapis.com/jax-releases/jax_releases.html)), but I'm not sure, nor do I know how to check.
```
root@c870cdb1bcfc:/# cat /etc/lsb-release 
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=22.04
DISTRIB_CODENAME=jammy
DISTRIB_DESCRIPTION="Ubuntu 22.04.2 LTS"

root@c870cdb1bcfc:/# pip install jaxlib
ERROR: Could not find a version that satisfies the requirement jaxlib (from versions: none)
ERROR: No matching distribution found for jaxlib
```