### PR TITLE
Increase codecov coverage

### DIFF
--- a/tests/ops/qubit/test_parametric_ops.py
+++ b/tests/ops/qubit/test_parametric_ops.py
@@ -1247,6 +1247,23 @@ class TestMatrix:
         evs_expected = [1, 1, -qml.math.exp(1j * phi), qml.math.exp(1j * phi)]
         assert qml.math.allclose(evs, evs_expected)
 
+    @pytest.mark.tf
+    @pytest.mark.parametrize("phi", np.linspace(-np.pi, np.pi, 10))
+    def test_pcphase_eigvals_tf(self, phi):
+        """Test eigenvalues computation for PCPhase using Tensorflow interface"""
+        import tensorflow as tf
+
+        phi = 0.5432
+        param_tf = tf.Variable(phi)
+
+        op = qml.PCPhase(param_tf, dim=2, wires=[0, 1])
+        evs = qml.PCPhase.compute_eigvals(*op.parameters, **op.hyperparameters)
+        evs_expected = np.array(
+            [np.exp(1j * phi), np.exp(1j * phi), np.exp(-1j * phi), np.exp(-1j * phi)]
+        )
+
+        assert qml.math.allclose(evs, evs_expected)
+
     def test_isingxy(self, tol):
         """Test that the IsingXY operation is correct"""
         assert np.allclose(qml.IsingXY.compute_matrix(0), np.identity(4), atol=tol, rtol=0)
@@ -1519,6 +1536,25 @@ class TestMatrix:
         assert np.allclose(
             qml.IsingZZ.compute_eigvals(param), np.diagonal(get_expected(param)), atol=tol, rtol=0
         )
+
+    @pytest.mark.tf
+    @pytest.mark.parametrize("phi", np.linspace(-np.pi, np.pi, 10))
+    def test_isingzz_eigvals_tf(self, phi):
+        """Test eigenvalues computation for IsingXY using Tensorflow interface"""
+        import tensorflow as tf
+
+        param_tf = tf.Variable(phi)
+        evs = qml.IsingZZ.compute_eigvals(param_tf)
+
+        def get_expected(theta):
+            neg_imag = np.exp(-1j * theta / 2)
+            plus_imag = np.exp(1j * theta / 2)
+            expected = np.array(
+                np.diag([neg_imag, plus_imag, plus_imag, neg_imag]), dtype=np.complex128
+            )
+            return expected
+
+        assert qml.math.allclose(evs, np.diagonal(get_expected(phi)))
 
     def test_isingzz_broadcasted(self, tol):
         """Test that the broadcasted IsingZZ operation is correct"""

--- a/tests/ops/qubit/test_parametric_ops.py
+++ b/tests/ops/qubit/test_parametric_ops.py
@@ -1253,7 +1253,6 @@ class TestMatrix:
         """Test eigenvalues computation for PCPhase using Tensorflow interface"""
         import tensorflow as tf
 
-        phi = 0.5432
         param_tf = tf.Variable(phi)
 
         op = qml.PCPhase(param_tf, dim=2, wires=[0, 1])

--- a/tests/test_vqe.py
+++ b/tests/test_vqe.py
@@ -314,12 +314,13 @@ class TestVQE:
     # pylint: disable=protected-access
     @pytest.mark.torch
     @pytest.mark.slow
+    @pytest.mark.parametrize("dev_name", ["default.qubit", "default.qubit.legacy"])
     @pytest.mark.parametrize("shots", [None, [(8000, 5)], [(8000, 5), (9000, 4)]])
-    def test_optimize_torch(self, shots):
+    def test_optimize_torch(self, dev_name, shots):
         """Test that an ExpvalCost with observable optimization gives the same result as another
         ExpvalCost without observable optimization."""
 
-        dev = qml.device("default.qubit", wires=4, shots=shots)
+        dev = qml.device(dev_name, wires=4, shots=shots)
 
         hamiltonian1 = copy.copy(big_hamiltonian)
         hamiltonian2 = copy.copy(big_hamiltonian)

--- a/tests/transforms/test_hamiltonian_expand.py
+++ b/tests/transforms/test_hamiltonian_expand.py
@@ -306,7 +306,9 @@ class TestHamiltonianExpand:
         r = len(dev.execute(tape))
 
         # create a "result" whose dimensions force the condition len(r_group) != 1)
-        processing_fn([np.ones(r + 1)])
+        processed_res = processing_fn([np.ones(r + 1)])
+
+        assert np.all(processed_res == [1, 1])
 
 
 with AnnotatedQueue() as s_tape1:

--- a/tests/transforms/test_hamiltonian_expand.py
+++ b/tests/transforms/test_hamiltonian_expand.py
@@ -292,6 +292,22 @@ class TestHamiltonianExpand:
             g = gtape.gradient(res, var)
             assert np.allclose(list(g[0]) + list(g[1]), output2)
 
+    def test_processing_function_conditional_clause(self):
+        """Test the conditional logic for `len(c_group) == 1` and `len(r_group) != 1`
+        in the processing function returned by hamiltonian_expand."""
+
+        # hamiltonian with a single c_group of `len(c_group) == 1`
+        H = qml.Hamiltonian([1], [qml.PauliX(0)])
+        tape = qml.tape.QuantumTape([], [qml.expval(H)])
+
+        tape, processing_fn = qml.transforms.hamiltonian_expand(tape)
+
+        # get dimensions of execution result
+        r = len(dev.execute(tape))
+
+        # create a "result" whose dimensions force the condition len(r_group) != 1)
+        processing_fn([np.ones(r + 1)])
+
 
 with AnnotatedQueue() as s_tape1:
     qml.PauliX(0)


### PR DESCRIPTION
**Context:**
After updating to the new device API, codecov was unhappy with the lost coverage [here](https://app.codecov.io/gh/PennyLaneAI/pennylane/pull/4436/indirect-changes?src=pr&el=tree-more). Coverage loss was reported in:

1. testing TF support for `compute_eigvals` for `PCPhase` and `IsingZZ`
2. one line in interfaces/torch.py
3. one line in transforms/hamiltonian_expand.py

**Description of the Change:**

Added tests for points 1 and 3. 

Reintroduced running `test_vqe.py` test `test_optimize_torch` with DQL (in addition to DQ2) to maintain code coverage from before the device swap, as its not clear if that line is reachable with DQ2.

**Benefits:**

Code coverage didn't decrease when switching device API
