### PR TITLE
[WIP] replace indexing with slicing in qchem integrals 

### DIFF
--- a/pennylane/qchem/integrals.py
+++ b/pennylane/qchem/integrals.py
@@ -774,7 +774,7 @@ def _hermite_coulomb(t, u, v, n, p, dr):
     Returns:
         array[float]: value of the Hermite integral
     """
-    x, y, z = dr[0], dr[1], dr[2]
+    x, y, z = dr[0:3]
     T = p * (dr**2).sum(axis=0)
     r = 0
 
@@ -967,12 +967,17 @@ def electron_repulsion(la, lb, lc, ld, ra, rb, rc, rd, alpha, beta, gamma, delta
         + delta * rd[:, np.newaxis, np.newaxis, np.newaxis, np.newaxis]
     ) / (gamma + delta)
 
-    g_t = [expansion(l1, l2, ra[0], rb[0], alpha, beta, t) for t in range(l1 + l2 + 1)]
-    g_u = [expansion(m1, m2, ra[1], rb[1], alpha, beta, u) for u in range(m1 + m2 + 1)]
-    g_v = [expansion(n1, n2, ra[2], rb[2], alpha, beta, v) for v in range(n1 + n2 + 1)]
-    g_r = [expansion(l3, l4, rc[0], rd[0], gamma, delta, r) for r in range(l3 + l4 + 1)]
-    g_s = [expansion(m3, m4, rc[1], rd[1], gamma, delta, s) for s in range(m3 + m4 + 1)]
-    g_w = [expansion(n3, n4, rc[2], rd[2], gamma, delta, w) for w in range(n3 + n4 + 1)]
+    ra0, ra1, ra2 = ra[0:3]
+    rb0, rb1, rb2 = rb[0:3]
+    rc0, rc1, rc2 = rc[0:3]
+    rd0, rd1, rd2 = rc[0:3]
+
+    g_t = [expansion(l1, l2, ra0, rb0, alpha, beta, t) for t in range(l1 + l2 + 1)]
+    g_u = [expansion(m1, m2, ra1, rb1, alpha, beta, u) for u in range(m1 + m2 + 1)]
+    g_v = [expansion(n1, n2, ra2, rb2, alpha, beta, v) for v in range(n1 + n2 + 1)]
+    g_r = [expansion(l3, l4, rc0, rd0, gamma, delta, r) for r in range(l3 + l4 + 1)]
+    g_s = [expansion(m3, m4, rc1, rd1, gamma, delta, s) for s in range(m3 + m4 + 1)]
+    g_w = [expansion(n3, n4, rc2, rd2, gamma, delta, w) for w in range(n3 + n4 + 1)]
 
     g = 0.0
     lengths = [l1 + l2 + 1, m1 + m2 + 1, n1 + n2 + 1, l3 + l4 + 1, m3 + m4 + 1, n3 + n4 + 1]


### PR DESCRIPTION
**Context:**
The qchem code for computing molecular integrals needs to be modified for a better compatibility with JAX as described [here](https://app.shortcut.com/xanaduai/write/IkRvYyI6I3V1aWQgIjYyZGIxMTAxLTg2NDEtNGI0OS1hNmNkLWRiMTE5ZTJhY2FmYyI=).

**Description of the Change:**
The function `integrals.py` is modified to replace indexing with slicing in the computationally expensive functions `electron_repulsion` and `_hermite_coulomb`.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
