### PR TITLE
Rename `string_to_fermi_word` to `from_string`

### DIFF
--- a/doc/releases/changelog-0.31.0.md
+++ b/doc/releases/changelog-0.31.0.md
@@ -41,7 +41,7 @@
   `qml.FermiC(0)` and `qml.FermiA(3)`.
   [(#4200)](https://github.com/PennyLaneAI/pennylane/pull/4200)
 
-* Added the function `string_to_fermi_word` to create a `FermiWord` object from a compact string
+* Added the function `from_string` to create a `FermiWord` object from a compact string
   representation.
   [(#4229)](https://github.com/PennyLaneAI/pennylane/pull/4229)
 

--- a/pennylane/fermi/__init__.py
+++ b/pennylane/fermi/__init__.py
@@ -16,4 +16,4 @@ fermionic operators. """
 
 
 from .conversion import jordan_wigner
-from .fermionic import FermiWord, FermiC, FermiA, FermiSentence, string_to_fermi_word
+from .fermionic import FermiWord, FermiC, FermiA, FermiSentence, from_string

--- a/pennylane/fermi/fermionic.py
+++ b/pennylane/fermi/fermionic.py
@@ -462,7 +462,7 @@ class FermiSentence(dict):
                 del self[fw]
 
 
-def string_to_fermi_word(fermi_string):
+def from_string(fermi_string):
     r"""Return a fermionic operator object from its string representation.
 
     The string representation is a compact format that uses the orbital index and ``'+'`` or ``'-'``
@@ -480,17 +480,17 @@ def string_to_fermi_word(fermi_string):
 
     **Example**
 
-    >>> string_to_fermi_word('0+ 1- 0+ 1-')
+    >>> from_string('0+ 1- 0+ 1-')
     a⁺(0) a(1) a⁺(0) a(1)
 
-    >>> string_to_fermi_word('0+ 1 0+ 1')
+    >>> from_string('0+ 1 0+ 1')
     a⁺(0) a(1) a⁺(0) a(1)
 
-    >>> string_to_fermi_word('0^ 1 0^ 1')
+    >>> from_string('0^ 1 0^ 1')
     a⁺(0) a(1) a⁺(0) a(1)
 
     >>> op1 = FermiC(0) * FermiA(1) * FermiC(2) * FermiA(3)
-    >>> op2 = string_to_fermi_word('0+ 1- 2+ 3-')
+    >>> op2 = from_string('0+ 1- 2+ 3-')
     >>> op1 == op2
     True
     """

--- a/tests/fermi/test_fermionic.py
+++ b/tests/fermi/test_fermionic.py
@@ -19,7 +19,7 @@ import pytest
 
 
 from pennylane import numpy as pnp
-from pennylane.fermi.fermionic import FermiSentence, FermiWord, string_to_fermi_word
+from pennylane.fermi.fermionic import FermiSentence, FermiWord, from_string
 
 # pylint: disable=too-many-public-methods
 
@@ -994,8 +994,8 @@ class TestFermiSentenceArithmetic:
     )
 
     @pytest.mark.parametrize("string, result_fw", tup_fw_string)
-    def test_string_to_fermi_word(self, string, result_fw):
-        assert string_to_fermi_word(string) == result_fw
+    def test_from_string(self, string, result_fw):
+        assert from_string(string) == result_fw
 
     tup_fw_string_error = (
         "0+ a-",
@@ -1003,9 +1003,9 @@ class TestFermiSentenceArithmetic:
     )
 
     @pytest.mark.parametrize("string", tup_fw_string_error)
-    def test_string_to_fermi_word_error(self, string):
+    def test_from_string_error(self, string):
         with pytest.raises(ValueError, match="Invalid character encountered in string "):
-            string_to_fermi_word(string)  # pylint: disable=pointless-statement
+            from_string(string)  # pylint: disable=pointless-statement
 
     @pytest.mark.parametrize(
         "method_name", ("__add__", "__sub__", "__mul__", "__radd__", "__rsub__", "__rmul__")


### PR DESCRIPTION
**Context:**
The function  `string_to_fermi_word` is renamed to `from_string` for user convenience. 

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
