### PR TITLE
Update `Hermitian.decomposition` test to use `qml.matrix`

### DIFF
--- a/tests/ops/qubit/test_observables.py
+++ b/tests/ops/qubit/test_observables.py
@@ -369,8 +369,8 @@ class TestHermitian:  # pylint: disable=too-many-public-methods
         )
         A_decomp = qml.Hermitian(observable, wires=list(range(num_wires))).decomposition()
 
-        assert np.allclose(A_decomp_static[0].matrix(), observable, rtol=0)
-        assert np.allclose(A_decomp[0].matrix(), observable, rtol=0)
+        assert np.allclose(qml.matrix(A_decomp_static[0]), observable, rtol=0)
+        assert np.allclose(qml.matrix(A_decomp[0]), observable, rtol=0)
 
     @pytest.mark.parametrize("observable, eigvals, eigvecs", EIGVALS_TEST_DATA)
     def test_hermitian_diagonalizing_gates(self, observable, eigvals, eigvecs, tol, mocker):


### PR DESCRIPTION
After the merge of #6062 , the legacy op math tests in the plugin test matrix fail (see [here](https://github.com/PennyLaneAI/pennylane/actions/runs/10362479768/job/28685492331)), since the test uses the `Operator.matrix` method to verify the decomposition, but the decomposed operator is a legacy `Hamiltonian` with new op math disabled, which doesn't have a matrix. This PR just updates the test to use `qml.matrix` instead of `Operator.matrix`.