### PR TITLE
Add manylinux2014 migration to deprecations page

### DIFF
--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -9,7 +9,7 @@ deprecations are listed below.
 Pending deprecations
 --------------------
 
-* PennyLane Lightning and Catalyst will no longer support manylinux2014 (GLIBC 2.17) compatibile Linux operating systems, and will be migrated to manylinux_2_28 (GLIBC 2.28). See `pypa/manylinux <https://github.com/pypa/manylinux>`_ for additional details.
+* PennyLane Lightning and Catalyst will no longer support ``manylinux2014`` (GLIBC 2.17) compatibile Linux operating systems, and will be migrated to ``manylinux_2_28`` (GLIBC 2.28). See `pypa/manylinux <https://github.com/pypa/manylinux>`_ for additional details.
   
   - Last supported version of ``manylinux2014`` with v0.36
   - Fully migrated to ``manylinux_2_28`` with v0.37

--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -9,7 +9,7 @@ deprecations are listed below.
 Pending deprecations
 --------------------
 
-* PennyLane Lightning and Catalyst will no longer support manylinux2014 (GLIBC 2.17) compatibile Linux operating systems, and will be migrated to manylinux_2_28 (GLIBC 2.28). See [pypa/manylinux](https://github.com/pypa/manylinux) for additional details.
+* PennyLane Lightning and Catalyst will no longer support manylinux2014 (GLIBC 2.17) compatibile Linux operating systems, and will be migrated to manylinux_2_28 (GLIBC 2.28). See `pypa/manylinux <https://github.com/pypa/manylinux>`_ for additional details.
   
   - Last supported version of manylinux2014 with v0.36
   - Fully migrated to manylinux_2_28 with v0.37

--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -9,6 +9,11 @@ deprecations are listed below.
 Pending deprecations
 --------------------
 
+* PennyLane Lightning and Catalyst will no longer support manylinux2014 (GLIBC 2.17) compatibile Linux operating systems, and will be migrated to manylinux_2_28 (GLIBC 2.28). See [pypa/manylinux](https://github.com/pypa/manylinux) for additional details.
+  
+  - Last supported version of manylinux2014 with v0.36
+  - Fully migrated to manylinux_2_28 with v0.37
+
 * ``MultiControlledX`` is the only controlled operation that still supports specifying control
   values with a bit string. In the future, it will no longer accepts strings as control values.
 


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      test directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `doc/releases/changelog-dev.md` file, summarizing the
      change, and including a link back to the PR.

- [ ] The PennyLane source code conforms to
      [PEP8 standards](https://www.python.org/dev/peps/pep-0008/).
      We check all of our code against [Pylint](https://www.pylint.org/).
      To lint modified files, simply `pip install pylint`, and then
      run `pylint pennylane/path/to/file.py`.

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:** As Centos7 is EOL, we will be migrating Lightning and Catalyst to manylinux_2_28. This will drop support for older linux variants that do not have a modern enough library ecosystem to maintain compatibility. This PR updates the deprecations page to ensure this is known.

**Description of the Change:** Notify end-users of migration from manylinux2014 to manylinux_2_28

**Benefits:** Allows developers on affected systems to know in advance if their OS needs to be updated.

**Possible Drawbacks:**

**Related GitHub Issues:**
