### PR TITLE
More 0.32 related fixes

### DIFF
--- a/doc/code/qml_measurements.rst
+++ b/doc/code/qml_measurements.rst
@@ -15,4 +15,4 @@ qml.measurements
     :no-heading:
     :include-all-objects:
     :inheritance-diagram:
-    :skip: MeasurementShapeError, MeasurementValueError, ObservableReturnTypes
+    :skip: MeasurementShapeError, ObservableReturnTypes

--- a/pennylane/measurements/__init__.py
+++ b/pennylane/measurements/__init__.py
@@ -213,7 +213,7 @@ from .measurements import (
     Variance,
     VnEntropy,
 )
-from .mid_measure import MeasurementValue, MeasurementValueError, MidMeasureMP, measure
+from .mid_measure import MeasurementValue, MidMeasureMP, measure
 from .mutual_info import MutualInfoMP, mutual_info
 from .purity import PurityMP, purity
 from .probs import ProbabilityMP, probs

--- a/pennylane/measurements/mid_measure.py
+++ b/pennylane/measurements/mid_measure.py
@@ -155,10 +155,6 @@ class MidMeasureMP(MeasurementProcess):
         return hash(fingerprint)
 
 
-class MeasurementValueError(ValueError):
-    """Error raised when an unknown measurement value is being used."""
-
-
 class MeasurementValue(Generic[T]):
     """A class representing unknown measurement outcomes in the qubit model.
 

--- a/pennylane/optimize/adaptive.py
+++ b/pennylane/optimize/adaptive.py
@@ -195,7 +195,10 @@ class AdaptiveOptimizer:
                 if (gate.name == operation.name and gate.wires == operation.wires)
             ]
             for gate in repeated_gates:
-                operator_pool.remove(gate)
+                for i, op in enumerate(operator_pool):
+                    if op is gate:
+                        operator_pool.pop(i)
+                        break
 
         params = np.array([gate.parameters[0] for gate in operator_pool], requires_grad=True)
         qnode.func = self._circuit

--- a/pennylane/optimize/adaptive.py
+++ b/pennylane/optimize/adaptive.py
@@ -188,17 +188,14 @@ class AdaptiveOptimizer:
         qnode = copy.copy(circuit)
 
         if drain_pool:
-            repeated_gates = [
+            operator_pool = [
                 gate
                 for gate in operator_pool
-                for operation in circuit.tape.operations
-                if (gate.name == operation.name and gate.wires == operation.wires)
+                if all(
+                    gate.name != operation.name or gate.wires != operation.wires
+                    for operation in circuit.tape.operations
+                )
             ]
-            for gate in repeated_gates:
-                for i, op in enumerate(operator_pool):
-                    if op is gate:
-                        operator_pool.pop(i)
-                        break
 
         params = np.array([gate.parameters[0] for gate in operator_pool], requires_grad=True)
         qnode.func = self._circuit


### PR DESCRIPTION
* `list_of_ops.remove(op)` causes operator hash warning to be raised. This PR fixes it in the `AdaptiveOptimizer`.
* Removed `MeasurementValueError`.
