### PR TITLE
Small improvements and updates to `default.tensor` based on `quimb 1.8.2`

### DIFF
--- a/pennylane/devices/default_tensor.py
+++ b/pennylane/devices/default_tensor.py
@@ -190,7 +190,7 @@ class DefaultTensor(Device):
             contains unique labels for the wires as numbers (i.e., ``[-1, 0, 2]``) or strings
             (``['aux_wire', 'q1', 'q2']``).
         method (str): Supported method. The supported methods are ``"mps"`` (Matrix Product State) and ``"tn"`` (Tensor Network).
-        c_dtype (type): Data type for the tensor representation. Must be one of ``numpy.complex64`` or ``numpy.complex128``.
+        c_dtype (type): Complex data type for the tensor representation. Must be one of ``numpy.complex64`` or ``numpy.complex128``.
         **kwargs: keyword arguments for the device, passed to the ``quimb`` backend.
 
     Keyword Args:
@@ -307,7 +307,7 @@ class DefaultTensor(Device):
 
                 phi = 0.1
                 depth = 10
-                num_qubits = 25
+                num_qubits = 100
 
                 dev = qml.device("default.tensor", method="tn", contract="auto-split-gate")
 
@@ -324,10 +324,10 @@ class DefaultTensor(Device):
                         qml.CNOT(wires=[qubit, qubit + 1])
                     return qml.expval(qml.Z(0))
 
-            >>> circuit(phi, dept, num_qubits)
-            -0.9511499466743266
+            >>> circuit(phi, depth, num_qubits)
+            -0.9511499466743283
 
-            The execution time for this circuit with the above parameters is around 0.2 seconds on a standard laptop.
+            The execution time for this circuit with the above parameters is around 0.8 seconds on a standard laptop.
 
             The tensor network method can be faster than MPS and state vector methods in some cases.
             As a comparison, the time for the exact calculation of the same circuit with the MPS method and with the ``default.qubit``

--- a/pennylane/devices/default_tensor.py
+++ b/pennylane/devices/default_tensor.py
@@ -762,7 +762,7 @@ class DefaultTensor(Device):
         """
 
         # We need to copy the quimb circuit since `local_expectation` modifies it.
-        # If there is only one measurement and we don't wanto to keep track of the state
+        # If there is only one measurement and we don't want to keep track of the state
         # after the execution, we could avoid copying the circuit.
         qc = self._quimb_circuit.copy()
 


### PR DESCRIPTION
**Context:** `quimb 1.8.2` has been released recently. This PR implements small improvements and updates to `default.tensor` based on new features introduced in the new version of `quimb`.

**Description of the Change:** As above.

**Benefits:** One fewer package to import.

**Possible Drawbacks:** None that I can think of.

**Related GitHub Issues:** None.

**Related Shortcut Stories:** [sc-65970]