### PR TITLE
bump lightning to 0.31 in setup.py, pin scipy to [1.8,1.10]

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -10,7 +10,7 @@ m2r2
 numpy
 pygments-github-lexers
 semantic_version==2.10
-scipy
+scipy>=1.8,<=1.10
 docutils==0.16
 sphinx==3.5; python_version < "3.10"
 sphinx==4.2; python_version == "3.10"

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,7 +1,7 @@
 --find-links https://download.pytorch.org/whl/torch_stable.html
 pip
 appdirs
-autograd>=1.4,<=1.5
+autograd<=1.5
 autoray
 jax==0.4.10
 jaxlib==0.4.10

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -10,7 +10,7 @@ m2r2
 numpy
 pygments-github-lexers
 semantic_version==2.10
-scipy>=1.8,<=1.10
+scipy<=1.10
 docutils==0.16
 sphinx==3.5; python_version < "3.10"
 sphinx==4.2; python_version == "3.10"

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -10,7 +10,7 @@ m2r2
 numpy
 pygments-github-lexers
 semantic_version==2.10
-scipy>=1.8,<=1.10
+scipy
 docutils==0.16
 sphinx==3.5; python_version < "3.10"
 sphinx==4.2; python_version == "3.10"

--- a/pennylane/qchem/integrals.py
+++ b/pennylane/qchem/integrals.py
@@ -56,12 +56,15 @@ def primitive_norm(l, alpha):
     array([1.79444183])
     """
     lx, ly, lz = l
-    n = (
+    fac_x = fac2(2 * lx - 1) if lx > 0 else 1.0
+    fac_y = fac2(2 * ly - 1) if ly > 0 else 1.0
+    fac_z = fac2(2 * lz - 1) if ly > 0 else 1.0
+
+    return (
         (2 * alpha / np.pi) ** 0.75
         * (4 * alpha) ** (sum(l) / 2)
-        / qml.math.sqrt(fac2(2 * lx - 1) * fac2(2 * ly - 1) * fac2(2 * lz - 1))
+        / qml.math.sqrt(fac_x * fac_y * fac_z)
     )
-    return n
 
 
 def contracted_norm(l, alpha, a):

--- a/pennylane/qchem/integrals.py
+++ b/pennylane/qchem/integrals.py
@@ -56,15 +56,12 @@ def primitive_norm(l, alpha):
     array([1.79444183])
     """
     lx, ly, lz = l
-    fac_x = fac2(2 * lx - 1) if lx > 0 else 1.0
-    fac_y = fac2(2 * ly - 1) if ly > 0 else 1.0
-    fac_z = fac2(2 * lz - 1) if ly > 0 else 1.0
-
-    return (
+    n = (
         (2 * alpha / np.pi) ** 0.75
         * (4 * alpha) ** (sum(l) / 2)
-        / qml.math.sqrt(fac_x * fac_y * fac_z)
+        / qml.math.sqrt(fac2(2 * lx - 1) * fac2(2 * ly - 1) * fac2(2 * lz - 1))
     )
+    return n
 
 
 def contracted_norm(l, alpha, a):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy<1.24
-scipy>=1.8,<=1.10
+scipy~=1.8
 cvxpy~=1.2
 cvxopt~=1.3.0
 cachetools~=5.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy<1.24
-scipy~=1.8
+scipy>=1.8,<=1.10
 cvxpy~=1.2
 cvxopt~=1.3.0
 cachetools~=5.0.0

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ with open("pennylane/_version.py") as f:
 
 requirements = [
     "numpy<1.24",
-    "scipy",
+    "scipy>=1.8,<=1.10",
     "networkx",
     "rustworkx",
     "autograd>=1.4,<=1.5",

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ with open("pennylane/_version.py") as f:
 
 requirements = [
     "numpy<1.24",
-    "scipy>=1.8,<=1.10",
+    "scipy",
     "networkx",
     "rustworkx",
     "autograd>=1.4,<=1.5",

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ requirements = [
     "semantic-version>=2.7",
     "autoray>=0.3.1",
     "cachetools",
-    "pennylane-lightning>=0.30",
+    "pennylane-lightning>=0.31",
     "requests",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ requirements = [
     "scipy<=1.10",
     "networkx",
     "rustworkx",
-    "autograd>=1.4,<=1.5",
+    "autograd<=1.5",
     "toml",
     "appdirs",
     "semantic-version>=2.7",

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ with open("pennylane/_version.py") as f:
 
 requirements = [
     "numpy<1.24",
-    "scipy>=1.8,<=1.10",
+    "scipy<=1.10",
     "networkx",
     "rustworkx",
     "autograd>=1.4,<=1.5",


### PR DESCRIPTION
same as #4066. ~blocked until lightning is out.~ it's out

scipy needs to be pinned because they just released a new version (1.11). Collecting tests failed at [this line](https://github.com/PennyLaneAI/pennylane/blob/d6955cf1e704b8cc9a274c843c51705d097f9a0d/tests/optimize/test_adaptive.py#L27) because it called scipy's `factorial2` somewhere along the line. That function used to return 1.0 for negative values, but returns 0 in the latest scipy. We tried a forward fix (see commits), but this came with other failures, one of which being an incompatibility with cvxpy (see scipy/scipy#18749, fix PR already proposed). So, for this release, we will pin scipy.