### PR TITLE
Jax jit support for single precision mode

### DIFF
--- a/doc/releases/changelog-0.34.0.md
+++ b/doc/releases/changelog-0.34.0.md
@@ -704,6 +704,7 @@
   [(#5987)](https://github.com/PennyLaneAI/pennylane/pull/4987)
   
 * The jax-jit interface can now be used with float32 mode.
+  [(#4990)](https://github.com/PennyLaneAI/pennylane/pull/4990)
 
 <h3>Contributors ✍️</h3>
 

--- a/doc/releases/changelog-0.34.0.md
+++ b/doc/releases/changelog-0.34.0.md
@@ -703,6 +703,8 @@
 * `MPLDrawer` does not add the bonus space for classical wires when no classical wires are present.
   [(#5987)](https://github.com/PennyLaneAI/pennylane/pull/4987)
   
+* The jax-jit interface can now be used with float32 mode.
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane/interfaces/jax_jit.py
+++ b/pennylane/interfaces/jax_jit.py
@@ -71,11 +71,13 @@ def _set_parameters_on_copy(tapes, params):
 
 
 def _jax_dtype(m_type):
-    if m_type != float:
-        return jnp.dtype(m_type)
-    if jax.config.jax_enable_x64:
-        return jnp.float64
-    return jnp.float32
+    if m_type == int:
+        return jnp.int64 if jax.config.jax_enable_x64 else jnp.int32
+    if m_type == float:
+        return jnp.float64 if jax.config.jax_enable_x64 else jnp.float32
+    if m_type == complex:
+        return jnp.complex128 if jax.config.jax_enable_x64 else jnp.complex64
+    return jnp.dtype(m_type)
 
 
 def _result_shape_dtype_struct(tape: "qml.tape.QuantumScript", device: "qml.Device"):

--- a/pennylane/interfaces/jax_jit.py
+++ b/pennylane/interfaces/jax_jit.py
@@ -46,7 +46,6 @@ from .jacobian_products import _compute_jvps
 
 from .jax import _NonPytreeWrapper
 
-dtype = jnp.float64
 Zero = jax.custom_derivatives.SymbolicZero
 
 
@@ -71,18 +70,26 @@ def _set_parameters_on_copy(tapes, params):
     return tuple(t.bind_new_parameters(a, list(range(len(a)))) for t, a in zip(tapes, params))
 
 
+def _jax_dtype(m_type):
+    if m_type != float:
+        return jnp.dtype(m_type)
+    if jax.config.jax_enable_x64:
+        return jnp.float64
+    return jnp.float32
+
+
 def _result_shape_dtype_struct(tape: "qml.tape.QuantumScript", device: "qml.Device"):
     """Auxiliary function for creating the shape and dtype object structure
     given a tape."""
 
     shape = tape.shape(device)
     if len(tape.measurements) == 1:
-        tape_dtype = jnp.dtype(tape.numeric_type)
+        m_dtype = _jax_dtype(tape.measurements[0].numeric_type)
         if tape.shots.has_partitioned_shots:
-            return tuple(jax.ShapeDtypeStruct(s, tape_dtype) for s in shape)
-        return jax.ShapeDtypeStruct(tuple(shape), tape_dtype)
+            return tuple(jax.ShapeDtypeStruct(s, m_dtype) for s in shape)
+        return jax.ShapeDtypeStruct(tuple(shape), m_dtype)
 
-    tape_dtype = tuple(jnp.dtype(elem) for elem in tape.numeric_type)
+    tape_dtype = tuple(_jax_dtype(m.numeric_type) for m in tape.measurements)
     if tape.shots.has_partitioned_shots:
         return tuple(
             tuple(jax.ShapeDtypeStruct(tuple(s), d) for s, d in zip(si, tape_dtype)) for si in shape
@@ -129,7 +136,7 @@ def _execute_wrapper(params, tapes, execute_fn, _, device) -> ResultBatch:
 
     def pure_callback_wrapper(p):
         new_tapes = _set_parameters_on_copy(tapes.vals, p)
-        res = tuple(execute_fn(new_tapes))
+        res = tuple(_to_jax(execute_fn(new_tapes)))
         # When executed under `jax.vmap` the `result_shapes_dtypes` will contain
         # the shape without the vmap dimensions, while the function here will be
         # executed with objects containing the vmap dimensions. So res[i].ndim
@@ -143,7 +150,7 @@ def _execute_wrapper(params, tapes, execute_fn, _, device) -> ResultBatch:
         return jax.tree_map(lambda r, s: r.T if r.ndim > s.ndim else r, res, shape_dtype_structs)
 
     out = jax.pure_callback(pure_callback_wrapper, shape_dtype_structs, params, vectorized=True)
-    return _to_jax(out)
+    return out
 
 
 def _execute_and_compute_jvp(tapes, execute_fn, jpc, device, primals, tangents):
@@ -165,7 +172,7 @@ def _execute_and_compute_jvp(tapes, execute_fn, jpc, device, primals, tangents):
 
     def wrapper(inner_params):
         new_tapes = _set_parameters_on_copy(tapes.vals, inner_params)
-        return jpc.execute_and_compute_jacobian(new_tapes)
+        return _to_jax(jpc.execute_and_compute_jacobian(new_tapes))
 
     res_struct = tuple(_result_shape_dtype_struct(t, device) for t in tapes.vals)
     jac_struct = tuple(_jac_shape_dtype_struct(t, device) for t in tapes.vals)
@@ -173,7 +180,7 @@ def _execute_and_compute_jvp(tapes, execute_fn, jpc, device, primals, tangents):
 
     jvps = _compute_jvps(jacobians, tangents_trainable, tapes.vals)
 
-    return _to_jax(results), _to_jax(jvps)
+    return results, jvps
 
 
 def _vjp_fwd(params, tapes, execute_fn, jpc, device):
@@ -186,7 +193,7 @@ def _vjp_bwd(tapes, execute_fn, jpc, device, params, dy):
 
     def wrapper(inner_params, inner_dy):
         new_tapes = _set_parameters_on_copy(tapes.vals, inner_params)
-        return tuple(jpc.compute_vjp(new_tapes, inner_dy))
+        return _to_jax(jpc.compute_vjp(new_tapes, inner_dy))
 
     vjp_shape = _pytree_shape_dtype_struct(params)
     return (jax.pure_callback(wrapper, vjp_shape, params, dy),)

--- a/tests/interfaces/default_qubit_2_integration/test_jax_jit_qnode_default_qubit_2.py
+++ b/tests/interfaces/default_qubit_2_integration/test_jax_jit_qnode_default_qubit_2.py
@@ -2930,7 +2930,6 @@ class TestSinglePrecision:
         jax.config.update("jax_enable_x64", False)
 
         try:
-
             tol = 2e-2 if diff_method == "finite-diff" else 1e-6
 
             @jax.jit

--- a/tests/interfaces/default_qubit_2_integration/test_jax_jit_qnode_default_qubit_2.py
+++ b/tests/interfaces/default_qubit_2_integration/test_jax_jit_qnode_default_qubit_2.py
@@ -2905,20 +2905,59 @@ class TestSubsetArgnums:
             assert np.allclose(jac[1], expected[1], atol=tol)
 
 
-@pytest.mark.parametrize("diff_method", ("adjoint", "parameter-shift"))
-def test_float32_return(diff_method):
-    """Test that jax jit works when float64 mode is disabled."""
-    jax.config.update("jax_enable_x64", False)
+class TestSinglePrecision:
+    @pytest.mark.parametrize("diff_method", ("adjoint", "parameter-shift"))
+    def test_float32_return(self, diff_method):
+        """Test that jax jit works when float64 mode is disabled."""
+        jax.config.update("jax_enable_x64", False)
 
-    try:
+        try:
 
-        @jax.jit
-        @qml.qnode(qml.device("default.qubit"), diff_method=diff_method)
-        def circuit(x):
-            qml.RX(x, wires=0)
-            return qml.expval(qml.PauliZ(0))
+            @jax.jit
+            @qml.qnode(qml.device("default.qubit"), diff_method=diff_method)
+            def circuit(x):
+                qml.RX(x, wires=0)
+                return qml.expval(qml.PauliZ(0))
 
-        grad = jax.grad(circuit)(jax.numpy.array(0.1))
-        assert qml.math.allclose(grad, -np.sin(0.1))
-    finally:
-        jax.config.update("jax_enable_x64", True)
+            grad = jax.grad(circuit)(jax.numpy.array(0.1))
+            assert qml.math.allclose(grad, -np.sin(0.1))
+        finally:
+            jax.config.update("jax_enable_x64", True)
+
+    @pytest.mark.parametrize("diff_method", ("adjoint", "finite-diff"))
+    def test_complex64_return(self, diff_method):
+        """Test that jax jit works with differentiating the state."""
+        jax.config.update("jax_enable_x64", False)
+
+        try:
+
+            tol = 2e-2 if diff_method == "finite-diff" else 1e-6
+
+            @jax.jit
+            @qml.qnode(qml.device("default.qubit", wires=1), diff_method=diff_method)
+            def circuit(x):
+                qml.RX(x, wires=0)
+                return qml.state()
+
+            j = jax.jacobian(circuit, holomorphic=True)(jax.numpy.array(0.1 + 0j))
+            assert qml.math.allclose(j, [-np.sin(0.05) / 2, -np.cos(0.05) / 2 * 1j], atol=tol)
+
+        finally:
+            jax.config.update("jax_enable_x64", True)
+
+    def test_int32_return(self):
+        """Test that jax jit forward execution works with samples and int32"""
+
+        jax.config.update("jax_enable_x64", False)
+
+        try:
+
+            @jax.jit
+            @qml.qnode(qml.device("default.qubit", shots=10), diff_method=qml.gradients.param_shift)
+            def circuit(x):
+                qml.RX(x, wires=0)
+                return qml.sample(wires=0)
+
+            _ = circuit(jax.numpy.array(0.1))
+        finally:
+            jax.config.update("jax_enable_x64", True)


### PR DESCRIPTION
Currently PennyLane is raising errors whenever jax-jit is used with single precision. This eliminates those errors.