### PR TITLE
Fix bug in Tensor equal check

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -309,7 +309,8 @@
   [(#5502)](https://github.com/PennyLaneAI/pennylane/pull/5502)
  
 * Implement support in `assert_equal` for `Operator`, `Controlled`, `Adjoint`, `Pow`, `Exp`, `SProd`, `ControlledSequence`, `Prod`, `Sum`, `Tensor` and `Hamiltonian`
- [(#5780)](https://github.com/PennyLaneAI/pennylane/pull/5780)
+  [(#5780)](https://github.com/PennyLaneAI/pennylane/pull/5780)
+  [(#5877)](https://github.com/PennyLaneAI/pennylane/pull/5877)
 
 * `qml.QutritChannel` has been added, enabling the specification of noise using a collection of (3x3) Kraus matrices on the `default.qutrit.mixed` device.
   [(#5793)](https://github.com/PennyLaneAI/pennylane/issues/5793)

--- a/pennylane/ops/functions/equal.py
+++ b/pennylane/ops/functions/equal.py
@@ -612,18 +612,20 @@ def _equal_sprod(op1: SProd, op2: SProd, **kwargs):
 # pylint: disable=unused-argument
 def _equal_tensor(op1: Tensor, op2: Observable, **kwargs):
     """Determine whether a Tensor object is equal to a Hamiltonian/Tensor"""
+
     if not isinstance(op2, Observable):
         return f"{op2} is not of type Observable"
 
     if isinstance(op2, (Hamiltonian, LinearCombination, Hermitian)):
-        if not op2.compare(op1):
-            return f"'{op1}' and '{op2}' are not same"
+        return op2.compare(op1) or f"{op1} and {op2} are not same"
 
     if isinstance(op2, Tensor):
-        if not op1._obs_data() == op2._obs_data():  # pylint: disable=protected-access
-            return "op1 and op2 have different _obs_data outputs"
+        return (
+            op1._obs_data() == op2._obs_data()  # pylint: disable=protected-access
+            or f"{op1} and {op2} have different _obs_data outputs"
+        )
 
-    return True
+    return f"{op1} and {op2} are not same"
 
 
 @_equal_dispatch.register

--- a/pennylane/ops/functions/equal.py
+++ b/pennylane/ops/functions/equal.py
@@ -625,7 +625,7 @@ def _equal_tensor(op1: Tensor, op2: Observable, **kwargs):
             or f"{op1} and {op2} have different _obs_data outputs"
         )
 
-    return f"{op1} and {op2} are not same"
+    return f"{op1} is of type {type(op1)} and {op2} is of type {type(op2)}"
 
 
 @_equal_dispatch.register

--- a/pennylane/ops/functions/equal.py
+++ b/pennylane/ops/functions/equal.py
@@ -617,7 +617,9 @@ def _equal_tensor(op1: Tensor, op2: Observable, **kwargs):
         return f"{op2} is not of type Observable"
 
     if isinstance(op2, (Hamiltonian, LinearCombination, Hermitian)):
-        return op2.compare(op1) or f"{op1} and {op2} are not the same for an unspecified reason."
+        return (
+            op2.compare(op1) or f"'{op1}' and '{op2}' are not the same for an unspecified reason."
+        )
 
     if isinstance(op2, Tensor):
         return (

--- a/pennylane/ops/functions/equal.py
+++ b/pennylane/ops/functions/equal.py
@@ -632,13 +632,11 @@ def _equal_tensor(op1: Tensor, op2: Observable, **kwargs):
 # pylint: disable=unused-argument
 def _equal_hamiltonian(op1: Hamiltonian, op2: Observable, **kwargs):
     """Determine whether a Hamiltonian object is equal to a Hamiltonian/Tensor objects"""
+
     if not isinstance(op2, Observable):
         return f"{op2} is not of type Observable"
 
-    if not op1.compare(op2):
-        return f"'{op1}' and '{op2}' are not the same"
-
-    return True
+    return op1.compare(op2) or f"'{op1}' and '{op2}' are not the same for an unspecified reason"
 
 
 @_equal_dispatch.register

--- a/pennylane/ops/functions/equal.py
+++ b/pennylane/ops/functions/equal.py
@@ -617,7 +617,7 @@ def _equal_tensor(op1: Tensor, op2: Observable, **kwargs):
         return f"{op2} is not of type Observable"
 
     if isinstance(op2, (Hamiltonian, LinearCombination, Hermitian)):
-        return op2.compare(op1) or f"{op1} and {op2} are not the same"
+        return op2.compare(op1) or f"{op1} and {op2} are not the same for an unspecified reason."
 
     if isinstance(op2, Tensor):
         return (

--- a/pennylane/ops/functions/equal.py
+++ b/pennylane/ops/functions/equal.py
@@ -617,7 +617,7 @@ def _equal_tensor(op1: Tensor, op2: Observable, **kwargs):
         return f"{op2} is not of type Observable"
 
     if isinstance(op2, (Hamiltonian, LinearCombination, Hermitian)):
-        return op2.compare(op1) or f"{op1} and {op2} are not same"
+        return op2.compare(op1) or f"{op1} and {op2} are not the same"
 
     if isinstance(op2, Tensor):
         return (
@@ -636,7 +636,7 @@ def _equal_hamiltonian(op1: Hamiltonian, op2: Observable, **kwargs):
         return f"{op2} is not of type Observable"
 
     if not op1.compare(op2):
-        return f"'{op1}' and '{op2}' are not same"
+        return f"'{op1}' and '{op2}' are not the same"
 
     return True
 

--- a/tests/ops/functions/test_equal.py
+++ b/tests/ops/functions/test_equal.py
@@ -1481,7 +1481,7 @@ class TestObservablesComparisons:
         """Tensors are not equal because of different observable data"""
         op1 = qml.operation.Tensor(qml.X(0), qml.Y(1))
         op2 = qml.operation.Tensor(qml.Y(0), qml.X(1))
-        with pytest.raises(AssertionError, match="op1 and op2 have different _obs_data outputs"):
+        with pytest.raises(AssertionError, match="have different _obs_data outputs"):
             assert_equal(op1, op2)
 
     @pytest.mark.parametrize(("H", "T", "res"), equal_hamiltonians_and_tensors)

--- a/tests/ops/functions/test_equal.py
+++ b/tests/ops/functions/test_equal.py
@@ -1467,7 +1467,7 @@ class TestObservablesComparisons:
         assert qml.equal(H1, H2) == qml.equal(H2, H1)
         assert qml.equal(H1, H2) == res
         if not res:
-            error_message_pattern = re.compile(r"'([^']+)' and '([^']+)' are not same")
+            error_message_pattern = re.compile(r"'([^']+)' and '([^']+)' are not the same")
             with pytest.raises(AssertionError, match=error_message_pattern):
                 assert_equal(H1, H2)
 
@@ -1537,7 +1537,7 @@ class TestObservablesComparisons:
         op2 = qml.Hermitian([[0, 1], [1, 0]], 0)
 
         assert not qml.equal(op1, op2)
-        error_message_pattern = re.compile(r"'([^']+)' and '([^']+)' are not same")
+        error_message_pattern = re.compile(r"'([^']+)' and '([^']+)' are not the same")
         with pytest.raises(AssertionError, match=error_message_pattern):
             assert_equal(op1, op2)
 

--- a/tests/ops/functions/test_equal.py
+++ b/tests/ops/functions/test_equal.py
@@ -1522,6 +1522,15 @@ class TestObservablesComparisons:
         with pytest.raises(AssertionError, match="is not of type Observable"):
             assert_equal(op1, op2)
 
+    def test_tensor_and_observable_not_equal(self):
+        """Tests that comparing a Tensor with an Observable that is not a Tensor returns False"""
+        op1 = qml.PauliX(0) @ qml.PauliY(1)
+        op2 = qml.Z(0)
+        assert qml.equal(op1, op2) is False
+        assert qml.equal(op2, op1) is False
+        with pytest.raises(AssertionError, match="is of type <class 'pennylane.operation.Tensor'>"):
+            assert_equal(op1, op2)
+
     def test_tensor_and_unsupported_observable_returns_false(self):
         """Tests that trying to compare a Tensor to something other than another Tensor or a Hamiltonian returns False"""
         op1 = qml.PauliX(0) @ qml.PauliY(1)


### PR DESCRIPTION
Fixes bug where `qml.equal` incorrectly returns `True` when a `Tensor` is not equal with another non-`Tensor` observable.