### PR TITLE
Qchem jax docstrings

### DIFF
--- a/pennylane/qchem/hamiltonian.py
+++ b/pennylane/qchem/hamiltonian.py
@@ -16,16 +16,18 @@ This module contains the functions needed for computing the molecular Hamiltonia
 """
 from functools import singledispatch
 
-# pylint: disable= too-many-branches, too-many-arguments, too-many-locals, too-many-nested-blocks
-# pylint: disable=consider-using-generator, protected-access, too-many-positional-arguments
-# pylint: disable=possibly-used-before-assignment
-
 import pennylane as qml
 
 from .basis_data import atomic_numbers
 from .hartree_fock import nuclear_energy, scf
 from .molecule import Molecule
 from .observable_hf import fermionic_observable, qubit_observable
+
+# pylint: disable= too-many-branches, too-many-arguments, too-many-locals, too-many-nested-blocks
+# pylint: disable=consider-using-generator, protected-access, too-many-positional-arguments
+# pylint: disable=possibly-used-before-assignment
+
+
 
 # Bohr-Angstrom correlation coefficient (https://physics.nist.gov/cgi-bin/cuu/Value?bohrrada0)
 bohr_angs = 0.529177210903


### PR DESCRIPTION
**Context:**
Now that qchem is jax compatible we need some examples to show users how to do it!

**Description of the Change:**
Add docstring examples for using JAX

**Benefits:**
Can now know how to differentiate stuff using Jax