### PR TITLE
`Prod.terms` and `Sum.terms` don't queue operators

### DIFF
--- a/pennylane/ops/op_math/prod.py
+++ b/pennylane/ops/op_math/prod.py
@@ -472,10 +472,8 @@ class Prod(CompositeOp):
 
         with qml.QueuingManager.stop_recording():
             global_phase, factors = self._simplify_factors(factors=self.operands)
+            factors = list(itertools.product(*factors))
 
-        factors = list(itertools.product(*factors))
-
-        with qml.QueuingManager.stop_recording():
             factors = [
                 Prod(*factor).simplify() if len(factor) > 1 else factor[0] for factor in factors
             ]

--- a/pennylane/ops/op_math/prod.py
+++ b/pennylane/ops/op_math/prod.py
@@ -466,14 +466,19 @@ class Prod(CompositeOp):
         """
         # try using pauli_rep:
         if pr := self.pauli_rep:
-            ops = [pauli.operation() for pauli in pr.keys()]
+            with qml.QueuingManager.stop_recording():
+                ops = [pauli.operation() for pauli in pr.keys()]
             return list(pr.values()), ops
 
-        global_phase, factors = self._simplify_factors(factors=self.operands)
+        with qml.QueuingManager.stop_recording():
+            global_phase, factors = self._simplify_factors(factors=self.operands)
 
         factors = list(itertools.product(*factors))
 
-        factors = [Prod(*factor).simplify() if len(factor) > 1 else factor[0] for factor in factors]
+        with qml.QueuingManager.stop_recording():
+            factors = [
+                Prod(*factor).simplify() if len(factor) > 1 else factor[0] for factor in factors
+            ]
 
         # harvest coeffs and ops
         coeffs = []

--- a/pennylane/ops/op_math/sum.py
+++ b/pennylane/ops/op_math/sum.py
@@ -333,10 +333,12 @@ class Sum(CompositeOp):
         """
         # try using pauli_rep:
         if pr := self.pauli_rep:
-            ops = [pauli.operation() for pauli in pr.keys()]
+            with qml.QueuingManager.stop_recording():
+                ops = [pauli.operation() for pauli in pr.keys()]
             return list(pr.values()), ops
 
-        new_summands = self._simplify_summands(summands=self.operands).get_summands()
+        with qml.QueuingManager.stop_recording():
+            new_summands = self._simplify_summands(summands=self.operands).get_summands()
 
         coeffs = []
         ops = []

--- a/tests/ops/op_math/test_prod.py
+++ b/tests/ops/op_math/test_prod.py
@@ -14,7 +14,7 @@
 """
 Unit tests for the Prod arithmetic class of qubit operations
 """
-# pylint:disable=protected-access
+# pylint:disable=protected-access, unused-argument
 import gate_data as gd  # a file containing matrix rep of each gate
 import numpy as np
 import pytest
@@ -260,6 +260,17 @@ class TestInitialization:  # pylint:disable=too-many-public-methods
         x = qml.numpy.array([1.0, 2.0, 3.0])
         prod_op = prod(qml.PauliX(0), qml.RX(x, wires=0))
         assert prod_op.batch_size == 3
+
+    @pytest.mark.parametrize(
+        "op, coeffs_true, ops_true", PROD_TERMS_OP_PAIRS_PAULI + PROD_TERMS_OP_PAIRS_MIXED
+    )
+    def test_terms_does_not_change_queue(self, op, coeffs_true, ops_true):
+        """Test that calling Prod.terms does not queue anything."""
+        with qml.queuing.AnnotatedQueue() as q:
+            qml.apply(op)
+            _, _ = op.terms()
+
+        assert q.queue == [op]
 
     def test_batch_size_None(self):
         """Test that the batch size is none if no factors have batching."""

--- a/tests/ops/op_math/test_sum.py
+++ b/tests/ops/op_math/test_sum.py
@@ -14,7 +14,7 @@
 """
 Unit tests for the Sum arithmetic class of qubit operations
 """
-# pylint: disable=eval-used
+# pylint: disable=eval-used, unused-argument
 from typing import Tuple
 
 import gate_data as gd  # a file containing matrix rep of each gate
@@ -229,7 +229,7 @@ class TestInitialization:
     ]
     Hamiltonian_mixed = qml.dot(coeffs_, ops_)
 
-    SUM_TERMS_OP_PAIRS_MIXEDPAULI = (  # all operands have pauli representation
+    SUM_TERMS_OP_PAIRS_MIXEDPAULI = (  # not all operands have pauli representation
         (
             qml.sum(*(i * qml.Hadamard(i) for i in range(1, 5))),
             [float(i) for i in range(1, 5)],
@@ -272,6 +272,17 @@ class TestInitialization:
         coeffs, ops1 = op.terms()
         assert coeffs == coeffs_true
         assert ops1 == ops_true
+
+    @pytest.mark.parametrize(
+        "op, coeffs_true, ops_true", SUM_TERMS_OP_PAIRS_PAULI + SUM_TERMS_OP_PAIRS_MIXEDPAULI
+    )
+    def test_terms_does_not_change_queue(self, op, coeffs_true, ops_true):
+        """Test that calling Prod.terms does not queue anything."""
+        with qml.queuing.AnnotatedQueue() as q:
+            qml.apply(op)
+            _, _ = op.terms()
+
+        assert q.queue == [op]
 
     def test_eigen_caching(self):
         """Test that the eigendecomposition is stored in cache."""


### PR DESCRIPTION
**Context:**
Found out that the updates to `Prod.terms` and `Sum.terms` cause new operators to get queued.

**Description of the Change:**
* Added a bunch of `qml.QueuingManager.stop_recording()`s

I didn't add a changelog entry because the changes to `Sum/Prod.terms()` are part of v0.35.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
