### PR TITLE
Support `StatePrep` mid-circuit for `DefaultQubit2`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -139,6 +139,9 @@ array([False, False])
 * Updated `default_expand_fn()` to decompose `StatePrep` operations present in the middle of a provided circuit.
   [(#4437)](https://github.com/PennyLaneAI/pennylane/pull/4437)
 
+* Updated `expand_fn()` for `DefaultQubit2` to decompose `StatePrep` operations present in the middle of a circuit.
+  [(#4444)](https://github.com/PennyLaneAI/pennylane/pull/4444)
+
 <h3>Breaking changes 💔</h3>
 
 * `Operator.expand` now uses the output of `Operator.decomposition` instead of what it queues.

--- a/pennylane/tape/tape.py
+++ b/pennylane/tape/tape.py
@@ -260,7 +260,7 @@ def expand_tape_state_prep(tape, skip_first=True):
     )
     new_prep.extend(prep_decomp)
 
-    for i, op in enumerate(tape.operations[1:]):
+    for op in tape.operations[1:]:
         if isinstance(op, StatePrep):
             new_ops.extend(op.decomposition())
         else:

--- a/tests/devices/qubit/test_preprocess.py
+++ b/tests/devices/qubit/test_preprocess.py
@@ -170,14 +170,6 @@ class TestExpandFnValidation:
         tape = QuantumScript([], [qml.expval(qml.PauliZ(0) @ qml.PauliY(1))])
         assert expand_fn(tape) is tape
 
-    def test_state_prep_only_one(self):
-        """Test that a device error is raised if the script has multiple state prep ops."""
-        qs = QuantumScript(prep=[qml.BasisState([0], wires=0), qml.BasisState([1], wires=1)])
-        with pytest.raises(
-            DeviceError, match=r"DefaultQubit2 accepts at most one state prep operation."
-        ):
-            expand_fn(qs)
-
     def test_expand_fn_passes(self):
         """Test that expand_fn doesn't throw any errors for a valid circuit"""
         tape = QuantumScript(
@@ -259,6 +251,33 @@ class TestExpandFnTransformations:
         qs = QuantumScript([NoMatOp("a")], [qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliY(0))])
         new_qs = expand_fn(qs)
         assert new_qs.measurements == qs.measurements
+
+    @pytest.mark.parametrize(
+        "prep_op", (qml.BasisState([1], wires=0), qml.QubitStateVector([0, 1], wires=1))
+    )
+    def test_expand_fn_state_prep(self, prep_op):
+        """Test that the expand_fn only expands mid-circuit instances of StatePrep"""
+        ops = [
+            prep_op,
+            qml.Hadamard(wires=0),
+            qml.QubitStateVector([0, 1], wires=1),
+            qml.BasisState([1], wires=0),
+            qml.RZ(0.123, wires=1),
+        ]
+        measurements = [qml.expval(qml.PauliZ(0)), qml.probs()]
+        tape = QuantumScript(ops=ops, measurements=measurements)
+
+        expanded_tape = expand_fn(tape)
+        expected = [
+            prep_op,
+            qml.Hadamard(0),
+            qml.RY(3.14159265, wires=1),  # decomposition of QubitStateVector
+            qml.PauliX(wires=0),  # decomposition of BasisState
+            qml.RZ(0.123, wires=1),
+        ]
+
+        for op, exp in zip(expanded_tape.circuit, expected + measurements):
+            assert qml.equal(op, exp)
 
 
 class TestValidateMeasurements:


### PR DESCRIPTION
**Context:**
Working towards the goal of support LCUs in Pennylane. This PR allows StatePrep operations to be called in the middle of a circuit without raising errors.

**Description of the Change:**
- Removed an error the used to be raised if more than 1 `StatePrep` operation was present in the circuit. 
- The `expand_fn()` in `device/qubit/preprocess.py` is updated to allow the first operation in the circuit to remain un-expanded if it is a `StatePrep` operation, otherwise expanding all other instances of `StatePrep`
