### PR TITLE
Default preprocessing transforms handles diagonalization of measurements

### DIFF
--- a/pennylane/devices/device_api.py
+++ b/pennylane/devices/device_api.py
@@ -514,12 +514,30 @@ class Device(abc.ABC):
         capabilities_analytic = self.capabilities.filter(finite_shots=False)
         capabilities_shots = self.capabilities.filter(finite_shots=True)
 
-        program.add_transform(
-            decompose,
-            stopping_condition=lambda o: capabilities_analytic.supports_operation(o.name),
-            stopping_condition_shots=lambda o: capabilities_shots.supports_operation(o.name),
-            name=self.name,
-        )
+        needs_diagonalization = False
+        base_obs = {"PauliZ": qml.Z, "PauliX": qml.X, "PauliY": qml.Y, "Hadamard": qml.H}
+        if (
+            not all(obs in self.capabilities.observables for obs in base_obs)
+            # This check is to confirm that `split_non_commuting` has been applied, since
+            # `diagonalize_measurements` does not work with non-commuting measurements. If
+            # a device is flexible enough to support non-commuting observables but for some
+            # reason does not support all of `PauliZ`, `PauliX`, `PauliY`, and `Hadamard`,
+            # we consider it enough of an edge case that the device should just implement
+            # its own preprocessing transform.
+            and not self.capabilities.non_commuting_observables
+        ):
+            needs_diagonalization = True
+        else:
+            # If the circuit does not need diagonalization, we decompose the circuit before
+            # potentially applying `split_non_commuting` that produces multiple tapes with
+            # duplicated operations. Otherwise, `decompose` has to be applied last because
+            # `diagonalize_measurements` may add additional gates that are not supported.
+            program.add_transform(
+                decompose,
+                stopping_condition=lambda o: capabilities_analytic.supports_operation(o.name),
+                stopping_condition_shots=lambda o: capabilities_shots.supports_operation(o.name),
+                name=self.name,
+            )
 
         if not self.capabilities.overlapping_observables:
             program.add_transform(qml.transforms.split_non_commuting, grouping_strategy="wires")
@@ -528,8 +546,16 @@ class Device(abc.ABC):
         elif not self.capabilities.supports_observable("Sum"):
             program.add_transform(qml.transforms.split_to_single_terms)
 
-        # TODO: diagonalization should be part of the default transform program, but we decided
-        #       not to include it in this PR due to complications. See sc-79422
+        if needs_diagonalization:
+            obs_names = base_obs.keys() & self.capabilities.observables.keys()
+            obs = {base_obs[obs] for obs in obs_names}
+            program.add_transform(qml.transforms.diagonalize_measurements, supported_base_obs=obs)
+            program.add_transform(
+                decompose,
+                stopping_condition=lambda o: capabilities_analytic.supports_operation(o.name),
+                stopping_condition_shots=lambda o: capabilities_shots.supports_operation(o.name),
+                name=self.name,
+            )
 
         program.add_transform(qml.transforms.broadcast_expand)
 

--- a/pennylane/transforms/diagonalize_measurements.py
+++ b/pennylane/transforms/diagonalize_measurements.py
@@ -61,7 +61,11 @@ def diagonalize_measurements(tape, supported_base_obs=_default_supported_obs, to
         can be applied.
 
     .. note::
-        This transform will skip observables that cannot be diagonalized.
+        This transform will diagonalize what it can, i.e., `qml.X`, `qml.Y`, `qml.Z`, `qml.Hadamard`,
+        `qml.Identity`, or a linear combination of them. Any other observable will be skipped and
+        left undiagonalized. In the context of preprocessing a quantum circuit for execution on a
+        device, observable validation should be performed after this transform to ensure that all
+        undiagonalized observables are supported by the device.
 
     **Examples:**
 

--- a/tests/devices/test_device_api.py
+++ b/tests/devices/test_device_api.py
@@ -14,6 +14,7 @@
 """
 Tests for the basic default behavior of the Device API.
 """
+import re
 from typing import Optional, Union
 
 import pytest
@@ -471,8 +472,10 @@ class TestPreprocessTransforms:
         with pytest.raises(qml.DeviceError, match=r"Measurement var\(Z\(0\)\) not accepted"):
             _, __ = program((invalid_tape,))
 
-        invalid_tape = QuantumScript([], [qml.expval(qml.PauliX(0))], shots=shots)
-        with pytest.raises(qml.DeviceError, match=r"Observable X\(0\) not supported"):
+        invalid_tape = QuantumScript(
+            [], [qml.expval(qml.Hermitian([[1.0, 0], [0, 1.0]], 0))], shots=shots
+        )
+        with pytest.raises(qml.DeviceError, match=r"Observable Hermitian"):
             _, __ = program((invalid_tape,))
 
         shots_only_meas_tape = QuantumScript([], [qml.counts()], shots=shots)

--- a/tests/devices/test_device_api.py
+++ b/tests/devices/test_device_api.py
@@ -555,6 +555,57 @@ class TestPreprocessTransforms:
             assert qml.transforms.split_to_single_terms not in program
             assert qml.transforms.split_to_single_terms not in program
 
+    @pytest.mark.usefixtures("create_temporary_toml_file")
+    @pytest.mark.parametrize("create_temporary_toml_file", [EXAMPLE_TOML_FILE], indirect=True)
+    @pytest.mark.parametrize("non_commuting_obs", [True, False])
+    @pytest.mark.parametrize("all_obs_support", [True, False])
+    def test_diagonalize_measurements(self, request, non_commuting_obs, all_obs_support):
+        """Tests that the diagonalize_measurements transform is applied correctly."""
+
+        class CustomDevice(Device):
+
+            config_filepath = request.node.toml_file
+
+            def __init__(self):
+                super().__init__()
+                self.capabilities.non_commuting_observables = non_commuting_obs
+                if all_obs_support:
+                    self.capabilities.observables.update(
+                        {
+                            "PauliX": OperatorProperties(),
+                            "PauliY": OperatorProperties(),
+                            "PauliZ": OperatorProperties(),
+                            "Hadamard": OperatorProperties(),
+                        }
+                    )
+                else:
+                    self.capabilities.observables.update(
+                        {
+                            "PauliZ": OperatorProperties(),
+                            "PauliX": OperatorProperties(),
+                            "PauliY": OperatorProperties(),
+                        }
+                    )
+
+            def execute(self, circuits, execution_config=DefaultExecutionConfig):
+                return (0,)
+
+        dev = CustomDevice()
+        program = dev.preprocess_transforms()
+        if non_commuting_obs is True:
+            assert qml.transforms.diagonalize_measurements not in program
+        elif all_obs_support is True:
+            assert qml.transforms.diagonalize_measurements not in program
+        else:
+            assert qml.transforms.diagonalize_measurements in program
+            for transform_container in program:
+                if transform_container._transform is qml.transforms.diagonalize_measurements:
+                    assert transform_container._kwargs["supported_base_obs"] == {
+                        "PauliZ",
+                        "PauliX",
+                        "PauliY",
+                    }
+
 
 class TestMinimalDevice:
     """Tests for a device with only a minimal execute provided."""

--- a/tests/devices/test_device_api.py
+++ b/tests/devices/test_device_api.py
@@ -587,6 +587,7 @@ class TestPreprocessTransforms:
                             "PauliZ": OperatorProperties(),
                             "PauliX": OperatorProperties(),
                             "PauliY": OperatorProperties(),
+                            "Hermitian": OperatorProperties(),
                         }
                     )
 

--- a/tests/transforms/test_diagonalize_measurements.py
+++ b/tests/transforms/test_diagonalize_measurements.py
@@ -215,19 +215,6 @@ class TestDiagonalizeObservable:
         with pytest.raises(ValueError, match="Expected measurements on the same wire to commute"):
             _ = _diagonalize_observable(obs, supported_base_obs=device_supported_obs)
 
-    def test_diagonalizing_unknown_observable_raises_error(self):
-        """Test that an unknown observable raises an error when diagonalizing"""
-
-        # pylint: disable=too-few-public-methods
-        class MyObs(qml.operation.Observable):
-
-            @property
-            def name(self):
-                return f"MyObservable[{self.wires}]"
-
-        with pytest.raises(NotImplementedError, match="Unable to convert observable"):
-            _ = _diagonalize_observable(MyObs(wires=[2]))
-
     @pytest.mark.parametrize(
         "obs, input_visited_obs, switch_basis, expected_res",
         [

--- a/tests/transforms/test_diagonalize_measurements.py
+++ b/tests/transforms/test_diagonalize_measurements.py
@@ -215,6 +215,21 @@ class TestDiagonalizeObservable:
         with pytest.raises(ValueError, match="Expected measurements on the same wire to commute"):
             _ = _diagonalize_observable(obs, supported_base_obs=device_supported_obs)
 
+    def test_diagonalizing_unknown_observable(self):
+        """Test that an unknown observable is left undiagonalized"""
+
+        # pylint: disable=too-few-public-methods
+        class MyObs(qml.operation.Observable):
+
+            @property
+            def name(self):
+                return f"MyObservable[{self.wires}]"
+
+        initial_tape = qml.tape.QuantumScript([], [qml.expval(MyObs(wires=[2]))])
+        tapes, _ = diagonalize_measurements([initial_tape])
+        assert tapes[0].operations == []
+        assert tapes[0].measurements == [ExpectationMP(MyObs(wires=[2]))]
+
     @pytest.mark.parametrize(
         "obs, input_visited_obs, switch_basis, expected_res",
         [


### PR DESCRIPTION
The original intention was to include it in https://github.com/PennyLaneAI/pennylane/pull/6632 but we decided to exclude it for now due to the following complications (and potential solutions):

- The diagonalize_measurements transform assumes that split_non_commuting has been applied (wouldn't make sense otherwise). What if the device requires diagonalization of some observables but supports commuting measurements?
  - We consider this enough of an edge case that a device like that should just implement its own preprocessing transform program.
- The diagonalize_measurements transform raises an error when it sees anything that is not one of PauliX, PauliY, PauliZ, Hadamard, or a linear combination of the four. For example, if a device supports Hermitian but not Hadamard, it would expect that Hermitian is allowed but Hadamard is diagonalized.
  - We might consider changing diagonalize_measurements to simply leave unrecognized observables as is instead of raising an error. The unsupported observables that are not diagonalized will remain in the circuit past the diagonalize_measurements transform but caught later in the transform program by validate_observables.
- Diagonalization produces additional gates that the device may not support.
  - decompose should be applied after diagonalization. Hopefully with restructured decompositions, diagonalizing gates can always be mapped to the device native gate set.