### PR TITLE
Refactor batched_partial_trace to Public API and Update Usage

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -191,8 +191,12 @@
 * A function called `apply_operation` has been added to the new `qutrit_mixed` module found in `qml.devices` that applies operations to device-compatible states.
   [(#5032)](https://github.com/PennyLaneAI/pennylane/pull/5032)
 
+* The function `batched_partial_trace` has been refactored to be public-facing for computing the partial trace of matrices other than density matrices.
+
+
 * The module `pennylane/math/quantum.py` has now support for the min-entropy.
   [(#3959)](https://github.com/PennyLaneAI/pennylane/pull/3959/)
+
 
 <h3>Breaking changes 💔</h3>
 
@@ -364,6 +368,7 @@ This release contains contributions from (in alphabetical order):
 
 Abhishek Abhishek,
 Utkarsh Azad,
+Trenten Babcock,
 Gabriel Bottrill,
 Astral Cai,
 Isaac De Vlugt,

--- a/pennylane/math/quantum.py
+++ b/pennylane/math/quantum.py
@@ -238,7 +238,7 @@ def reduce_dm(density_matrix, indices, check_state=False, c_dtype="complex128"):
 
     # Compute the partial trace
     traced_wires = [x for x in consecutive_indices if x not in indices]
-    density_matrix = _batched_partial_trace(density_matrix, traced_wires)
+    density_matrix = batched_partial_trace(density_matrix, traced_wires)
 
     if batch_dim is None:
         density_matrix = density_matrix[0]
@@ -247,11 +247,11 @@ def reduce_dm(density_matrix, indices, check_state=False, c_dtype="complex128"):
     return _permute_dense_matrix(density_matrix, sorted(indices), indices, batch_dim)
 
 
-def _batched_partial_trace(density_matrix, indices):
+def batched_partial_trace(matrix, indices, c_dtype="complex128"):
     """Compute the reduced density matrix by tracing out the provided indices.
 
     Args:
-        density_matrix (tensor_like): 3D density matrix tensor. This tensor should be of size
+        matrix (tensor_like): 3D density matrix tensor. This tensor should be of size
             ``(batch_dim, 2**N, 2**N)``, for some integer number of wires``N``.
         indices (list(int)): List of indices to be traced.
 
@@ -262,7 +262,7 @@ def _batched_partial_trace(density_matrix, indices):
 
     >>> x = np.array([[[1, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]],
     ...               [[0, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]]])
-    >>> _batched_partial_trace(x, indices=[0])
+    >>> batched_partial_trace(x, indices=[0])
     array([[[1, 0],
             [0, 0]],
 
@@ -271,7 +271,7 @@ def _batched_partial_trace(density_matrix, indices):
 
     >>> x = tf.Variable([[[1, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]],
     ...                  [[0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 1, 0], [0, 0, 0, 0]]], dtype=tf.complex128)
-    >>> _batched_partial_trace(x, indices=[1])
+    >>> batched_partial_trace(x, indices=[1])
     <tf.Tensor: shape=(2, 2, 2), dtype=complex128, numpy=
     array([[[1.+0.j, 0.+0.j],
             [0.+0.j, 0.+0.j]],
@@ -281,15 +281,17 @@ def _batched_partial_trace(density_matrix, indices):
     """
     # Autograd does not support same indices sum in backprop, and tensorflow
     # has a limit of 8 dimensions if same indices are used
-    if get_interface(density_matrix) in ["autograd", "tensorflow"]:
-        return _batched_partial_trace_nonrep_indices(density_matrix, indices)
+    matrix = cast(matrix, dtype=c_dtype)
+    
+    if get_interface(matrix) in ["autograd", "tensorflow"]:
+        return _batched_partial_trace_nonrep_indices(matrix, indices)
 
     # Dimension and reshape
-    batch_dim, dim = density_matrix.shape[:2]
+    batch_dim, dim = matrix.shape[:2]
     num_indices = int(np.log2(dim))
     rho_dim = 2 * num_indices
 
-    density_matrix = np.reshape(density_matrix, [batch_dim] + [2] * 2 * num_indices)
+    matrix = np.reshape(matrix, [batch_dim] + [2] * 2 * num_indices)
     indices = np.sort(indices)
 
     # For loop over wires
@@ -303,32 +305,32 @@ def _batched_partial_trace(density_matrix, indices):
         state_indices = "".join(state_indices)
 
         einsum_indices = f"a{state_indices}"
-        density_matrix = einsum(einsum_indices, density_matrix)
+        matrix = einsum(einsum_indices, matrix)
 
     number_wires_sub = num_indices - len(indices)
     reduced_density_matrix = np.reshape(
-        density_matrix, (batch_dim, 2**number_wires_sub, 2**number_wires_sub)
+        matrix, (batch_dim, 2**number_wires_sub, 2**number_wires_sub)
     )
     return reduced_density_matrix
 
 
-def _batched_partial_trace_nonrep_indices(density_matrix, indices):
+def _batched_partial_trace_nonrep_indices(matrix, indices):
     """Compute the reduced density matrix for autograd interface by tracing out the provided indices with the use
     of projectors as same subscripts indices are not supported in autograd backprop.
     """
     # Dimension and reshape
-    batch_dim, dim = density_matrix.shape[:2]
+    batch_dim, dim = matrix.shape[:2]
     num_indices = int(np.log2(dim))
     rho_dim = 2 * num_indices
-    density_matrix = np.reshape(density_matrix, [batch_dim] + [2] * 2 * num_indices)
+    matrix = np.reshape(matrix, [batch_dim] + [2] * 2 * num_indices)
 
-    kraus = cast(np.eye(2), density_matrix.dtype)
+    kraus = cast(np.eye(2), matrix.dtype)
 
     kraus = np.reshape(kraus, (2, 1, 2))
     kraus_dagger = np.asarray([np.conj(np.transpose(k)) for k in kraus])
 
-    kraus = convert_like(kraus, density_matrix)
-    kraus_dagger = convert_like(kraus_dagger, density_matrix)
+    kraus = convert_like(kraus, matrix)
+    kraus_dagger = convert_like(kraus_dagger, matrix)
     # For loop over wires
     for target_wire in indices:
         # Tensor indices of density matrix
@@ -360,11 +362,11 @@ def _batched_partial_trace_nonrep_indices(density_matrix, indices):
             f"{kraus_index}{new_row_indices}{row_indices}, a{state_indices},"
             f"{kraus_index}{col_indices}{new_col_indices}->a{new_state_indices}"
         )
-        density_matrix = einsum(einsum_indices, kraus, density_matrix, kraus_dagger)
+        matrix = einsum(einsum_indices, kraus, matrix, kraus_dagger)
 
     number_wires_sub = num_indices - len(indices)
     reduced_density_matrix = np.reshape(
-        density_matrix, (batch_dim, 2**number_wires_sub, 2**number_wires_sub)
+        matrix, (batch_dim, 2**number_wires_sub, 2**number_wires_sub)
     )
     return reduced_density_matrix
 


### PR DESCRIPTION
**Context:**

This pull request includes a significant update to the batched_partial_trace function, transitioning it from a private to a public-facing API. The changes are aimed at enhancing the flexibility of the function, allowing it to handle matrices other than density matrices for partial trace computations.

**Description of the Change:**
- The private function _batched_partial_trace in pennylane/math/quantum.py has been renamed to batched_partial_trace and made public. This function is used to compute the reduced density matrix by tracing out provided indices.
- The batched_partial_trace function now accepts an additional optional parameter c_dtype with a default value of "complex128". This allows for specifying the data type of the resulting density matrix.
- The batched_partial_trace function now includes a line to cast the input density_matrix to the specified c_dtype.
Updated the docstring examples to reflect the change from _batched_partial_trace to batched_partial_trace.


**Benefits:**
- Increased Flexibility: By making batched_partial_trace a public function, users now have access to a more flexible tool for computing the partial trace of various types of matrices, not just density matrices.
- Code Reusability: The change promotes code reusability and could potentially reduce duplication of similar functionality across different parts of the library or in user code.
- Clearer API: The renaming and repurposing of the function to handle a generic matrix clarify the API and its intended use.
- Interface Compatibility: The added checks for different interfaces (Autograd, TensorFlow) ensure that the function works seamlessly across different computational backends, which is crucial for a library like PennyLane that supports multiple interfaces.

**Possible Drawbacks:**
- Breaking Change: Since the function was previously private (prefixed with an underscore), users who were using _batched_partial_trace directly in their code will need to update their imports and function calls, which could cause temporary inconvenience.
- Maintenance Overhead: Public functions typically come with a higher maintenance burden, as they need to be robust, well-documented, and backward compatible.
- Complexity for Users: Some users may find the more generic function slightly more complex to use if they are only interested in working with density matrices.
**Related GitHub Issues:**
[(#5093)](https://github.com/PennyLaneAI/pennylane/issues/5093)
