### PR TITLE
Fix coefficient in `qml.pulse.transmon_interaction`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -171,7 +171,7 @@ array([False, False])
 * Updated `expand_fn()` for `DefaultQubit2` to decompose `StatePrep` operations present in the middle of a circuit.
   [(#4444)](https://github.com/PennyLaneAI/pennylane/pull/4444)
 
-* `transmon_drive` is updated in accordance with [1904.06560](https://arxiv.org/abs/1904.06560). In particular, the functional form has been changed from $\Omega(t)(\cos(\omega_d t + \phi) X - \sin(\omega_d t + \phi) Y)$ to $\Omega(t) \sin(\omega_d t + \phi) Y$. Also, qubit frequencies in `transmon_interaction` are now divided by 2 as is common as well.
+* `transmon_drive` is updated in accordance with [1904.06560](https://arxiv.org/abs/1904.06560). In particular, the functional form has been changed from $\Omega(t)(\cos(\omega_d t + \phi) X - \sin(\omega_d t + \phi) Y)$ to $\Omega(t) \sin(\omega_d t + \phi) Y$. Furthermore, qubit frequencies in `transmon_interaction` are now divided by 2 as is common as well.
   [(#4418)](https://github.com/PennyLaneAI/pennylane/pull/4418/)
   [(#4465)](https://github.com/PennyLaneAI/pennylane/pull/4465/)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -165,8 +165,9 @@ array([False, False])
 * Updated `expand_fn()` for `DefaultQubit2` to decompose `StatePrep` operations present in the middle of a circuit.
   [(#4444)](https://github.com/PennyLaneAI/pennylane/pull/4444)
 
-* `transmon_drive` is updated in accordance with [1904.06560](https://arxiv.org/abs/1904.06560). In particular, the functional form has been changed from $\Omega(t)(\cos(\omega_d t + \phi) X - \sin(\omega_d t + \phi) Y)$ to $\Omega(t) \sin(\omega_d t + \phi) Y$.
+* `transmon_drive` is updated in accordance with [1904.06560](https://arxiv.org/abs/1904.06560). In particular, the functional form has been changed from $\Omega(t)(\cos(\omega_d t + \phi) X - \sin(\omega_d t + \phi) Y)$ to $\Omega(t) \sin(\omega_d t + \phi) Y$. Also, qubit frequencies in `transmon_interaction` are now divided by 2 as is common as well.
   [(#4418)](https://github.com/PennyLaneAI/pennylane/pull/4418/)
+  [(#4465)](https://github.com/PennyLaneAI/pennylane/pull/4465/)
 
 <h3>Breaking changes 💔</h3>
 

--- a/pennylane/pulse/transmon.py
+++ b/pennylane/pulse/transmon.py
@@ -53,7 +53,7 @@ def transmon_interaction(
 
     .. math::
 
-        H = \sum_{q\in \text{wires}} \omega_q b^\dagger_q b_q
+        H = \sum_{q\in \text{wires}} \frac{\omega_q}{2} b^\dagger_q b_q
         + \sum_{(i, j) \in \mathcal{C}} g_{ij} \left(b^\dagger_i b_j + b_j^\dagger b_i \right)
         + \sum_{q\in \text{wires}} \alpha_q b^\dagger_q b^\dagger_q b_q b_q
 
@@ -179,7 +179,7 @@ def transmon_interaction(
 
     # qubit term
     coeffs = list(omega)
-    observables = [ad(i, d) @ a(i, d) for i in wires]
+    observables = [qml.s_prod(0.5, ad(i, d) @ a(i, d)) for i in wires]
 
     # coupling term
     coeffs += list(g)

--- a/tests/pulse/test_transmon.py
+++ b/tests/pulse/test_transmon.py
@@ -356,7 +356,7 @@ class TestTransmonInteraction:
         g = 2 * np.pi * coupling
         assert H.coeffs[:6] == [2 * np.pi] * 6
         assert all(H.coeffs[6:] == g)
-        for o1, o2 in zip(H.ops[:6], [ad(i, 2) @ a(i, 2) for i in wires]):
+        for o1, o2 in zip(H.ops[:6], [qml.s_prod(0.5, ad(i, 2) @ a(i, 2)) for i in wires]):
             assert qml.equal(o1, o2)
 
     def test_single_callable_qubit_freq_with_explicit_wires(self):
@@ -377,7 +377,7 @@ class TestTransmonInteraction:
         assert qml.math.allclose(H.coeffs[:10], g)
         for coeff in H.coeffs[10:]:
             assert coeff([3, 4, 5], 6) == omega([3, 4, 5], 6)
-        for o1, o2 in zip(H.ops[10:], [ad(i, 2) @ a(i, 2) for i in wires0]):
+        for o1, o2 in zip(H.ops[10:], [qml.s_prod(0.5, ad(i, 2) @ a(i, 2)) for i in wires0]):
             assert qml.equal(o1, o2)
 
     def test_d_neq_2_raises_error(self):


### PR DESCRIPTION
Changing $\omega \mapsto \omega/2$, this is important for resonance conditions in the drive, which otherwise leads to mismatches (and confusion).