### PR TITLE
[Bug Fix] The `PauliSentence.__mul__()` method to treat empty PS as 0 operator.

### DIFF
--- a/pennylane/ops/op_math/pow.py
+++ b/pennylane/ops/op_math/pow.py
@@ -1,4 +1,3 @@
-# Copyright 2018-2022 Xanadu Quantum Technologies Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -216,8 +215,8 @@ class Pow(ScalarSymbolicOp):
             if (base_pauli_rep := getattr(self.base, "_pauli_rep", None)) and (
                 self.batch_size is None
             ):
-                pr = qml.pauli.PauliSentence({})
-                for _ in range(self.z):
+                pr = base_pauli_rep
+                for _ in range(self.z - 1):
                     pr = pr * base_pauli_rep
                 self._pauli_rep = pr
             else:

--- a/pennylane/pauli/pauli_arithmetic.py
+++ b/pennylane/pauli/pauli_arithmetic.py
@@ -369,11 +369,8 @@ class PauliSentence(dict):
         the Pauli words pair-wise"""
         final_ps = PauliSentence()
 
-        if len(self) == 0:
-            return copy(other)
-
-        if len(other) == 0:
-            return copy(self)
+        if len(self) == 0 or len(other) == 0:
+            return final_ps
 
         for pw1 in self:
             for pw2 in other:

--- a/tests/pauli/test_pauli_arithmetic.py
+++ b/tests/pauli/test_pauli_arithmetic.py
@@ -355,8 +355,8 @@ class TestPauliSentence:
         ),
         (ps3, ps4, ps3),
         (ps4, ps3, ps3),
-        (ps1, ps5, ps1),
-        (ps5, ps1, ps1),
+        (ps1, ps5, ps5),
+        (ps5, ps1, ps5),
         (
             PauliSentence(
                 {PauliWord({0: "Z"}): np.array(1.0), PauliWord({0: "Z", 1: "X"}): np.array(1.0)}


### PR DESCRIPTION
**Context:**
The PS class assumes that an empty PS is treated as an additive identity. In this case, the Mul method was treating it as a multiplicative identity as well.

**Description of the Change:**
Remove the implicit multiplicative identity assumption.