### PR TITLE
raise error for trainable state-prep with adjoint

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -8,6 +8,9 @@
 
 * Update `tests/ops/functions/conftest.py` to ensure all operator types are tested for validity.
   [(#4978)](https://github.com/PennyLaneAI/pennylane/pull/4978)
+
+* Raise a more informative error when calling `adjoint_jacobian` with trainable state-prep operations.
+  [(#)]()
   
 <h4>Community contributions 🥳</h4>
 

--- a/pennylane/devices/__init__.py
+++ b/pennylane/devices/__init__.py
@@ -68,7 +68,7 @@ method for devices.
     validate_measurements
     validate_device_wires
     validate_multiprocessing_workers
-    warn_about_trainable_observables
+    validate_adjoint_trainable_params
     no_sampling
 
 Other transforms that may be relevant to device preprocessing include:

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -37,7 +37,7 @@ from .preprocess import (
     validate_measurements,
     validate_multiprocessing_workers,
     validate_device_wires,
-    warn_about_trainable_observables,
+    validate_adjoint_trainable_params,
     no_sampling,
 )
 from .execution_config import ExecutionConfig, DefaultExecutionConfig
@@ -179,7 +179,7 @@ def _add_adjoint_transforms(program: TransformProgram) -> None:
     )
     program.add_transform(adjoint_state_measurements)
     program.add_transform(qml.transforms.broadcast_expand)
-    program.add_transform(warn_about_trainable_observables)
+    program.add_transform(validate_adjoint_trainable_params)
 
 
 class DefaultQubit(Device):

--- a/pennylane/devices/preprocess.py
+++ b/pennylane/devices/preprocess.py
@@ -207,15 +207,23 @@ def validate_multiprocessing_workers(
 
 
 @transform
-def warn_about_trainable_observables(
+def validate_adjoint_trainable_params(
     tape: qml.tape.QuantumTape,
 ) -> (Sequence[qml.tape.QuantumTape], Callable):
-    """Raises a warning if any of the observables is trainable. Can be used in validating circuits
+    """Raises a warning if any of the observables is trainable, and raises an error if any
+    trainable parameters belong to state-prep operations. Can be used in validating circuits
     for adjoint differentiation.
     """
 
+    num_preps = tape.num_preps
     for k in tape.trainable_params:
-        mp_or_op = tape[tape._par_info[k]["op_idx"]]
+        op_idx = tape._par_info[k]["op_idx"]
+        if op_idx < num_preps:
+            raise qml.QuantumFunctionError(
+                "Differentiating with respect to the input parameters of state-prep operations "
+                "is not supported with the adjoint differentiation method."
+            )
+        mp_or_op = tape[op_idx]
         if isinstance(mp_or_op, MeasurementProcess):
             warnings.warn(
                 "Differentiating with respect to the input parameters of "

--- a/tests/devices/test_preprocess.py
+++ b/tests/devices/test_preprocess.py
@@ -26,7 +26,7 @@ from pennylane.devices.preprocess import (
     no_sampling,
     validate_device_wires,
     validate_multiprocessing_workers,
-    warn_about_trainable_observables,
+    validate_adjoint_trainable_params,
     _operator_decomposition_gen,
     decompose,
     validate_observables,
@@ -136,11 +136,18 @@ def test_no_sampling():
         no_sampling(tape2, name="abc")
 
 
-def test_warn_about_trainable_observables():
-    """Tests warning raised for warn_about_trainable_observables."""
+def test_validate_adjoint_trainable_params_obs_warning():
+    """Tests warning raised for validate_adjoint_trainable_params with trainable observables."""
     tape = qml.tape.QuantumScript([], [qml.expval(2 * qml.PauliX(0))])
     with pytest.warns(UserWarning, match="Differentiating with respect to the input "):
-        warn_about_trainable_observables(tape)
+        validate_adjoint_trainable_params(tape)
+
+
+def test_validate_adjoint_trainable_params_state_prep_error():
+    """Tests error raised for validate_adjoint_trainable_params with trainable state-preps."""
+    tape = qml.tape.QuantumScript([qml.StatePrep([1.0, 0.0], wires=[0])])
+    with pytest.raises(qml.QuantumFunctionError, match="Differentiating with respect to"):
+        validate_adjoint_trainable_params(tape)
 
 
 class TestValidateDeviceWires:


### PR DESCRIPTION
**Context:**
The adjoint-jacobian gradient computation method doesn't currently support trainable `StatePrepBase` operations. If you try to make it work, the function skips over the state-prep operation when collecting jac values, and you get a cryptic error talking nonsense about shape.

**Description of the Change:**
Update an adjoint-jacobian preprocessing validation transform to raise more informative errors when a circuit has a trainable state-prep operation

**Benefits:**
The user knows that we explicitly do not support trainable state-prep operations instead of having to debug strange shape errors from their ML framework of choice.

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
Came up in discussion in bug #4964