### PR TITLE
Add more registered dispatches to `bind_new_parameters`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -4,9 +4,9 @@
 
 <h3>New features since last release</h3>
 
-* Added a new function `qml.ops.functions.bind_new_parameters` that creates a copy of an operator with new parameters
-  without mutating the original operator.
+* Added a new function `qml.ops.functions.bind_new_parameters` that creates a copy of an operator with new parameters without mutating the original operator.
   [(#4113)](https://github.com/PennyLaneAI/pennylane/pull/4113)
+  [(#4256)](https://github.com/PennyLaneAI/pennylane/pull/4256)
 
 * Added the `TRX` qutrit rotation operation, which allows applying an X rotation on a
   given subspace.

--- a/pennylane/ops/functions/bind_new_parameters.py
+++ b/pennylane/ops/functions/bind_new_parameters.py
@@ -53,12 +53,6 @@ def bind_new_parameters(op: Operator, params: Sequence[TensorLike]) -> Operator:
 
 
 @bind_new_parameters.register
-def bind_new_parameters_pcphase(op: qml.PCPhase, params: Sequence[TensorLike]):
-    dim = op.hyperparameters["dimension"][0]
-    return qml.PCPhase(params[0], dim, wires=op.wires)
-
-
-@bind_new_parameters.register
 def bind_new_parameters_approx_time_evolution(
     op: qml.ApproxTimeEvolution, params: Sequence[TensorLike]
 ):

--- a/pennylane/ops/functions/bind_new_parameters.py
+++ b/pennylane/ops/functions/bind_new_parameters.py
@@ -46,7 +46,7 @@ def bind_new_parameters(op: Operator, params: Sequence[TensorLike]) -> Operator:
     """
     try:
         return op.__class__(*params, wires=op.wires, **copy.deepcopy(op.hyperparameters))
-    except:
+    except TypeError:
         new_op = copy.deepcopy(op)
         new_op.data = tuple(params)
         return new_op

--- a/pennylane/ops/functions/bind_new_parameters.py
+++ b/pennylane/ops/functions/bind_new_parameters.py
@@ -48,7 +48,7 @@ def bind_new_parameters(op: Operator, params: Sequence[TensorLike]) -> Operator:
         return op.__class__(*params, wires=op.wires, **copy.deepcopy(op.hyperparameters))
     except:
         new_op = copy.deepcopy(op)
-        op.data = tuple(params)
+        new_op.data = tuple(params)
         return new_op
 
 

--- a/pennylane/ops/functions/bind_new_parameters.py
+++ b/pennylane/ops/functions/bind_new_parameters.py
@@ -45,12 +45,11 @@ def bind_new_parameters(op: Operator, params: Sequence[TensorLike]) -> Operator:
         .Operator: New operator with updated parameters
     """
     try:
-        new_op = op.__class__(*params, wires=op.wires, **copy.deepcopy(op.hyperparameters))
+        return op.__class__(*params, wires=op.wires, **copy.deepcopy(op.hyperparameters))
     except:
         new_op = copy.deepcopy(op)
         op.data = tuple(params)
-
-    return new_op
+        return new_op
 
 
 @bind_new_parameters.register

--- a/pennylane/ops/functions/bind_new_parameters.py
+++ b/pennylane/ops/functions/bind_new_parameters.py
@@ -44,8 +44,13 @@ def bind_new_parameters(op: Operator, params: Sequence[TensorLike]) -> Operator:
     Returns:
         .Operator: New operator with updated parameters
     """
+    try:
+        new_op = op.__class__(*params, wires=op.wires, **copy.deepcopy(op.hyperparameters))
+    except:
+        new_op = copy.deepcopy(op)
+        op.data = tuple(params)
 
-    return op.__class__(*params, wires=op.wires, **copy.deepcopy(op.hyperparameters))
+    return new_op
 
 
 @bind_new_parameters.register
@@ -58,7 +63,7 @@ def bind_new_parameters_pcphase(op: qml.PCPhase, params: Sequence[TensorLike]):
 def bind_new_parameters_approx_time_evolution(
     op: qml.ApproxTimeEvolution, params: Sequence[TensorLike]
 ):
-    new_hamiltonian = qml.Hamiltonian(params[:-1], op.hyperparameters["hamiltonian"].ops)
+    new_hamiltonian = bind_new_parameters(op.hyperparameters["hamiltonian"], params[:-1])
     time = params[-1]
     n = op.hyperparameters["n"]
 
@@ -69,7 +74,7 @@ def bind_new_parameters_approx_time_evolution(
 def bind_new_parameters_commuting_evolution(
     op: qml.CommutingEvolution, params: Sequence[TensorLike]
 ):
-    new_hamiltonian = qml.Hamiltonian(params[1:], op.hyperparameters["hamiltonian"].ops)
+    new_hamiltonian = bind_new_parameters(op.hyperparameters["hamiltonian"], params[1:])
     freq = op.hyperparameters["frequencies"]
     shifts = op.hyperparameters["shifts"]
     time = params[0]

--- a/pennylane/ops/functions/bind_new_parameters.py
+++ b/pennylane/ops/functions/bind_new_parameters.py
@@ -48,6 +48,7 @@ def bind_new_parameters(op: Operator, params: Sequence[TensorLike]) -> Operator:
     try:
         return op.__class__(*params, wires=op.wires, **copy.deepcopy(op.hyperparameters))
     except TypeError:
+        # operation is doing something different with its call signature.
         new_op = copy.deepcopy(op)
         new_op.data = tuple(params)
         return new_op

--- a/pennylane/ops/functions/bind_new_parameters.py
+++ b/pennylane/ops/functions/bind_new_parameters.py
@@ -84,6 +84,7 @@ def bind_new_parameters_fermionic_double_excitation(
 
     return qml.FermionicDoubleExcitation(params[0], wires1=wires1, wires2=wires2)
 
+
 @bind_new_parameters.register
 def bind_new_parameters_identity(op: Identity, params: Sequence[TensorLike]):
     return qml.Identity(*params, wires=op.wires)

--- a/tests/ops/functions/test_bind_new_parameters.py
+++ b/tests/ops/functions/test_bind_new_parameters.py
@@ -359,7 +359,6 @@ def test_projector(op, new_params, expected_op):
     assert new_op is not op
 
 
-
 def test_unsupported_op_copy_and_set():
     """Test that trying to use `bind_new_parameters` on an operator without
     a supported dispatcher will fall back to copying the operator and setting


### PR DESCRIPTION
**Context:**
Some template operations and other operators whose `data` does not match the parameters of the class interface were causing `bind_new_parameters` to break.

**Description of the Change:**
* Added `bind_new_parameters` dispatch for `PCPhase`, `ApproxTimeEvolution`, `CommutingEvolution`, `FermionicDoubleExcitation`.

**Benefits:**
`bind_new_parameters` will not fail for the operators mentioned above.

**Possible Drawbacks:**

**Related GitHub Issues:**
