### PR TITLE
Fix ML interfaces with `dynamic_one_shot`

### DIFF
--- a/doc/releases/changelog-0.36.0.md
+++ b/doc/releases/changelog-0.36.0.md
@@ -553,7 +553,7 @@
 
 * Fixed an issue with the `dynamic_one_shot` transform where `qml.sample` and `qml.var` were not working correctly with
   all machine learning interfaces.
-  [(#)]()
+  [(#5630)](https://github.com/PennyLaneAI/pennylane/pull/5630)
 
 * Improves the error message for setting shots on the new device interface, or trying to access a property
   that no longer exists.

--- a/doc/releases/changelog-0.36.0.md
+++ b/doc/releases/changelog-0.36.0.md
@@ -551,6 +551,10 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Fixed an issue with the `dynamic_one_shot` transform where `qml.sample` and `qml.var` were not working correctly with
+  all machine learning interfaces.
+  [(#)]()
+
 * Improves the error message for setting shots on the new device interface, or trying to access a property
   that no longer exists.
   [(#5616)](https://github.com/PennyLaneAI/pennylane/pull/5616)

--- a/pennylane/math/single_dispatch.py
+++ b/pennylane/math/single_dispatch.py
@@ -243,6 +243,7 @@ ar.autoray._SUBMODULE_ALIASES["tensorflow", "sinc"] = "tensorflow.experimental.n
 ar.autoray._SUBMODULE_ALIASES["tensorflow", "isclose"] = "tensorflow.experimental.numpy"
 ar.autoray._SUBMODULE_ALIASES["tensorflow", "atleast_1d"] = "tensorflow.experimental.numpy"
 ar.autoray._SUBMODULE_ALIASES["tensorflow", "all"] = "tensorflow.experimental.numpy"
+ar.autoray._SUBMODULE_ALIASES["tensorflow", "ravel"] = "tensorflow.experimental.numpy"
 
 tf_fft_functions = [
     "fft",
@@ -309,6 +310,9 @@ ar.register_function(
     lambda x: _i("tf").math.sqrt(
         _i("tf").cast(x, "float64") if x.dtype.name in ("int64", "int32") else x
     ),
+)
+ar.register_function(
+    "tensorflow", "var", lambda tensor, **kwargs: _i("tf").math.reduce_variance(tensor, **kwargs)
 )
 
 

--- a/pennylane/transforms/dynamic_one_shot.py
+++ b/pennylane/transforms/dynamic_one_shot.py
@@ -87,6 +87,10 @@ def dynamic_one_shot(tape: qml.tape.QuantumTape) -> (Sequence[qml.tape.QuantumTa
     if not any(isinstance(o, MidMeasureMP) for o in tape.operations):
         return (tape,), null_postprocessing
 
+    print(tape.measurements)
+    print(tape.measurements[0])
+    print(tape.measurements[0].obs, tape.measurements[0].wires, tape.measurements[0].mv)
+
     for m in tape.measurements:
         if not isinstance(m, (CountsMP, ExpectationMP, ProbabilityMP, SampleMP, VarianceMP)):
             raise TypeError(
@@ -268,7 +272,7 @@ def accumulate_native_mcm(circuit: qml.tape.QuantumScript, all_shot_meas, one_sh
         elif isinstance(m, (ExpectationMP, ProbabilityMP)):
             new_shot_meas[i] = all_shot_meas[i] + one_shot_meas[i]
         elif isinstance(m, SampleMP):
-            new_shot_meas[i].append(one_shot_meas[i])
+            new_shot_meas[i] = qml.math.vstack([new_shot_meas[i], one_shot_meas[i]])
         else:
             raise TypeError(
                 f"Native mid-circuit measurement mode does not support {type(m).__name__} measurements."

--- a/pennylane/transforms/dynamic_one_shot.py
+++ b/pennylane/transforms/dynamic_one_shot.py
@@ -338,12 +338,9 @@ def gather_non_mcm(circuit_measurement, measurement, samples):
             qml.math.concatenate(tuple(qml.math.reshape(s, (1, -1)) for s in measurement))
         )
     # VarianceMP
-    # Casting is needed for torch and tf to compute variance. Ravel to convert 0-D arrays into
-    # 1-D arrays. Contatenate to maintain the interface. Without these changes, the input to var
-    # is a list and the returned value's interface is always numpy
-    # return qml.math.var(
-    #     qml.math.concatenate(tuple(qml.math.ravel(qml.math.cast(s, "float")) for s in measurement))
-    # )
+    # Casting is needed for torch and tf to compute variance. Conversion is needed to convert
+    # list of 0-D arrays to 1-D array. Without these changes, the input to var is a list and
+    # the returned value's interface is always numpy
     return qml.math.var(qml.math.cast(qml.math.convert_like(measurement, measurement[0]), "float"))
 
 

--- a/tests/devices/default_qubit/test_default_qubit_native_mcm.py
+++ b/tests/devices/default_qubit/test_default_qubit_native_mcm.py
@@ -407,6 +407,120 @@ def test_simple_composite_mcm(mcm_f, measure_f):
     validate_measurements(measure_f, shots, results1, results2)
 
 
+@pytest.mark.tf
+@pytest.mark.parametrize("shots", [3000, [3000, 3001]])
+@pytest.mark.parametrize("postselect", [None, 0, 1])
+@pytest.mark.parametrize("reset", [False, True])
+@pytest.mark.parametrize("measure_f", [qml.counts, qml.probs, qml.sample, qml.expval, qml.var])
+@pytest.mark.parametrize("meas_obj", [qml.PauliX(1), [0], [0, 1], "mcm"])
+def test_tf(shots, postselect, reset, measure_f, meas_obj):
+    """Test that native MCM circuits are executed correctly with TensorFlow"""
+    if measure_f in (qml.var, qml.expval) and isinstance(meas_obj, list):
+        pytest.skip("Can't use wires with var or expval")
+
+    import tensorflow as tf
+
+    dev = get_device(shots=shots)
+    param = tf.Variable(np.pi / 3)
+
+    @qml.qnode(dev)
+    def func(x):
+        qml.RX(x, 0)
+        m0 = qml.measure(0, reset=reset)
+        qml.RX(0.5 * x, 1)
+        m1 = qml.measure(1, postselect=postselect)
+        qml.cond((m0 + m1) == 2, qml.RY)(2.0 * x, 0)
+        m2 = qml.measure(0)
+
+        measurement_key = "wires" if isinstance(meas_obj, list) else "op"
+        measurement_value = m2 if isinstance(meas_obj, str) else meas_obj
+        return measure_f(**{measurement_key: measurement_value})
+
+    func1 = func
+    func2 = qml.defer_measurements(func)
+
+    results1 = func1(param)
+    results2 = func2(param)
+
+    validate_measurements(measure_f, shots, results1, results2)
+
+
+@pytest.mark.torch
+@pytest.mark.parametrize("shots", [3000, [3000, 3001]])
+@pytest.mark.parametrize("postselect", [None, 0, 1])
+@pytest.mark.parametrize("reset", [False, True])
+@pytest.mark.parametrize("measure_f", [qml.counts, qml.probs, qml.sample, qml.expval, qml.var])
+@pytest.mark.parametrize("meas_obj", [qml.PauliX(1), [0], [0, 1], "mcm"])
+def test_torch(shots, postselect, reset, measure_f, meas_obj):
+    """Test that native MCM circuits are executed correctly with Torch"""
+    if measure_f in (qml.var, qml.expval) and isinstance(meas_obj, list):
+        pytest.skip("Can't use wires with var or expval")
+
+    import torch
+
+    dev = get_device(shots=shots)
+    param = torch.tensor(np.pi / 3)
+
+    @qml.qnode(dev)
+    def func(x):
+        qml.RX(x, 0)
+        m0 = qml.measure(0, reset=reset)
+        qml.RX(0.5 * x, 1)
+        m1 = qml.measure(1, postselect=postselect)
+        qml.cond((m0 + m1) == 2, qml.RY)(2.0 * x, 0)
+        m2 = qml.measure(0)
+
+        measurement_key = "wires" if isinstance(meas_obj, list) else "op"
+        measurement_value = m2 if isinstance(meas_obj, str) else meas_obj
+        return measure_f(**{measurement_key: measurement_value})
+
+    func1 = func
+    func2 = qml.defer_measurements(func)
+
+    results1 = func1(param)
+    results2 = func2(param)
+
+    validate_measurements(measure_f, shots, results1, results2)
+
+
+@pytest.mark.jax
+@pytest.mark.parametrize("shots", [3000, [3000, 3001]])
+@pytest.mark.parametrize("postselect", [None, 0, 1])
+@pytest.mark.parametrize("reset", [False, True])
+@pytest.mark.parametrize("measure_f", [qml.counts, qml.probs, qml.sample, qml.expval, qml.var])
+@pytest.mark.parametrize("meas_obj", [qml.PauliX(1), [0], [0, 1], "mcm"])
+def test_jax(shots, postselect, reset, measure_f, meas_obj):
+    """Test that native MCM circuits are executed correctly with Jax"""
+    if measure_f in (qml.var, qml.expval) and isinstance(meas_obj, list):
+        pytest.skip("Can't use wires with var or expval")
+
+    import jax.numpy as jnp
+
+    dev = get_device(shots=shots)
+    param = jnp.array(np.pi / 3)
+
+    @qml.qnode(dev)
+    def func(x):
+        qml.RX(x, 0)
+        m0 = qml.measure(0, reset=reset)
+        qml.RX(0.5 * x, 1)
+        m1 = qml.measure(1, postselect=postselect)
+        qml.cond((m0 + m1) == 2, qml.RY)(2.0 * x, 0)
+        m2 = qml.measure(0)
+
+        measurement_key = "wires" if isinstance(meas_obj, list) else "op"
+        measurement_value = m2 if isinstance(meas_obj, str) else meas_obj
+        return measure_f(**{measurement_key: measurement_value})
+
+    func1 = func
+    func2 = qml.defer_measurements(func)
+
+    results1 = func1(param)
+    results2 = func2(param)
+
+    validate_measurements(measure_f, shots, results1, results2)
+
+
 @pytest.mark.parametrize("shots", [None, 5000, [5000, 5001]])
 @pytest.mark.parametrize("postselect", [None, 0, 1])
 @pytest.mark.parametrize("reset", [False, True])

--- a/tests/math/test_functions.py
+++ b/tests/math/test_functions.py
@@ -1369,6 +1369,25 @@ def test_shape(shape, interface, create_array):
     assert fn.shape(t) == shape
 
 
+@pytest.mark.parametrize(
+    "interface,create_array",
+    [
+        ("sequence", lambda shape: np.empty(shape).tolist()),
+        ("autograd", np.empty),
+        ("torch", torch.empty),
+        ("jax", jnp.ones),
+        ("tf", tf.ones),
+    ],
+)
+@pytest.mark.parametrize("shape", shape_test_data)
+def test_ravel(shape, interface, create_array):
+    """Test that ravel works as expected"""
+    # pylint: disable=unused-argument
+    t = create_array(shape)
+    ravelled_t = fn.ravel(t)
+    assert fn.shape(ravelled_t) == (fn.size(t),)
+
+
 @pytest.mark.parametrize("interface", ["numpy", "autograd", "jax", "torch", "tensorflow"])
 def test_shape_and_ndim_deep(interface):
     val = [[fn.asarray(1, like=interface)]]


### PR DESCRIPTION
**Context:**
As name says. `qml.sample` and `qml.var` were not working when using certain interfaces due to the usage of numpy functions rather than qml.math functions.

**Description of the Change:**
* Update `dynamic_one_shot` to use `qml.math` instead of `numpy`.
* Add `qml.math.ravel` dispatch for tensorflow. This was needed for an earlier iteration for this bug fix. It is no longer being used, but is still a useful function to have.
* Updated the casting/conversion rules used when computing variance with `dynamic_one_shot`. This added a 1-10x speedup for all interfaces, with the biggest speedup for tensorflow and torch, and the smallest speedup for jax.

**Benefits:**
Better support for interfaces with `dynamic_one_shot`.

**Possible Drawbacks:**

**Related GitHub Issues:**
#5442 
