### PR TITLE
Add broadcasting support to mitigate_with_zne

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -492,6 +492,9 @@
   operators have a valid `pauli_rep` property.
   [(#5177)](https://github.com/PennyLaneAI/pennylane/pull/5177)
 
+* A `QNode` transformed with `mitigate_with_zne` now accepts batch parameters.
+  [(#5195)](https://github.com/PennyLaneAI/pennylane/pull/5195)
+
 
 <h3>Contributors ✍️</h3>
 

--- a/pennylane/transforms/mitigate.py
+++ b/pennylane/transforms/mitigate.py
@@ -261,7 +261,7 @@ def _polyfit(x, y, order):
     # i.e. coeffs = (X.T @ X)**-1 X.T @ y see https://en.wikipedia.org/wiki/Polynomial_regression
     c = qml.math.linalg.pinv(qml.math.transpose(X) @ X)
     c = c @ qml.math.transpose(X)
-    c = qml.math.dot(c, y)
+    c = qml.math.tensordot(c, y, axes=1)
     c = qml.math.transpose(qml.math.transpose(c) / scale)
     return c
 

--- a/tests/transforms/test_mitigate.py
+++ b/tests/transforms/test_mitigate.py
@@ -179,6 +179,29 @@ class TestMitigateWithZNE:
         assert args[0][0] == scale_factors
         assert np.allclose(args[0][1], np.mean(np.reshape(random_results, (3, 2)), axis=1))
 
+    def test_braodcasting(self):
+        """Tests that mitigate_with_zne supports batch arguments"""
+
+        batch_size = 2
+
+        @qml.qnode(dev_noisy)
+        def original_qnode(inputs):
+            qml.AmplitudeEmbedding(features=inputs, wires=range(2), normalize=True)
+            return [qml.expval(qml.PauliZ(wires=i)) for i in range(2)]
+
+        expanded_qnode = qml.transforms.broadcast_expand(original_qnode)
+
+        mitigated_qnode_orig = qml.transforms.mitigate_with_zne(
+            original_qnode, [1, 2, 3], fold_global, richardson_extrapolate
+        )
+        mitigated_qnode_expanded = qml.transforms.mitigate_with_zne(
+            expanded_qnode, [1, 2, 3], fold_global, richardson_extrapolate
+        )
+        inputs = np.random.uniform(0, 1, size=(batch_size, 2**2))
+        result_orig = mitigated_qnode_orig(inputs)
+        result_expanded = mitigated_qnode_expanded(inputs)
+        assert qml.math.allclose(result_orig, result_expanded)
+
 
 @pytest.fixture
 def skip_if_no_mitiq_support():

--- a/tests/transforms/test_mitigate.py
+++ b/tests/transforms/test_mitigate.py
@@ -197,7 +197,8 @@ class TestMitigateWithZNE:
         mitigated_qnode_expanded = qml.transforms.mitigate_with_zne(
             expanded_qnode, [1, 2, 3], fold_global, richardson_extrapolate
         )
-        inputs = np.random.uniform(0, 1, size=(batch_size, 2**2))
+        rng = np.random.default_rng(seed=18954959)
+        inputs = rng.uniform(0, 1, size=(batch_size, 2**2))
         result_orig = mitigated_qnode_orig(inputs)
         result_expanded = mitigated_qnode_expanded(inputs)
         assert qml.math.allclose(result_orig, result_expanded)


### PR DESCRIPTION
**Context:**
A QNode transformed with `mitigate_with_zne` does not accept parameters with a leading dimension

**Description of the Change:**
1. Replace `qml.math.dot` with `qml.math.tensordot` in `_polyfit`
2. Test case added for parameter broadcasting with `mitigate_with_zne`

**Benefits:**
BugFix

**Related GitHub Issues:**
https://github.com/PennyLaneAI/pennylane/issues/5100

**Related Shortcut Story:**
[sc-55298]