### PR TITLE
Pauliadd

### DIFF
--- a/pennylane/pauli/pauli_arithmetic.py
+++ b/pennylane/pauli/pauli_arithmetic.py
@@ -462,6 +462,14 @@ class PauliSentence(dict):
                 self[other] = 1.0
             return self
 
+        if isinstance(other, TensorLike):
+            IdWord = PauliWord({})
+            if IdWord in self:
+                self[IdWord] += other
+            else:
+                self[IdWord] = other
+            return self
+
     def __copy__(self):
         """Copy the PauliSentence instance."""
         copied_ps = {}

--- a/pennylane/pauli/pauli_arithmetic.py
+++ b/pennylane/pauli/pauli_arithmetic.py
@@ -454,12 +454,12 @@ class PauliSentence(dict):
                 else:
                     self[key] = other[key]
             return self
-        
+
         if isinstance(other, PauliWord):
             if other in self:
-                self[other] += 1.
+                self[other] += 1.0
             else:
-                self[other] = 1.
+                self[other] = 1.0
             return self
 
     def __copy__(self):

--- a/pennylane/pauli/pauli_arithmetic.py
+++ b/pennylane/pauli/pauli_arithmetic.py
@@ -236,18 +236,18 @@ class PauliWord(dict):
     #     if isinstance(other, PauliSentence):
     #         res = copy(other)
     #         return res + PauliSentence({self:1.})
-        
+
     #     elif isinstance(other, TensorLike):
     #         IdWord = PauliWord({0:I})
     #         res = PauliSentence({self:1., IdWord: other})
     #         return res
-        
+
     #     elif isinstance(other, PauliWord):
     #         return PauliSentence({self: 1., other: 1.})
     #     raise TypeError(
     #         f"PauliWord can only be added to other PauliWords or PauliSentences. Attempting to add by {other} of type {type(other)}"
     #     )
-    
+
     # __radd__ = __add__
 
     def __truediv__(self, other):
@@ -431,24 +431,26 @@ class PauliSentence(dict):
                 larger_ps[key] += smaller_ps[key]
 
             return larger_ps
-        
+
         elif isinstance(other, PauliWord):
             res = copy(self)
-            if len(other)==0:
-                # Note that empty PauliWord is treated as Identity
-                return res
-            return res + PauliSentence({other:1.})
-        
-        elif isinstance(other, TensorLike):
-            res = copy(self)
-            IdWord = PauliWord({0:I})
-            res[IdWord] = 1.
+            if other in res:
+                res[other] += 1.0
+            else:
+                res[other] = 1.0
             return res
 
-        raise TypeError(
-            f"Cannot add {other} of type {type(other)} to PauliSentence"
-        )
-    
+        elif isinstance(other, TensorLike):
+            res = copy(self)
+            IdWord = PauliWord({})
+            if IdWord in res:
+                res[IdWord] += other
+            else:
+                res[IdWord] = other
+            return res
+
+        raise TypeError(f"Cannot add {other} of type {type(other)} to PauliSentence")
+
     __radd__ = __add__
 
     def __iadd__(self, other):

--- a/pennylane/pauli/pauli_arithmetic.py
+++ b/pennylane/pauli/pauli_arithmetic.py
@@ -231,24 +231,16 @@ class PauliWord(dict):
 
     __rmul__ = __mul__
 
-    # def __add__(self, other):
-    #     """Add PauliWords/Sentences"""
-    #     if isinstance(other, PauliSentence):
-    #         res = copy(other)
-    #         return res + PauliSentence({self:1.})
+    def __add__(self, other):
+        """Add PauliWords/Sentences"""
+        if isinstance(other, PauliWord):
+            return PauliSentence({self: 1.0, other: 1.0})
+        return NotImplemented
+        # raise TypeError(
+        #     f"PauliWord can only be added to other PauliWords or PauliSentences. Attempting to add {other} of type {type(other)} to {self}"
+        # )
 
-    #     elif isinstance(other, TensorLike):
-    #         IdWord = PauliWord({0:I})
-    #         res = PauliSentence({self:1., IdWord: other})
-    #         return res
-
-    #     elif isinstance(other, PauliWord):
-    #         return PauliSentence({self: 1., other: 1.})
-    #     raise TypeError(
-    #         f"PauliWord can only be added to other PauliWords or PauliSentences. Attempting to add by {other} of type {type(other)}"
-    #     )
-
-    # __radd__ = __add__
+    __radd__ = __add__
 
     def __truediv__(self, other):
         """Divide a PauliWord by a scalar"""
@@ -455,12 +447,20 @@ class PauliSentence(dict):
 
     def __iadd__(self, other):
         """Inplace addition of two Pauli sentence together by adding terms of other to self"""
-        for key in other:
-            if key in self:
-                self[key] += other[key]
+        if isinstance(other, PauliSentence):
+            for key in other:
+                if key in self:
+                    self[key] += other[key]
+                else:
+                    self[key] = other[key]
+            return self
+        
+        if isinstance(other, PauliWord):
+            if other in self:
+                self[other] += 1.
             else:
-                self[key] = other[key]
-        return self
+                self[other] = 1.
+            return self
 
     def __copy__(self):
         """Copy the PauliSentence instance."""

--- a/tests/pauli/test_pauli_arithmetic.py
+++ b/tests/pauli/test_pauli_arithmetic.py
@@ -517,8 +517,8 @@ class TestPauliSentence:
     add_ps_pw = list(enumerate(words))  # tuples of (i, pw_i)
     add_ps_pw = (
         (ps1, pw1, PauliSentence({pw1: 2.23, pw2: 4j, pw3: -0.5})),
-        (ps1, pw2, PauliSentence({pw1: 1.23, pw2: 1+4j, pw3: -0.5})),
-        (ps1, pw4, PauliSentence({pw1: 1.23, pw2: 4j, pw3: -0.5, pw4: 1.})),
+        (ps1, pw2, PauliSentence({pw1: 1.23, pw2: 1 + 4j, pw3: -0.5})),
+        (ps1, pw4, PauliSentence({pw1: 1.23, pw2: 4j, pw3: -0.5, pw4: 1.0})),
     )
 
     @pytest.mark.parametrize("ps, pw, true_res", add_ps_pw)
@@ -574,15 +574,15 @@ class TestPauliSentence:
 
         assert copied_string1 == result  # Check if the modified object matches the expected result
         assert copied_string2 == string2  # Ensure the original object is not modified
-    
+
     @pytest.mark.parametrize("ps, pw, res", add_ps_pw)
     def test_iadd_ps_pw(self, ps, pw, res):
         """Test that the correct result of inplace addition with PauliWord is produced and other object is not changed."""
         copy_ps1 = copy(ps)
         copy_ps2 = copy(ps)
         copy_ps1 += pw
-        assert copy_ps1 == res # Check if the modified object matches the expected result
-        assert copy_ps2 == ps # Ensure the original object is not modified
+        assert copy_ps1 == res  # Check if the modified object matches the expected result
+        assert copy_ps2 == ps  # Ensure the original object is not modified
 
     @pytest.mark.parametrize("ps, match", ps_match)
     def test_to_mat_error_empty(self, ps, match):

--- a/tests/pauli/test_pauli_arithmetic.py
+++ b/tests/pauli/test_pauli_arithmetic.py
@@ -514,11 +514,11 @@ class TestPauliSentence:
         assert string1 == copy_ps1
         assert string2 == copy_ps2
 
-    add_ps_pw = list(enumerate(words))  # tuples of (i, pw_i)
     add_ps_pw = (
         (ps1, pw1, PauliSentence({pw1: 2.23, pw2: 4j, pw3: -0.5})),
         (ps1, pw2, PauliSentence({pw1: 1.23, pw2: 1 + 4j, pw3: -0.5})),
         (ps1, pw4, PauliSentence({pw1: 1.23, pw2: 4j, pw3: -0.5, pw4: 1.0})),
+        (ps3, pw1, PauliSentence({pw1: 1.0, pw3: -0.5, pw4: 1})),
     )
 
     @pytest.mark.parametrize("ps, pw, true_res", add_ps_pw)
@@ -529,20 +529,6 @@ class TestPauliSentence:
         assert res1 == true_res
         assert res2 == true_res
 
-    def test_add_PS_and_PW_non_existent(self):
-        """Test adding PW to PS that is not already present"""
-        res11 = ps1 + pw4
-        res12 = pw4 + ps1
-        true_res1 = PauliSentence({pw1: 1.23, pw2: 4j, pw3: -0.5, pw4: 1.0})
-        assert res11 == true_res1
-        assert res12 == true_res1
-
-        res21 = ps4 + pw1
-        res22 = pw1 + ps4
-        true_res2 = PauliSentence({pw4: 1, pw1: 1.0})
-        assert res21 == true_res2
-        assert res22 == true_res2
-
     @pytest.mark.parametrize("scalar", [0.0, 0.5, 0.5j, 0.5 + 0.5j])
     def test_add_PS_and_scalar(self, scalar):
         """Test adding PauliSentence and scalar"""
@@ -552,12 +538,30 @@ class TestPauliSentence:
         assert res2[pw_id] == scalar
 
     @pytest.mark.parametrize("scalar", [0.0, 0.5, 0.5j, 0.5 + 0.5j])
+    def test_iadd_PS_and_scalar(self, scalar):
+        """Test inplace adding PauliSentence and scalar"""
+        copy_ps1 = copy(ps1)
+        copy_ps2 = copy(ps1)
+        copy_ps1 += scalar
+        assert copy_ps1[pw_id] == scalar
+        assert copy_ps2 == ps1
+
+    @pytest.mark.parametrize("scalar", [0.0, 0.5, 0.5j, 0.5 + 0.5j])
     def test_add_PS_and_scalar_with_1_present(self, scalar):
         """Test adding scalar to a PauliSentence that already contains identity"""
         res1 = ps4 + scalar
         res2 = scalar + ps4
         assert res1[pw_id] == 1 + scalar
         assert res2[pw_id] == 1 + scalar
+
+    @pytest.mark.parametrize("scalar", [0.0, 0.5, 0.5j, 0.5 + 0.5j])
+    def test_iadd_PS_and_scalar_1_present(self, scalar):
+        """Test inplace adding scalar to PauliSentence that already contains identity"""
+        copy_ps1 = copy(ps4)
+        copy_ps2 = copy(ps4)
+        copy_ps1 += scalar
+        assert copy_ps1[pw_id] == 1 + scalar
+        assert copy_ps2 == ps4
 
     ps_match = (
         (ps4, "Can't get the matrix of an empty PauliWord."),

--- a/tests/pauli/test_pauli_arithmetic.py
+++ b/tests/pauli/test_pauli_arithmetic.py
@@ -484,8 +484,8 @@ class TestPauliSentence:
     )
 
     @pytest.mark.parametrize("string1, string2, result", tup_ps_add)
-    def test_add(self, string1, string2, result):
-        """Test that the correct result of addition is produced."""
+    def test_add_PS_and_PS(self, string1, string2, result):
+        """Test adding two PauliSentences"""
         copy_ps1 = copy(string1)
         copy_ps2 = copy(string2)
 
@@ -495,6 +495,17 @@ class TestPauliSentence:
         assert simplified_product == result
         assert string1 == copy_ps1
         assert string2 == copy_ps2
+    
+    def test_add_PS_and_PW(self):
+        """Test adding PauliSentence and PauliWord"""
+        ps = PauliSentence(dict(zip(words, list(range(len(words))))))
+        for i, pw in enumerate(words):
+            res1 = ps + pw
+            res2 = pw + ps
+            true_res = list(range(len(words)))
+            true_res[i] += 1
+            assert list(res1.values()) == true_res
+            assert list(res2.values()) == true_res
 
     ps_match = (
         (ps4, "Can't get the matrix of an empty PauliWord."),

--- a/tests/pauli/test_pauli_arithmetic.py
+++ b/tests/pauli/test_pauli_arithmetic.py
@@ -38,6 +38,7 @@ pw1 = PauliWord({0: I, 1: X, 2: Y})
 pw2 = PauliWord({"a": X, "b": X, "c": Z})
 pw3 = PauliWord({0: Z, "b": Z, "c": Z})
 pw4 = PauliWord({})
+pw_id = pw4  # Identity PauliWord
 
 words = [pw1, pw2, pw3, pw4]
 
@@ -495,17 +496,35 @@ class TestPauliSentence:
         assert simplified_product == result
         assert string1 == copy_ps1
         assert string2 == copy_ps2
-    
-    def test_add_PS_and_PW(self):
+
+    add_ps_pw = list(enumerate(words))  # tuples of (i, pw_i)
+
+    @pytest.mark.parametrize("i, pw", add_ps_pw)
+    def test_add_PS_and_PW(self, i, pw):
         """Test adding PauliSentence and PauliWord"""
         ps = PauliSentence(dict(zip(words, list(range(len(words))))))
-        for i, pw in enumerate(words):
-            res1 = ps + pw
-            res2 = pw + ps
-            true_res = list(range(len(words)))
-            true_res[i] += 1
-            assert list(res1.values()) == true_res
-            assert list(res2.values()) == true_res
+        res1 = ps + pw
+        res2 = pw + ps
+        true_res = list(range(len(words)))
+        true_res[i] += 1
+        assert list(res1.values()) == true_res
+        assert list(res2.values()) == true_res
+
+    @pytest.mark.parametrize("scalar", [0.0, 0.5, 0.5j, 0.5 + 0.5j])
+    def test_add_PS_and_scalar(self, scalar):
+        """Test adding PauliSentence and scalar"""
+        res1 = ps1 + scalar
+        res2 = scalar + ps1
+        assert res1[pw_id] == scalar
+        assert res2[pw_id] == scalar
+
+    @pytest.mark.parametrize("scalar", [0.0, 0.5, 0.5j, 0.5 + 0.5j])
+    def test_add_PS_and_scalar_with_1_present(self, scalar):
+        """Test adding scalar to a PauliSentence that already contains identity"""
+        res1 = ps4 + scalar
+        res2 = scalar + ps4
+        assert res1[pw_id] == 1 + scalar
+        assert res2[pw_id] == 1 + scalar
 
     ps_match = (
         (ps4, "Can't get the matrix of an empty PauliWord."),


### PR DESCRIPTION
Adding cross-functionality for additions between PauliSentence, PauliWord and scalars.
This now allows to intuitively add them to each other, e.g.

```python
XX = PauliWord({0:"X", 1:"X"})
YY = PauliWord({0:"Y", 1:"Y"})

H = 0.5 * XX + 0.7 * YY
>>> isinstance(H, PauliSentence)
True
```
