### PR TITLE
Update measurement tests for new op math

### DIFF
--- a/tests/measurements/test_sample.py
+++ b/tests/measurements/test_sample.py
@@ -320,38 +320,43 @@ class TestSample:
         circuit()
 
     @pytest.mark.parametrize(
-        "obs,exp",
+        "obs",
         [
             # Single observables
-            (None, int),  # comp basis samples
-            (qml.PauliX(0), int),
-            (qml.PauliY(0), int),
-            (qml.PauliZ(0), int),
-            (qml.Hadamard(0), int),
-            (qml.Identity(0), int),
-            (qml.Hermitian(np.diag([1, 2]), 0), float),
-            (qml.Hermitian(np.diag([1.0, 2.0]), 0), float),
+            (None),  # comp basis samples, expected to be int
+            (qml.PauliX(0)),
+            (qml.PauliY(0)),
+            (qml.PauliZ(0)),
+            (qml.Hadamard(0)),
+            (qml.Identity(0)),
+            (qml.Hermitian(np.diag([1, 2]), 0)),
+            (qml.Hermitian(np.diag([1.0, 2.0]), 0)),
             # Tensor product observables
             (
                 qml.PauliX("c")
                 @ qml.PauliY("a")
                 @ qml.PauliZ(1)
                 @ qml.Hadamard("wire1")
-                @ qml.Identity("b"),
-                int,
+                @ qml.Identity("b")
             ),
-            (qml.Projector([0, 1], wires=[0, 1]) @ qml.PauliZ(2), float),
-            (qml.Hermitian(np.array(np.eye(2)), wires=[0]) @ qml.PauliZ(2), float),
-            (
-                qml.Projector([0, 1], wires=[0, 1]) @ qml.Hermitian(np.array(np.eye(2)), wires=[2]),
-                float,
-            ),
+            (qml.Projector([0, 1], wires=[0, 1]) @ qml.PauliZ(2)),
+            (qml.Hermitian(np.array(np.eye(2)), wires=[0]) @ qml.PauliZ(2)),
+            (qml.Projector([0, 1], wires=[0, 1]) @ qml.Hermitian(np.array(np.eye(2)), wires=[2])),
         ],
     )
-    def test_numeric_type(self, obs, exp):
+    def test_numeric_type(self, obs):
         """Test that the numeric type is correct."""
+        eigval_type = type(obs.eigvals()[0]) if obs is not None else np.int64
+
         res = qml.sample(obs) if obs is not None else qml.sample()
-        assert res.numeric_type is exp
+        if res.numeric_type == int:
+            expected_type = np.int64
+        elif res.numeric_type == float:
+            expected_type = np.float64
+        elif res.numeric_type == complex:
+            expected_type = np.complex64
+
+        assert expected_type == eigval_type
 
     def test_shape_no_shots_error(self):
         """Test that the appropriate error is raised with no shots are specified"""


### PR DESCRIPTION
Only one test needed updating. Data type for eigvals is `float` for `Prod` and `int` for `Tensor`. This is acceptable because what we actually care about here is that the `sample(obs).numeric_type` matches the `obs.eigvals` numeric type. In light of that, the test is updated to check that instead. 

In doing that, we discovered that while the numeric type for Identity is `int` (as expected by the previous implementation of the test), the eigvals on `Identity` are floats, causing the issue #5369. **This particular test currently does not pass, but that is because it reveals a bug, not because the test is wrong.**

The bug is general and not related to the `new_op_math` project, and will be fixed on master (pending decision about how to resolve). The one test failure in `test_sample.py` will be resolved when that fix is merged into here.

