### PR TITLE
turn QuantumScript.hash into a cached property

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -9,6 +9,7 @@
 <h3>Improvements 🛠</h3>
 
 * `QuantumScript.hash` is now cached, leading to performance improvements.
+  [(#5919)](https://github.com/PennyLaneAI/pennylane/pull/5919)
 
 <h3>Breaking changes 💔</h3>
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -8,6 +8,8 @@
   
 <h3>Improvements 🛠</h3>
 
+* `QuantumScript.hash` is now cached, leading to performance improvements.
+
 <h3>Breaking changes 💔</h3>
 
 <h3>Deprecations 👋</h3>
@@ -20,4 +22,5 @@
 
 This release contains contributions from (in alphabetical order):
 
-Yushao Chen.
+Yushao Chen,
+Christina Lee,

--- a/pennylane/tape/qscript.py
+++ b/pennylane/tape/qscript.py
@@ -188,7 +188,7 @@ class QuantumScript:
     def __repr__(self):
         return f"<{self.__class__.__name__}: wires={self.wires.tolist()}, params={self.num_params}>"
 
-    @property
+    @cached_property
     def hash(self):
         """int: returns an integer hash uniquely representing the quantum script"""
         fingerprint = []
@@ -383,6 +383,7 @@ class QuantumScript:
             # Invalidate cached properties so they get recalculated
             del self.wires
             del self.par_info
+            del self.hash
         except AttributeError:
             pass
 

--- a/pennylane/tape/qscript.py
+++ b/pennylane/tape/qscript.py
@@ -378,6 +378,7 @@ class QuantumScript:
         """Update all internal metadata regarding processed operations and observables"""
         self._graph = None
         self._specs = None
+        self._trainable_params = None
 
         try:
             # Invalidate cached properties so they get recalculated

--- a/tests/tape/test_qscript.py
+++ b/tests/tape/test_qscript.py
@@ -199,11 +199,18 @@ class TestUpdate:
         ]
         m = [qml.expval(qml.Hermitian(2 * np.eye(2), wires=0))]
         qs = QuantumScript(ops, m)
+        assert qs.wires == qml.wires.Wires((0,))
+        qs.par_info  # trigger caching # pylint: disable=pointless-statement
+        qs.hash  # trigger caching # pylint: disable=pointless-statement
+        assert qs.trainable_params == [0, 1, 2, 3, 4, 5, 6, 7]
+
         qs._ops = []
         qs._measurements = []
         qs._update()
         assert qs.wires == qml.wires.Wires([])
         assert isinstance(qs.par_info, list) and len(qs.par_info) == 0
+        assert QuantumScript([], []).hash == qs.hash
+        assert qs.trainable_params == []
 
     # pylint: disable=unbalanced-tuple-unpacking
     def test_get_operation(self):

--- a/tests/tape/test_qscript.py
+++ b/tests/tape/test_qscript.py
@@ -201,16 +201,14 @@ class TestUpdate:
         qs = QuantumScript(ops, m)
         assert qs.wires == qml.wires.Wires((0,))
         assert isinstance(qs.par_info, list) and len(qs.par_info) > 0
-        qs.hash  # trigger caching # pylint: disable=pointless-statement
+        old_hash = qs.hash
         assert qs.trainable_params == [0, 1, 2, 3, 4, 5, 6, 7]
-
         qs._ops = []
         qs._measurements = []
         qs._update()
         assert qs.wires == qml.wires.Wires([])
-        assert qs.par_info == []
-        assert QuantumScript([], []).hash == qs.hash
-        assert qs.trainable_params == []
+        assert isinstance(qs.par_info, list) and len(qs.par_info) == 0
+        assert QuantumScript([], []).hash == qs.hash and qs.hash != old_hash
 
     # pylint: disable=unbalanced-tuple-unpacking
     def test_get_operation(self):

--- a/tests/tape/test_qscript.py
+++ b/tests/tape/test_qscript.py
@@ -200,7 +200,7 @@ class TestUpdate:
         m = [qml.expval(qml.Hermitian(2 * np.eye(2), wires=0))]
         qs = QuantumScript(ops, m)
         assert qs.wires == qml.wires.Wires((0,))
-        qs.par_info  # trigger caching # pylint: disable=pointless-statement
+        assert isinstance(qs.par_info, list) and len(qs.par_info) > 0
         qs.hash  # trigger caching # pylint: disable=pointless-statement
         assert qs.trainable_params == [0, 1, 2, 3, 4, 5, 6, 7]
 
@@ -208,7 +208,7 @@ class TestUpdate:
         qs._measurements = []
         qs._update()
         assert qs.wires == qml.wires.Wires([])
-        assert isinstance(qs.par_info, list) and len(qs.par_info) == 0
+        assert qs.par_info == []
         assert QuantumScript([], []).hash == qs.hash
         assert qs.trainable_params == []
 


### PR DESCRIPTION


**Context:**

When investigating some performance issues, I noticed that we weren't caching `QuantumScript.hash`, even though calculating it is a known performance bottleneck.

**Description of the Change:**

Make `QuantumScript.hash` a cached property.

**Benefits:**

Much lower classical overhead when we are using caching.

<img width="839" alt="Screenshot 2024-06-28 at 5 38 15 PM" src="https://github.com/PennyLaneAI/pennylane/assets/6364575/9d25401d-af74-455b-8a18-04fc7dc07c33">

**Possible Drawbacks:**

If someone does bad things and mutates the tape in place, they will have to deal with the resulting consequences.

**Related GitHub Issues:**
