### PR TITLE
Reset qnode after execution error

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -291,6 +291,8 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* The `QNode` now resets if an error occurs during execution.
+
 * Fix Torch tensor locality with autoray-registered coerce method.
   [(#5438)](https://github.com/PennyLaneAI/pennylane/pull/5438)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -291,7 +291,8 @@
 
 <h3>Bug fixes 🐛</h3>
 
-* The `QNode` now resets if an error occurs during execution.
+* The `QNode` interface now resets if an error occurs during execution.
+  [(#5449)](https://github.com/PennyLaneAI/pennylane/pull/5449)
 
 * Fix Torch tensor locality with autoray-registered coerce method.
   [(#5438)](https://github.com/PennyLaneAI/pennylane/pull/5438)

--- a/tests/test_qnode.py
+++ b/tests/test_qnode.py
@@ -49,6 +49,8 @@ class CustomDevice(qml.devices.Device):
 
 
 class CustomDeviceWithDiffMethod(qml.devices.Device):
+    """A device that defines a derivative."""
+
     def execute(self, circuits, execution_config=None):
         return 0
 
@@ -79,6 +81,8 @@ def test_copy():
 
 
 class TestInitialization:
+    """Testing the initialization of the qnode."""
+
     def test_cache_initialization_maxdiff_1(self):
         """Test that when max_diff = 1, the cache initializes to false."""
 
@@ -929,6 +933,9 @@ class TestIntegration:
 
     @pytest.mark.parametrize("dev_name", ["default.qubit.legacy", "default.mixed"])
     def test_dynamic_one_shot_if_mcm_unsupported(self, dev_name):
+        """Test an error is raised if the dynamic one shot transform is a applied to a qnode with a device that
+        does not support mid circuit measurements.
+        """
         dev = qml.device(dev_name, wires=2, shots=100)
 
         with pytest.raises(
@@ -1363,6 +1370,8 @@ class TestShots:
 
 
 class TestTransformProgramIntegration:
+    """Tests for the integration of the transform program with the qnode."""
+
     def test_transform_program_modifies_circuit(self):
         """Test qnode integration with a transform that turns the circuit into just a pauli x."""
         dev = qml.device("default.qubit", wires=1)
@@ -1638,6 +1647,8 @@ class TestNewDeviceIntegration:
         """Test a device that has its own custom diff method."""
 
         class CustomDeviceWithDiffMethod2(qml.devices.DefaultQubit):
+            """A device with a custom derivative named hello."""
+
             def supports_derivatives(self, execution_config=None, circuit=None):
                 return getattr(execution_config, "gradient_method", None) == "hello"
 
@@ -1865,8 +1876,9 @@ class TestTapeExpansion:
 def test_resets_after_execution_error():
     """Test that the interface is reset to ``"auto"`` if an error occurs during execution."""
 
+    # pylint: disable=too-few-public-methods
     class BadOp(qml.operation.Operator):
-        pass
+        """An operator that will cause an error during execution."""
 
     @qml.qnode(qml.device("default.qubit"))
     def circuit(x):

--- a/tests/test_qnode.py
+++ b/tests/test_qnode.py
@@ -1860,3 +1860,20 @@ class TestTapeExpansion:
         ):
             x = pnp.array([0.5, 0.4, 0.3], requires_grad=True)
             circuit.construct([x], {})
+
+
+def test_resets_after_execution_error():
+    """Test that the interface is reset to ``"auto"`` if an error occurs during execution."""
+
+    class BadOp(qml.operation.Operator):
+        pass
+
+    @qml.qnode(qml.device("default.qubit"))
+    def circuit(x):
+        BadOp(x, wires=0)
+        return qml.state()
+
+    with pytest.raises(qml.DeviceError):
+        circuit(qml.numpy.array(0.1))
+
+    assert circuit.interface == "auto"


### PR DESCRIPTION
**Context:**

While investigating Issue #5442, I was getting really confused by why my tensorflow execution was giving a torch error. I realized that when the execution fails, we do not properly reset `QNode.interface` back to `"auto"`.  

**Description of the Change:**

Pulls a block of the code to a helper method so that we can wrap it in a `try-finally` block.

**Benefits:**

We can continue using a qnode after a failure has occured during execution.

**Possible Drawbacks:**

**Related GitHub Issues:**

[sc-60047]
