### PR TITLE
Enable validation against numpy 2.0 release-candidates

### DIFF
--- a/pennylane/numpy/random.py
+++ b/pennylane/numpy/random.py
@@ -18,15 +18,19 @@ it works with the PennyLane :class:`~.tensor` class.
 import semantic_version
 
 from autograd.numpy import random as _random
-from numpy import __version__ as np_version
 from numpy.random import MT19937, PCG64, Philox, SFC64  # pylint: disable=unused-import
 
 from .wrapper import wrap_arrays, tensor_wrapper
 
 wrap_arrays(_random.__dict__, globals())
 
-
 np_version_spec = semantic_version.SimpleSpec(">=0.17.0")
+np_version = semantic_version.version("numpy")
+
+# Ensure pre/post release tags are compatible with semver
+if any((match := s) in np_version for s in ["rc", "dev", "post"]):
+    np_version = (f"-{match}").join(np_version.split("rc"))
+
 if np_version_spec.match(semantic_version.Version(np_version)):
     # pylint: disable=too-few-public-methods
     # pylint: disable=missing-class-docstring


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      test directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `doc/releases/changelog-dev.md` file, summarizing the
      change, and including a link back to the PR.

- [ ] The PennyLane source code conforms to
      [PEP8 standards](https://www.python.org/dev/peps/pep-0008/).
      We check all of our code against [Pylint](https://www.pylint.org/).
      To lint modified files, simply `pip install pylint`, and then
      run `pylint pennylane/path/to/file.py`.

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:** This Pr allows PennyLane to bee tested with an env-installed numpy 2.0 release candidate. Numpy 2.0 version strings are not compatible with semver, and require so preprocessing to enter the correct form. This will also enable testing against future numpy releases during the dev/rc/post cycles, if published to PyPI.

**Description of the Change:** As above.

**Benefits:** Enables testing against numpy dev and RC wheels (post also).

**Possible Drawbacks:**

**Related GitHub Issues:**
