### PR TITLE
Fix consistency of `QNode` results processing

### DIFF
--- a/pennylane/workflow/qnode.py
+++ b/pennylane/workflow/qnode.py
@@ -110,12 +110,10 @@ def _to_qfunc_output_type(
     if has_partitioned_shots:
         return tuple(_to_qfunc_output_type(r, qfunc_output, False) for r in results)
 
-    # Special case of single Measurement in a list
-    if isinstance(qfunc_output, list) and len(qfunc_output) == 1:
+    if isinstance(qfunc_output, Sequence) and len(qfunc_output) == 1:
         results = [results]
 
-    # If the return type is not tuple (list or ndarray) (Autograd and TF backprop removed)
-    if isinstance(qfunc_output, (tuple, qml.measurements.MeasurementProcess)):
+    if isinstance(qfunc_output, qml.measurements.MeasurementProcess):
         return results
 
     return type(qfunc_output)(results)

--- a/pennylane/workflow/qnode.py
+++ b/pennylane/workflow/qnode.py
@@ -116,6 +116,10 @@ def _to_qfunc_output_type(
     results_leaves, _ = qml.pytrees.flatten(results)
 
     if len(results_leaves) != len(qfunc_output_leaves):
+        if qml.math.get_interface(qfunc_output) == "autograd":
+            if isinstance(qfunc_output, Sequence):
+                results = [results]
+            return type(qfunc_output)(results)
         return results
 
     if isinstance(qfunc_output, Sequence):

--- a/pennylane/workflow/qnode.py
+++ b/pennylane/workflow/qnode.py
@@ -110,7 +110,15 @@ def _to_qfunc_output_type(
     if has_partitioned_shots:
         return tuple(_to_qfunc_output_type(r, qfunc_output, False) for r in results)
 
-    if isinstance(qfunc_output, Sequence) and len(qfunc_output) == 1:
+    qfunc_output_leaves, _ = qml.pytrees.flatten(
+        qfunc_output, is_leaf=lambda obj: isinstance(obj, qml.measurements.MeasurementProcess)
+    )
+    results_leaves, _ = qml.pytrees.flatten(results)
+
+    if len(results_leaves) != len(qfunc_output_leaves):
+        return results
+
+    if isinstance(qfunc_output, Sequence):
         results = [results]
 
     if isinstance(qfunc_output, qml.measurements.MeasurementProcess):

--- a/tests/measurements/test_counts.py
+++ b/tests/measurements/test_counts.py
@@ -482,7 +482,7 @@ class TestCountsIntegration:
                 qml.counts(qml.PauliZ(2)),
             )
 
-        result = circuit()
+        result = circuit()[0]
 
         # If all the dimensions are equal the result will end up to be a proper rectangular array
         assert isinstance(result, tuple)
@@ -696,21 +696,21 @@ class TestCountsIntegration:
             return qml.counts(wires=0), qml.apply(meas2)
 
         res = circuit()
-        assert isinstance(res, tuple)
+        assert isinstance(res[0], tuple)
 
         num_shot_bins = 1 if isinstance(shots, int) else len(shots)
 
         if num_shot_bins == 1:
             counts_term_indices = [i * 2 for i in range(num_shot_bins)]
             for ind in counts_term_indices:
-                assert isinstance(res[ind], dict)
+                assert isinstance(res[0][ind], dict)
         else:
             assert len(res) == 2
 
             assert isinstance(res[0], tuple)
-            assert isinstance(res[0][0], dict)
+            assert isinstance(res[0][0][0], dict)
             assert isinstance(res[1], tuple)
-            assert isinstance(res[1][0], dict)
+            assert isinstance(res[1][0][0], dict)
 
     def test_all_outcomes_kwarg_providing_observable(self):
         """Test that the dictionary keys *all* eigenvalues of the observable,

--- a/tests/test_qnode.py
+++ b/tests/test_qnode.py
@@ -119,6 +119,16 @@ class TestInitialization:
 class TestValidation:
     """Tests for QNode creation and validation"""
 
+    @pytest.mark.parametrize("return_type", (tuple, list))
+    def test_return_behaviour_consistency(self, return_type):
+        """Test that the QNode return typing stays consistent"""
+
+        @qml.qnode(qml.device("default.qubit"))
+        def circuit(return_type):
+            return return_type([qml.expval(qml.Z(0))])
+
+        assert isinstance(circuit(return_type), return_type)
+
     def test_expansion_strategy_error(self):
         """Test that an error is raised if expansion_strategy is passed to the qnode."""
 


### PR DESCRIPTION
**Context:**

The output of QNode execution was not consistent based on the type of the qfunc output,
```python
@qml.qnode(qml.device('default.qubit'))
def circuit(t):
    return t([qml.expval(qml.Z(0))])
>>> circuit(tuple)
1.0
>>> circuit(list)
[1.0]
```

**Description of the Change:**

Update how the results of the execution get type converted based on the qfunc output type.

After this fix we get consistency,
```python
@qml.qnode(qml.device('default.qubit'))
def circuit(t):
    return t([qml.expval(qml.Z(0))])
>>> circuit(tuple)
(1.0,)
>>> circuit(list)
[1.0]
```

**Benefits:** Consistency

**Possible Drawbacks:** Output of QNode execution may look different than people are used to.

[sc-77682]
