### PR TITLE
Fix error raised when taking dot of a single Tensor

### DIFF
--- a/pennylane/ops/functions/dot.py
+++ b/pennylane/ops/functions/dot.py
@@ -132,16 +132,16 @@ def dot(
         :ref:`Pauli Graph Colouring<graph_colouring>` and :func:`~pennylane.pauli.group_observables`.
     """
 
-    if len(coeffs) != len(ops):
-        raise ValueError("Number of coefficients and operators does not match.")
-    if len(coeffs) == 0 and len(ops) == 0:
-        raise ValueError("Cannot compute the dot product of an empty sequence.")
-
     for t in (Operator, PauliWord, PauliSentence):
         if isinstance(ops, t):
             raise ValueError(
                 f"ops must be an Iterable of {t.__name__}'s, not a {t.__name__} itself."
             )
+
+    if len(coeffs) != len(ops):
+        raise ValueError("Number of coefficients and operators does not match.")
+    if len(coeffs) == 0 and len(ops) == 0:
+        raise ValueError("Cannot compute the dot product of an empty sequence.")
 
     if any(callable(c) for c in coeffs):
         return ParametrizedHamiltonian(coeffs, ops)


### PR DESCRIPTION
When `ops` is a `Tensor`, this line:
```
if len(coeffs) != len(ops)
```
raises an error because `Tensor` does not have `len`. Moving the `isinstance` checks for `ops` to the beginning of the function.