### PR TITLE
Incrementing the version number to `v0.36.0-dev`

### DIFF
--- a/doc/development/release_notes.md
+++ b/doc/development/release_notes.md
@@ -3,6 +3,8 @@ Release notes
 
 This page contains the release notes for PennyLane.
 
+.. mdinclude:: ../releases/changelog-dev.md
+
 .. mdinclude:: ../releases/changelog-0.35.0.md
 
 .. mdinclude:: ../releases/changelog-0.34.0.md

--- a/doc/development/release_notes.md
+++ b/doc/development/release_notes.md
@@ -3,7 +3,7 @@ Release notes
 
 This page contains the release notes for PennyLane.
 
-.. mdinclude:: ../releases/changelog-dev.md
+.. mdinclude:: ../releases/changelog-0.35.0.md
 
 .. mdinclude:: ../releases/changelog-0.34.0.md
 

--- a/doc/releases/changelog-0.34.0.md
+++ b/doc/releases/changelog-0.34.0.md
@@ -1,6 +1,6 @@
 :orphan:
 
-# Release 0.34.0 (current release)
+# Release 0.34.0
 
 <h3>New features since last release</h3>
 

--- a/doc/releases/changelog-0.35.0.md
+++ b/doc/releases/changelog-0.35.0.md
@@ -1,6 +1,6 @@
 :orphan:
 
-# Release 0.35.0-dev (development release)
+# Release 0.35.0 (current release)
 
 <h3>New features since last release</h3>
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1,0 +1,19 @@
+:orphan:
+
+# Release 0.36.0-dev (development release)
+
+<h3>New features since last release</h3>
+
+<h3>Improvements 🛠</h3>
+
+<h3>Breaking changes 💔</h3>
+
+<h3>Deprecations 👋</h3>
+
+<h3>Documentation 📝</h3>
+
+<h3>Bug fixes 🐛</h3>
+
+<h3>Contributors ✍️</h3>
+
+This release contains contributions from (in alphabetical order):

--- a/pennylane/_version.py
+++ b/pennylane/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.35.0"
+__version__ = "0.36.0-dev"

--- a/pennylane/_version.py
+++ b/pennylane/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.35.0-dev"
+__version__ = "0.35.0"


### PR DESCRIPTION
**Must not be merged before the creation of the release candidate branch 0.35.0**

Updates PennyLane as we're entering a new development version (release of v0.35.0 coming up):

- Create changelog-dev.md
- Add changelog-dev.md to release-notes.md
- Increments the version number to v0.36.0-dev


```
rc    master
|     |
|     - (**THIS PR**)add changelog-dev.md, add changelog-dev reference to release_notes.md, bump version to 0.36.0-dev
|    /
|   /
|  /
| /
|/
- rename changelog-dev.md to changelog-0.35.0.md, change changelog-dev reference to changelog-0.35 reference in release_notes.md, move "current release" label from changelog-0.34 to changelog-0.35, change version from 0.35.0-dev to 0.25.0
|
| 
```