### PR TITLE
Release notes v0.36 - op arithmetic section and updates to deprecations page

### DIFF
--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -18,7 +18,8 @@ for more details. The old system is still accessible via :func:`~.disable_new_op
 old system will be removed in an upcoming release and should be treated as deprecated. The following
 functionality will explicitly raise a deprecation warning when used:
 
-* ``op.ops`` and ``op.coeffs`` will be deprecated in the future. Use ``op.terms()`` instead.
+* ``op.ops`` and ``op.coeffs`` will be deprecated in the future. Use 
+  :meth:`~.Operator.terms` instead.
 
   - Added and deprecated for ``Sum`` and ``Prod`` instances in v0.35
 
@@ -34,10 +35,10 @@ functionality will explicitly raise a deprecation warning when used:
   Alternatively, to continue accessing the legacy functionality, you can use
   ``qml.operation.disable_new_opmath()``.
 
-  - Deprecated in v0.36
+  - Use of ``qml.ops.Hamiltonian`` is deprecated in v0.36
 
 * Accessing terms of a tensor product (e.g., ``op = X(0) @ X(1)``) via ``op.obs`` is deprecated with new operator arithmetic.
-  A user should use ``op.operands`` instead.
+  A user should use :class:`op.operands <~.CompositeOp>` instead.
 
   - Deprecated in v0.36
 

--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -9,6 +9,41 @@ deprecations are listed below.
 Pending deprecations
 --------------------
 
+New operator arithmetic deprecations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This release completes the main phase of PennyLane's switchover to an updated approach for handling
+arithmetic operations between operators, check out the :ref:`Updated operators <new_opmath>` page
+for more details. The old system is still accessible via :func:`~.disable_new_opmath`. However, the
+old system will be removed in an upcoming release and should be treated as deprecated. The following
+functionality will explicitly raise a deprecation warning when used:
+
+* ``op.ops`` and ``op.coeffs`` will be deprecated in the future. Use ``op.terms()`` instead.
+
+  - Added and deprecated for ``Sum`` and ``Prod`` instances in v0.35
+
+* Accessing ``qml.ops.Hamiltonian`` with new operator arithmetic enabled is deprecated. Using ``qml.Hamiltonian``
+  with new operator arithmetic enabled now returns a ``LinearCombination`` instance. Some functionality
+  may not work as expected, and use of the Hamiltonian class with the new operator arithmetic will not
+  be supported in future releases of PennyLane.
+
+  You can update your code to the new operator arithmetic by using ``qml.Hamiltonian`` instead of importing
+  the Hamiltonian class directly or via ``qml.ops.Hamiltonian``. When the new operator arithmetic is enabled,
+  ``qml.Hamiltonian`` will access the new corresponding implementation.
+
+  Alternatively, to continue accessing the legacy functionality, you can use
+  ``qml.operation.disable_new_opmath()``.
+
+  - Deprecated in v0.36
+
+* Accessing terms of a tensor product ``op = X(0) @ X(1)`` via ``op.obs`` is deprecated with new operator arithmetic.
+  A user should use ``op.operands`` instead.
+
+  - Deprecated in v0.36
+
+Other deprecations
+~~~~~~~~~~~~~~~~~~
+
 * PennyLane Lightning and Catalyst will no longer support ``manylinux2014`` (GLIBC 2.17) compatibile Linux operating systems, and will be migrated to ``manylinux_2_28`` (GLIBC 2.28). See `pypa/manylinux <https://github.com/pypa/manylinux>`_ for additional details.
   
   - Last supported version of ``manylinux2014`` with v0.36
@@ -34,32 +69,6 @@ Pending deprecations
 
   - Deprecated in v0.36
   - Will be removed in v0.37
-
-New operator arithmetic deprecations
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-* ``op.ops`` and ``op.coeffs`` will be deprecated in the future. Use ``op.terms()`` instead.
-
-  - Added and deprecated for ``Sum`` and ``Prod`` instances in v0.35
-
-* Accessing ``qml.ops.Hamiltonian`` with new operator arithmetic enabled is deprecated. Using ``qml.Hamiltonian``
-  with new operator arithmetic enabled now returns a ``LinearCombination`` instance. Some functionality
-  may not work as expected, and use of the Hamiltonian class with the new operator arithmetic will not
-  be supported in future releases of PennyLane.
-
-  You can update your code to the new operator arithmetic by using ``qml.Hamiltonian`` instead of importing
-  the Hamiltonian class directly or via ``qml.ops.Hamiltonian``. When the new operator arithmetic is enabled, 
-  ``qml.Hamiltonian`` will access the new corresponding implementation. 
-
-  Alternatively, to continue accessing the legacy functionality, you can use 
-  ``qml.operation.disable_new_opmath()``.
-
-  - Deprecated in v0.36
-
-* Accessing terms of a tensor product ``op = X(0) @ X(1)`` via ``op.obs`` is deprecated with new operator arithmetic.
-  A user should use ``op.operands`` instead.
-
-  - Deprecated in v0.36
 
 Completed deprecation cycles
 ----------------------------

--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -12,7 +12,7 @@ Pending deprecations
 New operator arithmetic deprecations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This release completes the main phase of PennyLane's switchover to an updated approach for handling
+The v0.36 release completes the main phase of PennyLane's switchover to an updated approach for handling
 arithmetic operations between operators, check out the :ref:`Updated operators <new_opmath>` page
 for more details. The old system is still accessible via :func:`~.disable_new_opmath`. However, the
 old system will be removed in an upcoming release and should be treated as deprecated. The following
@@ -36,7 +36,7 @@ functionality will explicitly raise a deprecation warning when used:
 
   - Deprecated in v0.36
 
-* Accessing terms of a tensor product ``op = X(0) @ X(1)`` via ``op.obs`` is deprecated with new operator arithmetic.
+* Accessing terms of a tensor product (e.g., ``op = X(0) @ X(1)``) via ``op.obs`` is deprecated with new operator arithmetic.
   A user should use ``op.operands`` instead.
 
   - Deprecated in v0.36

--- a/doc/releases/changelog-0.36.0.md
+++ b/doc/releases/changelog-0.36.0.md
@@ -249,11 +249,11 @@
   and don't hesitate to reach out to us on the
   [PennyLane discussion forum](https://discuss.pennylane.ai/). As a last resort the old behaviour
   can be enabled by calling `qml.operation.disable_new_opmath()`, but this is not recommended
-  because support will not continue in future PennyLane versions.
+  because support will not continue in future PennyLane versions (v0.36 and higher).
   [(#5269)](https://github.com/PennyLaneAI/pennylane/pull/5269)
 
-* A new class `qml.ops.LinearCombination` is introduced. In essence, this class is an updated equivalent of `qml.ops.Hamiltonian`
-  but for usage with new operator arithmetic.
+* A new class called `qml.ops.LinearCombination` has been introduced. In essence, this class is an updated equivalent of the now-deprecated `qml.ops.Hamiltonian`
+  but for usage with the new operator arithmetic.
   [(#5216)](https://github.com/PennyLaneAI/pennylane/pull/5216)
 
 * `qml.ops.Sum` now supports storing grouping information. Grouping type and method can be
@@ -303,7 +303,7 @@
 
   Note that the grouping indices refer to the lists returned by `Sum.terms()`, not `Sum.operands`.
 
-* Added new function `qml.operation.convert_to_legacy_H` to convert `Sum`, `SProd`, and `Prod` to `Hamiltonian` instances.
+* A new function called `qml.operation.convert_to_legacy_H` that converts `Sum`, `SProd`, and `Prod` to `Hamiltonian` instances has been added.
   This function is intended for developers and will be removed in a future release without a
   deprecation cycle.
   [(#5309)](https://github.com/PennyLaneAI/pennylane/pull/5309)

--- a/doc/releases/changelog-0.36.0.md
+++ b/doc/releases/changelog-0.36.0.md
@@ -237,6 +237,25 @@
 
 <h4>Work easily and efficiently with operators</h4>
 
+* This release completes the main phase of PennyLane's switchover to an updated approach for
+  handling arithmetic operations between operators. The new approach is now enabled by default and
+  is intended to realize a few objectives:
+
+  1. To make it as easy to work with PennyLane operators as it would be with pen and paper.
+  2. To improve the efficiency of operator arithmetic.
+
+  In many cases, this update should not break code. If issues do arise, check out the
+  [updated operator troubleshooting page](https://docs.pennylane.ai/en/stable/news/new_opmath.html)
+  and don't hesitate to reach out to us on the
+  [PennyLane discussion forum](https://discuss.pennylane.ai/). As a last resort the old behaviour
+  can be enabled by calling `qml.operation.disable_new_opmath()`, but this is not recommended
+  because support will not continue in future PennyLane versions.
+  [(#5269)](https://github.com/PennyLaneAI/pennylane/pull/5269)
+
+* A new class `qml.ops.LinearCombination` is introduced. In essence, this class is an updated equivalent of `qml.ops.Hamiltonian`
+  but for usage with new operator arithmetic.
+  [(#5216)](https://github.com/PennyLaneAI/pennylane/pull/5216)
+
 * `qml.ops.Sum` now supports storing grouping information. Grouping type and method can be
   specified during construction using the `grouping_type` and `method` keyword arguments of
   `qml.dot`, `qml.sum`, or `qml.ops.Sum`. The grouping indices are stored in `Sum.grouping_indices`.
@@ -285,6 +304,8 @@
   Note that the grouping indices refer to the lists returned by `Sum.terms()`, not `Sum.operands`.
 
 * Added new function `qml.operation.convert_to_legacy_H` to convert `Sum`, `SProd`, and `Prod` to `Hamiltonian` instances.
+  This function is intended for developers and will be removed in a future release without a
+  deprecation cycle.
   [(#5309)](https://github.com/PennyLaneAI/pennylane/pull/5309)
 
 * The `qml.is_commuting` function now accepts `Sum`, `SProd`, and `Prod` instances.
@@ -292,10 +313,6 @@
 
 * Operators can now be left multiplied `x * op` by numpy arrays.
   [(#5361)](https://github.com/PennyLaneAI/pennylane/pull/5361)
-
-* A new class `qml.ops.LinearCombination` is introduced. In essence, this class is an updated equivalent of `qml.ops.Hamiltonian`
-  but for usage with new operator arithmetic.
-  [(#5216)](https://github.com/PennyLaneAI/pennylane/pull/5216)
 
 * The generators in the source code return operators consistent with the global setting for
   `qml.operator.active_new_opmath()` wherever possible. `Sum`, `SProd` and `Prod` instances


### PR DESCRIPTION
**Context:**

We want to communicate the change in default op arithmetic behaviour happening in v0.36 very clearly to the user.

**Description of the Change:**

Adds a section in the release notes and in the deprecations page.