### PR TITLE
Fix coverage upload to codecov being broken

### DIFF
--- a/.github/workflows/interface-unit-tests.yml
+++ b/.github/workflows/interface-unit-tests.yml
@@ -1,6 +1,10 @@
 name: Unit Test - All Interfaces
 on:
   workflow_call:
+    secrets:
+      codecov_token:
+        description: The codecov token to use when uploading coverage files
+        required: true
     inputs:
       branch:
         description: The PennyLane branch to checkout and run unit tests for
@@ -569,5 +573,5 @@ jobs:
       - name: Upload to Codecov
         uses: codecov/codecov-action@v4
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ secrets.codecov_token }}
           fail_ci_if_error: true  # upload errors should be caught early

--- a/.github/workflows/interface-unit-tests.yml
+++ b/.github/workflows/interface-unit-tests.yml
@@ -567,7 +567,7 @@ jobs:
         uses: actions/download-artifact@v3
 
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true  # upload errors should be caught early

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,8 @@ jobs:
   tests:
     uses: ./.github/workflows/interface-unit-tests.yml
     with:
+      secrets:
+        codecov_token: ${{ secrets.CODECOV_TOKEN }}
       branch: ${{ github.ref }}
 
       # Run a 'lightened' version of the CI on Pull Requests by default

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,9 +15,9 @@ env:
 jobs:
   tests:
     uses: ./.github/workflows/interface-unit-tests.yml
+    secrets:
+      codecov_token: ${{ secrets.CODECOV_TOKEN }}
     with:
-      secrets:
-        codecov_token: ${{ secrets.CODECOV_TOKEN }}
       branch: ${{ github.ref }}
 
       # Run a 'lightened' version of the CI on Pull Requests by default


### PR DESCRIPTION
**Context:** Fix codecov coverage upload breaking for tests

**Description of the Change:**
Codecov recently changed their API where a token has to be specified during coverage upload. Previously this was not needed for public repos. 

According to their docs, this token should still not be needed for forks, so it should be fine for us, however, the token is needed for PRs within the same repo.

**Benefits:**
Fixes codecov upload.

**Possible Drawbacks:**

**Related GitHub Issues:**
