### PR TITLE
fix Resources.__str__ to match attribute names

### DIFF
--- a/pennylane/resource/resource.py
+++ b/pennylane/resource/resource.py
@@ -64,7 +64,7 @@ class Resources:
     shots: Shots = field(default_factory=Shots)
 
     def __str__(self):
-        keys = ["wires", "gates", "depth"]
+        keys = ["num_wires", "num_gates", "depth"]
         vals = [self.num_wires, self.num_gates, self.depth]
         items = "\n".join([str(i) for i in zip(keys, vals)])
         items = items.replace("('", "")

--- a/tests/resource/test_resource.py
+++ b/tests/resource/test_resource.py
@@ -14,6 +14,7 @@
 """
 Test base Resource class and its associated methods
 """
+# pylint: disable=unnecessary-dunder-call
 from collections import defaultdict
 from dataclasses import FrozenInstanceError
 
@@ -80,8 +81,8 @@ class TestResources:
 
     test_str_data = (
         (
-            "wires: 0\n"
-            + "gates: 0\n"
+            "num_wires: 0\n"
+            + "num_gates: 0\n"
             + "depth: 0\n"
             + "shots: Shots(total=None)\n"
             + "gate_types:\n"
@@ -90,8 +91,8 @@ class TestResources:
             + "{}"
         ),
         (
-            "wires: 5\n"
-            + "gates: 0\n"
+            "num_wires: 5\n"
+            + "num_gates: 0\n"
             + "depth: 0\n"
             + "shots: Shots(total=None)\n"
             + "gate_types:\n"
@@ -100,8 +101,8 @@ class TestResources:
             + "{}"
         ),
         (
-            "wires: 1\n"
-            + "gates: 3\n"
+            "num_wires: 1\n"
+            + "num_gates: 3\n"
             + "depth: 3\n"
             + "shots: Shots(total=110, vector=[10 shots, 50 shots x 2])\n"
             + "gate_types:\n"
@@ -110,8 +111,8 @@ class TestResources:
             + "{1: 3}"
         ),
         (
-            "wires: 4\n"
-            + "gates: 2\n"
+            "num_wires: 4\n"
+            + "num_gates: 2\n"
             + "depth: 2\n"
             + "shots: Shots(total=100)\n"
             + "gate_types:\n"


### PR DESCRIPTION
Minor thing:
The resources repr and attribute names dont coincide, e.g.
```
>>> U = qml.TrotterProduct(qml.X(0) + qml.Y(0), time=0.5, n=2, order=2)
>>> U.resources()
wires: 1
gates: 8
depth: 8
shots: Shots(total=None)
gate_types:
{'Exp': 8}
gate_sizes:
{1: 8}
```
I would e.g. expect to be able to obtain the number of gates but neither U.resources().gates nor U.resources()["gates"] or getattr(U.resources(), "gates") work - because the attribute is actually called `num_gates`.

This PR just fixes the str representation to match the attribute name.
This is such a minor thing that it was easier and faster to just fix it than open an issue / sc story 😬 