### PR TITLE
run qnode transforms on new device with draw_mpl as well

### DIFF
--- a/pennylane/drawer/draw.py
+++ b/pennylane/drawer/draw.py
@@ -577,10 +577,22 @@ def _draw_mpl_qnode(
             try:
                 qnode.expansion_strategy = expansion_strategy or original_expansion_strategy
                 qnode.construct(args, kwargs_qnode)
+                if isinstance(qnode.device, qml.devices.Device):
+                    program = qnode.transform_program
+                    if any(
+                        isinstance(op, qml.measurements.MidMeasureMP)
+                        for op in qnode.tape.operations
+                    ):
+                        tapes, _ = qml.defer_measurements(qnode.tape, device=qnode.device)
+                    else:
+                        tapes = [qnode.tape]
+
+                    tapes, _ = program(tapes)
+                    tape = tapes[0]
+                else:
+                    tape = qnode.tape
             finally:
                 qnode.expansion_strategy = original_expansion_strategy
-
-            tape = qnode.tape
 
         _wire_order = wire_order or qnode.device.wires or tape.wires
 

--- a/pennylane/drawer/draw.py
+++ b/pennylane/drawer/draw.py
@@ -259,7 +259,6 @@ def _draw_qnode(
             qnode.construct(args, kwargs)
             program, _ = qnode.device.preprocess()
             tapes = program([qnode.tape])
-            _wire_order = wire_order or qnode.tape.wires
         else:
             original_expansion_strategy = getattr(qnode, "expansion_strategy", None)
             try:
@@ -280,7 +279,7 @@ def _draw_qnode(
             finally:
                 qnode.expansion_strategy = original_expansion_strategy
 
-            _wire_order = wire_order or qnode.device.wires
+        _wire_order = wire_order or qnode.device.wires or qnode.tape.wires
 
         if tapes is not None:
             cache = {"tape_offset": 0, "matrices": []}
@@ -572,7 +571,6 @@ def _draw_mpl_qnode(
             program, _ = qnode.device.preprocess()
             tapes, _ = program([qnode.tape])
             tape = tapes[0]
-            _wire_order = wire_order or qnode.tape.wires
         else:
             original_expansion_strategy = getattr(qnode, "expansion_strategy", None)
 
@@ -583,7 +581,8 @@ def _draw_mpl_qnode(
                 qnode.expansion_strategy = original_expansion_strategy
 
             tape = qnode.tape
-            _wire_order = wire_order or qnode.device.wires
+
+        _wire_order = wire_order or qnode.device.wires or tape.wires
 
         return tape_mpl(
             tape,

--- a/pennylane/transforms/tape_expand.py
+++ b/pennylane/transforms/tape_expand.py
@@ -467,7 +467,7 @@ def set_decomposition(custom_decomps, dev, decomp_depth=10):
     Now let's set up a context where the custom decomposition will be applied:
 
     >>> with qml.transforms.set_decomposition({qml.CNOT : custom_cnot}, dev):
-    ...     print(qml.draw(circuit, wire_order=[0, 1])())
+    ...     print(qml.draw(circuit)())
     0: ────╭●────┤  <Z>
     1: ──H─╰Z──H─┤
 


### PR DESCRIPTION
**Context:**
This is already being done in the text drawer, I'm just copying it over for consistency.

**Description of the Change:**
If expansion_strategy is _not_ "device" but we're drawing a QNode with a new device, run the QNode transform program on the tape before drawing it. This is for draw_mpl, it's already present for `draw`

**Benefits:**
Parity between the two draw tools

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
done in #4595 for the text drawer