### PR TITLE
raise error with actual identifier name

### DIFF
--- a/pennylane/data/data_manager/foldermap.py
+++ b/pennylane/data/data_manager/foldermap.py
@@ -141,7 +141,7 @@ class FolderMapView(typing.Mapping[str, Union["FolderMapView", DataPath]]):
                     )
                 except KeyError as exc:
                     raise ValueError(
-                        f"molname '{exc.args[0]}' is not available. Available values are: {list(curr_level)}"
+                        f"{param_name} '{exc.args[0]}' is not available. Available values are: {list(curr_level)}"
                     ) from exc
 
             curr, todo = todo, curr


### PR DESCRIPTION
we were always saying "molname" as the identifier when saying an invalid one was provided.

Before:
```pycon
>>> qml.data.load("qchem", molname="H2", bondlength=100)
Traceback (most recent call last):
  ...
  File "/Users/matthews/src/github.com/PennyLaneAI/pennylane/pennylane/data/data_manager/foldermap.py", line 168, in __getitem__
    elem = self.__curr_level[__key]
KeyError: '100.0'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  ...
  File "/Users/matthews/src/github.com/PennyLaneAI/pennylane/pennylane/data/data_manager/foldermap.py", line 143, in find
    raise ValueError(
ValueError: molname '100.0' is not available. Available values are: ['0.5', '0.54', '0.58', '0.62', '0.66', '0.7', '0.74', '0.742', '0.78', '0.82', '0.86', '0.9', '0.94', '0.98', '1.02', '1.06', '1.1', '1.14', '1.18', '1.22', '1.26', '1.3', '1.34', '1.38', '1.42', '1.46', '1.5', '1.54', '1.58', '1.62', '1.66', '1.7', '1.74', '1.78', '1.82', '1.86', '1.9', '1.94', '1.98', '2.02', '2.06', '2.1']
```

After:
```pycon
>>> qml.data.load("qchem", molname="H2", bondlength=100)
Traceback (most recent call last):
  ...
  File "/Users/matthews/src/github.com/PennyLaneAI/pennylane/pennylane/data/data_manager/foldermap.py", line 168, in __getitem__
    elem = self.__curr_level[__key]
KeyError: '100.0'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  ...
  File "/Users/matthews/src/github.com/PennyLaneAI/pennylane/pennylane/data/data_manager/foldermap.py", line 143, in find
    raise ValueError(
ValueError: bondlength '100.0' is not available. Available values are: ['0.5', '0.54', '0.58', '0.62', '0.66', '0.7', '0.74', '0.742', '0.78', '0.82', '0.86', '0.9', '0.94', '0.98', '1.02', '1.06', '1.1', '1.14', '1.18', '1.22', '1.26', '1.3', '1.34', '1.38', '1.42', '1.46', '1.5', '1.54', '1.58', '1.62', '1.66', '1.7', '1.74', '1.78', '1.82', '1.86', '1.9', '1.94', '1.98', '2.02', '2.06', '2.1']
```