### PR TITLE
Bugfix for split_non_commuting when tape measurements is empty

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -105,6 +105,7 @@
 * `qml.transforms.split_non_commuting` can now handle circuits containing measurements of multi-term observables.
   [(#5729)](https://github.com/PennyLaneAI/pennylane/pull/5729)
   [(#5853)](https://github.com/PennyLaneAI/pennylane/pull/5838)
+  [(#5869)](https://github.com/PennyLaneAI/pennylane/pull/5869)
 
 * The qchem module has dedicated functions for calling `pyscf` and `openfermion` backends.
   [(#5553)](https://github.com/PennyLaneAI/pennylane/pull/5553)
@@ -342,9 +343,6 @@
 
 * `qml.transforms.map_batch_transform` is deprecated, since a transform can be applied directly to a batch of tapes.
   [(#5676)](https://github.com/PennyLaneAI/pennylane/pull/5676)
-
-* `split_non_commuting` returns the unmodified tape if there are no measurements, instead of an empty list.
-  [(#5869)](https://github.com/PennyLaneAI/pennylane/pull/5869)
 
 <h3>Documentation 📝</h3>
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -343,6 +343,9 @@
 * `qml.transforms.map_batch_transform` is deprecated, since a transform can be applied directly to a batch of tapes.
   [(#5676)](https://github.com/PennyLaneAI/pennylane/pull/5676)
 
+* `split_non_commuting` returns the unmodified tape if there are no measurements, instead of an empty list.
+  [(#5869)](https://github.com/PennyLaneAI/pennylane/pull/5869)
+
 <h3>Documentation 📝</h3>
 
 * The documentation for the `default.tensor` device has been added.

--- a/pennylane/transforms/split_non_commuting.py
+++ b/pennylane/transforms/split_non_commuting.py
@@ -28,6 +28,13 @@ from pennylane.transforms import transform
 from pennylane.typing import Result, ResultBatch
 
 
+def null_postprocessing(results):
+    """A postprocessing function returned by a transform that only converts the batch of results
+    into a result for a single ``QuantumTape``.
+    """
+    return results[0]
+
+
 @transform
 def split_non_commuting(
     tape: qml.tape.QuantumScript,
@@ -244,7 +251,7 @@ def split_non_commuting(
 
     """
     if len(tape.measurements) == 0:
-        return [tape], lambda x: x[0]
+        return [tape], null_postprocessing
 
     # Special case for a single measurement of a Sum or Hamiltonian, in which case
     # the grouping information can be computed and cached in the observable.

--- a/pennylane/transforms/split_non_commuting.py
+++ b/pennylane/transforms/split_non_commuting.py
@@ -243,6 +243,8 @@ def split_non_commuting(
         [[expval(X(0)), probs(wires=[1])], [probs(wires=[0, 1])]]
 
     """
+    if len(tape.measurements) == 0:
+        return [tape], lambda x: x[0]
 
     # Special case for a single measurement of a Sum or Hamiltonian, in which case
     # the grouping information can be computed and cached in the observable.

--- a/tests/transforms/test_split_non_commuting.py
+++ b/tests/transforms/test_split_non_commuting.py
@@ -568,6 +568,17 @@ class TestUnits:
             fn([[0.1, 0.2], [0.3, 0.6], 0.4, 0.5, 0.7]), [0.01, 0.06, 0.06, 0.16, 0.25, 0.36, 0.49]
         )
 
+    @pytest.mark.parametrize("grouping_strategy", [None, "default", "qwc", "wires"])
+    def test_no_measurements(self, grouping_strategy):
+        """Test that if the tape contains no measurements, the transform doesn't
+        modify it"""
+
+        tape = qml.tape.QuantumScript([qml.X(0)])
+        tapes, post_processing_fn = split_non_commuting(tape, grouping_strategy=grouping_strategy)
+        assert len(tapes) == 1
+        assert tapes[0] == tape
+        assert post_processing_fn(tapes) == tape
+
 
 class TestIntegration:
     """Tests the ``split_non_commuting`` transform performed on a QNode"""


### PR DESCRIPTION
**Context:**
Currently on master, if we apply `split_non_commuting` to a tape with empty measurements, we delete the tape:

```
>>> from pennylane.transforms import split_non_commuting
>>> tape = qml.tape.QuantumScript([qml.X(0)], measurements=[])
>>> tapes, _ = split_non_commuting(tape)
>>> tapes
[]
```

**Description of the Change:**

We add a check for `len(measurements) == 0` and just return the tape if there are no measurements to split, so we get:

```
>>> from pennylane.transforms import split_non_commuting
>>> tape = qml.tape.QuantumScript([qml.X(0)], measurements=[])
>>> tapes, _ = split_non_commuting(tape)
>>> tapes
[<QuantumScript: wires=[0], params=0>]
```

**Benefits:**
We don't delete the tape if it has no measurements (came up in catalyst tests)