### PR TITLE
Fix Attribute Error when accessing identifiers on partial dataset

### DIFF
--- a/pennylane/data/base/dataset.py
+++ b/pennylane/data/base/dataset.py
@@ -214,6 +214,7 @@ class Dataset(MapperMixin, _DatasetTransform):
         return {
             attr_name: getattr(self, attr_name)
             for attr_name in self.info.get("identifiers", self.info.get("params", []))
+            if attr_name in self.bind
         }
 
     @property

--- a/pennylane/data/base/dataset.py
+++ b/pennylane/data/base/dataset.py
@@ -288,7 +288,7 @@ class Dataset(MapperMixin, _DatasetTransform):
                 values are "w-" (create, fail if file exists), "w" (create, overwrite existing),
                 and "a" (append existing, create if doesn't exist). Default is "w-".
             attributes: Optional list of attributes to copy. If None, all attributes
-                will be copied.
+                will be copied. Note that identifiers will always be copied.
             overwrite: Whether to overwrite attributes that already exist in this
                 dataset.
         """
@@ -301,6 +301,12 @@ class Dataset(MapperMixin, _DatasetTransform):
             dest.info.update(self.info)
 
         hdf5.copy_all(self.bind, dest.bind, *attributes, on_conflict=on_conflict)
+
+        missing_identifiers = [
+            identifier for identifier in self.identifiers if not hasattr(dest, identifier)
+        ]
+        if missing_identifiers:
+            hdf5.copy_all(self.bind, dest.bind, *missing_identifiers)
 
     def _init_bind(
         self, data_name: Optional[str] = None, identifiers: Optional[Tuple[str, ...]] = None

--- a/pennylane/data/data_manager/__init__.py
+++ b/pennylane/data/data_manager/__init__.py
@@ -299,7 +299,9 @@ def load_interactive():
         value = _interactive_request_single(node, param)
         description[param] = value
 
-    attributes = _interactive_request_attributes(data_struct[data_name]["attributes"])
+    attributes = _interactive_request_attributes(
+        [attribute for attribute in data_struct[data_name]["attributes"] if attribute not in params]
+    )
     force = input("Force download files? (Default is no) [y/N]: ") in ["y", "Y"]
     dest_folder = Path(
         input("Folder to download to? (Default is pwd, will download to /datasets subdirectory): ")

--- a/pennylane/data/data_manager/__init__.py
+++ b/pennylane/data/data_manager/__init__.py
@@ -97,6 +97,23 @@ def _download_dataset(
         f.write(resp.content)
 
 
+def _validate_attributes(data_struct: dict, data_name: str, attributes: typing.Iterable[str]):
+    """Checks that ``attributes`` contains only valid attributes for the given
+    ``data_name``. If any attributes do not exist, raise a ValueError."""
+    invalid_attributes = [
+        attr for attr in attributes if attr not in data_struct[data_name]["attributes"]
+    ]
+    if not invalid_attributes:
+        return
+
+    if len(invalid_attributes) == 1:
+        values_err = f"'{invalid_attributes[0]}' is an invalid attribute for '{data_name}'"
+    else:
+        values_err = f"{invalid_attributes} are invalid attributes for '{data_name}'"
+
+    raise ValueError(f"{values_err}. Valid attributes are: {data_struct[data_name]['attributes']}")
+
+
 def load(  # pylint: disable=too-many-arguments
     data_name: str,
     attributes: Optional[typing.Iterable[str]] = None,
@@ -186,13 +203,17 @@ def load(  # pylint: disable=too-many-arguments
     >>> print(circuit())
     -1.0791430411076344
     """
+    foldermap = _get_foldermap()
+    data_struct = _get_data_struct()
+
     params = format_params(**params)
+
+    if attributes:
+        _validate_attributes(data_struct, data_name, attributes)
 
     folder_path = Path(folder_path)
     if cache_dir and not Path(cache_dir).is_absolute():
         cache_dir = folder_path / cache_dir
-
-    foldermap = _get_foldermap()
 
     data_paths = [data_path for _, data_path in foldermap.find(data_name, **params)]
 

--- a/pennylane/data/data_manager/__init__.py
+++ b/pennylane/data/data_manager/__init__.py
@@ -310,6 +310,7 @@ def load_interactive():
     if approve not in ["Y", "", "y"]:
         print("Aborting and not downloading!")
         return None
+
     return load(
         data_name, attributes=attributes, folder_path=dest_folder, force=force, **description
     )[0]

--- a/pennylane/data/data_manager/foldermap.py
+++ b/pennylane/data/data_manager/foldermap.py
@@ -141,7 +141,7 @@ class FolderMapView(typing.Mapping[str, Union["FolderMapView", DataPath]]):
                     )
                 except KeyError as exc:
                     raise ValueError(
-                        f"molname '{exc.args[0]}' is not available. Available values are: {list(curr_level)}"
+                        f"{param_name} '{exc.args[0]}' is not available. Available values are: {list(curr_level)}"
                     ) from exc
 
             curr, todo = todo, curr

--- a/tests/data/test_dataset.py
+++ b/tests/data/test_dataset.py
@@ -370,6 +370,22 @@ class TestDataset:
         assert ds_2.bind is not ds.bind
         assert ds.attrs == ds_2.attrs
 
+    @pytest.mark.parametrize(
+        "attributes_arg,attributes_expect",
+        [
+            (["x"], ["x", "y"]),
+            (["x", "y", "data"], ["x", "y", "data"]),
+            (["data"], ["x", "y", "data"]),
+        ],
+    )
+    def test_write_partial_always_copies_identifiers(self, attributes_arg, attributes_expect):
+        """Test that ``write`` will always copy attributes that are identifiers."""
+        ds = Dataset(x="a", y="b", data="Some data", identifiers=("x", "y"))
+        ds_2 = Dataset()
+
+        ds.write(ds_2, attributes=attributes_arg)
+        assert set(ds_2.list_attributes()) == set(attributes_expect)
+
     def test_init_subclass(self):
         """Test that __init_subclass__() does the following:
 

--- a/tests/data/test_dataset.py
+++ b/tests/data/test_dataset.py
@@ -198,11 +198,24 @@ class TestDataset:
 
         assert ds.identifiers == expect
 
+    def test_identifiers_base_missing(self):
+        """Test that identifiers whose attribute is missing on the
+        dataset will not be in the returned dict."""
+        ds = Dataset(x="1", identifiers=("x", "y"))
+
+        assert ds.identifiers == {"x": "1"}
+
     def test_subclass_identifiers(self):
         """Test that dataset subclasses' identifiers can be set."""
         ds = MyDataset(x="1", y="2", description="abc")
 
         assert ds.identifiers == {"x": "1", "y": "2"}
+
+    def test_subclass_identifiers_missing(self):
+        """Test that dataset subclasses' identifiers can be set."""
+        ds = MyDataset(x="1", description="abc")
+
+        assert ds.identifiers == {"x": "1"}
 
     def test_attribute_info(self):
         """Test that attribute info can be set and accessed


### PR DESCRIPTION
**Context:**
Accessing `identifiers` on a dataset for which all identifier attributes are not downloaded results in an `AttributeError`:

```
>>> dset = qml.data.load(
    'qchem', 
    molname='H3', 
    basis='STO-3G', 
    bondlength='0.5', 
    attributes=['molname'])[0]
>>> dset.identifiers #AttributeError
```

**Description of the Change:**

`Dataset.identifiers` will only return identifiers that are available on the dataset. The above example now looks like:

```
>>> dset.identifiers
{'molname': 'H3'}
```

**Benefits:**
Removes unexpected and potentially confusing error.

**Possible Drawbacks:**


**Related GitHub Issues:**
