### PR TITLE
[BUGFIX] Update `Pow.matrix` to handle integer powers with TensorFlow

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -346,6 +346,9 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* `qml.ops.Pow.matrix()` is now differentiable with TensorFlow with integer exponents.
+[(#5178)](https://github.com/PennyLaneAI/pennylane/pull/5178)
+
 * The `qml.MottonenStatePreparation` template is updated to include a global phase operation.
   [(#5166)](https://github.com/PennyLaneAI/pennylane/pull/5166)
 

--- a/pennylane/ops/op_math/pow.py
+++ b/pennylane/ops/op_math/pow.py
@@ -227,12 +227,16 @@ class Pow(ScalarSymbolicOp):
             if qml.math.get_deep_interface(mat) != "tensorflow":
                 return qmlmath.linalg.matrix_power(mat, scalar)
 
+            # TensorFlow doesn't have a matrix_power func, and scipy.linalg.fractional_matrix_power
+            # is not differentiable. So we use a custom implementation of matrix power for integer
+            # exponents below.
             if scalar == 0:
-                return qmlmath.eye(qml.math.shape(mat)[-1], like=mat)
+                # Used instead of qml.math.eye for tracing derivatives
+                return mat @ qmlmath.linalg.inv(mat)
             if scalar > 0:
                 out = mat
             else:
-                out = qmlmath.linalg.inv(mat)
+                out = mat = qmlmath.linalg.inv(mat)
                 scalar *= -1
 
             for _ in range(scalar - 1):

--- a/pennylane/ops/op_math/pow.py
+++ b/pennylane/ops/op_math/pow.py
@@ -223,8 +223,22 @@ class Pow(ScalarSymbolicOp):
 
     @staticmethod
     def _matrix(scalar, mat):
-        if isinstance(scalar, int) and qml.math.get_deep_interface(mat) != "tensorflow":
-            return qmlmath.linalg.matrix_power(mat, scalar)
+        if isinstance(scalar, int):
+            if qml.math.get_deep_interface(mat) != "tensorflow":
+                return qmlmath.linalg.matrix_power(mat, scalar)
+
+            if scalar == 0:
+                return qmlmath.eye(qml.math.shape(mat)[-1], like=mat)
+            if scalar > 0:
+                out = mat
+            else:
+                out = qmlmath.linalg.inv(mat)
+                scalar *= -1
+
+            for _ in range(scalar - 1):
+                out @= mat
+            return out
+
         return fractional_matrix_power(mat, scalar)
 
     # pylint: disable=arguments-differ

--- a/tests/ops/functions/test_iterative_qpe.py
+++ b/tests/ops/functions/test_iterative_qpe.py
@@ -121,7 +121,6 @@ class TestIQPE:
         phi = torch.tensor(1.0, requires_grad=True)
         assert torch.isclose(torch.func.grad(circuit)(phi), torch.func.grad(manual_circuit)(phi))
 
-    @pytest.mark.xfail(reason="See https://github.com/PennyLaneAI/pennylane/issues/5002")
     @pytest.mark.tf
     def test_check_gradients_tf(self):
         """Test to check that the gradients are correct comparing with the expanded circuit using TensorFlow"""


### PR DESCRIPTION
**Context:**
This is a bugfix for #5002 , which was being caused by `Pow.matrix` not being differentiable with tensorflow due to the use of `scipy.linalg.fractional_matrix_power`.

**Description of the Change:**
* Updated `Pow._matrix` to do the matrix power operation manually when the scalar is an integer and the interface is "tensorflow". This can be traced by tensorflow, and hence, is diff-compatible.

**Benefits:**
`Pow` is differentiable with tensorflow.

**Possible Drawbacks:**

**Related GitHub Issues:**
#5002 