### PR TITLE
Selecting wires of `default.tensor` at runtime if they are not provided by user

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -9,6 +9,9 @@
 
 <h3>Improvements 🛠</h3>
 
+* The `wires` argument for the `default.tensor` device are selected at runtime if they are not provided by user.
+  [(#5744)](https://github.com/PennyLaneAI/pennylane/pull/5744)
+
 * `ctrl` now works with tuple-valued `control_values` when applied to any already controlled operation.
   [(#5725)](https://github.com/PennyLaneAI/pennylane/pull/5725)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -9,7 +9,7 @@
 
 <h3>Improvements 🛠</h3>
 
-* The `wires` argument for the `default.tensor` device are selected at runtime if they are not provided by user.
+* The wires for the `default.tensor` device are selected at runtime if they are not provided by user.
   [(#5744)](https://github.com/PennyLaneAI/pennylane/pull/5744)
 
 * `ctrl` now works with tuple-valued `control_values` when applied to any already controlled operation.

--- a/pennylane/devices/default_tensor.py
+++ b/pennylane/devices/default_tensor.py
@@ -328,13 +328,6 @@ class DefaultTensor(Device):
             gate_contract=self._contract,
             cutoff=self._cutoff,
         )
-    def _reset_state(self) -> None:
-        """
-        Reset the MPS.
-
-        This method modifies the tensor state of the device.
-        """
-        self._circuitMPS = qtn.CircuitMPS(psi0=self._initial_mps())
 
     def _initial_mps(self, wires: qml.wires.Wires) -> "qtn.MatrixProductState":
         r"""

--- a/pennylane/devices/default_tensor.py
+++ b/pennylane/devices/default_tensor.py
@@ -384,9 +384,7 @@ class DefaultTensor(Device):
             op (Operator): The operation to apply.
         """
 
-        self._quimb_mps.apply_gate(
-            qml.matrix(op).astype(self._dtype), *op.wires, parametrize=None
-        )
+        self._quimb_mps.apply_gate(qml.matrix(op).astype(self._dtype), *op.wires, parametrize=None)
 
     def measurement(self, measurementprocess: MeasurementProcess) -> TensorLike:
         """Measure the measurement required by the circuit over the MPS.

--- a/pennylane/devices/default_tensor.py
+++ b/pennylane/devices/default_tensor.py
@@ -290,6 +290,10 @@ class DefaultTensor(Device):
         self._cutoff = kwargs.get("cutoff", np.finfo(self._dtype).eps)
         self._contract = kwargs.get("contract", "auto-mps")
 
+        # The `quimb` state is a class attribute so that we can implement methods
+        # that access it as soon as the device is created without running a circuit.
+        # The state is reset every time a new circuit is executed, and number of wires
+        # can be established at runtime to match the circuit.
         self._quimb_mps = qtn.CircuitMPS(psi0=self._initial_mps(self.wires))
 
         for arg in kwargs:


### PR DESCRIPTION
**Context:** In the `default.tensor` device, we need to create an initial state (e.g. in the MPS case using the `MPS_computational_state function`) in `quimb`, which requires the number of qubits to be defined.

We have a very cryptic error from `quimb` as soon as we compute something with this device if there is a mismatch between the circuit wires and those on the device. 

To circumvent this issue, we previously made `wires` the last positional argument for this device (as in `lightning.qubit`), checking at runtime if there's a mismatch between the wires on the device and those associated with the circuit.

**Description of the Change:** We now instantiate the `quimb` tensor directly in the `simulate` function. The wires on the device are selected at runtime to match those on the circuit in case they haven't been provided by the user.

Otherwise, `default.tensor` raises an informative error if the wires have been provided by the user and there is a mismatch.
This allows the `wires` argument to be optional for this device.

**Benefits:** This makes the `default.tensor` more flexible and, generally, more compatible with the existing devices in PL.

**Possible Drawbacks:** As stated above, we have an error if there is a clear mismatch, such as:

```
dev = qml.device("default.tensor", wires=2)
ops = [
    qml.Identity(wires=0),
    qml.Identity(wires=(0, 1)),
    qml.CNOT(wires=[0, 1]),
    qml.RX(phi=0.5, wires=0),
    qml.RY(phi=1, wires=5),
    qml.RX(phi=2, wires=1),
]
measurements = [qml.expval(qml.PauliZ(wires=15))]
tape = qml.tape.QuantumScript(ops, measurements)

>>> dev.execute(tape)
WireError: Mismatch between circuit and device wires. Circuit has wires [0, 1, 5, 15]. Tensor on device has wires [0, 1]
```
which seems justified. However, the error disappears if we don't provide wires:

```
dev = qml.device("default.tensor")
ops = [
    qml.Identity(wires=0),
    qml.Identity(wires=(0, 1)),
    qml.CNOT(wires=[0, 1]),
    qml.RX(phi=0.5, wires=0),
    qml.RY(phi=1, wires=5),
    qml.RX(phi=2, wires=1),
]
measurements = [qml.expval(qml.PauliZ(wires=15))]
tape = qml.tape.QuantumScript(ops, measurements)

dev.execute(tape)
1.0
```

**Related GitHub Issues:** None.

**Related Shortcut Stories:** [sc-64007]