### PR TITLE
fail CI if coverage fails to upload

### DIFF
--- a/.github/workflows/interface-unit-tests.yml
+++ b/.github/workflows/interface-unit-tests.yml
@@ -592,3 +592,5 @@ jobs:
 
       - name: Upload to Codecov
         uses: codecov/codecov-action@v3
+        with:
+          fail_ci_if_error: true  # upload errors should be caught early

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -88,6 +88,10 @@
 * `CRX`, `CRY`, `CRZ`, `CROT`, and `ControlledPhaseShift` (i.e. `CPhaseShift`) now inherit from `ControlledOp`, giving them additional properties such as `control_wire` and `control_values`. Calling `qml.ctrl` on `RX`, `RY`, `RZ`, `Rot`, and `PhaseShift` with a single control wire will return gates of types `CRX`, `CRY`, etc. as opposed to a general `Controlled` operator.
   [(#5069)](https://github.com/PennyLaneAI/pennylane/pull/5069)
 
+* CI will now fail if coverage data fails to upload to codecov. Previously, it would silently pass
+  and the codecov check itself would never execute.
+  [(#5101)](https://github.com/PennyLaneAI/pennylane/pull/5101)
+
 <h4>Community contributions 🥳</h4>
 
 * The transform `split_non_commuting` now accepts measurements of type `probs`, `sample` and `counts` which accept both wires and observables. 


### PR DESCRIPTION
**Context:**
When the Codecov upload action fails because of network issues or the like, the action reports as passed, then the `codecov` action stays as "Expected" forevermore. This is worse than a failure because it continues to block us but we don't immediately know why. If we knew, we could just re-run it when we find out.

**Description of the Change:**
Set the codecov upload action to fail on failure 😄 

**Benefits:**
We will know when it fails to upload, and we can re-run the upload task manually

**Possible Drawbacks:**
External contributors might hit this, and although the old ways were also bad, this might be a bit more visibly frightening if you don't know why you got a big red ❌ 