### PR TITLE
fix jax jacobians when one circuit not trainable

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -83,7 +83,7 @@
 <h3>Bug fixes 🐛</h3>
 
 * Jax can now differeniate a batch of circuits where one tape does not have trainable parameters.
-  [(#4836)](https://github.com/PennyLaneAI/pennylane/pull/4837)
+  [(#4837)](https://github.com/PennyLaneAI/pennylane/pull/4837)
 
 * Fixes a bug where the adjoint method differentiation would fail if
   an operation with `grad_method=None` that has a parameter is present.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -80,6 +80,7 @@
 <h3>Bug fixes 🐛</h3>
 
 * Jax can now differeniate a batch of circuits where one tape does not have trainable parameters.
+  [(#4836)](https://github.com/PennyLaneAI/pennylane/pull/4837)
 
 * Fixes a bug where the adjoint method differentiation would fail if
   an operation with `grad_method=None` that has a parameter is present.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -79,6 +79,8 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Jax can now differeniate a batch of circuits where one tape does not have trainable parameters.
+
 * Fixes a bug where the adjoint method differentiation would fail if
   an operation with `grad_method=None` that has a parameter is present.
   [(#4820)](https://github.com/PennyLaneAI/pennylane/pull/4820)

--- a/pennylane/gradients/jvp.py
+++ b/pennylane/gradients/jvp.py
@@ -294,7 +294,11 @@ def jvp(tape, tangent, gradient_fn, gradient_kwargs=None):
     if len(tape.trainable_params) == 0:
         # The tape has no trainable parameters; the JVP
         # is simply none.
-        return [], lambda _, num=None: None
+        def zero_vjp(_):
+            res = tuple(np.zeros(mp.shape(None, tape.shots)) for mp in tape.measurements)
+            return res[0] if len(tape.measurements) == 1 else res
+
+        return tuple(), zero_vjp
 
     multi_m = len(tape.measurements) > 1
 

--- a/pennylane/interfaces/jacobian_products.py
+++ b/pennylane/interfaces/jacobian_products.py
@@ -56,10 +56,11 @@ def _compute_jvps(jacs, tangents, tapes):
     for jac, dx, t in zip(jacs, tangents, tapes):
         multi = len(t.measurements) > 1
         if len(t.trainable_params) == 0:
-            zeros_jvp = tuple(np.zeros(mp.shape(None, t.shots)) for mp in t.measurements)
+            empty_shots = qml.measurements.Shots(None)
+            zeros_jvp = tuple(np.zeros(mp.shape(None, empty_shots)) for mp in t.measurements)
             zeros_jvp = zeros_jvp[0] if len(t.measurements) == 1 else zeros_jvp
             if t.shots.has_partitioned_shots:
-                jvps.extend(zeros_jvp for _ in t.shots.num_copies)
+                jvps.append(tuple(zeros_jvp for _ in range(t.shots.num_copies)))
             else:
                 jvps.append(zeros_jvp)
         elif t.shots.has_partitioned_shots:

--- a/pennylane/interfaces/jacobian_products.py
+++ b/pennylane/interfaces/jacobian_products.py
@@ -21,6 +21,7 @@ import logging
 from typing import Tuple, Callable, Optional, Union
 
 from cachetools import LRUCache
+import numpy as np
 
 import pennylane as qml
 from pennylane.tape import QuantumScript
@@ -54,7 +55,14 @@ def _compute_jvps(jacs, tangents, tapes):
     jvps = []
     for jac, dx, t in zip(jacs, tangents, tapes):
         multi = len(t.measurements) > 1
-        if t.shots.has_partitioned_shots:
+        if len(t.trainable_params) == 0:
+            zeros_jvp = tuple(np.zeros(mp.shape(None, t.shots)) for mp in t.measurements)
+            zeros_jvp = zeros_jvp[0] if len(t.measurements) == 1 else zeros_jvp
+            if t.shots.has_partitioned_shots:
+                jvps.extend(zeros_jvp for _ in t.shots.num_copies)
+            else:
+                jvps.append(zeros_jvp)
+        elif t.shots.has_partitioned_shots:
             jvps.append(tuple(f[multi](dx, j) for j in jac))
         else:
             jvps.append(f[multi](dx, jac))

--- a/pennylane/interfaces/jax.py
+++ b/pennylane/interfaces/jax.py
@@ -215,7 +215,6 @@ def _execute_bwd(
             new_tapes = set_parameters_on_copy_and_unwrap(tapes, primals[0], unwrap=False)
             jacs = gradient_fn(new_tapes, **gradient_kwargs)
             jvps = _compute_jvps(jacs, tangents[0], new_tapes)
-
         return res, jvps
 
     return execute_wrapper(params)

--- a/tests/gradients/core/test_jvp.py
+++ b/tests/gradients/core/test_jvp.py
@@ -350,8 +350,8 @@ class TestJVP:
         tangent = np.array([1.0])
         tapes, fn = qml.gradients.jvp(tape, tangent, param_shift)
 
-        assert tapes == []
-        assert fn(tapes) is None
+        assert tapes == tuple()
+        assert qml.math.allclose(fn(tapes), np.array(0.0))
 
     def test_zero_tangent_single_measurement_single_param(self, batch_dim):
         """A zero tangent vector will return no tapes and a zero matrix"""
@@ -831,7 +831,7 @@ class TestBatchJVP:
         # to the JVP, so only 2*2=4 quantum evals
         res = fn(dev.execute(v_tapes))
 
-        assert res[0] is None
+        assert qml.math.allclose(res[0], np.array(0.0))
         assert res[1] is not None
 
     def test_all_tapes_no_trainable_parameters(self):
@@ -859,7 +859,8 @@ class TestBatchJVP:
         v_tapes, fn = qml.gradients.batch_jvp(tapes, tangents, param_shift)
 
         assert v_tapes == []
-        assert fn([]) == (None, None)
+        assert qml.math.allclose(fn([])[0], np.array(0.0))
+        assert qml.math.allclose(fn([])[1], np.array(0.0))
 
     def test_zero_tangent(self):
         """A zero dy vector will return no tapes and a zero matrix"""

--- a/tests/interfaces/default_qubit_2_integration/test_jax_default_qubit_2.py
+++ b/tests/interfaces/default_qubit_2_integration/test_jax_default_qubit_2.py
@@ -787,7 +787,6 @@ class TestHamiltonianWorkflows:
 
         res = jax.jacobian(cost_fn)(weights, coeffs1, coeffs2)
         expected = self.cost_fn_jacobian(weights, coeffs1, coeffs2)[:, :2]
-        print(res, expected)
         if shots.has_partitioned_shots:
             assert np.allclose(res[:2, :], expected, atol=atol_for_shots(shots), rtol=0)
             assert np.allclose(res[2:, :], expected, atol=atol_for_shots(shots), rtol=0)

--- a/tests/interfaces/test_jax.py
+++ b/tests/interfaces/test_jax.py
@@ -148,6 +148,13 @@ class TestJaxExecuteUnitTests:
         assert dev.num_executions == 3
         spy.assert_called()
 
+        g = jax.jacobian(cost)(a)
+        expected_g = (-np.sin(x) * np.cos(y), -np.cos(x) * np.sin(y))
+        assert qml.math.allclose(g[0][0], expected_g)
+        assert qml.math.allclose(g[0][1], np.zeros(2))
+        assert qml.math.allclose(g[1], np.zeros(2))
+        assert qml.math.allclose(g[2], expected_g)
+
     def test_no_grad_on_execution(self, mocker):
         """Test that no grad on execution uses the `device.batch_execute` and `device.gradients` pathway"""
         dev = qml.device("default.qubit.legacy", wires=1)
@@ -592,7 +599,7 @@ class TestJaxExecuteIntegration:
         res = cost(a, U, device=dev)
         assert np.allclose(res, -np.cos(a), atol=tol, rtol=0)
 
-        jac_fn = jax.grad(cost, argnums=(0))
+        jac_fn = jax.grad(cost, argnums=0)
         res = jac_fn(a, U, device=dev)
         assert np.allclose(res, np.sin(a), atol=tol, rtol=0)
 
@@ -629,7 +636,7 @@ class TestJaxExecuteIntegration:
         )
         assert np.allclose(res, expected, atol=tol, rtol=0)
 
-        jac_fn = jax.grad(cost_fn, argnums=(1))
+        jac_fn = jax.grad(cost_fn, argnums=1)
         res = jac_fn(a, p, device=dev)
         expected = jax.numpy.array(
             [


### PR DESCRIPTION
Fixes #4834 [sc-50137]

Long story short, our jvp tools, `qml.gradients.jvp` and `qml.interfaces.jacobian_products._compute_jvps` failed to return proper shapes and values when there is no trainable parameters. This fixes that.

Note to reviewers:

To properly test this fix, I needed integration tests for when the device provides a derivative with a shot vector.  So I added tests for device-provided derivatives with a shotvector.  Those test changes are a little painful, but they seem to work. Similar tests have already been added to autograd and torch in previous PR's.