### PR TITLE
Custom kernel for expectation values of `Identity` and `scalar*Identity`

### DIFF
--- a/pennylane/measurements/expval.py
+++ b/pennylane/measurements/expval.py
@@ -64,12 +64,6 @@ def expval(
             "qml.expval does not support measuring sequences of measurements or observables"
         )
 
-    if isinstance(op, qml.Identity) and len(op.wires) == 0:
-        # temporary solution to merge https://github.com/PennyLaneAI/pennylane/pull/5106
-        raise NotImplementedError(
-            "Expectation values of qml.Identity() without wires are currently not allowed."
-        )
-
     return ExpectationMP(obs=op)
 
 


### PR DESCRIPTION
**Context:**
Currently `qml.expval(qml.I())` and `qml.expval(0.2 * qml.I())` are not supported. 

**Description of the Change:**
Support the above

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
fixes #5532
duplicates https://github.com/PennyLaneAI/pennylane/pull/5570