### PR TITLE
fix keraslayer set and get attr dunders

### DIFF
--- a/doc/releases/changelog-0.34.0.md
+++ b/doc/releases/changelog-0.34.0.md
@@ -723,6 +723,10 @@
 * The jax-jit interface can now be used with float32 mode.
   [(#4990)](https://github.com/PennyLaneAI/pennylane/pull/4990)
 
+* Keras models with a `qnn.KerasLayer` no longer fail to save and load weights
+  properly when they are named "weights".
+  [(#5008)](https://github.com/PennyLaneAI/pennylane/pull/5008)
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane/qnn/keras.py
+++ b/pennylane/qnn/keras.py
@@ -384,6 +384,7 @@ class KerasLayer(Layer):
 
         # reshape to the correct number of batch dims
         if has_batch_dim:
+            # pylint:disable=unexpected-keyword-arg,no-value-for-parameter
             new_shape = tf.concat([batch_dims, tf.shape(results)[1:]], axis=0)
             results = tf.reshape(results, new_shape)
 
@@ -438,17 +439,14 @@ class KerasLayer(Layer):
         if self._initialized and hasattr(self.qnode, item):
             return getattr(self.qnode, item)
 
-        try:
-            return self.__dict__[item]
-        except KeyError as exc:
-            raise AttributeError(item) from exc
+        return super().__getattr__(item)
 
     def __setattr__(self, item, val):
         """If the given attribute does not exist in the class, try to set it in the wrapped QNode."""
         if self._initialized and hasattr(self.qnode, item):
             setattr(self.qnode, item, val)
         else:
-            self.__dict__[item] = val
+            super().__setattr__(item, val)
 
     def compute_output_shape(self, input_shape):
         """Computes the output shape after passing data of shape ``input_shape`` through the

--- a/tests/qnn/test_keras.py
+++ b/tests/qnn/test_keras.py
@@ -920,3 +920,40 @@ def test_specs():
     assert info["num_trainable_params"] == 2
     assert info["interface"] == "tf"
     assert info["device_name"] == "default.qubit"
+
+
+def test_save_and_load_preserves_weights(tmpdir):
+    """
+    Test that saving and loading a model doesn't lose the weights. This particular
+    test is important aside from `test_save_whole_model` because a bug caused issues
+    when the name of (at least one of) your weights is 'weights'.
+    """
+
+    dev = qml.device("default.qubit")
+    n_qubits = 2
+
+    @qml.qnode(dev)
+    def circuit(inputs, weights):
+        qml.AngleEmbedding(inputs, wires=range(n_qubits))
+        qml.RX(weights[0], 0)
+        qml.RX(weights[1], 1)
+        return [qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliZ(1))]
+
+    weight_shapes = {"weights": (n_qubits,)}
+    quantum_layer = qml.qnn.KerasLayer(circuit, weight_shapes, output_dim=2)
+
+    model0 = tf.keras.models.Sequential()
+    model0.add(quantum_layer)
+    model0.add(tf.keras.layers.Dense(2, activation=tf.nn.softmax, input_shape=(2,)))
+
+    model0.compile(optimizer="adam", loss="categorical_crossentropy", metrics=["accuracy"])
+
+    num_points = 5
+    dummy_input_data = np.random.uniform(0, np.pi, size=(num_points, 2))
+    dummy_output_data = np.random.randint(2, size=(num_points, 2))
+
+    model0.fit(dummy_input_data, dummy_output_data, epochs=1, batch_size=0)
+    file = str(tmpdir) + "/model"
+    model0.save(file)
+    loaded_model = tf.keras.models.load_model(file)
+    assert np.array_equal(model0.layers[0].weights, loaded_model.layers[0].weights)


### PR DESCRIPTION
**Context:**
Fixes #4999. We re-implemented the default `setattr` and `getattr` dunders for `KerasLayer` (needed to modify the QNode saved on the layer) but we should have called `super()`, because `keras.layer.Layer` has its own custom implementation that we needed to use. Our `TorchLayer` already calls `super` in these cases.

Note - our existing tests were passing because the weights used had custom names ("w1", "w2", etc.), and this issue only comes up when your weights are named "weights" (which is a rather common case, I'm sure).

**Description of the Change:**
- Replace our default-handling of `get/set-attr` dunders with a call to `super()`
- add a test case matching the one in the bug report using the "weights" identifier

**Benefits:**
Models using `KerasLayer` can be saved and loaded properly!

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
Reported initially in #4999, same as #4611 but for Keras