### PR TITLE
`Pow` operators are now pickleable.

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -568,6 +568,8 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* `Pow` operators are now picklable.
+
 * Finite differences and SPSA can now be used with tensorflow-autograph on setups that were seeing a bus error.
   [(#4961)](https://github.com/PennyLaneAI/pennylane/pull/4961)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -569,6 +569,7 @@
 <h3>Bug fixes 🐛</h3>
 
 * `Pow` operators are now picklable.
+  [(#4966)](https://github.com/PennyLaneAI/pennylane/pull/4966)
 
 * Finite differences and SPSA can now be used with tensorflow-autograph on setups that were seeing a bus error.
   [(#4961)](https://github.com/PennyLaneAI/pennylane/pull/4961)

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -86,7 +86,7 @@ def stopping_condition(op: qml.operation.Operator) -> bool:
         return False
     if op.name == "Snapshot":
         return True
-    if op.__class__.__name__ == "Pow" and qml.operation.is_trainable(op):
+    if op.__class__.__name__[:3] == "Pow" and qml.operation.is_trainable(op):
         return False
 
     return op.has_matrix

--- a/pennylane/devices/default_qubit_legacy.py
+++ b/pennylane/devices/default_qubit_legacy.py
@@ -232,7 +232,7 @@ class DefaultQubitLegacy(QubitDevice):
             if getattr(obj, "has_matrix", False):
                 # pow operations dont work with backprop or adjoint without decomposition
                 # use class name string so we don't need to use isinstance check
-                return not (obj.__class__.__name__ == "Pow" and qml.operation.is_trainable(obj))
+                return not (obj.__class__.__name__[:3] == "Pow" and qml.operation.is_trainable(obj))
             return obj.name in self.observables.union(self.operations)
 
         return qml.BooleanFn(accepts_obj)

--- a/pennylane/ops/functions/assert_valid.py
+++ b/pennylane/ops/functions/assert_valid.py
@@ -102,7 +102,7 @@ def _check_matrix_matches_decomp(op):
     """Check that if both the matrix and decomposition are defined, they match."""
     if op.has_matrix and op.has_decomposition:
         mat = op.matrix()
-        decomp_mat = qml.matrix(op.decomposition, wire_order=op.wires)()
+        decomp_mat = qml.matrix(qml.tape.QuantumScript(op.decomposition()), wire_order=op.wires)
         failure_comment = (
             f"matrix and matrix from decomposition must match. Got \n{mat}\n\n {decomp_mat}"
         )

--- a/pennylane/ops/op_math/pow.py
+++ b/pennylane/ops/op_math/pow.py
@@ -31,7 +31,7 @@ from pennylane.operation import (
 from pennylane.ops.identity import Identity
 from pennylane.queuing import QueuingManager, apply
 
-from .symbolicop import ScalarSymbolicOp, SymbolicOp
+from .symbolicop import ScalarSymbolicOp
 
 _superscript = str.maketrans("0123456789.+-", "⁰¹²³⁴⁵⁶⁷⁸⁹⋅⁺⁻")
 
@@ -106,29 +106,6 @@ def pow(base, z=1, lazy=True, id=None):
     return pow_op
 
 
-# pylint: disable=no-member
-class PowOperation(Operation):
-    """Operation-specific methods and properties for the ``Pow`` class.
-
-    Dynamically mixed in based on the provided base operator.  If the base operator is an
-    Operation, this class will be mixed in.
-
-    When we no longer rely on certain functionality through `Operation`, we can get rid of this
-    class.
-    """
-
-    # until we add gradient support
-    grad_method = None
-
-    @property
-    def name(self):
-        return self._name
-
-    @property
-    def control_wires(self):
-        return self.base.control_wires
-
-
 class Pow(ScalarSymbolicOp):
     """Symbolic operator denoting an operator raised to a power.
 
@@ -160,10 +137,6 @@ class Pow(ScalarSymbolicOp):
     def _unflatten(cls, data, _):
         return pow(data[0], z=data[1])
 
-    _operation_type = None  # type if base inherits from operation and not observable
-    _operation_observable_type = None  # type if base inherits from both operation and observable
-    _observable_type = None  # type if base inherits from observable and not oepration
-
     # pylint: disable=unused-argument
     def __new__(cls, base=None, z=1, id=None):
         """Mixes in parents based on inheritance structure of base.
@@ -187,22 +160,13 @@ class Pow(ScalarSymbolicOp):
 
         if isinstance(base, Operation):
             if isinstance(base, Observable):
-                if cls._operation_observable_type is None:
-                    base_classes = (PowOperation, Pow, SymbolicOp, Observable, Operation)
-                    cls._operation_observable_type = type("Pow", base_classes, dict(cls.__dict__))
-                return object.__new__(cls._operation_observable_type)
+                return object.__new__(PowOpObs)
 
             # not an observable
-            if cls._operation_type is None:
-                base_classes = (PowOperation, Pow, SymbolicOp, Operation)
-                cls._operation_type = type("Pow", base_classes, dict(cls.__dict__))
-            return object.__new__(cls._operation_type)
+            return object.__new__(PowOperation)
 
         if isinstance(base, Observable):
-            if cls._observable_type is None:
-                base_classes = (Pow, SymbolicOp, Observable)
-                cls._observable_type = type("Pow", base_classes, dict(cls.__dict__))
-            return object.__new__(cls._observable_type)
+            return object.__new__(PowObs)
 
         return object.__new__(Pow)
 
@@ -370,3 +334,46 @@ class Pow(ScalarSymbolicOp):
             return op.simplify()
         except PowUndefinedError:
             return Pow(base=base, z=self.z)
+
+
+# pylint: disable=no-member
+class PowOperation(Pow, Operation):
+    """Operation-specific methods and properties for the ``Pow`` class.
+
+    Dynamically mixed in based on the provided base operator.  If the base operator is an
+    Operation, this class will be mixed in.
+
+    When we no longer rely on certain functionality through `Operation`, we can get rid of this
+    class.
+    """
+
+    def __new__(cls, *_, **__):
+        return object.__new__(cls)
+
+    # until we add gradient support
+    grad_method = None
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def control_wires(self):
+        return self.base.control_wires
+
+
+class PowObs(Pow, Observable):
+    """A child class of ``Pow`` that also inherits from ``Observable``."""
+
+    def __new__(cls, *_, **__):
+        return object.__new__(cls)
+
+
+# pylint: disable=too-many-ancestors
+class PowOpObs(PowOperation, Observable):
+    """A child class of ``Pow`` that inherits from both
+    ``Observable`` and ``Operation``.
+    """
+
+    def __new__(cls, *_, **__):
+        return object.__new__(cls)

--- a/tests/ops/functions/conftest.py
+++ b/tests/ops/functions/conftest.py
@@ -22,6 +22,7 @@ import pytest
 import pennylane as qml
 from pennylane.operation import Operator, Operation, Observable, Tensor, Channel
 from pennylane.ops.op_math.adjoint import Adjoint, AdjointObs, AdjointOperation, AdjointOpObs
+from pennylane.ops.op_math.pow import PowObs, PowOperation, PowOpObs
 
 # if you would like to validate one of these operators, add an instance to the parametrization
 # of `test_explicit_list_of_ops` in `test_assert_valid.py`, and kindly move it below the
@@ -81,6 +82,9 @@ _ABSTRACT_OR_META_TYPES = {
     AdjointOpObs,
     AdjointOperation,
     AdjointObs,
+    PowOpObs,
+    PowOperation,
+    PowObs,
 }
 
 

--- a/tests/ops/op_math/test_pow_op.py
+++ b/tests/ops/op_math/test_pow_op.py
@@ -44,6 +44,12 @@ def test_basic_validity():
     op = qml.pow(qml.RX(1.2, wires=0), 3)
     qml.ops.functions.assert_valid(op)
 
+    op = qml.pow(qml.PauliX(0), 2.5)
+    qml.ops.functions.assert_valid(op)
+
+    op = qml.pow(qml.Hermitian(np.eye(2), 0), 2)
+    qml.ops.functions.assert_valid(op)
+
 
 class TestConstructor:
     def test_lazy_mode(self):

--- a/tests/ops/op_math/test_pow_op.py
+++ b/tests/ops/op_math/test_pow_op.py
@@ -39,7 +39,6 @@ def pow_using_dunder_method(base, z, id=None):
     return base**z
 
 
-@pytest.mark.xfail  # TODO: remove xfail as part of story 49618
 def test_basic_validity():
     """Run basic operator validity checks."""
     op = qml.pow(qml.RX(1.2, wires=0), 3)


### PR DESCRIPTION
[sc-49618]

We discovered that pow operators are currently not pickleable due to `__new__` black magic.  This PR makes it so `Pow` is updated to use the same behavior as `Adjoint`, which is picklable.