### PR TITLE
Rremove labeled PR types from workflows

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,6 @@ on:
       - reopened
       - synchronize
       - ready_for_review
-      - labeled
 
 jobs:
   sphinx:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -6,7 +6,6 @@ on:
       - reopened
       - synchronize
       - ready_for_review
-      - labeled
 
 jobs:
   black-pylint:

--- a/.github/workflows/tests-gpu.yml
+++ b/.github/workflows/tests-gpu.yml
@@ -9,7 +9,6 @@ on:
       - reopened
       - synchronize
       - ready_for_review
-      - labeled
 
 concurrency:
   group: gpu-test-${{ github.ref }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,6 @@ on:
       - reopened
       - synchronize
       - ready_for_review
-      - labeled
   # Scheduled trigger on Monday at 2:47am UTC
   schedule:
   - cron: '47 2 * * 1'


### PR DESCRIPTION
**Context:**
CI is being triggered when labels are added to "ready for review" PRs, this removes that undesired behaviour.

**Description of the Change:**
`labeled` PR types are removed from workflows

**Benefits:**
Prevents CI from running each time any label is added

**Possible Drawbacks:**
When labels are added that intend to affect CI, a followup commit must be made to trigger the CI

### Verification:
- Added and removed labels from this PR in "ready for review" state, CI checks were not triggered. 
- Added `ci:run-full-test-suite` label, CI checks were not triggered until a followup commit was pushed to branch 