### PR TITLE
Removing ambiguity in `PauliRot` error message.

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -164,6 +164,9 @@
 * Add `work_wires` parameter to `qml.MultiControlledX` docstring signature.
   [(#6271)](https://github.com/PennyLaneAI/pennylane/pull/6271)
 
+* Removed ambiguity in error raised by the `PauliRot` class.
+  [(#6298)](https://github.com/PennyLaneAI/pennylane/pull/6298)
+
 <h3>Bug fixes 🐛</h3>
 
 * Fix float-to-complex casting in various places across PennyLane.

--- a/pennylane/devices/tests/conftest.py
+++ b/pennylane/devices/tests/conftest.py
@@ -85,6 +85,8 @@ def skip_if():
 @pytest.fixture
 def validate_diff_method(device, diff_method, device_kwargs):
     """Skip tests if a device does not support a diff_method"""
+    if diff_method in {"parameter-shift", "hadamard"}:
+        return
     if diff_method == "backprop" and device_kwargs.get("shots") is not None:
         pytest.skip(reason="test should only be run in analytic mode")
     dev = device(1)

--- a/pennylane/ops/qubit/parametric_ops_multi_qubit.py
+++ b/pennylane/ops/qubit/parametric_ops_multi_qubit.py
@@ -291,8 +291,9 @@ class PauliRot(Operation):
 
         if not len(pauli_word) == num_wires:
             raise ValueError(
-                f"The given Pauli word has length {len(pauli_word)}, length "
-                f"{num_wires} was expected for wires {wires}"
+                f"The number of wires must be equal to the length of the Pauli Word. "
+                f"The Pauli word {pauli_word} has length {len(pauli_word)}, and "
+                f"{num_wires} wires were given {wires}."
             )
 
     def __repr__(self) -> str:

--- a/pennylane/ops/qubit/parametric_ops_multi_qubit.py
+++ b/pennylane/ops/qubit/parametric_ops_multi_qubit.py
@@ -291,7 +291,7 @@ class PauliRot(Operation):
 
         if not len(pauli_word) == num_wires:
             raise ValueError(
-                f"The number of wires must be equal to the length of the Pauli Word. "
+                f"The number of wires must be equal to the length of the Pauli word. "
                 f"The Pauli word {pauli_word} has length {len(pauli_word)}, and "
                 f"{num_wires} wires were given {wires}."
             )

--- a/tests/ops/qubit/test_parametric_ops.py
+++ b/tests/ops/qubit/test_parametric_ops.py
@@ -2995,7 +2995,7 @@ class TestPauliRot:
 
         with pytest.raises(
             ValueError,
-            match="The given Pauli word has length .*, length .* was expected for wires .*",
+            match="The number of wires must be equal to the length of the Pauli word\. The Pauli word .* has length .*, and .* wires were given .*\.",
         ):
             qml.PauliRot(0.3, pauli_word, wires=wires)
 

--- a/tests/ops/qubit/test_parametric_ops.py
+++ b/tests/ops/qubit/test_parametric_ops.py
@@ -2995,7 +2995,7 @@ class TestPauliRot:
 
         with pytest.raises(
             ValueError,
-            match="The number of wires must be equal to the length of the Pauli word\. The Pauli word .* has length .*, and .* wires were given .*\.",
+            match=r"The number of wires must be equal to the length of the Pauli word\. The Pauli word .* has length .*, and .* wires were given .*\.",
         ):
             qml.PauliRot(0.3, pauli_word, wires=wires)
 


### PR DESCRIPTION
**Context:**
For the input of `PauliRot` the number of wires given must equal the length of the given Pauli word. Otherwise a `ValueError` is raised. For example, `op = qml.PauliRot(0.5, "XY", wires=[0,1,2])` results in `ValueError: The given Pauli word has length 2, length 3 was expected for wires [0,1,2]`.

However, this message can be ambiguous. `op = qml.PauliRot(0.5, "XYZZXYI", wires=[0])` raises the exception `ValueError: The given Pauli word has length 7, length 1 was expected for wires [0]`. It's unclear if "length 1" refers to the length of the Pauli word or the length of the wires.

**Description of the Change:**
This PR changes the error message to remove the ambiguity. Now it will say `ValueError: The number of wires must be equal to the length of the Pauli Word. The Pauli word XY has length 2, and 3 wires were given [0, 1, 2].`
