### PR TITLE
Add utility for extracting classical control information to drawer

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -51,6 +51,7 @@
   [(#4803)](https://github.com/PennyLaneAI/pennylane/pull/4803)
   [(#4832)](https://github.com/PennyLaneAI/pennylane/pull/4832)
   [(#4901)](https://github.com/PennyLaneAI/pennylane/pull/4901)
+  [(#4917)](https://github.com/PennyLaneAI/pennylane/pull/4917)
 
 <h4>Catalyst is seamlessly integrated with PennyLane ⚗️</h4>
 

--- a/pennylane/drawer/tape_text.py
+++ b/pennylane/drawer/tape_text.py
@@ -70,6 +70,8 @@ def _add_cond_grouping_symbols(op, layer_str, config):
     n_wires = len(config.wire_map)
 
     mapped_wires = [config.wire_map[w] for w in op.wires]
+    print(config.bit_map)
+    print(op.meas_val.measurements)
     mapped_bits = [config.bit_map[m] for m in op.meas_val.measurements]
     max_w = max(mapped_wires)
     max_b = max(mapped_bits) + n_wires
@@ -398,10 +400,9 @@ def tape_text(
     wire_fillers = ["─", " "]
     bit_fillers = ["═", " "]
     enders = [True, False]  # add "─┤" after all operations
-    bit_maps = [{}, {}]
 
     bit_map, cwire_layers, _ = cwire_connections(layers_list[0] + layers_list[1])
-    n_bits = len(bit_maps[0])
+    n_bits = len(bit_map)
 
     wire_totals = [f"{wire}: " for wire in wire_map]
     bit_totals = ["" for _ in range(n_bits)]
@@ -410,8 +411,8 @@ def tape_text(
     wire_totals = [s.rjust(line_length, " ") for s in wire_totals]
     bit_totals = [s.rjust(line_length, " ") for s in bit_totals]
 
-    for layers, add, w_filler, b_filler, ender, bit_map in zip(
-        layers_list, add_list, wire_fillers, bit_fillers, enders, bit_maps
+    for layers, add, w_filler, b_filler, ender in zip(
+        layers_list, add_list, wire_fillers, bit_fillers, enders
     ):
         # Collect information needed for drawing layers
         config = _Config(

--- a/pennylane/drawer/tape_text.py
+++ b/pennylane/drawer/tape_text.py
@@ -70,8 +70,6 @@ def _add_cond_grouping_symbols(op, layer_str, config):
     n_wires = len(config.wire_map)
 
     mapped_wires = [config.wire_map[w] for w in op.wires]
-    print(config.bit_map)
-    print(op.meas_val.measurements)
     mapped_bits = [config.bit_map[m] for m in op.meas_val.measurements]
     max_w = max(mapped_wires)
     max_b = max(mapped_bits) + n_wires

--- a/pennylane/drawer/tape_text.py
+++ b/pennylane/drawer/tape_text.py
@@ -23,7 +23,7 @@ import pennylane as qml
 from pennylane.measurements import Expectation, Probability, Sample, Variance, State, MidMeasureMP
 
 from .drawable_layers import drawable_layers
-from .utils import convert_wire_order, unwrap_controls, find_mid_measure_cond_connections
+from .utils import convert_wire_order, unwrap_controls, cwire_connections
 
 
 @dataclass
@@ -39,8 +39,8 @@ class _Config:
     cur_layer: Optional[int] = None
     """Current layer index that is being updated"""
 
-    final_cond_layers: Optional[list] = None
-    """List mapping bits to the last layer where they are used"""
+    cwire_layers: Optional[list] = None
+    """A list of layers used (mid measure or conditional) for each classical wire."""
 
     decimals: Optional[int] = None
     """Specifies how to round the parameters of operators"""
@@ -74,19 +74,19 @@ def _add_cond_grouping_symbols(op, layer_str, config):
     max_w = max(mapped_wires)
     max_b = max(mapped_bits) + n_wires
 
-    ctrl_symbol = "╩" if config.cur_layer != config.final_cond_layers[max(mapped_bits)] else "╝"
-    layer_str[max_b] = "═" + ctrl_symbol
+    ctrl_symbol = "╩" if config.cur_layer != config.cwire_layers[max(mapped_bits)][-1] else "╝"
+    layer_str[max_b] = f"═{ctrl_symbol}"
 
     for w in range(max_w + 1, max(config.wire_map.values()) + 1):
         layer_str[w] = "─║"
 
     for b in range(n_wires, max_b):
         if b - n_wires in mapped_bits:
-            intersection = "╣" if config.cur_layer == config.final_cond_layers[b - n_wires] else "╬"
-            layer_str[b] = "═" + intersection
+            intersection = "╣" if config.cur_layer == config.cwire_layers[b - n_wires][-1] else "╬"
+            layer_str[b] = f"═{intersection}"
         else:
             filler = " " if layer_str[b][-1] == " " else "═"
-            layer_str[b] = filler + "║"
+            layer_str[b] = f"{filler}║"
 
     return layer_str
 
@@ -107,7 +107,7 @@ def _add_mid_measure_grouping_symbols(op, layer_str, config):
 
     for b in range(n_wires, bit):
         filler = " " if layer_str[b][-1] == " " else "═"
-        layer_str[b] += filler + "║"
+        layer_str[b] += f"{filler}║"
 
     return layer_str
 
@@ -400,9 +400,7 @@ def tape_text(
     enders = [True, False]  # add "─┤" after all operations
     bit_maps = [{}, {}]
 
-    bit_maps[0], measurement_layers, final_cond_layers = find_mid_measure_cond_connections(
-        tape.operations, layers_list[0]
-    )
+    bit_map, cwire_layers, _ = cwire_connections(layers_list[0] + layers_list[1])
     n_bits = len(bit_maps[0])
 
     wire_totals = [f"{wire}: " for wire in wire_map]
@@ -420,7 +418,7 @@ def tape_text(
             wire_map=wire_map,
             bit_map=bit_map,
             cur_layer=-1,
-            final_cond_layers=final_cond_layers,
+            cwire_layers=cwire_layers,
             decimals=decimals,
             cache=cache,
         )
@@ -429,7 +427,7 @@ def tape_text(
             # Add filler before current layer
             layer_str = [w_filler] * n_wires + [" "] * n_bits
             for b in bit_map.values():
-                cur_b_filler = b_filler if measurement_layers[b] < i < final_cond_layers[b] else " "
+                cur_b_filler = b_filler if min(cwire_layers[b]) < i < max(cwire_layers[b]) else " "
                 layer_str[b + n_wires] = cur_b_filler
 
             config.cur_layer = i
@@ -462,13 +460,11 @@ def tape_text(
                     # that are used for conditions correctly
                     cur_b_filler = (
                         b_filler
-                        if bit_map[cur_layer_mid_measure] >= b and i < final_cond_layers[b]
+                        if bit_map[cur_layer_mid_measure] >= b and i < cwire_layers[b][-1]
                         else " "
                     )
                 else:
-                    cur_b_filler = (
-                        b_filler if measurement_layers[b] < i < final_cond_layers[b] else " "
-                    )
+                    cur_b_filler = b_filler if cwire_layers[b][0] < i < cwire_layers[b][-1] else " "
                 layer_str[b + n_wires] = layer_str[b + n_wires].ljust(max_label_len, cur_b_filler)
 
             line_length += max_label_len + 1  # one for the filler character
@@ -484,7 +480,7 @@ def tape_text(
                 bit_totals = []
                 for b in range(n_bits):
                     cur_b_filler = (
-                        b_filler if measurement_layers[b] < i <= final_cond_layers[b] else " "
+                        b_filler if cwire_layers[b][0] < i <= cwire_layers[b][-1] else " "
                     )
                     bit_totals.append(cur_b_filler)
 
@@ -495,14 +491,12 @@ def tape_text(
             wire_totals = [w_filler.join([t, s]) for t, s in zip(wire_totals, layer_str[:n_wires])]
 
             for j, (bt, s) in enumerate(zip(bit_totals, layer_str[n_wires : n_wires + n_bits])):
-                cur_b_filler = (
-                    b_filler if measurement_layers[j] < i <= final_cond_layers[j] else " "
-                )
+                cur_b_filler = b_filler if cwire_layers[j][0] < i <= cwire_layers[j][-1] else " "
                 bit_totals[j] = cur_b_filler.join([bt, s])
 
         if ender:
-            wire_totals = [s + "─┤" for s in wire_totals]
-            bit_totals = [s + "  " for s in bit_totals]
+            wire_totals = [f"{s}─┤" for s in wire_totals]
+            bit_totals = [f"{s}  " for s in bit_totals]
 
             line_length += 2
 

--- a/pennylane/drawer/utils.py
+++ b/pennylane/drawer/utils.py
@@ -135,15 +135,21 @@ def cwire_connections(layers):
 
     """
     bit_map = {}
+    for layer in layers:
+        for op in layer:
+            if isinstance(op, Conditional):
+                for m in op.meas_val.measurements:
+                    bit_map[m] = None
+
+    connected_layers = [[] for _ in bit_map]
+    connected_wires = [[] for _ in bit_map]
     num_cwires = 0
-    connected_layers = []
-    connected_wires = []
     for layer_idx, layer in enumerate(layers):
         for op in layer:
-            if isinstance(op, MidMeasureMP):
+            if isinstance(op, MidMeasureMP) and op in bit_map:
                 bit_map[op] = num_cwires
-                connected_layers.append([layer_idx])
-                connected_wires.append([op.wires[0]])
+                connected_layers[num_cwires].append(layer_idx)
+                connected_wires[num_cwires].append(op.wires[0])
                 num_cwires += 1
             elif isinstance(op, Conditional):
                 for m in op.meas_val.measurements:

--- a/pennylane/drawer/utils.py
+++ b/pennylane/drawer/utils.py
@@ -139,7 +139,7 @@ def cwire_connections(layers):
         for op in layer:
             if isinstance(op, Conditional):
                 for m in op.meas_val.measurements:
-                    bit_map[m] = None
+                    bit_map[m] = None  # place holder till next pass
 
     connected_layers = [[] for _ in bit_map]
     connected_wires = [[] for _ in bit_map]

--- a/tests/drawer/test_drawer_utils.py
+++ b/tests/drawer/test_drawer_utils.py
@@ -21,7 +21,6 @@ from pennylane.drawer.utils import (
     default_wire_map,
     convert_wire_order,
     unwrap_controls,
-    find_mid_measure_cond_connections,
 )
 from pennylane.wires import Wires
 
@@ -162,49 +161,3 @@ class TestUnwrapControls:
 
         assert control_wires == expected_control_wires
         assert control_values == expected_control_values
-
-
-class TestFindMidMeasureCondConnections:
-    """Tests for the find_mid_measure_cond_connections helper function"""
-
-    def test_no_conds(self):
-        """Test that the return values are empty if there are no conditional operations."""
-        operations = [
-            qml.RX(0.123, 0),
-            qml.measurements.MidMeasureMP(0),
-            qml.RX(0.456, 1),
-            qml.measurements.MidMeasureMP(1),
-        ]
-        layers = [
-            [qml.RX(0.123, 0), qml.RX(0.456, 1)],
-            [qml.measurements.MidMeasureMP(0), qml.measurements.MidMeasureMP(1)],
-        ]
-
-        bit_map, measurement_layers, final_cond_layers = find_mid_measure_cond_connections(
-            operations, layers
-        )
-
-        assert bit_map == {}
-        assert len(measurement_layers) == len(final_cond_layers) == 0
-
-    def test_multi_meas_multi_cond(self):
-        """Test that multiple measurements and multiple conditions return the correct
-        output."""
-        with qml.queuing.AnnotatedQueue() as q:
-            m0 = qml.measure(0)
-            m1 = qml.measure(1)
-            m2 = qml.measure(2)
-            qml.cond(m0 & m1, qml.PauliX)(wires=4)
-            qml.cond(m1 & m2, qml.PauliX)(wires=5)
-            qml.cond(m2 & m0, qml.PauliX)(wires=6)
-
-        operations = q.queue
-        layers = [[op] for op in operations]
-
-        bit_map, measurement_layers, final_cond_layers = find_mid_measure_cond_connections(
-            operations, layers
-        )
-
-        assert bit_map == {operations[0]: 0, operations[1]: 1, operations[2]: 2}
-        assert measurement_layers == [0, 1, 2]
-        assert final_cond_layers == [5, 4, 5]

--- a/tests/drawer/test_drawer_utils.py
+++ b/tests/drawer/test_drawer_utils.py
@@ -21,6 +21,7 @@ from pennylane.drawer.utils import (
     default_wire_map,
     convert_wire_order,
     unwrap_controls,
+    cwire_connections,
 )
 from pennylane.wires import Wires
 
@@ -161,3 +162,58 @@ class TestUnwrapControls:
 
         assert control_wires == expected_control_wires
         assert control_values == expected_control_values
+
+
+# pylint: disable=use-implicit-booleaness-not-comparison
+class TestCwireConnections:
+    """Tests for the cwire_connections helper method."""
+
+    def test_null_circuit(self):
+        """Test null behavior with an empty circuit."""
+        cmap, layers, wires = cwire_connections([[]])
+        assert cmap == {}
+        assert layers == []
+        assert wires == []
+
+    def test_single_measure(self):
+        """Test a single meassurment that does not have a conditional."""
+        cmap, layers, wires = cwire_connections([qml.measure(0).measurements])
+        assert cmap == {}
+        assert layers == []
+        assert wires == []
+
+    def test_single_measure_single_cond(self):
+        """Test a case with a single measurement and a single conditional."""
+        m = qml.measure(0)
+        cond = qml.ops.Conditional(m, qml.PauliX(0))
+        layers = [m.measurements, [cond]]
+        cmap, clayers, wires = cwire_connections(layers)
+        assert cmap == {m.measurements[0]: 0}
+        assert clayers == [[0, 1]]
+        assert wires == [[0, 0]]
+
+    def test_multiple_measure_multiple_cond(self):
+        """Test a case with multiple measurments and multiple conditionals."""
+        m0 = qml.measure(0)
+        m1 = qml.measure(1)
+        m2_nonused = qml.measure(2)
+
+        cond0 = qml.ops.Conditional(m0 + m1, qml.PauliX(1))
+        cond1 = qml.ops.Conditional(m1, qml.PauliY(2))
+
+        layers = [m0.measurements, m1.measurements, [cond0], m2_nonused.measurements, [cond1]]
+        cmap, clayers, wires = cwire_connections(layers)
+        assert cmap == {m0.measurements[0]: 0, m1.measurements[0]: 1}
+        assert clayers == [[0, 2], [1, 2, 4]]
+        assert wires == [[0, 1], [1, 1, 2]]
+
+    def test_measurements_layer(self):
+        """Test cwire_connections works if measurement layers are appended at the end."""
+
+        m0 = qml.measure(0)
+        cond0 = qml.ops.Conditional(m0, qml.S(0))
+        layers = [m0.measurements, [cond0], [qml.expval(qml.PauliX(0))]]
+        cmap, clayers, wires = cwire_connections(layers)
+        assert cmap == {m0.measurements[0]: 0}
+        assert clayers == [[0, 1]]
+        assert wires == [[0, 0]]

--- a/tests/drawer/test_tape_text.py
+++ b/tests/drawer/test_tape_text.py
@@ -167,7 +167,7 @@ class TestHelperFunctions:  # pylint: disable=too-many-arguments
                 wire_map=default_wire_map,
                 bit_map=bit_map,
                 cur_layer=cur_layer,
-                final_cond_layers=[0, 1],
+                cwire_layers=[[0], [1]],
             ),
         )
 
@@ -290,7 +290,7 @@ class TestHelperFunctions:  # pylint: disable=too-many-arguments
             op,
             layer_str,
             _Config(
-                wire_map=default_wire_map, bit_map=bit_map, cur_layer=1, final_cond_layers=[0, 1]
+                wire_map=default_wire_map, bit_map=bit_map, cur_layer=1, cwire_layers=[[0], [1]]
             ),
         )
 


### PR DESCRIPTION
This PR replaces `find_mid_measure_cond_connections` with `cwire_connections`.  It returns very similar information, but is a slight variant that will be easier to use in the matplotlib drawing of classical wires.