### PR TITLE
Make Clifford device compatible with the new `stim` release

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -141,6 +141,10 @@
 * `Hamiltonian.pauli_rep` is now defined if the hamiltonian is a linear combination of paulis.
   [(#5377)](https://github.com/PennyLaneAI/pennylane/pull/5377)
 
+* Obtaining classical shadows using the `default.clifford` device is now compatible with
+  [stim](https://github.com/quantumlib/Stim) `v1.13.0`.
+  [(#5409)](https://github.com/PennyLaneAI/pennylane/pull/5409)
+
 <h4>Community contributions 🥳</h4>
 
 * Functions `measure_with_samples` and `sample_state` have been added to the new `qutrit_mixed` module found in

--- a/pennylane/devices/default_clifford.py
+++ b/pennylane/devices/default_clifford.py
@@ -1034,7 +1034,7 @@ class DefaultClifford(Device):
         for recipe in recipes:
             bits.append(
                 [
-                    self._measure_single_sample(stim_circuit, [rec + 1], idx, meas_wire)
+                    self._measure_single_sample(stim_circuit, [int(rec) + 1], idx, meas_wire)
                     for idx, rec in enumerate(recipe)
                 ]
             )

--- a/tests/devices/test_default_clifford.py
+++ b/tests/devices/test_default_clifford.py
@@ -255,7 +255,7 @@ def test_meas_samples(circuit, shots):
 
 
 @pytest.mark.parametrize("tableau", [True, False])
-@pytest.mark.parametrize("shots", [None, 8192])
+@pytest.mark.parametrize("shots", [None, 50000])
 @pytest.mark.parametrize(
     "ops",
     [


### PR DESCRIPTION
**Context:** A couple of tests failed with the new `stim` release.

**Description of the Change:** Force `int` conversion from `numpy.int64` type and increase the number of shots to improve the robustness of sampling tests.

**Benefits:**

**Possible Drawbacks:** N/A 

**Related GitHub Issues:** N/A
