### PR TITLE
Polishing Pennylane v0.39.0 Documentation

### DIFF
--- a/pennylane/drawer/draw.py
+++ b/pennylane/drawer/draw.py
@@ -44,17 +44,16 @@ def draw(
     r"""Create a function that draws the given qnode or quantum function.
 
     Args:
-        qnode (.QNode or Callable): the input QNode or quantum function that is to be drawn.
-        wire_order (Sequence[Any]): the order (from top to bottom) to print the wires of the circuit.
-           If not provided, the wire order defaults to the device wires. If device wires are not
-           available, the circuit wires are sorted if possible.
+        qnode (.QNode or Callable): the input QNode or quantum function that is to be drawn
+        wire_order (Sequence[Any]): The order (from top to bottom) to print the wires of the circuit.
+            Defaults to the device wires. If device wires are not available, the circuit wires are sorted if possible.
         show_all_wires (bool): If True, all wires, including empty wires, are printed.
-        decimals (int): How many decimal points to include when formatting operation parameters.
+        decimals (int): How many decimal points to include when formatting operation parameters. Defaults to ``2`` decimal points.
             ``None`` will omit parameters from operation labels.
-        max_length (int): Maximum string width (columns) when printing the circuit
-        show_matrices=False (bool): show matrix valued parameters below all circuit diagrams
-        show_wire_labels (bool): Whether or not to show the wire labels.
-        level (None, str, int, slice): An indication of what transforms to apply before drawing.
+        max_length (int): Maximum string width (columns) when printing the circuit. Defaults to ``100``.
+        show_matrices (bool): Show matrix valued parameters below all circuit diagrams. Defaults to ``False``.
+        show_wire_labels (bool): Whether or not to show the wire labels. Defaults to ``True``.
+        level (None, str, int, slice): An indication of what transforms to apply before drawing. Defaults to ``"gradient"``.
             Check :func:`~.workflow.get_transform_program` for more information on the allowed values and usage details of
             this argument.
 

--- a/pennylane/ops/functions/iterative_qpe.py
+++ b/pennylane/ops/functions/iterative_qpe.py
@@ -28,13 +28,17 @@ def iterative_qpe(base, aux_wire="unset", iters="unset", ancilla="unset"):
     Given a unitary :math:`U`, this function applies the circuit for iterative quantum phase
     estimation and returns a list of mid-circuit measurements with qubit reset.
 
+    .. warning::
+
+        The ``ancilla`` argument below is deprecated and will be removed in v0.40. The ``aux_wire`` argument should be used instead. If both arguments
+        are provided, ``aux_wire`` will be used and ``ancilla`` will be ignored.
+
     Args:
       base (Operator): the phase estimation unitary, specified as an :class:`~.Operator`
       aux_wire (Union[Wires, int, str]): the wire to be used for the estimation
       iters (int): the number of measurements to be performed
-      ancilla (Union[Wires, int, str]): the wire to be used for the estimation. This argument
-        is deprecated, and the ``aux_wire`` argument should be used instead. If both arguments
-        are provided, ``aux_wire`` will be used and ``ancilla`` will be ignored.
+      ancilla (Union[Wires, int, str]): The wire to be used for the estimation. This argument
+        is deprecated.
 
     Returns:
       list[MidMeasureMP]: the list of measurements performed

--- a/pennylane/ops/functions/iterative_qpe.py
+++ b/pennylane/ops/functions/iterative_qpe.py
@@ -93,8 +93,8 @@ def iterative_qpe(base, aux_wire="unset", iters="unset", ancilla="unset"):
 
     if ancilla != "unset":
         warn(
-            "The 'ancilla' argument for qml.iterative_qpe has been deprecated. Please use the "
-            "'aux_wire' argument instead.",
+            "The 'ancilla' argument for qml.iterative_qpe has been deprecated and will be removed in v0.40. "
+            "Please use the 'aux_wire' argument instead.",
             qml.PennyLaneDeprecationWarning,
         )
         if aux_wire == "unset":

--- a/pennylane/ops/qubit/state_preparation.py
+++ b/pennylane/ops/qubit/state_preparation.py
@@ -57,11 +57,10 @@ class BasisState(StatePrepBase):
         as :math:`U|0\rangle = |\psi\rangle`
 
     Args:
-        state (tensor_like): binary input of shape ``(len(wires), )``, e.g., for ``state=np.array([0, 1, 0])`` or ``state=2`` (binary 010), the quantum system will be prepared in state :math:`|010 \rangle`.
+        state (tensor_like): Binary input of shape ``(len(wires), )``. For example, if ``state=np.array([0, 1, 0])`` or ``state=2`` (equivalent to 010 in binary), the quantum system will be prepared in the state :math:`|010 \rangle`.
 
         wires (Sequence[int] or int): the wire(s) the operation acts on
-        id (str): custom label given to an operator instance,
-            can be useful for some applications where the instance has to be identified.
+        id (str): Custom label given to an operator instance. Can be useful for some applications where the instance has to be identified.
 
     **Example**
 

--- a/pennylane/qinfo/transforms.py
+++ b/pennylane/qinfo/transforms.py
@@ -32,7 +32,7 @@ def reduced_dm(tape: QuantumScript, wires, **kwargs) -> tuple[QuantumScriptBatch
 
     .. warning::
 
-        The ``qml.qinfo.reduced_dm`` transform is deprecated and will be removed in v0.40. Instead include
+        The ``qml.qinfo.reduced_dm`` transform is deprecated and will be removed in v0.40. Instead, include
         the :func:`pennylane.density_matrix` measurement process in the return line of your QNode.
 
     Args:
@@ -85,7 +85,7 @@ def reduced_dm(tape: QuantumScript, wires, **kwargs) -> tuple[QuantumScriptBatch
 
     warnings.warn(
         "The qml.qinfo.reduced_dm transform is deprecated and will be removed "
-        "in v0.40. Instead include the qml.density_matrix measurement process in the "
+        "in v0.40. Instead, include the qml.density_matrix measurement process in the "
         "return line of your QNode.",
         qml.PennyLaneDeprecationWarning,
     )
@@ -151,7 +151,7 @@ def purity(tape: QuantumScript, wires, **kwargs) -> tuple[QuantumScriptBatch, Po
 
     .. warning::
 
-        The ``qml.qinfo.purity transform`` is deprecated and will be removed in v0.40. Instead include
+        The ``qml.qinfo.purity transform`` is deprecated and will be removed in v0.40. Instead, include
         the :func:`pennylane.purity` measurement process in the return line of your QNode.
 
     Args:
@@ -195,7 +195,7 @@ def purity(tape: QuantumScript, wires, **kwargs) -> tuple[QuantumScriptBatch, Po
 
     warnings.warn(
         "The qml.qinfo.purity transform is deprecated and will be removed "
-        "in v0.40. Instead include the qml.purity measurement process in the "
+        "in v0.40. Instead, include the qml.purity measurement process in the "
         "return line of your QNode.",
         qml.PennyLaneDeprecationWarning,
     )
@@ -256,7 +256,7 @@ def vn_entropy(
 
     .. warning::
 
-        The ``qml.qinfo.vn_entropy`` transform is deprecated and will be removed in v0.40. Instead include
+        The ``qml.qinfo.vn_entropy`` transform is deprecated and will be removed in v0.40. Instead, include
         the :func:`pennylane.vn_entropy` measurement process in the return line of your QNode.
 
     Args:
@@ -296,7 +296,7 @@ def vn_entropy(
 
     warnings.warn(
         "The qml.qinfo.vn_entropy transform is deprecated and will be removed "
-        "in v0.40. Instead include the qml.vn_entropy measurement process in the "
+        "in v0.40. Instead, include the qml.vn_entropy measurement process in the "
         "return line of your QNode.",
         qml.PennyLaneDeprecationWarning,
     )
@@ -406,7 +406,7 @@ def mutual_info(
 
     .. warning::
 
-        The ``qml.qinfo.mutual_info`` transform is deprecated and will be removed in v0.40. Instead include
+        The ``qml.qinfo.mutual_info`` transform is deprecated and will be removed in v0.40. Instead, include
         the :func:`pennylane.mutual_info` measurement process in the return line of your QNode.
 
     Args:
@@ -449,7 +449,7 @@ def mutual_info(
 
     warnings.warn(
         "The qml.qinfo.mutual_info transform is deprecated and will be removed "
-        "in v0.40. Instead include the qml.mutual_info measurement process in the "
+        "in v0.40. Instead, include the qml.mutual_info measurement process in the "
         "return line of your QNode.",
         qml.PennyLaneDeprecationWarning,
     )
@@ -514,7 +514,7 @@ def vn_entanglement_entropy(
 
     warnings.warn(
         "The qml.qinfo.vn_entanglement_entropy transform is deprecated and will "
-        "be removed in v0.40. Instead include the qml.vn_entropy measurement process "
+        "be removed in v0.40. Instead, include the qml.vn_entropy measurement process "
         "on one of the subsystems.",
         qml.PennyLaneDeprecationWarning,
     )

--- a/pennylane/shadows/transforms.py
+++ b/pennylane/shadows/transforms.py
@@ -64,7 +64,7 @@ def shadow_expval(tape: QuantumScript, H, k=1) -> tuple[QuantumScriptBatch, Post
 
     .. warning::
 
-        ``qml.shadows.shadow_expval`` is deprecated. Please use the :func:`~pennylane.shadow_expval`
+        ``qml.shadows.shadow_expval`` is deprecated and will be removed in v0.40. Please use the :func:`~pennylane.shadow_expval`
         measurement process in your circuits instead.
 
     Args:
@@ -103,8 +103,8 @@ def shadow_expval(tape: QuantumScript, H, k=1) -> tuple[QuantumScriptBatch, Post
     """
 
     warnings.warn(
-        "qml.shadows.shadow_expval is deprecated. Instead, use the qml.shadow_expval "
-        "measurement process in your circuit.",
+        "qml.shadows.shadow_expval is deprecated and will be removed in v0.40. "
+        "Instead, use the qml.shadow_expval measurement process in your circuit.",
         qml.PennyLaneDeprecationWarning,
     )
 

--- a/pennylane/tape/qscript.py
+++ b/pennylane/tape/qscript.py
@@ -897,11 +897,11 @@ class QuantumScript:
                 measurements will replace the copied measurements on the new tape.
             shots (None, int, Sequence[int], ~.Shots): Number and/or batches of shots for execution. If provided, these
                 shots will replace the copied shots on the new tape.
-            trainable_params (None, Sequence[int]): the indices for which parameters are trainable. If provided, these
-                parameter indices will replace the copied parameter indicies on the new tape.
+            trainable_params (None, Sequence[int]): The indices for which parameters are trainable. If provided, these
+                parameter indices will replace the copied parameter indices on the new tape.
 
         Returns:
-            QuantumScript : a copy of the quantum script, with modified attributes if specified by keyword argument.
+            QuantumScript : A copy of the quantum script, with modified attributes if specified by keyword argument.
 
         **Example**
 

--- a/pennylane/templates/broadcast.py
+++ b/pennylane/templates/broadcast.py
@@ -216,7 +216,7 @@ def broadcast(unitary, wires, pattern, parameters=None, kwargs=None):
 
     .. warning::
 
-        ``qml.broadcast`` has been deprecated. Please use ``for`` loops instead.
+        ``qml.broadcast`` has been deprecated and will be removed in v0.40. Please use ``for`` loops instead.
 
     Args:
         unitary (func): quantum gate or template
@@ -561,7 +561,7 @@ def broadcast(unitary, wires, pattern, parameters=None, kwargs=None):
     # pylint: disable=consider-using-enumerate
 
     warn(
-        "qml.broadcast is deprecated. Please use a for loop instead",
+        "qml.broadcast is deprecated and will be removed in v0.40. Please use a for loop instead",
         qml.PennyLaneDeprecationWarning,
     )
 

--- a/pennylane/templates/embeddings/basis.py
+++ b/pennylane/templates/embeddings/basis.py
@@ -32,9 +32,9 @@ class BasisEmbedding(BasisState):
         gradients with respect to the argument cannot be computed by PennyLane.
 
     Args:
-        features (tensor_like or int): binary input of shape ``(len(wires), )`` or integer
+        features (tensor_like or int): Binary input of shape ``(len(wires), )`` or integer
             that represents the binary input.
-        wires (Any or Iterable[Any]): wires that the template acts on.
+        wires (Any or Iterable[Any]): the wire(s) that the template acts on
 
     Example:
 

--- a/pennylane/templates/subroutines/qft.py
+++ b/pennylane/templates/subroutines/qft.py
@@ -167,10 +167,14 @@ class QFT(Operation):
         **Example:**
 
         >>> qml.QFT.compute_decomposition(wires=(0,1,2), n_wires=3)
-        [Hadamard(wires=[0]), ControlledPhaseShift(1.5707963267948966, wires=Wires([1, 0])),
-        ControlledPhaseShift(0.7853981633974483, wires=Wires([2, 0])), Hadamard(wires=[1]),
-        ControlledPhaseShift(1.5707963267948966, wires=Wires([2, 1])), Hadamard(wires=[2]),
-        SWAP(wires=[0, 2])]
+        [H(0),
+         ControlledPhaseShift(1.5707963267948966, wires=Wires([1, 0])),
+         ControlledPhaseShift(0.7853981633974483, wires=Wires([2, 0])),
+         H(1),
+         ControlledPhaseShift(1.5707963267948966, wires=Wires([2, 1])),
+         H(2),
+         H(4),
+         SWAP(wires=[0, 4])]
 
         """
         shifts = [2 * np.pi * 2**-i for i in range(2, n_wires + 1)]

--- a/tests/measurements/test_mutual_info.py
+++ b/tests/measurements/test_mutual_info.py
@@ -24,7 +24,7 @@ from pennylane.wires import Wires
 
 DEP_WARNING_MESSAGE_MUTUAL_INFO = (
     "The qml.qinfo.mutual_info transform is deprecated and will be removed "
-    "in v0.40. Instead include the qml.mutual_info measurement process in the "
+    "in v0.40. Instead, include the qml.mutual_info measurement process in the "
     "return line of your QNode."
 )
 


### PR DESCRIPTION
**Context:**

Contains the full set of documentation corrections that were discovered during v0.39.0 quality assurance.

**Description of the Change:**

- Typos 
- Improving docstring consistency with the rest of codebase
- Adding deprecation warning blocks in the docs
- Fixing deprecation warnings to indicate removal version

**Benefits:** 

Consistency and correctness.