### PR TITLE
merge instead of rebase so the stable workflow works

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,7 @@ jobs:
   upload-stable-deps:
     needs: tests
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,13 +31,9 @@ jobs:
   upload-stable-deps:
     needs: tests
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          fetch-tags: true
-          sparse-checkout: .github
 
       - name: Prepare local repo
         run: |
@@ -46,7 +42,7 @@ jobs:
           git config user.email "<>"
           if git ls-remote --exit-code origin "refs/heads/${{ env.DEPS_BRANCH }}"; then
             git checkout "${{ env.DEPS_BRANCH }}"
-            git rebase origin/master
+            git merge origin/master
           else
             git checkout master
             git checkout -b "${{ env.DEPS_BRANCH }}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,11 +80,13 @@ jobs:
           pr_title: "Update stable dependency files"
           pr_body: |
             Automatic update of stable requirement files to snapshot valid python environments.
+
             Because bots are not able to trigger CI on their own, please do so by pushing an empty commit to this branch using the following command:
 
             ```
             git commit --allow-empty -m 'trigger ci'
             ```
+
+            Alternatively, wait for this branch to be out-of-date with master, then just use the "Update branch" button!
           pr_allow_empty: false
           pr_draft: false
-          pr_reviewer: "timmysilv"


### PR DESCRIPTION
git rebase failed [badly](https://github.com/PennyLaneAI/pennylane/actions/runs/7892879771/job/21541221953), so I'm just gonna `git merge origin/master` instead. maybe we could just skip the whole thing.. but idk I don't have great amounts of faith in the checkout bot for some reason. anyway this [worked](https://github.com/PennyLaneAI/pennylane/actions/runs/7893410969/job/21542363385?pr=5201)!