### PR TITLE
[skip ci] corrected openshell warnings

### DIFF
--- a/pennylane/qchem/hamiltonian.py
+++ b/pennylane/qchem/hamiltonian.py
@@ -107,6 +107,11 @@ def electron_integrals(mol, core=None, active=None):
         Returns:
             tuple[array[float]]: 1D tuple containing core constant, one- and two-electron integrals
         """
+        if mol.n_electrons % 2 == 1 or mol.mult != 1:
+            raise ValueError(
+                "Openshell systems are not supported. Change the charge or spin multiplicity of the molecule."
+            )
+
         _, coeffs, _, h_core, repulsion_tensor = scf(mol)(*args)
         one = qml.math.einsum("qr,rs,st->qt", coeffs.T, h_core, coeffs)
         two = qml.math.swapaxes(

--- a/pennylane/qchem/hartree_fock.py
+++ b/pennylane/qchem/hartree_fock.py
@@ -116,6 +116,11 @@ def scf(mol, n_steps=50, tol=1e-8):
             tuple(array[float]): eigenvalues of the Fock matrix, molecular orbital coefficients,
             Fock matrix, core matrix
         """
+        if mol.n_electrons % 2 == 1 or mol.mult != 1:
+            raise ValueError(
+                "Openshell systems are not supported. Change the charge or spin multiplicity of the molecule."
+            )
+
         basis_functions = mol.basis_set
         charges = mol.nuclear_charges
         r = mol.coordinates

--- a/pennylane/qchem/molecule.py
+++ b/pennylane/qchem/molecule.py
@@ -107,12 +107,6 @@ class Molecule:
 
         self.n_electrons = sum(self.nuclear_charges) - self.charge
 
-        if self.n_electrons % 2 == 1 or self.mult != 1:
-            raise ValueError(
-                "Openshell systems are not supported. Change the charge or spin "
-                "multiplicity of the molecule."
-            )
-
         if l is None:
             l = [i[0] for i in self.basis_data]
 

--- a/pennylane/qchem/openfermion_obs.py
+++ b/pennylane/qchem/openfermion_obs.py
@@ -24,6 +24,7 @@ import pennylane as qml
 from pennylane.operation import active_new_opmath
 from pennylane.pauli.utils import simplify
 from pennylane.qchem.molecule import Molecule
+from .basis_data import atomic_numbers
 
 # Bohr-Angstrom correlation coefficient (https://physics.nist.gov/cgi-bin/cuu/Value?bohrrada0)
 bohr_angs = 0.529177210903
@@ -1032,11 +1033,16 @@ def _molecular_hamiltonian(
             raise ValueError(
                 "Only 'jordan_wigner' mapping is supported for the differentiable workflow."
             )
-        if mult != 1:
+        nuclear_charges = [atomic_numbers[s] for s in symbols]
+
+        n_electrons = sum(nuclear_charges) - charge
+
+        if n_electrons % 2 == 1 or mult != 1:
             raise ValueError(
                 "Openshell systems are not supported for the differentiable workflow. Use "
                 "`method = 'pyscf'` or change the charge or spin multiplicity of the molecule."
             )
+
         if args is None and isinstance(geometry_dhf, qml.numpy.tensor):
             geometry_dhf.requires_grad = False
         mol = qml.qchem.Molecule(

--- a/tests/qchem/of_tests/test_molecular_hamiltonian.py
+++ b/tests/qchem/of_tests/test_molecular_hamiltonian.py
@@ -116,6 +116,8 @@ def test_building_hamiltonian(
     ),
     [
         (0, 1, "pyscf", 2, 2, "jordan_WIGNER"),
+        (1, 2, "pyscf", 3, 4, "BRAVYI_kitaev"),
+        (-1, 2, "pyscf", 1, 2, "jordan_WIGNER"),
         (2, 1, "pyscf", 2, 2, "BRAVYI_kitaev"),
     ],
 )
@@ -661,6 +663,10 @@ def test_diff_hamiltonian_error_molecule_class(symbols, geometry):
     ):
         qchem.molecular_hamiltonian(molecule, method="psi4")
 
+    with pytest.raises(ValueError, match="Openshell systems are not supported"):
+
+        qchem.molecular_hamiltonian(symbols, geometry, mult=3)
+
 
 @pytest.mark.parametrize(
     ("symbols", "geometry", "method", "args"),
@@ -778,8 +784,17 @@ def test_molecule_as_kwargs(tmpdir):
     keyword argument
     """
 
-    molecule = qchem.Molecule(test_symbols, test_coordinates, )
-    built_hamiltonian, qubits = qchem.molecular_hamiltonian(molecule=molecule, method="pyscf", active_electrons=2, active_orbitals=2, outpath=tmpdir.strpath)
+    molecule = qchem.Molecule(
+        test_symbols,
+        test_coordinates,
+    )
+    built_hamiltonian, qubits = qchem.molecular_hamiltonian(
+        molecule=molecule,
+        method="pyscf",
+        active_electrons=2,
+        active_orbitals=2,
+        outpath=tmpdir.strpath,
+    )
 
     if active_new_opmath():
         assert not isinstance(built_hamiltonian, qml.Hamiltonian)

--- a/tests/qchem/test_hamiltonians.py
+++ b/tests/qchem/test_hamiltonians.py
@@ -107,6 +107,16 @@ def test_electron_integrals(symbols, geometry, core, active, e_core, one_ref, tw
     assert np.allclose(two, two_ref)
 
 
+def test_electron_integrals_openshell_warning():
+    r"""Test that electron_integrals raises the error when openshell molecule is provided."""
+    symbols = ["H", "H", "H"]
+    geometry = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, 2.0]], requires_grad=False)
+    mol = qchem.Molecule(symbols, geometry)
+
+    with pytest.raises(ValueError, match="Openshell systems are not supported."):
+        qchem.electron_integrals(mol)()
+
+
 @pytest.mark.parametrize(
     ("symbols", "geometry", "alpha", "h_ref"),
     [

--- a/tests/qchem/test_hartree_fock.py
+++ b/tests/qchem/test_hartree_fock.py
@@ -79,6 +79,16 @@ def test_scf(symbols, geometry, v_fock, coeffs, fock_matrix, h_core, repulsion_t
     assert np.allclose(e, repulsion_tensor)
 
 
+def test_scf_openshell_warning():
+    r"""Test that scf raises the error when openshell molecule is provided."""
+    symbols = ["H", "H", "H"]
+    geometry = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, 2.0]], requires_grad=False)
+    mol = qchem.Molecule(symbols, geometry)
+
+    with pytest.raises(ValueError, match="Openshell systems are not supported."):
+        qchem.scf(mol)()
+
+
 @pytest.mark.parametrize(
     ("symbols", "geometry", "charge", "basis_name", "e_ref"),
     [

--- a/tests/qchem/test_molecule.py
+++ b/tests/qchem/test_molecule.py
@@ -47,17 +47,6 @@ class TestMolecule:
             qchem.Molecule(symbols, geometry, basis_name="6-3_1_g")
 
     @pytest.mark.parametrize(
-        ("symbols", "geometry", "charge", "mult"),
-        [
-            (["H", "He"], np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]]), 0, 2),
-        ],
-    )
-    def test_openshell_error(self, symbols, geometry, charge, mult):
-        r"""Test that an error is raised if the molecule has unpaired electrons."""
-        with pytest.raises(ValueError, match="Openshell systems are not supported"):
-            qchem.Molecule(symbols, geometry, charge=charge, mult=mult)
-
-    @pytest.mark.parametrize(
         ("symbols", "geometry"),
         [
             (["H", "Og"], np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]])),


### PR DESCRIPTION

**Context:**
Changes openshell warnings.

**Description of the Change:**
Changed openshell warnings to work with new molecular_hamiltonian function

**Benefits:**
molecular_hamiltonian function works with openshell molecules when method is pyscf

**Possible Drawbacks:**

**Related GitHub Issues:**
