### PR TITLE
Fix `split_non_commuting` with non-trainable coefficients

### DIFF
--- a/doc/releases/changelog-0.37.0.md
+++ b/doc/releases/changelog-0.37.0.md
@@ -350,6 +350,7 @@
   [(#5838)](https://github.com/PennyLaneAI/pennylane/pull/5838)
   [(#5828)](https://github.com/PennyLaneAI/pennylane/pull/5828)
   [(#5869)](https://github.com/PennyLaneAI/pennylane/pull/5869)
+  [(#5938)](https://github.com/PennyLaneAI/pennylane/pull/5938)
 
 * `qml.devices.LegacyDevice` is now an alias for `qml.Device`, so it is easier to distinguish it from
   `qml.devices.Device`, which follows the new device API.

--- a/pennylane/workflow/interfaces/autograd.py
+++ b/pennylane/workflow/interfaces/autograd.py
@@ -97,6 +97,21 @@ logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
 
+# pylint: disable=no-member
+def _to_autograd(result: qml.typing.ResultBatch) -> qml.typing.ResultBatch:
+    """Converts an arbitrary result batch to one with jax arrays.
+    Args:
+        result (ResultBatch): a nested structure of lists, tuples, dicts, and numpy arrays
+    Returns:
+        ResultBatch: a nested structure of tuples, dicts, and jax arrays
+    """
+    if isinstance(result, dict):
+        return result
+    if isinstance(result, (list, tuple, autograd.builtins.tuple, autograd.builtins.list)):
+        return tuple(_to_autograd(r) for r in result)
+    return qml.numpy.array(result)
+
+
 # pylint: disable=unused-argument
 def autograd_execute(
     tapes: Batch,
@@ -165,7 +180,7 @@ def _execute(
             for the input tapes.
 
     """
-    return execute_fn(tapes)
+    return _to_autograd(execute_fn(tapes))
 
 
 # pylint: disable=unused-argument


### PR DESCRIPTION
Honestly, I don't really understand what the root issue is, and I don't really understand why this fixes it.

But it does 🤷 

All the other interfaces were doing the conversion back to the ML framework, but autograd wasn't.

Fixes #5924 [sc-67508]