### PR TITLE
Documentation fixes to `is_pauli_word`, `transform`, and `one_qubit_decomposition`

### DIFF
--- a/pennylane/pauli/utils.py
+++ b/pennylane/pauli/utils.py
@@ -51,8 +51,7 @@ def _wire_map_from_pauli_pair(pauli_word_1, pauli_word_2):
     return {label: i for i, label in enumerate(wire_labels)}
 
 
-@singledispatch
-def is_pauli_word(observable):  # pylint:disable=unused-argument
+def is_pauli_word(observable):
     """
     Checks if an observable instance consists only of Pauli and Identity Operators.
 
@@ -93,36 +92,45 @@ def is_pauli_word(observable):  # pylint:disable=unused-argument
     >>> is_pauli_word(4 * qml.PauliX(0) @ qml.PauliZ(0))
     True
     """
+    return _is_pauli_word(observable)
+
+
+@singledispatch
+def _is_pauli_word(observable):  # pylint:disable=unused-argument
+    """
+    Private implementation of is_pauli_word, to prevent all of the
+    registered functions from appearing in the Sphinx docs.
+    """
     return False
 
 
-@is_pauli_word.register(PauliX)
-@is_pauli_word.register(PauliY)
-@is_pauli_word.register(PauliZ)
-@is_pauli_word.register(Identity)
+@_is_pauli_word.register(PauliX)
+@_is_pauli_word.register(PauliY)
+@_is_pauli_word.register(PauliZ)
+@_is_pauli_word.register(Identity)
 def _is_pw_pauli(
     observable: Union[PauliX, PauliY, PauliZ, Identity]
 ):  # pylint:disable=unused-argument
     return True
 
 
-@is_pauli_word.register
+@_is_pauli_word.register
 def _is_pw_tensor(observable: Tensor):
     pauli_word_names = ["Identity", "PauliX", "PauliY", "PauliZ"]
     return set(observable.name).issubset(pauli_word_names)
 
 
-@is_pauli_word.register
+@_is_pauli_word.register
 def _is_pw_ham(observable: Hamiltonian):
     return False if len(observable.ops) != 1 else is_pauli_word(observable.ops[0])
 
 
-@is_pauli_word.register
+@_is_pauli_word.register
 def _is_pw_prod(observable: Prod):
     return all(is_pauli_word(op) for op in observable)
 
 
-@is_pauli_word.register
+@_is_pauli_word.register
 def _is_pw_sprod(observable: SProd):
     return is_pauli_word(observable.base)
 

--- a/pennylane/transforms/core/transform.py
+++ b/pennylane/transforms/core/transform.py
@@ -58,9 +58,9 @@ def transform(quantum_transform, expand_transform=None, classical_cotransform=No
 
             return [tape1, tape2], post_processing_fn
 
-    Of course, we want to be able to apply this transform on `qfunc` and `qnodes`. That's where the `transform` function
+    Of course, we want to be able to apply this transform on ``qfunc`` and ``qnodes``. That's where the ``transform`` function
     comes into play. This function validates the signature of your quantum transform and dispatches it on the different
-    object. Let's define a circuit as a qfunc and as qnode.
+    object. Let's define a circuit as a qfunc and as a qnode.
 
         .. code-block:: python
 
@@ -85,7 +85,7 @@ def transform(quantum_transform, expand_transform=None, classical_cotransform=No
 
     Now you can use the dispatched transform directly on qfunc and qnodes.
 
-    For QNodes, the dispatched transform populates the `TransformProgram` of your QNode. The transform and its
+    For QNodes, the dispatched transform populates the ``TransformProgram`` of your QNode. The transform and its
     processing function are applied in the execution.
 
     >>> transformed_qnode = dispatched_transform(qfunc_circuit)

--- a/pennylane/transforms/decompositions/single_qubit_unitary.py
+++ b/pennylane/transforms/decompositions/single_qubit_unitary.py
@@ -417,10 +417,10 @@ def _zxz_decomposition(U, wire, return_global_phase=False):
 def one_qubit_decomposition(U, wire, rotations="ZYZ", return_global_phase=False):
     r"""Decompose a one-qubit unitary :math:`U` in terms of elementary operations. (batched operation)
 
-    Any one qubit unitary operation can be implemented upto a global phase by composing RX, RY,
+    Any one qubit unitary operation can be implemented up to a global phase by composing RX, RY,
     and RZ gates.
 
-    Currently supported values for `rotations` are "ZYZ", "XYX", and "ZXZ".
+    Currently supported values for ``rotations`` are "ZYZ", "XYX", and "ZXZ".
 
     Args:
         U (tensor): A :math:`2 \times 2` unitary matrix.
@@ -431,7 +431,7 @@ def one_qubit_decomposition(U, wire, rotations="ZYZ", return_global_phase=False)
 
     Returns:
         list[Operation]: Returns a list of gates which when applied in the order of appearance in
-        the list is equivalent to the unitary :math:`U` up to a global phase. If `return_global_phase=True`,
+        the list is equivalent to the unitary :math:`U` up to a global phase. If ``return_global_phase=True``,
         the global phase is returned as the last element of the list.
 
     **Example**


### PR DESCRIPTION
Minor documentation changes to these 3 functions.

For `is_pauli_word`, the usage of `singledispatch` caused the function to appear multiple times in the documentation builds:
![screenshot](https://github.com/PennyLaneAI/pennylane/assets/34989448/8b00c653-68e4-4f4d-a6c0-0b3661546b9b)

To fix this, the `singledispatch` decorator was moved to decorate a private function instead. This function is called from `is_pauli_word`.
