### PR TITLE
bugfix: substraction works with new opmath

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -276,6 +276,9 @@ array([False, False])
   and `var` measurements.
   [(#4426)](https://github.com/PennyLaneAI/pennylane/pull/4426)
 
+* Subtracting a `Prod` from another operator now works as expected.
+  [(#4441)](https://github.com/PennyLaneAI/pennylane/pull/4441)
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -1511,6 +1511,13 @@ class Operator(abc.ABC):
 
     def __sub__(self, other):
         """The subtraction operation of Operator-Operator objects and Operator-scalar."""
+        if active_new_opmath():
+            if isinstance(other, Operator):
+                return self + qml.s_prod(-1, other)
+            if isinstance(other, TensorLike):
+                return self + (qml.math.multiply(-1, other))
+            return NotImplemented
+
         if isinstance(other, (Operator, TensorLike)):
             return self + (qml.math.multiply(-1, other))
         return NotImplemented

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -1511,14 +1511,9 @@ class Operator(abc.ABC):
 
     def __sub__(self, other):
         """The subtraction operation of Operator-Operator objects and Operator-scalar."""
-        if active_new_opmath():
-            if isinstance(other, Operator):
-                return self + qml.s_prod(-1, other)
-            if isinstance(other, TensorLike):
-                return self + (qml.math.multiply(-1, other))
-            return NotImplemented
-
-        if isinstance(other, (Operator, TensorLike)):
+        if isinstance(other, Operator):
+            return self + qml.s_prod(-1, other)
+        if isinstance(other, TensorLike):
             return self + (qml.math.multiply(-1, other))
         return NotImplemented
 

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -1147,6 +1147,14 @@ class TestOperatorIntegration:
         neg_op = -qml.PauliX(0)
         assert np.allclose(a=neg_op.matrix(), b=np.array([[0, -1], [-1, 0]]), rtol=0)
 
+    def test_sub_obs_from_op(self):
+        """Test that __sub__ returns an SProd to be consistent with other Operator dunders."""
+        op = qml.S(0) - qml.PauliX(1)
+        assert isinstance(op, Sum)
+        assert isinstance(op[1], SProd)
+        assert qml.equal(op[0], qml.S(0))
+        assert qml.equal(op[1], SProd(-1, qml.PauliX(1)))
+
     def test_mul_with_scalar(self):
         """Test the __mul__ dunder method with a scalar value."""
         sprod_op = 4 * qml.RX(1, 0)

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -2523,6 +2523,11 @@ class TestNewOpMath:
             assert op[1].scalar == -1
             assert qml.equal(op[1].base, op1)
 
+        def test_sub_with_unknown_not_supported(self):
+            """Test subtracting an unexpected type from an Operator."""
+            with pytest.raises(TypeError, match="unsupported operand type"):
+                _ = qml.S(0) - "foo"
+
         def test_op_with_scalar(self):
             """Tests adding/subtracting ops with scalars."""
             x0 = qml.PauliX(0)

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -2489,6 +2489,7 @@ pairs_of_ops = [
     (qml.S(0), qml.PauliX(0)),
     (qml.PauliX(0), qml.S(0)),
     (qml.PauliX(0), qml.PauliY(0)),
+    (qml.PauliZ(0), qml.prod(qml.PauliX(0), qml.PauliY(1))),
 ]
 
 


### PR DESCRIPTION
**Context:**
Subtraction of new opmath was broken when the operator being subtracted is a prod. See bug report for details, but in short, this used to happen:
```pycon
>>> qml.PauliZ(0) - qml.prod(qml.PauliX(0), qml.PauliY(1))
PauliZ(wires=[0]) + ([-1*(PauliX(wires=[0])) -1*(PauliY(wires=[1]))]*(Identity(wires=[0])))
```
That's right, the old scalar for the second term was a numpy array of SProds, with an Identity as base. But now this happens:
```pycon
>>> qml.PauliZ(0) - qml.prod(qml.PauliX(0), qml.PauliY(1))
PauliZ(wires=[0]) + (-1*(PauliX(wires=[0]) @ PauliY(wires=[1])))
```

**Description of the Change:**
use `qml.s_prod(-1, other)` instead of `qml.math.multiply(-1, other)` to create the second term being added (assuming `other` is an operator)

**Benefits:**
No more bug!

**Possible Drawbacks:**
N/A

~Also, I only fixed this for when `qml.operation.active_new_opmath()`, since you'd only hit this while using new ops.~ changed it to always occur. see discussion below.

**Related GitHub Issues:**
Fixes #4438