### PR TITLE
Fix `parameter_frequencies` of `qml.ctrl(op)` if `op.generator()` is `SparseHamiltonian`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -284,6 +284,7 @@
 
 * Fixed a bug where the parameter-shift rule of `qml.ctrl(op)` was wrong if `op` had a generator
   that has two or more eigenvalues and is stored as a `SparseHamiltonian`.
+  [(#4899)](https://github.com/PennyLaneAI/pennylane/pull/4899)
 
 * `qml.grad` and `qml.jacobian` now explicitly raise errors if trainable parameters are integers.
   [(#4836)](https://github.com/PennyLaneAI/pennylane/pull/4836)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -282,6 +282,9 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Fixed a bug where the parameter-shift rule of `qml.ctrl(op)` was wrong if `op` had a generator
+  that has two or more eigenvalues and is stored as a `SparseHamiltonian`.
+
 * `qml.grad` and `qml.jacobian` now explicitly raise errors if trainable parameters are integers.
   [(#4836)](https://github.com/PennyLaneAI/pennylane/pull/4836)
 

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -1760,7 +1760,7 @@ class Operation(Operator):
                 warnings.filterwarnings(
                     action="ignore", message=r".+ eigenvalues will be computed numerically\."
                 )
-                eigvals = qml.eigvals(gen)
+                eigvals = qml.eigvals(gen, k=2**self.num_wires)
 
             eigvals = tuple(np.round(eigvals, 8))
             return [qml.gradients.eigvals_to_frequencies(eigvals)]

--- a/pennylane/ops/op_math/controlled.py
+++ b/pennylane/ops/op_math/controlled.py
@@ -652,7 +652,7 @@ class ControlledOp(Controlled, operation.Operation):
                 warnings.filterwarnings(
                     action="ignore", message=r".+ eigenvalues will be computed numerically\."
                 )
-                base_gen_eigvals = qml.eigvals(base_gen)
+                base_gen_eigvals = qml.eigvals(base_gen, k=2**self.base.num_wires)
 
             # The projectors in the full generator add a eigenvalue of `0` to
             # the eigenvalues of the base generator.

--- a/tests/ops/op_math/test_controlled.py
+++ b/tests/ops/op_math/test_controlled.py
@@ -544,12 +544,13 @@ class TestOperationProperties:
             (qml.RX(1.23, wires=0), [(0.5, 1.0)]),
             (qml.PhaseShift(-2.4, wires=0), [(1,)]),
             (qml.IsingZZ(-9.87, (0, 1)), [(0.5, 1.0)]),
+            (qml.DoubleExcitationMinus(0.7, [0, 1, 2, 3]), [(0.5, 1.0)]),
         ],
     )
     def test_parameter_frequencies(self, base, expected):
         """Test parameter-frequencies against expected values."""
 
-        op = Controlled(base, (3, 4))
+        op = Controlled(base, (4, 5))
         assert op.parameter_frequencies == expected
 
     def test_parameter_frequencies_no_generator_error(self):

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -836,6 +836,15 @@ class TestOperationConstruction:
         for i in range(num_param):
             assert f[i] == (0.2, x[i])
 
+    def test_frequencies_sparse_generator(self):
+        """Test that the parameter frequencies are correctly deduced from a generator
+        that is a ``SparseHamiltonian``."""
+        DummyOp = copy.copy(qml.DoubleExcitationPlus)
+        DummyOp.parameter_frequencies = qml.operation.Operation.parameter_frequencies
+
+        op = DummyOp(0.7, [0, 1, 2, 3])
+        assert op.parameter_frequencies == [(1.0,)]
+
     def test_no_wires_passed(self):
         """Test exception raised if no wires are passed"""
 

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -843,6 +843,7 @@ class TestOperationConstruction:
         DummyOp.parameter_frequencies = qml.operation.Operation.parameter_frequencies
 
         op = DummyOp(0.7, [0, 1, 2, 3])
+        assert isinstance(op.generator(), qml.SparseHamiltonian)
         assert op.parameter_frequencies == [(1.0,)]
 
     def test_no_wires_passed(self):


### PR DESCRIPTION
**Context:**
The `parameter_frequencies` of `qml.ctrl(op)` are obtained using `qml.eigvals`. If `op.generator` is a `SparseHamiltonian`, `qml.eigvals` only returns one eigenvalue because of the default setting of the kwarg `k`.

**edit:** The same problem appears for the default `qml.operation.parameter_frequencies`.

**Description of the Change:**
This PR explicitly sets the `k` kwarg, in order to obtain all eigenvalues of the generator, even if it is a `SparseHamiltonian`.

**edit:** Also sets `k` in `qml.operation.parameter_frequencies`

**Benefits:**
parameter-shift rule for `qml.ctrl(op)` works, also for `op` being a `DoubleExcitation`, e.g.

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
Fixed #4898 