### PR TITLE
Disable Docker builds on PR merges

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,8 +1,5 @@
 name: Docker builds
-on:
-  push:
-    branches:
-      - master
+on: workflow_dispatch
 
 jobs:
   base-tests:

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -190,6 +190,9 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Disable Docker builds on PR merge.
+  [(#5777)](https://github.com/PennyLaneAI/pennylane/pull/5777)
+
 * The validation of the adjoint method in `DefaultQubit` correctly handles device wires now.
   [(#5761)](https://github.com/PennyLaneAI/pennylane/pull/5761)
 


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      test directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `doc/releases/changelog-dev.md` file, summarizing the
      change, and including a link back to the PR.

- [ ] The PennyLane source code conforms to
      [PEP8 standards](https://www.python.org/dev/peps/pep-0008/).
      We check all of our code against [Pylint](https://www.pylint.org/).
      To lint modified files, simply `pip install pylint`, and then
      run `pylint pennylane/path/to/file.py`.

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:** As the docker builds can be replaced by those from the Lightning repository, we can turn replace the auto-docker build action to be manually triggered when requested. 

**Description of the Change:** Migrates docker github action to be manually trgiggered instead of auto triggered following a PR merge.

**Benefits:** No more failures on master following a failed build.

**Possible Drawbacks:**

**Related GitHub Issues:**
