### PR TITLE
[Closes #6047] Implements custom `compute_decomposition` method in `Hermitian`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -52,7 +52,7 @@
 * Removed `semantic_version` from the list of required packages in PennyLane. 
   [(#5836)](https://github.com/PennyLaneAI/pennylane/pull/5836)
 
-* Added the `compute_decomposition` method for `qml.ops.qubit.Hermitian`.
+* Added the `compute_decomposition` method for `qml.Hermitian`.
   [(#6062)](https://github.com/PennyLaneAI/pennylane/pull/6062)
 
 * During experimental program capture, the qnode can now use closure variables.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -44,7 +44,7 @@
 <h3>Improvements 🛠</h3>
 
 * Added the `compute_decomposition` method for `qml.ops.qubit.Hermitian`.
-  [(#6047)](https://github.com/PennyLaneAI/pennylane/pull/6047)
+  [(#6062)](https://github.com/PennyLaneAI/pennylane/pull/6062)
 
 * During experimental program capture, the qnode can now use closure variables.
   [(#6052)](https://github.com/PennyLaneAI/pennylane/pull/6052)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -43,6 +43,9 @@
 
 <h3>Improvements 🛠</h3>
 
+* Added the `compute_decomposition` method for `qml.ops.qubit.Hermitian`.
+  [(#6047)](https://github.com/PennyLaneAI/pennylane/pull/6047)
+
 * During experimental program capture, the qnode can now use closure variables.
   [(#6052)](https://github.com/PennyLaneAI/pennylane/pull/6052)
 
@@ -288,6 +291,7 @@ William Maxwell,
 Vincent Michaud-Rioux,
 Anurav Modak,
 Mudit Pandey,
+Andrija Paurevic,
 Erik Schultheis,
 nate stemen,
 David Wierichs,

--- a/pennylane/ops/qubit/observables.py
+++ b/pennylane/ops/qubit/observables.py
@@ -170,7 +170,7 @@ class Hermitian(Observable):
             A (array or Sequence): hermitian matrix
             wires (Iterable[Any], Wires): wires that the operator acts on
         Returns:
-            list[.Operator]: Hermitian matrix decomposition as a linear combination of Pauli operators.
+            .PauliSentence: Hermitian matrix decomposition as a linear combination of Pauli operators.
             Returned as :class:`~.PauliSentence` class instance.
 
         **Examples**
@@ -188,18 +188,15 @@ class Hermitian(Observable):
 
         """
         A = qml.math.asarray(A)
-        Hermitian._validate_input(A)
-        A_DIMENSION = A.shape[0]
+        A_SHAPE = qml.math.shape(A)
+        A_DIMENSION = A_SHAPE[0]
 
         if isinstance(wires, (int, str)):
             wires = Wires(wires)
 
         if len(wires) == 0:
             raise ValueError("Hermitian: wrong number of wires. At least one wire has to be given.")
-        if len(wires) != int(np.log2(A_DIMENSION)):
-            raise ValueError(
-                f"Hermitian: wrong number of wires. Expected wires of length {int(np.log2(A_DIMENSION))}, but received {len(wires)}."
-            )
+        Hermitian._validate_input(A, expected_mx_shape=2 ** len(wires))
 
         MAX_DIMENSION = (
             256  # determined heuristically from test_hermitian_decomposition_performance

--- a/pennylane/ops/qubit/observables.py
+++ b/pennylane/ops/qubit/observables.py
@@ -170,21 +170,20 @@ class Hermitian(Observable):
             A (array or Sequence): hermitian matrix
             wires (Iterable[Any], Wires): wires that the operator acts on
         Returns:
-            .PauliSentence: Hermitian matrix decomposition as a linear combination of Pauli operators.
-            Returned as :class:`~.PauliSentence` class instance.
+            list[.PauliSentence]: decomposition of the hermitian matrix
 
         **Examples**
 
         >>> op = qml.X(0) + qml.Y(1) + 2 * qml.X(0) @ qml.Z(3)
         >>> op_matrix = qml.matrix(op)
         >>> qml.Hermitian.compute_decomposition(op_matrix, wires=['a', 'b', 'aux'])
-        1.0 * Y(b)
+        [1.0 * Y(b)
         + 1.0 * X(a)
-        + 2.0 * X(a) @ Z(aux)
+        + 2.0 * X(a) @ Z(aux)]
         >>> op = np.array([[1, 1], [1, -1]]) / np.sqrt(2)
         >>> qml.Hermitian.compute_decomposition(op, wires=0)
-        0.7071067811865475 * X(0)
-        + 0.7071067811865475 * Z(0)
+        [0.7071067811865475 * X(0)
+        + 0.7071067811865475 * Z(0)]
 
         """
         A = qml.math.asarray(A)
@@ -207,7 +206,7 @@ class Hermitian(Observable):
                 UserWarning,
             )
 
-        return qml.pauli.conversion.pauli_decompose(A, wire_order=wires, pauli=True)
+        return [qml.pauli.conversion.pauli_decompose(A, wire_order=wires, pauli=True)]
 
     @staticmethod
     def compute_diagonalizing_gates(eigenvectors, wires):  # pylint: disable=arguments-differ

--- a/pennylane/ops/qubit/observables.py
+++ b/pennylane/ops/qubit/observables.py
@@ -170,7 +170,8 @@ class Hermitian(Observable):
             A (array or Sequence): hermitian matrix
             wires (Iterable[Any], Wires): wires that the operator acts on
         Returns:
-            ~.PauliSentence: hermitian matrix decomposed as a linear combination of Pauli operators
+            list[.Operator]: Hermitian matrix decomposition as a linear combination of Pauli operators.
+            Returned as :class:`~.PauliSentence` class instance.
 
         **Examples**
 
@@ -180,7 +181,6 @@ class Hermitian(Observable):
         1.0 * Y(b)
         + 1.0 * X(a)
         + 2.0 * X(a) @ Z(aux)
-
         >>> op = np.array([[1, 1], [1, -1]]) / np.sqrt(2)
         >>> op_matrix = qml.matrix(op)
         >>> qml.Hermitian.compute_decomposition(op_matrix, wires=0)

--- a/pennylane/ops/qubit/observables.py
+++ b/pennylane/ops/qubit/observables.py
@@ -182,8 +182,7 @@ class Hermitian(Observable):
         + 1.0 * X(a)
         + 2.0 * X(a) @ Z(aux)
         >>> op = np.array([[1, 1], [1, -1]]) / np.sqrt(2)
-        >>> op_matrix = qml.matrix(op)
-        >>> qml.Hermitian.compute_decomposition(op_matrix, wires=0)
+        >>> qml.Hermitian.compute_decomposition(op, wires=0)
         0.7071067811865475 * X(0)
         + 0.7071067811865475 * Z(0)
 

--- a/tests/ops/functions/conftest.py
+++ b/tests/ops/functions/conftest.py
@@ -82,10 +82,6 @@ _INSTANCES_TO_FAIL = [
         (AssertionError, ValueError),  # qutrit ops fail validation
     ),
     (
-        qml.Hermitian(np.eye(2), wires=0),
-        ValueError,  # cannot map wires of decomposition type PauliSentence
-    ),
-    (
         qml.ops.qubit.special_unitary.TmpPauliRot(1.1, "X", [0]),
         AssertionError,  # private type with has_matrix=False despite having one
     ),

--- a/tests/ops/functions/conftest.py
+++ b/tests/ops/functions/conftest.py
@@ -79,7 +79,11 @@ _INSTANCES_TO_FAIL = [
     ),
     (
         qml.THermitian(np.eye(3), wires=0),
-        AssertionError,  # qutrit ops fail validation
+        (AssertionError, ValueError),  # qutrit ops fail validation
+    ),
+    (
+        qml.Hermitian(np.eye(2), wires=0),
+        ValueError,  # cannot map wires of decomposition type PauliSentence
     ),
     (
         qml.ops.qubit.special_unitary.TmpPauliRot(1.1, "X", [0]),

--- a/tests/ops/qubit/test_observables.py
+++ b/tests/ops/qubit/test_observables.py
@@ -315,10 +315,10 @@ class TestHermitian:  # pylint: disable-msg=too-many-public-methods
             qml.Hermitian.compute_decomposition(single_wire_observable, wires=[])
 
         # test wrong number of wires
-        with pytest.raises(ValueError, match="wrong number of wires"):
+        with pytest.raises(ValueError, match="Expected input matrix to have shape"):
             qml.Hermitian.compute_decomposition(double_wire_observable, wires=[0, 1, 2])
 
-        with pytest.raises(ValueError, match="wrong number of wires"):
+        with pytest.raises(ValueError, match="Expected input matrix to have shape"):
             qml.Hermitian.compute_decomposition(double_wire_observable, wires="aux")
 
         # test int as wire type

--- a/tests/ops/qubit/test_observables.py
+++ b/tests/ops/qubit/test_observables.py
@@ -323,11 +323,11 @@ class TestHermitian:  # pylint: disable-msg=too-many-public-methods
 
         # test int as wire type
         A_decomp = qml.Hermitian.compute_decomposition(single_wire_observable, wires=0)
-        assert np.allclose(A_decomp.to_mat(), single_wire_observable, rtol=0)
+        assert np.allclose(A_decomp[0].to_mat(), single_wire_observable, rtol=0)
 
         # test str as wire type
         A_decomp = qml.Hermitian.compute_decomposition(single_wire_observable, wires="aux")
-        assert np.allclose(A_decomp.to_mat(), single_wire_observable, rtol=0)
+        assert np.allclose(A_decomp[0].to_mat(), single_wire_observable, rtol=0)
 
     def test_hermitian_compute_decomposition_inefficiency_warning(self):
         """Tests user inefficiency warning associated with large matrix decomposition"""
@@ -357,14 +357,14 @@ class TestHermitian:  # pylint: disable-msg=too-many-public-methods
         A = qml.Hermitian(observable, wires=[0])
         A_decomp = A.decomposition()
 
-        assert np.allclose(A_decomp.to_mat(), observable, rtol=0)
+        assert np.allclose(A_decomp[0].to_mat(), observable, rtol=0)
 
     def test_hermitian_compute_decomposition(self):
         """Tests that the compute_decomposition method of the Hermitian class returns the correct result."""
         observable = np.array([[1, 1], [1, -1]]) / np.sqrt(2)
         A_decomp = qml.Hermitian.compute_decomposition(observable, wires=[0])
 
-        assert np.allclose(A_decomp.to_mat(), observable, rtol=0)
+        assert np.allclose(A_decomp[0].to_mat(), observable, rtol=0)
 
     @pytest.mark.parametrize("observable, eigvals, eigvecs", EIGVALS_TEST_DATA)
     def test_hermitian_diagonalizing_gates(self, observable, eigvals, eigvecs, tol, mocker):

--- a/tests/ops/qubit/test_observables.py
+++ b/tests/ops/qubit/test_observables.py
@@ -323,11 +323,11 @@ class TestHermitian:  # pylint: disable-msg=too-many-public-methods
 
         # test int as wire type
         A_decomp = qml.Hermitian.compute_decomposition(single_wire_observable, wires=0)
-        assert np.allclose(A_decomp[0].to_mat(), single_wire_observable, rtol=0)
+        assert np.allclose(A_decomp[0].matrix(), single_wire_observable, rtol=0)
 
         # test str as wire type
         A_decomp = qml.Hermitian.compute_decomposition(single_wire_observable, wires="aux")
-        assert np.allclose(A_decomp[0].to_mat(), single_wire_observable, rtol=0)
+        assert np.allclose(A_decomp[0].matrix(), single_wire_observable, rtol=0)
 
     def test_hermitian_compute_decomposition_inefficiency_warning(self):
         """Tests user inefficiency warning associated with large matrix decomposition"""
@@ -357,14 +357,14 @@ class TestHermitian:  # pylint: disable-msg=too-many-public-methods
         A = qml.Hermitian(observable, wires=[0])
         A_decomp = A.decomposition()
 
-        assert np.allclose(A_decomp[0].to_mat(), observable, rtol=0)
+        assert np.allclose(A_decomp[0].matrix(), observable, rtol=0)
 
     def test_hermitian_compute_decomposition(self):
         """Tests that the compute_decomposition method of the Hermitian class returns the correct result."""
         observable = np.array([[1, 1], [1, -1]]) / np.sqrt(2)
         A_decomp = qml.Hermitian.compute_decomposition(observable, wires=[0])
 
-        assert np.allclose(A_decomp[0].to_mat(), observable, rtol=0)
+        assert np.allclose(A_decomp[0].matrix(), observable, rtol=0)
 
     @pytest.mark.parametrize("observable, eigvals, eigvecs", EIGVALS_TEST_DATA)
     def test_hermitian_diagonalizing_gates(self, observable, eigvals, eigvecs, tol, mocker):

--- a/tests/ops/qubit/test_observables.py
+++ b/tests/ops/qubit/test_observables.py
@@ -361,11 +361,15 @@ class TestHermitian:  # pylint: disable=too-many-public-methods
         )
 
     @pytest.mark.parametrize("observable", DECOMPOSITION_TEST_DATA_MULTI_WIRES)
-    def test_hermitian_compute_decomposition(self, observable):
+    def test_hermitian_decomposition(self, observable):
         """Tests that the compute_decomposition method of the Hermitian class returns the correct result."""
         num_wires = int(np.log2(len(observable)))
-        A_decomp = qml.Hermitian.compute_decomposition(observable, wires=list(range(num_wires)))
+        A_decomp_static = qml.Hermitian.compute_decomposition(
+            observable, wires=list(range(num_wires))
+        )
+        A_decomp = qml.Hermitian(observable, wires=list(range(num_wires))).decomposition()
 
+        assert np.allclose(A_decomp_static[0].matrix(), observable, rtol=0)
         assert np.allclose(A_decomp[0].matrix(), observable, rtol=0)
 
     @pytest.mark.parametrize("observable, eigvals, eigvecs", EIGVALS_TEST_DATA)


### PR DESCRIPTION
**Context:**

Prior to this fix, the `compute_decomposition` method of `Hermitian` returned a `qml.DecompositionUndefinedError` (due to its `Operator` base class inheritance). The desired fix, as laid out by the issue, was to use the existing `pauli_decompose` method to perform the desired decomposition. 

**Description of the Change:**

Implemented a custom `compute_decomposition` static method  in `Hermitian` to have it call the existing `pauli_decompose` method. 

<ins>Examples</ins>

```python
>>> op = qml.X(0) + qml.Y(1) + 2 * qml.X(0) @ qml.Z(3)
>>> op_matrix = qml.matrix(op)
>>> qml.Hermitian.compute_decomposition(op_matrix, wires=['a', 'b', 'aux'])
[(
      1.0 * (I('a') @ Y('b') @ I('aux'))
    + 1.0 * (X('a') @ I('b') @ I('aux'))
    + 2.0 * (X('a') @ I('b') @ Z('aux'))
)]

>>> op = np.array([[1, 1], [1, -1]]) / np.sqrt(2)
>>> qml.Hermitian.compute_decomposition(op, wires=0)
[(
      0.7071067811865475 * X(0)
    + 0.7071067811865475 * Z(0)
)]
```

 ⏰ *Benchmarking Performance* ⏰

Performance was benchmarked as a function of matrix size (see figure below). I heuristically chose to raise an inefficiency warning if the decomposition time would take longer than a second (open to suggestions 🙂). Any observable with more than seven wires will raise a user warning indicating that the decomposition may be inefficient. 

I've also plotted the theoretical time complexity of the `pauli_decompose` method and the data is in agreement.

![benchmark.pdf](https://github.com/user-attachments/files/16459301/benchmark.pdf)

**Benefits:**

Can now compute the decomposition of any Hermitian matrix.

**Possible Drawbacks:**

N/A

**Related GitHub Issues:**

Closes #6047 
