### PR TITLE
Add shots.bins() generator method

### DIFF
--- a/pennylane/measurements/shots.py
+++ b/pennylane/measurements/shots.py
@@ -261,3 +261,20 @@ class Shots:
     def num_copies(self):
         """The total number of copies of any shot quantity."""
         return sum(s.copies for s in self.shot_vector)
+
+    def bins(self):
+        """
+        Yields:
+            tuple: A tuple containing the lower and upper bounds for each shot quantity shot_vector.
+
+        Example:
+            >>> shots = Shots((1, 1, 2, 3))
+            >>> list(shots.bins())
+            [(0,1), (1,2), (2,4), (4,7)]
+        """
+        lower_bound = 0
+        for sc in self.shot_vector:
+            for _ in range(sc.copies):
+                upper_bound = lower_bound + sc.shots
+                yield lower_bound, upper_bound
+                lower_bound = upper_bound

--- a/pennylane/measurements/shots.py
+++ b/pennylane/measurements/shots.py
@@ -265,7 +265,7 @@ class Shots:
     def bins(self):
         """
         Yields:
-            tuple: A tuple containing the lower and upper bounds for each shot quantity shot_vector.
+            tuple: A tuple containing the lower and upper bounds for each shot quantity in shot_vector.
 
         Example:
             >>> shots = Shots((1, 1, 2, 3))

--- a/tests/measurements/test_shots.py
+++ b/tests/measurements/test_shots.py
@@ -283,3 +283,23 @@ class TestProperties:
         scaled_sh1 = 2 * sh1
         rev_scaled_sh1 = sh1 * 2
         assert scaled_sh1.total_shots == rev_scaled_sh1.total_shots
+
+
+class TestShotsBins:
+    """Tests Shots.bins() method."""
+
+    def test_when_shots_is_none(self):
+        """Tests that the method returns an empty list when shots is None."""
+        shots = Shots(None)
+        assert not list(shots.bins())
+
+    def test_when_shots_is_int(self):
+        """Tests that the method returns the correct bins when shots is an int."""
+        shots = Shots(10)
+        assert list(shots.bins()) == [(0, 10)]
+
+    @pytest.mark.parametrize("sequence", [[1, 1, 3, 4], [(1, 2), 3, 4]])
+    def test_when_shots_is_sequence_with_copies(self, sequence):
+        """Tests that the method returns the correct bins when shots is a sequence with copies."""
+        shots = Shots(sequence)
+        assert list(shots.bins()) == [(0, 1), (1, 2), (2, 5), (5, 9)]


### PR DESCRIPTION
**Context:**
The current approach for sampling multiple shots involves handling shot vectors by sampling multiple times and processing each shot independently. However, a more efficient strategy would be to sample all shots at once and then process each bin separately. The `shots.bins()` method facilitates this by providing the lower and upper bounds for each bin.

**Description of the Change:**
The `shots.bins()` method generates a sequence of tuples, where each tuple represents the lower and upper bounds of a bin.

**Benefits:**
This method is particularly useful for processing shot quantities in a partitioned manner, as it allows for the separate handling of each bin's range

**Possible Drawbacks:**

**Related GitHub Issues:**
Fixes #5433 