### PR TITLE
[BUG] Fix a fermi sentence bug in bravyi_kitaev

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -81,10 +81,14 @@
   with circuits with non-commuting measurements.
   [(#5424)](https://github.com/PennyLaneAI/pennylane/pull/5424)
 
+* A correction is added to `bravyi_kitaev` to call the correct function for a FermiSentence input.
+  [(#5671)](https://github.com/PennyLaneAI/pennylane/pull/5671)
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):
 
 Pietropaolo Frisoni,
+Soran Jahangiri,
 Christina Lee,
 David Wierichs.

--- a/pennylane/fermi/conversion.py
+++ b/pennylane/fermi/conversion.py
@@ -556,7 +556,7 @@ def _(fermi_operator: FermiSentence, n, ps=False, wire_map=None, tol=None):
     qubit_operator = PauliSentence()  # Empty PS as 0 operator to add Pws to
 
     for fw, coeff in fermi_operator.items():
-        fermi_word_as_ps = parity_transform(fw, n, ps=True)
+        fermi_word_as_ps = bravyi_kitaev(fw, n, ps=True)
 
         for pw in fermi_word_as_ps:
             qubit_operator[pw] = qubit_operator[pw] + fermi_word_as_ps[pw] * coeff

--- a/tests/fermi/test_bravyi_kitaev.py
+++ b/tests/fermi/test_bravyi_kitaev.py
@@ -928,6 +928,7 @@ fw1 = FermiWord({(0, 0): "+", (1, 1): "-"})
 fw2 = FermiWord({(0, 0): "+", (1, 0): "-"})
 fw3 = FermiWord({(0, 0): "+", (1, 3): "-", (2, 0): "+", (3, 4): "-"})
 fw4 = FermiWord({})
+fw5 = FermiWord({(0, 3): "+", (1, 2): "-"})
 
 
 def test_empty_fermi_sentence():
@@ -992,6 +993,22 @@ FERMI_AND_PAULI_SENTENCES = [
                 PauliWord({0: "Y", 1: "Z"}): (-0.25 + 0j),
                 PauliWord({}): (-1 + 0j),
                 PauliWord({0: "Z"}): (1 + 0j),
+            }
+        ),
+    ),
+    (
+        FermiSentence({fw1: -2, fw5: 1j}),
+        4,
+        PauliSentence(
+            {
+                PauliWord({0: "X"}): -0.5,
+                PauliWord({0: "X", 1: "Z"}): 0.5,
+                PauliWord({0: "Y"}): 0.5j,
+                PauliWord({0: "Y", 1: "Z"}): -0.5j,
+                PauliWord({1: "Z", 2: "X", 3: "Z"}): -0.25j,
+                PauliWord({1: "Z", 2: "Y", 3: "Z"}): 0.25,
+                PauliWord({2: "X"}): 0.25j,
+                PauliWord({2: "Y"}): -0.25,
             }
         ),
     ),


### PR DESCRIPTION
**Context:**
There is a wrong call in bravyi_kitaev when the input object is FermiSentence, which is only observed for some specific inputs that were not covered by our current tests. The PR fixes the bug and adds an extra test to check the accuracy.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
