### PR TITLE
Change casting rules in various places

### DIFF
--- a/pennylane/devices/qubit/apply_operation.py
+++ b/pennylane/devices/qubit/apply_operation.py
@@ -71,7 +71,7 @@ def apply_operation_einsum(op: qml.operation.Operator, state, is_state_batched: 
     Returns:
         array[complex]: output_state
     """
-    mat = op.matrix()
+    mat = qml.math.cast_like(op.matrix(), 1j)
 
     total_indices = len(state.shape) - is_state_batched
     num_indices = len(op.wires)
@@ -114,7 +114,7 @@ def apply_operation_tensordot(op: qml.operation.Operator, state, is_state_batche
     Returns:
         array[complex]: output_state
     """
-    mat = op.matrix()
+    mat = qml.math.cast_like(op.matrix(), 1j)
     total_indices = len(state.shape) - is_state_batched
     num_indices = len(op.wires)
 

--- a/pennylane/measurements/expval.py
+++ b/pennylane/measurements/expval.py
@@ -151,5 +151,5 @@ class ExpectationMP(SampleMeasurement, StateMeasurement):
         Args:
             probabilities (array): the probabilities of collapsing to eigen states
         """
-        eigvals = qml.math.asarray(self.eigvals(), dtype="float64")
+        eigvals = qml.math.cast_like(self.eigvals(), 1.0)
         return qml.math.dot(probabilities, eigvals)

--- a/pennylane/ops/op_math/controlled_decompositions.py
+++ b/pennylane/ops/op_math/controlled_decompositions.py
@@ -55,7 +55,7 @@ def _convert_to_su2(U, return_global_phase=False):
     with np.errstate(divide="ignore", invalid="ignore"):
         dets = math.linalg.det(U)
 
-    global_phase = math.cast_like(math.angle(dets), 1j) / 2
+    global_phase = math.cast_like(math.angle(dets), 1.0) / 2
     U_SU2 = math.cast_like(U, dets) * math.exp(-1j * global_phase)
     return (U_SU2, global_phase) if return_global_phase else U_SU2
 

--- a/pennylane/ops/qubit/special_unitary.py
+++ b/pennylane/ops/qubit/special_unitary.py
@@ -480,8 +480,8 @@ class SpecialUnitary(Operation):
                [-0.0942679 +0.47133952j,  0.83004499+0.28280371j]])
         """
         interface = qml.math.get_interface(theta)
-        if interface == "tensorflow":
-            theta = qml.math.cast_like(theta, 1j)
+        theta = qml.math.cast_like(theta, 1j)
+
         if num_wires > 5:
             matrices = product(_pauli_matrices, repeat=num_wires)
             # Drop the identity from the generator of matrices


### PR DESCRIPTION
Lot's of places cast to float/complex (or don't cast at all when they should). This caused a huge splurge of warnings in many demos in `qml` (see https://github.com/PennyLaneAI/qml/issues/1212).

* Cast matrices to complex before applying to the state vector in `devices.qubit.apply_operation`. This should be fine since the state vector will always be complex anyway. This is also consistent with what the legacy devices do.
* Change how eigvals are cast to float for computing expvals. I don't entirely understand this, but it works.
* Stop casting global phases to complex when computing controlled decompositions. This is because  recursively decomposing `QROM` will create controlled ops, and decomposing those will add controlled `GlobalPhase` with a real phase, but with a complex dtype.
* Cast `theta` to complex for all interfaces in `SpecialUnitary.compute_matrix`. This is needed because the matrix with which we `tensordot` `theta` is complex as it contains `PauliY`'s matrix.

**Open question**:
Do we want to do a bug fix release for this PR?

[sc-73429]