### PR TITLE
Bosonic mapping

### DIFF
--- a/pennylane/labs/tests/vibrational_ham/test_bosonic_mapping.py
+++ b/pennylane/labs/tests/vibrational_ham/test_bosonic_mapping.py
@@ -1,0 +1,96 @@
+import pytest
+
+import pennylane as qml
+from pennylane.labs.vibrational_ham import BoseWord, BoseSentence, binary_mapping
+from pennylane.pauli import PauliSentence, PauliWord
+from pennylane import I, X, Y, Z
+from pennylane.pauli.conversion import pauli_sentence
+
+# Expected results were generated manually
+BOSE_WORDS_AND_OPS = [
+    (
+        BoseWord({(0, 0): "+"}),
+        # trivial case of a creation operator with 2 states in a boson, 0^ -> (X_0 - iY_0) / 2
+        2,
+        ([0.5, -0.5j], [X(0), Y(0)]),
+    ),
+    (
+        BoseWord({(0, 0): "-"}),
+        # trivial case of an annihilation operator with 2 states in a boson, 0 -> (X_0 + iY_0) / 2
+        2,
+        ([(0.5 + 0j), (0.0 + 0.5j)], [X(0), Y(0)]),
+    ),
+    (
+        BoseWord({(0, 0): "+"}),
+        # creation operator with 4 states in a boson
+        4,
+        (
+            [
+                0.6830127018922193,
+                0.3535533905932738,
+                -0.3535533905932738j,
+                -0.1830127018922193,
+                -0.6830127018922193j,
+                0.3535533905932738j,
+                (0.3535533905932738 + 0j),
+                0.1830127018922193j,
+            ],
+            [
+                X(0),
+                X(0) @ X(1),
+                X(0) @ Y(1),
+                X(0) @ Z(1),
+                Y(0),
+                Y(0) @ X(1),
+                Y(0) @ Y(1),
+                Y(0) @ Z(1),
+            ],
+        ),
+    ),
+    (
+        BoseWord({(0, 0): "-"}),
+        # annihilation operator with 4 states in a boson
+        4,
+        (
+            [
+                0.6830127018922193,
+                0.3535533905932738,
+                0.3535533905932738j,
+                -0.1830127018922193,
+                0.6830127018922193j,
+                -0.3535533905932738j,
+                (0.3535533905932738 + 0j),
+                -0.1830127018922193j,
+            ],
+            [
+                X(0),
+                X(0) @ X(1),
+                X(0) @ Y(1),
+                X(0) @ Z(1),
+                Y(0),
+                Y(0) @ X(1),
+                Y(0) @ Y(1),
+                Y(0) @ Z(1),
+            ],
+        ),
+    ),
+    (
+        BoseWord({(0, 0): "+", (1, 0): "-"}),
+        4,
+        ([(1.5 + 0j), (-0.4999999999999999 + 0j), (-0.9999999999999999 + 0j)], [I(0), Z(0), Z(1)]),
+    ),
+]
+
+
+@pytest.mark.parametrize("bose_op, d, result", BOSE_WORDS_AND_OPS)
+def test_binary_mapping_boseword(bose_op, d, result):
+    """Test that the binary_mapping function returns the correct qubit operator."""
+    # convert BoseWord to PauliSentence and simplify
+    qubit_op = binary_mapping(bose_op, d=d)
+    qubit_op.simplify(tol=1e-8)
+
+    # get expected op as PauliSentence and simplify
+    expected_op = pauli_sentence(qml.Hamiltonian(result[0], result[1]))
+    expected_op.simplify(tol=1e-8)
+    print(qubit_op)
+    assert qubit_op == expected_op

--- a/pennylane/labs/vibrational_ham/__init__.py
+++ b/pennylane/labs/vibrational_ham/__init__.py
@@ -3,3 +3,4 @@ This submodule provides the functionality to calculate vibrational Hamiltonians.
 """
 
 from .bosonic import BoseWord, BoseSentence
+from .bosonic_mapping import binary_mapping

--- a/pennylane/labs/vibrational_ham/bosonic_mapping.py
+++ b/pennylane/labs/vibrational_ham/bosonic_mapping.py
@@ -1,0 +1,151 @@
+# Copyright 2024 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""This module contains functions to map bosonic operators to qubit operators."""
+
+from functools import singledispatch
+from typing import Union
+
+import numpy as np
+import pennylane as qml
+from pennylane.operation import Operator
+from pennylane.pauli import PauliSentence, PauliWord
+
+from .bosonic import BoseSentence, BoseWord
+
+
+def _get_pauli_op(i, j, qub_id):
+    r"""Returns expression to convert qubit-local term ::math::``\ket{x_j}\bra{x^{'}}``
+    to qubit operators as given in Eq. (6-9) <https://www.nature.com/articles/s41534-020-0278-0>"""
+
+    if i == 0 and j == 0:
+        return PauliSentence({PauliWord({}): 0.5, PauliWord({qub_id: "Z"}): 0.5})
+    if i == 0 and j == 1:
+        return PauliSentence({PauliWord({qub_id: "X"}): 0.5, PauliWord({qub_id: "Y"}): 0.5j})
+    if i == 1 and j == 0:
+        return PauliSentence({PauliWord({qub_id: "X"}): 0.5, PauliWord({qub_id: "Y"}): -0.5j})
+
+    return PauliSentence({PauliWord({}): 0.5, PauliWord({qub_id: "Z"}): -0.5})
+
+
+def binary_mapping(
+    bose_operator: Union[BoseWord, BoseSentence],
+    d: int = 2,
+    ps: bool = True,
+    wire_map: dict = None,
+    tol: float = None,
+):
+    r"""Convert a bosonic operator to a qubit operator using the standard-binary mapping
+    as described in <https://www.nature.com/articles/s41534-020-0278-0>
+    Args:
+      bose_operator(BoseWord, BoseSentence): the bosonic operator
+      d(int): Number of states in the boson.
+      ps (bool): whether to return the result as a PauliSentence instead of an operator. Defaults to False.
+      wire_map (dict): a dictionary defining how to map the orbitals of
+      the Fermi operator to qubit wires. If None, the integers used to
+      order the orbitals will be used as wire labels. Defaults to None.
+      tol (float): tolerance for discarding the imaginary part of the coefficients
+
+    Returns:
+      a linear combination of qubit operators
+
+    **Example**
+
+    >>> w = qml.vibrational_ham.BoseWord()
+    >>> binary_mapping(w, d=2)
+
+    """
+
+    return _binary_mapping_dispatch(bose_operator, d, ps, wire_map, tol)
+
+
+@singledispatch
+def _binary_mapping_dispatch(bose_operator, d, ps=False, wires_map=None, tol=None):
+    """Dispatches to appropriate function if bose_operator is a BoseWord or BoseSentence."""
+    raise ValueError(f"bose_operator must be a BoseWord or BoseSentence, got: {bose_operator}")
+
+
+@_binary_mapping_dispatch.register
+def _(bose_operator: BoseWord, d, ps=False, wire_map=None, tol=None):
+    nqub_per_boson = int(np.ceil(np.log2(d)))
+
+    cr = np.zeros((d, d))
+    for s in range(d - 1):
+        cr[s + 1, s] = np.sqrt(s + 1.0)
+
+    d_mat = {"+": cr, "-": cr.T}
+
+    if len(bose_operator) == 0:
+        qubit_operator = PauliSentence({PauliWord({}): 1.0})
+
+    else:
+        qubit_operator = PauliSentence({PauliWord({}): 1.0})
+        for item in bose_operator.items():
+            (_, boson), sign = item
+            oper = PauliSentence()
+            for i in range(d):
+                for j in range(d):
+                    coeff = d_mat[sign][i][j]
+                    if coeff != 0:
+
+                        # Least significant bit is written leftmost
+                        binary_row = list(map(int, bin(i)[2:]))[::-1]
+
+                        if nqub_per_boson > len(binary_row):
+                            binary_row += [0] * (nqub_per_boson - len(binary_row))
+
+                        # Least significant bit is written leftmost
+                        binary_col = list(map(int, bin(j)[2:]))[::-1]
+                        if nqub_per_boson > len(binary_col):
+                            binary_col += [0] * (nqub_per_boson - len(binary_col))
+
+                        pauliOp = PauliSentence({PauliWord({}): 1.0})
+                        for n in range(nqub_per_boson):
+                            pauliOp @= _get_pauli_op(
+                                binary_row[n], binary_col[n], n + boson * nqub_per_boson
+                            )
+
+                        oper += coeff * pauliOp
+            qubit_operator @= oper
+    qubit_operator.simplify()
+
+    for pw in qubit_operator:
+        if tol is not None and abs(qml.math.imag(qubit_operator[pw])) <= tol:
+            qubit_operator[pw] = qml.math.real(qubit_operator[pw])
+
+    if wire_map:
+        return qubit_operator.map_wires(wire_map)
+
+    return qubit_operator
+
+
+@_binary_mapping_dispatch.register
+def _(bose_operator: BoseSentence, d, ps=False, wire_map=None, tol=None):
+
+    qubit_operator = PauliSentence()
+
+    for bw, coeff in bose_operator.items():
+        bose_word_as_ps = binary_mapping(bw, d=d)
+
+        for pw in bose_word_as_ps:
+            qubit_operator[pw] = qubit_operator[pw] + bose_word_as_ps[pw] * coeff
+
+            if tol is not None and abs(qml.math.imag(qubit_operator[pw])) <= tol:
+                qubit_operator[pw] = qml.math.real(qubit_operator[pw])
+
+    qubit_operator.simplify(tol=1e-16)
+
+    if wire_map:
+        return qubit_operator.map_wires(wire_map)
+
+    return qubit_operator


### PR DESCRIPTION

**Context:**
Standard-binary mapping for bosonic operators

**Description of the Change:**
Added function for mapping bosonic operators (BoseWord and BoseSentence) to qubit operators.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
