### PR TITLE
Raise DeprecationWarning only when the qasm code contains measurements

### DIFF
--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -22,9 +22,9 @@ Pending deprecations
   - Will be removed in v0.38
 
 * ``qml.from_qasm`` will no longer remove measurements from the QASM code. Calling ``qml.from_qasm``
-  without specifying ``measurements`` will raise a deprecation warning in v0.37, and in v0.38,
-  the default behaviour will be changed to keeping measurements. Use ``measurements=[]`` to remove
-  measurements from the original circuit.
+  on a circuit containing measurements without specifying ``measurements`` will raise a deprecation 
+  warning in v0.37, and in v0.38, the default behaviour will be changed to keeping measurements. Use 
+  ``measurements=[]`` to remove measurements from the original circuit.
 
   - Deprecated in v0.37
   - Default behaviour will be changed in v0.38

--- a/doc/releases/changelog-0.37.0.md
+++ b/doc/releases/changelog-0.37.0.md
@@ -306,7 +306,6 @@
 * The `qml.data` module now supports PyTree data types as dataset attributes
   [(#5732)](https://github.com/PennyLaneAI/pennylane/pull/5732)
 
-
 * `qml.ops.Conditional` now inherits from `qml.ops.SymbolicOp`, thus it inherits several useful common functionalities. Other properties such as adjoint and diagonalizing gates have been added using the `base` properties.
   [(##5772)](https://github.com/PennyLaneAI/pennylane/pull/5772)
 
@@ -416,6 +415,7 @@
 
 * The default behaviour of `qml.from_qasm()` to remove measurements in the QASM code is deprecated. Use `measurements=[]` to keep this behaviour or `measurements=None` to keep the measurements from the QASM code.
   [(#5882)](https://github.com/PennyLaneAI/pennylane/pull/5882)
+  [(#5904)](https://github.com/PennyLaneAI/pennylane/pull/5904)
 
 <h3>Documentation 📝</h3>
 

--- a/pennylane/io.py
+++ b/pennylane/io.py
@@ -506,7 +506,7 @@ def from_qasm(quantum_circuit: str, measurements=False):
     plugin_converter = plugin_converters["qasm"].load()
     if measurements is False:
         warnings.warn(
-            "The current default behaviour of removing measurements in the QASM code is "
+            "Here, The current default behaviour of removing measurements in the QASM code is "
             "deprecated. Set measurements=None to keep the existing measurements in the QASM "
             "code or set measurements=[] to remove them from the returned circuit. Starting "
             "in version 0.38, measurements=None will be the new default.",

--- a/pennylane/io.py
+++ b/pennylane/io.py
@@ -505,14 +505,15 @@ def from_qasm(quantum_circuit: str, measurements=False):
     """
     plugin_converter = plugin_converters["qasm"].load()
     if measurements is False:
-        warnings.warn(
-            "Here, The current default behaviour of removing measurements in the QASM code is "
-            "deprecated. Set measurements=None to keep the existing measurements in the QASM "
-            "code or set measurements=[] to remove them from the returned circuit. Starting "
-            "in version 0.38, measurements=None will be the new default.",
-            qml.PennyLaneDeprecationWarning,
-        )
         measurements = []
+        if "measure" in quantum_circuit:
+            warnings.warn(
+                "The current default behaviour of removing measurements in the QASM code "
+                "is deprecated. Set measurements=None to keep existing measurements in the QASM "
+                "code or set measurements=[] to remove them from the returned circuit. Starting "
+                "in version 0.38, measurements=None will be the new default.",
+                qml.PennyLaneDeprecationWarning,
+            )
     return plugin_converter(quantum_circuit, measurements=measurements)
 
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -137,7 +137,7 @@ class TestLoad:
     def test_from_qasm(self, mock_plugin_converters):
         """Tests that the correct entry point is called for from_qasm."""
 
-        qml.from_qasm("Test", measurements=None)
+        qml.from_qasm("Test")
         assert mock_plugin_converters["qasm"].called
         assert mock_plugin_converters["qasm"].last_args == ("Test",)
 
@@ -149,10 +149,10 @@ class TestLoad:
         """Tests that the current default behaviour of from_qasm is deprecated."""
 
         with pytest.warns(qml.PennyLaneDeprecationWarning, match="The current default behaviour"):
-            qml.from_qasm("Test")
+            qml.from_qasm("measure q[i] -> c[i];")
 
         called_args, called_kwargs = mock_plugin_converters["qasm"].call_args
-        assert called_args == ("Test",)
+        assert called_args == ("measure q[i] -> c[i];",)
         assert called_kwargs == {"measurements": []}
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
**Context:**
https://github.com/PennyLaneAI/pennylane/pull/5882 led to deprecation warnings raised in non-applicable scenarios

**Description of the Change:**
Only raise deprecation warning if the circuit contains measurements

**Benefits:**
Less confusing deprecation warnings
