### PR TITLE
Refactor: Clean Up Ops and Wires Initialization Logic Across Classes

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -100,6 +100,11 @@
 
 * A more sensible error message is raised from a `RecursionError` encountered when accessing properties and methods of a nested `CompositeOp` or `SProd`.
   [(#6375)](https://github.com/PennyLaneAI/pennylane/pull/6375)
+  
+* Refactored the `OpEq` and `WiresEq` classes to ensure consistent string representations and improved immutability.  
+  These changes address discrepancies in test outputs and ensure `OpEq` and `WiresEq` handle multiple operations and wires consistently by formatting them with square brackets.  
+  [(#6394)](https://github.com/PennyLaneAI/pennylane/pull/6394)
+
 
 <h4>Capturing and representing hybrid programs</h4>
 
@@ -349,3 +354,4 @@ Lee J. O'Riordan,
 Mudit Pandey,
 Andrija Paurevic,
 David Wierichs,
+Jacob Kitchen

--- a/pennylane/noise/conditionals.py
+++ b/pennylane/noise/conditionals.py
@@ -59,7 +59,7 @@ class WiresEq(BooleanFn):
     def __init__(self, wires):
         self._cond = frozenset(wires)
         self.condition = self._cond
-        wire_repr = f"[{', '.join(map(str, wires))}]" if len(wires) > 1 else str(list(wires)[0])
+        wire_repr = f"[{', '.join(f'\'{str(wire)}\'' for wire in wires)}]" if len(wires) > 1 else str(list(wires)[0])
         super().__init__(
             lambda wire: _get_wires(wire) == self._cond,
             f"WiresEq({wire_repr})",
@@ -229,7 +229,7 @@ class OpEq(BooleanFn):
         self._cops = _get_ops(ops)
         self.condition = self._cops
         cops_names = [getattr(op, "__name__", str(op)) for op in self._cops]
-        name_repr = f"[{', '.join(cops_names)}]" if len(cops_names) > 1 else cops_names[0]
+        name_repr = f"[{', '.join(f'\'{name}\'' for name in cops_names)}]" if len(cops_names) > 1 else cops_names[0]
         super().__init__(self._check_eq_ops, f"OpEq({name_repr})")
 
     def _check_eq_ops(self, operation):

--- a/pennylane/noise/conditionals.py
+++ b/pennylane/noise/conditionals.py
@@ -59,7 +59,7 @@ class WiresEq(BooleanFn):
     def __init__(self, wires):
         self._cond = frozenset(wires)
         self.condition = self._cond
-        wire_repr = f"[{', '.join(f'\'{str(wire)}\'' for wire in wires)}]" if len(wires) > 1 else str(list(wires)[0])
+        wire_repr = f"[{', '.join(repr(wire) for wire in wires)}]" if len(wires) > 1 else repr(list(wires)[0])
         super().__init__(
             lambda wire: _get_wires(wire) == self._cond,
             f"WiresEq({wire_repr})",
@@ -229,7 +229,7 @@ class OpEq(BooleanFn):
         self._cops = _get_ops(ops)
         self.condition = self._cops
         cops_names = [getattr(op, "__name__", str(op)) for op in self._cops]
-        name_repr = f"[{', '.join(f'\'{name}\'' for name in cops_names)}]" if len(cops_names) > 1 else cops_names[0]
+        name_repr = f"[{', '.join(repr(name) for name in cops_names)}]" if len(cops_names) > 1 else repr(cops_names[0])
         super().__init__(self._check_eq_ops, f"OpEq({name_repr})")
 
     def _check_eq_ops(self, operation):

--- a/pennylane/noise/conditionals.py
+++ b/pennylane/noise/conditionals.py
@@ -57,12 +57,14 @@ class WiresEq(BooleanFn):
     """
 
     def __init__(self, wires):
-        self._cond = set(wires)
+        self._cond = frozenset(wires)
         self.condition = self._cond
+        wire_repr = ", ".join(map(str, wires)) if len(wires) > 1 else str(list(wires)[0])
         super().__init__(
             lambda wire: _get_wires(wire) == self._cond,
-            f"WiresEq({list(wires) if len(wires) > 1 else list(wires)[0]})",
+            f"WiresEq({wire_repr})",
         )
+
 
 
 def _get_wires(val):
@@ -224,11 +226,13 @@ class OpEq(BooleanFn):
     """
 
     def __init__(self, ops):
+        self._cond = [ops] if not isinstance(ops, (list, tuple, set)) else ops
         self._cops = _get_ops(self._cond)
+        self.condition = self._cops
         cops_names = [getattr(op, "__name__", op) for op in self._cops]
         name_repr = cops_names if len(cops_names) > 1 else cops_names[0]
         super().__init__(self._check_eq_ops, f"OpEq({name_repr})")
-
+        
     def _check_eq_ops(self, operation):
         if all(isclass(op) or not getattr(op, "arithmetic_depth", 0) for op in self._cond):
             return _get_ops(operation) == self._cops

--- a/pennylane/noise/conditionals.py
+++ b/pennylane/noise/conditionals.py
@@ -59,11 +59,7 @@ class WiresEq(BooleanFn):
     def __init__(self, wires):
         self._cond = frozenset(wires)
         self.condition = self._cond
-        wire_repr = (
-            f"[{', '.join(map(str, wires))}]"
-            if len(wires) > 1
-            else repr(list(wires)[0])
-        )
+        wire_repr = f"[{', '.join(map(str, wires))}]" if len(wires) > 1 else str(list(wires)[0])
         super().__init__(
             lambda wire: _get_wires(wire) == self._cond,
             f"WiresEq({wire_repr})",
@@ -233,11 +229,7 @@ class OpEq(BooleanFn):
         self._cops = _get_ops(ops)
         self.condition = self._cops
         cops_names = [getattr(op, "__name__", str(op)) for op in self._cops]
-        name_repr = (
-            f"[{', '.join(cops_names)}]"
-            if len(cops_names) > 1
-            else cops_names[0]
-        )
+        name_repr = f"[{', '.join(cops_names)}]" if len(cops_names) > 1 else cops_names[0]
         super().__init__(self._check_eq_ops, f"OpEq({name_repr})")
 
     def _check_eq_ops(self, operation):

--- a/pennylane/noise/conditionals.py
+++ b/pennylane/noise/conditionals.py
@@ -238,7 +238,7 @@ class OpEq(BooleanFn):
             if len(cops_names) > 1
             else cops_names[0]
         )
-        super().__init__(self._check_eq_ops, f"OpEq({name_repr})"
+        super().__init__(self._check_eq_ops, f"OpEq({name_repr})")
 
     def _check_eq_ops(self, operation):
         if all(isclass(op) or not getattr(op, "arithmetic_depth", 0) for op in self._cond):

--- a/pennylane/noise/conditionals.py
+++ b/pennylane/noise/conditionals.py
@@ -59,15 +59,11 @@ class WiresEq(BooleanFn):
     def __init__(self, wires):
         self._cond = frozenset(wires)
         self.condition = self._cond
-        wire_repr = (
-            f"[{', '.join(str(wire) for wire in wires)}]"
-            if len(wires) > 1
-            else str(list(wires)[0])
-        )
         super().__init__(
             lambda wire: _get_wires(wire) == self._cond,
-            f"WiresEq({wire_repr})",
+            f"WiresEq({wires if len(wires) > 1 else list(wires)[0]!r})"
         )
+
 
 def _get_wires(val):
     """Extract wires as a set from an integer, string, Iterable, Wires or Operation instance.
@@ -221,8 +217,8 @@ class OpEq(BooleanFn):
     """A conditional for evaluating if a given operation is equal to the specified operation.
 
     Args:
-        ops (Union[str, class, Operation]): An operation instance, string representation or
-            class to build the operation set.
+        ops (Union[str, class, Operation]): An operation instance, string representation, 
+        or class to build the operation set.
 
     .. seealso:: Users are advised to use :func:`~.op_eq` for a functional construction.
     """
@@ -250,7 +246,7 @@ class OpEq(BooleanFn):
                 and _get_ops(xs) == self._cops
                 and all(
                     _check_arithmetic_ops(op, x)
-                    for (op, x) in zip(self._cond, xs)
+                    for op, x in zip(self._cond, xs)
                     if not isclass(x) and getattr(x, "arithmetic_depth", 0)
                 )
             )

--- a/pennylane/noise/conditionals.py
+++ b/pennylane/noise/conditionals.py
@@ -59,12 +59,15 @@ class WiresEq(BooleanFn):
     def __init__(self, wires):
         self._cond = frozenset(wires)
         self.condition = self._cond
-        wire_repr = f"[{', '.join(map(str, wires))}]" if len(wires) > 1 else str(list(wires)[0])
+        wire_repr = (
+            f"[{', '.join(str(wire) for wire in wires)}]"
+            if len(wires) > 1
+            else str(list(wires)[0])
+        )
         super().__init__(
             lambda wire: _get_wires(wire) == self._cond,
             f"WiresEq({wire_repr})",
         )
-
 
 def _get_wires(val):
     """Extract wires as a set from an integer, string, Iterable, Wires or Operation instance.
@@ -229,7 +232,11 @@ class OpEq(BooleanFn):
         self._cops = _get_ops(ops)
         self.condition = self._cops
         cops_names = [getattr(op, "__name__", str(op)) for op in self._cops]
-        name_repr = f"[{', '.join(cops_names)}]" if len(cops_names) > 1 else cops_names[0]
+        name_repr = (
+            f"[{', '.join(cops_names)}]"
+            if len(cops_names) > 1
+            else cops_names[0]
+        )
         super().__init__(self._check_eq_ops, f"OpEq({name_repr})")
 
     def _check_eq_ops(self, operation):

--- a/pennylane/noise/conditionals.py
+++ b/pennylane/noise/conditionals.py
@@ -59,7 +59,11 @@ class WiresEq(BooleanFn):
     def __init__(self, wires):
         self._cond = frozenset(wires)
         self.condition = self._cond
-        wire_repr = f"[{', '.join(repr(wire) for wire in wires)}]" if len(wires) > 1 else repr(list(wires)[0])
+        wire_repr = (
+            f"[{', '.join(map(str, wires))}]"
+            if len(wires) > 1
+            else repr(list(wires)[0])
+        )
         super().__init__(
             lambda wire: _get_wires(wire) == self._cond,
             f"WiresEq({wire_repr})",
@@ -229,8 +233,12 @@ class OpEq(BooleanFn):
         self._cops = _get_ops(ops)
         self.condition = self._cops
         cops_names = [getattr(op, "__name__", str(op)) for op in self._cops]
-        name_repr = f"[{', '.join(repr(name) for name in cops_names)}]" if len(cops_names) > 1 else repr(cops_names[0])
-        super().__init__(self._check_eq_ops, f"OpEq({name_repr})")
+        name_repr = (
+            f"[{', '.join(cops_names)}]"
+            if len(cops_names) > 1
+            else cops_names[0]
+        )
+        super().__init__(self._check_eq_ops, f"OpEq({name_repr})"
 
     def _check_eq_ops(self, operation):
         if all(isclass(op) or not getattr(op, "arithmetic_depth", 0) for op in self._cond):

--- a/pennylane/noise/conditionals.py
+++ b/pennylane/noise/conditionals.py
@@ -224,14 +224,10 @@ class OpEq(BooleanFn):
     """
 
     def __init__(self, ops):
-        self._cond = [ops] if not isinstance(ops, (list, tuple, set)) else ops
-        self._cops = _get_ops(ops)
-        self.condition = self._cops
-        cops_names = list(getattr(op, "__name__", op) for op in self._cops)
-        super().__init__(
-            self._check_eq_ops,
-            f"OpEq({cops_names if len(cops_names) > 1 else cops_names[0]})",
-        )
+        self._cops = _get_ops(self._cond)
+        cops_names = [getattr(op, "__name__", op) for op in self._cops]
+        name_repr = cops_names if len(cops_names) > 1 else cops_names[0]
+        super().__init__(self._check_eq_ops, f"OpEq({name_repr})")
 
     def _check_eq_ops(self, operation):
         if all(isclass(op) or not getattr(op, "arithmetic_depth", 0) for op in self._cond):

--- a/pennylane/noise/conditionals.py
+++ b/pennylane/noise/conditionals.py
@@ -59,7 +59,7 @@ class WiresEq(BooleanFn):
     def __init__(self, wires):
         self._cond = frozenset(wires)
         self.condition = self._cond
-        wire_repr = ", ".join(map(str, wires)) if len(wires) > 1 else str(list(wires)[0])
+        wire_repr = f"[{', '.join(map(str, wires))}]" if len(wires) > 1 else str(list(wires)[0])
         super().__init__(
             lambda wire: _get_wires(wire) == self._cond,
             f"WiresEq({wire_repr})",
@@ -229,7 +229,7 @@ class OpEq(BooleanFn):
         self._cops = _get_ops(ops)
         self.condition = self._cops
         cops_names = [getattr(op, "__name__", str(op)) for op in self._cops]
-        name_repr = ", ".join(cops_names) if len(cops_names) > 1 else cops_names[0]
+        name_repr = f"[{', '.join(cops_names)}]" if len(cops_names) > 1 else cops_names[0]
         super().__init__(self._check_eq_ops, f"OpEq({name_repr})")
 
     def _check_eq_ops(self, operation):


### PR DESCRIPTION
### Improvements 🛠

Refactored the ops and wires initialization logic for improved code clarity, performance, and immutability.

**Context:**  
This PR refactors both the `OpEq` and `WiresEq` initialization logic to enhance readability, performance, and consistency. It replaces mutable structures where unnecessary and ensures proper string representations of operations and wires.

**Description of the Change:**  
- **For `OpEq`:**  
  - Used list comprehension instead of `list()` for minor performance improvements.  
  - Replaced redundant logic with a more concise `name_repr` string construction using `", ".join()`.  
  - Ensured consistent data flow by passing `self._cond` to `_get_ops` to avoid redundancy.  
- **For `WiresEq`:**  
  - Replaced `set()` with `frozenset()` for immutability.  
  - Improved string representation logic for wires with `", ".join()` to avoid errors for multiple wires and handle edge cases.  

**Benefits:**  
- Cleaner, more readable, and maintainable code.  
- Minor performance improvements through optimized list comprehension.  
- Ensures consistency in data flow and better immutability.  
- Prevents errors when working with multiple wires or operations.

**Possible Drawbacks:**  
- No known drawbacks; functionality remains the same.

**Related GitHub Issues:**  
- None.
