### PR TITLE
Fix `adjoint_metric_tensor` with `StatePrep`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -237,6 +237,9 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* `adjoint_metric_tensor` now works with circuits containing state preparation operations.
+  [(#6358)](https://github.com/PennyLaneAI/pennylane/pull/6358)
+
 * `quantum_fisher` now respects the classical Jacobian of QNodes.
   [(#6350)](https://github.com/PennyLaneAI/pennylane/pull/6350)
 

--- a/pennylane/gradients/adjoint_metric_tensor.py
+++ b/pennylane/gradients/adjoint_metric_tensor.py
@@ -184,7 +184,7 @@ def adjoint_metric_tensor(
         L = qml.math.convert_like(qml.math.zeros((tape.num_params, tape.num_params)), like_real)
         T = qml.math.convert_like(qml.math.zeros((tape.num_params,)), like_real)
 
-        for op in group_after_trainable_op[-1]:
+        for op in group_after_trainable_op[-1][int(prep is not None) :]:
             psi = qml.devices.qubit.apply_operation(op, psi)
 
         for j, outer_op in enumerate(trainable_operations):

--- a/tests/gradients/core/test_adjoint_metric_tensor.py
+++ b/tests/gradients/core/test_adjoint_metric_tensor.py
@@ -622,6 +622,7 @@ def test_works_with_state_prep():
     """Test that a state preparation operation is respected."""
     dev = qml.device("default.qubit")
 
+    # Some random normalized state, no particular relevance
     init_state = onp.array([0.16769259, 0.71277864, 0.54562903, 0.4075718])
 
     def ansatz(angles, wires):

--- a/tests/gradients/core/test_adjoint_metric_tensor.py
+++ b/tests/gradients/core/test_adjoint_metric_tensor.py
@@ -217,10 +217,10 @@ def autodiff_metric_tensor(ansatz, num_wires):
         state = qnode(*params)
 
         def rqnode(*params):
-            return qml.math.real(qnode(*params))
+            return np.real(qnode(*params))
 
         def iqnode(*params):
-            return qml.math.imag(qnode(*params))
+            return np.imag(qnode(*params))
 
         rjac = qml.jacobian(rqnode)(*params)
         ijac = qml.jacobian(iqnode)(*params)
@@ -229,20 +229,20 @@ def autodiff_metric_tensor(ansatz, num_wires):
             out = []
             for rc, ic in zip(rjac, ijac):
                 c = rc + 1j * ic
-                psidpsi = qml.math.tensordot(qml.math.conj(state), c, axes=([0], [0]))
+                psidpsi = np.tensordot(np.conj(state), c, axes=([0], [0]))
                 out.append(
-                    qml.math.real(
-                        qml.math.tensordot(qml.math.conj(c), c, axes=([0], [0]))
-                        - qml.math.tensordot(qml.math.conj(psidpsi), psidpsi, axes=0)
+                    np.real(
+                        np.tensordot(np.conj(c), c, axes=([0], [0]))
+                        - np.tensordot(np.conj(psidpsi), psidpsi, axes=0)
                     )
                 )
             return tuple(out)
 
         jac = rjac + 1j * ijac
-        psidpsi = qml.math.tensordot(qml.math.conj(state), jac, axes=([0], [0]))
-        return qml.math.real(
-            qml.math.tensordot(qml.math.conj(jac), jac, axes=([0], [0]))
-            - qml.math.tensordot(qml.math.conj(psidpsi), psidpsi, axes=0)
+        psidpsi = np.tensordot(np.conj(state), jac, axes=([0], [0]))
+        return np.real(
+            np.tensordot(np.conj(jac), jac, axes=([0], [0]))
+            - np.tensordot(np.conj(psidpsi), psidpsi, axes=0)
         )
 
     return mt


### PR DESCRIPTION
**Context:**
If there is a `StatePrep` op in a circuit, `adjoint_metric_tensor` errors out as described in #6357 

**Description of the Change:**
Make `adjoint_metric_tensor` skip over the initial operation of the tape if it is a `StatePrep` op, because it is already considered when creating the initial state internally.

**Benefits:**
Fixes #6357 

**Possible Drawbacks:**

**Related GitHub Issues:**
#6357 
[sc-75331]
