### PR TITLE
Add test workflow for legacy opmath

### DIFF
--- a/.github/workflows/legacy_op_math.yml
+++ b/.github/workflows/legacy_op_math.yml
@@ -1,0 +1,14 @@
+name: Legacy opmath tests
+
+on:
+  schedule:
+    - cron: "0 0 2 * *"
+  workflow_dispatch:
+
+jobs:
+  tests:
+    uses: ./.github/workflows/interface-unit-tests.yml
+    with:
+      branch: 'master'
+      run_lightened_ci: false
+      use_new_opmath: false

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -94,6 +94,11 @@ on:
         required: false
         type: string
         default: ''
+      use_new_opmath:
+        description: Whether to use the new op_math or not when running the tests
+        required: false
+        type: bool
+        default: true
 
 jobs:
   test:
@@ -169,6 +174,7 @@ jobs:
           COV_CORE_CONFIG: .coveragerc
           COV_CORE_DATAFILE: .coverage.eager
         # Calling PyTest by invoking Python first as that adds the current directory to sys.path
+        run: python -m import pennylane as qml && qml.operation.__use_new_opmath = ${{ inputs.use_new_opmath }}
         run: python -m pytest ${{ inputs.pytest_test_directory }} ${{ steps.pytest_args.outputs.args }} ${{ env.PYTEST_MARKER }}
 
       - name: Adjust coverage file for Codecov


### PR DESCRIPTION
Initially adding an `enable_new_opmath` variable (so we can run workflows with it set to `False`) to the basic `unit_test.yml` file, and making sure doing so doesn't break the normal tests.