### PR TITLE
Example update qfunc: cancel inverses

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -4,6 +4,9 @@
 
 <h3>New features since last release</h3>
 
+* Transform programs can be executed (forward pass) with ``qml.execute`` and are integrated with ``QNode``.
+  [(#4328)](https://github.com/PennyLaneAI/pennylane/pull/4328)
+
 <h3>Improvements 🛠</h3>
 
 * Treat auxiliary wires and device wires in the same way in `transforms.metric_tensor`
@@ -119,6 +122,7 @@ Soran Jahangiri,
 Isaac De Vlugt,
 Edward Jiang,
 Christina Lee,
+Romain Moyard,
 Mudit Pandey,
 Borja Requena,
 Matthew Silverman,

--- a/pennylane/interfaces/execution.py
+++ b/pennylane/interfaces/execution.py
@@ -548,7 +548,6 @@ def execute(
             results = cached_execute_fn(tapes, execution_config=config)
         else:
             results = tapes
-
         return _post_processing(results, processing_fns, classical_cotransforms)
 
     # the default execution function is batch_execute

--- a/pennylane/interfaces/execution.py
+++ b/pennylane/interfaces/execution.py
@@ -941,7 +941,8 @@ def _post_processing(results, processing_fns, classical_cotransforms):
     # Apply postprocessing (apply classical cotransform and processing function)
     for p_fn, cotransform in zip(processing_fns, classical_cotransforms):
         if cotransform:
-            results = cotransform(results)
+            # TODO: add coverage with gradient transform
+            results = cotransform(results)  # pragma:no cover
         results = p_fn(results)
     return results
 

--- a/pennylane/transforms/core/transform_dispatcher.py
+++ b/pennylane/transforms/core/transform_dispatcher.py
@@ -110,7 +110,7 @@ class TransformDispatcher:
             for op in transformed_tape.circuit:
                 qml.apply(op)
 
-            return tape._qfunc_output
+            return tape._qfunc_output  # pylint:disable=protected-access
 
         return qfunc_transformed
 

--- a/pennylane/transforms/core/transform_dispatcher.py
+++ b/pennylane/transforms/core/transform_dispatcher.py
@@ -110,6 +110,8 @@ class TransformDispatcher:
             for op in transformed_tape.circuit:
                 qml.apply(op)
 
+            return tape._qfunc_output
+
         return qfunc_transformed
 
     def _qnode_transform(self, qnode, targs, tkwargs):

--- a/pennylane/transforms/optimization/__init__.py
+++ b/pennylane/transforms/optimization/__init__.py
@@ -16,7 +16,7 @@ This subpackage contains quantum function transforms for optimizing quantum circ
 """
 
 from .remove_barrier import remove_barrier
-from .cancel_inverses import cancel_inverses
+from .cancel_inverses import cancel_inverses, cancel_inverses_new
 from .commute_controlled import commute_controlled
 from .merge_rotations import merge_rotations
 from .merge_amplitude_embedding import merge_amplitude_embedding

--- a/tests/transforms/test_optimization/test_cancel_inverses.py
+++ b/tests/transforms/test_optimization/test_cancel_inverses.py
@@ -20,7 +20,7 @@ from utils import compare_operation_lists
 import pennylane as qml
 from pennylane import numpy as np
 from pennylane.wires import Wires
-from pennylane.transforms.optimization import cancel_inverses
+from pennylane.transforms.optimization import cancel_inverses, cancel_inverses_new
 
 
 class TestCancelInverses:
@@ -329,3 +329,343 @@ class TestCancelInversesInterfaces:
         # Check operation list
         ops = transformed_qnode.qtape.operations
         compare_operation_lists(ops, expected_op_list, expected_wires_list)
+
+
+class TestCancelInversesNew:
+    """Test that adjacent inverse gates are cancelled."""
+
+    def test_one_qubit_cancel_adjacent_self_inverse(self):
+        """Test that a single-qubit circuit with adjacent self-inverse gate cancels."""
+
+        def qfunc():
+            qml.Hadamard(wires=0)
+            qml.Hadamard(wires=0)
+
+        transformed_qfunc = cancel_inverses_new(qfunc)
+
+        new_tape = qml.tape.make_qscript(transformed_qfunc)()
+
+        assert len(new_tape.operations) == 0
+
+    def test_one_qubit_cancel_followed_adjoint(self):
+        """Test that a single-qubit circuit with adjacent adjoint gate cancels."""
+
+        def qfunc():
+            qml.S(wires=0)
+            qml.adjoint(qml.S)(wires=0)
+
+        transformed_qfunc = cancel_inverses_new(qfunc)
+
+        new_tape = qml.tape.make_qscript(transformed_qfunc)()
+
+        assert len(new_tape.operations) == 0
+
+    def test_one_qubit_cancel_preceded_adjoint(self):
+        """Test that a single-qubit circuit with adjacent adjoint gate cancels."""
+
+        def qfunc():
+            qml.adjoint(qml.S)(wires=0)
+            qml.S(wires=0)
+
+        transformed_qfunc = cancel_inverses_new(qfunc)
+
+        new_tape = qml.tape.make_qscript(transformed_qfunc)()
+
+        assert len(new_tape.operations) == 0
+
+    def test_one_qubit_no_inverse(self):
+        """Test that a one-qubit circuit with a gate in the way does not cancel the inverses."""
+
+        def qfunc():
+            qml.Hadamard(wires=0)
+            qml.RZ(0.3, wires=0)
+            qml.Hadamard(wires=0)
+
+        transformed_qfunc = cancel_inverses_new(qfunc)
+
+        ops = qml.tape.make_qscript(transformed_qfunc)().operations
+
+        names_expected = ["Hadamard", "RZ", "Hadamard"]
+        wires_expected = [Wires(0)] * 3
+        compare_operation_lists(ops, names_expected, wires_expected)
+
+    def test_two_qubits_no_inverse(self):
+        """Test that a two-qubit circuit self-inverse on each qubit does not cancel."""
+
+        def qfunc():
+            qml.Hadamard(wires=0)
+            qml.Hadamard(wires=1)
+
+        transformed_qfunc = cancel_inverses_new(qfunc)
+
+        ops = qml.tape.make_qscript(transformed_qfunc)().operations
+
+        names_expected = ["Hadamard"] * 2
+        wires_expected = [Wires(0), Wires(1)]
+        compare_operation_lists(ops, names_expected, wires_expected)
+
+    def test_three_qubits_inverse_after_cnot(self):
+        """Test that a three-qubit circuit with a CNOT still allows cancellation."""
+
+        def qfunc():
+            qml.Hadamard(wires=0)
+            qml.PauliX(wires=1)
+            qml.CNOT(wires=[0, 2])
+            qml.RZ(0.5, wires=2)
+            qml.PauliX(wires=1)
+
+        transformed_qfunc = cancel_inverses_new(qfunc)
+
+        ops = qml.tape.make_qscript(transformed_qfunc)().operations
+
+        names_expected = ["Hadamard", "CNOT", "RZ"]
+        wires_expected = [Wires(0), Wires([0, 2]), Wires(2)]
+        compare_operation_lists(ops, names_expected, wires_expected)
+
+    def test_three_qubits_blocking_cnot(self):
+        """Test that a three-qubit circuit with a blocking CNOT causes no cancellation."""
+
+        def qfunc():
+            qml.Hadamard(wires=0)
+            qml.PauliX(wires=1)
+            qml.CNOT(wires=[0, 1])
+            qml.RZ(0.5, wires=2)
+            qml.PauliX(wires=1)
+
+        transformed_qfunc = cancel_inverses_new(qfunc)
+
+        ops = qml.tape.make_qscript(transformed_qfunc)().operations
+
+        names_expected = ["Hadamard", "PauliX", "CNOT", "RZ", "PauliX"]
+        wires_expected = [Wires(0), Wires(1), Wires([0, 1]), Wires(2), Wires(1)]
+        compare_operation_lists(ops, names_expected, wires_expected)
+
+    def test_three_qubits_toffolis(self):
+        """Test that Toffolis on different permutations of wires cancel correctly."""
+
+        def qfunc():
+            # These two will cancel
+            qml.Toffoli(wires=["a", "b", "c"])
+            qml.Toffoli(wires=["b", "a", "c"])
+            # These three will not cancel
+            qml.Toffoli(wires=["a", "b", "c"])
+            qml.Toffoli(wires=["a", "c", "b"])
+            qml.Toffoli(wires=["a", "c", "d"])
+
+        transformed_qfunc = cancel_inverses_new(qfunc)
+
+        ops = qml.tape.make_qscript(transformed_qfunc)().operations
+
+        names_expected = ["Toffoli"] * 3
+        wires_expected = [Wires(["a", "b", "c"]), Wires(["a", "c", "b"]), Wires(["a", "c", "d"])]
+        compare_operation_lists(ops, names_expected, wires_expected)
+
+    def test_two_qubits_cnot_same_direction(self):
+        """Test that two adjacent CNOTs cancel."""
+
+        def qfunc():
+            qml.CNOT(wires=[0, 1])
+            qml.CNOT(wires=[0, 1])
+
+        transformed_qfunc = cancel_inverses_new(qfunc)
+
+        ops = qml.tape.make_qscript(transformed_qfunc)().operations
+
+        assert len(ops) == 0
+
+    def test_two_qubits_cnot_opposite_direction(self):
+        """Test that two adjacent CNOTs with the control/target flipped do NOT cancel."""
+
+        def qfunc():
+            qml.CNOT(wires=[0, 1])
+            qml.CNOT(wires=[1, 0])
+
+        transformed_qfunc = cancel_inverses_new(qfunc)
+
+        ops = qml.tape.make_qscript(transformed_qfunc)().operations
+
+        names_expected = ["CNOT"] * 2
+        wires_expected = [Wires([0, 1]), Wires([1, 0])]
+        compare_operation_lists(ops, names_expected, wires_expected)
+
+    def test_two_qubits_cz_opposite_direction(self):
+        """Test that two adjacent CZ with the control/target flipped do cancel due to symmetry."""
+
+        def qfunc():
+            qml.CZ(wires=[0, 1])
+            qml.CZ(wires=[1, 0])
+
+        transformed_qfunc = cancel_inverses_new(qfunc)
+
+        ops = qml.tape.make_qscript(transformed_qfunc)().operations
+
+        assert len(ops) == 0
+
+
+# Example QNode and device for interface testing
+dev = qml.device("default.qubit", wires=3)
+
+
+def qfunc_all_ops(theta):
+    qml.Hadamard(wires=0)
+    qml.PauliX(wires=1)
+    qml.S(wires=1)
+    qml.adjoint(qml.S)(wires=1)
+    qml.Hadamard(wires=0)
+    qml.CNOT(wires=[0, 1])
+    qml.RZ(theta[0], wires=2)
+    qml.PauliX(wires=1)
+    qml.CZ(wires=[1, 0])
+    qml.RY(theta[1], wires=2)
+    qml.CZ(wires=[0, 1])
+    return qml.expval(qml.PauliX(0) @ qml.PauliX(2))
+
+
+transformed_qfunc_all_ops = cancel_inverses_new(qfunc_all_ops)
+
+expected_op_list = ["PauliX", "CNOT", "RZ", "PauliX", "RY"]
+expected_wires_list = [Wires(1), Wires([0, 1]), Wires(2), Wires(1), Wires(2)]
+
+
+class TestCancelInversesInterfacesNew:
+    """Test that adjacent inverse gates are cancelled in all interfaces."""
+
+    @pytest.mark.autograd
+    def test_cancel_inverses_autograd(self):
+        """Test QNode and gradient in autograd interface."""
+
+        original_qnode = qml.QNode(qfunc_all_ops, dev)
+        transformed_qnode = qml.QNode(transformed_qfunc_all_ops, dev)
+
+        input = np.array([0.1, 0.2], requires_grad=True)
+
+        # Check that the numerical output is the same
+        assert qml.math.allclose(original_qnode(input), transformed_qnode(input))
+
+        # Check that the gradient is the same
+        assert qml.math.allclose(
+            qml.grad(original_qnode)(input), qml.grad(transformed_qnode)(input)
+        )
+
+        # Check operation list
+        ops = transformed_qnode.qtape.operations
+        compare_operation_lists(ops, expected_op_list, expected_wires_list)
+
+    @pytest.mark.torch
+    def test_cancel_inverses_torch(self):
+        """Test QNode and gradient in torch interface."""
+        import torch
+
+        original_qnode = qml.QNode(qfunc_all_ops, dev)
+        transformed_qnode = qml.QNode(transformed_qfunc_all_ops, dev)
+
+        original_input = torch.tensor([0.1, 0.2], requires_grad=True)
+        transformed_input = torch.tensor([0.1, 0.2], requires_grad=True)
+
+        original_result = original_qnode(original_input)
+        transformed_result = transformed_qnode(transformed_input)
+
+        # Check that the numerical output is the same
+        assert qml.math.allclose(original_result, transformed_result)
+
+        # Check that the gradient is the same
+        original_result.backward()
+        transformed_result.backward()
+
+        assert qml.math.allclose(original_input.grad, transformed_input.grad)
+
+        # Check operation list
+        ops = transformed_qnode.qtape.operations
+        compare_operation_lists(ops, expected_op_list, expected_wires_list)
+
+    @pytest.mark.tf
+    def test_cancel_inverses_tf(self):
+        """Test QNode and gradient in tensorflow interface."""
+        import tensorflow as tf
+
+        original_qnode = qml.QNode(qfunc_all_ops, dev)
+        transformed_qnode = qml.QNode(transformed_qfunc_all_ops, dev)
+
+        original_input = tf.Variable([0.1, 0.2])
+        transformed_input = tf.Variable([0.1, 0.2])
+
+        original_result = original_qnode(original_input)
+        transformed_result = transformed_qnode(transformed_input)
+
+        # Check that the numerical output is the same
+        assert qml.math.allclose(original_result, transformed_result)
+
+        # Check that the gradient is the same
+        with tf.GradientTape() as tape:
+            loss = original_qnode(original_input)
+        original_grad = tape.gradient(loss, original_input)
+
+        with tf.GradientTape() as tape:
+            loss = transformed_qnode(transformed_input)
+        transformed_grad = tape.gradient(loss, transformed_input)
+
+        assert qml.math.allclose(original_grad, transformed_grad)
+
+        # Check operation list
+        ops = transformed_qnode.qtape.operations
+        compare_operation_lists(ops, expected_op_list, expected_wires_list)
+
+    @pytest.mark.jax
+    def test_cancel_inverses_jax(self):
+        """Test QNode and gradient in JAX interface."""
+        import jax
+        from jax import numpy as jnp
+
+        # Enable float64 support
+        from jax.config import config
+
+        config.update("jax_enable_x64", True)
+
+        original_qnode = qml.QNode(qfunc_all_ops, dev)
+        transformed_qnode = qml.QNode(transformed_qfunc_all_ops, dev)
+
+        input = jnp.array([0.1, 0.2], dtype=jnp.float64)
+
+        # Check that the numerical output is the same
+        assert qml.math.allclose(original_qnode(input), transformed_qnode(input))
+
+        # Check that the gradient is the same
+        assert qml.math.allclose(
+            jax.grad(original_qnode)(input), jax.grad(transformed_qnode)(input)
+        )
+
+        # Check operation list
+        ops = transformed_qnode.qtape.operations
+        compare_operation_lists(ops, expected_op_list, expected_wires_list)
+
+
+@qml.qnode(device=dev)
+def qnode_all_ops(theta):
+    qml.Hadamard(wires=0)
+    qml.PauliX(wires=1)
+    qml.S(wires=1)
+    qml.adjoint(qml.S)(wires=1)
+    qml.Hadamard(wires=0)
+    qml.CNOT(wires=[0, 1])
+    qml.RZ(theta[0], wires=2)
+    qml.PauliX(wires=1)
+    qml.CZ(wires=[1, 0])
+    qml.RY(theta[1], wires=2)
+    qml.CZ(wires=[0, 1])
+    return qml.expval(qml.PauliX(0) @ qml.PauliX(2))
+
+
+class TestCancelInversesQNode:
+    """Test cancel inverses directly applied on QNodes."""
+
+    def test_qnode_execution(self):
+        """Test cancel inverses on a qnode."""
+        original_qnode = qnode_all_ops
+        transformed_qnode = cancel_inverses_new(qnode_all_ops)
+
+        input = np.array([0.1, 0.2], requires_grad=True)
+        # Check that the numerical output is the same
+        assert qml.math.allclose(original_qnode(input), transformed_qnode(input))
+
+        transformed_qnode = cancel_inverses_new(cancel_inverses_new(qnode_all_ops))
+        assert qml.math.allclose(original_qnode(input), transformed_qnode(input))


### PR DESCRIPTION
**Description of the Change:**

This PR is an example on how to adapt quantum function transforms to the new transform system.

1. Use the decorator on the function
2. Add the type hints
3. Remove the queuing, instead create a tape directly
4. Add and update the tests (add a test for qnode)

See https://github.com/PennyLaneAI/pennylane/pull/4342