### PR TITLE
Fix adjoint validation with global measurements

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -160,6 +160,9 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* The validation of the adjoint method in `DefaultQubit` correctly handles device wires now.
+  [(#5759)](https://github.com/PennyLaneAI/pennylane/pull/5759)
+
 * The `dynamic_one_shot` transform now has expanded support for the `jax` and `torch` interfaces.
   [(#5672)](https://github.com/PennyLaneAI/pennylane/pull/5672)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -161,7 +161,7 @@
 <h3>Bug fixes 🐛</h3>
 
 * The validation of the adjoint method in `DefaultQubit` correctly handles device wires now.
-  [(#5759)](https://github.com/PennyLaneAI/pennylane/pull/5759)
+  [(#5761)](https://github.com/PennyLaneAI/pennylane/pull/5761)
 
 * The `dynamic_one_shot` transform now has expanded support for the `jax` and `torch` interfaces.
   [(#5672)](https://github.com/PennyLaneAI/pennylane/pull/5672)

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -184,11 +184,12 @@ def adjoint_observables(obs: qml.operation.Operator) -> bool:
     return obs.has_matrix
 
 
-def _supports_adjoint(circuit):
+def _supports_adjoint(circuit, device_wires, device_name):
     if circuit is None:
         return True
 
     prog = TransformProgram()
+    prog.add_transform(validate_device_wires, device_wires, name=device_name)
     _add_adjoint_transforms(prog)
 
     try:
@@ -472,7 +473,7 @@ class DefaultQubit(Device):
             )
 
         if execution_config.gradient_method in {"adjoint", "best"}:
-            return _supports_adjoint(circuit=circuit)
+            return _supports_adjoint(circuit, device_wires=self.wires, device_name=self.name)
         return False
 
     def preprocess(

--- a/tests/devices/default_qubit/test_default_qubit.py
+++ b/tests/devices/default_qubit/test_default_qubit.py
@@ -127,15 +127,24 @@ class TestSupportsDerivatives:
         assert dev.supports_jvp(config) is True
         assert dev.supports_vjp(config) is True
 
-    def test_supports_adjoint(self):
+    @pytest.mark.parametrize(
+        "device_wires, measurement",
+        [
+            (None, qml.expval(qml.PauliZ(0))),
+            (2, qml.expval(qml.PauliZ(0))),
+            (2, qml.probs()),
+            (2, qml.probs([0])),
+        ],
+    )
+    def test_supports_adjoint(self, device_wires, measurement):
         """Test that DefaultQubit says that it supports adjoint differentiation."""
-        dev = DefaultQubit()
+        dev = DefaultQubit(wires=device_wires)
         config = ExecutionConfig(gradient_method="adjoint", use_device_gradient=True)
         assert dev.supports_derivatives(config) is True
         assert dev.supports_jvp(config) is True
         assert dev.supports_vjp(config) is True
 
-        qs = qml.tape.QuantumScript([], [qml.expval(qml.PauliZ(0))])
+        qs = qml.tape.QuantumScript([], [measurement])
         assert dev.supports_derivatives(config, qs) is True
         assert dev.supports_jvp(config, qs) is True
         assert dev.supports_vjp(config, qs) is True


### PR DESCRIPTION
**Context:**
Validation of the adjoint method did not take device wires into account, leading to the linked issue.

**Description of the Change:**
Include `validate_device_wires` in `_supports_adjoint` in `DefaultQubit`.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
fixes #5760

[sc-64278]