### PR TITLE
Make links to qml.eigvals and the eigvals method appear distinctly.

### DIFF
--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -808,7 +808,7 @@ class Operator(abc.ABC):
 
         Otherwise, no particular order for the eigenvalues is guaranteed.
 
-        .. seealso:: :meth:`~.eigvals` and :func:`pennylane.eigvals`
+        .. seealso:: :meth:`Operator.eigvals() <.eigvals>` and :func:`qml.eigvals() <pennylane.eigvals>`
 
         Args:
             *params (list): trainable parameters of the operator, as stored in the ``parameters`` attribute

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -808,7 +808,7 @@ class Operator(abc.ABC):
 
         Otherwise, no particular order for the eigenvalues is guaranteed.
 
-        .. seealso:: :meth:`~.Operator.eigvals` and :func:`~.eigvals`
+        .. seealso:: :meth:`~.eigvals` and :func:`pennylane.eigvals`
 
         Args:
             *params (list): trainable parameters of the operator, as stored in the ``parameters`` attribute


### PR DESCRIPTION
**Context:**
Currently the `compute_eigvals` method in operators contains the note "See also eigvals and eigvals." (e.g. [here](https://docs.pennylane.ai/en/stable/code/api/pennylane.U3.html#pennylane.U3.compute_eigvals))

**Description of the Change:**
Link one to the method `eigvals` of the respective class and the other one directly to `pennylane.eigvals()`.
