### PR TITLE
Fix bug in fermi op arithmetic for np.array([1, 2])[0]

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -55,6 +55,7 @@
   using `+`, `-` and `*` between 
   `FermiWord`, `FermiSentence` and `int`, `float` and `complex` objects.
   [(#4209)](https://github.com/PennyLaneAI/pennylane/pull/4209)
+  [(#4262)](https://github.com/PennyLaneAI/pennylane/pull/4262)
 
 * Added the `one_qubit_decomposition` function to provide a unified interface for all one qubit decompositions. All
   decompositions simplify the rotations angles to be between `0` and `4` pi.

--- a/pennylane/fermi/fermionic.py
+++ b/pennylane/fermi/fermionic.py
@@ -17,6 +17,8 @@ from copy import copy
 from numbers import Number
 from numpy import ndarray
 
+import pennylane as qml
+
 
 class FermiWord(dict):
     r"""Immutable dictionary used to represent a Fermi word, a product of fermionic creation and
@@ -133,7 +135,7 @@ class FermiWord(dict):
             return self_fs + FermiSentence({other: 1.0})
 
         if isinstance(other, (Number, ndarray)):
-            if isinstance(other, ndarray) and len(other) > 1:
+            if isinstance(other, ndarray) and qml.math.size(other) > 1:
                 raise ValueError(
                     f"Arithmetic Fermi operations can only accept an array of length 1, "
                     f"but received {other} of length {len(other)}"
@@ -165,7 +167,7 @@ class FermiWord(dict):
             return self_fs + other_fs
 
         if isinstance(other, (Number, ndarray)):
-            if isinstance(other, ndarray) and len(other) > 1:
+            if isinstance(other, ndarray) and qml.math.size(other) > 1:
                 raise ValueError(
                     f"Arithmetic Fermi operations can only accept an array of length 1, "
                     f"but received {other} of length {len(other)}"
@@ -177,7 +179,7 @@ class FermiWord(dict):
     def __rsub__(self, other):
         """Subtract a FermiWord to a constant, i.e. `2 - FermiWord({...})`"""
         if isinstance(other, (Number, ndarray)):
-            if isinstance(other, ndarray) and len(other) > 1:
+            if isinstance(other, ndarray) and qml.math.size(other) > 1:
                 raise ValueError(
                     f"Arithmetic Fermi operations can only accept an array of length 1, "
                     f"but received {other} of length {len(other)}"
@@ -222,7 +224,7 @@ class FermiWord(dict):
             return FermiSentence({self: 1}) * other
 
         if isinstance(other, (Number, ndarray)):
-            if isinstance(other, ndarray) and len(other) > 1:
+            if isinstance(other, ndarray) and qml.math.size(other) > 1:
                 raise ValueError(
                     f"Arithmetic Fermi operations can only accept an array of length 1, "
                     f"but received {other} of length {len(other)}"
@@ -240,7 +242,7 @@ class FermiWord(dict):
         will fail to multiply with a FermiWord"""
 
         if isinstance(other, (Number, ndarray)):
-            if isinstance(other, ndarray) and len(other) > 1:
+            if isinstance(other, ndarray) and qml.math.size(other) > 1:
                 raise ValueError(
                     f"Arithmetic Fermi operations can only accept an array of length 1, "
                     f"but received {other} of length {len(other)}"
@@ -314,7 +316,7 @@ class FermiSentence(dict):
         if isinstance(other, Number):
             other = FermiSentence({FermiWord({}): other})
         if isinstance(other, ndarray):
-            if len(other) > 1:
+            if qml.math.size(other) > 1:
                 raise ValueError(
                     f"Arithmetic Fermi operations can only accept an array of length 1, "
                     f"but received {other} of length {len(other)}"
@@ -351,7 +353,7 @@ class FermiSentence(dict):
             return self.__add__(other)
 
         if isinstance(other, ndarray):
-            if len(other) > 1:
+            if qml.math.size(other) > 1:
                 raise ValueError(
                     f"Arithmetic Fermi operations can only accept an array of length 1, "
                     f"but received {other} of length {len(other)}"
@@ -372,7 +374,7 @@ class FermiSentence(dict):
         """
 
         if isinstance(other, (Number, ndarray)):
-            if isinstance(other, ndarray) and len(other) > 1:
+            if isinstance(other, ndarray) and qml.math.size(other) > 1:
                 raise ValueError(
                     f"Arithmetic Fermi operations can only accept an array of length 1, "
                     f"but received {other} of length {len(other)}"
@@ -403,7 +405,7 @@ class FermiSentence(dict):
             return product
 
         if isinstance(other, (Number, ndarray)):
-            if isinstance(other, ndarray) and len(other) > 1:
+            if isinstance(other, ndarray) and qml.math.size(other) > 1:
                 raise ValueError(
                     f"Arithmetic Fermi operations can only accept an array of length 1, "
                     f"but received {other} of length {len(other)}"
@@ -422,7 +424,7 @@ class FermiSentence(dict):
         will fail to multiply with a FermiSentence"""
 
         if isinstance(other, (Number, ndarray)):
-            if isinstance(other, ndarray) and len(other) > 1:
+            if isinstance(other, ndarray) and qml.math.size(other) > 1:
                 raise ValueError(
                     f"Arithmetic Fermi operations can only accept an array of length 1, "
                     f"but received {other} of length {len(other)}"

--- a/tests/fermi/test_fermionic.py
+++ b/tests/fermi/test_fermionic.py
@@ -192,6 +192,7 @@ class TestFermiWordArithmetic:
         (fw2, 2j, FermiSentence({fw2: 2j})),  # complex
         (fw2, np.array([2]), FermiSentence({fw2: 2})),  # numpy array
         (fw1, pnp.array([2]), FermiSentence({fw1: 2})),  # pennylane numpy array
+        (fw1, pnp.array([2, 2])[0], FermiSentence({fw1: 2})),  # pennylane tensor with no length
     )
 
     @pytest.mark.parametrize("fw, number, result", WORDS_AND_NUMBERS_MUL)
@@ -282,6 +283,11 @@ class TestFermiWordArithmetic:
         (fw3, (1 + 3j), FermiSentence({fw3: 1, fw4: (1 + 3j)})),  # complex
         (fw1, np.array([5]), FermiSentence({fw1: 1, fw4: 5})),  # numpy array
         (fw2, pnp.array([2.8]), FermiSentence({fw2: 1, fw4: 2.8})),  # pennylane numpy array
+        (
+            fw1,
+            pnp.array([2, 2])[0],
+            FermiSentence({fw1: 1, fw4: 2}),
+        ),  # pennylane tensor with no length
         (fw4, 2, FermiSentence({fw4: 3})),  # FermiWord is Identity
     ]
 
@@ -345,6 +351,11 @@ class TestFermiWordArithmetic:
         (fw3, (1 + 3j), FermiSentence({fw3: 1, fw4: -(1 + 3j)})),  # complex
         (fw1, np.array([5]), FermiSentence({fw1: 1, fw4: -5})),  # numpy array
         (fw2, pnp.array([2.8]), FermiSentence({fw2: 1, fw4: -2.8})),  # pennylane numpy array
+        (
+            fw1,
+            pnp.array([2, 2])[0],
+            FermiSentence({fw1: 1, fw4: -2}),
+        ),  # pennylane tensor with no length
         (fw4, 2, FermiSentence({fw4: -1})),  # FermiWord is Identity
     ]
 
@@ -366,6 +377,11 @@ class TestFermiWordArithmetic:
         (fw3, (1 + 3j), FermiSentence({fw3: -1, fw4: (1 + 3j)})),  # complex
         (fw1, np.array([5]), FermiSentence({fw1: -1, fw4: 5})),  # numpy array
         (fw2, pnp.array([2.8]), FermiSentence({fw2: -1, fw4: 2.8})),  # pennylane numpy array
+        (
+            fw1,
+            pnp.array([2, 2])[0],
+            FermiSentence({fw1: -1, fw4: 2}),
+        ),  # pennylane tensor with no length
         (fw4, 2, FermiSentence({fw4: 1})),  # FermiWord is Identity
     ]
 
@@ -665,6 +681,11 @@ class TestFermiSentenceArithmetic:
             pnp.array([2]),
             FermiSentence({fw1: 1.23 * 2, fw2: 4j * 2, fw3: -0.5 * 2}),
         ),  # pennylane numpy array
+        (
+            fs1,
+            pnp.array([2, 2])[0],
+            FermiSentence({fw1: 1.23 * 2, fw2: 4j * 2, fw3: -0.5 * 2}),
+        ),  # pennylane tensor with no length
     )
 
     @pytest.mark.parametrize("fs, number, result", SENTENCES_AND_NUMBERS_MUL)
@@ -736,6 +757,11 @@ class TestFermiSentenceArithmetic:
             pnp.array([3]),
             FermiSentence({fw1: 1.2, fw3: 3j, fw4: 3}),
         ),  # pennylane numpy array
+        (
+            FermiSentence({fw1: 1.2, fw3: 3j}),
+            pnp.array([3, 0])[0],
+            FermiSentence({fw1: 1.2, fw3: 3j, fw4: 3}),
+        ),  # pennylane tensor with no length
     ]
 
     @pytest.mark.parametrize("s, c, res", SENTENCES_AND_CONSTANTS_ADD)
@@ -803,6 +829,11 @@ class TestFermiSentenceArithmetic:
             pnp.array([3]),
             FermiSentence({fw1: 1.2, fw3: 3j, fw4: -3}),
         ),  # pennylane numpy array
+        (
+            FermiSentence({fw1: 1.2, fw3: 3j}),
+            pnp.array([3, 2])[0],
+            FermiSentence({fw1: 1.2, fw3: 3j, fw4: -3}),
+        ),  # pennylane tensor with no len
     )
 
     @pytest.mark.parametrize("fs, c, result", SENTENCE_MINUS_CONSTANT)
@@ -834,6 +865,11 @@ class TestFermiSentenceArithmetic:
             pnp.array([3]),
             FermiSentence({fw1: -1.2, fw3: -3j, fw4: 3}),
         ),  # pennylane numpy array
+        (
+            FermiSentence({fw1: 1.2, fw3: 3j}),
+            pnp.array([3, 3])[0],
+            FermiSentence({fw1: -1.2, fw3: -3j, fw4: 3}),
+        ),  # pennylane tensor with to len
     )
 
     @pytest.mark.parametrize("fs, c, result", CONSTANT_MINUS_SENTENCE)


### PR DESCRIPTION
**Context:**
This should work in principal:
```
k = np.array([2.0, 3.0])
k[0] * FermiC(1)
```
but if its a `pennylane.numpy` array it raises an error at `len(k[0])`

**Description of the Change:**

Use `qml.math.size` instead of `len`
