### PR TITLE
Stop turning warning to error in `pytest.ini`

### DIFF
--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -20,4 +20,3 @@ filterwarnings =
     ignore:Casting complex values to real discards the imaginary part:UserWarning:torch.autograd
     ignore:Call to deprecated create function:DeprecationWarning
     ignore:the imp module is deprecated:DeprecationWarning
-    error:The behaviour of operator:UserWarning


### PR DESCRIPTION
**Description of the Change:**
* Remove change to `pytest.ini` that causes operator `__eq__` or `__hash__` related warnings to turn into errors.