### PR TITLE
Update condition for swapping iterators in `PauliWord._matmul` 

### DIFF
--- a/pennylane/pauli/pauli_arithmetic.py
+++ b/pennylane/pauli/pauli_arithmetic.py
@@ -227,7 +227,7 @@ class PauliWord(dict):
     def _matmul(self, other):
         """Private matrix multiplication that returns (pauli_word, coeff) tuple for more lightweight processing"""
         base, iterator, swapped = (
-            (self, other, False) if len(self) > len(other) else (other, self, True)
+            (self, other, False) if len(self) >= len(other) else (other, self, True)
         )
         result = copy(dict(base))
         coeff = 1


### PR DESCRIPTION
**Context:**
We found that the wire order in `Sum/Prod.terms` was being swapped for the first and second term in terms that were `Prod`s. This was due to the use of the `pauli_rep`. While building the pauli rep, we use `PauliWord._matmul` which swaps the order of `self` and `other` if `len(other) >= len(self)` so that we iterate through the larger `PauliWord`.

Example:
```python
H = qml.prod(X(0), X(1), X(2))
Sum_coeffs, Sum_ops = H.terms()
```
```pycon
>>> Sum_ops[0].wires, H.wires
(<Wires = [1, 0, 2]>, <Wires = [0, 1, 2]>)
```

**Description of the Change:**
Changed the condition for swapping from `len(other) >= len(self)` to `len(other) > len(self)`.

**Benefits:**
More consistent `Sum/Prod.pauli_rep`, and `Sum/Prod.terms()` with the original operands. The above example now behaves as follows:
```python
H = qml.prod(X(0), X(1), X(2))
Sum_coeffs, Sum_ops = H.terms()
```
```pycon
>>> Sum_ops[0].wires, H.wires
(<Wires = [0, 1, 2]>, <Wires = [0, 1, 2]>)
```

**Possible Drawbacks:**

**Related GitHub Issues:**
