### PR TITLE
Add `SProd.terms()` method

### DIFF
--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -70,7 +70,7 @@ Pending deprecations
 
 * ``op.ops`` and ``op.coeffs`` will be deprecated in the future. Use ``op.terms()`` instead.
 
-  - Added and deprecated for ``Sum`` and ``Prod`` instances in v0.35
+  - Added and deprecated for ``Sum``, ``Prod`` and ``SProd`` instances in v0.35
 
 Completed deprecation cycles
 ----------------------------

--- a/doc/releases/changelog-0.35.0.md
+++ b/doc/releases/changelog-0.35.0.md
@@ -449,11 +449,12 @@
   [(#5141)](https://github.com/PennyLaneAI/pennylane/pull/5141)
   [(#5150)](https://github.com/PennyLaneAI/pennylane/pull/5150)
 
-* Akin to `qml.Hamiltonian` features, the coefficients and operators that make up composite operators formed via `Sum` or `Prod` can now be accessed 
+* Akin to `qml.Hamiltonian` features, the coefficients and operators that make up composite operators formed via `Sum`, `Prod` and `SProd` can now be accessed 
   with the `terms()` method.
   [(#5132)](https://github.com/PennyLaneAI/pennylane/pull/5132)
   [(#5133)](https://github.com/PennyLaneAI/pennylane/pull/5133)
   [(#5164)](https://github.com/PennyLaneAI/pennylane/pull/5164)
+  [(#5287)](https://github.com/PennyLaneAI/pennylane/pull/5287)
 
   ```python
   >>> qml.operation.enable_new_opmath()
@@ -650,8 +651,9 @@
   functionality can be achieved using newer features in the `pauli` module.
   [(#5057)](https://github.com/PennyLaneAI/pennylane/pull/5057)
 
-* `Sum.ops`, `Sum.coeffs`, `Prod.ops` and `Prod.coeffs` will be deprecated in the future.
+* `Sum.ops`, `Sum.coeffs`, `Prod.ops`, `Prod.coeffs`, `SProd.ops` and `SProd.coeffs` will be deprecated in the future.
   [(#5164)](https://github.com/PennyLaneAI/pennylane/pull/5164)
+  [(#5287)](https://github.com/PennyLaneAI/pennylane/pull/5287)
 
 <h3>Documentation 📝</h3>
 

--- a/pennylane/ops/op_math/sprod.py
+++ b/pennylane/ops/op_math/sprod.py
@@ -224,7 +224,7 @@ class SProd(ScalarSymbolicOp):
 
         This is a deprecated attribute, please use :meth:`~SProd.terms` instead.
 
-        .. seealso:: :attr:`~Prod.ops`, :class:`~Prod.pauli_rep`"""
+        .. seealso:: :attr:`~SProd.ops`, :class:`~SProd.pauli_rep`"""
         warnings.warn(
             "SProd.coeffs is deprecated and will be removed in future releases. You can access both (coeffs, ops) via op.terms(). Also consider op.operands.",
             qml.PennyLaneDeprecationWarning,
@@ -239,7 +239,7 @@ class SProd(ScalarSymbolicOp):
 
         This is a deprecated attribute, please use :meth:`~SProd.terms` instead.
 
-        .. seealso:: :attr:`~Prod.coeffs`, :class:`~Prod.pauli_rep`"""
+        .. seealso:: :attr:`~SProd.coeffs`, :class:`~SProd.pauli_rep`"""
         warnings.warn(
             "SProd.ops is deprecated and will be removed in future releases. You can access both (coeffs, ops) via op.terms() Also consider op.operands.",
             qml.PennyLaneDeprecationWarning,

--- a/pennylane/ops/op_math/sprod.py
+++ b/pennylane/ops/op_math/sprod.py
@@ -197,9 +197,9 @@ class SProd(ScalarSymbolicOp):
         **Example**
 
         >>> qml.operation.enable_new_opmath()
-        >>> op = X(0) @ (0.5 * X(1) + X(2))
+        >>> op = 0.5 * (X(0) @ (0.5 * X(1) + X(2)))
         >>> op.terms()
-        ([0.5, 1.0],
+        ([0.25, 0.5],
          [X(1) @ X(0),
           X(2) @ X(0)])
 

--- a/pennylane/ops/op_math/sprod.py
+++ b/pennylane/ops/op_math/sprod.py
@@ -15,6 +15,7 @@
 This file contains the implementation of the SProd class which contains logic for
 computing the scalar product of operations.
 """
+import warnings
 from typing import Union
 from copy import copy
 
@@ -215,6 +216,36 @@ class SProd(ScalarSymbolicOp):
             return new_coeffs, ops
 
         return [self.scalar], [self.base]
+
+    @property
+    def coeffs(self):
+        r"""
+        Scalar coefficients of the operator when flattened out.
+
+        This is a deprecated attribute, please use :meth:`~SProd.terms` instead.
+
+        .. seealso:: :attr:`~Prod.ops`, :class:`~Prod.pauli_rep`"""
+        warnings.warn(
+            "SProd.coeffs is deprecated and will be removed in future releases. You can access both (coeffs, ops) via op.terms(). Also consider op.operands.",
+            qml.PennyLaneDeprecationWarning,
+        )
+        coeffs, _ = self.terms()
+        return coeffs
+
+    @property
+    def ops(self):
+        r"""
+        Operator terms without scalar coefficients of the operator when flattened out.
+
+        This is a deprecated attribute, please use :meth:`~SProd.terms` instead.
+
+        .. seealso:: :attr:`~Prod.coeffs`, :class:`~Prod.pauli_rep`"""
+        warnings.warn(
+            "SProd.ops is deprecated and will be removed in future releases. You can access both (coeffs, ops) via op.terms() Also consider op.operands.",
+            qml.PennyLaneDeprecationWarning,
+        )
+        _, ops = self.terms()
+        return ops
 
     @property
     def is_hermitian(self):

--- a/tests/ops/op_math/test_sprod.py
+++ b/tests/ops/op_math/test_sprod.py
@@ -156,14 +156,26 @@ class TestInitialization:
         assert op.base[1].data == (0.4,)
         assert op.base[1][1].data == (0.4,)
 
-    @pytest.mark.parametrize("scalar, op", ops)
-    def test_terms(self, op, scalar):
-        sprod_op = SProd(scalar, op)
-        coeff, op2 = sprod_op.terms()
+    TERMS = (
+        (qml.s_prod(0.5, qml.sum(qml.X(0), qml.X(1))), [0.5, 0.5], [qml.X(0), qml.X(1)]),
+        (
+            qml.s_prod(0.5, qml.sum(qml.X(0), qml.Hadamard(1))),
+            [0.5, 0.5],
+            [qml.X(0), qml.Hadamard(1)],
+        ),
+        (qml.s_prod(0.5, qml.prod(qml.X(0), qml.X(1))), [0.5], [qml.prod(qml.X(0), qml.X(1))]),
+        (
+            qml.s_prod(0.5, qml.sum(qml.X(0), qml.prod(qml.X(0), qml.X(1)))),
+            [0.5, 0.5],
+            [qml.X(0), qml.prod(qml.X(0), qml.X(1))],
+        ),
+    )
 
-        assert coeff == [scalar]
-        for op1, op2 in zip(op2, [op]):
-            assert qml.equal(op1, op2)
+    @pytest.mark.parametrize("op, true_coeffs, true_ops", TERMS)
+    def test_terms(self, op, true_coeffs, true_ops):
+        coeffs, ops_ = op.terms()
+        assert coeffs == true_coeffs
+        assert ops_ == true_ops
 
     def test_decomposition_raises_error(self):
         sprod_op = s_prod(3.14, qml.Identity(wires=1))

--- a/tests/ops/op_math/test_sprod.py
+++ b/tests/ops/op_math/test_sprod.py
@@ -96,6 +96,7 @@ ops_rep = (
     "42 * Rot(0.34, 1.0, 0, wires=[0])",
 )
 
+
 def test_legacy_ops():
     """Test that PennyLaneDepcreationWarning is raised when Prod.ops is called"""
     H = qml.s_prod(0.5, qml.X(0))

--- a/tests/ops/op_math/test_sprod.py
+++ b/tests/ops/op_math/test_sprod.py
@@ -96,6 +96,19 @@ ops_rep = (
     "42 * Rot(0.34, 1.0, 0, wires=[0])",
 )
 
+def test_legacy_ops():
+    """Test that PennyLaneDepcreationWarning is raised when Prod.ops is called"""
+    H = qml.s_prod(0.5, qml.X(0))
+    with pytest.warns(qml.PennyLaneDeprecationWarning, match="SProd.ops is deprecated and"):
+        _ = H.ops
+
+
+def test_legacy_coeffs():
+    """Test that PennyLaneDepcreationWarning is raised when Prod.coeffs is called"""
+    H = qml.s_prod(0.5, qml.X(0))
+    with pytest.warns(qml.PennyLaneDeprecationWarning, match="SProd.coeffs is deprecated and"):
+        _ = H.coeffs
+
 
 class TestInitialization:
     """Test initialization of the SProd Class."""


### PR DESCRIPTION
Missed to add `SProd.terms()`, `SProd.ops` and `SProd.coeffs`, fixing this here