### PR TITLE
Change strategy for determining RC branch version

### DIFF
--- a/.github/workflows/rc_sync.yml
+++ b/.github/workflows/rc_sync.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Check for rc branch
         run: |
           VERSION=$(python setup.py --version)
-          IFS=. read MAJ MIN PAT <<< "${VERSION%.dev0}"
+          IFS=. read MAJ MIN PAT <<< "${VERSION%.dev[0-9]*}"
           RC_BRANCH="v${MAJ}.$((MIN-1)).${PAT}-rc0"
           if git ls-remote --exit-code origin "refs/heads/$RC_BRANCH"; then
             echo "branch_exists=true" >> $GITHUB_ENV


### PR DESCRIPTION
We originally used to end the dev release version with `dev0`. However, since the nightly releases, the dev version number increases everyday. This change broke the RC sync to master action, which would check for the RC branch's existence using the version number from `master`. I updating the step that computes the RC branch's name to use a regex instead.