### PR TITLE
equal with sum and product of no wires op

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -546,6 +546,8 @@
 * Fixes a bug in `_group_measurements` that fails to group measurements with commuting observables when they are operands of `Prod`.
   [(#5512)](https://github.com/PennyLaneAI/pennylane/issues/5512)
 
+* `qml.equal` can now be used with sums and products that contain operators on no wires like `I` and `GlobalPhase`.
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane/ops/op_math/prod.py
+++ b/pennylane/ops/op_math/prod.py
@@ -536,6 +536,9 @@ def _swappable_ops(op1, op2, wire_map: dict = None) -> bool:
     Returns:
         bool: True if operators should be swapped, False otherwise.
     """
+    # one is broadcasted onto all wires.
+    if not op1.wires or not op2.wires:
+        return False
     wires1 = op1.wires
     wires2 = op2.wires
     if wire_map is not None:

--- a/pennylane/ops/op_math/sum.py
+++ b/pennylane/ops/op_math/sum.py
@@ -567,7 +567,10 @@ class Sum(CompositeOp):
             wires = op.wires
             if wire_map is not None:
                 wires = wires.map(wire_map)
-            return sorted(list(map(str, wires)))[0], len(wires), str(op)
+            if not op.wires:
+                return ("", 0, str(op))
+            sorted_wires = sorted(list(map(str, wires)))[0]
+            return sorted_wires, len(wires), str(op)
 
         return sorted(op_list, key=_sort_key)
 

--- a/tests/ops/op_math/test_prod.py
+++ b/tests/ops/op_math/test_prod.py
@@ -1650,6 +1650,14 @@ class TestSortWires:
             assert op1.wires == op2.wires
             assert op1.data == op2.data
 
+    def test_sorting_operators_with_no_wires(self):
+        """Test that sorting can occur when an operator acts on no wires."""
+
+        op_list = [qml.GlobalPhase(0.5), qml.X(0), qml.I(), qml.CNOT((1, 2)), qml.I()]
+
+        sorted_list = Prod._sort(op_list)
+        assert op_list == sorted_list
+
 
 swappable_ops = [
     (qml.PauliX(1), qml.PauliY(0)),

--- a/tests/ops/op_math/test_sum.py
+++ b/tests/ops/op_math/test_sum.py
@@ -1127,6 +1127,16 @@ class TestSortWires:
         for op1, op2 in zip(final_list, sorted_list):
             assert qml.equal(op1, op2)
 
+    def test_sorting_operators_with_no_wires(self):
+        """Test that sorting can occur when an operator acts on no wires."""
+
+        op_list = [qml.GlobalPhase(0.5), qml.X(0), qml.Y(1), qml.I(), qml.CNOT((1, 2)), qml.I()]
+
+        sorted_list = Sum._sort(op_list)  # pylint: disable=protected-access
+
+        expected = [qml.GlobalPhase(0.5), qml.I(), qml.I(), qml.X(0), qml.Y(1), qml.CNOT((1, 2))]
+        assert sorted_list == expected
+
 
 class TestWrapperFunc:
     """Test wrapper function."""


### PR DESCRIPTION

**Context:**

Operators that don't have any wires (`GlobalPhase` and `Identity`) are newer additions that don't have full feature coverage in all places.  This can lead to some logic that is unable to handle them.

**Description of the Change:**

Allows `Sum._sort` and `Prod._sort` to work with operators that don't have any wires.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**

Fixes #5498 [sc-61115]