### PR TITLE
Removed unused `interface` property from `QuantumScript` class

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -25,6 +25,9 @@
 
 <h3>Breaking changes 💔</h3>
 
+* `QuantumScript.interface` has been removed.
+  [(#5980)](https://github.com/PennyLaneAI/pennylane/pull/5980)
+
 <h3>Deprecations 👋</h3>
 
 <h3>Documentation 📝</h3>

--- a/pennylane/tape/qscript.py
+++ b/pennylane/tape/qscript.py
@@ -218,11 +218,6 @@ class QuantumScript:
     # ========================================================
 
     @property
-    def interface(self):
-        """str, None: automatic differentiation interface used by the quantum script (if any)"""
-        return None
-
-    @property
     def circuit(self):
         """Returns the underlying quantum circuit as a list of operations and measurements.
 

--- a/tests/interfaces/default_qubit_2_integration/test_autograd_qnode_default_qubit_2.py
+++ b/tests/interfaces/default_qubit_2_integration/test_autograd_qnode_default_qubit_2.py
@@ -96,8 +96,6 @@ class TestQNode:
 
         res = circuit(a)
 
-        assert circuit.qtape.interface is None
-
         # without the interface, the QNode simply returns a scalar array or float
         assert isinstance(res, (np.ndarray, float))
         assert qml.math.shape(res) == tuple()  # pylint: disable=comparison-with-callable

--- a/tests/interfaces/test_autograd_qnode.py
+++ b/tests/interfaces/test_autograd_qnode.py
@@ -138,8 +138,6 @@ class TestQNode:
 
         res = circuit(a)
 
-        assert circuit.qtape.interface is None
-
         # without the interface, the QNode simply returns a scalar array
         assert isinstance(res, np.ndarray)
         assert res.shape == tuple()
@@ -167,6 +165,7 @@ class TestQNode:
 
         a = np.array(0.1, requires_grad=True)
         assert circuit.interface == interface
+
         # gradients should work
         grad = qml.grad(circuit)(a)
 

--- a/tests/tape/test_tape.py
+++ b/tests/tape/test_tape.py
@@ -87,7 +87,6 @@ class TestConstruction:
         assert tape.observables == obs
         assert tape.output_dim == 5
         assert tape.batch_size is None
-        assert tape.interface is None
 
         assert tape.wires == qml.wires.Wires([0, "a", 4])
         assert tape._output_dim == len(obs[0].wires) + 2 ** len(obs[1].wires)


### PR DESCRIPTION
**Context:**
The `interface` property of `QuantumScript` is pretty much unused (always returns `None`) throughout the codebase, with no meaningful tests for it.

**Description of the Change:**
The property has been removed.

[[sc-67608](https://app.shortcut.com/xanaduai/story/67608)]