### PR TITLE
use partial in transform docs

### DIFF
--- a/pennylane/transforms/batch_input.py
+++ b/pennylane/transforms/batch_input.py
@@ -58,9 +58,10 @@ def batch_input(
 
     .. code-block:: python
 
+        from functools import partial
         dev = qml.device("default.qubit", wires=2, shots=None)
 
-        @qml.batch_input(argnum=1)
+        @partial(qml.batch_input, argnum=1)
         @qml.qnode(dev, diff_method="parameter-shift", interface="tf")
         def circuit(inputs, weights):
             qml.RY(weights[0], wires=0)

--- a/pennylane/transforms/batch_params.py
+++ b/pennylane/transforms/batch_params.py
@@ -156,7 +156,9 @@ def batch_params(
 
     .. code-block:: python
 
-        @qml.batch_params(all_operations=True)
+        from functools import partial
+
+        @partial(qml.batch_params, all_operations=True)
         @qml.qnode(dev)
         def circuit(x, weights):
             qml.RX(x, wires=0)

--- a/pennylane/transforms/qcut/cutcircuit.py
+++ b/pennylane/transforms/qcut/cutcircuit.py
@@ -161,7 +161,9 @@ def cut_circuit(
 
     .. code-block:: python
 
-        @qml.cut_circuit(auto_cutter=True)
+        from functools import partial
+
+        @partial(qml.cut_circuit, auto_cutter=True)
         @qml.qnode(dev)
         def circuit(x):
             qml.RX(x, wires=0)

--- a/pennylane/transforms/qcut/montecarlo.py
+++ b/pennylane/transforms/qcut/montecarlo.py
@@ -168,7 +168,9 @@ def cut_circuit_mc(
 
     .. code-block:: python
 
-        @qml.cut_circuit_mc(auto_cutter=True)
+        from functools import partial
+
+        @partial(qml.cut_circuit_mc, auto_cutter=True)
         @qml.qnode(dev)
         def circuit(x):
             qml.RX(0.89, wires=0)
@@ -388,12 +390,13 @@ def cut_circuit_mc(
 
         .. code-block::
 
+            from functools import partial
             dev = qml.device("default.qubit", wires=2, shots=10000)
 
             def observable(bitstring):
                 return (-1) ** np.sum(bitstring)
 
-            @qml.cut_circuit_mc(classical_processing_fn=observable)
+            @partial(qml.cut_circuit_mc, classical_processing_fn=observable)
             @qml.qnode(dev)
             def circuit(x):
                 qml.RX(0.89, wires=0)

--- a/tests/templates/test_subroutines/test_controlled_sequence.py
+++ b/tests/templates/test_subroutines/test_controlled_sequence.py
@@ -283,8 +283,8 @@ class TestIntegration:
 
         dev = qml.device("default.qubit", wires=4)
 
+        @qml.compile
         @qml.qnode(dev)
-        @qml.compile()
         def circuit(thetas):
             qml.ControlledSequence(U(thetas), control=[2, 3])
             return qml.state()


### PR DESCRIPTION
**Context:**
new transforms should use `partial` if they require additional args. most docs were already updated, but some were missed

**Description of the Change:**
try to update some docs (and a test) to not use deprecated transform syntax

**Benefits:**
less deprecated code being used, less warnings!

**Possible Drawbacks:**
you had to spend a minute or two reviewing this.