### PR TITLE
Adding an is_abtract check in pauli_decompose so it does not break under jit (either jax.jit or catalyst.qjit)

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -487,6 +487,9 @@
 * Fix bug where `CompositeOp.overlapping_ops` sometimes puts overlapping ops in different groups, leading to incorrect results returned by `LinearCombination.eigvals()`
   [(#5847)](https://github.com/PennyLaneAI/pennylane/pull/5847)
 
+* `qml.pauli_decompose` now works in a jit-ted context, such as `jax.jit` and `catalyst.qjit`.
+  [(#5878)](https://github.com/PennyLaneAI/pennylane/pull/5878)
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane/pauli/conversion.py
+++ b/pennylane/pauli/conversion.py
@@ -320,7 +320,7 @@ def pauli_decompose(
         if shape != (N, N):
             raise ValueError("The matrix should have shape (2**n, 2**n), for any qubit number n>=1")
 
-        if not qml.math.allclose(H, qml.math.conj(qml.math.transpose(H))):
+        if not is_abstract(H) and not qml.math.allclose(H, qml.math.conj(qml.math.transpose(H))):
             raise ValueError("The matrix is not Hermitian")
 
     coeffs, obs = _generalized_pauli_decompose(

--- a/pennylane/pauli/conversion.py
+++ b/pennylane/pauli/conversion.py
@@ -20,6 +20,7 @@ from operator import matmul
 from typing import Tuple, Union
 
 import pennylane as qml
+from pennylane.math.utils import is_abstract
 from pennylane.operation import Tensor
 from pennylane.ops import (
     Hamiltonian,
@@ -206,15 +207,17 @@ def _generalized_pauli_decompose(
         ).T
         coefficient = term_mat[tuple(int("".join(map(str, x)), 2) for x in bit_array)]
 
-        if not qml.math.allclose(coefficient, 0):
-            observables = (
-                [(o, w) for w, o in zip(wire_order, pauli_rep) if o != I]
-                if hide_identity and not all(t == I for t in pauli_rep)
-                else [(o, w) for w, o in zip(wire_order, pauli_rep)]
-            )
-            if observables:
-                coeffs.append(coefficient)
-                obs.append(observables)
+        if not is_abstract(matrix) and qml.math.allclose(coefficient, 0):
+            continue
+
+        observables = (
+            [(o, w) for w, o in zip(wire_order, pauli_rep) if o != I]
+            if hide_identity and not all(t == I for t in pauli_rep)
+            else [(o, w) for w, o in zip(wire_order, pauli_rep)]
+        )
+        if observables:
+            coeffs.append(coefficient)
+            obs.append(observables)
 
     coeffs = qml.math.stack(coeffs)
 

--- a/tests/pauli/test_conversion.py
+++ b/tests/pauli/test_conversion.py
@@ -218,8 +218,8 @@ class TestDecomposition:
             coeffs, unitaries = qml.pauli_decompose(m, check_hermitian=False).terms()
             return coeffs, unitaries
 
-        x = jax.numpy.array([[1, 1 - 1j], [1 + 1j, -1]])
-        assert np.allclose(f(x)[0], [1, 1, 1])
+        x = jax.numpy.array([[1 + 42j, 5.678 - 1.234j], [5.678 + 1.234j, -1 + 42j]])
+        assert np.allclose(f(x)[0], [42j, 5.678, 1.234, 1])
 
 
 class TestPhasedDecomposition:

--- a/tests/pauli/test_conversion.py
+++ b/tests/pauli/test_conversion.py
@@ -217,7 +217,8 @@ class TestDecomposition:
         def f(m):
             coeffs, unitaries = qml.pauli_decompose(m, check_hermitian=False).terms()
             return coeffs, unitaries
-        x = jax.numpy.array([[1,1-1j], [1+1j,-1]])
+
+        x = jax.numpy.array([[1, 1 - 1j], [1 + 1j, -1]])
         assert np.allclose(f(x)[0], [1, 1, 1])
 
 

--- a/tests/pauli/test_conversion.py
+++ b/tests/pauli/test_conversion.py
@@ -215,12 +215,20 @@ class TestDecomposition:
         import jax
 
         @jax.jit
-        def f(m):
+        def decompose_non_hermitian(m):
             coeffs, unitaries = qml.pauli_decompose(m, check_hermitian=False).terms()
             return coeffs, unitaries
 
         x = jax.numpy.array([[1 + 42j, 5.678 - 1.234j], [5.678 + 1.234j, -1 + 42j]])
-        assert np.allclose(f(x)[0], [42j, 5.678, 1.234, 1])
+        assert np.allclose(decompose_non_hermitian(x)[0], [42j, 5.678, 1.234, 1])
+
+        @jax.jit
+        def decompose_hermitian(m):
+            coeffs, unitaries = qml.pauli_decompose(m).terms()
+            return coeffs, unitaries
+
+        x = jax.numpy.array([[2, 1 - 1j], [1 + 1j, 0]])
+        assert np.allclose(decompose_hermitian(x)[0], [1, 1, 1, 1])
 
 
 class TestPhasedDecomposition:

--- a/tests/pauli/test_conversion.py
+++ b/tests/pauli/test_conversion.py
@@ -209,6 +209,7 @@ class TestDecomposition:
         ):
             qml.pauli_decompose(hamiltonian, pauli=pauli, wire_order=wire_order)
 
+    @pytest.mark.jax
     def test_jit(self):
         """Test that pauli_decompose can be used inside a jit context"""
         import jax

--- a/tests/pauli/test_conversion.py
+++ b/tests/pauli/test_conversion.py
@@ -209,6 +209,17 @@ class TestDecomposition:
         ):
             qml.pauli_decompose(hamiltonian, pauli=pauli, wire_order=wire_order)
 
+    def test_jit(self):
+        """Test that pauli_decompose can be used inside a jit context"""
+        import jax
+
+        @jax.jit
+        def f(m):
+            coeffs, unitaries = qml.pauli_decompose(m, check_hermitian=False).terms()
+            return coeffs, unitaries
+        x = jax.numpy.array([[1,1-1j], [1+1j,-1]])
+        assert np.allclose(f(x)[0], [1, 1, 1])
+
 
 class TestPhasedDecomposition:
     """Tests the _generalized_pauli_decompose via pauli_decompose function"""


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      test directory!

- [x] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `doc/releases/changelog-dev.md` file, summarizing the
      change, and including a link back to the PR.

- [x] The PennyLane source code conforms to
      [PEP8 standards](https://www.python.org/dev/peps/pep-0008/).
      We check all of our code against [Pylint](https://www.pylint.org/).
      To lint modified files, simply `pip install pylint`, and then
      run `pylint pennylane/path/to/file.py`.

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:** `pauli_decompose` currently fails under a `jax.jit` and `catalyst.qjit`

**Description of the Change:** An `is_abstract` check is added to avoid jit trying to compare an `isallclose` during compile time on an abstract tracer value

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:** closes #5817 

[sc-65302]
[sc-65344]