### PR TITLE
Move `qml.cond` to `ops.op_math`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -46,6 +46,10 @@
 * Simplified the logic for re-arranging states before returning.
   [(#4817)](https://github.com/PennyLaneAI/pennylane/pull/4817)
 
+* Moved `qml.cond` and the `Conditional` operation from the `transforms` folder to the `ops/op_math` folder. `qml.transforms.Conditional`
+  will now be available as `qml.ops.Conditional`.
+  [(#)]()
+
 <h3>Breaking changes 💔</h3>
 
 * The `prep` keyword argument has been removed from `QuantumScript` and `QuantumTape`.

--- a/pennylane/__init__.py
+++ b/pennylane/__init__.py
@@ -69,7 +69,7 @@ from pennylane.measurements import (
     shadow_expval,
 )
 from pennylane.ops import *
-from pennylane.ops import adjoint, ctrl, exp, sum, pow, prod, s_prod
+from pennylane.ops import adjoint, ctrl, cond, exp, sum, pow, prod, s_prod
 from pennylane.templates import broadcast, layer
 from pennylane.templates.embeddings import *
 from pennylane.templates.layers import *
@@ -89,7 +89,6 @@ from pennylane.transforms import (
     cut_circuit,
     cut_circuit_mc,
     compile,
-    cond,
     defer_measurements,
     metric_tensor,
     specs,

--- a/pennylane/ops/op_math/__init__.py
+++ b/pennylane/ops/op_math/__init__.py
@@ -30,6 +30,17 @@ Constructor Functions
     ~prod
     ~s_prod
 
+Functions that act on quantum functions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+These functions accept quantum functions (Python functions
+containing quantum operations) that are used to construct QNodes.
+
+.. autosummary::
+    :toctree: api
+
+    ~cond
+
 Symbolic Classes
 ~~~~~~~~~~~~~~~~
 
@@ -40,6 +51,7 @@ Symbolic Classes
 
     ~Adjoint
     ~CompositeOp
+    ~Conditional
     ~Controlled
     ~ControlledOp
     ~Evolution
@@ -78,6 +90,7 @@ Decompositions
 
 from .adjoint import Adjoint, adjoint
 from .composite import CompositeOp
+from .condition import cond, Conditional
 from .controlled import Controlled, ControlledOp, ctrl
 from .controlled_ops import ControlledQubitUnitary, CY, CZ
 from .evolution import Evolution

--- a/pennylane/ops/op_math/condition.py
+++ b/pennylane/ops/op_math/condition.py
@@ -15,9 +15,7 @@
 Contains the condition transform.
 """
 from functools import wraps
-from typing import Type
 
-from pennylane.measurements import MeasurementValue
 from pennylane.operation import AnyWires, Operation
 from pennylane.tape import make_qscript
 
@@ -48,12 +46,7 @@ class Conditional(Operation):
 
     num_wires = AnyWires
 
-    def __init__(
-        self,
-        expr: MeasurementValue[bool],
-        then_op: Type[Operation],
-        id=None,
-    ):
+    def __init__(self, expr, then_op, id=None):
         self.meas_val = expr
         self.then_op = then_op
         super().__init__(wires=then_op.wires, id=id)

--- a/pennylane/transforms/__init__.py
+++ b/pennylane/transforms/__init__.py
@@ -167,18 +167,6 @@ that compute the desired quantity.
     ~draw
     ~draw_mpl
 
-
-Transforms that act on quantum functions
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-These transforms accept quantum functions (Python functions
-containing quantum operations) that are used to construct QNodes.
-
-.. autosummary::
-    :toctree: api
-
-    ~transforms.cond
-
 Decorators and utility functions
 --------------------------------
 
@@ -237,7 +225,6 @@ from .batch_params import batch_params
 from .batch_input import batch_input
 from .batch_partial import batch_partial
 from .classical_jacobian import classical_jacobian
-from .condition import cond, Conditional
 from .convert_to_numpy_parameters import convert_to_numpy_parameters
 from .compile import compile
 from .decompositions import (

--- a/tests/ops/test_condition.py
+++ b/tests/ops/test_condition.py
@@ -26,7 +26,7 @@ files.
 import pytest
 
 import pennylane as qml
-from pennylane.transforms.condition import ConditionalTransformError
+from pennylane.ops.op_math.condition import ConditionalTransformError
 
 terminal_meas = [
     qml.probs(wires=[1, 0]),


### PR DESCRIPTION
* Moved `condition.py` from the `transforms` folder to `ops/op_math`. `qml.transforms.Conditional` is now available as `qml.ops.Conditional`.
* Updated docs accordingly.