### PR TITLE
Move-get_random_mixed_state-to-conftest

### DIFF
--- a/tests/devices/qubit_mixed/conftest.py
+++ b/tests/devices/qubit_mixed/conftest.py
@@ -1,0 +1,44 @@
+# Copyright 2018-2024 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Pytest configuration file for PennyLane qubit mixed state test suite."""
+import numpy as np
+import pytest
+from scipy.stats import unitary_group
+
+
+def get_random_mixed_state(num_qubits):
+    """
+    Generates a random mixed state for testing purposes.
+
+    Args:
+        num_qubits (int): The number of qubits in the mixed state.
+
+    Returns:
+        np.ndarray: A tensor representing the random mixed state.
+    """
+    dim = 2**num_qubits
+
+    rng = np.random.default_rng(seed=4774)
+    basis = unitary_group(dim=dim, seed=584545).rvs()
+    schmidt_weights = rng.dirichlet(np.ones(dim), size=1).astype(complex)[0]
+    mixed_state = np.zeros((dim, dim)).astype(complex)
+    for i in range(dim):
+        mixed_state += schmidt_weights[i] * np.outer(np.conj(basis[i]), basis[i])
+
+    return mixed_state.reshape([2] * (2 * num_qubits))
+
+
+@pytest.fixture(scope="package")
+def random_mixed_state():
+    return get_random_mixed_state

--- a/tests/devices/qubit_mixed/test_qubit_mixed_apply_operation.py
+++ b/tests/devices/qubit_mixed/test_qubit_mixed_apply_operation.py
@@ -20,7 +20,6 @@ import pytest
 from scipy.stats import unitary_group
 
 import pennylane as qml
-import pennylane.math as math
 from pennylane import (
     CNOT,
     ISWAP,
@@ -30,6 +29,7 @@ from pennylane import (
     PauliError,
     PauliX,
     ResetError,
+    math,
 )
 from pennylane.devices.qubit_mixed import apply_operation
 from pennylane.devices.qubit_mixed.apply_operation import (
@@ -98,28 +98,6 @@ def root_state(nr_wires):
 
 
 special_state_generator = [base0, base1, cat_state, hadamard_state, max_mixed_state, root_state]
-
-
-def get_random_mixed_state(num_qubits):
-    """
-    Generates a random mixed state for testing purposes.
-
-    Args:
-        num_qubits (int): The number of qubits in the mixed state.
-
-    Returns:
-        np.ndarray: A tensor representing the random mixed state.
-    """
-    dim = 2**num_qubits
-
-    rng = np.random.default_rng(seed=4774)
-    basis = unitary_group(dim=dim, seed=584545).rvs()
-    schmidt_weights = rng.dirichlet(np.ones(dim), size=1).astype(complex)[0]
-    mixed_state = np.zeros((dim, dim)).astype(complex)
-    for i in range(dim):
-        mixed_state += schmidt_weights[i] * np.outer(np.conj(basis[i]), basis[i])
-
-    return mixed_state.reshape([2] * (2 * num_qubits))
 
 
 def get_expected_state(expanded_operator, state, num_q):
@@ -196,7 +174,7 @@ class TestOperation:  # pylint: disable=too-few-public-methods
 
     @pytest.mark.parametrize("op", unbroadcasted_ops)
     @pytest.mark.parametrize("num_q", num_qubits)
-    def test_no_broadcasting(self, op, num_q, ml_framework):
+    def test_no_broadcasting(self, op, num_q, ml_framework, random_mixed_state):
         """
         Tests that unbatched operations are applied correctly to an unbatched state.
 
@@ -204,7 +182,7 @@ class TestOperation:  # pylint: disable=too-few-public-methods
             op (Operation): Quantum operation to apply.
             ml_framework (str): The machine learning framework in use (numpy, autograd, etc.).
         """
-        state = math.asarray(get_random_mixed_state(num_q), like=ml_framework)
+        state = math.asarray(random_mixed_state(num_q), like=ml_framework)
         res = apply_operation(op, state)
         res_tensordot = apply_operation_tensordot(op, state)
         res_einsum = apply_operation_einsum(op, state)
@@ -220,7 +198,7 @@ class TestOperation:  # pylint: disable=too-few-public-methods
 
     @pytest.mark.parametrize("op", diagonal_ops)
     @pytest.mark.parametrize("num_q", num_qubits)
-    def test_diagonal(self, op, num_q, ml_framework):
+    def test_diagonal(self, op, num_q, ml_framework, random_mixed_state):
         """
         Tests that diagonal operations are applied correctly to an unbatched state.
 
@@ -228,7 +206,7 @@ class TestOperation:  # pylint: disable=too-few-public-methods
             op (Operation): Quantum operation to apply.
             ml_framework (str): The machine learning framework in use (numpy, autograd, etc.).
         """
-        state_np = get_random_mixed_state(num_q)
+        state_np = random_mixed_state(num_q)
         state = math.asarray(state_np, like=ml_framework)
         res = apply_operation(op, state)
 
@@ -238,9 +216,9 @@ class TestOperation:  # pylint: disable=too-few-public-methods
         assert math.allclose(res, expected), f"Operation {op} failed. {res} != {expected}"
 
     @pytest.mark.parametrize("num_q", num_qubits)
-    def test_identity(self, num_q, ml_framework):
+    def test_identity(self, num_q, ml_framework, random_mixed_state):
         """Tests that the identity operation is applied correctly to an unbatched state."""
-        state_np = get_random_mixed_state(num_q)
+        state_np = random_mixed_state(num_q)
         state = math.asarray(state_np, like=ml_framework)
         op = qml.Identity(wires=0)
         res = apply_operation(op, state)
@@ -248,9 +226,9 @@ class TestOperation:  # pylint: disable=too-few-public-methods
         assert math.allclose(res, state), f"Operation {op} failed. {res} != {state}"
 
     @pytest.mark.parametrize("num_q", num_qubits)
-    def test_globalphase(self, num_q, ml_framework):
+    def test_globalphase(self, num_q, ml_framework, random_mixed_state):
         """Tests that the identity operation is applied correctly to an unbatched state."""
-        state_np = get_random_mixed_state(num_q)
+        state_np = random_mixed_state(num_q)
         state = math.asarray(state_np, like=ml_framework)
         op = qml.GlobalPhase(np.pi / 7, wires=0)
         res = apply_operation(op, state)
@@ -259,10 +237,10 @@ class TestOperation:  # pylint: disable=too-few-public-methods
 
     @pytest.mark.parametrize("op", unbroadcasted_ops)
     @pytest.mark.parametrize("num_q", num_qubits)
-    def test_unbroadcasted_ops_batched(self, op, num_q, ml_framework):
+    def test_unbroadcasted_ops_batched(self, op, num_q, ml_framework, random_mixed_state):
         """Test that unbroadcasted operations are applied correctly to batched states."""
         batch_size = self.num_batched
-        state = np.array([get_random_mixed_state(num_q) for _ in range(batch_size)])
+        state = np.array([random_mixed_state(num_q) for _ in range(batch_size)])
         state = math.asarray(state, like=ml_framework)
         res = apply_operation(op, state, is_state_batched=True)
 
@@ -286,10 +264,10 @@ class TestOperation:  # pylint: disable=too-few-public-methods
 
     @pytest.mark.parametrize("op", diagonal_ops)
     @pytest.mark.parametrize("num_q", num_qubits)
-    def test_diagonal_ops_batched(self, op, num_q, ml_framework):
+    def test_diagonal_ops_batched(self, op, num_q, ml_framework, random_mixed_state):
         """Test that diagonal operations are applied correctly to batched states."""
         batch_size = self.num_batched
-        state = np.array([get_random_mixed_state(num_q) for _ in range(batch_size)])
+        state = np.array([random_mixed_state(num_q) for _ in range(batch_size)])
         state = math.asarray(state, like=ml_framework)
         res = apply_operation(op, state, is_state_batched=True)
 
@@ -325,9 +303,9 @@ class TestApplyGroverOperator:
             (9, "custom"),
         ],
     )
-    def test_dispatch_method(self, num_wires, expected_method, mocker):
+    def test_dispatch_method(self, num_wires, expected_method, mocker, random_mixed_state):
         """Test that the correct dispatch method is used based on the number of wires."""
-        state = get_random_mixed_state(num_wires)
+        state = random_mixed_state(num_wires)
 
         op = qml.GroverOperator(wires=range(num_wires))
 
@@ -348,9 +326,9 @@ class TestApplyGroverOperator:
             # assert not spy_tensordot.called
 
     @pytest.mark.parametrize("num_wires", [2, 3, 7, 8, 9])
-    def test_correctness(self, num_wires):
+    def test_correctness(self, num_wires, random_mixed_state):
         """Test that the GroverOperator is applied correctly for various wire numbers."""
-        state = get_random_mixed_state(num_wires)
+        state = random_mixed_state(num_wires)
 
         op = qml.GroverOperator(wires=range(num_wires))
         op_mat = op.matrix()
@@ -364,10 +342,10 @@ class TestApplyGroverOperator:
         assert np.allclose(result.reshape(flat_shape), expected)
 
     @pytest.mark.parametrize("num_wires", [2, 3, 7, 8, 9])
-    def test_batched_state(self, num_wires):
+    def test_batched_state(self, num_wires, random_mixed_state):
         """Test that the GroverOperator works correctly with batched states."""
         batch_size = 3
-        state = np.array([get_random_mixed_state(num_wires) for _ in range(batch_size)])
+        state = np.array([random_mixed_state(num_wires) for _ in range(batch_size)])
 
         op = qml.GroverOperator(wires=range(num_wires))
         op_mat = op.matrix()
@@ -382,10 +360,10 @@ class TestApplyGroverOperator:
         assert np.allclose(result.reshape(flat_shape), expected)
 
     @pytest.mark.parametrize("interface", ml_frameworks_list)
-    def test_interface_compatibility(self, interface):
+    def test_interface_compatibility(self, interface, random_mixed_state):
         """Test that the GroverOperator works with different interfaces."""
         num_wires = 5
-        state = get_random_mixed_state(num_wires)
+        state = random_mixed_state(num_wires)
         state = math.asarray(state, like=interface)
 
         op = qml.GroverOperator(wires=range(num_wires))
@@ -403,6 +381,7 @@ class TestApplyGroverOperator:
 class TestApplyMultiControlledX:
     """Test that MultiControlledX is applied correctly to mixed states."""
 
+    # pylint: disable=too-many-arguments, too-many-positional-arguments
     @pytest.mark.parametrize(
         "num_wires, interface, expected_method",
         [
@@ -414,10 +393,12 @@ class TestApplyMultiControlledX:
             (9, "autograd", "custom"),
         ],
     )
-    def test_dispatch_method(self, num_wires, expected_method, interface, mocker):
+    def test_dispatch_method(
+        self, num_wires, expected_method, interface, mocker, random_mixed_state
+    ):
         """Test that the correct dispatch method is used based on the number of wires
         for numpy and autograd."""
-        state = get_random_mixed_state(num_wires)
+        state = random_mixed_state(num_wires)
         # Convert to interface
         state = math.asarray(state, like=interface)
 
@@ -438,6 +419,7 @@ class TestApplyMultiControlledX:
             assert not spy_einsum.called
             assert not spy_tensordot.called
 
+    # pylint: disable=too-many-arguments, too-many-positional-arguments
     @pytest.mark.parametrize("interface", ml_frameworks_list[2:])
     @pytest.mark.parametrize(
         "num_wires, expected_method",
@@ -448,10 +430,12 @@ class TestApplyMultiControlledX:
             (9, "custom"),
         ],
     )
-    def test_dispatch_method_interfaces(self, num_wires, expected_method, interface, mocker):
+    def test_dispatch_method_interfaces(
+        self, num_wires, expected_method, interface, mocker, random_mixed_state
+    ):
         """Test that the correct dispatch method is used based on the number of wires
         for torch, tensorflow, and jax."""
-        state = get_random_mixed_state(num_wires)
+        state = random_mixed_state(num_wires)
         # Convert to interface
         state = math.asarray(state, like=interface)
 
@@ -473,9 +457,9 @@ class TestApplyMultiControlledX:
             assert not spy_tensordot.called
 
     @pytest.mark.parametrize("num_wires", [2, 3, 7, 8, 9])
-    def test_correctness(self, num_wires):
+    def test_correctness(self, num_wires, random_mixed_state):
         """Test that the MultiControlledX is applied correctly for various wire numbers."""
-        state = get_random_mixed_state(num_wires)
+        state = random_mixed_state(num_wires)
 
         op = qml.MultiControlledX(wires=range(num_wires))
         op_mat = op.matrix()
@@ -489,10 +473,10 @@ class TestApplyMultiControlledX:
         assert np.allclose(result.reshape(flat_shape), expected)
 
     @pytest.mark.parametrize("num_wires", [2, 3, 7, 8, 9])
-    def test_batched_state(self, num_wires):
+    def test_batched_state(self, num_wires, random_mixed_state):
         """Test that the MultiControlledX works correctly with batched states."""
         batch_size = 3
-        state = np.array([get_random_mixed_state(num_wires) for _ in range(batch_size)])
+        state = np.array([random_mixed_state(num_wires) for _ in range(batch_size)])
 
         op = qml.MultiControlledX(wires=range(num_wires))
         op_mat = op.matrix()
@@ -507,10 +491,10 @@ class TestApplyMultiControlledX:
         assert np.allclose(result.reshape(flat_shape), expected)
 
     @pytest.mark.parametrize("interface", ml_frameworks_list)
-    def test_interface_compatibility(self, interface):
+    def test_interface_compatibility(self, interface, random_mixed_state):
         """Test that the MultiControlledX works with different interfaces."""
         num_wires = 5
-        state = get_random_mixed_state(num_wires)
+        state = random_mixed_state(num_wires)
         state = math.asarray(state, like=interface)
 
         op = qml.MultiControlledX(wires=range(num_wires))
@@ -651,10 +635,10 @@ class TestBroadcasting:  # pylint: disable=too-few-public-methods
     ]
 
     @pytest.mark.parametrize("op", broadcasted_ops)
-    def test_broadcasted_op(self, op, ml_framework):
+    def test_broadcasted_op(self, op, ml_framework, random_mixed_state):
         """Tests that batched operations are applied correctly to an unbatched state."""
         num_q = 3
-        state = math.asarray(get_random_mixed_state(num_q), like=ml_framework)
+        state = math.asarray(random_mixed_state(num_q), like=ml_framework)
 
         res = apply_operation(op, state)
 
@@ -665,10 +649,10 @@ class TestBroadcasting:  # pylint: disable=too-few-public-methods
         assert math.allclose(res, expected)
 
     @pytest.mark.parametrize("op", unbroadcasted_ops)
-    def test_broadcasted_state(self, op, ml_framework):
+    def test_broadcasted_state(self, op, ml_framework, random_mixed_state):
         """Tests that batched operations are applied correctly to an unbatched state."""
         num_q = 3
-        state = [math.asarray(get_random_mixed_state(num_q), like=ml_framework) for _ in range(3)]
+        state = [math.asarray(random_mixed_state(num_q), like=ml_framework) for _ in range(3)]
         state = math.stack(state)
 
         res = apply_operation(op, state, is_state_batched=True)
@@ -680,10 +664,10 @@ class TestBroadcasting:  # pylint: disable=too-few-public-methods
         assert math.allclose(res, expected)
 
     @pytest.mark.parametrize("op", broadcasted_ops)
-    def test_broadcasted_op_broadcasted_state(self, op, ml_framework):
+    def test_broadcasted_op_broadcasted_state(self, op, ml_framework, random_mixed_state):
         """Tests that batched operations are applied correctly to batched state."""
         num_q = 3
-        state = [math.asarray(get_random_mixed_state(num_q), like=ml_framework) for _ in range(3)]
+        state = [math.asarray(random_mixed_state(num_q), like=ml_framework) for _ in range(3)]
         state = math.stack(state)
 
         res = apply_operation(op, state, is_state_batched=True)


### PR DESCRIPTION
**Context:**
A small refactor to the `tests/devices/qubit_mixed/test_qubit_mixed_apply_operation.py`


**Description of the Change:**
We would love to move the `get_random_mixed_state` separately from the mentioned test file to a conftest file as fixture. It will be used in multiple different test suites.

**Benefits:**
Less redundancy, repeating definitions of the same functions.

**Possible Drawbacks:**
No

**Related GitHub Issues:**
