### PR TITLE
delete duplicate entropy deprecation entry from bad merge

### DIFF
--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -83,13 +83,6 @@ Pending deprecations
         some_qfunc(params)
         return qml.expval(Hamiltonian)
 
-* ``ClassicalShadow.entropy()`` no longer needs an ``atol`` keyword as a better
-  method to estimate entropies from approximate density matrix reconstructions
-  (with potentially negative eigenvalues) has been implemented.
-
-  - Deprecated in v0.34
-  - Will be removed in v0.35
-
 * ``PauliWord`` and ``PauliSentence`` no longer use ``*`` for matrix and tensor products,
   but instead use ``@`` to conform with the PennyLane convention.
 


### PR DESCRIPTION
this was left behind by me in a bad merge conflict resolution. the true entry is on line 136 and is correct