### PR TITLE
Draw sorts wires

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -329,6 +329,7 @@
 
 * `qml.draw` and `qml.draw_mpl` will now attempt to sort the wires if no wire order
   is provided by the user or the device.
+  [(#5576)](https://github.com/PennyLaneAI/pennylane/pull/5576)
 
 * `qml.ops.Conditional` now stores the `data`, `num_params`, and `ndim_param` attributes of
   the operator it wraps.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -327,6 +327,9 @@
 
 <h4>Other improvements</h4>
 
+* `qml.draw` and `qml.draw_mpl` will now attempt to sort the wires if no wire order
+  is provided by the user or the device.
+
 * `qml.ops.Conditional` now stores the `data`, `num_params`, and `ndim_param` attributes of
   the operator it wraps.
   [(#5473)](https://github.com/PennyLaneAI/pennylane/pull/5473)

--- a/pennylane/drawer/draw.py
+++ b/pennylane/drawer/draw.py
@@ -230,7 +230,14 @@ def draw(
     @wraps(qnode)
     def wrapper(*args, **kwargs):
         tape = qml.tape.make_qscript(qnode)(*args, **kwargs)
-        _wire_order = wire_order or tape.wires
+
+        if wire_order:
+            _wire_order = wire_order
+        else:
+            try:
+                _wire_order = sorted(tape.wires)
+            except TypeError:
+                _wire_order = tape.wires
 
         return tape_text(
             tape,
@@ -273,7 +280,15 @@ def _draw_qnode(
             finally:
                 qnode.expansion_strategy = original_expansion_strategy
 
-        _wire_order = wire_order or qnode.device.wires or qnode.tape.wires
+        if wire_order:
+            _wire_order = wire_order
+        elif qnode.device.wires:
+            _wire_order = qnode.device.wires
+        else:
+            try:
+                _wire_order = sorted(tapes[0].wires)
+            except TypeError:
+                _wire_order = tapes[0].wires
 
         if tapes is not None:
             cache = {"tape_offset": 0, "matrices": []}
@@ -547,7 +562,13 @@ def draw_mpl(
     @wraps(qnode)
     def wrapper(*args, **kwargs):
         tape = qml.tape.make_qscript(qnode)(*args, **kwargs)
-        _wire_order = wire_order or tape.wires
+        if wire_order:
+            _wire_order = wire_order
+        else:
+            try:
+                _wire_order = sorted(tape.wires)
+            except TypeError:
+                _wire_order = tape.wires
 
         return tape_mpl(
             tape,
@@ -592,7 +613,15 @@ def _draw_mpl_qnode(
             finally:
                 qnode.expansion_strategy = original_expansion_strategy
 
-        _wire_order = wire_order or qnode.device.wires or tape.wires
+        if wire_order:
+            _wire_order = wire_order
+        elif qnode.device.wires:
+            _wire_order = qnode.device.wires
+        else:
+            try:
+                _wire_order = sorted(tape.wires)
+            except TypeError:
+                _wire_order = tape.wires
 
         return tape_mpl(
             tape,

--- a/pennylane/drawer/draw.py
+++ b/pennylane/drawer/draw.py
@@ -47,7 +47,9 @@ def draw(
 
     Args:
         qnode (.QNode or Callable): the input QNode or quantum function that is to be drawn.
-        wire_order (Sequence[Any]): the order (from top to bottom) to print the wires of the circuit
+        wire_order (Sequence[Any]): the order (from top to bottom) to print the wires of the circuit.
+           If not provided, the wire order defaults to the device wires. If device wires are not
+           available, the circuit wires are sorted if possible.
         show_all_wires (bool): If True, all wires, including empty wires, are printed.
         decimals (int): How many decimal points to include when formatting operation parameters.
             ``None`` will omit parameters from operation labels.
@@ -342,7 +344,9 @@ def draw_mpl(
         qnode (.QNode or Callable): the input QNode/quantum function that is to be drawn.
 
     Keyword Args:
-        wire_order (Sequence[Any]): the order (from top to bottom) to print the wires of the circuit
+        wire_order (Sequence[Any]): the order (from top to bottom) to print the wires of the circuit.
+           If not provided, the wire order defaults to the device wires. If device wires are not
+           available, the circuit wires are sorted if possible.
         show_all_wires (bool): If True, all wires, including empty wires, are printed.
         decimals (int): How many decimal points to include when formatting operation parameters.
             Default ``None`` will omit parameters from operation labels.

--- a/tests/drawer/test_draw.py
+++ b/tests/drawer/test_draw.py
@@ -44,10 +44,21 @@ class TestLabelling:
         assert split_str[1][:6] == "    a:"
         assert split_str[2][:6] == "1.234:"
 
-    def test_wire_order(self):
+    @pytest.mark.parametrize("as_qnode", (True, False))
+    def test_wire_order(self, as_qnode):
         """Test wire_order keyword changes order of the wires."""
 
-        split_str = draw(circuit, wire_order=[1.234, "a", 0, "b"])(1.2, 2.3, 3.4).split("\n")
+        def f(x, y, z):
+            """A quantum circuit on three wires."""
+            qml.RX(x, wires=0)
+            qml.RY(y, wires="a")
+            qml.RZ(z, wires=1.234)
+            return qml.expval(qml.PauliZ(0))
+
+        if as_qnode:
+            f = qml.QNode(f, qml.device("default.qubit", wires=(0, "a", 1.234)))
+
+        split_str = draw(f, wire_order=[1.234, "a", 0, "b"])(1.2, 2.3, 3.4).split("\n")
         assert split_str[0][:6] == "1.234:"
         assert split_str[1][:6] == "    a:"
         assert split_str[2][:6] == "    0:"

--- a/tests/drawer/test_draw_mpl.py
+++ b/tests/drawer/test_draw_mpl.py
@@ -189,10 +189,21 @@ class TestKwargs:
 class TestWireBehaviour:
     """Tests that involve how wires are displayed"""
 
-    def test_wire_order(self):
+    @pytest.mark.parametrize("use_qnode", (True, False))
+    def test_wire_order(self, use_qnode):
         """Test wire_order changes order of wires"""
 
-        _, ax = qml.draw_mpl(circuit1, wire_order=(1.23, "a"))(1.23, 2.34)
+        def f(x, y):
+            """Circuit on three qubits."""
+            qml.RX(x, wires=0)
+            qml.CNOT(wires=(0, "a"))
+            qml.RY(y, wires=1.23)
+            return qml.expval(qml.PauliZ(0))
+
+        if use_qnode:
+            f = qml.QNode(f, qml.device("default.qubit", wires=(0, "a", 1.23)))
+
+        _, ax = qml.draw_mpl(f, wire_order=(1.23, "a"))(1.23, 2.34)
 
         assert len(ax.texts) == 5
 

--- a/tests/drawer/test_draw_mpl.py
+++ b/tests/drawer/test_draw_mpl.py
@@ -426,3 +426,43 @@ def test_applied_transforms(device):
     assert len(ax.texts) == 2  # one wire label, one gate label
 
     plt.close()
+
+
+@pytest.mark.parametrize("use_qnode", (True, False))
+def test_wire_sorting_if_no_wire_order(use_qnode):
+    """Test that wires are automatically sorted if the device and user
+    dont provide a wire order."""
+
+    def f():
+        qml.X(4)
+        qml.X(2)
+        return qml.expval(qml.Z(0))
+
+    if use_qnode:
+        f = qml.QNode(f, qml.device("default.qubit"))
+
+    _, ax = qml.draw_mpl(f)()
+
+    assert ax.texts[0].get_text() == "0"
+    assert ax.texts[1].get_text() == "2"
+    assert ax.texts[2].get_text() == "4"
+
+
+@pytest.mark.parametrize("use_qnode", (True, False))
+def test_wire_sorting_fallback_if_no_wire_order(use_qnode):
+    """Test that wires are automatically sorted if the device and user
+    dont provide a wire order."""
+
+    def f():
+        qml.X(4)
+        qml.X("a")
+        return qml.expval(qml.Z(0))
+
+    if use_qnode:
+        f = qml.QNode(f, qml.device("default.qubit"))
+
+    _, ax = qml.draw_mpl(f)()
+
+    assert ax.texts[0].get_text() == "4"
+    assert ax.texts[1].get_text() == "a"
+    assert ax.texts[2].get_text() == "0"


### PR DESCRIPTION
**Context:**

Devices may no longer provide a wire order, and we can also draw quantum functions that do not have an intrinsic wire order.  This can lead to the wire order in the drawing being unexpected, like `[4,3,0,1]`.

**Description of the Change:**

Tries to sort the wires if no other wires are provided, but fallbacks to the tape wires if sorting fails.


Before:
![Screenshot 2024-04-24 at 3 25 56 PM](https://github.com/PennyLaneAI/pennylane/assets/6364575/d8c8507b-2dd1-4d8e-a057-7614e7b9ab5c)

After: 
![Screenshot 2024-04-24 at 3 25 20 PM](https://github.com/PennyLaneAI/pennylane/assets/6364575/b13534bf-6683-438b-b5ed-682396cf8670)

**Benefits:**

Nicer looking drawings.

**Possible Drawbacks:**

try-except as logical control.

**Related GitHub Issues:**
[sc-61203]