### PR TITLE
[WIP] Use `pauli_rep` to compute `Sum.matrix()` more efficiently

### DIFF
--- a/pennylane/ops/op_math/sum.py
+++ b/pennylane/ops/op_math/sum.py
@@ -287,6 +287,9 @@ class Sum(CompositeOp):
         Returns:
             tensor_like: matrix representation
         """
+        if self.pauli_rep:  # Get the matrix from the PauliSentence representation
+            return self.pauli_rep.to_mat(wire_order=wire_order or self.wires)
+
         gen = (
             (qml.matrix(op) if isinstance(op, Hamiltonian) else op.matrix(), op.wires)
             for op in self

--- a/pennylane/pauli/pauli_arithmetic.py
+++ b/pennylane/pauli/pauli_arithmetic.py
@@ -832,6 +832,9 @@ class PauliSentence(dict):
             the PauliWord is empty ({}), choose any arbitrary wire from the
             PauliSentence it is composed in.
             """
+            if self.wires == qml.wires.Wires([]):
+                print(w)
+                return w
             return w or Wires(self.wires[0]) if self.wires else self.wires
 
         if len(self) == 0:


### PR DESCRIPTION
Use `pauli_rep` whenever possible to compute the matrix of a `Sum` operator more efficiently.

This is currently blocked by https://github.com/PennyLaneAI/pennylane/issues/5354