### PR TITLE
deprecate gradient_transform

### DIFF
--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -6,7 +6,7 @@ Deprecations
 Pending deprecations
 --------------------
 
-* ``single_tape_transform``, ``batch_transform``, ``qfunc_transform``, and ``op_transform`` are
+* ``single_tape_transform``, ``batch_transform``, ``qfunc_transform``, ``gradient_transform`` and ``op_transform`` are
   deprecated. Instead switch to using the new ``qml.transform`` function. Please refer to
   `the transform docs <https://docs.pennylane.ai/en/stable/code/qml_transforms.html#custom-transforms>`_
   to see how this can be done.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -39,6 +39,7 @@
 * `single_tape_transform`, `batch_transform`, `qfunc_transform`, `gradient_transform` and
   `op_transform` are deprecated. Instead switch to using the new `qml.transform` function.
   [(#4774)](https://github.com/PennyLaneAI/pennylane/pull/4774)
+  [(#4794)](https://github.com/PennyLaneAI/pennylane/pull/4794)
 
 <h3>Documentation 📝</h3>
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -36,8 +36,8 @@
   Users should now validate these properties manually.
   [(#4773)](https://github.com/PennyLaneAI/pennylane/pull/4773)
 
-* `single_tape_transform`, `batch_transform`, `qfunc_transform`, and `op_transform` are deprecated.
-  Instead switch to using the new `qml.transform` function.
+* `single_tape_transform`, `batch_transform`, `qfunc_transform`, `gradient_transform` and
+  `op_transform` are deprecated. Instead switch to using the new `qml.transform` function.
   [(#4774)](https://github.com/PennyLaneAI/pennylane/pull/4774)
 
 <h3>Documentation 📝</h3>

--- a/pennylane/gradients/gradient_transform.py
+++ b/pennylane/gradients/gradient_transform.py
@@ -467,6 +467,13 @@ class gradient_transform(qml.batch_transform):  # pragma: no cover
     a batch of tapes to be independently executed on a quantum device, alongside
     a post-processing function that returns the result.
 
+    .. warning::
+
+        Use of ``gradient_transform`` to create a custom transform is deprecated. Instead
+        switch to using the new :func:`transform` function. Follow the instructions
+        `here <https://docs.pennylane.ai/en/stable/code/qml_transforms.html#custom-transforms>`_
+        for further details
+
     Args:
         expand_fn (function): An expansion function (if required) to be applied to the
             input tape before the gradient computation takes place. If not provided,

--- a/tests/gradients/core/test_gradient_transform.py
+++ b/tests/gradients/core/test_gradient_transform.py
@@ -20,6 +20,7 @@ from pennylane.gradients.gradient_transform import (
     _gradient_analysis,
     choose_grad_methods,
     _grad_method_validation,
+    gradient_transform,
 )
 
 
@@ -730,3 +731,15 @@ class TestInterfaceIntegration:
         res = jax.grad(circuit)(x)
         expected = -2 * (4 * x**2 * np.cos(2 * x**2) + np.sin(2 * x**2))
         assert np.allclose(res, expected, atol=tol, rtol=0)
+
+
+def test_gradient_transform_is_deprecated():
+    """Test that the gradient_transform class is deprecated (being a child of batch_transform)."""
+
+    def func(op):
+        return op
+
+    with pytest.warns(
+        UserWarning, match="Use of `batch_transform` to create a custom transform is deprecated"
+    ):
+        _ = gradient_transform(func)


### PR DESCRIPTION
**Context:**
after #4774 was merged, @albi3ro realized we should have deprecated `gradient_transform` as well.

**Description of the Change:**
Deprecate `gradient_transform` which is no longer used

**Benefits:**
`gradient_transform` is closer to being removed.

**Possible Drawbacks:**
N/A