### PR TITLE
Update version number to 0.39.0

### DIFF
--- a/pennylane/_version.py
+++ b/pennylane/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.39.0-rc0"
+__version__ = "0.39.0"


### PR DESCRIPTION
**Context:**
When it branched off from `master`, the RC branch version number in `_version.py` was `0.39.0-rc0`, to make sure we didn't merge anything into `master` that would have the `0.39.0` tag and mess things up for Test PyPI. 

Now that the RC branch is separate, this isn't needed (and needs to be updated before release), and it is causing a test that checks the current versioning to fail.

**Description of the Change:**
We update the version to `0.39.0`

**Benefits:**
The test stops failing, and the version number is up-do-date for when the RC branch is released
