### PR TITLE
ctrl of PauliX does not return MultiControlledX

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -227,6 +227,8 @@ array([False, False])
   [(#4465)](https://github.com/PennyLaneAI/pennylane/pull/4465/)
   [(#4478)](https://github.com/PennyLaneAI/pennylane/pull/4478/)
 
+* `qml.ctrl(qml.PauliX)` returns a `Controlled` instead of a `MultiControlledX` like before.
+
 <h3>Breaking changes 💔</h3>
 
 * Gradient transforms no longer implicitly cast `float32` parameters to `float64`. Finite diff

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -228,6 +228,7 @@ array([False, False])
   [(#4478)](https://github.com/PennyLaneAI/pennylane/pull/4478/)
 
 * `qml.ctrl(qml.PauliX)` returns a `Controlled` instead of a `MultiControlledX` like before.
+  [(#4486)](https://github.com/PennyLaneAI/pennylane/pull/4486)
 
 <h3>Breaking changes 💔</h3>
 

--- a/pennylane/ops/op_math/controlled.py
+++ b/pennylane/ops/op_math/controlled.py
@@ -96,14 +96,6 @@ def ctrl(op, control, control_values=None, work_wires=None):
     if custom_key in custom_controlled_ops and (control_values is None or all(control_values)):
         qml.QueuingManager.remove(op)
         return custom_controlled_ops[custom_key](control + op.wires)
-    if isinstance(op, qml.PauliX):
-        qml.QueuingManager.remove(op)
-        control_string = (
-            None if control_values is None else "".join([str(int(v)) for v in control_values])
-        )
-        return qml.MultiControlledX(
-            wires=control + op.wires, control_values=control_string, work_wires=work_wires
-        )
     if isinstance(op, Operator):
         return Controlled(
             op, control_wires=control, control_values=control_values, work_wires=work_wires

--- a/tests/ops/op_math/test_controlled.py
+++ b/tests/ops/op_math/test_controlled.py
@@ -1685,12 +1685,12 @@ class TestCtrlCustomOperator:
             ([1, 2, 3], None, None),
         ],
     )
-    def test_ctrl_PauliX_MultiControlledX(self, control_wires, control_values, expected_values):
+    def test_ctrl_PauliX_multi(self, control_wires, control_values, expected_values):
         """Tests that ctrl(PauliX) with 3+ control wires or Falsy control values make a MCX"""
         with qml.queuing.AnnotatedQueue() as q:
             op = qml.ctrl(qml.PauliX(0), control_wires, control_values=control_values)
 
-        expected = qml.MultiControlledX(wires=control_wires + [0], control_values=expected_values)
+        expected = Controlled(qml.PauliX(0), control_wires, expected_values)
         assert len(q) == 1
         assert qml.equal(op, expected)
         assert qml.equal(q.queue[0], expected)


### PR DESCRIPTION
**Context:**
In the past, `qml.ctrl` of `PauliX` would return a Controlled (which would decompose to `MultiControlledX`), so I changed it to go directly to that instead. However, Catalyst depended on `Controlled` because it provides a custom decomposition for `Controlled`, but doesn't support `MultiControlledX` (and _its_ decomposition needs work wires which are likely not provided).

**Description of the Change:**
Restore `qml.ctrl` of `PauliX` to its old way such that it decomposes to `Controlled(PauliX)`. Note that in the case of 1 or 2 wires with all control values being 1, it still returns `CNOT` or `Toffoli`, respectively. Only the case of some 0-control-values or more than 2 control wires is being changed from `MultiControlledX` to `Controlled(PauliX)`

**Benefits:**
Catalyst is unblocked!

**Possible Drawbacks:**
Users have to call `decomposition` one more time if they really want to?