### PR TITLE
Allow old `batch_transform` decorator syntax in new transform API

### DIFF
--- a/pennylane/transforms/core/transform_dispatcher.py
+++ b/pennylane/transforms/core/transform_dispatcher.py
@@ -15,6 +15,8 @@
 This module contains the transform function, the transform dispatcher and the transform container.
 """
 import copy
+import warnings
+
 import pennylane as qml
 
 
@@ -72,6 +74,14 @@ class TransformDispatcher:
         # Assume Python decorator syntax:
         #
         # result = some_transform(*transform_args)(qnode)(*qnode_args)
+
+        warnings.warn(
+            "The decorator syntax transform_fn(*transform_args)(qnode) has been "
+            "deprecated and will be removed in a future version. Please use either "
+            "transform_fn(qnode, *transform_args) or "
+            "functools.partial(transform_fn, *transform_args)(qnode) instead.",
+            UserWarning,
+        )
 
         if obj is not None:
             targs = (obj, *targs)

--- a/pennylane/transforms/core/transform_dispatcher.py
+++ b/pennylane/transforms/core/transform_dispatcher.py
@@ -68,9 +68,18 @@ class TransformDispatcher:
         if callable(obj):
             return self._qfunc_transform(obj, targs, tkwargs)
 
-        raise TransformError(
-            "The object on which the transform is applied is not valid. It can only be a tape, a QNode or a qfunc."
-        )
+        # Input is not a QNode nor a quantum tape nor a device.
+        # Assume Python decorator syntax:
+        #
+        # result = some_transform(*transform_args)(qnode)(*qnode_args)
+
+        if obj is not None:
+            targs = (obj, *targs)
+
+        def wrapper(obj):
+            return self(obj, *targs, **tkwargs)
+
+        return wrapper
 
     @property
     def transform(self):

--- a/tests/transforms/test_experimental/test_transform_dispatcher.py
+++ b/tests/transforms/test_experimental/test_transform_dispatcher.py
@@ -199,21 +199,23 @@ class TestTransformDispatcher:
 
     @pytest.mark.parametrize("valid_transform", valid_transforms)
     def test_integration_dispatcher_with_valid_transform_decorator(self, valid_transform):
-        """Test that no error is raised with the transform function and that the transform dispatcher returns
+        """Test that a warning is raised with the transform function and that the transform dispatcher returns
         the right object."""
 
         dispatched_transform = transform(valid_transform)
         targs = [0]
 
-        @dispatched_transform(targs=targs)
-        @qml.qnode(device=dev)
-        def qnode_circuit(a):
-            """QNode circuit."""
-            qml.Hadamard(wires=0)
-            qml.CNOT(wires=[0, 1])
-            qml.PauliX(wires=0)
-            qml.RZ(a, wires=1)
-            return qml.expval(qml.PauliZ(wires=0))
+        with pytest.warns(UserWarning, match="The decorator syntax"):
+
+            @dispatched_transform(targs=targs)
+            @qml.qnode(device=dev)
+            def qnode_circuit(a):
+                """QNode circuit."""
+                qml.Hadamard(wires=0)
+                qml.CNOT(wires=[0, 1])
+                qml.PauliX(wires=0)
+                qml.RZ(a, wires=1)
+                return qml.expval(qml.PauliZ(wires=0))
 
         assert isinstance(qnode_circuit, qml.QNode)
         assert isinstance(qnode_circuit.transform_program, qml.transforms.core.TransformProgram)

--- a/tests/transforms/test_experimental/test_transform_dispatcher.py
+++ b/tests/transforms/test_experimental/test_transform_dispatcher.py
@@ -211,7 +211,7 @@ class TestTransformDispatcher:
 
         with pytest.warns(UserWarning, match="The decorator syntax"):
 
-            @dispatched_transform(targs=targs)
+            @dispatched_transform(targs)
             @qml.qnode(device=dev)
             def qnode_circuit(a):
                 """QNode circuit."""

--- a/tests/transforms/test_experimental/test_transform_dispatcher.py
+++ b/tests/transforms/test_experimental/test_transform_dispatcher.py
@@ -174,7 +174,7 @@ class TestTransformDispatcher:
         assert not dispatched_transform.is_informative
 
     @pytest.mark.parametrize("valid_transform", valid_transforms)
-    def test_integration_dispatcher_with_valid_transform_decorator(self, valid_transform):
+    def test_integration_dispatcher_with_valid_transform_decorator_partial(self, valid_transform):
         """Test that no error is raised with the transform function and that the transform dispatcher returns
         the right object."""
 
@@ -182,6 +182,30 @@ class TestTransformDispatcher:
         targs = [0]
 
         @partial(dispatched_transform, targs=targs)
+        @qml.qnode(device=dev)
+        def qnode_circuit(a):
+            """QNode circuit."""
+            qml.Hadamard(wires=0)
+            qml.CNOT(wires=[0, 1])
+            qml.PauliX(wires=0)
+            qml.RZ(a, wires=1)
+            return qml.expval(qml.PauliZ(wires=0))
+
+        assert isinstance(qnode_circuit, qml.QNode)
+        assert isinstance(qnode_circuit.transform_program, qml.transforms.core.TransformProgram)
+        assert isinstance(
+            qnode_circuit.transform_program.pop_front(), qml.transforms.core.TransformContainer
+        )
+
+    @pytest.mark.parametrize("valid_transform", valid_transforms)
+    def test_integration_dispatcher_with_valid_transform_decorator(self, valid_transform):
+        """Test that no error is raised with the transform function and that the transform dispatcher returns
+        the right object."""
+
+        dispatched_transform = transform(valid_transform)
+        targs = [0]
+
+        @dispatched_transform(targs=targs)
         @qml.qnode(device=dev)
         def qnode_circuit(a):
             """QNode circuit."""
@@ -338,17 +362,6 @@ class TestTransformDispatcher:
             NotImplementedError, match="Classical cotransforms are not yet integrated."
         ):
             transform(first_valid_transform, classical_cotransform=non_callable)
-
-    def test_apply_dispatched_transform_non_valid_obj(self):
-        """Test that applying a dispatched function on a non-valid object raises an error."""
-        dispatched_transform = transform(first_valid_transform)
-        obj = qml.RX(0.1, wires=0)
-        with pytest.raises(
-            TransformError,
-            match="The object on which the transform is applied is not valid. It can only be a tape, a QNode or a "
-            "qfunc.",
-        ):
-            dispatched_transform(obj)
 
     def test_qfunc_transform_multiple_tapes(self):
         """Test that quantum function is not compatible with multiple tapes."""


### PR DESCRIPTION
This change allows the user to continue to do:
```python
@qml.batch_input(argnum=0)
@qml.qnode(dev)
def circuit(inputs):
    ...
```
instead of forcing the user to switch to
```python
@partial(qml.batch_input, argnum=0)
@qml.qnode(dev)
def circuit(inputs):
    ...
```
which is a major breaking change. The latter is still possible, but this PR allows for the former to also be valid.