### PR TITLE
fix np.random.seed usage

### DIFF
--- a/tests/gradients/finite_diff/test_spsa_gradient.py
+++ b/tests/gradients/finite_diff/test_spsa_gradient.py
@@ -81,7 +81,7 @@ class TestRademacherSampler:
         num = 5
         rng = np.random.default_rng(42)
         first_direction = _rademacher_sampler(ids, num, rng=rng)
-        np.random.seed = 0  # Setting the global seed should have no effect.
+        np.random.seed(0)  # Setting the global seed should have no effect.
         rng = np.random.default_rng(42)
         second_direction = _rademacher_sampler(ids, num, rng=rng)
         assert np.allclose(first_direction, second_direction)


### PR DESCRIPTION
No clue why regular CI doesn't catch this, but [docker CI does](https://github.com/PennyLaneAI/pennylane/actions/runs/6102750018/job/16561865816#step:4:4086). A lot.