### PR TITLE
Clear error message if plugin is not installed

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -293,6 +293,10 @@
   when converting a `QuantumCircuit` using `qml.from_qiskit`.
   [(#5168)](https://github.com/PennyLaneAI/pennylane/pull/5168)
 
+* An error message provides clearer instructions for installing PennyLane-Qiskit if the `qml.from_qiskit` 
+  function fails because the Qiskit converter is missing.
+  [(#5218)](https://github.com/PennyLaneAI/pennylane/pull/5218)
+
 <h3>Breaking changes 💔</h3>
 
 * The entry point convention registering compilers with PennyLane has changed.

--- a/pennylane/io.py
+++ b/pennylane/io.py
@@ -142,7 +142,18 @@ def from_qiskit(quantum_circuit, measurements=None):
         1: ───────────────────╰X─┤  vnentropy
 
     """
-    return load(quantum_circuit, format="qiskit", measurements=measurements)
+    try:
+        return load(quantum_circuit, format="qiskit", measurements=measurements)
+    except ValueError as e:
+        if e.args[0].split(".")[0] == "Converter does not exist":
+            raise RuntimeError(
+                "Conversion from Qiskit requires the PennyLane-Qiskit plugin. "
+                "You can install the plugin by running ``pip install pennylane-qiskit``. "
+                "You may need to restart your kernel after installation. "
+                "If you have any difficulties, you can reach out on the PennyLane forum at "
+                "https://discuss.pennylane.ai/c/pennylane-plugins/pennylane-qiskit/"
+            ) from e
+        raise e
 
 
 def from_qasm(quantum_circuit: str):

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -73,7 +73,8 @@ class TestLoad:
 
     def test_qiskit_not_installed(self, monkeypatch):
         """Test that a specific error is raised if qml.from_qiskit is called and the qiskit
-        plugin converter isn't found, instead of the generic 'ValueError: Converter does not exist.'"""
+        plugin converter isn't found, instead of the generic 'ValueError: Converter does not exist.'
+        """
 
         # temporarily make a mock_converter_dict with no "qiskit"
         mock_plugin_converter_dict = {

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -73,7 +73,7 @@ class TestLoad:
 
     def test_qiskit_not_installed(self, monkeypatch):
         """Test that a specific error is raised if qml.from_qiskit is called and the qiskit
-        plugin converter isn't found"""
+        plugin converter isn't found, instead of the generic 'ValueError: Converter does not exist.'"""
 
         # temporarily make a mock_converter_dict with no "qiskit"
         mock_plugin_converter_dict = {
@@ -82,10 +82,23 @@ class TestLoad:
         del mock_plugin_converter_dict["qiskit"]
         monkeypatch.setattr(qml.io, "plugin_converters", mock_plugin_converter_dict)
 
+        # calling from_qiskit raises the specific RuntimeError rather than the generic ValueError
         with pytest.raises(
             RuntimeError,
             match="Conversion from Qiskit requires the PennyLane-Qiskit plugin. "
             "You can install the plugin by",
+        ):
+            qml.from_qiskit("Test")
+
+        # if load raises some other ValueError instead of the "converter does not exist" error, it is unaffected
+        def mock_load_with_error(*args, **kwargs):
+            raise ValueError("Some other error raised than instead of converter does not exist")
+
+        monkeypatch.setattr(qml.io, "load", mock_load_with_error)
+
+        with pytest.raises(
+            ValueError,
+            match="Some other error raised than instead of converter does not exist",
         ):
             qml.from_qiskit("Test")
 


### PR DESCRIPTION
**Context:**
Currently if you try to use `qml.from_qiskit` without the plugin installed, you get the somewhat non-specific
`ValueError: Converter does not exist. Make sure the required plugin is installed and supports conversion.`

**Description of the Change:**
If the "converter does not exist" error is raised when calling `qml.from_qiskit`, the user is shown a more explicit message with instructions for installing the plugin and for contacting the forum if they have issues.

