### PR TITLE
Stop queuing terms with `SProd.terms()`

### DIFF
--- a/pennylane/ops/op_math/sprod.py
+++ b/pennylane/ops/op_math/sprod.py
@@ -207,7 +207,8 @@ class SProd(ScalarSymbolicOp):
         """
         # try using pauli_rep:
         if pr := self.pauli_rep:
-            ops = [pauli.operation() for pauli in pr.keys()]
+            with qml.QueuingManager.stop_recording():
+                ops = [pauli.operation() for pauli in pr.keys()]
             return list(pr.values()), ops
 
         if isinstance(base := self.base, (Sum, qml.ops.Prod)):

--- a/tests/ops/op_math/test_sprod.py
+++ b/tests/ops/op_math/test_sprod.py
@@ -183,6 +183,7 @@ class TestInitialization:
             [0.5, 0.5],
             [qml.X(0), qml.prod(qml.X(0), qml.X(1))],
         ),
+        (qml.s_prod(0.5, qml.Hadamard(0)), [0.5], [qml.Hadamard(0)]),
     )
 
     @pytest.mark.parametrize("op, true_coeffs, true_ops", TERMS)
@@ -190,6 +191,15 @@ class TestInitialization:
         coeffs, ops_ = op.terms()
         assert coeffs == true_coeffs
         assert ops_ == true_ops
+
+    @pytest.mark.parametrize("op, true_coeffs, true_ops", TERMS)
+    def test_terms_queuing(self, op, true_coeffs, true_ops):  # pylint: disable=unused-argument
+        """Test that no operations are queued by SProd.terms"""
+        with qml.queuing.AnnotatedQueue() as q:
+            qml.apply(op)
+            _, _ = op.terms()
+
+        assert q.queue == [op]
 
     def test_decomposition_raises_error(self):
         sprod_op = s_prod(3.14, qml.Identity(wires=1))


### PR DESCRIPTION
Follow up to #5292 . Missed `SProd.terms`, which was still queuing the terms if the `SProd` has a pauli rep.