### PR TITLE
Bugfix: Lightning simulators do not support `rotations` anymore.

### DIFF
--- a/doc/releases/changelog-0.35.1.md
+++ b/doc/releases/changelog-0.35.1.md
@@ -1,0 +1,14 @@
+:orphan:
+
+# Release 0.35.1
+
+<h3>Bug fixes 🐛</h3>
+
+* Lightning simulators need special handling of diagonalizing gates when performing sampling measurements.
+  [(#5343)](https://github.com/PennyLaneAI/pennylane/pull/5343)
+
+<h3>Contributors ✍️</h3>
+
+This release contains contributions from (in alphabetical order):
+
+Vincent Michaud-Rioux

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -280,17 +280,17 @@ class QubitDevice(Device):
         sample_type = (SampleMP, CountsMP, ClassicalShadowMP, ShadowExpvalMP)
         if self.shots is not None or any(isinstance(m, sample_type) for m in circuit.measurements):
             # Lightning does not support apply(rotations) anymore, so we need to rotate here
-            if hasattr(self, "name") and isinstance(self.name, str) and "Lightning" in self.name:
-                diagonalizing_gates = self._get_diagonalizing_gates(circuit)
-                if diagonalizing_gates:
-                    self.apply_lightning(diagonalizing_gates)
+            is_lightning = (
+                hasattr(self, "name") and isinstance(self.name, str) and "Lightning" in self.name
+            )
+            diagonalizing_gates = self._get_diagonalizing_gates(circuit) if is_lightning else None
+            if is_lightning and diagonalizing_gates:
+                self.apply_lightning(diagonalizing_gates)
             self._samples = self.generate_samples()
-            if hasattr(self, "name") and isinstance(self.name, str) and "Lightning" in self.name:
-                diagonalizing_gates = self._get_diagonalizing_gates(circuit)
-                if diagonalizing_gates:
-                    self.apply_lightning(
-                        [qml.adjoint(g, lazy=False) for g in reversed(diagonalizing_gates)]
-                    )
+            if is_lightning and diagonalizing_gates:
+                self.apply_lightning(
+                    [qml.adjoint(g, lazy=False) for g in reversed(diagonalizing_gates)]
+                )
 
         # compute the required statistics
         if self._shot_vector is not None:

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@
 """Setup file for package installation."""
 # pylint: disable=unspecified-encoding, consider-using-with
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 with open("pennylane/_version.py") as f:
     version = f.readlines()[-1].split()[-1].strip("\"'")
@@ -31,7 +31,7 @@ requirements = [
     "semantic-version>=2.7",
     "autoray>=0.6.1",
     "cachetools",
-    "pennylane-lightning>=0.35",
+    "pennylane-lightning>=0.35.1",
     "requests",
     "typing_extensions",
 ]

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ requirements = [
     "semantic-version>=2.7",
     "autoray>=0.6.1",
     "cachetools",
-    "pennylane-lightning>=0.35.1",
+    "pennylane-lightning>=0.35",
     "requests",
     "typing_extensions",
 ]


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      test directory!

- [x] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `doc/releases/changelog-dev.md` file, summarizing the
      change, and including a link back to the PR.

- [x] The PennyLane source code conforms to
      [PEP8 standards](https://www.python.org/dev/peps/pep-0008/).
      We check all of our code against [Pylint](https://www.pylint.org/).
      To lint modified files, simply `pip install pylint`, and then
      run `pylint pennylane/path/to/file.py`.

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
Lightning simulators have never or currently do not support the optional `rotations` argument in their `apply` method. Sampling measurements are therefore performed in the wrong basis, among other issues.

**Description of the Change:**
Apply the diagonalizing gates within the sampling measurement section if the device is a Lightning device.
Apply the adjoint of the diagonalizing gates to restore the state for further processing.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
