### PR TITLE
`MeasurementValue` accepts `MidMeasureMP`s instead of IDs in constructor

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -116,10 +116,8 @@ array([False, False])
 * When given a callable, `qml.ctrl` now does its custom pre-processing on all queued operators from the callable.
   [(#4370)](https://github.com/PennyLaneAI/pennylane/pull/4370)
 
-
 * `qml.interfaces.set_shots` accepts `Shots` object as well as `int`'s and tuples of `int`'s.
   [(#4388)](https://github.com/PennyLaneAI/pennylane/pull/4388)
-
 
 * `pennylane.devices.experimental.Device` now accepts a shots keyword argument and has a `shots`
   property. This property is merely used to set defaults for a workflow, and does not directly
@@ -140,6 +138,10 @@ array([False, False])
   [(#4418)](https://github.com/PennyLaneAI/pennylane/pull/4418/)
 
 <h3>Breaking changes 💔</h3>
+
+* `MeasurementValue`'s signature has been updated to accept a list of `MidMeasureMP`'s rather than a list of
+  their IDs.
+  [(#)]()
 
 * `Operator.expand` now uses the output of `Operator.decomposition` instead of what it queues.
   [(#4355)](https://github.com/PennyLaneAI/pennylane/pull/4355)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -141,7 +141,7 @@ array([False, False])
 
 * `MeasurementValue`'s signature has been updated to accept a list of `MidMeasureMP`'s rather than a list of
   their IDs.
-  [(#)]()
+  [(#4446)](https://github.com/PennyLaneAI/pennylane/pull/4446)
 
 * `Operator.expand` now uses the output of `Operator.decomposition` instead of what it queues.
   [(#4355)](https://github.com/PennyLaneAI/pennylane/pull/4355)

--- a/pennylane/drawer/drawable_layers.py
+++ b/pennylane/drawer/drawable_layers.py
@@ -120,7 +120,7 @@ def drawable_layers(ops, wire_map=None):
             mapped_wires = {wire_map[wire] for wire in op.wires}
             if op.__class__.__name__ == "Conditional":
                 is_conditional = True
-                mapped_wires.update(measured_wires[m_id] for m_id in op.meas_val.measurement_ids)
+                mapped_wires.update(measured_wires[m.id] for m in op.meas_val.measurements)
             # get all integers from the minimum to the maximum
             min_wire = min(mapped_wires)
             max_wire = max(mapped_wires)
@@ -129,10 +129,10 @@ def drawable_layers(ops, wire_map=None):
         op_layer = _recursive_find_layer(max_layer, op_occupied_wires, occupied_wires_per_layer)
 
         if is_conditional:
-            m_layers = [measured_layers[m_id] for m_id in op.meas_val.measurement_ids]
+            m_layers = [measured_layers[m.id] for m in op.meas_val.measurements]
             max_control_layer = max(m_layers)
 
-            for m_id, m_layer in zip(op.meas_val.measurement_ids, m_layers):
+            for m, m_layer in zip(op.meas_val.measurements, m_layers):
                 # TODO: remove from measurement caches for qubit reuse
                 # Note that along with this, wire lines will need to be re-drawn if being reused
                 #
@@ -142,7 +142,7 @@ def drawable_layers(ops, wire_map=None):
                 # measurements for a conditional should all be in the same layer
                 if m_layer < max_control_layer:
                     for i, o in enumerate(ops_in_layer[m_layer]):
-                        if m_id == o.id:
+                        if m.id == o.id:
                             ops_in_layer[max_control_layer].append(o)  # add to cond. op. layer
                             ops_in_layer[m_layer].pop(i)  # remove from original layer
                             # no need to remove from previous occupied_wires_per_layer

--- a/pennylane/drawer/tape_mpl.py
+++ b/pennylane/drawer/tape_mpl.py
@@ -143,11 +143,10 @@ def _tape_mpl(tape, wire_order=None, show_all_wires=False, decimals=None, **kwar
                 specialfunc(drawer, layer, mapped_wires, op)
 
             elif type(op).__name__ == "Conditional":
-                measured_layer = {_measured_layers[i] for i in op.meas_val.measurement_ids}.pop()
+                m_ids = [m.id for m in op.meas_val.measurements]
+                measured_layer = {_measured_layers[m_id] for m_id in m_ids}.pop()
                 control_wires = [
-                    wire_map[o.wires[0]]
-                    for o in layers[measured_layer]
-                    if o.id in op.meas_val.measurement_ids
+                    wire_map[o.wires[0]] for o in layers[measured_layer] if o.id in m_ids
                 ]
                 target_wires = [wire_map[w] for w in op.wires]
                 drawer.cond(layer, measured_layer, control_wires, target_wires)

--- a/pennylane/measurements/mid_measure.py
+++ b/pennylane/measurements/mid_measure.py
@@ -100,7 +100,7 @@ class MidMeasureMP(MeasurementProcess):
     """
 
     def __init__(self, wires: Optional[Wires] = None, id: Optional[str] = None):
-        super().__init__(wires=wires, id=id)
+        super().__init__(wires=Wires(wires), id=id)
 
     @property
     def return_type(self):

--- a/pennylane/transforms/condition.py
+++ b/pennylane/transforms/condition.py
@@ -111,14 +111,8 @@ def cond(condition, true_fn, false_fn=None):
 
     .. warning::
 
-        The following are not supported as the ``condition`` argument:
-
-        * Expressions that contain multiple measurement values;
-        * Expressions with boolean logic flow using operators like ``and``,
-          ``or`` and ``not``.
-
-        While such statements may not result in errors, they may result in
-        incorrect behaviour.
+        Expressions with boolean logic flow using operators like ``and``,
+        ``or`` and ``not`` are not supported as the ``condition`` argument.
 
 
     .. details::

--- a/pennylane/transforms/defer_measurements.py
+++ b/pennylane/transforms/defer_measurements.py
@@ -111,7 +111,7 @@ def defer_measurements(tape):
 
 def _add_control_gate(op, measured_wires):
     """Helper function to add control gates"""
-    control = [measured_wires[m_id] for m_id in op.meas_val.measurement_ids]
+    control = [measured_wires[m.id] for m in op.meas_val.measurements]
     for branch, value in op.meas_val._items():  # pylint: disable=protected-access
         if value:
             ctrl(

--- a/tests/devices/qubit/test_preprocess.py
+++ b/tests/devices/qubit/test_preprocess.py
@@ -225,10 +225,11 @@ class TestExpandFnTransformations:
     # pylint: disable=no-member
     def test_expand_fn_defer_measurement(self):
         """Test that expand_fn defers mid-circuit measurements."""
-        mv = MeasurementValue(["test_id"], processing_fn=lambda v: v)
+        mp = MidMeasureMP(wires=[0], id="test_id")
+        mv = MeasurementValue([mp], processing_fn=lambda v: v)
         ops = [
             qml.Hadamard(0),
-            MidMeasureMP(wires=[0], id="test_id"),
+            mp,
             qml.transforms.Conditional(mv, qml.RX(0.123, wires=1)),
         ]
         measurements = [qml.expval(qml.PauliZ(1))]

--- a/tests/measurements/test_mid_measure.py
+++ b/tests/measurements/test_mid_measure.py
@@ -19,13 +19,14 @@ import pytest
 import pennylane as qml
 import pennylane.numpy as np
 from pennylane.measurements import MidMeasureMP, MeasurementValue
+from pennylane.wires import Wires
 
 # pylint: disable=too-few-public-methods, too-many-public-methods
 
 
 def test_samples_computational_basis():
     """Test that samples_computational_basis is always false for mid circuit measurements."""
-    m = qml.measurements.MidMeasureMP(qml.wires.Wires(0))
+    m = qml.measurements.MidMeasureMP(Wires(0))
     assert not m.samples_computational_basis
 
 
@@ -41,10 +42,21 @@ class TestMeasure:
         ):
             qml.measure(wires=[0, 1])
 
+    def test_hash(self):
+        """Test that the hash for `MidMeasureMP` is defined correctly."""
+        m1 = MidMeasureMP(Wires(0), "m1")
+        m2 = MidMeasureMP(Wires(0), "m2")
+        m3 = MidMeasureMP(Wires(1), "m1")
+        m4 = MidMeasureMP(Wires(0), "m1")
 
-mp1 = MidMeasureMP(0, "m0")
-mp2 = MidMeasureMP(1, "m1")
-mp3 = MidMeasureMP(2, "m2")
+        assert m1.hash != m2.hash
+        assert m1.hash != m3.hash
+        assert m1.hash == m4.hash
+
+
+mp1 = MidMeasureMP(Wires(0), "m0")
+mp2 = MidMeasureMP(Wires(1), "m1")
+mp3 = MidMeasureMP(Wires(2), "m2")
 
 
 class TestMeasurementValueManipulation:

--- a/tests/measurements/test_mid_measure.py
+++ b/tests/measurements/test_mid_measure.py
@@ -18,7 +18,7 @@ import pytest
 
 import pennylane as qml
 import pennylane.numpy as np
-from pennylane.measurements import MeasurementValue
+from pennylane.measurements import MidMeasureMP, MeasurementValue
 
 # pylint: disable=too-few-public-methods, too-many-public-methods
 
@@ -42,13 +42,18 @@ class TestMeasure:
             qml.measure(wires=[0, 1])
 
 
+mp1 = MidMeasureMP(0, "m0")
+mp2 = MidMeasureMP(1, "m1")
+mp3 = MidMeasureMP(2, "m2")
+
+
 class TestMeasurementValueManipulation:
     """Test all the dunder methods associated with the MeasurementValue class"""
 
     def test_apply_function_to_measurement(self):
         """Test the general _apply method that can apply an arbitrary function to a measurement."""
 
-        m = MeasurementValue(["m"], lambda v: v)
+        m = MeasurementValue([mp1], lambda v: v)
 
         sin_of_m = m._apply(np.sin)  # pylint: disable=protected-access
         assert sin_of_m[0] == 0.0
@@ -56,15 +61,15 @@ class TestMeasurementValueManipulation:
 
     def test_and_with_bool(self):
         """Test the __add__ dunder method between MeasurementValue and scalar."""
-        m = MeasurementValue(["m"], lambda v: v)
+        m = MeasurementValue([mp1], lambda v: v)
         m_add = m & False
         assert not m_add[0]
         assert not m_add[1]
 
     def test_and_to_measurements(self):
         """Test the __add__ dunder method between two MeasurementValues."""
-        m0 = MeasurementValue(["m0"], lambda v: v)
-        m1 = MeasurementValue(["m1"], lambda v: v)
+        m0 = MeasurementValue([mp1], lambda v: v)
+        m1 = MeasurementValue([mp2], lambda v: v)
         sum_of_measurements = m0 & m1
         assert not sum_of_measurements[0]
         assert not sum_of_measurements[1]
@@ -73,15 +78,15 @@ class TestMeasurementValueManipulation:
 
     def test_or_with_bool(self):
         """Test the __or__ dunder method between MeasurementValue and scalar."""
-        m = MeasurementValue(["m"], lambda v: v)
+        m = MeasurementValue([mp1], lambda v: v)
         m_add = m | False
         assert not m_add[0]
         assert m_add[1]
 
     def test_or_to_measurements(self):
         """Test the __or__ dunder method between two MeasurementValues."""
-        m0 = MeasurementValue(["m0"], lambda v: v)
-        m1 = MeasurementValue(["m1"], lambda v: v)
+        m0 = MeasurementValue([mp1], lambda v: v)
+        m1 = MeasurementValue([mp2], lambda v: v)
         sum_of_measurements = m0 | m1
         assert not sum_of_measurements[0]
         assert sum_of_measurements[1]
@@ -90,15 +95,15 @@ class TestMeasurementValueManipulation:
 
     def test_add_with_scalar(self):
         """Test the __add__ dunder method between MeasurementValue and scalar."""
-        m = MeasurementValue(["m"], lambda v: v)
+        m = MeasurementValue([mp1], lambda v: v)
         m_add = m + 5
         assert m_add[0] == 5
         assert m_add[1] == 6
 
     def test_add_to_measurements(self):
         """Test the __add__ dunder method between two MeasurementValues."""
-        m0 = MeasurementValue(["m0"], lambda v: v)
-        m1 = MeasurementValue(["m1"], lambda v: v)
+        m0 = MeasurementValue([mp1], lambda v: v)
+        m1 = MeasurementValue([mp2], lambda v: v)
         sum_of_measurements = m0 + m1
         assert sum_of_measurements[0] == 0
         assert sum_of_measurements[1] == 1
@@ -107,22 +112,22 @@ class TestMeasurementValueManipulation:
 
     def test_radd_with_scalar(self):
         """Test the __radd__ dunder method between a scalar and a MeasurementValue."""
-        m = MeasurementValue(["m"], lambda v: v)
+        m = MeasurementValue([mp1], lambda v: v)
         m_add = 5 + m
         assert m_add[0] == 5
         assert m_add[1] == 6
 
     def test_sub_with_scalar(self):
         """Test the __sub__ dunder method between MeasurementValue and scalar."""
-        m = MeasurementValue(["m"], lambda v: v)
+        m = MeasurementValue([mp1], lambda v: v)
         m_add = m - 5
         assert m_add[0] == -5
         assert m_add[1] == -4
 
     def test_sub_to_measurements(self):
         """Test the __sub__ dunder method between two MeasurementValues."""
-        m0 = MeasurementValue(["m0"], lambda v: v)
-        m1 = MeasurementValue(["m1"], lambda v: v)
+        m0 = MeasurementValue([mp1], lambda v: v)
+        m1 = MeasurementValue([mp2], lambda v: v)
         sum_of_measurements = m0 - m1
         assert sum_of_measurements[0] == 0
         assert sum_of_measurements[1] == -1
@@ -131,22 +136,22 @@ class TestMeasurementValueManipulation:
 
     def test_rsub_with_scalar(self):
         """Test the __rsub__ dunder method between a scalar and a MeasurementValue."""
-        m = MeasurementValue(["m"], lambda v: v)
+        m = MeasurementValue([mp1], lambda v: v)
         m_add = 5 - m
         assert m_add[0] == 5
         assert m_add[1] == 4
 
     def test_mul_with_scalar(self):
         """Test the __mul__ dunder method between a MeasurementValue and a scalar"""
-        m = MeasurementValue(["m"], lambda v: v)
+        m = MeasurementValue([mp1], lambda v: v)
         m_mul = m * 5
         assert m_mul[0] == 0
         assert m_mul[1] == 5
 
     def test_mul_with_measurement(self):
         """Test the __mul__ dunder method between two MeasurementValues."""
-        m0 = MeasurementValue(["m0"], lambda v: v)
-        m1 = MeasurementValue(["m1"], lambda v: v)
+        m0 = MeasurementValue([mp1], lambda v: v)
+        m1 = MeasurementValue([mp2], lambda v: v)
         mul_of_measurements = m0 * m1
         assert mul_of_measurements[0] == 0
         assert mul_of_measurements[1] == 0
@@ -155,22 +160,22 @@ class TestMeasurementValueManipulation:
 
     def test_rmul_with_scalar(self):
         """Test the __rmul__ dunder method between a scalar and a MeasurementValue."""
-        m = MeasurementValue(["m"], lambda v: v)
+        m = MeasurementValue([mp1], lambda v: v)
         m_mul = 5 * m
         assert m_mul[0] == 0
         assert m_mul[1] == 5
 
     def test_truediv_with_scalar(self):
         """Test the __truediv__ dunder method between a MeasurementValue and a scalar"""
-        m = MeasurementValue(["m"], lambda v: v)
+        m = MeasurementValue([mp1], lambda v: v)
         m_mul = m / 5.0
         assert m_mul[0] == 0
         assert m_mul[1] == 1 / 5.0
 
     def test_truediv_with_measurement(self):
         """Test the __truediv__ dunder method between two MeasurementValues."""
-        m0 = MeasurementValue(["m0"], lambda v: v) + 3.0
-        m1 = MeasurementValue(["m1"], lambda v: v) + 5.0
+        m0 = MeasurementValue([mp1], lambda v: v) + 3.0
+        m1 = MeasurementValue([mp2], lambda v: v) + 5.0
         mul_of_measurements = m0 / m1
         assert mul_of_measurements[0] == 3.0 / 5.0
         assert mul_of_measurements[1] == 3.0 / 6.0
@@ -179,29 +184,29 @@ class TestMeasurementValueManipulation:
 
     def test_rtruediv_with_scalar(self):
         """Test the __rtruediv__ dunder method between a scalar and a MeasurementValue."""
-        m = MeasurementValue(["m"], lambda v: v) + 3.0
+        m = MeasurementValue([mp1], lambda v: v) + 3.0
         m_mul = 5 / m
         assert m_mul[0] == 5 / 3.0
         assert m_mul[1] == 5 / 4.0
 
     def test_inversion(self):
         """Test the __inv__ dunder method."""
-        m = MeasurementValue(["m"], lambda v: v)
+        m = MeasurementValue([mp1], lambda v: v)
         m_inversion = ~m
         assert m_inversion[0] is True
         assert m_inversion[1] is False
 
     def test_lt(self):
         """Test the __lt__ dunder method between a MeasurementValue and a float."""
-        m = MeasurementValue(["m"], lambda v: v)
+        m = MeasurementValue([mp1], lambda v: v)
         m_inversion = m < 0.5
         assert m_inversion[0] is True
         assert m_inversion[1] is False
 
     def test_lt_with_other_measurement_value(self):
         """Test the __lt__ dunder method between two MeasurementValues"""
-        m1 = MeasurementValue(["m1"], lambda v: v)
-        m2 = MeasurementValue(["m2"], lambda v: v)
+        m1 = MeasurementValue([mp1], lambda v: v)
+        m2 = MeasurementValue([mp2], lambda v: v)
         compared = m1 < m2
         assert compared[0] is False
         assert compared[1] is True
@@ -210,15 +215,15 @@ class TestMeasurementValueManipulation:
 
     def test_gt(self):
         """Test the __gt__ dunder method between a MeasurementValue and a float."""
-        m = MeasurementValue(["m"], lambda v: v)
+        m = MeasurementValue([mp1], lambda v: v)
         m_inversion = m > 0.5
         assert m_inversion[0] is False
         assert m_inversion[1] is True
 
     def test_gt_with_other_measurement_value(self):
         """Test the __gt__ dunder method between two MeasurementValues."""
-        m1 = MeasurementValue(["m1"], lambda v: v)
-        m2 = MeasurementValue(["m2"], lambda v: v)
+        m1 = MeasurementValue([mp1], lambda v: v)
+        m2 = MeasurementValue([mp2], lambda v: v)
         compared = m1 > m2
         assert compared[0] is False
         assert compared[1] is False
@@ -227,15 +232,15 @@ class TestMeasurementValueManipulation:
 
     def test_le(self):
         """Test the __le__ dunder method between a MeasurementValue and a float."""
-        m = MeasurementValue(["m"], lambda v: v)
+        m = MeasurementValue([mp1], lambda v: v)
         m_inversion = m <= 0.5
         assert m_inversion[0] is True
         assert m_inversion[1] is False
 
     def test_le_with_other_measurement_value(self):
         """Test the __le__ dunder method between two MeasurementValues"""
-        m1 = MeasurementValue(["m1"], lambda v: v)
-        m2 = MeasurementValue(["m2"], lambda v: v)
+        m1 = MeasurementValue([mp1], lambda v: v)
+        m2 = MeasurementValue([mp2], lambda v: v)
         compared = m1 <= m2
         assert compared[0] is True
         assert compared[1] is True
@@ -244,15 +249,15 @@ class TestMeasurementValueManipulation:
 
     def test_ge(self):
         """Test the __ge__ dunder method between a MeasurementValue and a flaot."""
-        m = MeasurementValue(["m"], lambda v: v)
+        m = MeasurementValue([mp1], lambda v: v)
         m_inversion = m >= 0.5
         assert m_inversion[0] is False
         assert m_inversion[1] is True
 
     def test_ge_with_other_measurement_value(self):
         """Test the __ge__ dunder method between two MeasurementValues."""
-        m1 = MeasurementValue(["m1"], lambda v: v)
-        m2 = MeasurementValue(["m2"], lambda v: v)
+        m1 = MeasurementValue([mp1], lambda v: v)
+        m2 = MeasurementValue([mp2], lambda v: v)
         compared = m1 >= m2
         assert compared[0] is True
         assert compared[1] is False
@@ -261,22 +266,22 @@ class TestMeasurementValueManipulation:
 
     def test_equality_with_scalar(self):
         """Test the __eq__ dunder method between a MeasurementValue and an integer."""
-        m = MeasurementValue(["m"], lambda v: v)
+        m = MeasurementValue([mp1], lambda v: v)
         m_eq = m == 0
         assert m_eq[0] is True  # confirming value is actually eq to True, not just truthy
         assert m_eq[1] is False
 
     def test_equality_with_scalar_opposite(self):
         """Test the __eq__ dunder method between a MeasurementValue and an integer."""
-        m = MeasurementValue(["m"], lambda v: v)
+        m = MeasurementValue([mp1], lambda v: v)
         m_eq = m == 1
         assert m_eq[0] is False
         assert m_eq[1] is True
 
     def test_eq_with_other_measurement_value(self):
         """Test the __eq__ dunder method between two MeasurementValues."""
-        m1 = MeasurementValue(["m1"], lambda v: v)
-        m2 = MeasurementValue(["m2"], lambda v: v)
+        m1 = MeasurementValue([mp1], lambda v: v)
+        m2 = MeasurementValue([mp2], lambda v: v)
         compared = m1 == m2
         assert compared[0] is True
         assert compared[1] is False
@@ -285,22 +290,22 @@ class TestMeasurementValueManipulation:
 
     def test_non_equality_with_scalar(self):
         """Test the __ne__ dunder method between a MeasurementValue and an integer."""
-        m = MeasurementValue(["m"], lambda v: v)
+        m = MeasurementValue([mp1], lambda v: v)
         m_eq = m != 0
         assert m_eq[0] is False  # confirming value is actually eq to True, not just truthy
         assert m_eq[1] is True
 
     def test_non_equality_with_scalar_opposite(self):
         """Test the __ne__ dunder method between a MeasurementValue and an integer."""
-        m = MeasurementValue(["m"], lambda v: v)
+        m = MeasurementValue([mp1], lambda v: v)
         m_eq = m != 1
         assert m_eq[0] is True
         assert m_eq[1] is False
 
     def test_non_eq_with_other_measurement_value(self):
         """Test the __ne__ dunder method between two MeasurementValues."""
-        m1 = MeasurementValue(["m1"], lambda v: v)
-        m2 = MeasurementValue(["m2"], lambda v: v)
+        m1 = MeasurementValue([mp1], lambda v: v)
+        m2 = MeasurementValue([mp2], lambda v: v)
         compared = m1 != m2
         assert compared[0] is False
         assert compared[1] is True
@@ -310,8 +315,8 @@ class TestMeasurementValueManipulation:
     def test_merge_measurements_values_dependant_on_same_measurement(self):
         """Test that the _merge operation does not create more than 2 branches when combining two MeasurementValues
         that are based on the same measurement."""
-        m0 = MeasurementValue(["m"], lambda v: v)
-        m1 = MeasurementValue(["m"], lambda v: v)
+        m0 = MeasurementValue([mp1], lambda v: v)
+        m1 = MeasurementValue([mp1], lambda v: v)
         combined = m0 + m1
         assert combined[0] == 0
         assert combined[1] == 2
@@ -319,15 +324,15 @@ class TestMeasurementValueManipulation:
     def test_combine_measurement_value_with_non_measurement(self):
         """Test that we can use dunder methods to combine a MeasurementValue with the underlying "primitive"
         of that measurement value."""
-        m0 = MeasurementValue(["m"], lambda v: v)
+        m0 = MeasurementValue([mp1], lambda v: v)
         out = m0 + 10
         assert out[0] == 10
         assert out[1] == 11
 
     def test_branches_method(self):
         """Test the __eq__ dunder method between two MeasurementValues."""
-        m1 = MeasurementValue(["m1"], lambda v: v)
-        m2 = MeasurementValue(["m2"], lambda v: v)
+        m1 = MeasurementValue([mp1], lambda v: v)
+        m2 = MeasurementValue([mp2], lambda v: v)
         compared = m1 == m2
         branches = compared.branches
         assert branches[(0, 0)] is True
@@ -337,20 +342,20 @@ class TestMeasurementValueManipulation:
 
     def test_str(self):
         """Test that the output of the __str__ dunder method is as expected"""
-        m = MeasurementValue(["m"], lambda v: v)
-        assert str(m) == "if m=0 => 0\nif m=1 => 1"
+        m = MeasurementValue([mp1], lambda v: v)
+        assert str(m) == "if m0=0 => 0\nif m0=1 => 1"
 
     def test_complex_str(self):
         """Test that the output of the __str__ dunder method is as expected
         w.r.t a more complicated MeasurementValue"""
-        a = MeasurementValue(["a"], lambda v: v)
-        b = MeasurementValue(["b"], lambda v: v)
+        a = MeasurementValue([mp1], lambda v: v)
+        b = MeasurementValue([mp2], lambda v: v)
         assert (
             str(a + b)
-            == """if a=0,b=0 => 0
-if a=0,b=1 => 1
-if a=1,b=0 => 1
-if a=1,b=1 => 2"""
+            == """if m0=0,m1=0 => 0
+if m0=0,m1=1 => 1
+if m0=1,m1=0 => 1
+if m0=1,m1=1 => 2"""
         )
 
 
@@ -389,8 +394,8 @@ class TestMeasurementCompositeValueManipulation:
     @pytest.mark.parametrize("binary1_name, binary2_name", product(binary_dunders, binary_dunders))
     def test_composition_between_measurement_values(self, unary_name, binary1_name, binary2_name):
         """Test the composition of dunder methods."""
-        m0 = MeasurementValue(["m0"], lambda v: v)
-        m1 = MeasurementValue(["m1"], lambda v: v)
+        m0 = MeasurementValue([mp1], lambda v: v)
+        m1 = MeasurementValue([mp2], lambda v: v)
 
         # 1. Apply a unary dunder method
         unary = getattr(m0, unary_name)
@@ -410,21 +415,21 @@ class TestMeasurementCompositeValueManipulation:
         # 4. Apply second binary dunder method
         binary_dunder2 = getattr(m0, binary2_name)
 
-        m2 = MeasurementValue(["m2"], lambda v: v)
+        m2 = MeasurementValue([mp1], lambda v: v)
         boolean_of_measurements = binary_dunder2(m2)
 
         assert isinstance(boolean_of_measurements, MeasurementValue)
 
     @pytest.mark.parametrize("mv_dunder_name", measurement_value_binary_dunders)
     @pytest.mark.parametrize("boolean_dunder_name", boolean_binary_dunders)
-    @pytest.mark.parametrize("scalar", [MeasurementValue(["m1"], lambda v: v), 0, 1.0, 1.0 + 0j])
-    @pytest.mark.parametrize("boolean", [MeasurementValue(["m2"], lambda v: v), True, False, None])
+    @pytest.mark.parametrize("scalar", [MeasurementValue([mp2], lambda v: v), 0, 1.0, 1.0 + 0j])
+    @pytest.mark.parametrize("boolean", [MeasurementValue([mp3], lambda v: v), True, False, None])
     def test_composition_measurement_values_and_boolean(
         self, mv_dunder_name, boolean_dunder_name, scalar, boolean
     ):  # pylint: disable=too-many-arguments
         """Test the composition of dunder methods, applying one whose argument is scalar and one whose argument
         is a boolean."""
-        m0 = MeasurementValue(["m0"], lambda v: v)
+        m0 = MeasurementValue([mp1], lambda v: v)
 
         # 1. Apply first binary dunder method between m0 and scalar
         binary_dunder1 = getattr(m0, mv_dunder_name)
@@ -437,13 +442,13 @@ class TestMeasurementCompositeValueManipulation:
         assert isinstance(boolean_of_measurements, MeasurementValue)
 
     @pytest.mark.parametrize("div", divisions)
-    @pytest.mark.parametrize("other", [MeasurementValue(["m2"], lambda v: v) + 5, np.pi])
+    @pytest.mark.parametrize("other", [MeasurementValue([mp3], lambda v: v) + 5, np.pi])
     @pytest.mark.parametrize("binary", binary_dunders)
     def test_composition_with_division(self, binary, div, other):
         """Test the composition of dunder methods with division."""
         # 1. Apply a binary dundar
-        m0 = MeasurementValue(["m0"], lambda v: v)
-        m1 = MeasurementValue(["m1"], lambda v: v)
+        m0 = MeasurementValue([mp1], lambda v: v)
+        m1 = MeasurementValue([mp2], lambda v: v)
 
         binary_dunder = getattr(m0, binary)
         m0 = binary_dunder(m1)


### PR DESCRIPTION
**Context:**
Updates for mid-circuit measurement overhaul. This change is being made instead of #4408 

**Description of the Change:**
* Changed signature of `MeasurementValue` constructor to accept a list of `MidMeasureMP`s rather than their ids.

**Benefits:**
* `MeasurementValue`s store references to their respective `MidMeasureMP`s, so `MidMeasureMP`s can be used without queuing with `qml.measure`.

**Possible Drawbacks:**

**Related GitHub Issues:**
