### PR TITLE
Update outdated `requirements-dev.txt` and `requirements-ci.txt` dependencies

### DIFF
--- a/.github/workflows/interface-unit-tests.yml
+++ b/.github/workflows/interface-unit-tests.yml
@@ -235,7 +235,6 @@ jobs:
       pytest_additional_args: --splits 3 --group ${{ matrix.group }}
       pytest_durations_file_path: '.github/workflows/tf_tests_durations.json'
       pytest_store_durations: ${{ inputs.pytest_store_durations }}
-      additional_pip_packages: pytest-split
       requirements_file: ${{ github.event_name == 'schedule' && strategy.job-index == 0 && 'tf.txt' || '' }}
       disable_new_opmath: ${{ inputs.disable_new_opmath }}
 
@@ -273,7 +272,6 @@ jobs:
       pytest_additional_args: --dist=loadscope --splits 5 --group ${{ matrix.group }}
       pytest_durations_file_path: '.github/workflows/jax_tests_durations.json'
       pytest_store_durations: ${{ inputs.pytest_store_durations }}
-      additional_pip_packages: pytest-split
       requirements_file: ${{ github.event_name == 'schedule' && strategy.job-index == 0 && 'jax.txt' || '' }}
       disable_new_opmath: ${{ inputs.disable_new_opmath }}
 
@@ -311,7 +309,6 @@ jobs:
       pytest_additional_args: --splits 5 --group ${{ matrix.group }}
       pytest_durations_file_path: '.github/workflows/core_tests_durations.json'
       pytest_store_durations: ${{ inputs.pytest_store_durations }}
-      additional_pip_packages: pytest-split
       requirements_file: ${{ github.event_name == 'schedule' && strategy.job-index == 0 && 'core.txt' || '' }}
       disable_new_opmath: ${{ inputs.disable_new_opmath }}
 

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -4,7 +4,7 @@ cvxpy
 cvxopt
 networkx
 rustworkx
-autograd
+autograd>=0.6.11
 toml
 appdirs
 packaging

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,5 +1,5 @@
 numpy
-scipy<=1.13.0
+scipy
 cvxpy
 cvxopt
 networkx
@@ -8,7 +8,7 @@ autograd
 toml
 appdirs
 packaging
-autoray>=0.6.1,<0.6.10
+autoray>=0.6.1
 matplotlib
 requests
 rich

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -4,11 +4,11 @@ cvxpy
 cvxopt
 networkx
 rustworkx
-autograd>=0.6.11
+autograd
 toml
 appdirs
 packaging
-autoray>=0.6.1
+autoray>=0.6.11
 matplotlib
 requests
 rich

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,6 +6,7 @@ pytest-xdist>=2.5.0
 flaky>=3.7.0
 pytest-forked>=1.4.0
 pytest-benchmark
+pytest-split
 black>=21
 tomli~=2.0.0 # Drop once minimum Python version is 3.11
 isort==5.13.2


### PR DESCRIPTION
`requirements-ci.txt`:
* Remove `autoray` upper bound
* Unpin `scipy`

`requirements-dev.txt`:
* Add `pytest-split`. This is selectively installed in CI for tests that are split among multiple runners, but I think it makes sense to include it in the `dev` requirements so that developers can split tests locally and also generate durations artifacts, which has become quite important lately 😅 
* Keeping the above change in mind, I removed the steps from all workflows that manually install `pytest-split` and also install `requirements-dev.txt`.