### PR TITLE
The IUPAC standard symbol for Hartree energy is Eh not Ha.

### DIFF
--- a/doc/code/qml_qchem.rst
+++ b/doc/code/qml_qchem.rst
@@ -138,7 +138,7 @@ Running this optimization, we get the following output in atomic units:
     Step: 15, Energy: -1.140321384816611, Maximum Absolute Force: 0.0004138319900744425
     Step: 20, Energy: -1.1403680839339787, Maximum Absolute Force: 8.223248376348913e-06
 
-Note that the computed energy is lower than the Full-CI energy, -1.1373060483 Ha, obtained without
+Note that the computed energy is lower than the Full-CI energy, -1.1373060483 Eh, obtained without
 optimizing the basis set parameters.
 
 The components of the HF solver can also be differentiated individually. For instance, the overlap

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -185,6 +185,9 @@
 * `qml.equal` now supports comparison of `QuantumScript` objects
   [#4902](https://github.com/PennyLaneAI/pennylane/pull/4902)
 
+* Changed notation of Hartree energy from Ha to the IUPAC standard Eh
+  [#4925](https://github.com/PennyLaneAI/pennylane/pull/4925)
+
 <h4>Better support for batching</h4>
 
 * `default.qubit` now can evolve already batched states with `ParametrizedEvolution`

--- a/pennylane/resource/first_quantization.py
+++ b/pennylane/resource/first_quantization.py
@@ -31,7 +31,7 @@ class FirstQuantization(Operation):
     the number of electrons and the lattice vectors need to be defined. The costs can then be
     computed using the functions :func:`~.pennylane.resource.FirstQuantization.gate_cost` and
     :func:`~.pennylane.resource.FirstQuantization.qubit_cost` with a target error that has the default
-    value of 0.0016 Ha (chemical accuracy). Atomic units are used throughout the class.
+    value of 0.0016 Eh (chemical accuracy). Atomic units are used throughout the class.
 
     Args:
         n (int): number of plane waves

--- a/pennylane/resource/second_quantization.py
+++ b/pennylane/resource/second_quantization.py
@@ -83,7 +83,7 @@ class DoubleFactorization(Operation):
         for the given Hamiltonian can then be computed using the functions
         :func:`~.pennylane.resource.DoubleFactorization.gate_cost` and
         :func:`~.pennylane.resource.DoubleFactorization.qubit_cost` with a target error that has the
-        default value of 0.0016 Ha (chemical accuracy). The costs are computed using Eqs. (C39-C40)
+        default value of 0.0016 Eh (chemical accuracy). The costs are computed using Eqs. (C39-C40)
         of [`PRX Quantum 2, 030305 (2021) <https://journals.aps.org/prxquantum/abstract/10.1103/PRXQuantum.2.030305>`_].
     """
     num_wires = AnyWires

--- a/pennylane/templates/layers/gate_fabric.py
+++ b/pennylane/templates/layers/gate_fabric.py
@@ -134,22 +134,22 @@ class GateFabric(Operation):
                 conv = np.abs(energy[-1] - prev_energy)
 
                 if n % 2 == 0:
-                    print(f"Step = {n},  Energy = {energy[-1]:.8f} Ha")
+                    print(f"Step = {n},  Energy = {energy[-1]:.8f} Eh")
 
                 if conv <= conv_tol:
                     break
 
-            print("\n" f"Final value of the ground-state energy = {energy[-1]:.8f} Ha")
+            print("\n" f"Final value of the ground-state energy = {energy[-1]:.8f} Eh")
             print("\n" f"Optimal value of the circuit parameters = {angle[-1]}")
 
         .. code-block:: none
 
-            Step = 0,  Energy = -0.87007254 Ha
-            Step = 2,  Energy = -1.13107530 Ha
-            Step = 4,  Energy = -1.13611971 Ha
-            Step = 6,  Energy = -1.13618810 Ha
+            Step = 0,  Energy = -0.87007254 Eh
+            Step = 2,  Energy = -1.13107530 Eh
+            Step = 4,  Energy = -1.13611971 Eh
+            Step = 6,  Energy = -1.13618810 Eh
 
-            Final value of the ground-state energy = -1.13618903 Ha
+            Final value of the ground-state energy = -1.13618903 Eh
 
             Optimal value of the circuit parameters = [[[ 0.60328427  0.41850407]]
             [[ 0.85581129 -0.24522642]]]

--- a/pennylane/templates/subroutines/kupccgsd.py
+++ b/pennylane/templates/subroutines/kupccgsd.py
@@ -162,23 +162,23 @@ class kUpCCGSD(Operation):
                 angle.append(weights)
                 conv = np.abs(energy[-1] - prev_energy)
                 if n % 4 == 0:
-                    print(f"Step = {n},  Energy = {energy[-1]:.8f} Ha")
+                    print(f"Step = {n},  Energy = {energy[-1]:.8f} Eh")
                 if conv <= conv_tol:
                     break
 
-            print("\n" f"Final value of the ground-state energy = {energy[-1]:.8f} Ha")
+            print("\n" f"Final value of the ground-state energy = {energy[-1]:.8f} Eh")
             print("\n" f"Optimal value of the circuit parameters = {angle[-1]}")
 
         .. code-block:: none
 
-            Step = 0,  Energy = -1.08949110 Ha
-            Step = 4,  Energy = -1.13370605 Ha
-            Step = 8,  Energy = -1.13581648 Ha
-            Step = 12,  Energy = -1.13613171 Ha
-            Step = 16,  Energy = -1.13618030 Ha
-            Step = 20,  Energy = -1.13618779 Ha
+            Step = 0,  Energy = -1.08949110 Eh
+            Step = 4,  Energy = -1.13370605 Eh
+            Step = 8,  Energy = -1.13581648 Eh
+            Step = 12,  Energy = -1.13613171 Eh
+            Step = 16,  Energy = -1.13618030 Eh
+            Step = 20,  Energy = -1.13618779 Eh
 
-            Final value of the ground-state energy = -1.13618779 Ha
+            Final value of the ground-state energy = -1.13618779 Eh
 
             Optimal value of the circuit parameters = [[0.97879636 0.46093583 0.98108824
             0.45864352 0.65531446 0.44558289]]

--- a/pennylane/templates/subroutines/uccsd.py
+++ b/pennylane/templates/subroutines/uccsd.py
@@ -146,21 +146,21 @@ class UCCSD(Operation):
                 params, energy = optimizer.step_and_cost(circuit, params,
                 wires=range(qubits), s_wires=s_wires, d_wires=d_wires, hf_state=hf_state)
                 if n % 2 == 0:
-                    print("step = {:},  E = {:.8f} Ha".format(n, energy))
+                    print("step = {:},  E = {:.8f} Eh".format(n, energy))
 
         .. code-block:: none
 
-            step = 0,  E = -1.24654994 Ha
-            step = 2,  E = -1.27016844 Ha
-            step = 4,  E = -1.27379541 Ha
-            step = 6,  E = -1.27434106 Ha
-            step = 8,  E = -1.27442311 Ha
-            step = 10,  E = -1.27443547 Ha
-            step = 12,  E = -1.27443733 Ha
-            step = 14,  E = -1.27443761 Ha
-            step = 16,  E = -1.27443765 Ha
-            step = 18,  E = -1.27443766 Ha
-            step = 20,  E = -1.27443766 Ha
+            step = 0,  E = -1.24654994 Eh
+            step = 2,  E = -1.27016844 Eh
+            step = 4,  E = -1.27379541 Eh
+            step = 6,  E = -1.27434106 Eh
+            step = 8,  E = -1.27442311 Eh
+            step = 10,  E = -1.27443547 Eh
+            step = 12,  E = -1.27443733 Eh
+            step = 14,  E = -1.27443761 Eh
+            step = 16,  E = -1.27443765 Eh
+            step = 18,  E = -1.27443766 Eh
+            step = 20,  E = -1.27443766 Eh
 
     """
 


### PR DESCRIPTION
**Context:**
PennyLane employs the non-standard notation `Ha` for the Hartree energy.

The international standard notation, defined in the [gold book of the International Union of Pure and Applied Chemistry](https://goldbook.iupac.org/terms/view/H02748), is $E_h$.

**Description of the Change:**
Changes output from `Ha` to `Eh`.

**Benefits:**
Conforms to standard.

**Possible Drawbacks:**

**Related GitHub Issues:**
#4924