### PR TITLE
[Bug Fix] Fix `TrotterProduct` to be compatible with resource tracking and error tracking

### DIFF
--- a/doc/releases/changelog-0.36.0.md
+++ b/doc/releases/changelog-0.36.0.md
@@ -681,7 +681,7 @@
 * `qml.equal` can now be used with sums and products that contain operators on no wires like `I` and `GlobalPhase`.
   [(#5562)](https://github.com/PennyLaneAI/pennylane/pull/5562)
 
-* Fixed `qml.TrotterProduct` to be compatible with resource tracking by inheirting from `ResourcesOperation`.
+* Fixed `qml.TrotterProduct` to be compatible with resource tracking by inheriting from `ResourcesOperation`. Updated the names for the `method` kwarg of the `error` method from "one-norm" and "commutator" to "one-norm-bound" and "commutator-bound".
   [(#5629)](https://github.com/PennyLaneAI/pennylane/pull/5629)
 
 * `CompositeOp.has_diagonalizing_gates` now does a more complete check of the base operators to ensure consistency 

--- a/doc/releases/changelog-0.36.0.md
+++ b/doc/releases/changelog-0.36.0.md
@@ -681,7 +681,7 @@
 * `qml.equal` can now be used with sums and products that contain operators on no wires like `I` and `GlobalPhase`.
   [(#5562)](https://github.com/PennyLaneAI/pennylane/pull/5562)
 
-* Fixed `qml.TrotterProduct` to be compatible with resource tracking by inheriting from `ResourcesOperation`. Updated the names for the `method` kwarg of the `error` method from "one-norm" and "commutator" to "one-norm-bound" and "commutator-bound".
+* `qml.TrotterProduct` is now compatible with resource tracking by inheriting from `ResourcesOperation`. Updated the names for the values of `method` kwarg of the `error` method from "one-norm" and "commutator" to "one-norm-bound" and "commutator-bound", respectively.
   [(#5629)](https://github.com/PennyLaneAI/pennylane/pull/5629)
 
 * `CompositeOp.has_diagonalizing_gates` now does a more complete check of the base operators to ensure consistency 

--- a/doc/releases/changelog-0.36.0.md
+++ b/doc/releases/changelog-0.36.0.md
@@ -681,6 +681,9 @@
 * `qml.equal` can now be used with sums and products that contain operators on no wires like `I` and `GlobalPhase`.
   [(#5562)](https://github.com/PennyLaneAI/pennylane/pull/5562)
 
+* Fixed `qml.TrotterProduct` to be compatible with resource tracking by inheirting from `ResourcesOperation`.
+  [(#5629)](https://github.com/PennyLaneAI/pennylane/pull/5629)
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane/templates/subroutines/trotter.py
+++ b/pennylane/templates/subroutines/trotter.py
@@ -147,13 +147,13 @@ class TrotterProduct(ErrorOperation, ResourcesOperation):
 
         An *upper-bound* for the error in approximating time-evolution using this operator can be
         computed by calling :func:`~.TrotterProduct.error()`. It is computed using two different methods; the
-        "one-norm" scaling method and the "commutator" scaling method. (see `Childs et al. (2021) <https://arxiv.org/abs/1912.08854>`_)
+        "one-norm-bound" scaling method and the "commutator-bound" scaling method. (see `Childs et al. (2021) <https://arxiv.org/abs/1912.08854>`_)
 
         >>> hamiltonian = qml.dot([1.0, 0.5, -0.25], [qml.X(0), qml.Y(0), qml.Z(0)])
         >>> op = qml.TrotterProduct(hamiltonian, time=0.01, order=2)
-        >>> op.error(method="one-norm")
+        >>> op.error(method="one-norm-bound")
         SpectralNormError(8.039062500000003e-06)
-        >>> op.error(method="commutator")
+        >>> op.error(method="commutator-bound")
         SpectralNormError(6.166666666666668e-06)
 
         This operation is similar to the :class:`~.ApproxTimeEvolution`. One can recover the behaviour
@@ -264,7 +264,7 @@ class TrotterProduct(ErrorOperation, ResourcesOperation):
         return Resources(num_wires, num_gates, gate_types, gate_sizes, depth)
 
     def error(
-        self, method: str = "commutator", fast: bool = True
+        self, method: str = "commutator-bound", fast: bool = True
     ):  # pylint: disable=arguments-differ
         # pylint: disable=protected-access
         r"""Compute an *upper-bound* on the spectral norm error for approximating the
@@ -280,26 +280,26 @@ class TrotterProduct(ErrorOperation, ResourcesOperation):
 
         **Example:**
 
-        The "one-norm" error bound can be computed by passing the kwarg :code:`method="one-norm"`, and
+        The "one-norm" error bound can be computed by passing the kwarg :code:`method="one-norm-bound"`, and
         is defined according to Section 2.3 (lemma 6, equation 22 and 23) of
         `Childs et al. (2021) <https://arxiv.org/abs/1912.08854>`_.
 
         >>> hamiltonian = qml.dot([1.0, 0.5, -0.25], [qml.X(0), qml.Y(0), qml.Z(0)])
         >>> op = qml.TrotterProduct(hamiltonian, time=0.01, order=2)
-        >>> op.error(method="one-norm")
+        >>> op.error(method="one-norm-bound")
         SpectralNormError(8.039062500000003e-06)
 
-        The "commutator" error bound can be computed by passing the kwarg :code:`method="commutator"`, and
+        The "commutator" error bound can be computed by passing the kwarg :code:`method="commutator-bound"`, and
         is defined according to Appendix C (equation 189) `Childs et al. (2021) <https://arxiv.org/abs/1912.08854>`_.
 
         >>> hamiltonian = qml.dot([1.0, 0.5, -0.25], [qml.X(0), qml.Y(0), qml.Z(0)])
         >>> op = qml.TrotterProduct(hamiltonian, time=0.01, order=2)
-        >>> op.error(method="commutator")
+        >>> op.error(method="commutator-bound")
         SpectralNormError(6.166666666666668e-06)
 
         Args:
-            method (str, optional): Options include "one-norm" and "commutator" and specify the
-                method with which the error is computed. Defaults to "commutator".
+            method (str, optional): Options include "one-norm-bound" and "commutator-bound" and specify the
+                method with which the error is computed. Defaults to "commutator-bound".
             fast (bool, optional): Uses more approximations to speed up computation. Defaults to True.
 
         Raises:
@@ -320,10 +320,10 @@ class TrotterProduct(ErrorOperation, ResourcesOperation):
             )
 
         terms = base_unitary.operands
-        if method == "one-norm":
+        if method == "one-norm-bound":
             return SpectralNormError(qml.resource.error._one_norm_error(terms, t, p, n, fast=fast))
 
-        if method == "commutator":
+        if method == "commutator-bound":
             return SpectralNormError(
                 qml.resource.error._commutator_error(terms, t, p, n, fast=fast)
             )

--- a/pennylane/templates/subroutines/trotter.py
+++ b/pennylane/templates/subroutines/trotter.py
@@ -14,10 +14,13 @@
 """
 Contains templates for Suzuki-Trotter approximation based subroutines.
 """
+import copy
+from collections import defaultdict
 
 import pennylane as qml
 from pennylane.ops import Sum
 from pennylane.ops.op_math import SProd
+from pennylane.resource import ResourcesOperation, Resources
 from pennylane.resource.error import ErrorOperation, SpectralNormError
 
 
@@ -62,7 +65,7 @@ def _recursive_expression(x, order, ops):
     return (2 * ops_lst_1) + ops_lst_2 + (2 * ops_lst_1)
 
 
-class TrotterProduct(ErrorOperation):
+class TrotterProduct(ErrorOperation, ResourcesOperation):
     r"""An operation representing the Suzuki-Trotter product approximation for the complex matrix
     exponential of a given Hamiltonian.
 
@@ -235,6 +238,30 @@ class TrotterProduct(ErrorOperation):
         context.remove(self.hyperparameters["base"])
         context.append(self)
         return self
+
+    def resources(self) -> Resources:
+        """The resource requirements for a given instance of the Suzuki-Trotter product.
+
+        Returns:
+            Resources: The resources for an instance of TrotterProduct.
+        """
+        with qml.QueuingManager.stop_recording():
+            decomp = self.compute_decomposition(*self.parameters, **self.hyperparameters)
+
+        num_wires = len(self.wires)
+        num_gates = len(decomp)
+
+        unique_operation_decomp = (copy.deepcopy(op) for op in decomp)
+        depth = qml.tape.QuantumTape(ops=unique_operation_decomp).graph.get_depth()
+
+        gate_types = defaultdict(int)
+        gate_sizes = defaultdict(int)
+
+        for op in decomp:
+            gate_types[op.name] += 1
+            gate_sizes[len(op.wires)] += 1
+
+        return Resources(num_wires, num_gates, gate_types, gate_sizes, depth)
 
     def error(
         self, method: str = "commutator", fast: bool = True

--- a/tests/templates/test_subroutines/test_trotter.py
+++ b/tests/templates/test_subroutines/test_trotter.py
@@ -214,7 +214,8 @@ test_decompositions = (
 )
 
 test_resources_data = {
-    (0, 1): Resources(  # (hamiltonian_index, order): Resources computed by hand
+    # (hamiltonian_index, order): Resources computed by hand
+    (0, 1): Resources( 
         num_wires=2,
         num_gates=3,
         gate_types=defaultdict(int, {"Exp": 3}),

--- a/tests/templates/test_subroutines/test_trotter.py
+++ b/tests/templates/test_subroutines/test_trotter.py
@@ -17,12 +17,14 @@ Tests for the TrotterProduct template and helper functions.
 # pylint: disable=private-access, protected-access
 import copy
 from functools import reduce
+from collections import defaultdict
 
 import pytest
 
 import pennylane as qml
 from pennylane import numpy as qnp
 from pennylane.math import allclose, get_interface
+from pennylane.resource import Resources
 from pennylane.resource.error import SpectralNormError
 from pennylane.templates.subroutines.trotter import _recursive_expression, _scalar
 
@@ -210,6 +212,93 @@ test_decompositions = (
         ],
     }
 )
+
+test_resources_data = {
+    (0, 1): Resources(
+        num_wires=2,
+        num_gates=3,
+        gate_types=defaultdict(int, {"Exp": 3}),
+        gate_sizes=defaultdict(int, {1: 3}),
+        depth=2,
+    ),
+    (0, 2): Resources(
+        num_wires=2,
+        num_gates=6,
+        gate_types=defaultdict(int, {"Exp": 6}),
+        gate_sizes=defaultdict(int, {1: 6}),
+        depth=4,
+    ),
+    (0, 4): Resources(
+        num_wires=2,
+        num_gates=30,
+        gate_types=defaultdict(int, {"Exp": 30}),
+        gate_sizes=defaultdict(int, {1: 30}),
+        depth=20,
+    ),
+    (1, 1): Resources(
+        num_wires=2,
+        num_gates=2,
+        gate_types=defaultdict(int, {"Exp": 2}),
+        gate_sizes=defaultdict(int, {1: 1, 2: 1}),
+        depth=2,
+    ),
+    (1, 2): Resources(
+        num_wires=2,
+        num_gates=4,
+        gate_types=defaultdict(int, {"Exp": 4}),
+        gate_sizes=defaultdict(int, {1: 2, 2: 2}),
+        depth=4,
+    ),
+    (1, 4): Resources(
+        num_wires=2,
+        num_gates=20,
+        gate_types=defaultdict(int, {"Exp": 20}),
+        gate_sizes=defaultdict(int, {1: 10, 2: 10}),
+        depth=20,
+    ),
+    (2, 1): Resources(
+        num_wires=2,
+        num_gates=3,
+        gate_types=defaultdict(int, {"Exp": 3}),
+        gate_sizes=defaultdict(int, {1: 2, 2: 1}),
+        depth=3,
+    ),
+    (2, 2): Resources(
+        num_wires=2,
+        num_gates=6,
+        gate_types=defaultdict(int, {"Exp": 6}),
+        gate_sizes=defaultdict(int, {1: 4, 2: 2}),
+        depth=6,
+    ),
+    (2, 4): Resources(
+        num_wires=2,
+        num_gates=30,
+        gate_types=defaultdict(int, {"Exp": 30}),
+        gate_sizes=defaultdict(int, {1: 20, 2: 10}),
+        depth=30,
+    ),
+    (3, 1): Resources(
+        num_wires=2,
+        num_gates=3,
+        gate_types=defaultdict(int, {"Exp": 3}),
+        gate_sizes=defaultdict(int, {1: 3}),
+        depth=2,
+    ),
+    (3, 2): Resources(
+        num_wires=2,
+        num_gates=6,
+        gate_types=defaultdict(int, {"Exp": 6}),
+        gate_sizes=defaultdict(int, {1: 6}),
+        depth=4,
+    ),
+    (3, 4): Resources(
+        num_wires=2,
+        num_gates=30,
+        gate_types=defaultdict(int, {"Exp": 30}),
+        gate_sizes=defaultdict(int, {1: 30}),
+        depth=20,
+    ),
+}
 
 
 def _generate_simple_decomp(coeffs, ops, time, order, n):
@@ -563,6 +652,74 @@ class TestError:
         op = qml.TrotterProduct(hamiltonian, 1.23, order=2, n=5)
         with pytest.raises(TypeError, match="Calculating error bound for Tensorflow objects"):
             _ = op.error()
+
+
+class TestResources:
+    """Test the resources methof of the TrotterProduct class"""
+
+    def test_resources_no_queuing(self):
+        """Test that no operations are queued when computing resources."""
+        time = 0.5
+        hamiltonian = qml.sum(qml.PauliX(0), qml.PauliZ(0))
+        op = qml.TrotterProduct(hamiltonian, time, n=5, order=2)
+
+        with qml.queuing.AnnotatedQueue() as q:
+            _ = op.resources()
+
+        assert len(q.queue) == 0
+
+    @pytest.mark.parametrize("order", (1, 2, 4))
+    @pytest.mark.parametrize("hamiltonian_index, hamiltonian", enumerate(test_hamiltonians))
+    def test_resources(self, hamiltonian, hamiltonian_index, order):
+        """Test that the resources are tracked accurately."""
+        op = qml.TrotterProduct(hamiltonian, 4.2, order=order)
+
+        tracked_resources = op.resources()
+        expected_resources = test_resources_data[(hamiltonian_index, order)]
+
+        assert expected_resources == tracked_resources
+
+    @pytest.mark.parametrize("n", (1, 5, 10))
+    def test_resources_with_trotter_steps(self, n):
+        """Test that the resources are tracked accurately with number of steps."""
+        order = 2
+        hamiltonian_index = 0
+
+        op = qml.TrotterProduct(test_hamiltonians[hamiltonian_index], 0.5, order=order, n=n)
+        tracked_resources = op.resources()
+
+        expected_resources = Resources(
+            num_wires=2,
+            num_gates=6 * n,
+            gate_types=defaultdict(int, {"Exp": 6 * n}),
+            gate_sizes=defaultdict(int, {1: 6 * n}),
+            depth=4 * n,
+        )
+
+        assert expected_resources == tracked_resources
+
+    def test_resources_integration(self):
+        """Test that the resources integrate well with specs resource tracking."""
+        time = 0.5
+        hamiltonian = qml.sum(qml.X(0), qml.Y(0), qml.Z(1))
+
+        dev = qml.device("default.qubit")
+
+        @qml.qnode(dev)
+        def circ():
+            qml.TrotterProduct(hamiltonian, time, n=5, order=2)
+            return qml.expval(qml.Z(0))
+
+        tracked_resources = qml.specs(circ)()["resources"]
+        expected_resources = Resources(
+            num_wires=2,
+            num_gates=30,
+            gate_types=defaultdict(int, {"Exp": 30}),
+            gate_sizes=defaultdict(int, {1: 30}),
+            depth=20,
+        )
+
+        assert expected_resources == tracked_resources
 
 
 class TestDecomposition:

--- a/tests/templates/test_subroutines/test_trotter.py
+++ b/tests/templates/test_subroutines/test_trotter.py
@@ -214,7 +214,7 @@ test_decompositions = (
 )
 
 test_resources_data = {
-    (0, 1): Resources(
+    (0, 1): Resources(  # (hamiltonian_index, order): Resources computed by hand
         num_wires=2,
         num_gates=3,
         gate_types=defaultdict(int, {"Exp": 3}),

--- a/tests/templates/test_subroutines/test_trotter.py
+++ b/tests/templates/test_subroutines/test_trotter.py
@@ -655,7 +655,7 @@ class TestError:
 
 
 class TestResources:
-    """Test the resources methof of the TrotterProduct class"""
+    """Test the resources method of the TrotterProduct class"""
 
     def test_resources_no_queuing(self):
         """Test that no operations are queued when computing resources."""

--- a/tests/templates/test_subroutines/test_trotter.py
+++ b/tests/templates/test_subroutines/test_trotter.py
@@ -602,8 +602,8 @@ class TestError:
         expected_error = ((10**5 + 1) / 120) * (0.1**5)
 
         for computed_error in (
-            op.error(method="one-norm"),
-            op.error(method="one-norm", fast=False),
+            op.error(method="one-norm-bound"),
+            op.error(method="one-norm-bound", fast=False),
         ):
             assert isinstance(computed_error, SpectralNormError)
             assert qnp.isclose(computed_error.error, expected_error)
@@ -614,15 +614,15 @@ class TestError:
         expected_error = (32 / 3) * (0.05**3) * (1 / 100)
 
         for computed_error in (
-            op.error(method="commutator"),
-            op.error(method="commutator", fast=False),
+            op.error(method="commutator-bound"),
+            op.error(method="commutator-bound", fast=False),
         ):
             assert isinstance(computed_error, SpectralNormError)
             assert qnp.isclose(computed_error.error, expected_error)
 
     @pytest.mark.all_interfaces
     @pytest.mark.parametrize(
-        "method, expected_error", (("one-norm", 0.001265625), ("commutator", 0.001))
+        "method, expected_error", (("one-norm-bound", 0.001265625), ("commutator-bound", 0.001))
     )
     @pytest.mark.parametrize("interface", ("autograd", "jax", "torch"))
     def test_error_interfaces(self, method, interface, expected_error):


### PR DESCRIPTION
**Context:**
`qml.TrotterProduct()` now has error tracking functionality, but ins't compatible with resource tracking. This bug fix adds native resource tracking functionality to allow for compatibility with both pipelines.

![image](https://github.com/PennyLaneAI/pennylane/assets/21964864/f815b1e5-bf5d-46a0-8539-840013c51d85)

**Description of the Change:**
Inherit from `ResourcesOperation` class as well and directly implement the resource method. 

**Benefits:**
Allows for tracking resources without decomposing the template. 

**Possible Drawbacks:**
If we change the target gate-set or want to decompose further, then this method is no longer accurate.

**Related GitHub Issues:**
