### PR TITLE
Fix incorrect zero gradient shape for shot vectors

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -37,12 +37,16 @@
 * The ``qml.QSVT`` template now orders the ``projector`` wires first and the ``UA`` wires second, which is the expected order of the decomposition.
   [(#6212)](https://github.com/PennyLaneAI/pennylane/pull/6212)
 
+* Fixes a bug where shot vectors are not taken into account correctly when doing parameter shift of a tape without differentiable parameters.
+  [(#6221)](https://github.com/PennyLaneAI/pennylane/pull/6221)
+
 * <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):
 
-Guillermo Alonso
-Utkarsh Azad
-Jack Brown
-Christina Lee
-William Maxwell
+Guillermo Alonso,
+Utkarsh Azad,
+Jack Brown,
+Astral Cai,
+Christina Lee,
+William Maxwell,

--- a/pennylane/gradients/jvp.py
+++ b/pennylane/gradients/jvp.py
@@ -296,8 +296,12 @@ def jvp(tape, tangent, gradient_fn, gradient_kwargs=None):
         # The tape has no trainable parameters; the JVP
         # is simply none.
         def zero_vjp(_):
-            res = tuple(np.zeros(mp.shape(None, tape.shots)) for mp in tape.measurements)
-            return res[0] if len(tape.measurements) == 1 else res
+            res = tuple(np.zeros(mp.shape(tape.shots)) for mp in tape.measurements)
+            if len(tape.measurements) == 1:
+                res = res[0]
+            if tape.shots.has_partitioned_shots:
+                res = tuple(res for _ in range(tape.shots.num_copies))
+            return res
 
         return tuple(), zero_vjp
 

--- a/tests/interfaces/test_jax.py
+++ b/tests/interfaces/test_jax.py
@@ -122,16 +122,18 @@ class TestCaching:
 # add tests for lightning 2 when possible
 # set rng for device when possible
 no_shots = Shots(None)
+shots_10k = Shots(10000)
 shots_2_10k = Shots((10000, 10000))
 dev_def = DefaultQubit()
 dev_ps = ParamShiftDerivativesDevice(seed=54353453)
 test_matrix = [
-    ({"gradient_fn": param_shift}, Shots(100000), DefaultQubit(seed=42)),  # 0
-    ({"gradient_fn": param_shift}, no_shots, dev_def),  # 1
-    ({"gradient_fn": "backprop"}, no_shots, dev_def),  # 2
-    ({"gradient_fn": "adjoint"}, no_shots, dev_def),  # 3
-    ({"gradient_fn": "adjoint", "device_vjp": True}, no_shots, dev_def),  # 4
-    ({"gradient_fn": "device"}, shots_2_10k, dev_ps),  # 5
+    ({"gradient_fn": param_shift}, shots_10k, DefaultQubit(seed=42)),  # 0
+    ({"gradient_fn": param_shift}, shots_2_10k, DefaultQubit(seed=42)),  # 1
+    ({"gradient_fn": param_shift}, no_shots, dev_def),  # 2
+    ({"gradient_fn": "backprop"}, no_shots, dev_def),  # 3
+    ({"gradient_fn": "adjoint"}, no_shots, dev_def),  # 4
+    ({"gradient_fn": "adjoint", "device_vjp": True}, no_shots, dev_def),  # 5
+    ({"gradient_fn": "device"}, shots_2_10k, dev_ps),  # 6
 ]
 
 


### PR DESCRIPTION
Fixes a bug where shot vectors are not taken into account correctly when doing parameter shift of a tape without diffable params, causing errors when taking `jax.jacobian`