### PR TITLE
Modify Software Tests page of the developer's guide to be requirements-agnostic

### DIFF
--- a/doc/development/guide/installation.rst
+++ b/doc/development/guide/installation.rst
@@ -1,6 +1,8 @@
 .. role:: html(raw)
    :format: html
 
+.. _installation:
+
 Installation and dependencies
 =============================
 

--- a/doc/development/guide/installation.rst
+++ b/doc/development/guide/installation.rst
@@ -1,3 +1,6 @@
+.. role:: html(raw)
+   :format: html
+
 Installation and dependencies
 =============================
 

--- a/doc/development/guide/installation.rst
+++ b/doc/development/guide/installation.rst
@@ -68,7 +68,7 @@ importing PennyLane in Python.
 
 Apart from the core packages needed to run PennyLane. Some extra packages need
 to be installed for several development processes, such as linting, testing, and
-pre-commit quality checks to name a few. Those can be installed easily via ``pip``:
+pre-commit quality checks. Those can be installed easily via ``pip``:
 
 .. code-block:: bash
 

--- a/doc/development/guide/installation.rst
+++ b/doc/development/guide/installation.rst
@@ -66,6 +66,14 @@ importing PennyLane in Python.
     requires ``pip install -e .`` to be re-run in the plugin repository
     for the changes to take effect.
 
+Apart from the core packages needed to run PennyLane. Some extra packages need
+to be installed for several development processes, such as linting, testing, and
+pre-commit quality checks to name a few. Those can be installed easily via ``pip``:
+
+.. code-block:: bash
+
+    pip install -r requirements-dev.txt
+
 Docker
 ------
 

--- a/doc/development/guide/tests.rst
+++ b/doc/development/guide/tests.rst
@@ -12,7 +12,7 @@ some extentions thereof, for example:
 * ``pytest-benchmark``: benchmarks the performance of functions, and can be used to ensure consistent runtime
 * ``pytest-xdist``: currently used to force some tests to run on the same thread to avoid race conditions
 
-If you properly followed the `installation guide <./installation>`__, you should have all of these packages and others installed in your
+If you properly followed the :doc:`installation guide <./installation>`, you should have all of these packages and others installed in your
 environment, so you can go ahead and put your code to the test!
 
 Creating a test

--- a/doc/development/guide/tests.rst
+++ b/doc/development/guide/tests.rst
@@ -12,7 +12,7 @@ some extentions thereof, for example:
 * ``pytest-benchmark``: benchmarks the performance of functions, and can be used to ensure consistent runtime
 * ``pytest-xdist``: currently used to force some tests to run on the same thread to avoid race conditions
 
-If you properly followed the :doc:`installation guide <./installation>`, you should have all of these packages and others installed in your
+If you properly followed the :doc:`installation guide <installation>`, you should have all of these packages and others installed in your
 environment, so you can go ahead and put your code to the test!
 
 Creating a test

--- a/doc/development/guide/tests.rst
+++ b/doc/development/guide/tests.rst
@@ -12,7 +12,7 @@ some extentions thereof, for example:
 * ``pytest-benchmark``: benchmarks the performance of functions, and can be used to ensure consistent runtime
 * ``pytest-xdist``: currently used to force some tests to run on the same thread to avoid race conditions
 
-If you properly followed the installation guide, you should have all of these packages and others installed in your
+If you properly followed the `installation guide <./installation>`__, you should have all of these packages and others installed in your
 environment, so you can go ahead and put your code to the test!
 
 Creating a test

--- a/doc/development/guide/tests.rst
+++ b/doc/development/guide/tests.rst
@@ -9,7 +9,7 @@ some extentions thereof, for example:
 * ``pytest-cov``: determines test coverage
 * ``pytest-mock``: allows replacing components with dummy/mock objects
 * ``flaky``: manages tests with non-deterministic behaviour
-* ``pytest-benchmark``: benchmarks the performance of functions, and can be used to ensure consistent runtime.
+* ``pytest-benchmark``: benchmarks the performance of functions, and can be used to ensure consistent runtime
 * ``pytest-xdist``: currently used to force some tests to run on the same thread to avoid race conditions
 
 If you properly followed the installation guide, you should have all of these packages and others installed in your

--- a/doc/development/guide/tests.rst
+++ b/doc/development/guide/tests.rst
@@ -12,7 +12,7 @@ some extentions thereof, for example:
 * ``pytest-benchmark``: benchmarks the performance of functions, and can be used to ensure consistent runtime
 * ``pytest-xdist``: currently used to force some tests to run on the same thread to avoid race conditions
 
-If you properly followed the :doc:`installation guide <installation>`, you should have all of these packages and others installed in your
+If you properly followed the :doc:`installation guide </development/guide/installation>`, you should have all of these packages and others installed in your
 environment, so you can go ahead and put your code to the test!
 
 Creating a test

--- a/doc/development/guide/tests.rst
+++ b/doc/development/guide/tests.rst
@@ -12,7 +12,7 @@ some extentions thereof, for example:
 * ``pytest-benchmark``: benchmarks the performance of functions, and can be used to ensure consistent runtime
 * ``pytest-xdist``: currently used to force some tests to run on the same thread to avoid race conditions
 
-If you properly followed the :doc:`installation guide </development/guide/installation>`, you should have all of these packages and others installed in your
+If you properly followed the instructions in :doc:`/development/guide/installation`, you should have all of these packages and others installed in your
 environment, so you can go ahead and put your code to the test!
 
 Creating a test

--- a/doc/development/guide/tests.rst
+++ b/doc/development/guide/tests.rst
@@ -3,17 +3,17 @@ Software tests
 
 Requirements
 ~~~~~~~~~~~~
-The PennyLane test suite requires the Python ``pytest`` package, as well as:
+The PennyLane test suite requires the Python ``pytest`` package, as well as
+some extentions thereof, for example:
 
 * ``pytest-cov``: determines test coverage
 * ``pytest-mock``: allows replacing components with dummy/mock objects
 * ``flaky``: manages tests with non-deterministic behaviour
+* ``pytest-benchmark``: benchmarks the performance of functions, and can be used to ensure consistent runtime.
+* ``pytest-xdist``: currently used to force some tests to run on the same thread to avoid race conditions
 
-These requirements can be installed via ``pip``:
-
-.. code-block:: bash
-
-    pip install pytest pytest-cov pytest-mock flaky
+If you properly followed the installation guide, you should have all of these packages and others installed in your
+environment, so you can go ahead and put your code to the test!
 
 Creating a test
 ~~~~~~~~~~~~~~~


### PR DESCRIPTION
**Context:**
Software Tests page was outdated and relied on listing the testing requirements instead of relying on the continuously updated `requirements-dev.txt` file. 

**Description of the Change:**
Instructions for installing the development requirements was added to the Installation page and the Requirements section of Software Tests has been modified to be more informative rather than instructive.

**Benefits:**
Less overhead to update the guide later if deps are added/removed.

[[sc-63429](https://app.shortcut.com/xanaduai/story/63429)]