### PR TITLE
Add `packaging` as a new required package in PennyLane

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -2,7 +2,7 @@
 # A comma-separated list of package or module names from where C extensions may
 # be loaded. Extensions are loading into the active Python interpreter and may
 # run arbitrary code
-extension-pkg-whitelist=numpy,scipy,autograd,toml,appdir,autograd.numpy,autograd.numpy.linalg,autograd.numpy.builtins,packaging,torch,tensorflow,tensorflow.contrib,tensorflow.contrib.eager,LazyLoader,networkx,networkx.dag
+extension-pkg-whitelist=numpy,scipy,autograd,toml,appdir,autograd.numpy,autograd.numpy.linalg,autograd.numpy.builtins,semantic_version,packaging,torch,tensorflow,tensorflow.contrib,tensorflow.contrib.eager,LazyLoader,networkx,networkx.dag
 
 [TYPECHECK]
 
@@ -10,12 +10,12 @@ extension-pkg-whitelist=numpy,scipy,autograd,toml,appdir,autograd.numpy,autograd
 # (useful for modules/projects where namespaces are manipulated during runtime
 # and thus existing member attributes cannot be deduced by static analysis. It
 # supports qualified module names, as well as Unix pattern matching.
-ignored-modules=numpy,scipy,autograd,toml,appdir,autograd.numpy,autograd.numpy.linalg,autograd.numpy.builtins,packaging,torch,tensorflow,tensorflow.contrib,tensorflow.contrib.eager,LazyLoader,networkx,networkx.dag,math,pennylane.numpy
+ignored-modules=numpy,scipy,autograd,toml,appdir,autograd.numpy,autograd.numpy.linalg,autograd.numpy.builtins,semantic_version,packaging,torch,tensorflow,tensorflow.contrib,tensorflow.contrib.eager,LazyLoader,networkx,networkx.dag,math,pennylane.numpy
 
 # List of classes names for which member attributes should not be checked
 # (useful for classes with attributes dynamically set). This supports can work
 # with qualified names.
-ignored-classes=numpy,scipy,autograd,toml,appdir,autograd.numpy,autograd.numpy.linalg,autograd.numpy.builtins,packaging,torch,tensorflow,tensorflow.contrib,tensorflow.contrib.eager,LazyLoader,networkx,networkx.dag,math,pennylane.numpy,pennylane.numpy.random,pennylane.numpy.linalg,pennylane.numpy.builtins,pennylane.operation,rustworkx,kahypar
+ignored-classes=numpy,scipy,autograd,toml,appdir,autograd.numpy,autograd.numpy.linalg,autograd.numpy.builtins,semantic_version,packaging,torch,tensorflow,tensorflow.contrib,tensorflow.contrib.eager,LazyLoader,networkx,networkx.dag,math,pennylane.numpy,pennylane.numpy.random,pennylane.numpy.linalg,pennylane.numpy.builtins,pennylane.operation,rustworkx,kahypar
 
 [MESSAGES CONTROL]
 

--- a/.pylintrc
+++ b/.pylintrc
@@ -2,7 +2,7 @@
 # A comma-separated list of package or module names from where C extensions may
 # be loaded. Extensions are loading into the active Python interpreter and may
 # run arbitrary code
-extension-pkg-whitelist=numpy,scipy,autograd,toml,appdir,autograd.numpy,autograd.numpy.linalg,autograd.numpy.builtins,semantic_version,torch,tensorflow,tensorflow.contrib,tensorflow.contrib.eager,LazyLoader,networkx,networkx.dag
+extension-pkg-whitelist=numpy,scipy,autograd,toml,appdir,autograd.numpy,autograd.numpy.linalg,autograd.numpy.builtins,packaging,torch,tensorflow,tensorflow.contrib,tensorflow.contrib.eager,LazyLoader,networkx,networkx.dag
 
 [TYPECHECK]
 
@@ -10,12 +10,12 @@ extension-pkg-whitelist=numpy,scipy,autograd,toml,appdir,autograd.numpy,autograd
 # (useful for modules/projects where namespaces are manipulated during runtime
 # and thus existing member attributes cannot be deduced by static analysis. It
 # supports qualified module names, as well as Unix pattern matching.
-ignored-modules=numpy,scipy,autograd,toml,appdir,autograd.numpy,autograd.numpy.linalg,autograd.numpy.builtins,semantic_version,torch,tensorflow,tensorflow.contrib,tensorflow.contrib.eager,LazyLoader,networkx,networkx.dag,math,pennylane.numpy
+ignored-modules=numpy,scipy,autograd,toml,appdir,autograd.numpy,autograd.numpy.linalg,autograd.numpy.builtins,packaging,torch,tensorflow,tensorflow.contrib,tensorflow.contrib.eager,LazyLoader,networkx,networkx.dag,math,pennylane.numpy
 
 # List of classes names for which member attributes should not be checked
 # (useful for classes with attributes dynamically set). This supports can work
 # with qualified names.
-ignored-classes=numpy,scipy,autograd,toml,appdir,autograd.numpy,autograd.numpy.linalg,autograd.numpy.builtins,semantic_version,torch,tensorflow,tensorflow.contrib,tensorflow.contrib.eager,LazyLoader,networkx,networkx.dag,math,pennylane.numpy,pennylane.numpy.random,pennylane.numpy.linalg,pennylane.numpy.builtins,pennylane.operation,rustworkx,kahypar
+ignored-classes=numpy,scipy,autograd,toml,appdir,autograd.numpy,autograd.numpy.linalg,autograd.numpy.builtins,packaging,torch,tensorflow,tensorflow.contrib,tensorflow.contrib.eager,LazyLoader,networkx,networkx.dag,math,pennylane.numpy,pennylane.numpy.random,pennylane.numpy.linalg,pennylane.numpy.builtins,pennylane.operation,rustworkx,kahypar
 
 [MESSAGES CONTROL]
 

--- a/doc/development/guide/installation.rst
+++ b/doc/development/guide/installation.rst
@@ -19,6 +19,7 @@ be installed alongside PennyLane:
 * `appdirs <https://github.com/ActiveState/appdirs>`_
 * `semantic-version <https://github.com/rbarrois/python-semanticversion>`_ >= 2.7
 * `autoray <https://github.com/jcmgray/autoray>`__ >= 0.6.11
+* `packaging <https://github.com/pypa/packaging>`_
 
 The following Python packages are optional:
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -9,6 +9,9 @@
 
 <h3>Improvements 🛠</h3>
 
+* Added `packaging` in the required list of packages.
+  [(#5769)](https://github.com/PennyLaneAI/pennylane/pull/5769).
+
 * Logging now allows for an easier opt-in across the stack, and also extends control support to `catalyst`.
   [(#5528)](https://github.com/PennyLaneAI/pennylane/pull/5528).
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -9,7 +9,7 @@ mistune==0.8.4
 m2r2
 numpy
 pygments-github-lexers
-semantic_version==2.10
+packaging
 scipy
 docutils==0.16
 sphinx~=3.5.0; python_version < "3.10"

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -9,6 +9,7 @@ mistune==0.8.4
 m2r2
 numpy
 pygments-github-lexers
+semantic_version==2.10
 packaging
 scipy
 docutils==0.16

--- a/pennylane/__init__.py
+++ b/pennylane/__init__.py
@@ -20,7 +20,9 @@ from sys import version_info
 
 
 import numpy as _np
-from semantic_version import SimpleSpec, Version
+
+from packaging.specifiers import SpecifierSet
+from packaging.version import Version
 
 from pennylane.boolean_fn import BooleanFn
 import pennylane.numpy
@@ -386,7 +388,7 @@ def device(name, *args, **kwargs):
 
         if hasattr(plugin_device_class, "pennylane_requires") and Version(
             version()
-        ) not in SimpleSpec(plugin_device_class.pennylane_requires):
+        ) not in SpecifierSet(f"=={plugin_device_class.pennylane_requires}"):
             raise DeviceError(
                 f"The {name} plugin requires PennyLane versions {plugin_device_class.pennylane_requires}, "
                 f"however PennyLane version {__version__} is installed."

--- a/pennylane/__init__.py
+++ b/pennylane/__init__.py
@@ -21,8 +21,8 @@ from sys import version_info
 
 import numpy as _np
 
-from packaging.specifiers import SpecifierSet
 from packaging.version import Version
+from semantic_version import SimpleSpec
 
 from pennylane.boolean_fn import BooleanFn
 import pennylane.numpy
@@ -388,7 +388,7 @@ def device(name, *args, **kwargs):
 
         if hasattr(plugin_device_class, "pennylane_requires") and Version(
             version()
-        ) not in SpecifierSet(f"=={plugin_device_class.pennylane_requires}"):
+        ) not in SimpleSpec(plugin_device_class.pennylane_requires):
             raise DeviceError(
                 f"The {name} plugin requires PennyLane versions {plugin_device_class.pennylane_requires}, "
                 f"however PennyLane version {__version__} is installed."

--- a/pennylane/__init__.py
+++ b/pennylane/__init__.py
@@ -20,7 +20,8 @@ from sys import version_info
 
 
 import numpy as _np
-from semantic_version import SimpleSpec, Version
+from packaging.version import Version, parse
+from packaging.specifiers import SpecifierSet
 
 from pennylane.boolean_fn import BooleanFn
 import pennylane.numpy
@@ -384,13 +385,23 @@ def device(name, *args, **kwargs):
         # loads the device class
         plugin_device_class = plugin_devices[name].load()
 
-        if hasattr(plugin_device_class, "pennylane_requires") and Version(
-            version()
-        ) not in SimpleSpec(plugin_device_class.pennylane_requires):
-            raise DeviceError(
-                f"The {name} plugin requires PennyLane versions {plugin_device_class.pennylane_requires}, "
-                f"however PennyLane version {__version__} is installed."
-            )
+        # if hasattr(plugin_device_class, "pennylane_requires") and Version(
+        #    version()
+        # ) not in SimpleSpec(plugin_device_class.pennylane_requires):
+        #    raise DeviceError(
+        #        f"The {name} plugin requires PennyLane versions {plugin_device_class.pennylane_requires}, "
+        #        f"however PennyLane version {__version__} is installed."
+        #    )
+
+        if hasattr(plugin_device_class, "pennylane_requires"):
+            pennylane_version = Version(__version__)
+            required_versions = SpecifierSet(plugin_device_class.pennylane_requires)
+
+            if pennylane_version not in required_versions:
+                raise DeviceError(
+                    f"The {name} plugin requires PennyLane versions {plugin_device_class.pennylane_requires}, "
+                    f"however PennyLane version {__version__} is installed."
+                )
 
         # Construct the device
         dev = plugin_device_class(*args, **options)

--- a/pennylane/__init__.py
+++ b/pennylane/__init__.py
@@ -20,7 +20,6 @@ from sys import version_info
 
 
 import numpy as _np
-from packaging.version import Version, parse
 from semantic_version import SimpleSpec, Version
 
 from pennylane.boolean_fn import BooleanFn

--- a/pennylane/__init__.py
+++ b/pennylane/__init__.py
@@ -21,7 +21,7 @@ from sys import version_info
 
 import numpy as _np
 from packaging.version import Version, parse
-from packaging.specifiers import SpecifierSet
+from semantic_version import SimpleSpec, Version
 
 from pennylane.boolean_fn import BooleanFn
 import pennylane.numpy
@@ -385,23 +385,13 @@ def device(name, *args, **kwargs):
         # loads the device class
         plugin_device_class = plugin_devices[name].load()
 
-        # if hasattr(plugin_device_class, "pennylane_requires") and Version(
-        #    version()
-        # ) not in SimpleSpec(plugin_device_class.pennylane_requires):
-        #    raise DeviceError(
-        #        f"The {name} plugin requires PennyLane versions {plugin_device_class.pennylane_requires}, "
-        #        f"however PennyLane version {__version__} is installed."
-        #    )
-
-        if hasattr(plugin_device_class, "pennylane_requires"):
-            pennylane_version = Version(__version__)
-            required_versions = SpecifierSet(plugin_device_class.pennylane_requires)
-
-            if pennylane_version not in required_versions:
-                raise DeviceError(
-                    f"The {name} plugin requires PennyLane versions {plugin_device_class.pennylane_requires}, "
-                    f"however PennyLane version {__version__} is installed."
-                )
+        if hasattr(plugin_device_class, "pennylane_requires") and Version(
+            version()
+        ) not in SimpleSpec(plugin_device_class.pennylane_requires):
+            raise DeviceError(
+                f"The {name} plugin requires PennyLane versions {plugin_device_class.pennylane_requires}, "
+                f"however PennyLane version {__version__} is installed."
+            )
 
         # Construct the device
         dev = plugin_device_class(*args, **options)

--- a/pennylane/__init__.py
+++ b/pennylane/__init__.py
@@ -21,8 +21,7 @@ from sys import version_info
 
 import numpy as _np
 
-from packaging.version import Version
-from semantic_version import SimpleSpec
+from semantic_version import SimpleSpec, Version
 
 from pennylane.boolean_fn import BooleanFn
 import pennylane.numpy

--- a/pennylane/__init__.py
+++ b/pennylane/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2021 Xanadu Quantum Technologies Inc.
+# Copyright 2018-2024 Xanadu Quantum Technologies Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pennylane/compiler/compiler.py
+++ b/pennylane/compiler/compiler.py
@@ -20,7 +20,7 @@ from importlib import metadata, reload
 from sys import version_info
 from typing import List, Optional
 
-from semantic_version import Version
+from packaging.version import Version
 
 PL_CATALYST_MIN_VERSION = Version("0.6.0")
 

--- a/pennylane/devices/default_qubit_tf.py
+++ b/pennylane/devices/default_qubit_tf.py
@@ -17,7 +17,7 @@ reference plugin.
 import itertools
 
 import numpy as np
-import semantic_version
+from packaging.version import Version
 
 import pennylane as qml
 
@@ -29,7 +29,7 @@ try:
 
     from tensorflow.python.framework.errors_impl import InvalidArgumentError
 
-    SUPPORTS_APPLY_OPS = semantic_version.match(">=2.3.0", tf.__version__)
+    SUPPORTS_APPLY_OPS = Version(tf.__version__) >= Version("2.3.0")
 
 except ImportError as e:  # pragma: no cover
     raise ImportError("default.qubit.tf device requires TensorFlow>=2.0") from e

--- a/pennylane/devices/default_qubit_tf.py
+++ b/pennylane/devices/default_qubit_tf.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2021 Xanadu Quantum Technologies Inc.
+# Copyright 2018-2024 Xanadu Quantum Technologies Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pennylane/devices/default_qubit_torch.py
+++ b/pennylane/devices/default_qubit_torch.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2021 Xanadu Quantum Technologies Inc.
+# Copyright 2018-2024 Xanadu Quantum Technologies Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pennylane/devices/default_qubit_torch.py
+++ b/pennylane/devices/default_qubit_torch.py
@@ -18,12 +18,14 @@ import inspect
 import logging
 import warnings
 
-import semantic_version
+from packaging.version import Version
 
 try:
     import torch
 
-    VERSION_SUPPORT = semantic_version.match(">=1.8.1", torch.__version__)
+    VERSION_SUPPORT = Version(torch.__version__) >= Version(
+        "1.8.1",
+    )
     if not VERSION_SUPPORT:  # pragma: no cover
         raise ImportError("default.qubit.torch device requires Torch>=1.8.1")
 

--- a/pennylane/numpy/random.py
+++ b/pennylane/numpy/random.py
@@ -15,18 +15,23 @@
 This package provides a wrapped version of autograd.numpy.random, such that
 it works with the PennyLane :class:`~.tensor` class.
 """
-import semantic_version
 from autograd.numpy import random as _random
 from numpy import __version__ as np_version
 from numpy.random import MT19937, PCG64, SFC64, Philox  # pylint: disable=unused-import
+from packaging.specifiers import SpecifierSet
+from packaging.version import Version
 
 from .wrapper import tensor_wrapper, wrap_arrays
 
 wrap_arrays(_random.__dict__, globals())
 
+# Define the version requirement
+np_version_spec = SpecifierSet(">=0.17.0")
 
-np_version_spec = semantic_version.SimpleSpec(">=0.17.0")
-if np_version_spec.match(semantic_version.Version(np_version)):
+# Parse the current NumPy version
+np_version = Version(np_version)
+
+if np_version in np_version_spec:
     # pylint: disable=too-few-public-methods
     # pylint: disable=missing-class-docstring
     class Generator(_random.Generator):

--- a/pennylane/numpy/random.py
+++ b/pennylane/numpy/random.py
@@ -25,13 +25,8 @@ from .wrapper import tensor_wrapper, wrap_arrays
 
 wrap_arrays(_random.__dict__, globals())
 
-# Define the version requirement
-np_version_spec = SpecifierSet(">=0.17.0")
 
-# Parse the current NumPy version
-np_version = Version(np_version)
-
-if np_version in np_version_spec:
+if Version(np_version) in SpecifierSet(">=0.17.0"):
     # pylint: disable=too-few-public-methods
     # pylint: disable=missing-class-docstring
     class Generator(_random.Generator):

--- a/pennylane/numpy/random.py
+++ b/pennylane/numpy/random.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2024 Xanadu Quantum Technologies Inc.
+# Copyright 2018-2021 Xanadu Quantum Technologies Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,18 +15,18 @@
 This package provides a wrapped version of autograd.numpy.random, such that
 it works with the PennyLane :class:`~.tensor` class.
 """
+import semantic_version
 from autograd.numpy import random as _random
 from numpy import __version__ as np_version
 from numpy.random import MT19937, PCG64, SFC64, Philox  # pylint: disable=unused-import
-from packaging.specifiers import SpecifierSet
-from packaging.version import Version
 
 from .wrapper import tensor_wrapper, wrap_arrays
 
 wrap_arrays(_random.__dict__, globals())
 
 
-if Version(np_version) in SpecifierSet(">=0.17.0"):
+np_version_spec = semantic_version.SimpleSpec(">=0.17.0")
+if np_version_spec.match(semantic_version.Version(np_version)):
     # pylint: disable=too-few-public-methods
     # pylint: disable=missing-class-docstring
     class Generator(_random.Generator):

--- a/pennylane/numpy/random.py
+++ b/pennylane/numpy/random.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2021 Xanadu Quantum Technologies Inc.
+# Copyright 2018-2024 Xanadu Quantum Technologies Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pennylane/qnn/keras.py
+++ b/pennylane/qnn/keras.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2021 Xanadu Quantum Technologies Inc.
+# Copyright 2018-2024 Xanadu Quantum Technologies Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pennylane/qnn/keras.py
+++ b/pennylane/qnn/keras.py
@@ -17,7 +17,7 @@ import inspect
 from collections.abc import Iterable
 from typing import Optional, Text
 
-from semantic_version import Version
+from packaging.version import Version
 
 try:
     import tensorflow as tf

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -7,6 +7,7 @@ rustworkx
 autograd
 toml
 appdirs
+semantic_version
 packaging
 autoray>=0.6.1,<0.6.10
 matplotlib

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -7,7 +7,7 @@ rustworkx
 autograd
 toml
 appdirs
-semantic_version
+packaging
 autoray>=0.6.1,<0.6.10
 matplotlib
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ rustworkx~=0.12.1
 autograd~=1.4
 toml~=0.10
 appdirs~=1.4
-semantic_version~=2.10
+packaging
 autoray>=0.6.11
 matplotlib~=3.5
 opt_einsum~=3.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ rustworkx~=0.12.1
 autograd~=1.4
 toml~=0.10
 appdirs~=1.4
+semantic_version~=2.10
 packaging
 autoray>=0.6.11
 matplotlib~=3.5

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2020 Xanadu Quantum Technologies Inc.
+# Copyright 2018-2024 Xanadu Quantum Technologies Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ requirements = [
     "pennylane-lightning>=0.36",
     "requests",
     "typing_extensions",
+    "packaging",
 ]
 
 info = {

--- a/tests/.pylintrc
+++ b/tests/.pylintrc
@@ -2,7 +2,7 @@
 # A comma-separated list of package or module names from where C extensions may
 # be loaded. Extensions are loading into the active Python interpreter and may
 # run arbitrary code
-extension-pkg-whitelist=numpy,scipy,autograd,toml,appdir,autograd.numpy,autograd.numpy.linalg,autograd.numpy.builtins,packaging,torch,tensorflow,tensorflow.contrib,tensorflow.contrib.eager,LazyLoader,networkx,networkx.dag
+extension-pkg-whitelist=numpy,scipy,autograd,toml,appdir,autograd.numpy,autograd.numpy.linalg,autograd.numpy.builtins,semantic_version,packaging,torch,tensorflow,tensorflow.contrib,tensorflow.contrib.eager,LazyLoader,networkx,networkx.dag
 
 [TYPECHECK]
 
@@ -10,12 +10,12 @@ extension-pkg-whitelist=numpy,scipy,autograd,toml,appdir,autograd.numpy,autograd
 # (useful for modules/projects where namespaces are manipulated during runtime
 # and thus existing member attributes cannot be deduced by static analysis. It
 # supports qualified module names, as well as Unix pattern matching.
-ignored-modules=numpy,scipy,autograd,toml,appdir,autograd.numpy,autograd.numpy.linalg,autograd.numpy.builtins,packaging,torch,tensorflow,tensorflow.contrib,tensorflow.contrib.eager,LazyLoader,networkx,networkx.dag,math,pennylane.numpy
+ignored-modules=numpy,scipy,autograd,toml,appdir,autograd.numpy,autograd.numpy.linalg,autograd.numpy.builtins,semantic_version,packaging,torch,tensorflow,tensorflow.contrib,tensorflow.contrib.eager,LazyLoader,networkx,networkx.dag,math,pennylane.numpy
 
 # List of classes names for which member attributes should not be checked
 # (useful for classes with attributes dynamically set). This supports can work
 # with qualified names.
-ignored-classes=numpy,scipy,autograd,toml,appdir,autograd.numpy,autograd.numpy.linalg,autograd.numpy.builtins,packaging,torch,tensorflow,tensorflow.contrib,tensorflow.contrib.eager,LazyLoader,networkx,networkx.dag,math,pennylane.numpy,pennylane.numpy.random,pennylane.numpy.linalg,pennylane.numpy.builtins,pennylane.operation,rustworkx,kahypar
+ignored-classes=numpy,scipy,autograd,toml,appdir,autograd.numpy,autograd.numpy.linalg,autograd.numpy.builtins,semantic_version,packaging,torch,tensorflow,tensorflow.contrib,tensorflow.contrib.eager,LazyLoader,networkx,networkx.dag,math,pennylane.numpy,pennylane.numpy.random,pennylane.numpy.linalg,pennylane.numpy.builtins,pennylane.operation,rustworkx,kahypar
 
 [MESSAGES CONTROL]
 

--- a/tests/.pylintrc
+++ b/tests/.pylintrc
@@ -2,7 +2,7 @@
 # A comma-separated list of package or module names from where C extensions may
 # be loaded. Extensions are loading into the active Python interpreter and may
 # run arbitrary code
-extension-pkg-whitelist=numpy,scipy,autograd,toml,appdir,autograd.numpy,autograd.numpy.linalg,autograd.numpy.builtins,semantic_version,torch,tensorflow,tensorflow.contrib,tensorflow.contrib.eager,LazyLoader,networkx,networkx.dag
+extension-pkg-whitelist=numpy,scipy,autograd,toml,appdir,autograd.numpy,autograd.numpy.linalg,autograd.numpy.builtins,packaging,torch,tensorflow,tensorflow.contrib,tensorflow.contrib.eager,LazyLoader,networkx,networkx.dag
 
 [TYPECHECK]
 
@@ -10,12 +10,12 @@ extension-pkg-whitelist=numpy,scipy,autograd,toml,appdir,autograd.numpy,autograd
 # (useful for modules/projects where namespaces are manipulated during runtime
 # and thus existing member attributes cannot be deduced by static analysis. It
 # supports qualified module names, as well as Unix pattern matching.
-ignored-modules=numpy,scipy,autograd,toml,appdir,autograd.numpy,autograd.numpy.linalg,autograd.numpy.builtins,semantic_version,torch,tensorflow,tensorflow.contrib,tensorflow.contrib.eager,LazyLoader,networkx,networkx.dag,math,pennylane.numpy
+ignored-modules=numpy,scipy,autograd,toml,appdir,autograd.numpy,autograd.numpy.linalg,autograd.numpy.builtins,packaging,torch,tensorflow,tensorflow.contrib,tensorflow.contrib.eager,LazyLoader,networkx,networkx.dag,math,pennylane.numpy
 
 # List of classes names for which member attributes should not be checked
 # (useful for classes with attributes dynamically set). This supports can work
 # with qualified names.
-ignored-classes=numpy,scipy,autograd,toml,appdir,autograd.numpy,autograd.numpy.linalg,autograd.numpy.builtins,semantic_version,torch,tensorflow,tensorflow.contrib,tensorflow.contrib.eager,LazyLoader,networkx,networkx.dag,math,pennylane.numpy,pennylane.numpy.random,pennylane.numpy.linalg,pennylane.numpy.builtins,pennylane.operation,rustworkx,kahypar
+ignored-classes=numpy,scipy,autograd,toml,appdir,autograd.numpy,autograd.numpy.linalg,autograd.numpy.builtins,packaging,torch,tensorflow,tensorflow.contrib,tensorflow.contrib.eager,LazyLoader,networkx,networkx.dag,math,pennylane.numpy,pennylane.numpy.random,pennylane.numpy.linalg,pennylane.numpy.builtins,pennylane.operation,rustworkx,kahypar
 
 [MESSAGES CONTROL]
 


### PR DESCRIPTION
**Context:** In #5754, we forgot to add `packaging` as a new hard requirement for PennyLane. Some developers experienced troubles when importing PL.

**Description of the Change:** We included `packaging` in the relevant contexts as a new required package.

**Benefits:** The user would not experience trouble importing PennyLane if `packaging` is not installed on his/her system.

**Possible Drawbacks:** None that I can think of, except possible issues with external plugins for incompatibilities between the previous workflow of `semantic_version` and the new one of `packaging` (in which case, we can quickly restore the previous `semantic_version` usage where it occurs).

**Related GitHub Issues:** None.

**Related Shortcut Stories:** [sc-64576].
