### PR TITLE
unpin black, make code black-friendly

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -18,7 +18,7 @@ jobs:
           python-version: 3.9
 
       - name: Install dependencies
-        run: pip install black~=23.12
+        run: pip install black
 
       - uses: actions/checkout@v2
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -132,7 +132,7 @@
 
 * Make PennyLane code compatible with the latest version of `black`.
   [(#5112)](https://github.com/PennyLaneAI/pennylane/pull/5112)
-  [()](https://github.com/PennyLaneAI/pennylane/pull/)
+  [(#5119)](https://github.com/PennyLaneAI/pennylane/pull/5119)
 
 * `gradient_analysis_and_validation` is now renamed to `find_and_validate_gradient_methods`. Instead of returning a list, it now returns a dictionary of gradient methods for each parameter index, and no longer mutates the tape.
   [(#5035)](https://github.com/PennyLaneAI/pennylane/pull/5035)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -130,8 +130,9 @@
 
 <h3>Breaking changes 💔</h3>
 
-* Pin Black to `v23.12` to prevent unnecessary formatting changes.
+* Make PennyLane code compatible with the latest version of `black`.
   [(#5112)](https://github.com/PennyLaneAI/pennylane/pull/5112)
+  [()](https://github.com/PennyLaneAI/pennylane/pull/)
 
 * `gradient_analysis_and_validation` is now renamed to `find_and_validate_gradient_methods`. Instead of returning a list, it now returns a dictionary of gradient methods for each parameter index, and no longer mutates the tape.
   [(#5035)](https://github.com/PennyLaneAI/pennylane/pull/5035)

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -1311,10 +1311,13 @@ class QubitDevice(Device):
         if self.shots is None:
             try:
                 eigvals = self._asarray(
-                    observable.eigvals() if not isinstance(observable, MeasurementValue)
-                    # Indexing a MeasurementValue gives the output of the processing function
-                    # for that index as a binary number.
-                    else [observable[i] for i in range(2 ** len(observable.measurements))],
+                    (
+                        observable.eigvals()
+                        if not isinstance(observable, MeasurementValue)
+                        # Indexing a MeasurementValue gives the output of the processing function
+                        # for that index as a binary number.
+                        else [observable[i] for i in range(2 ** len(observable.measurements))]
+                    ),
                     dtype=self.R_DTYPE,
                 )
             except qml.operation.EigvalsUndefinedError as e:
@@ -1339,10 +1342,13 @@ class QubitDevice(Device):
         if self.shots is None:
             try:
                 eigvals = self._asarray(
-                    observable.eigvals() if not isinstance(observable, MeasurementValue)
-                    # Indexing a MeasurementValue gives the output of the processing function
-                    # for that index as a binary number.
-                    else [observable[i] for i in range(2 ** len(observable.measurements))],
+                    (
+                        observable.eigvals()
+                        if not isinstance(observable, MeasurementValue)
+                        # Indexing a MeasurementValue gives the output of the processing function
+                        # for that index as a binary number.
+                        else [observable[i] for i in range(2 ** len(observable.measurements))]
+                    ),
                     dtype=self.R_DTYPE,
                 )
             except qml.operation.EigvalsUndefinedError as e:

--- a/pennylane/data/attributes/list.py
+++ b/pennylane/data/attributes/list.py
@@ -98,11 +98,11 @@ class DatasetList(  # pylint: disable=too-many-ancestors
 
     @overload
     def __getitem__(self, index: slice) -> typing.List[T]:
-        ...
+        pass
 
     @overload
     def __getitem__(self, index: int) -> T:
-        ...
+        pass
 
     def __getitem__(self, index: Union[int, slice]):
         if isinstance(index, slice):

--- a/pennylane/data/base/_lazy_modules.py
+++ b/pennylane/data/base/_lazy_modules.py
@@ -1,6 +1,5 @@
 """Contains a lazy-loaded interface to the HDF5 module. For internal use only."""
 
-
 import importlib
 from types import ModuleType
 from typing import Any, Callable, Optional, Union

--- a/pennylane/data/base/attribute.py
+++ b/pennylane/data/base/attribute.py
@@ -65,11 +65,11 @@ class AttributeInfo(MutableMapping):
         py_type: Optional[str] = None,
         **kwargs: Any,
     ):
-        ...
+        pass
 
     @overload
     def __init__(self):  # need at least two overloads when using @overload
-        ...
+        pass
 
     def __init__(self, attrs_bind: Optional[typing.MutableMapping[str, Any]] = None, **kwargs: Any):
         object.__setattr__(self, "attrs_bind", attrs_bind if attrs_bind is not None else {})

--- a/pennylane/devices/default_gaussian.py
+++ b/pennylane/devices/default_gaussian.py
@@ -648,6 +648,7 @@ class DefaultGaussian(Device):
         hbar (float): (default 2) the value of :math:`\hbar` in the commutation
             relation :math:`[\x,\p]=i\hbar`
     """
+
     name = "Default Gaussian PennyLane plugin"
     short_name = "default.gaussian"
     pennylane_requires = __version__

--- a/pennylane/fermi/conversion.py
+++ b/pennylane/fermi/conversion.py
@@ -25,7 +25,7 @@ from .fermionic import FermiSentence, FermiWord
 
 # pylint: disable=unexpected-keyword-arg
 def jordan_wigner(
-    fermi_operator: (Union[FermiWord, FermiSentence]),
+    fermi_operator: Union[FermiWord, FermiSentence],
     ps: bool = False,
     wire_map: dict = None,
     tol: float = None,

--- a/pennylane/fermi/conversion.py
+++ b/pennylane/fermi/conversion.py
@@ -152,7 +152,7 @@ def _(fermi_operator: FermiSentence, ps=False, wire_map=None, tol=None):
 
 
 def parity_transform(
-    fermi_operator: (Union[FermiWord, FermiSentence]),
+    fermi_operator: Union[FermiWord, FermiSentence],
     n: int,
     ps: bool = False,
     wire_map: dict = None,

--- a/pennylane/fermi/fermionic.py
+++ b/pennylane/fermi/fermionic.py
@@ -285,6 +285,7 @@ class FermiSentence(dict):
     1.2 * a⁺(0) a(1)
     + 3.1 * a⁺(1) a(2)
     """
+
     # override the arithmetic dunder methods for numpy arrays so that the
     # methods defined on this class are used instead
     # (i.e. ensure `np.array + FermiSentence` uses `FermiSentence.__radd__` instead of `np.array.__add__`)

--- a/pennylane/math/multi_dispatch.py
+++ b/pennylane/math/multi_dispatch.py
@@ -963,9 +963,11 @@ def jax_argnums_to_tape_trainable(qnode, argnums, program, args, kwargs):
         trace = jax.interpreters.ad.JVPTrace(main, 0)
 
     args_jvp = [
-        jax.interpreters.ad.JVPTracer(trace, arg, jax.numpy.zeros(arg.shape))
-        if i in argnums
-        else arg
+        (
+            jax.interpreters.ad.JVPTracer(trace, arg, jax.numpy.zeros(arg.shape))
+            if i in argnums
+            else arg
+        )
         for i, arg in enumerate(args)
     ]
 

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -688,6 +688,7 @@ class Operator(abc.ABC):
         one of them (in other words, without the leading underscore) for the first time will
         trigger a call to ``_check_batching``, which validates and sets these properties.
     """
+
     # pylint: disable=too-many-public-methods, too-many-instance-attributes
 
     def __init_subclass__(cls, **_):
@@ -1814,6 +1815,7 @@ class Channel(Operation, abc.ABC):
         id (str): custom label given to an operator instance,
             can be useful for some applications where the instance has to be identified
     """
+
     # pylint: disable=abstract-method
 
     @staticmethod
@@ -2805,6 +2807,7 @@ class CVObservable(CV, Observable):
        id (str): custom label given to an operator instance,
            can be useful for some applications where the instance has to be identified
     """
+
     # pylint: disable=abstract-method
     ev_order = None  #: None, int: Order in `(x, p)` that a CV observable is a polynomial of.
 

--- a/pennylane/ops/channel.py
+++ b/pennylane/ops/channel.py
@@ -53,6 +53,7 @@ class AmplitudeDamping(Channel):
         wires (Sequence[int] or int): the wire the channel acts on
         id (str or None): String representing the operation (optional)
     """
+
     num_params = 1
     num_wires = 1
     grad_method = "F"
@@ -131,6 +132,7 @@ class GeneralizedAmplitudeDamping(Channel):
         wires (Sequence[int] or int): the wire the channel acts on
         id (str or None): String representing the operation (optional)
     """
+
     num_params = 2
     num_wires = 1
     grad_method = "F"
@@ -209,6 +211,7 @@ class PhaseDamping(Channel):
         gamma (float): phase damping probability
         wires (Sequence[int] or int): the wire the channel acts on
     """
+
     num_params = 1
     num_wires = 1
     grad_method = "F"
@@ -294,6 +297,7 @@ class DepolarizingChannel(Channel):
         wires (Sequence[int] or int): the wire the channel acts on
         id (str or None): String representing the operation (optional)
     """
+
     num_params = 1
     num_wires = 1
     grad_method = "A"
@@ -367,6 +371,7 @@ class BitFlip(Channel):
         wires (Sequence[int] or int): the wire the channel acts on
         id (str or None): String representing the operation (optional)
     """
+
     num_params = 1
     num_wires = 1
     grad_method = "A"
@@ -449,6 +454,7 @@ class ResetError(Channel):
         wires (Sequence[int] or int): the wire the channel acts on
         id (str or None): String representing the operation (optional)
     """
+
     num_params = 2
     num_wires = 1
     grad_method = "F"
@@ -550,6 +556,7 @@ class PauliError(Channel):
         array([[0.        , 0.70710678],
                [0.70710678, 0.        ]])
     """
+
     num_wires = AnyWires
     """int: Number of wires that the operator acts on."""
 
@@ -651,6 +658,7 @@ class PhaseFlip(Channel):
         wires (Sequence[int] or int): the wire the channel acts on
         id (str or None): String representing the operation (optional)
     """
+
     num_params = 1
     num_wires = 1
     grad_method = "A"
@@ -701,6 +709,7 @@ class QubitChannel(Channel):
         wires (Union[Wires, Sequence[int], or int]): the wire(s) the operation acts on
         id (str or None): String representing the operation (optional)
     """
+
     num_wires = AnyWires
     grad_method = None
 
@@ -830,6 +839,7 @@ class ThermalRelaxationError(Channel):
         wires (Sequence[int] or int): the wire the channel acts on
         id (str or None): String representing the operation (optional)
     """
+
     num_params = 4
     num_wires = 1
     grad_method = "F"
@@ -896,13 +906,14 @@ class ThermalRelaxationError(Channel):
             e1 = -p_reset * pe + p_reset
             v1 = np.array([[0, 1], [0, 0]])
             K1 = np.sqrt(e1 + np.eps) * v1
-            common_term = np.sqrt(
-                4 * eT2**2
-                + 4 * p_reset**2 * pe**2
-                - 4 * p_reset**2 * pe
-                + p_reset**2
-                + np.eps
+            base = sum(
+                4 * eT2**2,
+                4 * p_reset**2 * pe**2,
+                -4 * p_reset**2 * pe,
+                p_reset**2,
+                np.eps,
             )
+            common_term = np.sqrt(base)
             e2 = 1 - p_reset / 2 - common_term / 2
             term2 = 2 * eT2 / (2 * p_reset * pe - p_reset - common_term)
             v2 = (term2 * np.array([[1, 0], [0, 0]]) + np.array([[0, 0], [0, 1]])) / np.sqrt(

--- a/pennylane/ops/channel.py
+++ b/pennylane/ops/channel.py
@@ -907,11 +907,13 @@ class ThermalRelaxationError(Channel):
             v1 = np.array([[0, 1], [0, 0]])
             K1 = np.sqrt(e1 + np.eps) * v1
             base = sum(
-                4 * eT2**2,
-                4 * p_reset**2 * pe**2,
-                -4 * p_reset**2 * pe,
-                p_reset**2,
-                np.eps,
+                (
+                    4 * eT2**2,
+                    4 * p_reset**2 * pe**2,
+                    -4 * p_reset**2 * pe,
+                    p_reset**2,
+                    np.eps,
+                )
             )
             common_term = np.sqrt(base)
             e2 = 1 - p_reset / 2 - common_term / 2

--- a/pennylane/ops/cv.py
+++ b/pennylane/ops/cv.py
@@ -103,6 +103,7 @@ class Rotation(CVOperation):
         wires (Sequence[Any] or Any): the wire the operation acts on
         id (str or None): String representing the operation (optional)
     """
+
     num_params = 1
     num_wires = 1
     grad_method = "A"
@@ -152,6 +153,7 @@ class Squeezing(CVOperation):
         wires (Sequence[Any] or Any): the wire the operation acts on
         id (str or None): String representing the operation (optional)
     """
+
     num_params = 2
     num_wires = 1
     grad_method = "A"
@@ -207,6 +209,7 @@ class Displacement(CVOperation):
         wires (Sequence[Any] or Any): the wire the operation acts on
         id (str or None): String representing the operation (optional)
     """
+
     num_params = 2
     num_wires = 1
     grad_method = "A"
@@ -268,6 +271,7 @@ class Beamsplitter(CVOperation):
         wires (Sequence[Any]): the wire the operation acts on
         id (str or None): String representing the operation (optional)
     """
+
     num_params = 2
     num_wires = 2
     grad_method = "A"
@@ -330,6 +334,7 @@ class TwoModeSqueezing(CVOperation):
         wires (Sequence[Any]): the wire the operation acts on
         id (str or None): String representing the operation (optional)
     """
+
     num_params = 2
     num_wires = 2
 
@@ -392,6 +397,7 @@ class QuadraticPhase(CVOperation):
         wires (Sequence[Any] or Any): the wire the operation acts on
         id (str or None): String representing the operation (optional)
     """
+
     num_params = 1
     num_wires = 1
 
@@ -446,6 +452,7 @@ class ControlledAddition(CVOperation):
         wires (Sequence[Any]): the wire the operation acts on
         id (str or None): String representing the operation (optional)
     """
+
     num_params = 1
     num_wires = 2
     grad_method = "A"
@@ -503,6 +510,7 @@ class ControlledPhase(CVOperation):
         wires (Sequence[Any]): the wire the operation acts on
         id (str or None): String representing the operation (optional)
     """
+
     num_params = 1
     num_wires = 2
     grad_method = "A"
@@ -547,6 +555,7 @@ class Kerr(CVOperation):
         wires (Sequence[Any] or Any): the wire the operation acts on
         id (str or None): String representing the operation (optional)
     """
+
     num_params = 1
     num_wires = 1
     grad_method = "F"
@@ -576,6 +585,7 @@ class CrossKerr(CVOperation):
         wires (Sequence[Any]): the wire the operation acts on
         id (str or None): String representing the operation (optional)
     """
+
     num_params = 1
     num_wires = 2
     grad_method = "F"
@@ -605,6 +615,7 @@ class CubicPhase(CVOperation):
         wires (Sequence[Any] or Any): the wire the operation acts on
         id (str or None): String representing the operation (optional)
     """
+
     num_params = 1
     num_wires = 1
     grad_method = "F"
@@ -654,6 +665,7 @@ class InterferometerUnitary(CVOperation):
         wires (Sequence[Any] or Any): the wires the operation acts on
         id (str or None): String representing the operation (optional)
     """
+
     num_params = 1
     num_wires = AnyWires
     grad_method = None
@@ -706,6 +718,7 @@ class CoherentState(CVOperation):
         wires (Sequence[Any] or Any): the wire the operation acts on
         id (str or None): String representing the operation (optional)
     """
+
     num_params = 2
     num_wires = 1
     grad_method = "F"
@@ -730,6 +743,7 @@ class SqueezedState(CVOperation):
         wires (Sequence[Any] or Any): the wire the operation acts on
         id (str or None): String representing the operation (optional)
     """
+
     num_params = 2
     num_wires = 1
     grad_method = "F"
@@ -764,6 +778,7 @@ class DisplacedSqueezedState(CVOperation):
         wires (Sequence[Any] or Any): the wire the operation acts on
         id (str or None): String representing the operation (optional)
     """
+
     num_params = 4
     num_wires = 1
     grad_method = "F"
@@ -787,6 +802,7 @@ class ThermalState(CVOperation):
         wires (Sequence[Any] or Any): the wire the operation acts on
         id (str or None): String representing the operation (optional)
     """
+
     num_params = 1
     num_wires = 1
     grad_method = "F"
@@ -815,6 +831,7 @@ class GaussianState(CVOperation):
         wires (Sequence[Any] or Any): the wire the operation acts on
         id (str or None): String representing the operation (optional)
     """
+
     num_params = 2
     num_wires = AnyWires
     grad_method = "F"
@@ -841,6 +858,7 @@ class FockState(CVOperation):
         wires (Sequence[Any] or Any): the wire the operation acts on
         id (str or None): String representing the operation (optional)
     """
+
     num_params = 1
     num_wires = 1
     grad_method = None
@@ -932,6 +950,7 @@ class FockStateVector(CVOperation):
                 return qml.expval(qml.NumberOperator(wires=0))
 
     """
+
     num_params = 1
     num_wires = AnyWires
     grad_method = "F"
@@ -980,6 +999,7 @@ class FockDensityMatrix(CVOperation):
         wires (Sequence[Any] or Any): the wire the operation acts on
         id (str or None): String representing the operation (optional)
     """
+
     num_params = 1
     num_wires = AnyWires
     grad_method = "F"
@@ -1015,6 +1035,7 @@ class CatState(CVOperation):
         wires (Sequence[Any] or Any): the wire the operation acts on
         id (str or None): String representing the operation (optional)
     """
+
     num_params = 3
     num_wires = 1
     grad_method = "F"
@@ -1054,6 +1075,7 @@ class NumberOperator(CVObservable):
     Args:
         wires (Sequence[Any] or Any): the wire the operation acts on
     """
+
     num_params = 0
     num_wires = 1
 
@@ -1109,6 +1131,7 @@ class TensorN(CVObservable):
         >>> cv_obs.ev_order
         2
     """
+
     num_params = 0
     num_wires = AnyWires
     ev_order = None
@@ -1151,6 +1174,7 @@ class QuadX(CVObservable):
     Args:
         wires (Sequence[Any] or Any): the wire the operation acts on
     """
+
     num_params = 0
     num_wires = 1
 
@@ -1184,6 +1208,7 @@ class QuadP(CVObservable):
     Args:
         wires (Sequence[Any] or Any): the wire the operation acts on
     """
+
     num_params = 0
     num_wires = 1
 
@@ -1220,6 +1245,7 @@ class QuadOperator(CVObservable):
         wires (Sequence[Any] or Any): the wire the operation acts on
         id (str or None): String representing the operation (optional)
     """
+
     num_params = 1
     num_wires = 1
 
@@ -1298,6 +1324,7 @@ class PolyXP(CVObservable):
         id (str or None): String representing the operation (optional)
 
     """
+
     num_params = 1
     num_wires = AnyWires
 
@@ -1356,6 +1383,7 @@ class FockStateProjector(CVObservable):
         wires (Sequence[Any] or Any): the wire the operation acts on
         id (str or None): String representing the operation (optional)
     """
+
     num_params = 1
     num_wires = AnyWires
 

--- a/pennylane/ops/functions/map_wires.py
+++ b/pennylane/ops/functions/map_wires.py
@@ -110,9 +110,11 @@ def _map_wires_transform(
     tape: qml.tape.QuantumTape, wire_map=None, queue=False
 ) -> (Sequence[qml.tape.QuantumTape], Callable):
     ops = [
-        map_wires(op, wire_map, queue=queue)
-        if not isinstance(op, QuantumScript)
-        else map_wires(op, wire_map, queue=queue)[0][0]
+        (
+            map_wires(op, wire_map, queue=queue)
+            if not isinstance(op, QuantumScript)
+            else map_wires(op, wire_map, queue=queue)[0][0]
+        )
         for op in tape.operations
     ]
     measurements = [map_wires(m, wire_map, queue=queue) for m in tape.measurements]

--- a/pennylane/ops/identity.py
+++ b/pennylane/ops/identity.py
@@ -39,6 +39,7 @@ class Identity(CVObservable, Operation):
     Corresponds to the trace of the quantum state, which in exact
     simulators should always be equal to 1.
     """
+
     num_params = 0
     num_wires = AnyWires
     """int: Number of wires that the operator acts on."""
@@ -239,6 +240,7 @@ class GlobalPhase(Operation):
 
 
     """
+
     grad_method = "A"
     num_params = 1
     num_wires = AllWires

--- a/pennylane/ops/meta.py
+++ b/pennylane/ops/meta.py
@@ -36,6 +36,7 @@ class Barrier(Operation):
         only_visual (bool): True if we do not want it to have an impact on the compilation process. Default is False.
         wires (Sequence[int] or int): the wires the operation acts on
     """
+
     num_params = 0
     """int: Number of trainable parameters that the operator depends on."""
 
@@ -110,6 +111,7 @@ class WireCut(Operation):
     Args:
         wires (Sequence[int] or int): the wires the operation acts on
     """
+
     num_params = 0
     num_wires = AnyWires
     grad_method = None
@@ -194,6 +196,7 @@ class Snapshot(Operation):
 
     .. seealso:: :func:`~.snapshots`
     """
+
     num_wires = AnyWires
     num_params = 0
     grad_method = None

--- a/pennylane/ops/op_math/controlled.py
+++ b/pennylane/ops/op_math/controlled.py
@@ -344,9 +344,11 @@ class Controlled(SymbolicOp):
         if self.base.name in ("RX", "RY", "RZ", "Rot"):
             base_params = str(
                 [
-                    id(d)
-                    if qml.math.is_abstract(d)
-                    else qml.math.round(qml.math.real(d) % (4 * np.pi), 10)
+                    (
+                        id(d)
+                        if qml.math.is_abstract(d)
+                        else qml.math.round(qml.math.real(d) % (4 * np.pi), 10)
+                    )
                     for d in self.base.data
                 ]
             )

--- a/pennylane/ops/op_math/controlled_ops.py
+++ b/pennylane/ops/op_math/controlled_ops.py
@@ -95,6 +95,7 @@ class ControlledQubitUnitary(ControlledOp):
 
     >>> qml.ControlledQubitUnitary(U, control_wires=[0, 1, 2], wires=3, control_values=[False, True, True])
     """
+
     num_wires = AnyWires
     """int: Number of wires that the operator acts on."""
 
@@ -186,6 +187,7 @@ class CY(ControlledOp):
         id (str): custom label given to an operator instance,
             can be useful for some applications where the instance has to be identified.
     """
+
     num_wires = 2
     """int: Number of wires that the operator acts on."""
 
@@ -288,6 +290,7 @@ class CZ(ControlledOp):
     Args:
         wires (Sequence[int]): the wires the operation acts on
     """
+
     num_wires = 2
     """int: Number of wires that the operator acts on."""
 
@@ -375,6 +378,7 @@ class CRX(ControlledOp):
         wires (Sequence[int]): the wire the operation acts on
         id (str or None): String representing the operation (optional)
     """
+
     num_wires = 2
     """int: Number of wires that the operation acts on."""
 
@@ -532,6 +536,7 @@ class CRY(ControlledOp):
         wires (Sequence[int]): the wire the operation acts on
         id (str or None): String representing the operation (optional)
     """
+
     num_wires = 2
     """int: Number of wires that the operation acts on."""
 
@@ -690,6 +695,7 @@ class CRZ(ControlledOp):
         id (str or None): String representing the operation (optional)
 
     """
+
     num_wires = 2
     """int: Number of wires that the operation acts on."""
 
@@ -880,6 +886,7 @@ class CRot(ControlledOp):
         id (str or None): String representing the operation (optional)
 
     """
+
     num_wires = 2
     """int: Number of wires this operator acts on."""
 
@@ -1049,6 +1056,7 @@ class ControlledPhaseShift(ControlledOp):
         id (str or None): String representing the operation (optional)
 
     """
+
     num_wires = 2
     """int: Number of wires the operator acts on."""
 

--- a/pennylane/ops/op_math/sprod.py
+++ b/pennylane/ops/op_math/sprod.py
@@ -127,6 +127,7 @@ class SProd(ScalarSymbolicOp):
         (array(-0.68362956), array(0.21683382))
 
     """
+
     _name = "SProd"
 
     def _flatten(self):

--- a/pennylane/ops/qubit/arithmetic_ops.py
+++ b/pennylane/ops/qubit/arithmetic_ops.py
@@ -92,6 +92,7 @@ class QubitCarry(Operation):
     >>> carry
     1
     """
+
     num_wires = 4
     """int: Number of wires that the operator acts on."""
 
@@ -235,6 +236,7 @@ class QubitSum(Operation):
     >>> abc_sum
     1
     """
+
     num_wires = 3
     """int: Number of wires that the operator acts on."""
 
@@ -351,6 +353,7 @@ class IntegerComparator(Operation):
     >>> circuit([0, 1, 0], 3, False).reshape(2, 2, 2)[0, 1, 1]
     tensor(1.+0.j, requires_grad=True)
     """
+
     is_self_inverse = True
     num_wires = AnyWires
     num_params = 0

--- a/pennylane/ops/qubit/matrix_ops.py
+++ b/pennylane/ops/qubit/matrix_ops.py
@@ -105,6 +105,7 @@ class QubitUnitary(Operation):
     >>> print(example_circuit())
     0.0
     """
+
     num_wires = AnyWires
     """int: Number of wires that the operator acts on."""
 
@@ -264,6 +265,7 @@ class DiagonalQubitUnitary(Operation):
         D (array[complex]): diagonal of unitary matrix
         wires (Sequence[int] or int): the wire(s) the operation acts on
     """
+
     num_wires = AnyWires
     """int: Number of wires that the operator acts on."""
 

--- a/pennylane/ops/qubit/non_parametric_ops.py
+++ b/pennylane/ops/qubit/non_parametric_ops.py
@@ -48,6 +48,7 @@ class Hadamard(Observable, Operation):
     Args:
         wires (Sequence[int] or int): the wire the operation acts on
     """
+
     num_wires = 1
     """int: Number of wires that the operator acts on."""
 
@@ -192,6 +193,7 @@ class PauliX(Observable, Operation):
     Args:
         wires (Sequence[int] or int): the wire the operation acts on
     """
+
     num_wires = 1
     """int: Number of wires that the operator acts on."""
 
@@ -347,6 +349,7 @@ class PauliY(Observable, Operation):
     Args:
         wires (Sequence[int] or int): the wire the operation acts on
     """
+
     num_wires = 1
     """int: Number of wires that the operator acts on."""
 
@@ -501,6 +504,7 @@ class PauliZ(Observable, Operation):
     Args:
         wires (Sequence[int] or int): the wire the operation acts on
     """
+
     num_wires = 1
     num_params = 0
     """int: Number of trainable parameters that the operator depends on."""
@@ -657,6 +661,7 @@ class S(Operation):
     Args:
         wires (Sequence[int] or int): the wire the operation acts on
     """
+
     num_wires = 1
     num_params = 0
     """int: Number of trainable parameters that the operator depends on."""
@@ -766,6 +771,7 @@ class T(Operation):
     Args:
         wires (Sequence[int] or int): the wire the operation acts on
     """
+
     num_wires = 1
     num_params = 0
     """int: Number of trainable parameters that the operator depends on."""
@@ -875,6 +881,7 @@ class SX(Operation):
     Args:
         wires (Sequence[int] or int): the wire the operation acts on
     """
+
     num_wires = 1
     num_params = 0
     """int: Number of trainable parameters that the operator depends on."""
@@ -992,6 +999,7 @@ class CNOT(Operation):
     Args:
         wires (Sequence[int]): the wires the operation acts on
     """
+
     num_wires = 2
     num_params = 0
     """int: Number of trainable parameters that the operator depends on."""
@@ -1064,6 +1072,7 @@ class CH(Operation):
     Args:
         wires (Sequence[int]): the wires the operation acts on
     """
+
     num_wires = 2
     num_params = 0
     """int: Number of trainable parameters that the operator depends on."""
@@ -1166,6 +1175,7 @@ class SWAP(Operation):
     Args:
         wires (Sequence[int]): the wires the operation acts on
     """
+
     num_wires = 2
     num_params = 0
     """int: Number of trainable parameters that the operator depends on."""
@@ -1381,6 +1391,7 @@ class ISWAP(Operation):
     Args:
         wires (Sequence[int]): the wires the operation acts on
     """
+
     num_wires = 2
     num_params = 0
     """int: Number of trainable parameters that the operator depends on."""
@@ -1496,6 +1507,7 @@ class SISWAP(Operation):
     Args:
         wires (Sequence[int]): the wires the operation acts on
     """
+
     num_wires = 2
     num_params = 0
     """int: Number of trainable parameters that the operator depends on."""
@@ -1638,6 +1650,7 @@ class CSWAP(Operation):
     Args:
         wires (Sequence[int]): the wires the operation acts on
     """
+
     is_self_inverse = True
     num_wires = 3
     num_params = 0
@@ -1753,6 +1766,7 @@ class CCZ(Operation):
     Args:
         wires (Sequence[int]): the subsystem the gate acts on
     """
+
     num_wires = 3
     num_params = 0
     """int: Number of trainable parameters that the operator depends on."""
@@ -1895,6 +1909,7 @@ class Toffoli(Operation):
     Args:
         wires (Sequence[int]): the subsystem the gate acts on
     """
+
     num_wires = 3
     num_params = 0
     """int: Number of trainable parameters that the operator depends on."""
@@ -2056,6 +2071,7 @@ class MultiControlledX(Operation):
         unchanged.
 
     """
+
     is_self_inverse = True
     num_wires = AnyWires
     num_params = 0

--- a/pennylane/ops/qubit/observables.py
+++ b/pennylane/ops/qubit/observables.py
@@ -54,6 +54,7 @@ class Hermitian(Observable):
         wires (Sequence[int] or int): the wire(s) the operation acts on
         id (str or None): String representing the operation (optional)
     """
+
     num_wires = AnyWires
     num_params = 1
     """int: Number of trainable parameters that the operator depends on."""
@@ -237,6 +238,7 @@ class SparseHamiltonian(Observable):
     >>> Hmat = H.sparse_matrix()
     >>> H_sparse = qml.SparseHamiltonian(Hmat, wires)
     """
+
     num_wires = AnyWires
     num_params = 1
     """int: Number of trainable parameters that the operator depends on."""
@@ -378,6 +380,7 @@ class Projector(Observable):
         0.25
 
     """
+
     name = "Projector"
     num_wires = AnyWires
     num_params = 1

--- a/pennylane/ops/qubit/parametric_ops_multi_qubit.py
+++ b/pennylane/ops/qubit/parametric_ops_multi_qubit.py
@@ -57,6 +57,7 @@ class MultiRZ(Operation):
         wires (Sequence[int] or int): the wires the operation acts on
         id (str or None): String representing the operation (optional)
     """
+
     num_wires = AnyWires
     num_params = 1
     """int: Number of trainable parameters that the operator depends on."""
@@ -239,6 +240,7 @@ class PauliRot(Operation):
     >>> print(example_circuit())
     0.8775825618903724
     """
+
     num_wires = AnyWires
     num_params = 1
     """int: Number of trainable parameters that the operator depends on."""
@@ -564,6 +566,7 @@ class PCPhase(Operation):
      [0.  +0.j   0.  +0.j   0.33+0.94j 0.  +0.j  ]
      [0.  +0.j   0.  +0.j   0.  +0.j   0.33-0.94j]]
     """
+
     num_wires = AnyWires
     num_params = 1
     """int: Number of trainable parameters that the operator depends on."""
@@ -759,6 +762,7 @@ class IsingXX(Operation):
         wires (int): the subsystem the gate acts on
         id (str or None): String representing the operation (optional)
     """
+
     num_wires = 2
     num_params = 1
     """int: Number of trainable parameters that the operator depends on."""
@@ -894,6 +898,7 @@ class IsingYY(Operation):
         wires (int): the subsystem the gate acts on
         id (str or None): String representing the operation (optional)
     """
+
     num_wires = 2
     num_params = 1
     """int: Number of trainable parameters that the operator depends on."""
@@ -1036,6 +1041,7 @@ class IsingZZ(Operation):
         wires (int): the subsystem the gate acts on
         id (str or None): String representing the operation (optional)
     """
+
     num_wires = 2
     num_params = 1
     """int: Number of trainable parameters that the operator depends on."""
@@ -1218,6 +1224,7 @@ class IsingXY(Operation):
         wires (int): the subsystem the gate acts on
         id (str or None): String representing the operation (optional)
     """
+
     num_wires = 2
     num_params = 1
     """int: Number of trainable parameters that the operator depends on."""
@@ -1396,6 +1403,7 @@ class PSWAP(Operation):
         wires (int): the subsystem the gate acts on
         id (str or None): String representing the operation (optional)
     """
+
     num_wires = 2
     num_params = 1
     """int: Number of trainable parameters that the operator depends on."""
@@ -1549,6 +1557,7 @@ class CPhaseShift00(Operation):
         wires (Sequence[int]): the wire the operation acts on
         id (str or None): String representing the operation (optional)
     """
+
     num_wires = 2
     num_params = 1
     """int: Number of trainable parameters that the operator depends on."""
@@ -1735,6 +1744,7 @@ class CPhaseShift01(Operation):
         wires (Sequence[int]): the wire the operation acts on
         id (str or None): String representing the operation (optional)
     """
+
     num_wires = 2
     num_params = 1
     """int: Number of trainable parameters that the operator depends on."""
@@ -1913,6 +1923,7 @@ class CPhaseShift10(Operation):
         wires (Any, Wires): the wire the operation acts on
         id (str or None): String representing the operation (optional)
     """
+
     num_wires = 2
     num_params = 1
     """int: Number of trainable parameters that the operator depends on."""

--- a/pennylane/ops/qubit/parametric_ops_single_qubit.py
+++ b/pennylane/ops/qubit/parametric_ops_single_qubit.py
@@ -57,6 +57,7 @@ class RX(Operation):
         wires (Sequence[int] or int): the wire the operation acts on
         id (str or None): String representing the operation (optional)
     """
+
     num_wires = 1
     num_params = 1
     """int: Number of trainable parameters that the operator depends on."""
@@ -152,6 +153,7 @@ class RY(Operation):
         wires (Sequence[int] or int): the wire the operation acts on
         id (str or None): String representing the operation (optional)
     """
+
     num_wires = 1
     num_params = 1
     """int: Number of trainable parameters that the operator depends on."""
@@ -246,6 +248,7 @@ class RZ(Operation):
         wires (Sequence[int] or int): the wire the operation acts on
         id (str or None): String representing the operation (optional)
     """
+
     num_wires = 1
     num_params = 1
     """int: Number of trainable parameters that the operator depends on."""
@@ -381,6 +384,7 @@ class PhaseShift(Operation):
         wires (Sequence[int] or int): the wire the operation acts on
         id (str or None): String representing the operation (optional)
     """
+
     num_wires = 1
     num_params = 1
     """int: Number of trainable parameters that the operator depends on."""
@@ -555,6 +559,7 @@ class Rot(Operation):
         wires (Any, Wires): the wire the operation acts on
         id (str or None): String representing the operation (optional)
     """
+
     num_wires = 1
     num_params = 3
     """int: Number of trainable parameters that the operator depends on."""
@@ -718,6 +723,7 @@ class U1(Operation):
         wires (Sequence[int] or int): the wire the operation acts on
         id (str or None): String representing the operation (optional)
     """
+
     num_wires = 1
     num_params = 1
     """int: Number of trainable parameters that the operator depends on."""
@@ -845,6 +851,7 @@ class U2(Operation):
         wires (Sequence[int] or int): the subsystem the gate acts on
         id (str or None): String representing the operation (optional)
     """
+
     num_wires = 1
     num_params = 2
     """int: Number of trainable parameters that the operator depends on."""
@@ -986,6 +993,7 @@ class U3(Operation):
         wires (Sequence[int] or int): the subsystem the gate acts on
         id (str or None): String representing the operation (optional)
     """
+
     num_wires = 1
     num_params = 3
     """int: Number of trainable parameters that the operator depends on."""

--- a/pennylane/ops/qubit/qchem_ops.py
+++ b/pennylane/ops/qubit/qchem_ops.py
@@ -298,6 +298,7 @@ class SingleExcitationMinus(Operation):
         id (str or None): String representing the operation (optional)
 
     """
+
     num_wires = 2
     """int: Number of wires that the operator acts on."""
 
@@ -427,6 +428,7 @@ class SingleExcitationPlus(Operation):
         id (str or None): String representing the operation (optional)
 
     """
+
     num_wires = 2
     """int: Number of wires that the operator acts on."""
 
@@ -580,6 +582,7 @@ class DoubleExcitation(Operation):
 
         circuit(0.1)
     """
+
     num_wires = 4
     """int: Number of wires that the operator acts on."""
 
@@ -761,6 +764,7 @@ class DoubleExcitationPlus(Operation):
         wires (Sequence[int]): the wires the operation acts on
         id (str or None): String representing the operation (optional)
     """
+
     num_wires = 4
     """int: Number of wires that the operator acts on."""
 
@@ -842,6 +846,7 @@ class DoubleExcitationMinus(Operation):
         wires (Sequence[int]): the wires the operation acts on
         id (str or None): String representing the operation (optional)
     """
+
     num_wires = 4
     """int: Number of wires that the operator acts on."""
 
@@ -948,6 +953,7 @@ class OrbitalRotation(Operation):
                 0.99750208+0.j,  0.        +0.j,  0.        +0.j,
                 0.        +0.j])
     """
+
     num_wires = 4
     """int: Number of wires that the operator acts on."""
 

--- a/pennylane/ops/qubit/special_unitary.py
+++ b/pennylane/ops/qubit/special_unitary.py
@@ -390,6 +390,7 @@ class SpecialUnitary(Operation):
         the number of qubits to which we can apply a ``SpecialUnitary`` gate in practice.
 
     """
+
     num_wires = AnyWires
     """int: Number of wires that the operator acts on."""
 

--- a/pennylane/ops/qubit/state_preparation.py
+++ b/pennylane/ops/qubit/state_preparation.py
@@ -64,6 +64,7 @@ class BasisState(StatePrepBase):
     >>> print(example_circuit())
     [0.+0.j 0.+0.j 0.+0.j 1.+0.j]
     """
+
     num_wires = AnyWires
     num_params = 1
     """int: Number of trainable parameters that the operator depends on."""
@@ -159,6 +160,7 @@ class StatePrep(StatePrepBase):
     >>> print(example_circuit())
     [1.+0.j 0.+0.j 0.+0.j 0.+0.j]
     """
+
     num_wires = AnyWires
     num_params = 1
     """int: Number of trainable parameters that the operator depends on."""
@@ -285,6 +287,7 @@ class QubitDensityMatrix(Operation):
          [0.+0.j 0.+0.j 0.+0.j 0.+0.j]
          [0.+0.j 0.+0.j 0.+0.j 0.+0.j]]
     """
+
     num_wires = AnyWires
     num_params = 1
     """int: Number of trainable parameters that the operator depends on."""

--- a/pennylane/ops/qutrit/matrix_ops.py
+++ b/pennylane/ops/qutrit/matrix_ops.py
@@ -185,6 +185,7 @@ class ControlledQutritUnitary(QutritUnitary):
 
     >>> qml.ControlledQutritUnitary(U, control_wires=[0, 1, 2], wires=3, control_values='012')
     """
+
     num_wires = AnyWires
     """int: Number of wires that the operator acts on."""
 

--- a/pennylane/ops/qutrit/non_parametric_ops.py
+++ b/pennylane/ops/qutrit/non_parametric_ops.py
@@ -47,6 +47,7 @@ class TShift(Operation):
     Args:
         wires (Sequence[int] or int): the wire the operation acts on
     """
+
     num_wires = 1
     """int: Number of wires that the operator acts on."""
 
@@ -128,6 +129,7 @@ class TClock(Operation):
     Args:
         wires (Sequence[int] or int): the wire the operation acts on
     """
+
     num_wires = 1
     """int: Number of wires that the operator acts on."""
 
@@ -217,6 +219,7 @@ class TAdd(Operation):
     Args:
         wires (Sequence[int]): the wires the operation acts on
     """
+
     num_wires = 2
     """int: Number of wires that the operator acts on."""
 
@@ -323,6 +326,7 @@ class TSWAP(Operation):
     Args:
         wires (Sequence[int]): the wires the operation acts on
     """
+
     num_wires = 2
     num_params = 0
     """int: Number of trainable parameters that the operator depends on."""
@@ -459,6 +463,7 @@ class THadamard(Operation):
            [ 0. -0.57735027j,  0.5+0.28867513j, -0.5+0.28867513j],
            [ 0. -0.57735027j, -0.5+0.28867513j,  0.5+0.28867513j]])
     """
+
     num_wires = 1
     num_params = 0
     """int: Number of trainable parameters that the operator depends on."""

--- a/pennylane/ops/qutrit/observables.py
+++ b/pennylane/ops/qutrit/observables.py
@@ -197,6 +197,7 @@ class GellMann(Observable):
     1: ──TShift─────────╰TAdd─┤
 
     """
+
     num_wires = 1
     num_params = 0
     """int: Number of trainable parameters the operator depends on"""

--- a/pennylane/ops/qutrit/parametric_ops.py
+++ b/pennylane/ops/qutrit/parametric_ops.py
@@ -97,6 +97,7 @@ class TRX(Operation):
            [0.        +0.j        , 0.96891242+0.j        , 0.        -0.24740396j],
            [0.        +0.j        , 0.        -0.24740396j, 0.96891242+0.j        ]])
     """
+
     num_wires = 1
     num_params = 1
     """int: Number of trainable parameters that the operator depends on."""
@@ -241,6 +242,7 @@ class TRY(Operation):
            [ 0.        +0.j,  0.96891242+0.j, -0.24740396-0.j],
            [ 0.        +0.j,  0.24740396+0.j,  0.96891242+0.j]])
     """
+
     num_wires = 1
     num_params = 1
     """int: Number of trainable parameters that the operator depends on."""
@@ -381,6 +383,7 @@ class TRZ(Operation):
            [0.        +0.j        , 0.96891242-0.24740396j, 0.        +0.j        ],
            [0.        +0.j        , 0.        +0.j        , 0.96891242+0.24740396j]])
     """
+
     num_wires = 1
     num_params = 1
     """int: Number of trainable parameters that the operator depends on."""

--- a/pennylane/ops/qutrit/state_preparation.py
+++ b/pennylane/ops/qutrit/state_preparation.py
@@ -62,6 +62,7 @@ class QutritBasisState(StatePrepBase):
     >>> print(example_circuit())
     [0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 1.+0.j]
     """
+
     num_wires = AnyWires
     num_params = 1
     """int: Number of trainable parameters that the operator depends on."""

--- a/pennylane/optimize/rotoselect.py
+++ b/pennylane/optimize/rotoselect.py
@@ -88,6 +88,7 @@ class RotoselectOptimizer:
     The optimized values for x should now be stored in ``x`` together with the optimal gates for
     the circuit, while steps-vs-cost can be seen by plotting ``cost_rotosel``.
     """
+
     # pylint: disable=too-few-public-methods
 
     def __init__(self, possible_generators=None):

--- a/pennylane/optimize/rotosolve.py
+++ b/pennylane/optimize/rotosolve.py
@@ -324,6 +324,7 @@ class RotosolveOptimizer:
     to converge than previously, Rotosolve was able to adapt to the more complicated
     dependence on the input arguments and still found the global minimum successfully.
     """
+
     # pylint: disable=too-few-public-methods
 
     def __init__(self, substep_optimizer="brute", substep_kwargs=None):

--- a/pennylane/qcut/processing.py
+++ b/pennylane/qcut/processing.py
@@ -64,9 +64,11 @@ def qcut_processing_fn(
     # each tape contains only expval measurements or sample measurements, so
     # stacking won't create any ragged arrays
     results = [
-        qml.math.stack(tape_res)
-        if isinstance(tape_res, tuple)
-        else qml.math.reshape(tape_res, [-1])
+        (
+            qml.math.stack(tape_res)
+            if isinstance(tape_res, tuple)
+            else qml.math.reshape(tape_res, [-1])
+        )
         for tape_res in results
     ]
 

--- a/pennylane/resource/resource.py
+++ b/pennylane/resource/resource.py
@@ -55,6 +55,7 @@ class Resources:
         gate_sizes:
         {1: 1, 2: 1}
     """
+
     num_wires: int = 0
     num_gates: int = 0
     gate_types: dict = field(default_factory=dict)

--- a/pennylane/resource/second_quantization.py
+++ b/pennylane/resource/second_quantization.py
@@ -85,6 +85,7 @@ class DoubleFactorization(Operation):
         default value of 0.0016 Ha (chemical accuracy). The costs are computed using Eqs. (C39-C40)
         of [`PRX Quantum 2, 030305 (2021) <https://journals.aps.org/prxquantum/abstract/10.1103/PRXQuantum.2.030305>`_].
     """
+
     num_wires = AnyWires
     grad_method = None
 

--- a/pennylane/templates/layers/gate_fabric.py
+++ b/pennylane/templates/layers/gate_fabric.py
@@ -170,6 +170,7 @@ class GateFabric(Operation):
         (2, 1, 2)
 
     """
+
     num_wires = AnyWires
     grad_method = None
 

--- a/pennylane/templates/layers/simplified_two_design.py
+++ b/pennylane/templates/layers/simplified_two_design.py
@@ -98,6 +98,7 @@ class SimplifiedTwoDesign(Operation):
             weights = [np.random.random(size=shape) for shape in shapes]
 
     """
+
     num_wires = AnyWires
     grad_method = None
 

--- a/pennylane/templates/layers/strongly_entangling.py
+++ b/pennylane/templates/layers/strongly_entangling.py
@@ -129,6 +129,7 @@ class StronglyEntanglingLayers(Operation):
             weights = np.random.random(size=shape)
 
     """
+
     num_wires = AnyWires
     grad_method = None
 

--- a/pennylane/templates/state_preparations/basis.py
+++ b/pennylane/templates/state_preparations/basis.py
@@ -51,6 +51,7 @@ class BasisStatePreparation(Operation):
     [ 1. -1. -1.  1.]
 
     """
+
     num_params = 1
     num_wires = AnyWires
     grad_method = None

--- a/pennylane/templates/state_preparations/basis_qutrit.py
+++ b/pennylane/templates/state_preparations/basis_qutrit.py
@@ -50,6 +50,7 @@ class QutritBasisStatePreparation(Operation):
     >>> print(circuit(basis_state, obs))
     [array(0.70710678), array(-0.70710678), array(-0.70710678), array(0.70710678)]
     """
+
     num_params = 1
     num_wires = AnyWires
     grad_method = None

--- a/pennylane/templates/state_preparations/cosine_window.py
+++ b/pennylane/templates/state_preparations/cosine_window.py
@@ -99,10 +99,10 @@ class CosineWindow(StatePrepBase):
 
         num_op_wires = len(self.wires)
         op_vector_shape = (2,) * num_op_wires
+        coeff = np.sqrt(2 ** (1 - num_op_wires))
         vector = np.array(
             [
-                np.sqrt(2 ** (1 - num_op_wires))
-                * np.cos(-np.pi / 2 + np.pi * x / 2**num_op_wires)
+                coeff * np.cos(-np.pi / 2 + np.pi * x / 2**num_op_wires)
                 for x in range(2**num_op_wires)
             ]
         )

--- a/pennylane/templates/subroutines/grover.py
+++ b/pennylane/templates/subroutines/grover.py
@@ -97,6 +97,7 @@ class GroverOperator(Operation):
     Optimally, the oracle-operator pairing should be repeated :math:`\lceil \frac{\pi}{4}\sqrt{2^{n}} \rceil` times.
 
     """
+
     num_wires = AnyWires
     grad_method = None
 

--- a/pennylane/templates/subroutines/hilbert_schmidt.py
+++ b/pennylane/templates/subroutines/hilbert_schmidt.py
@@ -93,6 +93,7 @@ class HilbertSchmidt(Operation):
         1
 
     """
+
     num_wires = AnyWires
     grad_method = None
 

--- a/pennylane/templates/subroutines/qft.py
+++ b/pennylane/templates/subroutines/qft.py
@@ -63,6 +63,7 @@ class QFT(Operation):
 
         circuit_qft(np.array([1.0, 0.0, 0.0], requires_grad=False))
     """
+
     num_wires = AnyWires
     grad_method = None
 

--- a/pennylane/templates/subroutines/qmc.py
+++ b/pennylane/templates/subroutines/qmc.py
@@ -336,6 +336,7 @@ class QuantumMonteCarlo(Operation):
         >>> (1 - np.cos(np.pi * phase_estimated)) / 2
         0.4327096457464369
     """
+
     num_wires = AnyWires
     grad_method = None
 

--- a/pennylane/templates/subroutines/qpe.py
+++ b/pennylane/templates/subroutines/qpe.py
@@ -136,6 +136,7 @@ class QuantumPhaseEstimation(Operation):
             phase_estimated = np.argmax(circuit()) / 2 ** n_estimation_wires
 
     """
+
     num_wires = AnyWires
     grad_method = None
 

--- a/pennylane/transforms/transpile.py
+++ b/pennylane/transforms/transpile.py
@@ -1,6 +1,7 @@
 """
 Contains the transpiler transform.
 """
+
 from functools import partial
 from typing import List, Union, Sequence, Callable
 

--- a/pennylane/typing.py
+++ b/pennylane/typing.py
@@ -73,6 +73,7 @@ class TensorLike(metaclass=TensorLikeMETA):
 
 def _is_jax(other, subclass=False):
     """Check if other is an instance or a subclass of a jax tensor."""
+    # pylint: disable=c-extension-no-member
     if "jax" in sys.modules:
         with contextlib.suppress(ImportError):
             import jax
@@ -81,11 +82,11 @@ def _is_jax(other, subclass=False):
 
             JaxTensor = Union[
                 ndarray,
-                jax.Array  # TODO: keep this after jax>=0.4 is required
-                if hasattr(jax, "Array")
-                else Union[
-                    jaxlib.xla_extension.DeviceArray, jax.core.Tracer
-                ],  # pylint: disable=c-extension-no-member
+                (
+                    jax.Array  # TODO: keep this after jax>=0.4 is required
+                    if hasattr(jax, "Array")
+                    else Union[jaxlib.xla_extension.DeviceArray, jax.core.Tracer]
+                ),
             ]
             check = issubclass if subclass else isinstance
 

--- a/pennylane/workflow/execution.py
+++ b/pennylane/workflow/execution.py
@@ -19,10 +19,10 @@ Also contains the general execute function, for exectuting tapes on
 devices with autodifferentiation support.
 """
 
-# pylint: disable=import-outside-toplevel,too-many-arguments,too-many-branches,not-callable
-# pylint: disable=unused-argument,unnecessary-lambda-assignment,inconsistent-return-statements,
-# pylint: disable=too-many-statements, invalid-unary-operand-type, function-redefined
-# pylint: disable=isinstance-second-argument-not-valid-type
+# pylint: disable=import-outside-toplevel,too-many-branches,not-callable,unexpected-keyword-arg
+# pylint: disable=unused-argument,unnecessary-lambda-assignment,inconsistent-return-statements
+# pylint: disable=invalid-unary-operand-type,isinstance-second-argument-not-valid-type
+# pylint: disable=too-many-arguments,too-many-statements,function-redefined,too-many-function-args
 
 import inspect
 import warnings
@@ -323,15 +323,19 @@ def cache_execute(fn: Callable, cache, pass_kwargs=False, return_tuple=True, exp
     if logger.isEnabledFor(logging.DEBUG):
         logger.debug(
             "Entry with args=(fn=%s, cache=%s, pass_kwargs=%s, return_tuple=%s, expand_fn=%s) called by=%s",
-            fn
-            if not (logger.isEnabledFor(qml.logging.TRACE) and inspect.isfunction(fn))
-            else "\n" + inspect.getsource(fn),
+            (
+                fn
+                if not (logger.isEnabledFor(qml.logging.TRACE) and inspect.isfunction(fn))
+                else "\n" + inspect.getsource(fn)
+            ),
             cache,
             pass_kwargs,
             return_tuple,
-            expand_fn
-            if not (logger.isEnabledFor(qml.logging.TRACE) and inspect.isfunction(expand_fn))
-            else "\n" + inspect.getsource(expand_fn) + "\n",
+            (
+                expand_fn
+                if not (logger.isEnabledFor(qml.logging.TRACE) and inspect.isfunction(expand_fn))
+                else "\n" + inspect.getsource(expand_fn) + "\n"
+            ),
             "::L".join(str(i) for i in inspect.getouterframes(inspect.currentframe(), 2)[1][1:3]),
         )
 
@@ -553,9 +557,11 @@ def execute(
             """Entry with args=(tapes=%s, device=%s, gradient_fn=%s, interface=%s, grad_on_execution=%s, gradient_kwargs=%s, cache=%s, cachesize=%s, max_diff=%s, override_shots=%s, expand_fn=%s, max_expansion=%s, device_batch_transform=%s) called by=%s""",
             tapes,
             repr(device),
-            gradient_fn
-            if not (logger.isEnabledFor(qml.logging.TRACE) and inspect.isfunction(gradient_fn))
-            else "\n" + inspect.getsource(gradient_fn) + "\n",
+            (
+                gradient_fn
+                if not (logger.isEnabledFor(qml.logging.TRACE) and inspect.isfunction(gradient_fn))
+                else "\n" + inspect.getsource(gradient_fn) + "\n"
+            ),
             interface,
             grad_on_execution,
             gradient_kwargs,
@@ -563,9 +569,11 @@ def execute(
             cachesize,
             max_diff,
             override_shots,
-            expand_fn
-            if not (logger.isEnabledFor(qml.logging.TRACE) and inspect.isfunction(expand_fn))
-            else "\n" + inspect.getsource(expand_fn) + "\n",
+            (
+                expand_fn
+                if not (logger.isEnabledFor(qml.logging.TRACE) and inspect.isfunction(expand_fn))
+                else "\n" + inspect.getsource(expand_fn) + "\n"
+            ),
             max_expansion,
             device_batch_transform,
             "::L".join(str(i) for i in inspect.getouterframes(inspect.currentframe(), 2)[1][1:3]),

--- a/pennylane/workflow/interfaces/torch.py
+++ b/pennylane/workflow/interfaces/torch.py
@@ -212,9 +212,11 @@ def execute(tapes, execute_fn, jpc, device=None):
         logger.debug(
             "Entry with args=(tapes=%s, execute_fn=%s, jpc=%s",
             tapes,
-            f"\n{inspect.getsource(execute_fn)}\n"
-            if logger.isEnabledFor(qml.logging.TRACE)
-            else execute_fn,
+            (
+                f"\n{inspect.getsource(execute_fn)}\n"
+                if logger.isEnabledFor(qml.logging.TRACE)
+                else execute_fn
+            ),
             jpc,
         )
 

--- a/pennylane/workflow/jacobian_products.py
+++ b/pennylane/workflow/jacobian_products.py
@@ -249,9 +249,13 @@ class TransformJacobianProducts(JacobianProductCalculator):
         if logger.isEnabledFor(logging.DEBUG):  # pragma: no cover
             logger.debug(
                 "TransformJacobianProduct being created with (%s, %s, %s, %s)",
-                inspect.getsource(inner_execute)
-                if (logger.isEnabledFor(qml.logging.TRACE) and inspect.isfunction(inner_execute))
-                else inner_execute,
+                (
+                    inspect.getsource(inner_execute)
+                    if (
+                        logger.isEnabledFor(qml.logging.TRACE) and inspect.isfunction(inner_execute)
+                    )
+                    else inner_execute
+                ),
                 gradient_transform,
                 gradient_kwargs,
                 cache_full_jacobian,

--- a/pennylane/workflow/qnode.py
+++ b/pennylane/workflow/qnode.py
@@ -404,9 +404,11 @@ class QNode:
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug(
                 """Creating QNode(func=%s, device=%s, interface=%s, diff_method=%s, expansion_strategy=%s, max_expansion=%s, grad_on_execution=%s, cache=%s, cachesize=%s, max_diff=%s, gradient_kwargs=%s""",
-                func
-                if not (logger.isEnabledFor(qml.logging.TRACE) and inspect.isfunction(func))
-                else "\n" + inspect.getsource(func),
+                (
+                    func
+                    if not (logger.isEnabledFor(qml.logging.TRACE) and inspect.isfunction(func))
+                    else "\n" + inspect.getsource(func)
+                ),
                 repr(device),
                 interface,
                 diff_method,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,5 +6,5 @@ pytest-xdist>=2.5.0
 flaky>=3.7.0
 pytest-forked>=1.4.0
 pytest-benchmark
-black~=23.12
+black>=21
 tomli~=2.0.0 # Drop once minimum Python version is 3.11

--- a/tests/devices/qubit/test_apply_operation.py
+++ b/tests/devices/qubit/test_apply_operation.py
@@ -786,10 +786,11 @@ class TestBroadcasting:  # pylint: disable=too-few-public-methods
         res = method(op, qml.math.asarray(state, like=ml_framework))
         missing_wires = 3 - len(op.wires)
         mat = op.matrix()
-        expanded_mat = [
-            np.kron(np.eye(2**missing_wires), mat[i]) if missing_wires else mat[i]
-            for i in range(3)
-        ]
+        expanded_mat = (
+            [np.kron(np.eye(2**missing_wires), mat[i]) for i in range(3)]
+            if missing_wires
+            else [mat[i] for i in range(3)]
+        )
         expected = [(expanded_mat[i] @ state.flatten()).reshape((2, 2, 2)) for i in range(3)]
 
         assert qml.math.get_interface(res) == ml_framework
@@ -820,10 +821,11 @@ class TestBroadcasting:  # pylint: disable=too-few-public-methods
         res = method(op, qml.math.asarray(state, like=ml_framework), is_state_batched=True)
         missing_wires = 3 - len(op.wires)
         mat = op.matrix()
-        expanded_mat = [
-            np.kron(np.eye(2**missing_wires), mat[i]) if missing_wires else mat[i]
-            for i in range(3)
-        ]
+        expanded_mat = (
+            [np.kron(np.eye(2**missing_wires), mat[i]) for i in range(3)]
+            if missing_wires
+            else [mat[i] for i in range(3)]
+        )
         expected = [(expanded_mat[i] @ state[i].flatten()).reshape((2, 2, 2)) for i in range(3)]
 
         assert qml.math.get_interface(res) == ml_framework

--- a/tests/devices/test_default_gaussian.py
+++ b/tests/devices/test_default_gaussian.py
@@ -558,12 +558,8 @@ class TestDefaultGaussianDevice:
         r = 0.4523
         dev.apply("SqueezedState", wires=Wires([0]), par=[r, 0])
         mean = dev.expval("FockStateProjector", Wires([0]), [np.array([2 * n])])
-        expected = (
-            np.abs(
-                np.sqrt(fac(2 * n)) / (2**n * fac(n)) * (-np.tanh(r)) ** n / np.sqrt(np.cosh(r))
-            )
-            ** 2
-        )
+        base = np.sqrt(fac(2 * n)) / (2**n * fac(n)) * (-np.tanh(r)) ** n / np.sqrt(np.cosh(r))
+        expected = np.abs(base) ** 2
         assert mean == pytest.approx(expected, abs=tol)
 
     def test_variance_displaced_thermal_mean_photon(self, tol):
@@ -615,12 +611,8 @@ class TestDefaultGaussianDevice:
         r = 0.4523
         dev.apply("SqueezedState", wires=Wires([0]), par=[r, 0])
         var = dev.var("FockStateProjector", Wires([0]), [np.array([2 * n])])
-        mean = (
-            np.abs(
-                np.sqrt(fac(2 * n)) / (2**n * fac(n)) * (-np.tanh(r)) ** n / np.sqrt(np.cosh(r))
-            )
-            ** 2
-        )
+        base = np.sqrt(fac(2 * n)) / (2**n * fac(n)) * (-np.tanh(r)) ** n / np.sqrt(np.cosh(r))
+        mean = np.abs(base) ** 2
         assert var == pytest.approx(mean * (1 - mean), abs=tol)
 
     def test_reduced_state(self, gaussian_dev, tol):

--- a/tests/devices/test_default_qutrit.py
+++ b/tests/devices/test_default_qutrit.py
@@ -115,9 +115,11 @@ class TestApply:
         qutrit_device_1_wire._state = np.array(input, dtype=qutrit_device_1_wire.C_DTYPE)
         qutrit_device_1_wire.apply(
             [
-                qml.adjoint(operation(wires=[0]))
-                if subspace is None
-                else qml.adjoint(operation(wires=[0], subspace=subspace))
+                (
+                    qml.adjoint(operation(wires=[0]))
+                    if subspace is None
+                    else qml.adjoint(operation(wires=[0], subspace=subspace))
+                )
             ]
         )
 
@@ -172,9 +174,11 @@ class TestApply:
         )
         qutrit_device_2_wires.apply(
             [
-                operation(wires=[0, 1])
-                if subspace is None
-                else operation(wires=[0, 1], subspace=subspace)
+                (
+                    operation(wires=[0, 1])
+                    if subspace is None
+                    else operation(wires=[0, 1], subspace=subspace)
+                )
             ]
         )
 
@@ -196,9 +200,11 @@ class TestApply:
         )
         qutrit_device_2_wires.apply(
             [
-                qml.adjoint(operation(wires=[0, 1]))
-                if subspace is None
-                else qml.adjoint(operation(wires=[0, 1], subspace=subspace))
+                (
+                    qml.adjoint(operation(wires=[0, 1]))
+                    if subspace is None
+                    else qml.adjoint(operation(wires=[0, 1], subspace=subspace))
+                )
             ]
         )
 

--- a/tests/fermi/test_parity_mapping.py
+++ b/tests/fermi/test_parity_mapping.py
@@ -1,4 +1,5 @@
 """Unit testing of conversion functions for parity transform"""
+
 import pytest
 
 import pennylane as qml

--- a/tests/gate_data.py
+++ b/tests/gate_data.py
@@ -1,4 +1,5 @@
 """Convenience gate representations for testing"""
+
 import pennylane as qml
 from pennylane import numpy as np
 from pennylane import math

--- a/tests/gradients/core/test_jvp.py
+++ b/tests/gradients/core/test_jvp.py
@@ -979,9 +979,11 @@ class TestBatchJVP:
             tapes,
             tangents,
             param_shift,
-            reduction=lambda jvps, x: jvps.extend(qml.math.reshape(x, (1,)))
-            if not isinstance(x, tuple) and x.shape == ()
-            else jvps.extend(x),
+            reduction=lambda jvps, x: (
+                jvps.extend(qml.math.reshape(x, (1,)))
+                if not isinstance(x, tuple) and x.shape == ()
+                else jvps.extend(x)
+            ),
         )
         res = fn(dev.execute(v_tapes))
 

--- a/tests/gradients/parameter_shift/test_parameter_shift.py
+++ b/tests/gradients/parameter_shift/test_parameter_shift.py
@@ -645,9 +645,11 @@ class TestParamShift:
 
         tape = qml.tape.QuantumScript.from_queue(q)
         gradient_recipes = tuple(
-            [[-1e-7, 1, 0], [1e-7, 1, 0], [-1e5, 1, -5e-6], [1e5, 1, 5e-6]]
-            if i in ops_with_custom_recipe
-            else None
+            (
+                [[-1e-7, 1, 0], [1e-7, 1, 0], [-1e5, 1, -5e-6], [1e5, 1, 5e-6]]
+                if i in ops_with_custom_recipe
+                else None
+            )
             for i in range(2)
         )
         tapes, fn = qml.gradients.param_shift(tape, gradient_recipes=gradient_recipes)

--- a/tests/qchem/test_structure.py
+++ b/tests/qchem/test_structure.py
@@ -365,8 +365,10 @@ def mock_from_cid(cid, record_type, pcp=None):
     if [cid, record_type] in [[297, "3d"], [783, "2d"]]:
         return pcp.Compound(records[cid])
 
-    raise pcp.NotFoundError if [cid, record_type] == [783, "3d"] else ValueError(
-        "Provided CID (or Identifier) is None."
+    raise (
+        pcp.NotFoundError
+        if [cid, record_type] == [783, "3d"]
+        else ValueError("Provided CID (or Identifier) is None.")
     )
 
 

--- a/tests/templates/test_swapnetworks/test_ccl2.py
+++ b/tests/templates/test_swapnetworks/test_ccl2.py
@@ -83,9 +83,11 @@ class TestDecomposition:
 
         # number of gates
         assert len(queue) == sum(
-            2 * len(i)
-            if acquaintances is not None and acquaintances([0, 1], [0, 1], 0.0)
-            else len(i)
+            (
+                2 * len(i)
+                if acquaintances is not None and acquaintances([0, 1], [0, 1], 0.0)
+                else len(i)
+            )
             for i in qubit_pairs
         )
 

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -73,6 +73,7 @@ class TestOperatorConstruction:
 
         class DummyOp(qml.operation.Operator):
             r"""Dummy custom operator"""
+
             num_wires = 1
 
         with pytest.raises(ValueError, match="wrong number of wires"):
@@ -83,6 +84,7 @@ class TestOperatorConstruction:
 
         class DummyOp(qml.operation.Operator):
             r"""Dummy custom operator"""
+
             num_wires = 1
 
         with pytest.raises(qml.wires.WireError, match="Wires must be unique"):
@@ -102,6 +104,7 @@ class TestOperatorConstruction:
 
         class DummyOp(qml.operation.Operator):
             r"""Dummy custom operator that declares num_params as an instance property"""
+
             num_wires = 1
             grad_method = "A"
 
@@ -117,6 +120,7 @@ class TestOperatorConstruction:
 
         class DummyOp2(qml.operation.Operator):
             r"""Dummy custom operator that declares num_params as a class property"""
+
             num_params = 4
             num_wires = 1
             grad_method = "A"
@@ -130,6 +134,7 @@ class TestOperatorConstruction:
 
         class DummyOp3(qml.operation.Operator):
             r"""Dummy custom operator that does not declare num_params at all"""
+
             num_wires = 1
             grad_method = "A"
 
@@ -142,6 +147,7 @@ class TestOperatorConstruction:
 
         class DummyOp(qml.operation.Operator):
             r"""Dummy custom operator that declares ndim_params as an instance property"""
+
             num_wires = 1
             grad_method = "A"
             ndim_params = (0,)
@@ -155,6 +161,7 @@ class TestOperatorConstruction:
 
         class DummyOp2(qml.operation.Operator):
             r"""Dummy custom operator that declares ndim_params as a class property"""
+
             ndim_params = (1, 2)
             num_wires = 1
             grad_method = "A"
@@ -169,6 +176,7 @@ class TestOperatorConstruction:
 
         class DummyOp3(qml.operation.Operator):
             r"""Dummy custom operator that does not declare ndim_params at all"""
+
             num_wires = 1
             grad_method = "A"
 
@@ -180,6 +188,7 @@ class TestOperatorConstruction:
 
         class DummyOp4(qml.operation.Operator):
             r"""Dummy custom operator that declares ndim_params as a class property"""
+
             ndim_params = (0, 2)
             num_wires = 1
 
@@ -193,6 +202,7 @@ class TestOperatorConstruction:
 
         class DummyOp(qml.operation.Operator):
             r"""Dummy custom operator"""
+
             num_wires = 1
 
         op = DummyOp(wires=0)
@@ -203,6 +213,7 @@ class TestOperatorConstruction:
 
         class DummyOp(qml.operation.Operator):
             r"""Dummy custom operator"""
+
             num_wires = 1
 
         op = DummyOp([1, 2, 3], wires=0)
@@ -238,6 +249,7 @@ class TestOperatorConstruction:
 
         class DummyOp(qml.operation.Operator):
             r"""Dummy custom operator"""
+
             num_wires = 1
 
         op = DummyOp(wires=0)
@@ -370,6 +382,7 @@ class TestBroadcasting:
 
         class DummyOp(qml.operation.Operator):
             r"""Dummy custom operator that declares ndim_params as a class property"""
+
             ndim_params = (0, 2)
             num_wires = 1
 
@@ -385,6 +398,7 @@ class TestBroadcasting:
 
         class DummyOp(qml.operation.Operator):
             r"""Dummy custom operator that declares ndim_params as a class property"""
+
             ndim_params = (0, 2)
             num_wires = 1
 
@@ -402,6 +416,7 @@ class TestBroadcasting:
 
         class DummyOp(qml.operation.Operator):
             r"""Dummy custom operator that declares ndim_params as a class property"""
+
             ndim_params = (0, 2)
             num_wires = 1
 
@@ -419,6 +434,7 @@ class TestBroadcasting:
 
         class DummyOp(qml.operation.Operator):
             r"""Dummy custom operator that declares ndim_params as a class property"""
+
             ndim_params = (0, 2)
             num_wires = 1
 
@@ -436,6 +452,7 @@ class TestBroadcasting:
 
         class DummyOp(qml.operation.Operator):
             r"""Dummy custom operator that declares ndim_params as a class property"""
+
             ndim_params = (0, 2)
             num_wires = 1
 
@@ -651,6 +668,7 @@ class TestModificationMethods:
 
         class DummyOp(qml.operation.Operator):
             r"""Dummy custom operator that declares ndim_params as a class property"""
+
             num_wires = 1
 
         op = DummyOp(wires=0)
@@ -662,6 +680,7 @@ class TestModificationMethods:
 
         class DummyOp(qml.operation.Operator):
             r"""Dummy custom operator that declares ndim_params as a class property"""
+
             num_wires = 3
 
         op = DummyOp(wires=[0, 1, 2])
@@ -690,6 +709,7 @@ class TestModificationMethods:
 
         class DummyOp(qml.operation.Operator):
             r"""Dummy custom operator that declares ndim_params as a class property"""
+
             num_wires = 3
 
         op = DummyOp(wires=[0, 1, 2])
@@ -709,6 +729,7 @@ class TestOperationConstruction:
 
         class DummyOp(qml.operation.Operation):
             r"""Dummy custom operation"""
+
             num_wires = 1
             grad_method = "A"
 
@@ -728,6 +749,7 @@ class TestOperationConstruction:
 
         class DummyOp(qml.operation.Operation):
             r"""Dummy custom operation"""
+
             num_wires = 1
 
             @property
@@ -745,6 +767,7 @@ class TestOperationConstruction:
 
         class DummyOp(qml.operation.Operation):
             r"""Dummy custom operation"""
+
             num_wires = 1
 
             def generator(self):
@@ -761,6 +784,7 @@ class TestOperationConstruction:
 
         class DummyOp(qml.operation.Operation):
             r"""Dummy custom operation"""
+
             num_wires = 1
 
         x = 0.654
@@ -774,6 +798,7 @@ class TestOperationConstruction:
 
         class DummyOp(qml.operation.Operation):
             r"""Dummy custom operation"""
+
             num_wires = 1
             grad_recipe = ["not a recipe"]
 
@@ -788,6 +813,7 @@ class TestOperationConstruction:
 
         class DummyOp(qml.operation.Operation):
             r"""Dummy custom operation"""
+
             num_wires = 1
 
         op = DummyOp(wires=0)
@@ -799,6 +825,7 @@ class TestOperationConstruction:
 
         class DummyOp(qml.operation.Operation):
             r"""Dummy custom operation"""
+
             num_wires = 1
             grad_method = "A"
 
@@ -815,6 +842,7 @@ class TestOperationConstruction:
 
         class DummyOp(qml.operation.Operation):
             r"""Dummy custom operation"""
+
             num_params = 3
             num_wires = 1
             grad_method = "A"
@@ -833,6 +861,7 @@ class TestOperationConstruction:
 
         class DummyOp(qml.operation.Operation):
             r"""Dummy custom operation"""
+
             num_params = num_param
             num_wires = 1
             grad_method = "A"
@@ -863,6 +892,7 @@ class TestOperationConstruction:
 
         class DummyOp(qml.operation.Operation):
             r"""Dummy custom operation"""
+
             num_wires = 1
             num_params = 1
             grad_method = None
@@ -875,6 +905,7 @@ class TestOperationConstruction:
 
         class DummyOp(qml.operation.Operation):
             r"""Dummy custom operation"""
+
             num_wires = 1
             grad_method = None
 
@@ -886,6 +917,7 @@ class TestOperationConstruction:
 
         class DummyOp(qml.operation.Operation):
             r"""Dummy custom operation"""
+
             num_wires = 1
             grad_method = None
 
@@ -897,6 +929,7 @@ class TestOperationConstruction:
 
         class DummyOp(qml.operation.Operation):
             r"""Dummy custom operation"""
+
             num_wires = 1
             grad_method = None
 
@@ -912,6 +945,7 @@ class TestObservableConstruction:
 
         class DummyObserv(qml.operation.Observable):
             r"""Dummy custom observable"""
+
             num_wires = 1
             grad_method = None
 
@@ -929,6 +963,7 @@ class TestObservableConstruction:
 
         class DummyObserv(qml.operation.Observable, qml.operation.Operation):
             r"""Dummy custom observable"""
+
             num_wires = 1
             grad_method = None
 
@@ -991,6 +1026,7 @@ class TestObservableConstruction:
 
         class DummyObserv(qml.operation.Observable):
             r"""Dummy custom observable"""
+
             num_wires = 1
             grad_method = None
 
@@ -1011,6 +1047,7 @@ class TestObservableConstruction:
 
         class DummyObserv(qml.operation.Observable):
             r"""Dummy custom observable"""
+
             num_wires = 1
             grad_method = None
 
@@ -1029,6 +1066,7 @@ class TestOperatorIntegration:
 
         class DummyOp(qml.operation.Operation):
             r"""Dummy custom operator"""
+
             num_wires = qml.operation.WiresEnum.AllWires
 
         @qml.qnode(dev1)
@@ -1048,6 +1086,7 @@ class TestOperatorIntegration:
 
         class DummyOp(qml.operation.Operation):
             r"""Dummy custom operator"""
+
             num_wires = 1
 
         with pytest.raises(TypeError, match="unsupported operand type"):
@@ -2254,6 +2293,7 @@ class TestChannel:
 
         class DummyOp(qml.operation.Channel):
             r"""Dummy custom channel"""
+
             num_wires = 1
             grad_method = "F"
 

--- a/tests/transforms/test_transpile.py
+++ b/tests/transforms/test_transpile.py
@@ -1,6 +1,7 @@
 """
 Unit tests for transpiler function.
 """
+
 from math import isclose
 import pytest
 


### PR DESCRIPTION
**Context:**
See #5112. New version of `black` came out, and it auto-formatted a bunch of files. Most of these changes are backwards-compatible (with previous versions of `black`) but not all, so it was non-trivial

**Description of the Change:**
Did the following:
```shell
pip install -U black
make format
git add .
pip install black~=23.12
make format
```
At this point, all unstaged changes are non-backwards-compatible lines. So, I tweaked those lines, ran `make format` to make sure they were good with old black, then re-ran the above set of commands to ensure it's forwards-compatible too. I'll inline comment each actual change I made.

**Benefits:**
- devs can use whatever version of `black` they choose, including the new one
- less pinned packages == more pennylane spirit

**Possible Drawbacks:**
N/A

[sc-55823]