### PR TITLE
remove pulse_generator

### DIFF
--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -56,14 +56,13 @@ Pending deprecations
         some_qfunc(params)
         return qml.expval(Hamiltonian)
 
-* ``qml.gradients.pulse_generator`` becomes ``qml.gradients.pulse_odegen`` to adhere to paper naming conventions. During v0.33, ``pulse_generator``
-  is still available but raises a warning.
-
-  - Deprecated in v0.33
-  - Will be removed in v0.34
-
 Completed deprecation cycles
 ----------------------------
+
+* ``qml.gradients.pulse_generator`` has become ``qml.gradients.pulse_odegen`` to adhere to paper naming conventions.
+
+  - Deprecated in v0.33
+  - Removed in v0.34
 
 * The public methods of ``DefaultQubit`` are pending changes to
   follow the new device API.
@@ -109,7 +108,7 @@ Completed deprecation cycles
   - Behaviour changed in v0.33
 
 * The ``prep`` keyword argument in ``QuantumScript`` has been removed.
-  ``StatePrepBase`` operations should be placed at the beginning of the `ops` list instead.
+  ``StatePrepBase`` operations should be placed at the beginning of the ``ops`` list instead.
 
   - Deprecated in v0.33
   - Removed in v0.34

--- a/doc/introduction/interfaces.rst
+++ b/doc/introduction/interfaces.rst
@@ -240,7 +240,7 @@ with the number of trainable circuit parameters.
 * :func:`qml.gradients.stoch_pulse_grad <~.stoch_pulse_grad>`: Use a stochastic variant of the
   parameter-shift rule for pulse programs.
 
-* :func:`qml.gradients.pulse_generator <~.pulse_generator>`: Combine classical processing with the parameter-shift rule for multivariate gates to differentiate pulse programs.
+* :func:`qml.gradients.pulse_odegen <~.pulse_odegen>`: Combine classical processing with the parameter-shift rule for multivariate gates to differentiate pulse programs.
 
 
 Device gradients

--- a/doc/introduction/interfaces.rst
+++ b/doc/introduction/interfaces.rst
@@ -199,7 +199,7 @@ Simulation-based differentiation
 The following methods use `reverse accumulation
 <https://en.wikipedia.org/wiki/Automatic_differentiation#Reverse_accumulation>`__ to compute
 gradients; a well-known example of this approach is backpropagation. These methods are **not** hardware compatible; they are only supported on
-*statevector* simulator devices such as :class:`default.qubit <~.DefaultQubit>`.
+*statevector* simulator devices such as :class:`default.qubit <pennylane.devices.DefaultQubit>`.
 
 However, for rapid prototyping on simulators, these methods typically out-perform forward-mode
 accumulators such as the parameter-shift rule and finite-differences. For more details, see the
@@ -209,7 +209,7 @@ accumulators such as the parameter-shift rule and finite-differences. For more d
 
   This differentiation method is only allowed on simulator
   devices that are classically end-to-end differentiable, for example
-  :class:`default.qubit <~.DefaultQubit>`. This method does *not* work on devices
+  :class:`default.qubit <pennylane.devices.DefaultQubit>`. This method does *not* work on devices
   that estimate measurement statistics using a finite number of shots; please use
   the ``parameter-shift`` rule instead.
 
@@ -237,10 +237,10 @@ with the number of trainable circuit parameters.
 
 * ``"hadamard"``: Use hadamard tests on the generators for all compatible quantum operations arguments.
 
-* :func:`qml.gradients.stoch_pulse_grad <~.stoch_pulse_grad>`: Use a stochastic variant of the
+* :func:`qml.gradients.stoch_pulse_grad <pennylane.gradients.stoch_pulse_grad>`: Use a stochastic variant of the
   parameter-shift rule for pulse programs.
 
-* :func:`qml.gradients.pulse_odegen <~.pulse_odegen>`: Combine classical processing with the parameter-shift rule for multivariate gates to differentiate pulse programs.
+* :func:`qml.gradients.pulse_odegen <pennylane.gradients.pulse_odegen>`: Combine classical processing with the parameter-shift rule for multivariate gates to differentiate pulse programs.
 
 
 Device gradients

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -28,7 +28,7 @@
   [(#4756)](https://github.com/PennyLaneAI/pennylane/pull/4756)
 
 * `qml.gradients.pulse_generator` has become `qml.gradients.pulse_odegen` to adhere to paper naming conventions.
-  [(#)]()
+  [(#4769)](https://github.com/PennyLaneAI/pennylane/pull/4769)
 
 <h3>Deprecations 👋</h3>
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -24,8 +24,11 @@
 <h3>Breaking changes 💔</h3>
 
 * The `prep` keyword argument has been removed from `QuantumScript` and `QuantumTape`.
-  ``StatePrepBase`` operations should be placed at the beginning of the `ops` list instead.
+  `StatePrepBase` operations should be placed at the beginning of the `ops` list instead.
   [(#4756)](https://github.com/PennyLaneAI/pennylane/pull/4756)
+
+* `qml.gradients.pulse_generator` has become `qml.gradients.pulse_odegen` to adhere to paper naming conventions.
+  [(#)]()
 
 <h3>Deprecations 👋</h3>
 

--- a/pennylane/gradients/__init__.py
+++ b/pennylane/gradients/__init__.py
@@ -315,9 +315,6 @@ during autodifferentiation.
 For more details, please see the :func:`qml.transform <pennylane.transform>`
 documentation.
 """
-import pennylane as qml
-from pennylane.gradients.pulse_gradient_odegen import pulse_generator
-
 from . import parameter_shift
 from . import parameter_shift_cv
 from . import parameter_shift_hessian

--- a/pennylane/gradients/pulse_gradient_odegen.py
+++ b/pennylane/gradients/pulse_gradient_odegen.py
@@ -16,7 +16,6 @@ This module contains functions for computing the pulse generator
 parameter-shift gradient of pulse sequences in a qubit-based quantum tape.
 """
 from typing import Callable, Sequence
-import warnings
 from functools import partial
 import numpy as np
 
@@ -695,18 +694,6 @@ def pulse_odegen(
     argnum = [i for i, dm in method_map.items() if dm == "A"]
 
     return _expval_pulse_odegen(tape, argnum, atol)
-
-
-def _legacy_pulse_generator_wrapper(
-    tape: qml.tape.QuantumTape, argnum=None, atol=1e-7
-) -> (Sequence[qml.tape.QuantumTape], Callable):
-    warnings.warn(
-        "pulse_generator for gradient computation has been renamed to pulse_odegen and will not be available in pennylane v0.34 onwards"
-    )
-    return pulse_odegen(tape, argnum, atol)
-
-
-pulse_generator = transform(_legacy_pulse_generator_wrapper, final_transform=True)
 
 
 @pulse_odegen.custom_qnode_transform

--- a/tests/gradients/core/test_pulse_odegen.py
+++ b/tests/gradients/core/test_pulse_odegen.py
@@ -35,25 +35,6 @@ from pennylane.gradients.pulse_gradient_odegen import (
 )
 
 
-@pytest.mark.jax
-def test_deprecation_warning_pulse_generator():
-    """Test that the warning is raised when trying to use pulse_generator for gradient computation"""
-    import jax
-
-    dev = qml.device("default.qubit", wires=1)
-
-    @qml.qnode(dev, diff_method=qml.gradients.pulse_generator)
-    def qnode(x):
-        qml.evolve(qml.pulse.constant * qml.PauliZ(0))(x, 1.0)
-        return qml.expval(qml.PauliX(0))
-
-    x = jax.numpy.array([0.5])
-    with pytest.warns(
-        UserWarning, match="pulse_generator for gradient computation has been renamed"
-    ):
-        jax.grad(qnode)(x)
-
-
 X, Y, Z = qml.PauliX, qml.PauliY, qml.PauliZ
 
 


### PR DESCRIPTION
**Context:**
`pulse_generator` has been deprecated in favour of `pulse_odegen`. This completes the deprecation cycle.

**Description of the Change:**
Remove `pulse_generator`.

[sc-47810]