### PR TITLE
Switch to GA4

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -80,7 +80,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "PennyLane"
-copyright = "2022, Xanadu Quantum Technologies"
+copyright = "2023, Xanadu Quantum Technologies"
 author = "Xanadu Inc."
 
 add_module_names = False
@@ -234,7 +234,7 @@ html_theme_options = {
     "extra_copyrights": [
         "TensorFlow, the TensorFlow logo, and any related marks are trademarks " "of Google Inc."
     ],
-    "google_analytics_tracking_id": "UA-130507810-1",
+    "google_analytics_tracking_id": "G-C480Z9JL0D",
 }
 
 edit_on_github_project = "PennyLaneAI/pennylane"


### PR DESCRIPTION
Google is deprecating Universal Analytics on July 1st. This PR replaces that tag with the newer GA4 tag on the PennyLane docs website.