### PR TITLE
Remove global seeds from tests

### DIFF
--- a/pennylane/devices/tests/test_gates.py
+++ b/pennylane/devices/tests/test_gates.py
@@ -31,7 +31,6 @@ import pennylane as qml
 
 pytestmark = pytest.mark.skip_unsupported
 
-np.random.seed(42)
 
 # ==========================================================
 # Some useful global variables

--- a/pennylane/devices/tests/test_gates_with_expval.py
+++ b/pennylane/devices/tests/test_gates_with_expval.py
@@ -28,8 +28,6 @@ import pennylane as qml
 
 pytestmark = pytest.mark.skip_unsupported
 
-np.random.seed(42)
-
 
 # ===============================================================
 

--- a/tests/devices/default_tensor/test_default_tensor.py
+++ b/tests/devices/default_tensor/test_default_tensor.py
@@ -297,7 +297,7 @@ class TestSupportedGatesAndObservables:
         nwires = 4
         dq = qml.device("default.qubit", wires=nwires)
         dev = qml.device("default.tensor", wires=nwires, method=method)
-        np.random.seed(0)
+
         state = np.random.rand(2**nwires) + 1j * np.random.rand(2**nwires)
         state /= np.linalg.norm(state)
         wires = qml.wires.Wires(range(nwires))

--- a/tests/devices/default_tensor/test_scalability.py
+++ b/tests/devices/default_tensor/test_scalability.py
@@ -35,7 +35,6 @@ class TestMultiQubitGates:
         wires = 16
         dev = qml.device("default.tensor", wires=wires, method=method)
 
-        np.random.seed(0)
         state = np.random.rand(2**wires) + 1j * np.random.rand(2**wires)
         state /= np.linalg.norm(state)
 
@@ -51,7 +50,6 @@ class TestMultiQubitGates:
         wires = 16
         dev = qml.device("default.tensor", wires=wires, method=method)
 
-        np.random.seed(0)
         state = np.random.rand(2**wires) + 1j * np.random.rand(2**wires)
         state /= np.linalg.norm(state)
 

--- a/tests/devices/qubit/test_apply_operation.py
+++ b/tests/devices/qubit/test_apply_operation.py
@@ -948,7 +948,6 @@ class TestApplyGroverOperator:
     def test_dispatching(self, op_wires, state_wires, einsum_called, tensordot_called, mocker):
         """Test that apply_operation dispatches to einsum, tensordot and the kernel correctly."""
         # pylint: disable=too-many-arguments
-        np.random.seed(752)
         state = np.random.random([2] * state_wires) + 1j * np.random.random([2] * state_wires)
 
         op = qml.GroverOperator(list(range(op_wires)))
@@ -963,7 +962,6 @@ class TestApplyGroverOperator:
     def test_correctness_full_wires(self, op_wires, state_wires, batch_dim):
         """Test that apply_operation is correct for GroverOperator for all dispatch branches
         when applying it to all wires of a state."""
-        np.random.seed(752)
         batched = batch_dim is not None
         shape = [batch_dim] + [2] * state_wires if batched else [2] * state_wires
         flat_shape = (batch_dim, 2**state_wires) if batched else (2**state_wires,)
@@ -983,7 +981,6 @@ class TestApplyGroverOperator:
         """Test that apply_operation is correct for GroverOperator for all dispatch branches
         but einsum (because Grover can't act on a single wire)
         when applying it only to some of the wires of a state."""
-        np.random.seed(752)
         batched = batch_dim is not None
         shape = [batch_dim] + [2] * state_wires if batched else [2] * state_wires
         state = np.random.random(shape) + 1j * np.random.random(shape)
@@ -1006,7 +1003,6 @@ class TestApplyGroverOperator:
         batched = batch_dim is not None
         shape = [batch_dim] + [2] * state_wires if batched else [2] * state_wires
         # Input state
-        np.random.seed(752)
         state = np.random.random(shape) + 1j * np.random.random(shape)
 
         wires = list(range(op_wires))
@@ -1035,7 +1031,6 @@ class TestApplyGroverOperator:
         batched = batch_dim is not None
         shape = [batch_dim] + [2] * state_wires if batched else [2] * state_wires
         # Input state
-        np.random.seed(752)
         state = np.random.random(shape) + 1j * np.random.random(shape)
 
         wires = list(range(op_wires))
@@ -1066,7 +1061,6 @@ class TestApplyGroverOperator:
         batched = batch_dim is not None
         shape = [batch_dim] + [2] * state_wires if batched else [2] * state_wires
         # Input state
-        np.random.seed(752)
         state = np.random.random(shape) + 1j * np.random.random(shape)
 
         wires = list(range(op_wires))
@@ -1095,7 +1089,6 @@ class TestApplyGroverOperator:
         batched = batch_dim is not None
         shape = [batch_dim] + [2] * state_wires if batched else [2] * state_wires
         # Input state
-        np.random.seed(752)
         state = np.random.random(shape) + 1j * np.random.random(shape)
 
         wires = list(range(op_wires))
@@ -1140,7 +1133,6 @@ class TestMultiControlledXKernel:
         self, num_op_wires, num_state_wires, einsum_called, tdot_called, mocker
     ):
         """Test that apply_multicontrolledx dispatches to the right method and is correct."""
-        np.random.seed(2751)
         op = qml.MultiControlledX(wires=list(range(num_op_wires)))
         state = np.random.random([2] * num_state_wires).astype(complex)
         spies = [mocker.spy(qml.math, "einsum"), mocker.spy(qml.math, "tensordot")]
@@ -1159,7 +1151,6 @@ class TestMultiControlledXKernel:
         """Test that the custom kernel works with JAX."""
         from jax import numpy as jnp
 
-        np.random.seed(2751)
         op = qml.MultiControlledX(wires=[0, 4, 3, 1])
         state_shape = ([batch_dim] if batch_dim is not None else []) + [2] * 5
         state = np.random.random(state_shape).astype(complex)
@@ -1176,7 +1167,6 @@ class TestMultiControlledXKernel:
         """Test that the custom kernel works with Tensorflow."""
         import tensorflow as tf
 
-        np.random.seed(2751)
         op = qml.MultiControlledX(wires=[0, 4, 3, 1])
         state_shape = ([batch_dim] if batch_dim is not None else []) + [2] * 5
         state = np.random.random(state_shape).astype(complex)
@@ -1191,7 +1181,6 @@ class TestMultiControlledXKernel:
     @pytest.mark.parametrize("batch_dim", [None, 1, 3])
     def test_with_autograd(self, batch_dim):
         """Test that the custom kernel works with Autograd."""
-        np.random.seed(2751)
         op = qml.MultiControlledX(wires=[0, 4, 3, 1])
         state_shape = ([batch_dim] if batch_dim is not None else []) + [2] * 5
         state = np.random.random(state_shape).astype(complex)
@@ -1208,7 +1197,6 @@ class TestMultiControlledXKernel:
         """Test that the custom kernel works with Torch."""
         import torch
 
-        np.random.seed(2751)
         op = qml.MultiControlledX(wires=[0, 4, 3, 1])
         state_shape = ([batch_dim] if batch_dim is not None else []) + [2] * 5
         state = np.random.random(state_shape).astype(complex)

--- a/tests/devices/test_default_mixed.py
+++ b/tests/devices/test_default_mixed.py
@@ -511,7 +511,7 @@ class TestApplyChannel:
         """Test the application of a channel againt matrix multiplication."""
         if num_dev_wires < max(op.wires) + 1:
             pytest.skip("Need at least as many wires in the device as in the operation.")
-        np.random.seed(52)
+
         dev = qml.device("default.mixed", wires=num_dev_wires)
         init_state = random_state(num_dev_wires)
         dev._state = qml.math.reshape(init_state, [2] * (2 * num_dev_wires))
@@ -1110,7 +1110,7 @@ class TestApply:
     @pytest.mark.parametrize("num_wires", [1, 2, 3])
     def test_apply_specialunitary(self, tol, num_wires):
         """Tests that a special unitary is correctly applied"""
-        np.random.seed(2514)
+
         theta = np.random.random(4**num_wires - 1)
 
         dev = qml.device("default.mixed", wires=num_wires)

--- a/tests/devices/test_default_qubit_tf.py
+++ b/tests/devices/test_default_qubit_tf.py
@@ -56,9 +56,6 @@ from pennylane.devices.default_qubit_tf import (  # pylint: disable=wrong-import
     DefaultQubitTF,
 )
 
-np.random.seed(42)
-
-
 #####################################################
 # Test matrices
 #####################################################
@@ -117,7 +114,6 @@ def init_state_fixture(scope="session"):
 
     def _init_state(n):
         """random initial state"""
-        np.random.seed(4214152)
         state = np.random.random([2**n]) + np.random.random([2**n]) * 1j
         state /= np.linalg.norm(state)
         return state
@@ -132,7 +128,6 @@ def broadcasted_init_state_fixture(scope="session"):
 
     def _broadcasted_init_state(n, batch_size):
         """random initial state"""
-        np.random.seed(4214152)
         state = np.random.random([batch_size, 2**n]) + np.random.random([batch_size, 2**n]) * 1j
         return state / np.linalg.norm(state, axis=1)[:, np.newaxis]
 

--- a/tests/devices/test_default_qubit_torch.py
+++ b/tests/devices/test_default_qubit_torch.py
@@ -75,8 +75,6 @@ if torch.cuda.is_available():
     torch_devices.append("cuda")
 
 
-np.random.seed(42)
-
 #####################################################
 # Test matrices
 #####################################################

--- a/tests/devices/test_default_qutrit_mixed.py
+++ b/tests/devices/test_default_qutrit_mixed.py
@@ -22,8 +22,6 @@ import pennylane as qml
 from pennylane import math
 from pennylane.devices import DefaultQutritMixed, ExecutionConfig
 
-np.random.seed(0)
-
 
 class TestDeviceProperties:
     """Tests for general device properties."""

--- a/tests/devices/test_lightning_qubit.py
+++ b/tests/devices/test_lightning_qubit.py
@@ -32,7 +32,6 @@ def test_integration():
         qml.templates.StronglyEntanglingLayers(weights, wires=range(wires))
         return qml.expval(qml.PauliZ(0))
 
-    np.random.seed(1967)
     weights = np.random.random(
         qml.templates.StronglyEntanglingLayers.shape(layers, wires), requires_grad=True
     )

--- a/tests/devices/test_null_qubit.py
+++ b/tests/devices/test_null_qubit.py
@@ -27,8 +27,6 @@ from pennylane.measurements import (
     StateMeasurement,
 )
 
-np.random.seed(0)
-
 
 def test_name():
     """Tests the name of NullQubit."""

--- a/tests/gradients/core/test_gradient_transform.py
+++ b/tests/gradients/core/test_gradient_transform.py
@@ -223,7 +223,6 @@ class TestGradientTransformIntegration:
     @pytest.mark.parametrize("prefactor", [1.0, 2.0])
     def test_acting_on_qnodes_single_param(self, shots, slicing, prefactor, atol):
         """Test that a gradient transform acts on QNodes with a single parameter correctly"""
-        np.random.seed(412)
         dev = qml.device("default.qubit", wires=2, shots=shots)
 
         @qml.qnode(dev)
@@ -252,7 +251,6 @@ class TestGradientTransformIntegration:
     @pytest.mark.parametrize("prefactor", [1.0, 2.0])
     def test_acting_on_qnodes_multi_param(self, shots, prefactor, atol):
         """Test that a gradient transform acts on QNodes with multiple parameters correctly"""
-        np.random.seed(412)
         dev = qml.device("default.qubit", wires=2, shots=shots)
 
         @qml.qnode(dev)
@@ -288,7 +286,6 @@ class TestGradientTransformIntegration:
     def test_acting_on_qnodes_multi_param_multi_arg(self, shots, atol):
         """Test that a gradient transform acts on QNodes with multiple parameters
         in both the tape and the QNode correctly"""
-        np.random.seed(234)
         dev = qml.device("default.qubit", wires=2, shots=shots)
 
         @qml.qnode(dev)

--- a/tests/gradients/core/test_pulse_gradient.py
+++ b/tests/gradients/core/test_pulse_gradient.py
@@ -295,8 +295,6 @@ class TestParshiftAndIntegrate:
         """
         from jax import numpy as jnp
 
-        np.random.seed(3751)
-
         cjac_shape = (num_split_times,) + par_shape
         if multi_term > 1:
             cjacs = tuple(np.random.random(cjac_shape) for _ in range(multi_term))
@@ -353,8 +351,6 @@ class TestParshiftAndIntegrate:
         This is the variant of the previous test that uses broadcasting.
         """
         from jax import numpy as jnp
-
-        np.random.seed(3751)
 
         cjac_shape = (num_split_times,) + par_shape
         if multi_term > 1:
@@ -417,8 +413,6 @@ class TestParshiftAndIntegrate:
         the number of shifts in the shift rule and with the number of splitting times.
         """
         from jax import numpy as jnp
-
-        np.random.seed(3751)
 
         num_meas_or_shots = 5
 
@@ -491,8 +485,6 @@ class TestParshiftAndIntegrate:
         This is the variant of the previous test that uses broadcasting.
         """
         from jax import numpy as jnp
-
-        np.random.seed(3751)
 
         num_meas_or_shots = 5
 
@@ -568,8 +560,6 @@ class TestParshiftAndIntegrate:
         """
         from jax import numpy as jnp
 
-        np.random.seed(3751)
-
         num_shots = 3
         num_meas = 5
 
@@ -643,8 +633,6 @@ class TestParshiftAndIntegrate:
         This is the variant of the previous test that uses broadcasting.
         """
         from jax import numpy as jnp
-
-        np.random.seed(3751)
 
         num_shots = 3
         num_meas = 5

--- a/tests/gradients/finite_diff/test_spsa_gradient_shot_vec.py
+++ b/tests/gradients/finite_diff/test_spsa_gradient_shot_vec.py
@@ -24,8 +24,6 @@ from pennylane.gradients import spsa_grad
 from pennylane.measurements import Shots
 from pennylane.operation import AnyWires, Observable
 
-np.random.seed(0)
-
 h_val = 0.1
 spsa_shot_vec_tol = 0.31
 

--- a/tests/gradients/parameter_shift/test_parameter_shift_shot_vec.py
+++ b/tests/gradients/parameter_shift/test_parameter_shift_shot_vec.py
@@ -512,7 +512,6 @@ class TestParameterShiftRule:
         """Tests that the automatic gradients of Pauli rotations are correct."""
         # pylint: disable=too-many-arguments
 
-        np.random.seed(824)
         spy = mocker.spy(qml.gradients.parameter_shift, "_get_operation_recipe")
         shot_vec = many_shots_shot_vector
         dev = qml.device("default.qubit", wires=1, shots=shot_vec)
@@ -2060,7 +2059,6 @@ class TestHamiltonianExpvalGradients:
 
     def test_no_trainable_coeffs(self, mocker, broadcast, tol):
         """Test no trainable Hamiltonian coefficients"""
-        np.random.seed(3751)
         shot_vec = many_shots_shot_vector
         dev = qml.device("default.qubit", wires=2, shots=shot_vec)
         spy = mocker.spy(qml.gradients, "hamiltonian_grad")

--- a/tests/interfaces/default_qubit_2_integration/test_tensorflow_autograph_qnode_shot_vector_default_qubit_2.py
+++ b/tests/interfaces/default_qubit_2_integration/test_tensorflow_autograph_qnode_shot_vector_default_qubit_2.py
@@ -391,7 +391,6 @@ class TestReturnShotVectorIntegration:
     ):
         """Tests correct output shape and evaluation for a tape
         with a single expval output"""
-        np.random.seed(215)
         x = tf.Variable(0.543, dtype=tf.float64)
         y = tf.Variable(-0.654, dtype=tf.float64)
 
@@ -425,7 +424,6 @@ class TestReturnShotVectorIntegration:
     ):
         """Tests correct output shape and evaluation for a tape
         with prob and expval outputs"""
-        np.random.seed(214)
         x = tf.Variable(0.543, dtype=tf.float64)
         y = tf.Variable(-0.654, dtype=tf.float64)
 

--- a/tests/interfaces/default_qubit_2_integration/test_tensorflow_qnode_shot_vector_default_qubit_2.py
+++ b/tests/interfaces/default_qubit_2_integration/test_tensorflow_qnode_shot_vector_default_qubit_2.py
@@ -453,7 +453,6 @@ class TestReturnShotVectorIntegration:
     ):
         """Tests correct output shape and evaluation for a tape
         with a single expval output"""
-        np.random.seed(215)
 
         x = tf.Variable(0.543)
         y = tf.Variable(-0.654)
@@ -487,7 +486,6 @@ class TestReturnShotVectorIntegration:
     ):
         """Tests correct output shape and evaluation for a tape
         with prob and expval outputs"""
-        np.random.seed(214)
 
         x = tf.Variable(0.543)
         y = tf.Variable(-0.654)

--- a/tests/interfaces/test_autograd_qnode_shot_vector.py
+++ b/tests/interfaces/test_autograd_qnode_shot_vector.py
@@ -567,7 +567,6 @@ class TestReturnShotVectorIntegration:
     ):
         """Tests correct output shape and evaluation for a tape
         with a single expval output"""
-        np.random.seed(42)
         dev = qml.device(dev_name, wires=2, shots=shots)
         x = np.array(0.543)
         y = np.array(-0.654)
@@ -601,7 +600,6 @@ class TestReturnShotVectorIntegration:
     ):
         """Tests correct output shape and evaluation for a tape
         with prob and expval outputs"""
-        np.random.seed(42)
         dev = qml.device(dev_name, wires=2, shots=shots)
         x = np.array(0.543)
         y = np.array(-0.654)

--- a/tests/interfaces/test_jax_qnode_shot_vector.py
+++ b/tests/interfaces/test_jax_qnode_shot_vector.py
@@ -838,7 +838,6 @@ class TestReturnShotVectorIntegration:
     ):
         """Tests correct output shape and evaluation for a tape
         with a single expval output"""
-        np.random.seed(42)
         dev = qml.device(dev_name, wires=2, shots=shots)
         x = jax.numpy.array(0.543)
         y = jax.numpy.array(-0.654)
@@ -874,7 +873,6 @@ class TestReturnShotVectorIntegration:
     ):
         """Tests correct output shape and evaluation for a tape
         with prob and expval outputs"""
-        np.random.seed(42)
         dev = qml.device(dev_name, wires=2, shots=shots)
         x = jax.numpy.array(0.543)
         y = jax.numpy.array(-0.654)

--- a/tests/interfaces/test_tensorflow_autograph_qnode_shot_vector.py
+++ b/tests/interfaces/test_tensorflow_autograph_qnode_shot_vector.py
@@ -401,7 +401,6 @@ class TestReturnShotVectorIntegration:
     ):
         """Tests correct output shape and evaluation for a tape
         with a single expval output"""
-        np.random.seed(215)
         dev = qml.device(dev_name, wires=2, shots=shots)
         x = tf.Variable(0.543, dtype=tf.float64)
         y = tf.Variable(-0.654, dtype=tf.float64)
@@ -436,7 +435,6 @@ class TestReturnShotVectorIntegration:
     ):
         """Tests correct output shape and evaluation for a tape
         with prob and expval outputs"""
-        np.random.seed(214)
         dev = qml.device(dev_name, wires=2, shots=shots)
         x = tf.Variable(0.543, dtype=tf.float64)
         y = tf.Variable(-0.654, dtype=tf.float64)

--- a/tests/interfaces/test_tensorflow_qnode_shot_vector.py
+++ b/tests/interfaces/test_tensorflow_qnode_shot_vector.py
@@ -468,7 +468,6 @@ class TestReturnShotVectorIntegration:
     ):
         """Tests correct output shape and evaluation for a tape
         with a single expval output"""
-        np.random.seed(215)
         dev = qml.device(dev_name, wires=2, shots=shots)
         x = tf.Variable(0.543)
         y = tf.Variable(-0.654)
@@ -502,7 +501,6 @@ class TestReturnShotVectorIntegration:
     ):
         """Tests correct output shape and evaluation for a tape
         with prob and expval outputs"""
-        np.random.seed(214)
         dev = qml.device(dev_name, wires=2, shots=shots)
         x = tf.Variable(0.543)
         y = tf.Variable(-0.654)

--- a/tests/interfaces/test_torch_qnode.py
+++ b/tests/interfaces/test_torch_qnode.py
@@ -1490,8 +1490,6 @@ class TestTapeExpansion:
         elif diff_method == "hadamard":
             pytest.skip("The hadamard method does not yet support Hamiltonians")
 
-        np.random.seed(1235)
-
         dev = qml.device(dev_name, wires=3, shots=50000)
         spy = mocker.spy(qml.transforms, "split_non_commuting")
         obs = [qml.PauliX(0), qml.PauliX(0) @ qml.PauliZ(1), qml.PauliZ(0) @ qml.PauliZ(1)]

--- a/tests/measurements/legacy/test_classical_shadow_legacy.py
+++ b/tests/measurements/legacy/test_classical_shadow_legacy.py
@@ -192,7 +192,6 @@ class TestClassicalShadow:
         """Test that the distribution of the bits and recipes are correct for a circuit
         that prepares all qubits in a Pauli basis"""
         # high number of shots to prevent true negatives
-        np.random.seed(42)
         shots = 1000
 
         circuit = circuit_fn(wires, shots=shots, interface=interface, device=device)

--- a/tests/measurements/legacy/test_expval_legacy.py
+++ b/tests/measurements/legacy/test_expval_legacy.py
@@ -105,7 +105,6 @@ class TestExpval:
     ):  # pylint: disable=too-many-arguments
         """Test that expectation values for mid-circuit measurement values
         are correct for a single measurement value."""
-        np.random.seed(42)
         dev = qml.device(device_name, wires=2, shots=shots)
 
         @qml.qnode(dev)
@@ -133,7 +132,6 @@ class TestExpval:
     ):  # pylint: disable=too-many-arguments
         """Test that expectation values for mid-circuit measurement values
         are correct for a composite measurement value."""
-        np.random.seed(42)
         dev = qml.device(device_name, wires=6, shots=shots)
 
         @qml.qnode(dev)
@@ -201,7 +199,6 @@ class TestExpval:
         """Tests that the expectation of a ``Projector`` object is computed correctly for both of
         its subclasses."""
         dev = qml.device("default.qubit.legacy", wires=3, shots=shots)
-        np.random.seed(42)
 
         @qml.qnode(dev)
         def circuit():

--- a/tests/measurements/legacy/test_probs_legacy.py
+++ b/tests/measurements/legacy/test_probs_legacy.py
@@ -49,10 +49,6 @@ def custom_measurement_process(device, spy):
         assert qml.math.allequal(old_res, new_res)
 
 
-# make the test deterministic
-np.random.seed(42)
-
-
 @pytest.fixture(name="init_state")
 def fixture_init_state():
     """Fixture that creates an initial state"""
@@ -181,7 +177,6 @@ class TestProbs:
     ):  # pylint: disable=too-many-arguments
         """Test that probs for mid-circuit measurement values
         are correct for a single measurement value."""
-        np.random.seed(42)
         dev = qml.device(device_name, wires=2, shots=shots)
 
         @qml.qnode(dev)
@@ -215,7 +210,6 @@ class TestProbs:
     ):  # pylint: disable=too-many-arguments
         """Test that probs for mid-circuit measurement values
         are correct for a list of measurement value."""
-        np.random.seed(42)
         dev = qml.device(device_name, wires=6, shots=shots)
 
         @qml.qnode(dev)

--- a/tests/measurements/legacy/test_var_legacy.py
+++ b/tests/measurements/legacy/test_var_legacy.py
@@ -100,7 +100,6 @@ class TestVar:
     ):  # pylint: disable=too-many-arguments
         """Test that variances for mid-circuit measurement values
         are correct for a single measurement value."""
-        np.random.seed(42)
         dev = qml.device(device_name, wires=2, shots=shots)
 
         @qml.qnode(dev)
@@ -129,7 +128,6 @@ class TestVar:
     ):  # pylint: disable=too-many-arguments
         """Test that variances for mid-circuit measurement values
         are correct for a composite measurement value."""
-        np.random.seed(42)
         dev = qml.device(device_name, wires=6, shots=shots)
 
         @qml.qnode(dev)

--- a/tests/measurements/test_classical_shadow.py
+++ b/tests/measurements/test_classical_shadow.py
@@ -318,7 +318,6 @@ class TestClassicalShadow:
         """Test that the distribution of the bits and recipes are correct for a circuit
         that prepares all qubits in a Pauli basis"""
         # high number of shots to prevent true negatives
-        np.random.seed(42)
         shots = 1000
 
         circuit = circuit_fn(wires, shots=shots, interface=interface)

--- a/tests/measurements/test_expval.py
+++ b/tests/measurements/test_expval.py
@@ -113,8 +113,7 @@ class TestExpval:
     ):  # pylint: disable=too-many-arguments
         """Test that expectation values for mid-circuit measurement values
         are correct for a composite measurement value."""
-        np.random.seed(0)
-        dev = qml.device("default.qubit")
+        dev = qml.device("default.qubit", seed=123)
 
         @qml.qnode(dev)
         def circuit(phi):
@@ -203,8 +202,7 @@ class TestExpval:
     def test_projector_expval(self, state, shots):
         """Tests that the expectation of a ``Projector`` object is computed correctly for both of
         its subclasses."""
-        dev = qml.device("default.qubit", wires=3, shots=shots)
-        np.random.seed(42)
+        dev = qml.device("default.qubit", wires=3, shots=shots, seed=123)
 
         @qml.qnode(dev)
         def circuit():

--- a/tests/measurements/test_probs.py
+++ b/tests/measurements/test_probs.py
@@ -22,9 +22,6 @@ from pennylane import numpy as pnp
 from pennylane.measurements import MeasurementProcess, Probability, ProbabilityMP, Shots
 from pennylane.queuing import AnnotatedQueue
 
-# make the test deterministic
-np.random.seed(42)
-
 
 @pytest.fixture(name="init_state")
 def fixture_init_state():
@@ -32,7 +29,8 @@ def fixture_init_state():
 
     def _init_state(n):
         """An initial state over n wires"""
-        state = np.random.random([2**n]) + np.random.random([2**n]) * 1j
+        rng = np.random.default_rng(42)
+        state = rng.random([2**n]) + rng.random([2**n]) * 1j
         state /= np.linalg.norm(state)
         return state
 

--- a/tests/ops/op_math/test_controlled_decompositions.py
+++ b/tests/ops/op_math/test_controlled_decompositions.py
@@ -148,10 +148,10 @@ class TestControlledDecompositionZYZ:
         """Tests that the controlled decomposition of a single-qubit operation
         behaves as expected in a quantum circuit"""
         n_qubits = 4
-        np.random.seed(1337)
+        rng = np.random.default_rng(1337)
 
         dev = qml.device("default.qubit", wires=n_qubits)
-        init_state = np.random.rand(2**n_qubits) + 1.0j * np.random.rand(2**n_qubits)
+        init_state = rng.rand(2**n_qubits) + 1.0j * rng.rand(2**n_qubits)
         init_state /= np.sqrt(np.dot(np.conj(init_state), init_state))
         init_state = np.array(init_state)
         target_wires = [0]

--- a/tests/ops/qubit/test_matrix_ops.py
+++ b/tests/ops/qubit/test_matrix_ops.py
@@ -387,8 +387,8 @@ class TestWalshHadamardTransform:
     @pytest.mark.parametrize("provide_n", [True, False])
     def test_compare_matrix_mult(self, n, provide_n):
         """Test against matrix multiplication for a few random inputs."""
-        np.random.seed(382)
-        inp = np.random.random(2**n)
+        rng = np.random.default_rng(382)
+        inp = rng.random(2**n)
         output = _walsh_hadamard_transform(inp, n=n if provide_n else None)
         h = np.array([[0.5, 0.5], [0.5, -0.5]])
         h = reduce(np.kron, [h] * n)
@@ -406,8 +406,8 @@ class TestWalshHadamardTransform:
     @pytest.mark.parametrize("provide_n", [True, False])
     def test_compare_matrix_mult_broadcasted(self, n, provide_n):
         """Test against matrix multiplication for a few random inputs."""
-        np.random.seed(382)
-        inp = np.random.random((5, 2**n))
+        rng = np.random.default_rng(382)
+        inp = rng.random((5, 2**n))
         output = _walsh_hadamard_transform(inp, n=n if provide_n else None)
         h = np.array([[0.5, 0.5], [0.5, -0.5]])
         h = reduce(np.kron, [h] * n)
@@ -531,8 +531,8 @@ class TestDiagonalQubitUnitary:
     @pytest.mark.parametrize("n", [1, 2, 3])
     def test_decomposition_matrix_match(self, n):
         """Test that the matrix of the decomposition matches the original matrix."""
-        np.random.seed(7241)
-        D = np.exp(1j * np.random.random(2**n))
+        rng = np.random.default_rng(382)
+        D = np.exp(1j * rng.random(2**n))
         wires = list(range(n))
         decomp = qml.DiagonalQubitUnitary.compute_decomposition(D, wires)
         decomp2 = qml.DiagonalQubitUnitary(D, wires=wires).decomposition()
@@ -546,8 +546,8 @@ class TestDiagonalQubitUnitary:
     @pytest.mark.parametrize("n", [1, 2, 3])
     def test_decomposition_matrix_match_broadcasted(self, n):
         """Test that the broadcasted matrix of the decomposition matches the original matrix."""
-        np.random.seed(7241)
-        D = np.exp(1j * np.random.random((5, 2**n)))
+        rng = np.random.default_rng(382)
+        D = np.exp(1j * rng.random((5, 2**n)))
         wires = list(range(n))
         decomp = qml.DiagonalQubitUnitary.compute_decomposition(D, wires)
         decomp2 = qml.DiagonalQubitUnitary(D, wires=wires).decomposition()

--- a/tests/ops/qubit/test_special_unitary.py
+++ b/tests/ops/qubit/test_special_unitary.py
@@ -120,9 +120,9 @@ class TestGetOneParameterGenerators:
         jax.config.update("jax_enable_x64", True)
         from jax import numpy as jnp
 
-        np.random.seed(14521)
+        rng = np.random.default_rng(14521)
         d = 4**n - 1
-        theta = jnp.array(np.random.random(d))
+        theta = jnp.array(rng.random(d))
         fn = (
             jax.jit(self.get_one_parameter_generators, static_argnums=[1, 2])
             if use_jit
@@ -161,7 +161,6 @@ class TestGetOneParameterGenerators:
         """Test that generators are computed correctly in Tensorflow."""
         import tensorflow as tf
 
-        np.random.seed(14521)
         d = 4**n - 1
         theta = tf.Variable(np.random.random(d))
         Omegas = self.get_one_parameter_generators(theta, n, "tf")
@@ -189,7 +188,6 @@ class TestGetOneParameterGenerators:
         """Test that generators are computed correctly in Torch."""
         import torch
 
-        np.random.seed(14521)
         d = 4**n - 1
         theta = torch.tensor(np.random.random(d), requires_grad=True)
         Omegas = self.get_one_parameter_generators(theta, n, "torch")
@@ -254,7 +252,6 @@ class TestGetOneParameterGeneratorsDiffability:
         jax.config.update("jax_enable_x64", True)
         from jax import numpy as jnp
 
-        np.random.seed(14521)
         d = 4**n - 1
         theta = jnp.array(np.random.random(d), dtype=jnp.complex128)
         fn = (
@@ -271,7 +268,6 @@ class TestGetOneParameterGeneratorsDiffability:
         """Test that generators are differentiable in Tensorflow."""
         import tensorflow as tf
 
-        np.random.seed(14521)
         d = 4**n - 1
         theta = tf.Variable(np.random.random(d))
         with tf.GradientTape() as t:
@@ -285,7 +281,6 @@ class TestGetOneParameterGeneratorsDiffability:
         """Test that generators are differentiable in Torch."""
         import torch
 
-        np.random.seed(14521)
         d = 4**n - 1
         theta = torch.tensor(np.random.random(d), requires_grad=True)
 
@@ -315,7 +310,6 @@ class TestGetOneParameterCoeffs:
         jax.config.update("jax_enable_x64", True)
         from jax import numpy as jnp
 
-        np.random.seed(14521)
         d = 4**n - 1
         theta = jnp.array(np.random.random(d))
         op = qml.SpecialUnitary(theta, list(range(n)))
@@ -334,7 +328,6 @@ class TestGetOneParameterCoeffs:
         """Test that the coefficients of the generators are computed correctly in Tensorflow."""
         import tensorflow as tf
 
-        np.random.seed(14521)
         d = 4**n - 1
         theta = tf.Variable(np.random.random(d))
         op = qml.SpecialUnitary(theta, list(range(n)))
@@ -353,7 +346,6 @@ class TestGetOneParameterCoeffs:
         """Test that the coefficients of the generators are computed correctly in Torch."""
         import torch
 
-        np.random.seed(14521)
         d = 4**n - 1
         theta = torch.tensor(np.random.random(d), requires_grad=True)
         op = qml.SpecialUnitary(theta, list(range(n)))

--- a/tests/optimize/test_optimize_shot_adaptive.py
+++ b/tests/optimize/test_optimize_shot_adaptive.py
@@ -674,7 +674,6 @@ class TestStepAndCost:
     def test_qnode_cost(self, tol):
         """Test that the cost is correctly returned
         when using a QNode as the cost function"""
-        np.random.seed(0)
 
         dev = qml.device("default.qubit", wires=1, shots=10)
 

--- a/tests/shadow/test_shadow_class.py
+++ b/tests/shadow/test_shadow_class.py
@@ -22,8 +22,6 @@ import pennylane as qml
 import pennylane.numpy as np
 from pennylane.shadows import ClassicalShadow, median_of_means, pauli_expval
 
-np.random.seed(777)
-
 wires = range(3)
 shots = 10000
 dev = qml.device("default.qubit", wires=wires, shots=shots)

--- a/tests/shadow/test_shadow_entropies.py
+++ b/tests/shadow/test_shadow_entropies.py
@@ -22,8 +22,6 @@ import pennylane.numpy as np
 from pennylane.shadows import ClassicalShadow
 from pennylane.shadows.classical_shadow import _project_density_matrix_spectrum
 
-np.random.seed(777)
-
 
 def max_entangled_circuit(wires, shots=10000, interface="autograd"):
     """maximally entangled state preparation circuit"""

--- a/tests/templates/test_layers/test_cv_neural_net.py
+++ b/tests/templates/test_layers/test_cv_neural_net.py
@@ -209,7 +209,6 @@ def circuit_decomposed(*weights):
 def test_adjoint():
     """Test that the adjoint method works"""
     dev = DummyDevice(wires=2)
-    np.random.seed(42)
 
     shapes = qml.CVNeuralNetLayers.shape(n_layers=1, n_wires=2)
     weights = [np.random.random(shape) for shape in shapes]

--- a/tests/test_classical_gradients.py
+++ b/tests/test_classical_gradients.py
@@ -20,8 +20,6 @@ import pytest
 import pennylane as qml
 from pennylane import numpy as np
 
-np.random.seed(42)
-
 
 def test_grad_no_ints():
     """Test that grad raises a `ValueError` if the trainable parameter is an int."""

--- a/tests/test_debugging.py
+++ b/tests/test_debugging.py
@@ -671,7 +671,6 @@ class TestSnapshotUnsupportedQNode:
     @pytest.mark.parametrize("method", [None, "parameter-shift"])
     def test_default_qutrit(self, method):
         """Test that multiple snapshots are returned correctly on the pure qutrit simulator."""
-        np.random.seed(7)
 
         dev = qml.device("default.qutrit", wires=2, shots=100)
 

--- a/tests/test_hermitian_edge_cases.py
+++ b/tests/test_hermitian_edge_cases.py
@@ -21,9 +21,6 @@ import pytest
 
 import pennylane as qml
 
-np.random.seed(0)
-
-
 THETA = np.linspace(0.11, 1, 3)
 PHI = np.linspace(0.32, 1, 3)
 

--- a/tests/test_tensor_measurements.py
+++ b/tests/test_tensor_measurements.py
@@ -22,8 +22,6 @@ import pytest
 import pennylane as qml
 from pennylane import expval, sample, var
 
-np.random.seed(0)
-
 Z = np.array([[1, 0], [0, -1]])
 THETA = np.linspace(0.11, 3, 5)
 PHI = np.linspace(0.32, 3, 5)

--- a/tests/test_vqe.py
+++ b/tests/test_vqe.py
@@ -23,12 +23,6 @@ import pennylane as qml
 from pennylane import numpy as pnp
 
 
-@pytest.fixture(scope="function")
-def seed():
-    """Resets the random seed with every test"""
-    np.random.seed(0)
-
-
 def generate_cost_fn(ansatz, hamiltonian, device, **kwargs):
     """Generates a QNode and computes the expectation value of a cost Hamiltonian with respect
     to the parameters provided to an ansatz"""
@@ -342,7 +336,6 @@ class TestVQE:
             diff_method="parameter-shift",
         )
 
-        np.random.seed(1967)
         shape = qml.templates.StronglyEntanglingLayers.shape(n_layers=2, n_wires=4)
         w = np.random.random(shape)
 
@@ -394,7 +387,6 @@ class TestVQE:
             diff_method="parameter-shift",
         )
 
-        np.random.seed(1967)
         shape = qml.templates.StronglyEntanglingLayers.shape(n_layers=2, n_wires=4)
         w = np.random.random(shape)
 
@@ -444,7 +436,6 @@ class TestVQE:
             diff_method="parameter-shift",
         )
 
-        np.random.seed(1967)
         shape = qml.templates.StronglyEntanglingLayers.shape(n_layers=2, n_wires=4)
         w = np.random.random(shape)
 
@@ -500,7 +491,6 @@ class TestVQE:
             diff_method="parameter-shift",
         )
 
-        np.random.seed(1967)
         shape = qml.templates.StronglyEntanglingLayers.shape(n_layers=2, n_wires=5)
         w = np.random.random(shape)
 
@@ -556,7 +546,6 @@ class TestVQE:
             diff_method="parameter-shift",
         )
 
-        np.random.seed(1967)
         shape = qml.templates.StronglyEntanglingLayers.shape(n_layers=2, n_wires=5)
         w = np.random.random(shape)
 
@@ -612,7 +601,6 @@ class TestVQE:
             diff_method="parameter-shift",
         )
 
-        np.random.seed(1967)
         shape = qml.templates.StronglyEntanglingLayers.shape(n_layers=2, n_wires=5)
         w = np.random.random(shape)
 
@@ -654,7 +642,6 @@ class TestVQE:
             diff_method="parameter-shift",
         )
 
-        np.random.seed(1967)
         shape = qml.templates.StronglyEntanglingLayers.shape(n_layers=2, n_wires=4)
         w = pnp.random.uniform(low=0, high=2 * np.pi, size=shape, requires_grad=True)
 
@@ -688,7 +675,6 @@ class TestVQE:
             diff_method="parameter-shift",
         )
 
-        np.random.seed(1967)
         shape = qml.templates.StronglyEntanglingLayers.shape(n_layers=2, n_wires=4)
         w = pnp.random.random(shape, requires_grad=True)
 
@@ -714,7 +700,6 @@ class TestVQE:
             interface="torch",
         )
 
-        np.random.seed(1967)
         shape = qml.templates.StronglyEntanglingLayers.shape(n_layers=2, n_wires=4)
         w = np.random.uniform(low=0, high=2 * np.pi, size=shape)
         w = torch.tensor(w, requires_grad=True)
@@ -741,7 +726,6 @@ class TestVQE:
             qml.templates.StronglyEntanglingLayers, hamiltonian, dev, interface="tf"
         )
 
-        np.random.seed(1967)
         shape = qml.templates.StronglyEntanglingLayers.shape(n_layers=2, n_wires=4)
         w = np.random.uniform(low=0, high=2 * np.pi, size=shape)
         w = tf.Variable(w)
@@ -755,9 +739,9 @@ class TestVQE:
 
 
 # Test data
-np.random.seed(1967)
+rng = np.random.default_rng(1967)
 _shape = qml.templates.StronglyEntanglingLayers.shape(2, 4)
-PARAMS = np.random.uniform(low=0, high=2 * np.pi, size=_shape)
+PARAMS = rng.uniform(low=0, high=2 * np.pi, size=_shape)
 
 
 class TestNewVQE:
@@ -802,7 +786,7 @@ class TestNewVQE:
         """Tests a VQE circuit where the observable does not act on all wires."""
         dev = qml.device("default.qubit", wires=3)
         coeffs = [1.0, 1.0, 1.0]
-        np.random.seed(1967)
+
         w = np.random.random(qml.templates.StronglyEntanglingLayers.shape(n_layers=1, n_wires=2))
 
         observables1 = [qml.PauliZ(0), qml.PauliY(0), qml.PauliZ(1)]
@@ -1038,7 +1022,7 @@ class TestNewVQE:
 
         dev = qml.device("default.qubit", wires=4)
         H = big_hamiltonian
-        np.random.seed(1967)
+
         w = jnp.array(PARAMS)
 
         @qml.qnode(dev)
@@ -1219,7 +1203,6 @@ class TestInterfaces:
 
         H = qml.Hamiltonian(coeffs, observables)
 
-        np.random.seed(1)
         shape = qml.templates.StronglyEntanglingLayers.shape(3, 2)
         params = np.random.uniform(low=0, high=2 * np.pi, size=shape)
 

--- a/tests/transforms/test_batch_input.py
+++ b/tests/transforms/test_batch_input.py
@@ -128,7 +128,6 @@ def test_value_error():
         qml.RY(weights[1], wires=1)
         return qml.expval(qml.PauliZ(1))
 
-    np.random.seed(42)
     batch_size = 5
     input1 = np.random.uniform(0, np.pi, (batch_size, 2), requires_grad=False)
     input2 = np.random.uniform(0, np.pi, (4, 1), requires_grad=False)

--- a/tests/transforms/test_defer_measurements.py
+++ b/tests/transforms/test_defer_measurements.py
@@ -371,8 +371,7 @@ class TestQNode:
     def test_some_postselection_qnode(self, phi, shots, reduce_postselected, tol, tol_stochastic):
         """Test that a qnode with some mid-circuit measurements with postselection
         is transformed correctly by defer_measurements"""
-        np.random.seed(822)
-        dev = DefaultQubit()
+        dev = DefaultQubit(seed=822)
 
         dm_transform = qml.defer_measurements
         if reduce_postselected is not None:
@@ -420,8 +419,6 @@ class TestQNode:
         """Test that a qnode with all mid-circuit measurements with postselection
         is transformed correctly by defer_measurements"""
         dev = DefaultQubit()
-
-        np.random.seed(None)
 
         # Initializing mid circuit measurements here so that id can be controlled (affects
         # wire ordering for qml.cond)

--- a/tests/transforms/test_mitigate.py
+++ b/tests/transforms/test_mitigate.py
@@ -120,7 +120,6 @@ class TestMitigateWithZNE:
         n_layers = 2
 
         shapes = qml.SimplifiedTwoDesign.shape(n_layers, n_wires)
-        np.random.seed(0)
         w1, w2 = [np.random.random(s) for s in shapes]
 
         @partial(
@@ -242,7 +241,6 @@ class TestMitiqIntegration:
         n_layers = 2
 
         shapes = qml.SimplifiedTwoDesign.shape(n_layers, n_wires)
-        np.random.seed(0)
         w1, w2 = [np.random.random(s) for s in shapes]
 
         @partial(
@@ -292,7 +290,6 @@ class TestMitiqIntegration:
         n_layers = 2
 
         shapes = qml.SimplifiedTwoDesign.shape(n_layers, n_wires)
-        np.random.seed(0)
         w1, w2 = [np.random.random(s) for s in shapes]
 
         @partial(
@@ -332,7 +329,6 @@ class TestMitiqIntegration:
         n_layers = 2
 
         shapes = qml.SimplifiedTwoDesign.shape(n_layers, n_wires)
-        np.random.seed(0)
         w1, w2 = [np.random.random(s) for s in shapes]
 
         @partial(
@@ -372,7 +368,6 @@ class TestMitiqIntegration:
         n_layers = 2
 
         shapes = qml.SimplifiedTwoDesign.shape(n_layers, n_wires)
-        np.random.seed(0)
         w1, w2 = [np.random.random(s) for s in shapes]
 
         def circuit(w1, w2):
@@ -430,7 +425,6 @@ class TestMitiqIntegration:
         n_layers = 2
 
         shapes = qml.SimplifiedTwoDesign.shape(n_layers, n_wires)
-        np.random.seed(0)
         w1, w2 = [np.random.random(s, requires_grad=True) for s in shapes]
 
         @partial(


### PR DESCRIPTION
**Context:**
A while back we added an autouse fixture to our test suite that sets a global seed before each test. Thus there is no need to be setting global seeds inside tests unless they're explicitly testing behaviour related to seeding.

**Description of the Change:**
* Remove all references to `np.random.seed` from the tests, unless the test cases are specifically for seeding related functionality.

Optional TODO:
* If tests use np.random, add a `np.random.default_rng` to the test and use the rng instead of `np.random`.

**Benefits:**
* Better practices with setting seeds in stochastic tests.

**Possible Drawbacks:**

**Related GitHub Issues:**
