### PR TITLE
Remove coverage for untestable logging functionality

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,7 @@
 ignore:
   - "pennylane/devices/tests/*"
   - "pennylane/data/base/_lazy_modules.py"
+  - "pennylane/logging/*"
 
 codecov:
   notify:


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      test directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `doc/releases/changelog-dev.md` file, summarizing the
      change, and including a link back to the PR.

- [ ] The PennyLane source code conforms to
      [PEP8 standards](https://www.python.org/dev/peps/pep-0008/).
      We check all of our code against [Pylint](https://www.pylint.org/).
      To lint modified files, simply `pip install pylint`, and then
      run `pylint pennylane/path/to/file.py`.

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:** The logging module does not play nicely with pytest, so hitting most of the custom options without the protection of pytest's `caplog` can see logging enabled across the stack, which slows tests considerably. As the recent PR dropped coverage, this is playing havoc with the CodeCov reports on other PRs. This PR ignores the logging options from coverage reporting to alleviate this burden, while keeping the existing tests in place.

**Description of the Change:** As above.

**Benefits:** Avoids CodeCov errors.

**Possible Drawbacks:**

**Related GitHub Issues:**
