### PR TITLE
Fix rendering issues in release doc from deprecations and removals

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -125,19 +125,19 @@
 
 <h3>Breaking changes 💔</h3>
 
-* The private functions ``_pauli_mult``, ``_binary_matrix`` and ``_get_pauli_map`` from the ``pauli`` module have been removed. The same functionality can be achieved using newer features in the ``pauli`` module.
+* The private functions `_pauli_mult`, `_binary_matrix` and `_get_pauli_map` from the `pauli` module have been removed. The same functionality can be achieved using newer features in the ``pauli`` module.
   [(#5323)](https://github.com/PennyLaneAI/pennylane/pull/5323)
 
 * `qml.matrix()` called on the following will raise an error if `wire_order` is not specified:
   * tapes with more than one wire.
   * quantum functions.
-  * Operator class where ``num_wires`` does not equal to 1
+  * Operator class where `num_wires` does not equal to 1
   * QNodes if the device does not have wires specified.
   * PauliWords and PauliSentences with more than one wire.
   [(#5328)](https://github.com/PennyLaneAI/pennylane/pull/5328)
   [(#5359)](https://github.com/PennyLaneAI/pennylane/pull/5359)
 
-* ``qml.pauli.pauli_mult`` and ``qml.pauli.pauli_mult_with_phase`` are now removed. Instead, you  should use ``qml.simplify(qml.prod(pauli_1, pauli_2))`` to get the reduced operator.
+* `qml.pauli.pauli_mult` and `qml.pauli.pauli_mult_with_phase` are now removed. Instead, you  should use `qml.simplify(qml.prod(pauli_1, pauli_2))` to get the reduced operator.
   [(#5324)](https://github.com/PennyLaneAI/pennylane/pull/5324)
   
   ```pycon
@@ -149,30 +149,30 @@
   (-1j, PauliY(wires=[0]))
   ```
 
-* ``MeasurementProcess.name`` and ``MeasurementProcess.data`` have been removed. Use ``MeasurementProcess.obs.name`` and ``MeasurementProcess.obs.data`` instead.
+* `MeasurementProcess.name` and `MeasurementProcess.data` have been removed. Use `MeasurementProcess.obs.name` and `MeasurementProcess.obs.data` instead.
   [(#5321)](https://github.com/PennyLaneAI/pennylane/pull/5321)
 
 * `Operator.validate_subspace(subspace)` has been removed. Instead, you should use `qml.ops.qutrit.validate_subspace(subspace)`.
   [(#5311)](https://github.com/PennyLaneAI/pennylane/pull/5311)
 
-* The contents of ``qml.interfaces`` is moved inside ``qml.workflow``. The old import path no longer exists.
+* The contents of `qml.interfaces` is moved inside `qml.workflow`. The old import path no longer exists.
   [(#5329)](https://github.com/PennyLaneAI/pennylane/pull/5329)
 
-* ``single_tape_transform``, ``batch_transform``, ``qfunc_transform``, ``op_transform``, `` gradient_transform``
-  and ``hessian_transform`` are removed. Instead, switch to using the new ``qml.transform`` function. Please refer to
+* `single_tape_transform`, `batch_transform`, `qfunc_transform`, `op_transform`, `gradient_transform`
+  and `hessian_transform` are removed. Instead, switch to using the new `qml.transform` function. Please refer to
   `the transform docs <https://docs.pennylane.ai/en/stable/code/qml_transforms.html#custom-transforms>`_
   to see how this can be done.
   [(#5339)](https://github.com/PennyLaneAI/pennylane/pull/5339)
 
-* Attempting to multiply ``PauliWord`` and ``PauliSentence`` with ``*`` will raise an error. Instead, use ``@`` to conform with the PennyLane convention.
+* Attempting to multiply `PauliWord` and `PauliSentence` with `*` will raise an error. Instead, use `@` to conform with the PennyLane convention.
   [(#5341)](https://github.com/PennyLaneAI/pennylane/pull/5341)
 
 <h3>Deprecations 👋</h3>
 
-* ``qml.load`` is deprecated. Instead, please use the functions outlined in the *Importing workflows* quickstart guide, such as ``qml.from_qiskit``.
+* `qml.load` is deprecated. Instead, please use the functions outlined in the *Importing workflows* quickstart guide, such as `qml.from_qiskit`.
   [(#5312)](https://github.com/PennyLaneAI/pennylane/pull/5312)
 
-* ``qml.from_qasm_file`` is deprecated. Instead, please open the file and then load its content using ``qml.from_qasm``.
+* `qml.from_qasm_file` is deprecated. Instead, please open the file and then load its content using `qml.from_qasm`.
   [(#5331)](https://github.com/PennyLaneAI/pennylane/pull/5331)
 
   ```pycon


### PR DESCRIPTION
**Context:**
Changelog entries in the deprecations and removals PRs have rendering issues on readthedocs

**Description of the Change:**
Replace double quotes with single quotes for code snippets