### PR TITLE
Entanglement entropy of pure bipartite states

### DIFF
--- a/pennylane/math/__init__.py
+++ b/pennylane/math/__init__.py
@@ -76,6 +76,7 @@ from .quantum import (
     relative_entropy,
     sqrt_matrix,
     vn_entropy,
+    vn_entanglement_entropy,
     max_entropy,
     min_entropy,
     trace_distance,
@@ -180,5 +181,6 @@ __all__ = [
     "trace_distance",
     "unwrap",
     "vn_entropy",
+    "vn_entanglement_entropy",
     "where",
 ]

--- a/pennylane/math/quantum.py
+++ b/pennylane/math/quantum.py
@@ -733,6 +733,80 @@ def _compute_mutual_info(
     return vn_entropy_1 + vn_entropy_2 - vn_entropy_12
 
 
+# pylint: disable=too-many-arguments
+def vn_entanglement_entropy(
+    state, indices0, indices1, base=None, check_state=False, c_dtype="complex128"
+):
+    r"""Compute the Von Neumann entanglement entropy between two subsystems in a given state
+
+    .. math::
+
+        S(\rho_A) = -\text{Tr}[\rho_A log \rho_A] = -\text{Tr}[\rho_B log \rho_B] = S(\rho_B)
+
+    where :math:`S` is the von Neumann entropy, and :math:`\rho_A = \text{Tr_B}[\rho_{AB}]` and
+    :math:`\rho_B = \text{Tr_A}[\rho_{AB}]` are the reduced density matrices for each partition.
+
+    The Von Neumann entanglement entropy is a measure of the degree of quantum entanglement between
+    two subsystems constituting a pure bipartite quantum state. The entropy of entanglement is the
+    Von Neumann entropy of the reduced density matrix for any of the subsystems. If it is non-zero,
+    it indicates the two subsystems are entangled.
+
+    Each state must be given as a density matrix. To find the mutual information given
+    a pure state, call :func:`~.math.dm_from_state_vector` first.
+
+    Args:
+        state (tensor_like): ``(2**N)`` state vector or ``(2**N, 2**N)`` density matrix.
+        indices0 (list[int]): List of indices in the first subsystem.
+        indices1 (list[int]): List of indices in the second subsystem.
+        base (float): Base for the logarithm. If None, the natural logarithm is used.
+        check_state (bool): If True, the function will check the state validity (shape and norm).
+        c_dtype (str): Complex floating point precision type.
+
+    Returns:
+        float: The von Neumann entanglement entropy of the bipartite state.
+
+    **Examples**
+
+    The entanglement entropy between subsystems for a state vector can be returned as follows:
+    >>> x = np.array([0, -1, 1, 0]) / np.sqrt(2)
+    >>> qml.math.vn_entanglement_entropy(x, indices0=[0], indices1=[1])
+    0.6931471805599453
+
+    It is also possible to change the log basis.
+    >>> qml.math.vn_entanglement_entropy(x, indices0=[0], indices1=[1], base=2)
+    1
+
+    Similarly, the quantum state can be provided as a density matrix:
+    >>> y = np.array([[1, 1, -1, -1], [1, 1, -1, -1], [-1, -1, 1, 1], [-1, -1, 1, 1]]) * 0.25
+    >>> qml.math.vn_entanglement_entropy(y, indices0=[0], indices1=[1])
+    0
+
+    """
+
+    # The subsystems cannot overlap
+    if len([index for index in indices0 if index in indices1]) > 0:
+        raise ValueError("Subsystems for computing the entanglement entropy must not overlap.")
+
+    return _compute_vn_entanglement_entropy(
+        state, indices0, indices1, base=base, check_state=check_state, c_dtype=c_dtype
+    )
+
+
+def _compute_vn_entanglement_entropy(
+    state, indices0, _, base=None, check_state=False, c_dtype="complex128"
+):
+    """Computes the Von Neumann entanglement entropy between the subsystems."""
+
+    vn_entropy_1 = vn_entropy(
+        state, indices=indices0, base=base, check_state=check_state, c_dtype=c_dtype
+    )
+
+    # The Von Neumann entropy of the two subsystems should be the same if the overall state is a
+    # pure state. Here we trust that the user only uses this function for pure states, and do not
+    # perform any checks so that the code is compatible with jax.jit
+    return vn_entropy_1
+
+
 def sqrt_matrix(density_matrix):
     r"""Compute the square root matrix of a density matrix where :math:`\rho = \sqrt{\rho} \times \sqrt{\rho}`
 

--- a/pennylane/qinfo/__init__.py
+++ b/pennylane/qinfo/__init__.py
@@ -23,4 +23,5 @@ from .transforms import (
     fidelity,
     relative_entropy,
     trace_distance,
+    vn_entanglement_entropy,
 )

--- a/pennylane/qinfo/transforms.py
+++ b/pennylane/qinfo/transforms.py
@@ -295,6 +295,42 @@ def _vn_entropy_qnode(self, qnode, targs, tkwargs):
     return self.default_qnode_transform(qnode, targs, tkwargs)
 
 
+def _bipartite_qinfo_transform(
+    transform_func: Callable,
+    tape: QuantumTape,
+    wires0: Sequence[int],
+    wires1: Sequence[int],
+    base: float = None,
+    **kwargs
+):
+
+    # device_wires is provided by the custom QNode transform
+    all_wires = kwargs.get("device_wires", tape.wires)
+    wire_map = {w: i for i, w in enumerate(all_wires)}
+    indices0 = [wire_map[w] for w in wires0]
+    indices1 = [wire_map[w] for w in wires1]
+
+    # Check measurement
+    measurements = tape.measurements
+    if len(measurements) != 1 or not isinstance(measurements[0], StateMP):
+        raise ValueError("The qfunc return type needs to be a state.")
+
+    def processing_fn(res):
+        # device is provided by the custom QNode transform
+        device = kwargs.get("device", None)
+        c_dtype = getattr(device, "C_DTYPE", "complex128")
+
+        density_matrix = (
+            res[0]
+            if isinstance(measurements[0], DensityMatrixMP) or isinstance(device, DefaultMixed)
+            else qml.math.dm_from_state_vector(res[0], c_dtype=c_dtype)
+        )
+        entropy = transform_func(density_matrix, indices0, indices1, base=base, c_dtype=c_dtype)
+        return entropy
+
+    return [tape], processing_fn
+
+
 @partial(transform, final_transform=True)
 def mutual_info(
     tape: QuantumTape, wires0: Sequence[int], wires1: Sequence[int], base: float = None, **kwargs
@@ -348,33 +384,7 @@ def mutual_info(
 
     .. seealso:: :func:`~.qinfo.vn_entropy`, :func:`pennylane.math.mutual_info` and :func:`pennylane.mutual_info`
     """
-    # device_wires is provided by the custom QNode transform
-    all_wires = kwargs.get("device_wires", tape.wires)
-    wire_map = {w: i for i, w in enumerate(all_wires)}
-    indices0 = [wire_map[w] for w in wires0]
-    indices1 = [wire_map[w] for w in wires1]
-
-    # Check measurement
-    measurements = tape.measurements
-    if len(measurements) != 1 or not isinstance(measurements[0], StateMP):
-        raise ValueError("The qfunc return type needs to be a state.")
-
-    def processing_fn(res):
-        # device is provided by the custom QNode transform
-        device = kwargs.get("device", None)
-        c_dtype = getattr(device, "C_DTYPE", "complex128")
-
-        density_matrix = (
-            res[0]
-            if isinstance(measurements[0], DensityMatrixMP) or isinstance(device, DefaultMixed)
-            else qml.math.dm_from_state_vector(res[0], c_dtype=c_dtype)
-        )
-        entropy = qml.math.mutual_info(
-            density_matrix, indices0, indices1, base=base, c_dtype=c_dtype
-        )
-        return entropy
-
-    return [tape], processing_fn
+    return _bipartite_qinfo_transform(qml.math.mutual_info, tape, wires0, wires1, base, **kwargs)
 
 
 @mutual_info.custom_qnode_transform
@@ -393,6 +403,42 @@ def _mutual_info_qnode(self, qnode, targs, tkwargs):
     tkwargs.setdefault("device", qnode.device)
     tkwargs.setdefault("device_wires", qnode.device.wires)
     return self.default_qnode_transform(qnode, targs, tkwargs)
+
+
+@partial(transform, final_transform=True)
+def vn_entanglement_entropy(
+    tape, wires0: Sequence[int], wires1: Sequence[int], base: float = None, **kwargs
+):
+    r"""Compute the Von Neumann entanglement entropy from a circuit returning a :func:`~pennylane.state`:
+
+    .. math::
+
+        S(\rho_A) = -\text{Tr}[\rho_A log \rho_A] = -\text{Tr}[\rho_B log \rho_B] = S(\rho_B)
+
+    where :math:`S` is the von Neumann entropy; :math:`\rho_A = \text{Tr_B}[\rho_{AB}]` and
+    :math:`\rho_B = \text{Tr_A}[\rho_{AB}]` are the reduced density matrices for each partition.
+
+    The Von Neumann entanglement entropy is a measure of the degree of quantum entanglement between
+    two subsystems constituting a pure bipartite quantum state. The entropy of entanglement is the
+    Von Neumann entropy of the reduced density matrix for any of the subsystems. If it is non-zero,
+    it indicates the two subsystems are entangled.
+
+    Args:
+        tape (QNode or QuantumTape or Callable): A quantum circuit returning a :func:`~pennylane.state`.
+        wires0 (Sequence(int)): List of wires in the first subsystem.
+        wires1 (Sequence(int)): List of wires in the second subsystem.
+        base (float): Base for the logarithm. If None, the natural logarithm is used.
+
+    Returns:
+        qnode (QNode) or quantum function (Callable) or tuple[List[QuantumTape], function]:
+
+        The transformed circuit as described in :func:`qml.transform <pennylane.transform>`. Executing this circuit
+        will provide the entanglement entropy in the form of a tensor.
+
+    """
+    return _bipartite_qinfo_transform(
+        qml.math.vn_entanglement_entropy, tape, wires0, wires1, base, **kwargs
+    )
 
 
 # TODO: create qml.math.jacobian and replace it here

--- a/tests/qinfo/test_vn_entanglement_entropy.py
+++ b/tests/qinfo/test_vn_entanglement_entropy.py
@@ -1,0 +1,225 @@
+# Copyright 2024 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the vn entanglement entropy transform"""
+
+
+import pytest
+import numpy as np
+import pennylane as qml
+
+
+class TestVnEntanglementEntropy:
+    """Tests for the vn entanglement entropy transform"""
+
+    @pytest.mark.all_interfaces
+    @pytest.mark.parametrize("device", ["default.qubit", "lightning.qubit"])
+    @pytest.mark.parametrize("interface", ["autograd", "jax", "tensorflow", "torch"])
+    @pytest.mark.parametrize("params", np.linspace(0, 2 * np.pi, 4)[1:])
+    def test_qnode_transform(self, device, interface, params):
+        """Test that the entanglement entropy transform works for QNodes"""
+
+        dev = qml.device(device, wires=2)
+        params = qml.math.asarray(params, like=interface)
+
+        @qml.qnode(dev, interface=interface)
+        def circuit(theta):
+            qml.RY(theta, wires=0)
+            qml.CNOT(wires=[0, 1])
+            return qml.state()
+
+        actual = qml.qinfo.vn_entanglement_entropy(circuit, wires0=[0], wires1=[1])(params)
+
+        # Compare transform results with analytic values
+        expected = -np.cos(params / 2) ** 2 * np.log(np.cos(params / 2) ** 2) - np.sin(
+            params / 2
+        ) ** 2 * np.log(np.sin(params / 2) ** 2)
+
+        assert qml.math.allclose(actual, expected)
+
+    @pytest.mark.jax
+    @pytest.mark.parametrize("params", np.linspace(0, 2 * np.pi, 4)[1:])
+    def test_qnode_transform_jax_jit(self, params):
+        """Test that the entanglement entropy works for QNodes for the JAX-jit interface"""
+
+        import jax
+        import jax.numpy as jnp
+
+        dev = qml.device("default.qubit", wires=2)
+
+        params = jnp.array(params)
+
+        @qml.qnode(dev, interface="jax-jit")
+        def circuit(theta):
+            qml.RY(theta, wires=0)
+            qml.CNOT(wires=[0, 1])
+            return qml.state()
+
+        actual = jax.jit(qml.qinfo.vn_entanglement_entropy(circuit, wires0=[0], wires1=[1]))(params)
+
+        # Compare transform results with analytic values
+        expected = -jnp.cos(params / 2) ** 2 * jnp.log(jnp.cos(params / 2) ** 2) - jnp.sin(
+            params / 2
+        ) ** 2 * jnp.log(jnp.sin(params / 2) ** 2)
+
+        assert qml.math.allclose(actual, expected)
+
+    @pytest.mark.autograd
+    @pytest.mark.parametrize("params", np.linspace(0, 2 * np.pi, 4)[1:])
+    def test_qnode_transform_grad(self, params):
+
+        dev = qml.device("default.qubit", wires=2)
+
+        @qml.qnode(dev, diff_method="backprop")
+        def circuit(theta):
+            qml.RY(theta, wires=0)
+            qml.CNOT(wires=[0, 1])
+            return qml.state()
+
+        actual = qml.grad(qml.qinfo.vn_entanglement_entropy(circuit, wires0=[0], wires1=[1]))(
+            params
+        )
+
+        # Compare transform results with analytic values
+        expected = (
+            np.sin(params / 2)
+            * np.cos(params / 2)
+            * (np.log(np.cos(params / 2) ** 2) - np.log(np.sin(params / 2) ** 2))
+        )
+
+        assert qml.math.allclose(actual, expected)
+
+    @pytest.mark.jax
+    @pytest.mark.parametrize("params", np.linspace(0, 2 * np.pi, 4)[1:])
+    def test_qnode_transform_grad_jax(self, params):
+        import jax
+
+        dev = qml.device("default.qubit", wires=2)
+
+        @qml.qnode(dev, interface="jax", diff_method="backprop")
+        def circuit(theta):
+            qml.RY(theta, wires=0)
+            qml.CNOT(wires=[0, 1])
+            return qml.state()
+
+        actual = jax.grad(qml.qinfo.vn_entanglement_entropy(circuit, wires0=[0], wires1=[1]))(
+            jax.numpy.array(params)
+        )
+
+        # Compare transform results with analytic values
+        expected = (
+            np.sin(params / 2)
+            * np.cos(params / 2)
+            * (np.log(np.cos(params / 2) ** 2) - np.log(np.sin(params / 2) ** 2))
+        )
+
+        assert qml.math.allclose(actual, expected, rtol=1e-04, atol=1e-05)
+
+    @pytest.mark.jax
+    @pytest.mark.parametrize("params", np.linspace(0, 2 * np.pi, 4)[1:])
+    def test_qnode_transform_grad_jax_jit(self, params):
+        import jax
+
+        dev = qml.device("default.qubit", wires=2)
+
+        @qml.qnode(dev, interface="jax", diff_method="backprop")
+        def circuit(theta):
+            qml.RY(theta, wires=0)
+            qml.CNOT(wires=[0, 1])
+            return qml.state()
+
+        actual = jax.jit(
+            jax.grad(qml.qinfo.vn_entanglement_entropy(circuit, wires0=[0], wires1=[1]))
+        )(jax.numpy.array(params))
+
+        # Compare transform results with analytic values
+        expected = (
+            np.sin(params / 2)
+            * np.cos(params / 2)
+            * (np.log(np.cos(params / 2) ** 2) - np.log(np.sin(params / 2) ** 2))
+        )
+
+        assert qml.math.allclose(actual, expected, rtol=1e-04, atol=1e-05)
+
+    @pytest.mark.torch
+    @pytest.mark.parametrize("params", np.linspace(0, 2 * np.pi, 4)[1:])
+    def test_qnode_transform_grad_torch(self, params):
+
+        import torch
+
+        dev = qml.device("default.qubit", wires=2)
+
+        @qml.qnode(dev, interface="torch", diff_method="backprop")
+        def circuit(theta):
+            qml.RY(theta, wires=0)
+            qml.CNOT(wires=[0, 1])
+            return qml.state()
+
+        # Compare transform results with analytic values
+        expected = (
+            np.sin(params / 2)
+            * np.cos(params / 2)
+            * (np.log(np.cos(params / 2) ** 2) - np.log(np.sin(params / 2) ** 2))
+        )
+
+        params = torch.tensor(params, dtype=torch.float64, requires_grad=True)
+        entropy = qml.qinfo.vn_entanglement_entropy(circuit, wires0=[0], wires1=[1])(params)
+        entropy.backward()
+        actual = params.grad
+
+        assert qml.math.allclose(actual, expected)
+
+    @pytest.mark.tf
+    @pytest.mark.parametrize("params", np.linspace(0, 2 * np.pi, 4)[1:])
+    def test_qnode_transform_grad_tf(self, params):
+        import tensorflow as tf
+
+        dev = qml.device("default.qubit", wires=2)
+
+        @qml.qnode(dev, interface="tf", diff_method="backprop")
+        def circuit(theta):
+            qml.RY(theta, wires=0)
+            qml.CNOT(wires=[0, 1])
+            return qml.state()
+
+        # Compare transform results with analytic values
+        expected = (
+            np.sin(params / 2)
+            * np.cos(params / 2)
+            * (np.log(np.cos(params / 2) ** 2) - np.log(np.sin(params / 2) ** 2))
+        )
+
+        params = tf.Variable(params)
+        with tf.GradientTape() as tape:
+            entropy = qml.qinfo.vn_entanglement_entropy(circuit, wires0=[0], wires1=[1])(params)
+        actual = tape.gradient(entropy, params)
+
+        assert qml.math.allclose(actual, expected)
+
+    def test_qnode_transform_not_state(self):
+        """Test the qnode transform needs a QNode returning state."""
+
+        dev = qml.device("default.qubit", wires=2)
+
+        @qml.qnode(dev)
+        def circuit(theta):
+            qml.RY(theta, wires=0)
+            qml.CNOT(wires=[0, 1])
+            return qml.expval(qml.PauliX(wires=0))
+
+        with pytest.raises(
+            ValueError,
+            match="The qfunc return type needs to be a state.",
+        ):
+            qml.qinfo.vn_entanglement_entropy(circuit, wires0=[0], wires1=[1])(0.1)


### PR DESCRIPTION
**Context:**

[Quantifying the entanglement](https://www.quantiki.org/wiki/entanglement-measure) for example by determining the [entropy of entanglement](https://en.wikipedia.org/wiki/Entropy_of_entanglement) of bipartite quantum states can be useful for applications of quantum information (e.g., in quantum cryptography).

One way of determining entanglement entropy is to compute the [von Neumann entropy](https://docs.pennylane.ai/en/stable/code/api/pennylane.qinfo.transforms.vn_entropy.html) of one of the reduced states (see [reduced density matrix feature](https://docs.pennylane.ai/en/stable/code/api/pennylane.qinfo.transforms.reduced_dm.html) here).

It could be useful to add a user interface for such a measure specifically for the bipartite quantum state case.

**Description of the Change:**

The von Neumann entanglement entropy feature is now added to ```math``` and ```qinfo```. ```qml.math.vn_entanglement_entropy()``` returns the Von Neumann entanglement entropy between two subsystems in a given density matrix. ```qml.qinfo.vn_entanglement_entropy()``` computes the Von Neumann entanglement entropy from a ```QNode``` returning a ```state()```.

**Benefits:**

It enables users to find the entanglement entropy of a pure bipartite state.

**Possible Drawbacks:**

The von Neumann entanglement entropy is only defined for pure bipartite states. The current implementation does not perform any checks on if the overall input state is pure or mixed, since such a check would be jax.jit-unfriendly.

**Related GitHub Issues:**
https://github.com/PennyLaneAI/pennylane/issues/3150

**Related Shortcut Story**
[sc-55206]
