### PR TITLE
make warnings into errors

### DIFF
--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -21,12 +21,61 @@ markers =
     catalyst: marks tests for catalyst testing (select with '-m "catalyst"')
     local_salt(salt): adds a salt to the seed provided by the pytest-rng fixture
 filterwarnings =
+    error
     ignore::DeprecationWarning:autograd.numpy.numpy_wrapper
     ignore:Casting complex values to real::autograd.numpy.numpy_wrapper
     ignore:Casting complex values to real discards the imaginary part:UserWarning:torch.autograd
     ignore:Call to deprecated create function:DeprecationWarning
     ignore:the imp module is deprecated:DeprecationWarning
     error::pennylane.PennyLaneDeprecationWarning
+    ;the below warnings require investigation
+    ignore:Casting complex values:numpy.exceptions.ComplexWarning
+    ignore:Calling np.sum:DeprecationWarning
+    ignore:Casting from complex:DeprecationWarning
+    ignore:Conversion of an:DeprecationWarning
+    ignore:Treating CircuitInstruction as:DeprecationWarning
+    ignore:__array_wrap__ must accept:DeprecationWarning
+    ignore:hstack requires ndarray:DeprecationWarning
+    ignore:In the future:FutureWarning
+    ignore:scatter inputs have:FutureWarning
+    ignore:the matrix subclass:PendingDeprecationWarning
+    ignore:Benchmarks are automatically:pytest_benchmark.logger.PytestBenchmarkWarning
+    ignore:cannot collect:pytest.PytestCollectionWarning
+    ;catalyst has pennylane.operation.Tensor
+    ignore::pytest.PytestDeprecationWarning
+    ignore:Marks applied to:pytest.PytestRemovedIn9Warning
+    ignore:Exception ignored in:pytest.PytestUnraisableExceptionWarning
+    ignore:unclosed running multiprocessing:ResourceWarning
+    ignore:Degrees of freedom:RuntimeWarning
+    ignore:Mean of empty:RuntimeWarning
+    ignore:More than 20 figures:RuntimeWarning
+    ignore:The two-qubit decomposition may not be diff:RuntimeWarning
+    ignore:divide by zero:RuntimeWarning
+    ignore:invalid value encountered:RuntimeWarning
+    ignore:is incompatible with multithreaded code:RuntimeWarning
+    ignore:Converting a tensor to a Python boolean:torch.jit._trace.TracerWarning
+    ignore:torch.as_tensor results:torch.jit._trace.TracerWarning
+    ignore:Attempted to compute the gradient of a tape with no trainable:UserWarning
+    ignore:Attempted to differentiate a function with no trainable:UserWarning
+    ignore:Casting complex values:UserWarning
+    ignore:Caution, wires:UserWarning
+    ignore:Contains tensors of types:UserWarning
+    ignore:Creating a tensor from a list of numpy:UserWarning
+    ignore:Decomposition may be inefficient:UserWarning
+    ignore:as an argument to the given quantum function:UserWarning
+    ignore:Explicitly requested dtype:UserWarning
+    ignore:Finite differences with float32:UserWarning
+    ignore:It appears you may be trying to set the method:UserWarning
+    ignore:is not affected by readout error:UserWarning
+    ignore:may not be unitary:UserWarning
+    ignore:Output seems independent of input:UserWarning
+    ignore:PennyLane does not provide:UserWarning
+    ignore:Received gradient_kwarg:UserWarning
+    ignore:Requested state or density matrix with finite shots:UserWarning
+    ignore:Snapshots are not supported:UserWarning
+    ignore:may not be hermitian:UserWarning
+    ignore:The condition number of the Fourier:UserWarning
+    ignore:The device requested:UserWarning
 addopts = --benchmark-disable
 xfail_strict=true
 rng_salt = v0.39.0


### PR DESCRIPTION
**Context:**
Warnings-as-errors is great, and we should enable it.

**Description of the Change:**
Set all warnings as errors, except for all the warnings that exist today.

**Benefits:**
Any new warnings will immediately be caught and converted into errors.

**Possible Drawbacks:**
To make this extra-useful, someone ought to work on reducing this list by addressing the warnings. At least this makes it more concretely actionable:
1. remove an `ignore` filter line from this file
2. make a PR
3. choose one:
  a. fix the now-failing tests by fixing the root cause
  b. filter the warnings within the now-failing tests
  c. put back the filter and enshrine it forevermore as a PennyLane standard
4. repeat