### PR TITLE
Handle recursion errors in CompositeOp methods

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -78,6 +78,9 @@
   unprocessed diagonalizing gates.
   [(#6290)](https://github.com/PennyLaneAI/pennylane/pull/6290)
 
+* A more sensible error message is raised from a `RecursionError` encountered when accessing properties and methods of a nested `CompositeOp`.
+  [(#6375)](https://github.com/PennyLaneAI/pennylane/pull/6375)
+
 <h4>Capturing and representing hybrid programs</h4>
 
 * `qml.wires.Wires` now accepts JAX arrays as input. Furthermore, a `FutureWarning` is no longer raised in `JAX 0.4.30+`

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -82,7 +82,7 @@
   unprocessed diagonalizing gates.
   [(#6290)](https://github.com/PennyLaneAI/pennylane/pull/6290)
 
-* A more sensible error message is raised from a `RecursionError` encountered when accessing properties and methods of a nested `CompositeOp`.
+* A more sensible error message is raised from a `RecursionError` encountered when accessing properties and methods of a nested `CompositeOp` or `SProd`.
   [(#6375)](https://github.com/PennyLaneAI/pennylane/pull/6375)
 
 <h4>Capturing and representing hybrid programs</h4>

--- a/pennylane/ops/op_math/composite.py
+++ b/pennylane/ops/op_math/composite.py
@@ -17,8 +17,8 @@ This submodule defines a base class for composite operations.
 # pylint: disable=too-many-instance-attributes,invalid-sequence-index
 import abc
 import copy
-from functools import wraps
 from collections.abc import Callable
+from functools import wraps
 
 import pennylane as qml
 from pennylane import math

--- a/pennylane/ops/op_math/composite.py
+++ b/pennylane/ops/op_math/composite.py
@@ -37,9 +37,9 @@ def handle_recursion_error(func):
             return func(*args, **kwargs)
         except RecursionError as e:
             raise RuntimeError(
-                "Maximum recursion depth reached! This is likely due to nesting too many "
-                "levels of composite operators. Try setting lazy=False when calling qml.sum "
-                "and qml.prod, or use the + and @ operators instead. Alternatively, you "
+                "Maximum recursion depth reached! This is likely due to nesting too many levels "
+                "of composite operators. Try setting lazy=False when calling qml.sum, qml.prod, "
+                "and qml.s_prod, or use the +, @, and * operators instead. Alternatively, you "
                 "can periodically call qml.simplify on your operators."
             ) from e
 
@@ -89,6 +89,7 @@ class CompositeOp(Operator):
         self.queue()
         self._batch_size = _UNSET_BATCH_SIZE
 
+    @handle_recursion_error
     def _check_batching(self):
         batch_sizes = {op.batch_size for op in self if op.batch_size is not None}
         if len(batch_sizes) > 1:

--- a/pennylane/ops/op_math/composite.py
+++ b/pennylane/ops/op_math/composite.py
@@ -29,7 +29,7 @@ from pennylane.wires import Wires
 
 
 def handle_recursion_error(func):
-    """Handles any recursion errors raised from too many nested products."""
+    """Handles any recursion errors raised from too many levels of nesting."""
 
     @wraps(func)
     def wrapper(*args, **kwargs):

--- a/pennylane/ops/op_math/composite.py
+++ b/pennylane/ops/op_math/composite.py
@@ -39,7 +39,8 @@ def handle_recursion_error(func):
             raise RuntimeError(
                 "Maximum recursion depth reached! This is likely due to nesting too many "
                 "levels of composite operators. Try setting lazy=False when calling qml.sum "
-                "and qml.prod, or use the + and @ operators instead."
+                "and qml.prod, or use the + and @ operators instead. Alternatively, you "
+                "can periodically call qml.simplify on your operators."
             ) from e
 
     return wrapper

--- a/pennylane/ops/op_math/sprod.py
+++ b/pennylane/ops/op_math/sprod.py
@@ -25,8 +25,8 @@ from pennylane.ops.op_math.pow import Pow
 from pennylane.ops.op_math.sum import Sum
 from pennylane.queuing import QueuingManager
 
-from .symbolicop import ScalarSymbolicOp
 from .composite import handle_recursion_error
+from .symbolicop import ScalarSymbolicOp
 
 
 def s_prod(scalar, operator, lazy=True, id=None):

--- a/pennylane/ops/op_math/sprod.py
+++ b/pennylane/ops/op_math/sprod.py
@@ -26,6 +26,7 @@ from pennylane.ops.op_math.sum import Sum
 from pennylane.queuing import QueuingManager
 
 from .symbolicop import ScalarSymbolicOp
+from .composite import handle_recursion_error
 
 
 def s_prod(scalar, operator, lazy=True, id=None):
@@ -155,12 +156,14 @@ class SProd(ScalarSymbolicOp):
         else:
             self._pauli_rep = None
 
+    @handle_recursion_error
     def __repr__(self):
         """Constructor-call-like representation."""
         if isinstance(self.base, qml.ops.CompositeOp):
             return f"{self.scalar} * ({self.base})"
         return f"{self.scalar} * {self.base}"
 
+    @handle_recursion_error
     def label(self, decimals=None, base_label=None, cache=None):
         """The label produced for the SProd op."""
         scalar_val = (
@@ -172,6 +175,7 @@ class SProd(ScalarSymbolicOp):
         return base_label or f"{scalar_val}*{self.base.label(decimals=decimals, cache=cache)}"
 
     @property
+    @handle_recursion_error
     def num_params(self):
         """Number of trainable parameters that the operator depends on.
         Usually 1 + the number of trainable parameters for the base op.
@@ -181,6 +185,7 @@ class SProd(ScalarSymbolicOp):
         """
         return 1 + self.base.num_params
 
+    @handle_recursion_error
     def terms(self):
         r"""Representation of the operator as a linear combination of other operators.
 
@@ -200,6 +205,7 @@ class SProd(ScalarSymbolicOp):
             return [self.scalar], [self.base]
 
     @property
+    @handle_recursion_error
     def is_hermitian(self):
         """If the base operator is hermitian and the scalar is real,
         then the scalar product operator is hermitian."""
@@ -207,10 +213,12 @@ class SProd(ScalarSymbolicOp):
 
     # pylint: disable=arguments-renamed,invalid-overridden-method
     @property
+    @handle_recursion_error
     def has_diagonalizing_gates(self):
         """Bool: Whether the Operator returns defined diagonalizing gates."""
         return self.base.has_diagonalizing_gates
 
+    @handle_recursion_error
     def diagonalizing_gates(self):
         r"""Sequence of gates that diagonalize the operator in the computational basis.
 
@@ -230,6 +238,7 @@ class SProd(ScalarSymbolicOp):
         """
         return self.base.diagonalizing_gates()
 
+    @handle_recursion_error
     def eigvals(self):
         r"""Return the eigenvalues of the specified operator.
 
@@ -244,6 +253,7 @@ class SProd(ScalarSymbolicOp):
             base_eigs = qml.math.convert_like(base_eigs, self.scalar)
         return self.scalar * base_eigs
 
+    @handle_recursion_error
     def sparse_matrix(self, wire_order=None):
         """Computes, by default, a `scipy.sparse.csr_matrix` representation of this Tensor.
 
@@ -264,15 +274,18 @@ class SProd(ScalarSymbolicOp):
         return mat
 
     @property
+    @handle_recursion_error
     def has_sparse_matrix(self):
         return self.pauli_rep is not None or self.base.has_sparse_matrix
 
     @property
+    @handle_recursion_error
     def has_matrix(self):
         """Bool: Whether or not the Operator returns a defined matrix."""
         return isinstance(self.base, qml.ops.Hamiltonian) or self.base.has_matrix
 
     @staticmethod
+    @handle_recursion_error
     def _matrix(scalar, mat):
         return scalar * mat
 
@@ -303,6 +316,7 @@ class SProd(ScalarSymbolicOp):
         return SProd(scalar=qml.math.conjugate(self.scalar), base=qml.adjoint(self.base))
 
     # pylint: disable=too-many-return-statements
+    @handle_recursion_error
     def simplify(self) -> Operator:
         """Reduce the depth of nested operators to the minimum.
 

--- a/pennylane/ops/op_math/sum.py
+++ b/pennylane/ops/op_math/sum.py
@@ -28,7 +28,7 @@ from pennylane import math
 from pennylane.operation import Operator, convert_to_opmath
 from pennylane.queuing import QueuingManager
 
-from .composite import CompositeOp
+from .composite import CompositeOp, handle_recursion_error
 
 
 def sum(*summands, grouping_type=None, method="rlf", id=None, lazy=True):
@@ -238,6 +238,7 @@ class Sum(CompositeOp):
             self.compute_grouping(grouping_type=grouping_type, method=method)
 
     @property
+    @handle_recursion_error
     def hash(self):
         # Since addition is always commutative, we do not need to sort
         return hash(("Sum", hash(frozenset(Counter(self.operands).items()))))
@@ -277,11 +278,13 @@ class Sum(CompositeOp):
         # make sure all tuples so can be hashable
         self._grouping_indices = tuple(tuple(sublist) for sublist in value)
 
+    @handle_recursion_error
     def __str__(self):
         """String representation of the Sum."""
         ops = self.operands
         return " + ".join(f"{str(op)}" if i == 0 else f"{str(op)}" for i, op in enumerate(ops))
 
+    @handle_recursion_error
     def __repr__(self):
         """Terminal representation for Sum"""
         # post-processing the flat str() representation
@@ -293,6 +296,7 @@ class Sum(CompositeOp):
         return main_string
 
     @property
+    @handle_recursion_error
     def is_hermitian(self):
         """If all of the terms in the sum are hermitian, then the Sum is hermitian."""
         if self.pauli_rep is not None:
@@ -304,10 +308,12 @@ class Sum(CompositeOp):
 
         return all(s.is_hermitian for s in self)
 
+    @handle_recursion_error
     def label(self, decimals=None, base_label=None, cache=None):
         decimals = None if (len(self.parameters) > 3) else decimals
         return Operator.label(self, decimals=decimals, base_label=base_label or "𝓗", cache=cache)
 
+    @handle_recursion_error
     def matrix(self, wire_order=None):
         r"""Representation of the operator as a matrix in the computational basis.
 
@@ -344,9 +350,11 @@ class Sum(CompositeOp):
 
     # pylint: disable=arguments-renamed, invalid-overridden-method
     @property
+    @handle_recursion_error
     def has_sparse_matrix(self) -> bool:
         return self.pauli_rep is not None or all(op.has_sparse_matrix for op in self)
 
+    @handle_recursion_error
     def sparse_matrix(self, wire_order=None):
         if self.pauli_rep:  # Get the sparse matrix from the PauliSentence representation
             return self.pauli_rep.to_mat(wire_order=wire_order or self.wires, format="csr")
@@ -417,6 +425,7 @@ class Sum(CompositeOp):
 
         return new_summands
 
+    @handle_recursion_error
     def simplify(self, cutoff=1.0e-12) -> "Sum":  # pylint: disable=arguments-differ
         # try using pauli_rep:
         if pr := self.pauli_rep:
@@ -428,6 +437,7 @@ class Sum(CompositeOp):
             return Sum(*new_summands) if len(new_summands) > 1 else new_summands[0]
         return qml.s_prod(0, qml.Identity(self.wires))
 
+    @handle_recursion_error
     def terms(self):
         r"""Representation of the operator as a linear combination of other operators.
 

--- a/pennylane/ops/op_math/symbolicop.py
+++ b/pennylane/ops/op_math/symbolicop.py
@@ -22,6 +22,7 @@ import numpy as np
 import pennylane as qml
 from pennylane.operation import _UNSET_BATCH_SIZE, Operator
 from pennylane.queuing import QueuingManager
+from .composite import handle_recursion_error
 
 
 class SymbolicOp(Operator):
@@ -53,6 +54,7 @@ class SymbolicOp(Operator):
         return cls._primitive.bind(*args, **kwargs)
 
     # pylint: disable=attribute-defined-outside-init
+    @handle_recursion_error
     def __copy__(self):
         # this method needs to be overwritten because the base must be copied too.
         copied_op = object.__new__(type(self))
@@ -98,11 +100,13 @@ class SymbolicOp(Operator):
         return self.base.num_params
 
     @property
+    @handle_recursion_error
     def wires(self):
         return self.base.wires
 
     # pylint:disable = missing-function-docstring
     @property
+    @handle_recursion_error
     def basis(self):
         return self.base.basis
 
@@ -130,6 +134,7 @@ class SymbolicOp(Operator):
         return self
 
     @property
+    @handle_recursion_error
     def arithmetic_depth(self) -> int:
         return 1 + self.base.arithmetic_depth
 
@@ -142,6 +147,7 @@ class SymbolicOp(Operator):
             )
         )
 
+    @handle_recursion_error
     def map_wires(self, wire_map: dict):
         new_op = copy(self)
         new_op.hyperparameters["base"] = self.base.map_wires(wire_map=wire_map)
@@ -172,6 +178,7 @@ class ScalarSymbolicOp(SymbolicOp):
         self._batch_size = _UNSET_BATCH_SIZE
 
     @property
+    @handle_recursion_error
     def batch_size(self):
         if self._batch_size is _UNSET_BATCH_SIZE:
             base_batch_size = self.base.batch_size
@@ -190,6 +197,7 @@ class ScalarSymbolicOp(SymbolicOp):
         return self._batch_size
 
     @property
+    @handle_recursion_error
     def data(self):
         return (self.scalar, *self.base.data)
 
@@ -199,10 +207,12 @@ class ScalarSymbolicOp(SymbolicOp):
         self.base.data = new_data[1:]
 
     @property
+    @handle_recursion_error
     def has_matrix(self):
         return self.base.has_matrix or isinstance(self.base, qml.ops.Hamiltonian)
 
     @property
+    @handle_recursion_error
     def hash(self):
         return hash(
             (
@@ -225,6 +235,7 @@ class ScalarSymbolicOp(SymbolicOp):
             mat (ndarray): non-broadcasted matrix
         """
 
+    @handle_recursion_error
     def matrix(self, wire_order=None):
         r"""Representation of the operator as a matrix in the computational basis.
 

--- a/pennylane/ops/op_math/symbolicop.py
+++ b/pennylane/ops/op_math/symbolicop.py
@@ -22,6 +22,7 @@ import numpy as np
 import pennylane as qml
 from pennylane.operation import _UNSET_BATCH_SIZE, Operator
 from pennylane.queuing import QueuingManager
+
 from .composite import handle_recursion_error
 
 

--- a/tests/ops/op_math/test_composite.py
+++ b/tests/ops/op_math/test_composite.py
@@ -236,6 +236,18 @@ class TestConstruction:
 class TestMscMethods:
     """Test dunder and other visualizing methods."""
 
+    @pytest.mark.parametrize("math_op", [qml.prod, qml.sum])
+    @pytest.mark.parametrize("method", ["terms", "eigvals", "__copy__", "label"])
+    def test_recursion_depth_error_message(self, math_op, method):
+        """Tests that a sensible error is raised from a recursion error"""
+
+        op = qml.PauliRot(np.random.uniform(0, 2 * np.pi), "X", wires=1)
+        for _ in range(2000):
+            op = math_op(op, qml.PauliRot(np.random.uniform(0, 2 * np.pi), "Y", wires=1))
+
+        with pytest.raises(RuntimeError, match="This is likely due to nesting too many levels"):
+            getattr(op, method)()
+
     @pytest.mark.parametrize("ops_lst, op_rep", tuple((i, j) for i, j in zip(ops, ops_rep)))
     def test_repr(self, ops_lst, op_rep):
         """Test __repr__ method."""
@@ -315,6 +327,21 @@ class TestMscMethods:
 
 class TestProperties:
     """Test class properties."""
+
+    @pytest.mark.parametrize("math_op", [qml.prod, qml.sum])
+    @pytest.mark.parametrize(
+        "attr",
+        ["arithmetic_depth", "has_matrix", "has_sparse_matrix", "num_params", "hash", "data"],
+    )
+    def test_recursion_depth_error_message(self, math_op, attr):
+        """Tests that a sensible error is raised from a recursion error"""
+
+        op = qml.PauliRot(np.random.uniform(0, 2 * np.pi), "X", wires=1)
+        for _ in range(2000):
+            op = math_op(op, qml.PauliRot(np.random.uniform(0, 2 * np.pi), "Y", wires=1))
+
+        with pytest.raises(RuntimeError, match="This is likely due to nesting too many levels"):
+            getattr(op, attr)
 
     @pytest.mark.parametrize("ops_lst", ops)
     def test_num_params(self, ops_lst):

--- a/tests/ops/op_math/test_composite.py
+++ b/tests/ops/op_math/test_composite.py
@@ -258,10 +258,11 @@ def _assert_method_and_property_no_recursion_error(instance):
     """Checks that all methods and properties do not raise a RecursionError when accessed."""
 
     for name, attr in inspect.getmembers(instance.__class__):
+
         if inspect.isfunction(attr) and _is_method_with_no_argument(attr):
             _assert_method_no_recursion_error(instance, name)
 
-        if isinstance(attr, property) and not name.startswith("__"):
+        if isinstance(attr, property):
             _assert_property_no_recursion_error(instance, name)
 
 

--- a/tests/ops/op_math/test_sprod.py
+++ b/tests/ops/op_math/test_sprod.py
@@ -211,13 +211,6 @@ class TestInitialization:
 class TestMscMethods:
     """Test miscellaneous methods of the SProd class."""
 
-    def test_recursion_depth_error_message(self):
-        """Tests that a sensible error is raised from a recursion error"""
-
-        op = qml.PauliRot(np.random.uniform(0, 2 * np.pi), "X", wires=1)
-        for _ in range(2000):
-            op = qml.s_prod(1, op)
-
     def test_string_with_single_pauli(self):
         """Test the string representation with single pauli"""
         res = qml.s_prod(0.5, qml.PauliX("a"))

--- a/tests/ops/op_math/test_sprod.py
+++ b/tests/ops/op_math/test_sprod.py
@@ -211,6 +211,13 @@ class TestInitialization:
 class TestMscMethods:
     """Test miscellaneous methods of the SProd class."""
 
+    def test_recursion_depth_error_message(self):
+        """Tests that a sensible error is raised from a recursion error"""
+
+        op = qml.PauliRot(np.random.uniform(0, 2 * np.pi), "X", wires=1)
+        for _ in range(2000):
+            op = qml.s_prod(1, op)
+
     def test_string_with_single_pauli(self):
         """Test the string representation with single pauli"""
         res = qml.s_prod(0.5, qml.PauliX("a"))


### PR DESCRIPTION
By default, `qml.sum` and `qml.prod` set `lazy=True`, which keeps its operands nested. Given the recursive nature of such structures, if there are too many levels of nesting, a `RecursionError` would occur when accessing many of the properties and methods. Catching these errors and re-raising a more sensible error message suggesting that the user could either set `lazy=False` or use the `+` and `@` operators instead, which sets `lazy=False`.

**Update**
Extending the behaviour to `SProd`

Fixes https://github.com/PennyLaneAI/pennylane/issues/5948
[sc-67745]