### PR TITLE
ML layers docstring typo

### DIFF
--- a/pennylane/qnn/keras.py
+++ b/pennylane/qnn/keras.py
@@ -34,7 +34,7 @@ except ImportError:
 
 
 class KerasLayer(Layer):
-    """Converts a :func:`~.QNode` to a Keras
+    """Converts a :class:`~.QNode` to a Keras
     `Layer <https://www.tensorflow.org/api_docs/python/tf/keras/layers/Layer>`__.
 
     The result can be used within the Keras

--- a/pennylane/qnn/torch.py
+++ b/pennylane/qnn/torch.py
@@ -37,7 +37,7 @@ except ImportError:
 
 
 class TorchLayer(Module):
-    r"""Converts a :func:`~.QNode` to a Torch layer.
+    r"""Converts a :class:`~.QNode` to a Torch layer.
 
     The result can be used within the ``torch.nn``
     `Sequential <https://pytorch.org/docs/stable/nn.html#sequential>`__ or


### PR DESCRIPTION
The docstring for `TorchLayer` and `KerasLayer` classes currently refer to ```func:`~.Qnode` ```, while actually referring to the class.