### PR TITLE
`qml.matrix` returns identity matrix for empty objects if `wire_order` is specified

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -29,6 +29,9 @@
 
 <h3>Improvements 🛠</h3>
 
+* `qml.matrix` now works with empty objects (such as empty tapes, `QNode`s and quantum functions that do
+  not call operations, single operators with empty decompositions).
+  
 * PennyLane is now compatible with NumPy 2.0.
   [(#6061)](https://github.com/PennyLaneAI/pennylane/pull/6061)
   [(#6258)](https://github.com/PennyLaneAI/pennylane/pull/6258)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -37,6 +37,7 @@
 
 * `qml.matrix` now works with empty objects (such as empty tapes, `QNode`s and quantum functions that do
   not call operations, single operators with empty decompositions).
+  [(#6347)](https://github.com/PennyLaneAI/pennylane/pull/6347)
   
 * PennyLane is now compatible with NumPy 2.0.
   [(#6061)](https://github.com/PennyLaneAI/pennylane/pull/6061)

--- a/pennylane/ops/functions/matrix.py
+++ b/pennylane/ops/functions/matrix.py
@@ -188,19 +188,17 @@ def matrix(op: Union[Operator, PauliWord, PauliSentence], wire_order=None) -> Te
 
     if not isinstance(op, Operator):
 
-        if isinstance(op, (PauliWord, PauliSentence)):
-            if wire_order is None and len(op.wires) > 1:
-                raise ValueError(
-                    "wire_order is required by qml.matrix() for PauliWords "
-                    "or PauliSentences with more than one wire."
-                )
-            return op.to_mat(wire_order=wire_order)
-
-        if isinstance(op, QuantumScript):
-            if wire_order is None and len(op.wires) > 1:
-                raise ValueError(
-                    "wire_order is required by qml.matrix() for tapes with more than one wire."
-                )
+        if (is_pauli := isinstance(op, (PauliWord, PauliSentence))) or isinstance(
+            op, QuantumScript
+        ):
+            if wire_order is None:
+                error_base_str = f"wire_order is required by qml.matrix() for {type(op)}s"
+                if len(op.wires) > 1:
+                    raise ValueError(error_base_str + " with more than one wire.")
+                if len(op.wires) == 0:
+                    raise ValueError(error_base_str + " without wires.")
+            if is_pauli:
+                return op.to_mat(wire_order=wire_order)
 
         elif isinstance(op, qml.QNode):
             if wire_order is None and op.device.wires is None:
@@ -235,8 +233,6 @@ def matrix(op: Union[Operator, PauliWord, PauliSentence], wire_order=None) -> Te
 def _matrix_transform(
     tape: QuantumScript, wire_order=None, **kwargs
 ) -> tuple[QuantumScriptBatch, PostprocessingFn]:
-    if not tape.wires:
-        raise qml.operation.MatrixUndefinedError
 
     if wire_order and not set(tape.wires).issubset(wire_order):
         raise TransformError(

--- a/pennylane/ops/functions/matrix.py
+++ b/pennylane/ops/functions/matrix.py
@@ -198,7 +198,7 @@ def matrix(op: Union[Operator, PauliWord, PauliSentence], wire_order=None) -> Te
 
         if isinstance(op, QuantumScript):
             if wire_order is None:
-                error_base_str = f"wire_order is required by qml.matrix() for tapes"
+                error_base_str = "wire_order is required by qml.matrix() for tapes"
                 if len(op.wires) > 1:
                     raise ValueError(error_base_str + " with more than one wire.")
                 if len(op.wires) == 0:

--- a/pennylane/ops/functions/matrix.py
+++ b/pennylane/ops/functions/matrix.py
@@ -188,17 +188,21 @@ def matrix(op: Union[Operator, PauliWord, PauliSentence], wire_order=None) -> Te
 
     if not isinstance(op, Operator):
 
-        if (is_pauli := isinstance(op, (PauliWord, PauliSentence))) or isinstance(
-            op, QuantumScript
-        ):
+        if isinstance(op, (PauliWord, PauliSentence)):
+            if wire_order is None and len(op.wires) > 1:
+                raise ValueError(
+                    "wire_order is required by qml.matrix() for PauliWords "
+                    "or PauliSentences with more than one wire."
+                )
+            return op.to_mat(wire_order=wire_order)
+
+        if isinstance(op, QuantumScript):
             if wire_order is None:
-                error_base_str = f"wire_order is required by qml.matrix() for {type(op)}s"
+                error_base_str = f"wire_order is required by qml.matrix() for tapes"
                 if len(op.wires) > 1:
                     raise ValueError(error_base_str + " with more than one wire.")
                 if len(op.wires) == 0:
                     raise ValueError(error_base_str + " without wires.")
-            if is_pauli:
-                return op.to_mat(wire_order=wire_order)
 
         elif isinstance(op, qml.QNode):
             if wire_order is None and op.device.wires is None:

--- a/tests/ops/functions/conftest.py
+++ b/tests/ops/functions/conftest.py
@@ -72,6 +72,7 @@ _INSTANCES_TO_TEST = [
     (qml.prod(qml.RX(1.1, 0), qml.RY(2.2, 0), qml.RZ(3.3, 1)), {}),
     (qml.Snapshot(measurement=qml.expval(qml.Z(0)), tag="hi"), {}),
     (qml.Snapshot(tag="tag"), {}),
+    (qml.Identity(0), {}),
 ]
 """Valid operator instances that could not be auto-generated."""
 
@@ -109,12 +110,8 @@ _INSTANCES_TO_FAIL = [
         AssertionError,  # needs flattening helpers to be updated, also cannot be pickled
     ),
     (
-        qml.Identity(0),
-        MatrixUndefinedError,  # empty decomposition, matrix differs from decomp's matrix
-    ),
-    (
         qml.GlobalPhase(1.1),
-        MatrixUndefinedError,  # empty decomposition, matrix differs from decomp's matrix
+        AssertionError,  # empty decomposition, matrix differs from decomp's matrix
     ),
     (
         qml.pulse.ParametrizedEvolution(qml.PauliX(0) + sum * qml.PauliZ(0)),

--- a/tests/ops/functions/conftest.py
+++ b/tests/ops/functions/conftest.py
@@ -23,14 +23,7 @@ import numpy as np
 import pytest
 
 import pennylane as qml
-from pennylane.operation import (
-    Channel,
-    MatrixUndefinedError,
-    Observable,
-    Operation,
-    Operator,
-    Tensor,
-)
+from pennylane.operation import Channel, Observable, Operation, Operator, Tensor
 from pennylane.ops.op_math.adjoint import Adjoint, AdjointObs, AdjointOperation, AdjointOpObs
 from pennylane.ops.op_math.pow import PowObs, PowOperation, PowOpObs
 

--- a/tests/ops/functions/test_matrix.py
+++ b/tests/ops/functions/test_matrix.py
@@ -183,6 +183,25 @@ class TestSingleOperation:
 
         assert np.allclose(mat, expected)
 
+    def test_empty_decomposition(self):
+        """Test the matrix of a single operation that has an empty list as decomposition."""
+
+        dev = qml.device("default.qubit", wires=2)
+
+        @qml.qnode(dev)
+        def node():
+            qml.Snapshot("tag")
+            return qml.expval(qml.Z(0))
+
+        mats = [
+            qml.matrix(qml.Snapshot(), wire_order=[0, 1]),  # op without wires
+            qml.matrix(qml.Barrier(1), wire_order=[0, 1]),  # op with wires w/ wire_order
+            qml.matrix(qml.Barrier([0, 1])),  # op with wires w/o wire_order
+            qml.matrix((lambda *_: qml.Barrier(1) and None), wire_order=[0, 1])(),  # qfunc
+            qml.matrix(node)(),  # qnode
+        ]
+        assert all(np.allclose(mat, np.eye(4)) for mat in mats)
+
 
 class TestMultipleOperations:
     def test_multiple_operations_tape(self):
@@ -416,6 +435,11 @@ class TestCustomWireOrdering:
         op2 = qml.PauliY(0) @ qml.PauliZ(1) @ qml.PauliX(2)
         op = 1.5 * op1 + 0.5 * op2
         assert qml.math.allclose(qml.matrix(ps, wire_order), qml.matrix(op, wire_order))
+
+    def test_empty_tape_with_wire_order(self):
+        """Test that an empty tape's matrix can be computed if wire_order is specified."""
+        qs = qml.tape.QuantumScript()
+        assert np.allclose(qml.matrix(qs, wire_order=[0, 2]), np.eye(4))
 
 
 pw1 = PauliWord({0: "X", 1: "Z"})
@@ -828,21 +852,24 @@ class TestMeasurements:
 class TestWireOrderErrors:
     """Test that wire_order=None raises an error in qml.matrix transform."""
 
-    def test_error_pauli_word(self):
+    @pytest.mark.parametrize("pw", [PauliWord({0: "X", 1: "X"}), PauliWord({})])
+    def test_error_pauli_word(self, pw):
         """Test that an error is raised when calling qml.matrix without wire_order on a PauliWord"""
-        pw = PauliWord({0: "X", 1: "X"})
         with pytest.raises(ValueError, match=r"wire_order is required"):
             _ = qml.matrix(pw)
 
-    def test_error_pauli_sentence(self):
+    @pytest.mark.parametrize(
+        "ps", [PauliSentence({PauliWord({0: "X", 1: "X"}): 1.0}), PauliSentence({})]
+    )
+    def test_error_pauli_sentence(self, ps):
         """Test that an error is raised when calling qml.matrix without wire_order on a PauliSentence"""
-        ps = PauliSentence({PauliWord({0: "X", 1: "X"}): 1.0})
         with pytest.raises(ValueError, match=r"wire_order is required"):
             _ = qml.matrix(ps)
 
-    def test_error_tape(self):
+    @pytest.mark.parametrize("ops", [[qml.PauliX(1), qml.PauliX(0)], []])
+    def test_error_tape_multiple_wires(self, ops):
         """Test that an error is raised when calling qml.matrix without wire_order on a tape."""
-        qs = qml.tape.QuantumScript([qml.PauliX(1), qml.PauliX(0)])
+        qs = qml.tape.QuantumScript(ops)
         with pytest.raises(ValueError, match=r"wire_order is required"):
             _ = qml.matrix(qs)
 

--- a/tests/ops/functions/test_matrix.py
+++ b/tests/ops/functions/test_matrix.py
@@ -852,14 +852,14 @@ class TestMeasurements:
 class TestWireOrderErrors:
     """Test that wire_order=None raises an error in qml.matrix transform."""
 
-    @pytest.mark.parametrize("pw", [PauliWord({0: "X", 1: "X"}), PauliWord({})])
+    @pytest.mark.parametrize("pw", [PauliWord({0: "X", 1: "X"})])#, PauliWord({})])
     def test_error_pauli_word(self, pw):
         """Test that an error is raised when calling qml.matrix without wire_order on a PauliWord"""
         with pytest.raises(ValueError, match=r"wire_order is required"):
             _ = qml.matrix(pw)
 
     @pytest.mark.parametrize(
-        "ps", [PauliSentence({PauliWord({0: "X", 1: "X"}): 1.0}), PauliSentence({})]
+        "ps", [PauliSentence({PauliWord({0: "X", 1: "X"}): 1.0})]#, PauliSentence({})]
     )
     def test_error_pauli_sentence(self, ps):
         """Test that an error is raised when calling qml.matrix without wire_order on a PauliSentence"""

--- a/tests/ops/functions/test_matrix.py
+++ b/tests/ops/functions/test_matrix.py
@@ -852,17 +852,15 @@ class TestMeasurements:
 class TestWireOrderErrors:
     """Test that wire_order=None raises an error in qml.matrix transform."""
 
-    @pytest.mark.parametrize("pw", [PauliWord({0: "X", 1: "X"})])  # , PauliWord({})])
-    def test_error_pauli_word(self, pw):
+    def test_error_pauli_word(self):
         """Test that an error is raised when calling qml.matrix without wire_order on a PauliWord"""
+        pw = PauliWord({0: "X", 1: "X"})
         with pytest.raises(ValueError, match=r"wire_order is required"):
             _ = qml.matrix(pw)
 
-    @pytest.mark.parametrize(
-        "ps", [PauliSentence({PauliWord({0: "X", 1: "X"}): 1.0})]  # , PauliSentence({})]
-    )
-    def test_error_pauli_sentence(self, ps):
+    def test_error_pauli_sentence(self):
         """Test that an error is raised when calling qml.matrix without wire_order on a PauliSentence"""
+        ps = PauliSentence({PauliWord({0: "X", 1: "X"}): 1.0})
         with pytest.raises(ValueError, match=r"wire_order is required"):
             _ = qml.matrix(ps)
 

--- a/tests/ops/functions/test_matrix.py
+++ b/tests/ops/functions/test_matrix.py
@@ -852,14 +852,14 @@ class TestMeasurements:
 class TestWireOrderErrors:
     """Test that wire_order=None raises an error in qml.matrix transform."""
 
-    @pytest.mark.parametrize("pw", [PauliWord({0: "X", 1: "X"})])#, PauliWord({})])
+    @pytest.mark.parametrize("pw", [PauliWord({0: "X", 1: "X"})])  # , PauliWord({})])
     def test_error_pauli_word(self, pw):
         """Test that an error is raised when calling qml.matrix without wire_order on a PauliWord"""
         with pytest.raises(ValueError, match=r"wire_order is required"):
             _ = qml.matrix(pw)
 
     @pytest.mark.parametrize(
-        "ps", [PauliSentence({PauliWord({0: "X", 1: "X"}): 1.0})]#, PauliSentence({})]
+        "ps", [PauliSentence({PauliWord({0: "X", 1: "X"}): 1.0})]  # , PauliSentence({})]
     )
     def test_error_pauli_sentence(self, ps):
         """Test that an error is raised when calling qml.matrix without wire_order on a PauliSentence"""

--- a/tests/ops/test_meta.py
+++ b/tests/ops/test_meta.py
@@ -165,11 +165,16 @@ class TestBarrier:
         op = qml.Barrier(wires=(0, 1, 2, 3), only_visual=False)
         assert op.simplify() is op
 
-    def test_qml_matrix_fails(self):
+    def test_qml_matrix_gives_identity(self):
+        """Test that qml.matrix(op) gives an identity."""
+        op = qml.Barrier(0)
+        assert np.allclose(qml.matrix(op), np.eye(2))
+        op = qml.Barrier()
+        assert np.allclose(qml.matrix(op, wire_order=[0, 3]), np.eye(4))
+
+    def test_op_matrix_fails(self):
         """Test that qml.matrix(op) and op.matrix() both fail."""
         op = qml.Barrier(0)
-        with pytest.raises(qml.operation.MatrixUndefinedError):
-            qml.matrix(op)
         with pytest.raises(qml.operation.MatrixUndefinedError):
             op.matrix()
 
@@ -203,11 +208,14 @@ class TestWireCut:
         ):
             qml.WireCut(wires=[])
 
-    def test_qml_matrix_fails(self):
+    def test_qml_matrix_gives_identity(self):
+        """Test that qml.matrix(op) gives an identity."""
+        op = qml.WireCut(0)
+        assert np.allclose(qml.matrix(op), np.eye(2))
+
+    def test_op_matrix_fails(self):
         """Test that qml.matrix(op) and op.matrix() both fail."""
         op = qml.WireCut(0)
-        with pytest.raises(qml.operation.MatrixUndefinedError):
-            qml.matrix(op)
         with pytest.raises(qml.operation.MatrixUndefinedError):
             op.matrix()
 


### PR DESCRIPTION
**Context:**
Currently, `qml.matrix` raises a `ValueError` for 
- empty `QuantumTape`s
- quantum functions that do not call any operations
- single operations with an empty decomposition
- `QNode`s that do not call any operations, but only if no device wires are given and `wire_order is None`.

In particular, empty `QNode` and `PauliWord`/`PauliSentence`  do not raise an error if `wire_order` is specified.
The Pauli classes even don't raise an error without `wire_order`, which will be a very mild inconsistency that is left untouched by this PR.

**Description of the Change:**
This PR changes the above, so that `qml.matrix` always returns the identity matrix on `len(wire_order)` qubits for empty objects, for which currently a `ValueError` is raised.

**Benefits:**
- More objects are supported. In particular, the matrix of tapes containing `qml.Barrier` and `qml.Snapshot` can be computed.
- More consistent behaviour between different inputs to `qml.matrix`.

**Possible Drawbacks:**
- Mildly breaking change, although the only change is `ValueError -> identity matrix return`.

**Related GitHub Issues:**
Supersedes #6339.
[sc-74913]
