### PR TITLE
Fix compiler JVP test.

### DIFF
--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -658,7 +658,7 @@ class TestCatalystGrad:
         res = jvp(x, tangent)
         assert len(res) == 2
         assert jnp.allclose(res[0], jnp.array([0.09983342, 0.04, 0.02]))
-        assert jnp.allclose(res[1], jnp.array([0.29850125, 0.24000006, 0.12]))
+        assert jnp.allclose(res[1][0], jnp.array([0.29850125, 0.24000006, 0.12]))
 
     def test_jvp_without_qjit(self):
         """Test that an error is raised when using JVP without QJIT."""


### PR DESCRIPTION
**Description of the Change:** This commit changes the compiler's JVP test to match the result type with JAX. 