### PR TITLE
Add a `Prod.obs` property for the transition period of switching operator arithmetic

### DIFF
--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -53,6 +53,11 @@ Pending deprecations
 
   - Deprecated in v0.36
 
+* Accessing terms of a tensor product ``op = X(0) @ X(1)`` via ``op.obs`` is deprecated with new operator arithmetic.
+  A user should use ``op.operands`` instead.
+
+  - Deprecated in v0.36
+
 Completed deprecation cycles
 ----------------------------
 

--- a/pennylane/ops/op_math/prod.py
+++ b/pennylane/ops/op_math/prod.py
@@ -280,6 +280,13 @@ class Prod(CompositeOp):
     @property
     def has_decomposition(self):
         return True
+    
+    @property
+    def obs(self):
+        warnings.warn(
+            "Accessing the terms of a tensor product operator via op.obs is deprecated, please use op.operands instead.",
+            qml.PennyLaneDeprecationWarning)
+        return self.operands
 
     def decomposition(self):
         r"""Decomposition of the product operator is given by each factor applied in succession.

--- a/pennylane/ops/op_math/prod.py
+++ b/pennylane/ops/op_math/prod.py
@@ -280,12 +280,13 @@ class Prod(CompositeOp):
     @property
     def has_decomposition(self):
         return True
-    
+
     @property
     def obs(self):
         warnings.warn(
             "Accessing the terms of a tensor product operator via op.obs is deprecated, please use op.operands instead.",
-            qml.PennyLaneDeprecationWarning)
+            qml.PennyLaneDeprecationWarning,
+        )
         return self.operands
 
     def decomposition(self):

--- a/tests/ops/op_math/test_prod.py
+++ b/tests/ops/op_math/test_prod.py
@@ -102,6 +102,14 @@ def test_legacy_coeffs():
     with pytest.warns(qml.PennyLaneDeprecationWarning, match="Prod.coeffs is deprecated and"):
         _ = H.coeffs
 
+def test_obs_attribute():
+    """Test that operands can be accessed via Prod.obs and a deprecation warning is raised"""
+    op = qml.prod(X(0), X(1), X(2))
+    with pytest.warns(qml.PennyLaneDeprecationWarning, match="Accessing the terms of a tensor product operator via op.obs is deprecated"):
+        obs = op.obs
+    
+    assert obs == (X(0), X(1), X(2))
+
 
 # currently failing due to has_diagonalizing_gates logic
 @pytest.mark.xfail  # TODO: fix with story 49608

--- a/tests/ops/op_math/test_prod.py
+++ b/tests/ops/op_math/test_prod.py
@@ -102,12 +102,16 @@ def test_legacy_coeffs():
     with pytest.warns(qml.PennyLaneDeprecationWarning, match="Prod.coeffs is deprecated and"):
         _ = H.coeffs
 
+
 def test_obs_attribute():
     """Test that operands can be accessed via Prod.obs and a deprecation warning is raised"""
     op = qml.prod(X(0), X(1), X(2))
-    with pytest.warns(qml.PennyLaneDeprecationWarning, match="Accessing the terms of a tensor product operator via op.obs is deprecated"):
+    with pytest.warns(
+        qml.PennyLaneDeprecationWarning,
+        match="Accessing the terms of a tensor product operator via op.obs is deprecated",
+    ):
         obs = op.obs
-    
+
     assert obs == (X(0), X(1), X(2))
 
 


### PR DESCRIPTION
Adding a property `Prod.obs` to not break code that uses `Tensor.obs`, but immediately deprecating it.