### PR TITLE
[BUG FIX] Add support for adjoint operations in `default.qutrit`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -80,7 +80,7 @@
   [#4331](https://github.com/PennyLaneAI/pennylane/pull/4331)
 
 * `default.qutrit` now supports all qutrit operations used with `qml.adjoint`.
-[(#)]()
+[(#4348)](https://github.com/PennyLaneAI/pennylane/pull/4348)
 
 <h3>Contributors ✍️</h3>
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -80,7 +80,7 @@
   [#4331](https://github.com/PennyLaneAI/pennylane/pull/4331)
 
 * `default.qutrit` now supports all qutrit operations used with `qml.adjoint`.
-[(#4348)](https://github.com/PennyLaneAI/pennylane/pull/4348)
+  [(#4348)](https://github.com/PennyLaneAI/pennylane/pull/4348)
 
 <h3>Contributors ✍️</h3>
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -79,6 +79,9 @@
 * `qml.qinfo.purity` now produces correct results with custom wire labels.
   [#4331](https://github.com/PennyLaneAI/pennylane/pull/4331)
 
+* `default.qutrit` now supports all qutrit operations used with `qml.adjoint`.
+[(#)]()
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane/devices/default_qutrit.py
+++ b/pennylane/devices/default_qutrit.py
@@ -71,10 +71,14 @@ class DefaultQutrit(QutritDevice):
         "QutritUnitary",
         "ControlledQutritUnitary",
         "TShift",
+        "Adjoint(TShift)",
         "TClock",
+        "Adjoint(TClock)",
         "TAdd",
+        "Adjoint(TAdd)",
         "TSWAP",
         "THadamard",
+        "Adjoint(THadamard)",
         "TRX",
         "TRY",
         "TRZ",
@@ -208,6 +212,9 @@ class DefaultQutrit(QutritDevice):
         if operation.name in self._apply_ops:
             axes = self.wires.indices(wires)
             return self._apply_ops[operation.name](state, axes)
+        elif isinstance(operation, qml.ops.Adjoint) and operation.base.name in self._apply_ops:
+            axes = self.wires.indices(wires)
+            return self._apply_ops[operation.base.name](state, axes, inverse=True)
 
         matrix = self._asarray(self._get_unitary_matrix(operation), dtype=self.C_DTYPE)
 

--- a/pennylane/devices/default_qutrit.py
+++ b/pennylane/devices/default_qutrit.py
@@ -209,10 +209,13 @@ class DefaultQutrit(QutritDevice):
             return state
         wires = operation.wires
 
-        if operation.name in self._apply_ops:
+        if operation.name in self._apply_ops:  # pylint: disable=no-else-return
             axes = self.wires.indices(wires)
             return self._apply_ops[operation.name](state, axes)
-        elif isinstance(operation, qml.ops.Adjoint) and operation.base.name in self._apply_ops:
+        elif (
+            isinstance(operation, qml.ops.Adjoint)  # pylint: disable=no-member
+            and operation.base.name in self._apply_ops
+        ):
             axes = self.wires.indices(wires)
             return self._apply_ops[operation.base.name](state, axes, inverse=True)
 

--- a/tests/devices/test_default_qutrit.py
+++ b/tests/devices/test_default_qutrit.py
@@ -106,6 +106,24 @@ class TestApply:
         assert np.allclose(qutrit_device_1_wire._state, np.array(expected_output), atol=tol, rtol=0)
         assert qutrit_device_1_wire._state.dtype == qutrit_device_1_wire.C_DTYPE
 
+    @pytest.mark.parametrize("operation, expected_output, input, subspace", test_data_no_parameters)
+    def test_apply_operation_single_wire_no_parameters_adjoint(
+        self, qutrit_device_1_wire, tol, operation, input, expected_output, subspace
+    ):
+        """Tests that applying an adjoint operation yields the expected output state for single wire
+        operations that have no parameters."""
+        qutrit_device_1_wire._state = np.array(input, dtype=qutrit_device_1_wire.C_DTYPE)
+        qutrit_device_1_wire.apply(
+            [
+                qml.adjoint(operation(wires=[0]))
+                if subspace is None
+                else qml.adjoint(operation(wires=[0], subspace=subspace))
+            ]
+        )
+
+        assert np.allclose(qutrit_device_1_wire._state, np.array(expected_output), atol=tol, rtol=0)
+        assert qutrit_device_1_wire._state.dtype == qutrit_device_1_wire.C_DTYPE
+
     test_data_two_wires_no_parameters = [
         (qml.TSWAP, [0, 1, 0, 0, 0, 0, 0, 0, 0], np.array([0, 0, 0, 1, 0, 0, 0, 0, 0]), None),
         (
@@ -165,6 +183,30 @@ class TestApply:
         )
         assert qutrit_device_2_wires._state.dtype == qutrit_device_2_wires.C_DTYPE
 
+    @pytest.mark.parametrize(
+        "operation,expected_output,input, subspace", all_two_wires_no_parameters
+    )
+    def test_apply_operation_two_wires_no_parameters_adjoint(
+        self, qutrit_device_2_wires, tol, operation, input, expected_output, subspace
+    ):
+        """Tests that applying an adjoint operation yields the expected output state for two wire
+        operations that have no parameters."""
+        qutrit_device_2_wires._state = np.array(input, dtype=qutrit_device_2_wires.C_DTYPE).reshape(
+            (3, 3)
+        )
+        qutrit_device_2_wires.apply(
+            [
+                qml.adjoint(operation(wires=[0, 1]))
+                if subspace is None
+                else qml.adjoint(operation(wires=[0, 1], subspace=subspace))
+            ]
+        )
+
+        assert np.allclose(
+            qutrit_device_2_wires._state.flatten(), np.array(expected_output), atol=tol, rtol=0
+        )
+        assert qutrit_device_2_wires._state.dtype == qutrit_device_2_wires.C_DTYPE
+
     # TODO: Add more data as parametric ops get added
     test_data_single_wire_with_parameters = [
         (qml.QutritUnitary, [1, 0, 0], [1, 1, 0] / np.sqrt(2), [U_thadamard_01], None),
@@ -214,6 +256,23 @@ class TestApply:
         assert np.allclose(qutrit_device_1_wire._state, np.array(expected_output), atol=tol, rtol=0)
         assert qutrit_device_1_wire._state.dtype == qutrit_device_1_wire.C_DTYPE
 
+    @pytest.mark.parametrize(
+        "operation, expected_output, input, par, subspace", test_data_single_wire_with_parameters
+    )
+    def test_apply_operation_single_wire_with_parameters_adjoint(
+        self, qutrit_device_1_wire, tol, operation, input, expected_output, par, subspace
+    ):
+        """Tests that applying an adjoint operation yields the expected output state for single wire
+        operations that have parameters."""
+
+        qutrit_device_1_wire._state = np.array(input, dtype=qutrit_device_1_wire.C_DTYPE)
+
+        kwargs = {} if subspace is None else {"subspace": subspace}
+        qutrit_device_1_wire.apply([qml.adjoint(operation(*par, wires=[0], **kwargs))])
+
+        assert np.allclose(qutrit_device_1_wire._state, np.array(expected_output), atol=tol, rtol=0)
+        assert qutrit_device_1_wire._state.dtype == qutrit_device_1_wire.C_DTYPE
+
     # TODO: Add more ops as parametric operations get added
     test_data_two_wires_with_parameters = [
         (qml.QutritUnitary, [0, 0, 0, 0, 0, 1, 0, 0, 0], [0, 0, 0, 0, 0, 0, 0, 1, 0], [TSWAP]),
@@ -247,6 +306,25 @@ class TestApply:
             (3, 3)
         )
         qutrit_device_2_wires.apply([operation(*par, wires=[0, 1])])
+
+        assert np.allclose(
+            qutrit_device_2_wires._state.flatten(), np.array(expected_output), atol=tol, rtol=0
+        )
+        assert qutrit_device_2_wires._state.dtype == qutrit_device_2_wires.C_DTYPE
+
+    @pytest.mark.parametrize(
+        "operation,expected_output,input,par", test_data_two_wires_with_parameters
+    )
+    def test_apply_operation_two_wires_with_parameters_adjoint(
+        self, qutrit_device_2_wires, tol, operation, input, expected_output, par
+    ):
+        """Tests that applying an adjoint operation yields the expected output state for two wire
+        operations that have parameters."""
+
+        qutrit_device_2_wires._state = np.array(input, dtype=qutrit_device_2_wires.C_DTYPE).reshape(
+            (3, 3)
+        )
+        qutrit_device_2_wires.apply([qml.adjoint(operation(*par, wires=[0, 1]))])
 
         assert np.allclose(
             qutrit_device_2_wires._state.flatten(), np.array(expected_output), atol=tol, rtol=0


### PR DESCRIPTION
**Context:**
Many non-parametric qutrit operations don't have available adjoints in PennyLane, because of which using `qml.adjoint` with these operations was not working with `DefaultQutrit`.

**Description of the Change:**
* Added `Adjoint(op)` to list of supported operations in `DefaultQutrit`for non-parametric qutrit operations.

**Benefits:**
Adjoint operations work correctly on `DefaultQutrit`.

**Possible Drawbacks:**

**Related GitHub Issues:**
#4347 