### PR TITLE
simplify state reordering logic

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -30,7 +30,7 @@
   [(#4749)](https://github.com/PennyLaneAI/pennylane/pull/4749)
 
 * Simplified the logic for re-arranging states before returning.
-  [(#)]()
+  [(#4817)](https://github.com/PennyLaneAI/pennylane/pull/4817)
 
 <h3>Breaking changes 💔</h3>
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -29,6 +29,9 @@
 * `qml.draw` and `qml.draw_mpl` now render operator ids.
   [(#4749)](https://github.com/PennyLaneAI/pennylane/pull/4749)
 
+* Simplified the logic for re-arranging states before returning.
+  [(#)]()
+
 <h3>Breaking changes 💔</h3>
 
 * The `prep` keyword argument has been removed from `QuantumScript` and `QuantumTape`.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -116,6 +116,7 @@
 * Parametrized circuits whose operators do not act on all wires return pennylane tensors as
   expected, instead of numpy arrays.
   [(#4811)](https://github.com/PennyLaneAI/pennylane/pull/4811)
+  [(#4817)](https://github.com/PennyLaneAI/pennylane/pull/4817)
 
 <h3>Contributors ✍️</h3>
 

--- a/pennylane/measurements/state.py
+++ b/pennylane/measurements/state.py
@@ -160,33 +160,22 @@ class StateMP(StateMeasurement):
         if not wires or wire_order == wires:
             return qml.math.cast(state, "complex128")
 
-        if not wires.contains_wires(wire_order):
+        if set(wires) != set(wire_order):
             raise WireError(
-                f"Unexpected wires {set(wire_order) - set(wires)} found in wire order. Expected wire order to be a subset of {wires}"
+                f"Unexpected unique wires {Wires.unique_wires([wires, wire_order])} found. "
+                f"Expected wire order {wire_order} to be a rearrangement of {wires}"
             )
 
-        # pad with zeros, put existing wires last
-        is_state_batched = qml.math.ndim(state) == 2
-        pad_width = 2 ** len(wires) - 2 ** len(wire_order)
-        pad = (pad_width, 0) if qml.math.get_interface(state) == "torch" else (0, pad_width)
         shape = (2,) * len(wires)
         flat_shape = (2 ** len(wires),)
-        if is_state_batched:
+        desired_axes = [wire_order.index(w) for w in wires]
+        if qml.math.ndim(state) == 2:  # batched state
             batch_size = qml.math.shape(state)[0]
-            pad = ((0, 0), pad)
             shape = (batch_size,) + shape
             flat_shape = (batch_size,) + flat_shape
-        else:
-            pad = (pad,)
-
-        state = qml.math.pad(state, pad, mode="constant")
-        state = qml.math.reshape(state, shape)
-
-        # re-order
-        new_wire_order = Wires.unique_wires([wires, wire_order]) + wire_order
-        desired_axes = [new_wire_order.index(w) for w in wires]
-        if is_state_batched:
             desired_axes = [0] + [i + 1 for i in desired_axes]
+
+        state = qml.math.reshape(state, shape)
         state = qml.math.transpose(state, desired_axes)
         state = qml.math.reshape(state, flat_shape)
         return qml.math.cast(state, "complex128")

--- a/pennylane/tape/qscript.py
+++ b/pennylane/tape/qscript.py
@@ -1187,19 +1187,19 @@ class QuantumScript:
         **Example:**
 
         >>> circuit = qml.tape.QuantumScript([qml.PauliX("a")], [qml.expval(qml.PauliZ("b"))])
-        >>> map_circuit_to_standard_wires(circuit).circuit
+        >>> circuit.map_to_standard_wires().circuit
         [PauliX(wires=[0]), expval(PauliZ(wires=[1]))]
 
         If any measured wires are not in any operations, they will be mapped last:
 
         >>> circuit = qml.tape.QuantumScript([qml.PauliX(1)], [qml.probs(wires=[0, 1])])
-        >>> qml.devices.qubit.map_circuit_to_standard_wires(circuit).circuit
+        >>> circuit.map_to_standard_wires().circuit
         [PauliX(wires=[0]), probs(wires=[1, 0])]
 
         If no wire-mapping is needed, then the returned circuit *is* the inputted circuit:
 
         >>> circuit = qml.tape.QuantumScript([qml.PauliX(0)], [qml.expval(qml.PauliZ(1))])
-        >>> qml.devices.qubit.map_circuit_to_standard_wires(circuit) is circuit
+        >>> circuit.map_to_standard_wires() is circuit
         True
 
         """

--- a/tests/interfaces/default_qubit_2_integration/test_torch_default_qubit_2.py
+++ b/tests/interfaces/default_qubit_2_integration/test_torch_default_qubit_2.py
@@ -27,9 +27,9 @@ pytestmark = pytest.mark.torch
 
 @pytest.fixture(autouse=True)
 def run_before_and_after_tests():
-    torch.set_default_tensor_type(torch.DoubleTensor)
+    torch.set_default_dtype(torch.float64)
     yield
-    torch.set_default_tensor_type(torch.FloatTensor)
+    torch.set_default_dtype(torch.float32)
 
 
 # pylint: disable=too-few-public-methods


### PR DESCRIPTION
**Context:**
I wrote the same function twice, differing only by state flattening, to get the DQ upgrade done. It's starting to cause trouble.

**Description of the Change:**
Greatly simplified the state re-arrangement logic. There used to be a whole mess of things happening, but now things are much more straightforward.
1. `simulate` first puts things in our "standard" order, and this means that if any measured wires are not also operator wires, they are put to the _end_ of our tape wires. Therefore, for each measured-only wire, we just have to stack a `zeros_like(state)` to the last axis of our final state! `simulate` never tried to transpose wires back to a different ordering, so that was always wasted work.
2. `StateMP.process_state` _always_ receives the full state, and never needed to pad. No other device has done this optimization (the function used to literally just `return state` before DQ2 migration), and `simulate` already ensures that the final state has all wires in it - they just might be out of order. The only thing we might need from `process_state` is a transposition to the correct wire order. The inputted `wire_order` _should_ always be `range(len(wires))`, but whatever, we don't need to assume that.

I'll paint a picture for a normal scenario:

```python
@qml.qnode(qml.device("default.qubit", wires=3))
def circuit(x):
    qml.RX(x, 0)
    qml.CNOT([0, 2])
    return qml.state()
```

What happens with this QNode?
1. Device preprocessing sticks the device wires (`[0, 1, 2]`) onto the `StateMP`
2. `simulate` maps the wires to our standard order. I'll demonstrate (with `probs` so I can specify wires):

```pycon
>>> qs = qml.tape.QuantumScript([qml.RX(1.1, 0), qml.CNOT([0, 2])], [qml.probs(wires=[0, 1, 2])])
>>> qs.map_to_standard_wires().circuit
[RX(1.1, wires=[0]), CNOT(wires=[0, 1]), probs(wires=[0, 2, 1])]
```

3. Operate on the 2-qubit state, then stack another `[[0, 0], [0, 0]]` on the end of it (wire "1")
4. `StateMP(wires=[0, 1, 2]).process_state(state, wire_order=[0, 2, 1])` transposes the result to the correct order

I also changed the torch tests to stop using a deprecated setter for default float types.

**Benefits:**
Duplicate code is cleaned up, existing code is simplified, no unnecessary call to transpose.

**Possible Drawbacks:**
- Have to call `qml.math.stack` for every wire that was not operated on. Hopefully this is usually not a lot, and it's not that costly anyway
- functions now do less than they used to (I see this as a perk - they now do _exactly_ what they're supposed to)