### PR TITLE
Fix `jordan_wigner` and `compile` to remove deprecation warnings

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -185,12 +185,14 @@
   of a tuple `(new_word, coeff)`.
   [(#4989)](https://github.com/PennyLaneAI/pennylane/pull/4989)
   [(#5054)](https://github.com/PennyLaneAI/pennylane/pull/5054)
+  [(#5109)](https://github.com/PennyLaneAI/pennylane/pull/5109)
 
 * `MeasurementProcess.name` and `MeasurementProcess.data` are now deprecated, as they contain dummy
   values that are no longer needed.
   [(#5047)](https://github.com/PennyLaneAI/pennylane/pull/5047)
   [(#5071)](https://github.com/PennyLaneAI/pennylane/pull/5071)
   [(#5076)](https://github.com/PennyLaneAI/pennylane/pull/5076)
+  [(#5109)](https://github.com/PennyLaneAI/pennylane/pull/5109)
 
 * Calling `qml.matrix` without providing a `wire_order` on objects where the wire order could be
   ambiguous now raises a warning. In the future, the `wire_order` argument will be required in

--- a/pennylane/fermi/conversion.py
+++ b/pennylane/fermi/conversion.py
@@ -104,7 +104,7 @@ def _(fermi_operator: FermiWord, ps=False, wire_map=None, tol=None):
             (_, wire), sign = item
 
             z_string = dict(zip(range(wire), ["Z"] * wire))
-            qubit_operator *= PauliSentence(
+            qubit_operator @= PauliSentence(
                 {
                     PauliWord({**z_string, **{wire: "X"}}): 0.5,
                     PauliWord({**z_string, **{wire: "Y"}}): coeffs[sign],

--- a/pennylane/transforms/compile.py
+++ b/pennylane/transforms/compile.py
@@ -17,6 +17,7 @@ from functools import partial
 from typing import Sequence, Callable
 
 from pennylane.queuing import QueuingManager
+from pennylane.measurements import MeasurementProcess
 from pennylane.ops import __all__ as all_ops
 from pennylane.tape import QuantumTape
 from pennylane.transforms.core import transform, TransformDispatcher
@@ -185,7 +186,11 @@ def compile(
         basis_set = basis_set or all_ops
 
         def stop_at(obj):
-            return obj.name in basis_set and (not getattr(obj, "only_visual", False))
+            return (
+                isinstance(obj, MeasurementProcess)
+                or obj.name in basis_set
+                and (not getattr(obj, "only_visual", False))
+            )
 
         expanded_tape = tape.expand(depth=expand_depth, stop_at=stop_at)
 


### PR DESCRIPTION
No idea why the CI wasn't catching the fact that these functions are raising deprecation warnings. That might be worth further investigation.  

But this is a quick fix for now to both `qml.fermi.jordan_wigner` and `qml.compile`.