### PR TITLE
Increase number of shots in `test_value` to avoid failures due to statistic fluctuations

### DIFF
--- a/tests/measurements/test_var.py
+++ b/tests/measurements/test_var.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Unit tests for the var module"""
-import random
 
 from flaky import flaky
 import numpy as np

--- a/tests/measurements/test_var.py
+++ b/tests/measurements/test_var.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Unit tests for the var module"""
+import random
+
 from flaky import flaky
 import numpy as np
 import pytest
@@ -23,9 +25,10 @@ from pennylane.measurements import Variance, Shots
 class TestVar:
     """Tests for the var function"""
 
-    @pytest.mark.parametrize("shots", [None, 1111, [1111, 1111]])
+    @pytest.mark.parametrize("shots", [None, 5000, [5000, 5000]])
     def test_value(self, tol, shots):
         """Test that the var function works"""
+
         dev = qml.device("default.qubit", wires=2, shots=shots)
 
         @qml.qnode(dev, diff_method="parameter-shift")


### PR DESCRIPTION
**Context:**
``test_value`` in `test_var.py` fails in CI sometimes due to random samples sometimes not having a distribution that is exactly as expected. Increase the number of shots from around 1000 to 5000 such that the sample distribution is closer to the theoretical.

**Description of the Change:**
Increasing the number of shots from 1111 to 5000 to reduce the probability of test case failing due to statistical fluctuations

**Benefits:**
Less failing in CI

[sc-58507]