### PR TITLE
Update `interfaces` module to use `bind_new_parameters`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -40,6 +40,10 @@
 * The experimental device interface is integrated with the `QNode` for Jax.
   [(#4323)](https://github.com/PennyLaneAI/pennylane/pull/4323)
 
+* The `QuantumScript` class now has a `bind_new_parameters` method that allows creation of
+  new `QuantumScript` objects with the provided parameters.
+  [(#4345)](https://github.com/PennyLaneAI/pennylane/pull/4345)
+
 <h3>Breaking changes 💔</h3>
 
 * The `do_queue` keyword argument in `qml.operation.Operator` has been removed. Instead of

--- a/pennylane/interfaces/jax.py
+++ b/pennylane/interfaces/jax.py
@@ -29,8 +29,7 @@ dtype = jnp.float64
 
 def _set_copy_and_unwrap_tape(t, a, unwrap=True):
     """Copy a given tape with operations and set parameters"""
-    tc = t.copy(copy_operations=True)
-    tc.set_parameters(a)
+    tc = qml.tape.qscript.bind_new_parameters_tape(t, a, t.trainable_params)
     return convert_to_numpy_parameters(tc) if unwrap else tc
 
 

--- a/pennylane/interfaces/jax.py
+++ b/pennylane/interfaces/jax.py
@@ -29,7 +29,7 @@ dtype = jnp.float64
 
 def _set_copy_and_unwrap_tape(t, a, unwrap=True):
     """Copy a given tape with operations and set parameters"""
-    tc = qml.tape.qscript.bind_new_parameters_tape(t, a, t.trainable_params)
+    tc = t.bind_new_parameters(a, t.trainable_params)
     return convert_to_numpy_parameters(tc) if unwrap else tc
 
 

--- a/pennylane/interfaces/jax_jit.py
+++ b/pennylane/interfaces/jax_jit.py
@@ -25,7 +25,6 @@ import pennylane as qml
 from pennylane.interfaces import InterfaceUnsupportedError
 from pennylane.interfaces.jax import _raise_vector_valued_fwd
 from pennylane.measurements import ProbabilityMP
-from pennylane.transforms import convert_to_numpy_parameters
 
 from .jax import set_parameters_on_copy_and_unwrap
 

--- a/pennylane/interfaces/jax_jit.py
+++ b/pennylane/interfaces/jax_jit.py
@@ -27,6 +27,8 @@ from pennylane.interfaces.jax import _raise_vector_valued_fwd
 from pennylane.measurements import ProbabilityMP
 from pennylane.transforms import convert_to_numpy_parameters
 
+from .jax import set_parameters_on_copy_and_unwrap
+
 dtype = jnp.float64
 
 
@@ -142,16 +144,6 @@ def _execute_legacy(
     _n=1,
 ):  # pylint: disable=dangerous-default-value,unused-argument
     total_params = np.sum([len(p) for p in params])
-
-    # Copy a given tape with operations and set parameters
-    def _set_copy_and_unwrap_tape(t, a, unwrap=True):
-        tc = t.copy(copy_operations=True)
-        tc.set_parameters(a)
-        return convert_to_numpy_parameters(tc) if unwrap else tc
-
-    def set_parameters_on_copy_and_unwrap(tapes, params, unwrap=True):
-        """Copy a set of tapes with operations and set parameters"""
-        return tuple(_set_copy_and_unwrap_tape(t, a, unwrap=unwrap) for t, a in zip(tapes, params))
 
     @jax.custom_vjp
     def wrapped_exec(params):

--- a/pennylane/interfaces/jax_jit_tuple.py
+++ b/pennylane/interfaces/jax_jit_tuple.py
@@ -34,7 +34,7 @@ Zero = jax.custom_derivatives.SymbolicZero
 
 def _set_copy_and_unwrap_tape(t, a, unwrap=True):
     """Copy a given tape with operations and set parameters"""
-    tc = qml.tape.qscript.bind_new_parameters_tape(t, a, list(range(len(a))))
+    tc = t.bind_new_parameters(a, list(range(len(a))))
     return convert_to_numpy_parameters(tc) if unwrap else tc
 
 

--- a/pennylane/interfaces/jax_jit_tuple.py
+++ b/pennylane/interfaces/jax_jit_tuple.py
@@ -27,14 +27,14 @@ from pennylane.interfaces.jax import _compute_jvps
 from pennylane.interfaces.jax_jit import _numeric_type_to_dtype
 from pennylane.transforms import convert_to_numpy_parameters
 
+
 dtype = jnp.float64
 Zero = jax.custom_derivatives.SymbolicZero
 
 
 def _set_copy_and_unwrap_tape(t, a, unwrap=True):
     """Copy a given tape with operations and set parameters"""
-    tc = t.copy(copy_operations=True)
-    tc.set_parameters(a, trainable_only=False)
+    tc = qml.tape.qscript.bind_new_parameters_tape(t, a, list(range(len(a))))
     return convert_to_numpy_parameters(tc) if unwrap else tc
 
 

--- a/pennylane/interfaces/tensorflow.py
+++ b/pennylane/interfaces/tensorflow.py
@@ -28,7 +28,7 @@ from pennylane.transforms import convert_to_numpy_parameters
 
 def _set_copy_and_unwrap_tape(t, a):
     """Copy a given tape with operations and set parameters"""
-    tc = qml.tape.qscript.bind_new_parameters_tape(t, a, list(range(len(a))))
+    tc = t.bind_new_parameters(a, list(range(len(a))))
     return convert_to_numpy_parameters(tc)
 
 

--- a/pennylane/interfaces/tensorflow.py
+++ b/pennylane/interfaces/tensorflow.py
@@ -28,8 +28,7 @@ from pennylane.transforms import convert_to_numpy_parameters
 
 def _set_copy_and_unwrap_tape(t, a):
     """Copy a given tape with operations and set parameters"""
-    tc = t.copy(copy_operations=True)
-    tc.set_parameters(a, trainable_only=False)
+    tc = qml.tape.qscript.bind_new_parameters_tape(t, a, list(range(len(a))))
     return convert_to_numpy_parameters(tc)
 
 

--- a/pennylane/interfaces/tensorflow_autograph.py
+++ b/pennylane/interfaces/tensorflow_autograph.py
@@ -31,19 +31,8 @@ from .tensorflow import (
     _jac_restructured,
     _res_restructured,
     _to_tensors,
+    set_parameters_on_copy_and_unwrap,
 )
-
-
-def _set_copy_and_unwrap_tape(t, a):
-    """Copy a given tape with operations and set parameters"""
-    tc = t.copy(copy_operations=True)
-    tc.set_parameters(a, trainable_only=False)
-    return convert_to_numpy_parameters(tc)
-
-
-def set_parameters_on_copy_and_unwrap(tapes, params):
-    """Copy a set of tapes with operations and set parameters"""
-    return tuple(_set_copy_and_unwrap_tape(t, a) for t, a in zip(tapes, params))
 
 
 def _flatten_nested_list(x):

--- a/pennylane/interfaces/tensorflow_autograph.py
+++ b/pennylane/interfaces/tensorflow_autograph.py
@@ -23,7 +23,6 @@ import tensorflow as tf
 
 import pennylane as qml
 from pennylane.measurements import SampleMP, StateMP
-from pennylane.transforms import convert_to_numpy_parameters
 
 from .tensorflow import (
     _compute_vjp,

--- a/pennylane/pulse/parametrized_evolution.py
+++ b/pennylane/pulse/parametrized_evolution.py
@@ -18,11 +18,13 @@
 This file contains the ``ParametrizedEvolution`` operator.
 """
 
-from typing import List, Union
+from typing import List, Union, Sequence
 import warnings
 
 import pennylane as qml
 from pennylane.operation import AnyWires, Operation
+from pennylane.typing import TensorLike
+from pennylane.ops import functions
 
 from .parametrized_hamiltonian import ParametrizedHamiltonian
 from .hardware_hamiltonian import HardwareHamiltonian
@@ -502,3 +504,16 @@ class ParametrizedEvolution(Operation):
         elif not self.hyperparameters["return_intermediate"]:
             mat = mat[-1]
         return qml.math.expand_matrix(mat, wires=self.wires, wire_order=wire_order)
+
+
+@functions.bind_new_parameters.register
+def bind_new_parameters_parametrized_evol(op: ParametrizedEvolution, params: Sequence[TensorLike]):
+    return ParametrizedEvolution(
+        op.H,
+        params=params,
+        t=op.t,
+        return_intermediate=op.hyperparameters["return_intermediate"],
+        complementary=op.hyperparameters["complementary"],
+        dense=op.dense,
+        **op.odeint_kwargs,
+    )

--- a/pennylane/pulse/parametrized_evolution.py
+++ b/pennylane/pulse/parametrized_evolution.py
@@ -507,7 +507,7 @@ class ParametrizedEvolution(Operation):
 
 
 @functions.bind_new_parameters.register
-def bind_new_parameters_parametrized_evol(op: ParametrizedEvolution, params: Sequence[TensorLike]):
+def _bind_new_parameters_parametrized_evol(op: ParametrizedEvolution, params: Sequence[TensorLike]):
     return ParametrizedEvolution(
         op.H,
         params=params,

--- a/pennylane/tape/qscript.py
+++ b/pennylane/tape/qscript.py
@@ -1430,6 +1430,8 @@ def bind_new_parameters_tape(
     Returns:
         .tape.QuantumScript: New tape with updated parameters
     """
+    # pylint: disable=no-member
+
     new_ops = []
     idx = 0
     p_idx = 0
@@ -1445,12 +1447,12 @@ def bind_new_parameters_tape(
         # determine if any parameters of the operator need to be rebinded
         if any(i + idx in indices for i in range(len(data))):
             new_params = []
-            for i in range(len(data)):
+            for i, d in enumerate(data):
                 if i + idx in indices:
                     new_params.append(params[p_idx])
                     p_idx += 1
                 else:
-                    new_params.append(data[i])
+                    new_params.append(d)
 
             if isinstance(op, Operator):
                 new_op = qml.ops.functions.bind_new_parameters(op, new_params)

--- a/pennylane/tape/qscript.py
+++ b/pennylane/tape/qscript.py
@@ -1434,6 +1434,9 @@ def bind_new_parameters_tape(
     """
     # pylint: disable=no-member
 
+    if len(params) != len(indices):
+        raise ValueError("Number of provided parameters does not match number of indices")
+
     new_ops = []
     idx = 0
     p_idx = 0
@@ -1478,3 +1481,6 @@ def bind_new_parameters_tape(
     new_tape._qfunc_output = tape._qfunc_output
 
     return new_tape
+
+
+QuantumScript.bind_new_parameters = bind_new_parameters_tape

--- a/pennylane/tape/qscript.py
+++ b/pennylane/tape/qscript.py
@@ -771,9 +771,7 @@ class QuantumScript:
         new_operations = new_ops[len(self._prep) : len(self.operations)]
         new_measurements = new_ops[len(self.operations) :]
 
-        new_tape = self.__class__(
-            new_operations, new_measurements, new_prep, shots=self.shots
-        )
+        new_tape = self.__class__(new_operations, new_measurements, new_prep, shots=self.shots)
         new_tape.trainable_params = self.trainable_params
         new_tape._qfunc_output = self._qfunc_output
 

--- a/pennylane/tape/qscript.py
+++ b/pennylane/tape/qscript.py
@@ -771,7 +771,7 @@ class QuantumScript:
         new_operations = new_ops[len(self._prep) : len(self.operations)]
         new_measurements = new_ops[len(self.operations) :]
 
-        new_tape = qml.tape.QuantumScript(
+        new_tape = self.__class__(
             new_operations, new_measurements, new_prep, shots=self.shots
         )
         new_tape.trainable_params = self.trainable_params

--- a/pennylane/tape/qscript.py
+++ b/pennylane/tape/qscript.py
@@ -1416,16 +1416,18 @@ def make_qscript(fn, shots: Optional[Union[int, Sequence, Shots]] = None):
 def bind_new_parameters_tape(
     tape: QuantumScript, params: Sequence[TensorLike], indices: Sequence[int]
 ):
-    """Create a new operator with updated parameters.
+    """Create a new tape with updated parameters.
 
-    This function takes a :class:`~.tape.QuantumScript` and new parameters as
-    input, and returns a new ``QuantumScript`` containing the new parameters.
-    This function does not mutate the original ``QuantumScript``.
+    This function takes a :class:`~.tape.QuantumScript` as input, and returns
+    a new ``QuantumScript`` containing the new parameters at the provided indices,
+    with the parameters at all other indices remaining the same.
 
     Args:
         tape (.tape.QuantumScript): Tape to update
-        params (Sequence[TensorLike]): New parameters to create tape with. This
-            must have the same shape as ``tape.get_parameters``.
+        params (Sequence[TensorLike]): New parameters to create the tape with. This
+            must have the same length as ``indices``.
+        indices (Sequence[int]): The parameter indices to update with the given parameters.
+            The index of a parameter is defined as its index in ``tape.get_parameters()``.
 
     Returns:
         .tape.QuantumScript: New tape with updated parameters
@@ -1456,10 +1458,8 @@ def bind_new_parameters_tape(
 
             if isinstance(op, Operator):
                 new_op = qml.ops.functions.bind_new_parameters(op, new_params)
-                new_op._check_batching(new_op.data)
             else:
                 new_obs = qml.ops.functions.bind_new_parameters(op.obs, new_params)
-                new_obs._check_batching(new_obs.data)
                 new_op = op.__class__(obs=new_obs)
 
             new_ops.append(new_op)

--- a/pennylane/tape/qscript.py
+++ b/pennylane/tape/qscript.py
@@ -35,6 +35,7 @@ from pennylane.measurements import (
     VarianceMP,
     Shots,
 )
+from pennylane.typing import TensorLike
 from pennylane.operation import Observable, Operator, Operation
 from pennylane.queuing import AnnotatedQueue, process_queue
 
@@ -1410,3 +1411,68 @@ def make_qscript(fn, shots: Optional[Union[int, Sequence, Shots]] = None):
         return qscript
 
     return wrapper
+
+
+def bind_new_parameters_tape(
+    tape: QuantumScript, params: Sequence[TensorLike], indices: Sequence[int]
+):
+    """Create a new operator with updated parameters.
+
+    This function takes a :class:`~.tape.QuantumScript` and new parameters as
+    input, and returns a new ``QuantumScript`` containing the new parameters.
+    This function does not mutate the original ``QuantumScript``.
+
+    Args:
+        tape (.tape.QuantumScript): Tape to update
+        params (Sequence[TensorLike]): New parameters to create tape with. This
+            must have the same shape as ``tape.get_parameters``.
+
+    Returns:
+        .tape.QuantumScript: New tape with updated parameters
+    """
+    new_ops = []
+    idx = 0
+    p_idx = 0
+
+    for op in tape.circuit:
+        if isinstance(op, Operator):
+            data = op.data
+        elif op.obs is not None:
+            data = op.obs.data
+        else:
+            data = ()
+
+        # determine if any parameters of the operator need to be rebinded
+        if any(i + idx in indices for i in range(len(data))):
+            new_params = []
+            for i in range(len(data)):
+                if i + idx in indices:
+                    new_params.append(params[p_idx])
+                    p_idx += 1
+                else:
+                    new_params.append(data[i])
+
+            if isinstance(op, Operator):
+                new_op = qml.ops.functions.bind_new_parameters(op, new_params)
+                new_op._check_batching(new_op.data)
+            else:
+                new_obs = qml.ops.functions.bind_new_parameters(op.obs, new_params)
+                new_obs._check_batching(new_obs.data)
+                new_op = op.__class__(obs=new_obs)
+
+            new_ops.append(new_op)
+        else:
+            # no need to change the operator
+            new_ops.append(op)
+
+        idx += len(data)
+
+    new_prep = new_ops[: len(tape._prep)]
+    new_operations = new_ops[len(tape._prep) : len(tape.operations)]
+    new_measurements = new_ops[len(tape.operations) :]
+
+    new_tape = qml.tape.QuantumScript(new_operations, new_measurements, new_prep, shots=tape.shots)
+    new_tape.trainable_params = tape.trainable_params
+    new_tape._qfunc_output = tape._qfunc_output
+
+    return new_tape

--- a/tests/gradients/core/test_pulse_generator_gradient.py
+++ b/tests/gradients/core/test_pulse_generator_gradient.py
@@ -1394,7 +1394,9 @@ class TestPulseGeneratorIntegration:
         assert dev.num_executions == 1 + 12  # one forward execution, dim(DLA)=6
         grad_backprop = jax.grad(qnode_backprop)(params)
 
-        assert all(qml.math.allclose(r, e) for r, e in zip(grad_pulse_grad, grad_backprop))
+        assert all(
+            qml.math.allclose(r, e, atol=1e-7) for r, e in zip(grad_pulse_grad, grad_backprop)
+        )
 
     @pytest.mark.parametrize("argnums", [[0, 1], 0, 1])
     def test_simple_qnode_expval_multiple_params(self, argnums):

--- a/tests/tape/test_qscript.py
+++ b/tests/tape/test_qscript.py
@@ -249,7 +249,7 @@ class TestUpdate:
     )
     def test_update_batch_size(self, x, rot, exp_batch_size):
         """Test that the batch size is correctly inferred from all operation's
-        batch_size, when creating and when using `set_parameters`."""
+        batch_size when creating"""
 
         obs = [qml.RX(x, wires=0), qml.Rot(*rot, wires=1)]
         m = [qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliX(1))]
@@ -502,18 +502,6 @@ class TestScriptCopying:
         # check that the output dim is identical
         assert qs.output_dim == copied_qs.output_dim
 
-        # since the copy is shallow, mutating the parameters
-        # on one tape will affect the parameters on another tape
-        new_params = [np.array([0, 0]), 0.2]
-        qs.set_parameters(new_params)
-
-        # check that they are the same objects in memory
-        for i, j in zip(qs.get_parameters(), new_params):
-            assert i is j
-
-        for i, j in zip(copied_qs.get_parameters(), new_params):
-            assert i is j
-
     # pylint: disable=unnecessary-lambda
     @pytest.mark.parametrize(
         "copy_fn", [lambda tape: tape.copy(copy_operations=True), lambda tape: copy.copy(tape)]
@@ -549,18 +537,6 @@ class TestScriptCopying:
 
         # check that the output dim is identical
         assert qs.output_dim == copied_qs.output_dim
-
-        # Since they have unique operations, mutating the parameters
-        # on one script will *not* affect the parameters on another script
-        new_params = [np.array([0, 0]), 0.2]
-        qs.set_parameters(new_params)
-
-        for i, j in zip(qs.get_parameters(), new_params):
-            assert i is j
-
-        for i, j in zip(copied_qs.get_parameters(), new_params):
-            assert not np.all(i == j)
-            assert i is not j
 
     def test_deep_copy(self):
         """Test that deep copying a tape works, and copies all constituent data except parameters"""

--- a/tests/tape/test_qscript.py
+++ b/tests/tape/test_qscript.py
@@ -249,7 +249,7 @@ class TestUpdate:
     )
     def test_update_batch_size(self, x, rot, exp_batch_size):
         """Test that the batch size is correctly inferred from all operation's
-        batch_size when creating"""
+        batch_size when creating a QuantumScript."""
 
         obs = [qml.RX(x, wires=0), qml.Rot(*rot, wires=1)]
         m = [qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliX(1))]

--- a/tests/tape/test_tape.py
+++ b/tests/tape/test_tape.py
@@ -859,6 +859,232 @@ class TestParameters:
         assert np.all(new_tape[1].obs.data[0] == H2)
 
 
+class TestParametersOld:
+    """Tests for parameter processing, setting, and manipulation"""
+
+    @pytest.fixture
+    def make_tape(self):
+        params = [0.432, 0.123, 0.546, 0.32, 0.76]
+
+        with QuantumTape() as tape:
+            qml.RX(params[0], wires=0)
+            qml.Rot(*params[1:4], wires=0)
+            qml.CNOT(wires=[0, "a"])
+            qml.RX(params[4], wires=4)
+            qml.expval(qml.PauliX(wires="a"))
+            qml.probs(wires=[0, "a"])
+
+        return tape, params
+
+    @pytest.fixture
+    def make_tape_with_hermitian(self):
+        params = [0.432, 0.123, 0.546, 0.32, 0.76]
+        hermitian = qml.numpy.eye(2, requires_grad=False)
+
+        with QuantumTape() as tape:
+            qml.RX(params[0], wires=0)
+            qml.Rot(*params[1:4], wires=0)
+            qml.CNOT(wires=[0, "a"])
+            qml.RX(params[4], wires=4)
+            qml.expval(qml.Hermitian(hermitian, wires="a"))
+
+        return tape, params, hermitian
+
+    def test_parameter_processing(self, make_tape):
+        """Test that parameters are correctly counted and processed"""
+        tape, params = make_tape
+        assert tape.num_params == len(params)
+        assert tape.trainable_params == list(range(len(params)))
+        assert tape.get_parameters() == params
+
+    @pytest.mark.parametrize("operations_only", [False, True])
+    def test_parameter_processing_operations_only(self, make_tape_with_hermitian, operations_only):
+        """Test the operations_only flag for getting the parameters on a tape with
+        qml.Hermitian is measured"""
+        tape, circuit_params, hermitian = make_tape_with_hermitian
+        num_all_params = len(circuit_params) + 1  # + 1 for hermitian
+        assert tape.num_params == num_all_params
+        assert tape.trainable_params == list(range(num_all_params))
+        assert (
+            tape.get_parameters(operations_only=operations_only) == circuit_params
+            if operations_only
+            else circuit_params + [hermitian]
+        )
+
+    def test_set_trainable_params(self, make_tape):
+        """Test that setting trainable parameters works as expected"""
+        tape, params = make_tape
+        trainable = [0, 2, 3]
+        tape.trainable_params = trainable
+        assert tape._trainable_params == trainable
+        assert tape.num_params == 3
+        assert tape.get_parameters() == [params[i] for i in tape.trainable_params]
+
+        # add additional trainable parameters
+        trainable = {1, 2, 3, 4}
+        tape.trainable_params = trainable
+        assert tape._trainable_params == [1, 2, 3, 4]
+        assert tape.num_params == 4
+        assert tape.get_parameters() == [params[i] for i in tape.trainable_params]
+
+        # set trainable_params in wrong order
+        trainable = {3, 4, 1}
+        tape.trainable_params = trainable
+        assert tape._trainable_params == [1, 3, 4]
+        assert tape.num_params == 3
+        assert tape.get_parameters() == [params[i] for i in tape.trainable_params]
+
+    def test_changing_params(self, make_tape):
+        """Test that changing trainable parameters works as expected"""
+        tape, params = make_tape
+        trainable = (0, 2, 3)
+        tape.trainable_params = trainable
+        assert tape._trainable_params == list(trainable)
+        assert tape.num_params == 3
+        assert tape.get_parameters() == [params[i] for i in tape.trainable_params]
+        assert tape.get_parameters(trainable_only=False) == params
+
+    def test_set_trainable_params_error(self, make_tape):
+        """Test that exceptions are raised if incorrect parameters
+        are set as trainable"""
+        tape, _ = make_tape
+
+        with pytest.raises(ValueError, match="must be non-negative integers"):
+            tape.trainable_params = [-1, 0]
+
+        with pytest.raises(ValueError, match="must be non-negative integers"):
+            tape.trainable_params = (0.5,)
+
+        with pytest.raises(ValueError, match="only has 5 parameters"):
+            tape.trainable_params = {0, 7}
+
+    def test_setting_parameters(self, make_tape):
+        """Test that parameters are correctly modified after construction"""
+        tape, _ = make_tape
+        new_params = [0.6543, -0.654, 0, 0.3, 0.6]
+
+        tape.set_parameters(new_params)
+
+        for pinfo, pval in zip(tape._par_info, new_params):
+            assert pinfo["op"].data[pinfo["p_idx"]] == pval
+
+        assert tape.get_parameters() == new_params
+
+        new_params = (0.1, -0.2, 1, 5, 0)
+        tape.data = new_params
+
+        for pinfo, pval in zip(tape._par_info, new_params):
+            assert pinfo["op"].data[pinfo["p_idx"]] == pval
+
+        assert tape.get_parameters() == list(new_params)
+
+    def test_setting_free_parameters(self, make_tape):
+        """Test that free parameters are correctly modified after construction"""
+        tape, params = make_tape
+        new_params = [-0.654, 0.3]
+
+        tape.trainable_params = [1, 3]
+        tape.set_parameters(new_params)
+
+        count = 0
+        for idx, pinfo in enumerate(tape._par_info):
+            if idx in tape.trainable_params:
+                assert pinfo["op"].data[pinfo["p_idx"]] == new_params[count]
+                count += 1
+            else:
+                assert pinfo["op"].data[pinfo["p_idx"]] == params[idx]
+
+        assert tape.get_parameters(trainable_only=False) == [
+            params[0],
+            new_params[0],
+            params[2],
+            new_params[1],
+            params[4],
+        ]
+
+    def test_setting_parameters_unordered(self, make_tape):
+        """Test that an 'unordered' trainable_params set does not affect
+        the setting of parameter values"""
+        tape, params = make_tape
+        new_params = [-0.654, 0.3]
+
+        tape.trainable_params = [3, 1]
+        tape.set_parameters(new_params)
+
+        assert tape.get_parameters(trainable_only=True) == new_params
+        assert tape.get_parameters(trainable_only=False) == [
+            params[0],
+            new_params[0],
+            params[2],
+            new_params[1],
+            params[4],
+        ]
+
+    def test_setting_all_parameters(self, make_tape):
+        """Test that all parameters are correctly modified after construction"""
+        tape, _ = make_tape
+        new_params = [0.6543, -0.654, 0, 0.3, 0.6]
+
+        tape.trainable_params = [1, 3]
+        tape.set_parameters(new_params, trainable_only=False)
+
+        for pinfo, pval in zip(tape._par_info, new_params):
+            assert pinfo["op"].data[pinfo["p_idx"]] == pval
+
+        assert tape.get_parameters(trainable_only=False) == new_params
+
+    def test_setting_parameters_error(self, make_tape):
+        """Test that exceptions are raised if incorrect parameters
+        are attempted to be set"""
+        tape, _ = make_tape
+
+        with pytest.raises(ValueError, match="Number of provided parameters does not match"):
+            tape.set_parameters([0.54])
+
+        with pytest.raises(ValueError, match="Number of provided parameters does not match"):
+            tape.trainable_params = [2, 3]
+            tape.set_parameters([0.54, 0.54, 0.123])
+
+    def test_array_parameter(self):
+        """Test that array parameters integrate properly"""
+        a = np.array([1, 1, 0, 0]) / np.sqrt(2)
+        params = [a, 0.32, 0.76, 1.0]
+
+        with QuantumTape() as tape:
+            op_ = qml.QubitStateVector(params[0], wires=[0, 1])
+            qml.Rot(params[1], params[2], params[3], wires=0)
+
+        assert tape.num_params == len(params)
+        assert tape.get_parameters() == params
+
+        b = np.array([0, 1, 0, 0])
+        new_params = [b, 0.543, 0.654, 0.123]
+        tape.set_parameters(new_params)
+        assert tape.get_parameters() == new_params
+
+        assert np.all(op_.data[0] == b)
+
+    def test_measurement_parameter(self):
+        """Test that measurement parameters integrate properly"""
+        H = np.array([[1, 0], [0, -1]])
+        params = [0.32, 0.76, 1.0, H]
+
+        with QuantumTape() as tape:
+            qml.Rot(params[0], params[1], params[2], wires=0)
+            obs = qml.Hermitian(params[3], wires=0)
+            qml.expval(obs)
+
+        assert tape.num_params == len(params)
+        assert tape.get_parameters() == params
+
+        H2 = np.array([[0, 1], [1, 1]])
+        new_params = [0.543, 0.654, 0.123, H2]
+        tape.set_parameters(new_params)
+        assert tape.get_parameters() == new_params
+
+        assert np.all(obs.data[0] == H2)
+
+
 class TestInverseAdjoint:
     """Tests for tape inversion"""
 


### PR DESCRIPTION
**Context:**
Part of the effort towards `QuantumScript` immutability. In the end we want to deprecate `QuantumScript.set_parameters` altogether.

**Description of the Change:**
Define a new function `bind_new_parameters_tape` that takes a tape and the new parameters, and returns a new tape. The original tape is unmodified.

Update the `jax`, `jax-jit`, `tensorflow`, and `tensorflow-autograph` interfaces to call this new `bind_new_parameters_tape` function instead of `QuantumScript.set_parameters`.
