### PR TITLE
Fix typo in `qml.transforms.mitigate_with_zne` docstring.

### DIFF
--- a/pennylane/transforms/mitigate.py
+++ b/pennylane/transforms/mitigate.py
@@ -436,7 +436,7 @@ def mitigate_with_zne(
         n_wires = 2
         n_layers = 2
 
-        shapes = qml.SimplifiedTwoDesign.shape(n_wires, n_layers)
+        shapes = qml.SimplifiedTwoDesign.shape(n_layers, n_wires)
         np.random.seed(0)
         w1, w2 = [np.random.random(s) for s in shapes]
 


### PR DESCRIPTION
Currently the usage example contains the line of code `qml.SimplifiedTwoDesign.shape(n_wires, n_layers)`. The arguments are the wrong order, so this PR changes it to `qml.SimplifiedTwoDesign.shape(n_layers, n_wires)`.