### PR TITLE
Deprecate `qinfo.vn_entropy` 

### DIFF
--- a/pennylane/measurements/vn_entropy.py
+++ b/pennylane/measurements/vn_entropy.py
@@ -73,7 +73,7 @@ def vn_entropy(wires, log_base=None) -> "VnEntropyMP":
 class VnEntropyMP(StateMeasurement):
     """Measurement process that computes the Von Neumann entropy of the system prior to measurement.
 
-    Please refer to :func:`vn_entropy` for detailed documentation.
+    Please refer to :func:`~.vn_entropy` for detailed documentation.
 
     Args:
         wires (.Wires): The wires the measurement process applies to.

--- a/pennylane/qinfo/transforms.py
+++ b/pennylane/qinfo/transforms.py
@@ -231,6 +231,11 @@ def vn_entropy(
     .. math::
         S( \rho ) = -\text{Tr}( \rho \log ( \rho ))
 
+    .. warning::
+
+        The qml.qinfo.vn_entropy transform is deprecated and will be removed in 0.40. Instead include
+        the :func:`pennylane.vn_entropy` measurement process in the return line of your QNode.
+
     Args:
         tape (QNode or QuantumTape or Callable): A quantum circuit returning a :func:`~pennylane.state`.
         wires (Sequence(int)): List of wires in the considered subsystem.

--- a/pennylane/qinfo/transforms.py
+++ b/pennylane/qinfo/transforms.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """QNode transforms for the quantum information quantities."""
 # pylint: disable=import-outside-toplevel, not-callable
+import warnings
 from functools import partial
 from typing import Callable, Sequence
 
@@ -22,8 +23,6 @@ from pennylane.devices import DefaultMixed, DefaultQubit, DefaultQubitLegacy
 from pennylane.gradients import adjoint_metric_tensor, metric_tensor
 from pennylane.measurements import DensityMatrixMP, StateMP
 from pennylane.tape import QuantumTape
-
-import warnings
 
 
 @partial(transform, final_transform=True)

--- a/pennylane/qinfo/transforms.py
+++ b/pennylane/qinfo/transforms.py
@@ -23,6 +23,8 @@ from pennylane.gradients import adjoint_metric_tensor, metric_tensor
 from pennylane.measurements import DensityMatrixMP, StateMP
 from pennylane.tape import QuantumTape
 
+import warnings
+
 
 @partial(transform, final_transform=True)
 def reduced_dm(tape: QuantumTape, wires, **kwargs) -> (Sequence[QuantumTape], Callable):
@@ -76,6 +78,7 @@ def reduced_dm(tape: QuantumTape, wires, **kwargs) -> (Sequence[QuantumTape], Ca
 
     .. seealso:: :func:`pennylane.density_matrix` and :func:`pennylane.math.reduce_dm`
     """
+
     # device_wires is provided by the custom QNode transform
     all_wires = kwargs.get("device_wires", tape.wires)
     wire_map = {w: i for i, w in enumerate(all_wires)}
@@ -173,6 +176,7 @@ def purity(tape: QuantumTape, wires, **kwargs) -> (Sequence[QuantumTape], Callab
 
     .. seealso:: :func:`pennylane.math.purity`
     """
+
     # device_wires is provided by the custom QNode transform
     all_wires = kwargs.get("device_wires", tape.wires)
     wire_map = {w: i for i, w in enumerate(all_wires)}
@@ -261,6 +265,14 @@ def vn_entropy(
 
     .. seealso:: :func:`pennylane.math.vn_entropy` and :func:`pennylane.vn_entropy`
     """
+
+    warnings.warn(
+        "The qml.qinfo.vn_entropy transform is deprecated and will be removed "
+        "in 0.40. Instead include the qml.vn_entropy measurement process in the "
+        "return line of your QNode.",
+        qml.PennyLaneDeprecationWarning,
+    )
+
     # device_wires is provided by the custom QNode transform
     all_wires = kwargs.get("device_wires", tape.wires)
     wire_map = {w: i for i, w in enumerate(all_wires)}
@@ -401,6 +413,7 @@ def mutual_info(
 
     .. seealso:: :func:`~.qinfo.vn_entropy`, :func:`pennylane.math.mutual_info` and :func:`pennylane.mutual_info`
     """
+
     return _bipartite_qinfo_transform(qml.math.mutual_info, tape, wires0, wires1, base, **kwargs)
 
 
@@ -453,6 +466,7 @@ def vn_entanglement_entropy(
         will provide the entanglement entropy in the form of a tensor.
 
     """
+
     return _bipartite_qinfo_transform(
         qml.math.vn_entanglement_entropy, tape, wires0, wires1, base, **kwargs
     )

--- a/tests/qinfo/test_entropies.py
+++ b/tests/qinfo/test_entropies.py
@@ -19,6 +19,12 @@ import pytest
 import pennylane as qml
 from pennylane import numpy as np
 
+DEP_WARNING_MESSAGE_VN_ENTROPY = (
+    "The qml.qinfo.vn_entropy transform is deprecated and will be removed "
+    "in 0.40. Instead include the qml.vn_entropy measurement process in the "
+    "return line of your QNode."
+)
+
 
 def expected_entropy_ising_xx(param):
     """
@@ -82,7 +88,11 @@ class TestVonNeumannEntropy:
             return qml.state()
 
         with pytest.raises(ValueError, match="Cannot provide a 'device' value"):
-            _ = qml.qinfo.vn_entropy(circuit, wires=[0], device=dev)
+            with pytest.warns(
+                qml.PennyLaneDeprecationWarning,
+                match=DEP_WARNING_MESSAGE_VN_ENTROPY,
+            ):
+                _ = qml.qinfo.vn_entropy(circuit, wires=[0], device=dev)
 
         with pytest.raises(ValueError, match="Cannot provide a 'device_wires' value"):
             _ = qml.qinfo.vn_entropy(circuit, wires=[0], device_wires=dev.wires)
@@ -101,7 +111,11 @@ class TestVonNeumannEntropy:
             qml.IsingXX(x, wires=[0, 1])
             return qml.state()
 
-        entropy = qml.qinfo.vn_entropy(circuit_state, wires=wires, base=base)(param)
+        with pytest.warns(
+            qml.PennyLaneDeprecationWarning,
+            match=DEP_WARNING_MESSAGE_VN_ENTROPY,
+        ):
+            entropy = qml.qinfo.vn_entropy(circuit_state, wires=wires, base=base)(param)
 
         expected_entropy = expected_entropy_ising_xx(param) / np.log(base)
         assert qml.math.allclose(entropy, expected_entropy)
@@ -123,7 +137,13 @@ class TestVonNeumannEntropy:
             qml.IsingXX(x, wires=[0, 1])
             return qml.state()
 
-        grad_entropy = qml.grad(qml.qinfo.vn_entropy(circuit_state, wires=wires, base=base))(param)
+        with pytest.warns(
+            qml.PennyLaneDeprecationWarning,
+            match=DEP_WARNING_MESSAGE_VN_ENTROPY,
+        ):
+            grad_entropy = qml.grad(qml.qinfo.vn_entropy(circuit_state, wires=wires, base=base))(
+                param
+            )
 
         grad_expected_entropy = expected_entropy_grad_ising_xx(param) / np.log(base)
         assert qml.math.allclose(grad_entropy, grad_expected_entropy)
@@ -147,7 +167,13 @@ class TestVonNeumannEntropy:
             qml.IsingXX(x, wires=[0, 1])
             return qml.state()
 
-        entropy = qml.qinfo.vn_entropy(circuit_state, wires=wires, base=base)(torch.tensor(param))
+        with pytest.warns(
+            qml.PennyLaneDeprecationWarning,
+            match=DEP_WARNING_MESSAGE_VN_ENTROPY,
+        ):
+            entropy = qml.qinfo.vn_entropy(circuit_state, wires=wires, base=base)(
+                torch.tensor(param)
+            )
 
         expected_entropy = expected_entropy_ising_xx(param) / np.log(base)
         assert qml.math.allclose(entropy, expected_entropy)
@@ -176,7 +202,12 @@ class TestVonNeumannEntropy:
         grad_expected_entropy = expected_entropy_grad_ising_xx(param) / np.log(base)
 
         param = torch.tensor(param, dtype=torch.float64, requires_grad=True)
-        entropy = qml.qinfo.vn_entropy(circuit_state, wires=wires, base=base)(param)
+
+        with pytest.warns(
+            qml.PennyLaneDeprecationWarning,
+            match=DEP_WARNING_MESSAGE_VN_ENTROPY,
+        ):
+            entropy = qml.qinfo.vn_entropy(circuit_state, wires=wires, base=base)(param)
 
         entropy.backward()
         grad_entropy = param.grad
@@ -202,7 +233,13 @@ class TestVonNeumannEntropy:
             qml.IsingXX(x, wires=[0, 1])
             return qml.state()
 
-        entropy = qml.qinfo.vn_entropy(circuit_state, wires=wires, base=base)(tf.Variable(param))
+        with pytest.warns(
+            qml.PennyLaneDeprecationWarning,
+            match=DEP_WARNING_MESSAGE_VN_ENTROPY,
+        ):
+            entropy = qml.qinfo.vn_entropy(circuit_state, wires=wires, base=base)(
+                tf.Variable(param)
+            )
 
         expected_entropy = expected_entropy_ising_xx(param) / np.log(base)
 
@@ -226,7 +263,11 @@ class TestVonNeumannEntropy:
 
         param = tf.Variable(param)
         with tf.GradientTape() as tape:
-            entropy = qml.qinfo.vn_entropy(circuit_state, wires=wires, base=base)(param)
+            with pytest.warns(
+                qml.PennyLaneDeprecationWarning,
+                match=DEP_WARNING_MESSAGE_VN_ENTROPY,
+            ):
+                entropy = qml.qinfo.vn_entropy(circuit_state, wires=wires, base=base)(param)
 
         grad_entropy = tape.gradient(entropy, param)
 
@@ -253,7 +294,11 @@ class TestVonNeumannEntropy:
             qml.IsingXX(x, wires=[0, 1])
             return qml.state()
 
-        entropy = qml.qinfo.vn_entropy(circuit_state, wires=wires, base=base)(jnp.array(param))
+        with pytest.warns(
+            qml.PennyLaneDeprecationWarning,
+            match=DEP_WARNING_MESSAGE_VN_ENTROPY,
+        ):
+            entropy = qml.qinfo.vn_entropy(circuit_state, wires=wires, base=base)(jnp.array(param))
 
         expected_entropy = expected_entropy_ising_xx(param) / np.log(base)
 
@@ -275,9 +320,13 @@ class TestVonNeumannEntropy:
             qml.IsingXX(x, wires=[0, 1])
             return qml.state()
 
-        grad_entropy = jax.grad(qml.qinfo.vn_entropy(circuit_state, wires=wires, base=base))(
-            jax.numpy.array(param)
-        )
+        with pytest.warns(
+            qml.PennyLaneDeprecationWarning,
+            match=DEP_WARNING_MESSAGE_VN_ENTROPY,
+        ):
+            grad_entropy = jax.grad(qml.qinfo.vn_entropy(circuit_state, wires=wires, base=base))(
+                jax.numpy.array(param)
+            )
 
         grad_expected_entropy = expected_entropy_grad_ising_xx(param) / np.log(base)
 
@@ -302,9 +351,13 @@ class TestVonNeumannEntropy:
             qml.IsingXX(x, wires=[0, 1])
             return qml.state()
 
-        entropy = jax.jit(qml.qinfo.vn_entropy(circuit_state, wires=wires, base=base))(
-            jnp.array(param)
-        )
+        with pytest.warns(
+            qml.PennyLaneDeprecationWarning,
+            match=DEP_WARNING_MESSAGE_VN_ENTROPY,
+        ):
+            entropy = jax.jit(qml.qinfo.vn_entropy(circuit_state, wires=wires, base=base))(
+                jnp.array(param)
+            )
 
         expected_entropy = expected_entropy_ising_xx(param) / np.log(base)
 
@@ -348,7 +401,11 @@ class TestVonNeumannEntropy:
             ValueError,
             match="The qfunc return type needs to be a state.",
         ):
-            qml.qinfo.vn_entropy(circuit_state, wires=[0, 1])(param)
+            with pytest.warns(
+                qml.PennyLaneDeprecationWarning,
+                match=DEP_WARNING_MESSAGE_VN_ENTROPY,
+            ):
+                qml.qinfo.vn_entropy(circuit_state, wires=[0, 1])(param)
 
     def test_qnode_entropy_wires_full_range_state_vector(self):
         """Test entropy for a QNode that returns a state vector with all wires, entropy is 0."""
@@ -360,7 +417,11 @@ class TestVonNeumannEntropy:
             qml.IsingXX(x, wires=[0, 1])
             return qml.state()
 
-        entropy = qml.qinfo.vn_entropy(circuit_state, wires=[0, 1])(param)
+        with pytest.warns(
+            qml.PennyLaneDeprecationWarning,
+            match=DEP_WARNING_MESSAGE_VN_ENTROPY,
+        ):
+            entropy = qml.qinfo.vn_entropy(circuit_state, wires=[0, 1])(param)
 
         expected_entropy = 0.0
         assert qml.math.allclose(entropy, expected_entropy)
@@ -375,7 +436,12 @@ class TestVonNeumannEntropy:
             qml.IsingXX(x, wires=[0, 1])
             return qml.state()
 
-        entropy = qml.qinfo.vn_entropy(circuit_state, wires=[0, 1])(param)
+        with pytest.warns(
+            qml.PennyLaneDeprecationWarning,
+            match=DEP_WARNING_MESSAGE_VN_ENTROPY,
+        ):
+            entropy = qml.qinfo.vn_entropy(circuit_state, wires=[0, 1])(param)
+
         expected_entropy = 0.0
 
         assert qml.math.allclose(entropy, expected_entropy)
@@ -393,11 +459,21 @@ class TestVonNeumannEntropy:
             qml.IsingXX(x, wires=wires)
             return qml.state()
 
-        entropy0 = qml.qinfo.vn_entropy(circuit, wires=[wires[0]])(param)
+        with pytest.warns(
+            qml.PennyLaneDeprecationWarning,
+            match=DEP_WARNING_MESSAGE_VN_ENTROPY,
+        ):
+            entropy0 = qml.qinfo.vn_entropy(circuit, wires=[wires[0]])(param)
+
         eigs0 = [np.sin(param / 2) ** 2, np.cos(param / 2) ** 2]
         exp0 = -np.sum(eigs0 * np.log(eigs0))
 
-        entropy1 = qml.qinfo.vn_entropy(circuit, wires=[wires[1]])(param)
+        with pytest.warns(
+            qml.PennyLaneDeprecationWarning,
+            match=DEP_WARNING_MESSAGE_VN_ENTROPY,
+        ):
+            entropy1 = qml.qinfo.vn_entropy(circuit, wires=[wires[1]])(param)
+
         eigs1 = [np.cos(param / 2) ** 2, np.sin(param / 2) ** 2]
         exp1 = -np.sum(eigs1 * np.log(eigs1))
 

--- a/tests/qinfo/test_entropies.py
+++ b/tests/qinfo/test_entropies.py
@@ -87,15 +87,15 @@ class TestVonNeumannEntropy:
             qml.CNOT(wires=[0, 1])
             return qml.state()
 
-        with pytest.raises(ValueError, match="Cannot provide a 'device' value"):
-            with pytest.warns(
-                qml.PennyLaneDeprecationWarning,
-                match=DEP_WARNING_MESSAGE_VN_ENTROPY,
-            ):
+        with pytest.warns(
+            qml.PennyLaneDeprecationWarning,
+            match=DEP_WARNING_MESSAGE_VN_ENTROPY,
+        ):
+            with pytest.raises(ValueError, match="Cannot provide a 'device' value"):
                 _ = qml.qinfo.vn_entropy(circuit, wires=[0], device=dev)
 
-        with pytest.raises(ValueError, match="Cannot provide a 'device_wires' value"):
-            _ = qml.qinfo.vn_entropy(circuit, wires=[0], device_wires=dev.wires)
+            with pytest.raises(ValueError, match="Cannot provide a 'device_wires' value"):
+                _ = qml.qinfo.vn_entropy(circuit, wires=[0], device_wires=dev.wires)
 
     @pytest.mark.parametrize("wires", single_wires_list)
     @pytest.mark.parametrize("param", parameters)
@@ -379,9 +379,13 @@ class TestVonNeumannEntropy:
             qml.IsingXX(x, wires=[0, 1])
             return qml.state()
 
-        grad_entropy = jax.jit(
-            jax.grad(qml.qinfo.vn_entropy(circuit_state, wires=wires, base=base))
-        )(jax.numpy.array(param))
+        with pytest.warns(
+            qml.PennyLaneDeprecationWarning,
+            match=DEP_WARNING_MESSAGE_VN_ENTROPY,
+        ):
+            grad_entropy = jax.jit(
+                jax.grad(qml.qinfo.vn_entropy(circuit_state, wires=wires, base=base))
+            )(jax.numpy.array(param))
 
         grad_expected_entropy = expected_entropy_grad_ising_xx(param) / np.log(base)
 
@@ -923,7 +927,11 @@ class TestBroadcasting:
             return qml.state()
 
         x = np.array([0.4, 0.6, 0.8])
-        entropy = qml.qinfo.vn_entropy(circuit_state, wires=[0])(x)
+        with pytest.warns(
+            qml.PennyLaneDeprecationWarning,
+            match=DEP_WARNING_MESSAGE_VN_ENTROPY,
+        ):
+            entropy = qml.qinfo.vn_entropy(circuit_state, wires=[0])(x)
 
         expected = [expected_entropy_ising_xx(_x) for _x in x]
         assert qml.math.allclose(entropy, expected)

--- a/tests/qinfo/test_entropies.py
+++ b/tests/qinfo/test_entropies.py
@@ -87,15 +87,11 @@ class TestVonNeumannEntropy:
             qml.CNOT(wires=[0, 1])
             return qml.state()
 
-        with pytest.warns(
-            qml.PennyLaneDeprecationWarning,
-            match=DEP_WARNING_MESSAGE_VN_ENTROPY,
-        ):
-            with pytest.raises(ValueError, match="Cannot provide a 'device' value"):
-                _ = qml.qinfo.vn_entropy(circuit, wires=[0], device=dev)
+        with pytest.raises(ValueError, match="Cannot provide a 'device' value"):
+            _ = qml.qinfo.vn_entropy(circuit, wires=[0], device=dev)
 
-            with pytest.raises(ValueError, match="Cannot provide a 'device_wires' value"):
-                _ = qml.qinfo.vn_entropy(circuit, wires=[0], device_wires=dev.wires)
+        with pytest.raises(ValueError, match="Cannot provide a 'device_wires' value"):
+            _ = qml.qinfo.vn_entropy(circuit, wires=[0], device_wires=dev.wires)
 
     @pytest.mark.parametrize("wires", single_wires_list)
     @pytest.mark.parametrize("param", parameters)


### PR DESCRIPTION
**Context:**

https://app.shortcut.com/xanaduai/story/66716/deprecate-qml-qinfo-transforms-vn-entropy

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
