### PR TITLE
Update how finite shots are validated for MCM configuration

### DIFF
--- a/pennylane/workflow/execution.py
+++ b/pennylane/workflow/execution.py
@@ -720,15 +720,7 @@ def execute(
 
     # Mid-circuit measurement configuration validation
     mcm_interface = interface or _get_interface_name(tapes, "auto")
-    finite_shots = (
-        (
-            qml.measurements.Shots(device.shots)
-            if isinstance(device, qml.devices.LegacyDevice)
-            else device.shots
-        )
-        if override_shots is False
-        else override_shots
-    )
+    finite_shots = any(tape.shots for tape in tapes)
     _update_mcm_config(config.mcm_config, mcm_interface, finite_shots)
 
     is_gradient_transform = isinstance(gradient_fn, qml.transforms.core.TransformDispatcher)


### PR DESCRIPTION
As name says. Original implementation was using `override_shots` and/or device shots, which is correct, but outdated behaviour. I just changed it to use `tape.shots` instead.