### PR TITLE
Make sure two counts are always returned in test_counts

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -67,6 +67,9 @@
 * We no longer perform unwanted dtype promotion in the `pauli_rep` of `SProd` instances when using tensorflow.
   [(#5246)](https://github.com/PennyLaneAI/pennylane/pull/5246)
 
+* Fixed `TestQubitIntegration.test_counts` in `tests/interfaces/test_jax_qnode.py` to always produce counts for all outcomes.
+  [(#5336)](https://github.com/PennyLaneAI/pennylane/pull/5336)
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/tests/interfaces/test_jax_qnode.py
+++ b/tests/interfaces/test_jax_qnode.py
@@ -871,7 +871,10 @@ class TestQubitIntegration:
         def circuit():
             qml.Hadamard(wires=[0])
             qml.CNOT(wires=[0, 1])
-            return qml.counts(qml.PauliZ(0)), qml.counts(qml.PauliX(1))
+            return (
+                qml.counts(qml.PauliZ(0), all_outcomes=True),
+                qml.counts(qml.PauliX(1), all_outcomes=True),
+            )
 
         res = circuit()
 


### PR DESCRIPTION
**Context:**
`tests/interfaces/test_jax_qnode.py::TestQubitIntegration::test_counts` occasionally fails in CI due to sometimes we only get counts for one outcome.

**Description of the Change:**
Adds `all_outcomes=True` in calls to `qml.count` in this test case.

**Benefits:**
Less time wasted rerunning CI tests