### PR TITLE
No qnode post processing on informative transforms

### DIFF
--- a/pennylane/qnode.py
+++ b/pennylane/qnode.py
@@ -975,7 +975,7 @@ class QNode:
 
         # convert result to the interface in case the qfunc has no parameters
 
-        if len(self.tape.get_parameters(trainable_only=False)) == 0:
+        if len(self.tape.get_parameters(trainable_only=False)) == 0 and not self.transform_program.is_informative:
             res = _convert_to_interface(res, self.interface)
 
         if old_interface == "auto":

--- a/pennylane/qnode.py
+++ b/pennylane/qnode.py
@@ -975,7 +975,10 @@ class QNode:
 
         # convert result to the interface in case the qfunc has no parameters
 
-        if len(self.tape.get_parameters(trainable_only=False)) == 0 and not self.transform_program.is_informative:
+        if (
+            len(self.tape.get_parameters(trainable_only=False)) == 0
+            and not self.transform_program.is_informative
+        ):
             res = _convert_to_interface(res, self.interface)
 
         if old_interface == "auto":

--- a/tests/transforms/test_zx.py
+++ b/tests/transforms/test_zx.py
@@ -664,3 +664,18 @@ class TestConvertersZX:
         g = circuit(params)
 
         assert isinstance(g, pyzx.graph.graph_s.GraphS)
+
+    def test_qnode_decorator_no_params(self):
+        """Test the QNode decorator."""
+        dev = qml.device("default.qubit", wires=2)
+
+        @partial(qml.transforms.to_zx, expand_measurements=True)
+        @qml.qnode(device=dev)
+        def circuit():
+            qml.PauliZ(wires=0)
+            qml.PauliX(wires=1)
+            return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
+
+        g = circuit()
+
+        assert isinstance(g, pyzx.graph.graph_s.GraphS)


### PR DESCRIPTION
**Description of the Change:**

Remove post processing applied by qnode when there are no parameters for informative transforms.
