### PR TITLE
Fixing pytest: no longer turn warning into error

### DIFF
--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -20,4 +20,3 @@ filterwarnings =
     ignore:Casting complex values to real discards the imaginary part:UserWarning:torch.autograd
     ignore:Call to deprecated create function:DeprecationWarning
     ignore:the imp module is deprecated:DeprecationWarning
-    error:The behaviour of operator:UserWarning


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      test directory!

- [x] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `doc/releases/changelog-dev.md` file, summarizing the
      change, and including a link back to the PR.

- [x] The PennyLane source code conforms to
      [PEP8 standards](https://www.python.org/dev/peps/pep-0008/).
      We check all of our code against [Pylint](https://www.pylint.org/).
      To lint modified files, simply `pip install pylint`, and then
      run `pylint pennylane/path/to/file.py`.

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:** This PR fixes current test warnings causing pytest failures:
```bash
================================================================================== short test summary info ===================================================================================
ERROR tests/legacy/test_legacy_qcut_old.py - UserWarning: The behaviour of operator hashing will be updated soon. Currently, each operator instance has a unique hash. Soon, an operator's hash will be determined by the combined has...
ERROR tests/ops/functions/test_matrix.py - UserWarning: The behaviour of operator hashing will be updated soon. Currently, each operator instance has a unique hash. Soon, an operator's hash will be determined by the combined has...
ERROR tests/ops/op_math/test_prod.py - UserWarning: The behaviour of operator hashing will be updated soon. Currently, each operator instance has a unique hash. Soon, an operator's hash will be determined by the combined has...
ERROR tests/transforms/test_qcut.py - UserWarning: The behaviour of operator hashing will be updated soon. Currently, each operator instance has a unique hash. Soon, an operator's hash will be determined by the combined has...
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 4 errors during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
========================================================================= 51 skipped, 10 warnings, 4 errors in 7.19s ===
```

**Description of the Change:** Remove a pytest.ini warning entry.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
