### PR TITLE
Fix typo in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ build
 dist
 qit.egg-info
 .idea
-*.ipynp
+*.ipynb
 *.ipynb_checkpoints
 *.egg-info*
 .coverage*


### PR DESCRIPTION
Jupyter notebooks end with `.ipynb`, not `.ipynp`.