### PR TITLE
Remove requests from dev requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,5 +6,4 @@ pytest-xdist>=2.5.0
 flaky>=3.7.0
 pytest-forked>=1.4.0
 black>=21
-requests~=2.28.1
 tomli~=2.0.0 # Drop once minimum Python version is 3.11


### PR DESCRIPTION
**Context:**
`requirements-dev.txt` is supposed to be a list of additional packages that might be useful if contributing to pennylane. `requests` is used as part of the data module (to talk to the S3 database) and is already a requirement of PL itself, so it doesn't belong here. Plus, there's a dependabot security warning about an old `requests` version that we aren't even pinned to, but this makes it look like we might support it.

**Description of the Change:**
Remove `requests` from requirements-dev.txt

**Benefits:**
The requirements file only has what it should.

**Possible Drawbacks:**
N/A