### PR TITLE
Pin autoray to 0.6.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ toml~=0.10
 appdirs~=1.4
 semantic_version~=2.10
 dask[delayed]~=2022.4.1
-autoray==0.3.1
+autoray>=0.3.1,<=0.6.3
 matplotlib~=3.5
 opt_einsum~=3.3
 requests~=2.31.0

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ requirements = [
     "toml",
     "appdirs",
     "semantic-version>=2.7",
-    "autoray>=0.3.1",
+    "autoray>=0.3.1,<=0.6.3",
     "cachetools",
     "pennylane-lightning>=0.31",
     "requests",


### PR DESCRIPTION
A recent release of autoray broke some stuff, so we pin the autoray version to the one that was concurrent with the last release.