### PR TITLE
Suggested changes to #4342

### DIFF
--- a/pennylane/qnode.py
+++ b/pennylane/qnode.py
@@ -912,8 +912,7 @@ class QNode:
 
     def __call__(self, *args, **kwargs) -> qml.typing.Result:
 
-        # really not sure why pylint is complaining about this
-        if self.transform_program.is_informative:  # pylint: disable=using-constant-test
+        if self.transform_program.is_informative():
             raise NotImplementedError("Informative transform programs are not yet implemented.")
         override_shots = False
         old_interface = self.interface

--- a/pennylane/qnode.py
+++ b/pennylane/qnode.py
@@ -506,7 +506,7 @@ class QNode:
         self._update_gradient_fn()
 
     @property
-    def transform_program(self) -> qml.transforms.core.TransformProgram:
+    def transform_program(self) -> "qml.transforms.core.TransformProgram":
         """The transform program used by the QNode.
 
         .. warning:: This is an experimental feature.
@@ -912,7 +912,7 @@ class QNode:
 
     def __call__(self, *args, **kwargs) -> qml.typing.Result:
 
-        if self.transform_program.is_informative():
+        if self.transform_program.is_informative:
             raise NotImplementedError("Informative transform programs are not yet implemented.")
         override_shots = False
         old_interface = self.interface
@@ -1021,6 +1021,7 @@ class QNode:
             [self.tape],
             device=self.device,
             gradient_fn=self.gradient_fn,
+            transform_program=self.transform_program,
             interface=self.interface,
             gradient_kwargs=self.gradient_kwargs,
             override_shots=override_shots,

--- a/pennylane/qnode.py
+++ b/pennylane/qnode.py
@@ -506,7 +506,7 @@ class QNode:
         self._update_gradient_fn()
 
     @property
-    def transform_program(self):
+    def transform_program(self) -> qml.transforms.core.TransformProgram:
         """The transform program used by the QNode.
 
         .. warning:: This is an experimental feature.
@@ -911,6 +911,10 @@ class QNode:
             self.interface = "auto"
 
     def __call__(self, *args, **kwargs) -> qml.typing.Result:
+
+        # really not sure why pylint is complaining about this
+        if self.transform_program.is_informative:  # pylint: disable=using-constant-test
+            raise NotImplementedError("Informative transform programs are not yet implemented.")
         override_shots = False
         old_interface = self.interface
 
@@ -963,14 +967,10 @@ class QNode:
             if "mode" in self.execute_kwargs:
                 self.execute_kwargs.pop("mode")
             # pylint: disable=unexpected-keyword-arg
-            if self.transform_program.is_empty():
-                transform_program = None
-            else:
-                transform_program = self.transform_program
             res = qml.execute(
                 [self.tape],
                 device=self.device,
-                transform_program=transform_program,
+                transform_program=self.transform_program,
                 gradient_fn=self.gradient_fn,
                 interface=self.interface,
                 gradient_kwargs=self.gradient_kwargs,

--- a/pennylane/transforms/core/transform.py
+++ b/pennylane/transforms/core/transform.py
@@ -38,7 +38,7 @@ def transform(
 
             * An expand transform is a function that is applied before applying the defined quantum transform. It
               takes a quantum tape as single input and returns a single tape in a sequence with a dummy processing
-              function, lambda x: x.
+              function.
 
             * The expand transform must have the same type hinting as a quantum transform.
 

--- a/pennylane/transforms/core/transform_program.py
+++ b/pennylane/transforms/core/transform_program.py
@@ -156,7 +156,7 @@ class TransformProgram:
             raise TransformError("Only transform container can be added to the transform program.")
 
         # Program can only contain one informative transform and at the end of the program
-        if not self.is_informative:
+        if not self.is_informative():
             raise TransformError("The transform program already has an informative transform.")
         self._transform_program.append(transform_container)
 
@@ -209,7 +209,7 @@ class TransformProgram:
         Returns:
             bool: Boolean
         """
-        return self[-1].is_informative if self else False
+        return self[-1].is_informative() if self else False
 
     def __call__(self, tapes: Tuple[QuantumTape]) -> Tuple[ResultBatch, BatchPostProcessingFn]:
         if not self:

--- a/pennylane/transforms/core/transform_program.py
+++ b/pennylane/transforms/core/transform_program.py
@@ -14,7 +14,100 @@
 """
 This module contains the transform program class.
 """
+from functools import partial
+from typing import Callable, List, Tuple, Optional
+
+from pennylane.typing import Result, ResultBatch
+from pennylane.tape import QuantumTape
+
 from .transform_dispatcher import TransformContainer, TransformError
+
+PostProcessingFn = Callable[[ResultBatch], Result]
+BatchPostProcessingFn = Callable[[ResultBatch], ResultBatch]
+
+
+def _batch_postprocessing(results: ResultBatch, individual_fns: PostProcessingFn) -> ResultBatch:
+    """Broadcast individual post processing functions onto the their respective tapes.
+
+    Args:
+        results (ResultBatch): The numeric outcome from executing a batch of :class:`~.QuantumTape`
+
+    Keyword Args:
+        individual_fns (Callable): postprocessing functions converting a batch of results into a single result
+           corresponding to only a single :class:`~.QuantumTape`.
+
+    Note that this function does not perform validation on the sizes.
+
+    If there are ``N`` ``individual_fns`` each one accepts a batch of ``M`` results, then the input ``results`` must be
+    ``M*N`` long.
+
+    >>> results = (1.0, 2.0, 3.0, 4.0)
+    >>> def postprocessing1(results):
+    ...     return results[0] + results[1]
+    >>> def postprocessing2(results):
+    ...     return results[0]+0.5
+    >>> _batch_postprocessing(results, (postprocessing1, postprocessing2))
+    (3.0, 3.5)
+
+    """
+    num_results = len(results)
+    num_input_tapes = len(individual_fns)
+    results_per_input_tape = num_results // num_input_tapes
+
+    new_results = []
+    for i, post_processing_fn in enumerate(individual_fns):
+        selected_results = results[i * results_per_input_tape : (i + 1) * results_per_input_tape]
+        new_results.append(post_processing_fn(selected_results))
+
+    return tuple(new_results)
+
+
+def _apply_postprocessing_stack(
+    results: ResultBatch,
+    postprocessing_stack: List[BatchPostProcessingFn],
+    cotransform_stack: List[Optional[BatchPostProcessingFn]],
+) -> ResultBatch:
+    """Applies the postprocessing and cotransform postprocessing functions in a Last-In-First-Out LIFO manner.
+
+    Args:
+        results (ResultBatch): The numeric outcome from executing a batch of :class:`~.QuantumTape`
+
+    Keyword Args:
+        postprocessing_stack (List(BatchPostProcessingFn)): a LIFO stack of post processing functions.
+        cotransform_stack (List(BatchPostProcessingFn)): a LIFO stack of classical cotransform functions.
+
+    Returns:
+        ResultBatch: the post processed results.
+
+    >>> results = (1.0, 2.0, 3.0, 4.0)
+    >>> def postprocessing1(results):
+    ...     return (results[0] + results[1], results[2] + results[3])
+    >>> def postprocessing2(results):
+    .... return (results[0] + 1, results[1] + 2)
+    >>> _apply_postprocessing_stack(results, [postprocessing1], [None, None])
+    (3.0, 7.0)
+    >>> _apply_postprocessing_stack(results, [postprocessing2, postprocessing1], [None, None])
+    (4.0, 9.0)
+
+    """
+    for postprocessing, cotransform in zip(postprocessing_stack[::-1], cotransform_stack[::-1]):
+        if cotransform:
+            results = cotransform(results)
+        results = postprocessing(results)
+    return results
+
+
+def null_postprocessing(results: ResultBatch) -> ResultBatch:
+    """An empty postprocessing function that simply returns its input.
+
+    Args:
+        results (ResultBatch): Results from executing a batch of :class:`~.QuantumTape`.
+
+    Returns:
+        ResultBatch: the input to the function.
+
+    """
+    return results
 
 
 class TransformProgram:
@@ -29,8 +122,8 @@ class TransformProgram:
 
     """
 
-    def __init__(self):
-        self._transform_program = []
+    def __init__(self, initial_program: Optional["TransformProgram"] = None):
+        self._transform_program = list(initial_program) if initial_program else []
 
     def __iter__(self):
         """list[TransformContainer]: Return an iterator to the underlying transform program."""
@@ -45,12 +138,13 @@ class TransformProgram:
         transform program"""
         return self._transform_program[idx]
 
+    def __bool__(self):
+        return bool(self._transform_program)
+
     def __repr__(self):
         """The string representation of the transform program class."""
-        repr = "TransformProgram("
-        transforms_repr = ", ".join([f"{transform_c.transform.__name__}" for transform_c in self])
-        end = ")"
-        return repr + transforms_repr + end
+        contents = ", ".join(f"{transform_c.transform.__name__}" for transform_c in self)
+        return f"TransformProgram({contents})"
 
     def push_back(self, transform_container: TransformContainer):
         """Add a transform (container) to the end of the program.
@@ -62,7 +156,7 @@ class TransformProgram:
             raise TransformError("Only transform container can be added to the transform program.")
 
         # Program can only contain one informative transform and at the end of the program
-        if not self.is_empty() and self.get_last().is_informative:
+        if not self.is_informative:
             raise TransformError("The transform program already has an informative transform.")
         self._transform_program.append(transform_container)
 
@@ -72,7 +166,7 @@ class TransformProgram:
         Args:
             transform_container(TransformContainer): A transform represented by its container.
         """
-        if transform_container.is_informative and not self.is_empty():
+        if transform_container.is_informative() and not self.is_empty():
             raise TransformError(
                 "Informative transforms can only be added at the end of the program."
             )
@@ -84,8 +178,7 @@ class TransformProgram:
         Returns:
             TransformContainer: The transform container at the beginning of the program.
         """
-        first_container = self._transform_program.pop(0)
-        return first_container
+        return self._transform_program.pop(0)
 
     def get_last(self):
         """Get the last transform container.
@@ -96,7 +189,7 @@ class TransformProgram:
         Raises:
             TransformError: It raises an error if the program is empty.
         """
-        if not self.is_empty():
+        if not self:
             return self._transform_program[-1]
         raise TransformError(
             "The transform program is empty and you cannot get the last transform container."
@@ -110,20 +203,21 @@ class TransformProgram:
         """
         return len(self) == 0
 
-    def is_informative(self):
+    def is_informative(self) -> bool:
         """Check if the transform program is informative or not.
 
         Returns:
-            bool: Boolean, True if empty, False otherwise.
+            bool: Boolean
         """
-        return self.get_last().is_informative
+        return self[-1].is_informative if self else False
 
-    def __call__(self, tapes):
-        processing_fns_list = []
-        classical_cotransforms_list = []
+    def __call__(self, tapes: Tuple[QuantumTape]) -> Tuple[ResultBatch, BatchPostProcessingFn]:
+        if not self:
+            return tapes, null_postprocessing
+        processing_fns_stack = []
+        classical_cotransforms_stack = []
 
         for transform_container in self:
-            num_tapes = len(tapes)
             transform, args, kwargs, cotransform, _ = transform_container
 
             execution_tapes = []
@@ -134,30 +228,20 @@ class TransformProgram:
                 execution_tapes.extend(new_tapes)
                 fns.append(fn)
 
-            new_num_tapes = len(new_tapes)
+            batch_postprocessing = partial(_batch_postprocessing, inidividual_fns=fns)
+            batch_postprocessing.__doc__ = _batch_postprocessing.__doc__
 
-            # Merge the processing function into in a single one
-            def processing_fn(
-                res,
-                num_tapes=num_tapes,
-                new_num_tapes=new_num_tapes,
-                p_fns=tuple(fns),
-            ):  # pylint: disable=cell-var-from-loop
-                final_results = [
-                    p_fns[idx](res[idx * new_num_tapes : (idx + 1) * new_num_tapes])
-                    for idx in range(num_tapes)
-                ]
-                return final_results
+            processing_fns_stack.append(batch_postprocessing)
+            classical_cotransforms_stack.append(cotransform)
 
-            processing_fns_list.append(processing_fn)
-
-            # Merge the cotransform functions into in a single one
-            if transform_container.classical_cotransform is None:
-                classical_cotransforms_list.append(None)
-            else:
-                # TODO: coverage when add gradient transform
-                classical_cotransforms_list.append(cotransform)  # pragma: no cover
-
+            # set input tapes for next iteration.
             tapes = execution_tapes
 
-        return tapes, processing_fns_list[::-1], classical_cotransforms_list[::-1]
+        postprocessing_fn = partial(
+            _apply_postprocessing_stack,
+            postprocessing_stack=processing_fns_stack,
+            cotransfrom_stack=classical_cotransforms_stack,
+        )
+        postprocessing_fn.__doc__ = _apply_postprocessing_stack.__doc__
+
+        return tuple(tapes), postprocessing_fn

--- a/tests/gradients/core/test_adjoint_diff.py
+++ b/tests/gradients/core/test_adjoint_diff.py
@@ -119,7 +119,7 @@ class TestAdjointJacobian:
 
         # compare to finite differences
         tapes, fn = qml.gradients.finite_diff(tape)
-        numeric_val = fn(qml.execute(tapes, dev, gradient_fn=None))
+        numeric_val = fn(qml.execute(tapes, dev, None))
 
         assert isinstance(calculated_val, np.ndarray)
         assert calculated_val.shape == ()
@@ -144,7 +144,7 @@ class TestAdjointJacobian:
 
         # compare to finite differences
         tapes, fn = qml.gradients.finite_diff(tape)
-        numeric_val = fn(qml.execute(tapes, dev, gradient_fn=None))
+        numeric_val = fn(qml.execute(tapes, dev, None))
 
         assert isinstance(calculated_val, tuple)
         assert len(calculated_val) == 3
@@ -166,7 +166,7 @@ class TestAdjointJacobian:
         # gradients
         exact = np.cos(par)
         tapes, fn = qml.gradients.finite_diff(tape)
-        grad_F = fn(qml.execute(tapes, dev, gradient_fn=None))
+        grad_F = fn(qml.execute(tapes, dev, None))
         grad_A = dev.adjoint_jacobian(tape)
 
         # different methods must agree
@@ -245,7 +245,7 @@ class TestAdjointJacobian:
         tape.trainable_params = set(range(1, 1 + op.num_params))
 
         tapes, fn = qml.gradients.finite_diff(tape)
-        grad_F = fn(qml.execute(tapes, dev, gradient_fn=None))
+        grad_F = fn(qml.execute(tapes, dev, None))
         grad_D = dev.adjoint_jacobian(tape)
 
         assert isinstance(grad_D, tuple)
@@ -275,7 +275,7 @@ class TestAdjointJacobian:
 
         grad_D = dev.adjoint_jacobian(tape)
         tapes, fn = qml.gradients.finite_diff(tape)
-        grad_F = fn(qml.execute(tapes, dev, gradient_fn=None))
+        grad_F = fn(qml.execute(tapes, dev, None))
 
         # gradient has the correct shape and every element is nonzero
         assert isinstance(grad_D, tuple)

--- a/tests/gradients/core/test_hadamard_gradient.py
+++ b/tests/gradients/core/test_hadamard_gradient.py
@@ -810,7 +810,7 @@ class TestHadamardGradEdgeCases:
 
         with pytest.warns(UserWarning, match="gradient of a tape with no trainable parameters"):
             g_tapes, post_processing = qml.gradients.hadamard_grad(tape)
-        res_hadamard = post_processing(qml.execute(g_tapes, dev, gradient_fn=None))
+        res_hadamard = post_processing(qml.execute(g_tapes, dev, None))
 
         assert g_tapes == []
         assert isinstance(res_hadamard, np.ndarray)

--- a/tests/gradients/core/test_pulse_generator_gradient.py
+++ b/tests/gradients/core/test_pulse_generator_gradient.py
@@ -840,7 +840,7 @@ class TestPulseGeneratorEdgeCases:
 
         with pytest.warns(UserWarning, match="gradient of a tape with no trainable parameters"):
             g_tapes, post_processing = pulse_generator(tape)
-        res = post_processing(qml.execute(g_tapes, dev, gradient_fn=None))
+        res = post_processing(qml.execute(g_tapes, dev, None))
 
         assert g_tapes == []
         assert isinstance(res, np.ndarray)
@@ -1394,7 +1394,9 @@ class TestPulseGeneratorIntegration:
         assert dev.num_executions == 1 + 12  # one forward execution, dim(DLA)=6
         grad_backprop = jax.grad(qnode_backprop)(params)
 
-        assert all(qml.math.allclose(r, e) for r, e in zip(grad_pulse_grad, grad_backprop))
+        assert all(
+            qml.math.allclose(r, e, atol=1e-7) for r, e in zip(grad_pulse_grad, grad_backprop)
+        )
 
     @pytest.mark.parametrize("argnums", [[0, 1], 0, 1])
     def test_simple_qnode_expval_multiple_params(self, argnums):
@@ -1453,7 +1455,7 @@ class TestPulseGeneratorDiff:
             tape = qml.tape.QuantumScript([op], [qml.expval(Z(0))])
             tape.trainable_params = [0]
             _tapes, fn = pulse_generator(tape)
-            return fn(qml.execute(_tapes, dev, gradient_fn=None))
+            return fn(qml.execute(_tapes, dev, None))
 
         params = [jnp.array(0.4)]
         p = params[0] * T

--- a/tests/gradients/core/test_pulse_gradient.py
+++ b/tests/gradients/core/test_pulse_gradient.py
@@ -887,7 +887,7 @@ class TestStochPulseGrad:
         assert len(tapes) == 2 * 3
 
         dev = qml.device("default.qubit.jax", wires=2)
-        res = fn(qml.execute(tapes, dev, gradient_fn=None))
+        res = fn(qml.execute(tapes, dev, None))
         assert isinstance(res, tuple) and len(res) == 2
         assert qml.math.allclose(res[0][0], np.zeros(5))
         assert qml.math.allclose(res[1][0], np.zeros((2, 5)))
@@ -916,7 +916,7 @@ class TestStochPulseGrad:
         tapes, fn = stoch_pulse_grad(tape, num_split_times=num_split_times)
         assert len(tapes) == num_split_times * 2
 
-        res = fn(qml.execute(tapes, dev, gradient_fn=None))
+        res = fn(qml.execute(tapes, dev, None))
         assert qml.math.isclose(res, -2 * jnp.sin(2 * p) * delta_t)
         jax.clear_caches()
 
@@ -947,7 +947,7 @@ class TestStochPulseGrad:
         tapes, fn = stoch_pulse_grad(tape, num_split_times=num_split_times)
         assert len(tapes) == num_split_times * 2
 
-        res = fn(qml.execute(tapes, dev, gradient_fn=None))
+        res = fn(qml.execute(tapes, dev, None))
         assert qml.math.isclose(res, -2 * jnp.sin(2 * p) * delta_t * prefactor)
         jax.clear_caches()
 
@@ -984,7 +984,7 @@ class TestStochPulseGrad:
         tapes, fn = stoch_pulse_grad(tape, num_split_times=num_split_times)
         assert len(tapes) == 2 * num_split_times
 
-        res = fn(qml.execute(tapes, dev, gradient_fn=None))
+        res = fn(qml.execute(tapes, dev, None))
         exp_grad = -2 * jnp.sin(2 * theta) * theta_jac
         # classical Jacobian is being estimated with the Monte Carlo sampling -> coarse tolerance
         assert qml.math.allclose(res, exp_grad, atol=0.2)
@@ -1024,7 +1024,7 @@ class TestStochPulseGrad:
         tapes, fn = stoch_pulse_grad(tape, num_split_times=num_split_times)
         assert len(tapes) == 2 * num_split_times
 
-        jac = fn(qml.execute(tapes, dev, gradient_fn=None))
+        jac = fn(qml.execute(tapes, dev, None))
         probs_jac = jnp.array([-1, 1]) * (2 * jnp.sin(theta) * jnp.cos(theta))
         exp_jac = jnp.tensordot(probs_jac, theta_jac, axes=0)
         # classical Jacobian is being estimated with the Monte Carlo sampling -> coarse tolerance
@@ -1067,7 +1067,7 @@ class TestStochPulseGrad:
         tapes, fn = stoch_pulse_grad(tape, num_split_times=num_split_times)
         assert len(tapes) == 2 * num_split_times
 
-        jac = fn(qml.execute(tapes, dev, gradient_fn=None))
+        jac = fn(qml.execute(tapes, dev, None))
         expval_jac = -2 * jnp.sin(2 * theta)
         probs_jac = jnp.array([-1, 1]) * (2 * jnp.sin(theta) * jnp.cos(theta))
         exp_jac = (expval_jac * theta_jac, jnp.tensordot(probs_jac, theta_jac, axes=0))
@@ -1098,7 +1098,7 @@ class TestStochPulseGrad:
         tapes, fn = stoch_pulse_grad(tape, num_split_times=num_split_times, sampler_seed=7512)
         assert len(tapes) == 2 * num_split_times
 
-        res = fn(qml.execute(tapes, dev, gradient_fn=None))
+        res = fn(qml.execute(tapes, dev, None))
         # The sampling of pwc functions does not automatically reduce to the analytically
         # correct time integrals, leading to approximations -> coarse tolerance
         assert qml.math.allclose(
@@ -1129,7 +1129,7 @@ class TestStochPulseGrad:
         tapes, fn = stoch_pulse_grad(tape)
         assert len(tapes) == 4
 
-        res = fn(qml.execute(tapes, dev, gradient_fn=None))
+        res = fn(qml.execute(tapes, dev, None))
         exp_grad = [
             -2 * jnp.sin(2 * p[0]) * jnp.cos(2 * p[1]) * (T[1] - T[0]),
             -2 * jnp.sin(2 * p[1]) * jnp.cos(2 * p[0]) * (T[1] - T[0]),
@@ -1170,7 +1170,7 @@ class TestStochPulseGrad:
         num_shifts = 2 * 2 + 8
         assert len(tapes) == num_shifts * num_split_times
 
-        res = fn(qml.execute(tapes, dev, gradient_fn=None))
+        res = fn(qml.execute(tapes, dev, None))
         exp_grad = jax.grad(qnode)(params)
         assert all(qml.math.allclose(r, e, rtol=0.4) for r, e in zip(res, exp_grad))
         jax.clear_caches()
@@ -1240,7 +1240,7 @@ class TestStochPulseGrad:
         tapes, fn = stoch_pulse_grad(qnode.tape, num_split_times=num_split_times, sampler_seed=7123)
         assert len(tapes) == 3 * 2 * num_split_times
 
-        res = fn(qml.execute(tapes, dev, gradient_fn=None))
+        res = fn(qml.execute(tapes, dev, None))
         exp_grad = jax.grad(qnode, argnums=(0, 1))(params_0, params_1)
         exp_grad = exp_grad[0] + exp_grad[1]
         assert all(qml.math.allclose(r, e, rtol=0.4) for r, e in zip(res, exp_grad))
@@ -1272,7 +1272,7 @@ class TestStochPulseGrad:
             tape = qml.tape.QuantumScript([op], meas)
             tapes, fn = stoch_pulse_grad(tape)
             assert len(tapes) == exp_num_tapes
-            res = fn(qml.execute(tapes, dev, gradient_fn=None))
+            res = fn(qml.execute(tapes, dev, None))
             return res
 
         params = [jnp.array(0.24)]
@@ -1766,7 +1766,7 @@ class TestStochPulseGradDiff:
             tape = qml.tape.QuantumScript([op], [qml.expval(qml.PauliZ(0))])
             tape.trainable_params = [0]
             tapes, fn = stoch_pulse_grad(tape)
-            return fn(qml.execute(tapes, dev, gradient_fn=None))
+            return fn(qml.execute(tapes, dev, None))
 
         params = [jnp.array(0.4)]
         p = params[0] * T

--- a/tests/gradients/core/test_vjp.py
+++ b/tests/gradients/core/test_vjp.py
@@ -425,7 +425,7 @@ class TestVJPGradients:
         tape = qml.tape.QuantumScript.from_queue(q)
         tape.trainable_params = {0, 1}
         tapes, fn = qml.gradients.vjp(tape, dy, param_shift)
-        vjp = fn(qml.execute(tapes, dev, gradient_fn=qml.gradients.param_shift))
+        vjp = fn(qml.execute(tapes, dev, qml.gradients.param_shift))
 
         assert np.allclose(vjp.detach(), expected(params.detach()), atol=tol, rtol=0)
 

--- a/tests/gradients/finite_diff/test_finite_difference.py
+++ b/tests/gradients/finite_diff/test_finite_difference.py
@@ -166,7 +166,7 @@ class TestFiniteDiff:
         tape.trainable_params = []
         with pytest.warns(UserWarning, match="gradient of a tape with no trainable parameters"):
             g_tapes, post_processing = qml.gradients.finite_diff(tape)
-        res = post_processing(qml.execute(g_tapes, dev, gradient_fn=None))
+        res = post_processing(qml.execute(g_tapes, dev, None))
 
         assert g_tapes == []
         assert isinstance(res, numpy.ndarray)
@@ -188,7 +188,7 @@ class TestFiniteDiff:
         tape.trainable_params = []
         with pytest.warns(UserWarning, match="gradient of a tape with no trainable parameters"):
             g_tapes, post_processing = qml.gradients.finite_diff(tape)
-        res = post_processing(qml.execute(g_tapes, dev, gradient_fn=None))
+        res = post_processing(qml.execute(g_tapes, dev, None))
 
         assert g_tapes == []
         assert isinstance(res, tuple)

--- a/tests/gradients/finite_diff/test_finite_difference_shot_vec.py
+++ b/tests/gradients/finite_diff/test_finite_difference_shot_vec.py
@@ -122,7 +122,7 @@ class TestFiniteDiff:
             g_tapes, post_processing = qml.gradients.finite_diff(
                 tape, h=h_val, shots=default_shot_vector
             )
-        all_res = post_processing(qml.execute(g_tapes, dev, gradient_fn=None))
+        all_res = post_processing(qml.execute(g_tapes, dev, None))
         assert len(all_res) == len(default_shot_vector)
 
         for res in all_res:
@@ -148,7 +148,7 @@ class TestFiniteDiff:
             g_tapes, post_processing = qml.gradients.finite_diff(
                 tape, h=h_val, shots=default_shot_vector
             )
-        res = post_processing(qml.execute(g_tapes, dev, gradient_fn=None))
+        res = post_processing(qml.execute(g_tapes, dev, None))
 
         assert g_tapes == []
         assert isinstance(res, tuple)

--- a/tests/gradients/finite_diff/test_spsa_gradient.py
+++ b/tests/gradients/finite_diff/test_spsa_gradient.py
@@ -120,7 +120,7 @@ class TestSpsaGradient:
         tape.trainable_params = []
         with pytest.warns(UserWarning, match="gradient of a tape with no trainable parameters"):
             g_tapes, post_processing = spsa_grad(tape)
-        res = post_processing(qml.execute(g_tapes, dev, gradient_fn=None))
+        res = post_processing(qml.execute(g_tapes, dev, None))
 
         assert g_tapes == []
         assert isinstance(res, numpy.ndarray)
@@ -142,7 +142,7 @@ class TestSpsaGradient:
         tape.trainable_params = []
         with pytest.warns(UserWarning, match="gradient of a tape with no trainable parameters"):
             g_tapes, post_processing = spsa_grad(tape)
-        res = post_processing(qml.execute(g_tapes, dev, gradient_fn=None))
+        res = post_processing(qml.execute(g_tapes, dev, None))
 
         assert g_tapes == []
         assert isinstance(res, tuple)

--- a/tests/gradients/finite_diff/test_spsa_gradient_shot_vec.py
+++ b/tests/gradients/finite_diff/test_spsa_gradient_shot_vec.py
@@ -137,7 +137,7 @@ class TestSpsaGradient:
         tape.trainable_params = []
         with pytest.warns(UserWarning, match="gradient of a tape with no trainable parameters"):
             g_tapes, post_processing = spsa_grad(tape, h=h_val, shots=default_shot_vector)
-        all_res = post_processing(qml.execute(g_tapes, dev, gradient_fn=None))
+        all_res = post_processing(qml.execute(g_tapes, dev, None))
         assert len(all_res) == len(default_shot_vector)
 
         for res in all_res:
@@ -161,7 +161,7 @@ class TestSpsaGradient:
         tape.trainable_params = []
         with pytest.warns(UserWarning, match="gradient of a tape with no trainable parameters"):
             g_tapes, post_processing = spsa_grad(tape, h=h_val, shots=default_shot_vector)
-        res = post_processing(qml.execute(g_tapes, dev, gradient_fn=None))
+        res = post_processing(qml.execute(g_tapes, dev, None))
 
         assert g_tapes == []
         assert isinstance(res, tuple)

--- a/tests/gradients/parameter_shift/test_parameter_shift_cv.py
+++ b/tests/gradients/parameter_shift/test_parameter_shift_cv.py
@@ -377,7 +377,7 @@ class TestParameterShiftLogic:
 
         with pytest.warns(UserWarning, match="gradient of a tape with no trainable parameters"):
             g_tapes, post_processing = qml.gradients.param_shift_cv(tape, dev)
-        res = post_processing(qml.execute(g_tapes, dev, gradient_fn=None))
+        res = post_processing(qml.execute(g_tapes, dev, None))
 
         assert g_tapes == []
         assert res.shape == (1, 0)
@@ -1172,11 +1172,7 @@ class TestParamShiftInterfaces:
             tapes, fn = param_shift_cv(tape, dev)
             jac = fn(
                 qml.execute(
-                    tapes,
-                    dev,
-                    gradient_fn=param_shift_cv,
-                    gradient_kwargs={"dev": dev},
-                    interface="tf",
+                    tapes, dev, param_shift_cv, gradient_kwargs={"dev": dev}, interface="tf"
                 )
             )
             res = jac[1]
@@ -1215,13 +1211,7 @@ class TestParamShiftInterfaces:
         tape.trainable_params = {0, 2}
         tapes, fn = qml.gradients.param_shift_cv(tape, dev)
         jac = fn(
-            qml.execute(
-                tapes,
-                dev,
-                gradient_fn=param_shift_cv,
-                gradient_kwargs={"dev": dev},
-                interface="torch",
-            )
+            qml.execute(tapes, dev, param_shift_cv, gradient_kwargs={"dev": dev}, interface="torch")
         )
 
         r, phi = params.detach().numpy()
@@ -1268,11 +1258,7 @@ class TestParamShiftInterfaces:
             tapes, fn = qml.gradients.param_shift_cv(tape, dev)
             jac = fn(
                 qml.execute(
-                    tapes,
-                    dev,
-                    gradient_fn=param_shift_cv,
-                    gradient_kwargs={"dev": dev},
-                    interface="jax",
+                    tapes, dev, param_shift_cv, gradient_kwargs={"dev": dev}, interface="jax"
                 )
             )
             return jac

--- a/tests/gradients/parameter_shift/test_parameter_shift_shot_vec.py
+++ b/tests/gradients/parameter_shift/test_parameter_shift_shot_vec.py
@@ -256,7 +256,7 @@ class TestParamShift:
             g_tapes, post_processing = qml.gradients.param_shift(
                 tape, broadcast=broadcast, shots=shot_vec
             )
-        all_res = post_processing(qml.execute(g_tapes, dev, gradient_fn=None))
+        all_res = post_processing(qml.execute(g_tapes, dev, None))
         assert isinstance(all_res, tuple)
         assert len(all_res) == len(shot_vec)
 
@@ -282,7 +282,7 @@ class TestParamShift:
         tape.trainable_params = []
         with pytest.warns(UserWarning, match="gradient of a tape with no trainable parameters"):
             g_tapes, post_processing = qml.gradients.param_shift(tape, shots=shot_vec)
-        all_res = post_processing(qml.execute(g_tapes, dev, gradient_fn=None))
+        all_res = post_processing(qml.execute(g_tapes, dev, None))
         assert isinstance(all_res, tuple)
         assert len(all_res) == len(shot_vec)
 
@@ -310,7 +310,7 @@ class TestParamShift:
         g_tapes, post_processing = qml.gradients.param_shift(tape, shots=shot_vec)
         assert g_tapes == []
 
-        all_res = post_processing(qml.execute(g_tapes, dev, gradient_fn=None))
+        all_res = post_processing(qml.execute(g_tapes, dev, None))
         assert isinstance(all_res, tuple)
         assert len(all_res) == len(shot_vec)
 
@@ -435,7 +435,7 @@ class TestParamShift:
         num_ops_standard_recipe = tape.num_params - len(ops_with_custom_recipe)
         assert len(tapes) == 2 * num_ops_standard_recipe + len(ops_with_custom_recipe) + 1
         # Test that executing the tapes and the postprocessing function works
-        grad = fn(qml.execute(tapes, dev, gradient_fn=None))
+        grad = fn(qml.execute(tapes, dev, None))
 
         assert isinstance(grad, tuple)
         assert len(grad) == len(shot_vec)

--- a/tests/legacy/test_legacy_hamiltonian_expand_old.py
+++ b/tests/legacy/test_legacy_hamiltonian_expand_old.py
@@ -227,7 +227,7 @@ class TestHamiltonianExpand:
         def cost(x):
             tape.set_parameters(x, trainable_only=False)
             tapes, fn = hamiltonian_expand(tape)
-            res = qml.execute(tapes, dev, gradient_fn=qml.gradients.param_shift)
+            res = qml.execute(tapes, dev, qml.gradients.param_shift)
             return fn(res)
 
         assert np.isclose(cost(var), output)
@@ -270,7 +270,7 @@ class TestHamiltonianExpand:
 
             tape = QuantumScript.from_queue(q)
             tapes, fn = hamiltonian_expand(tape)
-            res = fn(qml.execute(tapes, dev, gradient_fn=qml.gradients.param_shift))
+            res = fn(qml.execute(tapes, dev, qml.gradients.param_shift))
 
             assert np.isclose(res, output)
 
@@ -493,7 +493,7 @@ class TestSumExpand:
         def cost(x):
             qscript.set_parameters(x, trainable_only=False)
             tapes, fn = sum_expand(qscript)
-            res = qml.execute(tapes, dev, gradient_fn=qml.gradients.param_shift)
+            res = qml.execute(tapes, dev, qml.gradients.param_shift)
             return fn(res)
 
         assert np.isclose(cost(var), output)
@@ -538,7 +538,7 @@ class TestSumExpand:
 
             qscript = QuantumScript.from_queue(q)
             tapes, fn = sum_expand(qscript)
-            res = fn(qml.execute(tapes, dev, gradient_fn=qml.gradients.param_shift))
+            res = fn(qml.execute(tapes, dev, qml.gradients.param_shift))
 
             assert np.isclose(res, output)
 
@@ -587,7 +587,7 @@ class TestSumExpand:
         def cost(x):
             qscript.set_parameters(x, trainable_only=False)
             tapes, fn = sum_expand(qscript)
-            res = qml.execute(tapes, dev, gradient_fn=qml.gradients.param_shift)
+            res = qml.execute(tapes, dev, qml.gradients.param_shift)
             return fn(res)
 
         assert np.isclose(cost(var), output)

--- a/tests/legacy/test_legacy_parameter_shift_cv_old.py
+++ b/tests/legacy/test_legacy_parameter_shift_cv_old.py
@@ -375,7 +375,7 @@ class TestParameterShiftLogic:
 
         with pytest.warns(UserWarning, match="gradient of a tape with no trainable parameters"):
             g_tapes, post_processing = qml.gradients.param_shift_cv(tape, dev)
-        res = post_processing(qml.execute(g_tapes, dev, gradient_fn=None))
+        res = post_processing(qml.execute(g_tapes, dev, None))
 
         assert g_tapes == []
         assert res.shape == (1, 0)
@@ -818,7 +818,7 @@ class TestExpectationQuantumGradients:
 
         tape = qml.tape.QuantumScript.from_queue(q)
         dev = qml.device("default.gaussian", wires=2)
-        res = qml.execute([tape], dev, gradient_fn=None)
+        res = qml.execute([tape], dev, None)
 
         tape.trainable_params = set(range(2, 2 + op.num_params))
 
@@ -934,7 +934,7 @@ class TestVarianceQuantumGradients:
         tape = qml.tape.QuantumScript.from_queue(q)
         tape.trainable_params = {0, 2}
 
-        res = qml.execute([tape], dev, gradient_fn=None)
+        res = qml.execute([tape], dev, None)
         expected = np.exp(2 * r) * np.sin(phi) ** 2 + np.exp(-2 * r) * np.cos(phi) ** 2
         assert np.allclose(res, expected, atol=tol, rtol=0)
 
@@ -971,7 +971,7 @@ class TestVarianceQuantumGradients:
         tape = qml.tape.QuantumScript.from_queue(q)
         tape.trainable_params = {0, 1}
 
-        res = qml.execute([tape], dev, gradient_fn=None)
+        res = qml.execute([tape], dev, None)
         expected = n**2 + n + np.abs(a) ** 2 * (1 + 2 * n)
         assert np.allclose(res, expected, atol=tol, rtol=0)
 
@@ -1076,7 +1076,7 @@ class TestVarianceQuantumGradients:
 
         tape = qml.tape.QuantumScript.from_queue(q)
         dev = qml.device("default.gaussian", wires=2)
-        res = qml.execute([tape], dev, gradient_fn=None)
+        res = qml.execute([tape], dev, None)
 
         tape.trainable_params = set(range(2, 2 + op.num_params))
 
@@ -1162,9 +1162,7 @@ class TestParamShiftInterfaces:
 
             tape = qml.tape.QuantumScript.from_queue(q)
             tapes, fn = param_shift_cv(tape, dev)
-            jac = fn(
-                qml.execute(tapes, dev, gradient_fn=param_shift_cv, gradient_kwargs={"dev": dev})
-            )
+            jac = fn(qml.execute(tapes, dev, param_shift_cv, gradient_kwargs={"dev": dev}))
             return jac[0, 2]
 
         params = np.array([r, phi], requires_grad=True)
@@ -1194,11 +1192,7 @@ class TestParamShiftInterfaces:
             tapes, fn = param_shift_cv(tape, dev)
             jac = fn(
                 qml.execute(
-                    tapes,
-                    dev,
-                    gradient_fn=param_shift_cv,
-                    gradient_kwargs={"dev": dev},
-                    interface="tf",
+                    tapes, dev, param_shift_cv, gradient_kwargs={"dev": dev}, interface="tf"
                 )
             )
             res = jac[0, 1]
@@ -1237,13 +1231,7 @@ class TestParamShiftInterfaces:
         tape.trainable_params = {0, 2}
         tapes, fn = qml.gradients.param_shift_cv(tape, dev)
         jac = fn(
-            qml.execute(
-                tapes,
-                dev,
-                gradient_fn=param_shift_cv,
-                gradient_kwargs={"dev": dev},
-                interface="torch",
-            )
+            qml.execute(tapes, dev, param_shift_cv, gradient_kwargs={"dev": dev}, interface="torch")
         )
 
         r, phi = params.detach().numpy()
@@ -1288,11 +1276,7 @@ class TestParamShiftInterfaces:
             tapes, fn = qml.gradients.param_shift_cv(tape, dev)
             jac = fn(
                 qml.execute(
-                    tapes,
-                    dev,
-                    gradient_fn=param_shift_cv,
-                    gradient_kwargs={"dev": dev},
-                    interface="jax",
+                    tapes, dev, param_shift_cv, gradient_kwargs={"dev": dev}, interface="jax"
                 )
             )
             return jac

--- a/tests/legacy/test_legacy_vjp_old.py
+++ b/tests/legacy/test_legacy_vjp_old.py
@@ -323,7 +323,7 @@ class TestVJPGradients:
         tape = qml.tape.QuantumScript.from_queue(q)
         tape.trainable_params = {0, 1}
         tapes, fn = qml.gradients.vjp(tape, dy, param_shift)
-        vjp = fn(qml.execute(tapes, dev, gradient_fn=qml.gradients.param_shift))
+        vjp = fn(qml.execute(tapes, dev, qml.gradients.param_shift))
 
         assert np.allclose(vjp.detach(), expected(params.detach()), atol=tol, rtol=0)
 

--- a/tests/templates/test_subroutines/test_approx_time_evolution.py
+++ b/tests/templates/test_subroutines/test_approx_time_evolution.py
@@ -393,7 +393,7 @@ def test_trainable_hamiltonian(dev_name, diff_method):
         if diff_method is qml.gradients.param_shift:
             tape = dev.expand_fn(tape)
 
-        return qml.execute([tape], dev, gradient_fn=diff_method)[0]
+        return qml.execute([tape], dev, diff_method)[0]
 
     t = pnp.array(0.54, requires_grad=True)
     coeffs = pnp.array([-0.6, 2.0], requires_grad=True)
@@ -412,5 +412,5 @@ def test_trainable_hamiltonian(dev_name, diff_method):
     # compare to finite-differences
     tape = create_tape(coeffs, t)
     g_tapes, fn = finite_diff(tape, _expand=False, validate_params=False)
-    expected = fn(qml.execute(g_tapes, dev, gradient_fn=None))
+    expected = fn(qml.execute(g_tapes, dev, None))
     assert np.allclose(qml.math.hstack(grad), qml.math.stack(expected))

--- a/tests/transforms/test_batch_transform.py
+++ b/tests/transforms/test_batch_transform.py
@@ -703,9 +703,7 @@ class TestMapBatchTransform:
         spy.assert_called()
         assert len(tapes) == 5
 
-        res = qml.execute(
-            tapes, dev, gradient_fn=qml.gradients.param_shift, device_batch_transform=False
-        )
+        res = qml.execute(tapes, dev, qml.gradients.param_shift, device_batch_transform=False)
         expected = [np.cos(y), 0.5 + 0.5 * np.cos(x) - 0.5 * np.sin(x / 2)]
 
         assert np.allclose(fn(res), expected)
@@ -735,9 +733,7 @@ class TestMapBatchTransform:
             tapes, fn = qml.transforms.map_batch_transform(
                 qml.transforms.hamiltonian_expand, [tape1, tape2]
             )
-            res = qml.execute(
-                tapes, dev, gradient_fn=qml.gradients.param_shift, device_batch_transform=False
-            )
+            res = qml.execute(tapes, dev, qml.gradients.param_shift, device_batch_transform=False)
             return np.sum(fn(res))
 
         res = cost(weights)

--- a/tests/transforms/test_broadcast_expand.py
+++ b/tests/transforms/test_broadcast_expand.py
@@ -104,7 +104,7 @@ class TestBroadcastExpand:
         assert len(tapes) == size
         assert all(_tape.batch_size is None for _tape in tapes)
 
-        result = fn(qml.execute(tapes, dev, gradient_fn=None))
+        result = fn(qml.execute(tapes, dev, None))
         expected = exp_fn(*params)
 
         if len(tape.measurements) > 1 and size == 1:
@@ -128,7 +128,7 @@ class TestBroadcastExpand:
         assert len(tapes) == 4
         assert all(t.batch_size is None for t in tapes)
 
-        result = fn(qml.execute(tapes, dev, gradient_fn=None))
+        result = fn(qml.execute(tapes, dev, None))
         expected = np.array([1, -1, -1, 1])
 
         assert qml.math.allclose(result, expected)
@@ -165,10 +165,8 @@ class TestBroadcastExpand:
             tape = make_tape(*params, obs)
             tapes, fn = qml.transforms.broadcast_expand(tape)
             if len(tape.measurements) > 1:
-                return qml.math.stack(
-                    fn(qml.execute(tapes, dev, gradient_fn=qml.gradients.param_shift))
-                )
-            return fn(qml.execute(tapes, dev, gradient_fn=qml.gradients.param_shift))
+                return qml.math.stack(fn(qml.execute(tapes, dev, qml.gradients.param_shift)))
+            return fn(qml.execute(tapes, dev, qml.gradients.param_shift))
 
         expected = exp_fn(*params)
 
@@ -199,7 +197,7 @@ class TestBroadcastExpand:
         def cost(*params):
             tape = make_tape(*params, obs)
             tapes, fn = qml.transforms.broadcast_expand(tape)
-            return fn(qml.execute(tapes, dev, gradient_fn=qml.gradients.param_shift))
+            return fn(qml.execute(tapes, dev, qml.gradients.param_shift))
 
         expected = exp_fn(*params)
 
@@ -234,7 +232,7 @@ class TestBroadcastExpand:
         def cost(*params):
             tape = make_tape(*params, obs)
             tapes, fn = qml.transforms.broadcast_expand(tape)
-            return fn(qml.execute(tapes, dev, gradient_fn=qml.gradients.param_shift))
+            return fn(qml.execute(tapes, dev, qml.gradients.param_shift))
 
         with tf.GradientTape(persistent=True) as t:
             out = tf.stack(cost(*params))
@@ -269,10 +267,8 @@ class TestBroadcastExpand:
             tape = make_tape(*params, obs)
             tapes, fn = qml.transforms.broadcast_expand(tape)
             if len(tape.measurements) > 1:
-                return qml.math.stack(
-                    fn(qml.execute(tapes, dev, gradient_fn=qml.gradients.param_shift))
-                )
-            return fn(qml.execute(tapes, dev, gradient_fn=qml.gradients.param_shift))
+                return qml.math.stack(fn(qml.execute(tapes, dev, qml.gradients.param_shift)))
+            return fn(qml.execute(tapes, dev, qml.gradients.param_shift))
 
         jac = torch.autograd.functional.jacobian(cost, torch_params)
         exp_jac = qml.jacobian(exp_fn)(*params)

--- a/tests/transforms/test_insert_ops.py
+++ b/tests/transforms/test_insert_ops.py
@@ -413,12 +413,12 @@ def test_insert_dev(mocker):
 
     in_tape = QuantumScript.from_queue(q_in_tape)
     dev = qml.device("default.mixed", wires=2)
-    res_without_noise = qml.execute([in_tape], dev, gradient_fn=qml.gradients.param_shift)
+    res_without_noise = qml.execute([in_tape], dev, qml.gradients.param_shift)
 
     new_dev = insert(qml.PhaseDamping, 0.4)(dev)
     spy = mocker.spy(new_dev, "default_expand_fn")
 
-    res_with_noise = qml.execute([in_tape], new_dev, gradient_fn=qml.gradients.param_shift)
+    res_with_noise = qml.execute([in_tape], new_dev, qml.gradients.param_shift)
     tape = spy.call_args[0][0]
 
     with qml.queuing.AnnotatedQueue() as q_tape_exp:

--- a/tests/transforms/test_metric_tensor.py
+++ b/tests/transforms/test_metric_tensor.py
@@ -578,11 +578,11 @@ class TestMetricTensor:
             circuit(weights)
 
         tapes, proc_fn = qml.metric_tensor(tape)
-        res = qml.execute(tapes, dev, gradient_fn=None)
+        res = qml.execute(tapes, dev, None)
         mt = proc_fn(res)
 
         tapes, proc_fn = qml.metric_tensor(tape, argnum=(0, 1, 3))
-        res = qml.execute(tapes, dev, gradient_fn=None, interface=interface)
+        res = qml.execute(tapes, dev, None, interface=interface)
         mt013 = proc_fn(res)
         assert isinstance(mt013, np.ndarray)
 
@@ -594,7 +594,7 @@ class TestMetricTensor:
         assert qml.math.allclose(0, mt013[:, 2], atol=tol, rtol=0)
 
         tapes, proc_fn = qml.metric_tensor(tape, argnum=(2, 3))
-        res = qml.execute(tapes, dev, gradient_fn=None, interface=interface)
+        res = qml.execute(tapes, dev, None, interface=interface)
         mt23 = proc_fn(res)
         assert isinstance(mt23, np.ndarray)
 
@@ -605,7 +605,7 @@ class TestMetricTensor:
         assert qml.math.allclose(0, mt23[:, :2], atol=tol, rtol=0)
 
         tapes, proc_fn = qml.metric_tensor(tape, argnum=0)
-        res = qml.execute(tapes, dev, gradient_fn=None, interface=interface)
+        res = qml.execute(tapes, dev, None, interface=interface)
         mt0 = proc_fn(res)
         assert isinstance(mt0, np.ndarray)
 
@@ -637,11 +637,11 @@ class TestMetricTensor:
             circuit(weights)
 
         tapes, proc_fn = qml.metric_tensor(tape)
-        res = qml.execute(tapes, dev, gradient_fn=None)
+        res = qml.execute(tapes, dev, None)
         mt = proc_fn(res)
 
         tapes, proc_fn = qml.metric_tensor(tape, argnum=(0, 1, 3))
-        res = qml.execute(tapes, dev, gradient_fn=None, interface=interface)
+        res = qml.execute(tapes, dev, None, interface=interface)
         mt013 = proc_fn(res)
         assert isinstance(mt013, tf.Tensor)
 
@@ -653,7 +653,7 @@ class TestMetricTensor:
         assert qml.math.allclose(0, mt013[:, 2], atol=tol, rtol=0)
 
         tapes, proc_fn = qml.metric_tensor(tape, argnum=(2, 3))
-        res = qml.execute(tapes, dev, gradient_fn=None, interface=interface)
+        res = qml.execute(tapes, dev, None, interface=interface)
         mt23 = proc_fn(res)
         assert isinstance(mt23, tf.Tensor)
 
@@ -664,7 +664,7 @@ class TestMetricTensor:
         assert qml.math.allclose(0, mt23[:, :2], atol=tol, rtol=0)
 
         tapes, proc_fn = qml.metric_tensor(tape, argnum=0)
-        res = qml.execute(tapes, dev, gradient_fn=None, interface=interface)
+        res = qml.execute(tapes, dev, None, interface=interface)
         mt0 = proc_fn(res)
         assert isinstance(mt0, tf.Tensor)
 
@@ -696,11 +696,11 @@ class TestMetricTensor:
             circuit(weights)
 
         tapes, proc_fn = qml.metric_tensor(tape)
-        res = qml.execute(tapes, dev, gradient_fn=None)
+        res = qml.execute(tapes, dev, None)
         mt = proc_fn(res)
 
         tapes, proc_fn = qml.metric_tensor(tape, argnum=(0, 1, 3))
-        res = qml.execute(tapes, dev, gradient_fn=None, interface=interface)
+        res = qml.execute(tapes, dev, None, interface=interface)
         mt013 = proc_fn(res)
         assert isinstance(mt013, torch.Tensor)
 
@@ -712,7 +712,7 @@ class TestMetricTensor:
         assert qml.math.allclose(0, mt013[:, 2], atol=tol, rtol=0)
 
         tapes, proc_fn = qml.metric_tensor(tape, argnum=(2, 3))
-        res = qml.execute(tapes, dev, gradient_fn=None, interface=interface)
+        res = qml.execute(tapes, dev, None, interface=interface)
         mt23 = proc_fn(res)
         assert isinstance(mt23, torch.Tensor)
 
@@ -723,7 +723,7 @@ class TestMetricTensor:
         assert qml.math.allclose(0, mt23[:, :2], atol=tol, rtol=0)
 
         tapes, proc_fn = qml.metric_tensor(tape, argnum=0)
-        res = qml.execute(tapes, dev, gradient_fn=None, interface=interface)
+        res = qml.execute(tapes, dev, None, interface=interface)
         mt0 = proc_fn(res)
         assert isinstance(mt0, torch.Tensor)
 
@@ -755,11 +755,11 @@ class TestMetricTensor:
             circuit(weights)
 
         tapes, proc_fn = qml.metric_tensor(tape)
-        res = qml.execute(tapes, dev, gradient_fn=None)
+        res = qml.execute(tapes, dev, None)
         mt = proc_fn(res)
 
         tapes, proc_fn = qml.metric_tensor(tape, argnum=(0, 1, 3))
-        res = qml.execute(tapes, dev, gradient_fn=None, interface=interface)
+        res = qml.execute(tapes, dev, None, interface=interface)
         mt013 = proc_fn(res)
         assert isinstance(mt013, jax.numpy.ndarray)
 
@@ -771,7 +771,7 @@ class TestMetricTensor:
         assert qml.math.allclose(0, mt013[:, 2], atol=tol, rtol=0)
 
         tapes, proc_fn = qml.metric_tensor(tape, argnum=(2, 3))
-        res = qml.execute(tapes, dev, gradient_fn=None, interface=interface)
+        res = qml.execute(tapes, dev, None, interface=interface)
         mt23 = proc_fn(res)
         assert isinstance(mt23, jax.numpy.ndarray)
 
@@ -782,7 +782,7 @@ class TestMetricTensor:
         assert qml.math.allclose(0, mt23[:, :2], atol=tol, rtol=0)
 
         tapes, proc_fn = qml.metric_tensor(tape, argnum=0)
-        res = qml.execute(tapes, dev, gradient_fn=None, interface=interface)
+        res = qml.execute(tapes, dev, None, interface=interface)
         mt0 = proc_fn(res)
         assert isinstance(mt0, jax.numpy.ndarray)
 
@@ -939,7 +939,7 @@ class TestMetricTensor:
 
         with pytest.warns(UserWarning, match="tensor of a tape with no trainable parameters"):
             mt_tapes, post_processing = qml.metric_tensor(tape)
-        res = post_processing(qml.execute(mt_tapes, dev, gradient_fn=None))
+        res = post_processing(qml.execute(mt_tapes, dev, None))
 
         assert mt_tapes == []
         assert res == ()


### PR DESCRIPTION
This PR branches off of #4342 and makes several recommended changes:

1) Moves more logic into `TransformProgram.__call__`. Now this function returns a single post-processing function, so the execution pipeline does not have to chain the post-processing functions together itself.

2) Gives default behaviour for an empty `TransformProgram`. Now we do not need separate logic for an empty program.

3) Applies transform program when binding machine learning interfaces and in the legacy execute.  It's just an additional line or two, though will require more test cases.

4) Extracts local functions to global helper functions, and binds them with specific metadata using `functools.partial`.  This allows us to unit test the functions, and to examine their bound keyword arguments.  This also allows us to eliminate potential namespacing and closure issues.

5) Explicitly removes support for classical cotransforms and informative transforms. More clarity is needed about the call signature of classical cotransforms and the implementation plan for informative transforms.