### PR TITLE
add is_state_batched to StateMeasurement.process_state to fix tf.function with probs

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -331,6 +331,8 @@ array([False, False])
 * Subtracting a `Prod` from another operator now works as expected.
   [(#4441)](https://github.com/PennyLaneAI/pennylane/pull/4441)
 
+* `tf.function` no longer breaks `ProbabilityMP.process_state` which is needed by new devices.
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane/devices/qubit/measure.py
+++ b/pennylane/devices/qubit/measure.py
@@ -49,7 +49,9 @@ def state_diagonalizing_gates(
     flattened_state = (
         math.reshape(state, (state.shape[0], -1)) if is_state_batched else math.flatten(state)
     )
-    return measurementprocess.process_state(flattened_state, wires)
+    return measurementprocess.process_state(
+        flattened_state, wires, is_state_batched=is_state_batched
+    )
 
 
 def csr_dot_products(

--- a/pennylane/devices/qubit/sampling.py
+++ b/pennylane/devices/qubit/sampling.py
@@ -340,7 +340,9 @@ def sample_state(
     num_wires = len(wires_to_sample)
     basis_states = np.arange(2**num_wires)
 
-    probs = qml.probs(wires=wires_to_sample).process_state(state, state_wires)
+    probs = qml.probs(wires=wires_to_sample).process_state(
+        state, state_wires, is_state_batched=is_state_batched
+    )
 
     if is_state_batched:
         # rng.choice doesn't support broadcasting

--- a/pennylane/devices/tests/test_measurements.py
+++ b/pennylane/devices/tests/test_measurements.py
@@ -1680,7 +1680,7 @@ class TestStateMeasurement:
         class MyMeasurement(StateMeasurement):
             """Dummy state measurement."""
 
-            def process_state(self, state, wire_order):
+            def process_state(self, state, wire_order, is_state_batched=False):
                 return 1
 
         @qml.qnode(dev)
@@ -1701,7 +1701,7 @@ class TestStateMeasurement:
         class MyMeasurement(StateMeasurement):
             """Dummy state measurement."""
 
-            def process_state(self, state, wire_order):
+            def process_state(self, state, wire_order, is_state_batched=False):
                 return 1
 
         @qml.qnode(dev)

--- a/pennylane/measurements/expval.py
+++ b/pennylane/measurements/expval.py
@@ -121,15 +121,21 @@ class ExpectationMP(SampleMeasurement, StateMeasurement):
         # TODO: do we need to squeeze here? Maybe remove with new return types
         return qml.math.squeeze(qml.math.mean(samples, axis=axis))
 
-    def process_state(self, state: Sequence[complex], wire_order: Wires):
+    def process_state(
+        self, state: Sequence[complex], wire_order: Wires, is_state_batched: bool = False
+    ):
         if isinstance(self.obs, Projector):
             # branch specifically to handle the projector observable
             idx = int("".join(str(i) for i in self.obs.parameters[0]), 2)
-            probs = qml.probs(wires=self.wires).process_state(state=state, wire_order=wire_order)
+            probs = qml.probs(wires=self.wires).process_state(
+                state=state, wire_order=wire_order, is_state_batched=is_state_batched
+            )
             return probs[idx]
         eigvals = qml.math.asarray(self.obs.eigvals(), dtype="float64")
         # we use ``self.wires`` instead of ``self.obs`` because the observable was
         # already applied to the state
-        prob = qml.probs(wires=self.wires).process_state(state=state, wire_order=wire_order)
+        prob = qml.probs(wires=self.wires).process_state(
+            state=state, wire_order=wire_order, is_state_batched=is_state_batched
+        )
         # In case of broadcasting, `prob` has two axes and this is a matrix-vector product
         return qml.math.dot(prob, eigvals)

--- a/pennylane/measurements/measurements.py
+++ b/pennylane/measurements/measurements.py
@@ -570,16 +570,17 @@ class StateMeasurement(MeasurementProcess):
     * state (Sequence[complex]): quantum state
     * wire_order (Wires): wires determining the subspace that ``state`` acts on; a matrix of
         dimension :math:`2^n` acts on a subspace of :math:`n` wires
+    * is_state_batched (Optional[bool]): whether the state is batched or not
 
     **Example:**
 
     Let's create a measurement that returns the diagonal of the reduced density matrix.
 
     >>> class MyMeasurement(StateMeasurement):
-    ...     def process_state(self, state, wire_order):
+    ...     def process_state(self, state, wire_order, is_state_batched=False):
     ...         # use the already defined `qml.density_matrix` measurement to compute the
     ...         # reduced density matrix from the given state
-    ...         density_matrix = qml.density_matrix(wires=self.wires).process_state(state, wire_order)
+    ...         density_matrix = qml.density_matrix(wires=self.wires).process_state(state, wire_order, is_state_batched=is_state_batched)
     ...         return qml.math.diagonal(qml.math.real(density_matrix))
 
     We can now execute it in a QNode:
@@ -595,13 +596,16 @@ class StateMeasurement(MeasurementProcess):
     """
 
     @abstractmethod
-    def process_state(self, state: Sequence[complex], wire_order: Wires):
+    def process_state(
+        self, state: Sequence[complex], wire_order: Wires, is_state_batched: bool = False
+    ):
         """Process the given quantum state.
 
         Args:
             state (Sequence[complex]): quantum state
             wire_order (Wires): wires determining the subspace that ``state`` acts on; a matrix of
                 dimension :math:`2^n` acts on a subspace of :math:`n` wires
+            is_state_batched (Optional[bool]): whether the state is batched or not
         """
 
 

--- a/pennylane/measurements/mutual_info.py
+++ b/pennylane/measurements/mutual_info.py
@@ -145,7 +145,9 @@ class MutualInfoMP(StateMeasurement):
         num_shot_elements = sum(s.copies for s in shots.shot_vector)
         return tuple(() for _ in range(num_shot_elements))
 
-    def process_state(self, state: Sequence[complex], wire_order: Wires):
+    def process_state(
+        self, state: Sequence[complex], wire_order: Wires, is_state_batched: bool = False
+    ):
         state = qml.math.dm_from_state_vector(state)
         return qml.math.mutual_info(
             state,

--- a/pennylane/measurements/probs.py
+++ b/pennylane/measurements/probs.py
@@ -194,18 +194,13 @@ class ProbabilityMP(SampleMeasurement, StateMeasurement):
         prob = self._count_samples(indices, batch_size, dim)
         return qml.math.squeeze(prob) if bin_size is None else prob
 
-    def process_state(self, state: Sequence[complex], wire_order: Wires):
+    def process_state(
+        self, state: Sequence[complex], wire_order: Wires, is_state_batched: bool = False
+    ):
         num_wires = len(wire_order)
         dim = 2**num_wires
         # Compute batch_size
-        expected_shape = [2] * num_wires
-        expected_size = dim
-        size = qml.math.size(state)
-        batch_size = (
-            size // expected_size
-            if qml.math.ndim(state) > len(expected_shape) or size > expected_size
-            else None
-        )
+        batch_size = qml.math.size(state) // dim if is_state_batched else None
         flat_state = qml.math.reshape(
             state, (batch_size, dim) if batch_size is not None else (dim,)
         )

--- a/pennylane/measurements/purity.py
+++ b/pennylane/measurements/purity.py
@@ -98,7 +98,9 @@ class PurityMP(StateMeasurement):
         num_shot_elements = sum(s.copies for s in shots.shot_vector)
         return tuple(() for _ in range(num_shot_elements))
 
-    def process_state(self, state: Sequence[complex], wire_order: Wires):
+    def process_state(
+        self, state: Sequence[complex], wire_order: Wires, is_state_batched: bool = False
+    ):
         wire_map = dict(zip(wire_order, list(range(len(wire_order)))))
         indices = [wire_map[w] for w in self.wires]
         state = qml.math.dm_from_state_vector(state)

--- a/pennylane/measurements/state.py
+++ b/pennylane/measurements/state.py
@@ -183,7 +183,9 @@ class StateMP(StateMeasurement):
         return (dim,) if num_shot_elements == 1 else tuple((dim,) for _ in range(num_shot_elements))
 
     # pylint: disable=redefined-outer-name
-    def process_state(self, state: Sequence[complex], wire_order: Wires):
+    def process_state(
+        self, state: Sequence[complex], wire_order: Wires, is_state_batched: bool = False
+    ):
         if self.wires:
             # qml.density_matrix
             wire_map = dict(zip(wire_order, range(len(wire_order))))

--- a/pennylane/measurements/var.py
+++ b/pennylane/measurements/var.py
@@ -124,19 +124,25 @@ class VarianceMP(SampleMeasurement, StateMeasurement):
         # TODO: do we need to squeeze here? Maybe remove with new return types
         return qml.math.squeeze(qml.math.var(samples, axis=axis))
 
-    def process_state(self, state: Sequence[complex], wire_order: Wires):
+    def process_state(
+        self, state: Sequence[complex], wire_order: Wires, is_state_batched: bool = False
+    ):
         if isinstance(self.obs, Projector):
             # branch specifically to handle the projector observable
             idx = int("".join(str(i) for i in self.obs.parameters[0]), 2)
             # we use ``self.wires`` instead of ``self.obs`` because the observable was
             # already applied to the state
-            probs = qml.probs(wires=self.wires).process_state(state=state, wire_order=wire_order)
+            probs = qml.probs(wires=self.wires).process_state(
+                state=state, wire_order=wire_order, is_state_batched=is_state_batched
+            )
             return probs[idx] - probs[idx] ** 2
 
         eigvals = qml.math.asarray(self.obs.eigvals(), dtype=float)
 
         # we use ``wires`` instead of ``op`` because the observable was
         # already applied to the state
-        prob = qml.probs(wires=self.wires).process_state(state=state, wire_order=wire_order)
+        prob = qml.probs(wires=self.wires).process_state(
+            state=state, wire_order=wire_order, is_state_batched=is_state_batched
+        )
         # In case of broadcasting, `prob` has two axes and these are a matrix-vector products
         return qml.math.dot(prob, (eigvals**2)) - qml.math.dot(prob, eigvals) ** 2

--- a/pennylane/measurements/vn_entropy.py
+++ b/pennylane/measurements/vn_entropy.py
@@ -122,7 +122,9 @@ class VnEntropyMP(StateMeasurement):
         num_shot_elements = sum(s.copies for s in shots.shot_vector)
         return tuple(() for _ in range(num_shot_elements))
 
-    def process_state(self, state: Sequence[complex], wire_order: Wires):
+    def process_state(
+        self, state: Sequence[complex], wire_order: Wires, is_state_batched: bool = False
+    ):
         state = qml.math.dm_from_state_vector(state)
         return qml.math.vn_entropy(
             state, indices=self.wires, c_dtype=state.dtype, base=self.log_base

--- a/tests/measurements/test_probs.py
+++ b/tests/measurements/test_probs.py
@@ -280,6 +280,19 @@ class TestProbs:
 
         custom_measurement_process(dev, spy)
 
+    @pytest.mark.tf
+    def test_process_state_tf_autograph(self):
+        """Test that process_state passes when decorated with tf.function."""
+        import tensorflow as tf
+
+        @tf.function
+        def probs_from_state(state, wires):
+            return qml.probs(wires=wires).process_state(state, wires)
+
+        wires = qml.wires.Wires([0])
+        state = qml.devices.qubit.create_initial_state(wires)
+        assert np.allclose(probs_from_state(state, wires), [1, 0])
+
     @pytest.mark.parametrize("shots", [None, 100])
     def test_batch_size(self, mocker, shots):
         """Test the probability is correct for a batched input."""


### PR DESCRIPTION
This should probably (😉) not be merged in its current state (😉). I separated this bugfix out from the linked PR since it will need its own discussion.

**Context:**
While migrating default.qubit to the new device API (#4436), I found that `tf.function` breaks `qml.probs.process_state`. This is because sometimes the `batch_size` is None, and sometimes it's an int. Tensorflow jitting doesn't allow the type of this value to vary from call to call, so it fails.

**Description of the Change:**
- Add `is_state_batched` as a kwarg to all `StateMeasurement.process_state` implementations (mostly unused)
- Change `ProbabilityMP.process_state` to use this kwarg instead of computing it

**Benefits:**
Our code is more `tf.function`-friendly

**Possible Drawbacks:**
Most state measurements are not using `is_state_batched` so it's just making a mess. To make it work, we'd probably have to make changes to math/quantum for density-matrix stuff and it might be a whole to-do.