### PR TITLE
`qml.wire.Wires` accepts JAX tracers

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -58,6 +58,9 @@
 
 <h4>Capturing and representing hybrid programs</h4>
 
+* PennyLane will not raise a `FutureWarning` in `JAX 0.4.30+` when providing JAX tracers as input to `qml.wires.Wires`.
+  [(#6335)](https://github.com/PennyLaneAI/pennylane/pull/6335)
+
 * `qml.wires.Wires` now accepts JAX arrays as input.
   [(#6312)](https://github.com/PennyLaneAI/pennylane/pull/6312)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -58,7 +58,7 @@
 
 <h4>Capturing and representing hybrid programs</h4>
 
-* PennyLane will not raise a `FutureWarning` in `JAX 0.4.30+` when providing JAX tracers as input to `qml.wires.Wires`.
+* PennyLane no longer raises a `FutureWarning` in `JAX 0.4.30+` when providing JAX tracers as input to `qml.wires.Wires`.
   [(#6335)](https://github.com/PennyLaneAI/pennylane/pull/6335)
 
 * `qml.wires.Wires` now accepts JAX arrays as input.

--- a/pennylane/wires.py
+++ b/pennylane/wires.py
@@ -17,12 +17,24 @@ This module contains the :class:`Wires` class, which takes care of wire bookkeep
 import functools
 import itertools
 from collections.abc import Hashable, Iterable, Sequence
+from importlib import import_module, util
 from typing import Union
 
 import numpy as np
 
 import pennylane as qml
 from pennylane.pytrees import register_pytree
+
+if util.find_spec("jax") is not None:
+    jax = import_module("jax")
+    jax_available = True
+else:
+    jax_available = False
+    jax = None
+
+if jax_available:
+    # pylint: disable=unnecessary-lambda
+    setattr(jax.interpreters.partial_eval.DynamicJaxprTracer, "__hash__", lambda x: id(x))
 
 
 class WireError(Exception):

--- a/pennylane/wires.py
+++ b/pennylane/wires.py
@@ -65,11 +65,13 @@ def _process(wires):
 
     if qml.math.get_interface(wires) == "jax":
 
-        if qml.math.is_abstract(wires) and qml.capture.enabled():
-            return (wires,)
+        if not qml.math.is_abstract(wires):
+            wires = tuple(wires.tolist() if wires.ndim > 0 else (wires.item(),))
 
         else:
-            wires = tuple(wires.tolist() if wires.ndim > 0 else (wires.item(),))
+
+            if qml.capture.enabled():
+                return (wires,)
 
     try:
         # Use tuple conversion as a check for whether `wires` can be iterated over.

--- a/pennylane/wires.py
+++ b/pennylane/wires.py
@@ -52,10 +52,9 @@ def _process(wires):
         # of considering the elements of iterables as wire labels.
         wires = [wires]
 
-    if qml.math.get_interface(wires) == "jax":
-        if qml.math.is_abstract(wires):
-            if qml.capture.enabled():
-                return (wires,)
+    if qml.math.is_abstract(wires, like="jax"):
+        if qml.capture.enabled():
+            return (wires,)
         else:
             wires = tuple(wires.tolist() if wires.ndim > 0 else (wires.item(),))
 
@@ -73,6 +72,9 @@ def _process(wires):
             if str(e).startswith("unhashable"):
                 raise WireError(f"Wires must be hashable; got object of type {type(wires)}.") from e
         return (wires,)
+
+    if any(qml.math.is_abstract(w, like="jax") for w in tuple_of_wires) and qml.capture.enabled():
+        return tuple_of_wires
 
     try:
         # We need the set for the uniqueness check,

--- a/pennylane/wires.py
+++ b/pennylane/wires.py
@@ -52,9 +52,10 @@ def _process(wires):
         # of considering the elements of iterables as wire labels.
         wires = [wires]
 
-    if qml.math.is_abstract(wires, like="jax"):
-        if qml.capture.enabled():
-            return (wires,)
+    if qml.math.get_interface(wires) == "jax":
+        if qml.math.is_abstract(wires):
+            if qml.capture.enabled():
+                return (wires,)
         else:
             wires = tuple(wires.tolist() if wires.ndim > 0 else (wires.item(),))
 
@@ -73,7 +74,7 @@ def _process(wires):
                 raise WireError(f"Wires must be hashable; got object of type {type(wires)}.") from e
         return (wires,)
 
-    if any(qml.math.is_abstract(w, like="jax") for w in tuple_of_wires) and qml.capture.enabled():
+    if any(qml.math.is_abstract(w) for w in tuple_of_wires) and qml.capture.enabled():
         return tuple_of_wires
 
     try:

--- a/pennylane/wires.py
+++ b/pennylane/wires.py
@@ -169,11 +169,6 @@ class Wires(Sequence):
     def __hash__(self):
         """Implements the hash function."""
 
-        if any(qml.math.is_abstract(w) for w in self._labels) and qml.capture.enabled():
-            raise WireError(
-                "Cannot hash wires that contain abstract objects with qml.capture enabled."
-            )
-
         if self._hash is None:
             self._hash = hash(self._labels)
         return self._hash

--- a/pennylane/wires.py
+++ b/pennylane/wires.py
@@ -17,7 +17,6 @@ This module contains the :class:`Wires` class, which takes care of wire bookkeep
 import functools
 import itertools
 from collections.abc import Hashable, Iterable, Sequence
-
 from typing import Union
 
 import numpy as np

--- a/pennylane/wires.py
+++ b/pennylane/wires.py
@@ -17,12 +17,24 @@ This module contains the :class:`Wires` class, which takes care of wire bookkeep
 import functools
 import itertools
 from collections.abc import Hashable, Iterable, Sequence
+from importlib import import_module, util
 from typing import Union
 
 import numpy as np
 
 import pennylane as qml
 from pennylane.pytrees import register_pytree
+
+if util.find_spec("jax") is not None:
+    jax = import_module("jax")
+    jax_available = True
+else:
+    jax_available = False
+    jax = None
+
+if jax_available:
+    # pylint: disable=unnecessary-lambda
+    setattr(jax.interpreters.partial_eval.DynamicJaxprTracer, "__hash__", lambda x: id(x))
 
 
 class WireError(Exception):
@@ -51,12 +63,8 @@ def _process(wires):
         # of considering the elements of iterables as wire labels.
         wires = [wires]
 
-    if qml.math.get_interface(wires) == "jax":
-        if qml.math.is_abstract(wires):
-            if qml.capture.enabled():
-                return (wires,)
-        else:
-            wires = tuple(wires.tolist() if wires.ndim > 0 else (wires.item(),))
+    if qml.math.get_interface(wires) == "jax" and not qml.math.is_abstract(wires):
+        wires = tuple(wires.tolist() if wires.ndim > 0 else (wires.item(),))
 
     try:
         # Use tuple conversion as a check for whether `wires` can be iterated over.
@@ -72,9 +80,6 @@ def _process(wires):
             if str(e).startswith("unhashable"):
                 raise WireError(f"Wires must be hashable; got object of type {type(wires)}.") from e
         return (wires,)
-
-    if any(qml.math.is_abstract(w) for w in tuple_of_wires) and qml.capture.enabled():
-        return tuple_of_wires
 
     try:
         # We need the set for the uniqueness check,
@@ -168,7 +173,6 @@ class Wires(Sequence):
 
     def __hash__(self):
         """Implements the hash function."""
-
         if self._hash is None:
             self._hash = hash(self._labels)
         return self._hash

--- a/tests/capture/test_measurements_capture.py
+++ b/tests/capture/test_measurements_capture.py
@@ -171,6 +171,7 @@ def test_capture_and_eval(func):
     qml.assert_equal(mp, out)
 
 
+@pytest.mark.filterwarnings("error::FutureWarning")
 @pytest.mark.parametrize("x64_mode", [True, False])
 def test_mid_measure(x64_mode):
     """Test that mid circuit measurements can be captured and executed."""
@@ -354,6 +355,7 @@ class TestExpvalVar:
 @pytest.mark.parametrize("x64_mode", (True, False))
 class TestProbs:
 
+    @pytest.mark.filterwarnings("error::FutureWarning")
     @pytest.mark.parametrize("wires, shape", [([0, 1, 2], 8), ([], 16)])
     def test_wires(self, wires, shape, x64_mode):
         """Tests capturing probabilities on wires."""
@@ -578,6 +580,7 @@ def test_shadow_expval(x64_mode):
     jax.config.update("jax_enable_x64", initial_mode)
 
 
+@pytest.mark.filterwarnings("error::FutureWarning")
 @pytest.mark.parametrize("x64_mode", (True, False))
 @pytest.mark.parametrize("mtype, kwargs", [(VnEntropyMP, {"log_base": 2}), (PurityMP, {})])
 def test_vn_entropy_purity(mtype, kwargs, x64_mode):
@@ -610,6 +613,7 @@ def test_vn_entropy_purity(mtype, kwargs, x64_mode):
     jax.config.update("jax_enable_x64", initial_mode)
 
 
+@pytest.mark.filterwarnings("error::FutureWarning")
 @pytest.mark.parametrize("x64_mode", (True, False))
 @pytest.mark.parametrize("mtype", [MutualInfoMP, VnEntanglementEntropyMP])
 def test_mutual_info_vn_entanglement_entropy(mtype, x64_mode):

--- a/tests/capture/test_nested_plxpr.py
+++ b/tests/capture/test_nested_plxpr.py
@@ -218,6 +218,7 @@ class TestCtrlQfunc:
         assert plxpr.eqns[0].params["work_wires"] is None
         assert plxpr.eqns[0].params["n_consts"] == 0
 
+    @pytest.mark.filterwarnings("error::FutureWarning")
     def test_dynamic_control_wires(self):
         """Test that control wires can be dynamic."""
 

--- a/tests/test_wires.py
+++ b/tests/test_wires.py
@@ -499,6 +499,7 @@ class TestWires:
 
 
 @pytest.mark.jax
+@pytest.mark.filterwarnings("error::FutureWarning")
 class TestWiresJax:
     """Tests the support for JAX arrays in the ``Wires`` class."""
 


### PR DESCRIPTION
**Context:** If we try to use JAX tracers as wires in PennyLane using `JAX 0.4.30+`, we currently get `FutureWarning` in some of the tests:

```
FutureWarning: unhashable type: <class 'jax._src.interpreters.partial_eval.DynamicJaxprTracer'>. Attempting to hash a tracer will lead to an error in a future JAX release.

```

Notice that this future warning was introduced in `JAX 0.4.30` and is still not implemented as an error in `0.4.32`. At present, both PL and Catalyst currently use version `0.4.28`). Although this is not a super-urgent priority, it is best to take care of this now rather than later. 

**Description of the Change:** ...

**Benefits:** ...

**Possible Drawbacks:** ...

**Related GitHub Issues:** None.

**Related ShortCut Stories:** [sc-74904]