### PR TITLE
[PROTOTYPE] Expanding mid-circuit measurement functionality

### DIFF
--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -6,6 +6,12 @@ Deprecations
 Pending deprecations
 --------------------
 
+* The `RandomLayers.compute_decomposition` keyword argument `ratio_imprivitive` will be changed to `ratio_imprim` to
+  match the call signature of the operation. 
+
+  - Deprecated in v0.32
+  - Removed in v0.33
+
 * ``qml.enable_return`` and ``qml.disable_return`` are deprecated. Please avoid calling
   ``disable_return``, as the old return system is deprecated along with these switch functions.
 

--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -66,6 +66,12 @@ Pending deprecations
   - Deprecated in v0.32
   - Will be removed in v0.33
 
+* The ``QuantumScript.set_parameters`` method and the ``QuantumScript.data`` setter has
+  been deprecated. Please use ``QuantumScript.bind_new_parameters`` instead.
+
+  - Deprecated in v0.32
+  - Will be removed in v0.33
+
 
 Completed deprecation cycles
 ----------------------------

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -97,6 +97,10 @@
   old return system (which is also deprecated). Please use `grad_on_execution` instead.
   [(#4316)](https://github.com/PennyLaneAI/pennylane/pull/4316)
 
+* The `QuantumScript.set_parameters` method and the `QuantumScript.data` setter has
+  been deprecated. Please use `QuantumScript.bind_new_parameters` instead.
+  [(#4346)](https://github.com/PennyLaneAI/pennylane/pull/4346)
+
 <h3>Documentation 📝</h3>
 
 * `qml.ApproxTimeEvolution.compute_decomposition()` now has a code example.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -6,6 +6,11 @@
 
 <h3>Improvements 🛠</h3>
 
+* All `Operator` objects now define `Operator._flatten` and `Operator._unflatten` methods that separate
+  trainable from untrainable components. These methods will be used in serialization and pytree registration.
+  Custom operations may need an update to ensure compatibility with new PennyLane features.
+  [(#4314)](https://github.com/PennyLaneAI/pennylane/pull/4314)
+
 * Treat auxiliary wires and device wires in the same way in `transforms.metric_tensor`
   as in `gradients.hadamard_grad`. Support all valid wire input formats for `aux_wire`.
   [(#4328)](https://github.com/PennyLaneAI/pennylane/pull/4328)
@@ -84,6 +89,10 @@
   [(#4322)](https://github.com/PennyLaneAI/pennylane/pull/4322)
 
 <h3>Deprecations 👋</h3>
+
+* The `qml.RandomLayers.compute_decomposition` keyword argument `ratio_imprimitive` will be changed to `ratio_imprim` to
+  match the call signature of the operation.
+  [(#4314)](https://github.com/PennyLaneAI/pennylane/pull/4314)
 
 * The CV observables ``qml.X`` and ``qml.P`` have been deprecated. Use ``qml.QuadX`` 
   and ``qml.QuadP`` instead.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -47,6 +47,9 @@
 * `qml.ctrl(qml.PauliX)` returns a `CNOT`, `Toffoli` or `MultiControlledX` instead of a `Controlled(PauliX)`.
   [(#4339)](https://github.com/PennyLaneAI/pennylane/pull/4339)
 
+* The experimental device interface is integrated with the `QNode` for Jax jit.
+  [(#4352)](https://github.com/PennyLaneAI/pennylane/pull/4352)
+
 <h3>Breaking changes 💔</h3>
 
 * The `do_queue` keyword argument in `qml.operation.Operator` has been removed. Instead of

--- a/pennylane/devices/qubit/measure.py
+++ b/pennylane/devices/qubit/measure.py
@@ -131,6 +131,9 @@ def get_measurement_function(
         Callable: function that returns the measurement result
     """
     if isinstance(measurementprocess, StateMeasurement):
+        if measurementprocess.mid_measure:
+            return state_diagonalizing_gates
+
         if isinstance(measurementprocess, ExpectationMP):
             if measurementprocess.obs.name == "SparseHamiltonian":
                 return csr_dot_products
@@ -153,7 +156,7 @@ def get_measurement_function(
 
                     return csr_dot_products
 
-        if measurementprocess.obs is None or isinstance(measurementprocess.obs, MeasurementValue) or measurementprocess.obs.has_diagonalizing_gates:
+        if measurementprocess.obs is None or measurementprocess.obs.has_diagonalizing_gates:
             return state_diagonalizing_gates
 
     raise NotImplementedError

--- a/pennylane/devices/qubit/measure.py
+++ b/pennylane/devices/qubit/measure.py
@@ -20,7 +20,7 @@ from scipy.sparse import csr_matrix
 
 from pennylane import math
 from pennylane.ops import Sum, Hamiltonian
-from pennylane.measurements import StateMeasurement, MeasurementProcess, ExpectationMP
+from pennylane.measurements import StateMeasurement, MeasurementProcess, ExpectationMP, MeasurementValue
 from pennylane.typing import TensorLike
 from pennylane.wires import Wires
 
@@ -153,7 +153,7 @@ def get_measurement_function(
 
                     return csr_dot_products
 
-        if measurementprocess.obs is None or measurementprocess.obs.has_diagonalizing_gates:
+        if measurementprocess.obs is None or isinstance(measurementprocess.obs, MeasurementValue) or measurementprocess.obs.has_diagonalizing_gates:
             return state_diagonalizing_gates
 
     raise NotImplementedError

--- a/pennylane/devices/qubit/preprocess.py
+++ b/pennylane/devices/qubit/preprocess.py
@@ -24,12 +24,13 @@ import pennylane as qml
 
 from pennylane.operation import Tensor
 from pennylane.measurements import (
-    MidMeasureMP,
-    StateMeasurement,
-    SampleMeasurement,
-    ExpectationMP,
     ClassicalShadowMP,
+    ExpectationMP,
+    MeasurementValue,
+    MidMeasureMP,
+    SampleMeasurement,
     ShadowExpvalMP,
+    StateMeasurement,
 )
 from pennylane.typing import ResultBatch, Result
 from pennylane import DeviceError
@@ -242,7 +243,7 @@ def expand_fn(circuit: qml.tape.QuantumScript) -> qml.tape.QuantumScript:
         if isinstance(observable, Tensor):
             if any(o.name not in _observables for o in observable.obs):
                 raise DeviceError(f"Observable {observable} not supported on DefaultQubit2")
-        elif observable.name not in _observables:
+        elif not isinstance(observable, MeasurementValue) and observable.name not in _observables:
             raise DeviceError(f"Observable {observable} not supported on DefaultQubit2")
 
     return circuit

--- a/pennylane/devices/qubit/simulate.py
+++ b/pennylane/devices/qubit/simulate.py
@@ -72,7 +72,7 @@ def simulate(circuit: qml.tape.QuantumScript, rng=None, debugger=None) -> Result
         # analytic case
 
         if len(circuit.measurements) == 1:
-            return measure(circuit.measurements[0], state)
+            return measure(circuit.measurements[0], state, is_state_batched=is_state_batched)
 
         return tuple(
             measure(mp, state, is_state_batched=is_state_batched) for mp in circuit.measurements
@@ -81,7 +81,13 @@ def simulate(circuit: qml.tape.QuantumScript, rng=None, debugger=None) -> Result
     # finite-shot case
 
     if len(circuit.measurements) == 1:
-        return measure_with_samples(circuit.measurements[0], state, shots=circuit.shots, rng=rng)
+        return measure_with_samples(
+            circuit.measurements[0],
+            state,
+            shots=circuit.shots,
+            is_state_batched=is_state_batched,
+            rng=rng,
+        )
 
     rng = default_rng(rng)
     results = tuple(

--- a/pennylane/gradients/jvp.py
+++ b/pennylane/gradients/jvp.py
@@ -445,7 +445,7 @@ def batch_jvp(tapes, tangents, gradient_fn, shots=None, reduction="append", grad
             elif callable(reduction):
                 reduction(jvps, jvp_)
 
-        return jvps
+        return tuple(jvps)
 
     return gradient_tapes, processing_fn
 

--- a/pennylane/interfaces/jax.py
+++ b/pennylane/interfaces/jax.py
@@ -543,7 +543,7 @@ def _compute_jvps(jacs, tangents, multi_measurements):
             qml.gradients.compute_jvp_multi if multi else qml.gradients.compute_jvp_single
         )
         jvps.append(compute_func(tangents[i], jacs[i]))
-    return jvps
+    return tuple(jvps)
 
 
 def _is_count_result(r):
@@ -568,7 +568,7 @@ def _to_jax(res):
                 else:
                     sub_r.append(jnp.array(r_i))
             res_.append(tuple(sub_r))
-    return res_
+    return tuple(res_)
 
 
 def _to_jax_shot_vector(res):
@@ -576,4 +576,4 @@ def _to_jax_shot_vector(res):
 
     The expected structure of the inputs is a list of tape results with each element in the list being a tuple due to execution using shot vectors.
     """
-    return [tuple(_to_jax([r_])[0] for r_ in r) for r in res]
+    return tuple(tuple(_to_jax([r_])[0] for r_ in r) for r in res)

--- a/pennylane/measurements/counts.py
+++ b/pennylane/measurements/counts.py
@@ -22,6 +22,7 @@ from pennylane.operation import Operator
 from pennylane.wires import Wires
 
 from .measurements import AllCounts, Counts, SampleMeasurement
+from .mid_measure import MeasurementValue
 
 
 def _sample_to_str(sample):
@@ -131,7 +132,7 @@ def counts(op=None, wires=None, all_outcomes=False) -> "CountsMP":
     {'00': 0, '01': 0, '10': 4, '11': 0}
 
     """
-    if op is not None and not op.is_hermitian:  # None type is also allowed for op
+    if op is not None and not isinstance(op, MeasurementValue) and not op.is_hermitian:  # None type is also allowed for op
         warnings.warn(f"{op.name} might not be hermitian.")
 
     if wires is not None:

--- a/pennylane/measurements/counts.py
+++ b/pennylane/measurements/counts.py
@@ -132,7 +132,9 @@ def counts(op=None, wires=None, all_outcomes=False) -> "CountsMP":
     {'00': 0, '01': 0, '10': 4, '11': 0}
 
     """
-    if op is not None and not isinstance(op, MeasurementValue) and not op.is_hermitian:  # None type is also allowed for op
+    if (
+        op is not None and not isinstance(op, MeasurementValue) and not op.is_hermitian
+    ):  # None type is also allowed for op
         warnings.warn(f"{op.name} might not be hermitian.")
 
     if wires is not None:
@@ -176,6 +178,7 @@ class CountsMP(SampleMeasurement):
         all_outcomes: bool = False,
     ):
         self.all_outcomes = all_outcomes
+        self.mid_measure = True if obs is not None and isinstance(obs, MeasurementValue) else False
         super().__init__(obs, wires, eigvals, id)
 
     def __repr__(self):

--- a/pennylane/measurements/expval.py
+++ b/pennylane/measurements/expval.py
@@ -15,7 +15,7 @@
 This module contains the qml.expval measurement.
 """
 import warnings
-from typing import Sequence, Tuple
+from typing import Sequence, Tuple, Optional
 
 import pennylane as qml
 from pennylane.operation import Operator
@@ -76,6 +76,16 @@ class ExpectationMP(SampleMeasurement, StateMeasurement):
             where the instance has to be identified
     """
 
+    def __init__(
+        self,
+        obs: Optional[Operator] = None,
+        wires: Optional[Wires] = None,
+        eigvals=None,
+        id: Optional[str] = None,
+    ):
+        self.mid_measure = True if obs is not None and isinstance(obs, MeasurementValue) else False
+        super().__init__(obs=obs, wires=wires, eigvals=eigvals, id=id)
+
     @property
     def return_type(self):
         return Expectation
@@ -116,6 +126,10 @@ class ExpectationMP(SampleMeasurement, StateMeasurement):
         samples = qml.sample(op=self.obs).process_samples(
             samples=samples, wire_order=wire_order, shot_range=shot_range, bin_size=bin_size
         )
+        if self.mid_measure:
+            powers_of_two = 2 ** qml.math.arange(num_wires)[::-1]
+            samples = samples @ powers_of_two
+
         # With broadcasting, we want to take the mean over axis 1, which is the -1st/-2nd with/
         # without bin_size. Without broadcasting, axis 0 is the -1st/-2nd with/without bin_size
         axis = -1 if bin_size is None else -2
@@ -130,12 +144,13 @@ class ExpectationMP(SampleMeasurement, StateMeasurement):
             return probs[idx]
 
         if self.mid_measure:
-            eigvals = qml.math.arange(0, 2**len(self.wires))
+            eigvals = qml.math.arange(0, 2 ** len(self.wires))
+            prob = qml.probs(wires=self.wires).process_state(state=state, wire_order=wire_order)
         else:
             eigvals = qml.math.asarray(self.obs.eigvals(), dtype="float64")
+            # we use ``self.wires`` instead of ``self.obs`` because the observable was
+            # already applied to the state
+            prob = qml.probs(wires=self.wires).process_state(state=state, wire_order=wire_order)
 
-        # we use ``self.wires`` instead of ``self.obs`` because the observable was
-        # already applied to the state
-        prob = qml.probs(wires=self.wires).process_state(state=state, wire_order=wire_order)
         # In case of broadcasting, `prob` has two axes and this is a matrix-vector product
         return qml.math.dot(prob, eigvals)

--- a/pennylane/measurements/mid_measure.py
+++ b/pennylane/measurements/mid_measure.py
@@ -246,9 +246,9 @@ class MeasurementValue(Generic[T]):
     def _merge(self, other: "MeasurementValue"):
         """Merge two measurement values"""
 
-        # create a new merged list with no duplicates and in lexical ordering
-        # all_ids_list = itertools.chain(*(self.measurement_ids + other.measurement_ids))
+        # create a new merged list with no duplicates
         all_measurement_ids = list(dict.fromkeys(self.measurement_ids + other.measurement_ids))
+        # Order the list lexicographically for merging sub functions
         merged_measurement_ids = sorted(all_measurement_ids)
 
         # create a new function that selects the correct indices for each sub function

--- a/pennylane/measurements/mid_measure.py
+++ b/pennylane/measurements/mid_measure.py
@@ -107,8 +107,16 @@ class MidMeasureMP(MeasurementProcess):
             Can be ``0`` or ``1``. ``None`` by default.
     """
 
-    def __init__(self, wires: Optional[Wires] = None, id: Optional[str] = None, reset: bool = False):
+    def __init__(
+        self,
+        wires: Optional[Wires] = None,
+        id: Optional[str] = None,
+        reset: bool = False,
+        postselect: Optional[int] = None,
+    ):
         super().__init__(wires=wires, id=id)
+        self.reset = reset
+        self.postselect = postselect
 
     @property
     def return_type(self):

--- a/pennylane/measurements/mid_measure.py
+++ b/pennylane/measurements/mid_measure.py
@@ -24,7 +24,7 @@ from pennylane.wires import Wires
 from .measurements import MeasurementProcess, MidMeasure
 
 
-def measure(wires):  # TODO: Change name to mid_measure
+def measure(wires, reset=False, postselect=None):  # TODO: Change name to mid_measure
     """Perform a mid-circuit measurement in the computational basis on the
     supplied qubit.
 
@@ -56,13 +56,19 @@ def measure(wires):  # TODO: Change name to mid_measure
     tensor([0.90165331, 0.09834669], requires_grad=True)
 
     Mid circuit measurements can be manipulated using the following dunder methods
-    `+`, `-`, `*`, `/`, `~` (not), `&` (and), `|` (or), `==`, `<=`, `>=`, `<`, `>`. With other mid-circuit measurements or scalars.
+    ``+``, ``-``, ``*``, ``/``, ``~`` (not), ``&`` (and), ``|`` (or), ``==``, ``<=``, ``>=``, ``<``, ``>``
+    with other mid-circuit measurements or scalars.
 
     Note:
-        python `not`, `and`, `or`, do not work since these do not have dunder methods. Instead use `~`, `&`, `|`.
+        Python ``not``, ``and``, ``or``, do not work since these do not have dunder methods.
+        Instead use ``~``, ``&``, ``|``.
 
     Args:
         wires (Wires): The wire of the qubit the measurement process applies to.
+        reset (bool): Whether to reset the measured wire to the :math:`|0>` state.
+            ``False`` by default.
+        postselect (Optional[int]): Which measurement outcome to postselect the circuit on.
+            Can be ``0`` or ``1``. ``None`` by default.
 
     Returns:
         MidMeasureMP: measurement process instance
@@ -78,7 +84,7 @@ def measure(wires):  # TODO: Change name to mid_measure
 
     # Create a UUID and a map between MP and MV to support serialization
     measurement_id = str(uuid.uuid4())[:8]
-    MidMeasureMP(wires=wire, id=measurement_id)
+    MidMeasureMP(wires=wire, id=measurement_id, reset=reset, postselect=postselect)
     return MeasurementValue([measurement_id], processing_fn=lambda v: v)
 
 
@@ -94,10 +100,14 @@ class MidMeasureMP(MeasurementProcess):
         wires (.Wires): The wires the measurement process applies to.
             This can only be specified if an observable was not provided.
         id (str): custom label given to a measurement instance, can be useful for some applications
-            where the instance has to be identified
+            where the instance has to be identified.
+        reset (bool): Whether to reset the measured wire to the :math:`|0>` state.
+            ``False`` by default.
+        postselect (Optional[int]): Which measurement outcome to postselect the circuit on.
+            Can be ``0`` or ``1``. ``None`` by default.
     """
 
-    def __init__(self, wires: Optional[Wires] = None, id: Optional[str] = None):
+    def __init__(self, wires: Optional[Wires] = None, id: Optional[str] = None, reset: bool = False):
         super().__init__(wires=wires, id=id)
 
     @property

--- a/pennylane/measurements/probs.py
+++ b/pennylane/measurements/probs.py
@@ -14,10 +14,11 @@
 """
 This module contains the qml.probs measurement.
 """
-from typing import Sequence, Tuple
+from typing import Sequence, Tuple, Optional
 
 import pennylane as qml
 from pennylane import numpy as np
+from pennylane.operation import Operator
 from pennylane.wires import Wires
 
 from .measurements import Probability, SampleMeasurement, StateMeasurement
@@ -100,7 +101,11 @@ def probs(wires=None, op=None) -> "ProbabilityMP":
             "Symbolic Operations are not supported for rotating probabilities yet."
         )
 
-    if op is not None and not isinstance(op, MeasurementValue) and not qml.operation.defines_diagonalizing_gates(op):
+    if (
+        op is not None
+        and not isinstance(op, MeasurementValue)
+        and not qml.operation.defines_diagonalizing_gates(op)
+    ):
         raise qml.QuantumFunctionError(
             f"{op} does not define diagonalizing gates : cannot be used to rotate the probability"
         )
@@ -131,6 +136,16 @@ class ProbabilityMP(SampleMeasurement, StateMeasurement):
         id (str): custom label given to a measurement instance, can be useful for some applications
             where the instance has to be identified
     """
+
+    def __init__(
+        self,
+        obs: Optional[Operator] = None,
+        wires: Optional[Wires] = None,
+        eigvals=None,
+        id: Optional[str] = None,
+    ):
+        self.mid_measure = True if obs is not None and isinstance(obs, MeasurementValue) else False
+        super().__init__(obs=obs, wires=wires, eigvals=eigvals, id=id)
 
     @property
     def return_type(self):

--- a/pennylane/measurements/probs.py
+++ b/pennylane/measurements/probs.py
@@ -21,6 +21,7 @@ from pennylane import numpy as np
 from pennylane.wires import Wires
 
 from .measurements import Probability, SampleMeasurement, StateMeasurement
+from .mid_measure import MeasurementValue
 
 
 def probs(wires=None, op=None) -> "ProbabilityMP":
@@ -99,7 +100,7 @@ def probs(wires=None, op=None) -> "ProbabilityMP":
             "Symbolic Operations are not supported for rotating probabilities yet."
         )
 
-    if op is not None and not qml.operation.defines_diagonalizing_gates(op):
+    if op is not None and not isinstance(op, MeasurementValue) and not qml.operation.defines_diagonalizing_gates(op):
         raise qml.QuantumFunctionError(
             f"{op} does not define diagonalizing gates : cannot be used to rotate the probability"
         )

--- a/pennylane/measurements/sample.py
+++ b/pennylane/measurements/sample.py
@@ -23,6 +23,7 @@ from pennylane.operation import Operator
 from pennylane.wires import Wires
 
 from .measurements import MeasurementShapeError, Sample, SampleMeasurement
+from .mid_measure import MeasurementValue
 
 
 def sample(op: Optional[Operator] = None, wires=None) -> "SampleMP":

--- a/pennylane/ops/op_math/adjoint.py
+++ b/pennylane/ops/op_math/adjoint.py
@@ -208,6 +208,13 @@ class Adjoint(SymbolicOp):
     _operation_observable_type = None  # type if base inherits from both operation and observable
     _observable_type = None  # type if base inherits from observable and not operation
 
+    def _flatten(self):
+        return (self.base,), tuple()
+
+    @classmethod
+    def _unflatten(cls, data, _):
+        return cls(data[0])
+
     # pylint: disable=unused-argument
     def __new__(cls, base=None, id=None):
         """Mixes in parents based on inheritance structure of base.

--- a/pennylane/ops/op_math/composite.py
+++ b/pennylane/ops/op_math/composite.py
@@ -43,6 +43,13 @@ class CompositeOp(Operator):
     :meth:`~.operation.Operator.matrix` and :meth:`~.operation.Operator.decomposition`.
     """
 
+    def _flatten(self):
+        return tuple(self.operands), tuple()
+
+    @classmethod
+    def _unflatten(cls, data, metadata):
+        return cls(*data)
+
     _eigs = {}  # cache eigen vectors and values like in qml.Hermitian
 
     def __init__(self, *operands: Operator, id=None):  # pylint: disable=super-init-not-called

--- a/pennylane/ops/op_math/controlled.py
+++ b/pennylane/ops/op_math/controlled.py
@@ -228,6 +228,15 @@ class Controlled(SymbolicOp):
 
     """
 
+    def _flatten(self):
+        return (self.base,), (self.control_wires, tuple(self.control_values), self.work_wires)
+
+    @classmethod
+    def _unflatten(cls, data, metadata):
+        return cls(
+            data[0], control_wires=metadata[0], control_values=metadata[1], work_wires=metadata[2]
+        )
+
     # pylint: disable=no-self-argument
     @operation.classproperty
     def __signature__(cls):  # pragma: no cover

--- a/pennylane/ops/op_math/controlled_ops.py
+++ b/pennylane/ops/op_math/controlled_ops.py
@@ -102,6 +102,12 @@ class ControlledQubitUnitary(ControlledOp):
     grad_method = None
     """Gradient computation method."""
 
+    @classmethod
+    def _unflatten(cls, data, metadata):
+        return cls(
+            data[0], control_wires=metadata[0], control_values=metadata[1], work_wires=metadata[2]
+        )
+
     # pylint: disable= too-many-arguments
     def __init__(
         self,
@@ -173,6 +179,13 @@ class CY(ControlledOp):
 
     grad_method = None
     """Gradient computation method."""
+
+    def _flatten(self):
+        return tuple(), (self.wires,)
+
+    @classmethod
+    def _unflatten(cls, data, metadata):
+        return cls(metadata[0])
 
     def __init__(self, wires, id=None):
         control_wire, wire = wires
@@ -269,6 +282,13 @@ class CZ(ControlledOp):
 
     ndim_params = ()
     """tuple[int]: Number of dimensions per trainable parameter that the operator depends on."""
+
+    def _flatten(self):
+        return tuple(), (self.wires,)
+
+    @classmethod
+    def _unflatten(cls, data, metadata):
+        return cls(metadata[0])
 
     def __init__(self, wires):
         control_wire, wire = wires

--- a/pennylane/ops/op_math/exp.py
+++ b/pennylane/ops/op_math/exp.py
@@ -167,6 +167,13 @@ class Exp(ScalarSymbolicOp, Operation):
     control_wires = Wires([])
     _name = "Exp"
 
+    def _flatten(self):
+        return (self.base, self.data[0]), (self.num_steps,)
+
+    @classmethod
+    def _unflatten(cls, data, metadata):
+        return cls(data[0], data[1], num_steps=metadata[0])
+
     # pylint: disable=too-many-arguments
     def __init__(self, base, coeff=1, num_steps=None, id=None):
         super().__init__(base, scalar=coeff, id=id)

--- a/pennylane/ops/op_math/pow.py
+++ b/pennylane/ops/op_math/pow.py
@@ -158,6 +158,13 @@ class Pow(ScalarSymbolicOp):
 
     """
 
+    def _flatten(self):
+        return (self.base, self.z), tuple()
+
+    @classmethod
+    def _unflatten(cls, data, _):
+        return pow(data[0], z=data[1])
+
     _operation_type = None  # type if base inherits from operation and not observable
     _operation_observable_type = None  # type if base inherits from both operation and observable
     _observable_type = None  # type if base inherits from observable and not oepration

--- a/pennylane/ops/op_math/sprod.py
+++ b/pennylane/ops/op_math/sprod.py
@@ -129,6 +129,13 @@ class SProd(ScalarSymbolicOp):
     """
     _name = "SProd"
 
+    def _flatten(self):
+        return (self.scalar, self.base), tuple()
+
+    @classmethod
+    def _unflatten(cls, data, _):
+        return cls(data[0], data[1])
+
     def __init__(self, scalar: Union[int, float, complex], base: Operator, id=None):
         super().__init__(base=base, scalar=scalar, id=id)
 

--- a/pennylane/ops/qubit/arithmetic_ops.py
+++ b/pennylane/ops/qubit/arithmetic_ops.py
@@ -171,12 +171,11 @@ class QubitCarry(Operation):
         [Toffoli(wires=[1, 2, 4]), CNOT(wires=[1, 2]), Toffoli(wires=[0, 2, 4])]
 
         """
-        decomp_ops = [
+        return [
             qml.Toffoli(wires=wires[1:]),
             qml.CNOT(wires=[wires[1], wires[2]]),
             qml.Toffoli(wires=[wires[0], wires[2], wires[3]]),
         ]
-        return decomp_ops
 
 
 class QubitSum(Operation):
@@ -358,6 +357,15 @@ class IntegerComparator(Operation):
     """int: Number of trainable parameters that the operator depends on."""
 
     grad_method = None
+
+    def _flatten(self):
+        hp = self.hyperparameters
+        metadata = (
+            ("work_wires", hp["work_wires"]),
+            ("value", hp["value"]),
+            ("geq", hp["geq"]),
+        )
+        return tuple(), (hp["control_wires"] + hp["target_wires"], metadata)
 
     # pylint: disable=too-many-arguments
     def __init__(self, value, geq=True, wires=None, work_wires=None):

--- a/pennylane/ops/qubit/non_parametric_ops.py
+++ b/pennylane/ops/qubit/non_parametric_ops.py
@@ -2063,6 +2063,18 @@ class MultiControlledX(Operation):
 
     grad_method = None
 
+    def _flatten(self):
+        hyperparameters = (
+            ("wires", self.wires),
+            ("control_values", self.hyperparameters["control_values"]),
+            ("work_wires", self.hyperparameters["work_wires"]),
+        )
+        return tuple(), hyperparameters
+
+    @classmethod
+    def _unflatten(cls, _, metadata):
+        return cls(**dict(metadata))
+
     # pylint: disable=too-many-arguments
     def __init__(self, control_wires=None, wires=None, control_values=None, work_wires=None):
         if wires is None:

--- a/pennylane/ops/qubit/parametric_ops_multi_qubit.py
+++ b/pennylane/ops/qubit/parametric_ops_multi_qubit.py
@@ -67,6 +67,9 @@ class MultiRZ(Operation):
     grad_method = "A"
     parameter_frequencies = [(1,)]
 
+    def _flatten(self):
+        return self.data, (self.wires, tuple())
+
     def __init__(self, theta, wires=None, id=None):
         wires = Wires(wires)
         self.hyperparameters["num_wires"] = len(wires)
@@ -575,6 +578,10 @@ class PCPhase(Operation):
         dim, shape = self.hyperparameters["dimension"]
         mat = np.diag([1 if index < dim else -1 for index in range(shape)])
         return qml.Hermitian(mat, wires=self.wires)
+
+    def _flatten(self):
+        hyperparameter = (("dim", self.hyperparameters["dimension"][0]),)
+        return tuple(self.data), (self.wires, hyperparameter)
 
     def __init__(self, phi, dim, wires, id=None):
         wires = wires if isinstance(wires, Wires) else Wires(wires)

--- a/pennylane/tape/qscript.py
+++ b/pennylane/tape/qscript.py
@@ -432,7 +432,7 @@ class QuantumScript:
 
         n_ops = len(self.operations)
         for idx, m in enumerate(self.measurements):
-            if m.obs is not None:
+            if m.obs is not None and not m.mid_measure:
                 self._par_info.extend(
                     {"op": m.obs, "op_idx": idx + n_ops, "p_idx": i}
                     for i, d in enumerate(m.obs.data)
@@ -657,7 +657,7 @@ class QuantumScript:
         if operations_only:
             return params
         for m in self.measurements:
-            if m.obs is not None:
+            if m.obs is not None and not m.mid_measure:
                 params.extend(m.obs.data)
         return params
 

--- a/pennylane/tape/qscript.py
+++ b/pennylane/tape/qscript.py
@@ -994,11 +994,20 @@ class QuantumScript:
         if not qml.active_return():
             return self._shape_legacy(device)
 
-        shots = (
-            Shots(device._raw_shot_sequence)
-            if device.shot_vector is not None
-            else Shots(device.shots)
-        )
+        if isinstance(device, qml.devices.experimental.Device):
+            # MP.shape (called below) takes 2 arguments: `device` and `shots`.
+            # With the new device interface, shots are stored on tapes rather than the device
+            # As well, MP.shape needs the device largely to see the device wires, and this is
+            # also stored on tapes in the new device interface. TODO: refactor MP.shape to accept
+            # `wires` instead of device (not currently done because probs.shape uses device.cutoff)
+            shots = self.shots
+            device = self
+        else:
+            shots = (
+                Shots(device._raw_shot_sequence)
+                if device.shot_vector is not None
+                else Shots(device.shots)
+            )
 
         if len(shots.shot_vector) > 1 and self.batch_size is not None:
             raise NotImplementedError(

--- a/pennylane/tape/qscript.py
+++ b/pennylane/tape/qscript.py
@@ -19,6 +19,7 @@ executed by a device.
 
 import contextlib
 import copy
+import warnings
 from collections import Counter
 from typing import List, Union, Optional, Sequence
 
@@ -527,6 +528,11 @@ class QuantumScript:
 
     @data.setter
     def data(self, params):
+        warnings.warn(
+            "The tape.data setter is deprecated and will be removed in v0.33. "
+            "Please use tape.bind_new_parameters instead.",
+            UserWarning,
+        )
         self.set_parameters(params, trainable_only=False)
 
     @property
@@ -692,6 +698,12 @@ class QuantumScript:
         >>> qscript.get_parameters(trainable_only=False)
         [4, 1, 6]
         """
+        warnings.warn(
+            "The method tape.set_parameters is deprecated and will be removed in v0.33. "
+            "Please use tape.bind_new_parameters instead.",
+            UserWarning,
+        )
+
         if trainable_only:
             iterator = zip(self.trainable_params, params)
             required_length = self.num_params

--- a/pennylane/templates/embeddings/angle.py
+++ b/pennylane/templates/embeddings/angle.py
@@ -75,6 +75,13 @@ class AngleEmbedding(Operation):
     num_wires = AnyWires
     grad_method = None
 
+    def _flatten(self):
+        hyperparameters = (("rotation", self._rotation),)
+        return self.data, (self.wires, hyperparameters)
+
+    def __repr__(self):
+        return f"AngleEmbedding({self.data[0]}, wires={self.wires.tolist()}, rotation={self._rotation})"
+
     def __init__(self, features, wires, rotation="X", id=None):
         if rotation not in ROT:
             raise ValueError(f"Rotation option {rotation} not recognized.")
@@ -86,6 +93,7 @@ class AngleEmbedding(Operation):
                 f"Features must be of length {len(wires)} or less; got length {n_features}."
             )
 
+        self._rotation = rotation
         self._hyperparameters = {"rotation": ROT[rotation]}
 
         wires = wires[:n_features]

--- a/pennylane/templates/embeddings/basis.py
+++ b/pennylane/templates/embeddings/basis.py
@@ -71,6 +71,15 @@ class BasisEmbedding(Operation):
     num_wires = AnyWires
     grad_method = None
 
+    def _flatten(self):
+        basis_state = self.hyperparameters["basis_state"]
+        basis_state = tuple(basis_state) if isinstance(basis_state, list) else basis_state
+        return tuple(), (self.wires, basis_state)
+
+    @classmethod
+    def _unflatten(cls, _, metadata) -> "BasisEmbedding":
+        return cls(features=metadata[1], wires=metadata[0])
+
     def __init__(self, features, wires, id=None):
         if isinstance(features, list):
             features = qml.math.stack(features)

--- a/pennylane/templates/embeddings/displacement.py
+++ b/pennylane/templates/embeddings/displacement.py
@@ -100,6 +100,12 @@ class DisplacementEmbedding(Operation):
     num_wires = AnyWires
     grad_method = None
 
+    @classmethod
+    def _unflatten(cls, data, metadata):
+        new_op = cls.__new__(cls)
+        Operation.__init__(new_op, *data, wires=metadata[0])
+        return new_op
+
     def __init__(self, features, wires, method="amplitude", c=0.1, id=None):
         shape = qml.math.shape(features)
         constants = [c] * shape[0]

--- a/pennylane/templates/embeddings/qaoaembedding.py
+++ b/pennylane/templates/embeddings/qaoaembedding.py
@@ -64,7 +64,8 @@ class QAOAEmbedding(Operation):
         features (tensor_like): tensor of features to encode
         weights (tensor_like): tensor of weights
         wires (Iterable): wires that the template acts on
-        local_field (str): type of local field used, one of ``'X'``, ``'Y'``, or ``'Z'``
+        local_field (str, type): type of local field used, either one of ``'X'``, ``'Y'``, or ``'Z'`` or
+            :class:`~.RX`, :class:`~.RY`, or :class:`~.RZ`.
 
     Raises:
         ValueError: if inputs do not have the correct format
@@ -166,7 +167,9 @@ class QAOAEmbedding(Operation):
             local_field = qml.RX
         elif local_field == "Y":
             local_field = qml.RY
-        else:
+        elif not (
+            isinstance(local_field, type) and issubclass(local_field, (qml.RX, qml.RY, qml.RZ))
+        ):
             raise ValueError(f"did not recognize local field {local_field}")
 
         shape = qml.math.shape(features)
@@ -230,7 +233,7 @@ class QAOAEmbedding(Operation):
             features (tensor_like): tensor of features to encode
             weights (tensor_like): tensor of weights
             wires (Any or Iterable[Any]): wires that the template acts on
-            local_field (.Operator): class of local field gate
+            local_field (type): type of :class:`~.Operator` for local field gate
 
         Returns:
             list[.Operator]: decomposition of the operator

--- a/pennylane/templates/embeddings/squeezing.py
+++ b/pennylane/templates/embeddings/squeezing.py
@@ -102,6 +102,12 @@ class SqueezingEmbedding(Operation):
     num_wires = AnyWires
     grad_method = None
 
+    @classmethod
+    def _unflatten(cls, data, metadata) -> "SqueezingEmbedding":
+        new_op = cls.__new__(cls)
+        Operation.__init__(new_op, *data, wires=metadata[0])
+        return new_op
+
     def __init__(self, features, wires, method="amplitude", c=0.1, id=None):
         shape = qml.math.shape(features)
         constants = [c] * shape[0]

--- a/pennylane/templates/layers/random.py
+++ b/pennylane/templates/layers/random.py
@@ -15,6 +15,8 @@ r"""
 Contains the RandomLayers template.
 """
 # pylint: disable-msg=too-many-branches,too-many-arguments,protected-access
+import warnings
+
 import numpy as np
 import pennylane as qml
 from pennylane.operation import Operation, AnyWires
@@ -52,7 +54,7 @@ class RandomLayers(Operation):
         wires (Iterable): wires that the template acts on
         ratio_imprim (float): value between 0 and 1 that determines the ratio of imprimitive to rotation gates
         imprimitive (pennylane.ops.Operation): two-qubit gate to use, defaults to :class:`~pennylane.ops.CNOT`
-        rotations (list[pennylane.ops.Operation]): List of Pauli-X, Pauli-Y and/or Pauli-Z gates. The frequency
+        rotations (tuple[pennylane.ops.Operation]): List of Pauli-X, Pauli-Y and/or Pauli-Z gates. The frequency
             determines how often a particular rotation type is used. Defaults to the use of all three
             rotations with equal frequency.
         seed (int): seed to generate random architecture, defaults to 42
@@ -183,9 +185,9 @@ class RandomLayers(Operation):
             raise ValueError(f"Weights tensor must be 2-dimensional; got shape {shape}")
 
         self._hyperparameters = {
-            "ratio_imprimitive": ratio_imprim,
+            "ratio_imprim": ratio_imprim,
             "imprimitive": imprimitive or qml.CNOT,
-            "rotations": rotations or [qml.RX, qml.RY, qml.RZ],
+            "rotations": tuple(rotations) if rotations else (qml.RX, qml.RY, qml.RZ),
             "seed": seed,
         }
 
@@ -197,7 +199,7 @@ class RandomLayers(Operation):
 
     @staticmethod
     def compute_decomposition(
-        weights, wires, ratio_imprimitive, imprimitive, rotations, seed
+        weights, wires, ratio_imprim, imprimitive, rotations, seed, ratio_imprimitive=None
     ):  # pylint: disable=arguments-differ
         r"""Representation of the operator as a product of other operators.
 
@@ -230,6 +232,13 @@ class RandomLayers(Operation):
          CNOT(wires=['b', 'a']),
          RX(tensor(1.4000), wires=['a'])]
         """
+        if ratio_imprimitive:
+            warnings.warn(
+                "In RandomLayers.compute_decomposition, ratio_imprim should be changed to `ratio_imprimitive` to match the "
+                "call signature of the operation.",
+                UserWarning,
+            )
+            ratio_imprim = ratio_imprimitive
         wires = qml.wires.Wires(wires)
         rng = np.random.default_rng(seed)
 
@@ -240,7 +249,7 @@ class RandomLayers(Operation):
         for l in range(n_layers):
             i = 0
             while i < shape[1]:
-                if rng.random() > ratio_imprimitive:
+                if rng.random() > ratio_imprim:
                     # apply a random rotation gate to a random wire
                     gate = rng.choice(rotations)
                     rnd_wire = wires.select_random(1, seed=rng)

--- a/pennylane/templates/layers/strongly_entangling.py
+++ b/pennylane/templates/layers/strongly_entangling.py
@@ -48,7 +48,7 @@ class StronglyEntanglingLayers(Operation):
         wires (Iterable): wires that the template acts on
         ranges (Sequence[int]): sequence determining the range hyperparameter for each subsequent layer; if ``None``
                                 using :math:`r=l \mod M` for the :math:`l` th layer and :math:`M` wires.
-        imprimitive (pennylane.ops.Operation): two-qubit gate to use, defaults to :class:`~pennylane.ops.CNOT`
+        imprimitive (type of pennylane.ops.Operation): two-qubit gate to use, defaults to :class:`~pennylane.ops.CNOT`
 
     Example:
 

--- a/pennylane/templates/subroutines/approx_time_evolution.py
+++ b/pennylane/templates/subroutines/approx_time_evolution.py
@@ -101,6 +101,15 @@ class ApproxTimeEvolution(Operation):
     num_wires = AnyWires
     grad_method = None
 
+    def _flatten(self):
+        h = self.hyperparameters["hamiltonian"]
+        data = (h, self.data[-1])
+        return data, (self.hyperparameters["n"],)
+
+    @classmethod
+    def _unflatten(cls, data, metadata):
+        return cls(data[0], data[1], n=metadata[0])
+
     def __init__(self, hamiltonian, time, n, id=None):
         if not isinstance(hamiltonian, qml.Hamiltonian):
             raise ValueError(

--- a/pennylane/templates/subroutines/commuting_evolution.py
+++ b/pennylane/templates/subroutines/commuting_evolution.py
@@ -106,6 +106,15 @@ class CommutingEvolution(Operation):
     num_wires = AnyWires
     grad_method = None
 
+    def _flatten(self):
+        h = self.hyperparameters["hamiltonian"]
+        data = (h, self.data[0])
+        return data, (self.hyperparameters["frequencies"], self.hyperparameters["shifts"])
+
+    @classmethod
+    def _unflatten(cls, data, metadata) -> "CommutingEvolution":
+        return cls(data[0], data[1], frequencies=metadata[0], shifts=metadata[1])
+
     def __init__(self, hamiltonian, time, frequencies=None, shifts=None, id=None):
         # pylint: disable=import-outside-toplevel
         from pennylane.gradients.general_shift_rules import (

--- a/pennylane/templates/subroutines/fermionic_double_excitation.py
+++ b/pennylane/templates/subroutines/fermionic_double_excitation.py
@@ -497,6 +497,13 @@ class FermionicDoubleExcitation(Operation):
     grad_method = "A"
     parameter_frequencies = [(0.5, 1.0)]
 
+    def _flatten(self):
+        return self.data, (self.hyperparameters["wires1"], self.hyperparameters["wires2"])
+
+    @classmethod
+    def _unflatten(cls, data, metadata) -> "FermionicDoubleExcitation":
+        return cls(data[0], wires1=metadata[0], wires2=metadata[1])
+
     def __init__(self, weight, wires1=None, wires2=None, id=None):
         if len(wires1) < 2:
             raise ValueError(
@@ -513,8 +520,8 @@ class FermionicDoubleExcitation(Operation):
         if shape != ():
             raise ValueError(f"Weight must be a scalar; got shape {shape}.")
 
-        wires1 = list(wires1)
-        wires2 = list(wires2)
+        wires1 = qml.wires.Wires(wires1)
+        wires2 = qml.wires.Wires(wires2)
 
         self._hyperparameters = {
             "wires1": wires1,

--- a/pennylane/templates/subroutines/flip_sign.py
+++ b/pennylane/templates/subroutines/flip_sign.py
@@ -66,6 +66,13 @@ class FlipSign(Operation):
 
     num_wires = AnyWires
 
+    def _flatten(self):
+        hyperparameters = (("n", tuple(self.hyperparameters["arr_bin"])),)
+        return tuple(), (self.wires, hyperparameters)
+
+    def __repr__(self):
+        return f"FlipSign({self.hyperparameters['arr_bin']}, wires={self.wires.tolist()})"
+
     def __init__(self, n, wires, id=None):
         if not isinstance(wires, int) and len(wires) == 0:
             raise ValueError("expected at least one wire representing the qubit ")

--- a/pennylane/templates/subroutines/grover.py
+++ b/pennylane/templates/subroutines/grover.py
@@ -19,6 +19,7 @@ import functools
 import numpy as np
 from pennylane.operation import AnyWires, Operation
 from pennylane.ops import Hadamard, PauliZ, MultiControlledX
+from pennylane.wires import Wires
 
 
 class GroverOperator(Operation):
@@ -101,11 +102,18 @@ class GroverOperator(Operation):
     num_wires = AnyWires
     grad_method = None
 
+    def __repr__(self):
+        return f"GroverOperator(wires={self.wires.tolist()}, work_wires={self.hyperparameters['work_wires'].tolist()})"
+
+    def _flatten(self):
+        hyperparameters = (("work_wires", self.hyperparameters["work_wires"]),)
+        return tuple(), (self.wires, hyperparameters)
+
     def __init__(self, wires=None, work_wires=None, id=None):
         if (not hasattr(wires, "__len__")) or (len(wires) < 2):
             raise ValueError("GroverOperator must have at least two wires provided.")
 
-        self._hyperparameters = {"n_wires": len(wires), "work_wires": work_wires}
+        self._hyperparameters = {"n_wires": len(wires), "work_wires": Wires(work_wires)}
 
         super().__init__(wires=wires, id=id)
 

--- a/pennylane/templates/subroutines/hilbert_schmidt.py
+++ b/pennylane/templates/subroutines/hilbert_schmidt.py
@@ -96,6 +96,18 @@ class HilbertSchmidt(Operation):
     num_wires = AnyWires
     grad_method = None
 
+    def _flatten(self):
+        metadata = (
+            ("v_function", self.hyperparameters["v_function"]),
+            ("v_wires", self.hyperparameters["v_wires"]),
+            ("u_tape", self.hyperparameters["u_tape"]),
+        )
+        return self.data, metadata
+
+    @classmethod
+    def _unflatten(cls, data, metadata):
+        return cls(*data, **dict(metadata))
+
     def __init__(self, *params, v_function, v_wires, u_tape, id=None):
         self._num_params = len(params)
 
@@ -114,7 +126,7 @@ class HilbertSchmidt(Operation):
 
         v_tape = qml.tape.make_qscript(v_function)(*params)
         self.hyperparameters["v_tape"] = v_tape
-        self.hyperparameters["v_wires"] = v_tape.wires
+        self.hyperparameters["v_wires"] = qml.wires.Wires(v_wires)
 
         if len(u_wires) != len(v_wires):
             raise qml.QuantumFunctionError("U and V must have the same number of wires.")
@@ -152,7 +164,8 @@ class HilbertSchmidt(Operation):
         # Unitary U
         for op_u in u_tape.operations:
             # The operation has been defined outside of this function, to queue it we call qml.apply.
-            qml.apply(op_u)
+            if qml.QueuingManager.recording():
+                qml.apply(op_u)
             decomp_ops.append(op_u)
 
         # Unitary V conjugate

--- a/pennylane/templates/subroutines/kupccgsd.py
+++ b/pennylane/templates/subroutines/kupccgsd.py
@@ -203,6 +203,15 @@ class kUpCCGSD(Operation):
     num_wires = AnyWires
     grad_method = None
 
+    def _flatten(self):
+        hyperparameters = (
+            ("k", self.hyperparameters["k"]),
+            ("delta_sz", self.hyperparameters["delta_sz"]),
+            # tuple version of init_state is essentially identical, but is hashable
+            ("init_state", tuple(self.hyperparameters["init_state"])),
+        )
+        return self.data, (self.wires, hyperparameters)
+
     def __init__(self, weights, wires, k=1, delta_sz=0, init_state=None, id=None):
         if len(wires) < 4:
             raise ValueError(f"Requires at least four wires; got {len(wires)} wires.")
@@ -236,6 +245,7 @@ class kUpCCGSD(Operation):
             "s_wires": s_wires,
             "d_wires": d_wires,
             "k": k,
+            "delta_sz": delta_sz,
         }
         super().__init__(weights, wires=wires, id=id)
 
@@ -245,8 +255,14 @@ class kUpCCGSD(Operation):
 
     @staticmethod
     def compute_decomposition(
-        weights, wires, s_wires, d_wires, k, init_state
-    ):  # pylint: disable=arguments-differ
+        weights,
+        wires,
+        s_wires,
+        d_wires,
+        k,
+        init_state,
+        delta_sz=None,
+    ):  # pylint: disable=arguments-differ, unused-argument
         r"""Representation of the operator as a product of other operators.
 
         .. math:: O = O_1 O_2 \dots O_n.

--- a/pennylane/templates/subroutines/qft.py
+++ b/pennylane/templates/subroutines/qft.py
@@ -66,10 +66,10 @@ class QFT(Operation):
     num_wires = AnyWires
     grad_method = None
 
-    def __init__(self, *params, wires=None, id=None):
+    def __init__(self, wires=None, id=None):
         wires = qml.wires.Wires(wires)
         self.hyperparameters["n_wires"] = len(wires)
-        super().__init__(*params, wires=wires, id=id)
+        super().__init__(wires=wires, id=id)
 
     @property
     def num_params(self):

--- a/pennylane/templates/subroutines/qmc.py
+++ b/pennylane/templates/subroutines/qmc.py
@@ -339,6 +339,15 @@ class QuantumMonteCarlo(Operation):
     num_wires = AnyWires
     grad_method = None
 
+    @classmethod
+    def _unflatten(cls, data, metadata):
+        new_op = cls.__new__(cls)
+        new_op._hyperparameters = dict(metadata[1])  # pylint: disable=protected-access
+
+        # call operation.__init__ to initialize private properties like _name, _id, _pauli_rep, etc.
+        Operation.__init__(new_op, *data, wires=metadata[0])
+        return new_op
+
     def __init__(self, probs, func, target_wires, estimation_wires, id=None):
         if isinstance(probs, np.ndarray) and probs.ndim != 1:
             raise ValueError("The probability distribution must be specified as a flat array")

--- a/pennylane/templates/subroutines/qpe.py
+++ b/pennylane/templates/subroutines/qpe.py
@@ -139,6 +139,16 @@ class QuantumPhaseEstimation(Operation):
     num_wires = AnyWires
     grad_method = None
 
+    # pylint: disable=no-member
+    def _flatten(self):
+        data = (self.hyperparameters["unitary"],)
+        metadata = (self.hyperparameters["estimation_wires"],)
+        return data, metadata
+
+    @classmethod
+    def _unflatten(cls, data, metadata) -> "QuantumPhaseEstimation":
+        return cls(data[0], estimation_wires=metadata[0])
+
     def __init__(self, unitary, target_wires=None, estimation_wires=None, id=None):
         if isinstance(unitary, Operator):
             # If the unitary is expressed in terms of operators, do not provide target wires
@@ -162,8 +172,8 @@ class QuantumPhaseEstimation(Operation):
         if estimation_wires is None:
             raise qml.QuantumFunctionError("No estimation wires specified.")
 
-        target_wires = list(target_wires)
-        estimation_wires = list(estimation_wires)
+        target_wires = qml.wires.Wires(target_wires)
+        estimation_wires = qml.wires.Wires(estimation_wires)
         wires = target_wires + estimation_wires
 
         if any(wire in target_wires for wire in estimation_wires):

--- a/pennylane/templates/subroutines/qsvt.py
+++ b/pennylane/templates/subroutines/qsvt.py
@@ -263,6 +263,14 @@ class QSVT(Operation):
     grad_method = None
     """Gradient computation method."""
 
+    def _flatten(self):
+        data = (self.hyperparameters["UA"], self.hyperparameters["projectors"])
+        return data, tuple()
+
+    @classmethod
+    def _unflatten(cls, data, _) -> "QSVT":
+        return cls(*data)
+
     def __init__(self, UA, projectors, id=None):
         if not isinstance(UA, qml.operation.Operator):
             raise ValueError("Input block encoding must be an Operator")

--- a/pennylane/templates/swapnetworks/ccl2.py
+++ b/pennylane/templates/swapnetworks/ccl2.py
@@ -27,8 +27,13 @@ class TwoLocalSwapNetwork(Operation):
 
     Args:
         wires (Iterable or Wires): ordered sequence of wires on which the swap network acts
-        acquaintances (Callable): callable `func(index, wires, param=None, **kwargs)` that returns a two-local operation applied on a pair of logical wires specified by `index` currently stored in physical wires provided by `wires` before they are swapped apart. Parameters for the operation are specified using `param`, and any additional keyword arguments for the callable should be provided using the ``kwargs`` separately
-        weights (tensor): weight tensor for the parameterized acquaintances of length :math:`N \times (N - 1) / 2`, where `N` is the length of `wires`
+        acquaintances (Callable): callable `func(index, wires, param=None, **kwargs)` that returns
+            a two-local operation applied on a pair of logical wires specified by `index` currently
+            stored in physical wires provided by `wires` before they are swapped apart.
+            Parameters for the operation are specified using `param`, and any additional
+            keyword arguments for the callable should be provided using the ``kwargs`` separately
+        weights (tensor): weight tensor for the parameterized acquaintances of length
+            :math:`N \times (N - 1) / 2`, where `N` is the length of `wires`
         fermionic (bool): If ``True``, qubits are realized as fermionic modes and :class:`~.pennylane.FermionicSWAP` with :math:`\phi=\pi` is used instead of :class:`~.pennylane.SWAP`
         shift (bool): If ``True``, odd-numbered layers begins from the second qubit instead of first one
         **kwargs: additional keyword arguments for `acquaintances`
@@ -83,6 +88,14 @@ class TwoLocalSwapNetwork(Operation):
 
     num_wires = AnyWires
     grad_method = None
+
+    @classmethod
+    def _unflatten(cls, data, metadata):
+        new_op = cls.__new__(cls)
+        new_op._hyperparameters = dict(metadata[1])  # pylint: disable=protected-access
+        new_op._weights = data[0]  # pylint: disable=protected-access
+        Operation.__init__(new_op, *data, wires=metadata[0])
+        return new_op
 
     def __init__(
         self,

--- a/pennylane/templates/tensornetworks/mera.py
+++ b/pennylane/templates/tensornetworks/mera.py
@@ -16,6 +16,9 @@ Contains the MERA template.
 """
 # pylint: disable-msg=too-many-branches,too-many-arguments,protected-access
 import warnings
+from typing import Callable
+
+
 import pennylane as qml
 import pennylane.numpy as np
 from pennylane.operation import Operation, AnyWires
@@ -93,7 +96,7 @@ def compute_indices(wires, n_block_wires):
                 + wires_list[list_len - n_elements_pre][0 : n_block_wires // 2]
             )
             wires_list = wires_list + new_list
-    return wires_list[::-1]
+    return tuple(tuple(l) for l in wires_list[::-1])
 
 
 class MERA(Operation):
@@ -172,11 +175,18 @@ class MERA(Operation):
     def num_params(self):
         return 1
 
+    @classmethod
+    def _unflatten(cls, data, metadata):
+        new_op = cls.__new__(cls)
+        new_op._hyperparameters = dict(metadata[1])
+        Operation.__init__(new_op, data, wires=metadata[0])
+        return new_op
+
     def __init__(
         self,
         wires,
         n_block_wires,
-        block,
+        block: Callable,
         n_params_block,
         template_weights=None,
         id=None,
@@ -187,7 +197,7 @@ class MERA(Operation):
         n_blocks = int(2 ** (np.floor(np.log2(n_wires / n_block_wires)) + 2) - 3)
 
         if shape == ():
-            template_weights = np.random.rand(n_params_block, int(n_blocks))
+            template_weights = np.random.rand(n_params_block, n_blocks)
 
         else:
             if shape[0] != n_blocks:

--- a/pennylane/templates/tensornetworks/mps.py
+++ b/pennylane/templates/tensornetworks/mps.py
@@ -28,7 +28,7 @@ def compute_indices_MPS(wires, n_block_wires):
         wires (Iterable): wires that the template acts on
         n_block_wires (int): number of wires per block
     Returns:
-        layers (array): array of wire indices or wire labels for each block
+        layers (Tuple[Tuple]]): array of wire indices or wire labels for each block
     """
 
     n_wires = len(wires)
@@ -51,17 +51,14 @@ def compute_indices_MPS(wires, n_block_wires):
             f"The number of wires should be a multiple of {int(n_block_wires/2)}; got {n_wires}"
         )
 
-    layers = np.array(
-        [
-            [wires[idx] for idx in range(j, j + n_block_wires)]
-            for j in range(
-                0,
-                len(wires) - int(len(wires) % (n_block_wires // 2)) - n_block_wires // 2,
-                n_block_wires // 2,
-            )
-        ]
+    return tuple(
+        tuple(wires[idx] for idx in range(j, j + n_block_wires))
+        for j in range(
+            0,
+            len(wires) - int(len(wires) % (n_block_wires // 2)) - n_block_wires // 2,
+            n_block_wires // 2,
+        )
     )
-    return layers
 
 
 class MPS(Operation):
@@ -124,6 +121,13 @@ class MPS(Operation):
     num_wires = AnyWires
     par_domain = "A"
 
+    @classmethod
+    def _unflatten(cls, data, metadata):
+        new_op = cls.__new__(cls)
+        new_op._hyperparameters = dict(metadata[1])
+        Operation.__init__(new_op, data, wires=metadata[0])
+        return new_op
+
     def __init__(
         self,
         wires,
@@ -178,7 +182,7 @@ class MPS(Operation):
         decomp = []
         block_gen = qml.tape.make_qscript(block)
         for idx, w in enumerate(ind_gates):
-            decomp += block_gen(weights=weights[idx][:], wires=w.tolist())
+            decomp += block_gen(weights=weights[idx][:], wires=w)
         return [qml.apply(op) for op in decomp] if qml.QueuingManager.recording() else decomp
 
     @staticmethod

--- a/pennylane/templates/tensornetworks/ttn.py
+++ b/pennylane/templates/tensornetworks/ttn.py
@@ -29,7 +29,7 @@ def compute_indices(wires, n_block_wires):
         n_block_wires (int): number of wires per block
 
     Returns:
-        layers (array): array of wire labels for each block
+        layers (tuple): array of wire labels for each block
     """
 
     n_wires = len(wires)
@@ -56,33 +56,20 @@ def compute_indices(wires, n_block_wires):
     n_wires = 2 ** (int(np.log2(len(wires) / n_block_wires))) * n_block_wires
     n_layers = int(np.log2(n_wires // n_block_wires)) + 1
 
-    layers = [
-        [
-            wires[i]
-            for i in range(
-                x + 2 ** (j - 1) * n_block_wires // 2 - n_block_wires // 2,
-                x + n_block_wires // 2 + 2 ** (j - 1) * n_block_wires // 2 - n_block_wires // 2,
-            )
-        ]
-        + [
-            wires[i]
-            for i in range(
-                x
-                + 2 ** (j - 1) * n_block_wires // 2
-                + 2 ** (j - 1) * n_block_wires // 2
-                - n_block_wires // 2,
-                x
-                + 2 ** (j - 1) * n_block_wires // 2
-                + n_block_wires // 2
-                + 2 ** (j - 1) * n_block_wires // 2
-                - n_block_wires // 2,
-            )
-        ]
-        for j in range(1, n_layers + 1)
-        for x in range(0, n_wires - n_block_wires // 2, 2 ** (j - 1) * n_block_wires)
-    ]
+    half_block_wires = n_block_wires // 2
 
-    return layers
+    block_wires = []
+    for layer in range(n_layers):
+        lower_shift = (2 ** (layer) - 1) * half_block_wires
+        upper_shift = (2 ** (layer + 1) - 1) * half_block_wires
+
+        step = 2**layer * n_block_wires
+        for block_offset in range(0, n_wires - half_block_wires, step):
+            wires1 = tuple(wires[block_offset + lower_shift + i] for i in range(half_block_wires))
+            wires2 = tuple(wires[block_offset + upper_shift + i] for i in range(half_block_wires))
+            block_wires.append(wires1 + wires2)
+
+    return tuple(block_wires)
 
 
 class TTN(Operation):
@@ -156,6 +143,13 @@ class TTN(Operation):
     @property
     def num_params(self):
         return 1
+
+    @classmethod
+    def _unflatten(cls, data, metadata):
+        new_op = cls.__new__(cls)
+        new_op._hyperparameters = dict(metadata[1])
+        Operation.__init__(new_op, data, wires=metadata[0])
+        return new_op
 
     def __init__(
         self,

--- a/pennylane/transforms/convert_to_numpy_parameters.py
+++ b/pennylane/transforms/convert_to_numpy_parameters.py
@@ -34,7 +34,7 @@ def _convert_op_to_numpy_data(op: qml.operation.Operator) -> qml.operation.Opera
 def _convert_measurement_to_numpy_data(
     m: qml.measurements.MeasurementProcess,
 ) -> qml.measurements.MeasurementProcess:
-    if m.obs is None or math.get_interface(*m.obs.data) == "numpy":
+    if m.obs is None or m.mid_measure or math.get_interface(*m.obs.data) == "numpy":
         return m
     # Use measurement method to change parameters when it becomes available
     copied_m = copy.copy(m)

--- a/tests/gradients/core/test_jvp.py
+++ b/tests/gradients/core/test_jvp.py
@@ -835,7 +835,7 @@ class TestBatchJVP:
         v_tapes, fn = qml.gradients.batch_jvp(tapes, tangents, param_shift)
 
         assert v_tapes == []
-        assert fn([]) == [None, None]
+        assert fn([]) == (None, None)
 
     def test_zero_tangent(self):
         """A zero dy vector will return no tapes and a zero matrix"""

--- a/tests/gradients/parameter_shift/test_parameter_shift.py
+++ b/tests/gradients/parameter_shift/test_parameter_shift.py
@@ -1139,9 +1139,8 @@ class TestParameterShiftRule:
 
         autograd_val = fn(dev.batch_execute(tapes))
 
-        tape_fwd, tape_bwd = tape.copy(copy_operations=True), tape.copy(copy_operations=True)
-        tape_fwd.set_parameters([theta + np.pi / 2])
-        tape_bwd.set_parameters([theta - np.pi / 2])
+        tape_fwd = tape.bind_new_parameters([theta + np.pi / 2], [1])
+        tape_bwd = tape.bind_new_parameters([theta - np.pi / 2], [1])
 
         manualgrad_val = np.subtract(*dev.batch_execute([tape_fwd, tape_bwd])) / 2
         assert np.allclose(autograd_val, manualgrad_val, atol=tol, rtol=0)
@@ -1184,10 +1183,10 @@ class TestParameterShiftRule:
             s = np.zeros_like(params)
             s[idx] += np.pi / 2
 
-            tape.set_parameters(params + s)
+            tape = tape.bind_new_parameters(params + s, [1, 2, 3])
             forward = dev.execute(tape)
 
-            tape.set_parameters(params - s)
+            tape = tape.bind_new_parameters(params - s, [1, 2, 3])
             backward = dev.execute(tape)
 
             component = (forward - backward) / 2
@@ -2432,9 +2431,8 @@ class TestParameterShiftRuleBroadcast:
 
         autograd_val = fn(dev.batch_execute(tapes))
 
-        tape_fwd, tape_bwd = tape.copy(copy_operations=True), tape.copy(copy_operations=True)
-        tape_fwd.set_parameters([theta + np.pi / 2])
-        tape_bwd.set_parameters([theta - np.pi / 2])
+        tape_fwd = tape.bind_new_parameters([theta + np.pi / 2], [1])
+        tape_bwd = tape.bind_new_parameters([theta - np.pi / 2], [1])
 
         manualgrad_val = np.subtract(*dev.batch_execute([tape_fwd, tape_bwd])) / 2
         assert np.allclose(autograd_val, manualgrad_val, atol=tol, rtol=0)
@@ -2472,10 +2470,10 @@ class TestParameterShiftRuleBroadcast:
             s = np.zeros_like(params)
             s[idx] += np.pi / 2
 
-            tape.set_parameters(params + s)
+            tape = tape.bind_new_parameters(params + s, [1, 2, 3])
             forward = dev.execute(tape)
 
-            tape.set_parameters(params - s)
+            tape = tape.bind_new_parameters(params - s, [1, 2, 3])
             backward = dev.execute(tape)
 
             manualgrad_val[idx] = (forward - backward) / 2

--- a/tests/gradients/parameter_shift/test_parameter_shift_shot_vec.py
+++ b/tests/gradients/parameter_shift/test_parameter_shift_shot_vec.py
@@ -668,9 +668,8 @@ class TestParameterShiftRule:
 
         autograd_val = fn(dev.batch_execute(tapes))
 
-        tape_fwd, tape_bwd = tape.copy(copy_operations=True), tape.copy(copy_operations=True)
-        tape_fwd.set_parameters([theta + np.pi / 2])
-        tape_bwd.set_parameters([theta - np.pi / 2])
+        tape_fwd = tape.bind_new_parameters([theta + np.pi / 2], [1])
+        tape_bwd = tape.bind_new_parameters([theta - np.pi / 2], [1])
 
         shot_vec_manual_res = dev.batch_execute([tape_fwd, tape_bwd])
 
@@ -724,10 +723,10 @@ class TestParameterShiftRule:
             s = np.zeros_like(params)
             s[idx] += np.pi / 2
 
-            tape.set_parameters(params + s)
+            tape = tape.bind_new_parameters(params + s, [1, 2, 3])
             forward = dev.execute(tape)
 
-            tape.set_parameters(params - s)
+            tape = tape.bind_new_parameters(params - s, [1, 2, 3])
             backward = dev.execute(tape)
 
             shot_vec_comp = []

--- a/tests/interfaces/default_qubit_2_integration/test_autograd_default_qubit_2.py
+++ b/tests/interfaces/default_qubit_2_integration/test_autograd_default_qubit_2.py
@@ -325,8 +325,8 @@ class TestAutogradExecuteIntegration:
         assert tape.trainable_params == [0, 1]
 
         def cost(a, b):
-            tape.set_parameters([a, b])
-            return autograd.numpy.hstack(execute([tape], device, **execute_kwargs)[0])
+            new_tape = tape.bind_new_parameters([a, b], [0, 1])
+            return autograd.numpy.hstack(execute([new_tape], device, **execute_kwargs)[0])
 
         jac_fn = qml.jacobian(cost)
         jac = jac_fn(a, b)

--- a/tests/interfaces/default_qubit_2_integration/test_jax_default_qubit_2.py
+++ b/tests/interfaces/default_qubit_2_integration/test_jax_default_qubit_2.py
@@ -308,8 +308,8 @@ class TestJaxExecuteIntegration:
         assert tape.trainable_params == [0, 1]
 
         def cost(a, b):
-            tape.set_parameters([a, b])
-            return jnp.hstack(execute([tape], device, **execute_kwargs)[0])
+            new_tape = tape.bind_new_parameters([a, b], [0, 1])
+            return jnp.hstack(execute([new_tape], device, **execute_kwargs)[0])
 
         jac_fn = jax.jacobian(cost, argnums=[0, 1])
         jac = jac_fn(a, b)

--- a/tests/interfaces/default_qubit_2_integration/test_jax_jit_qnode_default_qubit_2.py
+++ b/tests/interfaces/default_qubit_2_integration/test_jax_jit_qnode_default_qubit_2.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2021 Xanadu Quantum Technologies Inc.
+# Copyright 2018-2023 Xanadu Quantum Technologies Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,21 +13,23 @@
 # limitations under the License.
 """Integration tests for using the JAX-JIT interface with a QNode"""
 # pylint: disable=too-many-arguments,too-few-public-methods
+from functools import partial
 import pytest
 
 import pennylane as qml
 from pennylane import numpy as np
 from pennylane import qnode
 from pennylane.tape import QuantumScript
+from pennylane.devices.experimental import DefaultQubit2
 
 qubit_device_and_diff_method = [
-    ["default.qubit", "backprop", True],
-    ["default.qubit", "finite-diff", False],
-    ["default.qubit", "parameter-shift", False],
-    ["default.qubit", "adjoint", True],
-    ["default.qubit", "adjoint", False],
-    ["default.qubit", "spsa", False],
-    ["default.qubit", "hadamard", False],
+    [DefaultQubit2(), "backprop", True],
+    [DefaultQubit2(), "finite-diff", False],
+    [DefaultQubit2(), "parameter-shift", False],
+    [DefaultQubit2(), "adjoint", True],
+    [DefaultQubit2(), "adjoint", False],
+    [DefaultQubit2(), "spsa", False],
+    [DefaultQubit2(), "hadamard", False],
 ]
 interface_and_qubit_device_and_diff_method = [
     ["auto"] + inner_list for inner_list in qubit_device_and_diff_method
@@ -45,23 +47,16 @@ H_FOR_SPSA = 0.05
 
 
 @pytest.mark.parametrize(
-    "interface,dev_name,diff_method,grad_on_execution", interface_and_qubit_device_and_diff_method
+    "interface,dev,diff_method,grad_on_execution", interface_and_qubit_device_and_diff_method
 )
 class TestQNode:
     """Test that using the QNode with JAX integrates with the PennyLane
     stack"""
 
-    def test_execution_with_interface(self, dev_name, diff_method, grad_on_execution, interface):
+    def test_execution_with_interface(self, dev, diff_method, grad_on_execution, interface):
         """Test execution works with the interface"""
         if diff_method == "backprop":
             pytest.skip("Test does not support backprop")
-
-        num_wires = 1
-
-        if diff_method == "hadamard":
-            num_wires = 2
-
-        dev = qml.device(dev_name, wires=num_wires)
 
         @qnode(
             dev, interface=interface, diff_method=diff_method, grad_on_execution=grad_on_execution
@@ -85,7 +80,7 @@ class TestQNode:
         assert grad.shape == ()
 
     def test_changing_trainability(
-        self, dev_name, diff_method, grad_on_execution, interface, mocker, tol
+        self, dev, diff_method, grad_on_execution, interface, mocker, tol
     ):
         """Test changing the trainability of parameters changes the
         number of differentiation requests made"""
@@ -94,8 +89,6 @@ class TestQNode:
 
         a = jax.numpy.array(0.1)
         b = jax.numpy.array(0.2)
-
-        dev = qml.device(dev_name, wires=2)
 
         @qnode(
             dev,
@@ -141,18 +134,11 @@ class TestQNode:
         circuit(a, b)
         assert circuit.qtape.trainable_params == [1]
 
-    def test_classical_processing(self, dev_name, diff_method, grad_on_execution, interface):
+    def test_classical_processing(self, dev, diff_method, grad_on_execution, interface):
         """Test classical processing within the quantum tape"""
         a = jax.numpy.array(0.1)
         b = jax.numpy.array(0.2)
         c = jax.numpy.array(0.3)
-
-        num_wires = 1
-
-        if diff_method == "hadamard":
-            num_wires = 2
-
-        dev = qml.device(dev_name, wires=num_wires)
 
         @qnode(
             dev, diff_method=diff_method, interface=interface, grad_on_execution=grad_on_execution
@@ -170,18 +156,11 @@ class TestQNode:
 
         assert len(res) == 2
 
-    def test_matrix_parameter(self, dev_name, diff_method, grad_on_execution, interface, tol):
+    def test_matrix_parameter(self, dev, diff_method, grad_on_execution, interface, tol):
         """Test that the jax interface works correctly
         with a matrix parameter"""
         U = jax.numpy.array([[0, 1], [1, 0]])
         a = jax.numpy.array(0.1)
-
-        num_wires = 2
-
-        if diff_method == "hadamard":
-            num_wires = 3
-
-        dev = qml.device(dev_name, wires=num_wires)
 
         @qnode(
             dev, diff_method=diff_method, interface=interface, grad_on_execution=grad_on_execution
@@ -197,7 +176,7 @@ class TestQNode:
         if diff_method == "finite-diff":
             assert circuit.qtape.trainable_params == [1]
 
-    def test_differentiable_expand(self, dev_name, diff_method, grad_on_execution, interface, tol):
+    def test_differentiable_expand(self, dev, diff_method, grad_on_execution, interface, tol):
         """Test that operation and nested tape expansion
         is differentiable"""
 
@@ -213,13 +192,6 @@ class TestQNode:
                 return QuantumScript(
                     [qml.Rot(lam, theta, -lam, wires=wires), qml.PhaseShift(phi + lam, wires=wires)]
                 )
-
-        num_wires = 1
-
-        if diff_method == "hadamard":
-            num_wires = 2
-
-        dev = qml.device(dev_name, wires=num_wires)
 
         a = jax.numpy.array(0.1)
         p = jax.numpy.array([0.1, 0.2, 0.3])
@@ -255,7 +227,7 @@ class TestQNode:
         )
         assert np.allclose(res, expected, atol=tol, rtol=0)
 
-    def test_jacobian_options(self, dev_name, diff_method, grad_on_execution, interface, mocker):
+    def test_jacobian_options(self, dev, diff_method, grad_on_execution, interface, mocker):
         """Test setting jacobian options"""
         if diff_method != "finite-diff":
             pytest.skip("Test only applies to finite diff.")
@@ -263,8 +235,6 @@ class TestQNode:
         spy = mocker.spy(qml.gradients.finite_diff, "transform_fn")
 
         a = np.array([0.1, 0.2], requires_grad=True)
-
-        dev = qml.device(dev_name, wires=1)
 
         @qnode(
             dev,
@@ -291,15 +261,13 @@ class TestQNode:
 
 
 @pytest.mark.parametrize(
-    "interface,dev_name,diff_method,grad_on_execution", interface_and_qubit_device_and_diff_method
+    "interface,dev,diff_method,grad_on_execution", interface_and_qubit_device_and_diff_method
 )
 class TestVectorValuedQNode:
     """Test that using vector-valued QNodes with JAX integrate with the
     PennyLane stack"""
 
-    def test_diff_expval_expval(
-        self, dev_name, diff_method, grad_on_execution, interface, mocker, tol
-    ):
+    def test_diff_expval_expval(self, dev, diff_method, grad_on_execution, interface, mocker, tol):
         """Test jacobian calculation"""
 
         gradient_kwargs = {}
@@ -316,13 +284,6 @@ class TestVectorValuedQNode:
 
         a = np.array(0.1, requires_grad=True)
         b = np.array(0.2, requires_grad=True)
-
-        num_wires = 2
-
-        if diff_method == "hadamard":
-            num_wires = 3
-
-        dev = qml.device(dev_name, wires=num_wires)
 
         @qnode(
             dev,
@@ -374,7 +335,7 @@ class TestVectorValuedQNode:
             spy.assert_called()
 
     def test_jacobian_no_evaluate(
-        self, dev_name, diff_method, grad_on_execution, interface, mocker, tol
+        self, dev, diff_method, grad_on_execution, interface, mocker, tol
     ):
         """Test jacobian calculation when no prior circuit evaluation has been performed"""
 
@@ -392,13 +353,6 @@ class TestVectorValuedQNode:
 
         a = jax.numpy.array(0.1)
         b = jax.numpy.array(0.2)
-
-        num_wires = 2
-
-        if diff_method == "hadamard":
-            num_wires = 3
-
-        dev = qml.device(dev_name, wires=num_wires)
 
         @qnode(
             dev,
@@ -448,7 +402,7 @@ class TestVectorValuedQNode:
                 assert r.shape == ()
                 assert np.allclose(r, e, atol=tol, rtol=0)
 
-    def test_diff_single_probs(self, dev_name, diff_method, grad_on_execution, interface, tol):
+    def test_diff_single_probs(self, dev, diff_method, grad_on_execution, interface, tol):
         """Tests correct output shape and evaluation for a tape
         with a single prob output"""
         gradient_kwargs = {}
@@ -458,12 +412,6 @@ class TestVectorValuedQNode:
             gradient_kwargs = {"sampler_seed": SEED_FOR_SPSA}
             tol = TOL_FOR_SPSA
 
-        num_wires = 2
-
-        if diff_method == "hadamard":
-            num_wires = 3
-
-        dev = qml.device(dev_name, wires=num_wires)
         x = jax.numpy.array(0.543)
         y = jax.numpy.array(-0.654)
 
@@ -501,7 +449,7 @@ class TestVectorValuedQNode:
         assert np.allclose(res[0], expected.T[0], atol=tol, rtol=0)
         assert np.allclose(res[1], expected.T[1], atol=tol, rtol=0)
 
-    def test_diff_multi_probs(self, dev_name, diff_method, grad_on_execution, interface, tol):
+    def test_diff_multi_probs(self, dev, diff_method, grad_on_execution, interface, tol):
         """Tests correct output shape and evaluation for a tape
         with multiple prob outputs"""
         gradient_kwargs = {}
@@ -511,12 +459,6 @@ class TestVectorValuedQNode:
             gradient_kwargs = {"sampler_seed": SEED_FOR_SPSA}
             tol = TOL_FOR_SPSA
 
-        num_wires = 3
-
-        if diff_method == "hadamard":
-            num_wires = 4
-
-        dev = qml.device(dev_name, wires=num_wires)
         x = jax.numpy.array(0.543)
         y = jax.numpy.array(-0.654)
 
@@ -587,7 +529,7 @@ class TestVectorValuedQNode:
         assert jac[1][1].shape == (4,)
         assert np.allclose(jac[1][1], expected_1[1], atol=tol, rtol=0)
 
-    def test_diff_expval_probs(self, dev_name, diff_method, grad_on_execution, interface, tol):
+    def test_diff_expval_probs(self, dev, diff_method, grad_on_execution, interface, tol):
         """Tests correct output shape and evaluation for a tape
         with prob and expval outputs"""
         gradient_kwargs = {}
@@ -597,12 +539,6 @@ class TestVectorValuedQNode:
             gradient_kwargs = {"sampler_seed": SEED_FOR_SPSA}
             tol = TOL_FOR_SPSA
 
-        num_wires = 2
-
-        if diff_method == "hadamard":
-            num_wires = 3
-
-        dev = qml.device(dev_name, wires=num_wires)
         x = jax.numpy.array(0.543)
         y = jax.numpy.array(-0.654)
 
@@ -664,7 +600,7 @@ class TestVectorValuedQNode:
         assert np.allclose(jac[1][1], expected[1][1], atol=tol, rtol=0)
 
     def test_diff_expval_probs_sub_argnums(
-        self, dev_name, diff_method, grad_on_execution, interface, tol
+        self, dev, diff_method, grad_on_execution, interface, tol
     ):
         """Tests correct output shape and evaluation for a tape with prob and expval outputs with less
         trainable parameters (argnums) than parameters."""
@@ -673,12 +609,6 @@ class TestVectorValuedQNode:
         elif diff_method == "spsa":
             tol = TOL_FOR_SPSA
 
-        num_wires = 2
-
-        if diff_method == "hadamard":
-            num_wires = 3
-
-        dev = qml.device(dev_name, wires=num_wires)
         x = jax.numpy.array(0.543)
         y = jax.numpy.array(-0.654)
 
@@ -715,7 +645,7 @@ class TestVectorValuedQNode:
         assert jac[1][0].shape == (2,)
         assert np.allclose(jac[1][0], expected[1][0], atol=tol, rtol=0)
 
-    def test_diff_var_probs(self, dev_name, diff_method, grad_on_execution, interface, tol):
+    def test_diff_var_probs(self, dev, diff_method, grad_on_execution, interface, tol):
         """Tests correct output shape and evaluation for a tape
         with prob and variance outputs"""
         gradient_kwargs = {}
@@ -727,7 +657,6 @@ class TestVectorValuedQNode:
             gradient_kwargs = {"sampler_seed": SEED_FOR_SPSA}
             tol = TOL_FOR_SPSA
 
-        dev = qml.device(dev_name, wires=3)
         x = jax.numpy.array(0.543)
         y = jax.numpy.array(-0.654)
 
@@ -796,8 +725,8 @@ class TestShotsIntegration:
     remains differentiable."""
 
     def test_diff_method_None(self, interface):
-        """Test jax device works with diff_method=None."""
-        dev = qml.device("default.qubit.jax", wires=1, shots=10)
+        """Test device works with diff_method=None."""
+        dev = DefaultQubit2()
 
         @jax.jit
         @qml.qnode(dev, diff_method=None, interface=interface)
@@ -807,43 +736,32 @@ class TestShotsIntegration:
 
         assert jax.numpy.allclose(circuit(jax.numpy.array(0.0)), 1)
 
-    def test_changing_shots(self, interface, mocker, tol):
+    @pytest.mark.skip("jax.jit does not work with sample")
+    def test_changing_shots(self, interface):
         """Test that changing shots works on execution"""
-        dev = qml.device("default.qubit", wires=2, shots=None)
         a, b = jax.numpy.array([0.543, -0.654])
 
-        @qnode(dev, diff_method=qml.gradients.param_shift, interface=interface)
+        @qnode(DefaultQubit2(), diff_method=qml.gradients.param_shift, interface=interface)
         def circuit(a, b):
             qml.RY(a, wires=0)
             qml.RX(b, wires=1)
             qml.CNOT(wires=[0, 1])
-            return qml.expval(qml.PauliY(1))
-
-        spy = mocker.spy(dev, "sample")
+            return qml.sample(wires=(0, 1))
 
         # execute with device default shots (None)
-        res = circuit(a, b)
-        assert np.allclose(res, -np.cos(a) * np.sin(b), atol=tol, rtol=0)
-        spy.assert_not_called()
+        with pytest.raises(qml.DeviceError):
+            circuit(a, b)
 
         # execute with shots=100
         res = circuit(a, b, shots=100)  # pylint: disable=unexpected-keyword-arg
-        spy.assert_called_once()
-        assert spy.spy_return.shape == (100,)
-
-        # device state has been unaffected
-        assert dev.shots is None
-        res = circuit(a, b)
-        assert np.allclose(res, -np.cos(a) * np.sin(b), atol=tol, rtol=0)
-        spy.assert_called_once()  # no additional calls
+        assert res.shape == (100, 2)  # pylint:disable=comparison-with-callable
 
     def test_gradient_integration(self, interface):
         """Test that temporarily setting the shots works
         for gradient computations"""
-        dev = qml.device("default.qubit", wires=2, shots=1)
         a, b = jax.numpy.array([0.543, -0.654])
 
-        @qnode(dev, diff_method=qml.gradients.param_shift, interface=interface)
+        @qnode(DefaultQubit2(), diff_method=qml.gradients.param_shift, interface=interface)
         def cost_fn(a, b):
             qml.RY(a, wires=0)
             qml.RX(b, wires=1)
@@ -852,7 +770,6 @@ class TestShotsIntegration:
 
         # TODO: jit when https://github.com/PennyLaneAI/pennylane/issues/3474 is resolved
         res = jax.grad(cost_fn, argnums=[0, 1])(a, b, shots=30000)
-        assert dev.shots == 1
 
         expected = [np.sin(a) * np.sin(b), -np.cos(a) * np.cos(b)]
         assert np.allclose(res, expected, atol=0.1, rtol=0)
@@ -860,52 +777,41 @@ class TestShotsIntegration:
     def test_update_diff_method(self, mocker, interface):
         """Test that temporarily setting the shots updates the diff method"""
         # pylint: disable=unused-argument
-        dev = qml.device("default.qubit", wires=2, shots=100)
         a, b = jax.numpy.array([0.543, -0.654])
 
         spy = mocker.spy(qml, "execute")
 
-        # We're choosing interface="jax" such that backprop can be used in the
-        # test later
-        @qnode(dev, interface="jax")
+        @qnode(DefaultQubit2(), interface=interface)
         def cost_fn(a, b):
             qml.RY(a, wires=0)
             qml.RX(b, wires=1)
             qml.CNOT(wires=[0, 1])
             return qml.expval(qml.PauliY(1))
 
+        cost_fn(a, b, shots=100)  # pylint:disable=unexpected-keyword-arg
         # since we are using finite shots, parameter-shift will
         # be chosen
-        assert cost_fn.gradient_fn is qml.gradients.param_shift
-
-        cost_fn(a, b)
+        assert cost_fn.gradient_fn == "backprop"
         assert spy.call_args[1]["gradient_fn"] is qml.gradients.param_shift
 
+        cost_fn(a, b)
         # if we set the shots to None, backprop can now be used
-        cost_fn(a, b, shots=None)  # pylint: disable=unexpected-keyword-arg
         assert spy.call_args[1]["gradient_fn"] == "backprop"
-
-        # original QNode settings are unaffected
-        assert cost_fn.gradient_fn is qml.gradients.param_shift
-        cost_fn(a, b)
-        assert spy.call_args[1]["gradient_fn"] is qml.gradients.param_shift
 
 
 @pytest.mark.parametrize(
-    "interface,dev_name,diff_method,grad_on_execution", interface_and_qubit_device_and_diff_method
+    "interface,dev,diff_method,grad_on_execution", interface_and_qubit_device_and_diff_method
 )
 class TestQubitIntegration:
     """Tests that ensure various qubit circuits integrate correctly"""
 
-    def test_sampling(self, dev_name, diff_method, grad_on_execution, interface):
+    def test_sampling(self, dev, diff_method, grad_on_execution, interface):
         """Test sampling works as expected"""
         if grad_on_execution:
             pytest.skip("Sampling not possible with forward grad_on_execution differentiation.")
 
         if diff_method == "adjoint":
             pytest.skip("Adjoint warns with finite shots")
-
-        dev = qml.device(dev_name, wires=2, shots=10)
 
         @qnode(
             dev, diff_method=diff_method, interface=interface, grad_on_execution=grad_on_execution
@@ -915,7 +821,7 @@ class TestQubitIntegration:
             qml.CNOT(wires=[0, 1])
             return qml.sample(qml.PauliZ(0)), qml.sample(qml.PauliX(1))
 
-        res = jax.jit(circuit)()
+        res = jax.jit(circuit, static_argnames="shots")(shots=10)
 
         assert isinstance(res, tuple)
 
@@ -924,15 +830,13 @@ class TestQubitIntegration:
         assert isinstance(res[1], jax.Array)
         assert res[1].shape == (10,)
 
-    def test_counts(self, dev_name, diff_method, grad_on_execution, interface):
+    def test_counts(self, dev, diff_method, grad_on_execution, interface):
         """Test counts works as expected"""
         if grad_on_execution:
             pytest.skip("Sampling not possible with forward grad_on_execution differentiation.")
 
         if diff_method == "adjoint":
             pytest.skip("Adjoint warns with finite shots")
-
-        dev = qml.device(dev_name, wires=2, shots=10)
 
         @qnode(
             dev, diff_method=diff_method, interface=interface, grad_on_execution=grad_on_execution
@@ -946,9 +850,9 @@ class TestQubitIntegration:
             with pytest.raises(
                 NotImplementedError, match="The JAX-JIT interface doesn't support qml.counts."
             ):
-                jax.jit(circuit)()
+                jax.jit(circuit, static_argnames="shots")(shots=10)
         else:
-            res = jax.jit(circuit)()
+            res = jax.jit(circuit, static_argnames="shots")(shots=10)
 
             assert isinstance(res, tuple)
 
@@ -957,14 +861,8 @@ class TestQubitIntegration:
             assert isinstance(res[1], dict)
             assert len(res[1]) == 2
 
-    def test_chained_qnodes(self, dev_name, diff_method, grad_on_execution, interface):
+    def test_chained_qnodes(self, dev, diff_method, grad_on_execution, interface):
         """Test that the gradient of chained QNodes works without error"""
-        num_wires = 2
-
-        if diff_method == "hadamard":
-            num_wires = 3
-
-        dev = qml.device(dev_name, wires=num_wires)
 
         class Template(qml.templates.StronglyEntanglingLayers):
             def expand(self):
@@ -1008,12 +906,12 @@ class TestQubitIntegration:
 
 
 @pytest.mark.parametrize(
-    "interface,dev_name,diff_method,grad_on_execution", interface_and_qubit_device_and_diff_method
+    "interface,dev,diff_method,grad_on_execution", interface_and_qubit_device_and_diff_method
 )
 class TestQubitIntegrationHigherOrder:
     """Tests that ensure various qubit circuits integrate correctly when computing higher-order derivatives"""
 
-    def test_second_derivative(self, dev_name, diff_method, grad_on_execution, interface, tol):
+    def test_second_derivative(self, dev, diff_method, grad_on_execution, interface, tol):
         """Test second derivative calculation of a scalar-valued QNode"""
 
         gradient_kwargs = {}
@@ -1022,13 +920,6 @@ class TestQubitIntegrationHigherOrder:
         elif diff_method == "spsa":
             gradient_kwargs = {"sampler_seed": SEED_FOR_SPSA}
             tol = TOL_FOR_SPSA
-
-        num_wires = 1
-
-        if diff_method == "hadamard":
-            num_wires = 3
-
-        dev = qml.device(dev_name, wires=num_wires)
 
         @qnode(
             dev,
@@ -1065,7 +956,7 @@ class TestQubitIntegrationHigherOrder:
         else:
             assert np.allclose(g2, expected_g2, atol=tol, rtol=0)
 
-    def test_hessian(self, dev_name, diff_method, grad_on_execution, interface, tol):
+    def test_hessian(self, dev, diff_method, grad_on_execution, interface, tol):
         """Test hessian calculation of a scalar-valued QNode"""
         gradient_kwargs = {}
         if diff_method == "adjoint":
@@ -1074,13 +965,6 @@ class TestQubitIntegrationHigherOrder:
             qml.math.random.seed(42)
             gradient_kwargs = {"h": H_FOR_SPSA, "num_directions": 20}
             tol = TOL_FOR_SPSA
-
-        num_wires = 1
-
-        if diff_method == "hadamard":
-            num_wires = 3
-
-        dev = qml.device(dev_name, wires=num_wires)
 
         @qnode(
             dev,
@@ -1120,7 +1004,7 @@ class TestQubitIntegrationHigherOrder:
         else:
             assert np.allclose(hess, expected_hess, atol=tol, rtol=0)
 
-    def test_hessian_vector_valued(self, dev_name, diff_method, grad_on_execution, interface, tol):
+    def test_hessian_vector_valued(self, dev, diff_method, grad_on_execution, interface, tol):
         """Test hessian calculation of a vector-valued QNode"""
         gradient_kwargs = {}
         if diff_method == "adjoint":
@@ -1129,13 +1013,6 @@ class TestQubitIntegrationHigherOrder:
             qml.math.random.seed(42)
             gradient_kwargs = {"h": H_FOR_SPSA, "num_directions": 20}
             tol = TOL_FOR_SPSA
-
-        num_wires = 1
-
-        if diff_method == "hadamard":
-            num_wires = 3
-
-        dev = qml.device(dev_name, wires=num_wires)
 
         @qnode(
             dev,
@@ -1185,7 +1062,7 @@ class TestQubitIntegrationHigherOrder:
             assert np.allclose(hess, expected_hess, atol=tol, rtol=0)
 
     def test_hessian_vector_valued_postprocessing(
-        self, dev_name, diff_method, interface, grad_on_execution, tol
+        self, dev, diff_method, interface, grad_on_execution, tol
     ):
         """Test hessian calculation of a vector valued QNode with post-processing"""
         gradient_kwargs = {}
@@ -1195,13 +1072,6 @@ class TestQubitIntegrationHigherOrder:
             qml.math.random.seed(42)
             gradient_kwargs = {"h": H_FOR_SPSA, "num_directions": 20}
             tol = TOL_FOR_SPSA
-
-        num_wires = 1
-
-        if diff_method == "hadamard":
-            num_wires = 3
-
-        dev = qml.device(dev_name, wires=num_wires)
 
         @qnode(
             dev,
@@ -1254,7 +1124,7 @@ class TestQubitIntegrationHigherOrder:
             assert np.allclose(hess, expected_hess, atol=tol, rtol=0)
 
     def test_hessian_vector_valued_separate_args(
-        self, dev_name, diff_method, grad_on_execution, interface, mocker, tol
+        self, dev, diff_method, grad_on_execution, interface, mocker, tol
     ):
         """Test hessian calculation of a vector valued QNode that has separate input arguments"""
         gradient_kwargs = {}
@@ -1264,13 +1134,6 @@ class TestQubitIntegrationHigherOrder:
             qml.math.random.seed(42)
             gradient_kwargs = {"h": H_FOR_SPSA, "num_directions": 20}
             tol = TOL_FOR_SPSA
-
-        num_wires = 1
-
-        if diff_method == "hadamard":
-            num_wires = 3
-
-        dev = qml.device(dev_name, wires=num_wires)
 
         @qnode(
             dev,
@@ -1328,17 +1191,10 @@ class TestQubitIntegrationHigherOrder:
         else:
             assert np.allclose(hess, expected_hess, atol=tol, rtol=0)
 
-    def test_state(self, dev_name, diff_method, grad_on_execution, interface, tol):
+    def test_state(self, dev, diff_method, grad_on_execution, interface, tol):
         """Test that the state can be returned and differentiated"""
         if diff_method == "adjoint":
             pytest.skip("Adjoint does not support states")
-
-        num_wires = 2
-
-        if diff_method == "hadamard":
-            num_wires = 3
-
-        dev = qml.device(dev_name, wires=num_wires)
 
         x = jax.numpy.array(0.543)
         y = jax.numpy.array(-0.654)
@@ -1367,7 +1223,7 @@ class TestQubitIntegrationHigherOrder:
         expected = np.array([-np.sin(x) * np.cos(y) / 2, -np.cos(x) * np.sin(y) / 2])
         assert np.allclose(res, expected, atol=tol, rtol=0)
 
-    def test_projector(self, dev_name, diff_method, grad_on_execution, interface, tol):
+    def test_projector(self, dev, diff_method, grad_on_execution, interface, tol):
         """Test that the variance of a projector is correctly returned"""
         gradient_kwargs = {}
         if diff_method == "adjoint":
@@ -1379,7 +1235,6 @@ class TestQubitIntegrationHigherOrder:
             gradient_kwargs = {"h": H_FOR_SPSA}
             tol = TOL_FOR_SPSA
 
-        dev = qml.device(dev_name, wires=2)
         P = jax.numpy.array([1])
         x, y = 0.765, -0.654
 
@@ -1410,96 +1265,8 @@ class TestQubitIntegrationHigherOrder:
         assert np.allclose(res, expected, atol=tol, rtol=0)
 
 
-# TODO: Add CV test when return types and custom diff are compatible
-@pytest.mark.xfail(reason="CV variables with new return types.")
 @pytest.mark.parametrize(
-    "diff_method,kwargs",
-    [
-        ["finite-diff", {}],
-        ["spsa", {"num_directions": 100, "h": H_FOR_SPSA}],
-        ("parameter-shift", {}),
-        ("parameter-shift", {"force_order2": True}),
-    ],
-)
-@pytest.mark.parametrize("interface", ["auto", "jax-jit", "jax"])
-class TestCV:
-    """Tests for CV integration"""
-
-    def test_first_order_observable(self, diff_method, kwargs, interface, tol):
-        """Test variance of a first order CV observable"""
-        dev = qml.device("default.gaussian", wires=1)
-        if diff_method == "spsa":
-            tol = TOL_FOR_SPSA
-
-        r = 0.543
-        phi = -0.654
-
-        @qnode(dev, interface=interface, diff_method=diff_method, **kwargs)
-        def circuit(r, phi):
-            qml.Squeezing(r, 0, wires=0)
-            qml.Rotation(phi, wires=0)
-            return qml.var(qml.QuadX(0))
-
-        res = circuit(r, phi)
-        expected = np.exp(2 * r) * np.sin(phi) ** 2 + np.exp(-2 * r) * np.cos(phi) ** 2
-        assert np.allclose(res, expected, atol=tol, rtol=0)
-
-        # circuit jacobians
-        res = jax.grad(circuit, argnums=[0, 1])(r, phi)
-        expected = np.array(
-            [
-                2 * np.exp(2 * r) * np.sin(phi) ** 2 - 2 * np.exp(-2 * r) * np.cos(phi) ** 2,
-                2 * np.sinh(2 * r) * np.sin(2 * phi),
-            ]
-        )
-        assert np.allclose(res, expected, atol=tol, rtol=0)
-
-    def test_second_order_observable(self, diff_method, kwargs, interface, tol):
-        """Test variance of a second order CV expectation value"""
-        dev = qml.device("default.gaussian", wires=1)
-        if diff_method == "spsa":
-            tol = TOL_FOR_SPSA
-
-        n = 0.12
-        a = 0.765
-
-        @qnode(dev, interface=interface, diff_method=diff_method, **kwargs)
-        def circuit(n, a):
-            qml.ThermalState(n, wires=0)
-            qml.Displacement(a, 0, wires=0)
-            return qml.var(qml.NumberOperator(0))
-
-        res = circuit(n, a)
-        expected = n**2 + n + np.abs(a) ** 2 * (1 + 2 * n)
-        assert np.allclose(res, expected, atol=tol, rtol=0)
-
-        # circuit jacobians
-        res = jax.grad(circuit, argnums=[0, 1])(n, a)
-        expected = np.array([2 * a**2 + 2 * n + 1, 2 * a * (2 * n + 1)])
-        assert np.allclose(res, expected, atol=tol, rtol=0)
-
-
-# TODO: add support for fwd grad_on_execution to JAX-JIT
-@pytest.mark.parametrize("interface", ["auto", "jax-jit"])
-def test_adjoint_reuse_device_state(mocker, interface):
-    """Tests that the jax interface reuses the device state for adjoint differentiation"""
-    dev = qml.device("default.qubit", wires=1)
-
-    @qnode(dev, interface=interface, diff_method="adjoint")
-    def circ(x):
-        qml.RX(x, wires=0)
-        return qml.expval(qml.PauliZ(0))
-
-    spy = mocker.spy(dev, "adjoint_jacobian")
-
-    jax.grad(circ)(1.0)
-    assert circ.device.num_executions == 1
-
-    spy.assert_called_with(mocker.ANY, use_device_state=True)
-
-
-@pytest.mark.parametrize(
-    "interface,dev_name,diff_method,grad_on_execution", interface_and_qubit_device_and_diff_method
+    "interface,dev,diff_method,grad_on_execution", interface_and_qubit_device_and_diff_method
 )
 class TestTapeExpansion:
     """Test that tape expansion within the QNode integrates correctly
@@ -1507,19 +1274,12 @@ class TestTapeExpansion:
 
     @pytest.mark.parametrize("max_diff", [1, 2])
     def test_gradient_expansion_trainable_only(
-        self, dev_name, diff_method, grad_on_execution, max_diff, interface, mocker
+        self, dev, diff_method, grad_on_execution, max_diff, interface, mocker
     ):
         """Test that a *supported* operation with no gradient recipe is only
         expanded for parameter-shift and finite-differences when it is trainable."""
         if diff_method not in ("parameter-shift", "finite-diff", "spsa"):
             pytest.skip("Only supports gradient transforms")
-
-        num_wires = 1
-
-        if diff_method == "hadamard":
-            num_wires = 2
-
-        dev = qml.device(dev_name, wires=num_wires)
 
         class PhaseShift(qml.PhaseShift):
             grad_method = None
@@ -1540,7 +1300,6 @@ class TestTapeExpansion:
             PhaseShift(2 * y, wires=0)
             return qml.expval(qml.PauliX(0))
 
-        spy = mocker.spy(circuit.device, "batch_execute")
         x = jax.numpy.array(0.5)
         y = jax.numpy.array(0.7)
         circuit(x, y)
@@ -1557,7 +1316,7 @@ class TestTapeExpansion:
 
     @pytest.mark.parametrize("max_diff", [1, 2])
     def test_hamiltonian_expansion_analytic(
-        self, dev_name, diff_method, grad_on_execution, max_diff, interface, mocker, tol
+        self, dev, diff_method, grad_on_execution, max_diff, interface, mocker, tol
     ):
         """Test that the Hamiltonian is not expanded if there
         are non-commuting groups and the number of shots is None
@@ -1572,7 +1331,6 @@ class TestTapeExpansion:
             gradient_kwargs = {"h": H_FOR_SPSA, "num_directions": 20}
             tol = TOL_FOR_SPSA
 
-        dev = qml.device(dev_name, wires=3, shots=None)
         spy = mocker.spy(qml.transforms, "hamiltonian_expand")
         obs = [qml.PauliX(0), qml.PauliX(0) @ qml.PauliZ(1), qml.PauliZ(0) @ qml.PauliZ(1)]
 
@@ -1626,7 +1384,7 @@ class TestTapeExpansion:
 
     @pytest.mark.parametrize("max_diff", [1, 2])
     def test_hamiltonian_expansion_finite_shots(
-        self, dev_name, diff_method, grad_on_execution, interface, max_diff, mocker
+        self, dev, diff_method, grad_on_execution, interface, max_diff, mocker
     ):
         """Test that the Hamiltonian is expanded if there
         are non-commuting groups and the number of shots is finite
@@ -1641,7 +1399,6 @@ class TestTapeExpansion:
             gradient_kwargs = {"sampler_seed": SEED_FOR_SPSA, "h": H_FOR_SPSA}
             tol = TOL_FOR_SPSA
 
-        dev = qml.device(dev_name, wires=3, shots=50000)
         spy = mocker.spy(qml.transforms, "hamiltonian_expand")
         obs = [qml.PauliX(0), qml.PauliX(0) @ qml.PauliZ(1), qml.PauliZ(0) @ qml.PauliZ(1)]
 
@@ -1666,13 +1423,13 @@ class TestTapeExpansion:
         c = jax.numpy.array([-0.6543, 0.24, 0.54])
 
         # test output
-        res = circuit(d, w, c)
+        res = circuit(d, w, c, shots=50000)  # pylint:disable=unexpected-keyword-arg
         expected = c[2] * np.cos(d[1] + w[1]) - c[1] * np.sin(d[0] + w[0]) * np.sin(d[1] + w[1])
         assert np.allclose(res, expected, atol=tol)
-        spy.assert_called()
+        spy.assert_not_called()
 
         # test gradients
-        grad = jax.grad(circuit, argnums=[1, 2])(d, w, c)
+        grad = jax.grad(circuit, argnums=[1, 2])(d, w, c, shots=50000)
         expected_w = [
             -c[1] * np.cos(d[0] + w[0]) * np.sin(d[1] + w[1]),
             -c[1] * np.cos(d[1] + w[1]) * np.sin(d[0] + w[0]) - c[2] * np.sin(d[1] + w[1]),
@@ -1697,7 +1454,7 @@ class TestTapeExpansion:
     #         assert np.allclose(grad2_w_c, expected, atol=tol)
 
     def test_vmap_compared_param_broadcasting(
-        self, dev_name, diff_method, grad_on_execution, interface, tol
+        self, dev, diff_method, grad_on_execution, interface, tol
     ):
         """Test that jax.vmap works just as well as parameter-broadcasting with JAX JIT on the forward pass when
         vectorized=True is specified for the callback when caching is disabled."""
@@ -1712,12 +1469,8 @@ class TestTapeExpansion:
                 "The backprop method does not yet support parameter-broadcasting with Hamiltonians"
             )
 
-        phys_qubits = 2
-        if diff_method == "hadamard":
-            phys_qubits = 3
         n_configs = 5
         pars_q = np.random.rand(n_configs, 2)
-        dev = qml.device(dev_name, wires=tuple(range(phys_qubits)), shots=None)
 
         def minimal_circ(params):
             @qml.qnode(
@@ -1741,7 +1494,7 @@ class TestTapeExpansion:
         )
 
     def test_vmap_compared_param_broadcasting_multi_output(
-        self, dev_name, diff_method, grad_on_execution, interface, tol
+        self, dev, diff_method, grad_on_execution, interface, tol
     ):
         """Test that jax.vmap works just as well as parameter-broadcasting with JAX JIT on the forward pass when
         vectorized=True is specified for the callback when caching is disabled and when multiple output values
@@ -1757,10 +1510,8 @@ class TestTapeExpansion:
                 "The backprop method does not yet support parameter-broadcasting with Hamiltonians"
             )
 
-        phys_qubits = 2
         n_configs = 5
         pars_q = np.random.rand(n_configs, 2)
-        dev = qml.device(dev_name, wires=tuple(range(phys_qubits)), shots=None)
 
         def minimal_circ(params):
             @qml.qnode(
@@ -1791,21 +1542,14 @@ jacobian_fn = [jax.jacobian, jax.jacrev, jax.jacfwd]
 
 @pytest.mark.parametrize("jacobian", jacobian_fn)
 @pytest.mark.parametrize(
-    "interface,dev_name,diff_method,grad_on_execution", interface_and_qubit_device_and_diff_method
+    "interface,dev,diff_method,grad_on_execution", interface_and_qubit_device_and_diff_method
 )
 class TestJIT:
     """Test JAX JIT integration with the QNode and automatic resolution of the
     correct JAX interface variant."""
 
-    def test_gradient(self, dev_name, diff_method, grad_on_execution, jacobian, tol, interface):
+    def test_gradient(self, dev, diff_method, grad_on_execution, jacobian, tol, interface):
         """Test derivative calculation of a scalar valued QNode"""
-        num_wires = 1
-
-        if diff_method == "hadamard":
-            num_wires = 2
-
-        dev = qml.device(dev_name, wires=num_wires)
-
         gradient_kwargs = {}
         if diff_method == "adjoint":
             pytest.xfail(reason="The adjoint method is not using host-callback currently")
@@ -1841,7 +1585,7 @@ class TestJIT:
         "ignore:Requested adjoint differentiation to be computed with finite shots."
     )
     @pytest.mark.parametrize("shots", [10, 1000])
-    def test_hermitian(self, dev_name, diff_method, grad_on_execution, shots, jacobian, interface):
+    def test_hermitian(self, dev, diff_method, grad_on_execution, shots, jacobian, interface):
         """Test that the jax device works with qml.Hermitian and jitting even
         when shots>0.
 
@@ -1849,13 +1593,6 @@ class TestJIT:
         to different reasons, hence the parametrization in the test.
         """
         # pylint: disable=unused-argument
-        num_wires = 2
-
-        if diff_method == "hadamard":
-            num_wires = 3
-
-        dev = qml.device(dev_name, wires=num_wires, shots=shots)
-
         if diff_method == "backprop":
             pytest.skip("Backpropagation is unsupported if shots > 0.")
 
@@ -1877,19 +1614,10 @@ class TestJIT:
         "ignore:Requested adjoint differentiation to be computed with finite shots."
     )
     @pytest.mark.parametrize("shots", [10, 1000])
-    def test_probs_obs_none(
-        self, dev_name, diff_method, grad_on_execution, shots, jacobian, interface
-    ):
+    def test_probs_obs_none(self, dev, diff_method, grad_on_execution, shots, jacobian, interface):
         """Test that the jax device works with qml.probs, a MeasurementProcess
         that has obs=None even when shots>0."""
         # pylint: disable=unused-argument
-        num_wires = 2
-
-        if diff_method == "hadamard":
-            num_wires = 3
-
-        dev = qml.device(dev_name, wires=num_wires, shots=shots)
-
         if diff_method in ["backprop", "adjoint"]:
             pytest.skip("Backpropagation is unsupported if shots > 0.")
 
@@ -1904,15 +1632,11 @@ class TestJIT:
     @pytest.mark.xfail(
         reason="Non-trainable parameters are not being correctly unwrapped by the interface"
     )
-    def test_gradient_subset(
-        self, dev_name, diff_method, grad_on_execution, jacobian, tol, interface
-    ):
+    def test_gradient_subset(self, dev, diff_method, grad_on_execution, jacobian, tol, interface):
         """Test derivative calculation of a scalar valued QNode with respect
         to a subset of arguments"""
         a = jax.numpy.array(0.1)
         b = jax.numpy.array(0.2)
-
-        dev = qml.device(dev_name, wires=1)
 
         @qnode(
             dev, diff_method=diff_method, interface=interface, grad_on_execution=grad_on_execution
@@ -1932,17 +1656,10 @@ class TestJIT:
         assert np.allclose(g, expected_g, atol=tol, rtol=0)
 
     def test_gradient_scalar_cost_vector_valued_qnode(
-        self, dev_name, diff_method, grad_on_execution, jacobian, tol, interface
+        self, dev, diff_method, grad_on_execution, jacobian, tol, interface
     ):
         """Test derivative calculation of a scalar valued cost function that
         uses the output of a vector-valued QNode"""
-        num_wires = 2
-
-        if diff_method == "hadamard":
-            num_wires = 3
-
-        dev = qml.device(dev_name, wires=num_wires)
-
         gradient_kwargs = {}
         if diff_method == "adjoint":
             pytest.xfail(reason="The adjoint method is not using host-callback currently")
@@ -1987,19 +1704,11 @@ class TestJIT:
         assert np.allclose(g0, expected_g[0][idx], atol=tol, rtol=0)
         assert np.allclose(g1, expected_g[1][idx], atol=tol, rtol=0)
 
-    def test_matrix_parameter(
-        self, dev_name, diff_method, grad_on_execution, jacobian, tol, interface
-    ):
+    def test_matrix_parameter(self, dev, diff_method, grad_on_execution, jacobian, tol, interface):
         """Test that the JAX-JIT interface works correctly with a matrix
         parameter"""
+
         # pylint: disable=unused-argument
-        num_wires = 1
-
-        if diff_method == "hadamard":
-            num_wires = 2
-
-        dev = qml.device(dev_name, wires=num_wires)
-
         @qml.qnode(
             dev, diff_method=diff_method, interface=interface, grad_on_execution=grad_on_execution
         )
@@ -2021,24 +1730,17 @@ class TestJIT:
 @pytest.mark.parametrize("shots", [None, 10000])
 @pytest.mark.parametrize("jacobian", jacobian_fn)
 @pytest.mark.parametrize(
-    "interface,dev_name,diff_method,grad_on_execution", interface_and_qubit_device_and_diff_method
+    "interface,dev,diff_method,grad_on_execution", interface_and_qubit_device_and_diff_method
 )
 class TestReturn:
     """Class to test the shape of the Grad/Jacobian with different return types."""
 
     def test_grad_single_measurement_param(
-        self, dev_name, diff_method, grad_on_execution, jacobian, shots, interface
+        self, dev, diff_method, grad_on_execution, jacobian, shots, interface
     ):
         """For one measurement and one param, the gradient is a float."""
         if shots is not None and diff_method in ("backprop", "adjoint"):
             pytest.skip("Test does not support finite shots and adjoint/backprop")
-
-        num_wires = 1
-
-        if diff_method == "hadamard":
-            num_wires = 2
-
-        dev = qml.device(dev_name, wires=num_wires, shots=shots)
 
         @qnode(
             dev, interface=interface, diff_method=diff_method, grad_on_execution=grad_on_execution
@@ -2050,24 +1752,17 @@ class TestReturn:
 
         a = jax.numpy.array(0.1)
 
-        grad = jax.jit(jacobian(circuit))(a)
+        grad = jax.jit(jacobian(circuit), static_argnames="shots")(a, shots=shots)
 
         assert isinstance(grad, jax.numpy.ndarray)
         assert grad.shape == ()
 
     def test_grad_single_measurement_multiple_param(
-        self, dev_name, diff_method, grad_on_execution, jacobian, shots, interface
+        self, dev, diff_method, grad_on_execution, jacobian, shots, interface
     ):
         """For one measurement and multiple param, the gradient is a tuple of arrays."""
         if shots is not None and diff_method in ("backprop", "adjoint"):
             pytest.skip("Test does not support finite shots and adjoint/backprop")
-
-        num_wires = 1
-
-        if diff_method == "hadamard":
-            num_wires = 2
-
-        dev = qml.device(dev_name, wires=num_wires, shots=shots)
 
         @qnode(
             dev, interface=interface, diff_method=diff_method, grad_on_execution=grad_on_execution
@@ -2080,7 +1775,9 @@ class TestReturn:
         a = jax.numpy.array(0.1)
         b = jax.numpy.array(0.2)
 
-        grad = jax.jit(jacobian(circuit, argnums=[0, 1]))(a, b)
+        grad = jax.jit(jacobian(circuit, argnums=[0, 1]), static_argnames="shots")(
+            a, b, shots=shots
+        )
 
         assert isinstance(grad, tuple)
         assert len(grad) == 2
@@ -2088,18 +1785,11 @@ class TestReturn:
         assert grad[1].shape == ()
 
     def test_grad_single_measurement_multiple_param_array(
-        self, dev_name, diff_method, grad_on_execution, jacobian, shots, interface
+        self, dev, diff_method, grad_on_execution, jacobian, shots, interface
     ):
         """For one measurement and multiple param as a single array params, the gradient is an array."""
         if shots is not None and diff_method in ("backprop", "adjoint"):
             pytest.skip("Test does not support finite shots and adjoint/backprop")
-
-        num_wires = 1
-
-        if diff_method == "hadamard":
-            num_wires = 2
-
-        dev = qml.device(dev_name, wires=num_wires, shots=shots)
 
         @qnode(
             dev, interface=interface, diff_method=diff_method, grad_on_execution=grad_on_execution
@@ -2111,13 +1801,13 @@ class TestReturn:
 
         a = jax.numpy.array([0.1, 0.2])
 
-        grad = jax.jit(jacobian(circuit))(a)
+        grad = jax.jit(jacobian(circuit), static_argnames="shots")(a, shots=shots)
 
         assert isinstance(grad, jax.numpy.ndarray)
         assert grad.shape == (2,)
 
     def test_jacobian_single_measurement_param_probs(
-        self, dev_name, diff_method, grad_on_execution, jacobian, shots, interface
+        self, dev, diff_method, grad_on_execution, jacobian, shots, interface
     ):
         """For a multi dimensional measurement (probs), check that a single array is returned with the correct
         dimension"""
@@ -2126,13 +1816,6 @@ class TestReturn:
 
         if diff_method == "adjoint":
             pytest.skip("Test does not supports adjoint because of probabilities.")
-
-        num_wires = 2
-
-        if diff_method == "hadamard":
-            num_wires = 3
-
-        dev = qml.device(dev_name, wires=num_wires, shots=shots)
 
         @qnode(
             dev, interface=interface, diff_method=diff_method, grad_on_execution=grad_on_execution
@@ -2144,13 +1827,13 @@ class TestReturn:
 
         a = jax.numpy.array(0.1)
 
-        jac = jax.jit(jacobian(circuit))(a)
+        jac = jax.jit(jacobian(circuit), static_argnames="shots")(a, shots=shots)
 
         assert isinstance(jac, jax.numpy.ndarray)
         assert jac.shape == (4,)
 
     def test_jacobian_single_measurement_probs_multiple_param(
-        self, dev_name, diff_method, grad_on_execution, jacobian, shots, interface
+        self, dev, diff_method, grad_on_execution, jacobian, shots, interface
     ):
         """For a multi dimensional measurement (probs), check that a single tuple is returned containing arrays with
         the correct dimension"""
@@ -2158,13 +1841,6 @@ class TestReturn:
             pytest.skip("Test does not supports adjoint because of probabilities.")
         if shots is not None and diff_method in ("backprop", "adjoint"):
             pytest.skip("Test does not support finite shots and adjoint/backprop")
-
-        num_wires = 2
-
-        if diff_method == "hadamard":
-            num_wires = 3
-
-        dev = qml.device(dev_name, wires=num_wires, shots=shots)
 
         @qnode(
             dev, interface=interface, diff_method=diff_method, grad_on_execution=grad_on_execution
@@ -2177,7 +1853,7 @@ class TestReturn:
         a = jax.numpy.array(0.1)
         b = jax.numpy.array(0.2)
 
-        jac = jax.jit(jacobian(circuit, argnums=[0, 1]))(a, b)
+        jac = jax.jit(jacobian(circuit, argnums=[0, 1]), static_argnames="shots")(a, b, shots=shots)
 
         assert isinstance(jac, tuple)
 
@@ -2188,7 +1864,7 @@ class TestReturn:
         assert jac[1].shape == (4,)
 
     def test_jacobian_single_measurement_probs_multiple_param_single_array(
-        self, dev_name, diff_method, grad_on_execution, jacobian, shots, interface
+        self, dev, diff_method, grad_on_execution, jacobian, shots, interface
     ):
         """For a multi dimensional measurement (probs), check that a single tuple is returned containing arrays with
         the correct dimension"""
@@ -2196,13 +1872,6 @@ class TestReturn:
             pytest.skip("Test does not supports adjoint because of probabilities.")
         if shots is not None and diff_method in ("backprop", "adjoint"):
             pytest.skip("Test does not support finite shots and adjoint/backprop")
-
-        num_wires = 2
-
-        if diff_method == "hadamard":
-            num_wires = 3
-
-        dev = qml.device(dev_name, wires=num_wires, shots=shots)
 
         @qnode(
             dev, interface=interface, diff_method=diff_method, grad_on_execution=grad_on_execution
@@ -2213,23 +1882,17 @@ class TestReturn:
             return qml.probs(wires=[0, 1])
 
         a = jax.numpy.array([0.1, 0.2])
-        jac = jax.jit(jacobian(circuit))(a)
+        jac = jax.jit(jacobian(circuit), static_argnames="shots")(a, shots=shots)
 
         assert isinstance(jac, jax.numpy.ndarray)
         assert jac.shape == (4, 2)
 
     def test_jacobian_expval_expval_multiple_params(
-        self, dev_name, diff_method, grad_on_execution, jacobian, shots, interface
+        self, dev, diff_method, grad_on_execution, jacobian, shots, interface
     ):
         """The jacobian of multiple measurements with multiple params return a tuple of arrays."""
         if shots is not None and diff_method in ("backprop", "adjoint"):
             pytest.skip("Test does not support finite shots and adjoint/backprop")
-        num_wires = 2
-
-        if diff_method == "hadamard":
-            num_wires = 3
-
-        dev = qml.device(dev_name, wires=num_wires, shots=shots)
 
         par_0 = jax.numpy.array(0.1)
         par_1 = jax.numpy.array(0.2)
@@ -2243,7 +1906,9 @@ class TestReturn:
             qml.CNOT(wires=[0, 1])
             return qml.expval(qml.PauliZ(0) @ qml.PauliX(1)), qml.expval(qml.PauliZ(0))
 
-        jac = jax.jit(jacobian(circuit, argnums=[0, 1]))(par_0, par_1)
+        jac = jax.jit(jacobian(circuit, argnums=[0, 1]), static_argnames="shots")(
+            par_0, par_1, shots=shots
+        )
 
         assert isinstance(jac, tuple)
 
@@ -2262,17 +1927,11 @@ class TestReturn:
         assert jac[1][1].shape == ()
 
     def test_jacobian_expval_expval_multiple_params_array(
-        self, dev_name, diff_method, grad_on_execution, jacobian, shots, interface
+        self, dev, diff_method, grad_on_execution, jacobian, shots, interface
     ):
         """The jacobian of multiple measurements with a multiple params array return a single array."""
         if shots is not None and diff_method in ("backprop", "adjoint"):
             pytest.skip("Test does not support finite shots and adjoint/backprop")
-        num_wires = 2
-
-        if diff_method == "hadamard":
-            num_wires = 3
-
-        dev = qml.device(dev_name, wires=num_wires, shots=shots)
 
         @qnode(
             dev, interface=interface, diff_method=diff_method, grad_on_execution=grad_on_execution
@@ -2284,7 +1943,7 @@ class TestReturn:
 
         a = jax.numpy.array([0.1, 0.2])
 
-        jac = jax.jit(jacobian(circuit))(a)
+        jac = jax.jit(jacobian(circuit), static_argnames="shots")(a, shots=shots)
 
         assert isinstance(jac, tuple)
         assert len(jac) == 2  # measurements
@@ -2296,7 +1955,7 @@ class TestReturn:
         assert jac[1].shape == (2,)
 
     def test_jacobian_var_var_multiple_params(
-        self, dev_name, diff_method, grad_on_execution, jacobian, shots, interface
+        self, dev, diff_method, grad_on_execution, jacobian, shots, interface
     ):
         """The jacobian of multiple measurements with multiple params return a tuple of arrays."""
         if diff_method == "adjoint":
@@ -2305,8 +1964,6 @@ class TestReturn:
             pytest.skip("Test does not supports hadamard because of var.")
         if shots is not None and diff_method in ("backprop", "adjoint"):
             pytest.skip("Test does not support finite shots and adjoint/backprop")
-
-        dev = qml.device(dev_name, wires=2, shots=shots)
 
         par_0 = jax.numpy.array(0.1)
         par_1 = jax.numpy.array(0.2)
@@ -2320,7 +1977,9 @@ class TestReturn:
             qml.CNOT(wires=[0, 1])
             return qml.var(qml.PauliZ(0) @ qml.PauliX(1)), qml.var(qml.PauliZ(0))
 
-        jac = jax.jit(jacobian(circuit, argnums=[0, 1]))(par_0, par_1)
+        jac = jax.jit(jacobian(circuit, argnums=[0, 1]), static_argnames="shots")(
+            par_0, par_1, shots=shots
+        )
 
         assert isinstance(jac, tuple)
         assert len(jac) == 2
@@ -2340,7 +1999,7 @@ class TestReturn:
         assert jac[1][1].shape == ()
 
     def test_jacobian_var_var_multiple_params_array(
-        self, dev_name, diff_method, grad_on_execution, jacobian, shots, interface
+        self, dev, diff_method, grad_on_execution, jacobian, shots, interface
     ):
         """The jacobian of multiple measurements with a multiple params array return a single array."""
         if diff_method == "adjoint":
@@ -2349,8 +2008,6 @@ class TestReturn:
             pytest.skip("Test does not supports hadamard because of var.")
         if shots is not None and diff_method in ("backprop", "adjoint"):
             pytest.skip("Test does not support finite shots and adjoint/backprop")
-
-        dev = qml.device(dev_name, wires=2, shots=shots)
 
         @qnode(
             dev, interface=interface, diff_method=diff_method, grad_on_execution=grad_on_execution
@@ -2362,7 +2019,7 @@ class TestReturn:
 
         a = jax.numpy.array([0.1, 0.2])
 
-        jac = jax.jit(jacobian(circuit))(a)
+        jac = jax.jit(jacobian(circuit), static_argnames="shots")(a, shots=shots)
 
         assert isinstance(jac, tuple)
         assert len(jac) == 2  # measurements
@@ -2374,17 +2031,11 @@ class TestReturn:
         assert jac[1].shape == (2,)
 
     def test_jacobian_multiple_measurement_single_param(
-        self, dev_name, diff_method, grad_on_execution, jacobian, shots, interface
+        self, dev, diff_method, grad_on_execution, jacobian, shots, interface
     ):
         """The jacobian of multiple measurements with a single params return an array."""
         if shots is not None and diff_method in ("backprop", "adjoint"):
             pytest.skip("Test does not support finite shots and adjoint/backprop")
-        num_wires = 2
-
-        if diff_method == "hadamard":
-            num_wires = 3
-
-        dev = qml.device(dev_name, wires=num_wires, shots=shots)
 
         if diff_method == "adjoint":
             pytest.skip("Test does not supports adjoint because of probabilities.")
@@ -2399,7 +2050,7 @@ class TestReturn:
 
         a = jax.numpy.array(0.1)
 
-        jac = jax.jit(jacobian(circuit))(a)
+        jac = jax.jit(jacobian(circuit), static_argnames="shots")(a, shots=shots)
 
         assert isinstance(jac, tuple)
         assert len(jac) == 2
@@ -2411,20 +2062,13 @@ class TestReturn:
         assert jac[1].shape == (4,)
 
     def test_jacobian_multiple_measurement_multiple_param(
-        self, dev_name, diff_method, grad_on_execution, jacobian, shots, interface
+        self, dev, diff_method, grad_on_execution, jacobian, shots, interface
     ):
         """The jacobian of multiple measurements with a multiple params return a tuple of arrays."""
         if diff_method == "adjoint":
             pytest.skip("Test does not supports adjoint because of probabilities.")
         if shots is not None and diff_method in ("backprop", "adjoint"):
             pytest.skip("Test does not support finite shots and adjoint/backprop")
-
-        num_wires = 2
-
-        if diff_method == "hadamard":
-            num_wires = 3
-
-        dev = qml.device(dev_name, wires=num_wires, shots=shots)
 
         @qnode(
             dev, interface=interface, diff_method=diff_method, grad_on_execution=grad_on_execution
@@ -2437,7 +2081,7 @@ class TestReturn:
         a = np.array(0.1, requires_grad=True)
         b = np.array(0.2, requires_grad=True)
 
-        jac = jax.jit(jacobian(circuit, argnums=[0, 1]))(a, b)
+        jac = jax.jit(jacobian(circuit, argnums=[0, 1]), static_argnames="shots")(a, b, shots=shots)
 
         assert isinstance(jac, tuple)
         assert len(jac) == 2
@@ -2457,20 +2101,13 @@ class TestReturn:
         assert jac[1][1].shape == (4,)
 
     def test_jacobian_multiple_measurement_multiple_param_array(
-        self, dev_name, diff_method, grad_on_execution, jacobian, shots, interface
+        self, dev, diff_method, grad_on_execution, jacobian, shots, interface
     ):
         """The jacobian of multiple measurements with a multiple params array return a single array."""
         if diff_method == "adjoint":
             pytest.skip("Test does not supports adjoint because of probabilities.")
         if shots is not None and diff_method in ("backprop", "adjoint"):
             pytest.skip("Test does not support finite shots and adjoint/backprop")
-
-        num_wires = 2
-
-        if diff_method == "hadamard":
-            num_wires = 3
-
-        dev = qml.device(dev_name, wires=num_wires, shots=shots)
 
         @qnode(
             dev, interface=interface, diff_method=diff_method, grad_on_execution=grad_on_execution
@@ -2482,7 +2119,7 @@ class TestReturn:
 
         a = jax.numpy.array([0.1, 0.2])
 
-        jac = jax.jit(jacobian(circuit))(a)
+        jac = jax.jit(jacobian(circuit), static_argnames="shots")(a, shots=shots)
 
         assert isinstance(jac, tuple)
         assert len(jac) == 2  # measurements
@@ -2503,22 +2140,15 @@ hessian_fn = [
 
 @pytest.mark.parametrize("hessian", hessian_fn)
 @pytest.mark.parametrize(
-    "interface,dev_name,diff_method,grad_on_execution", interface_and_qubit_device_and_diff_method
+    "interface,dev,diff_method,grad_on_execution", interface_and_qubit_device_and_diff_method
 )
 class TestReturnHessian:
     """Class to test the shape of the Hessian with different return types."""
 
     def test_hessian_expval_multiple_params(
-        self, dev_name, diff_method, hessian, grad_on_execution, interface
+        self, dev, diff_method, hessian, grad_on_execution, interface
     ):
         """The hessian of single a measurement with multiple params return a tuple of arrays."""
-        num_wires = 2
-
-        if diff_method == "hadamard":
-            num_wires = 4
-
-        dev = qml.device(dev_name, wires=num_wires)
-
         if diff_method == "adjoint":
             pytest.skip("Test does not supports adjoint because second order diff.")
 
@@ -2558,19 +2188,12 @@ class TestReturnHessian:
         assert hess[1][1].shape == ()
 
     def test_hessian_expval_multiple_param_array(
-        self, dev_name, diff_method, hessian, grad_on_execution, interface
+        self, dev, diff_method, hessian, grad_on_execution, interface
     ):
         """The hessian of single measurement with a multiple params array return a single array."""
 
         if diff_method == "adjoint":
             pytest.skip("Test does not supports adjoint because second order diff.")
-
-        num_wires = 2
-
-        if diff_method == "hadamard":
-            num_wires = 4
-
-        dev = qml.device(dev_name, wires=num_wires)
 
         params = jax.numpy.array([0.1, 0.2], dtype=jax.numpy.float64)
 
@@ -2593,11 +2216,9 @@ class TestReturnHessian:
         assert hess.shape == (2, 2)
 
     def test_hessian_var_multiple_params(
-        self, dev_name, diff_method, hessian, grad_on_execution, interface
+        self, dev, diff_method, hessian, grad_on_execution, interface
     ):
         """The hessian of single a measurement with multiple params return a tuple of arrays."""
-        dev = qml.device(dev_name, wires=2)
-
         if diff_method == "adjoint":
             pytest.skip("Test does not supports adjoint because second order diff.")
         elif diff_method == "hadamard":
@@ -2639,15 +2260,13 @@ class TestReturnHessian:
         assert hess[1][1].shape == ()
 
     def test_hessian_var_multiple_param_array(
-        self, dev_name, diff_method, hessian, grad_on_execution, interface
+        self, dev, diff_method, hessian, grad_on_execution, interface
     ):
         """The hessian of single measurement with a multiple params array return a single array."""
         if diff_method == "adjoint":
             pytest.skip("Test does not supports adjoint because second order diff.")
         elif diff_method == "hadamard":
             pytest.skip("Test does not supports hadamard because of var.")
-
-        dev = qml.device(dev_name, wires=2)
 
         params = jax.numpy.array([0.1, 0.2], dtype=jax.numpy.float64)
 
@@ -2670,16 +2289,9 @@ class TestReturnHessian:
         assert hess.shape == (2, 2)
 
     def test_hessian_probs_expval_multiple_params(
-        self, dev_name, diff_method, hessian, grad_on_execution, interface
+        self, dev, diff_method, hessian, grad_on_execution, interface
     ):
         """The hessian of multiple measurements with multiple params return a tuple of arrays."""
-        num_wires = 2
-
-        if diff_method == "hadamard":
-            num_wires = 4
-
-        dev = qml.device(dev_name, wires=num_wires)
-
         if diff_method == "adjoint":
             pytest.skip("Test does not supports adjoint because second order diff.")
         elif diff_method == "hadamard":
@@ -2720,7 +2332,7 @@ class TestReturnHessian:
                 assert h_comp.shape == (2,)
 
     def test_hessian_probs_expval_multiple_param_array(
-        self, dev_name, diff_method, hessian, grad_on_execution, interface
+        self, dev, diff_method, hessian, grad_on_execution, interface
     ):
         """The hessian of multiple measurements with a multiple param array return a single array."""
 
@@ -2728,13 +2340,6 @@ class TestReturnHessian:
             pytest.skip("Test does not supports adjoint because second order diff.")
         elif diff_method == "hadamard":
             pytest.skip("Test does not supports hadamard because of non commuting obs.")
-
-        num_wires = 2
-
-        if diff_method == "hadamard":
-            num_wires = 4
-
-        dev = qml.device(dev_name, wires=num_wires)
 
         params = jax.numpy.array([0.1, 0.2], dtype=jax.numpy.float64)
 
@@ -2762,11 +2367,9 @@ class TestReturnHessian:
         assert hess[1].shape == (2, 2, 2)
 
     def test_hessian_probs_var_multiple_params(
-        self, dev_name, diff_method, hessian, grad_on_execution, interface
+        self, dev, diff_method, hessian, grad_on_execution, interface
     ):
         """The hessian of multiple measurements with multiple params return a tuple of arrays."""
-        dev = qml.device(dev_name, wires=2)
-
         if diff_method == "adjoint":
             pytest.skip("Test does not supports adjoint because second order diff.")
         elif diff_method == "hadamard":
@@ -2807,15 +2410,13 @@ class TestReturnHessian:
                 assert h_comp.shape == (2,)
 
     def test_hessian_probs_var_multiple_param_array(
-        self, dev_name, diff_method, hessian, grad_on_execution, interface
+        self, dev, diff_method, hessian, grad_on_execution, interface
     ):
         """The hessian of multiple measurements with a multiple param array return a single array."""
         if diff_method == "adjoint":
             pytest.skip("Test does not supports adjoint because second order diff.")
         elif diff_method == "hadamard":
             pytest.skip("Test does not supports hadamard because of var.")
-
-        dev = qml.device(dev_name, wires=2)
 
         params = jax.numpy.array([0.1, 0.2], dtype=jax.numpy.float64)
 
@@ -2847,15 +2448,9 @@ class TestReturnHessian:
 @pytest.mark.parametrize("diff_method", ["parameter-shift", "hadamard"])
 def test_jax_device_hessian_shots(hessian, diff_method):
     """The hessian of multiple measurements with a multiple param array return a single array."""
-    num_wires = 1
 
-    if diff_method == "hadamard":
-        num_wires = 3
-
-    dev = qml.device("default.qubit.jax", wires=num_wires, shots=10000)
-
-    @jax.jit
-    @qml.qnode(dev, diff_method=diff_method, max_diff=2)
+    @partial(jax.jit, static_argnames="shots")
+    @qml.qnode(DefaultQubit2(), diff_method=diff_method, max_diff=2)
     def circuit(x):
         qml.RY(x[0], wires=0)
         qml.RX(x[1], wires=0)
@@ -2864,7 +2459,7 @@ def test_jax_device_hessian_shots(hessian, diff_method):
     x = jax.numpy.array([1.0, 2.0])
     a, b = x
 
-    hess = jax.jit(hessian(circuit))(x)
+    hess = jax.jit(hessian(circuit), static_argnames="shots")(x, shots=10000)
 
     expected_hess = [
         [-np.cos(a) * np.cos(b), np.sin(a) * np.sin(b)],
@@ -2878,13 +2473,13 @@ def test_jax_device_hessian_shots(hessian, diff_method):
 @pytest.mark.parametrize("argnums", [0, 1, [0, 1]])
 @pytest.mark.parametrize("jacobian", jacobian_fn)
 @pytest.mark.parametrize(
-    "interface,dev_name,diff_method,grad_on_execution", interface_and_qubit_device_and_diff_method
+    "interface,dev,diff_method,grad_on_execution", interface_and_qubit_device_and_diff_method
 )
 class TestSubsetArgnums:
     def test_single_measurement(
         self,
         interface,
-        dev_name,
+        dev,
         diff_method,
         grad_on_execution,
         jacobian,
@@ -2893,8 +2488,6 @@ class TestSubsetArgnums:
         tol,
     ):
         """Test single measurement with different diff methods with argnums."""
-
-        dev = qml.device(dev_name, wires=3)
 
         @qml.qnode(
             dev,
@@ -2933,7 +2526,7 @@ class TestSubsetArgnums:
     def test_multi_measurements(
         self,
         interface,
-        dev_name,
+        dev,
         diff_method,
         grad_on_execution,
         jacobian,
@@ -2942,7 +2535,6 @@ class TestSubsetArgnums:
         tol,
     ):
         """Test multiple measurements with different diff methods with argnums."""
-        dev = qml.device(dev_name, wires=3)
 
         @qml.qnode(
             dev, interface=interface, diff_method=diff_method, grad_on_execution=grad_on_execution

--- a/tests/interfaces/default_qubit_2_integration/test_tensorflow_default_qubit_2.py
+++ b/tests/interfaces/default_qubit_2_integration/test_tensorflow_default_qubit_2.py
@@ -324,8 +324,10 @@ class TestTensorflowExecuteIntegration:
         assert tape.trainable_params == [0, 1]
 
         def cost(a, b):
-            tape.set_parameters([a, b])
-            return qml.math.hstack(execute([tape], device, **execute_kwargs)[0], like="tensorflow")
+            new_tape = tape.bind_new_parameters([a, b], [0, 1])
+            return qml.math.hstack(
+                execute([new_tape], device, **execute_kwargs)[0], like="tensorflow"
+            )
 
         with tf.GradientTape() as t:
             res = cost(a, b)

--- a/tests/interfaces/default_qubit_2_integration/test_torch_default_qubit_2.py
+++ b/tests/interfaces/default_qubit_2_integration/test_torch_default_qubit_2.py
@@ -332,8 +332,8 @@ class TestTorchExecuteIntegration:
         assert tape.trainable_params == [0, 1]
 
         def cost(a, b):
-            tape.set_parameters([a, b])
-            return torch.hstack(execute([tape], device, **execute_kwargs)[0])
+            new_tape = tape.bind_new_parameters([a, b], [0, 1])
+            return torch.hstack(execute([new_tape], device, **execute_kwargs)[0])
 
         jac = torch.autograd.functional.jacobian(cost, (a, b))
 

--- a/tests/interfaces/test_autograd.py
+++ b/tests/interfaces/test_autograd.py
@@ -665,8 +665,8 @@ class TestAutogradExecuteIntegration:
         assert tape.trainable_params == [0, 1]
 
         def cost(a, b):
-            tape.set_parameters([a, b])
-            return autograd.numpy.hstack(qml.execute([tape], dev, **execute_kwargs)[0])
+            new_tape = tape.bind_new_parameters([a, b], [0, 1])
+            return autograd.numpy.hstack(qml.execute([new_tape], dev, **execute_kwargs)[0])
 
         jac_fn = qml.jacobian(cost)
         jac = jac_fn(a, b)

--- a/tests/interfaces/test_jax.py
+++ b/tests/interfaces/test_jax.py
@@ -474,8 +474,8 @@ class TestJaxExecuteIntegration:
             # number of provided parameters fails in the tape: (len(params) !=
             # required_length) and the tape produces incorrect results.
             tape._update()
-            tape.set_parameters([a, b])
-            return execute([tape], dev, **execute_kwargs)[0]
+            new_tape = tape.bind_new_parameters([a, b], [0, 1])
+            return execute([new_tape], dev, **execute_kwargs)[0]
 
         jac_fn = jax.grad(cost)
         jac = jac_fn(a, b)

--- a/tests/interfaces/test_jax_jit.py
+++ b/tests/interfaces/test_jax_jit.py
@@ -476,8 +476,8 @@ class TestJaxExecuteIntegration:
             # number of provided parameters fails in the tape: (len(params) !=
             # required_length) and the tape produces incorrect results.
             tape._update()
-            tape.set_parameters([a, b])
-            return execute([tape], dev, **execute_kwargs)[0]
+            new_tape = tape.bind_new_parameters([a, b], [0, 1])
+            return execute([new_tape], dev, **execute_kwargs)[0]
 
         jac_fn = jax.jit(jax.grad(cost))
         jac = jac_fn(a, b)

--- a/tests/interfaces/test_tensorflow.py
+++ b/tests/interfaces/test_tensorflow.py
@@ -466,7 +466,7 @@ class TestTensorFlowExecuteIntegration:
         # check that the cost function continues to depend on the
         # values of the parameters for subsequent calls
         with tf.GradientTape() as t:
-            tape.set_parameters([2 * a, b])
+            tape = tape.bind_new_parameters([2 * a, b], [0, 1])
             res2 = execute([tape], dev, **execute_kwargs)[0]
             res2 = tf.stack(res2)
 
@@ -497,7 +497,7 @@ class TestTensorFlowExecuteIntegration:
 
         tape = qml.tape.QuantumScript.from_queue(q)
         with tf.GradientTape() as t:
-            tape.set_parameters([a, b])
+            tape = tape.bind_new_parameters([a, b], [0, 1])
             assert tape.trainable_params == [0, 1]
             res = execute([tape], dev, **execute_kwargs)[0]
             res = qml.math.stack(res)
@@ -508,7 +508,7 @@ class TestTensorFlowExecuteIntegration:
         b = tf.Variable(0.8, dtype=tf.float64)
 
         with tf.GradientTape() as t:
-            tape.set_parameters([2 * a, b])
+            tape = tape.bind_new_parameters([2 * a, b], [0, 1])
             res2 = execute([tape], dev, **execute_kwargs)[0]
             res2 = qml.math.stack(res2)
 

--- a/tests/interfaces/test_torch.py
+++ b/tests/interfaces/test_torch.py
@@ -571,7 +571,7 @@ class TestTorchExecuteIntegration:
         a = torch.tensor(a_val, requires_grad=True, device=torch_device)
         b = torch.tensor(b_val, requires_grad=True, device=torch_device)
 
-        tape.set_parameters([2 * a, b])
+        tape = tape.bind_new_parameters([2 * a, b], [0, 1])
         res2 = execute([tape], dev, **execute_kwargs)[0]
 
         expected = torch.tensor(

--- a/tests/ops/op_math/test_adjoint.py
+++ b/tests/ops/op_math/test_adjoint.py
@@ -421,6 +421,25 @@ class TestMiscMethods:
         assert isinstance(diag_gate, qml.RY)
         assert qml.math.allclose(diag_gate.data[0], -np.pi / 4)
 
+    # pylint: disable=protected-access
+    def test_flatten_unflatten(self):
+        """Test the flatten and unflatten methods."""
+
+        # pylint: disable=too-few-public-methods
+        class CustomOp(qml.operation.Operator):
+            pass
+
+        op = CustomOp(1.2, 2.3, wires=0)
+        adj_op = Adjoint(op)
+        data, metadata = adj_op._flatten()
+        assert len(data) == 1
+        assert data[0] is op
+
+        assert metadata == tuple()
+
+        new_op = type(adj_op)._unflatten(*adj_op._flatten())
+        assert qml.equal(adj_op, new_op)
+
 
 class TestAdjointOperation:
     """Test methods in the AdjointOperation mixin."""

--- a/tests/ops/op_math/test_composite.py
+++ b/tests/ops/op_math/test_composite.py
@@ -276,6 +276,19 @@ class TestMscMethods:
         for i, operand in enumerate(ops_lst):
             assert op[i] == operand
 
+    @pytest.mark.parametrize("ops_lst", ops)
+    def test_flatten_unflatten(self, ops_lst):
+        """Test _flatten and _unflatten."""
+        op = ValidOp(*ops_lst)
+        data, metadata = op._flatten()
+        for data_op, input_op in zip(data, ops_lst):
+            assert data_op is input_op
+
+        assert metadata == tuple()
+
+        new_op = type(op)._unflatten(*op._flatten())
+        assert qml.equal(op, new_op)
+
 
 class TestProperties:
     """Test class properties."""

--- a/tests/ops/op_math/test_controlled.py
+++ b/tests/ops/op_math/test_controlled.py
@@ -365,6 +365,28 @@ class TestMiscMethods:
             == "Controlled(S(wires=[0]) + T(wires=[1]), control_wires=[2, 3], work_wires=[4], control_values=[True, False])"
         )
 
+    def test_flatten_unflatten(self):
+        """Tests the _flatten and _unflatten methods."""
+        target = qml.S(0)
+        control_wires = qml.wires.Wires((1, 2))
+        control_values = (0, 0)
+        work_wires = qml.wires.Wires(3)
+
+        op = Controlled(target, control_wires, control_values=control_values, work_wires=work_wires)
+
+        data, metadata = op._flatten()
+        assert data[0] is target
+        assert len(data) == 1
+
+        assert metadata == (control_wires, control_values, work_wires)
+
+        # make sure metadata is hashable
+        assert hash(metadata)
+
+        new_op = type(op)._unflatten(*op._flatten())
+        assert qml.equal(op, new_op)
+        assert new_op._name == "C(S)"  # make sure initialization was called
+
     def test_copy(self):
         """Test that a copy of a controlled oeprator can have its parameters updated
         independently of the original operator."""

--- a/tests/ops/op_math/test_exp.py
+++ b/tests/ops/op_math/test_exp.py
@@ -588,6 +588,24 @@ class TestMiscMethods:
         op = Exp(qml.PauliX(0), 3)
         assert repr(op) == "Exp(3 PauliX)"
 
+    # pylint: disable=protected-access
+    @pytest.mark.parametrize("exp_type", (Exp, Evolution))
+    def test_flatten_unflatten(self, exp_type):
+        """Tests the _unflatten and _flatten methods."""
+        base = qml.RX(1.2, wires=0)
+        op = exp_type(base, 2.5, num_steps=5)
+
+        data, metadata = op._flatten()
+        assert data[0] is base
+        assert data[1] == 2.5
+
+        assert metadata == (5,)
+
+        assert hash(metadata)
+
+        new_op = type(op)._unflatten(*op._flatten())
+        assert qml.equal(new_op, op)
+
     def test_repr_tensor(self):
         """Test the __repr__ method when the base is a tensor."""
         t = qml.PauliX(0) @ qml.PauliX(1)

--- a/tests/ops/op_math/test_pow_op.py
+++ b/tests/ops/op_math/test_pow_op.py
@@ -482,6 +482,25 @@ class TestMiscMethods:
         op = Pow(base, 2.5)
         assert repr(op) == "(RX(1, wires=[0]) + S(wires=[1]))**2.5"
 
+    # pylint: disable=protected-access
+    def test_flatten_unflatten(self):
+        """Test the _flatten and _unflatten methods."""
+
+        target = qml.S(0)
+        z = -0.5
+        op = Pow(target, z)
+        data, metadata = op._flatten()
+
+        assert len(data) == 2
+        assert data[0] is target
+        assert data[1] == z
+
+        assert metadata == tuple()
+
+        new_op = type(op)._unflatten(*op._flatten())
+        assert new_op is not op
+        assert qml.equal(new_op, op)
+
     def test_copy(self):
         """Test that a copy of a power operator can have its parameters updated
         independently of the original operator."""

--- a/tests/ops/op_math/test_sprod.py
+++ b/tests/ops/op_math/test_sprod.py
@@ -192,6 +192,24 @@ class TestMscMethods:
         sprod_op = SProd(scalar, op)
         assert op_rep == repr(sprod_op)
 
+    # pylint: disable=protected-access
+    @pytest.mark.parametrize("op_scalar_tup", ops)
+    def test_flatten_unflatten(self, op_scalar_tup):
+        scalar, op = op_scalar_tup
+        sprod_op = SProd(scalar, op)
+
+        data, metadata = sprod_op._flatten()
+
+        assert len(data) == 2
+        assert data[0] == scalar
+        assert data[1] is op
+
+        assert metadata == tuple()
+
+        new_op = type(sprod_op)._unflatten(*sprod_op._flatten())
+        assert qml.equal(new_op, sprod_op)
+        assert new_op is not sprod_op
+
     @pytest.mark.parametrize("op_scalar_tup", ops)
     def test_copy(self, op_scalar_tup):
         """Test the copy dunder method properly copies the operator."""

--- a/tests/ops/qubit/test_arithmetic_ops.py
+++ b/tests/ops/qubit/test_arithmetic_ops.py
@@ -247,6 +247,33 @@ class TestQubitSum:
 class TestIntegerComparator:
     """Tests for the IntegerComparator"""
 
+    # pylint: disable=protected-access
+    def test_flatten_unflatten(self):
+        """Tests the flatten and unflatten methods"""
+        wires = qml.wires.Wires((0, 1, 2, 3))
+        work_wires = qml.wires.Wires(4)
+        op = qml.IntegerComparator(
+            2,
+            geq=False,
+            wires=(0, 1, 2, 3),
+            work_wires=(4),
+        )
+
+        data, metadata = op._flatten()
+        assert data == tuple()
+        assert len(metadata) == 2
+        assert metadata[0] == wires
+        assert metadata[1][0] == ("work_wires", work_wires)
+        assert metadata[1][1] == ("value", 2)
+        assert metadata[1][2] == ("geq", False)
+
+        # check hashable
+        assert hash(metadata)
+
+        new_op = type(op)._unflatten(*op._flatten())
+        assert qml.equal(new_op, op)
+        assert new_op is not op
+
     @pytest.mark.parametrize(
         "value,geq,wires,work_wires,expected_error_message",
         [
@@ -432,6 +459,7 @@ class TestIntegerComparator:
         tape2 = qml.tape.QuantumScript.from_queue(q2)
         assert all(isinstance(op, qml.Identity) for op in tape2.operations)
 
+    # pylint: disable=use-implicit-booleaness-not-comparison
     def test_power(self):
         """Test ``pow`` method."""
         op = qml.IntegerComparator(3, wires=[0, 1, 2, 3])

--- a/tests/ops/qubit/test_parametric_ops.py
+++ b/tests/ops/qubit/test_parametric_ops.py
@@ -141,6 +141,16 @@ class TestOperations:
         copied_op = copy.copy(op)
         np.testing.assert_allclose(op.matrix(), copied_op.matrix(), atol=tol)
 
+    # pylint: disable=protected-access
+    @pytest.mark.parametrize("op", ALL_OPERATIONS + BROADCASTED_OPERATIONS)
+    def test_flatten_unflatten(self, op):
+        """Test that the flatten and unflatten methods work as expected."""
+        _, metadata = op._flatten()
+        assert hash(metadata)
+
+        new_op = type(op)._unflatten(*op._flatten())
+        assert qml.equal(op, new_op)
+
     @pytest.mark.parametrize("op", PARAMETRIZED_OPERATIONS)
     def test_adjoint_unitaries(self, op, tol):
         op_d = op.adjoint()

--- a/tests/tape/test_tape.py
+++ b/tests/tape/test_tape.py
@@ -738,14 +738,6 @@ class TestParameters:
         assert new_tape.get_parameters() == new_params
         assert tape.get_parameters() == params
 
-        new_params = (0.1, -0.2, 1, 5, 0)
-        tape.data = new_params
-
-        for pinfo, pval in zip(tape._par_info, new_params):
-            assert pinfo["op"].data[pinfo["p_idx"]] == pval
-
-        assert tape.get_parameters() == list(new_params)
-
     def test_setting_free_parameters(self, make_tape):
         """Test that free parameters are correctly modified after construction"""
         tape, params = make_tape
@@ -859,6 +851,7 @@ class TestParameters:
         assert np.all(new_tape[1].obs.data[0] == H2)
 
 
+# TODO: remove this class when set_parameters is removed
 class TestParametersOld:
     """Tests for parameter processing, setting, and manipulation"""
 
@@ -963,7 +956,8 @@ class TestParametersOld:
         tape, _ = make_tape
         new_params = [0.6543, -0.654, 0, 0.3, 0.6]
 
-        tape.set_parameters(new_params)
+        with pytest.warns(UserWarning, match=r"The method tape.set_parameters is deprecated"):
+            tape.set_parameters(new_params)
 
         for pinfo, pval in zip(tape._par_info, new_params):
             assert pinfo["op"].data[pinfo["p_idx"]] == pval
@@ -971,7 +965,8 @@ class TestParametersOld:
         assert tape.get_parameters() == new_params
 
         new_params = (0.1, -0.2, 1, 5, 0)
-        tape.data = new_params
+        with pytest.warns(UserWarning, match=r"The tape.data setter is deprecated"):
+            tape.data = new_params
 
         for pinfo, pval in zip(tape._par_info, new_params):
             assert pinfo["op"].data[pinfo["p_idx"]] == pval
@@ -984,7 +979,8 @@ class TestParametersOld:
         new_params = [-0.654, 0.3]
 
         tape.trainable_params = [1, 3]
-        tape.set_parameters(new_params)
+        with pytest.warns(UserWarning, match=r"The method tape.set_parameters is deprecated"):
+            tape.set_parameters(new_params)
 
         count = 0
         for idx, pinfo in enumerate(tape._par_info):
@@ -1009,7 +1005,8 @@ class TestParametersOld:
         new_params = [-0.654, 0.3]
 
         tape.trainable_params = [3, 1]
-        tape.set_parameters(new_params)
+        with pytest.warns(UserWarning, match=r"The method tape.set_parameters is deprecated"):
+            tape.set_parameters(new_params)
 
         assert tape.get_parameters(trainable_only=True) == new_params
         assert tape.get_parameters(trainable_only=False) == [
@@ -1026,7 +1023,8 @@ class TestParametersOld:
         new_params = [0.6543, -0.654, 0, 0.3, 0.6]
 
         tape.trainable_params = [1, 3]
-        tape.set_parameters(new_params, trainable_only=False)
+        with pytest.warns(UserWarning, match=r"The method tape.set_parameters is deprecated"):
+            tape.set_parameters(new_params, trainable_only=False)
 
         for pinfo, pval in zip(tape._par_info, new_params):
             assert pinfo["op"].data[pinfo["p_idx"]] == pval
@@ -1039,11 +1037,13 @@ class TestParametersOld:
         tape, _ = make_tape
 
         with pytest.raises(ValueError, match="Number of provided parameters does not match"):
-            tape.set_parameters([0.54])
+            with pytest.warns(UserWarning, match=r"The method tape.set_parameters is deprecated"):
+                tape.set_parameters([0.54])
 
         with pytest.raises(ValueError, match="Number of provided parameters does not match"):
-            tape.trainable_params = [2, 3]
-            tape.set_parameters([0.54, 0.54, 0.123])
+            with pytest.warns(UserWarning, match=r"The method tape.set_parameters is deprecated"):
+                tape.trainable_params = [2, 3]
+                tape.set_parameters([0.54, 0.54, 0.123])
 
     def test_array_parameter(self):
         """Test that array parameters integrate properly"""
@@ -1059,7 +1059,9 @@ class TestParametersOld:
 
         b = np.array([0, 1, 0, 0])
         new_params = [b, 0.543, 0.654, 0.123]
-        tape.set_parameters(new_params)
+        with pytest.warns(UserWarning, match=r"The method tape.set_parameters is deprecated"):
+            tape.set_parameters(new_params)
+
         assert tape.get_parameters() == new_params
 
         assert np.all(op_.data[0] == b)
@@ -1079,7 +1081,9 @@ class TestParametersOld:
 
         H2 = np.array([[0, 1], [1, 1]])
         new_params = [0.543, 0.654, 0.123, H2]
-        tape.set_parameters(new_params)
+        with pytest.warns(UserWarning, match=r"The method tape.set_parameters is deprecated"):
+            tape.set_parameters(new_params)
+
         assert tape.get_parameters() == new_params
 
         assert np.all(obs.data[0] == H2)

--- a/tests/templates/test_embeddings/test_angle.py
+++ b/tests/templates/test_embeddings/test_angle.py
@@ -20,6 +20,30 @@ from pennylane import numpy as pnp
 import pennylane as qml
 
 
+def test_repr():
+    """Test the custom repr for angle embedding."""
+    op = qml.AngleEmbedding(features=[1, 2, 3], wires=range(3), rotation="Z")
+    expected = "AngleEmbedding([1 2 3], wires=[0, 1, 2], rotation=Z)"
+    assert repr(op) == expected
+
+
+# pylint: disable=protected-access
+def test_flatten_unflatten():
+    """Test the _flatten and _unflatten methods."""
+    wires = qml.wires.Wires((0, 1, 2))
+    op = qml.AngleEmbedding(features=[1, 2, 3], wires=wires, rotation="Z")
+
+    data, metadata = op._flatten()
+    assert data == op.data
+    assert len(metadata) == 2
+    assert metadata[0] == wires
+    assert metadata[1] == (("rotation", "Z"),)
+
+    new_op = type(op)._unflatten(*op._flatten())
+    assert qml.equal(op, new_op)
+    assert op is not new_op
+
+
 class TestDecomposition:
     """Tests that the template defines the correct decomposition."""
 

--- a/tests/templates/test_embeddings/test_basis.py
+++ b/tests/templates/test_embeddings/test_basis.py
@@ -20,6 +20,24 @@ import pennylane as qml
 from pennylane import numpy as pnp
 
 
+# pylint: disable=protected-access
+def test_flatten_unflatten():
+    """Test the _flatten and _unflatten methods."""
+    wires = qml.wires.Wires((0, 1, 2))
+    op = qml.BasisEmbedding(features=[1, 1, 1], wires=wires)
+    data, metadata = op._flatten()
+    assert data == tuple()
+    assert metadata[0] == wires
+    assert metadata[1] == (1, 1, 1)
+
+    # make sure metadata hashable
+    assert hash(metadata)
+
+    new_op = op._unflatten(*op._flatten())
+    assert qml.equal(op, new_op)
+    assert op is not new_op
+
+
 class TestDecomposition:
     """Tests that the template defines the correct decomposition."""
 

--- a/tests/templates/test_embeddings/test_displacement_emb.py
+++ b/tests/templates/test_embeddings/test_displacement_emb.py
@@ -21,6 +21,22 @@ from pennylane import numpy as pnp
 import pennylane as qml
 
 
+def test_flatten_unflatten_methods():
+    """Test the _flatten and _unflatten methods."""
+    feature_vector = [1, 2, 3]
+    op = qml.DisplacementEmbedding(features=feature_vector, wires=range(3), method="phase", c=0.5)
+    data, metadata = op._flatten()
+    assert op.data == data
+
+    # make sure metadata hashable
+    assert hash(metadata)
+
+    new_op = type(op)._unflatten(*op._flatten())
+    assert qml.equal(new_op, op)
+    assert new_op is not op
+    assert new_op._name == "DisplacementEmbedding"  # make sure initialized
+
+
 class TestDecomposition:
     """Tests that the template defines the correct decomposition."""
 

--- a/tests/templates/test_embeddings/test_qaoa_emb.py
+++ b/tests/templates/test_embeddings/test_qaoa_emb.py
@@ -21,6 +21,22 @@ import pennylane as qml
 from pennylane import numpy as pnp
 
 
+# pylint: disable=protected-access
+def test_flatten_unflatten():
+    """Test _flatten and _unflatten methods."""
+    features = [1.0, 2.0]
+    layer1 = [0.1, -0.3, 1.5]
+    layer2 = [3.1, 0.2, -2.8]
+    weights = [layer1, layer2]
+
+    op = qml.QAOAEmbedding(features=features, wires=(0, 1), weights=weights)
+    _, metadata = op._flatten()
+    assert hash(metadata)
+
+    new_op = type(op)._unflatten(*op._flatten())
+    assert qml.equal(op, new_op)
+
+
 class TestDecomposition:
     """Tests that the template defines the correct decomposition."""
 
@@ -214,6 +230,29 @@ class TestDecomposition:
 
 class TestInputs:
     """Test inputs and pre-processing."""
+
+    @pytest.mark.parametrize(
+        "local_field, expected",
+        (
+            ("X", qml.RX),
+            ("Y", qml.RY),
+            ("Z", qml.RZ),
+            (qml.RX, qml.RX),
+            (qml.RY, qml.RY),
+            (qml.RZ, qml.RZ),
+        ),
+    )
+    def test_local_field_options(self, local_field, expected):
+        """Verifies all allowed options for local field are accepted and set properly."""
+
+        features = [0]
+        n_wires = 1
+        weights = np.zeros(shape=(1, 1))
+        op = qml.QAOAEmbedding(
+            features=features, weights=weights, wires=range(n_wires), local_field=local_field
+        )
+
+        assert op.hyperparameters["local_field"] == expected
 
     def test_exception_fewer_qubits_than_features(
         self,

--- a/tests/templates/test_embeddings/test_squeezing_emb.py
+++ b/tests/templates/test_embeddings/test_squeezing_emb.py
@@ -21,6 +21,22 @@ from pennylane import numpy as pnp
 import pennylane as qml
 
 
+def test_flatten_unflatten_methods():
+    """Test the _flatten and _unflatten methods."""
+    feature_vector = [1, 2, 3]
+    op = qml.SqueezingEmbedding(features=feature_vector, wires=range(3), method="phase", c=0.5)
+    data, metadata = op._flatten()
+    assert op.data == data
+
+    # make sure metadata hashable
+    assert hash(metadata)
+
+    new_op = type(op)._unflatten(*op._flatten())
+    assert qml.equal(new_op, op)
+    assert new_op is not op
+    assert new_op._name == "SqueezingEmbedding"  # make sure initialized
+
+
 class TestDecomposition:
     """Tests that the template defines the correct decomposition."""
 

--- a/tests/templates/test_layers/test_random.py
+++ b/tests/templates/test_layers/test_random.py
@@ -21,6 +21,47 @@ import pennylane as qml
 from pennylane import numpy as pnp
 
 
+def test_hyperparameters():
+    """Test that the hyperparmaeters are set as expected."""
+    weights = np.array([[0.1, -2.1, 1.4]])
+    op = qml.RandomLayers(weights, wires=(0, 1))
+
+    assert op.hyperparameters == {
+        "ratio_imprim": 0.3,
+        "imprimitive": qml.CNOT,
+        "rotations": (qml.RX, qml.RY, qml.RZ),
+        "seed": 42,
+    }
+
+    op2 = qml.RandomLayers(
+        weights, wires=(0, 1), ratio_imprim=1.0, imprimitive=qml.CZ, rotations=(qml.RX,), seed=None
+    )
+
+    assert op2.hyperparameters == {
+        "ratio_imprim": 1.0,
+        "imprimitive": qml.CZ,
+        "rotations": (qml.RX,),
+        "seed": None,
+    }
+
+
+# pylint: disable=protected-access
+def test_flatten_unflatten():
+    """Test the behavior of the flatten and unflatten methods."""
+    weights = np.array([[0.1, -2.1, 1.4]])
+    op = qml.RandomLayers(weights, wires=(0, 1))
+
+    data, metadata = op._flatten()
+
+    assert qml.math.allclose(data[0], weights)
+    # check metadata hashable
+    assert hash(metadata)
+
+    new_op = type(op)._unflatten(*op._flatten())
+    assert qml.equal(new_op, op)
+    assert new_op is not op
+
+
 class TestDecomposition:
     """Tests that the template defines the correct decomposition."""
 
@@ -33,11 +74,18 @@ class TestDecomposition:
         op3 = qml.RandomLayers(weights, wires=range(2), seed=42)
 
         queue1 = op1.expand().operations
+        decomp1 = op1.compute_decomposition(*op1.parameters, wires=op1.wires, **op1.hyperparameters)
         queue2 = op2.expand().operations
+        decomp2 = op2.compute_decomposition(*op2.parameters, wires=op2.wires, **op2.hyperparameters)
         queue3 = op3.expand().operations
+        decomp3 = op3.compute_decomposition(*op3.parameters, wires=op3.wires, **op3.hyperparameters)
 
         assert not all(g1.name == g2.name for g1, g2 in zip(queue1, queue2))
         assert all(g2.name == g3.name for g2, g3 in zip(queue2, queue3))
+
+        assert all(qml.equal(op1, op2) for op1, op2 in zip(queue1, decomp1))
+        assert all(qml.equal(op1, op2) for op1, op2 in zip(queue2, decomp2))
+        assert all(qml.equal(op1, op2) for op1, op2 in zip(queue3, decomp3))
 
     @pytest.mark.parametrize("n_layers, n_rots", [(3, 4), (1, 2)])
     def test_number_gates(self, n_layers, n_rots):
@@ -57,11 +105,19 @@ class TestDecomposition:
         weights = np.random.random(size=(1, n_rots))
 
         op = qml.RandomLayers(weights, wires=range(2), ratio_imprim=ratio)
-        queue = op.expand().operations
+        queue = op.decomposition()
 
         gate_names = [gate.name for gate in queue]
         ratio_impr = gate_names.count("CNOT") / len(gate_names)
         assert np.isclose(ratio_impr, ratio, atol=0.05)
+
+        with pytest.warns(UserWarning):
+            decomp = op.compute_decomposition(
+                *op.parameters, wires=op.wires, **op.hyperparameters, ratio_imprimitive=0.9
+            )
+            gate_names = [gate.name for gate in decomp]
+            ratio_impr = gate_names.count("CNOT") / len(gate_names)
+            assert np.isclose(ratio_impr, 0.9, atol=0.05)
 
     def test_random_wires(self):
         """Test that random wires are picked for the gates. This is done by

--- a/tests/templates/test_subroutines/test_approx_time_evolution.py
+++ b/tests/templates/test_subroutines/test_approx_time_evolution.py
@@ -21,6 +21,25 @@ import pennylane as qml
 from pennylane.gradients.finite_difference import finite_diff
 
 
+# pylint: disable=protected-access
+def test_flatten_unflatten():
+    """Tests the _flatten and _unflatten methods."""
+    H = 2.0 * qml.PauliX(0) + 3.0 * qml.PauliY(0)
+    t = 0.1
+    op = qml.ApproxTimeEvolution(H, t, n=20)
+    data, metadata = op._flatten()
+    assert data[0] is H
+    assert data[1] == t
+    assert metadata == (20,)
+
+    # check metadata hashable
+    assert hash(metadata)
+
+    new_op = type(op)._unflatten(*op._flatten())
+    assert qml.equal(op, new_op)
+    assert new_op is not op
+
+
 class TestDecomposition:
     """Tests that the template defines the correct decomposition."""
 
@@ -365,6 +384,7 @@ class TestInterfaces:
         assert np.allclose(grads[0], grads2[0], atol=tol, rtol=0)
 
 
+# pylint: disable=protected-access, unexpected-keyword-arg
 @pytest.mark.autograd
 @pytest.mark.parametrize(
     "dev_name,diff_method",

--- a/tests/templates/test_subroutines/test_commuting_evolution.py
+++ b/tests/templates/test_subroutines/test_commuting_evolution.py
@@ -21,6 +21,28 @@ import pennylane as qml
 from pennylane import numpy as np
 
 
+# pylint: disable=protected-access
+def test_flatten_unflatten():
+    """Unit tests for the flatten and unflatten methods."""
+    H = 2.0 * qml.PauliX(0) @ qml.PauliY(1) + 3.0 * qml.PauliY(0) @ qml.PauliZ(1)
+    time = 0.5
+    frequencies = (2, 4)
+    shifts = (1, 0.5)
+    op = qml.CommutingEvolution(H, time, frequencies=frequencies, shifts=shifts)
+    data, metadata = op._flatten()
+
+    assert hash(metadata)
+
+    assert len(data) == 2
+    assert data[0] is H
+    assert data[1] == time
+    assert metadata == (frequencies, shifts)
+
+    new_op = type(op)._unflatten(*op._flatten())
+    assert qml.equal(op, new_op)
+    assert op is not new_op
+
+
 def test_adjoint():
     """Tests the CommutingEvolution.adjoint method provides the correct adjoint operation."""
 
@@ -138,11 +160,13 @@ class TestGradients:
 
         x_vals = np.linspace(-np.pi, np.pi, num=10)
 
+        # pylint: disable=not-callable
         grads_finite_diff = [qml.gradients.finite_diff(circuit)(x) for x in x_vals]
         grads_param_shift = [qml.gradients.param_shift(circuit)(x) for x in x_vals]
 
         assert all(np.isclose(grads_finite_diff, grads_param_shift, atol=1e-4))
 
+    # pylint: disable=not-callable
     def test_four_term_case(self):
         """Tests the parameter shift rules for `CommutingEvolution` equal the
         finite difference result for a four term shift rule case."""
@@ -168,6 +192,7 @@ class TestGradients:
 
         assert all(np.isclose(grads_finite_diff, grads_param_shift, atol=1e-4))
 
+    # pylint: disable=not-callable
     def test_differentiable_hamiltonian(self):
         """Tests correct gradients are produced when the Hamiltonian is differentiable."""
 

--- a/tests/templates/test_subroutines/test_double_excitation.py
+++ b/tests/templates/test_subroutines/test_double_excitation.py
@@ -20,6 +20,27 @@ from pennylane import numpy as pnp
 import pennylane as qml
 
 
+# pylint: disable=protected-access
+def test_flatten_unflatten():
+    """Test the _flatten and _unflatten methods."""
+    weight = 0.5
+    wires1 = qml.wires.Wires((0, 1))
+    wires2 = qml.wires.Wires((2, 3, 4))
+    op = qml.FermionicDoubleExcitation(weight, wires1=wires1, wires2=wires2)
+
+    data, metadata = op._flatten()
+    assert data == (0.5,)
+    assert metadata[0] == wires1
+    assert metadata[1] == wires2
+
+    # test that its hashable
+    assert hash(metadata)
+
+    new_op = type(op)._unflatten(*op._flatten())
+    assert qml.equal(op, new_op)
+    assert op is not new_op
+
+
 class TestDecomposition:
     """Tests that the template defines the correct decomposition."""
 

--- a/tests/templates/test_subroutines/test_flip_sign.py
+++ b/tests/templates/test_subroutines/test_flip_sign.py
@@ -19,6 +19,32 @@ from pennylane import numpy as np
 import pennylane as qml
 
 
+def test_repr():
+    """Test the repr for a flip sign operator."""
+    op = qml.FlipSign([0, 1], wires=("a", "b"))
+    expected = "FlipSign([0, 1], wires=['a', 'b'])"
+    assert repr(op) == expected
+
+
+# pylint: disable=protected-access
+def test_flatten_unflatten():
+    """Test the flatten and unflatten methods."""
+    op = qml.FlipSign([0, 1], wires=2)
+    data, metadata = op._flatten()
+
+    assert data == tuple()
+    hyperparameters = (("n", (0, 1)),)
+    assert metadata == (op.wires, hyperparameters)
+
+    # make sure metadata hasable
+    assert hash(metadata)
+
+    new_op = type(op)._unflatten(*op._flatten())
+    # data casted to tuple. unimportant difference
+    assert qml.equal(qml.FlipSign((0, 1), wires=2), new_op)
+    assert op is not new_op
+
+
 class TestFlipSign:
     """Tests that the template defines the correct sign flip."""
 
@@ -52,7 +78,7 @@ class TestFlipSign:
             return qml.state()
 
         def to_number(status):
-            return sum([status[i] * 2 ** (len(status) - i - 1) for i in range(len(status))])
+            return sum(status[i] * 2 ** (len(status) - i - 1) for i in range(len(status)))
 
         if isinstance(n_status, list):
             n_status = to_number(n_status)

--- a/tests/templates/test_subroutines/test_grover.py
+++ b/tests/templates/test_subroutines/test_grover.py
@@ -22,6 +22,32 @@ import pennylane as qml
 from pennylane.ops import Hadamard, PauliZ, MultiControlledX
 
 
+def test_repr():
+    """Tests the repr method for GroverOperator."""
+    op = qml.GroverOperator(wires=(0, 1, 2), work_wires=(3, 4))
+    expected = "GroverOperator(wires=[0, 1, 2], work_wires=[3, 4])"
+    assert repr(op) == expected
+
+
+# pylint: disable=protected-access
+def test_flatten_unflatten():
+    """Tests the flatten and unflatten methods for GroverOperator."""
+    work_wires = qml.wires.Wires((3, 4))
+    op = qml.GroverOperator(wires=(0, 1, 2), work_wires=work_wires)
+    data, metadata = op._flatten()
+    assert data == tuple()
+    assert len(metadata) == 2
+    assert metadata[0] == op.wires
+    assert metadata[1] == (("work_wires", work_wires),)
+
+    # make sure metadata hashable
+    assert hash(metadata)
+
+    new_op = type(op)._unflatten(*op._flatten())
+    assert qml.equal(op, new_op)
+    assert new_op is not op
+
+
 def test_work_wires():
     """Assert work wires get passed to MultiControlledX"""
     wires = ("a", "b")

--- a/tests/templates/test_subroutines/test_kupccgsd.py
+++ b/tests/templates/test_subroutines/test_kupccgsd.py
@@ -344,6 +344,40 @@ class TestDecomposition:
         assert gen_doubles_wires == generalized_pair_doubles_wires
 
 
+# pylint: disable=protected-access
+def test_flatten_unflatten():
+    """Tests the flatten and unflatten methods."""
+    weights = qml.math.array([[0.55, 0.72, 0.6, 0.54, 0.42, 0.65]])
+    wires = qml.wires.Wires((0, 1, 2, 3))
+    init_state = qml.math.array([1, 1, 0, 0])
+    op = qml.kUpCCGSD(
+        weights,
+        wires=wires,
+        k=1,
+        delta_sz=0,
+        init_state=init_state,
+    )
+    data, metadata = op._flatten()
+    assert data == (weights,)
+    assert len(metadata) == 2
+    assert metadata[0] == wires
+    assert metadata[1] == (("k", 1), ("delta_sz", 0), ("init_state", tuple(init_state)))
+
+    # make sure metadata hashable
+    assert hash(metadata)
+
+    new_op = type(op)._unflatten(*op._flatten())
+    assert op.data == new_op.data
+    assert type(new_op) is type(op)
+    assert op.hyperparameters["s_wires"] == new_op.hyperparameters["s_wires"]
+    assert op.hyperparameters["d_wires"] == new_op.hyperparameters["d_wires"]
+    assert op.hyperparameters["k"] == new_op.hyperparameters["k"]
+    assert op.hyperparameters["delta_sz"] == new_op.hyperparameters["delta_sz"]
+    assert qml.math.allclose(op.hyperparameters["init_state"], new_op.hyperparameters["init_state"])
+
+    assert op is not new_op
+
+
 class TestInputs:
     """Test inputs and pre-processing."""
 

--- a/tests/templates/test_subroutines/test_qmc.py
+++ b/tests/templates/test_subroutines/test_qmc.py
@@ -255,6 +255,23 @@ class TestQuantumMonteCarlo:
     def func(i):
         return np.sin(i) ** 2
 
+    # pylint: disable=protected-access
+    def test_flatten_unflatten(self):
+        """Test the flatten and unflatten methods."""
+        p = np.ones(4) / 4
+        target_wires, estimation_wires = Wires(range(3)), Wires(range(3, 5))
+
+        op = QuantumMonteCarlo(p, self.func, target_wires, estimation_wires)
+
+        data, metadata = op._flatten()
+        assert data is op.data
+        assert metadata[0] == op.wires
+        assert dict(metadata[1]) == op.hyperparameters
+
+        new_op = type(op)._unflatten(*op._flatten())
+        assert qml.equal(op, new_op)
+        assert op is not new_op
+
     def test_non_flat(self):
         """Test if a ValueError is raised when a non-flat array is input"""
         p = np.ones((4, 1)) / 4

--- a/tests/templates/test_subroutines/test_qpe.py
+++ b/tests/templates/test_subroutines/test_qpe.py
@@ -20,6 +20,24 @@ from scipy.stats import unitary_group
 import pennylane as qml
 
 
+# pylint: disable=protected-access
+def test_flatten_unflatten():
+    """Tests the flatten and unflatten methods."""
+    op = qml.QuantumPhaseEstimation(np.eye(4), target_wires=(0, 1), estimation_wires=[2, 3])
+    data, metadata = op._flatten()
+    expected_data = qml.QubitUnitary(np.eye(4), (0, 1))
+    assert qml.equal(data[0], expected_data)
+
+    assert metadata[0] == qml.wires.Wires((2, 3))
+
+    # make sure metadata is hashable
+    assert hash(metadata)
+
+    new_op = type(op)._unflatten(*op._flatten())
+    assert qml.equal(op, new_op)
+    assert op is not new_op
+
+
 class TestDecomposition:
     """Tests that the template defines the correct decomposition."""
 
@@ -52,7 +70,7 @@ class TestDecomposition:
         assert qscript[3].base.z == qscript2[3].base.z
         assert qscript[3].control_wires == qscript2[3].control_wires
 
-        assert isinstance(qscript[-1], qml.ops.op_math.Adjoint)
+        assert isinstance(qscript[-1], qml.ops.op_math.Adjoint)  # pylint: disable=no-member
         assert qml.equal(qscript[-1].base, qml.QFT(wires=(1, 2)))
 
         assert np.allclose(qscript[1].matrix(), qscript[1].matrix())
@@ -304,7 +322,7 @@ class TestDecomposition:
 
             return qml.state()
 
-        assert qml.math.isclose(qpe_circuit()[0], 1)
+        assert qml.math.isclose(qpe_circuit()[0], 1)  # pylint: disable=unsubscriptable-object
 
 
 class TestInputs:

--- a/tests/templates/test_subroutines/test_qsvt.py
+++ b/tests/templates/test_subroutines/test_qsvt.py
@@ -38,6 +38,21 @@ def lst_phis(phis):
 class TestQSVT:
     """Test the qml.QSVT template."""
 
+    # pylint: disable=protected-access
+    def test_flatten_unflatten(self):
+        projectors = [qml.PCPhase(0.2, dim=1, wires=0), qml.PCPhase(0.3, dim=1, wires=0)]
+        op = qml.QSVT(qml.PauliX(wires=0), projectors)
+        data, metadata = op._flatten()
+        assert qml.equal(data[0], qml.PauliX(0))
+        assert len(data[1]) == len(projectors)
+        assert all(qml.equal(op1, op2) for op1, op2 in zip(data[1], projectors))
+
+        assert metadata == tuple()
+
+        new_op = type(op)._unflatten(*op._flatten())
+        assert qml.equal(op, new_op)
+        assert op is not new_op
+
     def test_init_error(self):
         """Test that an error is raised if a non-operation object is passed
         for the block-encoding."""

--- a/tests/templates/test_swapnetworks/test_ccl2.py
+++ b/tests/templates/test_swapnetworks/test_ccl2.py
@@ -14,12 +14,44 @@
 """
 Tests for the TwoLocalSwapNetwork template.
 """
-# pylint: disable=too-many-arguments,too-few-public-methods
+
 import pytest
 from pennylane import numpy as np
 import pennylane as qml
 
 
+# pylint: disable=protected-access
+def test_flatten_unflatten():
+    """Test the flatten and unflatten methods."""
+
+    def acquaintances(index, *_, use_CNOT=True, **__):
+        return qml.CNOT(index) if use_CNOT else qml.CZ(index)
+
+    weights = np.array([0.5, 0.6, 0.7])
+    wires = qml.wires.Wires((0, 1, 2))
+
+    op = qml.templates.TwoLocalSwapNetwork(
+        wires, acquaintances, weights, fermionic=True, shift=False, use_CNOT=False
+    )
+    data, metadata = op._flatten()
+    assert qml.math.allclose(data[0], weights)
+    assert metadata[0] == wires
+    assert metadata[1] == (
+        ("acquaintances", acquaintances),
+        ("fermionic", True),
+        ("shift", False),
+        ("use_CNOT", False),
+    )
+
+    # make sure metadata is hashable
+    assert hash(metadata)
+
+    new_op = type(op)._unflatten(*op._flatten())
+    assert qml.equal(new_op, op)
+    assert new_op is not op
+
+
+# pylint: disable=too-many-arguments
 class TestDecomposition:
     """Test that the template defines the correct decomposition."""
 
@@ -73,8 +105,10 @@ class TestDecomposition:
     def test_custom_wire_labels(self, tol=1e-8):
         """Test that template can deal with non-numeric, nonconsecutive wire labels."""
 
-        acquaintances = lambda index, wires, param=None: qml.CNOT(index)
-        weights = np.random.random(size=(10))
+        def acquaintances(index, *_, **___):
+            return qml.CNOT(index)
+
+        weights = np.random.random(size=10)
 
         dev = qml.device("default.qubit", wires=5)
         dev2 = qml.device("default.qubit", wires=["z", "a", "k", "e", "y"])
@@ -350,7 +384,7 @@ class TestInterfaces:
         import jax
         import jax.numpy as jnp
 
-        weights = jnp.array(np.random.random(size=(6)))
+        weights = jnp.array(np.random.random(size=6))
 
         dev = qml.device("default.qubit", wires=4)
 
@@ -375,7 +409,7 @@ class TestInterfaces:
 
         import tensorflow as tf
 
-        weights = tf.Variable(np.random.random(size=(6)))
+        weights = tf.Variable(np.random.random(size=6))
 
         dev = qml.device("default.qubit", wires=4)
 
@@ -402,7 +436,7 @@ class TestInterfaces:
 
         import torch
 
-        weights = torch.tensor(np.random.random(size=(6)), requires_grad=True)
+        weights = torch.tensor(np.random.random(size=6), requires_grad=True)
 
         dev = qml.device("default.qubit", wires=4)
 
@@ -424,6 +458,7 @@ class TestInterfaces:
         assert np.allclose(grads[0], grads2[0], atol=tol, rtol=0)
 
 
+# pylint: disable=too-few-public-methods
 class TestGradient:
     """Test that the parameter-shift rule for this template matches that of backprop."""
 

--- a/tests/templates/test_tensornetworks/test_MPS.py
+++ b/tests/templates/test_tensornetworks/test_MPS.py
@@ -21,6 +21,41 @@ import pennylane as qml
 from pennylane.templates.tensornetworks.mps import compute_indices_MPS, MPS
 
 
+# pylint: disable=protected-access
+def test_flatten_unflatten():
+    """Test the flatten and unflatten methods."""
+
+    def block(weights, wires):
+        qml.CNOT(wires=[wires[0], wires[1]])
+        qml.RY(weights[0], wires=wires[0])
+        qml.RY(weights[1], wires=wires[1])
+
+    n_wires = 4
+    n_block_wires = 2
+    n_params_block = 2
+    n_blocks = qml.MPS.get_n_blocks(range(n_wires), n_block_wires)
+    template_weights = [[0.1, -0.3]] * n_blocks
+
+    wires = qml.wires.Wires((0, 1, 2, 3))
+
+    op = qml.MPS(wires, n_block_wires, block, n_params_block, template_weights)
+
+    data, metadata = op._flatten()
+    assert len(data) == 1
+    assert qml.math.allclose(data[0], template_weights)
+
+    assert metadata[0] == wires
+    assert dict(metadata[1]) == op.hyperparameters
+
+    # make sure metadata hashable
+    assert hash(metadata)
+
+    new_op = qml.MPS._unflatten(*op._flatten())
+    assert qml.equal(new_op, op)
+    assert new_op._name == "MPS"  # make sure acutally initialized
+    assert new_op is not op
+
+
 class TestIndicesMPS:
     """Test function that computes MPS indices"""
 
@@ -91,15 +126,14 @@ class TestIndicesMPS:
     @pytest.mark.parametrize(
         ("wires", "n_block_wires", "expected_indices"),
         [
-            ([1, 2, 3, 4], 2, [[1, 2], [2, 3], [3, 4]]),
-            (["a", "b", "c", "d"], 2, [["a", "b"], ["b", "c"], ["c", "d"]]),
+            ([1, 2, 3, 4], 2, ((1, 2), (2, 3), (3, 4))),
+            (["a", "b", "c", "d"], 2, (("a", "b"), ("b", "c"), ("c", "d"))),
         ],
     )
     def test_indices_output(self, wires, n_block_wires, expected_indices):
         """Verifies the indices are correct for both integer and string wire labels."""
         indices = compute_indices_MPS(wires, n_block_wires)
-        for idx, exp_idx in zip(indices, expected_indices):
-            assert all(idx == exp_idx)
+        assert indices == expected_indices
 
 
 class TestTemplateInputs:

--- a/tests/templates/test_tensornetworks/test_TTN.py
+++ b/tests/templates/test_tensornetworks/test_TTN.py
@@ -21,6 +21,41 @@ import pennylane as qml
 from pennylane.templates.tensornetworks.ttn import compute_indices, TTN
 
 
+# pylint: disable=protected-access
+def test_flatten_unflatten_methods():
+    """Tests the _flatten and _unflatten methods."""
+
+    def block(weights, wires):
+        qml.CNOT(wires=[wires[0], wires[1]])
+        qml.RY(weights[0], wires=wires[0])
+        qml.RY(weights[1], wires=wires[1])
+
+    n_wires = 4
+    n_block_wires = 2
+    n_params_block = 2
+    n_blocks = qml.MPS.get_n_blocks(range(n_wires), n_block_wires)
+    template_weights = [[0.1, -0.3]] * n_blocks
+
+    wires = qml.wires.Wires((0, 1, 2, 3))
+
+    op = qml.TTN(wires, n_block_wires, block, n_params_block, template_weights)
+
+    data, metadata = op._flatten()
+    assert len(data) == 1
+    assert qml.math.allclose(data[0], template_weights)
+
+    assert metadata[0] == wires
+    assert dict(metadata[1]) == op.hyperparameters
+
+    # make sure metadata hashable
+    assert hash(metadata)
+
+    new_op = qml.TTN._unflatten(*op._flatten())
+    assert qml.equal(new_op, op)
+    assert new_op._name == "TTN"  # make sure acutally initialized
+    assert new_op is not op
+
+
 def circuit0_block(wires):
     qml.PauliX(wires=wires[1])
     qml.PauliZ(wires=wires[0])
@@ -148,9 +183,9 @@ class TestIndicesTTN:
     @pytest.mark.parametrize(
         ("wires", "n_block_wires", "expected_indices"),
         [
-            ([1, 2, 3, 4], 2, [[1, 2], [3, 4], [2, 4]]),
-            (range(12), 6, [[0, 1, 2, 3, 4, 5], [6, 7, 8, 9, 10, 11], [3, 4, 5, 9, 10, 11]]),
-            (["a", "b", "c", "d"], 2, [["a", "b"], ["c", "d"], ["b", "d"]]),
+            ([1, 2, 3, 4], 2, ((1, 2), (3, 4), (2, 4))),
+            (range(12), 6, ((0, 1, 2, 3, 4, 5), (6, 7, 8, 9, 10, 11), (3, 4, 5, 9, 10, 11))),
+            (("a", "b", "c", "d"), 2, (("a", "b"), ("c", "d"), ("b", "d"))),
         ],
     )
     def test_indices_output(self, wires, n_block_wires, expected_indices):

--- a/tests/test_qaoa.py
+++ b/tests/test_qaoa.py
@@ -166,7 +166,7 @@ class TestMixerHamiltonians:
         assert all(qml.is_commuting(o, mixer_hamiltonian.ops[0]) for o in mixer_hamiltonian.ops[1:])
         # check that the 1-group grouping information was set
         assert mixer_hamiltonian.grouping_indices is not None
-        assert mixer_hamiltonian.grouping_indices == [[0, 1, 2, 3]]
+        assert mixer_hamiltonian.grouping_indices == ((0, 1, 2, 3),)
 
     def test_xy_mixer_type_error(self):
         """Tests that the XY mixer throws the correct error"""
@@ -960,7 +960,7 @@ class TestCostHamiltonians:
         assert all(qml.is_commuting(o, cost_h.ops[0]) for o in cost_h.ops[1:])
         # check that the 1-group grouping information was set
         assert cost_h.grouping_indices is not None
-        assert cost_h.grouping_indices == [list(range(len(cost_h.ops)))]
+        assert cost_h.grouping_indices == (tuple(range(len(cost_h.ops))),)
 
     @pytest.mark.parametrize(("graph", "constrained", "cost_hamiltonian", "mixer_hamiltonian"), MIS)
     def test_mis_output(self, graph, constrained, cost_hamiltonian, mixer_hamiltonian):
@@ -981,7 +981,7 @@ class TestCostHamiltonians:
         assert all(qml.is_commuting(o, cost_h.ops[0]) for o in cost_h.ops[1:])
         # check that the 1-group grouping information was set
         assert cost_h.grouping_indices is not None
-        assert cost_h.grouping_indices == [list(range(len(cost_h.ops)))]
+        assert cost_h.grouping_indices == (tuple(range(len(cost_h.ops))),)
 
     @pytest.mark.parametrize(("graph", "constrained", "cost_hamiltonian", "mixer_hamiltonian"), MVC)
     def test_mvc_output(self, graph, constrained, cost_hamiltonian, mixer_hamiltonian):
@@ -1002,7 +1002,7 @@ class TestCostHamiltonians:
         assert all(qml.is_commuting(o, cost_h.ops[0]) for o in cost_h.ops[1:])
         # check that the 1-group grouping information was set
         assert cost_h.grouping_indices is not None
-        assert cost_h.grouping_indices == [list(range(len(cost_h.ops)))]
+        assert cost_h.grouping_indices == (tuple(range(len(cost_h.ops))),)
 
     @pytest.mark.parametrize(
         ("graph", "constrained", "cost_hamiltonian", "mixer_hamiltonian"), MAXCLIQUE
@@ -1025,7 +1025,7 @@ class TestCostHamiltonians:
         assert all(qml.is_commuting(o, cost_h.ops[0]) for o in cost_h.ops[1:])
         # check that the 1-group grouping information was set
         assert cost_h.grouping_indices is not None
-        assert cost_h.grouping_indices == [list(range(len(cost_h.ops)))]
+        assert cost_h.grouping_indices == (tuple(range(len(cost_h.ops))),)
 
     # pylint: disable=too-many-arguments
     @pytest.mark.parametrize(
@@ -1060,7 +1060,7 @@ class TestCostHamiltonians:
         assert all(qml.is_commuting(o, cost_h.ops[0]) for o in cost_h.ops[1:])
         # check that the 1-group grouping information was set
         assert cost_h.grouping_indices is not None
-        assert cost_h.grouping_indices == [list(range(len(cost_h.ops)))]
+        assert cost_h.grouping_indices == (tuple(range(len(cost_h.ops))),)
 
 
 # pylint: disable=too-few-public-methods

--- a/tests/transforms/test_hamiltonian_expand.py
+++ b/tests/transforms/test_hamiltonian_expand.py
@@ -240,8 +240,8 @@ class TestHamiltonianExpand:
         tape = QuantumScript.from_queue(q)
 
         def cost(x):
-            tape.set_parameters(x, trainable_only=False)
-            tapes, fn = hamiltonian_expand(tape)
+            new_tape = tape.bind_new_parameters(x, list(range(9)))
+            tapes, fn = hamiltonian_expand(new_tape)
             res = qml.execute(tapes, dev, qml.gradients.param_shift)
             return fn(res)
 
@@ -523,8 +523,8 @@ class TestSumExpand:
         qscript = QuantumScript.from_queue(q)
 
         def cost(x):
-            qscript.set_parameters(x, trainable_only=False)
-            tapes, fn = sum_expand(qscript)
+            new_qscript = qscript.bind_new_parameters(x, list(range(9)))
+            tapes, fn = sum_expand(new_qscript)
             res = qml.execute(tapes, dev, qml.gradients.param_shift)
             return fn(res)
 
@@ -617,8 +617,8 @@ class TestSumExpand:
         qscript = QuantumScript.from_queue(q)
 
         def cost(x):
-            qscript.set_parameters(x, trainable_only=False)
-            tapes, fn = sum_expand(qscript)
+            new_qscript = qscript.bind_new_parameters(x, list(range(9)))
+            tapes, fn = sum_expand(new_qscript)
             res = qml.execute(tapes, dev, qml.gradients.param_shift)
             return fn(res)
 


### PR DESCRIPTION
**Context:**

**Description of the Change:**
* Add qubit reuse capability.
* Add `reset` keyword argument to `qml.measure` to enable reseting wire after mid-circuit measurement.
* Allow collecting statistics of mid-circuit measurements together with the terminal measurements.
```python
@qml.qnode(dev)
def circuit():
    ...
    m = qml.measure(0, reset=True)
    ...
    return qml.expval(qml.PauliZ(0)), qml.expval(m)
```

Currently, `expval`, `var`, `probs`, and `sample` are supported. Users can also request statistics for joint mid-circuit measurements. Multiple measurement values can be combined using `@`:
```python
@qml.qnode(dev)
def circuit():
    ...
    m1 = qml.measure(0, reset=True)
    ...
    m2 = qml.measure(1)
    ...
    return qml.expval(qml.PauliZ(0)), qml.expval(m1 @ m2)
```

**Benefits:**
Expanded functionality of mid-circuit measurements

**Possible Drawbacks:**
* Every mid-circuit measurement adds a new "auxiliary" wire to the tape, so for a tape with n mid-circuit measurements, devices must be initialized with n extra wires. This isn't applicable to `DefaultQubit2`, which infers the number of wires dynamically.
* Measurement logic is implemented in the `pennylane.measurements` module, so mid-circuit measurement statistics will not currently work with any devices that implement custom measurement logic.
* Adding new wires impacts increases space complexity by a factor of `O(2**n)`.

**Related GitHub Issues:**
