### PR TITLE
Making `default.tensor` compatible with opmath disabled

### DIFF
--- a/pennylane/devices/default_tensor.py
+++ b/pennylane/devices/default_tensor.py
@@ -388,7 +388,9 @@ class DefaultTensor(Device):
             op (Operator): The operation to apply.
         """
 
-        self._circuitMPS.apply_gate(op.matrix().astype(self._dtype), *op.wires, **self._gate_opts)
+        self._circuitMPS.apply_gate(
+            qml.matrix(op).astype(self._dtype), *op.wires, **self._gate_opts
+        )
 
     def measurement(self, measurementprocess: MeasurementProcess) -> TensorLike:
         """Measure the measurement required by the circuit over the MPS.
@@ -434,7 +436,7 @@ class DefaultTensor(Device):
 
         obs = measurementprocess.obs
 
-        result = self._local_expectation(obs.matrix(), tuple(obs.wires))
+        result = self._local_expectation(qml.matrix(obs), tuple(obs.wires))
 
         return result
 
@@ -450,7 +452,7 @@ class DefaultTensor(Device):
 
         obs = measurementprocess.obs
 
-        obs_mat = obs.matrix()
+        obs_mat = qml.matrix(obs)
         expect_op = self.expval(measurementprocess)
         expect_squar_op = self._local_expectation(obs_mat @ obs_mat.conj().T, tuple(obs.wires))
 

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -3017,7 +3017,7 @@ def enable_new_opmath(warn=True):
     """
     if warn:
         warnings.warn(
-            "Re-enabling the new Operator arithmetic system after disabling it is not advised."
+            "Re-enabling the new Operator arithmetic system after disabling it is not advised. "
             "Please visit https://docs.pennylane.ai/en/stable/news/new_opmath.html for help troubleshooting.",
             UserWarning,
         )
@@ -3044,8 +3044,8 @@ def disable_new_opmath(warn=True):
     """
     if warn:
         warnings.warn(
-            "Disabling the new Operator arithmetic system for legacy support."
-            "If you need help troubleshooting your code, please visit"
+            "Disabling the new Operator arithmetic system for legacy support. "
+            "If you need help troubleshooting your code, please visit "
             "https://docs.pennylane.ai/en/stable/news/new_opmath.html",
             UserWarning,
         )

--- a/tests/devices/default_tensor/test_default_tensor.py
+++ b/tests/devices/default_tensor/test_default_tensor.py
@@ -330,7 +330,6 @@ class TestSupportsDerivatives:
             return qml.expval(qml.Z(0))
 
         weights = jax.numpy.array([0.2, 0.5, 0.1])
-        print(isinstance(dev, qml.Device))
         qnode = qml.QNode(circuit, dev, interface="jax")
         ref_qnode = qml.QNode(circuit, ref_dev, interface="jax")
 

--- a/tests/devices/default_tensor/test_tensor_expval.py
+++ b/tests/devices/default_tensor/test_tensor_expval.py
@@ -188,7 +188,6 @@ class TestExpval:
 
         assert np.allclose(calculated_val, reference_val, tol)
 
-    @pytest.mark.usefixtures("new_opmath_only")
     def test_hamiltonian_expectation(self, theta, phi, tol, dev):
         """Tests a Hamiltonian."""
 
@@ -355,7 +354,6 @@ class TestTensorExpval:
         assert np.allclose(calculated_val, reference_val, tol)
 
 
-@pytest.mark.usefixtures("new_opmath_only")
 @pytest.mark.parametrize("theta, phi", list(zip(THETA, PHI)))
 def test_multi_qubit_gates(theta, phi, dev):
     """Tests a simple circuit with multi-qubit gates."""

--- a/tests/devices/default_tensor/test_tensor_var.py
+++ b/tests/devices/default_tensor/test_tensor_var.py
@@ -187,7 +187,6 @@ class TestVar:
         tol = 1e-5 if dev.dtype == np.complex64 else 1e-7
         assert np.allclose(calculated_val, reference_val, atol=tol, rtol=0)
 
-    @pytest.mark.usefixtures("new_opmath_only")
     def test_hamiltonian_variance(self, theta, phi, dev):
         """Tests a Hamiltonian."""
 
@@ -362,6 +361,8 @@ class TestTensorVar:
         assert np.allclose(calculated_val, reference_val, tol)
 
 
+# This test is only for the new opmath since there is an error
+# in the tape computation with `default.qubit`, that we use as reference.
 @pytest.mark.usefixtures("new_opmath_only")
 @pytest.mark.parametrize("theta, phi", list(zip(THETA, PHI)))
 def test_multi_qubit_gates(theta, phi, dev):


### PR DESCRIPTION
**Context:**

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:** None

**Related Shortcut Stories.** [sc-64197] 