### PR TITLE
[Compiler] Activate integration tests & Update codecov and docstrings

### DIFF
--- a/doc/introduction/compiling_circuits.rst
+++ b/doc/introduction/compiling_circuits.rst
@@ -441,6 +441,3 @@ with PennyLane, please refer to the Catalyst
 bits and debugging tips <catalyst:dev/sharp_bits>` page for an overview of
 the differences between Catalyst and PennyLane, and how to best structure
 your workflows to improve performance when using Catalyst.
-
-To make your own compiler compatible with PennyLane, please see
-the :mod:`~.compiler` module documentation.

--- a/doc/introduction/compiling_circuits.rst
+++ b/doc/introduction/compiling_circuits.rst
@@ -441,3 +441,6 @@ with PennyLane, please refer to the Catalyst
 bits and debugging tips <catalyst:dev/sharp_bits>` page for an overview of
 the differences between Catalyst and PennyLane, and how to best structure
 your workflows to improve performance when using Catalyst.
+
+To make your own compiler compatible with PennyLane, please see
+the :mod:`~.compiler` module documentation.

--- a/pennylane/_grad.py
+++ b/pennylane/_grad.py
@@ -63,18 +63,15 @@ class grad:
             to determine differentiability, by examining the ``requires_grad``
             property.
 
-        method (str): Specifies the gradient method when used with the :func:`~.qjit` decorator.
-            Outside of the :func:`~.qjit`, this keyword argument has no effect and should not be
-            set. In just-in-time (JIT) mode, this can be any of ``["auto", "fd"]``, where:
+        method (str): Specifies the gradient method when used with the :func:`~.qjit` decorator. Outside of the :func:`~.qjit`, this keyword argument has no effect and should not be set. In just-in-time (JIT) mode, this can be any of ``["auto", "fd"]``, where:
 
-                - ``"auto"`` represents deferring the quantum differentiation to the method
-                specified by the QNode, while the classical computation is differentiated
-                using traditional auto-diff. Catalyst supports ``"parameter-shift"`` and
-                ``"adjoint"`` on internal QNodes. Notably, QNodes with
-                ``diff_method="finite-diff"`` are not supported with ``"auto"``.
+            - ``"auto"`` represents deferring the quantum differentiation to the method
+            specified by the QNode, while the classical computation is differentiated
+            using traditional auto-diff. Catalyst supports ``"parameter-shift"`` and
+            ``"adjoint"`` on internal QNodes. Notably, QNodes with
+            ``diff_method="finite-diff"`` are not supported with ``"auto"``.
 
-                - ``"fd"`` represents first-order finite-differences for the entire hybrid
-                function.
+            - ``"fd"`` represents first-order finite-differences for the entire hybrid function.
 
         step_size (float): The step-size value for the finite-difference (``"fd"``) method within
             :func:`~.qjit` decorated functions. This value has no effect in non-compiled functions.

--- a/pennylane/_grad.py
+++ b/pennylane/_grad.py
@@ -63,15 +63,17 @@ class grad:
             to determine differentiability, by examining the ``requires_grad``
             property.
 
-        method (str): Specifies the gradient method when used with the :func:`~.qjit` decorator. Outside of the :func:`~.qjit`, this keyword argument has no effect and should not be set. In just-in-time (JIT) mode, this can be any of ``["auto", "fd"]``, where:
+        method (str): The method used for differentiation, which can be any of ``["auto", "fd"]``,
+                      where:
 
-            - ``"auto"`` represents deferring the quantum differentiation to the method
-            specified by the QNode, while the classical computation is differentiated
-            using traditional auto-diff. Catalyst supports ``"parameter-shift"`` and
-            ``"adjoint"`` on internal QNodes. Notably, QNodes with
-            ``diff_method="finite-diff"`` are not supported with ``"auto"``.
+                      - ``"auto"`` represents deferring the quantum differentiation to the method
+                        specified by the QNode, while the classical computation is differentiated
+                        using traditional auto-diff. Catalyst supports ``"parameter-shift"`` and
+                        ``"adjoint"`` on internal QNodes. Notably, QNodes with
+                        ``diff_method="finite-diff"`` is not supported with ``"auto"``.
 
-            - ``"fd"`` represents first-order finite-differences for the entire hybrid function.
+                      - ``"fd"`` represents first-order finite-differences for the entire hybrid
+                        function.
 
         step_size (float): The step-size value for the finite-difference (``"fd"``) method within
             :func:`~.qjit` decorated functions. This value has no effect in non-compiled functions.
@@ -212,18 +214,17 @@ def jacobian(func, argnum=None, method=None, step_size=None):
             with respect to. If a sequence is given, the Jacobian corresponding
             to all marked inputs and all output elements is returned.
 
-        method (str): Specifies the gradient method when used with the :func:`~.qjit` decorator.
-            Outside of the :func:`~.qjit`, this keyword argument has no effect and should not be
-            set. In just-in-time (JIT) mode, this can be any of ``["auto", "fd"]``, where:
+        method (str): The method used for differentiation, which can be any of ``["auto", "fd"]``,
+                      where:
 
-                - ``"auto"`` represents deferring the quantum differentiation to the method
-                specified by the QNode, while the classical computation is differentiated
-                using traditional auto-diff. Catalyst supports ``"parameter-shift"`` and
-                ``"adjoint"`` on internal QNodes. Notably, QNodes with
-                ``diff_method="finite-diff"`` are not supported with ``"auto"``.
+                      - ``"auto"`` represents deferring the quantum differentiation to the method
+                        specified by the QNode, while the classical computation is differentiated
+                        using traditional auto-diff. Catalyst supports ``"parameter-shift"`` and
+                        ``"adjoint"`` on internal QNodes. Notably, QNodes with
+                        ``diff_method="finite-diff"`` is not supported with ``"auto"``.
 
-                - ``"fd"`` represents first-order finite-differences for the entire hybrid
-                function.
+                      - ``"fd"`` represents first-order finite-differences for the entire hybrid
+                        function.
 
         step_size (float): The step-size value for the finite-difference (``"fd"``) method within
             :func:`~.qjit` decorated functions. This value has no effect in non-compiled functions.

--- a/pennylane/_grad.py
+++ b/pennylane/_grad.py
@@ -63,24 +63,21 @@ class grad:
             to determine differentiability, by examining the ``requires_grad``
             property.
 
-        method (str): Specifies the gradient method when used with
-                      the :func:`~.qjit` decorator. Outside of the
-                      :func:`~.qjit`, this keyword argument has no effect.
-                      and should not be set.
-                      In just-in-time (JIT) mode, this can be any of ``["auto", "fd"]``, where:
+        method (str): Specifies the gradient method when used with the :func:`~.qjit` decorator.
+            Outside of the :func:`~.qjit`, this keyword argument has no effect and should not be
+            set. In just-in-time (JIT) mode, this can be any of ``["auto", "fd"]``, where:
 
-                      - ``"auto"`` represents deferring the quantum differentiation to the method
-                        specified by the QNode, while the classical computation is differentiated
-                        using traditional auto-diff. Catalyst supports ``"parameter-shift"`` and
-                        ``"adjoint"`` on internal QNodes. Notably, QNodes with
-                        ``diff_method="finite-diff"`` are not supported with ``"auto"``.
+                - ``"auto"`` represents deferring the quantum differentiation to the method
+                specified by the QNode, while the classical computation is differentiated
+                using traditional auto-diff. Catalyst supports ``"parameter-shift"`` and
+                ``"adjoint"`` on internal QNodes. Notably, QNodes with
+                ``diff_method="finite-diff"`` are not supported with ``"auto"``.
 
-                      - ``"fd"`` represents first-order finite-differences for the entire hybrid
-                        function.
+                - ``"fd"`` represents first-order finite-differences for the entire hybrid
+                function.
 
         step_size (float): The step-size value for the finite-difference (``"fd"``) method within
-                      :func:`~.qjit` decorated functions. This value has
-                      no effect in non-compiled functions.
+            :func:`~.qjit` decorated functions. This value has no effect in non-compiled functions.
 
     Returns:
         function: The function that returns the gradient of the input
@@ -218,23 +215,21 @@ def jacobian(func, argnum=None, method=None, step_size=None):
             with respect to. If a sequence is given, the Jacobian corresponding
             to all marked inputs and all output elements is returned.
 
-        method (str): Specifies the gradient method when used within
-                      the :func:`~.qjit` decorator. Outside of the
-                      :func:`~.qjit`, this keyword argument has no effect
-                      and should not be set.
+        method (str): Specifies the gradient method when used with the :func:`~.qjit` decorator.
+            Outside of the :func:`~.qjit`, this keyword argument has no effect and should not be
+            set. In just-in-time (JIT) mode, this can be any of ``["auto", "fd"]``, where:
 
-                      - ``"auto"`` represents deferring the quantum differentiation to the method
-                        specified by the QNode, while the classical computation is differentiated
-                        using traditional auto-diff. Catalyst supports ``"parameter-shift"`` and
-                        ``"adjoint"`` on internal QNodes. Notably, QNodes with
-                        ``diff_method="finite-diff"`` are not supported with ``"auto"``.
+                - ``"auto"`` represents deferring the quantum differentiation to the method
+                specified by the QNode, while the classical computation is differentiated
+                using traditional auto-diff. Catalyst supports ``"parameter-shift"`` and
+                ``"adjoint"`` on internal QNodes. Notably, QNodes with
+                ``diff_method="finite-diff"`` are not supported with ``"auto"``.
 
-                      - ``"fd"`` represents first-order finite-differences for the entire hybrid
-                        function.
+                - ``"fd"`` represents first-order finite-differences for the entire hybrid
+                function.
 
         step_size (float): The step-size value for the finite-difference (``"fd"``) method within
-                      :func:`~.qjit`. The value of this method should be ``None`` when is *not*
-                      called inside a :func:`~.qjit` decorated method. (default value is ``None``)
+            :func:`~.qjit` decorated functions. This value has no effect in non-compiled functions.
 
     Returns:
         function: the function that returns the Jacobian of the input function with respect to the

--- a/pennylane/_grad.py
+++ b/pennylane/_grad.py
@@ -27,11 +27,10 @@ make_vjp = unary_to_nary(_make_vjp)
 
 
 class grad:
-    """A :func:`~.qjit` compatible gradient transformation that returns the gradient
-    as a callable function of (functions of) QNodes.
+    """Returns the gradient as a callable function of (functions of) QNodes.
 
 
-    By default, in interpreted mode, gradients are computed for arguments which contain
+    By default, gradients are computed for arguments which contain
     the property ``requires_grad=True``. Alternatively, the ``argnum`` keyword argument
     can be specified to compute gradients for function arguments without this property,
     such as scalars, lists, tuples, dicts, or vanilla NumPy arrays. Setting
@@ -47,8 +46,8 @@ class grad:
 
     .. note::
 
-        When used with :func:`~.qjit`, this function only supports the Catalyst compiler.
-        Please see :func:`catalyst.grad` for more details.
+        When used with :func:`~.qjit`, this function currently only supports the
+        Catalyst compiler. See :func:`catalyst.grad` for more details.
 
         Please see the Catalyst :doc:`quickstart guide <catalyst:dev/quick_start>`,
         as well as the :doc:`sharp bits and debugging tips <catalyst:dev/sharp_bits>`
@@ -63,21 +62,6 @@ class grad:
             to determine differentiability, by examining the ``requires_grad``
             property.
 
-        method (str): The method used for differentiation, which can be any of ``["auto", "fd"]``,
-                      where:
-
-                      - ``"auto"`` represents deferring the quantum differentiation to the method
-                        specified by the QNode, while the classical computation is differentiated
-                        using traditional auto-diff. Catalyst supports ``"parameter-shift"`` and
-                        ``"adjoint"`` on internal QNodes. Notably, QNodes with
-                        ``diff_method="finite-diff"`` is not supported with ``"auto"``.
-
-                      - ``"fd"`` represents first-order finite-differences for the entire hybrid
-                        function.
-
-        step_size (float): The step-size value for the finite-difference (``"fd"``) method within
-            :func:`~.qjit` decorated functions. This value has no effect in non-compiled functions.
-
     Returns:
         function: The function that returns the gradient of the input
         function with respect to the differentiable arguments, or, if specified,
@@ -90,7 +74,7 @@ class grad:
         if active_jit := compiler.active_compiler():
             available_eps = compiler.AvailableCompilers.names_entrypoints
             ops_loader = available_eps[active_jit]["ops"].load()
-            return ops_loader.grad(func, method=method, h=step_size, argnum=argnum)
+            return ops_loader.graddd(func, method=method, h=step_size, argnum=argnum)
 
         if method or step_size:
             raise ValueError(
@@ -188,17 +172,16 @@ class grad:
 
 
 def jacobian(func, argnum=None, method=None, step_size=None):
-    """A :func:`~.qjit` compatible Jacobian transformation that returns the Jacobian
-    as a callable function of vector-valued (functions of) QNodes.
+    """Returns the Jacobian as a callable function of vector-valued
+    (functions of) QNodes.
 
 
-    By default, in interpreted mode, this is a wrapper around the :mod:`autograd.jacobian`
-    function.
+    By default, this is a wrapper around the :mod:`autograd.jacobian` function.
 
     .. note::
 
-        When used with :func:`~.qjit`, this function only supports the Catalyst compiler.
-        Please see :func:`catalyst.jacobian` for more details.
+        When used with :func:`~.qjit`, this function currently only supports the
+        Catalyst compiler. See :func:`catalyst.jacobian` for more details.
 
         Please see the Catalyst :doc:`quickstart guide <catalyst:dev/quick_start>`,
         as well as the :doc:`sharp bits and debugging tips <catalyst:dev/sharp_bits>`
@@ -214,31 +197,14 @@ def jacobian(func, argnum=None, method=None, step_size=None):
             with respect to. If a sequence is given, the Jacobian corresponding
             to all marked inputs and all output elements is returned.
 
-        method (str): The method used for differentiation, which can be any of ``["auto", "fd"]``,
-                      where:
-
-                      - ``"auto"`` represents deferring the quantum differentiation to the method
-                        specified by the QNode, while the classical computation is differentiated
-                        using traditional auto-diff. Catalyst supports ``"parameter-shift"`` and
-                        ``"adjoint"`` on internal QNodes. Notably, QNodes with
-                        ``diff_method="finite-diff"`` is not supported with ``"auto"``.
-
-                      - ``"fd"`` represents first-order finite-differences for the entire hybrid
-                        function.
-
-        step_size (float): The step-size value for the finite-difference (``"fd"``) method within
-            :func:`~.qjit` decorated functions. This value has no effect in non-compiled functions.
-
     Returns:
-        function: the function that returns the Jacobian of the input function with respect to the
-        arguments in argnum
+        function: the function that returns the Jacobian of the input
+        function with respect to the arguments in argnum
 
     .. note::
 
-        In interpreted mode, due to a limitation in Autograd, this function can only differentiate
-        built-in scalar or NumPy array arguments.
-
-
+        Due to a limitation in Autograd, this function can only differentiate built-in scalar
+        or NumPy array arguments.
 
     For ``argnum=None``, the trainable arguments are inferred dynamically from the arguments
     passed to the function. The returned function takes the same arguments as the original

--- a/pennylane/_grad.py
+++ b/pennylane/_grad.py
@@ -27,8 +27,8 @@ make_vjp = unary_to_nary(_make_vjp)
 
 
 class grad:
-    """A :func:`~.qjit` compatible gradient transformation that returns the gradient
-    as a callable function of (functions of) QNodes.
+    """Returns the gradient as a callable function of hybrid quantum-classical functions.
+    :func:`~.qjit` and Autograd compatible.
 
 
     By default, gradients are computed for arguments which contain
@@ -191,11 +191,8 @@ class grad:
 
 
 def jacobian(func, argnum=None, method=None, h=None):
-    """A :func:`~.qjit` compatible Jacobian transformation that returns the Jacobian
-    as a callable function of vector-valued (functions of) QNodes.
-
-
-    By default, this is a wrapper around the :mod:`autograd.jacobian` function.
+    """Returns the Jacobian as a callable function of vector-valued (functions of) QNodes.
+    :func:`~.qjit` and Autograd compatible.
 
     .. note::
 

--- a/pennylane/_grad.py
+++ b/pennylane/_grad.py
@@ -63,24 +63,23 @@ class grad:
             to determine differentiability, by examining the ``requires_grad``
             property.
 
-        method (str): Specifies the gradient method when used with
-            the :func:`~.qjit` decorator. Outside of the
-            :func:`~.qjit`, this keyword argument has no effect.
-            and should not be set.
+        method (str): Specifies the gradient method when used with the :func:`~.qjit`
+            decorator. Outside of :func:`~.qjit`, this keyword argument
+            has no effect and should not be set. In just-in-time (JIT) mode,
+            this can be any of ``["auto", "fd"]``, where:
 
-            In just-in-time (JIT) mode, this can be any of ``["auto", "fd"]``, where:
+            - ``"auto"`` represents deferring the quantum differentiation to the method
+              specified by the QNode, while the classical computation is differentiated
+              using traditional auto-diff. Catalyst supports ``"parameter-shift"`` and
+              ``"adjoint"`` on internal QNodes. QNodes with ``diff_method="finite-diff"``
+              are not supported with ``"auto"``.
 
-                - ``"auto"`` represents deferring the quantum differentiation to the method
-                specified by the QNode, while the classical computation is differentiated
-                using traditional auto-diff. Catalyst supports ``"parameter-shift"`` and
-                ``"adjoint"`` on internal QNodes. Notably, QNodes with
-                ``diff_method="finite-diff"`` are not supported with ``"auto"``.
-                - ``"fd"`` represents first-order finite-differences for the entire hybrid
-                function.
+            - ``"fd"`` represents first-order finite-differences for the entire hybrid
+              function.
 
-        step_size (float): The step-size value for the finite-difference (``"fd"``) method within
-                :func:`~.qjit` decorated functions. This value has
-                no effect in non-compiled functions.
+        h (float): The step-size value for the finite-difference (``"fd"``) method within
+            :func:`~.qjit` decorated functions. This value has
+            no effect in non-compiled functions.
 
     Returns:
         function: The function that returns the gradient of the input
@@ -217,24 +216,23 @@ def jacobian(func, argnum=None, method=None, h=None):
             with respect to. If a sequence is given, the Jacobian corresponding
             to all marked inputs and all output elements is returned.
 
-        method (str): Specifies the gradient method when used with
-            the :func:`~.qjit` decorator. Outside of the
-            :func:`~.qjit`, this keyword argument has no effect.
-            and should not be set.
+        method (str): Specifies the gradient method when used with the :func:`~.qjit`
+            decorator. Outside of :func:`~.qjit`, this keyword argument
+            has no effect and should not be set. In just-in-time (JIT) mode,
+            this can be any of ``["auto", "fd"]``, where:
 
-            In just-in-time (JIT) mode, this can be any of ``["auto", "fd"]``, where:
+            - ``"auto"`` represents deferring the quantum differentiation to the method
+              specified by the QNode, while the classical computation is differentiated
+              using traditional auto-diff. Catalyst supports ``"parameter-shift"`` and
+              ``"adjoint"`` on internal QNodes. QNodes with ``diff_method="finite-diff"``
+              are not supported with ``"auto"``.
 
-                - ``"auto"`` represents deferring the quantum differentiation to the method
-                specified by the QNode, while the classical computation is differentiated
-                using traditional auto-diff. Catalyst supports ``"parameter-shift"`` and
-                ``"adjoint"`` on internal QNodes. Notably, QNodes with
-                ``diff_method="finite-diff"`` are not supported with ``"auto"``.
-                - ``"fd"`` represents first-order finite-differences for the entire hybrid
-                function.
+            - ``"fd"`` represents first-order finite-differences for the entire hybrid
+              function.
 
-        step_size (float): The step-size value for the finite-difference (``"fd"``) method within
-                :func:`~.qjit` decorated functions. This value has no effect in non-compiled
-                functions.
+        h (float): The step-size value for the finite-difference (``"fd"``) method within
+            :func:`~.qjit` decorated functions. This value has no effect in non-compiled
+            functions.
 
     Returns:
         function: the function that returns the Jacobian of the input

--- a/pennylane/_grad.py
+++ b/pennylane/_grad.py
@@ -57,25 +57,31 @@ class grad:
     Args:
         func (function): a plain QNode, or a Python function that contains
             a combination of quantum and classical nodes
+
         argnum (int, list(int), None): Which argument(s) to take the gradient
             with respect to. By default, the arguments themselves are used
             to determine differentiability, by examining the ``requires_grad``
             property.
+
         method (str): Specifies the gradient method when used with
             the :func:`~.qjit` decorator. Outside of the
             :func:`~.qjit`, this keyword argument has no effect.
             and should not be set.
+
             In just-in-time (JIT) mode, this can be any of ``["auto", "fd"]``, where:
-                  - ``"auto"`` represents deferring the quantum differentiation to the method
+
+                - ``"auto"`` represents deferring the quantum differentiation to the method
                 specified by the QNode, while the classical computation is differentiated
                 using traditional auto-diff. Catalyst supports ``"parameter-shift"`` and
                 ``"adjoint"`` on internal QNodes. Notably, QNodes with
                 ``diff_method="finite-diff"`` are not supported with ``"auto"``.
-                  - ``"fd"`` represents first-order finite-differences for the entire hybrid
+                - ``"fd"`` represents first-order finite-differences for the entire hybrid
                 function.
+
         step_size (float): The step-size value for the finite-difference (``"fd"``) method within
                 :func:`~.qjit` decorated functions. This value has
                 no effect in non-compiled functions.
+
     Returns:
         function: The function that returns the gradient of the input
         function with respect to the differentiable arguments, or, if specified,
@@ -206,24 +212,30 @@ def jacobian(func, argnum=None, method=None, h=None):
             a combination of quantum and classical nodes. The output of the computation
             must consist of a single NumPy array (if classical) or a tuple of
             expectation values (if a quantum node)
+
         argnum (int or Sequence[int]): Which argument to take the gradient
             with respect to. If a sequence is given, the Jacobian corresponding
             to all marked inputs and all output elements is returned.
+
         method (str): Specifies the gradient method when used with
             the :func:`~.qjit` decorator. Outside of the
             :func:`~.qjit`, this keyword argument has no effect.
             and should not be set.
+
             In just-in-time (JIT) mode, this can be any of ``["auto", "fd"]``, where:
-                  - ``"auto"`` represents deferring the quantum differentiation to the method
+
+                - ``"auto"`` represents deferring the quantum differentiation to the method
                 specified by the QNode, while the classical computation is differentiated
                 using traditional auto-diff. Catalyst supports ``"parameter-shift"`` and
                 ``"adjoint"`` on internal QNodes. Notably, QNodes with
                 ``diff_method="finite-diff"`` are not supported with ``"auto"``.
-                  - ``"fd"`` represents first-order finite-differences for the entire hybrid
+                - ``"fd"`` represents first-order finite-differences for the entire hybrid
                 function.
+
         step_size (float): The step-size value for the finite-difference (``"fd"``) method within
                 :func:`~.qjit` decorated functions. This value has no effect in non-compiled
                 functions.
+
     Returns:
         function: the function that returns the Jacobian of the input
         function with respect to the arguments in argnum

--- a/pennylane/_grad.py
+++ b/pennylane/_grad.py
@@ -27,7 +27,8 @@ make_vjp = unary_to_nary(_make_vjp)
 
 
 class grad:
-    """Returns the gradient as a callable function of (functions of) QNodes.
+    """A :func:`~.qjit` compatible gradient transformation that returns the gradient
+    as a callable function of (functions of) QNodes.
 
 
     By default, gradients are computed for arguments which contain
@@ -56,12 +57,25 @@ class grad:
     Args:
         func (function): a plain QNode, or a Python function that contains
             a combination of quantum and classical nodes
-
         argnum (int, list(int), None): Which argument(s) to take the gradient
             with respect to. By default, the arguments themselves are used
             to determine differentiability, by examining the ``requires_grad``
             property.
-
+        method (str): Specifies the gradient method when used with
+            the :func:`~.qjit` decorator. Outside of the
+            :func:`~.qjit`, this keyword argument has no effect.
+            and should not be set.
+            In just-in-time (JIT) mode, this can be any of ``["auto", "fd"]``, where:
+                  - ``"auto"`` represents deferring the quantum differentiation to the method
+                specified by the QNode, while the classical computation is differentiated
+                using traditional auto-diff. Catalyst supports ``"parameter-shift"`` and
+                ``"adjoint"`` on internal QNodes. Notably, QNodes with
+                ``diff_method="finite-diff"`` are not supported with ``"auto"``.
+                  - ``"fd"`` represents first-order finite-differences for the entire hybrid
+                function.
+        step_size (float): The step-size value for the finite-difference (``"fd"``) method within
+                :func:`~.qjit` decorated functions. This value has
+                no effect in non-compiled functions.
     Returns:
         function: The function that returns the gradient of the input
         function with respect to the differentiable arguments, or, if specified,
@@ -172,8 +186,8 @@ class grad:
 
 
 def jacobian(func, argnum=None, method=None, h=None):
-    """Returns the Jacobian as a callable function of vector-valued
-    (functions of) QNodes.
+    """A :func:`~.qjit` compatible Jacobian transformation that returns the Jacobian
+    as a callable function of vector-valued (functions of) QNodes.
 
 
     By default, this is a wrapper around the :mod:`autograd.jacobian` function.
@@ -192,11 +206,24 @@ def jacobian(func, argnum=None, method=None, h=None):
             a combination of quantum and classical nodes. The output of the computation
             must consist of a single NumPy array (if classical) or a tuple of
             expectation values (if a quantum node)
-
         argnum (int or Sequence[int]): Which argument to take the gradient
             with respect to. If a sequence is given, the Jacobian corresponding
             to all marked inputs and all output elements is returned.
-
+        method (str): Specifies the gradient method when used with
+            the :func:`~.qjit` decorator. Outside of the
+            :func:`~.qjit`, this keyword argument has no effect.
+            and should not be set.
+            In just-in-time (JIT) mode, this can be any of ``["auto", "fd"]``, where:
+                  - ``"auto"`` represents deferring the quantum differentiation to the method
+                specified by the QNode, while the classical computation is differentiated
+                using traditional auto-diff. Catalyst supports ``"parameter-shift"`` and
+                ``"adjoint"`` on internal QNodes. Notably, QNodes with
+                ``diff_method="finite-diff"`` are not supported with ``"auto"``.
+                  - ``"fd"`` represents first-order finite-differences for the entire hybrid
+                function.
+        step_size (float): The step-size value for the finite-difference (``"fd"``) method within
+                :func:`~.qjit` decorated functions. This value has no effect in non-compiled
+                functions.
     Returns:
         function: the function that returns the Jacobian of the input
         function with respect to the arguments in argnum

--- a/pennylane/compiler/__init__.py
+++ b/pennylane/compiler/__init__.py
@@ -59,7 +59,7 @@ available hybrid compilers.
 
 Presented below is the list of :func:`~.qjit` compatible
 PennyLane primitives.
-    
+
 .. autosummary::
     :toctree: api
 

--- a/pennylane/compiler/__init__.py
+++ b/pennylane/compiler/__init__.py
@@ -32,13 +32,14 @@ autodifferentiation.
 
 .. note::
 
-    Catalyst currently only supports the JAX interface of PennyLane.
+    `Catalyst <https://github.com/pennylaneai/catalyst>`__ currently only
+    supports the JAX interface of PennyLane.
 
 Overview
 --------
 
 The main entry point to hybrid compilation in PennyLane
-is via the qjit decorator.
+is via the :func:`~.qjit` decorator.
 
 .. autosummary::
     :toctree: api
@@ -69,15 +70,14 @@ to incorporate additional compilers in the near future.
 
 .. note::
 
-    Catalyst is officially supported on Linux (x86_64) and macOS (aarch64) platforms.
-    To install it, simply run the following ``pip`` command:
+    To install Catalyst, simply run the following ``pip`` command:
 
     .. code-block:: console
 
       pip install pennylane-catalyst
 
-    Please see the :doc:`installation <catalyst:dev/installation>`
-    guide for more information.
+    See the :doc:`installation <catalyst:dev/installation>`
+    guide for more information and supported platforms.
 
 Basic usage
 -----------
@@ -88,7 +88,7 @@ Basic usage
     ``lightning.kokkos``, ``braket.local.qubit``, and ``braket.aws.qubit``
     devices. It does not support ``default.qubit``.
 
-    Please see the :doc:`Catalyst documentation <catalyst:index>` for more details on supported
+    See the :doc:`Catalyst documentation <catalyst:index>` for more details on supported
     devices, operations, and measurements.
 
 When using just-in-time (JIT) compilation, the compilation is triggered at the call site the
@@ -200,7 +200,7 @@ In order to support applying the ``qjit`` decorator with and without arguments,
     def function(x, y):
         ...
 
-you should ensure that the ``qjit`` decorator itself returns a decorator
+You should ensure that the ``qjit`` decorator itself returns a decorator
 if no function is provided:
 
 .. code-block:: python

--- a/pennylane/compiler/__init__.py
+++ b/pennylane/compiler/__init__.py
@@ -57,6 +57,15 @@ available hybrid compilers.
     ~compiler.active_compiler
     ~compiler.active
 
+Presented below is the list of :func:`~.qjit` compatible
+PennyLane primitives.
+    
+.. autosummary::
+    :toctree: api
+
+    ~grad
+    ~jacobian
+
 Compiler
 --------
 
@@ -170,9 +179,10 @@ using Catalyst.
 Adding a compiler
 -----------------
 
-For any compiler packages seeking to be registered, it is imperative that they
-expose the ``entry_points`` metadata under the designated group name
-``pennylane.compilers``, with the following entry points:
+To register any compiler packages, an experimental interface is available,
+and it is subject to further change. This interface exposes the ``entry_points``
+metadata under the designated group name ``pennylane.compilers``, including the
+following entry points:
 
 - ``context``: Path to the compilation evaluation context manager.
   This context manager should have the method ``context.is_tracing()``,

--- a/pennylane/compiler/__init__.py
+++ b/pennylane/compiler/__init__.py
@@ -102,7 +102,7 @@ Basic usage
 
 When using just-in-time (JIT) compilation, the compilation is triggered at the call site the
 first time the quantum function is executed. For example, ``circuit`` is
-compiled as early as the first call.
+compiled in the first call.
 
 .. code-block:: python
 

--- a/pennylane/compiler/__init__.py
+++ b/pennylane/compiler/__init__.py
@@ -19,7 +19,7 @@ Through the use of the :func:`~.qjit` decorator, entire workflows
 can be just-in-time (JIT) compiled --- including both quantum and
 classical processing --- down to a machine binary on first
 function execution. Subsequent calls to the compiled function will execute
-the previously compiled binary, resulting in significant
+the previously-compiled binary, resulting in significant
 performance improvements.
 
 Currently, PennyLane supports the

--- a/pennylane/compiler/__init__.py
+++ b/pennylane/compiler/__init__.py
@@ -179,8 +179,12 @@ using Catalyst.
 Adding a compiler
 -----------------
 
-To register any compiler packages, an experimental interface is available,
-and it is subject to further change. This interface exposes the ``entry_points``
+.. warning::
+
+    The PennyLane compiler API is experimental and subject to change.
+
+To register any compiler packages, an experimental interface is available.
+This interface exposes the ``entry_points``
 metadata under the designated group name ``pennylane.compilers``, including the
 following entry points:
 

--- a/pennylane/compiler/compiler.py
+++ b/pennylane/compiler/compiler.py
@@ -28,7 +28,18 @@ class CompileError(Exception):
 class AvailableCompilers:
     """This contains data of installed PennyLane compiler packages."""
 
-    entrypoints_interface = ("qjit", "context", "ops")
+    # The collection of entry points that compiler packages must export.
+    # This is used for validity checks of installed packages entry points.
+    # For any compiler packages seeking to be registered, it is imperative
+    # that they expose the ``entry_points`` metadata under the designated
+    # group name ``pennylane.compilers``, with the following entry points:
+    # - ``context``: Path to the compilation evaluation context manager.
+    # - ``ops``: Path to the compiler operations module.
+    # - ``qjit``: Path to the JIT decorator provided by the compiler.
+    entrypoints_interface = ("context", "qjit", "ops")
+
+    # The dictionary of installed compiler packages
+    # and their entry point loaders.
     names_entrypoints = {}
 
 
@@ -79,7 +90,7 @@ def _reload_compilers():
 
 
 def available_compilers() -> List[str]:
-    """Loads and returns a list of available compilers that are
+    """Load and return a list of available compilers that are
     installed and compatible with the :func:`~.qjit` decorator.
 
     **Example**
@@ -104,7 +115,7 @@ def available(compiler="catalyst") -> bool:
     """Check the availability of the given compiler package.
 
     Args:
-        compiler (str): name of the compiler package (default value is ``catalyst``)
+        compiler (str): Name of the compiler package (default value is ``catalyst``)
 
     Return:
         bool: ``True`` if the compiler package is installed on the system
@@ -186,7 +197,7 @@ def active() -> bool:
     just-in-time compiled versus those that are not.
 
     Return:
-        bool: True if the caller is inside a QJIT evaluation context
+        bool: ``True`` if the caller is inside a QJIT evaluation context
 
     **Example**
 

--- a/pennylane/compiler/compiler.py
+++ b/pennylane/compiler/compiler.py
@@ -118,7 +118,7 @@ def available(compiler="catalyst") -> bool:
     Args:
         compiler (str): Name of the compiler package (default value is ``catalyst``)
 
-    Return:
+    Returns:
         bool: ``True`` if the compiler package is installed on the system
 
     **Example**
@@ -152,10 +152,9 @@ def active_compiler() -> Optional[str]:
     to allow differing logic for transformations or operations that are
     just-in-time compiled, versus those that are not.
 
-    Return:
-        Optional[str]: Name of the active compiler inside a :func:`~.qjit`
-            evaluation context. If there is no active compiler, ``None``
-            will be returned.
+    Returns:
+        Optional[str]: Name of the active compiler inside a :func:`~.qjit` evaluation
+        context. If there is no active compiler, ``None`` will be returned.
 
     **Example**
 
@@ -197,7 +196,7 @@ def active() -> bool:
     to allow differing logic for circuits or operations that are
     just-in-time compiled versus those that are not.
 
-    Return:
+    Returns:
         bool: ``True`` if the caller is inside a QJIT evaluation context
 
     **Example**

--- a/pennylane/compiler/compiler.py
+++ b/pennylane/compiler/compiler.py
@@ -70,7 +70,7 @@ def _refresh_compilers():
     for _, eps_dict in AvailableCompilers.names_entrypoints.items():
         ep_interface = AvailableCompilers.entrypoints_interface
         if any(ep not in eps_dict.keys() for ep in ep_interface):
-            raise KeyError(f"expected {ep_interface}, but recieved {eps_dict}")
+            raise KeyError(f"expected {ep_interface}, but recieved {eps_dict}")  # pragma: no cover
 
 
 # Scan installed compiler packages

--- a/pennylane/compiler/compiler.py
+++ b/pennylane/compiler/compiler.py
@@ -29,7 +29,8 @@ class AvailableCompilers:
     """This contains data of installed PennyLane compiler packages."""
 
     # The collection of entry points that compiler packages must export.
-    # This is used for validity checks of installed packages entry points.
+    # Note that this is still an experimental interface and is subject to change.
+    # This variable is used for validity checks of installed packages entry points.
     # For any compiler packages seeking to be registered, it is imperative
     # that they expose the ``entry_points`` metadata under the designated
     # group name ``pennylane.compilers``, with the following entry points:

--- a/pennylane/compiler/compiler.py
+++ b/pennylane/compiler/compiler.py
@@ -202,7 +202,7 @@ def active() -> bool:
     **Example**
 
     For example, you can use this method in your hybrid program to execute it
-    conditionally whether is called inside :func:`~.qjit` or not.
+    conditionally whether called inside :func:`~.qjit` or not.
 
     .. code-block:: python
 

--- a/pennylane/compiler/qjit_api.py
+++ b/pennylane/compiler/qjit_api.py
@@ -28,7 +28,7 @@ def qjit(fn=None, *args, compiler="catalyst", **kwargs):  # pylint:disable=keywo
         Currently, only the :doc:`Catalyst <catalyst:index>` hybrid quantum-classical
         compiler is supported. The Catalyst compiler works with the JAX interface
 
-        For more details, please see the Catalyst documentation and :func:`catalyst:.qjit`
+        For more details, see the Catalyst documentation and :func:`catalyst:.qjit`
         docstring.
 
     .. note::
@@ -41,14 +41,13 @@ def qjit(fn=None, *args, compiler="catalyst", **kwargs):  # pylint:disable=keywo
         supported devices, operations, and measurements.
 
     Args:
-        compiler (str): name of the compiler to use for just-in-time compilation
-        fn (Callable): the quantum or classical function to compile
+        compiler (str): Name of the compiler to use for just-in-time compilation
+        fn (Callable): Hybrid (quantum-classical) function to compile
         autograph (bool): Experimental support for automatically converting Python control
             flow statements to Catalyst-compatible control flow. Currently supports Python ``if``,
             ``elif``, ``else``, and ``for`` statements. Note that this feature requires an
-            available TensorFlow installation. Please see the
+            available TensorFlow installation. See the
             :doc:`AutoGraph guide <catalyst:dev/autograph>` for more information.
-        target (str): the compilation target
         keep_intermediate (bool): Whether or not to store the intermediate files throughout the
             compilation. If ``True``, intermediate representations are available via the
             :attr:`~.QJIT.mlir`, :attr:`~.QJIT.jaxpr`, and :attr:`~.QJIT.qir`, representing
@@ -56,14 +55,14 @@ def qjit(fn=None, *args, compiler="catalyst", **kwargs):  # pylint:disable=keywo
         verbosity (bool): If ``True``, the tools and flags used by Catalyst behind the scenes are
             printed out.
         logfile (TextIOWrapper): File object to write verbose messages to (default is
-            ``sys.stderr``).
+            ``sys.stderr``)
         pipelines (List[Tuple[str, List[str]]]): A list of pipelines to be executed. The
             elements of this list are named sequences of MLIR passes to be executed. A ``None``
             value (the default) results in the execution of the default pipeline. This option is
             considered to be used by advanced users for low-level debugging purposes.
 
     Returns:
-        catalyst.QJIT: a class that, when executed, just-in-time compiles and executes the
+        catalyst.QJIT: A class that, when executed, just-in-time compiles and executes the
         decorated function
 
     Raises:

--- a/pennylane/compiler/qjit_api.py
+++ b/pennylane/compiler/qjit_api.py
@@ -105,7 +105,7 @@ def qjit(fn=None, *args, compiler="catalyst", **kwargs):  # pylint:disable=keywo
     """
 
     if not available(compiler):
-        raise CompileError(f"The {compiler} package is not installed.")
+        raise CompileError(f"The {compiler} package is not installed.")  # pragma: no cover
 
     compilers = AvailableCompilers.names_entrypoints
     qjit_loader = compilers[compiler]["qjit"].load()

--- a/pennylane/compiler/qjit_api.py
+++ b/pennylane/compiler/qjit_api.py
@@ -28,7 +28,7 @@ def qjit(fn=None, *args, compiler="catalyst", **kwargs):  # pylint:disable=keywo
         Currently, only the :doc:`Catalyst <catalyst:index>` hybrid quantum-classical
         compiler is supported. The Catalyst compiler works with the JAX interface
 
-        For more details, see the Catalyst documentation and :func:`catalyst:.qjit`
+        For more details, see the Catalyst documentation and :func:`catalyst.qjit`
         docstring.
 
     .. note::

--- a/pennylane/compiler/qjit_api.py
+++ b/pennylane/compiler/qjit_api.py
@@ -41,8 +41,8 @@ def qjit(fn=None, *args, compiler="catalyst", **kwargs):  # pylint:disable=keywo
         supported devices, operations, and measurements.
 
     Args:
-        compiler (str): Name of the compiler to use for just-in-time compilation
         fn (Callable): Hybrid (quantum-classical) function to compile
+        compiler (str): Name of the compiler to use for just-in-time compilation
         autograph (bool): Experimental support for automatically converting Python control
             flow statements to Catalyst-compatible control flow. Currently supports Python ``if``,
             ``elif``, ``else``, and ``for`` statements. Note that this feature requires an

--- a/pennylane/compiler/qjit_api.py
+++ b/pennylane/compiler/qjit_api.py
@@ -49,7 +49,8 @@ def qjit(fn=None, *args, compiler="catalyst", **kwargs):  # pylint:disable=keywo
             available TensorFlow installation. See the
             :doc:`AutoGraph guide <catalyst:dev/autograph>` for more information.
         keep_intermediate (bool): Whether or not to store the intermediate files throughout the
-            compilation. If ``True``, intermediate representations are available via the
+            compilation. The files are stored at the location where the Python script is called.
+            If ``True``, intermediate representations are available via the
             :attr:`~.QJIT.mlir`, :attr:`~.QJIT.jaxpr`, and :attr:`~.QJIT.qir`, representing
             different stages in the optimization process.
         verbosity (bool): If ``True``, the tools and flags used by Catalyst behind the scenes are

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -38,6 +38,7 @@ class TestCatalyst:
         """Test compiler active and available methods"""
 
         assert not qml.compiler.active()
+        assert not qml.compiler.available("SomeRandomCompiler")
 
         assert qml.compiler.available("catalyst")
         assert qml.compiler.available_compilers() == ["catalyst"]
@@ -333,10 +334,8 @@ class TestCatalyst:
             return g(x)
 
         result = qml.qjit(workflow)(np.array([2.0, 1.0]))
-        print(result)
-
         reference = np.array([[-0.37120096, -0.45467246], [0.37120096, 0.45467246]])
-        print(jnp.allclose(result, reference))
+        assert jnp.allclose(result, reference)
 
         with pytest.raises(
             ValueError,

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -330,7 +330,7 @@ class TestCatalyst:
                 qml.RY(x[1], wires=0)
                 return qml.probs()
 
-            g = qml.jacobian(circuit, method="fd", step_size=0.3)
+            g = qml.jacobian(circuit, method="fd", h=0.3)
             return g(x)
 
         result = qml.qjit(workflow)(np.array([2.0, 1.0]))
@@ -339,6 +339,6 @@ class TestCatalyst:
 
         with pytest.raises(
             ValueError,
-            match="Invalid values for 'method=fd' and 'step_size=0.3' in interpreted mode",
+            match="Invalid values for 'method=fd' and 'h=0.3' in interpreted mode",
         ):
             workflow(np.array([2.0, 1.0]))

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -20,10 +20,10 @@ import pennylane as qml
 
 from pennylane import numpy as np
 
-pytestmark = pytest.mark.external
-
 catalyst = pytest.importorskip("catalyst")
 jax = pytest.importorskip("jax")
+
+pytestmark = pytest.mark.external
 
 from jax import numpy as jnp  # pylint:disable=wrong-import-order, wrong-import-position
 from jax.core import ShapedArray  # pylint:disable=wrong-import-order, wrong-import-position

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 """
 Unit tests for the compiler subpackage.
-TODO: Uncomment 'pytest.mark.external' to check these tests in GitHub actions with
-    the 'pennylane-catalyst' v0.3.2 release. These tests require the installation
-    of Catalyst from the main branch at the moment.
 """
 # pylint: disable=import-outside-toplevel
 import pytest
@@ -23,10 +20,10 @@ import pennylane as qml
 
 from pennylane import numpy as np
 
+pytestmark = pytest.mark.external
+
 catalyst = pytest.importorskip("catalyst")
 jax = pytest.importorskip("jax")
-
-# pytestmark = pytest.mark.external
 
 from jax import numpy as jnp  # pylint:disable=wrong-import-order, wrong-import-position
 from jax.core import ShapedArray  # pylint:disable=wrong-import-order, wrong-import-position
@@ -41,9 +38,6 @@ class TestCatalyst:
         """Test compiler active and available methods"""
 
         assert not qml.compiler.active()
-
-        assert qml.compiler.available("catalyst")
-        assert qml.compiler.available_compilers() == ["catalyst"]
 
         assert qml.compiler.available("catalyst")
         assert qml.compiler.available_compilers() == ["catalyst"]
@@ -97,13 +91,18 @@ class TestCatalyst:
 
         dev = qml.device("lightning.qubit", wires=2)
 
-        @qml.qjit  # compilation happens at definition
+        @qml.qjit
         @qml.qnode(dev)
         def circuit(x: complex, z: ShapedArray(shape=(3,), dtype=jnp.float64)):
             theta = jnp.abs(x)
             qml.RY(theta, wires=0)
             qml.Rot(z[0], z[1], z[2], wires=0)
             return qml.state()
+
+        # Check that the compilation happens at definition
+        assert circuit.jaxpr
+        assert circuit.mlir
+        assert circuit.qir
 
         result = circuit(0.2j, jnp.array([0.3, 0.6, 0.9]))
         expected = jnp.array(


### PR DESCRIPTION
This PR updates the support and addresses code review suggestions in PR #4692.

- [x] Activate integration tests in CI (using Catalyst v0.3.2)
- [x] Fix docstring issues in the compiler and grad docs
- [x] Use `h` instead of `step_size` in grad ops
- [x] Update code coverage of the compiler module