### PR TITLE
Always draw with device wires first

### DIFF
--- a/pennylane/drawer/draw.py
+++ b/pennylane/drawer/draw.py
@@ -259,7 +259,6 @@ def _draw_qnode(
             qnode.construct(args, kwargs)
             program, _ = qnode.device.preprocess()
             tapes = program([qnode.tape])
-            _wire_order = wire_order or qnode.tape.wires
         else:
             original_expansion_strategy = getattr(qnode, "expansion_strategy", None)
             try:
@@ -280,7 +279,7 @@ def _draw_qnode(
             finally:
                 qnode.expansion_strategy = original_expansion_strategy
 
-            _wire_order = wire_order or qnode.device.wires
+        _wire_order = wire_order or qnode.device.wires or qnode.tape.wires
 
         if tapes is not None:
             cache = {"tape_offset": 0, "matrices": []}
@@ -572,7 +571,6 @@ def _draw_mpl_qnode(
             program, _ = qnode.device.preprocess()
             tapes, _ = program([qnode.tape])
             tape = tapes[0]
-            _wire_order = wire_order or qnode.tape.wires
         else:
             original_expansion_strategy = getattr(qnode, "expansion_strategy", None)
 
@@ -583,7 +581,8 @@ def _draw_mpl_qnode(
                 qnode.expansion_strategy = original_expansion_strategy
 
             tape = qnode.tape
-            _wire_order = wire_order or qnode.device.wires
+
+        _wire_order = wire_order or qnode.device.wires or tape.wires
 
         return tape_mpl(
             tape,

--- a/pennylane/transforms/tape_expand.py
+++ b/pennylane/transforms/tape_expand.py
@@ -467,7 +467,7 @@ def set_decomposition(custom_decomps, dev, decomp_depth=10):
     Now let's set up a context where the custom decomposition will be applied:
 
     >>> with qml.transforms.set_decomposition({qml.CNOT : custom_cnot}, dev):
-    ...     print(qml.draw(circuit, wire_order=[0, 1])())
+    ...     print(qml.draw(circuit)())
     0: ────╭●────┤  <Z>
     1: ──H─╰Z──H─┤
 


### PR DESCRIPTION
**Context:**
Sometimes, tapes will use standard wires (eg. `[0, 1, 2]`) but will report them out of order, depending on the order in which they are used. If we are drawing a qnode (in other words, a circuit bound to a device), we have the true wire order available to us.

**Description of the Change:**
Use the device wire order wherever possible in drawing logic

**Benefits:**
We don't accidentally draw in funky wire orders like `[1, 0]`. See the docstring that I changed in `tape_expand` as an example (before this PR, it would swap wires without the `wire_order` specified)

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
first found in #4711 