### PR TITLE
move `qnode_call` to the `workflow` module and make it private

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -58,6 +58,7 @@
   [(#6580)](https://github.com/PennyLaneAI/pennylane/pull/6580)
 
 * `qml.capture.qnode_call` has been made private and moved to the `workflow` module.
+  [(#6620)](https://github.com/PennyLaneAI/pennylane/pull/6620/)
 
 <h4>Other Improvements</h4>
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -57,6 +57,8 @@
 * An optional method `eval_jaxpr` is added to the device API for native execution of plxpr programs.
   [(#6580)](https://github.com/PennyLaneAI/pennylane/pull/6580)
 
+* `qml.capture.qnode_call` has been made private and moved to the `workflow` module.
+
 <h4>Other Improvements</h4>
 
 * `qml.BasisRotation` template is now JIT compatible.

--- a/pennylane/capture/__init__.py
+++ b/pennylane/capture/__init__.py
@@ -34,7 +34,6 @@ quantum-classical programs.
     ~create_measurement_wires_primitive
     ~create_measurement_mcm_primitive
     ~make_plxpr
-    ~qnode_call
     ~PlxprInterpreter
     ~FlatFn
 
@@ -156,7 +155,6 @@ from .capture_measurements import (
     create_measurement_wires_primitive,
     create_measurement_mcm_primitive,
 )
-from .capture_qnode import qnode_call
 from .flatfn import FlatFn
 from .make_plxpr import make_plxpr
 
@@ -182,7 +180,7 @@ def __getattr__(key):
         return _get_abstract_measurement()
 
     if key == "qnode_prim":
-        from .capture_qnode import _get_qnode_prim
+        from ..workflow._capture_qnode import _get_qnode_prim
 
         return _get_qnode_prim()
 
@@ -204,7 +202,6 @@ __all__ = (
     "create_measurement_obs_primitive",
     "create_measurement_wires_primitive",
     "create_measurement_mcm_primitive",
-    "qnode_call",
     "AbstractOperator",
     "AbstractMeasurement",
     "qnode_prim",

--- a/pennylane/capture/primitives.py
+++ b/pennylane/capture/primitives.py
@@ -22,11 +22,11 @@ from pennylane.measurements.mid_measure import _create_mid_measure_primitive
 from pennylane.ops.op_math.adjoint import _get_adjoint_qfunc_prim
 from pennylane.ops.op_math.condition import _get_cond_qfunc_prim
 from pennylane.ops.op_math.controlled import _get_ctrl_qfunc_prim
+from pennylane.workflow._capture_qnode import _get_qnode_prim
 
 from .capture_diff import _get_grad_prim, _get_jacobian_prim
 from .capture_measurements import _get_abstract_measurement
 from .capture_operators import _get_abstract_operator
-from .capture_qnode import _get_qnode_prim
 
 AbstractOperator = _get_abstract_operator()
 AbstractMeasurement = _get_abstract_measurement()

--- a/pennylane/workflow/_capture_qnode.py
+++ b/pennylane/workflow/_capture_qnode.py
@@ -21,9 +21,8 @@ from numbers import Number
 from warnings import warn
 
 import pennylane as qml
+from pennylane.capture import FlatFn
 from pennylane.typing import TensorLike
-
-from .flatfn import FlatFn
 
 has_jax = True
 try:
@@ -135,9 +134,11 @@ def _get_qnode_prim():
             *mps, shots=shots, num_device_wires=len(device.wires), batch_shape=batch_shape
         )
 
+    # pylint: disable=too-many-arguments
     def _qnode_batching_rule(
         batched_args,
         batch_dims,
+        *,
         qnode,
         shots,
         device,
@@ -209,7 +210,7 @@ def _get_qnode_prim():
     return qnode_prim
 
 
-def qnode_call(qnode: "qml.QNode", *args, **kwargs) -> "qml.typing.Result":
+def capture_qnode(qnode: "qml.QNode", *args, **kwargs) -> "qml.typing.Result":
     """A capture compatible call to a QNode. This function is internally used by ``QNode.__call__``.
 
     Args:

--- a/pennylane/workflow/qnode.py
+++ b/pennylane/workflow/qnode.py
@@ -33,6 +33,7 @@ from pennylane.measurements import MidMeasureMP
 from pennylane.tape import QuantumScript, QuantumScriptBatch, QuantumTape
 from pennylane.transforms.core import TransformContainer, TransformDispatcher, TransformProgram
 
+from ._capture_qnode import capture_qnode
 from .execution import (
     INTERFACE_MAP,
     SUPPORTED_INTERFACE_NAMES,
@@ -1059,7 +1060,7 @@ class QNode:
 
     def __call__(self, *args, **kwargs) -> qml.typing.Result:
         if qml.capture.enabled():
-            return qml.capture.qnode_call(self, *args, **kwargs)
+            return capture_qnode(self, *args, **kwargs)
         return self._impl_call(*args, **kwargs)
 
 


### PR DESCRIPTION
**Context:**

As we are integrating more things with the capture project, we are making changes across the entirety of pennylane. Previously, we stuck most capture related code in the capture module, and then imported in whichever relevant place we needed too.

I don't think this makes sense anymore.  As we are tying together the capture work to more parts of pennylane, the capture code should just be located next to the code it is capturing.

**Description of the Change:**

Move `qml.capture.qnode_call` to the workflow module and make it private.

**Benefits:**

Code for managing the workflow is located in the `workflow` module.

**Possible Drawbacks:**

This is all experimental, so we should be able to move things around whenever we see fit.  I'm not concerned about this being "breaking".

**Related GitHub Issues:**
[sc-78505