### PR TITLE
Fix code coverage issue due to `shadow_expval` removal

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -55,6 +55,7 @@
 * The `qml.shadows.shadow_expval` transform has been removed. Instead, please use the
   `qml.shadow_expval` measurement process.
   [(#6530)](https://github.com/PennyLaneAI/pennylane/pull/6530)
+  [(#6561)](https://github.com/PennyLaneAI/pennylane/pull/6561)
 
 <h3>Deprecations 👋</h3>
 

--- a/pennylane/shadows/transforms.py
+++ b/pennylane/shadows/transforms.py
@@ -21,7 +21,6 @@ import numpy as np
 
 import pennylane as qml
 from pennylane import transform
-from pennylane.measurements import ClassicalShadowMP
 from pennylane.tape import QuantumScript, QuantumScriptBatch
 from pennylane.typing import PostprocessingFn
 
@@ -33,13 +32,6 @@ def _replace_obs(
     """
     Tape transform to replace the measurement processes with the given one
     """
-    # check if the measurement process of the tape is qml.classical_shadow
-    for m in tape.measurements:
-        if not isinstance(m, ClassicalShadowMP):
-            raise ValueError(
-                f"Tape measurement must be ClassicalShadowMP, got {m.__class__.__name__!r}"
-            )
-
     with qml.queuing.AnnotatedQueue() as q:
         # queue everything from the old tape except the measurement processes
         for op in tape.operations:


### PR DESCRIPTION
**Context:**

Follow up PR addressing the `-0.01%` project code coverage issue that slipped through the cracks in #6530.

**Description of the Change:**

Removed the relevant check because it was being exclusively tested by a removed unit test (associated with `qml.shadows.shadow_expval`),

Here's the old test that was removed which was testing that logic branch:
```python
...
    def test_non_shadow_error(self):
        """Test that an exception is raised when the decorated QNode does not
        return shadows"""
        dev = qml.device("default.qubit", wires=1, shots=100)

        @partial(qml.shadows.shadow_expval, H=qml.PauliZ(0))
        @qml.qnode(dev)
        def circuit():
            qml.Hadamard(0)
            return qml.expval(qml.PauliZ(0))

        msg = "Tape measurement must be ClassicalShadowMP, got 'ExpectationMP'"
        with pytest.raises(ValueError, match=msg):
            circuit()
...
```

**Benefits:** Better code coverage.

**Possible Drawbacks:** None.

[sc-77485]
