### PR TITLE
Update `typing_extensions` pinning in `requirements.txt`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,6 @@ autoray>=0.6.11
 matplotlib~=3.5
 opt_einsum~=3.3
 requests~=2.31.0
-typing_extensions~=4.5.0
+typing_extensions>=4.6.0
 tomli~=2.0.0 # Drop once minimum Python version is 3.11
 tach~=0.13.1


### PR DESCRIPTION
Required due to datasets issue with python 3.12

> Hey all, there's a few things undergoing checks right now, but I believe I have found a potential problem with datasets under Python 3.12 ---
TypeError: type 'typing.TypeVar' is not an acceptable base type
This is due to the external dep https://github.com/python/typing_extensions/issues/243
We need to immediately bump the typing_extensions package to 4.6 minimum to ensure compatibility with 3.12