### PR TITLE
Fix failing `qml.Evolution` test for legacy opmath failures

### DIFF
--- a/tests/ops/op_math/test_evolution.py
+++ b/tests/ops/op_math/test_evolution.py
@@ -206,7 +206,10 @@ class TestEvolution:
         """Test that qml.generator will return generator if it is_hermitian, but is not a subclass of Observable"""
         op = Evolution(base, 1)
         gen, c = qml.generator(op)
-        qml.assert_equal(gen if c == 1 else qml.s_prod(c, gen), -1 * base)
+        print(gen)
+        print(type(gen))
+        print(c)
+        qml.assert_equal(gen if c == 1 else qml.s_prod(c, gen), qml.s_prod(-1, base))
 
     def test_generator_error_if_not_hermitian(self):
         """Tests that an error is raised if the generator is not hermitian."""

--- a/tests/ops/op_math/test_evolution.py
+++ b/tests/ops/op_math/test_evolution.py
@@ -206,9 +206,6 @@ class TestEvolution:
         """Test that qml.generator will return generator if it is_hermitian, but is not a subclass of Observable"""
         op = Evolution(base, 1)
         gen, c = qml.generator(op)
-        print(gen)
-        print(type(gen))
-        print(c)
         qml.assert_equal(gen if c == 1 else qml.s_prod(c, gen), qml.s_prod(-1, base))
 
     def test_generator_error_if_not_hermitian(self):


### PR DESCRIPTION
Failing legacy op math run [here](https://github.com/PennyLaneAI/pennylane/actions/runs/11266288191/job/31330095237). We're just comparing an `SProd` against a `Hamiltonian`, so I've made a small change to the test.