### PR TITLE
Tests always enable jax float64

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -221,7 +221,8 @@ except ImportError as e:
     jax_available = False
 
 
-def pytest_generate_tests(_):
+# pylint: disable=unused-argument
+def pytest_generate_tests(metafunc):
     if jax_available:
         jax.config.update("jax_enable_x64", True)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -221,6 +221,11 @@ except ImportError as e:
     jax_available = False
 
 
+def pytest_generate_tests(_):
+    if jax_available:
+        jax.config.update("jax_enable_x64", True)
+
+
 def pytest_collection_modifyitems(items, config):
     rootdir = pathlib.Path(config.rootdir)
     for item in items:

--- a/tests/devices/test_default_qubit_jax.py
+++ b/tests/devices/test_default_qubit_jax.py
@@ -97,6 +97,7 @@ class TestQNodeIntegration:
         dev = qml.device("default.qubit.jax", wires=2)
         assert dev.state.dtype == c_dtype
         assert dev.state.real.dtype == r_dtype
+        jax.config.update("jax_enable_x64", True)
 
     def test_qubit_circuit(self, tol):
         """Test that the device provides the correct


### PR DESCRIPTION
This is just a quality-of-life improvement for developers. When running the tests locally, I always get a bunch of failures not due to my change, but due to using float32 with jax instead of float64.

This just makes it so that float64 mode is always enabled.