### PR TITLE
test fix: use vanilla numpy to fix jax test

### DIFF
--- a/tests/devices/qubit/test_sampling.py
+++ b/tests/devices/qubit/test_sampling.py
@@ -16,9 +16,9 @@
 from random import shuffle
 
 import pytest
+import numpy as np
 
 import pennylane as qml
-from pennylane import numpy as np
 from pennylane.devices.qubit import simulate
 from pennylane.devices.qubit.simulate import _FlexShots
 from pennylane.devices.qubit import sample_state, measure_with_samples


### PR DESCRIPTION
**Context:**
A test in this file keeps intermittently failing (see the [ironic failure] on my other PR updating when we use vanilla numpy) because we're checking a result to be a numpy int, and it is, but we're actually ensuring that it's an _autograd_ numpy int, and it (sometimes?? idk) isn't

**Description of the Change:**
Use vanilla numpy in the test and hope that it fixes the issue

**Benefits:**
The test should stop bothering people on unrelated PRs

**Possible Drawbacks:**
- it might not fix it
- I don't know why it only started failing recently