### PR TITLE
Update documentation of `quantum_fisher`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -266,6 +266,10 @@
 
 <h3>Documentation 📝</h3>
 
+* Improves the docstring for `qinfo.quantum_fisher` regarding the internally used functions and
+  potentially required auxiliary wires.
+  [(#6074)](https://github.com/PennyLaneAI/pennylane/pull/6074)
+
 * Improves the docstring for `QuantumScript.expand` and `qml.tape.tape.expand_tape`.
   [(#5974)](https://github.com/PennyLaneAI/pennylane/pull/5974)
 

--- a/pennylane/gradients/fisher.py
+++ b/pennylane/gradients/fisher.py
@@ -305,9 +305,12 @@ def quantum_fisher(
 
     .. note::
 
-        ``quantum_fisher`` coincides with the ``metric_tensor`` with a prefactor of :math:`4`. Internally, :func:`~.pennylane.adjoint_metric_tensor` is used when executing on a device with
-        exact expectations (``shots=None``) that inherits from ``"default.qubit"``. In all other cases, i.e. if a device with finite shots is used, the hardware compatible transform :func:`~.pennylane.metric_tensor` is used.
-        Please refer to their respective documentations for details on the arguments.
+        ``quantum_fisher`` coincides with the ``metric_tensor`` with a prefactor of :math:`4`.
+        Internally, :func:`~.pennylane.adjoint_metric_tensor` is used when executing on ``"default.qubit"``
+        with exact expectations (``shots=None``). In all other cases, e.g. if a device with finite shots
+        is used, the hardware-compatible transform :func:`~.pennylane.metric_tensor` is used, which
+        may require an additional wire on the device.
+        Please refer to the respective documentations for details.
 
     **Example**
 

--- a/pennylane/qinfo/transforms.py
+++ b/pennylane/qinfo/transforms.py
@@ -651,9 +651,12 @@ def quantum_fisher(
 
     .. note::
 
-        ``quantum_fisher`` coincides with the ``metric_tensor`` with a prefactor of :math:`4`. Internally, :func:`~.pennylane.adjoint_metric_tensor` is used when executing on a device with
-        exact expectations (``shots=None``) that inherits from ``"default.qubit"``. In all other cases, i.e. if a device with finite shots is used, the hardware compatible transform :func:`~.pennylane.metric_tensor` is used.
-        Please refer to their respective documentations for details on the arguments.
+        ``quantum_fisher`` coincides with the ``metric_tensor`` with a prefactor of :math:`4`.
+        Internally, :func:`~.pennylane.adjoint_metric_tensor` is used when executing on ``"default.qubit"``
+        with exact expectations (``shots=None``). In all other cases, e.g. if a device with finite shots
+        is used, the hardware-compatible transform :func:`~.pennylane.metric_tensor` is used, which
+        may require an additional wire on the device.
+        Please refer to the respective documentations for details on the arguments.
 
     **Example**
 

--- a/pennylane/qinfo/transforms.py
+++ b/pennylane/qinfo/transforms.py
@@ -656,7 +656,7 @@ def quantum_fisher(
         with exact expectations (``shots=None``). In all other cases, e.g. if a device with finite shots
         is used, the hardware-compatible transform :func:`~.pennylane.metric_tensor` is used, which
         may require an additional wire on the device.
-        Please refer to the respective documentations for details on the arguments.
+        Please refer to the respective documentations for details.
 
     **Example**
 


### PR DESCRIPTION
**Context:**
The documentation of `qinfo.quantum_fisher` was not quite precise on when `adjoint_metric_tensor` is being used (successfully), and did not mention potential auxiliary wire requirements.

**Description of the Change:**
Make the criterion on using default.qubit precise (because we catch other devices), and mention that for other settings, an auxiliary wire may be required.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
#6059 
[sc-70300]
