### PR TITLE
deprecate qml.matrix with wire_order=None

### DIFF
--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -9,6 +9,13 @@ deprecations are listed below.
 Pending deprecations
 --------------------
 
+* Calling ``qml.matrix`` without providing a ``wire_order`` on objects where the wire order could be
+  ambiguous now raises a warning. This includes tapes with multiple wires, QNodes with a device that
+  does not provide wires, or quantum functions.
+
+  - Deprecated in v0.35
+  - Will raise an error in v0.36
+
 * The contents of ``qml.interfaces`` is moved inside ``qml.workflow``.
 
   - Contents moved in v0.35

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -46,6 +46,11 @@
 * Matrix and tensor products between `PauliWord` and `PauliSentence` instances are done using the `@` operator, `*` will be used only for scalar multiplication.
   [(#4989)](https://github.com/PennyLaneAI/pennylane/pull/4989)
 
+* Calling `qml.matrix` without providing a `wire_order` on objects where the wire order could be
+  ambiguous now raises a warning. In the future, the `wire_order` argument will be required in
+  these cases.
+  [(#5039)](https://github.com/PennyLaneAI/pennylane/pull/5039)
+
 <h3>Documentation 📝</h3>
 
 * A typo in a code example in the `qml.transforms` API has been fixed.

--- a/pennylane/ops/functions/matrix.py
+++ b/pennylane/ops/functions/matrix.py
@@ -17,6 +17,7 @@ This module contains the qml.matrix function.
 # pylint: disable=protected-access
 from typing import Sequence, Callable
 from functools import partial
+from warnings import warn
 
 import pennylane as qml
 from pennylane.transforms.op_transforms import OperationTransformError
@@ -171,6 +172,13 @@ def matrix(op: qml.operation.Operator, wire_order=None) -> TensorLike:
         if not isinstance(op, (qml.tape.QuantumScript, qml.QNode)) and not callable(op):
             raise OperationTransformError(
                 "Input is not an Operator, tape, QNode, or quantum function"
+            )
+        if wire_order is None:
+            warn(
+                "Calling qml.matrix() on a QuantumTape, QNode or quantum function without "
+                "specifying a value for wire_order is deprecated. Please provide a wire_order "
+                "value to avoid future issues.",
+                qml.PennyLaneDeprecationWarning,
             )
         return _matrix_transform(op, wire_order=wire_order)
 

--- a/pennylane/ops/functions/matrix.py
+++ b/pennylane/ops/functions/matrix.py
@@ -25,8 +25,10 @@ from pennylane import transform
 from pennylane.typing import TensorLike
 
 _wire_order_none_warning = (
-    "Calling qml.matrix() on a QuantumTape, QNode or quantum function without specifying a value "
-    "for wire_order is deprecated. Please provide a wire_order value to avoid future issues."
+    "Calling qml.matrix() on a QuantumTape, quantum functions, or certain QNodes without "
+    "specifying a value for wire_order is deprecated. Please provide a wire_order value to avoid "
+    "future issues. Note that a wire order is not required for QNodes with devices that have "
+    "wires specified, because the wire order is taken from the device."
 )
 
 


### PR DESCRIPTION
**Context:**
Wire-ordering can surprise people because PennyLane gives no promises. For example:
```pycon
>>> qs = qml.tape.QuantumScript([qml.Identity(1), qml.CNOT([0, 1])])
>>> qml.matrix(qs)
array([[1., 0., 0., 0.],
       [0., 0., 0., 1.],
       [0., 0., 1., 0.],
       [0., 1., 0., 0.]])
```
This is in wire-order `[1, 0]` because that's the order in which they appeared in the tape. Most users would expect the other way.

**Description of the Change:**
Deprecate the default `wire_order=None` value in `qml.matrix` in certain cases. The warning is raised if:
- the object is a tape with more than one wire
- the object is a QNode and the device does not provide wires
- the object is a qfunc

**Benefits:**
Users won't be surprised when they get a matrix in an unexpected wire order

**Possible Drawbacks:**
More deprecations, the user has to enter wire_order even though it's often safe to assume they meant ascending integers (but not often enough, so here we are)

**Related GitHub Issues:**
It was discussed in #3131

[sc-51277]