### PR TITLE
Revert change to `Prod.pauli_rep` construction order

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -105,6 +105,7 @@
 
 * Cuts down on performance bottlenecks in converting a `PauliSentence` to a `Sum`.
   [(#5141)](https://github.com/PennyLaneAI/pennylane/pull/5141)
+  [(#5150)](https://github.com/PennyLaneAI/pennylane/pull/5150)
 
 * The `qml.qsvt` function uses `qml.GlobalPhase` instead of `qml.exp` to define global phase.
   [(#5105)](https://github.com/PennyLaneAI/pennylane/pull/5105)

--- a/pennylane/ops/op_math/prod.py
+++ b/pennylane/ops/op_math/prod.py
@@ -354,30 +354,9 @@ class Prod(CompositeOp):
 
     def _build_pauli_rep(self):
         """PauliSentence representation of the Product of operations."""
-        if any(op.pauli_rep is None for op in self.operands):
-            return None
-        paulis = {"PauliX", "PauliY", "PauliZ"}
-
-        single_word = {}
-        still_single_word = True
-
-        ind = 0
-        for ind, op in enumerate(self):
-            if op.name == "Identity":
-                continue
-            if op.name in paulis and op.wires[0] not in single_word:
-                single_word[op.wires[0]] = op.name[-1]
-            else:
-                still_single_word = False
-                break
-        ps = qml.pauli.PauliSentence({qml.pauli.PauliWord(single_word): 1.0})
-        if still_single_word:
-            return ps
-
-        for op in self[ind:]:
-            ps = ps @ op.pauli_rep
-
-        return ps
+        if all(operand_pauli_reps := [op.pauli_rep for op in self.operands]):
+            return reduce(lambda a, b: a @ b, operand_pauli_reps)
+        return None
 
     def _simplify_factors(self, factors: Tuple[Operator]) -> Tuple[complex, Operator]:
         """Reduces the depth of nested factors and groups identical factors.

--- a/tests/ops/op_math/test_prod.py
+++ b/tests/ops/op_math/test_prod.py
@@ -981,7 +981,7 @@ class TestSimplify:
         """Test the simplify method with a product of sums."""
         prod_op = Prod(qml.PauliX(0) + qml.RX(1, 0), qml.PauliX(1) + qml.RX(1, 1), qml.Identity(3))
         final_op = qml.sum(
-            Prod(qml.PauliX(0), qml.PauliX(1)),
+            Prod(qml.PauliX(1), qml.PauliX(0)),
             qml.PauliX(0) @ qml.RX(1, 1),
             qml.PauliX(1) @ qml.RX(1, 0),
             qml.RX(1, 0) @ qml.RX(1, 1),

--- a/tests/ops/op_math/test_prod.py
+++ b/tests/ops/op_math/test_prod.py
@@ -891,6 +891,15 @@ class TestProperties:
         ),
     )
 
+    def test_pauli_rep_order(self):
+        """Lightning qubit tests are relying on the specific order of the pauli rep keys.
+        If the order of pauli word keys is changed, lightning tests must be changed as well.
+        """
+        op = qml.prod(qml.PauliX(0), qml.PauliY(1), qml.PauliZ(2))
+        pw = list(op.pauli_rep.keys())[0]
+        assert list(pw.keys()) == [1, 0, 2]
+        assert list(pw.values()) == ["Y", "X", "Z"]
+
     @pytest.mark.parametrize("op, rep", op_pauli_reps)
     def test_pauli_rep(self, op, rep):
         """Test that the pauli rep gives the expected result."""


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      test directory!

- [x] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `doc/releases/changelog-dev.md` file, summarizing the
      change, and including a link back to the PR.

- [x] The PennyLane source code conforms to
      [PEP8 standards](https://www.python.org/dev/peps/pep-0008/).
      We check all of our code against [Pylint](https://www.pylint.org/).
      To lint modified files, simply `pip install pylint`, and then
      run `pylint pennylane/path/to/file.py`.

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**

So it turns out lightning tests are sensitive to the order of keys and values in pauli words.  I am reverting the change made in #5141 so that the `pauli_rep` order remains what it was before.

**Description of the Change:**

Reverts `Prod._build_pauli_rep` back to what it was before.

**Benefits:**

Lightning is unblocked.

**Possible Drawbacks:**

Slower construction times, and the required order doesn't match the order of terms in `Prod`.

**Related GitHub Issues:**

[sc-55482]