### PR TITLE
Allow accessing datasets uploaded using Tensor/legacy Hamiltonian

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -80,6 +80,7 @@
   Note that `qml.Hamiltonian` will continue to dispatch to `qml.ops.LinearCombination`. For more information, 
   check out the [updated operator troubleshooting page](https://docs.pennylane.ai/en/stable/news/new_opmath.html).
   [(#6548)](https://github.com/PennyLaneAI/pennylane/pull/6548)
+  [(#6602)](https://github.com/PennyLaneAI/pennylane/pull/6602)
 
 * The developer-facing `qml.utils` module has been removed. Specifically, the
 following 4 sets of functions have been either moved or removed[(#6588)](https://github.com/PennyLaneAI/pennylane/pull/6588):

--- a/pennylane/data/attributes/operator/operator.py
+++ b/pennylane/data/attributes/operator/operator.py
@@ -249,7 +249,6 @@ class DatasetOperator(Generic[Op], DatasetAttribute[HDF5Group, Op, Op]):
         with qml.QueuingManager.stop_recording():
             for i, op_class_name in enumerate(op_class_names):
                 op_key = f"op_{i}"
-
                 op_cls = self._supported_ops_dict()[op_class_name]
                 if op_cls is qml.ops.LinearCombination:
                     ops.append(
@@ -283,4 +282,7 @@ class DatasetOperator(Generic[Op], DatasetAttribute[HDF5Group, Op, Op]):
     @lru_cache(1)
     def _supported_ops_dict(cls) -> dict[str, Type[Operator]]:
         """Returns a dict mapping ``Operator`` subclass names to the class."""
-        return {op.__name__: op for op in cls.supported_ops()}
+        ops_dict = {op.__name__: op for op in cls.supported_ops()}
+        ops_dict["Hamiltonian"] = qml.ops.LinearCombination
+        ops_dict["Tensor"] = qml.ops.Prod
+        return ops_dict

--- a/tests/data/attributes/operator/test_operator.py
+++ b/tests/data/attributes/operator/test_operator.py
@@ -243,3 +243,13 @@ def test_value_init_not_supported():
         TypeError, match="Serialization of operator type 'NotSupported' is not supported"
     ):
         DatasetOperator(NotSupported(1))
+
+
+def test_retrieve_operator_from_loaded_data():
+    """Test that uploaded data can be downloaded and used to retrieve an
+    operation representing the Hamiltonian"""
+
+    h2 = qml.data.load("qchem", molname="H2", bondlength=0.742, basis="STO-3G")[0]
+    H = h2.hamiltonian
+
+    assert isinstance(H, qml.ops.LinearCombination)


### PR DESCRIPTION
**Context:**
We were already converting to `Prod` and `LinearCombination` when downloading datasets that were uploaded using legacy opmath, but we were relying on using the `Hamiltonian` and `Tensor` class in the supported ops mapping to recognize them and know how to handle them. 

As a result, when we removed legacy opmath, we removed the context needed to download legacy datasets.

**Description of the Change:**
We add them as keys in the ops dictionary and map them to `LinearCombination` and `Prod`.

**Benefits:**
The datasets will work

[sc-78651][sc-77523]
