### PR TITLE
Add default values to `for_loop`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -46,6 +46,9 @@
 * `qml.for_loop` can now be captured into plxpr.
   [(#6041)](https://github.com/PennyLaneAI/pennylane/pull/6041)
 
+* `qml.for_loop` now supports `range`-like syntax with default `step=1`.
+  [(#6068)](https://github.com/PennyLaneAI/pennylane/pull/6068)
+
 * Removed `semantic_version` from the list of required packages in PennyLane. 
   [(#5836)](https://github.com/PennyLaneAI/pennylane/pull/5836)
 

--- a/pennylane/compiler/qjit_api.py
+++ b/pennylane/compiler/qjit_api.py
@@ -426,7 +426,7 @@ class WhileLoopCallable:  # pylint:disable=too-few-public-methods
         return fn_res
 
 
-def for_loop(start=0, stop=None, step=1):
+def for_loop(start, stop=None, step=1):
     """for_loop([start, ]stop[, step])
     A :func:`~.qjit` compatible for-loop for PennyLane programs. When
     used without :func:`~.qjit`, this function will fall back to a standard

--- a/pennylane/compiler/qjit_api.py
+++ b/pennylane/compiler/qjit_api.py
@@ -426,9 +426,8 @@ class WhileLoopCallable:  # pylint:disable=too-few-public-methods
         return fn_res
 
 
-def for_loop(start, stop=None, step=1):
-    """for_loop([start, ]stop, [step, ])
-    A :func:`~.qjit` compatible for-loop for PennyLane programs. When
+def for_loop(start=0, stop=None, step=1):
+    """A :func:`~.qjit` compatible for-loop for PennyLane programs. When
     used without :func:`~.qjit`, this function will fall back to a standard
     Python for loop.
 
@@ -468,10 +467,10 @@ def for_loop(start, stop=None, step=1):
            with spacing between the values given by ``step``
 
     Args:
-        start (Optional[int]): starting value of the iteration index.
+        start (int, optional): starting value of the iteration index.
             The default start value is ``0``
-        stop (int): upper bound of the iteration index
-        step (Optional[int]): increment applied to the iteration index at the end of
+        stop (int | None): upper bound of the iteration index
+        step (int, optional): increment applied to the iteration index at the end of
             each iteration. The default step size is ``1``
 
     Returns:

--- a/pennylane/compiler/qjit_api.py
+++ b/pennylane/compiler/qjit_api.py
@@ -426,7 +426,7 @@ class WhileLoopCallable:  # pylint:disable=too-few-public-methods
         return fn_res
 
 
-def for_loop(lower_bound, upper_bound, step):
+def for_loop(lower_bound, upper_bound=None, step=1):
     """A :func:`~.qjit` compatible for-loop for PennyLane programs. When
     used without :func:`~.qjit`, this function will fall back to a standard
     Python for loop.
@@ -459,8 +459,11 @@ def for_loop(lower_bound, upper_bound, step):
 
     Args:
         lower_bound (int): starting value of the iteration index
-        upper_bound (int): (exclusive) upper bound of the iteration index
-        step (int): increment applied to the iteration index at the end of each iteration
+        upper_bound (int | None): (exclusive) upper bound of the iteration index. If ``None``,
+            provided ``lower_bound`` is used as the ``upper_bound`` and ``lower_bound`` is
+            considered to be ``0``.
+        step (int): increment applied to the iteration index at the end of each iteration.
+            Default is ``1``.
 
     Returns:
         Callable[[int, ...], ...]: A wrapper around the loop body function.
@@ -510,6 +513,8 @@ def for_loop(lower_bound, upper_bound, step):
         page for an overview of using quantum just-in-time compilation.
 
     """
+    if upper_bound is None:
+        lower_bound, upper_bound = 0, lower_bound
 
     if active_jit := active_compiler():
         compilers = AvailableCompilers.names_entrypoints

--- a/pennylane/compiler/qjit_api.py
+++ b/pennylane/compiler/qjit_api.py
@@ -427,7 +427,8 @@ class WhileLoopCallable:  # pylint:disable=too-few-public-methods
 
 
 def for_loop(start=0, stop=None, step=1):
-    """A :func:`~.qjit` compatible for-loop for PennyLane programs. When
+    """for_loop([start, ]stop[, step])
+    A :func:`~.qjit` compatible for-loop for PennyLane programs. When
     used without :func:`~.qjit`, this function will fall back to a standard
     Python for loop.
 
@@ -469,7 +470,7 @@ def for_loop(start=0, stop=None, step=1):
     Args:
         start (int, optional): starting value of the iteration index.
             The default start value is ``0``
-        stop (int | None): upper bound of the iteration index
+        stop (int): upper bound of the iteration index
         step (int, optional): increment applied to the iteration index at the end of
             each iteration. The default step size is ``1``
 

--- a/tests/capture/test_capture_for_loop.py
+++ b/tests/capture/test_capture_for_loop.py
@@ -65,6 +65,37 @@ class TestCaptureForLoop:
         assert np.allclose(res_ev_jxpr, expected), f"Expected {expected}, but got {res_ev_jxpr}"
 
     @pytest.mark.parametrize("array", [jax.numpy.zeros(0), jax.numpy.zeros(5)])
+    def test_for_loop_defaults(self, array):
+        """Test simple for-loop primitive using default values."""
+
+        def fn(arg):
+
+            a = jax.numpy.ones(arg.shape)
+
+            @qml.for_loop(0, 10, 1)
+            def loop1(_, a):
+                return a
+
+            @qml.for_loop(10, 1)
+            def loop2(_, a):
+                return a
+
+            @qml.for_loop(10)
+            def loop3(_, a):
+                return a
+
+            r1, r2, r3 = loop1(a), loop2(a), loop3(a)
+            return r1, r2, r3
+
+        expected = jax.numpy.ones(array.shape)
+        result = fn(array)
+        assert np.allclose(result, expected), f"Expected {expected}, but got {result}"
+
+        jaxpr = jax.make_jaxpr(fn)(array)
+        res_ev_jxpr = jax.core.eval_jaxpr(jaxpr.jaxpr, jaxpr.consts, array)
+        assert np.allclose(res_ev_jxpr, expected), f"Expected {expected}, but got {res_ev_jxpr}"
+
+    @pytest.mark.parametrize("array", [jax.numpy.zeros(0), jax.numpy.zeros(5)])
     def test_for_loop_shared_indbidx(self, array):
         """Test for-loops with shared dynamic input dimensions."""
 


### PR DESCRIPTION
**Context:** This adds the default `step=1` and a `range`-like syntax support for single-parameter. 

**Description of the Change:** One can now do the following instead of specifying complete `(0, 3, 1)`:
```py
@for_loop(0, 3)
def f(i):
    qml.X(i)

@for_loop(3)
def f(i):
    qml.X(i)
```

**Benefits:**

**Possible Drawbacks:** None

**Related GitHub Issues:** [sc-70477] [sc-70478]
