### PR TITLE
Update  documentation jax.rst

### DIFF
--- a/doc/introduction/interfaces/jax.rst
+++ b/doc/introduction/interfaces/jax.rst
@@ -176,7 +176,7 @@ Example:
 
         # Device construction should happen inside a `jax.jit` decorated
         # method when using a PRNGKey.
-        dev = qml.device('default.qubit', wires=2, prng_key=key, shots=100)
+        dev = qml.device('default.qubit', wires=2, seed=key, shots=100)
 
 
         @qml.qnode(dev, interface='jax', diff_method=None)


### PR DESCRIPTION
`prng_key` does not exist anymore. `seed` seems to have taken its place
