### PR TITLE
Fixes for the 0.35 release

### DIFF
--- a/doc/introduction/interfaces.rst
+++ b/doc/introduction/interfaces.rst
@@ -31,6 +31,7 @@ a :class:`QNode <pennylane.QNode>`, e.g.,
 
 .. note::
     If no interface is specified, PennyLane will automatically determine the interface based on provided arguments and keyword arguments.
+    See ``qml.workflow.SUPPORTED_INTERFACES`` for a list of all accepted interface strings.
 
 This will allow native numerical objects of the specified library (NumPy arrays, JAX arrays, Torch Tensors,
 or TensorFlow Tensors) to be passed as parameters to the quantum circuit. It also makes

--- a/pennylane/devices/preprocess.py
+++ b/pennylane/devices/preprocess.py
@@ -153,7 +153,8 @@ def mid_circuit_measurements(
 ) -> (Sequence[qml.tape.QuantumTape], Callable):
     """Provide the transform to handle mid-circuit measurements.
 
-    If the tape of device uses finite-shot, use the native implementation (i.e. no transform), and use defer measurements transforms otherwise.
+    If the tape or device uses finite-shot, use the native implementation (i.e. no transform),
+    and use the ``qml.defer_measurements`` transform otherwise.
     """
     if tape.shots and tape.batch_size is None:
         return (tape,), null_postprocessing
@@ -270,7 +271,7 @@ def decompose(
             a ``DecompositionUndefinedError`` will be raised.
         stopping_condition_shots (Callable): a function from an operator to a boolean. If ``False``, the operator
             should be decomposed. If an operator cannot be decomposed and is not accepted by ``stopping_condition``,
-            a ``DecompositionUndefinedError`` will be raised. This replaces stopping_condition if and only if the tape as shots.
+            a ``DecompositionUndefinedError`` will be raised. This replaces stopping_condition if and only if the tape has shots.
         skip_initial_state_prep=True (bool): If ``True``, the first operator will not be decomposed if it inherits from :class:`~.StatePrepBase`.
         decomposer (Callable): an optional callable that takes an operator and implements the relevant decomposition.
             If None, defaults to using a callable returning ``op.decomposition()`` for any :class:`~.Operator` .

--- a/pennylane/devices/qubit/simulate.py
+++ b/pennylane/devices/qubit/simulate.py
@@ -382,7 +382,7 @@ def accumulate_native_mcm(circuit: qml.tape.QuantumScript, all_shot_meas, one_sh
     """Incorporates new measurements in current measurement sequence.
 
     Args:
-        circuit (QuantumTape): A one-shot (auxiliary) QuantumScript
+        circuit (QuantumTape): A one-shot (auxiliary) ``QuantumScript``
         all_shot_meas (Sequence[Any]): List of accumulated measurement results
         one_shot_meas (Sequence[Any]): List of measurement results
 
@@ -415,13 +415,13 @@ def accumulate_native_mcm(circuit: qml.tape.QuantumScript, all_shot_meas, one_sh
 def has_mid_circuit_measurements(
     circuit: qml.tape.QuantumScript,
 ):
-    """Returns True if the circuit contains a MidMeasureMP object and False otherwise.
+    """Returns ``True`` if the circuit contains a ``MidMeasureMP`` object and ``False`` otherwise.
 
     Args:
-        circuit (QuantumTape): A QuantumScript
+        circuit (QuantumTape): A ``QuantumScript``
 
     Returns:
-        bool: Whether the circuit contains a MidMeasureMP object
+        bool: Whether the circuit contains a ``MidMeasureMP`` object
     """
     return any(isinstance(op, MidMeasureMP) for op in circuit.operations)
 
@@ -432,7 +432,7 @@ def parse_native_mid_circuit_measurements(
     """Combines, gathers and normalizes the results of native mid-circuit measurement runs.
 
     Args:
-        circuit (QuantumTape): A one-shot (auxiliary) QuantumScript
+        circuit (QuantumTape): A one-shot (auxiliary) ``QuantumScript``
         all_shot_meas (Sequence[Any]): List of accumulated measurement results
         mcm_shot_meas (Sequence[dict]): List of dictionaries containing the mid-circuit measurement results of each shot
 

--- a/pennylane/io.py
+++ b/pennylane/io.py
@@ -68,8 +68,8 @@ def load(quantum_circuit_object, format: str, **load_kwargs):
         quantum_circuit_object: the quantum circuit that will be converted
             to a PennyLane template
         format (str): the format of the quantum circuit object to convert from
-        **load_kwargs: keyword argument to pass when converting the quantum circuit
-            using the plugin
+        **load_kwargs: keyword arguments to pass when converting the quantum circuit
+            using the plugin. See below for details about supported keyword arguments.
 
     Keyword Args:
         measurements (list[MeasurementProcess]): the list of PennyLane measurements that
@@ -86,7 +86,7 @@ def load(quantum_circuit_object, format: str, **load_kwargs):
         plugin_converter = plugin_converters[format].load()
 
         # calls the load function of the converter on the quantum circuit object
-        return plugin_converter(quantum_circuit_object, **(load_kwargs or {}))
+        return plugin_converter(quantum_circuit_object, **load_kwargs)
 
     raise ValueError(
         "Converter does not exist. Make sure the required plugin is installed "
@@ -148,8 +148,8 @@ def from_qiskit(quantum_circuit, measurements=None):
                 return quantum_circuit()
 
         >>> print(qml.draw(circuit_loaded_qiskit_circuit)())
-        0: ──H──┤↗├──RZ(0.24)─╭●─┤  <Z>
-        1: ───────────────────╰X─┤  vnentropy
+        0: ──H──┤↗├──RZ(0.24)─╭●─╭||─┤  <Z>
+        1: ───────────────────╰X─╰||─┤  vnentropy
 
     """
     try:

--- a/pennylane/ops/op_math/sum.py
+++ b/pennylane/ops/op_math/sum.py
@@ -167,12 +167,12 @@ class Sum(CompositeOp):
         return hash(("Sum", frozenset(o.hash for o in self.operands)))
 
     def __str__(self):
-        """String representation of the PauliSentence."""
+        """String representation of the Sum."""
         ops = self.operands
         return " + ".join(f"{str(op)}" if i == 0 else f"{str(op)}" for i, op in enumerate(ops))
 
     def __repr__(self):
-        """Terminal representation for PauliSentence"""
+        """Terminal representation for Sum"""
         # post-processing the flat str() representation
         # We have to do it like this due to the possible
         # nesting of Sums, e.g. X(0) + X(1) + X(2) is a sum(sum(X(0), X(1)), X(2))

--- a/pennylane/transforms/defer_measurements.py
+++ b/pennylane/transforms/defer_measurements.py
@@ -155,7 +155,7 @@ def defer_measurements(tape: QuantumTape, **kwargs) -> (Sequence[QuantumTape], C
         ValueError: If any measurements with no wires or observable are present
         ValueError: If continuous variable operations or measurements are present
         ValueError: If using the transform with any device other than
-            :mod:`default.qubit <~pennylane.devices.DefaultQubit>` and postselection is used
+            :class:`default.qubit <~pennylane.devices.DefaultQubit>` and postselection is used
 
     **Example**
 

--- a/pennylane/transforms/defer_measurements.py
+++ b/pennylane/transforms/defer_measurements.py
@@ -38,6 +38,9 @@ def _check_tape_validity(tape: QuantumTape):
     if ops_cv or obs_cv:
         raise ValueError("Continuous variable operations and observables are not supported.")
 
+    if not all(isinstance(w, int) for w in tape.wires):
+        raise ValueError("qml.defer_measurements does not support custom wire labels.")
+
     for mp in tape.measurements:
         if isinstance(mp, (CountsMP, ProbabilityMP, SampleMP)) and not (
             mp.obs or mp._wires or mp.mv
@@ -117,8 +120,7 @@ def defer_measurements(tape: QuantumTape, **kwargs) -> (Sequence[QuantumTape], C
         Devices that inherit from :class:`~pennylane.QubitDevice` **must** be initialized
         with an additional wire for each mid-circuit measurement after which the measured
         wire is reused or reset for ``defer_measurements`` to transform the quantum tape
-        correctly. Hence, devices and quantum tapes must also be initialized without custom
-        wire labels for correct behaviour.
+        correctly.
 
     .. note::
 
@@ -138,6 +140,11 @@ def defer_measurements(tape: QuantumTape, **kwargs) -> (Sequence[QuantumTape], C
         Additionally, :func:`~.pennylane.probs`, :func:`~.pennylane.sample` and
         :func:`~.pennylane.counts` can only be used with ``defer_measurements`` if wires
         or an observable are explicitly specified.
+
+    .. warning::
+
+        ``defer_measurements`` does not support custom wire labels. Only integer wires are
+        supported.
 
     Args:
         tape (QNode or QuantumTape or Callable): a quantum circuit.

--- a/pennylane/transforms/defer_measurements.py
+++ b/pennylane/transforms/defer_measurements.py
@@ -150,6 +150,13 @@ def defer_measurements(tape: QuantumTape, **kwargs) -> (Sequence[QuantumTape], C
         qnode (QNode) or quantum function (Callable) or tuple[List[QuantumTape], function]: The
         transformed circuit as described in :func:`qml.transform <pennylane.transform>`.
 
+    Raises:
+        ValueError: If custom wire labels are used with qubit reuse or reset
+        ValueError: If any measurements with no wires or observable are present
+        ValueError: If continuous variable operations or measurements are present
+        ValueError: If using the transform with any device other than
+            :mod:`default.qubit <~pennylane.devices.DefaultQubit>` and postselection is used
+
     **Example**
 
     Suppose we have a quantum function with mid-circuit measurements and

--- a/pennylane/workflow/interfaces/tensorflow.py
+++ b/pennylane/workflow/interfaces/tensorflow.py
@@ -78,7 +78,7 @@ Unfortunately, we then get an extra call to the vjp function.
 
         @tf.py_function(Tout=x.dtype)
         def vjp(*dy):
-            print("In the VJP function with")
+            print("In the VJP function with: ", dy)
             print("eager? ", tf.executing_eagerly())
             return dy[0] * 2 * x
 
@@ -88,17 +88,13 @@ Unfortunately, we then get an extra call to the vjp function.
 >>> with tf.GradientTape(persistent=True) as tape:
 ...         y = f(x)
 >>> tape.jacobian(y, x)
-In the VJP function with:  (<tf.Tensor: shape=(2,), dtype=float32, numpy=array([1., 0.], dtype=float32)>,)
+In the VJP function with:  (<tf.Tensor: shape=(), dtype=float32, numpy=1.0>,)
 eager?  True
-In the VJP function with:  (<tf.Tensor: shape=(2,), dtype=float32, numpy=array([1., 0.], dtype=float32)>,)
+In the VJP function with:  (<tf.Tensor: shape=(), dtype=float32, numpy=1.0>,)
 eager?  True
-In the VJP function with:  (<tf.Tensor: shape=(2,), dtype=float32, numpy=array([0., 1.], dtype=float32)>,)
-eager?  True
-<tf.Tensor: shape=(2, 2), dtype=float32, numpy=
-array([[0.2, 0. ],
-       [0. , 0.4]], dtype=float32)>
+<tf.Tensor: shape=(), dtype=float32, numpy=0.2>
 
-As you can see, we got 3 calls to ``vjp`` instead of 2, and the first calls have identical ``dy``. We do not want
+As you can see, we got 2 calls to ``vjp`` instead of 1, and the calls have identical ``dy``. We do not want
 to have to perform this extra call.
 
 """

--- a/tests/transforms/test_defer_measurements.py
+++ b/tests/transforms/test_defer_measurements.py
@@ -97,6 +97,18 @@ def test_unsupported_measurements(mp, err_msg):
         _, _ = qml.defer_measurements(tape)
 
 
+def test_custom_wires_error():
+    """Test that using custom wire labels raises an error"""
+    tape = qml.tape.QuantumScript(
+        [qml.PauliX("a"), qml.CNOT(["a", 1]), MidMeasureMP("a")], [qml.expval(qml.PauliZ(1))]
+    )
+
+    with pytest.raises(
+        ValueError, match="qml.defer_measurements does not support custom wire labels."
+    ):
+        _, _ = qml.defer_measurements(tape)
+
+
 @pytest.mark.parametrize(
     "mp, compose_mv",
     [
@@ -1529,34 +1541,3 @@ class TestDrawing:
             "3: ─╰X─╰●─╰●──────────────────┤     "
         )
         assert qml.draw(transformed_qnode)() == expected
-
-
-def test_custom_wire_labels_allowed_without_reset():
-    """Test that custom wire labels work if no qubits are re-used."""
-    with qml.queuing.AnnotatedQueue() as q:
-        qml.Hadamard("a")
-        ma = qml.measure("a", reset=False)
-        qml.cond(ma, qml.PauliX)("b")
-        qml.probs(wires="b")
-
-    tape = qml.tape.QuantumScript.from_queue(q)
-    tapes, _ = qml.defer_measurements(tape)
-    tape = tapes[0]
-
-    assert len(tape) == 3
-    assert qml.equal(tape[0], qml.Hadamard("a"))
-    assert qml.equal(tape[1], qml.CNOT(["a", "b"]))
-    assert qml.equal(tape[2], qml.probs(wires="b"))
-
-
-def test_custom_wire_labels_fails_with_reset():
-    """Test that custom wire labels do not work if any qubits are re-used."""
-    with qml.queuing.AnnotatedQueue() as q:
-        qml.Hadamard("a")
-        ma = qml.measure("a", reset=True)
-        qml.cond(ma, qml.PauliX)("b")
-        qml.probs(wires="a")
-
-    tape = qml.tape.QuantumScript.from_queue(q)
-    with pytest.raises(TypeError, match="can only concatenate str"):
-        qml.defer_measurements(tape)


### PR DESCRIPTION
Following changes have been made:
* `qml.defer_measurements` doesn't work with custom wire labels if any of the measured wires are reused/reset.
* Added a note to `interfaces.rst` to tell users to how see all supported interfaces. Jason pointed out that the [`workflow` internals page](https://docs.pennylane.ai/en/latest/code/qml_workflow.html#supported-interfaces), which uses file names with underscores for the different interfaces (`tensorflow_autograph`, `jax_jit`), might indicate to users that the interface `jax_jit` is a valid one rather than `jax-jit`.
* Grammar fixes, markdown to sphinx code-block conversions, code example doc fixes.
* Tensorflow interface docs for custom gradient functions had a mistake that is resolved here.