### PR TITLE
raise warning if control indicators are hidden in drawer

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -15,6 +15,7 @@
 <h3>Bug fixes 🐛</h3>
 
 * Raise a warning if control indicators are hidden when calling `qml.draw_mpl`
+  [(#4295)](https://github.com/PennyLaneAI/pennylane/pull/4295)
 
 <h3>Contributors ✍️</h3>
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -14,6 +14,10 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Raise a warning if control indicators are hidden when calling `qml.draw_mpl`
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):
+
+Matthew Silverman

--- a/pennylane/drawer/mpldrawer.py
+++ b/pennylane/drawer/mpldrawer.py
@@ -594,7 +594,11 @@ class MPLDrawer:
 
         min_target, max_target = min(wires_target), max(wires_target)
         if min_target < min(wires_ctrl) < max_target or min_target < max(wires_ctrl) < max_target:
-            warnings.warn("Some control indicators are hidden behind an operator", UserWarning)
+            warnings.warn(
+                "Some control indicators are hidden behind an operator. Consider "
+                "re-ordering your circuit wires to ensure all control indicators are visible.",
+                UserWarning,
+            )
 
         line = plt.Line2D((layer, layer), (min_wire, max_wire), **options)
         self._ax.add_line(line)

--- a/pennylane/drawer/mpldrawer.py
+++ b/pennylane/drawer/mpldrawer.py
@@ -594,10 +594,7 @@ class MPLDrawer:
 
         if len(wires_target) > 1:
             min_target, max_target = min(wires_target), max(wires_target)
-            if (
-                min_target < min(wires_ctrl) < max_target
-                or min_target < max(wires_ctrl) < max_target
-            ):
+            if any(min_target < w < max_target for w in wires_ctrl):
                 warnings.warn(
                     "Some control indicators are hidden behind an operator. Consider re-ordering "
                     "your circuit wires to ensure all control indicators are visible.",

--- a/pennylane/drawer/mpldrawer.py
+++ b/pennylane/drawer/mpldrawer.py
@@ -15,6 +15,7 @@
 This module contains the MPLDrawer class for creating circuit diagrams with matplotlib
 """
 from collections.abc import Iterable
+import warnings
 
 has_mpl = True
 try:
@@ -590,6 +591,10 @@ class MPLDrawer:
         wires_all = wires_ctrl + wires_target
         min_wire = min(wires_all)
         max_wire = max(wires_all)
+
+        min_target, max_target = min(wires_target), max(wires_target)
+        if min_target < min(wires_ctrl) < max_target or min_target < max(wires_ctrl) < max_target:
+            warnings.warn("Some control indicators are hidden behind an operator", UserWarning)
 
         line = plt.Line2D((layer, layer), (min_wire, max_wire), **options)
         self._ax.add_line(line)

--- a/pennylane/drawer/mpldrawer.py
+++ b/pennylane/drawer/mpldrawer.py
@@ -592,13 +592,17 @@ class MPLDrawer:
         min_wire = min(wires_all)
         max_wire = max(wires_all)
 
-        min_target, max_target = min(wires_target), max(wires_target)
-        if min_target < min(wires_ctrl) < max_target or min_target < max(wires_ctrl) < max_target:
-            warnings.warn(
-                "Some control indicators are hidden behind an operator. Consider "
-                "re-ordering your circuit wires to ensure all control indicators are visible.",
-                UserWarning,
-            )
+        if len(wires_target) > 1:
+            min_target, max_target = min(wires_target), max(wires_target)
+            if (
+                min_target < min(wires_ctrl) < max_target
+                or min_target < max(wires_ctrl) < max_target
+            ):
+                warnings.warn(
+                    "Some control indicators are hidden behind an operator. Consider re-ordering "
+                    "your circuit wires to ensure all control indicators are visible.",
+                    UserWarning,
+                )
 
         line = plt.Line2D((layer, layer), (min_wire, max_wire), **options)
         self._ax.add_line(line)

--- a/tests/drawer/test_mpldrawer.py
+++ b/tests/drawer/test_mpldrawer.py
@@ -25,6 +25,7 @@ plt = pytest.importorskip("matplotlib.pyplot")
 
 from matplotlib.colors import to_rgba
 from matplotlib.patches import FancyArrow
+import warnings
 
 from pennylane.drawer import MPLDrawer
 from pennylane.math import allclose
@@ -428,6 +429,27 @@ class TestCTRL:
         assert circle.width == 0.2
         assert circle.center == (0, 0)
         plt.close()
+
+    @pytest.mark.parametrize(
+        "control_wires,target_wires",
+        [
+            ((1,), (0, 2)),
+            ((0, 2), (1, 3)),
+            ((1, 3), (0, 2)),
+        ],
+    )
+    def test_ctrl_raises_warning_with_overlap(self, control_wires, target_wires):
+        """Tests that a warning is raised if some control indicators are not visible."""
+        drawer = MPLDrawer(1, 4)
+        with pytest.warns(UserWarning, match="control indicators are hidden behind an operator"):
+            drawer.ctrl(0, control_wires, target_wires)
+
+    @pytest.mark.parametrize("control_wires,target_wires", [((0,), (1, 2)), ((2,), (0, 1))])
+    def test_ctrl_no_warning_without_overlap(self, control_wires, target_wires):
+        drawer = MPLDrawer(1, 3)
+        with warnings.catch_warnings(record=True) as w:
+            drawer.ctrl(0, control_wires, target_wires)
+        assert len(w) == 0
 
     def test_target_x(self):
         """Tests hidden target_x drawing method"""

--- a/tests/drawer/test_mpldrawer.py
+++ b/tests/drawer/test_mpldrawer.py
@@ -19,13 +19,13 @@ page in the developement guide.
 """
 # pylint: disable=protected-access,wrong-import-position
 
+import warnings
 import pytest
 
 plt = pytest.importorskip("matplotlib.pyplot")
 
 from matplotlib.colors import to_rgba
 from matplotlib.patches import FancyArrow
-import warnings
 
 from pennylane.drawer import MPLDrawer
 from pennylane.math import allclose

--- a/tests/drawer/test_mpldrawer.py
+++ b/tests/drawer/test_mpldrawer.py
@@ -436,6 +436,7 @@ class TestCTRL:
             ((1,), (0, 2)),
             ((0, 2), (1, 3)),
             ((1, 3), (0, 2)),
+            ((0, 2, 4), (1, 3)),
         ],
     )
     def test_ctrl_raises_warning_with_overlap(self, control_wires, target_wires):


### PR DESCRIPTION
**Context:**
While working on `MPLDrawer.cond`, I realized that the the drawing of controlled ops will hide control indicators if they are between target wires.

**Description of the Change:**
Raise a warning if some control indicators are not visible in `draw_mpl`

**Benefits:**
The user will not have to wonder why their circuit drawing isn't identical to their circuit

**Possible Drawbacks:**
The circuit drawing is still incorrect

**Related GitHub Issues:**
Fixes #4221 