### PR TITLE
ApproxTimeEvolution.compute_decomposition docstring has example

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -98,6 +98,7 @@
 
 This release contains contributions from (in alphabetical order):
 
+Isaac De Vlugt,
 Edward Jiang,
 Christina Lee,
 Mudit Pandey,

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -79,6 +79,9 @@
 
 <h3>Documentation 📝</h3>
 
+* `qml.ApproxTimeEvolution.compute_decomposition()` now has a code example.
+  [(#4354)](https://github.com/PennyLaneAI/pennylane/pull/4354)
+
 <h3>Bug fixes 🐛</h3>
   
 * Stop `metric_tensor` from accidentally catching errors that stem from

--- a/pennylane/templates/subroutines/approx_time_evolution.py
+++ b/pennylane/templates/subroutines/approx_time_evolution.py
@@ -148,22 +148,23 @@ class ApproxTimeEvolution(Operation):
             from pennylane.templates import ApproxTimeEvolution
 
             num_qubits = 2
-            
+
             hamiltonian = qml.Hamiltonian(
                 [0.1, 0.2, 0.3], [qml.PauliZ(0) @ qml.PauliZ(1), qml.PauliX(0), qml.PauliX(1)]
             )
-            
+
             dev = qml.device("default.qubit", wires=num_qubits)
-            
+
             evolution_time = 0.5
             trotter_steps = 1
-            
+
             coeffs_and_time = [*hamiltonian.coeffs, evolution_time]
-            
-            >>> ApproxTimeEvolution.compute_decomposition(
-            ...     *coeffs_and_time, wires=range(num_qubits), n=trotter_steps, hamiltonian=hamiltonian
-            ... )
-            [PauliRot(0.1, ZZ, wires=[0, 1]), PauliRot(0.2, X, wires=[0]), PauliRot(0.3, X, wires=[1])]
+
+
+        >>> ApproxTimeEvolution.compute_decomposition(
+        ...     *coeffs_and_time, wires=range(num_qubits), n=trotter_steps, hamiltonian=hamiltonian
+        ... )
+        [PauliRot(0.1, ZZ, wires=[0, 1]), PauliRot(0.2, X, wires=[0]), PauliRot(0.3, X, wires=[1])]
         """
         pauli = {"Identity": "I", "PauliX": "X", "PauliY": "Y", "PauliZ": "Z"}
 

--- a/pennylane/templates/subroutines/approx_time_evolution.py
+++ b/pennylane/templates/subroutines/approx_time_evolution.py
@@ -140,6 +140,30 @@ class ApproxTimeEvolution(Operation):
 
         Returns:
             list[.Operator]: decomposition of the operator
+
+
+        .. code-block:: python
+
+            import pennylane as qml
+            from pennylane.templates import ApproxTimeEvolution
+
+            num_qubits = 2
+            
+            hamiltonian = qml.Hamiltonian(
+                [0.1, 0.2, 0.3], [qml.PauliZ(0) @ qml.PauliZ(1), qml.PauliX(0), qml.PauliX(1)]
+            )
+            
+            dev = qml.device("default.qubit", wires=num_qubits)
+            
+            evolution_time = 0.5
+            trotter_steps = 1
+            
+            coeffs_and_time = [*hamiltonian.coeffs, evolution_time]
+            
+            >>> qml.ApproxTimeEvolution.compute_decomposition(
+            ...     *coeffs_and_time, wires=range(num_qubits), n=trotter_steps, hamiltonian=hamiltonian
+            ... )
+                [PauliRot(0.1, ZZ, wires=[0, 1]), PauliRot(0.2, X, wires=[0]), PauliRot(0.3, X, wires=[1])]
         """
         pauli = {"Identity": "I", "PauliX": "X", "PauliY": "Y", "PauliZ": "Z"}
 

--- a/pennylane/templates/subroutines/approx_time_evolution.py
+++ b/pennylane/templates/subroutines/approx_time_evolution.py
@@ -160,7 +160,7 @@ class ApproxTimeEvolution(Operation):
             
             coeffs_and_time = [*hamiltonian.coeffs, evolution_time]
             
-            >>> qml.ApproxTimeEvolution.compute_decomposition(
+            >>> ApproxTimeEvolution.compute_decomposition(
             ...     *coeffs_and_time, wires=range(num_qubits), n=trotter_steps, hamiltonian=hamiltonian
             ... )
                 [PauliRot(0.1, ZZ, wires=[0, 1]), PauliRot(0.2, X, wires=[0]), PauliRot(0.3, X, wires=[1])]

--- a/pennylane/templates/subroutines/approx_time_evolution.py
+++ b/pennylane/templates/subroutines/approx_time_evolution.py
@@ -78,7 +78,7 @@ class ApproxTimeEvolution(Operation):
         .. code-block:: python
 
             import pennylane as qml
-            from pennylane.templates import ApproxTimeEvolution
+            from pennylane import ApproxTimeEvolution
 
             n_wires = 2
             wires = range(n_wires)
@@ -129,8 +129,7 @@ class ApproxTimeEvolution(Operation):
         .. seealso:: :meth:`~.ApproxTimeEvolution.decomposition`.
 
         Args:
-            coeffs_and_time (list[tensor_like or float]): list of coefficients of the Hamiltonian, appended by the time
-                variable
+            *coeffs_and_time (TensorLike): coefficients of the Hamiltonian, appended by the time.
             wires (Any or Iterable[Any]): wires that the operator acts on
             hamiltonian (.Hamiltonian): The Hamiltonian defining the
                time-evolution operator. The Hamiltonian must be explicitly written
@@ -145,15 +144,13 @@ class ApproxTimeEvolution(Operation):
         .. code-block:: python
 
             import pennylane as qml
-            from pennylane.templates import ApproxTimeEvolution
+            from pennylane import ApproxTimeEvolution
 
             num_qubits = 2
 
             hamiltonian = qml.Hamiltonian(
                 [0.1, 0.2, 0.3], [qml.PauliZ(0) @ qml.PauliZ(1), qml.PauliX(0), qml.PauliX(1)]
             )
-
-            dev = qml.device("default.qubit", wires=num_qubits)
 
             evolution_time = 0.5
             trotter_steps = 1

--- a/pennylane/templates/subroutines/approx_time_evolution.py
+++ b/pennylane/templates/subroutines/approx_time_evolution.py
@@ -163,7 +163,7 @@ class ApproxTimeEvolution(Operation):
             >>> ApproxTimeEvolution.compute_decomposition(
             ...     *coeffs_and_time, wires=range(num_qubits), n=trotter_steps, hamiltonian=hamiltonian
             ... )
-                [PauliRot(0.1, ZZ, wires=[0, 1]), PauliRot(0.2, X, wires=[0]), PauliRot(0.3, X, wires=[1])]
+            [PauliRot(0.1, ZZ, wires=[0, 1]), PauliRot(0.2, X, wires=[0]), PauliRot(0.3, X, wires=[1])]
         """
         pauli = {"Identity": "I", "PauliX": "X", "PauliY": "Y", "PauliZ": "Z"}
 


### PR DESCRIPTION
**Context:**

The docstring of `compute_decomposition` for `ApproxTimeEvolution` is slightly misleading with the `coeffs_and_time` argument.

**Description of the Change:**

Adds an example to the docstring to clear things up.

**Related GitHub Issues:**

https://discuss.pennylane.ai/t/approxtimeevo-decomposition-bug/3178/2
