### PR TITLE
Support broadcasting in `merge_amplitude_embedding`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -91,6 +91,10 @@
 * `qml.qinfo.purity` now produces correct results with custom wire labels.
   [#4331](https://github.com/PennyLaneAI/pennylane/pull/4331)
 
+* `qml.transforms.merge_amplitude_embedding` now works correctly when the `AmplitudeEmbeddings`
+  have a batch dimension.
+  [#4353](https://github.com/PennyLaneAI/pennylane/pull/4353)
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -94,7 +94,7 @@
 * `default.qutrit` now supports all qutrit operations used with `qml.adjoint`.
   [(#4348)](https://github.com/PennyLaneAI/pennylane/pull/4348)
 
-* `qml.transforms.merge_amplitude_embedding` now works correctly when the `AmplitudeEmbeddings`
+* `qml.transforms.merge_amplitude_embedding` now works correctly when the `AmplitudeEmbedding`s
   have a batch dimension.
   [(#4353)](https://github.com/PennyLaneAI/pennylane/pull/4353)
 

--- a/pennylane/transforms/optimization/merge_amplitude_embedding.py
+++ b/pennylane/transforms/optimization/merge_amplitude_embedding.py
@@ -17,7 +17,7 @@ from pennylane.transforms import qfunc_transform
 
 from pennylane import AmplitudeEmbedding
 from pennylane._device import DeviceError
-from pennylane.math import kron
+from pennylane.math import flatten, reshape
 
 
 @qfunc_transform
@@ -62,7 +62,7 @@ def merge_amplitude_embedding(tape):
     list_copy = tape.operations.copy()
     not_amplitude_embedding = []
     visited_wires = set()
-    input_wires, input_vectors = [], []
+    input_wires, input_vectors, input_batch_size = [], [], []
     while len(list_copy) > 0:
         current_gate = list_copy[0]
         wires_set = set(current_gate.wires)
@@ -81,17 +81,25 @@ def merge_amplitude_embedding(tape):
             )
         input_wires.append(current_gate.wires)
         input_vectors.append(current_gate.parameters[0])
+        input_batch_size.append(current_gate.batch_size)
         list_copy.pop(0)
         visited_wires = visited_wires.union(wires_set)
 
     if len(input_wires) > 0:
         final_wires = input_wires[0]
         final_vector = input_vectors[0]
+        final_batch_size = input_batch_size[0]
 
         # Merge all parameters and qubits into a single one.
-        for w, v in zip(input_wires[1:], input_vectors[1:]):
-            final_vector = kron(final_vector, v)
+        for w, v, b in zip(input_wires[1:], input_vectors[1:], input_batch_size[1:]):
+            final_vector = final_vector[..., :, None] * v[..., None, :]
+            final_batch_size = final_batch_size or b
             final_wires = final_wires + w
+
+            if final_batch_size:
+                final_vector = reshape(final_vector, (final_batch_size, -1))
+            else:
+                final_vector = flatten(final_vector)
 
         AmplitudeEmbedding(final_vector, wires=final_wires)
 


### PR DESCRIPTION
**Context:**
If the `AmplitudeEmbeddings` inside a QNode each have a batch dimension, and that QNode is decorated with `merge_amplitude_embedding`, then the batch dimensions would not be broadcasted over correctly. This is illustrated with the below example:

```python
@qml.qnode(qml.device('default.qubit', wires=2))
@qml.transforms.merge_amplitude_embedding
def circuit(m1, m2):
    qml.AmplitudeEmbedding(m1, wires=0)
    qml.AmplitudeEmbedding(m2, wires=1)
    return  qml.expval(qml.PauliZ(0))

m1 = np.array([[1, 0], [0, 1]])  # batch size 2
m2 = np.array([[0, 1], [1, 0]])  # batch size 2
```
```
>>> circuit(m1, m2)
tensor([ 1.,  1., -1., -1.], requires_grad=True)
```
The output above has a batch size of 4, which is incorrect.

See the Github issue below for more details.

**Description of the Change:**
Inside `merge_amplitude_embedding` we use `kron`. We change this to be a simple broadcasted matrix multiplication.

**Related GitHub Issues:**
Fixes https://github.com/PennyLaneAI/pennylane/issues/4333
