### PR TITLE
add default.qubit.legacy and rename some test devices to prepare for DQ2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ info = {
         # This requires a rename in the setup file of all devices, and is best done during another refactor
         "pennylane.plugins": [
             "default.qubit = pennylane.devices:DefaultQubit",
+            "default.qubit.legacy = pennylane.devices:DefaultQubit",
             "default.gaussian = pennylane.devices:DefaultGaussian",
             "default.qubit.tf = pennylane.devices.default_qubit_tf:DefaultQubitTF",
             "default.qubit.torch = pennylane.devices.default_qubit_torch:DefaultQubitTorch",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,22 +70,28 @@ def n_subsystems_fixture(request):
 
 @pytest.fixture(scope="session")
 def qubit_device(n_subsystems):
-    return qml.device("default.qubit", wires=n_subsystems)
+    return qml.device("default.qubit.legacy", wires=n_subsystems)
 
 
 @pytest.fixture(scope="function", params=[(np.float32, np.complex64), (np.float64, np.complex128)])
 def qubit_device_1_wire(request):
-    return qml.device("default.qubit", wires=1, r_dtype=request.param[0], c_dtype=request.param[1])
+    return qml.device(
+        "default.qubit.legacy", wires=1, r_dtype=request.param[0], c_dtype=request.param[1]
+    )
 
 
 @pytest.fixture(scope="function", params=[(np.float32, np.complex64), (np.float64, np.complex128)])
 def qubit_device_2_wires(request):
-    return qml.device("default.qubit", wires=2, r_dtype=request.param[0], c_dtype=request.param[1])
+    return qml.device(
+        "default.qubit.legacy", wires=2, r_dtype=request.param[0], c_dtype=request.param[1]
+    )
 
 
 @pytest.fixture(scope="function", params=[(np.float32, np.complex64), (np.float64, np.complex128)])
 def qubit_device_3_wires(request):
-    return qml.device("default.qubit", wires=3, r_dtype=request.param[0], c_dtype=request.param[1])
+    return qml.device(
+        "default.qubit.legacy", wires=3, r_dtype=request.param[0], c_dtype=request.param[1]
+    )
 
 
 # The following 3 fixtures are for default.qutrit devices to be used

--- a/tests/devices/test_default_qubit_autograd.py
+++ b/tests/devices/test_default_qubit_autograd.py
@@ -407,8 +407,8 @@ class TestPassthruIntegration:
                 qml.CNOT(wires=[i, i + 1])
             return qml.expval(qml.PauliZ(0)), qml.var(qml.PauliZ(1))
 
-        dev1 = qml.device("default.qubit", wires=3)
-        dev2 = qml.device("default.qubit", wires=3)
+        dev1 = qml.device("default.qubit.legacy", wires=3)
+        dev2 = qml.device("default.qubit.legacy", wires=3)
 
         def cost(x):
             return qml.math.stack(circuit(x))

--- a/tests/devices/test_default_qubit_legacy.py
+++ b/tests/devices/test_default_qubit_legacy.py
@@ -643,7 +643,7 @@ class TestApply:
         with pytest.raises(
             DeviceError,
             match="Operation StatePrep cannot be used after other Operations have already been applied "
-            "on a default.qubit.legacy device.",
+            "on a default.qubit device.",
         ):
             qubit_device_2_wires.reset()
             qubit_device_2_wires.apply(
@@ -664,7 +664,7 @@ class TestApply:
         with pytest.raises(
             DeviceError,
             match="Operation BasisState cannot be used after other Operations have already been applied "
-            "on a default.qubit.legacy device.",
+            "on a default.qubit device.",
         ):
             qubit_device_2_wires.reset()
             qubit_device_2_wires.apply(

--- a/tests/devices/test_default_qubit_legacy.py
+++ b/tests/devices/test_default_qubit_legacy.py
@@ -98,17 +98,17 @@ def test_analytic_deprecation():
         DeviceError,
         match=msg,
     ):
-        qml.device("default.qubit", wires=1, shots=1, analytic=True)
+        qml.device("default.qubit.legacy", wires=1, shots=1, analytic=True)
 
 
 def test_dtype_errors():
     """Test that if an incorrect dtype is provided to the device then an error is raised."""
     with pytest.raises(DeviceError, match="Real datatype must be a floating point type."):
-        qml.device("default.qubit", wires=1, r_dtype=np.complex128)
+        qml.device("default.qubit.legacy", wires=1, r_dtype=np.complex128)
     with pytest.raises(
         DeviceError, match="Complex datatype must be a complex floating point type."
     ):
-        qml.device("default.qubit", wires=1, c_dtype=np.float64)
+        qml.device("default.qubit.legacy", wires=1, c_dtype=np.float64)
 
 
 def test_custom_op_with_matrix():
@@ -117,7 +117,7 @@ def test_custom_op_with_matrix():
     class DummyOp(qml.operation.Operation):
         num_wires = 1
 
-        def compute_matrix(self):
+        def compute_matrix(self):  # pylint:disable=arguments-differ
             return np.eye(2)
 
     with qml.queuing.AnnotatedQueue() as q:
@@ -125,7 +125,7 @@ def test_custom_op_with_matrix():
         qml.state()
 
     tape = qml.tape.QuantumScript.from_queue(q)
-    dev = qml.device("default.qubit", wires=1)
+    dev = qml.device("default.qubit.legacy", wires=1)
     assert qml.math.allclose(dev.execute(tape), np.array([1, 0]))
 
 
@@ -643,7 +643,7 @@ class TestApply:
         with pytest.raises(
             DeviceError,
             match="Operation StatePrep cannot be used after other Operations have already been applied "
-            "on a default.qubit device.",
+            "on a default.qubit.legacy device.",
         ):
             qubit_device_2_wires.reset()
             qubit_device_2_wires.apply(
@@ -664,7 +664,7 @@ class TestApply:
         with pytest.raises(
             DeviceError,
             match="Operation BasisState cannot be used after other Operations have already been applied "
-            "on a default.qubit device.",
+            "on a default.qubit.legacy device.",
         ):
             qubit_device_2_wires.reset()
             qubit_device_2_wires.apply(
@@ -792,7 +792,7 @@ class TestExpval:
     def test_expval_estimate(self):
         """Test that the expectation value is not analytically calculated"""
 
-        dev = qml.device("default.qubit", wires=1, shots=3)
+        dev = qml.device("default.qubit.legacy", wires=1, shots=3)
 
         @qml.qnode(dev, diff_method="parameter-shift")
         def circuit():
@@ -919,7 +919,7 @@ class TestVar:
     def test_var_estimate(self):
         """Test that the variance is not analytically calculated"""
 
-        dev = qml.device("default.qubit", wires=1, shots=3)
+        dev = qml.device("default.qubit.legacy", wires=1, shots=3)
 
         @qml.qnode(dev, diff_method="parameter-shift")
         def circuit():
@@ -943,7 +943,7 @@ class TestSample:
         # Explicitly resetting is necessary as the internal
         # state is set to None in __init__ and only properly
         # initialized during reset
-        dev = qml.device("default.qubit", wires=2, shots=1000)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=1000)
 
         dev.apply([qml.RX(1.5708, wires=[0]), qml.RX(1.5708, wires=[1])])
 
@@ -975,7 +975,7 @@ class TestSample:
         # Explicitly resetting is necessary as the internal
         # state is set to None in __init__ and only properly
         # initialized during reset
-        dev = qml.device("default.qubit", wires=2, shots=1000)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=1000)
 
         dev.apply([qml.RX(1.5708, wires=[0])])
         dev._wires_measured = {0}
@@ -995,7 +995,7 @@ class TestDefaultQubitIntegration:
     def test_defines_correct_capabilities(self):
         """Test that the device defines the right capabilities"""
 
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
         cap = dev.capabilities()
         capabilities = {
             "model": "qubit",
@@ -1033,7 +1033,7 @@ class TestDefaultQubitIntegration:
 
         res = circuit(p)
         assert np.isclose(res, expected, atol=tol, rtol=0)
-        assert res.dtype == r_dtype
+        assert res.dtype == r_dtype  # pylint:disable=no-member
 
     def test_qubit_identity(self, qubit_device_1_wire, tol):
         """Test that the default qubit plugin provides correct result for the Identity expectation"""
@@ -1052,7 +1052,7 @@ class TestDefaultQubitIntegration:
         """Test that the default qubit plugin provides correct result for high shot number"""
 
         shots = 10**5
-        dev = qml.device("default.qubit", wires=1, shots=shots)
+        dev = qml.device("default.qubit.legacy", wires=1, shots=shots)
 
         p = 0.543
 
@@ -1195,7 +1195,7 @@ class TestDefaultQubitIntegration:
         the correct dimensions
         """
 
-        dev = qml.device("default.qubit", wires=2, shots=1000)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=1000)
 
         @qml.qnode(dev, diff_method="parameter-shift")
         def circuit():
@@ -1215,7 +1215,7 @@ class TestDefaultQubitIntegration:
         the correct dimensions
         """
 
-        dev = qml.device("default.qubit", wires=num_wires, shots=1000)
+        dev = qml.device("default.qubit.legacy", wires=num_wires, shots=1000)
 
         @qml.qnode(dev, diff_method="parameter-shift")
         def circuit():
@@ -1235,7 +1235,7 @@ class TestTensorExpval:
 
     def test_paulix_pauliy(self, theta, phi, varphi, tol):
         """Test that a tensor product involving PauliX and PauliY works correctly"""
-        dev = qml.device("default.qubit", wires=3)
+        dev = qml.device("default.qubit.legacy", wires=3)
         dev.reset()
 
         obs = qml.PauliX(0) @ qml.PauliY(2)
@@ -1259,7 +1259,7 @@ class TestTensorExpval:
 
     def test_pauliz_identity(self, theta, phi, varphi, tol):
         """Test that a tensor product involving PauliZ and Identity works correctly"""
-        dev = qml.device("default.qubit", wires=3)
+        dev = qml.device("default.qubit.legacy", wires=3)
         dev.reset()
 
         obs = qml.PauliZ(0) @ qml.Identity(1) @ qml.PauliZ(2)
@@ -1283,7 +1283,7 @@ class TestTensorExpval:
 
     def test_pauliz_hadamard(self, theta, phi, varphi, tol):
         """Test that a tensor product involving PauliZ and PauliY and hadamard works correctly"""
-        dev = qml.device("default.qubit", wires=3)
+        dev = qml.device("default.qubit.legacy", wires=3)
         obs = qml.PauliZ(0) @ qml.Hadamard(1) @ qml.PauliY(2)
 
         dev.reset()
@@ -1306,7 +1306,7 @@ class TestTensorExpval:
 
     def test_hermitian(self, theta, phi, varphi, tol):
         """Test that a tensor product involving qml.Hermitian works correctly"""
-        dev = qml.device("default.qubit", wires=3)
+        dev = qml.device("default.qubit.legacy", wires=3)
         dev.reset()
 
         A = np.array(
@@ -1344,7 +1344,7 @@ class TestTensorExpval:
 
     def test_hermitian_hermitian(self, theta, phi, varphi, tol):
         """Test that a tensor product involving two Hermitian matrices works correctly"""
-        dev = qml.device("default.qubit", wires=3)
+        dev = qml.device("default.qubit.legacy", wires=3)
 
         A1 = np.array([[1, 2], [2, 4]])
 
@@ -1393,7 +1393,7 @@ class TestTensorExpval:
 
     def test_hermitian_identity_expectation(self, theta, phi, varphi, tol):
         """Test that a tensor product involving an Hermitian matrix and the identity works correctly"""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         A = np.array(
             [[1.02789352, 1.61296440 - 0.3498192j], [1.61296440 + 0.3498192j, 1.23920938 + 0j]]
@@ -1417,7 +1417,7 @@ class TestTensorExpval:
 
     def test_hermitian_two_wires_identity_expectation(self, theta, phi, varphi, tol):
         """Test that a tensor product involving an Hermitian matrix for two wires and the identity works correctly"""
-        dev = qml.device("default.qubit", wires=3)
+        dev = qml.device("default.qubit.legacy", wires=3)
 
         A = np.array(
             [[1.02789352, 1.61296440 - 0.3498192j], [1.61296440 + 0.3498192j, 1.23920938 + 0j]]
@@ -1446,7 +1446,7 @@ class TestTensorVar:
 
     def test_paulix_pauliy(self, theta, phi, varphi, tol):
         """Test that a tensor product involving PauliX and PauliY works correctly"""
-        dev = qml.device("default.qubit", wires=3)
+        dev = qml.device("default.qubit.legacy", wires=3)
 
         obs = qml.PauliX(0) @ qml.PauliY(2)
 
@@ -1476,7 +1476,7 @@ class TestTensorVar:
 
     def test_pauliz_hadamard(self, theta, phi, varphi, tol):
         """Test that a tensor product involving PauliZ and PauliY and hadamard works correctly"""
-        dev = qml.device("default.qubit", wires=3)
+        dev = qml.device("default.qubit.legacy", wires=3)
         obs = qml.PauliZ(0) @ qml.Hadamard(1) @ qml.PauliY(2)
 
         dev.reset()
@@ -1504,7 +1504,7 @@ class TestTensorVar:
 
     def test_hermitian(self, theta, phi, varphi, tol):
         """Test that a tensor product involving qml.Hermitian works correctly"""
-        dev = qml.device("default.qubit", wires=3)
+        dev = qml.device("default.qubit.legacy", wires=3)
 
         A = np.array(
             [
@@ -1570,7 +1570,7 @@ class TestTensorSample:
 
     def test_paulix_pauliy(self, theta, phi, varphi, tol_stochastic):
         """Test that a tensor product involving PauliX and PauliY works correctly"""
-        dev = qml.device("default.qubit", wires=3, shots=int(1e6))
+        dev = qml.device("default.qubit.legacy", wires=3, shots=int(1e6))
 
         obs = qml.PauliX(0) @ qml.PauliY(2)
 
@@ -1612,7 +1612,7 @@ class TestTensorSample:
 
     def test_pauliz_hadamard(self, theta, phi, varphi, tol_stochastic):
         """Test that a tensor product involving PauliZ and PauliY and hadamard works correctly"""
-        dev = qml.device("default.qubit", wires=3, shots=int(1e6))
+        dev = qml.device("default.qubit.legacy", wires=3, shots=int(1e6))
         obs = qml.PauliZ(0) @ qml.Hadamard(1) @ qml.PauliY(2)
         dev.apply(
             [
@@ -1650,7 +1650,7 @@ class TestTensorSample:
 
     def test_hermitian(self, theta, phi, varphi, tol_stochastic):
         """Test that a tensor product involving qml.Hermitian works correctly"""
-        dev = qml.device("default.qubit", wires=3, shots=int(1e6))
+        dev = qml.device("default.qubit.legacy", wires=3, shots=int(1e6))
 
         A = 0.1 * np.array(
             [
@@ -1765,7 +1765,7 @@ class TestDtypePreserved:
         examples.
         """
 
-        dev = qml.device("default.qubit", wires=4, r_dtype=r_dtype, c_dtype=c_dtype)
+        dev = qml.device("default.qubit.legacy", wires=4, r_dtype=r_dtype, c_dtype=c_dtype)
 
         n_wires = op.num_wires
         n_params = op.num_params
@@ -1781,7 +1781,7 @@ class TestDtypePreserved:
             return qml.state()
 
         res = circuit()
-        assert res.dtype == c_dtype
+        assert res.dtype == c_dtype  # pylint:disable=no-member
 
     @pytest.mark.parametrize(
         "measurement",
@@ -1796,7 +1796,7 @@ class TestDtypePreserved:
         """Test that the default qubit plugin provides correct result for a simple circuit"""
         p = 0.543
 
-        dev = qml.device("default.qubit", wires=3, r_dtype=r_dtype, c_dtype=c_dtype)
+        dev = qml.device("default.qubit.legacy", wires=3, r_dtype=r_dtype, c_dtype=c_dtype)
 
         @qml.qnode(dev, diff_method="parameter-shift")
         def circuit(x):
@@ -1814,7 +1814,7 @@ class TestDtypePreserved:
         """Test that the default qubit plugin provides correct result for a simple circuit"""
         p = 0.543
 
-        dev = qml.device("default.qubit", wires=3, r_dtype=r_dtype, c_dtype=c_dtype)
+        dev = qml.device("default.qubit.legacy", wires=3, r_dtype=r_dtype, c_dtype=c_dtype)
 
         @qml.qnode(dev, diff_method="parameter-shift")
         def circuit(x):
@@ -1836,8 +1836,8 @@ class TestProbabilityIntegration:
     @pytest.mark.parametrize("x", [[0.2, 0.5], [0.4, 0.9], [0.8, 0.3]])
     def test_probability(self, x, tol):
         """Test that the probability function works for finite and infinite shots"""
-        dev = qml.device("default.qubit", wires=2, shots=1000)
-        dev_analytic = qml.device("default.qubit", wires=2, shots=None)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=1000)
+        dev_analytic = qml.device("default.qubit.legacy", wires=2, shots=None)
 
         def circuit(x):
             qml.RX(x[0], wires=0)
@@ -1857,7 +1857,7 @@ class TestProbabilityIntegration:
         """Test analytic_probability call when generating samples"""
         self.analytic_counter = False
 
-        dev = qml.device("default.qubit", wires=2, shots=1000)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=1000)
         monkeypatch.setattr(dev, "analytic_probability", self.mock_analytic_counter)
 
         # generate samples through `generate_samples` (using 'analytic_probability')
@@ -1868,7 +1868,7 @@ class TestProbabilityIntegration:
 
     def test_stateless_analytic_return(self):
         """Test that analytic_probability returns None if device is stateless"""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
         dev._state = None
 
         assert dev.analytic_probability() is None
@@ -1879,7 +1879,7 @@ class TestWiresIntegration:
 
     def make_circuit_probs(self, wires):
         """Factory for a qnode returning probabilities using arbitrary wire labels."""
-        dev = qml.device("default.qubit", wires=wires)
+        dev = qml.device("default.qubit.legacy", wires=wires)
         n_wires = len(wires)
 
         @qml.qnode(dev, diff_method="parameter-shift")
@@ -1912,7 +1912,7 @@ class TestWiresIntegration:
 
     def test_wires_not_found_exception(self):
         """Tests that an exception is raised when wires not present on the device are adressed."""
-        dev = qml.device("default.qubit", wires=["a", "b"])
+        dev = qml.device("default.qubit.legacy", wires=["a", "b"])
 
         with qml.queuing.AnnotatedQueue() as q:
             qml.RX(0.5, wires="c")
@@ -1931,7 +1931,7 @@ class TestWiresIntegration:
     @pytest.mark.parametrize("dev_wires, wires_to_map", wires_to_try)
     def test_map_wires_caches(self, dev_wires, wires_to_map):
         """Test that multiple calls to map_wires will use caching."""
-        dev = qml.device("default.qubit", wires=dev_wires)
+        dev = qml.device("default.qubit.legacy", wires=dev_wires)
 
         original_hits = dev.map_wires.cache_info().hits
         original_misses = dev.map_wires.cache_info().misses
@@ -2002,7 +2002,7 @@ class TestApplyOps:
     gates in DefaultQubit."""
 
     state = np.arange(2**4, dtype=np.complex128).reshape((2, 2, 2, 2))
-    dev = qml.device("default.qubit", wires=4)
+    dev = qml.device("default.qubit.legacy", wires=4)
 
     single_qubit_ops = [
         (qml.PauliX, dev._apply_x),
@@ -2155,7 +2155,7 @@ class TestApplyOperationUnit:
         This test provides a new internal function that `default.qubit` uses to
         apply `PauliX` (rather than redefining the gate itself).
         """
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
 
         # Create a dummy operation
         expected_test_output = np.ones(1)
@@ -2174,7 +2174,7 @@ class TestApplyOperationUnit:
     def test_diagonal_operation_case(self, monkeypatch):
         """Tests the case when the operation to be applied is
         diagonal in the computational basis and the _apply_diagonal_unitary method is used."""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
         par = 0.3
 
         test_state = np.array([1, 0])
@@ -2200,7 +2200,7 @@ class TestApplyOperationUnit:
     def test_apply_einsum_case(self, monkeypatch):
         """Tests the case when np.einsum is used to apply an operation in
         default.qubit."""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
 
         test_state = np.array([1, 0])
         wires = 0
@@ -2238,7 +2238,7 @@ class TestApplyOperationUnit:
     def test_apply_tensordot_case(self, monkeypatch):
         """Tests the case when np.tensordot is used to apply an operation in
         default.qubit."""
-        dev = qml.device("default.qubit", wires=3)
+        dev = qml.device("default.qubit.legacy", wires=3)
 
         test_state = np.array([1, 0])
         wires = [0, 1, 2]
@@ -2277,7 +2277,7 @@ class TestApplyOperationUnit:
     def test_apply_unitary_tensordot_double_broadcasting_error(self):
         """Tests that an error is raised if attempting to use _apply_unitary
         with a broadcasted matrix and a broadcasted state simultaneously."""
-        dev = qml.device("default.qubit", wires=3)
+        dev = qml.device("default.qubit.legacy", wires=3)
 
         class BroadcastedToffoli(qml.operation.Operation):
             num_wires = 3
@@ -2298,7 +2298,7 @@ class TestApplyOperationUnit:
 
     def test_identity_skipped(self, mocker):
         """Test that applying the identity operation does not perform any additional computations."""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
 
         starting_state = np.array([1, 0])
         op = qml.Identity(0)
@@ -2320,7 +2320,7 @@ class TestHamiltonianSupport:
 
     def test_do_not_split_analytic(self, mocker):
         """Tests that the Hamiltonian is not split for shots=None."""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
         H = qml.Hamiltonian(np.array([0.1, 0.2]), [qml.PauliX(0), qml.PauliZ(1)])
 
         @qml.qnode(dev, diff_method="parameter-shift", interface=None)
@@ -2335,7 +2335,7 @@ class TestHamiltonianSupport:
 
     def test_split_finite_shots(self, mocker):
         """Tests that the Hamiltonian is split for finite shots."""
-        dev = qml.device("default.qubit", wires=2, shots=10)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=10)
         spy = mocker.spy(dev, "expval")
 
         H = qml.Hamiltonian(np.array([0.1, 0.2]), [qml.PauliX(0), qml.PauliZ(1)])
@@ -2351,7 +2351,7 @@ class TestHamiltonianSupport:
 
     def test_error_hamiltonian_expval_finite_shots(self):
         """Tests that the Hamiltonian is split for finite shots."""
-        dev = qml.device("default.qubit", wires=2, shots=10)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=10)
         H = qml.Hamiltonian([0.1, 0.2], [qml.PauliX(0), qml.PauliZ(1)])
 
         with pytest.raises(AssertionError, match="Hamiltonian must be used with shots=None"):
@@ -2359,7 +2359,7 @@ class TestHamiltonianSupport:
 
     def test_error_hamiltonian_expval_wrong_wires(self):
         """Tests that expval fails if Hamiltonian uses non-device wires."""
-        dev = qml.device("default.qubit", wires=2, shots=None)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=None)
         H = qml.Hamiltonian([0.1, 0.2, 0.3], [qml.PauliX(0), qml.PauliZ(1), qml.PauliY(2)])
 
         with pytest.raises(
@@ -2370,7 +2370,7 @@ class TestHamiltonianSupport:
 
     def test_Hamiltonian_filtered_from_rotations(self, mocker):
         """Tests that the device does not attempt to get rotations for Hamiltonians."""
-        dev = qml.device("default.qubit", wires=2, shots=10)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=10)
         H = qml.Hamiltonian([0.1, 0.2], [qml.PauliX(0), qml.PauliZ(1)])
 
         spy = mocker.spy(qml.QubitDevice, "_get_diagonalizing_gates")
@@ -2410,7 +2410,7 @@ class TestSumSupport:
 
     def test_super_expval_not_called(self, is_state_batched, mocker):
         """Tests basic expval result, and ensures QubitDevice.expval is not called."""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
         spy = mocker.spy(qml.QubitDevice, "expval")
         obs = qml.sum(qml.s_prod(0.1, qml.PauliX(0)), qml.s_prod(0.2, qml.PauliZ(0)))
         assert np.isclose(dev.expval(obs), 0.2)
@@ -2421,7 +2421,7 @@ class TestSumSupport:
         """Tests that coeffs passed to a sum are trainable with autograd."""
         if is_state_batched:
             pytest.skip(msg="Broadcasting, qml.jacobian and new return types do not work together")
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
         qnode = qml.QNode(self.circuit, dev, interface="autograd")
         y, z = np.array([1.1, 2.2])
         actual = qml.grad(qnode, argnum=[0, 1])(y, z, is_state_batched)
@@ -2432,7 +2432,7 @@ class TestSumSupport:
         """Tests that coeffs passed to a sum are trainable with torch."""
         import torch
 
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
         qnode = qml.QNode(self.circuit, dev, interface="torch")
         y, z = torch.tensor(1.1, requires_grad=True), torch.tensor(2.2, requires_grad=True)
         _qnode = partial(qnode, is_state_batched=is_state_batched)
@@ -2444,7 +2444,7 @@ class TestSumSupport:
         """Tests that coeffs passed to a sum are trainable with tf."""
         import tensorflow as tf
 
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
         qnode = qml.QNode(self.circuit, dev, interface="tensorflow")
         y, z = tf.Variable(1.1, dtype=tf.float64), tf.Variable(2.2, dtype=tf.float64)
         with tf.GradientTape() as tape:
@@ -2457,7 +2457,7 @@ class TestSumSupport:
         """Tests that coeffs passed to a sum are trainable with jax."""
         import jax
 
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
         qnode = qml.QNode(self.circuit, dev, interface="jax")
         y, z = jax.numpy.array([1.1, 2.2])
         actual = jax.jacobian(qnode, argnums=[0, 1])(y, z, is_state_batched)
@@ -2470,7 +2470,7 @@ class TestGetBatchSize:
     @pytest.mark.parametrize("shape", [(4, 4), (1, 8), (4,)])
     def test_batch_size_None(self, shape):
         """Test that a ``batch_size=None`` is reported correctly."""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
         tensor0 = np.ones(shape, dtype=complex)
         assert dev._get_batch_size(tensor0, shape, qml.math.prod(shape)) is None
         tensor1 = np.arange(np.prod(shape)).reshape(shape)
@@ -2480,7 +2480,7 @@ class TestGetBatchSize:
     @pytest.mark.parametrize("batch_size", [1, 3])
     def test_batch_size_int(self, shape, batch_size):
         """Test that an integral ``batch_size`` is reported correctly."""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
         full_shape = (batch_size,) + shape
         tensor0 = np.ones(full_shape, dtype=complex)
         assert dev._get_batch_size(tensor0, shape, qml.math.prod(shape)) == batch_size
@@ -2491,7 +2491,7 @@ class TestGetBatchSize:
     def test_invalid_tensor(self):
         """Test that an error is raised if a tensor is provided that does not
         have a proper shape/ndim."""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
         with pytest.raises(ValueError, match="could not broadcast"):
             dev._get_batch_size([qml.math.ones((2, 3)), qml.math.ones((2, 2))], (2, 2, 2), 8)
 
@@ -2511,4 +2511,5 @@ class TestDenseMatrixDecompositionThreshold:
     def test_threshold(self, op, n_wires, condition):
         wires = np.linspace(0, n_wires - 1, n_wires, dtype=int)
         op = op(wires=wires)
+        # pylint:disable=no-member
         assert DefaultQubit.stopping_condition.__get__(op)(op) == condition

--- a/tests/devices/test_default_qubit_legacy_broadcasting.py
+++ b/tests/devices/test_default_qubit_legacy_broadcasting.py
@@ -462,7 +462,7 @@ class TestApplyBroadcasted:
         with pytest.raises(
             DeviceError,
             match="Operation StatePrep cannot be used after other Operations have already been applied "
-            "on a default.qubit device.",
+            "on a default.qubit.legacy device.",
         ):
             qubit_device_2_wires.apply([qml.RZ(0.5, wires=[0]), vec])
 
@@ -491,7 +491,7 @@ class TestApplyBroadcasted:
         with pytest.raises(
             DeviceError,
             match="Operation BasisState cannot be used after other Operations have already been applied "
-            "on a default.qubit device.",
+            "on a default.qubit.legacy device.",
         ):
             qubit_device_2_wires.apply([vec])
 
@@ -591,7 +591,7 @@ class TestExpvalBroadcasted:
     def test_expval_estimate_broadcasted(self):
         """Test that the expectation value is not analytically calculated"""
 
-        dev = qml.device("default.qubit", wires=1, shots=3)
+        dev = qml.device("default.qubit.legacy", wires=1, shots=3)
 
         @qml.qnode(dev, diff_method="parameter-shift")
         def circuit():
@@ -691,7 +691,7 @@ class TestVarBroadcasted:
     def test_var_estimate_broadcasted(self):
         """Test that the variance is not analytically calculated"""
 
-        dev = qml.device("default.qubit", wires=1, shots=3)
+        dev = qml.device("default.qubit.legacy", wires=1, shots=3)
 
         @qml.qnode(dev, diff_method="parameter-shift")
         def circuit():
@@ -716,7 +716,7 @@ class TestSampleBroadcasted:
         # Explicitly resetting is necessary as the internal
         # state is set to None in __init__ and only properly
         # initialized during reset
-        dev = qml.device("default.qubit", wires=2, shots=1000)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=1000)
 
         dev.apply([qml.RX(np.array([np.pi / 2, 0.0]), 0), qml.RX(np.array([np.pi / 2, 0.0]), 1)])
 
@@ -752,7 +752,7 @@ class TestSampleBroadcasted:
         # Explicitly resetting is necessary as the internal
         # state is set to None in __init__ and only properly
         # initialized during reset
-        dev = qml.device("default.qubit", wires=2, shots=1000)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=1000)
 
         dev.apply([qml.RX(np.ones(3), wires=[0])])
         dev._wires_measured = {0}
@@ -787,7 +787,7 @@ class TestDefaultQubitIntegrationBroadcasted:
 
         res = circuit(p)
         assert np.allclose(res, expected, atol=tol, rtol=0)
-        assert res.dtype == r_dtype
+        assert res.dtype == r_dtype  # pylint:disable=no-member
 
     def test_qubit_identity_broadcasted(self, qubit_device_1_wire, tol):
         """Test that the default qubit plugin provides correct result for the Identity expectation"""
@@ -806,7 +806,7 @@ class TestDefaultQubitIntegrationBroadcasted:
         """Test that the default qubit plugin provides correct result for high shot number"""
 
         shots = 10**5
-        dev = qml.device("default.qubit", wires=1, shots=shots)
+        dev = qml.device("default.qubit.legacy", wires=1, shots=shots)
 
         p = np.array([0.543, np.pi / 2, 0.0, 1.0])
 
@@ -912,7 +912,7 @@ class TestDefaultQubitIntegrationBroadcasted:
         correctly for correlated observables.
         """
 
-        dev = qml.device("default.qubit", wires=2, shots=1000)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=1000)
 
         @qml.qnode(dev, diff_method="parameter-shift")
         def circuit():
@@ -933,7 +933,7 @@ class TestDefaultQubitIntegrationBroadcasted:
         correctly for correlated observables on larger devices than the observables
         """
 
-        dev = qml.device("default.qubit", wires=num_wires, shots=1000)
+        dev = qml.device("default.qubit.legacy", wires=num_wires, shots=1000)
 
         @qml.qnode(dev, diff_method="parameter-shift")
         def circuit():
@@ -956,7 +956,7 @@ class TestTensorExpvalBroadcasted:
 
     def test_paulix_pauliy_broadcasted(self, theta, phi, varphi, tol):
         """Test that a tensor product involving PauliX and PauliY works correctly"""
-        dev = qml.device("default.qubit", wires=3)
+        dev = qml.device("default.qubit.legacy", wires=3)
         dev.reset()
 
         obs = qml.PauliX(0) @ qml.PauliY(2)
@@ -980,7 +980,7 @@ class TestTensorExpvalBroadcasted:
 
     def test_pauliz_identity_broadcasted(self, theta, phi, varphi, tol):
         """Test that a tensor product involving PauliZ and Identity works correctly"""
-        dev = qml.device("default.qubit", wires=3)
+        dev = qml.device("default.qubit.legacy", wires=3)
         dev.reset()
 
         obs = qml.PauliZ(0) @ qml.Identity(1) @ qml.PauliZ(2)
@@ -1004,7 +1004,7 @@ class TestTensorExpvalBroadcasted:
 
     def test_pauliz_hadamard_broadcasted(self, theta, phi, varphi, tol):
         """Test that a tensor product involving PauliZ and PauliY and hadamard works correctly"""
-        dev = qml.device("default.qubit", wires=3)
+        dev = qml.device("default.qubit.legacy", wires=3)
         obs = qml.PauliZ(0) @ qml.Hadamard(1) @ qml.PauliY(2)
 
         dev.reset()
@@ -1027,7 +1027,7 @@ class TestTensorExpvalBroadcasted:
 
     def test_hermitian_broadcasted(self, theta, phi, varphi, tol):
         """Test that a tensor product involving qml.Hermitian works correctly"""
-        dev = qml.device("default.qubit", wires=3)
+        dev = qml.device("default.qubit.legacy", wires=3)
         dev.reset()
 
         A = np.array(
@@ -1065,7 +1065,7 @@ class TestTensorExpvalBroadcasted:
 
     def test_hermitian_hermitian_broadcasted(self, theta, phi, varphi, tol):
         """Test that a tensor product involving two Hermitian matrices works correctly"""
-        dev = qml.device("default.qubit", wires=3)
+        dev = qml.device("default.qubit.legacy", wires=3)
 
         A1 = np.array([[1, 2], [2, 4]])
 
@@ -1114,7 +1114,7 @@ class TestTensorExpvalBroadcasted:
 
     def test_hermitian_identity_expectation_broadcasted(self, theta, phi, varphi, tol):
         """Test that a tensor product involving an Hermitian matrix and the identity works correctly"""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         A = np.array(
             [[1.02789352, 1.61296440 - 0.3498192j], [1.61296440 + 0.3498192j, 1.23920938 + 0j]]
@@ -1138,7 +1138,7 @@ class TestTensorExpvalBroadcasted:
 
     def test_hermitian_two_wires_identity_expectation_broadcasted(self, theta, phi, varphi, tol):
         """Test that a tensor product involving an Hermitian matrix for two wires and the identity works correctly"""
-        dev = qml.device("default.qubit", wires=3)
+        dev = qml.device("default.qubit.legacy", wires=3)
 
         A = np.array(
             [[1.02789352, 1.61296440 - 0.3498192j], [1.61296440 + 0.3498192j, 1.23920938 + 0j]]
@@ -1169,7 +1169,7 @@ class TestTensorVarBroadcasted:
 
     def test_paulix_pauliy_broadcasted(self, theta, phi, varphi, tol):
         """Test that a tensor product involving PauliX and PauliY works correctly"""
-        dev = qml.device("default.qubit", wires=3)
+        dev = qml.device("default.qubit.legacy", wires=3)
 
         obs = qml.PauliX(0) @ qml.PauliY(2)
 
@@ -1199,7 +1199,7 @@ class TestTensorVarBroadcasted:
 
     def test_pauliz_hadamard_broadcasted(self, theta, phi, varphi, tol):
         """Test that a tensor product involving PauliZ and PauliY and hadamard works correctly"""
-        dev = qml.device("default.qubit", wires=3)
+        dev = qml.device("default.qubit.legacy", wires=3)
         obs = qml.PauliZ(0) @ qml.Hadamard(1) @ qml.PauliY(2)
 
         dev.reset()
@@ -1227,7 +1227,7 @@ class TestTensorVarBroadcasted:
 
     def test_hermitian_broadcasted(self, theta, phi, varphi, tol):
         """Test that a tensor product involving qml.Hermitian works correctly"""
-        dev = qml.device("default.qubit", wires=3)
+        dev = qml.device("default.qubit.legacy", wires=3)
 
         A = np.array(
             [
@@ -1295,7 +1295,7 @@ class TestTensorSampleBroadcasted:
 
     def test_paulix_pauliy_broadcasted(self, theta, phi, varphi, tol_stochastic):
         """Test that a tensor product involving PauliX and PauliY works correctly"""
-        dev = qml.device("default.qubit", wires=3, shots=int(1e6))
+        dev = qml.device("default.qubit.legacy", wires=3, shots=int(1e6))
 
         obs = qml.PauliX(0) @ qml.PauliY(2)
 
@@ -1337,7 +1337,7 @@ class TestTensorSampleBroadcasted:
 
     def test_pauliz_hadamard_broadcasted(self, theta, phi, varphi, tol_stochastic):
         """Test that a tensor product involving PauliZ and PauliY and hadamard works correctly"""
-        dev = qml.device("default.qubit", wires=3, shots=int(1e6))
+        dev = qml.device("default.qubit.legacy", wires=3, shots=int(1e6))
         obs = qml.PauliZ(0) @ qml.Hadamard(1) @ qml.PauliY(2)
         dev.apply(
             [
@@ -1375,7 +1375,7 @@ class TestTensorSampleBroadcasted:
 
     def test_hermitian_broadcasted(self, theta, phi, varphi, tol_stochastic):
         """Test that a tensor product involving qml.Hermitian works correctly"""
-        dev = qml.device("default.qubit", wires=3, shots=int(1e6))
+        dev = qml.device("default.qubit.legacy", wires=3, shots=int(1e6))
 
         A = 0.1 * np.array(
             [
@@ -1490,7 +1490,7 @@ class TestDtypePreservedBroadcasted:
         examples.
         """
 
-        dev = qml.device("default.qubit", wires=4, r_dtype=r_dtype, c_dtype=c_dtype)
+        dev = qml.device("default.qubit.legacy", wires=4, r_dtype=r_dtype, c_dtype=c_dtype)
 
         n_wires = op.num_wires
         n_params = op.num_params
@@ -1507,7 +1507,7 @@ class TestDtypePreservedBroadcasted:
             return qml.state()
 
         res = circuit()
-        assert res.dtype == c_dtype
+        assert res.dtype == c_dtype  # pylint:disable=no-member
 
     @pytest.mark.parametrize(
         "measurement",
@@ -1522,7 +1522,7 @@ class TestDtypePreservedBroadcasted:
         """Test that the default qubit plugin provides correct result for a simple circuit"""
         p = np.array([0.543, 0.622, 1.3])
 
-        dev = qml.device("default.qubit", wires=3, r_dtype=r_dtype, c_dtype=c_dtype)
+        dev = qml.device("default.qubit.legacy", wires=3, r_dtype=r_dtype, c_dtype=c_dtype)
 
         @qml.qnode(dev, diff_method="parameter-shift")
         def circuit(x):
@@ -1537,7 +1537,7 @@ class TestDtypePreservedBroadcasted:
         p = np.array([0.543, 0.622, 1.3])
         m = qml.state()
 
-        dev = qml.device("default.qubit", wires=3, r_dtype=r_dtype, c_dtype=c_dtype)
+        dev = qml.device("default.qubit.legacy", wires=3, r_dtype=r_dtype, c_dtype=c_dtype)
 
         @qml.qnode(dev, diff_method="parameter-shift")
         def circuit(x):
@@ -1558,8 +1558,8 @@ class TestProbabilityIntegrationBroadcasted:
 
     def test_probability_broadcasted(self, tol):
         """Test that the probability function works for finite and infinite shots"""
-        dev = qml.device("default.qubit", wires=2, shots=1000)
-        dev_analytic = qml.device("default.qubit", wires=2, shots=None)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=1000)
+        dev_analytic = qml.device("default.qubit.legacy", wires=2, shots=None)
 
         x = np.array([[0.2, 0.5, 0.4], [0.9, 0.8, 0.3]])
 
@@ -1582,7 +1582,7 @@ class TestWiresIntegrationBroadcasted:
 
     def make_circuit_probs(self, wires):
         """Factory for a qnode returning probabilities using arbitrary wire labels."""
-        dev = qml.device("default.qubit", wires=wires)
+        dev = qml.device("default.qubit.legacy", wires=wires)
         n_wires = len(wires)
 
         @qml.qnode(dev, diff_method="parameter-shift")
@@ -1619,7 +1619,7 @@ class TestApplyOpsBroadcasted:
     gates in DefaultQubit."""
 
     broadcasted_state = np.arange(2**4 * 3, dtype=np.complex128).reshape((3, 2, 2, 2, 2))
-    dev = qml.device("default.qubit", wires=4)
+    dev = qml.device("default.qubit.legacy", wires=4)
 
     single_qubit_ops = [
         (qml.PauliX, dev._apply_x),
@@ -1746,7 +1746,7 @@ class TestApplyOperationBroadcasted:
         This test provides a new internal function that `default.qubit` uses to
         apply `PauliX` (rather than redefining the gate itself).
         """
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
 
         test_state = np.array([[1, 0], [INVSQ2, INVSQ2], [0, 1]])
         # Create a dummy operation
@@ -1765,7 +1765,7 @@ class TestApplyOperationBroadcasted:
     def test_diagonal_operation_case_broadcasted(self, monkeypatch):
         """Tests the case when the operation to be applied is
         diagonal in the computational basis and the _apply_diagonal_unitary method is used."""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
         par = 0.3
 
         test_state = np.array([[1, 0], [INVSQ2, INVSQ2], [0, 1]])
@@ -1791,7 +1791,7 @@ class TestApplyOperationBroadcasted:
     def test_apply_einsum_case_broadcasted(self, monkeypatch):
         """Tests the case when np.einsum is used to apply an operation in
         default.qubit."""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
 
         test_state = np.array([[1, 0], [INVSQ2, INVSQ2], [0, 1]])
         wires = 0
@@ -1830,7 +1830,7 @@ class TestApplyOperationBroadcasted:
     def test_apply_tensordot_case_broadcasted(self, monkeypatch):
         """Tests the case when np.tensordot is used to apply an operation in
         default.qubit."""
-        dev = qml.device("default.qubit", wires=3)
+        dev = qml.device("default.qubit.legacy", wires=3)
 
         test_state = np.array([[1, 0], [INVSQ2, INVSQ2], [0, 1]])
         wires = [0, 1, 2]
@@ -1869,7 +1869,7 @@ class TestApplyOperationBroadcasted:
 
     def test_identity_skipped_broadcasted(self, mocker):
         """Test that applying the identity operation does not perform any additional computations."""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
 
         starting_state = np.array([[1, 0], [INVSQ2, INVSQ2], [0, 1]])
         op = qml.Identity(0)
@@ -1891,7 +1891,7 @@ class TestHamiltonianSupportBroadcasted:
 
     def test_do_not_split_analytic_broadcasted(self, mocker):
         """Tests that the Hamiltonian is not split for shots=None."""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
         Ham = qml.Hamiltonian(np.array([0.1, 0.2]), [qml.PauliX(0), qml.PauliZ(1)])
 
         @qml.qnode(dev, diff_method="parameter-shift", interface=None)
@@ -1907,7 +1907,7 @@ class TestHamiltonianSupportBroadcasted:
 
     def test_split_finite_shots_broadcasted(self, mocker):
         """Tests that the Hamiltonian is split for finite shots."""
-        dev = qml.device("default.qubit", wires=2, shots=10)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=10)
         spy = mocker.spy(dev, "expval")
 
         ham = qml.Hamiltonian(np.array([0.1, 0.2]), [qml.PauliX(0), qml.PauliZ(1)])

--- a/tests/devices/test_default_qubit_legacy_broadcasting.py
+++ b/tests/devices/test_default_qubit_legacy_broadcasting.py
@@ -462,7 +462,7 @@ class TestApplyBroadcasted:
         with pytest.raises(
             DeviceError,
             match="Operation StatePrep cannot be used after other Operations have already been applied "
-            "on a default.qubit.legacy device.",
+            "on a default.qubit device.",
         ):
             qubit_device_2_wires.apply([qml.RZ(0.5, wires=[0]), vec])
 
@@ -491,7 +491,7 @@ class TestApplyBroadcasted:
         with pytest.raises(
             DeviceError,
             match="Operation BasisState cannot be used after other Operations have already been applied "
-            "on a default.qubit.legacy device.",
+            "on a default.qubit device.",
         ):
             qubit_device_2_wires.apply([vec])
 

--- a/tests/devices/test_default_qubit_tf.py
+++ b/tests/devices/test_default_qubit_tf.py
@@ -1795,8 +1795,8 @@ class TestPassthruIntegration:
                 qml.CNOT(wires=[i, i + 1])
             return qml.expval(qml.PauliZ(0)), qml.var(qml.PauliZ(1))
 
-        dev1 = qml.device("default.qubit", wires=3)
-        dev2 = qml.device("default.qubit", wires=3)
+        dev1 = qml.device("default.qubit.legacy", wires=3)
+        dev2 = qml.device("default.qubit.legacy", wires=3)
 
         def cost(x):
             return qml.math.stack(circuit(x))

--- a/tests/devices/test_default_qubit_torch.py
+++ b/tests/devices/test_default_qubit_torch.py
@@ -1962,7 +1962,7 @@ class TestPassthruIntegration:
             return qml.expval(qml.PauliZ(0))  # , qml.var(qml.PauliZ(1))
 
         dev1 = qml.device("default.qubit.torch", wires=3, torch_device=torch_device)
-        dev2 = qml.device("default.qubit", wires=3)
+        dev2 = qml.device("default.qubit.legacy", wires=3)
 
         circuit1 = qml.QNode(circuit, dev1, diff_method="backprop", interface="torch")
         circuit2 = qml.QNode(circuit, dev2, diff_method="parameter-shift")

--- a/tests/gradients/core/test_adjoint_diff.py
+++ b/tests/gradients/core/test_adjoint_diff.py
@@ -26,7 +26,7 @@ class TestAdjointJacobian:
     @pytest.fixture
     def dev(self):
         """Fixture that creates a device with two wires."""
-        return qml.device("default.qubit", wires=2)
+        return qml.device("default.qubit.legacy", wires=2)
 
     def test_not_expval(self, dev):
         """Test if a QuantumFunctionError is raised for a tape with measurements that are not
@@ -43,7 +43,7 @@ class TestAdjointJacobian:
     def test_finite_shots_warns(self):
         """Tests warning raised when finite shots specified"""
 
-        dev = qml.device("default.qubit", wires=1, shots=10)
+        dev = qml.device("default.qubit.legacy", wires=1, shots=10)
 
         with qml.queuing.AnnotatedQueue() as q:
             qml.expval(qml.PauliZ(0))
@@ -88,7 +88,7 @@ class TestAdjointJacobian:
         """Test attempting to compute the gradient of a tape that obtains the
         expectation value of a Hermitian operator emits a warning if the
         parameters to Hermitian are trainable."""
-        dev = qml.device("default.qubit", wires=3)
+        dev = qml.device("default.qubit.legacy", wires=3)
 
         mx = qml.matrix(qml.PauliX(0) @ qml.PauliY(2))
         with qml.queuing.AnnotatedQueue() as q:
@@ -193,7 +193,7 @@ class TestAdjointJacobian:
 
     def test_multiple_rx_gradient(self, tol):
         """Tests that the gradient of multiple RX gates in a circuit yields the correct result."""
-        dev = qml.device("default.qubit", wires=3)
+        dev = qml.device("default.qubit.legacy", wires=3)
         params = np.array([np.pi, np.pi / 2, np.pi / 3])
 
         with qml.queuing.AnnotatedQueue() as q:
@@ -331,7 +331,7 @@ class TestAdjointJacobian:
     def test_gradient_of_tape_with_hermitian(self, tol):
         """Test that computing the gradient of a tape that obtains the
         expectation value of a Hermitian operator works correctly."""
-        dev = qml.device("default.qubit", wires=3)
+        dev = qml.device("default.qubit.legacy", wires=3)
 
         a, b, c = [0.5, 0.3, -0.7]
 

--- a/tests/interfaces/test_autograd.py
+++ b/tests/interfaces/test_autograd.py
@@ -41,7 +41,7 @@ class TestAutogradExecuteUnitTests:
         except KeyError:
             pass
 
-        dev = qml.device("default.qubit", wires=2, shots=None)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=None)
 
         with qml.queuing.AnnotatedQueue() as q:
             qml.expval(qml.PauliY(1))
@@ -60,7 +60,7 @@ class TestAutogradExecuteUnitTests:
 
         a = np.array([0.1, 0.2], requires_grad=True)
 
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
 
         def cost(a, device):
             with qml.queuing.AnnotatedQueue() as q:
@@ -86,7 +86,7 @@ class TestAutogradExecuteUnitTests:
         is used with grad_on_execution=True"""
         a = np.array([0.1, 0.2], requires_grad=True)
 
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
 
         def cost(a, device):
             with qml.queuing.AnnotatedQueue() as q:
@@ -106,7 +106,7 @@ class TestAutogradExecuteUnitTests:
         """Test that an error is raised if the interface is unknown"""
         a = np.array([0.1, 0.2], requires_grad=True)
 
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
 
         def cost(a, device):
             with qml.queuing.AnnotatedQueue() as q:
@@ -122,7 +122,7 @@ class TestAutogradExecuteUnitTests:
 
     def test_grad_on_execution(self, mocker):
         """Test that grad on execution uses the `device.execute_and_gradients` pathway"""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
         spy = mocker.spy(dev, "execute_and_gradients")
 
         def cost(a):
@@ -148,7 +148,7 @@ class TestAutogradExecuteUnitTests:
 
     def test_no_gradients_on_execution(self, mocker):
         """Test that no grad on execution uses the `device.batch_execute` and `device.gradients` pathway"""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
         spy_execute = mocker.spy(qml.devices.DefaultQubit, "batch_execute")
         spy_gradients = mocker.spy(qml.devices.DefaultQubit, "gradients")
 
@@ -184,7 +184,7 @@ class TestBatchTransformExecution:
 
     def test_no_batch_transform(self, mocker):
         """Test that batch transforms can be disabled and enabled"""
-        dev = qml.device("default.qubit", wires=2, shots=100000)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=100000)
 
         H = qml.PauliZ(0) @ qml.PauliZ(1) - qml.PauliX(0)
         x = 0.6
@@ -214,7 +214,7 @@ class TestBatchTransformExecution:
     def test_batch_transform_dynamic_shots(self):
         """Tests that the batch transform considers the number of shots for the execution, not those
         statically on the device."""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
         H = 2.0 * qml.PauliZ(0)
         qscript = qml.tape.QuantumScript(measurements=[qml.expval(H)])
         res = qml.execute([qscript], dev, interface=None, override_shots=10)
@@ -226,7 +226,7 @@ class TestCaching:
 
     def test_cache_maxsize(self, mocker):
         """Test the cachesize property of the cache"""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
         spy = mocker.spy(qml.interfaces, "cache_execute")
 
         def cost(a, cachesize):
@@ -248,7 +248,7 @@ class TestCaching:
 
     def test_custom_cache(self, mocker):
         """Test the use of a custom cache object"""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
         spy = mocker.spy(qml.interfaces, "cache_execute")
 
         def cost(a, cache):
@@ -270,7 +270,7 @@ class TestCaching:
     def test_caching_param_shift(self, tol):
         """Test that, when using parameter-shift transform,
         caching reduces the number of evaluations to their optimum."""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
 
         def cost(a, cache):
             with qml.queuing.AnnotatedQueue() as q:
@@ -315,7 +315,7 @@ class TestCaching:
         """Test that, when using parameter-shift transform,
         caching reduces the number of evaluations to their optimum
         when computing Hessians."""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
         params = np.arange(1, num_params + 1) / 10
 
         N = len(params)
@@ -378,7 +378,7 @@ class TestCaching:
     def test_caching_adjoint_no_grad_on_execution(self):
         """Test that caching reduces the number of adjoint evaluations
         when the grads is not on execution."""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
         params = np.array([0.1, 0.2, 0.3])
 
         def cost(a, cache):
@@ -418,7 +418,7 @@ class TestCaching:
         """Tests that the backward pass is one single batch, not a bunch of batches, when parameter shift
         is requested for multiple tapes."""
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         def f(x):
             tape1 = qml.tape.QuantumScript([qml.RX(x, 0)], [qml.probs(wires=0)])
@@ -440,7 +440,7 @@ class TestCaching:
         """Tests that the backward pass is one single batch, not a bunch of batches, when parameter shift
         derivatives are requested for a a tape that the device split into batches."""
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         H = qml.Hamiltonian([1, 1], [qml.PauliY(0), qml.PauliZ(0)], grouping_type="qwc")
 
@@ -480,7 +480,7 @@ class TestAutogradExecuteIntegration:
 
     def test_execution(self, execute_kwargs):
         """Test execution"""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
 
         def cost(a, b):
             with qml.queuing.AnnotatedQueue() as q1:
@@ -508,7 +508,7 @@ class TestAutogradExecuteIntegration:
     def test_scalar_jacobian(self, execute_kwargs, tol):
         """Test scalar jacobian calculation"""
         a = np.array(0.1, requires_grad=True)
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         def cost(a):
             with qml.queuing.AnnotatedQueue() as q:
@@ -548,7 +548,7 @@ class TestAutogradExecuteIntegration:
             tape = qml.tape.QuantumScript.from_queue(q)
             return autograd.numpy.hstack(qml.execute([tape], device, **execute_kwargs)[0])
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         res = cost(a, b, device=dev)
         expected = [np.cos(a), -np.cos(a) * np.sin(b)]
@@ -570,7 +570,7 @@ class TestAutogradExecuteIntegration:
         if execute_kwargs["gradient_fn"] == "device":
             pytest.skip("Adjoint differentiation does not yet support probabilities")
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         def cost(params):
             with qml.queuing.AnnotatedQueue() as q1:
@@ -614,7 +614,7 @@ class TestAutogradExecuteIntegration:
     @pytest.mark.filterwarnings("ignore:Attempted to compute the gradient")
     def test_tapes_with_different_return_size(self, execute_kwargs):
         """Test that tapes wit different can be executed and differentiated."""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         def cost(params):
             with qml.queuing.AnnotatedQueue() as q1:
@@ -652,7 +652,7 @@ class TestAutogradExecuteIntegration:
         a = np.array(0.1, requires_grad=True)
         b = np.array(0.2, requires_grad=True)
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         with qml.queuing.AnnotatedQueue() as q:
             qml.RY(a, wires=0)
@@ -705,7 +705,7 @@ class TestAutogradExecuteIntegration:
             tape = qml.tape.QuantumScript.from_queue(q)
             return qml.execute([tape], device, **execute_kwargs)[0]
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
         res = qml.jacobian(cost)(a, b, c, device=dev)
 
         # Only two arguments are trainable
@@ -728,7 +728,7 @@ class TestAutogradExecuteIntegration:
             tape = qml.tape.QuantumScript.from_queue(q)
             return autograd.numpy.hstack(qml.execute([tape], device, **execute_kwargs)[0])
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
         res = cost(a, b, device=dev)
         assert res.shape == (2,)
 
@@ -758,7 +758,7 @@ class TestAutogradExecuteIntegration:
             tape = qml.tape.QuantumScript.from_queue(q)
             return qml.execute([tape], device, **execute_kwargs)[0]
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
         res = cost(a, U, device=dev)
         assert isinstance(res, np.ndarray)
         assert np.allclose(res, -np.cos(a), atol=tol, rtol=0)
@@ -794,7 +794,7 @@ class TestAutogradExecuteIntegration:
         a = np.array(0.1, requires_grad=False)
         p = np.array([0.1, 0.2, 0.3], requires_grad=True)
 
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
         res = cost_fn(a, p, device=dev)
         expected = np.cos(a) * np.cos(p[1]) * np.sin(p[0]) + np.sin(a) * (
             np.cos(p[2]) * np.sin(p[1]) + np.cos(p[0]) * np.cos(p[1]) * np.sin(p[2])
@@ -833,7 +833,7 @@ class TestAutogradExecuteIntegration:
             tape = qml.tape.QuantumScript.from_queue(q)
             return autograd.numpy.hstack(qml.execute([tape], device, **execute_kwargs)[0])
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
         x = np.array(0.543, requires_grad=True)
         y = np.array(-0.654, requires_grad=True)
 
@@ -894,7 +894,7 @@ class TestAutogradExecuteIntegration:
             tape = qml.tape.QuantumScript.from_queue(q)
             return autograd.numpy.hstack(qml.execute([tape], device, **execute_kwargs)[0])
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
         x = np.array(0.543, requires_grad=True)
         y = np.array(-0.654, requires_grad=True)
 
@@ -936,7 +936,7 @@ class TestAutogradExecuteIntegration:
             return qml.execute([tape], device, **execute_kwargs)[0]
 
         shots = 10
-        dev = qml.device("default.qubit", wires=2, shots=shots)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=shots)
         res = cost(device=dev)
         assert isinstance(res, tuple)
         assert len(res) == 2
@@ -1056,7 +1056,7 @@ class TestHigherOrderDerivatives:
     def test_max_diff(self, tol):
         """Test that setting the max_diff parameter blocks higher-order
         derivatives"""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
         params = np.array([0.543, -0.654], requires_grad=True)
 
         def cost_fn(x):
@@ -1100,7 +1100,7 @@ class TestOverridingShots:
 
     def test_changing_shots(self, mocker, tol):
         """Test that changing shots works on execution"""
-        dev = qml.device("default.qubit", wires=2, shots=None)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=None)
         a, b = np.array([0.543, -0.654], requires_grad=True)
 
         with qml.queuing.AnnotatedQueue() as q:
@@ -1130,7 +1130,7 @@ class TestOverridingShots:
 
     def test_overriding_shots_with_same_value(self, mocker):
         """Overriding shots with the same value as the device will have no effect"""
-        dev = qml.device("default.qubit", wires=2, shots=123)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=123)
         a, b = np.array([0.543, -0.654], requires_grad=True)
 
         with qml.queuing.AnnotatedQueue() as q:
@@ -1161,7 +1161,7 @@ class TestOverridingShots:
     def test_overriding_device_with_shot_vector(self):
         """Overriding a device that has a batch of shots set
         results in original shots being returned after execution"""
-        dev = qml.device("default.qubit", wires=2, shots=[10, (1, 3), 5])
+        dev = qml.device("default.qubit.legacy", wires=2, shots=[10, (1, 3), 5])
 
         assert dev.shots == 18
         assert dev._shot_vector == [(10, 1), (1, 3), (5, 1)]
@@ -1192,7 +1192,7 @@ class TestOverridingShots:
         """Test that temporarily setting the shots works
         for gradient computations"""
         # TODO: Update here when shot vectors are supported
-        dev = qml.device("default.qubit", wires=2, shots=None)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=None)
         a, b = np.array([0.543, -0.654], requires_grad=True)
 
         def cost_fn(a, b, shots):
@@ -1285,7 +1285,7 @@ class TestHamiltonianWorkflows:
         coeffs1 = np.array([0.1, 0.2, 0.3], requires_grad=False)
         coeffs2 = np.array([0.7], requires_grad=False)
         weights = np.array([0.4, 0.5], requires_grad=True)
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         res = cost_fn(weights, coeffs1, coeffs2, dev=dev)
         expected = self.cost_fn_expected(weights, coeffs1, coeffs2)
@@ -1301,7 +1301,7 @@ class TestHamiltonianWorkflows:
         coeffs1 = np.array([0.1, 0.2, 0.3], requires_grad=True)
         coeffs2 = np.array([0.7], requires_grad=True)
         weights = np.array([0.4, 0.5], requires_grad=True)
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         res = cost_fn(weights, coeffs1, coeffs2, dev=dev)
         expected = self.cost_fn_expected(weights, coeffs1, coeffs2)

--- a/tests/interfaces/test_autograd_qnode.py
+++ b/tests/interfaces/test_autograd_qnode.py
@@ -22,30 +22,30 @@ from pennylane import numpy as np
 from pennylane import qnode
 
 qubit_device_and_diff_method = [
-    ["default.qubit", "finite-diff", False],
-    ["default.qubit", "parameter-shift", False],
-    ["default.qubit", "backprop", True],
-    ["default.qubit", "adjoint", True],
-    ["default.qubit", "adjoint", False],
-    ["default.qubit", "spsa", False],
-    ["default.qubit", "hadamard", False],
+    ["default.qubit.legacy", "finite-diff", False],
+    ["default.qubit.legacy", "parameter-shift", False],
+    ["default.qubit.legacy", "backprop", True],
+    ["default.qubit.legacy", "adjoint", True],
+    ["default.qubit.legacy", "adjoint", False],
+    ["default.qubit.legacy", "spsa", False],
+    ["default.qubit.legacy", "hadamard", False],
 ]
 
 interface_qubit_device_and_diff_method = [
-    ["autograd", "default.qubit", "finite-diff", False],
-    ["autograd", "default.qubit", "parameter-shift", False],
-    ["autograd", "default.qubit", "backprop", True],
-    ["autograd", "default.qubit", "adjoint", True],
-    ["autograd", "default.qubit", "adjoint", False],
-    ["autograd", "default.qubit", "spsa", False],
-    ["autograd", "default.qubit", "hadamard", False],
-    ["auto", "default.qubit", "finite-diff", False],
-    ["auto", "default.qubit", "parameter-shift", False],
-    ["auto", "default.qubit", "backprop", True],
-    ["auto", "default.qubit", "adjoint", True],
-    ["auto", "default.qubit", "adjoint", False],
-    ["auto", "default.qubit", "spsa", False],
-    ["auto", "default.qubit", "hadamard", False],
+    ["autograd", "default.qubit.legacy", "finite-diff", False],
+    ["autograd", "default.qubit.legacy", "parameter-shift", False],
+    ["autograd", "default.qubit.legacy", "backprop", True],
+    ["autograd", "default.qubit.legacy", "adjoint", True],
+    ["autograd", "default.qubit.legacy", "adjoint", False],
+    ["autograd", "default.qubit.legacy", "spsa", False],
+    ["autograd", "default.qubit.legacy", "hadamard", False],
+    ["auto", "default.qubit.legacy", "finite-diff", False],
+    ["auto", "default.qubit.legacy", "parameter-shift", False],
+    ["auto", "default.qubit.legacy", "backprop", True],
+    ["auto", "default.qubit.legacy", "adjoint", True],
+    ["auto", "default.qubit.legacy", "adjoint", False],
+    ["auto", "default.qubit.legacy", "spsa", False],
+    ["auto", "default.qubit.legacy", "hadamard", False],
 ]
 
 pytestmark = pytest.mark.autograd
@@ -71,7 +71,7 @@ class TestQNode:
         if diff_method != "parameter-shift":
             pytest.skip("Test only supports parameter-shift")
 
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
 
         @qnode(dev, interface=interface, diff_method=diff_method)
         def circuit(x, y):
@@ -301,7 +301,7 @@ class TestQNode:
 
         a = np.array([0.1, 0.2], requires_grad=True)
 
-        dev = qml.device("default.qubit", wires=wires)
+        dev = qml.device("default.qubit.legacy", wires=wires)
 
         @qnode(dev, interface=interface, diff_method=diff_method, **kwargs)
         def circuit(a):
@@ -329,7 +329,7 @@ class TestQNode:
         a = np.array(0.1, requires_grad=True)
         b = np.array(0.2, requires_grad=True)
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         @qnode(dev, interface=interface, diff_method=diff_method)
         def circuit(a, b):
@@ -554,7 +554,7 @@ class TestShotsIntegration:
 
     def test_changing_shots(self, mocker, tol):
         """Test that changing shots works on execution"""
-        dev = qml.device("default.qubit", wires=2, shots=None)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=None)
         a, b = np.array([0.543, -0.654], requires_grad=True)
 
         @qnode(dev, diff_method=qml.gradients.param_shift)
@@ -586,7 +586,7 @@ class TestShotsIntegration:
     def test_gradient_integration(self):
         """Test that temporarily setting the shots works
         for gradient computations"""
-        dev = qml.device("default.qubit", wires=2, shots=None)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=None)
         a, b = np.array([0.543, -0.654], requires_grad=True)
 
         @qnode(dev, diff_method=qml.gradients.param_shift)
@@ -609,7 +609,7 @@ class TestShotsIntegration:
 
     def test_update_diff_method(self, mocker):
         """Test that temporarily setting the shots updates the diff method"""
-        dev = qml.device("default.qubit", wires=2, shots=100)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=100)
         a, b = np.array([0.543, -0.654], requires_grad=True)
 
         spy = mocker.spy(qml, "execute")
@@ -934,7 +934,7 @@ class TestQubitIntegration:
             qml.CNOT(wires=[1, 2])
             return qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliY(2))
 
-        dev2 = qml.device("default.qubit", wires=num_wires)
+        dev2 = qml.device("default.qubit.legacy", wires=num_wires)
 
         @qnode(dev2, interface=interface, diff_method=diff_method)
         def circuit2(data, weights):
@@ -1562,7 +1562,7 @@ class TestCV:
 
 def test_adjoint_reuse_device_state(mocker):
     """Tests that the autograd interface reuses the device state for adjoint differentiation"""
-    dev = qml.device("default.qubit", wires=1)
+    dev = qml.device("default.qubit.legacy", wires=1)
 
     @qnode(dev, diff_method="adjoint")
     def circ(x):
@@ -1773,7 +1773,7 @@ class TestSample:
 
     def test_backprop_error(self):
         """Test that sampling in backpropagation grad_on_execution raises an error"""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         @qnode(dev, diff_method="backprop")
         def circuit():
@@ -1787,7 +1787,7 @@ class TestSample:
         """Test that the sample function outputs samples of the right size"""
         n_sample = 10
 
-        dev = qml.device("default.qubit", wires=2, shots=n_sample)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=n_sample)
 
         @qnode(dev)
         def circuit():
@@ -1810,7 +1810,7 @@ class TestSample:
 
         n_sample = 10
 
-        dev = qml.device("default.qubit", wires=3, shots=n_sample)
+        dev = qml.device("default.qubit.legacy", wires=3, shots=n_sample)
 
         @qnode(dev, diff_method="parameter-shift")
         def circuit():
@@ -1832,7 +1832,7 @@ class TestSample:
         """Test the return type and shape of sampling a single wire"""
         n_sample = 10
 
-        dev = qml.device("default.qubit", wires=1, shots=n_sample)
+        dev = qml.device("default.qubit.legacy", wires=1, shots=n_sample)
 
         @qnode(dev)
         def circuit():
@@ -1850,7 +1850,7 @@ class TestSample:
         where a rectangular array is expected"""
         n_sample = 10
 
-        dev = qml.device("default.qubit", wires=3, shots=n_sample)
+        dev = qml.device("default.qubit.legacy", wires=3, shots=n_sample)
 
         @qnode(dev)
         def circuit():
@@ -2388,7 +2388,7 @@ class TestReturn:
         assert hess.shape == (3, 2, 2)
 
 
-@pytest.mark.parametrize("dev_name", ["default.qubit", "default.mixed"])
+@pytest.mark.parametrize("dev_name", ["default.qubit.legacy", "default.mixed"])
 def test_no_ops(dev_name):
     """Test that the return value of the QNode matches in the interface
     even if there are no ops"""

--- a/tests/interfaces/test_autograd_qnode_shot_vector.py
+++ b/tests/interfaces/test_autograd_qnode_shot_vector.py
@@ -29,9 +29,9 @@ SEED_FOR_SPSA = 42
 spsa_kwargs = {"h": 0.05, "num_directions": 20, "sampler_rng": np.random.default_rng(SEED_FOR_SPSA)}
 
 qubit_device_and_diff_method = [
-    ["default.qubit", "finite-diff", {"h": 0.05}],
-    ["default.qubit", "parameter-shift", {}],
-    ["default.qubit", "spsa", spsa_kwargs],
+    ["default.qubit.legacy", "finite-diff", {"h": 0.05}],
+    ["default.qubit.legacy", "parameter-shift", {}],
+    ["default.qubit.legacy", "spsa", spsa_kwargs],
 ]
 
 TOLS = {

--- a/tests/interfaces/test_jax.py
+++ b/tests/interfaces/test_jax.py
@@ -35,7 +35,7 @@ class TestJaxExecuteUnitTests:
 
         a = jax.numpy.array([0.1, 0.2])
 
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
 
         def cost(a, device):
             with qml.queuing.AnnotatedQueue() as q:
@@ -61,7 +61,7 @@ class TestJaxExecuteUnitTests:
         is used with grad_on_execution=True"""
         a = jax.numpy.array([0.1, 0.2])
 
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
 
         def cost(a, device):
             with qml.queuing.AnnotatedQueue() as q:
@@ -86,7 +86,7 @@ class TestJaxExecuteUnitTests:
         """Test that an error is raised if the interface is unknown"""
         a = jax.numpy.array([0.1, 0.2])
 
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
 
         def cost(a, device):
             with qml.queuing.AnnotatedQueue() as q:
@@ -107,7 +107,7 @@ class TestJaxExecuteUnitTests:
 
     def test_grad_on_execution(self, mocker):
         """Test that grad_on_execution uses the `device.execute_and_gradients` pathway"""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
         spy = mocker.spy(dev, "execute_and_gradients")
 
         def cost(params):
@@ -150,7 +150,7 @@ class TestJaxExecuteUnitTests:
 
     def test_no_grad_on_execution(self, mocker):
         """Test that no grad on execution uses the `device.batch_execute` and `device.gradients` pathway"""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
         spy_execute = mocker.spy(qml.devices.DefaultQubit, "batch_execute")
         spy_gradients = mocker.spy(qml.devices.DefaultQubit, "gradients")
 
@@ -185,7 +185,7 @@ class TestCaching:
 
     def test_cache_maxsize(self, mocker):
         """Test the cachesize property of the cache"""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
         spy = mocker.spy(qml.interfaces, "cache_execute")
 
         def cost(a, cachesize):
@@ -212,7 +212,7 @@ class TestCaching:
 
     def test_custom_cache(self, mocker):
         """Test the use of a custom cache object"""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
         spy = mocker.spy(qml.interfaces, "cache_execute")
 
         def cost(a, cache):
@@ -238,7 +238,7 @@ class TestCaching:
 
     def test_custom_cache_multiple(self, mocker):
         """Test the use of a custom cache object with multiple tapes"""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
         spy = mocker.spy(qml.interfaces, "cache_execute")
 
         a = jax.numpy.array(0.1)
@@ -274,7 +274,7 @@ class TestCaching:
     def test_caching_param_shift(self, tol):
         """Test that, when using parameter-shift transform,
         caching produces the optimum number of evaluations."""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
 
         def cost(a, cache):
             with qml.queuing.AnnotatedQueue() as q:
@@ -319,7 +319,7 @@ class TestCaching:
     def test_caching_adjoint_backward(self):
         """Test that caching produces the optimum number of adjoint evaluations
         when no grad on execution."""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
         params = jax.numpy.array([0.1, 0.2, 0.3])
 
         def cost(a, cache):
@@ -375,7 +375,7 @@ class TestJaxExecuteIntegration:
 
     def test_execution(self, execute_kwargs):
         """Test execution"""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
 
         def cost(a, b):
             with qml.queuing.AnnotatedQueue() as q1:
@@ -404,7 +404,7 @@ class TestJaxExecuteIntegration:
     def test_scalar_jacobian(self, execute_kwargs, tol):
         """Test scalar jacobian calculation"""
         a = jax.numpy.array(0.1)
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         def cost(a):
             with qml.queuing.AnnotatedQueue() as q:
@@ -436,7 +436,7 @@ class TestJaxExecuteIntegration:
         a = jax.numpy.array(0.1)
         b = jax.numpy.array(0.2)
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         with qml.queuing.AnnotatedQueue() as q:
             qml.RY(a, wires=0)
@@ -477,7 +477,7 @@ class TestJaxExecuteIntegration:
 
     def test_grad_with_different_grad_on_execution(self, execute_kwargs):
         """Test jax grad for adjoint diff method with different execution kwargs."""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
         params = jax.numpy.array([0.1, 0.2, 0.3])
         expected_results = jax.numpy.array([-0.3875172, -0.18884787, -0.38355705])
 
@@ -513,14 +513,14 @@ class TestJaxExecuteIntegration:
 
             return execute([tape], device, **execute_kwargs)[0]
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
         res = jax.grad(cost, argnums=(0, 1, 2))(a, b, c, device=dev)
         assert len(res) == 3
 
     def test_classical_processing_multiple_tapes(self, execute_kwargs):
         """Test classical processing within the quantum tape for multiple
         tapes"""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
         params = jax.numpy.array([0.3, 0.2])
 
         def cost_fn(x):
@@ -546,7 +546,7 @@ class TestJaxExecuteIntegration:
 
     def test_multiple_tapes_output(self, execute_kwargs):
         """Test the output types for the execution of multiple quantum tapes"""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
         params = jax.numpy.array([0.3, 0.2])
 
         def cost_fn(x):
@@ -588,7 +588,7 @@ class TestJaxExecuteIntegration:
             tape.trainable_params = [0]
             return execute([tape], device, **execute_kwargs)[0]
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
         res = cost(a, U, device=dev)
         assert np.allclose(res, -np.cos(a), atol=tol, rtol=0)
 
@@ -622,7 +622,7 @@ class TestJaxExecuteIntegration:
         a = jax.numpy.array(0.1)
         p = jax.numpy.array([0.1, 0.2, 0.3])
 
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
         res = cost_fn(a, p, device=dev)
         expected = np.cos(a) * np.cos(p[1]) * np.sin(p[0]) + np.sin(a) * (
             np.cos(p[2]) * np.sin(p[1]) + np.cos(p[0]) * np.cos(p[1]) * np.sin(p[2])
@@ -646,7 +646,7 @@ class TestJaxExecuteIntegration:
     def test_independent_expval(self, execute_kwargs):
         """Tests computing an expectation value that is independent of trainable
         parameters."""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
         params = jax.numpy.array([0.1, 0.2, 0.3])
 
         def cost(a, cache):
@@ -672,7 +672,7 @@ class TestVectorValued:
     def test_multiple_expvals(self, execute_kwargs):
         """Tests computing multiple expectation values in a tape."""
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
         params = jax.numpy.array([0.1, 0.2, 0.3])
 
         def cost(a, cache):
@@ -701,7 +701,7 @@ class TestVectorValued:
     def test_multiple_expvals_single_par(self, execute_kwargs):
         """Tests computing multiple expectation values in a tape with a single
         trainable parameter."""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
         params = jax.numpy.array([0.1])
 
         def cost(a, cache):
@@ -727,7 +727,7 @@ class TestVectorValued:
     def test_multi_tape_fwd(self, execute_kwargs):
         """Test the forward evaluation of a cost function that uses the output
         of multiple tapes that be vector-valued."""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
         params = jax.numpy.array([0.3, 0.2])
 
         def cost_fn(x):
@@ -773,7 +773,7 @@ class TestVectorValued:
             tape2 = qml.tape.QuantumScript.from_queue(q2)
             return qml.execute([tape1, tape2], device, **ek, interface=interface)
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
         x = jax.numpy.array(0.543)
         y = jax.numpy.array(-0.654)
 
@@ -830,7 +830,7 @@ class TestVectorValued:
             tape2 = qml.tape.QuantumScript.from_queue(q2)
             return qml.execute([tape1, tape2], device, **ek, interface=interface)
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
         x = jax.numpy.array(0.543)
         y = jax.numpy.array(-0.654)
 

--- a/tests/interfaces/test_jax_jit.py
+++ b/tests/interfaces/test_jax_jit.py
@@ -36,7 +36,7 @@ class TestJaxExecuteUnitTests:
 
         a = jax.numpy.array([0.1, 0.2])
 
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
 
         def cost(a, device):
             with qml.queuing.AnnotatedQueue() as q:
@@ -63,7 +63,7 @@ class TestJaxExecuteUnitTests:
         is used with grad_on_execution=True"""
         a = jax.numpy.array([0.1, 0.2])
 
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
 
         def cost(a, device):
             with qml.queuing.AnnotatedQueue() as q:
@@ -89,7 +89,7 @@ class TestJaxExecuteUnitTests:
         """Test that an error is raised if the interface is unknown"""
         a = jax.numpy.array([0.1, 0.2])
 
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
 
         def cost(a, device):
             with qml.queuing.AnnotatedQueue() as q:
@@ -111,7 +111,7 @@ class TestJaxExecuteUnitTests:
 
     def test_grad_on_execution(self, mocker):
         """Test that grad on execution uses the `device.execute_and_gradients` pathway"""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
         spy = mocker.spy(dev, "execute_and_gradients")
 
         def cost(a):
@@ -141,7 +141,7 @@ class TestJaxExecuteUnitTests:
 
     def test_no_gradients_on_execution(self, mocker):
         """Test that no grad on execution uses the `device.batch_execute` and `device.gradients` pathway"""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
         spy_execute = mocker.spy(qml.devices.DefaultQubit, "batch_execute")
         spy_gradients = mocker.spy(qml.devices.DefaultQubit, "gradients")
 
@@ -177,7 +177,7 @@ class TestCaching:
 
     def test_cache_maxsize(self, mocker):
         """Test the cachesize property of the cache"""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
         spy = mocker.spy(qml.interfaces, "cache_execute")
 
         def cost(a, cachesize):
@@ -205,7 +205,7 @@ class TestCaching:
 
     def test_custom_cache(self, mocker):
         """Test the use of a custom cache object"""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
         spy = mocker.spy(qml.interfaces, "cache_execute")
 
         def cost(a, cache):
@@ -232,7 +232,7 @@ class TestCaching:
 
     def test_custom_cache_multiple(self, mocker):
         """Test the use of a custom cache object with multiple tapes"""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
         spy = mocker.spy(qml.interfaces, "cache_execute")
 
         a = jax.numpy.array(0.1)
@@ -270,7 +270,7 @@ class TestCaching:
     def test_caching_param_shift(self, tol):
         """Test that, when using parameter-shift transform,
         caching produces the optimum number of evaluations."""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
 
         def cost(a, cache):
             with qml.queuing.AnnotatedQueue() as q:
@@ -316,7 +316,7 @@ class TestCaching:
     def test_caching_adjoint_backward(self):
         """Test that caching produces the optimum number of adjoint evaluations
         when mode=backward"""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
         params = jax.numpy.array([0.1, 0.2, 0.3])
 
         def cost(a, cache):
@@ -373,7 +373,7 @@ class TestJaxExecuteIntegration:
 
     def test_execution(self, execute_kwargs):
         """Test execution"""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
 
         def cost(a, b):
             with qml.queuing.AnnotatedQueue() as q1:
@@ -403,7 +403,7 @@ class TestJaxExecuteIntegration:
     def test_scalar_jacobian(self, execute_kwargs, tol):
         """Test scalar jacobian calculation"""
         a = jax.numpy.array(0.1)
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         def cost(a):
             with qml.queuing.AnnotatedQueue() as q:
@@ -436,7 +436,7 @@ class TestJaxExecuteIntegration:
         a = jax.numpy.array(0.1)
         b = jax.numpy.array(0.2)
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         with qml.queuing.AnnotatedQueue() as q:
             qml.RY(a, wires=0)
@@ -478,7 +478,7 @@ class TestJaxExecuteIntegration:
 
     def test_grad_with_backward_mode(self, execute_kwargs):
         """Test jax grad for adjoint diff method in backward mode"""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
         params = jax.numpy.array([0.1, 0.2, 0.3])
         expected_results = jax.numpy.array([-0.3875172, -0.18884787, -0.38355705])
 
@@ -517,14 +517,14 @@ class TestJaxExecuteIntegration:
 
             return execute([tape], device, **execute_kwargs)[0]
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
         res = jax.jit(jax.grad(cost, argnums=(0, 1, 2)), static_argnums=3)(a, b, c, device=dev)
         assert len(res) == 3
 
     def test_classical_processing_multiple_tapes(self, execute_kwargs):
         """Test classical processing within the quantum tape for multiple
         tapes"""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
         params = jax.numpy.array([0.3, 0.2])
 
         def cost_fn(x):
@@ -552,7 +552,7 @@ class TestJaxExecuteIntegration:
 
     def test_multiple_tapes_output(self, execute_kwargs):
         """Test the output types for the execution of multiple quantum tapes"""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
         params = jax.numpy.array([0.3, 0.2])
 
         def cost_fn(x):
@@ -596,7 +596,7 @@ class TestJaxExecuteIntegration:
             tape.trainable_params = [0]
             return execute([tape], device, **execute_kwargs)[0]
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
         res = jax.jit(cost, static_argnums=2)(a, U, device=dev)
         assert np.allclose(res, -np.cos(a), atol=tol, rtol=0)
 
@@ -627,7 +627,7 @@ class TestJaxExecuteIntegration:
         a = jax.numpy.array(0.1)
         p = jax.numpy.array([0.1, 0.2, 0.3])
 
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
         res = jax.jit(cost_fn, static_argnums=2)(a, p, device=dev)
         expected = np.cos(a) * np.cos(p[1]) * np.sin(p[0]) + np.sin(a) * (
             np.cos(p[2]) * np.sin(p[1]) + np.cos(p[0]) * np.cos(p[1]) * np.sin(p[2])
@@ -651,7 +651,7 @@ class TestJaxExecuteIntegration:
     def test_independent_expval(self, execute_kwargs):
         """Tests computing an expectation value that is independent of trainable
         parameters."""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
         params = jax.numpy.array([0.1, 0.2, 0.3])
 
         def cost(a, cache):
@@ -687,7 +687,7 @@ class TestVectorValuedJIT:
         if adjoint:
             pytest.skip("The adjoint diff method doesn't support probabilities.")
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
         params = jax.numpy.array([0.1, 0.2, 0.3])
 
         def cost(a, cache):
@@ -715,7 +715,7 @@ class TestVectorValuedJIT:
     def test_independent_expval(self, execute_kwargs):
         """Tests computing an expectation value that is independent of trainable
         parameters."""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
         params = jax.numpy.array([0.1, 0.2, 0.3])
 
         def cost(a, cache):
@@ -747,7 +747,7 @@ class TestVectorValuedJIT:
     def test_vector_valued_qnode(self, execute_kwargs, ret, out_dim, expected_type):
         """Tests the shape of vector-valued QNode results."""
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
         params = jax.numpy.array([0.1, 0.2, 0.3])
         grad_meth = (
             execute_kwargs["gradient_kwargs"]["method"]
@@ -786,7 +786,7 @@ class TestVectorValuedJIT:
 
     def test_qnode_sample(self, execute_kwargs):
         """Tests computing multiple expectation values in a tape."""
-        dev = qml.device("default.qubit", wires=2, shots=10)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=10)
         params = jax.numpy.array([0.1, 0.2, 0.3])
 
         grad_meth = (
@@ -814,7 +814,7 @@ class TestVectorValuedJIT:
 
     def test_multiple_expvals_grad(self, execute_kwargs):
         """Tests computing multiple expectation values in a tape."""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
         params = jax.numpy.array([0.1, 0.2, 0.3])
 
         def cost(a, cache):
@@ -861,7 +861,7 @@ class TestVectorValuedJIT:
 
             return qml.execute([tape1, tape2], device, **ek, interface=interface)[0]
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
         x = jax.numpy.array(0.543)
         y = jax.numpy.array(-0.654)
 

--- a/tests/interfaces/test_jax_jit_qnode.py
+++ b/tests/interfaces/test_jax_jit_qnode.py
@@ -20,13 +20,13 @@ from pennylane import numpy as np
 from pennylane import qnode
 
 qubit_device_and_diff_method = [
-    ["default.qubit", "backprop", True],
-    ["default.qubit", "finite-diff", False],
-    ["default.qubit", "parameter-shift", False],
-    ["default.qubit", "adjoint", True],
-    ["default.qubit", "adjoint", False],
-    ["default.qubit", "spsa", False],
-    ["default.qubit", "hadamard", False],
+    ["default.qubit.legacy", "backprop", True],
+    ["default.qubit.legacy", "finite-diff", False],
+    ["default.qubit.legacy", "parameter-shift", False],
+    ["default.qubit.legacy", "adjoint", True],
+    ["default.qubit.legacy", "adjoint", False],
+    ["default.qubit.legacy", "spsa", False],
+    ["default.qubit.legacy", "hadamard", False],
 ]
 interface_and_qubit_device_and_diff_method = [
     ["auto"] + inner_list for inner_list in qubit_device_and_diff_method
@@ -818,7 +818,7 @@ class TestShotsIntegration:
 
     def test_changing_shots(self, interface, mocker, tol):
         """Test that changing shots works on execution"""
-        dev = qml.device("default.qubit", wires=2, shots=None)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=None)
         a, b = jax.numpy.array([0.543, -0.654])
 
         @qnode(dev, diff_method=qml.gradients.param_shift, interface=interface)
@@ -849,7 +849,7 @@ class TestShotsIntegration:
     def test_gradient_integration(self, interface):
         """Test that temporarily setting the shots works
         for gradient computations"""
-        dev = qml.device("default.qubit", wires=2, shots=1)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=1)
         a, b = jax.numpy.array([0.543, -0.654])
 
         @qnode(dev, diff_method=qml.gradients.param_shift, interface=interface)
@@ -869,7 +869,7 @@ class TestShotsIntegration:
     def test_update_diff_method(self, mocker, interface):
         """Test that temporarily setting the shots updates the diff method"""
         # pylint: disable=unused-argument
-        dev = qml.device("default.qubit", wires=2, shots=100)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=100)
         a, b = jax.numpy.array([0.543, -0.654])
 
         spy = mocker.spy(qml, "execute")
@@ -1504,7 +1504,7 @@ class TestCV:
 @pytest.mark.parametrize("interface", ["auto", "jax-jit"])
 def test_adjoint_reuse_device_state(mocker, interface):
     """Tests that the jax interface reuses the device state for adjoint differentiation"""
-    dev = qml.device("default.qubit", wires=1)
+    dev = qml.device("default.qubit.legacy", wires=1)
 
     @qnode(dev, interface=interface, diff_method="adjoint")
     def circ(x):

--- a/tests/interfaces/test_jax_qnode.py
+++ b/tests/interfaces/test_jax_qnode.py
@@ -21,13 +21,13 @@ from pennylane import qnode
 from pennylane.tape import QuantumScript
 
 qubit_device_and_diff_method = [
-    ["default.qubit", "backprop", True],
-    ["default.qubit", "finite-diff", False],
-    ["default.qubit", "parameter-shift", False],
-    ["default.qubit", "adjoint", True],
-    ["default.qubit", "adjoint", False],
-    ["default.qubit", "spsa", False],
-    ["default.qubit", "hadamard", False],
+    ["default.qubit.legacy", "backprop", True],
+    ["default.qubit.legacy", "finite-diff", False],
+    ["default.qubit.legacy", "parameter-shift", False],
+    ["default.qubit.legacy", "adjoint", True],
+    ["default.qubit.legacy", "adjoint", False],
+    ["default.qubit.legacy", "spsa", False],
+    ["default.qubit.legacy", "hadamard", False],
 ]
 
 interface_and_qubit_device_and_diff_method = [
@@ -782,7 +782,7 @@ class TestShotsIntegration:
 
     def test_changing_shots(self, interface, mocker, tol):
         """Test that changing shots works on execution"""
-        dev = qml.device("default.qubit", wires=2, shots=None)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=None)
         a, b = jax.numpy.array([0.543, -0.654])
 
         @qnode(dev, diff_method=qml.gradients.param_shift, interface=interface)
@@ -813,7 +813,7 @@ class TestShotsIntegration:
     def test_gradient_integration(self, interface):
         """Test that temporarily setting the shots works
         for gradient computations"""
-        dev = qml.device("default.qubit", wires=2, shots=1)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=1)
         a, b = jax.numpy.array([0.543, -0.654])
 
         @qnode(dev, diff_method=qml.gradients.param_shift, interface=interface)
@@ -832,7 +832,7 @@ class TestShotsIntegration:
     def test_update_diff_method(self, mocker, interface):
         """Test that temporarily setting the shots updates the diff method"""
         # pylint: disable=unused-argument
-        dev = qml.device("default.qubit", wires=2, shots=100)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=100)
         a, b = jax.numpy.array([0.543, -0.654])
 
         spy = mocker.spy(qml, "execute")
@@ -1448,7 +1448,7 @@ class TestCV:
 @pytest.mark.parametrize("interface", ["auto", "jax", "jax-python"])
 def test_adjoint_reuse_device_state(mocker, interface):
     """Tests that the jax interface reuses the device state for adjoint differentiation"""
-    dev = qml.device("default.qubit", wires=1)
+    dev = qml.device("default.qubit.legacy", wires=1)
 
     @qnode(dev, interface=interface, diff_method="adjoint")
     def circ(x):
@@ -2549,7 +2549,7 @@ class TestReturn:
         assert hess[1].shape == (2, 2, 2)
 
 
-@pytest.mark.parametrize("dev_name", ["default.qubit", "default.mixed"])
+@pytest.mark.parametrize("dev_name", ["default.qubit.legacy", "default.mixed"])
 def test_no_ops(dev_name):
     """Test that the return value of the QNode matches in the interface
     even if there are no ops"""

--- a/tests/interfaces/test_jax_qnode_shot_vector.py
+++ b/tests/interfaces/test_jax_qnode_shot_vector.py
@@ -29,9 +29,9 @@ config.config.update("jax_enable_x64", True)
 all_shots = [(1, 20, 100), (1, (20, 1), 100), (1, (5, 4), 100)]
 
 qubit_device_and_diff_method = [
-    ["default.qubit", "finite-diff", {"h": 10e-2}],
-    ["default.qubit", "parameter-shift", {}],
-    ["default.qubit", "spsa", {"h": 10e-2, "num_directions": 20}],
+    ["default.qubit.legacy", "finite-diff", {"h": 10e-2}],
+    ["default.qubit.legacy", "parameter-shift", {}],
+    ["default.qubit.legacy", "spsa", {"h": 10e-2, "num_directions": 20}],
 ]
 
 interface_and_qubit_device_and_diff_method = [
@@ -773,7 +773,7 @@ class TestReturnShotVectorsDevice:
 
     def test_jac_adjoint_fwd_error(self, shots):
         """Test that an error is raised for adjoint forward."""
-        dev = qml.device("default.qubit", wires=1, shots=shots)
+        dev = qml.device("default.qubit.legacy", wires=1, shots=shots)
 
         with pytest.warns(
             UserWarning, match="Requested adjoint differentiation to be computed with finite shots."
@@ -796,7 +796,7 @@ class TestReturnShotVectorsDevice:
 
     def test_jac_adjoint_bwd_error(self, shots):
         """Test that an error is raised for adjoint backward."""
-        dev = qml.device("default.qubit", wires=1, shots=shots)
+        dev = qml.device("default.qubit.legacy", wires=1, shots=shots)
 
         with pytest.warns(
             UserWarning, match="Requested adjoint differentiation to be computed with finite shots."
@@ -818,8 +818,8 @@ class TestReturnShotVectorsDevice:
 
 
 qubit_device_and_diff_method = [
-    ["default.qubit", "finite-diff", {"h": 10e-2}],
-    ["default.qubit", "parameter-shift", {}],
+    ["default.qubit.legacy", "finite-diff", {"h": 10e-2}],
+    ["default.qubit.legacy", "parameter-shift", {}],
 ]
 
 shots_large = [(1000000, 900000, 800000), (1000000, (900000, 2))]

--- a/tests/interfaces/test_tensorflow.py
+++ b/tests/interfaces/test_tensorflow.py
@@ -34,7 +34,7 @@ class TestTensorFlowExecuteUnitTests:
 
         a = tf.Variable([0.1, 0.2], dtype=tf.float64)
 
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
 
         with tf.GradientTape() as t:
             with qml.queuing.AnnotatedQueue() as q:
@@ -61,7 +61,7 @@ class TestTensorFlowExecuteUnitTests:
         is used with grad_on_execution"""
         a = tf.Variable([0.1, 0.2])
 
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
 
         with tf.GradientTape():
             with qml.queuing.AnnotatedQueue() as q:
@@ -77,7 +77,7 @@ class TestTensorFlowExecuteUnitTests:
 
     def test_grad_on_execution(self, mocker):
         """Test that grad on execution uses the `device.execute_and_gradients` pathway"""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
         a = tf.Variable([0.1, 0.2])
         spy = mocker.spy(dev, "execute_and_gradients")
 
@@ -102,7 +102,7 @@ class TestTensorFlowExecuteUnitTests:
 
     def test_no_grad_execution(self, mocker):
         """Test that no grad on execution uses the `device.batch_execute` and `device.gradients` pathway"""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
         spy_execute = mocker.spy(qml.devices.DefaultQubit, "batch_execute")
         spy_gradients = mocker.spy(qml.devices.DefaultQubit, "gradients")
         a = tf.Variable([0.1, 0.2])
@@ -136,7 +136,7 @@ class TestCaching:
 
     def test_cache_maxsize(self, mocker):
         """Test the cachesize property of the cache"""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
         spy = mocker.spy(qml.interfaces, "cache_execute")
         a = tf.Variable([0.1, 0.2])
 
@@ -158,7 +158,7 @@ class TestCaching:
 
     def test_custom_cache(self, mocker):
         """Test the use of a custom cache object"""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
         spy = mocker.spy(qml.interfaces, "cache_execute")
         a = tf.Variable([0.1, 0.2])
         custom_cache = {}
@@ -188,7 +188,7 @@ class TestCaching:
     def test_caching_param_shift(self):
         """Test that, when using parameter-shift transform,
         caching reduces the number of evaluations to their optimum."""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
         a = tf.Variable([0.1, 0.2], dtype=tf.float64)
 
         def cost(a, cache):
@@ -228,7 +228,7 @@ class TestCaching:
         """Test that, when using parameter-shift transform,
         caching reduces the number of evaluations to their optimum
         when computing Hessians."""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
         params = tf.Variable(np.arange(1, num_params + 1) / 10, dtype=tf.float64)
 
         N = params.shape[0]
@@ -324,7 +324,7 @@ class TestTensorFlowExecuteIntegration:
 
     def test_execution(self, execute_kwargs):
         """Test execution"""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
         a = tf.Variable(0.1)
         b = tf.Variable(0.2)
 
@@ -352,7 +352,7 @@ class TestTensorFlowExecuteIntegration:
     def test_scalar_jacobian(self, execute_kwargs, tol):
         """Test scalar jacobian calculation"""
         a = tf.Variable(0.1, dtype=tf.float64)
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         with tf.GradientTape() as t:
             with qml.queuing.AnnotatedQueue() as q:
@@ -381,7 +381,7 @@ class TestTensorFlowExecuteIntegration:
         """Test jacobian calculation"""
         a = tf.Variable(0.1, dtype=tf.float64)
         b = tf.Variable(0.2, dtype=tf.float64)
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         with tf.GradientTape() as t:
             with qml.queuing.AnnotatedQueue() as q:
@@ -407,7 +407,7 @@ class TestTensorFlowExecuteIntegration:
     def test_tape_no_parameters(self, execute_kwargs, tol):
         """Test that a tape with no parameters is correctly
         ignored during the gradient computation"""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
         params = tf.Variable([0.1, 0.2], dtype=tf.float64)
         x, y = 1.0 * params
 
@@ -443,7 +443,7 @@ class TestTensorFlowExecuteIntegration:
         a = tf.Variable(0.1, dtype=tf.float64)
         b = tf.Variable(0.2, dtype=tf.float64)
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         with tf.GradientTape() as t:
             with qml.queuing.AnnotatedQueue() as q:
@@ -486,7 +486,7 @@ class TestTensorFlowExecuteIntegration:
         a = tf.Variable(0.1, dtype=tf.float64)
         b = tf.Variable(0.2, dtype=tf.float64)
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         with qml.queuing.AnnotatedQueue() as q:
             qml.RY(a, wires=0)
@@ -528,7 +528,7 @@ class TestTensorFlowExecuteIntegration:
         b = tf.constant(0.2, dtype=tf.float64)
         c = tf.Variable(0.3, dtype=tf.float64)
 
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
 
         with tf.GradientTape() as t:
             with qml.queuing.AnnotatedQueue() as q:
@@ -550,7 +550,7 @@ class TestTensorFlowExecuteIntegration:
     def test_no_trainable_parameters(self, execute_kwargs):
         """Test evaluation and Jacobian if there are no trainable parameters"""
         b = tf.constant(0.2, dtype=tf.float64)
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         with tf.GradientTape() as t:
             with qml.queuing.AnnotatedQueue() as q:
@@ -576,7 +576,7 @@ class TestTensorFlowExecuteIntegration:
         with a matrix parameter"""
         a = tf.Variable(0.1, dtype=tf.float64)
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         with tf.GradientTape() as t:
             with qml.queuing.AnnotatedQueue() as q:
@@ -606,7 +606,7 @@ class TestTensorFlowExecuteIntegration:
                     qml.PhaseShift(phi + lam, wires=wires),
                 ]
 
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
         a = np.array(0.1)
         p = tf.Variable([0.1, 0.2, 0.3], dtype=tf.float64)
 
@@ -644,7 +644,7 @@ class TestTensorFlowExecuteIntegration:
         if execute_kwargs["gradient_fn"] == "device":
             pytest.skip("Adjoint differentiation does not yet support probabilities")
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
         x = tf.Variable(0.543, dtype=tf.float64)
         y = tf.Variable(-0.654, dtype=tf.float64)
 
@@ -689,7 +689,7 @@ class TestTensorFlowExecuteIntegration:
         if execute_kwargs["gradient_fn"] == "device":
             pytest.skip("Adjoint differentiation does not yet support probabilities")
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
         x = tf.Variable(0.543, dtype=tf.float64)
         y = tf.Variable(-0.654, dtype=tf.float64)
 
@@ -727,7 +727,7 @@ class TestTensorFlowExecuteIntegration:
         ):
             pytest.skip("Adjoint differentiation does not support samples")
 
-        dev = qml.device("default.qubit", wires=2, shots=10)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=10)
 
         with tf.GradientTape():
             with qml.queuing.AnnotatedQueue() as q:
@@ -855,7 +855,7 @@ class TestHigherOrderDerivatives:
     def test_adjoint_hessian(self, interface):
         """Since the adjoint hessian is not a differentiable transform,
         higher-order derivatives are not supported."""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
         params = tf.Variable([0.543, -0.654])
 
         with tf.GradientTape() as t2:
@@ -994,7 +994,7 @@ class TestHamiltonianWorkflows:
         weights = tf.Variable([0.4, 0.5], dtype=tf.float64)
         coeffs1 = tf.constant([0.1, 0.2, 0.3], dtype=tf.float64)
         coeffs2 = tf.constant([0.7], dtype=tf.float64)
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         with tf.GradientTape() as tape:
             res = cost_fn(weights, coeffs1, coeffs2, dev=dev)
@@ -1013,7 +1013,7 @@ class TestHamiltonianWorkflows:
         weights = tf.Variable([0.4, 0.5], dtype=tf.float64)
         coeffs1 = tf.Variable([0.1, 0.2, 0.3], dtype=tf.float64)
         coeffs2 = tf.Variable([0.7], dtype=tf.float64)
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         with tf.GradientTape() as tape:
             res = cost_fn(weights, coeffs1, coeffs2, dev=dev)

--- a/tests/interfaces/test_tensorflow_autograph_qnode_shot_vector.py
+++ b/tests/interfaces/test_tensorflow_autograph_qnode_shot_vector.py
@@ -28,9 +28,9 @@ shots_and_num_copies_hess = [((10, (5, 1)), 2)]
 
 spsa_kwargs = {"h": 10e-2, "num_directions": 30, "sampler_rng": np.random.default_rng(42)}
 qubit_device_and_diff_method = [
-    ["default.qubit", "finite-diff", {"h": 10e-2}],
-    ["default.qubit", "parameter-shift", {}],
-    ["default.qubit", "spsa", spsa_kwargs],
+    ["default.qubit.legacy", "finite-diff", {"h": 10e-2}],
+    ["default.qubit.legacy", "parameter-shift", {}],
+    ["default.qubit.legacy", "spsa", spsa_kwargs],
 ]
 
 TOLS = {

--- a/tests/interfaces/test_tensorflow_qnode.py
+++ b/tests/interfaces/test_tensorflow_qnode.py
@@ -24,13 +24,13 @@ tf = pytest.importorskip("tensorflow")
 
 
 qubit_device_and_diff_method = [
-    ["default.qubit", "finite-diff", False],
-    ["default.qubit", "parameter-shift", False],
-    ["default.qubit", "backprop", True],
-    ["default.qubit", "adjoint", True],
-    ["default.qubit", "adjoint", False],
-    ["default.qubit", "spsa", False],
-    ["default.qubit", "hadamard", False],
+    ["default.qubit.legacy", "finite-diff", False],
+    ["default.qubit.legacy", "parameter-shift", False],
+    ["default.qubit.legacy", "backprop", True],
+    ["default.qubit.legacy", "adjoint", True],
+    ["default.qubit.legacy", "adjoint", False],
+    ["default.qubit.legacy", "spsa", False],
+    ["default.qubit.legacy", "hadamard", False],
 ]
 
 TOL_FOR_SPSA = 1.0
@@ -534,7 +534,7 @@ class TestShotsIntegration:
 
     def test_changing_shots(self, mocker, tol, interface):
         """Test that changing shots works on execution"""
-        dev = qml.device("default.qubit", wires=2, shots=None)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=None)
         a, b = [0.543, -0.654]
         weights = tf.Variable([a, b], dtype=tf.float64)
 
@@ -569,7 +569,7 @@ class TestShotsIntegration:
         """Test that temporarily setting the shots works
         for gradient computations"""
         # pylint: disable=unexpected-keyword-arg
-        dev = qml.device("default.qubit", wires=2, shots=None)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=None)
         a, b = [0.543, -0.654]
         weights = tf.Variable([a, b], dtype=tf.float64)
 
@@ -595,7 +595,7 @@ class TestShotsIntegration:
         """Test that temporarily setting the shots works
         for gradient computations, even if the QNode has been re-evaluated
         with a different number of shots in the meantime."""
-        dev = qml.device("default.qubit", wires=2, shots=None)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=None)
         a, b = [0.543, -0.654]
         weights = tf.Variable([a, b], dtype=tf.float64)
 
@@ -620,7 +620,7 @@ class TestShotsIntegration:
 
     def test_update_diff_method(self, mocker, interface):
         """Test that temporarily setting the shots updates the diff method"""
-        dev = qml.device("default.qubit", wires=2, shots=100)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=100)
         weights = tf.Variable([0.543, -0.654], dtype=tf.float64)
 
         spy = mocker.spy(qml, "execute")
@@ -656,7 +656,7 @@ class TestAdjoint:
 
     def test_reuse_state(self, mocker, interface):
         """Tests that the TF interface reuses the device state for adjoint differentiation"""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         @qnode(dev, diff_method="adjoint", interface=interface)
         def circ(x):
@@ -683,7 +683,7 @@ class TestAdjoint:
     def test_resuse_state_multiple_evals(self, mocker, tol, interface):
         """Tests that the TF interface reuses the device state for adjoint differentiation,
         even where there are intermediate evaluations."""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         x_val = 0.543
         y_val = -0.654
@@ -1527,7 +1527,7 @@ class TestSample:
 
     def test_sample_dimension(self):
         """Test sampling works as expected"""
-        dev = qml.device("default.qubit", wires=2, shots=10)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=10)
 
         @qnode(dev, diff_method="parameter-shift", interface="tf")
         def circuit():
@@ -1547,7 +1547,7 @@ class TestSample:
 
     def test_sampling_expval(self):
         """Test sampling works as expected if combined with expectation values"""
-        dev = qml.device("default.qubit", wires=2, shots=10)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=10)
 
         @qnode(dev, diff_method="parameter-shift", interface="tf")
         def circuit():
@@ -1568,7 +1568,7 @@ class TestSample:
         """Test the output of combining expval, var and sample"""
         n_sample = 10
 
-        dev = qml.device("default.qubit", wires=3, shots=n_sample)
+        dev = qml.device("default.qubit.legacy", wires=3, shots=n_sample)
 
         @qnode(dev, diff_method="parameter-shift", interface="tf")
         def circuit():
@@ -1593,7 +1593,7 @@ class TestSample:
         """Test the return type and shape of sampling a single wire"""
         n_sample = 10
 
-        dev = qml.device("default.qubit", wires=1, shots=n_sample)
+        dev = qml.device("default.qubit.legacy", wires=1, shots=n_sample)
 
         @qnode(dev, diff_method="parameter-shift", interface="tf")
         def circuit():
@@ -1611,7 +1611,7 @@ class TestSample:
         where a rectangular array is expected"""
         n_sample = 10
 
-        dev = qml.device("default.qubit", wires=3, shots=n_sample)
+        dev = qml.device("default.qubit.legacy", wires=3, shots=n_sample)
 
         @qnode(dev, diff_method="parameter-shift", interface="tf")
         def circuit():
@@ -1627,7 +1627,7 @@ class TestSample:
 
     def test_counts(self):
         """Test counts works as expected for TF"""
-        dev = qml.device("default.qubit", wires=2, shots=100)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=100)
 
         @qnode(dev, interface="tf")
         def circuit():
@@ -1665,7 +1665,7 @@ class TestAutograph:
     def test_autograph_gradients(self, decorator, interface, tol):
         """Test that a parameter-shift QNode can be compiled
         using @tf.function, and differentiated"""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
         x = tf.Variable(0.543, dtype=tf.float64)
         y = tf.Variable(-0.654, dtype=tf.float64)
 
@@ -1691,7 +1691,7 @@ class TestAutograph:
     def test_autograph_jacobian(self, decorator, interface, tol):
         """Test that a parameter-shift vector-valued QNode can be compiled
         using @tf.function, and differentiated"""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
         x = tf.Variable(0.543, dtype=tf.float64)
         y = tf.Variable(-0.654, dtype=tf.float64)
 
@@ -1734,7 +1734,7 @@ class TestAutograph:
     def test_autograph_adjoint_single_param(self, grad_on_execution, decorator, interface, tol):
         """Test that a parameter-shift QNode can be compiled
         using @tf.function, and differentiated to second order"""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
 
         @decorator
         @qnode(dev, diff_method="adjoint", interface=interface, grad_on_execution=grad_on_execution)
@@ -1758,7 +1758,7 @@ class TestAutograph:
     def test_autograph_adjoint_multi_params(self, grad_on_execution, decorator, interface, tol):
         """Test that a parameter-shift QNode can be compiled
         using @tf.function, and differentiated to second order"""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
 
         @decorator
         @qnode(dev, diff_method="adjoint", interface=interface, grad_on_execution=grad_on_execution)
@@ -1783,7 +1783,7 @@ class TestAutograph:
     def test_autograph_ragged_differentiation(self, decorator, interface, tol):
         """Tests correct output shape and evaluation for a tape
         with prob and expval outputs"""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         x = tf.Variable(0.543, dtype=tf.float64)
         y = tf.Variable(-0.654, dtype=tf.float64)
@@ -1821,7 +1821,7 @@ class TestAutograph:
     def test_autograph_hessian(self, decorator, interface, tol):
         """Test that a parameter-shift QNode can be compiled
         using @tf.function, and differentiated to second order"""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
         a = tf.Variable(0.543, dtype=tf.float64)
         b = tf.Variable(-0.654, dtype=tf.float64)
 
@@ -1855,7 +1855,7 @@ class TestAutograph:
     def test_autograph_state(self, decorator, interface, tol):
         """Test that a parameter-shift QNode returning a state can be compiled
         using @tf.function"""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
         x = tf.Variable(0.543, dtype=tf.float64)
         y = tf.Variable(-0.654, dtype=tf.float64)
 
@@ -1878,7 +1878,7 @@ class TestAutograph:
 
     def test_autograph_dimension(self, decorator, interface):
         """Test sampling works as expected"""
-        dev = qml.device("default.qubit", wires=2, shots=10)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=10)
 
         @decorator
         @qnode(dev, diff_method="parameter-shift", interface=interface)
@@ -2552,7 +2552,7 @@ class TestReturn:
         assert hess.shape == (3, 2, 2)
 
 
-@pytest.mark.parametrize("dev_name", ["default.qubit", "default.mixed"])
+@pytest.mark.parametrize("dev_name", ["default.qubit.legacy", "default.mixed"])
 def test_no_ops(dev_name):
     """Test that the return value of the QNode matches in the interface
     even if there are no ops"""

--- a/tests/interfaces/test_tensorflow_qnode_shot_vector.py
+++ b/tests/interfaces/test_tensorflow_qnode_shot_vector.py
@@ -27,9 +27,9 @@ shots_and_num_copies = [(((5, 2), 1, 10), 4), ((1, 10, (5, 2)), 4)]
 shots_and_num_copies_hess = [((10, (5, 1)), 2)]
 
 qubit_device_and_diff_method = [
-    ["default.qubit", "finite-diff", {"h": 10e-2}],
-    ["default.qubit", "parameter-shift", {}],
-    ["default.qubit", "spsa", {"h": 10e-2, "num_directions": 20}],
+    ["default.qubit.legacy", "finite-diff", {"h": 10e-2}],
+    ["default.qubit.legacy", "parameter-shift", {}],
+    ["default.qubit.legacy", "spsa", {"h": 10e-2, "num_directions": 20}],
 ]
 
 TOLS = {

--- a/tests/interfaces/test_torch.py
+++ b/tests/interfaces/test_torch.py
@@ -36,7 +36,7 @@ class TestTorchExecuteUnitTests:
 
         a = torch.tensor([0.1, 0.2], requires_grad=True)
 
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
 
         with qml.queuing.AnnotatedQueue() as q:
             qml.RY(a[0], wires=0)
@@ -63,7 +63,7 @@ class TestTorchExecuteUnitTests:
         is used with grad_on_execution=True"""
         a = torch.tensor([0.1, 0.2], requires_grad=True)
 
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
 
         with qml.queuing.AnnotatedQueue() as q:
             qml.RY(a[0], wires=0)
@@ -82,7 +82,7 @@ class TestTorchExecuteUnitTests:
     def test_grad_on_execution_reuse_state(self, interface, mocker):
         """Test that grad_on_execution uses the `device.execute_and_gradients` pathway
         while reusing the quantum state."""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
         spy = mocker.spy(dev, "execute_and_gradients")
 
         a = torch.tensor([0.1, 0.2], requires_grad=True)
@@ -108,7 +108,7 @@ class TestTorchExecuteUnitTests:
 
     def test_grad_on_execution(self, interface, mocker):
         """Test that grad on execution uses the `device.execute_and_gradients` pathway"""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
         spy = mocker.spy(dev, "execute_and_gradients")
 
         a = torch.tensor([0.1, 0.2], requires_grad=True)
@@ -134,7 +134,7 @@ class TestTorchExecuteUnitTests:
 
     def test_no_grad_on_execution(self, interface, mocker):
         """Test that no grad on execution uses the `device.batch_execute` and `device.gradients` pathway"""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
         spy_execute = mocker.spy(qml.devices.DefaultQubit, "batch_execute")
         spy_gradients = mocker.spy(qml.devices.DefaultQubit, "gradients")
 
@@ -169,7 +169,7 @@ class TestCaching:
 
     def test_cache_maxsize(self, mocker):
         """Test the cachesize property of the cache"""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
         spy = mocker.spy(qml.interfaces, "cache_execute")
 
         def cost(a, cachesize):
@@ -195,7 +195,7 @@ class TestCaching:
 
     def test_custom_cache(self, mocker):
         """Test the use of a custom cache object"""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
         spy = mocker.spy(qml.interfaces, "cache_execute")
 
         def cost(a, cache):
@@ -221,7 +221,7 @@ class TestCaching:
     def test_caching_param_shift(self):
         """Test that, with the parameter-shift transform,
         Torch always uses the optimum number of evals when computing the Jacobian."""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
 
         def cost(a, cache):
             with qml.queuing.AnnotatedQueue() as q:
@@ -252,7 +252,7 @@ class TestCaching:
         """Test that, with the parameter-shift transform,
         caching reduces the number of evaluations to their optimum
         when computing Hessians."""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
         params = torch.tensor(np.arange(1, num_params + 1) / 10, requires_grad=True)
 
         N = len(params)
@@ -309,7 +309,7 @@ class TestCaching:
     def test_caching_adjoint_no_grad_on_execution(self):
         """Test that caching reduces the number of adjoint evaluations
         when grad_on_execution=False"""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
         params = torch.tensor([0.1, 0.2, 0.3])
 
         def cost(a, cache):
@@ -402,7 +402,7 @@ class TestTorchExecuteIntegration:
 
     def test_execution(self, torch_device, execute_kwargs):
         """Test that the execute function produces results with the expected shapes"""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
         a = torch.tensor(0.1, requires_grad=True, device=torch_device)
         b = torch.tensor(0.2, requires_grad=False, device=torch_device)
 
@@ -430,7 +430,7 @@ class TestTorchExecuteIntegration:
     def test_scalar_jacobian(self, torch_device, execute_kwargs, tol):
         """Test scalar jacobian calculation by comparing two types of pipelines"""
         a = torch.tensor(0.1, requires_grad=True, dtype=torch.float64, device=torch_device)
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         with qml.queuing.AnnotatedQueue() as q:
             qml.RY(a, wires=0)
@@ -463,7 +463,7 @@ class TestTorchExecuteIntegration:
         a = torch.tensor(a_val, requires_grad=True, device=torch_device)
         b = torch.tensor(b_val, requires_grad=True, device=torch_device)
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         with qml.queuing.AnnotatedQueue() as q:
             qml.RZ(torch.tensor(0.543, device=torch_device), wires=0)
@@ -506,7 +506,7 @@ class TestTorchExecuteIntegration:
     def test_tape_no_parameters(self, torch_device, execute_kwargs, tol):
         """Test that a tape with no parameters is correctly
         ignored during the gradient computation"""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
         params = torch.tensor([0.1, 0.2], requires_grad=True, device=torch_device)
         x, y = params.detach()
 
@@ -549,7 +549,7 @@ class TestTorchExecuteIntegration:
         a = torch.tensor(0.1, requires_grad=True, device=torch_device)
         b = torch.tensor(0.2, requires_grad=True, device=torch_device)
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         with qml.queuing.AnnotatedQueue() as q:
             qml.RY(a, wires=0)
@@ -602,7 +602,7 @@ class TestTorchExecuteIntegration:
         p_val = [0.1, 0.2]
         params = torch.tensor(p_val, requires_grad=True, device=torch_device)
 
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
 
         with qml.queuing.AnnotatedQueue() as q:
             qml.RY(params[0] * params[1], wires=0)
@@ -637,7 +637,7 @@ class TestTorchExecuteIntegration:
 
     def test_no_trainable_parameters(self, torch_device, execute_kwargs):
         """Test evaluation and Jacobian if there are no trainable parameters"""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         with qml.queuing.AnnotatedQueue() as q:
             qml.RY(0.2, wires=0)
@@ -684,7 +684,7 @@ class TestTorchExecuteIntegration:
         if isinstance(U, torch.Tensor) and torch_device is not None:
             U = U.to(torch_device)
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         with qml.queuing.AnnotatedQueue() as q:
             qml.QubitUnitary(U, wires=0)
@@ -716,7 +716,7 @@ class TestTorchExecuteIntegration:
                     qml.PhaseShift(phi + lam, wires=wires),
                 ]
 
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
         a = np.array(0.1)
         p_val = [0.1, 0.2, 0.3]
         p = torch.tensor(p_val, requires_grad=True, device=torch_device)
@@ -768,7 +768,7 @@ class TestTorchExecuteIntegration:
         if execute_kwargs["gradient_fn"] == "device":
             pytest.skip("Adjoint differentiation does not yet support probabilities")
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
         x_val = 0.543
         y_val = -0.654
         x = torch.tensor(x_val, requires_grad=True, device=torch_device)
@@ -835,7 +835,7 @@ class TestTorchExecuteIntegration:
         if execute_kwargs["gradient_fn"] == "device":
             pytest.skip("Adjoint differentiation does not yet support probabilities")
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
         x_val = 0.543
         y_val = -0.654
         x = torch.tensor(x_val, requires_grad=True, device=torch_device)
@@ -908,7 +908,7 @@ class TestTorchExecuteIntegration:
         if execute_kwargs["interface"] == "auto":
             pytest.skip("Can't detect interface without a parametrized gate in the tape")
 
-        dev = qml.device("default.qubit", wires=2, shots=10)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=10)
 
         with qml.queuing.AnnotatedQueue() as q:
             qml.Hadamard(wires=[0])
@@ -940,7 +940,7 @@ class TestTorchExecuteIntegration:
         if execute_kwargs["interface"] == "auto":
             pytest.skip("Can't detect interface without a parametrized gate in the tape")
 
-        dev = qml.device("default.qubit", wires=2, shots=10)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=10)
 
         with qml.queuing.AnnotatedQueue() as q:
             qml.Hadamard(wires=[0])
@@ -968,7 +968,7 @@ class TestTorchExecuteIntegration:
         ):
             pytest.skip("Adjoint differentiation does not support samples")
 
-        dev = qml.device("default.qubit", wires=1, shots=10)
+        dev = qml.device("default.qubit.legacy", wires=1, shots=10)
 
         x = torch.tensor(0.65, requires_grad=True)
 
@@ -991,7 +991,7 @@ class TestTorchExecuteIntegration:
         tape expansions"""
         # pylint: disable=unused-argument
         n_qubits = 2
-        dev = qml.device("default.qubit", wires=n_qubits)
+        dev = qml.device("default.qubit.legacy", wires=n_qubits)
 
         weights = torch.ones((3,))
 
@@ -1021,7 +1021,7 @@ class TestHigherOrderDerivatives:
         """Tests that the output of the parameter-shift transform
         can be differentiated using torch, yielding second derivatives."""
         # pylint: disable=unused-argument
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
         params = torch.tensor([0.543, -0.654], requires_grad=True, dtype=torch.float64)
 
         def cost_fn(x):
@@ -1068,7 +1068,7 @@ class TestHigherOrderDerivatives:
 
     def test_hessian_vector_valued(self, torch_device, tol):
         """Test hessian calculation of a vector valued tape"""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
 
         def circuit(x):
             with qml.queuing.AnnotatedQueue() as q:
@@ -1135,7 +1135,7 @@ class TestHigherOrderDerivatives:
     def test_adjoint_hessian(self, torch_device, tol):
         """Since the adjoint hessian is not a differentiable transform,
         higher-order derivatives are not supported."""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
         params = torch.tensor(
             [0.543, -0.654], requires_grad=True, dtype=torch.float64, device=torch_device
         )
@@ -1164,7 +1164,7 @@ class TestHigherOrderDerivatives:
     def test_max_diff(self, torch_device, tol):
         """Test that setting the max_diff parameter blocks higher-order
         derivatives"""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
         params = torch.tensor([0.543, -0.654], requires_grad=True, dtype=torch.float64)
 
         def cost_fn(x):
@@ -1275,7 +1275,7 @@ class TestHamiltonianWorkflows:
         coeffs1 = torch.tensor([0.1, 0.2, 0.3], requires_grad=False, dtype=torch.float64)
         coeffs2 = torch.tensor([0.7], requires_grad=False, dtype=torch.float64)
         weights = torch.tensor([0.4, 0.5], requires_grad=True, dtype=torch.float64)
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         res = cost_fn(weights, coeffs1, coeffs2, dev=dev)
         expected = self.cost_fn_expected(weights, coeffs1, coeffs2)
@@ -1293,7 +1293,7 @@ class TestHamiltonianWorkflows:
         coeffs1 = torch.tensor([0.1, 0.2, 0.3], requires_grad=True, dtype=torch.float64)
         coeffs2 = torch.tensor([0.7], requires_grad=True, dtype=torch.float64)
         weights = torch.tensor([0.4, 0.5], requires_grad=True, dtype=torch.float64)
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         res = cost_fn(weights, coeffs1, coeffs2, dev=dev)
         expected = self.cost_fn_expected(weights, coeffs1, coeffs2)

--- a/tests/interfaces/test_torch_qnode.py
+++ b/tests/interfaces/test_torch_qnode.py
@@ -26,13 +26,13 @@ jacobian = torch.autograd.functional.jacobian
 hessian = torch.autograd.functional.hessian
 
 qubit_device_and_diff_method = [
-    ["default.qubit", "finite-diff", False],
-    ["default.qubit", "parameter-shift", False],
-    ["default.qubit", "backprop", True],
-    ["default.qubit", "adjoint", True],
-    ["default.qubit", "adjoint", False],
-    ["default.qubit", "spsa", False],
-    ["default.qubit", "hadamard", False],
+    ["default.qubit.legacy", "finite-diff", False],
+    ["default.qubit.legacy", "parameter-shift", False],
+    ["default.qubit.legacy", "backprop", True],
+    ["default.qubit.legacy", "adjoint", True],
+    ["default.qubit.legacy", "adjoint", False],
+    ["default.qubit.legacy", "spsa", False],
+    ["default.qubit.legacy", "hadamard", False],
 ]
 
 interface_and_qubit_device_and_diff_method = [
@@ -554,7 +554,7 @@ class TestShotsIntegration:
 
     def test_changing_shots(self, mocker, tol):
         """Test that changing shots works on execution"""
-        dev = qml.device("default.qubit", wires=2, shots=None)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=None)
         a, b = torch.tensor([0.543, -0.654], requires_grad=True, dtype=torch.float64)
 
         @qnode(dev, interface="torch", diff_method=qml.gradients.param_shift)
@@ -588,7 +588,7 @@ class TestShotsIntegration:
         """Test that temporarily setting the shots works
         for gradient computations"""
         # pylint: disable=unexpected-keyword-arg
-        dev = qml.device("default.qubit", wires=2, shots=None)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=None)
         a, b = torch.tensor([0.543, -0.654], requires_grad=True)
 
         @qnode(dev, interface="torch", diff_method=qml.gradients.param_shift)
@@ -610,7 +610,7 @@ class TestShotsIntegration:
         """Test that temporarily setting the shots works
         for gradient computations, even if the QNode has been re-evaluated
         with a different number of shots in the meantime."""
-        dev = qml.device("default.qubit", wires=2, shots=None)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=None)
         weights = torch.tensor([0.543, -0.654], requires_grad=True)
         a, b = weights
 
@@ -634,7 +634,7 @@ class TestShotsIntegration:
 
     def test_update_diff_method(self, mocker):
         """Test that temporarily setting the shots updates the diff method"""
-        dev = qml.device("default.qubit", wires=2, shots=100)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=100)
         a, b = torch.tensor([0.543, -0.654], requires_grad=True)
 
         spy = mocker.spy(qml, "execute")
@@ -668,7 +668,7 @@ class TestAdjoint:
 
     def test_reuse_state(self, mocker):
         """Tests that the Torch interface reuses the device state for adjoint differentiation"""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         @qnode(dev, diff_method="adjoint", interface="torch")
         def circ(x):
@@ -692,7 +692,7 @@ class TestAdjoint:
     def test_resuse_state_multiple_evals(self, mocker, tol):
         """Tests that the Torch interface reuses the device state for adjoint differentiation,
         even where there are intermediate evaluations."""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         x_val = 0.543
         y_val = -0.654
@@ -1616,7 +1616,7 @@ class TestSample:
 
     def test_sample_dimension(self):
         """Test sampling works as expected"""
-        dev = qml.device("default.qubit", wires=2, shots=10)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=10)
 
         @qnode(dev, diff_method="parameter-shift", interface="torch")
         def circuit():
@@ -1638,7 +1638,7 @@ class TestSample:
     def test_sampling_expval(self):
         """Test sampling works as expected if combined with expectation values"""
         shots = 10
-        dev = qml.device("default.qubit", wires=2, shots=shots)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=shots)
 
         @qnode(dev, diff_method="parameter-shift", interface="torch")
         def circuit():
@@ -1659,7 +1659,7 @@ class TestSample:
     def test_counts_expval(self):
         """Test counts works as expected if combined with expectation values"""
         shots = 10
-        dev = qml.device("default.qubit", wires=2, shots=shots)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=shots)
 
         @qnode(dev, diff_method="parameter-shift", interface="torch")
         def circuit():
@@ -1680,7 +1680,7 @@ class TestSample:
         """Test the output of combining expval, var and sample"""
         n_sample = 10
 
-        dev = qml.device("default.qubit", wires=3, shots=n_sample)
+        dev = qml.device("default.qubit.legacy", wires=3, shots=n_sample)
 
         @qnode(dev, diff_method="parameter-shift", interface="torch")
         def circuit():
@@ -1704,7 +1704,7 @@ class TestSample:
         """Test the return type and shape of sampling a single wire"""
         n_sample = 10
 
-        dev = qml.device("default.qubit", wires=1, shots=n_sample)
+        dev = qml.device("default.qubit.legacy", wires=1, shots=n_sample)
 
         @qnode(dev, diff_method="parameter-shift", interface="torch")
         def circuit():
@@ -1721,7 +1721,7 @@ class TestSample:
         where a rectangular array is expected"""
         n_sample = 10
 
-        dev = qml.device("default.qubit", wires=3, shots=n_sample)
+        dev = qml.device("default.qubit.legacy", wires=3, shots=n_sample)
 
         @qnode(dev, diff_method="parameter-shift", interface="torch")
         def circuit():
@@ -1740,12 +1740,12 @@ class TestSample:
 
 
 qubit_device_and_diff_method_and_grad_on_execution = [
-    ["default.qubit", "backprop", True],
-    ["default.qubit", "finite-diff", False],
-    ["default.qubit", "parameter-shift", False],
-    ["default.qubit", "adjoint", True],
-    ["default.qubit", "adjoint", False],
-    ["default.qubit", "hadamard", False],
+    ["default.qubit.legacy", "backprop", True],
+    ["default.qubit.legacy", "finite-diff", False],
+    ["default.qubit.legacy", "parameter-shift", False],
+    ["default.qubit.legacy", "adjoint", True],
+    ["default.qubit.legacy", "adjoint", False],
+    ["default.qubit.legacy", "hadamard", False],
 ]
 
 
@@ -2581,7 +2581,7 @@ class TestReturn:
         assert tuple(hess.shape) == (3, 2, 2)
 
 
-@pytest.mark.parametrize("dev_name", ["default.qubit", "default.mixed"])
+@pytest.mark.parametrize("dev_name", ["default.qubit.legacy", "default.mixed"])
 def test_no_ops(dev_name):
     """Test that the return value of the QNode matches in the interface
     even if there are no ops"""

--- a/tests/interfaces/test_transform_program_integration.py
+++ b/tests/interfaces/test_transform_program_integration.py
@@ -25,7 +25,7 @@ import pennylane as qml
 
 
 device_suite = (
-    qml.device("default.qubit", wires=5),
+    qml.device("default.qubit.legacy", wires=5),
     qml.devices.experimental.DefaultQubit2(),
     qml.device("lightning.qubit", wires=5),
 )
@@ -168,7 +168,7 @@ class TestTransformProgram:
     def test_chained_preprocessing(self):
         """Test a transform program with two transforms where their order affects the output."""
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         def null_postprocessing(results):
             return results[0]

--- a/tests/measurements/test_classical_shadow.py
+++ b/tests/measurements/test_classical_shadow.py
@@ -26,7 +26,7 @@ from pennylane.measurements.classical_shadow import ShadowExpvalMP
 # pylint: disable=dangerous-default-value, too-many-arguments, comparison-with-callable, no-member
 
 
-def get_circuit(wires, shots, seed_recipes, interface="autograd", device="default.qubit"):
+def get_circuit(wires, shots, seed_recipes, interface="autograd", device="default.qubit.legacy"):
     """
     Return a QNode that prepares the state (|00...0> + |11...1>) / sqrt(2)
         and performs the classical shadow measurement
@@ -34,7 +34,7 @@ def get_circuit(wires, shots, seed_recipes, interface="autograd", device="defaul
     if device is not None:
         dev = qml.device(device, wires=wires, shots=shots)
     else:
-        dev = qml.device("default.qubit", wires=wires, shots=shots)
+        dev = qml.device("default.qubit.legacy", wires=wires, shots=shots)
 
         # make the device call the superclass method to switch between the general qubit device and device specific implementations (i.e. for default qubit)
         dev.classical_shadow = super(type(dev), dev).classical_shadow
@@ -51,14 +51,14 @@ def get_circuit(wires, shots, seed_recipes, interface="autograd", device="defaul
     return circuit
 
 
-def get_x_basis_circuit(wires, shots, interface="autograd", device="default.qubit"):
+def get_x_basis_circuit(wires, shots, interface="autograd", device="default.qubit.legacy"):
     """
     Return a QNode that prepares the |++..+> state and performs a classical shadow measurement
     """
     if device is not None:
         dev = qml.device(device, wires=wires, shots=shots)
     else:
-        dev = qml.device("default.qubit", wires=wires, shots=shots)
+        dev = qml.device("default.qubit.legacy", wires=wires, shots=shots)
 
         # make the device call the superclass method to switch between the general qubit device and device specific implementations (i.e. for default qubit)
         dev.classical_shadow = super(type(dev), dev).classical_shadow
@@ -72,14 +72,14 @@ def get_x_basis_circuit(wires, shots, interface="autograd", device="default.qubi
     return circuit
 
 
-def get_y_basis_circuit(wires, shots, interface="autograd", device="default.qubit"):
+def get_y_basis_circuit(wires, shots, interface="autograd", device="default.qubit.legacy"):
     """
     Return a QNode that prepares the |+i>|+i>...|+i> state and performs a classical shadow measurement
     """
     if device is not None:
         dev = qml.device(device, wires=wires, shots=shots)
     else:
-        dev = qml.device("default.qubit", wires=wires, shots=shots)
+        dev = qml.device("default.qubit.legacy", wires=wires, shots=shots)
 
         # make the device call the superclass method to switch between the general qubit device and device specific implementations (i.e. for default qubit)
         dev.classical_shadow = super(type(dev), dev).classical_shadow
@@ -94,14 +94,14 @@ def get_y_basis_circuit(wires, shots, interface="autograd", device="default.qubi
     return circuit
 
 
-def get_z_basis_circuit(wires, shots, interface="autograd", device="default.qubit"):
+def get_z_basis_circuit(wires, shots, interface="autograd", device="default.qubit.legacy"):
     """
     Return a QNode that prepares the |00..0> state and performs a classical shadow measurement
     """
     if device is not None:
         dev = qml.device(device, wires=wires, shots=shots)
     else:
-        dev = qml.device("default.qubit", wires=wires, shots=shots)
+        dev = qml.device("default.qubit.legacy", wires=wires, shots=shots)
 
         # make the device call the superclass method to switch between the general qubit device and device specific implementations (i.e. for default qubit)
         dev.classical_shadow = super(type(dev), dev).classical_shadow
@@ -263,7 +263,7 @@ class TestClassicalShadow:
     @pytest.mark.parametrize("seed", seed_recipes_list)
     def test_measurement_process_shape(self, wires, shots, seed):
         """Test that the shape of the MeasurementProcess instance is correct"""
-        dev = qml.device("default.qubit", wires=wires, shots=shots)
+        dev = qml.device("default.qubit.legacy", wires=wires, shots=shots)
         shots_obj = Shots(shots)
         res = qml.classical_shadow(wires=range(wires), seed=seed)
         assert res.shape(dev, shots_obj) == (2, shots, wires)
@@ -304,7 +304,7 @@ class TestClassicalShadow:
     @pytest.mark.parametrize("shots", shots_list)
     @pytest.mark.parametrize("seed", seed_recipes_list)
     @pytest.mark.parametrize("interface", ["autograd", "jax", "tf", "torch"])
-    @pytest.mark.parametrize("device", ["default.qubit", "default.mixed", None])
+    @pytest.mark.parametrize("device", ["default.qubit.legacy", "default.mixed", None])
     def test_format(self, wires, shots, seed, interface, device):
         """Test that the format of the returned classical shadow
         measurement is correct"""
@@ -334,7 +334,7 @@ class TestClassicalShadow:
 
     @pytest.mark.all_interfaces
     @pytest.mark.parametrize("interface", ["autograd", "jax", "tf", "torch"])
-    @pytest.mark.parametrize("device", ["default.qubit", None])
+    @pytest.mark.parametrize("device", ["default.qubit.legacy", None])
     @pytest.mark.parametrize(
         "circuit_fn, basis_recipe",
         [(get_x_basis_circuit, 0), (get_y_basis_circuit, 1), (get_z_basis_circuit, 2)],
@@ -390,7 +390,7 @@ class TestClassicalShadow:
     def test_multi_measurement_error(self, wires, shots):
         """Test that an error is raised when classical shadows is returned
         with other measurement processes"""
-        dev = qml.device("default.qubit", wires=wires, shots=shots)
+        dev = qml.device("default.qubit.legacy", wires=wires, shots=shots)
 
         @qml.qnode(dev)
         def circuit():
@@ -407,7 +407,7 @@ class TestClassicalShadow:
 
 
 def hadamard_circuit(wires, shots=10000, interface="autograd"):
-    dev = qml.device("default.qubit", wires=wires, shots=shots)
+    dev = qml.device("default.qubit.legacy", wires=wires, shots=shots)
 
     @qml.qnode(dev, interface=interface)
     def circuit(obs, k=1):
@@ -419,7 +419,7 @@ def hadamard_circuit(wires, shots=10000, interface="autograd"):
 
 
 def max_entangled_circuit(wires, shots=10000, interface="autograd"):
-    dev = qml.device("default.qubit", wires=wires, shots=shots)
+    dev = qml.device("default.qubit.legacy", wires=wires, shots=shots)
 
     @qml.qnode(dev, interface=interface)
     def circuit(obs, k=1):
@@ -432,7 +432,7 @@ def max_entangled_circuit(wires, shots=10000, interface="autograd"):
 
 
 def qft_circuit(wires, shots=10000, interface="autograd"):
-    dev = qml.device("default.qubit", wires=wires, shots=shots)
+    dev = qml.device("default.qubit.legacy", wires=wires, shots=shots)
 
     one_state = np.zeros(wires)
     one_state[-1] = 1
@@ -458,7 +458,7 @@ class TestExpvalMeasurement:
     @pytest.mark.parametrize("shots", [1, 10])
     def test_measurement_process_shape(self, wires, shots):
         """Test that the shape of the MeasurementProcess instance is correct"""
-        dev = qml.device("default.qubit", wires=wires, shots=shots)
+        dev = qml.device("default.qubit.legacy", wires=wires, shots=shots)
         H = qml.PauliZ(0)
         res = qml.shadow_expval(H)
         assert len(res.shape(dev, Shots(shots))) == 0
@@ -504,7 +504,7 @@ class TestExpvalMeasurement:
     def test_multi_measurement_error(self):
         """Test that an error is raised when classical shadows is returned
         with other measurement processes"""
-        dev = qml.device("default.qubit", wires=2, shots=100)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=100)
 
         @qml.qnode(dev)
         def circuit():
@@ -647,7 +647,7 @@ obs_strongly_entangled = [
 
 
 def strongly_entangling_circuit(wires, shots=10000, interface="autograd"):
-    dev = qml.device("default.qubit", wires=wires, shots=shots)
+    dev = qml.device("default.qubit.legacy", wires=wires, shots=shots)
 
     @qml.qnode(dev, interface=interface)
     def circuit(x, obs, k):
@@ -658,7 +658,7 @@ def strongly_entangling_circuit(wires, shots=10000, interface="autograd"):
 
 
 def strongly_entangling_circuit_exact(wires, interface="autograd"):
-    dev = qml.device("default.qubit", wires=wires)
+    dev = qml.device("default.qubit.legacy", wires=wires)
 
     @qml.qnode(dev, interface=interface)
     def circuit(x, obs):

--- a/tests/measurements/test_counts.py
+++ b/tests/measurements/test_counts.py
@@ -215,7 +215,7 @@ class TestCountsIntegration:
         """Test that the counts function outputs counts of the right size"""
         n_sample = 10
 
-        dev = qml.device("default.qubit", wires=2, shots=n_sample)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=n_sample)
         spy = mocker.spy(qml.QubitDevice, "sample")
 
         @qml.qnode(dev)
@@ -234,7 +234,7 @@ class TestCountsIntegration:
         """Test that the counts function outputs counts of the right size with batching"""
         n_sample = 10
 
-        dev = qml.device("default.qubit", wires=2, shots=n_sample)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=n_sample)
         spy = mocker.spy(qml.QubitDevice, "sample")
 
         @qml.qnode(dev)
@@ -254,7 +254,7 @@ class TestCountsIntegration:
         """Test the output of combining expval, var and counts"""
         n_sample = 10
 
-        dev = qml.device("default.qubit", wires=3, shots=n_sample)
+        dev = qml.device("default.qubit.legacy", wires=3, shots=n_sample)
         spy = mocker.spy(qml.QubitDevice, "sample")
 
         @qml.qnode(dev, diff_method="parameter-shift")
@@ -278,7 +278,7 @@ class TestCountsIntegration:
         """Test the return type and shape of sampling counts from a single wire"""
         n_sample = 10
 
-        dev = qml.device("default.qubit", wires=1, shots=n_sample)
+        dev = qml.device("default.qubit.legacy", wires=1, shots=n_sample)
         spy = mocker.spy(qml.QubitDevice, "sample")
 
         @qml.qnode(dev)
@@ -299,7 +299,7 @@ class TestCountsIntegration:
         where a rectangular array is expected"""
         n_sample = 10
 
-        dev = qml.device("default.qubit", wires=3, shots=n_sample)
+        dev = qml.device("default.qubit.legacy", wires=3, shots=n_sample)
         spy = mocker.spy(qml.QubitDevice, "sample")
 
         @qml.qnode(dev)
@@ -323,7 +323,7 @@ class TestCountsIntegration:
     def test_observable_return_type_is_counts(self):
         """Test that the return type of the observable is :attr:`ObservableReturnTypes.Counts`"""
         n_shots = 10
-        dev = qml.device("default.qubit", wires=1, shots=n_shots)
+        dev = qml.device("default.qubit.legacy", wires=1, shots=n_shots)
 
         @qml.qnode(dev)
         def circuit():
@@ -335,7 +335,7 @@ class TestCountsIntegration:
 
     def test_providing_no_observable_and_no_wires_counts(self, mocker):
         """Test that we can provide no observable and no wires to sample function"""
-        dev = qml.device("default.qubit", wires=2, shots=1000)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=1000)
         spy = mocker.spy(qml.QubitDevice, "sample")
 
         @qml.qnode(dev)
@@ -354,7 +354,7 @@ class TestCountsIntegration:
         """Test that we can provide no observable but specify wires to the sample function"""
         wires = [0, 2]
         wires_obj = qml.wires.Wires(wires)
-        dev = qml.device("default.qubit", wires=3, shots=1000)
+        dev = qml.device("default.qubit.legacy", wires=3, shots=1000)
         spy = mocker.spy(qml.QubitDevice, "sample")
 
         @qml.qnode(dev)
@@ -373,7 +373,7 @@ class TestCountsIntegration:
     def test_batched_counts_work_individually(self, mocker):
         """Test that each counts call operates independently"""
         n_shots = 10
-        dev = qml.device("default.qubit", wires=1, shots=n_shots)
+        dev = qml.device("default.qubit.legacy", wires=1, shots=n_shots)
         spy = mocker.spy(qml.QubitDevice, "sample")
 
         @qml.qnode(dev)
@@ -391,7 +391,7 @@ class TestCountsIntegration:
         """Check all interfaces with computational basis state counts and
         finite shot"""
         n_shots = 10
-        dev = qml.device("default.qubit", wires=3, shots=n_shots)
+        dev = qml.device("default.qubit.legacy", wires=3, shots=n_shots)
         spy = mocker.spy(qml.QubitDevice, "sample")
 
         @qml.qnode(dev, interface=interface)
@@ -411,7 +411,7 @@ class TestCountsIntegration:
         """Check all interfaces with observable measurement counts and finite
         shot"""
         n_shots = 10
-        dev = qml.device("default.qubit", wires=3, shots=n_shots)
+        dev = qml.device("default.qubit.legacy", wires=3, shots=n_shots)
         spy = mocker.spy(qml.QubitDevice, "sample")
 
         @qml.qnode(dev, interface=interface)
@@ -432,7 +432,7 @@ class TestCountsIntegration:
     ):  # pylint:disable=too-many-arguments
         """Check all interfaces with computational basis state counts and
         different shot vectors"""
-        dev = qml.device("default.qubit", wires=3, shots=shot_vec)
+        dev = qml.device("default.qubit.legacy", wires=3, shots=shot_vec)
         spy = mocker.spy(qml.QubitDevice, "sample")
 
         @qml.qnode(dev, interface=interface)
@@ -457,7 +457,7 @@ class TestCountsIntegration:
     def test_counts_operator_binned(self, shot_vec, interface, mocker):
         """Check all interfaces with observable measurement counts and different
         shot vectors"""
-        dev = qml.device("default.qubit", wires=3, shots=shot_vec)
+        dev = qml.device("default.qubit.legacy", wires=3, shots=shot_vec)
         spy = mocker.spy(qml.QubitDevice, "sample")
 
         @qml.qnode(dev, interface=interface)
@@ -479,7 +479,7 @@ class TestCountsIntegration:
     def test_counts_binned_4_wires(self, shot_vec, mocker):
         """Check the autograd interface with computational basis state counts and
         different shot vectors on a device with 4 wires"""
-        dev = qml.device("default.qubit", wires=4, shots=shot_vec)
+        dev = qml.device("default.qubit.legacy", wires=4, shots=shot_vec)
         spy = mocker.spy(qml.QubitDevice, "sample")
 
         @qml.qnode(dev, interface="autograd")
@@ -505,7 +505,7 @@ class TestCountsIntegration:
     def test_counts_operator_binned_4_wires(self, shot_vec, mocker):
         """Check the autograd interface with observable samples to obtain
         counts from and different shot vectors on a device with 4 wires"""
-        dev = qml.device("default.qubit", wires=4, shots=shot_vec)
+        dev = qml.device("default.qubit.legacy", wires=4, shots=shot_vec)
         spy = mocker.spy(qml.QubitDevice, "sample")
 
         @qml.qnode(dev, interface="autograd")
@@ -541,7 +541,7 @@ class TestCountsIntegration:
     def test_counts_observable_finite_shots(self, interface, meas2, shots, mocker):
         """Check all interfaces with observable measurement counts and finite
         shot"""
-        dev = qml.device("default.qubit", wires=3, shots=shots)
+        dev = qml.device("default.qubit.legacy", wires=3, shots=shots)
         spy = mocker.spy(qml.QubitDevice, "sample")
 
         if isinstance(shots, tuple) and interface == "torch":
@@ -576,7 +576,7 @@ class TestCountsIntegration:
         including 0 count values, if observable is given and all_outcomes=True"""
 
         n_shots = 10
-        dev = qml.device("default.qubit", wires=1, shots=n_shots)
+        dev = qml.device("default.qubit.legacy", wires=1, shots=n_shots)
         spy = mocker.spy(qml.QubitDevice, "sample")
 
         @qml.qnode(dev)
@@ -596,7 +596,7 @@ class TestCountsIntegration:
         count and no observable are given and all_outcomes=True"""
 
         n_shots = 10
-        dev = qml.device("default.qubit", wires=2, shots=n_shots)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=n_shots)
         spy = mocker.spy(qml.QubitDevice, "sample")
 
         @qml.qnode(dev)
@@ -615,7 +615,7 @@ class TestCountsIntegration:
         if wire count is given and all_outcomes=True"""
 
         n_shots = 10
-        dev = qml.device("default.qubit", wires=4, shots=n_shots)
+        dev = qml.device("default.qubit.legacy", wires=4, shots=n_shots)
         spy = mocker.spy(qml.QubitDevice, "sample")
 
         @qml.qnode(dev)
@@ -633,7 +633,7 @@ class TestCountsIntegration:
         qml.Hermitian observable"""
 
         n_shots = 10
-        dev = qml.device("default.qubit", wires=2, shots=n_shots)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=n_shots)
         spy = mocker.spy(qml.QubitDevice, "sample")
 
         A = np.array([[1, 0], [0, -1]])
@@ -652,7 +652,7 @@ class TestCountsIntegration:
         """Tests that the all_outcomes=True option for counts works when
         multiple measurements are performed"""
 
-        dev = qml.device("default.qubit", wires=2, shots=10)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=10)
         spy = mocker.spy(qml.QubitDevice, "sample")
 
         @qml.qnode(dev)
@@ -669,7 +669,7 @@ class TestCountsIntegration:
     def test_batched_all_outcomes(self, mocker):
         """Tests that all_outcomes=True works with broadcasting."""
         n_shots = 10
-        dev = qml.device("default.qubit", wires=1, shots=n_shots)
+        dev = qml.device("default.qubit.legacy", wires=1, shots=n_shots)
         spy = mocker.spy(qml.QubitDevice, "sample")
 
         @qml.qnode(dev)
@@ -689,7 +689,7 @@ class TestCountsIntegration:
     @pytest.mark.parametrize("shots", [1, 100])
     def test_counts_no_arguments(self, shots):
         """Test that using ``qml.counts`` with no arguments returns the counts of all wires."""
-        dev = qml.device("default.qubit", wires=3, shots=shots)
+        dev = qml.device("default.qubit.legacy", wires=3, shots=shots)
 
         @qml.qnode(dev)
         def circuit():
@@ -706,7 +706,7 @@ class TestCountsIntegration:
 def test_counts_no_op_finite_shots(interface, wires, basis_state, mocker):
     """Check all interfaces with computational basis state counts and finite shot"""
     n_shots = 10
-    dev = qml.device("default.qubit", wires=3, shots=n_shots)
+    dev = qml.device("default.qubit.legacy", wires=3, shots=n_shots)
     spy = mocker.spy(qml.QubitDevice, "sample")
 
     @qml.qnode(dev, interface=interface)
@@ -728,7 +728,7 @@ def test_batched_counts_no_op_finite_shots(interface, wires, basis_states, mocke
     """Check all interfaces with computational basis state counts and
     finite shot"""
     n_shots = 10
-    dev = qml.device("default.qubit", wires=3, shots=n_shots)
+    dev = qml.device("default.qubit.legacy", wires=3, shots=n_shots)
     spy = mocker.spy(qml.QubitDevice, "sample")
 
     @qml.qnode(dev, interface=interface)
@@ -748,7 +748,7 @@ def test_batched_counts_and_expval_no_op_finite_shots(interface, wires, basis_st
     """Check all interfaces with computational basis state counts and
     finite shot"""
     n_shots = 10
-    dev = qml.device("default.qubit", wires=3, shots=n_shots)
+    dev = qml.device("default.qubit.legacy", wires=3, shots=n_shots)
     spy = mocker.spy(qml.QubitDevice, "sample")
 
     @qml.qnode(dev, interface=interface)
@@ -769,7 +769,7 @@ def test_batched_counts_and_expval_no_op_finite_shots(interface, wires, basis_st
 def test_batched_counts_operator_finite_shots(interface, mocker):
     """Check all interfaces with observable measurement counts, batching and finite shots"""
     n_shots = 10
-    dev = qml.device("default.qubit", wires=3, shots=n_shots)
+    dev = qml.device("default.qubit.legacy", wires=3, shots=n_shots)
     spy = mocker.spy(qml.QubitDevice, "sample")
 
     @qml.qnode(dev, interface=interface)
@@ -787,7 +787,7 @@ def test_batched_counts_operator_finite_shots(interface, mocker):
 def test_batched_counts_and_expval_operator_finite_shots(interface, mocker):
     """Check all interfaces with observable measurement counts, batching and finite shots"""
     n_shots = 10
-    dev = qml.device("default.qubit", wires=3, shots=n_shots)
+    dev = qml.device("default.qubit.legacy", wires=3, shots=n_shots)
     spy = mocker.spy(qml.QubitDevice, "sample")
 
     @qml.qnode(dev, interface=interface)

--- a/tests/measurements/test_expval.py
+++ b/tests/measurements/test_expval.py
@@ -53,7 +53,7 @@ class TestExpval:
     @pytest.mark.parametrize("r_dtype", [np.float32, np.float64])
     def test_value(self, tol, r_dtype, mocker, shots):
         """Test that the expval interface works"""
-        dev = qml.device("default.qubit", wires=2, shots=shots)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=shots)
         dev.R_DTYPE = r_dtype
 
         @qml.qnode(dev, diff_method="parameter-shift")
@@ -84,7 +84,7 @@ class TestExpval:
     def test_not_an_observable(self, mocker):
         """Test that a warning is raised if the provided
         argument might not be hermitian."""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         @qml.qnode(dev)
         def circuit():
@@ -101,7 +101,7 @@ class TestExpval:
 
     def test_observable_return_type_is_expectation(self, mocker):
         """Test that the return type of the observable is :attr:`ObservableReturnTypes.Expectation`"""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         @qml.qnode(dev)
         def circuit():
@@ -131,7 +131,7 @@ class TestExpval:
     )
     def test_shape(self, obs):
         """Test that the shape is correct."""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
 
         res = qml.expval(obs)
         # pylint: disable=use-implicit-booleaness-not-comparison
@@ -146,7 +146,7 @@ class TestExpval:
         """Test that the shape is correct with the shot vector too."""
         res = qml.expval(obs)
         shot_vector = (1, 2, 3)
-        dev = qml.device("default.qubit", wires=3, shots=shot_vector)
+        dev = qml.device("default.qubit.legacy", wires=3, shots=shot_vector)
         assert res.shape(dev, Shots(shot_vector)) == ((), (), ())
 
     @pytest.mark.parametrize("state", [np.array([0, 0, 0]), np.array([1, 0, 0, 0, 0, 0, 0, 0])])
@@ -154,7 +154,7 @@ class TestExpval:
     def test_projector_expval(self, state, shots, mocker):
         """Tests that the expectation of a ``Projector`` object is computed correctly for both of
         its subclasses."""
-        dev = qml.device("default.qubit", wires=3, shots=shots)
+        dev = qml.device("default.qubit.legacy", wires=3, shots=shots)
         np.random.seed(42)
 
         @qml.qnode(dev)
@@ -178,7 +178,7 @@ class TestExpval:
             qml.s_prod(3, qml.PauliZ("h")), qml.PauliZ(8), qml.s_prod(2, qml.PauliZ(10))
         )
 
-        dev = qml.device("default.qubit", wires=["h", 8, 10])
+        dev = qml.device("default.qubit.legacy", wires=["h", 8, 10])
         spy = mocker.spy(qml.QubitDevice, "expval")
 
         @qml.qnode(dev)

--- a/tests/measurements/test_measurements.py
+++ b/tests/measurements/test_measurements.py
@@ -78,7 +78,7 @@ def test_ObservableReturnTypes(return_type, value):
 def test_no_measure():
     """Test that failing to specify a measurement
     raises an exception"""
-    dev = qml.device("default.qubit", wires=2)
+    dev = qml.device("default.qubit.legacy", wires=2)
 
     @qml.qnode(dev)
     def circuit(x):
@@ -104,7 +104,7 @@ def test_numeric_type_unrecognized_error():
 def test_shape_unrecognized_error():
     """Test that querying the shape of a measurement process with an
     unrecognized return type raises an error."""
-    dev = qml.device("default.qubit", wires=2)
+    dev = qml.device("default.qubit.legacy", wires=2)
     mp = NotValidMeasurement()
     with pytest.raises(
         qml.QuantumFunctionError,
@@ -244,7 +244,7 @@ class TestStatisticsQueuing:
         if stat_func is sample:
             pytest.skip("Sampling is not yet supported with symbolic operators.")
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         @qml.qnode(dev)
         def circuit():
@@ -483,7 +483,7 @@ class TestSampleMeasurement:
             def process_samples(self, samples, wire_order, shot_range, bin_size):
                 return qml.math.sum(samples[..., self.wires])
 
-        dev = qml.device("default.qubit", wires=2, shots=1000)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=1000)
 
         @qml.qnode(dev)
         def circuit():
@@ -500,7 +500,7 @@ class TestSampleMeasurement:
             def process_samples(self, samples, wire_order, shot_range, bin_size):
                 return qml.math.sum(samples[..., self.wires])
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         @qml.qnode(dev)
         def circuit():
@@ -515,7 +515,7 @@ class TestSampleMeasurement:
     def test_method_overriden_by_device(self):
         """Test that the device can override a measurement process."""
 
-        dev = qml.device("default.qubit", wires=2, shots=1000)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=1000)
 
         @qml.qnode(dev)
         def circuit():
@@ -538,7 +538,7 @@ class TestStateMeasurement:
             def process_state(self, state, wire_order):
                 return qml.math.sum(state)
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         @qml.qnode(dev)
         def circuit():
@@ -553,7 +553,7 @@ class TestStateMeasurement:
             def process_state(self, state, wire_order):
                 return qml.math.sum(state)
 
-        dev = qml.device("default.qubit", wires=2, shots=1000)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=1000)
 
         @qml.qnode(dev)
         def circuit():
@@ -568,7 +568,7 @@ class TestStateMeasurement:
     def test_method_overriden_by_device(self):
         """Test that the device can override a measurement process."""
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         @qml.qnode(dev, interface="autograd")
         def circuit():
@@ -590,7 +590,7 @@ class TestMeasurementTransform:
             def process(self, tape, device):
                 return {device.shots: len(tape)}
 
-        dev = qml.device("default.qubit", wires=2, shots=1000)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=1000)
 
         @qml.qnode(dev)
         def circuit():
@@ -601,7 +601,7 @@ class TestMeasurementTransform:
     def test_method_overriden_by_device(self):
         """Test that the device can override a measurement process."""
 
-        dev = qml.device("default.qubit", wires=2, shots=1000)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=1000)
 
         @qml.qnode(dev)
         def circuit():

--- a/tests/measurements/test_mutual_info.py
+++ b/tests/measurements/test_mutual_info.py
@@ -39,7 +39,7 @@ class TestMutualInfoUnitTests:
     @pytest.mark.parametrize("shots, shape", [(None, ()), (10, ()), ([1, 10], ((), ()))])
     def test_shape(self, shots, shape):
         """Test that the shape is correct."""
-        dev = qml.device("default.qubit", wires=3, shots=shots)
+        dev = qml.device("default.qubit.legacy", wires=3, shots=shots)
         res = qml.mutual_info(wires0=[0], wires1=[1])
         assert res.shape(dev, Shots(shots)) == shape
 
@@ -88,7 +88,7 @@ class TestIntegration:
     )
     def test_mutual_info_output(self, interface, state, expected):
         """Test the output of qml.mutual_info"""
-        dev = qml.device("default.qubit", wires=4)
+        dev = qml.device("default.qubit.legacy", wires=4)
 
         @qml.qnode(dev, interface=interface)
         def circuit():
@@ -106,7 +106,7 @@ class TestIntegration:
 
     def test_shot_vec_error(self):
         """Test an error is raised when using shot vectors with mutual_info."""
-        dev = qml.device("default.qubit", wires=2, shots=[1, 10, 10, 1000])
+        dev = qml.device("default.qubit.legacy", wires=2, shots=[1, 10, 10, 1000])
 
         @qml.qnode(device=dev)
         def circuit(x):
@@ -122,7 +122,7 @@ class TestIntegration:
     diff_methods = ["backprop", "finite-diff"]
 
     @pytest.mark.all_interfaces
-    @pytest.mark.parametrize("device", ["default.qubit", "default.mixed", "lightning.qubit"])
+    @pytest.mark.parametrize("device", ["default.qubit.legacy", "default.mixed", "lightning.qubit"])
     @pytest.mark.parametrize("interface", ["autograd", "jax", "tensorflow", "torch"])
     @pytest.mark.parametrize("params", np.linspace(0, 2 * np.pi, 8))
     def test_qnode_state(self, device, interface, params):
@@ -148,7 +148,7 @@ class TestIntegration:
         assert np.allclose(actual, expected)
 
     @pytest.mark.all_interfaces
-    @pytest.mark.parametrize("device", ["default.qubit", "default.mixed", "lightning.qubit"])
+    @pytest.mark.parametrize("device", ["default.qubit.legacy", "default.mixed", "lightning.qubit"])
     @pytest.mark.parametrize("interface", ["autograd", "jax", "tensorflow", "torch"])
     @pytest.mark.parametrize("params", zip(np.linspace(0, np.pi, 8), np.linspace(0, 2 * np.pi, 8)))
     def test_qnode_mutual_info(self, device, interface, params):
@@ -179,7 +179,7 @@ class TestIntegration:
 
         assert np.allclose(actual, expected)
 
-    @pytest.mark.parametrize("device", ["default.qubit", "default.mixed", "lightning.qubit"])
+    @pytest.mark.parametrize("device", ["default.qubit.legacy", "default.mixed", "lightning.qubit"])
     def test_mutual_info_wire_labels(self, device):
         """Test that mutual_info is correct with custom wire labels"""
         param = np.array([0.678, 1.234])
@@ -209,7 +209,7 @@ class TestIntegration:
         import jax
         import jax.numpy as jnp
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         params = jnp.array(params)
 
@@ -237,7 +237,7 @@ class TestIntegration:
         import jax
         import jax.numpy as jnp
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         params = jnp.array(params)
 
@@ -269,7 +269,7 @@ class TestIntegration:
     def test_qnode_grad(self, param, diff_method, interface):
         """Test that the gradient of mutual information works for QNodes
         with the autograd interface"""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         @qml.qnode(dev, interface=interface, diff_method=diff_method)
         def circuit(param):
@@ -301,7 +301,7 @@ class TestIntegration:
         import jax
         import jax.numpy as jnp
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         param = jnp.array(param)
 
@@ -335,7 +335,7 @@ class TestIntegration:
         import jax
         import jax.numpy as jnp
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         param = jnp.array(param)
 
@@ -368,7 +368,7 @@ class TestIntegration:
         with the tensorflow interface"""
         import tensorflow as tf
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         param = tf.Variable(param)
 
@@ -404,7 +404,7 @@ class TestIntegration:
         with the torch interface"""
         import torch
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         @qml.qnode(dev, interface=interface, diff_method=diff_method)
         def circuit(param):
@@ -431,7 +431,7 @@ class TestIntegration:
         assert np.allclose(actual, expected, atol=tol)
 
     @pytest.mark.all_interfaces
-    @pytest.mark.parametrize("device", ["default.qubit", "default.mixed", "lightning.qubit"])
+    @pytest.mark.parametrize("device", ["default.qubit.legacy", "default.mixed", "lightning.qubit"])
     @pytest.mark.parametrize("interface", ["autograd", "jax", "tensorflow", "torch"])
     @pytest.mark.parametrize(
         "params", [np.array([0.0, 0.0]), np.array([0.3, 0.4]), np.array([0.6, 0.8])]
@@ -455,7 +455,7 @@ class TestIntegration:
             circuit(params)
 
     @pytest.mark.all_interfaces
-    @pytest.mark.parametrize("device", ["default.qubit", "default.mixed", "lightning.qubit"])
+    @pytest.mark.parametrize("device", ["default.qubit.legacy", "default.mixed", "lightning.qubit"])
     @pytest.mark.parametrize("interface", ["autograd", "jax", "tensorflow", "torch"])
     @pytest.mark.parametrize(
         "params", [np.array([0.0, 0.0]), np.array([0.3, 0.4]), np.array([0.6, 0.8])]

--- a/tests/measurements/test_probs.py
+++ b/tests/measurements/test_probs.py
@@ -78,7 +78,7 @@ class TestProbs:
 
     def test_queue(self):
         """Test that the right measurement class is queued."""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         @qml.qnode(dev)
         def circuit():
@@ -97,7 +97,7 @@ class TestProbs:
     @pytest.mark.parametrize("shots", [None, 10])
     def test_shape(self, wires, shots):
         """Test that the shape is correct."""
-        dev = qml.device("default.qubit", wires=3, shots=shots)
+        dev = qml.device("default.qubit.legacy", wires=3, shots=shots)
         res = qml.probs(wires=wires)
         assert res.shape(dev, Shots(shots)) == (2 ** len(wires),)
 
@@ -106,7 +106,7 @@ class TestProbs:
         """Test that the shape is correct with the shot vector too."""
         res = qml.probs(wires=wires)
         shot_vector = (1, 2, 3)
-        dev = qml.device("default.qubit", wires=3, shots=shot_vector)
+        dev = qml.device("default.qubit.legacy", wires=3, shots=shot_vector)
         assert res.shape(dev, Shots(shot_vector)) == (
             (2 ** len(wires),),
             (2 ** len(wires),),
@@ -133,7 +133,7 @@ class TestProbs:
     @pytest.mark.parametrize("shots", [None, 100])
     def test_probs_no_arguments(self, shots):
         """Test that using ``qml.probs`` with no arguments returns the probabilities of all wires."""
-        dev = qml.device("default.qubit", wires=3, shots=shots)
+        dev = qml.device("default.qubit.legacy", wires=3, shots=shots)
 
         @qml.qnode(dev)
         def circuit():
@@ -145,7 +145,7 @@ class TestProbs:
 
     def test_full_prob(self, init_state, tol, mocker):
         """Test that the correct probability is returned."""
-        dev = qml.device("default.qubit", wires=4)
+        dev = qml.device("default.qubit.legacy", wires=4)
         spy = mocker.spy(qml.QubitDevice, "probability")
 
         state = init_state(4)
@@ -163,7 +163,7 @@ class TestProbs:
 
     def test_marginal_prob(self, init_state, tol, mocker):
         """Test that the correct marginal probability is returned."""
-        dev = qml.device("default.qubit", wires=4)
+        dev = qml.device("default.qubit.legacy", wires=4)
         spy = mocker.spy(qml.QubitDevice, "probability")
 
         state = init_state(4)
@@ -183,7 +183,7 @@ class TestProbs:
     def test_marginal_prob_more_wires(self, init_state, mocker, tol):
         """Test that the correct marginal probability is returned, when the
         states_to_binary method is used for probability computations."""
-        dev = qml.device("default.qubit", wires=4)
+        dev = qml.device("default.qubit.legacy", wires=4)
         spy_probs = mocker.spy(qml.QubitDevice, "probability")
         state = init_state(4)
 
@@ -244,7 +244,7 @@ class TestProbs:
 
     def test_integration(self, tol, mocker):
         """Test the probability is correct for a known state preparation."""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
         spy = mocker.spy(qml.QubitDevice, "probability")
 
         @qml.qnode(dev)
@@ -266,7 +266,7 @@ class TestProbs:
     def test_integration_analytic_false(self, tol, mocker, shots):
         """Test the probability is correct for a known state preparation when the
         analytic attribute is set to False."""
-        dev = qml.device("default.qubit", wires=3, shots=shots)
+        dev = qml.device("default.qubit.legacy", wires=3, shots=shots)
         spy = mocker.spy(qml.QubitDevice, "probability")
 
         @qml.qnode(dev)
@@ -283,7 +283,7 @@ class TestProbs:
     @pytest.mark.parametrize("shots", [None, 100])
     def test_batch_size(self, mocker, shots):
         """Test the probability is correct for a batched input."""
-        dev = qml.device("default.qubit", wires=1, shots=shots)
+        dev = qml.device("default.qubit.legacy", wires=1, shots=shots)
         spy = mocker.spy(qml.QubitDevice, "probability")
 
         @qml.qnode(dev)
@@ -324,7 +324,7 @@ class TestProbs:
         """Test that the finite difference and parameter shift rule
         provide the same Jacobian."""
         w = 4
-        dev = qml.device("default.qubit", wires=w)
+        dev = qml.device("default.qubit.legacy", wires=w)
         spy = mocker.spy(qml.QubitDevice, "probability")
 
         def circuit(x, y, z):
@@ -360,7 +360,7 @@ class TestProbs:
     @pytest.mark.parametrize("hermitian", [1 / np.sqrt(2) * np.array([[1, 1], [1, -1]])])
     def test_prob_generalize_param_one_qubit(self, hermitian, tol, mocker):
         """Test that the correct probability is returned."""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
         spy = mocker.spy(qml.QubitDevice, "probability")
 
         @qml.qnode(dev)
@@ -387,7 +387,7 @@ class TestProbs:
     @pytest.mark.parametrize("hermitian", [1 / np.sqrt(2) * np.array([[1, 1], [1, -1]])])
     def test_prob_generalize_param(self, hermitian, tol, mocker):
         """Test that the correct probability is returned."""
-        dev = qml.device("default.qubit", wires=3)
+        dev = qml.device("default.qubit.legacy", wires=3)
         spy = mocker.spy(qml.QubitDevice, "probability")
 
         @qml.qnode(dev)
@@ -419,7 +419,7 @@ class TestProbs:
     @pytest.mark.parametrize("hermitian", [1 / np.sqrt(2) * np.array([[1, 1], [1, -1]])])
     def test_prob_generalize_param_multiple(self, hermitian, tol, mocker):
         """Test that the correct probability is returned."""
-        dev = qml.device("default.qubit", wires=3)
+        dev = qml.device("default.qubit.legacy", wires=3)
         spy = mocker.spy(qml.QubitDevice, "probability")
 
         @qml.qnode(dev)
@@ -464,7 +464,7 @@ class TestProbs:
     def test_prob_generalize_initial_state(self, hermitian, wire, init_state, tol, mocker):
         """Test that the correct probability is returned."""
         # pylint:disable=too-many-arguments
-        dev = qml.device("default.qubit", wires=4)
+        dev = qml.device("default.qubit.legacy", wires=4)
         spy = mocker.spy(qml.QubitDevice, "probability")
         state = init_state(4)
 
@@ -508,7 +508,7 @@ class TestProbs:
     def test_operation_prob(self, operation, wire, init_state, tol, mocker):
         "Test the rotated probability with different wires and rotating operations."
         # pylint:disable=too-many-arguments
-        dev = qml.device("default.qubit", wires=4)
+        dev = qml.device("default.qubit.legacy", wires=4)
         spy = mocker.spy(qml.QubitDevice, "probability")
         state = init_state(4)
 
@@ -550,7 +550,7 @@ class TestProbs:
     @pytest.mark.parametrize("observable", [(qml.PauliX, qml.PauliY)])
     def test_observable_tensor_prob(self, observable, init_state, tol, mocker):
         "Test the rotated probability with a tensor observable."
-        dev = qml.device("default.qubit", wires=4)
+        dev = qml.device("default.qubit.legacy", wires=4)
         spy = mocker.spy(qml.QubitDevice, "probability")
         state = init_state(4)
 
@@ -588,7 +588,7 @@ class TestProbs:
         "Test that an error is returned for hamiltonians."
         H = qml.Hamiltonian(coeffs, obs)
 
-        dev = qml.device("default.qubit", wires=4)
+        dev = qml.device("default.qubit.legacy", wires=4)
         state = init_state(4)
 
         @qml.qnode(dev)
@@ -613,7 +613,7 @@ class TestProbs:
         """Test that Operators that do not have a diagonalizing_gates representation cannot
         be used in probability measurements."""
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         @qml.qnode(dev)
         def circuit():
@@ -631,7 +631,7 @@ class TestProbs:
     def test_prob_wires_and_hermitian(self, hermitian):
         """Test that we can cannot give simultaneously wires and a hermitian."""
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         @qml.qnode(dev)
         def circuit():
@@ -683,7 +683,7 @@ class TestProbs:
         assert np.allclose(res, expected)
 
     def test_non_commuting_probs_raises_error(self):
-        dev = qml.device("default.qubit", wires=5)
+        dev = qml.device("default.qubit.legacy", wires=5)
 
         @qml.qnode(dev)
         def circuit(x, y):
@@ -699,7 +699,7 @@ class TestProbs:
 
     def test_commuting_probs_in_computational_basis(self):
         """Test that `qml.probs` can be used in the computational basis with other commuting observables."""
-        dev = qml.device("default.qubit", wires=5)
+        dev = qml.device("default.qubit.legacy", wires=5)
 
         @qml.qnode(dev)
         def circuit(x, y):

--- a/tests/measurements/test_purity_measurement.py
+++ b/tests/measurements/test_purity_measurement.py
@@ -71,15 +71,15 @@ class TestPurityUnitTest:
     def test_shape_new(self, shots, shape):
         """Test the ``shape_new`` method."""
         meas = qml.purity(wires=0)
-        dev = qml.device("default.qubit", wires=1, shots=shots)
+        dev = qml.device("default.qubit.legacy", wires=1, shots=shots)
         assert meas.shape(dev, Shots(shots)) == shape
 
 
 class TestPurityIntegration:
     """Test the purity meausrement with qnodes and devices."""
 
-    devices = ["default.qubit", "lightning.qubit", "default.mixed"]
-    grad_supported_devices = ["default.qubit", "default.mixed"]
+    devices = ["default.qubit.legacy", "lightning.qubit", "default.mixed"]
+    grad_supported_devices = ["default.qubit.legacy", "default.mixed"]
     mix_supported_devices = ["default.mixed"]
 
     diff_methods = ["backprop", "finite-diff"]

--- a/tests/measurements/test_sample.py
+++ b/tests/measurements/test_sample.py
@@ -51,7 +51,7 @@ class TestSample:
     def test_sample_dimension(self, mocker, n_sample):
         """Test that the sample function outputs samples of the right size"""
 
-        dev = qml.device("default.qubit", wires=2, shots=n_sample)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=n_sample)
         spy = mocker.spy(qml.QubitDevice, "sample")
 
         @qml.qnode(dev)
@@ -76,7 +76,7 @@ class TestSample:
         """Test the output of combining expval, var and sample"""
         n_sample = 10
 
-        dev = qml.device("default.qubit", wires=3, shots=n_sample)
+        dev = qml.device("default.qubit.legacy", wires=3, shots=n_sample)
         spy = mocker.spy(qml.QubitDevice, "sample")
 
         @qml.qnode(dev, diff_method="parameter-shift")
@@ -99,7 +99,7 @@ class TestSample:
         """Test the return type and shape of sampling a single wire"""
         n_sample = 10
 
-        dev = qml.device("default.qubit", wires=1, shots=n_sample)
+        dev = qml.device("default.qubit.legacy", wires=1, shots=n_sample)
         spy = mocker.spy(qml.QubitDevice, "sample")
 
         @qml.qnode(dev)
@@ -120,7 +120,7 @@ class TestSample:
         where a rectangular array is expected"""
         n_sample = 10
 
-        dev = qml.device("default.qubit", wires=3, shots=n_sample)
+        dev = qml.device("default.qubit.legacy", wires=3, shots=n_sample)
         spy = mocker.spy(qml.QubitDevice, "sample")
 
         @qml.qnode(dev)
@@ -146,7 +146,7 @@ class TestSample:
         in combination with expvals and vars"""
         n_sample = 10
 
-        dev = qml.device("default.qubit", wires=3, shots=n_sample)
+        dev = qml.device("default.qubit.legacy", wires=3, shots=n_sample)
         spy = mocker.spy(qml.QubitDevice, "sample")
 
         @qml.qnode(dev, diff_method="parameter-shift")
@@ -167,7 +167,7 @@ class TestSample:
     def test_not_an_observable(self, mocker):
         """Test that a UserWarning is raised if the provided
         argument might not be hermitian."""
-        dev = qml.device("default.qubit", wires=2, shots=10)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=10)
         spy = mocker.spy(qml.QubitDevice, "sample")
 
         @qml.qnode(dev)
@@ -183,7 +183,7 @@ class TestSample:
     def test_observable_return_type_is_sample(self, mocker):
         """Test that the return type of the observable is :attr:`ObservableReturnTypes.Sample`"""
         n_shots = 10
-        dev = qml.device("default.qubit", wires=1, shots=n_shots)
+        dev = qml.device("default.qubit.legacy", wires=1, shots=n_shots)
         spy = mocker.spy(qml.QubitDevice, "sample")
 
         @qml.qnode(dev)
@@ -198,7 +198,7 @@ class TestSample:
 
     def test_providing_observable_and_wires(self):
         """Test that a ValueError is raised if both an observable is provided and wires are specified"""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         @qml.qnode(dev)
         def circuit():
@@ -214,7 +214,7 @@ class TestSample:
 
     def test_providing_no_observable_and_no_wires(self, mocker):
         """Test that we can provide no observable and no wires to sample function"""
-        dev = qml.device("default.qubit", wires=2, shots=1000)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=1000)
         spy = mocker.spy(qml.QubitDevice, "sample")
 
         @qml.qnode(dev)
@@ -237,7 +237,7 @@ class TestSample:
         shots1 = 1
         shots2 = 10
         shots3 = 1000
-        dev = qml.device("default.qubit", wires=num_wires, shots=[shots1, shots2, shots3])
+        dev = qml.device("default.qubit.legacy", wires=num_wires, shots=[shots1, shots2, shots3])
         spy = mocker.spy(qml.QubitDevice, "sample")
 
         @qml.qnode(dev)
@@ -266,7 +266,7 @@ class TestSample:
         """Test that we can provide no observable but specify wires to the sample function"""
         wires = [0, 2]
         wires_obj = qml.wires.Wires(wires)
-        dev = qml.device("default.qubit", wires=3, shots=1000)
+        dev = qml.device("default.qubit.legacy", wires=3, shots=1000)
         spy = mocker.spy(qml.QubitDevice, "sample")
 
         @qml.qnode(dev)
@@ -318,7 +318,7 @@ class TestSample:
 
     def test_shape_no_shots_error(self):
         """Test that the appropriate error is raised with no shots are specified"""
-        dev = qml.device("default.qubit", wires=2, shots=None)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=None)
         shots = Shots(None)
         mp = qml.sample()
 
@@ -339,7 +339,7 @@ class TestSample:
     def test_shape(self, obs):
         """Test that the shape is correct."""
         shots = 10
-        dev = qml.device("default.qubit", wires=3, shots=shots)
+        dev = qml.device("default.qubit.legacy", wires=3, shots=shots)
         res = qml.sample(obs) if obs is not None else qml.sample()
         expected = (shots,) if obs is not None else (shots, 3)
         assert res.shape(dev, Shots(shots)) == expected
@@ -347,7 +347,7 @@ class TestSample:
     @pytest.mark.parametrize("n_samples", (1, 10))
     def test_shape_wires(self, n_samples):
         """Test that the shape is correct when wires are provided."""
-        dev = qml.device("default.qubit", wires=3, shots=n_samples)
+        dev = qml.device("default.qubit.legacy", wires=3, shots=n_samples)
         mp = qml.sample(wires=(0, 1))
         assert mp.shape(dev, Shots(n_samples)) == (n_samples, 2) if n_samples != 1 else (2,)
 
@@ -363,7 +363,7 @@ class TestSample:
     def test_shape_shot_vector(self, obs):
         """Test that the shape is correct with the shot vector too."""
         shot_vector = (1, 2, 3)
-        dev = qml.device("default.qubit", wires=3, shots=shot_vector)
+        dev = qml.device("default.qubit.legacy", wires=3, shots=shot_vector)
         res = qml.sample(obs) if obs is not None else qml.sample()
         expected = ((), (2,), (3,)) if obs is not None else ((3,), (2, 3), (3, 3))
         assert res.shape(dev, Shots(shot_vector)) == expected
@@ -371,7 +371,7 @@ class TestSample:
     def test_shape_shot_vector_obs(self):
         """Test that the shape is correct with the shot vector and a observable too."""
         shot_vec = (2, 2)
-        dev = qml.device("default.qubit", wires=3, shots=shot_vec)
+        dev = qml.device("default.qubit.legacy", wires=3, shots=shot_vec)
 
         @qml.qnode(dev)
         def circuit():
@@ -394,7 +394,7 @@ class TestSample:
     @pytest.mark.parametrize("shots", [2, 100])
     def test_sample_no_arguments(self, shots):
         """Test that using ``qml.sample`` with no arguments returns the samples of all wires."""
-        dev = qml.device("default.qubit", wires=3, shots=shots)
+        dev = qml.device("default.qubit.legacy", wires=3, shots=shots)
 
         @qml.qnode(dev)
         def circuit():
@@ -425,7 +425,7 @@ def test_jitting_with_sampling_on_subset_of_wires(samples):
 
     jax.config.update("jax_enable_x64", True)
 
-    dev = qml.device("default.qubit", wires=3, shots=samples)
+    dev = qml.device("default.qubit.legacy", wires=3, shots=samples)
 
     @qml.qnode(dev, interface="jax")
     def circuit(x):

--- a/tests/measurements/test_state.py
+++ b/tests/measurements/test_state.py
@@ -125,7 +125,7 @@ class TestState:
     def test_state_shape_and_dtype(self, wires):
         """Test that the state is of correct size and dtype for a trivial circuit"""
 
-        dev = qml.device("default.qubit", wires=wires)
+        dev = qml.device("default.qubit.legacy", wires=wires)
 
         @qml.qnode(dev)
         def func():
@@ -138,7 +138,7 @@ class TestState:
     def test_return_type_is_state(self):
         """Test that the return type of the observable is State"""
 
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
 
         @qml.qnode(dev)
         def func():
@@ -154,7 +154,7 @@ class TestState:
     def test_state_correct_ghz(self, wires):
         """Test that the correct state is returned when the circuit prepares a GHZ state"""
 
-        dev = qml.device("default.qubit", wires=wires)
+        dev = qml.device("default.qubit.legacy", wires=wires)
 
         @qml.qnode(dev)
         def func():
@@ -175,7 +175,7 @@ class TestState:
         """Test that an exception is raised when a state is returned along with another return
         type"""
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         @qml.qnode(dev)
         def func():
@@ -193,7 +193,7 @@ class TestState:
         """Test that the returned state is equal to the one stored in dev.state for a template
         circuit"""
 
-        dev = qml.device("default.qubit", wires=wires)
+        dev = qml.device("default.qubit.legacy", wires=wires)
 
         weights = np.random.random(
             qml.templates.StronglyEntanglingLayers.shape(n_layers=3, n_wires=wires)
@@ -212,7 +212,7 @@ class TestState:
         """Test that the state correctly outputs in the tensorflow interface"""
         import tensorflow as tf
 
-        dev = qml.device("default.qubit", wires=4)
+        dev = qml.device("default.qubit.legacy", wires=4)
 
         @qml.qnode(dev, interface="tf")
         def func():
@@ -233,7 +233,7 @@ class TestState:
         """Test that the state correctly outputs in the torch interface"""
         import torch
 
-        dev = qml.device("default.qubit", wires=4)
+        dev = qml.device("default.qubit.legacy", wires=4)
 
         @qml.qnode(dev, interface="torch")
         def func():
@@ -252,7 +252,7 @@ class TestState:
     @pytest.mark.autograd
     def test_jacobian_not_supported(self):
         """Test if an error is raised if the jacobian method is called via qml.grad"""
-        dev = qml.device("default.qubit", wires=4)
+        dev = qml.device("default.qubit.legacy", wires=4)
 
         @qml.qnode(dev, diff_method="parameter-shift")
         def func(x):
@@ -274,7 +274,7 @@ class TestState:
     def test_no_state_capability(self, monkeypatch):
         """Test if an error is raised for devices that are not capable of returning the state.
         This is tested by changing the capability of default.qubit"""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
         capabilities = dev.capabilities().copy()
         capabilities["returns_state"] = False
 
@@ -304,7 +304,7 @@ class TestState:
         """Test that the returned state is equal to the expected returned state for all of
         PennyLane's built in statevector devices"""
 
-        dev = qml.device("default.qubit", wires=4)
+        dev = qml.device("default.qubit.legacy", wires=4)
 
         @qml.qnode(dev, diff_method=diff_method)
         def func():
@@ -408,7 +408,7 @@ class TestState:
     @pytest.mark.parametrize("wires", [[0, 2, 3, 1], ["a", -1, "b", 1000]])
     def test_custom_wire_labels(self, wires):
         """Test the state when custom wire labels are used"""
-        dev = qml.device("default.qubit", wires=wires)
+        dev = qml.device("default.qubit.legacy", wires=wires)
 
         @qml.qnode(dev, diff_method="parameter-shift")
         def func():
@@ -424,14 +424,14 @@ class TestState:
     @pytest.mark.parametrize("shots", [None, 1, 10])
     def test_shape(self, shots):
         """Test that the shape is correct for qml.state."""
-        dev = qml.device("default.qubit", wires=3, shots=shots)
+        dev = qml.device("default.qubit.legacy", wires=3, shots=shots)
         res = qml.state()
         assert res.shape(dev, Shots(shots)) == (2**3,)
 
     @pytest.mark.parametrize("s_vec", [(3, 2, 1), (1, 5, 10), (3, 1, 20)])
     def test_shape_shot_vector(self, s_vec):
         """Test that the shape is correct for qml.state with the shot vector too."""
-        dev = qml.device("default.qubit", wires=3, shots=s_vec)
+        dev = qml.device("default.qubit.legacy", wires=3, shots=s_vec)
         res = qml.state()
         assert res.shape(dev, Shots(s_vec)) == ((2**3,), (2**3,), (2**3,))
 
@@ -447,7 +447,7 @@ class TestDensityMatrix:
     # pylint: disable=too-many-public-methods
 
     @pytest.mark.parametrize("wires", range(2, 5))
-    @pytest.mark.parametrize("dev_name", ["default.qubit", "default.mixed"])
+    @pytest.mark.parametrize("dev_name", ["default.qubit.legacy", "default.mixed"])
     def test_density_matrix_shape_and_dtype(self, dev_name, wires):
         """Test that the density matrix is of correct size and dtype for a
         trivial circuit"""
@@ -463,7 +463,7 @@ class TestDensityMatrix:
         assert state_val.shape == (2, 2)
         assert state_val.dtype == np.complex128
 
-    @pytest.mark.parametrize("dev_name", ["default.qubit", "default.mixed"])
+    @pytest.mark.parametrize("dev_name", ["default.qubit.legacy", "default.mixed"])
     def test_return_type_is_state(self, dev_name):
         """Test that the return type of the observable is State"""
 
@@ -480,7 +480,7 @@ class TestDensityMatrix:
         assert obs[0].return_type is State
 
     @pytest.mark.torch
-    @pytest.mark.parametrize("dev_name", ["default.qubit", "default.mixed"])
+    @pytest.mark.parametrize("dev_name", ["default.qubit.legacy", "default.mixed"])
     @pytest.mark.parametrize("diff_method", [None, "backprop"])
     def test_correct_density_matrix_torch(self, dev_name, diff_method):
         """Test that the correct density matrix is returned using torch interface."""
@@ -504,7 +504,7 @@ class TestDensityMatrix:
             )
 
     @pytest.mark.jax
-    @pytest.mark.parametrize("dev_name", ["default.qubit", "default.mixed"])
+    @pytest.mark.parametrize("dev_name", ["default.qubit.legacy", "default.mixed"])
     @pytest.mark.parametrize("diff_method", [None, "backprop"])
     def test_correct_density_matrix_jax(self, dev_name, diff_method):
         """Test that the correct density matrix is returned using JAX interface."""
@@ -527,7 +527,7 @@ class TestDensityMatrix:
             )
 
     @pytest.mark.tf
-    @pytest.mark.parametrize("dev_name", ["default.qubit", "default.mixed"])
+    @pytest.mark.parametrize("dev_name", ["default.qubit.legacy", "default.mixed"])
     @pytest.mark.parametrize("diff_method", [None, "backprop"])
     def test_correct_density_matrix_tf(self, dev_name, diff_method):
         """Test that the correct density matrix is returned using the TensorFlow interface."""
@@ -549,7 +549,7 @@ class TestDensityMatrix:
                 qml.density_matrix(wires=0).process_state(state=dev.state, wire_order=dev.wires),
             )
 
-    @pytest.mark.parametrize("dev_name", ["default.qubit", "default.mixed"])
+    @pytest.mark.parametrize("dev_name", ["default.qubit.legacy", "default.mixed"])
     def test_correct_density_matrix_product_state_first(self, dev_name):
         """Test that the correct density matrix is returned when
         tracing out a product state"""
@@ -573,7 +573,7 @@ class TestDensityMatrix:
                 qml.density_matrix(wires=0).process_state(state=dev.state, wire_order=dev.wires),
             )
 
-    @pytest.mark.parametrize("dev_name", ["default.qubit", "default.mixed"])
+    @pytest.mark.parametrize("dev_name", ["default.qubit.legacy", "default.mixed"])
     def test_correct_density_matrix_product_state_second(self, dev_name):
         """Test that the correct density matrix is returned when
         tracing out a product state"""
@@ -596,7 +596,7 @@ class TestDensityMatrix:
                 qml.density_matrix(wires=1).process_state(state=dev.state, wire_order=dev.wires),
             )
 
-    @pytest.mark.parametrize("dev_name", ["default.qubit", "default.mixed"])
+    @pytest.mark.parametrize("dev_name", ["default.qubit.legacy", "default.mixed"])
     @pytest.mark.parametrize("return_wire_order", ([0, 1], [1, 0]))
     def test_correct_density_matrix_product_state_both(self, dev_name, return_wire_order):
         """Test that the correct density matrix is returned
@@ -625,7 +625,7 @@ class TestDensityMatrix:
                 ),
             )
 
-    @pytest.mark.parametrize("dev_name", ["default.qubit", "default.mixed"])
+    @pytest.mark.parametrize("dev_name", ["default.qubit.legacy", "default.mixed"])
     def test_correct_density_matrix_three_wires_first_two(self, dev_name):
         """Test that the correct density matrix is returned for an example with three wires,
         and tracing out the third wire."""
@@ -657,7 +657,7 @@ class TestDensityMatrix:
                 ),
             )
 
-    @pytest.mark.parametrize("dev_name", ["default.qubit", "default.mixed"])
+    @pytest.mark.parametrize("dev_name", ["default.qubit.legacy", "default.mixed"])
     def test_correct_density_matrix_three_wires_last_two(self, dev_name):
         """Test that the correct density matrix is returned for an example with three wires,
         and tracing out the first wire."""
@@ -693,7 +693,7 @@ class TestDensityMatrix:
                 ),
             )
 
-    @pytest.mark.parametrize("dev_name", ["default.qubit", "default.mixed"])
+    @pytest.mark.parametrize("dev_name", ["default.qubit.legacy", "default.mixed"])
     @pytest.mark.parametrize(
         "return_wire_order", ([0], [1], [2], [0, 1], [1, 0], [0, 2], [2, 0], [1, 2, 0], [2, 1, 0])
     )
@@ -733,7 +733,7 @@ class TestDensityMatrix:
                 ),
             )
 
-    @pytest.mark.parametrize("dev_name", ["default.qubit", "default.mixed"])
+    @pytest.mark.parametrize("dev_name", ["default.qubit.legacy", "default.mixed"])
     def test_correct_density_matrix_mixed_state(self, dev_name):
         """Test that the correct density matrix for an example with a mixed state"""
 
@@ -749,7 +749,7 @@ class TestDensityMatrix:
 
         assert np.allclose(np.array([[0.5 + 0.0j, 0.0 + 0.0j], [0.0 + 0.0j, 0.5 + 0.0j]]), density)
 
-    @pytest.mark.parametrize("dev_name", ["default.qubit", "default.mixed"])
+    @pytest.mark.parametrize("dev_name", ["default.qubit.legacy", "default.mixed"])
     def test_correct_density_matrix_all_wires(self, dev_name):
         """Test that the correct density matrix is returned when all wires are given"""
 
@@ -781,7 +781,7 @@ class TestDensityMatrix:
                 ),
             )
 
-    @pytest.mark.parametrize("dev_name", ["default.qubit", "default.mixed"])
+    @pytest.mark.parametrize("dev_name", ["default.qubit.legacy", "default.mixed"])
     def test_return_with_other_types(self, dev_name):
         """Test that an exception is raised when a state is returned along with another return
         type"""
@@ -804,7 +804,7 @@ class TestDensityMatrix:
     def test_no_state_capability(self, monkeypatch):
         """Test if an error is raised for devices that are not capable of returning
         the density matrix. This is tested by changing the capability of default.qubit"""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
         capabilities = dev.capabilities().copy()
         capabilities["returns_state"] = False
 
@@ -833,7 +833,7 @@ class TestDensityMatrix:
             func()
 
     @pytest.mark.parametrize("wires", [[0, 2], ["a", -1]])
-    @pytest.mark.parametrize("dev_name", ["default.qubit", "default.mixed"])
+    @pytest.mark.parametrize("dev_name", ["default.qubit.legacy", "default.mixed"])
     def test_custom_wire_labels(self, wires, dev_name):
         """Test that the correct density matrix for an example with a mixed
         state when using custom wires"""
@@ -860,7 +860,7 @@ class TestDensityMatrix:
             )
 
     @pytest.mark.parametrize("wires", [[3, 1], ["b", 1000]])
-    @pytest.mark.parametrize("dev_name", ["default.qubit", "default.mixed"])
+    @pytest.mark.parametrize("dev_name", ["default.qubit.legacy", "default.mixed"])
     def test_custom_wire_labels_all_wires(self, wires, dev_name):
         """Test that the correct density matrix for an example with a mixed
         state when using custom wires"""
@@ -889,14 +889,14 @@ class TestDensityMatrix:
     @pytest.mark.parametrize("shots", [None, 1, 10])
     def test_shape(self, shots):
         """Test that the shape is correct for qml.density_matrix."""
-        dev = qml.device("default.qubit", wires=3, shots=shots)
+        dev = qml.device("default.qubit.legacy", wires=3, shots=shots)
         res = qml.density_matrix(wires=[0, 1])
         assert res.shape(dev, Shots(shots)) == (2**2, 2**2)
 
     @pytest.mark.parametrize("s_vec", [(3, 2, 1), (1, 5, 10), (3, 1, 20)])
     def test_shape_shot_vector(self, s_vec):
         """Test that the shape is correct for qml.density_matrix with the shot vector too."""
-        dev = qml.device("default.qubit", wires=3, shots=s_vec)
+        dev = qml.device("default.qubit.legacy", wires=3, shots=s_vec)
         res = qml.density_matrix(wires=[0, 1])
         assert res.shape(dev, Shots(s_vec)) == (
             (2**2, 2**2),

--- a/tests/measurements/test_var.py
+++ b/tests/measurements/test_var.py
@@ -51,7 +51,7 @@ class TestVar:
     @pytest.mark.parametrize("r_dtype", [np.float32, np.float64])
     def test_value(self, tol, r_dtype, mocker, shots):
         """Test that the var function works"""
-        dev = qml.device("default.qubit", wires=2, shots=shots)
+        dev = qml.device("default.qubit.legacy", wires=2, shots=shots)
         spy = mocker.spy(qml.QubitDevice, "var")
         dev.R_DTYPE = r_dtype
 
@@ -79,7 +79,7 @@ class TestVar:
     def test_not_an_observable(self, mocker):
         """Test that a UserWarning is raised if the provided
         argument might not be hermitian."""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
         spy = mocker.spy(qml.QubitDevice, "var")
 
         @qml.qnode(dev)
@@ -94,7 +94,7 @@ class TestVar:
 
     def test_observable_return_type_is_variance(self, mocker):
         """Test that the return type of the observable is :attr:`ObservableReturnTypes.Variance`"""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
         spy = mocker.spy(qml.QubitDevice, "var")
 
         @qml.qnode(dev)
@@ -122,7 +122,7 @@ class TestVar:
     )
     def test_shape(self, obs):
         """Test that the shape is correct."""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
         res = qml.var(obs)
         # pylint: disable=use-implicit-booleaness-not-comparison
         assert res.shape(dev, Shots(None)) == ()
@@ -136,14 +136,14 @@ class TestVar:
         """Test that the shape is correct with the shot vector too."""
         res = qml.var(obs)
         shot_vector = (1, 2, 3)
-        dev = qml.device("default.qubit", wires=3, shots=shot_vector)
+        dev = qml.device("default.qubit.legacy", wires=3, shots=shot_vector)
         assert res.shape(dev, Shots(shot_vector)) == ((), (), ())
 
     @pytest.mark.parametrize("state", [np.array([0, 0, 0]), np.array([1, 0, 0, 0, 0, 0, 0, 0])])
     @pytest.mark.parametrize("shots", [None, 1000, [1000, 10000]])
     def test_projector_var(self, state, shots, mocker):
         """Tests that the variance of a ``Projector`` object is computed correctly."""
-        dev = qml.device("default.qubit", wires=3, shots=shots)
+        dev = qml.device("default.qubit.legacy", wires=3, shots=shots)
         spy = mocker.spy(qml.QubitDevice, "var")
 
         @qml.qnode(dev)
@@ -165,7 +165,7 @@ class TestVar:
             qml.s_prod(3, qml.PauliZ("h")), qml.PauliZ(8), qml.s_prod(2, qml.PauliZ(10))
         )
 
-        dev = qml.device("default.qubit", wires=["h", 8, 10])
+        dev = qml.device("default.qubit.legacy", wires=["h", 8, 10])
         spy = mocker.spy(qml.QubitDevice, "var")
 
         @qml.qnode(dev)

--- a/tests/measurements/test_vn_entropy.py
+++ b/tests/measurements/test_vn_entropy.py
@@ -76,7 +76,7 @@ class TestInitialization:
     @pytest.mark.parametrize("interface", ["autograd", "jax", "tf", "torch"])
     def test_vn_entropy(self, interface, state_vector, expected):
         """Tests the output of qml.vn_entropy"""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         @qml.qnode(dev, interface=interface)
         def circuit():
@@ -94,7 +94,7 @@ class TestInitialization:
 
     def test_queue(self):
         """Test that the right measurement class is queued."""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         @qml.qnode(dev)
         def circuit():
@@ -121,7 +121,7 @@ class TestInitialization:
     def test_shape(self, shots, shape):
         """Test the ``shape`` method."""
         meas = qml.vn_entropy(wires=0)
-        dev = qml.device("default.qubit", wires=1, shots=shots)
+        dev = qml.device("default.qubit.legacy", wires=1, shots=shots)
 
         assert meas.shape(dev, Shots(shots)) == shape
 
@@ -131,7 +131,7 @@ class TestIntegration:
 
     parameters = np.linspace(0, 2 * np.pi, 10)
 
-    devices = ["default.qubit", "default.mixed", "lightning.qubit"]
+    devices = ["default.qubit.legacy", "default.mixed", "lightning.qubit"]
 
     single_wires_list = [
         [0],
@@ -142,12 +142,12 @@ class TestIntegration:
 
     check_state = [True, False]
 
-    devices = ["default.qubit", "default.mixed"]
+    devices = ["default.qubit.legacy", "default.mixed"]
     diff_methods = ["backprop", "finite-diff"]
 
     def test_shot_vec_error(self):
         """Test an error is raised when using shot vectors with vn_entropy."""
-        dev = qml.device("default.qubit", wires=2, shots=[1, 10, 10, 1000])
+        dev = qml.device("default.qubit.legacy", wires=2, shots=[1, 10, 10, 1000])
 
         @qml.qnode(device=dev)
         def circuit(x):
@@ -187,7 +187,7 @@ class TestIntegration:
     def test_IsingXX_qnode_entropy_grad(self, param, wires, base, diff_method):
         """Test entropy for a QNode gradient with autograd."""
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         @qml.qnode(dev, diff_method=diff_method)
         def circuit_entropy(x):
@@ -234,7 +234,7 @@ class TestIntegration:
         """Test entropy for a QNode gradient with torch."""
         import torch
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         @qml.qnode(dev, interface="torch", diff_method=diff_method)
         def circuit_entropy(x):
@@ -286,7 +286,7 @@ class TestIntegration:
         """Test entropy for a QNode gradient with tf."""
         import tensorflow as tf
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         @qml.qnode(dev, interface=interface, diff_method=diff_method)
         def circuit_entropy(x):
@@ -339,7 +339,7 @@ class TestIntegration:
         """Test entropy for a QNode gradient with Jax."""
         import jax
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         @qml.qnode(dev, interface=interface, diff_method=diff_method)
         def circuit_entropy(x):
@@ -388,7 +388,7 @@ class TestIntegration:
         """Test entropy for a QNode gradient with Jax-jit."""
         import jax
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         @qml.qnode(dev, interface=interface, diff_method=diff_method)
         def circuit_entropy(x):

--- a/tests/qinfo/test_reduced_dm.py
+++ b/tests/qinfo/test_reduced_dm.py
@@ -158,7 +158,7 @@ class TestDensityMatrixQNode:
     def test_density_matrix_c_dtype(self, wires, c_dtype):
         """Test different complex dtype."""
 
-        dev = qml.device("default.qubit", wires=2, c_dtype=c_dtype)
+        dev = qml.device("default.qubit.legacy", wires=2, c_dtype=c_dtype)
 
         @qml.qnode(dev, diff_method=None)
         def circuit(x):

--- a/tests/test_debugging.py
+++ b/tests/test_debugging.py
@@ -24,9 +24,9 @@ class TestSnapshot:
 
     # pylint: disable=protected-access
     @pytest.mark.parametrize("method", [None, "backprop", "parameter-shift", "adjoint"])
-    def test_default_qubit(self, method):
+    def test_default_qubit_legacy(self, method):
         """Test that multiple snapshots are returned correctly on the state-vector simulator."""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         @qml.qnode(dev, diff_method=method)
         def circuit():
@@ -190,7 +190,7 @@ class TestSnapshot:
 
     def test_unsupported_device(self):
         """Test that an error is raised on unsupported devices."""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
         # remove attributes to simulate unsupported device
         delattr(dev, "_debugger")
         dev.operations.remove("Snapshot")

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -561,7 +561,7 @@ class TestInternalFunctions:
         prep = [op]
         ops = [qml.AngleEmbedding(features=[0.1], wires=[0], rotation="Z"), op, qml.PauliZ(wires=2)]
 
-        dev = qml.device("default.qubit", wires=3)
+        dev = qml.device("default.qubit.legacy", wires=3)
         tape = qml.tape.QuantumTape(ops=ops, measurements=[], prep=prep, shots=100)
         new_tape = dev.default_expand_fn(tape)
 
@@ -918,7 +918,7 @@ class TestDeviceInit:
         with monkeypatch.context() as m:
             m.setattr(qml, "version", lambda: "0.0.1")
             with pytest.raises(DeviceError, match="plugin requires PennyLane versions"):
-                qml.device("default.qubit", wires=0)
+                qml.device("default.qubit.legacy", wires=0)
 
     @pytest.mark.skip(reason="Reloading PennyLane messes with tape mode")
     def test_refresh_entrypoints(self, monkeypatch):
@@ -975,7 +975,7 @@ class TestDeviceInit:
 
     def test_shot_vector_property(self):
         """Tests shot vector initialization."""
-        dev = qml.device("default.qubit", wires=1, shots=[1, 3, 3, 4, 4, 4, 3])
+        dev = qml.device("default.qubit.legacy", wires=1, shots=[1, 3, 3, 4, 4, 4, 3])
         shot_vector = dev.shot_vector
         assert len(shot_vector) == 4
         assert shot_vector[0].shots == 1

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -1010,7 +1010,7 @@ class TestOperatorIntegration:
         """Test that an exception is raised if the class is defined with ALL wires,
         but then instantiated with only one"""
 
-        dev1 = qml.device("default.qubit", wires=2)
+        dev1 = qml.device("default.qubit.legacy", wires=2)
 
         class DummyOp(qml.operation.Operation):
             r"""Dummy custom operator"""
@@ -2686,7 +2686,7 @@ def test_custom_operator_is_jax_pytree():
     assert qml.equal(new_op, CustomOperator(2.3, wires=0))
 
 
-# pylint: disable=unused-import
+# pylint: disable=unused-import,no-name-in-module
 def test_get_attr():
     """Test that importing attributes of operation work as expected"""
 

--- a/tests/test_qubit_device.py
+++ b/tests/test_qubit_device.py
@@ -1148,7 +1148,7 @@ class TestExecution:
         """Test the number of times a qubit device is executed over a QNode's
         lifetime is tracked by `num_executions`"""
 
-        dev_1 = qml.device("default.qubit", wires=2)
+        dev_1 = qml.device("default.qubit.legacy", wires=2)
 
         def circuit_1(x, y):
             qml.RX(x, wires=[0])
@@ -1164,7 +1164,7 @@ class TestExecution:
         assert dev_1.num_executions == num_evals_1
 
         # test a second instance of a default qubit device
-        dev_2 = qml.device("default.qubit", wires=2)
+        dev_2 = qml.device("default.qubit.legacy", wires=2)
 
         def circuit_2(x):
             qml.RX(x, wires=[0])
@@ -1209,7 +1209,7 @@ class TestExecutionBroadcasted:
         """Test the number of times a qubit device is executed over a QNode's
         lifetime is tracked by `num_executions`"""
 
-        dev_1 = qml.device("default.qubit", wires=2)
+        dev_1 = qml.device("default.qubit.legacy", wires=2)
 
         def circuit_1(x, y):
             qml.RX(x, wires=[0])
@@ -1225,7 +1225,7 @@ class TestExecutionBroadcasted:
         assert dev_1.num_executions == num_evals_1
 
         # test a second instance of a default qubit device
-        dev_2 = qml.device("default.qubit", wires=2)
+        dev_2 = qml.device("default.qubit.legacy", wires=2)
 
         assert dev_2.num_executions == 0
 
@@ -1392,7 +1392,7 @@ class TestResourcesTracker:
     )  # Resources(wires, gates, gate_types, gate_sizes, depth, shots)
 
     devices = (
-        "default.qubit",
+        "default.qubit.legacy",
         "default.qubit.autograd",
         "default.qubit.jax",
         "default.qubit.torch",
@@ -1441,7 +1441,7 @@ class TestResourcesTracker:
     @pytest.mark.all_interfaces
     def test_tracker_grad(self):
         """Test that the tracker can track resources through a gradient computation"""
-        dev = qml.device("default.qubit", wires=1, shots=100)
+        dev = qml.device("default.qubit.legacy", wires=1, shots=100)
 
         @qml.qnode(dev, diff_method="parameter-shift")
         def circuit(x):

--- a/tests/transforms/test_batch_transform.py
+++ b/tests/transforms/test_batch_transform.py
@@ -340,7 +340,7 @@ class TestBatchTransform:
         b = 0.4
         x = 0.543
 
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
         dev = self.my_transform(dev, a, b)
 
         @qml.qnode(dev, interface="autograd")
@@ -371,7 +371,7 @@ class TestBatchTransform:
         b = 0.4
         x = 0.543
 
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
         dev = self.my_transform(a, b)(dev)  # pylint: disable=no-value-for-parameter
 
         @qml.qnode(dev, interface="autograd")
@@ -679,7 +679,7 @@ class TestMapBatchTransform:
 
     def test_result(self, mocker):
         """Test that it correctly applies the transform to be mapped"""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
         H = qml.PauliZ(0) @ qml.PauliZ(1) - qml.PauliX(0)
         x = 0.6
         y = 0.7
@@ -713,7 +713,7 @@ class TestMapBatchTransform:
 
     def test_differentiation(self):
         """Test that an execution using map_batch_transform can be differentiated"""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
         H = qml.PauliZ(0) @ qml.PauliZ(1) - qml.PauliX(0)
 
         weights = np.array([0.6, 0.8], requires_grad=True)

--- a/tests/transforms/test_tape_expand.py
+++ b/tests/transforms/test_tape_expand.py
@@ -64,7 +64,7 @@ class TestCreateExpandFn:
         """Test that passing a device alongside a stopping condition ensures
         that all operations are expanded to match the devices default gate
         set"""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
         expand_fn = qml.transforms.create_expand_fn(device=dev, depth=10, stop_at=self.crit_0)
 
         with qml.queuing.AnnotatedQueue() as q:
@@ -80,7 +80,7 @@ class TestCreateExpandFn:
     def test_device_only_expansion(self):
         """Test that passing a device ensures that all operations are expanded
         to match the devices default gate set"""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("default.qubit.legacy", wires=1)
         expand_fn = qml.transforms.create_expand_fn(device=dev, depth=10)
 
         with qml.queuing.AnnotatedQueue() as q:
@@ -432,8 +432,8 @@ class TestCreateCustomDecompExpandFn:
             qml.CNOT(wires=[0, 1])
             return qml.expval(qml.PauliZ(0))
 
-        original_dev = qml.device("default.qubit", wires=3)
-        decomp_dev = qml.device("default.qubit", wires=3, custom_decomps={})
+        original_dev = qml.device("default.qubit.legacy", wires=3)
+        decomp_dev = qml.device("default.qubit.legacy", wires=3, custom_decomps={})
 
         original_qnode = qml.QNode(circuit, original_dev, expansion_strategy="device")
         decomp_qnode = qml.QNode(circuit, decomp_dev, expansion_strategy="device")
@@ -457,8 +457,8 @@ class TestCreateCustomDecompExpandFn:
             qml.BasicEntanglerLayers([[0.1, 0.2]], wires=[0, 1])
             return qml.expval(qml.PauliZ(0))
 
-        original_dev = qml.device("default.qubit", wires=3)
-        decomp_dev = qml.device("default.qubit", wires=3, custom_decomps={})
+        original_dev = qml.device("default.qubit.legacy", wires=3)
+        decomp_dev = qml.device("default.qubit.legacy", wires=3, custom_decomps={})
 
         original_qnode = qml.QNode(circuit, original_dev, expansion_strategy="device")
         decomp_qnode = qml.QNode(circuit, decomp_dev, expansion_strategy="device")
@@ -474,7 +474,7 @@ class TestCreateCustomDecompExpandFn:
             )
         ]
 
-    @pytest.mark.parametrize("device_name", ["default.qubit", "lightning.qubit"])
+    @pytest.mark.parametrize("device_name", ["default.qubit.legacy", "lightning.qubit"])
     def test_one_custom_decomp(self, device_name):
         """Test that specifying a single custom decomposition works as expected."""
 
@@ -509,7 +509,7 @@ class TestCreateCustomDecompExpandFn:
 
         custom_decomps = {"Hadamard": custom_hadamard, "CNOT": custom_cnot}
         decomp_dev = qml.device(
-            "default.qubit", wires=2, custom_decomps=custom_decomps, decomp_depth=0
+            "default.qubit.legacy", wires=2, custom_decomps=custom_decomps, decomp_depth=0
         )
         decomp_qnode = qml.QNode(circuit, decomp_dev, expansion_strategy="device")
         _ = decomp_qnode()
@@ -529,8 +529,8 @@ class TestCreateCustomDecompExpandFn:
             qml.Hadamard(wires=0)
             return qml.expval(qml.PauliZ(0))
 
-        original_dev = qml.device("default.qubit", wires=3)
-        decomp_dev = qml.device("default.qubit", wires=3, custom_decomps={"Rot": custom_rot})
+        original_dev = qml.device("default.qubit.legacy", wires=3)
+        decomp_dev = qml.device("default.qubit.legacy", wires=3, custom_decomps={"Rot": custom_rot})
 
         original_qnode = qml.QNode(circuit, original_dev, expansion_strategy="device")
         decomp_qnode = qml.QNode(circuit, decomp_dev, expansion_strategy="device")
@@ -558,7 +558,7 @@ class TestCreateCustomDecompExpandFn:
             return qml.expval(qml.PauliZ(0))
 
         custom_decomps = {"Hadamard": custom_hadamard, qml.CNOT: custom_cnot}
-        decomp_dev = qml.device("default.qubit", wires=2, custom_decomps=custom_decomps)
+        decomp_dev = qml.device("default.qubit.legacy", wires=2, custom_decomps=custom_decomps)
         decomp_qnode = qml.QNode(circuit, decomp_dev, expansion_strategy="device")
         _ = decomp_qnode()
         decomp_ops = decomp_qnode.qtape.operations
@@ -596,7 +596,7 @@ class TestCreateCustomDecompExpandFn:
             return qml.expval(qml.PauliZ(0))
 
         custom_decomps = {"Hadamard": custom_hadamard, qml.CNOT: custom_cnot}
-        decomp_dev = qml.device("default.qubit", wires=2, custom_decomps=custom_decomps)
+        decomp_dev = qml.device("default.qubit.legacy", wires=2, custom_decomps=custom_decomps)
         decomp_qnode = qml.QNode(circuit, decomp_dev, expansion_strategy="device")
         _ = decomp_qnode()
         decomp_ops = decomp_qnode.qtape.operations
@@ -640,7 +640,7 @@ class TestCreateCustomDecompExpandFn:
 
         # BasicEntanglerLayers custom decomposition involves AngleEmbedding
         custom_decomps = {"BasicEntanglerLayers": custom_basic_entangler_layers, "RX": custom_rx}
-        decomp_dev = qml.device("default.qubit", wires=2, custom_decomps=custom_decomps)
+        decomp_dev = qml.device("default.qubit.legacy", wires=2, custom_decomps=custom_decomps)
         decomp_qnode = qml.QNode(circuit, decomp_dev, expansion_strategy="device")
         _ = decomp_qnode()
         decomp_ops = decomp_qnode.qtape.operations
@@ -677,7 +677,7 @@ class TestCreateCustomDecompExpandFn:
         # not be further decomposed even though the custom decomposition is specified.
         custom_decomps = {"BasicEntanglerLayers": custom_basic_entangler_layers, "RX": custom_rx}
         decomp_dev = qml.device(
-            "default.qubit", wires=2, custom_decomps=custom_decomps, decomp_depth=2
+            "default.qubit.legacy", wires=2, custom_decomps=custom_decomps, decomp_depth=2
         )
         decomp_qnode = qml.QNode(circuit, decomp_dev, expansion_strategy="device")
         _ = decomp_qnode()
@@ -706,7 +706,7 @@ class TestCreateCustomDecompExpandFn:
             return qml.expval(qml.PauliZ("a"))
 
         custom_decomps = {qml.RX: custom_rx}
-        decomp_dev = qml.device("default.qubit", wires="a", custom_decomps=custom_decomps)
+        decomp_dev = qml.device("default.qubit.legacy", wires="a", custom_decomps=custom_decomps)
         decomp_qnode = qml.QNode(circuit, decomp_dev, expansion_strategy="device")
         _ = decomp_qnode()
         decomp_ops = decomp_qnode.qtape.operations
@@ -732,7 +732,7 @@ class TestCreateCustomDecompExpandFn:
                 return [qml.S(wire)]
 
         custom_decomps = {CustomOp: lambda wires: [qml.T(wires), qml.T(wires)]}
-        decomp_dev = qml.device("default.qubit", wires=2, custom_decomps=custom_decomps)
+        decomp_dev = qml.device("default.qubit.legacy", wires=2, custom_decomps=custom_decomps)
 
         @qml.qnode(decomp_dev, expansion_strategy="device")
         def circuit():
@@ -751,7 +751,7 @@ class TestCreateCustomDecompExpandFn:
     def test_custom_decomp_in_separate_context(self):
         """Test that the set_decomposition context manager works."""
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qml.device("default.qubit.legacy", wires=2)
 
         @qml.qnode(dev, expansion_strategy="device")
         def circuit():


### PR DESCRIPTION
**Context:**
DefaultQubit2 will replace DefaultQubit when users call `qml.device("default.qubit")` soon. DefaultQubit will still be available with the name `"default.qubit.legacy"`. My goal in this PR is to ease that transition, because a lot of tests need changing. There are 2 reasons a test would be changed to use `default.qubit.legacy`.
1. It tests the old device
2. It fails with the new device (for better or for worse)

This PR should _only_ change tests of the first kind.

**Description of the Change:**
- Add `default.qubit.legacy` as an alternate entrypoint for `qml.devices.DefaultQubit` (which I may now sometimes call DQL). Note that `default.qubit` also points to DQL (for now)
- Change tests that need the old device to use `default.qubit.legacy` as the name to help with the transition in the future.

**Benefits:**
Future PRs will be easier to review when completing the migration.

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
#4436, #4534