### PR TITLE
Define BasisStateProjector.compute_sparse_matrix

### DIFF
--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -1004,7 +1004,6 @@ class Device(abc.ABC):
                         )
 
             elif isinstance(o, qml.ops.Prod):
-
                 supports_prod = self.supports_observable(o.name)
                 if not supports_prod:
                     raise DeviceError(f"Observable Prod not supported on device {self.short_name}")

--- a/pennylane/devices/default_tensor.py
+++ b/pennylane/devices/default_tensor.py
@@ -183,7 +183,6 @@ class DefaultTensor(Device):
         dtype=np.complex128,
         **kwargs,
     ) -> None:
-
         if wires is None:
             raise TypeError("Wires must be provided for the default.tensor device.")
 

--- a/pennylane/devices/preprocess.py
+++ b/pennylane/devices/preprocess.py
@@ -342,7 +342,6 @@ def decompose(
     if all(stopping_condition(op) for op in tape.operations[len(prep_op) :]):
         return (tape,), null_postprocessing
     try:
-
         new_ops = [
             final_op
             for op in tape.operations[len(prep_op) :]

--- a/pennylane/devices/qubit/sampling.py
+++ b/pennylane/devices/qubit/sampling.py
@@ -107,7 +107,6 @@ def _get_num_executions_for_expval_H(obs):
 
 
 def _get_num_executions_for_sum(obs):
-
     if obs.grouping_indices:
         return len(obs.grouping_indices)
 

--- a/pennylane/drawer/utils.py
+++ b/pennylane/drawer/utils.py
@@ -122,7 +122,6 @@ def unwrap_controls(op):
         next_ctrl = op
 
         while hasattr(next_ctrl, "base"):
-
             if isinstance(next_ctrl.base, Controlled):
                 base_control_wires = getattr(next_ctrl.base, "control_wires", [])
                 control_wires += base_control_wires

--- a/pennylane/math/multi_dispatch.py
+++ b/pennylane/math/multi_dispatch.py
@@ -342,7 +342,6 @@ def dot(tensor1, tensor2, like=None):
     x, y = np.coerce([tensor1, tensor2], like=like)
 
     if like == "torch":
-
         if x.ndim == 0 or y.ndim == 0:
             return x * y
 
@@ -352,7 +351,6 @@ def dot(tensor1, tensor2, like=None):
         return np.tensordot(x, y, axes=[[-1], [-2]], like=like)
 
     if like in {"tensorflow", "autograd"}:
-
         ndim_y = len(np.shape(y))
         ndim_x = len(np.shape(x))
 

--- a/pennylane/measurements/sample.py
+++ b/pennylane/measurements/sample.py
@@ -156,7 +156,6 @@ class SampleMP(SampleMeasurement):
     """
 
     def __init__(self, obs=None, wires=None, eigvals=None, id=None):
-
         if isinstance(obs, MeasurementValue):
             super().__init__(obs=obs)
             return

--- a/pennylane/measurements/var.py
+++ b/pennylane/measurements/var.py
@@ -144,4 +144,6 @@ class VarianceMP(SampleMeasurement, StateMeasurement):
             probabilities (array): the probabilities of collapsing to eigen states
         """
         eigvals = qml.math.asarray(self.eigvals(), dtype="float64")
-        return qml.math.dot(probabilities, (eigvals**2)) - qml.math.dot(probabilities, eigvals) ** 2
+        return (
+            qml.math.dot(probabilities, (eigvals**2)) - qml.math.dot(probabilities, eigvals) ** 2
+        )

--- a/pennylane/ops/functions/eigvals.py
+++ b/pennylane/ops/functions/eigvals.py
@@ -116,7 +116,6 @@ def eigvals(op: qml.operation.Operator, k=1, which="SA") -> TensorLike:
         return _eigvals_tranform(op, k=k, which=which)
 
     if isinstance(op, qml.ops.Hamiltonian):
-
         warnings.warn(
             "For Hamiltonians, the eigenvalues will be computed numerically. "
             "This may be computationally intensive for a large number of wires. "

--- a/pennylane/ops/functions/is_commuting.py
+++ b/pennylane/ops/functions/is_commuting.py
@@ -155,7 +155,6 @@ def _check_opmath_operations(operation1, operation2):
     """Check that `Tensor`, `SProd`, `Prod`, and `Sum` instances only contain Pauli words."""
 
     for op in [operation1, operation2]:
-
         if op.pauli_rep is not None:
             continue
 

--- a/pennylane/ops/functions/matrix.py
+++ b/pennylane/ops/functions/matrix.py
@@ -178,7 +178,6 @@ def matrix(op: Union[Operator, PauliWord, PauliSentence], wire_order=None) -> Te
 
     """
     if not isinstance(op, Operator):
-
         if isinstance(op, (PauliWord, PauliSentence)):
             if wire_order is None and len(op.wires) > 1:
                 raise ValueError(
@@ -213,7 +212,6 @@ def matrix(op: Union[Operator, PauliWord, PauliSentence], wire_order=None) -> Te
         op = 1.0 * op  # convert to a Hamiltonian
 
     if isinstance(op, qml.ops.Hamiltonian):
-
         return op.sparse_matrix(wire_order=wire_order).toarray()
 
     try:

--- a/pennylane/ops/op_math/controlled.py
+++ b/pennylane/ops/op_math/controlled.py
@@ -647,7 +647,6 @@ class Controlled(SymbolicOp):
         return False
 
     def decomposition(self):
-
         if self.compute_decomposition is not Operator.compute_decomposition:
             return self.compute_decomposition(*self.data, self.wires)
 

--- a/pennylane/ops/op_math/controlled_ops.py
+++ b/pennylane/ops/op_math/controlled_ops.py
@@ -1036,7 +1036,6 @@ class MultiControlledX(ControlledOp):
 
     # pylint: disable=too-many-arguments
     def __init__(self, control_wires=None, wires=None, control_values=None, work_wires=None):
-
         # First raise deprecation warnings regardless of the validity of other arguments
         if isinstance(control_values, str):
             warnings.warn(

--- a/pennylane/ops/op_math/linear_combination.py
+++ b/pennylane/ops/op_math/linear_combination.py
@@ -135,7 +135,6 @@ class LinearCombination(Sum):
             _pauli_rep = self._build_pauli_rep_static(coeffs, observables)
 
         if simplify:
-
             warnings.warn(
                 "The simplify argument in qml.Hamiltonian and qml.ops.LinearCombination is deprecated. "
                 "Instead, you can call qml.simplify on the constructed operator.",

--- a/pennylane/ops/qubit/hamiltonian.py
+++ b/pennylane/ops/qubit/hamiltonian.py
@@ -283,7 +283,6 @@ class Hamiltonian(Observable):
         self._grouping_indices = None
 
         if simplify:
-
             warn(
                 "The simplify argument in qml.Hamiltonian and qml.ops.LinearCombination is deprecated. "
                 "Instead, you can call qml.simplify on the constructed operator.",

--- a/pennylane/ops/qubit/observables.py
+++ b/pennylane/ops/qubit/observables.py
@@ -584,6 +584,24 @@ class BasisStateProjector(Projector, Operation):
         """
         return []
 
+    @staticmethod
+    def compute_sparse_matrix(basis_state):  # pylint: disable=arguments-differ,unused-argument
+        """
+        Computes the sparse CSR matrix representation of the projector onto the basis state.
+
+        Args:
+            basis_state (Iterable): The basis state as an iterable of integers (0 or 1).
+
+        Returns:
+            scipy.sparse.csr_matrix: The sparse CSR matrix representation of the projector.
+        """
+
+        num_qubits = len(basis_state)
+        data = [1]
+        rows = [int("".join(str(bit) for bit in basis_state), 2)]
+        cols = rows
+        return csr_matrix((data, (rows, cols)), shape=(2**num_qubits, 2**num_qubits))
+
 
 class StateVectorProjector(Projector):
     r"""Observable corresponding to the state projector :math:`P=\ket{\phi}\bra{\phi}`, where

--- a/pennylane/ops/qubit/parametric_ops_multi_qubit.py
+++ b/pennylane/ops/qubit/parametric_ops_multi_qubit.py
@@ -1244,7 +1244,6 @@ class IsingXY(Operation):
     parameter_frequencies = [(0.5, 1.0)]
 
     def generator(self):
-
         return qml.Hamiltonian(
             [0.25, 0.25],
             [

--- a/pennylane/pauli/dla/lie_closure.py
+++ b/pennylane/pauli/dla/lie_closure.py
@@ -239,7 +239,6 @@ class PauliVSpace:
     """
 
     def __init__(self, generators, dtype=float, tol=None):
-
         self.dtype = dtype
 
         if any(not isinstance(g, PauliSentence) for g in generators):

--- a/pennylane/qchem/openfermion_obs.py
+++ b/pennylane/qchem/openfermion_obs.py
@@ -934,7 +934,6 @@ def molecular_hamiltonian(
         wires_map = dict(zip(range(len(wires_new)), list(wires_new.labels)))
 
     if method == "dhf":
-
         if mapping != "jordan_wigner":
             raise ValueError(
                 "Only 'jordan_wigner' mapping is supported for the differentiable workflow."

--- a/pennylane/qinfo/transforms.py
+++ b/pennylane/qinfo/transforms.py
@@ -320,7 +320,6 @@ def _bipartite_qinfo_transform(
     base: float = None,
     **kwargs,
 ):
-
     # device_wires is provided by the custom QNode transform
     all_wires = kwargs.get("device_wires", tape.wires)
     wire_map = {w: i for i, w in enumerate(all_wires)}

--- a/pennylane/templates/subroutines/qubitization.py
+++ b/pennylane/templates/subroutines/qubitization.py
@@ -115,7 +115,6 @@ class Qubitization(Operation):
         return cls(hamiltonian, **hyperparams_dict)
 
     def __copy__(self):
-
         clone = Qubitization.__new__(Qubitization)
 
         # Ensure the operators in the hyper-parameters are copied instead of aliased.

--- a/pennylane/workflow/qnode.py
+++ b/pennylane/workflow/qnode.py
@@ -86,7 +86,6 @@ def _make_execution_config(
 def _to_qfunc_output_type(
     results: qml.typing.Result, qfunc_output, has_partitioned_shots
 ) -> qml.typing.Result:
-
     if has_partitioned_shots:
         return tuple(_to_qfunc_output_type(r, qfunc_output, False) for r in results)
 
@@ -723,7 +722,6 @@ class QNode:
         """
         config = _make_execution_config(None, "best")
         if isinstance(device, qml.devices.Device):
-
             if device.supports_derivatives(config, circuit=tape):
                 new_config = device.preprocess(config)[1]
                 return new_config.gradient_method, {}, device
@@ -1075,7 +1073,6 @@ class QNode:
         )
 
     def __call__(self, *args, **kwargs) -> qml.typing.Result:
-
         old_interface = self.interface
         if old_interface == "auto":
             interface = qml.math.get_interface(*args, *list(kwargs.values()))

--- a/tests/devices/modifiers/test_all_modifiers.py
+++ b/tests/devices/modifiers/test_all_modifiers.py
@@ -74,7 +74,6 @@ class TestModifierDefaultBeahviour:
 
         @modifier
         class DummyDev2(qml.devices.Device):
-
             _applied_modifiers = [None]  # some existing value
 
             def execute(self, circuits, execution_config=qml.devices.DefaultExecutionConfig):

--- a/tests/gradients/core/test_metric_tensor.py
+++ b/tests/gradients/core/test_metric_tensor.py
@@ -1132,7 +1132,6 @@ class TestFullMetricTensor:
     @pytest.mark.parametrize("interface", ["auto", "autograd"])
     @pytest.mark.parametrize("dev_name", ("default.qubit", "lightning.qubit"))
     def test_correct_output_autograd(self, dev_name, ansatz, params, interface):
-
         expected = autodiff_metric_tensor(ansatz, self.num_wires)(*params)
         dev = qml.device(dev_name, wires=self.num_wires + 1)
 

--- a/tests/math/test_multi_dispatch.py
+++ b/tests/math/test_multi_dispatch.py
@@ -185,7 +185,6 @@ def test_gammainc(n, t, gamma_ref):
 
 
 def test_dot_autograd():
-
     x = np.array([1.0, 2.0], requires_grad=False)
     y = np.array([2.0, 3.0], requires_grad=True)
 
@@ -198,7 +197,6 @@ def test_dot_autograd():
 
 
 def test_dot_autograd_with_scalar():
-
     x = np.array(1.0, requires_grad=False)
     y = np.array([2.0, 3.0], requires_grad=True)
 
@@ -214,7 +212,6 @@ def test_dot_autograd_with_scalar():
 
 
 def test_dot_tf_with_scalar():
-
     x = tf.Variable(1.0)
     y = tf.Variable([2.0, 3.0])
 
@@ -228,7 +225,6 @@ def test_dot_tf_with_scalar():
 
 
 def test_dot_torch_with_scalar():
-
     x = torch.tensor(1.0)
     y = torch.tensor([2.0, 3.0])
 

--- a/tests/ops/functions/test_equal.py
+++ b/tests/ops/functions/test_equal.py
@@ -327,7 +327,6 @@ def test_assert_equal_types():
 
 
 def test_assert_equal_unspecified():
-
     # pylint: disable=too-few-public-methods
     class RandomType:
         """dummy type"""

--- a/tests/ops/op_math/test_pow_op.py
+++ b/tests/ops/op_math/test_pow_op.py
@@ -347,7 +347,6 @@ class TestProperties:
         """Test that if an error occurs with a batched exponent, has_decomposition is False."""
 
         class MyOp(qml.operation.Operator):
-
             def pow(self, z):
                 return super().pow(z % 2)
 
@@ -361,7 +360,6 @@ class TestProperties:
         """Test that if Operator.pow raises an error and no batching is present, the erorr is raised."""
 
         class MyOp(qml.operation.Operator):
-
             def pow(self, z):
                 raise ValueError
 

--- a/tests/ops/qubit/test_hamiltonian.py
+++ b/tests/ops/qubit/test_hamiltonian.py
@@ -66,7 +66,6 @@ H_TWO_QUBITS = np.array(
 COEFFS = [(0.5, 1.2, -0.7), (2.2, -0.2, 0.0), (0.33,)]
 
 with qml.operation.disable_new_opmath_cm():
-
     OBSERVABLES = [
         (qml.PauliZ(0), qml.PauliY(0), qml.PauliZ(1)),
         (qml.PauliX(0) @ qml.PauliZ(1), qml.PauliY(0) @ qml.PauliZ(1), qml.PauliZ(1)),

--- a/tests/ops/qubit/test_observables.py
+++ b/tests/ops/qubit/test_observables.py
@@ -19,6 +19,7 @@ import pickle
 import numpy as np
 import pytest
 from gate_data import H, I, X, Y, Z
+from scipy.sparse import csr_matrix
 
 import pennylane as qml
 from pennylane.ops.qubit.observables import BasisStateProjector, StateVectorProjector
@@ -577,6 +578,72 @@ class TestProjector:
 
         expected = np.array([[0, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]])
         assert qml.math.allclose(out, expected)
+
+    def test_single_qubit_basis_state_0(self):
+        """Tests the function with a single-qubit basis state |0>."""
+        basis_state = [0]
+        expected_matrix = csr_matrix(([], ([], [])), shape=(2, 2))
+        expected_matrix.data = [1]
+        expected_matrix.rows = [0]
+        expected_matrix.cols = [0]
+        actual_matrix = BasisStateProjector.compute_sparse_matrix(basis_state)
+        self.assertEqual(expected_matrix.toarray(), actual_matrix.toarray())
+
+    def test_single_qubit_basis_state_1(self):
+        """Tests the function with a single-qubit basis state |1>."""
+        basis_state = [1]
+        expected_matrix = csr_matrix(([], ([], [])), shape=(2, 2))
+        expected_matrix.data = [1]
+        expected_matrix.rows = [1]
+        expected_matrix.cols = [1]
+        actual_matrix = BasisStateProjector.compute_sparse_matrix(basis_state)
+        self.assertEqual(expected_matrix.toarray(), actual_matrix.toarray())
+
+    def test_two_qubit_basis_state_10(self):
+        """Tests the function with a two-qubits basis state |10>."""
+        basis_state = [1, 0]
+        expected_matrix = csr_matrix(([], ([], [])), shape=(4, 4))
+        expected_matrix.data = [1]
+        expected_matrix.rows = [2]
+        expected_matrix.cols = [2]
+        actual_matrix = BasisStateProjector.compute_sparse_matrix(basis_state)
+        self.assertEqual(expected_matrix.toarray(), actual_matrix.toarray())
+
+    def test_two_qubit_basis_state_01(self):
+        """Tests the function with a two-qubits basis state |01>."""
+        basis_state = [0, 1]
+        expected_matrix = csr_matrix(([], ([], [])), shape=(4, 4))
+        expected_matrix.data = [1]
+        expected_matrix.rows = [1]
+        expected_matrix.cols = [1]
+        actual_matrix = BasisStateProjector.compute_sparse_matrix(basis_state)
+        self.assertEqual(expected_matrix.toarray(), actual_matrix.toarray())
+
+    def test_two_qubit_basis_state_11(self):
+        """Tests the function with a two-qubits basis state |11>."""
+        basis_state = [1, 1]
+        expected_matrix = csr_matrix(([], ([], [])), shape=(4, 4))
+        expected_matrix.data = [1]
+        expected_matrix.rows = [3]
+        expected_matrix.cols = [3]
+        actual_matrix = BasisStateProjector.compute_sparse_matrix(basis_state)
+        self.assertEqual(expected_matrix.toarray(), actual_matrix.toarray())
+
+    def test_three_qubit_basis_state_101(self):
+        """Tests the function with a three-qubits basis state |101>."""
+        basis_state = [1, 1]
+        expected_matrix = csr_matrix(([], ([], [])), shape=(8, 8))
+        expected_matrix.data = [1]
+        expected_matrix.rows = [5]
+        expected_matrix.cols = [5]
+        actual_matrix = BasisStateProjector.compute_sparse_matrix(basis_state)
+        self.assertEqual(expected_matrix.toarray(), actual_matrix.toarray())
+
+    def test_invalid_basis_state(self):
+        """Tests the function with an invalid state."""
+        basis_state = [0, 2]  # Invalid basis state
+        with self.assertRaises(ValueError):
+            BasisStateProjector.compute_sparse_matrix(basis_state)
 
 
 class TestBasisStateProjector:

--- a/tests/pauli/dla/test_structure_constants.py
+++ b/tests/pauli/dla/test_structure_constants.py
@@ -56,7 +56,6 @@ class TestAdjointRepr:
         ad_rep = structure_constants(dla, pauli=True)
         for i in range(d):
             for j in range(d):
-
                 comm_res = 1j * dla[i].commutator(dla[j])
 
                 res = sum(

--- a/tests/pauli/test_pauli_utils.py
+++ b/tests/pauli/test_pauli_utils.py
@@ -1010,7 +1010,6 @@ class TestMeasurementTransformations:
 
 
 class TestObservableHF:
-
     with qml.operation.disable_new_opmath_cm():
         HAMILTONIAN_SIMPLIFY = [
             (

--- a/tests/qchem/test_tapering.py
+++ b/tests/qchem/test_tapering.py
@@ -535,7 +535,6 @@ def test_taper_obs(symbols, geometry, charge):
         qml.qchem.spinz(len(hamiltonian.wires)),
     ]
     for observable in observables:
-
         obs_ps = qml.pauli.pauli_sentence(observable)
         tapered_obs = qml.taper(observable, generators, paulixops, paulix_sector)
         tapered_ps = _taper_pauli_sentence(obs_ps, generators, paulixops, paulix_sector)

--- a/tests/qinfo/test_vn_entanglement_entropy.py
+++ b/tests/qinfo/test_vn_entanglement_entropy.py
@@ -79,7 +79,6 @@ class TestVnEntanglementEntropy:
     @pytest.mark.autograd
     @pytest.mark.parametrize("params", np.linspace(0, 2 * np.pi, 4)[1:])
     def test_qnode_transform_grad(self, params):
-
         dev = qml.device("default.qubit", wires=2)
 
         @qml.qnode(dev, diff_method="backprop")
@@ -156,7 +155,6 @@ class TestVnEntanglementEntropy:
     @pytest.mark.torch
     @pytest.mark.parametrize("params", np.linspace(0, 2 * np.pi, 4)[1:])
     def test_qnode_transform_grad_torch(self, params):
-
         import torch
 
         dev = qml.device("default.qubit", wires=2)

--- a/tests/qnn/test_qnn_torch.py
+++ b/tests/qnn/test_qnn_torch.py
@@ -383,7 +383,6 @@ class TestTorchLayer:  # pylint: disable=too-many-public-methods
         circuit_out_raw = c(x, *weights)
 
         if isinstance(shots, list):
-
             assert isinstance(layer_out, tuple)
             for out, exp in zip(layer_out, circuit_out_raw):
                 circuit_out = torch.hstack(exp)

--- a/tests/resource/test_error/test_trotter_error.py
+++ b/tests/resource/test_error/test_trotter_error.py
@@ -233,7 +233,9 @@ class TestErrorFunctions:
     one_norm_error_dict = {
         1: lambda a1, a2, t, n: (1 / n) * (t * (abs(a1) + abs(a2))) ** 2,
         2: lambda a1, a2, t, n: (1 / n**2) * (3 / 2) * (t * (abs(a1) + abs(a2))) ** 3,
-        4: lambda a1, a2, t, n: (1 / n**4) * ((10**5 + 1) / 120) * (t * (abs(a1) + abs(a2))) ** 5,
+        4: lambda a1, a2, t, n: (1 / n**4)
+        * ((10**5 + 1) / 120)
+        * (t * (abs(a1) + abs(a2))) ** 5,
     }
 
     @pytest.mark.parametrize(

--- a/tests/templates/test_subroutines/test_qubitization.py
+++ b/tests/templates/test_subroutines/test_qubitization.py
@@ -85,7 +85,6 @@ def test_operator_definition_qpe(hamiltonian):
 
     @qml.qnode(qml.device("default.qubit"))
     def circuit(theta):
-
         # initial state
         qml.RX(theta[2], wires=0)
         qml.CRY(theta[3], wires=[0, 2])

--- a/tests/test_qaoa.py
+++ b/tests/test_qaoa.py
@@ -100,7 +100,6 @@ def matrix(hamiltonian: qml.Hamiltonian, n_wires: int) -> csc_matrix:
     ops_matrices = []
 
     for op in hamiltonian.ops:
-
         if isinstance(op, qml.ops.Prod):
             op_matrix = op.sparse_matrix(wire_order=list(range(n_wires)))
         else:

--- a/tests/transforms/test_qcut.py
+++ b/tests/transforms/test_qcut.py
@@ -1587,12 +1587,10 @@ class TestGetMeasurements:
         assert obs[1].wires.tolist() == [1, 0]
 
         if qml.operation.active_new_opmath():
-
             assert [get_name(o) for o in obs[0].terms()[1]] == ["Prod"]
             assert [get_name(o) for o in obs[1].terms()[1]] == ["Prod"]
 
         else:
-
             assert [get_name(o) for o in obs[0].obs] == ["PauliZ", "PauliX", "PauliZ"]
             assert [get_name(o) for o in obs[1].obs] == ["PauliZ", "PauliX"]
 


### PR DESCRIPTION
Towards #5721.

I have implemented the BasisStateProjector.compute_sparse_matrix.

Just need one clarification, in #5721 it is mentioned that the units tests has to placed under `tests/ops/qubit/test_observable.py:TestProjector` https://github.com/PennyLaneAI/pennylane/blob/0dcba4495af81890f8d76e6a5715f6994505f560/tests/ops/qubit/test_observables.py#L461

But i think the unit tests for BasisStateProjector should be place under `class TestBasisStateProjector1` inside `tests/ops/qubit/test_observable.py`, Please correct if i am wrong!