### PR TITLE
Option to skip drawing wire labels

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -4,7 +4,7 @@
 
 <h3>New features since last release</h3>
 
-* Added `show_wire_labels` option to `tape_text` and `tape_mpl`, which hides wire labels when set to `False`.
+* Added `show_wire_labels` option to `draw` and `draw_mpl`, which hides wire labels when set to `False`.
   Defaults to `True`.
   [(#6410)](https://github.com/PennyLaneAI/pennylane/pull/6410)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -4,6 +4,10 @@
 
 <h3>New features since last release</h3>
 
+* Added `show_wire_labels` option to `tape_text` and `tape_mpl`, which hides wire labels when set to `False`.
+  Defaults to `True`.
+  [(#6410)](https://github.com/PennyLaneAI/pennylane/pull/6410)
+
 * Introduced `sample_probs` function for the `qml.devices.qubit` and `qml.devices.qutrit_mixed` modules:
   - This function takes probability distributions as input and returns sampled outcomes.
   - Simplifies the sampling process by separating it from other operations in the measurement chain.

--- a/pennylane/drawer/draw.py
+++ b/pennylane/drawer/draw.py
@@ -38,6 +38,7 @@ def draw(
     decimals=2,
     max_length=100,
     show_matrices=True,
+    show_wire_labels=True,
     level: Union[None, Literal["top", "user", "device", "gradient"], int, slice] = "gradient",
 ):
     r"""Create a function that draws the given qnode or quantum function.
@@ -52,6 +53,7 @@ def draw(
             ``None`` will omit parameters from operation labels.
         max_length (int): Maximum string width (columns) when printing the circuit
         show_matrices=False (bool): show matrix valued parameters below all circuit diagrams
+        show_wire_labels (bool): Whether or not to show the wire labels.
         level (None, str, int, slice): An indication of what transforms to apply before drawing.
             Check :func:`~.workflow.get_transform_program` for more information on the allowed values and usage details of
             this argument.
@@ -254,6 +256,7 @@ def draw(
             decimals=decimals,
             max_length=max_length,
             show_matrices=show_matrices,
+            show_wire_labels=show_wire_labels,
             level=level,
         )
 
@@ -281,6 +284,7 @@ def draw(
             show_all_wires=show_all_wires,
             decimals=decimals,
             show_matrices=show_matrices,
+            show_wire_labels=show_wire_labels,
             max_length=max_length,
         )
 
@@ -294,6 +298,7 @@ def _draw_qnode(
     decimals=2,
     max_length=100,
     show_matrices=True,
+    show_wire_labels=True,
     level: Union[None, Literal["top", "user", "device", "gradient"], int, slice] = "gradient",
 ):
     @wraps(qnode)
@@ -319,6 +324,7 @@ def _draw_qnode(
                     show_all_wires=show_all_wires,
                     decimals=decimals,
                     show_matrices=False,
+                    show_wire_labels=show_wire_labels,
                     max_length=max_length,
                     cache=cache,
                 )
@@ -341,6 +347,7 @@ def _draw_qnode(
             show_all_wires=show_all_wires,
             decimals=decimals,
             show_matrices=show_matrices,
+            show_wire_labels=show_wire_labels,
             max_length=max_length,
         )
 
@@ -381,6 +388,7 @@ def draw_mpl(
             Default is ``14``.
         wire_options (dict): matplotlib formatting options for the wire lines
         label_options (dict): matplotlib formatting options for the wire labels
+        show_wire_labels (bool): Whether or not to show the wire labels.
         active_wire_notches (bool): whether or not to add notches indicating active wires.
             Defaults to ``True``.
         level (None, str, int, slice): An indication of what transforms to apply before drawing.

--- a/pennylane/drawer/mpldrawer.py
+++ b/pennylane/drawer/mpldrawer.py
@@ -1112,3 +1112,9 @@ class MPLDrawer:
 
         for line in lines:
             self._ax.add_line(line)
+
+    def crop_wire_labels(self):
+        xlim = self._ax.get_xlim()
+        self._ax.set_xlim((-1, xlim[1]))
+        factor = (self.n_layers + 2) / (self.n_layers + 3)
+        self._fig.set_figwidth(self._fig.get_figwidth() * factor)

--- a/pennylane/drawer/mpldrawer.py
+++ b/pennylane/drawer/mpldrawer.py
@@ -1114,6 +1114,7 @@ class MPLDrawer:
             self._ax.add_line(line)
 
     def crop_wire_labels(self):
+        """Crop away the wire labels and resize figure accordingly."""
         xlim = self._ax.get_xlim()
         self._ax.set_xlim((-1, xlim[1]))
         factor = (self.n_layers + 2) / (self.n_layers + 3)

--- a/pennylane/drawer/tape_mpl.py
+++ b/pennylane/drawer/tape_mpl.py
@@ -305,7 +305,7 @@ def tape_mpl(
             Default is ``14``.
         wire_options (dict): matplotlib formatting options for the wire lines
         label_options (dict): matplotlib formatting options for the wire labels
-        show_wire_labels (bool): Whether to show the wire labels.
+        show_wire_labels (bool): Whether or not to show the wire labels.
         active_wire_notches (bool): whether or not to add notches indicating active wires.
             Defaults to ``True``.
         fig (None or matplotlib Figure): Matplotlib figure to plot onto. If None, then create a new figure.

--- a/pennylane/drawer/tape_mpl.py
+++ b/pennylane/drawer/tape_mpl.py
@@ -259,7 +259,8 @@ def _tape_mpl(tape, wire_order=None, show_all_wires=False, decimals=None, *, fig
     if fontsize is not None:
         drawer.fontsize = fontsize
 
-    drawer.label(list(wire_map), text_options=label_options)
+    if label_options != "off":
+        drawer.label(list(wire_map), text_options=label_options)
 
     _add_classical_wires(drawer, cwire_layers, cwire_wires)
 
@@ -273,6 +274,9 @@ def _tape_mpl(tape, wire_order=None, show_all_wires=False, decimals=None, *, fig
     measured_bits = _get_measured_bits(tape.measurements, bit_map, drawer.n_wires)
     if measured_bits:
         drawer.measure(n_layers, measured_bits)
+
+    if label_options == "off":
+        drawer.crop_wire_labels()
 
     return drawer.fig, drawer.ax
 

--- a/pennylane/drawer/tape_mpl.py
+++ b/pennylane/drawer/tape_mpl.py
@@ -219,6 +219,7 @@ def _tape_mpl(tape, wire_order=None, show_all_wires=False, decimals=None, *, fig
     """Private function wrapped with styling."""
     wire_options = kwargs.get("wire_options", None)
     label_options = kwargs.get("label_options", None)
+    show_wire_labels = kwargs.get("show_wire_labels", True)
     active_wire_notches = kwargs.get("active_wire_notches", True)
     fontsize = kwargs.get("fontsize", None)
 
@@ -259,10 +260,10 @@ def _tape_mpl(tape, wire_order=None, show_all_wires=False, decimals=None, *, fig
     if fontsize is not None:
         drawer.fontsize = fontsize
 
-    if label_options == "off":
-        drawer.crop_wire_labels()
-    else:
+    if show_wire_labels:
         drawer.label(list(wire_map), text_options=label_options)
+    else:
+        drawer.crop_wire_labels()
 
     _add_classical_wires(drawer, cwire_layers, cwire_wires)
 
@@ -304,6 +305,7 @@ def tape_mpl(
             Default is ``14``.
         wire_options (dict): matplotlib formatting options for the wire lines
         label_options (dict): matplotlib formatting options for the wire labels
+        show_wire_labels (bool): Whether to show the wire labels.
         active_wire_notches (bool): whether or not to add notches indicating active wires.
             Defaults to ``True``.
         fig (None or matplotlib Figure): Matplotlib figure to plot onto. If None, then create a new figure.

--- a/pennylane/drawer/tape_mpl.py
+++ b/pennylane/drawer/tape_mpl.py
@@ -259,7 +259,9 @@ def _tape_mpl(tape, wire_order=None, show_all_wires=False, decimals=None, *, fig
     if fontsize is not None:
         drawer.fontsize = fontsize
 
-    if label_options != "off":
+    if label_options == "off":
+        drawer.crop_wire_labels()
+    else:
         drawer.label(list(wire_map), text_options=label_options)
 
     _add_classical_wires(drawer, cwire_layers, cwire_wires)
@@ -274,9 +276,6 @@ def _tape_mpl(tape, wire_order=None, show_all_wires=False, decimals=None, *, fig
     measured_bits = _get_measured_bits(tape.measurements, bit_map, drawer.n_wires)
     if measured_bits:
         drawer.measure(n_layers, measured_bits)
-
-    if label_options == "off":
-        drawer.crop_wire_labels()
 
     return drawer.fig, drawer.ax
 

--- a/pennylane/drawer/tape_text.py
+++ b/pennylane/drawer/tape_text.py
@@ -250,8 +250,8 @@ def tape_text(
     decimals=None,
     max_length=100,
     show_matrices=True,
-    cache=None,
     show_wire_labels=True,
+    cache=None,
 ):
     """Text based diagram for a Quantum Tape.
 
@@ -266,9 +266,9 @@ def tape_text(
         max_length (Int) : Maximum length of a individual line.  After this length, the diagram will
             begin anew beneath the previous lines.
         show_matrices=True (bool): show matrix valued parameters below all circuit diagrams
+        show_wire_labels (bool): Whether or not to show the wire labels.
         cache (dict): Used to store information between recursive calls. Necessary keys are ``'tape_offset'``
             and ``'matrices'``.
-        show_wire_labels (bool): Whether to show the wire labels.
 
     Returns:
         str : String based graphic of the circuit.

--- a/pennylane/drawer/tape_text.py
+++ b/pennylane/drawer/tape_text.py
@@ -268,6 +268,7 @@ def tape_text(
         show_matrices=True (bool): show matrix valued parameters below all circuit diagrams
         cache (dict): Used to store information between recursive calls. Necessary keys are ``'tape_offset'``
             and ``'matrices'``.
+        show_wire_labels (bool): Whether to show the wire labels.
 
     Returns:
         str : String based graphic of the circuit.

--- a/pennylane/drawer/tape_text.py
+++ b/pennylane/drawer/tape_text.py
@@ -251,6 +251,7 @@ def tape_text(
     max_length=100,
     show_matrices=True,
     cache=None,
+    show_wire_labels=True,
 ):
     """Text based diagram for a Quantum Tape.
 
@@ -456,7 +457,10 @@ def tape_text(
     # classical conditions, and terminal measurements for processing mid-circuit measurements.
     cwire_layers, _ = cwire_connections(layers, bit_map)
 
-    wire_totals = [f"{wire}: " for wire in wire_map]
+    if show_wire_labels:
+        wire_totals = [f"{wire}: " for wire in wire_map]
+    else:
+        wire_totals = ["" for _ in wire_map]
     bit_totals = ["" for _ in range(n_bits)]
     line_length = max(len(s) for s in wire_totals)
 

--- a/pennylane/drawer/tape_text.py
+++ b/pennylane/drawer/tape_text.py
@@ -460,8 +460,8 @@ def tape_text(
     if show_wire_labels:
         wire_totals = [f"{wire}: " for wire in wire_map]
     else:
-        wire_totals = ["" for _ in wire_map]
-    bit_totals = ["" for _ in range(n_bits)]
+        wire_totals = [""] * n_wires
+    bit_totals = [""] * n_bits
     line_length = max(len(s) for s in wire_totals)
 
     wire_totals = [s.rjust(line_length, " ") for s in wire_totals]

--- a/tests/drawer/test_draw.py
+++ b/tests/drawer/test_draw.py
@@ -85,6 +85,17 @@ class TestLabelling:
         assert split_str[0][:2] == "0:"
         assert split_str[1][:2] == "a:"
 
+    def test_hiding_labels(self):
+        """Test that printing wire labels can be skipped with show_wire_labels=False."""
+
+        @qml.qnode(qml.device("default.qubit"))
+        def circ():
+            return qml.expval(qml.Z(0) @ qml.X(1))
+
+        split_str = draw(circ, show_wire_labels=False)().split("\n")
+        assert split_str[0].startswith("─")
+        assert split_str[1].startswith("─")
+
 
 class TestDecimals:
     """Test the decimals keyword argument."""

--- a/tests/drawer/test_draw_mpl.py
+++ b/tests/drawer/test_draw_mpl.py
@@ -187,6 +187,21 @@ class TestKwargs:
             assert l.get_fontsize() == 20
         plt.close()
 
+    def test_hide_wire_labels(self):
+        """Test that wire labels are skipped with show_wire_labels=False."""
+        fig, ax = qml.draw_mpl(circuit1, show_wire_labels=False)(1.23, 2.34)
+        fig_with_labels, ax_with_labels = qml.draw_mpl(circuit1)(1.23, 2.34)
+
+        # Only PauliX gate labels should be present
+        assert len(ax.texts) == 2
+        assert len(ax_with_labels.texts) == 2 + 3
+        assert ax.texts[0].get_text() == "RX"
+        assert ax.texts[1].get_text() == "RY"
+        assert fig.get_figwidth() == 4
+        assert fig_with_labels.get_figwidth() == 4 + 1
+
+        plt.close()
+
     @pytest.mark.parametrize(
         "notches, n_patches",
         [

--- a/tests/drawer/test_mpldrawer.py
+++ b/tests/drawer/test_mpldrawer.py
@@ -169,6 +169,23 @@ class TestLabels:
 
         plt.close()
 
+    @pytest.mark.parametrize("n_layers", [1, 4])
+    def test_crop_wire_labels(self, n_layers):
+        """Test that cropping wire labels works."""
+        drawer = MPLDrawer(n_layers, 3)
+
+        labels = ("a", "b", "c")
+        drawer.label(labels)
+        old_width = drawer.fig.get_figwidth()
+        assert old_width == n_layers + 3
+        old_xlim = drawer.ax.get_xlim()
+        assert old_xlim == (-2, n_layers + 1)
+        drawer.crop_wire_labels()
+        new_width = drawer.fig.get_figwidth()
+        assert new_width == n_layers + 2
+        new_xlim = drawer.ax.get_xlim()
+        assert new_xlim == (-1, n_layers + 1)
+
 
 def test_erase_wire():
     """Test the erase wire method."""

--- a/tests/drawer/test_tape_mpl.py
+++ b/tests/drawer/test_tape_mpl.py
@@ -117,6 +117,18 @@ class TestLabelling:
 
         plt.close()
 
+    @pytest.mark.parametrize("kwargs, labels", label_data)
+    def test_hide_wire_labels(self, kwargs, labels):
+        """Test that wire labels are skipped with show_wire_labels=False."""
+        fig, ax = tape_mpl(tape1, show_wire_labels=False, **kwargs)
+
+        # Only PauliX gate labels should be present
+        assert len(ax.texts) == 3
+        assert all(t.get_text() == "X" for t in ax.texts)
+        assert fig.get_figwidth() == 3
+
+        plt.close()
+
 
 class TestWires:
     """Test that wire lines are produced correctly in different situations."""

--- a/tests/drawer/test_tape_mpl.py
+++ b/tests/drawer/test_tape_mpl.py
@@ -117,8 +117,8 @@ class TestLabelling:
 
         plt.close()
 
-    @pytest.mark.parametrize("kwargs, labels", label_data)
-    def test_hide_wire_labels(self, kwargs, labels):
+    @pytest.mark.parametrize("kwargs, _", label_data)
+    def test_hide_wire_labels(self, kwargs, _):
         """Test that wire labels are skipped with show_wire_labels=False."""
         fig, ax = tape_mpl(tape1, show_wire_labels=False, **kwargs)
 

--- a/tests/drawer/test_tape_text.py
+++ b/tests/drawer/test_tape_text.py
@@ -433,6 +433,14 @@ class TestLabeling:
         assert split_str[2][:6] == "    a:"
         assert split_str[3][:6] == "1.234:"
 
+    def test_hiding_labels(self):
+        """Test that printing wire labels can be skipped with show_wire_labels=False."""
+
+        split_str = tape_text(tape, show_wire_labels=False).split("\n")
+        assert split_str[0].startswith("─")
+        assert split_str[1].startswith("─")
+        assert split_str[2].startswith("─")
+
 
 class TestDecimals:
     """Test the decimals keyword argument."""


### PR DESCRIPTION
**Context:**
Wire labels are drawn by default.

**Description of the Change:**
This PR adds an option to hide the wire labels, which can be useful to produce more clean images, for example.

**Benefits:**
A convenient feature.

**Possible Drawbacks:**
More options, I suppose.

**Related GitHub Issues:**
