### PR TITLE
`mitigate_with_zne` preserves shots on the original tape

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -400,6 +400,9 @@
 * Fixes a bug where `CommutingEvolution` with a trainable `Hamiltonian` cannot be differentiated using parameter shift.
   [(#6372)](https://github.com/PennyLaneAI/pennylane/pull/6372)
 
+* Fixes a bug where `mitigate_with_zne` loses the `shots` information of the original tape.
+  [(#6444)](https://github.com/PennyLaneAI/pennylane/pull/6444)
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane/transforms/mitigate.py
+++ b/pennylane/transforms/mitigate.py
@@ -581,7 +581,7 @@ def mitigate_with_zne(
         tapes = [t[0] for t, _ in tapes]
 
     prep_ops = tape.operations[: tape.num_preps]
-    out_tapes = [QuantumScript(prep_ops + tape_.operations, tape.measurements) for tape_ in tapes]
+    out_tapes = [tape.copy(operations=prep_ops + tape_.operations) for tape_ in tapes]
 
     def processing_fn(results):
         """Maps from input tape executions to an error-mitigated estimate"""

--- a/tests/transforms/test_mitigate.py
+++ b/tests/transforms/test_mitigate.py
@@ -118,9 +118,8 @@ class TestMitigateWithZNE:
     def test_shots_preserved(self):
         """Tests that the mitigated circuits contain the same shots as the original circuit"""
 
-        w1, w2 = [np.random.random(2) for _ in range(2)]
         _tape = qml.tape.QuantumScript(
-            [qml.SimplifiedTwoDesign(w1, w2, wires=range(2))],
+            [qml.RX(0.1, wires=0)],
             [qml.expval(qml.PauliZ(0))],
             shots=1000,
         )

--- a/tests/transforms/test_mitigate.py
+++ b/tests/transforms/test_mitigate.py
@@ -115,6 +115,18 @@ class TestMitigateWithZNE:
         for t in tapes:
             same_tape(t, tape)
 
+    def test_shots_preserved(self):
+        """Tests that the mitigated circuits contain the same shots as the original circuit"""
+
+        w1, w2 = [np.random.random(2) for _ in range(2)]
+        tape = qml.tape.QuantumScript(
+            [qml.SimplifiedTwoDesign(w1, w2, wires=range(2))],
+            [qml.expval(qml.PauliZ(0))],
+            shots=1000,
+        )
+        tapes, _ = mitigate_with_zne(tape, [1, 2, 3], fold_global, exponential_extrapolate)
+        assert all(t.shots.total_shots == 1000 for t in tapes)
+
     @pytest.mark.parametrize("extrapolate", [richardson_extrapolate, exponential_extrapolate])
     def test_multi_returns(self, extrapolate):
         """Tests if the expected shape is returned when mitigating a circuit with two returns"""

--- a/tests/transforms/test_mitigate.py
+++ b/tests/transforms/test_mitigate.py
@@ -119,12 +119,12 @@ class TestMitigateWithZNE:
         """Tests that the mitigated circuits contain the same shots as the original circuit"""
 
         w1, w2 = [np.random.random(2) for _ in range(2)]
-        tape = qml.tape.QuantumScript(
+        _tape = qml.tape.QuantumScript(
             [qml.SimplifiedTwoDesign(w1, w2, wires=range(2))],
             [qml.expval(qml.PauliZ(0))],
             shots=1000,
         )
-        tapes, _ = mitigate_with_zne(tape, [1, 2, 3], fold_global, exponential_extrapolate)
+        tapes, _ = mitigate_with_zne(_tape, [1, 2, 3], fold_global, exponential_extrapolate)
         assert all(t.shots.total_shots == 1000 for t in tapes)
 
     @pytest.mark.parametrize("extrapolate", [richardson_extrapolate, exponential_extrapolate])


### PR DESCRIPTION
**Context:**
The output tapes of `mitigate_with_zne` loses the `shots` of the original tape.

**Description of the Change:**
Use `QuantumScript.copy` to create new tapes within the transform

**Benefits:**
Fixes a bug

**Related GitHub Issues:**
Fixes https://github.com/PennyLaneAI/pennylane/issues/6440
[sc-76678]