### PR TITLE
deprecate tape.is_sampled and tape.all_sampled

### DIFF
--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -6,6 +6,20 @@ Deprecations
 Pending deprecations
 --------------------
 
+* ``QuantumScript.is_sampled`` and ``QuantumScript.all_sampled`` are deprecated. Users should now validate
+  these properties manually.
+
+  .. code-block:: python
+
+    from pennylane.measurements import *
+    sample_types = (SampleMP, CountsMP, ClassicalShadowMP, ShadowExpvalMP)
+    is_sample_type = [isinstance(m, sample_types) for m in tape.measurements]
+    is_sampled = any(is_sample_type)
+    all_sampled = all(is_sample_type)
+
+  - Deprecated in v0.34
+  - Will be removed in v0.35
+
 * Passing additional arguments to a transform that decorates a QNode should now be done through use
   of ``functools.partial``. For example, the :func:`~pennylane.metric_tensor` transform has an
   optional ``approx`` argument which should now be set using:
@@ -64,6 +78,12 @@ Completed deprecation cycles
   - Deprecated in v0.33
   - Removed in v0.34
 
+* The ``prep`` keyword argument in ``QuantumScript`` has been removed.
+  ``StatePrepBase`` operations should be placed at the beginning of the ``ops`` list instead.
+
+  - Deprecated in v0.33
+  - Removed in v0.34
+
 * The public methods of ``DefaultQubit`` are pending changes to
   follow the new device API.
 
@@ -106,12 +126,6 @@ Completed deprecation cycles
 
   - Added in v0.32
   - Behaviour changed in v0.33
-
-* The ``prep`` keyword argument in ``QuantumScript`` has been removed.
-  ``StatePrepBase`` operations should be placed at the beginning of the ``ops`` list instead.
-
-  - Deprecated in v0.33
-  - Removed in v0.34
 
 * ``qml.qchem.jordan_wigner`` had been removed.
   Use ``qml.jordan_wigner`` instead. List input to define the fermionic operator

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -32,6 +32,10 @@
 
 <h3>Deprecations 👋</h3>
 
+* `QuantumScript.is_sampled` and `QuantumScript.all_sampled` are deprecated.
+  Users should now validate these properties manually.
+  [(#)]()
+
 <h3>Documentation 📝</h3>
 
 * Documentation page for `qml.measurements` now links top-level accessible functions (e.g. `qml.expval`) 

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -99,8 +99,6 @@ def _local_tape_expand(tape, depth, stop_at):
     # Update circuit info
     new_tape.wires = copy.copy(tape.wires)
     new_tape.num_wires = tape.num_wires
-    new_tape.is_sampled = tape.is_sampled
-    new_tape.all_sampled = tape.all_sampled
     new_tape._batch_size = tape.batch_size
     new_tape._output_dim = tape.output_dim
     return new_tape

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -279,7 +279,8 @@ class QubitDevice(Device):
         self.apply(circuit.operations, rotations=self._get_diagonalizing_gates(circuit), **kwargs)
 
         # generate computational basis samples
-        if self.shots is not None or circuit.is_sampled:
+        sample_type = (SampleMP, CountsMP, ClassicalShadowMP, ShadowExpvalMP)
+        if self.shots is not None or any(isinstance(m, sample_type) for m in circuit.measurements):
             self._samples = self.generate_samples()
 
         # compute the required statistics

--- a/pennylane/tape/qscript.py
+++ b/pennylane/tape/qscript.py
@@ -21,6 +21,7 @@ import contextlib
 import copy
 from collections import Counter
 from typing import List, Union, Optional, Sequence
+from warnings import warn
 
 import pennylane as qml
 from pennylane.measurements import (
@@ -202,9 +203,6 @@ class QuantumScript:
 
         self.wires = _empty_wires
         self.num_wires = 0
-
-        self.is_sampled = False
-        self.all_sampled = False
 
         self._obs_sharing_wires = []
         """list[.Observable]: subset of the observables that share wires with another observable,
@@ -398,13 +396,41 @@ class QuantumScript:
         """Returns the wires that the tape operations act on."""
         return Wires.all_wires(op.wires for op in self.operations)
 
+    @property
+    def is_sampled(self) -> bool:
+        """Whether any measurements are of a type that requires samples."""
+        warn(
+            "QuantumScript.is_sampled is deprecated. This property should now be "
+            "validated manually:\n\n"
+            ">>> from pennylane.measurements import *\n"
+            ">>> sample_types = (SampleMP, CountsMP, ClassicalShadowMP, ShadowExpvalMP)\n"
+            ">>> is_sampled = any(isinstance(m, sample_types) for m in tape.measurements)\n",
+            UserWarning,
+        )
+        sample_type = (SampleMP, CountsMP, ClassicalShadowMP, ShadowExpvalMP)
+        return any(isinstance(m, sample_type) for m in self.measurements)
+
+    @property
+    def all_sampled(self) -> bool:
+        """Whether all measurements are of a type that requires samples."""
+        warn(
+            "QuantumScript.all_sampled is deprecated. This property should now be "
+            "validated manually:\n\n"
+            ">>> from pennylane.measurements import *\n"
+            ">>> sample_types = (SampleMP, CountsMP, ClassicalShadowMP, ShadowExpvalMP)\n"
+            ">>> all_sampled = all(isinstance(m, sample_types) for m in tape.measurements)\n",
+            UserWarning,
+        )
+        sample_type = (SampleMP, CountsMP, ClassicalShadowMP, ShadowExpvalMP)
+        return all(isinstance(m, sample_type) for m in self.measurements)
+
     ##### Update METHODS ###############
 
     def _update(self):
         """Update all internal metadata regarding processed operations and observables"""
         self._graph = None
         self._specs = None
-        self._update_circuit_info()  # Updates wires, num_wires, is_sampled, all_sampled; O(ops+obs)
+        self._update_circuit_info()  # Updates wires, num_wires; O(ops+obs)
         self._update_par_info()  # Updates _par_info; O(ops+obs)
 
         # The following line requires _par_info to be up to date
@@ -422,18 +448,9 @@ class QuantumScript:
         Sets:
             wires (~.Wires): Wires
             num_wires (int): Number of wires
-            is_sampled (bool): Whether any measurement is of type ``Sample`` or ``Counts``
-            all_sampled (bool): Whether all measurements are of type ``Sample`` or ``Counts``
         """
         self.wires = Wires.all_wires(dict.fromkeys(op.wires for op in self))
         self.num_wires = len(self.wires)
-
-        is_sample_type = [
-            isinstance(m, (SampleMP, CountsMP, ClassicalShadowMP, ShadowExpvalMP))
-            for m in self.measurements
-        ]
-        self.is_sampled = any(is_sample_type)
-        self.all_sampled = all(is_sample_type)
 
     def _update_par_info(self):
         """Update the parameter information list. Each entry in the list with an operation and an index
@@ -873,8 +890,6 @@ class QuantumScript:
         new_qscript._specs = None
         new_qscript.wires = copy.copy(self.wires)
         new_qscript.num_wires = self.num_wires
-        new_qscript.is_sampled = self.is_sampled
-        new_qscript.all_sampled = self.all_sampled
         new_qscript._update_par_info()
         new_qscript.trainable_params = self.trainable_params.copy()
         new_qscript._obs_sharing_wires = self._obs_sharing_wires

--- a/pennylane/tape/tape.py
+++ b/pennylane/tape/tape.py
@@ -227,8 +227,6 @@ def expand_tape(tape, depth=1, stop_at=None, expand_measurements=False):
     # Update circuit info
     new_tape.wires = copy.copy(tape.wires)
     new_tape.num_wires = tape.num_wires
-    new_tape.is_sampled = tape.is_sampled
-    new_tape.all_sampled = tape.all_sampled
     new_tape._batch_size = tape.batch_size
     new_tape._output_dim = tape.output_dim
     return new_tape
@@ -280,8 +278,6 @@ def expand_tape_state_prep(tape, skip_first=True):
     # Update circuit info
     new_tape.wires = copy.copy(tape.wires)
     new_tape.num_wires = tape.num_wires
-    new_tape.is_sampled = tape.is_sampled
-    new_tape.all_sampled = tape.all_sampled
     new_tape._batch_size = tape.batch_size
     new_tape._output_dim = tape.output_dim
     return new_tape

--- a/tests/tape/test_qscript.py
+++ b/tests/tape/test_qscript.py
@@ -41,8 +41,6 @@ class TestInitialization:
         assert qs._batch_size is None
         assert qs.wires == qml.wires.Wires([])
         assert qs.num_wires == 0
-        assert qs.is_sampled is False
-        assert qs.all_sampled is False
         assert qs.samples_computational_basis is False
         assert len(qs._obs_sharing_wires) == 0
         assert len(qs._obs_sharing_wires_id) == 0
@@ -129,8 +127,10 @@ class TestUpdate:
     @pytest.mark.parametrize("sample_ms", sample_measurements)
     def test_update_circuit_info_sampling(self, sample_ms):
         qs = QuantumScript(measurements=[qml.expval(qml.PauliZ(0)), sample_ms])
-        assert qs.is_sampled is True
-        assert qs.all_sampled is False
+        with pytest.warns(UserWarning, match="QuantumScript.is_sampled is deprecated"):
+            assert qs.is_sampled is True
+        with pytest.warns(UserWarning, match="QuantumScript.all_sampled is deprecated"):
+            assert qs.all_sampled is False
 
         shadow_mp = sample_ms.return_type not in (
             qml.measurements.Shadow,
@@ -139,16 +139,20 @@ class TestUpdate:
         assert qs.samples_computational_basis is shadow_mp
 
         qs = QuantumScript(measurements=[sample_ms, sample_ms, qml.sample()])
-        assert qs.is_sampled is True
-        assert qs.all_sampled is True
+        with pytest.warns(UserWarning, match="QuantumScript.is_sampled is deprecated"):
+            assert qs.is_sampled is True
+        with pytest.warns(UserWarning, match="QuantumScript.all_sampled is deprecated"):
+            assert qs.all_sampled is True
         assert qs.samples_computational_basis is True
 
     def test_update_circuit_info_no_sampling(self):
         """Test that all_sampled, is_sampled and samples_computational_basis properties are set to False if no sampling
         measurement process exists."""
         qs = QuantumScript(measurements=[qml.expval(qml.PauliZ(0))])
-        assert qs.is_sampled is False
-        assert qs.all_sampled is False
+        with pytest.warns(UserWarning, match="QuantumScript.is_sampled is deprecated"):
+            assert qs.is_sampled is False
+        with pytest.warns(UserWarning, match="QuantumScript.all_sampled is deprecated"):
+            assert qs.all_sampled is False
         assert qs.samples_computational_basis is False
 
     def test_samples_computational_basis_correctly(self):

--- a/tests/tape/test_tape.py
+++ b/tests/tape/test_tape.py
@@ -262,18 +262,6 @@ class TestConstruction:
                 qml.RX(0.5, wires=0)
                 qml.expval(qml.PauliZ(wires=1))
 
-    def test_sampling(self):
-        """Test that the tape correctly marks itself as returning samples"""
-        with QuantumTape() as tape:
-            qml.expval(qml.PauliZ(wires=1))
-
-        assert not tape.is_sampled
-
-        with QuantumTape() as tape:
-            qml.sample(qml.PauliZ(wires=0))
-
-        assert tape.is_sampled
-
     def test_repr(self):
         """Test the string representation"""
 
@@ -1233,27 +1221,6 @@ class TestExpand:
         assert qml.equal(expanded.measurements[0], qml.expval(qml.PauliZ(0)))
         assert qml.equal(expanded.measurements[1], qml.expval(qml.PauliZ(0)))
         assert expanded.shots is tape.shots
-
-    def test_is_sampled_reserved_after_expansion(self):
-        """Test that the is_sampled property is correctly set when tape
-        expansion happens."""
-        dev = qml.device("default.qubit", wires=1, shots=10)
-
-        class UnsupportedT(qml.operation.Operation):
-            """A T gate that provides a decomposition, but no matrix."""
-
-            @staticmethod
-            def compute_decomposition(wires):  # pylint:disable=arguments-differ
-                return [qml.PhaseShift(np.pi / 4, wires=wires)]
-
-        @qml.qnode(dev, diff_method="parameter-shift")
-        def circuit():
-            UnsupportedT(wires=0)
-            return sample(qml.PauliZ(0))
-
-        circuit()
-
-        assert circuit.qtape.is_sampled
 
 
 class TestExecution:

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -610,8 +610,6 @@ class TestInternalFunctions:
 
         assert new_tape.shots is tape.shots
         assert new_tape.wires == tape.wires
-        assert new_tape.is_sampled == tape.is_sampled
-        assert new_tape.all_sampled == tape.all_sampled
         assert new_tape.batch_size == tape.batch_size
         assert new_tape.output_dim == tape.output_dim
 


### PR DESCRIPTION
**Context:**
`tape.is_sampled` and `tape.all_sampled` are not very useful and could really be evaluated on a per-call basis. Plus, maintaining the correctness of these values can be difficult if new measurements are introduced.

**Description of the Change:**
Raise a warning whenever those properties are accessed.

**Benefits:**
We're getting rid of stuff that may not necessarily belong on the tape API! 🧹 

**Possible Drawbacks:**
In the deprecation notice, we're suggesting the 4 measurement types that are currently being used, but they are theoretically subject to change. We discussed other things to recommend, but I think this is the best option so far because it's the same as what we use in `QubitDevice.execute`. Sure, it might change one day. But by then, the properties (and their warnings) will be removed altogether!

[sc-45870]