### PR TITLE
Remove QuantumScript.is_sampled and QuantumScript.all_sampled

### DIFF
--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -61,20 +61,6 @@ Pending deprecations
   - Deprecated in v0.34
   - Will be removed in v0.36
 
-* ``QuantumScript.is_sampled`` and ``QuantumScript.all_sampled`` are deprecated. Users should now validate
-  these properties manually.
-
-  .. code-block:: python
-
-    from pennylane.measurements import *
-    sample_types = (SampleMP, CountsMP, ClassicalShadowMP, ShadowExpvalMP)
-    is_sample_type = [isinstance(m, sample_types) for m in tape.measurements]
-    is_sampled = any(is_sample_type)
-    all_sampled = all(is_sample_type)
-
-  - Deprecated in v0.34
-  - Will be removed in v0.35
-
 * ``qml.ExpvalCost`` has been deprecated, and usage will now raise a warning.
 
   - Deprecated in v0.24
@@ -150,6 +136,20 @@ Completed deprecation cycles
 * ``ClassicalShadow.entropy()`` no longer needs an ``atol`` keyword as a better
   method to estimate entropies from approximate density matrix reconstructions
   (with potentially negative eigenvalues) has been implemented.
+
+  - Deprecated in v0.34
+  - Removed in v0.35
+
+* ``QuantumScript.is_sampled`` and ``QuantumScript.all_sampled`` are deprecated. Users should now validate
+  these properties manually.
+
+  .. code-block:: python
+
+    from pennylane.measurements import *
+    sample_types = (SampleMP, CountsMP, ClassicalShadowMP, ShadowExpvalMP)
+    is_sample_type = [isinstance(m, sample_types) for m in tape.measurements]
+    is_sampled = any(is_sample_type)
+    all_sampled = all(is_sample_type)
 
   - Deprecated in v0.34
   - Removed in v0.35

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -66,6 +66,9 @@
   (with potentially negative eigenvalues) has been implemented.
   [(#5048)](https://github.com/PennyLaneAI/pennylane/pull/5048)
 
+* `QuantumScript.is_sampled` and `QuantumScript.all_sampled` have been removed. Users should now
+  validate these properties manually.
+
 <h3>Deprecations 👋</h3>
 
 * Matrix and tensor products between `PauliWord` and `PauliSentence` instances are done using the `@` operator, `*` will be used only for scalar multiplication.

--- a/pennylane/tape/qscript.py
+++ b/pennylane/tape/qscript.py
@@ -21,16 +21,11 @@ import contextlib
 import copy
 from collections import Counter
 from typing import List, Union, Optional, Sequence
-from warnings import warn
 
 import pennylane as qml
 from pennylane.measurements import (
-    ClassicalShadowMP,
-    CountsMP,
     MeasurementProcess,
     ProbabilityMP,
-    SampleMP,
-    ShadowExpvalMP,
     StateMP,
     Shots,
 )
@@ -398,34 +393,6 @@ class QuantumScript:
     def op_wires(self) -> Wires:
         """Returns the wires that the tape operations act on."""
         return Wires.all_wires(op.wires for op in self.operations)
-
-    @property
-    def is_sampled(self) -> bool:
-        """Whether any measurements are of a type that requires samples."""
-        warn(
-            "QuantumScript.is_sampled is deprecated. This property should now be "
-            "validated manually:\n\n"
-            ">>> from pennylane.measurements import *\n"
-            ">>> sample_types = (SampleMP, CountsMP, ClassicalShadowMP, ShadowExpvalMP)\n"
-            ">>> is_sampled = any(isinstance(m, sample_types) for m in tape.measurements)\n",
-            qml.PennyLaneDeprecationWarning,
-        )
-        sample_type = (SampleMP, CountsMP, ClassicalShadowMP, ShadowExpvalMP)
-        return any(isinstance(m, sample_type) for m in self.measurements)
-
-    @property
-    def all_sampled(self) -> bool:
-        """Whether all measurements are of a type that requires samples."""
-        warn(
-            "QuantumScript.all_sampled is deprecated. This property should now be "
-            "validated manually:\n\n"
-            ">>> from pennylane.measurements import *\n"
-            ">>> sample_types = (SampleMP, CountsMP, ClassicalShadowMP, ShadowExpvalMP)\n"
-            ">>> all_sampled = all(isinstance(m, sample_types) for m in tape.measurements)\n",
-            qml.PennyLaneDeprecationWarning,
-        )
-        sample_type = (SampleMP, CountsMP, ClassicalShadowMP, ShadowExpvalMP)
-        return all(isinstance(m, sample_type) for m in self.measurements)
 
     ##### Update METHODS ###############
 

--- a/tests/tape/test_qscript.py
+++ b/tests/tape/test_qscript.py
@@ -131,11 +131,6 @@ class TestUpdate:
     @pytest.mark.parametrize("sample_ms", sample_measurements)
     def test_update_circuit_info_sampling(self, sample_ms):
         qs = QuantumScript(measurements=[qml.expval(qml.PauliZ(0)), sample_ms])
-        with pytest.warns(UserWarning, match="QuantumScript.is_sampled is deprecated"):
-            assert qs.is_sampled is True
-        with pytest.warns(UserWarning, match="QuantumScript.all_sampled is deprecated"):
-            assert qs.all_sampled is False
-
         shadow_mp = sample_ms.return_type not in (
             qml.measurements.Shadow,
             qml.measurements.ShadowExpval,
@@ -143,20 +138,12 @@ class TestUpdate:
         assert qs.samples_computational_basis is shadow_mp
 
         qs = QuantumScript(measurements=[sample_ms, sample_ms, qml.sample()])
-        with pytest.warns(UserWarning, match="QuantumScript.is_sampled is deprecated"):
-            assert qs.is_sampled is True
-        with pytest.warns(UserWarning, match="QuantumScript.all_sampled is deprecated"):
-            assert qs.all_sampled is True
         assert qs.samples_computational_basis is True
 
     def test_update_circuit_info_no_sampling(self):
         """Test that all_sampled, is_sampled and samples_computational_basis properties are set to False if no sampling
         measurement process exists."""
         qs = QuantumScript(measurements=[qml.expval(qml.PauliZ(0))])
-        with pytest.warns(UserWarning, match="QuantumScript.is_sampled is deprecated"):
-            assert qs.is_sampled is False
-        with pytest.warns(UserWarning, match="QuantumScript.all_sampled is deprecated"):
-            assert qs.all_sampled is False
         assert qs.samples_computational_basis is False
 
     def test_samples_computational_basis_correctly(self):


### PR DESCRIPTION
Complete deprecation cycle and remove `QuantumScript.is_sampled` and `QuantumScript.all_sampled`.