### PR TITLE
Include results on tracker for default.qubit

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -80,8 +80,10 @@
 
 * `default.qubit` now tracks the number of equivalent qpu executions and total shots
   when the device is sampling. Note that `"simulations"` denotes the number of simulation passes, where as
-  `"executions"` denotes how many different computational bases need to be sampled in.
+  `"executions"` denotes how many different computational bases need to be sampled in. Additionally, the
+  new `default.qubit` also tracks the results of `device.execute`.
   [(#4628)](https://github.com/PennyLaneAI/pennylane/pull/4628)
+  [(#4649)](https://github.com/PennyLaneAI/pennylane/pull/4649)
 
 * The `JacobianProductCalculator` abstract base class and implementation `TransformJacobianProducts`
   have been added to `pennylane.interfaces.jacobian_products`.

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -335,12 +335,13 @@ class DefaultQubit(Device):
         if self.tracker.active:
             self.tracker.update(batches=1)
             self.tracker.record()
-            for c in circuits:
+            for i, c in enumerate(circuits):
                 qpu_executions, shots = get_num_shots_and_executions(c)
                 if c.shots:
                     self.tracker.update(
                         simulations=1,
                         executions=qpu_executions,
+                        results=results[i],
                         shots=shots,
                         resources=c.specs["resources"],
                     )
@@ -348,7 +349,7 @@ class DefaultQubit(Device):
                     self.tracker.update(
                         simulations=1,
                         executions=qpu_executions,
-                        results=results,
+                        results=results[i],
                         resources=c.specs["resources"],
                     )
                 self.tracker.record()

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -129,6 +129,7 @@ class DefaultQubit(Device):
         * ``resources``: the :class:`~.resource.Resources` for the executed circuit.
         * ``simulations``: the number of simulations performed. One simulation can cover multiple QPU executions, such as for non-commuting measurements and batched parameters.
         * ``batches``: The number of times :meth:`~.execute` is called.
+        * ``results``: The results of each call of :meth:`~.execute`
         * ``derivative_batches``: How many times :meth:`~.compute_derivatives` is called.
         * ``execute_and_derivative_batches``: How many times :meth:`~.execute_and_compute_derivatives` is called
         * ``vjp_batches``: How many times :meth:`~.compute_vjp` is called
@@ -298,24 +299,6 @@ class DefaultQubit(Device):
             is_single_circuit = True
             circuits = [circuits]
 
-        if self.tracker.active:
-            self.tracker.update(batches=1)
-            self.tracker.record()
-            for c in circuits:
-                qpu_executions, shots = get_num_shots_and_executions(c)
-                if c.shots:
-                    self.tracker.update(
-                        simulations=1,
-                        executions=qpu_executions,
-                        shots=shots,
-                        resources=c.specs["resources"],
-                    )
-                else:
-                    self.tracker.update(
-                        simulations=1, executions=qpu_executions, resources=c.specs["resources"]
-                    )
-                self.tracker.record()
-
         max_workers = execution_config.device_options.get("max_workers", self._max_workers)
         interface = (
             execution_config.interface
@@ -348,6 +331,27 @@ class DefaultQubit(Device):
 
             # reset _rng to mimic serial behavior
             self._rng = np.random.default_rng(self._rng.integers(2**31 - 1))
+
+        if self.tracker.active:
+            self.tracker.update(batches=1)
+            self.tracker.record()
+            for c in circuits:
+                qpu_executions, shots = get_num_shots_and_executions(c)
+                if c.shots:
+                    self.tracker.update(
+                        simulations=1,
+                        executions=qpu_executions,
+                        shots=shots,
+                        resources=c.specs["resources"],
+                    )
+                else:
+                    self.tracker.update(
+                        simulations=1,
+                        executions=qpu_executions,
+                        results=results,
+                        resources=c.specs["resources"],
+                    )
+                self.tracker.record()
 
         return results[0] if is_single_circuit else results
 

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -337,11 +337,12 @@ class DefaultQubit(Device):
             self.tracker.record()
             for i, c in enumerate(circuits):
                 qpu_executions, shots = get_num_shots_and_executions(c)
+                res = np.array(results[i]) if isinstance(results[i], Number) else results[i]
                 if c.shots:
                     self.tracker.update(
                         simulations=1,
                         executions=qpu_executions,
-                        results=results[i],
+                        results=res,
                         shots=shots,
                         resources=c.specs["resources"],
                     )
@@ -349,7 +350,7 @@ class DefaultQubit(Device):
                     self.tracker.update(
                         simulations=1,
                         executions=qpu_executions,
-                        results=results[i],
+                        results=res,
                         resources=c.specs["resources"],
                     )
                 self.tracker.record()

--- a/tests/devices/test_default_qubit_tracking.py
+++ b/tests/devices/test_default_qubit_tracking.py
@@ -55,7 +55,7 @@ class TestTracking:
             "batches": [1, 1],
             "executions": [1, 1, 1],
             "simulations": [1, 1, 1],
-            "results": [(1.0,), (1.0, 1.0), (1.0, 1.0)],
+            "results": [1.0, 1.0, 1.0],
             "resources": [Resources(num_wires=1), Resources(num_wires=1), Resources(num_wires=1)],
             "derivative_batches": [1],
             "derivatives": [1],
@@ -70,7 +70,7 @@ class TestTracking:
         assert tracker.latest == {
             "executions": 1,
             "simulations": 1,
-            "results": (1.0, 1.0),
+            "results": 1,
             "resources": Resources(num_wires=1),
         }
 

--- a/tests/devices/test_default_qubit_tracking.py
+++ b/tests/devices/test_default_qubit_tracking.py
@@ -55,6 +55,7 @@ class TestTracking:
             "batches": [1, 1],
             "executions": [1, 1, 1],
             "simulations": [1, 1, 1],
+            "results": [(1.0,), (1.0, 1.0), (1.0, 1.0)],
             "resources": [Resources(num_wires=1), Resources(num_wires=1), Resources(num_wires=1)],
             "derivative_batches": [1],
             "derivatives": [1],
@@ -69,6 +70,7 @@ class TestTracking:
         assert tracker.latest == {
             "executions": 1,
             "simulations": 1,
+            "results": (1.0, 1.0),
             "resources": Resources(num_wires=1),
         }
 


### PR DESCRIPTION
DQL included results in the tracker, DQ2 currently does not. Results for each call of `execute` added here.