### PR TITLE
Escape special characters in Dataset URL

### DIFF
--- a/doc/releases/changelog-0.31.1.md
+++ b/doc/releases/changelog-0.31.1.md
@@ -14,7 +14,7 @@
 <h3>Bug Fixes 🐛</h3>
 
 * Dataset URLs are now properly escaped when fetching from S3.
-  [(4412)](https://github.com/PennyLaneAI/pennylane/pull/4412)
+  [(#4412)](https://github.com/PennyLaneAI/pennylane/pull/4412)
 
 <h3>Contributors ✍️</h3>
 

--- a/doc/releases/changelog-0.31.1.md
+++ b/doc/releases/changelog-0.31.1.md
@@ -11,6 +11,11 @@
   be compatible with higher versions of scipy.
   [(#4321)](https://github.com/PennyLaneAI/pennylane/pull/4321)
 
+<h3>Bug Fixes 🐛</h3>
+
+* Dataset URLs are now properly escaped when fetching from S3.
+  [(4412)](https://github.com/PennyLaneAI/pennylane/pull/4412)
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane/data/data_manager/__init__.py
+++ b/pennylane/data/data_manager/__init__.py
@@ -17,6 +17,7 @@ them.
 """
 
 import typing
+import urllib.parse
 from concurrent.futures import FIRST_EXCEPTION, ThreadPoolExecutor, wait
 from functools import lru_cache
 from pathlib import Path
@@ -76,7 +77,11 @@ def _download_dataset(
 ) -> None:
     """Downloads the dataset at ``data_path`` to ``dest``, optionally downloading
     only requested attributes."""
-    s3_path = f"{S3_URL}/{data_path}"
+
+    # URL-escape special characters like '+', '$', and '%' in the data path
+    url_safe_datapath = urllib.parse.quote(str(data_path))
+
+    s3_path = f"{S3_URL}/{url_safe_datapath}"
 
     if attributes is not None:
         _download_partial(s3_path, dest, attributes, overwrite=force)
@@ -290,9 +295,12 @@ def load_interactive():
 
     params = data_struct[data_name]["params"]
     for param in params:
-        node = node[value]
-        value = _interactive_request_single(node, param)
-        description[param] = value
+        try:
+            node = node[value]
+            value = _interactive_request_single(node, param)
+            description[param] = value
+        except TypeError as exc:
+            raise ValueError(param) from exc
 
     attributes = _interactive_request_attributes(data_struct[data_name]["attributes"])
     force = input("Force download files? (Default is no) [y/N]: ") in ["y", "Y"]

--- a/pennylane/data/data_manager/__init__.py
+++ b/pennylane/data/data_manager/__init__.py
@@ -295,12 +295,9 @@ def load_interactive():
 
     params = data_struct[data_name]["params"]
     for param in params:
-        try:
-            node = node[value]
-            value = _interactive_request_single(node, param)
-            description[param] = value
-        except TypeError as exc:
-            raise ValueError(param) from exc
+        node = node[value]
+        value = _interactive_request_single(node, param)
+        description[param] = value
 
     attributes = _interactive_request_attributes(data_struct[data_name]["attributes"])
     force = input("Force download files? (Default is no) [y/N]: ") in ["y", "Y"]

--- a/tests/data/data_manager/test_dataset_access.py
+++ b/tests/data/data_manager/test_dataset_access.py
@@ -26,7 +26,7 @@ import pennylane.data.data_manager
 from pennylane.data import Dataset
 from pennylane.data.data_manager import DataPath, S3_URL
 
-# pylint:disable=protected-access
+# pylint:disable=protected-access,redefined-outer-name
 
 
 pytestmark = pytest.mark.data

--- a/tests/data/data_manager/test_dataset_access.py
+++ b/tests/data/data_manager/test_dataset_access.py
@@ -24,6 +24,7 @@ import requests
 import pennylane as qml
 import pennylane.data.data_manager
 from pennylane.data import Dataset
+from pennylane.data.data_manager import DataPath, S3_URL
 
 # pylint:disable=protected-access
 
@@ -79,12 +80,21 @@ def get_mock(url, timeout=1.0):
     return resp
 
 
+@pytest.fixture
+def mock_get_args():
+    """A Mock object that tracks the arguments passed to ``mock_requests_get``."""
+
+    return MagicMock()
+
+
 @pytest.fixture(autouse=True)
-def mock_requests_get(request, monkeypatch):
+def mock_requests_get(request, monkeypatch, mock_get_args):
     """Patches `requests.get()` in the data_manager module so that
     it returns mock JSON data for the foldermap and data struct."""
 
-    def mock_get(url, **kwargs):
+    def mock_get(url, *args, **kwargs):
+        mock_get_args(url, *args, **kwargs)
+
         mock_resp = MagicMock()
         if url == qml.data.data_manager.FOLDERMAP_URL:
             json_data = _folder_map
@@ -328,3 +338,41 @@ def test_download_dataset_partial(tmp_path, monkeypatch):
 
     assert local.x == 1
     assert not hasattr(local, "y")
+
+
+@patch("builtins.open")
+@pytest.mark.parametrize(
+    "datapath, escaped",
+    [("data/NH3+/data.h5", "data/NH3%2B/data.h5"), ("data/CA$H/money.h5", "data/CA%24H/money.h5")],
+)
+def test_download_dataset_escapes_url(_, mock_get_args, datapath, escaped):
+    """Tests that _download_dataset escapes special characters in a URL when doing a full download."""
+
+    dest = MagicMock()
+    dest.exists.return_value = False
+
+    pennylane.data.data_manager._download_dataset(DataPath(datapath), dest=dest, attributes=None)
+
+    mock_get_args.assert_called_once()
+    assert mock_get_args.call_args[0] == (f"{S3_URL}/{escaped}",)
+
+
+@patch("pennylane.data.data_manager._download_partial")
+@pytest.mark.parametrize(
+    "datapath, escaped",
+    [("data/NH3+/data.h5", "data/NH3%2B/data.h5"), ("data/CA$H/money.h5", "data/CA%24H/money.h5")],
+)
+def test_download_dataset_escapes_url_partial(mock_download_partial, datapath, escaped):
+    """Tests that _download_dataset escapes special characters in a URL when doing a partial
+    download."""
+    dest = Path("dest")
+    attributes = ["attr"]
+    force = False
+
+    pennylane.data.data_manager._download_dataset(
+        DataPath(datapath), dest=dest, attributes=attributes, force=force
+    )
+
+    mock_download_partial.assert_called_once_with(
+        f"{S3_URL}/{escaped}", dest, attributes, overwrite=force
+    )


### PR DESCRIPTION
**Context:**
Requests for datasets with '+' in the name (e.g `NH3+`) fail because '+' is a special character in URLs. This bug would also occur for other characters like '%', '$', etc

**Description of the Change:**
Uses `urllib.parse.quote` to replace special characters in the dataset path with their escape codes.

**Benefits:**
Can download datasets with special characters in their name.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
