### PR TITLE
Fix `QNSPSA` Optimizer

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -291,6 +291,8 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* The `QNSPSAOptimizer` can now be used for more than one step.
+
 * `jax.jit` now works with `qml.sample` with a multi-wire observable.
   [(#5422)](https://github.com/PennyLaneAI/pennylane/pull/5422)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -291,7 +291,7 @@
 
 <h3>Bug fixes 🐛</h3>
 
-* The `QNSPSAOptimizer` can now be used for more than one step.
+* The `QNSPSAOptimizer` now properly handles differentiable parameters, resulting in being able to use it for more than one optimization step.
   [(#5439)](https://github.com/PennyLaneAI/pennylane/pull/5439)
 
 * `jax.jit` now works with `qml.sample` with a multi-wire observable.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -292,6 +292,7 @@
 <h3>Bug fixes 🐛</h3>
 
 * The `QNSPSAOptimizer` can now be used for more than one step.
+  [(#5439)](https://github.com/PennyLaneAI/pennylane/pull/5439)
 
 * `jax.jit` now works with `qml.sample` with a multi-wire observable.
   [(#5422)](https://github.com/PennyLaneAI/pennylane/pull/5422)

--- a/pennylane/optimize/adaptive.py
+++ b/pennylane/optimize/adaptive.py
@@ -79,12 +79,12 @@ class AdaptiveOptimizer:
     adaptive circuit for the :math:`\text{H}_3^+` cation.
 
     >>> import pennylane as qml
-    >>> from pennylane import numpy as np
+    >>> from pennylane import numpy as pnp
 
     The molecule is defined and the Hamiltonian is computed with:
 
     >>> symbols = ["H", "H", "H"]
-    >>> geometry = np.array([[0.01076341, 0.04449877, 0.0],
+    >>> geometry = pnp.array([[0.01076341, 0.04449877, 0.0],
     ...                      [0.98729513, 1.63059094, 0.0],
     ...                      [1.87262415, -0.00815842, 0.0]], requires_grad=False)
     >>> H, qubits = qml.qchem.molecular_hamiltonian(symbols, geometry, charge = 1)

--- a/tests/optimize/test_adaptive.py
+++ b/tests/optimize/test_adaptive.py
@@ -118,7 +118,7 @@ def test_step_and_cost_nodrain(circuit, energy_ref, pool):
     """Test that step_and_cost function returns the correct results when drain_pool is False."""
     opt = qml.AdaptiveOptimizer()
     for _ in range(4):
-        circuit, energy, __ = opt.step_and_cost(circuit, pool, drain_pool=False)
+        circuit, energy, _ = opt.step_and_cost(circuit, pool, drain_pool=False)
 
     circuit()
     selected_excitations = [op.wires for op in circuit.tape.operations[1:]]

--- a/tests/optimize/test_qnspsa.py
+++ b/tests/optimize/test_qnspsa.py
@@ -435,3 +435,24 @@ def test_template_no_adjoint():
     opt = qml.QNSPSAOptimizer(stepsize=5e-2)
     assert opt.step_and_cost(cost, params)  # just checking it runs without error
     assert not qml.RandomLayers.has_adjoint
+
+
+def test_workflow_integration():
+    """Test that the optimizer can optimize a workflow."""
+
+    num_qubits = 2
+    dev = qml.device("default.qubit", wires=num_qubits)
+
+    @qml.qnode(dev)
+    def cost(params):
+        qml.RX(params[0], wires=0)
+        qml.CRY(params[1], wires=[0, 1])
+        return qml.expval(qml.Z(0) @ qml.Z(1))
+
+    params = qml.numpy.array([0.5, 0.5], requires_grad=True)
+    opt = qml.optimize.QNSPSAOptimizer(stepsize=5e-2)
+    for _ in range(51):
+        params, loss = opt.step_and_cost(cost, params)
+
+    assert qml.math.allclose(loss, -1, atol=1e-3)
+    assert qml.math.allclose(params, np.array([np.pi, 0]), atol=1e-2)

--- a/tests/optimize/test_qnspsa.py
+++ b/tests/optimize/test_qnspsa.py
@@ -455,4 +455,6 @@ def test_workflow_integration():
         params, loss = opt.step_and_cost(cost, params)
 
     assert qml.math.allclose(loss, -1, atol=1e-3)
-    assert qml.math.allclose(params, np.array([np.pi, 0]), atol=1e-2)
+    # compare sine of params and target params as could converge to params + 2* np.pi
+    target_params = np.array([np.pi, 0])
+    assert qml.math.allclose(np.sin(params), np.sin(target_params), atol=1e-2)


### PR DESCRIPTION
Fixes #5437 .  [sc-59838]

When we started distinguishing vanilla numpy and autograd numpy in our source code, we accidentally switched to using vanilla numpy in the `QNSPSA` optimizer instead of autograd numpy.  This switches it back.