### PR TITLE
Make `QubitChannel` compatible with jitting

### DIFF
--- a/doc/releases/changelog-0.35.0.md
+++ b/doc/releases/changelog-0.35.0.md
@@ -689,6 +689,7 @@
 <h3>Bug fixes 🐛</h3>
 
 *  `QubitChannel` can now be used with jitting.
+  [(#5288)](https://github.com/PennyLaneAI/pennylane/pull/5288)
 
 * Fixed a bug in the matplotlib drawer where the colour of `Barrier` did not match the requested style.
   [(#5276)](https://github.com/PennyLaneAI/pennylane/pull/5276)

--- a/doc/releases/changelog-0.35.0.md
+++ b/doc/releases/changelog-0.35.0.md
@@ -688,6 +688,8 @@
 
 <h3>Bug fixes 🐛</h3>
 
+*  `QubitChannel` can now be used with jitting.
+
 * Fixed a bug in the matplotlib drawer where the colour of `Barrier` did not match the requested style.
   [(#5276)](https://github.com/PennyLaneAI/pennylane/pull/5276)
 

--- a/pennylane/ops/channel.py
+++ b/pennylane/ops/channel.py
@@ -18,7 +18,7 @@ quantum channels supported by PennyLane, as well as their conventions.
 """
 import warnings
 
-from pennylane import math
+from pennylane import math as np
 from pennylane.operation import AnyWires, Channel
 
 
@@ -77,12 +77,12 @@ class AmplitudeDamping(Channel):
         [array([[1., 0.], [0., 0.70710678]]),
          array([[0., 0.70710678], [0., 0.]])]
         """
-        if not math.is_abstract(gamma) and not 0.0 <= gamma <= 1.0:
+        if not np.is_abstract(gamma) and not 0.0 <= gamma <= 1.0:
             raise ValueError("gamma must be in the interval [0,1].")
 
-        K0 = math.diag([1, math.sqrt(1 - gamma + math.eps)])
-        K1 = math.sqrt(gamma + math.eps) * math.convert_like(
-            math.cast_like(math.array([[0, 1], [0, 0]]), gamma), gamma
+        K0 = np.diag([1, np.sqrt(1 - gamma + np.eps)])
+        K1 = np.sqrt(gamma + np.eps) * np.convert_like(
+            np.cast_like(np.array([[0, 1], [0, 0]]), gamma), gamma
         )
         return [K0, K1]
 
@@ -159,23 +159,23 @@ class GeneralizedAmplitudeDamping(Channel):
          array([[0.52915026, 0.        ], [0.        , 0.63245553]]),
          array([[0.        , 0.        ], [0.34641016, 0.        ]])]
         """
-        if not math.is_abstract(gamma) and not 0.0 <= gamma <= 1.0:
+        if not np.is_abstract(gamma) and not 0.0 <= gamma <= 1.0:
             raise ValueError("gamma must be in the interval [0,1].")
 
-        if not math.is_abstract(p) and not 0.0 <= p <= 1.0:
+        if not np.is_abstract(p) and not 0.0 <= p <= 1.0:
             raise ValueError("p must be in the interval [0,1].")
 
-        K0 = math.sqrt(p + math.eps) * math.diag([1, math.sqrt(1 - gamma + math.eps)])
+        K0 = np.sqrt(p + np.eps) * np.diag([1, np.sqrt(1 - gamma + np.eps)])
         K1 = (
-            math.sqrt(p + math.eps)
-            * math.sqrt(gamma)
-            * math.convert_like(math.cast_like(math.array([[0, 1], [0, 0]]), gamma), gamma)
+            np.sqrt(p + np.eps)
+            * np.sqrt(gamma)
+            * np.convert_like(np.cast_like(np.array([[0, 1], [0, 0]]), gamma), gamma)
         )
-        K2 = math.sqrt(1 - p + math.eps) * math.diag([math.sqrt(1 - gamma + math.eps), 1])
+        K2 = np.sqrt(1 - p + np.eps) * np.diag([np.sqrt(1 - gamma + np.eps), 1])
         K3 = (
-            math.sqrt(1 - p + math.eps)
-            * math.sqrt(gamma)
-            * math.convert_like(math.cast_like(math.array([[0, 0], [1, 0]]), gamma), gamma)
+            np.sqrt(1 - p + np.eps)
+            * np.sqrt(gamma)
+            * np.convert_like(np.cast_like(np.array([[0, 0], [1, 0]]), gamma), gamma)
         )
         return [K0, K1, K2, K3]
 
@@ -235,11 +235,11 @@ class PhaseDamping(Channel):
         [array([[1.        , 0.        ], [0.        , 0.70710678]]),
          array([[0.        , 0.        ], [0.        , 0.70710678]])]
         """
-        if not math.is_abstract(gamma) and not 0.0 <= gamma <= 1.0:
+        if not np.is_abstract(gamma) and not 0.0 <= gamma <= 1.0:
             raise ValueError("gamma must be in the interval [0,1].")
 
-        K0 = math.diag([1, math.sqrt(1 - gamma + math.eps)])
-        K1 = math.diag([0, math.sqrt(gamma + math.eps)])
+        K0 = np.diag([1, np.sqrt(1 - gamma + np.eps)])
+        K1 = np.diag([0, np.sqrt(gamma + np.eps)])
         return [K0, K1]
 
 
@@ -324,21 +324,19 @@ class DepolarizingChannel(Channel):
          array([[0.+0.j        , 0.-0.40824829j], [0.+0.40824829j, 0.+0.j        ]]),
          array([[ 0.40824829,  0.        ], [ 0.        , -0.40824829]])]
         """
-        if not math.is_abstract(p) and not 0.0 <= p <= 1.0:
+        if not np.is_abstract(p) and not 0.0 <= p <= 1.0:
             raise ValueError("p must be in the interval [0,1]")
 
-        if math.get_interface(p) == "tensorflow":
-            p = math.cast_like(p, 1j)
+        if np.get_interface(p) == "tensorflow":
+            p = np.cast_like(p, 1j)
 
-        K0 = math.sqrt(1 - p + math.eps) * math.convert_like(math.eye(2, dtype=complex), p)
-        K1 = math.sqrt(p / 3 + math.eps) * math.convert_like(
-            math.array([[0, 1], [1, 0]], dtype=complex), p
+        K0 = np.sqrt(1 - p + np.eps) * np.convert_like(np.eye(2, dtype=complex), p)
+        K1 = np.sqrt(p / 3 + np.eps) * np.convert_like(np.array([[0, 1], [1, 0]], dtype=complex), p)
+        K2 = np.sqrt(p / 3 + np.eps) * np.convert_like(
+            np.array([[0, -1j], [1j, 0]], dtype=complex), p
         )
-        K2 = math.sqrt(p / 3 + math.eps) * math.convert_like(
-            math.array([[0, -1j], [1j, 0]], dtype=complex), p
-        )
-        K3 = math.sqrt(p / 3 + math.eps) * math.convert_like(
-            math.array([[1, 0], [0, -1]], dtype=complex), p
+        K3 = np.sqrt(p / 3 + np.eps) * np.convert_like(
+            np.array([[1, 0], [0, -1]], dtype=complex), p
         )
         return [K0, K1, K2, K3]
 
@@ -398,13 +396,11 @@ class BitFlip(Channel):
         [array([[0.70710678, 0.        ], [0.        , 0.70710678]]),
          array([[0.        , 0.70710678], [0.70710678, 0.        ]])]
         """
-        if not math.is_abstract(p) and not 0.0 <= p <= 1.0:
+        if not np.is_abstract(p) and not 0.0 <= p <= 1.0:
             raise ValueError("p must be in the interval [0,1]")
 
-        K0 = math.sqrt(1 - p + math.eps) * math.convert_like(math.cast_like(math.eye(2), p), p)
-        K1 = math.sqrt(p + math.eps) * math.convert_like(
-            math.cast_like(math.array([[0, 1], [1, 0]]), p), p
-        )
+        K0 = np.sqrt(1 - p + np.eps) * np.convert_like(np.cast_like(np.eye(2), p), p)
+        K1 = np.sqrt(p + np.eps) * np.convert_like(np.cast_like(np.array([[0, 1], [1, 0]]), p), p)
         return [K0, K1]
 
 
@@ -486,31 +482,29 @@ class ResetError(Channel):
          array([[0.        , 0.        ], [0.54772256, 0.        ]]),
          array([[0.        , 0.        ], [0.        , 0.54772256]])]
         """
-        if not math.is_abstract(p_0) and not 0.0 <= p_0 <= 1.0:
+        if not np.is_abstract(p_0) and not 0.0 <= p_0 <= 1.0:
             raise ValueError("p_0 must be in the interval [0,1]")
 
-        if not math.is_abstract(p_1) and not 0.0 <= p_1 <= 1.0:
+        if not np.is_abstract(p_1) and not 0.0 <= p_1 <= 1.0:
             raise ValueError("p_1 must be in the interval [0,1]")
 
-        if not math.is_abstract(p_0 + p_1) and not 0.0 <= p_0 + p_1 <= 1.0:
+        if not np.is_abstract(p_0 + p_1) and not 0.0 <= p_0 + p_1 <= 1.0:
             raise ValueError("p_0 + p_1 must be in the interval [0,1]")
 
-        interface = math.get_interface(p_0, p_1)
-        p_0, p_1 = math.coerce([p_0, p_1], like=interface)
-        K0 = math.sqrt(1 - p_0 - p_1 + math.eps) * math.convert_like(
-            math.cast_like(math.eye(2), p_0), p_0
+        interface = np.get_interface(p_0, p_1)
+        p_0, p_1 = np.coerce([p_0, p_1], like=interface)
+        K0 = np.sqrt(1 - p_0 - p_1 + np.eps) * np.convert_like(np.cast_like(np.eye(2), p_0), p_0)
+        K1 = np.sqrt(p_0 + np.eps) * np.convert_like(
+            np.cast_like(np.array([[1, 0], [0, 0]]), p_0), p_0
         )
-        K1 = math.sqrt(p_0 + math.eps) * math.convert_like(
-            math.cast_like(math.array([[1, 0], [0, 0]]), p_0), p_0
+        K2 = np.sqrt(p_0 + np.eps) * np.convert_like(
+            np.cast_like(np.array([[0, 1], [0, 0]]), p_0), p_0
         )
-        K2 = math.sqrt(p_0 + math.eps) * math.convert_like(
-            math.cast_like(math.array([[0, 1], [0, 0]]), p_0), p_0
+        K3 = np.sqrt(p_1 + np.eps) * np.convert_like(
+            np.cast_like(np.array([[0, 0], [1, 0]]), p_0), p_0
         )
-        K3 = math.sqrt(p_1 + math.eps) * math.convert_like(
-            math.cast_like(math.array([[0, 0], [1, 0]]), p_0), p_0
-        )
-        K4 = math.sqrt(p_1 + math.eps) * math.convert_like(
-            math.cast_like(math.array([[0, 0], [0, 1]]), p_0), p_0
+        K4 = np.sqrt(p_1 + np.eps) * np.convert_like(
+            np.cast_like(np.array([[0, 0], [0, 1]]), p_0), p_0
         )
 
         return [K0, K1, K2, K3, K4]
@@ -577,7 +571,7 @@ class PauliError(Channel):
             raise ValueError("The specified operators need to be either of 'X', 'Y' or 'Z'")
 
         # check if probabilities are legal
-        if not math.is_abstract(p) and not 0.0 <= p <= 1.0:
+        if not np.is_abstract(p) and not 0.0 <= p <= 1.0:
             raise ValueError("p must be in the interval [0,1]")
 
         # check if the number of operators matches the number of wires
@@ -611,27 +605,25 @@ class PauliError(Channel):
         nq = len(operators)
 
         # K0 is sqrt(1-p) * Identity
-        K0 = math.sqrt(1 - p + math.eps) * math.convert_like(
-            math.cast_like(math.eye(2**nq), p), p
-        )
+        K0 = np.sqrt(1 - p + np.eps) * np.convert_like(np.cast_like(np.eye(2**nq), p), p)
 
-        interface = math.get_interface(p)
+        interface = np.get_interface(p)
         if interface == "tensorflow" or "Y" in operators:
             if interface == "numpy":
                 p = (1 + 0j) * p
             else:
-                p = math.cast_like(p, 1j)
+                p = np.cast_like(p, 1j)
 
         ops = {
-            "X": math.convert_like(math.cast_like(math.array([[0, 1], [1, 0]]), p), p),
-            "Y": math.convert_like(math.cast_like(math.array([[0, -1j], [1j, 0]]), p), p),
-            "Z": math.convert_like(math.cast_like(math.array([[1, 0], [0, -1]]), p), p),
+            "X": np.convert_like(np.cast_like(np.array([[0, 1], [1, 0]]), p), p),
+            "Y": np.convert_like(np.cast_like(np.array([[0, -1j], [1j, 0]]), p), p),
+            "Z": np.convert_like(np.cast_like(np.array([[1, 0], [0, -1]]), p), p),
         }
 
         # K1 is composed by Kraus matrices of operators
-        K1 = math.sqrt(p + math.eps) * math.convert_like(math.cast_like(math.eye(1), p), p)
+        K1 = np.sqrt(p + np.eps) * np.convert_like(np.cast_like(np.eye(1), p), p)
         for op in operators[::-1]:
-            K1 = math.multi_dispatch()(math.kron)(ops[op], K1)
+            K1 = np.multi_dispatch()(np.kron)(ops[op], K1)
 
         return [K0, K1]
 
@@ -691,11 +683,11 @@ class PhaseFlip(Channel):
         [array([[0.70710678, 0.        ], [0.        , 0.70710678]]),
          array([[ 0.70710678,  0.        ], [ 0.        , -0.70710678]])]
         """
-        if not math.is_abstract(p) and not 0.0 <= p <= 1.0:
+        if not np.is_abstract(p) and not 0.0 <= p <= 1.0:
             raise ValueError("p must be in the interval [0,1]")
 
-        K0 = math.sqrt(1 - p + math.eps) * math.convert_like(math.cast_like(math.eye(2), p), p)
-        K1 = math.sqrt(p + math.eps) * math.convert_like(math.cast_like(math.diag([1, -1]), p), p)
+        K0 = np.sqrt(1 - p + np.eps) * np.convert_like(np.cast_like(np.eye(2), p), p)
+        K1 = np.sqrt(p + np.eps) * np.convert_like(np.cast_like(np.diag([1, -1]), p), p)
         return [K0, K1]
 
 
@@ -741,10 +733,10 @@ class QubitChannel(Channel):
             )
 
         # check that the channel represents a trace-preserving map
-        if not any(math.is_abstract(K) for K in K_list):
-            K_arr = math.array(K_list)
-            Kraus_sum = math.einsum("ajk,ajl->kl", K_arr.conj(), K_arr)
-            if not math.allclose(Kraus_sum, math.eye(K_list[0].shape[0])):
+        if not any(np.is_abstract(K) for K in K_list):
+            K_arr = np.array(K_list)
+            Kraus_sum = np.einsum("ajk,ajl->kl", K_arr.conj(), K_arr)
+            if not np.allclose(Kraus_sum, np.eye(K_list[0].shape[0])):
                 raise ValueError("Only trace preserving channels can be applied.")
 
     def _flatten(self):
@@ -764,7 +756,7 @@ class QubitChannel(Channel):
 
         >>> K_list = qml.PhaseFlip(0.5, wires=0).kraus_matrices()
         >>> res = qml.QubitChannel.compute_kraus_matrices(K_list)
-        >>> all(math.allclose(r, k) for r, k  in zip(res, K_list))
+        >>> all(np.allclose(r, k) for r, k  in zip(res, K_list))
         True
         """
         return list(kraus_matrices)
@@ -877,21 +869,21 @@ class ThermalRelaxationError(Channel):
          array([[-0.12718544,  0.        ], [ 0.        ,  0.13165421]]),
          array([[0.98784022, 0.        ], [0.        , 0.95430977]])]
         """
-        if not math.is_abstract(pe) and not 0.0 <= pe <= 1.0:
+        if not np.is_abstract(pe) and not 0.0 <= pe <= 1.0:
             raise ValueError("pe must be between 0 and 1.")
-        if not math.is_abstract(tg) and tg < 0:
+        if not np.is_abstract(tg) and tg < 0:
             raise ValueError(f"Invalid gate_time tg ({tg} < 0)")
-        if not math.is_abstract(t1) and t1 <= 0:
+        if not np.is_abstract(t1) and t1 <= 0:
             raise ValueError("Invalid T_1 relaxation time parameter: T_1 <= 0.")
-        if not math.is_abstract(t2) and t2 <= 0:
+        if not np.is_abstract(t2) and t2 <= 0:
             raise ValueError("Invalid T_2 relaxation time parameter: T_2 <= 0.")
-        if not math.is_abstract(t2 - 2 * t1) and t2 - 2 * t1 > 0:
+        if not np.is_abstract(t2 - 2 * t1) and t2 - 2 * t1 > 0:
             raise ValueError("Invalid T_2 relaxation time parameter: T_2 greater than 2 * T_1.")
         # T1 relaxation rate
-        eT1 = math.exp(-tg / t1)
+        eT1 = np.exp(-tg / t1)
         p_reset = 1 - eT1
         # T2 dephasing rate
-        eT2 = math.exp(-tg / t2)
+        eT2 = np.exp(-tg / t2)
 
         def kraus_ops_small_t2():
             pz = (1 - p_reset) * (1 - eT2 / eT1) / 2
@@ -899,50 +891,50 @@ class ThermalRelaxationError(Channel):
             pr1 = pe * p_reset
             pid = 1 - pz - pr0 - pr1
 
-            K0 = math.sqrt(pid + math.eps) * math.eye(2)
-            K1 = math.sqrt(pz + math.eps) * math.array([[1, 0], [0, -1]])
-            K2 = math.sqrt(pr0 + math.eps) * math.array([[1, 0], [0, 0]])
-            K3 = math.sqrt(pr0 + math.eps) * math.array([[0, 1], [0, 0]])
-            K4 = math.sqrt(pr1 + math.eps) * math.array([[0, 0], [1, 0]])
-            K5 = math.sqrt(pr1 + math.eps) * math.array([[0, 0], [0, 1]])
+            K0 = np.sqrt(pid + np.eps) * np.eye(2)
+            K1 = np.sqrt(pz + np.eps) * np.array([[1, 0], [0, -1]])
+            K2 = np.sqrt(pr0 + np.eps) * np.array([[1, 0], [0, 0]])
+            K3 = np.sqrt(pr0 + np.eps) * np.array([[0, 1], [0, 0]])
+            K4 = np.sqrt(pr1 + np.eps) * np.array([[0, 0], [1, 0]])
+            K5 = np.sqrt(pr1 + np.eps) * np.array([[0, 0], [0, 1]])
 
             return [K0, K1, K2, K3, K4, K5]
 
         def kraus_ops_large_t2():
             e0 = p_reset * pe
-            v0 = math.array([[0, 0], [1, 0]])
-            K0 = math.sqrt(e0 + math.eps) * v0
+            v0 = np.array([[0, 0], [1, 0]])
+            K0 = np.sqrt(e0 + np.eps) * v0
             e1 = -p_reset * pe + p_reset
-            v1 = math.array([[0, 1], [0, 0]])
-            K1 = math.sqrt(e1 + math.eps) * v1
+            v1 = np.array([[0, 1], [0, 0]])
+            K1 = np.sqrt(e1 + np.eps) * v1
             base = sum(
                 (
                     4 * eT2**2,
                     4 * p_reset**2 * pe**2,
                     -4 * p_reset**2 * pe,
                     p_reset**2,
-                    math.eps,
+                    np.eps,
                 )
             )
-            common_term = math.sqrt(base)
+            common_term = np.sqrt(base)
             e2 = 1 - p_reset / 2 - common_term / 2
             term2 = 2 * eT2 / (2 * p_reset * pe - p_reset - common_term)
-            v2 = (term2 * math.array([[1, 0], [0, 0]]) + math.array([[0, 0], [0, 1]])) / math.sqrt(
+            v2 = (term2 * np.array([[1, 0], [0, 0]]) + np.array([[0, 0], [0, 1]])) / np.sqrt(
                 term2**2 + 1
             )
-            K2 = math.sqrt(e2 + math.eps) * v2
+            K2 = np.sqrt(e2 + np.eps) * v2
             term3 = 2 * eT2 / (2 * p_reset * pe - p_reset + common_term)
             e3 = 1 - p_reset / 2 + common_term / 2
-            v3 = (term3 * math.array([[1, 0], [0, 0]]) + math.array([[0, 0], [0, 1]])) / math.sqrt(
+            v3 = (term3 * np.array([[1, 0], [0, 0]]) + np.array([[0, 0], [0, 1]])) / np.sqrt(
                 term3**2 + 1
             )
-            K3 = math.sqrt(e3 + math.eps) * v3
-            K4 = math.cast_like(math.zeros((2, 2)), K1)
-            K5 = math.cast_like(math.zeros((2, 2)), K1)
+            K3 = np.sqrt(e3 + np.eps) * v3
+            K4 = np.cast_like(np.zeros((2, 2)), K1)
+            K5 = np.cast_like(np.zeros((2, 2)), K1)
 
             return [K0, K1, K2, K3, K4, K5]
 
-        K = math.cond(t2 <= t1, kraus_ops_small_t2, kraus_ops_large_t2, ())
+        K = np.cond(t2 <= t1, kraus_ops_small_t2, kraus_ops_large_t2, ())
         return K
 
 

--- a/pennylane/ops/channel.py
+++ b/pennylane/ops/channel.py
@@ -18,7 +18,7 @@ quantum channels supported by PennyLane, as well as their conventions.
 """
 import warnings
 
-import pennylane.math as np
+from pennylane import math
 from pennylane.operation import AnyWires, Channel
 
 
@@ -77,12 +77,12 @@ class AmplitudeDamping(Channel):
         [array([[1., 0.], [0., 0.70710678]]),
          array([[0., 0.70710678], [0., 0.]])]
         """
-        if not np.is_abstract(gamma) and not 0.0 <= gamma <= 1.0:
+        if not math.is_abstract(gamma) and not 0.0 <= gamma <= 1.0:
             raise ValueError("gamma must be in the interval [0,1].")
 
-        K0 = np.diag([1, np.sqrt(1 - gamma + np.eps)])
-        K1 = np.sqrt(gamma + np.eps) * np.convert_like(
-            np.cast_like(np.array([[0, 1], [0, 0]]), gamma), gamma
+        K0 = math.diag([1, math.sqrt(1 - gamma + math.eps)])
+        K1 = math.sqrt(gamma + math.eps) * math.convert_like(
+            math.cast_like(math.array([[0, 1], [0, 0]]), gamma), gamma
         )
         return [K0, K1]
 
@@ -159,23 +159,23 @@ class GeneralizedAmplitudeDamping(Channel):
          array([[0.52915026, 0.        ], [0.        , 0.63245553]]),
          array([[0.        , 0.        ], [0.34641016, 0.        ]])]
         """
-        if not np.is_abstract(gamma) and not 0.0 <= gamma <= 1.0:
+        if not math.is_abstract(gamma) and not 0.0 <= gamma <= 1.0:
             raise ValueError("gamma must be in the interval [0,1].")
 
-        if not np.is_abstract(p) and not 0.0 <= p <= 1.0:
+        if not math.is_abstract(p) and not 0.0 <= p <= 1.0:
             raise ValueError("p must be in the interval [0,1].")
 
-        K0 = np.sqrt(p + np.eps) * np.diag([1, np.sqrt(1 - gamma + np.eps)])
+        K0 = math.sqrt(p + math.eps) * math.diag([1, math.sqrt(1 - gamma + math.eps)])
         K1 = (
-            np.sqrt(p + np.eps)
-            * np.sqrt(gamma)
-            * np.convert_like(np.cast_like(np.array([[0, 1], [0, 0]]), gamma), gamma)
+            math.sqrt(p + math.eps)
+            * math.sqrt(gamma)
+            * math.convert_like(math.cast_like(math.array([[0, 1], [0, 0]]), gamma), gamma)
         )
-        K2 = np.sqrt(1 - p + np.eps) * np.diag([np.sqrt(1 - gamma + np.eps), 1])
+        K2 = math.sqrt(1 - p + math.eps) * math.diag([math.sqrt(1 - gamma + math.eps), 1])
         K3 = (
-            np.sqrt(1 - p + np.eps)
-            * np.sqrt(gamma)
-            * np.convert_like(np.cast_like(np.array([[0, 0], [1, 0]]), gamma), gamma)
+            math.sqrt(1 - p + math.eps)
+            * math.sqrt(gamma)
+            * math.convert_like(math.cast_like(math.array([[0, 0], [1, 0]]), gamma), gamma)
         )
         return [K0, K1, K2, K3]
 
@@ -235,11 +235,11 @@ class PhaseDamping(Channel):
         [array([[1.        , 0.        ], [0.        , 0.70710678]]),
          array([[0.        , 0.        ], [0.        , 0.70710678]])]
         """
-        if not np.is_abstract(gamma) and not 0.0 <= gamma <= 1.0:
+        if not math.is_abstract(gamma) and not 0.0 <= gamma <= 1.0:
             raise ValueError("gamma must be in the interval [0,1].")
 
-        K0 = np.diag([1, np.sqrt(1 - gamma + np.eps)])
-        K1 = np.diag([0, np.sqrt(gamma + np.eps)])
+        K0 = math.diag([1, math.sqrt(1 - gamma + math.eps)])
+        K1 = math.diag([0, math.sqrt(gamma + math.eps)])
         return [K0, K1]
 
 
@@ -324,19 +324,21 @@ class DepolarizingChannel(Channel):
          array([[0.+0.j        , 0.-0.40824829j], [0.+0.40824829j, 0.+0.j        ]]),
          array([[ 0.40824829,  0.        ], [ 0.        , -0.40824829]])]
         """
-        if not np.is_abstract(p) and not 0.0 <= p <= 1.0:
+        if not math.is_abstract(p) and not 0.0 <= p <= 1.0:
             raise ValueError("p must be in the interval [0,1]")
 
-        if np.get_interface(p) == "tensorflow":
-            p = np.cast_like(p, 1j)
+        if math.get_interface(p) == "tensorflow":
+            p = math.cast_like(p, 1j)
 
-        K0 = np.sqrt(1 - p + np.eps) * np.convert_like(np.eye(2, dtype=complex), p)
-        K1 = np.sqrt(p / 3 + np.eps) * np.convert_like(np.array([[0, 1], [1, 0]], dtype=complex), p)
-        K2 = np.sqrt(p / 3 + np.eps) * np.convert_like(
-            np.array([[0, -1j], [1j, 0]], dtype=complex), p
+        K0 = math.sqrt(1 - p + math.eps) * math.convert_like(math.eye(2, dtype=complex), p)
+        K1 = math.sqrt(p / 3 + math.eps) * math.convert_like(
+            math.array([[0, 1], [1, 0]], dtype=complex), p
         )
-        K3 = np.sqrt(p / 3 + np.eps) * np.convert_like(
-            np.array([[1, 0], [0, -1]], dtype=complex), p
+        K2 = math.sqrt(p / 3 + math.eps) * math.convert_like(
+            math.array([[0, -1j], [1j, 0]], dtype=complex), p
+        )
+        K3 = math.sqrt(p / 3 + math.eps) * math.convert_like(
+            math.array([[1, 0], [0, -1]], dtype=complex), p
         )
         return [K0, K1, K2, K3]
 
@@ -396,11 +398,13 @@ class BitFlip(Channel):
         [array([[0.70710678, 0.        ], [0.        , 0.70710678]]),
          array([[0.        , 0.70710678], [0.70710678, 0.        ]])]
         """
-        if not np.is_abstract(p) and not 0.0 <= p <= 1.0:
+        if not math.is_abstract(p) and not 0.0 <= p <= 1.0:
             raise ValueError("p must be in the interval [0,1]")
 
-        K0 = np.sqrt(1 - p + np.eps) * np.convert_like(np.cast_like(np.eye(2), p), p)
-        K1 = np.sqrt(p + np.eps) * np.convert_like(np.cast_like(np.array([[0, 1], [1, 0]]), p), p)
+        K0 = math.sqrt(1 - p + math.eps) * math.convert_like(math.cast_like(math.eye(2), p), p)
+        K1 = math.sqrt(p + math.eps) * math.convert_like(
+            math.cast_like(math.array([[0, 1], [1, 0]]), p), p
+        )
         return [K0, K1]
 
 
@@ -482,29 +486,31 @@ class ResetError(Channel):
          array([[0.        , 0.        ], [0.54772256, 0.        ]]),
          array([[0.        , 0.        ], [0.        , 0.54772256]])]
         """
-        if not np.is_abstract(p_0) and not 0.0 <= p_0 <= 1.0:
+        if not math.is_abstract(p_0) and not 0.0 <= p_0 <= 1.0:
             raise ValueError("p_0 must be in the interval [0,1]")
 
-        if not np.is_abstract(p_1) and not 0.0 <= p_1 <= 1.0:
+        if not math.is_abstract(p_1) and not 0.0 <= p_1 <= 1.0:
             raise ValueError("p_1 must be in the interval [0,1]")
 
-        if not np.is_abstract(p_0 + p_1) and not 0.0 <= p_0 + p_1 <= 1.0:
+        if not math.is_abstract(p_0 + p_1) and not 0.0 <= p_0 + p_1 <= 1.0:
             raise ValueError("p_0 + p_1 must be in the interval [0,1]")
 
-        interface = np.get_interface(p_0, p_1)
-        p_0, p_1 = np.coerce([p_0, p_1], like=interface)
-        K0 = np.sqrt(1 - p_0 - p_1 + np.eps) * np.convert_like(np.cast_like(np.eye(2), p_0), p_0)
-        K1 = np.sqrt(p_0 + np.eps) * np.convert_like(
-            np.cast_like(np.array([[1, 0], [0, 0]]), p_0), p_0
+        interface = math.get_interface(p_0, p_1)
+        p_0, p_1 = math.coerce([p_0, p_1], like=interface)
+        K0 = math.sqrt(1 - p_0 - p_1 + math.eps) * math.convert_like(
+            math.cast_like(math.eye(2), p_0), p_0
         )
-        K2 = np.sqrt(p_0 + np.eps) * np.convert_like(
-            np.cast_like(np.array([[0, 1], [0, 0]]), p_0), p_0
+        K1 = math.sqrt(p_0 + math.eps) * math.convert_like(
+            math.cast_like(math.array([[1, 0], [0, 0]]), p_0), p_0
         )
-        K3 = np.sqrt(p_1 + np.eps) * np.convert_like(
-            np.cast_like(np.array([[0, 0], [1, 0]]), p_0), p_0
+        K2 = math.sqrt(p_0 + math.eps) * math.convert_like(
+            math.cast_like(math.array([[0, 1], [0, 0]]), p_0), p_0
         )
-        K4 = np.sqrt(p_1 + np.eps) * np.convert_like(
-            np.cast_like(np.array([[0, 0], [0, 1]]), p_0), p_0
+        K3 = math.sqrt(p_1 + math.eps) * math.convert_like(
+            math.cast_like(math.array([[0, 0], [1, 0]]), p_0), p_0
+        )
+        K4 = math.sqrt(p_1 + math.eps) * math.convert_like(
+            math.cast_like(math.array([[0, 0], [0, 1]]), p_0), p_0
         )
 
         return [K0, K1, K2, K3, K4]
@@ -571,7 +577,7 @@ class PauliError(Channel):
             raise ValueError("The specified operators need to be either of 'X', 'Y' or 'Z'")
 
         # check if probabilities are legal
-        if not np.is_abstract(p) and not 0.0 <= p <= 1.0:
+        if not math.is_abstract(p) and not 0.0 <= p <= 1.0:
             raise ValueError("p must be in the interval [0,1]")
 
         # check if the number of operators matches the number of wires
@@ -605,25 +611,27 @@ class PauliError(Channel):
         nq = len(operators)
 
         # K0 is sqrt(1-p) * Identity
-        K0 = np.sqrt(1 - p + np.eps) * np.convert_like(np.cast_like(np.eye(2**nq), p), p)
+        K0 = math.sqrt(1 - p + math.eps) * math.convert_like(
+            math.cast_like(math.eye(2**nq), p), p
+        )
 
-        interface = np.get_interface(p)
+        interface = math.get_interface(p)
         if interface == "tensorflow" or "Y" in operators:
             if interface == "numpy":
                 p = (1 + 0j) * p
             else:
-                p = np.cast_like(p, 1j)
+                p = math.cast_like(p, 1j)
 
         ops = {
-            "X": np.convert_like(np.cast_like(np.array([[0, 1], [1, 0]]), p), p),
-            "Y": np.convert_like(np.cast_like(np.array([[0, -1j], [1j, 0]]), p), p),
-            "Z": np.convert_like(np.cast_like(np.array([[1, 0], [0, -1]]), p), p),
+            "X": math.convert_like(math.cast_like(math.array([[0, 1], [1, 0]]), p), p),
+            "Y": math.convert_like(math.cast_like(math.array([[0, -1j], [1j, 0]]), p), p),
+            "Z": math.convert_like(math.cast_like(math.array([[1, 0], [0, -1]]), p), p),
         }
 
         # K1 is composed by Kraus matrices of operators
-        K1 = np.sqrt(p + np.eps) * np.convert_like(np.cast_like(np.eye(1), p), p)
+        K1 = math.sqrt(p + math.eps) * math.convert_like(math.cast_like(math.eye(1), p), p)
         for op in operators[::-1]:
-            K1 = np.multi_dispatch()(np.kron)(ops[op], K1)
+            K1 = math.multi_dispatch()(math.kron)(ops[op], K1)
 
         return [K0, K1]
 
@@ -683,11 +691,11 @@ class PhaseFlip(Channel):
         [array([[0.70710678, 0.        ], [0.        , 0.70710678]]),
          array([[ 0.70710678,  0.        ], [ 0.        , -0.70710678]])]
         """
-        if not np.is_abstract(p) and not 0.0 <= p <= 1.0:
+        if not math.is_abstract(p) and not 0.0 <= p <= 1.0:
             raise ValueError("p must be in the interval [0,1]")
 
-        K0 = np.sqrt(1 - p + np.eps) * np.convert_like(np.cast_like(np.eye(2), p), p)
-        K1 = np.sqrt(p + np.eps) * np.convert_like(np.cast_like(np.diag([1, -1]), p), p)
+        K0 = math.sqrt(1 - p + math.eps) * math.convert_like(math.cast_like(math.eye(2), p), p)
+        K1 = math.sqrt(p + math.eps) * math.convert_like(math.cast_like(math.diag([1, -1]), p), p)
         return [K0, K1]
 
 
@@ -717,26 +725,27 @@ class QubitChannel(Channel):
         super().__init__(*K_list, wires=wires, id=id)
 
         # check all Kraus matrices are square matrices
-        if not all(K.shape[0] == K.shape[1] for K in K_list):
+        if any(K.shape[0] != K.shape[1] for K in K_list):
             raise ValueError(
                 "Only channels with the same input and output Hilbert space dimensions can be applied."
             )
 
         # check all Kraus matrices have the same shape
-        if not all(K.shape == K_list[0].shape for K in K_list):
+        if any(K.shape != K_list[0].shape for K in K_list):
             raise ValueError("All Kraus matrices must have the same shape.")
 
         # check the dimension of all Kraus matrices are valid
-        if not all(K.ndim == 2 for K in K_list):
+        if any(K.ndim != 2 for K in K_list):
             raise ValueError(
                 "Dimension of all Kraus matrices must be (2**num_wires, 2**num_wires)."
             )
 
         # check that the channel represents a trace-preserving map
-        K_arr = np.array(K_list)
-        Kraus_sum = np.einsum("ajk,ajl->kl", K_arr.conj(), K_arr)
-        if not np.allclose(Kraus_sum, np.eye(K_list[0].shape[0])):
-            raise ValueError("Only trace preserving channels can be applied.")
+        if not any(math.is_abstract(K) for K in K_list):
+            K_arr = math.array(K_list)
+            Kraus_sum = math.einsum("ajk,ajl->kl", K_arr.conj(), K_arr)
+            if not math.allclose(Kraus_sum, math.eye(K_list[0].shape[0])):
+                raise ValueError("Only trace preserving channels can be applied.")
 
     def _flatten(self):
         return (self.data,), (self.wires, ())
@@ -755,7 +764,7 @@ class QubitChannel(Channel):
 
         >>> K_list = qml.PhaseFlip(0.5, wires=0).kraus_matrices()
         >>> res = qml.QubitChannel.compute_kraus_matrices(K_list)
-        >>> all(np.allclose(r, k) for r, k  in zip(res, K_list))
+        >>> all(math.allclose(r, k) for r, k  in zip(res, K_list))
         True
         """
         return list(kraus_matrices)
@@ -868,21 +877,21 @@ class ThermalRelaxationError(Channel):
          array([[-0.12718544,  0.        ], [ 0.        ,  0.13165421]]),
          array([[0.98784022, 0.        ], [0.        , 0.95430977]])]
         """
-        if not np.is_abstract(pe) and not 0.0 <= pe <= 1.0:
+        if not math.is_abstract(pe) and not 0.0 <= pe <= 1.0:
             raise ValueError("pe must be between 0 and 1.")
-        if not np.is_abstract(tg) and tg < 0:
+        if not math.is_abstract(tg) and tg < 0:
             raise ValueError(f"Invalid gate_time tg ({tg} < 0)")
-        if not np.is_abstract(t1) and t1 <= 0:
+        if not math.is_abstract(t1) and t1 <= 0:
             raise ValueError("Invalid T_1 relaxation time parameter: T_1 <= 0.")
-        if not np.is_abstract(t2) and t2 <= 0:
+        if not math.is_abstract(t2) and t2 <= 0:
             raise ValueError("Invalid T_2 relaxation time parameter: T_2 <= 0.")
-        if not np.is_abstract(t2 - 2 * t1) and t2 - 2 * t1 > 0:
+        if not math.is_abstract(t2 - 2 * t1) and t2 - 2 * t1 > 0:
             raise ValueError("Invalid T_2 relaxation time parameter: T_2 greater than 2 * T_1.")
         # T1 relaxation rate
-        eT1 = np.exp(-tg / t1)
+        eT1 = math.exp(-tg / t1)
         p_reset = 1 - eT1
         # T2 dephasing rate
-        eT2 = np.exp(-tg / t2)
+        eT2 = math.exp(-tg / t2)
 
         def kraus_ops_small_t2():
             pz = (1 - p_reset) * (1 - eT2 / eT1) / 2
@@ -890,50 +899,50 @@ class ThermalRelaxationError(Channel):
             pr1 = pe * p_reset
             pid = 1 - pz - pr0 - pr1
 
-            K0 = np.sqrt(pid + np.eps) * np.eye(2)
-            K1 = np.sqrt(pz + np.eps) * np.array([[1, 0], [0, -1]])
-            K2 = np.sqrt(pr0 + np.eps) * np.array([[1, 0], [0, 0]])
-            K3 = np.sqrt(pr0 + np.eps) * np.array([[0, 1], [0, 0]])
-            K4 = np.sqrt(pr1 + np.eps) * np.array([[0, 0], [1, 0]])
-            K5 = np.sqrt(pr1 + np.eps) * np.array([[0, 0], [0, 1]])
+            K0 = math.sqrt(pid + math.eps) * math.eye(2)
+            K1 = math.sqrt(pz + math.eps) * math.array([[1, 0], [0, -1]])
+            K2 = math.sqrt(pr0 + math.eps) * math.array([[1, 0], [0, 0]])
+            K3 = math.sqrt(pr0 + math.eps) * math.array([[0, 1], [0, 0]])
+            K4 = math.sqrt(pr1 + math.eps) * math.array([[0, 0], [1, 0]])
+            K5 = math.sqrt(pr1 + math.eps) * math.array([[0, 0], [0, 1]])
 
             return [K0, K1, K2, K3, K4, K5]
 
         def kraus_ops_large_t2():
             e0 = p_reset * pe
-            v0 = np.array([[0, 0], [1, 0]])
-            K0 = np.sqrt(e0 + np.eps) * v0
+            v0 = math.array([[0, 0], [1, 0]])
+            K0 = math.sqrt(e0 + math.eps) * v0
             e1 = -p_reset * pe + p_reset
-            v1 = np.array([[0, 1], [0, 0]])
-            K1 = np.sqrt(e1 + np.eps) * v1
+            v1 = math.array([[0, 1], [0, 0]])
+            K1 = math.sqrt(e1 + math.eps) * v1
             base = sum(
                 (
                     4 * eT2**2,
                     4 * p_reset**2 * pe**2,
                     -4 * p_reset**2 * pe,
                     p_reset**2,
-                    np.eps,
+                    math.eps,
                 )
             )
-            common_term = np.sqrt(base)
+            common_term = math.sqrt(base)
             e2 = 1 - p_reset / 2 - common_term / 2
             term2 = 2 * eT2 / (2 * p_reset * pe - p_reset - common_term)
-            v2 = (term2 * np.array([[1, 0], [0, 0]]) + np.array([[0, 0], [0, 1]])) / np.sqrt(
+            v2 = (term2 * math.array([[1, 0], [0, 0]]) + math.array([[0, 0], [0, 1]])) / math.sqrt(
                 term2**2 + 1
             )
-            K2 = np.sqrt(e2 + np.eps) * v2
+            K2 = math.sqrt(e2 + math.eps) * v2
             term3 = 2 * eT2 / (2 * p_reset * pe - p_reset + common_term)
             e3 = 1 - p_reset / 2 + common_term / 2
-            v3 = (term3 * np.array([[1, 0], [0, 0]]) + np.array([[0, 0], [0, 1]])) / np.sqrt(
+            v3 = (term3 * math.array([[1, 0], [0, 0]]) + math.array([[0, 0], [0, 1]])) / math.sqrt(
                 term3**2 + 1
             )
-            K3 = np.sqrt(e3 + np.eps) * v3
-            K4 = np.cast_like(np.zeros((2, 2)), K1)
-            K5 = np.cast_like(np.zeros((2, 2)), K1)
+            K3 = math.sqrt(e3 + math.eps) * v3
+            K4 = math.cast_like(math.zeros((2, 2)), K1)
+            K5 = math.cast_like(math.zeros((2, 2)), K1)
 
             return [K0, K1, K2, K3, K4, K5]
 
-        K = np.cond(t2 <= t1, kraus_ops_small_t2, kraus_ops_large_t2, ())
+        K = math.cond(t2 <= t1, kraus_ops_small_t2, kraus_ops_large_t2, ())
         return K
 
 

--- a/tests/ops/test_channel_ops.py
+++ b/tests/ops/test_channel_ops.py
@@ -124,11 +124,16 @@ class TestAmplitudeDamping:
         with pytest.raises(ValueError, match="gamma must be in the interval"):
             channel.AmplitudeDamping(1.5, wires=0).kraus_matrices()
 
-    expected_jac_fn = lambda self, gamma: [
-        qml.math.array([[0, 0], [0, -1 / (2 * qml.math.sqrt(1 - gamma))]]),
-        qml.math.array([[0, 1 / (2 * qml.math.sqrt(gamma))], [0, 0]]),
-    ]
-    kraus_fn = lambda self, x: qml.math.stack(channel.AmplitudeDamping(x, wires=0).kraus_matrices())
+    @staticmethod
+    def expected_jac_fn(gamma):
+        return [
+            qml.math.array([[0, 0], [0, -1 / (2 * qml.math.sqrt(1 - gamma))]]),
+            qml.math.array([[0, 1 / (2 * qml.math.sqrt(gamma))], [0, 0]]),
+        ]
+
+    @staticmethod
+    def kraus_fn(x):
+        return qml.math.stack(channel.AmplitudeDamping(x, wires=0).kraus_matrices())
 
     @pytest.mark.autograd
     def test_kraus_jac_autograd(self):
@@ -194,27 +199,37 @@ class TestGeneralizedAmplitudeDamping:
         with pytest.raises(ValueError, match="p must be in the interval"):
             channel.GeneralizedAmplitudeDamping(0.0, 1.5, wires=0).kraus_matrices()
 
-    expected_jac_fn = lambda self, gamma, p: (
-        [
-            qml.math.sqrt(p) * qml.math.array([[0, 0], [0, -1 / (2 * qml.math.sqrt(1 - gamma))]]),
-            qml.math.sqrt(p) * qml.math.array([[0, 1 / (2 * qml.math.sqrt(gamma))], [0, 0]]),
-            qml.math.sqrt(1 - p)
-            * qml.math.array([[-1 / (2 * qml.math.sqrt(1 - gamma)), 0], [0, 0]]),
-            qml.math.sqrt(1 - p) * qml.math.array([[0, 0], [1 / (2 * qml.math.sqrt(gamma)), 0]]),
-        ],
-        [
-            1 / (2 * qml.math.sqrt(p)) * qml.math.array([[1, 0], [0, qml.math.sqrt(1 - gamma)]]),
-            1 / (2 * qml.math.sqrt(p)) * qml.math.array([[0, qml.math.sqrt(gamma)], [0, 0]]),
-            -1
-            / (2 * qml.math.sqrt(1 - p))
-            * qml.math.array([[qml.math.sqrt(1 - gamma), 0], [0, 1]]),
-            -1 / (2 * qml.math.sqrt(1 - p)) * qml.math.array([[0, 0], [qml.math.sqrt(gamma), 0]]),
-        ],
-    )
+    @staticmethod
+    def expected_jac_fn(gamma, p):
+        return (
+            [
+                qml.math.sqrt(p)
+                * qml.math.array([[0, 0], [0, -1 / (2 * qml.math.sqrt(1 - gamma))]]),
+                qml.math.sqrt(p) * qml.math.array([[0, 1 / (2 * qml.math.sqrt(gamma))], [0, 0]]),
+                qml.math.sqrt(1 - p)
+                * qml.math.array([[-1 / (2 * qml.math.sqrt(1 - gamma)), 0], [0, 0]]),
+                qml.math.sqrt(1 - p)
+                * qml.math.array([[0, 0], [1 / (2 * qml.math.sqrt(gamma)), 0]]),
+            ],
+            [
+                1
+                / (2 * qml.math.sqrt(p))
+                * qml.math.array([[1, 0], [0, qml.math.sqrt(1 - gamma)]]),
+                1 / (2 * qml.math.sqrt(p)) * qml.math.array([[0, qml.math.sqrt(gamma)], [0, 0]]),
+                -1
+                / (2 * qml.math.sqrt(1 - p))
+                * qml.math.array([[qml.math.sqrt(1 - gamma), 0], [0, 1]]),
+                -1
+                / (2 * qml.math.sqrt(1 - p))
+                * qml.math.array([[0, 0], [qml.math.sqrt(gamma), 0]]),
+            ],
+        )
 
-    kraus_fn = lambda self, gamma, p: qml.math.stack(
-        channel.GeneralizedAmplitudeDamping(gamma, p, wires=0).kraus_matrices()
-    )
+    @staticmethod
+    def kraus_fn(gamma, p):
+        return qml.math.stack(
+            channel.GeneralizedAmplitudeDamping(gamma, p, wires=0).kraus_matrices()
+        )
 
     @pytest.mark.autograd
     def test_kraus_jac_autograd(self):
@@ -278,12 +293,16 @@ class TestPhaseDamping:
         with pytest.raises(ValueError, match="gamma must be in the interval"):
             channel.PhaseDamping(1.5, wires=0).kraus_matrices()
 
-    expected_jac_fn = lambda self, gamma: [
-        qml.math.array([[0, 0], [0, -1 / (2 * qml.math.sqrt(1 - gamma))]]),
-        qml.math.array([[0, 0], [0, 1 / (2 * qml.math.sqrt(gamma))]]),
-    ]
+    @staticmethod
+    def expected_jac_fn(gamma):
+        return [
+            qml.math.array([[0, 0], [0, -1 / (2 * qml.math.sqrt(1 - gamma))]]),
+            qml.math.array([[0, 0], [0, 1 / (2 * qml.math.sqrt(gamma))]]),
+        ]
 
-    kraus_fn = lambda self, x: qml.math.stack(channel.PhaseDamping(x, wires=0).kraus_matrices())
+    @staticmethod
+    def kraus_fn(x):
+        return qml.math.stack(channel.PhaseDamping(x, wires=0).kraus_matrices())
 
     @pytest.mark.autograd
     def test_kraus_jac_autograd(self):
@@ -354,12 +373,16 @@ class TestBitFlip:
         with pytest.raises(ValueError, match="p must be in the interval"):
             channel.BitFlip(1.5, wires=0).kraus_matrices()
 
-    expected_jac_fn = lambda self, p: [
-        -1 / (2 * qml.math.sqrt(1 - p)) * qml.math.eye(2),
-        1 / (2 * qml.math.sqrt(p)) * qml.math.array([[0, 1], [1, 0]]),
-    ]
+    @staticmethod
+    def expected_jac_fn(p):
+        return [
+            -1 / (2 * qml.math.sqrt(1 - p)) * qml.math.eye(2),
+            1 / (2 * qml.math.sqrt(p)) * qml.math.array([[0, 1], [1, 0]]),
+        ]
 
-    kraus_fn = lambda self, x: qml.math.stack(channel.BitFlip(x, wires=0).kraus_matrices())
+    @staticmethod
+    def kraus_fn(x):
+        return qml.math.stack(channel.BitFlip(x, wires=0).kraus_matrices())
 
     @pytest.mark.autograd
     def test_kraus_jac_autograd(self):
@@ -430,11 +453,16 @@ class TestPhaseFlip:
         with pytest.raises(ValueError, match="p must be in the interval"):
             channel.PhaseFlip(1.5, wires=0).kraus_matrices()
 
-    expected_jac_fn = lambda self, p: [
-        -1 / (2 * qml.math.sqrt(1 - p)) * qml.math.eye(2),
-        1 / (2 * qml.math.sqrt(p)) * qml.math.diag([1, -1]),
-    ]
-    kraus_fn = lambda self, x: qml.math.stack(channel.PhaseFlip(x, wires=0).kraus_matrices())
+    @staticmethod
+    def expected_jac_fn(p):
+        return [
+            -1 / (2 * qml.math.sqrt(1 - p)) * qml.math.eye(2),
+            1 / (2 * qml.math.sqrt(p)) * qml.math.diag([1, -1]),
+        ]
+
+    @staticmethod
+    def kraus_fn(x):
+        return qml.math.stack(channel.PhaseFlip(x, wires=0).kraus_matrices())
 
     @pytest.mark.autograd
     def test_kraus_jac_autograd(self):
@@ -507,23 +535,30 @@ class TestDepolarizingChannel:
         with pytest.raises(ValueError, match="p must be in the interval"):
             qml.DepolarizingChannel(1.5, wires=0).kraus_matrices()
 
-    expected_jac_fn = lambda self, p: [
-        -1 / (2 * qml.math.sqrt(1 - p)) * qml.math.eye(2),
-        1 / (6 * qml.math.sqrt(p / 3)) * qml.math.array([[0, 1], [1, 0]]),
-        1 / (6 * qml.math.sqrt(p / 3)) * qml.math.array([[0, -1j], [1j, 0]]),
-        1 / (6 * qml.math.sqrt(p / 3)) * qml.math.diag([1, -1]),
-    ]
+    @staticmethod
+    def expected_jac_fn(p):
+        return [
+            -1 / (2 * qml.math.sqrt(1 - p)) * qml.math.eye(2),
+            1 / (6 * qml.math.sqrt(p / 3)) * qml.math.array([[0, 1], [1, 0]]),
+            1 / (6 * qml.math.sqrt(p / 3)) * qml.math.array([[0, -1j], [1j, 0]]),
+            1 / (6 * qml.math.sqrt(p / 3)) * qml.math.diag([1, -1]),
+        ]
 
-    kraus_fn = lambda self, x: qml.math.stack(
-        channel.DepolarizingChannel(x, wires=0).kraus_matrices()
-    )
+    @staticmethod
+    def kraus_fn(x):
+        return qml.math.stack(channel.DepolarizingChannel(x, wires=0).kraus_matrices())
 
-    kraus_fn_real = lambda self, x: qml.math.real(
-        qml.math.stack(channel.DepolarizingChannel(x, wires=0).kraus_matrices())
-    )
-    kraus_fn_imag = lambda self, x: qml.math.imag(
-        qml.math.stack(channel.DepolarizingChannel(x, wires=0).kraus_matrices())
-    )
+    @staticmethod
+    def kraus_fn_real(x):
+        return qml.math.real(
+            qml.math.stack(channel.DepolarizingChannel(x, wires=0).kraus_matrices())
+        )
+
+    @staticmethod
+    def kraus_fn_imag(x):
+        return qml.math.imag(
+            qml.math.stack(channel.DepolarizingChannel(x, wires=0).kraus_matrices())
+        )
 
     @pytest.mark.autograd
     def test_kraus_jac_autograd(self):
@@ -630,26 +665,28 @@ class TestResetError:
             ),
         )
 
-    expected_jac_fn = lambda self, p0, p1: (
-        [
-            -1 / (2 * qml.math.sqrt(1 - p0 - p1)) * qml.math.eye(2),
-            1 / (2 * qml.math.sqrt(p0)) * qml.math.array([[1, 0], [0, 0]]),
-            1 / (2 * qml.math.sqrt(p0)) * qml.math.array([[0, 1], [0, 0]]),
-            qml.math.zeros((2, 2)),
-            qml.math.zeros((2, 2)),
-        ],
-        [
-            -1 / (2 * qml.math.sqrt(1 - p0 - p1)) * qml.math.eye(2),
-            qml.math.zeros((2, 2)),
-            qml.math.zeros((2, 2)),
-            1 / (2 * qml.math.sqrt(p1)) * qml.math.array([[0, 0], [1, 0]]),
-            1 / (2 * qml.math.sqrt(p1)) * qml.math.array([[0, 0], [0, 1]]),
-        ],
-    )
+    @staticmethod
+    def expected_jac_fn(p0, p1):
+        return (
+            [
+                -1 / (2 * qml.math.sqrt(1 - p0 - p1)) * qml.math.eye(2),
+                1 / (2 * qml.math.sqrt(p0)) * qml.math.array([[1, 0], [0, 0]]),
+                1 / (2 * qml.math.sqrt(p0)) * qml.math.array([[0, 1], [0, 0]]),
+                qml.math.zeros((2, 2)),
+                qml.math.zeros((2, 2)),
+            ],
+            [
+                -1 / (2 * qml.math.sqrt(1 - p0 - p1)) * qml.math.eye(2),
+                qml.math.zeros((2, 2)),
+                qml.math.zeros((2, 2)),
+                1 / (2 * qml.math.sqrt(p1)) * qml.math.array([[0, 0], [1, 0]]),
+                1 / (2 * qml.math.sqrt(p1)) * qml.math.array([[0, 0], [0, 1]]),
+            ],
+        )
 
-    kraus_fn = lambda self, p0, p1: qml.math.stack(
-        channel.ResetError(p0, p1, wires=0).kraus_matrices()
-    )
+    @staticmethod
+    def kraus_fn(p0, p1):
+        return qml.math.stack(channel.ResetError(p0, p1, wires=0).kraus_matrices())
 
     @pytest.mark.autograd
     def test_kraus_jac_autograd(self):
@@ -804,12 +841,17 @@ class TestPauliError:
     def test_kraus_jac_autograd(self, ops):
         p = pnp.array(0.43, requires_grad=True)
         wires = list(range(len(ops)))
-        fn_real = lambda x: qml.math.real(
-            qml.math.stack(channel.PauliError(ops, x, wires=wires).kraus_matrices())
-        )
-        fn_imag = lambda x: qml.math.imag(
-            qml.math.stack(channel.PauliError(ops, x, wires=wires).kraus_matrices())
-        )
+
+        def fn_real(x):
+            return qml.math.real(
+                qml.math.stack(channel.PauliError(ops, x, wires=wires).kraus_matrices())
+            )
+
+        def fn_imag(x):
+            return qml.math.imag(
+                qml.math.stack(channel.PauliError(ops, x, wires=wires).kraus_matrices())
+            )
+
         jac_fn_real = qml.jacobian(fn_real)
         jac_fn_imag = qml.jacobian(fn_imag)
         jac = jac_fn_real(p) + 1j * jac_fn_imag(p)
@@ -822,12 +864,17 @@ class TestPauliError:
 
         p = torch.tensor(0.43, requires_grad=True)
         wires = list(range(len(ops)))
-        fn_real = lambda x: qml.math.real(
-            qml.math.stack(channel.PauliError(ops, x, wires=wires).kraus_matrices())
-        )
-        fn_imag = lambda x: qml.math.imag(
-            qml.math.stack(channel.PauliError(ops, x, wires=wires).kraus_matrices())
-        )
+
+        def fn_real(x):
+            return qml.math.real(
+                qml.math.stack(channel.PauliError(ops, x, wires=wires).kraus_matrices())
+            )
+
+        def fn_imag(x):
+            return qml.math.imag(
+                qml.math.stack(channel.PauliError(ops, x, wires=wires).kraus_matrices())
+            )
+
         jac_real = torch.autograd.functional.jacobian(fn_real, p).detach().numpy()
         jac_imag = torch.autograd.functional.jacobian(fn_imag, p).detach().numpy()
         assert qml.math.allclose(
@@ -853,7 +900,10 @@ class TestPauliError:
 
         p = jax.numpy.array(0.43, dtype=jax.numpy.complex128)
         wires = list(range(len(ops)))
-        fn = lambda x: qml.math.stack(channel.PauliError(ops, x, wires=wires).kraus_matrices())
+
+        def fn(x):
+            return qml.math.stack(channel.PauliError(ops, x, wires=wires).kraus_matrices())
+
         jac_fn = jax.jacobian(fn, holomorphic=True)
         jac = jac_fn(p)
         assert qml.math.allclose(jac, self.expected_jac_fn[ops](p))
@@ -909,6 +959,25 @@ class TestQubitChannel:
         K_list2 = [np.sqrt(p) * Y, np.sqrt(1 - p) * np.eye(2)]
         with pytest.raises(ValueError, match="Only trace preserving channels can be applied."):
             channel.QubitChannel(K_list2 * 2, wires=0)
+
+    @pytest.mark.jax
+    def test_jit_compatibility(self):
+        """Test that QubitChannel can be jitted."""
+
+        import jax
+
+        dev = qml.device("default.mixed", wires=1)
+
+        @jax.jit
+        @qml.qnode(dev, interface="jax")
+        def noise_channel(p):
+            k0 = jax.numpy.sqrt(1 - p) * jax.numpy.eye(2)
+            k1 = jax.numpy.sqrt(p) * jax.numpy.eye(2)
+            qml.QubitChannel([k0, k1], wires=[0])
+            return qml.expval(qml.PauliZ(0))
+
+        # just checking it runs
+        noise_channel(0.1)
 
 
 class TestThermalRelaxationError:


### PR DESCRIPTION
Fixes #5285  [sc-57816]

Adds a `qml.math.is_abstract` check around a validation check that doesn't work with jitting.

I wanted to change `from pennylane import math as np` to `from pennylane import math` in this PR, but I realized that made the PR bigger than it needed to be.

I also had to change a bunch of unnecessary lambda assignments in the test code to standard functions in order to get the file passing pylint.