### PR TITLE
Fix QPE/QMC documentation rendering

### DIFF
--- a/pennylane/templates/subroutines/qmc.py
+++ b/pennylane/templates/subroutines/qmc.py
@@ -228,41 +228,6 @@ class QuantumMonteCarlo(Operation):
         :width: 60%
         :target: javascript:void(0);
 
-    The algorithm proceeds as follows:
-
-    #. The probability distribution :math:`p(i)` is encoded using a unitary :math:`\mathcal{A}`
-       applied to the first :math:`m` qubits specified by ``target_wires``.
-    #. The function :math:`f(i)` is encoded onto the last qubit of ``target_wires`` using a unitary
-       :math:`\mathcal{R}`.
-    #. The unitary :math:`\mathcal{Q}` is defined with eigenvalues
-       :math:`e^{\pm 2 \pi i \theta}` such that the phase :math:`\theta` encodes the expectation
-       value through the equation :math:`\mu = (1 + \cos (\pi \theta)) / 2`. The circuit in steps 1
-       and 2 prepares an equal superposition over the two states corresponding to the eigenvalues
-       :math:`e^{\pm 2 \pi i \theta}`.
-    #. The :func:`~.QuantumPhaseEstimation` circuit is applied so that :math:`\pm\theta` can be
-       estimated by finding the probabilities of the :math:`n` estimation wires. This in turn allows
-       for the estimation of :math:`\mu`.
-
-    Visit `Rebentrost et al. (2018) <https://arxiv.org/abs/1805.00109>`__ for further details. In
-    this algorithm, the number of applications :math:`N` of the :math:`\mathcal{Q}` unitary scales
-    as :math:`2^{n}`. However, due to the use of quantum phase estimation, the error
-    :math:`\epsilon` scales as :math:`\mathcal{O}(2^{-n})`. Hence,
-
-    .. math::
-
-        N = \mathcal{O}\left(\frac{1}{\epsilon}\right).
-
-    This scaling can be compared to standard Monte Carlo estimation, where :math:`N` samples are
-    generated from the probability distribution and the average over :math:`f` is taken. In that
-    case,
-
-    .. math::
-
-        N =  \mathcal{O}\left(\frac{1}{\epsilon^{2}}\right).
-
-    Hence, the quantum Monte Carlo algorithm has a quadratically improved time complexity with
-    :math:`N`.
-
     Args:
         probs (array): input probability distribution as a flat array
         func (callable): input function :math:`f` defined on the set of integers
@@ -284,6 +249,41 @@ class QuantumMonteCarlo(Operation):
 
     .. details::
         :title: Usage Details
+
+        The algorithm proceeds as follows:
+
+        #. The probability distribution :math:`p(i)` is encoded using a unitary :math:`\mathcal{A}`
+           applied to the first :math:`m` qubits specified by ``target_wires``.
+        #. The function :math:`f(i)` is encoded onto the last qubit of ``target_wires`` using a unitary
+           :math:`\mathcal{R}`.
+        #. The unitary :math:`\mathcal{Q}` is defined with eigenvalues
+           :math:`e^{\pm 2 \pi i \theta}` such that the phase :math:`\theta` encodes the expectation
+           value through the equation :math:`\mu = (1 + \cos (\pi \theta)) / 2`. The circuit in steps 1
+           and 2 prepares an equal superposition over the two states corresponding to the eigenvalues
+           :math:`e^{\pm 2 \pi i \theta}`.
+        #. The :func:`~.QuantumPhaseEstimation` circuit is applied so that :math:`\pm\theta` can be
+           estimated by finding the probabilities of the :math:`n` estimation wires. This in turn allows
+           for the estimation of :math:`\mu`.
+
+        Visit `Rebentrost et al. (2018) <https://arxiv.org/abs/1805.00109>`__ for further details. In
+        this algorithm, the number of applications :math:`N` of the :math:`\mathcal{Q}` unitary scales
+        as :math:`2^{n}`. However, due to the use of quantum phase estimation, the error
+        :math:`\epsilon` scales as :math:`\mathcal{O}(2^{-n})`. Hence,
+
+        .. math::
+
+            N = \mathcal{O}\left(\frac{1}{\epsilon}\right).
+
+        This scaling can be compared to standard Monte Carlo estimation, where :math:`N` samples are
+        generated from the probability distribution and the average over :math:`f` is taken. In that
+        case,
+
+        .. math::
+
+            N =  \mathcal{O}\left(\frac{1}{\epsilon^{2}}\right).
+
+        Hence, the quantum Monte Carlo algorithm has a quadratically improved time complexity with
+        :math:`N`. An example use case is given below.
 
         Consider a standard normal distribution :math:`p(x)` and a function
         :math:`f(x) = \sin ^{2} (x)`. The expectation value of :math:`f(x)` is

--- a/pennylane/templates/subroutines/qpe.py
+++ b/pennylane/templates/subroutines/qpe.py
@@ -38,18 +38,15 @@ class QuantumPhaseEstimation(Operation):
     of the following steps:
 
     #. Prepare ``target_wires`` in a given state. If ``target_wires`` are prepared in an eigenstate
-       of :math:`U` that has corresponding eigenvalue :math:`e^{2 \pi i \theta}` with phase
-       :math:`\theta \in [0, 1)`, this algorithm will measure :math:`\theta`. Other input states can
+       of `U` that has corresponding eigenvalue `e^{2 \pi i \theta}` with phase
+       `\theta \in [0, 1)`, this algorithm will measure `\theta`. Other input states can
        be prepared more generally.
-
     #. Apply the ``QuantumPhaseEstimation`` circuit.
-
     #. Measure ``estimation_wires`` using :func:`~.probs`, giving a probability distribution over
        measurement outcomes in the computational basis.
-
     #. Find the index of the largest value in the probability distribution and divide that number by
-       :math:`2^{n}`. This number will be an estimate of :math:`\theta` with an error that decreases
-       exponentially with the number of qubits :math:`n`.
+       `2^{n}`. This number will be an estimate of `\theta` with an error that decreases
+       exponentially with the number of qubits `n`.
 
     Note that if :math:`\theta \in (-1, 0]`, we can estimate the phase by again finding the index
     :math:`i` found in step 4 and calculating :math:`\theta \approx \frac{1 - i}{2^{n}}`. The

--- a/pennylane/templates/subroutines/qpe.py
+++ b/pennylane/templates/subroutines/qpe.py
@@ -41,9 +41,12 @@ class QuantumPhaseEstimation(Operation):
        of :math:`U` that has corresponding eigenvalue :math:`e^{2 \pi i \theta}` with phase
        :math:`\theta \in [0, 1)`, this algorithm will measure :math:`\theta`. Other input states can
        be prepared more generally.
+
     #. Apply the ``QuantumPhaseEstimation`` circuit.
+
     #. Measure ``estimation_wires`` using :func:`~.probs`, giving a probability distribution over
        measurement outcomes in the computational basis.
+
     #. Find the index of the largest value in the probability distribution and divide that number by
        :math:`2^{n}`. This number will be an estimate of :math:`\theta` with an error that decreases
        exponentially with the number of qubits :math:`n`.

--- a/pennylane/templates/subroutines/qpe.py
+++ b/pennylane/templates/subroutines/qpe.py
@@ -34,24 +34,6 @@ class QuantumPhaseEstimation(Operation):
         :width: 60%
         :target: javascript:void(0);
 
-    This circuit can be used to perform the standard quantum phase estimation algorithm, consisting
-    of the following steps:
-
-    #. Prepare ``target_wires`` in a given state. If ``target_wires`` are prepared in an eigenstate
-       of `U` that has corresponding eigenvalue `e^{2 \pi i \theta}` with phase
-       `\theta \in [0, 1)`, this algorithm will measure `\theta`. Other input states can
-       be prepared more generally.
-    #. Apply the ``QuantumPhaseEstimation`` circuit.
-    #. Measure ``estimation_wires`` using :func:`~.probs`, giving a probability distribution over
-       measurement outcomes in the computational basis.
-    #. Find the index of the largest value in the probability distribution and divide that number by
-       `2^{n}`. This number will be an estimate of `\theta` with an error that decreases
-       exponentially with the number of qubits `n`.
-
-    Note that if :math:`\theta \in (-1, 0]`, we can estimate the phase by again finding the index
-    :math:`i` found in step 4 and calculating :math:`\theta \approx \frac{1 - i}{2^{n}}`. The
-    usage details below give an example of this case.
-
     Args:
         unitary (array or Operator): the phase estimation unitary, specified as a matrix or an
             :class:`~.Operator`
@@ -67,6 +49,24 @@ class QuantumPhaseEstimation(Operation):
 
     .. details::
         :title: Usage Details
+
+        This circuit can be used to perform the standard quantum phase estimation algorithm, consisting
+        of the following steps:
+
+        #. Prepare ``target_wires`` in a given state. If ``target_wires`` are prepared in an eigenstate
+           of :math:`U` that has corresponding eigenvalue :math:`e^{2 \pi i \theta}` with phase
+           :math:`\theta \in [0, 1)`, this algorithm will measure :math:`\theta`. Other input states can
+           be prepared more generally.
+        #. Apply the ``QuantumPhaseEstimation`` circuit.
+        #. Measure ``estimation_wires`` using :func:`~.probs`, giving a probability distribution over
+           measurement outcomes in the computational basis.
+        #. Find the index of the largest value in the probability distribution and divide that number by
+           :math:`2^{n}`. This number will be an estimate of :math:`\theta` with an error that decreases
+           exponentially with the number of qubits :math:`n`.
+
+        Note that if :math:`\theta \in (-1, 0]`, we can estimate the phase by again finding the index
+        :math:`i` found in step 4 and calculating :math:`\theta \approx \frac{1 - i}{2^{n}}`. The
+        usage details below give an example of this case.
 
         Consider the matrix corresponding to a rotation from an :class:`~.RX` gate:
 

--- a/pennylane/templates/subroutines/qpe.py
+++ b/pennylane/templates/subroutines/qpe.py
@@ -65,8 +65,8 @@ class QuantumPhaseEstimation(Operation):
            exponentially with the number of qubits :math:`n`.
 
         Note that if :math:`\theta \in (-1, 0]`, we can estimate the phase by again finding the index
-        :math:`i` found in step 4 and calculating :math:`\theta \approx \frac{1 - i}{2^{n}}`. The
-        usage details below give an example of this case.
+        :math:`i` found in step 4 and calculating :math:`\theta \approx \frac{1 - i}{2^{n}}`. An example
+        of this case is below.
 
         Consider the matrix corresponding to a rotation from an :class:`~.RX` gate:
 


### PR DESCRIPTION
The docs for the QPE and QMC templates use Sphinx auto-numbered lists and aren't rendering correctly. There are other places we use auto-numbered lists, but those all render correctly. The difference between these other places and QPE/QMC is that the other lists are located in separate `Usage Details` sections, while the list for QPE/QMC is located in the top-level docstring. 

While I couldn't figure out what was causing this, I decided a workaround is to just move the list to the `Usage Details` sections. This seems more logical to me anyways since the point of the list in these two cases is to break down the template's intended usage.