### PR TITLE
Fix parameter counting in `DefaultQubitLegacy` adjoint method

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -72,6 +72,10 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Fixes a bug where the adjoint method differentiation with `DefaultQubitLegacy` would fail if
+  an operation with `grad_method=None` but with parameters is present.
+  [(#4820)](https://github.com/PennyLaneAI/pennylane/pull/4820)
+  
 * `MottonenStatePreparation` now raises an error if decomposing a broadcasted state vector.
   [(#4767)](https://github.com/PennyLaneAI/pennylane/pull/4767)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -72,8 +72,8 @@
 
 <h3>Bug fixes 🐛</h3>
 
-* Fixes a bug where the adjoint method differentiation with `DefaultQubitLegacy` would fail if
-  an operation with `grad_method=None` but with parameters is present.
+* Fixes a bug where the adjoint method differentiation would fail if
+  an operation with `grad_method=None` that has a parameter is present.
   [(#4820)](https://github.com/PennyLaneAI/pennylane/pull/4820)
   
 * `MottonenStatePreparation` now raises an error if decomposing a broadcasted state vector.

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -1669,7 +1669,7 @@ class QubitDevice(Device):
             adj_op = qml.adjoint(op)
             ket = self._apply_operation(ket, adj_op)
 
-            if op.grad_method is not None:
+            if op.num_params == 1:
                 if param_number in trainable_params:
                     d_op_matrix = operation_derivative(op)
                     ket_temp = self._apply_unitary(ket, d_op_matrix, op.wires)

--- a/pennylane/devices/qubit/adjoint_jacobian.py
+++ b/pennylane/devices/qubit/adjoint_jacobian.py
@@ -80,7 +80,7 @@ def adjoint_jacobian(tape: QuantumTape, state=None):
         adj_op = qml.adjoint(op)
         ket = apply_operation(adj_op, ket)
 
-        if op.grad_method is not None:
+        if op.num_params==1:
             if param_number in tape.trainable_params:
                 d_op_matrix = operation_derivative(op)
                 ket_temp = apply_operation(qml.QubitUnitary(d_op_matrix, wires=op.wires), ket)
@@ -157,7 +157,7 @@ def adjoint_jvp(tape: QuantumTape, tangents: Tuple[Number], state=None):
         adj_op = qml.adjoint(op)
         ket = apply_operation(adj_op, ket)
 
-        if op.grad_method is not None:
+        if op.num_params==1:
             if param_number in tape.trainable_params:
                 # don't do anything if the tangent is 0
                 if not np.allclose(tangents[trainable_param_number], 0):
@@ -232,7 +232,7 @@ def adjoint_vjp(tape: QuantumTape, cotangents: Tuple[Number], state=None):
         adj_op = qml.adjoint(op)
         ket = apply_operation(adj_op, ket)
 
-        if op.grad_method is not None:
+        if op.num_params==1:
             if param_number in tape.trainable_params:
                 d_op_matrix = operation_derivative(op)
                 ket_temp = apply_operation(qml.QubitUnitary(d_op_matrix, wires=op.wires), ket)

--- a/pennylane/devices/qubit/adjoint_jacobian.py
+++ b/pennylane/devices/qubit/adjoint_jacobian.py
@@ -80,7 +80,7 @@ def adjoint_jacobian(tape: QuantumTape, state=None):
         adj_op = qml.adjoint(op)
         ket = apply_operation(adj_op, ket)
 
-        if op.num_params==1:
+        if op.num_params == 1:
             if param_number in tape.trainable_params:
                 d_op_matrix = operation_derivative(op)
                 ket_temp = apply_operation(qml.QubitUnitary(d_op_matrix, wires=op.wires), ket)
@@ -157,7 +157,7 @@ def adjoint_jvp(tape: QuantumTape, tangents: Tuple[Number], state=None):
         adj_op = qml.adjoint(op)
         ket = apply_operation(adj_op, ket)
 
-        if op.num_params==1:
+        if op.num_params == 1:
             if param_number in tape.trainable_params:
                 # don't do anything if the tangent is 0
                 if not np.allclose(tangents[trainable_param_number], 0):
@@ -232,7 +232,7 @@ def adjoint_vjp(tape: QuantumTape, cotangents: Tuple[Number], state=None):
         adj_op = qml.adjoint(op)
         ket = apply_operation(adj_op, ket)
 
-        if op.num_params==1:
+        if op.num_params == 1:
             if param_number in tape.trainable_params:
                 d_op_matrix = operation_derivative(op)
                 ket_temp = apply_operation(qml.QubitUnitary(d_op_matrix, wires=op.wires), ket)


### PR DESCRIPTION
**Context:**
The adjoint method of `DefaultQubitLegacy` uses two incompatible ways to quantify tape parameters: It sets up the number of tape parameters correctly using `tape.get_parameters(trainable_only=False)` but checks whether an operation comes with a parameter via `grad_method is not None`. This lead to a bug where, for example, `QubitUnitary` disrupts the parameter counting.


**Description of the Change:**
As all operations with more than one parameter are being decomposed/raised an error upon anyways,  this PR changes the way to detect parametrized operations to `op.num_params==1`.

**Benefits:**
Bug fix: Correct adjoint method derivatives even when using `QubitUnitary` and other operations that have `grad_method=None` but have parameters.

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
N/A
