### PR TITLE
Requesting the full transform program in `construct_batch` is done through `level=all` instead of `level=None`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -170,6 +170,9 @@
 * `qml.QutritAmplitudeDamping` channel has been added, allowing for noise processes modelled by amplitude damping to be simulated on the `default.qutrit.mixed` device.
   [(#5503)](https://github.com/PennyLaneAI/pennylane/pull/5503)
 
+* `qml.workflow.construct_batch` and `qml.workflow.get_transform_program` do not accept `level=None` anymore. Rather, `level=all` should be used instead.
+  [(#5770)](https://github.com/PennyLaneAI/pennylane/pull/5770)
+
 <h3>Deprecations 👋</h3>
 
 * The `simplify` argument in `qml.Hamiltonian` and `qml.ops.LinearCombination` is deprecated. 


### PR DESCRIPTION
**Context:**
Previously, the `level` argument was introduced as a potential replacement for `expansion_strategy` that acts as a superset for the latter. However, one of the potential values of `level` is `None`, which signals a request to apply the whole transform program when constructing a batch. That is problematic as it is not possible to deprecate the old `expansion_strategy` and `qnode.expansion_strategy` as a `None` value can not be set as a valid value for `level` and at the same time signal a request to fall back to the values of these two attributes, especially given that `qnode.expansion_strategy` default value is `"gradient"`, which would result in an unexpected behaviour. Therefore, `None` as a value for a full transform program should be invalidated and replaced with something else.

**Description of the Change:**
`level=all` is now the equivalent of `level=None`

**Benefits:**
An easier transition away from `expansion_strategy` and `qnode.expansion_strategy`

**Possible Drawbacks:**
The change is breaking

[[sc-64537](https://app.shortcut.com/xanaduai/story/64537/)]
