### PR TITLE
fix assert valid pickling test

### DIFF
--- a/tests/ops/functions/test_assert_valid.py
+++ b/tests/ops/functions/test_assert_valid.py
@@ -188,7 +188,7 @@ class BadPickling0(Operator):
 def test_bad_pickling():
     """Test an error is raised in an operator cant be pickled."""
 
-    with pytest.raises(AttributeError, match="Can't pickle local object"):
+    with pytest.raises(AttributeError):
         assert_valid(BadPickling0(lambda x: x, wires=0))
 
 


### PR DESCRIPTION
In Python 3.12, a test in `test_assert_valid.py` fails due to a slightly different error message. 