### PR TITLE
[Compiler] Use importlib instead of pkg_resources

### DIFF
--- a/pennylane/compiler/compiler.py
+++ b/pennylane/compiler/compiler.py
@@ -42,7 +42,7 @@ def _refresh_compilers():
 
     # Iterator packages entry-points with the 'pennylane.compilers' group name
     entries = (
-        metadata.entry_points()["pennylane.compilers"]
+        defaultdict(dict, metadata.entry_points())["pennylane.compilers"]
         if version_info[:2] == (3, 9)
         # pylint:disable=unexpected-keyword-arg
         else metadata.entry_points(group="pennylane.compilers")

--- a/pennylane/compiler/compiler.py
+++ b/pennylane/compiler/compiler.py
@@ -71,6 +71,9 @@ def _reload_compilers():
     compilers names and entry points.
     """
 
+    # Note re-importing ``importlib.metadata`` can be a very slow operation
+    # on systems with a large number of installed packages.
+
     reload(metadata)
     _refresh_compilers()
 
@@ -119,10 +122,8 @@ def available(compiler="catalyst") -> bool:
     True
     """
 
-    # It only refreshes the compilers names and entry points if the name
-    # is not already stored. This reduces the number of re-importing
-    # ``importlib_metadata`` as it can be a very slow operation on systems
-    # with a large number of installed packages.
+    # It only refreshes the compilers names and entry points if
+    # the name is not already stored.
 
     if compiler not in AvailableCompilers.names_entrypoints:
         # Reload installed packages and updates


### PR DESCRIPTION
From the doc page of [pkg_resources](https://setuptools.pypa.io/en/latest/pkg_resources.html):

> Use of pkg_resources is deprecated in favor of [importlib.resources](https://docs.python.org/3.11/library/importlib.resources.html#module-importlib.resources), [importlib.metadata](https://docs.python.org/3.11/library/importlib.metadata.html#module-importlib.metadata) and their backports ([importlib_resources](https://pypi.org/project/importlib_resources), [importlib_metadata](https://pypi.org/project/importlib_metadata)). Some useful APIs are also provided by [packaging](https://pypi.org/project/packaging) (e.g. requirements and version parsing). Users should refrain from new usage of pkg_resources and should work to port to importlib-based solutions.

PR #4783 updates all occurrences of `pkg_resources` with `importlib.metadata` across the entire PL. This PR, however, addresses this replacement in the compiler driver, which has not yet been merged into PL.

[sc-46399]