### PR TITLE
Deprecate various unused pauli utils

### DIFF
--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -9,6 +9,19 @@ deprecations are listed below.
 Pending deprecations
 --------------------
 
+* ``qml.pauli.pauli_mult`` and ``qml.pauli.pauli_mult_with_phase`` are now deprecated. Instead, you
+  should use ``qml.prod(pauli_1, pauli_2).simplify()`` to get the reduced operator. Note that if there
+  is a phase, you can access it via ``op.scalar``.
+
+  >>> op = qml.prod(qml.PauliX(0), qml.PauliZ(0)).simplify()
+  >>> op, op.scalar, op.base
+  (-1j*(PauliY(wires=[0])), -1j, PauliY(wires=[0]))
+  >>> qml.prod(qml.PauliZ(0) @ qml.PauliX(0)).simplify()
+  PauliZ(wires=[0]) @ PauliX(wires=[0])
+
+  - Deprecated in v0.35
+  - Will be removed in v0.36
+
 * ``MeasurementProcess.name`` and ``MeasurementProcess.data`` have been deprecated, as they contain
   dummy values that are no longer needed.
 

--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -9,6 +9,13 @@ deprecations are listed below.
 Pending deprecations
 --------------------
 
+* The private functions ``_pauli_mult``, ``_binary_matrix`` and ``_get_pauli_map`` from the
+  ``pauli`` module have been deprecated, as they are no longer used anywhere and the same
+  functionality can be achieved using newer features in the ``pauli`` module.
+
+  - Deprecated in v0.35
+  - Will be removed in v0.36
+
 * ``qml.pauli.pauli_mult`` and ``qml.pauli.pauli_mult_with_phase`` are now deprecated. Instead, you
   should use ``qml.prod(pauli_1, pauli_2).simplify()`` to get the reduced operator. Note that if there
   is a phase, you can access it via ``op.scalar``.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -71,6 +71,11 @@
   is a phase, you can access it via `op.scalar`.
   [()]()
 
+* The private functions `_pauli_mult`, `_binary_matrix` and `_get_pauli_map` from the
+  `pauli` module have been deprecated, as they are no longer used anywhere and the same
+  functionality can be achieved using newer features in the `pauli` module.
+  [()]()
+
 <h3>Documentation 📝</h3>
 
 * A typo in a code example in the `qml.transforms` API has been fixed.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -66,6 +66,11 @@
   values that are no longer needed.
   [(#5047)](https://github.com/PennyLaneAI/pennylane/pull/5047)
 
+* `qml.pauli.pauli_mult` and `qml.pauli.pauli_mult_with_phase` are now deprecated. Instead, you
+  should use `qml.prod(pauli_1, pauli_2).simplify()` to get the reduced operator. Note that if there
+  is a phase, you can access it via `op.scalar`.
+  [()]()
+
 <h3>Documentation 📝</h3>
 
 * A typo in a code example in the `qml.transforms` API has been fixed.

--- a/pennylane/ops/op_math/pow.py
+++ b/pennylane/ops/op_math/pow.py
@@ -182,7 +182,7 @@ class Pow(ScalarSymbolicOp):
             ):
                 pr = base_pauli_rep
                 for _ in range(self.z - 1):
-                    pr = pr * base_pauli_rep
+                    pr = pr @ base_pauli_rep
                 self._pauli_rep = pr
             else:
                 self._pauli_rep = None

--- a/pennylane/ops/op_math/prod.py
+++ b/pennylane/ops/op_math/prod.py
@@ -354,7 +354,7 @@ class Prod(CompositeOp):
     def _build_pauli_rep(self):
         """PauliSentence representation of the Product of operations."""
         if all(operand_pauli_reps := [op.pauli_rep for op in self.operands]):
-            return reduce(lambda a, b: a * b, operand_pauli_reps)
+            return reduce(lambda a, b: a @ b, operand_pauli_reps)
         return None
 
     def _simplify_factors(self, factors: Tuple[Operator]) -> Tuple[complex, Operator]:

--- a/pennylane/pauli/conversion.py
+++ b/pennylane/pauli/conversion.py
@@ -387,13 +387,13 @@ def _(op: Tensor):
         raise ValueError(f"Op must be a linear combination of Pauli operators only, got: {op}")
 
     factors = (_pauli_sentence(factor) for factor in op.obs)
-    return reduce(lambda a, b: a * b, factors)
+    return reduce(lambda a, b: a @ b, factors)
 
 
 @_pauli_sentence.register
 def _(op: Prod):
     factors = (_pauli_sentence(factor) for factor in op)
-    return reduce(lambda a, b: a * b, factors)
+    return reduce(lambda a, b: a @ b, factors)
 
 
 @_pauli_sentence.register

--- a/pennylane/pauli/utils.py
+++ b/pennylane/pauli/utils.py
@@ -23,6 +23,7 @@ representation of Pauli words and applications, see:
 from functools import lru_cache, reduce, singledispatch
 from itertools import product
 from typing import List, Union
+from warnings import warn
 
 import numpy as np
 
@@ -932,6 +933,13 @@ def pauli_group(n_qubits, wire_map=None):
 def pauli_mult(pauli_1, pauli_2, wire_map=None):
     """Multiply two Pauli words together and return the product as a Pauli word.
 
+    .. warning::
+
+        ``pauli_mult`` is deprecated. Instead, you can multiply two Pauli words
+        together with ``qml.prod(pauli_1, pauli_2).simplify()``. Note that if
+        there is a phase, this will be in ``result.scalar``, and the base will be
+        available in ``result.base``.
+
     Two Pauli operations can be multiplied together by taking the additive
     OR of their binary symplectic representations.
 
@@ -960,6 +968,14 @@ def pauli_mult(pauli_1, pauli_2, wire_map=None):
     PauliZ(wires=[0])
     """
 
+    warn(
+        "`pauli_mult` is deprecated. Instead, you can multiply two Pauli words "
+        "together with `qml.prod(pauli_1, pauli_2).simplify()`. Note that if "
+        "there is a phase, this will be in `result.scalar`, and the base will be "
+        "available in `result.base`.",
+        qml.PennyLaneDeprecationWarning,
+    )
+
     if wire_map is None:
         wire_map = _wire_map_from_pauli_pair(pauli_1, pauli_2)
 
@@ -984,6 +1000,13 @@ def pauli_mult(pauli_1, pauli_2, wire_map=None):
 def pauli_mult_with_phase(pauli_1, pauli_2, wire_map=None):
     r"""Multiply two Pauli words together, and return both their product as a Pauli word
     and the global phase.
+
+    .. warning::
+
+        ``pauli_mult_with_phase`` is deprecated. Instead, you can multiply two Pauli
+        words together with ``qml.prod(pauli_1, pauli_2).simplify()``. Note that if
+        there is a phase, this will be in ``result.scalar``, and the base will be
+        available in ``result.base``.
 
     Two Pauli operations can be multiplied together by taking the additive
     OR of their binary symplectic representations. The phase is computed by
@@ -1017,6 +1040,14 @@ def pauli_mult_with_phase(pauli_1, pauli_2, wire_map=None):
     >>> phase
     1j
     """
+
+    warn(
+        "`pauli_mult_with_phase` is deprecated. Instead, you can multiply two Pauli words "
+        "together with `qml.prod(pauli_1, pauli_2).simplify()`. Note that if "
+        "there is a phase, this will be in `result.scalar`, and the base will be "
+        "available in `result.base`.",
+        qml.PennyLaneDeprecationWarning,
+    )
 
     if wire_map is None:
         wire_map = _wire_map_from_pauli_pair(pauli_1, pauli_2)

--- a/pennylane/pauli/utils.py
+++ b/pennylane/pauli/utils.py
@@ -1438,6 +1438,12 @@ def _pauli_mult(p1, p2):
     >>> _pauli_mult(p1, p2)
     ([(2, "Y"), (1, "Y")], 1.0) # p1 @ p2 = X_0 @ Y_1 @ X_0 @ Y_2
     """
+
+    warn(
+        "_pauli_mult is deprecated. Instead, please use the "
+        "PauliWord class, or regular PennyLane operators.",
+        qml.PennyLaneDeprecationWarning,
+    )
     c = 1.0
 
     t1 = [t[0] for t in p1]
@@ -1525,6 +1531,11 @@ def _binary_matrix(terms, num_qubits, wire_map=None):
            [1, 0, 1, 0, 0, 0, 1, 0],
            [0, 0, 0, 1, 1, 0, 0, 1]])
     """
+    warn(
+        "_binary_matrix is deprecated. Instead, please use PauliWords and _binary_matrix_from_pws",
+        qml.PennyLaneDeprecationWarning,
+    )
+
     if wire_map is None:
         all_wires = qml.wires.Wires.all_wires([term.wires for term in terms], sort=True)
         wire_map = {i: c for c, i in enumerate(all_wires)}
@@ -1590,6 +1601,7 @@ def _get_pauli_map(n):
 
     This function is used to accelerate ``qchem.observable_hf.jordan_wigner``.
     """
+    warn("_get_pauli_map is deprecated, as it is no longer used.", qml.PennyLaneDeprecationWarning)
     return [
         {"I": qml.Identity(i), "X": qml.PauliX(i), "Y": qml.PauliY(i), "Z": qml.PauliZ(i)}
         for i in range(n + 1)

--- a/tests/pauli/test_pauli_utils.py
+++ b/tests/pauli/test_pauli_utils.py
@@ -925,10 +925,11 @@ class TestObservableHF:
             ),
         ],
     )
-    def test_pauli_mult(self, p1, p2, p_ref):
-        r"""Test that _pauli_mult returns the correct operator."""
+    def test_deprecated_pauli_mult(self, p1, p2, p_ref):
+        r"""Test that _pauli_mult raises a deprecation warning."""
         # pylint: disable=protected-access
-        result = qml.pauli.utils._pauli_mult(p1, p2)
+        with pytest.warns(qml.PennyLaneDeprecationWarning, match="_pauli_mult is deprecated"):
+            result = qml.pauli.utils._pauli_mult(p1, p2)
 
         assert result == p_ref
 
@@ -1049,7 +1050,8 @@ class TestTapering:
     def test_binary_matrix(self, terms, num_qubits, result):
         r"""Test that _binary_matrix returns the correct result."""
         # pylint: disable=protected-access
-        binary_matrix = qml.pauli.utils._binary_matrix(terms, num_qubits)
+        with pytest.warns(qml.PennyLaneDeprecationWarning, match="_binary_matrix is deprecated"):
+            binary_matrix = qml.pauli.utils._binary_matrix(terms, num_qubits)
         assert (binary_matrix == result).all()
 
     @pytest.mark.parametrize(("terms", "num_qubits", "result"), terms_bin_mat_data)
@@ -1059,3 +1061,9 @@ class TestTapering:
         pws_lst = [list(qml.pauli.pauli_sentence(t))[0] for t in terms]
         binary_matrix = qml.pauli.utils._binary_matrix_from_pws(pws_lst, num_qubits)
         assert (binary_matrix == result).all()
+
+
+def test_deprecated_get_pauli_map():
+    """Test that _get_pauli_map is deprecated."""
+    with pytest.warns(qml.PennyLaneDeprecationWarning, match="_get_pauli_map is deprecated"):
+        _ = qml.pauli.utils._get_pauli_map(0)  # pylint:disable=protected-access


### PR DESCRIPTION
**Context:**
Much of the `pauli` module has been sitting stale, and is now being deprecated.

**Description of the Change:**
- Deprecated `pauli_mult_with_phase`, `pauli_mult`, `_pauli_mult`, `_binary_matrix` and `_get_pauli_map` from the `pauli` module
- Fixed some places that are still using `ps1 * ps2` instead of `ps1 @ ps2`. They don't seem to be caught by tests because they are used at test collection time, and pytest only catches ones at test run-time

**Benefits:**
cleaning up pennylane!