### PR TITLE
QA release fixes

### DIFF
--- a/doc/code/qml_noise.rst
+++ b/doc/code/qml_noise.rst
@@ -53,10 +53,11 @@ quantum circuit. One can construct standard Boolean functions using the followin
 For example, a Boolean function that checks if an operation is on wire ``0`` can be created
 as follows:
 
->>> fn = wires_eq(0)
+>>> fn = qml.noise.wires_eq(0)
 >>> op1, op2 = qml.PauliX(0), qml.PauliX(1)
 >>> fn(op1)
 True
+
 >>> fn(op2)
 False
 
@@ -117,6 +118,7 @@ For example, a constant-valued over-rotation can be created using:
 >>> rx_constant = qml.noise.partial_wires(qml.RX(0.1, wires=[0]))
 >>> rx_constant(2)
 RX(0.1, 2)
+
 >>> qml.NoiseModel({rx_condition: rx_constant})
 NoiseModel({
     BooleanFn(rx_condition): RX(phi=0.1)

--- a/doc/code/qml_noise.rst
+++ b/doc/code/qml_noise.rst
@@ -50,15 +50,15 @@ quantum circuit. One can construct standard Boolean functions using the followin
     ~wires_eq
     ~wires_in
 
-For example, a Boolean function that checks of an operation is on wire ``0`` can be created
-like so:
+For example, a Boolean function that checks if an operation is on wire ``0`` can be created
+as follows:
 
 >>> fn = wires_eq(0)
 >>> op1, op2 = qml.PauliX(0), qml.PauliX(1)
 >>> fn(op1)
-False
->>> fn(op2)
 True
+>>> fn(op2)
+False
 
 Arbitrary Boolean functions can also be defined by wrapping the functional form
 of custom conditions with the following decorator:
@@ -79,7 +79,7 @@ with a maximum parameter value:
     def rx_condition(op, **metadata):
         return isinstance(op, qml.RX) and op.parameters[0] < 1.0
 
-Boolean functions can be combined using standard bit-wise operators, such as
+Boolean functions can be combined using standard bitwise operators, such as
 ``&``, ``|``, ``^``, or ``~``. The result will be another Boolean function. It
 is important to note that as Python will evaluate the expression in the order
 of their combination, i.e., left to right, the order of composition could matter,
@@ -177,7 +177,7 @@ above, such as :func:`~.op_eq`. These objects do not need to be instantiated dir
     ~WiresEq
     ~WiresIn
 
-Bitwise operations like `And` and `Or` are represented with the following classes in the
+Bitwise operations like ``And`` and ``Or`` are represented with the following classes in the
 :mod:`boolean_fn` module:
 
 .. currentmodule:: pennylane.boolean_fn

--- a/pennylane/boolean_fn.py
+++ b/pennylane/boolean_fn.py
@@ -64,6 +64,7 @@ class BooleanFn:
     Other supported operators are ``|`` (logical or) and ``~`` (logical not):
 
     .. code-block:: python
+
         smaller_equal_than_4 = ~bigger_than_4
         smaller_than_10_or_int = smaller_than_10 | is_int
 

--- a/pennylane/boolean_fn.py
+++ b/pennylane/boolean_fn.py
@@ -22,7 +22,7 @@ import functools
 # pylint: disable=unnecessary-lambda
 class BooleanFn:
     r"""Wrapper for simple callables with Boolean output that can be
-    manipulated and combined with bit-wise operators.
+    manipulated and combined with bitwise operators.
 
     Args:
         fn (callable): Function to be wrapped. It can accept any number
@@ -103,7 +103,7 @@ class BooleanFn:
 
     @property
     def bitwise(self):
-        """Determine whether wrapped callable performs a bit-wise operation or not.
+        """Determine whether wrapped callable performs a bitwise operation or not.
         This checks for the ``operands`` attribute that should be defined by it."""
         return bool(getattr(self, "operands", tuple()))
 
@@ -115,12 +115,12 @@ class BooleanFn:
 
 
 class And(BooleanFn):
-    """Developer facing class for implemeting bit-wise ``AND`` for callables
+    """Developer facing class for implemeting bitwise ``AND`` for callables
     wrapped up with :class:`BooleanFn <pennylane.BooleanFn>`.
 
     Args:
-        left (~.BooleanFn): Left operand in the bit-wise expression.
-        right (~.BooleanFn): Right operand in the bit-wise expression.
+        left (~.BooleanFn): Left operand in the bitwise expression.
+        right (~.BooleanFn): Right operand in the bitwise expression.
     """
 
     def __init__(self, left, right):
@@ -139,12 +139,12 @@ class And(BooleanFn):
 
 
 class Or(BooleanFn):
-    """Developer facing class for implemeting bit-wise ``OR`` for callables
+    """Developer facing class for implemeting bitwise ``OR`` for callables
     wrapped up with :class:`BooleanFn <pennylane.BooleanFn>`.
 
     Args:
-        left (~.BooleanFn): Left operand in the bit-wise expression.
-        right (~.BooleanFn): Right operand in the bit-wise expression.
+        left (~.BooleanFn): Left operand in the bitwise expression.
+        right (~.BooleanFn): Right operand in the bitwise expression.
     """
 
     def __init__(self, left, right):
@@ -163,12 +163,12 @@ class Or(BooleanFn):
 
 
 class Xor(BooleanFn):
-    """Developer facing class for implemeting bit-wise ``XOR`` for callables
+    """Developer facing class for implemeting bitwise ``XOR`` for callables
     wrapped up with :class:`BooleanFn <pennylane.BooleanFn>`.
 
     Args:
-        left (~.BooleanFn): Left operand in the bit-wise expression.
-        right (~.BooleanFn): Right operand in the bit-wise expression.
+        left (~.BooleanFn): Left operand in the bitwise expression.
+        right (~.BooleanFn): Right operand in the bitwise expression.
     """
 
     def __init__(self, left, right):
@@ -187,11 +187,11 @@ class Xor(BooleanFn):
 
 
 class Not(BooleanFn):
-    """Developer facing class for implemeting bit-wise ``NOT`` for callables
+    """Developer facing class for implemeting bitwise ``NOT`` for callables
     wrapped up with :class:`BooleanFn <pennylane.BooleanFn>`.
 
     Args:
-        left (~.BooleanFn): Left operand in the bit-wise expression.
+        left (~.BooleanFn): Left operand in the bitwise expression.
     """
 
     def __init__(self, left):

--- a/pennylane/boolean_fn.py
+++ b/pennylane/boolean_fn.py
@@ -33,13 +33,18 @@ class BooleanFn:
     Consider functions that filter numbers to lie within a certain domain.
     We may wrap them using ``BooleanFn``:
 
-    >>> bigger_than_4 = qml.BooleanFn(lambda x: x > 4)
-    >>> smaller_than_10 = qml.BooleanFn(lambda x: x < 10)
-    >>> is_int = qml.BooleanFn(lambda x: isinstance(x, int))
+    .. code-block:: python
+
+        bigger_than_4 = qml.BooleanFn(lambda x: x > 4)
+        smaller_than_10 = qml.BooleanFn(lambda x: x < 10)
+        is_int = qml.BooleanFn(lambda x: isinstance(x, int))
+
     >>> bigger_than_4(5.2)
     True
+
     >>> smaller_than_10(20.1)
     False
+
     >>> is_int(2.3)
     False
 
@@ -49,15 +54,18 @@ class BooleanFn:
     >>> between_4_and_10 = bigger_than_4 & smaller_than_10
     >>> between_4_and_10(-3.2)
     False
+
     >>> between_4_and_10(9.9)
     True
+
     >>> between_4_and_10(19.7)
     False
 
     Other supported operators are ``|`` (logical or) and ``~`` (logical not):
 
-    >>> smaller_equal_than_4 = ~bigger_than_4
-    >>> smaller_than_10_or_int = smaller_than_10 | is_int
+    .. code-block:: python
+        smaller_equal_than_4 = ~bigger_than_4
+        smaller_than_10_or_int = smaller_than_10 | is_int
 
     .. warning::
 
@@ -71,8 +79,10 @@ class BooleanFn:
         >>> has_bit_length_3 = qml.BooleanFn(lambda x: x.bit_length()==3)
         >>> (is_int & has_bit_length_3)(4)
         True
+
         >>> (is_int & has_bit_length_3)(2.3)
         False
+
         >>> (has_bit_length_3 & is_int)(2.3)
         AttributeError: 'float' object has no attribute 'bit_length'
 

--- a/pennylane/boolean_fn.py
+++ b/pennylane/boolean_fn.py
@@ -30,7 +30,7 @@ class BooleanFn:
 
     **Example**
 
-    Consider functions that filter numbers to lie in a certain domain.
+    Consider functions that filter numbers to lie within a certain domain.
     We may wrap them using ``BooleanFn``:
 
     >>> bigger_than_4 = qml.BooleanFn(lambda x: x > 4)
@@ -44,7 +44,7 @@ class BooleanFn:
     False
 
     These can then be combined into a single callable using boolean operators,
-    such as ``&``, logical and:
+    such as ``&`` (logical and):
 
     >>> between_4_and_10 = bigger_than_4 & smaller_than_10
     >>> between_4_and_10(-3.2)
@@ -54,7 +54,7 @@ class BooleanFn:
     >>> between_4_and_10(19.7)
     False
 
-    Other supported operators are ``|``, logical or, and ``~``, logical not:
+    Other supported operators are ``|`` (logical or) and ``~`` (logical not):
 
     >>> smaller_equal_than_4 = ~bigger_than_4
     >>> smaller_than_10_or_int = smaller_than_10 | is_int
@@ -103,13 +103,13 @@ class BooleanFn:
 
     @property
     def bitwise(self):
-        """Determine whether wrapped callable performs a bitwise operation or not.
+        """Determine whether the wrapped callable performs a bitwise operation or not.
         This checks for the ``operands`` attribute that should be defined by it."""
         return bool(getattr(self, "operands", tuple()))
 
     @property
     def conditional(self):
-        """Determine whether wrapped callable is for a conditional or not.
+        """Determine whether the wrapped callable is for a conditional or not.
         This checks for the ``condition`` attribute that should be defined by it."""
         return bool(getattr(self, "condition", None))
 

--- a/pennylane/devices/default_tensor.py
+++ b/pennylane/devices/default_tensor.py
@@ -352,8 +352,7 @@ class DefaultTensor(Device):
             The execution time for this circuit with the above parameters is around 0.8 seconds on a standard laptop.
 
             The tensor network method can be faster than MPS and state vector methods in some cases.
-            As a comparison, the time for the exact calculation (i.e., with ``max_bond_dim = None``) of the same circuit using the MPS method with the ``default.qubit``
-            device is approximately three orders of magnitude slower.
+            As a comparison, the time for the exact calculation (i.e., with ``max_bond_dim = None``) of the same circuit with the `default.tensor` device using the MPS method is approximately three orders of magnitude slower. Using the ``default.qubit`` device also results in a much slower simulation.
     """
 
     # pylint: disable=too-many-instance-attributes

--- a/pennylane/devices/default_tensor.py
+++ b/pennylane/devices/default_tensor.py
@@ -266,7 +266,8 @@ class DefaultTensor(Device):
             setting the maximum bond dimension to 100 and the cutoff to the machine epsilon.
 
             We set ``"auto-mps"`` as the contraction technique to apply gates. With this option, ``quimb`` turns 3-qubit gates and 4-qubit gates
-            into Matrix Product Operators (MPO) and applies them directly to the MPS. On the other hand, qubits involved in 2-qubit gates may be temporarily swapped to adjacent positions before applying the gate and then returned to their original positions.
+            into Matrix Product Operators (MPO) and applies them directly to the MPS. On the other hand, qubits involved in 2-qubit gates may be
+            temporarily swapped to adjacent positions before applying the gate and then returned to their original positions.
 
             .. code-block:: python
 
@@ -348,7 +349,8 @@ class DefaultTensor(Device):
             The execution time for this circuit with the above parameters is around 0.8 seconds on a standard laptop.
 
             The tensor network method can be faster than MPS and state vector methods in some cases.
-            As a comparison, the time for the exact calculation (i.e., with ``max_bond_dim = None``) of the same circuit using the MPS method with the ``default.qubit`` device is approximately three orders of magnitude slower.
+            As a comparison, the time for the exact calculation (i.e., with ``max_bond_dim = None``) of the same circuit using the MPS method with the ``default.qubit``
+            device is approximately three orders of magnitude slower.
     """
 
     # pylint: disable=too-many-instance-attributes

--- a/pennylane/devices/default_tensor.py
+++ b/pennylane/devices/default_tensor.py
@@ -352,7 +352,9 @@ class DefaultTensor(Device):
             The execution time for this circuit with the above parameters is around 0.8 seconds on a standard laptop.
 
             The tensor network method can be faster than MPS and state vector methods in some cases.
-            As a comparison, the time for the exact calculation (i.e., with ``max_bond_dim = None``) of the same circuit with the `default.tensor` device using the MPS method is approximately three orders of magnitude slower. Using the ``default.qubit`` device also results in a much slower simulation.
+            As a comparison, the time for the exact calculation (i.e., with ``max_bond_dim = None``) of the same circuit
+            using the ``MPS`` method of the ``default.tensor`` device is approximately three orders of magnitude slower.
+            Similarly, using the ``default.qubit`` device results in a much slower simulation.
     """
 
     # pylint: disable=too-many-instance-attributes

--- a/pennylane/devices/default_tensor.py
+++ b/pennylane/devices/default_tensor.py
@@ -201,16 +201,16 @@ class DefaultTensor(Device):
     The backend uses the ``quimb`` library to perform the tensor network operations, and different methods can be used to simulate the quantum circuit.
     The supported methods are Matrix Product State (MPS) and Tensor Network (TN).
 
-    This device does not currently support finite shots or differentiation. At present, the supported measurement types are expectation values, variances and state measurements.
+    This device does not currently support finite-shots or differentiation. At present, the supported measurement types are expectation values, variances and state measurements.
     Finally, ``UserWarnings`` from the ``cotengra`` package may appear when using this device.
 
     Args:
         wires (int, Iterable[Number, str]): Number of wires present on the device, or iterable that
-            contains unique labels for the wires as numbers (i.e., ``[-1, 0, 2]``) or strings
-            (``['aux_wire', 'q1', 'q2']``).
+            contains unique labels for the wires as numbers (e.g., ``[-1, 0, 2]``) or strings
+            (e.g., ``['aux_wire', 'q1', 'q2']``).
         method (str): Supported method. The supported methods are ``"mps"`` (Matrix Product State) and ``"tn"`` (Tensor Network).
         c_dtype (type): Complex data type for the tensor representation. Must be one of ``numpy.complex64`` or ``numpy.complex128``.
-        **kwargs: keyword arguments for the device, passed to the ``quimb`` backend.
+        **kwargs: Keyword arguments for the device, passed to the ``quimb`` backend.
 
     Keyword Args:
         max_bond_dim (int): Maximum bond dimension for the MPS method.
@@ -266,8 +266,7 @@ class DefaultTensor(Device):
             setting the maximum bond dimension to 100 and the cutoff to the machine epsilon.
 
             We set ``"auto-mps"`` as the contraction technique to apply gates. With this option, ``quimb`` turns 3-qubit gates and 4-qubit gates
-            into Matrix Product Operators (MPO) and applies them directly to the MPS. On the other hand, qubits in 2-qubit gates are possibly
-            swapped to be adjacent before applying the gate, then swapped back.
+            into Matrix Product Operators (MPO) and applies them directly to the MPS. On the other hand, qubits involved in 2-qubit gates may be temporarily swapped to adjacent positions before applying the gate and then returned to their original positions.
 
             .. code-block:: python
 
@@ -349,8 +348,7 @@ class DefaultTensor(Device):
             The execution time for this circuit with the above parameters is around 0.8 seconds on a standard laptop.
 
             The tensor network method can be faster than MPS and state vector methods in some cases.
-            As a comparison, the time for the exact calculation of the same circuit with the MPS method and with the ``default.qubit``
-            device is about three orders of magnitude slower.
+            As a comparison, the time for the exact calculation (i.e., with ``max_bond_dim = None``) of the same circuit using the MPS method with the ``default.qubit`` device is approximately three orders of magnitude slower.
     """
 
     # pylint: disable=too-many-instance-attributes

--- a/pennylane/drawer/draw.py
+++ b/pennylane/drawer/draw.py
@@ -186,7 +186,7 @@ def draw(
 
         >>> print(qml.draw(circuit, wire_order=[1,0])(a=2.3, w=[1.2, 3.2, 0.7]))
         1: ────╭RX(2.30)──Rot(1.20,3.20,0.70,"arbitrary")─╭RX(-2.30)─┤ ╭<Z@Z>
-        0: ──H─╰●─────────────────────────────╰●─────────┤ ╰<Z@Z>
+        0: ──H─╰●─────────────────────────────────────────╰●─────────┤ ╰<Z@Z>
 
         If the device or ``wire_order`` has wires not used by operations, those wires are omitted
         unless requested with ``show_all_wires=True``

--- a/pennylane/drawer/draw.py
+++ b/pennylane/drawer/draw.py
@@ -91,9 +91,9 @@ def draw(
     .. note::
 
         At most, one of ``level`` or ``expansion_strategy`` needs to be provided. If neither is provided,
-        ``qnode.expansion_strategy`` would be used instead. Users are encouraged to predominantly use ``level``,
-        as it allows for the same values as ``expansion_strategy``, and allows for more flexibility choosing
-        the wanted transforms/expansions.
+        ``qnode.expansion_strategy`` will be used instead. Users are encouraged to predominantly use ``level``,
+        as it allows for the same values as ``expansion_strategy`` and offers more flexibility in choosing
+        the desired transforms/expansions.
 
 
     **Example**
@@ -173,23 +173,19 @@ def draw(
                 qml.StronglyEntanglingLayers(params, wires=range(3))
                 return [qml.expval(qml.Z(i)) for i in range(3)]
 
-            print(qml.draw(longer_circuit, max_length=60)(params))
-
-        .. code-block:: none
-
-            0: ──Rot(0.77,0.44,0.86)─╭●────╭X──Rot(0.45,0.37,0.93)─╭●─╭X
-            1: ──Rot(0.70,0.09,0.98)─╰X─╭●─│───Rot(0.64,0.82,0.44)─│──╰●
-            2: ──Rot(0.76,0.79,0.13)────╰X─╰●──Rot(0.23,0.55,0.06)─╰X───
-
-            ───Rot(0.83,0.63,0.76)──────────────────────╭●────╭X─┤  <Z>
-            ──╭X────────────────────Rot(0.35,0.97,0.89)─╰X─╭●─│──┤  <Z>
-            ──╰●────────────────────Rot(0.78,0.19,0.47)────╰X─╰●─┤  <Z>
+        >>> print(qml.draw(longer_circuit, max_length=60, expansion_strategy="device")(params))
+        0: ──Rot(0.77,0.44,0.86)─╭●────╭X──Rot(0.45,0.37,0.93)─╭●─╭X
+        1: ──Rot(0.70,0.09,0.98)─╰X─╭●─│───Rot(0.64,0.82,0.44)─│──╰●
+        2: ──Rot(0.76,0.79,0.13)────╰X─╰●──Rot(0.23,0.55,0.06)─╰X───
+        ───Rot(0.83,0.63,0.76)──────────────────────╭●────╭X─┤  <Z>
+        ──╭X────────────────────Rot(0.35,0.97,0.89)─╰X─╭●─│──┤  <Z>
+        ──╰●────────────────────Rot(0.78,0.19,0.47)────╰X─╰●─┤  <Z>
 
         The ``wire_order`` keyword specifies the order of the wires from
         top to bottom:
 
         >>> print(qml.draw(circuit, wire_order=[1,0])(a=2.3, w=[1.2, 3.2, 0.7]))
-        1: ────╭RX(2.30)──Rot(1.20,3.20,0.70)─╭RX(-2.30)─┤ ╭<Z@Z>
+        1: ────╭RX(2.30)──Rot(1.20,3.20,0.70,"arbitrary")─╭RX(-2.30)─┤ ╭<Z@Z>
         0: ──H─╰●─────────────────────────────╰●─────────┤ ╰<Z@Z>
 
         If the device or ``wire_order`` has wires not used by operations, those wires are omitted
@@ -207,6 +203,7 @@ def draw(
         .. code-block:: python
 
             from functools import partial
+            from pennylane import numpy as pnp
 
             @partial(qml.gradients.param_shift, shifts=[(0.1,)])
             @qml.qnode(qml.device('default.qubit', wires=1))
@@ -214,13 +211,9 @@ def draw(
                 qml.RX(x, wires=0)
                 return qml.expval(qml.Z(0))
 
-            print(qml.draw(transformed_circuit)(np.array(1.0, requires_grad=True)))
-
-        .. code-block:: none
-
-            0: ──RX(1.10)─┤  <Z>
-
-            0: ──RX(0.90)─┤  <Z>
+        >>> print(qml.draw(transformed_circuit)(pnp.array(1.0, requires_grad=True)))
+        0: ──RX(1.10)─┤  <Z>
+        0: ──RX(0.90)─┤  <Z>
 
         The function also accepts quantum functions rather than QNodes. This can be especially
         helpful if you want to visualize only a part of a circuit that may not be convertible into
@@ -236,7 +229,7 @@ def draw(
         **Levels:**
 
         The ``level`` keyword argument allows one to select a subset of the transforms to apply on the ``QNode``
-        before carrying out any drawing. Take for example this circuit:
+        before carrying out any drawing. Take, for example, this circuit:
 
         .. code-block:: python
 
@@ -271,7 +264,7 @@ def draw(
         1: ─╰RandomLayers(M0)─├Permute─┤
         2: ───────────────────╰Permute─┤
 
-        To apply all of the transforms, including those carried out by the differentitation method and the device, use ``level=None``:
+        To apply all of the transforms, including those carried out by the differentiation method and the device, use ``level=None``:
 
         >>> print(qml.draw(circ, level=None, show_matrices=False)(weights, order))
         0: ──RY(1.00)──╭SWAP─┤  <X>
@@ -446,9 +439,9 @@ def draw_mpl(
     .. note::
 
         At most, one of ``level`` or ``expansion_strategy`` needs to be provided. If neither is provided,
-        ``qnode.expansion_strategy`` would be used instead. Users are encouraged to predominantly use ``level``,
-        as it allows for the same values as ``expansion_strategy``, and allows for more flexibility choosing
-        the wanted transforms/expansions.
+        ``qnode.expansion_strategy`` will be used instead. Users are encouraged to predominantly use ``level``,
+        as it allows for the same values as ``expansion_strategy`` and offers more flexibility in choosing
+        the desired transforms/expansions.
 
     .. warning::
 

--- a/pennylane/drawer/draw.py
+++ b/pennylane/drawer/draw.py
@@ -622,7 +622,7 @@ def draw_mpl(
         **Levels:**
 
         The ``level`` keyword argument allows one to select a subset of the transforms to apply on the ``QNode``
-        before carrying out any drawing. Take for example this circuit:
+        before carrying out any drawing. Take, for example, this circuit:
 
         .. code-block:: python
 
@@ -655,14 +655,14 @@ def draw_mpl(
         .. code-block:: python
 
             fig, ax = qml.draw_mpl(circ, level="user")()
-            fog.show()
+            fig.show()
 
         .. figure:: ../../_static/draw_mpl/level_user.png
             :align: center
             :width: 60%
             :target: javascript:void(0);
 
-        To apply all of the transforms, including those carried out by the differentitation method and the device, use ``level=None``:
+        To apply all of the transforms, including those carried out by the differentiation method and the device, use ``level=None``:
 
         .. code-block:: python
 

--- a/pennylane/gradients/parameter_shift.py
+++ b/pennylane/gradients/parameter_shift.py
@@ -834,7 +834,7 @@ def param_shift(
         f0 (tensor_like[float] or None): Output of the evaluated input tape. If provided,
             and the gradient recipe contains an unshifted term, this value is used,
             saving a quantum evaluation.
-        broadcast (bool): Whether or not to use parameter broadcasting to create the
+        broadcast (bool): Whether or not to use parameter broadcasting to create
             a single broadcasted tape per operation instead of one tape per shift angle.
 
     Returns:
@@ -905,14 +905,20 @@ def param_shift(
     This transform can be registered directly as the quantum gradient transform
     to use during autodifferentiation:
 
-    >>> dev = qml.device("default.qubit")
-    >>> @qml.qnode(dev, interface="autograd", diff_method="parameter-shift")
-    ... def circuit(params):
-    ...     qml.RX(params[0], wires=0)
-    ...     qml.RY(params[1], wires=0)
-    ...     qml.RX(params[2], wires=0)
-    ...     return qml.expval(qml.Z(0))
-    >>> params = np.array([0.1, 0.2, 0.3], requires_grad=True)
+    .. code-block:: python
+
+        import pennylane as qml
+        from pennylane import numpy as pnp
+
+        dev = qml.device("default.qubit")
+        @qml.qnode(dev, interface="autograd", diff_method="parameter-shift")
+        def circuit(params):
+            qml.RX(params[0], wires=0)
+            qml.RY(params[1], wires=0)
+            qml.RX(params[2], wires=0)
+            return qml.expval(qml.Z(0))
+
+    >>> params = pnp.array([0.1, 0.2, 0.3], requires_grad=True)
     >>> qml.jacobian(circuit)(params)
     array([-0.3875172 , -0.18884787, -0.38355704])
 
@@ -921,14 +927,18 @@ def param_shift(
     tensor outputs, instead of functions that output sequences. In contrast, Jax and Torch require no additional
     post-processing.
 
-    >>> import jax
-    >>> dev = qml.device("default.qubit")
-    >>> @qml.qnode(dev, interface="jax", diff_method="parameter-shift")
-    ... def circuit(params):
-    ...     qml.RX(params[0], wires=0)
-    ...     qml.RY(params[1], wires=0)
-    ...     qml.RX(params[2], wires=0)
-    ...     return qml.expval(qml.Z(0)), qml.var(qml.Z(0))
+    .. code-block:: python
+
+        import jax
+
+        dev = qml.device("default.qubit")
+        @qml.qnode(dev, interface="jax", diff_method="parameter-shift")
+        def circuit(params):
+            qml.RX(params[0], wires=0)
+            qml.RY(params[1], wires=0)
+            qml.RX(params[2], wires=0)
+            return qml.expval(qml.Z(0)), qml.var(qml.Z(0))
+
     >>> params = jax.numpy.array([0.1, 0.2, 0.3])
     >>> jax.jacobian(circuit)(params)
     (Array([-0.3875172 , -0.18884787, -0.38355704], dtype=float64),
@@ -954,12 +964,10 @@ def param_shift(
 
     .. warning::
 
-        Note that using parameter broadcasting via ``broadcast=True`` is not supported for tapes
-        with multiple return values or for evaluations with shot vectors.
-        As the option ``broadcast=True`` adds a broadcasting dimension, it is not compatible
-        with circuits that already are broadcasted.
-        Finally, operations with trainable parameters are required to support broadcasting.
-        One way of checking this is the `Attribute` `supports_broadcasting`:
+        Note that as the option ``broadcast=True`` adds a broadcasting dimension, it is not compatible
+        with circuits that are already broadcasted.
+        In addition, operations with trainable parameters are required to support broadcasting.
+        One way to check this is through the ``supports_broadcasting`` attribute:
 
         >>> qml.RX in qml.ops.qubit.attributes.supports_broadcasting
         True
@@ -971,12 +979,15 @@ def param_shift(
         However, for performance reasons, we recommend providing the gradient transform as the ``diff_method`` argument
         of the QNode decorator, and differentiating with your preferred machine learning framework.
 
-        >>> @qml.qnode(dev)
-        ... def circuit(params):
-        ...     qml.RX(params[0], wires=0)
-        ...     qml.RY(params[1], wires=0)
-        ...     qml.RX(params[2], wires=0)
-        ...     return qml.expval(qml.Z(0)), qml.var(qml.Z(0))
+        .. code-block:: python
+
+            @qml.qnode(dev)
+            def circuit(params):
+                qml.RX(params[0], wires=0)
+                qml.RY(params[1], wires=0)
+                qml.RX(params[2], wires=0)
+                return qml.expval(qml.Z(0)), qml.var(qml.Z(0))
+
         >>> qml.gradients.param_shift(circuit)(params)
         (Array([-0.3875172 , -0.18884787, -0.38355704], dtype=float64),
          Array([0.69916862, 0.34072424, 0.69202359], dtype=float64))
@@ -1028,15 +1039,18 @@ def param_shift(
 
         This gradient transform is compatible with devices that use shot vectors for execution.
 
-        >>> shots = (10, 100, 1000)
-        >>> dev = qml.device("default.qubit", shots=shots)
-        >>> @qml.qnode(dev)
-        ... def circuit(params):
-        ...     qml.RX(params[0], wires=0)
-        ...     qml.RY(params[1], wires=0)
-        ...     qml.RX(params[2], wires=0)
-        ...     return qml.expval(qml.Z(0)), qml.var(qml.Z(0))
-        >>> params = np.array([0.1, 0.2, 0.3], requires_grad=True)
+        .. code-block:: python
+
+            shots = (10, 100, 1000)
+            dev = qml.device("default.qubit", shots=shots)
+            @qml.qnode(dev)
+            def circuit(params):
+                qml.RX(params[0], wires=0)
+                qml.RY(params[1], wires=0)
+                qml.RX(params[2], wires=0)
+                return qml.expval(qml.Z(0)), qml.var(qml.Z(0))
+
+        >>> params = pnp.array([0.1, 0.2, 0.3], requires_grad=True)
         >>> qml.gradients.param_shift(circuit)(params)
         ((array([-0.2, -0.1, -0.4]), array([0.4, 0.2, 0.8])),
          (array([-0.4 , -0.24, -0.43]), array([0.672 , 0.4032, 0.7224])),
@@ -1048,7 +1062,7 @@ def param_shift(
         circuit evaluations for each operation are batched together, resulting in
         broadcasted tapes:
 
-        >>> params = np.array([0.1, 0.2, 0.3], requires_grad=True)
+        >>> params = pnp.array([0.1, 0.2, 0.3], requires_grad=True)
         >>> ops = [qml.RX(params[0], 0), qml.RY(params[1], 0), qml.RX(params[2], 0)]
         >>> measurements = [qml.expval(qml.Z(0))]
         >>> tape = qml.tape.QuantumTape(ops, measurements)
@@ -1067,13 +1081,16 @@ def param_shift(
 
         An advantage of using ``broadcast=True`` is a speedup:
 
-        >>> import timeit
-        >>> @qml.qnode(qml.device("default.qubit"))
-        ... def circuit(params):
-        ...     qml.RX(params[0], wires=0)
-        ...     qml.RY(params[1], wires=0)
-        ...     qml.RX(params[2], wires=0)
-        ...     return qml.expval(qml.Z(0))
+        .. code-block:: python
+
+            import timeit
+            @qml.qnode(qml.device("default.qubit"))
+            def circuit(params):
+                qml.RX(params[0], wires=0)
+                qml.RY(params[1], wires=0)
+                qml.RX(params[2], wires=0)
+                return qml.expval(qml.Z(0))
+
         >>> number = 100
         >>> serial_call = "qml.gradients.param_shift(circuit, broadcast=False)(params)"
         >>> timeit.timeit(serial_call, globals=globals(), number=number) / number
@@ -1087,6 +1104,8 @@ def param_shift(
         of the circuit, at least a small improvement can be expected in most cases.
         Note that ``broadcast=True`` requires additional memory by a factor of the largest
         batch_size of the created tapes.
+
+        Shot vectors and multiple return measurements are supported with ``broadcast=True``.
     """
 
     transform_name = "parameter-shift rule"

--- a/pennylane/gradients/parameter_shift.py
+++ b/pennylane/gradients/parameter_shift.py
@@ -907,7 +907,6 @@ def param_shift(
 
     .. code-block:: python
 
-        import pennylane as qml
         from pennylane import numpy as pnp
 
         dev = qml.device("default.qubit")

--- a/pennylane/noise/conditionals.py
+++ b/pennylane/noise/conditionals.py
@@ -109,6 +109,7 @@ def wires_in(wires):
     >>> cond_func = qml.noise.wires_in([0, 1])
     >>> cond_func(qml.X(0))
     True
+
     >>> cond_func(qml.X(3))
     False
 
@@ -118,6 +119,7 @@ def wires_in(wires):
     >>> cond_func = qml.noise.wires_in(qml.CNOT(["alice", "bob"]))
     >>> cond_func("alice")
     True
+
     >>> cond_func("eve")
     False
     """
@@ -148,6 +150,7 @@ def wires_eq(wires):
     >>> cond_func = qml.noise.wires_eq(0)
     >>> cond_func(qml.X(0))
     True
+
     >>> cond_func(qml.RY(1.23, wires=[3]))
     False
 
@@ -157,6 +160,7 @@ def wires_eq(wires):
     >>> cond_func = qml.noise.wires_eq(qml.RX(1.0, "dino"))
     >>> cond_func(qml.RZ(1.23, wires="dino"))
     True
+
     >>> cond_func("eve")
     False
     """
@@ -350,8 +354,10 @@ def op_in(ops):
     >>> cond_func = qml.noise.op_in(["RX", "RY"])
     >>> cond_func(qml.RX(1.23, wires=[0]))
     True
+
     >>> cond_func(qml.RZ(1.23, wires=[3]))
     False
+
     >>> cond_func([qml.RX(1.23, wires=[1]), qml.RY(4.56, wires=[2])])
     True
 
@@ -361,8 +367,10 @@ def op_in(ops):
     >>> cond_func = qml.noise.op_in([qml.RX(1.0, "dino"), qml.RY(2.0, "rhino")])
     >>> cond_func(qml.RX(1.23, wires=["eve"]))
     True
+
     >>> cond_func(qml.RY(1.23, wires=["dino"]))
     True
+
     >>> cond_func([qml.RX(1.23, wires=[1]), qml.RZ(4.56, wires=[2])])
     False
     """
@@ -391,8 +399,10 @@ def op_eq(ops):
     >>> cond_func = qml.noise.op_eq("RX")
     >>> cond_func(qml.RX(1.23, wires=[0]))
     True
+
     >>> cond_func(qml.RZ(1.23, wires=[3]))
     False
+
     >>> cond_func("CNOT")
     False
 
@@ -402,6 +412,7 @@ def op_eq(ops):
     >>> cond_func = qml.noise.op_eq(qml.RX(1.0, "dino"))
     >>> cond_func(qml.RX(1.23, wires=["eve"]))
     True
+
     >>> cond_func(qml.RY(1.23, wires=["dino"]))
     False
     """

--- a/pennylane/noise/conditionals.py
+++ b/pennylane/noise/conditionals.py
@@ -33,7 +33,7 @@ class WiresIn(BooleanFn):
     """A conditional for evaluating if the wires of an operation exist in a specified set of wires.
 
     Args:
-        wires (Union[Iterable[int, str], Wires]): sequence of wires for building the wire set.
+        wires (Union[Iterable[int, str], Wires]): Sequence of wires for building the wire set.
 
     .. seealso:: Users are advised to use :func:`~.wires_in` for a functional construction.
     """
@@ -50,7 +50,7 @@ class WiresEq(BooleanFn):
     """A conditional for evaluating if a given wire is equal to a specified set of wires.
 
     Args:
-        wires (Union[Iterable[int, str], Wires]): sequence of wires for building the wire set.
+        wires (Union[Iterable[int, str], Wires]): Sequence of wires for building the wire set.
 
     .. seealso:: Users are advised to use :func:`~.wires_eq` for a functional construction.
     """
@@ -90,17 +90,17 @@ def wires_in(wires):
     if the wires of an input operation are within the specified set of wires.
 
     Args:
-        wires (Union(Iterable[int, str], Wires, Operation, int, str)): object to be used
+        wires (Union(Iterable[int, str], Wires, Operation, int, str)): Object to be used
             for building the wire set.
 
     Returns:
-        :class:`WiresIn <pennylane.noise.conditionals.WiresIn>`: a callable object with
+        :class:`WiresIn <pennylane.noise.conditionals.WiresIn>`: A callable object with
         signature ``Union(Iterable[int, str], Wires, Operation, int, str)``. It evaluates
         to ``True`` if the wire set constructed from the input to the callable is a
         subset of the one built from the specified ``wires`` set.
 
     Raises:
-        ValueError: if the wire set cannot be computed from ``wires``.
+        ValueError: If the wire set cannot be computed from ``wires``.
 
     **Example**
 
@@ -129,17 +129,17 @@ def wires_eq(wires):
     if a given wire is equal to specified set of wires.
 
     Args:
-        wires (Union(Iterable[int, str], Wires, Operation, int, str)): object to be used
+        wires (Union(Iterable[int, str], Wires, Operation, int, str)): Object to be used
             for building the wire set.
 
     Returns:
-        :class:`WiresEq <pennylane.noise.conditionals.WiresEq>`: a callable object with
+        :class:`WiresEq <pennylane.noise.conditionals.WiresEq>`: A callable object with
         signature ``Union(Iterable[int, str], Wires, Operation, int, str)``. It evaluates
         to ``True`` if the wire set constructed from the input to the callable is equal
         to the one built from the specified ``wires`` set.
 
     Raises:
-        ValueError: if the wire set cannot be computed from ``wires``.
+        ValueError: If the wire set cannot be computed from ``wires``.
 
     **Example**
 
@@ -167,7 +167,7 @@ class OpIn(BooleanFn):
     """A conditional for evaluating if a given operation exist in a specified set of operations.
 
     Args:
-        ops (Union[str, class, Operation, list[str, class, Operation]]): sequence of operation
+        ops (Union[str, class, Operation, list[str, class, Operation]]): Sequence of operation
             instances, string representations or classes to build the operation set.
 
     .. seealso:: Users are advised to use :func:`~.op_in` for a functional construction.
@@ -333,15 +333,15 @@ def op_in(ops):
     if a given operation exist in a specified set of operations.
 
     Args:
-        ops (str, class, Operation, list(Union[str, class, Operation])): sequence of string
-            representations, instances or classes of the operation(s).
+        ops (str, class, Operation, list(Union[str, class, Operation])): Sequence of string
+            representations, instances, or classes of the operation(s).
 
     Returns:
         :class:`OpIn <pennylane.noise.conditionals.OpIn>`: A callable object that accepts
-        an :class:`~.Operation` and gives a boolean output. It accepts any input from:
-        ``Union(str, class, Operation, list(Union[str, class, Operation]))`` and evaluates
-        to ``True``, if input operation(s) exist in the set of operation(s) specified by
-        ``ops``, based on a comparison of the operation type, irrespective of wires.
+        an :class:`~.Operation` and returns a boolean output. It accepts any input from:
+        ``Union[str, class, Operation, list(Union[str, class, Operation])]`` and evaluates
+        to ``True`` if the input operation(s) exists in the set of operation(s) specified by
+        ``ops``. Comparison is based on the operation's type, irrespective of wires.
 
     **Example**
 
@@ -375,14 +375,14 @@ def op_eq(ops):
     if a given operation is equal to the specified operation.
 
     Args:
-        ops (str, class, Operation): string representation, an instance or class of the operation.
+        ops (str, class, Operation): String representation, an instance or class of the operation.
 
     Returns:
         :class:`OpEq <pennylane.noise.conditionals.OpEq>`: A callable object that accepts
-        an :class:`~.Operation` and gives a boolean output. It accepts any input from:
-        ``Union(str, class, Operation)`` and evaluates to ``True``, if input operation(s)
-        is equal to the set of operation(s) specified by ``ops``, based on a comparison of
-        the operation type, irrespective of wires.
+        an :class:`~.Operation` and returns a boolean output. It accepts any input from:
+        ``Union[str, class, Operation]`` and evaluates to ``True`` if the input operation(s)
+        is equal to the set of operation(s) specified by ``ops``. Comparison is based on
+        the operation's type, irrespective of wires.
 
     **Example**
 
@@ -423,19 +423,19 @@ def partial_wires(operation, *args, **kwargs):
     all argument frozen except ``wires``.
 
     Args:
-        operation (Operation, class): instance of an operation or the class
+        operation (Operation, class): Instance of an operation or the class
             corresponding to the operation.
-        *args: positional arguments provided in the case where the keyword argument
+        *args: Positional arguments provided in the case where the keyword argument
             ``operation`` is a class for building the partially evaluated instance.
-        **kwargs: keyword arguments for the building the partially evaluated instance.
+        **kwargs: Keyword arguments for the building the partially evaluated instance.
             These will override any arguments present in the operation instance or ``args``.
 
     Returns:
-        callable: a wrapper function that accepts a sequence of wires as an argument or
+        callable: A wrapper function that accepts a sequence of wires as an argument or
         any object with a ``wires`` property.
 
     Raises:
-        ValueError: if ``args`` are provided when the given ``operation`` is an instance.
+        ValueError: If ``args`` are provided when the given ``operation`` is an instance.
 
     **Example**
 

--- a/pennylane/noise/noise_model.py
+++ b/pennylane/noise/noise_model.py
@@ -36,8 +36,8 @@ class NoiseModel:
 
         - The ``conditional`` should be either a function decorated with :class:`~.BooleanFn`,
           a callable object built via :ref:`constructor functions <intro_boolean_fn>` in
-          the ``qml.noise`` module, or their bit-wise combination.
-        - The definition of ``noise_fn(op, **kwargs)`` should have the operations in same the order
+          the ``qml.noise`` module, or their bitwise combination.
+        - The definition of ``noise_fn(op, **kwargs)`` should have the operations in the same the order
           in which they are to be queued for an operation ``op``, whenever the corresponding
           ``conditional`` evaluates to ``True``.
 
@@ -73,12 +73,12 @@ class NoiseModel:
 
     @property
     def model_map(self):
-        """Gives the conditional model for the noise model"""
+        """Gives the conditional model for the noise model."""
         return self._model_map
 
     @property
     def metadata(self):
-        """Gives the metadata for the noise model"""
+        """Gives the metadata for the noise model."""
         return self._metadata
 
     def __add__(self, data):

--- a/pennylane/ops/op_math/pow.py
+++ b/pennylane/ops/op_math/pow.py
@@ -348,6 +348,26 @@ class Pow(ScalarSymbolicOp):
         return isinstance(self.z, int)
 
     def adjoint(self):
+        """Create an operation that is the adjoint of this one.
+
+        Adjointed operations are the conjugated and transposed version of the
+        original operation. Adjointed ops are equivalent to the inverted operation for unitary
+        gates.
+
+        .. warning::
+
+            The adjoint of a fractional power of an operator is not well defined due to branch cuts in the power function.
+            Therefore, an ``AdjointUndefinedError`` is raised when the power ``z`` is not an integer.
+
+            The integer power check is a type check, so that floats like ``2.0`` are not considered to be integers.
+
+        Returns:
+            The adjointed operation.
+
+        Raises:
+            AdjointUndefinedError: If the exponent ``z`` is not of type ``int``.
+
+        """
         if isinstance(self.z, int):
             return Pow(base=qml.adjoint(self.base), z=self.z)
         raise AdjointUndefinedError(

--- a/pennylane/ops/op_math/pow.py
+++ b/pennylane/ops/op_math/pow.py
@@ -356,7 +356,7 @@ class Pow(ScalarSymbolicOp):
 
         .. warning::
 
-            The adjoint of a fractional power of an operator is not well defined due to branch cuts in the power function.
+            The adjoint of a fractional power of an operator is not well-defined due to branch cuts in the power function.
             Therefore, an ``AdjointUndefinedError`` is raised when the power ``z`` is not an integer.
 
             The integer power check is a type check, so that floats like ``2.0`` are not considered to be integers.

--- a/pennylane/qaoa/layers.py
+++ b/pennylane/qaoa/layers.py
@@ -96,9 +96,11 @@ def cost_layer(gamma, hamiltonian):
         1: ──H───────────╰RZZ(1.00)─┤  <Z>
 
     """
+    # NOTE: op is defined explicitely as validation inside ApproxTimeEvolution needs to be called before checking Hamiltonian
+    op = qml.templates.ApproxTimeEvolution(hamiltonian, gamma, 1)
     if not _diagonal_terms(hamiltonian):
         raise ValueError("hamiltonian must be written only in terms of PauliZ and Identity gates")
-    return qml.templates.ApproxTimeEvolution(hamiltonian, gamma, 1)
+    return op
 
 
 def mixer_layer(alpha, hamiltonian):

--- a/pennylane/qaoa/layers.py
+++ b/pennylane/qaoa/layers.py
@@ -96,10 +96,9 @@ def cost_layer(gamma, hamiltonian):
         1: ──H───────────╰RZZ(1.00)─┤  <Z>
 
     """
-    op = qml.templates.ApproxTimeEvolution(hamiltonian, gamma, 1)
     if not _diagonal_terms(hamiltonian):
         raise ValueError("hamiltonian must be written only in terms of PauliZ and Identity gates")
-    return op
+    return qml.templates.ApproxTimeEvolution(hamiltonian, gamma, 1)
 
 
 def mixer_layer(alpha, hamiltonian):

--- a/pennylane/qchem/convert_openfermion.py
+++ b/pennylane/qchem/convert_openfermion.py
@@ -53,15 +53,15 @@ def from_openfermion(openfermion_op, wires=None, tol=1e-16):
     to PennyLane :class:`~.LinearCombination`.
 
     Args:
-        openfermion_op (FermionOperator, QubitOperator): OpenFermion operator
+        openfermion_op (FermionOperator, QubitOperator): OpenFermion operator.
         wires (dict): Custom wire mapping used to convert the external qubit
             operator to a PennyLane operator.
             Only dictionaries with integer keys (for qubit-to-wire conversion) are accepted.
             If ``None``, the identity map (e.g., ``0->0, 1->1, ...``) will be used.
-        tol (float): tolerance for discarding negligible coefficients
+        tol (float): Tolerance for discarding negligible coefficients.
 
     Returns:
-        Union[FermiWord, FermiSentence, LinearCombination]: PennyLane operator
+        Union[FermiWord, FermiSentence, LinearCombination]: PennyLane operator.
 
     **Example**
 

--- a/pennylane/queuing.py
+++ b/pennylane/queuing.py
@@ -569,7 +569,7 @@ def process_queue(
         The list of tape operations, the list of tape measurements
 
     Raises:
-        QueuingError: if the queue contains objects that cannot be processed into a QuantumScript
+        QueuingError: If the queue contains objects that cannot be processed into a QuantumScript
 
     """
     lists = {"_ops": [], "_measurements": []}

--- a/pennylane/resource/specs.py
+++ b/pennylane/resource/specs.py
@@ -145,21 +145,39 @@ def specs(qnode, **kwargs):
         First, we can check the resource information of the ``QNode`` without any modifications. Note that ``level=top`` would
         return the same results:
 
-        >>> qml.specs(circuit, level=0)(0.1)["resources"]
-        Resources(num_wires=2, num_gates=6, gate_types=defaultdict(<class 'int'>, {'RandomLayers': 1, 'RX': 2, 'SWAP': 1, 'PauliX': 2}),
-        gate_sizes=defaultdict(<class 'int'>, {2: 2, 1: 4}), depth=6, shots=Shots(total_shots=None, shot_vector=()))
+        >>> print(qml.specs(circuit, level=0)(0.1)["resources"])
+        wires: 2
+        gates: 6
+        depth: 6
+        shots: Shots(total=None)
+        gate_types:
+        {'RandomLayers': 1, 'RX': 2, 'SWAP': 1, 'PauliX': 2}
+        gate_sizes:
+        {2: 2, 1: 4}
 
         We then check the resources after applying all transforms:
 
-        >>> qml.specs(circuit, level=None)(0.1)["resources"]
-        Resources(num_wires=2, num_gates=2, gate_types=defaultdict(<class 'int'>, {'RY': 1, 'RX': 1}),
-        gate_sizes=defaultdict(<class 'int'>, {1: 2}), depth=1, shots=Shots(total_shots=None, shot_vector=()))
+        >>> print(qml.specs(circuit, level=None)(0.1)["resources"])
+        wires: 2
+        gates: 2
+        depth: 1
+        shots: Shots(total=None)
+        gate_types:
+        {'RY': 1, 'RX': 1}
+        gate_sizes:
+        {1: 2}
 
         We can also notice that ``SWAP`` and ``PauliX`` are not present in the circuit if we set ``level=2``:
 
-        >>> qml.specs(circuit, level=2)(0.1)["resources"]
-        Resources(num_wires=2, num_gates=3, gate_types=defaultdict(<class 'int'>, {'RandomLayers': 1, 'RX': 2}),
-        gate_sizes=defaultdict(<class 'int'>, {2: 1, 1: 2}), depth=3, shots=Shots(total_shots=None, shot_vector=()))
+        >>> print(qml.specs(circuit, level=2)(0.1)["resources"])
+        wires: 2
+        gates: 3
+        depth: 3
+        shots: Shots(total=None)
+        gate_types:
+        {'RandomLayers': 1, 'RX': 2}
+        gate_sizes:
+        {2: 1, 1: 2}
 
         If we attempt to only apply the ``merge_rotations`` transform, we would end with only one trainable object, which is in ``RandomLayers``:
 

--- a/pennylane/resource/specs.py
+++ b/pennylane/resource/specs.py
@@ -50,7 +50,7 @@ def specs(qnode, **kwargs):
     about the circuit after applying the specified amount of transforms/expansions first.
 
     Args:
-        qnode (.QNode): the QNode to calculate the specifications for
+        qnode (.QNode): the QNode to calculate the specifications for.
 
     Keyword Args:
         level (None, str, int, slice): An indication of what transforms to apply before computing the resource information.
@@ -77,9 +77,9 @@ def specs(qnode, **kwargs):
     .. note::
 
         At most, one of ``level`` or ``expansion_strategy`` needs to be provided. If neither is provided,
-        ``qnode.expansion_strategy`` would be used instead. Users are encouraged to predominantly use ``level``,
-        as it allows for the same values as ``expansion_strategy``, and allows for more flexibility choosing
-        the wanted transforms/expansions.
+        ``qnode.expansion_strategy`` will be used instead. Users are encouraged to predominantly use ``level``,
+        as it allows for the same values as ``expansion_strategy`` and offers more flexibility in choosing
+        the desired transforms/expansions.
 
     .. warning::
 
@@ -91,11 +91,13 @@ def specs(qnode, **kwargs):
 
     .. code-block:: python3
 
-        x = np.array([0.1, 0.2])
+        from pennylane import numpy as pnp
+
+        x = pnp.array([0.1, 0.2])
         hamiltonian = qml.dot([1.0, 0.5], [qml.X(0), qml.Y(0)])
 
         dev = qml.device('default.qubit', wires=2)
-        @qml.qnode(dev, diff_method="parameter-shift", shifts=np.pi / 4)
+        @qml.qnode(dev, diff_method="parameter-shift", shifts=pnp.pi / 4)
         def circuit(x, add_ry=True):
             qml.RX(x[0], wires=0)
             qml.CNOT(wires=(0,1))
@@ -106,15 +108,15 @@ def specs(qnode, **kwargs):
             return qml.probs(wires=(0,1))
 
     >>> qml.specs(circuit)(x, add_ry=False)
-    {'resources': Resources(num_wires=2, num_gates=4, gate_types=defaultdict(<class 'int'>, {'RX': 1, 'CNOT': 1, 'TrotterPro
-    duct': 2}}), gate_sizes=defaultdict(<class 'int'>, {1: 3, 2: 1}), depth=4, shots=Shots(total_shots=None, shot_vector=())),
+    {'resources': Resources(num_wires=2, num_gates=98, gate_types=defaultdict(<class 'int'>, {'RX': 1, 'CNOT': 1, 'Exp': 96}), gate_sizes=defaultdict(<class 'int'>, {1: 97, 2: 1}), depth=98, shots=Shots(total_shots=None, shot_vector=())),
     'errors': {'SpectralNormError': SpectralNormError(0.42998560822421455)},
     'num_observables': 1,
     'num_diagonalizing_gates': 0,
     'num_trainable_params': 1,
     'num_device_wires': 2,
+    'num_tape_wires': 2,
     'device_name': 'default.qubit',
-    'expansion_strategy': 'gradient',
+    'level': 'gradient',
     'gradient_options': {'shifts': 0.7853981633974483},
     'interface': 'auto',
     'diff_method': 'parameter-shift',
@@ -179,18 +181,18 @@ def specs(qnode, **kwargs):
         gate_sizes:
         {2: 1, 1: 2}
 
-        If we attempt to only apply the ``merge_rotations`` transform, we would end with only one trainable object, which is in ``RandomLayers``:
+        If we attempt to apply only the ``merge_rotations`` transform, we end up with only one trainable object, which is in ``RandomLayers``:
 
         >>> qml.specs(circuit, level=slice(2, 3))(0.1)["num_trainable_params"]
         1
 
-        However, if we apply all transforms, ``RandomLayers`` would be decomposed to an ``RY`` and an ``RX``, giving us two trainable objects:
+        However, if we apply all transforms, ``RandomLayers`` is decomposed into an ``RY`` and an ``RX``, giving us two trainable objects:
 
         >>> qml.specs(circuit, level=None)(0.1)["num_trainable_params"]
         2
 
         If a ``QNode`` with a tape-splitting transform is supplied to the function, with the transform included in the desired transforms, a dictionary
-        would be returned for each resulting tapes:
+        is returned for each resulting tape:
 
         .. code-block:: python3
 

--- a/pennylane/transforms/add_noise.py
+++ b/pennylane/transforms/add_noise.py
@@ -90,6 +90,7 @@ def add_noise(tape, noise_model, level=None):
 
     >>> circuit(0.9, 0.4, 0.5, 0.6)
     array(0.60722291)
+
     >>> print(qml.draw(circuit, max_length=150)(0.9, 0.4, 0.5, 0.6))
     0: ──RX(0.90)──PhaseDamping(0.40)──────────────────────────╭●──RY(0.50)──ThermalRelaxationError(0.25,2.00,0.20,0.60)─┤ ╭<Z@Z>
     1: ──RY(0.40)──ThermalRelaxationError(0.20,2.00,0.20,0.60)─╰X──RX(0.60)──PhaseDamping(0.40)──────────────────────────┤ ╰<Z@Z>
@@ -123,6 +124,7 @@ def add_noise(tape, noise_model, level=None):
 
         >>> qml.workflow.get_transform_program(circuit)
         TransformProgram(cancel_inverses, merge_rotations, undo_swaps, _expand_metric_tensor, batch_transform, expand_fn, metric_tensor)
+
         >>> qml.workflow.get_transform_program(noisy_circuit)
         TransformProgram(cancel_inverses, merge_rotations, undo_swaps, _expand_metric_tensor, add_noise, batch_transform, expand_fn, metric_tensor)
 
@@ -139,8 +141,10 @@ def add_noise(tape, noise_model, level=None):
 
         >>> qml.transforms.add_noise(circuit, noise_model, level="top").transform_program
         TransformProgram(add_noise)
+
         >>> qml.transforms.add_noise(circuit, noise_model, level="user").transform_program
         TransformProgram(cancel_inverses, merge_rotations, undo_swaps, _expand_metric_tensor, add_noise, metric_tensor)
+
         >>> qml.transforms.add_noise(circuit, noise_model, level="device").transform_program
         TransformProgram(cancel_inverses, merge_rotations, undo_swaps, _expand_metric_tensor, batch_transform, expand_fn, add_noise, metric_tensor)
 
@@ -148,6 +152,7 @@ def add_noise(tape, noise_model, level=None):
 
         >>> qml.transforms.add_noise(circuit, noise_model, level=2).transform_program
         TransformProgram(cancel_inverses, merge_rotations, add_noise)
+
         >>> qml.transforms.add_noise(circuit, noise_model, level=slice(1,3)).transform_program
         TransformProgram(merge_rotations, undo_swaps, add_noise)
 

--- a/pennylane/transforms/add_noise.py
+++ b/pennylane/transforms/add_noise.py
@@ -22,25 +22,25 @@ from pennylane.transforms.core import TransformContainer, transform
 def add_noise(tape, noise_model, level=None):
     """Insert operations according to a provided noise model.
 
-    Circuits passed through this transform will be updated to apply the
+    Circuits passed through this quantum transform will be updated to apply the
     insertion-based :class:`~.NoiseModel`, which contains a mapping
     ``{BooleanFn: Callable}`` from conditions to the corresponding noise
-    gates. Each condition of the noise model will be evaluated on the
+    gates. Each condition in the noise model will be evaluated on the
     operations contained within the given circuit. For conditions that
     evaluate to ``True``, the noisy gates contained within the ``Callable``
     will be inserted after the operation under consideration.
 
     Args:
         tape (QNode or QuantumTape or Callable or pennylane.devices.Device): the input circuit or
-            device to be transformed
-        noise_model (~pennylane.NoiseModel): noise model according to which noise has to be inserted
+            device to be transformed.
+        noise_model (~pennylane.NoiseModel): noise model according to which noise has to be inserted.
         level (None, str, int, slice): An indication of which stage in the transform program the
             noise model should be applied to. Only relevant when transforming a ``QNode``. More details
             on the following permissible values can be found in the :func:`~.workflow.get_transform_program` -
 
             * ``None``: expands the tape to have no ``Adjoint`` and ``Templates``.
-            * ``str``: acceptable keys are ``"top"``, ``"user"``, ``"device"``, and ``"gradient"``
-            * ``int``: how many transforms to include, starting from the front of the program
+            * ``str``: acceptable keys are ``"top"``, ``"user"``, ``"device"``, and ``"gradient"``.
+            * ``int``: how many transforms to include, starting from the front of the program.
             * ``slice``: a slice to select out components of the transform program.
 
     Returns:
@@ -89,10 +89,10 @@ def add_noise(tape, noise_model, level=None):
     Executions of this circuit will differ from the noise-free value:
 
     >>> circuit(0.9, 0.4, 0.5, 0.6)
-    tensor(0.60722291, requires_grad=True)
-    >>> print(qml.draw(f)(0.9, 0.4, 0.5, 0.6))
-    0: ──RX(0.9)──PhaseDamping(0.4)───────────────────────╭●──RY(0.5)───ThermalRelaxationError(0.2,2.0,0.2,0.6)─┤ ╭<Z@Z>
-    1: ──RY(0.4)──ThermalRelaxationError(0.2,2.0,0.2,0.6)─╰X──RX(0.6)───PhaseDamping(0.4)───────────────────────┤ ╰<Z@Z>
+    array(0.60722291)
+    >>> print(qml.draw(circuit, max_length=150)(0.9, 0.4, 0.5, 0.6))
+    0: ──RX(0.90)──PhaseDamping(0.40)──────────────────────────╭●──RY(0.50)──ThermalRelaxationError(0.25,2.00,0.20,0.60)─┤ ╭<Z@Z>
+    1: ──RY(0.40)──ThermalRelaxationError(0.20,2.00,0.20,0.60)─╰X──RX(0.60)──PhaseDamping(0.40)──────────────────────────┤ ╰<Z@Z>
 
     .. details::
         :title: Tranform Levels
@@ -100,7 +100,7 @@ def add_noise(tape, noise_model, level=None):
 
         When transforming an already constructed ``QNode``, the ``add_noise`` transform will be
         added at the end of the "user" transforms by default, i.e., after all the transforms
-        that have been manually applied to the QNode until that point.
+        that have been manually applied to the QNode up to that point.
 
         .. code-block:: python3
 
@@ -126,17 +126,16 @@ def add_noise(tape, noise_model, level=None):
         >>> qml.workflow.get_transform_program(noisy_circuit)
         TransformProgram(cancel_inverses, merge_rotations, undo_swaps, _expand_metric_tensor, add_noise, batch_transform, expand_fn, metric_tensor)
 
-        However, one can request inserting it at any specific point of the transform program. Specifying the ``level`` keyword argument while
-        transforming a ``QNode``, will allow addition of the transform at the end of the transform program extracted at a designated level via
-        :func:`get_transform_program <pennylane.workflow.get_transform_program>`. For example, one could specify ``None`` to add it at the end,
-        which will also ensure that the tape is expanded to have no ``Adjoint`` and ``Templates``:
+        However, one can request to insert the ``add_noise`` transform at any specific point in the transform program. By specifying the ``level`` keyword argument while
+        transforming a ``QNode``, this transform can be added at a designated level within the transform program, as determined using the
+        :func:`get_transform_program <pennylane.workflow.get_transform_program>`. For example, specifying ``None`` will add it at the end, ensuring that the tape is expanded to have no ``Adjoint`` and ``Templates``:
 
         >>> qml.transforms.add_noise(circuit, noise_model, level=None).transform_program
         TransformProgram(cancel_inverses, merge_rotations, undo_swaps, _expand_metric_tensor, batch_transform, expand_fn, add_noise, metric_tensor)
 
-        Other, acceptable values for the level are ``"top"``, ``"user"``, ``"device"``, and ``"gradient"``. Among these, `"top"` will allow addition
-        to an empty transform program, `"user"` will allow addition at the end of user specified transforms, `"device"` will allow addition at the
-        end of device-specific transforms, and `"gradient"` will allow addition at the end of transform that expands trainable operations. For example:
+        Other acceptable values for ``level`` are ``"top"``, ``"user"``, ``"device"``, and ``"gradient"``. Among these, `"top"` will allow addition
+        to an empty transform program, `"user"` will allow addition at the end of user-specified transforms, `"device"` will allow addition at the
+        end of device-specific transforms, and `"gradient"` will allow addition at the end of transforms that expand trainable operations. For example:
 
         >>> qml.transforms.add_noise(circuit, noise_model, level="top").transform_program
         TransformProgram(add_noise)
@@ -145,8 +144,7 @@ def add_noise(tape, noise_model, level=None):
         >>> qml.transforms.add_noise(circuit, noise_model, level="device").transform_program
         TransformProgram(cancel_inverses, merge_rotations, undo_swaps, _expand_metric_tensor, batch_transform, expand_fn, add_noise, metric_tensor)
 
-        Finally, more precise control over the insertion of the transform can be achieved by specifying
-        an integer or slice for indexing for extracting the transform program. For example, one can do:
+        Finally, more precise control over the insertion of the transform can be achieved by specifying an integer or slice for indexing when extracting the transform program. For example, one can do:
 
         >>> qml.transforms.add_noise(circuit, noise_model, level=2).transform_program
         TransformProgram(cancel_inverses, merge_rotations, add_noise)

--- a/pennylane/transforms/dynamic_one_shot.py
+++ b/pennylane/transforms/dynamic_one_shot.py
@@ -60,7 +60,7 @@ def dynamic_one_shot(
     """Transform a QNode to into several one-shot tapes to support dynamic circuit execution.
 
     Args:
-        tape (QNode or QuantumTape or Callable): a quantum circuit to add a batch dimension to
+        tape (QNode or QuantumTape or Callable): a quantum circuit to add a batch dimension to.
 
     Returns:
         qnode (QNode) or quantum function (Callable) or tuple[List[QuantumTape], function]:
@@ -237,12 +237,12 @@ def parse_native_mid_circuit_measurements(
     """Combines, gathers and normalizes the results of native mid-circuit measurement runs.
 
     Args:
-        circuit (QuantumTape): The original ``QuantumScript``
-        aux_tapes (List[QuantumTape]): List of auxiliary ``QuantumScript`` objects
-        results (TensorLike): Array of measurement results
+        circuit (QuantumTape): The original ``QuantumScript``.
+        aux_tapes (List[QuantumTape]): List of auxiliary ``QuantumScript`` objects.
+        results (TensorLike): Array of measurement results.
 
     Returns:
-        tuple(TensorLike): The results of the simulation
+        tuple(TensorLike): The results of the simulation.
     """
 
     def measurement_with_no_shots(measurement):

--- a/pennylane/workflow/construct_batch.py
+++ b/pennylane/workflow/construct_batch.py
@@ -223,13 +223,13 @@ def construct_batch(
         qnode (QNode): the qnode we want to get the tapes and post-processing for.
         level (None, str, int, slice): And indication of what transforms to use from the full program.
 
-            * ``None``: use the full transform program
-            * ``str``: Acceptable keys are ``"top"``, ``"user"``, ``"device"``, and ``"gradient"``
-            * ``int``: How many transforms to include, starting from the front of the program
+            * ``None``: use the full transform program.
+            * ``str``: Acceptable keys are ``"top"``, ``"user"``, ``"device"``, and ``"gradient"``.
+            * ``int``: How many transforms to include, starting from the front of the program.
             * ``slice``: a slice to select out components of the transform program.
 
     Returns:
-        Callable:  a function with the same call signature as the initial quantum function. This function returns
+        Callable:  A function with the same call signature as the initial quantum function. This function returns
         a batch (tuple) of tapes and postprocessing function.
 
     .. seealso:: :func:`pennylane.workflow.get_transform_program` to inspect the contents of the transform program for a specified level.
@@ -241,6 +241,8 @@ def construct_batch(
         Suppose we have a QNode with several user transforms.
 
         .. code-block:: python
+
+            from pennylane.workflow import construct_batch
 
             @qml.transforms.undo_swaps
             @qml.transforms.merge_rotations
@@ -263,8 +265,8 @@ def construct_batch(
          RX(tensor(2., requires_grad=True), wires=[0]),
          expval(X(0) + Y(0))]
 
-        These tapes can be natively executed by the device, though with non-backprop devices the parameters
-        will need to be converted to numpy with :func:`~.convert_to_numpy_parameters`.
+        These tapes can be natively executed by the device. However, with non-backprop devices the parameters
+        will need to be converted to NumPy with :func:`~.convert_to_numpy_parameters`.
 
         >>> fn(dev.execute(batch))
         (tensor(-0.90929743, requires_grad=True),)


### PR DESCRIPTION
**Context:** 

Quality assurance work over several PR's for 0.37 release. 

Changes include:
- Change docstring capitalization and punctuation.
- Add missing imports to examples from docstrings
- Correct results from docstrings examples
- Improve formulation of convoluted sentences.

