### PR TITLE
Extract `qfunc_output` and `tape.measurement` validation to private helper function

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -35,6 +35,9 @@
 
 <h3>Improvements 🛠</h3>
 
+* Isolate `qfunc_output` and `tape.measurement` to a private helper function.
+  [(#6370)](https://github.com/PennyLaneAI/pennylane/pull/6370)
+
 * PennyLane is now compatible with NumPy 2.0.
   [(#6061)](https://github.com/PennyLaneAI/pennylane/pull/6061)
   [(#6258)](https://github.com/PennyLaneAI/pennylane/pull/6258)
@@ -312,4 +315,5 @@ William Maxwell,
 Erick Ochoa Lopez,
 Lee J. O'Riordan,
 Mudit Pandey,
+Andrija Paurevic,
 David Wierichs,

--- a/pennylane/workflow/qnode.py
+++ b/pennylane/workflow/qnode.py
@@ -151,6 +151,30 @@ def _validate_gradient_kwargs(gradient_kwargs: dict) -> None:
             )
 
 
+def _validate_qfunc_output(qfunc_output, measurements) -> None:
+    if isinstance(qfunc_output, qml.numpy.ndarray):
+        measurement_processes = tuple(measurements)
+    elif not isinstance(qfunc_output, Sequence):
+        measurement_processes = (qfunc_output,)
+    else:
+        measurement_processes = qfunc_output
+
+    if not measurement_processes or not all(
+        isinstance(m, qml.measurements.MeasurementProcess) for m in measurement_processes
+    ):
+        raise qml.QuantumFunctionError(
+            "A quantum function must return either a single measurement, "
+            "or a nonempty sequence of measurements."
+        )
+
+    terminal_measurements = [m for m in measurements if not isinstance(m, MidMeasureMP)]
+
+    if any(ret is not m for ret, m in zip(measurement_processes, terminal_measurements)):
+        raise qml.QuantumFunctionError(
+            "All measurements must be returned in the order they are measured."
+        )
+
+
 class QNode:
     r"""Represents a quantum node in the hybrid computational graph.
 
@@ -837,29 +861,7 @@ class QNode:
         params = self.tape.get_parameters(trainable_only=False)
         self.tape.trainable_params = qml.math.get_trainable_indices(params)
 
-        if isinstance(self._qfunc_output, qml.numpy.ndarray):
-            measurement_processes = tuple(self.tape.measurements)
-        elif not isinstance(self._qfunc_output, Sequence):
-            measurement_processes = (self._qfunc_output,)
-        else:
-            measurement_processes = self._qfunc_output
-
-        if not measurement_processes or not all(
-            isinstance(m, qml.measurements.MeasurementProcess) for m in measurement_processes
-        ):
-            raise qml.QuantumFunctionError(
-                "A quantum function must return either a single measurement, "
-                "or a nonempty sequence of measurements."
-            )
-
-        terminal_measurements = [
-            m for m in self.tape.measurements if not isinstance(m, MidMeasureMP)
-        ]
-
-        if any(ret is not m for ret, m in zip(measurement_processes, terminal_measurements)):
-            raise qml.QuantumFunctionError(
-                "All measurements must be returned in the order they are measured."
-            )
+        _validate_qfunc_output(self._qfunc_output, self.tape.measurements)
 
         num_wires = len(self.tape.wires) if not self.device.wires else len(self.device.wires)
         for obj in self.tape.operations + self.tape.observables:

--- a/tests/test_qnode.py
+++ b/tests/test_qnode.py
@@ -2063,7 +2063,7 @@ def test_prune_dynamic_transform_with_mcm():
 
 
 def test_gradient_fn_lightning_metric_tensor():
-    """Test that if lightning is used with the metric tensor, the graident_fn is parameter shift."""
+    """Test that if lightning is used with the metric tensor, the gradient_fn is parameter shift."""
 
     dev = qml.device("lightning.qubit", wires=2)
 


### PR DESCRIPTION
**Context:** 

In an effort to reduce the amount of code in the method `QNode.construct`, the validation of `qfunc_output` and `tape.measurement` is moved to private helper function.

**Description of the Change:** Extract validation code block into helper function.

**Benefits:** Improve readability of code.

**Possible Drawbacks:** None

[sc-72067]