### PR TITLE
ensure the correct interface is returned in expand_state

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -86,7 +86,7 @@
 
 * Parametrized circuits whose operators do not act on all wires return pennylane tensors as
   expected, instead of numpy arrays.
-  [(#)]()
+  [(#4811)](https://github.com/PennyLaneAI/pennylane/pull/4811)
 
 <h3>Contributors ✍️</h3>
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -84,6 +84,10 @@
   wire order.
   [(#4781)](https://github.com/PennyLaneAI/pennylane/pull/4781)
 
+* Parametrized circuits whose operators do not act on all wires return pennylane tensors as
+  expected, instead of numpy arrays.
+  [(#)]()
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane/devices/qubit/simulate.py
+++ b/pennylane/devices/qubit/simulate.py
@@ -75,8 +75,9 @@ def expand_state_over_wires(state, state_wires, all_wires, is_state_batched):
     Returns:
         TensorLike: The state in the new desired size and order
     """
+    interface = qml.math.get_interface(state)
     pad_width = 2 ** len(all_wires) - 2 ** len(state_wires)
-    pad = (pad_width, 0) if qml.math.get_interface(state) == "torch" else (0, pad_width)
+    pad = (pad_width, 0) if interface == "torch" else (0, pad_width)
     shape = (2,) * len(all_wires)
     if is_state_batched:
         pad = ((0, 0), pad)
@@ -87,7 +88,7 @@ def expand_state_over_wires(state, state_wires, all_wires, is_state_batched):
         pad = (pad,)
         state = qml.math.flatten(state)
 
-    state = qml.math.pad(state, pad, mode="constant")
+    state = qml.math.pad(state, pad, mode="constant", like=interface)
     state = qml.math.reshape(state, shape)
 
     # re-order

--- a/tests/devices/qubit/test_simulate.py
+++ b/tests/devices/qubit/test_simulate.py
@@ -189,6 +189,16 @@ class TestBasicCircuit:
         assert qml.math.get_interface(res) == "jax"
         assert qml.math.allclose(res, -1)
 
+    def test_expand_state_keeps_autograd_interface(self):
+        """Test that expand_state doesn't convert autograd to numpy."""
+
+        @qml.qnode(qml.device("default.qubit", wires=2))
+        def circuit(x):
+            qml.RX(x, 0)
+            return qml.probs(wires=[0, 1])
+
+        assert qml.math.get_interface(circuit(1.5)) == "autograd"
+
 
 class TestBroadcasting:
     """Test that simulate works with broadcasted parameters"""


### PR DESCRIPTION
**Context:**
In the past, QNodes would return pennylane tensors by default if there was no specific interface set. However, I introduced some funniness when I added `qml.math.pad` [here](https://github.com/PennyLaneAI/pennylane/blob/4eecda939f862d62662751e791ba58bb0fc13508/pennylane/devices/qubit/simulate.py#L90). For some reason, when given a pennylane tensor, it would return a vanilla numpy array.

**Description of the Change:**
Provide the `like` parameter to `qml.math.pad` when expanding the statevector over all wires.

**Benefits:**
Consistency with past versions of PennyLane

**Possible Drawbacks:**
What in tarnation. I can't make any sense of interfaces anymore.