### PR TITLE
remove pennylane numpy from qcut processing

### DIFF
--- a/tests/transforms/test_qcut.py
+++ b/tests/transforms/test_qcut.py
@@ -2216,7 +2216,7 @@ class TestMCPostprocessing:
                 assert np.allclose(arg, expected_arg)
 
         assert np.isclose(postprocessed, expected)
-        assert isinstance(convert_fixed_samples[0], type(postprocessed))
+        assert isinstance(convert_fixed_samples[0], autograd.numpy.ndarray)
 
     @pytest.mark.tf
     def test_mc_sample_postprocess_tf(self, mocker):
@@ -2873,7 +2873,8 @@ class TestCutCircuitMCTransform:
         assert isinstance(res, type(convert_input))
 
     @pytest.mark.jax
-    def test_samples_jax(self, dev_fn):
+    @pytest.mark.parametrize("use_jit", [False, True])
+    def test_samples_jax(self, dev_fn, use_jit):
         """
         Tests that `cut_circuit_mc` returns the correct type of sample
         output value in Jax
@@ -2901,6 +2902,8 @@ class TestCutCircuitMCTransform:
 
         v = 0.319
         convert_input = qml.math.convert_like(v, jax.numpy.ones(1))
+        if use_jit:
+            cut_circuit = jax.jit(cut_circuit)
 
         res = cut_circuit(convert_input)
 
@@ -2938,7 +2941,7 @@ class TestCutCircuitMCTransform:
         convert_input = qml.math.convert_like(v, autograd.numpy.ones(1))
         res = cut_circuit(convert_input)
 
-        assert isinstance(res, type(convert_input))
+        assert isinstance(res, np.float64)
 
     @pytest.mark.tf
     def test_mc_tf(self, dev_fn):


### PR DESCRIPTION
WIP bugfix for #4606 - casting the samples to `np.array` is required for `convert_like` to work, but this breaks jax-jit. Otherwise, it all works well. If I try some other casting method, torch usually complains (it doesn't like when you cast a list of vectors like `[torch.tensor([0.1, 0.2])]`, but it's ok with casting a list of scalars like `[[torch.tensor(0.1), torch.tensor(0.2)]]`)

### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      test directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `doc/releases/changelog-dev.md` file, summarizing the
      change, and including a link back to the PR.

- [ ] The PennyLane source code conforms to
      [PEP8 standards](https://www.python.org/dev/peps/pep-0008/).
      We check all of our code against [Pylint](https://www.pylint.org/).
      To lint modified files, simply `pip install pylint`, and then
      run `pylint pennylane/path/to/file.py`.

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
