### PR TITLE
Allow batching in `AmplitudeEmbedding` with Tensorflow

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -9,6 +9,9 @@
 
 <h3>Improvements 🛠</h3>
 
+* `AmplitudeEmbedding` now also supports batching when used with Tensorflow.
+  [(#4818)](https://github.com/PennyLaneAI/pennylane/pull/4818)
+
 * `qml.draw` now supports drawing mid-circuit measurements.
   [(#4775)](https://github.com/PennyLaneAI/pennylane/pull/4775)
 

--- a/pennylane/templates/embeddings/amplitude.py
+++ b/pennylane/templates/embeddings/amplitude.py
@@ -201,15 +201,11 @@ class AmplitudeEmbedding(StatePrep):
 
         if qml.math.is_abstract(norm):
             if normalize or pad_with:
-                features = features / qml.math.reshape(
-                    qml.math.sqrt(norm), (*qml.math.shape(norm), 1)
-                )
+                features = features / qml.math.reshape(qml.math.sqrt(norm), (*shape[:-1], 1))
 
         elif not qml.math.allclose(norm, 1.0, atol=TOLERANCE):
             if normalize or pad_with:
-                features = features / qml.math.reshape(
-                    qml.math.sqrt(norm), (*qml.math.shape(norm), 1)
-                )
+                features = features / qml.math.reshape(qml.math.sqrt(norm), (*shape[:-1], 1))
             else:
                 raise ValueError(
                     f"Features must be a vector of norm 1.0; got norm {norm}. "

--- a/pennylane/templates/embeddings/amplitude.py
+++ b/pennylane/templates/embeddings/amplitude.py
@@ -15,8 +15,6 @@ r"""
 Contains the AmplitudeEmbedding template.
 """
 # pylint: disable-msg=too-many-branches,too-many-arguments,protected-access
-import numpy as np
-
 import pennylane as qml
 from pennylane.ops import StatePrep
 from pennylane.wires import Wires

--- a/pennylane/templates/embeddings/amplitude.py
+++ b/pennylane/templates/embeddings/amplitude.py
@@ -167,63 +167,55 @@ class AmplitudeEmbedding(StatePrep):
         * If normalize is false, check that last dimension of features is normalised to one. Else, normalise the
           features tensor.
         """
+        shape = qml.math.shape(features)
 
-        # check if features is batched
-        batched = qml.math.ndim(features) > 1
+        # check shape
+        if len(shape) not in (1, 2):
+            raise ValueError(
+                f"Features must be a one-dimensional tensor, or two-dimensional with batching; got shape {shape}."
+            )
 
-        if batched and qml.math.get_interface(features) == "tensorflow":
-            raise ValueError("AmplitudeEmbedding does not support batched Tensorflow features.")
+        n_features = shape[-1]
+        dim = 2 ** len(wires)
+        if pad_with is None and n_features != dim:
+            raise ValueError(
+                f"Features must be of length {dim}; got length {n_features}. "
+                f"Use the 'pad_with' argument for automated padding."
+            )
 
-        features_batch = features if batched else [features]
-
-        new_features_batch = []
-        # apply pre-processing to each features tensor in the batch
-        for feature_set in features_batch:
-            shape = qml.math.shape(feature_set)
-
-            # check shape
-            if len(shape) != 1:
-                raise ValueError(f"Features must be a one-dimensional tensor; got shape {shape}.")
-
-            n_features = shape[0]
-            dim = 2 ** len(wires)
-            if pad_with is None and n_features != dim:
+        if pad_with is not None:
+            if n_features > dim:
                 raise ValueError(
-                    f"Features must be of length {dim}; got length {n_features}. "
-                    f"Use the 'pad_with' argument for automated padding."
+                    f"Features must be of length {dim} or "
+                    f"smaller to be padded; got length {n_features}."
                 )
 
-            if pad_with is not None:
-                if n_features > dim:
-                    raise ValueError(
-                        f"Features must be of length {dim} or "
-                        f"smaller to be padded; got length {n_features}."
-                    )
+            # pad
+            if n_features < dim:
+                padding = [pad_with] * (dim - n_features)
+                if len(shape) > 1:
+                    padding = [padding] * shape[0]
+                padding = qml.math.convert_like(padding, features)
+                features = qml.math.hstack([features, padding])
 
-                # pad
-                if n_features < dim:
-                    padding = [pad_with] * (dim - n_features)
-                    padding = qml.math.convert_like(padding, feature_set)
-                    feature_set = qml.math.hstack([feature_set, padding])
+        # normalize
+        norm = qml.math.sum(qml.math.abs(features) ** 2, axis=-1)
 
-            # normalize
-            norm = qml.math.sum(qml.math.abs(feature_set) ** 2)
+        if qml.math.is_abstract(norm):
+            if normalize or pad_with:
+                features = features / qml.math.reshape(
+                    qml.math.sqrt(norm), (*qml.math.shape(norm), 1)
+                )
 
-            if qml.math.is_abstract(norm):
-                if normalize or pad_with:
-                    feature_set = feature_set / qml.math.sqrt(norm)
+        elif not qml.math.allclose(norm, 1.0, atol=TOLERANCE):
+            if normalize or pad_with:
+                features = features / qml.math.reshape(
+                    qml.math.sqrt(norm), (*qml.math.shape(norm), 1)
+                )
+            else:
+                raise ValueError(
+                    f"Features must be a vector of norm 1.0; got norm {norm}. "
+                    "Use 'normalize=True' to automatically normalize."
+                )
 
-            elif not qml.math.allclose(norm, 1.0, atol=TOLERANCE):
-                if normalize or pad_with:
-                    feature_set = feature_set / qml.math.sqrt(norm)
-                else:
-                    raise ValueError(
-                        f"Features must be a vector of norm 1.0; got norm {norm}. "
-                        "Use 'normalize=True' to automatically normalize."
-                    )
-
-            new_features_batch.append(feature_set)
-
-        return qml.math.cast(
-            qml.math.stack(new_features_batch) if batched else new_features_batch[0], np.complex128
-        )
+        return features

--- a/tests/templates/test_embeddings/test_amplitude.py
+++ b/tests/templates/test_embeddings/test_amplitude.py
@@ -320,32 +320,27 @@ all_features = [
 ]
 
 
-class TestNoInterface:
-    """Tests that the template is compatible with Python iterables as inputs."""
-
-    @pytest.mark.parametrize("features", all_features)
-    def test_list_and_tuples(self, tol, features):
-        """Tests common iterables as inputs."""
-
-        dev = qml.device("default.qubit", wires=3)
-
-        circuit = qml.QNode(circuit_template, dev)
-        circuit2 = qml.QNode(circuit_decomposed, dev)
-
-        res = circuit(features)
-        res2 = circuit2(features)
-        assert qml.math.allclose(res, res2, atol=tol, rtol=0)
-
-        res = circuit(tuple(features))
-        res2 = circuit2(tuple(features))
-        assert qml.math.allclose(res, res2, atol=tol, rtol=0)
-
-
 @pytest.mark.parametrize("features", all_features)
 @pytest.mark.parametrize("pad_with", [None, 0.0, 0.1])
 @pytest.mark.parametrize("normalize", [False, True])
 class TestInterfaces:
     """Tests that the template is compatible with all interfaces."""
+
+    def test_list_and_tuples(self, tol, features, pad_with, normalize):
+        """Tests common iterables as inputs."""
+
+        dev = qml.device("default.qubit")
+
+        circuit = qml.QNode(circuit_template, dev)
+        circuit2 = qml.QNode(circuit_decomposed, dev)
+
+        res = circuit(features, pad_with, normalize)
+        res2 = circuit2(features, pad_with)
+        assert qml.math.allclose(res, res2, atol=tol, rtol=0)
+
+        res = circuit(tuple(features), pad_with, normalize)
+        res2 = circuit2(tuple(features), pad_with)
+        assert qml.math.allclose(res, res2, atol=tol, rtol=0)
 
     @pytest.mark.autograd
     def test_autograd(self, tol, features, pad_with, normalize):
@@ -370,8 +365,6 @@ class TestInterfaces:
 
         features = jnp.array(features)
 
-        padding = pad_with is not None
-
         dev = qml.device("default.qubit")
 
         circuit = qml.QNode(circuit_template, dev, interface="jax")
@@ -390,8 +383,6 @@ class TestInterfaces:
 
         features = jnp.array(features)
 
-        padding = pad_with is not None
-
         dev = qml.device("default.qubit")
 
         circuit = jax.jit(qml.QNode(circuit_template, dev, interface="jax"), static_argnums=[1, 2])
@@ -409,8 +400,6 @@ class TestInterfaces:
 
         features = tf.Variable(features)
 
-        padding = pad_with is not None
-
         dev = qml.device("default.qubit")
 
         circuit = qml.QNode(circuit_template, dev, interface="tensorflow")
@@ -427,8 +416,6 @@ class TestInterfaces:
         import tensorflow as tf
 
         features = tf.Variable(features)
-
-        padding = pad_with is not None
 
         dev = qml.device("default.qubit")
 
@@ -448,8 +435,6 @@ class TestInterfaces:
         import torch
 
         features = torch.tensor(features, requires_grad=True)
-
-        padding = pad_with is not None
 
         dev = qml.device("default.qubit")
 


### PR DESCRIPTION
**Context:**
The padding and normalization step in `AmplitudeEmbedding` previously used a manual for loop, making it incompatible with Tensorflow `tf.function(jit_compile=True)`.

**Description of the Change:**
The preprocessing now process the whole batch of features simultaneously, using numpy-like broadcasting instead.
(This also should be faster, usually).

Also, the tests have been complemented to test Tensorflow JITting with padding, and padding/non-padding tests have been combined into a single test function.

**Benefits:**
Support of Tensorflow,including JIT compilation in Tensorflow.
(probably) a speedup.

**Possible Drawbacks:**
Strictly speaking, the previous implementation allowed for different feature vector lengths across the batching dimension (because the padding happens before we rely on the input being a non-ragged array/tensor). 
I _think_ it is fine to constrain the input to the preprocessing already to non-ragged arrays.

**Related GitHub Issues:**
closes #2976 
