### PR TITLE
Deprecate prep kwarg and remove third list from process_queue

### DIFF
--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -109,6 +109,12 @@ Pending deprecations
   - Deprecated in v0.32
   - Will be removed in v0.33
 
+* The ``prep`` keyword argument in ``QuantumScript`` is deprecated and will be removed from `QuantumScript`.
+  ``StatePrepBase`` operations should be placed at the beginning of the `ops` list instead.
+
+  - Deprecated in v0.33
+  - Will be removed in v0.34
+
 
 Completed deprecation cycles
 ----------------------------

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -26,7 +26,7 @@
 
 * The ``prep`` keyword argument in ``QuantumScript`` is deprecated and will be removed from `QuantumScript`.
   ``StatePrepBase`` operations should be placed at the beginning of the `ops` list instead.
-  [#4554](https://github.com/PennyLaneAI/pennylane/pull/4554)
+  [(#4554)](https://github.com/PennyLaneAI/pennylane/pull/4554)
 
 <h3>Documentation 📝</h3>
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -24,6 +24,10 @@
   
 <h3>Deprecations 👋</h3>
 
+* The ``prep`` keyword argument in ``QuantumScript`` is deprecated and will be removed from `QuantumScript`.
+  ``StatePrepBase`` operations should be placed at the beginning of the `ops` list instead.
+  [#4554](https://github.com/PennyLaneAI/pennylane/pull/4554)
+
 <h3>Documentation 📝</h3>
 
 <h3>Bug fixes 🐛</h3>

--- a/pennylane/queuing.py
+++ b/pennylane/queuing.py
@@ -560,8 +560,8 @@ def process_queue(queue: AnnotatedQueue):
         queue (.AnnotatedQueue): The queue to be processed into individual lists
 
     Returns:
-        tuple[list(.Operation), list(.MeasurementProcess), list(.Operation)]:
-        The list of tape operations, the list of tape measurements, and the list of preparation operations
+        tuple[list(.Operation), list(.MeasurementProcess)]:
+        The list of tape operations, the list of tape measurements
     """
     lists = {"_ops": [], "_measurements": []}
     list_order = {"_ops": 1, "_measurements": 2}

--- a/pennylane/queuing.py
+++ b/pennylane/queuing.py
@@ -138,17 +138,15 @@ and measurements in the final circuit. This step eliminates any object that has 
 ...     base = qml.PauliX(0)
 ...     pow_op = base ** 1.5
 ...     qml.expval(qml.PauliZ(0) @ qml.PauliX(1))
->>> ops, measurements, prep = qml.queuing.process_queue(q)
+>>> ops, measurements = qml.queuing.process_queue(q)
 >>> ops
 [StatePrep(tensor([1., 0.], requires_grad=True), wires=[0]), PauliX(wires=[0])**1.5]
 >>> measurements
 [expval(PauliZ(wires=[0]) @ PauliX(wires=[1]))]
->>> prep
-[]
 
 These lists can be used to construct a :class:`~.QuantumScript`:
 
->>> qml.tape.QuantumScript(ops, measurements, prep)
+>>> qml.tape.QuantumScript(ops, measurements)
 <QuantumScript: wires=[0, 1], params=1>
 
 In order to construct new operators within a recording, but without queuing them

--- a/pennylane/queuing.py
+++ b/pennylane/queuing.py
@@ -580,4 +580,4 @@ def process_queue(queue: AnnotatedQueue):
                 )
             lists[obj._queue_category].append(obj)
 
-    return lists["_ops"], lists["_measurements"], []
+    return lists["_ops"], lists["_measurements"]

--- a/pennylane/tape/operation_recorder.py
+++ b/pennylane/tape/operation_recorder.py
@@ -66,7 +66,7 @@ class OperationRecorder(QuantumScript, AnnotatedQueue):
         # be done via the following:
         # if exception_type is None:
         #    self._process_queue()
-        self._ops, self._measurements, _ = process_queue(self)
+        self._ops, self._measurements = process_queue(self)
         self._update()
 
         for obj, info in self.items():

--- a/pennylane/tape/qscript.py
+++ b/pennylane/tape/qscript.py
@@ -182,12 +182,12 @@ class QuantumScript:
     ):  # pylint: disable=too-many-arguments
         self._ops = [] if ops is None else list(ops)
         if prep is not None:
-            # warnings.warn(
-            #     "The `prep` keyword argument is being removed from `QuantumScript`, and "
-            #     "`StatePrepBase` operations should be placed at the beginning of the `ops` list "
-            #     "instead.",
-            #     UserWarning,
-            # )
+            warnings.warn(
+                "The `prep` keyword argument is being removed from `QuantumScript`, and "
+                "`StatePrepBase` operations should be placed at the beginning of the `ops` list "
+                "instead.",
+                UserWarning,
+            )
             self._ops = list(prep) + self._ops
         self._measurements = [] if measurements is None else list(measurements)
         self._shots = Shots(shots)

--- a/pennylane/tape/tape.py
+++ b/pennylane/tape/tape.py
@@ -466,7 +466,7 @@ class QuantumTape(QuantumScript, AnnotatedQueue):
 
         Also calls `_update()` which sets many attributes.
         """
-        self._ops, self._measurements, _ = process_queue(self)
+        self._ops, self._measurements = process_queue(self)
         self._update()
 
     def __getitem__(self, key):

--- a/tests/tape/test_qscript.py
+++ b/tests/tape/test_qscript.py
@@ -97,11 +97,11 @@ class TestInitialization:
         """Test that the prep keyword ~is deprecated and~ behaves as expected."""
         prep = [qml.BasisState([1, 1], wires=(0, 1))]
         ops = [qml.PauliX(0)]
-        # with pytest.warns(UserWarning, match="`prep` keyword argument is being removed"):
-        qs = QuantumScript(ops=ops, prep=prep)
-        assert len(qs.operations) == len(qs._ops) == 2
-        assert qml.equal(qs.operations[0], prep[0])
-        assert qml.equal(qs.operations[1], ops[0])
+        with pytest.warns(UserWarning, match="`prep` keyword argument is being removed"):
+            qs = QuantumScript(ops=ops, prep=prep)
+            assert len(qs.operations) == len(qs._ops) == 2
+            assert qml.equal(qs.operations[0], prep[0])
+            assert qml.equal(qs.operations[1], ops[0])
 
 
 sample_measurements = [

--- a/tests/templates/test_subroutines/test_qsvt.py
+++ b/tests/templates/test_subroutines/test_qsvt.py
@@ -171,7 +171,7 @@ class TestQSVT:
         with qml.queuing.AnnotatedQueue() as q:
             decomp = op.decomposition()
 
-        ops, _, _ = qml.queuing.process_queue(q)
+        ops, _ = qml.queuing.process_queue(q)
         assert all(qml.equal(op1, op2) for op1, op2 in zip(ops, decomp))
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
The empty third list returned by `process_queue` is removed, and a deprecation warning is added when the `prep` kwarg is used in `QuantumScript`