### PR TITLE
bump tensorflow to 2.15 in CI

### DIFF
--- a/.github/workflows/interface-unit-tests.yml
+++ b/.github/workflows/interface-unit-tests.yml
@@ -15,7 +15,7 @@ on:
         description: The version of TensorFlow to install for any job that requires TensorFlow
         required: false
         type: string
-        default: 2.13.0
+        default: 2.15.0
       pytorch_version:
         description: The version of PyTorch to install for any job that requires PyTorch
         required: false

--- a/pennylane/math/single_dispatch.py
+++ b/pennylane/math/single_dispatch.py
@@ -21,7 +21,7 @@ import numpy as np
 import semantic_version
 from scipy.linalg import block_diag as _scipy_block_diag
 
-from .utils import get_deep_interface, is_abstract
+from .utils import get_deep_interface
 
 
 def _i(name):
@@ -335,7 +335,7 @@ ar.register_function("tensorflow", "round", _round_tf)
 
 
 def _ndim_tf(tensor):
-    return len(tensor.shape) if is_abstract(tensor) else int(_i("tf").rank(tensor))
+    return len(tensor.shape)
 
 
 ar.register_function("tensorflow", "ndim", _ndim_tf)

--- a/pennylane/math/single_dispatch.py
+++ b/pennylane/math/single_dispatch.py
@@ -21,7 +21,7 @@ import numpy as np
 import semantic_version
 from scipy.linalg import block_diag as _scipy_block_diag
 
-from .utils import get_deep_interface
+from .utils import get_deep_interface, is_abstract
 
 
 def _i(name):
@@ -335,13 +335,7 @@ ar.register_function("tensorflow", "round", _round_tf)
 
 
 def _ndim_tf(tensor):
-    try:
-        ndim = _i("tf").experimental.numpy.ndim(tensor)
-        if ndim is None:
-            return len(tensor.shape)
-        return ndim
-    except AttributeError:
-        return len(tensor.shape)
+    return len(tensor.shape) if is_abstract(tensor) else int(_i("tf").rank(tensor))
 
 
 ar.register_function("tensorflow", "ndim", _ndim_tf)


### PR DESCRIPTION
For some reason in 2.15, the `ndim()` of an abstract tensor with shape specified as `None` was -1, so it didn't raise an error, and didn't get handled with [this exception handling](https://github.com/PennyLaneAI/pennylane/blob/aab9ed91110ac95938fe2275625e1845970d5a9c/pennylane/operation.py#L1091)

**Description of the change**
`qml.math.ndim(tensor)` always returns `len(tensor.shape)` for tensorflow. this will still raise errors as expected for abstract tensors with abstract shapes (only happens when the user specifies the shape as None before compiling a function).

ran a bunch of tests (tf interface tests, the `tf.function` test that failed in test_operation.py) locally with python 3.9, TF 2.10 just to make sure I didn't break old versions of tensorflow, they all passed 🙌 