### PR TITLE
Fix `Tensor.map_wires`

### DIFF
--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -2539,7 +2539,9 @@ class Tensor(Observable):
         new_op.obs = [obs.map_wires(wire_map) for obs in self.obs]
         new_op._eigvals_cache = self._eigvals_cache
         new_op._batch_size = self._batch_size
-        new_op._pauli_rep = self._pauli_rep.map_wires(wire_map)
+        new_op._pauli_rep = (
+            self._pauli_rep.map_wires(wire_map) if self.pauli_rep is not None else None
+        )
         return new_op
 
 

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -1994,6 +1994,19 @@ class TestTensor:
         assert mapped_tensor.batch_size == tensor.batch_size
         for obs1, obs2 in zip(mapped_tensor.obs, final_obs):
             assert qml.equal(obs1, obs2)
+        assert mapped_tensor.pauli_rep == Tensor(*final_obs).pauli_rep
+
+    def test_map_wires_no_pauli_rep(self):
+        """Test that map_wires sets the pauli rep correctly if the original
+        Tensor did not have a pauli rep."""
+        tensor = Tensor(qml.PauliX(0), qml.Hadamard(1))
+        wire_map = {0: 10, 1: 11}
+        expected_tensor = Tensor(qml.PauliX(10), qml.Hadamard(11))
+
+        mapped_tensor = tensor.map_wires(wire_map=wire_map)
+        assert tensor is not mapped_tensor
+        assert mapped_tensor == expected_tensor
+        assert mapped_tensor.pauli_rep is None
 
     def test_matmul_not_implemented(self):
         """Test that matrix multiplication raises TypeError if unsupported


### PR DESCRIPTION
An edge case I missed in #5070 broke Lightning tests. This is to fix that.