### PR TITLE
Create global fixture for toggling capture in program capture tests

### DIFF
--- a/tests/capture/test_base_interpreter.py
+++ b/tests/capture/test_base_interpreter.py
@@ -32,15 +32,7 @@ from pennylane.capture.primitives import (  # pylint: disable=wrong-import-posit
     while_loop_prim,
 )
 
-pytestmark = pytest.mark.jax
-
-
-@pytest.fixture(autouse=True)
-def enable_disable_plxpr():
-    """Enable and disable the PennyLane JAX capture context manager."""
-    qml.capture.enable()
-    yield
-    qml.capture.disable()
+pytestmark = [pytest.mark.jax, pytest.mark.usefixtures("enable_disable_plxpr")]
 
 
 class SimplifyInterpreter(PlxprInterpreter):

--- a/tests/capture/test_capture_cond.py
+++ b/tests/capture/test_capture_cond.py
@@ -15,7 +15,7 @@
 Tests for capturing conditionals into jaxpr.
 """
 
-# pylint: disable=redefined-outer-name, too-many-arguments
+# pylint: disable=redefined-outer-name, too-many-arguments, too-many-positional-arguments
 # pylint: disable=no-self-use
 
 import numpy as np
@@ -24,20 +24,12 @@ import pytest
 import pennylane as qml
 from pennylane.ops.op_math.condition import CondCallable, ConditionalTransformError
 
-pytestmark = pytest.mark.jax
+pytestmark = [pytest.mark.jax, pytest.mark.usefixtures("enable_disable_plxpr")]
 
 jax = pytest.importorskip("jax")
 
 # must be below jax importorskip
 from pennylane.capture.primitives import cond_prim  # pylint: disable=wrong-import-position
-
-
-@pytest.fixture(autouse=True)
-def enable_disable_plxpr():
-    """Enable and disable the PennyLane JAX capture context manager."""
-    qml.capture.enable()
-    yield
-    qml.capture.disable()
 
 
 @pytest.fixture

--- a/tests/capture/test_capture_diff.py
+++ b/tests/capture/test_capture_diff.py
@@ -19,7 +19,7 @@ import pytest
 import pennylane as qml
 from pennylane.capture import qnode_prim
 
-pytestmark = pytest.mark.jax
+pytestmark = [pytest.mark.jax, pytest.mark.usefixtures("enable_disable_plxpr")]
 
 jax = pytest.importorskip("jax")
 
@@ -29,13 +29,6 @@ from pennylane.capture.primitives import (  # pylint: disable=wrong-import-posit
 )
 
 jnp = jax.numpy
-
-
-@pytest.fixture(autouse=True)
-def enable_disable_plxpr():
-    qml.capture.enable()
-    yield
-    qml.capture.disable()
 
 
 class TestExceptions:

--- a/tests/capture/test_capture_for_loop.py
+++ b/tests/capture/test_capture_for_loop.py
@@ -15,30 +15,20 @@
 Tests for capturing for loops into jaxpr.
 """
 
-# pylint: disable=no-value-for-parameter
-# pylint: disable=too-few-public-methods
-# pylint: disable=too-many-arguments
-# pylint: disable=no-self-use
+# pylint: disable=no-value-for-parameter, too-few-public-methods, no-self-use
+# pylint: disable=too-many-positional-arguments, too-many-arguments
 
 import numpy as np
 import pytest
 
 import pennylane as qml
 
-pytestmark = pytest.mark.jax
+pytestmark = [pytest.mark.jax, pytest.mark.usefixtures("enable_disable_plxpr")]
 
 jax = pytest.importorskip("jax")
 
 # must be below jax importorskip
 from pennylane.capture.primitives import for_loop_prim  # pylint: disable=wrong-import-position
-
-
-@pytest.fixture(autouse=True)
-def enable_disable_plxpr():
-    """Enable and disable the PennyLane JAX capture context manager."""
-    qml.capture.enable()
-    yield
-    qml.capture.disable()
 
 
 class TestCaptureForLoop:

--- a/tests/capture/test_capture_mid_measure.py
+++ b/tests/capture/test_capture_mid_measure.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Tests for capturing mid-circuit measurements."""
-# pylint: disable=ungrouped-imports, wrong-import-order, wrong-import-position
+# pylint: disable=ungrouped-imports, wrong-import-order, wrong-import-position, too-many-positional-arguments
 import pytest
 
 import pennylane as qml
@@ -23,14 +23,7 @@ import jax.numpy as jnp
 
 from pennylane.capture.primitives import AbstractOperator
 
-pytestmark = pytest.mark.jax
-
-
-@pytest.fixture(autouse=True)
-def enable_disable_plxpr():
-    qml.capture.enable()
-    yield
-    qml.capture.disable()
+pytestmark = [pytest.mark.jax, pytest.mark.usefixtures("enable_disable_plxpr")]
 
 
 @pytest.mark.unit

--- a/tests/capture/test_capture_module.py
+++ b/tests/capture/test_capture_module.py
@@ -20,15 +20,7 @@ import pennylane as qml
 
 jax = pytest.importorskip("jax")
 
-pytestmark = pytest.mark.jax
-
-
-@pytest.fixture(autouse=True)
-def enable_disable_plxpr():
-    """enable and disable capture around each test."""
-    qml.capture.enable()
-    yield
-    qml.capture.disable()
+pytestmark = [pytest.mark.jax, pytest.mark.usefixtures("enable_disable_plxpr")]
 
 
 def test_no_attribute_available():

--- a/tests/capture/test_capture_qnode.py
+++ b/tests/capture/test_capture_qnode.py
@@ -22,20 +22,12 @@ import pytest
 
 import pennylane as qml
 
-pytestmark = pytest.mark.jax
+pytestmark = [pytest.mark.jax, pytest.mark.usefixtures("enable_disable_plxpr")]
 
 jax = pytest.importorskip("jax")
 
 # must be below jax importorskip
 from pennylane.capture.primitives import qnode_prim  # pylint: disable=wrong-import-position
-
-
-@pytest.fixture(autouse=True)
-def enable_disable_plxpr():
-    """Enable and disable the PennyLane JAX capture context around each test."""
-    qml.capture.enable()
-    yield
-    qml.capture.disable()
 
 
 def get_qnode_output_eqns(jaxpr):

--- a/tests/capture/test_capture_while_loop.py
+++ b/tests/capture/test_capture_while_loop.py
@@ -20,19 +20,11 @@ import pytest
 
 import pennylane as qml
 
-pytestmark = pytest.mark.jax
+pytestmark = [pytest.mark.jax, pytest.mark.usefixtures("enable_disable_plxpr")]
 
 jax = pytest.importorskip("jax")
 
 from pennylane.capture.primitives import while_loop_prim  # pylint: disable=wrong-import-position
-
-
-@pytest.fixture(autouse=True)
-def enable_disable_plxpr():
-    """Enable and disable the PennyLane JAX capture context manager."""
-    qml.capture.enable()
-    yield
-    qml.capture.disable()
 
 
 class TestCaptureWhileLoop:

--- a/tests/capture/test_make_plxpr.py
+++ b/tests/capture/test_make_plxpr.py
@@ -30,15 +30,6 @@ jax = pytest.importorskip("jax")
 from pennylane.capture import make_plxpr  # pylint: disable=wrong-import-position
 
 
-@pytest.fixture
-def enable_disable_plxpr():
-    # if 'noautofixt' in request.keywords:
-    #     return
-    qml.capture.enable()
-    yield
-    qml.capture.disable()
-
-
 def test_error_is_raised_with_capture_disabled():
     dev = qml.device("default.qubit", wires=1)
 

--- a/tests/capture/test_measurements_capture.py
+++ b/tests/capture/test_measurements_capture.py
@@ -41,14 +41,7 @@ from pennylane.capture.primitives import (  # pylint: disable=wrong-import-posit
     AbstractMeasurement,
 )
 
-pytestmark = pytest.mark.jax
-
-
-@pytest.fixture(autouse=True)
-def enable_disable_plxpr():
-    qml.capture.enable()
-    yield
-    qml.capture.disable()
+pytestmark = [pytest.mark.jax, pytest.mark.usefixtures("enable_disable_plxpr")]
 
 
 def _get_shapes_for(*measurements, shots=qml.measurements.Shots(None), num_device_wires=0):

--- a/tests/capture/test_meta_type.py
+++ b/tests/capture/test_meta_type.py
@@ -19,20 +19,11 @@ from inspect import signature
 # pylint: disable=protected-access, undefined-variable
 import pytest
 
-import pennylane as qml
 from pennylane.capture.capture_meta import CaptureMeta
 
 jax = pytest.importorskip("jax")
 
-pytestmark = pytest.mark.jax
-
-
-@pytest.fixture(autouse=True)
-def enable_disable_plxpr():
-    """enable and disable capture around each test."""
-    qml.capture.enable()
-    yield
-    qml.capture.disable()
+pytestmark = [pytest.mark.jax, pytest.mark.usefixtures("enable_disable_plxpr")]
 
 
 def test_custom_capture_meta():

--- a/tests/capture/test_nested_plxpr.py
+++ b/tests/capture/test_nested_plxpr.py
@@ -19,19 +19,12 @@ import pytest
 
 import pennylane as qml
 
-pytestmark = pytest.mark.jax
+pytestmark = [pytest.mark.jax, pytest.mark.usefixtures("enable_disable_plxpr")]
 
 jax = pytest.importorskip("jax")
 
 # pylint: disable=wrong-import-position
 from pennylane.capture.primitives import adjoint_transform_prim, ctrl_transform_prim
-
-
-@pytest.fixture(autouse=True)
-def enable_disable_plxpr():
-    qml.capture.enable()
-    yield
-    qml.capture.disable()
 
 
 class TestAdjointQfunc:

--- a/tests/capture/test_operators.py
+++ b/tests/capture/test_operators.py
@@ -23,14 +23,7 @@ jax = pytest.importorskip("jax")
 
 from pennylane.capture.primitives import AbstractOperator  # pylint: disable=wrong-import-position
 
-pytestmark = pytest.mark.jax
-
-
-@pytest.fixture(autouse=True)
-def enable_disable_plxpr():
-    qml.capture.enable()
-    yield
-    qml.capture.disable()
+pytestmark = [pytest.mark.jax, pytest.mark.usefixtures("enable_disable_plxpr")]
 
 
 def test_abstract_operator():

--- a/tests/capture/test_templates.py
+++ b/tests/capture/test_templates.py
@@ -27,15 +27,8 @@ import pennylane as qml
 jax = pytest.importorskip("jax")
 jnp = jax.numpy
 
-pytestmark = pytest.mark.jax
+pytestmark = [pytest.mark.jax, pytest.mark.usefixtures("enable_disable_plxpr")]
 original_op_bind_code = qml.operation.Operator._primitive_bind_call.__code__
-
-
-@pytest.fixture(autouse=True)
-def enable_disable_plxpr():
-    qml.capture.enable()
-    yield
-    qml.capture.disable()
 
 
 unmodified_templates_cases = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -160,6 +160,14 @@ def seed(request):
     return original_seed
 
 
+@pytest.fixture(scope="function")
+def enable_disable_plxpr():
+    """enable and disable capture around each test."""
+    qml.capture.enable()
+    yield
+    qml.capture.disable()
+
+
 #######################################################################
 
 try:


### PR DESCRIPTION
As name says. Most test files create their own fixture for doing this. I updated the logic to have a single fixture in `conftest,py` that test files can now use instead.

[sc-78687]