### PR TITLE
Update Pennylane.ai links to be without `.html`

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -17,8 +17,8 @@ and help us make quantum computing a welcoming place for all.
 Start by experimenting with PennyLane.  Figure out how to do things and form opinions about what you
 like and dislike about the ecosystem.  What made your life easier? What was a source of
 difficulty and confusion? We can always use more user feedback. You can use our
-[demonstrations](https://pennylane.ai/qml/demonstrations.html) and
-[blog](https://pennylane.ai/blog/) to learn about features and applications.
+[demonstrations](https://pennylane.ai/qml/demonstrations) and
+[blog](https://pennylane.ai/blog) to learn about features and applications.
 
 As you get a feel for the user experience, you can start peeking under the hood and finding out how
 the package accomplishes its tasks.
@@ -33,7 +33,7 @@ Sometimes, it might take us a couple of hours to reply - please be patient!
 It's up to you!
 
 * **Write a Community Demo.** - Show off your PennyLane application on
-  [our community page](https://pennylane.ai/qml/demos_community.html). We take Jupyter notebooks,
+  [our community page](https://pennylane.ai/qml/demos_community). We take Jupyter notebooks,
   scripts with explanations, or entire repositories.  Community demos are a great way to showcase
   research and new papers.
 
@@ -42,7 +42,7 @@ It's up to you!
 
 * **Test the cutting-edge PennyLane releases.** - Clone our GitHub repository, and keep up with
   the latest features. Learn how to install PennyLane from source
-  [here](https://pennylane.ai/install.html?version=preview). If you run into any bugs, make a bug
+  [here](https://pennylane.ai/install). If you run into any bugs, make a bug
   report on our [issue tracker](https://github.com/XanaduAI/pennylane/issues).
 
 * **Report bugs.** - If you come across any bugs or issues, make a bug report. PennyLane has

--- a/README.md
+++ b/README.md
@@ -87,11 +87,11 @@ PennyLane's [quantum machine learning hub](https://pennylane.ai/qml/):
 
 <img src="https://raw.githubusercontent.com/PennyLaneAI/pennylane/master/doc/_static/readme/gpu_to_qpu.png" align="right" width="400px">
 
-* [What is quantum machine learning?](https://pennylane.ai/qml/whatisqml.html)
-* [QML tutorials and demos](https://pennylane.ai/qml/demonstrations.html)
-* [Frequently asked questions](https://pennylane.ai/faq.html)
-* [Key concepts of QML](https://pennylane.ai/qml/glossary.html)
-* [QML videos](https://pennylane.ai/qml/videos.html)
+* [What is quantum machine learning?](https://pennylane.ai/qml/whatisqml)
+* [QML tutorials and demos](https://pennylane.ai/qml/demonstrations)
+* [Frequently asked questions](https://pennylane.ai/faq)
+* [Key concepts of QML](https://pennylane.ai/qml/glossary)
+* [QML videos](https://pennylane.ai/qml/videos)
 
 You can also check out our [documentation](https://pennylane.readthedocs.io) for [quickstart
 guides](https://pennylane.readthedocs.io/en/stable/introduction/pennylane.html) to using PennyLane,
@@ -102,9 +102,9 @@ quantum device.
 ## Tutorials and demonstrations
 
 Take a deeper dive into quantum machine learning by exploring cutting-edge algorithms on our [demonstrations
-page](https://pennylane.ai/qml/demonstrations.html).
+page](https://pennylane.ai/qml/demonstrations).
 
-<a href="https://pennylane.ai/qml/demonstrations.html">
+<a href="https://pennylane.ai/qml/demonstrations">
   <img src="https://raw.githubusercontent.com/PennyLaneAI/pennylane/master/doc/_static/readme/demos.png" width="900px">
 </a>
 
@@ -112,14 +112,14 @@ All demonstrations are fully executable, and can be downloaded as Jupyter notebo
 scripts.
 
 If you would like to contribute your own demo, see our [demo submission
-guide](https://pennylane.ai/qml/demos_submission.html).
+guide](https://pennylane.ai/qml/demos_submission).
 
 ## Videos
 
-Seeing is believing! Check out [our videos](https://pennylane.ai/qml/videos.html) to learn about
+Seeing is believing! Check out [our videos](https://pennylane.ai/qml/videos) to learn about
 PennyLane, quantum computing concepts, and more. 
 
-<a href="https://pennylane.ai/qml/videos.html">
+<a href="https://pennylane.ai/qml/videos">
   <img src="https://raw.githubusercontent.com/PennyLaneAI/pennylane/master/doc/_static/readme/videos.png" width="900px">
 </a>
 

--- a/doc/code/qml_devices.rst
+++ b/doc/code/qml_devices.rst
@@ -8,7 +8,7 @@ qml.devices
     Unless you are a PennyLane or plugin developer, you likely do not need
     to use these classes directly.
 
-    See the `main plugins page <https://pennylane.ai/plugins.html>`_ for more
+    See the `main plugins page <https://pennylane.ai/plugins>`_ for more
     details on available plugins.
 
 .. rubric:: Modules

--- a/doc/code/qml_qchem.rst
+++ b/doc/code/qml_qchem.rst
@@ -71,7 +71,7 @@ The generated Hamiltonian can be used in a circuit where the molecular geometry,
 parameters, and the circuit parameters are optimized simultaneously. Further information about
 molecular geometry optimization with PennyLane is provided in this
 `paper <https://arxiv.org/abs/2106.13840>`__ and this
-`demo <https://pennylane.ai/qml/demos/tutorial_mol_geo_opt.html>`__.
+`demo <https://pennylane.ai/qml/demos/tutorial_mol_geo_opt>`__.
 
 .. code-block:: python3
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -84,7 +84,7 @@ Features
 
 - *Device-independent*.
   The same quantum circuit model can be **run on different backends**. Install
-  `plugins <https://pennylane.ai/plugins.html>`_ to access even more
+  `plugins <https://pennylane.ai/plugins>`_ to access even more
   devices, including **Strawberry Fields**, **Amazon Braket**, **IBM Q**, **Google Cirq**, **Rigetti Forest**,
   **Microsoft QDK**, and **ProjectQ**.
 
@@ -94,15 +94,15 @@ Getting started
 
 For an introduction to quantum machine learning, we have several guides and resources available
 on our `QML website <https://pennylane.ai/qml/>`_, including
-`What is QML? <https://pennylane.ai/qml/whatisqml.html>`_,
-`frequently asked questions <https://pennylane.ai/faq.html>`_,
-a `glossary of key concepts <https://pennylane.ai/qml/glossary.html>`_, and a curated selection
-of `QML videos <https://pennylane.ai/qml/videos.html>`_.
+`What is QML? <https://pennylane.ai/qml/whatisqml>`_,
+`frequently asked questions <https://pennylane.ai/faq>`_,
+a `glossary of key concepts <https://pennylane.ai/qml/glossary>`_, and a curated selection
+of `QML videos <https://pennylane.ai/qml/videos>`_.
 
 Then, take a deeper dive into quantum machine learning by
 exploring cutting-edge algorithms using PennyLane and near-term quantum hardware,
 with our collection of
-`QML demonstrations <https://pennylane.ai/qml/demonstrations.html>`_.
+`QML demonstrations <https://pennylane.ai/qml/demonstrations>`_.
 
 You can also check out the :doc:`Using PennyLane <introduction/pennylane>` section for
 more details on the :doc:`quantum operations <introduction/operations>`, and to explore
@@ -110,7 +110,7 @@ the available :doc:`optimization tools <introduction/interfaces>` provided by Pe
 We also have a detailed guide on :doc:`how to write your own <development/plugins>`
 PennyLane-compatible quantum device.
 
-Finally, play around with the numerous `devices and plugins <https://pennylane.ai/plugins.html>`_
+Finally, play around with the numerous `devices and plugins <https://pennylane.ai/plugins>`_
 available for running your hybrid optimizations—these include
 IBM Q, provided by the `PennyLane-Qiskit <https://docs.pennylane.ai/projects/qiskit/en/stable/>`__
 plugin, as well as the Rigetti Aspen QPU provided by `PennyLane-Rigetti

--- a/doc/introduction/circuits.rst
+++ b/doc/introduction/circuits.rst
@@ -89,7 +89,7 @@ instantiated using the :func:`device <pennylane.device>` loader.
 
 PennyLane offers some basic devices such as the ``'default.qubit'``, ``'default.mixed'``, ``lightning.qubit``,
 ``'default.gaussian'``, ``'default.clifford'``, and ``'default.tensor'`` simulators; additional devices can be installed as plugins
-(see `available plugins <https://pennylane.ai/plugins.html>`_ for more details). Note that the
+(see `available plugins <https://pennylane.ai/plugins>`_ for more details). Note that the
 choice of a device significantly determines the speed of your computation, as well as
 the available options that can be passed to the device loader.
 

--- a/doc/introduction/importing_workflows.rst
+++ b/doc/introduction/importing_workflows.rst
@@ -15,7 +15,7 @@ constructed using another framework. This includes circuits defined using `Qiski
 
     To import a quantum circuit defined using a particular framework, you will need to install the
     corresponding PennyLane plugin for that framework. More information about PennyLane plugins is
-    available on the `plugins <https://pennylane.ai/plugins.html>`_ page.
+    available on the `plugins <https://pennylane.ai/plugins>`_ page.
 
 Importing quantum circuits
 --------------------------

--- a/doc/introduction/pennylane.rst
+++ b/doc/introduction/pennylane.rst
@@ -42,5 +42,5 @@ the complex job of optimising communication with the devices, compiling circuits
 and choosing the best gradient strategies is taken care of.
 
 The library comes with default simulator devices, but is well-integrated with
-`external software and hardware <https://pennylane.ai/plugins.html>`__ to run quantum
+`external software and hardware <https://pennylane.ai/plugins>`__ to run quantum
 circuits---such as IBM's Qiskit, or Google's Cirq, Rigetti's Forest, or Xanadu's Strawberry Fields.

--- a/doc/releases/changelog-0.19.0.md
+++ b/doc/releases/changelog-0.19.0.md
@@ -1112,7 +1112,7 @@
 
 <h3>Documentation</h3>
 
-* Adds a link to https://pennylane.ai/qml/demonstrations.html in the navbar.
+* Adds a link to https://pennylane.ai/qml/demonstrations in the navbar.
   [(#1624)](https://github.com/PennyLaneAI/pennylane/pull/1624)
 
 * Corrects the docstring of `ExpvalCost` by adding `wires` to the signature of

--- a/doc/releases/changelog-0.24.0.md
+++ b/doc/releases/changelog-0.24.0.md
@@ -66,7 +66,7 @@
     qfim = qml.qinfo.quantum_fisher(circ)(params)
     ```
 
-    These quantities are typically employed in variational optimization schemes to tilt the gradient in a more favourable direction  --- producing what is known as the [natural gradient](https://pennylane.ai/qml/demos/tutorial_quantum_natural_gradient.html). For example:
+    These quantities are typically employed in variational optimization schemes to tilt the gradient in a more favourable direction  --- producing what is known as the [natural gradient](https://pennylane.ai/qml/demos/tutorial_quantum_natural_gradient). For example:
 
     ```pycon
     >>> grad = qml.grad(circ)(params)

--- a/doc/releases/changelog-0.25.0.md
+++ b/doc/releases/changelog-0.25.0.md
@@ -610,7 +610,7 @@
 * The deprecated `qml.hf` module is removed. Users with code that calls `qml.hf` 
   can simply replace `qml.hf` with `qml.qchem` in most cases, or refer to the 
   [qchem documentation](https://pennylane.readthedocs.io/en/stable/code/qml_qchem.html) 
-  and [demos](https://pennylane.ai/qml/demos_quantum-chemistry.html) for more 
+  and [demos](https://pennylane.ai/qml/demos_quantum-chemistry) for more 
   information.
   [(#2795)](https://github.com/PennyLaneAI/pennylane/pull/2795)
 

--- a/doc/releases/changelog-0.26.0.md
+++ b/doc/releases/changelog-0.26.0.md
@@ -227,7 +227,7 @@
       params, cost = opt.step_and_cost(cost, params)
   ```  
 
-  Check out [our demo](https://pennylane.ai/qml/demos/qnspsa.html) on the QNSPSA optimizer for more information.
+  Check out [our demo](https://pennylane.ai/qml/demos/qnspsa) on the QNSPSA optimizer for more information.
 
 <h4>Operator and parameter broadcasting supplements 📈</h4>
 
@@ -245,11 +245,11 @@
     array([[1.       +0.j        , 0.       +0.j        ,
         1.       +0.j        , 0.       +0.j        ],
        [0.       +0.j        , 0.8156179+0.j        ,
-        1.       +0.57859091j, 0.       +0.j        ],
+        2.       +0.57859091j, 0.       +0.j        ],
        [0.       +0.j        , 0.       +0.57859091j,
         0.8156179+0.j        , 0.       +0.j        ],
        [0.       +0.j        , 0.       +0.j        ,
-        1.       +0.j        , 1.       +0.j        ]]) 
+        3.       +0.j        , 1.       +0.j        ]]) 
     ```
 
   - The `qml.pow` function raises a given operator to a power:

--- a/doc/releases/changelog-0.27.0.md
+++ b/doc/releases/changelog-0.27.0.md
@@ -196,7 +196,7 @@
   ```
 
   For a detailed breakdown of its implementation, check out the [Adaptive circuits for quantum chemistry
-  demo](https://pennylane.ai/qml/demos/tutorial_adaptive_circuits.html).
+  demo](https://pennylane.ai/qml/demos/tutorial_adaptive_circuits).
 
 <h4>Automatic interface detection 🧩</h4>
 

--- a/pennylane/devices/device_constructor.py
+++ b/pennylane/devices/device_constructor.py
@@ -88,7 +88,7 @@ def device(name, *args, **kwargs):
       of quantum circuits based on tensor networks.
 
     Additional devices are supported through plugins — see
-    the  `available plugins <https://pennylane.ai/plugins.html>`_ for more
+    the  `available plugins <https://pennylane.ai/plugins>`_ for more
     details. To list all currently installed devices, run
     :func:`qml.about <pennylane.about>`.
 

--- a/pennylane/fourier/reconstruct.py
+++ b/pennylane/fourier/reconstruct.py
@@ -392,9 +392,9 @@ def reconstruct(qnode, ids=None, nums_frequency=None, spectra=None, shifts=None)
     `Wierichs, Izaac, Wang and Lin (2022) <https://doi.org/10.22331/q-2022-03-30-677>`__ .
     An introduction to the concept of quantum circuits as Fourier series can also be found in
     the
-    `Quantum models as Fourier series <https://pennylane.ai/qml/demos/tutorial_expressivity_fourier_series.html>`__
+    `Quantum models as Fourier series <https://pennylane.ai/qml/demos/tutorial_expressivity_fourier_series>`__
     and
-    `General parameter-shift rules <https://pennylane.ai/qml/demos/tutorial_general_parshift.html>`__
+    `General parameter-shift rules <https://pennylane.ai/qml/demos/tutorial_general_parshift>`__
     demos as well as the
     :mod:`qml.fourier <pennylane.fourier>` module docstring.
 

--- a/pennylane/optimize/qnspsa.py
+++ b/pennylane/optimize/qnspsa.py
@@ -77,7 +77,7 @@ class QNSPSAOptimizer:
         "Simultaneous Perturbation Stochastic Approximation of the Quantum Fisher Information."
         `Quantum, 5, 567 <https://quantum-journal.org/papers/q-2021-10-20-567/>`_, 2021.
 
-    You can also find a walkthrough of the implementation in this `tutorial <https://pennylane.ai/qml/demos/qnspsa.html>`_.
+    You can also find a walkthrough of the implementation in this `tutorial <https://pennylane.ai/qml/demos/qnspsa>`_.
 
     **Examples:**
 

--- a/pennylane/pulse/__init__.py
+++ b/pennylane/pulse/__init__.py
@@ -30,7 +30,7 @@ typically encountered in PennyLane. It requires separate installation, see
 `jax.readthedocs.io <https://jax.readthedocs.io/en/latest/>`_.
 
 For a demonstration of the basic pulse functionality in PennyLane and running a ctrl-VQE example, see our demo on
-`differentiable pulse programming <https://pennylane.ai/qml/demos/tutorial_pulse_programming101.html>`_.
+`differentiable pulse programming <https://pennylane.ai/qml/demos/tutorial_pulse_programming101>`_.
 
 Overview
 --------

--- a/pennylane/shadows/__init__.py
+++ b/pennylane/shadows/__init__.py
@@ -45,7 +45,7 @@ Classical Shadows formalism
 
 .. note:: As per `arXiv:2103.07510 <https://arxiv.org/abs/2103.07510>`_, when computing multiple expectation values it is advisable to directly estimate the desired observables by simultaneously measuring
     qubit-wise-commuting terms. One way of doing this in PennyLane is via :class:`~pennylane.Hamiltonian` and setting ``grouping_type="qwc"``. For more details on this topic, see the PennyLane demo
-    on `estimating expectation values with classical shadows <https://pennylane.ai/qml/demos/tutorial_diffable_shadows.html>`_.
+    on `estimating expectation values with classical shadows <https://pennylane.ai/qml/demos/tutorial_diffable_shadows>`_.
 
 A :class:`ClassicalShadow` is a classical description of a quantum state that is capable of reproducing expectation values of local Pauli observables, see `arXiv:2002.08953 <https://arxiv.org/abs/2002.08953>`_.
 

--- a/pennylane/shadows/classical_shadow.py
+++ b/pennylane/shadows/classical_shadow.py
@@ -46,7 +46,7 @@ class ClassicalShadow:
 
     .. note:: As per `arXiv:2103.07510 <https://arxiv.org/abs/2103.07510>`_, when computing multiple expectation values it is advisable to directly estimate the desired observables by simultaneously measuring
         qubit-wise-commuting terms. One way of doing this in PennyLane is via :class:`~pennylane.Hamiltonian` and setting ``grouping_type="qwc"``. For more details on this topic, see our demo
-        on `estimating expectation values with classical shadows <https://pennylane.ai/qml/demos/tutorial_diffable_shadows.html>`_.
+        on `estimating expectation values with classical shadows <https://pennylane.ai/qml/demos/tutorial_diffable_shadows>`_.
 
     Args:
         bits (tensor): recorded measurement outcomes in random Pauli bases.
@@ -55,7 +55,7 @@ class ClassicalShadow:
             they appear in the columns of ``bits`` and ``recipes``. If None, defaults
             to ``range(n)``, where ``n`` is the number of measured wires.
 
-    .. seealso:: Demo on `Estimating observables with classical shadows in the Pauli basis <https://pennylane.ai/qml/demos/tutorial_diffable_shadows.html>`_, :func:`~.pennylane.classical_shadow`
+    .. seealso:: Demo on `Estimating observables with classical shadows in the Pauli basis <https://pennylane.ai/qml/demos/tutorial_diffable_shadows>`_, :func:`~.pennylane.classical_shadow`
 
     **Example**
 

--- a/tests/optimize/test_rotoselect.py
+++ b/tests/optimize/test_rotoselect.py
@@ -71,7 +71,7 @@ class TestRotoselectOptimizer:
     def test_rotoselect_optimizer(self, x_start, generators, tol):
         """Tests that rotoselect optimizer finds the optimal generators and parameters for the
         VQE circuit defined in `this rotoselect tutorial
-        <https://pennylane.ai/qml/demos/tutorial_rotoselect.html>`_."""
+        <https://pennylane.ai/qml/demos/tutorial_rotoselect>`_."""
 
         # the optimal generators for the 2-qubit VQE circuit
         # H = 0.5 * Y_2 + 0.8 * Z_1 - 0.2 * X_1


### PR DESCRIPTION
## Changes
- Updated links to PennyLane.ai within the documentation to the current URL format which is without `.html` prefix