### PR TITLE
`process_state` assumes flat, `state()` is always complex

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -59,6 +59,7 @@
   method will re-order the given state to go from the inputted wire-order to the process's wire-order.
   If the process's wire-order contains extra wires, it will assume those are in the zero-state.
   [(#4570)](https://github.com/PennyLaneAI/pennylane/pull/4570)
+  [(#4602)](https://github.com/PennyLaneAI/pennylane/pull/4602)
 
 * Improve builtin types support with `qml.pauli_decompose`.
   [(#4577)](https://github.com/PennyLaneAI/pennylane/pull/4577)
@@ -78,6 +79,10 @@
 * `AmplitudeEmbedding` now inherits from `StatePrep`, allowing for it to not be decomposed
   when at the beginning of a circuit, thus behaving like `StatePrep`.
   [(#4583)](https://github.com/PennyLaneAI/pennylane/pull/4583)
+
+* `StateMeasurement.process_state` now assumes the input is flat. `ProbabilityMP.process_state` has
+  been updated to reflect this assumption and avoid redundant reshaping.
+  [(#4602)](https://github.com/PennyLaneAI/pennylane/pull/4602)
 
 <h3>Breaking changes 💔</h3>
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -162,6 +162,10 @@
   been removed. Please use ``QuantumScript.bind_new_parameters`` instead.
   [(#4548)](https://github.com/PennyLaneAI/pennylane/pull/4548)
 
+* `ProbabilityMP.marginal_prob` has been removed. Its contents have been moved into `process_state`,
+  which effectively just called `marginal_prob` with `np.abs(state) ** 2`.
+  [(#4602)](https://github.com/PennyLaneAI/pennylane/pull/4602)
+
 <h3>Deprecations 👋</h3>
 
 * The ``prep`` keyword argument in ``QuantumScript`` is deprecated and will be removed from `QuantumScript`.

--- a/pennylane/devices/qubit/sampling.py
+++ b/pennylane/devices/qubit/sampling.py
@@ -27,6 +27,7 @@ from pennylane.measurements import (
 )
 from pennylane.typing import TensorLike
 from .apply_operation import apply_operation
+from .measure import flatten_state
 
 
 def _group_measurements(mps: List[Union[SampleMeasurement, ClassicalShadowMP, ShadowExpvalMP]]):
@@ -342,7 +343,8 @@ def sample_state(
     num_wires = len(wires_to_sample)
     basis_states = np.arange(2**num_wires)
 
-    probs = qml.probs(wires=wires_to_sample).process_state(state, state_wires)
+    flat_state = flatten_state(state, total_indices)
+    probs = qml.probs(wires=wires_to_sample).process_state(flat_state, state_wires)
 
     if is_state_batched:
         # rng.choice doesn't support broadcasting

--- a/pennylane/measurements/measurements.py
+++ b/pennylane/measurements/measurements.py
@@ -510,7 +510,8 @@ class StateMeasurement(MeasurementProcess):
     Any class inheriting from ``StateMeasurement`` should define its own ``process_state`` method,
     which should have the following arguments:
 
-    * state (Sequence[complex]): quantum state
+    * state (Sequence[complex]): quantum state with a flat shape. It may also have an
+        optional batch dimension
     * wire_order (Wires): wires determining the subspace that ``state`` acts on; a matrix of
         dimension :math:`2^n` acts on a subspace of :math:`n` wires
 
@@ -542,7 +543,8 @@ class StateMeasurement(MeasurementProcess):
         """Process the given quantum state.
 
         Args:
-            state (Sequence[complex]): quantum state
+            state (Sequence[complex]): quantum state with a flat shape. It may also have an
+                optional batch dimension
             wire_order (Wires): wires determining the subspace that ``state`` acts on; a matrix of
                 dimension :math:`2^n` acts on a subspace of :math:`n` wires
         """

--- a/pennylane/measurements/probs.py
+++ b/pennylane/measurements/probs.py
@@ -184,32 +184,40 @@ class ProbabilityMP(SampleMeasurement, StateMeasurement):
         return qml.math.squeeze(prob) if bin_size is None else prob
 
     def process_state(self, state: Sequence[complex], wire_order: Wires):
-        num_wires = len(wire_order)
-        batch_size = self._compute_batch_size(state, num_wires)
-        shape = (2**num_wires,) if batch_size is None else (batch_size, 2**num_wires)
-        flat_state = qml.math.reshape(state, shape)
-        real_state = qml.math.real(flat_state)
-        imag_state = qml.math.imag(flat_state)
-        return self.marginal_prob(real_state**2 + imag_state**2, wire_order)
+        prob = qml.math.real(state) ** 2 + qml.math.imag(state) ** 2
+        if self.wires == Wires([]):
+            # no need to marginalize
+            return prob
 
-    @staticmethod
-    def _compute_batch_size(state, num_wires):
-        """This logic is isolated because tf.function cannot compile without the try-except
-        clause below (it raises a tf.errors.OperatorNotAllowedInGraphError because it can't
-        handle a function that sometimes returns a tuple, and other times returns None)."""
+        # determine which subsystems are to be summed over
+        inactive_wires = Wires.unique_wires([wire_order, self.wires])
 
-        expected_shape = [2] * num_wires
-        expected_size = 2**num_wires
-        size = qml.math.size(state)
+        # translate to wire labels used by device
+        wire_map = dict(zip(wire_order, range(len(wire_order))))
+        mapped_wires = [wire_map[w] for w in self.wires]
+        inactive_wires = [wire_map[w] for w in inactive_wires]
 
-        try:
-            if qml.math.ndim(state) > len(expected_shape) or size > expected_size:
-                return size // expected_size
-        except Exception as err:  # pylint:disable=broad-except
-            if not qml.math.is_abstract(state):
-                raise err
+        # reshape the probability so that each axis corresponds to a wire
+        num_device_wires = len(wire_order)
+        shape = [2] * num_device_wires
+        desired_axes = np.argsort(np.argsort(mapped_wires))
+        flat_shape = (-1,)
+        expected_size = 2**num_device_wires
+        batch_size = qml.math.get_batch_size(prob, (expected_size,), expected_size)
+        if batch_size is not None:
+            # prob now is reshaped to have self.num_wires+1 axes in the case of broadcasting
+            shape.insert(0, batch_size)
+            inactive_wires = [idx + 1 for idx in inactive_wires]
+            desired_axes = np.insert(desired_axes + 1, 0, 0)
+            flat_shape = (batch_size, -1)
 
-        return None
+        prob = qml.math.reshape(prob, shape)
+        # sum over all inactive wires
+        prob = qml.math.sum(prob, axis=tuple(inactive_wires))
+        # rearrange wires if necessary
+        prob = qml.math.transpose(prob, desired_axes)
+        # flatten and return probabilities
+        return qml.math.reshape(prob, flat_shape)
 
     @staticmethod
     def _count_samples(indices, batch_size, dim):
@@ -236,69 +244,3 @@ class ProbabilityMP(SampleMeasurement, StateMeasurement):
                 prob[i, basis_states, b] = counts / bin_size
 
         return prob
-
-    def marginal_prob(self, prob, wire_order):
-        r"""Return the marginal probability of the computational basis
-        states by summing the probabilities on the non-specified wires.
-
-        If no wires are specified, then all the basis states representable by
-        the device are considered and no marginalization takes place.
-
-        .. note::
-
-            If the provided wires are not in the order as they appear on the device,
-            the returned marginal probabilities take this permutation into account.
-
-            For example, if the addressable wires on this device are ``Wires([0, 1, 2])`` and
-            this function gets passed ``wires=[2, 0]``, then the returned marginal
-            probability vector will take this 'reversal' of the two wires
-            into account:
-
-            .. math::
-
-                \mathbb{P}^{(2, 0)}
-                            = \left[
-                               |00\rangle, |10\rangle, |01\rangle, |11\rangle
-                              \right]
-
-        Args:
-            prob: The probabilities to return the marginal probabilities
-                for
-            wire_order (Iterable[Number, str], Number, str, Wires): wires to return
-                marginal probabilities for. Wires not provided
-                are traced out of the system.
-
-        Returns:
-            array[float]: array of the resulting marginal probabilities.
-        """
-        if self.wires == Wires([]):
-            # no need to marginalize
-            return prob
-
-        # determine which subsystems are to be summed over
-        inactive_wires = Wires.unique_wires([wire_order, self.wires])
-
-        # translate to wire labels used by device
-        wire_map = dict(zip(wire_order, range(len(wire_order))))
-        mapped_wires = [wire_map[w] for w in self.wires]
-        inactive_wires = [wire_map[w] for w in inactive_wires]
-
-        # reshape the probability so that each axis corresponds to a wire
-        num_device_wires = len(wire_order)
-        shape = [2] * num_device_wires
-        desired_axes = np.argsort(np.argsort(mapped_wires))
-        flat_shape = (-1,)
-        if (batch_size := self._compute_batch_size(prob, num_device_wires)) is not None:
-            # prob now is reshaped to have self.num_wires+1 axes in the case of broadcasting
-            shape.insert(0, batch_size)
-            inactive_wires = [idx + 1 for idx in inactive_wires]
-            desired_axes = np.insert(desired_axes + 1, 0, 0)
-            flat_shape = (batch_size, -1)
-
-        prob = qml.math.reshape(prob, shape)
-        # sum over all inactive wires
-        prob = qml.math.sum(prob, axis=tuple(inactive_wires))
-        # rearrange wires if necessary
-        prob = qml.math.transpose(prob, desired_axes)
-        # flatten and return probabilities
-        return qml.math.reshape(prob, flat_shape)

--- a/pennylane/measurements/state.py
+++ b/pennylane/measurements/state.py
@@ -170,9 +170,12 @@ class StateMP(StateMeasurement):
         pad_width = 2 ** len(wires) - 2 ** len(wire_order)
         pad = (pad_width, 0) if qml.math.get_interface(state) == "torch" else (0, pad_width)
         shape = (2,) * len(wires)
+        flat_shape = (2 ** len(wires),)
         if is_state_batched:
+            batch_size = qml.math.shape(state)[0]
             pad = ((0, 0), pad)
-            shape = (qml.math.shape(state)[0],) + shape
+            shape = (batch_size,) + shape
+            flat_shape = (batch_size,) + flat_shape
         else:
             pad = (pad,)
 
@@ -185,7 +188,7 @@ class StateMP(StateMeasurement):
         if is_state_batched:
             desired_axes = [0] + [i + 1 for i in desired_axes]
         state = qml.math.transpose(state, desired_axes)
-        return qml.math.flatten(state)
+        return qml.math.reshape(state, flat_shape)
 
 
 class DensityMatrixMP(StateMP):

--- a/pennylane/measurements/state.py
+++ b/pennylane/measurements/state.py
@@ -158,7 +158,7 @@ class StateMP(StateMeasurement):
         # pylint:disable=redefined-outer-name
         wires = self.wires
         if not wires or wire_order == wires:
-            return state
+            return qml.math.cast(state, "complex128")
 
         if not wires.contains_wires(wire_order):
             raise WireError(
@@ -188,7 +188,8 @@ class StateMP(StateMeasurement):
         if is_state_batched:
             desired_axes = [0] + [i + 1 for i in desired_axes]
         state = qml.math.transpose(state, desired_axes)
-        return qml.math.reshape(state, flat_shape)
+        state = qml.math.reshape(state, flat_shape)
+        return qml.math.cast(state, "complex128")
 
 
 class DensityMatrixMP(StateMP):

--- a/tests/drawer/test_tape_mpl.py
+++ b/tests/drawer/test_tape_mpl.py
@@ -521,7 +521,7 @@ class TestControlledGates:
 
     def check_tape_controlled_qubit_unitary(self, tape):
         """Checks the control symbols for a tape with some version of a controlled qubit unitary."""
-        _, ax = tape_mpl(tape, style=None)  # set style to None to use plt.rcParams values
+        _, ax = tape_mpl(tape, style="rcParams")  # use plt.rcParams values
         layer = 0
 
         # 5 wires -> 4 control, 1 target

--- a/tests/measurements/legacy/test_expval_legacy.py
+++ b/tests/measurements/legacy/test_expval_legacy.py
@@ -17,6 +17,7 @@ import pytest
 
 import pennylane as qml
 from pennylane.measurements import Expectation, Shots
+from pennylane.devices.qubit.measure import flatten_state
 
 
 # TODO: Remove this when new CustomMP are the default
@@ -24,7 +25,7 @@ def custom_measurement_process(device, spy):
     assert len(spy.call_args_list) > 0  # make sure method is mocked properly
 
     samples = device._samples  # pylint: disable=protected-access
-    state = device._state  # pylint: disable=protected-access
+    state = flatten_state(device._state, device.num_wires)  # pylint: disable=protected-access
     call_args_list = list(spy.call_args_list)
     for call_args in call_args_list:
         obs = call_args.args[1]

--- a/tests/measurements/legacy/test_probs_legacy.py
+++ b/tests/measurements/legacy/test_probs_legacy.py
@@ -18,6 +18,7 @@ import pytest
 import pennylane as qml
 from pennylane import numpy as pnp
 from pennylane.measurements import ProbabilityMP, Shots
+from pennylane.devices.qubit.measure import flatten_state
 
 
 # TODO: Remove this when new CustomMP are the default
@@ -25,7 +26,7 @@ def custom_measurement_process(device, spy):
     assert len(spy.call_args_list) > 0  # make sure method is mocked properly
 
     samples = device._samples  # pylint: disable=protected-access
-    state = device._state  # pylint: disable=protected-access
+    state = flatten_state(device._state, device.num_wires)  # pylint: disable=protected-access
     call_args_list = list(spy.call_args_list)
     for call_args in call_args_list:
         wires, shot_range, bin_size = (

--- a/tests/measurements/legacy/test_var_legacy.py
+++ b/tests/measurements/legacy/test_var_legacy.py
@@ -17,6 +17,7 @@ import pytest
 
 import pennylane as qml
 from pennylane.measurements import Variance, Shots
+from pennylane.devices.qubit.measure import flatten_state
 
 
 # TODO: Remove this when new CustomMP are the default
@@ -25,7 +26,7 @@ def custom_measurement_process(device, spy):
 
     # pylint: disable=protected-access
     samples = device._samples
-    state = device._state
+    state = flatten_state(device._state, device.num_wires)
     call_args_list = list(spy.call_args_list)
     for call_args in call_args_list:
         obs = call_args.args[1]

--- a/tests/measurements/test_state.py
+++ b/tests/measurements/test_state.py
@@ -91,6 +91,7 @@ class TestStateMP:
         mp = StateMP(wires=mp_wires)
         ket = np.arange(1, 5)
         result = mp.process_state(ket, wire_order=Wires(wire_order))
+        assert qml.math.get_dtype_name(result) == "complex128"
         assert np.array_equal(result, expected_state)
 
     @pytest.mark.all_interfaces
@@ -554,6 +555,19 @@ class TestState:
         state_val = func()
 
         assert np.allclose(state_expected, state_val)
+
+    def test_return_type_is_complex(self):
+        """Test that state always returns a complex value."""
+        dev = qml.devices.DefaultQubit()
+
+        @qml.qnode(dev)
+        def func():
+            qml.StatePrep([1, 0, 0, 0], wires=[0, 1])
+            return state()
+
+        state_val = func()
+        assert state_val.dtype == np.complex128
+        assert np.array_equal(state_val, [1, 0, 0, 0])
 
     @pytest.mark.parametrize("shots", [None, 1, 10])
     def test_shape(self, shots):

--- a/tests/measurements/test_state.py
+++ b/tests/measurements/test_state.py
@@ -58,7 +58,9 @@ class TestStateMP:
     def test_state_returns_itself_if_wires_match(self, interface):
         """Test that when wire_order matches the StateMP, the state is returned."""
         ket = qml.math.array([0.48j, 0.48, -0.64j, 0.36], like=interface)
-        assert StateMP(wires=[1, 0]).process_state(ket, wire_order=Wires([1, 0])) is ket
+        assert np.array_equal(
+            StateMP(wires=[1, 0]).process_state(ket, wire_order=Wires([1, 0])), ket
+        )
 
     @pytest.mark.all_interfaces
     @pytest.mark.parametrize("interface", ["numpy", "autograd", "jax", "torch", "tensorflow"])


### PR DESCRIPTION
**Context:**
While porting to DQ2, we're discovering that some features are not at parity with DQL. These are a few more. `ProbabilityMP.process_state()` thought the input was not flat! What!!

**Description of the Change:**
- Change `ProbabilityMP.process_state` to assume the input is flat (I just copy-pasted the contents of `marginal_prob` and used the new `get_batch_size` helper, I didn't change `_count_samples`, Git just thinks I did).
- Fix `StateMP.process_state` so it returns the correct shape when batched
- Fix `StateMP.process_state` so it always returns complex values, even if the inputs are not complex
- Update the docstring for `process_state` to state (haha) this assumption

**Benefits:**
- Feature parity with DQL
- Better standardization, cleaner code, better code reuse