### PR TITLE
fix merge_amplitude_embedding queuing bug

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -111,6 +111,10 @@
   expected, instead of numpy arrays.
   [(#4811)](https://github.com/PennyLaneAI/pennylane/pull/4811)
 
+* `merge_amplitude_embeddings` no longer depends on queuing, allowing it to work as expected
+  with QNodes.
+  [(#)]()
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -113,7 +113,7 @@
 
 * `merge_amplitude_embeddings` no longer depends on queuing, allowing it to work as expected
   with QNodes.
-  [(#)]()
+  [(#4831)](https://github.com/PennyLaneAI/pennylane/pull/4831)
 
 <h3>Contributors ✍️</h3>
 

--- a/tests/transforms/test_optimization/test_merge_amplitude_embedding.py
+++ b/tests/transforms/test_optimization/test_merge_amplitude_embedding.py
@@ -55,10 +55,10 @@ class TestMergeAmplitudeEmbedding:
             qml.AmplitudeEmbedding([0.0, 1.0], wires=0)
             qml.AmplitudeEmbedding([0.0, 1.0], wires=1)
             qml.Hadamard(wires=0)
-            qml.Hadamard(wires=0)
+            qml.Hadamard(wires=1)
             return qml.state()
 
-        assert np.allclose(circuit()[0], 1)
+        assert qml.math.allclose(circuit(), np.array([1, -1, -1, 1]) / 2)
 
     def test_repeated_qubit(self):
         """Check that AmplitudeEmbedding cannot be applied if the qubit has already been used."""
@@ -93,8 +93,8 @@ class TestMergeAmplitudeEmbedding:
         """Test that merging preserves the batch dimension"""
         dev = qml.device("default.qubit", wires=3)
 
-        @qml.qnode(dev)
         @qml.transforms.merge_amplitude_embedding
+        @qml.qnode(dev)
         def qnode():
             qml.AmplitudeEmbedding([[1, 0], [0, 1]], wires=0)
             qml.AmplitudeEmbedding([1, 0], wires=1)


### PR DESCRIPTION
**Context:**
`merge_amplitude_embedding` was not following transform conventions, so it didn't work as expected with QNodes.

**Description of the Change:**
- stop the transform from depending on the new AmplitudeEmbedding on being queued, and actually add it to the transformed tape
- tidy up the transform because it was using some unnecessary copies of lists and I felt like it
- fix test that was asserting an incorrect answer (both tests that I changed were failing without the fix because they depended on queuing)

**Benefits:**
bug squashed! 🥾 🐞

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
Fixes #4830 [sc-50048]