### PR TITLE
transform callables wrap original qfunc

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -264,6 +264,8 @@
 * `qml.qchem.molecular_dipole` function is added for calculating the dipole operator using "dhf" and "openfermion" backends.
   [(#5764)](https://github.com/PennyLaneAI/pennylane/pull/5764)
 
+* Transforms applied to callables now use `functools.wraps` to preserve the docstring and call signature of the original function.
+
 <h4>Community contributions 🥳</h4>
 
 * Implemented kwargs (`check_interface`, `check_trainability`, `rtol` and `atol`) support in `qml.equal` for the operators `Pow`, `Adjoint`, `Exp`, and `SProd`.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -265,6 +265,7 @@
   [(#5764)](https://github.com/PennyLaneAI/pennylane/pull/5764)
 
 * Transforms applied to callables now use `functools.wraps` to preserve the docstring and call signature of the original function.
+  [(#5857)](https://github.com/PennyLaneAI/pennylane/pull/5857)
 
 <h4>Community contributions 🥳</h4>
 

--- a/pennylane/transforms/core/transform_dispatcher.py
+++ b/pennylane/transforms/core/transform_dispatcher.py
@@ -235,6 +235,7 @@ class TransformDispatcher:
     def _qfunc_transform(self, qfunc, targs, tkwargs):
         """Apply the transform on a quantum function."""
 
+        @functools.wraps(qfunc)
         def qfunc_transformed(*args, **kwargs):
             with qml.queuing.AnnotatedQueue() as q:
                 qfunc_output = qfunc(*args, **kwargs)

--- a/tests/transforms/core/test_transform_dispatcher.py
+++ b/tests/transforms/core/test_transform_dispatcher.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Unit and integration tests for the transform dispatcher."""
+import inspect
 from functools import partial
 from typing import Callable, Sequence
 
@@ -31,7 +32,7 @@ with qml.tape.QuantumTape() as tape_circuit:
     qml.expval(qml.PauliZ(wires=0))
 
 
-def qfunc_circuit(a):
+def qfunc_circuit(a: qml.typing.TensorLike):
     """Qfunc circuit/"""
     qml.Hadamard(wires=0)
     qml.CNOT(wires=[0, 1])
@@ -381,6 +382,8 @@ class TestTransformDispatcher:  # pylint: disable=too-many-public-methods
         # Applied on a qfunc (return a qfunc)
         qfunc_transformed = dispatched_transform(qfunc_circuit, 0)
         assert callable(qfunc_transformed)
+
+        assert inspect.signature(qfunc_transformed) == inspect.signature(qfunc_circuit)
 
         with qml.tape.QuantumTape() as transformed_tape:
             qfunc_transformed(0.42)


### PR DESCRIPTION
**Context:**

Issue #5843 made me realize when we apply a transform to a qfunc callable, we should use `functools.wraps` to preserve the docstring and signature of the original function.

**Description of the Change:**

Adds `functools.wraps` to the transformed qfunc.

**Benefits:**

transformed qfunc's keep information about the original function.

**Possible Drawbacks:**

**Related GitHub Issues:**

Fixes #5843 
