### PR TITLE
test: turn PL deprecation warnings into errors

### DIFF
--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -20,4 +20,5 @@ filterwarnings =
     ignore:Casting complex values to real discards the imaginary part:UserWarning:torch.autograd
     ignore:Call to deprecated create function:DeprecationWarning
     ignore:the imp module is deprecated:DeprecationWarning
+    error::pennylane.PennyLaneDeprecationWarning
 addopts = --benchmark-disable

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -21,4 +21,4 @@ filterwarnings =
     ignore:Call to deprecated create function:DeprecationWarning
     ignore:the imp module is deprecated:DeprecationWarning
     error::pennylane.PennyLaneDeprecationWarning
-addopts = --benchmark-disable
+addopts = --benchmark-disable -p no:warnings


### PR DESCRIPTION
confirmed locally that it works, and it won't be raised if the warning is caught/suppressed in a test