### PR TITLE
Removing `DefaultTensor` from `init` file

### DIFF
--- a/pennylane/devices/__init__.py
+++ b/pennylane/devices/__init__.py
@@ -151,12 +151,13 @@ from .default_qubit import DefaultQubit
 
 # DefaultQubitTF and DefaultQubitAutograd not imported here since this
 # would lead to an automatic import of tensorflow and autograd, which are
-# not PennyLane core dependencies
+# not PennyLane core dependencies.
+# DefaultTensor is not imported here to avoid warnings
+# from quimb in case it is installed on the system.
 from .default_qubit_legacy import DefaultQubitLegacy
 from .default_gaussian import DefaultGaussian
 from .default_mixed import DefaultMixed
 from .default_clifford import DefaultClifford
 from .null_qubit import NullQubit
 from .default_qutrit_mixed import DefaultQutritMixed
-from .default_tensor import DefaultTensor
 from .._device import Device as LegacyDevice


### PR DESCRIPTION
**Context:** To use the new `default.tensor` device in PennyLane, we must import the `quimb` Python package. 

The strategy adopted for this was the same previously used for the `default.clifford` device, which depends on the `stim` Python package. That is, when the user imports `pennylane`, the package is imported if installed on the system, otherwise it is not imported. An error is raised if the user explicitly tries to instantiate the device without the package installed.

However, `quimb` frequently raises a warning message when it is imported if `kahypar` is not installed. This causes the following unpleasant situation: if a user has `quimb` installed on the system and imports `pennylane`, the following warning message is raised:

```
UserWarning: Couldn't import `kahypar` - skipping from default hyper optimizer and using basic `labels` method instead.
```

**Description of the Change:** We no longer import the `DefaultTensor` class in `pennylane/devices/__init__.py`. 

**Benefits:** Now, the warning message is only raised if the user explicitly instantiates the device, which makes more sense and is less ambiguous:

```
qml.device("default.tensor", wires=2)

[/home/pietropaolo.frisoni/anaconda3/envs/PennyLane/lib/python3.9/site-packages/cotengra/hyperoptimizers/hyper.py:34](https://file+.vscode-resource.vscode-cdn.net/home/pietropaolo.frisoni/anaconda3/envs/PennyLane/lib/python3.9/site-packages/cotengra/hyperoptimizers/hyper.py:34): UserWarning: Couldn't import `kahypar` - skipping from default hyper optimizer and using basic `labels` method instead.
  warnings.warn(
```

Furthermore, this also speeds up the pennylane import process.

**Possible Drawbacks:** I cannot think of any, except that the `DefaultTensor` device will have less visibility (but will still appear in the documentation).

**Related GitHub Issues:** None.