### PR TITLE
Use new op math in generator of GlobalPhase and Controlled

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -477,6 +477,8 @@
   operators have a valid `pauli_rep` property.
   [(#5177)](https://github.com/PennyLaneAI/pennylane/pull/5177)
 
+* Controlled `GlobalPhase` with non-zero control wire no longer throws an error.
+  [(#5194)](https://github.com/PennyLaneAI/pennylane/pull/5194)
 
 <h3>Contributors ✍️</h3>
 

--- a/pennylane/ops/identity.py
+++ b/pennylane/ops/identity.py
@@ -389,5 +389,4 @@ class GlobalPhase(Operation):
         return [GlobalPhase(z * self.data[0], self.wires)]
 
     def generator(self):
-        wires = self.wires or [0]
-        return -1 * qml.Identity(wires)
+        return qml.s_prod(-1, qml.Identity(self.wires))

--- a/pennylane/ops/op_math/controlled.py
+++ b/pennylane/ops/op_math/controlled.py
@@ -666,11 +666,7 @@ class Controlled(SymbolicOp):
         projectors = (
             qml.Projector([val], wires=w) for val, w in zip(self.control_values, self.control_wires)
         )
-
-        if qml.operation.active_new_opmath():
-            return qml.prod(*projectors, sub_gen)
-
-        return 1.0 * operation.Tensor(*projectors) @ sub_gen
+        return qml.prod(*projectors, sub_gen)
 
     @property
     def has_adjoint(self):

--- a/tests/ops/qubit/test_parametric_ops.py
+++ b/tests/ops/qubit/test_parametric_ops.py
@@ -2007,18 +2007,19 @@ class TestGrad:
 
     @pytest.mark.autograd
     @pytest.mark.parametrize("dev_name,diff_method", device_methods)
-    def test_globalphase_autograd_grad(self, tol, dev_name, diff_method):
+    @pytest.mark.parametrize("wires", [(0, 1), (1, 0)])
+    def test_globalphase_autograd_grad(self, tol, dev_name, diff_method, wires):
         """Test the gradient with Autograd for a controlled GlobalPhase."""
 
         dev = qml.device(dev_name, wires=2)
 
         @qml.qnode(dev, diff_method=diff_method)
         def circuit(x):
-            qml.Identity(0)
-            qml.Hadamard(1)
-            qml.ctrl(qml.GlobalPhase(x), 1)
-            qml.Hadamard(1)
-            return qml.expval(qml.PauliZ(1))
+            qml.Identity(wires[0])
+            qml.Hadamard(wires[1])
+            qml.ctrl(qml.GlobalPhase(x), control=wires[1])
+            qml.Hadamard(wires[1])
+            return qml.expval(qml.PauliZ(wires[1]))
 
         phi = npp.array(2.1, requires_grad=True)
 
@@ -2351,7 +2352,8 @@ class TestGrad:
 
     @pytest.mark.tf
     @pytest.mark.parametrize("dev_name,diff_method", device_methods)
-    def test_globalphase_tf_grad(self, tol, dev_name, diff_method):
+    @pytest.mark.parametrize("wires", [(0, 1), (1, 0)])
+    def test_globalphase_tf_grad(self, tol, dev_name, diff_method, wires):
         """Test the gradient with Tensorflow for a controlled GlobalPhase."""
 
         import tensorflow as tf
@@ -2360,11 +2362,11 @@ class TestGrad:
 
         @qml.qnode(dev, diff_method=diff_method)
         def circuit(x):
-            qml.Identity(0)
-            qml.Hadamard(1)
-            qml.ctrl(qml.GlobalPhase(x), 1)
-            qml.Hadamard(1)
-            return qml.expval(qml.PauliZ(1))
+            qml.Identity(wires[0])
+            qml.Hadamard(wires[1])
+            qml.ctrl(qml.GlobalPhase(x), control=wires[1])
+            qml.Hadamard(wires[1])
+            return qml.expval(qml.PauliZ(wires[1]))
 
         phi = tf.Variable(2.1, dtype=tf.complex128)
 
@@ -2505,7 +2507,8 @@ class TestGrad:
 
     @pytest.mark.jax
     @pytest.mark.parametrize("dev_name,diff_method", device_methods)
-    def test_globalphase_jax_grad(self, tol, dev_name, diff_method):
+    @pytest.mark.parametrize("wires", [(1, 0), (0, 1)])
+    def test_globalphase_jax_grad(self, tol, dev_name, diff_method, wires):
         """Test the gradient with JAX for a controlled GlobalPhase."""
 
         import jax
@@ -2517,11 +2520,11 @@ class TestGrad:
 
         @qml.qnode(dev, diff_method=diff_method)
         def circuit(x):
-            qml.Identity(0)
-            qml.Hadamard(1)
-            qml.ctrl(qml.GlobalPhase(x), 1)
-            qml.Hadamard(1)
-            return qml.expval(qml.PauliZ(1))
+            qml.Identity(wires[0])
+            qml.Hadamard(wires[1])
+            qml.ctrl(qml.GlobalPhase(x), control=wires[1])
+            qml.Hadamard(wires[1])
+            return qml.expval(qml.PauliZ(wires[1]))
 
         phi = jnp.array(2.1)
 
@@ -2532,7 +2535,8 @@ class TestGrad:
 
     @pytest.mark.torch
     @pytest.mark.parametrize("dev_name,diff_method", device_methods)
-    def test_globalphase_torch_grad(self, tol, dev_name, diff_method):
+    @pytest.mark.parametrize("wires", [(1, 0), (0, 1)])
+    def test_globalphase_torch_grad(self, tol, dev_name, diff_method, wires):
         """Test the gradient with Torch for a controlled GlobalPhase."""
 
         import torch
@@ -2541,11 +2545,11 @@ class TestGrad:
 
         @qml.qnode(dev, diff_method=diff_method)
         def circuit(x):
-            qml.Identity(0)
-            qml.Hadamard(1)
-            qml.ctrl(qml.GlobalPhase(x), 1)
-            qml.Hadamard(1)
-            return qml.expval(qml.PauliZ(1))
+            qml.Identity(wires[0])
+            qml.Hadamard(wires[1])
+            qml.ctrl(qml.GlobalPhase(x), control=wires[1])
+            qml.Hadamard(wires[1])
+            return qml.expval(qml.PauliZ(wires[1]))
 
         phi = torch.tensor(2.1, requires_grad=True, dtype=torch.float64)
 


### PR DESCRIPTION
**Context:**
The `Tensor` and `Hamiltonian` does not work with `Identity` on no wires, causing issues with `ControlledGlobalPhase` when the `GlobalPhase` acts on no wires.

**Description of the Change:**
1. Use `prod` and `s_prod` in place of straight multiplication in the `generator` of `Controlled` and `GlobalPhase`
2. The generator of `GlobalPhase` now contains an identity that acts on the same wires as the `GlobalPhase`.

**Benefits:**
BugFix

**Related GitHub Issues:**
https://github.com/PennyLaneAI/pennylane/issues/4578

**Related Shortcut Story:**
[sc-44933]