### PR TITLE
Debug qubit device expval method with batch

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -661,7 +661,12 @@
 * Conversion of circuits to openqasm now decomposes to a depth of 10, allowing support 
   for operators requiring more than 2 iterations of decomposition, such as the `ApproxTimeEvolution` gate.
   [(#4951)](https://github.com/PennyLaneAI/pennylane/pull/4951)
-  
+
+* In default.qubit, the adjustment of expval indexing when used with batches and the BasisStateProjector 
+  operator ensures accurate retrieval of probabilities for the desired state across all entries in the batch.
+  [(#4971)](https://github.com/PennyLaneAI/pennylane/pull/4971)
+
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):
@@ -678,6 +683,7 @@ Amintor Dusko,
 Pieter Eendebak,
 Lillian Frederiksen,
 Pietropaolo Frisoni,
+Jérémie Gince,
 Josh Izaac,
 Juan Giraldo,
 Emiliano Godinez Ramirez,

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -1313,7 +1313,7 @@ class QubitDevice(Device):
             probs = self.probability(
                 wires=observable.wires, shot_range=shot_range, bin_size=bin_size
             )
-            return probs[idx]
+            return probs[..., idx]
 
         # exact expectation value
         if self.shots is None:


### PR DESCRIPTION
**Context:** When utilizing a qubit device with batch processing, expval output, and BasisStateProjector, the probabilities were incorrectly indexed in the wrong dimension. This resulted in the expval output returning the probabilities of a vector within the batch, rather than providing the probabilities of the desired state for all entries in the batch.

**Description of the Change:** This pull request focuses on a specific modification—adjusting the indexing of probs from probs[idx] to probs[..., idx].

**Benefits:** This change enhances the functionality, allowing the use of batch processing with BasisStateProjector in expval.

**Possible Drawbacks:** There are currently no known drawbacks associated with this modification.

**Related GitHub Issues:** [#4975](https://github.com/PennyLaneAI/pennylane/issues/4975) .