### PR TITLE
Deprecate star operator for matrix and tensor products in PauliWord and PauliSentence

### DIFF
--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -100,6 +100,12 @@ Pending deprecations
   - Deprecated in v0.34
   - Will be removed in v0.35
 
+* ``PauliWord`` and ``PauliSentence`` no longer use ``*`` for matrix and tensor products,
+  but instead use ``@`` to conform with the PennyLane standard.
+
+  - Deprecated in v0.34
+  - Will be removed in v0.35
+
 Completed deprecation cycles
 ----------------------------
 

--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -101,7 +101,7 @@ Pending deprecations
   - Will be removed in v0.35
 
 * ``PauliWord`` and ``PauliSentence`` no longer use ``*`` for matrix and tensor products,
-  but instead use ``@`` to conform with the PennyLane standard.
+  but instead use ``@`` to conform with the PennyLane convention.
 
   - Deprecated in v0.34
   - Will be removed in v0.35

--- a/doc/releases/changelog-0.34.0.md
+++ b/doc/releases/changelog-0.34.0.md
@@ -546,6 +546,10 @@
   becomes obsolete and will be removed in v0.35.
   [(#4959)](https://github.com/PennyLaneAI/pennylane/pull/4959)
 
+* The star operator `*` for matrix and tensor products of `PauliWord` and `PauliSentence` instances
+  will be removed. Use `@` instead.
+  [(#)]()
+
 <h3>Documentation 📝</h3>
 
 * Documentation for unitaries and operations decompositions was moved from `qml.transforms` to `qml.ops.ops_math`.

--- a/doc/releases/changelog-0.34.0.md
+++ b/doc/releases/changelog-0.34.0.md
@@ -548,7 +548,7 @@
 
 * The star operator `*` for matrix and tensor products of `PauliWord` and `PauliSentence` instances
   will be removed. Use `@` instead.
-  [(#)]()
+  [(#4982)](https://github.com/PennyLaneAI/pennylane/pull/4982)
 
 <h3>Documentation 📝</h3>
 

--- a/pennylane/pauli/pauli_arithmetic.py
+++ b/pennylane/pauli/pauli_arithmetic.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """The Pauli arithmetic abstract reduced representation classes"""
+import warnings
 from copy import copy
 from functools import reduce, lru_cache
 from typing import Iterable
@@ -172,7 +173,7 @@ class PauliWord(dict):
     def __hash__(self):
         return hash(frozenset(self.items()))
 
-    def __mul__(self, other):
+    def __matmul__(self, other):
         """Multiply two Pauli words together using the matrix product if wires overlap
         and the tensor product otherwise.
 
@@ -201,6 +202,13 @@ class PauliWord(dict):
                 result[wire] = term
 
         return PauliWord(result), coeff
+
+    def __mul__(self, other):
+        warnings.warn(
+            "Matrix/Tensor multiplication using the * operator on PauliWords and PauliSentences is deprecated, use @ instead.",
+            qml.PennyLaneDeprecationWarning,
+        )
+        return self @ other
 
     def __str__(self):
         """String representation of a PauliWord."""
@@ -394,7 +402,7 @@ class PauliSentence(dict):
         memo[id(self)] = res
         return res
 
-    def __mul__(self, other):
+    def __matmul__(self, other):
         """Multiply two Pauli sentences by iterating over each sentence and multiplying
         the Pauli words pair-wise"""
         final_ps = PauliSentence()
@@ -404,10 +412,17 @@ class PauliSentence(dict):
 
         for pw1 in self:
             for pw2 in other:
-                prod_pw, coeff = pw1 * pw2
+                prod_pw, coeff = pw1 @ pw2
                 final_ps[prod_pw] = final_ps[prod_pw] + coeff * self[pw1] * other[pw2]
 
         return final_ps
+
+    def __mul__(self, other):
+        warnings.warn(
+            "Matrix/Tensor multiplication using the * operator on PauliWords and PauliSentences is deprecated, use @ instead.",
+            qml.PennyLaneDeprecationWarning,
+        )
+        return self @ other
 
     def __str__(self):
         """String representation of the PauliSentence."""

--- a/tests/pauli/test_pauli_arithmetic.py
+++ b/tests/pauli/test_pauli_arithmetic.py
@@ -48,6 +48,32 @@ ps4 = PauliSentence({pw4: 1})
 ps5 = PauliSentence({})
 
 
+class TestDeprecations:
+    def test_deprecation_warning_PauliWord(
+        self,
+    ):
+        """Test that a PennyLaneDeprecationWarning is raised when using * for matrix multiplication of two PauliWords"""
+        pw1 = PauliWord({0: "X"})
+        pw2 = PauliWord({0: "Y"})
+
+        with pytest.warns(
+            qml.PennyLaneDeprecationWarning, match="Matrix/Tensor multiplication using"
+        ):
+            pw1 * pw2
+
+    def test_deprecation_warning_PauliSentence(
+        self,
+    ):
+        """Test that a PennyLaneDeprecationWarning is raised when using * for matrix multiplication of two PauliSentences"""
+        ps1 = PauliSentence({PauliWord({0: "X"}): 1})
+        ps2 = PauliSentence({PauliWord({0: "Y"}): 1})
+
+        with pytest.warns(
+            qml.PennyLaneDeprecationWarning, match="Matrix/Tensor multiplication using"
+        ):
+            ps1 * ps2
+
+
 class TestPauliWord:
     def test_identity_removed_on_init(self):
         """Test that identities are removed on init."""

--- a/tests/pauli/test_pauli_arithmetic.py
+++ b/tests/pauli/test_pauli_arithmetic.py
@@ -53,25 +53,25 @@ class TestDeprecations:
         self,
     ):
         """Test that a PennyLaneDeprecationWarning is raised when using * for matrix multiplication of two PauliWords"""
-        pw1 = PauliWord({0: "X"})
-        pw2 = PauliWord({0: "Y"})
+        pauli1 = PauliWord({0: "X"})
+        pauli2 = PauliWord({0: "Y"})
 
         with pytest.warns(
             qml.PennyLaneDeprecationWarning, match="Matrix/Tensor multiplication using"
         ):
-            pw1 * pw2
+            pauli1 * pauli2
 
     def test_deprecation_warning_PauliSentence(
         self,
     ):
         """Test that a PennyLaneDeprecationWarning is raised when using * for matrix multiplication of two PauliSentences"""
-        ps1 = PauliSentence({PauliWord({0: "X"}): 1})
-        ps2 = PauliSentence({PauliWord({0: "Y"}): 1})
+        pauli1 = PauliSentence({PauliWord({0: "X"}): 1})
+        pauli2 = PauliSentence({PauliWord({0: "Y"}): 1})
 
         with pytest.warns(
             qml.PennyLaneDeprecationWarning, match="Matrix/Tensor multiplication using"
         ):
-            ps1 * ps2
+            pauli1 * pauli2
 
 
 class TestPauliWord:

--- a/tests/pauli/test_pauli_arithmetic.py
+++ b/tests/pauli/test_pauli_arithmetic.py
@@ -59,7 +59,7 @@ class TestDeprecations:
         with pytest.warns(
             qml.PennyLaneDeprecationWarning, match="Matrix/Tensor multiplication using"
         ):
-            pauli1 * pauli2
+            _ = pauli1 * pauli2
 
     def test_deprecation_warning_PauliSentence(
         self,
@@ -71,7 +71,7 @@ class TestDeprecations:
         with pytest.warns(
             qml.PennyLaneDeprecationWarning, match="Matrix/Tensor multiplication using"
         ):
-            pauli1 * pauli2
+            _ = pauli1 * pauli2
 
 
 class TestPauliWord:


### PR DESCRIPTION
We are going to change the behavior of PauliWord and PauliSentence in v0.35:
 * `*` $\Rightarrow$ `@` for matrix (and tensor) products to conform with PennyLane convention
 * for scalar multiplication $\Rightarrow$ `*` (in the next release)

To get a head start on this and minimize friction in the next release, I would like to start this deprecation cycle already now.