### PR TITLE
[new opmath] Update tests/workflow/

### DIFF
--- a/tests/transforms/test_optimization/test_merge_rotations.py
+++ b/tests/transforms/test_optimization/test_merge_rotations.py
@@ -510,3 +510,18 @@ class TestTransformDispatch:
         res = transformed_qnode([0.1, 0.2, 0.3, 0.4])
         exp_res = qnode_circuit([0.1, 0.2, 0.3, 0.4])
         assert np.allclose(res, exp_res)
+
+
+@pytest.mark.xfail
+def test_merge_rotations_non_commuting_observables():
+    """Test that merge_roatations works with non-commuting observables."""
+
+    @qml.transforms.merge_rotations
+    def circuit(x):
+        qml.RX(x, wires=0)
+        qml.RX(-x, wires=0)
+        return qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliX(0))
+
+    res = circuit(0.5)
+    assert qml.math.allclose(res[0], 1.0)
+    assert qml.math.allclose(res[1], 0.0)

--- a/tests/workflow/test_construct_batch.py
+++ b/tests/workflow/test_construct_batch.py
@@ -322,7 +322,7 @@ class TestConstructBatch:
 
     @pytest.mark.usefixtures("use_legacy_opmath")
     @pytest.mark.parametrize("level", ("device", None))
-    def test_device_transforms_legacy_interface(self, level):
+    def test_device_transforms_legacy_interface_legacy_opmath(self, level):
         """Test that the device transforms can be selected with level=device or None."""
 
         @qml.transforms.merge_rotations
@@ -332,6 +332,33 @@ class TestConstructBatch:
             qml.RX(0.5, wires=0)
             qml.RX(-0.5, wires=0)
             return qml.expval(qml.PauliX(0) + qml.PauliY(0))
+
+        batch, fn = construct_batch(circuit, level=level)((2, 1, 0))
+
+        expected0 = qml.tape.QuantumScript(
+            [qml.SWAP((0, 2))], [qml.expval(qml.PauliX(0))], shots=50
+        )
+        assert qml.equal(expected0, batch[0])
+        expected1 = qml.tape.QuantumScript(
+            [qml.SWAP((0, 2))], [qml.expval(qml.PauliY(0))], shots=50
+        )
+        assert qml.equal(expected1, batch[1])
+        assert len(batch) == 2
+
+        assert fn((1.0, 2.0)) == (3.0,)
+
+    @pytest.mark.xfail
+    @pytest.mark.parametrize("level", ("device", None))
+    def test_device_transforms_legacy_interface_legacy_opmath(self, level):
+        """Test that the device transforms can be selected with level=device or None."""
+
+        @qml.transforms.merge_rotations
+        @qml.qnode(qml.device("default.qubit.legacy", wires=2, shots=50))
+        def circuit(order):
+            qml.Permute(order, wires=(0, 1, 2))
+            qml.RX(0.5, wires=0)
+            qml.RX(-0.5, wires=0)
+            return [qml.expval(qml.PauliX(0)), qml.expval(qml.PauliY(0))]
 
         batch, fn = construct_batch(circuit, level=level)((2, 1, 0))
 

--- a/tests/workflow/test_construct_batch.py
+++ b/tests/workflow/test_construct_batch.py
@@ -320,6 +320,7 @@ class TestConstructBatch:
         assert len(batch) == 1
         assert fn(("a",)) == ("a",)
 
+    @pytest.mark.usefixtures("use_legacy_opmath")
     @pytest.mark.parametrize("level", ("device", None))
     def test_device_transforms_legacy_interface(self, level):
         """Test that the device transforms can be selected with level=device or None."""

--- a/tests/workflow/test_construct_batch.py
+++ b/tests/workflow/test_construct_batch.py
@@ -320,7 +320,8 @@ class TestConstructBatch:
         assert len(batch) == 1
         assert fn(("a",)) == ("a",)
 
-    def test_device_transforms_legacy_interface(self):
+    @pytest.mark.parametrize("level", ("device", None))
+    def test_device_transforms_legacy_interface(self, level):
         """Test that the device transforms can be selected with level=device or None without trainable parameters"""
 
         @qml.transforms.cancel_inverses
@@ -331,7 +332,7 @@ class TestConstructBatch:
             qml.X(0)
             return [qml.expval(qml.PauliX(0)), qml.expval(qml.PauliY(0))]
 
-        batch, fn = qml.workflow.construct_batch(circuit, level=None)((2, 1, 0))
+        batch, fn = qml.workflow.construct_batch(circuit, level=level)((2, 1, 0))
 
         expected0 = qml.tape.QuantumScript(
             [qml.SWAP((0, 2))], [qml.expval(qml.PauliX(0))], shots=50

--- a/tests/workflow/test_construct_batch.py
+++ b/tests/workflow/test_construct_batch.py
@@ -349,7 +349,7 @@ class TestConstructBatch:
 
     @pytest.mark.xfail
     @pytest.mark.parametrize("level", ("device", None))
-    def test_device_transforms_legacy_interface_legacy_opmath(self, level):
+    def test_device_transforms_legacy_interface(self, level):
         """Test that the device transforms can be selected with level=device or None."""
 
         @qml.transforms.merge_rotations

--- a/tests/workflow/test_construct_batch.py
+++ b/tests/workflow/test_construct_batch.py
@@ -348,7 +348,7 @@ class TestConstructBatch:
         assert fn((1.0, 2.0)) == (3.0,)
 
     def test_device_transforms_legacy_interface(self):
-        """Test that the device transforms can be selected with level=device or None."""
+        """Test that the device transforms can be selected with level=device or None without trainable parameters"""
 
         @qml.transforms.cancel_inverses
         @qml.qnode(qml.device("default.qubit.legacy", wires=2, shots=50))
@@ -375,7 +375,7 @@ class TestConstructBatch:
     @pytest.mark.xfail  # TODO construct_batch handles new opmath non-commuting ops with shots and parameter shift
     @pytest.mark.parametrize("level", ("device", None))
     def test_device_transforms_legacy_interface_trainable_params(self, level):
-        """Test that the device transforms can be selected with level=device or None."""
+        """Test that the device transforms can be selected with level=device or None with trainable parameters"""
 
         @qml.transforms.merge_rotations
         @qml.qnode(qml.device("default.qubit.legacy", wires=2, shots=50))

--- a/tests/workflow/test_construct_batch.py
+++ b/tests/workflow/test_construct_batch.py
@@ -372,7 +372,7 @@ class TestConstructBatch:
         assert qml.equal(expected1, batch[1])
         assert len(batch) == 2
 
-        assert fn((1.0, 2.0)) == (3.0,)
+        assert fn((1.0, 2.0)) == (1.0, 2.0)
 
     def test_final_transform(self):
         """Test that the final transform is included when level=None."""

--- a/tests/workflow/test_construct_batch.py
+++ b/tests/workflow/test_construct_batch.py
@@ -372,7 +372,7 @@ class TestConstructBatch:
 
         assert fn((1.0, 2.0)) == ((1.0, 2.0),)
 
-    @pytest.mark.xfail # TODO construct_batch handles new opmath non-commuting ops with shots and parameter shift
+    @pytest.mark.xfail  # TODO construct_batch handles new opmath non-commuting ops with shots and parameter shift
     @pytest.mark.parametrize("level", ("device", None))
     def test_device_transforms_legacy_interface_trainable_params(self, level):
         """Test that the device transforms can be selected with level=device or None."""


### PR DESCRIPTION
"Fixing" `tests/workflow/test_construct_batch.py::TestConstructBatch::test_device_transforms_legacy_interface` by marking it as legacy as it is specifically testing `default.qubit.legacy`. Up for discussion, pelase leave feedback.