### PR TITLE
support measuring observables with abstract data

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -504,6 +504,9 @@
   Further, matrices of empty `PauliWord` and `PauliSentence` instances can be turned to matrices now.
   [(#5188)](https://github.com/PennyLaneAI/pennylane/pull/5188)
 
+* Measuring the expectation of observables with abstract data now uses the jit-compatible
+  dot-product computation method, thereby no longer raising unexpected jitting errors.
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane/devices/qubit/measure.py
+++ b/pennylane/devices/qubit/measure.py
@@ -190,7 +190,9 @@ def get_measurement_function(
             if measurementprocess.obs.name == "SparseHamiltonian":
                 return csr_dot_products
 
-            if measurementprocess.obs.name == "Hermitian":
+            if measurementprocess.obs.name == "Hermitian" or any(
+                math.is_abstract(d) for d in measurementprocess.obs.data
+            ):
                 return full_dot_products
 
             backprop_mode = math.get_interface(state, *measurementprocess.obs.data) != "numpy"


### PR DESCRIPTION
**Context:**
measuring observables with abstract data on default.qubit currently tries to use `state_diagonalizing_gates` which depends on the eigendecomposition. Today, this is not jit-compatible.

**Description of the Change:**
When an observable has abstract parameters, use `full_dot_products` instead.

**Benefits:**
Measuring abstract observables works with jax-jit

**Possible Drawbacks:**
Might not be the best solution

[sc-56801]