### PR TITLE
Fix available compiler test in catalyst 0.5.0.

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -23,10 +23,14 @@
 * We no longer perform unwanted dtype promotion in the `pauli_rep` of `SProd` instances when using tensorflow.
   [(#5246)](https://github.com/PennyLaneAI/pennylane/pull/5246)
 
+* Fixes incorrect tests after upgrading Catalyst to version 0.5.0.
+  [(#5310)](https://github.com/PennyLaneAI/pennylane/pull/5310)
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):
 
 Soran Jahangiri,
 Korbinian Kottmann,
+Erick Ochoa Lopez,
 Matthew Silverman.

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -683,7 +683,7 @@ class TestCatalystGrad:
     def test_vjp(self):
         """Test that the correct VJP is returned with QJIT."""
 
-        def f(params):
+        def f(x):
             y = [jnp.sin(x[0]), x[1] ** 2, x[0] * x[1]]
             return jnp.stack(y)
 

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -68,7 +68,9 @@ class TestCatalyst:
         assert not qml.compiler.available("SomeRandomCompiler")
 
         assert qml.compiler.available("catalyst")
-        assert qml.compiler.available_compilers() == ["catalyst"]
+        available_compilers = qml.compiler.available_compilers()
+        expected_compilers = {"catalyst", "cuda_quantum"}
+        assert all(compiler in expected_compilers for compiler in available_compilers)
 
     def test_active_compiler(self):
         """Test `qml.compiler.active_compiler` inside a simple circuit"""

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -647,20 +647,30 @@ class TestCatalystGrad:
     def test_jvp(self):
         """Test that the correct JVP is returned with QJIT."""
 
-        @qml.qjit
-        def jvp(params, tangent):
-            def f(x):
-                y = [jnp.sin(x[0]), x[1] ** 2, x[0] * x[1]]
-                return jnp.stack(y)
+        def f(params):
+            y = [jnp.sin(x[0]), x[1] ** 2, x[0] * x[1]]
+            return jnp.stack(y)
 
+        @qml.qjit
+        def cat_jvp(params, tangent):
             return qml.jvp(f, [params], [tangent])
+
+        def jax_jvp(params, tangent):
+            return jax.jvp(f, [params], [tangent])
 
         x = jnp.array([0.1, 0.2])
         tangent = jnp.array([0.3, 0.6])
-        res = jvp(x, tangent)
-        assert len(res) == 2
-        assert jnp.allclose(res[0], jnp.array([0.09983342, 0.04, 0.02]))
-        assert jnp.allclose(res[1], jnp.array([0.29850125, 0.24000006, 0.12]))
+
+        expected_res, expected_jvp = jax_jvp(x, tangent)
+        observed_res, observed_jvp = cat_jvp(x, tangent)
+
+        assert jnp.allclose(expected_res, observed_res)
+
+        exp_vals, exp_treedef = jax.tree_util.tree_flatten(expected_jvp)
+        obs_vals, obs_treedef = jax.tree_util.tree_flatten(observed_jvp)
+        assert exp_treedef == obs_treedef
+        for exp_val, obs_val in zip(exp_vals, obs_vals):
+            assert jnp.allclose(exp_val, obs_val)
 
     def test_jvp_without_qjit(self):
         """Test that an error is raised when using JVP without QJIT."""


### PR DESCRIPTION
**Context:** Catalyst v0.5.0 releases with two available compilers, `catalyst` and `cuda_quantum`. 

**Description of the Change:** Fixes a test that verifies which compilers are available when installing Catalyst.

**Benefits:** Test is compatible with Catalyst v0.5.0

**Related GitHub Issues:**
