### PR TITLE
Changed import_state to qml.qchem-level import

### DIFF
--- a/doc/code/qml_qchem.rst
+++ b/doc/code/qml_qchem.rst
@@ -13,7 +13,7 @@ number observables.
 .. automodapi:: pennylane.qchem
     :no-heading:
     :include-all-objects:
-    :skip: taper, symmetry_generators, paulix_ops, import_operator, import_state
+    :skip: taper, symmetry_generators, paulix_ops, import_operator
 
 Differentiable Hartree-Fock
 ---------------------------

--- a/doc/introduction/chemistry.rst
+++ b/doc/introduction/chemistry.rst
@@ -68,7 +68,7 @@ If the electronic Hamiltonian is built independently using
 to a PennyLane observable using the :func:`~.pennylane.import_operator` function. There is also 
 capability to import wavefunctions (states) that have been pre-computed by traditional quantum chemistry methods
 from `PySCF <https://github.com/sunqm/pyscf>`_, which could be used to for example to provide a better 
-starting point to a quantum algorithm. State import can be accomplished using the :func:`~pennylane.import_state` 
+starting point to a quantum algorithm. State import can be accomplished using the :func:`~pennylane.qchem.import_state` 
 utility function.
 
 
@@ -264,7 +264,7 @@ Utility functions
     ~pennylane.qchem.givens_decomposition
     ~pennylane.qchem.hf_state
     ~pennylane.import_operator
-    ~pennylane.import_state
+    ~pennylane.qchem.import_state
     ~pennylane.qchem.mol_data
     ~pennylane.qchem.read_structure
 

--- a/doc/releases/changelog-0.32.0.md
+++ b/doc/releases/changelog-0.32.0.md
@@ -365,14 +365,12 @@ array([False, False])
   some aspects of its use.
   [(#4391)](https://github.com/PennyLaneAI/pennylane/pull/4391)
 
-* `qml.import_state` is now accounted for in `doc/introduction/chemistry.rst`, adding the documentation for the function.
+* The `qml.qchem.import_state` function is now accounted for in `doc/introduction/chemistry.rst`, 
+  and input types and sources for external wavefunctions and operators for `qml.qchem.import_state` and 
+  `qml.import_operator` are specified.
   [(#4461)](https://github.com/PennyLaneAI/pennylane/pull/4461)
-
-* Input types and sources for external wavefunctions and operators for `qml.import_state` 
-  and `qml.import_operator` are clarified. [(#4476)](https://github.com/PennyLaneAI/pennylane/pull/4476)
-
-* Changed `qml.import_state` to no longer import at PennyLane level: it is now to be imported 
-  as `qml.qchem.import_state`. [(#4505)](https://github.com/PennyLaneAI/pennylane/pull/4505)
+  [(#4476)](https://github.com/PennyLaneAI/pennylane/pull/4476)
+  [(#4505)](https://github.com/PennyLaneAI/pennylane/pull/4505)
 
 <h3>Bug fixes 🐛</h3>
 

--- a/doc/releases/changelog-0.32.0.md
+++ b/doc/releases/changelog-0.32.0.md
@@ -371,6 +371,9 @@ array([False, False])
 * Input types and sources for external wavefunctions and operators for `qml.import_state` 
   and `qml.import_operator` are clarified. [(#4476)](https://github.com/PennyLaneAI/pennylane/pull/4476)
 
+* Changed `qml.import_state` to no longer import at PennyLane level: it is now to be imported 
+  as `qml.qchem.import_state`. [(#4505)](https://github.com/PennyLaneAI/pennylane/pull/4505)
+
 <h3>Bug fixes 🐛</h3>
 
 * `qml.math.get_dtype_name` now works with autograd array boxes.

--- a/pennylane/__init__.py
+++ b/pennylane/__init__.py
@@ -44,7 +44,6 @@ from pennylane.qchem import (
     paulix_ops,
     taper_operation,
     import_operator,
-    import_state,
 )
 from pennylane._device import Device, DeviceError
 from pennylane._grad import grad, jacobian


### PR DESCRIPTION
**Context:**

Docs change to switch import of `import_state` to `qml.qchem` level. 

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
