### PR TITLE
Update object paths in `fermi` docs

### DIFF
--- a/doc/code/qml_fermi.rst
+++ b/doc/code/qml_fermi.rst
@@ -6,12 +6,29 @@ Overview
 
 This module contains functions and classes for creating and manipulating fermionic operators.
 
-.. currentmodule:: pennylane.fermi
+Functions
+~~~~~~~~~
 
-.. automodapi:: pennylane.fermi
-    :no-heading:
-    :no-main-docstr:
-    :no-inherited-members:
+.. currentmodule:: pennylane
+
+.. autosummary::
+
+    jordan_wigner
+    ~fermi.string_to_fermi_word
+
+
+Classes
+~~~~~~~
+
+.. currentmodule:: pennylane
+
+.. autosummary::
+
+    FermiA
+    FermiC
+    ~fermi.FermiSentence
+    ~fermi.FermiWord
+
 
 FermiC and FermiA
 -----------------

--- a/doc/code/qml_fermi.rst
+++ b/doc/code/qml_fermi.rst
@@ -12,8 +12,9 @@ Functions
 .. currentmodule:: pennylane
 
 .. autosummary::
+    :toctree: api
 
-    jordan_wigner
+    ~jordan_wigner
     ~fermi.string_to_fermi_word
 
 
@@ -23,6 +24,7 @@ Classes
 .. currentmodule:: pennylane
 
 .. autosummary::
+    :toctree: api
 
     FermiA
     FermiC


### PR DESCRIPTION
**Context:**
The `FermiA` and `FermiC` classes and the `jordan_wigner` function are importable with both `qml.<name>` and `qml.fermi.<name>`. These paths are also reproduces in the documentation pages such that accessing these objects from the `qml` and `qml.fermi` API, links the user to  `qml.<name>` and `qml.fermi.<name>` pages, respectively. This PR modifies the docs such that clicking on the object links in both of the APIs links the user to the  `qml.<name>` documentation page.  

**Description of the Change:**
The `qml_fermi.rst` file is modified to link  `FermiA` and `FermiC` classes and the `jordan_wigner` function to the `qml` documentation pages. 

**Benefits:**
Provides a unified documentation page for those objects that are importable at both high and low levels. 

**Possible Drawbacks:**

**Related GitHub Issues:**
