### PR TITLE
Upgrade `fuse_rot_angles` to preserve derivatives and global phases

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -29,7 +29,7 @@
 <h3>Improvements 🛠</h3>
 
 * `fuse_rot_angles` respects now the global phase of the combined rotations.
-  [(#-___)](https://github.com/PennyLaneAI/pennylane/pull/-___)
+  [(#6031)](https://github.com/PennyLaneAI/pennylane/pull/6031)
 
 * `StateMP.process_state` defines rules in `cast_to_complex` for complex casting, avoiding a superfluous state vector copy in Lightning simulations
   [(#5995)](https://github.com/PennyLaneAI/pennylane/pull/5995)
@@ -128,7 +128,7 @@
 <h3>Bug fixes 🐛</h3>
 
 * `fuse_rot_angles` no longer returns wrong derivatives at singular points but returns NaN.
-  [(#____)](https://github.com/PennyLaneAI/pennylane/pull/____)
+  [(#6031)](https://github.com/PennyLaneAI/pennylane/pull/6031)
 
 * `CircuitGraph` can now handle circuits with the same operation instance occuring multiple times.
   [(#5907)](https://github.com/PennyLaneAI/pennylane/pull/5907)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -28,6 +28,9 @@
 
 <h3>Improvements 🛠</h3>
 
+* `fuse_rot_angles` respects now the global phase of the combined rotations.
+  [(#-___)](https://github.com/PennyLaneAI/pennylane/pull/-___)
+
 * `StateMP.process_state` defines rules in `cast_to_complex` for complex casting, avoiding a superfluous state vector copy in Lightning simulations
   [(#5995)](https://github.com/PennyLaneAI/pennylane/pull/5995)
 
@@ -124,6 +127,9 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* `fuse_rot_angles` no longer returns wrong derivatives at singular points but returns NaN.
+  [(#____)](https://github.com/PennyLaneAI/pennylane/pull/____)
+
 * `CircuitGraph` can now handle circuits with the same operation instance occuring multiple times.
   [(#5907)](https://github.com/PennyLaneAI/pennylane/pull/5907)
 
@@ -157,4 +163,5 @@ Christina Lee,
 William Maxwell,
 Vincent Michaud-Rioux,
 Mudit Pandey,
-Erik Schultheis.
+Erik Schultheis,
+David Wierichs.

--- a/pennylane/transforms/optimization/merge_rotations.py
+++ b/pennylane/transforms/optimization/merge_rotations.py
@@ -205,11 +205,11 @@ def merge_rotations(
                     current_gate.__class__(*cumulative_angles, wires=current_gate.wires)
                 )
         else:
-            if not allclose(cumulative_angles, zeros(len(cumulative_angles)), atol=atol, rtol=0):
-                with QueuingManager.stop_recording():
-                    new_operations.append(
-                        current_gate.__class__(*cumulative_angles, wires=current_gate.wires)
-                    )
+            # if not allclose(cumulative_angles, zeros(len(cumulative_angles)), atol=atol, rtol=0):
+            with QueuingManager.stop_recording():
+                new_operations.append(
+                    current_gate.__class__(*cumulative_angles, wires=current_gate.wires)
+                )
 
         # Remove the first gate from the working list
         list_copy.pop(0)

--- a/pennylane/transforms/optimization/optimization_utils.py
+++ b/pennylane/transforms/optimization/optimization_utils.py
@@ -13,13 +13,7 @@
 # limitations under the License.
 """Utility functions for circuit optimization."""
 # pylint: disable=too-many-return-statements,import-outside-toplevel
-from functools import partial
-
-import numpy as np
-
-from pennylane.math import abs as math_abs
-from pennylane.math import allclose, arccos, arctan2, cos, get_interface, is_abstract, sin, stack
-from pennylane.math import sum as math_sum
+from pennylane.math import arccos, arctan2, asarray, cos, sin, sqrt, stack
 from pennylane.ops.identity import GlobalPhase
 from pennylane.wires import Wires
 
@@ -47,109 +41,9 @@ def find_next_gate(wires, op_list):
     return next_gate_idx
 
 
-def _zyz_to_quat(angles):
-    """Converts a set of Euler angles in ZYZ format to a quaternion."""
-    qw = cos(angles[1] / 2) * cos(0.5 * (angles[0] + angles[2]))
-    qx = -sin(angles[1] / 2) * sin(0.5 * (angles[0] - angles[2]))
-    qy = sin(angles[1] / 2) * cos(0.5 * (angles[0] - angles[2]))
-    qz = cos(angles[1] / 2) * sin(0.5 * (angles[0] + angles[2]))
-
-    return stack([qw, qx, qy, qz])
-
-
-def _quaternion_product(q1, q2):
-    """Compute the product of two quaternions, q = q1 * q2."""
-    qw = q1[0] * q2[0] - q1[1] * q2[1] - q1[2] * q2[2] - q1[3] * q2[3]
-    qx = q1[0] * q2[1] + q1[1] * q2[0] + q1[2] * q2[3] - q1[3] * q2[2]
-    qy = q1[0] * q2[2] - q1[1] * q2[3] + q1[2] * q2[0] + q1[3] * q2[1]
-    qz = q1[0] * q2[3] + q1[1] * q2[2] - q1[2] * q2[1] + q1[3] * q2[0]
-
-    return stack([qw, qx, qy, qz])
-
-
-def _singular_quat_to_zyz(qw, qx, qy, qz, y_arg, abstract_jax=False):
-    """Compute the ZYZ angles for the singular case of qx = qy = 0"""
-    # pylint: disable=too-many-arguments
-    z1_arg1 = 2 * (qx * qy + qz * qw)
-    z1_arg2 = 1 - 2 * (qx**2 + qz**2)
-
-    if abstract_jax:
-        from jax.lax import cond
-
-        return cond(
-            y_arg > 0,
-            lambda z1_arg1, z1_arg2: stack([arctan2(z1_arg1, z1_arg2), 0.0, 0.0]),
-            lambda z1_arg1, z1_arg2: stack([-arctan2(z1_arg1, z1_arg2), np.pi, 0.0]),
-            z1_arg1,
-            z1_arg2,
-        )
-
-    if y_arg > 0:
-        z1 = arctan2(z1_arg1, z1_arg2)
-        y = z2 = 0.0
-    else:
-        z1 = -arctan2(z1_arg1, z1_arg2)
-        y = np.pi
-        z2 = 0.0
-    return stack([z1, y, z2])
-
-
-def _regular_quat_to_zyz(qw, qx, qy, qz, y_arg):
-    """Compute the ZYZ angles for the regular case (qx != 0 or qy != 0)"""
-    z1_arg1 = 2 * (qy * qz - qw * qx)
-    z1_arg2 = 2 * (qx * qz + qw * qy)
-    z1 = arctan2(z1_arg1, z1_arg2)
-
-    y = arccos(y_arg)
-
-    z2_arg1 = 2 * (qy * qz + qw * qx)
-    z2_arg2 = 2 * (qw * qy - qx * qz)
-    z2 = arctan2(z2_arg1, z2_arg2)
-
-    return stack([z1, y, z2])
-
-
-def _fuse(angles_1, angles_2, abstract_jax=False):
-    """Perform fusion of two angle sets. Separated out so we can do JIT with conditionals."""
-    # Compute the product of the quaternions
-    qw, qx, qy, qz = _quaternion_product(_zyz_to_quat(angles_1), _zyz_to_quat(angles_2))
-
-    # Convert the product back into the angles fed to Rot
-    y_arg = 1 - 2 * (qx**2 + qy**2)
-
-    # Require special treatment of the case qx = qy = 0. Note that we have to check
-    # for "greater than" as well, because of imprecisions
-    if abstract_jax:
-        from jax.lax import cond
-
-        return cond(
-            math_abs(y_arg) >= 1,
-            partial(_singular_quat_to_zyz, abstract_jax=True),
-            _regular_quat_to_zyz,
-            qw,
-            qx,
-            qy,
-            qz,
-            y_arg,
-        )
-
-    # Require special treatment of the case qx = qy = 0
-    if abs(y_arg) >= 1:  # Have to check for "greater than" as well, because of imprecisions
-        return _singular_quat_to_zyz(qw, qx, qy, qz, y_arg)
-    return _regular_quat_to_zyz(qw, qx, qy, qz, y_arg)
-
-
-def _no_fuse(angles_1, angles_2):
-    """Special case: do not perform fusion when both Y angles are zero:
-        Rot(a, 0, b) Rot(c, 0, d) = Rot(a + b + c + d, 0, 0)
-    The quaternion math itself will fail in this case without a conditional.
-    """
-    return stack([angles_1[0] + angles_1[2] + angles_2[0] + angles_2[2], 0.0, 0.0])
-
-
-def fuse_rot_angles(angles_1, angles_2):
-    """Computed the set of rotation angles that is obtained when composing
-    two ``qml.Rot`` operations.
+def fuse_rot_angles(angles1, angles2):
+    """Compute the set of rotation angles that is equivalent to performing
+    two successive ``qml.Rot`` operations.
 
     The ``qml.Rot`` operation represents the most general single-qubit operation.
     Two such operations can be fused into a new operation, however the angular dependence
@@ -162,31 +56,38 @@ def fuse_rot_angles(angles_1, angles_2):
     Returns:
         array[float]: Rotation angles for a single ``qml.Rot`` operation that
         implements the same operation as the two sets of input angles.
+
+    .. note::
+
+        The output angles are not always defined uniquely because Euler angles are not
+        defined uniquely for some rotations. ``fuse_rot_angles`` makes a particular
+        choice in this case.
+
+    .. warning::
+
+        This function is not differentiable everywhere. It has singularities for specific
+        input values, where the derivative will be ``nan``.
+
     """
+    phi1, theta1, omega1 = asarray(angles1).T
+    phi2, theta2, omega2 = asarray(angles2).T
+    c1, c2, s1, s2 = cos(theta1 / 2), cos(theta2 / 2), sin(theta1 / 2), sin(theta2 / 2)
 
-    # Check if we are tracing; if so, use the special conditionals
-    if is_abstract(angles_1) or is_abstract(angles_2):
-        interface = get_interface(angles_1, angles_2)
+    mag = sqrt(c1**2 * c2**2 + s1**2 * s2**2 - 2 * c1 * c2 * s1 * s2 * cos(omega1 + phi2))
+    theta_f = 2 * arccos(mag)
 
-        # TODO: implement something similar for torch and tensorflow interfaces
-        # If the interface is JAX, use jax.lax.cond so that we can jit even with conditionals
-        if interface == "jax":
-            from jax.lax import cond
+    alpha1, beta1 = (phi1 + omega1) / 2, (phi1 - omega1) / 2
+    alpha2, beta2 = (phi2 + omega2) / 2, (phi2 - omega2) / 2
 
-            return cond(
-                allclose(angles_1[1], 0.0) * allclose(angles_2[1], 0.0),
-                _no_fuse,
-                partial(_fuse, abstract_jax=True),
-                angles_1,
-                angles_2,
-            )
+    alpha_arg1 = -c1 * c2 * sin(alpha1 + alpha2) - s1 * s2 * sin(beta2 - beta1)
+    alpha_arg2 = c1 * c2 * cos(alpha1 + alpha2) - s1 * s2 * cos(beta2 - beta1)
+    alpha_f = -1 * arctan2(alpha_arg1, alpha_arg2)
 
-    # For other interfaces where we would not be jitting or tracing, we can simply check
-    # if we are dealing with the special case of Rot(a, 0, b) Rot(c, 0, d).
-    if allclose(angles_1[1], 0.0) and allclose(angles_2[1], 0.0):
-        return _no_fuse(angles_1, angles_2)
+    beta_arg1 = -c1 * s2 * sin(alpha1 + beta2) + s1 * c2 * sin(alpha2 - beta1)
+    beta_arg2 = c1 * s2 * cos(alpha1 + beta2) + s1 * c2 * cos(alpha2 - beta1)
+    beta_f = -1 * arctan2(beta_arg1, beta_arg2)
 
-    return _fuse(angles_1, angles_2)
+    return stack([alpha_f + beta_f, theta_f, alpha_f - beta_f], axis=-1)
 
 
 def _fuse_global_phases(operations):
@@ -206,5 +107,5 @@ def _fuse_global_phases(operations):
         else:
             fused_ops.append(op)
 
-    fused_ops.append(GlobalPhase(math_sum(op.data[0] for op in global_ops)))
+    fused_ops.append(GlobalPhase(sum(op.data[0] for op in global_ops)))
     return fused_ops

--- a/tests/transforms/test_optimization/test_optimization_utils.py
+++ b/tests/transforms/test_optimization/test_optimization_utils.py
@@ -16,17 +16,13 @@ Unit tests for utilities for optimization transforms.
 """
 # pylint: disable=too-few-public-methods
 
+from itertools import product
+
 import pytest
-from utils import check_matrix_equivalence
 
 import pennylane as qml
 from pennylane import numpy as np
-from pennylane.transforms.optimization.optimization_utils import (
-    _quaternion_product,
-    _zyz_to_quat,
-    find_next_gate,
-    fuse_rot_angles,
-)
+from pennylane.transforms.optimization.optimization_utils import find_next_gate, fuse_rot_angles
 
 sample_op_list = [
     qml.Hadamard(wires="a"),
@@ -57,42 +53,6 @@ class TestRotGateFusion:
     """Test that utility functions for fusing two qml.Rot gates function as expected."""
 
     @pytest.mark.parametrize(
-        ("angles", "expected_quat"),
-        # Examples generated at https://www.mathworks.com/help/robotics/ref/eul2quat.html
-        [
-            (
-                [0.15, 0.25, -0.90],
-                [0.923247491800509, -0.062488597726915, 0.107884031713695, -0.363414748929363],
-            ),
-            ([np.pi / 2, 0.0, 0.0], [1 / np.sqrt(2), 0.0, 0.0, 1 / np.sqrt(2)]),
-            ([0.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0]),
-            ([0.15, 0, -0.90], [0.930507621912314, 0.0, 0.0, -0.366272529086048]),
-            ([0.0, 0.2, 0.0], [0.995004165278026, 0.0, 0.099833416646828, 0.0]),
-        ],
-    )
-    def test_zyz_to_quat(self, angles, expected_quat):
-        """Test that ZYZ Euler angles are correctly converted to quaternions."""
-        obtained_quat = _zyz_to_quat(angles)
-        assert qml.math.allclose(obtained_quat, expected_quat)
-
-    @pytest.mark.parametrize(
-        ("angles_1", "angles_2", "expected_quat"),
-        # Examples generated at https://www.vcalc.com/wiki/vCalc/Quaternion+Multiplication
-        [
-            ([0.0, 0.0, 0.0, 0.0], [0.1, 0.2, 0.3, 0.4], [0.0, 0.0, 0.0, 0.0]),
-            ([1.0, 0.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0]),
-            ([1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0], [-60.0, 12.0, 30.0, 24.0]),
-            ([0.1, 0.0, -0.2, 0.15], [1.0, 0.05, 1.65, -0.25], [0.4675, -0.1925, -0.0275, 0.135]),
-            ([0.1, 0.0, 0.0, 0.15], [1.0, 0.0, 0.0, -0.25], [0.1375, 0.0, 0.0, 0.125]),
-        ],
-    )
-    def test_quaternion_product(self, angles_1, angles_2, expected_quat):
-        """Test that products of quaternions produce expected results."""
-        obtained_quat = _quaternion_product(angles_1, angles_2)
-        assert qml.math.allclose(obtained_quat, expected_quat)
-
-    @pytest.mark.autograd
-    @pytest.mark.parametrize(
         ("angles_1", "angles_2"),
         [
             ([0.15, 0.25, -0.90], [-0.5, 0.25, 1.3]),
@@ -117,7 +77,7 @@ class TestRotGateFusion:
             ([0.9, np.pi / 2, np.pi / 2], [-np.pi / 2, -np.pi / 2, 0.0]),
         ],
     )
-    def test_full_rot_fusion_autograd(self, angles_1, angles_2):
+    def test_full_rot_fusion(self, angles_1, angles_2):
         """Test that the fusion of two Rot gates has the same effect as
         applying the Rots sequentially."""
 
@@ -130,4 +90,134 @@ class TestRotGateFusion:
         fused_angles = fuse_rot_angles(angles_1, angles_2)
         matrix_obtained = qml.Rot(*fused_angles, wires=0).matrix()
 
-        assert check_matrix_equivalence(matrix_expected, matrix_obtained)
+        assert qml.math.allclose(matrix_expected, matrix_obtained)
+
+    @pytest.mark.slow
+    def test_full_rot_fusion_special_angles(self):
+        """Test the rotation angle fusion on special multiples of pi/2.
+        Also tests that fuse_rot_angles works with batching/broadcasting.
+        Do not change the test to non-broadcasted evaluation, as this will
+        increase the runtime significantly."""
+
+        special_points = np.array([3 / 2, 1, 1 / 2, 0, -1 / 2, -1, -3 / 2]) * np.pi
+        special_angles = np.array(list(product(special_points, repeat=6))).reshape((-1, 2, 3))
+        angles_1, angles_2 = np.transpose(special_angles, (1, 0, 2))
+
+        def original_ops():
+            qml.Rot(*angles_1.T, wires=0)  # Transpose to bring size-3 axis to front
+            qml.Rot(*angles_2.T, wires=0)  # Transpose to bring size-3 axis to front
+
+        matrix_expected = qml.matrix(original_ops, [0])()  # pylint:disable=too-many-function-args
+
+        fused_angles = fuse_rot_angles(angles_1, angles_2)
+        matrix_obtained = qml.Rot(
+            *fused_angles.T, wires=0
+        ).matrix()  # Transpose to bring size-3 axis to front
+
+        assert qml.math.allclose(matrix_expected, matrix_obtained)
+
+    @pytest.mark.slow
+    @pytest.mark.jax
+    def test_full_rot_fusion_jacobian(self):
+        """Test the Jacobian of the rotation angle fusion. Uses batching for performance reasons.
+        For known sources of singularities, the Jacobian is checked to indeed return NaN.
+        These sources are related to the absolute value of the upper left entry of the matrix product:
+         - If it is 1, the derivative of arccos becomes infinite (evaluated at 1), and
+         - if its square is 0, the derivative of sqrt becomes infinite (evaluated at 0).
+        """
+        import jax
+
+        special_points = np.array([3 / 2, 1, 1 / 2, 0, -1 / 2, -1, -3 / 2]) * np.pi
+        special_angles = np.array(list(product(special_points, repeat=6))).reshape((-1, 2, 3))
+        random_angles = np.random.random((1000, 2, 3))
+        all_angles = jax.numpy.concatenate([special_angles, random_angles], dtype=complex)
+
+        def mat_from_prod(angles):
+            def original_ops():
+                angles1, angles2 = angles[..., 0, :], angles[..., 1, :]
+                qml.Rot(angles1[..., 0], angles1[..., 1], angles1[..., 2], wires=0)
+                qml.Rot(angles2[..., 0], angles2[..., 1], angles2[..., 2], wires=0)
+
+            return qml.matrix(original_ops, [0])()  # pylint:disable=too-many-function-args
+
+        def mat_from_fuse(angles):
+            angles1, angles2 = angles[..., 0, :], angles[..., 1, :]
+            fused_angles = fuse_rot_angles(angles1, angles2)
+            return qml.Rot(*fused_angles.T, wires=0).matrix()
+
+        # Need holomorphic derivatives because the output matrices are complex-valued
+        jac_from_prod = jax.vmap(jax.jacobian(mat_from_prod, holomorphic=True))(all_angles)
+        jac_from_fuse = jax.vmap(jax.jacobian(mat_from_fuse, holomorphic=True))(all_angles)
+
+        # expected failures based on the sources mentioned in the docstring above.
+        thetas = all_angles[..., 1].T
+        (c1, c2), (s1, s2) = np.cos(thetas / 2), np.sin(thetas / 2)
+        omega1 = all_angles[:, 0, 2]
+        phi2 = all_angles[:, 1, 0]
+        # squared absolute value of the relevant entry of the product of the two rotation matrices
+        pre_mag = c1**2 * c2**2 + s1**2 * s2**2 - 2 * c1 * c2 * s1 * s2 * np.cos(omega1 + phi2)
+        # Compute condition for the two error sources combined
+        error_sources = (np.abs(pre_mag - 1) < 1e-12) + (pre_mag == 0j)
+
+        assert qml.math.allclose(jac_from_prod[~error_sources], jac_from_fuse[~error_sources])
+        assert qml.math.all(
+            qml.math.any(qml.math.isnan(jac_from_fuse[error_sources]), axis=[1, 2, 3, 4])
+        )
+
+        """
+        mag = np.sqrt(pre_mag)
+
+        alpha1, beta1 = (phi1 + omega1) / 2, (phi1 - omega1) / 2
+        alpha2, beta2 = (phi2 + omega2) / 2, (phi2 - omega2) / 2
+
+        alpha_arg1 = -c1 * c2 * np.sin(alpha1 + alpha2) - s1 * s2 * np.sin(beta2 - beta1)
+        alpha_arg2 = c1 * c2 * np.cos(alpha1 + alpha2) - s1 * s2 * np.cos(beta2 - beta1)
+        beta_arg1 = -c1 * s2 * np.sin(alpha1 + beta2) + s1 * c2 * np.sin(alpha2 - beta1)
+        beta_arg2 = c1 * s2 * np.cos(alpha1 + beta2) + s1 * c2 * np.cos(alpha2 - beta1)
+
+        def partial(all_angles):
+            phi1, theta1, omega1 = all_angles[..., 0, :].T
+            phi2, theta2, omega2 = all_angles[..., 1, :].T
+            c1, c2, s1, s2 = qml.math.cos(theta1 / 2), qml.math.cos(theta2 / 2), qml.math.sin(theta1 / 2), qml.math.sin(theta2 / 2)
+            mag = qml.math.sqrt(c1 ** 2 * c2 ** 2 + s1 ** 2 * s2 ** 2 - 2 * c1 * c2 * s1 * s2 * qml.math.cos(omega1 + phi2))
+
+            #alpha1, beta1 = (phi1 + omega1) / 2, (phi1 - omega1) / 2
+            #alpha2, beta2 = (phi2 + omega2) / 2, (phi2 - omega2) / 2
+
+            #alpha_arg1 = -c1 * c2 * np.sin(alpha1 + alpha2) - s1 * s2 * np.sin(beta2 - beta1)
+            #alpha_arg2 = c1 * c2 * np.cos(alpha1 + alpha2) - s1 * s2 * np.cos(beta2 - beta1)
+            #beta_arg1 = -c1 * s2 * np.sin(alpha1 + beta2) + s1 * c2 * np.sin(alpha2 - beta1)
+            #beta_arg2 = c1 * s2 * np.cos(alpha1 + beta2) + s1 * c2 * np.cos(alpha2 - beta1)
+            #print(mag)
+            return mag
+
+        jac_partial = jax.vmap(jax.jacobian(partial))(all_angles.real)
+
+        expected_singular_ids = np.where(
+            np.any([
+                (np.abs(pre_mag - 1) < 1e-12),
+                (pre_mag == 0j),
+                #np.isnan(mag),
+                #(np.abs(alpha_arg1) + np.abs(alpha_arg1) < 1e-10),
+                #(np.abs(beta_arg1) + np.abs(beta_arg1) < 1e-10)
+            ], axis=0)
+        )
+        pre_mag2 = c1 ** 2 * s2 ** 2 + s1 ** 2 * c2 ** 2 + 2 * c1 * c2 * s1 * s2 * qml.math.cos(omega1 + phi2)
+        print(pre_mag2[np.where(pre_mag==0j)[0]])
+        for idx in np.where(qml.math.any(qml.math.isnan(jac_from_fuse), axis=[1, 2, 3, 4]))[0]:
+            if idx not in expected_singular_ids[0]:
+                weird_idx = idx
+                break
+        print(weird_idx)
+        print(jac_from_fuse[weird_idx])
+        print(all_angles[weird_idx])
+        print(f"{pre_mag[weird_idx]:.20f}")
+        print(jax.jacobian(qml.math.sqrt,holomorphic=True)(pre_mag[weird_idx]))
+        print(jax.jacobian(qml.math.sqrt)(pre_mag.real[weird_idx]))
+        print(len(all_angles))
+        print(len(expected_singular_ids[0]))
+        print(len(np.where(qml.math.any(qml.math.isnan(jac_from_fuse), axis=[1, 2, 3, 4]))[0]))
+        print(jac_partial.shape)
+        print(len(np.where(qml.math.any(qml.math.isnan(jac_partial), axis=[1, 2]))[0]))
+        print(np.unique(mag[np.array(np.where(qml.math.any(qml.math.isnan(jac_partial), axis=[1, 2]))[0])]))
+        """


### PR DESCRIPTION
**Context:**
The current implementation of `fuse_rot_angles`, which is used by `merge_rotations` and `single_qubit_fusion`, has two issues:
1. It does not necessarily preserve global phases. As we move towards global-phase aware standards, this becomes an issue where it wasn't one before.
2. Its derivative is wrong, forming part (but not all) of the bug #5715. In particular, the custom handling of special input values prevents the calculation of correct derivatives, and `fuse_rot_angles` at singular points leads to wrong derivatives, rather than NaN values, which are mathematically well-motivated.
3. A minor technical issue is that the implementation requires nested conditionals, leading to a good bit of code and separate handling of traced JAX code, making it more complex.

**Description of the Change:**
The implementation of `fuse_rot_angles` is remade entirely. 

**Benefits:**
The remade code uses a comparably simple mathematical expression to compute the fused rotation angles that
1. preserves global phases
2. has the correct derivative everywhere except for well-understandable, predictable singular points. These singular points make sense because rotation fusion is not a smooth map everywhere. The predictability allowed us to write a dedicated test that confirms our understanding of the singularities, at least within a large set of special test points.
3. does not require conditionals beyond those that are implemented in `qml.math.arctan2` anyways, and thus available in all ML interfaces, including JAX with JIT-compatibility.

In summary, the global phases are fixed, Jacobians are only ever NaNs, rather than wrong, and Jacobians are only NaNs when they were NaN or wrong in the current implementation.

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
#5715 (not fixed entirely, just partially)
