### PR TITLE
Standardize higher-order primitives to use `jax.core.Jaxpr`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -67,6 +67,7 @@
 
 * All higher order primitives now use `jax.core.Jaxpr` as metadata instead of sometimes
   using `jax.core.ClosedJaxpr` and sometimes using `jax.core.Jaxpr`.
+  [(#6319)](https://github.com/PennyLaneAI/pennylane/pull/6319)
 
 * `FermiWord` class now has a method to apply anti-commutator relations.
    [(#6196)](https://github.com/PennyLaneAI/pennylane/pull/6196)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -65,6 +65,9 @@
   `from pennylane.capture.primitives import *`.
   [(#6129)](https://github.com/PennyLaneAI/pennylane/pull/6129)
 
+* All higher order primitives now use `jax.core.Jaxpr` as metadata instead of sometimes
+  using `jax.core.ClosedJaxpr` and sometimes using `jax.core.Jaxpr`.
+
 * `FermiWord` class now has a method to apply anti-commutator relations.
    [(#6196)](https://github.com/PennyLaneAI/pennylane/pull/6196)
 

--- a/pennylane/compiler/qjit_api.py
+++ b/pennylane/compiler/qjit_api.py
@@ -419,15 +419,15 @@ def _get_while_loop_qfunc_prim():
 
         # If cond_fn(*init_state) is False, return the initial state
         fn_res = init_state
-        while jax.core.eval_jaxpr(jaxpr_cond_fn.jaxpr, jaxpr_consts_cond, *fn_res)[0]:
-            fn_res = jax.core.eval_jaxpr(jaxpr_body_fn.jaxpr, jaxpr_consts_body, *fn_res)
+        while jax.core.eval_jaxpr(jaxpr_cond_fn, jaxpr_consts_cond, *fn_res)[0]:
+            fn_res = jax.core.eval_jaxpr(jaxpr_body_fn, jaxpr_consts_body, *fn_res)
 
         return fn_res
 
     @while_loop_prim.def_abstract_eval
     def _(*_, jaxpr_body_fn, **__):
 
-        return jaxpr_body_fn.out_avals
+        return [out.aval for out in jaxpr_body_fn.outvars]
 
     return while_loop_prim
 
@@ -471,8 +471,8 @@ class WhileLoopCallable:  # pylint:disable=too-few-public-methods
             *jaxpr_body_fn.consts,
             *jaxpr_cond_fn.consts,
             *flat_args,
-            jaxpr_body_fn=jaxpr_body_fn,
-            jaxpr_cond_fn=jaxpr_cond_fn,
+            jaxpr_body_fn=jaxpr_body_fn.jaxpr,
+            jaxpr_cond_fn=jaxpr_cond_fn.jaxpr,
             n_consts_body=len(jaxpr_body_fn.consts),
             n_consts_cond=len(jaxpr_cond_fn.consts),
         )
@@ -635,14 +635,14 @@ def _get_for_loop_qfunc_prim():
         fn_res = init_state
 
         for i in range(lower_bound, upper_bound, step):
-            fn_res = jax.core.eval_jaxpr(jaxpr_body_fn.jaxpr, jaxpr_consts, i, *fn_res)
+            fn_res = jax.core.eval_jaxpr(jaxpr_body_fn, jaxpr_consts, i, *fn_res)
 
         return fn_res
 
     @for_loop_prim.def_abstract_eval
     def _(*_, jaxpr_body_fn, **__):
 
-        return jaxpr_body_fn.out_avals
+        return [out.aval for out in jaxpr_body_fn.outvars]
 
     return for_loop_prim
 
@@ -695,7 +695,7 @@ class ForLoopCallable:  # pylint:disable=too-few-public-methods
             self.step,
             *jaxpr_body_fn.consts,
             *flat_args,
-            jaxpr_body_fn=jaxpr_body_fn,
+            jaxpr_body_fn=jaxpr_body_fn.jaxpr,
             n_consts=len(jaxpr_body_fn.consts),
         )
         assert flat_fn.out_tree is not None

--- a/pennylane/ops/op_math/condition.py
+++ b/pennylane/ops/op_math/condition.py
@@ -246,6 +246,7 @@ class CondCallable:  # pylint:disable=too-few-public-methods
 
         jaxpr_branches = [jaxpr_true, *jaxpr_elifs, jaxpr_false]
         jaxpr_consts = [jaxpr.consts if jaxpr is not None else () for jaxpr in jaxpr_branches]
+        jaxpr_branches = [j.jaxpr if j else None for j in jaxpr_branches]
 
         # We need to flatten the constants since JAX does not allow
         # to pass lists as positional arguments
@@ -717,7 +718,7 @@ def _get_cond_qfunc_prim():
             if pred and jaxpr is not None:
                 if isinstance(pred, qml.measurements.MeasurementValue):
                     with qml.queuing.AnnotatedQueue() as q:
-                        out = jax.core.eval_jaxpr(jaxpr.jaxpr, consts, *args)
+                        out = jax.core.eval_jaxpr(jaxpr, consts, *args)
 
                     if len(out) != 0:
                         raise ConditionalTransformError(
@@ -728,14 +729,14 @@ def _get_cond_qfunc_prim():
                         Conditional(pred, wrapped_op.obj)
 
                 else:
-                    return jax.core.eval_jaxpr(jaxpr.jaxpr, consts, *args)
+                    return jax.core.eval_jaxpr(jaxpr, consts, *args)
 
         return ()
 
     @cond_prim.def_abstract_eval
     def _(*_, jaxpr_branches, **__):
 
-        outvals_true = jaxpr_branches[0].out_avals
+        outvals_true = [out.aval for out in jaxpr_branches[0].outvars]
 
         for idx, jaxpr_branch in enumerate(jaxpr_branches):
             if idx == 0:
@@ -749,7 +750,7 @@ def _get_cond_qfunc_prim():
                 # this is tested, but coverage does not pick it up
                 continue  # pragma: no cover
 
-            outvals_branch = jaxpr_branch.out_avals
+            outvals_branch = [out.aval for out in jaxpr_branch.outvars]
             branch_type = "elif" if idx < len(jaxpr_branches) - 1 else "false"
             _validate_abstract_values(outvals_branch, outvals_true, branch_type, idx - 1)
 


### PR DESCRIPTION
**Context:**

Currently, some of our higher order primitives store `jax.core.Jaxpr` as the metadata, and some store `jax.core.ClosedJaxpr`.  It can be difficult to remember which one is which, and the consts from the `ClosedJaxpr` are already present in the positional arguments anyway.

**Description of the Change:**

Standardize all current HOP's to use `jax.core.Jaxpr` in the metadata.

**Benefits:**

Fewer things developers have to remember when using HOP's.

**Possible Drawbacks:**

**Related GitHub Issues:**

[sc-74718]
