### PR TITLE
create a PL-specific deprecation warning

### DIFF
--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -3,6 +3,9 @@
 Deprecations
 ============
 
+All PennyLane deprecations will raise a ``qml.PennyLaneDeprecationWarning``. Pending and completed
+deprecations are listed below.
+
 Pending deprecations
 --------------------
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -48,6 +48,9 @@
 
 <h3>Deprecations 👋</h3>
 
+* All deprecations now raise a `qml.PennyLaneDeprecationWarning` instead of a `UserWarning`.
+  [(#4814)](https://github.com/PennyLaneAI/pennylane/pull/4814)
+
 * `QuantumScript.is_sampled` and `QuantumScript.all_sampled` are deprecated.
   Users should now validate these properties manually.
   [(#4773)](https://github.com/PennyLaneAI/pennylane/pull/4773)

--- a/pennylane/__init__.py
+++ b/pennylane/__init__.py
@@ -139,6 +139,10 @@ class QuantumFunctionError(Exception):
     """Exception raised when an illegal operation is defined in a quantum function."""
 
 
+class PennyLaneDeprecationWarning(UserWarning):
+    """Warning raised when a PennyLane feature is being deprecated."""
+
+
 def _get_device_entrypoints():
     """Returns a dictionary mapping the device short name to the
     loadable entrypoint"""

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -1883,7 +1883,7 @@ class Observable(Operator):
         warnings.warn(
             "`Observable.return_type` is deprecated. Instead, you should "
             "inspect the type of the surrounding measurement process.",
-            UserWarning,
+            qml.PennyLaneDeprecationWarning,
         )
         return self._return_type
 
@@ -1893,7 +1893,7 @@ class Observable(Operator):
         warnings.warn(
             "`Observable.return_type` is deprecated. Instead, you should "
             "create a measurement process containing this Observable.",
-            UserWarning,
+            qml.PennyLaneDeprecationWarning,
         )
         self._return_type = value
 

--- a/pennylane/ops/functions/generator.py
+++ b/pennylane/ops/functions/generator.py
@@ -88,7 +88,7 @@ def _generator_backcompatibility(op):
         "The Operator.generator property is deprecated. Please update the operator so that "
         "\n\t1. Operator.generator() is a method, and"
         "\n\t2. Operator.generator() returns an Operator instance representing the operator.",
-        UserWarning,
+        qml.PennyLaneDeprecationWarning,
     )
     gen = op.generator
 

--- a/pennylane/ops/op_math/controlled.py
+++ b/pennylane/ops/op_math/controlled.py
@@ -268,7 +268,7 @@ class Controlled(SymbolicOp):
             if isinstance(control_values, str):
                 warnings.warn(
                     "Specifying control values as a string is deprecated. Please use Sequence[Bool]",
-                    UserWarning,
+                    qml.PennyLaneDeprecationWarning,
                 )
                 # All values not 0 are cast as true. Assumes a string of 1s and 0s.
                 control_values = [(x != "0") for x in control_values]

--- a/pennylane/tape/qscript.py
+++ b/pennylane/tape/qscript.py
@@ -405,7 +405,7 @@ class QuantumScript:
             ">>> from pennylane.measurements import *\n"
             ">>> sample_types = (SampleMP, CountsMP, ClassicalShadowMP, ShadowExpvalMP)\n"
             ">>> is_sampled = any(isinstance(m, sample_types) for m in tape.measurements)\n",
-            UserWarning,
+            qml.PennyLaneDeprecationWarning,
         )
         sample_type = (SampleMP, CountsMP, ClassicalShadowMP, ShadowExpvalMP)
         return any(isinstance(m, sample_type) for m in self.measurements)
@@ -419,7 +419,7 @@ class QuantumScript:
             ">>> from pennylane.measurements import *\n"
             ">>> sample_types = (SampleMP, CountsMP, ClassicalShadowMP, ShadowExpvalMP)\n"
             ">>> all_sampled = all(isinstance(m, sample_types) for m in tape.measurements)\n",
-            UserWarning,
+            qml.PennyLaneDeprecationWarning,
         )
         sample_type = (SampleMP, CountsMP, ClassicalShadowMP, ShadowExpvalMP)
         return all(isinstance(m, sample_type) for m in self.measurements)

--- a/pennylane/transforms/__init__.py
+++ b/pennylane/transforms/__init__.py
@@ -215,9 +215,9 @@ instead to the documentation of :func:`qml.transform <pennylane.transform>`.
 Old transforms framework
 ------------------------
 
-These utility functions were previously used to create transforms in PennyLane and will be
-deprecated soon. It is now recommended to use :class:`qml.transform <pennylane.transform>`
-for creation of custom transforms.
+These utility functions were previously used to create transforms in PennyLane and are now
+deprecated. It is now recommended to use :class:`qml.transform <pennylane.transform>`
+for the creation of custom transforms.
 
 .. autosummary::
     :toctree: api

--- a/pennylane/transforms/batch_transform.py
+++ b/pennylane/transforms/batch_transform.py
@@ -224,7 +224,7 @@ class batch_transform:
             "Use of `batch_transform` to create a custom transform is deprecated. Instead "
             "switch to using the new qml.transform function. Follow the instructions here for "
             "further details: https://docs.pennylane.ai/en/stable/code/qml_transforms.html#custom-transforms.",
-            UserWarning,
+            qml.PennyLaneDeprecationWarning,
         )
         self.transform_fn = transform_fn
         self.expand_fn = expand_fn

--- a/pennylane/transforms/core/transform_dispatcher.py
+++ b/pennylane/transforms/core/transform_dispatcher.py
@@ -134,7 +134,7 @@ class TransformDispatcher:
             "or call the transform directly using qnode = transform_fn(qnode, "
             "**transform_kwargs). Visit the deprecations page for more details: "
             "https://docs.pennylane.ai/en/stable/development/deprecations.html",
-            UserWarning,
+            qml.PennyLaneDeprecationWarning,
         )
 
         if obj is not None:

--- a/pennylane/transforms/op_transforms.py
+++ b/pennylane/transforms/op_transforms.py
@@ -203,7 +203,7 @@ class op_transform:
             "Use of `op_transform` to create a custom transform is deprecated. Instead "
             "switch to using the new qml.transform function. Follow the instructions here for "
             "further details: https://docs.pennylane.ai/en/stable/code/qml_transforms.html#custom-transforms.",
-            UserWarning,
+            qml.PennyLaneDeprecationWarning,
         )
         self._fn = fn
         self._sig = inspect.signature(fn).parameters

--- a/pennylane/transforms/qfunc_transforms.py
+++ b/pennylane/transforms/qfunc_transforms.py
@@ -150,7 +150,7 @@ class single_tape_transform:
             "Use of `single_tape_transform` to create a custom transform is deprecated. Instead "
             "switch to using the new qml.transform function. Follow the instructions here for "
             "further details: https://docs.pennylane.ai/en/stable/code/qml_transforms.html#custom-transforms.",
-            UserWarning,
+            qml.PennyLaneDeprecationWarning,
         )
         self.transform_fn = transform_fn
         functools.update_wrapper(self, transform_fn)
@@ -405,11 +405,11 @@ def qfunc_transform(tape_transform):
         "Use of `qfunc_transform` to create a custom transform is deprecated. Instead "
         "switch to using the new qml.transform function. Follow the instructions here for "
         "further details: https://docs.pennylane.ai/en/stable/code/qml_transforms.html#custom-transforms.",
-        UserWarning,
+        qml.PennyLaneDeprecationWarning,
     )
     if not isinstance(tape_transform, single_tape_transform):
         with warnings.catch_warnings():
-            warnings.simplefilter("ignore", UserWarning)
+            warnings.simplefilter("ignore", qml.PennyLaneDeprecationWarning)
             tape_transform = single_tape_transform(tape_transform)
 
     sig = inspect.signature(tape_transform)

--- a/pennylane/vqe/vqe.py
+++ b/pennylane/vqe/vqe.py
@@ -156,7 +156,7 @@ class ExpvalCost:
             "ExpvalCost is deprecated, use qml.expval() instead. "
             "For optimizing Hamiltonian measurements with measuring commuting "
             "terms in parallel, use the grouping_type keyword in qml.Hamiltonian.",
-            UserWarning,
+            qml.PennyLaneDeprecationWarning,
         )
 
         if kwargs.get("measure", "expval") != "expval":


### PR DESCRIPTION
**Context:**
When we deprecate features, it's hard to identify that we've done it.

**Description of the Change:**
Replace all deprecation warning categories with the new `PennyLaneDeprecationWarning`

**Benefits:**
We can add a pytest.ini filter to make this into failures on plugins!

```
[pytest]
filterwarnings =
    error::pennylane.PennyLaneDeprecationWarning
```

(I ran a test locally with a plugin that was setting `Observable.return_type` and saw that it raised the error)

**Possible Drawbacks:**
N/A