### PR TITLE
Update qchem docs to use Molecule everywhere

### DIFF
--- a/doc/code/qml_qchem.rst
+++ b/doc/code/qml_qchem.rst
@@ -172,10 +172,11 @@ OpenFermion-PySCF backend
 -------------------------
 
 The :func:`~.molecular_hamiltonian` function can be also used to construct the molecular Hamiltonian
-with a non-differentiable backend that uses the
-`OpenFermion-PySCF <https://github.com/quantumlib/OpenFermion-PySCF>`_ plugin interfaced with the
+with non-differentiable backends that use the
+`OpenFermion-PySCF <https://github.com/quantumlib/OpenFermion-PySCF>`_ plugin and the
 electronic structure package `PySCF <https://github.com/sunqm/pyscf>`_. The non-differentiable
-backend can be selected by setting ``method='pyscf'`` in :func:`~.molecular_hamiltonian`:
+backends can be selected by setting ``method='openfermion'`` and ``method='pyscf'``
+in :func:`~.molecular_hamiltonian`:
 
 .. code-block:: python
 
@@ -184,7 +185,7 @@ backend can be selected by setting ``method='pyscf'`` in :func:`~.molecular_hami
 
     symbols = ["H", "H"]
     geometry = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 2.0]])
-    molecule = qml.qchem.Molecule(symbols, geometry, charge=0, mult=1, basis='sto-3g')
+    molecule = qml.qchem.Molecule(symbols, geometry, charge=0, mult=1, basis_name='sto-3g')
     hamiltonian, qubits = qml.qchem.molecular_hamiltonian(molecule, method='pyscf')
 
 The non-differentiable backend requires the ``OpenFermion-PySCF`` plugin to be installed by the user

--- a/doc/code/qml_qchem.rst
+++ b/doc/code/qml_qchem.rst
@@ -171,12 +171,12 @@ integral can be differentiated with respect to the basis set parameters as follo
 OpenFermion-PySCF backend
 -------------------------
 
-The :func:`~.molecular_hamiltonian` function can be also used to construct the molecular Hamiltonian
+The :func:`~.molecular_hamiltonian` function can also be used to construct the molecular Hamiltonian
 with non-differentiable backends that use the
 `OpenFermion-PySCF <https://github.com/quantumlib/OpenFermion-PySCF>`_ plugin and the
 electronic structure package `PySCF <https://github.com/sunqm/pyscf>`_. The non-differentiable
 backends can be selected by setting ``method='openfermion'`` and ``method='pyscf'``
-in :func:`~.molecular_hamiltonian`:
+in ``molecular_hamiltonian``:
 
 .. code-block:: python
 
@@ -188,9 +188,10 @@ in :func:`~.molecular_hamiltonian`:
     molecule = qml.qchem.Molecule(symbols, geometry, charge=0, mult=1, basis_name='sto-3g')
     hamiltonian, qubits = qml.qchem.molecular_hamiltonian(molecule, method='pyscf')
 
-The non-differentiable backend requires the ``OpenFermion-PySCF`` plugin to be installed by the user
-with
+The non-differentiable backends require either ``OpenFermion-PySCF`` or ``PySCF`` to be installed by
+the user with
 
 .. code-block:: bash
 
     pip install openfermionpyscf
+    pip install pyscf

--- a/doc/introduction/chemistry.rst
+++ b/doc/introduction/chemistry.rst
@@ -27,7 +27,8 @@ to generate the electronic Hamiltonian in a single call. For example,
 
     symbols = ["H", "H"]
     geometry = np.array([[0., 0., -0.66140414], [0., 0., 0.66140414]])
-    hamiltonian, qubits = qml.qchem.molecular_hamiltonian(symbols, geometry)
+    molecule = qml.qchem.Molecule(symbols, geometry)
+    hamiltonian, qubits = qml.qchem.molecular_hamiltonian(molecule)
 
 where:
 
@@ -36,11 +37,11 @@ where:
 * ``qubits`` is the number of qubits needed to perform the quantum simulation.
 
 The :func:`~.molecular_hamiltonian` function can also be used to construct the molecular Hamiltonian
-with an external backend that uses the
-`OpenFermion-PySCF <https://github.com/quantumlib/OpenFermion-PySCF>`_ plugin interfaced with the
+with external backends that use the
+`OpenFermion-PySCF <https://github.com/quantumlib/OpenFermion-PySCF>`_ plugin or the
 electronic structure package `PySCF <https://github.com/pyscf/pyscf>`_, which requires separate
-installation. This backend is non-differentiable and can be selected by setting
-``method='pyscf'`` in :func:`~.molecular_hamiltonian`. 
+installation. These backends are non-differentiable and can be selected by setting
+``method='openfermion'`` and ``method='pyscf'`` in :func:`~.molecular_hamiltonian`.
 
 Furthermore, the net charge,
 the `spin multiplicity <https://en.wikipedia.org/wiki/Multiplicity_(chemistry)>`_, the
@@ -49,13 +50,14 @@ specified for each backend.
 
 .. code-block:: python
 
-    hamiltonian, qubits = qml.qchem.molecular_hamiltonian(
+    molecule = qml.qchem.Molecule(
         symbols,
         geometry,
         charge=0,
         mult=1,
-        basis='sto-3g',
-        method='pyscf',
+        basis_name='sto-3g')
+    hamiltonian, qubits = qml.qchem.molecular_hamiltonian(
+        molecule,
         active_electrons=2,
         active_orbitals=2
     )
@@ -100,7 +102,8 @@ expectation value of a Hamiltonian can be calculated using ``qml.expval``:
 
     symbols = ["H", "H"]
     geometry = np.array([[0., 0., -0.66140414], [0., 0., 0.66140414]])
-    hamiltonian, qubits = qml.qchem.molecular_hamiltonian(symbols, geometry)
+    molecule = qml.qchem.Molecule(symbols, geometry)
+    hamiltonian, qubits = qml.qchem.molecular_hamiltonian(molecule)
 
     @qml.qnode(dev)
     def circuit(params):

--- a/doc/introduction/chemistry.rst
+++ b/doc/introduction/chemistry.rst
@@ -41,12 +41,12 @@ with external backends that use the
 `OpenFermion-PySCF <https://github.com/quantumlib/OpenFermion-PySCF>`_ plugin or the
 electronic structure package `PySCF <https://github.com/pyscf/pyscf>`_, which requires separate
 installation. These backends are non-differentiable and can be selected by setting
-``method='openfermion'`` and ``method='pyscf'`` in :func:`~.molecular_hamiltonian`.
+``method='openfermion'`` and ``method='pyscf'`` in ``molecular_hamiltonian``.
 
 Furthermore, the net charge,
 the `spin multiplicity <https://en.wikipedia.org/wiki/Multiplicity_(chemistry)>`_, the
-`atomic basis functions <https://www.basissetexchange.org/>`_ and the active space can also be
-specified for each backend.
+`atomic basis functions <https://www.basissetexchange.org/>`_, the mapping method and the active
+space can also be specified for each backend.
 
 .. code-block:: python
 
@@ -58,6 +58,7 @@ specified for each backend.
         basis_name='sto-3g')
     hamiltonian, qubits = qml.qchem.molecular_hamiltonian(
         molecule,
+        mapping='jordan_wigner',
         active_electrons=2,
         active_orbitals=2
     )
@@ -69,7 +70,7 @@ If the electronic Hamiltonian is built independently using
 `OpenFermion <https://github.com/quantumlib/OpenFermion>`_ tools, it can be readily converted 
 to a PennyLane observable using the :func:`~.pennylane.import_operator` function. There is also 
 capability to import wavefunctions (states) that have been pre-computed by traditional quantum chemistry methods
-from `PySCF <https://github.com/pyscf/pyscf>`_, which could be used to for example to provide a better
+from `PySCF <https://github.com/pyscf/pyscf>`_, which could be used to for example provide a better
 starting point to a quantum algorithm. State import can be accomplished using the :func:`~pennylane.qchem.import_state` 
 utility function.
 

--- a/pennylane/qchem/molecule.py
+++ b/pennylane/qchem/molecule.py
@@ -46,7 +46,8 @@ class Molecule:
         mult (int): Spin multiplicity :math:`\mathrm{mult}=N_\mathrm{unpaired} + 1` for
             :math:`N_\mathrm{unpaired}` unpaired electrons occupying the HF orbitals.
         basis_name (str): Atomic basis set used to represent the molecular orbitals. Currently, the
-            only supported basis sets are 'STO-3G', '6-31G', '6-311G' and 'CC-PVDZ'.
+            only supported basis sets are ``STO-3G``, ``6-31G``, ``6-311G`` and ``CC-PVDZ``. Other
+            basis sets can be loaded from the basis-set-exchange library using ``load_data``.
         load_data (bool): flag to load data from the basis-set-exchange library
         l (tuple[int]): angular momentum quantum numbers of the basis function
         alpha (array[float]): exponents of the primitive Gaussian functions

--- a/pennylane/qchem/molecule.py
+++ b/pennylane/qchem/molecule.py
@@ -106,6 +106,7 @@ class Molecule:
         self.mult = mult
         self.basis_name = basis_name.lower()
         self.name = name
+        self.load_data = load_data
         self.n_basis, self.basis_data = mol_basis_data(self.basis_name, self.symbols, load_data)
 
         if self.unit not in ("angstrom", "bohr"):

--- a/pennylane/qchem/openfermion_obs.py
+++ b/pennylane/qchem/openfermion_obs.py
@@ -801,7 +801,7 @@ def decompose(hf_file, mapping="jordan_wigner", core=None, active=None):
 
 def molecular_hamiltonian(*args, **kwargs):
     """molecular_hamiltonian(molecule, method="dhf", active_electrons=None, active_orbitals=None,\
-    mapping="jordan_wigner", outpath=".", wires=None, args=None, load_data=False, convert_tol=1e12)
+    mapping="jordan_wigner", outpath=".", wires=None, args=None, convert_tol=1e12)
     Generate the qubit Hamiltonian of a molecule.
 
     This function drives the construction of the second-quantized electronic Hamiltonian
@@ -844,7 +844,6 @@ def molecular_hamiltonian(*args, **kwargs):
             For type dict, only int-keyed dict (for qubit-to-wire conversion) is accepted for
             partial mapping. If None, will use identity map.
         args (array[array[float]]): initial values of the differentiable parameters
-        load_data (bool): flag to load data from the basis-set-exchange library
         convert_tol (float): Tolerance in `machine epsilon <https://numpy.org/doc/stable/reference/generated/numpy.real_if_close.html>`_
             for the imaginary part of the Hamiltonian coefficients created by openfermion.
             Coefficients with imaginary part less than 2.22e-16*tol are considered to be real.
@@ -955,7 +954,6 @@ def _(
     outpath=".",
     wires=None,
     args=None,
-    load_data=False,
     convert_tol=1e12,
 ):
     return _molecular_hamiltonian(
@@ -974,7 +972,7 @@ def _(
         molecule.alpha,
         molecule.coeff,
         args,
-        load_data,
+        molecule.load_data,
         convert_tol,
     )
 


### PR DESCRIPTION
**Context:**
The PR updates the qchem docs after making Molecule the central object in qchem.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
