### PR TITLE
Fix capture of `GlobalPhase` and `Identity` when they act on no wires

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -236,6 +236,8 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* `qml.GlobalPhase` and `qml.I` can now be captured when acting on no wires.
+
 * Fix `jax.grad` + `jax.jit` not working for `AmplitudeEmbedding`, `StatePrep` and `MottonenStatePreparation`.
   [(#5620)](https://github.com/PennyLaneAI/pennylane/pull/5620) 
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -237,6 +237,7 @@
 <h3>Bug fixes 🐛</h3>
 
 * `qml.GlobalPhase` and `qml.I` can now be captured when acting on no wires.
+  [(#6060)](https://github.com/PennyLaneAI/pennylane/pull/6060)
 
 * Fix `jax.grad` + `jax.jit` not working for `AmplitudeEmbedding`, `StatePrep` and `MottonenStatePreparation`.
   [(#5620)](https://github.com/PennyLaneAI/pennylane/pull/5620) 

--- a/pennylane/capture/primitives.py
+++ b/pennylane/capture/primitives.py
@@ -190,10 +190,11 @@ def create_operator_primitive(
             return type.__call__(operator_type, *args, **kwargs)
         n_wires = kwargs.pop("n_wires")
 
+        split = None if n_wires == 0 else -n_wires
         # need to convert array values into integers
         # for plxpr, all wires must be integers
-        wires = tuple(int(w) for w in args[-n_wires:])
-        args = args[:-n_wires]
+        wires = tuple(int(w) for w in args[split:])
+        args = args[:split]
         return type.__call__(operator_type, *args, wires=wires, **kwargs)
 
     abstract_type = _get_abstract_operator()

--- a/pennylane/ops/identity.py
+++ b/pennylane/ops/identity.py
@@ -60,6 +60,11 @@ class Identity(CVObservable, Operation):
 
     ev_order = 1
 
+    @classmethod
+    def _primitive_bind_call(cls, wires=None, **kwargs):  # pylint: disable=arguments-differ
+        wires = [] if wires is None else wires
+        return super()._primitive_bind_call(wires=wires, **kwargs)
+
     def _flatten(self):
         return tuple(), (self.wires, tuple())
 
@@ -299,6 +304,11 @@ class GlobalPhase(Operation):
     """tuple[int]: Number of dimensions per trainable parameter that the operator depends on."""
 
     grad_method = None
+
+    @classmethod
+    def _primitive_bind_call(cls, phi, wires=None, **kwargs):  # pylint: disable=arguments-differ
+        wires = [] if wires is None else wires
+        return super()._primitive_bind_call(phi, wires=wires, **kwargs)
 
     def __init__(self, phi, wires=None, id=None):
         super().__init__(phi, wires=[] if wires is None else wires, id=id)

--- a/tests/capture/test_operators.py
+++ b/tests/capture/test_operators.py
@@ -193,27 +193,64 @@ def test_parametrized_op():
     qml.assert_equal(q.queue[0], qml.Rot(1.0, 2.0, 3.0, 10))
 
 
-def test_pauli_rot():
-    """Test a special operation that has positional metadata and overrides binding."""
+class TestSpecialOps:
 
-    def qfunc(a, wire0, wire1):
-        qml.PauliRot(a, "XY", (wire0, wire1))
+    def test_pauli_rot(self):
+        """Test a special operation that has positional metadata and overrides binding."""
 
-    jaxpr = jax.make_jaxpr(qfunc)(0.5, 2, 3)
-    assert len(jaxpr.eqns) == 1
-    eqn = jaxpr.eqns[0]
+        def qfunc(a, wire0, wire1):
+            qml.PauliRot(a, "XY", (wire0, wire1))
 
-    assert eqn.primitive == qml.PauliRot._primitive
-    assert eqn.params == {"pauli_word": "XY", "id": None, "n_wires": 2}
+        jaxpr = jax.make_jaxpr(qfunc)(0.5, 2, 3)
+        assert len(jaxpr.eqns) == 1
+        eqn = jaxpr.eqns[0]
 
-    assert len(eqn.invars) == 3  # The rotation parameter and the two wires
-    assert jaxpr.jaxpr.invars == eqn.invars
+        assert eqn.primitive == qml.PauliRot._primitive
+        assert eqn.params == {"pauli_word": "XY", "id": None, "n_wires": 2}
 
-    with qml.queuing.AnnotatedQueue() as q:
-        jax.core.eval_jaxpr(jaxpr.jaxpr, jaxpr.consts, 2.5, 3, 4)
+        assert len(eqn.invars) == 3  # The rotation parameter and the two wires
+        assert jaxpr.jaxpr.invars == eqn.invars
 
-    assert len(q) == 1
-    qml.assert_equal(q.queue[0], qml.PauliRot(2.5, "XY", (3, 4)))
+        with qml.queuing.AnnotatedQueue() as q:
+            jax.core.eval_jaxpr(jaxpr.jaxpr, jaxpr.consts, 2.5, 3, 4)
+
+        assert len(q) == 1
+        qml.assert_equal(q.queue[0], qml.PauliRot(2.5, "XY", (3, 4)))
+
+    def test_GlobalPhase(self):
+        """Test that a global phase on no wires can be captured."""
+
+        def qfunc(phi):
+            return qml.GlobalPhase(phi)
+
+        jaxpr = jax.make_jaxpr(qfunc)(0.5)
+        assert len(jaxpr.eqns) == 1
+
+        assert jaxpr.eqns[0].primitive == qml.GlobalPhase._primitive
+        assert len(jaxpr.eqns[0].invars) == 1
+        assert jaxpr.eqns[0].params == {"n_wires": 0}
+
+        with qml.queuing.AnnotatedQueue() as q:
+            jax.core.eval_jaxpr(jaxpr.jaxpr, jaxpr.consts, 1.2)
+
+        assert len(q.queue) == 1
+        qml.assert_equal(q.queue[0], qml.GlobalPhase(1.2))
+
+    def test_identity_no_wires(self):
+        """Test that an identity on no wires can be captured."""
+
+        jaxpr = jax.make_jaxpr(qml.I)()
+        assert len(jaxpr.eqns) == 1
+
+        assert jaxpr.eqns[0].primitive == qml.I._primitive
+        assert len(jaxpr.eqns[0].invars) == 0
+        assert jaxpr.eqns[0].params == {"n_wires": 0}
+
+        with qml.queuing.AnnotatedQueue() as q:
+            jax.core.eval_jaxpr(jaxpr.jaxpr, jaxpr.consts)
+
+        assert len(q.queue) == 1
+        qml.assert_equal(q.queue[0], qml.I())
 
 
 class TestTemplates:


### PR DESCRIPTION
**Context:**

When writing tests for [(#837)](https://github.com/PennyLaneAI/catalyst/pull/837), I found we weren't capturing `Identity` and `GlobalPhase` when they act on zero wires correctly.

**Description of the Change:**

Fix the capture of `GlobalPhase` and `Identity` when they act on no wires.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**

[sc-70350]