### PR TITLE
Add graphviz apt

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,6 +9,8 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.8"
+  apt_packages:
+    - graphviz
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:


### PR DESCRIPTION
The class inheritance diagram [stopped rendering](https://docs.pennylane.ai/en/latest/code/qml_tape.html#class-inheritance-diagram) for the tape module ever since changing the base image for the RTD builder (#4086, which was needed for a bugfix re: SSL packages being installed). readthedocs/readthedocs.org#8800 suggests that this should fix it