### PR TITLE
device test suite: convert kwargs values to ints and floats

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -171,6 +171,8 @@
 
 <h3>Breaking changes 💔</h3>
 
+* The device test suite now converts device kwargs to integers or floats if they can be converted to integers or floats.
+
 * `MeasurementProcess.eigvals()` now raises an `EigvalsUndefinedError` if the measurement observable
   does not have eigenvalues.
   [(#4544)](https://github.com/PennyLaneAI/pennylane/pull/4544)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -172,6 +172,7 @@
 <h3>Breaking changes 💔</h3>
 
 * The device test suite now converts device kwargs to integers or floats if they can be converted to integers or floats.
+  [(#4640)](https://github.com/PennyLaneAI/pennylane/pull/4640)
 
 * `MeasurementProcess.eigvals()` now raises an `EigvalsUndefinedError` if the measurement observable
   does not have eigenvalues.

--- a/pennylane/devices/tests/conftest.py
+++ b/pennylane/devices/tests/conftest.py
@@ -150,7 +150,8 @@ class StoreDictKeyPair(argparse.Action):
     >>> args.my_dict
     {"v1": "k1", "v2": "5"}
 
-    Note that strings will be converted to ints and floats is possible.
+    Note that strings will be converted to ints and floats if possible.
+
     """
 
     # pylint: disable=too-few-public-methods

--- a/pennylane/devices/tests/conftest.py
+++ b/pennylane/devices/tests/conftest.py
@@ -130,6 +130,16 @@ def pytest_runtest_setup(item):
 # These functions are required to define the device name to run the tests for
 
 
+def _convert_to_int_or_float(value):
+    try:
+        return int(value)
+    except ValueError:
+        try:
+            return float(value)
+        except ValueError:
+            return value
+
+
 class StoreDictKeyPair(argparse.Action):
     """Argparse action for storing key-value pairs as a dictionary.
 
@@ -140,7 +150,7 @@ class StoreDictKeyPair(argparse.Action):
     >>> args.my_dict
     {"v1": "k1", "v2": "5"}
 
-    Note that all keys will be strings.
+    Note that strings will be converted to ints and floats is possible.
     """
 
     # pylint: disable=too-few-public-methods
@@ -153,7 +163,7 @@ class StoreDictKeyPair(argparse.Action):
         my_dict = {}
         for kv in values:
             k, v = kv.split("=")
-            my_dict[k] = v
+            my_dict[k] = _convert_to_int_or_float(v)
         setattr(namespace, self.dest, my_dict)
 
 


### PR DESCRIPTION
The pasqal device was unable to be tested with the device test suite because it kept the `control_radius=2` as a string instead of converting `2` to an integer.

This change converts any kwargs to int or float if they can be converted to ints or floats.