### PR TITLE
Define a `grad_method` and `grad_recipe` for `CompositeOp`

### DIFF
--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -1680,7 +1680,8 @@ class Operation(Operator):
         if self.grad_recipe != [None] * self.num_params:
             return "A"
         try:
-            self.parameter_frequencies  # pylint:disable=pointless-statement
+            if getattr(self, "parameter_frequencies", None) is None:
+                return "F"
             return "A"
         except ParameterFrequenciesUndefinedError:
             return "F"

--- a/pennylane/ops/op_math/composite.py
+++ b/pennylane/ops/op_math/composite.py
@@ -21,7 +21,7 @@ import copy
 
 import pennylane as qml
 from pennylane import math
-from pennylane.operation import Operator, _UNSET_BATCH_SIZE
+from pennylane.operation import Operator, Operation, _UNSET_BATCH_SIZE
 from pennylane.wires import Wires
 
 # pylint: disable=too-many-instance-attributes
@@ -129,7 +129,17 @@ class CompositeOp(Operator):
 
     @property
     def num_params(self):
+        """Compute the number of parameters as the sum of the numbers of parameters
+        of the constituents."""
         return sum(op.num_params for op in self)
+
+    @property
+    def grad_recipe(self):
+        """The gradient recipe of the composite operator. By defauly, the recipe is
+        set to None (no parameters) or ([None]*num_params) (parameters)."""
+        if (num_params := self.num_params) == 0:
+            return None
+        return [None] * num_params
 
     @property
     def has_overlapping_wires(self) -> bool:
@@ -366,3 +376,6 @@ class CompositeOp(Operator):
     @abc.abstractmethod
     def _build_pauli_rep(self):
         """The function to generate the pauli representation for the composite operator."""
+
+
+CompositeOp.grad_method = Operation.grad_method

--- a/tests/ops/op_math/test_composite.py
+++ b/tests/ops/op_math/test_composite.py
@@ -384,3 +384,13 @@ class TestProperties:
         op = ValidOp(qml.RZ(1.32, wires=0), qml.Identity(wires=0), qml.RX(1.9, wires=1))
         overlapping_ops = op.overlapping_ops
         assert op._overlapping_ops == overlapping_ops
+
+    def test_grad_recipe_and_grad_method(self):
+        """Test that the grad_method and grad_recipe properties are obtained correctly."""
+        op = ValidOp(qml.S(0), qml.T(0))
+        assert op.grad_recipe is None
+        assert op.grad_method is None
+
+        op = ValidOp(qml.RZ(0.2, 0), qml.RX(0.1, 2))
+        assert op.grad_recipe == [None, None]
+        assert op.grad_method == "F"

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -798,7 +798,7 @@ class TestOperationConstruction:
         op = DummyOp(x, wires=0)
         assert op.grad_method == "A"
 
-    def test_default_grad_no_param(self):
+    def test_default_grad_method_no_param(self):
         """Test that the correct ``grad_method`` is returned by default
         if an operation does not have a parameter.
         """
@@ -810,6 +810,22 @@ class TestOperationConstruction:
 
         op = DummyOp(wires=0)
         assert op.grad_method is None
+
+    def test_default_grad_method_no_parameter_frequencies_property(self):
+        """Test that if an inheriting type has no parameter frequencies
+        property defined, grad_method is set to `"F"` as if it was the default
+        `ParameterFrequenciesUndefined`."""
+
+        class null_class:
+            r"""Dummy class without parameter-frequencies"""
+
+            grad_recipe = [None]
+            num_params = 1
+
+        null_class.grad_method = qml.operation.Operation.grad_method
+
+        op = null_class()
+        assert op.grad_method == "F"
 
     def test_frequencies_default_single_param(self):
         """Test that an operation with default parameter frequencies


### PR DESCRIPTION
**Context:**
Gradient methods are still determined using the `grad_method` property of `Operation`s. `CompositeOp` does not inherit from `Operation` and thus has not `grad_method` defined. However, it may occur within a circuit and is being queued.
This makes PennyLane try to determine the `grad_method` of the `CompositeOp`, which is not defined.

**Description of the Change:**
- Copy the `grad_method` property from `Operation` to `CompositeOp` (@albi3ro Do you think this may get us into trouble?)
- Define a dynamically computed `grad_recipe` property for `CompositeOp` that takes the number of parameters into account.
- Make `Operation.grad_method` compatible with objects that do not have an attribute `parameter_frequencies`, returning `"F"` like for the default `parameter_frequencies` property of `Operation` itself.

**Benefits:**
`CompositeOp` can be differentiated via finite differences.

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
