### PR TITLE
Ensure bounded values for numpy binomial

### DIFF
--- a/pennylane/devices/qubit/apply_operation.py
+++ b/pennylane/devices/qubit/apply_operation.py
@@ -265,7 +265,12 @@ def apply_mid_measure(
         return np.zeros_like(state)
     wire = op.wires
     probs = qml.devices.qubit.measure(qml.probs(wire), state)
-    sample = np.random.binomial(1, probs[1])
+
+    try:
+        sample = np.random.binomial(1, probs[1])
+    except ValueError as e:
+        sample = np.random.binomial(1, np.round(probs[1], 15))
+
     mid_measurements[op] = sample
     if op.postselect is not None and sample != op.postselect:
         return np.zeros_like(state)


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      test directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `doc/releases/changelog-dev.md` file, summarizing the
      change, and including a link back to the PR.

- [ ] The PennyLane source code conforms to
      [PEP8 standards](https://www.python.org/dev/peps/pep-0008/).
      We check all of our code against [Pylint](https://www.pylint.org/).
      To lint modified files, simply `pip install pylint`, and then
      run `pylint pennylane/path/to/file.py`.

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:** A user reports errors when running MCM circuits, which fail due to numpy-defined bounds checks in `qml.random.binomial` which should be `0<= x <=1`. This error is due to the input data to `binomial` being supplied with 1.0000000000000002 from another numpy layer, which triggers this bounds check. This PR rounds towards 1.0 if an associated ValueError is thrown.

**Description of the Change:** Adds a try-except block to catch and round if the boundary check fails.

**Benefits:** Ensures continued use of MCM circuits.

**Possible Drawbacks:** Depending on the occurrence frequency of boundary failures, replacing the try-except block may be better handled by pre-validation against differences between unity and unity+macheps.

**Related GitHub Issues:**
