### PR TITLE
Remove `ancilla` argument in `iterative_qpe`

### DIFF
--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -20,12 +20,6 @@ Pending deprecations
   - Deprecated in v0.39
   - Will be removed in v0.40
 
-* The ``'ancilla'`` argument for :func:`~pennylane.iterative_qpe` has been deprecated. Instead, use the ``'aux_wire'``
-  argument.
-
-  - Deprecated in v0.39
-  - Will be removed in v0.40
-
 * The ``qml.shadows.shadow_expval`` transform has been deprecated. Instead, please use the
   ``qml.shadow_expval`` measurement process.
 
@@ -130,6 +124,12 @@ Other deprecations
 
 Completed deprecation cycles
 ----------------------------
+
+* The ``'ancilla'`` argument for :func:`~pennylane.iterative_qpe` has been removed. Instead, use the ``'aux_wire'``
+  argument.
+
+  - Deprecated in v0.39
+  - Removed in v0.40
 
 * The ``simplify`` argument in ``qml.Hamiltonian`` and ``qml.ops.LinearCombination`` has been removed.
   Instead, ``qml.simplify()`` can be called on the constructed operator.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -20,12 +20,16 @@
 <h4>Other Improvements</h4>
 
 * Added `qml.devices.qubit_mixed` module for mixed-state qubit device support. This module introduces:
-
-  [(#6379)](https://github.com/PennyLaneAI/pennylane/pull/6379) An `apply_operation` helper function featuring:
-
-  * Two density matrix contraction methods using `einsum` and `tensordot`
-
-  * Optimized handling of special cases including: Diagonal operators, Identity operators, CX (controlled-X), Multi-controlled X gates, Grover operators
+  - A new API for mixed-state operations
+  - An `apply_operation` helper function featuring:
+    - Two density matrix contraction methods using `einsum` and `tensordot`
+    - Optimized handling of special cases including:
+      - Diagonal operators
+      - Identity operators 
+      - CX (controlled-X)
+      - Multi-controlled X gates
+      - Grover operators
+  [(#6379)](https://github.com/PennyLaneAI/pennylane/pull/6379)
 
 * `qml.BasisRotation` template is now JIT compatible.
   [(#6019)](https://github.com/PennyLaneAI/pennylane/pull/6019)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -24,7 +24,7 @@
 
 <h3>Breaking changes 💔</h3>
 
-* The ``'ancilla'`` argument for :func:`~pennylane.iterative_qpe` has been removed. Instead, use the ``'aux_wire'``.
+* The ``'ancilla'`` argument for :func:`~pennylane.iterative_qpe` has been removed. Instead, use the ``'aux_wire'`` argument.
   [(#6532)](https://github.com/PennyLaneAI/pennylane/pull/6532)
 
 <h3>Deprecations 👋</h3>

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -9,16 +9,12 @@
 <h4>Other Improvements</h4>
 
 * Added `qml.devices.qubit_mixed` module for mixed-state qubit device support. This module introduces:
-  - A new API for mixed-state operations
-  - An `apply_operation` helper function featuring:
-    - Two density matrix contraction methods using `einsum` and `tensordot`
-    - Optimized handling of special cases including:
-      - Diagonal operators
-      - Identity operators 
-      - CX (controlled-X)
-      - Multi-controlled X gates
-      - Grover operators
-  [(#6379)](https://github.com/PennyLaneAI/pennylane/pull/6379)
+
+  [(#6379)](https://github.com/PennyLaneAI/pennylane/pull/6379) An `apply_operation` helper function featuring:
+
+  * Two density matrix contraction methods using `einsum` and `tensordot`
+
+  * Optimized handling of special cases including: Diagonal operators, Identity operators, CX (controlled-X), Multi-controlled X gates, Grover operators
 
 * `qml.BasisRotation` template is now JIT compatible.
   [(#6019)](https://github.com/PennyLaneAI/pennylane/pull/6019)
@@ -27,6 +23,9 @@
   [(#6455)](https://github.com/PennyLaneAI/pennylane/pull/6455)
 
 <h3>Breaking changes 💔</h3>
+
+* The ``'ancilla'`` argument for :func:`~pennylane.iterative_qpe` has been removed. Instead, use the ``'aux_wire'``.
+  [(#6532)](https://github.com/PennyLaneAI/pennylane/pull/6532)
 
 <h3>Deprecations 👋</h3>
 

--- a/pennylane/_version.py
+++ b/pennylane/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.40.0-dev6"
+__version__ = "0.40.0-dev7"

--- a/pennylane/ops/functions/iterative_qpe.py
+++ b/pennylane/ops/functions/iterative_qpe.py
@@ -15,30 +15,22 @@
 This module contains the qml.iterative_qpe function.
 """
 
-from warnings import warn
 
 import numpy as np
 
 import pennylane as qml
 
 
-def iterative_qpe(base, aux_wire="unset", iters="unset", ancilla="unset"):
+def iterative_qpe(base, aux_wire="unset", iters="unset"):
     r"""Performs the `iterative quantum phase estimation <https://arxiv.org/pdf/quant-ph/0610214.pdf>`_ circuit.
 
     Given a unitary :math:`U`, this function applies the circuit for iterative quantum phase
     estimation and returns a list of mid-circuit measurements with qubit reset.
 
-    .. warning::
-
-        The ``ancilla`` argument below is deprecated and will be removed in v0.40. The ``aux_wire`` argument should be used instead. If both arguments
-        are provided, ``aux_wire`` will be used and ``ancilla`` will be ignored.
-
     Args:
       base (Operator): the phase estimation unitary, specified as an :class:`~.Operator`
       aux_wire (Union[Wires, int, str]): the wire to be used for the estimation
       iters (int): the number of measurements to be performed
-      ancilla (Union[Wires, int, str]): The wire to be used for the estimation. This argument
-        is deprecated.
 
     Returns:
       list[MidMeasureMP]: the list of measurements performed
@@ -84,7 +76,7 @@ def iterative_qpe(base, aux_wire="unset", iters="unset", ancilla="unset"):
                                                                                                                       ╚═══════╡ ╰Sample[MCM]
     """
     missing = []
-    if aux_wire == "unset" and ancilla == "unset":
+    if aux_wire == "unset":
         missing.append("'aux_wire'")
     if iters == "unset":
         missing.append("'iters'")
@@ -94,15 +86,6 @@ def iterative_qpe(base, aux_wire="unset", iters="unset", ancilla="unset"):
         raise TypeError(
             f"iterative_qpe() missing {len(missing)} required positional argument(s): {missing_args}"
         )
-
-    if ancilla != "unset":
-        warn(
-            "The 'ancilla' argument for qml.iterative_qpe has been deprecated and will be removed in v0.40. "
-            "Please use the 'aux_wire' argument instead.",
-            qml.PennyLaneDeprecationWarning,
-        )
-        if aux_wire == "unset":
-            aux_wire = ancilla
 
     measurements = []
 

--- a/pennylane/ops/functions/iterative_qpe.py
+++ b/pennylane/ops/functions/iterative_qpe.py
@@ -75,18 +75,6 @@ def iterative_qpe(base, aux_wire, iters):
                                                                      ╚══════════════════════╩═════════════════════════║═══════╡ ├Sample[MCM]
                                                                                                                       ╚═══════╡ ╰Sample[MCM]
     """
-    missing = []
-    if aux_wire == "unset":
-        missing.append("'aux_wire'")
-    if iters == "unset":
-        missing.append("'iters'")
-
-    if missing:
-        missing_args = " and ".join(missing)
-        raise TypeError(
-            f"iterative_qpe() missing {len(missing)} required positional argument(s): {missing_args}"
-        )
-
     measurements = []
 
     for i in range(iters):

--- a/pennylane/ops/functions/iterative_qpe.py
+++ b/pennylane/ops/functions/iterative_qpe.py
@@ -21,7 +21,7 @@ import numpy as np
 import pennylane as qml
 
 
-def iterative_qpe(base, aux_wire="unset", iters="unset"):
+def iterative_qpe(base, aux_wire, iters):
     r"""Performs the `iterative quantum phase estimation <https://arxiv.org/pdf/quant-ph/0610214.pdf>`_ circuit.
 
     Given a unitary :math:`U`, this function applies the circuit for iterative quantum phase

--- a/tests/ops/functions/test_iterative_qpe.py
+++ b/tests/ops/functions/test_iterative_qpe.py
@@ -23,26 +23,10 @@ import pennylane as qml
 class TestIQPE:
     """Test to check that the iterative quantum phase estimation function works as expected."""
 
-    def test_ancilla_deprecation(self):
-        """Test that the ancilla argument is deprecated and superceded by the aux_wire argument
-        if provided."""
-        aux_wire = 1
-        ancilla = 2
-
-        with pytest.warns(qml.PennyLaneDeprecationWarning, match="The 'ancilla' argument"):
-            meas1 = qml.iterative_qpe(qml.RZ(2.0, wires=0), ancilla=ancilla, iters=3)
-            meas2 = qml.iterative_qpe(
-                qml.RZ(2.0, wires=0), aux_wire=aux_wire, iters=3, ancilla=ancilla
-            )
-
-        assert all(m.wires == qml.wires.Wires(ancilla) for m in meas1)
-        assert all(m.wires == qml.wires.Wires(aux_wire) for m in meas2)
-
     @pytest.mark.parametrize(
         "args, n_missing, missing_args",
         [
             ({"aux_wire": 1}, 1, "'iters'"),
-            ({"ancilla": 1}, 1, "'iters'"),
             ({"iters": 1}, 1, "'aux_wire'"),
             ({}, 2, "'aux_wire' and 'iters'"),
         ],

--- a/tests/ops/functions/test_iterative_qpe.py
+++ b/tests/ops/functions/test_iterative_qpe.py
@@ -33,7 +33,9 @@ class TestIQPE:
     )
     def test_args_not_provided(self, args, n_missing, missing_args):
         """Test that the correct error is raised if there are missing arguments"""
-        err_msg = rf"iterative_qpe\(\) missing {n_missing} required positional argument\(s\): {missing_args}"
+        # Adjusted to use "arguments" for multiple missing args
+        plural_suffix = "s" if n_missing > 1 else ""
+        err_msg = rf"iterative_qpe\(\) missing {n_missing} required positional argument{plural_suffix}: {missing_args}"
         with pytest.raises(TypeError, match=err_msg):
             _ = qml.iterative_qpe(qml.RZ(1.5, 0), **args)
 

--- a/tests/ops/functions/test_iterative_qpe.py
+++ b/tests/ops/functions/test_iterative_qpe.py
@@ -23,22 +23,6 @@ import pennylane as qml
 class TestIQPE:
     """Test to check that the iterative quantum phase estimation function works as expected."""
 
-    @pytest.mark.parametrize(
-        "args, n_missing, missing_args",
-        [
-            ({"aux_wire": 1}, 1, "'iters'"),
-            ({"iters": 1}, 1, "'aux_wire'"),
-            ({}, 2, "'aux_wire' and 'iters'"),
-        ],
-    )
-    def test_args_not_provided(self, args, n_missing, missing_args):
-        """Test that the correct error is raised if there are missing arguments"""
-        # Adjusted to use "arguments" for multiple missing args
-        plural_suffix = "s" if n_missing > 1 else ""
-        err_msg = rf"iterative_qpe\(\) missing {n_missing} required positional argument{plural_suffix}: {missing_args}"
-        with pytest.raises(TypeError, match=err_msg):
-            _ = qml.iterative_qpe(qml.RZ(1.5, 0), **args)
-
     @pytest.mark.parametrize("mcm_method", ["deferred", "tree-traversal"])
     @pytest.mark.parametrize("phi", (1.0, 2.0, 3.0))
     def test_compare_qpe(self, mcm_method, phi):


### PR DESCRIPTION
**Context:**
as title
**Description of the Change:**
Here are the occurrences I noticed to move:
 - src: `qml.ops.functions.iterative_qpe.py`
 - test of the src mentioned above
 - 
**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**


**Related GitHub Issues:**
[sc-77483]