### PR TITLE
Fixes for new autoray version

### DIFF
--- a/pennylane/math/multi_dispatch.py
+++ b/pennylane/math/multi_dispatch.py
@@ -769,9 +769,8 @@ def add(*args, like=None, **kwargs):
     """Add arguments element-wise."""
     if like == "scipy":
         return onp.add(*args, **kwargs)  # Dispatch scipy add to numpy backed specifically.
-    try:
-        return np.add(*args, **kwargs)
-    except TypeError:
+
+    if like == "torch":
         # In autoray 0.6.5, np.add dispatches to torch instead of
         # numpy if one parameter is a torch tensor and the other is
         # a numpy array. torch.add raises an Exception if one of the
@@ -781,6 +780,8 @@ def add(*args, like=None, **kwargs):
         arg0 = np.asarray(args[0], device=dev, like=like)
         arg1 = np.asarray(args[1], device=dev, like=like)
         return np.add(arg0, arg1, *args[2:], **kwargs)
+
+    return np.add(*args, **kwargs)
 
 
 @multi_dispatch()

--- a/pennylane/math/multi_dispatch.py
+++ b/pennylane/math/multi_dispatch.py
@@ -23,7 +23,7 @@ from autoray import numpy as np
 from numpy import ndarray
 
 from . import single_dispatch  # pylint:disable=unused-import
-from .utils import cast, cast_like, convert_like, get_interface, requires_grad
+from .utils import cast, cast_like, get_interface, requires_grad
 
 
 # pylint:disable=redefined-outer-name

--- a/pennylane/math/multi_dispatch.py
+++ b/pennylane/math/multi_dispatch.py
@@ -770,7 +770,10 @@ def add(*args, like=None, **kwargs):
     if like == "scipy":
         return onp.add(*args, **kwargs)  # Dispatch scipy add to numpy backed specifically.
 
-    if like == "torch":
+    arg_interfaces = {get_interface(args[0]), get_interface(args[1])}
+
+    # case of one torch tensor and one vanilla numpy array
+    if like == "torch" and len(arg_interfaces) == 2:
         # In autoray 0.6.5, np.add dispatches to torch instead of
         # numpy if one parameter is a torch tensor and the other is
         # a numpy array. torch.add raises an Exception if one of the

--- a/tests/devices/qubit/test_apply_operation.py
+++ b/tests/devices/qubit/test_apply_operation.py
@@ -168,7 +168,7 @@ class TestTwoQubitStateSpecialCases:
         initial_state = qml.math.asarray(initial_state, like=ml_framework)
 
         phase = qml.math.asarray(-2.3, like=ml_framework)
-        shift = np.exp(qml.math.multiply(1j, phase))
+        shift = qml.math.exp(1j * qml.math.cast(phase, np.complex128))
 
         new_state = method(qml.PhaseShift(phase, wire), initial_state)
 


### PR DESCRIPTION
**Context:**
Autoray released a new version that changed the dispatch logic of some functions with multiple arguments, namely `add` and `multiply`. This was breaking some tests.

**Description of the Change:**
For `qml.math.add`, the only issue is with PyTorch since `torch.add` doesn't support NumPy arguments. The original overriden function switched the order of the arguments so that it dispatches via NumPy instead, but that doesn't work with the new autoray dispatch logic. Here we just cast both arguments to PyTorch tensors.

For `qml.math.multiply`, this is only used in one of the tests, and we simply cast the argument to `np.complex128`.
