### PR TITLE
fix requirements to make docker builds pass

### DIFF
--- a/docker/interfaces/gpu-cuda/cuda-base.dockerfile
+++ b/docker/interfaces/gpu-cuda/cuda-base.dockerfile
@@ -43,7 +43,7 @@ RUN git submodule update --init --recursive \
     && pip install wheel \
     && pip install -r requirements.txt \
     && python3 setup.py install \
-    && pip install pytest pytest-cov pytest-mock flaky \
+    && pip install -r requirements-dev.txt \
     && make test
 
 # create Second small build.

--- a/docker/pennylane.dockerfile
+++ b/docker/pennylane.dockerfile
@@ -42,7 +42,7 @@ COPY  . .
 RUN git submodule update --init --recursive
 RUN pip install wheel && pip install -r requirements.txt
 RUN python3 setup.py install
-RUN pip install pytest pytest-cov pytest-mock flaky
+RUN pip install -r requirements-dev.txt
 RUN pip install -i https://test.pypi.org/simple/ pennylane-lightning --pre --upgrade
 # hotfix, remove when pyscf 2.1 is released (currently no wheel for python3.10)
 RUN pip install openfermionpyscf || true


### PR DESCRIPTION
latest docker build on master failing because it doesn't have pytest-benchmark: https://github.com/PennyLaneAI/pennylane/actions/runs/6801575137/job/18492742357