### PR TITLE
restore test for `stop_recording` cleanup

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -183,7 +183,10 @@
   [(#5035)](https://github.com/PennyLaneAI/pennylane/pull/5035)
 
 * A typo in the code example for `qml.qchem.dipole_of` has been fixed.
-  [(#5036)](https://github.com/PennyLaneAI/pennylane/pull/5036) 
+  [(#5036)](https://github.com/PennyLaneAI/pennylane/pull/5036)
+
+* Added a development guide on deprecations and removals.
+  [(#5083)](https://github.com/PennyLaneAI/pennylane/pull/5083)
 
 <h3>Bug fixes 🐛</h3>
 

--- a/pennylane/queuing.py
+++ b/pennylane/queuing.py
@@ -300,8 +300,6 @@ class QueuingManager:
         cls._active_contexts = []
         try:
             yield
-        except Exception as e:
-            raise e
         finally:
             cls._active_contexts = previously_active_contexts
 

--- a/pennylane/queuing.py
+++ b/pennylane/queuing.py
@@ -301,9 +301,9 @@ class QueuingManager:
         try:
             yield
         except Exception as e:
-            cls._active_contexts = previously_active_contexts
             raise e
-        cls._active_contexts = previously_active_contexts
+        finally:
+            cls._active_contexts = previously_active_contexts
 
     @classmethod
     def append(cls, obj, **kwargs):

--- a/tests/test_queuing.py
+++ b/tests/test_queuing.py
@@ -137,6 +137,15 @@ class TestStopRecording:
         result = my_circuit()
         assert result == -1.0
 
+    def test_stop_recording_within_tape_cleans_up(self):
+        """Test if some error is raised within a stop_recording context, the previously
+        active contexts are still returned to avoid popping from an empty deque"""
+
+        with pytest.raises(ValueError):
+            with AnnotatedQueue():
+                with QueuingManager.stop_recording():
+                    raise ValueError
+
 
 class TestQueuingManager:
     """Test the logic associated with the QueuingManager class."""


### PR DESCRIPTION
This was originally added in #3182, but I only put the test in `test_tape.py`, so it was accidentally pruned in #3281 (anagram PR!) which isn't ideal. I'm putting it back in `test_queuing.py` where it truly belongs.

I know this PR seems a bit insignificant, but I remember this bug coming up and I don't want it to resurface because of a lack of testing. Plus, the `finally` is much prettier than writing the cleanup code twice 😄 

Not bothering with a changelog entry, but can add if we feel strongly about it