### PR TITLE
Make `Prod` compatible with qutrit operators

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -153,6 +153,7 @@
   [(#5377)](https://github.com/PennyLaneAI/pennylane/pull/5377)
 
 * `Prod.eigvals()` is now compatible with Qudit operators.
+  [(#5400)](https://github.com/PennyLaneAI/pennylane/pull/5400)
 
 <h4>Community contributions 🥳</h4>
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -152,6 +152,8 @@
 * `Hamiltonian.pauli_rep` is now defined if the hamiltonian is a linear combination of paulis.
   [(#5377)](https://github.com/PennyLaneAI/pennylane/pull/5377)
 
+* `Prod.eigvals()` is now compatible with Qudit operators.
+
 <h4>Community contributions 🥳</h4>
 
 * Functions `measure_with_samples` and `sample_state` have been added to the new `qutrit_mixed` module found in

--- a/pennylane/devices/default_qutrit.py
+++ b/pennylane/devices/default_qutrit.py
@@ -33,6 +33,7 @@ tolerance = 1e-10
 OMEGA = qml.math.exp(2 * np.pi * 1j / 3)
 
 
+# pylint: disable=too-many-arguments
 class DefaultQutrit(QutritDevice):
     """Default qutrit device for PennyLane.
 
@@ -87,11 +88,7 @@ class DefaultQutrit(QutritDevice):
 
     # Identity is supported as an observable for qml.state() to work correctly. However, any
     # measurement types that rely on eigenvalue decomposition will not work with qml.Identity
-    observables = {
-        "THermitian",
-        "GellMann",
-        "Identity",
-    }
+    observables = {"THermitian", "GellMann", "Identity", "Prod"}
 
     # Static methods to use qml.math to allow for backprop differentiation
     _reshape = staticmethod(qml.math.reshape)

--- a/pennylane/utils.py
+++ b/pennylane/utils.py
@@ -175,26 +175,26 @@ def expand_vector(vector, original_wires, expanded_wires):
     M = len(expanded_wires)
     D = M - N
 
+    len_vector = qml.math.shape(vector)[0]
+    qudit_order = int(2 ** (np.log2(len_vector) / N))
+
     if not set(expanded_wires).issuperset(original_wires):
         raise ValueError("Invalid target subsystems provided in 'original_wires' argument.")
 
-    if qml.math.shape(vector) != (2**N,):
-        raise ValueError("Vector parameter must be of length 2**len(original_wires)")
+    if qml.math.shape(vector) != (qudit_order**N,):
+        raise ValueError(f"Vector parameter must be of length {qudit_order}**len(original_wires)")
 
-    dims = [2] * N
+    dims = [qudit_order] * N
     tensor = qml.math.reshape(vector, dims)
 
     if D > 0:
-        extra_dims = [2] * D
-        ones = qml.math.ones(2**D).reshape(extra_dims)
+        extra_dims = [qudit_order] * D
+        ones = qml.math.ones(qudit_order**D).reshape(extra_dims)
         expanded_tensor = qml.math.tensordot(tensor, ones, axes=0)
     else:
         expanded_tensor = tensor
 
-    wire_indices = []
-    for wire in original_wires:
-        wire_indices.append(expanded_wires.index(wire))
-
+    wire_indices = [expanded_wires.index(wire) for wire in original_wires]
     wire_indices = np.array(wire_indices)
 
     # Order tensor factors according to wires
@@ -203,4 +203,4 @@ def expand_vector(vector, original_wires, expanded_wires):
         expanded_tensor, tuple(original_indices), tuple(wire_indices)
     )
 
-    return qml.math.reshape(expanded_tensor, 2**M)
+    return qml.math.reshape(expanded_tensor, qudit_order**M)

--- a/tests/ops/op_math/test_prod.py
+++ b/tests/ops/op_math/test_prod.py
@@ -959,6 +959,26 @@ class TestProperties:
         assert np.allclose(eig_vals, true_eigvals)
         assert np.allclose(eig_vecs, true_eigvecs)
 
+    def test_qutrit_eigvals(self):
+        """Test that the eigvals can be computed with qutrit observables."""
+
+        op1 = qml.GellMann(wires=0)
+        op2 = qml.GellMann(index=8, wires=1)
+
+        prod_op = qml.prod(op1, op2)
+        eigs = prod_op.eigvals()
+
+        mat_eigs = np.linalg.eigvals(prod_op.matrix())
+
+        sorted_eigs = np.sort(eigs)
+        sorted_mat_eigs = np.sort(mat_eigs)
+        assert qml.math.allclose(sorted_eigs, sorted_mat_eigs)
+
+        # pylint: disable=import-outside-top-level
+        from pennylane.ops.functions.assert_valid import _check_eigendecomposition
+
+        _check_eigendecomposition(prod_op)
+
     def test_eigen_caching(self):
         """Test that the eigendecomposition is stored in cache."""
         diag_prod_op = Prod(qml.PauliZ(wires=0), qml.PauliZ(wires=1))


### PR DESCRIPTION
[sc-59010]

The `tests/devices/test_default_qutrit.py` tests were failing due to `Prod.eigvals()`.  The eigenvalues were not defined for `Tensor`, but now `Prod` gives it its best effort. Unfortunately, `Prod`'s best effort was not sufficient.

This change improves `qml.utils.expand_vector` so it is compatible with qudit operators.