### PR TITLE
`qml.Projector` compatibility with new default qubit

### DIFF
--- a/pennylane/measurements/expval.py
+++ b/pennylane/measurements/expval.py
@@ -122,8 +122,8 @@ class ExpectationMP(SampleMeasurement, StateMeasurement):
         return qml.math.squeeze(qml.math.mean(samples, axis=axis))
 
     def process_state(self, state: Sequence[complex], wire_order: Wires):
-        if isinstance(self.obs, Projector):
-            # branch specifically to handle the projector observable
+        if isinstance(self.obs, Projector) and len(self.obs.parameters[0]) == len(self.obs.wires):
+            # branch specifically to handle the basis state projector observable
             idx = int("".join(str(i) for i in self.obs.parameters[0]), 2)
             probs = qml.probs(wires=self.wires).process_state(state=state, wire_order=wire_order)
             return probs[idx]

--- a/pennylane/measurements/var.py
+++ b/pennylane/measurements/var.py
@@ -125,8 +125,8 @@ class VarianceMP(SampleMeasurement, StateMeasurement):
         return qml.math.squeeze(qml.math.var(samples, axis=axis))
 
     def process_state(self, state: Sequence[complex], wire_order: Wires):
-        if isinstance(self.obs, Projector):
-            # branch specifically to handle the projector observable
+        if isinstance(self.obs, Projector) and len(self.obs.parameters[0]) == len(self.obs.wires):
+            # branch specifically to handle the basis state projector observable
             idx = int("".join(str(i) for i in self.obs.parameters[0]), 2)
             # we use ``self.wires`` instead of ``self.obs`` because the observable was
             # already applied to the state

--- a/pennylane/ops/qubit/observables.py
+++ b/pennylane/ops/qubit/observables.py
@@ -427,13 +427,25 @@ class Projector(Observable):
 
         return copied_op
 
+    def __reduce__(self):
+        """Defines how to pickle and unpickle a :class:`~.Projector`. Circumbents the pickling
+        issues caused by its dynamic type:
+        >>> qml.Projector([1], wires=[0]) is qml.Projector
+        False
+        >>> isinstance(qml.Projector([1], wires=[0]), qml.Projector)
+        True
+        For more information, see: https://docs.python.org/3/library/pickle.html#object.__reduce__
+        """
+        state = self.data[0]
+        return (Projector, (state, self.wires), {"_id": self.id})
+
 
 class _BasisStateProjector(Observable):
     # The call signature should be the same as Projector.__new__ for the positional
     # arguments, but with free key word arguments.
     def __init__(self, state, wires, id=None):
         wires = Wires(wires)
-        state = list(qml.math.toarray(state))
+        state = list(qml.math.toarray(state).astype(int))
 
         if not set(state).issubset({0, 1}):
             raise ValueError(f"Basis state must only consist of 0s and 1s; got {state}")

--- a/tests/devices/experimental/test_default_qubit_2.py
+++ b/tests/devices/experimental/test_default_qubit_2.py
@@ -1760,6 +1760,26 @@ class TestClassicalShadows:
             assert np.all(np.logical_or(np.logical_or(r[1] == 0, r[1] == 1), r[1] == 2))
 
 
+class TestDynamicType:
+    """Tests the compatibility with dynamic type classes such as `qml.Projector` or `qml.Pow`."""
+
+    @pytest.mark.parametrize("n_wires", [1, 2, 3])
+    @pytest.mark.parametrize("max_workers", [None, 1, 2])
+    def test_projector(self, max_workers, n_wires):
+        """Test that qml.Projector yields the expected results for both of its subclasses."""
+        wires = list(range(n_wires))
+        dev = DefaultQubit2(max_workers=max_workers)
+        ops = [qml.Hadamard(q) for q in wires]
+        basis_state = np.zeros((n_wires,))
+        state_vector = np.zeros((n_wires,))
+        state_vector[0] = 1
+
+        for state in [basis_state, state_vector]:
+            qs = qml.tape.QuantumScript(ops, [qml.expval(qml.Projector(state, wires))])
+            res = dev.execute(qs)
+            assert np.isclose(res, 1 / 2**n_wires)
+
+
 @pytest.mark.parametrize("max_workers", [None, 1, 2])
 def test_broadcasted_parameter(max_workers):
     """Test that DefaultQubit2 handles broadcasted parameters as expected."""

--- a/tests/ops/qubit/test_observables.py
+++ b/tests/ops/qubit/test_observables.py
@@ -14,6 +14,7 @@
 """Unit tests for qubit observables."""
 # pylint: disable=protected-access
 import functools
+import pickle
 import pytest
 import numpy as np
 
@@ -517,6 +518,23 @@ class TestProjector:
         with pytest.raises(ValueError, match="Input state must be one-dimensional"):
             state = np.random.randint(2, size=(2, 4))
             qml.Projector(state, range(4))
+
+    def test_serialization(self):
+        """Tests that Projector is pickle-able."""
+        # Basis state projector
+        proj = qml.Projector([1], wires=[0], id="Andy")
+        serialization = pickle.dumps(proj)
+        new_proj = pickle.loads(serialization)
+        assert qml.equal(new_proj, proj)
+        assert new_proj.id == proj.id  # Ensure they are identical
+
+        # State vector projector
+        proj = qml.Projector([0, 1], wires=[0])
+        serialization = pickle.dumps(proj)
+        new_proj = pickle.loads(serialization)
+
+        assert qml.equal(new_proj, proj)
+        assert new_proj.id == proj.id  # Ensure they are identical
 
 
 class TestBasisStateProjector:


### PR DESCRIPTION
With the last release, `qml.Projector` lost its pickle-ability with the new dynamic type. This has affected some users (e.g. #4443) and makes it incompatible with the new default qubit multiprocessing. Testing the observable with the new device, I found a couple of additional points that had to be fixed for it to be fully compatible.

I have written a `__reduce__` method for `qml.Projector` that allows it to be pickled. I have done so in a way that the object can be serialized and loaded keeping all its original attributes (including `id`). I have also changed the branching conditions for `qml.Projector` in `measurements/expval.py` and `measurements/var.py` as we had done originally for `_device.py`.

Fixes #4443 

[sc-43218]