### PR TITLE
Correct `jordan_wigner` to work with active space

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -168,6 +168,9 @@
   have a batch dimension.
   [(#4353)](https://github.com/PennyLaneAI/pennylane/pull/4353)
 
+* The `jordan_wigner` function is modified to work with Hamiltonians built with an active space.
+  [(#4372)](https://github.com/PennyLaneAI/pennylane/pull/4372)
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane/fermi/conversion.py
+++ b/pennylane/fermi/conversion.py
@@ -124,13 +124,13 @@ def _(fermi_operator: FermiSentence, ps=False, wire_map=None):
     wires = list(fermi_operator.wires) or [0]
     identity_wire = wires[0]
 
-    qubit_operator = PauliSentence({PauliWord({}): 0j})
+    qubit_operator = PauliSentence()
 
     for fw, coeff in fermi_operator.items():
         fermi_word_as_ps = jordan_wigner(fw, ps=True)
 
         for pw in fermi_word_as_ps:
-            qubit_operator[pw] += fermi_word_as_ps[pw] * coeff
+            qubit_operator[pw] = qubit_operator[pw] + fermi_word_as_ps[pw] * coeff
 
     if not ps:
         qubit_operator = qubit_operator.operation(wire_order=[identity_wire])

--- a/pennylane/fermi/conversion.py
+++ b/pennylane/fermi/conversion.py
@@ -124,17 +124,13 @@ def _(fermi_operator: FermiSentence, ps=False, wire_map=None):
     wires = list(fermi_operator.wires) or [0]
     identity_wire = wires[0]
 
-    if len(fermi_operator) == 0:
-        qubit_operator = PauliSentence({PauliWord({}): 0})  # does anything break if I remove this?
+    qubit_operator = PauliSentence({PauliWord({}): 0j})
 
-    else:
-        qubit_operator = PauliSentence()
+    for fw, coeff in fermi_operator.items():
+        fermi_word_as_ps = jordan_wigner(fw, ps=True)
 
-        for fw, coeff in fermi_operator.items():
-            fermi_word_as_ps = jordan_wigner(fw, ps=True)
-
-            for pw in fermi_word_as_ps:
-                qubit_operator[pw] += fermi_word_as_ps[pw] * coeff
+        for pw in fermi_word_as_ps:
+            qubit_operator[pw] += fermi_word_as_ps[pw] * coeff
 
     if not ps:
         qubit_operator = qubit_operator.operation(wire_order=[identity_wire])

--- a/tests/qchem/test_hamiltonians.py
+++ b/tests/qchem/test_hamiltonians.py
@@ -367,6 +367,26 @@ def test_diff_hamiltonian(symbols, geometry, h_ref_data, fs):
     )
 
 
+def test_diff_hamiltonian_active_space():
+    r"""Test that diff_hamiltonian works when an active space is defined."""
+
+    symbols = ["H", "H", "H"]
+    geometry = np.array([[0.0, 0.0, 0.0], [2.0, 0.0, 1.0], [0.0, 2.0, 0.0]])
+
+    mol = qchem.Molecule(symbols, geometry, charge=1)
+    args = [geometry]
+
+    h = qchem.diff_hamiltonian(mol, core=[0], active=[1, 2])(*args)
+
+    assert isinstance(h, qml.Hamiltonian)
+
+    enable_new_opmath()
+    h_op = qchem.diff_hamiltonian(mol, core=[0], active=[1, 2])(*args)
+    disable_new_opmath()
+
+    assert not isinstance(h_op, qml.Hamiltonian)
+
+
 @pytest.mark.parametrize("fs", [True, False])
 def test_gradient_expvalH(fs):
     r"""Test that the gradient of expval(H) computed with ``qml.grad`` is equal to the value


### PR DESCRIPTION
**Context:**
The `jordan_wigner` function gives a type casting error when an active space is defined for the Hamiltonian. This PR fixes this issue by using correct types.

**Description of the Change:**
The in-place addition of the Pauli sentence in `jordan_wigner`  is modified and the new test  `test_diff_hamiltonian_active_space` is added.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
