### PR TITLE
Fix `test_return_system`

### DIFF
--- a/doc/releases/changelog-0.37.0.md
+++ b/doc/releases/changelog-0.37.0.md
@@ -443,6 +443,9 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Skip `Projector`-measurement tests on devices that do not support it.
+  [(#5951)](https://github.com/PennyLaneAI/pennylane/pull/5951)
+
 * Fixes a bug where `hadamard_grad` returned a wrong shape for `qml.probs()` without wires.
   [(#5860)](https://github.com/PennyLaneAI/pennylane/pull/5860)
 

--- a/pennylane/devices/tests/test_return_system.py
+++ b/pennylane/devices/tests/test_return_system.py
@@ -39,6 +39,9 @@ class TestIntegrationMultipleReturns:
         n_wires = 2
         dev = device(n_wires)
 
+        if hasattr(dev, "observables") and "Projector" not in dev.observables:
+            pytest.skip("Skipped because device does not support the Projector observable.")
+
         obs1 = qml.Projector([0], wires=0)
         obs2 = qml.Z(1)
         func = qubit_ansatz

--- a/pennylane/devices/tests/test_return_system.py
+++ b/pennylane/devices/tests/test_return_system.py
@@ -59,8 +59,12 @@ class TestIntegrationMultipleReturns:
 
     def test_multiple_var(self, device):
         """Return multiple vars."""
+
         n_wires = 2
         dev = device(n_wires)
+
+        if hasattr(dev, "observables") and "Projector" not in dev.observables:
+            pytest.skip("Skipped because device does not support the Projector observable.")
 
         obs1 = qml.Projector([0], wires=0)
         obs2 = qml.Z(1)


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      test directory!

- [x] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `doc/releases/changelog-dev.md` file, summarizing the
      change, and including a link back to the PR.

- [x] The PennyLane source code conforms to
      [PEP8 standards](https://www.python.org/dev/peps/pep-0008/).
      We check all of our code against [Pylint](https://www.pylint.org/).
      To lint modified files, simply `pip install pylint`, and then
      run `pylint pennylane/path/to/file.py`.

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
Lightning-GPU fails some tests that it should in fact skip.

**Description of the Change:**
Skip measurement-of-projector tests if it is not supported.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
