### PR TITLE
Minor documentation changes

### DIFF
--- a/pennylane/devices/experimental/default_qubit_2.py
+++ b/pennylane/devices/experimental/default_qubit_2.py
@@ -49,12 +49,12 @@ class DefaultQubit2(Device):
     Args:
         shots (int, Sequence[int], Sequence[Union[int, Sequence[int]]]): The default number of shots to use in executions involving
             this device.
-        seed="global" (Union[str, None, int, array_like[int], SeedSequence, BitGenerator, Generator]): A
+        seed (Union[str, None, int, array_like[int], SeedSequence, BitGenerator, Generator]): A
             seed-like parameter matching that of ``seed`` for ``numpy.random.default_rng`` or
             a request to seed from numpy's global random number generator.
             The default, ``seed="global"`` pulls a seed from NumPy's global generator. ``seed=None``
             will pull a seed from the OS entropy.
-        max_workers=None (int): A ``ProcessPoolExecutor`` executes tapes asynchronously
+        max_workers (int): A ``ProcessPoolExecutor`` executes tapes asynchronously
             using a pool of at most ``max_workers`` processes. If ``max_workers`` is ``None``,
             only the current process executes tapes. If you experience any
             issue, say using JAX, TensorFlow, Torch, try setting ``max_workers`` to ``None``.

--- a/pennylane/logging/configuration.py
+++ b/pennylane/logging/configuration.py
@@ -78,6 +78,7 @@ def enable_logging():
     Enabling logging through this method will override any externally defined logging configurations.
 
     **Example**
+
     >>> qml.logging.enable_logging()
     """
     _add_trace_level()

--- a/pennylane/pulse/transmon.py
+++ b/pennylane/pulse/transmon.py
@@ -281,7 +281,7 @@ def transmon_drive(amplitude, phase, freq, wires, d=2):
 
     .. note:: Currently only supports ``d=2`` with qudit support planned in the future.
         For ``d>2``, we have :math:`Y \mapsto i (\sigma^- - \sigma^+)`
-        with lowering and raising operators  :math:`\sigma_^{\mp}`.
+        with lowering and raising operators  :math:`\sigma^{\mp}`.
 
     .. note:: Due to convention in the respective fields, we omit the factor :math:`\frac{1}{2}` present in the related constructor :func:`~.rydberg_drive`
 
@@ -313,8 +313,12 @@ def transmon_drive(amplitude, phase, freq, wires, d=2):
 
     .. code-block:: python3
 
-        def amp(A, t): return A * jnp.exp(-t**2)
-        def phase(phi0, t): return phi0
+        def amp(A, t):
+            return A * jnp.exp(-t**2)
+
+        def phase(phi0, t):
+            return phi0
+
         freq = 0
 
         H = qml.pulse.transmon_drive(amp, phase, freq, 0)

--- a/pennylane/tape/tape.py
+++ b/pennylane/tape/tape.py
@@ -239,7 +239,7 @@ def expand_tape_state_prep(tape, skip_first=True):
 
     Args:
         tape (QuantumScript): The tape to expand.
-        skip_first (Bool): If ``True``, will not expand a ``StatePrepBase`` operation if
+        skip_first (bool): If ``True``, will not expand a ``StatePrepBase`` operation if
             it is the first operation in the tape.
 
     Returns:

--- a/pennylane/tape/tape.py
+++ b/pennylane/tape/tape.py
@@ -239,14 +239,26 @@ def expand_tape_state_prep(tape, skip_first=True):
 
     Args:
         tape (QuantumScript): The tape to expand.
-        skip_first (Bool): If ``True``, will not expand a StatePrepBase operation if
+        skip_first (Bool): If ``True``, will not expand a ``StatePrepBase`` operation if
             it is the first operation in the tape.
 
     Returns:
         QuantumTape: The expanded version of ``tape``.
 
     **Example**
-    ...
+
+    If a ``StatePrepBase`` occurs as the first operation of a tape, the operation will not be expanded:
+
+    >>> ops = [qml.StatePrep([0, 1], wires=0), qml.PauliZ(1), qml.StatePrep([1, 0], wires=0)]
+    >>> tape = qml.tape.QuantumScript(ops, [])
+    >>> new_tape = qml.tape.tape.expand_tape_state_prep(tape)
+    >>> new_tape.operations
+    [StatePrep(array([0, 1]), wires=[0]), PauliZ(wires=[1]), MottonenStatePreparation(array([1, 0]), wires=[0])]
+
+    To force expansion, the keyword argument ``skip_first`` can be set to ``False``:
+
+    >>> new_tape = qml.tape.tape.expand_tape_state_prep(tape, skip_first=False)
+    [MottonenStatePreparation(array([0, 1]), wires=[0]), PauliZ(wires=[1]), MottonenStatePreparation(array([1, 0]), wires=[0])]
     """
     first_op = tape.operations[0]
     new_ops = (


### PR DESCRIPTION
- Remove default values for kwargs in docstring for `qml.device.DefaultQubit2`. This makes the code more in line with Google-style docstrings
- Fix rendering of example for `qml.logging.enable_logging`
- Fix rendering of math for `qml.pulse.transmon_drive`. Also add newlines after function definition in the example since the previous is incorrect syntax
- Add an example to `qml.tape.tape.expand_tape_state_prep`