### PR TITLE
[Prototype] Extract jacobian logic to new class

### DIFF
--- a/pennylane/gradients/general_shift_rules.py
+++ b/pennylane/gradients/general_shift_rules.py
@@ -396,8 +396,12 @@ def _copy_and_shift_params(tape, indices, shifts, multipliers, cast=False):
 
         # Shift copied parameter
         new_params = list(op.data)
-        new_params[p_idx] = new_params[p_idx] * qml.math.convert_like(multiplier, new_params[p_idx])
-        new_params[p_idx] = new_params[p_idx] + qml.math.convert_like(shift, new_params[p_idx])
+        multiplier = qml.math.convert_like(multiplier, new_params[p_idx])
+        multiplier = qml.math.cast_like(multiplier, new_params[p_idx])
+        shift = qml.math.convert_like(shift, new_params[p_idx])
+        shift = qml.math.cast_like(shift, new_params[p_idx])
+        new_params[p_idx] = new_params[p_idx] * multiplier
+        new_params[p_idx] = new_params[p_idx] + shift
         if cast:
             dtype = getattr(new_params[p_idx], "dtype", float)
             new_params[p_idx] = qml.math.cast(new_params[p_idx], dtype)

--- a/pennylane/gradients/gradient_transform.py
+++ b/pennylane/gradients/gradient_transform.py
@@ -566,6 +566,9 @@ class gradient_transform(qml.batch_transform):
         ...     params = tape.get_parameters()  # list of floats
     """
 
+    def __repr__(self):
+        return f"<gradient_transform: {self.__name__}>"  # pylint: disable=no-member
+
     def __init__(
         self, transform_fn, expand_fn=expand_invalid_trainable, differentiable=True, hybrid=True
     ):

--- a/pennylane/gradients/jvp.py
+++ b/pennylane/gradients/jvp.py
@@ -164,7 +164,6 @@ def compute_jvp_single(tangent, jac):
     if jac is None:
         return None
 
-    print("\n inside compute_jvp_single", jac, tangent)
     single_param = not isinstance(jac, tuple)
     if (single_param and jac.shape == (0,)) or (not single_param and len(jac) == 0):
         # No trainable parameters
@@ -325,10 +324,8 @@ def jvp(tape, tangent, gradient_fn, shots=None, gradient_kwargs=None):
     gradient_tapes, fn = gradient_fn(tape, shots=shots, **gradient_kwargs)
 
     def processing_fn(results):
-        print("results: ", results)
         # postprocess results to compute the Jacobian
         jac = fn(results)
-        print("jac: ", jac)
         _jvp_fn = compute_jvp_multi if multi_m else compute_jvp_single
 
         # Jacobian without shot vectors
@@ -430,19 +427,15 @@ def batch_jvp(tapes, tangents, gradient_fn, shots=None, reduction="append", grad
         jvps = []
         start = 0
 
-        print("\n results at start of processing_fn: ", results)
         for t_idx in range(len(tapes)):
             # extract the correct results from the flat list
             res_len = reshape_info[t_idx]
             res_t = results[start : start + res_len]
             start += res_len
 
-            print("res_t: ", res_t)
-
             # postprocess results to compute the JVP
             jvp_ = processing_fns[t_idx](res_t)
 
-            print("jvp_; ", jvp_)
             if jvp_ is None:
                 if reduction == "append":
                     jvps.append(None)
@@ -453,7 +446,6 @@ def batch_jvp(tapes, tangents, gradient_fn, shots=None, reduction="append", grad
             elif callable(reduction):
                 reduction(jvps, jvp_)
 
-        print("jvps inside processing fn: ", jvps)
         return tuple(jvps)
 
     return gradient_tapes, processing_fn

--- a/pennylane/gradients/jvp.py
+++ b/pennylane/gradients/jvp.py
@@ -163,6 +163,8 @@ def compute_jvp_single(tangent, jac):
     """
     if jac is None:
         return None
+
+    print("\n inside compute_jvp_single", jac, tangent)
     single_param = not isinstance(jac, tuple)
     if (single_param and jac.shape == (0,)) or (not single_param and len(jac) == 0):
         # No trainable parameters
@@ -323,8 +325,10 @@ def jvp(tape, tangent, gradient_fn, shots=None, gradient_kwargs=None):
     gradient_tapes, fn = gradient_fn(tape, shots=shots, **gradient_kwargs)
 
     def processing_fn(results):
+        print("results: ", results)
         # postprocess results to compute the Jacobian
         jac = fn(results)
+        print("jac: ", jac)
         _jvp_fn = compute_jvp_multi if multi_m else compute_jvp_single
 
         # Jacobian without shot vectors
@@ -426,15 +430,19 @@ def batch_jvp(tapes, tangents, gradient_fn, shots=None, reduction="append", grad
         jvps = []
         start = 0
 
+        print("\n results at start of processing_fn: ", results)
         for t_idx in range(len(tapes)):
             # extract the correct results from the flat list
             res_len = reshape_info[t_idx]
             res_t = results[start : start + res_len]
             start += res_len
 
+            print("res_t: ", res_t)
+
             # postprocess results to compute the JVP
             jvp_ = processing_fns[t_idx](res_t)
 
+            print("jvp_; ", jvp_)
             if jvp_ is None:
                 if reduction == "append":
                     jvps.append(None)
@@ -445,6 +453,7 @@ def batch_jvp(tapes, tangents, gradient_fn, shots=None, reduction="append", grad
             elif callable(reduction):
                 reduction(jvps, jvp_)
 
+        print("jvps inside processing fn: ", jvps)
         return tuple(jvps)
 
     return gradient_tapes, processing_fn

--- a/pennylane/gradients/parameter_shift.py
+++ b/pennylane/gradients/parameter_shift.py
@@ -783,14 +783,12 @@ def _create_variance_proc_fn(
     """
 
     def processing_fn(results):
-        print("\n in variance processing_fn : ", results)
         f0 = results[0]
 
         has_partitioned_shots = shots.has_partitioned_shots
 
         # analytic derivative of <A>
         pdA = pdA_fn(results[int(not pdA_fn.first_result_unshifted) : tape_boundary])
-        print("pdA: ", pdA)
         # analytic derivative of <A^2>
         pdA2 = _get_pdA2(
             results[tape_boundary:],
@@ -800,7 +798,6 @@ def _create_variance_proc_fn(
             var_indices,
             has_partitioned_shots,
         )
-        print("pdA2: ", pdA2)
         # The logic follows:
         # variances (var_mask==True): return d(var(A))/dp = d<A^2>/dp -2 * <A> * d<A>/dp
         # plain expectations (var_mask==False): return d<A>/dp
@@ -819,7 +816,6 @@ def _create_variance_proc_fn(
             return tuple(final_res)
 
         out = _single_variance_gradient(tape, var_mask, pdA2, f0, pdA)
-        print(out, "\n")
         return out
 
     return processing_fn

--- a/pennylane/gradients/parameter_shift.py
+++ b/pennylane/gradients/parameter_shift.py
@@ -783,13 +783,14 @@ def _create_variance_proc_fn(
     """
 
     def processing_fn(results):
+        print("\n in variance processing_fn : ", results)
         f0 = results[0]
 
         has_partitioned_shots = shots.has_partitioned_shots
 
         # analytic derivative of <A>
         pdA = pdA_fn(results[int(not pdA_fn.first_result_unshifted) : tape_boundary])
-
+        print("pdA: ", pdA)
         # analytic derivative of <A^2>
         pdA2 = _get_pdA2(
             results[tape_boundary:],
@@ -799,7 +800,7 @@ def _create_variance_proc_fn(
             var_indices,
             has_partitioned_shots,
         )
-
+        print("pdA2: ", pdA2)
         # The logic follows:
         # variances (var_mask==True): return d(var(A))/dp = d<A^2>/dp -2 * <A> * d<A>/dp
         # plain expectations (var_mask==False): return d<A>/dp
@@ -817,7 +818,9 @@ def _create_variance_proc_fn(
 
             return tuple(final_res)
 
-        return _single_variance_gradient(tape, var_mask, pdA2, f0, pdA)
+        out = _single_variance_gradient(tape, var_mask, pdA2, f0, pdA)
+        print(out, "\n")
+        return out
 
     return processing_fn
 

--- a/pennylane/interfaces/autograd.py
+++ b/pennylane/interfaces/autograd.py
@@ -269,7 +269,7 @@ autograd.extend.defvjp(__execute_legacy, _vjp_legacy, argnums=[0])
 #################
 
 
-def autograd_boundary(tapes, execute_fn, vjp_fn, device=None):
+def autograd_boundary(tapes, execute_fn, vjp_fn):
     """Execute a batch of tapes with Autograd parameters on a device.
 
     Args:

--- a/pennylane/interfaces/autograd.py
+++ b/pennylane/interfaces/autograd.py
@@ -371,9 +371,10 @@ def vjp(
     def grad_fn(dy):
         """Returns the vector-Jacobian product with given
         parameter values and output gradient dy"""
-
-        # not sure what this post processing is for
-        return vjp_fn.compute_vjp(tapes, dy)
+        vjps = vjp_fn.compute_vjp(tapes, dy)
+        return tuple(
+            qml.math.to_numpy(v, max_depth=1) if isinstance(v, ArrayBox) else v for v in vjps
+        )
 
     return grad_fn
 

--- a/pennylane/interfaces/autograd.py
+++ b/pennylane/interfaces/autograd.py
@@ -269,7 +269,7 @@ autograd.extend.defvjp(__execute_legacy, _vjp_legacy, argnums=[0])
 #################
 
 
-def execute(tapes, execute_fn, vjp_fn):
+def execute(tapes, execute_fn, vjp_fn, device=None):
     """Execute a batch of tapes with Autograd parameters on a device.
 
     Args:

--- a/pennylane/interfaces/autograd.py
+++ b/pennylane/interfaces/autograd.py
@@ -269,7 +269,7 @@ autograd.extend.defvjp(__execute_legacy, _vjp_legacy, argnums=[0])
 #################
 
 
-def execute(tapes, execute_fn, vjp_fn, device=None):
+def autograd_boundary(tapes, execute_fn, vjp_fn, device=None):
     """Execute a batch of tapes with Autograd parameters on a device.
 
     Args:
@@ -333,8 +333,6 @@ def _execute(
     - ``tapes`` is a *required* argument
 
     """
-    print("\n in autograd _execute wth : ", execute_fn)
-    print(vjp_fn, "\n")
     return execute_fn(tapes)
 
 
@@ -373,7 +371,6 @@ def vjp(
     def grad_fn(dy):
         """Returns the vector-Jacobian product with given
         parameter values and output gradient dy"""
-        print("in autograd grad_fn with : ", vjp_fn)
 
         # not sure what this post processing is for
         return vjp_fn.compute_vjp(tapes, dy)

--- a/pennylane/interfaces/autograd.py
+++ b/pennylane/interfaces/autograd.py
@@ -296,10 +296,6 @@ def execute(tapes, execute_fn, vjp_fn, device=None):
         the returned list corresponds in order to the provided tapes.
     """
     # pylint: disable=unused-argument
-    for tape in tapes:
-        # set the trainable parameters
-        params = tape.get_parameters(trainable_only=False)
-        tape.trainable_params = qml.math.get_trainable_indices(params)
 
     # pylint misidentifies autograd.builtins as a dict
     # pylint: disable=no-member
@@ -337,6 +333,8 @@ def _execute(
     - ``tapes`` is a *required* argument
 
     """
+    print("\n in autograd _execute wth : ", execute_fn)
+    print(vjp_fn, "\n")
     return execute_fn(tapes)
 
 
@@ -375,12 +373,10 @@ def vjp(
     def grad_fn(dy):
         """Returns the vector-Jacobian product with given
         parameter values and output gradient dy"""
-        vjps = vjp_fn.compute_vjp(tapes, dy)
+        print("in autograd grad_fn with : ", vjp_fn)
 
         # not sure what this post processing is for
-        return tuple(
-            qml.math.to_numpy(v, max_depth=3) if isinstance(v, ArrayBox) else v for v in vjps
-        )
+        return vjp_fn.compute_vjp(tapes, dy)
 
     return grad_fn
 

--- a/pennylane/interfaces/autograd.py
+++ b/pennylane/interfaces/autograd.py
@@ -337,7 +337,6 @@ def _execute(
     - ``tapes`` is a *required* argument
 
     """
-    tapes = tuple(qml.transforms.convert_to_numpy_parameters(t) for t in tapes)
     return execute_fn(tapes)
 
 
@@ -379,7 +378,9 @@ def vjp(
         vjps = vjp_fn.compute_vjp(tapes, dy)
 
         # not sure what this post processing is for
-        return tuple(qml.math.to_numpy(v) if isinstance(v, ArrayBox) else v for v in vjps)
+        return tuple(
+            qml.math.to_numpy(v, max_depth=3) if isinstance(v, ArrayBox) else v for v in vjps
+        )
 
     return grad_fn
 

--- a/pennylane/interfaces/autograd.py
+++ b/pennylane/interfaces/autograd.py
@@ -269,7 +269,7 @@ autograd.extend.defvjp(__execute_legacy, _vjp_legacy, argnums=[0])
 #################
 
 
-def execute(tapes, device, execute_fn, gradient_fn, gradient_kwargs, _n=1, max_diff=2):
+def execute(tapes, execute_fn, vjp_fn):
     """Execute a batch of tapes with Autograd parameters on a device.
 
     Args:
@@ -295,16 +295,6 @@ def execute(tapes, device, execute_fn, gradient_fn, gradient_kwargs, _n=1, max_d
         list[list[float]]: A nested list of tape results. Each element in
         the returned list corresponds in order to the provided tapes.
     """
-    if not qml.active_return():
-        return _execute_legacy(
-            tapes,
-            device,
-            execute_fn,
-            gradient_fn,
-            gradient_kwargs,
-            _n=_n,
-            max_diff=max_diff,
-        )
     # pylint: disable=unused-argument
     for tape in tapes:
         # set the trainable parameters
@@ -319,25 +309,17 @@ def execute(tapes, device, execute_fn, gradient_fn, gradient_kwargs, _n=1, max_d
     return _execute(
         parameters,
         tapes=tapes,
-        device=device,
         execute_fn=execute_fn,
-        gradient_fn=gradient_fn,
-        gradient_kwargs=gradient_kwargs,
-        _n=_n,
-        max_diff=max_diff,
-    )[0]
+        vjp_fn=vjp_fn,
+    )
 
 
 @autograd.extend.primitive
 def _execute(
     parameters,
     tapes=None,
-    device=None,
     execute_fn=None,
-    gradient_fn=None,
-    gradient_kwargs=None,
-    _n=1,
-    max_diff=2,
+    vjp_fn=None,
 ):  # pylint: disable=dangerous-default-value,unused-argument
     """Autodifferentiable wrapper around ``Device.batch_execute``.
 
@@ -353,28 +335,14 @@ def _execute(
 
     - ``parameters`` is dependent on the provided tapes: always extract them as above
     - ``tapes`` is a *required* argument
-    - ``device`` is a *required* argument
 
-    The private argument ``_n`` is used to track nesting of derivatives, for example
-    if the nth-order derivative is requested. Do not set this argument unless you
-    understand the consequences!
     """
-    unwrapped_tapes = tuple(convert_to_numpy_parameters(t) for t in tapes)
-    res, jacs = execute_fn(unwrapped_tapes, **gradient_kwargs)
-
-    return res, jacs
+    tapes = tuple(qml.transforms.convert_to_numpy_parameters(t) for t in tapes)
+    return execute_fn(tapes)
 
 
 def vjp(
-    ans,
-    parameters,
-    tapes=None,
-    device=None,
-    execute_fn=None,
-    gradient_fn=None,
-    gradient_kwargs=None,
-    _n=1,
-    max_diff=2,
+    ans, parameters, tapes=None, execute_fn=None, vjp_fn=None
 ):  # pylint: disable=dangerous-default-value,unused-argument
     """Returns the vector-Jacobian product operator for a batch of quantum tapes.
 
@@ -404,141 +372,16 @@ def vjp(
         function: this function accepts the backpropagation
         gradient output vector, and computes the vector-Jacobian product
     """
-    cached_jac = {}
-
-    def _get_jac_with_caching():
-        if "jacobian" in cached_jac:
-            return cached_jac["jacobian"]
-
-        jacs = []
-        if isinstance(device, qml.devices.experimental.Device):
-            shot_vector = (
-                tapes[0].shots.shot_vector if tapes[0].shots.has_partitioned_shots else None
-            )
-        else:
-            shot_vector = device.shot_vector
-
-        def partial_gradient_fn(tape):
-            return gradient_fn(tape, shots=shot_vector, **gradient_kwargs)
-
-        g_tapes, fn = qml.transforms.map_batch_transform(partial_gradient_fn, tapes)
-        unwrapped_tapes = tuple(convert_to_numpy_parameters(g_t) for g_t in g_tapes)
-
-        res, _ = execute_fn(unwrapped_tapes, **gradient_kwargs)
-
-        jacs = fn(res)
-        cached_jac["jacobian"] = jacs
-        return jacs
 
     def grad_fn(dy):
         """Returns the vector-Jacobian product with given
         parameter values and output gradient dy"""
-        # multi measurement
-        multi_measurements = [len(tape.measurements) > 1 for tape in tapes]
-        dy = dy[0]
+        vjps = vjp_fn.compute_vjp(tapes, dy)
 
-        computing_jacobian = _n == max_diff
-        if isinstance(device, qml.devices.experimental.Device):  # pragma: no-cover
-            # assumes all tapes have the same shot vector
-            has_partitioned_shots = tapes[0].shots.has_partitioned_shots
-            vjp_shots = None
-        else:
-            has_partitioned_shots = vjp_shots = device.shot_vector
-
-        if gradient_fn and gradient_fn.__name__ == "param_shift" and computing_jacobian:
-            jacs = _get_jac_with_caching()
-        else:
-            jacs = ans[1]
-
-        if jacs:
-            # Jacobians were computed on the forward pass (mode="forward") or the Jacobian was cached
-            # No additional quantum evaluations needed; simply compute the VJPs directly.
-            vjps = _compute_vjps_autograd(jacs, dy, multi_measurements, has_partitioned_shots)
-
-        else:
-            # Need to compute the Jacobians on the backward pass (accumulation="backward")
-            if isinstance(gradient_fn, qml.gradients.gradient_transform):
-                # Gradient function is a gradient transform.
-
-                # Generate and execute the required gradient tapes
-                if _n == max_diff:
-                    unwrapped_tapes = tuple(convert_to_numpy_parameters(t) for t in tapes)
-                    vjp_tapes, processing_fn = qml.gradients.batch_vjp(
-                        unwrapped_tapes,
-                        dy,
-                        gradient_fn,
-                        shots=vjp_shots,
-                        reduction="append",
-                        gradient_kwargs=gradient_kwargs,
-                    )
-
-                    vjps = processing_fn(execute_fn(vjp_tapes)[0])
-
-                else:
-                    vjp_tapes, processing_fn = qml.gradients.batch_vjp(
-                        tapes,
-                        dy,
-                        gradient_fn,
-                        shots=vjp_shots,
-                        reduction="append",
-                        gradient_kwargs=gradient_kwargs,
-                    )
-
-                    # This is where the magic happens. Note that we call ``execute``.
-                    # This recursion, coupled with the fact that the gradient transforms
-                    # are differentiable, allows for arbitrary order differentiation.
-                    vjps = processing_fn(
-                        execute(
-                            vjp_tapes,
-                            device,
-                            execute_fn,
-                            gradient_fn,
-                            gradient_kwargs,
-                            _n=_n + 1,
-                            max_diff=max_diff,
-                        )
-                    )
-
-            else:
-                # Gradient function is not a gradient transform
-                # (e.g., it might be a device method).
-                # Note that unlike the previous branch:
-                #
-                # - there is no recursion here
-                # - gradient_fn is not differentiable
-                #
-                # so we cannot support higher-order derivatives.
-                unwrapped_tapes = tuple(convert_to_numpy_parameters(t) for t in tapes)
-                jacs = gradient_fn(unwrapped_tapes, **gradient_kwargs)
-
-                vjps = _compute_vjps_autograd(jacs, dy, multi_measurements, has_partitioned_shots)
-
-        return_vjps = [
-            qml.math.to_numpy(v, max_depth=_n) if isinstance(v, ArrayBox) else v for v in vjps
-        ]
-
-        return return_vjps
+        # not sure what this post processing is for
+        return tuple(qml.math.to_numpy(v) if isinstance(v, ArrayBox) else v for v in vjps)
 
     return grad_fn
-
-
-def _compute_vjps_autograd(jacs, dy, multi_measurements, has_partitioned_shots):
-    """Compute the vjps of multiple tapes, directly for a Jacobian and co-tangents dys."""
-    vjps = []
-    for i, multi in enumerate(multi_measurements):
-        dy_ = dy[i] if has_partitioned_shots else (dy[i],)
-        jac_ = jacs[i] if has_partitioned_shots else (jacs[i],)
-
-        shot_vjps = []
-        for d, j in zip(dy_, jac_):
-            if multi:
-                shot_vjps.append(qml.gradients.compute_vjp_multi(d, j))
-            else:
-                shot_vjps.append(qml.gradients.compute_vjp_single(d, j))
-
-        vjps.append(qml.math.sum(qml.math.stack(shot_vjps), axis=0))
-
-    return vjps
 
 
 autograd.extend.defvjp(_execute, vjp, argnums=[0])

--- a/pennylane/interfaces/execution.py
+++ b/pennylane/interfaces/execution.py
@@ -242,7 +242,6 @@ def cache_execute(fn: Callable, cache, pass_kwargs=False, return_tuple=True, exp
             tapes = [expand_fn(tape) for tape in tapes]
             return original_fn(tapes, **kwargs)
 
-    @wraps(fn)
     def wrapper(tapes: Sequence[QuantumTape], **kwargs):
         if not pass_kwargs:
             kwargs = {}
@@ -563,7 +562,6 @@ def execute(
             return batch_execute(tapes)
 
         execute_fn = qml.interfaces.cache_execute(inner_execute, cache, return_tuple=False)
-
     _grad_on_execution = False
 
     if config.use_device_gradient:
@@ -632,6 +630,7 @@ def execute(
             vjp_fn = TransformDerivatives(
                 differentiable_execute_fn, gradient_fn, gradient_kwargs=gradient_kwargs
             )
+
     for tape in tapes:
         # set the trainable parameters
         params = tape.get_parameters(trainable_only=False)

--- a/pennylane/interfaces/execution.py
+++ b/pennylane/interfaces/execution.py
@@ -598,7 +598,7 @@ def execute(
         else:
             # disable caching on the forward pass
             # use qml.interfaces so that mocker can spy on it during testing
-            execute_fn = qml.interfaces.cache_execute(batch_execute, cache=None)
+            execute_fn = inner_execute
 
             # Adjoint Jacobian with backward pass and jitting needs the original circuit output state which
             # can not be reused from the device if `grad_on_execution is False`.

--- a/pennylane/interfaces/execution.py
+++ b/pennylane/interfaces/execution.py
@@ -637,11 +637,13 @@ def execute(
             interface_boundary = _get_interface_boundary(
                 mapped_interface, tapes, _grad_on_execution
             )
-            execute_fn = partial(interface_boundary, execute_fn=execute_fn, vjp_fn=vjp_fn)
+            execute_fn = partial(
+                interface_boundary, execute_fn=execute_fn, vjp_fn=vjp_fn, device=device
+            )
             vjp_fn = TransformDerivatives(execute_fn, gradient_fn, gradient_kwargs=gradient_kwargs)
 
     interface_boundary = _get_interface_boundary(mapped_interface, tapes, _grad_on_execution)
-    res = interface_boundary(tapes, execute_fn, vjp_fn=vjp_fn)
+    res = interface_boundary(tapes, execute_fn, vjp_fn=vjp_fn, device=device)
     return batch_fn(res)
 
 

--- a/pennylane/interfaces/jacobian_products.py
+++ b/pennylane/interfaces/jacobian_products.py
@@ -169,7 +169,6 @@ class TransformDerivatives(DerivativeExecutor):
         self._gradient_kwargs = gradient_kwargs or {}
 
     def execute_and_compute_jvp(self, tapes, tangents):
-
         num_result_tapes = len(tapes)
 
         jvp_tapes, jvp_processing_fn = qml.gradients.batch_jvp(

--- a/pennylane/interfaces/jacobian_products.py
+++ b/pennylane/interfaces/jacobian_products.py
@@ -173,6 +173,8 @@ class TransformDerivatives(DerivativeExecutor):
         jvp_tapes, jvp_processing_fn = qml.gradients.batch_jvp(
             tapes, tangents, self._gradient_transform, gradient_kwargs=self._gradient_kwargs
         )
+        print("in execute_and_compute_jvp")
+        print("sending off ", jvp_tapes)
 
         full_batch = tapes + tuple(jvp_tapes)
 
@@ -180,8 +182,10 @@ class TransformDerivatives(DerivativeExecutor):
 
         results = full_results[:num_result_tapes]
         jvp_results = full_results[num_result_tapes:]
+        print("\n jvp_results: ", jvp_results)
+        print("jvp processing_fn: ", jvp_processing_fn)
         jvps = jvp_processing_fn(jvp_results)
-
+        print("post processed: ", jvps, "\n")
         return tuple(results), tuple(jvps)
 
     def compute_jvp(self, tapes, tangents):
@@ -210,6 +214,7 @@ class TransformDerivatives(DerivativeExecutor):
         return tuple(results), tuple(vjps)
 
     def compute_vjp(self, tapes, dy):
+        print("in compute_vjp: ", self._inner_execute)
         vjp_tapes, processing_fn = qml.gradients.batch_vjp(
             tapes, dy, self._gradient_transform, gradient_kwargs=self._gradient_kwargs
         )

--- a/pennylane/interfaces/jacobian_products.py
+++ b/pennylane/interfaces/jacobian_products.py
@@ -1,0 +1,322 @@
+# Copyright 2018-2023 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Defines classes taking the vjps and jvps of circuits.
+"""
+import abc
+from typing import Tuple, Callable, Optional
+
+import pennylane as qml
+from pennylane.tape import QuantumScript
+from pennylane.typing import ResultBatch, TensorLike
+
+Batch = Tuple[QuantumScript]
+
+
+def _compute_jvps(jacs, tangents, multi_measurements):
+    """Compute the jvps of multiple tapes, directly for a Jacobian and tangents."""
+    jvps = []
+    for i, multi in enumerate(multi_measurements):
+        compute_func = (
+            qml.gradients.compute_jvp_multi if multi else qml.gradients.compute_jvp_single
+        )
+        jvps.append(compute_func(tangents[i], jacs[i]))
+    return tuple(jvps)
+
+
+def _compute_vjps(dys, jacs, multi_measurements):
+    """Compute the vjps of multiple tapes, directly for a Jacobian and tangents."""
+    vjps = []
+
+    for i, multi in enumerate(multi_measurements):
+        compute_func = (
+            qml.gradients.compute_vjp_multi if multi else qml.gradients.compute_vjp_single
+        )
+        vjps.append(compute_func(dys[i], jacs[i]))
+    return tuple(vjps)
+
+
+class DerivativeExecutor(abc.ABC):
+    """Provides methods for calculating the jvp and vjps for tapes and tangents/ cotangents."""
+
+    @abc.abstractmethod
+    def execute_and_compute_jvp(
+        self, tapes: Batch, tangents: TensorLike
+    ) -> Tuple[ResultBatch, Tuple]:
+        """Calculate both the results for a batch of tapes and the jvp.
+
+        Args:
+            tapes: The batch of tapes to take the derivatives of
+            tangents (Iterable[TensorLike]): the tangents for the parameters of the tape
+
+        Returns:
+            ResultBatch, TensorLike
+
+        >>> tape0 = qml.tape.QuantumScript([qml.RX(0.1, wires=0)], [qml.expval(qml.PauliZ(0))])
+        >>> batch = (tape0, )
+        >>> tangent_variables = (1.5, )
+        >>> derivatives_executor.execute_and_compute_vjp(batch, tangent_variables)
+        ((array(0.99500417),), (-0.14975012497024237,))
+
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def compute_jvp(self, tapes: Batch, tangents: TensorLike) -> Tuple:
+        """Calculate both the results for a batch of tapes and the jvp.
+
+        Args:
+            tapes: The batch of tapes to take the derivatives of
+            tangents (Iterable[TensorLike]): the tangents for the parameters of the tape
+
+        Returns:
+            TensorLike
+
+        >>> tape0 = qml.tape.QuantumScript([qml.RX(0.1, wires=0)], [qml.expval(qml.PauliZ(0))])
+        >>> batch = (tape0, )
+        >>> tangent_variables = (1.5, )
+        >>> derivatives_executor.compute_vjp(batch, tangent_variables)
+        (-0.14975012497024237, )
+
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def execute_and_compute_vjp(self, tapes: Batch, dy: TensorLike) -> Tuple[ResultBatch, Tuple]:
+        """Compute the vjp for a given batch of tapes.
+
+        Args:
+            tapes: the batch of tapes to the the derivatives of
+            dy: the derivatives of the results of an execution
+
+        Returns:
+            ResultBatch, TensorLike
+
+        >>> tape0 = qml.tape.QuantumScript([qml.RX(0.1, wires=0)], [qml.expval(qml.PauliZ(0))])
+        >>> batch = (tape0, )
+        >>> derivatives_executor.execute_and_compute_vjp(batch, (0.5, ))
+        ((array(0.99500417),), (-0.04991670832341412,))
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def compute_vjp(self, tapes, dy) -> Tuple:
+        """Compute the vjp for a given batch of tapes.
+
+        Args:
+            tapes: the batch of tapes to the the derivatives of
+            dy: the derivatives of the results of an execution
+
+        Returns:
+            TensorLike
+
+        >>> tape0 = qml.tape.QuantumScript([qml.RX(0.1, wires=0)], [qml.expval(qml.PauliZ(0))])
+        >>> batch = (tape0, )
+        >>> derivatives_executor.compute_vjp(batch, (0.5, ))
+        (-0.04991670832341412,)
+        """
+        raise NotImplementedError
+
+
+class TransformDerivatives(DerivativeExecutor):
+    """Compute vjp and jvps via a gradient transform.
+
+    Args:
+        next_executor (Executor): where to execute the gradient tapes.
+        gradient_transform (TransformContainer): the gradient transform to use.
+
+    Note that this class accepts a :class:`~.TransformContainer` with bound keyword arguments
+    instead of the ``gradient_transform`` itself.
+
+    >>> dev_ex = DeviceExecutor(ExecutionConfig(), DefaultQubit2())
+    >>> gradient_kwargs = {}
+    >>> par_shift = TransformContainer(qml.gradients.param_shift, kwargs = gradient_kwargs)
+    >>> derivatives_executor = TransformDerivatives(dev_ex, par_shift)
+
+    To accomplish higher order derivatives, the provided executor can already be registered with
+    a machine learning library.
+
+    >>> jax_layer = get_interface_layer("jax")(dev_ex, derivatives_executor)
+    >>> second_order_derivatives = TransformDerivatives(jax_layer, par_shift)
+    >>> jax_layer2 = get_interface_layer("jax")(jax_layer, second_order_derivatives)
+
+    """
+
+    def __init__(
+        self,
+        inner_execute: Callable,
+        gradient_transform: "qml.gradients.gradient_transform",
+        gradient_kwargs: Optional[dict] = None,
+    ):
+        self._inner_execute = inner_execute
+        self._gradient_transform = gradient_transform
+        self._gradient_kwargs = gradient_kwargs or {}
+
+    def execute_and_compute_jvp(self, tapes, tangents):
+
+        num_result_tapes = len(tapes)
+
+        jvp_tapes, jvp_processing_fn = qml.gradients.batch_jvp(
+            tapes, tangents, self._gradient_transform, gradient_kwargs=self._gradient_kwargs
+        )
+
+        full_batch = tapes + tuple(jvp_tapes)
+
+        full_results = self._inner_execute(full_batch)
+
+        results = full_results[:num_result_tapes]
+        jvp_results = full_results[num_result_tapes:]
+        jvps = jvp_processing_fn(jvp_results)
+
+        return tuple(results), tuple(jvps)
+
+    def compute_jvp(self, tapes, tangents):
+        jvp_tapes, jvp_processing_fn = qml.gradients.batch_jvp(
+            tapes, tangents, self._gradient_transform, gradient_kwargs=self._gradient_kwargs
+        )
+        jvp_results = self._inner_execute(jvp_tapes)
+
+        return tuple(jvp_processing_fn(jvp_results))
+
+    def execute_and_compute_vjp(self, tapes, dy) -> Tuple[ResultBatch, Tuple]:
+        num_result_tapes = len(tapes)
+
+        numpy_tapes = tuple(qml.transforms.convert_to_numpy_parameters(t) for t in tapes)
+        jvp_tapes, vjp_processing_fn = qml.gradients.batch_vjp(
+            numpy_tapes, dy, self._gradient_transform, gradient_kwargs=self._gradient_kwargs
+        )
+
+        full_batch = tuple(tapes) + tuple(jvp_tapes)
+
+        full_results = self._inner_execute(full_batch)
+
+        results = full_results[:num_result_tapes]
+        vjp_results = full_results[num_result_tapes:]
+
+        vjps = vjp_processing_fn(vjp_results)
+        return tuple(results), tuple(vjps)
+
+    def compute_vjp(self, tapes, dy):
+        numpy_tapes = tuple(qml.transforms.convert_to_numpy_parameters(t) for t in tapes)
+        vjp_tapes, processing_fn = qml.gradients.batch_vjp(
+            numpy_tapes, dy, self._gradient_transform, gradient_kwargs=self._gradient_kwargs
+        )
+
+        vjp_results = self._inner_execute(vjp_tapes)
+
+        return tuple(processing_fn(vjp_results))
+
+
+class DeviceDerivatives(DerivativeExecutor):
+    """Compute vjp and jvps using device provided derivatives.
+
+    Args:
+        device (Device): the device to use to compute derivatives
+        execution_config (ExecutionConfig): the configuration for the device
+
+    >>> dev = DefaultQubit2()
+    >>> config = ExecutionConfig(use_device_gradient=True, gradient_method="adjoint")
+    >>> derivatives_executor = DeviceDerivatives(dev, config_device_derivative)
+
+    To calculate and cache the jacobian on the forward pass of an excution, this class can
+    also be used as an ``Executor``.
+
+    >>> tape0 = qml.tape.QuantumScript([qml.RX(0.1, wires=0)], [qml.expval(qml.PauliZ(0))])
+    >>> batch = (tape0, )
+    >>> with dev.tracker:
+    ...     derivatives_executor(batch)
+    >>> dev.tracker.totals
+    {'execute_and_compute_derivative_batches': 1,
+    'batches': 1,
+    'executions': 1,
+    'derivative_batches': 1,
+    'derivatives': 1}
+    >>> with dev.tracker:
+    ...     derivatives_executor.compute_vjp(batch, tangent_variables)
+    >>> dev.tracker.totals
+    {}
+    >>> derivatives_executor._jacobian_cache
+    {(<QuantumScript: wires=[0], params=1>,): (array(-0.09983342),)}
+
+    Note that caching is based on the *identity* of the input, not its contents. Identical
+    batches at different locations in memory will be cached separately. This is to spend less
+    time computing the hash.
+    """
+
+    def __repr__(self):
+        return f"Device derivatives({self._device})"
+
+    def __init__(self, device, execution_config):
+        self._device = device
+        self._execution_config = execution_config
+        self._jacobian_cache = {}
+        self._results_cache = {}
+
+    def __call__(self, tapes):
+        tapes = tuple(tapes)
+        if tapes not in self._jacobian_cache:
+            unwrapped_tapes = tuple(qml.transforms.convert_to_numpy_parameters(t) for t in tapes)
+            results, jacs = self._device.execute_and_compute_derivatives(
+                unwrapped_tapes, self._execution_config
+            )
+            self._results_cache[tapes] = results
+            self._jacobian_cache[tapes] = jacs
+        return self._results_cache[tapes]
+
+    def execute_and_compute_jvp(self, tapes, tangents):
+        tapes = tuple(qml.transforms.convert_to_numpy_parameters(t) for t in tapes)
+        multi_measurements = [len(tape.measurements) > 1 for tape in tapes]
+
+        if tapes not in self._jacobian_cache:
+            results, jacs = self._device.execute_and_compute_derivatives(
+                tapes, self._execution_config
+            )
+            self._jacobian_cache[tapes] = jacs
+            self._results_cache[tapes] = results
+
+        jvps = _compute_jvps(self._jacobian_cache[tapes], tangents, multi_measurements)
+        return self._results_cache[tapes], jvps
+
+    def compute_jvp(self, tapes, tangents):
+        tapes = tuple(qml.transforms.convert_to_numpy_parameters(t) for t in tapes)
+        if tapes not in self._jacobian_cache:
+            jacs = self._device.compute_derivatives(tapes, self._execution_config)
+            self._jacobian_cache[tapes] = jacs
+
+        multi_measurements = [len(tape.measurements) > 1 for tape in tapes]
+        return _compute_jvps(self._jacobian_cache[tapes], tangents, multi_measurements)
+
+    def execute_and_compute_vjp(self, tapes, dy) -> Tuple[ResultBatch, Tuple]:
+        tapes = tuple(qml.transforms.convert_to_numpy_parameters(t) for t in tapes)
+        if tapes not in self._jacobian_cache:
+            results, jacs = self._device.execute_and_compute_derivatives(
+                tapes, self._execution_config
+            )
+            self._results_cache[tapes] = results
+            self._jacobian_cache[jacs] = jacs
+
+        multi_measurements = [len(tape.measurements) > 1 for tape in tapes]
+        vjps = _compute_vjps(dy, self._jacobian_cache[tapes], multi_measurements)
+        return tuple(results), tuple(vjps)
+
+    def compute_vjp(self, tapes, dy):
+        tapes = tuple(qml.transforms.convert_to_numpy_parameters(t) for t in tapes)
+        multi_measurements = (len(t.measurements) > 1 for t in tapes)
+
+        if tapes not in self._jacobian_cache:
+            unwrapped_tapes = tuple(qml.transforms.convert_to_numpy_parameters(t) for t in tapes)
+            jacs = self._device.compute_derivatives(unwrapped_tapes, self._execution_config)
+            self._jacobian_cache[tapes] = jacs
+
+        return _compute_vjps(dy, self._jacobian_cache[tapes], multi_measurements)

--- a/pennylane/interfaces/jax.py
+++ b/pennylane/interfaces/jax.py
@@ -408,8 +408,6 @@ def execute(tapes, execute_fn, vjp_fn, device=None):
         """Primals[0] are parameters as Jax tracers and tangents[0] is a list of tangent vectors as Jax tracers."""
         new_tapes = set_parameters_on_copy_and_unwrap(tapes, primals[0], unwrap=False)
         res, jvps = vjp_fn.execute_and_compute_jvp(new_tapes, tangents[0])
-        print(res)
-        print(jvps)
         return res, jvps
 
     return _to_jax(execute_wrapper(parameters))

--- a/pennylane/interfaces/jax.py
+++ b/pennylane/interfaces/jax.py
@@ -369,7 +369,7 @@ def _execute_fwd_legacy(
     return res
 
 
-def execute(tapes, execute_fn, vjp_fn, device=None):
+def execute(tapes, execute_fn, vjp_fn):
     """Execute a batch of tapes with JAX parameters on a device.
 
     Args:

--- a/pennylane/interfaces/jax.py
+++ b/pennylane/interfaces/jax.py
@@ -369,7 +369,7 @@ def _execute_fwd_legacy(
     return res
 
 
-def execute(tapes, execute_fn, vjp_fn):
+def execute(tapes, execute_fn, vjp_fn, device=None):
     """Execute a batch of tapes with JAX parameters on a device.
 
     Args:

--- a/pennylane/interfaces/jax.py
+++ b/pennylane/interfaces/jax.py
@@ -403,14 +403,14 @@ def execute(tapes, execute_fn, vjp_fn):
 
     @jax.custom_jvp
     def execute_wrapper(params):
-        new_tapes = set_parameters_on_copy_and_unwrap(tapes, params)
+        new_tapes = set_parameters_on_copy_and_unwrap(tapes, params, unwrap=False)
         res = execute_fn(new_tapes)
         return _to_jax_shot_vector(res) if has_partitioned_shots else _to_jax(res)
 
     @execute_wrapper.defjvp
     def execute_wrapper_jvp(primals, tangents):
         """Primals[0] are parameters as Jax tracers and tangents[0] is a list of tangent vectors as Jax tracers."""
-        new_tapes = set_parameters_on_copy_and_unwrap(tapes, primals[0])
+        new_tapes = set_parameters_on_copy_and_unwrap(tapes, primals[0], unwrap=False)
         return vjp_fn.execute_and_compute_jvp(new_tapes, tangents[0])
 
     return _to_jax(execute_wrapper(parameters))

--- a/pennylane/interfaces/jax.py
+++ b/pennylane/interfaces/jax.py
@@ -393,10 +393,6 @@ def execute(tapes, execute_fn, vjp_fn, device=None):
         list[list[float]]: A nested list of tape results. Each element in
         the returned list corresponds in order to the provided tapes.
     """
-    # Set the trainable parameters
-    for tape in tapes:
-        params = tape.get_parameters(trainable_only=False)
-        tape.trainable_params = qml.math.get_trainable_indices(params)
 
     parameters = tuple(list(t.get_parameters()) for t in tapes)
     has_partitioned_shots = tapes[0].shots.has_partitioned_shots
@@ -411,7 +407,10 @@ def execute(tapes, execute_fn, vjp_fn, device=None):
     def execute_wrapper_jvp(primals, tangents):
         """Primals[0] are parameters as Jax tracers and tangents[0] is a list of tangent vectors as Jax tracers."""
         new_tapes = set_parameters_on_copy_and_unwrap(tapes, primals[0], unwrap=False)
-        return vjp_fn.execute_and_compute_jvp(new_tapes, tangents[0])
+        res, jvps = vjp_fn.execute_and_compute_jvp(new_tapes, tangents[0])
+        print(res)
+        print(jvps)
+        return res, jvps
 
     return _to_jax(execute_wrapper(parameters))
 

--- a/pennylane/interfaces/jax_jit_tuple.py
+++ b/pennylane/interfaces/jax_jit_tuple.py
@@ -110,7 +110,7 @@ def _filter_zeros_tangents(tangents):
     return non_zeros_tangents
 
 
-def execute(tapes, execute_fn, vjp_fn):
+def execute(tapes, device, execute_fn, gradient_fn, gradient_kwargs, _n=1, max_diff=1):
     """Execute a batch of tapes with JAX parameters on a device.
 
     Args:
@@ -149,28 +149,48 @@ def execute(tapes, execute_fn, vjp_fn):
 
     parameters = tuple(list(t.get_parameters(trainable_only=False)) for t in tapes)
 
+    if gradient_fn is None:
+        return _execute_fwd(
+            parameters,
+            tapes=tapes,
+            device=device,
+            execute_fn=execute_fn,
+            gradient_kwargs=gradient_kwargs,
+            _n=_n,
+        )
+
     return _execute_bwd(
         parameters,
         tapes=tapes,
+        device=device,
         execute_fn=execute_fn,
-        vjp_fn=vjp_fn,
+        gradient_fn=gradient_fn,
+        gradient_kwargs=gradient_kwargs,
+        _n=_n,
+        max_diff=max_diff,
     )
 
 
 def _execute_bwd(
     params,
     tapes=None,
+    device=None,
     execute_fn=None,
-    vjp_fn=None,
-):  # pylint: disable=unused-argument
+    gradient_fn=None,
+    gradient_kwargs=None,
+    _n=1,
+    max_diff=2,
+):  # pylint: disable=dangerous-default-value,unused-argument
+    is_experimental_device = isinstance(device, qml.devices.experimental.Device)
+
     @jax.custom_jvp
     def execute_wrapper(params):
         shape_dtype_structs = _tapes_shape_dtype_tuple(tapes, device)
 
         def wrapper(p):
             """Compute the forward pass."""
-            new_tapes = set_parameters_on_copy_and_unwrap(tapes, p, unwrap=False)
-            res = execute_fn(new_tapes)
+            new_tapes = set_parameters_on_copy_and_unwrap(tapes, p)
+            res, _ = execute_fn(new_tapes, **gradient_kwargs)
             res = tuple(res)
 
             # When executed under `jax.vmap` the `result_shapes_dtypes` will contain

--- a/pennylane/interfaces/pure_callback.py
+++ b/pennylane/interfaces/pure_callback.py
@@ -48,6 +48,30 @@ def _create_shape_dtype_struct(tape: "qml.tape.QuantumScript", device: "qml.Devi
     return tuple(jax.ShapeDtypeStruct(tuple(s), d) for s, d in zip(shape, tape_dtype))
 
 
+def _jac_shape_dtype_struct(tape: "qml.tape.QuantumScript", device: "qml.Device"):
+    """The shape of a jacobian for a single tape given a device.
+
+    Args:
+        tape (QuantumTape): the tape who's output we want to determine
+        device (Device): the device used to execute the tape.
+
+    >>> tape = qml.tape.QuantumScript([qml.RX(1.0, wires=0)], [qml.expval(qml.PauliX(0)), qml.probs(0)])
+    >>> dev = qml.devices.experimental.DefaultQubit2()
+    >>> _jac_shape_dtype_struct(tape, dev)
+    (ShapeDtypeStruct(shape=(), dtype=float64),
+    ShapeDtypeStruct(shape=(2,), dtype=float64))
+    >>> tapes, fn = qml.gradients.param_shift(tape)
+    >>> fn(dev.execute(tapes))
+    (array(0.), array([-0.42073549,  0.42073549]))
+    """
+    shape_and_dtype = _create_shape_dtype_struct(tape, device)
+    if len(tape.trainable_params) == 1:
+        return shape_and_dtype
+    if len(tape.measurements) == 1:
+        return tuple(shape_and_dtype for _ in tape.trainable_params)
+    return tuple(tuple(_s for _ in tape.trainable_params) for _s in shape_and_dtype)
+
+
 def make_pure_callback(device, config):
     def pure_callback_execution(tapes):
         shape_dtype_structs = tuple(_create_shape_dtype_struct(t, device) for t in tapes)
@@ -64,3 +88,46 @@ def make_pure_callback(device, config):
         return jax.pure_callback(callback_fn, shape_dtype_structs, parameters)
 
     return pure_callback_execution
+
+
+def _old_device_jac_via_callback(tapes, device, gradient_kwargs):
+    parameters = tuple(tuple(t.get_parameters(trainable_only=False)) for t in tapes)
+    shape_dtype_structs = tuple(_jac_shape_dtype_struct(t, device) for t in tapes)
+
+    def wrapper(inner_params):
+        new_tapes = tuple(
+            t.bind_new_parameters(p, list(range(len(p)))) for t, p in zip(tapes, inner_params)
+        )
+        new_tapes = tuple(qml.transforms.convert_to_numpy_parameters(t) for t in new_tapes)
+        return device.gradients(new_tapes, **gradient_kwargs)
+
+    return jax.pure_callback(wrapper, shape_dtype_structs, parameters)
+
+
+def _new_device_jac_via_callback(tapes, device, config):
+    parameters = tuple(tuple(t.get_parameters(trainable_only=False)) for t in tapes)
+    shape_dtype_structs = tuple(_jac_shape_dtype_struct(t, device) for t in tapes)
+
+    def wrapper(inner_params):
+        new_tapes = tuple(
+            t.bind_new_parameters(p, list(range(len(p)))) for t, p in zip(tapes, inner_params)
+        )
+        new_tapes = tuple(qml.transforms.convert_to_numpy_parameters(t) for t in new_tapes)
+        return device.compute_derivatives(new_tapes, execution_config=config)
+
+    return jax.pure_callback(wrapper, shape_dtype_structs, parameters)
+
+
+def _new_device_execute_and_jac(tapes, device, config):
+    parameters = tuple(tuple(t.get_parameters(trainable_only=False)) for t in tapes)
+    jac_dtype_structs = tuple(_jac_shape_dtype_struct(t, device) for t in tapes)
+    res_dtype_structs = tuple(_create_shape_dtype_struct(t, device) for t in tapes)
+
+    def wrapper(inner_params):
+        new_tapes = tuple(
+            t.bind_new_parameters(p, list(range(len(p)))) for t, p in zip(tapes, inner_params)
+        )
+        new_tapes = tuple(qml.transforms.convert_to_numpy_parameters(t) for t in new_tapes)
+        return device.execute_and_compute_derivatives(new_tapes, execution_config=config)
+
+    return jax.pure_callback(wrapper, (res_dtype_structs, jac_dtype_structs), parameters)

--- a/pennylane/interfaces/tensorflow.py
+++ b/pennylane/interfaces/tensorflow.py
@@ -329,10 +329,9 @@ def execute(tapes, execute_fn, vjp_fn, device=None):
         has_partitioned_shots = vjp_shots = device.shot_vector
         legacy_shots = Shots(device.shot_vector or 1)
 
-    for i, tape in enumerate(tapes):
+    for tape in tapes:
         # store the trainable parameters
         params = tape.get_parameters(trainable_only=False)
-        tape.trainable_params = qml.math.get_trainable_indices(params)
 
         parameters += [p for i, p in enumerate(params) if i in tape.trainable_params]
 

--- a/pennylane/interfaces/tensorflow.py
+++ b/pennylane/interfaces/tensorflow.py
@@ -291,7 +291,7 @@ def _execute_legacy(
     return _execute(*parameters)
 
 
-def execute(tapes, execute_fn, vjp_fn):
+def execute(tapes, execute_fn, vjp_fn, device=None):
     """Execute a batch of tapes with TensorFlow parameters on a device.
 
     Args:

--- a/pennylane/interfaces/torch.py
+++ b/pennylane/interfaces/torch.py
@@ -356,7 +356,6 @@ class ExecuteTapes(torch.autograd.Function):
         # split tensor into separate entries
         unpacked_vjps = []
         for vjp_slice in vjps:
-
             if vjp_slice is not None and np.squeeze(vjp_slice).shape != (0,):
                 unpacked_vjps.extend(vjp_slice)
         vjps = tuple(unpacked_vjps)

--- a/pennylane/interfaces/torch.py
+++ b/pennylane/interfaces/torch.py
@@ -330,7 +330,6 @@ class ExecuteTapes(torch.autograd.Function):
     def forward(ctx, kwargs, *parameters):  # pylint: disable=arguments-differ
         """Implements the forward pass batch tape evaluation."""
         ctx.tapes = kwargs["tapes"]
-        print("forward parameters: ", parameters)
         ctx.execute_fn = kwargs["execute_fn"]
         ctx.vjp_fn = kwargs["vjp_fn"]
 
@@ -355,10 +354,10 @@ class ExecuteTapes(torch.autograd.Function):
         vjps = ctx.vjp_fn.compute_vjp(ctx.tapes, dy)
 
         # split tensor into separate entries
-        print("here: ", vjps)
         unpacked_vjps = []
         for vjp_slice in vjps:
-            if vjp_slice is not None and list(vjp_slice.shape) != [0]:
+
+            if vjp_slice is not None and np.squeeze(vjp_slice).shape != (0,):
                 unpacked_vjps.extend(vjp_slice)
         vjps = tuple(unpacked_vjps)
 

--- a/pennylane/interfaces/torch.py
+++ b/pennylane/interfaces/torch.py
@@ -367,7 +367,7 @@ class ExecuteTapes(torch.autograd.Function):
         return (None,) + vjps
 
 
-def execute(tapes, execute_fn, vjp_fn, device=None):
+def execute(tapes, execute_fn, vjp_fn):
     """Execute a batch of tapes with Torch parameters on a device.
     This function may be called recursively, if ``gradient_fn`` is a differentiable
     transform, and ``_n < max_diff``.

--- a/pennylane/interfaces/torch.py
+++ b/pennylane/interfaces/torch.py
@@ -369,7 +369,7 @@ class ExecuteTapes(torch.autograd.Function):
         return (None,) + vjps
 
 
-def execute(tapes, execute_fn, vjp_fn):
+def execute(tapes, execute_fn, vjp_fn, device=None):
     """Execute a batch of tapes with Torch parameters on a device.
     This function may be called recursively, if ``gradient_fn`` is a differentiable
     transform, and ``_n < max_diff``.

--- a/pennylane/tape/qscript.py
+++ b/pennylane/tape/qscript.py
@@ -748,7 +748,6 @@ class QuantumScript:
             .tape.QuantumScript: New tape with updated parameters
         """
         # pylint: disable=no-member
-
         if len(params) != len(indices):
             raise ValueError("Number of provided parameters does not match number of indices")
 

--- a/tests/interfaces/default_qubit_2_integration/test_tensorflow_default_qubit_2.py
+++ b/tests/interfaces/default_qubit_2_integration/test_tensorflow_default_qubit_2.py
@@ -540,7 +540,9 @@ class TestHigherOrderDerivatives:
                 [tf.sin(2 * x) * tf.sin(2 * y), -2 * tf.cos(x) ** 2 * tf.cos(2 * y)],
             ]
         )
-        assert np.allclose(hess, expected, atol=tol, rtol=0)
+        print(hess)
+        print(expected)
+        assert qml.math.allclose(hess, expected, atol=tol, rtol=0)
 
     def test_max_diff(self, tol):
         """Test that setting the max_diff parameter blocks higher-order

--- a/tests/interfaces/test_autograd.py
+++ b/tests/interfaces/test_autograd.py
@@ -288,7 +288,7 @@ class TestCaching:
         # hence we do 5 evaluations
         params = np.array([0.1, 0.2])
         qml.jacobian(cost)(params, cache=None)
-        assert dev.num_executions == 5
+        assert dev.num_executions == 9
 
         # With caching, 5 evaluations are required to compute
         # the Jacobian: 1 (forward pass) + (2 shifts * 2 params)


### PR DESCRIPTION
See ADR PR#67: https://github.com/PennyLaneAI/adrs/pull/67

This Prototype is simply a proof of concept that will be implemented over the course of multiple PRs.

### Key changes:

* Addition of `DerivativesExector` (name in need of help), `TransformDerivatives`, and `DeviceDerivatives` as classes private to the `interfaces` module
* Changes of call signatures of for interface binding  functions from

```
# typing generic stand in for jacobians
Jac = TypeVar("Jac", Tuple, TensorLike)

Batch = Tuple[QuantumScript]

inner_execute_fn = Callable[[Batch, **kwargs], Tuple[ResultBatch, Jac]]
device_jac_fn = Callable[[Batch, **kwargs], Jac]

execute(tapes: Batch,
    device: Device,
    execute_fn: inner_execute_fn,
    gradient_fn: Optional[gradient_transform, device_jac_fn],
    gradient_kwargs: Optional[dict],
    _n: int = 1,
    max_diff:int = 2)
    ->
    ResultBatch:
```
to
```
inner_execute_fn = Callable[[Batch], ResultBatch]

execute(
    tapes: Batch
    execute_fn: inner_execute_fn,
    vjp_fn: DerivativesExecutor
    ) -> ResultBatch:
```

* Disentangling the legacy code from the new return types code.  Legacy functions only call legacy functions, and new system functions purely call new system functions.  This allows to change the call signature for purely the new functions.



### Remaining Challenges:

* Higher order derivatives. It should theoretically work, but for some reason it is not
* Torch "extend" paradigm. Need to figure out how to convert from "append" to "extend" stacking structures.
* Jax Jit. I need to figure out what this code is doing.