### PR TITLE
Deprecate `qinfo.reduced_dm`

### DIFF
--- a/pennylane/qinfo/transforms.py
+++ b/pennylane/qinfo/transforms.py
@@ -23,6 +23,8 @@ from pennylane.gradients import adjoint_metric_tensor, metric_tensor
 from pennylane.measurements import DensityMatrixMP, StateMP
 from pennylane.tape import QuantumTape
 
+import warnings
+
 
 @partial(transform, final_transform=True)
 def reduced_dm(tape: QuantumTape, wires, **kwargs) -> (Sequence[QuantumTape], Callable):
@@ -76,6 +78,14 @@ def reduced_dm(tape: QuantumTape, wires, **kwargs) -> (Sequence[QuantumTape], Ca
 
     .. seealso:: :func:`pennylane.density_matrix` and :func:`pennylane.math.reduce_dm`
     """
+
+    warnings.warn(
+        "The qml.qinfo.reduced_dm transform is deprecated and will be removed "
+        "in 0.40. Instead include the qml.density_matrix measurement process in the "
+        "return line of your QNode.",
+        qml.PennyLaneDeprecationWarning,
+    )
+
     # device_wires is provided by the custom QNode transform
     all_wires = kwargs.get("device_wires", tape.wires)
     wire_map = {w: i for i, w in enumerate(all_wires)}


### PR DESCRIPTION
**Context:**

https://app.shortcut.com/xanaduai/story/66715/deprecate-qml-qinfo-transforms-reduced-dm?vc_group_by=day&ct_workflow=all&cf_workflow=500000005

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
