### PR TITLE
fix probs.process_state with tf.function and batching

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -184,6 +184,11 @@
 * `tf.function` no longer breaks `ProbabilityMP.process_state` which is needed by new devices.
   [(#4470)](https://github.com/PennyLaneAI/pennylane/pull/4470)
 
+* Fix `ProbabilityMP.process_state` so it allows for proper Autograph compilation. Without this,
+  decorating a QNode that returns an `expval` with `tf.function` would fail when computing the
+  expectation.
+  [(#)]()
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -187,7 +187,7 @@
 * Fix `ProbabilityMP.process_state` so it allows for proper Autograph compilation. Without this,
   decorating a QNode that returns an `expval` with `tf.function` would fail when computing the
   expectation.
-  [(#)]()
+  [(#4590)](https://github.com/PennyLaneAI/pennylane/pull/4590)
 
 <h3>Contributors ✍️</h3>
 

--- a/tests/measurements/test_expval.py
+++ b/tests/measurements/test_expval.py
@@ -187,3 +187,23 @@ class TestExpval:
         m4 = ExpectationMP(eigvals=[-1, 1], wires=qml.wires.Wires(1))
         assert m1.hash != m4.hash
         assert m3.hash != m4.hash
+
+    @pytest.mark.tf
+    @pytest.mark.parametrize(
+        "state,expected",
+        [
+            ([1.0, 0.0], 1.0),
+            ([[1.0, 0.0], [0.0, 1.0]], [1.0, -1.0]),
+        ],
+    )
+    def test_tf_function(self, state, expected):
+        """Test that tf.function does not break process_state"""
+        import tensorflow as tf
+
+        @tf.function
+        def compute_expval(s):
+            mp = ExpectationMP(obs=qml.PauliZ(0))
+            return mp.process_state(s, wire_order=qml.wires.Wires([0]))
+
+        state = tf.Variable(state, dtype=tf.float64)
+        assert qml.math.allequal(compute_expval(state), expected)


### PR DESCRIPTION
**Context:**
Tensorflow Autograph forces discipline upon me that I do not want! It doesn't like when something returns `None` sometimes and a tuple at other times. I thought I fixed `Probability.process_state` in #4470 because a test failed with `tf.function`. Unfortunately, I put the code into a state where Autograph could no longer properly compile it, so it traced all Tensors with shape `<unknown>`, and *that* made anything shape-related afterwards fail. This includes `qml.math.dot`, which `expval.process_state` does. Though I knew this was related to the problem, only yesterday was I able to single it out. And last night I realized, I ought not try to invent a fix. I should just copy from `default.qubit(.tf)`! So this PR takes code structure from [there](https://github.com/PennyLaneAI/pennylane/blob/1f93032a5f79ea0b9076d456b5b6c30515ef347d/pennylane/devices/default_qubit_tf.py#L189-L205).

**Description of the Change:**
Re-organize `Probability.process_state` so it allows for batching _and_ TF-Autograph support. This adds a try-expect to `ProbabilityMP._get_batch_size`, but it's what DefaultQubitTF was doing before (see link above).

**Benefits:**
Everything works! I am unblocked in replacing DQL with DQ2 because this broke `KerasLayer` with `model.save`!

**Possible Drawbacks:**
The extra try-except? I also changed the prototype for `ProbabilityMP.marginal_prob` (I removed `batch_size`) but it isn't used anywhere else