### PR TITLE
`PauliSentence.operation` always return a `LinearCombination`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -305,6 +305,9 @@
 * Transforms applied to callables now use `functools.wraps` to preserve the docstring and call signature of the original function.
   [(#5857)](https://github.com/PennyLaneAI/pennylane/pull/5857)
 
+* `PauliSentence.operation()` now always returns a `LinearCombination` for consistency.
+  [(#5879)](https://github.com/PennyLaneAI/pennylane/pull/5879)
+
 <h4>Community contributions 🥳</h4>
 
 * Implemented kwargs (`check_interface`, `check_trainability`, `rtol` and `atol`) support in `qml.equal` for the operators `Pow`, `Adjoint`, `Exp`, and `SProd`.

--- a/pennylane/pauli/pauli_arithmetic.py
+++ b/pennylane/pauli/pauli_arithmetic.py
@@ -1012,7 +1012,7 @@ class PauliSentence(dict):
         """Returns a native PennyLane :class:`~pennylane.ops.LinearCombination` representing the PauliSentence."""
 
         if len(self) == 0:
-            return qml.ops.LinearCombination([0], Identity(wires=wire_order))
+            return qml.ops.LinearCombination([0], [Identity(wires=wire_order)])
 
         wire_order = wire_order or self.wires
         ops, coeffs = zip(

--- a/pennylane/pauli/pauli_arithmetic.py
+++ b/pennylane/pauli/pauli_arithmetic.py
@@ -22,7 +22,7 @@ from scipy import sparse
 import pennylane as qml
 from pennylane import math
 from pennylane.operation import Tensor
-from pennylane.ops import Identity, PauliX, PauliY, PauliZ, Prod, SProd, Sum
+from pennylane.ops import Identity, PauliX, PauliY, PauliZ, Prod
 from pennylane.typing import TensorLike
 from pennylane.wires import Wires
 

--- a/tests/pauli/test_pauli_arithmetic.py
+++ b/tests/pauli/test_pauli_arithmetic.py
@@ -959,53 +959,48 @@ class TestPauliSentence:
     def test_operation(self, ps, op):
         """Test that a PauliSentence can be cast to a PL operation."""
         actual = ps.operation()
-        assert qml.equal(actual, op)
+        assert isinstance(actual, qml.ops.LinearCombination)
+        coeffs_expected, ops_expected = op.terms()
+        coeffs, ops = actual.terms()
+        for coeff, coeff_expected in zip(coeffs, coeffs_expected):
+            assert coeff == coeff_expected
+        for op, op_expected in zip(ops, ops_expected):
+            qml.assert_equal(op, op_expected)
 
     def test_operation_with_identity(self):
         """Test that a PauliSentence with an empty PauliWord can be cast to
         operation correctly."""
+
         full_ps_op = ps3.operation()
-        full_op = qml.sum(
-            -0.5 * qml.prod(qml.PauliZ(wires=0), qml.PauliZ(wires="b"), qml.PauliZ(wires="c")),
-            qml.s_prod(1, qml.Identity(wires=[0, "b", "c"])),
+        full_op = qml.ops.LinearCombination(
+            [-0.5, 1.0],
+            [
+                qml.prod(qml.PauliZ(wires=0), qml.PauliZ(wires="b"), qml.PauliZ(wires="c")),
+                qml.Identity(wires=[0, "b", "c"]),
+            ],
         )
-
-        ps_op, op = (
-            full_ps_op.operands[1],
-            full_op.operands[1],
-        )  # testing that the identity term is constructed well
-        if op.scalar != 1:
-            assert ps_op.scalar == op.scalar
-            ps_base, op_base = (ps_op.base, op.base)
-        else:
-            ps_base, op_base = ps_op, op.base
-
-        assert ps_base.name == op_base.name
-        assert set(ps_base.wires) == set(op_base.wires)
-        # in constructing the identity wires are cast from set -> list and the order is not preserved
+        assert qml.equal(full_ps_op, full_op)
 
     def test_operation_empty(self):
         """Test that an empty PauliSentence with wire_order returns Identity."""
         op = ps5.operation(wire_order=[0, 1])
-        id = qml.s_prod(0.0, qml.Identity(wires=[0, 1]))
-
-        assert op.name == id.name
-        assert op.wires == id.wires
+        expected = qml.ops.LinearCombination([0.0], [qml.Identity(wires=[0, 1])])
+        assert op.name == expected.name
+        assert op.wires == expected.wires
 
     def test_operation_empty_nowires(self):
         """Test that a ValueError is raised if an empty PauliSentence is
         cast to a PL operation."""
         res1 = ps4.operation()
-        assert res1 == qml.Identity()
+        qml.assert_equal(res1, qml.ops.LinearCombination([1], [qml.Identity()]))
         res2 = ps5.operation()
-        assert res2 == qml.s_prod(0, qml.Identity())
+        qml.assert_equal(res2, qml.ops.LinearCombination([0], [qml.Identity()]))
 
     def test_operation_wire_order(self):
         """Test that the wire_order parameter is used when the pauli representation is empty"""
         op = ps5.operation(wire_order=["a", "b"])
-        id = qml.s_prod(0.0, qml.Identity(wires=["a", "b"]))
-
-        qml.assert_equal(op, id)
+        expected = qml.ops.LinearCombination([0.0], [qml.Identity(wires=["a", "b"])])
+        qml.assert_equal(op, expected)
 
     tup_ps_hamiltonian = (
         (PauliSentence({PauliWord({0: X}): 1}), qml.Hamiltonian([1], [qml.PauliX(wires=0)])),

--- a/tests/pauli/test_pauli_arithmetic.py
+++ b/tests/pauli/test_pauli_arithmetic.py
@@ -22,8 +22,8 @@ from scipy import sparse
 
 import pennylane as qml
 from pennylane import numpy as np
-from pennylane.ops import Prod
 from pennylane.operation import Tensor
+from pennylane.ops import Prod
 from pennylane.pauli.pauli_arithmetic import I, PauliSentence, PauliWord, X, Y, Z
 
 matI = np.eye(2)

--- a/tests/pauli/test_pauli_arithmetic.py
+++ b/tests/pauli/test_pauli_arithmetic.py
@@ -964,8 +964,8 @@ class TestPauliSentence:
         coeffs, ops = actual.terms()
         for coeff, coeff_expected in zip(coeffs, coeffs_expected):
             assert coeff == coeff_expected
-        for op, op_expected in zip(ops, ops_expected):
-            qml.assert_equal(op, op_expected)
+        for op_actual, op_expected in zip(ops, ops_expected):
+            qml.assert_equal(op_actual, op_expected)
 
     def test_operation_with_identity(self):
         """Test that a PauliSentence with an empty PauliWord can be cast to


### PR DESCRIPTION
**Description of the Change:**
`PauliSentence.operation` always return a `LinearCombination`

**Benefits:**
More consistent behaviour.

[sc-63400]
