### PR TITLE
deprecate old transforms

### DIFF
--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -802,7 +802,7 @@ class Device(abc.ABC):
             return circuits, hamiltonian_fn
 
         # Expand each of the broadcasted Hamiltonian-expanded circuits
-        expanded_tapes, expanded_fn = qml.transforms.map_batch_transform(
+        expanded_tapes, expanded_fn = qml.transforms.map_transform(
             qml.transforms.broadcast_expand, circuits
         )
 

--- a/pennylane/interfaces/autograd.py
+++ b/pennylane/interfaces/autograd.py
@@ -201,7 +201,7 @@ def vjp(
         def partial_gradient_fn(tape):
             return gradient_fn(tape, **gradient_kwargs)
 
-        g_tapes, fn = qml.transforms.map_batch_transform(partial_gradient_fn, tapes)
+        g_tapes, fn = qml.transforms.map_transform(partial_gradient_fn, tapes)
         res, _ = execute_fn(g_tapes, **gradient_kwargs)
 
         jacs = fn(res)

--- a/pennylane/interfaces/execution.py
+++ b/pennylane/interfaces/execution.py
@@ -164,7 +164,7 @@ def _batch_transform(
     # TODO: Remove once old device are removed
     if device_batch_transform:
         dev_batch_transform = set_shots(device, override_shots)(device.batch_transform)
-        return *qml.transforms.map_batch_transform(dev_batch_transform, tapes), config
+        return *qml.transforms.map_transform(dev_batch_transform, tapes), config
 
     def null_post_processing_fn(results):
         """A null post processing function used because the user requested not to use the device batch transform."""

--- a/pennylane/interfaces/jacobian_products.py
+++ b/pennylane/interfaces/jacobian_products.py
@@ -242,9 +242,7 @@ class TransformJacobianProducts(JacobianProductCalculator):
         if logger.isEnabledFor(logging.DEBUG):  # pragma: no cover
             logger.debug("compute_jacobian called with %s", tapes)
         partial_gradient_fn = partial(self._gradient_transform, **self._gradient_kwargs)
-        jac_tapes, batch_post_processing = qml.transforms.map_batch_transform(
-            partial_gradient_fn, tapes
-        )
+        jac_tapes, batch_post_processing = qml.transforms.map_transform(partial_gradient_fn, tapes)
         results = self._inner_execute(jac_tapes)
         return tuple(batch_post_processing(results))
 

--- a/pennylane/transforms/__init__.py
+++ b/pennylane/transforms/__init__.py
@@ -189,7 +189,7 @@ to help build custom QNode, quantum function, and tape transforms:
     :toctree: api
 
     ~transforms.make_tape
-    ~transforms.map_batch_transform
+    ~transforms.map_transform
     ~transforms.create_expand_fn
     ~transforms.create_decomp_expand_fn
     ~transforms.expand_invalid_trainable
@@ -230,7 +230,7 @@ for creation of custom transforms.
 """
 # Import the decorators first to prevent circular imports when used in other transforms
 from .core import transform, TransformError
-from .batch_transform import batch_transform, map_batch_transform
+from .batch_transform import batch_transform, map_transform, map_batch_transform
 from .qfunc_transforms import make_tape, single_tape_transform, qfunc_transform
 from .op_transforms import op_transform
 from .batch_params import batch_params

--- a/pennylane/transforms/compile.py
+++ b/pennylane/transforms/compile.py
@@ -48,7 +48,7 @@ def compile(
 
     Args:
         tape (QNode or QuantumTape or Callable): A quantum circuit.
-        pipeline (list[single_tape_transform, qfunc_transform]): A list of
+        pipeline (list[.transform]): A list of
             tape and/or quantum function transforms to apply.
         basis_set (list[str]): A list of basis gates. When expanding the tape,
             expansion will continue until gates in the specific set are

--- a/pennylane/transforms/op_transforms.py
+++ b/pennylane/transforms/op_transforms.py
@@ -41,7 +41,10 @@ class op_transform:
 
     .. warning::
 
-        This is an experimental feature, and is subject to change.
+        Use of `op_transform` to create a custom transform is deprecated. Instead
+        switch to using the new qml.transform function. Follow the instructions
+        `here <https://docs.pennylane.ai/en/stable/code/qml_transforms.html#custom-transforms>`_
+        for further details
 
     Args:
         fn (function): The function to register as the operator transform.
@@ -196,6 +199,12 @@ class op_transform:
                 "does not appear to be a valid Python function or callable."
             )
 
+        warnings.warn(
+            "Use of `op_transform` to create a custom transform is deprecated. Instead "
+            "switch to using the new qml.transform function. Follow the instructions here for "
+            "further details: https://docs.pennylane.ai/en/stable/code/qml_transforms.html#custom-transforms.",
+            UserWarning,
+        )
         self._fn = fn
         self._sig = inspect.signature(fn).parameters
         self._tape_fn = None

--- a/pennylane/transforms/qfunc_transforms.py
+++ b/pennylane/transforms/qfunc_transforms.py
@@ -77,6 +77,13 @@ def make_tape(fn):
 class single_tape_transform:
     """For registering a tape transform that takes a tape and outputs a single new tape.
 
+    .. warning::
+
+        Use of `single_tape_transform` to create a custom transform is deprecated. Instead
+        switch to using the new qml.transform function. Follow the instructions
+        `here <https://docs.pennylane.ai/en/stable/code/qml_transforms.html#custom-transforms>`_
+        for further details
+
     Examples of such transforms include circuit compilation.
 
     Args:
@@ -139,6 +146,12 @@ class single_tape_transform:
                 "does not appear to be a valid Python function or callable."
             )
 
+        warnings.warn(
+            "Use of `single_tape_transform` to create a custom transform is deprecated. Instead "
+            "switch to using the new qml.transform function. Follow the instructions here for "
+            "further details: https://docs.pennylane.ai/en/stable/code/qml_transforms.html#custom-transforms.",
+            UserWarning,
+        )
         self.transform_fn = transform_fn
         functools.update_wrapper(self, transform_fn)
 
@@ -193,6 +206,13 @@ def _create_qfunc_internal_wrapper(
 def qfunc_transform(tape_transform):
     """Given a function which defines a tape transform, convert the function into
     one that applies the tape transform to quantum functions (qfuncs).
+
+    .. warning::
+
+        Use of `qfunc_transform` to create a custom transform is deprecated. Instead
+        switch to using the new qml.transform function. Follow the instructions
+        `here <https://docs.pennylane.ai/en/stable/code/qml_transforms.html#custom-transforms>`_
+        for further details
 
     Args:
         tape_transform (function or single_tape_transform): the single tape transform
@@ -381,8 +401,16 @@ def qfunc_transform(tape_transform):
             "to single tape transform functions."
         )
 
+    warnings.warn(
+        "Use of `qfunc_transform` to create a custom transform is deprecated. Instead "
+        "switch to using the new qml.transform function. Follow the instructions here for "
+        "further details: https://docs.pennylane.ai/en/stable/code/qml_transforms.html#custom-transforms.",
+        UserWarning,
+    )
     if not isinstance(tape_transform, single_tape_transform):
-        tape_transform = single_tape_transform(tape_transform)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            tape_transform = single_tape_transform(tape_transform)
 
     sig = inspect.signature(tape_transform)
     params = sig.parameters

--- a/tests/interfaces/test_autograd.py
+++ b/tests/interfaces/test_autograd.py
@@ -180,7 +180,7 @@ class TestAutogradExecuteUnitTests:
 
 class TestBatchTransformExecution:
     """Tests to ensure batch transforms can be correctly executed
-    via qml.execute and map_batch_transform"""
+    via qml.execute and map_transform"""
 
     def test_no_batch_transform(self, mocker):
         """Test that batch transforms can be disabled and enabled"""

--- a/tests/param_shift_dev.py
+++ b/tests/param_shift_dev.py
@@ -46,7 +46,7 @@ class ParamShiftDerivativesDevice(qml.devices.DefaultQubit):
             self.tracker.update(derivative_batches=1, derivatives=len(circuits))
             self.tracker.record()
 
-        diff_batch, fn = qml.transforms.map_batch_transform(qml.gradients.param_shift, circuits)
+        diff_batch, fn = qml.transforms.map_transform(qml.gradients.param_shift, circuits)
         diff_results = self.execute(diff_batch)
 
         jacs = fn(diff_results)
@@ -67,7 +67,7 @@ class ParamShiftDerivativesDevice(qml.devices.DefaultQubit):
             )
             self.tracker.record()
 
-        diff_batch, fn = qml.transforms.map_batch_transform(qml.gradients.param_shift, circuits)
+        diff_batch, fn = qml.transforms.map_transform(qml.gradients.param_shift, circuits)
         combined_batch = tuple(circuits) + tuple(diff_batch)
         all_results = self.execute(combined_batch)
         results = all_results[: len(circuits)]

--- a/tests/transforms/test_batch_transform.py
+++ b/tests/transforms/test_batch_transform.py
@@ -673,7 +673,7 @@ class TestBatchTransformGradients:
 
 
 class TestMapBatchTransform:
-    """Tests for the map_batch_transform function"""
+    """Tests for the map_transform function"""
 
     def test_result(self, mocker):
         """Test that it correctly applies the transform to be mapped"""
@@ -697,9 +697,7 @@ class TestMapBatchTransform:
 
         tape2 = qml.tape.QuantumScript.from_queue(q2)
         spy = mocker.spy(qml.transforms, "hamiltonian_expand")
-        tapes, fn = qml.transforms.map_batch_transform(
-            qml.transforms.hamiltonian_expand, [tape1, tape2]
-        )
+        tapes, fn = qml.transforms.map_transform(qml.transforms.hamiltonian_expand, [tape1, tape2])
 
         spy.assert_called()
         assert len(tapes) == 5
@@ -710,7 +708,7 @@ class TestMapBatchTransform:
         assert np.allclose(fn(res), expected)
 
     def test_differentiation(self):
-        """Test that an execution using map_batch_transform can be differentiated"""
+        """Test that an execution using map_transform can be differentiated"""
         dev = qml.device("default.qubit.legacy", wires=2)
         H = qml.PauliZ(0) @ qml.PauliZ(1) - qml.PauliX(0)
 
@@ -731,7 +729,7 @@ class TestMapBatchTransform:
                 qml.expval(H + 0.5 * qml.PauliY(0))
 
             tape2 = qml.tape.QuantumScript.from_queue(q2)
-            tapes, fn = qml.transforms.map_batch_transform(
+            tapes, fn = qml.transforms.map_transform(
                 qml.transforms.hamiltonian_expand, [tape1, tape2]
             )
             res = qml.execute(tapes, dev, qml.gradients.param_shift, device_batch_transform=False)


### PR DESCRIPTION
**Context:**
these transform-building tools are deprecated now that we have the new transform API

**Description of the Change:**
- Deprecate all old transform-building tools
- Rename `map_batch_transform` to `map_transform`, deprecating the old name

**Benefits:**
Cleaning up old code 🧹 🧹 