### PR TITLE
ignore hash/eq warnings until they are removed

### DIFF
--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -19,5 +19,5 @@ filterwarnings =
     ignore:Casting complex values to real discards the imaginary part:UserWarning:torch.autograd
     ignore:Call to deprecated create function:DeprecationWarning
     ignore:the imp module is deprecated:DeprecationWarning
-    error:The behaviour of operator:UserWarning
-    error:The behaviour of measurement process:UserWarning
+    ignore:The behaviour of operator:UserWarning
+    ignore:The behaviour of measurement process:UserWarning


### PR DESCRIPTION
**Context:**
Docker builds won't pass because of these warnings (look at any recent commit to master), and codecov [needs a commit to pass CI on master](https://docs.codecov.com/docs/comparing-commits#choosing-a-parent-commit) for it to compare against. Hopefully this does it.

**Description of the Change:**
Ignore warnings about op/mp hash/eq in tests

**Benefits:**
CI will (maybe) pass when this commit is merged to master

**Possible Drawbacks:**
Assuming #4536 is merged to master before the 0.33 release, none