### PR TITLE
Update eigvals function

### DIFF
--- a/pennylane/ops/op_math/linear_combination.py
+++ b/pennylane/ops/op_math/linear_combination.py
@@ -430,6 +430,35 @@ class LinearCombination(Sum):
             context.append(self)
         return self
 
+    def eigvals(self):
+        """Return the eigenvalues of the specified operator.
+
+        This method uses pre-stored eigenvalues for standard observables where
+        possible and stores the corresponding eigenvectors from the eigendecomposition.
+
+        Returns:
+            array: array containing the eigenvalues of the operator
+        """
+        eigvals = []
+        for ops in self.overlapping_ops:
+            if len(ops) == 1:
+                eigvals.append(
+                    qml.utils.expand_vector(ops[0].eigvals(), list(ops[0].wires), list(self.wires))
+                )
+            else:
+                tmp_composite = Sum(*ops)  # only change compared to CompositeOp.eigvals()
+                eigvals.append(
+                    qml.utils.expand_vector(
+                        tmp_composite.eigendecomposition["eigval"],
+                        list(tmp_composite.wires),
+                        list(self.wires),
+                    )
+                )
+
+        return self._math_op(
+            qml.math.asarray(eigvals, like=qml.math.get_deep_interface(eigvals)), axis=0
+        )
+
     def diagonalizing_gates(self):
         r"""Sequence of gates that diagonalize the operator in the computational basis.
 

--- a/tests/ops/op_math/test_linear_combination.py
+++ b/tests/ops/op_math/test_linear_combination.py
@@ -16,7 +16,6 @@ Tests for the LinearCombination class.
 """
 # pylint: disable=too-many-public-methods
 from collections.abc import Iterable
-from unittest.mock import patch
 from copy import copy
 
 import numpy as np
@@ -940,6 +939,19 @@ class TestLinearCombination:
 
         assert LC.diagonalizing_gates() == SUM.diagonalizing_gates()
 
+    def test_eigvals(self):
+        """Test that LinearCombination has valid eigvals"""
+        LC = qml.ops.LinearCombination([1.1, 2.2, 3.3], [qml.X(0), qml.Z(0), qml.Y(1)])
+
+        assert len(LC.overlapping_ops[0]) > 1  # will use one branch
+        assert len(LC.overlapping_ops[1]) == 1  # will use the other branch
+
+        SUM = qml.sum(
+            qml.s_prod(1.1, qml.X(0)), qml.s_prod(2.2, qml.Z(0)), qml.s_prod(3.3, qml.Y(1))
+        )
+
+        assert np.all(LC.eigvals() == SUM.eigvals())
+
 
 class TestLinearCombinationCoefficients:
     """Test the creation of a LinearCombination"""
@@ -1738,6 +1750,7 @@ class TestLinearCombinationDifferentiation:
         assert np.allclose(grad[0], grad_expected[0])
         assert np.allclose(grad[1], grad_expected[1])
 
+    # pylint: disable=superfluous-parens
     @pytest.mark.jax
     def test_nontrainable_coeffs_jax(self):
         """Test the jax interface if the coefficients are explicitly set non-trainable"""


### PR DESCRIPTION
The `eigvals` function inherited from `CompositeOp` was failing for the same reason as `diagonalizing_gates`. Fixed here.

Eigvals function is copy-pasted from `CompositeOp` and only the line indicated by the comment is modified.