### PR TITLE
bump jax version

### DIFF
--- a/.github/workflows/interface-unit-tests.yml
+++ b/.github/workflows/interface-unit-tests.yml
@@ -10,7 +10,7 @@ on:
         description: The version of JAX to install for any job that requires JAX
         required: false
         type: string
-        default: 0.4.19
+        default: 0.4.20
       tensorflow_version:
         description: The version of TensorFlow to install for any job that requires TensorFlow
         required: false


### PR DESCRIPTION
Bumping version of JAX from 0.4.19 to 0.4.20 in the CI