### PR TITLE
Remove warning in `parity_transform` and add a note

### DIFF
--- a/pennylane/fermi/conversion.py
+++ b/pennylane/fermi/conversion.py
@@ -15,7 +15,6 @@
 
 from functools import singledispatch
 from typing import Union
-import warnings
 
 import pennylane as qml
 from pennylane.operation import Operator

--- a/pennylane/fermi/conversion.py
+++ b/pennylane/fermi/conversion.py
@@ -165,8 +165,8 @@ def parity_transform(
 
     .. note::
 
-        Hamiltonians created with this mapping should be only used with operators and states in the
-        parity basis.
+        Hamiltonians created with this mapping should be used with operators and states that are
+        compatible with the parity basis.
 
     In parity mapping, qubit :math:`j` stores the parity of all :math:`j-1` qubits before it.
     In comparison, :func:`~.jordan_wigner` simply uses qubit :math:`j` to store the occupation number.

--- a/pennylane/fermi/conversion.py
+++ b/pennylane/fermi/conversion.py
@@ -220,9 +220,6 @@ def parity_transform(
     + (0.25+0j) * X(2)
     + 0.25j * Y(2) @ Z(3)
     """
-    warnings.warn(
-        "This mapping should be used with operators and states in the parity basis.", UserWarning
-    )
 
     return _parity_transform_dispatch(fermi_operator, n, ps, wire_map, tol)
 

--- a/pennylane/fermi/conversion.py
+++ b/pennylane/fermi/conversion.py
@@ -164,6 +164,11 @@ def parity_transform(
 ) -> Union[Operator, PauliSentence]:
     r"""Convert a fermionic operator to a qubit operator using the parity mapping.
 
+    .. note::
+
+        Hamiltonians created with this mapping should be only used with operators and states in the
+        parity basis.
+
     In parity mapping, qubit :math:`j` stores the parity of all :math:`j-1` qubits before it.
     In comparison, :func:`~.jordan_wigner` simply uses qubit :math:`j` to store the occupation number.
     In parity mapping, the fermionic creation and annihilation operators are mapped to the Pauli operators as

--- a/tests/fermi/test_parity_mapping.py
+++ b/tests/fermi/test_parity_mapping.py
@@ -26,16 +26,6 @@ def test_error_is_raised_for_dimension_mismatch():
         parity_transform(FermiWord({(0, 1): "-", (1, 0): "+", (2, 6): "-"}), 6)
 
 
-def test_warning_is_raised_with_use():
-    """Test that a UserWarning is raised when this mapping is used"""
-
-    with pytest.warns(
-        UserWarning,
-        match="This mapping should be used with operators and states in the parity basis.",
-    ):
-        parity_transform(FermiWord({(0, 1): "-", (1, 0): "+", (2, 2): "-"}), 4)
-
-
 FERMI_WORDS_AND_OPS = [
     (
         FermiWord({(0, 0): "+"}),


### PR DESCRIPTION
**Context:**
The warning in `parity_transform`, informing users to use the mapping consistently, is replaced with a note.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
