### PR TITLE
BugFix: Tensorflow type promotion error with Tensors

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -358,7 +358,7 @@
 * `draw_mpl` no longer raises an error when drawing a circuit containing an adjoint of a controlled operation.
   [(#5149)](https://github.com/PennyLaneAI/pennylane/pull/5149)
 
-* `default.mixed` no longer throws `ValueError` when applying a state vector that is not of type `complex128`.
+* `default.mixed` no longer throws `ValueError` when applying a state vector that is not of type `complex128` when used with tensorflow.
   [(#5155)](https://github.com/PennyLaneAI/pennylane/pull/5155)
 
 <h3>Contributors ✍️</h3>

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -358,6 +358,9 @@
 * `draw_mpl` no longer raises an error when drawing a circuit containing an adjoint of a controlled operation.
   [(#5149)](https://github.com/PennyLaneAI/pennylane/pull/5149)
 
+* `default.mixed` no longer throws `ValueError` when applying a state vector that is not of type `complex128`.
+  [(#5155)](https://github.com/PennyLaneAI/pennylane/pull/5155)
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane/math/single_dispatch.py
+++ b/pennylane/math/single_dispatch.py
@@ -264,9 +264,14 @@ ar.autoray._FUNC_ALIASES["tensorflow", "arctan"] = "atan"
 ar.autoray._FUNC_ALIASES["tensorflow", "arctan2"] = "atan2"
 ar.autoray._FUNC_ALIASES["tensorflow", "diag"] = "diag"
 
-ar.register_function(
-    "tensorflow", "asarray", lambda x, **kwargs: _i("tf").convert_to_tensor(x, **kwargs)
-)
+
+def _tf_convert_to_tensor(x, **kwargs):
+    if isinstance(x, _i("tf").Tensor) and "dtype" in kwargs:
+        return _i("tf").cast(x, **kwargs)
+    return _i("tf").convert_to_tensor(x, **kwargs)
+
+
+ar.register_function("tensorflow", "asarray", _tf_convert_to_tensor)
 ar.register_function(
     "tensorflow",
     "hstack",

--- a/tests/devices/test_default_mixed_tf.py
+++ b/tests/devices/test_default_mixed_tf.py
@@ -163,10 +163,11 @@ class TestOps:
 
         assert np.allclose(res, np.zeros(wires**2))
 
-    def test_full_subsystem(self, mocker):
+    @pytest.mark.parametrize("dtype", [tf.float32, tf.float64, tf.complex128])
+    def test_full_subsystem(self, mocker, dtype):
         """Test applying a state vector to the full subsystem"""
         dev = DefaultMixed(wires=["a", "b", "c"])
-        state = tf.constant([1, 0, 0, 0, 1, 0, 1, 1], dtype=tf.complex128) / 2.0
+        state = tf.constant([1, 0, 0, 0, 1, 0, 1, 1], dtype=dtype) / 2.0
         state_wires = qml.wires.Wires(["a", "b", "c"])
 
         spy = mocker.spy(qml.math, "scatter")
@@ -174,14 +175,15 @@ class TestOps:
 
         state = np.outer(state, np.conj(state))
 
-        assert np.all(tf.reshape(dev._state, (-1,)) == tf.reshape(state, (-1,)))
+        assert qml.math.allclose(tf.reshape(dev._state, (-1,)), tf.reshape(state, (-1,)))
         spy.assert_not_called()
 
-    def test_partial_subsystem(self, mocker):
+    @pytest.mark.parametrize("dtype", [tf.float32, tf.float64, tf.complex128])
+    def test_partial_subsystem(self, mocker, dtype):
         """Test applying a state vector to a subset of wires of the full subsystem"""
 
         dev = DefaultMixed(wires=["a", "b", "c"])
-        state = tf.constant([1, 0, 1, 0], dtype=tf.complex128) / np.sqrt(2.0)
+        state = tf.constant([1, 0, 1, 0], dtype=dtype) / np.sqrt(2.0)
         state_wires = qml.wires.Wires(["a", "c"])
 
         spy = mocker.spy(qml.math, "scatter")
@@ -189,7 +191,7 @@ class TestOps:
 
         state = np.kron(np.outer(state, np.conj(state)), np.array([[1, 0], [0, 0]]))
 
-        assert np.all(tf.reshape(dev._state, (8, 8)) == state)
+        assert qml.math.allclose(tf.reshape(dev._state, (8, 8)), state)
         spy.assert_called()
 
 


### PR DESCRIPTION
**Context:**
`default.mixed` used with tensorflow throws an error when applying a state that is not initialized in `complex128`, originally found here: https://discuss.pennylane.ai/t/error-with-keraslayer-and-amplitude-embedding/3924

**Description of the Change:**
`tf.convert_to_tensor` does not work for states that are already `Tensor` objects with a different `dtype`. Use `tf.cast` instead when this is the case.

**Benefits:**
BugFix

**Related GitHub Issues:**
https://github.com/PennyLaneAI/pennylane/issues/5085

**Shortcut**
[sc-55061]