### PR TITLE
dequeue ops in `Hamiltonian.__matmul__`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -292,6 +292,7 @@
 <h3>Bug fixes 🐛</h3>
 
 * Using `@` with legacy Hamiltonian instances now properly de-queues the previously existing operations.
+  [(#5454)](https://github.com/PennyLaneAI/pennylane/pull/5455)
 
 * The `QNSPSAOptimizer` now properly handles differentiable parameters, resulting in being able to use it for more than one optimization step.
   [(#5439)](https://github.com/PennyLaneAI/pennylane/pull/5439)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -291,6 +291,8 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Using `@` with legacy Hamiltonian instances now properly de-queues the previously existing operations.
+
 * The `QNSPSAOptimizer` now properly handles differentiable parameters, resulting in being able to use it for more than one optimization step.
   [(#5439)](https://github.com/PennyLaneAI/pennylane/pull/5439)
 

--- a/pennylane/ops/qubit/hamiltonian.py
+++ b/pennylane/ops/qubit/hamiltonian.py
@@ -662,6 +662,9 @@ class Hamiltonian(Observable):
         coeffs1 = copy(self.coeffs)
         ops1 = self.ops.copy()
 
+        qml.QueuingManager.remove(H)
+        qml.QueuingManager.remove(self)
+
         if isinstance(H, Hamiltonian):
             shared_wires = Wires.shared_wires([self.wires, H.wires])
             if len(shared_wires) > 0:

--- a/tests/ops/qubit/test_hamiltonian.py
+++ b/tests/ops/qubit/test_hamiltonian.py
@@ -679,6 +679,17 @@ dev = qml.device("default.qubit", wires=2)
 
 
 @pytest.mark.usefixtures("use_legacy_and_new_opmath")
+def test_matmul_queuing():
+    """Test that the other and self are removed during Hamiltonian.__matmul__ ."""
+
+    with qml.queuing.AnnotatedQueue() as q:
+        H = 0.5 * qml.X(0) @ qml.Y(1)
+
+    assert len(q) == 1
+    assert q.queue[0] is H
+
+
+@pytest.mark.usefixtures("use_legacy_and_new_opmath")
 def test_deprecation_with_new_opmath(recwarn):
     """Test that a warning is raised if attempting to create a Hamiltonian with new operator
     arithmetic enabled."""


### PR DESCRIPTION
**Context:**

A user was encountering issues where operations were remaining in the circuit after being used to construct a hamiltonian.

**Description of the Change:**

De-queue the arguments to `Hamiltonian.__matmul__`

**Benefits:**

No more things in the circuit that shouldn't be in the circuit.

**Possible Drawbacks:**

**Related GitHub Issues:**

Fixes #5454 [sc-60158]