### PR TITLE
update more spots that use MP.name

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -83,6 +83,7 @@
   values that are no longer needed.
   [(#5047)](https://github.com/PennyLaneAI/pennylane/pull/5047)
   [(#5071)](https://github.com/PennyLaneAI/pennylane/pull/5071)
+  [(#)](https://github.com/PennyLaneAI/pennylane/pull/)
 
 * Calling `qml.matrix` without providing a `wire_order` on objects where the wire order could be
   ambiguous now raises a warning. In the future, the `wire_order` argument will be required in

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -83,7 +83,7 @@
   values that are no longer needed.
   [(#5047)](https://github.com/PennyLaneAI/pennylane/pull/5047)
   [(#5071)](https://github.com/PennyLaneAI/pennylane/pull/5071)
-  [(#)](https://github.com/PennyLaneAI/pennylane/pull/)
+  [(#5076)](https://github.com/PennyLaneAI/pennylane/pull/5076)
 
 * Calling `qml.matrix` without providing a `wire_order` on objects where the wire order could be
   ambiguous now raises a warning. In the future, the `wire_order` argument will be required in

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -608,7 +608,8 @@ class Device(abc.ABC):
         function accepts a queuable object (including a PennyLane operation
         and observable) and returns ``True`` if supported by the device."""
         return qml.BooleanFn(
-            lambda obj: not isinstance(obj, QuantumScript) and self.supports_operation(obj.name)
+            lambda obj: not isinstance(obj, QuantumScript)
+            and (isinstance(obj, MeasurementProcess) or self.supports_operation(obj.name))
         )
 
     def custom_expand(self, fn):
@@ -986,8 +987,10 @@ class Device(abc.ABC):
                 )
 
         for o in observables:
-            if isinstance(o, qml.measurements.MeasurementProcess) and o.obs is not None:
+            if isinstance(o, MeasurementProcess):
                 o = o.obs
+                if o is None:
+                    continue
 
             if isinstance(o, Tensor):
                 # TODO: update when all capabilities keys changed to "supports_tensor_observables"


### PR DESCRIPTION
Same as #5071 but in other places.

I'm a little worried that maybe we shouldn't deprecate `MeasurementProcess.name` at all... seems like we kinda depend on it? My first thought was to just make them more correct (eg. "State", "Probs"), but I don't think any devices have those saved in their `dev.observables` so I suppose this might still be the best way forward