### PR TITLE
Remove ratio_imprivitive kwarg in favour of ratio_imprim

### DIFF
--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -6,12 +6,6 @@ Deprecations
 Pending deprecations
 --------------------
 
-* The `RandomLayers.compute_decomposition` keyword argument `ratio_imprivitive` will be changed to `ratio_imprim` to
-  match the call signature of the operation. 
-
-  - Deprecated in v0.32
-  - Removed in v0.33
-
 * The ``observables`` argument in ``QubitDevice.statistics`` is deprecated. Please use ``circuit``
   instead. Using a list of observables in ``QubitDevice.statistics`` is deprecated. Please use a
   ``QuantumTape`` instead.
@@ -112,6 +106,12 @@ Pending deprecations
 
 Completed deprecation cycles
 ----------------------------
+
+* The ``RandomLayers.compute_decomposition`` keyword argument ``ratio_imprivitive`` has been changed to
+  ``ratio_imprim`` to match the call signature of the operation.
+
+  - Deprecated in v0.32
+  - Removed in v0.33
 
 * The CV observables ``qml.X`` and ``qml.P`` have been removed. Use ``qml.QuadX`` and ``qml.QuadP`` instead.
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -21,6 +21,10 @@
   Instead of ``tape.unwrap()``, use :func:`~.transforms.convert_to_numpy_parameters`.
   [#4535](https://github.com/PennyLaneAI/pennylane/pull/4535)
 
+* The ``RandomLayers.compute_decomposition`` keyword argument ``ratio_imprivitive`` has been changed to
+  ``ratio_imprim`` to match the call signature of the operation.
+  [#4552](https://github.com/PennyLaneAI/pennylane/pull/4552)
+
   
 <h3>Deprecations 👋</h3>
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -9,21 +9,21 @@
 <h3>Breaking changes 💔</h3>
 
 * The old return type and associated functions ``qml.enable_return`` and ``qml.disable_return`` are removed.
-  [#4503](https://github.com/PennyLaneAI/pennylane/pull/4503)
+  [(#4503)](https://github.com/PennyLaneAI/pennylane/pull/4503)
 
 * The ``mode`` keyword argument in ``QNode`` is removed. Please use ``grad_on_execution`` instead.
-  [#4503](https://github.com/PennyLaneAI/pennylane/pull/4503)
+  [(#4503)](https://github.com/PennyLaneAI/pennylane/pull/4503)
 
 * The CV observables ``qml.X`` and ``qml.P`` are removed. Please use ``qml.QuadX`` and ``qml.QuadP`` instead.
-  [#4533](https://github.com/PennyLaneAI/pennylane/pull/4533)
+  [(#4533)](https://github.com/PennyLaneAI/pennylane/pull/4533)
 
 * The method ``tape.unwrap()`` and corresponding ``UnwrapTape`` and ``Unwrap`` classes are removed.
   Instead of ``tape.unwrap()``, use :func:`~.transforms.convert_to_numpy_parameters`.
-  [#4535](https://github.com/PennyLaneAI/pennylane/pull/4535)
+  [(#4535)](https://github.com/PennyLaneAI/pennylane/pull/4535)
 
 * The ``RandomLayers.compute_decomposition`` keyword argument ``ratio_imprivitive`` has been changed to
   ``ratio_imprim`` to match the call signature of the operation.
-  [#4552](https://github.com/PennyLaneAI/pennylane/pull/4552)
+  [(#4552)](https://github.com/PennyLaneAI/pennylane/pull/4552)
 
   
 <h3>Deprecations 👋</h3>

--- a/pennylane/templates/layers/random.py
+++ b/pennylane/templates/layers/random.py
@@ -15,7 +15,6 @@ r"""
 Contains the RandomLayers template.
 """
 # pylint: disable-msg=too-many-branches,too-many-arguments,protected-access
-import warnings
 
 import numpy as np
 import pennylane as qml
@@ -199,7 +198,7 @@ class RandomLayers(Operation):
 
     @staticmethod
     def compute_decomposition(
-        weights, wires, ratio_imprim, imprimitive, rotations, seed, ratio_imprimitive=None
+        weights, wires, ratio_imprim, imprimitive, rotations, seed
     ):  # pylint: disable=arguments-differ
         r"""Representation of the operator as a product of other operators.
 
@@ -232,13 +231,6 @@ class RandomLayers(Operation):
          CNOT(wires=['b', 'a']),
          RX(tensor(1.4000), wires=['a'])]
         """
-        if ratio_imprimitive:
-            warnings.warn(
-                "In RandomLayers.compute_decomposition, ratio_imprim should be changed to `ratio_imprimitive` to match the "
-                "call signature of the operation.",
-                UserWarning,
-            )
-            ratio_imprim = ratio_imprimitive
         wires = qml.wires.Wires(wires)
         rng = np.random.default_rng(seed)
 

--- a/pennylane/templates/layers/random.py
+++ b/pennylane/templates/layers/random.py
@@ -223,8 +223,8 @@ class RandomLayers(Operation):
 
         >>> weights = torch.tensor([[0.1, -2.1, 1.4]])
         >>> rotations=[qml.RY, qml.RX]
-        >>> qml.RandomLayers.compute_decomposition(weights, wires=["a", "b"], ratio_imprimitive=0.3,
-        ..                                         imprimitive=qml.CNOT, rotations=rotations, seed=42)
+        >>> qml.RandomLayers.compute_decomposition(weights, wires=["a", "b"], ratio_imprim=0.3,
+        ...                                         imprimitive=qml.CNOT, rotations=rotations, seed=42)
         [RY(tensor(0.1000), wires=['b']),
          RY(tensor(-2.1000), wires=['b']),
          CNOT(wires=['b', 'a']),

--- a/tests/templates/test_layers/test_random.py
+++ b/tests/templates/test_layers/test_random.py
@@ -111,14 +111,6 @@ class TestDecomposition:
         ratio_impr = gate_names.count("CNOT") / len(gate_names)
         assert np.isclose(ratio_impr, ratio, atol=0.05)
 
-        with pytest.warns(UserWarning):
-            decomp = op.compute_decomposition(
-                *op.parameters, wires=op.wires, **op.hyperparameters, ratio_imprim=0.9
-            )
-            gate_names = [gate.name for gate in decomp]
-            ratio_impr = gate_names.count("CNOT") / len(gate_names)
-            assert np.isclose(ratio_impr, 0.9, atol=0.05)
-
     def test_random_wires(self):
         """Test that random wires are picked for the gates. This is done by
         taking the mean of all wires, which should be 1 for labels [0, 1, 2]"""

--- a/tests/templates/test_layers/test_random.py
+++ b/tests/templates/test_layers/test_random.py
@@ -99,7 +99,7 @@ class TestDecomposition:
         assert len(gate_names) - gate_names.count("CNOT") == n_layers * n_rots
 
     @pytest.mark.parametrize("ratio", [0.2, 0.6])
-    def test_ratio_imprimitive(self, ratio):
+    def test_ratio_imprim(self, ratio):
         """Test the ratio of imprimitive gates."""
         n_rots = 500
         weights = np.random.random(size=(1, n_rots))
@@ -113,7 +113,7 @@ class TestDecomposition:
 
         with pytest.warns(UserWarning):
             decomp = op.compute_decomposition(
-                *op.parameters, wires=op.wires, **op.hyperparameters, ratio_imprimitive=0.9
+                *op.parameters, wires=op.wires, **op.hyperparameters, ratio_imprim=0.9
             )
             gate_names = [gate.name for gate in decomp]
             ratio_impr = gate_names.count("CNOT") / len(gate_names)


### PR DESCRIPTION
The ``RandomLayers.compute_decomposition`` keyword argument ``ratio_imprivitive`` has been changed to
  ``ratio_imprim`` to match the call signature of the operation. This PR completes the deprecation cycle by removing the option to use ``ratio_imprivitive``.