### PR TITLE
move dispatching into function to fix docstrings

### DIFF
--- a/pennylane/fermi/conversion.py
+++ b/pennylane/fermi/conversion.py
@@ -25,9 +25,8 @@ from .fermionic import FermiWord, FermiSentence
 
 
 # pylint: disable=unexpected-keyword-arg
-@singledispatch
 def jordan_wigner(
-    fermi_operator: (Union[FermiWord, FermiSentence]), *kwargs
+    fermi_operator: (Union[FermiWord, FermiSentence]), **kwargs
 ) -> Union[Operator, PauliSentence]:
     r"""Convert a fermionic operator to a qubit operator using the Jordan-Wigner mapping.
 
@@ -70,10 +69,17 @@ def jordan_wigner(
     + (0.25+0j) * X(2) @ X(3)
     + 0.25j * X(2) @ Y(3)
     """
+    return _jordan_wigner_dispatch(fermi_operator, **kwargs)
+
+
+@singledispatch
+def _jordan_wigner_dispatch(fermi_operator, **kwargs):
+    """Dispatches to appropriate function if fermi_operator is a FermiWord,
+    FermiSentence or list"""
     raise ValueError(f"fermi_operator must be a FermiWord or FermiSentence, got: {fermi_operator}")
 
 
-@jordan_wigner.register
+@_jordan_wigner_dispatch.register
 def _(fermi_operator: FermiWord, ps=False, wire_map=None):
     wires = list(fermi_operator.wires) or [0]
     identity_wire = wires[0]
@@ -106,7 +112,7 @@ def _(fermi_operator: FermiWord, ps=False, wire_map=None):
     return qubit_operator
 
 
-@jordan_wigner.register
+@_jordan_wigner_dispatch.register
 def _(fermi_operator: FermiSentence, ps=False, wire_map=None):
     wires = list(fermi_operator.wires) or [0]
     identity_wire = wires[0]
@@ -132,7 +138,7 @@ def _(fermi_operator: FermiSentence, ps=False, wire_map=None):
     return qubit_operator
 
 
-@jordan_wigner.register
+@_jordan_wigner_dispatch.register
 def _jordan_wigner_legacy(op: list, notation="physicist"):  # pylint:disable=too-many-branches
     r"""Convert a fermionic operator to a qubit operator using the Jordan-Wigner mapping.
 

--- a/pennylane/qchem/observable_hf.py
+++ b/pennylane/qchem/observable_hf.py
@@ -164,4 +164,4 @@ def jordan_wigner(op: list, notation="physicist"):  # pylint:disable=too-many-br
     >>> q # corresponds to :math:`\frac{1}{2}(I_0 - Z_0)`
     ([(0.5+0j), (-0.5+0j)], [Identity(wires=[0]), PauliZ(wires=[0])])
     """
-    return qml.fermi.jordan_wigner(op, notation)
+    return qml.fermi.jordan_wigner(op, notation=notation)


### PR DESCRIPTION
**Context:**
The call signature in docs for `jordan_wigner` is ugly due to `singledispatch`

**Description of the Change:**
Nest the dispatching inside the function so that sphinx doesn't make the call signature at the top ugly
