### PR TITLE
Change Torch wheel install variants for CI

### DIFF
--- a/.github/stable/all_interfaces.txt
+++ b/.github/stable/all_interfaces.txt
@@ -61,7 +61,7 @@ optree==0.12.1
 osqp==0.6.7.post1
 packaging==24.1
 pathspec==0.12.1
-PennyLane_Lightning==0.38.0
+PennyLane_Lightning==0.39.0
 pillow==10.4.0
 platformdirs==4.2.2
 pluggy==1.5.0
@@ -79,7 +79,7 @@ pytest-forked==1.6.0
 pytest-mock==3.14.0
 pytest-xdist==3.6.1
 python-dateutil==2.9.0.post0
-pytorch-triton-rocm==2.3.0
+pytorch-triton==2.3.0
 PyYAML==6.0.2
 qdldl==0.1.7.post4
 requests==2.32.3
@@ -97,7 +97,7 @@ termcolor==2.4.0
 tf_keras==2.16.0
 toml==0.10.2
 tomli==2.0.1
-torch==2.3.0+rocm6.0
+torch==2.3.0
 typing_extensions==4.12.2
 urllib3==2.2.2
 virtualenv==20.26.3

--- a/.github/stable/torch.txt
+++ b/.github/stable/torch.txt
@@ -58,7 +58,7 @@ pytest-forked==1.6.0
 pytest-mock==3.14.0
 pytest-xdist==3.6.1
 python-dateutil==2.9.0.post0
-pytorch-triton-rocm==2.3.0
+pytorch-triton==2.3.0
 PyYAML==6.0.2
 qdldl==0.1.7.post4
 requests==2.32.3
@@ -69,7 +69,7 @@ six==1.16.0
 sympy==1.13.2
 toml==0.10.2
 tomli==2.0.1
-torch==2.3.0+rocm6.0
+torch==2.3.0
 typing_extensions==4.12.2
 urllib3==2.2.2
 virtualenv==20.26.3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -90,4 +90,4 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         gh_pr_up() { gh pr create $* || gh pr edit $* }
-        gh_pr_up --title "Update stable doc dependency files" --body ""
+        gh_pr_up --title \"Update stable doc dependency files\" --body \"\"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -90,6 +90,6 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         function gh_pr_up() { 
-          echo "gh pr create $* || gh pr edit $*"
+          gh pr create $* || gh pr edit $*
         }
         gh_pr_up --title \"Update stable doc dependency files\" --body \".\"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -89,5 +89,7 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        gh_pr_up() { gh pr create $* || gh pr edit $* }
-        gh_pr_up --title \"Update stable doc dependency files\" --body \"\"
+        function gh_pr_up() { 
+          echo "gh pr create $* || gh pr edit $*"
+        }
+        gh_pr_up --title \"Update stable doc dependency files\" --body \".\"

--- a/.github/workflows/interface-dependency-versions.yml
+++ b/.github/workflows/interface-dependency-versions.yml
@@ -72,6 +72,6 @@ jobs:
     outputs:
       jax-version: jax==${{ steps.jax.outputs.version }} jaxlib==${{ steps.jax.outputs.version }}
       tensorflow-version: tensorflow~=${{ steps.tensorflow.outputs.version }} tf-keras~=${{ steps.tensorflow.outputs.version }}
-      pytorch-version: torch==${{ steps.pytorch.outputs.version }} -f https://download.pytorch.org/whl/torch_stable.html
+      pytorch-version: torch==${{ steps.pytorch.outputs.version }}
       catalyst-nightly: ${{ steps.catalyst.outputs.nightly }}
       pennylane-lightning-latest: ${{ steps.pennylane-lightning.outputs.latest }}

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -84,8 +84,6 @@ jobs:
     runs-on: ${{ inputs.job_runner_name }}
 
     steps:
-      - name: DF 1
-        run: df -h
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -93,16 +91,10 @@ jobs:
           fetch-depth: ${{ inputs.checkout_fetch_depth }}
           repository: PennyLaneAI/pennylane
 
-      - name: DF2
-        run: df -h
-
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
           python-version: '${{ inputs.python_version }}'
-
-      - name: DF3
-        run: df -h
 
       - name: Upgrade PIP and install wheel
         run: pip install --upgrade pip && pip install wheel --upgrade
@@ -111,9 +103,6 @@ jobs:
         run: |
           pip install -r requirements-ci.txt --upgrade
           pip install -r requirements-dev.txt --upgrade
-
-      - name: DF4
-        run: df -h
 
       - name: Install additional PIP packages (Pre-PennyLane)
         shell: bash
@@ -131,17 +120,11 @@ jobs:
             fi
           done <<< "$ADDITIONAL_PIP_PACKAGES"
 
-      - name: DF5
-        run: df -h
-
       - name: Install PennyLane
         shell: bash
         run: |
           python setup.py bdist_wheel
           pip install dist/PennyLane*.whl
-
-      - name: DF6
-        run: df -h
 
       - name: Install additional PIP packages (Post PennyLane Install)
         shell: bash
@@ -159,9 +142,6 @@ jobs:
             fi
           done <<< "$ADDITIONAL_PIP_PACKAGES"
 
-      - name: DF7
-        run: df -h
-
       - name: Set PyTest Args
         id: pytest_args
         env:
@@ -172,9 +152,6 @@ jobs:
         run: |
           echo "args=$PYTEST_COVERAGE_ARGS $PYTEST_PARALLELISE_ARGS $PYTEST_ADDITIONAL_ARGS $PYTEST_DURATIONS_ARGS" >> $GITHUB_OUTPUT
 
-      - name: DF8
-        run: df -h
-
       - name: Run PennyLane Unit Tests
         env:
           PYTEST_MARKER: ${{ inputs.pytest_markers != '' && format('-m "{0}"', inputs.pytest_markers) || '' }}
@@ -183,16 +160,10 @@ jobs:
         # Calling PyTest by invoking Python first as that adds the current directory to sys.path
         run: python -m pytest ${{ inputs.pytest_test_directory }} ${{ steps.pytest_args.outputs.args }} ${{ env.PYTEST_MARKER }}
 
-      - name: DF9
-        run: df -h
-
       - name: Freeze dependencies
         shell: bash
         if: inputs.requirements_file != ''
         run: pip freeze | grep -v "file:///" | sed 's/\(pennylane[-_]lightning==[0-9\.]\+\)\.dev[0-9]\+/\1/gI' > ${{ inputs.requirements_file }}
-  
-      - name: DF10
-        run: df -h
 
       - name: Upload frozen requirements
         if: inputs.requirements_file != ''
@@ -200,9 +171,6 @@ jobs:
         with:
           name: frozen-${{ inputs.requirements_file }}
           path: ${{ inputs.requirements_file }}
-
-      - name: DF11
-        run: df -h
 
       - name: Upload Durations file as artifact
         if: inputs.pytest_durations_file_path != ''
@@ -212,14 +180,8 @@ jobs:
           path: ${{ inputs.pytest_durations_file_path }}
           include-hidden-files: true
 
-      - name: DF12
-        run: df -h
-
       - name: Adjust coverage file for Codecov
         run: bash <(sed -i 's/filename=\"/filename=\"pennylane\//g' coverage.xml)
-
-      - name: DF13
-        run: df -h
 
       - name: Upload Coverage File
         uses: actions/upload-artifact@v4

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -84,18 +84,26 @@ jobs:
     runs-on: ${{ inputs.job_runner_name }}
 
     steps:
+      - name: DF 1
+        run: df -h
       - name: Checkout
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.branch }}
           fetch-depth: ${{ inputs.checkout_fetch_depth }}
           repository: PennyLaneAI/pennylane
-      
+
+      - name: DF2
+        run: df -h
+
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
           python-version: '${{ inputs.python_version }}'
-      
+
+      - name: DF3
+        run: df -h
+
       - name: Upgrade PIP and install wheel
         run: pip install --upgrade pip && pip install wheel --upgrade
       
@@ -103,7 +111,10 @@ jobs:
         run: |
           pip install -r requirements-ci.txt --upgrade
           pip install -r requirements-dev.txt --upgrade
-      
+
+      - name: DF4
+        run: df -h
+
       - name: Install additional PIP packages (Pre-PennyLane)
         shell: bash
         if: inputs.additional_pip_packages != ''
@@ -119,13 +130,19 @@ jobs:
                 pip install $line
             fi
           done <<< "$ADDITIONAL_PIP_PACKAGES"
-      
+
+      - name: DF5
+        run: df -h
+
       - name: Install PennyLane
         shell: bash
         run: |
           python setup.py bdist_wheel
           pip install dist/PennyLane*.whl
-      
+
+      - name: DF6
+        run: df -h
+
       - name: Install additional PIP packages (Post PennyLane Install)
         shell: bash
         if: inputs.additional_pip_packages_post != ''
@@ -142,6 +159,9 @@ jobs:
             fi
           done <<< "$ADDITIONAL_PIP_PACKAGES"
 
+      - name: DF7
+        run: df -h
+
       - name: Set PyTest Args
         id: pytest_args
         env:
@@ -152,6 +172,9 @@ jobs:
         run: |
           echo "args=$PYTEST_COVERAGE_ARGS $PYTEST_PARALLELISE_ARGS $PYTEST_ADDITIONAL_ARGS $PYTEST_DURATIONS_ARGS" >> $GITHUB_OUTPUT
 
+      - name: DF8
+        run: df -h
+
       - name: Run PennyLane Unit Tests
         env:
           PYTEST_MARKER: ${{ inputs.pytest_markers != '' && format('-m "{0}"', inputs.pytest_markers) || '' }}
@@ -159,18 +182,27 @@ jobs:
           TF_USE_LEGACY_KERAS: "1"  # sets to use tf-keras (Keras2) instead of keras (Keras3) when running TF tests
         # Calling PyTest by invoking Python first as that adds the current directory to sys.path
         run: python -m pytest ${{ inputs.pytest_test_directory }} ${{ steps.pytest_args.outputs.args }} ${{ env.PYTEST_MARKER }}
-      
+
+      - name: DF9
+        run: df -h
+
       - name: Freeze dependencies
         shell: bash
         if: inputs.requirements_file != ''
         run: pip freeze | grep -v "file:///" | sed 's/\(pennylane[-_]lightning==[0-9\.]\+\)\.dev[0-9]\+/\1/gI' > ${{ inputs.requirements_file }}
   
+      - name: DF10
+        run: df -h
+
       - name: Upload frozen requirements
         if: inputs.requirements_file != ''
         uses: actions/upload-artifact@v4
         with:
           name: frozen-${{ inputs.requirements_file }}
           path: ${{ inputs.requirements_file }}
+
+      - name: DF11
+        run: df -h
 
       - name: Upload Durations file as artifact
         if: inputs.pytest_durations_file_path != ''
@@ -180,8 +212,14 @@ jobs:
           path: ${{ inputs.pytest_durations_file_path }}
           include-hidden-files: true
 
+      - name: DF12
+        run: df -h
+
       - name: Adjust coverage file for Codecov
         run: bash <(sed -i 's/filename=\"/filename=\"pennylane\//g' coverage.xml)
+
+      - name: DF13
+        run: df -h
 
       - name: Upload Coverage File
         uses: actions/upload-artifact@v4

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -25,9 +25,7 @@ tensorflow==2.11.1; platform_machine == "x86_64"
 tensorflow_macos==2.9.0; sys_platform == "darwin" and platform_machine == "arm64"
 tensornetwork==0.3
 toml
-torch==2.3.0; sys_platform != "darwin" and python_version == "3.10"
-torch==1.13.1; sys_platform != "darwin" and python_version == "3.10"
-torch==1.13.1; sys_platform == "darwin" and python_version == "3.10"
+torch==2.3.0
 jinja2==3.0.3
 rustworkx>=0.14.0
 networkx==2.6

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,3 @@
---find-links https://download.pytorch.org/whl/torch_stable.html
 pip
 appdirs
 autograd
@@ -26,8 +25,7 @@ tensorflow==2.11.1; platform_machine == "x86_64"
 tensorflow_macos==2.9.0; sys_platform == "darwin" and platform_machine == "arm64"
 tensornetwork==0.3
 toml
-torch==1.9.0+cpu; sys_platform != "darwin" and python_version < "3.10"
-torch==1.9.0; sys_platform == "darwin" and python_version < "3.10"
+torch==2.3.0; sys_platform != "darwin" and python_version == "3.10"
 torch==1.13.1; sys_platform != "darwin" and python_version == "3.10"
 torch==1.13.1; sys_platform == "darwin" and python_version == "3.10"
 jinja2==3.0.3

--- a/pennylane/workflow/__init__.py
+++ b/pennylane/workflow/__init__.py
@@ -29,19 +29,6 @@ Execution functions and utilities
     ~workflow.get_transform_program
     ~workflow.get_best_diff_method
 
-Supported interfaces
-~~~~~~~~~~~~~~~~~~~~
-
-.. autosummary::
-    :toctree: api
-
-    ~workflow.interfaces.autograd
-    ~workflow.interfaces.jax
-    ~workflow.interfaces.jax_jit
-    ~workflow.interfaces.tensorflow
-    ~workflow.interfaces.tensorflow_autograph
-    ~workflow.interfaces.torch
-
 Jacobian Product Calculation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      test directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `doc/releases/changelog-dev.md` file, summarizing the
      change, and including a link back to the PR.

- [ ] The PennyLane source code conforms to
      [PEP8 standards](https://www.python.org/dev/peps/pep-0008/).
      We check all of our code against [Pylint](https://www.pylint.org/).
      To lint modified files, simply `pip install pylint`, and then
      run `pylint pennylane/path/to/file.py`.

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:** The existing CI infra uses Torch wheels pulled directly from the PyTorch hosted builds. This has defaulted to pulling in the ROCm build of the wheels, which are 2GB to download, and 12+GB when installed and unpacked. As Github action only provide 14GB guaranteed storage for runners, this immediately eats into the available storage and often causes out of space failures.

**Description of the Change:** This changes the Torch wheel installs to the default ones from PyPI. The default wheels still pull in a large number of external deps (several GB, including Nvidia runtime libs), but as of now allows us to remain below the 14GB threshold.

**Benefits:** Prevent out of space errors in the CI.

**Possible Drawbacks:**

**Related GitHub Issues:**
