### PR TITLE
Remove reference to `from jax.config import config`

### DIFF
--- a/doc/introduction/interfaces/jax.rst
+++ b/doc/introduction/interfaces/jax.rst
@@ -43,8 +43,7 @@ PennyLane in combination with JAX, we have to generate JAX-compatible quantum no
 
     .. code-block:: python
 
-        from jax.config import config
-        config.update("jax_enable_x64", True)
+        jax.config.update("jax_enable_x64", True)
 
 
 Construction via the decorator

--- a/pennylane/devices/default_qubit_jax.py
+++ b/pennylane/devices/default_qubit_jax.py
@@ -25,7 +25,6 @@ from pennylane.typing import TensorLike
 try:
     import jax
     import jax.numpy as jnp
-    from jax.config import config as jax_config
     from jax.experimental.ode import odeint
 
     from pennylane.pulse.parametrized_hamiltonian_pytree import ParametrizedHamiltonianPytree
@@ -166,7 +165,7 @@ class DefaultQubitJax(DefaultQubitLegacy):
     operations = DefaultQubitLegacy.operations.union({"ParametrizedEvolution"})
 
     def __init__(self, wires, *, shots=None, prng_key=None, analytic=None):
-        if jax_config.read("jax_enable_x64"):
+        if jax.config.read("jax_enable_x64"):
             c_dtype = jnp.complex128
             r_dtype = jnp.float64
         else:

--- a/tests/devices/default_qubit/test_default_qubit.py
+++ b/tests/devices/default_qubit/test_default_qubit.py
@@ -848,9 +848,7 @@ class TestSumOfTermsDifferentiability:
     def test_jax_backprop(self, style, use_jit):
         """Test that backpropagation derivatives work with jax with hamiltonians and large sums."""
         import jax
-        from jax.config import config
 
-        config.update("jax_enable_x64", True)  # otherwise output is too noisy
         x = jax.numpy.array(0.52, dtype=jax.numpy.float64)
         f = jax.jit(self.f_hashable, static_argnums=(1, 2, 3)) if use_jit else self.f_hashable
 

--- a/tests/devices/qubit/test_measure.py
+++ b/tests/devices/qubit/test_measure.py
@@ -418,9 +418,6 @@ class TestSumOfTermsDifferentiability:
     def test_jax_backprop(self, convert_to_hamiltonian, use_jit):
         """Test that backpropagation derivatives work with jax with hamiltonians and large sums."""
         import jax
-        from jax.config import config
-
-        config.update("jax_enable_x64", True)  # otherwise output is too noisy
 
         x = jax.numpy.array(0.52, dtype=jax.numpy.float64)
         coeffs = (5.2, 6.7)

--- a/tests/fourier/test_coefficients.py
+++ b/tests/fourier/test_coefficients.py
@@ -382,12 +382,6 @@ class TestInterfaces:
         """Test that coefficients are correctly computed when using the JAX interface."""
         import jax
 
-        # Need to enable float64 support
-        from jax.config import config
-
-        remember = config.read("jax_enable_x64")
-        config.update("jax_enable_x64", True)
-
         qnode = qml.QNode(self.circuit, self.dev, diff_method="parameter-shift")
 
         weights = jax.numpy.array([0.5, 0.2])
@@ -395,5 +389,3 @@ class TestInterfaces:
         obtained_result = coefficients(partial(qnode, weights), 2, 1)
 
         assert np.allclose(obtained_result, self.expected_result)
-
-        config.update("jax_enable_x64", remember)

--- a/tests/fourier/test_reconstruct.py
+++ b/tests/fourier/test_reconstruct.py
@@ -193,9 +193,7 @@ class TestReconstructEqu:
         """Test that the reconstruction of equidistant-frequency classical
         functions are differentiable for JAX input variables."""
         import jax
-        from jax.config import config
 
-        config.update("jax_enable_x64", True)
         # Convert fun to have integer frequencies
         _fun = lambda x: fun(x / base_f)
         _rec = _reconstruct_equ(_fun, num_frequency, interface="jax")
@@ -423,9 +421,7 @@ class TestReconstructGen:
         """Test that the reconstruction of equidistant-frequency classical
         functions are differentiable for JAX input variables."""
         import jax
-        from jax.config import config
 
-        config.update("jax_enable_x64", True)
         # Convert fun to have integer frequencies
         rec = _reconstruct_gen(fun, spectrum, interface="jax")
         grad = jax.grad(rec)
@@ -919,9 +915,7 @@ class TestReconstruct:
     ):
         """Tests the reconstruction and differentiability with JAX."""
         import jax
-        from jax.config import config
 
-        config.update("jax_enable_x64", True)
         params = tuple(jax.numpy.array(par) for par in params)
         qnode = qml.QNode(qnode, dev_1, interface="jax")
         with qml.Tracker(qnode.device) as tracker:

--- a/tests/gradients/core/test_adjoint_metric_tensor.py
+++ b/tests/gradients/core/test_adjoint_metric_tensor.py
@@ -288,9 +288,6 @@ class TestAdjointMetricTensorTape:
         calling the adjoint metric tensor directly on a tape."""
 
         import jax
-        from jax.config import config
-
-        config.update("jax_enable_x64", True)
 
         expected = autodiff_metric_tensor(ansatz, self.num_wires)(*params)
         j_params = tuple(jax.numpy.array(p) for p in params)
@@ -410,9 +407,6 @@ class TestAdjointMetricTensorQNode:
         calling the adjoint metric tensor on a QNode."""
 
         import jax
-        from jax.config import config
-
-        config.update("jax_enable_x64", True)
 
         expected = autodiff_metric_tensor(ansatz, self.num_wires)(*params)
         j_params = tuple(jax.numpy.array(p) for p in params)
@@ -538,9 +532,6 @@ class TestAdjointMetricTensorDifferentiability:
         calling the adjoint metric tensor on a QNode."""
 
         import jax
-        from jax.config import config
-
-        config.update("jax_enable_x64", True)
 
         expected = qml.jacobian(autodiff_metric_tensor(ansatz, self.num_wires))(*params)
         j_params = tuple(jax.numpy.array(p) for p in params)

--- a/tests/gradients/core/test_hadamard_gradient.py
+++ b/tests/gradients/core/test_hadamard_gradient.py
@@ -1140,9 +1140,6 @@ class TestHadamardTestGradDiff:
         can be differentiated using JAX, yielding second derivatives."""
         import jax
         from jax import numpy as jnp
-        from jax.config import config
-
-        config.update("jax_enable_x64", True)
 
         dev = qml.device(dev_name, wires=3)
         execute_fn = dev.execute if dev_name == "default.qubit" else dev.batch_execute

--- a/tests/gradients/core/test_jvp.py
+++ b/tests/gradients/core/test_jvp.py
@@ -283,9 +283,6 @@ class TestComputeJVPSingle:
         """Test that using the JAX interface the dtype of the result is
         determined by the dtype of the dy."""
         import jax
-        from jax.config import config
-
-        config.update("jax_enable_x64", True)
 
         dtype = dtype1
         dtype1 = getattr(jax.numpy, dtype1)

--- a/tests/gradients/core/test_metric_tensor.py
+++ b/tests/gradients/core/test_metric_tensor.py
@@ -1146,7 +1146,6 @@ class TestFullMetricTensor:
     @pytest.mark.parametrize("ansatz, params", zip(fubini_ansatze, fubini_params))
     @pytest.mark.parametrize("interface", ["auto", "jax"])
     def test_correct_output_jax(self, ansatz, params, interface):
-
         from jax import numpy as jnp
 
         expected = autodiff_metric_tensor(ansatz, self.num_wires)(*params)
@@ -1175,7 +1174,6 @@ class TestFullMetricTensor:
     @pytest.mark.parametrize("ansatz, params", zip(fubini_ansatze, fubini_params))
     @pytest.mark.parametrize("interface", ["auto", "jax"])
     def test_jax_argnum_error(self, ansatz, params, interface):
-
         from jax import numpy as jnp
 
         dev = qml.device("default.qubit.jax", wires=self.num_wires + 1)

--- a/tests/gradients/core/test_metric_tensor.py
+++ b/tests/gradients/core/test_metric_tensor.py
@@ -1146,9 +1146,6 @@ class TestFullMetricTensor:
     @pytest.mark.parametrize("ansatz, params", zip(fubini_ansatze, fubini_params))
     @pytest.mark.parametrize("interface", ["auto", "jax"])
     def test_correct_output_jax(self, ansatz, params, interface):
-        from jax.config import config
-
-        config.update("jax_enable_x64", True)
 
         from jax import numpy as jnp
 
@@ -1178,9 +1175,6 @@ class TestFullMetricTensor:
     @pytest.mark.parametrize("ansatz, params", zip(fubini_ansatze, fubini_params))
     @pytest.mark.parametrize("interface", ["auto", "jax"])
     def test_jax_argnum_error(self, ansatz, params, interface):
-        from jax.config import config
-
-        config.update("jax_enable_x64", True)
 
         from jax import numpy as jnp
 

--- a/tests/gradients/core/test_vjp.py
+++ b/tests/gradients/core/test_vjp.py
@@ -178,9 +178,6 @@ class TestComputeVJP:
         """Test that using the JAX interface the dtype of the result is
         determined by the dtype of the dy."""
         import jax
-        from jax.config import config
-
-        config.update("jax_enable_x64", True)
 
         dtype = dtype1
         dtype1 = getattr(jax.numpy, dtype1)

--- a/tests/gradients/finite_diff/test_finite_difference.py
+++ b/tests/gradients/finite_diff/test_finite_difference.py
@@ -1033,9 +1033,6 @@ class TestFiniteDiffGradients:
         can be differentiated using JAX, yielding second derivatives."""
         import jax
         from jax import numpy as jnp
-        from jax.config import config
-
-        config.update("jax_enable_x64", True)
 
         dev = qml.device(dev_name, wires=2)
         execute_fn = dev.execute if dev_name == "default.qubit" else dev.batch_execute
@@ -1072,9 +1069,6 @@ class TestFiniteDiffGradients:
     ):  # pylint: disable=unused-argument
         """Tests that the output of the finite-difference transform is similar using or not diff method on the QNode."""
         import jax
-        from jax.config import config
-
-        config.update("jax_enable_x64", True)
 
         dev = qml.device(dev_name, wires=2)
         x = jax.numpy.array(0.543)
@@ -1120,9 +1114,6 @@ class TestJaxArgnums:
     def test_single_expectation_value(self, argnums, interface, approx_order, strategy):
         """Test for single expectation value."""
         import jax
-        from jax.config import config
-
-        config.update("jax_enable_x64", True)
 
         dev = qml.device("default.qubit", wires=2)
 
@@ -1154,9 +1145,6 @@ class TestJaxArgnums:
     def test_multi_expectation_values(self, argnums, interface, approx_order, strategy):
         """Test for multiple expectation values."""
         import jax
-        from jax.config import config
-
-        config.update("jax_enable_x64", True)
 
         dev = qml.device("default.qubit", wires=2)
 
@@ -1191,9 +1179,6 @@ class TestJaxArgnums:
     def test_hessian(self, argnums, interface, approx_order, strategy):
         """Test for hessian."""
         import jax
-        from jax.config import config
-
-        config.update("jax_enable_x64", True)
 
         dev = qml.device("default.qubit", wires=2)
 

--- a/tests/gradients/finite_diff/test_finite_difference_shot_vec.py
+++ b/tests/gradients/finite_diff/test_finite_difference_shot_vec.py
@@ -1071,9 +1071,6 @@ class TestFiniteDiffGradients:
         can be differentiated using JAX, yielding second derivatives."""
         import jax
         from jax import numpy as jnp
-        from jax.config import config
-
-        config.update("jax_enable_x64", True)
 
         dev = qml.device(dev_name, wires=2, shots=many_shots_shot_vector)
         execute_fn = dev.execute if dev_name == "default.qubit" else dev.batch_execute

--- a/tests/gradients/finite_diff/test_spsa_gradient.py
+++ b/tests/gradients/finite_diff/test_spsa_gradient.py
@@ -1205,9 +1205,6 @@ class TestSpsaGradientDifferentiation:
         can be differentiated using JAX, yielding second derivatives."""
         import jax
         from jax import numpy as jnp
-        from jax.config import config
-
-        config.update("jax_enable_x64", True)
 
         dev = qml.device(dev_name, wires=2)
         execute_fn = dev.execute if dev_name == "default.qubit" else dev.batch_execute

--- a/tests/gradients/finite_diff/test_spsa_gradient_shot_vec.py
+++ b/tests/gradients/finite_diff/test_spsa_gradient_shot_vec.py
@@ -1201,9 +1201,6 @@ class TestSpsaGradientDifferentiation:
         can be differentiated using JAX, yielding second derivatives."""
         import jax
         from jax import numpy as jnp
-        from jax.config import config
-
-        config.update("jax_enable_x64", True)
 
         dev = qml.device(dev_name, wires=2, shots=many_shots_shot_vector)
         execute_fn = dev.execute if dev_name == "default.qubit" else dev.batch_execute

--- a/tests/gradients/parameter_shift/test_parameter_shift_cv.py
+++ b/tests/gradients/parameter_shift/test_parameter_shift_cv.py
@@ -1229,9 +1229,6 @@ class TestParamShiftInterfaces:
         can be differentiated using JAX, yielding second derivatives."""
         import jax
         from jax import numpy as jnp
-        from jax.config import config
-
-        config.update("jax_enable_x64", True)
 
         dev = qml.device("default.gaussian", wires=1)
         params = jnp.array([0.543, -0.654])

--- a/tests/ops/functions/test_matrix.py
+++ b/tests/ops/functions/test_matrix.py
@@ -604,9 +604,6 @@ class TestInterfaces:
         """Test with JAX interface"""
 
         from jax import numpy as jnp
-        from jax.config import config
-
-        config.update("jax_enable_x64", True)
 
         @qml.matrix
         def circuit(theta):

--- a/tests/ops/op_math/test_decompositions.py
+++ b/tests/ops/op_math/test_decompositions.py
@@ -155,17 +155,8 @@ class TestQubitUnitaryZYZDecomposition:
 
         import jax
 
-        # Enable float64 support
-        from jax.config import config
-
-        remember = config.read("jax_enable_x64")
-        config.update("jax_enable_x64", True)
-
         U = jax.numpy.array(U, dtype=jax.numpy.complex128)
         _test_decomposition(U, "ZYZ", typeof_gates_zyz, expected_params)
-
-        # Reset the configuration
-        config.update("jax_enable_x64", remember)
 
 
 typeof_gates_xyx = (qml.RX, qml.RY, qml.RX, qml.GlobalPhase)
@@ -239,17 +230,8 @@ class TestQubitUnitaryXYXDecomposition:
 
         import jax
 
-        # Enable float64 support
-        from jax.config import config
-
-        remember = config.read("jax_enable_x64")
-        config.update("jax_enable_x64", True)
-
         U = jax.numpy.array(U, dtype=jax.numpy.complex128)
         _test_decomposition(U, "XYX", typeof_gates_xyx, expected_params)
-
-        # Reset the configuration
-        config.update("jax_enable_x64", remember)
 
 
 typeof_gates_xzx = (qml.RX, qml.RZ, qml.RX, qml.GlobalPhase)
@@ -320,17 +302,8 @@ class TestQubitUnitaryXZXDecomposition:
 
         import jax
 
-        # Enable float64 support
-        from jax.config import config
-
-        remember = config.read("jax_enable_x64")
-        config.update("jax_enable_x64", True)
-
         U = jax.numpy.array(U, dtype=jax.numpy.complex128)
         _test_decomposition(U, "XZX", typeof_gates_xzx, expected_params)
-
-        # Reset the configuration
-        config.update("jax_enable_x64", remember)
 
 
 typeof_gates_zxz = (qml.RZ, qml.RX, qml.RZ, qml.GlobalPhase)
@@ -415,17 +388,8 @@ class TestQubitUnitaryZXZDecomposition:
 
         import jax
 
-        # Enable float64 support
-        from jax.config import config
-
-        remember = config.read("jax_enable_x64")
-        config.update("jax_enable_x64", True)
-
         U = jax.numpy.array(U, dtype=jax.numpy.complex128)
         _test_decomposition(U, "ZXZ", typeof_gates_zxz, expected_params)
-
-        # Restore the configuration
-        config.update("jax_enable_x64", remember)
 
 
 test_cases_rot = [
@@ -488,17 +452,8 @@ class TestOneQubitRotDecomposition:
 
         import jax
 
-        # Enable float64 support
-        from jax.config import config
-
-        remember = config.read("jax_enable_x64")
-        config.update("jax_enable_x64", True)
-
         U = jax.numpy.array(U, dtype=jax.numpy.complex128)
         _test_decomposition(U, "rot", expected_gates, expected_params)
-
-        # Restore the configuration
-        config.update("jax_enable_x64", remember)
 
 
 # Randomly generated set (scipy.unitary_group) of five U(4) operations.
@@ -1172,10 +1127,6 @@ class TestTwoQubitUnitaryDecompositionInterfaces:
         """Test that a two-qubit operation in JAX is correctly decomposed."""
 
         import jax
-        from jax.config import config
-
-        remember = config.read("jax_enable_x64")
-        config.update("jax_enable_x64", True)
 
         U = jax.numpy.array(U, dtype=jax.numpy.complex128)
 
@@ -1189,9 +1140,6 @@ class TestTwoQubitUnitaryDecompositionInterfaces:
         obtained_matrix = qml.matrix(tape, wire_order=wires)
 
         assert check_matrix_equivalence(U, obtained_matrix, atol=1e-7)
-
-        # Restore config
-        config.update("jax_enable_x64", remember)
 
     @pytest.mark.jax
     @pytest.mark.parametrize("wires", [[0, 1], ["a", "b"], [3, 2], ["c", 0]])
@@ -1200,10 +1148,6 @@ class TestTwoQubitUnitaryDecompositionInterfaces:
         """Test that a two-qubit tensor product in JAX is correctly decomposed."""
 
         import jax
-        from jax.config import config
-
-        remember = config.read("jax_enable_x64")
-        config.update("jax_enable_x64", True)
 
         U1 = jax.numpy.array(U_pair[0], dtype=jax.numpy.complex128)
         U2 = jax.numpy.array(U_pair[1], dtype=jax.numpy.complex128)
@@ -1220,9 +1164,6 @@ class TestTwoQubitUnitaryDecompositionInterfaces:
 
         assert check_matrix_equivalence(U, obtained_matrix, atol=1e-7)
 
-        # Restore config
-        config.update("jax_enable_x64", remember)
-
     @pytest.mark.jax
     @pytest.mark.parametrize("wires", [[0, 1], ["a", "b"], [3, 2], ["c", 0]])
     @pytest.mark.parametrize("U", samples_3_cnots + samples_2_cnots + samples_1_cnot)
@@ -1230,10 +1171,6 @@ class TestTwoQubitUnitaryDecompositionInterfaces:
         """Test that a two-qubit operation is correctly decomposed with JAX-JIT ."""
 
         import jax
-        from jax.config import config
-
-        remember = config.read("jax_enable_x64")
-        config.update("jax_enable_x64", True)
 
         U = jax.numpy.array(U, dtype=jax.numpy.complex128)
 
@@ -1255,9 +1192,6 @@ class TestTwoQubitUnitaryDecompositionInterfaces:
 
         assert check_matrix_equivalence(U, jitted_matrix, atol=1e-7)
 
-        # Restore config
-        config.update("jax_enable_x64", remember)
-
     @pytest.mark.jax
     @pytest.mark.parametrize("wires", [[0, 1], ["a", "b"], [3, 2], ["c", 0]])
     @pytest.mark.parametrize("U_pair", samples_su2_su2)
@@ -1265,10 +1199,6 @@ class TestTwoQubitUnitaryDecompositionInterfaces:
         """Test that a two-qubit tensor product is correctly decomposed with JAX-JIT."""
 
         import jax
-        from jax.config import config
-
-        remember = config.read("jax_enable_x64")
-        config.update("jax_enable_x64", True)
 
         U1 = jax.numpy.array(U_pair[0], dtype=jax.numpy.complex128)
         U2 = jax.numpy.array(U_pair[1], dtype=jax.numpy.complex128)
@@ -1291,9 +1221,6 @@ class TestTwoQubitUnitaryDecompositionInterfaces:
         jitted_matrix = jax.jit(wrapped_decomposition)(U)
 
         assert check_matrix_equivalence(U, jitted_matrix, atol=1e-7)
-
-        # Restore config
-        config.update("jax_enable_x64", remember)
 
 
 class TestTransformsDeprecations:

--- a/tests/test_return_types_qnode.py
+++ b/tests/test_return_types_qnode.py
@@ -753,9 +753,7 @@ class TestIntegrationSingleReturnJax:
     @pytest.mark.parametrize("wires", test_wires)
     def test_state_default(self, wires):
         """Return state with default.qubit."""
-        from jax.config import config
 
-        config.update("jax_enable_x64", True)
         import jax
 
         dev = qml.device("default.qubit.jax", wires=wires)
@@ -774,9 +772,6 @@ class TestIntegrationSingleReturnJax:
     @pytest.mark.parametrize("wires", test_wires)
     def test_state_mixed(self, wires):
         """Return state with default.mixed."""
-        from jax.config import config
-
-        config.update("jax_enable_x64", True)
         import jax
 
         dev = qml.device("default.mixed", wires=wires)
@@ -796,9 +791,6 @@ class TestIntegrationSingleReturnJax:
     @pytest.mark.parametrize("d_wires", test_wires)
     def test_density_matrix(self, d_wires, device):
         """Return density matrix."""
-        from jax.config import config
-
-        config.update("jax_enable_x64", True)
         import jax
 
         dev = qml.device(device, wires=4)
@@ -817,9 +809,6 @@ class TestIntegrationSingleReturnJax:
     @pytest.mark.parametrize("device", devices)
     def test_expval(self, device):
         """Return a single expval."""
-        from jax.config import config
-
-        config.update("jax_enable_x64", True)
         import jax
 
         dev = qml.device(device, wires=2)
@@ -838,9 +827,6 @@ class TestIntegrationSingleReturnJax:
     @pytest.mark.parametrize("device", devices)
     def test_var(self, device):
         """Return a single var."""
-        from jax.config import config
-
-        config.update("jax_enable_x64", True)
         import jax
 
         dev = qml.device(device, wires=2)
@@ -859,9 +845,6 @@ class TestIntegrationSingleReturnJax:
     @pytest.mark.parametrize("device", devices)
     def test_vn_entropy(self, device):
         """Return a single vn entropy."""
-        from jax.config import config
-
-        config.update("jax_enable_x64", True)
         import jax
 
         dev = qml.device(device, wires=2)
@@ -880,9 +863,6 @@ class TestIntegrationSingleReturnJax:
     @pytest.mark.parametrize("device", devices)
     def test_mutual_info(self, device):
         """Return a single mutual information."""
-        from jax.config import config
-
-        config.update("jax_enable_x64", True)
         import jax
 
         dev = qml.device(device, wires=2)
@@ -910,9 +890,6 @@ class TestIntegrationSingleReturnJax:
     @pytest.mark.parametrize("op,wires", probs_data)
     def test_probs(self, op, wires, device):
         """Return a single prob."""
-        from jax.config import config
-
-        config.update("jax_enable_x64", True)
         import jax
 
         dev = qml.device(device, wires=3)
@@ -937,9 +914,6 @@ class TestIntegrationSingleReturnJax:
     )
     def test_sample(self, measurement, device, shots=100):
         """Test the sample measurement."""
-        from jax.config import config
-
-        config.update("jax_enable_x64", True)
         import jax
 
         if device == "default.mixed":
@@ -968,9 +942,6 @@ class TestIntegrationSingleReturnJax:
     )
     def test_counts(self, measurement, device, shots=100):
         """Test the counts measurement."""
-        from jax.config import config
-
-        config.update("jax_enable_x64", True)
         import jax
 
         dev = qml.device(device, wires=2, shots=shots)
@@ -1918,9 +1889,6 @@ class TestIntegrationMultipleReturnJax:
     @pytest.mark.parametrize("device", devices)
     def test_multiple_expval(self, device):
         """Return multiple expvals."""
-        from jax.config import config
-
-        config.update("jax_enable_x64", True)
         import jax
 
         dev = qml.device(device, wires=2)
@@ -1945,9 +1913,6 @@ class TestIntegrationMultipleReturnJax:
     @pytest.mark.parametrize("device", devices)
     def test_multiple_var(self, device):
         """Return multiple vars."""
-        from jax.config import config
-
-        config.update("jax_enable_x64", True)
         import jax
 
         dev = qml.device(device, wires=2)
@@ -1986,9 +1951,6 @@ class TestIntegrationMultipleReturnJax:
     @pytest.mark.parametrize("op1,wires1,op2,wires2", multi_probs_data)
     def test_multiple_prob(self, op1, op2, wires1, wires2, device):
         """Return multiple probs."""
-        from jax.config import config
-
-        config.update("jax_enable_x64", True)
         import jax
 
         dev = qml.device(device, wires=2)
@@ -2022,9 +1984,6 @@ class TestIntegrationMultipleReturnJax:
     @pytest.mark.parametrize("wires3, wires4", multi_return_wires)
     def test_mix_meas(self, op1, wires1, op2, wires2, wires3, wires4, device):
         """Return multiple different measurements."""
-        from jax.config import config
-
-        config.update("jax_enable_x64", True)
         import jax
 
         dev = qml.device(device, wires=2)
@@ -2067,9 +2026,6 @@ class TestIntegrationMultipleReturnJax:
     @pytest.mark.parametrize("measurement", [qml.sample(qml.PauliZ(0)), qml.sample(wires=[0])])
     def test_expval_sample(self, measurement, device, shots=100):
         """Test the expval and sample measurements together."""
-        from jax.config import config
-
-        config.update("jax_enable_x64", True)
         import jax
 
         if device == "default.mixed":
@@ -2097,9 +2053,6 @@ class TestIntegrationMultipleReturnJax:
     @pytest.mark.parametrize("measurement", [qml.counts(qml.PauliZ(0)), qml.counts(wires=[0])])
     def test_expval_counts(self, measurement, device, shots=100):
         """Test the expval and counts measurements together."""
-        from jax.config import config
-
-        config.update("jax_enable_x64", True)
         import jax
 
         if device == "default.mixed":
@@ -2129,9 +2082,6 @@ class TestIntegrationMultipleReturnJax:
     @pytest.mark.parametrize("wires", wires)
     def test_list_one_expval(self, wires, device):
         """Return a comprehension list of one expvals."""
-        from jax.config import config
-
-        config.update("jax_enable_x64", True)
         import jax
 
         dev = qml.device(device, wires=wires)
@@ -2156,9 +2106,6 @@ class TestIntegrationMultipleReturnJax:
     @pytest.mark.parametrize("shot_vector", shot_vectors)
     def test_list_multiple_expval(self, wires, device, shot_vector):
         """Return a comprehension list of multiple expvals."""
-        from jax.config import config
-
-        config.update("jax_enable_x64", True)
         import jax
 
         if device == "default.mixed" and shot_vector:
@@ -3167,9 +3114,6 @@ class TestIntegrationJacobianBackpropMultipleReturns:
     @pytest.mark.parametrize("interface", ["auto", "jax"])
     def test_multiple_expval_jax(self, interface, device):
         """Return Jacobian of multiple expvals."""
-        from jax.config import config
-
-        config.update("jax_enable_x64", True)
         import jax
 
         dev = qml.device(device, wires=2)
@@ -3196,9 +3140,6 @@ class TestIntegrationJacobianBackpropMultipleReturns:
     @pytest.mark.parametrize("interface", ["auto", "jax"])
     def test_multiple_expval_jax_jit(self, interface, device):
         """Return Jacobian of multiple expvals with Jitting."""
-        from jax.config import config
-
-        config.update("jax_enable_x64", True)
         import jax
 
         dev = qml.device(device, wires=2)
@@ -3304,9 +3245,6 @@ class TestIntegrationJacobianBackpropMultipleReturns:
     @pytest.mark.parametrize("interface", ["auto", "jax"])
     def test_multiple_probs_jax(self, interface, device):
         """Return Jacobian of multiple probs."""
-        from jax.config import config
-
-        config.update("jax_enable_x64", True)
         import jax
 
         dev = qml.device(device, wires=2)
@@ -3334,9 +3272,6 @@ class TestIntegrationJacobianBackpropMultipleReturns:
     @pytest.mark.parametrize("interface", ["auto", "jax"])
     def test_multiple_probs_jax_jit(self, interface, device):
         """Return Jacobian of multiple probs with Jax jit."""
-        from jax.config import config
-
-        config.update("jax_enable_x64", True)
         import jax
 
         dev = qml.device(device, wires=2)
@@ -3452,9 +3387,6 @@ class TestIntegrationJacobianBackpropMultipleReturns:
     @pytest.mark.parametrize("interface", ["auto", "jax"])
     def test_multiple_meas_jax(self, interface, device):
         """Return Jacobian of multiple measurements."""
-        from jax.config import config
-
-        config.update("jax_enable_x64", True)
         import jax
 
         dev = qml.device(device, wires=2)
@@ -3487,9 +3419,6 @@ class TestIntegrationJacobianBackpropMultipleReturns:
     @pytest.mark.parametrize("interface", ["auto", "jax"])
     def test_multiple_meas_jax_jit(self, interface, device):
         """Return Jacobian of multiple measurements with Jax jit."""
-        from jax.config import config
-
-        config.update("jax_enable_x64", True)
         import jax
 
         dev = qml.device(device, wires=2)

--- a/tests/transforms/test_compile.py
+++ b/tests/transforms/test_compile.py
@@ -465,10 +465,6 @@ class TestCompileInterfaces:
         import jax
         from jax import numpy as jnp
 
-        from jax.config import config
-
-        config.update("jax_enable_x64", True)
-
         original_qnode = qml.QNode(qfunc_emb, dev_3wires, diff_method=diff_method)
         transformed_qnode = qml.QNode(transformed_qfunc_emb, dev_3wires, diff_method=diff_method)
 
@@ -495,9 +491,6 @@ class TestCompileInterfaces:
         """Test that compilation pipelines work with jax.jit, unitary_to_rot, and fusion."""
         import jax
         from jax import numpy as jnp
-        from jax.config import config
-
-        config.update("jax_enable_x64", True)
 
         dev = qml.device("default.qubit", wires=2)
 

--- a/tests/transforms/test_optimization/test_cancel_inverses.py
+++ b/tests/transforms/test_optimization/test_cancel_inverses.py
@@ -309,11 +309,6 @@ class TestCancelInversesInterfaces:
         import jax
         from jax import numpy as jnp
 
-        # Enable float64 support
-        from jax.config import config
-
-        config.update("jax_enable_x64", True)
-
         original_qnode = qml.QNode(qfunc_all_ops, dev)
         transformed_qnode = qml.QNode(transformed_qfunc_all_ops, dev)
 

--- a/tests/transforms/test_optimization/test_commute_controlled.py
+++ b/tests/transforms/test_optimization/test_commute_controlled.py
@@ -422,10 +422,6 @@ class TestCommuteControlledInterfaces:
         import jax
         from jax import numpy as jnp
 
-        from jax.config import config
-
-        config.update("jax_enable_x64", True)
-
         original_qnode = qml.QNode(qfunc_all_ops, dev)
         transformed_qnode = qml.QNode(transformed_qfunc_all_ops, dev)
 

--- a/tests/transforms/test_optimization/test_merge_amplitude_embedding.py
+++ b/tests/transforms/test_optimization/test_merge_amplitude_embedding.py
@@ -169,9 +169,6 @@ class TestMergeAmplitudeEmbeddingInterfaces:
     def test_merge_amplitude_embedding_jax(self):
         """Test QNode in JAX interface."""
         from jax import numpy as jnp
-        from jax.config import config
-
-        config.update("jax_enable_x64", True)
 
         def qfunc(amplitude):
             qml.AmplitudeEmbedding(amplitude, wires=0)

--- a/tests/transforms/test_optimization/test_merge_rotations.py
+++ b/tests/transforms/test_optimization/test_merge_rotations.py
@@ -384,9 +384,6 @@ class TestMergeRotationsInterfaces:
         """Test QNode and gradient in JAX interface."""
         import jax
         from jax import numpy as jnp
-        from jax.config import config
-
-        config.update("jax_enable_x64", True)
 
         original_qnode = qml.QNode(qfunc_all_ops, dev)
         transformed_qnode = qml.QNode(transformed_qfunc_all_ops, dev)
@@ -411,11 +408,6 @@ class TestMergeRotationsInterfaces:
         0 rotation angles does not break things."""
 
         import jax
-
-        # Enable float64 support
-        from jax.config import config
-
-        config.update("jax_enable_x64", True)
 
         @jax.jit
         @qml.qnode(qml.device("default.qubit", wires=["w1", "w2"]), interface="jax")

--- a/tests/transforms/test_optimization/test_single_qubit_fusion.py
+++ b/tests/transforms/test_optimization/test_single_qubit_fusion.py
@@ -292,11 +292,6 @@ class TestSingleQubitFusionInterfaces:
         import jax
         from jax import numpy as jnp
 
-        # Enable float64 support
-        from jax.config import config
-
-        config.update("jax_enable_x64", True)
-
         original_qnode = qml.QNode(qfunc_all_ops, dev)
         transformed_qnode = qml.QNode(transformed_qfunc_all_ops, dev)
 
@@ -319,10 +314,6 @@ class TestSingleQubitFusionInterfaces:
         """Test QNode and gradient in JAX interface with JIT."""
         import jax
         from jax import numpy as jnp
-
-        from jax.config import config
-
-        config.update("jax_enable_x64", True)
 
         original_qnode = qml.QNode(qfunc_all_ops, dev)
         jitted_qnode = jax.jit(original_qnode)

--- a/tests/transforms/test_optimization/test_undo_swaps.py
+++ b/tests/transforms/test_optimization/test_undo_swaps.py
@@ -258,10 +258,6 @@ class TestUndoSwapsInterfaces:
         import jax
         from jax import numpy as jnp
 
-        from jax.config import config
-
-        config.update("jax_enable_x64", True)
-
         original_qnode = qml.QNode(qfunc_all_ops, dev)
         transformed_qnode = qml.QNode(transformed_qfunc_all_ops, dev)
 

--- a/tests/transforms/test_unitary_to_rot.py
+++ b/tests/transforms/test_unitary_to_rot.py
@@ -196,11 +196,6 @@ class TestDecomposeSingleQubitUnitaryTransform:
         """Test that the transform works in the JAX interface."""
         import jax
 
-        # Enable float64 support
-        from jax.config import config
-
-        config.update("jax_enable_x64", True)
-
         U = jax.numpy.array(U, dtype=jax.numpy.complex128)
 
         transformed_qfunc = unitary_to_rot(qfunc)
@@ -228,11 +223,6 @@ class TestDecomposeSingleQubitUnitaryTransform:
         """Test that the transform works in the JAX interface with JIT."""
         # pylint: disable=unused-argument
         import jax
-
-        # Enable float64 support
-        from jax.config import config
-
-        config.update("jax_enable_x64", True)
 
         U = jax.numpy.array(U, dtype=jax.numpy.complex128)
 
@@ -411,11 +401,6 @@ class TestQubitUnitaryDifferentiability:
         """Tests differentiability in jax interface."""
         import jax
         from jax import numpy as jnp
-
-        # Enable float64 support
-        from jax.config import config
-
-        config.update("jax_enable_x64", True)
 
         def qfunc_with_qubit_unitary(angles):
             z = angles[0]
@@ -687,10 +672,6 @@ class TestTwoQubitUnitaryDifferentiability:
         """Tests differentiability in jax interface."""
         import jax
         from jax import numpy as jnp
-
-        from jax.config import config
-
-        config.update("jax_enable_x64", True)
 
         U0 = jnp.array(test_two_qubit_unitaries[0], dtype=jnp.complex128)
         U1 = jnp.array(test_two_qubit_unitaries[1], dtype=jnp.complex128)


### PR DESCRIPTION
In more recent versions of jax, the `from jax.config import config` syntax is deprecated.  Instead, we should set x64 suppport via `jax.config.update("jax_enable_x64", True)`.

```
>>> from jax.config import config
/var/folders/k1/0v_kvphn55lgf_45kntf1hqm0000gq/T/ipykernel_28191/927323724.py:1: DeprecationWarning: Accessing jax.config via the jax.config submodule is deprecated.
  from jax.config import config
```

This PR removes the reference to this syntax from the docs and the tests.

Since tests are now always run with `jax.config.update("jax_enable_x64", True)` set in the setup, we no longer need to manually set it in each test, so those lines are simply removed.