### PR TITLE
render docs for devices.qubit functions

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -26,6 +26,10 @@
 
 <h3>Documentation 📝</h3>
 
+* Add functions for qubit-simulation to the `qml.devices` sub-page of the "Internal" section.
+  Note that these functions are unstable while device upgrades are underway.
+  [(#4555)](https://github.com/PennyLaneAI/pennylane/pull/4555)
+
 <h3>Bug fixes 🐛</h3>
 
 * `tf.function` no longer breaks `ProbabilityMP.process_state` which is needed by new devices.

--- a/pennylane/devices/__init__.py
+++ b/pennylane/devices/__init__.py
@@ -52,6 +52,12 @@ accessible from the ``pennylane.devices.experimental`` submodule.
     Device
     DefaultQubit2
 
+Qubit Simulation Tools
+----------------------
+
+.. currentmodule:: pennylane.devices.qubit
+.. automodule:: pennylane.devices.qubit
+
 """
 
 from . import experimental

--- a/pennylane/devices/qubit/__init__.py
+++ b/pennylane/devices/qubit/__init__.py
@@ -24,9 +24,13 @@ at your own discretion.
     create_initial_state
     apply_operation
     measure
+    measure_with_samples
     sample_state
     preprocess
     simulate
+    adjoint_jacobian
+    adjoint_jvp
+    adjoint_vjp
 """
 
 from .apply_operation import apply_operation

--- a/pennylane/devices/qubit/adjoint_jacobian.py
+++ b/pennylane/devices/qubit/adjoint_jacobian.py
@@ -52,7 +52,7 @@ def adjoint_jacobian(tape: QuantumTape, state=None):
         * Observable being measured must have a matrix.
 
     Args:
-        tape (.QuantumTape): circuit that the function takes the gradient of
+        tape (QuantumTape): circuit that the function takes the gradient of
         state (TensorLike): the final state of the circuit; if not provided,
             the final state will be computed by executing the tape
 
@@ -127,7 +127,7 @@ def adjoint_jvp(tape: QuantumTape, tangents: Tuple[Number], state=None):
         * Observable being measured must have a matrix.
 
     Args:
-        tape (.QuantumTape): circuit that the function takes the gradient of
+        tape (QuantumTape): circuit that the function takes the gradient of
         tangents (Tuple[Number]): gradient vector for input parameters.
         state (TensorLike): the final state of the circuit; if not provided,
             the final state will be computed by executing the tape
@@ -201,7 +201,7 @@ def adjoint_vjp(tape: QuantumTape, cotangents: Tuple[Number], state=None):
         * Observable being measured must have a matrix.
 
     Args:
-        tape (.QuantumTape): circuit that the function takes the gradient of
+        tape (QuantumTape): circuit that the function takes the gradient of
         cotangents (Tuple[Number]): gradient vector for output parameters
         state (TensorLike): the final state of the circuit; if not provided,
             the final state will be computed by executing the tape

--- a/pennylane/devices/qubit/apply_operation.py
+++ b/pennylane/devices/qubit/apply_operation.py
@@ -146,9 +146,9 @@ def apply_operation(
 
     Args:
         op (Operator): The operation to apply to ``state``
-        state (tensor_like): The starting state.
+        state (TensorLike): The starting state.
         is_state_batched (bool): Boolean representing whether the state is batched or not
-        debugger (._Debugger): The debugger to use
+        debugger (_Debugger): The debugger to use
 
     Returns:
         ndarray: output state

--- a/pennylane/devices/qubit/preprocess.py
+++ b/pennylane/devices/qubit/preprocess.py
@@ -355,7 +355,7 @@ def preprocess(
 
     Args:
         circuits (Sequence[QuantumTape]): Batch of tapes to be processed.
-        execution_config (.ExecutionConfig): execution configuration with configurable
+        execution_config (ExecutionConfig): execution configuration with configurable
             options for the execution.
 
     Returns:

--- a/pennylane/devices/qubit/sampling.py
+++ b/pennylane/devices/qubit/sampling.py
@@ -119,10 +119,10 @@ def measure_with_samples(
     have already been mapped to integer wires used in the device.
 
     Args:
-        mp (List[Union[~.measurements.SampleMeasurement, ~.measurements.ClassicalShadowMP, ~.measurements.ShadowExpvalMP]]):
+        mp (List[Union[SampleMeasurement, ClassicalShadowMP, ShadowExpvalMP]]):
             The sample measurements to perform
         state (np.ndarray[complex]): The state vector to sample from
-        shots (~.measurements.Shots): The number of samples to take
+        shots (Shots): The number of samples to take
         is_state_batched (bool): whether the state is batched or not
         rng (Union[None, int, array_like[int], SeedSequence, BitGenerator, Generator]): A
             seed-like parameter matching that of ``seed`` for ``numpy.random.default_rng``.

--- a/pennylane/devices/qubit/simulate.py
+++ b/pennylane/devices/qubit/simulate.py
@@ -127,8 +127,6 @@ def simulate(circuit: qml.tape.QuantumScript, rng=None, debugger=None) -> Result
 
     Note that this function can return measurements for non-commuting observables simultaneously.
 
-    It currently does not support observables without diagonalizing gates.
-
     This function assumes that all operations provide matrices.
 
     >>> qs = qml.tape.QuantumScript([qml.RX(1.2, wires=0)], [qml.expval(qml.PauliZ(0)), qml.probs(wires=(0,1))])

--- a/pennylane/devices/qubit/simulate.py
+++ b/pennylane/devices/qubit/simulate.py
@@ -116,18 +116,18 @@ def simulate(circuit: qml.tape.QuantumScript, rng=None, debugger=None) -> Result
     This is an internal function that will be called by the successor to ``default.qubit``.
 
     Args:
-        circuit (.QuantumScript): The single circuit to simulate
+        circuit (QuantumTape): The single circuit to simulate
         rng (Union[None, int, array_like[int], SeedSequence, BitGenerator, Generator]): A
             seed-like parameter matching that of ``seed`` for ``numpy.random.default_rng``.
             If no value is provided, a default RNG will be used.
-        debugger (._Debugger): The debugger to use
+        debugger (_Debugger): The debugger to use
 
     Returns:
         tuple(TensorLike): The results of the simulation
 
     Note that this function can return measurements for non-commuting observables simultaneously.
 
-    It does currently not support sampling or observables without diagonalizing gates.
+    It currently does not support observables without diagonalizing gates.
 
     This function assumes that all operations provide matrices.
 


### PR DESCRIPTION
I am open to notable variation in the docs here, just lmk! I mostly just wanted to get this PR going.

**Context:**
The `devices.qubit` functions are very useful, and people should be able to see them! They're still a little unstable, so I'm inclined to leave those warnings in the docs for now, but they should be visible.

**Description of the Change:**
Add the `devices.qubit` qubit-simulation functions at the bottom of the `qml.devices` sub-page in the "Internal" section (check it out [here](https://xanaduai-pennylane--4555.com.readthedocs.build/en/4555/code/qml_devices.html#module-pennylane.devices.qubit)!)

**Benefits:**
Nice pretty docs to show users all the cool features and helper functions we have

**Possible Drawbacks:**
It's still kinda unstable while we ramp up DQ2, but it should be ready by the time we release 0.33