### PR TITLE
Remove the `shots` kwarg from the gradients module

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -166,9 +166,6 @@ array([False, False])
 * `transmon_drive` is updated in accordance with [1904.06560](https://arxiv.org/abs/1904.06560). In particular, the functional form has been changed from $\Omega(t)(\cos(\omega_d t + \phi) X - \sin(\omega_d t + \phi) Y)$ to $\Omega(t) \sin(\omega_d t + \phi) Y$.
   [(#4418)](https://github.com/PennyLaneAI/pennylane/pull/4418/)
 
-* The gradients module no longer needs shot information passed to it explicitly, as the shots are on the tapes.
-  [(#4448)](https://github.com/PennyLaneAI/pennylane/pull/4448)
-
 <h3>Breaking changes 💔</h3>
 
 * `Operator.expand` now uses the output of `Operator.decomposition` instead of what it queues.
@@ -207,6 +204,9 @@ array([False, False])
 
 * The Pauli-X-term in `transmon_drive` has been removed in accordance with [1904.06560](https://arxiv.org/abs/1904.06560)
   [(#4418)](https://github.com/PennyLaneAI/pennylane/pull/4418/)
+
+* The gradients module no longer needs shot information passed to it explicitly, as the shots are on the tapes.
+  [(#4448)](https://github.com/PennyLaneAI/pennylane/pull/4448)
 
 <h3>Deprecations 👋</h3>
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -160,6 +160,9 @@ array([False, False])
 * `transmon_drive` is updated in accordance with [1904.06560](https://arxiv.org/abs/1904.06560). In particular, the functional form has been changed from $\Omega(t)(\cos(\omega_d t + \phi) X - \sin(\omega_d t + \phi) Y)$ to $\Omega(t) \sin(\omega_d t + \phi) Y$.
   [(#4418)](https://github.com/PennyLaneAI/pennylane/pull/4418/)
 
+* The gradients module no longer needs shot information passed to it explicitly, as the shots are on the tapes.
+  [(#4448)](https://github.com/PennyLaneAI/pennylane/pull/4448)
+
 <h3>Breaking changes 💔</h3>
 
 * `Operator.expand` now uses the output of `Operator.decomposition` instead of what it queues.

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -736,7 +736,7 @@ class Device(abc.ABC):
         """
         supports_hamiltonian = self.supports_observable("Hamiltonian")
         supports_sum = self.supports_observable("Sum")
-        finite_shots = self.shots is not None or circuit.shots
+        finite_shots = self.shots is not None
         grouping_known = all(
             obs.grouping_indices is not None
             for obs in circuit.observables

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -736,7 +736,7 @@ class Device(abc.ABC):
         """
         supports_hamiltonian = self.supports_observable("Hamiltonian")
         supports_sum = self.supports_observable("Sum")
-        finite_shots = self.shots is not None
+        finite_shots = self.shots is not None or circuit.shots
         grouping_known = all(
             obs.grouping_indices is not None
             for obs in circuit.observables

--- a/pennylane/gradients/finite_difference.py
+++ b/pennylane/gradients/finite_difference.py
@@ -298,6 +298,8 @@ def finite_diff(
         ((array(-0.38751724), array(-0.18884792), array(-0.38355709)),
          (array(0.69916868), array(0.34072432), array(0.69202366)))
 
+        This gradient transform is compatible with devices that use shot vectors for execution.
+
         >>> shots = (10, 100, 1000)
         >>> dev = qml.device("default.qubit", wires=2, shots=shots)
         >>> @qml.qnode(dev)

--- a/pennylane/gradients/finite_difference.py
+++ b/pennylane/gradients/finite_difference.py
@@ -23,7 +23,7 @@ import numpy as np
 from scipy.special import factorial
 
 import pennylane as qml
-from pennylane.measurements import ProbabilityMP, Shots
+from pennylane.measurements import ProbabilityMP
 
 from .general_shift_rules import generate_shifted_tapes
 from .gradient_transform import (
@@ -156,7 +156,7 @@ def finite_diff_coeffs(n, approx_order, strategy):
     return coeffs_and_shifts
 
 
-def _processing_fn(results, shots: Shots = Shots(None), single_shot_batch_fn=None):
+def _processing_fn(results, shots, single_shot_batch_fn):
     if not shots.has_partitioned_shots:
         return single_shot_batch_fn(results)
     grads_tuple = []

--- a/pennylane/gradients/general_shift_rules.py
+++ b/pennylane/gradients/general_shift_rules.py
@@ -414,9 +414,7 @@ def _copy_and_shift_params(tape, indices, shifts, multipliers, cast=False):
     prep = all_ops[: len(tape._prep)]
     ops = all_ops[len(tape._prep) : len(tape.operations)]
     meas = all_ops[len(tape.operations) :]
-    shifted_tape = QuantumScript(ops=ops, measurements=meas, prep=prep, shots=tape.shots)
-
-    return shifted_tape
+    return QuantumScript(ops=ops, measurements=meas, prep=prep, shots=tape.shots)
 
 
 def generate_shifted_tapes(tape, index, shifts, multipliers=None, broadcast=False):

--- a/pennylane/gradients/gradient_transform.py
+++ b/pennylane/gradients/gradient_transform.py
@@ -26,7 +26,6 @@ from pennylane.measurements import (
     VarianceMP,
     VnEntropyMP,
     ProbabilityMP,
-    Shots,
 )
 
 SUPPORTED_GRADIENT_KWARGS = [
@@ -251,7 +250,7 @@ def choose_grad_methods(diff_methods, argnum):
     return {idx: diff_methods[idx] for idx in argnum}
 
 
-def _all_zero_grad(tape, shots=Shots(None)):
+def _all_zero_grad(tape):
     """Auxiliary function to return zeros for the all-zero gradient case."""
     list_zeros = []
 
@@ -266,10 +265,10 @@ def _all_zero_grad(tape, shots=Shots(None)):
 
         list_zeros.append(sub_list_zeros)
 
-    if shots.has_partitioned_shots:
+    if tape.shots.has_partitioned_shots:
         if len(tape.measurements) == 1:
-            return [], lambda _: tuple(list_zeros[0] for _ in range(shots.num_copies))
-        return [], lambda _: tuple(tuple(list_zeros) for _ in range(shots.num_copies))
+            return [], lambda _: tuple(list_zeros[0] for _ in range(tape.shots.num_copies))
+        return [], lambda _: tuple(tuple(list_zeros) for _ in range(tape.shots.num_copies))
 
     if len(tape.measurements) == 1:
         return [], lambda _: list_zeros[0]
@@ -284,16 +283,16 @@ _no_trainable_grad_warning = (
 )
 
 
-def _no_trainable_grad(tape, shots=Shots(None)):
+def _no_trainable_grad(tape):
     """Auxiliary function that returns correctly formatted gradients when there
     are no trainable parameters."""
     warnings.warn(_no_trainable_grad_warning)
-    if shots.has_partitioned_shots:
+    if tape.shots.has_partitioned_shots:
         if len(tape.measurements) == 1:
-            return [], lambda _: tuple(qml.math.zeros([0]) for _ in range(shots.num_copies))
+            return [], lambda _: tuple(qml.math.zeros([0]) for _ in range(tape.shots.num_copies))
         return [], lambda _: tuple(
             tuple(qml.math.zeros([0]) for _ in range(len(tape.measurements)))
-            for _ in range(shots.num_copies)
+            for _ in range(tape.shots.num_copies)
         )
 
     if len(tape.measurements) == 1:
@@ -629,7 +628,8 @@ class gradient_transform(qml.batch_transform):
 
             if qml.active_return():
                 num_measurements = len(qnode.tape.measurements)
-                has_partitioned_shots = Shots(tkwargs.get("shots", None)).has_partitioned_shots
+                # TODO: should this be tkwargs["tape"].shots?
+                has_partitioned_shots = qnode.tape.shots.has_partitioned_shots
                 return _contract_qjac_with_cjac(qjac, cjac, num_measurements, has_partitioned_shots)
 
             return _contract_qjac_with_cjac_legacy(qjac, cjac)

--- a/pennylane/gradients/gradient_transform.py
+++ b/pennylane/gradients/gradient_transform.py
@@ -628,7 +628,6 @@ class gradient_transform(qml.batch_transform):
 
             if qml.active_return():
                 num_measurements = len(qnode.tape.measurements)
-                # TODO: should this be tkwargs["tape"].shots?
                 has_partitioned_shots = qnode.tape.shots.has_partitioned_shots
                 return _contract_qjac_with_cjac(qjac, cjac, num_measurements, has_partitioned_shots)
 

--- a/pennylane/gradients/hadamard_gradient.py
+++ b/pennylane/gradients/hadamard_gradient.py
@@ -35,7 +35,6 @@ from .gradient_transform import (
 def _hadamard_grad(
     tape,
     argnum=None,
-    shots=None,
     aux_wire=None,
     device_wires=None,
 ):
@@ -46,9 +45,6 @@ def _hadamard_grad(
         argnum (int or list[int] or None): Trainable tape parameter indices to differentiate
             with respect to. If not provided, the derivatives with respect to all
             trainable parameters are returned.
-        shots (None, int, list[int]): The device shots that will be used to execute the tapes outputted by this
-            transform. Note that this argument doesn't influence the shots used for tape execution, but provides
-            information about the shots.
         aux_wire (pennylane.wires.Wires): Auxiliary wire to be used for the Hadamard tests. If ``None`` (the default),
             a suitable wire is inferred from the wires used in the original circuit and ``device_wires``.
         device_wires (pennylane.wires.Wires): Wires of the device that are going to be used for the
@@ -182,15 +178,14 @@ def _hadamard_grad(
     assert_active_return(transform_name)
     assert_no_state_returns(tape.measurements, transform_name)
     assert_no_variance(tape.measurements, transform_name)
-    shots = qml.measurements.Shots(shots)
 
     if argnum is None and not tape.trainable_params:
-        return _no_trainable_grad(tape, shots)
+        return _no_trainable_grad(tape)
 
     diff_methods = gradient_analysis_and_validation(tape, "analytic", grad_fn=hadamard_grad)
 
     if all(g == "0" for g in diff_methods):
-        return _all_zero_grad(tape, shots)
+        return _all_zero_grad(tape)
 
     method_map = choose_grad_methods(diff_methods, argnum)
 

--- a/pennylane/gradients/parameter_shift.py
+++ b/pennylane/gradients/parameter_shift.py
@@ -1276,6 +1276,8 @@ def param_shift(
         ((array(-0.3875172), array(-0.18884787), array(-0.38355704)),
          (array(0.69916862), array(0.34072424), array(0.69202359)))
 
+        This gradient transform is compatible with devices that use shot vectors for execution.
+        
         >>> shots = (10, 100, 1000)
         >>> dev = qml.device("default.qubit", wires=2, shots=shots)
         >>> @qml.qnode(dev)

--- a/pennylane/gradients/parameter_shift.py
+++ b/pennylane/gradients/parameter_shift.py
@@ -1277,7 +1277,7 @@ def param_shift(
          (array(0.69916862), array(0.34072424), array(0.69202359)))
 
         This gradient transform is compatible with devices that use shot vectors for execution.
-        
+
         >>> shots = (10, 100, 1000)
         >>> dev = qml.device("default.qubit", wires=2, shots=shots)
         >>> @qml.qnode(dev)

--- a/pennylane/gradients/parameter_shift.py
+++ b/pennylane/gradients/parameter_shift.py
@@ -17,12 +17,11 @@ of a qubit-based quantum tape.
 """
 # pylint: disable=protected-access,too-many-arguments,too-many-statements
 from collections.abc import Sequence
-from functools import partial
 
 import numpy as np
 
 import pennylane as qml
-from pennylane.measurements import VarianceMP, Shots
+from pennylane.measurements import VarianceMP
 
 from .finite_difference import finite_diff
 from .general_shift_rules import (
@@ -184,7 +183,7 @@ def _multi_meas_grad(res, coeffs, r0, unshifted_coeff, num_measurements):
     return tuple(g)
 
 
-def _evaluate_gradient(tape, res, data, r0, shots: Shots):
+def _evaluate_gradient(tape, res, data, r0):
     """Use shifted tape evaluations and parameter-shift rule coefficients to evaluate
     a gradient result. If res is an empty list, ``r0`` and ``data[3]``, which is the
     coefficient for the unshifted term, must be given and not None.
@@ -199,10 +198,10 @@ def _evaluate_gradient(tape, res, data, r0, shots: Shots):
     num_measurements = len(tape.measurements)
 
     if num_measurements == 1:
-        if not shots.has_partitioned_shots:
+        if not tape.shots.has_partitioned_shots:
             return _single_meas_grad(res, coeffs, unshifted_coeff, r0)
         g = []
-        len_shot_vec = shots.num_copies
+        len_shot_vec = tape.shots.num_copies
         # Res has order of axes:
         # 1. Number of parameters
         # 2. Shot vector
@@ -215,14 +214,14 @@ def _evaluate_gradient(tape, res, data, r0, shots: Shots):
         return tuple(g)
 
     g = []
-    if not shots.has_partitioned_shots:
+    if not tape.shots.has_partitioned_shots:
         return _multi_meas_grad(res, coeffs, r0, unshifted_coeff, num_measurements)
 
     # Res has order of axes:
     # 1. Number of parameters
     # 2. Shot vector
     # 3. Number of measurements
-    for idx_shot_comp in range(shots.num_copies):
+    for idx_shot_comp in range(tape.shots.num_copies):
         single_shot_component_result = [
             result_for_each_param[idx_shot_comp] for result_for_each_param in res
         ]
@@ -363,7 +362,7 @@ def _make_zero_rep(g, single_measure, has_partitioned_shots, par_shapes=None):
 
 
 def expval_param_shift(
-    tape, argnum=None, shifts=None, gradient_recipes=None, f0=None, broadcast=False, shots=None
+    tape, argnum=None, shifts=None, gradient_recipes=None, f0=None, broadcast=False
 ):
     r"""Generate the parameter-shift tapes and postprocessing methods required
         to compute the gradient of a gate parameter with respect to an
@@ -389,9 +388,6 @@ def expval_param_shift(
                 saving a quantum evaluation.
             broadcast (bool): Whether or not to use parameter broadcasting to create the
                 a single broadcasted tape per operation instead of one tape per shift angle.
-            shots (None, int, list[int], list[~pennylane.measurements.ShotCopies]): The device shots that will be
-                used to execute the tapes outputted by this transform. Note that this argument doesn't influence
-                the shots used for tape execution, but provides information to the transform about the shots.
 
         Returns:
             tuple[list[QuantumTape], function]: A tuple containing a
@@ -400,9 +396,7 @@ def expval_param_shift(
             in order to obtain the Jacobian matrix.
     """
     if not qml.active_return():
-        return _expval_param_shift_legacy(
-            tape, argnum, shifts, gradient_recipes, f0, broadcast, shots
-        )
+        return _expval_param_shift_legacy(tape, argnum, shifts, gradient_recipes, f0, broadcast)
 
     argnum = argnum or tape.trainable_params
 
@@ -452,8 +446,7 @@ def expval_param_shift(
     num_measurements = len(tape.measurements)
     single_measure = num_measurements == 1
     num_params = len(tape.trainable_params)
-    shots = Shots(shots)
-    tape_specs = (single_measure, num_params, num_measurements, shots)
+    tape_specs = (single_measure, num_params, num_measurements, tape.shots)
 
     def processing_fn(results):
         start, r0 = (1, results[0]) if at_least_one_unshifted and f0 is None else (0, f0)
@@ -467,19 +460,19 @@ def expval_param_shift(
                     grads.append(None)
                     continue
                 # The gradient for this parameter is computed from r0 alone.
-                g = _evaluate_gradient(tape, [], data, r0, shots)
+                g = _evaluate_gradient(tape, [], data, r0)
                 grads.append(g)
                 continue
 
             res = results[start : start + num_tapes] if batch_size is None else results[start]
             start = start + num_tapes
 
-            g = _evaluate_gradient(tape, res, data, r0, shots)
+            g = _evaluate_gradient(tape, res, data, r0)
             grads.append(g)
 
         # g will have been defined at least once (because otherwise all gradients would have
         # been zero), providing a representative for a zero gradient to emulate its type/shape.
-        zero_rep = _make_zero_rep(g, single_measure, shots.has_partitioned_shots)
+        zero_rep = _make_zero_rep(g, single_measure, tape.shots.has_partitioned_shots)
 
         # Fill in zero-valued gradients
         grads = [zero_rep if g is None else g for g in grads]
@@ -493,7 +486,7 @@ def expval_param_shift(
 
 # pylint: disable=unused-argument
 def _expval_param_shift_legacy(
-    tape, argnum=None, shifts=None, gradient_recipes=None, f0=None, broadcast=False, shots=None
+    tape, argnum=None, shifts=None, gradient_recipes=None, f0=None, broadcast=False
 ):
     r"""Generate the parameter-shift tapes and postprocessing methods required
     to compute the gradient of a gate parameter with respect to an
@@ -516,9 +509,6 @@ def _expval_param_shift_legacy(
             saving a quantum evaluation.
         broadcast (bool): Whether or not to use parameter broadcasting to create the
             a single broadcasted tape per operation instead of one tape per shift angle.
-        shots (None, int, list[int]): The device shots that will be used to execute the tapes
-            outputted by this transform. Note that this argument doesn't influence the shots used for tape
-            execution, but provides information to the transform about the shots.
 
     Returns:
         tuple[list[QuantumTape], function]: A tuple containing a
@@ -686,7 +676,7 @@ def _put_zeros_in_pdA2_involutory(tape, pdA2, involutory_indices):
     return tuple(new_pdA2)
 
 
-def _get_pdA2(results, tape, pdA2_fn, non_involutory_indices, var_indices, has_partitioned_shots):
+def _get_pdA2(results, tape, pdA2_fn, non_involutory_indices, var_indices):
     """The main auxiliary function to get the partial derivative of <A^2>."""
     pdA2 = 0
 
@@ -696,7 +686,7 @@ def _get_pdA2(results, tape, pdA2_fn, non_involutory_indices, var_indices, has_p
 
         # For involutory observables (A^2 = I) we have d<A^2>/dp = 0.
         if involutory := set(var_indices) - set(non_involutory_indices):
-            if has_partitioned_shots:
+            if tape.has_partitioned_shots:
                 pdA2 = tuple(
                     _put_zeros_in_pdA2_involutory(tape, pdA2_shot_comp, involutory)
                     for pdA2_shot_comp in pdA2
@@ -762,7 +752,7 @@ def _single_variance_gradient(tape, var_mask, pdA2, f0, pdA):
 
 
 def _create_variance_proc_fn(
-    tape, var_mask, var_indices, pdA_fn, pdA2_fn, tape_boundary, non_involutory_indices, shots
+    tape, var_mask, var_indices, pdA_fn, pdA2_fn, tape_boundary, non_involutory_indices
 ):
     """Auxiliary function to define the processing function for computing the
     derivative of variances using the parameter-shift rule.
@@ -778,14 +768,10 @@ def _create_variance_proc_fn(
             determine the number of results to post-process later
         non_involutory_indices (list): the indices in the measurement queue of all non-involutory
             observables
-        shots (.Shots): The device shots that will be used to execute the tapes outputted by this
-            the param-shift transform.
     """
 
     def processing_fn(results):
         f0 = results[0]
-
-        has_partitioned_shots = shots.has_partitioned_shots
 
         # analytic derivative of <A>
         pdA = pdA_fn(results[int(not pdA_fn.first_result_unshifted) : tape_boundary])
@@ -797,16 +783,15 @@ def _create_variance_proc_fn(
             pdA2_fn,
             non_involutory_indices,
             var_indices,
-            has_partitioned_shots,
         )
 
         # The logic follows:
         # variances (var_mask==True): return d(var(A))/dp = d<A^2>/dp -2 * <A> * d<A>/dp
         # plain expectations (var_mask==False): return d<A>/dp
         # Note: if pdA2 != 0, then len(pdA2) == len(pdA)
-        if has_partitioned_shots:
+        if tape.has_partitioned_shots:
             final_res = []
-            for idx_shot_comp in range(shots.num_copies):
+            for idx_shot_comp in range(tape.shots.num_copies):
                 f0_comp = f0[idx_shot_comp]
 
                 pdA_comp = pdA[idx_shot_comp]
@@ -822,9 +807,7 @@ def _create_variance_proc_fn(
     return processing_fn
 
 
-def var_param_shift(
-    tape, argnum, shifts=None, gradient_recipes=None, f0=None, broadcast=False, shots=None
-):
+def var_param_shift(tape, argnum, shifts=None, gradient_recipes=None, f0=None, broadcast=False):
     r"""Generate the parameter-shift tapes and postprocessing methods required
     to compute the gradient of a gate parameter with respect to a
     variance value.
@@ -848,9 +831,6 @@ def var_param_shift(
             saving a quantum evaluation.
         broadcast (bool): Whether or not to use parameter broadcasting to create the
             a single broadcasted tape per operation instead of one tape per shift angle.
-        shots (None, int, list[int]): The device shots that will be used to execute the tapes
-            outputted by this transform. Note that this argument doesn't influence the shots used for tape
-            execution, but provides information to the transform about the shots.
 
     Returns:
         tuple[list[QuantumTape], function]: A tuple containing a
@@ -859,10 +839,9 @@ def var_param_shift(
         in order to obtain the Jacobian matrix.
     """
     if not qml.active_return():
-        return _var_param_shift_legacy(tape, argnum, shifts, gradient_recipes, f0, broadcast, shots)
+        return _var_param_shift_legacy(tape, argnum, shifts, gradient_recipes, f0, broadcast)
 
     argnum = argnum or tape.trainable_params
-    shots = Shots(shots)
 
     # Determine the locations of any variance measurements in the measurement queue.
     var_mask = [isinstance(m, VarianceMP) for m in tape.measurements]
@@ -878,7 +857,7 @@ def var_param_shift(
 
     # evaluate the analytic derivative of <A>
     pdA_tapes, pdA_fn = expval_param_shift(
-        expval_tape, argnum, shifts, gradient_recipes, f0, broadcast, shots
+        expval_tape, argnum, shifts, gradient_recipes, f0, broadcast
     )
     gradient_tapes = [] if pdA_fn.first_result_unshifted else [expval_tape]
     gradient_tapes.extend(pdA_tapes)
@@ -917,19 +896,19 @@ def var_param_shift(
         # may be non-zero. Here, we calculate the analytic derivatives of the <A^2>
         # observables.
         pdA2_tapes, pdA2_fn = expval_param_shift(
-            tape_with_obs_squared_expval, argnum, shifts, gradient_recipes, f0, broadcast, shots
+            tape_with_obs_squared_expval, argnum, shifts, gradient_recipes, f0, broadcast
         )
         gradient_tapes.extend(pdA2_tapes)
 
     processing_fn = _create_variance_proc_fn(
-        tape, var_mask, var_indices, pdA_fn, pdA2_fn, tape_boundary, non_involutory_indices, shots
+        tape, var_mask, var_indices, pdA_fn, pdA2_fn, tape_boundary, non_involutory_indices
     )
     return gradient_tapes, processing_fn
 
 
 # pylint: disable=unused-argument
 def _var_param_shift_legacy(
-    tape, argnum, shifts=None, gradient_recipes=None, f0=None, broadcast=False, shots=None
+    tape, argnum, shifts=None, gradient_recipes=None, f0=None, broadcast=False
 ):
     r"""Generate the parameter-shift tapes and postprocessing methods required
     to compute the gradient of a gate parameter with respect to a
@@ -952,9 +931,6 @@ def _var_param_shift_legacy(
             saving a quantum evaluation.
         broadcast (bool): Whether or not to use parameter broadcasting to create the
             a single broadcasted tape per operation instead of one tape per shift angle.
-        shots (None, int, list[int]): The device shots that will be used to execute the tapes
-            outputted by this transform. Note that this argument doesn't influence the shots used for tape
-            execution, but provides information to the transform about the shots.
 
     Returns:
         tuple[list[QuantumTape], function]: A tuple containing a
@@ -1086,7 +1062,6 @@ def param_shift(
     fallback_fn=finite_diff,
     f0=None,
     broadcast=False,
-    shots=None,
 ):
     r"""Transform a QNode to compute the parameter-shift gradient of all gate
     parameters with respect to its inputs.
@@ -1121,9 +1096,6 @@ def param_shift(
             saving a quantum evaluation.
         broadcast (bool): Whether or not to use parameter broadcasting to create the
             a single broadcasted tape per operation instead of one tape per shift angle.
-        shots (None, int, list[int]): The device shots that will be used to execute the tapes outputted by this
-            transform. Note that this argument doesn't influence the shots used for tape execution, but provides
-            information about the shots.
 
     Returns:
         function or tuple[list[QuantumTape], function]:
@@ -1304,9 +1276,6 @@ def param_shift(
         ((array(-0.3875172), array(-0.18884787), array(-0.38355704)),
          (array(0.69916862), array(0.34072424), array(0.69202359)))
 
-        Devices that have a shot vector defined can also be used for execution, provided
-        the ``shots`` argument was passed to the transform:
-
         >>> shots = (10, 100, 1000)
         >>> dev = qml.device("default.qubit", wires=2, shots=shots)
         >>> @qml.qnode(dev)
@@ -1316,7 +1285,7 @@ def param_shift(
         ...     qml.RX(params[2], wires=0)
         ...     return qml.expval(qml.PauliZ(0)), qml.var(qml.PauliZ(0))
         >>> params = np.array([0.1, 0.2, 0.3], requires_grad=True)
-        >>> qml.gradients.param_shift(circuit, shots=shots)(params)
+        >>> qml.gradients.param_shift(circuit)(params)
         (((array(-0.6), array(-0.1), array(-0.1)),
           (array(1.2), array(0.2), array(0.2))),
          ((array(-0.39), array(-0.24), array(-0.49)),
@@ -1376,22 +1345,20 @@ def param_shift(
             fallback_fn=fallback_fn,
             f0=f0,
             broadcast=broadcast,
-            shots=shots,
         )
 
     transform_name = "parameter-shift rule"
-    shots = Shots(shots)
     assert_no_state_returns(tape.measurements, transform_name)
     assert_multimeasure_not_broadcasted(tape.measurements, broadcast)
 
     if argnum is None and not tape.trainable_params:
-        return _no_trainable_grad(tape, shots)
+        return _no_trainable_grad(tape)
 
     method = "analytic" if fallback_fn is None else "best"
     diff_methods = gradient_analysis_and_validation(tape, method, grad_fn=param_shift)
 
     if all(g == "0" for g in diff_methods):
-        return _all_zero_grad(tape, shots)
+        return _all_zero_grad(tape)
 
     method_map = choose_grad_methods(diff_methods, argnum)
 
@@ -1401,9 +1368,6 @@ def param_shift(
     gradient_tapes = []
 
     if unsupported_params:
-        # If shots were provided, assume that the fallback function also takes that arg
-
-        fallback_fn = partial(fallback_fn, shots=shots) if shots else fallback_fn
         if not argnum:
             return fallback_fn(tape)
 
@@ -1420,11 +1384,9 @@ def param_shift(
         gradient_recipes = [None] * len(argnum)
 
     if any(isinstance(m, VarianceMP) for m in tape.measurements):
-        g_tapes, fn = var_param_shift(tape, argnum, shifts, gradient_recipes, f0, broadcast, shots)
+        g_tapes, fn = var_param_shift(tape, argnum, shifts, gradient_recipes, f0, broadcast)
     else:
-        g_tapes, fn = expval_param_shift(
-            tape, argnum, shifts, gradient_recipes, f0, broadcast, shots
-        )
+        g_tapes, fn = expval_param_shift(tape, argnum, shifts, gradient_recipes, f0, broadcast)
 
     gradient_tapes.extend(g_tapes)
 
@@ -1463,7 +1425,7 @@ def param_shift(
             unsupported_res = results[:fallback_len]
             supported_res = results[fallback_len:]
 
-            if not shots.has_partitioned_shots:
+            if not tape.shots.has_partitioned_shots:
                 unsupported_grads = fallback_proc_fn(unsupported_res)
                 supported_grads = fn(supported_res)
                 return _single_shot_batch_grad(unsupported_grads, supported_grads)
@@ -1472,7 +1434,7 @@ def param_shift(
             unsupported_grads = fallback_proc_fn(unsupported_res)
 
             final_grad = []
-            for idx in range(shots.num_copies):
+            for idx in range(tape.shots.num_copies):
                 u_grads = unsupported_grads[idx]
                 sup = supported_grads[idx]
                 final_grad.append(_single_shot_batch_grad(u_grads, sup))
@@ -1480,20 +1442,7 @@ def param_shift(
 
         return gradient_tapes, processing_fn
 
-    def proc_with_validation(results):
-        """Assume if a ValueError is raised during the computation, then
-        shot vectors are used and the shots argument was not set correctly."""
-        try:
-            res = fn(results)
-        except (ValueError, TypeError) as e:
-            raise e.__class__(
-                "The processing function of the gradient transform ran into errors. "
-                "Make sure to pass the device shots to the param_shift gradient transform "
-                "using the shots argument."
-            ) from e
-        return res
-
-    return gradient_tapes, proc_with_validation
+    return gradient_tapes, fn
 
 
 # pylint: disable=unused-argument
@@ -1506,7 +1455,6 @@ def _param_shift_legacy(
     fallback_fn=finite_diff,
     f0=None,
     broadcast=False,
-    shots=None,
 ):
     r"""Transform a QNode to compute the parameter-shift gradient of all gate
     parameters with respect to its inputs.
@@ -1541,9 +1489,6 @@ def _param_shift_legacy(
             saving a quantum evaluation.
         broadcast (bool): Whether or not to use parameter broadcasting to create the
             a single broadcasted tape per operation instead of one tape per shift angle.
-        shots (None, int, list[int]): The device shots that will be used to execute the tapes
-            outputted by this transform. Note that this argument doesn't influence the shots used for tape
-            execution, but provides information to the transform about the shots.
 
     Returns:
         function or tuple[list[QuantumTape], function]:

--- a/pennylane/gradients/parameter_shift.py
+++ b/pennylane/gradients/parameter_shift.py
@@ -686,7 +686,7 @@ def _get_pdA2(results, tape, pdA2_fn, non_involutory_indices, var_indices):
 
         # For involutory observables (A^2 = I) we have d<A^2>/dp = 0.
         if involutory := set(var_indices) - set(non_involutory_indices):
-            if tape.has_partitioned_shots:
+            if tape.shots.has_partitioned_shots:
                 pdA2 = tuple(
                     _put_zeros_in_pdA2_involutory(tape, pdA2_shot_comp, involutory)
                     for pdA2_shot_comp in pdA2
@@ -789,7 +789,7 @@ def _create_variance_proc_fn(
         # variances (var_mask==True): return d(var(A))/dp = d<A^2>/dp -2 * <A> * d<A>/dp
         # plain expectations (var_mask==False): return d<A>/dp
         # Note: if pdA2 != 0, then len(pdA2) == len(pdA)
-        if tape.has_partitioned_shots:
+        if tape.shots.has_partitioned_shots:
             final_res = []
             for idx_shot_comp in range(tape.shots.num_copies):
                 f0_comp = f0[idx_shot_comp]

--- a/pennylane/gradients/parameter_shift_cv.py
+++ b/pennylane/gradients/parameter_shift_cv.py
@@ -498,7 +498,6 @@ def param_shift_cv(
     fallback_fn=finite_diff,
     f0=None,
     force_order2=False,
-    shots=None,
 ):
     r"""Transform a continuous-variable QNode to compute the parameter-shift gradient of all gate
     parameters with respect to its inputs.

--- a/pennylane/gradients/pulse_generator_gradient.py
+++ b/pennylane/gradients/pulse_generator_gradient.py
@@ -22,7 +22,6 @@ import pennylane as qml
 
 from pennylane.pulse import ParametrizedEvolution
 from pennylane.ops.qubit.special_unitary import pauli_basis_strings, _pauli_decompose
-from pennylane.measurements import Shots
 
 from .parameter_shift import _make_zero_rep
 from .pulse_gradient import _assert_has_jax, raise_pulse_diff_on_qnode
@@ -279,7 +278,7 @@ def _parshift_and_contract(results, coeffs, single_measure, single_shot_entry):
     )
 
 
-def _expval_pulse_generator(tape, argnum, shots, atol):
+def _expval_pulse_generator(tape, argnum, atol):
     """Compute the pulse generator parameter-shift rule for a quantum circuit that returns expectation
     values of observables.
 
@@ -289,10 +288,6 @@ def _expval_pulse_generator(tape, argnum, shots, atol):
         argnum (int or list[int] or None): Trainable tape parameter indices to differentiate
             with respect to. If not provided, the derivatives with respect to all
             trainable parameters are returned.
-        shots (None, int, list[int]): The shots of the device used to execute the tapes which are
-            returned by this transform. Note that this argument does not *influence* the shots
-            used for execution, but *informs* the transform about the shots to ensure a compatible
-            return value formatting.
         atol (float): absolute tolerance used to determine vanishing contributions.
 
     Returns:
@@ -352,8 +347,8 @@ def _expval_pulse_generator(tape, argnum, shots, atol):
     num_measurements = len(tape.measurements)
     single_measure = num_measurements == 1
     num_params = len(tape.trainable_params)
-    partitioned_shots = shots.has_partitioned_shots
-    tape_specs = (single_measure, num_params, num_measurements, shots)
+    partitioned_shots = tape.shots.has_partitioned_shots
+    tape_specs = (single_measure, num_params, num_measurements, tape.shots)
 
     def processing_fn(results):
         """Post-process the results of the parameter-shifted tapes for
@@ -401,7 +396,7 @@ def _expval_pulse_generator(tape, argnum, shots, atol):
     return gradient_tapes, processing_fn
 
 
-def _pulse_generator(tape, argnum=None, shots=None, atol=1e-7):
+def _pulse_generator(tape, argnum=None, atol=1e-7):
     r"""Transform a QNode to compute the pulse generator parameter-shift gradient of pulses
     in a pulse program with respect to their inputs.
     This method combines automatic differentiation of few-qubit operations with
@@ -431,10 +426,6 @@ def _pulse_generator(tape, argnum=None, shots=None, atol=1e-7):
         argnum (int or list[int] or None): Trainable tape parameter indices to differentiate
             with respect to. If not provided, the derivatives with respect to all
             trainable parameters are returned.
-        shots (None, int, list[int]): The shots of the device used to execute the tapes which are
-            returned by this transform. Note that this argument does not *influence* the shots
-            used for execution, but *informs* the transform about the shots to ensure a compatible
-            return value formatting.
         atol (float): Precision parameter used to truncate the Pauli basis coefficients
             of the effective generators. Coefficients ``x`` satisfying
             ``qml.math.isclose(x, 0., atol=atol, rtol=0) == True`` are neglected.
@@ -690,21 +681,20 @@ def _pulse_generator(tape, argnum=None, shots=None, atol=1e-7):
     assert_active_return(transform_name)
     assert_no_state_returns(tape.measurements, transform_name)
     assert_no_variance(tape.measurements, transform_name)
-    shots = Shots(shots)
 
     if argnum is None and not tape.trainable_params:
-        return _no_trainable_grad(tape, shots)
+        return _no_trainable_grad(tape)
 
     diff_methods = gradient_analysis_and_validation(tape, "analytic", grad_fn=pulse_generator)
 
     if all(g == "0" for g in diff_methods):
-        return _all_zero_grad(tape, shots)
+        return _all_zero_grad(tape)
 
     method_map = choose_grad_methods(diff_methods, argnum)
 
     argnum = [i for i, dm in method_map.items() if dm == "A"]
 
-    return _expval_pulse_generator(tape, argnum, shots, atol)
+    return _expval_pulse_generator(tape, argnum, atol)
 
 
 def expand_invalid_trainable_pulse_generator(x, *args, **kwargs):

--- a/pennylane/gradients/pulse_gradient.py
+++ b/pennylane/gradients/pulse_gradient.py
@@ -282,7 +282,7 @@ def _parshift_and_integrate(
 
 # pylint: disable=too-many-arguments
 def _stoch_pulse_grad(
-    tape, argnum=None, num_split_times=1, sampler_seed=None, shots=None, use_broadcasting=False
+    tape, argnum=None, num_split_times=1, sampler_seed=None, use_broadcasting=False
 ):
     r"""Compute the gradient of a quantum circuit composed of pulse sequences by applying the
     stochastic parameter shift rule.
@@ -335,10 +335,6 @@ def _stoch_pulse_grad(
             rule underlying the differentiation; also see details
         sample_seed (int): randomness seed to be used for the time samples in the stochastic
             parameter-shift rule
-        shots (None, int, list[int]): The shots of the device used to execute the tapes which are
-            returned by this transform. Note that this argument does not *influence* the shots
-            used for execution, but informs the transform about the shots to ensure a compatible
-            return value structure.
         use_broadcasting (bool): Whether to use broadcasting across the different sampled
             splitting times. If ``False`` (the default), one set of modified tapes per
             splitting time is created, if ``True`` only a single set of broadcasted, modified
@@ -618,9 +614,8 @@ def _stoch_pulse_grad(
             f"parameter-shift gradient, got {num_split_times}."
         )
 
-    shots = qml.measurements.Shots(shots)
     if argnum is None and not tape.trainable_params:
-        return _no_trainable_grad(tape, shots)
+        return _no_trainable_grad(tape)
 
     if use_broadcasting and tape.batch_size is not None:
         raise ValueError("Broadcasting is not supported for tapes that already are broadcasted.")
@@ -628,7 +623,7 @@ def _stoch_pulse_grad(
     diff_methods = gradient_analysis_and_validation(tape, "analytic", grad_fn=stoch_pulse_grad)
 
     if all(g == "0" for g in diff_methods):
-        return _all_zero_grad(tape, shots)
+        return _all_zero_grad(tape)
 
     method_map = choose_grad_methods(diff_methods, argnum)
 
@@ -637,7 +632,7 @@ def _stoch_pulse_grad(
     sampler_seed = sampler_seed or np.random.randint(18421)
     key = jax.random.PRNGKey(sampler_seed)
 
-    return _expval_stoch_pulse_grad(tape, argnum, num_split_times, key, shots, use_broadcasting)
+    return _expval_stoch_pulse_grad(tape, argnum, num_split_times, key, use_broadcasting)
 
 
 def _generate_tapes_and_cjacs(
@@ -784,7 +779,7 @@ def _tapes_data_hardware(tape, operation, key, num_split_times, use_broadcasting
 
 
 # pylint: disable=too-many-arguments
-def _expval_stoch_pulse_grad(tape, argnum, num_split_times, key, shots, use_broadcasting):
+def _expval_stoch_pulse_grad(tape, argnum, num_split_times, key, use_broadcasting):
     r"""Compute the gradient of a quantum circuit composed of pulse sequences that measures
     an expectation value or probabilities, by applying the stochastic parameter shift rule.
     See the main function for the signature.
@@ -822,8 +817,8 @@ def _expval_stoch_pulse_grad(tape, argnum, num_split_times, key, shots, use_broa
     num_measurements = len(tape.measurements)
     single_measure = num_measurements == 1
     num_params = len(tape.trainable_params)
-    has_partitioned_shots = shots.has_partitioned_shots
-    tape_specs = (single_measure, num_params, num_measurements, shots)
+    has_partitioned_shots = tape.shots.has_partitioned_shots
+    tape_specs = (single_measure, num_params, num_measurements, tape.shots)
 
     def processing_fn(results):
         start = 0

--- a/pennylane/gradients/spsa_gradient.py
+++ b/pennylane/gradients/spsa_gradient.py
@@ -228,7 +228,7 @@ def spsa_grad(
          (array(1.05046797), array(-1.05046797), array(1.05046797)))
 
         This gradient transform is compatible with devices that use shot vectors for execution.
-        
+
         >>> shots = (10, 100, 1000)
         >>> dev = qml.device("default.qubit", wires=2, shots=shots)
         >>> @qml.qnode(dev)

--- a/pennylane/gradients/spsa_gradient.py
+++ b/pennylane/gradients/spsa_gradient.py
@@ -227,6 +227,8 @@ def spsa_grad(
         ((array(-0.58222637), array(0.58222637), array(-0.58222637)),
          (array(1.05046797), array(-1.05046797), array(1.05046797)))
 
+        This gradient transform is compatible with devices that use shot vectors for execution.
+        
         >>> shots = (10, 100, 1000)
         >>> dev = qml.device("default.qubit", wires=2, shots=shots)
         >>> @qml.qnode(dev)

--- a/pennylane/gradients/spsa_gradient.py
+++ b/pennylane/gradients/spsa_gradient.py
@@ -68,7 +68,6 @@ def spsa_grad(
     strategy="center",
     f0=None,
     validate_params=True,
-    shots=None,
     num_directions=1,
     sampler=_rademacher_sampler,
     sampler_seed=None,
@@ -106,9 +105,6 @@ def spsa_grad(
             inferring that they support SPSA as well.
             If ``False``, the SPSA gradient method will be applied to all parameters without
             checking.
-        shots (None, int, list[int], list[~pennylane.measurements.ShotCopies]): The device shots that
-            will be used to execute the tapes outputted by this transform. Note that this argument doesn't
-            influence the shots used for tape execution, but provides information about the shots.
         num_directions (int): Number of sampled simultaneous perturbation vectors. An estimate for
             the gradient is computed for each vector using the underlying finite-difference
             method, and afterwards all estimates are averaged.
@@ -172,7 +168,7 @@ def spsa_grad(
     Note that the SPSA gradient is a statistical estimator that uses a given number of
     function evaluations that does not depend on the number of parameters. While this
     bounds the cost of the estimation, it also implies that the returned values are not
-    exact (even for devices with ``shots=None``) and that they will fluctuate.
+    exact (even with ``shots=None``) and that they will fluctuate.
     See the usage details below for more information.
 
     .. details::
@@ -231,10 +227,6 @@ def spsa_grad(
         ((array(-0.58222637), array(0.58222637), array(-0.58222637)),
          (array(1.05046797), array(-1.05046797), array(1.05046797)))
 
-
-        Devices that have a shot vector defined can also be used for execution, provided
-        the ``shots`` argument was passed to the transform:
-
         >>> shots = (10, 100, 1000)
         >>> dev = qml.device("default.qubit", wires=2, shots=shots)
         >>> @qml.qnode(dev)
@@ -244,7 +236,7 @@ def spsa_grad(
         ...     qml.RX(params[2], wires=0)
         ...     return qml.expval(qml.PauliZ(0)), qml.var(qml.PauliZ(0))
         >>> params = np.array([0.1, 0.2, 0.3], requires_grad=True)
-        >>> qml.gradients.spsa_grad(circuit, shots=shots, h=1e-2)(params)
+        >>> qml.gradients.spsa_grad(circuit, h=1e-2)(params)
         (((array(0.), array(0.), array(0.)), (array(0.), array(0.), array(0.))),
          ((array(-1.4), array(-1.4), array(-1.4)),
           (array(2.548), array(2.548), array(2.548))),
@@ -266,15 +258,13 @@ def spsa_grad(
             strategy=strategy,
             f0=f0,
             validate_params=validate_params,
-            shots=shots,
             num_directions=num_directions,
             sampler=sampler,
             sampler_seed=sampler_seed,
         )
 
-    shots = qml.measurements.Shots(shots)
     if argnum is None and not tape.trainable_params:
-        return _no_trainable_grad(tape, shots)
+        return _no_trainable_grad(tape)
 
     if validate_params:
         diff_methods = gradient_analysis_and_validation(tape, "numeric", grad_fn=spsa_grad)
@@ -282,7 +272,7 @@ def spsa_grad(
         diff_methods = ["F" for i in tape.trainable_params]
 
     if all(g == "0" for g in diff_methods):
-        return _all_zero_grad(tape, shots)
+        return _all_zero_grad(tape)
 
     gradient_tapes = []
     extract_r0 = False
@@ -360,7 +350,7 @@ def spsa_grad(
         return tuple(grads)
 
     processing_fn = partial(
-        _processing_fn, shots=shots, single_shot_batch_fn=_single_shot_batch_result
+        _processing_fn, shots=tape.shots, single_shot_batch_fn=_single_shot_batch_result
     )
 
     return gradient_tapes, processing_fn
@@ -377,7 +367,6 @@ def _spsa_grad_legacy(
     strategy="center",
     f0=None,
     validate_params=True,
-    shots=None,
     num_directions=1,
     sampler=_rademacher_sampler,
     sampler_seed=None,
@@ -415,9 +404,6 @@ def _spsa_grad_legacy(
             inferring that they support SPSA as well.
             If ``False``, the SPSA gradient method will be applied to all parameters without
             checking.
-        shots (None, int, list[int], list[~pennylane.measurements.ShotCopies]): The device shots that will
-            be used to execute the tapes outputted by this transform. Note that this argument doesn't
-            influence the shots used for tape execution, but provides information about the shots.
         num_directions (int): Number of sampled simultaneous perturbation vectors. An estimate for
             the gradient is computed for each vector using the underlying finite-difference
             method, and afterwards all estimates are averaged.
@@ -473,7 +459,7 @@ def _spsa_grad_legacy(
     Note that the SPSA gradient is a statistical estimator that uses a given number of
     function evaluations that does not depend on the number of parameters. While this
     bounds the cost of the estimation, it also implies that the returned values are not
-    exact (even for devices with ``shots=None``) and that they will fluctuate.
+    exact (even with ``shots=None``) and that they will fluctuate.
     See the usage details below for more information.
 
     .. details::

--- a/pennylane/gradients/vjp.py
+++ b/pennylane/gradients/vjp.py
@@ -378,7 +378,7 @@ def vjp(tape, dy, gradient_fn, gradient_kwargs=None):
     except (AttributeError, TypeError, NotImplementedError):
         pass
 
-    gradient_tapes, fn = gradient_fn(tape, shots=tape.shots, **gradient_kwargs)
+    gradient_tapes, fn = gradient_fn(tape, **gradient_kwargs)
 
     def processing_fn(results, num=None):
         # postprocess results to compute the Jacobian

--- a/pennylane/gradients/vjp.py
+++ b/pennylane/gradients/vjp.py
@@ -255,7 +255,7 @@ def compute_vjp(dy, jac, num=None):
     return qml.math.tensordot(jac, dy_row, [[0], [0]])
 
 
-def vjp(tape, dy, gradient_fn, shots=None, gradient_kwargs=None):
+def vjp(tape, dy, gradient_fn, gradient_kwargs=None):
     r"""Generate the gradient tapes and processing function required to compute
     the vector-Jacobian products of a tape.
 
@@ -358,8 +358,6 @@ def vjp(tape, dy, gradient_fn, shots=None, gradient_kwargs=None):
         # is simply none.
         return [], lambda _, num=None: None
 
-    shots = tape.shots if shots is None else qml.measurements.Shots(shots)
-
     try:
         if _all_close_to_zero(dy):
             # If the dy vector is zero, then the
@@ -380,7 +378,7 @@ def vjp(tape, dy, gradient_fn, shots=None, gradient_kwargs=None):
     except (AttributeError, TypeError, NotImplementedError):
         pass
 
-    gradient_tapes, fn = gradient_fn(tape, shots=shots, **gradient_kwargs)
+    gradient_tapes, fn = gradient_fn(tape, shots=tape.shots, **gradient_kwargs)
 
     def processing_fn(results, num=None):
         # postprocess results to compute the Jacobian
@@ -390,7 +388,7 @@ def vjp(tape, dy, gradient_fn, shots=None, gradient_kwargs=None):
             multi = len(tape.measurements) > 1
             comp_vjp_fn = compute_vjp_multi if multi else compute_vjp_single
 
-            if not shots.has_partitioned_shots:
+            if not tape.shots.has_partitioned_shots:
                 return comp_vjp_fn(dy, jac, num=num)
 
             vjp_ = [comp_vjp_fn(dy_, jac_, num=num) for dy_, jac_ in zip(dy, jac)]
@@ -402,7 +400,7 @@ def vjp(tape, dy, gradient_fn, shots=None, gradient_kwargs=None):
 
 
 # pylint: disable=too-many-arguments
-def batch_vjp(tapes, dys, gradient_fn, shots=None, reduction="append", gradient_kwargs=None):
+def batch_vjp(tapes, dys, gradient_fn, reduction="append", gradient_kwargs=None):
     r"""Generate the gradient tapes and processing function required to compute
     the vector-Jacobian products of a batch of tapes.
 
@@ -520,7 +518,7 @@ def batch_vjp(tapes, dys, gradient_fn, shots=None, reduction="append", gradient_
 
     # Loop through the tapes and dys vector
     for tape, dy in zip(tapes, dys):
-        g_tapes, fn = vjp(tape, dy, gradient_fn, shots=shots, gradient_kwargs=gradient_kwargs)
+        g_tapes, fn = vjp(tape, dy, gradient_fn, gradient_kwargs=gradient_kwargs)
         reshape_info.append(len(g_tapes))
         processing_fns.append(fn)
         gradient_tapes.extend(g_tapes)

--- a/pennylane/interfaces/jax.py
+++ b/pennylane/interfaces/jax.py
@@ -440,6 +440,7 @@ def _execute_bwd(
     # pylint: disable=unused-variable
     # Copy a given tape with operations and set parameters
 
+    # assumes all tapes have the same shot vector
     has_partitioned_shots = tapes[0].shots.has_partitioned_shots
 
     @jax.custom_jvp

--- a/pennylane/interfaces/jax.py
+++ b/pennylane/interfaces/jax.py
@@ -440,12 +440,7 @@ def _execute_bwd(
     # pylint: disable=unused-variable
     # Copy a given tape with operations and set parameters
 
-    if isinstance(device, qml.devices.experimental.Device):
-        # cant test until we integrate device with shot vector
-        has_partitioned_shots = tapes[0].shots.has_partitioned_shots
-        jvp_shots = None
-    else:
-        has_partitioned_shots = jvp_shots = device.shot_vector
+    has_partitioned_shots = tapes[0].shots.has_partitioned_shots
 
     @jax.custom_jvp
     def execute_wrapper(params):
@@ -463,7 +458,6 @@ def _execute_bwd(
                 new_tapes,
                 tangents[0],
                 gradient_fn,
-                jvp_shots,
             )
             _kwargs = {
                 "reduction": "append",

--- a/pennylane/interfaces/jax_jit_tuple.py
+++ b/pennylane/interfaces/jax_jit_tuple.py
@@ -182,13 +182,7 @@ def _grad_transform_jac_via_callback(
         new_tapes = set_parameters_on_copy_and_unwrap(tapes, inner_params)
         all_jacs = []
         for new_t in new_tapes:
-            jvp_tapes, res_processing_fn = gradient_fn(
-                new_t,
-                shots=new_t.shots
-                if isinstance(device, qml.devices.experimental.Device)
-                else device.shots,
-                **gradient_kwargs
-            )
+            jvp_tapes, res_processing_fn = gradient_fn(new_t, **gradient_kwargs)
             jacs = execute_fn(jvp_tapes)[0]
             jacs = res_processing_fn(jacs)
             all_jacs.append(jacs)
@@ -206,13 +200,7 @@ def _grad_transform_jac_no_callback(
     new_tapes = set_parameters_on_copy_and_unwrap(tapes, params, unwrap=False)
     jacobians = []
     for new_t in new_tapes:
-        jvp_tapes, res_processing_fn = gradient_fn(
-            new_t,
-            shots=new_t.shots
-            if isinstance(device, qml.devices.experimental.Device)
-            else device.shots,
-            **gradient_kwargs
-        )
+        jvp_tapes, res_processing_fn = gradient_fn(new_t, **gradient_kwargs)
         jacs = execute(
             jvp_tapes,
             device,

--- a/pennylane/interfaces/tensorflow.py
+++ b/pennylane/interfaces/tensorflow.py
@@ -332,6 +332,7 @@ def execute(tapes, device, execute_fn, gradient_fn, gradient_kwargs, _n=1, max_d
     parameters = []
     params_unwrapped = []
 
+    # assumes all tapes have the same shot vector
     has_partitioned_shots = tapes[0].shots.has_partitioned_shots
 
     for i, tape in enumerate(tapes):

--- a/pennylane/interfaces/tensorflow_autograph.py
+++ b/pennylane/interfaces/tensorflow_autograph.py
@@ -311,15 +311,9 @@ def execute(
     trainable = []
     output_types = []
 
-    if isinstance(device, qml.devices.experimental.Device):  # pragma: no-cover
-        # assumes all tapes have the same shot vector
-        has_partitioned_shots = tapes[0].shots.has_partitioned_shots
-        num_shot_copies = tapes[0].shots.num_copies or 1
-        vjp_shots = legacy_shots = None
-    else:
-        has_partitioned_shots = vjp_shots = device.shot_vector
-        legacy_shots = qml.measurements.Shots(device.shot_vector or 1)
-        num_shot_copies = legacy_shots.num_copies
+    # assumes all tapes have the same shot vector
+    has_partitioned_shots = tapes[0].shots.has_partitioned_shots
+    num_shot_copies = tapes[0].shots.num_copies or 1
 
     for tape in tapes:
         # store the trainable parameters
@@ -396,7 +390,7 @@ def execute(
         res = res[: total_measurements * num_shot_copies]
 
         # reconstruct the nested structure of res
-        res = _res_restructured(res, tapes, legacy_shots=legacy_shots)
+        res = _res_restructured(res, tapes)
 
         def grad_fn(*dy, **tfkwargs):
             """Returns the vector-Jacobian product with given
@@ -415,7 +409,7 @@ def execute(
                     jacs = args[total_measurements * num_shot_copies : -len(tapes)]
                     multi_measurements = args[-len(tapes) :]
 
-                    dy = _res_restructured(dy, tapes, legacy_shots=legacy_shots)
+                    dy = _res_restructured(dy, tapes)
                     jacs = _jac_restructured(jacs, tapes)
 
                     return _compute_vjp(dy, jacs, multi_measurements, has_partitioned_shots)
@@ -440,14 +434,13 @@ def execute(
                             all_params = all_params[:len_all_params]
                             params_unwrapped = _nest_params(all_params)
 
-                            dy = _res_restructured(dy, tapes, legacy_shots=legacy_shots)
+                            dy = _res_restructured(dy, tapes)
 
                             new_tapes = set_parameters_on_copy_and_unwrap(tapes, params_unwrapped)
                             vjp_tapes, processing_fn = qml.gradients.batch_vjp(
                                 new_tapes,
                                 dy,
                                 gradient_fn,
-                                shots=vjp_shots,
                                 reduction=lambda vjps, x: vjps.extend(qml.math.unstack(x)),
                                 gradient_kwargs=gradient_kwargs,
                             )
@@ -461,13 +454,12 @@ def execute(
                         )
 
                     else:
-                        dy = _res_restructured(dy, tapes, legacy_shots=legacy_shots)
+                        dy = _res_restructured(dy, tapes)
 
                         vjp_tapes, processing_fn = qml.gradients.batch_vjp(
                             tapes,
                             dy,
                             gradient_fn,
-                            shots=vjp_shots,
                             reduction="append",
                             gradient_kwargs=gradient_kwargs,
                         )

--- a/tests/gradients/core/test_gradient_transform.py
+++ b/tests/gradients/core/test_gradient_transform.py
@@ -209,7 +209,7 @@ class TestGradientTransformIntegration:
                 qml.RX(weights, wires=[0])
             return qml.expval(qml.PauliZ(0)), qml.var(qml.PauliX(1))
 
-        grad_fn = qml.gradients.param_shift(circuit, shots=shots)
+        grad_fn = qml.gradients.param_shift(circuit)
 
         w = np.array([0.543] if slicing else 0.543, requires_grad=True)
         res = grad_fn(w)
@@ -233,7 +233,7 @@ class TestGradientTransformIntegration:
             qml.CNOT(wires=[0, 1])
             return qml.expval(qml.PauliZ(0)), qml.var(qml.PauliX(1))
 
-        grad_fn = qml.gradients.param_shift(circuit, shots=shots)
+        grad_fn = qml.gradients.param_shift(circuit)
 
         w = np.array([0.543, -0.654], requires_grad=True)
         res = grad_fn(w)
@@ -260,7 +260,7 @@ class TestGradientTransformIntegration:
             qml.CNOT(wires=[0, 1])
             return qml.expval(qml.PauliZ(0)), qml.var(qml.PauliX(1))
 
-        grad_fn = qml.gradients.param_shift(circuit, shots=shots)
+        grad_fn = qml.gradients.param_shift(circuit)
 
         w = [np.array(0.543, requires_grad=True), np.array([-0.654], requires_grad=True)]
         res = grad_fn(*w)

--- a/tests/gradients/core/test_pulse_generator_gradient.py
+++ b/tests/gradients/core/test_pulse_generator_gradient.py
@@ -976,13 +976,13 @@ class TestPulseGeneratorTape:
         x = jnp.array([0.4, 0.2, 0.1])
         t = [0.2, 0.3]
         op = qml.evolve(H)([x], t=t)
-        tape = qml.tape.QuantumScript([op], [qml.expval(Z(0))])
+        tape = qml.tape.QuantumScript([op], [qml.expval(Z(0))], shots=shots)
 
         val = qml.execute([tape], dev)
         theta = integral_of_polyval(x, t)
         assert qml.math.allclose(val, jnp.cos(2 * theta), atol=tol)
 
-        _tapes, fn = pulse_generator(tape, shots=shots)
+        _tapes, fn = pulse_generator(tape)
         assert len(_tapes) == 2
 
         grad = fn(qml.execute(_tapes, dev))
@@ -1020,8 +1020,10 @@ class TestPulseGeneratorTape:
 
         circuit.construct(([x, y],), {})
         # TODO: remove once #2155 is resolved
-        circuit.tape.trainable_params = [0, 1]
-        _tapes, fn = pulse_generator(circuit.tape, argnum=[0, 1], shots=shots)
+        tape_with_shots = circuit.tape.copy()
+        tape_with_shots.trainable_params = [0, 1]
+        tape_with_shots._shots = qml.measurements.Shots(shots)  # pylint:disable=protected-access
+        _tapes, fn = pulse_generator(tape_with_shots, argnum=[0, 1])
         assert len(_tapes) == 6  # dim(DLA)=3, two shifts per basis element
 
         grad = fn(qml.execute(_tapes, dev_shots))
@@ -1101,8 +1103,10 @@ class TestPulseGeneratorTape:
 
         circuit.construct(([x, y, z],), {})
         # TODO: remove once #2155 is resolved
-        circuit.tape.trainable_params = [0, 1, 2]
-        _tapes, fn = pulse_generator(circuit.tape, argnum=[0, 1, 2], shots=shots)
+        tape_with_shots = circuit.tape.copy()
+        tape_with_shots.trainable_params = [0, 1, 2]
+        tape_with_shots._shots = qml.measurements.Shots(shots)  # pylint:disable=protected-access
+        _tapes, fn = pulse_generator(tape_with_shots, argnum=[0, 1, 2])
         assert len(_tapes) == 12  # two pulses, dim(DLA)=3, two shifts per basis element
 
         grad = fn(qml.execute(_tapes, dev_shots))

--- a/tests/gradients/finite_diff/test_spsa_gradient_shot_vec.py
+++ b/tests/gradients/finite_diff/test_spsa_gradient_shot_vec.py
@@ -59,7 +59,7 @@ class TestSpsaGradient:
             qml.CNOT(wires=[0, 1])
             qml.probs(wires=[0, 1])
 
-        tape = qml.tape.QuantumScript.from_queue(q)
+        tape = qml.tape.QuantumScript.from_queue(q, shots=default_shot_vector)
         # by default all parameters are assumed to be trainable
         with pytest.raises(
             ValueError, match=r"Cannot differentiate with respect to parameter\(s\) {0}"
@@ -69,7 +69,7 @@ class TestSpsaGradient:
         # setting trainable parameters avoids this
         tape.trainable_params = {1, 2}
         dev = qml.device("default.qubit", wires=2, shots=default_shot_vector)
-        tapes, fn = spsa_grad(tape, h=h_val, shots=default_shot_vector)
+        tapes, fn = spsa_grad(tape, h=h_val)
 
         all_res = fn(dev.batch_execute(tapes))
 
@@ -96,11 +96,9 @@ class TestSpsaGradient:
             qml.RY(-0.654, wires=[1])
             qml.expval(qml.PauliZ(0))
 
-        tape = qml.tape.QuantumScript.from_queue(q)
+        tape = qml.tape.QuantumScript.from_queue(q, shots=default_shot_vector)
         dev = qml.device("default.qubit", wires=2, shots=default_shot_vector)
-        tapes, fn = spsa_grad(
-            tape, h=h_val, shots=default_shot_vector, num_directions=num_directions
-        )
+        tapes, fn = spsa_grad(tape, h=h_val, num_directions=num_directions)
         all_res = fn(dev.batch_execute(tapes))
 
         assert isinstance(all_res, tuple)
@@ -132,11 +130,11 @@ class TestSpsaGradient:
             qml.RY(weights[1], wires=0)
             qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
-        tape = qml.tape.QuantumScript.from_queue(q)
+        tape = qml.tape.QuantumScript.from_queue(q, shots=default_shot_vector)
         # TODO: remove once #2155 is resolved
         tape.trainable_params = []
         with pytest.warns(UserWarning, match="gradient of a tape with no trainable parameters"):
-            g_tapes, post_processing = spsa_grad(tape, h=h_val, shots=default_shot_vector)
+            g_tapes, post_processing = spsa_grad(tape, h=h_val)
         all_res = post_processing(qml.execute(g_tapes, dev, None))
         assert len(all_res) == len(default_shot_vector)
 
@@ -157,10 +155,10 @@ class TestSpsaGradient:
             qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
             qml.probs(wires=[0, 1])
 
-        tape = qml.tape.QuantumScript.from_queue(q)
+        tape = qml.tape.QuantumScript.from_queue(q, shots=default_shot_vector)
         tape.trainable_params = []
         with pytest.warns(UserWarning, match="gradient of a tape with no trainable parameters"):
-            g_tapes, post_processing = spsa_grad(tape, h=h_val, shots=default_shot_vector)
+            g_tapes, post_processing = spsa_grad(tape, h=h_val)
         res = post_processing(qml.execute(g_tapes, dev, None))
 
         assert g_tapes == []
@@ -186,7 +184,7 @@ class TestSpsaGradient:
 
         weights = [0.1, 0.2]
         with pytest.warns(UserWarning, match="gradient of a QNode with no trainable parameters"):
-            res = spsa_grad(circuit, h=h_val, shots=default_shot_vector)(weights)
+            res = spsa_grad(circuit, h=h_val)(weights)
 
         assert res == ()
 
@@ -204,7 +202,7 @@ class TestSpsaGradient:
 
         weights = [0.1, 0.2]
         with pytest.warns(UserWarning, match="gradient of a QNode with no trainable parameters"):
-            res = spsa_grad(circuit, h=h_val, shots=default_shot_vector)(weights)
+            res = spsa_grad(circuit, h=h_val)(weights)
 
         assert res == ()
 
@@ -222,7 +220,7 @@ class TestSpsaGradient:
 
         weights = [0.1, 0.2]
         with pytest.warns(UserWarning, match="gradient of a QNode with no trainable parameters"):
-            res = spsa_grad(circuit, h=h_val, shots=default_shot_vector)(weights)
+            res = spsa_grad(circuit, h=h_val)(weights)
 
         assert res == ()
 
@@ -240,7 +238,7 @@ class TestSpsaGradient:
 
         weights = [0.1, 0.2]
         with pytest.warns(UserWarning, match="gradient of a QNode with no trainable parameters"):
-            res = spsa_grad(circuit, h=h_val, shots=default_shot_vector)(weights)
+            res = spsa_grad(circuit, h=h_val)(weights)
 
         assert res == ()
 
@@ -257,7 +255,7 @@ class TestSpsaGradient:
 
         params = np.array([0.5, 0.5, 0.5], requires_grad=True)
 
-        all_result = spsa_grad(circuit, h=h_val, shots=default_shot_vector)(params)
+        all_result = spsa_grad(circuit, h=h_val)(params)
         assert len(all_result) == len(default_shot_vector)
 
         for result in all_result:
@@ -277,7 +275,7 @@ class TestSpsaGradient:
             assert result[2].shape == (4,)
             assert np.allclose(result[2], 0)
 
-            tapes, _ = spsa_grad(circuit.tape, h=h_val, shots=default_shot_vector)
+            tapes, _ = spsa_grad(circuit.tape, h=h_val)
             assert tapes == []
 
     def test_all_zero_diff_methods_multiple_returns(self):
@@ -294,7 +292,7 @@ class TestSpsaGradient:
 
         params = np.array([0.5, 0.5, 0.5], requires_grad=True)
 
-        all_result = spsa_grad(circuit, h=h_val, shots=default_shot_vector)(params)
+        all_result = spsa_grad(circuit, h=h_val)(params)
         assert len(all_result) == len(default_shot_vector)
 
         for result in all_result:
@@ -332,7 +330,7 @@ class TestSpsaGradient:
             assert result[1][2].shape == (4,)
             assert np.allclose(result[1][2], 0)
 
-            tapes, _ = spsa_grad(circuit.tape, h=h_val, shots=default_shot_vector)
+            tapes, _ = spsa_grad(circuit.tape, h=h_val)
             assert tapes == []
 
     def test_y0(self):
@@ -344,14 +342,13 @@ class TestSpsaGradient:
             qml.RY(-0.654, wires=[0])
             qml.expval(qml.PauliZ(0))
 
-        tape = qml.tape.QuantumScript.from_queue(q)
+        tape = qml.tape.QuantumScript.from_queue(q, shots=default_shot_vector)
         n = 5
         tapes, _ = spsa_grad(
             tape,
             strategy="forward",
             approx_order=1,
             h=h_val,
-            shots=default_shot_vector,
             num_directions=n,
         )
 
@@ -367,7 +364,7 @@ class TestSpsaGradient:
             qml.RY(-0.654, wires=[0])
             qml.expval(qml.PauliZ(0))
 
-        tape = qml.tape.QuantumScript.from_queue(q)
+        tape = qml.tape.QuantumScript.from_queue(q, shots=default_shot_vector)
         f0 = dev.execute(tape)
         n = 3
         tapes, _ = spsa_grad(
@@ -376,7 +373,6 @@ class TestSpsaGradient:
             approx_order=1,
             f0=f0,
             h=h_val,
-            shots=default_shot_vector,
             num_directions=n,
         )
 
@@ -393,20 +389,19 @@ class TestSpsaGradient:
             qml.RX(1.0, wires=[1])
             qml.expval(qml.PauliZ(0))
 
-        tape1 = qml.tape.QuantumScript.from_queue(q1)
+        tape1 = qml.tape.QuantumScript.from_queue(q1, shots=many_shots_shot_vector)
         with qml.queuing.AnnotatedQueue() as q2:
             qml.RX(1.0, wires=[0])
             qml.RX(1.0, wires=[1])
             qml.expval(qml.PauliZ(1))
 
-        tape2 = qml.tape.QuantumScript.from_queue(q2)
+        tape2 = qml.tape.QuantumScript.from_queue(q2, shots=many_shots_shot_vector)
         n1 = 5
         tapes, fn = spsa_grad(
             tape1,
             approx_order=1,
             strategy="forward",
             num_directions=n1,
-            shots=many_shots_shot_vector,
             h=h_val,
         )
         j1 = fn(dev.batch_execute(tapes))
@@ -419,7 +414,6 @@ class TestSpsaGradient:
             approx_order=1,
             strategy="forward",
             h=h_val,
-            shots=default_shot_vector,
             num_directions=n2,
         )
         j2 = fn(dev.batch_execute(tapes))
@@ -470,9 +464,7 @@ class TestSpsaGradient:
         x = np.random.rand(3)
         circuits = [qml.QNode(cost, dev) for cost in (cost1, cost2, cost3, cost4, cost5, cost6)]
 
-        transform = [
-            qml.math.shape(spsa_grad(c, h=h_val, shots=default_shot_vector)(x)) for c in circuits
-        ]
+        transform = [qml.math.shape(spsa_grad(c, h=h_val)(x)) for c in circuits]
 
         expected = [(3,), (3,), (2, 3), (3, 4), (3, 4), (2, 3, 4)]
         expected = [(len(many_shots_shot_vector),) + e for e in expected]
@@ -577,13 +569,12 @@ class TestSpsaGradientIntegration:
             qml.probs(wires=0)
             qml.probs(wires=[1, 2])
 
-        tape = qml.tape.QuantumScript.from_queue(q)
+        tape = qml.tape.QuantumScript.from_queue(q, shots=many_shots_shot_vector)
         tapes, fn = spsa_grad(
             tape,
             approx_order=approx_order,
             strategy=strategy,
             validate_params=validate,
-            shots=many_shots_shot_vector,
             num_directions=3,
         )
         all_res = fn(dev.batch_execute(tapes))
@@ -619,7 +610,7 @@ class TestSpsaGradientIntegration:
             qml.CNOT(wires=[0, 1])
             qml.expval(qml.PauliZ(0) @ qml.PauliX(1))
 
-        tape = qml.tape.QuantumScript.from_queue(q)
+        tape = qml.tape.QuantumScript.from_queue(q, shots=many_shots_shot_vector)
         tapes, fn = spsa_grad(
             tape,
             approx_order=approx_order,
@@ -628,7 +619,6 @@ class TestSpsaGradientIntegration:
             h=h_val,
             num_directions=4,
             sampler=coordinate_sampler,
-            shots=default_shot_vector,
         )
         all_res = fn(dev.batch_execute(tapes))
 
@@ -666,7 +656,7 @@ class TestSpsaGradientIntegration:
             qml.CNOT(wires=[0, 1])
             qml.expval(qml.PauliZ(0) @ qml.PauliX(1))
 
-        tape = qml.tape.QuantumScript.from_queue(q)
+        tape = qml.tape.QuantumScript.from_queue(q, shots=many_shots_shot_vector)
         # we choose both trainable parameters
         tapes, fn = spsa_grad(
             tape,
@@ -677,7 +667,6 @@ class TestSpsaGradientIntegration:
             num_directions=4,
             sampler=coordinate_sampler,
             h=h_val,
-            shots=many_shots_shot_vector,
         )
         all_res = fn(dev.batch_execute(tapes))
 
@@ -719,7 +708,7 @@ class TestSpsaGradientIntegration:
             qml.CNOT(wires=[0, 1])
             qml.expval(qml.PauliZ(0) @ qml.PauliX(1))
 
-        tape = qml.tape.QuantumScript.from_queue(q)
+        tape = qml.tape.QuantumScript.from_queue(q, shots=many_shots_shot_vector)
         # we choose only 1 trainable parameter
         tapes, fn = spsa_grad(
             tape,
@@ -730,7 +719,6 @@ class TestSpsaGradientIntegration:
             num_directions=4,
             sampler=coordinate_sampler,
             h=h_val,
-            shots=many_shots_shot_vector,
         )
         all_res = fn(dev.batch_execute(tapes))
 
@@ -773,7 +761,7 @@ class TestSpsaGradientIntegration:
             qml.expval(qml.PauliZ(0) @ qml.PauliX(1))
             qml.probs(wires=[0, 1])
 
-        tape = qml.tape.QuantumScript.from_queue(q)
+        tape = qml.tape.QuantumScript.from_queue(q, shots=many_shots_shot_vector)
         # we choose only 1 trainable parameter
         tapes, fn = spsa_grad(
             tape,
@@ -784,7 +772,6 @@ class TestSpsaGradientIntegration:
             num_directions=4,
             sampler=coordinate_sampler,
             h=h_val,
-            shots=many_shots_shot_vector,
         )
         all_res = fn(dev.batch_execute(tapes))
 
@@ -815,7 +802,7 @@ class TestSpsaGradientIntegration:
             qml.expval(qml.PauliZ(0))
             qml.expval(qml.PauliX(1))
 
-        tape = qml.tape.QuantumScript.from_queue(q)
+        tape = qml.tape.QuantumScript.from_queue(q, shots=many_shots_shot_vector)
         tapes, fn = spsa_grad(
             tape,
             approx_order=approx_order,
@@ -824,7 +811,6 @@ class TestSpsaGradientIntegration:
             sampler=coordinate_sampler,
             h=h_val,
             num_directions=4,
-            shots=many_shots_shot_vector,
         )
         all_res = fn(dev.batch_execute(tapes))
 
@@ -869,7 +855,7 @@ class TestSpsaGradientIntegration:
             qml.expval(qml.PauliZ(0))
             qml.var(qml.PauliX(1))
 
-        tape = qml.tape.QuantumScript.from_queue(q)
+        tape = qml.tape.QuantumScript.from_queue(q, shots=many_shots_shot_vector)
         tapes, fn = spsa_grad(
             tape,
             approx_order=approx_order,
@@ -878,7 +864,6 @@ class TestSpsaGradientIntegration:
             h=h_val,
             num_directions=6,
             sampler=coordinate_sampler,
-            shots=many_shots_shot_vector,
         )
         all_res = fn(dev.batch_execute(tapes))
 
@@ -924,7 +909,7 @@ class TestSpsaGradientIntegration:
             qml.expval(qml.PauliZ(0))
             qml.probs(wires=[0, 1])
 
-        tape = qml.tape.QuantumScript.from_queue(q)
+        tape = qml.tape.QuantumScript.from_queue(q, shots=many_shots_shot_vector)
         tapes, fn = spsa_grad(
             tape,
             approx_order=approx_order,
@@ -933,7 +918,6 @@ class TestSpsaGradientIntegration:
             sampler=coordinate_sampler,
             num_directions=4,
             h=h_val,
-            shots=many_shots_shot_vector,
         )
         all_res = fn(dev.batch_execute(tapes))
 
@@ -1007,7 +991,7 @@ class TestSpsaGradientDifferentiation:
                 qml.CNOT(wires=[0, 1])
                 qml.expval(qml.PauliZ(0) @ qml.PauliX(1))
 
-            tape = qml.tape.QuantumScript.from_queue(q)
+            tape = qml.tape.QuantumScript.from_queue(q, shots=many_shots_shot_vector)
             tape.trainable_params = {0, 1}
             tapes, fn = spsa_grad(
                 tape,
@@ -1015,7 +999,6 @@ class TestSpsaGradientDifferentiation:
                 approx_order=approx_order,
                 strategy=strategy,
                 h=h_val,
-                shots=many_shots_shot_vector,
             )
             jac = np.array(fn(dev.batch_execute(tapes)))
             return jac
@@ -1052,7 +1035,7 @@ class TestSpsaGradientDifferentiation:
                 qml.expval(qml.PauliZ(0))
                 qml.probs(wires=[1])
 
-            tape = qml.tape.QuantumScript.from_queue(q)
+            tape = qml.tape.QuantumScript.from_queue(q, shots=many_shots_shot_vector)
             tape.trainable_params = {0, 1}
             tapes, fn = spsa_grad(
                 tape,
@@ -1060,7 +1043,6 @@ class TestSpsaGradientDifferentiation:
                 approx_order=approx_order,
                 strategy=strategy,
                 h=h_val,
-                shots=many_shots_shot_vector,
             )
             jac = fn(dev.batch_execute(tapes))
             return jac[1][0]
@@ -1093,7 +1075,7 @@ class TestSpsaGradientDifferentiation:
                 qml.CNOT(wires=[0, 1])
                 qml.expval(qml.PauliZ(0) @ qml.PauliX(1))
 
-            tape = qml.tape.QuantumScript.from_queue(q)
+            tape = qml.tape.QuantumScript.from_queue(q, shots=many_shots_shot_vector)
             tape.trainable_params = {0, 1}
             tapes, fn = spsa_grad(
                 tape,
@@ -1101,7 +1083,6 @@ class TestSpsaGradientDifferentiation:
                 approx_order=approx_order,
                 strategy=strategy,
                 h=h_val,
-                shots=many_shots_shot_vector,
             )
             jac_0, jac_1 = fn(dev.batch_execute(tapes))
 
@@ -1136,7 +1117,7 @@ class TestSpsaGradientDifferentiation:
                 qml.expval(qml.PauliZ(0))
                 qml.probs(wires=[1])
 
-            tape = qml.tape.QuantumScript.from_queue(q)
+            tape = qml.tape.QuantumScript.from_queue(q, shots=many_shots_shot_vector)
             tape.trainable_params = {0, 1}
             tapes, fn = spsa_grad(
                 tape,
@@ -1144,7 +1125,6 @@ class TestSpsaGradientDifferentiation:
                 approx_order=approx_order,
                 strategy=strategy,
                 h=h_val,
-                shots=many_shots_shot_vector,
             )
 
             jac_01 = fn(dev.batch_execute(tapes))[1][0]
@@ -1174,14 +1154,13 @@ class TestSpsaGradientDifferentiation:
                 qml.CNOT(wires=[0, 1])
                 qml.expval(qml.PauliZ(0) @ qml.PauliX(1))
 
-            tape = qml.tape.QuantumScript.from_queue(q)
+            tape = qml.tape.QuantumScript.from_queue(q, shots=many_shots_shot_vector)
             tapes, fn = spsa_grad(
                 tape,
                 n=1,
                 approx_order=approx_order,
                 strategy=strategy,
                 h=h_val,
-                shots=many_shots_shot_vector,
             )
             jac = fn(dev.batch_execute(tapes))
             return jac
@@ -1221,7 +1200,7 @@ class TestSpsaGradientDifferentiation:
                 qml.CNOT(wires=[0, 1])
                 qml.expval(qml.PauliZ(0) @ qml.PauliX(1))
 
-            tape = qml.tape.QuantumScript.from_queue(q)
+            tape = qml.tape.QuantumScript.from_queue(q, shots=many_shots_shot_vector)
             tape.trainable_params = {0, 1}
             tapes, fn = spsa_grad(
                 tape,
@@ -1229,7 +1208,6 @@ class TestSpsaGradientDifferentiation:
                 approx_order=approx_order,
                 strategy=strategy,
                 h=h_val,
-                shots=many_shots_shot_vector,
             )
             jac = fn(dev.batch_execute(tapes))
             return jac
@@ -1298,12 +1276,12 @@ class TestReturn:
             )  # Op acts either on wire 0 (non-zero grad) or wire 2 (zero grad)
             qml.apply(meas)  # Measurements act on wires 0 and 1
 
-        tape = qml.tape.QuantumScript.from_queue(q)
+        grad_transform_shots = Shots(shot_vec)
+        tape = qml.tape.QuantumScript.from_queue(q, shots=grad_transform_shots)
         # One trainable param
         tape.trainable_params = {0}
 
-        grad_transform_shots = Shots(shot_vec)
-        tapes, fn = spsa_grad(tape, shots=grad_transform_shots)
+        tapes, fn = spsa_grad(tape)
         all_res = fn(dev.batch_execute(tapes))
 
         assert len(all_res) == grad_transform_shots.num_copies
@@ -1332,12 +1310,12 @@ class TestReturn:
             qml.var(qml.Projector([1], wires=4))
             qml.var(qml.Hermitian(A, wires=5))
 
-        tape = qml.tape.QuantumScript.from_queue(q)
+        grad_transform_shots = Shots(shot_vec)
+        tape = qml.tape.QuantumScript.from_queue(q, shots=grad_transform_shots)
         # Multiple trainable params
         tape.trainable_params = {0}
 
-        grad_transform_shots = Shots(shot_vec)
-        tapes, fn = spsa_grad(tape, shots=grad_transform_shots)
+        tapes, fn = spsa_grad(tape)
         all_res = fn(dev.batch_execute(tapes))
 
         assert len(all_res) == grad_transform_shots.num_copies
@@ -1366,12 +1344,12 @@ class TestReturn:
             )  # Op acts either on wire 0 (non-zero grad) or wire 2 (zero grad)
             qml.apply(meas)  # Measurements act on wires 0 and 1
 
-        tape = qml.tape.QuantumScript.from_queue(q)
+        grad_transform_shots = Shots(shot_vec)
+        tape = qml.tape.QuantumScript.from_queue(q, shots=grad_transform_shots)
         # Multiple trainable params
         tape.trainable_params = {0, 1}
 
-        grad_transform_shots = Shots(shot_vec)
-        tapes, fn = spsa_grad(tape, shots=grad_transform_shots)
+        tapes, fn = spsa_grad(tape)
         all_res = fn(dev.batch_execute(tapes))
 
         assert len(all_res) == grad_transform_shots.num_copies
@@ -1405,12 +1383,12 @@ class TestReturn:
             qml.var(qml.Projector([1], wires=3))
             qml.var(qml.Hermitian(A, wires=4))
 
-        tape = qml.tape.QuantumScript.from_queue(q)
+        grad_transform_shots = Shots(shot_vec)
+        tape = qml.tape.QuantumScript.from_queue(q, shots=grad_transform_shots)
         # Multiple trainable params
         tape.trainable_params = {0, 1, 2, 3, 4}
 
-        grad_transform_shots = Shots(shot_vec)
-        tapes, fn = spsa_grad(tape, shots=grad_transform_shots)
+        tapes, fn = spsa_grad(tape)
         all_res = fn(dev.batch_execute(tapes))
 
         assert len(all_res) == grad_transform_shots.num_copies


### PR DESCRIPTION
**Context:**
By the time tapes reach the `gradients` module, they will have shots assigned directly onto them. This means the shots don't need to be passed around while the tapes themselves are being passed around.

**Description of the Change:**
Remove all extraneous references to shot values when they are already on tapes in gradient-related code

**Benefits:**
Less likely to make duplication errors, cleaner code, easier to work with

**Possible Drawbacks:**
Making (and reviewing) this change is ugly.