### PR TITLE
0.33 pre-release changes

### DIFF
--- a/doc/development/release_notes.md
+++ b/doc/development/release_notes.md
@@ -3,7 +3,7 @@ Release notes
 
 This page contains the release notes for PennyLane.
 
-.. mdinclude:: ../releases/changelog-dev.md
+.. mdinclude:: ../releases/changelog-0.33.0.md
 
 .. mdinclude:: ../releases/changelog-0.32.0.md
 

--- a/doc/releases/changelog-0.32.0.md
+++ b/doc/releases/changelog-0.32.0.md
@@ -1,6 +1,6 @@
 :orphan:
 
-# Release 0.32.0 (current release)
+# Release 0.32.0
 
 <h3>New features since last release</h3>
 

--- a/doc/releases/changelog-0.33.0.md
+++ b/doc/releases/changelog-0.33.0.md
@@ -1,6 +1,6 @@
 :orphan:
 
-# Release 0.33.0-dev (development release)
+# Release 0.33.0 (current release)
 
 <h3>New features since last release</h3>
 

--- a/pennylane/_version.py
+++ b/pennylane/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.33.0-dev"
+__version__ = "0.33.0"


### PR DESCRIPTION
PR 1:
- rename changelog-dev.md to changelog-0.X.0.md,
- change changelog-dev reference to changelog-0.X reference in release_notes.md,
- move "current release" label from changelog-0.X-1 to changelog-0.X,
- In changelog-0.X.0.md update title from 0.X.0-dev to 0.X.0
- change _version.py reference from 0.X.0-dev to 0.X.0