### PR TITLE
Fix grover operator work wires

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -337,6 +337,7 @@
 <h3>Bug fixes 🐛</h3>
 
 * Providing `work_wires=None` to `qml.GroverOperator` no longer interprets `None` as a wire.
+  [(#4668)](https://github.com/PennyLaneAI/pennylane/pull/4668)
 
 * Fixed issue where `__copy__` method of the `qml.Select()` operator attempted to access un-initialized data.
 [(#4551)](https://github.com/PennyLaneAI/pennylane/pull/4551)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -336,6 +336,8 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Providing `work_wires=None` to `qml.GroverOperator` no longer interprets `None` as a wire.
+
 * Fixed issue where `__copy__` method of the `qml.Select()` operator attempted to access un-initialized data.
 [(#4551)](https://github.com/PennyLaneAI/pennylane/pull/4551)
 

--- a/pennylane/templates/subroutines/grover.py
+++ b/pennylane/templates/subroutines/grover.py
@@ -113,7 +113,10 @@ class GroverOperator(Operation):
         if (not hasattr(wires, "__len__")) or (len(wires) < 2):
             raise ValueError("GroverOperator must have at least two wires provided.")
 
-        self._hyperparameters = {"n_wires": len(wires), "work_wires": Wires(work_wires)}
+        self._hyperparameters = {
+            "n_wires": len(wires),
+            "work_wires": Wires(work_wires) if work_wires else Wires([]),
+        }
 
         super().__init__(wires=wires, id=id)
 

--- a/pennylane/templates/subroutines/grover.py
+++ b/pennylane/templates/subroutines/grover.py
@@ -115,7 +115,7 @@ class GroverOperator(Operation):
 
         self._hyperparameters = {
             "n_wires": len(wires),
-            "work_wires": Wires(work_wires) if work_wires else Wires([]),
+            "work_wires": Wires(work_wires) if work_wires is not None else Wires([]),
         }
 
         super().__init__(wires=wires, id=id)

--- a/tests/templates/test_subroutines/test_grover.py
+++ b/tests/templates/test_subroutines/test_grover.py
@@ -62,6 +62,12 @@ def test_work_wires():
     assert ops[2].hyperparameters["work_wires"] == work_wire
 
 
+def test_work_wires_None():
+    """Test that work wires of None are not inpreted as work wires."""
+    op = qml.GroverOperator(wires=(0, 1, 2, 3), work_wires=None)
+    assert op.hyperparameters["work_wires"] == qml.wires.Wires([])
+
+
 @pytest.mark.parametrize("bad_wires", [0, (0,), tuple()])
 def test_single_wire_error(bad_wires):
     """Assert error raised when called with only a single wire"""


### PR DESCRIPTION
The default to `GroverOperator` for work wires was `None`. Unfortunately this was being interpreted as `work_wires = Wires([None,])`.  This PR makes it so that `work_wires=None` is interpreted as `work_wires = Wires([])`.

Fixes https://github.com/PennyLaneAI/pennylane-qiskit/issues/339