### PR TITLE
Update PySCF link in chemistry doc

### DIFF
--- a/doc/introduction/chemistry.rst
+++ b/doc/introduction/chemistry.rst
@@ -38,7 +38,7 @@ where:
 The :func:`~.molecular_hamiltonian` function can also be used to construct the molecular Hamiltonian
 with an external backend that uses the
 `OpenFermion-PySCF <https://github.com/quantumlib/OpenFermion-PySCF>`_ plugin interfaced with the
-electronic structure package `PySCF <https://github.com/sunqm/pyscf>`_, which requires separate
+electronic structure package `PySCF <https://github.com/pyscf/pyscf>`_, which requires separate
 installation. This backend is non-differentiable and can be selected by setting
 ``method='pyscf'`` in :func:`~.molecular_hamiltonian`. 
 
@@ -67,7 +67,7 @@ If the electronic Hamiltonian is built independently using
 `OpenFermion <https://github.com/quantumlib/OpenFermion>`_ tools, it can be readily converted 
 to a PennyLane observable using the :func:`~.pennylane.import_operator` function. There is also 
 capability to import wavefunctions (states) that have been pre-computed by traditional quantum chemistry methods
-from `PySCF <https://github.com/sunqm/pyscf>`_, which could be used to for example to provide a better 
+from `PySCF <https://github.com/pyscf/pyscf>`_, which could be used to for example to provide a better
 starting point to a quantum algorithm. State import can be accomplished using the :func:`~pennylane.qchem.import_state` 
 utility function.
 


### PR DESCRIPTION
**Context:**
Update PySCF link in `chemistry.rst`.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
