### PR TITLE
re-write state_vector so it's actually backprop-compatible

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -25,6 +25,9 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* `StatePrep` operations expanded onto more wires are now compatible with backprop.
+  [(#)](https://github.com/PennyLaneAI/pennylane/pull/)
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane/ops/qubit/state_preparation.py
+++ b/pennylane/ops/qubit/state_preparation.py
@@ -217,30 +217,17 @@ class StatePrep(StatePrepBase):
         if not wire_order.contains_wires(self.wires):
             raise WireError(f"Custom wire_order must contain all {self.name} wires")
 
-        num_total_wires = len(wire_order)
-        indices = tuple(
-            [Ellipsis] + [slice(None)] * num_op_wires + [0] * (num_total_wires - num_op_wires)
-        )
-        ket_shape = [2] * num_total_wires
+        # add zeros for each wire that isn't being set
+        extra_wires = Wires(set(wire_order) - set(self.wires))
+        for _ in extra_wires:
+            op_vector = math.stack([op_vector, math.zeros_like(op_vector)], axis=-1)
+
+        # transpose from operator wire order to provided wire order
+        current_wires = self.wires + extra_wires
+        transpose_axes = [current_wires.index(w) for w in wire_order]
         if self.batch_size:
-            # Add broadcasted dimension to the shape of the state vector
-            ket_shape = [self.batch_size] + ket_shape
-
-        ket = np.zeros(ket_shape, dtype=np.complex128)
-        ket[indices] = op_vector
-
-        # unless wire_order is [*self.wires, *rest_of_wire_order], need to rearrange
-        if self.wires != wire_order[:num_op_wires]:
-            current_order = self.wires + list(Wires.unique_wires([wire_order, self.wires]))
-            desired_order = [current_order.index(w) for w in wire_order]
-            if self.batch_size:
-                # If the operation is broadcasted, the desired order must include the batch dimension
-                # as the first dimension.
-                desired_order = [0] + [d + 1 for d in desired_order]
-
-            ket = ket.transpose(desired_order)
-
-        return math.convert_like(ket, op_vector)
+            transpose_axes = [0] + [a + 1 for a in transpose_axes]
+        return math.transpose(op_vector, transpose_axes)
 
 
 # pylint: disable=missing-class-docstring

--- a/tests/ops/qubit/test_state_prep.py
+++ b/tests/ops/qubit/test_state_prep.py
@@ -157,7 +157,7 @@ class TestStateVector:
         assert np.array_equal(ket, expected)
 
     @pytest.mark.all_interfaces
-    @pytest.mark.parametrize("interface", ["numpy", "jax", "torch", "tensorflow"])
+    @pytest.mark.parametrize("interface", ["autograd", "jax", "torch", "tensorflow"])
     def test_StatePrep_state_vector_preserves_parameter_type(self, interface):
         """Tests that given an array of some type, the resulting state vector is also that type."""
         qsv_op = qml.StatePrep(qml.math.array([0, 0, 0, 1], like=interface), wires=[1, 2])
@@ -165,7 +165,7 @@ class TestStateVector:
         assert qml.math.get_interface(qsv_op.state_vector(wire_order=[0, 1, 2])) == interface
 
     @pytest.mark.all_interfaces
-    @pytest.mark.parametrize("interface", ["numpy", "jax", "torch", "tensorflow"])
+    @pytest.mark.parametrize("interface", ["autograd", "jax", "torch", "tensorflow"])
     def test_StatePrep_state_vector_preserves_parameter_type_broadcasted(self, interface):
         """Tests that given an array of some type, the resulting state vector is also that type."""
         qsv_op = qml.StatePrep(
@@ -190,6 +190,56 @@ class TestStateVector:
         """Tests that the parameter must be of shape (2**num_wires,)."""
         with pytest.raises(ValueError, match="State vector must have shape"):
             _ = qml.StatePrep([0, 1], wires=[0, 1])
+
+    @pytest.mark.torch
+    def test_StatePrep_torch_differentiable(self):
+        """Test that StatePrep works with torch."""
+        import torch
+
+        def QuantumLayer():
+            @qml.qnode(qml.device("default.qubit"), interface="torch")
+            def qlayer(inputs, weights):
+                qml.StatePrep(inputs, wires=[1, 2, 3])
+                qml.RY(phi=weights, wires=[0])
+                return qml.expval(qml.PauliZ(wires=0))
+
+            weight_shapes = {"weights": (1)}
+            return qml.qnn.TorchLayer(qlayer, weight_shapes)
+
+        class SimpleQuantumModel(torch.nn.Module):  # pylint:disable=too-few-public-methods
+            def __init__(self):
+                super().__init__()
+                self.quantum_layer = QuantumLayer()
+
+            def forward(self, x):
+                return self.quantum_layer(x)
+
+        model = SimpleQuantumModel()
+        features = torch.tensor(
+            [[1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]],
+            requires_grad=True,
+        )
+        result = model(features)
+        assert qml.math.get_interface(result) == "torch"
+        assert qml.math.shape(result) == (2,)
+
+    @pytest.mark.torch
+    def test_StatePrep_backprop_torch(self):
+        """Test backprop with torch, getting state.grad"""
+        import torch
+
+        @qml.qnode(qml.device("default.qubit"), diff_method="backprop")
+        def circuit(state):
+            qml.StatePrep(state, wires=(0,))
+            qml.S(1)
+            return qml.expval(qml.PauliZ(0))
+
+        state = torch.tensor([1.0, 0.0], requires_grad=True)
+        res = circuit(state)
+        res.backward()
+        grad = state.grad
+        assert qml.math.get_interface(grad) == "torch"
+        assert np.array_equal(grad, [2.0, 0.0])
 
     @pytest.mark.parametrize(
         "num_wires,wire_order,one_position",
@@ -239,7 +289,7 @@ class TestStateVector:
         assert not np.any(basis_state)
 
     @pytest.mark.all_interfaces
-    @pytest.mark.parametrize("interface", ["numpy", "jax", "torch", "tensorflow"])
+    @pytest.mark.parametrize("interface", ["autograd", "jax", "torch", "tensorflow"])
     @pytest.mark.parametrize("dtype_like", [0, 0.0])
     def test_BasisState_state_vector_preserves_parameter_type(self, interface, dtype_like):
         """Tests that given an array of some type, the resulting state_vector is also that type."""


### PR DESCRIPTION
**Context:**
Had to re-make #4996 because it was against the RC branch which no longer exists. `StatePrep.state_vector` was not backprop-compatible

**Description of the Change:**
Re-wrote `StatePrep.state_vector` so it works with backprop

**Benefits:**
- Having a `StatePrep` in a circuit no longer breaks differentiation
- opinion: code looks better

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
Fixes #4964