### PR TITLE
Standardize eigvals to be floats

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -99,6 +99,11 @@
 * Upgraded `null.qubit` to the new device API. Also, added support for all measurements and various modes of differentiation.
   [(#5211)](https://github.com/PennyLaneAI/pennylane/pull/5211)
   
+* The `dtype` for `eigvals` of `X`, `Y`, `Z` and `Hadamard` are changed from `int` to `float`, making them 
+  consistent with the other observables. The `dtype` of the returned values when sampling these observables 
+  (e.g. `qml.sample(X(0))`) is also changed to `float`. 
+  [(#5370)](https://github.com/PennyLaneAI/pennylane/pull/5370)
+
 <h4>Community contributions 🥳</h4>
 
 * Functions `measure_with_samples` and `sample_state` have been added to the new `qutrit_mixed` module found in
@@ -151,6 +156,9 @@
 
 * Attempting to multiply ``PauliWord`` and ``PauliSentence`` with ``*`` will raise an error. Instead, use ``@`` to conform with the PennyLane convention.
 
+* Sampling observables composed of `X`, `Y`, `Z` and `Hadamard` now returns values of type `float` instead of `int`.
+  [(#5370)](https://github.com/PennyLaneAI/pennylane/pull/5370)
+
 <h3>Deprecations 👋</h3>
 
 * ``qml.load`` is deprecated. Instead, please use the functions outlined in the *Importing workflows* quickstart guide, such as ``qml.from_qiskit``.
@@ -179,6 +187,10 @@
 
 * Fixed `TestQubitIntegration.test_counts` in `tests/interfaces/test_jax_qnode.py` to always produce counts for all outcomes.
   [(#5336)](https://github.com/PennyLaneAI/pennylane/pull/5336)
+
+* Fixed a bug that raised an error regarding expected vs acutal `dtype` when using `JAX-JIT` on a circuit that 
+  returned samples of observables containing the `qml.Identity` operator.
+  [(#5370)](https://github.com/PennyLaneAI/pennylane/pull/5370)
 
 <h3>Contributors ✍️</h3>
 

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -1482,7 +1482,6 @@ class QubitDevice(Device):
         # translate to wire labels used by device. observable is list when measuring sequence
         # of multiple MeasurementValues
         device_wires = self.map_wires(observable.wires)
-        name = None if no_observable_provided else observable.name
         # Select the samples from self._samples that correspond to ``shot_range`` if provided
         if shot_range is None:
             sub_samples = self._samples
@@ -1492,11 +1491,7 @@ class QubitDevice(Device):
             # Ellipsis (...) otherwise would take up broadcasting and shots axes.
             sub_samples = self._samples[..., slice(*shot_range), :]
 
-        if isinstance(name, str) and name in {"PauliX", "PauliY", "PauliZ", "Hadamard"}:
-            # Process samples for observables with eigenvalues {1, -1}
-            samples = 1 - 2 * sub_samples[..., device_wires[0]]
-
-        elif no_observable_provided:
+        if no_observable_provided:
             # if no observable was provided then return the raw samples
             if len(observable.wires) != 0:
                 # if wires are provided, then we only return samples from those wires

--- a/pennylane/measurements/sample.py
+++ b/pennylane/measurements/sample.py
@@ -182,15 +182,10 @@ class SampleMP(SampleMeasurement):
     @property
     @functools.lru_cache()
     def numeric_type(self):
-        # Note: we only assume an integer numeric type if the observable is a
-        # built-in observable with integer eigenvalues or a tensor product thereof
         if self.obs is None:
             # Computational basis samples
             return int
-        int_eigval_obs = {qml.X, qml.Y, qml.Z, qml.Hadamard, qml.Identity}
-        tensor_terms = self.obs.obs if hasattr(self.obs, "obs") else [self.obs]
-        every_term_standard = all(o.__class__ in int_eigval_obs for o in tensor_terms)
-        return int if every_term_standard else float
+        return float
 
     def shape(self, device, shots):
         if not shots:

--- a/pennylane/ops/identity.py
+++ b/pennylane/ops/identity.py
@@ -17,7 +17,6 @@ cv and qubit computing paradigms in PennyLane.
 """
 from functools import lru_cache
 from scipy import sparse
-import numpy as np
 
 import pennylane as qml
 from pennylane.operation import AnyWires, AllWires, CVObservable, Operation
@@ -101,7 +100,7 @@ class Identity(CVObservable, Operation):
         >>> print(qml.I.compute_eigvals())
         [ 1 1]
         """
-        return np.ones(2**n_wires, dtype=np.int64)
+        return qml.math.ones(2**n_wires)
 
     @staticmethod
     @lru_cache()

--- a/pennylane/ops/identity.py
+++ b/pennylane/ops/identity.py
@@ -17,6 +17,7 @@ cv and qubit computing paradigms in PennyLane.
 """
 from functools import lru_cache
 from scipy import sparse
+import numpy as np
 
 import pennylane as qml
 from pennylane.operation import AnyWires, AllWires, CVObservable, Operation
@@ -100,7 +101,7 @@ class Identity(CVObservable, Operation):
         >>> print(qml.I.compute_eigvals())
         [ 1 1]
         """
-        return qml.math.ones(2**n_wires)
+        return np.ones(2**n_wires, dtype=np.int64)
 
     @staticmethod
     @lru_cache()

--- a/pennylane/utils.py
+++ b/pennylane/utils.py
@@ -152,7 +152,7 @@ def pauli_eigs(n):
         list: the eigenvalues of the specified observable
     """
     if n == 1:
-        return np.array([1, -1])
+        return np.array([1.0, -1.0])
     return np.concatenate([pauli_eigs(n - 1), -pauli_eigs(n - 1)])
 
 

--- a/tests/interfaces/default_qubit_2_integration/test_autograd_qnode_default_qubit_2.py
+++ b/tests/interfaces/default_qubit_2_integration/test_autograd_qnode_default_qubit_2.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Integration tests for using the autograd interface with a QNode"""
-# pylint: disable=no-member, too-many-arguments, unexpected-keyword-arg
+# pylint: disable=no-member, too-many-arguments, unexpected-keyword-arg, use-dict-literal, no-name-in-module
 
 import autograd
 import autograd.numpy as anp
@@ -1709,7 +1709,7 @@ class TestSample:
         assert np.array_equal(result[0].shape, (n_sample,))
         assert isinstance(result[1], (float, np.ndarray))
         assert isinstance(result[2], (float, np.ndarray))
-        assert result[0].dtype == np.dtype("int")
+        assert result[0].dtype == np.dtype("float")
 
     def test_single_wire_sample(self):
         """Test the return type and shape of sampling a single wire"""

--- a/tests/interfaces/default_qubit_2_integration/test_torch_qnode_default_qubit_2.py
+++ b/tests/interfaces/default_qubit_2_integration/test_torch_qnode_default_qubit_2.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Integration tests for using the Torch interface with a QNode"""
-# pylint: disable=too-many-arguments,unexpected-keyword-arg,no-member,comparison-with-callable
+# pylint: disable=too-many-arguments,unexpected-keyword-arg,no-member,comparison-with-callable, no-name-in-module
+# pylint: disable=use-implicit-booleaness-not-comparison, unnecessary-lambda-assignment, use-dict-literal
+
 import numpy as np
 import pytest
 
@@ -1542,7 +1544,7 @@ class TestSample:
         assert isinstance(result[1], torch.Tensor)
         assert result[2].shape == ()
         assert isinstance(result[2], torch.Tensor)
-        assert result[0].dtype is torch.int64
+        assert result[0].dtype is torch.float64
 
     def test_single_wire_sample(self):
         """Test the return type and shape of sampling a single wire"""
@@ -1572,9 +1574,9 @@ class TestSample:
         assert tuple(result[0].shape) == (10,)
         assert tuple(result[1].shape) == (10,)
         assert tuple(result[2].shape) == (10,)
-        assert result[0].dtype == torch.int64
-        assert result[1].dtype == torch.int64
-        assert result[2].dtype == torch.int64
+        assert result[0].dtype == torch.float64
+        assert result[1].dtype == torch.float64
+        assert result[2].dtype == torch.float64
 
 
 qubit_device_and_diff_method_and_grad_on_execution = [

--- a/tests/measurements/test_sample.py
+++ b/tests/measurements/test_sample.py
@@ -324,11 +324,11 @@ class TestSample:
         [
             # Single observables
             (None, int),  # comp basis samples
-            (qml.PauliX(0), int),
-            (qml.PauliY(0), int),
-            (qml.PauliZ(0), int),
-            (qml.Hadamard(0), int),
-            (qml.Identity(0), int),
+            (qml.PauliX(0), float),
+            (qml.PauliY(0), float),
+            (qml.PauliZ(0), float),
+            (qml.Hadamard(0), float),
+            (qml.Identity(0), float),
             (qml.Hermitian(np.diag([1, 2]), 0), float),
             (qml.Hermitian(np.diag([1.0, 2.0]), 0), float),
             # Tensor product observables
@@ -338,7 +338,7 @@ class TestSample:
                 @ qml.PauliZ(1)
                 @ qml.Hadamard("wire1")
                 @ qml.Identity("b"),
-                int,
+                float,
             ),
             (qml.Projector([0, 1], wires=[0, 1]) @ qml.PauliZ(2), float),
             (qml.Hermitian(np.array(np.eye(2)), wires=[0]) @ qml.PauliZ(2), float),

--- a/tests/measurements/test_sample.py
+++ b/tests/measurements/test_sample.py
@@ -506,3 +506,35 @@ def test_jitting_with_sampling_on_subset_of_wires(samples):
     assert (
         circuit._qfunc_output.shape(dev, Shots(samples)) == (samples, 2) if samples != 1 else (2,)
     )
+
+
+@pytest.mark.jax
+@pytest.mark.parametrize(
+    "obs",
+    [
+        # Single observables
+        (qml.PauliX(0)),
+        (qml.PauliY(0)),
+        (qml.PauliZ(0)),
+        (qml.Hadamard(0)),
+        (qml.Identity(0)),
+    ],
+)
+def test_jitting_with_sampling_on_different_observables(obs):
+    """Test case covering bug in Issue #5369. Sampling should be jit-able
+    when sampling occurs and obs is not None. The bug was occurring due mismatched
+    types on qml.sample(obs).numeric_type and obs.eigvals."""
+    import jax
+
+    jax.config.update("jax_enable_x64", True)
+
+    dev = qml.device("default.qubit", wires=5, shots=100)
+
+    @qml.qnode(dev, interface="jax")
+    def circuit(x):
+        qml.RX(x, wires=0)
+        return qml.sample(obs)
+
+    results = jax.jit(circuit)(jax.numpy.array(0.123, dtype=jax.numpy.float64))
+
+    assert results.shape == (100,)

--- a/tests/measurements/test_sample.py
+++ b/tests/measurements/test_sample.py
@@ -103,7 +103,7 @@ class TestSample:
         # If all the dimensions are equal the result will end up to be a proper rectangular array
         assert isinstance(result, tuple)
         assert len(result) == 3
-        assert result[0].dtype == np.dtype("int")
+        assert result[0].dtype == np.dtype("float")
 
     @pytest.mark.filterwarnings("ignore:Creating an ndarray from ragged nested sequences")
     def test_sample_output_type_in_combination(self):
@@ -123,7 +123,7 @@ class TestSample:
         assert len(result) == 3
         assert isinstance(result[0], np.ndarray)
         assert isinstance(result[1], np.ndarray)
-        assert result[2].dtype == np.dtype("int")
+        assert result[2].dtype == np.dtype("float")
         assert np.array_equal(result[2].shape, (n_sample,))
 
     def test_not_an_observable(self):
@@ -465,22 +465,6 @@ class TestSample:
         assert qml.math.shape(res) == (10,)
         assert all(r in {-1, 0, 1} for r in np.round(res, 13))
 
-    @pytest.mark.jax
-    def test_sample_fails_with_jax_jacobian(self):
-        """Test that qml.sample raises an error with parameter-shift and jax."""
-        import jax
-
-        dev = qml.device("default.qubit", shots=10)
-
-        @qml.qnode(dev, diff_method="parameter-shift")
-        def circuit(angle):
-            qml.RX(angle, wires=0)
-            return qml.sample(qml.PauliX(0))
-
-        angle = jax.numpy.array(0.1)
-        with pytest.raises(TypeError, match=r"got int64\[10\] and float64\[10\] respectively"):
-            _ = jax.jacobian(circuit)(angle)
-
 
 @pytest.mark.jax
 @pytest.mark.parametrize("samples", (1, 10))
@@ -534,6 +518,9 @@ def test_jitting_with_sampling_on_different_observables(obs):
     def circuit(x):
         qml.RX(x, wires=0)
         return qml.sample(obs)
+
+    print(qml.sample(obs).numeric_type)
+    print(type(obs.eigvals()[0]))
 
     results = jax.jit(circuit)(jax.numpy.array(0.123, dtype=jax.numpy.float64))
 

--- a/tests/tape/test_qscript.py
+++ b/tests/tape/test_qscript.py
@@ -1384,13 +1384,11 @@ class TestNumericType:
         assert np.issubdtype(result.dtype, complex)
         assert qs.numeric_type is complex
 
-    @pytest.mark.parametrize("ret", [qml.sample(), qml.sample(qml.PauliZ(wires=0))])
-    def test_sample_int_eigvals(self, ret):
+    def test_sample_int_eigvals(self):
         """Test that the tape can correctly determine the output domain for a
-        sampling measurement with a Hermitian observable with integer
-        eigenvalues."""
+        sampling measurement no observable."""
         dev = qml.device("default.qubit", wires=3, shots=5)
-        qs = QuantumScript([qml.RY(0.4, 0)], [ret], shots=5)
+        qs = QuantumScript([qml.RY(0.4, 0)], [qml.sample()], shots=5)
 
         result = qml.execute([qs], dev, gradient_fn=None)[0]
 
@@ -1438,7 +1436,7 @@ class TestNumericType:
 
         a, b = 0, 3
         ops = [qml.RY(a, 0), qml.RX(b, 0)]
-        m = [qml.sample(qml.Hermitian(herm, wires=0)), qml.sample(qml.PauliZ(1))]
+        m = [qml.sample(qml.Hermitian(herm, wires=0)), qml.sample()]
         qs = QuantumScript(ops, m, shots=5)
 
         result = qml.execute([qs], dev, gradient_fn=None)[0]

--- a/tests/tape/test_tape.py
+++ b/tests/tape/test_tape.py
@@ -2165,17 +2165,15 @@ class TestNumericType:
         assert np.issubdtype(result.dtype, complex)
         assert circuit.qtape.numeric_type is complex
 
-    @pytest.mark.parametrize("ret", [qml.sample(), qml.sample(qml.PauliZ(wires=0))])
-    def test_sample_int_eigvals(self, ret):
+    def test_sample_int_eigvals(self):
         """Test that the tape can correctly determine the output domain for a
-        sampling measurement with a Hermitian observable with integer
-        eigenvalues."""
+        sampling measurement no observable."""
         dev = qml.device("default.qubit", wires=3, shots=5)
 
         @qml.qnode(dev)
         def circuit():
             qml.RY(0.4, wires=[0])
-            return qml.apply(ret)
+            return qml.sample()
 
         result = circuit()
 
@@ -2229,7 +2227,7 @@ class TestNumericType:
         def circuit(a, b):
             qml.RY(a, wires=0)
             qml.RX(b, wires=0)
-            return qml.sample(qml.Hermitian(herm, wires=0)), qml.sample(qml.PauliZ(1))
+            return qml.sample(qml.Hermitian(herm, wires=0)), qml.sample()
 
         result = circuit(0, 3)
         assert isinstance(result, tuple)


### PR DESCRIPTION
**Context:**
The dtype for `qml.sample(Identity(0))` doesn't match the dtype for its eigvals, and it breaks JAX-JIT. Some observables use `int`, some use `float`, depending on the dtype of `eigvals`. We're opting to standardize this to be floats.

**Description of the Change:**
Change eigvals of `X`, `Y`, `Z` and `Hadamard` to be floats. This will also affect `Tensor`, which previously was `int` if it was composed only of those observables.

The generation of samples is modified in `_qubit_device` and on `SampleMP`, because it wasn't actually using the `eigvals` for these 4 operators.

**Benefits:**
We can do this:
```
@qml.qnode(qml.device('default.qubit', shots=50))
def circuit(x):
    qml.RX(x, wires=0)
    return qml.sample(op=qml.I(0))
    
jax.jit(circuit)(jax.numpy.array(0.5))
```

and we are less likely to have similar/related bugs in the future.

**Possible Drawbacks:**
Samples that used to be `int` will become `float`

**Related GitHub Issues:**
#5369
