### PR TITLE
[sc-36527]: Add new robots.txt to doc build to hide latest build from search engine

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -161,7 +161,7 @@ html_static_path = ["_static"]
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
 # directly to the root of the documentation.
-# html_extra_path = []
+html_extra_path = ["robots.txt"]
 
 # If not "", a "Last updated on:" timestamp is inserted at every page bottom,
 # using the given strftime format.

--- a/doc/robots.txt
+++ b/doc/robots.txt
@@ -1,0 +1,7 @@
+User-agent: *
+
+Disallow: /en/v0.30.0/  # Hidden version
+
+Disallow: /en/latest/   # Not hidden, but disallow from search engine results 
+
+Sitemap: https://docs.pennylane.ai/sitemap.xml


### PR DESCRIPTION
**Context:** This PR adds a new robots.txt to the output of the docs build

**Description of the Change:**

This stated in the context, the robots.txt file is in lieu of marking the builds in ReadTheDocs as hidden. We want the latest version of docs to show up on the flyout menu when a user goes to docs.pennylane.ai.

The robots.txt will mark the /latest and /v0.30.0/ builds as disallowed for indexing so they are not shown as results on google.

**Benefits:**
Marking builds as hidden on ReadTheDocs achieve this same behavior, but it also hides the build from the flyout menu, which is not desired in this case.

**Possible Drawbacks:**
None.

**Related GitHub Issues:**
N/A.