### PR TITLE
Apply all user transforms before drawing

### DIFF
--- a/doc/releases/changelog-0.35.0.md
+++ b/doc/releases/changelog-0.35.0.md
@@ -553,6 +553,7 @@
 <h3>Bug fixes 🐛</h3>
 
 * `qml.draw` and `qml.draw_mpl` now apply all applied transforms before drawing.
+  [(#5277)](https://github.com/PennyLaneAI/pennylane/pull/5277/)
 
 * Fixes a bug in the matplotlib drawer where the color of `Barrier` did not match the requested style.
   [(#5276)](https://github.com/PennyLaneAI/pennylane/pull/5276)

--- a/doc/releases/changelog-0.35.0.md
+++ b/doc/releases/changelog-0.35.0.md
@@ -552,6 +552,8 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* `qml.draw` and `qml.draw_mpl` now apply all applied transforms before drawing.
+
 * `ctrl_decomp_zyz` is now differentiable.
   [(#5198)](https://github.com/PennyLaneAI/pennylane/pull/5198)
 

--- a/tests/drawer/test_draw_mpl.py
+++ b/tests/drawer/test_draw_mpl.py
@@ -424,3 +424,5 @@ def test_applied_transforms(device):
     assert len(ax.lines) == 1  # single wire used in tape
     assert len(ax.patches) == 1  # single pauli x gate
     assert len(ax.texts) == 2  # one wire label, one gate label
+
+    plt.close()

--- a/tests/drawer/test_draw_mpl.py
+++ b/tests/drawer/test_draw_mpl.py
@@ -398,3 +398,29 @@ def test_draw_mpl_with_control_in_adjoint():
     assert len(ax.lines) == 4  # three wires, one control
     assert len(ax.texts) == 4  # three wire labels, one gate label
     assert ax.texts[-1].get_text() == "X†"
+
+
+@pytest.mark.parametrize(
+    "device",
+    [qml.device("default.qubit.legacy", wires=2), qml.device("default.qubit", wires=2)],
+)
+def test_applied_transforms(device):
+    """Test that any transforms applied to the qnode are included in the output."""
+
+    @qml.transform
+    def just_pauli_x(_):
+        new_tape = qml.tape.QuantumScript([qml.PauliX(0)])
+        return (new_tape,), lambda res: res[0]
+
+    @just_pauli_x
+    @qml.qnode(device)
+    def my_circuit():
+        qml.SWAP(wires=(0, 1))
+        qml.CNOT(wires=(0, 1))
+        return qml.probs(wires=(0, 1))
+
+    _, ax = qml.draw_mpl(my_circuit)()
+
+    assert len(ax.lines) == 1  # single wire used in tape
+    assert len(ax.patches) == 1  # single pauli x gate
+    assert len(ax.texts) == 2  # one wire label, one gate label

--- a/tests/drawer/test_tape_mpl.py
+++ b/tests/drawer/test_tape_mpl.py
@@ -371,6 +371,8 @@ class TestSpecialGates:
         for i in range(3):
             assert ax.patches[i].center == (layer, i)
 
+        plt.close()
+
     def test_Barrier(self):
         """Test Barrier gets correct special call."""
 
@@ -540,6 +542,8 @@ class TestControlledGates:
         tape = QuantumScript.from_queue(q_tape)
         self.check_tape_controlled_qubit_unitary(tape)
 
+        plt.close()
+
     def test_nested_control_values_bool(self):
         """Test control_values get displayed correctly for nested controlled operations
         when they are provided as a list of bools."""
@@ -647,6 +651,8 @@ class TestGeneralOperations:
         assert ax.patches[0].get_y() == -self.width / 2.0
         assert ax.patches[0].get_width() == self.width
         assert ax.patches[0].get_height() == 2 + self.width
+
+        plt.close()
 
     @pytest.mark.parametrize("op", general_op_data)
     def test_general_operations_decimals(self, op):
@@ -855,6 +861,7 @@ class TestClassicalControl:
             "linewidth": 3 * plt.rcParams["lines.linewidth"],
             "foreground": "white",  # figure.facecolor for black white sytle
         }
+        plt.close()
 
     def test_combo_measurement(self):
         """Test a control that depends on two mid circuit measurements."""
@@ -893,6 +900,8 @@ class TestClassicalControl:
         assert eraser.get_ydata() == (2, 2)
         assert eraser.get_color() == plt.rcParams["figure.facecolor"]
         assert eraser.get_linewidth() == 3 * plt.rcParams["lines.linewidth"]
+
+        plt.close()
 
     def test_combo_measurement_non_terminal(self):
         """Test a combination measurement where the classical wires continue on.
@@ -933,6 +942,8 @@ class TestClassicalControl:
         assert eraser.get_ydata() == (2, 2)
         assert eraser.get_color() == plt.rcParams["figure.facecolor"]
         assert eraser.get_linewidth() == 3 * plt.rcParams["lines.linewidth"]
+
+        plt.close()
 
     def test_single_mcm_measure(self):
         """Test a final measurement of a mid circuit measurement."""
@@ -999,3 +1010,5 @@ class TestClassicalControl:
         assert (
             final_measure_box.get_height() == 0.75 - 2 * 0.2 + 2 * 0.25
         )  # box_length - 2 * pad + 2 *cwire_scaling
+
+        plt.close()


### PR DESCRIPTION
Fixes #5275 [sc-57775]

Basically, we were only applying the transforms before drawing when the user provided `expansion_strategy` wasn't `"device"` and the device was from the new device interface.  This PR makes it so that we always apply all the user transforms before drawing.  This is a quick fix until #5139 can get in.