### PR TITLE
port device test suite to accept old interface

### DIFF
--- a/.github/workflows/interface-unit-tests.yml
+++ b/.github/workflows/interface-unit-tests.yml
@@ -496,6 +496,10 @@ jobs:
         config:
           - device: default.qubit.legacy
             shots: None
+          - device: default.qubit
+            shots: None
+          - device: default.qubit
+            shots: 10000
           - device: default.qubit.legacy
             shots: 10000
           # - device: default.qubit.tf

--- a/pennylane/devices/tests/conftest.py
+++ b/pennylane/devices/tests/conftest.py
@@ -105,10 +105,11 @@ def device(device_kwargs):
                 f"plugin and all of its dependencies must be installed."
             )
 
-        capabilities = dev.capabilities()
-        if capabilities.get("model", None) != "qubit":
-            # exit the tests if device based on cv model (currently not supported)
-            pytest.exit("The device test suite currently only runs on qubit-based devices.")
+        if isinstance(dev, qml.Device):
+            capabilities = dev.capabilities()
+            if capabilities.get("model", None) != "qubit":
+                # exit the tests if device based on cv model (currently not supported)
+                pytest.exit("The device test suite currently only runs on qubit-based devices.")
 
         return dev
 

--- a/pennylane/devices/tests/pytest.ini
+++ b/pennylane/devices/tests/pytest.ini
@@ -1,4 +1,7 @@
 [pytest]
 markers =
     skip_unsupported: skip a test if it uses an operation unsupported on a device
+    tier0: full substitution with defualt.qubit
+    tier1: somewhere between full capabilities and bare basics
+    tier2: just obeys interface
 addopts = --benchmark-disable

--- a/pennylane/devices/tests/test_compare_default_qubit.py
+++ b/pennylane/devices/tests/test_compare_default_qubit.py
@@ -17,7 +17,7 @@ import pytest
 from flaky import flaky
 
 import pennylane as qml
-from pennylane import numpy as np  # Import from PennyLane to mirror the standard approach in demos
+from pennylane import numpy as pnp  # Import from PennyLane to mirror the standard approach in demos
 from pennylane.templates.layers import RandomLayers
 
 pytestmark = pytest.mark.skip_unsupported
@@ -27,32 +27,33 @@ pytestmark = pytest.mark.skip_unsupported
 class TestComparison:
     """Test that a device different to default.qubit gives the same result"""
 
+    @pytest.mark.tier0
     def test_hermitian_expectation(self, device, tol, benchmark):
         """Test that arbitrary multi-mode Hermitian expectation values are correct"""
         n_wires = 2
         dev = device(n_wires)
-        dev_def = qml.device("default.qubit", wires=n_wires)
+        dev_def = qml.device("default.qubit")
 
-        if dev.shots is not None:
+        if dev.shots:
             pytest.skip("Device is in non-analytical mode.")
 
-        if "Hermitian" not in dev.observables:
+        if isinstance(dev, qml.Device) and "Hermitian" not in dev.observables:
             pytest.skip("Device does not support the Hermitian observable.")
 
-        if dev.name == dev_def.name:
+        if dev.name == "default.qubit":
             pytest.skip("Device is default.qubit.")
 
         theta = 0.432
         phi = 0.123
-        A_ = np.array(
+        A_ = pnp.array(
             [
                 [-6, 2 + 1j, -3, -5 + 2j],
                 [2 - 1j, 0, 2 - 1j, -5 + 4j],
                 [-3, 2 + 1j, 0, -4 + 3j],
                 [-5 - 2j, -5 - 4j, -4 - 3j, -6],
-            ]
+            ],
+            requires_grad=False,
         )
-        A_.requires_grad = False
 
         def circuit(theta, phi):
             qml.RX(theta, wires=[0])
@@ -76,9 +77,10 @@ class TestComparison:
 
         qnode_res, qnode_def_res, grad_res, grad_def_res = benchmark(workload)
 
-        assert np.allclose(qnode_res, qnode_def_res, atol=tol(dev.shots))
-        assert np.allclose(grad_res, grad_def_res, atol=tol(dev.shots))
+        assert pnp.allclose(qnode_res, qnode_def_res, atol=tol(dev.shots))
+        assert pnp.allclose(grad_res, grad_def_res, atol=tol(dev.shots))
 
+    @pytest.mark.tier0
     @pytest.mark.parametrize(
         "state",
         [
@@ -90,10 +92,10 @@ class TestComparison:
             [0, 1, 0, 0],
             [0, 0, 1, 0],
             [0, 0, 0, 1],
-            np.array([1, 1, 0, 0]) / np.sqrt(2),
-            np.array([0, 1, 0, 1]) / np.sqrt(2),
-            np.array([1, 1, 1, 0]) / np.sqrt(3),
-            np.array([1, 1, 1, 1]) / 2,
+            pnp.array([1, 1, 0, 0]) / pnp.sqrt(2),
+            pnp.array([0, 1, 0, 1]) / pnp.sqrt(2),
+            pnp.array([1, 1, 1, 0]) / pnp.sqrt(3),
+            pnp.array([1, 1, 1, 1]) / 2,
         ],
     )
     def test_projector_expectation(self, device, state, tol, benchmark):
@@ -102,13 +104,13 @@ class TestComparison:
         dev = device(n_wires)
         dev_def = qml.device("default.qubit", wires=n_wires)
 
-        if dev.shots is not None:
+        if dev.shots:
             pytest.skip("Device is in non-analytical mode.")
 
-        if "Projector" not in dev.observables:
+        if isinstance(dev, qml.Device) and "Projector" not in dev.observables:
             pytest.skip("Device does not support the Projector observable.")
 
-        if dev.name == dev_def.name:
+        if dev.name == "default.qubit":
             pytest.skip("Device is default.qubit.")
 
         theta = 0.432
@@ -136,9 +138,10 @@ class TestComparison:
 
         qnode_res, qnode_def_res, grad_res, grad_def_res = benchmark(workload)
 
-        assert np.allclose(qnode_res, qnode_def_res, atol=tol(dev.shots))
-        assert np.allclose(grad_res, grad_def_res, atol=tol(dev.shots))
+        assert pnp.allclose(qnode_res, qnode_def_res, atol=tol(dev.shots))
+        assert pnp.allclose(grad_res, grad_def_res, atol=tol(dev.shots))
 
+    @pytest.mark.tier1
     def test_pauliz_expectation_analytic(self, device, tol):
         """Test that the tensor product of PauliZ expectation value is correct"""
         n_wires = 2
@@ -148,7 +151,7 @@ class TestComparison:
         if dev.name == dev_def.name:
             pytest.skip("Device is default.qubit.")
 
-        supports_tensor = (
+        supports_tensor = isinstance(dev, qml.devices.Device) or (
             "supports_tensor_observables" in dev.capabilities()
             and dev.capabilities()["supports_tensor_observables"]
         )
@@ -156,7 +159,7 @@ class TestComparison:
         if not supports_tensor:
             pytest.skip("Device does not support tensor observables.")
 
-        if dev.shots is not None:
+        if dev.shots:
             pytest.skip("Device is in non-analytical mode.")
 
         theta = 0.432
@@ -174,9 +177,10 @@ class TestComparison:
         grad_def = qml.grad(qnode_def, argnum=[0, 1])
         grad = qml.grad(qnode, argnum=[0, 1])
 
-        assert np.allclose(qnode(theta, phi), qnode_def(theta, phi), atol=tol(dev.shots))
-        assert np.allclose(grad(theta, phi), grad_def(theta, phi), atol=tol(dev.shots))
+        assert pnp.allclose(qnode(theta, phi), qnode_def(theta, phi), atol=tol(dev.shots))
+        assert pnp.allclose(grad(theta, phi), grad_def(theta, phi), atol=tol(dev.shots))
 
+    @pytest.mark.tier1
     @pytest.mark.parametrize("ret", ["expval", "var"])
     def test_random_circuit(self, device, tol, ret):
         """Compare the result of a random circuit to default.qubit"""
@@ -187,7 +191,7 @@ class TestComparison:
         if dev.name == dev_def.name:
             pytest.skip("Device is default.qubit.")
 
-        supports_tensor = (
+        supports_tensor = isinstance(dev, qml.devices.Device) or (
             "supports_tensor_observables" in dev.capabilities()
             and dev.capabilities()["supports_tensor_observables"]
         )
@@ -195,11 +199,11 @@ class TestComparison:
         if not supports_tensor:
             pytest.skip("Device does not support tensor observables.")
 
-        if dev.shots is not None:
+        if dev.shots:
             pytest.skip("Device is in non-analytical mode.")
 
-        n_layers = np.random.randint(1, 5)
-        weights = 2 * np.pi * np.random.rand(n_layers, 1)
+        n_layers = pnp.random.randint(1, 5)
+        weights = 2 * pnp.pi * pnp.random.rand(n_layers, 1)
 
         ret_type = getattr(qml, ret)
 
@@ -213,19 +217,20 @@ class TestComparison:
         grad_def = qml.grad(qnode_def, argnum=0)
         grad = qml.grad(qnode, argnum=0)
 
-        assert np.allclose(qnode(weights), qnode_def(weights), atol=tol(dev.shots))
-        assert np.allclose(grad(weights), grad_def(weights), atol=tol(dev.shots))
+        assert pnp.allclose(qnode(weights), qnode_def(weights), atol=tol(dev.shots))
+        assert pnp.allclose(grad(weights), grad_def(weights), atol=tol(dev.shots))
 
+    @pytest.mark.tier1
     def test_four_qubit_random_circuit(self, device, tol):
         """Compare a four-qubit random circuit with lots of different gates to default.qubit"""
         n_wires = 4
         dev = device(n_wires)
-        dev_def = qml.device("default.qubit", wires=n_wires)
+        dev_def = qml.device("default.qubit")
 
         if dev.name == dev_def.name:
             pytest.skip("Device is default.qubit.")
 
-        if dev.shots is not None:
+        if dev.shots:
             pytest.skip("Device is in non-analytical mode.")
 
         gates = [
@@ -252,13 +257,13 @@ class TestComparison:
         ]
 
         layers = 3
-        np.random.seed(1967)
-        gates_per_layers = [np.random.permutation(gates).numpy() for _ in range(layers)]
+        pnp.random.seed(1967)
+        gates_per_layers = [pnp.random.permutation(gates).numpy() for _ in range(layers)]
 
         def circuit():
             """4-qubit circuit with layers of randomly selected gates and random connections for
             multi-qubit gates."""
-            np.random.seed(1967)
+            pnp.random.seed(1967)
             for gates in gates_per_layers:
                 for gate in gates:
                     qml.apply(gate)
@@ -267,4 +272,4 @@ class TestComparison:
         qnode_def = qml.QNode(circuit, dev_def)
         qnode = qml.QNode(circuit, dev)
 
-        assert np.allclose(qnode(), qnode_def(), atol=tol(dev.shots))
+        assert pnp.allclose(qnode(), qnode_def(), atol=tol(dev.shots))

--- a/pennylane/devices/tests/test_gates_with_expval.py
+++ b/pennylane/devices/tests/test_gates_with_expval.py
@@ -40,6 +40,7 @@ class TestGatesQubitExpval:
     application of gates."""
 
     # This test checks two Z expvals
+    @pytest.mark.tier1
     @pytest.mark.parametrize(
         "par,wires,expected_output",
         [([1, 1], [0, 1], [-1, -1]), ([1], [0], [-1, 1]), ([1], [1], [1, -1])],
@@ -57,6 +58,7 @@ class TestGatesQubitExpval:
         assert np.allclose(circuit(), expected_output, atol=tol(dev.shots))
 
     # This test checks three Z expvals
+    @pytest.mark.tier1
     @pytest.mark.parametrize(
         "par,wires,expected_output",
         [
@@ -89,6 +91,7 @@ class TestGatesQubitExpval:
         assert np.allclose(circuit(), expected_output, atol=tol(dev.shots))
 
     # This test uses initial state |0> and checks one Z expval
+    @pytest.mark.tier1
     @pytest.mark.parametrize(
         "name,par,expected_output",
         [
@@ -151,6 +154,7 @@ class TestGatesQubitExpval:
         assert np.isclose(circuit(), expected_output, atol=tol(dev.shots))
 
     # This test uses initial state 1/2|00>+sqrt(3)/2|11> and checks two Z expvals
+    @pytest.mark.tier1
     @pytest.mark.parametrize(
         "name,par,expected_output",
         [
@@ -220,6 +224,7 @@ class TestGatesQubitExpval:
         assert np.allclose(circuit(), expected_output, atol=tol(dev.shots))
 
     # This test uses initial state |0> and checks one Z expval
+    @pytest.mark.tier1
     @pytest.mark.parametrize(
         "name,expected_output",
         [
@@ -244,6 +249,7 @@ class TestGatesQubitExpval:
         assert np.isclose(circuit(), expected_output, atol=tol(dev.shots))
 
     # This test uses initial state |Phi+> and checks two Z expvals
+    @pytest.mark.tier1
     @pytest.mark.parametrize(
         "name,expected_output",
         [
@@ -258,7 +264,7 @@ class TestGatesQubitExpval:
         dev = device(n_wires)
 
         op = getattr(qml.ops, name)
-        if not dev.supports_operation(op):
+        if isinstance(dev, qml.Device) and not dev.supports_operation(op):
             pytest.skip("operation not supported")
 
         @qml.qnode(dev)
@@ -269,6 +275,7 @@ class TestGatesQubitExpval:
 
         assert np.allclose(circuit(), expected_output, atol=tol(dev.shots))
 
+    @pytest.mark.tier1
     @pytest.mark.parametrize(
         "name,expected_output",
         [

--- a/pennylane/devices/tests/test_measurements.py
+++ b/pennylane/devices/tests/test_measurements.py
@@ -100,37 +100,41 @@ def sub_routine(label_map):
 class TestSupportedObservables:
     """Test that the device can implement all observables that it supports."""
 
+    @pytest.mark.tier1
     @pytest.mark.parametrize("observable", all_obs)
     def test_supported_observables_can_be_implemented(self, device_kwargs, observable):
         """Test that the device can implement all its supported observables."""
         device_kwargs["wires"] = 3
         dev = qml.device(**device_kwargs)
 
-        if device_kwargs.get("shots", None) is not None and observable == "SparseHamiltonian":
+        if dev.shots and observable == "SparseHamiltonian":
             pytest.skip("SparseHamiltonian only supported in analytic mode")
 
-        assert hasattr(dev, "observables")
-        if observable in dev.observables:
-            kwargs = {"diff_method": "parameter-shift"} if observable == "SparseHamiltonian" else {}
+        if isinstance(dev, qml.Device):
+            assert hasattr(dev, "observables")
+            if observable not in dev.observables:
+                pytest.skip("observable not supported")
 
-            @qml.qnode(dev, **kwargs)
-            def circuit(obs_circ):
-                if dev.supports_operation(qml.PauliX):  # ionq can't have empty circuits
-                    qml.PauliX(0)
-                return qml.expval(obs_circ)
+        kwargs = {"diff_method": "parameter-shift"} if observable == "SparseHamiltonian" else {}
 
-            if observable == "Projector":
-                for o in obs[observable]:
-                    assert isinstance(circuit(o), (float, np.ndarray))
-            else:
-                assert isinstance(circuit(obs[observable]), (float, np.ndarray))
+        @qml.qnode(dev, **kwargs)
+        def circuit(obs_circ):
+            qml.PauliX(0)
+            return qml.expval(obs_circ)
 
+        if observable == "Projector":
+            for o in obs[observable]:
+                assert isinstance(circuit(o), (float, np.ndarray))
+        else:
+            assert isinstance(circuit(obs[observable]), (float, np.ndarray))
+
+    @pytest.mark.tier1
     def test_tensor_observables_can_be_implemented(self, device_kwargs):
         """Test that the device can implement a simple tensor observable.
         This test is skipped for devices that do not support tensor observables."""
         device_kwargs["wires"] = 2
         dev = qml.device(**device_kwargs)
-        supports_tensor = (
+        supports_tensor = isinstance(dev, qml.devices.Device) or (
             "supports_tensor_observables" in dev.capabilities()
             and dev.capabilities()["supports_tensor_observables"]
         )
@@ -139,8 +143,7 @@ class TestSupportedObservables:
 
         @qml.qnode(dev)
         def circuit():
-            if dev.supports_operation(qml.PauliX):  # ionq can't have empty circuits
-                qml.PauliX(0)
+            qml.PauliX(0)
             return qml.expval(qml.Identity(wires=0) @ qml.Identity(wires=1))
 
         assert isinstance(circuit(), (float, np.ndarray))
@@ -151,6 +154,7 @@ class TestSupportedObservables:
 class TestHamiltonianSupport:
     """Separate test to ensure that the device can differentiate Hamiltonian observables."""
 
+    @pytest.mark.tier0
     def test_hamiltonian_diff(self, device_kwargs, tol):
         """Tests a simple VQE gradient using parameter-shift rules."""
         device_kwargs["wires"] = 1
@@ -201,6 +205,7 @@ class TestHamiltonianSupport:
 class TestExpval:
     """Test expectation values"""
 
+    @pytest.mark.tier1
     def test_identity_expectation(self, device, tol):
         """Test that identity expectation value (i.e. the trace) is 1."""
         n_wires = 2
@@ -219,6 +224,7 @@ class TestExpval:
         res = circuit()
         assert np.allclose(res, np.array([1, 1]), atol=tol(dev.shots))
 
+    @pytest.mark.tier1
     def test_pauliz_expectation(self, device, tol):
         """Test that PauliZ expectation value is correct"""
         n_wires = 2
@@ -235,10 +241,10 @@ class TestExpval:
             return qml.expval(qml.PauliZ(wires=0)), qml.expval(qml.PauliZ(wires=1))
 
         res = circuit()
-        assert np.allclose(
-            res, np.array([np.cos(theta), np.cos(theta) * np.cos(phi)]), atol=tol(dev.shots)
-        )
+        expected = np.array([np.cos(theta), np.cos(theta) * np.cos(phi)])
+        assert np.allclose(res, expected, atol=tol(dev.shots))
 
+    @pytest.mark.tier1
     def test_paulix_expectation(self, device, tol):
         """Test that PauliX expectation value is correct"""
         n_wires = 2
@@ -258,6 +264,7 @@ class TestExpval:
         expected = np.array([np.sin(theta) * np.sin(phi), np.sin(phi)])
         assert np.allclose(res, expected, atol=tol(dev.shots))
 
+    @pytest.mark.tier1
     def test_pauliy_expectation(self, device, tol):
         """Test that PauliY expectation value is correct"""
         n_wires = 2
@@ -277,6 +284,7 @@ class TestExpval:
         expected = np.array([0.0, -np.cos(theta) * np.sin(phi)])
         assert np.allclose(res, expected, atol=tol(dev.shots))
 
+    @pytest.mark.tier1
     def test_hadamard_expectation(self, device, tol):
         """Test that Hadamard expectation value is correct"""
         n_wires = 2
@@ -298,12 +306,13 @@ class TestExpval:
         ) / np.sqrt(2)
         assert np.allclose(res, expected, atol=tol(dev.shots))
 
+    @pytest.mark.tier0
     def test_hermitian_expectation(self, device, tol):
         """Test that arbitrary Hermitian expectation values are correct"""
         n_wires = 2
         dev = device(n_wires)
 
-        if "Hermitian" not in dev.observables:
+        if isinstance(dev, qml.Device) and "Hermitian" not in dev.observables:
             pytest.skip("Skipped because device does not support the Hermitian observable.")
 
         theta = 0.432
@@ -327,12 +336,13 @@ class TestExpval:
 
         assert np.allclose(res, expected, atol=tol(dev.shots))
 
+    @pytest.mark.tier0
     def test_projector_expectation(self, device, tol):
         """Test that arbitrary Projector expectation values are correct"""
         n_wires = 2
         dev = device(n_wires)
 
-        if "Projector" not in dev.observables:
+        if isinstance(dev, qml.Device) and "Projector" not in dev.observables:
             pytest.skip("Skipped because device does not support the Projector observable.")
 
         theta = 0.732
@@ -365,12 +375,13 @@ class TestExpval:
         assert np.allclose(circuit(basis_state), expected, atol=tol(dev.shots))
         assert np.allclose(circuit(state_vector), expected, atol=tol(dev.shots))
 
+    @pytest.mark.tier0
     def test_multi_mode_hermitian_expectation(self, device, tol):
         """Test that arbitrary multi-mode Hermitian expectation values are correct"""
         n_wires = 2
         dev = device(n_wires)
 
-        if "Hermitian" not in dev.observables:
+        if isinstance(dev, qml.Device) and "Hermitian" not in dev.observables:
             pytest.skip("Skipped because device does not support the Hermitian observable.")
 
         theta = 0.432
@@ -410,11 +421,13 @@ class TestExpval:
 class TestTensorExpval:
     """Test tensor expectation values"""
 
+    @pytest.mark.tier1
     def test_paulix_pauliy(self, device, tol, skip_if):
         """Test that a tensor product involving PauliX and PauliY works correctly"""
         n_wires = 3
         dev = device(n_wires)
-        skip_if(dev, {"supports_tensor_observables": False})
+        if isinstance(dev, qml.Device):
+            skip_if(dev, {"supports_tensor_observables": False})
 
         theta = 0.432
         phi = 0.123
@@ -434,11 +447,13 @@ class TestTensorExpval:
         expected = np.sin(theta) * np.sin(phi) * np.sin(varphi)
         assert np.allclose(res, expected, atol=tol(dev.shots))
 
+    @pytest.mark.tier1
     def test_pauliz_hadamard(self, device, tol, skip_if):
         """Test that a tensor product involving PauliZ and PauliY and hadamard works correctly"""
         n_wires = 3
         dev = device(n_wires)
-        skip_if(dev, {"supports_tensor_observables": False})
+        if isinstance(dev, qml.Device):
+            skip_if(dev, {"supports_tensor_observables": False})
 
         theta = 0.432
         phi = 0.123
@@ -463,6 +478,7 @@ class TestTensorExpval:
         "base_obs, permuted_obs",
         list(zip(obs_lst, obs_permuted_lst)),
     )
+    @pytest.mark.tier1
     def test_wire_order_in_tensor_prod_observables(
         self, device, base_obs, permuted_obs, tol, skip_if
     ):
@@ -481,7 +497,8 @@ class TestTensorExpval:
         """
         n_wires = 3
         dev = device(n_wires)
-        skip_if(dev, {"supports_tensor_observables": False})
+        if isinstance(dev, qml.Device):
+            skip_if(dev, {"supports_tensor_observables": False})
 
         @qml.qnode(dev)
         def circ(ob):
@@ -490,6 +507,7 @@ class TestTensorExpval:
 
         assert np.allclose(circ(base_obs), circ(permuted_obs), atol=tol(dev.shots), rtol=0)
 
+    @pytest.mark.tier1
     @pytest.mark.parametrize("label_map", label_maps)
     def test_wire_label_in_tensor_prod_observables(self, device, label_map, tol, skip_if):
         """Test that when given a tensor observable the expectation value is the same regardless of how the
@@ -508,7 +526,8 @@ class TestTensorExpval:
         """
         dev = device(wires=3)
         dev_custom_labels = device(wires=label_map)
-        skip_if(dev, {"supports_tensor_observables": False})
+        if isinstance(dev, qml.Device):
+            skip_if(dev, {"supports_tensor_observables": False})
 
         def circ(wire_labels):
             sub_routine(wire_labels)
@@ -526,15 +545,17 @@ class TestTensorExpval:
             rtol=0,
         )
 
+    @pytest.mark.tier0
     def test_hermitian(self, device, tol, skip_if):
         """Test that a tensor product involving qml.Hermitian works correctly"""
         n_wires = 3
         dev = device(n_wires)
 
-        if "Hermitian" not in dev.observables:
-            pytest.skip("Skipped because device does not support the Hermitian observable.")
+        if isinstance(dev, qml.Device):
+            if "Hermitian" not in dev.observables:
+                pytest.skip("Skipped because device does not support the Hermitian observable.")
 
-        skip_if(dev, {"supports_tensor_observables": False})
+            skip_if(dev, {"supports_tensor_observables": False})
 
         theta = 0.432
         phi = 0.123
@@ -567,15 +588,17 @@ class TestTensorExpval:
         )
         assert np.allclose(res, expected, atol=tol(dev.shots))
 
+    @pytest.mark.tier0
     def test_projector(self, device, tol, skip_if):
         """Test that a tensor product involving qml.Projector works correctly"""
         n_wires = 3
         dev = device(n_wires)
 
-        if "Projector" not in dev.observables:
-            pytest.skip("Skipped because device does not support the Projector observable.")
+        if isinstance(dev, qml.Device):
+            if "Projector" not in dev.observables:
+                pytest.skip("Skipped because device does not support the Projector observable.")
 
-        skip_if(dev, {"supports_tensor_observables": False})
+            skip_if(dev, {"supports_tensor_observables": False})
 
         theta = 0.732
         phi = 0.523
@@ -618,14 +641,18 @@ class TestTensorExpval:
         assert np.allclose(circuit(basis_state), expected, atol=tol(dev.shots))
         assert np.allclose(circuit(state_vector), expected, atol=tol(dev.shots))
 
+    @pytest.mark.tier0
     def test_sparse_hamiltonian_expval(self, device, tol):
         """Test that expectation values of sparse Hamiltonians are properly calculated."""
         n_wires = 4
         dev = device(n_wires)
 
-        if "SparseHamiltonian" not in dev.observables:
-            pytest.skip("Skipped because device does not support the SparseHamiltonian observable.")
-        if dev.shots is not None:
+        if isinstance(dev, qml.Device):
+            if "SparseHamiltonian" not in dev.observables:
+                pytest.skip(
+                    "Skipped because device does not support the SparseHamiltonian observable."
+                )
+        if dev.shots:
             pytest.skip("SparseHamiltonian only supported in analytic mode")
 
         h_row = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
@@ -653,6 +680,7 @@ class TestTensorExpval:
 class TestSample:
     """Tests for the sample return type."""
 
+    @pytest.mark.tier1
     def test_sample_values(self, device, tol):
         """Tests if the samples returned by sample have
         the correct values
@@ -660,7 +688,7 @@ class TestSample:
         n_wires = 1
         dev = device(n_wires)
 
-        if dev.shots is None:
+        if not dev.shots:
             pytest.skip("Device is in analytic mode, cannot test sampling.")
 
         @qml.qnode(dev)
@@ -673,6 +701,7 @@ class TestSample:
         # res should only contain 1 and -1
         assert np.allclose(res**2, 1, atol=tol(False))
 
+    @pytest.mark.tier0
     def test_sample_values_hermitian(self, device, tol):
         """Tests if the samples of a Hermitian observable returned by sample have
         the correct values
@@ -680,10 +709,10 @@ class TestSample:
         n_wires = 1
         dev = device(n_wires)
 
-        if dev.shots is None:
+        if not dev.shots:
             pytest.skip("Device is in analytic mode, cannot test sampling.")
 
-        if "Hermitian" not in dev.observables:
+        if isinstance(dev, qml.Device) and "Hermitian" not in dev.observables:
             pytest.skip("Skipped because device does not support the Hermitian observable.")
 
         A_ = np.array([[1, 2j], [-2j, 0]])
@@ -709,6 +738,7 @@ class TestSample:
             np.var(res), 0.25 * (np.sin(theta) - 4 * np.cos(theta)) ** 2, atol=tol(False)
         )
 
+    @pytest.mark.tier0
     def test_sample_values_projector(self, device, tol):
         """Tests if the samples of a Projector observable returned by sample have
         the correct values
@@ -716,10 +746,10 @@ class TestSample:
         n_wires = 1
         dev = device(n_wires)
 
-        if dev.shots is None:
+        if not dev.shots:
             pytest.skip("Device is in analytic mode, cannot test sampling.")
 
-        if "Projector" not in dev.observables:
+        if isinstance(dev, qml.Device) and "Projector" not in dev.observables:
             pytest.skip("Skipped because device does not support the Projector observable.")
 
         theta = 0.543
@@ -757,6 +787,7 @@ class TestSample:
         assert np.allclose(np.mean(res), expected, atol=tol(False))
         assert np.allclose(np.var(res), expected - (expected) ** 2, atol=tol(False))
 
+    @pytest.mark.tier0
     def test_sample_values_hermitian_multi_qubit(self, device, tol):
         """Tests if the samples of a multi-qubit Hermitian observable returned by sample have
         the correct values
@@ -764,10 +795,10 @@ class TestSample:
         n_wires = 2
         dev = device(n_wires)
 
-        if dev.shots is None:
+        if not dev.shots:
             pytest.skip("Device is in analytic mode, cannot test sampling.")
 
-        if "Hermitian" not in dev.observables:
+        if isinstance(dev, qml.Device) and "Hermitian" not in dev.observables:
             pytest.skip("Skipped because device does not support the Hermitian observable.")
 
         theta = 0.543
@@ -806,6 +837,7 @@ class TestSample:
         ) / 32
         assert np.allclose(np.mean(res), expected, atol=tol(dev.shots))
 
+    @pytest.mark.tier0
     def test_sample_values_projector_multi_qubit(self, device, tol):
         """Tests if the samples of a multi-qubit Projector observable returned by sample have
         the correct values
@@ -813,10 +845,10 @@ class TestSample:
         n_wires = 2
         dev = device(n_wires)
 
-        if dev.shots is None:
+        if not dev.shots:
             pytest.skip("Device is in analytic mode, cannot test sampling.")
 
-        if "Projector" not in dev.observables:
+        if isinstance(dev, qml.Device) and "Projector" not in dev.observables:
             pytest.skip("Skipped because device does not support the Projector observable.")
 
         theta = 0.543
@@ -866,15 +898,17 @@ class TestSample:
 class TestTensorSample:
     """Test tensor sample values."""
 
+    @pytest.mark.tier1
     def test_paulix_pauliy(self, device, tol, skip_if):
         """Test that a tensor product involving PauliX and PauliY works correctly"""
         n_wires = 3
         dev = device(n_wires)
 
-        if dev.shots is None:
+        if not dev.shots:
             pytest.skip("Device is in analytic mode, cannot test sampling.")
 
-        skip_if(dev, {"supports_tensor_observables": False})
+        if isinstance(dev, qml.Device):
+            skip_if(dev, {"supports_tensor_observables": False})
 
         theta = 0.432
         phi = 0.123
@@ -909,15 +943,17 @@ class TestTensorSample:
         ) / 16
         assert np.allclose(var, expected, atol=tol(False))
 
+    @pytest.mark.tier1
     def test_pauliz_hadamard(self, device, tol, skip_if):
         """Test that a tensor product involving PauliZ and PauliY and hadamard works correctly"""
         n_wires = 3
         dev = device(n_wires)
 
-        if dev.shots is None:
+        if not dev.shots:
             pytest.skip("Device is in analytic mode, cannot test sampling.")
 
-        skip_if(dev, {"supports_tensor_observables": False})
+        if isinstance(dev, qml.Device):
+            skip_if(dev, {"supports_tensor_observables": False})
 
         theta = 0.432
         phi = 0.123
@@ -952,18 +988,20 @@ class TestTensorSample:
         ) / 4
         assert np.allclose(var, expected, atol=tol(False))
 
+    @pytest.mark.tier0
     def test_hermitian(self, device, tol, skip_if):
         """Test that a tensor product involving qml.Hermitian works correctly"""
         n_wires = 3
         dev = device(n_wires)
 
-        if dev.shots is None:
+        if not dev.shots:
             pytest.skip("Device is in analytic mode, cannot test sampling.")
 
-        if "Hermitian" not in dev.observables:
-            pytest.skip("Skipped because device does not support the Hermitian observable.")
+        if isinstance(dev, qml.Device):
+            if "Hermitian" not in dev.observables:
+                pytest.skip("Skipped because device does not support the Hermitian observable.")
 
-        skip_if(dev, {"supports_tensor_observables": False})
+            skip_if(dev, {"supports_tensor_observables": False})
 
         theta = 0.432
         phi = 0.123
@@ -1045,18 +1083,20 @@ class TestTensorSample:
         )
         assert np.allclose(var, expected, atol=tol(False))
 
+    @pytest.mark.tier0
     def test_projector(self, device, tol, skip_if):  # pylint: disable=too-many-statements
         """Test that a tensor product involving qml.Projector works correctly"""
         n_wires = 3
         dev = device(n_wires)
 
-        if dev.shots is None:
+        if not dev.shots:
             pytest.skip("Device is in analytic mode, cannot test sampling.")
 
-        if "Projector" not in dev.observables:
-            pytest.skip("Skipped because device does not support the Projector observable.")
+        if isinstance(dev, qml.Device):
+            if "Projector" not in dev.observables:
+                pytest.skip("Skipped because device does not support the Projector observable.")
 
-        skip_if(dev, {"supports_tensor_observables": False})
+            skip_if(dev, {"supports_tensor_observables": False})
 
         theta = 1.432
         phi = 1.123
@@ -1182,6 +1222,7 @@ class TestTensorSample:
 class TestVar:
     """Tests for the variance return type"""
 
+    @pytest.mark.tier1
     def test_var(self, device, tol):
         """Tests if the samples returned by sample have
         the correct values
@@ -1203,6 +1244,7 @@ class TestVar:
         expected = 0.25 * (3 - np.cos(2 * theta) - 2 * np.cos(theta) ** 2 * np.cos(2 * phi))
         assert np.allclose(res, expected, atol=tol(dev.shots))
 
+    @pytest.mark.tier0
     def test_var_hermitian(self, device, tol):
         """Tests if the samples of a Hermitian observable returned by sample have
         the correct values
@@ -1210,7 +1252,7 @@ class TestVar:
         n_wires = 2
         dev = device(n_wires)
 
-        if "Hermitian" not in dev.observables:
+        if isinstance(dev, qml.Device) and "Hermitian" not in dev.observables:
             pytest.skip("Skipped because device does not support the Hermitian observable.")
 
         phi = 0.543
@@ -1239,6 +1281,7 @@ class TestVar:
 
         assert np.allclose(res, expected, atol=tol(dev.shots))
 
+    @pytest.mark.tier0
     def test_var_projector(self, device, tol):
         """Tests if the samples of a Projector observable returned by sample have
         the correct values
@@ -1246,7 +1289,7 @@ class TestVar:
         n_wires = 2
         dev = device(n_wires)
 
-        if "Projector" not in dev.observables:
+        if isinstance(dev, qml.Device) and "Projector" not in dev.observables:
             pytest.skip("Skipped because device does not support the Projector observable.")
 
         phi = 0.543
@@ -1303,11 +1346,13 @@ class TestVar:
 class TestTensorVar:
     """Test tensor variance measurements."""
 
+    @pytest.mark.tier1
     def test_paulix_pauliy(self, device, tol, skip_if):
         """Test that a tensor product involving PauliX and PauliY works correctly"""
         n_wires = 3
         dev = device(n_wires)
-        skip_if(dev, {"supports_tensor_observables": False})
+        if isinstance(dev, qml.Device):
+            skip_if(dev, {"supports_tensor_observables": False})
 
         theta = 0.432
         phi = 0.123
@@ -1334,11 +1379,13 @@ class TestTensorVar:
         ) / 16
         assert np.allclose(res, expected, atol=tol(dev.shots))
 
+    @pytest.mark.tier1
     def test_pauliz_hadamard(self, device, tol, skip_if):
         """Test that a tensor product involving PauliZ and PauliY and hadamard works correctly"""
         n_wires = 3
         dev = device(n_wires)
-        skip_if(dev, {"supports_tensor_observables": False})
+        if isinstance(dev, qml.Device):
+            skip_if(dev, {"supports_tensor_observables": False})
 
         theta = 0.432
         phi = 0.123
@@ -1364,6 +1411,7 @@ class TestTensorVar:
         assert np.allclose(res, expected, atol=tol(dev.shots))
 
     # pylint: disable=too-many-arguments
+    @pytest.mark.tier1
     @pytest.mark.parametrize(
         "base_obs, permuted_obs",
         list(zip(obs_lst, obs_permuted_lst)),
@@ -1386,7 +1434,8 @@ class TestTensorVar:
         """
         n_wires = 3
         dev = device(n_wires)
-        skip_if(dev, {"supports_tensor_observables": False})
+        if isinstance(dev, qml.Device):
+            skip_if(dev, {"supports_tensor_observables": False})
 
         @qml.qnode(dev)
         def circ(ob):
@@ -1395,6 +1444,7 @@ class TestTensorVar:
 
         assert np.allclose(circ(base_obs), circ(permuted_obs), atol=tol(dev.shots), rtol=0)
 
+    @pytest.mark.tier1
     @pytest.mark.parametrize("label_map", label_maps)
     def test_wire_label_in_tensor_prod_observables(self, device, label_map, tol, skip_if):
         """Test that when given a tensor observable the variance is the same regardless of how the
@@ -1412,7 +1462,8 @@ class TestTensorVar:
         """
         dev = device(wires=3)
         dev_custom_labels = device(wires=label_map)
-        skip_if(dev, {"supports_tensor_observables": False})
+        if isinstance(dev, qml.Device):
+            skip_if(dev, {"supports_tensor_observables": False})
 
         def circ(wire_labels):
             sub_routine(wire_labels)
@@ -1430,15 +1481,17 @@ class TestTensorVar:
             rtol=0,
         )
 
+    @pytest.mark.tier0
     def test_hermitian(self, device, tol, skip_if):
         """Test that a tensor product involving qml.Hermitian works correctly"""
         n_wires = 3
         dev = device(n_wires)
 
-        if "Hermitian" not in dev.observables:
-            pytest.skip("Skipped because device does not support the Hermitian observable.")
+        if isinstance(dev, qml.Device):
+            if "Hermitian" not in dev.observables:
+                pytest.skip("Skipped because device does not support the Hermitian observable.")
 
-        skip_if(dev, {"supports_tensor_observables": False})
+            skip_if(dev, {"supports_tensor_observables": False})
 
         theta = 0.432
         phi = 0.123
@@ -1501,15 +1554,17 @@ class TestTensorVar:
 
         assert np.allclose(res, expected, atol=tol(dev.shots))
 
+    @pytest.mark.tier0
     def test_projector(self, device, tol, skip_if):
         """Test that a tensor product involving qml.Projector works correctly"""
         n_wires = 3
         dev = device(n_wires)
 
-        if "Projector" not in dev.observables:
-            pytest.skip("Skipped because device does not support the Projector observable.")
+        if isinstance(dev, qml.Device):
+            if "Projector" not in dev.observables:
+                pytest.skip("Skipped because device does not support the Projector observable.")
 
-        skip_if(dev, {"supports_tensor_observables": False})
+            skip_if(dev, {"supports_tensor_observables": False})
 
         theta = 0.432
         phi = 0.123
@@ -1594,20 +1649,21 @@ class TestTensorVar:
 
 def _skip_test_for_braket(dev):
     """Skip the specific test because the Braket plugin does not yet support custom measurement processes."""
-    if "braket" in dev.short_name:
+    if "braket" in getattr(dev, "short_name", dev.name):
         pytest.skip(f"Custom measurement test skipped for {dev.short_name}.")
 
 
 class TestSampleMeasurement:
     """Tests for the SampleMeasurement class."""
 
+    @pytest.mark.tier0
     def test_custom_sample_measurement(self, device):
         """Test the execution of a custom sampled measurement."""
 
         dev = device(2)
         _skip_test_for_braket(dev)
 
-        if dev.shots is None:
+        if not dev.shots:
             pytest.skip("Shots must be specified in the device to compute a sampled measurement.")
 
         class MyMeasurement(SampleMeasurement):
@@ -1624,11 +1680,12 @@ class TestSampleMeasurement:
         res = circuit()
         assert qml.math.allequal(res, [1, 1])
 
+    @pytest.mark.tier0
     def test_sample_measurement_without_shots(self, device):
         """Test that executing a sampled measurement with ``shots=None`` raises an error."""
         dev = device(2)
 
-        if dev.shots is not None:
+        if bool(dev.shots):
             pytest.skip("If shots!=None no error is raised.")
 
         class MyMeasurement(SampleMeasurement):
@@ -1642,14 +1699,14 @@ class TestSampleMeasurement:
             qml.PauliX(0)
             return MyMeasurement(wires=[0]), MyMeasurement(wires=[1])
 
-        with pytest.raises(
-            ValueError, match="Shots must be specified in the device to compute the measurement "
-        ):
+        with pytest.raises(Exception):
             circuit()
 
     def test_method_overriden_by_device(self, device):
         """Test that the device can override a measurement process."""
         dev = device(2)
+        if isinstance(dev, qml.devices.Device):
+            pytest.skip("test specific for old device interface.")
         _skip_test_for_braket(dev)
 
         if dev.shots is None:
@@ -1672,12 +1729,13 @@ class TestSampleMeasurement:
 class TestStateMeasurement:
     """Tests for the SampleMeasurement class."""
 
+    @pytest.mark.tier0
     def test_custom_state_measurement(self, device):
         """Test the execution of a custom state measurement."""
         dev = device(2)
         _skip_test_for_braket(dev)
 
-        if dev.shots is not None:
+        if bool(dev.shots):
             pytest.skip("Some plugins don't update state information when shots is not None.")
 
         class MyMeasurement(StateMeasurement):
@@ -1693,12 +1751,13 @@ class TestStateMeasurement:
 
         assert circuit() == 1
 
+    @pytest.mark.tier0
     def test_sample_measurement_with_shots(self, device):
         """Test that executing a state measurement with shots raises a warning."""
         dev = device(2)
         _skip_test_for_braket(dev)
 
-        if dev.shots is None:
+        if not dev.shots:
             pytest.skip("If shots=None no warning is raised.")
 
         class MyMeasurement(StateMeasurement):
@@ -1712,17 +1771,24 @@ class TestStateMeasurement:
             qml.PauliX(0)
             return MyMeasurement()
 
-        with pytest.warns(
-            UserWarning,
-            match="Requested measurement MyMeasurement with finite shots",
-        ):
-            circuit()
+        if isinstance(dev, qml.Device):
+            with pytest.warns(
+                UserWarning,
+                match="Requested measurement MyMeasurement with finite shots",
+            ):
+                circuit()
+        else:
+            with pytest.raises(qml.DeviceError):
+                circuit()
 
+    @pytest.mark.tier0
     def test_method_overriden_by_device(self, device):
         """Test that the device can override a measurement process."""
         dev = device(2)
 
         _skip_test_for_braket(dev)
+        if isinstance(dev, qml.devices.Device):
+            pytest.skip("test is specific to old device interface")
 
         @qml.qnode(dev, interface="autograd")
         def circuit():
@@ -1738,10 +1804,13 @@ class TestStateMeasurement:
 class TestCustomMeasurement:
     """Tests for the CustomMeasurement class."""
 
+    @pytest.mark.tier0
     def test_custom_measurement(self, device):
         """Test the execution of a custom measurement."""
         dev = device(2)
         _skip_test_for_braket(dev)
+        if dev.name == "default.qubit":
+            pytest.xfail("need to add support for this.")
 
         class MyMeasurement(MeasurementTransform):
             """Dummy measurement transform."""
@@ -1756,9 +1825,12 @@ class TestCustomMeasurement:
 
         assert circuit() == 1
 
+    @pytest.mark.tier0
     def test_method_overriden_by_device(self, device):
         """Test that the device can override a measurement process."""
         dev = device(2)
+        if isinstance(dev, qml.devices.Device):
+            pytest.skip("test specific to old device interface.")
         _skip_test_for_braket(dev)
 
         if dev.shots is None:

--- a/pennylane/devices/tests/test_properties.py
+++ b/pennylane/devices/tests/test_properties.py
@@ -16,7 +16,6 @@
 import pytest
 import pennylane.numpy as pnp
 import pennylane as qml
-from pennylane._device import DeviceError
 
 
 try:
@@ -71,6 +70,8 @@ class TestDeviceProperties:
         device_kwargs["shots"] = 1234
 
         dev = qml.device(**device_kwargs)
+        if isinstance(dev, qml.devices.Device):
+            pytest.skip("test is old interface specific.")
         assert dev.num_wires == 2
         assert dev.shots == 1234
         assert dev.short_name == device_kwargs["name"]
@@ -78,7 +79,9 @@ class TestDeviceProperties:
     def test_no_wires_given(self, device_kwargs):
         """Test that the device requires correct arguments."""
         with pytest.raises(TypeError, match="missing 1 required positional argument"):
-            qml.device(**device_kwargs)
+            dev = qml.device(**device_kwargs)
+            if isinstance(dev, qml.devices.Device):
+                pytest.skip("test is old interface specific.")
 
     def test_no_0_shots(self, device_kwargs):
         """Test that non-analytic devices cannot accept 0 shots."""
@@ -86,8 +89,10 @@ class TestDeviceProperties:
         device_kwargs["wires"] = 2
         device_kwargs["shots"] = 0
 
-        with pytest.raises(DeviceError, match="The specified number of shots needs to be"):
-            qml.device(**device_kwargs)
+        with pytest.raises(Exception):  # different types of error based on interface
+            dev = qml.device(**device_kwargs)
+            if isinstance(dev, qml.devices.Device):
+                pytest.skip("test is old interface specific.")
 
 
 class TestCapabilities:
@@ -97,6 +102,8 @@ class TestCapabilities:
         """Test that the device class has a capabilities() method returning a dictionary."""
         device_kwargs["wires"] = 1
         dev = qml.device(**device_kwargs)
+        if isinstance(dev, qml.devices.Device):
+            pytest.skip("test is old interface specific.")
         cap = dev.capabilities()
         assert isinstance(cap, dict)
 
@@ -104,6 +111,8 @@ class TestCapabilities:
         """Test that the capabilities dictionary defines a valid model."""
         device_kwargs["wires"] = 1
         dev = qml.device(**device_kwargs)
+        if isinstance(dev, qml.devices.Device):
+            pytest.skip("test is old interface specific.")
         cap = dev.capabilities()
         assert "model" in cap
         assert cap["model"] in ["qubit", "cv"]
@@ -129,6 +138,8 @@ class TestCapabilities:
         """Test that the capabilities dictionary defines a valid passthru interface, if not None."""
         device_kwargs["wires"] = 1
         dev = qml.device(**device_kwargs)
+        if isinstance(dev, qml.devices.Device):
+            pytest.skip("test is old interface specific.")
         cap = dev.capabilities()
 
         if "passthru_interface" not in cap:
@@ -178,6 +189,8 @@ class TestCapabilities:
         """Tests that the device reports correctly whether it supports tensor observables."""
         device_kwargs["wires"] = 2
         dev = qml.device(**device_kwargs)
+        if isinstance(dev, qml.devices.Device):
+            pytest.skip("test is old interface specific.")
         cap = dev.capabilities()
 
         if "supports_tensor_observables" not in cap:
@@ -202,6 +215,8 @@ class TestCapabilities:
         """Tests that the device reports correctly whether it supports returning the state."""
         device_kwargs["wires"] = 1
         dev = qml.device(**device_kwargs)
+        if isinstance(dev, qml.devices.Device):
+            pytest.skip("test is old interface specific.")
         cap = dev.capabilities()
 
         @qml.qnode(dev)
@@ -237,6 +252,8 @@ class TestCapabilities:
         """Tests that the device reports correctly whether it supports reversible differentiation."""
         device_kwargs["wires"] = 1
         dev = qml.device(**device_kwargs)
+        if isinstance(dev, qml.devices.Device):
+            pytest.skip("test is old interface specific.")
         cap = dev.capabilities()
 
         if "returns_probs" not in cap:
@@ -262,6 +279,8 @@ class TestCapabilities:
 
         device_kwargs["wires"] = 1
         dev = qml.device(**device_kwargs)
+        if isinstance(dev, qml.devices.Device):
+            pytest.skip("test is old interface specific.")
         cap = dev.capabilities()
 
         assert "supports_broadcasting" in cap

--- a/pennylane/devices/tests/test_return_system.py
+++ b/pennylane/devices/tests/test_return_system.py
@@ -34,6 +34,7 @@ class TestIntegrationMultipleReturns:
     measurements.
     """
 
+    @pytest.mark.tier1
     def test_multiple_expval(self, device):
         """Return multiple expvals."""
         n_wires = 2
@@ -53,12 +54,11 @@ class TestIntegrationMultipleReturns:
         assert isinstance(res, tuple)
         assert len(res) == 2
 
-        assert isinstance(res[0], np.ndarray)
-        assert res[0].shape == ()
+        assert isinstance(res[0], (float, np.ndarray))
 
-        assert isinstance(res[1], np.ndarray)
-        assert res[1].shape == ()
+        assert isinstance(res[1], (float, np.ndarray))
 
+    @pytest.mark.tier0
     def test_multiple_var(self, device):
         """Return multiple vars."""
         n_wires = 2
@@ -78,13 +78,12 @@ class TestIntegrationMultipleReturns:
         assert isinstance(res, tuple)
         assert len(res) == 2
 
-        assert isinstance(res[0], np.ndarray)
-        assert res[0].shape == ()
+        assert isinstance(res[0], (float, np.ndarray))
 
-        assert isinstance(res[1], np.ndarray)
-        assert res[1].shape == ()
+        assert isinstance(res[1], (float, np.ndarray))
 
-    def test_multiple_prob(self, device):  # pylint: disable=too-many-arguments
+    @pytest.mark.tier1
+    def test_multiple_prob(self, device):
         """Return multiple probs."""
 
         n_wires = 2
@@ -106,7 +105,8 @@ class TestIntegrationMultipleReturns:
         assert isinstance(res[1], np.ndarray)
         assert res[1].shape == (2**1,)
 
-    def test_mix_meas(self, device):  # pylint: disable=too-many-arguments
+    @pytest.mark.tier1
+    def test_mix_meas(self, device):
         """Return multiple different measurements."""
         n_wires = 2
         dev = device(n_wires)
@@ -129,11 +129,9 @@ class TestIntegrationMultipleReturns:
         assert isinstance(res[0], np.ndarray)
         assert res[0].shape == (2**1,)
 
-        assert isinstance(res[1], np.ndarray)
-        assert res[1].shape == ()
+        assert isinstance(res[1], (float, np.ndarray))
 
         assert isinstance(res[2], np.ndarray)
         assert res[2].shape == (2**1,)
 
-        assert isinstance(res[3], np.ndarray)
-        assert res[3].shape == ()
+        assert isinstance(res[3], (float, np.ndarray))

--- a/pennylane/devices/tests/test_tracker.py
+++ b/pennylane/devices/tests/test_tracker.py
@@ -21,61 +21,32 @@ import pennylane as qml
 class TestTracker:
     """Tests that the device uses a tracker attribute properly"""
 
+    @pytest.mark.tier2
     def test_tracker_initialization(self, device):
         """Tests a tracker instance is assigned at initialization."""
 
         dev = device(1)
 
-        if not dev.capabilities().get("supports_tracker", False):
+        if isinstance(dev, qml.Device) and not dev.capabilities().get("supports_tracker", False):
             pytest.skip("Device does not support a tracker")
 
         assert isinstance(dev.tracker, qml.Tracker)
 
-    def test_tracker_updated_in_execution_mode(self, device, mocker):
+    @pytest.mark.tier1
+    def test_tracker_updated_in_execution_mode(self, device):
         """Tests that device update and records during tracking mode"""
 
         dev = device(1)
 
-        if not dev.capabilities().get("supports_tracker", False):
+        if isinstance(dev, qml.Device) and not dev.capabilities().get("supports_tracker", False):
             pytest.skip("Device does not support a tracker")
 
         @qml.qnode(dev, diff_method="parameter-shift")
         def circ():
             return qml.expval(qml.PauliX(wires=[0]))
-
-        spy_update = mocker.spy(dev.tracker, "update")
-        spy_record = mocker.spy(dev.tracker, "record")
 
         dev.tracker.active = False
-        circ()
-
-        assert spy_update.call_count == 0
-        assert spy_record.call_count == 0
-
-        dev.tracker.active = True
-        circ()
-
-        assert spy_update.call_count == 1
-        assert spy_record.call_count == 1
-
-    def test_tracker_batch_execute(self, device, mocker):
-        """Asserts tracker updates and records upon both batch execute and standard execute."""
-
-        dev = device(1)
-
-        if not dev.capabilities().get("supports_tracker", False):
-            pytest.skip("Device does not support a tracker")
-
-        @qml.qnode(dev, diff_method="parameter-shift")
-        def circ():
-            return qml.expval(qml.PauliX(wires=[0]))
-
-        spy_update = mocker.spy(dev.tracker, "update")
-        spy_record = mocker.spy(dev.tracker, "record")
-
-        circ()
-        dev.tracker.active = True
-        dev.batch_execute([circ.qtape])
-
-        assert spy_update.call_count == 2
-        assert spy_record.call_count == 2
+        with dev.tracker:
+            circ()
+        assert dev.tracker.history["batches"] == [1]
+        assert dev.tracker.history["executions"] == [1]

--- a/pennylane/devices/tests/test_wires.py
+++ b/pennylane/devices/tests/test_wires.py
@@ -44,6 +44,7 @@ def make_simple_circuit_expval(device, wires):
 class TestWiresIntegration:
     """Test that the device integrates with PennyLane's wire management."""
 
+    @pytest.mark.tier1
     @pytest.mark.parametrize(
         "wires1, wires2",
         [

--- a/pennylane/measurements/measurements.py
+++ b/pennylane/measurements/measurements.py
@@ -313,7 +313,7 @@ class MeasurementProcess(ABC):
             return f"{self.return_type.value}(eigvals={self._eigvals}, wires={self.wires.tolist()})"
 
         # Todo: when tape is core the return type will always be taken from the MeasurementProcess
-        return f"{self.return_type.value}(wires={self.wires.tolist()})"
+        return f"{getattr(self.return_type, 'value', 'None')}(wires={self.wires.tolist()})"
 
     def __copy__(self):
         cls = self.__class__


### PR DESCRIPTION
**Context:**

The current `pl-device-suite` some assumptions about the contents of the device test suite.  Most of those assumptions are around determining what the device supports or doesn't support, such as operations, measurements and other properties.

Because of that, we haven't yet adjusted the test suite to work with the device interface.

**Description of the Change:**

This PR runs `qml.Device` capabilities checks only if the device inherits from `qml.Device`.

It the divides the tests into three markers, `tier0`, `tier1`, and `tier2`.

`tier2` is just really basic "does this obey the interface" tests that any valid devices should test.
`tier1` includes tests I would consider "expected" for a qubit device. This includes expecation values, variance, probabilities, and most qubit operations.
`tier0` includes the features a device is least likely to support, like measuring Hermitians, Projectors, Sparse Hamiltonians, special operations, etc.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
