### PR TITLE
Fix `qnn.TorchLayer` attributes

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -213,6 +213,8 @@
   expectation.
   [(#4590)](https://github.com/PennyLaneAI/pennylane/pull/4590)
 
+* The `torch.nn.Module` properties are now accessible on a `pennylane.qnn.TorchLayer`.
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):
@@ -220,6 +222,7 @@ This release contains contributions from (in alphabetical order):
 Utkarsh Azad,
 Diego Guala,
 Soran Jahangiri,
+Christina Lee,
 Lillian M. A. Frederiksen,
 Vincent Michaud-Rioux,
 Romain Moyard,

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -214,6 +214,7 @@
   [(#4590)](https://github.com/PennyLaneAI/pennylane/pull/4590)
 
 * The `torch.nn.Module` properties are now accessible on a `pennylane.qnn.TorchLayer`.
+  [(#4611)](https://github.com/PennyLaneAI/pennylane/pull/4611)
 
 * `qml.math.take` with torch now returns `tensor[..., indices]` when the user requests
   the last axis (`axis=-1`). Without the fix, it would wrongly return `tensor[indices]`.

--- a/pennylane/qnn/torch.py
+++ b/pennylane/qnn/torch.py
@@ -449,7 +449,7 @@ class TorchLayer(Module):
         self.qnode.construct((), kwargs)
 
     def __getattr__(self, item):
-        """If the given attribute does not exist in the class, look for it in the wrapped QNode."""
+        """If the qnode is initialized, first check to see if the attribute is on the qnode."""
         if self._initialized:
             with contextlib.suppress(AttributeError):
                 return getattr(self.qnode, item)
@@ -457,7 +457,8 @@ class TorchLayer(Module):
         return super().__getattr__(item)
 
     def __setattr__(self, item, val):
-        """If the given attribute does not exist in the class, try to set it in the wrapped QNode."""
+        """If the qnode is initialized and item is already a qnode property, update it on the qnode, else
+        just update the torch layer itself."""
         if self._initialized and item in self.qnode.__dict__:
             setattr(self.qnode, item, val)
         else:

--- a/pennylane/qnn/torch.py
+++ b/pennylane/qnn/torch.py
@@ -450,8 +450,8 @@ class TorchLayer(Module):
 
     def __getattr__(self, item):
         """If the given attribute does not exist in the class, look for it in the wrapped QNode."""
-        with contextlib.suppress(AttributeError):
-            if self._initialized:
+        if self._initialized:
+            with contextlib.suppress(AttributeError):
                 return getattr(self.qnode, item)
 
         return super().__getattr__(item)

--- a/pennylane/qnn/torch.py
+++ b/pennylane/qnn/torch.py
@@ -460,7 +460,8 @@ class TorchLayer(Module):
         """If the given attribute does not exist in the class, try to set it in the wrapped QNode."""
         if self._initialized and item in self.qnode.__dict__:
             setattr(self.qnode, item, val)
-        return super().__setattr__(item, val)
+        else:
+            super().__setattr__(item, val)
 
     def _init_weights(
         self,

--- a/pennylane/qnn/torch.py
+++ b/pennylane/qnn/torch.py
@@ -458,9 +458,9 @@ class TorchLayer(Module):
 
     def __setattr__(self, item, val):
         """If the given attribute does not exist in the class, try to set it in the wrapped QNode."""
-        if self._initialized:
+        if self._initialized and item in self.qnode.__dict__:
             setattr(self.qnode, item, val)
-        self.__dict__[item] = val
+        return super().__setattr__(item, val)
 
     def _init_weights(
         self,

--- a/pennylane/qnn/torch.py
+++ b/pennylane/qnn/torch.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 """This module contains the classes and functions for integrating QNodes with the Torch Module
 API."""
+
+import contextlib
 import functools
 import inspect
 import math
@@ -448,20 +450,17 @@ class TorchLayer(Module):
 
     def __getattr__(self, item):
         """If the given attribute does not exist in the class, look for it in the wrapped QNode."""
-        if self._initialized:
-            return getattr(self.qnode, item)
+        with contextlib.suppress(AttributeError):
+            if self._initialized:
+                return getattr(self.qnode, item)
 
-        try:
-            return self.__dict__[item]
-        except KeyError as exc:
-            raise AttributeError(item) from exc
+        return super().__getattr__(item)
 
     def __setattr__(self, item, val):
         """If the given attribute does not exist in the class, try to set it in the wrapped QNode."""
         if self._initialized:
             setattr(self.qnode, item, val)
-        else:
-            self.__dict__[item] = val
+        self.__dict__[item] = val
 
     def _init_weights(
         self,

--- a/tests/qnn/test_qnn_torch.py
+++ b/tests/qnn/test_qnn_torch.py
@@ -350,6 +350,9 @@ class TestTorchLayer:  # pylint: disable=too-many-public-methods
             )
             assert weight.requires_grad
 
+        assert layer.w1 is layer._parameters["w1"]  # pylint: disable=protected-access
+        assert layer.w2 is layer._parameters["w2"]  # pylint: disable=protected-access
+
     @pytest.mark.parametrize("n_qubits, output_dim", indices_up_to(2))
     def test_evaluate_qnode(self, get_circuit, n_qubits):  # pylint: disable=no-self-use
         """Test if the _evaluate_qnode() method works correctly, i.e., that it gives the same


### PR DESCRIPTION
Fixes bug #4584 

`torch.nn.Module` has some special `__getattr__` logic that we are ignoring if the qnode has been initialized.  This bugfix makes it so the `qnn.TorchLayer.__getattr__` uses `torch.nn.Module.__getattr__` if the requested property is not on the QNode.