### PR TITLE
use codecov token in upload action

### DIFF
--- a/.github/workflows/interface-unit-tests.yml
+++ b/.github/workflows/interface-unit-tests.yml
@@ -569,5 +569,5 @@ jobs:
       - name: Upload to Codecov
         uses: codecov/codecov-action@v3
         with:
-          fail_ci_if_error: true  # upload errors should be caught early
           token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true  # upload errors should be caught early

--- a/.github/workflows/interface-unit-tests.yml
+++ b/.github/workflows/interface-unit-tests.yml
@@ -570,3 +570,4 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: true  # upload errors should be caught early
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
We never added the token to the action like [it recommends us to](https://github.com/codecov/codecov-action/tree/v3?tab=readme-ov-file#usage) 🤦 adding the token should result in less intermittent failures like [this one](https://github.com/PennyLaneAI/pennylane/actions/runs/8597929198/job/23566821116?pr=5161), so we might as well.

~@albi3ro  can you confirm that this secret exists in our repo settings?~ confirmed offline