### PR TITLE
Small fix in the syntax of `jax.vmap`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -150,6 +150,7 @@ added `binary_mapping()` function to map `BoseWord` and `BoseSentence` to qubit 
 * `jax.vmap` can be captured with `qml.capture.make_plxpr` and is compatible with quantum circuits. 
   [(#6349)](https://github.com/PennyLaneAI/pennylane/pull/6349)
   [(#6422)](https://github.com/PennyLaneAI/pennylane/pull/6422)
+  [(#...)](https://github.com/PennyLaneAI/pennylane/pull/...)
 
 * `qml.capture.PlxprInterpreter` base class has been added for easy transformation and execution of
   pennylane variant jaxpr.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -150,7 +150,7 @@ added `binary_mapping()` function to map `BoseWord` and `BoseSentence` to qubit 
 * `jax.vmap` can be captured with `qml.capture.make_plxpr` and is compatible with quantum circuits. 
   [(#6349)](https://github.com/PennyLaneAI/pennylane/pull/6349)
   [(#6422)](https://github.com/PennyLaneAI/pennylane/pull/6422)
-  [(#...)](https://github.com/PennyLaneAI/pennylane/pull/...)
+  [(#6668)](https://github.com/PennyLaneAI/pennylane/pull/6668)
 
 * `qml.capture.PlxprInterpreter` base class has been added for easy transformation and execution of
   pennylane variant jaxpr.

--- a/pennylane/workflow/_capture_qnode.py
+++ b/pennylane/workflow/_capture_qnode.py
@@ -112,7 +112,7 @@ def _get_qnode_prim():
 
             # pylint: disable=protected-access
             return jax.vmap(partial(qnode._impl_call, shots=shots), batch_dims[n_consts:])(
-                *jax.tree_util.tree_leaves(non_const_args)
+                *non_const_args
             )
 
         # pylint: disable=protected-access

--- a/tests/capture/test_capture_qnode.py
+++ b/tests/capture/test_capture_qnode.py
@@ -909,7 +909,7 @@ class TestQNodeVmapIntegration:
             assert len(eqn.outvars) == 1
             assert eqn.outvars[0].aval.shape == (3,)
 
-        result = jax.core.eval_jaxpr(jaxpr.jaxpr, jaxpr.consts, x, y, 1)
+        result = jax.core.eval_jaxpr(jaxpr.jaxpr, jaxpr.consts, x["arr"], y, 1)
         expected = jax.numpy.array([0.93005586, 0.00498127, -0.88789978]) * y
         assert jax.numpy.allclose(result[0], expected)
         assert jax.numpy.allclose(result[1], expected)


### PR DESCRIPTION
Small fix in the syntax of `jax.vmap` and change to associated test
