### PR TITLE
[BUGFIX] Fix `math.get_dtype_name` for `ArrayBox`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -358,6 +358,7 @@ array([False, False])
 <h3>Bug fixes 🐛</h3>
 
 * `qml.math.get_dtype_name` now works with autograd array boxes.
+  [(#4494)](https://github.com/PennyLaneAI/pennylane/pull/4494)
 
 * `_copy_and_shift_params` does not cast or convert integral types, just relying on `+` and `*`'s casting rules in this case.
   [(#4477)](https://github.com/PennyLaneAI/pennylane/pull/4477)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -357,6 +357,8 @@ array([False, False])
 
 <h3>Bug fixes 🐛</h3>
 
+* `qml.math.get_dtype_name` now works with autograd array boxes.
+
 * `_copy_and_shift_params` does not cast or convert integral types, just relying on `+` and `*`'s casting rules in this case.
   [(#4477)](https://github.com/PennyLaneAI/pennylane/pull/4477)
 

--- a/pennylane/math/__init__.py
+++ b/pennylane/math/__init__.py
@@ -96,6 +96,12 @@ sum = ar.numpy.sum
 toarray = ar.numpy.to_numpy
 T = ar.numpy.transpose
 get_dtype_name = ar.get_dtype_name
+get_dtype_name.__doc__ = (
+    "An interface independent way of getting the name of the datatype.\n"
+    ">>> x = tf.Variable(0.1)\n"
+    ">>> qml.math.get_dtype_name(tf.Variable(0.1))\n"
+    "'float32'"
+)
 
 
 class NumpyMimic(ar.autoray.NumpyMimic):
@@ -142,6 +148,7 @@ __all__ = [
     "fidelity",
     "fidelity_statevector",
     "frobenius_inner_product",
+    "get_dtype_name",
     "get_interface",
     "get_trainable_indices",
     "in_backprop",

--- a/pennylane/math/__init__.py
+++ b/pennylane/math/__init__.py
@@ -95,13 +95,16 @@ from .utils import (
 sum = ar.numpy.sum
 toarray = ar.numpy.to_numpy
 T = ar.numpy.transpose
-get_dtype_name = ar.get_dtype_name
-get_dtype_name.__doc__ = (
-    "An interface independent way of getting the name of the datatype.\n"
-    ">>> x = tf.Variable(0.1)\n"
-    ">>> qml.math.get_dtype_name(tf.Variable(0.1))\n"
-    "'float32'"
-)
+
+
+def get_dtype_name(x) -> str:
+    """An interface independent way of getting the name of the datatype.
+
+    >>> x = tf.Variable(0.1)
+    >>> qml.math.get_dtype_name(tf.Variable(0.1))
+    'float32'
+    """
+    return ar.get_dtype_name(x)
 
 
 class NumpyMimic(ar.autoray.NumpyMimic):

--- a/pennylane/math/single_dispatch.py
+++ b/pennylane/math/single_dispatch.py
@@ -118,9 +118,8 @@ ar.register_function("autograd", "unstack", list)
 
 def autograd_get_dtype_name(x):
     """A autograd version of get_dtype_name that can handle array boxes."""
-    if hasattr(x, "_value"):
-        return ar.get_dtype_name(x._value)
-    return x.dtype.name
+    # this function seems to only get called with x is an arraybox.
+    return ar.get_dtype_name(x._value)
 
 
 ar.register_function("autograd", "get_dtype_name", autograd_get_dtype_name)

--- a/pennylane/math/single_dispatch.py
+++ b/pennylane/math/single_dispatch.py
@@ -116,6 +116,16 @@ ar.register_function("autograd", "gather", lambda x, indices: x[np.array(indices
 ar.register_function("autograd", "unstack", list)
 
 
+def autograd_get_dtype_name(x):
+    """A autograd version of get_dtype_name that can handle array boxes."""
+    if hasattr(x, "_value"):
+        return ar.get_dtype_name(x._value)
+    return x.dtype.name
+
+
+ar.register_function("autograd", "get_dtype_name", autograd_get_dtype_name)
+
+
 def _block_diag_autograd(tensors):
     """Autograd implementation of scipy.linalg.block_diag"""
     _np = _i("qml").numpy

--- a/tests/math/test_functions.py
+++ b/tests/math/test_functions.py
@@ -1335,7 +1335,7 @@ def test_shape(shape, interface, create_array):
         (onp.array(0.5), "float64"),
         (onp.array(1.0, dtype="float32"), "float32"),
         (ArrayBox(1, "a", "b"), "int64"),
-        (np.array(0.5, dtype="complex64"), "complex64")
+        (np.array(0.5, dtype="complex64"), "complex64"),
         # skip jax as output is dependent on global configuration
         (tf.Variable(0.1, dtype="float32"), "float32"),
         (tf.Variable(0.1, dtype="float64"), "float64"),

--- a/tests/math/test_functions.py
+++ b/tests/math/test_functions.py
@@ -1335,6 +1335,7 @@ def test_shape(shape, interface, create_array):
         (onp.array(0.5), "float64"),
         (onp.array(1.0, dtype="float32"), "float32"),
         (ArrayBox(1, "a", "b"), "int64"),
+        (np.array(0.5), "float64"),
         (np.array(0.5, dtype="complex64"), "complex64"),
         # skip jax as output is dependent on global configuration
         (tf.Variable(0.1, dtype="float32"), "float32"),

--- a/tests/math/test_functions.py
+++ b/tests/math/test_functions.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Unit tests for the TensorBox functional API in pennylane.fn.fn
+"""Unit tests for pennylane.math.single_dispatch
 """
 # pylint: disable=import-outside-toplevel
 import itertools
@@ -1325,6 +1325,28 @@ def test_shape(shape, interface, create_array):
 
     t = create_array(shape)
     assert fn.shape(t) == shape
+
+
+@pytest.mark.parametrize(
+    "x, expected",
+    (
+        (1.0, "float64"),
+        (1, "int64"),
+        (onp.array(0.5), "float64"),
+        (onp.array(1.0, dtype="float32"), "float32"),
+        (ArrayBox(1, "a", "b"), "int64"),
+        (np.array(0.5, dtype="complex64"), "complex64")
+        # skip jax as output is dependent on global configuration
+        (tf.Variable(0.1, dtype="float32"), "float32"),
+        (tf.Variable(0.1, dtype="float64"), "float64"),
+        (torch.tensor(0.1, dtype=torch.float32), "float32"),
+        (torch.tensor(0.5, dtype=torch.float64), "float64"),
+        (torch.tensor(0.1, dtype=torch.complex128), "complex128"),
+    ),
+)
+def test_get_dtype_name(x, expected):
+    """Test that get_dtype_name returns the a string for the datatype."""
+    assert fn.get_dtype_name(x) == expected
 
 
 @pytest.mark.parametrize("t", test_data)


### PR DESCRIPTION
Fixes #4492 [sc-43886]

The autoray version of `get_dtype_name` breaks with array boxes. This patch makes it so that `get_dtype_name` is called on the value of the array box.