### PR TITLE
[CI] Bump jax version to v0.4.16

### DIFF
--- a/.github/workflows/interface-unit-tests.yml
+++ b/.github/workflows/interface-unit-tests.yml
@@ -10,7 +10,7 @@ on:
         description: The version of JAX to install for any job that requires JAX
         required: false
         type: string
-        default: 0.4.14
+        default: 0.4.16
       tensorflow_version:
         description: The version of TensorFlow to install for any job that requires TensorFlow
         required: false


### PR DESCRIPTION
A new version of jax has been released. This PR attempts to bump the version in the CI 🤞 