### PR TITLE
Split adjoint to bypass catalyst dispatch

### DIFF
--- a/pennylane/ops/op_math/adjoint.py
+++ b/pennylane/ops/op_math/adjoint.py
@@ -167,6 +167,7 @@ def adjoint(fn, lazy=True):
     return create_adjoint_op(fn, lazy)
 
 def create_adjoint_op(fn, lazy):
+    """Main logic for qml.adjoint, but allows bypassing the compiler dispatch if needed."""
     if isinstance(fn, Operator):
         return Adjoint(fn) if lazy else _single_op_eager(fn, update_queue=True)
     if not callable(fn):

--- a/pennylane/ops/op_math/adjoint.py
+++ b/pennylane/ops/op_math/adjoint.py
@@ -164,6 +164,9 @@ def adjoint(fn, lazy=True):
         return ops_loader.adjoint(fn, lazy=lazy)
     if qml.math.is_abstract(fn):
         return Adjoint(fn)
+    return create_adjoint_op(fn, lazy)
+
+def create_adjoint_op(fn, lazy):
     if isinstance(fn, Operator):
         return Adjoint(fn) if lazy else _single_op_eager(fn, update_queue=True)
     if not callable(fn):

--- a/pennylane/ops/op_math/adjoint.py
+++ b/pennylane/ops/op_math/adjoint.py
@@ -166,6 +166,7 @@ def adjoint(fn, lazy=True):
         return Adjoint(fn)
     return create_adjoint_op(fn, lazy)
 
+
 def create_adjoint_op(fn, lazy):
     """Main logic for qml.adjoint, but allows bypassing the compiler dispatch if needed."""
     if isinstance(fn, Operator):


### PR DESCRIPTION
Analogous change to create_controlled_op.

Allows to bypass the dispatch of qml.adjoint to catalyst.adjoint, without which it would not be possible for Catalyst to instantiate the PennyLane adjoint operator while benefiting from the additional logic provided by the qml.adjoint user function.

No functional changes.

[sc-65586]

Needed for https://github.com/PennyLaneAI/catalyst/pull/802