### PR TITLE
Support multiple measurements and shot vectors in `param_shift(... broadcast=True)`

### DIFF
--- a/pennylane/gradients/gradient_transform.py
+++ b/pennylane/gradients/gradient_transform.py
@@ -277,7 +277,7 @@ def _no_trainable_grad(tape):
 
 def _swap_first_two_axes(grads, first_axis_size, second_axis_size, squeeze=True):
     """Transpose the first two axes of an iterable of iterables, returning
-    a tuple of tuples."""
+    a tuple of tuples. Tuple version of ``np.moveaxis(grads, 0, 1)``"""
     if first_axis_size == 1 and squeeze:
         return tuple(grads[0][i] for i in range(second_axis_size))
     return tuple(
@@ -288,8 +288,8 @@ def _swap_first_two_axes(grads, first_axis_size, second_axis_size, squeeze=True)
 def _move_first_axis_to_third_pos(
     grads, first_axis_size, second_axis_size, third_axis_size, squeeze=True
 ):
-    """Transpose the first three axes of an iterable of iterables like a tuple of tuples
-    the same way as np.transpose(..., [1, 2, 0]) would do."""
+    """Transpose the first two axes of an iterable of iterables, returning
+    a tuple of tuples. Tuple version of ``np.moveaxis(grads, 0, 2)``"""
     if first_axis_size == 1 and squeeze:
         return tuple(
             tuple(grads[0][i][j] for j in range(third_axis_size)) for i in range(second_axis_size)

--- a/pennylane/gradients/parameter_shift.py
+++ b/pennylane/gradients/parameter_shift.py
@@ -153,7 +153,7 @@ def _single_meas_grad(result, coeffs, unshifted_coeff, r0):
 
     If an unshifted term exists, its contribution is added to the gradient.
     """
-    if isinstance(result, (list, tuple)) and (result == [] or result == ()):
+    if isinstance(result, tuple) and result == ():
         if unshifted_coeff is None:
             raise ValueError(
                 "This gradient component neither has a shifted nor an unshifted component. "
@@ -424,7 +424,7 @@ def expval_param_shift(
                     grads.append(None)
                     continue
                 # The gradient for this parameter is computed from r0 alone.
-                g = _evaluate_gradient(tape_specs, [], data, r0, batch_size)
+                g = _evaluate_gradient(tape_specs, (), data, r0, batch_size)
                 grads.append(g)
                 continue
 


### PR DESCRIPTION
**Context:**
Shot vectors and multiple measurements are currently explicitly not supported when using `param_shift` with the `broadcast=True` option.

In #5666 , a crucial subroutine `_evaluat_gradient` is being prepared to allow for support of these scenarios.

**Description of the Change:**
Allow for shot vectors and/or multiple measurements in `param_shift(..., broadcast=true)`.
Due to the changes in #5666 including unit tests for the relevant subroutines, this PR mostly is concerned with integration tests.

**Benefits:**
Feature parity with `broadcast=False`, allowing faster gradient evaluation.

**Possible Drawbacks:**

**Related GitHub Issues:**
fixes #5598 