### PR TITLE
Bugfix/mcm key dtype

### DIFF
--- a/doc/releases/changelog-0.36.0.md
+++ b/doc/releases/changelog-0.36.0.md
@@ -551,6 +551,9 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Cast the keys of the `CountsMP` measurements returned `dynamic_one_shot` to the type produced by `MeasurementValue.concretize`.
+  [(#5587)](https://github.com/PennyLaneAI/pennylane/pull/5587)
+
 * `null.qubit` now automatically supports any operation without a decomposition.
   [(#5582)](https://github.com/PennyLaneAI/pennylane/pull/5582)
 

--- a/pennylane/transforms/dynamic_one_shot.py
+++ b/pennylane/transforms/dynamic_one_shot.py
@@ -365,7 +365,7 @@ def gather_mcm(measurement, samples):
     else:
         mcm_samples = [mv.concretize(dct) for dct in samples]
         use_as_is = mv.branches == {(0,): 0, (1,): 1}
-    mcm_samples = np.array(mcm_samples).reshape((-1, 1))
+    mcm_samples = np.array(mcm_samples).reshape((len(samples), 1))
     if use_as_is:
         wires, meas_tmp = mv.wires, measurement
     else:

--- a/pennylane/transforms/dynamic_one_shot.py
+++ b/pennylane/transforms/dynamic_one_shot.py
@@ -379,6 +379,6 @@ def gather_mcm(measurement, samples):
         meas_tmp = measurement.__class__(wires=wires)
     new_measurement = meas_tmp.process_samples(mcm_samples, wire_order=wires)
     if isinstance(measurement, CountsMP) and not use_as_is:
-        keys = np.array(list(new_measurement.values())).astype(mcm_samples.dtype)
+        keys = np.array(list(new_measurement.keys())).astype(mcm_samples.dtype)
         new_measurement = dict(sorted((x, y) for x, y in zip(keys, new_measurement.values())))
     return new_measurement

--- a/pennylane/transforms/dynamic_one_shot.py
+++ b/pennylane/transforms/dynamic_one_shot.py
@@ -359,15 +359,13 @@ def gather_mcm(measurement, samples):
         mcm_samples = np.concatenate(mcm_samples, axis=1)
         meas_tmp = measurement.__class__(wires=wires)
         return meas_tmp.process_samples(mcm_samples, wire_order=wires)
-    mcm_samples = np.zeros((len(samples), 1), dtype=np.int64)
     if isinstance(measurement, ProbabilityMP):
-        for i, dct in enumerate(samples):
-            mcm_samples[i, 0] = dct[mv.measurements[0]]
+        mcm_samples = [dct[mv.measurements[0]] for dct in samples]
         use_as_is = True
     else:
-        for i, dct in enumerate(samples):
-            mcm_samples[i, 0] = mv.concretize(dct)
+        mcm_samples = [mv.concretize(dct) for dct in samples]
         use_as_is = mv.branches == {(0,): 0, (1,): 1}
+    mcm_samples = np.array(mcm_samples).reshape((-1, 1))
     if use_as_is:
         wires, meas_tmp = mv.wires, measurement
     else:
@@ -381,5 +379,6 @@ def gather_mcm(measurement, samples):
         meas_tmp = measurement.__class__(wires=wires)
     new_measurement = meas_tmp.process_samples(mcm_samples, wire_order=wires)
     if isinstance(measurement, CountsMP) and not use_as_is:
-        new_measurement = dict(sorted((int(x), y) for x, y in new_measurement.items()))
+        keys = np.array(list(new_measurement.values())).astype(mcm_samples.dtype)
+        new_measurement = dict(sorted((x, y) for x, y in zip(keys, new_measurement.values())))
     return new_measurement


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      test directory!

- [x] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `doc/releases/changelog-dev.md` file, summarizing the
      change, and including a link back to the PR.

- [x] The PennyLane source code conforms to
      [PEP8 standards](https://www.python.org/dev/peps/pep-0008/).
      We check all of our code against [Pylint](https://www.pylint.org/).
      To lint modified files, simply `pip install pylint`, and then
      run `pylint pennylane/path/to/file.py`.

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
`qml.counts` does not return the same `keys` with `dynamic_one_shot` and `defer_measurements`. 

**Description of the Change:**
Cast `keys` to the type produced by `concretize`.

**Benefits:**
Consistent `keys`.

**Possible Drawbacks:**
Slight (likely unnoticeable) performance decrease since `NDArray` object cannot be preallocated. 

**Related GitHub Issues:**
#5566 