### PR TITLE
Bump lightning; `WrappedObj` coverage fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ requirements = [
     "semantic-version>=2.7",
     "autoray>=0.6.1",
     "cachetools",
-    "pennylane-lightning>=0.32",
+    "pennylane-lightning>=0.33",
     "requests",
     "typing_extensions",
 ]

--- a/tests/test_queuing.py
+++ b/tests/test_queuing.py
@@ -464,6 +464,13 @@ class TestWrappedObj:
         wo2 = WrappedObj(obj2)
         assert wo1 != wo2
 
+    def test_wrapped_obj_eq_false_other_obj(self):
+        """Test that WrappedObj.__eq__ returns False when the object being compared is not
+        a WrappedObj."""
+        op = qml.PauliX(0)
+        wo = WrappedObj(op)
+        assert wo != op
+
     def test_wrapped_obj_eq_true(self):
         """Test that ``WrappedObj.__eq__`` returns True when expected."""
         op = qml.PauliX(0)


### PR DESCRIPTION
* Bump lightning requirement in `setup.py`.
* I updated `WrappedObj.__eq__` for a bug fix, but forgot to add a test for the change, which is causing code cov to fail for the rc-master merge. Added it here