### PR TITLE
fixing `tests/test_device.py.test_device_default_expand_ops`

### DIFF
--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -680,6 +680,7 @@ class Device(abc.ABC):
         obs_on_same_wire &= not any(
             isinstance(o, (Hamiltonian, LinearCombination)) for o in circuit._obs_sharing_wires
         )
+
         ops_not_supported = not all(self.stopping_condition(op) for op in circuit.operations)
 
         if obs_on_same_wire:

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -679,8 +679,7 @@ class Device(abc.ABC):
         )
         obs_on_same_wire = len(circuit._obs_sharing_wires) > 0 or comp_basis_sampled_multi_measure
         obs_on_same_wire &= not any(
-            isinstance(o, (Hamiltonian, LinearCombination, Prod))
-            for o in circuit._obs_sharing_wires
+            isinstance(o, (Hamiltonian, LinearCombination)) for o in circuit._obs_sharing_wires
         )
         ops_not_supported = not all(self.stopping_condition(op) for op in circuit.operations)
 

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -42,7 +42,6 @@ from pennylane.measurements import (
 )
 
 from pennylane.operation import Observable, Operation, Tensor, Operator, StatePrepBase
-from pennylane.ops.op_math.prod import Prod
 from pennylane.ops import Hamiltonian, Sum, LinearCombination
 from pennylane.tape import QuantumScript, QuantumTape, expand_tape_state_prep
 from pennylane.wires import WireError, Wires

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -42,6 +42,7 @@ from pennylane.measurements import (
 )
 
 from pennylane.operation import Observable, Operation, Tensor, Operator, StatePrepBase
+from pennylane.ops.op_math.prod import Prod
 from pennylane.ops import Hamiltonian, Sum, LinearCombination
 from pennylane.tape import QuantumScript, QuantumTape, expand_tape_state_prep
 from pennylane.wires import WireError, Wires
@@ -678,9 +679,9 @@ class Device(abc.ABC):
         )
         obs_on_same_wire = len(circuit._obs_sharing_wires) > 0 or comp_basis_sampled_multi_measure
         obs_on_same_wire &= not any(
-            isinstance(o, (Hamiltonian, LinearCombination)) for o in circuit._obs_sharing_wires
+            isinstance(o, (Hamiltonian, LinearCombination, Prod))
+            for o in circuit._obs_sharing_wires
         )
-
         ops_not_supported = not all(self.stopping_condition(op) for op in circuit.operations)
 
         if obs_on_same_wire:

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -340,8 +340,6 @@ class TestInternalFunctions:  # pylint:disable=too-many-public-methods
         # Raises an error if queue or observables are invalid
         dev.check_validity(queue, observables)
 
-    # Works with opmath disabled by replacing
-    # match="Observable Prod not supported on device MockDevice"   with   match="Tensor observables not supported"
     def test_check_validity_on_tensor_support(self, mock_device_supporting_paulis):
         """Tests the function Device.check_validity with tensor support capability"""
         dev = mock_device_supporting_paulis()
@@ -355,11 +353,9 @@ class TestInternalFunctions:  # pylint:disable=too-many-public-methods
         observables = [qml.expval(qml.PauliZ(0) @ qml.PauliX(1))]
 
         # mock device does not support Tensor product
-        with pytest.raises(DeviceError, match="Observable Prod not supported on device MockDevice"):
+        with pytest.raises(DeviceError, match="Tensor observables not supported"):
             dev.check_validity(queue, observables)
 
-    # Works with opmath disabled by replacing
-    # match="Observable Prod not supported"   with   match="Observable Hadamard not supported"
     def test_check_validity_on_invalid_observable_with_tensor_support(self, monkeypatch):
         """Tests the function Device.check_validity with tensor support capability
         but with an invalid observable"""
@@ -382,7 +378,7 @@ class TestInternalFunctions:  # pylint:disable=too-many-public-methods
             dev = D()
 
             # mock device supports Tensor products but not hadamard
-            with pytest.raises(DeviceError, match="Observable Prod not supported"):
+            with pytest.raises(DeviceError, match="Observable Hadamard not supported"):
                 dev.check_validity(queue, observables)
 
     def test_check_validity_on_invalid_queue(self, mock_device_supporting_paulis):

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -491,7 +491,10 @@ class TestInternalFunctions:  # pylint:disable=too-many-public-methods
         without expanding measurements."""
 
         ops = [qml.PauliX(0), qml.BasisEmbedding([1, 0], wires=[1, 2])]
-        measurements = [qml.expval(qml.PauliZ(0)), qml.expval(2 * qml.PauliX(0) @ qml.PauliY(1))]
+        measurements = [
+            qml.expval(qml.PauliZ(0)),
+            qml.expval(qml.Hamiltonian([2], [qml.PauliX(0) @ qml.PauliY(1)])),
+        ]
         circuit = qml.tape.QuantumScript(ops=ops, measurements=measurements)
 
         dev = mock_device_with_paulis_hamiltonian_and_methods(wires=3)

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -340,6 +340,8 @@ class TestInternalFunctions:  # pylint:disable=too-many-public-methods
         # Raises an error if queue or observables are invalid
         dev.check_validity(queue, observables)
 
+    # Works with opmath disabled by replacing
+    # match="Observable Prod not supported on device MockDevice"   with   match="Tensor observables not supported"
     def test_check_validity_on_tensor_support(self, mock_device_supporting_paulis):
         """Tests the function Device.check_validity with tensor support capability"""
         dev = mock_device_supporting_paulis()
@@ -353,9 +355,11 @@ class TestInternalFunctions:  # pylint:disable=too-many-public-methods
         observables = [qml.expval(qml.PauliZ(0) @ qml.PauliX(1))]
 
         # mock device does not support Tensor product
-        with pytest.raises(DeviceError, match="Tensor observables not supported"):
+        with pytest.raises(DeviceError, match="Observable Prod not supported on device MockDevice"):
             dev.check_validity(queue, observables)
 
+    # Works with opmath disabled by replacing
+    # match="Observable Prod not supported"   with   match="Observable Hadamard not supported"
     def test_check_validity_on_invalid_observable_with_tensor_support(self, monkeypatch):
         """Tests the function Device.check_validity with tensor support capability
         but with an invalid observable"""
@@ -378,7 +382,7 @@ class TestInternalFunctions:  # pylint:disable=too-many-public-methods
             dev = D()
 
             # mock device supports Tensor products but not hadamard
-            with pytest.raises(DeviceError, match="Observable Hadamard not supported"):
+            with pytest.raises(DeviceError, match="Observable Prod not supported"):
                 dev.check_validity(queue, observables)
 
     def test_check_validity_on_invalid_queue(self, mock_device_supporting_paulis):


### PR DESCRIPTION
This PR fixes the following test:

- `tests/test_device.py::TestInternalFunctions::test_device_default_expand_ops`

Files modified in the source code:

- None

[sc-58795]