### PR TITLE
fix QubitDensityMatrix for subsystems with jit on default.mixed

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -601,6 +601,7 @@
 
 * `QubitDensityMatrix` now works with jax-jit on the `default.mixed` device.
   [(#5203)](https://github.com/PennyLaneAI/pennylane/pull/5203)
+  [()](https://github.com/PennyLaneAI/pennylane/pull/)
 
 <h3>Contributors ✍️</h3>
 

--- a/pennylane/devices/default_mixed.py
+++ b/pennylane/devices/default_mixed.py
@@ -573,7 +573,7 @@ class DefaultMixed(QubitDevice):
                     right_axes.append(index + self.num_wires)
             transpose_axes = left_axes + right_axes
             rho = qnp.transpose(rho, axes=transpose_axes)
-            assert qnp.allclose(
+            assert qml.math.is_abstract(rho) or qnp.allclose(
                 qnp.trace(qnp.reshape(rho, (2**self.num_wires, 2**self.num_wires))),
                 1.0,
                 atol=tolerance,

--- a/tests/devices/test_default_mixed_jax.py
+++ b/tests/devices/test_default_mixed_jax.py
@@ -89,10 +89,11 @@ class TestQNodeIntegration:
 
         assert np.allclose(state, expected, atol=tol, rtol=0)
 
-    def test_qubit_density_matrix_jit_compatible(self, mocker):
+    @pytest.mark.parametrize("n_qubits", [1, 2])
+    def test_qubit_density_matrix_jit_compatible(self, n_qubits, mocker):
         """Test that _apply_density_matrix works with jax-jit"""
 
-        dev = qml.device("default.mixed", wires=1)
+        dev = qml.device("default.mixed", wires=n_qubits)
         spy = mocker.spy(dev, "_apply_density_matrix")
 
         @jax.jit
@@ -106,7 +107,11 @@ class TestQNodeIntegration:
         rho_out = circuit(rho_ini)
         spy.assert_called_once()
         assert qml.math.get_interface(rho_out) == "jax"
-        assert np.array_equal(rho_out, [[1, 0], [0, 0]])
+
+        dim = 2**n_qubits
+        expected = np.zeros((dim, dim))
+        expected[0, 0] = 1.0
+        assert np.array_equal(rho_out, expected)
 
 
 class TestDtypePreserved:


### PR DESCRIPTION
I started this in #5203, but missed the case when it's only applied to a subset of the device wires. This handles that case now as well