### PR TITLE
Fix cotransform of `quantum_fisher`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -220,6 +220,9 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* `quantum_fisher` now respects the classical Jacobian of QNodes.
+  [(#6350)](https://github.com/PennyLaneAI/pennylane/pull/6350)
+
 * `qml.map_wires` can now be applied to a batch of tapes.
   [(#6295)](https://github.com/PennyLaneAI/pennylane/pull/6295)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -32,6 +32,7 @@
 * PennyLane is now compatible with NumPy 2.0.
   [(#6061)](https://github.com/PennyLaneAI/pennylane/pull/6061)
   [(#6258)](https://github.com/PennyLaneAI/pennylane/pull/6258)
+  [(#6342)](https://github.com/PennyLaneAI/pennylane/pull/6342)
 
 * PennyLane is now compatible with Jax 0.4.28.
   [(#6255)](https://github.com/PennyLaneAI/pennylane/pull/6255)

--- a/pennylane/gradients/fisher.py
+++ b/pennylane/gradients/fisher.py
@@ -19,6 +19,7 @@ import pennylane as qml
 from pennylane import transform
 from pennylane.devices import DefaultQubit
 from pennylane.gradients import adjoint_metric_tensor
+from pennylane.gradients.metric_tensor import _contract_metric_tensor_with_cjac
 from pennylane.typing import PostprocessingFn
 
 
@@ -280,7 +281,7 @@ def classical_fisher(qnode, argnums=0):
     return wrapper
 
 
-@partial(transform, is_informative=True)
+@partial(transform, classical_cotransfom=__contract_metric_tensor_with_cjac, is_informative=True)
 def quantum_fisher(
     tape: qml.tape.QuantumScript, device, *args, **kwargs
 ) -> tuple[qml.tape.QuantumScriptBatch, PostprocessingFn]:

--- a/pennylane/gradients/fisher.py
+++ b/pennylane/gradients/fisher.py
@@ -281,7 +281,7 @@ def classical_fisher(qnode, argnums=0):
     return wrapper
 
 
-@partial(transform, classical_cotransfom=_contract_metric_tensor_with_cjac, is_informative=True)
+@partial(transform, classical_cotransform=_contract_metric_tensor_with_cjac, is_informative=True)
 def quantum_fisher(
     tape: qml.tape.QuantumScript, device, *args, **kwargs
 ) -> tuple[qml.tape.QuantumScriptBatch, PostprocessingFn]:

--- a/pennylane/gradients/fisher.py
+++ b/pennylane/gradients/fisher.py
@@ -281,7 +281,7 @@ def classical_fisher(qnode, argnums=0):
     return wrapper
 
 
-@partial(transform, classical_cotransfom=__contract_metric_tensor_with_cjac, is_informative=True)
+@partial(transform, classical_cotransfom=_contract_metric_tensor_with_cjac, is_informative=True)
 def quantum_fisher(
     tape: qml.tape.QuantumScript, device, *args, **kwargs
 ) -> tuple[qml.tape.QuantumScriptBatch, PostprocessingFn]:

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ with open("pennylane/_version.py") as f:
     version = f.readlines()[-1].split()[-1].strip("\"'")
 
 requirements = [
-    "numpy<=2.0",
+    "numpy<2.1",
     "scipy",
     "networkx",
     "rustworkx>=0.14.0",

--- a/tests/gradients/core/test_fisher.py
+++ b/tests/gradients/core/test_fisher.py
@@ -152,7 +152,8 @@ class TestIntegration:
         ),
     )
     def test_quantum_fisher_info(self, dev):
-        """Integration test of quantum fisher information matrix CFIM. This is just calling ``qml.metric_tensor`` or ``qml.adjoint_metric_tensor`` and multiplying by a factor of 4"""
+        """Integration test of quantum fisher information matrix CFIM. This is just calling
+        ``qml.metric_tensor`` or ``qml.adjoint_metric_tensor`` and multiplying by a factor of 4"""
 
         n_wires = 2
 
@@ -160,8 +161,8 @@ class TestIntegration:
         dev_hard = qml.device("default.qubit", wires=n_wires + 1, shots=1000, seed=rng)
 
         def qfunc(params):
-            qml.RX(params[0], wires=0)
             qml.RX(params[1], wires=0)
+            qml.RX(params[0] / 3, wires=0)
             qml.CNOT(wires=(0, 1))
             return qml.probs(wires=[0, 1])
 


### PR DESCRIPTION
**Context:**
`quantum_fisher` does not respect the classical Jacobian of a QNode, because its `classical_cotransform` is not set.

**Description of the Change:**
Set the same classical_cotransform as `adjoint_metric_tensor` and `metric_tensor`.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
Fixes #6345 
[sc-75092]