### PR TITLE
[Prototype] Extend `Operator`s metaclass to treat wires always as kwarg

### DIFF
--- a/pennylane/capture/__init__.py
+++ b/pennylane/capture/__init__.py
@@ -14,4 +14,4 @@
 """
 Tools for enabling the capture of pennylane objects into JaxPR.
 """
-from .meta_type import JaxPRMeta, enable_plexpr, disable_plexpr
+from .meta_type import JaxPRMeta, JaxPRMetaCoerceWires, enable_plexpr, disable_plexpr

--- a/pennylane/capture/meta_type.py
+++ b/pennylane/capture/meta_type.py
@@ -119,11 +119,12 @@ class JaxPRMeta(type):
 class JaxPRMetaCoerceWires(JaxPRMeta):
 
     def __call__(cls, *args, **kwargs):
-        wires = kwargs.get("wires", None)
-        if wires is None:
-            if len(args) == 0:
-                raise ValueError("Can't create object without wires")
-            kwargs['wires'] = args[-1]
-            args = args[:-1]
+        if cls._meta_coerce_wires:
+            wires = kwargs.get("wires", None)
+            if wires is None:
+                if len(args) == 0:
+                    raise ValueError("Can't create object without wires")
+                kwargs['wires'] = args[-1]
+                args = args[:-1]
         return JaxPRMeta.__call__(cls, *args, **kwargs)
 

--- a/pennylane/capture/meta_type.py
+++ b/pennylane/capture/meta_type.py
@@ -115,3 +115,15 @@ class JaxPRMeta(type):
             return type.__call__(cls, *args, **kwargs)
         # use bind to construct the class if we want class construction to add it to the jaxpr
         return cls._primitive.bind(*args, **kwargs)
+
+class JaxPRMetaCoerceWires(JaxPRMeta):
+
+    def __call__(cls, *args, **kwargs):
+        wires = kwargs.get("wires", None)
+        if wires is None:
+            if len(args) == 0:
+                raise ValueError("Can't create object without wires")
+            kwargs['wires'] = args[-1]
+            args = args[:-1]
+        return JaxPRMeta.__call__(cls, *args, **kwargs)
+

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -697,6 +697,7 @@ class Operator(metaclass=JaxPRMetaCoerceWires):
     # this allows scalar multiplication from left with numpy arrays np.array(0.5) * ps1
     # taken from [stackexchange](https://stackoverflow.com/questions/40694380/forcing-multiplication-to-use-rmul-instead-of-numpy-array-mul-or-byp/44634634#44634634)
     __array_priority__ = 1000
+    _meta_coerce_wires = True
 
     def __init_subclass__(cls, **_):
         register_pytree(cls, cls._flatten, cls._unflatten)

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -261,7 +261,7 @@ from pennylane.queuing import QueuingManager
 from pennylane.typing import TensorLike
 from pennylane.wires import Wires
 
-from .capture import JaxPRMeta
+from .capture import JaxPRMetaCoerceWires
 from .utils import pauli_eigs
 from .pytrees import register_pytree
 
@@ -406,7 +406,7 @@ def _process_data(op):
     return str([id(d) if qml.math.is_abstract(d) else _mod_and_round(d, mod_val) for d in op.data])
 
 
-class Operator(metaclass=JaxPRMeta):
+class Operator(metaclass=JaxPRMetaCoerceWires):
     r"""Base class representing quantum operators.
 
     Operators are uniquely defined by their name, the wires they act on, their (trainable) parameters,

--- a/pennylane/ops/op_math/symbolicop.py
+++ b/pennylane/ops/op_math/symbolicop.py
@@ -45,6 +45,7 @@ class SymbolicOp(Operator):
     :meth:`~.operation.Operator.decomposition`.
     """
 
+    _meta_coerce_wires = False
     _name = "Symbolic"
 
     # pylint: disable=attribute-defined-outside-init


### PR DESCRIPTION
Allows users to do `qml.X(0)` and `qml.X(wires=0)` while having a uniform treatment in the Plexpr of a circuit.
Currently it is that we always treat `wires` as kwarg, but we could easily change it to always be an arg.