### PR TITLE
[BUGFIX] qml.equal via pauli_rep

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -404,7 +404,8 @@
 * `default.mixed` no longer throws `ValueError` when applying a state vector that is not of type `complex128` when used with tensorflow.
   [(#5155)](https://github.com/PennyLaneAI/pennylane/pull/5155)
 
-* Comparison of sum of sums with an equivalent sum in `qml.equal` yields the correct result now.
+* Comparing `Prod` and `Sum` objects now works regardless of nested structure with `qml.equal` if the
+  operators have a valid `pauli_rep` property.
   [(#5177)](https://github.com/PennyLaneAI/pennylane/pull/5177)
 
 <h3>Contributors ✍️</h3>

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -231,9 +231,6 @@
   are being raised unexpectedly.
   [(#5122)](https://github.com/PennyLaneAI/pennylane/pull/5122)
 
-* `qml.equal` compares operators based on their `pauli_rep` in case they have it.
-  [(#5177)](https://github.com/PennyLaneAI/pennylane/pull/5177)
-
 <h3>Breaking changes 💔</h3>
 
 * Make PennyLane code compatible with the latest version of `black`.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -231,6 +231,9 @@
   are being raised unexpectedly.
   [(#5122)](https://github.com/PennyLaneAI/pennylane/pull/5122)
 
+* `qml.equal` compares operators based on their `pauli_rep` in case they have it.
+  [(#5177)](https://github.com/PennyLaneAI/pennylane/pull/5177)
+
 <h3>Breaking changes 💔</h3>
 
 * Make PennyLane code compatible with the latest version of `black`.
@@ -403,6 +406,9 @@
 
 * `default.mixed` no longer throws `ValueError` when applying a state vector that is not of type `complex128` when used with tensorflow.
   [(#5155)](https://github.com/PennyLaneAI/pennylane/pull/5155)
+
+* Comparison of sum of sums with an equivalent sum in `qml.equal` yields the correct result now.
+  [(#5177)](https://github.com/PennyLaneAI/pennylane/pull/5177)
 
 <h3>Contributors ✍️</h3>
 

--- a/pennylane/ops/functions/equal.py
+++ b/pennylane/ops/functions/equal.py
@@ -154,10 +154,6 @@ def equal(
     if isinstance(op2, (Hamiltonian, Tensor)):
         return _equal(op2, op1)
 
-    if isinstance(op1, Operator) and isinstance(op2, Operator):
-        if (pr1 := op1.pauli_rep) and (pr2 := op2.pauli_rep):
-            return pr1 == pr2
-
     return _equal(
         op1,
         op2,
@@ -273,11 +269,11 @@ def _equal_operators(
 # pylint: disable=unused-argument, protected-access
 def _equal_prod_and_sum(op1: CompositeOp, op2: CompositeOp, **kwargs):
     """Determine whether two Prod or Sum objects are equal"""
-    if len(op1.operands) != len(op2.operands):
-        return False
-
     if op1.pauli_rep is not None and (op1.pauli_rep == op2.pauli_rep):  # shortcut check
         return True
+
+    if len(op1.operands) != len(op2.operands):
+        return False
 
     # organizes by wire indicies while respecting commutation relations
     sorted_ops1 = op1._sort(op1.operands)

--- a/pennylane/ops/functions/equal.py
+++ b/pennylane/ops/functions/equal.py
@@ -153,6 +153,11 @@ def equal(
 
     if isinstance(op2, (Hamiltonian, Tensor)):
         return _equal(op2, op1)
+    
+    if isinstance(op1, Operator) and isinstance(op2, Operator):
+        if (pr1 := op1.pauli_rep) and (pr2 := op2.pauli_rep):
+            return pr1 == pr2
+        
 
     return _equal(
         op1,

--- a/pennylane/ops/functions/equal.py
+++ b/pennylane/ops/functions/equal.py
@@ -153,11 +153,10 @@ def equal(
 
     if isinstance(op2, (Hamiltonian, Tensor)):
         return _equal(op2, op1)
-    
+
     if isinstance(op1, Operator) and isinstance(op2, Operator):
         if (pr1 := op1.pauli_rep) and (pr2 := op2.pauli_rep):
             return pr1 == pr2
-        
 
     return _equal(
         op1,

--- a/tests/ops/functions/test_equal.py
+++ b/tests/ops/functions/test_equal.py
@@ -1631,7 +1631,7 @@ class TestSymbolicOpComparison:
             + 0.5 * X(9)
         )
         op2 = qml.sum(*[0.5 * X(i) for i in range(10)])
-        assert qml.equal(op1, op2) == True
+        assert qml.equal(op1, op2)
         qml.operation.disable_new_opmath()
 
 

--- a/tests/ops/functions/test_equal.py
+++ b/tests/ops/functions/test_equal.py
@@ -1614,6 +1614,26 @@ class TestSymbolicOpComparison:
         assert qml.equal(op1, op2, atol=1e-3, rtol=1e-2)
         assert not qml.equal(op1, op2, atol=1e-5, rtol=1e-4)
 
+    def test_sum_of_sums(self):
+        """Test that sum of sums and just an equivalent sum get compared correctly"""
+        X = qml.PauliX
+        qml.operation.enable_new_opmath()
+        op1 = (
+            0.5 * X(0)
+            + 0.5 * X(1)
+            + 0.5 * X(2)
+            + 0.5 * X(3)
+            + 0.5 * X(4)
+            + 0.5 * X(5)
+            + 0.5 * X(6)
+            + 0.5 * X(7)
+            + 0.5 * X(8)
+            + 0.5 * X(9)
+        )
+        op2 = qml.sum(*[0.5 * X(i) for i in range(10)])
+        assert qml.equal(op1, op2) == True
+        qml.operation.disable_new_opmath()
+
 
 class TestProdComparisons:
     """Tests comparisons between Prod operators"""

--- a/tests/ops/functions/test_equal.py
+++ b/tests/ops/functions/test_equal.py
@@ -1605,6 +1605,7 @@ class TestSymbolicOpComparison:
         op2 = qml.s_prod(param2, base2)
         assert qml.equal(op1, op2) == (bases_match and params_match)
 
+    @pytest.mark.skip
     def test_s_prod_comparison_with_tolerance(self):
         """Test that equal compares the parameters within a provided tolerance."""
         op1 = qml.s_prod(0.12345, qml.PauliX(0))

--- a/tests/ops/functions/test_equal.py
+++ b/tests/ops/functions/test_equal.py
@@ -1605,7 +1605,6 @@ class TestSymbolicOpComparison:
         op2 = qml.s_prod(param2, base2)
         assert qml.equal(op1, op2) == (bases_match and params_match)
 
-    @pytest.mark.skip
     def test_s_prod_comparison_with_tolerance(self):
         """Test that equal compares the parameters within a provided tolerance."""
         op1 = qml.s_prod(0.12345, qml.PauliX(0))

--- a/tests/ops/functions/test_equal.py
+++ b/tests/ops/functions/test_equal.py
@@ -1706,20 +1706,8 @@ class TestProdComparisons:
         """Test that prod of prods and just an equivalent Prod get compared correctly"""
         X = qml.PauliX
         qml.operation.enable_new_opmath()
-        op1 = (
-            0.5
-            * X(0)
-            @ (0.5 * X(1))
-            @ (0.5 * X(2))
-            @ (0.5 * X(3))
-            @ (0.5 * X(4))
-            @ (0.5 * X(5))
-            @ (0.5 * X(6))
-            @ (0.5 * X(7))
-            @ (0.5 * X(8))
-            @ (0.5 * X(9))
-        )
-        op2 = qml.prod(*[0.5 * X(i) for i in range(10)])
+        op1 = (0.5 * X(0)) @ (0.5 * X(1)) @ (0.5 * X(2)) @ (0.5 * X(3)) @ (0.5 * X(4))
+        op2 = qml.prod(*[0.5 * X(i) for i in range(5)])
         assert qml.equal(op1, op2)
         qml.operation.disable_new_opmath()
 

--- a/tests/ops/functions/test_equal.py
+++ b/tests/ops/functions/test_equal.py
@@ -1701,12 +1701,14 @@ class TestProdComparisons:
         op1 = qml.prod(*base_list1)
         op2 = qml.prod(*base_list2)
         assert qml.equal(op1, op2) == res
-    
+
     def test_prod_of_prods(self):
         """Test that prod of prods and just an equivalent Prod get compared correctly"""
         X = qml.PauliX
         qml.operation.enable_new_opmath()
-        op1 = (0.5 * X(0)
+        op1 = (
+            0.5
+            * X(0)
             @ (0.5 * X(1))
             @ (0.5 * X(2))
             @ (0.5 * X(3))

--- a/tests/ops/functions/test_equal.py
+++ b/tests/ops/functions/test_equal.py
@@ -1613,26 +1613,6 @@ class TestSymbolicOpComparison:
         assert qml.equal(op1, op2, atol=1e-3, rtol=1e-2)
         assert not qml.equal(op1, op2, atol=1e-5, rtol=1e-4)
 
-    def test_sum_of_sums(self):
-        """Test that sum of sums and just an equivalent sum get compared correctly"""
-        X = qml.PauliX
-        qml.operation.enable_new_opmath()
-        op1 = (
-            0.5 * X(0)
-            + 0.5 * X(1)
-            + 0.5 * X(2)
-            + 0.5 * X(3)
-            + 0.5 * X(4)
-            + 0.5 * X(5)
-            + 0.5 * X(6)
-            + 0.5 * X(7)
-            + 0.5 * X(8)
-            + 0.5 * X(9)
-        )
-        op2 = qml.sum(*[0.5 * X(i) for i in range(10)])
-        assert qml.equal(op1, op2)
-        qml.operation.disable_new_opmath()
-
 
 class TestProdComparisons:
     """Tests comparisons between Prod operators"""
@@ -1721,6 +1701,25 @@ class TestProdComparisons:
         op1 = qml.prod(*base_list1)
         op2 = qml.prod(*base_list2)
         assert qml.equal(op1, op2) == res
+    
+    def test_prod_of_prods(self):
+        """Test that prod of prods and just an equivalent Prod get compared correctly"""
+        X = qml.PauliX
+        qml.operation.enable_new_opmath()
+        op1 = (0.5 * X(0)
+            @ (0.5 * X(1))
+            @ (0.5 * X(2))
+            @ (0.5 * X(3))
+            @ (0.5 * X(4))
+            @ (0.5 * X(5))
+            @ (0.5 * X(6))
+            @ (0.5 * X(7))
+            @ (0.5 * X(8))
+            @ (0.5 * X(9))
+        )
+        op2 = qml.prod(*[0.5 * X(i) for i in range(10)])
+        assert qml.equal(op1, op2)
+        qml.operation.disable_new_opmath()
 
 
 class TestSumComparisons:
@@ -1814,6 +1813,26 @@ class TestSumComparisons:
         res = res.simplify()
 
         assert true_res == res
+
+    def test_sum_of_sums(self):
+        """Test that sum of sums and just an equivalent sum get compared correctly"""
+        X = qml.PauliX
+        qml.operation.enable_new_opmath()
+        op1 = (
+            0.5 * X(0)
+            + 0.5 * X(1)
+            + 0.5 * X(2)
+            + 0.5 * X(3)
+            + 0.5 * X(4)
+            + 0.5 * X(5)
+            + 0.5 * X(6)
+            + 0.5 * X(7)
+            + 0.5 * X(8)
+            + 0.5 * X(9)
+        )
+        op2 = qml.sum(*[0.5 * X(i) for i in range(10)])
+        assert qml.equal(op1, op2)
+        qml.operation.disable_new_opmath()
 
 
 def f1(p, t):


### PR DESCRIPTION
**Potential** fix for https://github.com/PennyLaneAI/pennylane/issues/5162 and many other related issues  
Simply compares the pauli_rep between operators, when both have one.

[sc-56466]