### PR TITLE
Opmath tests pass with old Hamiltonian

### DIFF
--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -10,7 +10,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# pylint: disable=protected-access
+# pylint: disable=protected-access, no-member
 r"""
 This module contains the abstract base classes for defining PennyLane
 operations and observables.
@@ -3152,7 +3152,10 @@ def convert_to_legacy_H(op):
     else:
         raise ValueError("Could not convert to Hamiltonian. Some or all observables are not valid.")
 
-    return qml.Hamiltonian(coeffs, ops)
+    with disable_new_opmath_cm():
+        hamiltonian = qml.Hamiltonian(coeffs, ops)
+
+    return hamiltonian
 
 
 def __getattr__(name):

--- a/tests/ops/functions/conftest.py
+++ b/tests/ops/functions/conftest.py
@@ -43,7 +43,7 @@ _INSTANCES_TO_TEST = [
     qml.adjoint(qml.PauliX(0)),
     qml.adjoint(qml.RX(1.1, 0)),
     Tensor(qml.PauliX(0), qml.PauliX(1)),
-    qml.Hamiltonian([1.1, 2.2], [qml.PauliX(0), qml.PauliZ(0)]),
+    qml.operation.convert_to_legacy_H(qml.Hamiltonian([1.1, 2.2], [qml.PauliX(0), qml.PauliZ(0)])),
     qml.ops.LinearCombination([1.1, 2.2], [qml.PauliX(0), qml.PauliZ(0)]),
     qml.s_prod(1.1, qml.RX(1.1, 0)),
     qml.prod(qml.PauliX(0), qml.PauliY(1), qml.PauliZ(0)),

--- a/tests/ops/functions/test_assert_valid.py
+++ b/tests/ops/functions/test_assert_valid.py
@@ -373,7 +373,11 @@ def test_generated_list_of_ops(class_to_validate):
 
 def test_explicit_list_of_ops(valid_instance):
     """Test the validity of operators that could not be auto-generated."""
-    assert_valid(valid_instance)
+    if valid_instance.name == "Hamiltonian":
+        with qml.operation.disable_new_opmath_cm():
+            assert_valid(valid_instance)
+    else:
+        assert_valid(valid_instance)
 
 
 def test_explicit_list_of_failing_ops(invalid_instance_and_error):


### PR DESCRIPTION
The fixes over the last couple of days have LinearCombination already passing, but it was upset that Hamiltonian wasn't being tested, which was because it wasn't being created, which was because you can't with the new opmath.

This is one solution to that, pending a decision about whether we really want to mock all the things.