### PR TITLE
fix sprod matrix

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -313,6 +313,7 @@
 <h3>Bug fixes 🐛</h3>
 
 * Fixes the matrix of `SProd` when the coefficient is tensorflow and the target matrix is not `complex128`.
+  [(#4249)](https://github.com/PennyLaneAI/pennylane/pull/4249)
 
 * Fixes adjoint jacobian results with `grad_on_execution=False` in the JAX-JIT interface.
   [(4217)](https://github.com/PennyLaneAI/pennylane/pull/4217)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -312,6 +312,8 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Fixes the matrix of `SProd` when the coefficient is tensorflow and the target matrix is not `complex128`.
+
 * Fixes adjoint jacobian results with `grad_on_execution=False` in the JAX-JIT interface.
   [(4217)](https://github.com/PennyLaneAI/pennylane/pull/4217)
 

--- a/pennylane/ops/op_math/sprod.py
+++ b/pennylane/ops/op_math/sprod.py
@@ -254,9 +254,6 @@ class SProd(ScalarSymbolicOp):
 
     @staticmethod
     def _matrix(scalar, mat):
-        if qml.math.get_interface(scalar) == "tensorflow":
-            # we must cast ``scalar`` to complex to avoid an error
-            scalar = qml.math.cast_like(scalar, mat)
         return scalar * mat
 
     @property

--- a/pennylane/ops/op_math/symbolicop.py
+++ b/pennylane/ops/op_math/symbolicop.py
@@ -258,27 +258,30 @@ class ScalarSymbolicOp(SymbolicOp):
             base_matrix = self.base.matrix()
 
         scalar_interface = qml.math.get_interface(self.scalar)
+        scalar = self.scalar
         if scalar_interface == "torch":
             # otherwise get `RuntimeError: Can't call numpy() on Tensor that requires grad.`
             base_matrix = qml.math.convert_like(base_matrix, self.scalar)
-        elif scalar_interface == "tensorflow" and not qml.math.iscomplex(self.scalar):
-            # cast scalar to complex to avoid an error
-            self.scalar = qml.math.cast_like(self.scalar, base_matrix)
+        elif scalar_interface == "tensorflow":
+            # just cast everything to complex128. Otherwise we may have casting problems.
+            # where things get truncated like in SProd(tf.Variable(0.1), qml.PauliX(0))
+            scalar = qml.math.cast(scalar, "complex128")
+            base_matrix = qml.math.cast(base_matrix, "complex128")
 
         # compute scalar operation on base matrix taking batching into account
-        scalar_size = qml.math.size(self.scalar)
+        scalar_size = qml.math.size(scalar)
         if scalar_size != 1:
             if scalar_size == self.base.batch_size:
                 # both base and scalar are broadcasted
-                mat = qml.math.stack([self._matrix(s, m) for s, m in zip(self.scalar, base_matrix)])
+                mat = qml.math.stack([self._matrix(s, m) for s, m in zip(scalar, base_matrix)])
             else:
                 # only scalar is broadcasted
-                mat = qml.math.stack([self._matrix(s, base_matrix) for s in self.scalar])
+                mat = qml.math.stack([self._matrix(s, base_matrix) for s in scalar])
         elif self.base.batch_size is not None:
             # only base is broadcasted
-            mat = qml.math.stack([self._matrix(self.scalar, ar2) for ar2 in base_matrix])
+            mat = qml.math.stack([self._matrix(scalar, ar2) for ar2 in base_matrix])
         else:
             # none are broadcasted
-            mat = self._matrix(self.scalar, base_matrix)
+            mat = self._matrix(scalar, base_matrix)
 
         return qml.math.expand_matrix(mat, wires=self.wires, wire_order=wire_order)

--- a/pennylane/ops/op_math/symbolicop.py
+++ b/pennylane/ops/op_math/symbolicop.py
@@ -263,7 +263,7 @@ class ScalarSymbolicOp(SymbolicOp):
             # otherwise get `RuntimeError: Can't call numpy() on Tensor that requires grad.`
             base_matrix = qml.math.convert_like(base_matrix, self.scalar)
         elif scalar_interface == "tensorflow":
-            # just cast everything to complex128. Otherwise we may have casting problems.
+            # just cast everything to complex128. Otherwise we may have casting problems
             # where things get truncated like in SProd(tf.Variable(0.1), qml.PauliX(0))
             scalar = qml.math.cast(scalar, "complex128")
             base_matrix = qml.math.cast(base_matrix, "complex128")

--- a/tests/ops/op_math/test_sprod.py
+++ b/tests/ops/op_math/test_sprod.py
@@ -506,6 +506,7 @@ class TestMatrix:
         assert mat.dtype == tf.complex128
         expected = np.array([[0, 0.1], [0.1, 0.0]], dtype="complex128")
         assert qml.math.allclose(mat, expected)
+        assert s_prod.op.data[0].dtype == coeff.dtype  # coeff not modified by calling the matrix
 
 
 class TestSparseMatrix:

--- a/tests/ops/op_math/test_sprod.py
+++ b/tests/ops/op_math/test_sprod.py
@@ -506,7 +506,17 @@ class TestMatrix:
         assert mat.dtype == tf.complex128
         expected = np.array([[0, 0.1], [0.1, 0.0]], dtype="complex128")
         assert qml.math.allclose(mat, expected)
-        assert s_prod.op.data[0].dtype == coeff.dtype  # coeff not modified by calling the matrix
+        assert sprod_op.data[0].dtype == coeff.dtype  # coeff not modified by calling the matrix
+
+        op = qml.PauliY(0)
+
+        sprod_op = SProd(coeff, op)
+        mat = sprod_op.matrix()
+
+        assert mat.dtype == tf.complex128
+        expected = np.array([[0, -0.1j], [0.1j, 0.0]], dtype="complex128")
+        assert qml.math.allclose(mat, expected)
+        assert sprod_op.data[0].dtype == coeff.dtype  # coeff not modified by calling the matrix
 
 
 class TestSparseMatrix:

--- a/tests/ops/op_math/test_sprod.py
+++ b/tests/ops/op_math/test_sprod.py
@@ -492,6 +492,21 @@ class TestMatrix:
         assert mat.dtype == true_mat.dtype
         assert np.allclose(mat, true_mat)
 
+    @pytest.mark.tf
+    def test_tf_matrix_type_casting(self):
+        """Test that types for the matrix are always converted to complex128 and parameters aren't truncated."""
+        import tensorflow as tf
+
+        coeff = tf.Variable(0.1)
+        op = qml.PauliX(0)
+
+        sprod_op = SProd(coeff, op)
+        mat = sprod_op.matrix()
+
+        assert mat.dtype == tf.complex128
+        expected = np.array([[0, 0.1], [0.1, 0.0]], dtype="complex128")
+        assert qml.math.allclose(mat, expected)
+
 
 class TestSparseMatrix:
     sparse_ops = (


### PR DESCRIPTION
Fixes #4248 . [sc-40236]

Basically, tensorflow will not perform type promotion when things of two different types are multiplied.  Since the matrices for `PauliX` and `PauliZ` are integers, when multiplied by anything else, the resulting matrix is integer.  So we need to do manual type promotion on *both* the scalar and the matrix, not just the scalar.

Problematic example:
```
>>> op = tf.Variable(0.1) * qml.PauliX(0)
>>> op.matrix()
<tf.Tensor: shape=(2, 2), dtype=int64, numpy=
array([[0, 0],
       [0, 0]])>
```

