### PR TITLE
Performance fix for legacy device batch transform

### DIFF
--- a/doc/releases/changelog-0.38.0.md
+++ b/doc/releases/changelog-0.38.0.md
@@ -382,6 +382,9 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Bypass `split_non_commuting` in legacy devices when the transform yields more tapes than measurements and all observables are supported.
+  [(#6183)](https://github.com/PennyLaneAI/pennylane/pull/6183)
+
 * `qml.transforms.pattern_matching_optimization` now preserves the tape measurements.
   [(#6153)](https://github.com/PennyLaneAI/pennylane/pull/6153)
 


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      test directory!

- [x] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `doc/releases/changelog-dev.md` file, summarizing the
      change, and including a link back to the PR.

- [x] The PennyLane source code conforms to
      [PEP8 standards](https://www.python.org/dev/peps/pep-0008/).
      We check all of our code against [Pylint](https://www.pylint.org/).
      To lint modified files, simply `pip install pylint`, and then
      run `pylint pennylane/path/to/file.py`.

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
[sc-72467]
Consider a circuit like 
```
import pennylane as qml
import pennylane.numpy as np

dataset = qml.data.load("qchem", molname="H2", basis="STO-3G")[0]
ham, hf_state = dataset.hamiltonian, dataset.hf_state
n_electrons = dataset.molecule.n_electrons
wires = ham.wires
singles, doubles = qml.qchem.excitations(n_electrons, len(wires))

dev = qml.device("lightning.gpu", wires=wires)

@qml.qnode(dev, diff_method="adjoint")
def c(weights):
    qml.templates.AllSinglesDoubles(weights, wires, hf_state, singles, doubles)
    return np.array([qml.expval(ham), qml.expval(qml.PauliZ(0))])

params = np.random.normal(0, np.pi, len(singles) + len(doubles))
c(params)
```
If this is executed on an old API device, the circuit will hit the transform [batch_transform](https://github.com/PennyLaneAI/pennylane/blob/2fc4e228eb56b4e589827197b5608caa40f47c8d/pennylane/devices/_legacy_device.py#L723). Since the observables do not commute, the circuit is split with `split_non_commuting`, which will yield many tapes grouping the Hamiltonian terms into commuting groups of observables. The number of tapes can grow quite high (> 100s) for large molecules. This is wasteful for devices that natively support Hamiltonian measurements. 

**Description of the Change:**
If the device natively supports Hamiltonian measurements, and `split_non_commuting` yields more tapes than measurements, split into one circuit per measurement instead. 

**Benefits:**
Faster execution in the above case.

**Possible Drawbacks:**
Slower execution in other corner cases.

**Related GitHub Issues:**
