### PR TITLE
Remove test using `scipy.kron`

### DIFF
--- a/tests/math/test_multi_dispatch.py
+++ b/tests/math/test_multi_dispatch.py
@@ -17,7 +17,6 @@
 import autoray
 import numpy as onp
 import pytest
-import scipy as s
 from autoray import numpy as anp
 
 from pennylane import math as fn
@@ -157,18 +156,6 @@ def test_unwrap():
     assert fn.get_interface(out[3][1]) == "numpy"
 
     assert out[4] == 0.5
-
-
-def test_kron():
-    """Test that a deprecation warning is avoided when arrays
-    are dispatched to scipy.kron."""
-    m1 = s.array([[0, 1], [1, 0]])
-    m2 = s.array([[1, 0], [0, 1]])
-    expected_result = onp.kron(m1, m2)
-
-    assert np.allclose(expected_result, fn.kron(m1, m2, like="scipy"))
-    with pytest.warns(DeprecationWarning):
-        _ = s.kron(m1, m2)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
**Context:**
New version of `scipy` removed many deprecated functions, including `scipy.kron`. This was used in a test, causing CI to fail when using latest `scipy`

**Description of the Change:**
Removed problematic test