### PR TITLE
Bugfix: dynamic_one_shot is broken for old-API devices

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -126,6 +126,9 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* `dynamic_one_shot` was broken for old-API devices since `override_shots` was deprecated.
+  [(#6024)](https://github.com/PennyLaneAI/pennylane/pull/6024)
+
 * `CircuitGraph` can now handle circuits with the same operation instance occuring multiple times.
   [(#5907)](https://github.com/PennyLaneAI/pennylane/pull/5907)
 

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -283,7 +283,8 @@ class QubitDevice(Device):
                 shots=[1],
                 trainable_params=circuit.trainable_params,
             )
-            # Some devices like Lightning-Kokkos use `self.shots` to update `_samples`, and hence we update `self.shots` temporarily for this loop
+            # Some devices like Lightning-Kokkos use `self.shots` to update `_samples`,
+            # and hence we update `self.shots` temporarily for this loop
             shots_copy = self.shots
             self.shots = 1
             for _ in circuit.shots:

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -283,10 +283,14 @@ class QubitDevice(Device):
                 shots=[1],
                 trainable_params=circuit.trainable_params,
             )
+            # Some devices like Lightning-Kokkos use `self.shots` to update `_samples`, and hence we update `self.shots` temporarily for this loop
+            shots_copy = self.shots
+            self.shots = 1
             for _ in circuit.shots:
                 kwargs["mid_measurements"] = {}
                 self.reset()
                 results.append(self.execute(aux_circ, **kwargs))
+            self.shots = shots_copy
             return tuple(results)
         # apply all circuit operations
         self.apply(

--- a/pennylane/workflow/qnode.py
+++ b/pennylane/workflow/qnode.py
@@ -1095,7 +1095,6 @@ class QNode:
                 mcm_config=mcm_config,
                 interface=self.interface,
             )
-            override_shots = 1
         elif hasattr(self.device, "capabilities"):
             inner_transform_program.add_transform(
                 qml.defer_measurements,


### PR DESCRIPTION
…_shots is deprecated

### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      test directory!

- [x] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `doc/releases/changelog-dev.md` file, summarizing the
      change, and including a link back to the PR.

- [x] The PennyLane source code conforms to
      [PEP8 standards](https://www.python.org/dev/peps/pep-0008/).
      We check all of our code against [Pylint](https://www.pylint.org/).
      To lint modified files, simply `pip install pylint`, and then
      run `pylint pennylane/path/to/file.py`.

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
Some deprecation in #5984 causes [failures](https://github.com/PennyLaneAI/pennylane-lightning/actions/runs/10043598788/job/27756904942?pr=802#step:14:53) in the native MCM tests of Lightning-Kokkos.

**Description of the Change:**
Remove `override_shots=1` from the QNode logic and set both device/tape shots to `1` in the loop over shot vector in `QubitDevice`.

**Benefits:**
Lightning-Kokkos and other old-API devices can use `dynamic_one_shot`. 

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-69410]