### PR TITLE
[new opmath] Upgrade classical shadows with new opmath

### DIFF
--- a/pennylane/shadows/classical_shadow.py
+++ b/pennylane/shadows/classical_shadow.py
@@ -282,7 +282,7 @@ class ClassicalShadow:
         if (pr := observable.pauli_rep) is not None:
             return self._convert_to_pauli_words_with_pauli_rep(pr, num_wires)
 
-        raise ValueError("Observable must be a linear combination of Pauli observables")
+        raise ValueError("Observable must have a valid pauli representation. Recevied {observable} with observable.pauli_rep = {pr}")
 
     def expval(self, H, k=1):
         r"""Compute expectation value of an observable :math:`H`.

--- a/pennylane/shadows/classical_shadow.py
+++ b/pennylane/shadows/classical_shadow.py
@@ -228,8 +228,7 @@ class ClassicalShadow:
             (T, 2**n, 2**n),
         )
 
-    @staticmethod
-    def _convert_to_pauli_words_with_pauli_rep(pr, num_wires):
+    def _convert_to_pauli_words_with_pauli_rep(self, pr, num_wires):
         """Convert to recipe using pauli representation"""
         pr_to_recipe_map = {"X": 0, "Y": 1, "Z": 2, "I": -1}
 
@@ -237,7 +236,7 @@ class ClassicalShadow:
         for pw, c in pr.items():
             word = [-1] * num_wires
             for i, s in pw.items():
-                word[i] = pr_to_recipe_map[s]
+                word[self.wire_map.index(i)] = pr_to_recipe_map[s]
 
             coeffs_and_words.append((c, word))
 

--- a/pennylane/shadows/classical_shadow.py
+++ b/pennylane/shadows/classical_shadow.py
@@ -227,12 +227,29 @@ class ClassicalShadow:
             np.einsum(f'{",".join(old_indices)}->{new_indices}', *transposed_snapshots),
             (T, 2**n, 2**n),
         )
+    
+    @staticmethod
+    def _convert_to_pauli_words_with_pauli_rep(pr, num_wires):
+        """Convert to recipe using pauli representation"""
+        pr_to_recipe_map = {"X": 0, "Y": 1, "Z": 2, "I": -1}
+
+        coeffs_and_words = []
+        for pw, c in pr.items():
+            word = [-1] * num_wires
+            for i, s in pw.items():
+                word[i] = pr_to_recipe_map[s]
+
+            coeffs_and_words.append((c, word))
+
+        return coeffs_and_words
 
     def _convert_to_pauli_words(self, observable):
         """Given an observable, obtain a list of coefficients and Pauli words, the
         sum of which is equal to the observable"""
 
         num_wires = self.bits.shape[1]
+
+        # Legacy support for old opmath
         obs_to_recipe_map = {"PauliX": 0, "PauliY": 1, "PauliZ": 2, "Identity": -1}
 
         def pauli_list_to_word(obs):
@@ -253,8 +270,6 @@ class ClassicalShadow:
             word = pauli_list_to_word(observable.obs)
             return [(1, word)]
 
-        # TODO: cases for new operator arithmetic
-
         if isinstance(observable, qml.Hamiltonian):
             coeffs_and_words = []
             for coeff, op in zip(observable.data, observable.ops):
@@ -262,6 +277,12 @@ class ClassicalShadow:
                     [(coeff * c, w) for c, w in self._convert_to_pauli_words(op)]
                 )
             return coeffs_and_words
+
+        # Support for all operators with a valid pauli_rep
+        if (pr := observable.pauli_rep) is not None:
+            return self._convert_to_pauli_words_with_pauli_rep(pr, num_wires)
+
+        raise ValueError("Observable must be a linear combination of Pauli observables")
 
     def expval(self, H, k=1):
         r"""Compute expectation value of an observable :math:`H`.
@@ -306,7 +327,7 @@ class ClassicalShadow:
         >>> shadow.expval(H, k=1)
         array(1.9980000000000002)
         """
-        if not isinstance(H, Iterable):
+        if not isinstance(H, (list, tuple)):
             H = [H]
 
         coeffs_and_words = [self._convert_to_pauli_words(h) for h in H]

--- a/pennylane/shadows/classical_shadow.py
+++ b/pennylane/shadows/classical_shadow.py
@@ -227,7 +227,7 @@ class ClassicalShadow:
             np.einsum(f'{",".join(old_indices)}->{new_indices}', *transposed_snapshots),
             (T, 2**n, 2**n),
         )
-    
+
     @staticmethod
     def _convert_to_pauli_words_with_pauli_rep(pr, num_wires):
         """Convert to recipe using pauli representation"""

--- a/pennylane/shadows/classical_shadow.py
+++ b/pennylane/shadows/classical_shadow.py
@@ -282,7 +282,9 @@ class ClassicalShadow:
         if (pr := observable.pauli_rep) is not None:
             return self._convert_to_pauli_words_with_pauli_rep(pr, num_wires)
 
-        raise ValueError("Observable must have a valid pauli representation. Recevied {observable} with observable.pauli_rep = {pr}")
+        raise ValueError(
+            "Observable must have a valid pauli representation. Recevied {observable} with observable.pauli_rep = {pr}"
+        )
 
     def expval(self, H, k=1):
         r"""Compute expectation value of an observable :math:`H`.

--- a/tests/measurements/legacy/test_classical_shadow_legacy.py
+++ b/tests/measurements/legacy/test_classical_shadow_legacy.py
@@ -420,7 +420,7 @@ class TestExpvalForward:
         """Test that an error is raised when a non-Pauli observable is passed"""
         circuit = hadamard_circuit(3)
 
-        msg = "Observable must be a linear combination of Pauli observables"
+        msg = "Observable must have a valid pauli representation."
         with pytest.raises(ValueError, match=msg):
             circuit(qml.Hadamard(0) @ qml.Hadamard(2))
 

--- a/tests/measurements/test_classical_shadow.py
+++ b/tests/measurements/test_classical_shadow.py
@@ -573,7 +573,7 @@ class TestExpvalForward:
         """Test that an error is raised when a non-Pauli observable is passed"""
         circuit = hadamard_circuit(3)
 
-        msg = "Observable must be a linear combination of Pauli observables"
+        msg = "Observable must have a valid pauli representation."
         with pytest.raises(ValueError, match=msg):
             circuit(qml.Hadamard(0) @ qml.Hadamard(2))
 

--- a/tests/shadow/test_shadow_class.py
+++ b/tests/shadow/test_shadow_class.py
@@ -351,7 +351,7 @@ class TestExpvalEstimation:
         msg = "Observable must be a linear combination of Pauli observables"
         with pytest.raises(ValueError, match=msg):
             shadow.expval(H, k=10)
-    
+
     def test_non_pauli_error_no_pauli_rep(self):
         """Test that an error is raised when a non-Pauli observable is passed"""
         circuit = hadamard_circuit(3)
@@ -363,6 +363,7 @@ class TestExpvalEstimation:
         msg = "Observable must have a valid pauli representation."
         with pytest.raises(ValueError, match=msg):
             shadow.expval(H, k=10)
+
 
 @pytest.mark.all_interfaces
 class TestExpvalEstimationInterfaces:

--- a/tests/shadow/test_shadow_class.py
+++ b/tests/shadow/test_shadow_class.py
@@ -339,6 +339,7 @@ class TestExpvalEstimation:
         assert actual.dtype == np.float64
         assert qml.math.allclose(actual, expected, atol=1e-1)
 
+    @pytest.mark.usefixtures("use_legacy_opmath")
     def test_non_pauli_error(self):
         """Test that an error is raised when a non-Pauli observable is passed"""
         circuit = hadamard_circuit(3)
@@ -350,7 +351,18 @@ class TestExpvalEstimation:
         msg = "Observable must be a linear combination of Pauli observables"
         with pytest.raises(ValueError, match=msg):
             shadow.expval(H, k=10)
+    
+    def test_non_pauli_error_no_pauli_rep(self):
+        """Test that an error is raised when a non-Pauli observable is passed"""
+        circuit = hadamard_circuit(3)
+        bits, recipes = circuit()
+        shadow = ClassicalShadow(bits, recipes)
 
+        H = qml.Hadamard(0) @ qml.Hadamard(2)
+
+        msg = "Observable must have a valid pauli representation."
+        with pytest.raises(ValueError, match=msg):
+            shadow.expval(H, k=10)
 
 @pytest.mark.all_interfaces
 class TestExpvalEstimationInterfaces:


### PR DESCRIPTION
We missed this in the last release. Upgrading classical shadows functionality to play nice with new opmath

- [x] `tests/shadow` pass
- [x] `tests/measurements` pass (caveat that `tests/measurements/test_sample.py::test_numeric_type` currently fails due to unrelated reaons)

[sc-58404]
[sc-58626]