### PR TITLE
Create `v0.35.1` bugfix release

### DIFF
--- a/doc/releases/changelog-0.35.1.md
+++ b/doc/releases/changelog-0.35.1.md
@@ -1,0 +1,13 @@
+:orphan:
+
+# Release 0.35.1
+
+<h3>Bug fixes 🐛</h3>
+
+* `TODO`
+
+<h3>Contributors ✍️</h3>
+
+This release contains contributions from (in alphabetical order):
+
+`TODO`

--- a/doc/releases/changelog-0.35.1.md
+++ b/doc/releases/changelog-0.35.1.md
@@ -4,10 +4,11 @@
 
 <h3>Bug fixes 🐛</h3>
 
-* `TODO`
+* Updated the lower bound on the required Catalyst version to `v0.5.0`.
+  [(#5320)](https://github.com/PennyLaneAI/pennylane/pull/5320)
 
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):
 
-`TODO`
+Erick Ochoa Lopez.

--- a/pennylane/_version.py
+++ b/pennylane/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.35.0"
+__version__ = "0.35.1"

--- a/pennylane/compiler/compiler.py
+++ b/pennylane/compiler/compiler.py
@@ -22,7 +22,7 @@ import re
 
 from semantic_version import Version
 
-PL_CATALYST_MIN_VERSION = Version("0.4.0")
+PL_CATALYST_MIN_VERSION = Version("0.5.0")
 
 
 class CompileError(Exception):

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -53,7 +53,7 @@ def test_catalyst_incompatible():
         return qml.state()
 
     with pytest.raises(
-        CompileError, match="PennyLane-Catalyst 0.4.0 or greater is required, but installed 0.0.1"
+        CompileError, match="PennyLane-Catalyst 0.5.0 or greater is required, but installed 0.0.1"
     ):
         qml.qjit(circuit)()
 

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -68,7 +68,7 @@ class TestCatalyst:
         assert not qml.compiler.available("SomeRandomCompiler")
 
         assert qml.compiler.available("catalyst")
-        assert qml.compiler.available_compilers() == ["catalyst"]
+        assert qml.compiler.available_compilers() == ["catalyst", "cuda_quantum"]
 
     def test_active_compiler(self):
         """Test `qml.compiler.active_compiler` inside a simple circuit"""
@@ -695,7 +695,7 @@ class TestCatalystGrad:
         res = vjp(x, dy)
         assert len(res) == 2
         assert jnp.allclose(res[0], jnp.array([0.09983342, 0.04, 0.02]))
-        assert jnp.allclose(res[1], jnp.array([-0.43750208, 0.07000001]))
+        assert jnp.allclose(res[1][0], jnp.array([-0.43750208, 0.07000001]))
 
     def test_vjp_without_qjit(self):
         """Test that an error is raised when using VJP without QJIT."""


### PR DESCRIPTION
**Context:**

There are two compatibility issues with the v0.35.0 release of PennyLane:
1. The minimum required Catalyst version is now v0.5.0 (#5320).
2. Lightning simulators need special handling of diagonalizing gates when performing sampling measurements (#5343).

This PR cherry-picks the squashed commit corresponding to (1) into the RC branch as the change necessary for (2) is already being made directly to the RC branch.

**Description of the Change:**

* Bumped the PennyLane Python package version to `v0.35.1`.
* Cherry-picked the following commits into the RC branch: https://github.com/PennyLaneAI/pennylane/commit/a4f0fff1ad6e3f2b7d048384f43f839b4b0d88e6 and https://github.com/PennyLaneAI/pennylane/commit/79ce676fcebf702f72d1ae88f7948a5be572d6c3.

**Benefits:**

* The latest PennyLane release works with the latest releases of Catalyst and Lightning.

**Possible Drawbacks:**

None.

**Related GitHub Issues:**

None