### PR TITLE
Bumping `NumPy` allowing `<2.1` instead of `<2.0`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -32,6 +32,7 @@
 * PennyLane is now compatible with NumPy 2.0.
   [(#6061)](https://github.com/PennyLaneAI/pennylane/pull/6061)
   [(#6258)](https://github.com/PennyLaneAI/pennylane/pull/6258)
+  [(#6342)](https://github.com/PennyLaneAI/pennylane/pull/6342)
 
 * PennyLane is now compatible with Jax 0.4.28.
   [(#6255)](https://github.com/PennyLaneAI/pennylane/pull/6255)

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ with open("pennylane/_version.py") as f:
     version = f.readlines()[-1].split()[-1].strip("\"'")
 
 requirements = [
-    "numpy<=2.0",
+    "numpy<2.1",
     "scipy",
     "networkx",
     "rustworkx>=0.14.0",


### PR DESCRIPTION
**Context:** There's a bug in NumPy 2.0.0 that's blocking Catalyst from using the numpy C API with the Stable ABI.

**Description of the Change:** We shift the pin from `<2.0` to `<2.1` in `setup.py` for NumPy in PL. Notice that NumPy 2.1 has additional changes that may/may not play nicely with PL. We aren't worrying (yet) about the subsequent changes in NumPy 2.1

**Benefits:** Resolves the issue in Catalyst underlined in #6341.

**Possible Drawbacks:** None that I can think of (except that we still impose an upper bound to NumPy).

**Related GitHub Issues:** Closes #6341
