### PR TITLE
Rename `test_simplify_with_adjoint_not_defined` in `test_pow_ops.py`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -262,6 +262,9 @@
 * Removed ambiguity in error raised by the `PauliRot` class.
   [(#6298)](https://github.com/PennyLaneAI/pennylane/pull/6298)
 
+* Renamed an incorrectly named test in `test_pow_ops.py`.
+  [(#6388)](https://github.com/PennyLaneAI/pennylane/pull/6388)
+
 <h3>Bug fixes 🐛</h3>
 
 * `default.qutrit` now returns integer samples.

--- a/tests/ops/op_math/test_pow_op.py
+++ b/tests/ops/op_math/test_pow_op.py
@@ -568,7 +568,7 @@ class TestSimplify:
         assert final_op.wires == simplified_op.wires
         assert final_op.arithmetic_depth == simplified_op.arithmetic_depth
 
-    def test_simplify_with_adjoint_not_defined(self):
+    def test_simplify_with_pow_not_defined(self):
         """Test the simplify method with an operator that has not defined the op.pow method."""
         op = Pow(qml.U2(1, 1, 0), z=3)
         simplified_op = op.simplify()


### PR DESCRIPTION
This PR renames `test_simplify_with_adjoint_not_defined` to `test_simplify_with_pow_not_defined` in the `test_pow_ops.py` file. The test is given by the following code.
```
    def test_simplify_with_adjoint_not_defined(self):
        """Test the simplify method with an operator that has not defined the op.pow method."""
        op = Pow(qml.U2(1, 1, 0), z=3)
        simplified_op = op.simplify()
        assert isinstance(simplified_op, Pow)
        assert op.data == simplified_op.data
        assert op.wires == simplified_op.wires
        assert op.arithmetic_depth == simplified_op.arithmetic_depth
```
Note the function name says `adjoint` is not defined, but the docstring says that `pow` is not defined. The docstring is correct, since `qml.U2` defines the `adjoint` method.