### PR TITLE
Fix type hints for loading Qiskit circuits with a single measurement

### DIFF
--- a/pennylane/io.py
+++ b/pennylane/io.py
@@ -115,9 +115,10 @@ def from_qiskit(quantum_circuit, measurements=None):
     >>>     return qml.expval(qml.Z(0))
 
     Args:
-        quantum_circuit (qiskit.QuantumCircuit): a quantum circuit created in qiskit
-        measurements (list[MeasurementProcess]): the list of PennyLane measurements that
-            overrides the terminal measurements that may be present in the input circuit.
+        quantum_circuit (qiskit.QuantumCircuit): a quantum circuit created in Qiskit
+        measurements (None | MeasurementProcess | list[MeasurementProcess]): the PennyLane
+            measurements that override the terminal measurements that may be present in the input
+            circuit
 
     Returns:
         function: the PennyLane template created based on the ``QuantumCircuit`` object


### PR DESCRIPTION
This PR updates the `from_qiskit()` docstring to match the changes in PennyLaneAI/pennylane-qiskit#466.

This communicates that it is now possible to load a Qiskit circuit from PennyLane using
```python
qml.from_qiskit(qc, measurements=qml.expval(qml.PauliZ(0)))
```
instead of
```python
qml.from_qiskit(qc, measurements=[qml.expval(qml.PauliZ(0))])
```