### PR TITLE
Add relevant comments on qutrit generators

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -139,9 +139,10 @@
 * The `molecular_hamiltonian` function calls `PySCF` directly when `method='pyscf'` is selected.
   [(#5118)](https://github.com/PennyLaneAI/pennylane/pull/5118)
 
-* All generators in the source code (except those in the `qchem` module) no longer return
-  `Hamiltonian` or `Tensor` instances. Wherever possible, these return `Sum`, `SProd`, and `Prod` instances.
+* The generators in the source code return operators consistent with the global setting for 
+  `qml.operator.active_new_opmath()` whereever possible.
   [(#5253)](https://github.com/PennyLaneAI/pennylane/pull/5253)
+  [(#5412)](https://github.com/PennyLaneAI/pennylane/pull/5412)
 
 * Upgraded `null.qubit` to the new device API. Also, added support for all measurements and various modes of differentiation.
   [(#5211)](https://github.com/PennyLaneAI/pennylane/pull/5211)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -140,7 +140,7 @@
   [(#5118)](https://github.com/PennyLaneAI/pennylane/pull/5118)
 
 * The generators in the source code return operators consistent with the global setting for 
-  `qml.operator.active_new_opmath()` whereever possible.
+  `qml.operator.active_new_opmath()` whereever possible. `Sum`, `SProd` and `Prod` instances will be returned even after disabling the new operator arithmetic in cases where they offer additional functionality not available using legacy operators.
   [(#5253)](https://github.com/PennyLaneAI/pennylane/pull/5253)
   [(#5412)](https://github.com/PennyLaneAI/pennylane/pull/5412)
 

--- a/pennylane/ops/qutrit/parametric_ops.py
+++ b/pennylane/ops/qutrit/parametric_ops.py
@@ -112,7 +112,9 @@ class TRX(Operation):
     _index_dict = {(0, 1): 1, (0, 2): 4, (1, 2): 6}
 
     def generator(self):
-        return qml.Hamiltonian([-0.5], [qml.GellMann(self.wires, index=self._index_dict[self.subspace])])
+        return qml.Hamiltonian(
+            [-0.5], [qml.GellMann(self.wires, index=self._index_dict[self.subspace])]
+        )
 
     def __init__(self, phi, wires, subspace=(0, 1), id=None):
         self._subspace = validate_subspace(subspace)
@@ -257,7 +259,9 @@ class TRY(Operation):
     _index_dict = {(0, 1): 2, (0, 2): 5, (1, 2): 7}
 
     def generator(self):
-        return qml.Hamiltonian([-0.5], [qml.GellMann(self.wires, index=self._index_dict[self.subspace])])
+        return qml.Hamiltonian(
+            [-0.5], [qml.GellMann(self.wires, index=self._index_dict[self.subspace])]
+        )
 
     def __init__(self, phi, wires, subspace=(0, 1), id=None):
         self._subspace = validate_subspace(subspace)

--- a/pennylane/ops/qutrit/parametric_ops.py
+++ b/pennylane/ops/qutrit/parametric_ops.py
@@ -112,7 +112,7 @@ class TRX(Operation):
     _index_dict = {(0, 1): 1, (0, 2): 4, (1, 2): 6}
 
     def generator(self):
-        return qml.s_prod(-0.5, qml.GellMann(self.wires, index=self._index_dict[self.subspace]))
+        return -0.5 * qml.GellMann(self.wires, index=self._index_dict[self.subspace])
 
     def __init__(self, phi, wires, subspace=(0, 1), id=None):
         self._subspace = validate_subspace(subspace)
@@ -257,7 +257,7 @@ class TRY(Operation):
     _index_dict = {(0, 1): 2, (0, 2): 5, (1, 2): 7}
 
     def generator(self):
-        return qml.s_prod(-0.5, qml.GellMann(self.wires, index=self._index_dict[self.subspace]))
+        return -0.5 * qml.GellMann(self.wires, index=self._index_dict[self.subspace])
 
     def __init__(self, phi, wires, subspace=(0, 1), id=None):
         self._subspace = validate_subspace(subspace)

--- a/pennylane/ops/qutrit/parametric_ops.py
+++ b/pennylane/ops/qutrit/parametric_ops.py
@@ -112,7 +112,7 @@ class TRX(Operation):
     _index_dict = {(0, 1): 1, (0, 2): 4, (1, 2): 6}
 
     def generator(self):
-        return qml.Hamiltonian([-0.5], [qml.GellMann(self.wires, index=self._index_dict[self.subspace]])
+        return qml.Hamiltonian([-0.5], [qml.GellMann(self.wires, index=self._index_dict[self.subspace])])
 
     def __init__(self, phi, wires, subspace=(0, 1), id=None):
         self._subspace = validate_subspace(subspace)
@@ -257,7 +257,7 @@ class TRY(Operation):
     _index_dict = {(0, 1): 2, (0, 2): 5, (1, 2): 7}
 
     def generator(self):
-        return qml.Hamiltonian([-0.5], [qml.GellMann(self.wires, index=self._index_dict[self.subspace]])
+        return qml.Hamiltonian([-0.5], [qml.GellMann(self.wires, index=self._index_dict[self.subspace])])
 
     def __init__(self, phi, wires, subspace=(0, 1), id=None):
         self._subspace = validate_subspace(subspace)

--- a/pennylane/ops/qutrit/parametric_ops.py
+++ b/pennylane/ops/qutrit/parametric_ops.py
@@ -112,9 +112,9 @@ class TRX(Operation):
     _index_dict = {(0, 1): 1, (0, 2): 4, (1, 2): 6}
 
     def generator(self):
-        return qml.Hamiltonian(
-            [-0.5], [qml.GellMann(self.wires, index=self._index_dict[self.subspace])]
-        )
+        # this generator returns SProd, even with the old op_math, because other options are not suitable
+        # to qudit operators (for example, they do not have a matrix defined as a Hamiltonian)
+        return qml.s_prod(-0.5, qml.GellMann(self.wires, index=self._index_dict[self.subspace]))
 
     def __init__(self, phi, wires, subspace=(0, 1), id=None):
         self._subspace = validate_subspace(subspace)
@@ -259,9 +259,9 @@ class TRY(Operation):
     _index_dict = {(0, 1): 2, (0, 2): 5, (1, 2): 7}
 
     def generator(self):
-        return qml.Hamiltonian(
-            [-0.5], [qml.GellMann(self.wires, index=self._index_dict[self.subspace])]
-        )
+        # this generator returns SProd, even with the old op_math, because other options are not suitable
+        # to qudit operators (for example, they do not have a matrix defined as a Hamiltonian)
+        return qml.s_prod(-0.5, qml.GellMann(self.wires, index=self._index_dict[self.subspace]))
 
     def __init__(self, phi, wires, subspace=(0, 1), id=None):
         self._subspace = validate_subspace(subspace)
@@ -399,6 +399,8 @@ class TRZ(Operation):
     parameter_frequencies = [(0.5, 1)]
 
     def generator(self):
+        # these generators return SProd and Sum, even with the old op_math, because other options are
+        # not suitable to qudit operators (for example, they do not have a matrix defined as a Hamiltonian)
         if self.subspace == (0, 1):
             return qml.s_prod(-0.5, qml.GellMann(wires=self.wires, index=3))
 

--- a/pennylane/ops/qutrit/parametric_ops.py
+++ b/pennylane/ops/qutrit/parametric_ops.py
@@ -112,7 +112,7 @@ class TRX(Operation):
     _index_dict = {(0, 1): 1, (0, 2): 4, (1, 2): 6}
 
     def generator(self):
-        return -0.5 * qml.GellMann(self.wires, index=self._index_dict[self.subspace])
+        return qml.Hamiltonian([-0.5], [qml.GellMann(self.wires, index=self._index_dict[self.subspace]])
 
     def __init__(self, phi, wires, subspace=(0, 1), id=None):
         self._subspace = validate_subspace(subspace)
@@ -257,7 +257,7 @@ class TRY(Operation):
     _index_dict = {(0, 1): 2, (0, 2): 5, (1, 2): 7}
 
     def generator(self):
-        return -0.5 * qml.GellMann(self.wires, index=self._index_dict[self.subspace])
+        return qml.Hamiltonian([-0.5], [qml.GellMann(self.wires, index=self._index_dict[self.subspace]])
 
     def __init__(self, phi, wires, subspace=(0, 1), id=None):
         self._subspace = validate_subspace(subspace)


### PR DESCRIPTION
**Context:**
Updates the defined qutrit op generators to return as either a qml.ops.Hamiltonian or a qml.ops.LinearCombination as part of standardizing generators and keeping them consistent with the `opmath` setting. Previously always returned `sprod` regardless of `if active_new_opmath`.

**Description of the Change:**
Use `qml.Hamiltonian` instead of `sprod` to multiply the coefficient on to the operator

**Benefits:**
- The operator type returned will be consistent with the current setting to enable/disable `new_opmath` (i.e. no new opmath operators returned while `disable_new_opmath` is active)

- `isinstance(op.generator(), Hamiltonian)` checks won't break when you switch from old to new opmath
