### PR TITLE
Optimize `op.matrix()` for symmetric operators

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -6,6 +6,9 @@
 
 <h3>Improvements 🛠</h3>
 
+* Improve efficiency of matrix calculation when operator is symmetric over wires
+  [(#)](https://github.com/PennyLaneAI/pennylane/pull/)
+
 * Update `tests/ops/functions/conftest.py` to ensure all operator types are tested for validity.
   [(#4978)](https://github.com/PennyLaneAI/pennylane/pull/4978)
 
@@ -37,6 +40,7 @@
 This release contains contributions from (in alphabetical order):
 
 Abhishek Abhishek,
-Christina Lee,
 Isaac De Vlugt,
+Christina Lee,
+Mudit Pandey,
 Matthew Silverman.

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -254,7 +254,6 @@ from numpy.linalg import multi_dot
 from scipy.sparse import coo_matrix, eye, kron
 
 import pennylane as qml
-from pennylane.math import expand_matrix
 from pennylane.queuing import QueuingManager
 from pennylane.typing import TensorLike
 from pennylane.wires import Wires
@@ -785,10 +784,17 @@ class Operator(abc.ABC):
         """
         canonical_matrix = self.compute_matrix(*self.parameters, **self.hyperparameters)
 
-        if wire_order is None or self.wires == Wires(wire_order):
+        if (
+            wire_order is None
+            or self.wires == Wires(wire_order)
+            or (
+                self in qml.ops.qubit.attributes.symmetric_over_all_wires
+                and set(self.wires) == set(wire_order)
+            )
+        ):
             return canonical_matrix
 
-        return expand_matrix(canonical_matrix, wires=self.wires, wire_order=wire_order)
+        return qml.math.expand_matrix(canonical_matrix, wires=self.wires, wire_order=wire_order)
 
     @staticmethod
     def compute_sparse_matrix(*params, **hyperparams):  # pylint:disable=unused-argument
@@ -831,7 +837,9 @@ class Operator(abc.ABC):
             *self.parameters, **self.hyperparameters
         )
 
-        return expand_matrix(canonical_sparse_matrix, wires=self.wires, wire_order=wire_order)
+        return qml.math.expand_matrix(
+            canonical_sparse_matrix, wires=self.wires, wire_order=wire_order
+        )
 
     @staticmethod
     def compute_eigvals(*params, **hyperparams):

--- a/pennylane/ops/op_math/exp.py
+++ b/pennylane/ops/op_math/exp.py
@@ -30,7 +30,6 @@ from pennylane.operation import (
     Operator,
     OperatorPropertyUndefined,
     Tensor,
-    expand_matrix,
 )
 from pennylane.ops.qubit import Hamiltonian
 from pennylane.wires import Wires
@@ -391,10 +390,10 @@ class Exp(ScalarSymbolicOp, Operation):
                     else math.diag(eigvals)
                 )
                 if len(self.diagonalizing_gates()) == 0:
-                    return expand_matrix(eigvals_mat, wires=self.wires, wire_order=wire_order)
+                    return math.expand_matrix(eigvals_mat, wires=self.wires, wire_order=wire_order)
                 diagonalizing_mat = qml.matrix(self.diagonalizing_gates, wire_order=self.wires)()
                 mat = diagonalizing_mat.conj().T @ eigvals_mat @ diagonalizing_mat
-                return expand_matrix(mat, wires=self.wires, wire_order=wire_order)
+                return math.expand_matrix(mat, wires=self.wires, wire_order=wire_order)
             except OperatorPropertyUndefined:
                 warn(
                     f"The autograd matrix for {self} is not differentiable. "

--- a/pennylane/ops/qubit/attributes.py
+++ b/pennylane/ops/qubit/attributes.py
@@ -152,7 +152,23 @@ self_inverses = Attribute(
 """Attribute: Operations that are their own inverses."""
 
 
-symmetric_over_all_wires = Attribute(["CZ", "CCZ", "SWAP"])
+symmetric_over_all_wires = Attribute(
+    [
+        "CZ",
+        "CCZ",
+        "SWAP",
+        "IsingXX",
+        "Identity",
+        "ISWAP",
+        "SISWAP",
+        "SQISW",
+        "MultiRZ",
+        "IsingXY",
+        "IsingYY",
+        "IsingZZ",
+        "PSWAP",
+    ]
+)
 """Attribute: Operations that are the same if you exchange the order of wires.
 
 For example, ``qml.CZ(wires=[0, 1])`` has the same effect as ``qml.CZ(wires=[1,


### PR DESCRIPTION
**Context:**
Redoing stale PR #3601

**Description of the Change:**
* Updated `symmetric_over_all_wires` attribute with more operations.
* Use the attribute to skip matrix expansion if the set of wires is the same as the wire order. This doesn't work for `qml.CZ`, as it inherits `Controlled.matrix`, which shouldn't check for such attributes.

**Benefits:**
* Matrix computation for symmetric ops is slightly faster.

**Possible Drawbacks:**

**Related GitHub Issues:**
