### PR TITLE
Replacing `semantic version` with `Version`

### DIFF
--- a/pennylane/math/single_dispatch.py
+++ b/pennylane/math/single_dispatch.py
@@ -18,7 +18,7 @@ from importlib import import_module
 
 import autoray as ar
 import numpy as np
-import semantic_version
+from packaging.version import Version
 from scipy.linalg import block_diag as _scipy_block_diag
 
 from .utils import get_deep_interface, is_abstract
@@ -730,7 +730,7 @@ ar.register_function("torch", "sort", _sort_torch)
 
 def _tensordot_torch(tensor1, tensor2, axes):
     torch = _i("torch")
-    if not semantic_version.match(">=1.10.0", torch.__version__) and axes == 0:
+    if not Version(torch.__version__) >= Version("1.10.0") and axes == 0:
         return torch.outer(tensor1, tensor2)
     return torch.tensordot(tensor1, tensor2, axes)
 


### PR DESCRIPTION
**Context:**

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:** #5689 

**Related Shortcut Stories** [sc-63356]
