### PR TITLE
Address spelling/formatting errors in docs

### DIFF
--- a/doc/development/guide/architecture.rst
+++ b/doc/development/guide/architecture.rst
@@ -279,6 +279,6 @@ coded entirely in the framework's language (such as a TensorFlow quantum simulat
 Most devices, however, are blackboxes with regards to the autodifferentiation framework.
 This means that when the execution on the device begins, autograd, jax, PyTorch and TensorFlow
 tensors need to be converted to formats that the device understands - which is in most cases
-a representation as Numpy arrays. Likewise, the results of the execution have to be translated
+a representation as NumPy arrays. Likewise, the results of the execution have to be translated
 back to differentiable tensors. These two conversions happen at what PennyLane calls the
 "interface", and you can specify this interface in the QNode with the ``interface`` keyword argument.

--- a/pennylane/math/fidelity.py
+++ b/pennylane/math/fidelity.py
@@ -41,7 +41,7 @@ def fidelity_statevector(state0, state1, check_state=False, c_dtype="complex128"
     representation of pure states.
 
     .. note::
-        It supports all interfaces (Numpy, Autograd, Torch, Tensorflow and Jax). The second state is coerced
+        It supports all interfaces (NumPy, Autograd, Torch, TensorFlow and Jax). The second state is coerced
         to the type and dtype of the first state. The fidelity is returned in the type of the interface of the
         first state.
 
@@ -104,7 +104,7 @@ def fidelity(state0, state1, check_state=False, c_dtype="complex128"):
         F( \rho , \sigma ) = \text{Tr}( \sqrt{\sqrt{\rho} \sigma \sqrt{\rho}})^2
 
     .. note::
-        It supports all interfaces (Numpy, Autograd, Torch, Tensorflow and Jax). The second state is coerced
+        It supports all interfaces (NumPy, Autograd, Torch, TensorFlow and Jax). The second state is coerced
         to the type and dtype of the first state. The fidelity is returned in the type of the interface of the
         first state.
 

--- a/pennylane/math/quantum.py
+++ b/pennylane/math/quantum.py
@@ -582,7 +582,7 @@ def _compute_purity(density_matrix):
 
 def vn_entropy(state, indices, base=None, check_state=False, c_dtype="complex128"):
     r"""Compute the Von Neumann entropy from a density matrix on a given subsystem. It supports all
-    interfaces (Numpy, Autograd, Torch, Tensorflow and Jax).
+    interfaces (NumPy, Autograd, Torch, TensorFlow and Jax).
 
     .. math::
         S( \rho ) = -\text{Tr}( \rho \log ( \rho ))
@@ -666,7 +666,7 @@ def mutual_info(state, indices0, indices1, base=None, check_state=False, c_dtype
     The mutual information is a measure of correlation between two subsystems.
     More specifically, it quantifies the amount of information obtained about
     one system by measuring the other system. It supports all interfaces
-    (Numpy, Autograd, Torch, Tensorflow and Jax).
+    (NumPy, Autograd, Torch, TensorFlow and Jax).
 
     Each state must be given as a density matrix. To find the mutual information given
     a pure state, call :func:`~.math.dm_from_state_vector` first.
@@ -936,7 +936,7 @@ def _check_state_vector(state_vector):
 
 def max_entropy(state, indices, base=None, check_state=False, c_dtype="complex128"):
     r"""Compute the maximum entropy of a density matrix on a given subsystem. It supports all
-    interfaces (Numpy, Autograd, Torch, Tensorflow and Jax).
+    interfaces (NumPy, Autograd, Torch, TensorFlow and Jax).
 
     .. math::
         S_{\text{max}}( \rho ) = \log( \text{rank} ( \rho ))

--- a/pennylane/math/utils.py
+++ b/pennylane/math/utils.py
@@ -530,7 +530,7 @@ def requires_grad(tensor, interface=None):
 
 def in_backprop(tensor, interface=None):
     """Returns True if the tensor is considered to be in a backpropagation environment, it works for Autograd,
-    Tensorflow and Jax. It is not only checking the differentiability of the tensor like :func:`~.requires_grad`, but
+    TensorFlow and Jax. It is not only checking the differentiability of the tensor like :func:`~.requires_grad`, but
     rather checking if the gradient is actually calculated.
 
     Args:

--- a/pennylane/measurements/probs.py
+++ b/pennylane/measurements/probs.py
@@ -43,7 +43,7 @@ def probs(wires=None, op=None) -> "ProbabilityMP":
 
     Args:
         wires (Sequence[int] or int): the wire the operation acts on
-        op (Observable or MeasurementValue]): Observable (with a ``diagonalizing_gates``
+        op (Observable or MeasurementValue): Observable (with a ``diagonalizing_gates``
             attribute) that rotates the computational basis, or a  ``MeasurementValue``
             corresponding to mid-circuit measurements.
 

--- a/pennylane/ops/op_math/controlled.py
+++ b/pennylane/ops/op_math/controlled.py
@@ -56,7 +56,7 @@ def ctrl(op, control, control_values=None, work_wires=None):
         work_wires (Any): Any auxiliary wires that can be used in the decomposition
 
     Returns:
-        (function or :class:`~.operation.Operator`): If an Operator is provided, returns a Controlled version of the Operator.
+        function or :class:`~.operation.Operator`: If an Operator is provided, returns a Controlled version of the Operator.
         If a function is provided, returns a function with the same call signature that creates a controlled version of the
         provided function.
 

--- a/pennylane/ops/qubit/special_unitary.py
+++ b/pennylane/ops/qubit/special_unitary.py
@@ -226,7 +226,7 @@ class SpecialUnitary(Operation):
 
     .. warning::
 
-        This operation only is differentiable when using the JAX, Torch or Tensorflow
+        This operation only is differentiable when using the JAX, Torch or TensorFlow
         interfaces, even when using hardware-compatible differentiation techniques like
         the parameter-shift rule.
 
@@ -276,7 +276,7 @@ class SpecialUnitary(Operation):
             -0.29040522+0.00830631j,  0.15015337-0.76933485j]])
 
     The ``SpecialUnitary`` operation also can be differentiated with hardware-compatible
-    differentiation techniques if the JAX, Torch or Tensorflow interface is used.
+    differentiation techniques if the JAX, Torch or TensorFlow interface is used.
     See the theoretical background section below for details.
 
     .. details::
@@ -535,7 +535,7 @@ class SpecialUnitary(Operation):
 
             An auto-differentiation framework is required for this function.
             The matrix exponential is not differentiable in Autograd. Therefore this function
-            only supports JAX, Torch and Tensorflow.
+            only supports JAX, Torch and TensorFlow.
 
         """
         theta = self.data[0]

--- a/pennylane/qcut/cutcircuit_mc.py
+++ b/pennylane/qcut/cutcircuit_mc.py
@@ -113,7 +113,7 @@ def cut_circuit_mc(
             :func:`~.find_and_place_cuts` and :func:`~.kahypar_cut` for the available arguments.
 
     Returns:
-        qnode (QNode) or tuple[List[QuantumTape], function]:
+        qnode (QNode) or Tuple[List[QuantumTape], function]:
 
         The transformed circuit as described in :func:`qml.transform <pennylane.transform>`. Executing this circuit
         will sample from the partitioned circuit fragments and combine the results using a Monte Carlo method.

--- a/pennylane/transforms/batch_partial.py
+++ b/pennylane/transforms/batch_partial.py
@@ -55,7 +55,7 @@ def batch_partial(qnode, all_operations=False, preprocess=None, **partial_kwargs
         partial_kwargs (dict): pre-supplied arguments to pass to the QNode.
 
     Returns:
-        func: Function which wraps the QNode and accepts the same arguments minus the
+        function: Function which wraps the QNode and accepts the same arguments minus the
         pre-supplied arguments provided. The first dimension of each argument of the
         wrapper function will be treated as a batch dimension.
 

--- a/pennylane/transforms/optimization/pattern_matching.py
+++ b/pennylane/transforms/optimization/pattern_matching.py
@@ -191,7 +191,7 @@ def pattern_matching_optimization(
 
     .. seealso:: :func:`~.pattern_matching`
 
-    **Reference:**
+    **References**
 
     [1] Iten, R., Moyard, R., Metger, T., Sutter, D. and Woerner, S., 2022.
     Exact and practical pattern matching for quantum circuit optimization.

--- a/pennylane/workflow/execution.py
+++ b/pennylane/workflow/execution.py
@@ -450,7 +450,7 @@ def execute(
     device_vjp=False,
 ) -> ResultBatch:
     """New function to execute a batch of tapes on a device in an autodifferentiable-compatible manner. More cases will be added,
-    during the project. The current version is supporting forward execution for Numpy and does not support shot vectors.
+    during the project. The current version is supporting forward execution for NumPy and does not support shot vectors.
 
     Args:
         tapes (Sequence[.QuantumTape]): batch of tapes to execute

--- a/pennylane/workflow/interfaces/jax.py
+++ b/pennylane/workflow/interfaces/jax.py
@@ -153,7 +153,7 @@ class _NonPytreeWrapper:
 
     * Operators that aren't valid pytrees: ex. ParametrizedEvolution, ParametrizedHamiltonian, HardwareHamiltonian
     * Validation checks on initialization: see BasisStateProjector, StatePrep that does not allow the operator to store the cotangents
-    * Jitting non-jax parametrized circuits.  Numpy parameters turn into abstract parameters during the pytree process.
+    * Jitting non-jax parametrized circuits.  NumPy parameters turn into abstract parameters during the pytree process.
 
     ``jax.custom_vjp`` forbids any non-differentiable argument to be a pytree, so we need to wrap it in a non-pytree type.
 

--- a/pennylane/workflow/interfaces/tensorflow.py
+++ b/pennylane/workflow/interfaces/tensorflow.py
@@ -15,7 +15,7 @@
 This module contains functions for adding the TensorFlow interface
 to a PennyLane Device class.
 
-**How to bind a custom derivative with Tensorflow.**
+**How to bind a custom derivative with TensorFlow.**
 
 To bind a custom derivative with tensorflow, you:
 


### PR DESCRIPTION
Some spelling errors were found during QA. Fixed here.