### PR TITLE
[BUGFIX] Pytrees: Handle empty shot vector

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -14,6 +14,9 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Fix Pytree serialization of operators with empty shot vectors:
+  [(#6155)](https://github.com/PennyLaneAI/pennylane/pull/6155)
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -20,3 +20,5 @@
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):
+
+Jack Brown

--- a/pennylane/data/data_manager/__init__.py
+++ b/pennylane/data/data_manager/__init__.py
@@ -467,16 +467,6 @@ def _interactive_request_single(node, param):
     return options[choice - 1]
 
 
-def load_interactive_2():
-
-    avaialable_class_ids = get_class_ids()
-    chosen_class_id = prompt_for_class_id(avaialable_class_ids)
-
-    parameters = get_parameters(chosen_class_id)
-    for parameter in parameters:
-        options = get_parameter_options(chosen_class_id, parameter)
-
-
 def load_interactive():
     r"""Download a dataset using an interactive load prompt.
 

--- a/pennylane/data/data_manager/__init__.py
+++ b/pennylane/data/data_manager/__init__.py
@@ -467,6 +467,16 @@ def _interactive_request_single(node, param):
     return options[choice - 1]
 
 
+def load_interactive_2():
+
+    avaialable_class_ids = get_class_ids()
+    chosen_class_id = prompt_for_class_id(avaialable_class_ids)
+
+    parameters = get_parameters(chosen_class_id)
+    for parameter in parameters:
+        options = get_parameter_options(chosen_class_id, parameter)
+
+
 def load_interactive():
     r"""Download a dataset using an interactive load prompt.
 

--- a/pennylane/pytrees/serialization.py
+++ b/pennylane/pytrees/serialization.py
@@ -126,6 +126,9 @@ def _wires_to_json(obj: Wires) -> JSON:
 
 def _shots_to_json(obj: Shots) -> JSON:
     """JSON handler for serializing ``Shots``."""
+    if obj.total_shots is None:
+        return None
+
     return obj.shot_vector
 
 

--- a/tests/data/attributes/test_pytree.py
+++ b/tests/data/attributes/test_pytree.py
@@ -19,6 +19,7 @@ from dataclasses import dataclass
 
 import pytest
 
+import pennylane as qml
 from pennylane.data import Dataset, DatasetPyTree
 from pennylane.pytrees.pytrees import (
     _register_pytree_with_pennylane,
@@ -105,3 +106,11 @@ class TestDatasetPyTree:
         attr = DatasetPyTree(bind=bind)
 
         assert attr == value
+
+
+@pytest.mark.parametrize("shots", [None, 1, [1, 2]])
+def test_quantum_scripts(shots):
+    """Test that ``QuantumScript`` can be serialized as Pytrees."""
+    script = qml.tape.QuantumScript([qml.X(0)], shots=shots)
+
+    assert qml.equal(DatasetPyTree(script).get_value(), script)

--- a/tests/pytrees/test_serialization.py
+++ b/tests/pytrees/test_serialization.py
@@ -22,6 +22,7 @@ import numpy as np
 import pytest
 
 import pennylane as qml
+from pennylane.measurements import Shots
 from pennylane.ops import PauliX, Prod, Sum
 from pennylane.pytrees import PyTreeStructure, flatten, is_pytree, leaf, unflatten
 from pennylane.pytrees.pytrees import (
@@ -116,6 +117,23 @@ def test_pytree_structure_dump(decode):
             ["test.CustomNode", {"wires": [1, "a", 3.4, None]}, [None, None, None]],
         ],
     ]
+
+
+@pytest.mark.parametrize(
+    "shots, expect_metadata",
+    [
+        (Shots(), None),
+        (Shots(1), [[1, 1]]),
+        (Shots([1, 2]), [[1, 1], [2, 1]]),
+    ],
+)
+def test_pytree_structure_dump_shots(shots, expect_metadata):
+    """Test that ``pytree_structure_dump`` handles all forms of shots."""
+    data, struct = flatten(CustomNode([], {"shots": shots}))
+
+    flattened = pytree_structure_dump(struct)
+
+    assert json.loads(flattened) == ["test.CustomNode", {"shots": expect_metadata}, []]
 
 
 def test_pytree_structure_dump_unserializable_metadata():


### PR DESCRIPTION
**Context:**
The Pytrees module was not correctly serializing empty shot vectors, (`Shots(None)`), converting them to an empty list instead of `None`. This resulted in an `IndexError` when deserializing, since `Shots` expects any sequence passed in to contain at least one element.

This resulted in cryptic errors when datasets contained lists of operators with empty shots. The `DatasetList` type would interpret the `IndexError` as the end of the list, instead of a serialization error in one of the elements:

```
>>> dataset = qml.data.Dataset()
>>> dataset.circuits = [1, qml.tape.QuantumScript([qml.X(0)]), 3]
>>> list(iter(dataset.circuits))
[1]
>>> dataset.circuits[2]
3
>>> dataset.circuits[1]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/jack/src/pennylane/pennylane/data/attributes/list.py", line 114, in __getitem__
    return self._mapper[str(index)].get_value()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jack/src/pennylane/pennylane/data/base/attribute.py", line 308, in get_value
    return self.hdf5_to_value(self.bind)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jack/src/pennylane/pennylane/data/attributes/pytree.py", line 39, in hdf5_to_value
    return unflatten(
           ^^^^^^^^^^
  File "/Users/jack/src/pennylane/pennylane/pytrees/pytrees.py", line 287, in unflatten
    return _unflatten(iter(data), structure)
>>> dataset.circuits[2]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/jack/src/pennylane/pennylane/data/attributes/list.py", line 114, in __getitem__
    return self._mapper[str(index)].get_value()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jack/src/pennylane/pennylane/data/base/attribute.py", line 308, in get_value
    return self.hdf5_to_value(self.bind)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jack/src/pennylane/pennylane/data/attributes/pytree.py", line 39, in hdf5_to_value
    return unflatten(
           ^^^^^^^^^^
  File "/Users/jack/src/pennylane/pennylane/pytrees/pytrees.py", line 287, in unflatten
    return _unflatten(iter(data), structure)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jack/src/pennylane/pennylane/pytrees/pytrees.py", line 294, in _unflatten
    return unflatten_registrations[structure.type_](children, structure.metadata)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jack/src/pennylane/pennylane/tape/qscript.py", line 170, in _unflatten
    return cls(*data, shots=metadata[0], trainable_params=metadata[1])
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jack/src/pennylane/pennylane/tape/qscript.py", line 181, in __init__
    self._shots = Shots(shots)
                  ^^^^^^^^^^^^
  File "/Users/jack/src/pennylane/pennylane/measurements/shots.py", line 172, in __init__
    self.__all_tuple_init__([s if isinstance(s, Sequence) else (s, 1) for s in shots])
  File "/Users/jack/src/pennylane/pennylane/measurements/shots.py", line 219, in __all_tuple_init__
    current_shots, current_copies = shots[0]
                                    ~~~~~^^^
```

**Description of the Change:**
Serialize empty shot vector as `None`.

**Benefits:**
Fix the bug

**Possible Drawbacks:**
None
