### PR TITLE
Remove queue idx

### DIFF
--- a/.github/workflows/core_tests_durations.json
+++ b/.github/workflows/core_tests_durations.json
@@ -13182,7 +13182,6 @@
     "ops/op_math/test_composite.py::TestConstruction::test_map_wires[True-expected_overlapping_ops1]": 0.001044666045345366,
     "ops/op_math/test_composite.py::TestConstruction::test_ndim_params_raises_error": 0.0008577080443501472,
     "ops/op_math/test_composite.py::TestConstruction::test_parameters": 0.0009155830484814942,
-    "ops/op_math/test_composite.py::TestConstruction::test_queue_idx": 0.0008379160426557064,
     "ops/op_math/test_composite.py::TestConstruction::test_raise_error_fewer_than_2_operands": 0.0010355000267736614,
     "ops/op_math/test_composite.py::TestConstruction::test_tensor_and_hamiltonian_converted": 0.0014357499894686043,
     "ops/op_math/test_composite.py::TestMscMethods::test_copy[ops_lst0]": 0.0009615410235710442,

--- a/.github/workflows/install_deps/action.yml
+++ b/.github/workflows/install_deps/action.yml
@@ -23,7 +23,7 @@ inputs:
   tensorflow_version:
     description: The version of TensorFlow to install for any job that requires TensorFlow
     required: false
-    default: 2.16
+    default: 2.16.0
   install_pytorch:
     description: Indicate if PyTorch should be installed or not
     required: false

--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -73,6 +73,11 @@ Other deprecations
 Completed deprecation cycles
 ----------------------------
 
+* ``queue_idx`` attribute has been removed from the ``Operator``, ``CompositeOp``, and ``SymboliOp`` classes. Instead, the index is now stored as the label of the ``CircuitGraph.graph`` nodes.
+
+  - Deprecated in v0.38
+  - Removed in v0.38
+
 * ``qml.transforms.map_batch_transform`` has been removed, since transforms can be applied directly to a batch of tapes.
   See :func:`~.pennylane.transform` for more information.
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -45,6 +45,9 @@
   the circuit.
   [(#5907)](https://github.com/PennyLaneAI/pennylane/pull/5907)
 
+* `queue_idx` attribute has been removed from the `Operator`, `CompositeOp`, and `SymboliOp` classes.
+
+
 * ``qml.transforms.map_batch_transform`` has been removed, since transforms can be applied directly to a batch of tapes.
   See :func:`~.pennylane.transform` for more information.
   [(#5981)](https://github.com/PennyLaneAI/pennylane/pull/5981)
@@ -88,6 +91,7 @@ Astral Cai,
 Yushao Chen,
 Lillian M. A. Frederiksen,
 Pietropaolo Frisoni,
+Emiliano Godinez,
 Christina Lee,
 Austin Huang,
 William Maxwell,

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -1089,7 +1089,6 @@ class Operator(abc.ABC, metaclass=ABCCaptureMeta):
 
         self._name = self.__class__.__name__  #: str: name of the operator
         self._id = id
-        self.queue_idx = None  #: int, None: index of the Operator in the circuit queue, or None if not in a queue
         self._pauli_rep = None  # Union[PauliSentence, None]: Representation of the operator as a pauli sentence, if applicable
 
         wires_from_args = False

--- a/pennylane/ops/op_math/composite.py
+++ b/pennylane/ops/op_math/composite.py
@@ -59,7 +59,6 @@ class CompositeOp(Operator):
         self, *operands: Operator, id=None, _pauli_rep=None
     ):  # pylint: disable=super-init-not-called
         self._id = id
-        self.queue_idx = None
         self._name = self.__class__.__name__
 
         self.operands = operands

--- a/pennylane/ops/op_math/symbolicop.py
+++ b/pennylane/ops/op_math/symbolicop.py
@@ -72,7 +72,6 @@ class SymbolicOp(Operator):
     def __init__(self, base, id=None):
         self.hyperparameters["base"] = base
         self._id = id
-        self.queue_idx = None
         self._pauli_rep = None
         self.queue()
 

--- a/tests/ops/op_math/test_composite.py
+++ b/tests/ops/op_math/test_composite.py
@@ -87,11 +87,6 @@ class TestConstruction:
         assert op._name == "ValidOp"
         assert op._op_symbol == "#"
 
-    def test_queue_idx(self):
-        """Test that queue_idx is None."""
-        op = ValidOp(*self.simple_operands)
-        assert op.queue_idx is None
-
     def test_parameters(self):
         """Test that parameters are initialized correctly."""
         op = ValidOp(qml.RX(9.87, wires=0), qml.Rot(1.23, 4.0, 5.67, wires=1), qml.PauliX(0))

--- a/tests/ops/op_math/test_prod.py
+++ b/tests/ops/op_math/test_prod.py
@@ -165,7 +165,6 @@ class TestInitialization:  # pylint:disable=too-many-public-methods
         assert prod_op.num_wires == 2
         assert prod_op.name == "Prod"
         assert prod_op.id == id
-        assert prod_op.queue_idx is None
 
         assert prod_op.data == (0.23,)
         assert prod_op.parameters == [0.23]

--- a/tests/ops/op_math/test_sprod.py
+++ b/tests/ops/op_math/test_sprod.py
@@ -109,7 +109,6 @@ class TestInitialization:
         assert sprod_op.num_wires == 1
         assert sprod_op.name == "SProd"
         assert sprod_op.id == test_id
-        assert sprod_op.queue_idx is None
 
         assert sprod_op.data == (3.14, 0.23)
         assert sprod_op.parameters == [3.14, 0.23]

--- a/tests/ops/op_math/test_symbolic_op.py
+++ b/tests/ops/op_math/test_symbolic_op.py
@@ -52,7 +52,6 @@ def test_intialization():
     assert op.base is base
     assert op.hyperparameters["base"] is base
     assert op.id == "something"
-    assert op.queue_idx is None
     assert op.name == "Symbolic"
 
 

--- a/tests/pulse/test_parametrized_evolution.py
+++ b/tests/pulse/test_parametrized_evolution.py
@@ -155,7 +155,6 @@ class TestInitialization:
         assert ev.num_wires == AnyWires
         assert ev.name == "ParametrizedEvolution"
         assert ev.id is None
-        assert ev.queue_idx is None
 
         exp_params = [] if params is None else params
         assert qml.math.allequal(ev.data, exp_params)


### PR DESCRIPTION
**Context:**

`queue_idx` is a private detail of CircuitGraph that seeped into the Operator interface that didn't need to be there. Now we are making it actually private to CircuitGraph.

**Description of the Change:**

`queue_idx` attribute has been removed from the `Operator`, `CompositeOp`, and `SymboliOp` classes.

**Benefits:**

Less convolute `Operator` classes (and children classes) and proper encapsulation of attribute.

**Related GitHub Issues:**

[#5907]

[sc-67435]