### PR TITLE
Fix pytest.ini file

### DIFF
--- a/tests/interfaces/test_autograd.py
+++ b/tests/interfaces/test_autograd.py
@@ -852,11 +852,12 @@ class TestHamiltonianWorkflows:
         else:
             assert np.allclose(res, expected, atol=atol_for_shots(shots), rtol=0)
 
-    @pytest.mark.xfail(reason="parameter shift derivatives do not yet support sums.")
     def test_multiple_hamiltonians_trainable(self, execute_kwargs, cost_fn, shots):
         """Test hamiltonian with trainable parameters."""
         if execute_kwargs["diff_method"] == "adjoint":
             pytest.skip("trainable hamiltonians not supported with adjoint")
+        if execute_kwargs["diff_method"] != "backprop":
+            pytest.xfail(reason="parameter shift derivatives do not yet support sums.")
 
         coeffs1 = pnp.array([0.1, 0.2, 0.3], requires_grad=True)
         coeffs2 = pnp.array([0.7], requires_grad=True)

--- a/tests/interfaces/test_jax.py
+++ b/tests/interfaces/test_jax.py
@@ -815,11 +815,12 @@ class TestHamiltonianWorkflows:
         else:
             assert np.allclose(res, expected, atol=atol_for_shots(shots), rtol=0)
 
-    @pytest.mark.xfail(reason="parameter shift derivatives do not yet support sums.")
     def test_multiple_hamiltonians_trainable(self, execute_kwargs, cost_fn, shots):
         """Test hamiltonian with trainable parameters."""
         if execute_kwargs["diff_method"] == "adjoint":
             pytest.skip("trainable hamiltonians not supported with adjoint")
+        if execute_kwargs["diff_method"] != "backprop":
+            pytest.xfail(reason="parameter shift derivatives do not yet support sums.")
 
         coeffs1 = jnp.array([0.1, 0.2, 0.3])
         coeffs2 = jnp.array([0.7])

--- a/tests/interfaces/test_tensorflow.py
+++ b/tests/interfaces/test_tensorflow.py
@@ -807,11 +807,12 @@ class TestHamiltonianWorkflows:
         expected = self.cost_fn_jacobian(weights, coeffs1, coeffs2)[:, :2]
         assert np.allclose(jac, expected, atol=atol_for_shots(shots), rtol=0)
 
-    @pytest.mark.xfail(reason="parameter shift derivatives do not yet support sums.")
     def test_multiple_hamiltonians_trainable(self, cost_fn, execute_kwargs, shots):
         """Test hamiltonian with trainable parameters."""
         if execute_kwargs["diff_method"] == "adjoint":
             pytest.skip("trainable hamiltonians not supported with adjoint")
+        if execute_kwargs["diff_method"] != "backprop":
+            pytest.xfail(reason="parameter shift derivatives do not yet support sums.")
 
         coeffs1 = tf.Variable([0.1, 0.2, 0.3], dtype=tf.float64)
         coeffs2 = tf.Variable([0.7], dtype=tf.float64)

--- a/tests/interfaces/test_torch.py
+++ b/tests/interfaces/test_torch.py
@@ -847,11 +847,12 @@ class TestHamiltonianWorkflows:
         else:
             assert torch.allclose(res, expected, atol=atol_for_shots(shots), rtol=0)
 
-    @pytest.mark.xfail(reason="parameter shift derivatives do not yet support sums.")
     def test_multiple_hamiltonians_trainable(self, execute_kwargs, cost_fn, shots):
         """Test hamiltonian with trainable parameters."""
         if execute_kwargs["diff_method"] == "adjoint":
             pytest.skip("trainable hamiltonians not supported with adjoint")
+        if execute_kwargs["diff_method"] != "backprop":
+            pytest.xfail(reason="parameter shift derivatives do not yet support sums.")
 
         coeffs1 = torch.tensor([0.1, 0.2, 0.3], requires_grad=True)
         coeffs2 = torch.tensor([0.7], requires_grad=True)

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -27,11 +27,6 @@ filterwarnings =
     ignore:Call to deprecated create function:DeprecationWarning
     ignore:the imp module is deprecated:DeprecationWarning
     error::pennylane.PennyLaneDeprecationWarning
-    ignore:qml.ops.Hamiltonian uses the old approach:pennylane.PennyLaneDeprecationWarning
-    ignore:qml.operation.Tensor uses the old approach:pennylane.PennyLaneDeprecationWarning
-    ignore:qml.pauli.simplify:pennylane.PennyLaneDeprecationWarning
-    ignore:PauliSentence.hamiltonian:pennylane.PennyLaneDeprecationWarning
-    ignore:PauliWord.hamiltonian:pennylane.PennyLaneDeprecationWarning
 addopts = --benchmark-disable
-
+xfail_strict=true
 rng_salt = v0.39.0


### PR DESCRIPTION
Looks like I accidentally removed the xfail strict in #6549  .  This PR adds it back end, and removes the suppression of deprecation warnings related to legacy op math, as those are now removed.