### PR TITLE
BasisState accepts floats

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -74,6 +74,7 @@
   [(#4594)](https://github.com/PennyLaneAI/pennylane/pull/4594)
   [(#4436)](https://github.com/PennyLaneAI/pennylane/pull/4436)
   [(#4620)](https://github.com/PennyLaneAI/pennylane/pull/4620)
+  [(#4632)](https://github.com/PennyLaneAI/pennylane/pull/4632)
 
 <h3>Improvements 🛠</h3>
 
@@ -160,7 +161,6 @@
 * `StateMeasurement.process_state` now assumes the input is flat. `ProbabilityMP.process_state` has
   been updated to reflect this assumption and avoid redundant reshaping.
   [(#4602)](https://github.com/PennyLaneAI/pennylane/pull/4602)
-
 
 <h3>Breaking changes 💔</h3>
 

--- a/pennylane/ops/qubit/state_preparation.py
+++ b/pennylane/ops/qubit/state_preparation.py
@@ -105,15 +105,16 @@ class BasisState(StatePrepBase):
         if (num_wires := len(self.wires)) != len(prep_vals):
             raise ValueError("BasisState parameter and wires must be of equal length.")
 
+        prep_vals = math.cast(prep_vals, int)
         if wire_order is None:
-            indices = math.cast(prep_vals, int)
+            indices = prep_vals
         else:
             if not Wires(wire_order).contains_wires(self.wires):
                 raise WireError("Custom wire_order must contain all BasisState wires")
             num_wires = len(wire_order)
             indices = [0] * num_wires
             for base_wire_label, value in zip(self.wires, prep_vals):
-                indices[wire_order.index(base_wire_label)] = int(value)
+                indices[wire_order.index(base_wire_label)] = value
 
         ket = np.zeros((2,) * num_wires)
         ket[tuple(indices)] = 1

--- a/pennylane/ops/qubit/state_preparation.py
+++ b/pennylane/ops/qubit/state_preparation.py
@@ -106,14 +106,14 @@ class BasisState(StatePrepBase):
             raise ValueError("BasisState parameter and wires must be of equal length.")
 
         if wire_order is None:
-            indices = prep_vals
+            indices = math.cast(prep_vals, int)
         else:
             if not Wires(wire_order).contains_wires(self.wires):
                 raise WireError("Custom wire_order must contain all BasisState wires")
             num_wires = len(wire_order)
             indices = [0] * num_wires
             for base_wire_label, value in zip(self.wires, prep_vals):
-                indices[wire_order.index(base_wire_label)] = value
+                indices[wire_order.index(base_wire_label)] = int(value)
 
         ket = np.zeros((2,) * num_wires)
         ket[tuple(indices)] = 1

--- a/tests/ops/qubit/test_state_prep.py
+++ b/tests/ops/qubit/test_state_prep.py
@@ -240,9 +240,11 @@ class TestStateVector:
 
     @pytest.mark.all_interfaces
     @pytest.mark.parametrize("interface", ["numpy", "jax", "torch", "tensorflow"])
-    def test_BasisState_state_vector_preserves_parameter_type(self, interface):
+    @pytest.mark.parametrize("dtype_like", [0, 0.0])
+    def test_BasisState_state_vector_preserves_parameter_type(self, interface, dtype_like):
         """Tests that given an array of some type, the resulting state_vector is also that type."""
-        basis_op = qml.BasisState(qml.math.array([0, 1], like=interface), wires=[1, 2])
+        basis_state = qml.math.cast_like(qml.math.asarray([0, 1], like=interface), dtype_like)
+        basis_op = qml.BasisState(basis_state, wires=[1, 2])
         assert qml.math.get_interface(basis_op.state_vector()) == interface
         assert qml.math.get_interface(basis_op.state_vector(wire_order=[0, 1, 2])) == interface
 


### PR DESCRIPTION
**Context:**
It's been failing all over since switching DQL with DQ2

**Description of the Change:**
Cast inputted values to float before making state vector

**Benefits:**
Float inputs are accepted and CI is fixed, parity with DQL

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
PennyLaneAI/pennylane-rigetti#142