### PR TITLE
`qml.dot` always returns a `Sum` when there's more than one term.

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -103,6 +103,8 @@
 
 <h3>Improvements 🛠</h3>
 
+* `qml.dot` now returns a `Sum` class even when all the coefficients match.
+
 * The `qml.qsvt` function uses `qml.GlobalPhase` instead of `qml.exp` to define global phase.
   [(#5105)](https://github.com/PennyLaneAI/pennylane/pull/5105)
 

--- a/pennylane/ops/functions/dot.py
+++ b/pennylane/ops/functions/dot.py
@@ -19,7 +19,7 @@ from collections import defaultdict
 from typing import Sequence, Union, Callable
 
 import pennylane as qml
-from pennylane.operation import Operator, Tensor
+from pennylane.operation import Operator, convert_to_opmath
 from pennylane.pulse import ParametrizedHamiltonian
 
 
@@ -87,18 +87,7 @@ def dot(
         return _pauli_dot(coeffs, ops)
 
     # When casting a Hamiltonian to a Sum, we also cast its inner Tensors to Prods
-    ops = [qml.prod(*op.obs) if isinstance(op, Tensor) else op for op in ops]
-
-    if coeffs[0] != 1 and qml.math.allequal(coeffs[0], coeffs):
-        # Coefficients have the same value (different to 1)
-        return qml.s_prod(coeffs[0], ops[0] if len(ops) == 1 else qml.sum(*ops))
-
-    abs_coeffs = qml.math.abs(coeffs)
-    if abs_coeffs[0] != 1 and qml.math.allequal(abs_coeffs[0], abs_coeffs):
-        # Coefficients have the same absolute value (different to 1)
-        gcd = abs(coeffs[0])
-        coeffs = [c / gcd for c in coeffs]
-        return qml.s_prod(gcd, qml.dot(coeffs, ops))
+    ops = (convert_to_opmath(op) for op in ops)
 
     operands = [op if coeff == 1 else qml.s_prod(coeff, op) for coeff, op in zip(coeffs, ops)]
     return operands[0] if len(operands) == 1 else qml.sum(*operands)

--- a/tests/ops/functions/test_dot.py
+++ b/tests/ops/functions/test_dot.py
@@ -57,28 +57,22 @@ class TestDotSum:
         for op in result:
             assert isinstance(op, Prod)
 
-    def test_dot_groups_coeffs(self):
-        """Test that the `dot` function groups the coefficients."""
+    def test_dot_does_not_groups_coeffs(self):
+        """Test that the `dot` function does not groups the coefficients."""
         result = qml.dot(coeffs=[4, 4, 4], ops=[qml.PauliX(0), qml.PauliX(1), qml.PauliX(2)])
-        assert isinstance(result, SProd)
-        assert result.scalar == 4
-        assert isinstance(result.base, Sum)
-        assert len(result.base) == 3
-        for op in result.base:
-            assert isinstance(op, qml.PauliX)
+        assert isinstance(result, Sum)
+        assert result[0] == qml.s_prod(4, qml.PauliX(0))
+        assert result[1] == qml.s_prod(4, qml.PauliX(1))
+        assert result[2] == qml.s_prod(4, qml.PauliX(2))
 
-    def test_dot_groups_coeffs_with_different_sign(self):
-        """test that the `dot` function groups coefficients with different signs."""
+    def test_dot_does_not_groups_coeffs_with_different_sign(self):
+        """test that the `dot` function does not group coefficients with different signs."""
         cs = [4, -4, 4]
         result = qml.dot(coeffs=cs, ops=[qml.PauliX(0), qml.PauliX(1), qml.PauliX(2)])
-        assert isinstance(result, SProd)
-        assert result.scalar == 4
-        for op, c in zip(result.base, cs):
-            if c == -4:
-                assert isinstance(op, SProd)
-                assert op.scalar == -1
-            else:
-                assert isinstance(op, qml.PauliX)
+        assert isinstance(result, Sum)
+        assert result[0] == qml.s_prod(4, qml.PauliX(0))
+        assert result[1] == qml.s_prod(-4, qml.PauliX(1))
+        assert result[2] == qml.s_prod(4, qml.PauliX(2))
 
     def test_dot_different_number_of_coeffs_and_ops(self):
         """Test that a ValueError is raised when the number of coefficients and operators does


### PR DESCRIPTION
[sc-55330]

See also PR #5073  and Issue #5066 . Sometimes `qml.dot` was returning a scalar product between a single coefficient and a sum, instead of returning a sum.  `TrotterProduct` was not able to handle this sort of nested operator.

While we should also make our code more flexible in handling nested operators, we can also standardize the return of `qml.dot`.