### PR TITLE
Jax jit support for shot vectors

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -41,6 +41,7 @@
 <h3>Bug fixes 🐛</h3>
 
 * Jax jit now works with shot vectors.
+  [(#4772)](https://github.com/PennyLaneAI/pennylane/pull/4772/)
 
 * Any `ScalarSymbolicOp`, like `Evolution`, now states that it has a matrix if the target
   is a `Hamiltonian`.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -33,12 +33,15 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Jax jit now works with shot vectors.
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):
 
 Amintor Dusko,
 Ankit Khandelwal,
+Christina Lee,
 Anurav Modak,
 Matthew Silverman,
 David Wierichs,

--- a/pennylane/interfaces/jax_jit.py
+++ b/pennylane/interfaces/jax_jit.py
@@ -62,9 +62,15 @@ def _create_shape_dtype_struct(tape: "qml.tape.QuantumScript", device: "qml.Devi
     shape = tape.shape(device)
     if len(tape.measurements) == 1:
         tape_dtype = _numeric_type_to_dtype(tape.numeric_type)
+        if tape.shots.has_partitioned_shots:
+            return tuple(jax.ShapeDtypeStruct(s, tape_dtype) for s in shape)
         return jax.ShapeDtypeStruct(tuple(shape), tape_dtype)
 
     tape_dtype = tuple(_numeric_type_to_dtype(elem) for elem in tape.numeric_type)
+    if tape.shots.has_partitioned_shots:
+        return tuple(
+            tuple(jax.ShapeDtypeStruct(tuple(s), d) for s, d in zip(si, tape_dtype)) for si in shape
+        )
     return tuple(jax.ShapeDtypeStruct(tuple(s), d) for s, d in zip(shape, tape_dtype))
 
 

--- a/pennylane/tape/qscript.py
+++ b/pennylane/tape/qscript.py
@@ -811,7 +811,7 @@ class QuantumScript:
         if len(shapes) == 1:
             return shapes[0]
 
-        if len(shots.shot_vector) > 1:
+        if shots.num_copies > 1:
             # put the shot vector axis before the measurement axis
             shapes = tuple(zip(*shapes))
 

--- a/tests/interfaces/default_qubit_2_integration/test_jax_jit_qnode_default_qubit_2.py
+++ b/tests/interfaces/default_qubit_2_integration/test_jax_jit_qnode_default_qubit_2.py
@@ -779,7 +779,7 @@ class TestShotsIntegration:
     def test_shot_vectors_single_measurements(self, interface, shots):
         """Test jax-jit can work with shot vectors."""
 
-        dev = qml.device("default.qubit", shots=shots, seed=49393)
+        dev = qml.device("default.qubit", shots=shots, seed=4747)
 
         @jax.jit
         @qml.qnode(dev, interface=interface, diff_method="parameter-shift")
@@ -789,8 +789,14 @@ class TestShotsIntegration:
 
         res = circuit(0.5)
         expected = 1 - np.cos(0.5) ** 2
-        assert qml.math.allclose(res[0], expected, atol=5e-3)
-        assert qml.math.allclose(res[1], expected, atol=5e-3)
+        assert qml.math.allclose(res[0], expected, atol=1e-2)
+        assert qml.math.allclose(res[1], expected, atol=3e-2)
+
+        g = jax.jacobian(circuit)(0.5)
+
+        expected_g = 2 * np.cos(0.5) * np.sin(0.5)
+        assert qml.math.allclose(g[0], expected_g, atol=2e-2)
+        assert qml.math.allclose(g[1], expected_g, atol=2e-2)
 
     @pytest.mark.parametrize("shots", [(10000, 10000), (10000, 10005)])
     def test_shot_vectors_multiple_measurements(self, interface, shots):


### PR DESCRIPTION
[sc-48174] Fixes #4689 

Jax jit now works with shot vectors.

```
>>> dev = qml.device("default.qubit")
>>> @qml.qnode(dev, interface="jax")
... def f(p):
...     qml.RX(p, 0)
...     qml.CNOT([0, 1])
...     return qml.expval(qml.PauliZ(0))
... 
>>> f_jitted = jax.jit(f, static_argnames=["shots"])
>>> f_jitted(jax.numpy.array(np.pi / 2), shots=(10, 10))
```