### PR TITLE
bugfixes to unblock teleportation tutorial

### DIFF
--- a/pennylane/drawer/style.py
+++ b/pennylane/drawer/style.py
@@ -148,7 +148,7 @@ def _pennylane():
     plt.rcParams["patch.force_edgecolor"] = True
     plt.rcParams["lines.color"] = "black"
     plt.rcParams["text.color"] = "black"
-    if "Quicksand" in fm.get_font_names():  # pragma: no cover
+    if "Quicksand" in {font.name for font in fm.FontManager().ttflist}:  # pragma: no cover
         plt.rcParams["font.family"] = "Quicksand"
     plt.rcParams["font.weight"] = "bold"
     plt.rcParams["path.sketch"] = (1, 250, 1)

--- a/pennylane/transforms/defer_measurements.py
+++ b/pennylane/transforms/defer_measurements.py
@@ -144,7 +144,7 @@ def defer_measurements(tape: QuantumTape):
     # Apply controlled operations to store measurement outcomes and replace
     # classically controlled operations
     control_wires = {}
-    cur_wire = max(tape.wires) + 1
+    cur_wire = max(tape.wires) + 1 if reused_measurement_wires else None
 
     for op in tape:
         if isinstance(op, MidMeasureMP):

--- a/tests/transforms/test_defer_measurements.py
+++ b/tests/transforms/test_defer_measurements.py
@@ -1160,3 +1160,32 @@ class TestDrawing:
             "3: ─╰X─╰●─╰●──────────────────┤     "
         )
         assert qml.draw(transformed_qnode)() == expected
+
+
+def test_custom_wire_labels_allowed_without_reset():
+    """Test that custom wire labels work if no qubits are re-used."""
+    with qml.queuing.AnnotatedQueue() as q:
+        qml.Hadamard("a")
+        ma = qml.measure("a", reset=False)
+        qml.cond(ma, qml.PauliX)("b")
+        qml.state()
+
+    tape = qml.tape.QuantumScript.from_queue(q)
+    tape = qml.defer_measurements(tape)
+    assert len(tape) == 3
+    assert qml.equal(tape[0], qml.Hadamard("a"))
+    assert qml.equal(tape[1], qml.CNOT(["a", "b"]))
+    assert qml.equal(tape[2], qml.state())
+
+
+def test_custom_wire_labels_fails_with_reset():
+    """Test that custom wire labels do not work if any qubits are re-used."""
+    with qml.queuing.AnnotatedQueue() as q:
+        qml.Hadamard("a")
+        ma = qml.measure("a", reset=True)
+        qml.cond(ma, qml.PauliX)("b")
+        qml.state()
+
+    tape = qml.tape.QuantumScript.from_queue(q)
+    with pytest.raises(TypeError, match="can only concatenate str"):
+        qml.defer_measurements(tape)


### PR DESCRIPTION
**Context:**
The teleportation tutorial I wrote has "mid-circuit" measurements with custom labels, and I'd also like it to use the new `pennylane` MPL style, but they both aren't very compatible.

**Description of the Change:**
- Set `cur_wire` to `None` in `defer_measurements` if there are no wires being reused to allow for custom wire labels in the case when wires don't _need_ to be reused
- Change the way we check for a font in `qml.drawer.style` because the current way requires MPL >= 3.6, but `qml` is built with MPL 3.5

**Benefits:**
The tutorial will work without any changes (except me setting the style to pennylane for all to see!)

**Possible Drawbacks:**
N/A

PennyLaneAI/qml#812