### PR TITLE
update snapshot; little docs changes

### DIFF
--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -9,13 +9,13 @@ deprecations are listed below.
 Pending deprecations
 --------------------
 
-* `qml.transforms.one_qubit_decomposition` and `qml.transforms.two_qubit_decomposition` are deprecated. Instead,
-  you should use `qml.ops.one_qubit_decomposition` and `qml.ops.two_qubit_decomposition` .
+* ``qml.transforms.one_qubit_decomposition`` and ``qml.transforms.two_qubit_decomposition`` are deprecated. Instead,
+  you should use ``qml.ops.one_qubit_decomposition`` and ``qml.ops.two_qubit_decomposition`` .
 
   - Deprecated in v0.34
   - Will be removed in v0.35
 
-* `Observable.return_type` is deprecated. Instead, you should inspect the type
+* ``Observable.return_type`` is deprecated. Instead, you should inspect the type
   of the surrounding measurement process.
 
   - Deprecated in v0.34

--- a/doc/introduction/inspecting_circuits.rst
+++ b/doc/introduction/inspecting_circuits.rst
@@ -136,7 +136,7 @@ During normal execution, the snapshots are ignored:
 
     @qml.qnode(dev, interface=None)
     def circuit():
-        qml.Snapshot(measurement=qml.expval(qml.PauliZ(0))
+        qml.Snapshot(measurement=qml.expval(qml.PauliZ(0)))
         qml.Hadamard(wires=0)
         qml.Snapshot("very_important_state")
         qml.CNOT(wires=[0, 1])
@@ -149,8 +149,8 @@ results.
 
 >>> qml.snapshots(circuit)()
 {0: 1.0,
-'very_important_state': array([0.70710678, 0., 0.70710678, 0.]),
-2: array([0.70710678, 0., 0., 0.70710678]),
+'very_important_state': array([0.707+0.j, 0.+0.j, 0.707+0.j, 0.+0.j]),
+2: array([0.707+0.j, 0.+0.j, 0.+0.j, 0.707+0.j]),
 'execution_results': 0.0}
 
 Graph representation

--- a/pennylane/debugging.py
+++ b/pennylane/debugging.py
@@ -81,8 +81,8 @@ def snapshots(qnode):
 
     >>> qml.snapshots(circuit)()
     {0: 1.0,
-    'very_important_state': array([0.70710678, 0.        , 0.70710678, 0.        ]),
-    2: array([0.70710678, 0.        , 0.        , 0.70710678]),
+    'very_important_state': array([0.70710678+0.j, 0.        +0.j, 0.70710678+0.j, 0.        +0.j]),
+    2: array([0.70710678+0.j, 0.        +0.j, 0.        +0.j, 0.70710678+0.j]),
     'execution_results': 0.0}
     """
 

--- a/pennylane/devices/qubit/apply_operation.py
+++ b/pennylane/devices/qubit/apply_operation.py
@@ -365,7 +365,8 @@ def apply_snapshot(op: qml.Snapshot, state, is_state_batched: bool = False, debu
         if measurement:
             snapshot = qml.devices.qubit.measure(measurement, state)
         else:
-            snapshot = math.flatten(state)
+            flat_shape = (math.shape(state)[0], -1) if is_state_batched else (-1,)
+            snapshot = math.cast(math.reshape(state, flat_shape), complex)
         if op.tag:
             debugger.snapshots[op.tag] = snapshot
         else:

--- a/pennylane/measurements/shots.py
+++ b/pennylane/measurements/shots.py
@@ -114,6 +114,13 @@ class Shots:
     >>> shots.total_shots, shots.shot_vector
     (1210, (ShotCopies(10 shots x 1), ShotCopies(100 shots x 4), ShotCopies(200 shots x 4)))
 
+    Example constructing a Shots instance by multiplying an existing one by an int or float:
+
+    >>> Shots(100) * 2
+    Shots(total_shots=200, shot_vector=(ShotCopies(200 shots x 1),))
+    >>> Shots([7, (100, 2)]) * 1.5
+    Shots(total_shots=310, shot_vector=(ShotCopies(10 shots x 1), ShotCopies(150 shots x 2)))
+
     One should also note that specifying a single tuple of length 2 is considered two different
     shot values, and *not* a tuple-pair representing shots and copies to avoid special behaviour
     depending on the iterable type:

--- a/tests/devices/qubit/test_apply_operation.py
+++ b/tests/devices/qubit/test_apply_operation.py
@@ -624,6 +624,17 @@ class TestSnapshot:
         assert debugger.snapshots[0].shape == ()
         assert debugger.snapshots[0] == qml.devices.qubit.measure(measurement, initial_state)
 
+    def test_batched_state(self, ml_framework):
+        """Test that batched states create batched snapshots."""
+        initial_state = qml.math.asarray([[1.0, 0.0], [0.0, 0.1]], like=ml_framework)
+        debugger = self.Debugger()
+        new_state = apply_operation(
+            qml.Snapshot(), initial_state, is_state_batched=True, debugger=debugger
+        )
+        assert new_state.shape == initial_state.shape
+        assert set(debugger.snapshots) == {0}
+        assert np.array_equal(debugger.snapshots[0], initial_state)
+
 
 @pytest.mark.parametrize("method", methods)
 class TestRXCalcGrad:


### PR DESCRIPTION
**Context:**
Reviewed my PRs, found some stuffs.

**Description of the Change:**
- fix code markdown in deprecations file
- add examples to `Shots` docs on creating a new Shots instance by scaling an old one
- bugfix: `Snapshot` wrongly flattened batched states, so I handle it accordingly (for `default.qubit`, at least)
- bugfix: `Snapshot` assumed the current device state is complex, but `default.qubit` does not, so I always cast to complex in `apply_operation` when getting the state. Fixed the associated docs as well.

**Benefits:**
Improved docs, `Snapshot` is fixed up

**Possible Drawbacks:**
I am actually changing something (`Snapshot`) right before a release.