### PR TITLE
Fix issue with check_in_artifact being triggered for all docs builds

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -63,7 +63,9 @@ jobs:
         path: doc.txt
 
   upload-stable-deps:
-    if: github.event.pull_request.draft == false
+    # A) PR is not in draft mode
+    # B) PR is from the same repo as the workflow (i.e., not a fork)
+    if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
     needs:
       - determine_runner
       - sphinx


### PR DESCRIPTION
**Context:**
The `check_in_artifact` re-usable workflow is used by the CI/CD system to track changes/drifts for dependencies of pennylane.

For actual unit-tests, this is only done if the tests are triggered on schedule (cron) event. However, for docs, this was set to run for ALL pull requests. 

This is an issue as external pull requests lack the permissions to actually perform the steps that check_in_artifact does.

This has blocked all external PRs from being merged.

**Description of the Change:**
This PR adds an additional check to the `docs.yml` workflow. Ensuring the PR is not from a fork before triggering check_in_artifact.

**Benefits:**
Unblocks external PRs.

**Possible Drawbacks:**
We won't be detecting dependency changes for external PRs. But that's not something we are doing now anyways.

**Related GitHub Issues:**
[sc-79626](https://app.shortcut.com/xanaduai/story/79626/fix-issue-on-pennylane-with-check-in-artifact-failing-on-prs-from-external-contributors)