### PR TITLE
Make mpl color for `Barrier` match style sheet

### DIFF
--- a/doc/releases/changelog-0.35.0.md
+++ b/doc/releases/changelog-0.35.0.md
@@ -553,6 +553,7 @@
 <h3>Bug fixes 🐛</h3>
 
 * Fixes a bug in the matplotlib drawer where the color of `Barrier` did not match the requested style.
+  [(#5276)](https://github.com/PennyLaneAI/pennylane/pull/5276)
 
 * `ctrl_decomp_zyz` is now differentiable.
   [(#5198)](https://github.com/PennyLaneAI/pennylane/pull/5198)

--- a/doc/releases/changelog-0.35.0.md
+++ b/doc/releases/changelog-0.35.0.md
@@ -552,6 +552,8 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Fixes a bug in the matplotlib drawer where the color of `Barrier` did not match the requested style.
+
 * `ctrl_decomp_zyz` is now differentiable.
   [(#5198)](https://github.com/PennyLaneAI/pennylane/pull/5198)
 

--- a/pennylane/drawer/tape_mpl.py
+++ b/pennylane/drawer/tape_mpl.py
@@ -125,8 +125,9 @@ def _(op: ops.Barrier, drawer, layer, _):
     mapped_wires = op.wires if len(op.wires) != 0 else list(range(drawer.n_wires))
     ymin = min(mapped_wires) - 0.5
     ymax = max(mapped_wires) + 0.5
-    drawer.ax.vlines(layer - 0.05, ymin=ymin, ymax=ymax)
-    drawer.ax.vlines(layer + 0.05, ymin=ymin, ymax=ymax)
+    # wasnt obeying the stylesheet for some reason, so we have to manually force the color to be the line color.
+    drawer.ax.vlines(layer - 0.05, ymin=ymin, ymax=ymax, color=mpl.pyplot.rcParams["lines.color"])
+    drawer.ax.vlines(layer + 0.05, ymin=ymin, ymax=ymax, color=mpl.pyplot.rcParams["lines.color"])
 
 
 @_add_operation_to_drawer.register
@@ -267,6 +268,7 @@ def _tape_mpl(tape, wire_order=None, show_all_wires=False, decimals=None, *, fig
     return drawer.fig, drawer.ax
 
 
+# pylint: disable=too-many-arguments
 def tape_mpl(
     tape, wire_order=None, show_all_wires=False, decimals=None, style=None, *, fig=None, **kwargs
 ):

--- a/pennylane/drawer/tape_mpl.py
+++ b/pennylane/drawer/tape_mpl.py
@@ -125,7 +125,8 @@ def _(op: ops.Barrier, drawer, layer, _):
     mapped_wires = op.wires if len(op.wires) != 0 else list(range(drawer.n_wires))
     ymin = min(mapped_wires) - 0.5
     ymax = max(mapped_wires) + 0.5
-    # wasnt obeying the stylesheet for some reason, so we have to manually force the color to be the line color.
+    # by default, uses rcParams['lines.color'] at time when displayed, not at time when added to figure
+    # so we have to force it to use the value at the time the line was added to the figure
     drawer.ax.vlines(layer - 0.05, ymin=ymin, ymax=ymax, color=mpl.pyplot.rcParams["lines.color"])
     drawer.ax.vlines(layer + 0.05, ymin=ymin, ymax=ymax, color=mpl.pyplot.rcParams["lines.color"])
 

--- a/tests/drawer/test_tape_mpl.py
+++ b/tests/drawer/test_tape_mpl.py
@@ -19,6 +19,7 @@ page in the developement guide.
 # pylint: disable=protected-access, expression-not-assigned
 
 import pytest
+import numpy as np
 import pennylane as qml
 
 from pennylane.drawer import tape_mpl
@@ -382,6 +383,8 @@ class TestSpecialGates:
 
         assert len(ax.lines) == 3
         assert len(ax.collections) == 2
+        assert np.allclose(ax.collections[0].get_color(), np.array([[0.0, 0.0, 0.0, 1.0]]))  # black
+        assert np.allclose(ax.collections[0].get_color(), np.array([[0.0, 0.0, 0.0, 1.0]]))  # black
 
         plt.close()
 


### PR DESCRIPTION
For some reason the `qml.Barrier` operation was not being drawn with the correct `plt.rcParams['lines.color']`, but instead was still using the default value of `lines.color` (`'C0'`). 
<img width="404" alt="Screenshot 2024-02-28 at 10 24 46 AM" src="https://github.com/PennyLaneAI/pennylane/assets/6364575/1afa99f7-e0fa-49ad-8dfb-704edbae84bb">

I think the color of the vertical lines is decided when the lines are displayed, not when the lines are added to the figure.

As this shows the lines in black:
```
plt.rcParams['lines.color'] = "black"
_, ax = qml.drawer.tape_mpl(tape, style="rcParams")
```

but this shows them in blue.  Which is a strange departure from how other things seem to work in matplotlib.
```
plt.rcParams['lines.color'] = "black"
_, ax = qml.drawer.tape_mpl(tape, style="rcParams")
plt.rcParams['lines.color'] = "blue"
```

Anyway, we just force the color of that lines to match `plt.rcParams['lines.color']` when we add them to the drawer, and we are good.

<img width="399" alt="Screenshot 2024-02-28 at 10 24 29 AM" src="https://github.com/PennyLaneAI/pennylane/assets/6364575/4d00eb66-d60b-4110-b489-6d049fb7335f">