### PR TITLE
Miscellaneous `Tensor` deprecation fixes

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -176,6 +176,7 @@
   `qml.ops.LinearCombination`; this behaviour is not deprecated. For more information, check out the
   [updated operator troubleshooting page](https://docs.pennylane.ai/en/stable/news/new_opmath.html).
   [(#6287)](https://github.com/PennyLaneAI/pennylane/pull/6287)
+  [(#6365)](https://github.com/PennyLaneAI/pennylane/pull/6365)
 
 * `qml.pauli.PauliSentence.hamiltonian` and `qml.pauli.PauliWord.hamiltonian` are deprecated. Instead, please use
   `qml.pauli.PauliSentence.operation` and `qml.pauli.PauliWord.operation` respectively.

--- a/pennylane/data/attributes/operator/operator.py
+++ b/pennylane/data/attributes/operator/operator.py
@@ -262,7 +262,8 @@ class DatasetOperator(Generic[Op], DatasetAttribute[HDF5Group, Op, Op]):
 
                 op_cls = self._supported_ops_dict()[op_class_name]
                 if op_cls is Tensor:
-                    ops.append(Tensor(*self._hdf5_to_ops(bind[op_key])))
+                    prod_op = qml.ops.Prod if qml.operation.active_new_opmath() else Tensor
+                    ops.append(prod_op(*self._hdf5_to_ops(bind[op_key])))
                 elif op_cls in (qml.ops.Hamiltonian, qml.ops.LinearCombination):
                     ops.append(
                         qml.Hamiltonian(

--- a/pennylane/qaoa/mixers.py
+++ b/pennylane/qaoa/mixers.py
@@ -231,7 +231,12 @@ def bit_flip_mixer(graph: Union[nx.Graph, rx.PyGraph], b: int):
         ]
         n_coeffs = [[1, sign] for n in neighbours]
 
-        final_terms = [qml.operation.Tensor(*list(m)).prune() for m in itertools.product(*n_terms)]
+        prod_op = (
+            (lambda ops: qml.prod(*ops).simplify())
+            if qml.operation.active_new_opmath()
+            else (lambda ops: qml.operation.Tensor(*ops).prune)
+        )
+        final_terms = [prod_op(list(m)) for m in itertools.product(*n_terms)]
         final_coeffs = [
             (0.5**degree) * functools.reduce(lambda x, y: x * y, list(m), 1)
             for m in itertools.product(*n_coeffs)

--- a/pennylane/qaoa/mixers.py
+++ b/pennylane/qaoa/mixers.py
@@ -229,14 +229,14 @@ def bit_flip_mixer(graph: Union[nx.Graph, rx.PyGraph], b: int):
         n_terms = [[qml.X(get_nvalue(i))]] + [
             [qml.Identity(get_nvalue(n)), qml.Z(get_nvalue(n))] for n in neighbours
         ]
-        n_coeffs = [[1, sign] for n in neighbours]
+        n_coeffs = [[1, sign] for _ in neighbours]
 
-        prod_op = (
-            (lambda ops: qml.prod(*ops).simplify())
+        final_terms = (
+            [qml.prod(*list(m)).simplify() for m in itertools.product(*n_terms)]
             if qml.operation.active_new_opmath()
-            else (lambda ops: qml.operation.Tensor(*ops).prune)
+            else [qml.operation.Tensor(*list(m)).prune() for m in itertools.product(*n_terms)]
         )
-        final_terms = [prod_op(list(m)) for m in itertools.product(*n_terms)]
+
         final_coeffs = [
             (0.5**degree) * functools.reduce(lambda x, y: x * y, list(m), 1)
             for m in itertools.product(*n_coeffs)

--- a/pennylane/tape/tape.py
+++ b/pennylane/tape/tape.py
@@ -78,10 +78,9 @@ def _validate_computational_basis_sampling(tape):
         with (
             QueuingManager.stop_recording()
         ):  # stop recording operations - the constructed operator is just aux
+            prod_op = qml.ops.Prod if qml.operation.active_new_opmath() else qml.operation.Tensor
             pauliz_for_cb_obs = (
-                qml.Z(all_wires)
-                if len(all_wires) == 1
-                else qml.operation.Tensor(*[qml.Z(w) for w in all_wires])
+                qml.Z(all_wires) if len(all_wires) == 1 else prod_op(*[qml.Z(w) for w in all_wires])
             )
 
         for obs in non_comp_basis_sampling_obs:


### PR DESCRIPTION
* Update `bit_flip_mixer` to conditionally create `Tensor`s based on `active_new_opmath()`
* Update `_validate_computational_basis_sampling` to conditionally create `Tensor`s based on `active_new_opmath()`
* Update `qml.data.DatasetOperator` to deserialize `Tensor` into `Prod` if `active_new_opmath()`

[sc-71940]