### PR TITLE
Use native pytrees with jax interface

### DIFF
--- a/pennylane/devices/default_qubit_legacy.py
+++ b/pennylane/devices/default_qubit_legacy.py
@@ -18,6 +18,7 @@ It implements the necessary :class:`~pennylane._device.Device` methods as well a
 :mod:`qubit operations <pennylane.ops.qubit>`, and provides a very simple pure state
 simulation of a qubit-based quantum circuit architecture.
 """
+# pylint: disable=too-many-arguments
 import functools
 import itertools
 from string import ascii_letters as ABC
@@ -732,6 +733,10 @@ class DefaultQubitLegacy(QubitDevice):
                 or broadcasted state of shape ``(batch_size, 2**len(wires))``
             device_wires (Wires): wires that get initialized in the state
         """
+        if not qml.math.is_abstract(state):
+            norm = qml.math.linalg.norm(state, axis=-1, ord=2)
+            if not qml.math.is_abstract(norm) and not qml.math.allclose(norm, 1.0, atol=1e-10):
+                raise ValueError("Sum of amplitudes-squared does not equal one.")
 
         # translate to wire labels used by device
         device_wires = self.map_wires(device_wires)

--- a/pennylane/interfaces/execution.py
+++ b/pennylane/interfaces/execution.py
@@ -805,7 +805,7 @@ def execute(
     )
 
     if interface in jpc_interfaces:
-        results = ml_boundary_execute(tapes, execute_fn, jpc, device=device)
+        results = ml_boundary_execute(tuple(tapes), execute_fn, jpc, device=device)
     else:
         results = ml_boundary_execute(
             tapes, device, execute_fn, gradient_fn, gradient_kwargs, _n=1, max_diff=max_diff

--- a/pennylane/ops/qubit/hamiltonian.py
+++ b/pennylane/ops/qubit/hamiltonian.py
@@ -188,11 +188,11 @@ class Hamiltonian(Observable):
         method="rlf",
         id=None,
     ):
-        if qml.math.shape(coeffs)[0] != len(observables):
-            raise ValueError(
-                "Could not create valid Hamiltonian; "
-                "number of coefficients and operators does not match."
-            )
+        # if qml.math.shape(coeffs)[0] != len(observables):
+        #    raise ValueError(
+        #        "Could not create valid Hamiltonian; "
+        #        "number of coefficients and operators does not match."
+        #    )
 
         for obs in observables:
             if not isinstance(obs, Observable):
@@ -221,8 +221,7 @@ class Hamiltonian(Observable):
                     self.ops, grouping_type=grouping_type, method=method
                 )
 
-        coeffs_flat = [self._coeffs[i] for i in range(qml.math.shape(self._coeffs)[0])]
-
+        coeffs_flat = [self._coeffs[i] for i in range(len(self._ops))]
         # create the operator using each coefficient as a separate parameter;
         # this causes H.data to be a list of tensor scalars,
         # while H.coeffs is the original tensor

--- a/pennylane/ops/qubit/observables.py
+++ b/pennylane/ops/qubit/observables.py
@@ -436,11 +436,6 @@ class BasisStateProjector(Projector, Operation):
     # arguments, but with free key word arguments.
     def __init__(self, state, wires, id=None):
         wires = Wires(wires)
-        state = list(qml.math.toarray(state).astype(int))
-
-        if not set(state).issubset({0, 1}):
-            raise ValueError(f"Basis state must only consist of 0s and 1s; got {state}")
-
         super().__init__(state, wires=wires, id=id)
 
     def __new__(cls, *_, **__):  # pylint: disable=arguments-differ
@@ -494,6 +489,9 @@ class BasisStateProjector(Projector, Operation):
          [0. 0. 0. 0.]
          [0. 0. 0. 0.]]
         """
+        basis_state = list(qml.math.toarray(basis_state).astype(int))
+        if not set(basis_state).issubset({0, 1}):
+            raise ValueError(f"Basis state must only consist of 0s and 1s; got {basis_state}")
         m = np.zeros((2 ** len(basis_state), 2 ** len(basis_state)))
         idx = int("".join(str(i) for i in basis_state), 2)
         m[idx, idx] = 1
@@ -525,6 +523,9 @@ class BasisStateProjector(Projector, Operation):
         >>> BasisStateProjector.compute_eigvals([0, 1])
         [0. 1. 0. 0.]
         """
+        basis_state = list(qml.math.toarray(basis_state).astype(int))
+        if not set(basis_state).issubset({0, 1}):
+            raise ValueError(f"Basis state must only consist of 0s and 1s; got {basis_state}")
         w = np.zeros(2 ** len(basis_state))
         idx = int("".join(str(i) for i in basis_state), 2)
         w[idx] = 1
@@ -566,9 +567,6 @@ class StateVectorProjector(Projector):
     # The call signature should be the same as Projector.__new__ for the positional
     # arguments, but with free key word arguments.
     def __init__(self, state, wires, id=None):
-        wires = Wires(wires)
-        state = list(qml.math.toarray(state))
-
         super().__init__(state, wires=wires, id=id)
 
     def __new__(cls, *_, **__):  # pylint: disable=arguments-differ
@@ -649,6 +647,7 @@ class StateVectorProjector(Projector):
          [0. 0.5 0.5 0.]
          [0. 0.  0.  0.]]
         """
+        state_vector = list(qml.math.toarray(state_vector))
         return qml.math.outer(state_vector, qml.math.conj(state_vector))
 
     @staticmethod
@@ -677,6 +676,7 @@ class StateVectorProjector(Projector):
         >>> StateVectorProjector.compute_eigvals([0, 0, 1, 0])
         array([1, 0, 0, 0])
         """
+        state_vector = list(qml.math.toarray(state_vector))
         w = qml.math.zeros_like(state_vector)
         w[0] = 1
         return w
@@ -712,6 +712,7 @@ class StateVectorProjector(Projector):
         # Adapting the approach discussed in the link below to work with arbitrary complex-valued state vectors.
         # Alternatively, we could take the adjoint of the Mottonen decomposition for the state vector.
         # https://quantumcomputing.stackexchange.com/questions/10239/how-can-i-fill-a-unitary-knowing-only-its-first-column
+        state_vector = qml.math.toarray(state_vector)
         phase = qml.math.exp(-1j * qml.math.angle(state_vector[0]))
         psi = phase * state_vector
         denominator = qml.math.sqrt(2 + 2 * psi[0])

--- a/pennylane/ops/qubit/special_unitary.py
+++ b/pennylane/ops/qubit/special_unitary.py
@@ -402,6 +402,9 @@ class SpecialUnitary(Operation):
     grad_method = None
     """Gradient computation method."""
 
+    def _flatten(self):
+        return self.data, (self.wires, tuple())
+
     def __init__(self, theta, wires, id=None):
         num_wires = 1 if isinstance(wires, int) else len(wires)
         self.hyperparameters["num_wires"] = num_wires

--- a/pennylane/ops/qubit/state_preparation.py
+++ b/pennylane/ops/qubit/state_preparation.py
@@ -175,12 +175,6 @@ class StatePrep(StatePrepBase):
         if state.shape[1] != 2 ** len(self.wires):
             raise ValueError("State vector must have shape (2**wires,) or (batch_size, 2**wires).")
 
-        param = math.cast(state, np.complex128)
-        if not math.is_abstract(param):
-            norm = math.linalg.norm(param, axis=-1, ord=2)
-            if not math.allclose(norm, 1.0, atol=1e-10):
-                raise ValueError("Sum of amplitudes-squared does not equal one.")
-
     @staticmethod
     def compute_decomposition(state, wires):
         r"""Representation of the operator as a product of other operators (static method). :
@@ -203,9 +197,18 @@ class StatePrep(StatePrepBase):
         [MottonenStatePreparation(tensor([1, 0, 0, 0], requires_grad=True), wires=[0, 1])]
 
         """
+        if not math.is_abstract(state):
+            norm = math.linalg.norm(state, axis=-1, ord=2)
+            if not math.allclose(norm, 1.0, atol=1e-10):
+                raise ValueError("Sum of amplitudes-squared does not equal one.")
         return [MottonenStatePreparation(state, wires)]
 
     def state_vector(self, wire_order=None):
+        if not math.is_abstract(self.data[0]):
+            norm = math.linalg.norm(self.data[0], axis=-1, ord=2)
+            if not math.allclose(norm, 1.0, atol=1e-10):
+                raise ValueError("Sum of amplitudes-squared does not equal one.")
+
         num_op_wires = len(self.wires)
         op_vector_shape = (-1,) + (2,) * num_op_wires if self.batch_size else (2,) * num_op_wires
         op_vector = math.reshape(self.parameters[0], op_vector_shape)


### PR DESCRIPTION
[sc-42956]

Part of the motivation between binding pennylane objects (operators, measurements, and tapes) as pytrees was the opportunity to improve how we bind derivatives to jax. 

Now that all pennylane operators are registered as valid pytrees, we can use that to alter how we bind derivatives to jax.

The benefits of this change are:
* Simplified code

The downsides are:

Sometimes operators are not valid pytrees for some reason, or are not able to store tangents in place of the original data. Either of those conditions will break the machine learning interface.