### PR TITLE
legacy device: check if object is measurement before checking stopping_condition

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -75,6 +75,7 @@
 * `MeasurementProcess.name` and `MeasurementProcess.data` are now deprecated, as they contain dummy
   values that are no longer needed.
   [(#5047)](https://github.com/PennyLaneAI/pennylane/pull/5047)
+  [()]()
 
 * Calling `qml.matrix` without providing a `wire_order` on objects where the wire order could be
   ambiguous now raises a warning. In the future, the `wire_order` argument will be required in

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -75,7 +75,7 @@
 * `MeasurementProcess.name` and `MeasurementProcess.data` are now deprecated, as they contain dummy
   values that are no longer needed.
   [(#5047)](https://github.com/PennyLaneAI/pennylane/pull/5047)
-  [()]()
+  [(#5071)](https://github.com/PennyLaneAI/pennylane/pull/5071)
 
 * Calling `qml.matrix` without providing a `wire_order` on objects where the wire order could be
   ambiguous now raises a warning. In the future, the `wire_order` argument will be required in

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -75,7 +75,7 @@ def _local_tape_expand(tape, depth, stop_at):
         (tape.measurements, new_measurements),
     ]:
         for obj in queue:
-            if stop_at(obj) or isinstance(obj, qml.measurements.MeasurementProcess):
+            if isinstance(obj, MeasurementProcess) or stop_at(obj):
                 new_queue.append(obj)
                 continue
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -290,7 +290,7 @@ class TestDeviceSupportedLogic:
             dev.supports_observable(operation)
 
 
-class TestInternalFunctions:
+class TestInternalFunctions:  # pylint:disable=too-many-public-methods
     """Test the internal functions of the abstract Device class"""
 
     # pylint: disable=unnecessary-dunder-call
@@ -612,6 +612,15 @@ class TestInternalFunctions:
         assert new_tape.wires == tape.wires
         assert new_tape.batch_size == tape.batch_size
         assert new_tape.output_dim == tape.output_dim
+
+    def test_default_expand_fn_with_invalid_op(self, mock_device_with_operations, recwarn):
+        """Test that default_expand_fn works with an invalid op and some measurement."""
+        invalid_tape = qml.tape.QuantumScript([qml.S(0)], [qml.expval(qml.PauliZ(0))])
+        expected_tape = qml.tape.QuantumScript([qml.RZ(np.pi / 2, 0)], [qml.expval(qml.PauliZ(0))])
+        dev = mock_device_with_operations(wires=1)
+        expanded_tape = dev.expand_fn(invalid_tape, max_expansion=3)
+        assert qml.equal(expanded_tape, expected_tape)
+        assert len(recwarn) == 0
 
 
 # pylint: disable=too-few-public-methods


### PR DESCRIPTION
**Context:**
Many plugins are failing because of the deprecation of `MeasurementProcess.name` (#5047). The old device API checks if an object meets the stopping requirement _or_ if it's a measurement (in that order). Due to this ordering, we reference `mp.name` which is now deprecated.

**Description of the Change:**
Swap the order of conditions in `_local_tape_expand` to avoid hitting this deprecation warning

**Benefits:**
Plugins will work again!

**Possible Drawbacks:**
N/A