### PR TITLE
Deprecate `qinfo.mutual_info`

### DIFF
--- a/pennylane/qinfo/transforms.py
+++ b/pennylane/qinfo/transforms.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 """QNode transforms for the quantum information quantities."""
 # pylint: disable=import-outside-toplevel, not-callable
-from functools import partial
 import warnings
+from functools import partial
 from typing import Callable, Sequence
 
 import pennylane as qml

--- a/pennylane/qinfo/transforms.py
+++ b/pennylane/qinfo/transforms.py
@@ -359,6 +359,11 @@ def mutual_info(
 
         I(A, B) = S(\rho^A) + S(\rho^B) - S(\rho^{AB})
 
+    .. warning::
+
+        The qml.qinfo.mutual_info transform is deprecated and will be removed in 0.40. Instead include
+        the :func:`pennylane.mutual_info` measurement process in the return line of your QNode.
+
     where :math:`S` is the von Neumann entropy.
 
     The mutual information is a measure of correlation between two subsystems.

--- a/pennylane/qinfo/transforms.py
+++ b/pennylane/qinfo/transforms.py
@@ -14,6 +14,7 @@
 """QNode transforms for the quantum information quantities."""
 # pylint: disable=import-outside-toplevel, not-callable
 from functools import partial
+import warnings
 from typing import Callable, Sequence
 
 import pennylane as qml
@@ -22,8 +23,6 @@ from pennylane.devices import DefaultMixed, DefaultQubit, DefaultQubitLegacy
 from pennylane.gradients import adjoint_metric_tensor, metric_tensor
 from pennylane.measurements import DensityMatrixMP, StateMP
 from pennylane.tape import QuantumTape
-
-import warnings
 
 
 @partial(transform, final_transform=True)

--- a/pennylane/qinfo/transforms.py
+++ b/pennylane/qinfo/transforms.py
@@ -23,6 +23,8 @@ from pennylane.gradients import adjoint_metric_tensor, metric_tensor
 from pennylane.measurements import DensityMatrixMP, StateMP
 from pennylane.tape import QuantumTape
 
+import warnings
+
 
 @partial(transform, final_transform=True)
 def reduced_dm(tape: QuantumTape, wires, **kwargs) -> (Sequence[QuantumTape], Callable):
@@ -401,6 +403,14 @@ def mutual_info(
 
     .. seealso:: :func:`~.qinfo.vn_entropy`, :func:`pennylane.math.mutual_info` and :func:`pennylane.mutual_info`
     """
+
+    warnings.warn(
+        "The qml.qinfo.mutual_info transform is deprecated and will be removed "
+        "in 0.40. Instead include the qml.mutual_info measurement process in the "
+        "return line of your QNode.",
+        qml.PennyLaneDeprecationWarning,
+    )
+
     return _bipartite_qinfo_transform(qml.math.mutual_info, tape, wires0, wires1, base, **kwargs)
 
 

--- a/tests/measurements/legacy/test_mutual_info_legacy.py
+++ b/tests/measurements/legacy/test_mutual_info_legacy.py
@@ -19,6 +19,11 @@ import pennylane as qml
 from pennylane.measurements import Shots
 from pennylane.workflow import INTERFACE_MAP
 
+DEP_WARNING_MESSAGE_MUTUAL_INFO = (
+    "The qml.qinfo.mutual_info transform is deprecated and will be removed "
+    "in 0.40. Instead include the qml.mutual_info measurement process in the "
+    "return line of your QNode."
+)
 
 @pytest.mark.parametrize("shots, shape", [(None, ()), (10, ()), ([1, 10], ((), ()))])
 def test_shape(shots, shape):
@@ -94,7 +99,11 @@ class TestIntegration:
             qml.CNOT(wires=[0, 1])
             return qml.state()
 
-        actual = qml.qinfo.mutual_info(circuit, wires0=[0], wires1=[1])(params)
+        with pytest.warns(
+            qml.PennyLaneDeprecationWarning,
+            match=DEP_WARNING_MESSAGE_MUTUAL_INFO,
+        ):
+            actual = qml.qinfo.mutual_info(circuit, wires0=[0], wires1=[1])(params)
 
         # compare transform results with analytic values
         expected = -2 * np.cos(params / 2) ** 2 * np.log(
@@ -130,8 +139,12 @@ class TestIntegration:
 
         actual = circuit_mutual_info(params)
 
-        # compare measurement results with transform results
-        expected = qml.qinfo.mutual_info(circuit_state, wires0=[0], wires1=[1])(params)
+        with pytest.warns(
+            qml.PennyLaneDeprecationWarning,
+            match=DEP_WARNING_MESSAGE_MUTUAL_INFO,
+        ):
+            # compare measurement results with transform results
+            expected = qml.qinfo.mutual_info(circuit_state, wires0=[0], wires1=[1])(params)
 
         assert np.allclose(actual, expected)
 
@@ -148,7 +161,11 @@ class TestIntegration:
             qml.CNOT(wires=wires)
             return qml.state()
 
-        actual = qml.qinfo.mutual_info(circuit, wires0=[wires[0]], wires1=[wires[1]])(param)
+        with pytest.warns(
+            qml.PennyLaneDeprecationWarning,
+            match=DEP_WARNING_MESSAGE_MUTUAL_INFO,
+        ):
+            actual = qml.qinfo.mutual_info(circuit, wires0=[wires[0]], wires1=[wires[1]])(param)
 
         # compare transform results with analytic values
         expected = -2 * np.cos(param / 2) ** 2 * np.log(np.cos(param / 2) ** 2) - 2 * np.sin(
@@ -175,7 +192,11 @@ class TestIntegration:
             qml.CNOT(wires=[0, 1])
             return qml.state()
 
-        actual = jax.jit(qml.qinfo.mutual_info(circuit, wires0=[0], wires1=[1]))(params)
+        with pytest.warns(
+            qml.PennyLaneDeprecationWarning,
+            match=DEP_WARNING_MESSAGE_MUTUAL_INFO,
+        ):
+            actual = jax.jit(qml.qinfo.mutual_info(circuit, wires0=[0], wires1=[1]))(params)
 
         # compare transform results with analytic values
         expected = -2 * jnp.cos(params / 2) ** 2 * jnp.log(
@@ -213,8 +234,12 @@ class TestIntegration:
 
         actual = jax.jit(circuit_mutual_info)(params)
 
-        # compare measurement results with transform results
-        expected = jax.jit(qml.qinfo.mutual_info(circuit_state, wires0=[0], wires1=[1]))(params)
+        with pytest.warns(
+            qml.PennyLaneDeprecationWarning,
+            match=DEP_WARNING_MESSAGE_MUTUAL_INFO,
+        ):
+            # compare measurement results with transform results
+            expected = jax.jit(qml.qinfo.mutual_info(circuit_state, wires0=[0], wires1=[1]))(params)
 
         assert np.allclose(actual, expected)
 

--- a/tests/measurements/legacy/test_mutual_info_legacy.py
+++ b/tests/measurements/legacy/test_mutual_info_legacy.py
@@ -25,6 +25,7 @@ DEP_WARNING_MESSAGE_MUTUAL_INFO = (
     "return line of your QNode."
 )
 
+
 @pytest.mark.parametrize("shots, shape", [(None, ()), (10, ()), ([1, 10], ((), ()))])
 def test_shape(shots, shape):
     """Test that the shape is correct."""

--- a/tests/measurements/test_mutual_info.py
+++ b/tests/measurements/test_mutual_info.py
@@ -22,6 +22,12 @@ from pennylane.measurements import MutualInfo, Shots
 from pennylane.measurements.mutual_info import MutualInfoMP
 from pennylane.wires import Wires
 
+DEP_WARNING_MESSAGE_MUTUAL_INFO = (
+    "The qml.qinfo.mutual_info transform is deprecated and will be removed "
+    "in 0.40. Instead include the qml.mutual_info measurement process in the "
+    "return line of your QNode."
+)
+
 
 class TestMutualInfoUnitTests:
     """Tests for the mutual_info function"""
@@ -144,7 +150,11 @@ class TestIntegration:
             qml.CNOT(wires=[0, 1])
             return qml.state()
 
-        actual = qml.qinfo.mutual_info(circuit, wires0=[0], wires1=[1])(params)
+        with pytest.warns(
+            qml.PennyLaneDeprecationWarning,
+            match=DEP_WARNING_MESSAGE_MUTUAL_INFO,
+        ):
+            actual = qml.qinfo.mutual_info(circuit, wires0=[0], wires1=[1])(params)
 
         # compare transform results with analytic values
         expected = -2 * np.cos(params / 2) ** 2 * np.log(
@@ -181,7 +191,11 @@ class TestIntegration:
         actual = circuit_mutual_info(params)
 
         # compare measurement results with transform results
-        expected = qml.qinfo.mutual_info(circuit_state, wires0=[0], wires1=[1])(params)
+        with pytest.warns(
+            qml.PennyLaneDeprecationWarning,
+            match=DEP_WARNING_MESSAGE_MUTUAL_INFO,
+        ):
+            expected = qml.qinfo.mutual_info(circuit_state, wires0=[0], wires1=[1])(params)
 
         assert np.allclose(actual, expected)
 
@@ -198,7 +212,11 @@ class TestIntegration:
             qml.CNOT(wires=wires)
             return qml.state()
 
-        actual = qml.qinfo.mutual_info(circuit, wires0=[wires[0]], wires1=[wires[1]])(param)
+        with pytest.warns(
+            qml.PennyLaneDeprecationWarning,
+            match=DEP_WARNING_MESSAGE_MUTUAL_INFO,
+        ):
+            actual = qml.qinfo.mutual_info(circuit, wires0=[wires[0]], wires1=[wires[1]])(param)
 
         # compare transform results with analytic values
         expected = -2 * np.cos(param / 2) ** 2 * np.log(np.cos(param / 2) ** 2) - 2 * np.sin(
@@ -237,7 +255,11 @@ class TestIntegration:
         transformed_circuit = qml.qinfo.mutual_info(circuit, wires0=[0], wires1=[1])
 
         with pytest.raises(ValueError, match="The qfunc return type needs to be a state"):
-            _ = transformed_circuit(0.1)
+            with pytest.warns(
+                qml.PennyLaneDeprecationWarning,
+                match=DEP_WARNING_MESSAGE_MUTUAL_INFO,
+            ):
+                _ = transformed_circuit(0.1)
 
     @pytest.mark.jax
     @pytest.mark.parametrize("params", np.linspace(0, 2 * np.pi, 8))
@@ -257,7 +279,11 @@ class TestIntegration:
             qml.CNOT(wires=[0, 1])
             return qml.state()
 
-        actual = jax.jit(qml.qinfo.mutual_info(circuit, wires0=[0], wires1=[1]))(params)
+        with pytest.warns(
+            qml.PennyLaneDeprecationWarning,
+            match=DEP_WARNING_MESSAGE_MUTUAL_INFO,
+        ):
+            actual = jax.jit(qml.qinfo.mutual_info(circuit, wires0=[0], wires1=[1]))(params)
 
         # compare transform results with analytic values
         expected = -2 * jnp.cos(params / 2) ** 2 * jnp.log(
@@ -296,7 +322,11 @@ class TestIntegration:
         actual = jax.jit(circuit_mutual_info)(params)
 
         # compare measurement results with transform results
-        expected = jax.jit(qml.qinfo.mutual_info(circuit_state, wires0=[0], wires1=[1]))(params)
+        with pytest.warns(
+            qml.PennyLaneDeprecationWarning,
+            match=DEP_WARNING_MESSAGE_MUTUAL_INFO,
+        ):
+            expected = jax.jit(qml.qinfo.mutual_info(circuit_state, wires0=[0], wires1=[1]))(params)
 
         assert np.allclose(actual, expected)
 
@@ -517,5 +547,11 @@ class TestIntegration:
             return qml.state()
 
         actual = circuit(params)
-        expected = qml.qinfo.mutual_info(circuit_expected, wires0=["a"], wires1=["b"])(params)
+
+        with pytest.warns(
+            qml.PennyLaneDeprecationWarning,
+            match=DEP_WARNING_MESSAGE_MUTUAL_INFO,
+        ):
+            expected = qml.qinfo.mutual_info(circuit_expected, wires0=["a"], wires1=["b"])(params)
+
         assert np.allclose(actual, expected)

--- a/tests/qinfo/test_entropies.py
+++ b/tests/qinfo/test_entropies.py
@@ -215,9 +215,7 @@ class TestVonNeumannEntropy:
             qml.IsingXX(x, wires=[0, 1])
             return qml.state()
 
-        entropy = qml.qinfo.vn_entropy(circuit_state, wires=wires, base=base)(
-            tf.Variable(param)
-        )
+        entropy = qml.qinfo.vn_entropy(circuit_state, wires=wires, base=base)(tf.Variable(param))
 
         expected_entropy = expected_entropy_ising_xx(param) / np.log(base)
 
@@ -316,7 +314,7 @@ class TestVonNeumannEntropy:
         def circuit_state(x):
             qml.IsingXX(x, wires=[0, 1])
             return qml.state()
-        
+
         entropy = jax.jit(qml.qinfo.vn_entropy(circuit_state, wires=wires, base=base))(
             jnp.array(param)
         )

--- a/tests/qinfo/test_entropies.py
+++ b/tests/qinfo/test_entropies.py
@@ -19,12 +19,6 @@ import pytest
 import pennylane as qml
 from pennylane import numpy as np
 
-DEP_WARNING_MESSAGE_VN_ENTROPY = (
-    "The qml.qinfo.vn_entropy transform is deprecated and will be removed "
-    "in 0.40. Instead include the qml.vn_entropy measurement process in the "
-    "return line of your QNode."
-)
-
 DEP_WARNING_MESSAGE_MUTUAL_INFO = (
     "The qml.qinfo.mutual_info transform is deprecated and will be removed "
     "in 0.40. Instead include the qml.mutual_info measurement process in the "


### PR DESCRIPTION
**Context:**

https://app.shortcut.com/xanaduai/story/66713/deprecate-qml-qinfo-transforms-mutual-info?vc_group_by=day&ct_workflow=all&cf_workflow=500000005

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
