### PR TITLE
Make sure `@` is used for Pauli arithmetic in the codebase

### DIFF
--- a/pennylane/ops/op_math/prod.py
+++ b/pennylane/ops/op_math/prod.py
@@ -354,7 +354,7 @@ class Prod(CompositeOp):
     def _build_pauli_rep(self):
         """PauliSentence representation of the Product of operations."""
         if all(operand_pauli_reps := [op.pauli_rep for op in self.operands]):
-            return reduce(lambda a, b: a * b, operand_pauli_reps)
+            return reduce(lambda a, b: a @ b, operand_pauli_reps)
         return None
 
     def _simplify_factors(self, factors: Tuple[Operator]) -> Tuple[complex, Operator]:


### PR DESCRIPTION
Making sure `@` is used after deprecating `*` in the codebase (and avoiding unexpected warnings) https://github.com/PennyLaneAI/pennylane/pull/4989

Before, multiplication of pauli operators would raise an unexpected warning
```
import pennylane as qml
op1 = qml.PauliX(0)
op2 = qml.PauliY(0)
>>> qml.prod(op1, op2)
pennylane/pennylane/pauli/pauli_arithmetic.py:567: PennyLaneDeprecationWarning: Matrix/Tensor multiplication using the * operator on PauliWords and PauliSentences is deprecated, use @ instead.
  warnings.warn(
PauliX(wires=[0]) @ PauliY(wires=[0])
```

Not sure if a test is necessary, and if so, how do you test that a warning is _not_ raised?
Also, does this need an extra changelog entry?