### PR TITLE
Change dependency on toml to tomlkit

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -24,7 +24,7 @@ sphinxcontrib-serializinghtml==1.1.5
 tensorflow==2.11.1; platform_machine == "x86_64"
 tensorflow_macos==2.9.0; sys_platform == "darwin" and platform_machine == "arm64"
 tensornetwork==0.3
-toml
+tomlkit
 torch==2.3.0
 jinja2==3.0.3
 rustworkx>=0.14.0

--- a/pennylane/configuration.py
+++ b/pennylane/configuration.py
@@ -20,7 +20,7 @@ supported plugins and devices.
 import contextlib
 import os
 
-import toml
+import tomlkit as toml
 from appdirs import user_config_dir
 
 

--- a/pennylane/devices/capabilities.py
+++ b/pennylane/devices/capabilities.py
@@ -20,7 +20,7 @@ from enum import Enum
 from itertools import repeat
 from typing import Callable, Optional, Union
 
-import toml
+import tomlkit as toml
 
 import pennylane as qml
 from pennylane.operation import Operator
@@ -34,7 +34,8 @@ class InvalidCapabilitiesError(Exception):
 
 def load_toml_file(file_path: str) -> dict:
     """Loads a TOML file and returns the parsed dict."""
-    return toml.load(file_path)
+    with open(file_path, "rb") as file:
+        return toml.load(file)
 
 
 class ExecutionCondition(Enum):

--- a/pennylane/devices/capabilities.py
+++ b/pennylane/devices/capabilities.py
@@ -34,7 +34,7 @@ class InvalidCapabilitiesError(Exception):
 
 def load_toml_file(file_path: str) -> dict:
     """Loads a TOML file and returns the parsed dict."""
-    with open(file_path, "rb") as file:
+    with open(file_path, "r") as file:
         return toml.load(file)
 
 

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -5,13 +5,12 @@ cvxopt
 networkx
 rustworkx
 autograd
-toml
+tomlkit
 appdirs
 packaging
 autoray>=0.6.11
 matplotlib
 requests
 rich
-tomli # Drop once minimum Python version is 3.11
 diastatic-malt
 pandas

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,7 +9,7 @@ pytest-forked>=1.4.0
 pytest-benchmark
 pytest-split
 black>=21
-tomli~=2.0.0 # Drop once minimum Python version is 3.11
+tomlkit~=0.13
 isort==5.13.2
 pylint==2.7.4
 rich>=13.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ cachetools~=5.0.0
 networkx~=2.8
 rustworkx~=0.15.1
 autograd~=1.4
-toml~=0.10
+tomlkit~=0.13
 appdirs~=1.4
 packaging
 autoray>=0.6.11

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ requirements = [
     "networkx",
     "rustworkx>=0.14.0",
     "autograd",
-    "toml",
+    "tomlkit",
     "appdirs",
     "autoray>=0.6.11",
     "cachetools",


### PR DESCRIPTION
`toml` is not maintained anymore, alternatives include:
- `tomlkit`
- `tomli`
- `tomllib` (only available in Python 3.11)

Since `configuration.py` requires the ability to save to a TOML file, and both `tomli` and `tomllib` are read-only, updating the dependency to use `tomlkit` instead.