### PR TITLE
Add `adjoint_jvp` and `adjoint_vjp` functions for new device

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -50,6 +50,10 @@
 * The experimental device interface is integrated with the `QNode` for Jax jit.
   [(#4352)](https://github.com/PennyLaneAI/pennylane/pull/4352)
 
+* Added functions `adjoint_jvp` and `adjoint_vjp` to `qml.devices.qubit.preprocess` that computes
+  the JVP and VJP of a tape using the adjoint method.
+  [(#4358)](https://github.com/PennyLaneAI/pennylane/pull/4358)
+
 <h3>Breaking changes 💔</h3>
 
 * The `do_queue` keyword argument in `qml.operation.Operator` has been removed. Instead of

--- a/pennylane/devices/qubit/__init__.py
+++ b/pennylane/devices/qubit/__init__.py
@@ -30,7 +30,7 @@ at your own discretion.
 """
 
 from .apply_operation import apply_operation
-from .adjoint_jacobian import adjoint_jacobian
+from .adjoint_jacobian import adjoint_jacobian, adjoint_jvp, adjoint_vjp
 from .initialize_state import create_initial_state
 from .measure import measure
 from .preprocess import preprocess

--- a/pennylane/devices/qubit/adjoint_jacobian.py
+++ b/pennylane/devices/qubit/adjoint_jacobian.py
@@ -42,7 +42,7 @@ def _get_output_ket(tape):
     ket = create_initial_state(
         wires=tape.wires, prep_operation=prep_operation
     )  #  ket(0) if prep_operation is None, else
-    for op in tape.operations[bool(prep_operation): ]:
+    for op in tape.operations[bool(prep_operation) :]:
         ket = apply_operation(op, ket)
 
     return ket

--- a/pennylane/devices/qubit/adjoint_jacobian.py
+++ b/pennylane/devices/qubit/adjoint_jacobian.py
@@ -38,11 +38,11 @@ def _get_output_ket(tape):
     """Helper function to get the output state of a tape"""
 
     # Initialization of state
-    prep_operation = None if len(tape._prep) == 0 else tape._prep[0]
+    prep_operation = tape[0] if isinstance(tape[0], qml.operation.StatePrep) else None
     ket = create_initial_state(
         wires=tape.wires, prep_operation=prep_operation
     )  #  ket(0) if prep_operation is None, else
-    for op in tape._ops:
+    for op in tape.operations[bool(prep_operation): ]:
         ket = apply_operation(op, ket)
 
     return ket

--- a/tests/devices/qubit/test_adjoint_jacobian.py
+++ b/tests/devices/qubit/test_adjoint_jacobian.py
@@ -353,19 +353,20 @@ class TestAdjointJVP:
         assert np.allclose(actual, expected, atol=tol)
 
     @pytest.mark.parametrize("tangents", [(0, 0), (0, 0.653), (1.232, 2.963)])
-    def test_custom_wire_labels(self, tangents, tol):
+    @pytest.mark.parametrize("wires", [[1, 0], ["a", "b"]])
+    def test_custom_wire_labels(self, tangents, wires, tol):
         """Test JVP is correct for custom wire labels"""
         x = np.array(0.654)
         y = np.array(1.221)
 
         obs = [
-            qml.expval(qml.PauliZ("a")),
-            qml.expval(qml.PauliY("b")),
-            qml.expval(qml.PauliX("a")),
+            qml.expval(qml.PauliZ(wires[1])),
+            qml.expval(qml.PauliY(wires[0])),
+            qml.expval(qml.PauliX(wires[1])),
         ]
-        qs = QuantumScript([qml.RY(x, "b"), qml.RX(y, "a")], obs)
+        qs = QuantumScript([qml.RY(x, wires[0]), qml.RX(y, wires[1])], obs)
         qs.trainable_params = {0, 1}
-        assert qs.wires.tolist() == ["b", "a"]
+        assert qs.wires.tolist() == wires
 
         actual = adjoint_jvp(qs, tangents)
         assert isinstance(actual, tuple)
@@ -450,19 +451,20 @@ class TestAdjointVJP:
     @pytest.mark.parametrize(
         "cotangents", [(0, 0, 0), (0, 0.653, 0), (1.236, 0, 0.573), (1.232, 2.963, 1.942)]
     )
-    def test_custom_wire_labels(self, cotangents, tol):
+    @pytest.mark.parametrize("wires", [[1, 0], ["a", "b"]])
+    def test_custom_wire_labels(self, cotangents, wires, tol):
         """Test VJP is correct for custom wire labels"""
         x = np.array(0.654)
         y = np.array(1.221)
 
         obs = [
-            qml.expval(qml.PauliZ("a")),
-            qml.expval(qml.PauliY("b")),
-            qml.expval(qml.PauliX("a")),
+            qml.expval(qml.PauliZ(wires[1])),
+            qml.expval(qml.PauliY(wires[0])),
+            qml.expval(qml.PauliX(wires[1])),
         ]
-        qs = QuantumScript([qml.RY(x, "b"), qml.RX(y, "a")], obs)
+        qs = QuantumScript([qml.RY(x, wires[0]), qml.RX(y, wires[1])], obs)
         qs.trainable_params = {0, 1}
-        assert qs.wires.tolist() == ["b", "a"]
+        assert qs.wires.tolist() == wires
 
         actual = adjoint_vjp(qs, cotangents)
         assert isinstance(actual, tuple)

--- a/tests/devices/qubit/test_adjoint_jacobian.py
+++ b/tests/devices/qubit/test_adjoint_jacobian.py
@@ -360,11 +360,12 @@ class TestAdjointJVP:
 
         obs = [
             qml.expval(qml.PauliZ("a")),
+            qml.expval(qml.PauliY("b")),
             qml.expval(qml.PauliX("a")),
-            qml.expval(qml.PauliY("a")),
         ]
-        qs = QuantumScript([qml.RY(x, "a"), qml.RZ(y, "a")], obs)
+        qs = QuantumScript([qml.RY(x, "b"), qml.RX(y, "a")], obs)
         qs.trainable_params = {0, 1}
+        assert qs.wires.tolist() == ["b", "a"]
 
         actual = adjoint_jvp(qs, tangents)
         assert isinstance(actual, tuple)
@@ -456,11 +457,12 @@ class TestAdjointVJP:
 
         obs = [
             qml.expval(qml.PauliZ("a")),
+            qml.expval(qml.PauliY("b")),
             qml.expval(qml.PauliX("a")),
-            qml.expval(qml.PauliY("a")),
         ]
-        qs = QuantumScript([qml.RY(x, "a"), qml.RZ(y, "a")], obs)
+        qs = QuantumScript([qml.RY(x, "b"), qml.RX(y, "a")], obs)
         qs.trainable_params = {0, 1}
+        assert qs.wires.tolist() == ["b", "a"]
 
         actual = adjoint_vjp(qs, cotangents)
         assert isinstance(actual, tuple)

--- a/tests/devices/qubit/test_adjoint_jacobian.py
+++ b/tests/devices/qubit/test_adjoint_jacobian.py
@@ -297,8 +297,7 @@ class TestAdjointJVP:
         actual = adjoint_jvp(qs, tangents)
         assert isinstance(actual, np.ndarray)
 
-        jac = adjoint_jacobian(qs)
-        expected = jac * tangents[0]
+        expected = -tangents[0] * np.sin(x)
         assert np.allclose(actual, expected, atol=tol)
 
     @pytest.mark.parametrize("tangents", [(0,), (1.232,)])
@@ -313,8 +312,7 @@ class TestAdjointJVP:
         assert len(actual) == 2
         assert all(isinstance(r, np.ndarray) for r in actual)
 
-        jac = adjoint_jacobian(qs)
-        expected = np.array(jac) * tangents[0]
+        expected = tangents[0] * np.array([-np.sin(x), np.cos(x)])
         assert np.allclose(actual, expected, atol=tol)
 
     @pytest.mark.parametrize("tangents", [(0, 0), (0, 0.653), (1.232, 2.963)])
@@ -329,8 +327,9 @@ class TestAdjointJVP:
         actual = adjoint_jvp(qs, tangents)
         assert isinstance(actual, np.ndarray)
 
-        jac = adjoint_jacobian(qs)
-        expected = np.dot(np.array(jac), np.array(tangents))
+        expected = np.dot(
+            np.array([np.cos(x) * np.sin(y), np.sin(x) * np.cos(y)]), np.array(tangents)
+        )
         assert np.allclose(actual, expected, atol=tol)
 
     @pytest.mark.parametrize("tangents", [(0, 0), (0, 0.653), (1.232, 2.963)])
@@ -348,7 +347,13 @@ class TestAdjointJVP:
         assert len(actual) == 3
         assert all(isinstance(r, np.ndarray) for r in actual)
 
-        jac = np.array(adjoint_jacobian(qs))
+        jac = np.array(
+            [
+                [-np.sin(x), 0],
+                [np.cos(x) * np.cos(y), -np.sin(x) * np.sin(y)],
+                [np.cos(x) * np.sin(y), np.sin(x) * np.cos(y)],
+            ]
+        )
         expected = jac @ np.array(tangents)
         assert np.allclose(actual, expected, atol=tol)
 
@@ -360,9 +365,9 @@ class TestAdjointJVP:
         y = np.array(1.221)
 
         obs = [
-            qml.expval(qml.PauliZ(wires[1])),
-            qml.expval(qml.PauliY(wires[0])),
-            qml.expval(qml.PauliX(wires[1])),
+            qml.expval(qml.PauliZ(wires[0])),
+            qml.expval(qml.PauliY(wires[1])),
+            qml.expval(qml.PauliX(wires[0])),
         ]
         qs = QuantumScript([qml.RY(x, wires[0]), qml.RX(y, wires[1])], obs)
         qs.trainable_params = {0, 1}
@@ -373,7 +378,7 @@ class TestAdjointJVP:
         assert len(actual) == 3
         assert all(isinstance(r, np.ndarray) for r in actual)
 
-        jac = np.array(adjoint_jacobian(qs))
+        jac = np.array([[-np.sin(x), 0], [0, -np.cos(y)], [np.cos(x), 0]])
         expected = jac @ np.array(tangents)
         assert np.allclose(actual, expected, atol=tol)
 
@@ -391,8 +396,7 @@ class TestAdjointVJP:
         actual = adjoint_vjp(qs, cotangents)
         assert isinstance(actual, np.ndarray)
 
-        jac = adjoint_jacobian(qs)
-        expected = jac * cotangents[0]
+        expected = -cotangents[0] * np.sin(x)
         assert np.allclose(actual, expected, atol=tol)
 
     @pytest.mark.parametrize("cotangents", [(0, 0), (0, 0.653), (1.232, 2.963)])
@@ -405,8 +409,7 @@ class TestAdjointVJP:
         actual = adjoint_vjp(qs, cotangents)
         assert isinstance(actual, np.ndarray)
 
-        jac = adjoint_jacobian(qs)
-        expected = np.dot(np.array(jac), np.array(cotangents))
+        expected = np.dot(np.array([-np.sin(x), np.cos(x)]), np.array(cotangents))
         assert np.allclose(actual, expected, atol=tol)
 
     @pytest.mark.parametrize("cotangents", [(0,), (1.232,)])
@@ -423,8 +426,7 @@ class TestAdjointVJP:
         assert len(actual) == 2
         assert all(isinstance(r, np.ndarray) for r in actual)
 
-        jac = adjoint_jacobian(qs)
-        expected = np.array(jac) * cotangents[0]
+        expected = cotangents[0] * np.array([np.cos(x) * np.sin(y), np.sin(x) * np.cos(y)])
         assert np.allclose(actual, expected, atol=tol)
 
     @pytest.mark.parametrize(
@@ -444,7 +446,13 @@ class TestAdjointVJP:
         assert len(actual) == 2
         assert all(isinstance(r, np.ndarray) for r in actual)
 
-        jac = np.array(adjoint_jacobian(qs))
+        jac = np.array(
+            [
+                [-np.sin(x), 0],
+                [np.cos(x) * np.cos(y), -np.sin(x) * np.sin(y)],
+                [np.cos(x) * np.sin(y), np.sin(x) * np.cos(y)],
+            ]
+        )
         expected = np.array(cotangents) @ jac
         assert np.allclose(actual, expected, atol=tol)
 
@@ -458,9 +466,9 @@ class TestAdjointVJP:
         y = np.array(1.221)
 
         obs = [
-            qml.expval(qml.PauliZ(wires[1])),
-            qml.expval(qml.PauliY(wires[0])),
-            qml.expval(qml.PauliX(wires[1])),
+            qml.expval(qml.PauliZ(wires[0])),
+            qml.expval(qml.PauliY(wires[1])),
+            qml.expval(qml.PauliX(wires[0])),
         ]
         qs = QuantumScript([qml.RY(x, wires[0]), qml.RX(y, wires[1])], obs)
         qs.trainable_params = {0, 1}
@@ -471,6 +479,6 @@ class TestAdjointVJP:
         assert len(actual) == 2
         assert all(isinstance(r, np.ndarray) for r in actual)
 
-        jac = np.array(adjoint_jacobian(qs))
+        jac = np.array([[-np.sin(x), 0], [0, -np.cos(y)], [np.cos(x), 0]])
         expected = np.array(cotangents) @ jac
         assert np.allclose(actual, expected, atol=tol)


### PR DESCRIPTION
**Context:**
Part of the new device capability changes. This PR is one step closer to supporting JVP and VJP computations on the device.

**Description of the Change:**
Add two functions to `devices/qubit/adjoint_jacobian.py`, one that computes the VJP and the other the JVP, both using the adjoint diff method and without needing the full jacobian.

Advantages:
1. Less memory usage
2. If a tangent is zero, the bra and ket corresponding to that trainable parameter do not need to be dotted, saving some computation.
3. If a cotangent is zero, the entire observable can be ignored