### PR TITLE
Skip tests not supported with new opmath

### DIFF
--- a/tests/devices/qubit/test_measure.py
+++ b/tests/devices/qubit/test_measure.py
@@ -192,6 +192,10 @@ class TestMeasurements:
 
     def test_measure_identity_no_wires(self):
         """Test that measure can handle the expectation value of identity on no wires."""
+
+        if not qml.operation.active_new_opmath():
+            pytest.skip("Identity with no wires is not supported with legacy opmath.")
+
         state = np.random.random([2, 2, 2])
         out = measure(qml.measurements.ExpectationMP(qml.I()), state)
         assert qml.math.allclose(out, 1.0)

--- a/tests/devices/qubit/test_sampling.py
+++ b/tests/devices/qubit/test_sampling.py
@@ -521,6 +521,9 @@ class TestMeasureSamples:
     def test_identity_on_no_wires_with_other_observables(self):
         """Test that measuring an identity on no wires can be used in conjunction with other measurements."""
 
+        if not qml.operation.active_new_opmath():
+            pytest.skip("Identity with no wires is not supported with legacy opmath.")
+
         state = np.array([0, 1])
 
         mps = [

--- a/tests/pauli/grouping/test_pauli_group_observables.py
+++ b/tests/pauli/grouping/test_pauli_group_observables.py
@@ -469,6 +469,9 @@ class TestGroupObservables:
         """Test that observables on no wires are stuck in the first group and
         coefficients are tracked when provided."""
 
+        if not qml.operation.active_new_opmath():
+            pytest.skip("Identity with no wires is not supported with legacy opmath.")
+
         observables = [
             qml.X(0),
             qml.Z(0),

--- a/tests/test_qnode_legacy.py
+++ b/tests/test_qnode_legacy.py
@@ -1881,6 +1881,9 @@ class TestTapeExpansion:
     def test_multiple_hamiltonian_expansion_finite_shots(self, grouping):
         """Test that multiple Hamiltonians works correctly (sum_expand should be used)"""
 
+        if not qml.operation.active_new_opmath():
+            pytest.skip("expval of the legacy Hamiltonian does not support finite shots.")
+
         dev = qml.device("default.qubit.legacy", wires=3, shots=50000)
 
         obs = [qml.PauliX(0), qml.PauliX(0) @ qml.PauliZ(1), qml.PauliZ(0) @ qml.PauliZ(1)]


### PR DESCRIPTION
**Context:**
Some newly added test cases failing with legacy opmath

**Description of the Change:**
Skip these tests if new opmath is disabled:
`test_measure_identity_no_wires` in `tests/devices/qubit/test_measure.py`
`test_identity_on_no_wires_with_other_observables` in `tests/devices/qubit/test_sampling.py`
`test_observables_on_no_wires_coeffs` in `tests/pauli/grouping/test_pauli_group_observables.py`
`test_multiple_hamiltonian_expansion_finite_shots` in `tests/test_qnode_legacy.py`

**Related Shortcut Issues:**
[sc-62144]
[sc-62143]