### PR TITLE
Fixes `split_non_commuting` with non-trainable autograd coefficients

### DIFF
--- a/doc/releases/changelog-0.37.0.md
+++ b/doc/releases/changelog-0.37.0.md
@@ -351,6 +351,7 @@
   [(#5828)](https://github.com/PennyLaneAI/pennylane/pull/5828)
   [(#5869)](https://github.com/PennyLaneAI/pennylane/pull/5869)
   [(#5939)](https://github.com/PennyLaneAI/pennylane/pull/5939)
+  [(#5945)](https://github.com/PennyLaneAI/pennylane/pull/5945)
 
 * `qml.devices.LegacyDevice` is now an alias for `qml.Device`, so it is easier to distinguish it from
   `qml.devices.Device`, which follows the new device API.

--- a/pennylane/transforms/split_non_commuting.py
+++ b/pennylane/transforms/split_non_commuting.py
@@ -701,6 +701,8 @@ def _sum_terms(res: ResultBatch, coeffs: List[float], offset: float, shape: Tupl
     # The shape of res at this point is (n_terms, [,n_shots] [,batch_size])
     dot_products = []
     for c, r in zip(coeffs, res):
+        if qml.math.get_interface(r) == "autograd":
+            r = qml.math.array(r)
         dot_products.append(qml.math.dot(qml.math.squeeze(r), c))
     if len(dot_products) == 0:
         return qml.math.ones(shape) * offset

--- a/tests/transforms/test_split_non_commuting.py
+++ b/tests/transforms/test_split_non_commuting.py
@@ -1027,6 +1027,27 @@ class TestDifferentiability:
 
         assert qml.math.allclose(actual, [-0.5, np.cos(np.pi / 4)], rtol=0.05)
 
+    @pytest.mark.autograd
+    @pytest.mark.parametrize("grouping_strategy", [None, "default", "qwc", "wires"])
+    def test_non_trainable_obs_autograd(self, grouping_strategy):
+        """Test that we can measure a hamiltonian with non-trainable autograd coefficients."""
+
+        dev = qml.device("default.qubit")
+
+        @partial(split_non_commuting, grouping_strategy=grouping_strategy)
+        @qml.qnode(dev, diff_method="adjoint")
+        def circuit(x):
+            qml.RX(x, 0)
+            c1 = qml.numpy.array(0.1, requires_grad=False)
+            c2 = qml.numpy.array(0.2, requires_grad=False)
+            H = c1 * qml.Z(0) + c2 * qml.X(0)
+            return qml.expval(H)
+
+        x = qml.numpy.array(0.5)
+        actual = qml.grad(circuit)(x)
+
+        assert qml.math.allclose(actual, -0.1 * np.sin(x))
+
     @pytest.mark.jax
     @pytest.mark.parametrize("use_jit", [False, True])
     @pytest.mark.parametrize("grouping_strategy", [None, "default", "qwc", "wires"])


### PR DESCRIPTION
Honestly, I don't really understand what the root issue is, and I don't really understand why this fixes it.

But it does 🤷

Fixes https://github.com/PennyLaneAI/pennylane/issues/5924
[sc-67508]