### PR TITLE
stop allowing string control_values for ctrl

### DIFF
--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -87,6 +87,11 @@ Pending deprecations
 Completed deprecation cycles
 ----------------------------
 
+* Specifying ``control_values`` passed to ``qml.ctrl`` as a string is no longer supported.
+
+  - Deprecated in v0.25
+  - Removed in v0.34
+
 * ``qml.gradients.pulse_generator`` has become ``qml.gradients.pulse_odegen`` to adhere to paper naming conventions.
 
   - Deprecated in v0.33

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -47,7 +47,7 @@
   [(#4762)](https://github.com/PennyLaneAI/pennylane/pull/4762)
 
 * Specifying `control_values` passed to `qml.ctrl` as a string is no longer supported.
-  [(#)]()
+  [(#4816)](https://github.com/PennyLaneAI/pennylane/pull/4816)
 
 <h3>Deprecations 👋</h3>
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -46,6 +46,9 @@
   because it depended on the now-deprecated `Observable.return_type` property.
   [(#4762)](https://github.com/PennyLaneAI/pennylane/pull/4762)
 
+* Specifying `control_values` passed to `qml.ctrl` as a string is no longer supported.
+  [(#)]()
+
 <h3>Deprecations 👋</h3>
 
 * `QuantumScript.is_sampled` and `QuantumScript.all_sampled` are deprecated.

--- a/pennylane/ops/op_math/controlled.py
+++ b/pennylane/ops/op_math/controlled.py
@@ -265,14 +265,6 @@ class Controlled(SymbolicOp):
         if control_values is None:
             control_values = [True] * len(control_wires)
         else:
-            if isinstance(control_values, str):
-                warnings.warn(
-                    "Specifying control values as a string is deprecated. Please use Sequence[Bool]",
-                    UserWarning,
-                )
-                # All values not 0 are cast as true. Assumes a string of 1s and 0s.
-                control_values = [(x != "0") for x in control_values]
-
             control_values = (
                 [bool(control_values)]
                 if isinstance(control_values, int)

--- a/tests/drawer/test_tape_mpl.py
+++ b/tests/drawer/test_tape_mpl.py
@@ -478,22 +478,6 @@ class TestControlledGates:
         assert ax.texts[2].get_text() == "RX\n(1.23)"
         plt.close()
 
-    @pytest.mark.filterwarnings("ignore:Specifying control values as a string")
-    @pytest.mark.filterwarnings("ignore:The control_wires keyword will be removed soon")
-    def test_control_values_str(self):
-        """Test control values get displayed correctly when they are provided as a string."""
-
-        with qml.queuing.AnnotatedQueue() as q_tape:
-            qml.ControlledQubitUnitary(
-                qml.matrix(qml.RX)(0, 0),
-                control_wires=[0, 1, 2, 3],
-                wires=[4],
-                control_values="1010",
-            )
-
-        tape = QuantumScript.from_queue(q_tape)
-        self.check_tape_controlled_qubit_unitary(tape)
-
     def test_control_values_bool(self):
         """Test control_values get displayed correctly when they are provided as a list of bools."""
 

--- a/tests/ops/op_math/test_controlled.py
+++ b/tests/ops/op_math/test_controlled.py
@@ -156,14 +156,6 @@ class TestInitialization:
         op = Controlled(self.temp_op, (0, 1), control_values=[0, 1])
         assert op.control_values == [False, True]
 
-    def test_string_control_values(self):
-        """Test warning and conversion of string control_values."""
-
-        with pytest.warns(UserWarning, match="Specifying control values as a string"):
-            op = Controlled(self.temp_op, (0, 1), "01")
-
-        assert op.control_values == [False, True]
-
     def test_non_boolean_control_values(self):
         """Test control values are converted to booleans."""
         op = Controlled(self.temp_op, (0, 1, 2), control_values=["", None, 5])

--- a/tests/ops/op_math/test_controlled_ops.py
+++ b/tests/ops/op_math/test_controlled_ops.py
@@ -225,15 +225,15 @@ class TestControlledQubitUnitary:
     @pytest.mark.parametrize(
         "control_wires,wires,control_values",
         [
-            ([0], 1, "0"),
-            ([0, 1], 2, "00"),
-            ([0, 1], 2, "10"),
-            ([0, 1], 2, "11"),
-            ([1, 0], 2, "01"),
-            ([0, 1], [2, 3], "11"),
-            ([0, 2], [3, 1], "10"),
-            ([1, 2, 0], [3, 4], "100"),
-            ([1, 0, 2], [4, 3], "110"),
+            ([0], 1, [0]),
+            ([0, 1], 2, [0, 0]),
+            ([0, 1], 2, [1, 0]),
+            ([0, 1], 2, [1, 1]),
+            ([1, 0], 2, [0, 1]),
+            ([0, 1], [2, 3], [1, 1]),
+            ([0, 2], [3, 1], [1, 0]),
+            ([1, 2, 0], [3, 4], [1, 0, 0]),
+            ([1, 0, 2], [4, 3], [1, 1, 0]),
         ],
     )
     def test_mixed_polarity_controls(self, control_wires, wires, control_values):
@@ -264,7 +264,7 @@ class TestControlledQubitUnitary:
         # if we conjugated the specified control wires with Pauli X and applied the
         # "regular" ControlledQubitUnitary in between.
 
-        x_locations = [x for x in range(len(control_values)) if control_values[x] == "0"]
+        x_locations = [x for x in range(len(control_values)) if control_values[x] == 0]
 
         @qml.qnode(dev)
         def circuit_pauli_x():


### PR DESCRIPTION
**Context:**
This warning was added eons ago (#2634), but it pre-dates our deprecation management page so it slipped through the cracks.

**Description of the Change:**
Remove the support for passing `control_values` as a string to `qml.ctrl`

**Benefits:**
Deprecation cycle is now complete!

**Possible Drawbacks:**
It wasn't on our deprecations page and was therefore never formally scheduled for removal. But you know.. it's been almost 10 releases.

NOTE: I want to see PennyLaneAI/plugin-test-matrix#57 merged and get a look at the matrix before we merge this into master. Too many things breaking at once 😓 