### PR TITLE
Fix sparse matrix with global phase

### DIFF
--- a/doc/releases/changelog-0.38.0.md
+++ b/doc/releases/changelog-0.38.0.md
@@ -384,6 +384,7 @@
 
 * The sparse matrix can now be computed for a product operator when one operand is a `GlobalPhase`
   on no wires.
+  [(#6197)](https://github.com/PennyLaneAI/pennylane/pull/6197)
 
 * For `default.qubit`, JAX is now used for sampling whenever the state is a JAX array. This fixes normalization issues
   that can occur when the state uses 32-bit precision.

--- a/doc/releases/changelog-0.38.0.md
+++ b/doc/releases/changelog-0.38.0.md
@@ -382,6 +382,9 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* The sparse matrix can now be computed for a product operator when one operand is a `GlobalPhase`
+  on no wires.
+
 * For `default.qubit`, JAX is now used for sampling whenever the state is a JAX array. This fixes normalization issues
   that can occur when the state uses 32-bit precision.
   [(#6190)](https://github.com/PennyLaneAI/pennylane/pull/6190)

--- a/pennylane/math/matrix_manipulation.py
+++ b/pennylane/math/matrix_manipulation.py
@@ -105,6 +105,10 @@ def expand_matrix(mat, wires, wire_order=None, sparse_format="csr"):
     if (wire_order is None) or (wire_order == wires):
         return mat
 
+    if not wires and qml.math.shape(mat) == (2, 2):
+        # global phase
+        wires = wire_order[0:1]
+
     wires = list(wires)
     wire_order = list(wire_order)
 

--- a/tests/ops/op_math/test_prod.py
+++ b/tests/ops/op_math/test_prod.py
@@ -541,6 +541,7 @@ class TestInitialization:  # pylint:disable=too-many-public-methods
             prod(1)
 
 
+# pylint: disable=too-many-public-methods
 class TestMatrix:
     """Test matrix-related methods."""
 
@@ -844,6 +845,15 @@ class TestMatrix:
         prod_mat = prod_op.sparse_matrix().todense()
 
         assert np.allclose(true_mat, prod_mat)
+
+    def test_sparse_matrix_global_phase(self):
+        """Test that a prod with a global phase still defines a sparse matrix."""
+
+        op = qml.GlobalPhase(0.5) @ qml.X(0) @ qml.X(0)
+
+        sparse_mat = op.sparse_matrix(wire_order=(0, 1))
+        mat = sparse_mat.todense()
+        assert qml.math.allclose(mat, np.exp(-0.5j) * np.eye(4))
 
     @pytest.mark.parametrize("op1, mat1", non_param_ops[:5])
     @pytest.mark.parametrize("op2, mat2", non_param_ops[:5])


### PR DESCRIPTION
Calculating the sparse matrix for a product containing a global phase was causing an error:
```
op = qml.GlobalPhase(0.5) @ qml.X(0) @ qml.X(0)
op.sparse_matrix(wire_order=(0,1))
```

`expand_matrix` was not able to handle an operator with no wires.  So this is just a little patch for that case.