### PR TITLE
Fix typo in `NesterovMomentumOptimizer`'s `compute_grad` method docs

### DIFF
--- a/pennylane/optimize/nesterov_momentum.py
+++ b/pennylane/optimize/nesterov_momentum.py
@@ -45,7 +45,7 @@ class NesterovMomentumOptimizer(MomentumOptimizer):
     def compute_grad(
         self, objective_fn, args, kwargs, grad_fn=None
     ):  # pylint: disable=arguments-renamed
-        r"""Compute the gradient of the objective function at at the shifted point :math:`(x -
+        r"""Compute the gradient of the objective function at the shifted point :math:`(x -
         m\times\text{accumulation})` and return it along with the objective function forward pass
         (if available).
 


### PR DESCRIPTION
This PR fixes a minor typo in `NesterovMomentumOptimizer`'s `compute_grad` method docs.