### PR TITLE
Make templates valid Pytrees

### DIFF
--- a/pennylane/ops/functions/assert_valid.py
+++ b/pennylane/ops/functions/assert_valid.py
@@ -183,6 +183,7 @@ def _check_pytree(op):
             f"\nFor local testing, try type(op)._unflatten(*op._flatten())"
         )
         raise AssertionError(message) from e
+    assert qml.equal(op, new_op)
     assert op == new_op, "metadata and data must be able to reproduce the original operation"
 
     try:
@@ -193,6 +194,8 @@ def _check_pytree(op):
     unflattened_op = jax.tree_util.tree_unflatten(struct, leaves)
     assert unflattened_op == op, f"op must be a valid pytree. Got {unflattened_op} instead of {op}."
 
+    print(op.data)
+    print(leaves)
     for d1, d2 in zip(op.data, leaves):
         assert qml.math.allclose(
             d1, d2

--- a/pennylane/ops/functions/assert_valid.py
+++ b/pennylane/ops/functions/assert_valid.py
@@ -183,7 +183,6 @@ def _check_pytree(op):
             f"\nFor local testing, try type(op)._unflatten(*op._flatten())"
         )
         raise AssertionError(message) from e
-    assert qml.equal(op, new_op)
     assert op == new_op, "metadata and data must be able to reproduce the original operation"
 
     try:
@@ -194,8 +193,6 @@ def _check_pytree(op):
     unflattened_op = jax.tree_util.tree_unflatten(struct, leaves)
     assert unflattened_op == op, f"op must be a valid pytree. Got {unflattened_op} instead of {op}."
 
-    print(op.data)
-    print(leaves)
     for d1, d2 in zip(op.data, leaves):
         assert qml.math.allclose(
             d1, d2

--- a/pennylane/ops/functions/equal.py
+++ b/pennylane/ops/functions/equal.py
@@ -342,6 +342,7 @@ def _equal_operators(
         # If any new operations are added with arithmetic depth > 0, a new dispatch
         # should be created for them.
         return False
+    print(op1.data, op2.data)
     if not all(
         qml.math.allclose(d1, d2, rtol=rtol, atol=atol) for d1, d2 in zip(op1.data, op2.data)
     ):

--- a/pennylane/ops/functions/equal.py
+++ b/pennylane/ops/functions/equal.py
@@ -342,7 +342,6 @@ def _equal_operators(
         # If any new operations are added with arithmetic depth > 0, a new dispatch
         # should be created for them.
         return False
-    print(op1.data, op2.data)
     if not all(
         qml.math.allclose(d1, d2, rtol=rtol, atol=atol) for d1, d2 in zip(op1.data, op2.data)
     ):

--- a/pennylane/templates/subroutines/amplitude_amplification.py
+++ b/pennylane/templates/subroutines/amplitude_amplification.py
@@ -169,6 +169,8 @@ class AmplitudeAmplification(Operation):
         else:
             for _ in range(iters):
                 ops.append(O)
+                if qml.QueuingManager.recording():
+                    qml.apply(O)
                 ops.append(qml.Reflection(U, np.pi, reflection_wires=reflection_wires))
 
         return ops

--- a/pennylane/templates/subroutines/kupccgsd.py
+++ b/pennylane/templates/subroutines/kupccgsd.py
@@ -205,11 +205,10 @@ class kUpCCGSD(Operation):
     grad_method = None
 
     def _flatten(self):
-        hyperparameters = (
-            ("k", self.hyperparameters["k"]),
-            ("delta_sz", self.hyperparameters["delta_sz"]),
-            # tuple version of init_state is essentially identical, but is hashable
-            ("init_state", tuple(self.hyperparameters["init_state"])),
+
+        # Do not need to flatten s_wires or d_wires because they are derived hyperparameters
+        hyperparameters = tuple(
+            (key, self.hyperparameters[key]) for key in ["k", "delta_sz", "init_state"]
         )
         return self.data, (self.wires, hyperparameters)
 
@@ -242,7 +241,7 @@ class kUpCCGSD(Operation):
             raise ValueError(f"Elements of 'init_state' must be integers; got {init_state.dtype}")
 
         self._hyperparameters = {
-            "init_state": init_state,
+            "init_state": tuple(init_state),
             "s_wires": s_wires,
             "d_wires": d_wires,
             "k": k,

--- a/pennylane/templates/subroutines/qdrift.py
+++ b/pennylane/templates/subroutines/qdrift.py
@@ -199,7 +199,7 @@ class QDrift(Operation):
             "base": hamiltonian,
             "decomposition": decomposition,
         }
-        super().__init__(time, wires=hamiltonian.wires, id=id)
+        super().__init__(*hamiltonian.data, time, wires=hamiltonian.wires, id=id)
 
     def queue(self, context=qml.QueuingManager):
         context.remove(self.hyperparameters["base"])

--- a/pennylane/templates/subroutines/qdrift.py
+++ b/pennylane/templates/subroutines/qdrift.py
@@ -144,6 +144,17 @@ class QDrift(Operation):
 
     """
 
+    def _flatten(self):
+        h = self.hyperparameters["base"]
+        hashable_hyperparameters = tuple(
+            (key, value) for key, value in self.hyperparameters.items() if key != "base"
+        )
+        return (h, self.data[-1]), hashable_hyperparameters
+
+    @classmethod
+    def _unflatten(cls, data, metadata):
+        return cls(*data, **dict(metadata))
+
     def __init__(  # pylint: disable=too-many-arguments
         self, hamiltonian, time, n=1, seed=None, decomposition=None, id=None
     ):
@@ -178,7 +189,7 @@ class QDrift(Operation):
                 "coefficients of the input Hamiltonian."
             )
 
-        if decomposition is None:  # need to do this to allow flatten and _unflatten
+        if decomposition is None:  # need to do this to allow flatten and unflatten
             unwrapped_coeffs = unwrap(coeffs)
             decomposition = _sample_decomposition(unwrapped_coeffs, ops, time, n=n, seed=seed)
 
@@ -194,35 +205,6 @@ class QDrift(Operation):
         context.remove(self.hyperparameters["base"])
         context.append(self)
         return self
-
-    @classmethod
-    def _unflatten(cls, data, metadata):
-        """Recreate an operation from its serialized format.
-
-        Args:
-            data: the trainable component of the operation
-            metadata: the non-trainable component of the operation
-
-        The output of ``Operator._flatten`` and the class type must be sufficient to reconstruct the original
-        operation with ``Operator._unflatten``.
-
-        **Example:**
-
-        >>> op = qml.Rot(1.2, 2.3, 3.4, wires=0)
-        >>> op._flatten()
-        ((1.2, 2.3, 3.4), (<Wires = [0]>, ()))
-        >>> qml.Rot._unflatten(*op._flatten())
-        >>> op = qml.PauliRot(1.2, "XY", wires=(0,1))
-        >>> op._flatten()
-        ((1.2,), (<Wires = [0, 1]>, (('pauli_word', 'XY'),)))
-        >>> op = qml.ctrl(qml.U2(3.4, 4.5, wires="a"), ("b", "c") )
-        >>> type(op)._unflatten(*op._flatten())
-        Controlled(U2(3.4, 4.5, wires=['a']), control_wires=['b', 'c'])
-
-        """
-        hyperparameters_dict = dict(metadata[1])
-        hamiltonian = hyperparameters_dict.pop("base")
-        return cls(hamiltonian, *data, **hyperparameters_dict)
 
     @staticmethod
     def compute_decomposition(*args, **kwargs):  # pylint: disable=unused-argument

--- a/pennylane/templates/subroutines/qmc.py
+++ b/pennylane/templates/subroutines/qmc.py
@@ -363,8 +363,8 @@ class QuantumMonteCarlo(Operation):
                 "The probability distribution must have a length that is a power of two"
             )
 
-        target_wires = list(target_wires)
-        estimation_wires = list(estimation_wires)
+        target_wires = tuple(target_wires)
+        estimation_wires = tuple(estimation_wires)
         wires = target_wires + estimation_wires
 
         if num_target_wires != len(target_wires):

--- a/pennylane/templates/subroutines/qpe.py
+++ b/pennylane/templates/subroutines/qpe.py
@@ -15,10 +15,13 @@
 Contains the QuantumPhaseEstimation template.
 """
 # pylint: disable=too-many-arguments,arguments-differ
+import copy
+
 import pennylane as qml
 from pennylane.operation import AnyWires, Operator
 from pennylane.queuing import QueuingManager
 from pennylane.resource.error import ErrorOperation, SpectralNormError
+from pennylane.wires import Wires
 
 
 class QuantumPhaseEstimation(ErrorOperation):
@@ -232,17 +235,16 @@ class QuantumPhaseEstimation(ErrorOperation):
 
     # pylint: disable=protected-access
     def map_wires(self, wire_map: dict):
-        new_op = super().map_wires(wire_map)
+        new_op = copy.deepcopy(self)
+        new_op._wires = Wires([wire_map.get(wire, wire) for wire in self.wires])
         new_op._hyperparameters["unitary"] = qml.map_wires(
             new_op._hyperparameters["unitary"], wire_map
         )
 
-        new_op._hyperparameters["estimation_wires"] = [
-            wire_map.get(wire, wire) for wire in self.estimation_wires
-        ]
-        new_op._hyperparameters["target_wires"] = [
-            wire_map.get(wire, wire) for wire in self.target_wires
-        ]
+        for key in ["estimation_wires", "target_wires"]:
+            new_op._hyperparameters[key] = [
+                wire_map.get(wire, wire) for wire in self.hyperparameters[key]
+            ]
 
         return new_op
 

--- a/pennylane/templates/subroutines/reflection.py
+++ b/pennylane/templates/subroutines/reflection.py
@@ -40,7 +40,8 @@ class Reflection(Operation):
     Args:
         U (Operator): the operator that prepares the state :math:`|\Psi\rangle`
         alpha (float): the angle of the operator, default is :math:`\pi`
-        reflection_wires (Any or Iterable[Any]): subsystem of wires on which to reflect, the default is ``None`` and the reflection will be applied on the ``U`` wires
+        reflection_wires (Any or Iterable[Any]): subsystem of wires on which to reflect, the
+            default is ``None`` and the reflection will be applied on the ``U`` wires.
 
     **Example**
 
@@ -123,7 +124,7 @@ class Reflection(Operation):
 
         self._hyperparameters = {
             "base": U,
-            "reflection_wires": reflection_wires,
+            "reflection_wires": tuple(reflection_wires),
         }
 
         super().__init__(alpha, wires=wires, id=id)

--- a/pennylane/templates/subroutines/trotter.py
+++ b/pennylane/templates/subroutines/trotter.py
@@ -235,7 +235,7 @@ class TrotterProduct(ErrorOperation):
             "check_hermitian": check_hermitian,
         }
 
-        super().__init__(time, wires=hamiltonian.wires, id=id)
+        super().__init__(*hamiltonian.data, time, wires=hamiltonian.wires, id=id)
 
     def queue(self, context=qml.QueuingManager):
         context.remove(self.hyperparameters["base"])
@@ -288,7 +288,7 @@ class TrotterProduct(ErrorOperation):
             SpectralNormError: The spectral norm error.
         """
         base_unitary = self.hyperparameters["base"]
-        t, p, n = (self.parameters[0], self.hyperparameters["order"], self.hyperparameters["n"])
+        t, p, n = (self.parameters[-1], self.hyperparameters["order"], self.hyperparameters["n"])
 
         parameters = [t] + base_unitary.parameters
         if any(
@@ -343,10 +343,10 @@ class TrotterProduct(ErrorOperation):
         (<Wires = ['b', 'c']>, (True, True), <Wires = []>))
         """
         hamiltonian = self.hyperparameters["base"]
-        time = self.parameters[0]
+        time = self.data[-1]
 
         hashable_hyperparameters = tuple(
-            (key, value) for key, value in self.hyperparameters.items() if key != "base"
+            item for item in self.hyperparameters.items() if item[0] != "base"
         )
         return (hamiltonian, time), hashable_hyperparameters
 
@@ -375,8 +375,7 @@ class TrotterProduct(ErrorOperation):
         Controlled(U2(3.4, 4.5, wires=['a']), control_wires=['b', 'c'])
 
         """
-        hyperparameters_dict = dict(metadata)
-        return cls(*data, **hyperparameters_dict)
+        return cls(*data, **dict(metadata))
 
     @staticmethod
     def compute_decomposition(*args, **kwargs):
@@ -399,7 +398,7 @@ class TrotterProduct(ErrorOperation):
         Returns:
             list[Operator]: decomposition of the operator
         """
-        time = args[0]
+        time = args[-1]
         n = kwargs["n"]
         order = kwargs["order"]
         ops = kwargs["base"].operands

--- a/pennylane/templates/subroutines/uccsd.py
+++ b/pennylane/templates/subroutines/uccsd.py
@@ -191,7 +191,11 @@ class UCCSD(Operation):
         if init_state.dtype != np.dtype("int"):
             raise ValueError(f"Elements of 'init_state' must be integers; got {init_state.dtype}")
 
-        self._hyperparameters = {"init_state": init_state, "s_wires": s_wires, "d_wires": d_wires}
+        self._hyperparameters = {
+            "init_state": tuple(init_state),
+            "s_wires": tuple(tuple(w) for w in s_wires),
+            "d_wires": tuple(tuple(tuple(w) for w in dw) for dw in d_wires),
+        }
 
         super().__init__(weights, wires=wires, id=id)
 

--- a/tests/templates/test_subroutines/test_amplitude_amplification.py
+++ b/tests/templates/test_subroutines/test_amplitude_amplification.py
@@ -264,23 +264,6 @@ def test_correct_queueing():
     assert np.allclose(circuit1(), circuit3())
 
 
-# pylint: disable=protected-access
-def test_flatten_and_unflatten():
-    """Test the _flatten and _unflatten methods for AmplitudeAmplification."""
-
-    op = qml.AmplitudeAmplification(qml.RX(0.25, wires=0), qml.PauliZ(0))
-    data, metadata = op._flatten()
-
-    assert len(data) == 2
-    assert len(metadata) == 5
-
-    new_op = type(op)._unflatten(*op._flatten())
-    assert qml.equal(op, new_op)
-    assert op is not new_op
-
-    assert hash(metadata)
-
-
 def test_amplification():
     """Test that AmplitudeAmplification amplifies a marked element."""
 

--- a/tests/templates/test_subroutines/test_amplitude_amplification.py
+++ b/tests/templates/test_subroutines/test_amplitude_amplification.py
@@ -64,6 +64,13 @@ class TestInitialization:
         with pytest.raises(ValueError, match="work_wire must be different from the wires of O."):
             qml.AmplitudeAmplification(U, O, iters=3, fixed_point=fixed_point, work_wire=work_wire)
 
+    def test_standard_validity(self):
+        """Test standard validity using assert_valid."""
+        U = generator(wires=range(3))
+        O = oracle([0, 2], wires=range(3))
+        op = qml.AmplitudeAmplification(U, O, iters=3, fixed_point=False)
+        qml.ops.functions.assert_valid(op)
+
 
 @pytest.mark.parametrize(
     "n_wires, items, iters",

--- a/tests/templates/test_subroutines/test_approx_time_evolution.py
+++ b/tests/templates/test_subroutines/test_approx_time_evolution.py
@@ -27,25 +27,7 @@ def test_standard_validity():
     t = 0.1
     op = qml.ApproxTimeEvolution(H, t, n=20)
     qml.ops.functions.assert_valid(op)
-
-
-# pylint: disable=protected-access
-def test_flatten_unflatten():
-    """Tests the _flatten and _unflatten methods."""
-    H = 2.0 * qml.PauliX(0) + 3.0 * qml.PauliY(0)
-    t = 0.1
-    op = qml.ApproxTimeEvolution(H, t, n=20)
-    data, metadata = op._flatten()
-    assert data[0] is H
-    assert data[1] == t
-    assert metadata == (20,)
-
-    # check metadata hashable
-    assert hash(metadata)
-
-    new_op = type(op)._unflatten(*op._flatten())
-    assert qml.equal(op, new_op)
-    assert new_op is not op
+    assert False
 
 
 def test_queuing():

--- a/tests/templates/test_subroutines/test_approx_time_evolution.py
+++ b/tests/templates/test_subroutines/test_approx_time_evolution.py
@@ -27,7 +27,6 @@ def test_standard_validity():
     t = 0.1
     op = qml.ApproxTimeEvolution(H, t, n=20)
     qml.ops.functions.assert_valid(op)
-    assert False
 
 
 def test_queuing():

--- a/tests/templates/test_subroutines/test_commuting_evolution.py
+++ b/tests/templates/test_subroutines/test_commuting_evolution.py
@@ -32,28 +32,6 @@ def test_standard_validity():
     qml.ops.functions.assert_valid(op)
 
 
-# pylint: disable=protected-access
-def test_flatten_unflatten():
-    """Unit tests for the flatten and unflatten methods."""
-    H = 2.0 * qml.PauliX(0) @ qml.PauliY(1) + 3.0 * qml.PauliY(0) @ qml.PauliZ(1)
-    time = 0.5
-    frequencies = (2, 4)
-    shifts = (1, 0.5)
-    op = qml.CommutingEvolution(H, time, frequencies=frequencies, shifts=shifts)
-    data, metadata = op._flatten()
-
-    assert hash(metadata)
-
-    assert len(data) == 2
-    assert data[1] is H
-    assert data[0] == time
-    assert metadata == (frequencies, shifts)
-
-    new_op = type(op)._unflatten(*op._flatten())
-    assert qml.equal(op, new_op)
-    assert op is not new_op
-
-
 def test_adjoint():
     """Tests the CommutingEvolution.adjoint method provides the correct adjoint operation."""
 

--- a/tests/templates/test_subroutines/test_controlled_sequence.py
+++ b/tests/templates/test_subroutines/test_controlled_sequence.py
@@ -36,28 +36,6 @@ class TestInitialization:
         op = qml.ControlledSequence(qml.RX(0.25, wires=3), control=[0, 1, 2], id="a")
         assert op.id == "a"
 
-    # pylint: disable=protected-access
-    def test_flatten_and_unflatten(self):
-        """Test the _flatten and _unflatten methods for ControlledSequence"""
-
-        op = qml.ControlledSequence(qml.RX(0.25, wires=3), control=[0, 1, 2])
-        data, metadata = op._flatten()
-
-        assert len(data) == 1
-        assert qml.equal(data[0], op.base)
-
-        assert len(metadata) == 1
-        assert metadata[0] == op.control
-
-        # make sure metadata is hashable
-        assert hash(metadata)
-
-        new_op = type(op)._unflatten(*op._flatten())
-
-        assert qml.equal(op.base, new_op.base)
-        assert op.control_wires == new_op.control_wires
-        assert op is not new_op
-
     def test_overlapping_wires_error(self):
         """Test that an error is raised if the wires of the base
         operator and the control wires overlap"""

--- a/tests/templates/test_subroutines/test_double_excitation.py
+++ b/tests/templates/test_subroutines/test_double_excitation.py
@@ -30,27 +30,6 @@ def test_standard_validity():
     qml.ops.functions.assert_valid(op)
 
 
-# pylint: disable=protected-access
-def test_flatten_unflatten():
-    """Test the _flatten and _unflatten methods."""
-    weight = 0.5
-    wires1 = qml.wires.Wires((0, 1))
-    wires2 = qml.wires.Wires((2, 3, 4))
-    op = qml.FermionicDoubleExcitation(weight, wires1=wires1, wires2=wires2)
-
-    data, metadata = op._flatten()
-    assert data == (0.5,)
-    assert metadata[0] == wires1
-    assert metadata[1] == wires2
-
-    # test that its hashable
-    assert hash(metadata)
-
-    new_op = type(op)._unflatten(*op._flatten())
-    assert qml.equal(op, new_op)
-    assert op is not new_op
-
-
 class TestDecomposition:
     """Tests that the template defines the correct decomposition."""
 

--- a/tests/templates/test_subroutines/test_fable.py
+++ b/tests/templates/test_subroutines/test_fable.py
@@ -41,13 +41,6 @@ class TestFable:
         op = qml.FABLE(input_matrix, wires=range(5), tol=0.01)
         qml.ops.functions.assert_valid(op)
 
-    # pylint: disable=protected-access
-    def test_flatten_unflatten(self, input_matrix):
-        """Test the flatten and unflatten methods."""
-        op = qml.FABLE(input_matrix, wires=range(5), tol=0.01)
-        new_op = type(op)._unflatten(*op._flatten())
-        assert qml.equal(op, new_op)
-
     @pytest.mark.parametrize(
         ("input", "wires"),
         [

--- a/tests/templates/test_subroutines/test_flip_sign.py
+++ b/tests/templates/test_subroutines/test_flip_sign.py
@@ -33,25 +33,6 @@ def test_repr():
     assert repr(op) == expected
 
 
-# pylint: disable=protected-access
-def test_flatten_unflatten():
-    """Test the flatten and unflatten methods."""
-    op = qml.FlipSign([0, 1], wires=2)
-    data, metadata = op._flatten()
-
-    assert data == tuple()
-    hyperparameters = (("n", (0, 1)),)
-    assert metadata == (op.wires, hyperparameters)
-
-    # make sure metadata hasable
-    assert hash(metadata)
-
-    new_op = type(op)._unflatten(*op._flatten())
-    # data casted to tuple. unimportant difference
-    assert qml.equal(qml.FlipSign((0, 1), wires=2), new_op)
-    assert op is not new_op
-
-
 class TestFlipSign:
     """Tests that the template defines the correct sign flip."""
 

--- a/tests/templates/test_subroutines/test_grover.py
+++ b/tests/templates/test_subroutines/test_grover.py
@@ -31,25 +31,6 @@ def test_repr():
     assert repr(op) == expected
 
 
-# pylint: disable=protected-access
-def test_flatten_unflatten():
-    """Tests the flatten and unflatten methods for GroverOperator."""
-    work_wires = qml.wires.Wires((3, 4))
-    op = qml.GroverOperator(wires=(0, 1, 2), work_wires=work_wires)
-    data, metadata = op._flatten()
-    assert data == tuple()
-    assert len(metadata) == 2
-    assert metadata[0] == op.wires
-    assert metadata[1] == (("work_wires", work_wires),)
-
-    # make sure metadata hashable
-    assert hash(metadata)
-
-    new_op = type(op)._unflatten(*op._flatten())
-    assert qml.equal(op, new_op)
-    assert new_op is not op
-
-
 def test_standard_validity():
     """Test the standard criteria for a valid operation."""
     work_wires = qml.wires.Wires((3, 4))

--- a/tests/templates/test_subroutines/test_grover.py
+++ b/tests/templates/test_subroutines/test_grover.py
@@ -50,6 +50,13 @@ def test_flatten_unflatten():
     assert new_op is not op
 
 
+def test_standard_validity():
+    """Test the standard criteria for a valid operation."""
+    work_wires = qml.wires.Wires((3, 4))
+    op = qml.GroverOperator(wires=(0, 1, 2), work_wires=work_wires)
+    qml.ops.functions.assert_valid(op)
+
+
 def test_work_wires():
     """Assert work wires get passed to MultiControlledX"""
     wires = ("a", "b")

--- a/tests/templates/test_subroutines/test_kupccgsd.py
+++ b/tests/templates/test_subroutines/test_kupccgsd.py
@@ -349,40 +349,6 @@ class TestDecomposition:
         assert gen_doubles_wires == generalized_pair_doubles_wires
 
 
-# pylint: disable=protected-access
-def test_flatten_unflatten():
-    """Tests the flatten and unflatten methods."""
-    weights = qml.math.array([[0.55, 0.72, 0.6, 0.54, 0.42, 0.65]])
-    wires = qml.wires.Wires((0, 1, 2, 3))
-    init_state = qml.math.array([1, 1, 0, 0])
-    op = qml.kUpCCGSD(
-        weights,
-        wires=wires,
-        k=1,
-        delta_sz=0,
-        init_state=init_state,
-    )
-    data, metadata = op._flatten()
-    assert data == (weights,)
-    assert len(metadata) == 2
-    assert metadata[0] == wires
-    assert metadata[1] == (("k", 1), ("delta_sz", 0), ("init_state", tuple(init_state)))
-
-    # make sure metadata hashable
-    assert hash(metadata)
-
-    new_op = type(op)._unflatten(*op._flatten())
-    assert op.data == new_op.data
-    assert type(new_op) is type(op)
-    assert op.hyperparameters["s_wires"] == new_op.hyperparameters["s_wires"]
-    assert op.hyperparameters["d_wires"] == new_op.hyperparameters["d_wires"]
-    assert op.hyperparameters["k"] == new_op.hyperparameters["k"]
-    assert op.hyperparameters["delta_sz"] == new_op.hyperparameters["delta_sz"]
-    assert qml.math.allclose(op.hyperparameters["init_state"], new_op.hyperparameters["init_state"])
-
-    assert op is not new_op
-
-
 class TestInputs:
     """Test inputs and pre-processing."""
 

--- a/tests/templates/test_subroutines/test_kupccgsd.py
+++ b/tests/templates/test_subroutines/test_kupccgsd.py
@@ -21,45 +21,47 @@ import pytest
 
 import pennylane as qml
 
+k_delta_sz_init_state_wires = [
+    (1, 0, qml.math.array([1, 1, 0, 0]), qml.math.array([0, 1, 2, 3])),
+    (1, -1, qml.math.array([1, 1, 0, 0]), qml.math.array([0, 1, 2, 3])),
+    (2, 1, qml.math.array([1, 1, 0, 0]), qml.math.array([0, 1, 2, 3])),
+    (2, 0, qml.math.array([1, 1, 0, 0, 0, 0]), qml.math.array([0, 1, 2, 3, 4, 5])),
+    (2, 1, qml.math.array([1, 1, 0, 0, 0, 0, 0, 0]), qml.math.array([0, 1, 2, 3, 4, 5, 6, 7])),
+]
+
+
+@pytest.mark.parametrize("k, delta_sz, init_state, wires", k_delta_sz_init_state_wires)
+def test_standard_validity(k, delta_sz, init_state, wires):
+    """Test standard validity criteria for kUpCCGSD."""
+    sz = np.array([0.5 if (i % 2 == 0) else -0.5 for i in range(len(wires))])
+    gen_single_terms_wires = [
+        wires[r : p + 1] if r < p else wires[p : r + 1][::-1]
+        for r in range(len(wires))
+        for p in range(len(wires))
+        if sz[p] - sz[r] == delta_sz and p != r
+    ]
+
+    # wires for generalized pair coupled cluser double exictation terms
+    pair_double_terms_wires = [
+        [wires[r : r + 2], wires[p : p + 2]]
+        for r in range(0, len(wires) - 1, 2)
+        for p in range(0, len(wires) - 1, 2)
+        if p != r
+    ]
+
+    n_excit_terms = len(gen_single_terms_wires) + len(pair_double_terms_wires)
+    weights = np.random.normal(0, 2 * np.pi, (k, n_excit_terms))
+
+    n_gates = 1 + n_excit_terms * k
+    op = qml.kUpCCGSD(weights, wires=wires, k=k, delta_sz=delta_sz, init_state=init_state)
+
+    qml.ops.functions.assert_valid(op)
+
 
 class TestDecomposition:
     """Test that the template defines the correct decomposition."""
 
-    @pytest.mark.parametrize(
-        ("k", "delta_sz", "init_state", "wires"),
-        [
-            (
-                1,
-                0,
-                qml.math.array([1, 1, 0, 0]),
-                qml.math.array([0, 1, 2, 3]),
-            ),
-            (
-                1,
-                -1,
-                qml.math.array([1, 1, 0, 0]),
-                qml.math.array([0, 1, 2, 3]),
-            ),
-            (
-                2,
-                1,
-                qml.math.array([1, 1, 0, 0]),
-                qml.math.array([0, 1, 2, 3]),
-            ),
-            (
-                2,
-                0,
-                qml.math.array([1, 1, 0, 0, 0, 0]),
-                qml.math.array([0, 1, 2, 3, 4, 5]),
-            ),
-            (
-                2,
-                1,
-                qml.math.array([1, 1, 0, 0, 0, 0, 0, 0]),
-                qml.math.array([0, 1, 2, 3, 4, 5, 6, 7]),
-            ),
-        ],
-    )
+    @pytest.mark.parametrize("k, delta_sz, init_state, wires", k_delta_sz_init_state_wires)
     def test_kupccgsd_operations(self, k, delta_sz, init_state, wires):
         """Test the correctness of the k-UpCCGSD template including the gate count
         and order, the wires the operation acts on and the correct use of parameters

--- a/tests/templates/test_subroutines/test_qdrift.py
+++ b/tests/templates/test_subroutines/test_qdrift.py
@@ -65,8 +65,8 @@ class TestInitialization:
         qml.ops.functions.assert_valid(op)
 
         assert op.wires == h.wires
-        assert op.parameters == [time]
-        assert op.data == (time,)
+        assert op.parameters == [*h.data, time]
+        assert op.data == (*h.data, time)
 
         assert op.hyperparameters["n"] == n
         assert op.hyperparameters["seed"] == seed
@@ -132,28 +132,6 @@ class TestInitialization:
         with pytest.raises(ValueError, match=msg):
             h = qml.Hamiltonian([1.0], [qml.PauliX(0)])
             qml.QDrift(h, 1.23, n=2, seed=None)
-
-    @pytest.mark.parametrize("coeffs, ops", test_hamiltonians)
-    def test_flatten_and_unflatten(self, coeffs, ops):
-        """Test that the flatten and unflatten methods work correctly."""
-        time, n, seed = (0.5, 2, 1234)
-        hamiltonian = qml.dot(coeffs, ops)
-        op = qml.QDrift(hamiltonian, time, n=n, seed=seed)
-        decomp = op.decomposition()
-
-        data, metadata = op._flatten()  # pylint: disable=protected-access
-        assert data[0] == time
-        assert metadata[0] == op.wires
-        assert dict(metadata[1]) == {
-            "n": n,
-            "seed": seed,
-            "base": hamiltonian,
-            "decomposition": tuple(decomp),
-        }
-
-        new_op = type(op)._unflatten(data, metadata)  # pylint: disable=protected-access
-        assert qml.equal(op, new_op)
-        assert new_op is not op
 
 
 class TestDecomposition:

--- a/tests/templates/test_subroutines/test_qmc.py
+++ b/tests/templates/test_subroutines/test_qmc.py
@@ -255,6 +255,14 @@ class TestQuantumMonteCarlo:
     def func(i):
         return np.sin(i) ** 2
 
+    def test_standard_validity(self):
+        """Test standard validity criteria with assert_valid."""
+        p = np.ones(4) / 4
+        target_wires, estimation_wires = Wires(range(3)), Wires(range(3, 5))
+
+        op = QuantumMonteCarlo(p, self.func, target_wires, estimation_wires)
+        qml.ops.functions.assert_valid(op)
+
     # pylint: disable=protected-access
     def test_flatten_unflatten(self):
         """Test the flatten and unflatten methods."""

--- a/tests/templates/test_subroutines/test_qmc.py
+++ b/tests/templates/test_subroutines/test_qmc.py
@@ -263,23 +263,6 @@ class TestQuantumMonteCarlo:
         op = QuantumMonteCarlo(p, self.func, target_wires, estimation_wires)
         qml.ops.functions.assert_valid(op)
 
-    # pylint: disable=protected-access
-    def test_flatten_unflatten(self):
-        """Test the flatten and unflatten methods."""
-        p = np.ones(4) / 4
-        target_wires, estimation_wires = Wires(range(3)), Wires(range(3, 5))
-
-        op = QuantumMonteCarlo(p, self.func, target_wires, estimation_wires)
-
-        data, metadata = op._flatten()
-        assert data is op.data
-        assert metadata[0] == op.wires
-        assert dict(metadata[1]) == op.hyperparameters
-
-        new_op = type(op)._unflatten(*op._flatten())
-        assert qml.equal(op, new_op)
-        assert op is not new_op
-
     def test_non_flat(self):
         """Test if a ValueError is raised when a non-flat array is input"""
         p = np.ones((4, 1)) / 4

--- a/tests/templates/test_subroutines/test_qpe.py
+++ b/tests/templates/test_subroutines/test_qpe.py
@@ -21,22 +21,10 @@ from scipy.stats import unitary_group
 import pennylane as qml
 
 
-# pylint: disable=protected-access,too-few-public-methods
-def test_flatten_unflatten():
-    """Tests the flatten and unflatten methods."""
-    op = qml.QuantumPhaseEstimation(np.eye(4), target_wires=(0, 1), estimation_wires=[2, 3])
-    data, metadata = op._flatten()
-    expected_data = qml.QubitUnitary(np.eye(4), (0, 1))
-    assert qml.equal(data[0], expected_data)
-
-    assert metadata[0] == qml.wires.Wires((2, 3))
-
-    # make sure metadata is hashable
-    assert hash(metadata)
-
-    new_op = type(op)._unflatten(*op._flatten())
-    assert qml.equal(op, new_op)
-    assert op is not new_op
+def test_standard_validity():
+    """Test standard validity criteria using assert_valid."""
+    op = qml.QuantumPhaseEstimation(np.eye(4), target_wires=(0, 1), estimation_wires=[2, 5])
+    qml.ops.functions.assert_valid(op)
 
 
 class TestError:

--- a/tests/templates/test_subroutines/test_qsvt.py
+++ b/tests/templates/test_subroutines/test_qsvt.py
@@ -41,20 +41,11 @@ def lst_phis(phis):
 class TestQSVT:
     """Test the qml.QSVT template."""
 
-    # pylint: disable=protected-access
-    def test_flatten_unflatten(self):
+    def test_standard_validity(self):
+        """Test standard validity criteria with assert_valid."""
         projectors = [qml.PCPhase(0.2, dim=1, wires=0), qml.PCPhase(0.3, dim=1, wires=0)]
         op = qml.QSVT(qml.PauliX(wires=0), projectors)
-        data, metadata = op._flatten()
-        assert qml.equal(data[0], qml.PauliX(0))
-        assert len(data[1]) == len(projectors)
-        assert all(qml.equal(op1, op2) for op1, op2 in zip(data[1], projectors))
-
-        assert metadata == tuple()
-
-        new_op = type(op)._unflatten(*op._flatten())
-        assert qml.equal(op, new_op)
-        assert op is not new_op
+        qml.ops.functions.assert_valid(op)
 
     def test_init_error(self):
         """Test that an error is raised if a non-operation object is passed

--- a/tests/templates/test_subroutines/test_reflection.py
+++ b/tests/templates/test_subroutines/test_reflection.py
@@ -27,6 +27,12 @@ def hadamards(wires):
         qml.Hadamard(wires=wire)
 
 
+def test_standard_validity():
+    """Test standard validity criteria using assert_valid."""
+    op = qml.Reflection(qml.Hadamard(wires=0), 0.5, reflection_wires=[0])
+    qml.ops.functions.assert_valid(op)
+
+
 @pytest.mark.parametrize(
     ("prod", "reflection_wires"),
     [
@@ -296,20 +302,3 @@ def test_correct_reflection(state):
     expected = np.array(output[::-1])
 
     assert np.allclose(state, expected)
-
-
-# pylint: disable=protected-access
-def test_flatten_and_unflatten():
-    """Test the _flatten and _unflatten methods for Reflection."""
-
-    op = qml.Reflection(qml.RX(0.25, wires=0), alpha=0.5)
-    data, metadata = op._flatten()
-
-    assert len(data) == 2
-    assert len(metadata) == 1
-
-    new_op = type(op)._unflatten(*op._flatten())
-    assert qml.equal(op, new_op)
-    assert op is not new_op
-
-    assert hash(metadata)

--- a/tests/templates/test_subroutines/test_select.py
+++ b/tests/templates/test_subroutines/test_select.py
@@ -206,27 +206,6 @@ class TestSelect:
             qml.equal(op1, op2) for op1, op2 in zip(select_compute_decomposition, expected_gates)
         )
 
-    # pylint: disable=protected-access
-    def test_flatten_unflatten(self):
-        """Test that the _flatten and _unflatten functions work as expected."""
-        ops = [qml.PauliX(wires=2), qml.PauliX(wires=3), qml.PauliY(wires=2), qml.SWAP([2, 3])]
-        op = qml.Select(ops, control=[0, 1])
-        data, metadata = op._flatten()
-
-        assert hash(metadata)
-
-        assert len(data) == len(ops)
-        assert all(qml.equal(op1, op2) for op1, op2 in zip(data, ops))
-
-        assert metadata == op.control
-
-        new_op = type(op)._unflatten(*op._flatten())
-        assert all(qml.equal(op1, op2) for op1, op2 in zip(op.ops, new_op.ops))
-        assert op.wires == new_op.wires
-        assert op.control == new_op.control
-        assert op.target_wires == new_op.target_wires
-        assert op is not new_op
-
     def test_copy(self):
         """Test that the copy function of Select works correctly."""
         ops = [qml.PauliX(wires=2), qml.RX(0.2, wires=3), qml.PauliY(wires=2), qml.SWAP([2, 3])]

--- a/tests/templates/test_subroutines/test_single_excitation.py
+++ b/tests/templates/test_subroutines/test_single_excitation.py
@@ -21,6 +21,13 @@ import pennylane as qml
 from pennylane import numpy as pnp
 
 
+def test_standard_validity():
+    """Test standard validity criteria using assert_valid."""
+    weight = np.pi / 3
+    op = qml.FermionicSingleExcitation(weight, wires=[0, 1, 2])
+    qml.ops.functions.assert_valid(op)
+
+
 class TestDecomposition:
     """Tests that the template defines the correct decomposition."""
 

--- a/tests/templates/test_subroutines/test_trotter.py
+++ b/tests/templates/test_subroutines/test_trotter.py
@@ -333,8 +333,8 @@ class TestInitialization:
             hamiltonian = hamiltonian.simplify()
 
         assert op.wires == hamiltonian.wires
-        assert op.parameters == [time]
-        assert op.data == (time,)
+        assert op.parameters == [*hamiltonian.data, time]
+        assert op.data == (*hamiltonian.data, time)
         assert op.hyperparameters == {
             "base": hamiltonian,
             "n": n,
@@ -358,22 +358,11 @@ class TestInitialization:
         assert op is not new_op
 
     @pytest.mark.parametrize("hamiltonian", test_hamiltonians)
-    def test_flatten_and_unflatten(self, hamiltonian):
-        """Test that the flatten and unflatten methods work correctly."""
+    def test_standard_validity(self, hamiltonian):
+        """Test standard validity criteria using assert_valid."""
         time, n, order = (4.2, 10, 4)
         op = qml.TrotterProduct(hamiltonian, time, n=n, order=order)
-
-        if isinstance(hamiltonian, qml.ops.op_math.SProd):
-            hamiltonian = hamiltonian.simplify()
-
-        data, metadata = op._flatten()
-        assert qml.equal(data[0], hamiltonian)
-        assert data[1] == time
-        assert dict(metadata) == {"n": n, "order": order, "check_hermitian": True}
-
-        new_op = type(op)._unflatten(data, metadata)
-        assert qml.equal(op, new_op)
-        assert new_op is not op
+        qml.ops.functions.assert_valid(op)
 
     # TODO: Remove test when we deprecate ApproxTimeEvolution
     @pytest.mark.parametrize("n", (1, 2, 5, 10))

--- a/tests/templates/test_subroutines/test_uccsd.py
+++ b/tests/templates/test_subroutines/test_uccsd.py
@@ -22,84 +22,103 @@ import pytest
 import pennylane as qml
 from pennylane import numpy as pnp
 
+test_data_decomposition = [
+    (
+        [[0, 1, 2]],
+        [],
+        np.array([3.815]),
+        [
+            [0, qml.BasisState, [0, 1, 2, 3, 4, 5], [np.array([1, 1, 0, 0, 0, 0])]],
+            [1, qml.RX, [0], [-np.pi / 2]],
+            [5, qml.RZ, [2], [1.9075]],
+            [6, qml.CNOT, [1, 2], []],
+        ],
+    ),
+    (
+        [[0, 1, 2], [1, 2, 3]],
+        [],
+        np.array([3.815, 4.866]),
+        [
+            [2, qml.Hadamard, [2], []],
+            [8, qml.RX, [0], [np.pi / 2]],
+            [12, qml.CNOT, [0, 1], []],
+            [23, qml.RZ, [3], [2.433]],
+            [24, qml.CNOT, [2, 3], []],
+            [26, qml.RX, [1], [np.pi / 2]],
+        ],
+    ),
+    (
+        [],
+        [[[0, 1], [2, 3, 4, 5]]],
+        np.array([3.815]),
+        [
+            [3, qml.RX, [2], [-np.pi / 2]],
+            [29, qml.RZ, [5], [0.476875]],
+            [73, qml.Hadamard, [0], []],
+            [150, qml.RX, [1], [np.pi / 2]],
+            [88, qml.CNOT, [3, 4], []],
+            [121, qml.CNOT, [2, 3], []],
+        ],
+    ),
+    (
+        [],
+        [[[0, 1], [2, 3]], [[0, 1], [4, 5]]],
+        np.array([3.815, 4.866]),
+        [
+            [4, qml.Hadamard, [3], []],
+            [16, qml.RX, [0], [-np.pi / 2]],
+            [38, qml.RZ, [3], [0.476875]],
+            [78, qml.Hadamard, [2], []],
+            [107, qml.RX, [1], [-np.pi / 2]],
+            [209, qml.Hadamard, [4], []],
+            [218, qml.RZ, [5], [-0.60825]],
+            [82, qml.CNOT, [2, 3], []],
+            [159, qml.CNOT, [4, 5], []],
+        ],
+    ),
+    (
+        [[0, 1, 2, 3, 4], [1, 2, 3]],
+        [[[0, 1], [2, 3]], [[0, 1], [4, 5]]],
+        np.array([3.815, 4.866, 1.019, 0.639]),
+        [
+            [16, qml.RX, [0], [-np.pi / 2]],
+            [47, qml.Hadamard, [1], []],
+            [74, qml.Hadamard, [2], []],
+            [83, qml.RZ, [3], [-0.127375]],
+            [134, qml.RX, [4], [np.pi / 2]],
+            [158, qml.RZ, [5], [0.079875]],
+            [188, qml.RZ, [5], [-0.079875]],
+            [96, qml.CNOT, [1, 2], []],
+            [235, qml.CNOT, [1, 4], []],
+        ],
+    ),
+]
+
+
+@pytest.mark.parametrize("s_wires, d_wires, weights, ref_gates", test_data_decomposition)
+def test_standard_validity(s_wires, d_wires, weights, ref_gates):
+    """Test standard validity criteria using assert_valid."""
+    sqg = 10 * len(s_wires) + 72 * len(d_wires)
+
+    cnots = 0
+    for s_wires_ in s_wires:
+        cnots += 4 * (len(s_wires_) - 1)
+
+    for d_wires_ in d_wires:
+        cnots += 16 * (len(d_wires_[0]) - 1 + len(d_wires_[1]) - 1 + 1)
+    N = 6
+    wires = range(N)
+
+    ref_state = np.array([1, 1, 0, 0, 0, 0])
+
+    op = qml.UCCSD(weights, wires, s_wires=s_wires, d_wires=d_wires, init_state=ref_state)
+    qml.ops.functions.assert_valid(op)
+
 
 class TestDecomposition:
     """Tests that the template defines the correct decomposition."""
 
-    @pytest.mark.parametrize(
-        ("s_wires", "d_wires", "weights", "ref_gates"),
-        [
-            (
-                [[0, 1, 2]],
-                [],
-                np.array([3.815]),
-                [
-                    [0, qml.BasisState, [0, 1, 2, 3, 4, 5], [np.array([1, 1, 0, 0, 0, 0])]],
-                    [1, qml.RX, [0], [-np.pi / 2]],
-                    [5, qml.RZ, [2], [1.9075]],
-                    [6, qml.CNOT, [1, 2], []],
-                ],
-            ),
-            (
-                [[0, 1, 2], [1, 2, 3]],
-                [],
-                np.array([3.815, 4.866]),
-                [
-                    [2, qml.Hadamard, [2], []],
-                    [8, qml.RX, [0], [np.pi / 2]],
-                    [12, qml.CNOT, [0, 1], []],
-                    [23, qml.RZ, [3], [2.433]],
-                    [24, qml.CNOT, [2, 3], []],
-                    [26, qml.RX, [1], [np.pi / 2]],
-                ],
-            ),
-            (
-                [],
-                [[[0, 1], [2, 3, 4, 5]]],
-                np.array([3.815]),
-                [
-                    [3, qml.RX, [2], [-np.pi / 2]],
-                    [29, qml.RZ, [5], [0.476875]],
-                    [73, qml.Hadamard, [0], []],
-                    [150, qml.RX, [1], [np.pi / 2]],
-                    [88, qml.CNOT, [3, 4], []],
-                    [121, qml.CNOT, [2, 3], []],
-                ],
-            ),
-            (
-                [],
-                [[[0, 1], [2, 3]], [[0, 1], [4, 5]]],
-                np.array([3.815, 4.866]),
-                [
-                    [4, qml.Hadamard, [3], []],
-                    [16, qml.RX, [0], [-np.pi / 2]],
-                    [38, qml.RZ, [3], [0.476875]],
-                    [78, qml.Hadamard, [2], []],
-                    [107, qml.RX, [1], [-np.pi / 2]],
-                    [209, qml.Hadamard, [4], []],
-                    [218, qml.RZ, [5], [-0.60825]],
-                    [82, qml.CNOT, [2, 3], []],
-                    [159, qml.CNOT, [4, 5], []],
-                ],
-            ),
-            (
-                [[0, 1, 2, 3, 4], [1, 2, 3]],
-                [[[0, 1], [2, 3]], [[0, 1], [4, 5]]],
-                np.array([3.815, 4.866, 1.019, 0.639]),
-                [
-                    [16, qml.RX, [0], [-np.pi / 2]],
-                    [47, qml.Hadamard, [1], []],
-                    [74, qml.Hadamard, [2], []],
-                    [83, qml.RZ, [3], [-0.127375]],
-                    [134, qml.RX, [4], [np.pi / 2]],
-                    [158, qml.RZ, [5], [0.079875]],
-                    [188, qml.RZ, [5], [-0.079875]],
-                    [96, qml.CNOT, [1, 2], []],
-                    [235, qml.CNOT, [1, 4], []],
-                ],
-            ),
-        ],
-    )
+    @pytest.mark.parametrize("s_wires, d_wires, weights, ref_gates", test_data_decomposition)
     def test_uccsd_operations(self, s_wires, d_wires, weights, ref_gates):
         """Test the correctness of the UCCSD template including the gate count
         and order, the wires the operation acts on and the correct use of parameters


### PR DESCRIPTION
**Context:**
Most templates are operations themselves. Therefore they should be valid PyTrees, but some are not.

**Description of the Change:**
This PR adapts the `parameters` and/or `hyperparameters`, as well as the methods  `_flatten` and/or `_unflatten`  for a number of parameters.
It adds `standard_validity` tests to all template test files where `assert_valid` is not being called on the respective template yet.
Explicit flatten/unflatten tests are removed, because they are contained in `assert_valid`.

**Benefits:**
Code quality/self-consistency and consistency of templates with PL functionality.
Test suite quality.

**Possible Drawbacks:**

**Related GitHub Issues:**
This helps us go forward with capturing of templates, because `primitive_bind_call` can be created in a way that is consistent with `__init__` and `_unflatten`.
