### PR TITLE
Fix hyperlink typo in `qml.QNode` docstring

### DIFF
--- a/pennylane/workflow/qnode.py
+++ b/pennylane/workflow/qnode.py
@@ -108,7 +108,7 @@ class QNode:
     r"""Represents a quantum node in the hybrid computational graph.
 
     A *quantum node* contains a :ref:`quantum function <intro_vcirc_qfunc>` (corresponding to
-    a `variational circuit <https://pennylane.ai/qml/glossary/variational_circuit>`)__
+    a `variational circuit <https://pennylane.ai/qml/glossary/variational_circuit>`__)
     and the computational device it is executed on.
 
     The QNode calls the quantum function to construct a :class:`~.QuantumTape` instance representing


### PR DESCRIPTION
**Context:**
- The word 'variational circuit' is not hyperlinked, instead the link it next to the word due to a typo.

**Description of the Change:**
- Fix to hyperlink the URL to the text 'variational circuit'.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
