### PR TITLE
[BUGFIX] Qubit reuse for terminal measurements on wires with mid-circuit measurements

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -44,6 +44,10 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* `qml.defer_measurements` now correctly transforms circuits when terminal measurements include wires
+  used in mid-circuit measurements.
+  [(#4787)](https://github.com/PennyLaneAI/pennylane/pull/4787)
+
 * Jax jit now works with shot vectors.
   [(#4772)](https://github.com/PennyLaneAI/pennylane/pull/4772/)
 

--- a/pennylane/transforms/defer_measurements.py
+++ b/pennylane/transforms/defer_measurements.py
@@ -66,7 +66,7 @@ def _collect_mid_measure_info(tape: QuantumTape):
     any_repeated_measurements = False
     is_postselecting = False
 
-    for op in tape.operations:
+    for op in tape:
         if isinstance(op, MidMeasureMP):
             if op.postselect is not None:
                 is_postselecting = True

--- a/tests/transforms/test_defer_measurements.py
+++ b/tests/transforms/test_defer_measurements.py
@@ -1503,7 +1503,7 @@ def test_custom_wire_labels_allowed_without_reset():
         qml.Hadamard("a")
         ma = qml.measure("a", reset=False)
         qml.cond(ma, qml.PauliX)("b")
-        qml.probs(wires="a")
+        qml.probs(wires="b")
 
     tape = qml.tape.QuantumScript.from_queue(q)
     tapes, _ = qml.defer_measurements(tape)
@@ -1512,7 +1512,7 @@ def test_custom_wire_labels_allowed_without_reset():
     assert len(tape) == 3
     assert qml.equal(tape[0], qml.Hadamard("a"))
     assert qml.equal(tape[1], qml.CNOT(["a", "b"]))
-    assert qml.equal(tape[2], qml.probs(wires="a"))
+    assert qml.equal(tape[2], qml.probs(wires="b"))
 
 
 def test_custom_wire_labels_fails_with_reset():


### PR DESCRIPTION
**Context:**
When making terminal measurements on wires with mid-circuit measurements, the circuit was not being transformed correctly. This PR fixes that.

**Description of the Change:**
Wires are considered to be reused by `defer_measurements` when a measured wire has operators *and* terminal measurements applied to it after mid-circuit measurements.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**

[sc-49507]