### PR TITLE
Mark test_mixed_legacy_warning_Hamiltonian as new opmath only

### DIFF
--- a/tests/ops/op_math/test_linear_combination.py
+++ b/tests/ops/op_math/test_linear_combination.py
@@ -53,6 +53,7 @@ class TestParityWithHamiltonian:
         assert isinstance(H, qml.Hamiltonian)
 
 
+@pytest.mark.usefixtures("new_opmath_only")
 def test_mixed_legacy_warning_Hamiltonian():
     """Test that mixing legacy ops and LinearCombination.compare raises a warning"""
     op1 = qml.ops.LinearCombination([0.5, 0.5], [X(0) @ X(1), qml.Hadamard(0)])

--- a/tests/ops/op_math/test_linear_combination.py
+++ b/tests/ops/op_math/test_linear_combination.py
@@ -70,6 +70,19 @@ def test_mixed_legacy_warning_Hamiltonian():
     assert res
 
 
+@pytest.mark.usefixtures("legacy_opmath_only")
+def test_mixed_legacy_warning_Hamiltonian_legacy():
+    """Test that mixing legacy ops and LinearCombination.compare raises a warning in legacy opmath"""
+
+    op1 = qml.ops.LinearCombination([0.5, 0.5], [X(0) @ X(1), qml.Hadamard(0)])
+    op2 = qml.ops.Hamiltonian([0.5, 0.5], [qml.operation.Tensor(X(0), X(1)), qml.Hadamard(0)])
+
+    with pytest.warns(UserWarning, match="Attempting to compare a legacy operator class instance"):
+        res = op1.compare(op2)
+
+    assert res
+
+
 def test_mixed_legacy_warning_Tensor():
     """Test that mixing legacy ops and LinearCombination.compare raises a warning"""
     op1 = qml.ops.LinearCombination([1.0], [X(0) @ qml.Hadamard(1)])


### PR DESCRIPTION
This test case explicitly tests behaviour with new opmath enabled.