### PR TITLE
Pinning quimb in CI

### DIFF
--- a/.github/workflows/interface-unit-tests.yml
+++ b/.github/workflows/interface-unit-tests.yml
@@ -465,7 +465,7 @@ jobs:
       pytest_markers: external
       pytest_additional_args: -W ${{ inputs.python_warning_level }} ${{ inputs.python_warning_level != 'default' && '--continue-on-collection-errors' || '' }}
       additional_pip_packages: |
-        pyzx matplotlib stim quimb mitiq ply
+        pyzx matplotlib stim quimb==1.8.4 mitiq ply
         git+https://github.com/PennyLaneAI/pennylane-qiskit.git@master
         ${{ needs.default-dependency-versions.outputs.jax-version }}
         ${{ needs.default-dependency-versions.outputs.tensorflow-version }}


### PR DESCRIPTION
Pinning `quimb` to version 1.8.4 in the workflow file since version 1.9.0 (released on 2024-11-19) broke our CI.

The `default.tensor` device will be updated as soon as possible to be compatible with the newest `quimb` version.
