### PR TITLE
only run doc freeze on non-fork PRs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,16 +37,8 @@ jobs:
             && pip freeze | grep -v 'file:///' > .github/stable/doc.txt.tmp
         build-command: "sphinx-build -b html . _build -W --keep-going"
 
-    - name: Check if organization member
-      id: is_organization_member
-      uses: JamesSingleton/is-organization-member@1.0.1
-      with:
-        organization: PennyLaneAI
-        username: ${{ github.actor }}
-        token: ${{ secrets.GITHUB_TOKEN }}
-
     - name: Prepare local repo
-      if: steps.is_organization_member.outputs.result == 'true'
+      if: github.event.pull_request.head.repo.full_name == 'PennyLaneAI/pennylane'
       run: |
         git fetch
         git config user.name "GitHub Actions Bot"
@@ -61,13 +53,13 @@ jobs:
         mv -f .github/stable/doc.txt.tmp .github/stable/doc.txt
 
     - name: Determine if changes have been made
-      if: steps.is_organization_member.outputs.result == 'true'
+      if: github.event.pull_request.head.repo.full_name == 'PennyLaneAI/pennylane'
       id: changed
       run: |
         echo "has_changes=$(git status --porcelain | wc -l | awk '{print $1}')" >> $GITHUB_OUTPUT
 
     - name: Stage changes
-      if: steps.is_organization_member.outputs.result == 'true' && steps.changed.outputs.has_changes != '0'
+      if: github.event.pull_request.head.repo.full_name == 'PennyLaneAI/pennylane' && steps.changed.outputs.has_changes != '0'
       run: |
         git add .github/stable/doc.txt
         git commit -m "Update stable docs dependencies"
@@ -75,7 +67,7 @@ jobs:
 
     # Create PR to master
     - name: Create pull request
-      if: steps.is_organization_member.outputs.result == 'true' && steps.changed.outputs.has_changes != '0'
+      if: github.event.pull_request.head.repo.full_name == 'PennyLaneAI/pennylane' && steps.changed.outputs.has_changes != '0'
       uses: repo-sync/pull-request@v2
       with:
         source_branch: "${{ env.DEPS_BRANCH }}"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,7 +37,16 @@ jobs:
             && pip freeze | grep -v 'file:///' > .github/stable/doc.txt.tmp
         build-command: "sphinx-build -b html . _build -W --keep-going"
 
+    - name: Check if organization member
+      id: is_organization_member
+      uses: JamesSingleton/is-organization-member@1.0.1
+      with:
+        organization: PennyLaneAI
+        username: ${{ github.actor }}
+        token: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Prepare local repo
+      if: steps.is_organization_member.outputs.result == 'true'
       run: |
         git fetch
         git config user.name "GitHub Actions Bot"
@@ -52,12 +61,13 @@ jobs:
         mv -f .github/stable/doc.txt.tmp .github/stable/doc.txt
 
     - name: Determine if changes have been made
+      if: steps.is_organization_member.outputs.result == 'true'
       id: changed
       run: |
         echo "has_changes=$(git status --porcelain | wc -l | awk '{print $1}')" >> $GITHUB_OUTPUT
 
     - name: Stage changes
-      if: steps.changed.outputs.has_changes != '0'
+      if: steps.is_organization_member.outputs.result == 'true' && steps.changed.outputs.has_changes != '0'
       run: |
         git add .github/stable/doc.txt
         git commit -m "Update stable docs dependencies"
@@ -65,7 +75,7 @@ jobs:
 
     # Create PR to master
     - name: Create pull request
-      if: steps.changed.outputs.has_changes != '0'
+      if: steps.is_organization_member.outputs.result == 'true' && steps.changed.outputs.has_changes != '0'
       uses: repo-sync/pull-request@v2
       with:
         source_branch: "${{ env.DEPS_BRANCH }}"


### PR DESCRIPTION
**Context:**
PRs on forks fail the docs CI when trying to upload freeze changes, so I'd like to just skip that part if the PR is from a fork.

**Description of the Change:**
Skip those steps if on a fork, as described [here](https://github.com/orgs/community/discussions/25217).

**Benefits:**
External contributor PRs won't fail unexpectedly

**Possible Drawbacks:**
N/A - it will run often enough by us internally that the docs freeze file will be kept up-to-date regardless

**Related GitHub Issues:**
- Example failure: https://github.com/PennyLaneAI/pennylane/actions/runs/8039250831/job/21956066233?pr=5256
- Confirmed it skips on forks: https://github.com/PennyLaneAI/pennylane/actions/runs/8071064111/job/22049837508?pr=5272