### PR TITLE
include the the num_steps in Exp.simplify

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -366,6 +366,9 @@
 * Fixed a bug where `split_non_commuting` raises an error when the circuit contains measurements of observables that are not pauli words.
   [(#5827)](https://github.com/PennyLaneAI/pennylane/pull/5827)
 
+* `Exp.simplify()` now returns an operator with the correct number of Trotter steps, i.e. equal to the one from the pre-simplified operator.
+  [(#5831)](https://github.com/PennyLaneAI/pennylane/pull/5831)
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -366,7 +366,7 @@
 * Fixed a bug where `split_non_commuting` raises an error when the circuit contains measurements of observables that are not pauli words.
   [(#5827)](https://github.com/PennyLaneAI/pennylane/pull/5827)
 
-* `Exp.simplify()` now returns an operator with the correct number of Trotter steps, i.e. equal to the one from the pre-simplified operator.
+* Simplify method for `Exp` now returns an operator with the correct number of Trotter steps, i.e. equal to the one from the pre-simplified operator.
   [(#5831)](https://github.com/PennyLaneAI/pennylane/pull/5831)
 
 <h3>Contributors ✍️</h3>

--- a/pennylane/ops/op_math/exp.py
+++ b/pennylane/ops/op_math/exp.py
@@ -464,8 +464,8 @@ class Exp(ScalarSymbolicOp, Operation):
     def simplify(self):
         new_base = self.base.simplify()
         if isinstance(new_base, qml.ops.op_math.SProd):  # pylint: disable=no-member
-            return Exp(new_base.base, self.coeff * new_base.scalar)
-        return Exp(new_base, self.coeff)
+            return Exp(new_base.base, self.coeff * new_base.scalar, self.num_steps)
+        return Exp(new_base, self.coeff, self.num_steps)
 
     # pylint: disable=arguments-renamed, invalid-overridden-method
     @property

--- a/tests/ops/op_math/test_exp.py
+++ b/tests/ops/op_math/test_exp.py
@@ -736,6 +736,13 @@ class TestMiscMethods:
         assert qml.equal(new_op.base, qml.PauliX(0))
         assert new_op.coeff == 0.2
 
+    def test_simplify_num_steps(self):
+        """Test that the number of Trotter steps is conserved after simplification"""
+        base = qml.Z(0) + 1.2 * qml.Z(1)
+        op = Exp(base, coeff=-1.2j, num_steps=2)
+        new_op = op.simplify()
+        assert new_op.num_steps == op.num_steps
+
     def test_simplify_s_prod(self):
         """Tests that when simplification of the base results in an SProd,
         the scalar is included in the coeff rather than the base"""


### PR DESCRIPTION
**Context:**

The simplified operator of an exponential was not returning the correct number of steps.

**Description of the Change:**

`Exp.simplify()`now returns an operator with the correct number of Trotter steps, i.e. equal to the one from the pre-simplified operator.


**Benefits:**
Correct number of Trotter steps is now included after simplification

**Related GitHub Issues:**
Fixes #5747
[sc-64181]