### PR TITLE
`has_matrix` detects if `Operator.matrix` is overridden

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -35,6 +35,7 @@
 
 * `has_matrix` will now automatically be `True` if `Operator.matrix` is overridden, even if
   `Operator.compute_matrix` is not.
+   [(#4844)](https://github.com/PennyLaneAI/pennylane/pull/4844)
 
 <h3>Breaking changes 💔</h3>
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -35,7 +35,7 @@
 
 * `has_matrix` will now automatically be `True` if `Operator.matrix` is overridden, even if
   `Operator.compute_matrix` is not.
-   [(#4844)](https://github.com/PennyLaneAI/pennylane/pull/4844)
+  [(#4844)](https://github.com/PennyLaneAI/pennylane/pull/4844)
 
 <h3>Breaking changes 💔</h3>
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -33,6 +33,9 @@
 * `qml.draw` and `qml.draw_mpl` now render operator ids.
   [(#4749)](https://github.com/PennyLaneAI/pennylane/pull/4749)
 
+* `has_matrix` will now automatically be `True` if `Operator.matrix` is overridden, even if
+  `Operator.compute_matrix` is not.
+
 <h3>Breaking changes 💔</h3>
 
 * The `prep` keyword argument has been removed from `QuantumScript` and `QuantumTape`.

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -750,7 +750,7 @@ class Operator(abc.ABC):
 
         Note: Child classes may have this as an instance property instead of as a class property.
         """
-        return cls.compute_matrix != Operator.compute_matrix
+        return cls.compute_matrix != Operator.compute_matrix or cls.matrix != Operator.matrix
 
     def matrix(self, wire_order=None):
         r"""Representation of the operator as a matrix in the computational basis.

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -470,6 +470,16 @@ class TestHasReprProperties:
         assert MyOp.has_matrix is True
         assert MyOp(wires=0).has_matrix is True
 
+    def test_has_matrix_true_overridden_matrix(self):
+        """Test has_matrix is true if `matrix` is overridden instead of `compute_matrix`."""
+
+        class MyOp(qml.operation.Operator):
+            def matrix(self, _=None):
+                return np.eye(2)
+
+        assert MyOp.has_matrix is True
+        assert MyOp(wires=0).has_matrix is True
+
     def test_has_matrix_false(self):
         """Test has_matrix property defaults to false if `compute_matrix` not overwritten."""
 


### PR DESCRIPTION
Currently, `has_matrix` only is automatically `True` if `compute_matrix` is overridden.  If someone overrides `Operator.matrix` but not `Operator.compute_matrix`, they will have to manually set `has_matrix = True`.

This behaviour is a historical remnant from when `Operation` overrode the `Operator.matrix` method to include in-place inversion. As in-place inversion is no longer a thing, we no longer have any reason to keep that behaviour.

With this change, it will be easier for people to write their own custom operators.


This change is motivated by confusion over why an operator with a matrix wasn't supported by `default.qubit`.