### PR TITLE
call ctrl again if given a function; non-custom op in tests

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -69,6 +69,9 @@
   the JVP and VJP of a tape using the adjoint method.
   [(#4358)](https://github.com/PennyLaneAI/pennylane/pull/4358)
 
+* When given a callable, `qml.ctrl` now does its custom pre-processing on all queued operators from the callable.
+  [(#4370)](https://github.com/PennyLaneAI/pennylane/pull/4370)
+
 <h3>Breaking changes 💔</h3>
 
 * The `do_queue` keyword argument in `qml.operation.Operator` has been removed. Instead of

--- a/pennylane/ops/op_math/controlled.py
+++ b/pennylane/ops/op_math/controlled.py
@@ -126,9 +126,7 @@ def ctrl(op, control, control_values=None, work_wires=None):
             _ = [qml.PauliX(w) for w, val in zip(control, control_values) if not val]
 
         _ = [
-            Controlled(
-                op, control_wires=control, control_values=op_control_values, work_wires=work_wires
-            )
+            ctrl(op, control=control, control_values=op_control_values, work_wires=work_wires)
             for op in qscript.operations
         ]
 


### PR DESCRIPTION
**Context:**
Same motivation as #4339 (to make my tutorial look nicer), except it actually works! Turns out we don't pass the base to `ctrl` directly in `defer_measurements`, but we instead give it a lambda. So we need a callable argument to `ctrl` to also take advantage of `ctrl`'s custom logic.

**Description of the Change:**
Use `ctrl` instead of `Controlled` inside the wrapper function created when a callable is passed to `ctrl`

**Benefits:**
Operators queued in some callable passed to `ctrl` also get the custom processing from `ctrl`

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
Expands on #4339 