### PR TITLE
BUGFIX: ensure that operators are not queued upon deserialization

### DIFF
--- a/pennylane/data/attributes/operator/operator.py
+++ b/pennylane/data/attributes/operator/operator.py
@@ -234,28 +234,29 @@ class DatasetOperator(Generic[Op], DatasetAttribute[HDF5Group, Op, Op]):
         op_class_names = [] if names_bind.shape == (0,) else names_bind.asstr()
         op_wire_labels = [] if wires_bind.shape == (0,) else wires_bind.asstr()
 
-        for i, op_class_name in enumerate(op_class_names):
-            op_key = f"op_{i}"
+        with qml.QueuingManager.stop_recording():
+            for i, op_class_name in enumerate(op_class_names):
+                op_key = f"op_{i}"
 
-            op_cls = self._supported_ops_dict()[op_class_name]
-            if op_cls is Tensor:
-                ops.append(Tensor(*self._hdf5_to_ops(bind[op_key])))
-            elif op_cls is qml.Hamiltonian:
-                ops.append(
-                    qml.Hamiltonian(
-                        coeffs=list(bind[op_key]["hamiltonian_coeffs"]),
-                        observables=self._hdf5_to_ops(bind[op_key]),
+                op_cls = self._supported_ops_dict()[op_class_name]
+                if op_cls is Tensor:
+                    ops.append(Tensor(*self._hdf5_to_ops(bind[op_key])))
+                elif op_cls is qml.Hamiltonian:
+                    ops.append(
+                        qml.Hamiltonian(
+                            coeffs=list(bind[op_key]["hamiltonian_coeffs"]),
+                            observables=self._hdf5_to_ops(bind[op_key]),
+                        )
                     )
-                )
-            else:
-                wire_labels = json.loads(op_wire_labels[i])
-                op_data = bind[op_key]
-                if op_data.shape is not None:
-                    params = np.zeros(shape=op_data.shape, dtype=op_data.dtype)
-                    op_data.read_direct(params)
-                    ops.append(op_cls(*params, wires=wire_labels))
                 else:
-                    ops.append(op_cls(wires=wire_labels))
+                    wire_labels = json.loads(op_wire_labels[i])
+                    op_data = bind[op_key]
+                    if op_data.shape is not None:
+                        params = np.zeros(shape=op_data.shape, dtype=op_data.dtype)
+                        op_data.read_direct(params)
+                        ops.append(op_cls(*params, wires=wire_labels))
+                    else:
+                        ops.append(op_cls(wires=wire_labels))
 
         return ops
 

--- a/tests/data/attributes/operator/test_operator.py
+++ b/tests/data/attributes/operator/test_operator.py
@@ -173,7 +173,7 @@ class TestDatasetOperator:
         """Tests that ops are not queued upon deserialization."""
         d = qml.data.Dataset(op=qml.PauliX(0))
         with qml.queuing.AnnotatedQueue() as q:
-            d.op
+            _ = d.op
 
         assert len(q) == 0
 

--- a/tests/data/attributes/operator/test_operator.py
+++ b/tests/data/attributes/operator/test_operator.py
@@ -168,3 +168,16 @@ class TestDatasetOperator:
         assert op_in.data == op_out.data
         assert op_in.wires == op_out.wires
         assert repr(op_in) == repr(op_out)
+
+    def test_op_not_queued_on_deserialization(self):
+        """Tests that ops are not queued upon deserialization."""
+        d = qml.data.Dataset(op=qml.PauliX(0))
+        with qml.queuing.AnnotatedQueue() as q:
+            d.op
+
+        assert len(q) == 0
+
+        with qml.queuing.AnnotatedQueue() as q2:
+            qml.apply(d.op)
+
+        assert len(q2) == 1


### PR DESCRIPTION
**Context:**
Discussed on Slack, operators are queued upon deserialization, which is unexpected.

**Description of the Change:**
Wrap operator deserialization (in other words, construction) in a `stop_recording` context to ensure operators are not queued merely by being referenced.

**Benefits:**
User expectations are met

**Possible Drawbacks:**
N/A