### PR TITLE
Test param shift and hadamard in device test suite

### DIFF
--- a/pennylane/devices/tests/conftest.py
+++ b/pennylane/devices/tests/conftest.py
@@ -85,6 +85,8 @@ def skip_if():
 @pytest.fixture
 def validate_diff_method(device, diff_method, device_kwargs):
     """Skip tests if a device does not support a diff_method"""
+    if diff_method in {"parameter-shift", "hadamard"}:
+        return
     if diff_method == "backprop" and device_kwargs.get("shots") is not None:
         pytest.skip(reason="test should only be run in analytic mode")
     dev = device(1)


### PR DESCRIPTION
**Context:**

We have tests to check that the device works with various differentiation methods, (backprop, param shift, and hadamard).  But we were skipping the test if the device didn't natively support that differentiation method.  parameter shift and hadamard shouldn't need to be natively supported.  Pennylane itself handles that.  So we should always be checking parameter shift and hadamard grad with any device.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
