### PR TITLE
Fix `qml.gradients` docs examples

### DIFF
--- a/.github/workflows/install_deps/action.yml
+++ b/.github/workflows/install_deps/action.yml
@@ -31,7 +31,7 @@ inputs:
   pytorch_version:
     description: The version of PyTorch to install for any job that requires PyTorch
     required: false
-    default: 2.2.0
+    default: 2.3.0
   install_pennylane_lightning_master:
     description: Indicate if PennyLane-Lightning should be installed from the master branch
     required: false

--- a/pennylane/gradients/__init__.py
+++ b/pennylane/gradients/__init__.py
@@ -98,7 +98,7 @@ and takes into account the circuit, device, autodiff framework, and metadata
 
 .. code-block:: python
 
-    dev = qml.device("default.qubit", wires=2, shots=1000)
+    dev = qml.device("default.qubit", shots=1000)
 
     @qml.qnode(dev, interface="tf")
     def circuit(weights):
@@ -143,7 +143,7 @@ framework.
 
 .. code-block:: python
 
-    dev = qml.device("default.qubit", wires=2)
+    dev = qml.device("default.qubit")
 
     @qml.qnode(dev)
     def circuit(weights):
@@ -157,9 +157,8 @@ framework.
 >>> circuit(weights)
 tensor([0.9658079, 0.0341921], requires_grad=True)
 >>> qml.gradients.param_shift(circuit)(weights)
-(tensor([-0.04673668,  0.04673668], requires_grad=True),
- tensor([-0.09442394,  0.09442394], requires_grad=True),
- tensor([-0.14409127,  0.14409127], requires_grad=True))
+tensor([[-0.04673668, -0.09442394, -0.14409127],
+        [ 0.04673668,  0.09442394,  0.14409127]], requires_grad=True)
 
 Comparing this to autodifferentiation:
 
@@ -173,7 +172,7 @@ automatically return the gradient:
 
 .. code-block:: python
 
-    dev = qml.device("default.qubit", wires=2)
+    dev = qml.device("default.qubit")
 
     @qml.gradients.param_shift
     @qml.qnode(dev)
@@ -185,9 +184,8 @@ automatically return the gradient:
         return qml.probs(wires=1)
 
 >>> decorated_circuit(weights)
-(tensor([-0.04673668,  0.04673668], requires_grad=True),
- tensor([-0.09442394,  0.09442394], requires_grad=True),
- tensor([-0.14409127,  0.14409127], requires_grad=True))
+tensor([[-0.04673668, -0.09442394, -0.14409127],
+        [ 0.04673668,  0.09442394,  0.14409127]], requires_grad=True)
 
 .. note::
 
@@ -203,6 +201,9 @@ automatically return the gradient:
     when applying the transform:
 
     >>> qml.gradients.param_shift(circuit, hybrid=False)(weights)
+    (tensor([-0.04673668,  0.04673668], requires_grad=True),
+     tensor([-0.09442394,  0.09442394], requires_grad=True),
+     tensor([-0.14409127,  0.14409127], requires_grad=True))
 
 
 Differentiating gradient transforms and higher-order derivatives
@@ -213,7 +214,7 @@ gradients to be computed:
 
 .. code-block:: python
 
-    dev = qml.device("default.qubit", wires=2)
+    dev = qml.device("default.qubit")
 
     @qml.qnode(dev)
     def circuit(weights):
@@ -227,9 +228,7 @@ gradients to be computed:
 >>> circuit(weights)
 tensor(0.9316158, requires_grad=True)
 >>> qml.gradients.param_shift(circuit)(weights)  # gradient
-(tensor(-0.09347337, requires_grad=True),
- tensor(-0.18884787, requires_grad=True),
- tensor(-0.28818254, requires_grad=True))
+tensor([-0.09347337, -0.18884787, -0.28818254], requires_grad=True)
 >>> def stacked_output(weights):
 ...     return qml.numpy.stack(qml.gradients.param_shift(circuit)(weights))
 >>> qml.jacobian(stacked_output)(weights)  # hessian
@@ -298,7 +297,7 @@ computation need to be analyzed.
 The output tapes can then be evaluated and post-processed to retrieve
 the gradient:
 
->>> dev = qml.device("default.qubit", wires=2)
+>>> dev = qml.device("default.qubit")
 >>> fn(qml.execute(gradient_tapes, dev, None))
 (tensor(-0.09347337, requires_grad=True),
  tensor(-0.18884787, requires_grad=True),

--- a/pennylane/gradients/classical_jacobian.py
+++ b/pennylane/gradients/classical_jacobian.py
@@ -61,8 +61,7 @@ def classical_jacobian(qnode, argnum=None, expand_fn=None, trainable_only=True):
     >>> print(cjac)
     [[1.  0.  0. ]
      [0.2 0.  0. ]
-     [0.  0.  0. ]
-     [0.  1.2 0. ]
+     [0.  2.  0. ]
      [0.  0.  1. ]]
 
     The returned Jacobian has rows corresponding to gate arguments, and columns

--- a/pennylane/gradients/finite_difference.py
+++ b/pennylane/gradients/finite_difference.py
@@ -253,7 +253,7 @@ def finite_diff(
     This transform can be registered directly as the quantum gradient transform
     to use during autodifferentiation:
 
-    >>> dev = qml.device("default.qubit", wires=2)
+    >>> dev = qml.device("default.qubit")
     >>> @qml.qnode(dev, interface="autograd", diff_method="finite-diff")
     ... def circuit(params):
     ...     qml.RX(params[0], wires=0)
@@ -270,7 +270,7 @@ def finite_diff(
     post-processing.
 
     >>> import jax
-    >>> dev = qml.device("default.qubit", wires=2)
+    >>> dev = qml.device("default.qubit")
     >>> @qml.qnode(dev, interface="jax", diff_method="finite-diff")
     ... def circuit(params):
     ...     qml.RX(params[0], wires=0)
@@ -280,7 +280,7 @@ def finite_diff(
     >>> params = jax.numpy.array([0.1, 0.2, 0.3])
     >>> jax.jacobian(circuit)(params)
     (Array([-0.38751727, -0.18884793, -0.3835571 ], dtype=float32),
-    Array([0.6991687 , 0.34072432, 0.6920237 ], dtype=float32))
+     Array([0.6991687 , 0.34072432, 0.6920237 ], dtype=float32))
 
 
     .. details::
@@ -299,12 +299,8 @@ def finite_diff(
         ...     return qml.expval(qml.Z(0)), qml.var(qml.Z(0))
         >>> params = np.array([0.1, 0.2, 0.3], requires_grad=True)
         >>> qml.gradients.finite_diff(circuit)(params)
-        ((tensor(-0.38751724, requires_grad=True),
-          tensor(-0.18884792, requires_grad=True),
-          tensor(-0.38355709, requires_grad=True)),
-         (tensor(0.69916868, requires_grad=True),
-          tensor(0.34072432, requires_grad=True),
-          tensor(0.69202366, requires_grad=True)))
+        (tensor([-0.38751724, -0.18884792, -0.38355708], requires_grad=True),
+         tensor([0.69916868, 0.34072432, 0.69202365], requires_grad=True))
 
         This quantum gradient transform can also be applied to low-level
         :class:`~.QuantumTape` objects. This will result in no implicit quantum
@@ -317,9 +313,9 @@ def finite_diff(
         >>> gradient_tapes, fn = qml.gradients.finite_diff(tape)
         >>> gradient_tapes
         [<QuantumTape: wires=[0], params=3>,
-         <QuantumTape: wires=[0], params=3>,
-         <QuantumTape: wires=[0], params=3>,
-         <QuantumTape: wires=[0], params=3>]
+         <QuantumScript: wires=[0], params=3>,
+         <QuantumScript: wires=[0], params=3>,
+         <QuantumScript: wires=[0], params=3>]
 
         This can be useful if the underlying circuits representing the gradient
         computation need to be analyzed.
@@ -338,19 +334,20 @@ def finite_diff(
 
         The output tapes can then be evaluated and post-processed to retrieve the gradient:
 
-        >>> dev = qml.device("default.qubit", wires=2)
+        >>> dev = qml.device("default.qubit")
         >>> fn(qml.execute(gradient_tapes, dev, None))
         ((tensor(-0.56464251, requires_grad=True),
-         tensor(-0.56464251, requires_grad=True),
-         tensor(-0.56464251, requires_grad=True)),
-        (tensor(0.93203912, requires_grad=True),
-         tensor(0.93203912, requires_grad=True),
-         tensor(0.93203912, requires_grad=True)))
+          tensor(-0.56464251, requires_grad=True),
+          tensor(-0.56464251, requires_grad=True)),
+         (tensor(0.93203912, requires_grad=True),
+          tensor(0.93203912, requires_grad=True),
+          tensor(0.93203912, requires_grad=True)))
 
         This gradient transform is compatible with devices that use shot vectors for execution.
 
+        >>> np.random.seed(251)
         >>> shots = (10, 100, 1000)
-        >>> dev = qml.device("default.qubit", wires=2, shots=shots)
+        >>> dev = qml.device("default.qubit", shots=shots)
         >>> @qml.qnode(dev)
         ... def circuit(params):
         ...     qml.RX(params[0], wires=0)
@@ -358,12 +355,10 @@ def finite_diff(
         ...     qml.RX(params[2], wires=0)
         ...     return qml.expval(qml.Z(0)), qml.var(qml.Z(0))
         >>> params = np.array([0.1, 0.2, 0.3], requires_grad=True)
-        >>> qml.gradients.finite_diff(circuit, h=10e-2)(params)
-        (((array(-2.), array(-2.), array(0.)), (array(3.6), array(3.6), array(0.))),
-         ((array(1.), array(0.4), array(1.)),
-          (array(-1.62), array(-0.624), array(-1.62))),
-         ((array(-0.48), array(-0.34), array(-0.46)),
-          (array(0.84288), array(0.6018), array(0.80868))))
+        >>> qml.gradients.finite_diff(circuit, h=0.1)(params)
+        ((array([-2., -2.,  0.]), array([3.6, 3.6, 0. ])),
+         (array([1. , 0.2, 0.4]), array([-1.78 , -0.34 , -0.688])),
+         (array([-0.9 , -0.22, -0.48]), array([1.5498 , 0.3938 , 0.84672])))
 
         The outermost tuple contains results corresponding to each element of the shot vector.
     """

--- a/pennylane/gradients/general_shift_rules.py
+++ b/pennylane/gradients/general_shift_rules.py
@@ -310,7 +310,7 @@ def generate_shift_rule(frequencies, shifts=None, order=1):
            [ 0.5       , -3.14159265]])
 
     This corresponds to the shift rule
-    :math:`\frac{\partial^2 f}{\partial phi^2} = \frac{1}{2} \left[f(\phi) - f(\phi-\pi)\right]`.
+    :math:`\frac{\partial^2 f}{\partial \phi^2} = \frac{1}{2} \left[f(\phi) - f(\phi-\pi)\right]`.
     """
     frequencies = tuple(f for f in frequencies if f > 0)
     rule = _get_shift_rule(frequencies, shifts=shifts)
@@ -366,11 +366,12 @@ def generate_multi_shift_rule(frequencies, shifts=None, orders=None):
 
     This corresponds to the gradient rule
 
+    TODO THERE IS A BUG CHECK RENDERING
     .. math::
 
         \frac{\partial^2 f}{\partial x\partial y} &= \frac{1}{4}
         \left[f(x+\pi/2, y+\pi/2) - f(x+\pi/2, y-\pi/2)\\
-        &~~~- f(x-\pi/2, y+\pi/2) + f(x-\pi/2, y-\pi/2) \right].
+        &- f(x-\pi/2, y+\pi/2) + f(x-\pi/2, y-\pi/2) \right].
     """
     rules = []
     shifts = shifts or [None] * len(frequencies)

--- a/pennylane/gradients/general_shift_rules.py
+++ b/pennylane/gradients/general_shift_rules.py
@@ -366,12 +366,14 @@ def generate_multi_shift_rule(frequencies, shifts=None, orders=None):
 
     This corresponds to the gradient rule
 
-    TODO THERE IS A BUG CHECK RENDERING
     .. math::
 
+        \begin{align*}
         \frac{\partial^2 f}{\partial x\partial y} &= \frac{1}{4}
-        \left[f(x+\pi/2, y+\pi/2) - f(x+\pi/2, y-\pi/2)\\
-        &- f(x-\pi/2, y+\pi/2) + f(x-\pi/2, y-\pi/2) \right].
+        [f(x+\pi/2, y+\pi/2) - f(x+\pi/2, y-\pi/2)\\
+        &\phantom{\frac{1}{4}[}-f(x-\pi/2, y+\pi/2) + f(x-\pi/2, y-\pi/2) ].
+        \end{align*}
+
     """
     rules = []
     shifts = shifts or [None] * len(frequencies)

--- a/pennylane/gradients/hadamard_gradient.py
+++ b/pennylane/gradients/hadamard_gradient.py
@@ -112,8 +112,9 @@ def hadamard_grad(
     This transform can be registered directly as the quantum gradient transform
     to use during autodifferentiation:
 
+    TODO THERE IS A BUG
     >>> import jax
-    >>> dev = qml.device("default.qubit", wires=2)
+    >>> dev = qml.device("default.qubit")
     >>> @qml.qnode(dev, interface="jax", diff_method="hadamard")
     ... def circuit(params):
     ...     qml.RX(params[0], wires=0)
@@ -133,7 +134,7 @@ def hadamard_grad(
         as the ``diff_method`` argument of the QNode decorator, and differentiating with your
         preferred machine learning framework.
 
-        >>> dev = qml.device("default.qubit", wires=2)
+        >>> dev = qml.device("default.qubit")
         >>> @qml.qnode(dev)
         ... def circuit(params):
         ...     qml.RX(params[0], wires=0)
@@ -142,9 +143,7 @@ def hadamard_grad(
         ...     return qml.expval(qml.Z(0))
         >>> params = np.array([0.1, 0.2, 0.3], requires_grad=True)
         >>> qml.gradients.hadamard_grad(circuit)(params)
-        (tensor([-0.3875172], requires_grad=True),
-         tensor([-0.18884787], requires_grad=True),
-         tensor([-0.38355704], requires_grad=True))
+        tensor([-0.3875172 , -0.18884787, -0.38355704], requires_grad=True)
 
         This quantum gradient transform can also be applied to low-level
         :class:`~.QuantumTape` objects. This will result in no implicit quantum
@@ -156,9 +155,9 @@ def hadamard_grad(
         >>> tape = qml.tape.QuantumTape(ops, measurements)
         >>> gradient_tapes, fn = qml.gradients.hadamard_grad(tape)
         >>> gradient_tapes
-        [<QuantumTape: wires=[0, 1], params=3>,
-         <QuantumTape: wires=[0, 1], params=3>,
-         <QuantumTape: wires=[0, 1], params=3>]
+        [<QuantumScript: wires=[0, 1], params=3>,
+         <QuantumScript: wires=[0, 1], params=3>,
+         <QuantumScript: wires=[0, 1], params=3>]
 
         This can be useful if the underlying circuits representing the gradient
         computation need to be analyzed.
@@ -177,14 +176,17 @@ def hadamard_grad(
 
         The output tapes can then be evaluated and post-processed to retrieve the gradient:
 
-        >>> dev = qml.device("default.qubit", wires=2)
+        TODO THERE IS A BUG OR BAD DOC EX
+        >>> dev = qml.device("default.qubit")
         >>> fn(qml.execute(gradient_tapes, dev, None))
-        (array(-0.3875172), array(-0.18884787), array(-0.38355704))
+        (tensor(-0.56464247, requires_grad=True),
+         tensor(-0.56464247, requires_grad=True),
+         tensor(-0.56464247, requires_grad=True))
 
         This transform can be registered directly as the quantum gradient transform
         to use during autodifferentiation:
 
-        >>> dev = qml.device("default.qubit", wires=3)
+        >>> dev = qml.device("default.qubit")
         >>> @qml.qnode(dev, interface="jax", diff_method="hadamard")
         ... def circuit(params):
         ...     qml.RX(params[0], wires=0)
@@ -193,7 +195,7 @@ def hadamard_grad(
         ...     return qml.expval(qml.Z(0))
         >>> params = jax.numpy.array([0.1, 0.2, 0.3])
         >>> jax.jacobian(circuit)(params)
-        [-0.3875172  -0.18884787 -0.38355704]
+        Array([-0.3875172 , -0.18884787, -0.38355704], dtype=float64)
 
         If you use custom wires on your device, you need to pass an auxiliary wire.
 
@@ -207,24 +209,24 @@ def hadamard_grad(
         ...    return qml.expval(qml.Z("a"))
         >>> params = jax.numpy.array([0.1, 0.2, 0.3])
         >>> jax.jacobian(circuit)(params)
-        [-0.3875172  -0.18884787 -0.38355704]
+        Array([-0.3875172 , -0.18884787, -0.38355704], dtype=float64)
 
     .. note::
 
         ``hadamard_grad`` will decompose the operations that are not in the list of supported operations.
 
-        - ``pennylane.RX``
-        - ``pennylane.RY``
-        - ``pennylane.RZ``
-        - ``pennylane.Rot``
-        - ``pennylane.PhaseShift``
-        - ``pennylane.U1``
-        - ``pennylane.CRX``
-        - ``pennylane.CRY``
-        - ``pennylane.CRZ``
-        - ``pennylane.IsingXX``
-        - ``pennylane.IsingYY``
-        - ``pennylane.IsingZZ``
+        - :class:`~.pennylane.RX`
+        - :class:`~.pennylane.RY`
+        - :class:`~.pennylane.RZ`
+        - :class:`~.pennylane.Rot`
+        - :class:`~.pennylane.PhaseShift`
+        - :class:`~.pennylane.U1`
+        - :class:`~.pennylane.CRX`
+        - :class:`~.pennylane.CRY`
+        - :class:`~.pennylane.CRZ`
+        - :class:`~.pennylane.IsingXX`
+        - :class:`~.pennylane.IsingYY`
+        - :class:`~.pennylane.IsingZZ`
 
         The expansion will fail if a suitable decomposition in terms of supported operation is not found.
         The number of trainable parameters may increase due to the decomposition.

--- a/pennylane/gradients/hadamard_gradient.py
+++ b/pennylane/gradients/hadamard_gradient.py
@@ -112,7 +112,6 @@ def hadamard_grad(
     This transform can be registered directly as the quantum gradient transform
     to use during autodifferentiation:
 
-    TODO THERE IS A BUG
     >>> import jax
     >>> dev = qml.device("default.qubit")
     >>> @qml.qnode(dev, interface="jax", diff_method="hadamard")
@@ -120,11 +119,12 @@ def hadamard_grad(
     ...     qml.RX(params[0], wires=0)
     ...     qml.RY(params[1], wires=0)
     ...     qml.RX(params[2], wires=0)
-    ...     return qml.expval(qml.Z(0)), qml.var(qml.Z(0))
+    ...     return qml.expval(qml.Z(0)), qml.probs(wires=0)
     >>> params = jax.numpy.array([0.1, 0.2, 0.3])
     >>> jax.jacobian(circuit)(params)
-    (Array([-0.38751727, -0.18884793, -0.3835571 ], dtype=float32),
-    Array([0.6991687 , 0.34072432, 0.6920237 ], dtype=float32))
+    (Array([-0.3875172 , -0.18884787, -0.38355704], dtype=float64),
+     Array([[-0.1937586 , -0.09442394, -0.19177852],
+            [ 0.1937586 ,  0.09442394,  0.19177852]], dtype=float64))
 
     .. details::
         :title: Usage Details
@@ -150,7 +150,7 @@ def hadamard_grad(
         device evaluation. Instead, the processed tapes, and post-processing
         function, which together define the gradient are directly returned:
 
-        >>> ops = [qml.RX(p, wires=0) for p in params]
+        >>> ops = [qml.RX(params[0], 0), qml.RY(params[1], 0), qml.RX(params[2], 0)]
         >>> measurements = [qml.expval(qml.Z(0))]
         >>> tape = qml.tape.QuantumTape(ops, measurements)
         >>> gradient_tapes, fn = qml.gradients.hadamard_grad(tape)
@@ -176,12 +176,11 @@ def hadamard_grad(
 
         The output tapes can then be evaluated and post-processed to retrieve the gradient:
 
-        TODO THERE IS A BUG OR BAD DOC EX
         >>> dev = qml.device("default.qubit")
         >>> fn(qml.execute(gradient_tapes, dev, None))
-        (tensor(-0.56464247, requires_grad=True),
-         tensor(-0.56464247, requires_grad=True),
-         tensor(-0.56464247, requires_grad=True))
+        (tensor(-0.3875172, requires_grad=True),
+         tensor(-0.18884787, requires_grad=True),
+         tensor(-0.38355704, requires_grad=True))
 
         This transform can be registered directly as the quantum gradient transform
         to use during autodifferentiation:

--- a/pennylane/gradients/jvp.py
+++ b/pennylane/gradients/jvp.py
@@ -44,7 +44,7 @@ def compute_jvp_single(tangent, jac):
         >>> tangent = np.array([1.0])
         >>> jac = np.array(0.2)
         >>> qml.gradients.compute_jvp_single(tangent, jac)
-        np.array(0.2)
+        array(0.2)
 
     2. For a single parameter and a single measurement with shape (e.g. ``probs``):
 
@@ -53,7 +53,7 @@ def compute_jvp_single(tangent, jac):
         >>> tangent = np.array([2.0])
         >>> jac = np.array([0.3, 0.4])
         >>> qml.gradients.compute_jvp_single(tangent, jac)
-        np.array([0.6, 0.8])
+        array([0.6, 0.8])
 
     3. For multiple parameters (in this case 2 parameters) and a single measurement
        without shape (e.g. ``expval``, ``var``):
@@ -63,7 +63,7 @@ def compute_jvp_single(tangent, jac):
         >>> tangent = np.array([1.0, 2.0])
         >>> jac = tuple([np.array(0.1), np.array(0.2)])
         >>> qml.gradients.compute_jvp_single(tangent, jac)
-        np.array(0.5)
+        array(0.5)
 
     4. For multiple parameters (in this case 2 parameters) and a single measurement with
        shape (e.g. ``probs``):
@@ -73,7 +73,7 @@ def compute_jvp_single(tangent, jac):
         >>> tangent = np.array([1.0, 0.5])
         >>> jac = tuple([np.array([0.1, 0.3]), np.array([0.2, 0.4])])
         >>> qml.gradients.compute_jvp_single(tangent, jac)
-        np.array([0.2, 0.5])
+        array([0.2, 0.5])
 
     .. details::
         :title: Technical description
@@ -219,7 +219,7 @@ def compute_jvp_multi(tangent, jac):
         >>> tangent = np.array([2.0])
         >>> jac = tuple([np.array([0.3]), np.array([0.2, 0.5])])
         >>> qml.gradients.compute_jvp_multi(tangent, jac)
-        (np.array([0.6]), np.array([0.4, 1. ]))
+        (array([0.6]), array([0.4, 1. ]))
 
     2. For multiple parameters (in this case 2 parameters) and multiple measurements (one without shape and one with
     shape, e.g. expval and probs):
@@ -229,7 +229,7 @@ def compute_jvp_multi(tangent, jac):
         >>> tangent = np.array([1.0, 2.0])
         >>> jac = tuple([tuple([np.array([0.3]), np.array([0.4])]), tuple([np.array([0.2, 0.5]), np.array([0.3, 0.8])]),])
         >>> qml.gradients.compute_jvp_multi(tangent, jac)
-        (np.array([1.1]), np.array([0.8, 2.1]))
+        (array([1.1]), array([0.8, 2.1]))
     """
     if jac is None:
         return None
@@ -286,10 +286,11 @@ def jvp(tape, tangent, gradient_fn, gradient_kwargs=None):
 
     Executing the JVP tapes, and applying the processing function:
 
-    >>> dev = qml.device("default.qubit", wires=2)
+    >>> dev = qml.device("default.qubit")
     >>> jvp = fn(dev.execute(jvp_tapes))
     >>> jvp
-    (Array(-0.62073976, dtype=float32), Array([-0.3259707 ,  0.32597077], dtype=float32))
+    (Array(-0.62073968, dtype=float64),
+     Array([-0.32597067,  0.32597067], dtype=float64))
     """
     if len(tape.trainable_params) == 0:
         # The tape has no trainable parameters; the JVP
@@ -400,10 +401,12 @@ def batch_jvp(tapes, tangents, gradient_fn, reduction="append", gradient_kwargs=
 
     >>> jvp_tapes, fn = qml.gradients.batch_jvp(tapes, tangents, qml.gradients.param_shift)
 
-    >>> dev = qml.device("default.qubit", wires=2)
+    >>> dev = qml.device("default.qubit")
     >>> jvps = fn(dev.execute(jvp_tapes))
     >>> jvps
-    ((Array(-0.62073976, dtype=float32), Array([-0.3259707 ,  0.32597077], dtype=float32)), Array(-0.6900841, dtype=float32))
+    ((Array(-0.62073968, dtype=float64),
+      Array([-0.32597067,  0.32597067], dtype=float64)),
+     Array(-0.690084, dtype=float64))
 
     We have two JVPs; one per tape. Each one corresponds to the shape of the output of their respective tape.
     """

--- a/pennylane/gradients/parameter_shift.py
+++ b/pennylane/gradients/parameter_shift.py
@@ -892,7 +892,7 @@ def param_shift(
     This transform can be registered directly as the quantum gradient transform
     to use during autodifferentiation:
 
-    >>> dev = qml.device("default.qubit", wires=2)
+    >>> dev = qml.device("default.qubit")
     >>> @qml.qnode(dev, interface="autograd", diff_method="parameter-shift")
     ... def circuit(params):
     ...     qml.RX(params[0], wires=0)
@@ -909,7 +909,7 @@ def param_shift(
     post-processing.
 
     >>> import jax
-    >>> dev = qml.device("default.qubit", wires=2)
+    >>> dev = qml.device("default.qubit")
     >>> @qml.qnode(dev, interface="jax", diff_method="parameter-shift")
     ... def circuit(params):
     ...     qml.RX(params[0], wires=0)
@@ -918,7 +918,8 @@ def param_shift(
     ...     return qml.expval(qml.Z(0)), qml.var(qml.Z(0))
     >>> params = jax.numpy.array([0.1, 0.2, 0.3])
     >>> jax.jacobian(circuit)(params)
-    (Array([-0.38751727, -0.18884793, -0.3835571 ], dtype=float32), Array([0.6991687 , 0.34072432, 0.6920237 ], dtype=float32))
+    (Array([-0.3875172 , -0.18884787, -0.38355704], dtype=float64),
+     Array([0.69916862, 0.34072424, 0.69202359], dtype=float64))
 
     .. note::
 
@@ -964,10 +965,8 @@ def param_shift(
         ...     qml.RX(params[2], wires=0)
         ...     return qml.expval(qml.Z(0)), qml.var(qml.Z(0))
         >>> qml.gradients.param_shift(circuit)(params)
-        ((tensor(-0.38751724, requires_grad=True),
-          tensor(-0.18884792, requires_grad=True),
-          tensor(-0.38355709, requires_grad=True)),
-         (array(0.69916862), array(0.34072424), array(0.69202359)))
+        (Array([-0.3875172 , -0.18884787, -0.38355704], dtype=float64),
+         Array([0.69916862, 0.34072424, 0.69202359], dtype=float64))
 
         This quantum gradient transform can also be applied to low-level
         :class:`~.QuantumTape` objects. This will result in no implicit quantum
@@ -979,12 +978,13 @@ def param_shift(
         >>> tape = qml.tape.QuantumTape(ops, measurements)
         >>> gradient_tapes, fn = qml.gradients.param_shift(tape)
         >>> gradient_tapes
-        [<QuantumTape: wires=[0, 1], params=3>,
-         <QuantumTape: wires=[0, 1], params=3>,
-         <QuantumTape: wires=[0, 1], params=3>,
-         <QuantumTape: wires=[0, 1], params=3>,
-         <QuantumTape: wires=[0, 1], params=3>,
-         <QuantumTape: wires=[0, 1], params=3>]
+        [<QuantumScript: wires=[0], params=3>,
+         <QuantumScript: wires=[0], params=3>,
+         <QuantumScript: wires=[0], params=3>,
+         <QuantumScript: wires=[0], params=3>,
+         <QuantumScript: wires=[0], params=3>,
+         <QuantumScript: wires=[0], params=3>,
+         <QuantumScript: wires=[0], params=3>]
 
         This can be useful if the underlying circuits representing the gradient
         computation need to be analyzed.
@@ -1004,17 +1004,20 @@ def param_shift(
         The output tapes can then be evaluated and post-processed to retrieve
         the gradient:
 
-        >>> dev = qml.device("default.qubit", wires=2)
+        >>> dev = qml.device("default.qubit")
         >>> fn(qml.execute(gradient_tapes, dev, None))
-        ((tensor(-0.3875172, requires_grad=True),
-          tensor(-0.18884787, requires_grad=True),
-          tensor(-0.38355704, requires_grad=True)),
-         (array(0.69916862), array(0.34072424), array(0.69202359)))
+        ((Array(-0.3875172, dtype=float64),
+          Array(-0.18884787, dtype=float64),
+          Array(-0.38355704, dtype=float64)),
+         (Array(0.69916862, dtype=float64),
+          Array(0.34072424, dtype=float64),
+          Array(0.69202359, dtype=float64)))
 
         This gradient transform is compatible with devices that use shot vectors for execution.
 
+        >>> np.random.seed(251)
         >>> shots = (10, 100, 1000)
-        >>> dev = qml.device("default.qubit", wires=2, shots=shots)
+        >>> dev = qml.device("default.qubit", shots=shots)
         >>> @qml.qnode(dev)
         ... def circuit(params):
         ...     qml.RX(params[0], wires=0)
@@ -1023,12 +1026,9 @@ def param_shift(
         ...     return qml.expval(qml.Z(0)), qml.var(qml.Z(0))
         >>> params = np.array([0.1, 0.2, 0.3], requires_grad=True)
         >>> qml.gradients.param_shift(circuit)(params)
-        (((array(-0.6), array(-0.1), array(-0.1)),
-          (array(1.2), array(0.2), array(0.2))),
-         ((array(-0.39), array(-0.24), array(-0.49)),
-          (array(0.7488), array(0.4608), array(0.9408))),
-         ((array(-0.36), array(-0.191), array(-0.37)),
-          (array(0.65808), array(0.349148), array(0.67636))))
+        ((array([-0.2, -0.1, -0.4]), array([0.4, 0.2, 0.8])),
+         (array([-0.4 , -0.24, -0.43]), array([0.672 , 0.4032, 0.7224])),
+         (array([-0.399, -0.179, -0.387]), array([0.722988, 0.324348, 0.701244])))
 
         The outermost tuple contains results corresponding to each element of the shot vector.
 
@@ -1048,11 +1048,14 @@ def param_shift(
 
         The postprocessing function will know that broadcasting is used and handle the results accordingly:
 
+        TODO: THERE IS A BUG
         >>> fn(qml.execute(gradient_tapes, dev, None))
         (array(-0.3875172), array(-0.18884787), array(-0.38355704))
 
         An advantage of using ``broadcast=True`` is a speedup:
 
+        TODO: THERE IS A BUG
+        >>> import timeit
         >>> @qml.qnode(dev)
         ... def circuit(params):
         ...     qml.RX(params[0], wires=0)

--- a/pennylane/gradients/parameter_shift.py
+++ b/pennylane/gradients/parameter_shift.py
@@ -1055,9 +1055,8 @@ def param_shift(
 
         An advantage of using ``broadcast=True`` is a speedup:
 
-        TODO: THERE IS A BUG
         >>> import timeit
-        >>> @qml.qnode(dev)
+        >>> @qml.qnode(qml.device("default.qubit"))
         ... def circuit(params):
         ...     qml.RX(params[0], wires=0)
         ...     qml.RY(params[1], wires=0)

--- a/pennylane/gradients/parameter_shift.py
+++ b/pennylane/gradients/parameter_shift.py
@@ -1037,7 +1037,7 @@ def param_shift(
         broadcasted tapes:
 
         >>> params = np.array([0.1, 0.2, 0.3], requires_grad=True)
-        >>> ops = [qml.RX(p, wires=0) for p in params]
+        >>> ops = [qml.RX(params[0], 0), qml.RY(params[1], 0), qml.RX(params[2], 0)]
         >>> measurements = [qml.expval(qml.Z(0))]
         >>> tape = qml.tape.QuantumTape(ops, measurements)
         >>> gradient_tapes, fn = qml.gradients.param_shift(tape, broadcast=True)
@@ -1048,9 +1048,10 @@ def param_shift(
 
         The postprocessing function will know that broadcasting is used and handle the results accordingly:
 
-        TODO: THERE IS A BUG
         >>> fn(qml.execute(gradient_tapes, dev, None))
-        (array(-0.3875172), array(-0.18884787), array(-0.38355704))
+        (tensor(-0.3875172, requires_grad=True),
+         tensor(-0.18884787, requires_grad=True),
+         tensor(-0.38355704, requires_grad=True))
 
         An advantage of using ``broadcast=True`` is a speedup:
 

--- a/pennylane/gradients/parameter_shift_cv.py
+++ b/pennylane/gradients/parameter_shift_cv.py
@@ -663,7 +663,7 @@ def param_shift_cv(
         function, which together define the gradient are directly returned:
 
         >>> r0, phi0, r1, phi1 = [0.4, -0.3, -0.7, 0.2]
-        >>> ops = [qml.Squeezing(r0, phi0, wires=0), qml.Squeezing(r1, phi2, wires=0)]
+        >>> ops = [qml.Squeezing(r0, phi0, wires=0), qml.Squeezing(r1, phi1, wires=0)]
         >>> tape = qml.tape.QuantumTape(ops, [qml.expval(qml.NumberOperator(0))])
         >>> gradient_tapes, fn = qml.gradients.param_shift_cv(tape, dev)
         >>> gradient_tapes
@@ -680,7 +680,10 @@ def param_shift_cv(
 
         >>> dev = qml.device("default.gaussian", wires=2)
         >>> fn(qml.execute(gradient_tapes, dev, None))
-        array([[-0.32487113, -0.4054074 , -0.87049853,  0.4054074 ]])
+        (-0.32487113372219933,
+         -0.4054074025310772,
+         -0.8704985300843778,
+         0.4054074025310775)
     """
     if len(tape.measurements) > 1:
         raise ValueError(

--- a/pennylane/gradients/parameter_shift_hessian.py
+++ b/pennylane/gradients/parameter_shift_hessian.py
@@ -496,7 +496,7 @@ def param_shift_hessian(
     This works best if no classical processing is applied within the
     QNode to operation parameters.
 
-    >>> dev = qml.device("default.qubit", wires=2)
+    >>> dev = qml.device("default.qubit")
     >>> @qml.qnode(dev)
     ... def circuit(x):
     ...     qml.RX(x[0], wires=0)
@@ -576,7 +576,8 @@ def param_shift_hessian(
 
         >>> hessian_tapes, postproc_fn = qml.gradients.param_shift_hessian(tape, argnum=(1,))
         >>> postproc_fn(qml.execute(hessian_tapes, dev, None))
-        ((array(0.), array(0.)), (array(0.), array(0.05998862)))
+        ((tensor(0., requires_grad=True), tensor(0., requires_grad=True)),
+         (tensor(0., requires_grad=True), array(0.05998862)))
 
     """
     # Perform input validation before generating tapes.

--- a/pennylane/gradients/pulse_gradient.py
+++ b/pennylane/gradients/pulse_gradient.py
@@ -391,7 +391,7 @@ def stoch_pulse_grad(
 
         jax.config.update("jax_enable_x64", True)
 
-        dev = qml.device("default.qubit.jax", wires=2)
+        dev = qml.device("default.qubit.jax")
 
         def sin(p, t):
             return jax.numpy.sin(p * t)

--- a/pennylane/gradients/pulse_gradient_odegen.py
+++ b/pennylane/gradients/pulse_gradient_odegen.py
@@ -469,6 +469,7 @@ def pulse_odegen(
 
     .. code-block:: python
 
+        from jax import numpy as jnp
         jax.config.update("jax_enable_x64", True)
         H = (
             qml.pulse.constant * qml.Y(0)
@@ -483,7 +484,7 @@ def pulse_odegen(
 
     .. code-block:: python
 
-        dev = qml.device("default.qubit.jax", wires=2)
+        dev = qml.device("default.qubit.jax")
 
         @qml.qnode(dev, interface="jax", diff_method=qml.gradients.pulse_odegen)
         def circuit(params):
@@ -503,7 +504,8 @@ def pulse_odegen(
     the tapes with inserted ``PauliRot`` gates together with the post-processing function:
 
     >>> circuit.construct((params,), {}) # Build the tape of the circuit.
-    >>> tapes, fun = qml.gradients.pulse_odegen(circuit.tape, argnums=[0, 1, 2])
+    >>> circuit.tape.trainable_params = [0, 1, 2]
+    >>> tapes, fun = qml.gradients.pulse_odegen(circuit.tape, argnum=[0, 1, 2])
     >>> len(tapes)
     12
 

--- a/pennylane/gradients/spsa_gradient.py
+++ b/pennylane/gradients/spsa_gradient.py
@@ -186,12 +186,8 @@ def spsa_grad(
     ...     return qml.expval(qml.Z(0)), qml.var(qml.Z(0))
     >>> params = np.array([0.1, 0.2, 0.3], requires_grad=True)
     >>> qml.gradients.spsa_grad(circuit)(params)
-    ((tensor(-0.19280803, requires_grad=True),
-      tensor(-0.19280803, requires_grad=True),
-      tensor(0.19280803, requires_grad=True)),
-     (tensor(0.34786926, requires_grad=True),
-      tensor(0.34786926, requires_grad=True),
-      tensor(-0.34786926, requires_grad=True)))
+    (tensor([ 0.18488771, -0.18488771, -0.18488771], requires_grad=True),
+     tensor([-0.33357922,  0.33357922,  0.33357922], requires_grad=True))
 
     Note that the SPSA gradient is a statistical estimator that uses a given number of
     function evaluations that does not depend on the number of parameters. While this
@@ -207,22 +203,14 @@ def spsa_grad(
         a more precise gradient estimation from ``num_directions=20`` directions yields
 
         >>> qml.gradients.spsa_grad(circuit, num_directions=20)(params)
-        ((tensor(-0.27362235, requires_grad=True),
-          tensor(-0.07219669, requires_grad=True),
-          tensor(-0.36369011, requires_grad=True)),
-         (tensor(0.49367656, requires_grad=True),
-          tensor(0.13025915, requires_grad=True),
-          tensor(0.65617915, requires_grad=True)))
+        (tensor([-0.53976776, -0.34385475, -0.46106048], requires_grad=True),
+         tensor([0.97386303, 0.62039169, 0.83185731], requires_grad=True))
 
         We may compare this to the more precise values obtained from finite differences:
 
         >>> qml.gradients.finite_diff(circuit)(params)
-        ((tensor(-0.38751724, requires_grad=True),
-          tensor(-0.18884792, requires_grad=True),
-          tensor(-0.38355708, requires_grad=True)),
-         (tensor(0.69916868, requires_grad=True),
-          tensor(0.34072432, requires_grad=True),
-          tensor(0.69202365, requires_grad=True)))
+        (tensor([-0.38751724, -0.18884792, -0.38355708], requires_grad=True),
+         tensor([0.69916868, 0.34072432, 0.69202365], requires_grad=True))
 
         As we can see, the SPSA output is a rather coarse approximation to the true
         gradient, and this although the parameter-shift rule for three parameters uses
@@ -241,7 +229,7 @@ def spsa_grad(
         >>> tape = qml.tape.QuantumTape(ops, measurements)
         >>> gradient_tapes, fn = qml.gradients.spsa_grad(tape)
         >>> gradient_tapes
-        [<QuantumTape: wires=[0], params=3>, <QuantumTape: wires=[0], params=3>]
+        [<QuantumScript: wires=[0], params=3>, <QuantumScript: wires=[0], params=3>]
 
         This can be useful if the underlying circuits representing the gradient
         computation need to be analyzed. Here we see that for ``num_directions=1``,
@@ -262,15 +250,20 @@ def spsa_grad(
         The output tapes can then be evaluated and post-processed to retrieve
         the gradient:
 
-        >>> dev = qml.device("default.qubit", wires=2)
+        >>> dev = qml.device("default.qubit")
         >>> fn(qml.execute(gradient_tapes, dev, None))
-        ((array(-0.58222637), array(0.58222637), array(-0.58222637)),
-         (array(1.05046797), array(-1.05046797), array(1.05046797)))
+        ((tensor(0.18488771, requires_grad=True),
+          tensor(-0.18488771, requires_grad=True),
+          tensor(-0.18488771, requires_grad=True)),
+         (tensor(-0.33357922, requires_grad=True),
+          tensor(0.33357922, requires_grad=True),
+          tensor(0.33357922, requires_grad=True)))
 
         This gradient transform is compatible with devices that use shot vectors for execution.
 
+        >>> np.random.seed(251)
         >>> shots = (10, 100, 1000)
-        >>> dev = qml.device("default.qubit", wires=2, shots=shots)
+        >>> dev = qml.device("default.qubit", shots=shots)
         >>> @qml.qnode(dev)
         ... def circuit(params):
         ...     qml.RX(params[0], wires=0)
@@ -279,11 +272,9 @@ def spsa_grad(
         ...     return qml.expval(qml.Z(0)), qml.var(qml.Z(0))
         >>> params = np.array([0.1, 0.2, 0.3], requires_grad=True)
         >>> qml.gradients.spsa_grad(circuit, h=1e-2)(params)
-        (((array(0.), array(0.), array(0.)), (array(0.), array(0.), array(0.))),
-         ((array(-1.4), array(-1.4), array(-1.4)),
-          (array(2.548), array(2.548), array(2.548))),
-         ((array(-1.06), array(-1.06), array(-1.06)),
-          (array(1.90588), array(1.90588), array(1.90588))))
+        ((array([ 10.,  10., -10.]), array([-18., -18.,  18.])),
+         (array([-5., -5.,  5.]), array([ 8.9,  8.9, -8.9])),
+         (array([ 1.5,  1.5, -1.5]), array([-2.667, -2.667,  2.667])))
 
         The outermost tuple contains results corresponding to each element of the shot vector,
         as is also visible by the increasing precision.

--- a/pennylane/gradients/vjp.py
+++ b/pennylane/gradients/vjp.py
@@ -73,7 +73,7 @@ def compute_vjp_single(dy, jac, num=None):
         >>> jac = np.array(0.1)
         >>> dy = np.array(2)
         >>> compute_vjp_single(dy, jac)
-        np.array([0.2])
+        array([0.2])
 
     2. For a single parameter and a single measurement with shape (e.g. probs):
 
@@ -82,7 +82,7 @@ def compute_vjp_single(dy, jac, num=None):
         >>> jac = np.array([0.1, 0.2])
         >>> dy = np.array([1.0, 1.0])
         >>> compute_vjp_single(dy, jac)
-        np.array([0.3])
+        array([0.3])
 
 
     3. For multiple parameters (in this case 2 parameters) and a single measurement without shape (e.g. expval, var):
@@ -92,7 +92,7 @@ def compute_vjp_single(dy, jac, num=None):
         >>> jac = tuple([np.array(0.1), np.array(0.2)])
         >>> dy = np.array(2)
         >>> compute_vjp_single(dy, jac)
-        np.array([0.2, 0.4])
+        array([0.2, 0.4])
 
     4. For multiple parameters (in this case 2 parameters) and a single measurement with shape (e.g. probs):
 
@@ -101,7 +101,7 @@ def compute_vjp_single(dy, jac, num=None):
         >>> jac = tuple([np.array([0.1, 0.2]), np.array([0.3, 0.4])])
         >>> dy = np.array([1.0, 2.0])
         >>> compute_vjp_single(dy, jac)
-        np.array([0.5, 1.1])
+        array([0.5, 1.1])
 
     """
     if jac is None:
@@ -182,17 +182,17 @@ def compute_vjp_multi(dy, jac, num=None):
         >>> jac = tuple([np.array(0.1), np.array([0.3, 0.4])])
         >>> dy = tuple([np.array(1.0), np.array([1.0, 2.0])])
         >>> compute_vjp_multi(dy, jac)
-        np.array([1.2])
+        array([1.2])
 
     2. For multiple parameters (in this case 2 parameters) and multiple measurement (one without shape and one with
     shape, e.g. expval and probs):
 
     .. code-block:: pycon
 
-        >>> jac = tuple([tuple([np.array(0.1), np.array(0.2)]), tuple([np.array([0.3, 0.4]), np.array([0.5, 0.6])])])
+        >>> jac = ((np.array(0.1), np.array(0.2)), (np.array([0.3, 0.4]), np.array([0.5, 0.6])))
         >>> dy = tuple([np.array(1.0), np.array([1.0, 2.0])])
         >>> compute_vjp_multi(dy, jac)
-        np.array([1.2, 1.9])
+        array([1.2, 1.9])
 
     """
     if jac is None:
@@ -318,11 +318,11 @@ def vjp(tape, dy, gradient_fn, gradient_kwargs=None):
 
     Executing the VJP tapes, and applying the processing function:
 
-    >>> dev = qml.device("default.qubit", wires=2)
+    >>> dev = qml.device("default.qubit")
     >>> vjp = fn(qml.execute(vjp_tapes, dev, gradient_fn=qml.gradients.param_shift, interface="torch"))
     >>> vjp
-    tensor([-1.1562e-01, -1.3862e-02, -9.0841e-03, -1.3878e-16, -4.8217e-01,
-             2.1329e-17], dtype=torch.float64, grad_fn=<ViewBackward>)
+    tensor([-1.1562e-01, -1.3862e-02, -9.0841e-03, -1.5214e-16, -4.8217e-01,
+             2.1329e-17], dtype=torch.float64, grad_fn=<SumBackward1>)
 
     The output VJP is also differentiable with respect to the tape parameters:
 
@@ -436,6 +436,8 @@ def batch_vjp(tapes, dys, gradient_fn, reduction="append", gradient_kwargs=None)
 
     .. code-block:: python
 
+        import torch
+
         x = torch.tensor([[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]], requires_grad=True, dtype=torch.float64)
 
         ops = [
@@ -461,7 +463,7 @@ def batch_vjp(tapes, dys, gradient_fn, reduction="append", gradient_kwargs=None)
     given a list of gradient-output vectors ``dys`` per tape:
 
     >>> dys = [torch.tensor([1., 1., 1.], dtype=torch.float64),
-    ...  torch.tensor([1.], dtype=torch.float64)]
+    ...        torch.tensor([1.], dtype=torch.float64)]
     >>> vjp_tapes, fn = qml.gradients.batch_vjp(tapes, dys, qml.gradients.param_shift)
 
     Note that each ``dy`` has shape matching the output dimension of the tape
@@ -470,13 +472,13 @@ def batch_vjp(tapes, dys, gradient_fn, reduction="append", gradient_kwargs=None)
 
     Executing the VJP tapes, and applying the processing function:
 
-    >>> dev = qml.device("default.qubit", wires=2)
+    >>> dev = qml.device("default.qubit")
     >>> vjps = fn(qml.execute(vjp_tapes, dev, gradient_fn=qml.gradients.param_shift, interface="torch"))
     >>> vjps
-    [tensor([-1.1562e-01, -1.3862e-02, -9.0841e-03, -1.3878e-16, -4.8217e-01,
-              2.1329e-17], dtype=torch.float64, grad_fn=<ViewBackward>),
+    [tensor([-1.1562e-01, -1.3862e-02, -9.0841e-03, -1.5214e-16, -4.8217e-01,
+          2.1329e-17], dtype=torch.float64, grad_fn=<SumBackward1>),
      tensor([ 1.7393e-01, -1.6412e-01, -5.3983e-03, -2.9366e-01, -4.0083e-01,
-              2.1134e-17], dtype=torch.float64, grad_fn=<ViewBackward>)]
+              2.1134e-17], dtype=torch.float64, grad_fn=<SqueezeBackward3>)]
 
     We have two VJPs; one per tape. Each one corresponds to the number of parameters
     on the tapes (6).

--- a/pennylane/kernels/cost_functions.py
+++ b/pennylane/kernels/cost_functions.py
@@ -67,7 +67,7 @@ def polarity(
 
     .. code-block :: python
 
-        dev = qml.device('default.qubit', wires=2, shots=None)
+        dev = qml.device('default.qubit')
         @qml.qnode(dev)
         def circuit(x1, x2):
             qml.templates.AngleEmbedding(x1, wires=dev.wires)
@@ -143,7 +143,7 @@ def target_alignment(
 
     .. code-block :: python
 
-        dev = qml.device('default.qubit', wires=2, shots=None)
+        dev = qml.device('default.qubit')
         @qml.qnode(dev)
         def circuit(x1, x2):
             qml.templates.AngleEmbedding(x1, wires=dev.wires)

--- a/pennylane/kernels/postprocessing.py
+++ b/pennylane/kernels/postprocessing.py
@@ -193,8 +193,8 @@ def closest_psd_matrix(K, fix_diagonal=False, solver=None, **kwargs):
 
         >>> K_psd = qml.kernels.closest_psd_matrix(K)
         >>> K_psd
-        tensor([[0.95, 0.95],
-                [0.95, 0.95]], requires_grad=True)
+        array([[0.95, 0.95],
+               [0.95, 0.95]])
         >>> np.linalg.eigvalsh(K_psd)
         array([0., 1.9])
         >>> np.allclose(K_psd, qml.kernels.threshold_matrix(K))

--- a/pennylane/kernels/utils.py
+++ b/pennylane/kernels/utils.py
@@ -38,7 +38,7 @@ def square_kernel_matrix(X, kernel, assume_normalized_kernel=False):
 
     .. code-block :: python
 
-        dev = qml.device('default.qubit', wires=2, shots=None)
+        dev = qml.device('default.qubit')
         @qml.qnode(dev)
         def circuit(x1, x2):
             qml.templates.AngleEmbedding(x1, wires=dev.wires)
@@ -102,7 +102,7 @@ def kernel_matrix(X1, X2, kernel):
 
     .. code-block :: python
 
-        dev = qml.device('default.qubit', wires=2, shots=None)
+        dev = qml.device('default.qubit')
         @qml.qnode(dev)
         def circuit(x1, x2):
             qml.templates.AngleEmbedding(x1, wires=dev.wires)


### PR DESCRIPTION
- [x] Fix last open bug or open issue


**Context:**
Docs get out of sync over time.
In particular, the output shape of gradient transforms applied to QNodes was changed in #4945 but not updated in the docs.

**Description of the Change:**
Update examples in docs of `qml.gradients` module.

Also updates the `qml.kernels` docs, with a few very small changes.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
