### PR TITLE
Various things while validating changes for 0.31

### DIFF
--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -6,7 +6,7 @@ Deprecations
 Pending deprecations
 --------------------
 
-* The `grouping_type` and `grouping_method` arguments of `qchem.molecular_hamiltonian()` are deprecated.
+* The ``grouping_type`` and ``grouping_method`` arguments of ``qchem.molecular_hamiltonian()`` are deprecated.
 
   - Deprecated in v0.31
   - Will be removed in v0.32

--- a/pennylane/qchem/convert.py
+++ b/pennylane/qchem/convert.py
@@ -332,6 +332,7 @@ def import_operator(qubit_observable, format="openfermion", wires=None, tol=1e01
     + (-0.0548) [X0 X1 Y2 Y3]
 
     If the new op-math is active, an arithmetic operator is returned instead.
+
     >>> qml.operation.enable_new_opmath()
     >>> h_pl = import_operator(h_of, format='openfermion')
     >>> print(h_pl)

--- a/pennylane/qchem/observable_hf.py
+++ b/pennylane/qchem/observable_hf.py
@@ -91,7 +91,7 @@ def qubit_observable(o_ferm, cutoff=1.0e-12):
         cutoff (float): cutoff value for discarding the negligible terms
 
     Returns:
-        (~.Operator): Simplified PennyLane Hamiltonian
+        (Operator): Simplified PennyLane Hamiltonian
 
     **Example**
 

--- a/pennylane/qchem/tapering.py
+++ b/pennylane/qchem/tapering.py
@@ -133,10 +133,10 @@ def symmetry_generators(h):
     in the Hamiltonian as given in `arXiv:1910.14644 <https://arxiv.org/abs/1910.14644>`_.
 
     Args:
-        h (~.Operator): Hamiltonian for which symmetries are to be generated to perform tapering
+        h (Operator): Hamiltonian for which symmetries are to be generated to perform tapering
 
     Returns:
-        list[~.Operator]: list of generators of symmetries, :math:`\tau`'s, for the Hamiltonian
+        list[Operator]: list of generators of symmetries, :math:`\tau`'s, for the Hamiltonian
 
     **Example**
 
@@ -188,7 +188,7 @@ def paulix_ops(generators, num_qubits):  # pylint: disable=protected-access
     These are required to obtain the Clifford operators :math:`U` for the Hamiltonian :math:`H`.
 
     Args:
-        generators (list[~.Operator]): list of generators of symmetries, :math:`\tau`'s,
+        generators (list[Operator]): list of generators of symmetries, :math:`\tau`'s,
             for the Hamiltonian
         num_qubits (int): number of wires required to define the Hamiltonian
 
@@ -232,11 +232,11 @@ def clifford(generators, paulixops):
     :math:`k` Pauli-X operators.
 
     Args:
-        generators (list[~.Operator]): generators expressed as PennyLane Hamiltonians
-        paulixops (list[~.Operation]): list of single-qubit Pauli-X operators
+        generators (list[Operator]): generators expressed as PennyLane Hamiltonians
+        paulixops (list[Operation]): list of single-qubit Pauli-X operators
 
     Returns:
-        (~.Operator): Clifford operator expressed as a PennyLane operator
+        (Operator): Clifford operator expressed as a PennyLane operator
 
     **Example**
 
@@ -285,12 +285,12 @@ def _taper_pauli_sentence(ps_h, generators, paulixops, paulix_sector):
 
     Args:
         ps_h (~.PauliSentence): The Hamiltonian to be tapered
-        generators (list[~.Operator]): generators expressed as PennyLane Hamiltonians
+        generators (list[Operator]): generators expressed as PennyLane Hamiltonians
         paulixops (list[~.PauliX]): list of single-qubit Pauli-X operators
         paulix_sector (list[int]): eigenvalues of the Pauli-X operators.
 
     Returns:
-        (~.Operator): the tapered Hamiltonian
+        (Operator): the tapered Hamiltonian
     """
 
     u = clifford(generators, paulixops)
@@ -357,13 +357,13 @@ def taper(h, generators, paulixops, paulix_sector):
     eigenvalues is defined as the Pauli sector.
 
     Args:
-        h (~.Operator): Hamiltonian as a PennyLane operator
-        generators (list[~.Operator]): generators expressed as PennyLane Hamiltonians
+        h (Operator): Hamiltonian as a PennyLane operator
+        generators (list[Operator]): generators expressed as PennyLane Hamiltonians
         paulixops (list[Operation]): list of single-qubit Pauli-X operators
         paulix_sector (list[int]): eigenvalues of the Pauli-X operators
 
     Returns:
-        (~.Operator): the tapered Hamiltonian
+        (Operator): the tapered Hamiltonian
 
     **Example**
 
@@ -402,8 +402,8 @@ def optimal_sector(qubit_op, generators, active_electrons):
     act and the wires that correspond to occupied orbitals in the HF state.
 
     Args:
-        qubit_op (~.Operator): Hamiltonian for which symmetries are being generated
-        generators (list[~.Operator]): list of symmetry generators for the Hamiltonian
+        qubit_op (Operator): Hamiltonian for which symmetries are being generated
+        generators (list[Operator]): list of symmetry generators for the Hamiltonian
         active_electrons (int): The number of active electrons in the system
 
     Returns:
@@ -455,7 +455,7 @@ def taper_hf(generators, paulixops, paulix_sector, num_electrons, num_wires):
     and leaving the rest in state :math:`|0\rangle`.
 
     Args:
-        generators (list[~.Operator]): list of generators of symmetries, taus, for the Hamiltonian
+        generators (list[Operator]): list of generators of symmetries, taus, for the Hamiltonian
         paulixops (list[Operation]):  list of single-qubit Pauli-X operators
         paulix_sector (list[int]): list of eigenvalues of Pauli-X operators
         num_electrons (int): number of active electrons in the system

--- a/pennylane/transforms/qcut/cutcircuit.py
+++ b/pennylane/transforms/qcut/cutcircuit.py
@@ -119,7 +119,7 @@ def cut_circuit(
     Futhermore, the output of the cut circuit is also differentiable:
 
     >>> qml.grad(circuit)(x)
-    -0.276982865449393
+    tensor(-0.27698287, requires_grad=True)
 
     Alternatively, if the optimal wire-cut placement is unknown for an arbitrary circuit, the
     ``auto_cutter`` option can be enabled to make attempts in finding such an optimal cut. The
@@ -146,7 +146,7 @@ def cut_circuit(
     >>> circuit(x)
     0.47165198882111165
     >>> qml.grad(circuit)(x)
-    -0.276982865449393
+    tensor(-0.27698287, requires_grad=True)
 
     .. details::
         :title: Usage Details
@@ -187,7 +187,7 @@ def cut_circuit(
 
                 qml.CZ(wires=[1, 2]),
             ]
-            measurments = [qml.expval(qml.Pauli.string_to_pauli_word("ZZZ"))]
+            measurements = [qml.expval(qml.pauli.string_to_pauli_word("ZZZ"))]
             tape = qml.tape.QuantumTape(ops, measurements)
 
         >>> print(qml.drawer.tape_text(tape))
@@ -223,12 +223,12 @@ def cut_circuit(
                 qml.CZ(wires=[1, 2]),
             ]
             measurements = [qml.expval(qml.pauli.string_to_pauli_word("ZZZ"))]
-            tape = qml.tape.QuantumTape(ops, measurements)
+            uncut_tape = qml.tape.QuantumTape(ops, measurements)
 
         >>> cut_graph = qml.transforms.qcut.find_and_place_cuts(
-                graph = qml.transforms.qcut.tape_to_graph(uncut_tape),
-                cut_strategy = qml.transforms.qcut.CutStrategy(max_free_wires=2),
-            )
+        ...     graph = qml.transforms.qcut.tape_to_graph(uncut_tape),
+        ...     cut_strategy = qml.transforms.qcut.CutStrategy(max_free_wires=2),
+        ... )
         >>> print(qml.transforms.qcut.graph_to_tape(cut_graph).draw())
         0: ──RX─╭●──RY────┤ ╭<Z@Z@Z>
         1: ──RY─╰Z──//─╭●─┤ ├<Z@Z@Z>

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Setup file for package installation."""
+
 from setuptools import setup, find_packages
 
 with open("pennylane/_version.py") as f:
@@ -37,7 +39,7 @@ info = {
     "version": version,
     "maintainer": "Xanadu Inc.",
     "maintainer_email": "software@xanadu.ai",
-    "url": "https://github.com/XanaduAI/pennylane",
+    "url": "https://github.com/PennyLaneAI/pennylane",
     "license": "Apache License 2.0",
     "packages": find_packages(where="."),
     "entry_points": {


### PR DESCRIPTION
- The URL in setup.py is old (and because I changed it, the pylint pre-commit hook made me add a docstring)
- deprecations.rst needs ReST code-blocks, not markdown
- qchem/convert.py had an example that didn't render because it needed a new line
- the rest of the QChem changes are just to fix links to other classes in public functions
- The QCut PR itself was fine, but got me thinking I should validate the existing QCut doc. minor touch-ups there