### PR TITLE
remove duplicate controlled operation entries

### DIFF
--- a/pennylane/ops/op_math/__init__.py
+++ b/pennylane/ops/op_math/__init__.py
@@ -54,6 +54,8 @@ Symbolic Classes
 Controlled Operator Classes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. currentmodule:: pennylane
+
 .. autosummary::
     :toctree: api
 


### PR DESCRIPTION
In the current docs build, the controlled operations `qml.CY`, `qml.CZ` and `qml.ControlledQubitUnitary` have duplicate entries: one for `qml` and one for `qml.ops.op_math`.

This change removes the second one. This way, the doc links in the qml/ops/op_math point to the unique `qml.` entry.
