### PR TITLE
Reduce the number of operations and control wires for `cond` with `defer_measurements` and postselection

### DIFF
--- a/pennylane/measurements/mid_measure.py
+++ b/pennylane/measurements/mid_measure.py
@@ -336,6 +336,24 @@ class MeasurementValue(Generic[T]):
             branch = tuple(int(b) for b in np.binary_repr(i, width=len(self.measurements)))
             yield branch, self.processing_fn(*branch)
 
+    def _postselected_items(self):
+        """A generator representing all the possible outcomes of the MeasurementValue,
+        taking postselection into account."""
+        ps = {i: p for i, m in enumerate(self.measurements) if (p:=m.postselect) is not None}
+        num_non_ps = len(self.measurements)-len(ps)
+        if num_non_ps == 0:
+            yield (), self.processing_fn(*ps.values())
+            return
+        for i in range(2 ** num_non_ps):
+            # Create the branch ignoring postselected measurements
+            non_ps_branch = tuple(int(b) for b in np.binary_repr(i, width=num_non_ps))
+            pos = -1
+            # Extend the branch to include postselected measurements
+            full_branch = tuple(ps[j] if j in ps else non_ps_branch[pos:=pos+1] for j in range(len(self.measurements)))
+            # Return the reduced non-postselected branch and the procesing function
+            # evaluated on the full branch
+            yield non_ps_branch, self.processing_fn(*full_branch)
+
     @property
     def wires(self):
         """Returns a list of wires corresponding to the mid-circuit measurements."""

--- a/pennylane/measurements/mid_measure.py
+++ b/pennylane/measurements/mid_measure.py
@@ -339,17 +339,20 @@ class MeasurementValue(Generic[T]):
     def _postselected_items(self):
         """A generator representing all the possible outcomes of the MeasurementValue,
         taking postselection into account."""
-        ps = {i: p for i, m in enumerate(self.measurements) if (p:=m.postselect) is not None}
-        num_non_ps = len(self.measurements)-len(ps)
+        ps = {i: p for i, m in enumerate(self.measurements) if (p := m.postselect) is not None}
+        num_non_ps = len(self.measurements) - len(ps)
         if num_non_ps == 0:
             yield (), self.processing_fn(*ps.values())
             return
-        for i in range(2 ** num_non_ps):
+        for i in range(2**num_non_ps):
             # Create the branch ignoring postselected measurements
             non_ps_branch = tuple(int(b) for b in np.binary_repr(i, width=num_non_ps))
             pos = -1
             # Extend the branch to include postselected measurements
-            full_branch = tuple(ps[j] if j in ps else non_ps_branch[pos:=pos+1] for j in range(len(self.measurements)))
+            full_branch = tuple(
+                ps[j] if j in ps else non_ps_branch[pos := pos + 1]
+                for j in range(len(self.measurements))
+            )
             # Return the reduced non-postselected branch and the procesing function
             # evaluated on the full branch
             yield non_ps_branch, self.processing_fn(*full_branch)

--- a/pennylane/transforms/defer_measurements.py
+++ b/pennylane/transforms/defer_measurements.py
@@ -346,11 +346,14 @@ def _defer_measurements_qnode(self, qnode, targs, tkwargs):
 
 def _add_control_gate(op, control_wires):
     """Helper function to add control gates"""
-    control = [control_wires[m.id] for m in op.meas_val.measurements]
+    control = [control_wires[m.id] for m in op.meas_val.measurements if m.postselect is None]
     new_ops = []
 
-    for branch, value in op.meas_val._items():
+    for branch, value in op.meas_val._postselected_items():
         if value:
+            if branch == ():
+                new_ops.append(op.then_op)
+                continue
             qscript = qml.tape.make_qscript(
                 ctrl(
                     lambda: qml.apply(op.then_op),  # pylint: disable=cell-var-from-loop

--- a/tests/measurements/test_mid_measure.py
+++ b/tests/measurements/test_mid_measure.py
@@ -503,3 +503,96 @@ class TestMeasurementCompositeValueManipulation:
         division_dunder = getattr(m0, div)
         res = division_dunder(other)
         assert isinstance(res, MeasurementValue)
+
+
+class TestMeasurementValueItems:
+    """Test that a MeasurementValue returns its items correctly."""
+
+    funcs_and_expected_single = [
+        ((lambda v: v), [0, 1]),
+        ((lambda v: 1- v), [1, 0]),
+    ]
+
+    @pytest.mark.parametrize("postselect", [None, 0, 1])
+    @pytest.mark.parametrize("func, expected", funcs_and_expected_single)
+    def test_items_single_mp(self, func, expected, postselect):
+        """Test the full items. Note that postselect should not affect the
+        output at all."""
+        mp = MidMeasureMP(0, postselect=postselect)
+        mv = MeasurementValue([mp], func)
+        items = list(mv._items())
+        assert items == [((0,), expected[0]), ((1,), expected[1])]
+
+    funcs_and_expected_multi = [
+        ((lambda *v: sum(v)==1), [0, 1, 1, 0, 1, 0, 0, 0]),
+        ((lambda *v: v[0]), [0, 0, 0, 0, 1, 1, 1, 1]),
+    ]
+
+    @pytest.mark.parametrize("func, expected", funcs_and_expected_multi)
+    def test_items_multiple_mps(self, func, expected):
+        """Test the full items."""
+        mp0 = MidMeasureMP(0)
+        mp1 = MidMeasureMP(0)
+        mp2 = MidMeasureMP(0)
+        branches3 = [
+            (0, 0, 0),
+            (0, 0, 1),
+            (0, 1, 0),
+            (0, 1, 1),
+            (1, 0, 0),
+            (1, 0, 1),
+            (1, 1, 0),
+            (1, 1, 1),
+        ]
+        mv = MeasurementValue([mp0, mp1, mp2], func)
+        items = list(mv._items())
+        assert len(items) == len(branches3) == len(expected)
+        for item, branch, exp in zip(items, branches3, expected):
+            assert item == (branch, exp)
+
+    @pytest.mark.parametrize("postselect", [None, 0, 1])
+    @pytest.mark.parametrize("func, expected", funcs_and_expected_single)
+    def test_postselected_items_single_mp(self, postselect, func, expected):
+        """Test the full items."""
+        mp = MidMeasureMP(0, postselect=postselect)
+        mv = MeasurementValue([mp], func)
+        items = list(mv._postselected_items())
+        if postselect is None:
+            assert items == [((0,), expected[0]), ((1,), expected[1])]
+        else:
+            all_items = [((), expected[0]), ((), expected[1])]
+            assert items == [all_items[postselect]]
+
+    branches3 = [
+        (0, 0, 0),
+        (0, 0, 1),
+        (0, 1, 0),
+        (0, 1, 1),
+        (1, 0, 0),
+        (1, 0, 1),
+        (1, 1, 0),
+        (1, 1, 1),
+    ]
+
+    postselects_and_branches = [
+        ((None, 1, None), [(0, 1, 0), (0, 1, 1), (1, 1, 0), (1, 1, 1)]),
+        ((None, 1, 0), [(0, 1, 0), (1, 1, 0)]),
+        ((1, 1, 1), [(1, 1, 1)]),
+        ((0, None, None), [(0, 0, 0), (0, 0, 1), (0, 1, 0), (0, 1, 1)]),
+        ((None, None, None), branches3),
+    ]
+
+    @pytest.mark.parametrize("postselects, branches", postselects_and_branches)
+    @pytest.mark.parametrize("func, expected", funcs_and_expected_multi)
+    def test_postselected_items_multiple_mps(self, func, expected, postselects, branches):
+        """Test the full items."""
+        mp0 = MidMeasureMP(0, postselect=postselects[0])
+        mp1 = MidMeasureMP(0, postselect=postselects[1])
+        mp2 = MidMeasureMP(0, postselect=postselects[2])
+
+        mv = MeasurementValue([mp0, mp1, mp2], func)
+        items = list(mv._postselected_items())
+        assert len(items) == len(branches)
+        for item, branch in zip(items, branches):
+            pruned_branch = tuple(b for i, b in enumerate(branch) if postselects[i] is None)
+            assert item == (pruned_branch, func(*branch))

--- a/tests/measurements/test_mid_measure.py
+++ b/tests/measurements/test_mid_measure.py
@@ -507,6 +507,7 @@ class TestMeasurementCompositeValueManipulation:
 
 class TestMeasurementValueItems:
     """Test that a MeasurementValue returns its items correctly."""
+    # pylint: disable=protected-access
 
     funcs_and_expected_single = [
         ((lambda v: v), [0, 1]),
@@ -531,9 +532,9 @@ class TestMeasurementValueItems:
     @pytest.mark.parametrize("func, expected", funcs_and_expected_multi)
     def test_items_multiple_mps(self, func, expected):
         """Test the full items."""
-        mp0 = MidMeasureMP(0)
-        mp1 = MidMeasureMP(0)
-        mp2 = MidMeasureMP(0)
+        MP0 = MidMeasureMP(0)
+        MP1 = MidMeasureMP(1)
+        MP2 = MidMeasureMP(2)
         branches3 = [
             (0, 0, 0),
             (0, 0, 1),
@@ -544,7 +545,7 @@ class TestMeasurementValueItems:
             (1, 1, 0),
             (1, 1, 1),
         ]
-        mv = MeasurementValue([mp0, mp1, mp2], func)
+        mv = MeasurementValue([MP0, MP1, MP2], func)
         items = list(mv._items())
         assert len(items) == len(branches3) == len(expected)
         for item, branch, exp in zip(items, branches3, expected):
@@ -586,13 +587,13 @@ class TestMeasurementValueItems:
     @pytest.mark.parametrize("func, expected", funcs_and_expected_multi)
     def test_postselected_items_multiple_mps(self, func, expected, postselects, branches):
         """Test the full items."""
-        mp0 = MidMeasureMP(0, postselect=postselects[0])
-        mp1 = MidMeasureMP(0, postselect=postselects[1])
-        mp2 = MidMeasureMP(0, postselect=postselects[2])
+        MP0 = MidMeasureMP(0, postselect=postselects[0])
+        MP1 = MidMeasureMP(1, postselect=postselects[1])
+        MP2 = MidMeasureMP(2, postselect=postselects[2])
 
-        mv = MeasurementValue([mp0, mp1, mp2], func)
+        mv = MeasurementValue([MP0, MP1, MP2], func)
         items = list(mv._postselected_items())
         assert len(items) == len(branches)
         for item, branch in zip(items, branches):
             pruned_branch = tuple(b for i, b in enumerate(branch) if postselects[i] is None)
-            assert item == (pruned_branch, func(*branch))
+            assert item == (pruned_branch, expected[self.branches3.index(branch)])

--- a/tests/measurements/test_mid_measure.py
+++ b/tests/measurements/test_mid_measure.py
@@ -510,7 +510,7 @@ class TestMeasurementValueItems:
 
     funcs_and_expected_single = [
         ((lambda v: v), [0, 1]),
-        ((lambda v: 1- v), [1, 0]),
+        ((lambda v: 1 - v), [1, 0]),
     ]
 
     @pytest.mark.parametrize("postselect", [None, 0, 1])
@@ -524,7 +524,7 @@ class TestMeasurementValueItems:
         assert items == [((0,), expected[0]), ((1,), expected[1])]
 
     funcs_and_expected_multi = [
-        ((lambda *v: sum(v)==1), [0, 1, 1, 0, 1, 0, 0, 0]),
+        ((lambda *v: sum(v) == 1), [0, 1, 1, 0, 1, 0, 0, 0]),
         ((lambda *v: v[0]), [0, 0, 0, 0, 1, 1, 1, 1]),
     ]
 

--- a/tests/measurements/test_mid_measure.py
+++ b/tests/measurements/test_mid_measure.py
@@ -507,6 +507,7 @@ class TestMeasurementCompositeValueManipulation:
 
 class TestMeasurementValueItems:
     """Test that a MeasurementValue returns its items correctly."""
+
     # pylint: disable=protected-access
 
     funcs_and_expected_single = [

--- a/tests/transforms/test_defer_measurements.py
+++ b/tests/transforms/test_defer_measurements.py
@@ -322,7 +322,7 @@ class TestQNode:
             qml.RX(phi, 0),
             qml.Projector([1], wires=0),
             qml.X(1),
-            #qml.CNOT([0, 1]),
+            # qml.CNOT([0, 1]),
             qml.probs(wires=1),
         ]
 
@@ -379,20 +379,20 @@ class TestQNode:
             qml.Projector([0], wires=1),
             qml.CNOT([1, 4]),
             qml.RY(theta, wires=[2]),
-            #qml.ops.Controlled(
-                #qml.RY(theta, wires=[2]), control_wires=[3, 4], control_values=[False, False]
-            #),
-            #qml.ops.Controlled(
-                #qml.RY(theta, wires=[2]), control_wires=[3, 4], control_values=[False, True]
-            #),
-            #qml.ops.Controlled(
-                #qml.RY(theta, wires=[2]), control_wires=[3, 4], control_values=[True, False]
-            #),
+            # qml.ops.Controlled(
+            # qml.RY(theta, wires=[2]), control_wires=[3, 4], control_values=[False, False]
+            # ),
+            # qml.ops.Controlled(
+            # qml.RY(theta, wires=[2]), control_wires=[3, 4], control_values=[False, True]
+            # ),
+            # qml.ops.Controlled(
+            # qml.RY(theta, wires=[2]), control_wires=[3, 4], control_values=[True, False]
+            # ),
             qml.Projector([1], wires=2),
             qml.CNOT([2, 5]),
             qml.PauliX(2),
             qml.PauliX(1),
-            #qml.CNOT([5, 1]),
+            # qml.CNOT([5, 1]),
             qml.probs(wires=[0, 1, 2]),
         ]
 

--- a/tests/transforms/test_defer_measurements.py
+++ b/tests/transforms/test_defer_measurements.py
@@ -321,7 +321,8 @@ class TestQNode:
         expected_circuit = [
             qml.RX(phi, 0),
             qml.Projector([1], wires=0),
-            qml.CNOT([0, 1]),
+            qml.X(1),
+            #qml.CNOT([0, 1]),
             qml.probs(wires=1),
         ]
 
@@ -377,19 +378,21 @@ class TestQNode:
             qml.CNOT([0, 1]),
             qml.Projector([0], wires=1),
             qml.CNOT([1, 4]),
-            qml.ops.Controlled(
-                qml.RY(theta, wires=[2]), control_wires=[3, 4], control_values=[False, False]
-            ),
-            qml.ops.Controlled(
-                qml.RY(theta, wires=[2]), control_wires=[3, 4], control_values=[False, True]
-            ),
-            qml.ops.Controlled(
-                qml.RY(theta, wires=[2]), control_wires=[3, 4], control_values=[True, False]
-            ),
+            qml.RY(theta, wires=[2]),
+            #qml.ops.Controlled(
+                #qml.RY(theta, wires=[2]), control_wires=[3, 4], control_values=[False, False]
+            #),
+            #qml.ops.Controlled(
+                #qml.RY(theta, wires=[2]), control_wires=[3, 4], control_values=[False, True]
+            #),
+            #qml.ops.Controlled(
+                #qml.RY(theta, wires=[2]), control_wires=[3, 4], control_values=[True, False]
+            #),
             qml.Projector([1], wires=2),
             qml.CNOT([2, 5]),
             qml.PauliX(2),
-            qml.CNOT([5, 1]),
+            qml.PauliX(1),
+            #qml.CNOT([5, 1]),
             qml.probs(wires=[0, 1, 2]),
         ]
 


### PR DESCRIPTION
**Context:**
Deferring measurements implies that we replace operations classically controlled on mid-circuit measurement values by standard controlled quantum operations. If postselection is used, we can save on the number of control wires and on the overall number of operations queued by `defer_measurements`. 

Note that a single postselected measurement can reduce the number of operations drastically, depending on the classical coprocessing.

**Description of the Change:**
This PR changes `defer_measurements` to only queue operations that are not reduced to the identity because of postselection rules. In addition, control wires corresponding to postselected measurements are excluded, as their value is known at transform time already.

To achieve the above, this PR adds a method `_postselected_items` to `MeasurementValue` that only returns a (pruned) branch together with the classical processing result of the non-pruned branch.

**Benefits:**
Reduction of operation count and complexity when using `defer_measurements` with postselection.

**Possible Drawbacks:**

**Related GitHub Issues:**
