### PR TITLE
Using `np` instead of `pnp` in documentation for `numpy` 

### DIFF
--- a/pennylane/_grad.py
+++ b/pennylane/_grad.py
@@ -316,7 +316,7 @@ def jacobian(func, argnum=None, method=None, h=None):
     .. code-block::
 
         import pennylane as qml
-        from pennylane import numpy as pnp
+        from pennylane import numpy as np
 
         dev = qml.device("default.qubit", wires=2)
 
@@ -327,7 +327,7 @@ def jacobian(func, argnum=None, method=None, h=None):
             qml.RZ(weights[1, 0, 2], wires=0)
             return qml.probs()
 
-        weights = pnp.array([[[0.2, 0.9, -1.4]], [[0.5, 0.2, 0.1]]], requires_grad=True)
+        weights = np.array([[[0.2, 0.9, -1.4]], [[0.5, 0.2, 0.1]]], requires_grad=True)
 
     It has a single array-valued QNode argument with shape ``(2, 1, 3)`` and outputs
     the probability of each 2-wire basis state, of which there are ``2**num_wires`` = 4.
@@ -348,9 +348,9 @@ def jacobian(func, argnum=None, method=None, h=None):
             qml.RZ(z, wires=0)
             return qml.probs()
 
-        x = pnp.array(0.2, requires_grad=True)
-        y = pnp.array(0.9, requires_grad=True)
-        z = pnp.array(-1.4, requires_grad=True)
+        x = np.array(0.2, requires_grad=True)
+        y = np.array(0.9, requires_grad=True)
+        z = np.array(-1.4, requires_grad=True)
 
     It has three scalar QNode arguments and outputs the probability for each of
     the 4 basis states. Consequently, its Jacobian will be a three-tuple of
@@ -378,8 +378,8 @@ def jacobian(func, argnum=None, method=None, h=None):
             qml.RX(x[1], wires=2)
             return qml.probs()
 
-        x = pnp.array([0.1, 0.5], requires_grad=True)
-        y = pnp.array([[-0.3, 1.2, 0.1, 0.9], [-0.2, -3.1, 0.5, -0.7]], requires_grad=True)
+        x = np.array([0.1, 0.5], requires_grad=True)
+        y = np.array([[-0.3, 1.2, 0.1, 0.9], [-0.2, -3.1, 0.5, -0.7]], requires_grad=True)
 
     If we do not provide ``argnum``, ``qml.jacobian`` will correctly identify both,
     ``x`` and ``y``, as trainable function arguments:
@@ -431,14 +431,14 @@ def jacobian(func, argnum=None, method=None, h=None):
         def workflow(x):
             @qml.qnode(dev)
             def circuit(x):
-                qml.RX(pnp.pi * x[0], wires=0)
+                qml.RX(np.pi * x[0], wires=0)
                 qml.RY(x[1], wires=0)
                 return qml.probs()
 
             g = qml.jacobian(circuit)
             return g(x)
 
-    >>> workflow(pnp.array([2.0, 1.0]))
+    >>> workflow(np.array([2.0, 1.0]))
     Array([[ 3.48786850e-16, -4.20735492e-01],
            [-8.71967125e-17,  4.20735492e-01]], dtype=float64)
 
@@ -451,14 +451,14 @@ def jacobian(func, argnum=None, method=None, h=None):
         def workflow(x):
             @qml.qnode(dev)
             def circuit(x):
-                qml.RX(pnp.pi * x[0], wires=0)
+                qml.RX(np.pi * x[0], wires=0)
                 qml.RY(x[1], wires=0)
                 return qml.probs()
 
             g = qml.jacobian(circuit, method="fd", h=0.3)
             return g(x)
 
-    >>> workflow(pnp.array([2.0, 1.0]))
+    >>> workflow(np.array([2.0, 1.0]))
     Array([[-0.03996468, -0.42472435],
            [ 0.03996468,  0.42472435]], dtype=float64)
 

--- a/pennylane/optimize/qng.py
+++ b/pennylane/optimize/qng.py
@@ -116,7 +116,7 @@ class QNGOptimizer(GradientDescentOptimizer):
     optimizer's :meth:`~.step` function:
 
     >>> eta = 0.01
-    >>> init_params = pnp.array([0.011, 0.012])
+    >>> init_params = np.array([0.011, 0.012])
     >>> opt = qml.QNGOptimizer(eta)
     >>> theta_new = opt.step(circuit, init_params)
     >>> theta_new

--- a/pennylane/optimize/rotosolve.py
+++ b/pennylane/optimize/rotosolve.py
@@ -236,12 +236,12 @@ class RotosolveOptimizer:
     .. code-block :: python
 
         init_param = (
-            pnp.array([0.3, 0.2, 0.67], requires_grad=True),
-            pnp.array(1.1, requires_grad=True),
-            pnp.array([-0.2, 0.1, -2.5], requires_grad=True),
+            np.array([0.3, 0.2, 0.67], requires_grad=True),
+            np.array(1.1, requires_grad=True),
+            np.array([-0.2, 0.1, -2.5], requires_grad=True),
         )
-        rot_weights = pnp.ones(3)
-        crot_weights = pnp.ones(3)
+        rot_weights = np.ones(3)
+        crot_weights = np.ones(3)
 
         nums_frequency = {
             "rot_param": {(0,): 1, (1,): 1, (2,): 1},
@@ -271,7 +271,7 @@ class RotosolveOptimizer:
     ...         crot_weights=crot_weights,
     ...     )
     ...     print(f"Cost before step: {cost}")
-    ...     print(f"Minimization substeps: {pnp.round(sub_cost, 6)}")
+    ...     print(f"Minimization substeps: {np.round(sub_cost, 6)}")
     ...     cost_rotosolve.extend(sub_cost)
     Cost before step: 0.04200821039253547
     Minimization substeps: [-0.230905 -0.863336 -0.980072 -0.980072 -1.       -1.       -1.      ]
@@ -290,8 +290,8 @@ class RotosolveOptimizer:
     but their concrete values. For the example QNode above, this happens if the
     weights are no longer one:
 
-    >>> rot_weights = pnp.array([0.4, 0.8, 1.2], requires_grad=False)
-    >>> crot_weights = pnp.array([0.5, 1.0, 1.5], requires_grad=False)
+    >>> rot_weights = np.array([0.4, 0.8, 1.2], requires_grad=False)
+    >>> crot_weights = np.array([0.5, 1.0, 1.5], requires_grad=False)
     >>> spectrum_fn = qml.fourier.qnode_spectrum(cost_function)
     >>> spectra = spectrum_fn(*param, rot_weights=rot_weights, crot_weights=crot_weights)
     >>> spectra["rot_param"]
@@ -313,7 +313,7 @@ class RotosolveOptimizer:
     ...         crot_weights = crot_weights,
     ...     )
     ...     print(f"Cost before step: {cost}")
-    ...     print(f"Minimization substeps: {pnp.round(sub_cost, 6)}")
+    ...     print(f"Minimization substeps: {np.round(sub_cost, 6)}")
     Cost before step: 0.09299359486191039
     Minimization substeps: [-0.268008 -0.713209 -0.24993  -0.871989 -0.907672 -0.907892 -0.940474]
     Cost before step: -0.9404742138557066

--- a/pennylane/optimize/shot_adaptive.py
+++ b/pennylane/optimize/shot_adaptive.py
@@ -86,7 +86,7 @@ class ShotAdaptiveOptimizer(GradientDescentOptimizer):
     iteration, and across the life of the optimizer, respectively.
 
     >>> shape = qml.templates.StronglyEntanglingLayers.shape(n_layers=2, n_wires=2)
-    >>> params = pnp.random.random(shape)
+    >>> params = np.random.random(shape)
     >>> opt = qml.ShotAdaptiveOptimizer(min_shots=10, term_sampling="weighted_random_sampling")
     >>> for i in range(60):
     ...    params = opt.step(cost, params)

--- a/pennylane/optimize/spsa.py
+++ b/pennylane/optimize/spsa.py
@@ -89,7 +89,7 @@ class SPSAOptimizer:
     >>> dev = qml.device("default.qubit", wires=num_qubits)
     >>> @qml.qnode(dev)
     ... def cost(params, num_qubits=1):
-    ...     qml.BasisState(pnp.array([1, 1, 0, 0]), wires=range(num_qubits))
+    ...     qml.BasisState(np.array([1, 1, 0, 0]), wires=range(num_qubits))
     ...     for i in range(num_qubits):
     ...         qml.Rot(*params[i], wires=0)
     ...         qml.CNOT(wires=[2, 3])
@@ -97,7 +97,7 @@ class SPSAOptimizer:
     ...         qml.CNOT(wires=[3, 1])
     ...     return qml.expval(H)
     ...
-    >>> params = pnp.random.normal(0, pnp.pi, (num_qubits, 3), requires_grad=True)
+    >>> params = np.random.normal(0, np.pi, (num_qubits, 3), requires_grad=True)
 
     Once constructed, the cost function can be passed directly to the
     ``step`` or ``step_and_cost`` function of the optimizer:


### PR DESCRIPTION
**Context:** While we use `from pennylane import numpy as pnp` internally in the code base, we should not use it for user-facing documentation. The current convention is:

```
from pennylane import numpy as np
```

**Description of the Change:** We revert the change to the documentation introduced in #6283 and #6303 

**Benefits:** Consistent convention across the documentation.

**Possible Drawbacks:** None that I can think of

**Related GitHub Issues:** None
