### PR TITLE
Fix the wire order of state prep operations in `default.qubit`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -44,7 +44,7 @@
   is a `Hamiltonian`.
   [(#4768)](https://github.com/PennyLaneAI/pennylane/pull/4768)
 
-* In `defualt.qubit`, initial states are now initialized with the simulation's wire order, not the circuit's
+* In `default.qubit`, initial states are now initialized with the simulation's wire order, not the circuit's
   wire order.
   [(#4781)](https://github.com/PennyLaneAI/pennylane/pull/4781)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -44,7 +44,7 @@
   is a `Hamiltonian`.
   [(#4768)](https://github.com/PennyLaneAI/pennylane/pull/4768)
 
-* In `default.qubit`, initial states are now initialized with the simulation's wire order, not the circuit's
+* In `default.qubit`, initial states are now initialized with the simulator's wire order, not the circuit's
   wire order.
   [(#4781)](https://github.com/PennyLaneAI/pennylane/pull/4781)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -46,6 +46,7 @@
 
 * In `defualt.qubit`, initial states are now initialized with the simulation's wire order, not the circuit's
   wire order.
+  [(#4781)](https://github.com/PennyLaneAI/pennylane/pull/4781)
 
 <h3>Contributors ✍️</h3>
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -44,6 +44,9 @@
   is a `Hamiltonian`.
   [(#4768)](https://github.com/PennyLaneAI/pennylane/pull/4768)
 
+* In `defualt.qubit`, initial states are now initialized with the simulation's wire order, not the circuit's
+  wire order.
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane/devices/qubit/simulate.py
+++ b/pennylane/devices/qubit/simulate.py
@@ -153,7 +153,7 @@ def get_final_state(circuit, debugger=None, interface=None):
     if len(circuit) > 0 and isinstance(circuit[0], qml.operation.StatePrepBase):
         prep = circuit[0]
 
-    state = create_initial_state(circuit.op_wires, prep, like=INTERFACE_TO_LIKE[interface])
+    state = create_initial_state(sorted(circuit.op_wires), prep, like=INTERFACE_TO_LIKE[interface])
 
     # initial state is batched only if the state preparation (if it exists) is batched
     is_state_batched = bool(prep and prep.batch_size is not None)

--- a/tests/devices/default_qubit/test_default_qubit.py
+++ b/tests/devices/default_qubit/test_default_qubit.py
@@ -317,6 +317,17 @@ class TestBasicCircuit:
         assert qml.math.get_interface(res) == "tensorflow"
         assert qml.math.allclose(res, -1)
 
+    def test_basis_state_wire_order(self):
+        """Test that the wire order is correct with a basis state if the tape wires have a non standard order."""
+
+        dev = DefaultQubit()
+
+        tape = qml.tape.QuantumScript([qml.BasisState([1], wires=1), qml.PauliZ(0)], [qml.state()])
+
+        expected = np.array([0, 1, 0, 0], dtype=np.complex128)
+        res = dev.execute(tape)
+        assert qml.math.allclose(res, expected)
+
 
 class TestSampleMeasurements:
     """A copy of the `qubit.simulate` tests, but using the device"""

--- a/tests/gradients/finite_diff/test_finite_difference_shot_vec.py
+++ b/tests/gradients/finite_diff/test_finite_difference_shot_vec.py
@@ -611,7 +611,7 @@ class TestFiniteDiffIntegration:
         This test relies on the fact that exactly one term of the estimated
         jacobian will match the expected analytical value.
         """
-        dev = qml.device("default.qubit", wires=2, shots=many_shots_shot_vector)
+        dev = qml.device("default.qubit", seed=58743587, shots=many_shots_shot_vector)
         x = 0.543
         y = -0.654
 


### PR DESCRIPTION
Fixes #4779 . [sc-49381]

When creating an initial state, `get_final_state` was using `tape.op_wires` for the wire order, even though the simulation always occurred using the wire order `(0,1,2,3,...)`.  Sometimes `tape.op_wires` would have a different order, leading to a mismatch.

Now we use `sorted(circuit.op_wires)`, so they will always be in the monotonically increasing integers used by the simulation.