### PR TITLE
[Exploration] Removing autograd from list of mandatory dependencies

### DIFF
--- a/pennylane/__init__.py
+++ b/pennylane/__init__.py
@@ -18,7 +18,6 @@ PennyLane can be directly imported.
 
 
 from pennylane.boolean_fn import BooleanFn
-import pennylane.numpy
 from pennylane.queuing import QueuingManager, apply
 
 import pennylane.capture

--- a/pennylane/devices/qubit_mixed/apply_operation.py
+++ b/pennylane/devices/qubit_mixed/apply_operation.py
@@ -17,9 +17,10 @@
 from functools import singledispatch
 from string import ascii_letters as alphabet
 
+import numpy as np
+
 import pennylane as qml
 from pennylane import math
-from pennylane import numpy as np
 from pennylane.devices.qubit.apply_operation import _apply_grover_without_matrix
 from pennylane.operation import Channel
 from pennylane.ops.qubit.attributes import diagonal_in_z_basis

--- a/pennylane/devices/qubit_mixed/einsum_manpulation.py
+++ b/pennylane/devices/qubit_mixed/einsum_manpulation.py
@@ -15,9 +15,10 @@
 import functools
 from string import ascii_letters as alphabet
 
+import numpy as np
+
 import pennylane as qml
 from pennylane import math
-from pennylane import numpy as np
 
 alphabet_array = np.array(list(alphabet))
 

--- a/pennylane/devices/qubit_mixed/initialize_state.py
+++ b/pennylane/devices/qubit_mixed/initialize_state.py
@@ -16,8 +16,9 @@
 from collections.abc import Iterable
 from typing import Union
 
+import numpy as np
+
 import pennylane as qml
-import pennylane.numpy as np
 from pennylane import math
 
 
@@ -53,7 +54,7 @@ def create_initial_state(
 
     else:
         pure_state = prep_operation.state_vector(wire_order=list(wires))
-        density_matrix = np.outer(pure_state, np.conj(pure_state))
+        density_matrix = math.outer(pure_state, math.conj(pure_state))
     return _post_process(density_matrix, num_axes, like)
 
 

--- a/pennylane/devices/qutrit_mixed/apply_operation.py
+++ b/pennylane/devices/qutrit_mixed/apply_operation.py
@@ -17,9 +17,10 @@
 from functools import singledispatch
 from string import ascii_letters as alphabet
 
+import numpy as np
+
 import pennylane as qml
 from pennylane import math
-from pennylane import numpy as np
 from pennylane.operation import Channel
 
 from .utils import QUDIT_DIM, get_einsum_mapping, get_new_state_einsum_indices

--- a/pennylane/devices/qutrit_mixed/utils.py
+++ b/pennylane/devices/qutrit_mixed/utils.py
@@ -15,9 +15,10 @@
 import functools
 from string import ascii_letters as alphabet
 
+import numpy as np
+
 import pennylane as qml
 from pennylane import math
-from pennylane import numpy as np
 
 alphabet_array = np.array(list(alphabet))
 QUDIT_DIM = 3  # specifies qudit dimension

--- a/pennylane/gradients/vjp.py
+++ b/pennylane/gradients/vjp.py
@@ -15,7 +15,6 @@
 This module contains functions for computing the vector-Jacobian product
 of tapes.
 """
-import autograd
 
 # pylint: disable=no-member, too-many-branches
 import numpy as np
@@ -120,7 +119,7 @@ def compute_vjp_single(dy, jac, num=None):
     # TODO: Excplictly catalogue and update raises for known types.
 
     # Single measurement with a single param
-    if not isinstance(jac, (tuple, autograd.builtins.SequenceBox)):
+    if type(jac).__name__ != "SequenceBox" and not isinstance(jac, (tuple, list)):
         # No trainable parameters
         if jac.shape == (0,):
             res = qml.math.zeros((1, 0))
@@ -200,7 +199,7 @@ def compute_vjp_multi(dy, jac, num=None):
         return None
 
     # Single parameter
-    if not isinstance(jac[0], (tuple, autograd.builtins.SequenceBox)):
+    if type(jac[0]).__name__ != "SequenceBox" and not isinstance(jac[0], (tuple, list)):
         res = []
         for d, j_ in zip(dy, jac):
             res.append(compute_vjp_single(d, j_, num=num))

--- a/pennylane/math/is_independent.py
+++ b/pennylane/math/is_independent.py
@@ -24,10 +24,6 @@ import warnings
 from functools import partial
 
 import numpy as np
-from autograd.core import VJPNode
-from autograd.tracer import isbox, new_box, trace_stack
-
-from pennylane import numpy as pnp
 
 
 def _autograd_is_indep_analytic(func, *args, **kwargs):
@@ -56,6 +52,9 @@ def _autograd_is_indep_analytic(func, *args, **kwargs):
     <https://github.com/HIPS/autograd/blob/master/autograd/tracer.py#L7>`__.
     """
     # pylint: disable=protected-access
+    from autograd.core import VJPNode
+    from autograd.tracer import isbox, new_box, trace_stack
+
     node = VJPNode.new_root()
     with trace_stack.new_trace() as t:
         start_box = new_box(args, t, node)
@@ -207,7 +206,12 @@ def _get_random_args(args, interface, num, seed, bounds):
         ]
         if interface == "autograd":
             # Mark the arguments as trainable with Autograd
-            rnd_args = [tuple(pnp.array(a, requires_grad=True) for a in arg) for arg in rnd_args]
+            import autograd
+
+            rnd_args = [
+                tuple(autograd.numpy.asarray(a, requires_grad=True) for a in arg)
+                for arg in rnd_args
+            ]
 
     return rnd_args
 

--- a/pennylane/math/multi_dispatch.py
+++ b/pennylane/math/multi_dispatch.py
@@ -19,7 +19,6 @@ from collections.abc import Sequence
 # pylint: disable=wrong-import-order
 import autoray as ar
 import numpy as onp
-from autograd.numpy.numpy_boxes import ArrayBox
 from autoray import numpy as np
 from numpy import ndarray
 
@@ -775,7 +774,9 @@ def unwrap(values, max_depth=None):
         if isinstance(val, (tuple, list)):
             return unwrap(val)
         new_val = (
-            np.to_numpy(val, max_depth=max_depth) if isinstance(val, ArrayBox) else np.to_numpy(val)
+            np.to_numpy(val, max_depth=max_depth)
+            if type(val).__name__ == "ArrayBox"
+            else np.to_numpy(val)
         )
         return new_val.tolist() if isinstance(new_val, ndarray) and not new_val.shape else new_val
 
@@ -783,7 +784,7 @@ def unwrap(values, max_depth=None):
         return type(values)(convert(val) for val in values)
     return (
         np.to_numpy(values, max_depth=max_depth)
-        if isinstance(values, ArrayBox)
+        if type(val).__name__ == "ArrayBox"
         else np.to_numpy(values)
     )
 

--- a/pennylane/math/utils.py
+++ b/pennylane/math/utils.py
@@ -18,7 +18,6 @@ import autoray as ar
 import numpy as _np
 
 # pylint: disable=import-outside-toplevel
-from autograd.numpy.numpy_boxes import ArrayBox
 from autoray import numpy as np
 
 from . import single_dispatch  # pylint:disable=unused-import
@@ -141,7 +140,7 @@ def cast_like(tensor1, tensor2):
     """
     if isinstance(tensor2, tuple) and len(tensor2) > 0:
         tensor2 = tensor2[0]
-    if isinstance(tensor2, ArrayBox):
+    if type(tensor2).__name__ == "ArrayBox":
         dtype = ar.to_numpy(tensor2._value).dtype.type  # pylint: disable=protected-access
     elif not is_abstract(tensor2):
         dtype = ar.to_numpy(tensor2).dtype.type

--- a/pennylane/ops/qubit/matrix_ops.py
+++ b/pennylane/ops/qubit/matrix_ops.py
@@ -24,7 +24,6 @@ import numpy as np
 from scipy.linalg import fractional_matrix_power
 
 import pennylane as qml
-from pennylane import numpy as pnp
 from pennylane.math import cast, conj, eye, norm, sqrt, sqrt_matrix, transpose, zeros
 from pennylane.operation import AnyWires, DecompositionUndefinedError, FlatPytree, Operation
 from pennylane.typing import TensorLike
@@ -546,8 +545,8 @@ class BlockEncode(Operation):
                 shape_a = qml.math.shape(A)
 
             normalization = qml.math.maximum(
-                norm(A @ qml.math.transpose(qml.math.conj(A)), ord=pnp.inf),
-                norm(qml.math.transpose(qml.math.conj(A)) @ A, ord=pnp.inf),
+                norm(A @ qml.math.transpose(qml.math.conj(A)), ord=np.inf),
+                norm(qml.math.transpose(qml.math.conj(A)) @ A, ord=np.inf),
             )
             subspace = (*shape_a, 2 ** len(wires))
 

--- a/pennylane/optimize/momentum_qng.py
+++ b/pennylane/optimize/momentum_qng.py
@@ -15,7 +15,7 @@
 
 # pylint: disable=too-many-branches
 # pylint: disable=too-many-arguments
-from pennylane import numpy as pnp
+from pennylane import math
 
 from .qng import QNGOptimizer, _flatten_np, _unflatten_np
 
@@ -120,7 +120,7 @@ class MomentumQNGOptimizer(QNGOptimizer):
         args_new = list(args)
 
         if self.accumulation is None:
-            self.accumulation = [pnp.zeros_like(g) for g in grad]
+            self.accumulation = [math.zeros_like(g) for g in grad]
 
         metric_tensor = (
             self.metric_tensor if isinstance(self.metric_tensor, tuple) else (self.metric_tensor,)
@@ -130,9 +130,9 @@ class MomentumQNGOptimizer(QNGOptimizer):
 
         for index, arg in enumerate(args):
             if getattr(arg, "requires_grad", False):
-                grad_flat = pnp.array(list(_flatten_np(grad[trained_index])))
+                grad_flat = math.asarray(list(_flatten_np(grad[trained_index])), like="autograd")
                 # self.metric_tensor has already been reshaped to 2D, matching flat gradient.
-                qng_update = pnp.linalg.pinv(metric_tensor[trained_index]) @ grad_flat
+                qng_update = math.linalg.pinv(metric_tensor[trained_index]) @ grad_flat
 
                 self.accumulation[trained_index] *= self.momentum
                 self.accumulation[trained_index] += self.stepsize * _unflatten_np(

--- a/pennylane/pytrees/pytrees.py
+++ b/pennylane/pytrees/pytrees.py
@@ -18,8 +18,6 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any, Optional
 
-import autograd
-
 import pennylane.queuing
 
 has_jax = True
@@ -296,19 +294,24 @@ def _unflatten(new_data, structure):
     return unflatten_registrations[structure.type_](children, structure.metadata)
 
 
-# pylint: disable=no-member
-register_pytree(
-    autograd.builtins.list,
-    lambda obj: (list(obj), ()),
-    lambda data, _: autograd.builtins.list(data),
-)
-register_pytree(
-    autograd.builtins.tuple,
-    lambda obj: (list(obj), ()),
-    lambda data, _: autograd.builtins.tuple(data),
-)
-register_pytree(
-    autograd.builtins.SequenceBox,
-    lambda obj: (list(obj), ()),
-    lambda data, _: autograd.builtins.SequenceBox(data),
-)
+import contextlib
+
+with contextlib.suppress(ImportError):
+    import autograd
+
+    # pylint: disable=no-member
+    register_pytree(
+        autograd.builtins.list,
+        lambda obj: (list(obj), ()),
+        lambda data, _: autograd.builtins.list(data),
+    )
+    register_pytree(
+        autograd.builtins.tuple,
+        lambda obj: (list(obj), ()),
+        lambda data, _: autograd.builtins.tuple(data),
+    )
+    register_pytree(
+        autograd.builtins.SequenceBox,
+        lambda obj: (list(obj), ()),
+        lambda data, _: autograd.builtins.SequenceBox(data),
+    )

--- a/pennylane/qchem/convert_openfermion.py
+++ b/pennylane/qchem/convert_openfermion.py
@@ -20,7 +20,6 @@ from typing import Union
 
 # pylint: disable= import-outside-toplevel,no-member,unused-import
 import pennylane as qml
-from pennylane import numpy as np
 from pennylane.fermi.fermionic import FermiSentence, FermiWord
 from pennylane.ops import LinearCombination, Sum
 from pennylane.qchem.convert import _openfermion_to_pennylane, _pennylane_to_openfermion
@@ -155,7 +154,9 @@ def _to_openfermion_dispatch(pl_op, wires=None, tol=1.0e-16):
 @_to_openfermion_dispatch.register
 def _(pl_op: Sum, wires=None, tol=1.0e-16):
     coeffs, ops = pl_op.terms()
-    return _pennylane_to_openfermion(np.array(coeffs), ops, wires=wires, tol=tol)
+    return _pennylane_to_openfermion(
+        qml.math.asarray(coeffs, like="autograd"), ops, wires=wires, tol=tol
+    )
 
 
 # pylint: disable=unused-argument, protected-access
@@ -178,7 +179,7 @@ def _(pl_op: FermiSentence, wires=None, tol=1.0e-16):
 
     fermion_op = openfermion.ops.FermionOperator()
     for fermi_word in pl_op:
-        if np.abs(pl_op[fermi_word].imag) < tol:
+        if qml.math.abs(pl_op[fermi_word].imag) < tol:
             fermion_op += pl_op[fermi_word].real * to_openfermion(fermi_word)
         else:
             fermion_op += pl_op[fermi_word] * to_openfermion(fermi_word)

--- a/pennylane/wires.py
+++ b/pennylane/wires.py
@@ -32,9 +32,12 @@ else:
     jax_available = False
     jax = None
 
-if jax_available:
-    # pylint: disable=unnecessary-lambda
-    setattr(jax.interpreters.partial_eval.DynamicJaxprTracer, "__hash__", lambda x: id(x))
+try:
+    if jax_available:
+        # pylint: disable=unnecessary-lambda
+        setattr(jax.interpreters.partial_eval.DynamicJaxprTracer, "__hash__", lambda x: id(x))
+except AttributeError:
+    pass
 
 
 class WireError(Exception):

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ requirements = [
     "scipy",
     "networkx",
     "rustworkx>=0.14.0",
-    "autograd",
     "tomlkit",
     "appdirs",
     "autoray>=0.6.11",


### PR DESCRIPTION
**Context:**

We are wanting to downgrade the priority given autograd, given the package is no longer maintained and has fewer features than the other interfaces. One way to do this is by making autograd an optional dependency, that must be installed by the user.

**Description of the Change:**

This prototype creates a version of pennylane where `autograd` is no longer a mandatory dependency.  The version right now is rather rough and clunky, but we are able to use pennylane without autograd being installed.

**Benefits:**

**Possible Drawbacks:**

Making the CI work might be a nightmare. Actually, it will very likely be nightmare.

**Related GitHub Issues:**
