### PR TITLE
remove observable.return_type

### DIFF
--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -20,12 +20,6 @@ Pending deprecations
   - Deprecated in v0.34
   - Will be removed in v0.35
 
-* ``Observable.return_type`` is deprecated. Instead, you should inspect the type
-  of the surrounding measurement process.
-
-  - Deprecated in v0.34
-  - Will be removed in v0.35
-
 * ``single_tape_transform``, ``batch_transform``, ``qfunc_transform``, and ``op_transform`` are
   deprecated. Instead switch to using the new ``qml.transform`` function. Please refer to
   `the transform docs <https://docs.pennylane.ai/en/stable/code/qml_transforms.html#custom-transforms>`_
@@ -113,6 +107,12 @@ Pending deprecations
 
 Completed deprecation cycles
 ----------------------------
+
+* ``Observable.return_type`` has been removed. Instead, you should inspect the type
+  of the surrounding measurement process.
+
+  - Deprecated in v0.34
+  - Removed in v0.35
 
 * Specifying ``control_values`` passed to ``qml.ctrl`` as a string is no longer supported.
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -43,7 +43,7 @@
 
 * `Observable.return_type` has been removed. Instead, you should inspect the type
   of the surrounding measurement process.
-  [()]()
+  [(#5044)](https://github.com/PennyLaneAI/pennylane/pull/5044)
 
 <h3>Deprecations 👋</h3>
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -41,6 +41,10 @@
 
 <h3>Breaking changes 💔</h3>
 
+* `Observable.return_type` has been removed. Instead, you should inspect the type
+  of the surrounding measurement process.
+  [()]()
+
 <h3>Deprecations 👋</h3>
 
 * Matrix and tensor products between `PauliWord` and `PauliSentence` instances are done using the `@` operator, `*` will be used only for scalar multiplication.

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -1859,8 +1859,6 @@ class Observable(Operator):
             can be useful for some applications where the instance has to be identified
     """
 
-    _return_type = None
-
     @property
     def _queue_category(self):
         """Used for sorting objects into their respective lists in `QuantumTape` objects.
@@ -1882,26 +1880,6 @@ class Observable(Operator):
     def is_hermitian(self):
         """All observables must be hermitian"""
         return True
-
-    @property
-    def return_type(self):
-        """None or ObservableReturnTypes: Measurement type that this observable is called with."""
-        warnings.warn(
-            "`Observable.return_type` is deprecated. Instead, you should "
-            "inspect the type of the surrounding measurement process.",
-            qml.PennyLaneDeprecationWarning,
-        )
-        return self._return_type
-
-    @return_type.setter
-    def return_type(self, value):
-        """Change the return type of an Observable. Note that this property is deprecated."""
-        warnings.warn(
-            "`Observable.return_type` is deprecated. Instead, you should "
-            "create a measurement process containing this Observable.",
-            qml.PennyLaneDeprecationWarning,
-        )
-        self._return_type = value
 
     def __matmul__(self, other):
         if active_new_opmath():
@@ -2489,8 +2467,6 @@ class Tensor(Observable):
         """Returns a pruned tensor product of observables by removing :class:`~.Identity` instances from
         the observables building up the :class:`~.Tensor`.
 
-        The ``return_type`` attribute is preserved while pruning.
-
         If the tensor product only contains one observable, then this observable instance is
         returned.
 
@@ -2528,7 +2504,6 @@ class Tensor(Observable):
         else:
             obs = Tensor(*self.non_identity_obs)
 
-        obs._return_type = self._return_type
         return obs
 
     def map_wires(self, wire_map: dict):

--- a/pennylane/tape/qscript.py
+++ b/pennylane/tape/qscript.py
@@ -304,7 +304,6 @@ class QuantumScript:
 
         for m in self.measurements:
             if m.obs is not None:
-                m.obs._return_type = m.return_type
                 obs.append(m.obs)
             else:
                 obs.append(m)

--- a/tests/ops/op_math/test_adjoint.py
+++ b/tests/ops/op_math/test_adjoint.py
@@ -98,7 +98,6 @@ class TestInheritanceMixins:
         assert isinstance(1.0 * ob @ ob, qml.Hamiltonian)
 
         # check the dir
-        assert "return_type" in dir(ob)
         assert "grad_recipe" not in dir(ob)
 
     @pytest.mark.parametrize(

--- a/tests/ops/op_math/test_pow_op.py
+++ b/tests/ops/op_math/test_pow_op.py
@@ -164,7 +164,6 @@ class TestInheritanceMixins:
         assert isinstance(1.0 * ob @ ob, qml.Hamiltonian)
 
         # check the dir
-        assert "return_type" in dir(ob)
         assert "grad_recipe" not in dir(ob)
 
 

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -922,22 +922,6 @@ class TestOperationConstruction:
 class TestObservableConstruction:
     """Test custom observables construction."""
 
-    def test_observable_return_type_none(self):
-        """Check that the return_type of an observable is initially None"""
-
-        class DummyObserv(qml.operation.Observable):
-            r"""Dummy custom observable"""
-            num_wires = 1
-            grad_method = None
-
-        with pytest.warns(UserWarning, match="`Observable.return_type` is deprecated. Instead"):
-            assert DummyObserv(0, wires=[1]).return_type is None
-
-        obs = DummyObserv(0, wires=[1])
-        with pytest.warns(UserWarning, match="`Observable.return_type` is deprecated. Instead"):
-            # pylint:disable=attribute-defined-outside-init
-            obs.return_type = qml.measurements.Sample
-
     def test_construction_with_wires_pos_arg(self):
         """Test that the wires can be given as a positional argument"""
 


### PR DESCRIPTION
completing the deprecation cycle. will break braket-*-latest as they haven't moved yet.

[sc-51274]