### PR TITLE
Rename values for `method` kwarg in `TrotterProduct` class

### DIFF
--- a/doc/releases/changelog-0.36.0.md
+++ b/doc/releases/changelog-0.36.0.md
@@ -690,6 +690,9 @@
   between `op.has_diagonalzing_gates` and `op.diagonalizing_gates()`
   [(#5603)](https://github.com/PennyLaneAI/pennylane/pull/5603)
 
+* Updated the `method` kwarg of `qml.TrotterProduct().error()` to be more clear that we are computing upper-bounds.
+  [(#5637)](https://github.com/PennyLaneAI/pennylane/pull/5637)
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane/templates/subroutines/trotter.py
+++ b/pennylane/templates/subroutines/trotter.py
@@ -144,13 +144,13 @@ class TrotterProduct(ErrorOperation):
 
         An *upper-bound* for the error in approximating time-evolution using this operator can be
         computed by calling :func:`~.TrotterProduct.error()`. It is computed using two different methods; the
-        "one-norm" scaling method and the "commutator" scaling method. (see `Childs et al. (2021) <https://arxiv.org/abs/1912.08854>`_)
+        "one-norm-bound" scaling method and the "commutator-bound" scaling method. (see `Childs et al. (2021) <https://arxiv.org/abs/1912.08854>`_)
 
         >>> hamiltonian = qml.dot([1.0, 0.5, -0.25], [qml.X(0), qml.Y(0), qml.Z(0)])
         >>> op = qml.TrotterProduct(hamiltonian, time=0.01, order=2)
-        >>> op.error(method="one-norm")
+        >>> op.error(method="one-norm-bound")
         SpectralNormError(8.039062500000003e-06)
-        >>> op.error(method="commutator")
+        >>> op.error(method="commutator-bound")
         SpectralNormError(6.166666666666668e-06)
 
         This operation is similar to the :class:`~.ApproxTimeEvolution`. One can recover the behaviour
@@ -237,7 +237,7 @@ class TrotterProduct(ErrorOperation):
         return self
 
     def error(
-        self, method: str = "commutator", fast: bool = True
+        self, method: str = "commutator-bound", fast: bool = True
     ):  # pylint: disable=arguments-differ
         # pylint: disable=protected-access
         r"""Compute an *upper-bound* on the spectral norm error for approximating the
@@ -253,26 +253,26 @@ class TrotterProduct(ErrorOperation):
 
         **Example:**
 
-        The "one-norm" error bound can be computed by passing the kwarg :code:`method="one-norm"`, and
+        The "one-norm" error bound can be computed by passing the kwarg :code:`method="one-norm-bound"`, and
         is defined according to Section 2.3 (lemma 6, equation 22 and 23) of
         `Childs et al. (2021) <https://arxiv.org/abs/1912.08854>`_.
 
         >>> hamiltonian = qml.dot([1.0, 0.5, -0.25], [qml.X(0), qml.Y(0), qml.Z(0)])
         >>> op = qml.TrotterProduct(hamiltonian, time=0.01, order=2)
-        >>> op.error(method="one-norm")
+        >>> op.error(method="one-norm-bound")
         SpectralNormError(8.039062500000003e-06)
 
-        The "commutator" error bound can be computed by passing the kwarg :code:`method="commutator"`, and
+        The "commutator" error bound can be computed by passing the kwarg :code:`method="commutator-bound"`, and
         is defined according to Appendix C (equation 189) `Childs et al. (2021) <https://arxiv.org/abs/1912.08854>`_.
 
         >>> hamiltonian = qml.dot([1.0, 0.5, -0.25], [qml.X(0), qml.Y(0), qml.Z(0)])
         >>> op = qml.TrotterProduct(hamiltonian, time=0.01, order=2)
-        >>> op.error(method="commutator")
+        >>> op.error(method="commutator-bound")
         SpectralNormError(6.166666666666668e-06)
 
         Args:
-            method (str, optional): Options include "one-norm" and "commutator" and specify the
-                method with which the error is computed. Defaults to "commutator".
+            method (str, optional): Options include "one-norm-bound" and "commutator-bound" and specify the
+                method with which the error is computed. Defaults to "commutator-bound".
             fast (bool, optional): Uses more approximations to speed up computation. Defaults to True.
 
         Raises:
@@ -293,10 +293,10 @@ class TrotterProduct(ErrorOperation):
             )
 
         terms = base_unitary.operands
-        if method == "one-norm":
+        if method == "one-norm-bound":
             return SpectralNormError(qml.resource.error._one_norm_error(terms, t, p, n, fast=fast))
 
-        if method == "commutator":
+        if method == "commutator-bound":
             return SpectralNormError(
                 qml.resource.error._commutator_error(terms, t, p, n, fast=fast)
             )

--- a/tests/templates/test_subroutines/test_trotter.py
+++ b/tests/templates/test_subroutines/test_trotter.py
@@ -513,8 +513,8 @@ class TestError:
         expected_error = ((10**5 + 1) / 120) * (0.1**5)
 
         for computed_error in (
-            op.error(method="one-norm"),
-            op.error(method="one-norm", fast=False),
+            op.error(method="one-norm-bound"),
+            op.error(method="one-norm-bound", fast=False),
         ):
             assert isinstance(computed_error, SpectralNormError)
             assert qnp.isclose(computed_error.error, expected_error)
@@ -525,15 +525,15 @@ class TestError:
         expected_error = (32 / 3) * (0.05**3) * (1 / 100)
 
         for computed_error in (
-            op.error(method="commutator"),
-            op.error(method="commutator", fast=False),
+            op.error(method="commutator-bound"),
+            op.error(method="commutator-bound", fast=False),
         ):
             assert isinstance(computed_error, SpectralNormError)
             assert qnp.isclose(computed_error.error, expected_error)
 
     @pytest.mark.all_interfaces
     @pytest.mark.parametrize(
-        "method, expected_error", (("one-norm", 0.001265625), ("commutator", 0.001))
+        "method, expected_error", (("one-norm-bound", 0.001265625), ("commutator-bound", 0.001))
     )
     @pytest.mark.parametrize("interface", ("autograd", "jax", "torch"))
     def test_error_interfaces(self, method, interface, expected_error):


### PR DESCRIPTION
**Context:**
Rename the accepted values for the method keyword argument in the TrotterProduct class to be more verbose. 

**Description of the Change:**
Change: 
- `method="one-norm"` --> `method="one-norm-bound"`
- `method="commutator"` --> `method="commutator-bound"`