### PR TITLE
improve error on setting shots on new device api

### DIFF
--- a/doc/releases/changelog-0.36.0.md
+++ b/doc/releases/changelog-0.36.0.md
@@ -551,6 +551,9 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Improves the error message for setting shots on the new device interface, or trying to access a property
+  that no longer exists.
+
 * Using shot vectors with `param_shift(... broadcast=True)` caused a bug. This combination is no longer supported
   and will be added again in the next release.
   [(#5612)](https://github.com/PennyLaneAI/pennylane/pull/5612)

--- a/pennylane/devices/device_api.py
+++ b/pennylane/devices/device_api.py
@@ -177,6 +177,14 @@ class Device(abc.ABC):
         details = f"({', '.join(details)}) " if details else ""
         return f"<{self.name} device {details}at {hex(id(self))}>"
 
+    def __getattr__(self, key):
+        raise AttributeError(
+            f"{type(self).__name__} has no attribute '{key}'. "
+            " You may be looking for a property or method present in the legacy device interface. "
+            f" Please consult the {type(self).__name__} documentation for an updated list of public "
+            " properties and methods."
+        )
+
     @property
     def shots(self) -> Shots:
         """Default shots for execution workflows containing this device.
@@ -186,6 +194,16 @@ class Device(abc.ABC):
 
         """
         return self._shots
+
+    @shots.setter
+    def shots(self, _):
+        raise AttributeError(
+            (
+                "Shots can no longer be set on a device instance. "
+                "You can set shots on a call to a QNode, on individual tapes, or "
+                "create a new device instance instead."
+            )
+        )
 
     @property
     def wires(self) -> Wires:

--- a/tests/devices/experimental/test_device_api.py
+++ b/tests/devices/experimental/test_device_api.py
@@ -71,8 +71,19 @@ class TestMinimalDevice:
         shots_dev = self.MinimalDevice(shots=100)
         assert shots_dev.shots == qml.measurements.Shots(100)
 
-        with pytest.raises(AttributeError):
+        with pytest.raises(
+            AttributeError, match="Shots can no longer be set on a device instance."
+        ):
             self.dev.shots = 100  # pylint: disable=attribute-defined-outside-init
+
+    def test_getattr_error(self):
+        """Test that querying a property that doesn't exist informs about interface change."""
+
+        with pytest.raises(
+            AttributeError,
+            match=r"You may be looking for a property or method present in the legacy device",
+        ):
+            _ = self.dev.expand_fn
 
     def test_tracker_set_on_initialization(self):
         """Test that a new tracker instance is initialized with the class."""


### PR DESCRIPTION
**Context:**

As more devices switch to the new device interface, users may request properties or behaviours that are no longer there. The current error messages do not sufficiently alert users to the fact that the device interface has changed.

**Description of the Change:**

Make a more informative error when trying to set the shots or access a non-existant attribute.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
