### PR TITLE
Doc fix for fable template

### DIFF
--- a/pennylane/templates/subroutines/fable.py
+++ b/pennylane/templates/subroutines/fable.py
@@ -34,7 +34,7 @@ class FABLE(Operation):
         input_matrix (tensor_like): a :math:`(2^n \times 2^n)` matrix to be encoded,
             where :math:`n` is an integer
         wires (Iterable[int, str], Wires): the wires the operation acts on. The number of wires can
-            be computed as :math:`(2 \times n + 1)`, where the additional wire is for the ancilla
+            be computed as :math:`(2 \times n + 1)`, where the additional wire is an auxiliary wire.
         tol (float): rotation gates that have an angle value smaller than this tolerance are removed
         id (str or None): string representing the operation (optional)
 

--- a/pennylane/templates/subroutines/fable.py
+++ b/pennylane/templates/subroutines/fable.py
@@ -32,7 +32,9 @@ class FABLE(Operation):
 
     Args:
         input_matrix (tensor_like): a :math:`(2^n \times 2^n)` matrix to be encoded,
-            where :math:`n` is the number of wires used
+            where :math:`n` is an integer
+        wires (Iterable[int, str], Wires): the wires the operation acts on. The number of wires can 
+            be computed as :math:`(2 \times n + 1)`, where the additional wire is for the ancilla
         tol (float): rotation gates that have an angle value smaller than this tolerance are removed
         id (str or None): string representing the operation (optional)
 

--- a/pennylane/templates/subroutines/fable.py
+++ b/pennylane/templates/subroutines/fable.py
@@ -33,7 +33,7 @@ class FABLE(Operation):
     Args:
         input_matrix (tensor_like): a :math:`(2^n \times 2^n)` matrix to be encoded,
             where :math:`n` is an integer
-        wires (Iterable[int, str], Wires): the wires the operation acts on. The number of wires can 
+        wires (Iterable[int, str], Wires): the wires the operation acts on. The number of wires can
             be computed as :math:`(2 \times n + 1)`, where the additional wire is for the ancilla
         tol (float): rotation gates that have an angle value smaller than this tolerance are removed
         id (str or None): string representing the operation (optional)

--- a/pennylane/templates/subroutines/fable.py
+++ b/pennylane/templates/subroutines/fable.py
@@ -34,7 +34,7 @@ class FABLE(Operation):
         input_matrix (tensor_like): a :math:`(2^n \times 2^n)` matrix to be encoded,
             where :math:`n` is an integer
         wires (Iterable[int, str], Wires): the wires the operation acts on. The number of wires can
-            be computed as :math:`(2 \times n + 1)`, where the additional wire is an auxiliary wire.
+            be computed as :math:`(2 \times n + 1)`.
         tol (float): rotation gates that have an angle value smaller than this tolerance are removed
         id (str or None): string representing the operation (optional)
 


### PR DESCRIPTION
**Context:**
As pointed out by @isaacdevlugt, Fable template docs are unclear regarding the number of wires needed. This seeks to clarify that.

**Description of the Change:**
Docs changed to reflect that the # of wires needed is 2n+1

**Benefits:**
Users don't get confused by the seemingly random additional wire

**Possible Drawbacks:**

**Related GitHub Issues:**
