### PR TITLE
[WIP] Matrix/Tensor product between two PauliWords now returns PauliSentence

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -45,9 +45,11 @@
   of `functools.partial`.
   [(#5046)](https://github.com/PennyLaneAI/pennylane/pull/5046)
 
+* Multiplying two `PauliWord` instances no longer returns a tuple `(new_word, coeff)` but instead `PauliSentence({new_word: coeff})`. The old behavior is still available with the private method `PauliWord._matmul(other)` for faster processing.
+
 <h3>Deprecations 👋</h3>
 
-* Matrix and tensor products between `PauliWord` and `PauliSentence` instances are done using the `@` operator, `*` will be used only for scalar multiplication.
+* Matrix and tensor products between `PauliWord` and `PauliSentence` instances are done using the `@` operator, `*` will be used only for scalar multiplication. Note also the breaking change that the product of two `PauliWord` instances now returns a `PauliSentence` instead of a tuple `(new_word, coeff)`.
   [(#4989)](https://github.com/PennyLaneAI/pennylane/pull/4989)
 
 <h3>Documentation 📝</h3>

--- a/tests/pauli/test_pauli_arithmetic.py
+++ b/tests/pauli/test_pauli_arithmetic.py
@@ -86,7 +86,7 @@ class TestDeprecations:
 def test_legacy_multiplication_pwords(pauli1, pauli2):
     """Test the legacy behavior for using the star operator for matrix multiplication of pauli words"""
     res1, coeff1 = pauli1 * pauli2
-    res2, coeff2 = pauli1 @ pauli2
+    res2, coeff2 = pauli1._matmul(pauli2)
     assert res1 == res2
     assert coeff1 == coeff2
 
@@ -304,10 +304,21 @@ class TestPauliWord:
 
     @pytest.mark.parametrize("word1, word2, result_pw, coeff", tup_pws_matmult)
     def test_matmul(self, word1, word2, result_pw, coeff):
+        """Test the user facing matrix multiplication between two pauli words"""
         copy_pw1 = copy(word1)
         copy_pw2 = copy(word2)
 
-        assert word1 @ word2 == (result_pw, coeff)
+        assert word1 @ word2 == PauliSentence({result_pw: coeff})
+        assert copy_pw1 == word1  # check for mutation of the pw themselves
+        assert copy_pw2 == word2
+    
+    @pytest.mark.parametrize("word1, word2, result_pw, coeff", tup_pws_matmult)
+    def test_private_private_matmul(self, word1, word2, result_pw, coeff):
+        """Test the private matrix multiplication that returns a tuple (new_word, coeff)"""
+        copy_pw1 = copy(word1)
+        copy_pw2 = copy(word2)
+
+        assert word1._matmul(word2) == (result_pw, coeff)
         assert copy_pw1 == word1  # check for mutation of the pw themselves
         assert copy_pw2 == word2
 


### PR DESCRIPTION
Following discussion here](https://github.com/PennyLaneAI/pennylane/pull/5017#discussion_r1447873880) changing the default behavior of products between two `PauliWord` instances.

One thing I am still unsure about at the moment is for pure tensor products (where no coefficient is raised). E.g.
```
pw1 = PauliWord({0:"X"})
pw2 = PauliWord({1:"X"})
```
I would find it counterintuitive to get a PauliSentence from `pw1 @ pw2` but would expect `PauliWord({0:"X", 1:"X"})`