### PR TITLE
BugFix: CompositeOp.overlapping_ops maintains the original order of ops.

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -321,6 +321,9 @@
 * Workflows that parameterize the coefficients of `qml.exp` are now jit-compatible.
   [(#6082)](https://github.com/PennyLaneAI/pennylane/pull/6082)
 
+* Fixes a bug where `CompositeOp.overlapping_ops` changes the original ordering of ops, causing incorrect matrix generated for `Prod` with `Sum` as operands.
+  [(#6091)](https://github.com/PennyLaneAI/pennylane/pull/6091)
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane/ops/op_math/composite.py
+++ b/pennylane/ops/op_math/composite.py
@@ -207,7 +207,6 @@ class CompositeOp(Operator):
             while i < len(groups):
                 if first_group_idx is None and any(wire in op.wires for wire in groups[i][1]):
                     # Found the first group that has overlapping wires with this op
-                    groups[i][0].append(op)
                     groups[i][1] = groups[i][1] + op.wires
                     first_group_idx = i  # record the index of this group
                     i += 1
@@ -219,7 +218,9 @@ class CompositeOp(Operator):
                     groups[first_group_idx][1] = groups[first_group_idx][1] + wires
                 else:
                     i += 1
-            if first_group_idx is None:
+            if first_group_idx is not None:
+                groups[first_group_idx][0].append(op)
+            else:
                 # Create new group
                 groups.append([[op], op.wires])
 

--- a/tests/ops/op_math/test_composite.py
+++ b/tests/ops/op_math/test_composite.py
@@ -357,8 +357,8 @@ class TestProperties:
             [
                 qml.sum(qml.PauliX(0), qml.PauliY(5), qml.PauliZ(10)),
                 qml.prod(qml.PauliX(10), qml.PauliY(2)),
-                qml.Hamiltonian([1, 1], [qml.PauliX(2), qml.PauliZ(7)]),
                 qml.PauliY(7),
+                qml.Hamiltonian([1, 1], [qml.PauliX(2), qml.PauliZ(7)]),
             ],
             [
                 qml.sum(qml.PauliX(1), qml.PauliY(4), qml.PauliZ(6)),


### PR DESCRIPTION
Fixes a bug where `CompositeOp.overlapping_ops` changes the original ordering of ops.

Fixes https://github.com/PennyLaneAI/pennylane/issues/6090
[sc-71201]