### PR TITLE
[BUGFIX] `shadow_expval` doesn't work with parameter broadcasting

### DIFF
--- a/doc/releases/changelog-0.39.0.md
+++ b/doc/releases/changelog-0.39.0.md
@@ -394,7 +394,7 @@
 
 <h3>Bug fixes 🐛</h3>
 
-* `qml.classical_shadow` and `qml.shadow_expval` now support parameter broadcasting.
+* The `default.qubit` device now supports parameter broadcasting with `qml.classical_shadow` and `qml.shadow_expval`.
   [(#6301)](https://github.com/PennyLaneAI/pennylane/pull/6301)
 
 * Fixes unnecessary call of `eigvals` in `qml.ops.op_math.decompositions.two_qubit_unitary.py` that was causing an error in VJP. Raises warnings to users if this essentially nondifferentiable module is used.

--- a/doc/releases/changelog-0.39.0.md
+++ b/doc/releases/changelog-0.39.0.md
@@ -394,6 +394,9 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* `qml.classical_shadow` and `qml.shadow_expval` now support parameter broadcasting.
+  [(#6301)](https://github.com/PennyLaneAI/pennylane/pull/6301)
+
 * Fixes unnecessary call of `eigvals` in `qml.ops.op_math.decompositions.two_qubit_unitary.py` that was causing an error in VJP. Raises warnings to users if this essentially nondifferentiable module is used.
   [(#6437)](https://github.com/PennyLaneAI/pennylane/pull/6437)
 

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -26,7 +26,7 @@ import numpy as np
 
 import pennylane as qml
 from pennylane.logging import debug_logger, debug_logger_init
-from pennylane.measurements import ShadowExpvalMP, ClassicalShadowMP
+from pennylane.measurements import ClassicalShadowMP, ShadowExpvalMP
 from pennylane.measurements.mid_measure import MidMeasureMP
 from pennylane.ops.op_math.condition import Conditional
 from pennylane.tape import QuantumScript, QuantumScriptBatch, QuantumScriptOrBatch

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -165,9 +165,9 @@ def all_state_postprocessing(results, measurements, wire_order):
 
 @qml.transform
 def conditional_broastcast_expand(tape):
+    """Apply conditional broadcast expansion to the tape if needed."""
     if any(isinstance(mp, (ShadowExpvalMP)) for mp in tape.measurements):
         return qml.transforms.broadcast_expand(tape)
-
     return (tape,), null_postprocessing
 
 

--- a/tests/measurements/test_classical_shadow.py
+++ b/tests/measurements/test_classical_shadow.py
@@ -365,6 +365,25 @@ class TestClassicalShadow:
         assert qml.math.shape(res[0]) == (2, shots, wires)
         assert qml.math.shape(res[1]) == ()
 
+    @pytest.mark.parametrize("shots", shots_list)
+    @pytest.mark.parametrize("params", [[0.1, 0.2], [0.1, 0.2, 0.3]])
+    def test_parameter_broadcasting(self, wires, shots, params):
+        """Test that the classical_shadow measurement process supports parameter broadcasting"""
+
+        @qml.qnode(qml.device("default.qubit", wires=wires, shots=shots))
+        def circuit(x):
+            qml.RX(x, wires=0)
+            qml.Hadamard(wires=0)
+            return qml.classical_shadow(wires=range(wires))
+
+        result = circuit(params)
+        sequential_result = [circuit(i) for i in params]
+
+        assert isinstance(result, np.ndarray)
+        assert qml.math.shape(result) == (len(params), 2, shots, wires)
+        for seq_res, res in zip(sequential_result, result):
+            assert qml.math.shape(seq_res) == qml.math.shape(res)
+
 
 def hadamard_circuit(wires, shots=10000, interface="autograd"):
     dev = qml.device("default.qubit", wires=wires, shots=shots)
@@ -486,6 +505,24 @@ class TestExpvalMeasurement:
         assert tape.operations[0].name == "PauliY"
         assert len(tape.measurements) == 1
         assert isinstance(tape.measurements[0], ShadowExpvalMP)
+
+    @pytest.mark.parametrize("params", [[0.1, 0.2], [0.1, 0.2, 0.3]])
+    def test_expval_parameter_broadcasting(self, params):
+        """Test that the shadow_expval measurement process supports parameter broadcasting"""
+
+        @qml.qnode(qml.device("default.qubit", wires=2, shots=10))
+        def circuit(x):
+            qml.RX(x, wires=1)
+            qml.Hadamard(wires=0)
+            return qml.shadow_expval([qml.PauliZ(0), qml.PauliZ(1)])
+
+        result = circuit(params)
+        sequential_result = [circuit(i) for i in params]
+
+        assert isinstance(result, np.ndarray)
+        assert qml.math.shape(result)[0] == len(params)
+        for seq_res, res in zip(sequential_result, result):
+            assert qml.math.shape(seq_res) == qml.math.shape(res)
 
 
 obs_hadamard = [

--- a/tests/transforms/core/test_transform_dispatcher.py
+++ b/tests/transforms/core/test_transform_dispatcher.py
@@ -636,8 +636,8 @@ class TestTransformDispatcher:  # pylint: disable=too-many-public-methods
         assert isinstance(program, qml.transforms.core.TransformProgram)
         assert isinstance(new_program, qml.transforms.core.TransformProgram)
 
-        assert len(program) == 4
-        assert len(new_program) == 5
+        assert len(program) == 5
+        assert len(new_program) == 6
 
         assert new_program[-1].transform is valid_transform
 

--- a/tests/workflow/test_construct_batch.py
+++ b/tests/workflow/test_construct_batch.py
@@ -105,7 +105,7 @@ class TestTransformProgramGetter:
         p_none = get_transform_program(circuit, None)
         assert p_dev == p_default
         assert p_none == p_dev
-        assert len(p_dev) == 8
+        assert len(p_dev) == 9
         config = qml.devices.ExecutionConfig(interface=getattr(circuit, "interface", None))
         assert p_dev == p_grad + dev.preprocess(config)[0]
 
@@ -140,7 +140,7 @@ class TestTransformProgramGetter:
             return qml.expval(qml.PauliZ(0))
 
         full_prog = get_transform_program(circuit)
-        assert len(full_prog) == 12
+        assert len(full_prog) == 13
 
         config = qml.devices.ExecutionConfig(
             interface=getattr(circuit, "interface", None),


### PR DESCRIPTION
**Context:** WIth `default.qubit`, parameter broadcasting does not work with `shadow_expval` (or `classical_shadow`) as the measurement process.

These latest developments might be relevant for historical reasons:

- In [this PR](https://github.com/PennyLaneAI/pennylane/pull/4238), support for parameter broadcasting was added for `measure` and `measure_with_samples` (presumably as an effort for the new device API). Specifically, a new keyword argument `is_state_batched` has been introduced to these functions to deal with the parameter broadcasting case.

- In [this PR](https://github.com/PennyLaneAI/pennylane/pull/4162), the classical shadow measurement process was integrated into the new device API as well. A new logical branch was integrated into `measure_with_samples` adding a new `_measure_classical_shadow function`. This function did not receive the `is_state_batched argument`, so apparently supporting parameter broadcasting for classical shadows was not part of the requirements (the shortcut story was not linked so I cannot investigate further).

- In [this PR](https://github.com/PennyLaneAI/pennylane/pull/4429), the `is_state_batched` argument has been added to `_measure_classical_shadow`, but support for parameter broadcasting was never implemented (the argument is unused).

**Description of the Change:** We added an internal conditional quantum transform to `default.qubit` such that the `qml.transforms.broadcast_expand` is conditionally applied if `ShadowExpvalMP` or `ClassicalShadowMP` are found in the tape measurement process.

**Benefits:** Now `default.qubit` supports (non-native) parameter broadcasting with shadow measurement processes.

**Possible Drawbacks:** Since we are applying the `broadcast_expand` quantum transform, we are not supporting *native* parameter broadcasting, This should not be a big deal.

**Related GitHub Issues:** #6301 

**Related ShortCut Stories:** [sc-74387]