### PR TITLE
tidy up optimization transform testing

### DIFF
--- a/pennylane/transforms/optimization/pattern_matching.py
+++ b/pennylane/transforms/optimization/pattern_matching.py
@@ -277,8 +277,7 @@ def pattern_matching_optimization(
                         qml.apply(inst)
 
                 qscript = QuantumScript.from_queue(q_inside)
-                tapes, fn = qml.map_wires(input=qscript, wire_map=inverse_wires_map)
-                tape = fn(tapes)
+                [tape], _ = qml.map_wires(input=qscript, wire_map=inverse_wires_map)
 
     new_tape = type(tape)(tape.operations, tape.measurements, shots=tape.shots)
 

--- a/pennylane/transforms/optimization/remove_barrier.py
+++ b/pennylane/transforms/optimization/remove_barrier.py
@@ -78,19 +78,7 @@ def remove_barrier(tape: QuantumTape) -> (Sequence[QuantumTape], Callable):
            1: ──H─────┤
 
     """
-    # Make a working copy of the list to traverse
-    list_copy = tape.operations.copy()
-    operations = []
-    while len(list_copy) > 0:
-        current_gate = list_copy[0]
-
-        # Remove Barrier gate
-        if current_gate.name != "Barrier":
-            operations.append(current_gate)
-
-        list_copy.pop(0)
-        continue
-
+    operations = filter(lambda op: op.name != "Barrier", tape.operations)
     new_tape = type(tape)(operations, tape.measurements, shots=tape.shots)
 
     def null_postprocessing(results):

--- a/tests/transforms/test_compile.py
+++ b/tests/transforms/test_compile.py
@@ -168,6 +168,13 @@ class TestCompileIntegration:
 
         assert np.allclose(qfun_res, qnode_res)
 
+    def test_compile_default_pipeline_removes_barrier(self):
+        """Test that the default pipeline removes Barriers."""
+
+        tape = qml.tape.QuantumScript([qml.PauliX(0), qml.Barrier([0, 1]), qml.CNOT([0, 1])])
+        [compiled_tape], _ = qml.compile(tape)
+        assert compiled_tape.operations == [qml.PauliX(0), qml.CNOT([0, 1])]
+
     @pytest.mark.parametrize(("wires"), [["a", "b", "c"], [0, 1, 2], [3, 1, 2], [0, "a", 4]])
     def test_compile_pipeline_with_non_default_arguments(self, wires):
         """Test that using non-default arguments returns the correct results."""

--- a/tests/transforms/test_optimization/test_cancel_inverses.py
+++ b/tests/transforms/test_optimization/test_cancel_inverses.py
@@ -383,7 +383,7 @@ def qnode_circuit(theta):
     qml.CZ(wires=[1, 0])
     qml.RY(theta[1], wires=2)
     qml.CZ(wires=[0, 1])
-    return qml.expval(qml.PauliX(0) @ qml.PauliX(2))
+    return qml.expval(qml.PauliZ(0) @ qml.PauliZ(2))
 
 
 class TestTransformDispatch:
@@ -412,8 +412,10 @@ class TestTransformDispatch:
         transformed_qnode = cancel_inverses(qnode_circuit)
         assert not transformed_qnode.transform_program.is_empty()
         assert len(transformed_qnode.transform_program) == 1
-        res = transformed_qnode(([0.1, 0.2]))
-        assert np.allclose(res, 0.0)
+        params = [0.1, 0.2]
+        res = transformed_qnode(params)
+        expected = qnode_circuit(params)
+        assert np.allclose(res, expected)
 
     @pytest.mark.jax
     def test_qnode_diff_jax(self):
@@ -423,4 +425,5 @@ class TestTransformDispatch:
         a = jax.numpy.array([0.1, 0.2])
         transformed_qnode = cancel_inverses(qnode_circuit)
         res = jax.jacobian(transformed_qnode)(a)
-        assert jax.numpy.allclose(res, jax.numpy.array([0.0, 0.0]))
+        expected = jax.jacobian(qnode_circuit)(a)
+        assert jax.numpy.allclose(res, expected)

--- a/tests/transforms/test_optimization/test_commute_controlled.py
+++ b/tests/transforms/test_optimization/test_commute_controlled.py
@@ -482,7 +482,7 @@ def qnode_circuit():
     qml.SX(wires=1)
     qml.PauliX(wires=1)
     qml.CRX(0.1, wires=[0, 1])
-    return qml.expval(qml.PauliX(0) @ qml.PauliX(2))
+    return qml.expval(qml.PauliY(1) @ qml.PauliZ(2))
 
 
 class TestTransformDispatch:
@@ -536,4 +536,5 @@ class TestTransformDispatch:
         assert not transformed_qnode.transform_program.is_empty()
         assert len(transformed_qnode.transform_program) == 1
         res = transformed_qnode()
-        assert np.allclose(res, 0.0)
+        expected = qnode_circuit()
+        assert np.allclose(res, expected)

--- a/tests/transforms/test_optimization/test_undo_swaps.py
+++ b/tests/transforms/test_optimization/test_undo_swaps.py
@@ -125,9 +125,13 @@ class TestUndoSwaps:
 
         assert np.allclose(res1, res2)
 
-    def test_decorator(self):
-        @qml.qnode(qml.device("default.qubit", wires=3))
+    def test_decorator(self, mocker):
+        """Test that the decorator works on a QNode."""
+
+        spy = mocker.spy(dev, "execute")
+
         @undo_swaps
+        @qml.qnode(dev)
         def qfunc():
             qml.Hadamard(wires=0)
             qml.PauliX(wires=1)
@@ -136,8 +140,9 @@ class TestUndoSwaps:
             qml.PauliY(wires=0)
             return qml.expval(qml.PauliZ(0))
 
-        qfunc()
-        assert len(qfunc.qtape.operations) == 3
+        assert np.allclose(qfunc(), -1)
+        [[tape]], _ = spy.call_args
+        assert tape.operations == [qml.Hadamard(1), qml.PauliX(2), qml.PauliY(0)]
 
 
 # Example QNode and device for interface testing


### PR DESCRIPTION
**Context:**
While working on #4831, we grew suspicious that similar bugs might exist in other optimization transforms. This PR is the result of that audit.

**Description of the Change:**
- make sure optimization-transform tests actually test QNode transforms
  - this involved changing some observables to get actual non-zero results
- simplify the `remove_barrier` code
- add a test for `remove_barrier` (in test_compile.py because the qml.compile default pipeline is the only place where it's used) because there are no tests for it!

**Benefits:**
More comfort with the state of this module.

**Possible Drawbacks:**
N/A

[sc-50172]