### PR TITLE
Clarify difference between `QuantumTape` and `QuantumScript`

### DIFF
--- a/doc/code/qml_tape.rst
+++ b/doc/code/qml_tape.rst
@@ -6,7 +6,7 @@ Quantum tapes are a datastructure that can represent quantum circuits and measur
 In addition to being created internally by QNodes, quantum tapes can also be created,
 nested, expanded (via :meth:`~.QuantumTape.expand`), and executed manually.
 
-Finally, quantum tapes are fully compatible with autodifferentiating via NumPy/Autograd,
+Finally, quantum tapes are fully compatible with autodifferentiating via Autograd, JAX, 
 TensorFlow, and PyTorch.
 
 .. warning::
@@ -17,6 +17,51 @@ TensorFlow, and PyTorch.
     See the :doc:`quantum circuits <../introduction/circuits>` page for more
     details on creating QNodes, as well as the :func:`~pennylane.qnode` decorator
     and :func:`~pennylane.QNode` constructor.
+
+**``QuantumTape`` versus ``QuantumScript``**
+
+A ``QuantumScript`` is purely a representation of a quantum circuit, and can only be constructed
+via initialization. Once it is initialized, the contents should then remain immutable throughout its lifetime.
+
+>>> ops = [qml.PauliX(0)]
+>>> measurements = [qml.expval(qml.PauliZ(0))]
+>>> QuantumScript(ops, measurements, shots=10)
+<QuantumScript: wires=[0], params=0>
+
+A ``QuantumTape`` has additional queuing capabilities and also inherits from :class:`~.AnnotatedQueue`.  It's contents
+are set on exiting the context, rather than upon initialization. Since queuing requires interaction with the global singleton
+:class:`~.QueuingManager`, the ``QuantumTape`` requires a ``threading.RLock`` which complicates its use in distributed
+situations.
+
+>>> with QuantumTape(shots=10) as tape:
+...     qml.PauliX(0)
+...     qml.expval(qml.PauliZ(0))
+>>> tape
+<QuantumTape: wires=[0], params=0>
+
+The ``QuantumTape`` also carries around the unprocessed queue in addtion to the processed ``operations`` and ``measurements``, leading
+to a larger memory footprint.
+
+>>> tape.items()
+((PauliX(wires=[0]), {}), (expval(PauliZ(wires=[0])), {}))
+
+To capture a quantum function, we instead recommend queuing a quantum function into an :class:`~.AnnotatedQueue`,
+and then processing that into a ``QuantumScript``.
+
+>>> with qml.queuing.AnnotatedQueue() as q:
+...     qfunc(*args, **kwargs)
+>>> QuantumScript.from_queue(q)
+<QuantumScript: wires=[0], params=0> 
+
+Since queuing is also sensitive to the "identity" of an operation, not just its contents, an operation has to be copied in
+order for it to be used multiple times in a ``QuantumTape``.  A ``QuantumScript`` can allow the same operation to be
+used many times in the circuit, potentially reducing its memory footprint.
+
+>>> op = qml.T(0)
+>>> QuantumScript([op] * 100, [qml.probs(wires=0)])
+
+Since users are familiar with the term ``QuantumTape``, that term should be used in documentation. For performance
+and a reduction in unintended side effects, ``QuantumScript`` is strictly used in PennyLane source code.
 
 .. automodapi:: pennylane.tape
     :no-main-docstr:

--- a/doc/code/qml_tape.rst
+++ b/doc/code/qml_tape.rst
@@ -29,10 +29,9 @@ via initialization. Once it is initialized, the contents should then remain immu
 >>> QuantumScript(ops, measurements, shots=10)
 <QuantumScript: wires=[0], params=0>
 
-A ``QuantumTape`` has additional queuing capabilities and also inherits from :class:`~.AnnotatedQueue`.  It's contents
+A ``QuantumTape`` has additional queuing capabilities and also inherits from :class:`~.AnnotatedQueue`.  Its contents
 are set on exiting the context, rather than upon initialization. Since queuing requires interaction with the global singleton
 :class:`~pennylane.QueuingManager`, the ``QuantumTape`` requires a ``threading.RLock`` which complicates its use in distributed
-
 situations.
 
 >>> with QuantumTape(shots=10) as tape:

--- a/doc/code/qml_tape.rst
+++ b/doc/code/qml_tape.rst
@@ -18,7 +18,8 @@ TensorFlow, and PyTorch.
     details on creating QNodes, as well as the :func:`~pennylane.qnode` decorator
     and :func:`~pennylane.QNode` constructor.
 
-**``QuantumTape`` versus ``QuantumScript``**
+QuantumTape versus QuantumScript
+--------------------------------
 
 A ``QuantumScript`` is purely a representation of a quantum circuit, and can only be constructed
 via initialization. Once it is initialized, the contents should then remain immutable throughout its lifetime.
@@ -30,7 +31,8 @@ via initialization. Once it is initialized, the contents should then remain immu
 
 A ``QuantumTape`` has additional queuing capabilities and also inherits from :class:`~.AnnotatedQueue`.  It's contents
 are set on exiting the context, rather than upon initialization. Since queuing requires interaction with the global singleton
-:class:`~.QueuingManager`, the ``QuantumTape`` requires a ``threading.RLock`` which complicates its use in distributed
+:class:`~pennylane.QueuingManager`, the ``QuantumTape`` requires a ``threading.RLock`` which complicates its use in distributed
+
 situations.
 
 >>> with QuantumTape(shots=10) as tape:
@@ -39,7 +41,7 @@ situations.
 >>> tape
 <QuantumTape: wires=[0], params=0>
 
-The ``QuantumTape`` also carries around the unprocessed queue in addtion to the processed ``operations`` and ``measurements``, leading
+The ``QuantumTape`` also carries around the unprocessed queue in addition to the processed ``operations`` and ``measurements``, 
 to a larger memory footprint.
 
 >>> tape.items()

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -76,6 +76,7 @@
 <h3>Documentation 📝</h3>
 
 * The module documentation for `pennylane.tape` now explains the difference between `QuantumTape` and `QuantumScript`.
+  [(#5065)](https://github.com/PennyLaneAI/pennylane/pull/5065)
 
 * A typo in a code example in the `qml.transforms` API has been fixed.
   [(#5014)](https://github.com/PennyLaneAI/pennylane/pull/5014)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -76,6 +76,8 @@
 
 <h3>Documentation 📝</h3>
 
+* The module documentation for `pennylane.tape` now explains the difference between `QuantumTape` and `QuantumScript`.
+
 * A typo in a code example in the `qml.transforms` API has been fixed.
   [(#5014)](https://github.com/PennyLaneAI/pennylane/pull/5014)
 


### PR DESCRIPTION
[sc-54022]

**Context:**

We keep the name `QuantumTape` in documentation, but strictly use its parent `QuantumScript` in PennyLane source code. We use `QuantumScript` because carrying around an unnecessary `AnnotatedQueue` can cause difficulties with parallelism and construction via queuing is substantially more expensive in both memory and time. Queuing can also lead to unintended side effects of things entering the circuit that shouldn't, or things not entering the circuit that should.

This disconnect between documentation and source code is not explained anyone, and a bit confusing.  So this adds some clarification to the module documentation for `qml.tape.`.

**Description of the Change:**

Added module documentation.

**Benefits:**

Hopefully this clears up some confusion.

**Possible Drawbacks:**

**Related GitHub Issues:**
