### PR TITLE
`CompositeOp.map_wires` correctly maps `overlapping_ops`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -272,6 +272,7 @@
   [(#5407)](https://github.com/PennyLaneAI/pennylane/pull/5407)
 
 * `CompositeOp.map_wires` now correctly maps the `overlapping_ops` property.
+  [(#5430)](https://github.com/PennyLaneAI/pennylane/pull/5430)
 
 <h3>Contributors ✍️</h3>
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -271,6 +271,8 @@
 * Fixed `PauliSentence.to_mat(wire_order)` to support identities with wires.
   [(#5407)](https://github.com/PennyLaneAI/pennylane/pull/5407)
 
+* `CompositeOp.map_wires` now correctly maps the `overlapping_ops` property.
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane/ops/op_math/composite.py
+++ b/pennylane/ops/op_math/composite.py
@@ -351,8 +351,15 @@ class CompositeOp(Operator):
         new_op.operands = tuple(op.map_wires(wire_map=wire_map) for op in self)
         new_op._wires = Wires([wire_map.get(wire, wire) for wire in self.wires])
         new_op.data = copy.copy(self.data)
+        if self._overlapping_ops is not None:
+            new_op._overlapping_ops = [
+                [o.map_wires(wire_map) for o in _ops] for _ops in self._overlapping_ops
+            ]
+        else:
+            new_op._overlapping_ops = None
+
         for attr, value in vars(self).items():
-            if attr not in {"data", "operands", "_wires"}:
+            if attr not in {"data", "operands", "_wires", "_overlapping_ops"}:
                 setattr(new_op, attr, value)
         if (p_rep := new_op.pauli_rep) is not None:
             new_op._pauli_rep = p_rep.map_wires(wire_map)

--- a/tests/ops/op_math/test_composite.py
+++ b/tests/ops/op_math/test_composite.py
@@ -186,11 +186,17 @@ class TestConstruction:
         assert np.allclose(eig_vals, cached_vals)
         assert np.allclose(eig_vecs, cached_vecs)
 
-    def test_map_wires(self):
+    @pytest.mark.parametrize(
+        "construct_overlapping_ops, expected_overlapping_ops",
+        [(False, None), (True, [[qml.S(5)], [qml.T(7)]])],
+    )
+    def test_map_wires(self, construct_overlapping_ops, expected_overlapping_ops):
         """Test the map_wires method."""
         diag_op = ValidOp(*self.simple_operands)
         # pylint:disable=attribute-defined-outside-init
         diag_op._pauli_rep = qml.pauli.PauliSentence({qml.pauli.PauliWord({0: "X", 1: "Y"}): 1})
+        if construct_overlapping_ops:
+            _ = diag_op.overlapping_ops
 
         wire_map = {0: 5, 1: 7, 2: 9, 3: 11}
         mapped_op = diag_op.map_wires(wire_map=wire_map)
@@ -202,6 +208,7 @@ class TestConstruction:
         assert mapped_op.pauli_rep == qml.pauli.PauliSentence(
             {qml.pauli.PauliWord({5: "X", 7: "Y"}): 1}
         )
+        assert mapped_op._overlapping_ops == expected_overlapping_ops
 
     def test_build_pauli_rep(self):
         """Test the build_pauli_rep"""


### PR DESCRIPTION
**Context:**
As title says. Previously if `op.overlapping_ops` was not `None`, the `overlapping_ops` of the new operator still had the original wires.

**Description of the Change:**
Update `new_op._overlapping_ops` in `CompositeOp.map_wires`.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
