### PR TITLE
update neighbour_order error in Lattice

### DIFF
--- a/pennylane/spin/lattice.py
+++ b/pennylane/spin/lattice.py
@@ -132,9 +132,9 @@ class Lattice:
             edges = self._identify_neighbours(cutoff)
             self.edges = Lattice._generate_true_edges(edges, lattice_map, neighbour_order)
         else:
-            if neighbour_order > 1:
+            if neighbour_order != 1:
                 raise ValueError(
-                    "custom_edges cannot be specified if neighbour_order argument is set to greater than 1."
+                    "custom_edges cannot be specified if neighbour_order argument is set to a value other than 1."
                 )
             lattice_map = dict(zip(lattice_map, self.lattice_points))
             self.edges = self._get_custom_edges(custom_edges, lattice_map)

--- a/tests/spin/test_lattice.py
+++ b/tests/spin/test_lattice.py
@@ -801,7 +801,7 @@ def test_neighbour_order_error():
     custom_edges = [[(0, 1)], [(0, 5)], [(0, 4)]]
     with pytest.raises(
         ValueError,
-        match="custom_edges cannot be specified if neighbour_order argument is set to greater than 1.",
+        match="custom_edges cannot be specified if neighbour_order argument is set to a value other than 1.",
     ):
         Lattice(n_cells=n_cells, vectors=vectors, neighbour_order=2, custom_edges=custom_edges)
 


### PR DESCRIPTION
Documentation previously said `neighbour_order` was limited to "not being more than 1" when `custom_edges` are defined. The phrasing is potentially confusing, as it begs the question what inputs aside from 1 are allowed; physically it doesn't make sense for it to be _less_ than one. 

In practice, it was treating any input `neighbour_order < 1` as `neighbour_order = 1`, and raising an error for any input above 1. In https://github.com/PennyLaneAI/pennylane/pull/6481 we changed the docstring to explicitly say "must be 1" rather than "must not be more than 1". Here we also update the condition for raising the error, and the error message, for consistency with the docstring.