### PR TITLE
Fix failure in legacy opmath

### DIFF
--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -2476,6 +2476,10 @@ class Tensor(Observable):
                 return 1
         return 0
 
+    @property
+    def has_sparse_matrix(self):
+        return all(op.has_matrix for op in self.obs)
+
     def sparse_matrix(
         self, wire_order=None, wires=None, format="csr"
     ):  # pylint:disable=arguments-renamed, arguments-differ

--- a/tests/devices/qubit/test_measure.py
+++ b/tests/devices/qubit/test_measure.py
@@ -124,7 +124,7 @@ class TestMeasurementDispatch:
     def test_no_sparse_matrix(self):
         """Tests Hamiltonians/Sums containing observables that do not have a sparse matrix."""
 
-        class DummyOp(qml.operation.Operator):  # pylint: disable=too-few-public-methods
+        class DummyOp(qml.operation.Observable):  # pylint: disable=too-few-public-methods
             num_wires = 1
 
         S1 = qml.Hamiltonian([0.5, 0.5], [qml.X(0), DummyOp(wires=1)])


### PR DESCRIPTION
A follow up PR to https://github.com/PennyLaneAI/pennylane/pull/6278, fixes recent failure in legacy opmath.