### PR TITLE
Jax jit qnode integration with DefaultQubit2

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -31,7 +31,7 @@
   [#4331](https://github.com/PennyLaneAI/pennylane/pull/4331)
 
 * The experimental device interface is integrated with the `QNode` for Jax jit.
-  [(#)](https://github.com/PennyLaneAI/pennylane/pull/)
+  [(#4352)](https://github.com/PennyLaneAI/pennylane/pull/4352)
 
 <h3>Breaking changes 💔</h3>
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -26,6 +26,9 @@
 * QNode transforms in `qml.qinfo` now support custom wire labels.
   [#4331](https://github.com/PennyLaneAI/pennylane/pull/4331)
 
+* The experimental device interface is integrated with the `QNode` for Jax jit.
+  [(#)](https://github.com/PennyLaneAI/pennylane/pull/)
+
 <h3>Breaking changes 💔</h3>
 
 * The `do_queue` keyword argument in `qml.operation.Operator` has been removed. Instead of

--- a/pennylane/devices/qubit/simulate.py
+++ b/pennylane/devices/qubit/simulate.py
@@ -72,7 +72,7 @@ def simulate(circuit: qml.tape.QuantumScript, rng=None, debugger=None) -> Result
         # analytic case
 
         if len(circuit.measurements) == 1:
-            return measure(circuit.measurements[0], state)
+            return measure(circuit.measurements[0], state, is_state_batched=is_state_batched)
 
         return tuple(
             measure(mp, state, is_state_batched=is_state_batched) for mp in circuit.measurements

--- a/pennylane/devices/qubit/simulate.py
+++ b/pennylane/devices/qubit/simulate.py
@@ -81,7 +81,13 @@ def simulate(circuit: qml.tape.QuantumScript, rng=None, debugger=None) -> Result
     # finite-shot case
 
     if len(circuit.measurements) == 1:
-        return measure_with_samples(circuit.measurements[0], state, shots=circuit.shots, rng=rng)
+        return measure_with_samples(
+            circuit.measurements[0],
+            state,
+            shots=circuit.shots,
+            is_state_batched=is_state_batched,
+            rng=rng,
+        )
 
     rng = default_rng(rng)
     results = tuple(

--- a/pennylane/gradients/jvp.py
+++ b/pennylane/gradients/jvp.py
@@ -445,7 +445,7 @@ def batch_jvp(tapes, tangents, gradient_fn, shots=None, reduction="append", grad
             elif callable(reduction):
                 reduction(jvps, jvp_)
 
-        return jvps
+        return tuple(jvps)
 
     return gradient_tapes, processing_fn
 

--- a/pennylane/interfaces/jax.py
+++ b/pennylane/interfaces/jax.py
@@ -544,7 +544,7 @@ def _compute_jvps(jacs, tangents, multi_measurements):
             qml.gradients.compute_jvp_multi if multi else qml.gradients.compute_jvp_single
         )
         jvps.append(compute_func(tangents[i], jacs[i]))
-    return jvps
+    return tuple(jvps)
 
 
 def _is_count_result(r):
@@ -569,7 +569,7 @@ def _to_jax(res):
                 else:
                     sub_r.append(jnp.array(r_i))
             res_.append(tuple(sub_r))
-    return res_
+    return tuple(res_)
 
 
 def _to_jax_shot_vector(res):
@@ -577,4 +577,4 @@ def _to_jax_shot_vector(res):
 
     The expected structure of the inputs is a list of tape results with each element in the list being a tuple due to execution using shot vectors.
     """
-    return [tuple(_to_jax([r_])[0] for r_ in r) for r in res]
+    return tuple(tuple(_to_jax([r_])[0] for r_ in r) for r in res)

--- a/pennylane/interfaces/jax_jit_tuple.py
+++ b/pennylane/interfaces/jax_jit_tuple.py
@@ -181,6 +181,8 @@ def _execute_bwd(
     _n=1,
     max_diff=2,
 ):  # pylint: disable=dangerous-default-value,unused-argument
+    is_experimental_device = isinstance(device, qml.devices.experimental.Device)
+
     @jax.custom_jvp
     def execute_wrapper(params):
         shape_dtype_structs = _tapes_shape_dtype_tuple(tapes, device)
@@ -189,6 +191,7 @@ def _execute_bwd(
             """Compute the forward pass."""
             new_tapes = set_parameters_on_copy_and_unwrap(tapes, p)
             res, _ = execute_fn(new_tapes, **gradient_kwargs)
+            res = list(res)
 
             # When executed under `jax.vmap` the `result_shapes_dtypes` will contain
             # the shape without the vmap dimensions, while the function here will be
@@ -245,7 +248,9 @@ def _execute_bwd(
                 all_jacs = []
                 for new_t in new_tapes:
                     jvp_tapes, res_processing_fn = gradient_fn(
-                        new_t, shots=device.shots, **gradient_kwargs
+                        new_t,
+                        shots=new_t.shots if is_experimental_device else device.shots,
+                        **gradient_kwargs
                     )
                     jacs = execute(
                         jvp_tapes,
@@ -299,7 +304,9 @@ def _execute_bwd(
             all_jacs = []
             for new_t in new_tapes:
                 jvp_tapes, res_processing_fn = gradient_fn(
-                    new_t, shots=device.shots, **gradient_kwargs
+                    new_t,
+                    shots=new_t.shots if is_experimental_device else device.shots,
+                    **gradient_kwargs
                 )
                 jacs = execute_fn(jvp_tapes)[0]
                 jacs = res_processing_fn(jacs)
@@ -407,7 +414,9 @@ def _execute_fwd(
                 intermediate_jacs = []
 
                 # Adapt the shape of the empty jacobian given the measurement shape
-                shape_dtype = original_shape[0] if len(tapes) == 1 else original_shape[i][0]
+                shape_dtype = original_shape if len(tapes) == 1 else original_shape[i]
+                if isinstance(shape_dtype, tuple):
+                    shape_dtype = shape_dtype[0]
 
                 # Multi measurement
                 if multi_measurement:

--- a/pennylane/interfaces/jax_jit_tuple.py
+++ b/pennylane/interfaces/jax_jit_tuple.py
@@ -72,7 +72,7 @@ def _tapes_shape_dtype_tuple(tapes, device):
     for t in tapes:
         shape_and_dtype = _create_shape_dtype_struct(t, device)
         shape_dtypes.append(shape_and_dtype)
-    return shape_dtypes
+    return tuple(shape_dtypes)
 
 
 def _jac_shape_dtype_tuple(tapes, device):
@@ -191,7 +191,7 @@ def _execute_bwd(
             """Compute the forward pass."""
             new_tapes = set_parameters_on_copy_and_unwrap(tapes, p)
             res, _ = execute_fn(new_tapes, **gradient_kwargs)
-            res = list(res)
+            res = tuple(res)
 
             # When executed under `jax.vmap` the `result_shapes_dtypes` will contain
             # the shape without the vmap dimensions, while the function here will be

--- a/pennylane/tape/qscript.py
+++ b/pennylane/tape/qscript.py
@@ -933,11 +933,15 @@ class QuantumScript:
         if not qml.active_return():
             return self._shape_legacy(device)
 
-        shots = (
-            Shots(device._raw_shot_sequence)
-            if device.shot_vector is not None
-            else Shots(device.shots)
-        )
+        if isinstance(device, qml.devices.experimental.Device):
+            shots = self.shots
+            device = self  # most MPs use `device.wires`, one checks `device.cutoff`
+        else:
+            shots = (
+                Shots(device._raw_shot_sequence)
+                if device.shot_vector is not None
+                else Shots(device.shots)
+            )
 
         if len(shots.shot_vector) > 1 and self.batch_size is not None:
             raise NotImplementedError(

--- a/pennylane/tape/qscript.py
+++ b/pennylane/tape/qscript.py
@@ -936,8 +936,13 @@ class QuantumScript:
             return self._shape_legacy(device)
 
         if isinstance(device, qml.devices.experimental.Device):
+            # MP.shape (called below) takes 2 arguments: `device` and `shots`.
+            # With the new device interface, shots are stored on tapes rather than the device
+            # As well, MP.shape needs the device largely to see the device wires, and this is
+            # also stored on tapes in the new device interface. TODO: refactor MP.shape to accept
+            # `wires` instead of device (not currently done because probs.shape uses device.cutoff)
             shots = self.shots
-            device = self  # most MPs use `device.wires`, one checks `device.cutoff`
+            device = self
         else:
             shots = (
                 Shots(device._raw_shot_sequence)

--- a/tests/gradients/core/test_jvp.py
+++ b/tests/gradients/core/test_jvp.py
@@ -835,7 +835,7 @@ class TestBatchJVP:
         v_tapes, fn = qml.gradients.batch_jvp(tapes, tangents, param_shift)
 
         assert v_tapes == []
-        assert fn([]) == [None, None]
+        assert fn([]) == (None, None)
 
     def test_zero_tangent(self):
         """A zero dy vector will return no tapes and a zero matrix"""

--- a/tests/interfaces/default_qubit_2_integration/test_jax_jit_qnode_default_qubit_2.py
+++ b/tests/interfaces/default_qubit_2_integration/test_jax_jit_qnode_default_qubit_2.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2021 Xanadu Quantum Technologies Inc.
+# Copyright 2018-2023 Xanadu Quantum Technologies Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/interfaces/default_qubit_2_integration/test_jax_jit_qnode_default_qubit_2.py
+++ b/tests/interfaces/default_qubit_2_integration/test_jax_jit_qnode_default_qubit_2.py
@@ -19,15 +19,16 @@ import pennylane as qml
 from pennylane import numpy as np
 from pennylane import qnode
 from pennylane.tape import QuantumScript
+from pennylane.devices.experimental import DefaultQubit2
 
 qubit_device_and_diff_method = [
-    ["default.qubit", "backprop", True],
-    ["default.qubit", "finite-diff", False],
-    ["default.qubit", "parameter-shift", False],
-    ["default.qubit", "adjoint", True],
-    ["default.qubit", "adjoint", False],
-    ["default.qubit", "spsa", False],
-    ["default.qubit", "hadamard", False],
+    [DefaultQubit2(), "backprop", True],
+    [DefaultQubit2(), "finite-diff", False],
+    [DefaultQubit2(), "parameter-shift", False],
+    [DefaultQubit2(), "adjoint", True],
+    [DefaultQubit2(), "adjoint", False],
+    [DefaultQubit2(), "spsa", False],
+    [DefaultQubit2(), "hadamard", False],
 ]
 interface_and_qubit_device_and_diff_method = [
     ["auto"] + inner_list for inner_list in qubit_device_and_diff_method
@@ -45,23 +46,16 @@ H_FOR_SPSA = 0.05
 
 
 @pytest.mark.parametrize(
-    "interface,dev_name,diff_method,grad_on_execution", interface_and_qubit_device_and_diff_method
+    "interface,dev,diff_method,grad_on_execution", interface_and_qubit_device_and_diff_method
 )
 class TestQNode:
     """Test that using the QNode with JAX integrates with the PennyLane
     stack"""
 
-    def test_execution_with_interface(self, dev_name, diff_method, grad_on_execution, interface):
+    def test_execution_with_interface(self, dev, diff_method, grad_on_execution, interface):
         """Test execution works with the interface"""
         if diff_method == "backprop":
             pytest.skip("Test does not support backprop")
-
-        num_wires = 1
-
-        if diff_method == "hadamard":
-            num_wires = 2
-
-        dev = qml.device(dev_name, wires=num_wires)
 
         @qnode(
             dev, interface=interface, diff_method=diff_method, grad_on_execution=grad_on_execution
@@ -85,7 +79,7 @@ class TestQNode:
         assert grad.shape == ()
 
     def test_changing_trainability(
-        self, dev_name, diff_method, grad_on_execution, interface, mocker, tol
+        self, dev, diff_method, grad_on_execution, interface, mocker, tol
     ):
         """Test changing the trainability of parameters changes the
         number of differentiation requests made"""
@@ -94,8 +88,6 @@ class TestQNode:
 
         a = jax.numpy.array(0.1)
         b = jax.numpy.array(0.2)
-
-        dev = qml.device(dev_name, wires=2)
 
         @qnode(
             dev,
@@ -141,18 +133,11 @@ class TestQNode:
         circuit(a, b)
         assert circuit.qtape.trainable_params == [1]
 
-    def test_classical_processing(self, dev_name, diff_method, grad_on_execution, interface):
+    def test_classical_processing(self, dev, diff_method, grad_on_execution, interface):
         """Test classical processing within the quantum tape"""
         a = jax.numpy.array(0.1)
         b = jax.numpy.array(0.2)
         c = jax.numpy.array(0.3)
-
-        num_wires = 1
-
-        if diff_method == "hadamard":
-            num_wires = 2
-
-        dev = qml.device(dev_name, wires=num_wires)
 
         @qnode(
             dev, diff_method=diff_method, interface=interface, grad_on_execution=grad_on_execution
@@ -170,18 +155,11 @@ class TestQNode:
 
         assert len(res) == 2
 
-    def test_matrix_parameter(self, dev_name, diff_method, grad_on_execution, interface, tol):
+    def test_matrix_parameter(self, dev, diff_method, grad_on_execution, interface, tol):
         """Test that the jax interface works correctly
         with a matrix parameter"""
         U = jax.numpy.array([[0, 1], [1, 0]])
         a = jax.numpy.array(0.1)
-
-        num_wires = 2
-
-        if diff_method == "hadamard":
-            num_wires = 3
-
-        dev = qml.device(dev_name, wires=num_wires)
 
         @qnode(
             dev, diff_method=diff_method, interface=interface, grad_on_execution=grad_on_execution
@@ -197,7 +175,7 @@ class TestQNode:
         if diff_method == "finite-diff":
             assert circuit.qtape.trainable_params == [1]
 
-    def test_differentiable_expand(self, dev_name, diff_method, grad_on_execution, interface, tol):
+    def test_differentiable_expand(self, dev, diff_method, grad_on_execution, interface, tol):
         """Test that operation and nested tape expansion
         is differentiable"""
 
@@ -213,13 +191,6 @@ class TestQNode:
                 return QuantumScript(
                     [qml.Rot(lam, theta, -lam, wires=wires), qml.PhaseShift(phi + lam, wires=wires)]
                 )
-
-        num_wires = 1
-
-        if diff_method == "hadamard":
-            num_wires = 2
-
-        dev = qml.device(dev_name, wires=num_wires)
 
         a = jax.numpy.array(0.1)
         p = jax.numpy.array([0.1, 0.2, 0.3])
@@ -255,7 +226,7 @@ class TestQNode:
         )
         assert np.allclose(res, expected, atol=tol, rtol=0)
 
-    def test_jacobian_options(self, dev_name, diff_method, grad_on_execution, interface, mocker):
+    def test_jacobian_options(self, dev, diff_method, grad_on_execution, interface, mocker):
         """Test setting jacobian options"""
         if diff_method != "finite-diff":
             pytest.skip("Test only applies to finite diff.")
@@ -263,8 +234,6 @@ class TestQNode:
         spy = mocker.spy(qml.gradients.finite_diff, "transform_fn")
 
         a = np.array([0.1, 0.2], requires_grad=True)
-
-        dev = qml.device(dev_name, wires=1)
 
         @qnode(
             dev,
@@ -291,15 +260,13 @@ class TestQNode:
 
 
 @pytest.mark.parametrize(
-    "interface,dev_name,diff_method,grad_on_execution", interface_and_qubit_device_and_diff_method
+    "interface,dev,diff_method,grad_on_execution", interface_and_qubit_device_and_diff_method
 )
 class TestVectorValuedQNode:
     """Test that using vector-valued QNodes with JAX integrate with the
     PennyLane stack"""
 
-    def test_diff_expval_expval(
-        self, dev_name, diff_method, grad_on_execution, interface, mocker, tol
-    ):
+    def test_diff_expval_expval(self, dev, diff_method, grad_on_execution, interface, mocker, tol):
         """Test jacobian calculation"""
 
         gradient_kwargs = {}
@@ -316,13 +283,6 @@ class TestVectorValuedQNode:
 
         a = np.array(0.1, requires_grad=True)
         b = np.array(0.2, requires_grad=True)
-
-        num_wires = 2
-
-        if diff_method == "hadamard":
-            num_wires = 3
-
-        dev = qml.device(dev_name, wires=num_wires)
 
         @qnode(
             dev,
@@ -374,7 +334,7 @@ class TestVectorValuedQNode:
             spy.assert_called()
 
     def test_jacobian_no_evaluate(
-        self, dev_name, diff_method, grad_on_execution, interface, mocker, tol
+        self, dev, diff_method, grad_on_execution, interface, mocker, tol
     ):
         """Test jacobian calculation when no prior circuit evaluation has been performed"""
 
@@ -392,13 +352,6 @@ class TestVectorValuedQNode:
 
         a = jax.numpy.array(0.1)
         b = jax.numpy.array(0.2)
-
-        num_wires = 2
-
-        if diff_method == "hadamard":
-            num_wires = 3
-
-        dev = qml.device(dev_name, wires=num_wires)
 
         @qnode(
             dev,
@@ -448,7 +401,7 @@ class TestVectorValuedQNode:
                 assert r.shape == ()
                 assert np.allclose(r, e, atol=tol, rtol=0)
 
-    def test_diff_single_probs(self, dev_name, diff_method, grad_on_execution, interface, tol):
+    def test_diff_single_probs(self, dev, diff_method, grad_on_execution, interface, tol):
         """Tests correct output shape and evaluation for a tape
         with a single prob output"""
         gradient_kwargs = {}
@@ -458,12 +411,6 @@ class TestVectorValuedQNode:
             gradient_kwargs = {"sampler_seed": SEED_FOR_SPSA}
             tol = TOL_FOR_SPSA
 
-        num_wires = 2
-
-        if diff_method == "hadamard":
-            num_wires = 3
-
-        dev = qml.device(dev_name, wires=num_wires)
         x = jax.numpy.array(0.543)
         y = jax.numpy.array(-0.654)
 
@@ -501,7 +448,7 @@ class TestVectorValuedQNode:
         assert np.allclose(res[0], expected.T[0], atol=tol, rtol=0)
         assert np.allclose(res[1], expected.T[1], atol=tol, rtol=0)
 
-    def test_diff_multi_probs(self, dev_name, diff_method, grad_on_execution, interface, tol):
+    def test_diff_multi_probs(self, dev, diff_method, grad_on_execution, interface, tol):
         """Tests correct output shape and evaluation for a tape
         with multiple prob outputs"""
         gradient_kwargs = {}
@@ -511,12 +458,6 @@ class TestVectorValuedQNode:
             gradient_kwargs = {"sampler_seed": SEED_FOR_SPSA}
             tol = TOL_FOR_SPSA
 
-        num_wires = 3
-
-        if diff_method == "hadamard":
-            num_wires = 4
-
-        dev = qml.device(dev_name, wires=num_wires)
         x = jax.numpy.array(0.543)
         y = jax.numpy.array(-0.654)
 
@@ -587,7 +528,7 @@ class TestVectorValuedQNode:
         assert jac[1][1].shape == (4,)
         assert np.allclose(jac[1][1], expected_1[1], atol=tol, rtol=0)
 
-    def test_diff_expval_probs(self, dev_name, diff_method, grad_on_execution, interface, tol):
+    def test_diff_expval_probs(self, dev, diff_method, grad_on_execution, interface, tol):
         """Tests correct output shape and evaluation for a tape
         with prob and expval outputs"""
         gradient_kwargs = {}
@@ -597,12 +538,6 @@ class TestVectorValuedQNode:
             gradient_kwargs = {"sampler_seed": SEED_FOR_SPSA}
             tol = TOL_FOR_SPSA
 
-        num_wires = 2
-
-        if diff_method == "hadamard":
-            num_wires = 3
-
-        dev = qml.device(dev_name, wires=num_wires)
         x = jax.numpy.array(0.543)
         y = jax.numpy.array(-0.654)
 
@@ -664,7 +599,7 @@ class TestVectorValuedQNode:
         assert np.allclose(jac[1][1], expected[1][1], atol=tol, rtol=0)
 
     def test_diff_expval_probs_sub_argnums(
-        self, dev_name, diff_method, grad_on_execution, interface, tol
+        self, dev, diff_method, grad_on_execution, interface, tol
     ):
         """Tests correct output shape and evaluation for a tape with prob and expval outputs with less
         trainable parameters (argnums) than parameters."""
@@ -673,12 +608,6 @@ class TestVectorValuedQNode:
         elif diff_method == "spsa":
             tol = TOL_FOR_SPSA
 
-        num_wires = 2
-
-        if diff_method == "hadamard":
-            num_wires = 3
-
-        dev = qml.device(dev_name, wires=num_wires)
         x = jax.numpy.array(0.543)
         y = jax.numpy.array(-0.654)
 
@@ -715,7 +644,7 @@ class TestVectorValuedQNode:
         assert jac[1][0].shape == (2,)
         assert np.allclose(jac[1][0], expected[1][0], atol=tol, rtol=0)
 
-    def test_diff_var_probs(self, dev_name, diff_method, grad_on_execution, interface, tol):
+    def test_diff_var_probs(self, dev, diff_method, grad_on_execution, interface, tol):
         """Tests correct output shape and evaluation for a tape
         with prob and variance outputs"""
         gradient_kwargs = {}
@@ -727,7 +656,6 @@ class TestVectorValuedQNode:
             gradient_kwargs = {"sampler_seed": SEED_FOR_SPSA}
             tol = TOL_FOR_SPSA
 
-        dev = qml.device(dev_name, wires=3)
         x = jax.numpy.array(0.543)
         y = jax.numpy.array(-0.654)
 
@@ -796,8 +724,8 @@ class TestShotsIntegration:
     remains differentiable."""
 
     def test_diff_method_None(self, interface):
-        """Test jax device works with diff_method=None."""
-        dev = qml.device("default.qubit.jax", wires=1, shots=10)
+        """Test device works with diff_method=None."""
+        dev = DefaultQubit2()
 
         @jax.jit
         @qml.qnode(dev, diff_method=None, interface=interface)
@@ -807,43 +735,31 @@ class TestShotsIntegration:
 
         assert jax.numpy.allclose(circuit(jax.numpy.array(0.0)), 1)
 
-    def test_changing_shots(self, interface, mocker, tol):
+    def test_changing_shots(self, interface):
         """Test that changing shots works on execution"""
-        dev = qml.device("default.qubit", wires=2, shots=None)
         a, b = jax.numpy.array([0.543, -0.654])
 
-        @qnode(dev, diff_method=qml.gradients.param_shift, interface=interface)
+        @qnode(DefaultQubit2(), diff_method=qml.gradients.param_shift, interface=interface)
         def circuit(a, b):
             qml.RY(a, wires=0)
             qml.RX(b, wires=1)
             qml.CNOT(wires=[0, 1])
-            return qml.expval(qml.PauliY(1))
-
-        spy = mocker.spy(dev, "sample")
+            return qml.sample(wires=(0, 1))
 
         # execute with device default shots (None)
-        res = circuit(a, b)
-        assert np.allclose(res, -np.cos(a) * np.sin(b), atol=tol, rtol=0)
-        spy.assert_not_called()
+        with pytest.raises(qml.DeviceError):
+            circuit(a, b)
 
         # execute with shots=100
         res = circuit(a, b, shots=100)  # pylint: disable=unexpected-keyword-arg
-        spy.assert_called_once()
-        assert spy.spy_return.shape == (100,)
-
-        # device state has been unaffected
-        assert dev.shots is None
-        res = circuit(a, b)
-        assert np.allclose(res, -np.cos(a) * np.sin(b), atol=tol, rtol=0)
-        spy.assert_called_once()  # no additional calls
+        assert res.shape == (100, 2)  # pylint:disable=comparison-with-callable
 
     def test_gradient_integration(self, interface):
         """Test that temporarily setting the shots works
         for gradient computations"""
-        dev = qml.device("default.qubit", wires=2, shots=1)
         a, b = jax.numpy.array([0.543, -0.654])
 
-        @qnode(dev, diff_method=qml.gradients.param_shift, interface=interface)
+        @qnode(DefaultQubit2(), diff_method=qml.gradients.param_shift, interface=interface)
         def cost_fn(a, b):
             qml.RY(a, wires=0)
             qml.RX(b, wires=1)
@@ -852,7 +768,6 @@ class TestShotsIntegration:
 
         # TODO: jit when https://github.com/PennyLaneAI/pennylane/issues/3474 is resolved
         res = jax.grad(cost_fn, argnums=[0, 1])(a, b, shots=30000)
-        assert dev.shots == 1
 
         expected = [np.sin(a) * np.sin(b), -np.cos(a) * np.cos(b)]
         assert np.allclose(res, expected, atol=0.1, rtol=0)
@@ -860,52 +775,41 @@ class TestShotsIntegration:
     def test_update_diff_method(self, mocker, interface):
         """Test that temporarily setting the shots updates the diff method"""
         # pylint: disable=unused-argument
-        dev = qml.device("default.qubit", wires=2, shots=100)
         a, b = jax.numpy.array([0.543, -0.654])
 
         spy = mocker.spy(qml, "execute")
 
-        # We're choosing interface="jax" such that backprop can be used in the
-        # test later
-        @qnode(dev, interface="jax")
+        @qnode(DefaultQubit2(), interface=interface)
         def cost_fn(a, b):
             qml.RY(a, wires=0)
             qml.RX(b, wires=1)
             qml.CNOT(wires=[0, 1])
             return qml.expval(qml.PauliY(1))
 
+        cost_fn(a, b, shots=100)  # pylint:disable=unexpected-keyword-arg
         # since we are using finite shots, parameter-shift will
         # be chosen
-        assert cost_fn.gradient_fn is qml.gradients.param_shift
-
-        cost_fn(a, b)
+        assert cost_fn.gradient_fn == "backprop"
         assert spy.call_args[1]["gradient_fn"] is qml.gradients.param_shift
 
+        cost_fn(a, b)
         # if we set the shots to None, backprop can now be used
-        cost_fn(a, b, shots=None)  # pylint: disable=unexpected-keyword-arg
         assert spy.call_args[1]["gradient_fn"] == "backprop"
-
-        # original QNode settings are unaffected
-        assert cost_fn.gradient_fn is qml.gradients.param_shift
-        cost_fn(a, b)
-        assert spy.call_args[1]["gradient_fn"] is qml.gradients.param_shift
 
 
 @pytest.mark.parametrize(
-    "interface,dev_name,diff_method,grad_on_execution", interface_and_qubit_device_and_diff_method
+    "interface,dev,diff_method,grad_on_execution", interface_and_qubit_device_and_diff_method
 )
 class TestQubitIntegration:
     """Tests that ensure various qubit circuits integrate correctly"""
 
-    def test_sampling(self, dev_name, diff_method, grad_on_execution, interface):
+    def test_sampling(self, dev, diff_method, grad_on_execution, interface):
         """Test sampling works as expected"""
         if grad_on_execution:
             pytest.skip("Sampling not possible with forward grad_on_execution differentiation.")
 
         if diff_method == "adjoint":
             pytest.skip("Adjoint warns with finite shots")
-
-        dev = qml.device(dev_name, wires=2, shots=10)
 
         @qnode(
             dev, diff_method=diff_method, interface=interface, grad_on_execution=grad_on_execution
@@ -924,15 +828,13 @@ class TestQubitIntegration:
         assert isinstance(res[1], jax.Array)
         assert res[1].shape == (10,)
 
-    def test_counts(self, dev_name, diff_method, grad_on_execution, interface):
+    def test_counts(self, dev, diff_method, grad_on_execution, interface):
         """Test counts works as expected"""
         if grad_on_execution:
             pytest.skip("Sampling not possible with forward grad_on_execution differentiation.")
 
         if diff_method == "adjoint":
             pytest.skip("Adjoint warns with finite shots")
-
-        dev = qml.device(dev_name, wires=2, shots=10)
 
         @qnode(
             dev, diff_method=diff_method, interface=interface, grad_on_execution=grad_on_execution
@@ -957,14 +859,8 @@ class TestQubitIntegration:
             assert isinstance(res[1], dict)
             assert len(res[1]) == 2
 
-    def test_chained_qnodes(self, dev_name, diff_method, grad_on_execution, interface):
+    def test_chained_qnodes(self, dev, diff_method, grad_on_execution, interface):
         """Test that the gradient of chained QNodes works without error"""
-        num_wires = 2
-
-        if diff_method == "hadamard":
-            num_wires = 3
-
-        dev = qml.device(dev_name, wires=num_wires)
 
         class Template(qml.templates.StronglyEntanglingLayers):
             def expand(self):
@@ -1008,12 +904,12 @@ class TestQubitIntegration:
 
 
 @pytest.mark.parametrize(
-    "interface,dev_name,diff_method,grad_on_execution", interface_and_qubit_device_and_diff_method
+    "interface,dev,diff_method,grad_on_execution", interface_and_qubit_device_and_diff_method
 )
 class TestQubitIntegrationHigherOrder:
     """Tests that ensure various qubit circuits integrate correctly when computing higher-order derivatives"""
 
-    def test_second_derivative(self, dev_name, diff_method, grad_on_execution, interface, tol):
+    def test_second_derivative(self, dev, diff_method, grad_on_execution, interface, tol):
         """Test second derivative calculation of a scalar-valued QNode"""
 
         gradient_kwargs = {}
@@ -1022,13 +918,6 @@ class TestQubitIntegrationHigherOrder:
         elif diff_method == "spsa":
             gradient_kwargs = {"sampler_seed": SEED_FOR_SPSA}
             tol = TOL_FOR_SPSA
-
-        num_wires = 1
-
-        if diff_method == "hadamard":
-            num_wires = 3
-
-        dev = qml.device(dev_name, wires=num_wires)
 
         @qnode(
             dev,
@@ -1065,7 +954,7 @@ class TestQubitIntegrationHigherOrder:
         else:
             assert np.allclose(g2, expected_g2, atol=tol, rtol=0)
 
-    def test_hessian(self, dev_name, diff_method, grad_on_execution, interface, tol):
+    def test_hessian(self, dev, diff_method, grad_on_execution, interface, tol):
         """Test hessian calculation of a scalar-valued QNode"""
         gradient_kwargs = {}
         if diff_method == "adjoint":
@@ -1074,13 +963,6 @@ class TestQubitIntegrationHigherOrder:
             qml.math.random.seed(42)
             gradient_kwargs = {"h": H_FOR_SPSA, "num_directions": 20}
             tol = TOL_FOR_SPSA
-
-        num_wires = 1
-
-        if diff_method == "hadamard":
-            num_wires = 3
-
-        dev = qml.device(dev_name, wires=num_wires)
 
         @qnode(
             dev,
@@ -1120,7 +1002,7 @@ class TestQubitIntegrationHigherOrder:
         else:
             assert np.allclose(hess, expected_hess, atol=tol, rtol=0)
 
-    def test_hessian_vector_valued(self, dev_name, diff_method, grad_on_execution, interface, tol):
+    def test_hessian_vector_valued(self, dev, diff_method, grad_on_execution, interface, tol):
         """Test hessian calculation of a vector-valued QNode"""
         gradient_kwargs = {}
         if diff_method == "adjoint":
@@ -1129,13 +1011,6 @@ class TestQubitIntegrationHigherOrder:
             qml.math.random.seed(42)
             gradient_kwargs = {"h": H_FOR_SPSA, "num_directions": 20}
             tol = TOL_FOR_SPSA
-
-        num_wires = 1
-
-        if diff_method == "hadamard":
-            num_wires = 3
-
-        dev = qml.device(dev_name, wires=num_wires)
 
         @qnode(
             dev,
@@ -1185,7 +1060,7 @@ class TestQubitIntegrationHigherOrder:
             assert np.allclose(hess, expected_hess, atol=tol, rtol=0)
 
     def test_hessian_vector_valued_postprocessing(
-        self, dev_name, diff_method, interface, grad_on_execution, tol
+        self, dev, diff_method, interface, grad_on_execution, tol
     ):
         """Test hessian calculation of a vector valued QNode with post-processing"""
         gradient_kwargs = {}
@@ -1195,13 +1070,6 @@ class TestQubitIntegrationHigherOrder:
             qml.math.random.seed(42)
             gradient_kwargs = {"h": H_FOR_SPSA, "num_directions": 20}
             tol = TOL_FOR_SPSA
-
-        num_wires = 1
-
-        if diff_method == "hadamard":
-            num_wires = 3
-
-        dev = qml.device(dev_name, wires=num_wires)
 
         @qnode(
             dev,
@@ -1254,7 +1122,7 @@ class TestQubitIntegrationHigherOrder:
             assert np.allclose(hess, expected_hess, atol=tol, rtol=0)
 
     def test_hessian_vector_valued_separate_args(
-        self, dev_name, diff_method, grad_on_execution, interface, mocker, tol
+        self, dev, diff_method, grad_on_execution, interface, mocker, tol
     ):
         """Test hessian calculation of a vector valued QNode that has separate input arguments"""
         gradient_kwargs = {}
@@ -1264,13 +1132,6 @@ class TestQubitIntegrationHigherOrder:
             qml.math.random.seed(42)
             gradient_kwargs = {"h": H_FOR_SPSA, "num_directions": 20}
             tol = TOL_FOR_SPSA
-
-        num_wires = 1
-
-        if diff_method == "hadamard":
-            num_wires = 3
-
-        dev = qml.device(dev_name, wires=num_wires)
 
         @qnode(
             dev,
@@ -1328,17 +1189,10 @@ class TestQubitIntegrationHigherOrder:
         else:
             assert np.allclose(hess, expected_hess, atol=tol, rtol=0)
 
-    def test_state(self, dev_name, diff_method, grad_on_execution, interface, tol):
+    def test_state(self, dev, diff_method, grad_on_execution, interface, tol):
         """Test that the state can be returned and differentiated"""
         if diff_method == "adjoint":
             pytest.skip("Adjoint does not support states")
-
-        num_wires = 2
-
-        if diff_method == "hadamard":
-            num_wires = 3
-
-        dev = qml.device(dev_name, wires=num_wires)
 
         x = jax.numpy.array(0.543)
         y = jax.numpy.array(-0.654)
@@ -1367,7 +1221,7 @@ class TestQubitIntegrationHigherOrder:
         expected = np.array([-np.sin(x) * np.cos(y) / 2, -np.cos(x) * np.sin(y) / 2])
         assert np.allclose(res, expected, atol=tol, rtol=0)
 
-    def test_projector(self, dev_name, diff_method, grad_on_execution, interface, tol):
+    def test_projector(self, dev, diff_method, grad_on_execution, interface, tol):
         """Test that the variance of a projector is correctly returned"""
         gradient_kwargs = {}
         if diff_method == "adjoint":
@@ -1379,7 +1233,6 @@ class TestQubitIntegrationHigherOrder:
             gradient_kwargs = {"h": H_FOR_SPSA}
             tol = TOL_FOR_SPSA
 
-        dev = qml.device(dev_name, wires=2)
         P = jax.numpy.array([1])
         x, y = 0.765, -0.654
 
@@ -1410,96 +1263,8 @@ class TestQubitIntegrationHigherOrder:
         assert np.allclose(res, expected, atol=tol, rtol=0)
 
 
-# TODO: Add CV test when return types and custom diff are compatible
-@pytest.mark.xfail(reason="CV variables with new return types.")
 @pytest.mark.parametrize(
-    "diff_method,kwargs",
-    [
-        ["finite-diff", {}],
-        ["spsa", {"num_directions": 100, "h": H_FOR_SPSA}],
-        ("parameter-shift", {}),
-        ("parameter-shift", {"force_order2": True}),
-    ],
-)
-@pytest.mark.parametrize("interface", ["auto", "jax-jit", "jax"])
-class TestCV:
-    """Tests for CV integration"""
-
-    def test_first_order_observable(self, diff_method, kwargs, interface, tol):
-        """Test variance of a first order CV observable"""
-        dev = qml.device("default.gaussian", wires=1)
-        if diff_method == "spsa":
-            tol = TOL_FOR_SPSA
-
-        r = 0.543
-        phi = -0.654
-
-        @qnode(dev, interface=interface, diff_method=diff_method, **kwargs)
-        def circuit(r, phi):
-            qml.Squeezing(r, 0, wires=0)
-            qml.Rotation(phi, wires=0)
-            return qml.var(qml.QuadX(0))
-
-        res = circuit(r, phi)
-        expected = np.exp(2 * r) * np.sin(phi) ** 2 + np.exp(-2 * r) * np.cos(phi) ** 2
-        assert np.allclose(res, expected, atol=tol, rtol=0)
-
-        # circuit jacobians
-        res = jax.grad(circuit, argnums=[0, 1])(r, phi)
-        expected = np.array(
-            [
-                2 * np.exp(2 * r) * np.sin(phi) ** 2 - 2 * np.exp(-2 * r) * np.cos(phi) ** 2,
-                2 * np.sinh(2 * r) * np.sin(2 * phi),
-            ]
-        )
-        assert np.allclose(res, expected, atol=tol, rtol=0)
-
-    def test_second_order_observable(self, diff_method, kwargs, interface, tol):
-        """Test variance of a second order CV expectation value"""
-        dev = qml.device("default.gaussian", wires=1)
-        if diff_method == "spsa":
-            tol = TOL_FOR_SPSA
-
-        n = 0.12
-        a = 0.765
-
-        @qnode(dev, interface=interface, diff_method=diff_method, **kwargs)
-        def circuit(n, a):
-            qml.ThermalState(n, wires=0)
-            qml.Displacement(a, 0, wires=0)
-            return qml.var(qml.NumberOperator(0))
-
-        res = circuit(n, a)
-        expected = n**2 + n + np.abs(a) ** 2 * (1 + 2 * n)
-        assert np.allclose(res, expected, atol=tol, rtol=0)
-
-        # circuit jacobians
-        res = jax.grad(circuit, argnums=[0, 1])(n, a)
-        expected = np.array([2 * a**2 + 2 * n + 1, 2 * a * (2 * n + 1)])
-        assert np.allclose(res, expected, atol=tol, rtol=0)
-
-
-# TODO: add support for fwd grad_on_execution to JAX-JIT
-@pytest.mark.parametrize("interface", ["auto", "jax-jit"])
-def test_adjoint_reuse_device_state(mocker, interface):
-    """Tests that the jax interface reuses the device state for adjoint differentiation"""
-    dev = qml.device("default.qubit", wires=1)
-
-    @qnode(dev, interface=interface, diff_method="adjoint")
-    def circ(x):
-        qml.RX(x, wires=0)
-        return qml.expval(qml.PauliZ(0))
-
-    spy = mocker.spy(dev, "adjoint_jacobian")
-
-    jax.grad(circ)(1.0)
-    assert circ.device.num_executions == 1
-
-    spy.assert_called_with(mocker.ANY, use_device_state=True)
-
-
-@pytest.mark.parametrize(
-    "interface,dev_name,diff_method,grad_on_execution", interface_and_qubit_device_and_diff_method
+    "interface,dev,diff_method,grad_on_execution", interface_and_qubit_device_and_diff_method
 )
 class TestTapeExpansion:
     """Test that tape expansion within the QNode integrates correctly
@@ -1507,19 +1272,12 @@ class TestTapeExpansion:
 
     @pytest.mark.parametrize("max_diff", [1, 2])
     def test_gradient_expansion_trainable_only(
-        self, dev_name, diff_method, grad_on_execution, max_diff, interface, mocker
+        self, dev, diff_method, grad_on_execution, max_diff, interface, mocker
     ):
         """Test that a *supported* operation with no gradient recipe is only
         expanded for parameter-shift and finite-differences when it is trainable."""
         if diff_method not in ("parameter-shift", "finite-diff", "spsa"):
             pytest.skip("Only supports gradient transforms")
-
-        num_wires = 1
-
-        if diff_method == "hadamard":
-            num_wires = 2
-
-        dev = qml.device(dev_name, wires=num_wires)
 
         class PhaseShift(qml.PhaseShift):
             grad_method = None
@@ -1557,7 +1315,7 @@ class TestTapeExpansion:
 
     @pytest.mark.parametrize("max_diff", [1, 2])
     def test_hamiltonian_expansion_analytic(
-        self, dev_name, diff_method, grad_on_execution, max_diff, interface, mocker, tol
+        self, dev, diff_method, grad_on_execution, max_diff, interface, mocker, tol
     ):
         """Test that the Hamiltonian is not expanded if there
         are non-commuting groups and the number of shots is None
@@ -1572,7 +1330,6 @@ class TestTapeExpansion:
             gradient_kwargs = {"h": H_FOR_SPSA, "num_directions": 20}
             tol = TOL_FOR_SPSA
 
-        dev = qml.device(dev_name, wires=3, shots=None)
         spy = mocker.spy(qml.transforms, "hamiltonian_expand")
         obs = [qml.PauliX(0), qml.PauliX(0) @ qml.PauliZ(1), qml.PauliZ(0) @ qml.PauliZ(1)]
 
@@ -1626,7 +1383,7 @@ class TestTapeExpansion:
 
     @pytest.mark.parametrize("max_diff", [1, 2])
     def test_hamiltonian_expansion_finite_shots(
-        self, dev_name, diff_method, grad_on_execution, interface, max_diff, mocker
+        self, dev, diff_method, grad_on_execution, interface, max_diff, mocker
     ):
         """Test that the Hamiltonian is expanded if there
         are non-commuting groups and the number of shots is finite
@@ -1641,7 +1398,6 @@ class TestTapeExpansion:
             gradient_kwargs = {"sampler_seed": SEED_FOR_SPSA, "h": H_FOR_SPSA}
             tol = TOL_FOR_SPSA
 
-        dev = qml.device(dev_name, wires=3, shots=50000)
         spy = mocker.spy(qml.transforms, "hamiltonian_expand")
         obs = [qml.PauliX(0), qml.PauliX(0) @ qml.PauliZ(1), qml.PauliZ(0) @ qml.PauliZ(1)]
 
@@ -1666,13 +1422,13 @@ class TestTapeExpansion:
         c = jax.numpy.array([-0.6543, 0.24, 0.54])
 
         # test output
-        res = circuit(d, w, c)
+        res = circuit(d, w, c, shots=50000)  # pylint:disable=unexpected-keyword-arg
         expected = c[2] * np.cos(d[1] + w[1]) - c[1] * np.sin(d[0] + w[0]) * np.sin(d[1] + w[1])
         assert np.allclose(res, expected, atol=tol)
         spy.assert_called()
 
         # test gradients
-        grad = jax.grad(circuit, argnums=[1, 2])(d, w, c)
+        grad = jax.grad(circuit, argnums=[1, 2])(d, w, c, shots=50000)
         expected_w = [
             -c[1] * np.cos(d[0] + w[0]) * np.sin(d[1] + w[1]),
             -c[1] * np.cos(d[1] + w[1]) * np.sin(d[0] + w[0]) - c[2] * np.sin(d[1] + w[1]),
@@ -1697,7 +1453,7 @@ class TestTapeExpansion:
     #         assert np.allclose(grad2_w_c, expected, atol=tol)
 
     def test_vmap_compared_param_broadcasting(
-        self, dev_name, diff_method, grad_on_execution, interface, tol
+        self, dev, diff_method, grad_on_execution, interface, tol
     ):
         """Test that jax.vmap works just as well as parameter-broadcasting with JAX JIT on the forward pass when
         vectorized=True is specified for the callback when caching is disabled."""
@@ -1712,12 +1468,8 @@ class TestTapeExpansion:
                 "The backprop method does not yet support parameter-broadcasting with Hamiltonians"
             )
 
-        phys_qubits = 2
-        if diff_method == "hadamard":
-            phys_qubits = 3
         n_configs = 5
         pars_q = np.random.rand(n_configs, 2)
-        dev = qml.device(dev_name, wires=tuple(range(phys_qubits)), shots=None)
 
         def minimal_circ(params):
             @qml.qnode(
@@ -1741,7 +1493,7 @@ class TestTapeExpansion:
         )
 
     def test_vmap_compared_param_broadcasting_multi_output(
-        self, dev_name, diff_method, grad_on_execution, interface, tol
+        self, dev, diff_method, grad_on_execution, interface, tol
     ):
         """Test that jax.vmap works just as well as parameter-broadcasting with JAX JIT on the forward pass when
         vectorized=True is specified for the callback when caching is disabled and when multiple output values
@@ -1757,10 +1509,8 @@ class TestTapeExpansion:
                 "The backprop method does not yet support parameter-broadcasting with Hamiltonians"
             )
 
-        phys_qubits = 2
         n_configs = 5
         pars_q = np.random.rand(n_configs, 2)
-        dev = qml.device(dev_name, wires=tuple(range(phys_qubits)), shots=None)
 
         def minimal_circ(params):
             @qml.qnode(
@@ -1791,21 +1541,14 @@ jacobian_fn = [jax.jacobian, jax.jacrev, jax.jacfwd]
 
 @pytest.mark.parametrize("jacobian", jacobian_fn)
 @pytest.mark.parametrize(
-    "interface,dev_name,diff_method,grad_on_execution", interface_and_qubit_device_and_diff_method
+    "interface,dev,diff_method,grad_on_execution", interface_and_qubit_device_and_diff_method
 )
 class TestJIT:
     """Test JAX JIT integration with the QNode and automatic resolution of the
     correct JAX interface variant."""
 
-    def test_gradient(self, dev_name, diff_method, grad_on_execution, jacobian, tol, interface):
+    def test_gradient(self, dev, diff_method, grad_on_execution, jacobian, tol, interface):
         """Test derivative calculation of a scalar valued QNode"""
-        num_wires = 1
-
-        if diff_method == "hadamard":
-            num_wires = 2
-
-        dev = qml.device(dev_name, wires=num_wires)
-
         gradient_kwargs = {}
         if diff_method == "adjoint":
             pytest.xfail(reason="The adjoint method is not using host-callback currently")
@@ -1841,7 +1584,7 @@ class TestJIT:
         "ignore:Requested adjoint differentiation to be computed with finite shots."
     )
     @pytest.mark.parametrize("shots", [10, 1000])
-    def test_hermitian(self, dev_name, diff_method, grad_on_execution, shots, jacobian, interface):
+    def test_hermitian(self, dev, diff_method, grad_on_execution, shots, jacobian, interface):
         """Test that the jax device works with qml.Hermitian and jitting even
         when shots>0.
 
@@ -1849,13 +1592,6 @@ class TestJIT:
         to different reasons, hence the parametrization in the test.
         """
         # pylint: disable=unused-argument
-        num_wires = 2
-
-        if diff_method == "hadamard":
-            num_wires = 3
-
-        dev = qml.device(dev_name, wires=num_wires, shots=shots)
-
         if diff_method == "backprop":
             pytest.skip("Backpropagation is unsupported if shots > 0.")
 
@@ -1877,19 +1613,10 @@ class TestJIT:
         "ignore:Requested adjoint differentiation to be computed with finite shots."
     )
     @pytest.mark.parametrize("shots", [10, 1000])
-    def test_probs_obs_none(
-        self, dev_name, diff_method, grad_on_execution, shots, jacobian, interface
-    ):
+    def test_probs_obs_none(self, dev, diff_method, grad_on_execution, shots, jacobian, interface):
         """Test that the jax device works with qml.probs, a MeasurementProcess
         that has obs=None even when shots>0."""
         # pylint: disable=unused-argument
-        num_wires = 2
-
-        if diff_method == "hadamard":
-            num_wires = 3
-
-        dev = qml.device(dev_name, wires=num_wires, shots=shots)
-
         if diff_method in ["backprop", "adjoint"]:
             pytest.skip("Backpropagation is unsupported if shots > 0.")
 
@@ -1904,15 +1631,11 @@ class TestJIT:
     @pytest.mark.xfail(
         reason="Non-trainable parameters are not being correctly unwrapped by the interface"
     )
-    def test_gradient_subset(
-        self, dev_name, diff_method, grad_on_execution, jacobian, tol, interface
-    ):
+    def test_gradient_subset(self, dev, diff_method, grad_on_execution, jacobian, tol, interface):
         """Test derivative calculation of a scalar valued QNode with respect
         to a subset of arguments"""
         a = jax.numpy.array(0.1)
         b = jax.numpy.array(0.2)
-
-        dev = qml.device(dev_name, wires=1)
 
         @qnode(
             dev, diff_method=diff_method, interface=interface, grad_on_execution=grad_on_execution
@@ -1932,17 +1655,10 @@ class TestJIT:
         assert np.allclose(g, expected_g, atol=tol, rtol=0)
 
     def test_gradient_scalar_cost_vector_valued_qnode(
-        self, dev_name, diff_method, grad_on_execution, jacobian, tol, interface
+        self, dev, diff_method, grad_on_execution, jacobian, tol, interface
     ):
         """Test derivative calculation of a scalar valued cost function that
         uses the output of a vector-valued QNode"""
-        num_wires = 2
-
-        if diff_method == "hadamard":
-            num_wires = 3
-
-        dev = qml.device(dev_name, wires=num_wires)
-
         gradient_kwargs = {}
         if diff_method == "adjoint":
             pytest.xfail(reason="The adjoint method is not using host-callback currently")
@@ -1987,19 +1703,10 @@ class TestJIT:
         assert np.allclose(g0, expected_g[0][idx], atol=tol, rtol=0)
         assert np.allclose(g1, expected_g[1][idx], atol=tol, rtol=0)
 
-    def test_matrix_parameter(
-        self, dev_name, diff_method, grad_on_execution, jacobian, tol, interface
-    ):
+    def test_matrix_parameter(self, dev, diff_method, grad_on_execution, jacobian, tol, interface):
         """Test that the JAX-JIT interface works correctly with a matrix
         parameter"""
         # pylint: disable=unused-argument
-        num_wires = 1
-
-        if diff_method == "hadamard":
-            num_wires = 2
-
-        dev = qml.device(dev_name, wires=num_wires)
-
         @qml.qnode(
             dev, diff_method=diff_method, interface=interface, grad_on_execution=grad_on_execution
         )
@@ -2021,24 +1728,17 @@ class TestJIT:
 @pytest.mark.parametrize("shots", [None, 10000])
 @pytest.mark.parametrize("jacobian", jacobian_fn)
 @pytest.mark.parametrize(
-    "interface,dev_name,diff_method,grad_on_execution", interface_and_qubit_device_and_diff_method
+    "interface,dev,diff_method,grad_on_execution", interface_and_qubit_device_and_diff_method
 )
 class TestReturn:
     """Class to test the shape of the Grad/Jacobian with different return types."""
 
     def test_grad_single_measurement_param(
-        self, dev_name, diff_method, grad_on_execution, jacobian, shots, interface
+        self, dev, diff_method, grad_on_execution, jacobian, shots, interface
     ):
         """For one measurement and one param, the gradient is a float."""
         if shots is not None and diff_method in ("backprop", "adjoint"):
             pytest.skip("Test does not support finite shots and adjoint/backprop")
-
-        num_wires = 1
-
-        if diff_method == "hadamard":
-            num_wires = 2
-
-        dev = qml.device(dev_name, wires=num_wires, shots=shots)
 
         @qnode(
             dev, interface=interface, diff_method=diff_method, grad_on_execution=grad_on_execution
@@ -2050,24 +1750,17 @@ class TestReturn:
 
         a = jax.numpy.array(0.1)
 
-        grad = jax.jit(jacobian(circuit))(a)
+        grad = jax.jit(jacobian(circuit))(a, shots=shots)
 
         assert isinstance(grad, jax.numpy.ndarray)
         assert grad.shape == ()
 
     def test_grad_single_measurement_multiple_param(
-        self, dev_name, diff_method, grad_on_execution, jacobian, shots, interface
+        self, dev, diff_method, grad_on_execution, jacobian, shots, interface
     ):
         """For one measurement and multiple param, the gradient is a tuple of arrays."""
         if shots is not None and diff_method in ("backprop", "adjoint"):
             pytest.skip("Test does not support finite shots and adjoint/backprop")
-
-        num_wires = 1
-
-        if diff_method == "hadamard":
-            num_wires = 2
-
-        dev = qml.device(dev_name, wires=num_wires, shots=shots)
 
         @qnode(
             dev, interface=interface, diff_method=diff_method, grad_on_execution=grad_on_execution
@@ -2080,7 +1773,7 @@ class TestReturn:
         a = jax.numpy.array(0.1)
         b = jax.numpy.array(0.2)
 
-        grad = jax.jit(jacobian(circuit, argnums=[0, 1]))(a, b)
+        grad = jax.jit(jacobian(circuit, argnums=[0, 1]))(a, b, shots=shots)
 
         assert isinstance(grad, tuple)
         assert len(grad) == 2
@@ -2088,18 +1781,11 @@ class TestReturn:
         assert grad[1].shape == ()
 
     def test_grad_single_measurement_multiple_param_array(
-        self, dev_name, diff_method, grad_on_execution, jacobian, shots, interface
+        self, dev, diff_method, grad_on_execution, jacobian, shots, interface
     ):
         """For one measurement and multiple param as a single array params, the gradient is an array."""
         if shots is not None and diff_method in ("backprop", "adjoint"):
             pytest.skip("Test does not support finite shots and adjoint/backprop")
-
-        num_wires = 1
-
-        if diff_method == "hadamard":
-            num_wires = 2
-
-        dev = qml.device(dev_name, wires=num_wires, shots=shots)
 
         @qnode(
             dev, interface=interface, diff_method=diff_method, grad_on_execution=grad_on_execution
@@ -2111,13 +1797,13 @@ class TestReturn:
 
         a = jax.numpy.array([0.1, 0.2])
 
-        grad = jax.jit(jacobian(circuit))(a)
+        grad = jax.jit(jacobian(circuit))(a, shots=shots)
 
         assert isinstance(grad, jax.numpy.ndarray)
         assert grad.shape == (2,)
 
     def test_jacobian_single_measurement_param_probs(
-        self, dev_name, diff_method, grad_on_execution, jacobian, shots, interface
+        self, dev, diff_method, grad_on_execution, jacobian, shots, interface
     ):
         """For a multi dimensional measurement (probs), check that a single array is returned with the correct
         dimension"""
@@ -2126,13 +1812,6 @@ class TestReturn:
 
         if diff_method == "adjoint":
             pytest.skip("Test does not supports adjoint because of probabilities.")
-
-        num_wires = 2
-
-        if diff_method == "hadamard":
-            num_wires = 3
-
-        dev = qml.device(dev_name, wires=num_wires, shots=shots)
 
         @qnode(
             dev, interface=interface, diff_method=diff_method, grad_on_execution=grad_on_execution
@@ -2144,13 +1823,13 @@ class TestReturn:
 
         a = jax.numpy.array(0.1)
 
-        jac = jax.jit(jacobian(circuit))(a)
+        jac = jax.jit(jacobian(circuit))(a, shots=shots)
 
         assert isinstance(jac, jax.numpy.ndarray)
         assert jac.shape == (4,)
 
     def test_jacobian_single_measurement_probs_multiple_param(
-        self, dev_name, diff_method, grad_on_execution, jacobian, shots, interface
+        self, dev, diff_method, grad_on_execution, jacobian, shots, interface
     ):
         """For a multi dimensional measurement (probs), check that a single tuple is returned containing arrays with
         the correct dimension"""
@@ -2158,13 +1837,6 @@ class TestReturn:
             pytest.skip("Test does not supports adjoint because of probabilities.")
         if shots is not None and diff_method in ("backprop", "adjoint"):
             pytest.skip("Test does not support finite shots and adjoint/backprop")
-
-        num_wires = 2
-
-        if diff_method == "hadamard":
-            num_wires = 3
-
-        dev = qml.device(dev_name, wires=num_wires, shots=shots)
 
         @qnode(
             dev, interface=interface, diff_method=diff_method, grad_on_execution=grad_on_execution
@@ -2177,7 +1849,7 @@ class TestReturn:
         a = jax.numpy.array(0.1)
         b = jax.numpy.array(0.2)
 
-        jac = jax.jit(jacobian(circuit, argnums=[0, 1]))(a, b)
+        jac = jax.jit(jacobian(circuit, argnums=[0, 1]))(a, b, shots=shots)
 
         assert isinstance(jac, tuple)
 
@@ -2188,7 +1860,7 @@ class TestReturn:
         assert jac[1].shape == (4,)
 
     def test_jacobian_single_measurement_probs_multiple_param_single_array(
-        self, dev_name, diff_method, grad_on_execution, jacobian, shots, interface
+        self, dev, diff_method, grad_on_execution, jacobian, shots, interface
     ):
         """For a multi dimensional measurement (probs), check that a single tuple is returned containing arrays with
         the correct dimension"""
@@ -2196,13 +1868,6 @@ class TestReturn:
             pytest.skip("Test does not supports adjoint because of probabilities.")
         if shots is not None and diff_method in ("backprop", "adjoint"):
             pytest.skip("Test does not support finite shots and adjoint/backprop")
-
-        num_wires = 2
-
-        if diff_method == "hadamard":
-            num_wires = 3
-
-        dev = qml.device(dev_name, wires=num_wires, shots=shots)
 
         @qnode(
             dev, interface=interface, diff_method=diff_method, grad_on_execution=grad_on_execution
@@ -2213,23 +1878,17 @@ class TestReturn:
             return qml.probs(wires=[0, 1])
 
         a = jax.numpy.array([0.1, 0.2])
-        jac = jax.jit(jacobian(circuit))(a)
+        jac = jax.jit(jacobian(circuit))(a, shots=shots)
 
         assert isinstance(jac, jax.numpy.ndarray)
         assert jac.shape == (4, 2)
 
     def test_jacobian_expval_expval_multiple_params(
-        self, dev_name, diff_method, grad_on_execution, jacobian, shots, interface
+        self, dev, diff_method, grad_on_execution, jacobian, shots, interface
     ):
         """The jacobian of multiple measurements with multiple params return a tuple of arrays."""
         if shots is not None and diff_method in ("backprop", "adjoint"):
             pytest.skip("Test does not support finite shots and adjoint/backprop")
-        num_wires = 2
-
-        if diff_method == "hadamard":
-            num_wires = 3
-
-        dev = qml.device(dev_name, wires=num_wires, shots=shots)
 
         par_0 = jax.numpy.array(0.1)
         par_1 = jax.numpy.array(0.2)
@@ -2243,7 +1902,7 @@ class TestReturn:
             qml.CNOT(wires=[0, 1])
             return qml.expval(qml.PauliZ(0) @ qml.PauliX(1)), qml.expval(qml.PauliZ(0))
 
-        jac = jax.jit(jacobian(circuit, argnums=[0, 1]))(par_0, par_1)
+        jac = jax.jit(jacobian(circuit, argnums=[0, 1]))(par_0, par_1, shots=shots)
 
         assert isinstance(jac, tuple)
 
@@ -2262,17 +1921,11 @@ class TestReturn:
         assert jac[1][1].shape == ()
 
     def test_jacobian_expval_expval_multiple_params_array(
-        self, dev_name, diff_method, grad_on_execution, jacobian, shots, interface
+        self, dev, diff_method, grad_on_execution, jacobian, shots, interface
     ):
         """The jacobian of multiple measurements with a multiple params array return a single array."""
         if shots is not None and diff_method in ("backprop", "adjoint"):
             pytest.skip("Test does not support finite shots and adjoint/backprop")
-        num_wires = 2
-
-        if diff_method == "hadamard":
-            num_wires = 3
-
-        dev = qml.device(dev_name, wires=num_wires, shots=shots)
 
         @qnode(
             dev, interface=interface, diff_method=diff_method, grad_on_execution=grad_on_execution
@@ -2284,7 +1937,7 @@ class TestReturn:
 
         a = jax.numpy.array([0.1, 0.2])
 
-        jac = jax.jit(jacobian(circuit))(a)
+        jac = jax.jit(jacobian(circuit))(a, shots=shots)
 
         assert isinstance(jac, tuple)
         assert len(jac) == 2  # measurements
@@ -2296,7 +1949,7 @@ class TestReturn:
         assert jac[1].shape == (2,)
 
     def test_jacobian_var_var_multiple_params(
-        self, dev_name, diff_method, grad_on_execution, jacobian, shots, interface
+        self, dev, diff_method, grad_on_execution, jacobian, shots, interface
     ):
         """The jacobian of multiple measurements with multiple params return a tuple of arrays."""
         if diff_method == "adjoint":
@@ -2305,8 +1958,6 @@ class TestReturn:
             pytest.skip("Test does not supports hadamard because of var.")
         if shots is not None and diff_method in ("backprop", "adjoint"):
             pytest.skip("Test does not support finite shots and adjoint/backprop")
-
-        dev = qml.device(dev_name, wires=2, shots=shots)
 
         par_0 = jax.numpy.array(0.1)
         par_1 = jax.numpy.array(0.2)
@@ -2320,7 +1971,7 @@ class TestReturn:
             qml.CNOT(wires=[0, 1])
             return qml.var(qml.PauliZ(0) @ qml.PauliX(1)), qml.var(qml.PauliZ(0))
 
-        jac = jax.jit(jacobian(circuit, argnums=[0, 1]))(par_0, par_1)
+        jac = jax.jit(jacobian(circuit, argnums=[0, 1]))(par_0, par_1, shots=shots)
 
         assert isinstance(jac, tuple)
         assert len(jac) == 2
@@ -2340,7 +1991,7 @@ class TestReturn:
         assert jac[1][1].shape == ()
 
     def test_jacobian_var_var_multiple_params_array(
-        self, dev_name, diff_method, grad_on_execution, jacobian, shots, interface
+        self, dev, diff_method, grad_on_execution, jacobian, shots, interface
     ):
         """The jacobian of multiple measurements with a multiple params array return a single array."""
         if diff_method == "adjoint":
@@ -2349,8 +2000,6 @@ class TestReturn:
             pytest.skip("Test does not supports hadamard because of var.")
         if shots is not None and diff_method in ("backprop", "adjoint"):
             pytest.skip("Test does not support finite shots and adjoint/backprop")
-
-        dev = qml.device(dev_name, wires=2, shots=shots)
 
         @qnode(
             dev, interface=interface, diff_method=diff_method, grad_on_execution=grad_on_execution
@@ -2362,7 +2011,7 @@ class TestReturn:
 
         a = jax.numpy.array([0.1, 0.2])
 
-        jac = jax.jit(jacobian(circuit))(a)
+        jac = jax.jit(jacobian(circuit))(a, shots=shots)
 
         assert isinstance(jac, tuple)
         assert len(jac) == 2  # measurements
@@ -2374,17 +2023,11 @@ class TestReturn:
         assert jac[1].shape == (2,)
 
     def test_jacobian_multiple_measurement_single_param(
-        self, dev_name, diff_method, grad_on_execution, jacobian, shots, interface
+        self, dev, diff_method, grad_on_execution, jacobian, shots, interface
     ):
         """The jacobian of multiple measurements with a single params return an array."""
         if shots is not None and diff_method in ("backprop", "adjoint"):
             pytest.skip("Test does not support finite shots and adjoint/backprop")
-        num_wires = 2
-
-        if diff_method == "hadamard":
-            num_wires = 3
-
-        dev = qml.device(dev_name, wires=num_wires, shots=shots)
 
         if diff_method == "adjoint":
             pytest.skip("Test does not supports adjoint because of probabilities.")
@@ -2399,7 +2042,7 @@ class TestReturn:
 
         a = jax.numpy.array(0.1)
 
-        jac = jax.jit(jacobian(circuit))(a)
+        jac = jax.jit(jacobian(circuit))(a, shots=shots)
 
         assert isinstance(jac, tuple)
         assert len(jac) == 2
@@ -2411,20 +2054,13 @@ class TestReturn:
         assert jac[1].shape == (4,)
 
     def test_jacobian_multiple_measurement_multiple_param(
-        self, dev_name, diff_method, grad_on_execution, jacobian, shots, interface
+        self, dev, diff_method, grad_on_execution, jacobian, shots, interface
     ):
         """The jacobian of multiple measurements with a multiple params return a tuple of arrays."""
         if diff_method == "adjoint":
             pytest.skip("Test does not supports adjoint because of probabilities.")
         if shots is not None and diff_method in ("backprop", "adjoint"):
             pytest.skip("Test does not support finite shots and adjoint/backprop")
-
-        num_wires = 2
-
-        if diff_method == "hadamard":
-            num_wires = 3
-
-        dev = qml.device(dev_name, wires=num_wires, shots=shots)
 
         @qnode(
             dev, interface=interface, diff_method=diff_method, grad_on_execution=grad_on_execution
@@ -2437,7 +2073,7 @@ class TestReturn:
         a = np.array(0.1, requires_grad=True)
         b = np.array(0.2, requires_grad=True)
 
-        jac = jax.jit(jacobian(circuit, argnums=[0, 1]))(a, b)
+        jac = jax.jit(jacobian(circuit, argnums=[0, 1]))(a, b, shots=shots)
 
         assert isinstance(jac, tuple)
         assert len(jac) == 2
@@ -2457,20 +2093,13 @@ class TestReturn:
         assert jac[1][1].shape == (4,)
 
     def test_jacobian_multiple_measurement_multiple_param_array(
-        self, dev_name, diff_method, grad_on_execution, jacobian, shots, interface
+        self, dev, diff_method, grad_on_execution, jacobian, shots, interface
     ):
         """The jacobian of multiple measurements with a multiple params array return a single array."""
         if diff_method == "adjoint":
             pytest.skip("Test does not supports adjoint because of probabilities.")
         if shots is not None and diff_method in ("backprop", "adjoint"):
             pytest.skip("Test does not support finite shots and adjoint/backprop")
-
-        num_wires = 2
-
-        if diff_method == "hadamard":
-            num_wires = 3
-
-        dev = qml.device(dev_name, wires=num_wires, shots=shots)
 
         @qnode(
             dev, interface=interface, diff_method=diff_method, grad_on_execution=grad_on_execution
@@ -2482,7 +2111,7 @@ class TestReturn:
 
         a = jax.numpy.array([0.1, 0.2])
 
-        jac = jax.jit(jacobian(circuit))(a)
+        jac = jax.jit(jacobian(circuit))(a, shots=shots)
 
         assert isinstance(jac, tuple)
         assert len(jac) == 2  # measurements
@@ -2503,22 +2132,15 @@ hessian_fn = [
 
 @pytest.mark.parametrize("hessian", hessian_fn)
 @pytest.mark.parametrize(
-    "interface,dev_name,diff_method,grad_on_execution", interface_and_qubit_device_and_diff_method
+    "interface,dev,diff_method,grad_on_execution", interface_and_qubit_device_and_diff_method
 )
 class TestReturnHessian:
     """Class to test the shape of the Hessian with different return types."""
 
     def test_hessian_expval_multiple_params(
-        self, dev_name, diff_method, hessian, grad_on_execution, interface
+        self, dev, diff_method, hessian, grad_on_execution, interface
     ):
         """The hessian of single a measurement with multiple params return a tuple of arrays."""
-        num_wires = 2
-
-        if diff_method == "hadamard":
-            num_wires = 4
-
-        dev = qml.device(dev_name, wires=num_wires)
-
         if diff_method == "adjoint":
             pytest.skip("Test does not supports adjoint because second order diff.")
 
@@ -2558,19 +2180,12 @@ class TestReturnHessian:
         assert hess[1][1].shape == ()
 
     def test_hessian_expval_multiple_param_array(
-        self, dev_name, diff_method, hessian, grad_on_execution, interface
+        self, dev, diff_method, hessian, grad_on_execution, interface
     ):
         """The hessian of single measurement with a multiple params array return a single array."""
 
         if diff_method == "adjoint":
             pytest.skip("Test does not supports adjoint because second order diff.")
-
-        num_wires = 2
-
-        if diff_method == "hadamard":
-            num_wires = 4
-
-        dev = qml.device(dev_name, wires=num_wires)
 
         params = jax.numpy.array([0.1, 0.2], dtype=jax.numpy.float64)
 
@@ -2593,11 +2208,9 @@ class TestReturnHessian:
         assert hess.shape == (2, 2)
 
     def test_hessian_var_multiple_params(
-        self, dev_name, diff_method, hessian, grad_on_execution, interface
+        self, dev, diff_method, hessian, grad_on_execution, interface
     ):
         """The hessian of single a measurement with multiple params return a tuple of arrays."""
-        dev = qml.device(dev_name, wires=2)
-
         if diff_method == "adjoint":
             pytest.skip("Test does not supports adjoint because second order diff.")
         elif diff_method == "hadamard":
@@ -2639,15 +2252,13 @@ class TestReturnHessian:
         assert hess[1][1].shape == ()
 
     def test_hessian_var_multiple_param_array(
-        self, dev_name, diff_method, hessian, grad_on_execution, interface
+        self, dev, diff_method, hessian, grad_on_execution, interface
     ):
         """The hessian of single measurement with a multiple params array return a single array."""
         if diff_method == "adjoint":
             pytest.skip("Test does not supports adjoint because second order diff.")
         elif diff_method == "hadamard":
             pytest.skip("Test does not supports hadamard because of var.")
-
-        dev = qml.device(dev_name, wires=2)
 
         params = jax.numpy.array([0.1, 0.2], dtype=jax.numpy.float64)
 
@@ -2670,16 +2281,9 @@ class TestReturnHessian:
         assert hess.shape == (2, 2)
 
     def test_hessian_probs_expval_multiple_params(
-        self, dev_name, diff_method, hessian, grad_on_execution, interface
+        self, dev, diff_method, hessian, grad_on_execution, interface
     ):
         """The hessian of multiple measurements with multiple params return a tuple of arrays."""
-        num_wires = 2
-
-        if diff_method == "hadamard":
-            num_wires = 4
-
-        dev = qml.device(dev_name, wires=num_wires)
-
         if diff_method == "adjoint":
             pytest.skip("Test does not supports adjoint because second order diff.")
         elif diff_method == "hadamard":
@@ -2720,7 +2324,7 @@ class TestReturnHessian:
                 assert h_comp.shape == (2,)
 
     def test_hessian_probs_expval_multiple_param_array(
-        self, dev_name, diff_method, hessian, grad_on_execution, interface
+        self, dev, diff_method, hessian, grad_on_execution, interface
     ):
         """The hessian of multiple measurements with a multiple param array return a single array."""
 
@@ -2728,13 +2332,6 @@ class TestReturnHessian:
             pytest.skip("Test does not supports adjoint because second order diff.")
         elif diff_method == "hadamard":
             pytest.skip("Test does not supports hadamard because of non commuting obs.")
-
-        num_wires = 2
-
-        if diff_method == "hadamard":
-            num_wires = 4
-
-        dev = qml.device(dev_name, wires=num_wires)
 
         params = jax.numpy.array([0.1, 0.2], dtype=jax.numpy.float64)
 
@@ -2762,11 +2359,9 @@ class TestReturnHessian:
         assert hess[1].shape == (2, 2, 2)
 
     def test_hessian_probs_var_multiple_params(
-        self, dev_name, diff_method, hessian, grad_on_execution, interface
+        self, dev, diff_method, hessian, grad_on_execution, interface
     ):
         """The hessian of multiple measurements with multiple params return a tuple of arrays."""
-        dev = qml.device(dev_name, wires=2)
-
         if diff_method == "adjoint":
             pytest.skip("Test does not supports adjoint because second order diff.")
         elif diff_method == "hadamard":
@@ -2807,15 +2402,13 @@ class TestReturnHessian:
                 assert h_comp.shape == (2,)
 
     def test_hessian_probs_var_multiple_param_array(
-        self, dev_name, diff_method, hessian, grad_on_execution, interface
+        self, dev, diff_method, hessian, grad_on_execution, interface
     ):
         """The hessian of multiple measurements with a multiple param array return a single array."""
         if diff_method == "adjoint":
             pytest.skip("Test does not supports adjoint because second order diff.")
         elif diff_method == "hadamard":
             pytest.skip("Test does not supports hadamard because of var.")
-
-        dev = qml.device(dev_name, wires=2)
 
         params = jax.numpy.array([0.1, 0.2], dtype=jax.numpy.float64)
 
@@ -2844,18 +2437,12 @@ class TestReturnHessian:
 
 
 @pytest.mark.parametrize("hessian", hessian_fn)
-@pytest.mark.parametrize("diff_method", ["param-shift", "hadamard"])
+@pytest.mark.parametrize("diff_method", ["parameter-shift", "hadamard"])
 def test_jax_device_hessian_shots(hessian, diff_method):
     """The hessian of multiple measurements with a multiple param array return a single array."""
-    num_wires = 1
-
-    if diff_method == "hadamard":
-        num_wires = 3
-
-    dev = qml.device("default.qubit.jax", wires=num_wires, shots=10000)
 
     @jax.jit
-    @qml.qnode(dev, diff_method="parameter-shift", max_diff=2)
+    @qml.qnode(DefaultQubit2(), diff_method=diff_method, max_diff=2)
     def circuit(x):
         qml.RY(x[0], wires=0)
         qml.RX(x[1], wires=0)
@@ -2864,7 +2451,7 @@ def test_jax_device_hessian_shots(hessian, diff_method):
     x = jax.numpy.array([1.0, 2.0])
     a, b = x
 
-    hess = jax.jit(hessian(circuit))(x)
+    hess = jax.jit(hessian(circuit))(x, shots=10000)
 
     expected_hess = [
         [-np.cos(a) * np.cos(b), np.sin(a) * np.sin(b)],
@@ -2878,13 +2465,13 @@ def test_jax_device_hessian_shots(hessian, diff_method):
 @pytest.mark.parametrize("argnums", [0, 1, [0, 1]])
 @pytest.mark.parametrize("jacobian", jacobian_fn)
 @pytest.mark.parametrize(
-    "interface,dev_name,diff_method,grad_on_execution", interface_and_qubit_device_and_diff_method
+    "interface,dev,diff_method,grad_on_execution", interface_and_qubit_device_and_diff_method
 )
 class TestSubsetArgnums:
     def test_single_measurement(
         self,
         interface,
-        dev_name,
+        dev,
         diff_method,
         grad_on_execution,
         jacobian,
@@ -2893,8 +2480,6 @@ class TestSubsetArgnums:
         tol,
     ):
         """Test single measurement with different diff methods with argnums."""
-
-        dev = qml.device(dev_name, wires=3)
 
         @qml.qnode(
             dev,
@@ -2933,7 +2518,7 @@ class TestSubsetArgnums:
     def test_multi_measurements(
         self,
         interface,
-        dev_name,
+        dev,
         diff_method,
         grad_on_execution,
         jacobian,
@@ -2942,7 +2527,6 @@ class TestSubsetArgnums:
         tol,
     ):
         """Test multiple measurements with different diff methods with argnums."""
-        dev = qml.device(dev_name, wires=3)
 
         @qml.qnode(
             dev, interface=interface, diff_method=diff_method, grad_on_execution=grad_on_execution

--- a/tests/interfaces/default_qubit_2_integration/test_jax_jit_qnode_default_qubit_2.py
+++ b/tests/interfaces/default_qubit_2_integration/test_jax_jit_qnode_default_qubit_2.py
@@ -1,0 +1,2975 @@
+# Copyright 2018-2021 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration tests for using the JAX-JIT interface with a QNode"""
+# pylint: disable=too-many-arguments,too-few-public-methods
+import pytest
+
+import pennylane as qml
+from pennylane import numpy as np
+from pennylane import qnode
+from pennylane.tape import QuantumScript
+
+qubit_device_and_diff_method = [
+    ["default.qubit", "backprop", True],
+    ["default.qubit", "finite-diff", False],
+    ["default.qubit", "parameter-shift", False],
+    ["default.qubit", "adjoint", True],
+    ["default.qubit", "adjoint", False],
+    ["default.qubit", "spsa", False],
+    ["default.qubit", "hadamard", False],
+]
+interface_and_qubit_device_and_diff_method = [
+    ["auto"] + inner_list for inner_list in qubit_device_and_diff_method
+] + [["jax-jit"] + inner_list for inner_list in qubit_device_and_diff_method]
+
+pytestmark = pytest.mark.jax
+
+jax = pytest.importorskip("jax")
+config = pytest.importorskip("jax.config")
+config.config.update("jax_enable_x64", True)
+
+TOL_FOR_SPSA = 1.0
+SEED_FOR_SPSA = 32651
+H_FOR_SPSA = 0.05
+
+
+@pytest.mark.parametrize(
+    "interface,dev_name,diff_method,grad_on_execution", interface_and_qubit_device_and_diff_method
+)
+class TestQNode:
+    """Test that using the QNode with JAX integrates with the PennyLane
+    stack"""
+
+    def test_execution_with_interface(self, dev_name, diff_method, grad_on_execution, interface):
+        """Test execution works with the interface"""
+        if diff_method == "backprop":
+            pytest.skip("Test does not support backprop")
+
+        num_wires = 1
+
+        if diff_method == "hadamard":
+            num_wires = 2
+
+        dev = qml.device(dev_name, wires=num_wires)
+
+        @qnode(
+            dev, interface=interface, diff_method=diff_method, grad_on_execution=grad_on_execution
+        )
+        def circuit(a):
+            qml.RY(a, wires=0)
+            qml.RX(0.2, wires=0)
+            return qml.expval(qml.PauliZ(0))
+
+        a = np.array(0.1, requires_grad=True)
+        jax.jit(circuit)(a)
+
+        assert circuit.interface == interface
+
+        # the tape is able to deduce trainable parameters
+        assert circuit.qtape.trainable_params == [0]
+
+        # gradients should work
+        grad = jax.jit(jax.grad(circuit))(a)
+        assert isinstance(grad, jax.Array)
+        assert grad.shape == ()
+
+    def test_changing_trainability(
+        self, dev_name, diff_method, grad_on_execution, interface, mocker, tol
+    ):
+        """Test changing the trainability of parameters changes the
+        number of differentiation requests made"""
+        if diff_method != "parameter-shift":
+            pytest.skip("Test only supports parameter-shift")
+
+        a = jax.numpy.array(0.1)
+        b = jax.numpy.array(0.2)
+
+        dev = qml.device(dev_name, wires=2)
+
+        @qnode(
+            dev,
+            interface=interface,
+            diff_method="parameter-shift",
+            grad_on_execution=grad_on_execution,
+        )
+        def circuit(a, b):
+            qml.RY(a, wires=0)
+            qml.RX(b, wires=1)
+            qml.CNOT(wires=[0, 1])
+            return qml.expval(qml.Hamiltonian([1, 1], [qml.PauliZ(0), qml.PauliY(1)]))
+
+        grad_fn = jax.jit(jax.grad(circuit, argnums=[0, 1]))
+        spy = mocker.spy(qml.gradients.param_shift, "transform_fn")
+        res = grad_fn(a, b)
+
+        # the tape has reported both arguments as trainable
+        assert circuit.qtape.trainable_params == [0, 1]
+
+        expected = [-np.sin(a) + np.sin(a) * np.sin(b), -np.cos(a) * np.cos(b)]
+        assert np.allclose(res, expected, atol=tol, rtol=0)
+
+        # The parameter-shift rule has been called for each argument
+        assert len(spy.spy_return[0]) == 4
+
+        # make the second QNode argument a constant
+        grad_fn = jax.grad(circuit, argnums=0)
+        res = grad_fn(a, b)
+
+        # the tape has reported only the first argument as trainable
+        assert circuit.qtape.trainable_params == [0]
+
+        expected = [-np.sin(a) + np.sin(a) * np.sin(b)]
+        assert np.allclose(res, expected, atol=tol, rtol=0)
+
+        # The parameter-shift rule has been called only once
+        assert len(spy.spy_return[0]) == 2
+
+        # trainability also updates on evaluation
+        a = np.array(0.54, requires_grad=False)
+        b = np.array(0.8, requires_grad=True)
+        circuit(a, b)
+        assert circuit.qtape.trainable_params == [1]
+
+    def test_classical_processing(self, dev_name, diff_method, grad_on_execution, interface):
+        """Test classical processing within the quantum tape"""
+        a = jax.numpy.array(0.1)
+        b = jax.numpy.array(0.2)
+        c = jax.numpy.array(0.3)
+
+        num_wires = 1
+
+        if diff_method == "hadamard":
+            num_wires = 2
+
+        dev = qml.device(dev_name, wires=num_wires)
+
+        @qnode(
+            dev, diff_method=diff_method, interface=interface, grad_on_execution=grad_on_execution
+        )
+        def circuit(a, b, c):
+            qml.RY(a * c, wires=0)
+            qml.RZ(b, wires=0)
+            qml.RX(c + c**2 + jax.numpy.sin(a), wires=0)
+            return qml.expval(qml.PauliZ(0))
+
+        res = jax.grad(circuit, argnums=[0, 2])(a, b, c)
+
+        if diff_method == "finite-diff":
+            assert circuit.qtape.trainable_params == [0, 2]
+
+        assert len(res) == 2
+
+    def test_matrix_parameter(self, dev_name, diff_method, grad_on_execution, interface, tol):
+        """Test that the jax interface works correctly
+        with a matrix parameter"""
+        U = jax.numpy.array([[0, 1], [1, 0]])
+        a = jax.numpy.array(0.1)
+
+        num_wires = 2
+
+        if diff_method == "hadamard":
+            num_wires = 3
+
+        dev = qml.device(dev_name, wires=num_wires)
+
+        @qnode(
+            dev, diff_method=diff_method, interface=interface, grad_on_execution=grad_on_execution
+        )
+        def circuit(U, a):
+            qml.QubitUnitary(U, wires=0)
+            qml.RY(a, wires=0)
+            return qml.expval(qml.PauliZ(0))
+
+        res = jax.grad(circuit, argnums=1)(U, a)
+        assert np.allclose(res, np.sin(a), atol=tol, rtol=0)
+
+        if diff_method == "finite-diff":
+            assert circuit.qtape.trainable_params == [1]
+
+    def test_differentiable_expand(self, dev_name, diff_method, grad_on_execution, interface, tol):
+        """Test that operation and nested tape expansion
+        is differentiable"""
+
+        gradient_kwargs = {}
+        if diff_method == "spsa":
+            gradient_kwargs = {"sampler_seed": SEED_FOR_SPSA}
+            tol = TOL_FOR_SPSA
+
+        class U3(qml.U3):
+            def expand(self):
+                theta, phi, lam = self.data
+                wires = self.wires
+                return QuantumScript(
+                    [qml.Rot(lam, theta, -lam, wires=wires), qml.PhaseShift(phi + lam, wires=wires)]
+                )
+
+        num_wires = 1
+
+        if diff_method == "hadamard":
+            num_wires = 2
+
+        dev = qml.device(dev_name, wires=num_wires)
+
+        a = jax.numpy.array(0.1)
+        p = jax.numpy.array([0.1, 0.2, 0.3])
+
+        @qnode(
+            dev,
+            diff_method=diff_method,
+            interface=interface,
+            grad_on_execution=grad_on_execution,
+            **gradient_kwargs
+        )
+        def circuit(a, p):
+            qml.RX(a, wires=0)
+            U3(p[0], p[1], p[2], wires=0)
+            return qml.expval(qml.PauliX(0))
+
+        res = jax.jit(circuit)(a, p)
+        expected = np.cos(a) * np.cos(p[1]) * np.sin(p[0]) + np.sin(a) * (
+            np.cos(p[2]) * np.sin(p[1]) + np.cos(p[0]) * np.cos(p[1]) * np.sin(p[2])
+        )
+        assert np.allclose(res, expected, atol=tol, rtol=0)
+
+        res = jax.jit(jax.grad(circuit, argnums=1))(a, p)
+        expected = np.array(
+            [
+                np.cos(p[1]) * (np.cos(a) * np.cos(p[0]) - np.sin(a) * np.sin(p[0]) * np.sin(p[2])),
+                np.cos(p[1]) * np.cos(p[2]) * np.sin(a)
+                - np.sin(p[1])
+                * (np.cos(a) * np.sin(p[0]) + np.cos(p[0]) * np.sin(a) * np.sin(p[2])),
+                np.sin(a)
+                * (np.cos(p[0]) * np.cos(p[1]) * np.cos(p[2]) - np.sin(p[1]) * np.sin(p[2])),
+            ]
+        )
+        assert np.allclose(res, expected, atol=tol, rtol=0)
+
+    def test_jacobian_options(self, dev_name, diff_method, grad_on_execution, interface, mocker):
+        """Test setting jacobian options"""
+        if diff_method != "finite-diff":
+            pytest.skip("Test only applies to finite diff.")
+
+        spy = mocker.spy(qml.gradients.finite_diff, "transform_fn")
+
+        a = np.array([0.1, 0.2], requires_grad=True)
+
+        dev = qml.device(dev_name, wires=1)
+
+        @qnode(
+            dev,
+            interface=interface,
+            diff_method="finite-diff",
+            h=1e-8,
+            approx_order=2,
+            grad_on_execution=grad_on_execution,
+        )
+        def circuit(a):
+            qml.RY(a[0], wires=0)
+            qml.RX(a[1], wires=0)
+            return qml.expval(qml.PauliZ(0))
+
+        if diff_method in {"finite-diff", "parameter-shift", "spsa"} and interface == "jax-jit":
+            # No jax.jacobian support for call
+            pytest.xfail(reason="batching rules are implemented only for id_tap, not for call.")
+
+        jax.jit(jax.jacobian(circuit))(a)
+
+        for args in spy.call_args_list:
+            assert args[1]["approx_order"] == 2
+            assert args[1]["h"] == 1e-8
+
+
+@pytest.mark.parametrize(
+    "interface,dev_name,diff_method,grad_on_execution", interface_and_qubit_device_and_diff_method
+)
+class TestVectorValuedQNode:
+    """Test that using vector-valued QNodes with JAX integrate with the
+    PennyLane stack"""
+
+    def test_diff_expval_expval(
+        self, dev_name, diff_method, grad_on_execution, interface, mocker, tol
+    ):
+        """Test jacobian calculation"""
+
+        gradient_kwargs = {}
+        if diff_method == "parameter-shift":
+            spy = mocker.spy(qml.gradients.param_shift, "transform_fn")
+        elif diff_method == "finite-diff":
+            spy = mocker.spy(qml.gradients.finite_diff, "transform_fn")
+        elif diff_method == "spsa":
+            spy = mocker.spy(qml.gradients.spsa_grad, "transform_fn")
+            gradient_kwargs = {"sampler_seed": SEED_FOR_SPSA}
+            tol = TOL_FOR_SPSA
+        elif diff_method == "hadamard":
+            spy = mocker.spy(qml.gradients.hadamard_grad, "transform_fn")
+
+        a = np.array(0.1, requires_grad=True)
+        b = np.array(0.2, requires_grad=True)
+
+        num_wires = 2
+
+        if diff_method == "hadamard":
+            num_wires = 3
+
+        dev = qml.device(dev_name, wires=num_wires)
+
+        @qnode(
+            dev,
+            diff_method=diff_method,
+            interface=interface,
+            grad_on_execution=grad_on_execution,
+            **gradient_kwargs
+        )
+        def circuit(a, b):
+            qml.RY(a, wires=0)
+            qml.RX(b, wires=1)
+            qml.CNOT(wires=[0, 1])
+            return qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliY(1))
+
+        res = jax.jit(circuit)(a, b)
+
+        assert circuit.qtape.trainable_params == [0, 1]
+        assert isinstance(res, tuple)
+        assert len(res) == 2
+
+        expected = [np.cos(a), -np.cos(a) * np.sin(b)]
+        assert np.allclose(res[0], expected[0], atol=tol, rtol=0)
+        assert np.allclose(res[1], expected[1], atol=tol, rtol=0)
+
+        res = jax.jit(jax.jacobian(circuit, argnums=[0, 1]))(a, b)
+        assert circuit.qtape.trainable_params == [0, 1]
+
+        expected = np.array([[-np.sin(a), 0], [np.sin(a) * np.sin(b), -np.cos(a) * np.cos(b)]])
+        assert isinstance(res, tuple)
+        assert len(res) == 2
+
+        assert isinstance(res[0], tuple)
+        assert isinstance(res[0][0], jax.numpy.ndarray)
+        assert res[0][0].shape == ()
+        assert np.allclose(res[0][0], expected[0][0], atol=tol, rtol=0)
+        assert isinstance(res[0][1], jax.numpy.ndarray)
+        assert res[0][1].shape == ()
+        assert np.allclose(res[0][1], expected[0][1], atol=tol, rtol=0)
+
+        assert isinstance(res[1], tuple)
+        assert isinstance(res[1][0], jax.numpy.ndarray)
+        assert res[1][0].shape == ()
+        assert np.allclose(res[1][0], expected[1][0], atol=tol, rtol=0)
+        assert isinstance(res[1][1], jax.numpy.ndarray)
+        assert res[1][1].shape == ()
+        assert np.allclose(res[1][1], expected[1][1], atol=tol, rtol=0)
+
+        if diff_method in ("parameter-shift", "finite-diff"):
+            spy.assert_called()
+
+    def test_jacobian_no_evaluate(
+        self, dev_name, diff_method, grad_on_execution, interface, mocker, tol
+    ):
+        """Test jacobian calculation when no prior circuit evaluation has been performed"""
+
+        gradient_kwargs = {}
+        if diff_method == "parameter-shift":
+            spy = mocker.spy(qml.gradients.param_shift, "transform_fn")
+        elif diff_method == "finite-diff":
+            spy = mocker.spy(qml.gradients.finite_diff, "transform_fn")
+        elif diff_method == "spsa":
+            spy = mocker.spy(qml.gradients.spsa_grad, "transform_fn")
+            gradient_kwargs = {"sampler_seed": SEED_FOR_SPSA}
+            tol = TOL_FOR_SPSA
+        elif diff_method == "hadamard":
+            spy = mocker.spy(qml.gradients.hadamard_grad, "transform_fn")
+
+        a = jax.numpy.array(0.1)
+        b = jax.numpy.array(0.2)
+
+        num_wires = 2
+
+        if diff_method == "hadamard":
+            num_wires = 3
+
+        dev = qml.device(dev_name, wires=num_wires)
+
+        @qnode(
+            dev,
+            diff_method=diff_method,
+            interface=interface,
+            grad_on_execution=grad_on_execution,
+            **gradient_kwargs
+        )
+        def circuit(a, b):
+            qml.RY(a, wires=0)
+            qml.RX(b, wires=1)
+            qml.CNOT(wires=[0, 1])
+            return qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliY(1))
+
+        jac_fn = jax.jit(jax.jacobian(circuit, argnums=[0, 1]))
+
+        res = jac_fn(a, b)
+
+        assert isinstance(res, tuple)
+        assert len(res) == 2
+
+        expected = np.array([[-np.sin(a), 0], [np.sin(a) * np.sin(b), -np.cos(a) * np.cos(b)]])
+
+        for _res, _exp in zip(res, expected):
+            for r, e in zip(_res, _exp):
+                assert isinstance(r, jax.numpy.ndarray)
+                assert r.shape == ()
+                assert np.allclose(r, e, atol=tol, rtol=0)
+
+        if diff_method in ("parameter-shift", "finite-diff", "spsa"):
+            spy.assert_called()
+
+        # call the Jacobian with new parameters
+        a = jax.numpy.array(0.6)
+        b = jax.numpy.array(0.832)
+
+        res = jac_fn(a, b)
+
+        assert isinstance(res, tuple)
+        assert len(res) == 2
+
+        expected = np.array([[-np.sin(a), 0], [np.sin(a) * np.sin(b), -np.cos(a) * np.cos(b)]])
+
+        for _res, _exp in zip(res, expected):
+            for r, e in zip(_res, _exp):
+                assert isinstance(r, jax.numpy.ndarray)
+                assert r.shape == ()
+                assert np.allclose(r, e, atol=tol, rtol=0)
+
+    def test_diff_single_probs(self, dev_name, diff_method, grad_on_execution, interface, tol):
+        """Tests correct output shape and evaluation for a tape
+        with a single prob output"""
+        gradient_kwargs = {}
+        if diff_method == "adjoint":
+            pytest.skip("Adjoint does not support probs")
+        elif diff_method == "spsa":
+            gradient_kwargs = {"sampler_seed": SEED_FOR_SPSA}
+            tol = TOL_FOR_SPSA
+
+        num_wires = 2
+
+        if diff_method == "hadamard":
+            num_wires = 3
+
+        dev = qml.device(dev_name, wires=num_wires)
+        x = jax.numpy.array(0.543)
+        y = jax.numpy.array(-0.654)
+
+        @qnode(
+            dev,
+            diff_method=diff_method,
+            interface=interface,
+            grad_on_execution=grad_on_execution,
+            **gradient_kwargs
+        )
+        def circuit(x, y):
+            qml.RX(x, wires=[0])
+            qml.RY(y, wires=[1])
+            qml.CNOT(wires=[0, 1])
+            return qml.probs(wires=[1])
+
+        res = jax.jit(jax.jacobian(circuit, argnums=[0, 1]))(x, y)
+
+        expected = np.array(
+            [
+                [-np.sin(x) * np.cos(y) / 2, -np.cos(x) * np.sin(y) / 2],
+                [np.cos(y) * np.sin(x) / 2, np.cos(x) * np.sin(y) / 2],
+            ]
+        )
+
+        assert isinstance(res, tuple)
+        assert len(res) == 2
+
+        assert isinstance(res[0], jax.numpy.ndarray)
+        assert res[0].shape == (2,)
+
+        assert isinstance(res[1], jax.numpy.ndarray)
+        assert res[1].shape == (2,)
+
+        assert np.allclose(res[0], expected.T[0], atol=tol, rtol=0)
+        assert np.allclose(res[1], expected.T[1], atol=tol, rtol=0)
+
+    def test_diff_multi_probs(self, dev_name, diff_method, grad_on_execution, interface, tol):
+        """Tests correct output shape and evaluation for a tape
+        with multiple prob outputs"""
+        gradient_kwargs = {}
+        if diff_method == "adjoint":
+            pytest.skip("Adjoint does not support probs")
+        elif diff_method == "spsa":
+            gradient_kwargs = {"sampler_seed": SEED_FOR_SPSA}
+            tol = TOL_FOR_SPSA
+
+        num_wires = 3
+
+        if diff_method == "hadamard":
+            num_wires = 4
+
+        dev = qml.device(dev_name, wires=num_wires)
+        x = jax.numpy.array(0.543)
+        y = jax.numpy.array(-0.654)
+
+        @qnode(
+            dev,
+            diff_method=diff_method,
+            interface=interface,
+            grad_on_execution=grad_on_execution,
+            **gradient_kwargs
+        )
+        def circuit(x, y):
+            qml.RX(x, wires=[0])
+            qml.RY(y, wires=[1])
+            qml.CNOT(wires=[0, 1])
+            return qml.probs(wires=[0]), qml.probs(wires=[1, 2])
+
+        res = circuit(x, y)
+
+        assert isinstance(res, tuple)
+        assert len(res) == 2
+
+        expected = [
+            [np.cos(x / 2) ** 2, np.sin(x / 2) ** 2],
+            [(1 + np.cos(x) * np.cos(y)) / 2, 0, (1 - np.cos(x) * np.cos(y)) / 2, 0],
+        ]
+
+        assert isinstance(res[0], jax.numpy.ndarray)
+        assert res[0].shape == (2,)  # pylint:disable=comparison-with-callable
+        assert np.allclose(res[0], expected[0], atol=tol, rtol=0)
+
+        assert isinstance(res[1], jax.numpy.ndarray)
+        assert res[1].shape == (4,)  # pylint:disable=comparison-with-callable
+        assert np.allclose(res[1], expected[1], atol=tol, rtol=0)
+
+        jac = jax.jit(jax.jacobian(circuit, argnums=[0, 1]))(x, y)
+        expected_0 = np.array(
+            [
+                [-np.sin(x) / 2, np.sin(x) / 2],
+                [0, 0],
+            ]
+        )
+
+        expected_1 = np.array(
+            [
+                [-np.cos(y) * np.sin(x) / 2, 0, np.sin(x) * np.cos(y) / 2, 0],
+                [-np.cos(x) * np.sin(y) / 2, 0, np.cos(x) * np.sin(y) / 2, 0],
+            ]
+        )
+
+        assert isinstance(jac, tuple)
+        assert isinstance(jac[0], tuple)
+
+        assert len(jac[0]) == 2
+        assert isinstance(jac[0][0], jax.numpy.ndarray)
+        assert jac[0][0].shape == (2,)
+        assert np.allclose(jac[0][0], expected_0[0], atol=tol, rtol=0)
+        assert isinstance(jac[0][1], jax.numpy.ndarray)
+        assert jac[0][1].shape == (2,)
+        assert np.allclose(jac[0][1], expected_0[1], atol=tol, rtol=0)
+
+        assert isinstance(jac[1], tuple)
+        assert len(jac[1]) == 2
+        assert isinstance(jac[1][0], jax.numpy.ndarray)
+        assert jac[1][0].shape == (4,)
+
+        assert np.allclose(jac[1][0], expected_1[0], atol=tol, rtol=0)
+        assert isinstance(jac[1][1], jax.numpy.ndarray)
+        assert jac[1][1].shape == (4,)
+        assert np.allclose(jac[1][1], expected_1[1], atol=tol, rtol=0)
+
+    def test_diff_expval_probs(self, dev_name, diff_method, grad_on_execution, interface, tol):
+        """Tests correct output shape and evaluation for a tape
+        with prob and expval outputs"""
+        gradient_kwargs = {}
+        if diff_method == "adjoint":
+            pytest.skip("Adjoint does not support probs")
+        elif diff_method == "spsa":
+            gradient_kwargs = {"sampler_seed": SEED_FOR_SPSA}
+            tol = TOL_FOR_SPSA
+
+        num_wires = 2
+
+        if diff_method == "hadamard":
+            num_wires = 3
+
+        dev = qml.device(dev_name, wires=num_wires)
+        x = jax.numpy.array(0.543)
+        y = jax.numpy.array(-0.654)
+
+        @qnode(
+            dev,
+            diff_method=diff_method,
+            interface=interface,
+            grad_on_execution=grad_on_execution,
+            **gradient_kwargs
+        )
+        def circuit(x, y):
+            qml.RX(x, wires=[0])
+            qml.RY(y, wires=[1])
+            qml.CNOT(wires=[0, 1])
+            return qml.expval(qml.PauliZ(0)), qml.probs(wires=[1])
+
+        res = jax.jit(circuit)(x, y)
+        expected = [np.cos(x), [(1 + np.cos(x) * np.cos(y)) / 2, (1 - np.cos(x) * np.cos(y)) / 2]]
+
+        assert isinstance(res, tuple)
+        assert len(res) == 2
+
+        assert isinstance(res[0], jax.numpy.ndarray)
+        assert res[0].shape == ()
+        assert np.allclose(res[0], expected[0], atol=tol, rtol=0)
+
+        assert isinstance(res[1], jax.numpy.ndarray)
+        assert res[1].shape == (2,)
+        assert np.allclose(res[1], expected[1], atol=tol, rtol=0)
+
+        jac = jax.jit(jax.jacobian(circuit, argnums=[0, 1]))(x, y)
+        expected = [
+            [-np.sin(x), 0],
+            [
+                [-np.sin(x) * np.cos(y) / 2, np.cos(y) * np.sin(x) / 2],
+                [-np.cos(x) * np.sin(y) / 2, np.cos(x) * np.sin(y) / 2],
+            ],
+        ]
+
+        assert isinstance(jac, tuple)
+        assert len(jac) == 2
+
+        assert isinstance(jac[0], tuple)
+        assert len(jac[0]) == 2
+        assert isinstance(jac[0][0], jax.numpy.ndarray)
+        assert jac[0][0].shape == ()
+        assert np.allclose(jac[0][0], expected[0][0], atol=tol, rtol=0)
+        assert isinstance(jac[0][1], jax.numpy.ndarray)
+        assert jac[0][1].shape == ()
+        assert np.allclose(jac[0][1], expected[0][1], atol=tol, rtol=0)
+
+        assert isinstance(jac[1], tuple)
+        assert len(jac[1]) == 2
+        assert isinstance(jac[1][0], jax.numpy.ndarray)
+        assert jac[1][0].shape == (2,)
+        assert np.allclose(jac[1][0], expected[1][0], atol=tol, rtol=0)
+        assert isinstance(jac[1][1], jax.numpy.ndarray)
+        assert jac[1][1].shape == (2,)
+        assert np.allclose(jac[1][1], expected[1][1], atol=tol, rtol=0)
+
+    def test_diff_expval_probs_sub_argnums(
+        self, dev_name, diff_method, grad_on_execution, interface, tol
+    ):
+        """Tests correct output shape and evaluation for a tape with prob and expval outputs with less
+        trainable parameters (argnums) than parameters."""
+        if diff_method == "adjoint":
+            pytest.skip("Adjoint does not support probs")
+        elif diff_method == "spsa":
+            tol = TOL_FOR_SPSA
+
+        num_wires = 2
+
+        if diff_method == "hadamard":
+            num_wires = 3
+
+        dev = qml.device(dev_name, wires=num_wires)
+        x = jax.numpy.array(0.543)
+        y = jax.numpy.array(-0.654)
+
+        @qnode(
+            dev, diff_method=diff_method, interface=interface, grad_on_execution=grad_on_execution
+        )
+        def circuit(x, y):
+            qml.RX(x, wires=[0])
+            qml.RY(y, wires=[1])
+            qml.CNOT(wires=[0, 1])
+            return qml.expval(qml.PauliZ(0)), qml.probs(wires=[1])
+
+        jac = jax.jit(jax.jacobian(circuit, argnums=[0]))(x, y)
+
+        expected = [
+            [-np.sin(x), 0],
+            [
+                [-np.sin(x) * np.cos(y) / 2, np.cos(y) * np.sin(x) / 2],
+                [-np.cos(x) * np.sin(y) / 2, np.cos(x) * np.sin(y) / 2],
+            ],
+        ]
+        assert isinstance(jac, tuple)
+        assert len(jac) == 2
+
+        assert isinstance(jac[0], tuple)
+        assert len(jac[0]) == 1
+        assert isinstance(jac[0][0], jax.numpy.ndarray)
+        assert jac[0][0].shape == ()
+        assert np.allclose(jac[0][0], expected[0][0], atol=tol, rtol=0)
+
+        assert isinstance(jac[1], tuple)
+        assert len(jac[1]) == 1
+        assert isinstance(jac[1][0], jax.numpy.ndarray)
+        assert jac[1][0].shape == (2,)
+        assert np.allclose(jac[1][0], expected[1][0], atol=tol, rtol=0)
+
+    def test_diff_var_probs(self, dev_name, diff_method, grad_on_execution, interface, tol):
+        """Tests correct output shape and evaluation for a tape
+        with prob and variance outputs"""
+        gradient_kwargs = {}
+        if diff_method == "adjoint":
+            pytest.skip("Adjoint does not support probs")
+        elif diff_method == "hadamard":
+            pytest.skip("Hadamard does not support var")
+        elif diff_method == "spsa":
+            gradient_kwargs = {"sampler_seed": SEED_FOR_SPSA}
+            tol = TOL_FOR_SPSA
+
+        dev = qml.device(dev_name, wires=3)
+        x = jax.numpy.array(0.543)
+        y = jax.numpy.array(-0.654)
+
+        @qnode(
+            dev,
+            diff_method=diff_method,
+            interface=interface,
+            grad_on_execution=grad_on_execution,
+            **gradient_kwargs
+        )
+        def circuit(x, y):
+            qml.RX(x, wires=[0])
+            qml.RY(y, wires=[1])
+            qml.CNOT(wires=[0, 1])
+            return qml.var(qml.PauliZ(0)), qml.probs(wires=[1])
+
+        res = jax.jit(circuit)(x, y)
+
+        expected = [
+            np.sin(x) ** 2,
+            [(1 + np.cos(x) * np.cos(y)) / 2, (1 - np.cos(x) * np.cos(y)) / 2],
+        ]
+
+        assert isinstance(res[0], jax.numpy.ndarray)
+        assert res[0].shape == ()
+        assert np.allclose(res[0], expected[0], atol=tol, rtol=0)
+
+        assert isinstance(res[1], jax.numpy.ndarray)
+        assert res[1].shape == (2,)
+        assert np.allclose(res[1], expected[1], atol=tol, rtol=0)
+
+        jac = jax.jit(jax.jacobian(circuit, argnums=[0, 1]))(x, y)
+        expected = [
+            [2 * np.cos(x) * np.sin(x), 0],
+            [
+                [-np.sin(x) * np.cos(y) / 2, np.cos(y) * np.sin(x) / 2],
+                [-np.cos(x) * np.sin(y) / 2, np.cos(x) * np.sin(y) / 2],
+            ],
+        ]
+
+        assert isinstance(jac, tuple)
+        assert len(jac) == 2
+
+        assert isinstance(jac[0], tuple)
+        assert len(jac[0]) == 2
+        assert isinstance(jac[0][0], jax.numpy.ndarray)
+        assert jac[0][0].shape == ()
+        assert np.allclose(jac[0][0], expected[0][0], atol=tol, rtol=0)
+        assert isinstance(jac[0][1], jax.numpy.ndarray)
+        assert jac[0][1].shape == ()
+        assert np.allclose(jac[0][1], expected[0][1], atol=tol, rtol=0)
+
+        assert isinstance(jac[1], tuple)
+        assert len(jac[1]) == 2
+        assert isinstance(jac[1][0], jax.numpy.ndarray)
+        assert jac[1][0].shape == (2,)
+        assert np.allclose(jac[1][0], expected[1][0], atol=tol, rtol=0)
+        assert isinstance(jac[1][1], jax.numpy.ndarray)
+        assert jac[1][1].shape == (2,)
+        assert np.allclose(jac[1][1], expected[1][1], atol=tol, rtol=0)
+
+
+@pytest.mark.parametrize("interface", ["auto", "jax", "jax-jit"])
+class TestShotsIntegration:
+    """Test that the QNode correctly changes shot value, and
+    remains differentiable."""
+
+    def test_diff_method_None(self, interface):
+        """Test jax device works with diff_method=None."""
+        dev = qml.device("default.qubit.jax", wires=1, shots=10)
+
+        @jax.jit
+        @qml.qnode(dev, diff_method=None, interface=interface)
+        def circuit(x):
+            qml.RX(x, wires=0)
+            return qml.expval(qml.PauliZ(0))
+
+        assert jax.numpy.allclose(circuit(jax.numpy.array(0.0)), 1)
+
+    def test_changing_shots(self, interface, mocker, tol):
+        """Test that changing shots works on execution"""
+        dev = qml.device("default.qubit", wires=2, shots=None)
+        a, b = jax.numpy.array([0.543, -0.654])
+
+        @qnode(dev, diff_method=qml.gradients.param_shift, interface=interface)
+        def circuit(a, b):
+            qml.RY(a, wires=0)
+            qml.RX(b, wires=1)
+            qml.CNOT(wires=[0, 1])
+            return qml.expval(qml.PauliY(1))
+
+        spy = mocker.spy(dev, "sample")
+
+        # execute with device default shots (None)
+        res = circuit(a, b)
+        assert np.allclose(res, -np.cos(a) * np.sin(b), atol=tol, rtol=0)
+        spy.assert_not_called()
+
+        # execute with shots=100
+        res = circuit(a, b, shots=100)  # pylint: disable=unexpected-keyword-arg
+        spy.assert_called_once()
+        assert spy.spy_return.shape == (100,)
+
+        # device state has been unaffected
+        assert dev.shots is None
+        res = circuit(a, b)
+        assert np.allclose(res, -np.cos(a) * np.sin(b), atol=tol, rtol=0)
+        spy.assert_called_once()  # no additional calls
+
+    def test_gradient_integration(self, interface):
+        """Test that temporarily setting the shots works
+        for gradient computations"""
+        dev = qml.device("default.qubit", wires=2, shots=1)
+        a, b = jax.numpy.array([0.543, -0.654])
+
+        @qnode(dev, diff_method=qml.gradients.param_shift, interface=interface)
+        def cost_fn(a, b):
+            qml.RY(a, wires=0)
+            qml.RX(b, wires=1)
+            qml.CNOT(wires=[0, 1])
+            return qml.expval(qml.PauliY(1))
+
+        # TODO: jit when https://github.com/PennyLaneAI/pennylane/issues/3474 is resolved
+        res = jax.grad(cost_fn, argnums=[0, 1])(a, b, shots=30000)
+        assert dev.shots == 1
+
+        expected = [np.sin(a) * np.sin(b), -np.cos(a) * np.cos(b)]
+        assert np.allclose(res, expected, atol=0.1, rtol=0)
+
+    def test_update_diff_method(self, mocker, interface):
+        """Test that temporarily setting the shots updates the diff method"""
+        # pylint: disable=unused-argument
+        dev = qml.device("default.qubit", wires=2, shots=100)
+        a, b = jax.numpy.array([0.543, -0.654])
+
+        spy = mocker.spy(qml, "execute")
+
+        # We're choosing interface="jax" such that backprop can be used in the
+        # test later
+        @qnode(dev, interface="jax")
+        def cost_fn(a, b):
+            qml.RY(a, wires=0)
+            qml.RX(b, wires=1)
+            qml.CNOT(wires=[0, 1])
+            return qml.expval(qml.PauliY(1))
+
+        # since we are using finite shots, parameter-shift will
+        # be chosen
+        assert cost_fn.gradient_fn is qml.gradients.param_shift
+
+        cost_fn(a, b)
+        assert spy.call_args[1]["gradient_fn"] is qml.gradients.param_shift
+
+        # if we set the shots to None, backprop can now be used
+        cost_fn(a, b, shots=None)  # pylint: disable=unexpected-keyword-arg
+        assert spy.call_args[1]["gradient_fn"] == "backprop"
+
+        # original QNode settings are unaffected
+        assert cost_fn.gradient_fn is qml.gradients.param_shift
+        cost_fn(a, b)
+        assert spy.call_args[1]["gradient_fn"] is qml.gradients.param_shift
+
+
+@pytest.mark.parametrize(
+    "interface,dev_name,diff_method,grad_on_execution", interface_and_qubit_device_and_diff_method
+)
+class TestQubitIntegration:
+    """Tests that ensure various qubit circuits integrate correctly"""
+
+    def test_sampling(self, dev_name, diff_method, grad_on_execution, interface):
+        """Test sampling works as expected"""
+        if grad_on_execution:
+            pytest.skip("Sampling not possible with forward grad_on_execution differentiation.")
+
+        if diff_method == "adjoint":
+            pytest.skip("Adjoint warns with finite shots")
+
+        dev = qml.device(dev_name, wires=2, shots=10)
+
+        @qnode(
+            dev, diff_method=diff_method, interface=interface, grad_on_execution=grad_on_execution
+        )
+        def circuit():
+            qml.Hadamard(wires=[0])
+            qml.CNOT(wires=[0, 1])
+            return qml.sample(qml.PauliZ(0)), qml.sample(qml.PauliX(1))
+
+        res = jax.jit(circuit)()
+
+        assert isinstance(res, tuple)
+
+        assert isinstance(res[0], jax.Array)
+        assert res[0].shape == (10,)
+        assert isinstance(res[1], jax.Array)
+        assert res[1].shape == (10,)
+
+    def test_counts(self, dev_name, diff_method, grad_on_execution, interface):
+        """Test counts works as expected"""
+        if grad_on_execution:
+            pytest.skip("Sampling not possible with forward grad_on_execution differentiation.")
+
+        if diff_method == "adjoint":
+            pytest.skip("Adjoint warns with finite shots")
+
+        dev = qml.device(dev_name, wires=2, shots=10)
+
+        @qnode(
+            dev, diff_method=diff_method, interface=interface, grad_on_execution=grad_on_execution
+        )
+        def circuit():
+            qml.Hadamard(wires=[0])
+            qml.CNOT(wires=[0, 1])
+            return qml.counts(qml.PauliZ(0)), qml.counts(qml.PauliX(1))
+
+        if interface == "jax-jit":
+            with pytest.raises(
+                NotImplementedError, match="The JAX-JIT interface doesn't support qml.counts."
+            ):
+                jax.jit(circuit)()
+        else:
+            res = jax.jit(circuit)()
+
+            assert isinstance(res, tuple)
+
+            assert isinstance(res[0], dict)
+            assert len(res[0]) == 2
+            assert isinstance(res[1], dict)
+            assert len(res[1]) == 2
+
+    def test_chained_qnodes(self, dev_name, diff_method, grad_on_execution, interface):
+        """Test that the gradient of chained QNodes works without error"""
+        num_wires = 2
+
+        if diff_method == "hadamard":
+            num_wires = 3
+
+        dev = qml.device(dev_name, wires=num_wires)
+
+        class Template(qml.templates.StronglyEntanglingLayers):
+            def expand(self):
+                return QuantumScript(
+                    [qml.templates.StronglyEntanglingLayers(*self.parameters, self.wires)]
+                )
+
+        @qnode(
+            dev, interface=interface, diff_method=diff_method, grad_on_execution=grad_on_execution
+        )
+        def circuit1(weights):
+            Template(weights, wires=[0, 1])
+            return qml.expval(qml.PauliZ(0))
+
+        @qnode(
+            dev, interface=interface, diff_method=diff_method, grad_on_execution=grad_on_execution
+        )
+        def circuit2(data, weights):
+            qml.templates.AngleEmbedding(jax.numpy.stack([data, 0.7]), wires=[0, 1])
+            Template(weights, wires=[0, 1])
+            return qml.expval(qml.PauliX(0))
+
+        def cost(weights):
+            w1, w2 = weights
+            c1 = circuit1(w1)
+            c2 = circuit2(c1, w2)
+            return jax.numpy.sum(c2) ** 2
+
+        w1 = qml.templates.StronglyEntanglingLayers.shape(n_wires=2, n_layers=3)
+        w2 = qml.templates.StronglyEntanglingLayers.shape(n_wires=2, n_layers=4)
+
+        weights = [
+            jax.numpy.array(np.random.random(w1)),
+            jax.numpy.array(np.random.random(w2)),
+        ]
+
+        grad_fn = jax.jit(jax.grad(cost))
+        res = grad_fn(weights)
+
+        assert len(res) == 2
+
+
+@pytest.mark.parametrize(
+    "interface,dev_name,diff_method,grad_on_execution", interface_and_qubit_device_and_diff_method
+)
+class TestQubitIntegrationHigherOrder:
+    """Tests that ensure various qubit circuits integrate correctly when computing higher-order derivatives"""
+
+    def test_second_derivative(self, dev_name, diff_method, grad_on_execution, interface, tol):
+        """Test second derivative calculation of a scalar-valued QNode"""
+
+        gradient_kwargs = {}
+        if diff_method == "adjoint":
+            pytest.skip("Adjoint does not second derivative.")
+        elif diff_method == "spsa":
+            gradient_kwargs = {"sampler_seed": SEED_FOR_SPSA}
+            tol = TOL_FOR_SPSA
+
+        num_wires = 1
+
+        if diff_method == "hadamard":
+            num_wires = 3
+
+        dev = qml.device(dev_name, wires=num_wires)
+
+        @qnode(
+            dev,
+            diff_method=diff_method,
+            interface=interface,
+            grad_on_execution=grad_on_execution,
+            max_diff=2,
+            **gradient_kwargs
+        )
+        def circuit(x):
+            qml.RY(x[0], wires=0)
+            qml.RX(x[1], wires=0)
+            return qml.expval(qml.PauliZ(0))
+
+        x = jax.numpy.array([1.0, 2.0])
+        res = circuit(x)
+        g = jax.jit(jax.grad(circuit))(x)
+        g2 = jax.jit(jax.grad(lambda x: jax.numpy.sum(jax.grad(circuit)(x))))(x)
+
+        a, b = x
+
+        expected_res = np.cos(a) * np.cos(b)
+        assert np.allclose(res, expected_res, atol=tol, rtol=0)
+
+        expected_g = [-np.sin(a) * np.cos(b), -np.cos(a) * np.sin(b)]
+        assert np.allclose(g, expected_g, atol=tol, rtol=0)
+
+        expected_g2 = [
+            -np.cos(a) * np.cos(b) + np.sin(a) * np.sin(b),
+            np.sin(a) * np.sin(b) - np.cos(a) * np.cos(b),
+        ]
+        if diff_method == "finite-diff":
+            assert np.allclose(g2, expected_g2, atol=10e-2, rtol=0)
+        else:
+            assert np.allclose(g2, expected_g2, atol=tol, rtol=0)
+
+    def test_hessian(self, dev_name, diff_method, grad_on_execution, interface, tol):
+        """Test hessian calculation of a scalar-valued QNode"""
+        gradient_kwargs = {}
+        if diff_method == "adjoint":
+            pytest.skip("Adjoint does not support second derivative.")
+        elif diff_method == "spsa":
+            qml.math.random.seed(42)
+            gradient_kwargs = {"h": H_FOR_SPSA, "num_directions": 20}
+            tol = TOL_FOR_SPSA
+
+        num_wires = 1
+
+        if diff_method == "hadamard":
+            num_wires = 3
+
+        dev = qml.device(dev_name, wires=num_wires)
+
+        @qnode(
+            dev,
+            diff_method=diff_method,
+            interface=interface,
+            grad_on_execution=grad_on_execution,
+            max_diff=2,
+            **gradient_kwargs
+        )
+        def circuit(x):
+            qml.RY(x[0], wires=0)
+            qml.RX(x[1], wires=0)
+            return qml.expval(qml.PauliZ(0))
+
+        x = jax.numpy.array([1.0, 2.0])
+        res = jax.jit(circuit)(x)
+
+        a, b = x
+
+        expected_res = np.cos(a) * np.cos(b)
+        assert np.allclose(res, expected_res, atol=tol, rtol=0)
+
+        grad_fn = jax.jit(jax.grad(circuit))
+        g = grad_fn(x)
+
+        expected_g = [-np.sin(a) * np.cos(b), -np.cos(a) * np.sin(b)]
+        assert np.allclose(g, expected_g, atol=tol, rtol=0)
+
+        hess = jax.jit(jax.jacobian(grad_fn))(x)
+
+        expected_hess = [
+            [-np.cos(a) * np.cos(b), np.sin(a) * np.sin(b)],
+            [np.sin(a) * np.sin(b), -np.cos(a) * np.cos(b)],
+        ]
+        if diff_method == "finite-diff":
+            assert np.allclose(hess, expected_hess, atol=10e-2, rtol=0)
+        else:
+            assert np.allclose(hess, expected_hess, atol=tol, rtol=0)
+
+    def test_hessian_vector_valued(self, dev_name, diff_method, grad_on_execution, interface, tol):
+        """Test hessian calculation of a vector-valued QNode"""
+        gradient_kwargs = {}
+        if diff_method == "adjoint":
+            pytest.skip("Adjoint does not support second derivative.")
+        elif diff_method == "spsa":
+            qml.math.random.seed(42)
+            gradient_kwargs = {"h": H_FOR_SPSA, "num_directions": 20}
+            tol = TOL_FOR_SPSA
+
+        num_wires = 1
+
+        if diff_method == "hadamard":
+            num_wires = 3
+
+        dev = qml.device(dev_name, wires=num_wires)
+
+        @qnode(
+            dev,
+            diff_method=diff_method,
+            interface=interface,
+            grad_on_execution=grad_on_execution,
+            max_diff=2,
+            **gradient_kwargs
+        )
+        def circuit(x):
+            qml.RY(x[0], wires=0)
+            qml.RX(x[1], wires=0)
+            return qml.probs(wires=0)
+
+        x = jax.numpy.array([1.0, 2.0])
+        res = circuit(x)
+
+        a, b = x
+
+        expected_res = [0.5 + 0.5 * np.cos(a) * np.cos(b), 0.5 - 0.5 * np.cos(a) * np.cos(b)]
+        assert np.allclose(res, expected_res, atol=tol, rtol=0)
+
+        jac_fn = jax.jit(jax.jacobian(circuit))
+        g = jac_fn(x)
+
+        expected_g = [
+            [-0.5 * np.sin(a) * np.cos(b), -0.5 * np.cos(a) * np.sin(b)],
+            [0.5 * np.sin(a) * np.cos(b), 0.5 * np.cos(a) * np.sin(b)],
+        ]
+        assert np.allclose(g, expected_g, atol=tol, rtol=0)
+
+        hess = jax.jit(jax.jacobian(jac_fn))(x)
+
+        expected_hess = [
+            [
+                [-0.5 * np.cos(a) * np.cos(b), 0.5 * np.sin(a) * np.sin(b)],
+                [0.5 * np.sin(a) * np.sin(b), -0.5 * np.cos(a) * np.cos(b)],
+            ],
+            [
+                [0.5 * np.cos(a) * np.cos(b), -0.5 * np.sin(a) * np.sin(b)],
+                [-0.5 * np.sin(a) * np.sin(b), 0.5 * np.cos(a) * np.cos(b)],
+            ],
+        ]
+        if diff_method == "finite-diff":
+            assert np.allclose(hess, expected_hess, atol=10e-2, rtol=0)
+        else:
+            assert np.allclose(hess, expected_hess, atol=tol, rtol=0)
+
+    def test_hessian_vector_valued_postprocessing(
+        self, dev_name, diff_method, interface, grad_on_execution, tol
+    ):
+        """Test hessian calculation of a vector valued QNode with post-processing"""
+        gradient_kwargs = {}
+        if diff_method == "adjoint":
+            pytest.skip("Adjoint does not support second derivative.")
+        elif diff_method == "spsa":
+            qml.math.random.seed(42)
+            gradient_kwargs = {"h": H_FOR_SPSA, "num_directions": 20}
+            tol = TOL_FOR_SPSA
+
+        num_wires = 1
+
+        if diff_method == "hadamard":
+            num_wires = 3
+
+        dev = qml.device(dev_name, wires=num_wires)
+
+        @qnode(
+            dev,
+            diff_method=diff_method,
+            interface=interface,
+            grad_on_execution=grad_on_execution,
+            max_diff=2,
+            **gradient_kwargs
+        )
+        def circuit(x):
+            qml.RX(x[0], wires=0)
+            qml.RY(x[1], wires=0)
+            return qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliZ(0))
+
+        def cost_fn(x):
+            return x @ jax.numpy.array(circuit(x))
+
+        x = jax.numpy.array([0.76, -0.87])
+        res = jax.jit(cost_fn)(x)
+
+        a, b = x
+
+        expected_res = x @ jax.numpy.array([np.cos(a) * np.cos(b), np.cos(a) * np.cos(b)])
+        assert np.allclose(res, expected_res, atol=tol, rtol=0)
+
+        grad_fn = jax.jit(jax.grad(cost_fn))
+        g = grad_fn(x)
+
+        expected_g = [
+            np.cos(b) * (np.cos(a) - (a + b) * np.sin(a)),
+            np.cos(a) * (np.cos(b) - (a + b) * np.sin(b)),
+        ]
+        assert np.allclose(g, expected_g, atol=tol, rtol=0)
+        hess = jax.jit(jax.jacobian(grad_fn))(x)
+
+        expected_hess = [
+            [
+                -(np.cos(b) * ((a + b) * np.cos(a) + 2 * np.sin(a))),
+                -(np.cos(b) * np.sin(a)) + (-np.cos(a) + (a + b) * np.sin(a)) * np.sin(b),
+            ],
+            [
+                -(np.cos(b) * np.sin(a)) + (-np.cos(a) + (a + b) * np.sin(a)) * np.sin(b),
+                -(np.cos(a) * ((a + b) * np.cos(b) + 2 * np.sin(b))),
+            ],
+        ]
+
+        if diff_method == "finite-diff":
+            assert np.allclose(hess, expected_hess, atol=10e-2, rtol=0)
+        else:
+            assert np.allclose(hess, expected_hess, atol=tol, rtol=0)
+
+    def test_hessian_vector_valued_separate_args(
+        self, dev_name, diff_method, grad_on_execution, interface, mocker, tol
+    ):
+        """Test hessian calculation of a vector valued QNode that has separate input arguments"""
+        gradient_kwargs = {}
+        if diff_method == "adjoint":
+            pytest.skip("Adjoint does not support second derivative.")
+        elif diff_method == "spsa":
+            qml.math.random.seed(42)
+            gradient_kwargs = {"h": H_FOR_SPSA, "num_directions": 20}
+            tol = TOL_FOR_SPSA
+
+        num_wires = 1
+
+        if diff_method == "hadamard":
+            num_wires = 3
+
+        dev = qml.device(dev_name, wires=num_wires)
+
+        @qnode(
+            dev,
+            diff_method=diff_method,
+            interface=interface,
+            grad_on_execution=grad_on_execution,
+            max_diff=2,
+            **gradient_kwargs
+        )
+        def circuit(a, b):
+            qml.RY(a, wires=0)
+            qml.RX(b, wires=0)
+            return qml.probs(wires=0)
+
+        a = jax.numpy.array(1.0)
+        b = jax.numpy.array(2.0)
+        res = circuit(a, b)
+
+        expected_res = [0.5 + 0.5 * np.cos(a) * np.cos(b), 0.5 - 0.5 * np.cos(a) * np.cos(b)]
+        assert np.allclose(res, expected_res, atol=tol, rtol=0)
+
+        jac_fn = jax.jit(jax.jacobian(circuit, argnums=[0, 1]))
+        g = jac_fn(a, b)
+
+        expected_g = np.array(
+            [
+                [-0.5 * np.sin(a) * np.cos(b), -0.5 * np.cos(a) * np.sin(b)],
+                [0.5 * np.sin(a) * np.cos(b), 0.5 * np.cos(a) * np.sin(b)],
+            ]
+        )
+        assert np.allclose(g, expected_g.T, atol=tol, rtol=0)
+
+        spy = mocker.spy(qml.gradients.param_shift, "transform_fn")
+        hess = jax.jit(jax.jacobian(jac_fn, argnums=[0, 1]))(a, b)
+
+        if diff_method == "backprop":
+            spy.assert_not_called()
+        elif diff_method == "parameter-shift":
+            spy.assert_called()
+
+        expected_hess = np.array(
+            [
+                [
+                    [-0.5 * np.cos(a) * np.cos(b), 0.5 * np.cos(a) * np.cos(b)],
+                    [0.5 * np.sin(a) * np.sin(b), -0.5 * np.sin(a) * np.sin(b)],
+                ],
+                [
+                    [0.5 * np.sin(a) * np.sin(b), -0.5 * np.sin(a) * np.sin(b)],
+                    [-0.5 * np.cos(a) * np.cos(b), 0.5 * np.cos(a) * np.cos(b)],
+                ],
+            ]
+        )
+        if diff_method == "finite-diff":
+            assert np.allclose(hess, expected_hess, atol=10e-2, rtol=0)
+        else:
+            assert np.allclose(hess, expected_hess, atol=tol, rtol=0)
+
+    def test_state(self, dev_name, diff_method, grad_on_execution, interface, tol):
+        """Test that the state can be returned and differentiated"""
+        if diff_method == "adjoint":
+            pytest.skip("Adjoint does not support states")
+
+        num_wires = 2
+
+        if diff_method == "hadamard":
+            num_wires = 3
+
+        dev = qml.device(dev_name, wires=num_wires)
+
+        x = jax.numpy.array(0.543)
+        y = jax.numpy.array(-0.654)
+
+        @qnode(
+            dev, diff_method=diff_method, interface=interface, grad_on_execution=grad_on_execution
+        )
+        def circuit(x, y):
+            qml.RX(x, wires=[0])
+            qml.RY(y, wires=[1])
+            qml.CNOT(wires=[0, 1])
+            return qml.state()
+
+        def cost_fn(x, y):
+            res = circuit(x, y)
+            assert res.dtype is np.dtype("complex128")  # pylint:disable=no-member
+            probs = jax.numpy.abs(res) ** 2
+            return probs[0] + probs[2]
+
+        res = jax.jit(cost_fn)(x, y)
+
+        if diff_method not in {"backprop"}:
+            pytest.skip("Test only supports backprop")
+
+        res = jax.jit(jax.grad(cost_fn, argnums=[0, 1]))(x, y)
+        expected = np.array([-np.sin(x) * np.cos(y) / 2, -np.cos(x) * np.sin(y) / 2])
+        assert np.allclose(res, expected, atol=tol, rtol=0)
+
+    def test_projector(self, dev_name, diff_method, grad_on_execution, interface, tol):
+        """Test that the variance of a projector is correctly returned"""
+        gradient_kwargs = {}
+        if diff_method == "adjoint":
+            pytest.skip("Adjoint does not support projectors")
+        elif diff_method == "hadamard":
+            pytest.skip("Hadamard does not support var")
+        elif diff_method == "spsa":
+            qml.math.random.seed(42)
+            gradient_kwargs = {"h": H_FOR_SPSA}
+            tol = TOL_FOR_SPSA
+
+        dev = qml.device(dev_name, wires=2)
+        P = jax.numpy.array([1])
+        x, y = 0.765, -0.654
+
+        @qnode(
+            dev,
+            diff_method=diff_method,
+            interface=interface,
+            grad_on_execution=grad_on_execution,
+            **gradient_kwargs
+        )
+        def circuit(x, y):
+            qml.RX(x, wires=0)
+            qml.RY(y, wires=1)
+            qml.CNOT(wires=[0, 1])
+            return qml.var(qml.Projector(P, wires=0) @ qml.PauliX(1))
+
+        res = jax.jit(circuit)(x, y)
+        expected = 0.25 * np.sin(x / 2) ** 2 * (3 + np.cos(2 * y) + 2 * np.cos(x) * np.sin(y) ** 2)
+        assert np.allclose(res, expected, atol=tol, rtol=0)
+
+        res = jax.jit(jax.grad(circuit, argnums=[0, 1]))(x, y)
+        expected = np.array(
+            [
+                0.5 * np.sin(x) * (np.cos(x / 2) ** 2 + np.cos(2 * y) * np.sin(x / 2) ** 2),
+                -2 * np.cos(y) * np.sin(x / 2) ** 4 * np.sin(y),
+            ]
+        )
+        assert np.allclose(res, expected, atol=tol, rtol=0)
+
+
+# TODO: Add CV test when return types and custom diff are compatible
+@pytest.mark.xfail(reason="CV variables with new return types.")
+@pytest.mark.parametrize(
+    "diff_method,kwargs",
+    [
+        ["finite-diff", {}],
+        ["spsa", {"num_directions": 100, "h": H_FOR_SPSA}],
+        ("parameter-shift", {}),
+        ("parameter-shift", {"force_order2": True}),
+    ],
+)
+@pytest.mark.parametrize("interface", ["auto", "jax-jit", "jax"])
+class TestCV:
+    """Tests for CV integration"""
+
+    def test_first_order_observable(self, diff_method, kwargs, interface, tol):
+        """Test variance of a first order CV observable"""
+        dev = qml.device("default.gaussian", wires=1)
+        if diff_method == "spsa":
+            tol = TOL_FOR_SPSA
+
+        r = 0.543
+        phi = -0.654
+
+        @qnode(dev, interface=interface, diff_method=diff_method, **kwargs)
+        def circuit(r, phi):
+            qml.Squeezing(r, 0, wires=0)
+            qml.Rotation(phi, wires=0)
+            return qml.var(qml.QuadX(0))
+
+        res = circuit(r, phi)
+        expected = np.exp(2 * r) * np.sin(phi) ** 2 + np.exp(-2 * r) * np.cos(phi) ** 2
+        assert np.allclose(res, expected, atol=tol, rtol=0)
+
+        # circuit jacobians
+        res = jax.grad(circuit, argnums=[0, 1])(r, phi)
+        expected = np.array(
+            [
+                2 * np.exp(2 * r) * np.sin(phi) ** 2 - 2 * np.exp(-2 * r) * np.cos(phi) ** 2,
+                2 * np.sinh(2 * r) * np.sin(2 * phi),
+            ]
+        )
+        assert np.allclose(res, expected, atol=tol, rtol=0)
+
+    def test_second_order_observable(self, diff_method, kwargs, interface, tol):
+        """Test variance of a second order CV expectation value"""
+        dev = qml.device("default.gaussian", wires=1)
+        if diff_method == "spsa":
+            tol = TOL_FOR_SPSA
+
+        n = 0.12
+        a = 0.765
+
+        @qnode(dev, interface=interface, diff_method=diff_method, **kwargs)
+        def circuit(n, a):
+            qml.ThermalState(n, wires=0)
+            qml.Displacement(a, 0, wires=0)
+            return qml.var(qml.NumberOperator(0))
+
+        res = circuit(n, a)
+        expected = n**2 + n + np.abs(a) ** 2 * (1 + 2 * n)
+        assert np.allclose(res, expected, atol=tol, rtol=0)
+
+        # circuit jacobians
+        res = jax.grad(circuit, argnums=[0, 1])(n, a)
+        expected = np.array([2 * a**2 + 2 * n + 1, 2 * a * (2 * n + 1)])
+        assert np.allclose(res, expected, atol=tol, rtol=0)
+
+
+# TODO: add support for fwd grad_on_execution to JAX-JIT
+@pytest.mark.parametrize("interface", ["auto", "jax-jit"])
+def test_adjoint_reuse_device_state(mocker, interface):
+    """Tests that the jax interface reuses the device state for adjoint differentiation"""
+    dev = qml.device("default.qubit", wires=1)
+
+    @qnode(dev, interface=interface, diff_method="adjoint")
+    def circ(x):
+        qml.RX(x, wires=0)
+        return qml.expval(qml.PauliZ(0))
+
+    spy = mocker.spy(dev, "adjoint_jacobian")
+
+    jax.grad(circ)(1.0)
+    assert circ.device.num_executions == 1
+
+    spy.assert_called_with(mocker.ANY, use_device_state=True)
+
+
+@pytest.mark.parametrize(
+    "interface,dev_name,diff_method,grad_on_execution", interface_and_qubit_device_and_diff_method
+)
+class TestTapeExpansion:
+    """Test that tape expansion within the QNode integrates correctly
+    with the JAX interface"""
+
+    @pytest.mark.parametrize("max_diff", [1, 2])
+    def test_gradient_expansion_trainable_only(
+        self, dev_name, diff_method, grad_on_execution, max_diff, interface, mocker
+    ):
+        """Test that a *supported* operation with no gradient recipe is only
+        expanded for parameter-shift and finite-differences when it is trainable."""
+        if diff_method not in ("parameter-shift", "finite-diff", "spsa"):
+            pytest.skip("Only supports gradient transforms")
+
+        num_wires = 1
+
+        if diff_method == "hadamard":
+            num_wires = 2
+
+        dev = qml.device(dev_name, wires=num_wires)
+
+        class PhaseShift(qml.PhaseShift):
+            grad_method = None
+
+            def expand(self):
+                return QuantumScript([qml.RY(3 * self.data[0], wires=self.wires)])
+
+        @qnode(
+            dev,
+            diff_method=diff_method,
+            grad_on_execution=grad_on_execution,
+            max_diff=max_diff,
+            interface=interface,
+        )
+        def circuit(x, y):
+            qml.Hadamard(wires=0)
+            PhaseShift(x, wires=0)
+            PhaseShift(2 * y, wires=0)
+            return qml.expval(qml.PauliX(0))
+
+        spy = mocker.spy(circuit.device, "batch_execute")
+        x = jax.numpy.array(0.5)
+        y = jax.numpy.array(0.7)
+        circuit(x, y)
+
+        spy = mocker.spy(circuit.gradient_fn, "transform_fn")
+        jax.grad(circuit, argnums=[0])(x, y)
+
+        input_tape = spy.call_args[0][0]
+        assert len(input_tape.operations) == 3
+        assert input_tape.operations[1].name == "RY"
+        assert input_tape.operations[1].data[0] == 3 * x
+        assert input_tape.operations[2].name == "PhaseShift"
+        assert input_tape.operations[2].grad_method is None
+
+    @pytest.mark.parametrize("max_diff", [1, 2])
+    def test_hamiltonian_expansion_analytic(
+        self, dev_name, diff_method, grad_on_execution, max_diff, interface, mocker, tol
+    ):
+        """Test that the Hamiltonian is not expanded if there
+        are non-commuting groups and the number of shots is None
+        and the first and second order gradients are correctly evaluated"""
+        gradient_kwargs = {}
+        if diff_method == "adjoint":
+            pytest.skip("The adjoint method does not yet support Hamiltonians")
+        elif diff_method == "hadamard":
+            pytest.skip("The Hadamard method does not yet support Hamiltonians")
+        elif diff_method == "spsa":
+            qml.math.random.seed(42)
+            gradient_kwargs = {"h": H_FOR_SPSA, "num_directions": 20}
+            tol = TOL_FOR_SPSA
+
+        dev = qml.device(dev_name, wires=3, shots=None)
+        spy = mocker.spy(qml.transforms, "hamiltonian_expand")
+        obs = [qml.PauliX(0), qml.PauliX(0) @ qml.PauliZ(1), qml.PauliZ(0) @ qml.PauliZ(1)]
+
+        @qnode(
+            dev,
+            interface=interface,
+            diff_method=diff_method,
+            grad_on_execution=grad_on_execution,
+            max_diff=max_diff,
+            **gradient_kwargs
+        )
+        def circuit(data, weights, coeffs):
+            weights = weights.reshape(1, -1)
+            qml.templates.AngleEmbedding(data, wires=[0, 1])
+            qml.templates.BasicEntanglerLayers(weights, wires=[0, 1])
+            return qml.expval(qml.Hamiltonian(coeffs, obs))
+
+        d = jax.numpy.array([0.1, 0.2])
+        w = jax.numpy.array([0.654, -0.734])
+        c = jax.numpy.array([-0.6543, 0.24, 0.54])
+
+        # test output
+        res = circuit(d, w, c)
+        expected = c[2] * np.cos(d[1] + w[1]) - c[1] * np.sin(d[0] + w[0]) * np.sin(d[1] + w[1])
+        assert np.allclose(res, expected, atol=tol)
+        spy.assert_not_called()
+
+        # test gradients
+        grad = jax.grad(circuit, argnums=[1, 2])(d, w, c)
+        expected_w = [
+            -c[1] * np.cos(d[0] + w[0]) * np.sin(d[1] + w[1]),
+            -c[1] * np.cos(d[1] + w[1]) * np.sin(d[0] + w[0]) - c[2] * np.sin(d[1] + w[1]),
+        ]
+        expected_c = [0, -np.sin(d[0] + w[0]) * np.sin(d[1] + w[1]), np.cos(d[1] + w[1])]
+        assert np.allclose(grad[0], expected_w, atol=tol)
+        assert np.allclose(grad[1], expected_c, atol=tol)
+
+        # TODO: Add parameter shift when the bug with trainable params and hamiltonian_grad is solved.
+        # test second-order derivatives
+        if diff_method in "backprop" and max_diff == 2:
+            grad2_c = jax.jacobian(jax.grad(circuit, argnums=[2]), argnums=[2])(d, w, c)
+            assert np.allclose(grad2_c, 0, atol=tol)
+
+            grad2_w_c = jax.jacobian(jax.grad(circuit, argnums=[1]), argnums=[2])(d, w, c)
+            expected = [0, -np.cos(d[0] + w[0]) * np.sin(d[1] + w[1]), 0], [
+                0,
+                -np.cos(d[1] + w[1]) * np.sin(d[0] + w[0]),
+                -np.sin(d[1] + w[1]),
+            ]
+            assert np.allclose(grad2_w_c, expected, atol=tol)
+
+    @pytest.mark.parametrize("max_diff", [1, 2])
+    def test_hamiltonian_expansion_finite_shots(
+        self, dev_name, diff_method, grad_on_execution, interface, max_diff, mocker
+    ):
+        """Test that the Hamiltonian is expanded if there
+        are non-commuting groups and the number of shots is finite
+        and the first and second order gradients are correctly evaluated"""
+        gradient_kwargs = {}
+        tol = 0.1
+        if diff_method in ("adjoint", "backprop", "finite-diff"):
+            pytest.skip("The adjoint and backprop methods do not yet support sampling")
+        elif diff_method == "hadamard":
+            pytest.skip("The Hadamard method does not yet support Hamiltonians")
+        elif diff_method == "spsa":
+            gradient_kwargs = {"sampler_seed": SEED_FOR_SPSA, "h": H_FOR_SPSA}
+            tol = TOL_FOR_SPSA
+
+        dev = qml.device(dev_name, wires=3, shots=50000)
+        spy = mocker.spy(qml.transforms, "hamiltonian_expand")
+        obs = [qml.PauliX(0), qml.PauliX(0) @ qml.PauliZ(1), qml.PauliZ(0) @ qml.PauliZ(1)]
+
+        @qnode(
+            dev,
+            interface=interface,
+            diff_method=diff_method,
+            grad_on_execution=grad_on_execution,
+            max_diff=max_diff,
+            **gradient_kwargs
+        )
+        def circuit(data, weights, coeffs):
+            weights = weights.reshape(1, -1)
+            qml.templates.AngleEmbedding(data, wires=[0, 1])
+            qml.templates.BasicEntanglerLayers(weights, wires=[0, 1])
+            H = qml.Hamiltonian(coeffs, obs)
+            H.compute_grouping()
+            return qml.expval(H)
+
+        d = jax.numpy.array([0.1, 0.2])
+        w = jax.numpy.array([0.654, -0.734])
+        c = jax.numpy.array([-0.6543, 0.24, 0.54])
+
+        # test output
+        res = circuit(d, w, c)
+        expected = c[2] * np.cos(d[1] + w[1]) - c[1] * np.sin(d[0] + w[0]) * np.sin(d[1] + w[1])
+        assert np.allclose(res, expected, atol=tol)
+        spy.assert_called()
+
+        # test gradients
+        grad = jax.grad(circuit, argnums=[1, 2])(d, w, c)
+        expected_w = [
+            -c[1] * np.cos(d[0] + w[0]) * np.sin(d[1] + w[1]),
+            -c[1] * np.cos(d[1] + w[1]) * np.sin(d[0] + w[0]) - c[2] * np.sin(d[1] + w[1]),
+        ]
+        expected_c = [0, -np.sin(d[0] + w[0]) * np.sin(d[1] + w[1]), np.cos(d[1] + w[1])]
+        assert np.allclose(grad[0], expected_w, atol=tol)
+        assert np.allclose(grad[1], expected_c, atol=tol)
+
+    #     TODO: Fix hamiltonian grad for parameter shift and jax
+    #     # test second-order derivatives
+    #     if diff_method == "parameter-shift" and max_diff == 2:
+
+    #         grad2_c = jax.jacobian(jax.grad(circuit, argnum=2), argnum=2)(d, w, c)
+    #         assert np.allclose(grad2_c, 0, atol=tol)
+
+    #         grad2_w_c = jax.jacobian(jax.grad(circuit, argnum=1), argnum=2)(d, w, c)
+    #         expected = [0, -np.cos(d[0] + w[0]) * np.sin(d[1] + w[1]), 0], [
+    #             0,
+    #             -np.cos(d[1] + w[1]) * np.sin(d[0] + w[0]),
+    #             -np.sin(d[1] + w[1]),
+    #         ]
+    #         assert np.allclose(grad2_w_c, expected, atol=tol)
+
+    def test_vmap_compared_param_broadcasting(
+        self, dev_name, diff_method, grad_on_execution, interface, tol
+    ):
+        """Test that jax.vmap works just as well as parameter-broadcasting with JAX JIT on the forward pass when
+        vectorized=True is specified for the callback when caching is disabled."""
+        interface = "jax-jit"
+        if diff_method == "adjoint":
+            pytest.skip("The adjoint method does not yet support Hamiltonians")
+        elif diff_method == "hadamard":
+            pytest.skip("The Hadamard method does not yet support Hamiltonians")
+
+        if diff_method == "backprop":
+            pytest.skip(
+                "The backprop method does not yet support parameter-broadcasting with Hamiltonians"
+            )
+
+        phys_qubits = 2
+        if diff_method == "hadamard":
+            phys_qubits = 3
+        n_configs = 5
+        pars_q = np.random.rand(n_configs, 2)
+        dev = qml.device(dev_name, wires=tuple(range(phys_qubits)), shots=None)
+
+        def minimal_circ(params):
+            @qml.qnode(
+                dev,
+                interface=interface,
+                diff_method=diff_method,
+                grad_on_execution=grad_on_execution,
+                cache=None,
+            )
+            def _measure_operator():
+                qml.RY(params[..., 0], wires=0)
+                qml.RY(params[..., 1], wires=1)
+                op = qml.Hamiltonian([1.0], [qml.PauliZ(0) @ qml.PauliZ(1)])
+                return qml.expval(op)
+
+            res = _measure_operator()
+            return res
+
+        assert np.allclose(
+            jax.jit(minimal_circ)(pars_q), jax.jit(jax.vmap(minimal_circ))(pars_q), tol
+        )
+
+    def test_vmap_compared_param_broadcasting_multi_output(
+        self, dev_name, diff_method, grad_on_execution, interface, tol
+    ):
+        """Test that jax.vmap works just as well as parameter-broadcasting with JAX JIT on the forward pass when
+        vectorized=True is specified for the callback when caching is disabled and when multiple output values
+        are returned."""
+        interface = "jax-jit"
+        if diff_method == "adjoint":
+            pytest.skip("The adjoint method does not yet support Hamiltonians")
+        elif diff_method == "hadamard":
+            pytest.skip("The Hadamard method does not yet support Hamiltonians")
+
+        if diff_method == "backprop":
+            pytest.skip(
+                "The backprop method does not yet support parameter-broadcasting with Hamiltonians"
+            )
+
+        phys_qubits = 2
+        n_configs = 5
+        pars_q = np.random.rand(n_configs, 2)
+        dev = qml.device(dev_name, wires=tuple(range(phys_qubits)), shots=None)
+
+        def minimal_circ(params):
+            @qml.qnode(
+                dev,
+                interface=interface,
+                diff_method=diff_method,
+                grad_on_execution=grad_on_execution,
+                cache=None,
+            )
+            def _measure_operator():
+                qml.RY(params[..., 0], wires=0)
+                qml.RY(params[..., 1], wires=1)
+                op1 = qml.Hamiltonian([1.0], [qml.PauliZ(0) @ qml.PauliZ(1)])
+                op2 = qml.Hamiltonian([1.0], [qml.PauliX(0) @ qml.PauliX(1)])
+                return qml.expval(op1), qml.expval(op2)
+
+            res = _measure_operator()
+            return res
+
+        res1, res2 = jax.jit(minimal_circ)(pars_q)
+        vres1, vres2 = jax.jit(jax.vmap(minimal_circ))(pars_q)
+        assert np.allclose(res1, vres1, tol)
+        assert np.allclose(res2, vres2, tol)
+
+
+jacobian_fn = [jax.jacobian, jax.jacrev, jax.jacfwd]
+
+
+@pytest.mark.parametrize("jacobian", jacobian_fn)
+@pytest.mark.parametrize(
+    "interface,dev_name,diff_method,grad_on_execution", interface_and_qubit_device_and_diff_method
+)
+class TestJIT:
+    """Test JAX JIT integration with the QNode and automatic resolution of the
+    correct JAX interface variant."""
+
+    def test_gradient(self, dev_name, diff_method, grad_on_execution, jacobian, tol, interface):
+        """Test derivative calculation of a scalar valued QNode"""
+        num_wires = 1
+
+        if diff_method == "hadamard":
+            num_wires = 2
+
+        dev = qml.device(dev_name, wires=num_wires)
+
+        gradient_kwargs = {}
+        if diff_method == "adjoint":
+            pytest.xfail(reason="The adjoint method is not using host-callback currently")
+        elif diff_method == "spsa":
+            gradient_kwargs = {"h": H_FOR_SPSA}
+            tol = TOL_FOR_SPSA
+
+        @qnode(
+            dev,
+            diff_method=diff_method,
+            interface=interface,
+            grad_on_execution=grad_on_execution,
+            **gradient_kwargs
+        )
+        def circuit(x):
+            qml.RY(x[0], wires=0)
+            qml.RX(x[1], wires=0)
+            return qml.expval(qml.PauliZ(0))
+
+        x = jax.numpy.array([1.0, 2.0])
+        res = circuit(x)
+        g = jax.jit(jacobian(circuit))(x)
+
+        a, b = x
+
+        expected_res = np.cos(a) * np.cos(b)
+        assert np.allclose(res, expected_res, atol=tol, rtol=0)
+
+        expected_g = [-np.sin(a) * np.cos(b), -np.cos(a) * np.sin(b)]
+        assert np.allclose(g, expected_g, atol=tol, rtol=0)
+
+    @pytest.mark.filterwarnings(
+        "ignore:Requested adjoint differentiation to be computed with finite shots."
+    )
+    @pytest.mark.parametrize("shots", [10, 1000])
+    def test_hermitian(self, dev_name, diff_method, grad_on_execution, shots, jacobian, interface):
+        """Test that the jax device works with qml.Hermitian and jitting even
+        when shots>0.
+
+        Note: before a fix, the cases of shots=10 and shots=1000 were failing due
+        to different reasons, hence the parametrization in the test.
+        """
+        # pylint: disable=unused-argument
+        num_wires = 2
+
+        if diff_method == "hadamard":
+            num_wires = 3
+
+        dev = qml.device(dev_name, wires=num_wires, shots=shots)
+
+        if diff_method == "backprop":
+            pytest.skip("Backpropagation is unsupported if shots > 0.")
+
+        if diff_method == "adjoint":
+            pytest.skip("Computing the gradient for observables is not supported with adjoint.")
+
+        projector = np.array(qml.matrix(qml.PauliZ(0) @ qml.PauliZ(1)))
+
+        @qml.qnode(
+            dev, interface=interface, diff_method=diff_method, grad_on_execution=grad_on_execution
+        )
+        def circ(projector):
+            return qml.expval(qml.Hermitian(projector, wires=range(2)))
+
+        result = jax.jit(circ)(projector)
+        assert jax.numpy.allclose(result, 1)
+
+    @pytest.mark.filterwarnings(
+        "ignore:Requested adjoint differentiation to be computed with finite shots."
+    )
+    @pytest.mark.parametrize("shots", [10, 1000])
+    def test_probs_obs_none(
+        self, dev_name, diff_method, grad_on_execution, shots, jacobian, interface
+    ):
+        """Test that the jax device works with qml.probs, a MeasurementProcess
+        that has obs=None even when shots>0."""
+        # pylint: disable=unused-argument
+        num_wires = 2
+
+        if diff_method == "hadamard":
+            num_wires = 3
+
+        dev = qml.device(dev_name, wires=num_wires, shots=shots)
+
+        if diff_method in ["backprop", "adjoint"]:
+            pytest.skip("Backpropagation is unsupported if shots > 0.")
+
+        @qml.qnode(
+            dev, interface=interface, diff_method=diff_method, grad_on_execution=grad_on_execution
+        )
+        def circuit():
+            return qml.probs(wires=0)
+
+        assert jax.numpy.allclose(circuit(), jax.numpy.array([1.0, 0.0]))
+
+    @pytest.mark.xfail(
+        reason="Non-trainable parameters are not being correctly unwrapped by the interface"
+    )
+    def test_gradient_subset(
+        self, dev_name, diff_method, grad_on_execution, jacobian, tol, interface
+    ):
+        """Test derivative calculation of a scalar valued QNode with respect
+        to a subset of arguments"""
+        a = jax.numpy.array(0.1)
+        b = jax.numpy.array(0.2)
+
+        dev = qml.device(dev_name, wires=1)
+
+        @qnode(
+            dev, diff_method=diff_method, interface=interface, grad_on_execution=grad_on_execution
+        )
+        def circuit(a, b, c):
+            qml.RY(a, wires=0)
+            qml.RX(b, wires=0)
+            qml.RZ(c, wires=0)
+            return qml.expval(qml.PauliZ(0))
+
+        res = jax.jit(circuit)(a, b, 0.0)
+        expected_res = np.cos(a) * np.cos(b)
+        assert np.allclose(res, expected_res, atol=tol, rtol=0)
+
+        g = jax.jit(jacobian(circuit, argnums=[0, 1]))(a, b, 0.0)
+        expected_g = [-np.sin(a) * np.cos(b), -np.cos(a) * np.sin(b)]
+        assert np.allclose(g, expected_g, atol=tol, rtol=0)
+
+    def test_gradient_scalar_cost_vector_valued_qnode(
+        self, dev_name, diff_method, grad_on_execution, jacobian, tol, interface
+    ):
+        """Test derivative calculation of a scalar valued cost function that
+        uses the output of a vector-valued QNode"""
+        num_wires = 2
+
+        if diff_method == "hadamard":
+            num_wires = 3
+
+        dev = qml.device(dev_name, wires=num_wires)
+
+        gradient_kwargs = {}
+        if diff_method == "adjoint":
+            pytest.xfail(reason="The adjoint method is not using host-callback currently")
+        elif diff_method == "spsa":
+            gradient_kwargs = {"h": H_FOR_SPSA}
+            tol = TOL_FOR_SPSA
+
+        @qnode(
+            dev,
+            diff_method=diff_method,
+            interface=interface,
+            grad_on_execution=grad_on_execution,
+            **gradient_kwargs
+        )
+        def circuit(x, y):
+            qml.RX(x, wires=[0])
+            qml.RY(y, wires=[1])
+            qml.CNOT(wires=[0, 1])
+            return qml.probs(wires=[1])
+
+        def cost(x, y, idx):
+            res = circuit(x, y)
+            return res[idx]  # pylint:disable=unsubscriptable-object
+
+        x = jax.numpy.array(1.0)
+        y = jax.numpy.array(2.0)
+        expected_g = (
+            np.array([-np.sin(x) * np.cos(y) / 2, np.cos(y) * np.sin(x) / 2]),
+            np.array([-np.cos(x) * np.sin(y) / 2, np.cos(x) * np.sin(y) / 2]),
+        )
+
+        idx = 0
+        g0 = jax.jit(jacobian(cost, argnums=0))(x, y, idx)
+        g1 = jax.jit(jacobian(cost, argnums=1))(x, y, idx)
+        assert np.allclose(g0, expected_g[0][idx], atol=tol, rtol=0)
+        assert np.allclose(g1, expected_g[1][idx], atol=tol, rtol=0)
+
+        idx = 1
+        g0 = jax.jit(jacobian(cost, argnums=0))(x, y, idx)
+        g1 = jax.jit(jacobian(cost, argnums=1))(x, y, idx)
+
+        assert np.allclose(g0, expected_g[0][idx], atol=tol, rtol=0)
+        assert np.allclose(g1, expected_g[1][idx], atol=tol, rtol=0)
+
+    def test_matrix_parameter(
+        self, dev_name, diff_method, grad_on_execution, jacobian, tol, interface
+    ):
+        """Test that the JAX-JIT interface works correctly with a matrix
+        parameter"""
+        # pylint: disable=unused-argument
+        num_wires = 1
+
+        if diff_method == "hadamard":
+            num_wires = 2
+
+        dev = qml.device(dev_name, wires=num_wires)
+
+        @qml.qnode(
+            dev, diff_method=diff_method, interface=interface, grad_on_execution=grad_on_execution
+        )
+        def circ(p, U):
+            qml.QubitUnitary(U, wires=0)
+            qml.RY(p, wires=0)
+            return qml.expval(qml.PauliZ(0))
+
+        p = jax.numpy.array(0.1)
+        U = jax.numpy.array([[0, 1], [1, 0]])
+        res = jax.jit(circ)(p, U)
+        assert np.allclose(res, -np.cos(p), atol=tol, rtol=0)
+
+        jac_fn = jax.jit(jax.grad(circ, argnums=(0)))
+        res = jac_fn(p, U)
+        assert np.allclose(res, np.sin(p), atol=tol, rtol=0)
+
+
+@pytest.mark.parametrize("shots", [None, 10000])
+@pytest.mark.parametrize("jacobian", jacobian_fn)
+@pytest.mark.parametrize(
+    "interface,dev_name,diff_method,grad_on_execution", interface_and_qubit_device_and_diff_method
+)
+class TestReturn:
+    """Class to test the shape of the Grad/Jacobian with different return types."""
+
+    def test_grad_single_measurement_param(
+        self, dev_name, diff_method, grad_on_execution, jacobian, shots, interface
+    ):
+        """For one measurement and one param, the gradient is a float."""
+        if shots is not None and diff_method in ("backprop", "adjoint"):
+            pytest.skip("Test does not support finite shots and adjoint/backprop")
+
+        num_wires = 1
+
+        if diff_method == "hadamard":
+            num_wires = 2
+
+        dev = qml.device(dev_name, wires=num_wires, shots=shots)
+
+        @qnode(
+            dev, interface=interface, diff_method=diff_method, grad_on_execution=grad_on_execution
+        )
+        def circuit(a):
+            qml.RY(a, wires=0)
+            qml.RX(0.2, wires=0)
+            return qml.expval(qml.PauliZ(0))
+
+        a = jax.numpy.array(0.1)
+
+        grad = jax.jit(jacobian(circuit))(a)
+
+        assert isinstance(grad, jax.numpy.ndarray)
+        assert grad.shape == ()
+
+    def test_grad_single_measurement_multiple_param(
+        self, dev_name, diff_method, grad_on_execution, jacobian, shots, interface
+    ):
+        """For one measurement and multiple param, the gradient is a tuple of arrays."""
+        if shots is not None and diff_method in ("backprop", "adjoint"):
+            pytest.skip("Test does not support finite shots and adjoint/backprop")
+
+        num_wires = 1
+
+        if diff_method == "hadamard":
+            num_wires = 2
+
+        dev = qml.device(dev_name, wires=num_wires, shots=shots)
+
+        @qnode(
+            dev, interface=interface, diff_method=diff_method, grad_on_execution=grad_on_execution
+        )
+        def circuit(a, b):
+            qml.RY(a, wires=0)
+            qml.RX(b, wires=0)
+            return qml.expval(qml.PauliZ(0))
+
+        a = jax.numpy.array(0.1)
+        b = jax.numpy.array(0.2)
+
+        grad = jax.jit(jacobian(circuit, argnums=[0, 1]))(a, b)
+
+        assert isinstance(grad, tuple)
+        assert len(grad) == 2
+        assert grad[0].shape == ()
+        assert grad[1].shape == ()
+
+    def test_grad_single_measurement_multiple_param_array(
+        self, dev_name, diff_method, grad_on_execution, jacobian, shots, interface
+    ):
+        """For one measurement and multiple param as a single array params, the gradient is an array."""
+        if shots is not None and diff_method in ("backprop", "adjoint"):
+            pytest.skip("Test does not support finite shots and adjoint/backprop")
+
+        num_wires = 1
+
+        if diff_method == "hadamard":
+            num_wires = 2
+
+        dev = qml.device(dev_name, wires=num_wires, shots=shots)
+
+        @qnode(
+            dev, interface=interface, diff_method=diff_method, grad_on_execution=grad_on_execution
+        )
+        def circuit(a):
+            qml.RY(a[0], wires=0)
+            qml.RX(a[1], wires=0)
+            return qml.expval(qml.PauliZ(0))
+
+        a = jax.numpy.array([0.1, 0.2])
+
+        grad = jax.jit(jacobian(circuit))(a)
+
+        assert isinstance(grad, jax.numpy.ndarray)
+        assert grad.shape == (2,)
+
+    def test_jacobian_single_measurement_param_probs(
+        self, dev_name, diff_method, grad_on_execution, jacobian, shots, interface
+    ):
+        """For a multi dimensional measurement (probs), check that a single array is returned with the correct
+        dimension"""
+        if shots is not None and diff_method in ("backprop", "adjoint"):
+            pytest.skip("Test does not support finite shots and adjoint/backprop")
+
+        if diff_method == "adjoint":
+            pytest.skip("Test does not supports adjoint because of probabilities.")
+
+        num_wires = 2
+
+        if diff_method == "hadamard":
+            num_wires = 3
+
+        dev = qml.device(dev_name, wires=num_wires, shots=shots)
+
+        @qnode(
+            dev, interface=interface, diff_method=diff_method, grad_on_execution=grad_on_execution
+        )
+        def circuit(a):
+            qml.RY(a, wires=0)
+            qml.RX(0.2, wires=0)
+            return qml.probs(wires=[0, 1])
+
+        a = jax.numpy.array(0.1)
+
+        jac = jax.jit(jacobian(circuit))(a)
+
+        assert isinstance(jac, jax.numpy.ndarray)
+        assert jac.shape == (4,)
+
+    def test_jacobian_single_measurement_probs_multiple_param(
+        self, dev_name, diff_method, grad_on_execution, jacobian, shots, interface
+    ):
+        """For a multi dimensional measurement (probs), check that a single tuple is returned containing arrays with
+        the correct dimension"""
+        if diff_method == "adjoint":
+            pytest.skip("Test does not supports adjoint because of probabilities.")
+        if shots is not None and diff_method in ("backprop", "adjoint"):
+            pytest.skip("Test does not support finite shots and adjoint/backprop")
+
+        num_wires = 2
+
+        if diff_method == "hadamard":
+            num_wires = 3
+
+        dev = qml.device(dev_name, wires=num_wires, shots=shots)
+
+        @qnode(
+            dev, interface=interface, diff_method=diff_method, grad_on_execution=grad_on_execution
+        )
+        def circuit(a, b):
+            qml.RY(a, wires=0)
+            qml.RX(b, wires=0)
+            return qml.probs(wires=[0, 1])
+
+        a = jax.numpy.array(0.1)
+        b = jax.numpy.array(0.2)
+
+        jac = jax.jit(jacobian(circuit, argnums=[0, 1]))(a, b)
+
+        assert isinstance(jac, tuple)
+
+        assert isinstance(jac[0], jax.numpy.ndarray)
+        assert jac[0].shape == (4,)
+
+        assert isinstance(jac[1], jax.numpy.ndarray)
+        assert jac[1].shape == (4,)
+
+    def test_jacobian_single_measurement_probs_multiple_param_single_array(
+        self, dev_name, diff_method, grad_on_execution, jacobian, shots, interface
+    ):
+        """For a multi dimensional measurement (probs), check that a single tuple is returned containing arrays with
+        the correct dimension"""
+        if diff_method == "adjoint":
+            pytest.skip("Test does not supports adjoint because of probabilities.")
+        if shots is not None and diff_method in ("backprop", "adjoint"):
+            pytest.skip("Test does not support finite shots and adjoint/backprop")
+
+        num_wires = 2
+
+        if diff_method == "hadamard":
+            num_wires = 3
+
+        dev = qml.device(dev_name, wires=num_wires, shots=shots)
+
+        @qnode(
+            dev, interface=interface, diff_method=diff_method, grad_on_execution=grad_on_execution
+        )
+        def circuit(a):
+            qml.RY(a[0], wires=0)
+            qml.RX(a[1], wires=0)
+            return qml.probs(wires=[0, 1])
+
+        a = jax.numpy.array([0.1, 0.2])
+        jac = jax.jit(jacobian(circuit))(a)
+
+        assert isinstance(jac, jax.numpy.ndarray)
+        assert jac.shape == (4, 2)
+
+    def test_jacobian_expval_expval_multiple_params(
+        self, dev_name, diff_method, grad_on_execution, jacobian, shots, interface
+    ):
+        """The jacobian of multiple measurements with multiple params return a tuple of arrays."""
+        if shots is not None and diff_method in ("backprop", "adjoint"):
+            pytest.skip("Test does not support finite shots and adjoint/backprop")
+        num_wires = 2
+
+        if diff_method == "hadamard":
+            num_wires = 3
+
+        dev = qml.device(dev_name, wires=num_wires, shots=shots)
+
+        par_0 = jax.numpy.array(0.1)
+        par_1 = jax.numpy.array(0.2)
+
+        @qnode(
+            dev, interface=interface, diff_method=diff_method, grad_on_execution=grad_on_execution
+        )
+        def circuit(x, y):
+            qml.RX(x, wires=[0])
+            qml.RY(y, wires=[1])
+            qml.CNOT(wires=[0, 1])
+            return qml.expval(qml.PauliZ(0) @ qml.PauliX(1)), qml.expval(qml.PauliZ(0))
+
+        jac = jax.jit(jacobian(circuit, argnums=[0, 1]))(par_0, par_1)
+
+        assert isinstance(jac, tuple)
+
+        assert isinstance(jac[0], tuple)
+        assert len(jac[0]) == 2
+        assert isinstance(jac[0][0], jax.numpy.ndarray)
+        assert jac[0][0].shape == ()
+        assert isinstance(jac[0][1], jax.numpy.ndarray)
+        assert jac[0][1].shape == ()
+
+        assert isinstance(jac[1], tuple)
+        assert len(jac[1]) == 2
+        assert isinstance(jac[1][0], jax.numpy.ndarray)
+        assert jac[1][0].shape == ()
+        assert isinstance(jac[1][1], jax.numpy.ndarray)
+        assert jac[1][1].shape == ()
+
+    def test_jacobian_expval_expval_multiple_params_array(
+        self, dev_name, diff_method, grad_on_execution, jacobian, shots, interface
+    ):
+        """The jacobian of multiple measurements with a multiple params array return a single array."""
+        if shots is not None and diff_method in ("backprop", "adjoint"):
+            pytest.skip("Test does not support finite shots and adjoint/backprop")
+        num_wires = 2
+
+        if diff_method == "hadamard":
+            num_wires = 3
+
+        dev = qml.device(dev_name, wires=num_wires, shots=shots)
+
+        @qnode(
+            dev, interface=interface, diff_method=diff_method, grad_on_execution=grad_on_execution
+        )
+        def circuit(a):
+            qml.RY(a[0], wires=0)
+            qml.RX(a[1], wires=0)
+            return qml.expval(qml.PauliZ(0) @ qml.PauliX(1)), qml.expval(qml.PauliZ(0))
+
+        a = jax.numpy.array([0.1, 0.2])
+
+        jac = jax.jit(jacobian(circuit))(a)
+
+        assert isinstance(jac, tuple)
+        assert len(jac) == 2  # measurements
+
+        assert isinstance(jac[0], jax.numpy.ndarray)
+        assert jac[0].shape == (2,)
+
+        assert isinstance(jac[1], jax.numpy.ndarray)
+        assert jac[1].shape == (2,)
+
+    def test_jacobian_var_var_multiple_params(
+        self, dev_name, diff_method, grad_on_execution, jacobian, shots, interface
+    ):
+        """The jacobian of multiple measurements with multiple params return a tuple of arrays."""
+        if diff_method == "adjoint":
+            pytest.skip("Test does not supports adjoint because of var.")
+        elif diff_method == "hadamard":
+            pytest.skip("Test does not supports hadamard because of var.")
+        if shots is not None and diff_method in ("backprop", "adjoint"):
+            pytest.skip("Test does not support finite shots and adjoint/backprop")
+
+        dev = qml.device(dev_name, wires=2, shots=shots)
+
+        par_0 = jax.numpy.array(0.1)
+        par_1 = jax.numpy.array(0.2)
+
+        @qnode(
+            dev, interface=interface, diff_method=diff_method, grad_on_execution=grad_on_execution
+        )
+        def circuit(x, y):
+            qml.RX(x, wires=[0])
+            qml.RY(y, wires=[1])
+            qml.CNOT(wires=[0, 1])
+            return qml.var(qml.PauliZ(0) @ qml.PauliX(1)), qml.var(qml.PauliZ(0))
+
+        jac = jax.jit(jacobian(circuit, argnums=[0, 1]))(par_0, par_1)
+
+        assert isinstance(jac, tuple)
+        assert len(jac) == 2
+
+        assert isinstance(jac[0], tuple)
+        assert len(jac[0]) == 2
+        assert isinstance(jac[0][0], jax.numpy.ndarray)
+        assert jac[0][0].shape == ()
+        assert isinstance(jac[0][1], jax.numpy.ndarray)
+        assert jac[0][1].shape == ()
+
+        assert isinstance(jac[1], tuple)
+        assert len(jac[1]) == 2
+        assert isinstance(jac[1][0], jax.numpy.ndarray)
+        assert jac[1][0].shape == ()
+        assert isinstance(jac[1][1], jax.numpy.ndarray)
+        assert jac[1][1].shape == ()
+
+    def test_jacobian_var_var_multiple_params_array(
+        self, dev_name, diff_method, grad_on_execution, jacobian, shots, interface
+    ):
+        """The jacobian of multiple measurements with a multiple params array return a single array."""
+        if diff_method == "adjoint":
+            pytest.skip("Test does not supports adjoint because of var.")
+        elif diff_method == "hadamard":
+            pytest.skip("Test does not supports hadamard because of var.")
+        if shots is not None and diff_method in ("backprop", "adjoint"):
+            pytest.skip("Test does not support finite shots and adjoint/backprop")
+
+        dev = qml.device(dev_name, wires=2, shots=shots)
+
+        @qnode(
+            dev, interface=interface, diff_method=diff_method, grad_on_execution=grad_on_execution
+        )
+        def circuit(a):
+            qml.RY(a[0], wires=0)
+            qml.RX(a[1], wires=0)
+            return qml.var(qml.PauliZ(0) @ qml.PauliX(1)), qml.var(qml.PauliZ(0))
+
+        a = jax.numpy.array([0.1, 0.2])
+
+        jac = jax.jit(jacobian(circuit))(a)
+
+        assert isinstance(jac, tuple)
+        assert len(jac) == 2  # measurements
+
+        assert isinstance(jac[0], jax.numpy.ndarray)
+        assert jac[0].shape == (2,)
+
+        assert isinstance(jac[1], jax.numpy.ndarray)
+        assert jac[1].shape == (2,)
+
+    def test_jacobian_multiple_measurement_single_param(
+        self, dev_name, diff_method, grad_on_execution, jacobian, shots, interface
+    ):
+        """The jacobian of multiple measurements with a single params return an array."""
+        if shots is not None and diff_method in ("backprop", "adjoint"):
+            pytest.skip("Test does not support finite shots and adjoint/backprop")
+        num_wires = 2
+
+        if diff_method == "hadamard":
+            num_wires = 3
+
+        dev = qml.device(dev_name, wires=num_wires, shots=shots)
+
+        if diff_method == "adjoint":
+            pytest.skip("Test does not supports adjoint because of probabilities.")
+
+        @qnode(
+            dev, interface=interface, diff_method=diff_method, grad_on_execution=grad_on_execution
+        )
+        def circuit(a):
+            qml.RY(a, wires=0)
+            qml.RX(0.2, wires=0)
+            return qml.expval(qml.PauliZ(0)), qml.probs(wires=[0, 1])
+
+        a = jax.numpy.array(0.1)
+
+        jac = jax.jit(jacobian(circuit))(a)
+
+        assert isinstance(jac, tuple)
+        assert len(jac) == 2
+
+        assert isinstance(jac[0], jax.numpy.ndarray)
+        assert jac[0].shape == ()
+
+        assert isinstance(jac[1], jax.numpy.ndarray)
+        assert jac[1].shape == (4,)
+
+    def test_jacobian_multiple_measurement_multiple_param(
+        self, dev_name, diff_method, grad_on_execution, jacobian, shots, interface
+    ):
+        """The jacobian of multiple measurements with a multiple params return a tuple of arrays."""
+        if diff_method == "adjoint":
+            pytest.skip("Test does not supports adjoint because of probabilities.")
+        if shots is not None and diff_method in ("backprop", "adjoint"):
+            pytest.skip("Test does not support finite shots and adjoint/backprop")
+
+        num_wires = 2
+
+        if diff_method == "hadamard":
+            num_wires = 3
+
+        dev = qml.device(dev_name, wires=num_wires, shots=shots)
+
+        @qnode(
+            dev, interface=interface, diff_method=diff_method, grad_on_execution=grad_on_execution
+        )
+        def circuit(a, b):
+            qml.RY(a, wires=0)
+            qml.RX(b, wires=0)
+            return qml.expval(qml.PauliZ(0)), qml.probs(wires=[0, 1])
+
+        a = np.array(0.1, requires_grad=True)
+        b = np.array(0.2, requires_grad=True)
+
+        jac = jax.jit(jacobian(circuit, argnums=[0, 1]))(a, b)
+
+        assert isinstance(jac, tuple)
+        assert len(jac) == 2
+
+        assert isinstance(jac[0], tuple)
+        assert len(jac[0]) == 2
+        assert isinstance(jac[0][0], jax.numpy.ndarray)
+        assert jac[0][0].shape == ()
+        assert isinstance(jac[0][1], jax.numpy.ndarray)
+        assert jac[0][1].shape == ()
+
+        assert isinstance(jac[1], tuple)
+        assert len(jac[1]) == 2
+        assert isinstance(jac[1][0], jax.numpy.ndarray)
+        assert jac[1][0].shape == (4,)
+        assert isinstance(jac[1][1], jax.numpy.ndarray)
+        assert jac[1][1].shape == (4,)
+
+    def test_jacobian_multiple_measurement_multiple_param_array(
+        self, dev_name, diff_method, grad_on_execution, jacobian, shots, interface
+    ):
+        """The jacobian of multiple measurements with a multiple params array return a single array."""
+        if diff_method == "adjoint":
+            pytest.skip("Test does not supports adjoint because of probabilities.")
+        if shots is not None and diff_method in ("backprop", "adjoint"):
+            pytest.skip("Test does not support finite shots and adjoint/backprop")
+
+        num_wires = 2
+
+        if diff_method == "hadamard":
+            num_wires = 3
+
+        dev = qml.device(dev_name, wires=num_wires, shots=shots)
+
+        @qnode(
+            dev, interface=interface, diff_method=diff_method, grad_on_execution=grad_on_execution
+        )
+        def circuit(a):
+            qml.RY(a[0], wires=0)
+            qml.RX(a[1], wires=0)
+            return qml.expval(qml.PauliZ(0)), qml.probs(wires=[0, 1])
+
+        a = jax.numpy.array([0.1, 0.2])
+
+        jac = jax.jit(jacobian(circuit))(a)
+
+        assert isinstance(jac, tuple)
+        assert len(jac) == 2  # measurements
+
+        assert isinstance(jac[0], jax.numpy.ndarray)
+        assert jac[0].shape == (2,)
+
+        assert isinstance(jac[1], jax.numpy.ndarray)
+        assert jac[1].shape == (4, 2)
+
+
+hessian_fn = [
+    jax.hessian,
+    lambda fn, argnums=0: jax.jacrev(jax.jacfwd(fn, argnums=argnums), argnums=argnums),
+    lambda fn, argnums=0: jax.jacfwd(jax.jacrev(fn, argnums=argnums), argnums=argnums),
+]
+
+
+@pytest.mark.parametrize("hessian", hessian_fn)
+@pytest.mark.parametrize(
+    "interface,dev_name,diff_method,grad_on_execution", interface_and_qubit_device_and_diff_method
+)
+class TestReturnHessian:
+    """Class to test the shape of the Hessian with different return types."""
+
+    def test_hessian_expval_multiple_params(
+        self, dev_name, diff_method, hessian, grad_on_execution, interface
+    ):
+        """The hessian of single a measurement with multiple params return a tuple of arrays."""
+        num_wires = 2
+
+        if diff_method == "hadamard":
+            num_wires = 4
+
+        dev = qml.device(dev_name, wires=num_wires)
+
+        if diff_method == "adjoint":
+            pytest.skip("Test does not supports adjoint because second order diff.")
+
+        par_0 = jax.numpy.array(0.1)
+        par_1 = jax.numpy.array(0.2)
+
+        @qnode(
+            dev,
+            interface=interface,
+            diff_method=diff_method,
+            max_diff=2,
+            grad_on_execution=grad_on_execution,
+        )
+        def circuit(x, y):
+            qml.RX(x, wires=[0])
+            qml.RY(y, wires=[1])
+            qml.CNOT(wires=[0, 1])
+            return qml.expval(qml.PauliZ(0) @ qml.PauliX(1))
+
+        hess = jax.jit(hessian(circuit, argnums=[0, 1]))(par_0, par_1)
+
+        assert isinstance(hess, tuple)
+        assert len(hess) == 2
+
+        assert isinstance(hess[0], tuple)
+        assert len(hess[0]) == 2
+        assert isinstance(hess[0][0], jax.numpy.ndarray)
+        assert isinstance(hess[0][1], jax.numpy.ndarray)
+        assert hess[0][0].shape == ()
+        assert hess[0][1].shape == ()
+
+        assert isinstance(hess[1], tuple)
+        assert len(hess[1]) == 2
+        assert isinstance(hess[1][0], jax.numpy.ndarray)
+        assert isinstance(hess[1][1], jax.numpy.ndarray)
+        assert hess[1][0].shape == ()
+        assert hess[1][1].shape == ()
+
+    def test_hessian_expval_multiple_param_array(
+        self, dev_name, diff_method, hessian, grad_on_execution, interface
+    ):
+        """The hessian of single measurement with a multiple params array return a single array."""
+
+        if diff_method == "adjoint":
+            pytest.skip("Test does not supports adjoint because second order diff.")
+
+        num_wires = 2
+
+        if diff_method == "hadamard":
+            num_wires = 4
+
+        dev = qml.device(dev_name, wires=num_wires)
+
+        params = jax.numpy.array([0.1, 0.2], dtype=jax.numpy.float64)
+
+        @qnode(
+            dev,
+            interface=interface,
+            diff_method=diff_method,
+            max_diff=2,
+            grad_on_execution=grad_on_execution,
+        )
+        def circuit(x):
+            qml.RX(x[0], wires=[0])
+            qml.RY(x[1], wires=[1])
+            qml.CNOT(wires=[0, 1])
+            return qml.expval(qml.PauliZ(0) @ qml.PauliX(1))
+
+        hess = jax.jit(hessian(circuit))(params)
+
+        assert isinstance(hess, jax.numpy.ndarray)
+        assert hess.shape == (2, 2)
+
+    def test_hessian_var_multiple_params(
+        self, dev_name, diff_method, hessian, grad_on_execution, interface
+    ):
+        """The hessian of single a measurement with multiple params return a tuple of arrays."""
+        dev = qml.device(dev_name, wires=2)
+
+        if diff_method == "adjoint":
+            pytest.skip("Test does not supports adjoint because second order diff.")
+        elif diff_method == "hadamard":
+            pytest.skip("Test does not supports hadamard because of var.")
+
+        par_0 = jax.numpy.array(0.1, dtype=jax.numpy.float64)
+        par_1 = jax.numpy.array(0.2, dtype=jax.numpy.float64)
+
+        @qnode(
+            dev,
+            interface=interface,
+            diff_method=diff_method,
+            max_diff=2,
+            grad_on_execution=grad_on_execution,
+        )
+        def circuit(x, y):
+            qml.RX(x, wires=[0])
+            qml.RY(y, wires=[1])
+            qml.CNOT(wires=[0, 1])
+            return qml.var(qml.PauliZ(0) @ qml.PauliX(1))
+
+        hess = jax.jit(hessian(circuit, argnums=[0, 1]))(par_0, par_1)
+
+        assert isinstance(hess, tuple)
+        assert len(hess) == 2
+
+        assert isinstance(hess[0], tuple)
+        assert len(hess[0]) == 2
+        assert isinstance(hess[0][0], jax.numpy.ndarray)
+        assert isinstance(hess[0][1], jax.numpy.ndarray)
+        assert hess[0][0].shape == ()
+        assert hess[0][1].shape == ()
+
+        assert isinstance(hess[1], tuple)
+        assert len(hess[1]) == 2
+        assert isinstance(hess[1][0], jax.numpy.ndarray)
+        assert isinstance(hess[1][1], jax.numpy.ndarray)
+        assert hess[1][0].shape == ()
+        assert hess[1][1].shape == ()
+
+    def test_hessian_var_multiple_param_array(
+        self, dev_name, diff_method, hessian, grad_on_execution, interface
+    ):
+        """The hessian of single measurement with a multiple params array return a single array."""
+        if diff_method == "adjoint":
+            pytest.skip("Test does not supports adjoint because second order diff.")
+        elif diff_method == "hadamard":
+            pytest.skip("Test does not supports hadamard because of var.")
+
+        dev = qml.device(dev_name, wires=2)
+
+        params = jax.numpy.array([0.1, 0.2], dtype=jax.numpy.float64)
+
+        @qnode(
+            dev,
+            interface=interface,
+            diff_method=diff_method,
+            max_diff=2,
+            grad_on_execution=grad_on_execution,
+        )
+        def circuit(x):
+            qml.RX(x[0], wires=[0])
+            qml.RY(x[1], wires=[1])
+            qml.CNOT(wires=[0, 1])
+            return qml.var(qml.PauliZ(0) @ qml.PauliX(1))
+
+        hess = jax.jit(hessian(circuit))(params)
+
+        assert isinstance(hess, jax.numpy.ndarray)
+        assert hess.shape == (2, 2)
+
+    def test_hessian_probs_expval_multiple_params(
+        self, dev_name, diff_method, hessian, grad_on_execution, interface
+    ):
+        """The hessian of multiple measurements with multiple params return a tuple of arrays."""
+        num_wires = 2
+
+        if diff_method == "hadamard":
+            num_wires = 4
+
+        dev = qml.device(dev_name, wires=num_wires)
+
+        if diff_method == "adjoint":
+            pytest.skip("Test does not supports adjoint because second order diff.")
+        elif diff_method == "hadamard":
+            pytest.skip("Test does not supports hadamard because of non commuting obs.")
+
+        par_0 = jax.numpy.array(0.1, dtype=jax.numpy.float64)
+        par_1 = jax.numpy.array(0.2, dtype=jax.numpy.float64)
+
+        @qnode(
+            dev,
+            interface=interface,
+            diff_method=diff_method,
+            max_diff=2,
+            grad_on_execution=grad_on_execution,
+        )
+        def circuit(x, y):
+            qml.RX(x, wires=[0])
+            qml.RY(y, wires=[1])
+            qml.CNOT(wires=[0, 1])
+            return qml.expval(qml.PauliZ(0) @ qml.PauliX(1)), qml.probs(wires=[0])
+
+        hess = jax.jit(hessian(circuit, argnums=[0, 1]))(par_0, par_1)
+
+        assert isinstance(hess, tuple)
+        assert len(hess) == 2
+
+        assert isinstance(hess[0], tuple)
+        assert len(hess[0]) == 2
+
+        for h in hess[0]:
+            assert isinstance(h, tuple)
+            for h_comp in h:
+                assert h_comp.shape == ()
+
+        for h in hess[1]:
+            assert isinstance(h, tuple)
+            for h_comp in h:
+                assert h_comp.shape == (2,)
+
+    def test_hessian_probs_expval_multiple_param_array(
+        self, dev_name, diff_method, hessian, grad_on_execution, interface
+    ):
+        """The hessian of multiple measurements with a multiple param array return a single array."""
+
+        if diff_method == "adjoint":
+            pytest.skip("Test does not supports adjoint because second order diff.")
+        elif diff_method == "hadamard":
+            pytest.skip("Test does not supports hadamard because of non commuting obs.")
+
+        num_wires = 2
+
+        if diff_method == "hadamard":
+            num_wires = 4
+
+        dev = qml.device(dev_name, wires=num_wires)
+
+        params = jax.numpy.array([0.1, 0.2], dtype=jax.numpy.float64)
+
+        @qnode(
+            dev,
+            interface=interface,
+            diff_method=diff_method,
+            max_diff=2,
+            grad_on_execution=grad_on_execution,
+        )
+        def circuit(x):
+            qml.RX(x[0], wires=[0])
+            qml.RY(x[1], wires=[1])
+            qml.CNOT(wires=[0, 1])
+            return qml.expval(qml.PauliZ(0) @ qml.PauliX(1)), qml.probs(wires=[0])
+
+        hess = jax.jit(hessian(circuit))(params)
+
+        assert isinstance(hess, tuple)
+        assert len(hess) == 2
+        assert isinstance(hess[0], jax.numpy.ndarray)
+        assert hess[0].shape == (2, 2)
+
+        assert isinstance(hess[1], jax.numpy.ndarray)
+        assert hess[1].shape == (2, 2, 2)
+
+    def test_hessian_probs_var_multiple_params(
+        self, dev_name, diff_method, hessian, grad_on_execution, interface
+    ):
+        """The hessian of multiple measurements with multiple params return a tuple of arrays."""
+        dev = qml.device(dev_name, wires=2)
+
+        if diff_method == "adjoint":
+            pytest.skip("Test does not supports adjoint because second order diff.")
+        elif diff_method == "hadamard":
+            pytest.skip("Test does not supports hadamard because of var.")
+
+        par_0 = jax.numpy.array(0.1, dtype=jax.numpy.float64)
+        par_1 = jax.numpy.array(0.2, dtype=jax.numpy.float64)
+
+        @qnode(
+            dev,
+            interface=interface,
+            diff_method=diff_method,
+            max_diff=2,
+            grad_on_execution=grad_on_execution,
+        )
+        def circuit(x, y):
+            qml.RX(x, wires=[0])
+            qml.RY(y, wires=[1])
+            qml.CNOT(wires=[0, 1])
+            return qml.var(qml.PauliZ(0) @ qml.PauliX(1)), qml.probs(wires=[0])
+
+        hess = jax.jit(hessian(circuit, argnums=[0, 1]))(par_0, par_1)
+
+        assert isinstance(hess, tuple)
+        assert len(hess) == 2
+
+        assert isinstance(hess[0], tuple)
+        assert len(hess[0]) == 2
+
+        for h in hess[0]:
+            assert isinstance(h, tuple)
+            for h_comp in h:
+                assert h_comp.shape == ()
+
+        for h in hess[1]:
+            assert isinstance(h, tuple)
+            for h_comp in h:
+                assert h_comp.shape == (2,)
+
+    def test_hessian_probs_var_multiple_param_array(
+        self, dev_name, diff_method, hessian, grad_on_execution, interface
+    ):
+        """The hessian of multiple measurements with a multiple param array return a single array."""
+        if diff_method == "adjoint":
+            pytest.skip("Test does not supports adjoint because second order diff.")
+        elif diff_method == "hadamard":
+            pytest.skip("Test does not supports hadamard because of var.")
+
+        dev = qml.device(dev_name, wires=2)
+
+        params = jax.numpy.array([0.1, 0.2], dtype=jax.numpy.float64)
+
+        @qnode(
+            dev,
+            interface=interface,
+            diff_method=diff_method,
+            max_diff=2,
+            grad_on_execution=grad_on_execution,
+        )
+        def circuit(x):
+            qml.RX(x[0], wires=[0])
+            qml.RY(x[1], wires=[1])
+            qml.CNOT(wires=[0, 1])
+            return qml.var(qml.PauliZ(0) @ qml.PauliX(1)), qml.probs(wires=[0])
+
+        hess = jax.jit(hessian(circuit))(params)
+
+        assert isinstance(hess, tuple)
+        assert len(hess) == 2
+        assert isinstance(hess[0], jax.numpy.ndarray)
+        assert hess[0].shape == (2, 2)
+
+        assert isinstance(hess[1], jax.numpy.ndarray)
+        assert hess[1].shape == (2, 2, 2)
+
+
+@pytest.mark.parametrize("hessian", hessian_fn)
+@pytest.mark.parametrize("diff_method", ["param-shift", "hadamard"])
+def test_jax_device_hessian_shots(hessian, diff_method):
+    """The hessian of multiple measurements with a multiple param array return a single array."""
+    num_wires = 1
+
+    if diff_method == "hadamard":
+        num_wires = 3
+
+    dev = qml.device("default.qubit.jax", wires=num_wires, shots=10000)
+
+    @jax.jit
+    @qml.qnode(dev, diff_method="parameter-shift", max_diff=2)
+    def circuit(x):
+        qml.RY(x[0], wires=0)
+        qml.RX(x[1], wires=0)
+        return qml.expval(qml.PauliZ(0))
+
+    x = jax.numpy.array([1.0, 2.0])
+    a, b = x
+
+    hess = jax.jit(hessian(circuit))(x)
+
+    expected_hess = [
+        [-np.cos(a) * np.cos(b), np.sin(a) * np.sin(b)],
+        [np.sin(a) * np.sin(b), -np.cos(a) * np.cos(b)],
+    ]
+    shots_tol = 0.1
+    assert np.allclose(hess, expected_hess, atol=shots_tol, rtol=0)
+
+
+@pytest.mark.parametrize("jit_inside", [True, False])
+@pytest.mark.parametrize("argnums", [0, 1, [0, 1]])
+@pytest.mark.parametrize("jacobian", jacobian_fn)
+@pytest.mark.parametrize(
+    "interface,dev_name,diff_method,grad_on_execution", interface_and_qubit_device_and_diff_method
+)
+class TestSubsetArgnums:
+    def test_single_measurement(
+        self,
+        interface,
+        dev_name,
+        diff_method,
+        grad_on_execution,
+        jacobian,
+        argnums,
+        jit_inside,
+        tol,
+    ):
+        """Test single measurement with different diff methods with argnums."""
+
+        dev = qml.device(dev_name, wires=3)
+
+        @qml.qnode(
+            dev,
+            interface=interface,
+            diff_method=diff_method,
+            grad_on_execution=grad_on_execution,
+            cache=False,
+        )
+        def circuit(a, b):
+            qml.RY(a, wires=0)
+            qml.RX(b, wires=1)
+            qml.CNOT(wires=[0, 1])
+            return qml.expval(qml.PauliZ(0))
+
+        a = jax.numpy.array(1.0)
+        b = jax.numpy.array(2.0)
+
+        if jit_inside:
+            jac = jacobian(jax.jit(circuit), argnums=argnums)(a, b)
+        else:
+            jac = jax.jit(jacobian(circuit, argnums=argnums))(a, b)
+
+        expected = np.array([-np.sin(a), 0])
+
+        if diff_method == "spsa":
+            tol = TOL_FOR_SPSA
+
+        if argnums == 0:
+            assert np.allclose(jac, expected[0], atol=tol)
+        elif argnums == 1:
+            assert np.allclose(jac, expected[1], atol=tol)
+        else:
+            assert np.allclose(jac[0], expected[0], atol=tol)
+            assert np.allclose(jac[1], expected[1], atol=tol)
+
+    def test_multi_measurements(
+        self,
+        interface,
+        dev_name,
+        diff_method,
+        grad_on_execution,
+        jacobian,
+        argnums,
+        jit_inside,
+        tol,
+    ):
+        """Test multiple measurements with different diff methods with argnums."""
+        dev = qml.device(dev_name, wires=3)
+
+        @qml.qnode(
+            dev, interface=interface, diff_method=diff_method, grad_on_execution=grad_on_execution
+        )
+        def circuit(a, b):
+            qml.RY(a, wires=0)
+            qml.RX(b, wires=1)
+            qml.CNOT(wires=[0, 1])
+            return qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliY(1))
+
+        a = jax.numpy.array(1.0)
+        b = jax.numpy.array(2.0)
+
+        if jit_inside:
+            jac = jacobian(jax.jit(circuit), argnums=argnums)(a, b)
+        else:
+            jac = jax.jit(jacobian(circuit, argnums=argnums))(a, b)
+
+        if diff_method == "spsa":
+            tol = TOL_FOR_SPSA
+
+        expected = np.array([[-np.sin(a), 0], [np.sin(a) * np.sin(b), -np.cos(a) * np.cos(b)]])
+
+        if argnums == 0:
+            assert np.allclose(jac, expected.T[0], atol=tol)
+        elif argnums == 1:
+            assert np.allclose(jac, expected.T[1], atol=tol)
+        else:
+            assert np.allclose(jac[0], expected[0], atol=tol)
+            assert np.allclose(jac[1], expected[1], atol=tol)

--- a/tests/interfaces/default_qubit_2_integration/test_jax_jit_qnode_default_qubit_2.py
+++ b/tests/interfaces/default_qubit_2_integration/test_jax_jit_qnode_default_qubit_2.py
@@ -1707,6 +1707,7 @@ class TestJIT:
     def test_matrix_parameter(self, dev, diff_method, grad_on_execution, jacobian, tol, interface):
         """Test that the JAX-JIT interface works correctly with a matrix
         parameter"""
+
         # pylint: disable=unused-argument
         @qml.qnode(
             dev, diff_method=diff_method, interface=interface, grad_on_execution=grad_on_execution

--- a/tests/interfaces/test_jax_jit_qnode.py
+++ b/tests/interfaces/test_jax_jit_qnode.py
@@ -544,11 +544,11 @@ class TestVectorValuedQNode:
         ]
 
         assert isinstance(res[0], jax.numpy.ndarray)
-        assert res[0].shape == (2,)
+        assert res[0].shape == (2,)  # pylint:disable=comparison-with-callable
         assert np.allclose(res[0], expected[0], atol=tol, rtol=0)
 
         assert isinstance(res[1], jax.numpy.ndarray)
-        assert res[1].shape == (4,)
+        assert res[1].shape == (4,)  # pylint:disable=comparison-with-callable
         assert np.allclose(res[1], expected[1], atol=tol, rtol=0)
 
         jac = jax.jit(jax.jacobian(circuit, argnums=[0, 1]))(x, y)
@@ -1354,7 +1354,7 @@ class TestQubitIntegrationHigherOrder:
 
         def cost_fn(x, y):
             res = circuit(x, y)
-            assert res.dtype is np.dtype("complex128")
+            assert res.dtype is np.dtype("complex128")  # pylint:disable=no-member
             probs = jax.numpy.abs(res) ** 2
             return probs[0] + probs[2]
 
@@ -1965,7 +1965,7 @@ class TestJIT:
 
         def cost(x, y, idx):
             res = circuit(x, y)
-            return res[idx]
+            return res[idx]  # pylint:disable=unsubscriptable-object
 
         x = jax.numpy.array(1.0)
         y = jax.numpy.array(2.0)
@@ -2844,7 +2844,7 @@ class TestReturnHessian:
 
 
 @pytest.mark.parametrize("hessian", hessian_fn)
-@pytest.mark.parametrize("diff_method", ["param-shift", "hadamard"])
+@pytest.mark.parametrize("diff_method", ["parameter-shift", "hadamard"])
 def test_jax_device_hessian_shots(hessian, diff_method):
     """The hessian of multiple measurements with a multiple param array return a single array."""
     num_wires = 1
@@ -2855,7 +2855,7 @@ def test_jax_device_hessian_shots(hessian, diff_method):
     dev = qml.device("default.qubit.jax", wires=num_wires, shots=10000)
 
     @jax.jit
-    @qml.qnode(dev, diff_method="parameter-shift", max_diff=2)
+    @qml.qnode(dev, diff_method=diff_method, max_diff=2)
     def circuit(x):
         qml.RY(x[0], wires=0)
         qml.RX(x[1], wires=0)


### PR DESCRIPTION
**Context:**
All interfaces should work with the new device, and that includes jax-jit!

**Description of the Change:**
Add jax-jit QNode support. This involved a few little things:
1. a certain simulation was missing the `is_state_batched` arg when calling `measure`, so I fixed that
2. jax-jit expected all result types to match, so I cast a bunch of things to tuples (because those are better than lists 💪)
3. The `shape_dtype` thing is a weird thing that I can't explain easily in words, but I will give the low-down. The helper function that generates shape objects says "if only 1 measurement and only 1 tape, return `shapes[0]`", but the function that interpreted it assumed that it was always a list of shape objects. This was only found because a) the new devices does some pre-processing for adjoint differentiation (including setting `tape.trainable_parameters`) but wrongly - see #4351.
4. Change `QuantumScript.shape` to support the new device interface. Basically, `device` won't provide anything we need, but `self` (a tape) will! It shouldn't be a dangerous change because jax-jit is the only place that uses `QuantumScript.shape` afaik (pls correct me if I'm wrong)

**Benefits:**
jax-jit works with QNodes and DefaultQubit2

**Possible Drawbacks:**
Changes 2-4 from above all seem to suggest some cleanup could be necessary for various parts of our code (`tape.shape`, jax_jit_tuple.py in general)

[sc-41087]