### PR TITLE
deprecate mp.name and mp.data

### DIFF
--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -9,6 +9,12 @@ deprecations are listed below.
 Pending deprecations
 --------------------
 
+* ``MeasurementProcess.name`` and ``MeasurementProcess.data`` have been deprecated, as they contain
+  dummy values that are no longer needed.
+
+  - Deprecated in v0.35
+  - Will be removed in v0.36
+
 * The contents of ``qml.interfaces`` is moved inside ``qml.workflow``.
 
   - Contents moved in v0.35

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -48,7 +48,7 @@
 
 * `MeasurementProcess.name` and `MeasurementProcess.data` are now deprecated, as they contain dummy
   values that are no longer needed.
-  [()]()
+  [(#5047)](https://github.com/PennyLaneAI/pennylane/pull/5047)
 
 <h3>Documentation 📝</h3>
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -46,6 +46,10 @@
 * Matrix and tensor products between `PauliWord` and `PauliSentence` instances are done using the `@` operator, `*` will be used only for scalar multiplication.
   [(#4989)](https://github.com/PennyLaneAI/pennylane/pull/4989)
 
+* `MeasurementProcess.name` and `MeasurementProcess.data` are now deprecated, as they contain dummy
+  values that are no longer needed.
+  [()]()
+
 <h3>Documentation 📝</h3>
 
 * A typo in a code example in the `qml.transforms` API has been fixed.

--- a/pennylane/measurements/measurements.py
+++ b/pennylane/measurements/measurements.py
@@ -18,6 +18,8 @@ and measurement samples using AnnotatedQueues.
 """
 import copy
 import functools
+from warnings import warn
+
 from abc import ABC, abstractmethod
 from enum import Enum
 from typing import Sequence, Tuple, Optional, Union
@@ -185,21 +187,30 @@ class MeasurementProcess(ABC):
 
             self._eigvals = qml.math.asarray(eigvals)
 
-        # TODO: remove the following lines once devices
-        # have been refactored to accept and understand receiving
-        # measurement processes rather than specific observables.
-
-        # The following lines are only applicable for measurement processes
-        # that do not have corresponding observables (e.g., Probability). We use
-        # them to 'trick' the device into thinking it has received an observable.
-
-        # Below, we imitate an identity observable, so that the
-        # device undertakes no action upon receiving this observable.
-        self.name = "Identity"
-        self.data = []
-
         # Queue the measurement process
         self.queue()
+
+    @property
+    def name(self):
+        """A deprecated property that always returns 'Identity'."""
+        warn(
+            "MeasurementProcess.name is deprecated, and will be removed "
+            "in an upcoming release. To get the name of an observable "
+            "from a measurement, use MeasurementProcess.obs.name instead",
+            qml.PennyLaneDeprecationWarning,
+        )
+        return "Identity"
+
+    @property
+    def data(self):
+        """A deprecated property that always returns an empty list."""
+        warn(
+            "MeasurementProcess.data is deprecated, and will be removed "
+            "in an upcoming release. To get the data of an observable "
+            "from a measurement, use MeasurementProcess.obs.data instead",
+            qml.PennyLaneDeprecationWarning,
+        )
+        return []
 
     @property
     def return_type(self) -> Optional[ObservableReturnTypes]:

--- a/tests/measurements/test_measurements.py
+++ b/tests/measurements/test_measurements.py
@@ -414,6 +414,18 @@ class TestProperties:
         mapped_mp2 = mp2.map_wires(wire_map)
         assert qml.equal(mapped_mp2, qml.sample(op=m2 * m3))
 
+    def test_name_and_data_are_deprecated(self):
+        """Test that MP.name and MP.data are deprecated."""
+        mp = qml.expval(qml.PauliZ(0))
+        with pytest.warns(
+            qml.PennyLaneDeprecationWarning, match="MeasurementProcess.name is deprecated"
+        ):
+            _ = mp.name
+        with pytest.warns(
+            qml.PennyLaneDeprecationWarning, match="MeasurementProcess.data is deprecated"
+        ):
+            _ = mp.data
+
 
 class TestExpansion:
     """Test for measurement expansion"""


### PR DESCRIPTION
`mp.name` has always been "Identity", and `mp.data` has always been `[]`. This was needed as a hack in the past, but we don't need it anymore.

This PR deprecates those values, and they will be removed in the next release.

[sc-43949]