### PR TITLE
remove _qfunc_output from tape

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -181,6 +181,10 @@
   interface-specific scalar data, eg `[(tf.Variable(1.1), tf.Variable(2.2))]`.
   [(#4603)](https://github.com/PennyLaneAI/pennylane/pull/4603)
 
+* `_qfunc_output` has been removed from `QuantumScript`, as it is no longer necessary. There is
+  still a `_qfunc_output` property on `QNode` instances.
+  [(#4651)](https://github.com/PennyLaneAI/pennylane/pull/4651)
+
 <h3>Breaking changes 💔</h3>
 
 * The device test suite now converts device kwargs to integers or floats if they can be converted to integers or floats.

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -103,7 +103,6 @@ def _local_tape_expand(tape, depth, stop_at):
     new_tape.all_sampled = tape.all_sampled
     new_tape._batch_size = tape.batch_size
     new_tape._output_dim = tape.output_dim
-    new_tape._qfunc_output = tape._qfunc_output
     return new_tape
 
 

--- a/pennylane/gradients/parameter_shift_cv.py
+++ b/pennylane/gradients/parameter_shift_cv.py
@@ -18,7 +18,6 @@ of a CV-based quantum tape.
 # pylint: disable=protected-access,too-many-arguments,too-many-statements,too-many-branches
 import itertools
 import warnings
-from collections.abc import Sequence
 
 import numpy as np
 
@@ -263,11 +262,6 @@ def var_param_shift(tape, dev_wires, argnum=None, shifts=None, gradient_recipes=
     gradient_tapes.extend(pdA2_tapes)
 
     def processing_fn(results):
-        # HOTFIX: Apply the same squeezing as in qml.QNode to make the transform output consistent.
-        # pylint: disable=protected-access
-        if tape._qfunc_output is not None and not isinstance(tape._qfunc_output, Sequence):
-            results = [qml.math.squeeze(res) for res in results]
-
         mask = qml.math.convert_like(qml.math.reshape(var_mask, [-1, 1]), results[0])
         f0 = qml.math.expand_dims(results[0], -1)
 
@@ -435,11 +429,6 @@ def second_order_param_shift(tape, dev_wires, argnum=None, shifts=None, gradient
         gradient_values.append(None)
 
     def processing_fn(results):
-        # HOTFIX: Apply the same squeezing as in qml.QNode to make the transform output consistent.
-        # pylint: disable=protected-access
-        if tape._qfunc_output is not None and not isinstance(tape._qfunc_output, Sequence):
-            results = [qml.math.squeeze(res) for res in results]
-
         grads = []
         start = 0
 

--- a/pennylane/ops/functions/map_wires.py
+++ b/pennylane/ops/functions/map_wires.py
@@ -104,7 +104,6 @@ def map_wires(
 
         out = input.__class__(ops=ops, measurements=measurements, shots=input.shots)
         out.trainable_params = input.trainable_params
-        out._qfunc_output = input._qfunc_output  # pylint: disable=protected-access
         return out
 
     if callable(input):

--- a/pennylane/optimize/adaptive.py
+++ b/pennylane/optimize/adaptive.py
@@ -46,8 +46,7 @@ def append_gate(tape: QuantumTape, params, gates) -> (Sequence[QuantumTape], Cal
         g.data = new_params
         new_operations.append(g)
 
-    new_tape = QuantumTape(tape.operations + new_operations, tape.measurements, shots=tape.shots)
-    new_tape._qfunc_output = tape._qfunc_output
+    new_tape = type(tape)(tape.operations + new_operations, tape.measurements, shots=tape.shots)
 
     def null_postprocessing(results):
         """A postprocesing function returned by a transform that only converts the batch of results

--- a/pennylane/optimize/riemannian_gradient.py
+++ b/pennylane/optimize/riemannian_gradient.py
@@ -82,8 +82,7 @@ def append_time_evolution(
         with QueuingManager.stop_recording():
             new_operations.append(qml.templates.ApproxTimeEvolution(riemannian_gradient, t, n))
 
-    new_tape = QuantumTape(new_operations, tape.measurements, shots=tape.shots)
-    new_tape._qfunc_output = tape._qfunc_output  # pylint: disable=protected-access
+    new_tape = type(tape)(new_operations, tape.measurements, shots=tape.shots)
 
     def null_postprocessing(results):
         """A postprocesing function returned by a transform that only converts the batch of results

--- a/pennylane/qnode.py
+++ b/pennylane/qnode.py
@@ -26,7 +26,7 @@ import pennylane as qml
 from pennylane import Device
 from pennylane.interfaces import INTERFACE_MAP, SUPPORTED_INTERFACES, set_shots
 from pennylane.measurements import CountsMP, MidMeasureMP, Shots
-from pennylane.tape import QuantumTape, make_qscript
+from pennylane.tape import QuantumTape, QuantumScript
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
@@ -843,8 +843,10 @@ class QNode:
         if old_interface == "auto":
             self.interface = qml.math.get_interface(*args, *list(kwargs.values()))
 
-        self._tape = make_qscript(self.func, shots)(*args, **kwargs)
-        self._qfunc_output = self.tape._qfunc_output
+        with qml.queuing.AnnotatedQueue() as q:
+            self._qfunc_output = self.func(*args, **kwargs)
+
+        self._tape = QuantumScript.from_queue(q, shots)
 
         params = self.tape.get_parameters(trainable_only=False)
         self.tape.trainable_params = qml.math.get_trainable_indices(params)
@@ -998,10 +1000,10 @@ class QNode:
                 else self.device._shot_vector
             )
             if has_partitioned_shots:
-                res = [type(self.tape._qfunc_output)(r) for r in res]
+                res = [type(self._qfunc_output)(r) for r in res]
                 res = tuple(res)
             else:
-                res = type(self.tape._qfunc_output)(res)
+                res = type(self._qfunc_output)(res)
 
         if override_shots is not False:
             # restore the initialization gradient function

--- a/pennylane/tape/qscript.py
+++ b/pennylane/tape/qscript.py
@@ -212,7 +212,6 @@ class QuantumScript:
         self._specs = None
         self._output_dim = 0
         self._batch_size = None
-        self._qfunc_output = None
 
         self.wires = _empty_wires
         self.num_wires = 0
@@ -761,7 +760,6 @@ class QuantumScript:
 
         new_tape = self.__class__(new_operations, new_measurements, shots=self.shots)
         new_tape.trainable_params = self.trainable_params
-        new_tape._qfunc_output = self._qfunc_output
 
         return new_tape
 
@@ -896,7 +894,6 @@ class QuantumScript:
         new_qscript._obs_sharing_wires_id = self._obs_sharing_wires_id
         new_qscript._batch_size = self.batch_size
         new_qscript._output_dim = self.output_dim
-        new_qscript._qfunc_output = copy.copy(self._qfunc_output)
 
         return new_qscript
 
@@ -1258,12 +1255,9 @@ def make_qscript(fn, shots: Optional[Union[int, Sequence, Shots]] = None):
 
     def wrapper(*args, **kwargs):
         with AnnotatedQueue() as q:
-            result = fn(*args, **kwargs)
+            fn(*args, **kwargs)
 
-        qscript = QuantumScript.from_queue(q, shots)
-        qscript._qfunc_output = result
-
-        return qscript
+        return QuantumScript.from_queue(q, shots)
 
     return wrapper
 

--- a/pennylane/tape/tape.py
+++ b/pennylane/tape/tape.py
@@ -231,7 +231,6 @@ def expand_tape(tape, depth=1, stop_at=None, expand_measurements=False):
     new_tape.all_sampled = tape.all_sampled
     new_tape._batch_size = tape.batch_size
     new_tape._output_dim = tape.output_dim
-    new_tape._qfunc_output = tape._qfunc_output
     return new_tape
 
 
@@ -285,7 +284,6 @@ def expand_tape_state_prep(tape, skip_first=True):
     new_tape.all_sampled = tape.all_sampled
     new_tape._batch_size = tape.batch_size
     new_tape._output_dim = tape.output_dim
-    new_tape._qfunc_output = tape._qfunc_output
     return new_tape
 
 

--- a/pennylane/transforms/compile.py
+++ b/pennylane/transforms/compile.py
@@ -178,10 +178,9 @@ def compile(
                 tapes, _ = transf(expanded_tape)
                 expanded_tape = tapes[0]
 
-    new_tape = QuantumTape(
+    new_tape = type(tape)(
         expanded_tape.operations, expanded_tape.measurements, shots=expanded_tape.shots
     )
-    new_tape._qfunc_output = tape._qfunc_output  # pylint: disable=protected-access
 
     def null_postprocessing(results):
         """A postprocesing function returned by a transform that only converts the batch of results

--- a/pennylane/transforms/convert_to_numpy_parameters.py
+++ b/pennylane/transforms/convert_to_numpy_parameters.py
@@ -86,5 +86,4 @@ def convert_to_numpy_parameters(circuit: QuantumScript) -> QuantumScript:
     new_circuit = circuit.__class__(new_ops, new_measurements, shots=circuit.shots)
     # must preserve trainable params as we lose information about the machine learning interface
     new_circuit.trainable_params = circuit.trainable_params
-    new_circuit._qfunc_output = circuit._qfunc_output
     return new_circuit

--- a/pennylane/transforms/core/transform_dispatcher.py
+++ b/pennylane/transforms/core/transform_dispatcher.py
@@ -213,7 +213,16 @@ class TransformDispatcher:
             for op in transformed_tape.circuit:
                 qml.apply(op)
 
-            return qfunc_output
+            if isinstance(qfunc_output, qml.measurements.MeasurementProcess):
+                if len(transformed_tape.measurements) > 1:
+                    return tuple(transformed_tape.measurements)
+                return transformed_tape.measurements[0]
+
+            if isinstance(qfunc_output, (tuple, list)):
+                return type(qfunc_output)(transformed_tape.measurements)
+
+            interface = qml.math.get_interface(qfunc_output)
+            return qml.math.asarray(transformed_tape.measurements, like=interface)
 
         return qfunc_transformed
 

--- a/pennylane/transforms/core/transform_dispatcher.py
+++ b/pennylane/transforms/core/transform_dispatcher.py
@@ -213,16 +213,19 @@ class TransformDispatcher:
             for op in transformed_tape.circuit:
                 qml.apply(op)
 
+            mps = transformed_tape.measurements
+
+            if not mps:
+                return qfunc_output
+
             if isinstance(qfunc_output, qml.measurements.MeasurementProcess):
-                if len(transformed_tape.measurements) > 1:
-                    return tuple(transformed_tape.measurements)
-                return transformed_tape.measurements[0]
+                return tuple(mps) if len(mps) > 1 else mps[0]
 
             if isinstance(qfunc_output, (tuple, list)):
-                return type(qfunc_output)(transformed_tape.measurements)
+                return type(qfunc_output)(mps)
 
             interface = qml.math.get_interface(qfunc_output)
-            return qml.math.asarray(transformed_tape.measurements, like=interface)
+            return qml.math.asarray(mps, like=interface)
 
         return qfunc_transformed
 

--- a/pennylane/transforms/defer_measurements.py
+++ b/pennylane/transforms/defer_measurements.py
@@ -199,7 +199,6 @@ def defer_measurements(tape: QuantumTape) -> (Sequence[QuantumTape], Callable):
         new_measurements.append(mp)
 
     new_tape = type(tape)(new_operations, new_measurements, shots=tape.shots)
-    new_tape._qfunc_output = tape._qfunc_output  # pylint: disable=protected-access
 
     def null_postprocessing(results):
         """A postprocesing function returned by a transform that only converts the batch of results

--- a/pennylane/transforms/optimization/cancel_inverses.py
+++ b/pennylane/transforms/optimization/cancel_inverses.py
@@ -175,8 +175,7 @@ def cancel_inverses(tape: QuantumTape) -> (Sequence[QuantumTape], Callable):
         operations.append(current_gate)
         continue
 
-    new_tape = QuantumTape(operations, tape.measurements, shots=tape.shots)
-    new_tape._qfunc_output = tape._qfunc_output  # pylint: disable=protected-access
+    new_tape = type(tape)(operations, tape.measurements, shots=tape.shots)
 
     def null_postprocessing(results):
         """A postprocesing function returned by a transform that only converts the batch of results

--- a/pennylane/transforms/optimization/commute_controlled.py
+++ b/pennylane/transforms/optimization/commute_controlled.py
@@ -223,8 +223,7 @@ def commute_controlled(tape: QuantumTape, direction="right") -> (Sequence[Quantu
     else:
         op_list = _commute_controlled_left(tape.operations)
 
-    new_tape = QuantumTape(op_list, tape.measurements, shots=tape.shots)
-    new_tape._qfunc_output = tape._qfunc_output  # pylint: disable=protected-access
+    new_tape = type(tape)(op_list, tape.measurements, shots=tape.shots)
 
     def null_postprocessing(results):
         """A postprocesing function returned by a transform that only converts the batch of results

--- a/pennylane/transforms/optimization/merge_amplitude_embedding.py
+++ b/pennylane/transforms/optimization/merge_amplitude_embedding.py
@@ -112,8 +112,7 @@ def merge_amplitude_embedding(tape: QuantumTape) -> (Sequence[QuantumTape], Call
     for gate in not_amplitude_embedding:
         new_operations.append(gate)
 
-    new_tape = QuantumTape(new_operations, tape.measurements, shots=tape.shots)
-    new_tape._qfunc_output = tape._qfunc_output  # pylint: disable=protected-access
+    new_tape = type(tape)(new_operations, tape.measurements, shots=tape.shots)
 
     def null_postprocessing(results):
         """A postprocesing function returned by a transform that only converts the batch of results

--- a/pennylane/transforms/optimization/merge_rotations.py
+++ b/pennylane/transforms/optimization/merge_rotations.py
@@ -182,8 +182,7 @@ def merge_rotations(
         # Remove the first gate from the working list
         list_copy.pop(0)
 
-    new_tape = QuantumTape(new_operations, tape.measurements, shots=tape.shots)
-    new_tape._qfunc_output = tape._qfunc_output  # pylint: disable=protected-access
+    new_tape = type(tape)(new_operations, tape.measurements, shots=tape.shots)
 
     def null_postprocessing(results):
         """A postprocesing function returned by a transform that only converts the batch of results

--- a/pennylane/transforms/optimization/pattern_matching.py
+++ b/pennylane/transforms/optimization/pattern_matching.py
@@ -176,8 +176,7 @@ def pattern_matching_optimization(
     Exact and practical pattern matching for quantum circuit optimization.
     `doi.org/10.1145/3498325 <https://dl.acm.org/doi/abs/10.1145/3498325>`_
     """
-    # pylint: disable=protected-access, too-many-branches
-    original_qfunc_output = tape._qfunc_output  # pylint: disable=protected-access
+    # pylint: disable=too-many-branches
     consecutive_wires = Wires(range(len(tape.wires)))
     inverse_wires_map = OrderedDict(zip(consecutive_wires, tape.wires))
 
@@ -259,8 +258,7 @@ def pattern_matching_optimization(
                 qscript = QuantumScript.from_queue(q_inside)
                 tape = qml.map_wires(input=qscript, wire_map=inverse_wires_map)
 
-    new_tape = QuantumTape(tape.operations, tape.measurements, shots=tape.shots)
-    new_tape._qfunc_output = original_qfunc_output  # pylint: disable=protected-access
+    new_tape = type(tape)(tape.operations, tape.measurements, shots=tape.shots)
 
     def null_postprocessing(results):
         """A postprocesing function returned by a transform that only converts the batch of results

--- a/pennylane/transforms/optimization/remove_barrier.py
+++ b/pennylane/transforms/optimization/remove_barrier.py
@@ -77,8 +77,7 @@ def remove_barrier(tape: QuantumTape) -> (Sequence[QuantumTape], Callable):
         list_copy.pop(0)
         continue
 
-    new_tape = QuantumTape(operations, tape.measurements, shots=tape.shots)
-    new_tape._qfunc_output = tape._qfunc_output  # pylint: disable=protected-access
+    new_tape = type(tape)(operations, tape.measurements, shots=tape.shots)
 
     def null_postprocessing(results):
         """A postprocesing function returned by a transform that only converts the batch of results

--- a/pennylane/transforms/optimization/single_qubit_fusion.py
+++ b/pennylane/transforms/optimization/single_qubit_fusion.py
@@ -165,8 +165,7 @@ def single_qubit_fusion(
         # Remove the starting gate from the list
         list_copy.pop(0)
 
-    new_tape = QuantumTape(new_operations, tape.measurements, shots=tape.shots)
-    new_tape._qfunc_output = tape._qfunc_output  # pylint: disable=protected-access
+    new_tape = type(tape)(new_operations, tape.measurements, shots=tape.shots)
 
     def null_postprocessing(results):
         """A postprocesing function returned by a transform that only converts the batch of results

--- a/pennylane/transforms/optimization/undo_swaps.py
+++ b/pennylane/transforms/optimization/undo_swaps.py
@@ -108,8 +108,7 @@ def undo_swaps(tape: QuantumTape) -> (Sequence[QuantumTape], Callable):
 
         gates.reverse()
 
-    new_tape = QuantumTape(gates, tape.measurements, shots=tape.shots)
-    new_tape._qfunc_output = tape._qfunc_output  # pylint: disable=protected-access
+    new_tape = type(tape)(gates, tape.measurements, shots=tape.shots)
 
     def null_postprocessing(results):
         """A postprocesing function returned by a transform that only converts the batch of results

--- a/pennylane/transforms/transpile.py
+++ b/pennylane/transforms/transpile.py
@@ -147,6 +147,7 @@ def transpile(
             # for the shortest path between the two qubits in the connectivity graph. We then move the q2 into the
             # neighbourhood of q1 via swap operations.
             source_wire, dest_wire = op.wires
+            # pylint:disable=too-many-function-args
             shortest_path = nx.algorithms.shortest_path(coupling_graph, source_wire, dest_wire)
             path_length = len(shortest_path) - 1
             wires_to_swap = [shortest_path[(i - 1) : (i + 1)] for i in range(path_length, 1, -1)]
@@ -166,8 +167,7 @@ def transpile(
             # adjust qubit indices in remaining ops + measurements to new mapping
             list_op_copy = [_adjust_op_indices(op, map_wires) for op in list_op_copy]
             measurements = [_adjust_mmt_indices(m, map_wires) for m in measurements]
-    new_tape = QuantumTape(gates, measurements, shots=tape.shots)
-    new_tape._qfunc_output = tuple(measurements)  # pylint: disable=protected-access
+    new_tape = type(tape)(gates, measurements, shots=tape.shots)
 
     def null_postprocessing(results):
         """A postprocesing function returned by a transform that only converts the batch of results

--- a/pennylane/transforms/transpile.py
+++ b/pennylane/transforms/transpile.py
@@ -193,7 +193,7 @@ def _adjust_mmt_indices(_m, _map_wires):
 
     # change wires of observable
     if _m.obs is None:
-        return type(_m)(eigvals=_m.eigvals, wires=_new_wires)
+        return type(_m)(eigvals=_m.eigvals(), wires=_new_wires)
 
     _new_obs = type(_m.obs)(wires=_new_wires, id=_m.obs.id)
     return type(_m)(obs=_new_obs)

--- a/pennylane/transforms/unitary_to_rot.py
+++ b/pennylane/transforms/unitary_to_rot.py
@@ -156,8 +156,7 @@ def unitary_to_rot(tape: QuantumTape) -> (Sequence[QuantumTape], Callable):
         else:
             operations.append(op)
 
-    new_tape = QuantumTape(operations, measurements=tape.measurements, shots=tape.shots)
-    new_tape._qfunc_output = tape._qfunc_output  # pylint: disable=protected-access
+    new_tape = type(tape)(operations, measurements=tape.measurements, shots=tape.shots)
 
     def null_postprocessing(results):
         """A postprocesing function returned by a transform that only converts the batch of results

--- a/tests/ops/functions/test_map_wires.py
+++ b/tests/ops/functions/test_map_wires.py
@@ -127,11 +127,9 @@ class TestMapWiresTapes:
             qml.expval(op=qml.PauliZ(1))
 
         tape = QuantumScript.from_queue(q_tape, shots=shots)
-        tape._qfunc_output = (qml.expval(qml.PauliZ(1)),)  # pylint: disable=protected-access
         # TODO: Use qml.equal when supported
 
         m_tape = qml.map_wires(tape, wire_map=wire_map)
-        assert m_tape._qfunc_output is tape._qfunc_output  # pylint: disable=protected-access
         m_op = m_tape.operations[0]
         m_obs = m_tape.observables[0]
         assert qml.equal(m_op, mapped_op)

--- a/tests/optimize/test_adaptive.py
+++ b/tests/optimize/test_adaptive.py
@@ -158,7 +158,7 @@ def test_append_gate(circuit):
     final_circuit, fn = qml.optimize.adaptive.append_gate(qnode.tape, param, [gate])
 
     assert isinstance(final_circuit, list)
-    assert isinstance(fn(final_circuit), qml.tape.QuantumTape)
+    assert isinstance(fn(final_circuit), qml.tape.QuantumScript)
 
 
 @qml.qnode(dev)

--- a/tests/tape/test_qscript.py
+++ b/tests/tape/test_qscript.py
@@ -39,7 +39,6 @@ class TestInitialization:
         assert qs._specs is None
         assert qs._shots.total_shots is None
         assert qs._batch_size is None
-        assert qs._qfunc_output is None
         assert qs.wires == qml.wires.Wires([])
         assert qs.num_wires == 0
         assert qs.is_sampled is False
@@ -484,7 +483,6 @@ class TestScriptCopying:
         ops = [qml.RY(0.5, wires=1), qml.CNOT((0, 1))]
         m = [qml.expval(qml.PauliZ(0) @ qml.PauliY(1))]
         qs = QuantumScript(ops, m, prep=prep)
-        qs._qfunc_output = np.array(123)
 
         copied_qs = qs.copy()
 
@@ -503,8 +501,6 @@ class TestScriptCopying:
         assert qs.get_parameters() == copied_qs.get_parameters()
         assert qs.wires == copied_qs.wires
         assert qs.data == copied_qs.data
-        assert qs._qfunc_output == copied_qs._qfunc_output
-        assert qs._qfunc_output is not copied_qs._qfunc_output
         assert qs.shots is copied_qs.shots
 
         # check that the output dim is identical


### PR DESCRIPTION
**Context:**
`_qfunc_output` is a pain to keep track of, and we only need it for QNode handling. `QNode._qfunc_output` still exists, but `tape._qfunc_output` does not.

**Description of the Change:**
- Remove `tape._qfunc_output`
- update qnode.construct to not use `make_qscript` so it can get the tape result shape
- remove squeezing logic from `param_shift_cv` (the only other place that used `tape._qfunc_output`) because it doesn't accept parameter broadcasting, shot vectors, or multiple measurements, so it really never needs it
- if I saw a transform creating a QuantumTape explicitly, I changed it to create `type(tape)` so QuantumScript in = QuantumScript out
- qfunc_transform is the only other place that needed the qfunc output, so I added some handling there that's quite similar to qnode, but slightly different. see in-line comment

**Benefits:**
everyone hates `tape._qfunc_output` so this should bring peace of mind. less work, one less private attribute being used publicly.

**Possible Drawbacks:**
Maybe harder to see the output shape of a tape? `tape.measurements` should mostly make it clear.