### PR TITLE
Remove `__args__` method call after minimum Python version bump

### DIFF
--- a/pennylane/typing.py
+++ b/pennylane/typing.py
@@ -35,7 +35,7 @@ class TensorLikeMETA(type):
     def __instancecheck__(cls, other):
         """Dunder method used to check if an object is a `TensorLike` instance."""
         return (
-            isinstance(other, _TensorLike.__args__)  # TODO: Remove __args__ when python>=3.10
+            isinstance(other, _TensorLike)
             or _is_jax(other)
             or _is_torch(other)
             or _is_tensorflow(other)
@@ -44,7 +44,7 @@ class TensorLikeMETA(type):
     def __subclasscheck__(cls, other):
         """Dunder method that checks if a class is a subclass of ``TensorLike``."""
         return (
-            issubclass(other, _TensorLike.__args__)  # TODO: Remove __args__ when python>=3.10
+            issubclass(other, _TensorLike)
             or _is_jax(other, subclass=True)
             or _is_torch(other, subclass=True)
             or _is_tensorflow(other, subclass=True)


### PR DESCRIPTION
**Context:**

Don't need `__args__` anymore after supporting minimum version of `3.10` for Python.

In Python 3.10 and later, `isinstance()` supports direct use of `Union` and `Annotated` types, so `_TensorLike.__args__` won’t be necessary.

**Description of the Change:** Line removal.

**Benefits:** Code clean-up

**Possible Drawbacks:** None

[sc-77839]