### PR TITLE
pin sphinxcontrib-applehelp in doc requirements

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -17,6 +17,7 @@ sphinx==4.2; python_version == "3.10"
 sphinx-automodapi==0.13
 sphinx-copybutton
 sphinxcontrib-bibtex==2.4.2
+sphinxcontrib-applehelp==1.0.7
 tensorflow==2.11.1; platform_machine == "x86_64"
 tensorflow_macos==2.9.0; sys_platform == "darwin" and platform_machine == "arm64"
 tensornetwork==0.3

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -19,6 +19,8 @@ sphinx-copybutton
 sphinxcontrib-bibtex==2.4.2
 sphinxcontrib-applehelp==1.0.4
 sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-qthelp==1.0.3
+sphinxcontrib-htmlhelp==2.0.1
 tensorflow==2.11.1; platform_machine == "x86_64"
 tensorflow_macos==2.9.0; sys_platform == "darwin" and platform_machine == "arm64"
 tensornetwork==0.3

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -17,7 +17,7 @@ sphinx==4.2; python_version == "3.10"
 sphinx-automodapi==0.13
 sphinx-copybutton
 sphinxcontrib-bibtex==2.4.2
-sphinxcontrib-applehelp==1.0.7
+sphinxcontrib-applehelp==1.0.4
 tensorflow==2.11.1; platform_machine == "x86_64"
 tensorflow_macos==2.9.0; sys_platform == "darwin" and platform_machine == "arm64"
 tensornetwork==0.3

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -21,6 +21,7 @@ sphinxcontrib-applehelp==1.0.4
 sphinxcontrib-devhelp==1.0.2
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-htmlhelp==2.0.1
+sphinxcontrib-serializinghtml==1.1.5
 tensorflow==2.11.1; platform_machine == "x86_64"
 tensorflow_macos==2.9.0; sys_platform == "darwin" and platform_machine == "arm64"
 tensornetwork==0.3

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -18,6 +18,7 @@ sphinx-automodapi==0.13
 sphinx-copybutton
 sphinxcontrib-bibtex==2.4.2
 sphinxcontrib-applehelp==1.0.4
+sphinxcontrib-devhelp==1.0.2
 tensorflow==2.11.1; platform_machine == "x86_64"
 tensorflow_macos==2.9.0; sys_platform == "darwin" and platform_machine == "arm64"
 tensornetwork==0.3


### PR DESCRIPTION
it fails every time because they released a new version on Friday. See [this CI run](https://github.com/PennyLaneAI/pennylane/actions/runs/7528280758/job/20490145370) as an example.

```
Sphinx version error:
The sphinxcontrib.applehelp extension used by this project needs at least Sphinx v5.0; it therefore cannot be built with this version.
```