### PR TITLE
CNOT doesn't decompose to CNOT

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -141,6 +141,9 @@
 * A correction is added to `bravyi_kitaev` to call the correct function for a FermiSentence input.
   [(#5671)](https://github.com/PennyLaneAI/pennylane/pull/5671)
 
+* The `CNOT` operator no longer decomposes to itself.
+  [(#5712)](https://github.com/PennyLaneAI/pennylane/pull/5712)
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -151,6 +151,7 @@ This release contains contributions from (in alphabetical order):
 Ahmed Darwish,
 Gabriel Bottrill,
 Isaac De Vlugt,
+Lillian M.A. Frederiksen,
 Pietropaolo Frisoni,
 Soran Jahangiri,
 Korbinian Kottmann,

--- a/pennylane/ops/functions/assert_valid.py
+++ b/pennylane/ops/functions/assert_valid.py
@@ -56,6 +56,9 @@ def _check_decomposition(op):
         expand = op.expand()
 
         assert isinstance(decomp, list), "decomposition must be a list"
+        assert np.all(
+            [not qml.equal(op, decomp_op) for decomp_op in decomp]
+        ), "an operator should not be included in its own decomposition"
         assert isinstance(compute_decomp, list), "decomposition must be a list"
         assert isinstance(expand, qml.tape.QuantumScript), "expand must return a QuantumScript"
 

--- a/pennylane/ops/functions/assert_valid.py
+++ b/pennylane/ops/functions/assert_valid.py
@@ -56,9 +56,9 @@ def _check_decomposition(op):
         expand = op.expand()
 
         assert isinstance(decomp, list), "decomposition must be a list"
-        assert np.all(
-            [not qml.equal(op, decomp_op) for decomp_op in decomp]
-        ), "an operator should not be included in its own decomposition"
+        assert op.__class__ not in [
+            decomp_op.__class__ for decomp_op in decomp
+        ], "an operator should not be included in its own decomposition"
         assert isinstance(compute_decomp, list), "decomposition must be a list"
         assert isinstance(expand, qml.tape.QuantumScript), "expand must return a QuantumScript"
 

--- a/pennylane/ops/op_math/controlled.py
+++ b/pennylane/ops/op_math/controlled.py
@@ -740,6 +740,9 @@ def _is_single_qubit_special_unitary(op):
 def _decompose_pauli_x_based_no_control_values(op: Controlled):
     """Decomposes a PauliX-based operation"""
 
+    if isinstance(op, qml.CNOT):
+        return None
+
     if isinstance(op.base, qml.PauliX) and len(op.control_wires) == 1:
         return [qml.CNOT(wires=op.active_wires)]
 

--- a/pennylane/ops/op_math/controlled.py
+++ b/pennylane/ops/op_math/controlled.py
@@ -740,9 +740,6 @@ def _is_single_qubit_special_unitary(op):
 def _decompose_pauli_x_based_no_control_values(op: Controlled):
     """Decomposes a PauliX-based operation"""
 
-    if isinstance(op, qml.CNOT):
-        return None
-
     if isinstance(op.base, qml.PauliX) and len(op.control_wires) == 1:
         return [qml.CNOT(wires=op.active_wires)]
 

--- a/pennylane/ops/op_math/controlled_ops.py
+++ b/pennylane/ops/op_math/controlled_ops.py
@@ -801,6 +801,33 @@ class CNOT(ControlledOp):
     def _controlled(self, wire):
         return qml.Toffoli(wires=wire + self.wires)
 
+    @property
+    def has_decomposition(self):
+        return False
+
+    @staticmethod
+    def compute_decomposition(*params, wires=None, **hyperparameters):  # -> List["Operator"]:
+        r"""Representation of the operator as a product of other operators (static method).
+
+        .. math:: O = O_1 O_2 \dots O_n.
+
+        .. note::
+
+            Operations making up the decomposition should be queued within the
+            ``compute_decomposition`` method.
+
+        .. seealso:: :meth:`~.Operator.decomposition`.
+
+        Args:
+            *params (list): trainable parameters of the operator, as stored in the ``parameters`` attribute
+            wires (Iterable[Any], Wires): wires that the operator acts on
+            **hyperparams (dict): non-trainable hyperparameters of the operator, as stored in the ``hyperparameters`` attribute
+
+        Returns:
+            list[Operator]: decomposition of the operator
+        """
+        raise qml.operation.DecompositionUndefinedError
+
 
 class Toffoli(ControlledOp):
     r"""Toffoli(wires)

--- a/tests/ops/functions/test_assert_valid.py
+++ b/tests/ops/functions/test_assert_valid.py
@@ -78,6 +78,17 @@ class TestDecompositionErrors:
         with pytest.raises(AssertionError, match="decomposition must match expansion"):
             assert_valid(BadDecomp(wires=0), skip_pickle=True)
 
+    def test_decomposition_must_not_contain_op(self):
+        """Test that decomposition op an operator doesn't include the operator itself"""
+
+        class BadDecomp(Operator):
+            @staticmethod
+            def compute_decomposition(wires):
+                return [BadDecomp(wires)]
+
+        with pytest.raises(AssertionError, match="should not be included in its own decomposition"):
+            assert_valid(BadDecomp(wires=0), skip_pickle=True)
+
     def test_error_not_raised(self):
         """Test if has_decomposition is False but decomposition defined."""
 

--- a/tests/ops/op_math/test_controlled.py
+++ b/tests/ops/op_math/test_controlled.py
@@ -1930,13 +1930,14 @@ class TestTapeExpansionWithControlled:
             *qml.CRY(0.456, wires=[1, 2]).decomposition(),
             *qml.CRX(0.789, wires=[1, 0]).decomposition(),
             *qml.CRot(0.111, 0.222, 0.333, wires=[1, 2]).decomposition(),
-            qml.CNOT(wires=[1, 2]),
+            *qml.CNOT(wires=[1, 2]).decomposition(),
             *qml.CY(wires=[1, 4]).decomposition(),
             *qml.CZ(wires=[1, 0]).decomposition(),
             qml.PauliX(wires=1),
         ]
         assert len(tape) == 9
         expanded = tape.expand(stop_at=lambda obj: not isinstance(obj, Controlled))
+        print(expanded.circuit)
         assert expanded.circuit == expected
 
     @pytest.mark.parametrize(
@@ -2183,8 +2184,8 @@ class TestTapeExpansionWithControlled:
 
         tape = QuantumScript.from_queue(q_tape)
         tape = tape.expand(depth=1, stop_at=lambda obj: not isinstance(obj, Controlled))
-        assert len(tape.operations) == 10
-        assert all(o.name in {"CNOT", "CRX", "Toffoli"} for o in tape.operations)
+        assert len(tape.operations) == 12
+        assert all(o.name in {"ControlledPhaseShift", "CRX", "Toffoli"} for o in tape.operations)
 
 
 @pytest.mark.parametrize("diff_method", ["backprop", "parameter-shift", "finite-diff"])


### PR DESCRIPTION
**Context:**
Up to and including Pennylane 0.34, the CNOT gate raised a `DecompositionUndefinedError` in its `decomposition` method. We added some smart handling of decompositions for controlled operators that accidentally started decomposing CNOT into itself. 

**Description of the Change:**
Make it so `_decompose_pauli_x_based_no_control_values` no longer provides a decomposition for `CNOT` (it currently just sees a controlled op with a base of `PauliX`, and decomposes to `CNOT`). The decomposition functions then follow another pathway and return another decomposition for CNOT.

**Benefits:**
This fringe but odd behaviour doesn't happen anymore

**Possible Drawbacks:**
I tested it by adding a check to `assert_valid`, maybe this problem is too much of an edge case to be in `assert_valid`. But with the controlled ops finding their own decompositions instead of having them hardcoded, I guess it could happen again 🤷‍♀️ 

**Related GitHub Issues:**
#5711