### PR TITLE
Fix random seed for TestQubitIntegration.test_counts

### DIFF
--- a/tests/interfaces/test_jax_qnode.py
+++ b/tests/interfaces/test_jax_qnode.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Integration tests for using the JAX-Python interface with a QNode"""
+import random
+
 # pylint: disable=too-many-arguments,too-few-public-methods,too-many-public-methods
 import pytest
 
@@ -859,6 +861,9 @@ class TestQubitIntegration:
 
     def test_counts(self, dev_name, diff_method, grad_on_execution):
         """Test counts works as expected"""
+
+        random.seed(25)
+
         if grad_on_execution is True:
             pytest.skip("Sampling not possible with grad_on_execution differentiation.")
 


### PR DESCRIPTION
**Context:**
The global RNG state is causing ``TestQubitIntegration.test_counts`` to fail occasionally in CI

**Description of the Change:**
Sets the random seed at the beginning of the test case.

**Benefits:**
Less time wasted re-running failed CI tests

**Possible Drawbacks:**
Changing the RNG state here might cause other tests that relies on global RNG state to fail, which we will need to fix as well.
