### PR TITLE
Fix README image link (to master)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 
 <p align="center">
   The definitive open-source framework for quantum programming. Built by researchers, for research.
-  <img src="https://raw.githubusercontent.com/PennyLaneAI/pennylane/update-readme-image/doc/_static/readme/pl-logo-lightmode.png#gh-light-mode-only" width="700px">
+  <img src="https://raw.githubusercontent.com/PennyLaneAI/pennylane/master/doc/_static/readme/pl-logo-lightmode.png#gh-light-mode-only" width="700px">
     <!--
     Use a relative import for the dark mode image. When loading on PyPI, this
     will fail automatically and show nothing.


### PR DESCRIPTION
**Context:**
- Light mode README hero image currently points to the `update-readme-image` branch, it should point to `master`

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
