### PR TITLE
fix `has_decomposition` for ControlledQubitUnitary

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -209,6 +209,10 @@
   trainable parameters of the expanded tape.
   [(#4365)](https://github.com/PennyLaneAI/pennylane/pull/4365)
 
+* `qml.ControlledQubitUnitary` no longer reports `has_decomposition` as `True` when it does
+  not really have a decomposition.
+  [(#4407)](https://github.com/PennyLaneAI/pennylane/pull/4407)
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane/ops/op_math/controlled_ops.py
+++ b/pennylane/ops/op_math/controlled_ops.py
@@ -144,6 +144,17 @@ class ControlledQubitUnitary(ControlledOp):
             work_wires=self.work_wires,
         )
 
+    @property
+    def has_decomposition(self):
+        if not super().has_decomposition:
+            return False
+        with qml.QueuingManager.stop_recording():
+            try:
+                self.decomposition()
+            except qml.operation.DecompositionUndefinedError:
+                return False
+        return True
+
 
 class CY(ControlledOp):
     r"""CY(wires)

--- a/pennylane/ops/op_math/controlled_ops.py
+++ b/pennylane/ops/op_math/controlled_ops.py
@@ -149,6 +149,8 @@ class ControlledQubitUnitary(ControlledOp):
         if not super().has_decomposition:
             return False
         with qml.QueuingManager.stop_recording():
+            # we know this is using try-except as logical control, but are favouring
+            # certainty in it being correct over explicitness in an edge case.
             try:
                 self.decomposition()
             except qml.operation.DecompositionUndefinedError:

--- a/tests/ops/op_math/test_controlled_decompositions.py
+++ b/tests/ops/op_math/test_controlled_decompositions.py
@@ -673,3 +673,11 @@ def test_ControlledQubitUnitary_has_decomposition_correct():
     assert not op.has_decomposition
     with pytest.raises(qml.operation.DecompositionUndefinedError):
         op.decomposition()
+
+
+def test_ControlledQubitUnitary_has_decomposition_super_False(mocker):
+    """Test that has_decomposition returns False if super() returns False"""
+    spy = mocker.spy(qml.QueuingManager, "stop_recording")
+    op = qml.ControlledQubitUnitary(np.diag((1.0,) * 8), wires=[2, 3, 4], control_wires=[0, 1])
+    assert not op.has_decomposition
+    spy.assert_not_called()

--- a/tests/ops/op_math/test_controlled_decompositions.py
+++ b/tests/ops/op_math/test_controlled_decompositions.py
@@ -224,7 +224,7 @@ class TestControlledDecompositionZYZ:
         decomp = (
             op.expand().expand().circuit if test_expand else op.decomposition()[0].decomposition()
         )
-        expected = qml.ops.ctrl_decomp_zyz(base, (0,))
+        expected = qml.ops.ctrl_decomp_zyz(base, (0,))  # pylint:disable=no-member
         assert equal_list(decomp, expected)
 
     @pytest.mark.xfail
@@ -232,7 +232,7 @@ class TestControlledDecompositionZYZ:
     def test_zyz_decomp_control_values(self, test_expand):
         """Test that the ZYZ decomposition is used for single qubit target operations
         when other decompositions aren't available and control values are present."""
-
+        # pylint:disable=no-member
         base = qml.QubitUnitary(
             np.array(
                 [
@@ -663,3 +663,13 @@ class TestControlledBisectGeneral:
         expected = expected_op.matrix()
 
         assert np.allclose(res, expected, atol=tol, rtol=tol)
+
+
+def test_ControlledQubitUnitary_has_decomposition_correct():
+    """Test that ControlledQubitUnitary reports has_decomposition=False if it is False"""
+    U = qml.Toffoli(wires=[0, 1, 2]).matrix()
+    op = qml.ControlledQubitUnitary(U, wires=[1, 2, 3], control_wires=[0])
+
+    assert not op.has_decomposition
+    with pytest.raises(qml.operation.DecompositionUndefinedError):
+        op.decomposition()


### PR DESCRIPTION
**Context:**
In #4355, we changed the way tapes get expanded. Part of this says `if op.has_decomposition: use op.decomposition()`. Unfortunately, sometimes, instances of `ControlledQubitUnitary` will report `has_decomposition=True` when it does not really have one. This is especially unfortunate because it makes [qml builds fail](https://github.com/PennyLaneAI/qml/actions/runs/5674935721/job/15379372776)

**Description of the Change:**
Override `ControlledQubitUnitary.has_decomposition` to double-check its truthiness by trying to get its decomposition in a try-except, returning False if a `DecompositionUndefinedError` is caught.

**Benefits:**
No more lies! qml builds pass!

**Possible Drawbacks:**
If the operator _does_ have a decomposition, we have to evaluate it twice. I think the benefits (tape expansion involving these operators) outweigh the costs, especially considering that the base (`QubitUnitary`) only has decompositions for 1-qubit matrices, so evaluating its decomposition twice shouldn't be toooo bad