### PR TITLE
Preparation for release candidate `v0.34.0`

### DIFF
--- a/doc/development/release_notes.md
+++ b/doc/development/release_notes.md
@@ -3,7 +3,7 @@ Release notes
 
 This page contains the release notes for PennyLane.
 
-.. mdinclude:: ../releases/changelog-dev.md
+.. mdinclude:: ../releases/changelog-0.34.0.md
 
 .. mdinclude:: ../releases/changelog-0.33.1.md
 

--- a/doc/releases/changelog-0.33.1.md
+++ b/doc/releases/changelog-0.33.1.md
@@ -1,6 +1,6 @@
 :orphan:
 
-# Release 0.33.1 (current release)
+# Release 0.33.1
 
 <h3>Bug fixes 🐛</h3>
 

--- a/doc/releases/changelog-0.34.0.md
+++ b/doc/releases/changelog-0.34.0.md
@@ -1,6 +1,6 @@
 :orphan:
 
-# Release 0.34.0-dev (development release)
+# Release 0.34.0 (current release)
 
 <h3>New features since last release</h3>
 

--- a/pennylane/_version.py
+++ b/pennylane/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.34.0-dev"
+__version__ = "0.34.0"


### PR DESCRIPTION
Updates PennyLane as we're entering a new development version (release of v0.34.0 coming up):

Preparation of release candidate:

- rename changelog-dev.md to changelog-0.34.0.md,
- change changelog-dev reference to changelog-0.34.0 reference in release_notes.md,
- move "current release" label from changelog-0.33.1 to changelog-0.34.0,
- In changelog-0.34.0.md update title from 0.34.0-dev to 0.34.0
- change _version.py reference from 0.34.0-dev to 0.34.0


```
rc    master
|     |
|      - update changelog for new 0.35.0-dev
|    /
|   /
|  /
| /
|/
- (**THIS PR**) changelog and version updates for 0.34.0 RC branch
|
| 
```