### PR TITLE
Introduce special diagonalize procedure around ProbabilityMP measurements for Lightning 

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -364,6 +364,9 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Diagonalize the state around `ProbabilityMP` measurements in `statistics` when executing on a Lightning device.
+  [(#5529)](https://github.com/PennyLaneAI/pennylane/pull/5529)
+
 * `two_qubit_decomposition` no longer diverges at a special case of unitary matrix.
   [(#5448)](https://github.com/PennyLaneAI/pennylane/pull/5448)
 

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -298,12 +298,12 @@ class QubitDevice(Device):
             # Lightning does not support apply(rotations) anymore, so we need to rotate here
             # Lightning without binaries fallbacks to `QubitDevice`, and hence the _CPP_BINARY_AVAILABLE condition
             diagonalizing_gates = (
-                self._get_diagonalizing_gates(circuit) if self.is_lightning_device() else None
+                self._get_diagonalizing_gates(circuit) if self._is_lightning_device() else None
             )
-            if self.is_lightning_device() and diagonalizing_gates:  # pragma: no cover
+            if self._is_lightning_device() and diagonalizing_gates:  # pragma: no cover
                 self.apply(diagonalizing_gates)
             self._samples = self.generate_samples()
-            if self.is_lightning_device() and diagonalizing_gates:  # pragma: no cover
+            if self._is_lightning_device() and diagonalizing_gates:  # pragma: no cover
                 self.apply([qml.adjoint(g, lazy=False) for g in reversed(diagonalizing_gates)])
 
         # compute the required statistics
@@ -667,12 +667,12 @@ class QubitDevice(Device):
             elif isinstance(m, ProbabilityMP):
 
                 diagonalizing_gates = (
-                    self._get_diagonalizing_gates(circuit) if self.is_lightning_device() else None
+                    self._get_diagonalizing_gates(circuit) if self._is_lightning_device() else None
                 )
-                if self.is_lightning_device() and diagonalizing_gates:  # pragma: no cover
+                if self._is_lightning_device() and diagonalizing_gates:  # pragma: no cover
                     self.apply(diagonalizing_gates)
                 result = self.probability(wires=m.wires, shot_range=shot_range, bin_size=bin_size)
-                if self.is_lightning_device() and diagonalizing_gates:  # pragma: no cover
+                if self._is_lightning_device() and diagonalizing_gates:  # pragma: no cover
                     self.apply([qml.adjoint(g, lazy=False) for g in reversed(diagonalizing_gates)])
             elif isinstance(m, StateMP):
                 if len(measurements) > 1:
@@ -799,15 +799,6 @@ class QubitDevice(Device):
                 results.append(result)
 
         return results
-
-    def is_lightning_device(self):
-        """Returns True if the device is a Lightning plugin with C++ binaries and False otherwise."""
-        return (
-            hasattr(self, "name")
-            and isinstance(self.name, str)
-            and "Lightning" in self.name
-            and getattr(self, "_CPP_BINARY_AVAILABLE", False)
-        )
 
     def access_state(self, wires=None):
         """Check that the device has access to an internal state and return it if available.
@@ -1758,3 +1749,12 @@ class QubitDevice(Device):
         """
         # pylint:disable=no-self-use
         return circuit.diagonalizing_gates
+
+    def _is_lightning_device(self):
+        """Returns True if the device is a Lightning plugin with C++ binaries and False otherwise."""
+        return (
+            hasattr(self, "name")
+            and isinstance(self.name, str)
+            and "Lightning" in self.name
+            and getattr(self, "_CPP_BINARY_AVAILABLE", False)
+        )

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -297,9 +297,7 @@ class QubitDevice(Device):
         if self.shots is not None or any(isinstance(m, sample_type) for m in circuit.measurements):
             # Lightning does not support apply(rotations) anymore, so we need to rotate here
             # Lightning without binaries fallbacks to `QubitDevice`, and hence the _CPP_BINARY_AVAILABLE condition
-            diagonalizing_gates = (
-                self._get_diagonalizing_gates(circuit) if self._is_lightning_device() else None
-            )
+            diagonalizing_gates = self._get_diagonalizing_gates(circuit) if self.is_lightning() else None
             if is_lightning and diagonalizing_gates:  # pragma: no cover
                 self.apply(diagonalizing_gates)
             self._samples = self.generate_samples()

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -669,7 +669,7 @@ class QubitDevice(Device):
                 diagonalizing_gates = (
                     self._get_diagonalizing_gates(circuit) if self._is_lightning_device() else None
                 )
-                if self._is_lightning_device() and diagonalizing_gates:  # pragma: no cover
+                if is_lightning and diagonalizing_gates:  # pragma: no cover
                     self.apply(diagonalizing_gates)
                 result = self.probability(wires=m.wires, shot_range=shot_range, bin_size=bin_size)
                 if is_lightning and diagonalizing_gates:  # pragma: no cover

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -300,7 +300,7 @@ class QubitDevice(Device):
             diagonalizing_gates = (
                 self._get_diagonalizing_gates(circuit) if self._is_lightning_device() else None
             )
-            if self._is_lightning_device() and diagonalizing_gates:  # pragma: no cover
+            if is_lightning and diagonalizing_gates:  # pragma: no cover
                 self.apply(diagonalizing_gates)
             self._samples = self.generate_samples()
             if is_lightning and diagonalizing_gates:  # pragma: no cover

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -303,7 +303,7 @@ class QubitDevice(Device):
             if self._is_lightning_device() and diagonalizing_gates:  # pragma: no cover
                 self.apply(diagonalizing_gates)
             self._samples = self.generate_samples()
-            if self._is_lightning_device() and diagonalizing_gates:  # pragma: no cover
+            if is_lightning and diagonalizing_gates:  # pragma: no cover
                 self.apply([qml.adjoint(g, lazy=False) for g in reversed(diagonalizing_gates)])
 
         # compute the required statistics

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -672,7 +672,7 @@ class QubitDevice(Device):
                 if self._is_lightning_device() and diagonalizing_gates:  # pragma: no cover
                     self.apply(diagonalizing_gates)
                 result = self.probability(wires=m.wires, shot_range=shot_range, bin_size=bin_size)
-                if self._is_lightning_device() and diagonalizing_gates:  # pragma: no cover
+                if is_lightning and diagonalizing_gates:  # pragma: no cover
                     self.apply([qml.adjoint(g, lazy=False) for g in reversed(diagonalizing_gates)])
             elif isinstance(m, StateMP):
                 if len(measurements) > 1:

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -294,6 +294,8 @@ class QubitDevice(Device):
 
         # generate computational basis samples
         sample_type = (SampleMP, CountsMP, ClassicalShadowMP, ShadowExpvalMP)
+        is_lightning = self._is_lightning_device()
+
         if self.shots is not None or any(isinstance(m, sample_type) for m in circuit.measurements):
             # Lightning does not support apply(rotations) anymore, so we need to rotate here
             # Lightning without binaries fallbacks to `QubitDevice`, and hence the _CPP_BINARY_AVAILABLE condition

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -666,9 +666,7 @@ class QubitDevice(Device):
 
             elif isinstance(m, ProbabilityMP):
 
-                diagonalizing_gates = (
-                    self._get_diagonalizing_gates(circuit) if self._is_lightning_device() else None
-                )
+                diagonalizing_gates = self._get_diagonalizing_gates(circuit) if is_lightning else None
                 if is_lightning and diagonalizing_gates:  # pragma: no cover
                     self.apply(diagonalizing_gates)
                 result = self.probability(wires=m.wires, shot_range=shot_range, bin_size=bin_size)

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -21,12 +21,12 @@ This module contains the :class:`QubitDevice` abstract base class.
 # pylint: disable=arguments-differ, abstract-method, no-value-for-parameter,too-many-instance-attributes,too-many-branches, no-member, bad-option-value, arguments-renamed
 # pylint: disable=too-many-arguments
 import abc
+import inspect
 import itertools
+import logging
 import warnings
 from collections import defaultdict
-from typing import Union, List
-import inspect
-import logging
+from typing import List, Union
 
 import numpy as np
 
@@ -47,14 +47,14 @@ from pennylane.measurements import (
     SampleMeasurement,
     SampleMP,
     ShadowExpvalMP,
+    Shots,
     StateMeasurement,
     StateMP,
     VarianceMP,
     VnEntropyMP,
-    Shots,
 )
+from pennylane.operation import Operation, operation_derivative
 from pennylane.resource import Resources
-from pennylane.operation import operation_derivative, Operation
 from pennylane.tape import QuantumTape
 from pennylane.wires import Wires
 
@@ -297,17 +297,13 @@ class QubitDevice(Device):
         if self.shots is not None or any(isinstance(m, sample_type) for m in circuit.measurements):
             # Lightning does not support apply(rotations) anymore, so we need to rotate here
             # Lightning without binaries fallbacks to `QubitDevice`, and hence the _CPP_BINARY_AVAILABLE condition
-            is_lightning = (
-                hasattr(self, "name")
-                and isinstance(self.name, str)
-                and "Lightning" in self.name
-                and getattr(self, "_CPP_BINARY_AVAILABLE", False)
+            diagonalizing_gates = (
+                self._get_diagonalizing_gates(circuit) if self.is_lightning_device() else None
             )
-            diagonalizing_gates = self._get_diagonalizing_gates(circuit) if is_lightning else None
-            if is_lightning and diagonalizing_gates:  # pragma: no cover
+            if self.is_lightning_device() and diagonalizing_gates:  # pragma: no cover
                 self.apply(diagonalizing_gates)
             self._samples = self.generate_samples()
-            if is_lightning and diagonalizing_gates:  # pragma: no cover
+            if self.is_lightning_device() and diagonalizing_gates:  # pragma: no cover
                 self.apply([qml.adjoint(g, lazy=False) for g in reversed(diagonalizing_gates)])
 
         # compute the required statistics
@@ -669,8 +665,15 @@ class QubitDevice(Device):
                 result = self.sample(m, shot_range=shot_range, bin_size=bin_size, counts=True)
 
             elif isinstance(m, ProbabilityMP):
-                result = self.probability(wires=m.wires, shot_range=shot_range, bin_size=bin_size)
 
+                diagonalizing_gates = (
+                    self._get_diagonalizing_gates(circuit) if self.is_lightning_device() else None
+                )
+                if self.is_lightning_device() and diagonalizing_gates:  # pragma: no cover
+                    self.apply(diagonalizing_gates)
+                result = self.probability(wires=m.wires, shot_range=shot_range, bin_size=bin_size)
+                if self.is_lightning_device() and diagonalizing_gates:  # pragma: no cover
+                    self.apply([qml.adjoint(g, lazy=False) for g in reversed(diagonalizing_gates)])
             elif isinstance(m, StateMP):
                 if len(measurements) > 1:
                     raise qml.QuantumFunctionError(
@@ -796,6 +799,15 @@ class QubitDevice(Device):
                 results.append(result)
 
         return results
+
+    def is_lightning_device(self):
+        """Returns True if the device is a Lightning plugin with C++ binaries and False otherwise."""
+        return (
+            hasattr(self, "name")
+            and isinstance(self.name, str)
+            and "Lightning" in self.name
+            and getattr(self, "_CPP_BINARY_AVAILABLE", False)
+        )
 
     def access_state(self, wires=None):
         """Check that the device has access to an internal state and return it if available.


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      test directory!

- [x] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `doc/releases/changelog-dev.md` file, summarizing the
      change, and including a link back to the PR.

- [x] The PennyLane source code conforms to
      [PEP8 standards](https://www.python.org/dev/peps/pep-0008/).
      We check all of our code against [Pylint](https://www.pylint.org/).
      To lint modified files, simply `pip install pylint`, and then
      run `pylint pennylane/path/to/file.py`.

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
`_qubit_device`'s `statistics` only passes the [wires](https://github.com/PennyLaneAI/pennylane/blob/master/pennylane/_qubit_device.py#L672C17-L672C99) argument to `probability`. When this is called on the Lightning side, the basis info is not there to diagonalize the state. This does not happen in LQ since the whole measurement is passed to `probs`.  `expval/var` however accept `obs` which allows old device like L-Kokkos/GPU to diagonalize the state in these methods.
 
**Description of the Change:**
To avoid diagonalizing twice for `expval/var`, we diagonalize/undiagonalize the state around in `ProbabilityMP` measurements in `statistics` when executing on a Lightning device.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
