### PR TITLE
Fix unclear documentation and indicate variable-length argument lists.

### DIFF
--- a/doc/development/adding_operators.rst
+++ b/doc/development/adding_operators.rst
@@ -93,11 +93,6 @@ The basic components of operators are the following:
       [0+0j, 0+0j, 9.95e-01-2.26e-18j 2.72e-17-9.98e-02j]
       [0+0j, 0+0j, 2.72e-17-9.98e-02j 9.95e-01-2.26e-18j]]
 
-    .. note::
-
-        The :meth:`.Operator.matrix` method is temporary and will be renamed to :meth:`.Operator.matrix` in an
-        upcoming release. It is recommended to use the higher-level :func:`~.matrix` function where possible.
-
    * Representation as a **sparse matrix** (:meth:`.Operator.sparse_matrix`):
 
      >>> from scipy.sparse.coo import coo_matrix

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -342,6 +342,10 @@
   An if conditional was intended to prevent divide by zero errors but the division was by the sine of the argument so any multiple of $\pi$ should trigger the conditional, but it was only checking if the argument was 0. Example: `qml.Rot(2.3, 2.3, 2.3)`
   [(#4210)](https://github.com/PennyLaneAI/pennylane/pull/4210)
 
+* Fix unclear documentation and indicate variable-length argument lists of functions and methods in
+  the respective docstrings.
+  [(#4242)](https://github.com/PennyLaneAI/pennylane/pull/4242)
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -197,6 +197,10 @@
   `qml.qinfo.mutual_info`, `qml.qinfo.fidelity`, `qml.qinfo.relative_entropy`, and `qml.qinfo.trace_distance`.
   [(#4234)](https://github.com/PennyLaneAI/pennylane/pull/4234)
 
+* Fix unclear documentation and indicate variable-length argument lists of functions and methods in
+  the respective docstrings.
+  [(#4242)](https://github.com/PennyLaneAI/pennylane/pull/4242)
+
 <h4>Trace distance is now available in qml.qinfo 💥</h4>
 
 * The quantum information module now supports computation of [trace distance](https://en.wikipedia.org/wiki/Trace_distance).
@@ -341,10 +345,6 @@
 * Fixed buggy calculation of angle in `xyx_decomposition` causing it to give an incorrect decomposition.
   An if conditional was intended to prevent divide by zero errors but the division was by the sine of the argument so any multiple of $\pi$ should trigger the conditional, but it was only checking if the argument was 0. Example: `qml.Rot(2.3, 2.3, 2.3)`
   [(#4210)](https://github.com/PennyLaneAI/pennylane/pull/4210)
-
-* Fix unclear documentation and indicate variable-length argument lists of functions and methods in
-  the respective docstrings.
-  [(#4242)](https://github.com/PennyLaneAI/pennylane/pull/4242)
 
 <h3>Contributors ✍️</h3>
 

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -417,7 +417,7 @@ class Operator(abc.ABC):
     ``hyperparameters`` are the respective attributes of the operator class.
 
     Args:
-        params (tuple[tensor_like]): trainable parameters
+        *params (tuple[tensor_like]): trainable parameters
         wires (Iterable[Any] or Any): Wire label(s) that the operator acts on.
             If not given, args[-1] is interpreted as wires.
         do_queue (bool): indicates whether the operator should be recorded when created in
@@ -705,11 +705,11 @@ class Operator(abc.ABC):
         The canonical matrix is the textbook matrix representation that does not consider wires.
         Implicitly, this assumes that the wires of the operator correspond to the global wire order.
 
-        .. seealso:: :meth:`~.Operator.matrix` and :func:`~.matrix`
+        .. seealso:: :meth:`.Operator.matrix` and :func:`qml.matrix`
 
         Args:
-            params (list): trainable parameters of the operator, as stored in the ``parameters`` attribute
-            hyperparams (dict): non-trainable hyperparameters of the operator, as stored in the ``hyperparameters`` attribute
+            *params (list): trainable parameters of the operator, as stored in the ``parameters`` attribute
+            **hyperparams (dict): non-trainable hyperparameters of the operator, as stored in the ``hyperparameters`` attribute
 
         Returns:
             tensor_like: matrix representation
@@ -762,8 +762,8 @@ class Operator(abc.ABC):
         .. seealso:: :meth:`~.Operator.sparse_matrix`
 
         Args:
-            params (list): trainable parameters of the operator, as stored in the ``parameters`` attribute
-            hyperparams (dict): non-trainable hyperparameters of the operator, as stored in the ``hyperparameters``
+            *params (list): trainable parameters of the operator, as stored in the ``parameters`` attribute
+            **hyperparams (dict): non-trainable hyperparameters of the operator, as stored in the ``hyperparameters``
                 attribute
 
         Returns:
@@ -811,8 +811,8 @@ class Operator(abc.ABC):
         .. seealso:: :meth:`~.Operator.eigvals` and :func:`~.eigvals`
 
         Args:
-            params (list): trainable parameters of the operator, as stored in the ``parameters`` attribute
-            hyperparams (dict): non-trainable hyperparameters of the operator, as stored in the ``hyperparameters`` attribute
+            *params (list): trainable parameters of the operator, as stored in the ``parameters`` attribute
+            **hyperparams (dict): non-trainable hyperparameters of the operator, as stored in the ``hyperparameters`` attribute
 
         Returns:
             tensor_like: eigenvalues
@@ -1234,9 +1234,9 @@ class Operator(abc.ABC):
         .. seealso:: :meth:`~.Operator.decomposition`.
 
         Args:
-            params (list): trainable parameters of the operator, as stored in the ``parameters`` attribute
+            *params (list): trainable parameters of the operator, as stored in the ``parameters`` attribute
             wires (Iterable[Any], Wires): wires that the operator acts on
-            hyperparams (dict): non-trainable hyperparameters of the operator, as stored in the ``hyperparameters`` attribute
+            **hyperparams (dict): non-trainable hyperparameters of the operator, as stored in the ``hyperparameters`` attribute
 
         Returns:
             list[Operator]: decomposition of the operator
@@ -1713,8 +1713,8 @@ class Channel(Operation, abc.ABC):
             of a particular operator.
 
         Args:
-            params (list): trainable parameters of the operator, as stored in the ``parameters`` attribute
-            hyperparams (dict): non-trainable hyperparameters of the operator,
+            *params (list): trainable parameters of the operator, as stored in the ``parameters`` attribute
+            **hyperparams (dict): non-trainable hyperparameters of the operator,
                 as stored in the ``hyperparameters`` attribute
 
         Returns:

--- a/pennylane/ops/channel.py
+++ b/pennylane/ops/channel.py
@@ -764,7 +764,7 @@ class QubitChannel(Channel):
         """Kraus matrices representing the QubitChannel channel.
 
         Args:
-            K_list (list[array[complex]]): list of Kraus matrices
+            *K_list (list[array[complex]]): list of Kraus matrices
 
         Returns:
             list (array): list of Kraus matrices

--- a/pennylane/ops/op_math/prod.py
+++ b/pennylane/ops/op_math/prod.py
@@ -51,7 +51,7 @@ def prod(*ops, do_queue=None, id=None, lazy=True):
     that the given operators act on.
 
     Args:
-        ops (Union[tuple[~.operation.Operator], Callable]): The operators we would like to multiply.
+        *ops (Union[tuple[~.operation.Operator], Callable]): The operators we would like to multiply.
             Alternatively, a single qfunc that queues operators can be passed to this function.
 
     Keyword Args:
@@ -133,8 +133,8 @@ class Prod(CompositeOp):
     r"""Symbolic operator representing the product of operators.
 
     Args:
-        factors (tuple[~.operation.Operator]): a tuple of operators which will be multiplied
-        together.
+        *factors (tuple[~.operation.Operator]): a tuple of operators which will be multiplied
+            together.
 
     Keyword Args:
         do_queue (bool): determines if the product operator will be queued.

--- a/pennylane/ops/op_math/sum.py
+++ b/pennylane/ops/op_math/sum.py
@@ -34,7 +34,7 @@ def sum(*summands, do_queue=None, id=None, lazy=True):
     r"""Construct an operator which is the sum of the given operators.
 
     Args:
-        summands (tuple[~.operation.Operator]): the operators we want to sum together.
+        *summands (tuple[~.operation.Operator]): the operators we want to sum together.
 
     Keyword Args:
         do_queue (bool): determines if the sum operator will be queued (currently not supported).
@@ -91,7 +91,7 @@ class Sum(CompositeOp):
     r"""Symbolic operator representing the sum of operators.
 
     Args:
-        summands (tuple[~.operation.Operator]): a tuple of operators which will be summed together.
+        *summands (tuple[~.operation.Operator]): a tuple of operators which will be summed together.
 
     Keyword Args:
         do_queue (bool): determines if the sum operator will be queued.

--- a/pennylane/ops/qubit/matrix_ops.py
+++ b/pennylane/ops/qubit/matrix_ops.py
@@ -538,8 +538,8 @@ class BlockEncode(Operation):
         .. seealso:: :meth:`~.BlockEncode.matrix`
 
         Args:
-            params (list): trainable parameters of the operator, as stored in the ``parameters`` attribute
-            hyperparams (dict): non-trainable hyperparameters of the operator, as stored in the ``hyperparameters`` attribute
+            *params (list): trainable parameters of the operator, as stored in the ``parameters`` attribute
+            **hyperparams (dict): non-trainable hyperparameters of the operator, as stored in the ``hyperparameters`` attribute
 
 
         Returns:

--- a/pennylane/ops/qubit/parametric_ops_multi_qubit.py
+++ b/pennylane/ops/qubit/parametric_ops_multi_qubit.py
@@ -664,9 +664,9 @@ class PCPhase(Operation):
         .. seealso:: :meth:`~.Operator.decomposition`.
 
         Args:
-            params (list): trainable parameters of the operator, as stored in the ``parameters`` attribute
+            *params (list): trainable parameters of the operator, as stored in the ``parameters`` attribute
             wires (Iterable[Any], Wires): wires that the operator acts on
-            hyperparams (dict): non-trainable hyper-parameters of the operator, as stored in the ``hyperparameters`` attribute
+            **hyperparams (dict): non-trainable hyper-parameters of the operator, as stored in the ``hyperparameters`` attribute
 
         Returns:
             list[Operator]: decomposition of the operator

--- a/pennylane/qchem/dipole.py
+++ b/pennylane/qchem/dipole.py
@@ -97,7 +97,7 @@ def dipole_integrals(mol, core=None, active=None):
         r"""Compute the dipole moment integrals in the molecular orbital basis.
 
         Args:
-            args (array[array[float]]): initial values of the differentiable parameters
+            *args (array[array[float]]): initial values of the differentiable parameters
 
         Returns:
             tuple[array[float]]: tuple containing the core orbital contributions and the dipole
@@ -197,7 +197,7 @@ def fermionic_dipole(mol, cutoff=1.0e-18, core=None, active=None):
         r"""Build the fermionic dipole moment observable.
 
         Args:
-            args (array[array[float]]): initial values of the differentiable parameters
+            *args (array[array[float]]): initial values of the differentiable parameters
 
         Returns:
             tuple(array[float], list[list[int]]): the dipole moment coefficients and the indices of
@@ -297,7 +297,7 @@ def dipole_moment(mol, cutoff=1.0e-18, core=None, active=None):
         r"""Compute the qubit dipole moment observable.
 
         Args:
-            args (array[array[float]]): initial values of the differentiable parameters
+            *args (array[array[float]]): initial values of the differentiable parameters
 
         Returns:
             (list[Hamiltonian]): x, y and z components of the dipole moment observable

--- a/pennylane/qchem/hamiltonian.py
+++ b/pennylane/qchem/hamiltonian.py
@@ -103,7 +103,7 @@ def electron_integrals(mol, core=None, active=None):
         r"""Compute the one- and two-electron integrals in the molecular orbital basis.
 
         Args:
-            args (array[array[float]]): initial values of the differentiable parameters
+            *args (array[array[float]]): initial values of the differentiable parameters
 
         Returns:
             tuple[array[float]]: 1D tuple containing core constant, one- and two-electron integrals
@@ -167,7 +167,7 @@ def fermionic_hamiltonian(mol, cutoff=1.0e-12, core=None, active=None):
         r"""Compute the fermionic hamiltonian.
 
         Args:
-            args (array[array[float]]): initial values of the differentiable parameters
+            *args (array[array[float]]): initial values of the differentiable parameters
 
         Returns:
             tuple(array[float], list[list[int]]): the Hamiltonian coefficients and operators
@@ -210,7 +210,7 @@ def diff_hamiltonian(mol, cutoff=1.0e-12, core=None, active=None):
         r"""Compute the qubit hamiltonian.
 
         Args:
-            args (array[array[float]]): initial values of the differentiable parameters
+            *args (array[array[float]]): initial values of the differentiable parameters
 
         Returns:
             Hamiltonian: the qubit Hamiltonian

--- a/pennylane/qchem/hartree_fock.py
+++ b/pennylane/qchem/hartree_fock.py
@@ -110,7 +110,7 @@ def scf(mol, n_steps=50, tol=1e-8):
         r"""Perform the self-consistent-field iterations.
 
         Args:
-            args (array[array[float]]): initial values of the differentiable parameters
+            *args (array[array[float]]): initial values of the differentiable parameters
 
         Returns:
             tuple(array[float]): eigenvalues of the Fock matrix, molecular orbital coefficients,
@@ -203,7 +203,7 @@ def nuclear_energy(charges, r):
         r"""Compute the nuclear-repulsion energy.
 
         Args:
-            args (array[array[float]]): initial values of the differentiable parameters
+            *args (array[array[float]]): initial values of the differentiable parameters
 
         Returns:
             array[float]: nuclear-repulsion energy
@@ -246,7 +246,7 @@ def hf_energy(mol):
         r"""Compute the Hartree-Fock energy.
 
         Args:
-            args (array[array[float]]): initial values of the differentiable parameters
+            *args (array[array[float]]): initial values of the differentiable parameters
 
         Returns:
             float: the Hartree-Fock energy

--- a/pennylane/qchem/integrals.py
+++ b/pennylane/qchem/integrals.py
@@ -282,7 +282,7 @@ def overlap_integral(basis_a, basis_b, normalize=True):
         r"""Normalize and compute the overlap integral for two contracted Gaussian functions.
 
         Args:
-            args (array[float]): initial values of the differentiable parameters
+            *args (array[float]): initial values of the differentiable parameters
 
         Returns:
             array[float]: the overlap integral between two contracted Gaussian orbitals
@@ -475,7 +475,7 @@ def moment_integral(basis_a, basis_b, order, idx, normalize=True):
         r"""Normalize and compute the multipole moment integral for two contracted Gaussians.
 
         Args:
-            args (array[float]): initial values of the differentiable parameters
+            *args (array[float]): initial values of the differentiable parameters
 
         Returns:
             array[float]: the multipole moment integral between two contracted Gaussian orbitals
@@ -650,7 +650,7 @@ def kinetic_integral(basis_a, basis_b, normalize=True):
         r"""Compute the kinetic integral for two contracted Gaussian functions.
 
         Args:
-            args (array[float]): initial values of the differentiable parameters
+            *args (array[float]): initial values of the differentiable parameters
 
         Returns:
             array[float]: the kinetic integral between two contracted Gaussian orbitals
@@ -858,7 +858,7 @@ def attraction_integral(r, basis_a, basis_b, normalize=True):
         r"""Compute the electron-nuclear attraction integral for two contracted Gaussian functions.
 
         Args:
-            args (array[float]): initial values of the differentiable parameters
+            *args (array[float]): initial values of the differentiable parameters
 
         Returns:
             array[float]: the electron-nuclear attraction integral
@@ -1003,7 +1003,7 @@ def repulsion_integral(basis_a, basis_b, basis_c, basis_d, normalize=True):
         r"""Compute the electron-electron repulsion integral for four contracted Gaussian functions.
 
         Args:
-            args (array[float]): initial values of the differentiable parameters
+            *args (array[float]): initial values of the differentiable parameters
 
         Returns:
             array[float]: the electron repulsion integral between four contracted Gaussian functions

--- a/pennylane/qchem/matrices.py
+++ b/pennylane/qchem/matrices.py
@@ -85,7 +85,7 @@ def overlap_matrix(basis_functions):
         r"""Construct the overlap matrix for a given set of basis functions.
 
         Args:
-            args (array[array[float]]): initial values of the differentiable parameters
+            *args (array[array[float]]): initial values of the differentiable parameters
 
         Returns:
             array[array[float]]: the overlap matrix
@@ -136,7 +136,7 @@ def moment_matrix(basis_functions, order, idx):
         r"""Construct the multipole moment matrix for a given set of basis functions.
 
         Args:
-            args (array[array[float]]): initial values of the differentiable parameters
+            *args (array[array[float]]): initial values of the differentiable parameters
 
         Returns:
             array[array[float]]: the multipole moment matrix
@@ -184,7 +184,7 @@ def kinetic_matrix(basis_functions):
         r"""Construct the kinetic matrix for a given set of basis functions.
 
         Args:
-            args (array[array[float]]): initial values of the differentiable parameters
+            *args (array[array[float]]): initial values of the differentiable parameters
 
         Returns:
             array[array[float]]: the kinetic matrix
@@ -235,7 +235,7 @@ def attraction_matrix(basis_functions, charges, r):
         r"""Construct the electron-nuclear attraction matrix for a given set of basis functions.
 
         Args:
-            args (array[array[float]]): initial values of the differentiable parameters
+            *args (array[array[float]]): initial values of the differentiable parameters
 
         Returns:
             array[array[float]]: the electron-nuclear attraction matrix
@@ -307,7 +307,7 @@ def repulsion_tensor(basis_functions):
         Journal of Quantum Chemistry, 1971, 5, 657-668].
 
         Args:
-            args (array[array[float]]): initial values of the differentiable parameters
+            *args (array[array[float]]): initial values of the differentiable parameters
 
         Returns:
             array[array[float]]: the electron repulsion tensor
@@ -373,7 +373,7 @@ def core_matrix(basis_functions, charges, r):
         r"""Construct the core matrix for a given set of basis functions.
 
         Args:
-            args (array[array[float]]): initial values of the differentiable parameters
+            *args (array[array[float]]): initial values of the differentiable parameters
 
         Returns:
             array[array[float]]: the core matrix

--- a/pennylane/templates/subroutines/qsvt.py
+++ b/pennylane/templates/subroutines/qsvt.py
@@ -357,8 +357,8 @@ class QSVT(Operation):
         .. seealso:: :meth:`~.Operator.matrix` and :func:`~.matrix`
 
         Args:
-            params (list): trainable parameters of the operator, as stored in the ``parameters`` attribute
-            hyperparams (dict): non-trainable hyperparameters of the operator, as stored in the ``hyperparameters`` attribute
+            *params (list): trainable parameters of the operator, as stored in the ``parameters`` attribute
+            **hyperparams (dict): non-trainable hyperparameters of the operator, as stored in the ``hyperparameters`` attribute
 
         Returns:
             tensor_like: matrix representation


### PR DESCRIPTION
**Context:**
The documentation about [adding operators](https://github.com/PennyLaneAI/pennylane/blob/master/doc/development/adding_operators.rst?plain=1#L98) and [`Operator.compute_matrix()`](https://github.com/PennyLaneAI/pennylane/blob/master/pennylane/operation.py#L708) contain some confusing notes.
Variable-length argument lists (e.g. `foo(*args)`) are not always indicated in the respective docstrings.

**Description of the Change:**
The documentation is improved. Variable-length argument lists are indicated according to the [Google Styleguide](https://google.github.io/styleguide/pyguide.html).

**Benefits:**
Users can understand more easily how to pass arguments to functions and methods. Confusing notes are resolved.

**Possible Drawbacks:**
n/a

**Related GitHub Issues:**
n/a
