### PR TITLE
`LinearCombination.simplify` and `Hamiltonian.simplify` remove 0 coefficient terms.

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -286,6 +286,9 @@
 * The `qml.qchem.hf_state` function is upgraded to be compatible with the parity and Bravyi-Kitaev bases.
   [(#5472)](https://github.com/PennyLaneAI/pennylane/pull/5472)
 
+* `Hamiltonian.simplify` and `LinearCombination.simplify` now removes terms with near-zero coefficients.
+  [(#5555)](https://github.com/PennyLaneAI/pennylane/pull/5555)
+
 <h4>Community contributions 🥳</h4>
 
 * Functions `measure_with_samples` and `sample_state` have been added to the new `qutrit_mixed` module found in

--- a/pennylane/ops/op_math/linear_combination.py
+++ b/pennylane/ops/op_math/linear_combination.py
@@ -303,9 +303,10 @@ class LinearCombination(Sum):
             new_ops = []
 
             for pw, coeff in pr.items():
-                pw_op = pw.operation(wire_order=pr.wires)
-                new_ops.append(pw_op)
-                new_coeffs.append(coeff)
+                if qml.math.abs(coeff) > cutoff:
+                    pw_op = pw.operation(wire_order=pr.wires)
+                    new_ops.append(pw_op)
+                    new_coeffs.append(coeff)
 
             return new_coeffs, new_ops, pr
 

--- a/pennylane/ops/qubit/hamiltonian.py
+++ b/pennylane/ops/qubit/hamiltonian.py
@@ -471,7 +471,7 @@ class Hamiltonian(Observable):
         matrix += sum(temp_mats)
         return matrix
 
-    def simplify(self, cutoff=1e-12):
+    def simplify(self, cutoff=1e-12):  # pylint: disable=arguments-differ
         r"""Simplifies the Hamiltonian by combining like-terms.
 
         **Example**

--- a/pennylane/ops/qubit/hamiltonian.py
+++ b/pennylane/ops/qubit/hamiltonian.py
@@ -471,7 +471,7 @@ class Hamiltonian(Observable):
         matrix += sum(temp_mats)
         return matrix
 
-    def simplify(self):
+    def simplify(self, cutoff=1e-12):
         r"""Simplifies the Hamiltonian by combining like-terms.
 
         **Example**
@@ -507,6 +507,8 @@ class Hamiltonian(Observable):
                     del new_coeffs[ind]
                     del new_ops[ind]
             else:
+                if qml.math.abs(c) < cutoff:
+                    continue
                 new_ops.append(op.prune())
                 new_coeffs.append(c)
 

--- a/tests/ops/op_math/test_linear_combination.py
+++ b/tests/ops/op_math/test_linear_combination.py
@@ -686,7 +686,7 @@ class TestLinearCombination:
     def test_simplify(self, old_H, new_H):
         """Tests the simplify method"""
         old_H = old_H.simplify()
-        assert old_H.compare(new_H)
+        assert old_H.terms() == new_H.terms()
 
     def test_simplify_while_queueing(self):
         """Tests that simplifying a LinearCombination in a tape context

--- a/tests/ops/qubit/test_hamiltonian.py
+++ b/tests/ops/qubit/test_hamiltonian.py
@@ -185,7 +185,7 @@ with qml.operation.disable_new_opmath_cm():
         ),
         (
             qml.Hamiltonian([0], [qml.Identity(0)]),
-            qml.Hamiltonian([0], [qml.Identity(0)]),
+            qml.Hamiltonian([], []),
         ),
     ]
 
@@ -817,7 +817,7 @@ class TestHamiltonian:
     def test_simplify(self, old_H, new_H):
         """Tests the simplify method"""
         old_H.simplify()
-        assert old_H.compare(new_H)
+        assert old_H.terms() == new_H.terms()
 
     def test_simplify_while_queueing(self):
         """Tests that simplifying a Hamiltonian in a tape context


### PR DESCRIPTION
**Context:**
`LinearCombination.simplify` and `Hamiltonian.simplify` does not remove terms with 0 coefficients, this leads to a large amount of extra terms in some use cases.

**Description of the Change:**
Update `LinearCombination.simplify` and `Hamiltonian.simplify` to exclude terms with 0 coefficients

**Benefits:**
Cleaner outputs.

**Related Shortcut Issues:**
[sc-60202]