### PR TITLE
Fixed typo in docstring for the operation module

### DIFF
--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -56,7 +56,7 @@ Differentiation
 ^^^^^^^^^^^^^^^
 
 In general, an :class:`Operation` is differentiable (at least using the finite-difference
-method) with respect to a parameter iff
+method) with respect to a parameter if
 
 * the domain of that parameter is continuous.
 


### PR DESCRIPTION
**Context:**
I noticed the typo "iff" instead of "if" in the docs for the operation module.

**Description of the Change:**
The typo got fixed: "iff" was changed into "if".

**Benefits:**
One less typo :)

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None