### PR TITLE
Do not decompose non-trainable operations in adjoint

### DIFF
--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -169,7 +169,11 @@ def adjoint_state_measurements(
 
 def adjoint_ops(op: qml.operation.Operator) -> bool:
     """Specify whether or not an Operator is supported by adjoint differentiation."""
-    return op.num_params == 0 or (op.num_params == 1 and op.has_generator)
+    return (
+        op.num_params == 0
+        or not qml.operation.is_trainable(op)
+        or (op.num_params == 1 and op.has_generator)
+    )
 
 
 def adjoint_observables(obs: qml.operation.Operator) -> bool:


### PR DESCRIPTION
**Context:**
The following code throws an error trying to decompose non-trainable `QubitUnitary`.
```
import pennylane as qml
from pennylane import numpy as pnp

@qml.qnode(qml.device("default.qubit", wires=3), diff_method="adjoint")
def circuit(x):
    qml.RX(x, 0)
    qml.QubitUnitary(np.eye(8), [0, 1, 2])
    return qml.expval(qml.PauliZ(2))

x = pnp.array(1.1, requires_grad=True)
qml.jacobian(circuit)(x)
```

**Description of the Change:**
Add `qml.operation.is_trainable` check to the stopping condition for adjoint ops.

**Benefits:**
Bug Fix

**Related GitHub Issues:**
https://github.com/PennyLaneAI/pennylane/issues/5217

**Related Shortcut Stories**
[sc-56905]