### PR TITLE
Feature/mcm composite

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -82,6 +82,15 @@
 
 <h3>Improvements 🛠</h3>
 
+* The `default.qubit` device handles measurement value lists when executing mid-circuit measurements natively.
+  [(#5111)](https://github.com/PennyLaneAI/pennylane/pull/5111)
+
+* The `default.qubit` device handles composite measurements when executing mid-circuit measurements natively.
+  [(#5111)](https://github.com/PennyLaneAI/pennylane/pull/5111)
+
+* The `default.qubit` device handles post-selection when executing mid-circuit measurements natively.
+  [(#5111)](https://github.com/PennyLaneAI/pennylane/pull/5111)
+
 * `device_vjp` can now be used with normal Tensorflow. Support has not yet been added
   for `tf.Function` and Tensorflow Autograph.
   [(#4676)](https://github.com/PennyLaneAI/pennylane/pull/4676)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -83,13 +83,17 @@
 <h3>Improvements 🛠</h3>
 
 * The `default.qubit` device handles measurement value lists when executing mid-circuit measurements natively.
-  [(#5111)](https://github.com/PennyLaneAI/pennylane/pull/5111)
+  [(#5120)](https://github.com/PennyLaneAI/pennylane/pull/5120)
 
 * The `default.qubit` device handles composite measurements when executing mid-circuit measurements natively.
-  [(#5111)](https://github.com/PennyLaneAI/pennylane/pull/5111)
+  [(#5120)](https://github.com/PennyLaneAI/pennylane/pull/5120)
 
 * The `default.qubit` device handles post-selection when executing mid-circuit measurements natively.
-  [(#5111)](https://github.com/PennyLaneAI/pennylane/pull/5111)
+  [(#5120)](https://github.com/PennyLaneAI/pennylane/pull/5120)
+
+* Remove queuing (`AnnotatedQueue`) from `qml.cut_circuit` and `qml.cut_circuit_mc` to improve performance 
+  for large workflows.
+  [(#5108)](https://github.com/PennyLaneAI/pennylane/pull/5108)
 
 * `device_vjp` can now be used with normal Tensorflow. Support has not yet been added
   for `tf.Function` and Tensorflow Autograph.
@@ -146,6 +150,9 @@
 
 * The transform `split_non_commuting` now accepts measurements of type `probs`, `sample` and `counts` which accept both wires and observables.
   [(#4972)](https://github.com/PennyLaneAI/pennylane/pull/4972)
+
+* A function called `apply_operation` has been added to the new `qutrit_mixed` module found in `qml.devices` that applies operations to device-compatible states.
+  [(#5032)](https://github.com/PennyLaneAI/pennylane/pull/5032)
 
 <h3>Breaking changes 💔</h3>
 
@@ -248,6 +255,9 @@
 * Added a development guide on deprecations and removals.
   [(#5083)](https://github.com/PennyLaneAI/pennylane/pull/5083)
 
+* A note about the eigenspectrum of second-quantized Hamiltonians added to `qml.eigvals`.
+  [(#5095)](https://github.com/PennyLaneAI/pennylane/pull/5095)
+
 <h3>Bug fixes 🐛</h3>
 
 * Fixed a bug where caching together with JIT compilation and broadcasted tapes yielded wrong results
@@ -266,6 +276,9 @@
 * `StatePrep` operations expanded onto more wires are now compatible with backprop.
   [(#5028)](https://github.com/PennyLaneAI/pennylane/pull/5028)
 
+* `qml.equal` works well with `qml.Sum` operators when wire labels are a mix of integers and strings.
+  [(#5037)](https://github.com/PennyLaneAI/pennylane/pull/5037)
+
 * The return value of `Controlled.generator` now contains a projector that projects onto the correct subspace based on the control value specified.
   [(#5068)](https://github.com/PennyLaneAI/pennylane/pull/5068)
 
@@ -281,14 +294,17 @@ This release contains contributions from (in alphabetical order):
 
 Abhishek Abhishek,
 Utkarsh Azad,
+Gabriel Bottrill,
 Astral Cai,
 Isaac De Vlugt,
 Korbinian Kottmann,
 Christina Lee,
 Xiaoran Li,
 Vincent Michaud-Rioux,
+Romain Moyard,
 Pablo Antonio Moreno Casares,
 Lee J. O'Riordan,
 Mudit Pandey,
 Alex Preciado,
 Matthew Silverman.
+Jay Soni,

--- a/pennylane/compiler/compiler.py
+++ b/pennylane/compiler/compiler.py
@@ -48,31 +48,17 @@ class AvailableCompilers:
     # and their entry point loaders.
     names_entrypoints = defaultdict(dict)
 
-    # The map consists of supported compiler names (str) and their version compatibility (bool).
-    # This boolean indicates whether the installed version of a compiler package is greater
-    # than or equal to the minimum version. If `False`, it checks the compatibility again before
-    # raising a `CompileError`.
-    # This value will be updated in `_check_compiler_version` to reduce the required
-    # version checks of installed compiler packages at runtime.
-    compiler_checked = defaultdict(dict)
-
 
 def _check_compiler_version(name):
     """Check if the installed version of the given compiler is greater than
     or equal to the required minimum version.
     """
-    if AvailableCompilers.compiler_checked[name]:
-        return  # Used the cached value!
-
     if name == "catalyst":
         installed_catalyst_version = metadata.version("pennylane-catalyst")
         if Version(re.sub(r"\.dev\d+", "", installed_catalyst_version)) < PL_CATALYST_MIN_VERSION:
             raise CompileError(
                 f"PennyLane-Catalyst {PL_CATALYST_MIN_VERSION} or greater is required, but installed {installed_catalyst_version}"
             )
-
-    # else
-    AvailableCompilers.compiler_checked[name] = True
 
 
 def _refresh_compilers():

--- a/pennylane/devices/qutrit_mixed/__init__.py
+++ b/pennylane/devices/qutrit_mixed/__init__.py
@@ -17,11 +17,14 @@ Submodule for performing mixed state simulations of qutrit-based quantum circuit
 This submodule is internal and subject to change without a deprecation cycle. Use
 at your own discretion.
 
+
 .. currentmodule:: pennylane.devices.qutrit_mixed
 .. autosummary::
     :toctree: api
 
     create_initial_state
+    apply_operation
 """
 
+from .apply_operation import apply_operation
 from .initialize_state import create_initial_state

--- a/pennylane/devices/qutrit_mixed/apply_operation.py
+++ b/pennylane/devices/qutrit_mixed/apply_operation.py
@@ -1,0 +1,184 @@
+# Copyright 2018-2024 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Functions to apply operations to a qutrit mixed state."""
+# pylint: disable=unused-argument
+
+from functools import singledispatch
+from string import ascii_letters as alphabet
+import pennylane as qml
+from pennylane import math
+from pennylane import numpy as np
+from pennylane.operation import Channel
+from .utils import QUDIT_DIM, get_einsum_mapping, get_new_state_einsum_indices
+
+alphabet_array = np.array(list(alphabet))
+
+
+def _map_indices_apply_channel(**kwargs):
+    """Map indices to einsum string
+    Args:
+        **kwargs (dict): Stores indices calculated in `get_einsum_mapping`
+
+    Returns:
+        String of einsum indices to complete einsum calculations
+    """
+    op_1_indices = f"{kwargs['kraus_index']}{kwargs['new_row_indices']}{kwargs['row_indices']}"
+    op_2_indices = f"{kwargs['kraus_index']}{kwargs['col_indices']}{kwargs['new_col_indices']}"
+
+    new_state_indices = get_new_state_einsum_indices(
+        old_indices=kwargs["col_indices"] + kwargs["row_indices"],
+        new_indices=kwargs["new_col_indices"] + kwargs["new_row_indices"],
+        state_indices=kwargs["state_indices"],
+    )
+    # index mapping for einsum, e.g., '...iga,...abcdef,...idh->...gbchef'
+    return (
+        f"...{op_1_indices},...{kwargs['state_indices']},...{op_2_indices}->...{new_state_indices}"
+    )
+
+
+def apply_operation_einsum(op: qml.operation.Operator, state, is_state_batched: bool = False):
+    r"""Apply a quantum channel specified by a list of Kraus operators to subsystems of the
+    quantum state. For a unitary gate, there is a single Kraus operator.
+
+    Args:
+        op (Operator): Operator to apply to the quantum state
+        state (array[complex]): Input quantum state
+        is_state_batched (bool): Boolean representing whether the state is batched or not
+
+    Returns:
+        array[complex]: output_state
+    """
+    einsum_indices = get_einsum_mapping(op, state, _map_indices_apply_channel, is_state_batched)
+
+    num_ch_wires = len(op.wires)
+
+    # This could be pulled into separate function if tensordot is added
+    if isinstance(op, Channel):
+        kraus = op.kraus_matrices()
+    else:
+        kraus = [op.matrix()]
+
+    # Shape kraus operators
+    kraus_shape = [len(kraus)] + [QUDIT_DIM] * num_ch_wires * 2
+    if not isinstance(op, Channel):
+        mat = op.matrix()
+        dim = QUDIT_DIM**num_ch_wires
+        batch_size = math.get_batch_size(mat, (dim, dim), dim**2)
+        if batch_size is not None:
+            # Add broadcasting dimension to shape
+            kraus_shape = [batch_size] + kraus_shape
+            if op.batch_size is None:
+                op._batch_size = batch_size  # pylint:disable=protected-access
+
+    kraus = math.stack(kraus)
+    kraus_transpose = math.stack(math.moveaxis(kraus, source=-1, destination=-2))
+    # Torch throws error if math.conj is used before stack
+    kraus_dagger = math.conj(kraus_transpose)
+
+    kraus = math.cast(math.reshape(kraus, kraus_shape), complex)
+    kraus_dagger = math.cast(math.reshape(kraus_dagger, kraus_shape), complex)
+
+    return math.einsum(einsum_indices, kraus, state, kraus_dagger)
+
+
+@singledispatch
+def apply_operation(
+    op: qml.operation.Operator, state, is_state_batched: bool = False, debugger=None
+):
+    """Apply an operation to a given state.
+
+    Args:
+        op (Operator): The operation to apply to ``state``
+        state (TensorLike): The starting state.
+        is_state_batched (bool): Boolean representing whether the state is batched or not
+        debugger (_Debugger): The debugger to use
+
+    Returns:
+        ndarray: output state
+
+    .. warning::
+
+        ``apply_operation`` is an internal function, and thus subject to change without a deprecation cycle.
+
+    .. warning::
+        ``apply_operation`` applies no validation to its inputs.
+
+        This function assumes that the wires of the operator correspond to indices
+        of the state. See :func:`~.map_wires` to convert operations to integer wire labels.
+
+        The shape of state should be ``[QUDIT_DIM]*(num_wires * 2)``, where ``QUDIT_DIM`` is
+        the dimension of the system.
+
+    This is a ``functools.singledispatch`` function, so additional specialized kernels
+    for specific operations can be registered like:
+
+    .. code-block:: python
+
+        @apply_operation.register
+        def _(op: type_op, state):
+            # custom op application method here
+
+    **Example:**
+
+    >>> state = np.zeros((3,3))
+    >>> state[0][0] = 1
+    >>> state
+    tensor([[1., 0., 0.],
+        [0., 0., 0.],
+        [0., 0., 0.]], requires_grad=True)
+    >>> apply_operation(qml.TShift(0), state)
+    tensor([[0., 0., 0.],
+        [0., 1., 0],
+        [0., 0., 0.],], requires_grad=True)
+
+    """
+    return _apply_operation_default(op, state, is_state_batched, debugger)
+
+
+def _apply_operation_default(op, state, is_state_batched, debugger):
+    """The default behaviour of apply_operation, accessed through the standard dispatch
+    of apply_operation, as well as conditionally in other dispatches.
+    """
+
+    return apply_operation_einsum(op, state, is_state_batched=is_state_batched)
+    # TODO add tensordot and benchmark for performance
+
+
+# TODO add diagonal for speed up.
+
+
+@apply_operation.register
+def apply_snapshot(op: qml.Snapshot, state, is_state_batched: bool = False, debugger=None):
+    """Take a snapshot of the mixed state"""
+    if debugger and debugger.active:
+        measurement = op.hyperparameters["measurement"]
+        if measurement:
+            # TODO replace with: measure once added
+            raise NotImplementedError  # TODO
+        if is_state_batched:
+            dim = int(math.sqrt(math.size(state[0])))
+            flat_shape = [math.shape(state)[0], dim, dim]
+        else:
+            dim = int(math.sqrt(math.size(state)))
+            flat_shape = [dim, dim]
+
+        snapshot = math.reshape(state, flat_shape)
+        if op.tag:
+            debugger.snapshots[op.tag] = snapshot
+        else:
+            debugger.snapshots[len(debugger.snapshots)] = snapshot
+    return state
+
+
+# TODO add special case speedups

--- a/pennylane/devices/qutrit_mixed/initialize_state.py
+++ b/pennylane/devices/qutrit_mixed/initialize_state.py
@@ -16,8 +16,7 @@
 from typing import Iterable, Union
 import pennylane as qml
 from pennylane.operation import StatePrepBase
-
-qudit_dim = 3  # specifies qudit dimension
+from .utils import QUDIT_DIM
 
 
 def create_initial_state(
@@ -55,18 +54,18 @@ def _apply_state_vector(state, num_wires):  # function is easy to abstract for q
 
     Args:
         state (array[complex]): normalized input state of length
-            ``qudit_dim**num_wires``, where ``qudit_dim`` is the dimension of the system.
+            ``QUDIT_DIM**num_wires``, where ``QUDIT_DIM`` is the dimension of the system.
         num_wires (int): number of wires that get initialized in the state
 
     Returns:
-        array[complex]: complex array of shape ``[qudit_dim] * (2 * num_wires)``
-        representing the density matrix of this state, where ``qudit_dim`` is
+        array[complex]: complex array of shape ``[QUDIT_DIM] * (2 * num_wires)``
+        representing the density matrix of this state, where ``QUDIT_DIM`` is
         the dimension of the system.
     """
 
     # Initialize the entire set of wires with the state
     rho = qml.math.outer(state, qml.math.conj(state))
-    return qml.math.reshape(rho, [qudit_dim] * 2 * num_wires)
+    return qml.math.reshape(rho, [QUDIT_DIM] * 2 * num_wires)
 
 
 def _create_basis_state(num_wires, index):  # function is easy to abstract for qudit
@@ -77,10 +76,10 @@ def _create_basis_state(num_wires, index):  # function is easy to abstract for q
         index (int): integer representing the computational basis state.
 
     Returns:
-        array[complex]: complex array of shape ``[qudit_dim] * (2 * num_wires)``
-        representing the density matrix of the basis state, where ``qudit_dim`` is
+        array[complex]: complex array of shape ``[QUDIT_DIM] * (2 * num_wires)``
+        representing the density matrix of the basis state, where ``QUDIT_DIM`` is
         the dimension of the system.
     """
-    rho = qml.math.zeros((qudit_dim**num_wires, qudit_dim**num_wires))
+    rho = qml.math.zeros((QUDIT_DIM**num_wires, QUDIT_DIM**num_wires))
     rho[index, index] = 1
-    return qml.math.reshape(rho, [qudit_dim] * (2 * num_wires))
+    return qml.math.reshape(rho, [QUDIT_DIM] * (2 * num_wires))

--- a/pennylane/devices/qutrit_mixed/utils.py
+++ b/pennylane/devices/qutrit_mixed/utils.py
@@ -1,0 +1,86 @@
+# Copyright 2018-2024 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Functions and variables to be utilized by qutrit mixed state simulator."""
+import functools
+from string import ascii_letters as alphabet
+import pennylane as qml
+from pennylane import numpy as np
+
+alphabet_array = np.array(list(alphabet))
+QUDIT_DIM = 3  # specifies qudit dimension
+
+
+def get_einsum_mapping(
+    op: qml.operation.Operator, state, map_indices, is_state_batched: bool = False
+):
+    r"""Finds the indices for einsum to apply kraus operators to a mixed state
+
+    Args:
+        op (Operator): Operator to apply to the quantum state
+        state (array[complex]): Input quantum state
+        map_indices (function): Maps the calculated indices to an einsum indices string
+        is_state_batched (bool): Boolean representing whether the state is batched or not
+
+    Returns:
+        str: indices mapping that defines the einsum
+    """
+    num_ch_wires = len(op.wires)
+    num_wires = int((len(qml.math.shape(state)) - is_state_batched) / 2)
+    rho_dim = 2 * num_wires
+
+    # Tensor indices of the state. For each qutrit, need an index for rows *and* columns
+    state_indices = alphabet[:rho_dim]
+
+    # row indices of the quantum state affected by this operation
+    row_wires_list = op.wires.tolist()
+    row_indices = "".join(alphabet_array[row_wires_list].tolist())
+
+    # column indices are shifted by the number of wires
+    col_wires_list = [w + num_wires for w in row_wires_list]
+    col_indices = "".join(alphabet_array[col_wires_list].tolist())
+
+    # indices in einsum must be replaced with new ones
+    new_row_indices = alphabet[rho_dim : rho_dim + num_ch_wires]
+    new_col_indices = alphabet[rho_dim + num_ch_wires : rho_dim + 2 * num_ch_wires]
+
+    # index for summation over Kraus operators
+    kraus_index = alphabet[rho_dim + 2 * num_ch_wires : rho_dim + 2 * num_ch_wires + 1]
+
+    # apply mapping function
+    return map_indices(
+        state_indices=state_indices,
+        kraus_index=kraus_index,
+        row_indices=row_indices,
+        new_row_indices=new_row_indices,
+        col_indices=col_indices,
+        new_col_indices=new_col_indices,
+    )
+
+
+def get_new_state_einsum_indices(old_indices, new_indices, state_indices):
+    """Retrieves the einsum indices string for the new state
+
+    Args:
+        old_indices (str): indices that are summed
+        new_indices (str): indices that must be replaced with sums
+        state_indices (str): indices of the original state
+
+    Returns:
+        str: the einsum indices of the new state
+    """
+    return functools.reduce(
+        lambda old_string, idx_pair: old_string.replace(idx_pair[0], idx_pair[1]),
+        zip(old_indices, new_indices),
+        state_indices,
+    )

--- a/pennylane/measurements/mid_measure.py
+++ b/pennylane/measurements/mid_measure.py
@@ -390,6 +390,11 @@ class MeasurementValue(Generic[T]):
         """Apply a post computation to this measurement"""
         return MeasurementValue(self.measurements, lambda *x: fn(self.processing_fn(*x)))
 
+    def concretize(self, measurements: dict):
+        """Returns a concrete value from a dictionary of hashes with concrete values."""
+        values = tuple(measurements[meas.hash] for meas in self.measurements)
+        return self.processing_fn(*values)
+
     def _merge(self, other: "MeasurementValue"):
         """Merge two measurement values"""
 

--- a/pennylane/ops/functions/eigvals.py
+++ b/pennylane/ops/functions/eigvals.py
@@ -32,13 +32,17 @@ def eigvals(op: qml.operation.Operator, k=1, which="SA") -> TensorLike:
 
     .. note::
 
-        For a :class:`~.SparseHamiltonian` object, the eigenvalues are computed with the efficient
-        ``scipy.sparse.linalg.eigsh`` method which returns :math:`k` eigenvalues. The default value
-        of :math:`k` is :math:`1`. For an :math:`N \times N` sparse matrix, :math:`k` must be
-        smaller than :math:`N - 1`, otherwise ``scipy.sparse.linalg.eigsh`` fails. If the requested
-        :math:`k` is equal or larger than :math:`N - 1`, the regular ``qml.math.linalg.eigvalsh``
-        is applied on the dense matrix. For more details see the ``scipy.sparse.linalg.eigsh``
-        `documentation <https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.linalg.eigsh.html#scipy.sparse.linalg.eigsh>`_.
+        - For a :class:`~.SparseHamiltonian` object, the eigenvalues are computed with the efficient
+          ``scipy.sparse.linalg.eigsh`` method which returns :math:`k` eigenvalues. The default value
+          of :math:`k` is :math:`1`. For an :math:`N \times N` sparse matrix, :math:`k` must be
+          smaller than :math:`N - 1`, otherwise ``scipy.sparse.linalg.eigsh`` fails. If the requested
+          :math:`k` is equal or larger than :math:`N - 1`, the regular ``qml.math.linalg.eigvalsh``
+          is applied on the dense matrix. For more details see the ``scipy.sparse.linalg.eigsh``
+          `documentation <https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.linalg.eigsh.html#scipy.sparse.linalg.eigsh>`_.
+        - A second-quantized :mod:`molecular Hamiltonian <pennylane.qchem.molecular_hamiltonian>` is
+          independent of the number of electrons and its eigenspectrum contains the energies of the
+          neutral and charged molecules. Therefore, the `smallest` eigenvalue returned by ``qml.eigvals``
+          for a molecular Hamiltonian might not always correspond to the neutral molecule.
 
     Args:
         op (Operator or QNode or QuantumTape or Callable): A quantum operator or quantum circuit.

--- a/pennylane/ops/functions/equal.py
+++ b/pennylane/ops/functions/equal.py
@@ -272,6 +272,9 @@ def _equal_prod_and_sum(op1: CompositeOp, op2: CompositeOp, **kwargs):
     if len(op1.operands) != len(op2.operands):
         return False
 
+    if op1.pauli_rep is not None and (op1.pauli_rep == op2.pauli_rep):  # shortcut check
+        return True
+
     # organizes by wire indicies while respecting commutation relations
     sorted_ops1 = op1._sort(op1.operands)
     sorted_ops2 = op2._sort(op2.operands)
@@ -343,6 +346,9 @@ def _equal_exp(op1: Exp, op2: Exp, **kwargs):
 def _equal_sprod(op1: SProd, op2: SProd, **kwargs):
     """Determine whether two SProd objects are equal"""
     rtol, atol = (kwargs["rtol"], kwargs["atol"])
+
+    if op1.pauli_rep is not None and (op1.pauli_rep == op2.pauli_rep):  # shortcut check
+        return True
 
     if not qml.math.allclose(op1.scalar, op2.scalar, rtol=rtol, atol=atol):
         return False

--- a/pennylane/ops/op_math/sum.py
+++ b/pennylane/ops/op_math/sum.py
@@ -19,8 +19,6 @@ import itertools
 from copy import copy
 from typing import List
 
-import numpy as np
-
 import pennylane as qml
 from pennylane import math
 from pennylane.operation import Operator
@@ -330,7 +328,7 @@ class Sum(CompositeOp):
             wires = op.wires
             if wire_map is not None:
                 wires = wires.map(wire_map)
-            return np.min(wires), len(wires), str(op)
+            return sorted(list(map(str, wires)))[0], len(wires), str(op)
 
         return sorted(op_list, key=_sort_key)
 

--- a/pennylane/qcut/tapes.py
+++ b/pennylane/qcut/tapes.py
@@ -22,12 +22,12 @@ from typing import Callable, List, Sequence, Tuple, Union
 from networkx import MultiDiGraph
 
 import pennylane as qml
-from pennylane import apply, expval
+from pennylane import expval
 from pennylane.measurements import ExpectationMP, MeasurementProcess, SampleMP
 from pennylane.operation import Operator, Tensor
 from pennylane.ops.meta import WireCut
 from pennylane.pauli import string_to_pauli_word
-from pennylane.queuing import AnnotatedQueue, WrappedObj
+from pennylane.queuing import WrappedObj
 from pennylane.tape import QuantumScript, QuantumTape
 from pennylane.wires import Wires
 
@@ -162,50 +162,51 @@ def graph_to_tape(graph: MultiDiGraph) -> QuantumTape:
     copy_meas = [copy.copy(op) for _, op in ordered_ops if isinstance(op, MeasurementProcess)]
     observables = []
 
-    with AnnotatedQueue() as q:
-        for op in copy_ops:
-            op = qml.map_wires(op, wire_map=wire_map, queue=True)
-            if isinstance(op, MeasureNode):
-                assert len(op.wires) == 1
-                measured_wire = op.wires[0]
+    operations_from_graph = []
+    measurements_from_graph = []
+    for op in copy_ops:
+        op = qml.map_wires(op, wire_map=wire_map, queue=False)
+        operations_from_graph.append(op)
+        if isinstance(op, MeasureNode):
+            assert len(op.wires) == 1
+            measured_wire = op.wires[0]
 
-                new_wire = _find_new_wire(wires)
-                wires += new_wire
+            new_wire = _find_new_wire(wires)
+            wires += new_wire
 
-                original_wire = reverse_wire_map[measured_wire]
-                wire_map[original_wire] = new_wire
-                reverse_wire_map[new_wire] = original_wire
+            original_wire = reverse_wire_map[measured_wire]
+            wire_map[original_wire] = new_wire
+            reverse_wire_map[new_wire] = original_wire
 
-        if copy_meas:
-            measurement_types = {type(meas) for meas in copy_meas}
-            if len(measurement_types) > 1:
-                raise ValueError(
-                    "Only a single return type can be used for measurement "
-                    "nodes in graph_to_tape"
-                )
-            measurement_type = measurement_types.pop()
+    if copy_meas:
+        measurement_types = {type(meas) for meas in copy_meas}
+        if len(measurement_types) > 1:
+            raise ValueError(
+                "Only a single return type can be used for measurement nodes in graph_to_tape"
+            )
+        measurement_type = measurement_types.pop()
 
-            if measurement_type not in {SampleMP, ExpectationMP}:
-                raise ValueError(
-                    "Invalid return type. Only expectation value and sampling measurements "
-                    "are supported in graph_to_tape"
-                )
+        if measurement_type not in {SampleMP, ExpectationMP}:
+            raise ValueError(
+                "Invalid return type. Only expectation value and sampling measurements "
+                "are supported in graph_to_tape"
+            )
 
-            for meas in copy_meas:
-                meas = qml.map_wires(meas, wire_map=wire_map)
-                obs = meas.obs
-                observables.append(obs)
+        for meas in copy_meas:
+            meas = qml.map_wires(meas, wire_map=wire_map)
+            obs = meas.obs
+            observables.append(obs)
 
-                if measurement_type is SampleMP:
-                    apply(meas)
+            if measurement_type is SampleMP:
+                measurements_from_graph.append(meas)
 
-            if measurement_type is ExpectationMP:
-                if len(observables) > 1:
-                    qml.expval(Tensor(*observables))
-                else:
-                    qml.expval(obs)
+        if measurement_type is ExpectationMP:
+            if len(observables) > 1:
+                measurements_from_graph.append(qml.expval(Tensor(*observables)))
+            else:
+                measurements_from_graph.append(qml.expval(obs))
 
-    return QuantumScript.from_queue(q)
+    return QuantumScript(ops=operations_from_graph, measurements=measurements_from_graph)
 
 
 def _add_operator_node(graph: MultiDiGraph, op: Operator, order: int, wire_latest_node: dict):

--- a/pennylane/qcut/utils.py
+++ b/pennylane/qcut/utils.py
@@ -57,31 +57,27 @@ class PrepareNode(Operation):
 
 
 def _prep_zero_state(wire):
-    qml.Identity(wire)
+    return [qml.Identity(wire)]
 
 
 def _prep_one_state(wire):
-    qml.PauliX(wire)
+    return [qml.PauliX(wire)]
 
 
 def _prep_plus_state(wire):
-    qml.Hadamard(wire)
+    return [qml.Hadamard(wire)]
 
 
 def _prep_minus_state(wire):
-    qml.PauliX(wire)
-    qml.Hadamard(wire)
+    return [qml.PauliX(wire), qml.Hadamard(wire)]
 
 
 def _prep_iplus_state(wire):
-    qml.Hadamard(wire)
-    qml.S(wires=wire)
+    return [qml.Hadamard(wire), qml.S(wires=wire)]
 
 
 def _prep_iminus_state(wire):
-    qml.PauliX(wire)
-    qml.Hadamard(wire)
-    qml.S(wires=wire)
+    return [qml.PauliX(wire), qml.Hadamard(wire), qml.S(wires=wire)]
 
 
 def find_and_place_cuts(

--- a/tests/devices/default_qubit/test_default_qubit_native_mcm.py
+++ b/tests/devices/default_qubit/test_default_qubit_native_mcm.py
@@ -147,7 +147,7 @@ def test_single_mcm_single_measure_mcm(shots, reset, measure_f):
 @pytest.mark.parametrize("measure_f", [qml.expval, qml.probs, qml.sample, qml.counts, qml.var])
 def test_single_mcm_single_measure_obs(shots, reset, measure_f):
     """Tests that DefaultQubit handles a circuit with a single mid-circuit measurement and a
-    conditional gate. A single measurement of a common observable is is performed at the end."""
+    conditional gate. A single measurement of a common observable is performed at the end."""
     dev = qml.device("default.qubit", shots=shots)
     params = np.pi / 4 * np.ones(2)
     obs = qml.PauliZ(0)
@@ -213,10 +213,51 @@ def test_single_mcm_multiple_measurements(shots, reset, measure_f):
 @flaky(max_runs=5)
 @pytest.mark.parametrize("shots", [None, 1000, [1000, 1001]])
 @pytest.mark.parametrize("reset", [False, True])
+@pytest.mark.parametrize("measure_f", [qml.expval, qml.sample, qml.counts, qml.var])
+def test_composite_mcm_measure_composite_mcm(shots, reset, measure_f):
+    """Tests that DefaultQubit handles a circuit with a composite mid-circuit measurement and a
+    conditional gate. A single measurement of a composite mid-circuit measurement is performed
+    at the end."""
+    dev = qml.device("default.qubit", shots=shots)
+    param = np.pi / 3
+
+    @qml.qnode(dev)
+    def func1(x):
+        qml.RX(x, 0)
+        m0 = qml.measure(0)
+        qml.RX(0.5 * x, 1)
+        m1 = qml.measure(1, reset=reset)
+        qml.cond((m0 + m1) == 2, qml.RY)(2.0 * x, 0)
+        m2 = qml.measure(0)
+        return measure_f(op=(m0 - 2 * m1) * m2 + 7)
+
+    @qml.qnode(dev)
+    @qml.defer_measurements
+    def func2(x):
+        qml.RX(x, 0)
+        m0 = qml.measure(0)
+        qml.RX(0.5 * x, 1)
+        m1 = qml.measure(1, reset=reset)
+        qml.cond((m0 + m1) == 2, qml.RY)(2.0 * x, 0)
+        m2 = qml.measure(0)
+        return measure_f(op=(m0 - 2 * m1) * m2 + 7)
+
+    if shots is None and measure_f in (qml.counts, qml.sample):
+        return
+
+    results1 = func1(param)
+    results2 = func2(param)
+
+    validate_measurements(measure_f, shots, results1, results2)
+
+
+@flaky(max_runs=5)
+@pytest.mark.parametrize("shots", [None, 1000, [1000, 1001]])
+@pytest.mark.parametrize("reset", [False, True])
 @pytest.mark.parametrize("measure_f", [qml.expval, qml.probs, qml.sample, qml.counts, qml.var])
 def test_composite_mcm_single_measure_obs(shots, reset, measure_f):
     """Tests that DefaultQubit handles a circuit with a composite mid-circuit measurement and a
-    conditional gate. A single measurement of a common observable is is performed at the end."""
+    conditional gate. A single measurement of a common observable is performed at the end."""
     dev = qml.device("default.qubit", shots=shots)
     param = np.pi / 3
     obs = qml.PauliZ(0)
@@ -244,8 +285,6 @@ def test_composite_mcm_single_measure_obs(shots, reset, measure_f):
         return
 
     results1 = func1(param)
-    print(f"results1({reset}, {shots}) = {results1}")
     results2 = func2(param)
-    print(f"results2({reset}, {shots}) = {results2}")
 
     validate_measurements(measure_f, shots, results1, results2)

--- a/tests/devices/qubit/test_apply_operation.py
+++ b/tests/devices/qubit/test_apply_operation.py
@@ -1062,6 +1062,8 @@ class TestApplyGroverOperator:
         when applying it to a Jax state."""
         import jax
 
+        jax.config.update("jax_enable_x64", True)
+
         batched = batch_dim is not None
         shape = [batch_dim] + [2] * state_wires if batched else [2] * state_wires
         # Input state

--- a/tests/devices/qutrit_mixed/conftest.py
+++ b/tests/devices/qutrit_mixed/conftest.py
@@ -1,0 +1,63 @@
+# Copyright 2018-2024 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Pytest configuration file for PennyLane qutrit mixed state test suite."""
+import numpy as np
+from scipy.stats import unitary_group
+import pytest
+
+
+def get_random_mixed_state(num_qutrits):
+    dim = 3**num_qutrits
+
+    rng = np.random.default_rng(seed=4774)
+    basis = unitary_group(dim=dim, seed=584545).rvs()
+    schmidt_weights = rng.dirichlet(np.ones(dim), size=1).astype(complex)[0]
+    mixed_state = np.zeros((dim, dim)).astype(complex)
+    for i in range(dim):
+        mixed_state += schmidt_weights[i] * np.outer(np.conj(basis[i]), basis[i])
+
+    return mixed_state.reshape([3] * (2 * num_qutrits))
+
+
+# 1 qutrit states
+@pytest.fixture(scope="package")
+def one_qutrit_state():
+    return get_random_mixed_state(1)
+
+
+@pytest.fixture(scope="package")
+def one_qutrit_batched_state():
+    return np.array([get_random_mixed_state(1) for _ in range(2)])
+
+
+# 2 qutrit states
+@pytest.fixture(scope="package")
+def two_qutrit_state():
+    return get_random_mixed_state(2)
+
+
+@pytest.fixture(scope="package")
+def two_qutrit_batched_state():
+    return np.array([get_random_mixed_state(2) for _ in range(2)])
+
+
+# 3 qutrit states
+@pytest.fixture(scope="package")
+def three_qutrit_state():
+    return get_random_mixed_state(3)
+
+
+@pytest.fixture(scope="package")
+def three_qutrit_batched_state():
+    return np.array([get_random_mixed_state(3) for _ in range(2)])

--- a/tests/devices/qutrit_mixed/test_qutrit_mixed_apply_operation.py
+++ b/tests/devices/qutrit_mixed/test_qutrit_mixed_apply_operation.py
@@ -1,0 +1,322 @@
+# Copyright 2018-2024 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for apply_operation in devices/qutrit_mixed/apply_operation."""
+
+from functools import reduce
+import pytest
+import numpy as np
+from scipy.stats import unitary_group
+import pennylane as qml
+from pennylane import math
+from pennylane.operation import Channel
+from pennylane.devices.qutrit_mixed import apply_operation
+
+ml_frameworks_list = [
+    "numpy",
+    pytest.param("autograd", marks=pytest.mark.autograd),
+    pytest.param("jax", marks=pytest.mark.jax),
+    pytest.param("torch", marks=pytest.mark.torch),
+    pytest.param("tensorflow", marks=pytest.mark.tf),
+]
+
+subspaces = [(0, 1), (0, 2), (1, 2)]
+
+
+def test_custom_operator_with_matrix(one_qutrit_state):
+    """Test that apply_operation works with any operation that defines a matrix."""
+    mat = np.array(
+        [
+            [-0.35546532 - 0.03636115j, -0.19051888 - 0.38049108j, 0.07943913 - 0.8276115j],
+            [-0.2766807 - 0.71617593j, -0.1227771 + 0.61271557j, -0.0872488 - 0.11150285j],
+            [-0.2312502 - 0.47894201j, -0.04564929 - 0.65295532j, -0.3629075 + 0.3962342j],
+        ]
+    )
+
+    # pylint: disable=too-few-public-methods
+    class CustomOp(qml.operation.Operation):
+        num_wires = 1
+
+        def matrix(self):
+            return mat
+
+    new_state = apply_operation(CustomOp(0), one_qutrit_state)
+    assert qml.math.allclose(new_state, mat @ one_qutrit_state @ np.conj(mat).T)
+
+
+# TODO add tests for special cases as they are added
+
+
+@pytest.mark.parametrize("ml_framework", ml_frameworks_list)
+@pytest.mark.parametrize(
+    "state,shape", [("two_qutrit_state", (9, 9)), ("two_qutrit_batched_state", (2, 9, 9))]
+)
+class TestSnapshot:
+    """Test that apply_operation works for Snapshot ops"""
+
+    class Debugger:  # pylint: disable=too-few-public-methods
+        """A dummy debugger class"""
+
+        def __init__(self):
+            self.active = True
+            self.snapshots = {}
+
+    @pytest.mark.usefixtures("two_qutrit_state")
+    def test_no_debugger(
+        self, ml_framework, state, shape, request
+    ):  # pylint: disable=unused-argument
+        """Test nothing happens when there is no debugger"""
+        state = request.getfixturevalue(state)
+        initial_state = math.asarray(state, like=ml_framework)
+
+        new_state = apply_operation(qml.Snapshot(), initial_state, is_state_batched=len(shape) != 2)
+        assert new_state.shape == initial_state.shape
+        assert math.allclose(new_state, initial_state)
+
+    def test_empty_tag(self, ml_framework, state, shape, request):
+        """Test a snapshot is recorded properly when there is no tag"""
+        state = request.getfixturevalue(state)
+        initial_state = math.asarray(state, like=ml_framework)
+
+        debugger = self.Debugger()
+        new_state = apply_operation(
+            qml.Snapshot(), initial_state, debugger=debugger, is_state_batched=len(shape) != 2
+        )
+
+        assert new_state.shape == initial_state.shape
+        assert math.allclose(new_state, initial_state)
+
+        assert list(debugger.snapshots.keys()) == [0]
+        assert debugger.snapshots[0].shape == shape
+        assert math.allclose(debugger.snapshots[0], math.reshape(initial_state, shape))
+
+    def test_provided_tag(self, ml_framework, state, shape, request):
+        """Test a snapshot is recorded properly when provided a tag"""
+        state = request.getfixturevalue(state)
+        initial_state = math.asarray(state, like=ml_framework)
+
+        debugger = self.Debugger()
+        tag = "dense"
+        new_state = apply_operation(
+            qml.Snapshot(tag), initial_state, debugger=debugger, is_state_batched=len(shape) != 2
+        )
+
+        assert new_state.shape == initial_state.shape
+        assert math.allclose(new_state, initial_state)
+
+        assert list(debugger.snapshots.keys()) == [tag]
+        assert debugger.snapshots[tag].shape == shape
+        assert math.allclose(debugger.snapshots[tag], math.reshape(initial_state, shape))
+
+    def test_snapshot_with_measurement(self, ml_framework, state, shape, request):
+        """Test a snapshot with measurement throws NotImplementedError"""
+        state = request.getfixturevalue(state)
+        initial_state = math.asarray(state, like=ml_framework)
+
+        debugger = self.Debugger()
+        with pytest.raises(NotImplementedError):
+            _ = apply_operation(
+                qml.Snapshot(measurement=qml.expval(qml.GellMann(0, 1))),
+                initial_state,
+                debugger=debugger,
+                is_state_batched=len(shape) != 2,
+            )
+
+
+@pytest.mark.parametrize("ml_framework", ml_frameworks_list)
+class TestOperation:  # pylint: disable=too-few-public-methods
+    """Tests that broadcasted operations (not channels) are applied correctly."""
+
+    broadcasted_ops = [
+        qml.TRX(np.array([np.pi, np.pi / 2]), wires=0, subspace=(0, 1)),
+        qml.TRY(np.array([np.pi, np.pi / 2]), wires=1, subspace=(0, 1)),
+        qml.TRZ(np.array([np.pi, np.pi / 2]), wires=2, subspace=(1, 2)),
+        qml.QutritUnitary(
+            np.array([unitary_group.rvs(27), unitary_group.rvs(27)]),
+            wires=[0, 1, 2],
+        ),
+    ]
+    unbroadcasted_ops = [
+        qml.THadamard(wires=0),
+        qml.TClock(wires=1),
+        qml.TShift(wires=2),
+        qml.TAdd(wires=[1, 2]),
+        qml.TRX(np.pi / 3, wires=0, subspace=(0, 2)),
+        qml.TRY(2 * np.pi / 3, wires=1, subspace=(1, 2)),
+        qml.TRZ(np.pi / 6, wires=2, subspace=(0, 1)),
+        qml.QutritUnitary(unitary_group.rvs(27), wires=[0, 1, 2]),
+    ]
+    num_qutrits = 3
+    num_batched = 2
+
+    @classmethod
+    def expand_matrices(cls, op, batch_size=0):
+        """Find expanded operator matrices, since qml.matrix isn't working for qutrits #4367"""
+        pre_wires_identity = np.eye(3 ** op.wires[0])
+        post_wires_identity = np.eye(3 ** ((cls.num_qutrits - 1) - op.wires[-1]))
+        mat = op.matrix()
+
+        def expand_matrix(matrix):
+            return reduce(np.kron, (pre_wires_identity, matrix, post_wires_identity))
+
+        if batch_size:
+            return [expand_matrix(mat[i]) for i in range(batch_size)]
+        return expand_matrix(mat)
+
+    @classmethod
+    def get_expected_state(cls, expanded_operator, state):
+        """Finds expected state after applying operator"""
+        flattened_state = state.reshape((3**cls.num_qutrits,) * 2)
+        adjoint_matrix = np.conj(expanded_operator).T
+        new_state = expanded_operator @ flattened_state @ adjoint_matrix
+        return new_state.reshape([3] * (cls.num_qutrits * 2))
+
+    @pytest.mark.parametrize("op", unbroadcasted_ops)
+    def test_no_broadcasting(self, op, ml_framework, three_qutrit_state):
+        """Tests that unbatched operations are applied correctly to an unbatched state."""
+        state = three_qutrit_state
+        res = apply_operation(op, qml.math.asarray(state, like=ml_framework))
+
+        expanded_operator = self.expand_matrices(op)
+        expected = self.get_expected_state(expanded_operator, state)
+
+        assert qml.math.get_interface(res) == ml_framework
+        assert qml.math.allclose(res, expected)
+
+    @pytest.mark.parametrize("op", broadcasted_ops)
+    def test_broadcasted_op(self, op, ml_framework, three_qutrit_state):
+        """Tests that batched operations are applied correctly to an unbatched state."""
+        state = three_qutrit_state
+        res = apply_operation(op, qml.math.asarray(state, like=ml_framework))
+        expanded_operators = self.expand_matrices(op, self.num_batched)
+
+        def get_expected(m):
+            return self.get_expected_state(m, state)
+
+        expected = [get_expected(expanded_operators[i]) for i in range(self.num_batched)]
+
+        assert qml.math.get_interface(res) == ml_framework
+        assert qml.math.allclose(res, expected)
+
+    @pytest.mark.parametrize("op", unbroadcasted_ops)
+    def test_broadcasted_state(self, op, ml_framework, three_qutrit_batched_state):
+        """Tests that unbatched operations are applied correctly to a batched state."""
+        state = three_qutrit_batched_state
+        res = apply_operation(op, qml.math.asarray(state, like=ml_framework), is_state_batched=True)
+        expanded_operator = self.expand_matrices(op)
+
+        def get_expected(s):
+            return self.get_expected_state(expanded_operator, s)
+
+        expected = [get_expected(state[i]) for i in range(self.num_batched)]
+
+        assert qml.math.get_interface(res) == ml_framework
+        assert qml.math.allclose(res, expected)
+
+    @pytest.mark.parametrize("op", broadcasted_ops)
+    def test_broadcasted_op_broadcasted_state(self, op, ml_framework, three_qutrit_batched_state):
+        """Tests that batched operations are applied correctly to a batched state."""
+        state = three_qutrit_batched_state
+        res = apply_operation(op, qml.math.asarray(state, like=ml_framework), is_state_batched=True)
+        expanded_operators = self.expand_matrices(op, self.num_batched)
+
+        expected = [
+            self.get_expected_state(expanded_operators[i], state[i])
+            for i in range(self.num_batched)
+        ]
+
+        assert qml.math.get_interface(res) == ml_framework
+        assert qml.math.allclose(res, expected)
+
+    def test_batch_size_set_if_missing(self, ml_framework, one_qutrit_state):
+        """Tests that the batch_size is set on an operator if it was missing before."""
+        param = qml.math.asarray([0.1, 0.2], like=ml_framework)
+        state = one_qutrit_state
+        op = qml.TRX(param, 0)
+        op._batch_size = None  # pylint:disable=protected-access
+        state = apply_operation(op, state)
+        assert state.shape == (self.num_batched, 3, 3)
+        assert op.batch_size == self.num_batched
+
+
+@pytest.mark.parametrize("wire", [0, 1])
+@pytest.mark.parametrize("ml_framework", ml_frameworks_list)
+class TestChannels:  # pylint: disable=too-few-public-methods
+    """Tests that Channel operations are applied correctly."""
+
+    num_qutrits = 2
+    num_batched = 2
+
+    @classmethod
+    def expand_krons(cls, op):
+        """Find expanded operator kraus matrices"""
+        pre_wires_identity = np.eye(3 ** op.wires[0])
+        post_wires_identity = np.eye(3 ** ((cls.num_qutrits - 1) - op.wires[-1]))
+        krons = op.kraus_matrices()
+        return [reduce(np.kron, (pre_wires_identity, kron, post_wires_identity)) for kron in krons]
+
+    @classmethod
+    def get_expected_state(cls, expanded_krons, state):
+        """Finds expected state after applying channel"""
+        flattened_state = state.reshape((3**cls.num_qutrits,) * 2)
+        adjoint_krons = np.conj(np.transpose(expanded_krons, (0, 2, 1)))
+        new_state = np.sum(
+            [
+                expanded_kron @ flattened_state @ adjoint_krons[i]
+                for i, expanded_kron in enumerate(expanded_krons)
+            ],
+            axis=0,
+        )
+        return new_state.reshape([3] * (cls.num_qutrits * 2))
+
+    class CustomChannel(Channel):
+        num_params = 1
+        num_wires = 1
+
+        def __init__(self, p, wires, id=None):
+            super().__init__(p, wires=wires, id=id)
+
+        @staticmethod
+        def compute_kraus_matrices(p):
+            K0 = (np.sqrt(1 - p) * math.cast_like(np.eye(3), p)).astype(complex)
+            K1 = (
+                np.sqrt(p) * math.cast_like(np.array([[0, 0, 1], [1, 0, 0], [0, 1, 0]]), p)
+            ).astype(complex)
+            return [K0, K1]
+
+    def test_non_broadcasted_state(self, ml_framework, wire, two_qutrit_state):
+        """Tests that Channel operations are applied correctly to a state."""
+        state = two_qutrit_state
+        test_channel = self.CustomChannel(0.3, wires=wire)
+        res = apply_operation(test_channel, math.asarray(state, like=ml_framework))
+
+        expanded_krons = self.expand_krons(test_channel)
+        expected = self.get_expected_state(expanded_krons, state)
+
+        assert qml.math.get_interface(res) == ml_framework
+        assert qml.math.allclose(res, expected)
+
+    def test_broadcasted_state(self, ml_framework, wire, two_qutrit_batched_state):
+        """Tests that Channel operations are applied correctly to a batched state."""
+        state = two_qutrit_batched_state
+
+        test_channel = self.CustomChannel(0.3, wires=wire)
+        res = apply_operation(test_channel, math.asarray(state, like=ml_framework))
+
+        expanded_krons = self.expand_krons(test_channel)
+        expected = [
+            self.get_expected_state(expanded_krons, state[i]) for i in range(self.num_batched)
+        ]
+
+        assert qml.math.get_interface(res) == ml_framework
+        assert qml.math.allclose(res, expected)

--- a/tests/fourier/test_reconstruct.py
+++ b/tests/fourier/test_reconstruct.py
@@ -194,6 +194,8 @@ class TestReconstructEqu:
         functions are differentiable for JAX input variables."""
         import jax
 
+        jax.config.update("jax_enable_x64", True)
+
         # Convert fun to have integer frequencies
         _fun = lambda x: fun(x / base_f)
         _rec = _reconstruct_equ(_fun, num_frequency, interface="jax")

--- a/tests/gradients/core/test_metric_tensor.py
+++ b/tests/gradients/core/test_metric_tensor.py
@@ -1147,6 +1147,9 @@ class TestFullMetricTensor:
     @pytest.mark.parametrize("interface", ["auto", "jax"])
     def test_correct_output_jax(self, ansatz, params, interface):
         from jax import numpy as jnp
+        from jax import config
+
+        config.update("jax_enable_x64", True)
 
         expected = autodiff_metric_tensor(ansatz, self.num_wires)(*params)
         dev = qml.device("default.qubit.jax", wires=self.num_wires + 1)

--- a/tests/measurements/test_expval.py
+++ b/tests/measurements/test_expval.py
@@ -104,7 +104,6 @@ class TestExpval:
         dev = qml.device("default.qubit")
 
         @qml.qnode(dev)
-        @qml.defer_measurements
         def circuit(phi):
             qml.RX(phi, 0)
             m0 = qml.measure(0)

--- a/tests/measurements/test_probs.py
+++ b/tests/measurements/test_probs.py
@@ -274,7 +274,7 @@ class TestProbs:
                 assert np.allclose(r, expected, atol=atol, rtol=0)
 
     @pytest.mark.parametrize("shots", [None, 10000, [10000, 10000]])
-    @pytest.mark.parametrize("phi", np.arange(0, 2 * np.pi, np.pi / 3))
+    @pytest.mark.parametrize("phi", [0.0, np.pi / 3, np.pi])
     def test_observable_is_measurement_value_list(
         self, shots, phi, tol, tol_stochastic
     ):  # pylint: disable=too-many-arguments
@@ -283,7 +283,6 @@ class TestProbs:
         dev = qml.device("default.qubit")
 
         @qml.qnode(dev)
-        @qml.defer_measurements
         def circuit(phi):
             qml.RX(phi, 0)
             m0 = qml.measure(0)

--- a/tests/measurements/test_sample.py
+++ b/tests/measurements/test_sample.py
@@ -181,7 +181,6 @@ class TestSample:
         dev = qml.device("default.qubit", shots=shots)
 
         @qml.qnode(dev)
-        @qml.defer_measurements
         def circuit(phi):
             qml.RX(phi, 0)
             m0 = qml.measure(0)

--- a/tests/measurements/test_var.py
+++ b/tests/measurements/test_var.py
@@ -102,7 +102,6 @@ class TestVar:
         dev = qml.device("default.qubit")
 
         @qml.qnode(dev)
-        @qml.defer_measurements
         def circuit(phi):
             qml.RX(phi, 0)
             m0 = qml.measure(0)

--- a/tests/ops/functions/test_commutator.py
+++ b/tests/ops/functions/test_commutator.py
@@ -58,7 +58,6 @@ class TestLegacySupport:
         assert isinstance(res, SProd)
         assert true_res == res
 
-    @pytest.mark.xfail
     def test_Hamiltonian_sum(self):
         """Test that Hamiltonians with Tensors and sums get transformed to new operator classes and return the correct result"""
         H1 = qml.Hamiltonian([1.0], [qml.PauliX(0) @ qml.PauliX(1)])

--- a/tests/ops/functions/test_equal.py
+++ b/tests/ops/functions/test_equal.py
@@ -1588,7 +1588,14 @@ class TestSymbolicOpComparison:
         assert qml.equal(op1, op2, atol=1e-3, rtol=1e-2)
         assert not qml.equal(op1, op2, atol=1e-5, rtol=1e-4)
 
-    @pytest.mark.parametrize("bases_bases_match", BASES)
+    additional_cases = [
+        (qml.sum(qml.PauliX(0), qml.PauliY(0)), qml.sum(qml.PauliY(0), qml.PauliX(0)), True),
+        (qml.sum(qml.PauliX(0), qml.PauliY(1)), qml.sum(qml.PauliX(1), qml.PauliY(0)), False),
+        (qml.prod(qml.PauliX(0), qml.PauliY(1)), qml.prod(qml.PauliY(1), qml.PauliX(0)), True),
+        (qml.prod(qml.PauliX(0), qml.PauliY(1)), qml.prod(qml.PauliX(1), qml.PauliY(0)), False),
+    ]
+
+    @pytest.mark.parametrize("bases_bases_match", BASES + additional_cases)
     @pytest.mark.parametrize("params_params_match", PARAMS)
     def test_s_prod_comparison(self, bases_bases_match, params_params_match):
         """Test that equal compares two objects of the SProd class"""
@@ -1771,6 +1778,22 @@ class TestSumComparisons:
         op1 = qml.sum(*base_list1)
         op2 = qml.sum(*base_list2)
         assert qml.equal(op1, op2) == res
+
+    def test_sum_equal_order_invarient(self):
+        """Test that the order of operations doesn't affect equality"""
+        H1 = qml.prod(qml.PauliX(0), qml.PauliX(1))
+        H2 = qml.s_prod(1.0, qml.sum(qml.PauliY(0), qml.PauliY(1)))
+
+        true_res = qml.sum(
+            qml.s_prod(2j, qml.prod(qml.PauliZ(0), qml.PauliX(1))),
+            qml.s_prod(2j, qml.prod(qml.PauliX(0), qml.PauliZ(1))),
+        )
+        true_res = true_res.simplify()
+
+        res = qml.prod(H1, H2) - qml.prod(H2, H1)
+        res = res.simplify()
+
+        assert true_res == res
 
 
 def f1(p, t):

--- a/tests/ops/op_math/test_sum.py
+++ b/tests/ops/op_math/test_sum.py
@@ -23,9 +23,9 @@ import pytest
 import pennylane as qml
 import pennylane.numpy as qnp
 from pennylane import math
+from pennylane.wires import Wires
 from pennylane.operation import AnyWires, MatrixUndefinedError, Operator
 from pennylane.ops.op_math import Prod, Sum
-from pennylane.wires import Wires
 
 no_mat_ops = (
     qml.Barrier,
@@ -800,11 +800,13 @@ class TestSortWires:
         op_list = [
             qml.PauliX(3),
             qml.PauliZ(2),
+            qml.PauliY("a"),
             qml.RX(1, 5),
             qml.PauliY(0),
             qml.PauliY(1),
-            qml.PauliZ(3),
+            qml.PauliZ("c"),
             qml.PauliX(5),
+            qml.PauliZ("ba"),
         ]
         sorted_list = Sum._sort(op_list)  # pylint: disable=protected-access
         final_list = [
@@ -812,9 +814,11 @@ class TestSortWires:
             qml.PauliY(1),
             qml.PauliZ(2),
             qml.PauliX(3),
-            qml.PauliZ(3),
             qml.PauliX(5),
             qml.RX(1, 5),
+            qml.PauliY("a"),
+            qml.PauliZ("ba"),
+            qml.PauliZ("c"),
         ]
 
         for op1, op2 in zip(final_list, sorted_list):
@@ -827,23 +831,29 @@ class TestSortWires:
             qml.PauliX(5),
             qml.Toffoli([2, 3, 4]),
             qml.CNOT([2, 5]),
+            qml.PauliZ("ba"),
             qml.RX(1, 5),
             qml.PauliY(0),
             qml.CRX(1, [0, 2]),
             qml.PauliZ(3),
+            qml.Toffoli([1, "c", "ab"]),
             qml.CRY(1, [1, 2]),
+            qml.PauliX("d"),
         )
         sorted_list = Sum._sort(op_tuple)  # pylint: disable=protected-access
         final_list = [
             qml.PauliY(0),
             qml.CRX(1, [0, 2]),
             qml.CRY(1, [1, 2]),
+            qml.Toffoli([1, "c", "ab"]),
             qml.CNOT([2, 5]),
             qml.Toffoli([2, 3, 4]),
             qml.PauliX(3),
             qml.PauliZ(3),
             qml.PauliX(5),
             qml.RX(1, 5),
+            qml.PauliZ("ba"),
+            qml.PauliX("d"),
         ]
 
         for op1, op2 in zip(final_list, sorted_list):

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -41,15 +41,6 @@ def catalyst_incompatible_version():
         yield
 
 
-# TODO: Remove this fixture after the Catalyst v0.4.0 release
-@pytest.fixture
-def catalyst_compatible_version():
-    """A compatible (high) version for Catalyst"""
-    with patch("importlib.metadata.version") as mock_version:
-        mock_version.return_value = "0.4.0"
-        yield
-
-
 @pytest.mark.usefixtures("catalyst_incompatible_version")
 def test_catalyst_incompatible():
     """Test qjit with an incompatible Catalyst version < 0.4.0"""
@@ -67,7 +58,6 @@ def test_catalyst_incompatible():
         qml.qjit(circuit)()
 
 
-@pytest.mark.usefixtures("catalyst_compatible_version")
 class TestCatalyst:
     """Test ``qml.qjit`` with Catalyst"""
 
@@ -312,7 +302,6 @@ class TestCatalyst:
         )
 
 
-@pytest.mark.usefixtures("catalyst_compatible_version")
 class TestCatalystControlFlow:
     """Test ``qml.qjit`` with Catalyst's control-flow operations"""
 
@@ -516,7 +505,6 @@ class TestCatalystControlFlow:
             circuit(1.5)
 
 
-@pytest.mark.usefixtures("catalyst_compatible_version")
 class TestCatalystGrad:
     """Test ``qml.qjit`` with Catalyst's grad operations"""
 


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      test directory!

- [x] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `doc/releases/changelog-dev.md` file, summarizing the
      change, and including a link back to the PR.

- [x] The PennyLane source code conforms to
      [PEP8 standards](https://www.python.org/dev/peps/pep-0008/).
      We check all of our code against [Pylint](https://www.pylint.org/).
      To lint modified files, simply `pip install pylint`, and then
      run `pylint pennylane/path/to/file.py`.

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
This PR is a follow-up on #5088 .

[Epic 50811](https://app.shortcut.com/xanaduai/epic/50811)  states:

- [x] The deferred measurement principle is not used
- [x] Each shot is a new exploration of the tree of possible mid-circuit measurement results
- [x] The mid-circuit measurement results are correctly exposed to PennyLane's frontend
- [x] Compatible with qubit reuse
- [x] Compatible with qubit reset
- [x] Compatible with qubit postselection
- [x] Compatible with existing support for conditioning in PennyLane
  - [x] Addition, subtraction and multiplication of one or more mid-circuit measurement results

The current PR tackles the requirements above as indicated by the task list.

**Description of the Change:**

- `apply_mid_measure` handles post-selection returning a zero state and sample when the state isn't properly normalized (which happens when the state cannot be normalized).
- The `concretize` method is added to MeasurementValue object to obtain a concrete value from a dictionary of measurement values. This allows handling composite measurements. Other modules like `simulate` are simplified accordingly. 
- Post-selected-zero-state samples are thrown away at the `simulate` level, handling this exception. This means the final number of samples is lower or equal to the total number of shots.
- Tests for all introduced features.

**Benefits:**
Mid-circuit measurements are natively supported.

**Possible Drawbacks:**
Slower in several cases (e.g. when few MCMs).

**Missing features:**
To do in follow-up PRs:

- [ ] parameter-shift support
- [ ] optimisation

**Related GitHub Issues:**
sc-54987-mid-circuit-measurements-single-mcm-prototype
