### PR TITLE
BugFix: convert_to_opmath does not dequeue original op

### DIFF
--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -3043,10 +3043,14 @@ def convert_to_opmath(op):
         Operator: An operator using the new arithmetic operations, if relevant
     """
     if isinstance(op, (qml.ops.Hamiltonian, qml.ops.LinearCombination)):
+        if qml.QueuingManager.recording():
+            qml.QueuingManager.remove(op)
         c, ops = op.terms()
         ops = tuple(convert_to_opmath(o) for o in ops)
         return qml.dot(c, ops)
     if isinstance(op, Tensor):
+        if qml.QueuingManager.recording():
+            qml.QueuingManager.remove(op)
         return qml.prod(*op.obs)
     return op
 

--- a/tests/ops/op_math/test_sum.py
+++ b/tests/ops/op_math/test_sum.py
@@ -681,7 +681,11 @@ class TestProperties:
         assert sum_op._queue_category is None  # pylint: disable=protected-access
 
     def test_eigvals_Identity_no_wires(self):
-        """Test that the eigenvalues can be computed for a sum containing an identity with no wires."""
+        """Test that eigenvalues can be computed for a sum containing identity with no wires."""
+
+        if not qml.operation.active_new_opmath():
+            pytest.skip("Identity with no wires is not supported for legacy opmath")
+
         op1 = qml.X(0) + 2 * qml.I()
         op2 = qml.X(0) + 2 * qml.I(0)
         assert qml.math.allclose(sorted(op1.eigvals()), sorted(op2.eigvals()))

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -3071,3 +3071,22 @@ def test_get_attr():
     assert (
         StatePrep is qml.operation.StatePrepBase
     )  # StatePrep imported from operation.py is an alias for StatePrepBase
+
+
+@pytest.mark.parametrize(
+    "make_op",
+    [
+        lambda: qml.Hamiltonian([1, 2], [qml.PauliX(0), qml.PauliY(1)]),
+        lambda: 1.2 * qml.PauliX(0),
+    ],
+)
+@pytest.mark.usefixtures("use_legacy_and_new_opmath")
+def test_convert_to_opmath_queueing(make_op):
+    """Tests that converting to opmath dequeues the original operation"""
+
+    with qml.queuing.AnnotatedQueue() as q:
+        original_op = make_op()
+        new_op = qml.operation.convert_to_opmath(original_op)
+
+    assert len(q.queue) == 1
+    assert q.queue[0] is new_op


### PR DESCRIPTION
**Context:**
Fixes latest failures in the legacy opmath tests in the plugin test matrix.

**Description of the Change:**
1. `convert_to_opmath` now dequeues the original op.
2. Skip test with `I()` when new opmath is disabled.
