### PR TITLE
Disallow `param_shift(... broadcast=True)` with shot vectors

### DIFF
--- a/doc/releases/changelog-0.36.0.md
+++ b/doc/releases/changelog-0.36.0.md
@@ -551,6 +551,10 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Using shot vectors with `param_shift(... broadcast=True)` caused a bug. This combination is no longer supported
+  and will be added again in the next release.
+  [(#5612)](https://github.com/PennyLaneAI/pennylane/pull/5612)
+
 * Cast the keys of the `CountsMP` measurements returned `dynamic_one_shot` to the type produced by `MeasurementValue.concretize`.
   [(#5587)](https://github.com/PennyLaneAI/pennylane/pull/5587)
 

--- a/pennylane/gradients/gradient_transform.py
+++ b/pennylane/gradients/gradient_transform.py
@@ -58,11 +58,21 @@ SUPPORTED_GRADIENT_KWARGS = [
 
 def assert_multimeasure_not_broadcasted(measurements, broadcast):
     """Assert that there are not simultaneously multiple measurements and
-    broadcasting activated.Otherwise raises an error."""
+    broadcasting activated. Otherwise raises an error."""
     if broadcast and len(measurements) > 1:
         raise NotImplementedError(
             "Broadcasting with multiple measurements is not supported yet. "
             f"Set broadcast to False instead. The tape measurements are {measurements}."
+        )
+
+
+def assert_shot_vector_not_broadcasted(shots, broadcast):
+    """Assert that there are not simultaneously multiple shot settings (shot vector) and
+    broadcasting activated. Otherwise raises an error."""
+    if broadcast and shots.has_partitioned_shots:
+        raise NotImplementedError(
+            "Broadcasting with shot vectors is not supported yet. "
+            f"Set broadcast to False instead. The tape shots are {shots}."
         )
 
 

--- a/pennylane/gradients/parameter_shift.py
+++ b/pennylane/gradients/parameter_shift.py
@@ -39,6 +39,7 @@ from .gradient_transform import (
     assert_no_state_returns,
     assert_no_trainable_tape_batching,
     assert_multimeasure_not_broadcasted,
+    assert_shot_vector_not_broadcasted,
     choose_trainable_params,
     find_and_validate_gradient_methods,
     _no_trainable_grad,
@@ -1079,6 +1080,7 @@ def param_shift(
     transform_name = "parameter-shift rule"
     assert_no_state_returns(tape.measurements, transform_name)
     assert_multimeasure_not_broadcasted(tape.measurements, broadcast)
+    assert_shot_vector_not_broadcasted(tape.shots, broadcast)
     assert_no_trainable_tape_batching(tape, transform_name)
 
     if argnum is None and not tape.trainable_params:

--- a/tests/gradients/parameter_shift/test_parameter_shift_shot_vec.py
+++ b/tests/gradients/parameter_shift/test_parameter_shift_shot_vec.py
@@ -118,9 +118,15 @@ class TestParamShift:
         # TODO: remove once #2155 is resolved
         tape.trainable_params = []
 
+        if broadcast:
+            match_ = "Broadcasting with shot vectors is not supported yet"
+            with pytest.raises(NotImplementedError, match=match_):
+                g_tapes, fn = qml.gradients.param_shift(tape, broadcast=broadcast)
+            return
+
         with pytest.warns(UserWarning, match="gradient of a tape with no trainable parameters"):
-            g_tapes, post_processing = qml.gradients.param_shift(tape, broadcast=broadcast)
-        all_res = post_processing(qml.execute(g_tapes, dev, None))
+            g_tapes, fn = qml.gradients.param_shift(tape, broadcast=broadcast)
+        all_res = fn(qml.execute(g_tapes, dev, None))
         assert isinstance(all_res, tuple)
         assert len(all_res) == len(shot_vec)
 


### PR DESCRIPTION
**Context:**
Shot vectors together with the `broadcast=True` feature of `param_shift` suffers from the bug #5598 .
For some shot vector lengths, this bug causes silent wrong results, for other lengths it causes a non-comprehensive error.

**Description of the Change:**
This PR explicitly disallows this combination and raises a `NotImplementedError`.

A proper fix is in the works.

**Benefits:**
No silently wrong results and more comprehensive error message.

**Possible Drawbacks:**

**Related GitHub Issues:**
#5598
