### PR TITLE
Revert changes added for MidCircuitMeasure updates

### DIFF
--- a/doc/releases/changelog-0.37.0.md
+++ b/doc/releases/changelog-0.37.0.md
@@ -156,6 +156,7 @@
 * The `dynamic_one_shot` transform is made compatible with the Catalyst compiler.
   [(#5766)](https://github.com/PennyLaneAI/pennylane/pull/5766)
   [(#5888)](https://github.com/PennyLaneAI/pennylane/pull/5888)
+  [(#5930)](https://github.com/PennyLaneAI/pennylane/pull/5930)
   
 * Rationalize MCM tests, removing most end-to-end tests from the native MCM test file,
   but keeping one that validates multiple mid-circuit measurements with any allowed return

--- a/pennylane/ops/functions/equal.py
+++ b/pennylane/ops/functions/equal.py
@@ -674,6 +674,9 @@ def _equal_measurements(
         if isinstance(op1.mv, MeasurementValue) and isinstance(op2.mv, MeasurementValue):
             return qml.equal(op1.mv, op2.mv)
 
+        if qml.math.is_abstract(op1.mv) or qml.math.is_abstract(op2.mv):
+            return op1.mv is op2.mv
+
         if isinstance(op1.mv, Iterable) and isinstance(op2.mv, Iterable):
             if len(op1.mv) == len(op2.mv):
                 return all(mv1.measurements == mv2.measurements for mv1, mv2 in zip(op1.mv, op2.mv))

--- a/tests/ops/functions/test_equal.py
+++ b/tests/ops/functions/test_equal.py
@@ -1430,6 +1430,31 @@ class TestMeasurementsEqual:
         assert qml.equal(mp1, mp3)
         assert not qml.equal(mp1, mp4)
 
+    @pytest.mark.jax
+    @pytest.mark.parametrize("mp_fn", [qml.expval, qml.var, qml.sample, qml.counts, qml.probs])
+    def test_abstract_mv_equality(self, mp_fn):
+        """Test that equality is verified correctly for measurements collecting statistics for
+        abstract mid-circuit measurement values"""
+        import jax  # pylint: disable=import-outside-toplevel
+
+        m1 = True
+        m2 = False
+
+        @jax.jit
+        def eq_traced(a, b):
+            assert qml.math.is_abstract(a)
+            assert qml.math.is_abstract(b)
+
+            mp1 = mp_fn(op=a)
+            mp2 = mp_fn(op=a)
+            mp3 = mp_fn(op=b)
+
+            return qml.equal(mp1, mp2), qml.equal(mp1, mp3)
+
+        res = eq_traced(m1, m2)
+        assert res[0]
+        assert not res[1]
+
     def test_shadow_expval_list_versus_operator(self):
         """Check that if one shadow expval has an operator and the other has a list, they are not equal."""
 


### PR DESCRIPTION
**Context:**
Some changes were added preemptively in #5888 for changes that were being added to Catalyst in https://github.com/PennyLaneAI/catalyst/pull/832, but that PR is not merged, so the changes from #5888 have to be reverted.

**Description of the Change:**
Reverted changes from #5888 
Some updates to catalyst-`split_non_commuting` caused test failures in Catalyst in cases where terminal measurements contain mid-circuit measurements, so `qml.equal` was updated to handle abstract measurement values.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
