### PR TITLE
CircuitGraph allows the same operation instance to occur multiple times

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -16,6 +16,8 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* `CircuitGraph` can now handle circuits with the same operation instance occuring multiple times.
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane/circuit_graph.py
+++ b/pennylane/circuit_graph.py
@@ -416,9 +416,12 @@ class CircuitGraph:
             if obj is old:
                 self._queue[i] = new
 
-    @cached_property
     def get_depth(self):
         """Depth of the quantum circuit (longest path in the DAG)."""
+        return self._depth
+
+    @cached_property
+    def _depth(self):
         # If there are no operations in the circuit, the depth is 0
         if not self.operations:
             return 0

--- a/pennylane/templates/subroutines/trotter.py
+++ b/pennylane/templates/subroutines/trotter.py
@@ -438,10 +438,9 @@ class TrotterProduct(ErrorOperation, ResourcesOperation):
         ops = kwargs["base"].operands
 
         decomp = _recursive_expression(time / n, order, ops)[::-1] * n
-        unique_decomp = [copy.copy(op) for op in decomp]
 
         if qml.QueuingManager.recording():
-            for op in unique_decomp:  # apply operators in reverse order of expression
+            for op in decomp:  # apply operators in reverse order of expression
                 qml.apply(op)
 
-        return unique_decomp
+        return decomp


### PR DESCRIPTION
**Context:**

`CircuitGraph` is from the early queuing era, when we could trust that every operation in a circuit was unique, since queuing had that constraint.

This is no longer the case, and can cause errors when the same operation is repeated multiple times. For example, in `TrotterProduct.compute_decomposition`.

**Description of the Change:**

The nodes of the `CircuitGraph` are now the indices into the queue.  Indices will be fully unique, even if the same operation occurs multiple times.

This is accomplished in conjunction with two new private attributes:

* `_nodes_on_wires`: a dictionary mapping a wire to the nodes that are on that wire
* `_inds_for_objs`: a dictionary mapping a `WrappedObj` instance to all the indices where that instance occurs.  This is a more general successor to `Operator.queue_idx`.  By making this information a private attribute on `CircuitGraph`, we won't have conflicts if the same operation instance occurs in multiple different tapes/ graphs.

The private properties `_grid` , `_indices`, and `_operation_graph` are removed, as they are no longer needed.

The private method `_in_topological_order` is removed, since it was a private method that nothing used.

`graph.operations_in_order` and `graph.observable_in_order` now just return `graph.operations` and `graph.observables` respectively, since those lists are already in order.  It was basically "sort this list by the order the objects come in the list".  They already come in the order that they come in the list?

`_depth` and `max_simultaneous_measurements` are now cached properties.

The method for calculating the depth is also simplified. Now we simply provide a weight function on the edges to `rx.dag_longest_path_length`. 

**Benefits:**

We can use the same instance multiple times in a `CircuitGraph` object.

**Possible Drawbacks:**

`CircuitGraph` no longer sets `Operator.queue_idx`.  Maybe someone wanted that.

The nodes for `CircuitGraph` are now integer indices, rather than operations.  So anyone relying on the individual nodes will see a change in behavior.

**Related GitHub Issues:**

Fixes #4406 [sc-42719]