### PR TITLE
[QInfo broadcasting (3/3)] Support quantum information QNode transforms

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -174,6 +174,10 @@
   `qml.math.relative_entropy`, `qml.math.max_entropy`, and `qml.math.sqrt_matrix`.
   [(#4186)](https://github.com/PennyLaneAI/pennylane/pull/4186)
 
+* Added broadcasting support for `qml.qinfo.reduced_dm`, `qml.qinfo.purity`, `qml.qinfo.vn_entropy`,
+  `qml.qinfo.mutual_info`, `qml.qinfo.fidelity`, `qml.qinfo.relative_entropy`, and `qml.qinfo.trace_distance`.
+  []()
+
 <h4>Trace distance is now available in qml.qinfo 💥</h4>
 
 * The quantum information module now supports computation of [trace distance](https://en.wikipedia.org/wiki/Trace_distance).

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -187,7 +187,7 @@
 
 * Added broadcasting support for `qml.qinfo.reduced_dm`, `qml.qinfo.purity`, `qml.qinfo.vn_entropy`,
   `qml.qinfo.mutual_info`, `qml.qinfo.fidelity`, `qml.qinfo.relative_entropy`, and `qml.qinfo.trace_distance`.
-  []()
+  [(#4234)](https://github.com/PennyLaneAI/pennylane/pull/4234)
 
 <h4>Trace distance is now available in qml.qinfo 💥</h4>
 

--- a/tests/qinfo/test_entropies.py
+++ b/tests/qinfo/test_entropies.py
@@ -24,9 +24,7 @@ def expected_entropy_ising_xx(param):
     """
     Return the analytical entropy for the IsingXX.
     """
-    eig_1 = (1 + np.sqrt(1 - 4 * np.cos(param / 2) ** 2 * np.sin(param / 2) ** 2)) / 2
-    eig_2 = (1 - np.sqrt(1 - 4 * np.cos(param / 2) ** 2 * np.sin(param / 2) ** 2)) / 2
-    eigs = [eig_1, eig_2]
+    eigs = [np.cos(param / 2) ** 2, np.sin(param / 2) ** 2]
     eigs = [eig for eig in eigs if eig > 0]
 
     expected_entropy = eigs * np.log(eigs)
@@ -771,3 +769,58 @@ class TestRelativeEntropy:
         ) + (np.sin(x / 2) ** 2 * (np.log(np.sin(x / 2) ** 2) - np.log(np.sin(y / 2) ** 2)))
 
         assert np.allclose(actual, expected)
+
+
+@pytest.mark.parametrize("device", ["default.qubit", "default.mixed"])
+class TestBroadcasting:
+    """Test that the entropy transforms support broadcasting"""
+
+    def test_vn_entropy_broadcast(self, device):
+        """Test that the vn_entropy transform supports broadcasting"""
+        dev = qml.device(device, wires=2)
+
+        @qml.qnode(dev)
+        def circuit_state(x):
+            qml.IsingXX(x, wires=[0, 1])
+            return qml.state()
+
+        x = np.array([0.4, 0.6, 0.8])
+        entropy = qml.qinfo.vn_entropy(circuit_state, wires=[0])(x)
+
+        expected = [expected_entropy_ising_xx(_x) for _x in x]
+        assert qml.math.allclose(entropy, expected)
+
+    def test_mutual_info_broadcast(self, device):
+        """Test that the mutual_info transform supports broadcasting"""
+        dev = qml.device(device, wires=2)
+
+        @qml.qnode(dev)
+        def circuit_state(x):
+            qml.IsingXX(x, wires=[0, 1])
+            return qml.state()
+
+        x = np.array([0.4, 0.6, 0.8])
+        minfo = qml.qinfo.mutual_info(circuit_state, wires0=[0], wires1=[1])(x)
+
+        expected = [2 * expected_entropy_ising_xx(_x) for _x in x]
+        assert qml.math.allclose(minfo, expected)
+
+    def test_relative_entropy_broadcast(self, device):
+        """Test that the relative_entropy transform supports broadcasting"""
+        dev = qml.device(device, wires=2)
+
+        @qml.qnode(dev)
+        def circuit_state(x):
+            qml.IsingXX(x, wires=[0, 1])
+            return qml.state()
+
+        x = np.array([0.4, 0.6, 0.8])
+        y = np.array([0.6, 0.8, 1.0])
+        entropy = qml.qinfo.relative_entropy(circuit_state, circuit_state, wires0=[0], wires1=[1])(
+            x, y
+        )
+
+        eigs0 = np.stack([np.cos(x / 2) ** 2, np.sin(x / 2) ** 2])
+        eigs1 = np.stack([np.cos(y / 2) ** 2, np.sin(y / 2) ** 2])
+        expected = np.sum(eigs0 * np.log(eigs0), axis=0) - np.sum(eigs0 * np.log(eigs1), axis=0)
+        assert qml.math.allclose(entropy, expected)

--- a/tests/qinfo/test_fidelity.py
+++ b/tests/qinfo/test_fidelity.py
@@ -799,3 +799,21 @@ class TestFidelityQnode:
         )((jax.numpy.array(param)), (jax.numpy.array(2.0)))
         expected_fid_grad = expected_grad_fidelity_rx_pauliz(param)
         assert qml.math.allclose(fid_grad, (expected_fid_grad, 0.0), rtol=1e-03, atol=1e-04)
+
+
+@pytest.mark.parametrize("device", ["default.qubit", "default.mixed"])
+def test_broadcasting(device):
+    """Test that the fidelity transform supports broadcasting"""
+    dev = qml.device(device, wires=2)
+
+    @qml.qnode(dev)
+    def circuit_state(x):
+        qml.IsingXX(x, wires=[0, 1])
+        return qml.state()
+
+    x = np.array([0.4, 0.6, 0.8])
+    y = np.array([0.6, 0.8, 1.0])
+    fid = qml.qinfo.fidelity(circuit_state, circuit_state, wires0=[0], wires1=[1])(x, y)
+
+    expected = 0.5 * (np.sin(x) * np.sin(y) + np.cos(x) * np.cos(y) + 1)
+    assert qml.math.allclose(fid, expected)

--- a/tests/qinfo/test_purity.py
+++ b/tests/qinfo/test_purity.py
@@ -375,3 +375,20 @@ class TestPurity:
         grad_purity = tape.gradient(purity, param)
 
         assert qml.math.allclose(grad_purity, grad_expected_purity)
+
+
+@pytest.mark.parametrize("device", ["default.qubit", "default.mixed"])
+def test_broadcasting(device):
+    """Test that the purity transform supports broadcasting"""
+    dev = qml.device(device, wires=2)
+
+    @qml.qnode(dev)
+    def circuit_state(x):
+        qml.IsingXX(x, wires=[0, 1])
+        return qml.state()
+
+    x = np.array([0.4, 0.6, 0.8])
+    purity = qml.qinfo.purity(circuit_state, wires=[0])(x)
+
+    expected = expected_purity_ising_xx(x)
+    assert qml.math.allclose(purity, expected)

--- a/tests/qinfo/test_reduced_dm.py
+++ b/tests/qinfo/test_reduced_dm.py
@@ -33,7 +33,7 @@ devices = [
 interfaces = [
     "autograd",
     "torch",
-    "tf",
+    "tensorflow",
     "jax",
 ]
 wires_list = [[0], [1], [0, 1], [1, 0]]
@@ -149,3 +149,49 @@ class TestDensityMatrixQNode:
 
         density_matrix = qml.qinfo.reduced_dm(circuit, wires=wires)(0.5)
         assert density_matrix.dtype == c_dtype
+
+
+class TestBroadcasting:
+    """Test that the reduced_dm transform supports broadcasting"""
+
+    @pytest.mark.parametrize("device", devices)
+    @pytest.mark.parametrize("interface", interfaces)
+    def test_sv_broadcast(self, device, interface, tol):
+        """Test that broadcasting works for circuits returning state vectors"""
+        dev = qml.device(device, wires=2)
+
+        @qml.qnode(dev, interface=interface)
+        def circuit(x):
+            qml.PauliX(0)
+            qml.IsingXX(x, wires=[0, 1])
+            return qml.state()
+
+        x = qml.math.asarray([0.4, 0.6, 0.8], like=interface)
+        density_matrix = qml.qinfo.reduced_dm(circuit, wires=[0])(x)
+
+        expected = np.zeros((3, 2, 2))
+        expected[:, 0, 0] = np.sin(x / 2) ** 2
+        expected[:, 1, 1] = np.cos(x / 2) ** 2
+
+        assert qml.math.allclose(expected, density_matrix, atol=tol)
+
+    @pytest.mark.parametrize("device", devices)
+    @pytest.mark.parametrize("interface", interfaces)
+    def test_dm_broadcast(self, device, interface, tol):
+        """Test that broadcasting works for circuits returning density matrices"""
+        dev = qml.device(device, wires=2)
+
+        @qml.qnode(dev, interface=interface)
+        def circuit(x):
+            qml.PauliX(0)
+            qml.IsingXX(x, wires=[0, 1])
+            return qml.density_matrix(wires=[0, 1])
+
+        x = qml.math.asarray([0.4, 0.6, 0.8], like=interface)
+        density_matrix = qml.qinfo.reduced_dm(circuit, wires=[0])(x)
+
+        expected = np.zeros((3, 2, 2))
+        expected[:, 0, 0] = np.sin(x / 2) ** 2
+        expected[:, 1, 1] = np.cos(x / 2) ** 2
+
+        assert qml.math.allclose(expected, density_matrix, atol=tol)


### PR DESCRIPTION
Currently the quantum information functions in `qml.math` and the QNode transforms in `qml.qinfo` do not support broadcasting. Support for this will be added in a sequence of 3 PRs, of which this is the last. The individual aims of the PRs are roughly:

1. (done) Split `qml.math.reduced_dm` into two functions, `qml.math.reduced_dm_from_sv` and `qml.math.reduced_dm_from_dm`, each of which supports broadcasting. Also begin a deprecation cycle for `qml.math.reduced_dm`. [#4173](https://github.com/PennyLaneAI/pennylane/pull/4173)
2. (done) Support broadcasting for each of the remaining quantum info functions in `qml.math`. Also change their signatures to accept only a density matrix, and begin a deprecation cycle for passing in state vectors. [#4186](https://github.com/PennyLaneAI/pennylane/pull/4186)
3. (current) Support broadcasting for the `qml.qinfo` QNode transforms.

Closes https://github.com/PennyLaneAI/pennylane/issues/4140