### PR TITLE
Update links in `qml.QNode` docstring

### DIFF
--- a/pennylane/devices/qubit/simulate.py
+++ b/pennylane/devices/qubit/simulate.py
@@ -291,7 +291,7 @@ def simulate(
             ``"deferred"`` is ignored. If mid-circuit measurements are found in the circuit,
             the device will use ``"tree-traversal"`` if specified and the ``"one-shot"`` method
             otherwise. For usage details, please refer to the
-            :doc:`main measurements page </introduction/measurements>`.
+            :doc:`dynamic quantum circuits page </introduction/dynamic_quantum_circuits>`.
 
     Returns:
         tuple(TensorLike): The results of the simulation

--- a/pennylane/workflow/qnode.py
+++ b/pennylane/workflow/qnode.py
@@ -223,14 +223,14 @@ class QNode:
             ``"hw-like"``, invalid shots will be discarded and only results for valid shots will be returned.
             If ``"fill-shots"``, results corresponding to the original number of shots will be returned. The
             default is ``None``, in which case the device will automatically choose the best configuration. For
-            usage details, please refer to the :doc:`main measurements page </introduction/dynamic_quantum_circuit.html#configuring-mid-circuit-measurements>`.
+            usage details, please refer to the :doc:`dynamic quantum circuits page </introduction/dynamic_quantum_circuit>`.
         mcm_method (str): Strategy to use when executing circuits with mid-circuit measurements. Use ``"deferred"``
             to apply the deferred measurements principle (using the :func:`~pennylane.defer_measurements` transform),
             or ``"one-shot"`` if using finite shots to execute the circuit for each shot separately.
             ``default.qubit`` also supports ``"tree-traversal"`` which visits the tree of possible MCM sequences
             as the name suggests. If not provided,
             the device will determine the best choice automatically. For usage details, please refer to the
-            :doc:`main measurements page </introduction/dynamic_quantum_circuits.html#configuring-mid-circuit-measurements>`.
+            :doc:`dynamic quantum circuits page </introduction/dynamic_quantum_circuits>`.
 
     Keyword Args:
         **kwargs: Any additional keyword arguments provided are passed to the differentiation

--- a/pennylane/workflow/qnode.py
+++ b/pennylane/workflow/qnode.py
@@ -108,7 +108,7 @@ class QNode:
     r"""Represents a quantum node in the hybrid computational graph.
 
     A *quantum node* contains a :ref:`quantum function <intro_vcirc_qfunc>` (corresponding to
-    a `variational circuit <https://pennylane.ai/qml/glossary/variational_circuit>`)
+    a `variational circuit <https://pennylane.ai/qml/glossary/variational_circuit>`)__
     and the computational device it is executed on.
 
     The QNode calls the quantum function to construct a :class:`~.QuantumTape` instance representing

--- a/pennylane/workflow/qnode.py
+++ b/pennylane/workflow/qnode.py
@@ -223,14 +223,14 @@ class QNode:
             ``"hw-like"``, invalid shots will be discarded and only results for valid shots will be returned.
             If ``"fill-shots"``, results corresponding to the original number of shots will be returned. The
             default is ``None``, in which case the device will automatically choose the best configuration. For
-            usage details, please refer to the :doc:`main measurements page </introduction/measurements>`.
+            usage details, please refer to the :doc:`main measurements page </introduction/dynamic_quantum_circuits#configuring-mid-circuit-measurements>`.
         mcm_method (str): Strategy to use when executing circuits with mid-circuit measurements. Use ``"deferred"``
             to apply the deferred measurements principle (using the :func:`~pennylane.defer_measurements` transform),
             or ``"one-shot"`` if using finite shots to execute the circuit for each shot separately.
             ``default.qubit`` also supports ``"tree-traversal"`` which visits the tree of possible MCM sequences
             as the name suggests. If not provided,
             the device will determine the best choice automatically. For usage details, please refer to the
-            :doc:`main measurements page </introduction/measurements>`.
+            :doc:`main measurements page </introduction/dynamic_quantum_circuits#configuring-mid-circuit-measurements>`.
 
     Keyword Args:
         **kwargs: Any additional keyword arguments provided are passed to the differentiation

--- a/pennylane/workflow/qnode.py
+++ b/pennylane/workflow/qnode.py
@@ -223,14 +223,14 @@ class QNode:
             ``"hw-like"``, invalid shots will be discarded and only results for valid shots will be returned.
             If ``"fill-shots"``, results corresponding to the original number of shots will be returned. The
             default is ``None``, in which case the device will automatically choose the best configuration. For
-            usage details, please refer to the :doc:`main measurements page </introduction/dynamic_quantum_circuits#configuring-mid-circuit-measurements>`.
+            usage details, please refer to the :doc:`main measurements page </introduction/dynamic_quantum_circuit.html#configuring-mid-circuit-measurements>`.
         mcm_method (str): Strategy to use when executing circuits with mid-circuit measurements. Use ``"deferred"``
             to apply the deferred measurements principle (using the :func:`~pennylane.defer_measurements` transform),
             or ``"one-shot"`` if using finite shots to execute the circuit for each shot separately.
             ``default.qubit`` also supports ``"tree-traversal"`` which visits the tree of possible MCM sequences
             as the name suggests. If not provided,
             the device will determine the best choice automatically. For usage details, please refer to the
-            :doc:`main measurements page </introduction/dynamic_quantum_circuits#configuring-mid-circuit-measurements>`.
+            :doc:`main measurements page </introduction/dynamic_quantum_circuits.html#configuring-mid-circuit-measurements>`.
 
     Keyword Args:
         **kwargs: Any additional keyword arguments provided are passed to the differentiation

--- a/pennylane/workflow/qnode.py
+++ b/pennylane/workflow/qnode.py
@@ -223,7 +223,7 @@ class QNode:
             ``"hw-like"``, invalid shots will be discarded and only results for valid shots will be returned.
             If ``"fill-shots"``, results corresponding to the original number of shots will be returned. The
             default is ``None``, in which case the device will automatically choose the best configuration. For
-            usage details, please refer to the :doc:`dynamic quantum circuits page </introduction/dynamic_quantum_circuit>`.
+            usage details, please refer to the :doc:`dynamic quantum circuits page </introduction/dynamic_quantum_circuits>`.
         mcm_method (str): Strategy to use when executing circuits with mid-circuit measurements. Use ``"deferred"``
             to apply the deferred measurements principle (using the :func:`~pennylane.defer_measurements` transform),
             or ``"one-shot"`` if using finite shots to execute the circuit for each shot separately.


### PR DESCRIPTION
Update qml.QNode documentation "main measurements page" links to point to Dynamic quantum circuits page.

**Context:**
- From slack message in #pennylane-oss-qa channel: https://xanaduhq.slack.com/archives/C0743CNS9E3/p1722451700797329.
- links for `main measurement page` in `mcm_method` and `postselect_mode` are inaccurate and should link to Dynamic quantum circuits page instead (https://docs.pennylane.ai/en/stable/introduction/dynamic_quantum_circuits.html#configuring-mid-circuit-measurements)

**Description of the Change:**
- Update "main measurements page" links in `mcm_method` and `postselect_mode` to point to Dynamic quantum circuits page (https://docs.pennylane.ai/en/stable/introduction/dynamic_quantum_circuits.html#configuring-mid-circuit-measurements)

**Benefits:**
- Users can get real usage details for those parameters

**Possible Drawbacks:**
N/A
**Related GitHub Issues:**
N/A