### PR TITLE
`sum_expand` handles `Identity` terms with no wires

### DIFF
--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -42,7 +42,7 @@ from pennylane.measurements import (
 )
 
 from pennylane.operation import Observable, Operation, Tensor, Operator, StatePrepBase
-from pennylane.ops import Hamiltonian, Sum, LinearCombination, Prod
+from pennylane.ops import Hamiltonian, Sum, LinearCombination, Prod, SProd
 from pennylane.tape import QuantumScript, QuantumTape, expand_tape_state_prep
 from pennylane.wires import WireError, Wires
 from pennylane.queuing import QueuingManager
@@ -757,12 +757,9 @@ class Device(abc.ABC):
         hamiltonian_in_obs = any(
             isinstance(obs, (Hamiltonian, LinearCombination)) for obs in circuit.observables
         )
-        expval_sum_in_obs = any(
-            (
-                isinstance(m.obs, Sum)
-                or (isinstance(m.obs, Prod) and isinstance(m.obs.simplify(), Sum))
-            )
-            and isinstance(m, ExpectationMP)
+
+        expval_sum_or_prod_in_obs = any(
+            isinstance(m.obs, (Sum, Prod, SProd)) and isinstance(m, ExpectationMP)
             for m in circuit.measurements
         )
 
@@ -777,11 +774,10 @@ class Device(abc.ABC):
             # split tape into multiple tapes of diagonalizable known observables.
             try:
                 circuits, hamiltonian_fn = qml.transforms.hamiltonian_expand(circuit, group=False)
-            except ValueError as e:
-                raise ValueError(
-                    "Can only return the expectation of a single Hamiltonian observable"
-                ) from e
-        elif expval_sum_in_obs and not is_shadow and not supports_sum:
+            except ValueError:
+                circuits, hamiltonian_fn = qml.transforms.sum_expand(circuit)
+
+        elif expval_sum_or_prod_in_obs and not is_shadow and not supports_sum:
             circuits, hamiltonian_fn = qml.transforms.sum_expand(circuit)
 
         elif (

--- a/pennylane/ops/op_math/prod.py
+++ b/pennylane/ops/op_math/prod.py
@@ -543,6 +543,11 @@ def _swappable_ops(op1, op2, wire_map: dict = None) -> bool:
         wires2 = wires2.map(wire_map)
     wires1 = set(wires1)
     wires2 = set(wires2)
+    # handle ops with empty wires, swap
+    if len(wires1) == 0:
+        return False
+    if len(wires2) == 0:
+        return True
     # compare strings of wire labels so that we can compare arbitrary wire labels like 0 and "a"
     return False if wires1 & wires2 else str(wires1.pop()) > str(wires2.pop())
 

--- a/tests/transforms/test_hamiltonian_expand.py
+++ b/tests/transforms/test_hamiltonian_expand.py
@@ -407,7 +407,7 @@ class TestHamiltonianExpand:
 
 with AnnotatedQueue() as s_tape1:
     qml.PauliX(0)
-    S1 = qml.s_prod(1.5, qml.prod(qml.PauliZ(0), qml.PauliZ(1), qml.Identity()))
+    S1 = qml.s_prod(1.5, qml.sum(qml.prod(qml.PauliZ(0), qml.PauliZ(1)), qml.Identity()))
     qml.expval(S1)
     qml.expval(S1)
     qml.state()
@@ -448,7 +448,7 @@ S4 = qml.sum(
     qml.prod(qml.PauliX(0), qml.PauliZ(2), qml.Identity()),
     qml.s_prod(3, qml.PauliZ(2)),
     qml.s_prod(-2, qml.PauliX(0)),
-    qml.Identity(),
+    qml.s_prod(1.5, qml.Identity()),
     qml.PauliZ(2),
     qml.PauliZ(2),
     qml.prod(qml.PauliZ(0), qml.PauliX(1), qml.PauliY(2)),
@@ -472,8 +472,8 @@ s_qscript4 = QuantumScript.from_queue(s_tape4)
 SUM_QSCRIPTS = [s_qscript1, s_qscript2, s_qscript3, s_qscript4]
 SUM_OUTPUTS = [
     [
-        -1.5,
-        -1.5,
+        0,
+        0,
         np.array(
             [
                 0.0 + 0.0j,
@@ -495,9 +495,9 @@ SUM_OUTPUTS = [
             ]
         ),
     ],
-    [-6, np.array([0.5, 0.5]), -6],
-    [-1.5, np.array([1.0, 0.0, 0.0, 0.0]), 0.0, -1.5, np.array([0.5, 0.5])],
-    [-8, 0, -8, 0],
+    [-5, np.array([0.5, 0.5]), -5],
+    [-0.5, np.array([1.0, 0.0, 0.0, 0.0]), 0.0, -0.5, np.array([0.5, 0.5])],
+    [-6.5, 0, -6.5, 0],
 ]
 
 

--- a/tests/transforms/test_hamiltonian_expand.py
+++ b/tests/transforms/test_hamiltonian_expand.py
@@ -407,7 +407,7 @@ class TestHamiltonianExpand:
 
 with AnnotatedQueue() as s_tape1:
     qml.PauliX(0)
-    S1 = qml.s_prod(1.5, qml.prod(qml.PauliZ(0), qml.PauliZ(1)))
+    S1 = qml.s_prod(1.5, qml.prod(qml.PauliZ(0), qml.PauliZ(1), qml.Identity()))
     qml.expval(S1)
     qml.expval(S1)
     qml.state()
@@ -421,6 +421,7 @@ with AnnotatedQueue() as s_tape2:
         qml.prod(qml.PauliX(0), qml.PauliZ(2)),
         qml.s_prod(3, qml.PauliZ(2)),
         qml.s_prod(-2, qml.PauliX(0)),
+        qml.Identity(),
         qml.PauliX(2),
         qml.prod(qml.PauliZ(0), qml.PauliX(1)),
     )
@@ -429,7 +430,9 @@ with AnnotatedQueue() as s_tape2:
     qml.expval(S2)
 
 S3 = qml.sum(
-    qml.s_prod(1.5, qml.prod(qml.PauliZ(0), qml.PauliZ(1))), qml.s_prod(0.3, qml.PauliX(1))
+    qml.s_prod(1.5, qml.prod(qml.PauliZ(0), qml.PauliZ(1))),
+    qml.s_prod(0.3, qml.PauliX(1)),
+    qml.Identity(),
 )
 
 with AnnotatedQueue() as s_tape3:
@@ -442,9 +445,10 @@ with AnnotatedQueue() as s_tape3:
 
 
 S4 = qml.sum(
-    qml.prod(qml.PauliX(0), qml.PauliZ(2)),
+    qml.prod(qml.PauliX(0), qml.PauliZ(2), qml.Identity()),
     qml.s_prod(3, qml.PauliZ(2)),
     qml.s_prod(-2, qml.PauliX(0)),
+    qml.Identity(),
     qml.PauliZ(2),
     qml.PauliZ(2),
     qml.prod(qml.PauliZ(0), qml.PauliX(1), qml.PauliY(2)),
@@ -455,7 +459,6 @@ with AnnotatedQueue() as s_tape4:
     qml.Hadamard(1)
     qml.PauliZ(1)
     qml.PauliX(2)
-
     qml.expval(S4)
     qml.expval(qml.PauliX(2))
     qml.expval(S4)


### PR DESCRIPTION
**Context:**
`sum_expand` raises an error when the `Sum` contains `Identity()` terms.

**Description of the Change:**
Refactors `sum_expand` following the logic of `hamiltonian_expand` as in https://github.com/PennyLaneAI/pennylane/pull/5414, tracks a constant offset for measurements containing `Identity()` terms in the observable.

**Benefits:**
`sum_expand` can now handle `Identity()` terms. The new implementation of `sum_expand` also prepares for the refactor of all three expand transforms into one.

**Related Shortcut Issues:**
[sc-59302]