### PR TITLE
fix torch take with axis=-1

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -213,6 +213,10 @@
   expectation.
   [(#4590)](https://github.com/PennyLaneAI/pennylane/pull/4590)
 
+* `qml.math.take` with torch now returns `tensor[..., indices]` when the user requests
+  the last axis (`axis=-1`). Without the fix, it would wrongly return `tensor[indices]`.
+  [(#4605)](https://github.com/PennyLaneAI/pennylane/pull/4605)
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane/math/single_dispatch.py
+++ b/pennylane/math/single_dispatch.py
@@ -550,6 +550,8 @@ def _take_torch(tensor, indices, axis=None, **_):
 
         return torch.index_select(tensor, dim=axis, index=indices)
 
+    if axis == -1:
+        return tensor[..., indices]
     fancy_indices = [slice(None)] * axis + [indices]
     return tensor[fancy_indices]
 

--- a/tests/math/test_functions.py
+++ b/tests/math/test_functions.py
@@ -1596,6 +1596,12 @@ class TestTake:
         expected = np.array([[[3, 3], [1, 1], [0, 0]], [[3, 3], [1, 1], [0, 0]]])
         assert fn.allclose(grad, expected)
 
+    @pytest.mark.torch
+    def test_last_axis_support_torch(self):
+        """Test that _torch_take correctly sets the last axis"""
+        x = fn.arange(8, like="torch").reshape((2, 4))
+        assert np.array_equal(fn.take(x, indices=3, axis=-1), [3, 7])
+
 
 where_data = [
     np.array([[[1, 2], [3, 4], [-1, 1]], [[5, 6], [0, -1], [2, 1]]]),


### PR DESCRIPTION
**Context:**
Basically, if you call `qml.math.take(x, indices=your_indices, axis=2, like="torch")`, it returns `x[:, :, your_indices]` (with `axis` placeholder colons, in this case 2). If `axis` is -1, we would return `x[indices]` (because `[vals] * -1` gives an empty list). That's wrong.

**Description of the Change:**
`qml.math.take` for torch with `axis=-1` correctly returns `x[..., indices]` instead of `x[indices]`.

**Benefits:**
`qml.math.take` works with `torch` and `axis=-1`.

**Related GitHub Issues:**
First reported in #4589