### PR TITLE
Revert special handling of PhaseShift in ctrl

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -342,7 +342,7 @@
   [(#5114)](https://github.com/PennyLaneAI/pennylane/pull/5114)
 
 * Multi-wire controlled `CNOT` and `PhaseShift` can now be decomposed correctly.
-  [(#5125)](https://github.com/PennyLaneAI/pennylane/pull/5125) 
+  [(#5125)](https://github.com/PennyLaneAI/pennylane/pull/5125/) 
   [(#5148)](https://github.com/PennyLaneAI/pennylane/pull/5148)
 
 <h3>Contributors ✍️</h3>

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -341,6 +341,10 @@
   operators to the left, as is standard in quantum chemistry). 
   [(#5114)](https://github.com/PennyLaneAI/pennylane/pull/5114)
 
+* Multi-wire controlled `CNOT` and `PhaseShift` can now be decomposed correctly.
+  [(#5125)](https://github.com/PennyLaneAI/pennylane/pull/5125) 
+  [(#5148)](https://github.com/PennyLaneAI/pennylane/pull/5148)
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):


### PR DESCRIPTION
**Context:**
Multi-wire controlled `PhaseShift` should not be converted to a one-less-wire controlled `ControlledPhaseShift`

**Description of the Change:**
- `qml.ctrl` no longer convert multi-wire controlled `PhaseShift` to a one-less-wire controlled `ControlledPhaseShift`
- Special handling of multi-wire controlled `PhaseShift` in decompositions

**Benefits:**
1. Fixes test failing in lightning
2. Correct decomposition of multi-wire controlled `PhaseShift`
