### PR TITLE
pauli string reps added (#6243) and bug fixed in pauli arithmetic

### DIFF
--- a/pennylane/ops/qubit/non_parametric_ops.py
+++ b/pennylane/ops/qubit/non_parametric_ops.py
@@ -77,6 +77,21 @@ class Hadamard(Observable, Operation):
     def name(self) -> str:
         return "Hadamard"
 
+    @property
+    def pauli_rep(self):
+        if self._pauli_rep_cached is None:
+            self._pauli_rep_cached = qml.pauli.PauliSentence(
+                {
+                    qml.pauli.PauliWord({self.wires[0]: "X"}): INV_SQRT2,
+                    qml.pauli.PauliWord({self.wires[0]: "Z"}): INV_SQRT2,
+                }
+            )
+        return self._pauli_rep_cached
+
+    def __init__(self, wires: WiresLike, id: Optional[str] = None):
+        super().__init__(wires=wires, id=id)
+        self._pauli_rep_cached = None
+
     @staticmethod
     @lru_cache()
     def compute_matrix() -> np.ndarray:  # pylint: disable=arguments-differ
@@ -242,9 +257,17 @@ class PauliX(Observable, Operation):
 
     _queue_category = "_ops"
 
+    @property
+    def pauli_rep(self):
+        if self._pauli_rep_cached is None:
+            self._pauli_rep_cached = qml.pauli.PauliSentence(
+                {qml.pauli.PauliWord({self.wires[0]: "X"}): 1.0}
+            )
+        return self._pauli_rep_cached
+
     def __init__(self, wires: Optional[WiresLike] = None, id: Optional[str] = None):
         super().__init__(wires=wires, id=id)
-        self._pauli_rep = qml.pauli.PauliSentence({qml.pauli.PauliWord({self.wires[0]: "X"}): 1.0})
+        self._pauli_rep_cached = None
 
     def label(
         self,
@@ -434,9 +457,17 @@ class PauliY(Observable, Operation):
 
     _queue_category = "_ops"
 
+    @property
+    def pauli_rep(self):
+        if self._pauli_rep_cached is None:
+            self._pauli_rep_cached = qml.pauli.PauliSentence(
+                {qml.pauli.PauliWord({self.wires[0]: "Y"}): 1.0}
+            )
+        return self._pauli_rep_cached
+
     def __init__(self, wires: WiresLike, id: Optional[str] = None):
         super().__init__(wires=wires, id=id)
-        self._pauli_rep = qml.pauli.PauliSentence({qml.pauli.PauliWord({self.wires[0]: "Y"}): 1.0})
+        self._pauli_rep_cached = None
 
     def __repr__(self) -> str:
         """String representation."""
@@ -623,9 +654,17 @@ class PauliZ(Observable, Operation):
 
     _queue_category = "_ops"
 
+    @property
+    def pauli_rep(self):
+        if self._pauli_rep_cached is None:
+            self._pauli_rep_cached = qml.pauli.PauliSentence(
+                {qml.pauli.PauliWord({self.wires[0]: "Z"}): 1.0}
+            )
+        return self._pauli_rep_cached
+
     def __init__(self, wires: WiresLike, id: Optional[str] = None):
         super().__init__(wires=wires, id=id)
-        self._pauli_rep = qml.pauli.PauliSentence({qml.pauli.PauliWord({self.wires[0]: "Z"}): 1.0})
+        self._pauli_rep_cached = None
 
     def __repr__(self) -> str:
         """String representation."""
@@ -815,6 +854,21 @@ class S(Operation):
 
     batch_size = None
 
+    @property
+    def pauli_rep(self):
+        if self._pauli_rep_cached is None:
+            self._pauli_rep_cached = qml.pauli.PauliSentence(
+                {
+                    qml.pauli.PauliWord({self.wires[0]: "I"}): 0.5 + 0.5j,
+                    qml.pauli.PauliWord({self.wires[0]: "Z"}): 0.5 - 0.5j,
+                }
+            )
+        return self._pauli_rep_cached
+
+    def __init__(self, wires: WiresLike, id: Optional[str] = None):
+        super().__init__(wires=wires, id=id)
+        self._pauli_rep_cached = None
+
     @staticmethod
     @lru_cache()
     def compute_matrix() -> np.ndarray:  # pylint: disable=arguments-differ
@@ -927,6 +981,21 @@ class T(Operation):
 
     batch_size = None
 
+    @property
+    def pauli_rep(self):
+        if self._pauli_rep_cached is None:
+            self._pauli_rep_cached = qml.pauli.PauliSentence(
+                {
+                    qml.pauli.PauliWord({self.wires[0]: "I"}): (0.5 + 0.5 * INV_SQRT2 * (1 + 1.0j)),
+                    qml.pauli.PauliWord({self.wires[0]: "Z"}): (0.5 - 0.5 * INV_SQRT2 * (1 + 1.0j)),
+                }
+            )
+        return self._pauli_rep_cached
+
+    def __init__(self, wires: WiresLike, id: Optional[str] = None):
+        super().__init__(wires=wires, id=id)
+        self._pauli_rep_cached = None
+
     @staticmethod
     @lru_cache()
     def compute_matrix() -> np.ndarray:  # pylint: disable=arguments-differ
@@ -1036,6 +1105,21 @@ class SX(Operation):
     """int: Number of trainable parameters that the operator depends on."""
 
     basis = "X"
+
+    @property
+    def pauli_rep(self):
+        if self._pauli_rep_cached is None:
+            self._pauli_rep_cached = qml.pauli.PauliSentence(
+                {
+                    qml.pauli.PauliWord({self.wires[0]: "I"}): (0.5 + 0.5j),
+                    qml.pauli.PauliWord({self.wires[0]: "X"}): (0.5 - 0.5j),
+                }
+            )
+        return self._pauli_rep_cached
+
+    def __init__(self, wires: WiresLike, id: Optional[str] = None):
+        super().__init__(wires=wires, id=id)
+        self._pauli_rep_cached = None
 
     @staticmethod
     @lru_cache()
@@ -1152,6 +1236,23 @@ class SWAP(Operation):
 
     batch_size = None
 
+    @property
+    def pauli_rep(self):
+        if self._pauli_rep_cached is None:
+            self._pauli_rep_cached = qml.pauli.PauliSentence(
+                {
+                    qml.pauli.PauliWord({self.wires[0]: "I", self.wires[1]: "I"}): 0.5,
+                    qml.pauli.PauliWord({self.wires[0]: "X", self.wires[1]: "X"}): 0.5,
+                    qml.pauli.PauliWord({self.wires[0]: "Y", self.wires[1]: "Y"}): 0.5,
+                    qml.pauli.PauliWord({self.wires[0]: "Z", self.wires[1]: "Z"}): 0.5,
+                }
+            )
+        return self._pauli_rep_cached
+
+    def __init__(self, wires: WiresLike, id: Optional[str] = None):
+        super().__init__(wires=wires, id=id)
+        self._pauli_rep_cached = None
+
     @staticmethod
     @lru_cache()
     def compute_matrix() -> np.ndarray:  # pylint: disable=arguments-differ
@@ -1242,6 +1343,21 @@ class ECR(Operation):
     num_params = 0
 
     batch_size = None
+
+    @property
+    def pauli_rep(self):
+        if self._pauli_rep_cached is None:
+            self._pauli_rep_cached = qml.pauli.PauliSentence(
+                {
+                    qml.pauli.PauliWord({self.wires[0]: "X", self.wires[1]: "I"}): INV_SQRT2,
+                    qml.pauli.PauliWord({self.wires[0]: "Y", self.wires[1]: "X"}): -INV_SQRT2,
+                }
+            )
+        return self._pauli_rep_cached
+
+    def __init__(self, wires: WiresLike, id: Optional[str] = None):
+        super().__init__(wires=wires, id=id)
+        self._pauli_rep_cached = None
 
     @staticmethod
     def compute_matrix() -> np.ndarray:  # pylint: disable=arguments-differ
@@ -1371,6 +1487,23 @@ class ISWAP(Operation):
 
     batch_size = None
 
+    @property
+    def pauli_rep(self):
+        if self._pauli_rep_cached is None:
+            self._pauli_rep_cached = qml.pauli.PauliSentence(
+                {
+                    qml.pauli.PauliWord({self.wires[0]: "I", self.wires[1]: "I"}): 0.5,
+                    qml.pauli.PauliWord({self.wires[0]: "X", self.wires[1]: "X"}): 0.5j,
+                    qml.pauli.PauliWord({self.wires[0]: "Y", self.wires[1]: "Y"}): 0.5j,
+                    qml.pauli.PauliWord({self.wires[0]: "Z", self.wires[1]: "Z"}): 0.5,
+                }
+            )
+        return self._pauli_rep_cached
+
+    def __init__(self, wires: WiresLike, id: Optional[str] = None):
+        super().__init__(wires=wires, id=id)
+        self._pauli_rep_cached = None
+
     @staticmethod
     @lru_cache()
     def compute_matrix() -> np.ndarray:  # pylint: disable=arguments-differ
@@ -1487,6 +1620,25 @@ class SISWAP(Operation):
     """int: Number of trainable parameters that the operator depends on."""
 
     batch_size = None
+
+    @property
+    def pauli_rep(self):
+        if self._pauli_rep_cached is None:
+            self._pauli_rep_cached = qml.pauli.PauliSentence(
+                {
+                    qml.pauli.PauliWord({self.wires[0]: "I", self.wires[1]: "I"}): 0.5
+                    + 0.5 * INV_SQRT2,
+                    qml.pauli.PauliWord({self.wires[0]: "X", self.wires[1]: "X"}): 0.5j * INV_SQRT2,
+                    qml.pauli.PauliWord({self.wires[0]: "Y", self.wires[1]: "Y"}): 0.5j * INV_SQRT2,
+                    qml.pauli.PauliWord({self.wires[0]: "Z", self.wires[1]: "Z"}): 0.5
+                    - 0.5 * INV_SQRT2,
+                }
+            )
+        return self._pauli_rep_cached
+
+    def __init__(self, wires: WiresLike, id: Optional[str] = None):
+        super().__init__(wires=wires, id=id)
+        self._pauli_rep_cached = None
 
     @staticmethod
     @lru_cache()

--- a/pennylane/pauli/pauli_arithmetic.py
+++ b/pennylane/pauli/pauli_arithmetic.py
@@ -983,16 +983,21 @@ class PauliSentence(dict):
         ml_interface = qml.math.get_interface(coeff)
         if ml_interface == "torch":
             data0 = qml.math.convert_like(data0, coeff)
-        data = coeff * data0
+        data = coeff * data0 if np.isscalar(coeff) else np.outer(coeff, data0)
+
         for pw in pauli_words[1:]:
             coeff = self[pw]
             csr_data = pw._get_csr_data(wire_order, 1)
             ml_interface = qml.math.get_interface(coeff)
             if ml_interface == "torch":
                 csr_data = qml.math.convert_like(csr_data, coeff)
-            data += self[pw] * csr_data
+            data += coeff * csr_data if np.isscalar(coeff) else np.outer(self[pw], csr_data)
 
-        return qml.math.einsum("ij,i->ij", base_matrix, data)
+        return (
+            qml.math.einsum("ij,i->ij", base_matrix, data)
+            if np.isscalar(coeff)
+            else qml.math.einsum("ij,ki->kij", base_matrix, data)
+        )
 
     def _sum_same_structure_pws(self, pauli_words, wire_order):
         """Sums Pauli words with the same sparse structure."""


### PR DESCRIPTION
**Context:**
Prior to this commit, PennyLane only allowed access to Pauli string representations for the X, Z and Z gate via `X(0).pauli_rep`, etc. The Pauli representations of other gates were not implemented.

**Description of the Change:**
I added the Pauli string representations for X, Y, Z, H, S, T, SX, SWAP, ISWAP, ECR, SISWAP, RX, RY, RZ, Rot, PhaseShift, U1, U2 and U3. 

The correctness of each Pauli string representation is checked by converting the returned Pauli string into a matrix and comparing it with the respective `.matrix()` method.

The test `test_parametric_ops:TestDecompositions:test_pc_phase_decomposition_broadcasted` (Testing `qml.PCPhase([1.23, 4.56, 7.89], dim=5, wires=[0, 1, 2])`) returned a dimension error. I resolved this by adding an outer product in pauli_arithmetic for tensor-like coefficients (specifically tensor-like phi).

**Benefits:**

Pennylane now supports Pauli string decompositions for various operators. Pauli string decompositions of products of operators with available Pauli string decompositions can now be directly accessed. `Example: (Hadamard(0) @ S(1) @ T(1, 2) @ SX(1) @ SWAP([0, 1])).pauli_rep`

**Possible Drawbacks:**
Classes for parametrized gates may be slightly heavier, as the phase parameter has to be stored. However, the Pauli representation itself is only computed when needed.

**Related GitHub Issues:**
#6243
