### PR TITLE
[Bugfix] Make sure Identity, X, Y, Z have correct __name__ by default

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -633,6 +633,9 @@
 * When a QNode specifies `diff_method="adjoint"`, `default.qubit` no longer tries to decompose non-trainable operations with non-scalar parameters such as `QubitUnitary`.
   [(#5233)](https://github.com/PennyLaneAI/pennylane/pull/5233)
 
+* The overwriting of the class names of `I`, `X`, `Y`, and `Z` no longer happens in the init after causing problems with datasets. Now happens globally.
+  [(#5252)](https://github.com/PennyLaneAI/pennylane/pull/5252)
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane/ops/identity.py
+++ b/pennylane/ops/identity.py
@@ -55,7 +55,6 @@ class I(CVObservable, Operation):
         return tuple(), (self.wires, tuple())
 
     def __init__(self, wires=None, id=None):
-        self.__class__.__name__ = "Identity"
         super().__init__(wires=[] if wires is None else wires, id=id)
         self._hyperparameters = {"n_wires": len(self.wires)}
         self._pauli_rep = qml.pauli.PauliSentence({qml.pauli.PauliWord({}): 1.0})
@@ -196,6 +195,7 @@ class I(CVObservable, Operation):
     def pow(self, _):
         return [I(wires=self.wires)]
 
+I.__name__ = "Identity"
 
 Identity = I
 r"""

--- a/pennylane/ops/identity.py
+++ b/pennylane/ops/identity.py
@@ -195,6 +195,7 @@ class I(CVObservable, Operation):
     def pow(self, _):
         return [I(wires=self.wires)]
 
+
 I.__name__ = "Identity"
 
 Identity = I

--- a/pennylane/ops/qubit/non_parametric_ops.py
+++ b/pennylane/ops/qubit/non_parametric_ops.py
@@ -204,7 +204,6 @@ class X(Observable, Operation):
     _queue_category = "_ops"
 
     def __init__(self, *params, wires=None, id=None):
-        self.__class__.__name__ = "PauliX"
         super().__init__(*params, wires=wires, id=id)
         self._pauli_rep = qml.pauli.PauliSentence({qml.pauli.PauliWord({self.wires[0]: "X"}): 1.0})
 
@@ -344,6 +343,7 @@ class X(Observable, Operation):
         # X = RZ(-\pi/2) RY(\pi) RZ(\pi/2)
         return [np.pi / 2, np.pi, -np.pi / 2]
 
+X.__name__ = "PauliX"
 
 PauliX = X
 r"""
@@ -391,7 +391,6 @@ class Y(Observable, Operation):
     _queue_category = "_ops"
 
     def __init__(self, *params, wires=None, id=None):
-        self.__class__.__name__ = "PauliY"
         super().__init__(*params, wires=wires, id=id)
         self._pauli_rep = qml.pauli.PauliSentence({qml.pauli.PauliWord({self.wires[0]: "Y"}): 1.0})
 
@@ -530,6 +529,7 @@ class Y(Observable, Operation):
         # Y = RZ(0) RY(\pi) RZ(0)
         return [0.0, np.pi, 0.0]
 
+Y.__name__ = "PauliY"
 
 PauliY = Y
 r"""
@@ -575,7 +575,6 @@ class Z(Observable, Operation):
     _queue_category = "_ops"
 
     def __init__(self, *params, wires=None, id=None):
-        self.__class__.__name__ = "PauliZ"
         super().__init__(*params, wires=wires, id=id)
         self._pauli_rep = qml.pauli.PauliSentence({qml.pauli.PauliWord({self.wires[0]: "Z"}): 1.0})
 
@@ -716,6 +715,7 @@ class Z(Observable, Operation):
         # Z = RZ(\pi) RY(0) RZ(0)
         return [np.pi, 0.0, 0.0]
 
+Z.__name__ = "PauliZ"
 
 PauliZ = Z
 r"""

--- a/pennylane/ops/qubit/non_parametric_ops.py
+++ b/pennylane/ops/qubit/non_parametric_ops.py
@@ -343,6 +343,7 @@ class X(Observable, Operation):
         # X = RZ(-\pi/2) RY(\pi) RZ(\pi/2)
         return [np.pi / 2, np.pi, -np.pi / 2]
 
+
 X.__name__ = "PauliX"
 
 PauliX = X
@@ -529,6 +530,7 @@ class Y(Observable, Operation):
         # Y = RZ(0) RY(\pi) RZ(0)
         return [0.0, np.pi, 0.0]
 
+
 Y.__name__ = "PauliY"
 
 PauliY = Y
@@ -714,6 +716,7 @@ class Z(Observable, Operation):
     def single_qubit_rot_angles(self):
         # Z = RZ(\pi) RY(0) RZ(0)
         return [np.pi, 0.0, 0.0]
+
 
 Z.__name__ = "PauliZ"
 

--- a/tests/ops/qubit/test_non_parametric_ops.py
+++ b/tests/ops/qubit/test_non_parametric_ops.py
@@ -1246,17 +1246,18 @@ def test_pauli_rep(op, rep):
     # pylint: disable=protected-access
     assert op.pauli_rep == rep
 
+
 class TestPauliAlias:
     def test_X_class_name(self):
         """Test the class name of X is by default correct"""
         assert qml.X.__name__ == "PauliX"
         assert qml.PauliX.__name__ == "PauliX"
-    
+
     def test_Y_class_name(self):
         """Test the class name of Y is by default correct"""
         assert qml.Y.__name__ == "PauliY"
         assert qml.PauliY.__name__ == "PauliY"
-    
+
     def test_Z_class_name(self):
         """Test the class name of Z is by default correct"""
         assert qml.Z.__name__ == "PaulZ"

--- a/tests/ops/qubit/test_non_parametric_ops.py
+++ b/tests/ops/qubit/test_non_parametric_ops.py
@@ -1253,12 +1253,21 @@ class TestPauliAlias:
         assert qml.X.__name__ == "PauliX"
         assert qml.PauliX.__name__ == "PauliX"
 
+        assert qml.X(0).name == "PauliX"
+        assert qml.PauliX(0).name == "PauliX"
+
     def test_Y_class_name(self):
         """Test the class name of Y is by default correct"""
         assert qml.Y.__name__ == "PauliY"
         assert qml.PauliY.__name__ == "PauliY"
 
+        assert qml.Y(0).name == "PauliY"
+        assert qml.PauliY(0).name == "PauliY"
+
     def test_Z_class_name(self):
         """Test the class name of Z is by default correct"""
-        assert qml.Z.__name__ == "PaulZ"
+        assert qml.Z.__name__ == "PauliZ"
         assert qml.PauliZ.__name__ == "PauliZ"
+
+        assert qml.Z(0).name == "PauliZ"
+        assert qml.PauliZ(0).name == "PauliZ"

--- a/tests/ops/qubit/test_non_parametric_ops.py
+++ b/tests/ops/qubit/test_non_parametric_ops.py
@@ -1245,3 +1245,19 @@ op_pauli_rep = (
 def test_pauli_rep(op, rep):
     # pylint: disable=protected-access
     assert op.pauli_rep == rep
+
+class TestPauliAlias:
+    def test_X_class_name(self):
+        """Test the class name of X is by default correct"""
+        assert qml.X.__name__ == "PauliX"
+        assert qml.PauliX.__name__ == "PauliX"
+    
+    def test_Y_class_name(self):
+        """Test the class name of Y is by default correct"""
+        assert qml.Y.__name__ == "PauliY"
+        assert qml.PauliY.__name__ == "PauliY"
+    
+    def test_Z_class_name(self):
+        """Test the class name of Z is by default correct"""
+        assert qml.Z.__name__ == "PaulZ"
+        assert qml.PauliZ.__name__ == "PauliZ"

--- a/tests/ops/test_identity.py
+++ b/tests/ops/test_identity.py
@@ -32,11 +32,15 @@ class TestIdentity:
 
         new_op = Identity._unflatten(*op._flatten())
         assert qml.equal(op, new_op)
-
-    def test_class_name(self):
+    
+    def test_class_name(self, wires):
         """Test the class name of either I and Identity is by default 'Identity'"""
         assert qml.I.__name__ == "Identity"
         assert qml.Identity.__name__ == "Identity"
+
+        assert qml.I(wires).name == "Identity"
+        assert qml.Identity(wires).name == "Identity"
+
 
     @pytest.mark.jax
     def test_jax_pytree_integration(self, wires):

--- a/tests/ops/test_identity.py
+++ b/tests/ops/test_identity.py
@@ -32,9 +32,9 @@ class TestIdentity:
 
         new_op = Identity._unflatten(*op._flatten())
         assert qml.equal(op, new_op)
-    
+
     def test_class_name(self):
-        """Test the class name of either I and Identity is by default 'Identity' """
+        """Test the class name of either I and Identity is by default 'Identity'"""
         assert qml.I.__name__ == "Identity"
         assert qml.Identity.__name__ == "Identity"
 

--- a/tests/ops/test_identity.py
+++ b/tests/ops/test_identity.py
@@ -32,6 +32,11 @@ class TestIdentity:
 
         new_op = Identity._unflatten(*op._flatten())
         assert qml.equal(op, new_op)
+    
+    def test_class_name(self):
+        """Test the class name of either I and Identity is by default 'Identity' """
+        assert qml.I.__name__ == "Identity"
+        assert qml.Identity.__name__ == "Identity"
 
     @pytest.mark.jax
     def test_jax_pytree_integration(self, wires):

--- a/tests/ops/test_identity.py
+++ b/tests/ops/test_identity.py
@@ -32,7 +32,7 @@ class TestIdentity:
 
         new_op = Identity._unflatten(*op._flatten())
         assert qml.equal(op, new_op)
-    
+
     def test_class_name(self, wires):
         """Test the class name of either I and Identity is by default 'Identity'"""
         assert qml.I.__name__ == "Identity"
@@ -40,7 +40,6 @@ class TestIdentity:
 
         assert qml.I(wires).name == "Identity"
         assert qml.Identity(wires).name == "Identity"
-
 
     @pytest.mark.jax
     def test_jax_pytree_integration(self, wires):


### PR DESCRIPTION
Before, the overwriting of the class name happens in the initialization, which means that it is not overwritten until at least one class instance is initialized. This lead to problems in datasets. Fixed this by globally overwriting the class name instead.

Better long term solution:
Check for instances instead of class names (this is a bigger effort though as this happens in a lot of places in the codebase and, likely, plugins)