### PR TITLE
BugFix: adjoint metric tensor with jax

### DIFF
--- a/doc/releases/changelog-0.35.0.md
+++ b/doc/releases/changelog-0.35.0.md
@@ -652,6 +652,9 @@
 * The overwriting of the class names of `I`, `X`, `Y`, and `Z` no longer happens in the init after causing problems with datasets. Now happens globally.
   [(#5252)](https://github.com/PennyLaneAI/pennylane/pull/5252)
 
+* The `adjoint_metric_tensor` transform now works with `jax`.
+  [(#5271)](https://github.com/PennyLaneAI/pennylane/pull/5271)
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane/gradients/adjoint_metric_tensor.py
+++ b/pennylane/gradients/adjoint_metric_tensor.py
@@ -31,19 +31,15 @@ def _reshape_real_imag(state, dim):
     return qml.math.real(state), qml.math.imag(state)
 
 
-def _group_operations(tape, argnums):
+def _group_operations(tape):
     """Divide all operations of a tape into trainable operations and blocks
     of untrainable operations after each trainable one."""
 
     # Extract tape operations list
     ops = tape.operations
     # Find the indices of trainable operations in the tape operations list
-    if argnums is None:
-        argnums = tape.trainable_params
-    elif isinstance(argnums, int):
-        argnums = [argnums]
     # pylint: disable=protected-access
-    trainable_par_info = [tape._par_info[i] for i in argnums]
+    trainable_par_info = [tape._par_info[i] for i in tape.trainable_params]
     trainables = [info["op_idx"] for info in trainable_par_info]
     # Add the indices incremented by one to the trainable indices
     split_ids = list(chain.from_iterable([idx, idx + 1] for idx in trainables))
@@ -80,9 +76,7 @@ def _expand_trainable_multipar(
     is_informative=True,
     use_argnum_in_expand=True,
 )
-def adjoint_metric_tensor(
-    tape: qml.tape.QuantumTape, argnums=None
-) -> (Sequence[qml.tape.QuantumTape], Callable):
+def adjoint_metric_tensor(tape: qml.tape.QuantumTape) -> (Sequence[qml.tape.QuantumTape], Callable):
     r"""Implements the adjoint method outlined in
     `Jones <https://arxiv.org/abs/2011.02991>`__ to compute the metric tensor.
 
@@ -172,7 +166,7 @@ def adjoint_metric_tensor(
         # Divide all operations of a tape into trainable operations and blocks
         # of untrainable operations after each trainable one.
 
-        trainable_operations, group_after_trainable_op = _group_operations(tape, argnums)
+        trainable_operations, group_after_trainable_op = _group_operations(tape)
 
         dim = 2**tape.num_wires
         # generate and extract initial state

--- a/pennylane/gradients/adjoint_metric_tensor.py
+++ b/pennylane/gradients/adjoint_metric_tensor.py
@@ -42,6 +42,7 @@ def _group_operations(tape, argnums):
         argnums = tape.trainable_params
     elif isinstance(argnums, int):
         argnums = [argnums]
+    # pylint: disable=protected-access
     trainable_par_info = [tape._par_info[i] for i in argnums]
     trainables = [info["op_idx"] for info in trainable_par_info]
     # Add the indices incremented by one to the trainable indices

--- a/pennylane/transforms/__init__.py
+++ b/pennylane/transforms/__init__.py
@@ -330,6 +330,7 @@ from .tape_expand import (
     expand_trainable_multipar,
     create_expand_fn,
     create_decomp_expand_fn,
+    create_expand_trainable_multipar,
     set_decomposition,
 )
 from .transpile import transpile

--- a/pennylane/transforms/core/transform.py
+++ b/pennylane/transforms/core/transform.py
@@ -26,7 +26,7 @@ def transform(
     is_informative=False,
     final_transform=False,
     use_argnum_in_expand=False,
-):
+):  # pylint: disable=too-many-arguments
     """Generalizes a function that transforms tapes to work with additional circuit-like objects such as a
     :class:`~.QNode`.
 

--- a/pennylane/transforms/core/transform.py
+++ b/pennylane/transforms/core/transform.py
@@ -25,6 +25,7 @@ def transform(
     classical_cotransform=None,
     is_informative=False,
     final_transform=False,
+    use_argnum_in_expand=False,
 ):
     """Generalizes a function that transforms tapes to work with additional circuit-like objects such as a
     :class:`~.QNode`.
@@ -55,6 +56,8 @@ def transform(
             of the transform program and the tapes or qnode aren't executed.
         final_transform=False (bool): Whether or not the transform is terminal. If true the transform is queued at the end
             of the transform program. ``is_informative`` supersedes ``final_transform``.
+        use_argnum_in_expand=False (bool): Whether or not to use ``argnum`` of the tape to determine trainable parameters
+            during the expansion transform process.
 
     Returns:
 
@@ -187,4 +190,5 @@ def transform(
         classical_cotransform=classical_cotransform,
         is_informative=is_informative,
         final_transform=final_transform,
+        use_argnum_in_expand=use_argnum_in_expand,
     )

--- a/pennylane/transforms/core/transform_dispatcher.py
+++ b/pennylane/transforms/core/transform_dispatcher.py
@@ -71,6 +71,7 @@ class TransformDispatcher:
         classical_cotransform=None,
         is_informative=False,
         final_transform=False,
+        use_argnum_in_expand=False,
     ):  # pylint:disable=redefined-outer-name
         self._transform = transform
         self._expand_transform = expand_transform
@@ -79,6 +80,7 @@ class TransformDispatcher:
         # is_informative supersedes final_transform
         self._final_transform = is_informative or final_transform
         self._qnode_transform = self.default_qnode_transform
+        self._use_argnum_in_expand = use_argnum_in_expand
         functools.update_wrapper(self, transform)
 
     def __call__(self, *targs, **tkwargs):  # pylint: disable=too-many-return-statements
@@ -208,7 +210,11 @@ class TransformDispatcher:
         qnode = copy.copy(qnode)
 
         if self.expand_transform:
-            qnode.add_transform(TransformContainer(self._expand_transform, targs, tkwargs))
+            qnode.add_transform(
+                TransformContainer(
+                    self._expand_transform, targs, tkwargs, use_argnum=self._use_argnum_in_expand
+                )
+            )
         qnode.add_transform(
             TransformContainer(
                 self._transform,
@@ -382,6 +388,7 @@ class TransformContainer:
         classical_cotransform=None,
         is_informative=False,
         final_transform=False,
+        use_argnum=False,
     ):  # pylint:disable=redefined-outer-name,too-many-arguments
         self._transform = transform
         self._args = args or []
@@ -389,6 +396,7 @@ class TransformContainer:
         self._classical_cotransform = classical_cotransform
         self._is_informative = is_informative
         self._final_transform = is_informative or final_transform
+        self._use_argnum = use_argnum
 
     def __repr__(self):
         return f"<{self._transform.__name__}({self._args}, {self._kwargs})>"

--- a/pennylane/transforms/core/transform_program.py
+++ b/pennylane/transforms/core/transform_program.py
@@ -440,7 +440,8 @@ class TransformProgram:
         argnums_list = []
         for index, transform in enumerate(self):
             argnums = [0] if qnode.interface in ["jax", "jax-jit"] and argnums is None else argnums
-            if transform.classical_cotransform and argnums:
+            # pylint: disable=protected-access
+            if (transform._use_argnum or transform.classical_cotransform) and argnums:
                 params = qml.math.jax_argnums_to_tape_trainable(
                     qnode, argnums, TransformProgram(self[0:index]), args, kwargs
                 )

--- a/pennylane/transforms/tape_expand.py
+++ b/pennylane/transforms/tape_expand.py
@@ -163,6 +163,31 @@ expand_trainable_multipar = create_expand_fn(
     docstring=_expand_trainable_multipar_doc,
 )
 
+
+def create_expand_trainable_multipar(tape, use_tape_argnum=False):
+    """Creates the expand_trainable_multipar expansion transform with an option to include argnums."""
+
+    if not use_tape_argnum:
+        return expand_trainable_multipar
+
+    trainable_par_info = [tape._par_info[i] for i in tape.trainable_params]
+    trainable_ops = [info["op"] for info in trainable_par_info]
+
+    @qml.BooleanFn
+    def _is_trainable(obj):
+        return obj in trainable_ops
+
+    return create_expand_fn(
+        depth=10,
+        stop_at=not_tape
+        | is_measurement
+        | has_nopar
+        | (~_is_trainable)
+        | (has_gen & ~gen_is_multi_term_hamiltonian),
+        docstring=_expand_trainable_multipar_doc,
+    )
+
+
 _expand_nonunitary_gen_doc = """Expand out a tape so that all its parametrized
 operations have a unitary generator.
 

--- a/pennylane/transforms/tape_expand.py
+++ b/pennylane/transforms/tape_expand.py
@@ -170,6 +170,7 @@ def create_expand_trainable_multipar(tape, use_tape_argnum=False):
     if not use_tape_argnum:
         return expand_trainable_multipar
 
+    # pylint: disable=protected-access
     trainable_par_info = [tape._par_info[i] for i in tape.trainable_params]
     trainable_ops = [info["op"] for info in trainable_par_info]
 

--- a/tests/gradients/core/test_adjoint_metric_tensor.py
+++ b/tests/gradients/core/test_adjoint_metric_tensor.py
@@ -400,7 +400,6 @@ class TestAdjointMetricTensorQNode:
             assert qml.math.allclose(mt, expected)
 
     @pytest.mark.jax
-    @pytest.mark.skip("JAX does not support forward pass execution of the metric tensor.")
     @pytest.mark.parametrize("ansatz, params", list(zip(fubini_ansatze, fubini_params)))
     def test_correct_output_qnode_jax(self, ansatz, params):
         """Test that the output is correct when using JAX and
@@ -418,7 +417,7 @@ class TestAdjointMetricTensorQNode:
             ansatz(*params, dev.wires)
             return qml.expval(qml.PauliZ(0))
 
-        mt = qml.adjoint_metric_tensor(circuit)(*j_params)
+        mt = qml.adjoint_metric_tensor(circuit, argnums=list(range(len(j_params))))(*j_params)
 
         if isinstance(mt, tuple):
             assert all(qml.math.allclose(_mt, _exp) for _mt, _exp in zip(mt, expected))


### PR DESCRIPTION
**Context:**
The `adjoint_metric_tensor` transform does not work with jax variables because jax variables are not considered trainable parameters until they become tracers.

**Description of the Change:**
1. Add a custom expand transform to `adjoint_metric_tensor` that expands trainable parameters based on argnums.
2. Add an optional `use_argnum_in_expand` argument to transform programs to determine whether or not to perform `jax_argnums_to_tape_trainable` on the parameters.

**Benefits:**
BugFix

**Possible Drawbacks:**
Adding yet another keyword argument to `transform` may make code look messy.

**Related GitHub Issues:**
https://github.com/PennyLaneAI/pennylane/issues/5197

**Related Shortcut Stories:**
[sc-56734]
