### PR TITLE
Fix `qml.GellMann` observable data

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -133,7 +133,7 @@
 * The observable data of `qml.GellMann` now includes its index, allowing correct comparison
   between instances of `qml.GellMann`, as well as Hamiltonians and Tensors
   containing `qml.GellMann`.
-  [()]()
+  [(#4366)](https://github.com/PennyLaneAI/pennylane/pull/4366)
 
 * `qml.transforms.merge_amplitude_embedding` now works correctly when the `AmplitudeEmbedding`s
   have a batch dimension.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -130,6 +130,11 @@
 * `default.qutrit` now supports all qutrit operations used with `qml.adjoint`.
   [(#4348)](https://github.com/PennyLaneAI/pennylane/pull/4348)
 
+* The observable data of `qml.GellMann` now includes its index, allowing correct comparison
+  between instances of `qml.GellMann`, as well as Hamiltonians and Tensors
+  containing `qml.GellMann`.
+  [()]()
+
 * `qml.transforms.merge_amplitude_embedding` now works correctly when the `AmplitudeEmbedding`s
   have a batch dimension.
   [(#4353)](https://github.com/PennyLaneAI/pennylane/pull/4353)

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -1892,6 +1892,8 @@ class Observable(Operator):
 
         for ob in obs:
             parameters = tuple(param.tobytes() for param in ob.parameters)
+            if isinstance(ob, qml.GellMann):
+                parameters += (ob.hyperparameters["index"],)
             tensor.add((ob.name, ob.wires, parameters))
 
         return tensor

--- a/pennylane/ops/qubit/hamiltonian.py
+++ b/pennylane/ops/qubit/hamiltonian.py
@@ -564,6 +564,8 @@ class Hamiltonian(Observable):
                 parameters = tuple(
                     str(param) for param in ob.parameters
                 )  # Converts params into immutable type
+                if isinstance(ob, qml.GellMann):
+                    parameters += (ob.hyperparameters["index"],)
                 tensor.append((ob.name, ob.wires, parameters))
             data.add((co, frozenset(tensor)))
 

--- a/tests/ops/qubit/test_hamiltonian.py
+++ b/tests/ops/qubit/test_hamiltonian.py
@@ -786,6 +786,45 @@ class TestHamiltonian:
             (0.5, frozenset([("PauliX", qml.wires.Wires(2), ())])),
         }
 
+    def test_data_gell_mann(self):
+        """Tests that the obs_data method for Hamiltonians with qml.GellMann
+        observables includes the Gell-Mann index."""
+        H = qml.Hamiltonian(
+            [1, -1, 0.5],
+            [
+                qml.GellMann(wires=0, index=3),
+                qml.GellMann(wires=0, index=3) @ qml.GellMann(wires=1, index=1),
+                qml.GellMann(wires=2, index=2),
+            ],
+        )
+        data = H._obs_data()
+
+        assert data == {
+            (1, frozenset([("GellMann", qml.wires.Wires(0), (3,))])),
+            (
+                -1,
+                frozenset(
+                    [("GellMann", qml.wires.Wires(0), (3,)), ("GellMann", qml.wires.Wires(1), (1,))]
+                ),
+            ),
+            (0.5, frozenset([("GellMann", qml.wires.Wires(2), (2,))])),
+        }
+
+    def test_compare_gell_mann(self):
+        """Tests that the compare method returns the correct result for Hamiltonians
+        with qml.GellMann present."""
+        H1 = qml.Hamiltonian([1], [qml.GellMann(wires=2, index=2)])
+        H2 = qml.Hamiltonian([1], [qml.GellMann(wires=2, index=1) @ qml.GellMann(wires=1, index=2)])
+        H3 = qml.Hamiltonian([1], [qml.GellMann(wires=2, index=1)])
+        H4 = qml.Hamiltonian([1], [qml.GellMann(wires=2, index=1) @ qml.GellMann(wires=1, index=3)])
+
+        assert H1.compare(qml.GellMann(wires=2, index=2)) is True
+        assert H1.compare(qml.GellMann(wires=2, index=1)) is False
+        assert H1.compare(H3) is False
+        assert H2.compare(qml.GellMann(wires=2, index=1) @ qml.GellMann(wires=1, index=2)) is True
+        assert H2.compare(qml.GellMann(wires=2, index=2) @ qml.GellMann(wires=1, index=2)) is False
+        assert H2.compare(H4) is False
+
     def test_hamiltonian_equal_error(self):
         """Tests that the correct error is raised when compare() is called on invalid type"""
 

--- a/tests/ops/qutrit/test_qutrit_observables.py
+++ b/tests/ops/qutrit/test_qutrit_observables.py
@@ -371,6 +371,18 @@ class TestGellMann:
         assert np.allclose(res_static, mat)
         assert np.allclose(res_dynamic, mat)
 
+    def test_obs_data(self):
+        """Test that the _obs_data() method of qml.GellMann returns the correct
+        observable data."""
+        ob1 = qml.GellMann(wires=0, index=2)
+        ob2 = qml.GellMann(wires=0, index=2) @ qml.GellMann(wires=1, index=1)
+
+        assert ob1._obs_data() == {("GellMann", qml.wires.Wires(0), (2,))}
+        assert ob2._obs_data() == {
+            ("GellMann", qml.wires.Wires(0), (2,)),
+            ("GellMann", qml.wires.Wires(1), (1,)),
+        }
+
     @pytest.mark.parametrize("index, mat, eigs", GM_OBSERVABLES)
     def test_eigvals(self, index, mat, eigs, tol):
         """Test that the Gell-Mann eigenvalues are correct"""


### PR DESCRIPTION
**Context:**
Fixes #4341 .

**Description of the Change:**
* Update `Observable._obs_data()` to include the index of `qml.GellMann` in the parameter list.
* Update `Hamiltonian._obs_data()` to include the index of `qml.GellMann` in the parameter list.

<ins>**Note:**</ins>
I would still recommend using the new operator arithmetic with qutrits. The generators of parametric qutrit gates are instances of `Prod` and `Sum`, not `qml.Hamiltonian`. So, try using `qml.dot` instead of `qml.Hamiltonian` with qutrit observables.

**Benefits:**
Comparison of instances of `qml.GellMann`, `Hamiltonian`s and `Tensor`s containing `qml.GellMann` is correct.

**Possible Drawbacks:**

**Related GitHub Issues:**
#4341 