### PR TITLE
Update `Iterable` import package in `decompose` transform

### DIFF
--- a/pennylane/transforms/decompose.py
+++ b/pennylane/transforms/decompose.py
@@ -18,8 +18,8 @@ A transform for decomposing quantum circuits into user defined gate sets. Offers
 # pylint: disable=unnecessary-lambda-assignment
 
 import warnings
-from collections.abc import Callable, Generator
-from typing import Iterable, Optional
+from collections.abc import Callable, Generator, Iterable
+from typing import Optional
 
 import pennylane as qml
 from pennylane.transforms.core import transform


### PR DESCRIPTION
Codefactor is complaining about `typing.Iterable` not being a valid 2nd argument for `isinstance()` in the RC sync PR (see [here](https://github.com/PennyLaneAI/pennylane/pull/6505/checks?check_run_id=32482041932)). I don't know why it is happening now and didn't happen before, but we stopped using `typing.Iterable` in favour of `collections.abc.Iterable` some time ago, so this PR just updates that.

It is apparently a known issue in pylint to have false positive errors of this type (see [here](https://github.com/pylint-dev/pylint/issues/3507)), and was fixed in v2.7.5. We use v2.7.4...