### PR TITLE
move the interface toctree to the top and make it visible

### DIFF
--- a/doc/introduction/interfaces.rst
+++ b/doc/introduction/interfaces.rst
@@ -8,7 +8,17 @@ Gradients and training
 
 PennyLane offers seamless integration between classical and quantum computations. Code up quantum
 circuits in PennyLane, compute :doc:`gradients of quantum circuits <glossary/quantum_gradient>`, and
-connect them easily to the top scientific computing and machine learning libraries.
+connect them easily to the top scientific computing and machine learning libraries. To see more
+advanced usage details for a particular interface, please select it below:
+
+.. toctree::
+    :titlesonly:
+
+    interfaces/numpy
+    interfaces/torch
+    interfaces/tf
+    interfaces/jax
+    unsupported_gradients
 
 Training and interfaces
 -----------------------
@@ -494,11 +504,3 @@ At the moment, it takes into account the following parameters:
 
 :html:`</div>`
 
-.. toctree::
-    :hidden:
-
-    interfaces/numpy
-    interfaces/torch
-    interfaces/tf
-    interfaces/jax
-    unsupported_gradients


### PR DESCRIPTION
**Context:**
These are really important pages, and it's not immediately obvious for readers to find them.

**Description of the Change:**
Move the list of interfaces (and the unsupported gradients doc) links to the top of the file and make them visible. See the intro blurb [here](https://xanaduai-pennylane--4946.com.readthedocs.build/en/4946/introduction/interfaces.html) for what it looks like.

**Benefits:**
Users get the information they need

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
noticed in #4865 