### PR TITLE
Fix links in news/new_opmath.rst

### DIFF
--- a/doc/code/qml.rst
+++ b/doc/code/qml.rst
@@ -7,4 +7,3 @@ qml
     :no-heading:
     :include-all-objects:
     :skip: Version, SimpleSpec, plugin_devices, plugin_converters, default_config, reload, version_info, defaultdict
-    :include: ~.ops.qubit.Hamiltonian

--- a/doc/code/qml.rst
+++ b/doc/code/qml.rst
@@ -7,3 +7,5 @@ qml
     :no-heading:
     :include-all-objects:
     :skip: Version, SimpleSpec, plugin_devices, plugin_converters, default_config, reload, version_info, defaultdict
+
+    ~Hamiltonian

--- a/doc/code/qml.rst
+++ b/doc/code/qml.rst
@@ -7,5 +7,4 @@ qml
     :no-heading:
     :include-all-objects:
     :skip: Version, SimpleSpec, plugin_devices, plugin_converters, default_config, reload, version_info, defaultdict
-
-    ~Hamiltonian
+    :include: ~.ops.qubit.Hamiltonian

--- a/doc/news/new_opmath.rst
+++ b/doc/news/new_opmath.rst
@@ -40,13 +40,13 @@ Summary of the update
 * The underlying system for performing arithmetic with operators has been changed. Arithmetic can be carried out using
   standard Python operations like ``+``, ``*`` and ``@`` or via arithmetic functions located in :mod:`~.op_math`.
 
-* You can now easily access Pauli operators via :class:`~.I`, :class:`~.X`, :class:`~.Y`, and :class:`~.Z`.
+* You can now easily access Pauli operators via :class:`~.pennylane.I`, :class:`~.pennylane.X`, :class:`~.pennylane.Y`, and :class:`~.pennylane.Z`.
 
   >>> from pennylane import I, X, Y, Z
   >>> X(0)
   X(0)
 
-  The original long-form names :class:`~.Identity`, :class:`~.PauliX`, :class:`~.PauliY`, and :class:`~.PauliZ` remain available and are functionally equivalent to ``I``, ``X``, ``Y``, and ``Z``, but
+  The original long-form names :class:`~.Identity`, :class:`~.PauliX`, :class:`~.PauliY`, and :class:`~.PauliZ` remain available and are functionally equivalent to :class:`~.pennylane.I`, :class:`~.pennylane.X`, :class:`~.pennylane.Y`, and :class:`~.pennylane.Z`, but
   use of the short-form names is now recommended.
 
 * Operators in PennyLane can have a backend Pauli representation, which can be used to perform faster operator arithmetic. Now, the Pauli
@@ -60,7 +60,7 @@ Summary of the update
   >>> type(op.pauli_rep)
   pennylane.pauli.pauli_arithmetic.PauliSentence
 
-  You can transform the ``PauliSentence`` back to a suitable ``Operator`` via the :meth:`~pennylane.pauli.PauliSentence.operation` or :meth:`~pennylane.pauli.PauliSentence.hamiltonian`   method.
+  You can transform the :class:`~.pennylane.pauli.PauliSentence` back to a suitable :class:`~.pennylane.operation.Operator` via the :meth:`~pennylane.pauli.PauliSentence.operation` or :meth:`~pennylane.pauli.PauliSentence.hamiltonian`   method.
 
   >>> op.pauli_rep.operation()
   X(0) + Y(0)
@@ -111,8 +111,8 @@ Summary of the update
     +--------------------------------------------+----------------------+---------------------------+
 
 
-    The three main new opmath classes :class:`~.pennylane.ops.SProd`, :class:`~.pennylane.ops.Prod`, and :class:`~.pennylane.ops.Sum` have already been around for a while.
-    E.g., :func:`~.pennylane.dot` has always returned a :class:`~.pennylane.ops.Sum` instance.
+    The three main new opmath classes :class:`~.pennylane.ops.op_math.SProd`, :class:`~.pennylane.ops.op_math.Prod`, and :class:`~.pennylane.ops.op_math.Sum` have already been around for a while.
+    E.g., :func:`~.pennylane.dot` has always returned a :class:`~.pennylane.ops.op_math.Sum` instance.
 
     **Usage**
 
@@ -161,8 +161,8 @@ Summary of the update
 
     **qml.Hamiltonian**
 
-    The legacy classes :class:`~.pennylane.operation.Tensor` and :class:`~pennylane.Hamiltonian` will soon be deprecated.
-    :class:`~.ops.op_math.LinearCombination` offers the same API as :class:`~pennylane.Hamiltonian` but works well with new opmath classes.
+    The legacy classes :class:`~.pennylane.operation.Tensor` and :class:`~.pennylane.Hamiltonian` will soon be deprecated.
+    :class:`~.ops.op_math.LinearCombination` offers the same API as :class:`~.pennylane.Hamiltonian` but works well with new opmath classes.
 
     Depending on whether or not new opmath is active, ``qml.Hamiltonian`` will return either of the two classes.
 

--- a/doc/news/new_opmath.rst
+++ b/doc/news/new_opmath.rst
@@ -60,7 +60,7 @@ Summary of the update
   >>> type(op.pauli_rep)
   pennylane.pauli.pauli_arithmetic.PauliSentence
 
-  You can transform the ``PauliSentence`` back to a suitable ``Operator`` via the :py:method:`~pennylane.pauli.PauliSentence.operation` or :py:method:`~pennylane.pauli.PauliSentence.hamiltonian`   method.
+  You can transform the ``PauliSentence`` back to a suitable ``Operator`` via the :meth:`~pennylane.pauli.PauliSentence.operation` or :meth:`~pennylane.pauli.PauliSentence.hamiltonian`   method.
 
   >>> op.pauli_rep.operation()
   X(0) + Y(0)

--- a/doc/news/new_opmath.rst
+++ b/doc/news/new_opmath.rst
@@ -60,7 +60,7 @@ Summary of the update
   >>> type(op.pauli_rep)
   pennylane.pauli.pauli_arithmetic.PauliSentence
 
-  You can transform the ``PauliSentence`` back to a suitable ``Operator`` via the :meth:`~.pennylane.ops.PauliSentence.operation` or :meth:`~.pennylane.ops.PauliSentence.hamiltonian` method.
+  You can transform the ``PauliSentence`` back to a suitable ``Operator`` via the :py:method:`~pennylane.pauli.PauliSentence.operation` or :py:method:`~pennylane.pauli.PauliSentence.hamiltonian`   method.
 
   >>> op.pauli_rep.operation()
   X(0) + Y(0)
@@ -161,8 +161,8 @@ Summary of the update
 
     **qml.Hamiltonian**
 
-    The legacy classes :class:`~.pennylane.operation.Tensor` and :class:`~.Hamiltonian` will soon be deprecated.
-    :class:`~.ops.LinearCombination` offers the same API as :class:`~.Hamiltonian` but works well with new opmath classes.
+    The legacy classes :class:`~.pennylane.operation.Tensor` and :class:`~pennylane.Hamiltonian` will soon be deprecated.
+    :class:`~.ops.op_math.LinearCombination` offers the same API as :class:`~pennylane.Hamiltonian` but works well with new opmath classes.
 
     Depending on whether or not new opmath is active, ``qml.Hamiltonian`` will return either of the two classes.
 
@@ -231,7 +231,7 @@ To help identify a fix, select the option below that describes your situation.
     :title: Sharp bits about the qml.Hamiltonian dispatch
     :href: sharp-bits-hamiltonian
 
-    One of the reasons that :class:`~.ops.LinearCombination` exists is that the old Hamiltonian class is not compatible with new opmath tensor products.
+    One of the reasons that :class:`~.ops.op_math.LinearCombination` exists is that the old Hamiltonian class is not compatible with new opmath tensor products.
     We can try to instantiate an old ``qml.ops.Hamiltonian`` class with a ``X(0) @ X(1)`` tensor product, which returns a :class:`~.pennylane.ops.Prod` instance with new opmath enabled.
 
     >>> qml.operation.active_new_opmath() # confirm opmath is active (by default)
@@ -245,7 +245,7 @@ To help identify a fix, select the option below that describes your situation.
     >>> qml.Hamiltonian([0.5], [X(0) @ X(1)])
     0.5 * (X(0) @ X(1))
 
-    The API of :class:`~.ops.LinearCombination` is identical to that of :class:`~.Hamiltonian`. We can group observables or simplify upon initialization.
+    The API of :class:`~.ops.op_math.LinearCombination` is identical to that of :class:`~.Hamiltonian`. We can group observables or simplify upon initialization.
 
     >>> H1 = qml.Hamiltonian([0.5, 0.5, 0.5], [X(0) @ X(1), X(0), Y(0)], grouping_type="qwc", simplify=True)
     >>> H2 = qml.ops.LinearCombination([0.5, 0.5, 0.5], [X(0) @ X(1), X(0), Y(0)], grouping_type="qwc", simplify=True)
@@ -356,8 +356,8 @@ To help identify a fix, select the option below that describes your situation.
             assert isinstance(legacy_ham_example, qml.Hamiltonian) # True because we are in legacy opmath context
             assert not isinstance(legacy_ham_example, qml.ops.LinearCombination) # True
     
-    For all that, keep in mind that ``qml.Hamiltonian`` points to :class:`~Hamiltonian` and :class:`LinearCombination` depending on the status of ``qml.operation.active_new_opmath()``.
-    So if you want to test something specifically for the old :class:`~Hamiltonian`` class, use ``qml.ops.Hamiltonian`` instead.
+    For all that, keep in mind that ``qml.Hamiltonian`` points to :class:`~pennylane.Hamiltonian` and :class:`LinearCombination` depending on the status of ``qml.operation.active_new_opmath()``.
+    So if you want to test something specifically for the old :class:`~pennylane.Hamiltonian`` class, use ``qml.ops.Hamiltonian`` instead.
 
 .. details::
     :title: Sharp bits about the nesting structure of new opmath instances

--- a/doc/news/new_opmath.rst
+++ b/doc/news/new_opmath.rst
@@ -40,13 +40,13 @@ Summary of the update
 * The underlying system for performing arithmetic with operators has been changed. Arithmetic can be carried out using
   standard Python operations like ``+``, ``*`` and ``@`` or via arithmetic functions located in :mod:`~.op_math`.
 
-* You can now easily access Pauli operators via :const:`~.pennylane.I`, :const:`~.pennylane.X`, :const:`~.pennylane.Y`, and :const:`~.pennylane.Z`.
+* You can now easily access Pauli operators via :obj:`~.pennylane.I`, :obj:`~.pennylane.X`, :obj:`~.pennylane.Y`, and :obj:`~.pennylane.Z`.
 
   >>> from pennylane import I, X, Y, Z
   >>> X(0)
   X(0)
 
-  The original long-form names :class:`~.Identity`, :class:`~.PauliX`, :class:`~.PauliY`, and :class:`~.PauliZ` remain available and are functionally equivalent to :const:`~.pennylane.I`, :const:`~.pennylane.X`, :const:`~.pennylane.Y`, and :const:`~.pennylane.Z`, but
+  The original long-form names :class:`~.Identity`, :class:`~.PauliX`, :class:`~.PauliY`, and :class:`~.PauliZ` remain available and are functionally equivalent to :obj:`~.pennylane.I`, :obj:`~.pennylane.X`, :obj:`~.pennylane.Y`, and :obj:`~.pennylane.Z`, but
   use of the short-form names is now recommended.
 
 * Operators in PennyLane can have a backend Pauli representation, which can be used to perform faster operator arithmetic. Now, the Pauli

--- a/doc/news/new_opmath.rst
+++ b/doc/news/new_opmath.rst
@@ -40,13 +40,13 @@ Summary of the update
 * The underlying system for performing arithmetic with operators has been changed. Arithmetic can be carried out using
   standard Python operations like ``+``, ``*`` and ``@`` or via arithmetic functions located in :mod:`~.op_math`.
 
-* You can now easily access Pauli operators via :class:`~.pennylane.I`, :class:`~.pennylane.X`, :class:`~.pennylane.Y`, and :class:`~.pennylane.Z`.
+* You can now easily access Pauli operators via :const:`~.pennylane.I`, :const:`~.pennylane.X`, :const:`~.pennylane.Y`, and :const:`~.pennylane.Z`.
 
   >>> from pennylane import I, X, Y, Z
   >>> X(0)
   X(0)
 
-  The original long-form names :class:`~.Identity`, :class:`~.PauliX`, :class:`~.PauliY`, and :class:`~.PauliZ` remain available and are functionally equivalent to :class:`~.pennylane.I`, :class:`~.pennylane.X`, :class:`~.pennylane.Y`, and :class:`~.pennylane.Z`, but
+  The original long-form names :class:`~.Identity`, :class:`~.PauliX`, :class:`~.PauliY`, and :class:`~.PauliZ` remain available and are functionally equivalent to :const:`~.pennylane.I`, :const:`~.pennylane.X`, :const:`~.pennylane.Y`, and :const:`~.pennylane.Z`, but
   use of the short-form names is now recommended.
 
 * Operators in PennyLane can have a backend Pauli representation, which can be used to perform faster operator arithmetic. Now, the Pauli

--- a/doc/releases/changelog-0.36.0.md
+++ b/doc/releases/changelog-0.36.0.md
@@ -257,6 +257,10 @@
 
 <h4>Updated operators</h4>
 
+* A summary of all changes has been added in the "Updated Operators" page in the new "Release news" section in the docs.
+  [(#5483)](https://github.com/PennyLaneAI/pennylane/pull/5483)
+  [(#5636)](https://github.com/PennyLaneAI/pennylane/pull/5636)
+
 * `qml.ops.Sum` now supports storing grouping information. Grouping type and method can be
   specified during construction using the `grouping_type` and `method` keyword arguments of
   `qml.dot`, `qml.sum`, or `qml.ops.Sum`. The grouping indices are stored in `Sum.grouping_indices`.
@@ -354,10 +358,6 @@
 
 * `LinearCombination` and `Sum` now accept `_grouping_indices` on initialization.
   [(#5524)](https://github.com/PennyLaneAI/pennylane/pull/5524)
-
-* A "Updated Operators" page has been added to the new "Release news" section in the docs.
-  [(#5483)](https://github.com/PennyLaneAI/pennylane/pull/5483)
-  [(#5636)](https://github.com/PennyLaneAI/pennylane/pull/5636)
 
 <h4>Mid-circuit measurements and dynamic circuits</h4>
 

--- a/doc/releases/changelog-0.36.0.md
+++ b/doc/releases/changelog-0.36.0.md
@@ -257,10 +257,6 @@
 
 <h4>Updated operators</h4>
 
-* A summary of all changes has been added in the "Updated Operators" page in the new "Release news" section in the docs.
-  [(#5483)](https://github.com/PennyLaneAI/pennylane/pull/5483)
-  [(#5636)](https://github.com/PennyLaneAI/pennylane/pull/5636)
-
 * `qml.ops.Sum` now supports storing grouping information. Grouping type and method can be
   specified during construction using the `grouping_type` and `method` keyword arguments of
   `qml.dot`, `qml.sum`, or `qml.ops.Sum`. The grouping indices are stored in `Sum.grouping_indices`.
@@ -553,6 +549,10 @@
 * A new *Release news* section has been added to the table of contents, containing release notes,
   deprecations, and other pages focusing on recent changes.
   [(#5548)](https://github.com/PennyLaneAI/pennylane/pull/5548)
+
+* A summary of all changes has been added in the "Updated Operators" page in the new "Release news" section in the docs.
+  [(#5483)](https://github.com/PennyLaneAI/pennylane/pull/5483)
+  [(#5636)](https://github.com/PennyLaneAI/pennylane/pull/5636)
 
 <h3>Bug fixes 🐛</h3>
 

--- a/doc/releases/changelog-0.36.0.md
+++ b/doc/releases/changelog-0.36.0.md
@@ -355,6 +355,10 @@
 * `LinearCombination` and `Sum` now accept `_grouping_indices` on initialization.
   [(#5524)](https://github.com/PennyLaneAI/pennylane/pull/5524)
 
+* A "Updated Operators" page has been added to the new "Release news" section in the docs.
+  [(#5483)](https://github.com/PennyLaneAI/pennylane/pull/5483)
+  [(#5636)](https://github.com/PennyLaneAI/pennylane/pull/5636)
+
 <h4>Mid-circuit measurements and dynamic circuits</h4>
 
 * The `QubitDevice` class and children classes support the `dynamic_one_shot` transform provided that they support `MidMeasureMP` operations natively.


### PR DESCRIPTION
Some links in new opmath page did not work. Used https://github.com/bskinn/sphobjinv to identify the right objects.

The links to `Hamiltonian` class dont work because in `latest` there is no rendered version of that doc