### PR TITLE
Fix recent failures in legacy opmath

### DIFF
--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -2319,12 +2319,14 @@ class Tensor(Observable):
             for k, g in itertools.groupby(self.obs, lambda x: x.name in standard_observables):
                 if k:
                     # Subgroup g contains only standard observables.
-                    self._eigvals_cache = np.kron(self._eigvals_cache, pauli_eigs(len(list(g))))
+                    self._eigvals_cache = qml.math.kron(
+                        self._eigvals_cache, pauli_eigs(len(list(g)))
+                    )
                 else:
                     # Subgroup g contains only non-standard observables.
                     for ns_ob in g:
                         # loop through all non-standard observables
-                        self._eigvals_cache = np.kron(self._eigvals_cache, ns_ob.eigvals())
+                        self._eigvals_cache = qml.math.kron(self._eigvals_cache, ns_ob.eigvals())
 
         return self._eigvals_cache
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -217,6 +217,12 @@ def use_legacy_and_new_opmath(request):
         yield cm
 
 
+@pytest.fixture
+def new_opmath_only():
+    if not qml.operation.active_new_opmath():
+        pytest.skip("This feature only works with new opmath enabled")
+
+
 #######################################################################
 
 try:

--- a/tests/devices/default_tensor/test_tensor_expval.py
+++ b/tests/devices/default_tensor/test_tensor_expval.py
@@ -188,6 +188,7 @@ class TestExpval:
 
         assert np.allclose(calculated_val, reference_val, tol)
 
+    @pytest.mark.usefixtures("new_opmath_only")
     def test_hamiltonian_expectation(self, theta, phi, tol, dev):
         """Tests a Hamiltonian."""
 
@@ -354,6 +355,7 @@ class TestTensorExpval:
         assert np.allclose(calculated_val, reference_val, tol)
 
 
+@pytest.mark.usefixtures("new_opmath_only")
 @pytest.mark.parametrize("theta, phi", list(zip(THETA, PHI)))
 def test_multi_qubit_gates(theta, phi, dev):
     """Tests a simple circuit with multi-qubit gates."""

--- a/tests/devices/default_tensor/test_tensor_var.py
+++ b/tests/devices/default_tensor/test_tensor_var.py
@@ -187,6 +187,7 @@ class TestVar:
         tol = 1e-5 if dev.dtype == np.complex64 else 1e-7
         assert np.allclose(calculated_val, reference_val, atol=tol, rtol=0)
 
+    @pytest.mark.usefixtures("new_opmath_only")
     def test_hamiltonian_variance(self, theta, phi, dev):
         """Tests a Hamiltonian."""
 
@@ -361,6 +362,7 @@ class TestTensorVar:
         assert np.allclose(calculated_val, reference_val, tol)
 
 
+@pytest.mark.usefixtures("new_opmath_only")
 @pytest.mark.parametrize("theta, phi", list(zip(THETA, PHI)))
 def test_multi_qubit_gates(theta, phi, dev):
     """Tests a simple circuit with multi-qubit gates."""

--- a/tests/devices/qubit/test_measure.py
+++ b/tests/devices/qubit/test_measure.py
@@ -189,11 +189,9 @@ class TestMeasurements:
         t1, t2 = 0.5, 1.0
         assert qml.math.allclose(qnode(t1, t2), jax.jit(qnode)(t1, t2))
 
+    @pytest.mark.usefixtures("new_opmath_only")
     def test_measure_identity_no_wires(self):
         """Test that measure can handle the expectation value of identity on no wires."""
-
-        if not qml.operation.active_new_opmath():
-            pytest.skip("Identity with no wires is not supported with legacy opmath.")
 
         state = np.random.random([2, 2, 2])
         out = measure(qml.measurements.ExpectationMP(qml.I()), state)

--- a/tests/devices/qubit/test_sampling.py
+++ b/tests/devices/qubit/test_sampling.py
@@ -517,11 +517,9 @@ class TestMeasureSamples:
         [result] = measure_with_samples([mp], state, shots=qml.measurements.Shots(1))
         assert qml.math.allclose(result, 1.0)
 
+    @pytest.mark.usefixtures("new_opmath_only")
     def test_identity_on_no_wires_with_other_observables(self):
         """Test that measuring an identity on no wires can be used in conjunction with other measurements."""
-
-        if not qml.operation.active_new_opmath():
-            pytest.skip("Identity with no wires is not supported with legacy opmath.")
 
         state = np.array([0, 1])
 

--- a/tests/ops/op_math/test_sum.py
+++ b/tests/ops/op_math/test_sum.py
@@ -679,11 +679,9 @@ class TestProperties:
         sum_op = sum_method(*ops_lst)
         assert sum_op._queue_category is None  # pylint: disable=protected-access
 
+    @pytest.mark.usefixtures("new_opmath_only")
     def test_eigvals_Identity_no_wires(self):
         """Test that eigenvalues can be computed for a sum containing identity with no wires."""
-
-        if not qml.operation.active_new_opmath():
-            pytest.skip("Identity with no wires is not supported for legacy opmath")
 
         op1 = qml.X(0) + 2 * qml.I()
         op2 = qml.X(0) + 2 * qml.I(0)

--- a/tests/pauli/grouping/test_pauli_group_observables.py
+++ b/tests/pauli/grouping/test_pauli_group_observables.py
@@ -466,12 +466,10 @@ class TestGroupObservables:
         assert groups == [observables]
         assert coeffs == [[1, 2]]
 
+    @pytest.mark.usefixtures("new_opmath_only")
     def test_observables_on_no_wires_coeffs(self):
         """Test that observables on no wires are stuck in the first group and
         coefficients are tracked when provided."""
-
-        if not qml.operation.active_new_opmath():
-            pytest.skip("Identity with no wires is not supported with legacy opmath.")
 
         observables = [
             qml.X(0),

--- a/tests/test_pytrees.py
+++ b/tests/test_pytrees.py
@@ -14,6 +14,9 @@
 """
 Tests for the pennylane pytrees module
 """
+
+import pytest
+
 import pennylane as qml
 from pennylane.pytrees import PyTreeStructure, flatten, leaf, register_pytree, unflatten
 
@@ -102,6 +105,9 @@ def test_dict():
 
 def test_nested_pl_object():
     """Test that we can flatten and unflatten nested pennylane object."""
+
+    if not qml.operation.active_new_opmath():
+        pytest.skip("This feature is new opmath only.")
 
     tape = qml.tape.QuantumScript(
         [qml.adjoint(qml.RX(0.1, wires=0))],

--- a/tests/test_pytrees.py
+++ b/tests/test_pytrees.py
@@ -103,11 +103,9 @@ def test_dict():
     assert new_x == {"a": 5, "b": {"c": 6, "d": 7}}
 
 
+@pytest.mark.usefixtures("new_opmath_only")
 def test_nested_pl_object():
     """Test that we can flatten and unflatten nested pennylane object."""
-
-    if not qml.operation.active_new_opmath():
-        pytest.skip("This feature is new opmath only.")
 
     tape = qml.tape.QuantumScript(
         [qml.adjoint(qml.RX(0.1, wires=0))],

--- a/tests/test_qnode_legacy.py
+++ b/tests/test_qnode_legacy.py
@@ -1876,12 +1876,10 @@ class TestTapeExpansion:
 
         assert len(tapes) == 2
 
+    @pytest.mark.usefixtures("new_opmath_only")
     @pytest.mark.parametrize("grouping", [True, False])
     def test_multiple_hamiltonian_expansion_finite_shots(self, grouping):
         """Test that multiple Hamiltonians works correctly (sum_expand should be used)"""
-
-        if not qml.operation.active_new_opmath():
-            pytest.skip("expval of the legacy Hamiltonian does not support finite shots.")
 
         dev = qml.device("default.qubit.legacy", wires=3, shots=50000)
 


### PR DESCRIPTION
- Update `Tensor.eigvals` to use `qml.math.kron` instead of `np.kron`, fixes https://github.com/PennyLaneAI/pennylane/actions/runs/9248166629/job/25438052473
- Adds a `new_opmath_only` fixture that skips tests not meant to work for legacy opmath
- Mark `tests/test_pytrees.py::test_nested_pl_object` as `new_opmath_only` (confirmed with @albi3ro)
- Mark tests in `tests/devices/default_tensor` involving `Hamiltonian` as `new_opmath_only` (confirmed with @PietropaoloFrisoni)