### PR TITLE
Rename `qml.numpy` from `np` to `pnp`

### DIFF
--- a/pennylane/devices/qubit_mixed/apply_operation.py
+++ b/pennylane/devices/qubit_mixed/apply_operation.py
@@ -19,14 +19,14 @@ from string import ascii_letters as alphabet
 
 import pennylane as qml
 from pennylane import math
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane.devices.qubit.apply_operation import _apply_grover_without_matrix
 from pennylane.operation import Channel
 from pennylane.ops.qubit.attributes import diagonal_in_z_basis
 
 from .einsum_manpulation import get_einsum_mapping
 
-alphabet_array = np.array(list(alphabet))
+alphabet_array = pnp.array(list(alphabet))
 
 TENSORDOT_STATE_NDIM_PERF_THRESHOLD = 9
 
@@ -440,11 +440,11 @@ def apply_T(op: qml.T, state, is_state_batched: bool = False, debugger=None, **_
 
     # First, flip the left side
     axis = op.wires[0] + is_state_batched
-    state = _phase_shift(state, axis, phase_factor=math.exp(0.25j * np.pi))
+    state = _phase_shift(state, axis, phase_factor=math.exp(0.25j * pnp.pi))
 
     # Second, flip the right side
     axis = op.wires[0] + is_state_batched + num_wires
-    state = _phase_shift(state, axis, phase_factor=math.exp(-0.25j * np.pi))
+    state = _phase_shift(state, axis, phase_factor=math.exp(-0.25j * pnp.pi))
 
     return state
 

--- a/pennylane/devices/qubit_mixed/einsum_manpulation.py
+++ b/pennylane/devices/qubit_mixed/einsum_manpulation.py
@@ -17,9 +17,9 @@ from string import ascii_letters as alphabet
 
 import pennylane as qml
 from pennylane import math
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 
-alphabet_array = np.array(list(alphabet))
+alphabet_array = pnp.array(list(alphabet))
 
 
 def get_einsum_mapping(

--- a/pennylane/devices/qubit_mixed/initialize_state.py
+++ b/pennylane/devices/qubit_mixed/initialize_state.py
@@ -17,7 +17,7 @@ from collections.abc import Iterable
 from typing import Union
 
 import pennylane as qml
-import pennylane.numpy as np
+import pennylane.numpy as pnp
 from pennylane import math
 
 
@@ -44,7 +44,7 @@ def create_initial_state(
         2 * num_wires
     )  # we initialize the density matrix as the tensor form to keep compatibility with the rest of the module
     if not prep_operation:
-        state = np.zeros((2,) * num_axes, dtype=complex)
+        state = pnp.zeros((2,) * num_axes, dtype=complex)
         state[(0,) * num_axes] = 1
         return math.asarray(state, like=like)
 
@@ -53,7 +53,7 @@ def create_initial_state(
 
     else:
         pure_state = prep_operation.state_vector(wire_order=list(wires))
-        density_matrix = np.outer(pure_state, np.conj(pure_state))
+        density_matrix = pnp.outer(pure_state, pnp.conj(pure_state))
     return _post_process(density_matrix, num_axes, like)
 
 
@@ -61,7 +61,7 @@ def _post_process(density_matrix, num_axes, like):
     r"""
     This post processor is necessary to ensure that the density matrix is in the correct format, i.e. the original tensor form, instead of the pure matrix form, as requested by all the other more fundamental chore functions in the module (again from some legacy code).
     """
-    density_matrix = np.reshape(density_matrix, (2,) * num_axes)
+    density_matrix = pnp.reshape(density_matrix, (2,) * num_axes)
     dtype = str(density_matrix.dtype)
     floating_single = "float32" in dtype or "complex64" in dtype
     dtype = "complex64" if floating_single else "complex128"

--- a/pennylane/devices/qutrit_mixed/apply_operation.py
+++ b/pennylane/devices/qutrit_mixed/apply_operation.py
@@ -19,12 +19,12 @@ from string import ascii_letters as alphabet
 
 import pennylane as qml
 from pennylane import math
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane.operation import Channel
 
 from .utils import QUDIT_DIM, get_einsum_mapping, get_new_state_einsum_indices
 
-alphabet_array = np.array(list(alphabet))
+alphabet_array = pnp.array(list(alphabet))
 
 
 def _map_indices_apply_channel(**kwargs):

--- a/pennylane/devices/qutrit_mixed/utils.py
+++ b/pennylane/devices/qutrit_mixed/utils.py
@@ -17,9 +17,9 @@ from string import ascii_letters as alphabet
 
 import pennylane as qml
 from pennylane import math
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 
-alphabet_array = np.array(list(alphabet))
+alphabet_array = pnp.array(list(alphabet))
 QUDIT_DIM = 3  # specifies qudit dimension
 
 

--- a/pennylane/devices/tests/test_measurements.py
+++ b/pennylane/devices/tests/test_measurements.py
@@ -18,7 +18,7 @@ from flaky import flaky
 from scipy.sparse import csr_matrix
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane.measurements import (
     ClassicalShadowMP,
     MeasurementTransform,
@@ -41,7 +41,7 @@ obs = {
     "Identity": qml.Identity(wires=[0]),
     "Hadamard": qml.Hadamard(wires=[0]),
     "H": qml.H(wires=[0]),
-    "Hermitian": qml.Hermitian(np.eye(2), wires=[0]),
+    "Hermitian": qml.Hermitian(pnp.eye(2), wires=[0]),
     "PauliX": qml.PauliX(0),
     "PauliY": qml.PauliY(0),
     "PauliZ": qml.PauliZ(0),
@@ -49,10 +49,10 @@ obs = {
     "Y": qml.Y(0),
     "Z": qml.Z(0),
     "Projector": [
-        qml.Projector(np.array([1]), wires=[0]),
-        qml.Projector(np.array([0, 1]), wires=[0]),
+        qml.Projector(pnp.array([1]), wires=[0]),
+        qml.Projector(pnp.array([0, 1]), wires=[0]),
     ],
-    "SparseHamiltonian": qml.SparseHamiltonian(csr_matrix(np.eye(8)), wires=[0, 1, 2]),
+    "SparseHamiltonian": qml.SparseHamiltonian(csr_matrix(pnp.eye(8)), wires=[0, 1, 2]),
     "Prod": qml.prod(qml.X(0), qml.Z(1)),
     "SProd": qml.s_prod(0.1, qml.Z(0)),
     "Sum": qml.sum(qml.s_prod(0.1, qml.Z(0)), qml.prod(qml.X(0), qml.Z(1))),
@@ -76,7 +76,7 @@ if not set(all_obs) == all_available_obs | {"LinearCombination"}:
     )
 
 # single qubit Hermitian observable
-A = np.array([[1.02789352, 1.61296440 - 0.3498192j], [1.61296440 + 0.3498192j, 1.23920938 + 0j]])
+A = pnp.array([[1.02789352, 1.61296440 - 0.3498192j], [1.61296440 + 0.3498192j, 1.23920938 + 0j]])
 
 obs_lst = [
     qml.X(0) @ qml.Y(1),
@@ -132,9 +132,9 @@ class TestSupportedObservables:
 
         if observable == "Projector":
             for o in obs[observable]:
-                assert isinstance(circuit(o), (float, np.ndarray))
+                assert isinstance(circuit(o), (float, pnp.ndarray))
         else:
-            assert isinstance(circuit(obs[observable]), (float, np.ndarray))
+            assert isinstance(circuit(obs[observable]), (float, pnp.ndarray))
 
     def test_tensor_observables_can_be_implemented(self, device_kwargs):
         """Test that the device can implement a simple tensor observable.
@@ -152,7 +152,7 @@ class TestSupportedObservables:
             qml.PauliX(0)
             return qml.expval(qml.Identity(wires=0) @ qml.Identity(wires=1))
 
-        assert isinstance(circuit(), (float, np.ndarray))
+        assert isinstance(circuit(), (float, pnp.ndarray))
 
 
 # pylint: disable=too-few-public-methods
@@ -165,8 +165,8 @@ class TestHamiltonianSupport:
 
         device_kwargs["wires"] = 1
         dev = qml.device(**device_kwargs)
-        coeffs = np.array([-0.05, 0.17])
-        param = np.array(1.7, requires_grad=True)
+        coeffs = pnp.array([-0.05, 0.17])
+        param = pnp.array(1.7, requires_grad=True)
 
         @qml.qnode(dev, diff_method="parameter-shift")
         def circuit(coeffs, param):
@@ -203,8 +203,8 @@ class TestHamiltonianSupport:
         grad_fn_expected = qml.grad(combine)
         grad_expected = grad_fn_expected(coeffs, param)
 
-        assert np.allclose(grad[0], grad_expected[0], atol=tol(dev.shots))
-        assert np.allclose(grad[1], grad_expected[1], atol=tol(dev.shots))
+        assert pnp.allclose(grad[0], grad_expected[0], atol=tol(dev.shots))
+        assert pnp.allclose(grad[1], grad_expected[1], atol=tol(dev.shots))
 
 
 @flaky(max_runs=10)
@@ -227,7 +227,7 @@ class TestExpval:
             return qml.expval(qml.Identity(wires=0)), qml.expval(qml.Identity(wires=1))
 
         res = circuit()
-        assert np.allclose(res, np.array([1, 1]), atol=tol(dev.shots))
+        assert pnp.allclose(res, pnp.array([1, 1]), atol=tol(dev.shots))
 
     def test_pauliz_expectation(self, device, tol):
         """Test that PauliZ expectation value is correct"""
@@ -245,8 +245,8 @@ class TestExpval:
             return qml.expval(qml.Z(0)), qml.expval(qml.Z(1))
 
         res = circuit()
-        expected = np.array([np.cos(theta), np.cos(theta) * np.cos(phi)])
-        assert np.allclose(res, expected, atol=tol(dev.shots))
+        expected = pnp.array([pnp.cos(theta), pnp.cos(theta) * pnp.cos(phi)])
+        assert pnp.allclose(res, expected, atol=tol(dev.shots))
 
     def test_paulix_expectation(self, device, tol):
         """Test that PauliX expectation value is correct"""
@@ -264,8 +264,8 @@ class TestExpval:
             return qml.expval(qml.X(0)), qml.expval(qml.X(1))
 
         res = circuit()
-        expected = np.array([np.sin(theta) * np.sin(phi), np.sin(phi)])
-        assert np.allclose(res, expected, atol=tol(dev.shots))
+        expected = pnp.array([pnp.sin(theta) * pnp.sin(phi), pnp.sin(phi)])
+        assert pnp.allclose(res, expected, atol=tol(dev.shots))
 
     def test_pauliy_expectation(self, device, tol):
         """Test that PauliY expectation value is correct"""
@@ -283,8 +283,8 @@ class TestExpval:
             return qml.expval(qml.Y(0)), qml.expval(qml.Y(1))
 
         res = circuit()
-        expected = np.array([0.0, -np.cos(theta) * np.sin(phi)])
-        assert np.allclose(res, expected, atol=tol(dev.shots))
+        expected = pnp.array([0.0, -pnp.cos(theta) * pnp.sin(phi)])
+        assert pnp.allclose(res, expected, atol=tol(dev.shots))
 
     def test_hadamard_expectation(self, device, tol):
         """Test that Hadamard expectation value is correct"""
@@ -302,10 +302,10 @@ class TestExpval:
             return qml.expval(qml.Hadamard(wires=0)), qml.expval(qml.Hadamard(wires=1))
 
         res = circuit()
-        expected = np.array(
-            [np.sin(theta) * np.sin(phi) + np.cos(theta), np.cos(theta) * np.cos(phi) + np.sin(phi)]
-        ) / np.sqrt(2)
-        assert np.allclose(res, expected, atol=tol(dev.shots))
+        expected = pnp.array(
+            [pnp.sin(theta) * pnp.sin(phi) + pnp.cos(theta), pnp.cos(theta) * pnp.cos(phi) + pnp.sin(phi)]
+        ) / pnp.sqrt(2)
+        assert pnp.allclose(res, expected, atol=tol(dev.shots))
 
     def test_hermitian_expectation(self, device, tol):
         """Test that arbitrary Hermitian expectation values are correct"""
@@ -330,11 +330,11 @@ class TestExpval:
         a = A[0, 0]
         re_b = A[0, 1].real
         d = A[1, 1]
-        ev1 = ((a - d) * np.cos(theta) + 2 * re_b * np.sin(theta) * np.sin(phi) + a + d) / 2
-        ev2 = ((a - d) * np.cos(theta) * np.cos(phi) + 2 * re_b * np.sin(phi) + a + d) / 2
-        expected = np.array([ev1, ev2])
+        ev1 = ((a - d) * pnp.cos(theta) + 2 * re_b * pnp.sin(theta) * pnp.sin(phi) + a + d) / 2
+        ev2 = ((a - d) * pnp.cos(theta) * pnp.cos(phi) + 2 * re_b * pnp.sin(phi) + a + d) / 2
+        expected = pnp.array([ev1, ev2])
 
-        assert np.allclose(res, expected, atol=tol(dev.shots))
+        assert pnp.allclose(res, expected, atol=tol(dev.shots))
 
     def test_projector_expectation(self, device, tol):
         """Test that arbitrary Projector expectation values are correct"""
@@ -355,24 +355,24 @@ class TestExpval:
             return qml.expval(qml.Projector(state, wires=[0, 1]))
 
         basis_state, state_vector = [0, 0], [1, 0, 0, 0]
-        expected = (np.cos(phi / 2) * np.cos(theta / 2)) ** 2
-        assert np.allclose(circuit(basis_state), expected, atol=tol(dev.shots))
-        assert np.allclose(circuit(state_vector), expected, atol=tol(dev.shots))
+        expected = (pnp.cos(phi / 2) * pnp.cos(theta / 2)) ** 2
+        assert pnp.allclose(circuit(basis_state), expected, atol=tol(dev.shots))
+        assert pnp.allclose(circuit(state_vector), expected, atol=tol(dev.shots))
 
         basis_state, state_vector = [0, 1], [0, 1, 0, 0]
-        expected = (np.sin(phi / 2) * np.cos(theta / 2)) ** 2
-        assert np.allclose(circuit(basis_state), expected, atol=tol(dev.shots))
-        assert np.allclose(circuit(state_vector), expected, atol=tol(dev.shots))
+        expected = (pnp.sin(phi / 2) * pnp.cos(theta / 2)) ** 2
+        assert pnp.allclose(circuit(basis_state), expected, atol=tol(dev.shots))
+        assert pnp.allclose(circuit(state_vector), expected, atol=tol(dev.shots))
 
         basis_state, state_vector = [1, 0], [0, 0, 1, 0]
-        expected = (np.sin(phi / 2) * np.sin(theta / 2)) ** 2
-        assert np.allclose(circuit(basis_state), expected, atol=tol(dev.shots))
-        assert np.allclose(circuit(state_vector), expected, atol=tol(dev.shots))
+        expected = (pnp.sin(phi / 2) * pnp.sin(theta / 2)) ** 2
+        assert pnp.allclose(circuit(basis_state), expected, atol=tol(dev.shots))
+        assert pnp.allclose(circuit(state_vector), expected, atol=tol(dev.shots))
 
         basis_state, state_vector = [1, 1], [0, 0, 0, 1]
-        expected = (np.cos(phi / 2) * np.sin(theta / 2)) ** 2
-        assert np.allclose(circuit(basis_state), expected, atol=tol(dev.shots))
-        assert np.allclose(circuit(state_vector), expected, atol=tol(dev.shots))
+        expected = (pnp.cos(phi / 2) * pnp.sin(theta / 2)) ** 2
+        assert pnp.allclose(circuit(basis_state), expected, atol=tol(dev.shots))
+        assert pnp.allclose(circuit(state_vector), expected, atol=tol(dev.shots))
 
     def test_multi_mode_hermitian_expectation(self, device, tol):
         """Test that arbitrary multi-mode Hermitian expectation values are correct"""
@@ -384,7 +384,7 @@ class TestExpval:
 
         theta = 0.432
         phi = 0.123
-        A_ = np.array(
+        A_ = pnp.array(
             [
                 [-6, 2 + 1j, -3, -5 + 2j],
                 [2 - 1j, 0, 2 - 1j, -5 + 4j],
@@ -405,14 +405,14 @@ class TestExpval:
         # below is the analytic expectation value for this circuit with arbitrary
         # Hermitian observable A
         expected = 0.5 * (
-            6 * np.cos(theta) * np.sin(phi)
-            - np.sin(theta) * (8 * np.sin(phi) + 7 * np.cos(phi) + 3)
-            - 2 * np.sin(phi)
-            - 6 * np.cos(phi)
+            6 * pnp.cos(theta) * pnp.sin(phi)
+            - pnp.sin(theta) * (8 * pnp.sin(phi) + 7 * pnp.cos(phi) + 3)
+            - 2 * pnp.sin(phi)
+            - 6 * pnp.cos(phi)
             - 6
         )
 
-        assert np.allclose(res, expected, atol=tol(dev.shots))
+        assert pnp.allclose(res, expected, atol=tol(dev.shots))
 
     @pytest.mark.parametrize(
         "o",
@@ -436,7 +436,7 @@ class TestExpval:
         res_dq = qml.QNode(circuit, qml.device("default.qubit"))()
         res = qml.QNode(circuit, dev)()
         assert qml.math.shape(res) == ()
-        assert np.isclose(res, res_dq, atol=tol(dev.shots))
+        assert pnp.isclose(res, res_dq, atol=tol(dev.shots))
 
 
 @flaky(max_runs=10)
@@ -465,8 +465,8 @@ class TestTensorExpval:
 
         res = circuit()
 
-        expected = np.sin(theta) * np.sin(phi) * np.sin(varphi)
-        assert np.allclose(res, expected, atol=tol(dev.shots))
+        expected = pnp.sin(theta) * pnp.sin(phi) * pnp.sin(varphi)
+        assert pnp.allclose(res, expected, atol=tol(dev.shots))
 
     def test_pauliz_hadamard(self, device, tol, skip_if):
         """Test that a tensor product involving PauliZ and PauliY and hadamard works correctly"""
@@ -490,8 +490,8 @@ class TestTensorExpval:
 
         res = circuit()
 
-        expected = -(np.cos(varphi) * np.sin(phi) + np.sin(varphi) * np.cos(theta)) / np.sqrt(2)
-        assert np.allclose(res, expected, atol=tol(dev.shots))
+        expected = -(pnp.cos(varphi) * pnp.sin(phi) + pnp.sin(varphi) * pnp.cos(theta)) / pnp.sqrt(2)
+        assert pnp.allclose(res, expected, atol=tol(dev.shots))
 
     # pylint: disable=too-many-arguments
     @pytest.mark.parametrize(
@@ -524,7 +524,7 @@ class TestTensorExpval:
             sub_routine(label_map=range(3))
             return qml.expval(ob)
 
-        assert np.allclose(circ(base_obs), circ(permuted_obs), atol=tol(dev.shots), rtol=0)
+        assert pnp.allclose(circ(base_obs), circ(permuted_obs), atol=tol(dev.shots), rtol=0)
 
     @pytest.mark.parametrize("label_map", label_maps)
     def test_wire_label_in_tensor_prod_observables(self, device, label_map, tol, skip_if):
@@ -554,7 +554,7 @@ class TestTensorExpval:
         circ_base_label = qml.QNode(circ, device=dev)
         circ_custom_label = qml.QNode(circ, device=dev_custom_labels)
 
-        assert np.allclose(
+        assert pnp.allclose(
             circ_base_label(wire_labels=range(3)),
             circ_custom_label(wire_labels=label_map),
             atol=tol(dev.shots),
@@ -575,7 +575,7 @@ class TestTensorExpval:
         theta = 0.432
         phi = 0.123
         varphi = -0.543
-        A_ = np.array(
+        A_ = pnp.array(
             [
                 [-6, 2 + 1j, -3, -5 + 2j],
                 [2 - 1j, 0, 2 - 1j, -5 + 4j],
@@ -596,12 +596,12 @@ class TestTensorExpval:
         res = circuit()
 
         expected = 0.5 * (
-            -6 * np.cos(theta) * (np.cos(varphi) + 1)
-            - 2 * np.sin(varphi) * (np.cos(theta) + np.sin(phi) - 2 * np.cos(phi))
-            + 3 * np.cos(varphi) * np.sin(phi)
-            + np.sin(phi)
+            -6 * pnp.cos(theta) * (pnp.cos(varphi) + 1)
+            - 2 * pnp.sin(varphi) * (pnp.cos(theta) + pnp.sin(phi) - 2 * pnp.cos(phi))
+            + 3 * pnp.cos(varphi) * pnp.sin(phi)
+            + pnp.sin(phi)
         )
-        assert np.allclose(res, expected, atol=tol(dev.shots))
+        assert pnp.allclose(res, expected, atol=tol(dev.shots))
 
     def test_projector(self, device, tol, skip_if):
         """Test that a tensor product involving qml.Projector works correctly"""
@@ -628,32 +628,32 @@ class TestTensorExpval:
             return qml.expval(qml.Z(0) @ qml.Projector(state, wires=[1, 2]))
 
         basis_state, state_vector = [0, 0], [1, 0, 0, 0]
-        expected = (np.cos(varphi / 2) * np.cos(phi / 2) * np.cos(theta / 2)) ** 2 - (
-            np.cos(varphi / 2) * np.sin(phi / 2) * np.sin(theta / 2)
+        expected = (pnp.cos(varphi / 2) * pnp.cos(phi / 2) * pnp.cos(theta / 2)) ** 2 - (
+            pnp.cos(varphi / 2) * pnp.sin(phi / 2) * pnp.sin(theta / 2)
         ) ** 2
-        assert np.allclose(circuit(basis_state), expected, atol=tol(dev.shots))
-        assert np.allclose(circuit(state_vector), expected, atol=tol(dev.shots))
+        assert pnp.allclose(circuit(basis_state), expected, atol=tol(dev.shots))
+        assert pnp.allclose(circuit(state_vector), expected, atol=tol(dev.shots))
 
         basis_state, state_vector = [0, 1], [0, 1, 0, 0]
-        expected = (np.sin(varphi / 2) * np.cos(phi / 2) * np.cos(theta / 2)) ** 2 - (
-            np.sin(varphi / 2) * np.sin(phi / 2) * np.sin(theta / 2)
+        expected = (pnp.sin(varphi / 2) * pnp.cos(phi / 2) * pnp.cos(theta / 2)) ** 2 - (
+            pnp.sin(varphi / 2) * pnp.sin(phi / 2) * pnp.sin(theta / 2)
         ) ** 2
-        assert np.allclose(circuit(basis_state), expected, atol=tol(dev.shots))
-        assert np.allclose(circuit(state_vector), expected, atol=tol(dev.shots))
+        assert pnp.allclose(circuit(basis_state), expected, atol=tol(dev.shots))
+        assert pnp.allclose(circuit(state_vector), expected, atol=tol(dev.shots))
 
         basis_state, state_vector = [1, 0], [0, 0, 1, 0]
-        expected = (np.sin(varphi / 2) * np.sin(phi / 2) * np.cos(theta / 2)) ** 2 - (
-            np.sin(varphi / 2) * np.cos(phi / 2) * np.sin(theta / 2)
+        expected = (pnp.sin(varphi / 2) * pnp.sin(phi / 2) * pnp.cos(theta / 2)) ** 2 - (
+            pnp.sin(varphi / 2) * pnp.cos(phi / 2) * pnp.sin(theta / 2)
         ) ** 2
-        assert np.allclose(circuit(basis_state), expected, atol=tol(dev.shots))
-        assert np.allclose(circuit(state_vector), expected, atol=tol(dev.shots))
+        assert pnp.allclose(circuit(basis_state), expected, atol=tol(dev.shots))
+        assert pnp.allclose(circuit(state_vector), expected, atol=tol(dev.shots))
 
         basis_state, state_vector = [1, 1], [0, 0, 0, 1]
-        expected = (np.cos(varphi / 2) * np.sin(phi / 2) * np.cos(theta / 2)) ** 2 - (
-            np.cos(varphi / 2) * np.cos(phi / 2) * np.sin(theta / 2)
+        expected = (pnp.cos(varphi / 2) * pnp.sin(phi / 2) * pnp.cos(theta / 2)) ** 2 - (
+            pnp.cos(varphi / 2) * pnp.cos(phi / 2) * pnp.sin(theta / 2)
         ) ** 2
-        assert np.allclose(circuit(basis_state), expected, atol=tol(dev.shots))
-        assert np.allclose(circuit(state_vector), expected, atol=tol(dev.shots))
+        assert pnp.allclose(circuit(basis_state), expected, atol=tol(dev.shots))
+        assert pnp.allclose(circuit(state_vector), expected, atol=tol(dev.shots))
 
     def test_sparse_hamiltonian_expval(self, device, tol):
         """Test that expectation values of sparse Hamiltonians are properly calculated."""
@@ -668,10 +668,10 @@ class TestTensorExpval:
         if dev.shots:
             pytest.skip("SparseHamiltonian only supported in analytic mode")
 
-        h_row = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
-        h_col = np.array([15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0])
-        h_data = np.array(
-            [-1, 1, 1, -1, -1, 1, 1, -1, -1, 1, 1, -1, -1, 1, 1, -1], dtype=np.complex128
+        h_row = pnp.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
+        h_col = pnp.array([15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0])
+        h_data = pnp.array(
+            [-1, 1, 1, -1, -1, 1, 1, -1, -1, 1, 1, -1, -1, 1, 1, -1], dtype=pnp.complex128
         )
         h = csr_matrix((h_data, (h_row, h_col)), shape=(16, 16))  # XXYY
 
@@ -686,7 +686,7 @@ class TestTensorExpval:
 
         res = result()
         exp_res = 0.019833838076209875
-        assert np.allclose(res, exp_res, atol=tol(False))
+        assert pnp.allclose(res, exp_res, atol=tol(False))
 
 
 @flaky(max_runs=10)
@@ -730,7 +730,7 @@ class TestSample:
         res = circuit()
 
         # res should only contain 1 and -1
-        assert np.allclose(res**2, 1, atol=tol(False))
+        assert pnp.allclose(res**2, 1, atol=tol(False))
 
     def test_sample_values_hermitian(self, device, tol):
         """Tests if the samples of a Hermitian observable returned by sample have
@@ -745,7 +745,7 @@ class TestSample:
         if isinstance(dev, qml.devices.LegacyDevice) and "Hermitian" not in dev.observables:
             pytest.skip("Skipped because device does not support the Hermitian observable.")
 
-        A_ = np.array([[1, 2j], [-2j, 0]])
+        A_ = pnp.array([[1, 2j], [-2j, 0]])
         theta = 0.543
 
         @qml.qnode(dev)
@@ -757,15 +757,15 @@ class TestSample:
 
         # res should only contain the eigenvalues of
         # the hermitian matrix
-        eigvals = np.linalg.eigvalsh(A_)
-        assert np.allclose(sorted(list(set(res.tolist()))), sorted(eigvals), atol=tol(dev.shots))
+        eigvals = pnp.linalg.eigvalsh(A_)
+        assert pnp.allclose(sorted(list(set(res.tolist()))), sorted(eigvals), atol=tol(dev.shots))
         # the analytic mean is 2*sin(theta)+0.5*cos(theta)+0.5
-        assert np.allclose(
-            np.mean(res), 2 * np.sin(theta) + 0.5 * np.cos(theta) + 0.5, atol=tol(False)
+        assert pnp.allclose(
+            pnp.mean(res), 2 * pnp.sin(theta) + 0.5 * pnp.cos(theta) + 0.5, atol=tol(False)
         )
         # the analytic variance is 0.25*(sin(theta)-4*cos(theta))^2
-        assert np.allclose(
-            np.var(res), 0.25 * (np.sin(theta) - 4 * np.cos(theta)) ** 2, atol=tol(False)
+        assert pnp.allclose(
+            pnp.var(res), 0.25 * (pnp.sin(theta) - 4 * pnp.cos(theta)) ** 2, atol=tol(False)
         )
 
     def test_sample_values_projector(self, device, tol):
@@ -788,33 +788,33 @@ class TestSample:
             qml.RX(theta, wires=[0])
             return qml.sample(qml.Projector(state, wires=0))
 
-        expected = np.cos(theta / 2) ** 2
+        expected = pnp.cos(theta / 2) ** 2
         res_basis = circuit([0]).flatten()
         res_state = circuit([1, 0]).flatten()
         # res should only contain 0 or 1, the eigenvalues of the projector
-        assert np.allclose(sorted(list(set(res_basis.tolist()))), [0, 1], atol=tol(dev.shots))
-        assert np.allclose(sorted(list(set(res_state.tolist()))), [0, 1], atol=tol(dev.shots))
-        assert np.allclose(np.mean(res_basis), expected, atol=tol(False))
-        assert np.allclose(np.mean(res_state), expected, atol=tol(False))
-        assert np.allclose(np.var(res_basis), expected - (expected) ** 2, atol=tol(False))
-        assert np.allclose(np.var(res_state), expected - (expected) ** 2, atol=tol(False))
+        assert pnp.allclose(sorted(list(set(res_basis.tolist()))), [0, 1], atol=tol(dev.shots))
+        assert pnp.allclose(sorted(list(set(res_state.tolist()))), [0, 1], atol=tol(dev.shots))
+        assert pnp.allclose(pnp.mean(res_basis), expected, atol=tol(False))
+        assert pnp.allclose(pnp.mean(res_state), expected, atol=tol(False))
+        assert pnp.allclose(pnp.var(res_basis), expected - (expected) ** 2, atol=tol(False))
+        assert pnp.allclose(pnp.var(res_state), expected - (expected) ** 2, atol=tol(False))
 
-        expected = np.sin(theta / 2) ** 2
+        expected = pnp.sin(theta / 2) ** 2
         res_basis = circuit([1]).flatten()
         res_state = circuit([0, 1]).flatten()
         # res should only contain 0 or 1, the eigenvalues of the projector
-        assert np.allclose(sorted(list(set(res_basis.tolist()))), [0, 1], atol=tol(dev.shots))
-        assert np.allclose(sorted(list(set(res_state.tolist()))), [0, 1], atol=tol(dev.shots))
-        assert np.allclose(np.mean(res_basis), expected, atol=tol(False))
-        assert np.allclose(np.mean(res_state), expected, atol=tol(False))
-        assert np.allclose(np.var(res_basis), expected - (expected) ** 2, atol=tol(False))
-        assert np.allclose(np.var(res_state), expected - (expected) ** 2, atol=tol(False))
+        assert pnp.allclose(sorted(list(set(res_basis.tolist()))), [0, 1], atol=tol(dev.shots))
+        assert pnp.allclose(sorted(list(set(res_state.tolist()))), [0, 1], atol=tol(dev.shots))
+        assert pnp.allclose(pnp.mean(res_basis), expected, atol=tol(False))
+        assert pnp.allclose(pnp.mean(res_state), expected, atol=tol(False))
+        assert pnp.allclose(pnp.var(res_basis), expected - (expected) ** 2, atol=tol(False))
+        assert pnp.allclose(pnp.var(res_state), expected - (expected) ** 2, atol=tol(False))
 
         expected = 0.5
-        res = circuit(np.array([1, 1]) / np.sqrt(2)).flatten()
-        assert np.allclose(sorted(list(set(res.tolist()))), [0, 1], atol=tol(dev.shots))
-        assert np.allclose(np.mean(res), expected, atol=tol(False))
-        assert np.allclose(np.var(res), expected - (expected) ** 2, atol=tol(False))
+        res = circuit(pnp.array([1, 1]) / pnp.sqrt(2)).flatten()
+        assert pnp.allclose(sorted(list(set(res.tolist()))), [0, 1], atol=tol(dev.shots))
+        assert pnp.allclose(pnp.mean(res), expected, atol=tol(False))
+        assert pnp.allclose(pnp.var(res), expected - (expected) ** 2, atol=tol(False))
 
     def test_sample_values_hermitian_multi_qubit(self, device, tol):
         """Tests if the samples of a multi-qubit Hermitian observable returned by sample have
@@ -830,7 +830,7 @@ class TestSample:
             pytest.skip("Skipped because device does not support the Hermitian observable.")
 
         theta = 0.543
-        A_ = np.array(
+        A_ = pnp.array(
             [
                 [1, 2j, 1 - 2j, 0.5j],
                 [-2j, 0, 3 + 4j, 1],
@@ -850,20 +850,20 @@ class TestSample:
 
         # res should only contain the eigenvalues of
         # the hermitian matrix
-        eigvals = np.linalg.eigvalsh(A_)
-        assert np.allclose(sorted(list(set(res.tolist()))), sorted(eigvals), atol=tol(dev.shots))
+        eigvals = pnp.linalg.eigvalsh(A_)
+        assert pnp.allclose(sorted(list(set(res.tolist()))), sorted(eigvals), atol=tol(dev.shots))
 
         # make sure the mean matches the analytic mean
         expected = (
-            88 * np.sin(theta)
-            + 24 * np.sin(2 * theta)
-            - 40 * np.sin(3 * theta)
-            + 5 * np.cos(theta)
-            - 6 * np.cos(2 * theta)
-            + 27 * np.cos(3 * theta)
+            88 * pnp.sin(theta)
+            + 24 * pnp.sin(2 * theta)
+            - 40 * pnp.sin(3 * theta)
+            + 5 * pnp.cos(theta)
+            - 6 * pnp.cos(2 * theta)
+            + 27 * pnp.cos(3 * theta)
             + 6
         ) / 32
-        assert np.allclose(np.mean(res), expected, atol=tol(dev.shots))
+        assert pnp.allclose(pnp.mean(res), expected, atol=tol(dev.shots))
 
     def test_sample_values_projector_multi_qubit(self, device, tol):
         """Tests if the samples of a multi-qubit Projector observable returned by sample have
@@ -887,38 +887,38 @@ class TestSample:
             qml.CNOT(wires=[0, 1])
             return qml.sample(qml.Projector(state, wires=[0, 1]))
 
-        expected = (np.cos(theta / 2) * np.cos(theta)) ** 2
+        expected = (pnp.cos(theta / 2) * pnp.cos(theta)) ** 2
         res_basis = circuit([0, 0]).flatten()
         res_state = circuit([1, 0, 0, 0]).flatten()
         # res should only contain 0 or 1, the eigenvalues of the projector
-        assert np.allclose(sorted(list(set(res_basis.tolist()))), [0, 1], atol=tol(dev.shots))
-        assert np.allclose(sorted(list(set(res_state.tolist()))), [0, 1], atol=tol(dev.shots))
-        assert np.allclose(np.mean(res_basis), expected, atol=tol(dev.shots))
-        assert np.allclose(np.mean(res_state), expected, atol=tol(dev.shots))
+        assert pnp.allclose(sorted(list(set(res_basis.tolist()))), [0, 1], atol=tol(dev.shots))
+        assert pnp.allclose(sorted(list(set(res_state.tolist()))), [0, 1], atol=tol(dev.shots))
+        assert pnp.allclose(pnp.mean(res_basis), expected, atol=tol(dev.shots))
+        assert pnp.allclose(pnp.mean(res_state), expected, atol=tol(dev.shots))
 
-        expected = (np.cos(theta / 2) * np.sin(theta)) ** 2
+        expected = (pnp.cos(theta / 2) * pnp.sin(theta)) ** 2
         res_basis = circuit([0, 1]).flatten()
         res_state = circuit([0, 1, 0, 0]).flatten()
-        assert np.allclose(sorted(list(set(res_basis.tolist()))), [0, 1], atol=tol(dev.shots))
-        assert np.allclose(sorted(list(set(res_state.tolist()))), [0, 1], atol=tol(dev.shots))
-        assert np.allclose(np.mean(res_basis), expected, atol=tol(dev.shots))
-        assert np.allclose(np.mean(res_state), expected, atol=tol(dev.shots))
+        assert pnp.allclose(sorted(list(set(res_basis.tolist()))), [0, 1], atol=tol(dev.shots))
+        assert pnp.allclose(sorted(list(set(res_state.tolist()))), [0, 1], atol=tol(dev.shots))
+        assert pnp.allclose(pnp.mean(res_basis), expected, atol=tol(dev.shots))
+        assert pnp.allclose(pnp.mean(res_state), expected, atol=tol(dev.shots))
 
-        expected = (np.sin(theta / 2) * np.sin(theta)) ** 2
+        expected = (pnp.sin(theta / 2) * pnp.sin(theta)) ** 2
         res_basis = circuit([1, 0]).flatten()
         res_state = circuit([0, 0, 1, 0]).flatten()
-        assert np.allclose(sorted(list(set(res_basis.tolist()))), [0, 1], atol=tol(dev.shots))
-        assert np.allclose(sorted(list(set(res_state.tolist()))), [0, 1], atol=tol(dev.shots))
-        assert np.allclose(np.mean(res_basis), expected, atol=tol(dev.shots))
-        assert np.allclose(np.mean(res_state), expected, atol=tol(dev.shots))
+        assert pnp.allclose(sorted(list(set(res_basis.tolist()))), [0, 1], atol=tol(dev.shots))
+        assert pnp.allclose(sorted(list(set(res_state.tolist()))), [0, 1], atol=tol(dev.shots))
+        assert pnp.allclose(pnp.mean(res_basis), expected, atol=tol(dev.shots))
+        assert pnp.allclose(pnp.mean(res_state), expected, atol=tol(dev.shots))
 
-        expected = (np.sin(theta / 2) * np.cos(theta)) ** 2
+        expected = (pnp.sin(theta / 2) * pnp.cos(theta)) ** 2
         res_basis = circuit([1, 1]).flatten()
         res_state = circuit([0, 0, 0, 1]).flatten()
-        assert np.allclose(sorted(list(set(res_basis.tolist()))), [0, 1], atol=tol(dev.shots))
-        assert np.allclose(sorted(list(set(res_state.tolist()))), [0, 1], atol=tol(dev.shots))
-        assert np.allclose(np.mean(res_basis), expected, atol=tol(dev.shots))
-        assert np.allclose(np.mean(res_state), expected, atol=tol(dev.shots))
+        assert pnp.allclose(sorted(list(set(res_basis.tolist()))), [0, 1], atol=tol(dev.shots))
+        assert pnp.allclose(sorted(list(set(res_state.tolist()))), [0, 1], atol=tol(dev.shots))
+        assert pnp.allclose(pnp.mean(res_basis), expected, atol=tol(dev.shots))
+        assert pnp.allclose(pnp.mean(res_state), expected, atol=tol(dev.shots))
 
 
 @flaky(max_runs=10)
@@ -952,22 +952,22 @@ class TestTensorSample:
         res = circuit()
 
         # res should only contain 1 and -1
-        assert np.allclose(res**2, 1, atol=tol(False))
+        assert pnp.allclose(res**2, 1, atol=tol(False))
 
-        mean = np.mean(res)
-        expected = np.sin(theta) * np.sin(phi) * np.sin(varphi)
-        assert np.allclose(mean, expected, atol=tol(False))
+        mean = pnp.mean(res)
+        expected = pnp.sin(theta) * pnp.sin(phi) * pnp.sin(varphi)
+        assert pnp.allclose(mean, expected, atol=tol(False))
 
-        var = np.var(res)
+        var = pnp.var(res)
         expected = (
-            8 * np.sin(theta) ** 2 * np.cos(2 * varphi) * np.sin(phi) ** 2
-            - np.cos(2 * (theta - phi))
-            - np.cos(2 * (theta + phi))
-            + 2 * np.cos(2 * theta)
-            + 2 * np.cos(2 * phi)
+            8 * pnp.sin(theta) ** 2 * pnp.cos(2 * varphi) * pnp.sin(phi) ** 2
+            - pnp.cos(2 * (theta - phi))
+            - pnp.cos(2 * (theta + phi))
+            + 2 * pnp.cos(2 * theta)
+            + 2 * pnp.cos(2 * phi)
             + 14
         ) / 16
-        assert np.allclose(var, expected, atol=tol(False))
+        assert pnp.allclose(var, expected, atol=tol(False))
 
     def test_pauliz_hadamard(self, device, tol, skip_if):
         """Test that a tensor product involving PauliZ and PauliY and hadamard works correctly"""
@@ -996,20 +996,20 @@ class TestTensorSample:
         res = circuit()
 
         # s1 should only contain 1 and -1
-        assert np.allclose(res**2, 1, atol=tol(False))
+        assert pnp.allclose(res**2, 1, atol=tol(False))
 
-        mean = np.mean(res)
-        expected = -(np.cos(varphi) * np.sin(phi) + np.sin(varphi) * np.cos(theta)) / np.sqrt(2)
-        assert np.allclose(mean, expected, atol=tol(False))
+        mean = pnp.mean(res)
+        expected = -(pnp.cos(varphi) * pnp.sin(phi) + pnp.sin(varphi) * pnp.cos(theta)) / pnp.sqrt(2)
+        assert pnp.allclose(mean, expected, atol=tol(False))
 
-        var = np.var(res)
+        var = pnp.var(res)
         expected = (
             3
-            + np.cos(2 * phi) * np.cos(varphi) ** 2
-            - np.cos(2 * theta) * np.sin(varphi) ** 2
-            - 2 * np.cos(theta) * np.sin(phi) * np.sin(2 * varphi)
+            + pnp.cos(2 * phi) * pnp.cos(varphi) ** 2
+            - pnp.cos(2 * theta) * pnp.sin(varphi) ** 2
+            - 2 * pnp.cos(theta) * pnp.sin(phi) * pnp.sin(2 * varphi)
         ) / 4
-        assert np.allclose(var, expected, atol=tol(False))
+        assert pnp.allclose(var, expected, atol=tol(False))
 
     def test_hermitian(self, device, tol, skip_if):
         """Test that a tensor product involving qml.Hermitian works correctly"""
@@ -1029,7 +1029,7 @@ class TestTensorSample:
         phi = 0.123
         varphi = -0.543
 
-        A_ = 0.1 * np.array(
+        A_ = 0.1 * pnp.array(
             [
                 [-6, 2 + 1j, -3, -5 + 2j],
                 [2 - 1j, 0, 2 - 1j, -5 + 4j],
@@ -1051,59 +1051,59 @@ class TestTensorSample:
 
         # res should only contain the eigenvalues of
         # the hermitian matrix tensor product Z
-        Z = np.diag([1, -1])
-        eigvals = np.linalg.eigvalsh(np.kron(Z, A_))
-        assert np.allclose(sorted(np.unique(res)), sorted(eigvals), atol=tol(False))
+        Z = pnp.diag([1, -1])
+        eigvals = pnp.linalg.eigvalsh(pnp.kron(Z, A_))
+        assert pnp.allclose(sorted(pnp.unique(res)), sorted(eigvals), atol=tol(False))
 
-        mean = np.mean(res)
+        mean = pnp.mean(res)
         expected = (
             0.1
             * 0.5
             * (
-                -6 * np.cos(theta) * (np.cos(varphi) + 1)
-                - 2 * np.sin(varphi) * (np.cos(theta) + np.sin(phi) - 2 * np.cos(phi))
-                + 3 * np.cos(varphi) * np.sin(phi)
-                + np.sin(phi)
+                -6 * pnp.cos(theta) * (pnp.cos(varphi) + 1)
+                - 2 * pnp.sin(varphi) * (pnp.cos(theta) + pnp.sin(phi) - 2 * pnp.cos(phi))
+                + 3 * pnp.cos(varphi) * pnp.sin(phi)
+                + pnp.sin(phi)
             )
         )
-        assert np.allclose(mean, expected, atol=tol(False))
+        assert pnp.allclose(mean, expected, atol=tol(False))
 
-        var = np.var(res)
+        var = pnp.var(res)
         expected = (
             0.01
             * (
                 1057
-                - np.cos(2 * phi)
-                + 12 * (27 + np.cos(2 * phi)) * np.cos(varphi)
-                - 2 * np.cos(2 * varphi) * np.sin(phi) * (16 * np.cos(phi) + 21 * np.sin(phi))
-                + 16 * np.sin(2 * phi)
-                - 8 * (-17 + np.cos(2 * phi) + 2 * np.sin(2 * phi)) * np.sin(varphi)
-                - 8 * np.cos(2 * theta) * (3 + 3 * np.cos(varphi) + np.sin(varphi)) ** 2
-                - 24 * np.cos(phi) * (np.cos(phi) + 2 * np.sin(phi)) * np.sin(2 * varphi)
+                - pnp.cos(2 * phi)
+                + 12 * (27 + pnp.cos(2 * phi)) * pnp.cos(varphi)
+                - 2 * pnp.cos(2 * varphi) * pnp.sin(phi) * (16 * pnp.cos(phi) + 21 * pnp.sin(phi))
+                + 16 * pnp.sin(2 * phi)
+                - 8 * (-17 + pnp.cos(2 * phi) + 2 * pnp.sin(2 * phi)) * pnp.sin(varphi)
+                - 8 * pnp.cos(2 * theta) * (3 + 3 * pnp.cos(varphi) + pnp.sin(varphi)) ** 2
+                - 24 * pnp.cos(phi) * (pnp.cos(phi) + 2 * pnp.sin(phi)) * pnp.sin(2 * varphi)
                 - 8
-                * np.cos(theta)
+                * pnp.cos(theta)
                 * (
                     4
-                    * np.cos(phi)
+                    * pnp.cos(phi)
                     * (
                         4
-                        + 8 * np.cos(varphi)
-                        + np.cos(2 * varphi)
-                        - (1 + 6 * np.cos(varphi)) * np.sin(varphi)
+                        + 8 * pnp.cos(varphi)
+                        + pnp.cos(2 * varphi)
+                        - (1 + 6 * pnp.cos(varphi)) * pnp.sin(varphi)
                     )
-                    + np.sin(phi)
+                    + pnp.sin(phi)
                     * (
                         15
-                        + 8 * np.cos(varphi)
-                        - 11 * np.cos(2 * varphi)
-                        + 42 * np.sin(varphi)
-                        + 3 * np.sin(2 * varphi)
+                        + 8 * pnp.cos(varphi)
+                        - 11 * pnp.cos(2 * varphi)
+                        + 42 * pnp.sin(varphi)
+                        + 3 * pnp.sin(2 * varphi)
                     )
                 )
             )
             / 16
         )
-        assert np.allclose(var, expected, atol=tol(False))
+        assert pnp.allclose(var, expected, atol=tol(False))
 
     def test_projector(self, device, tol, skip_if):  # pylint: disable=too-many-statements
         """Test that a tensor product involving qml.Projector works correctly"""
@@ -1134,109 +1134,109 @@ class TestTensorSample:
 
         res_basis = circuit([0, 0]).flatten()
         res_state = circuit([1, 0, 0, 0]).flatten()
-        expected_mean = (np.cos(varphi / 2) * np.cos(phi / 2) * np.cos(theta / 2)) ** 2 - (
-            np.cos(varphi / 2) * np.sin(phi / 2) * np.sin(theta / 2)
+        expected_mean = (pnp.cos(varphi / 2) * pnp.cos(phi / 2) * pnp.cos(theta / 2)) ** 2 - (
+            pnp.cos(varphi / 2) * pnp.sin(phi / 2) * pnp.sin(theta / 2)
         ) ** 2
         expected_var = (
-            (np.cos(varphi / 2) * np.cos(phi / 2) * np.cos(theta / 2)) ** 2
-            + (np.cos(varphi / 2) * np.sin(phi / 2) * np.sin(theta / 2)) ** 2
+            (pnp.cos(varphi / 2) * pnp.cos(phi / 2) * pnp.cos(theta / 2)) ** 2
+            + (pnp.cos(varphi / 2) * pnp.sin(phi / 2) * pnp.sin(theta / 2)) ** 2
             - (
-                (np.cos(varphi / 2) * np.cos(phi / 2) * np.cos(theta / 2)) ** 2
-                - (np.cos(varphi / 2) * np.sin(phi / 2) * np.sin(theta / 2)) ** 2
+                (pnp.cos(varphi / 2) * pnp.cos(phi / 2) * pnp.cos(theta / 2)) ** 2
+                - (pnp.cos(varphi / 2) * pnp.sin(phi / 2) * pnp.sin(theta / 2)) ** 2
             )
             ** 2
         )
         # res should only contain the eigenvalues of the projector matrix tensor product Z, i.e. {-1, 0, 1}
-        assert np.allclose(sorted(np.unique(res_basis)), [-1, 0, 1], atol=tol(False))
-        assert np.allclose(sorted(np.unique(res_state)), [-1, 0, 1], atol=tol(False))
-        assert np.allclose(np.mean(res_basis), expected_mean, atol=tol(False))
-        assert np.allclose(np.mean(res_state), expected_mean, atol=tol(False))
-        assert np.allclose(np.var(res_basis), expected_var, atol=tol(False))
-        assert np.allclose(np.var(res_state), expected_var, atol=tol(False))
+        assert pnp.allclose(sorted(pnp.unique(res_basis)), [-1, 0, 1], atol=tol(False))
+        assert pnp.allclose(sorted(pnp.unique(res_state)), [-1, 0, 1], atol=tol(False))
+        assert pnp.allclose(pnp.mean(res_basis), expected_mean, atol=tol(False))
+        assert pnp.allclose(pnp.mean(res_state), expected_mean, atol=tol(False))
+        assert pnp.allclose(pnp.var(res_basis), expected_var, atol=tol(False))
+        assert pnp.allclose(pnp.var(res_state), expected_var, atol=tol(False))
 
         res_basis = circuit([0, 1]).flatten()
         res_state = circuit([0, 1, 0, 0]).flatten()
-        expected_mean = (np.sin(varphi / 2) * np.cos(phi / 2) * np.cos(theta / 2)) ** 2 - (
-            np.sin(varphi / 2) * np.sin(phi / 2) * np.sin(theta / 2)
+        expected_mean = (pnp.sin(varphi / 2) * pnp.cos(phi / 2) * pnp.cos(theta / 2)) ** 2 - (
+            pnp.sin(varphi / 2) * pnp.sin(phi / 2) * pnp.sin(theta / 2)
         ) ** 2
         expected_var = (
-            (np.sin(varphi / 2) * np.cos(phi / 2) * np.cos(theta / 2)) ** 2
-            + (np.sin(varphi / 2) * np.sin(phi / 2) * np.sin(theta / 2)) ** 2
+            (pnp.sin(varphi / 2) * pnp.cos(phi / 2) * pnp.cos(theta / 2)) ** 2
+            + (pnp.sin(varphi / 2) * pnp.sin(phi / 2) * pnp.sin(theta / 2)) ** 2
             - (
-                (np.sin(varphi / 2) * np.cos(phi / 2) * np.cos(theta / 2)) ** 2
-                - (np.sin(varphi / 2) * np.sin(phi / 2) * np.sin(theta / 2)) ** 2
+                (pnp.sin(varphi / 2) * pnp.cos(phi / 2) * pnp.cos(theta / 2)) ** 2
+                - (pnp.sin(varphi / 2) * pnp.sin(phi / 2) * pnp.sin(theta / 2)) ** 2
             )
             ** 2
         )
-        assert np.allclose(sorted(np.unique(res_basis)), [-1, 0, 1], atol=tol(False))
-        assert np.allclose(sorted(np.unique(res_state)), [-1, 0, 1], atol=tol(False))
-        assert np.allclose(np.mean(res_basis), expected_mean, atol=tol(False))
-        assert np.allclose(np.mean(res_state), expected_mean, atol=tol(False))
-        assert np.allclose(np.var(res_basis), expected_var, atol=tol(False))
-        assert np.allclose(np.var(res_state), expected_var, atol=tol(False))
+        assert pnp.allclose(sorted(pnp.unique(res_basis)), [-1, 0, 1], atol=tol(False))
+        assert pnp.allclose(sorted(pnp.unique(res_state)), [-1, 0, 1], atol=tol(False))
+        assert pnp.allclose(pnp.mean(res_basis), expected_mean, atol=tol(False))
+        assert pnp.allclose(pnp.mean(res_state), expected_mean, atol=tol(False))
+        assert pnp.allclose(pnp.var(res_basis), expected_var, atol=tol(False))
+        assert pnp.allclose(pnp.var(res_state), expected_var, atol=tol(False))
 
         res_basis = circuit([1, 0]).flatten()
         res_state = circuit([0, 0, 1, 0]).flatten()
-        expected_mean = (np.sin(varphi / 2) * np.sin(phi / 2) * np.cos(theta / 2)) ** 2 - (
-            np.sin(varphi / 2) * np.cos(phi / 2) * np.sin(theta / 2)
+        expected_mean = (pnp.sin(varphi / 2) * pnp.sin(phi / 2) * pnp.cos(theta / 2)) ** 2 - (
+            pnp.sin(varphi / 2) * pnp.cos(phi / 2) * pnp.sin(theta / 2)
         ) ** 2
         expected_var = (
-            (np.sin(varphi / 2) * np.sin(phi / 2) * np.cos(theta / 2)) ** 2
-            + (np.sin(varphi / 2) * np.cos(phi / 2) * np.sin(theta / 2)) ** 2
+            (pnp.sin(varphi / 2) * pnp.sin(phi / 2) * pnp.cos(theta / 2)) ** 2
+            + (pnp.sin(varphi / 2) * pnp.cos(phi / 2) * pnp.sin(theta / 2)) ** 2
             - (
-                (np.sin(varphi / 2) * np.sin(phi / 2) * np.cos(theta / 2)) ** 2
-                - (np.sin(varphi / 2) * np.cos(phi / 2) * np.sin(theta / 2)) ** 2
+                (pnp.sin(varphi / 2) * pnp.sin(phi / 2) * pnp.cos(theta / 2)) ** 2
+                - (pnp.sin(varphi / 2) * pnp.cos(phi / 2) * pnp.sin(theta / 2)) ** 2
             )
             ** 2
         )
-        assert np.allclose(sorted(np.unique(res_basis)), [-1, 0, 1], atol=tol(False))
-        assert np.allclose(sorted(np.unique(res_state)), [-1, 0, 1], atol=tol(False))
-        assert np.allclose(np.mean(res_basis), expected_mean, atol=tol(False))
-        assert np.allclose(np.mean(res_state), expected_mean, atol=tol(False))
-        assert np.allclose(np.var(res_basis), expected_var, atol=tol(False))
-        assert np.allclose(np.var(res_state), expected_var, atol=tol(False))
+        assert pnp.allclose(sorted(pnp.unique(res_basis)), [-1, 0, 1], atol=tol(False))
+        assert pnp.allclose(sorted(pnp.unique(res_state)), [-1, 0, 1], atol=tol(False))
+        assert pnp.allclose(pnp.mean(res_basis), expected_mean, atol=tol(False))
+        assert pnp.allclose(pnp.mean(res_state), expected_mean, atol=tol(False))
+        assert pnp.allclose(pnp.var(res_basis), expected_var, atol=tol(False))
+        assert pnp.allclose(pnp.var(res_state), expected_var, atol=tol(False))
 
         res_basis = circuit([1, 1]).flatten()
         res_state = circuit([0, 0, 0, 1]).flatten()
-        expected_mean = (np.cos(varphi / 2) * np.sin(phi / 2) * np.cos(theta / 2)) ** 2 - (
-            np.cos(varphi / 2) * np.cos(phi / 2) * np.sin(theta / 2)
+        expected_mean = (pnp.cos(varphi / 2) * pnp.sin(phi / 2) * pnp.cos(theta / 2)) ** 2 - (
+            pnp.cos(varphi / 2) * pnp.cos(phi / 2) * pnp.sin(theta / 2)
         ) ** 2
         expected_var = (
-            (np.cos(varphi / 2) * np.sin(phi / 2) * np.cos(theta / 2)) ** 2
-            + (np.cos(varphi / 2) * np.cos(phi / 2) * np.sin(theta / 2)) ** 2
+            (pnp.cos(varphi / 2) * pnp.sin(phi / 2) * pnp.cos(theta / 2)) ** 2
+            + (pnp.cos(varphi / 2) * pnp.cos(phi / 2) * pnp.sin(theta / 2)) ** 2
             - (
-                (np.cos(varphi / 2) * np.sin(phi / 2) * np.cos(theta / 2)) ** 2
-                - (np.cos(varphi / 2) * np.cos(phi / 2) * np.sin(theta / 2)) ** 2
+                (pnp.cos(varphi / 2) * pnp.sin(phi / 2) * pnp.cos(theta / 2)) ** 2
+                - (pnp.cos(varphi / 2) * pnp.cos(phi / 2) * pnp.sin(theta / 2)) ** 2
             )
             ** 2
         )
-        assert np.allclose(sorted(np.unique(res_basis)), [-1, 0, 1], atol=tol(False))
-        assert np.allclose(sorted(np.unique(res_state)), [-1, 0, 1], atol=tol(False))
-        assert np.allclose(np.mean(res_basis), expected_mean, atol=tol(False))
-        assert np.allclose(np.mean(res_state), expected_mean, atol=tol(False))
-        assert np.allclose(np.var(res_basis), expected_var, atol=tol(False))
-        assert np.allclose(np.var(res_state), expected_var, atol=tol(False))
+        assert pnp.allclose(sorted(pnp.unique(res_basis)), [-1, 0, 1], atol=tol(False))
+        assert pnp.allclose(sorted(pnp.unique(res_state)), [-1, 0, 1], atol=tol(False))
+        assert pnp.allclose(pnp.mean(res_basis), expected_mean, atol=tol(False))
+        assert pnp.allclose(pnp.mean(res_state), expected_mean, atol=tol(False))
+        assert pnp.allclose(pnp.var(res_basis), expected_var, atol=tol(False))
+        assert pnp.allclose(pnp.var(res_state), expected_var, atol=tol(False))
 
-        res = circuit(np.array([1, 0, 0, 1]) / np.sqrt(2))
+        res = circuit(pnp.array([1, 0, 0, 1]) / pnp.sqrt(2))
         expected_mean = 0.5 * (
-            (np.cos(theta / 2) * np.cos(phi / 2) * np.cos(varphi / 2)) ** 2
-            + (np.cos(theta / 2) * np.sin(phi / 2) * np.cos(varphi / 2)) ** 2
-            - (np.sin(theta / 2) * np.sin(phi / 2) * np.cos(varphi / 2)) ** 2
-            - (np.sin(theta / 2) * np.cos(phi / 2) * np.cos(varphi / 2)) ** 2
+            (pnp.cos(theta / 2) * pnp.cos(phi / 2) * pnp.cos(varphi / 2)) ** 2
+            + (pnp.cos(theta / 2) * pnp.sin(phi / 2) * pnp.cos(varphi / 2)) ** 2
+            - (pnp.sin(theta / 2) * pnp.sin(phi / 2) * pnp.cos(varphi / 2)) ** 2
+            - (pnp.sin(theta / 2) * pnp.cos(phi / 2) * pnp.cos(varphi / 2)) ** 2
         )
         expected_var = (
             0.5
             * (
-                (np.cos(theta / 2) * np.cos(phi / 2) * np.cos(varphi / 2)) ** 2
-                + (np.cos(theta / 2) * np.sin(phi / 2) * np.cos(varphi / 2)) ** 2
-                + (np.sin(theta / 2) * np.sin(phi / 2) * np.cos(varphi / 2)) ** 2
-                + (np.sin(theta / 2) * np.cos(phi / 2) * np.cos(varphi / 2)) ** 2
+                (pnp.cos(theta / 2) * pnp.cos(phi / 2) * pnp.cos(varphi / 2)) ** 2
+                + (pnp.cos(theta / 2) * pnp.sin(phi / 2) * pnp.cos(varphi / 2)) ** 2
+                + (pnp.sin(theta / 2) * pnp.sin(phi / 2) * pnp.cos(varphi / 2)) ** 2
+                + (pnp.sin(theta / 2) * pnp.cos(phi / 2) * pnp.cos(varphi / 2)) ** 2
             )
             - expected_mean**2
         )
-        assert np.allclose(sorted(np.unique(res)), [-1, 0, 1], atol=tol(False))
-        assert np.allclose(np.mean(res), expected_mean, atol=tol(False))
-        assert np.allclose(np.var(res), expected_var, atol=tol(False))
+        assert pnp.allclose(sorted(pnp.unique(res)), [-1, 0, 1], atol=tol(False))
+        assert pnp.allclose(pnp.mean(res), expected_mean, atol=tol(False))
+        assert pnp.allclose(pnp.var(res), expected_var, atol=tol(False))
 
 
 @flaky(max_runs=10)
@@ -1278,8 +1278,8 @@ class TestVar:
 
         res = circuit()
 
-        expected = 0.25 * (3 - np.cos(2 * theta) - 2 * np.cos(theta) ** 2 * np.cos(2 * phi))
-        assert np.allclose(res, expected, atol=tol(dev.shots))
+        expected = 0.25 * (3 - pnp.cos(2 * theta) - 2 * pnp.cos(theta) ** 2 * pnp.cos(2 * phi))
+        assert pnp.allclose(res, expected, atol=tol(dev.shots))
 
     def test_var_hermitian(self, device, tol):
         """Tests if the samples of a Hermitian observable returned by sample have
@@ -1294,7 +1294,7 @@ class TestVar:
         phi = 0.543
         theta = 0.6543
         # test correct variance for <H> of a rotated state
-        H = 0.1 * np.array([[4, -1 + 6j], [-1 - 6j, 2]])
+        H = 0.1 * pnp.array([[4, -1 + 6j], [-1 - 6j, 2]])
 
         @qml.qnode(dev)
         def circuit():
@@ -1308,14 +1308,14 @@ class TestVar:
             0.01
             * 0.5
             * (
-                2 * np.sin(2 * theta) * np.cos(phi) ** 2
-                + 24 * np.sin(phi) * np.cos(phi) * (np.sin(theta) - np.cos(theta))
-                + 35 * np.cos(2 * phi)
+                2 * pnp.sin(2 * theta) * pnp.cos(phi) ** 2
+                + 24 * pnp.sin(phi) * pnp.cos(phi) * (pnp.sin(theta) - pnp.cos(theta))
+                + 35 * pnp.cos(2 * phi)
                 + 39
             )
         )
 
-        assert np.allclose(res, expected, atol=tol(dev.shots))
+        assert pnp.allclose(res, expected, atol=tol(dev.shots))
 
     def test_var_projector(self, device, tol):
         """Tests if the samples of a Projector observable returned by sample have
@@ -1339,42 +1339,42 @@ class TestVar:
 
         res_basis = circuit([0, 0])
         res_state = circuit([1, 0, 0, 0])
-        expected = (np.cos(phi / 2) * np.cos(theta / 2)) ** 2 - (
-            (np.cos(phi / 2) * np.cos(theta / 2)) ** 2
+        expected = (pnp.cos(phi / 2) * pnp.cos(theta / 2)) ** 2 - (
+            (pnp.cos(phi / 2) * pnp.cos(theta / 2)) ** 2
         ) ** 2
-        assert np.allclose(res_basis, expected, atol=tol(dev.shots))
-        assert np.allclose(res_state, expected, atol=tol(dev.shots))
+        assert pnp.allclose(res_basis, expected, atol=tol(dev.shots))
+        assert pnp.allclose(res_state, expected, atol=tol(dev.shots))
 
         res_basis = circuit([0, 1])
         res_state = circuit([0, 1, 0, 0])
-        expected = (np.cos(phi / 2) * np.sin(theta / 2)) ** 2 - (
-            (np.cos(phi / 2) * np.sin(theta / 2)) ** 2
+        expected = (pnp.cos(phi / 2) * pnp.sin(theta / 2)) ** 2 - (
+            (pnp.cos(phi / 2) * pnp.sin(theta / 2)) ** 2
         ) ** 2
-        assert np.allclose(res_basis, expected, atol=tol(dev.shots))
-        assert np.allclose(res_state, expected, atol=tol(dev.shots))
+        assert pnp.allclose(res_basis, expected, atol=tol(dev.shots))
+        assert pnp.allclose(res_state, expected, atol=tol(dev.shots))
 
         res_basis = circuit([1, 0])
         res_state = circuit([0, 0, 1, 0])
-        expected = (np.sin(phi / 2) * np.sin(theta / 2)) ** 2 - (
-            (np.sin(phi / 2) * np.sin(theta / 2)) ** 2
+        expected = (pnp.sin(phi / 2) * pnp.sin(theta / 2)) ** 2 - (
+            (pnp.sin(phi / 2) * pnp.sin(theta / 2)) ** 2
         ) ** 2
-        assert np.allclose(res_basis, expected, atol=tol(dev.shots))
-        assert np.allclose(res_state, expected, atol=tol(dev.shots))
+        assert pnp.allclose(res_basis, expected, atol=tol(dev.shots))
+        assert pnp.allclose(res_state, expected, atol=tol(dev.shots))
 
         res_basis = circuit([1, 1])
         res_state = circuit([0, 0, 0, 1])
-        expected = (np.sin(phi / 2) * np.cos(theta / 2)) ** 2 - (
-            (np.sin(phi / 2) * np.cos(theta / 2)) ** 2
+        expected = (pnp.sin(phi / 2) * pnp.cos(theta / 2)) ** 2 - (
+            (pnp.sin(phi / 2) * pnp.cos(theta / 2)) ** 2
         ) ** 2
-        assert np.allclose(res_basis, expected, atol=tol(dev.shots))
-        assert np.allclose(res_state, expected, atol=tol(dev.shots))
+        assert pnp.allclose(res_basis, expected, atol=tol(dev.shots))
+        assert pnp.allclose(res_state, expected, atol=tol(dev.shots))
 
-        res = circuit(np.array([1, 0, 0, 1]) / np.sqrt(2))
+        res = circuit(pnp.array([1, 0, 0, 1]) / pnp.sqrt(2))
         expected_mean = 0.5 * (
-            (np.cos(theta / 2) * np.cos(phi / 2)) ** 2 + (np.cos(theta / 2) * np.sin(phi / 2)) ** 2
+            (pnp.cos(theta / 2) * pnp.cos(phi / 2)) ** 2 + (pnp.cos(theta / 2) * pnp.sin(phi / 2)) ** 2
         )
         expected_var = expected_mean - expected_mean**2
-        assert np.allclose(res, expected_var, atol=tol(dev.shots))
+        assert pnp.allclose(res, expected_var, atol=tol(dev.shots))
 
 
 @flaky(max_runs=10)
@@ -1404,14 +1404,14 @@ class TestTensorVar:
         res = circuit()
 
         expected = (
-            8 * np.sin(theta) ** 2 * np.cos(2 * varphi) * np.sin(phi) ** 2
-            - np.cos(2 * (theta - phi))
-            - np.cos(2 * (theta + phi))
-            + 2 * np.cos(2 * theta)
-            + 2 * np.cos(2 * phi)
+            8 * pnp.sin(theta) ** 2 * pnp.cos(2 * varphi) * pnp.sin(phi) ** 2
+            - pnp.cos(2 * (theta - phi))
+            - pnp.cos(2 * (theta + phi))
+            + 2 * pnp.cos(2 * theta)
+            + 2 * pnp.cos(2 * phi)
             + 14
         ) / 16
-        assert np.allclose(res, expected, atol=tol(dev.shots))
+        assert pnp.allclose(res, expected, atol=tol(dev.shots))
 
     def test_pauliz_hadamard(self, device, tol, skip_if):
         """Test that a tensor product involving PauliZ and PauliY and hadamard works correctly"""
@@ -1437,11 +1437,11 @@ class TestTensorVar:
 
         expected = (
             3
-            + np.cos(2 * phi) * np.cos(varphi) ** 2
-            - np.cos(2 * theta) * np.sin(varphi) ** 2
-            - 2 * np.cos(theta) * np.sin(phi) * np.sin(2 * varphi)
+            + pnp.cos(2 * phi) * pnp.cos(varphi) ** 2
+            - pnp.cos(2 * theta) * pnp.sin(varphi) ** 2
+            - 2 * pnp.cos(theta) * pnp.sin(phi) * pnp.sin(2 * varphi)
         ) / 4
-        assert np.allclose(res, expected, atol=tol(dev.shots))
+        assert pnp.allclose(res, expected, atol=tol(dev.shots))
 
     # pylint: disable=too-many-arguments
 
@@ -1475,7 +1475,7 @@ class TestTensorVar:
             sub_routine(label_map=range(3))
             return qml.var(ob)
 
-        assert np.allclose(circ(base_obs), circ(permuted_obs), atol=tol(dev.shots), rtol=0)
+        assert pnp.allclose(circ(base_obs), circ(permuted_obs), atol=tol(dev.shots), rtol=0)
 
     @pytest.mark.parametrize("label_map", label_maps)
     def test_wire_label_in_tensor_prod_observables(self, device, label_map, tol, skip_if):
@@ -1504,7 +1504,7 @@ class TestTensorVar:
         circ_base_label = qml.QNode(circ, device=dev)
         circ_custom_label = qml.QNode(circ, device=dev_custom_labels)
 
-        assert np.allclose(
+        assert pnp.allclose(
             circ_base_label(wire_labels=range(3)),
             circ_custom_label(wire_labels=label_map),
             atol=tol(dev.shots),
@@ -1526,7 +1526,7 @@ class TestTensorVar:
         phi = 0.123
         varphi = -0.543
 
-        A_ = 0.1 * np.array(
+        A_ = 0.1 * pnp.array(
             [
                 [-6, 2 + 1j, -3, -5 + 2j],
                 [2 - 1j, 0, 2 - 1j, -5 + 4j],
@@ -1550,38 +1550,38 @@ class TestTensorVar:
             0.01
             * (
                 1057
-                - np.cos(2 * phi)
-                + 12 * (27 + np.cos(2 * phi)) * np.cos(varphi)
-                - 2 * np.cos(2 * varphi) * np.sin(phi) * (16 * np.cos(phi) + 21 * np.sin(phi))
-                + 16 * np.sin(2 * phi)
-                - 8 * (-17 + np.cos(2 * phi) + 2 * np.sin(2 * phi)) * np.sin(varphi)
-                - 8 * np.cos(2 * theta) * (3 + 3 * np.cos(varphi) + np.sin(varphi)) ** 2
-                - 24 * np.cos(phi) * (np.cos(phi) + 2 * np.sin(phi)) * np.sin(2 * varphi)
+                - pnp.cos(2 * phi)
+                + 12 * (27 + pnp.cos(2 * phi)) * pnp.cos(varphi)
+                - 2 * pnp.cos(2 * varphi) * pnp.sin(phi) * (16 * pnp.cos(phi) + 21 * pnp.sin(phi))
+                + 16 * pnp.sin(2 * phi)
+                - 8 * (-17 + pnp.cos(2 * phi) + 2 * pnp.sin(2 * phi)) * pnp.sin(varphi)
+                - 8 * pnp.cos(2 * theta) * (3 + 3 * pnp.cos(varphi) + pnp.sin(varphi)) ** 2
+                - 24 * pnp.cos(phi) * (pnp.cos(phi) + 2 * pnp.sin(phi)) * pnp.sin(2 * varphi)
                 - 8
-                * np.cos(theta)
+                * pnp.cos(theta)
                 * (
                     4
-                    * np.cos(phi)
+                    * pnp.cos(phi)
                     * (
                         4
-                        + 8 * np.cos(varphi)
-                        + np.cos(2 * varphi)
-                        - (1 + 6 * np.cos(varphi)) * np.sin(varphi)
+                        + 8 * pnp.cos(varphi)
+                        + pnp.cos(2 * varphi)
+                        - (1 + 6 * pnp.cos(varphi)) * pnp.sin(varphi)
                     )
-                    + np.sin(phi)
+                    + pnp.sin(phi)
                     * (
                         15
-                        + 8 * np.cos(varphi)
-                        - 11 * np.cos(2 * varphi)
-                        + 42 * np.sin(varphi)
-                        + 3 * np.sin(2 * varphi)
+                        + 8 * pnp.cos(varphi)
+                        - 11 * pnp.cos(2 * varphi)
+                        + 42 * pnp.sin(varphi)
+                        + 3 * pnp.sin(2 * varphi)
                     )
                 )
             )
             / 16
         )
 
-        assert np.allclose(res, expected, atol=tol(dev.shots))
+        assert pnp.allclose(res, expected, atol=tol(dev.shots))
 
     def test_projector(self, device, tol, skip_if):
         """Test that a tensor product involving qml.Projector works correctly"""
@@ -1610,69 +1610,69 @@ class TestTensorVar:
         res_basis = circuit([0, 0])
         res_state = circuit([1, 0, 0, 0])
         expected = (
-            (np.cos(varphi / 2) * np.cos(phi / 2) * np.cos(theta / 2)) ** 2
-            + (np.cos(varphi / 2) * np.sin(phi / 2) * np.sin(theta / 2)) ** 2
+            (pnp.cos(varphi / 2) * pnp.cos(phi / 2) * pnp.cos(theta / 2)) ** 2
+            + (pnp.cos(varphi / 2) * pnp.sin(phi / 2) * pnp.sin(theta / 2)) ** 2
         ) - (
-            (np.cos(varphi / 2) * np.cos(phi / 2) * np.cos(theta / 2)) ** 2
-            - (np.cos(varphi / 2) * np.sin(phi / 2) * np.sin(theta / 2)) ** 2
+            (pnp.cos(varphi / 2) * pnp.cos(phi / 2) * pnp.cos(theta / 2)) ** 2
+            - (pnp.cos(varphi / 2) * pnp.sin(phi / 2) * pnp.sin(theta / 2)) ** 2
         ) ** 2
-        assert np.allclose(res_basis, expected, atol=tol(dev.shots))
-        assert np.allclose(res_state, expected, atol=tol(dev.shots))
+        assert pnp.allclose(res_basis, expected, atol=tol(dev.shots))
+        assert pnp.allclose(res_state, expected, atol=tol(dev.shots))
 
         res_basis = circuit([0, 1])
         res_state = circuit([0, 1, 0, 0])
         expected = (
-            (np.sin(varphi / 2) * np.cos(phi / 2) * np.cos(theta / 2)) ** 2
-            + (np.sin(varphi / 2) * np.sin(phi / 2) * np.sin(theta / 2)) ** 2
+            (pnp.sin(varphi / 2) * pnp.cos(phi / 2) * pnp.cos(theta / 2)) ** 2
+            + (pnp.sin(varphi / 2) * pnp.sin(phi / 2) * pnp.sin(theta / 2)) ** 2
         ) - (
-            (np.sin(varphi / 2) * np.cos(phi / 2) * np.cos(theta / 2)) ** 2
-            - (np.sin(varphi / 2) * np.sin(phi / 2) * np.sin(theta / 2)) ** 2
+            (pnp.sin(varphi / 2) * pnp.cos(phi / 2) * pnp.cos(theta / 2)) ** 2
+            - (pnp.sin(varphi / 2) * pnp.sin(phi / 2) * pnp.sin(theta / 2)) ** 2
         ) ** 2
-        assert np.allclose(res_basis, expected, atol=tol(dev.shots))
-        assert np.allclose(res_state, expected, atol=tol(dev.shots))
+        assert pnp.allclose(res_basis, expected, atol=tol(dev.shots))
+        assert pnp.allclose(res_state, expected, atol=tol(dev.shots))
 
         res_basis = circuit([1, 0])
         res_state = circuit([0, 0, 1, 0])
         expected = (
-            (np.sin(varphi / 2) * np.sin(phi / 2) * np.cos(theta / 2)) ** 2
-            + (np.sin(varphi / 2) * np.cos(phi / 2) * np.sin(theta / 2)) ** 2
+            (pnp.sin(varphi / 2) * pnp.sin(phi / 2) * pnp.cos(theta / 2)) ** 2
+            + (pnp.sin(varphi / 2) * pnp.cos(phi / 2) * pnp.sin(theta / 2)) ** 2
         ) - (
-            (np.sin(varphi / 2) * np.sin(phi / 2) * np.cos(theta / 2)) ** 2
-            - (np.sin(varphi / 2) * np.cos(phi / 2) * np.sin(theta / 2)) ** 2
+            (pnp.sin(varphi / 2) * pnp.sin(phi / 2) * pnp.cos(theta / 2)) ** 2
+            - (pnp.sin(varphi / 2) * pnp.cos(phi / 2) * pnp.sin(theta / 2)) ** 2
         ) ** 2
-        assert np.allclose(res_basis, expected, atol=tol(dev.shots))
-        assert np.allclose(res_state, expected, atol=tol(dev.shots))
+        assert pnp.allclose(res_basis, expected, atol=tol(dev.shots))
+        assert pnp.allclose(res_state, expected, atol=tol(dev.shots))
 
         res_basis = circuit([1, 1])
         res_state = circuit([0, 0, 0, 1])
         expected = (
-            (np.cos(varphi / 2) * np.sin(phi / 2) * np.cos(theta / 2)) ** 2
-            + (np.cos(varphi / 2) * np.cos(phi / 2) * np.sin(theta / 2)) ** 2
+            (pnp.cos(varphi / 2) * pnp.sin(phi / 2) * pnp.cos(theta / 2)) ** 2
+            + (pnp.cos(varphi / 2) * pnp.cos(phi / 2) * pnp.sin(theta / 2)) ** 2
         ) - (
-            (np.cos(varphi / 2) * np.sin(phi / 2) * np.cos(theta / 2)) ** 2
-            - (np.cos(varphi / 2) * np.cos(phi / 2) * np.sin(theta / 2)) ** 2
+            (pnp.cos(varphi / 2) * pnp.sin(phi / 2) * pnp.cos(theta / 2)) ** 2
+            - (pnp.cos(varphi / 2) * pnp.cos(phi / 2) * pnp.sin(theta / 2)) ** 2
         ) ** 2
-        assert np.allclose(res_basis, expected, atol=tol(dev.shots))
-        assert np.allclose(res_state, expected, atol=tol(dev.shots))
+        assert pnp.allclose(res_basis, expected, atol=tol(dev.shots))
+        assert pnp.allclose(res_state, expected, atol=tol(dev.shots))
 
-        res = circuit(np.array([1, 0, 0, 1]) / np.sqrt(2))
+        res = circuit(pnp.array([1, 0, 0, 1]) / pnp.sqrt(2))
         expected_mean = 0.5 * (
-            (np.cos(theta / 2) * np.cos(phi / 2) * np.cos(varphi / 2)) ** 2
-            + (np.cos(theta / 2) * np.sin(phi / 2) * np.cos(varphi / 2)) ** 2
-            - (np.sin(theta / 2) * np.sin(phi / 2) * np.cos(varphi / 2)) ** 2
-            - (np.sin(theta / 2) * np.cos(phi / 2) * np.cos(varphi / 2)) ** 2
+            (pnp.cos(theta / 2) * pnp.cos(phi / 2) * pnp.cos(varphi / 2)) ** 2
+            + (pnp.cos(theta / 2) * pnp.sin(phi / 2) * pnp.cos(varphi / 2)) ** 2
+            - (pnp.sin(theta / 2) * pnp.sin(phi / 2) * pnp.cos(varphi / 2)) ** 2
+            - (pnp.sin(theta / 2) * pnp.cos(phi / 2) * pnp.cos(varphi / 2)) ** 2
         )
         expected_var = (
             0.5
             * (
-                (np.cos(theta / 2) * np.cos(phi / 2) * np.cos(varphi / 2)) ** 2
-                + (np.cos(theta / 2) * np.sin(phi / 2) * np.cos(varphi / 2)) ** 2
-                + (np.sin(theta / 2) * np.sin(phi / 2) * np.cos(varphi / 2)) ** 2
-                + (np.sin(theta / 2) * np.cos(phi / 2) * np.cos(varphi / 2)) ** 2
+                (pnp.cos(theta / 2) * pnp.cos(phi / 2) * pnp.cos(varphi / 2)) ** 2
+                + (pnp.cos(theta / 2) * pnp.sin(phi / 2) * pnp.cos(varphi / 2)) ** 2
+                + (pnp.sin(theta / 2) * pnp.sin(phi / 2) * pnp.cos(varphi / 2)) ** 2
+                + (pnp.sin(theta / 2) * pnp.cos(phi / 2) * pnp.cos(varphi / 2)) ** 2
             )
             - expected_mean**2
         )
-        assert np.allclose(res, expected_var, atol=tol(False))
+        assert pnp.allclose(res, expected_var, atol=tol(False))
 
 
 def _skip_test_for_braket(dev):

--- a/pennylane/devices/tests/test_return_system.py
+++ b/pennylane/devices/tests/test_return_system.py
@@ -16,7 +16,7 @@
 import pytest
 
 import pennylane as qml
-from pennylane import numpy as np  # Import from PennyLane to mirror the standard approach in demos
+from pennylane import numpy as pnp  # Import from PennyLane to mirror the standard approach in demos
 
 pytestmark = pytest.mark.skip_unsupported
 
@@ -56,9 +56,9 @@ class TestIntegrationMultipleReturns:
         assert isinstance(res, tuple)
         assert len(res) == 2
 
-        assert isinstance(res[0], (float, np.ndarray))
+        assert isinstance(res[0], (float, pnp.ndarray))
 
-        assert isinstance(res[1], (float, np.ndarray))
+        assert isinstance(res[1], (float, pnp.ndarray))
 
     def test_multiple_var(self, device):
         """Return multiple vars."""
@@ -83,9 +83,9 @@ class TestIntegrationMultipleReturns:
         assert isinstance(res, tuple)
         assert len(res) == 2
 
-        assert isinstance(res[0], (float, np.ndarray))
+        assert isinstance(res[0], (float, pnp.ndarray))
 
-        assert isinstance(res[1], (float, np.ndarray))
+        assert isinstance(res[1], (float, pnp.ndarray))
 
     def test_multiple_prob(self, device):
         """Return multiple probs."""
@@ -103,10 +103,10 @@ class TestIntegrationMultipleReturns:
         assert isinstance(res, tuple)
         assert len(res) == 2
 
-        assert isinstance(res[0], np.ndarray)
+        assert isinstance(res[0], pnp.ndarray)
         assert res[0].shape == (2**1,)
 
-        assert isinstance(res[1], np.ndarray)
+        assert isinstance(res[1], pnp.ndarray)
         assert res[1].shape == (2**1,)
 
     def test_mix_meas(self, device):
@@ -129,12 +129,12 @@ class TestIntegrationMultipleReturns:
         assert isinstance(res, tuple)
         assert len(res) == 4
 
-        assert isinstance(res[0], np.ndarray)
+        assert isinstance(res[0], pnp.ndarray)
         assert res[0].shape == (2**1,)
 
-        assert isinstance(res[1], (float, np.ndarray))
+        assert isinstance(res[1], (float, pnp.ndarray))
 
-        assert isinstance(res[2], np.ndarray)
+        assert isinstance(res[2], pnp.ndarray)
         assert res[2].shape == (2**1,)
 
-        assert isinstance(res[3], (float, np.ndarray))
+        assert isinstance(res[3], (float, pnp.ndarray))

--- a/pennylane/devices/tests/test_wires.py
+++ b/pennylane/devices/tests/test_wires.py
@@ -16,7 +16,7 @@
 import pytest
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 
 # ===== Factories for circuits using arbitrary wire labels and numbers
 
@@ -65,4 +65,4 @@ class TestWiresIntegration:
         circuit1 = circuit_factory(dev1, wires1)
         circuit2 = circuit_factory(dev2, wires2)
 
-        assert np.allclose(circuit1(), circuit2(), atol=tol(dev1.shots))
+        assert pnp.allclose(circuit1(), circuit2(), atol=tol(dev1.shots))

--- a/pennylane/qchem/convert_openfermion.py
+++ b/pennylane/qchem/convert_openfermion.py
@@ -20,7 +20,7 @@ from typing import Union
 
 # pylint: disable= import-outside-toplevel,no-member,unused-import
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane.fermi.fermionic import FermiSentence, FermiWord
 from pennylane.ops import LinearCombination, Sum
 from pennylane.qchem.convert import _openfermion_to_pennylane, _pennylane_to_openfermion
@@ -155,7 +155,7 @@ def _to_openfermion_dispatch(pl_op, wires=None, tol=1.0e-16):
 @_to_openfermion_dispatch.register
 def _(pl_op: Sum, wires=None, tol=1.0e-16):
     coeffs, ops = pl_op.terms()
-    return _pennylane_to_openfermion(np.array(coeffs), ops, wires=wires, tol=tol)
+    return _pennylane_to_openfermion(pnp.array(coeffs), ops, wires=wires, tol=tol)
 
 
 # pylint: disable=unused-argument, protected-access
@@ -178,7 +178,7 @@ def _(pl_op: FermiSentence, wires=None, tol=1.0e-16):
 
     fermion_op = openfermion.ops.FermionOperator()
     for fermi_word in pl_op:
-        if np.abs(pl_op[fermi_word].imag) < tol:
+        if pnp.abs(pl_op[fermi_word].imag) < tol:
             fermion_op += pl_op[fermi_word].real * to_openfermion(fermi_word)
         else:
             fermion_op += pl_op[fermi_word] * to_openfermion(fermi_word)

--- a/tests/devices/qubit/test_initialize_state.py
+++ b/tests/devices/qubit/test_initialize_state.py
@@ -16,7 +16,7 @@
 import pytest
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane.devices.qubit import create_initial_state
 from pennylane.operation import StatePrepBase
 
@@ -64,26 +64,26 @@ class TestInitializeState:
         state = create_initial_state([0, 1, 2], prep_operation=prep_op)
         assert state[0, 1, 0] == 1
         state[0, 1, 0] = 0  # set to zero to make test below simple
-        assert qml.math.allequal(state, np.zeros((2, 2, 2)))
+        assert qml.math.allequal(state, pnp.zeros((2, 2, 2)))
 
     @pytest.mark.parametrize("prep_op_cls", [qml.StatePrep, qml.AmplitudeEmbedding])
     def test_create_initial_state_with_StatePrep(self, prep_op_cls):
         """Tests that create_initial_state works with the StatePrep operator."""
-        prep_op = prep_op_cls(np.array([0, 1, 0, 0, 0, 0, 0, 1]) / np.sqrt(2), wires=[0, 1, 2])
+        prep_op = prep_op_cls(pnp.array([0, 1, 0, 0, 0, 0, 0, 1]) / pnp.sqrt(2), wires=[0, 1, 2])
         state = create_initial_state([0, 1, 2], prep_operation=prep_op)
-        expected = np.zeros((2, 2, 2))
-        expected[0, 0, 1] = expected[1, 1, 1] = 1 / np.sqrt(2)
-        assert np.array_equal(state, expected)
+        expected = pnp.zeros((2, 2, 2))
+        expected[0, 0, 1] = expected[1, 1, 1] = 1 / pnp.sqrt(2)
+        assert pnp.array_equal(state, expected)
 
     @pytest.mark.parametrize("prep_op_cls", [qml.StatePrep, qml.AmplitudeEmbedding])
     def test_create_initial_state_with_StatePrep_broadcasted(self, prep_op_cls):
         """Tests that create_initial_state works with a broadcasted StatePrep
         operator."""
-        prep_op = prep_op_cls(np.array([[0, 1, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]]), wires=[0, 1])
+        prep_op = prep_op_cls(pnp.array([[0, 1, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]]), wires=[0, 1])
         state = create_initial_state([0, 1], prep_operation=prep_op)
-        expected = np.zeros((3, 2, 2))
+        expected = pnp.zeros((3, 2, 2))
         expected[0, 0, 1] = expected[1, 1, 1] = expected[2, 1, 0] = 1
-        assert np.array_equal(state, expected)
+        assert pnp.array_equal(state, expected)
 
     @pytest.mark.torch
     def test_create_initial_state_casts_to_like_with_prep_op(self):
@@ -113,4 +113,4 @@ class TestInitializeState:
         """Tests that the default interface is vanilla numpy."""
         state = qml.devices.qubit.create_initial_state((0, 1))
         assert qml.math.get_interface(state) == "numpy"
-        assert state.dtype == np.complex128
+        assert state.dtype == pnp.complex128

--- a/tests/devices/qubit_mixed/test_qubit_mixed_initialize_state.py
+++ b/tests/devices/qubit_mixed/test_qubit_mixed_initialize_state.py
@@ -17,7 +17,7 @@ import pytest
 
 import pennylane as qml
 from pennylane import StatePrep, math
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane.devices.qubit_mixed import create_initial_state
 from pennylane.operation import StatePrepBase
 
@@ -26,7 +26,7 @@ ml_interfaces = ["numpy", "autograd", "jax", "torch", "tensorflow"]
 
 def allzero_vec(num_wires, interface="numpy"):
     """Returns the state vector of the all-zero state."""
-    state = np.zeros(2**num_wires, dtype=complex)
+    state = pnp.zeros(2**num_wires, dtype=complex)
     state[0] = 1
     state = math.asarray(state, like=interface)
     return state
@@ -35,7 +35,7 @@ def allzero_vec(num_wires, interface="numpy"):
 def allzero_dm(num_wires, interface="numpy"):
     """Returns the density matrix of the all-zero state."""
     num_axes = 2 * num_wires
-    dm = np.zeros((2,) * num_axes, dtype=complex)
+    dm = pnp.zeros((2,) * num_axes, dtype=complex)
     dm[(0,) * num_axes] = 1
     dm = math.asarray(dm, like=interface)
     return dm

--- a/tests/devices/qutrit_mixed/test_qutrit_mixed_initialize_state.py
+++ b/tests/devices/qutrit_mixed/test_qutrit_mixed_initialize_state.py
@@ -17,7 +17,7 @@ import pytest
 
 import pennylane as qml
 from pennylane import QutritBasisState
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane.devices.qutrit_mixed import create_initial_state
 from pennylane.operation import StatePrepBase
 
@@ -39,7 +39,7 @@ class TestInitializeState:
     def test_create_initial_state_no_state_prep(self, interface):
         """Tests that create_initial_state works without a state-prep operation."""
         state = create_initial_state([0, 1], like=interface)
-        expected = np.zeros((3, 3, 3, 3))
+        expected = pnp.zeros((3, 3, 3, 3))
         expected[0, 0, 0, 0] = 1
         assert qml.math.allequal(state, expected)
         assert qml.math.get_interface(state) == interface
@@ -49,10 +49,10 @@ class TestInitializeState:
     def test_create_initial_state_with_state_prep(self, interface):
         """Tests that create_initial_state works with a state-prep operation."""
         prep_op = self.DefaultPrep(
-            qml.math.array([1 / np.sqrt(9)] * 9, like=interface), wires=[0, 1]
+            qml.math.array([1 / pnp.sqrt(9)] * 9, like=interface), wires=[0, 1]
         )
         state = create_initial_state([0, 1], prep_operation=prep_op)
-        expected = np.reshape([1 / 9] * 81, [3, 3, 3, 3])
+        expected = pnp.reshape([1 / 9] * 81, [3, 3, 3, 3])
 
         assert qml.math.allequal(state, expected)
         if interface == "autograd":
@@ -66,13 +66,13 @@ class TestInitializeState:
         state = create_initial_state([0, 1, 2], prep_operation=prep_op)
         assert state[1, 2, 0, 1, 2, 0] == 1
         state[1, 2, 0, 1, 2, 0] = 0  # set to zero to make test below simple
-        assert qml.math.allequal(state, np.zeros(([3] * 6)))
+        assert qml.math.allequal(state, pnp.zeros(([3] * 6)))
 
     @pytest.mark.parametrize("wires", [(0, 1), qml.wires.Wires([0, 1])])
     def test_create_initial_state_wires(self, wires):
         """Tests that create_initial_state works with qml.Wires object and list."""
         state = create_initial_state(wires)
-        expected = np.zeros((3, 3, 3, 3))
+        expected = pnp.zeros((3, 3, 3, 3))
         expected[0, 0, 0, 0] = 1
         assert qml.math.allequal(state, expected)
 
@@ -86,6 +86,6 @@ class TestInitializeState:
     @pytest.mark.torch
     def test_create_initial_state_casts_to_like_with_prep_op(self):
         """Tests that the like argument is not ignored when a prep-op is provided."""
-        prep_op = self.DefaultPrep([1 / np.sqrt(9)] * 9, wires=[0, 1])
+        prep_op = self.DefaultPrep([1 / pnp.sqrt(9)] * 9, wires=[0, 1])
         state = create_initial_state([0, 1], prep_operation=prep_op, like="torch")
         assert qml.math.get_interface(state) == "torch"

--- a/tests/devices/test_default_mixed_autograd.py
+++ b/tests/devices/test_default_mixed_autograd.py
@@ -19,7 +19,7 @@ import pytest
 
 import pennylane as qml
 from pennylane import DeviceError
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane.devices.default_mixed import DefaultMixed
 
 pytestmark = pytest.mark.autograd
@@ -74,7 +74,7 @@ class TestQNodeIntegration:
     def test_qubit_circuit(self, tol):
         """Test that the device provides the correct
         result for a simple circuit."""
-        p = np.array(0.543)
+        p = pnp.array(0.543)
 
         dev = qml.device("default.mixed", wires=1)
 
@@ -83,9 +83,9 @@ class TestQNodeIntegration:
             qml.RX(x, wires=0)
             return qml.expval(qml.PauliY(0))
 
-        expected = -np.sin(p)
+        expected = -pnp.sin(p)
 
-        assert np.isclose(circuit(p), expected, atol=tol, rtol=0)
+        assert pnp.isclose(circuit(p), expected, atol=tol, rtol=0)
 
     def test_correct_state(self, tol):
         """Test that the device state is correct after evaluating a
@@ -94,32 +94,32 @@ class TestQNodeIntegration:
         dev = qml.device("default.mixed", wires=2)
 
         state = dev.state
-        expected = np.zeros((4, 4))
+        expected = pnp.zeros((4, 4))
         expected[0, 0] = 1
-        assert np.allclose(state, expected, atol=tol, rtol=0)
+        assert pnp.allclose(state, expected, atol=tol, rtol=0)
 
         @qml.qnode(dev, interface="autograd", diff_method="backprop")
         def circuit():
             qml.Hadamard(wires=0)
-            qml.RZ(np.pi / 4, wires=0)
+            qml.RZ(pnp.pi / 4, wires=0)
             return qml.expval(qml.PauliZ(0))
 
         circuit()
         state = dev.state
 
-        amplitude = np.exp(-1j * np.pi / 4) / 2
-        expected = np.array(
-            [[0.5, 0, amplitude, 0], [0, 0, 0, 0], [np.conj(amplitude), 0, 0.5, 0], [0, 0, 0, 0]]
+        amplitude = pnp.exp(-1j * pnp.pi / 4) / 2
+        expected = pnp.array(
+            [[0.5, 0, amplitude, 0], [0, 0, 0, 0], [pnp.conj(amplitude), 0, 0.5, 0], [0, 0, 0, 0]]
         )
 
-        assert np.allclose(state, expected, atol=tol, rtol=0)
+        assert pnp.allclose(state, expected, atol=tol, rtol=0)
 
 
 class TestDtypePreserved:
     """Test that the user-defined dtype of the device is preserved for QNode
     evaluation"""
 
-    @pytest.mark.parametrize("r_dtype", [np.float32, np.float64])
+    @pytest.mark.parametrize("r_dtype", [pnp.float32, pnp.float64])
     @pytest.mark.parametrize(
         "measurement",
         [
@@ -154,7 +154,7 @@ class TestDtypePreserved:
         """Test that the user-defined dtype of the device is preserved
         for QNodes with complex-valued outputs"""
         p = 0.543
-        c_dtype = np.dtype(c_dtype_name)
+        c_dtype = pnp.dtype(c_dtype_name)
 
         dev = qml.device("default.mixed", wires=3, c_dtype=c_dtype)
 
@@ -181,53 +181,53 @@ class TestOps:
             qml.MultiRZ(param, wires=[0, 1])
             return qml.probs(wires=list(range(wires)))
 
-        param = np.array(0.3, requires_grad=True)
+        param = pnp.array(0.3, requires_grad=True)
         res = qml.jacobian(circuit)(param)
-        assert np.allclose(res, np.zeros(wires**2))
+        assert pnp.allclose(res, pnp.zeros(wires**2))
 
     def test_full_subsystem(self, mocker):
         """Test applying a state vector to the full subsystem"""
         dev = DefaultMixed(wires=["a", "b", "c"])
-        state = np.array([1, 0, 0, 0, 1, 0, 1, 1]) / 2.0
+        state = pnp.array([1, 0, 0, 0, 1, 0, 1, 1]) / 2.0
         state_wires = qml.wires.Wires(["a", "b", "c"])
 
         spy = mocker.spy(qml.math, "scatter")
         dev._apply_state_vector(state=state, device_wires=state_wires)
 
-        state = np.outer(state, np.conj(state))
+        state = pnp.outer(state, pnp.conj(state))
 
-        assert np.all(dev._state.flatten() == state.flatten())
+        assert pnp.all(dev._state.flatten() == state.flatten())
         spy.assert_not_called()
 
     def test_partial_subsystem(self, mocker):
         """Test applying a state vector to a subset of wires of the full subsystem"""
 
         dev = DefaultMixed(wires=["a", "b", "c"])
-        state = np.array([1, 0, 1, 0]) / np.sqrt(2.0)
+        state = pnp.array([1, 0, 1, 0]) / pnp.sqrt(2.0)
         state_wires = qml.wires.Wires(["a", "c"])
 
         spy = mocker.spy(qml.math, "scatter")
         dev._apply_state_vector(state=state, device_wires=state_wires)
 
-        state = np.kron(np.outer(state, np.conj(state)), np.array([[1, 0], [0, 0]]))
+        state = pnp.kron(pnp.outer(state, pnp.conj(state)), pnp.array([[1, 0], [0, 0]]))
 
-        assert np.all(np.reshape(dev._state, (8, 8)) == state)
+        assert pnp.all(pnp.reshape(dev._state, (8, 8)) == state)
         spy.assert_called()
 
 
 @pytest.mark.parametrize(
     "op, exp_method, dev_wires",
     [
-        (qml.RX(np.array(0.2), 0), "_apply_channel", 1),
-        (qml.RX(np.array(0.2), 0), "_apply_channel", 8),
+        (qml.RX(pnp.array(0.2), 0), "_apply_channel", 1),
+        (qml.RX(pnp.array(0.2), 0), "_apply_channel", 8),
         (qml.CNOT([0, 1]), "_apply_channel", 3),
         (qml.CNOT([0, 1]), "_apply_channel", 8),
         (qml.MultiControlledX(wires=list(range(2))), "_apply_channel", 3),
         (qml.MultiControlledX(wires=list(range(3))), "_apply_channel_tensordot", 3),
         (qml.MultiControlledX(wires=list(range(8))), "_apply_channel_tensordot", 8),
-        (qml.PauliError("X", np.array(0.5), 0), "_apply_channel", 2),
-        (qml.PauliError("XXX", np.array(0.5), [0, 1, 2]), "_apply_channel_tensordot", 4),
-        (qml.PauliError("X" * 8, np.array(0.5), list(range(8))), "_apply_channel_tensordot", 8),
+        (qml.PauliError("X", pnp.array(0.5), 0), "_apply_channel", 2),
+        (qml.PauliError("XXX", pnp.array(0.5), [0, 1, 2]), "_apply_channel_tensordot", 4),
+        (qml.PauliError("X" * 8, pnp.array(0.5), list(range(8))), "_apply_channel_tensordot", 8),
     ],
 )
 def test_method_choice(mocker, op, exp_method, dev_wires):
@@ -255,7 +255,7 @@ class TestPassthruIntegration:
         x = 0.43316321
         y = 0.2162158
         z = 0.75110998
-        weights = np.array([x, y, z], requires_grad=True)
+        weights = pnp.array([x, y, z], requires_grad=True)
 
         dev = qml.device("default.mixed", wires=1)
 
@@ -268,21 +268,21 @@ class TestPassthruIntegration:
 
         res = circuit(weights)
 
-        expected = np.cos(3 * x) * np.cos(y) * np.cos(z / 2) - np.sin(3 * x) * np.sin(z / 2)
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        expected = pnp.cos(3 * x) * pnp.cos(y) * pnp.cos(z / 2) - pnp.sin(3 * x) * pnp.sin(z / 2)
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
         grad_fn = qml.jacobian(circuit, 0)
-        res = grad_fn(np.array(weights))
+        res = grad_fn(pnp.array(weights))
 
-        expected = np.array(
+        expected = pnp.array(
             [
-                -3 * (np.sin(3 * x) * np.cos(y) * np.cos(z / 2) + np.cos(3 * x) * np.sin(z / 2)),
-                -np.cos(3 * x) * np.sin(y) * np.cos(z / 2),
-                -0.5 * (np.sin(3 * x) * np.cos(z / 2) + np.cos(3 * x) * np.cos(y) * np.sin(z / 2)),
+                -3 * (pnp.sin(3 * x) * pnp.cos(y) * pnp.cos(z / 2) + pnp.cos(3 * x) * pnp.sin(z / 2)),
+                -pnp.cos(3 * x) * pnp.sin(y) * pnp.cos(z / 2),
+                -0.5 * (pnp.sin(3 * x) * pnp.cos(z / 2) + pnp.cos(3 * x) * pnp.cos(y) * pnp.sin(z / 2)),
             ]
         )
 
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
     def test_jacobian_repeated(self, tol):
         """Test that jacobian of a QNode with an attached default.mixed.autograd device
@@ -290,7 +290,7 @@ class TestPassthruIntegration:
         x = 0.43316321
         y = 0.2162158
         z = 0.75110998
-        p = np.array([x, y, z], requires_grad=True)
+        p = pnp.array([x, y, z], requires_grad=True)
         dev = qml.device("default.mixed", wires=1)
 
         @qml.qnode(dev, interface="autograd", diff_method="backprop")
@@ -301,21 +301,21 @@ class TestPassthruIntegration:
 
         res = circuit(p)
 
-        expected = np.cos(y) ** 2 - np.sin(x) * np.sin(y) ** 2
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        expected = pnp.cos(y) ** 2 - pnp.sin(x) * pnp.sin(y) ** 2
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
         grad_fn = qml.jacobian(circuit, 0)
         res = grad_fn(p)
 
-        expected = np.array(
-            [-np.cos(x) * np.sin(y) ** 2, -2 * (np.sin(x) + 1) * np.sin(y) * np.cos(y), 0]
+        expected = pnp.array(
+            [-pnp.cos(x) * pnp.sin(y) ** 2, -2 * (pnp.sin(x) + 1) * pnp.sin(y) * pnp.cos(y), 0]
         )
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
     def test_jacobian_agrees_backprop_parameter_shift(self, tol):
         """Test that jacobian of a QNode with an attached default.mixed.autograd device
         gives the correct result with respect to the parameter-shift method"""
-        p = np.array([0.43316321, 0.2162158, 0.75110998, 0.94714242], requires_grad=True)
+        p = pnp.array([0.43316321, 0.2162158, 0.75110998, 0.94714242], requires_grad=True)
 
         def circuit(x):
             for i in range(0, len(p), 2):
@@ -336,16 +336,16 @@ class TestPassthruIntegration:
 
         res = circuit1(p)
 
-        assert np.allclose(res, circuit2(p), atol=tol, rtol=0)
+        assert pnp.allclose(res, circuit2(p), atol=tol, rtol=0)
 
         grad_fn = qml.jacobian(circuit1, 0)
         res = grad_fn(p)
-        assert np.allclose(res, qml.jacobian(circuit2)(p), atol=tol, rtol=0)
+        assert pnp.allclose(res, qml.jacobian(circuit2)(p), atol=tol, rtol=0)
 
     @pytest.mark.parametrize(
         "op, wire_ids, exp_fn",
         [
-            (qml.RY, [0], lambda a: -np.sin(a)),
+            (qml.RY, [0], lambda a: -pnp.sin(a)),
             (qml.AmplitudeDamping, [0], lambda a: -2),
             (qml.DepolarizingChannel, [-1], lambda a: -4 / 3),
             (lambda a, wires: qml.ResetError(p0=a, p1=0.1, wires=wires), [0], lambda a: -2),
@@ -364,18 +364,18 @@ class TestPassthruIntegration:
             op(a, wires=[wires[idx] for idx in wire_ids])
             return qml.state()
 
-        a = np.array(0.23, requires_grad=True)
+        a = pnp.array(0.23, requires_grad=True)
 
         def cost(a):
             """A function of the device quantum state, as a function
             of input QNode parameters."""
             state = circuit(a)
-            res = np.abs(state) ** 2
+            res = pnp.abs(state) ** 2
             return res[1][1] - res[0][0]
 
         grad = qml.grad(cost)(a)
         expected = exp_fn(a)
-        assert np.allclose(grad, expected, atol=tol, rtol=0)
+        assert pnp.allclose(grad, expected, atol=tol, rtol=0)
 
     @pytest.mark.parametrize("wires", [range(2), [-12.32, "abc"]])
     def test_density_matrix_differentiability(self, wires, tol):
@@ -388,18 +388,18 @@ class TestPassthruIntegration:
             qml.CNOT(wires=[wires[0], wires[1]])
             return qml.density_matrix(wires=wires[1])
 
-        a = np.array(0.54, requires_grad=True)
+        a = pnp.array(0.54, requires_grad=True)
 
         def cost(a):
             """A function of the device quantum state, as a function
             of input QNode parameters."""
             state = circuit(a)
-            res = np.abs(state) ** 2
+            res = pnp.abs(state) ** 2
             return res[1][1] - res[0][0]
 
         grad = qml.grad(cost)(a)
-        expected = np.sin(a)
-        assert np.allclose(grad, expected, atol=tol, rtol=0)
+        expected = pnp.sin(a)
+        assert pnp.allclose(grad, expected, atol=tol, rtol=0)
 
     def test_prob_differentiability(self, tol):
         """Test that the device probability can be differentiated"""
@@ -412,20 +412,20 @@ class TestPassthruIntegration:
             qml.CNOT(wires=[0, 1])
             return qml.probs(wires=[1])
 
-        a = np.array(0.54, requires_grad=True)
-        b = np.array(0.12, requires_grad=True)
+        a = pnp.array(0.54, requires_grad=True)
+        b = pnp.array(0.12, requires_grad=True)
 
         def cost(a, b):
             prob_wire_1 = circuit(a, b)
             return prob_wire_1[1] - prob_wire_1[0]
 
         res = cost(a, b)
-        expected = -np.cos(a) * np.cos(b)
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        expected = -pnp.cos(a) * pnp.cos(b)
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
         grad = qml.grad(cost)(a, b)
-        expected = [np.sin(a) * np.cos(b), np.cos(a) * np.sin(b)]
-        assert np.allclose(grad, expected, atol=tol, rtol=0)
+        expected = [pnp.sin(a) * pnp.cos(b), pnp.cos(a) * pnp.sin(b)]
+        assert pnp.allclose(grad, expected, atol=tol, rtol=0)
 
     def test_prob_vector_differentiability(self, tol):
         """Test that the device probability vector can be differentiated directly"""
@@ -438,25 +438,25 @@ class TestPassthruIntegration:
             qml.CNOT(wires=[0, 1])
             return qml.probs(wires=[1])
 
-        a = np.array(0.54, requires_grad=True)
-        b = np.array(0.12, requires_grad=True)
+        a = pnp.array(0.54, requires_grad=True)
+        b = pnp.array(0.12, requires_grad=True)
 
         res = circuit(a, b)
         expected = [
-            np.cos(a / 2) ** 2 * np.cos(b / 2) ** 2 + np.sin(a / 2) ** 2 * np.sin(b / 2) ** 2,
-            np.cos(a / 2) ** 2 * np.sin(b / 2) ** 2 + np.sin(a / 2) ** 2 * np.cos(b / 2) ** 2,
+            pnp.cos(a / 2) ** 2 * pnp.cos(b / 2) ** 2 + pnp.sin(a / 2) ** 2 * pnp.sin(b / 2) ** 2,
+            pnp.cos(a / 2) ** 2 * pnp.sin(b / 2) ** 2 + pnp.sin(a / 2) ** 2 * pnp.cos(b / 2) ** 2,
         ]
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
         grad = qml.jacobian(circuit)(a, b)
-        expected = 0.5 * np.array(
+        expected = 0.5 * pnp.array(
             [
-                [-np.sin(a) * np.cos(b), np.sin(a) * np.cos(b)],
-                [-np.cos(a) * np.sin(b), np.cos(a) * np.sin(b)],
+                [-pnp.sin(a) * pnp.cos(b), pnp.sin(a) * pnp.cos(b)],
+                [-pnp.cos(a) * pnp.sin(b), pnp.cos(a) * pnp.sin(b)],
             ]
         )
 
-        assert np.allclose(grad, expected, atol=tol, rtol=0)
+        assert pnp.allclose(grad, expected, atol=tol, rtol=0)
 
     def test_sample_backprop_error(self):
         """Test that sampling in backpropagation mode raises an error"""
@@ -482,22 +482,22 @@ class TestPassthruIntegration:
             qml.CRX(b, wires=[0, 1])
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
-        a = np.array(-0.234, requires_grad=True)
-        b = np.array(0.654, requires_grad=True)
+        a = pnp.array(-0.234, requires_grad=True)
+        b = pnp.array(0.654, requires_grad=True)
 
         res = circuit(a, b)
-        expected_cost = 0.5 * (np.cos(a) * np.cos(b) + np.cos(a) - np.cos(b) + 1)
-        assert np.allclose(res, expected_cost, atol=tol, rtol=0)
+        expected_cost = 0.5 * (pnp.cos(a) * pnp.cos(b) + pnp.cos(a) - pnp.cos(b) + 1)
+        assert pnp.allclose(res, expected_cost, atol=tol, rtol=0)
 
         res = qml.grad(circuit)(a, b)
-        expected_grad = np.array(
-            [-0.5 * np.sin(a) * (np.cos(b) + 1), 0.5 * np.sin(b) * (1 - np.cos(a))]
+        expected_grad = pnp.array(
+            [-0.5 * pnp.sin(a) * (pnp.cos(b) + 1), 0.5 * pnp.sin(b) * (1 - pnp.cos(a))]
         )
-        assert np.allclose(res, expected_grad, atol=tol, rtol=0)
+        assert pnp.allclose(res, expected_grad, atol=tol, rtol=0)
 
     @pytest.mark.parametrize(
         "x, shift",
-        [np.array((0.0, 0.0), requires_grad=True), np.array((0.5, -0.5), requires_grad=True)],
+        [pnp.array((0.0, 0.0), requires_grad=True), pnp.array((0.5, -0.5), requires_grad=True)],
     )
     def test_hessian_at_zero(self, x, shift):
         """Tests that the Hessian at vanishing state vector amplitudes
@@ -520,7 +520,7 @@ class TestPassthruIntegration:
         """Tests that the gradient of an arbitrary U3 gate is correct
         using the Autograd interface, using a variety of differentiation methods."""
         dev = qml.device("default.mixed", wires=1)
-        state = np.array(1j * np.array([1, -1]) / np.sqrt(2), requires_grad=False)
+        state = pnp.array(1j * pnp.array([1, -1]) / pnp.sqrt(2), requires_grad=False)
 
         @qml.qnode(dev, diff_method=diff_method, interface="autograd")
         def circuit(x, weights, w):
@@ -538,25 +538,25 @@ class TestPassthruIntegration:
         phi = -0.234
         lam = 0.654
 
-        params = np.array([theta, phi, lam], requires_grad=True)
+        params = pnp.array([theta, phi, lam], requires_grad=True)
 
         res = cost(params)
-        expected_cost = (np.sin(lam) * np.sin(phi) - np.cos(theta) * np.cos(lam) * np.cos(phi)) ** 2
-        assert np.allclose(res, expected_cost, atol=tol, rtol=0)
+        expected_cost = (pnp.sin(lam) * pnp.sin(phi) - pnp.cos(theta) * pnp.cos(lam) * pnp.cos(phi)) ** 2
+        assert pnp.allclose(res, expected_cost, atol=tol, rtol=0)
 
         res = qml.grad(cost)(params)
         expected_grad = (
-            np.array(
+            pnp.array(
                 [
-                    np.sin(theta) * np.cos(lam) * np.cos(phi),
-                    np.cos(theta) * np.cos(lam) * np.sin(phi) + np.sin(lam) * np.cos(phi),
-                    np.cos(theta) * np.sin(lam) * np.cos(phi) + np.cos(lam) * np.sin(phi),
+                    pnp.sin(theta) * pnp.cos(lam) * pnp.cos(phi),
+                    pnp.cos(theta) * pnp.cos(lam) * pnp.sin(phi) + pnp.sin(lam) * pnp.cos(phi),
+                    pnp.cos(theta) * pnp.sin(lam) * pnp.cos(phi) + pnp.cos(lam) * pnp.sin(phi),
                 ]
             )
             * 2
-            * (np.sin(lam) * np.sin(phi) - np.cos(theta) * np.cos(lam) * np.cos(phi))
+            * (pnp.sin(lam) * pnp.sin(phi) - pnp.cos(theta) * pnp.cos(lam) * pnp.cos(phi))
         )
-        assert np.allclose(res, expected_grad, atol=tol, rtol=0)
+        assert pnp.allclose(res, expected_grad, atol=tol, rtol=0)
 
     @pytest.mark.parametrize(
         "dev_name,diff_method,mode",
@@ -570,8 +570,8 @@ class TestPassthruIntegration:
         """Tests correct output shape and evaluation for a tape
         with prob and expval outputs"""
         dev = qml.device(dev_name, wires=2)
-        x = np.array(0.543, requires_grad=True)
-        y = np.array(-0.654, requires_grad=True)
+        x = pnp.array(0.543, requires_grad=True)
+        y = pnp.array(-0.654, requires_grad=True)
 
         @qml.qnode(dev, diff_method=diff_method, interface="autograd", grad_on_execution=mode)
         def circuit(x, y):
@@ -582,10 +582,10 @@ class TestPassthruIntegration:
 
         res = circuit(x, y)
 
-        expected = np.array(
-            [np.cos(x), (1 + np.cos(x) * np.cos(y)) / 2, (1 - np.cos(x) * np.cos(y)) / 2]
+        expected = pnp.array(
+            [pnp.cos(x), (1 + pnp.cos(x) * pnp.cos(y)) / 2, (1 - pnp.cos(x) * pnp.cos(y)) / 2]
         )
-        assert np.allclose(qml.math.hstack(res), expected, atol=tol, rtol=0)
+        assert pnp.allclose(qml.math.hstack(res), expected, atol=tol, rtol=0)
 
         def cost(x, y):
             return qml.math.hstack(circuit(x, y))
@@ -596,11 +596,11 @@ class TestPassthruIntegration:
         assert res[1].shape == (3,)
 
         expected = (
-            np.array([-np.sin(x), -np.sin(x) * np.cos(y) / 2, np.sin(x) * np.cos(y) / 2]),
-            np.array([0, -np.cos(x) * np.sin(y) / 2, np.cos(x) * np.sin(y) / 2]),
+            pnp.array([-pnp.sin(x), -pnp.sin(x) * pnp.cos(y) / 2, pnp.sin(x) * pnp.cos(y) / 2]),
+            pnp.array([0, -pnp.cos(x) * pnp.sin(y) / 2, pnp.cos(x) * pnp.sin(y) / 2]),
         )
-        assert np.allclose(res[0], expected[0], atol=tol, rtol=0)
-        assert np.allclose(res[1], expected[1], atol=tol, rtol=0)
+        assert pnp.allclose(res[0], expected[0], atol=tol, rtol=0)
+        assert pnp.allclose(res[1], expected[1], atol=tol, rtol=0)
 
     def test_batching(self, tol):
         """Tests that the gradient of the qnode is correct with batching"""
@@ -613,21 +613,21 @@ class TestPassthruIntegration:
             qml.CRX(b, wires=[0, 1])
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
-        a = np.array([-0.234, 0.678], requires_grad=True)
-        b = np.array([0.654, 1.236], requires_grad=True)
+        a = pnp.array([-0.234, 0.678], requires_grad=True)
+        b = pnp.array([0.654, 1.236], requires_grad=True)
 
         res = circuit(a, b)
-        expected_cost = 0.5 * (np.cos(a) * np.cos(b) + np.cos(a) - np.cos(b) + 1)
-        assert np.allclose(res, expected_cost, atol=tol, rtol=0)
+        expected_cost = 0.5 * (pnp.cos(a) * pnp.cos(b) + pnp.cos(a) - pnp.cos(b) + 1)
+        assert pnp.allclose(res, expected_cost, atol=tol, rtol=0)
 
         res_a, res_b = qml.jacobian(circuit)(a, b)
         expected_a, expected_b = [
-            -0.5 * np.sin(a) * (np.cos(b) + 1),
-            0.5 * np.sin(b) * (1 - np.cos(a)),
+            -0.5 * pnp.sin(a) * (pnp.cos(b) + 1),
+            0.5 * pnp.sin(b) * (1 - pnp.cos(a)),
         ]
 
-        assert np.allclose(np.diag(res_a), expected_a, atol=tol, rtol=0)
-        assert np.allclose(np.diag(res_b), expected_b, atol=tol, rtol=0)
+        assert pnp.allclose(pnp.diag(res_a), expected_a, atol=tol, rtol=0)
+        assert pnp.allclose(pnp.diag(res_b), expected_b, atol=tol, rtol=0)
 
 
 # pylint: disable=too-few-public-methods
@@ -644,7 +644,7 @@ class TestHighLevelIntegration:
             return qml.expval(qml.PauliZ(0))
 
         shape = qml.templates.StronglyEntanglingLayers.shape(n_layers=2, n_wires=2)
-        weights = np.random.random(shape, requires_grad=True)
+        weights = pnp.random.random(shape, requires_grad=True)
 
         grad = qml.grad(circuit)(weights)
         assert grad.shape == weights.shape
@@ -673,7 +673,7 @@ class TestMeasurements:
             qml.CRX(x, wires=[0, 1])
             return qml.apply(measurement)
 
-        res = circuit(np.array(0.5))
+        res = circuit(pnp.array(0.5))
 
         assert len(res) == 2 if isinstance(measurement, qml.measurements.CountsMP) else num_shots
 
@@ -694,7 +694,7 @@ class TestMeasurements:
         def cost(angle):
             return qml.math.hstack(circuit(angle))
 
-        angle = np.array(0.1234)
+        angle = pnp.array(0.1234)
 
-        assert isinstance(qml.jacobian(cost)(angle), np.ndarray)
+        assert isinstance(qml.jacobian(cost)(angle), pnp.ndarray)
         assert len(cost(angle)) == num_shots

--- a/tests/devices/test_default_qutrit.py
+++ b/tests/devices/test_default_qutrit.py
@@ -22,19 +22,19 @@ from gate_data import GELL_MANN, OMEGA, TADD, TCLOCK, TSHIFT, TSWAP
 from scipy.stats import unitary_group
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane.wires import WireError, Wires
 
-U_thadamard_01 = np.multiply(
-    1 / np.sqrt(2),
-    np.array(
-        [[1, 1, 0], [1, -1, 0], [0, 0, np.sqrt(2)]],
+U_thadamard_01 = pnp.multiply(
+    1 / pnp.sqrt(2),
+    pnp.array(
+        [[1, 1, 0], [1, -1, 0], [0, 0, pnp.sqrt(2)]],
     ),
 )
 
-U_x_02 = np.array([[0, 0, 1], [0, 1, 0], [1, 0, 0]], dtype=np.complex128)
+U_x_02 = pnp.array([[0, 0, 1], [0, 1, 0], [1, 0, 0]], dtype=pnp.complex128)
 
-U_z_12 = np.array([[1, 0, 0], [0, 1, 0], [0, 0, -1]], dtype=np.complex128)
+U_z_12 = pnp.array([[1, 0, 0], [0, 1, 0], [0, 0, -1]], dtype=pnp.complex128)
 
 
 def test_analytic_deprecation():
@@ -49,11 +49,11 @@ def test_analytic_deprecation():
 def test_dtype_errors():
     """Test that if an incorrect dtype is provided to the device then an error is raised."""
     with pytest.raises(qml.DeviceError, match="Real datatype must be a floating point type."):
-        qml.device("default.qutrit", wires=1, r_dtype=np.complex128)
+        qml.device("default.qutrit", wires=1, r_dtype=pnp.complex128)
     with pytest.raises(
         qml.DeviceError, match="Complex datatype must be a complex floating point type."
     ):
-        qml.device("default.qutrit", wires=1, c_dtype=np.float64)
+        qml.device("default.qutrit", wires=1, c_dtype=pnp.float64)
 
 
 # TODO: Add tests to check for dtype preservation after more ops and observables have been added
@@ -68,24 +68,24 @@ class TestApply:
 
     # TODO: Add tests for non-parametric ops after they're implemented
     test_data_no_parameters = [
-        (qml.TShift, [1, 0, 0], np.array([0, 1, 0]), None),
+        (qml.TShift, [1, 0, 0], pnp.array([0, 1, 0]), None),
         (
             qml.TShift,
             [1 / math.sqrt(2), 1 / math.sqrt(2), 0],
-            np.array([0, 1 / math.sqrt(2), 1 / math.sqrt(2)]),
+            pnp.array([0, 1 / math.sqrt(2), 1 / math.sqrt(2)]),
             None,
         ),
-        (qml.TClock, [1, 0, 0], np.array([1, 0, 0]), None),
-        (qml.TClock, [0, 1, 0], np.array([0, OMEGA, 0]), None),
-        (qml.THadamard, [0, 1, 0], np.array([0, 1, 0]), [0, 2]),
+        (qml.TClock, [1, 0, 0], pnp.array([1, 0, 0]), None),
+        (qml.TClock, [0, 1, 0], pnp.array([0, OMEGA, 0]), None),
+        (qml.THadamard, [0, 1, 0], pnp.array([0, 1, 0]), [0, 2]),
         (
             qml.THadamard,
-            [1 / np.sqrt(2), 0, 1 / np.sqrt(2)],
-            np.array([1 / np.sqrt(2), 0.5, -0.5]),
+            [1 / pnp.sqrt(2), 0, 1 / pnp.sqrt(2)],
+            pnp.array([1 / pnp.sqrt(2), 0.5, -0.5]),
             [1, 2],
         ),
-        (qml.THadamard, [0, 1, 0], np.array([1, OMEGA, OMEGA**2]) * (-1j / np.sqrt(3)), None),
-        (qml.THadamard, [0, 0, 1], np.array([1, OMEGA**2, OMEGA]) * (-1j / np.sqrt(3)), None),
+        (qml.THadamard, [0, 1, 0], pnp.array([1, OMEGA, OMEGA**2]) * (-1j / pnp.sqrt(3)), None),
+        (qml.THadamard, [0, 0, 1], pnp.array([1, OMEGA**2, OMEGA]) * (-1j / pnp.sqrt(3)), None),
     ]
 
     @pytest.mark.parametrize("operation, input, expected_output, subspace", test_data_no_parameters)
@@ -95,15 +95,15 @@ class TestApply:
         """Tests that applying an operation yields the expected output state for single wire
         operations that have no parameters."""
 
-        qutrit_device_1_wire.target_device._state = np.array(
+        qutrit_device_1_wire.target_device._state = pnp.array(
             input, dtype=qutrit_device_1_wire.C_DTYPE
         )
         qutrit_device_1_wire.apply(
             [operation(wires=[0]) if subspace is None else operation(wires=[0], subspace=subspace)]
         )
 
-        assert np.allclose(
-            qutrit_device_1_wire.target_device._state, np.array(expected_output), atol=tol, rtol=0
+        assert pnp.allclose(
+            qutrit_device_1_wire.target_device._state, pnp.array(expected_output), atol=tol, rtol=0
         )
         assert qutrit_device_1_wire.target_device._state.dtype == qutrit_device_1_wire.C_DTYPE
 
@@ -113,7 +113,7 @@ class TestApply:
     ):
         """Tests that applying an adjoint operation yields the expected output state for single wire
         operations that have no parameters."""
-        qutrit_device_1_wire.target_device._state = np.array(
+        qutrit_device_1_wire.target_device._state = pnp.array(
             input, dtype=qutrit_device_1_wire.C_DTYPE
         )
         qutrit_device_1_wire.apply(
@@ -126,39 +126,39 @@ class TestApply:
             ]
         )
 
-        assert np.allclose(
-            qutrit_device_1_wire.target_device._state, np.array(expected_output), atol=tol, rtol=0
+        assert pnp.allclose(
+            qutrit_device_1_wire.target_device._state, pnp.array(expected_output), atol=tol, rtol=0
         )
         assert qutrit_device_1_wire.target_device._state.dtype == qutrit_device_1_wire.C_DTYPE
 
     test_data_two_wires_no_parameters = [
-        (qml.TSWAP, [0, 1, 0, 0, 0, 0, 0, 0, 0], np.array([0, 0, 0, 1, 0, 0, 0, 0, 0]), None),
+        (qml.TSWAP, [0, 1, 0, 0, 0, 0, 0, 0, 0], pnp.array([0, 0, 0, 1, 0, 0, 0, 0, 0]), None),
         (
             qml.TSWAP,
             [0, 0, 0, 1 / math.sqrt(2), 0, 0, 0, 0, 1 / math.sqrt(2)],
-            np.array([0, 1 / math.sqrt(2), 0, 0, 0, 0, 0, 0, 1 / math.sqrt(2)]),
+            pnp.array([0, 1 / math.sqrt(2), 0, 0, 0, 0, 0, 0, 1 / math.sqrt(2)]),
             None,
         ),
         (
             qml.TSWAP,
             [0, 0, 0, -1j / math.sqrt(3), 0, 0, 0, -1 / math.sqrt(3), 1j / math.sqrt(3)],
-            np.array([0, -1j / math.sqrt(3), 0, 0, 0, -1 / math.sqrt(3), 0, 0, 1j / math.sqrt(3)]),
+            pnp.array([0, -1j / math.sqrt(3), 0, 0, 0, -1 / math.sqrt(3), 0, 0, 1j / math.sqrt(3)]),
             None,
         ),
     ]
 
     test_data_tadd = [
-        (qml.TAdd, [0, 0, 0, 0, 1, 0, 0, 0, 0], np.array([0, 0, 0, 0, 0, 1, 0, 0, 0]), None),
+        (qml.TAdd, [0, 0, 0, 0, 1, 0, 0, 0, 0], pnp.array([0, 0, 0, 0, 0, 1, 0, 0, 0]), None),
         (
             qml.TAdd,
             [0, 0, 0, 1 / math.sqrt(2), 0, 0, 0, 1 / math.sqrt(2), 0],
-            np.array([0, 0, 0, 0, 1 / math.sqrt(2), 0, 1 / math.sqrt(2), 0, 0]),
+            pnp.array([0, 0, 0, 0, 1 / math.sqrt(2), 0, 1 / math.sqrt(2), 0, 0]),
             None,
         ),
         (
             qml.TAdd,
             [0, 0.5, -0.5, 0, -0.5 * 1j, 0, 0, 0, 0.5 * 1j],
-            np.array([0, 0.5, -0.5, 0, 0, -0.5 * 1j, 0, 0.5 * 1j, 0]),
+            pnp.array([0, 0.5, -0.5, 0, 0, -0.5 * 1j, 0, 0.5 * 1j, 0]),
             None,
         ),
     ]
@@ -174,7 +174,7 @@ class TestApply:
         """Tests that applying an operation yields the expected output state for two wire
         operations that have no parameters."""
 
-        qutrit_device_2_wires.target_device._state = np.array(
+        qutrit_device_2_wires.target_device._state = pnp.array(
             input, dtype=qutrit_device_2_wires.C_DTYPE
         ).reshape((3, 3))
         qutrit_device_2_wires.apply(
@@ -187,9 +187,9 @@ class TestApply:
             ]
         )
 
-        assert np.allclose(
+        assert pnp.allclose(
             qutrit_device_2_wires.target_device._state.flatten(),
-            np.array(expected_output),
+            pnp.array(expected_output),
             atol=tol,
             rtol=0,
         )
@@ -203,7 +203,7 @@ class TestApply:
     ):
         """Tests that applying an adjoint operation yields the expected output state for two wire
         operations that have no parameters."""
-        qutrit_device_2_wires.target_device._state = np.array(
+        qutrit_device_2_wires.target_device._state = pnp.array(
             input, dtype=qutrit_device_2_wires.C_DTYPE
         ).reshape((3, 3))
         qutrit_device_2_wires.apply(
@@ -216,9 +216,9 @@ class TestApply:
             ]
         )
 
-        assert np.allclose(
+        assert pnp.allclose(
             qutrit_device_2_wires.target_device._state.flatten(),
-            np.array(expected_output),
+            pnp.array(expected_output),
             atol=tol,
             rtol=0,
         )
@@ -226,7 +226,7 @@ class TestApply:
 
     # TODO: Add more data as parametric ops get added
     test_data_single_wire_with_parameters = [
-        (qml.QutritUnitary, [1, 0, 0], [1, 1, 0] / np.sqrt(2), [U_thadamard_01], None),
+        (qml.QutritUnitary, [1, 0, 0], [1, 1, 0] / pnp.sqrt(2), [U_thadamard_01], None),
         (qml.QutritUnitary, [1, 0, 0], [0, 0, 1], [U_x_02], None),
         (qml.QutritUnitary, [1, 0, 0], [1, 0, 0], [U_z_12], None),
         (qml.QutritUnitary, [0, 1, 0], [0, 1, 0], [U_x_02], None),
@@ -239,7 +239,7 @@ class TestApply:
             qml.TRX,
             [0, 1 / math.sqrt(2), 1 / math.sqrt(2)],
             [0, 1 / 2 - 1j / 2, 1 / 2 - 1j / 2],
-            np.array([math.pi / 2]),
+            pnp.array([math.pi / 2]),
             [1, 2],
         ),
         (qml.TRY, [1, 0, 0], [1 / math.sqrt(2), 1 / math.sqrt(2), 0], [math.pi / 2], [0, 1]),
@@ -265,15 +265,15 @@ class TestApply:
         """Tests that applying an operation yields the expected output state for single wire
         operations that have parameters."""
 
-        qutrit_device_1_wire.target_device._state = np.array(
+        qutrit_device_1_wire.target_device._state = pnp.array(
             input, dtype=qutrit_device_1_wire.C_DTYPE
         )
 
         kwargs = {} if subspace is None else {"subspace": subspace}
         qutrit_device_1_wire.apply([operation(*par, wires=[0], **kwargs)])
 
-        assert np.allclose(
-            qutrit_device_1_wire.target_device._state, np.array(expected_output), atol=tol, rtol=0
+        assert pnp.allclose(
+            qutrit_device_1_wire.target_device._state, pnp.array(expected_output), atol=tol, rtol=0
         )
         assert qutrit_device_1_wire.target_device._state.dtype == qutrit_device_1_wire.C_DTYPE
 
@@ -286,15 +286,15 @@ class TestApply:
         """Tests that applying an adjoint operation yields the expected output state for single wire
         operations that have parameters."""
 
-        qutrit_device_1_wire.target_device._state = np.array(
+        qutrit_device_1_wire.target_device._state = pnp.array(
             input, dtype=qutrit_device_1_wire.C_DTYPE
         )
 
         kwargs = {} if subspace is None else {"subspace": subspace}
         qutrit_device_1_wire.apply([qml.adjoint(operation(*par, wires=[0], **kwargs))])
 
-        assert np.allclose(
-            qutrit_device_1_wire.target_device._state, np.array(expected_output), atol=tol, rtol=0
+        assert pnp.allclose(
+            qutrit_device_1_wire.target_device._state, pnp.array(expected_output), atol=tol, rtol=0
         )
         assert qutrit_device_1_wire.target_device._state.dtype == qutrit_device_1_wire.C_DTYPE
 
@@ -304,14 +304,14 @@ class TestApply:
         (qml.QutritUnitary, [1, 0, 0, 0, 0, 0, 0, 0, 0], [1, 0, 0, 0, 0, 0, 0, 0, 0], [TSWAP]),
         (
             qml.QutritUnitary,
-            [0, 0, 1, 0, 0, 0, 0, 1, 0] / np.sqrt(2),
-            [0, 0, 0, 0, 0, 1, 1, 0, 0] / np.sqrt(2),
+            [0, 0, 1, 0, 0, 0, 0, 1, 0] / pnp.sqrt(2),
+            [0, 0, 0, 0, 0, 1, 1, 0, 0] / pnp.sqrt(2),
             [TSWAP],
         ),
         (
             qml.QutritUnitary,
-            np.multiply(0.5, [0, 1, 1, 0, 0, 0, 0, 1, 1]),
-            np.multiply(0.5, [0, 0, 0, 1, 0, 1, 1, 0, 1]),
+            pnp.multiply(0.5, [0, 1, 1, 0, 0, 0, 0, 1, 1]),
+            pnp.multiply(0.5, [0, 0, 0, 1, 0, 1, 1, 0, 1]),
             [TSWAP],
         ),
         (qml.QutritUnitary, [0, 0, 0, 1, 0, 0, 0, 0, 0], [0, 0, 0, 0, 1, 0, 0, 0, 0], [TADD]),
@@ -327,14 +327,14 @@ class TestApply:
         """Tests that applying an operation yields the expected output state for two wire
         operations that have parameters."""
 
-        qutrit_device_2_wires.target_device._state = np.array(
+        qutrit_device_2_wires.target_device._state = pnp.array(
             input, dtype=qutrit_device_2_wires.C_DTYPE
         ).reshape((3, 3))
         qutrit_device_2_wires.apply([operation(*par, wires=[0, 1])])
 
-        assert np.allclose(
+        assert pnp.allclose(
             qutrit_device_2_wires.target_device._state.flatten(),
-            np.array(expected_output),
+            pnp.array(expected_output),
             atol=tol,
             rtol=0,
         )
@@ -349,14 +349,14 @@ class TestApply:
         """Tests that applying an adjoint operation yields the expected output state for two wire
         operations that have parameters."""
 
-        qutrit_device_2_wires.target_device._state = np.array(
+        qutrit_device_2_wires.target_device._state = pnp.array(
             input, dtype=qutrit_device_2_wires.C_DTYPE
         ).reshape((3, 3))
         qutrit_device_2_wires.apply([qml.adjoint(operation(*par, wires=[0, 1]))])
 
-        assert np.allclose(
+        assert pnp.allclose(
             qutrit_device_2_wires.target_device._state.flatten(),
-            np.array(expected_output),
+            pnp.array(expected_output),
             atol=tol,
             rtol=0,
         )
@@ -366,7 +366,7 @@ class TestApply:
         """Tests that rotations are applied in correct order after operations"""
 
         state = [1, 0, 0]
-        qutrit_device_1_wire.target_device._state = np.array(
+        qutrit_device_1_wire.target_device._state = pnp.array(
             state, dtype=qutrit_device_1_wire.C_DTYPE
         )
 
@@ -381,7 +381,7 @@ class TestApply:
 
         qutrit_device_1_wire.apply(ops, rotations)
 
-        assert np.allclose(qutrit_device_1_wire.target_device._state.flatten(), state)
+        assert pnp.allclose(qutrit_device_1_wire.target_device._state.flatten(), state)
 
     @pytest.mark.parametrize(
         "operation,expected_output,par",
@@ -397,13 +397,13 @@ class TestApply:
         """Tests that applying an operation yields the expected output state for single wire
         operations that have no parameters."""
 
-        par = np.array(par)
+        par = pnp.array(par)
         qutrit_device_2_wires.reset()
         qutrit_device_2_wires.apply([operation(par, wires=[0, 1])])
 
-        assert np.allclose(
+        assert pnp.allclose(
             qutrit_device_2_wires.target_device._state.flatten(),
-            np.array(expected_output),
+            pnp.array(expected_output),
             atol=tol,
             rtol=0,
         )
@@ -412,12 +412,12 @@ class TestApply:
         with pytest.raises(
             ValueError, match="QutritBasisState parameter must consist of 0, 1 or 2 integers."
         ):
-            qutrit_device_2_wires.apply([qml.QutritBasisState(np.array([-0.2, 4.2]), wires=[0, 1])])
+            qutrit_device_2_wires.apply([qml.QutritBasisState(pnp.array([-0.2, 4.2]), wires=[0, 1])])
 
         with pytest.raises(
             ValueError, match="QutritBasisState parameter and wires must be of equal length."
         ):
-            qutrit_device_2_wires.apply([qml.QutritBasisState(np.array([0, 1]), wires=[0])])
+            qutrit_device_2_wires.apply([qml.QutritBasisState(pnp.array([0, 1]), wires=[0])])
 
         with pytest.raises(
             qml.DeviceError,
@@ -426,7 +426,7 @@ class TestApply:
         ):
             qutrit_device_2_wires.reset()
             qutrit_device_2_wires.apply(
-                [qml.TClock(wires=0), qml.QutritBasisState(np.array([1, 1]), wires=[0, 1])]
+                [qml.TClock(wires=0), qml.QutritBasisState(pnp.array([1, 1]), wires=[0, 1])]
             )
 
 
@@ -470,23 +470,23 @@ class TestExpval:
         obs = (
             observable(wires=[0], index=par)
             if isinstance(par, int)
-            else observable(np.array(par), wires=[0])
+            else observable(pnp.array(par), wires=[0])
         )
 
         qutrit_device_1_wire.reset()
-        qutrit_device_1_wire.target_device._state = np.array(state).reshape([3])
+        qutrit_device_1_wire.target_device._state = pnp.array(state).reshape([3])
         qutrit_device_1_wire.apply([], obs.diagonalizing_gates())
         res = qutrit_device_1_wire.expval(obs)
 
-        assert np.isclose(res, expected_output, atol=tol, rtol=0)
+        assert pnp.isclose(res, expected_output, atol=tol, rtol=0)
 
-    A = np.array([[1, 0, 0], [0, -1, 0], [0, 0, 2]])
-    B = np.array([[4, 0, 0], [0, -2, 0], [0, 0, 1]])
-    obs_1 = np.kron(A, B)
+    A = pnp.array([[1, 0, 0], [0, -1, 0], [0, 0, 2]])
+    B = pnp.array([[4, 0, 0], [0, -2, 0], [0, 0, 1]])
+    obs_1 = pnp.kron(A, B)
 
-    C = np.array([[0, -1j, 0], [1j, 0, 0], [0, 0, 0]])
-    D = np.array([[1, 2, 3], [2, 1, 3], [3, 3, 2]])
-    obs_2 = np.kron(C, D)
+    C = pnp.array([[0, -1j, 0], [1j, 0, 0], [0, 0, 0]])
+    D = pnp.array([[1, 2, 3], [2, 1, 3], [3, 3, 2]])
+    obs_2 = pnp.kron(C, D)
 
     @pytest.mark.parametrize(
         "observable,state,expected_output,mat",
@@ -544,13 +544,13 @@ class TestExpval:
     ):
         """Tests that expectation values are properly calculated for two-wire observables with parameters."""
 
-        obs = observable(np.array(mat), wires=[0, 1])
+        obs = observable(pnp.array(mat), wires=[0, 1])
 
         qutrit_device_2_wires.reset()
-        qutrit_device_2_wires.target_device._state = np.array(state).reshape([3] * 2)
+        qutrit_device_2_wires.target_device._state = pnp.array(state).reshape([3] * 2)
         qutrit_device_2_wires.apply([], obs.diagonalizing_gates())
         res = qutrit_device_2_wires.expval(obs)
-        assert np.isclose(res, expected_output, atol=tol, rtol=0)
+        assert pnp.isclose(res, expected_output, atol=tol, rtol=0)
 
     def test_expval_estimate(self):
         """Test that the expectation value is not analytically calculated"""
@@ -559,13 +559,13 @@ class TestExpval:
 
         @qml.qnode(dev)
         def circuit():
-            return qml.expval(qml.THermitian(np.array([[0, 1, 0], [1, 0, 0], [0, 0, 0]]), wires=0))
+            return qml.expval(qml.THermitian(pnp.array([[0, 1, 0], [1, 0, 0], [0, 0, 0]]), wires=0))
 
         expval = circuit()
 
         # With 3 samples we are guaranteed to see a difference between
         # an estimated expectation value and an analytically calculated one
-        assert not np.isclose(expval, 0.0)
+        assert not pnp.isclose(expval, 0.0)
 
 
 class TestVar:
@@ -608,23 +608,23 @@ class TestVar:
         obs = (
             observable(wires=[0], index=par)
             if isinstance(par, int)
-            else observable(np.array(par), wires=[0])
+            else observable(pnp.array(par), wires=[0])
         )
 
         qutrit_device_1_wire.reset()
-        qutrit_device_1_wire.target_device._state = np.array(state).reshape([3])
+        qutrit_device_1_wire.target_device._state = pnp.array(state).reshape([3])
         qutrit_device_1_wire.apply([], obs.diagonalizing_gates())
         res = qutrit_device_1_wire.var(obs)
 
-        assert np.isclose(res, expected_output, atol=tol, rtol=0)
+        assert pnp.isclose(res, expected_output, atol=tol, rtol=0)
 
-    A = np.array([[1, 0, 0], [0, -1, 0], [0, 0, 2]])
-    B = np.array([[4, 0, 0], [0, -2, 0], [0, 0, 1]])
-    obs_1 = np.kron(A, B)
+    A = pnp.array([[1, 0, 0], [0, -1, 0], [0, 0, 2]])
+    B = pnp.array([[4, 0, 0], [0, -2, 0], [0, 0, 1]])
+    obs_1 = pnp.kron(A, B)
 
-    C = np.array([[0, -1j, 0], [1j, 0, 0], [0, 0, 0]])
-    D = np.array([[1, 2, 3], [2, 1, 3], [3, 3, 2]])
-    obs_2 = np.kron(C, D)
+    C = pnp.array([[0, -1j, 0], [1j, 0, 0], [0, 0, 0]])
+    D = pnp.array([[1, 2, 3], [2, 1, 3], [3, 3, 2]])
+    obs_2 = pnp.kron(C, D)
 
     @pytest.mark.parametrize(
         "observable,state,expected_output,mat",
@@ -672,14 +672,14 @@ class TestVar:
     ):
         """Tests that variances are properly calculated for two-wire observables with parameters."""
 
-        obs = observable(np.array(mat), wires=[0, 1])
+        obs = observable(pnp.array(mat), wires=[0, 1])
 
         qutrit_device_2_wires.reset()
-        qutrit_device_2_wires.target_device._state = np.array(state).reshape([3] * 2)
+        qutrit_device_2_wires.target_device._state = pnp.array(state).reshape([3] * 2)
         qutrit_device_2_wires.apply([], obs.diagonalizing_gates())
         res = qutrit_device_2_wires.var(obs)
 
-        assert np.isclose(res, expected_output, atol=tol, rtol=0)
+        assert pnp.isclose(res, expected_output, atol=tol, rtol=0)
 
     def test_var_estimate(self):
         """Test that the var is not analytically calculated"""
@@ -688,13 +688,13 @@ class TestVar:
 
         @qml.qnode(dev)
         def circuit():
-            return qml.var(qml.THermitian(np.array([[0, 1, 0], [1, 0, 0], [0, 0, 0]]), wires=0))
+            return qml.var(qml.THermitian(pnp.array([[0, 1, 0], [1, 0, 0], [0, 0, 0]]), wires=0))
 
         var = circuit()
 
         # With 3 samples we are guaranteed to see a difference between
         # an estimated variance and an analytically calculated one
-        assert not np.isclose(var, 1.0)
+        assert not pnp.isclose(var, 1.0)
 
 
 class TestSample:
@@ -725,22 +725,22 @@ class TestSample:
         dev.target_device.shots = 10
         dev.target_device._wires_measured = {0}
         dev.target_device._samples = dev.generate_samples()
-        s1 = dev.sample(qml.THermitian(np.eye(3), wires=0))
-        assert np.array_equal(s1.shape, (10,))
+        s1 = dev.sample(qml.THermitian(pnp.eye(3), wires=0))
+        assert pnp.array_equal(s1.shape, (10,))
 
         dev.reset()
         dev.target_device.shots = 12
         dev.target_device._wires_measured = {1}
         dev.target_device._samples = dev.generate_samples()
-        s2 = dev.sample(qml.THermitian(np.eye(3), wires=1))
-        assert np.array_equal(s2.shape, (12,))
+        s2 = dev.sample(qml.THermitian(pnp.eye(3), wires=1))
+        assert pnp.array_equal(s2.shape, (12,))
 
         dev.reset()
         dev.target_device.shots = 17
         dev.target_device._wires_measured = {0, 1}
         dev.target_device._samples = dev.generate_samples()
-        s3 = dev.sample(qml.THermitian(np.eye(3), wires=0) @ qml.THermitian(np.eye(3), wires=1))
-        assert np.array_equal(s3.shape, (17,))
+        s3 = dev.sample(qml.THermitian(pnp.eye(3), wires=0) @ qml.THermitian(pnp.eye(3), wires=1))
+        assert pnp.array_equal(s3.shape, (17,))
 
     def test_sample_values(self, tol):
         """Tests if the samples returned by sample have
@@ -756,11 +756,11 @@ class TestSample:
         dev.target_device._wires_measured = {0}
         dev.target_device._samples = dev.generate_samples()
 
-        s1 = dev.sample(qml.THermitian(np.array([[1, 0, 0], [0, 1, 0], [0, 0, -1]]), wires=0))
+        s1 = dev.sample(qml.THermitian(pnp.array([[1, 0, 0], [0, 1, 0], [0, 0, -1]]), wires=0))
 
         # s1 should only contain 1 and -1, which is guaranteed if
         # they square to 1
-        assert np.allclose(s1**2, 1, atol=tol, rtol=0)
+        assert pnp.allclose(s1**2, 1, atol=tol, rtol=0)
 
 
 class TestDefaultQutritIntegration:
@@ -790,35 +790,35 @@ class TestDefaultQutritIntegration:
         }
         assert cap == capabilities
 
-    three_wire_final_state = np.zeros(27)
+    three_wire_final_state = pnp.zeros(27)
     three_wire_final_state[0] = 1
     three_wire_final_state[4] = 1
 
-    four_wire_final_state = np.zeros(81)
+    four_wire_final_state = pnp.zeros(81)
     four_wire_final_state[0] = 1
     four_wire_final_state[1] = 1
     four_wire_final_state[36] = 1
     four_wire_final_state[37] = 1
     state_measurement_data = [
-        (1, U_thadamard_01, np.array([1, 1, 0]) / np.sqrt(2)),
-        (2, TADD @ np.kron(TSHIFT, np.eye(3)), [0, 0, 0, 0, 1, 0, 0, 0, 0]),
+        (1, U_thadamard_01, pnp.array([1, 1, 0]) / pnp.sqrt(2)),
+        (2, TADD @ pnp.kron(TSHIFT, pnp.eye(3)), [0, 0, 0, 0, 1, 0, 0, 0, 0]),
         (1, TSHIFT, [0, 1, 0]),
         (
             2,
-            TSWAP @ np.kron(U_thadamard_01, np.eye(3)),
-            np.array([1, 1, 0, 0, 0, 0, 0, 0, 0]) / np.sqrt(2),
+            TSWAP @ pnp.kron(U_thadamard_01, pnp.eye(3)),
+            pnp.array([1, 1, 0, 0, 0, 0, 0, 0, 0]) / pnp.sqrt(2),
         ),
-        (1, TCLOCK @ TSHIFT @ U_thadamard_01, np.array([0, OMEGA, OMEGA**2]) / np.sqrt(2)),
+        (1, TCLOCK @ TSHIFT @ U_thadamard_01, pnp.array([0, OMEGA, OMEGA**2]) / pnp.sqrt(2)),
         (
             3,
-            np.kron(np.eye(3), TADD) @ np.kron(np.eye(3), np.kron(U_thadamard_01, np.eye(3))),
-            three_wire_final_state / np.sqrt(2),
+            pnp.kron(pnp.eye(3), TADD) @ pnp.kron(pnp.eye(3), pnp.kron(U_thadamard_01, pnp.eye(3))),
+            three_wire_final_state / pnp.sqrt(2),
         ),
         (
             4,
-            np.kron(TADD, TSWAP)
-            @ np.kron(U_thadamard_01, np.eye(27))
-            @ np.kron(np.eye(9), np.kron(U_thadamard_01, np.eye(3))),
+            pnp.kron(TADD, TSWAP)
+            @ pnp.kron(U_thadamard_01, pnp.eye(27))
+            @ pnp.kron(pnp.eye(9), pnp.kron(U_thadamard_01, pnp.eye(3))),
             four_wire_final_state / 2.0,
         ),
     ]
@@ -834,7 +834,7 @@ class TestDefaultQutritIntegration:
             return qml.state()
 
         state = circuit(mat)
-        assert np.allclose(state, expected_out, atol=tol)
+        assert pnp.allclose(state, expected_out, atol=tol)
 
     def test_qutrit_circuit_adjoint_integration(self):
         """Test that using qml.adjoint in a `default.qutrit` qnode works as expected."""
@@ -852,18 +852,18 @@ class TestDefaultQutritIntegration:
 
         @qml.qnode(dev)
         def circuit():
-            phi, theta, omega = np.random.rand(3) * 2 * np.pi
+            phi, theta, omega = pnp.random.rand(3) * 2 * pnp.pi
             U = unitary_group.rvs(9, random_state=10)
 
             ansatz(phi, theta, omega, U)
             qml.adjoint(ansatz)(phi, theta, omega, U)
             return qml.state()
 
-        expected = np.zeros(27)
+        expected = pnp.zeros(27)
         expected[0] = 1
         res = circuit()
 
-        assert np.allclose(res, expected)
+        assert pnp.allclose(res, expected)
 
 
 class TestTensorExpval:
@@ -874,7 +874,7 @@ class TestTensorExpval:
         """Test that the variance of the tensor product of a Gell-Mann observable and a Hermitian
         matrix behaves correctly."""
         dev = qml.device("default.qutrit", wires=2)
-        A = np.array([[2, -0.5j, -1j], [0.5j, 1, -6], [1j, -6, 0]])
+        A = pnp.array([[2, -0.5j, -1j], [0.5j, 1, -6], [1j, -6, 0]])
         obs = qml.GellMann(wires=0, index=index) @ qml.THermitian(A, wires=1)
 
         dev.apply(
@@ -888,21 +888,21 @@ class TestTensorExpval:
         )
         res = dev.expval(obs)
 
-        state = np.array([[0, 0, 0, 0, 0, 1, 1, 0, 0]]) / math.sqrt(2)
-        obs_mat = np.kron(GELL_MANN[index - 1], A)
+        state = pnp.array([[0, 0, 0, 0, 0, 1, 1, 0, 0]]) / math.sqrt(2)
+        obs_mat = pnp.kron(GELL_MANN[index - 1], A)
 
         expected = state.conj() @ obs_mat @ state.T
-        assert np.isclose(res, expected[0], atol=tol, rtol=0)
+        assert pnp.isclose(res, expected[0], atol=tol, rtol=0)
 
     def test_hermitian_hermitian(self, tol):
         """Test that a tensor product involving two Hermitian matrices works correctly"""
         dev = qml.device("default.qutrit", wires=3)
 
-        A1 = np.array([[1, 2, 3], [2, 1, 3], [3, 3, 2]])
+        A1 = pnp.array([[1, 2, 3], [2, 1, 3], [3, 3, 2]])
 
-        A = np.array([[0, -1j, 0], [1j, 0, 0], [0, 0, 0]])
-        B = np.array([[4, 0, 0], [0, -2, 0], [0, 0, 1]])
-        A2 = np.kron(A, B)
+        A = pnp.array([[0, -1j, 0], [1j, 0, 0], [0, 0, 0]])
+        B = pnp.array([[4, 0, 0], [0, -2, 0], [0, 0, 1]])
+        A2 = pnp.kron(A, B)
 
         obs = qml.THermitian(A1, wires=[0]) @ qml.THermitian(A2, wires=[1, 2])
 
@@ -918,15 +918,15 @@ class TestTensorExpval:
         res = dev.expval(obs)
 
         expected = 0.0
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
     def test_hermitian_two_wires_identity_expectation(self, tol):
         """Test that a tensor product involving a Hermitian matrix for two wires and the identity works correctly"""
         dev = qml.device("default.qutrit", wires=3)
 
-        A = np.array([[-2, 0, 0], [0, 8, 0], [0, 0, -1]])
-        Identity = np.eye(3)
-        H = np.kron(np.kron(Identity, Identity), A)
+        A = pnp.array([[-2, 0, 0], [0, 8, 0], [0, 0, -1]])
+        Identity = pnp.eye(3)
+        H = pnp.kron(pnp.kron(Identity, Identity), A)
         obs = qml.THermitian(H, wires=[2, 1, 0])
 
         dev.apply(
@@ -941,7 +941,7 @@ class TestTensorExpval:
         res = dev.expval(obs)
 
         expected = 3.5 * 1 * 1
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
     @pytest.mark.parametrize("index_1", list(range(1, 9)))
     @pytest.mark.parametrize("index_2", list(range(1, 9)))
@@ -960,12 +960,12 @@ class TestTensorExpval:
         )
         res = dev.expval(obs)
 
-        obs_mat = np.kron(
+        obs_mat = pnp.kron(
             qml.GellMann.compute_matrix(index_1), qml.GellMann.compute_matrix(index_2)
         )
-        state = np.array([[1, 0, 0, 0, 1, 0, 0, 0, 0]]) / np.sqrt(2)
+        state = pnp.array([[1, 0, 0, 0, 1, 0, 0, 0, 0]]) / pnp.sqrt(2)
         expected = state.conj() @ obs_mat @ state.T
-        assert np.isclose(res, expected[0], atol=tol, rtol=0)
+        assert pnp.isclose(res, expected[0], atol=tol, rtol=0)
 
 
 class TestTensorVar:
@@ -989,20 +989,20 @@ class TestTensorVar:
         )
         res = dev.var(obs)
 
-        state = np.array([[0, 0, 0, 0, 0, 1, 1, 0, 0]]) / math.sqrt(2)
-        obs_mat = np.kron(GELL_MANN[index_1 - 1], GELL_MANN[index_2 - 1])
+        state = pnp.array([[0, 0, 0, 0, 0, 1, 1, 0, 0]]) / math.sqrt(2)
+        obs_mat = pnp.kron(GELL_MANN[index_1 - 1], GELL_MANN[index_2 - 1])
 
         expected = (
             state.conj() @ obs_mat @ obs_mat @ state.T - (state.conj() @ obs_mat @ state.T) ** 2
         )
-        assert np.isclose(res, expected[0], atol=tol, rtol=0)
+        assert pnp.isclose(res, expected[0], atol=tol, rtol=0)
 
     @pytest.mark.parametrize("index", list(range(1, 9)))
     def test_gell_mann_hermitian(self, index, tol):
         """Test that the variance of the tensor product of a Gell-Mann observable and a Hermitian
         matrix behaves correctly."""
         dev = qml.device("default.qutrit", wires=2)
-        A = np.array([[2, -0.5j, -1j], [0.5j, 1, -6], [1j, -6, 0]])
+        A = pnp.array([[2, -0.5j, -1j], [0.5j, 1, -6], [1j, -6, 0]])
         obs = qml.GellMann(wires=0, index=index) @ qml.THermitian(A, wires=1)
 
         dev.apply(
@@ -1016,23 +1016,23 @@ class TestTensorVar:
         )
         res = dev.var(obs)
 
-        state = np.array([[0, 0, 0, 0, 0, 1, 1, 0, 0]]) / math.sqrt(2)
-        obs_mat = np.kron(GELL_MANN[index - 1], A)
+        state = pnp.array([[0, 0, 0, 0, 0, 1, 1, 0, 0]]) / math.sqrt(2)
+        obs_mat = pnp.kron(GELL_MANN[index - 1], A)
 
         expected = (
             state.conj() @ obs_mat @ obs_mat @ state.T - (state.conj() @ obs_mat @ state.T) ** 2
         )
-        assert np.isclose(res, expected[0], atol=tol, rtol=0)
+        assert pnp.isclose(res, expected[0], atol=tol, rtol=0)
 
     def test_hermitian(self, tol):
         """Test that the variance of a tensor product of two Hermitian matrices behaves correctly"""
         dev = qml.device("default.qutrit", wires=3)
 
-        A1 = np.array([[2, -0.5j, -1j], [0.5j, 1, -6], [1j, -6, 0]])
+        A1 = pnp.array([[2, -0.5j, -1j], [0.5j, 1, -6], [1j, -6, 0]])
 
-        A = np.array([[1, 0, 0], [0, -1, 0], [0, 0, 2]])
-        B = np.array([[4, 0, 0], [0, -2, 0], [0, 0, 1]])
-        A2 = np.kron(A, B)
+        A = pnp.array([[1, 0, 0], [0, -1, 0], [0, 0, 2]])
+        B = pnp.array([[4, 0, 0], [0, -2, 0], [0, 0, 1]])
+        A2 = pnp.kron(A, B)
 
         obs = qml.THermitian(A1, wires=[0]) @ qml.THermitian(A2, wires=[1, 2])
 
@@ -1048,15 +1048,15 @@ class TestTensorVar:
 
         res = dev.var(obs)
 
-        state = np.zeros((1, 27))
-        state[0, 21] = 1 / np.sqrt(2)
-        state[0, 22] = 1 / np.sqrt(2)
-        obs_mat = np.kron(A1, A2)
+        state = pnp.zeros((1, 27))
+        state[0, 21] = 1 / pnp.sqrt(2)
+        state[0, 22] = 1 / pnp.sqrt(2)
+        obs_mat = pnp.kron(A1, A2)
 
         expected = (
             state.conj() @ obs_mat @ obs_mat @ state.T - (state.conj() @ obs_mat @ state.T) ** 2
         )
-        assert np.isclose(res, expected, atol=tol, rtol=0)
+        assert pnp.isclose(res, expected, atol=tol, rtol=0)
 
 
 class TestTensorSample:
@@ -1084,32 +1084,32 @@ class TestTensorSample:
         dev.target_device._samples = dev.generate_samples()
         dev.sample(obs)
 
-        state = np.array([[0, 0, 0, 0, 0, 1, 1, 0, 0]]) / np.sqrt(2)
+        state = pnp.array([[0, 0, 0, 0, 0, 1, 1, 0, 0]]) / pnp.sqrt(2)
         state = state.T
-        obs_mat = np.kron(GELL_MANN[index_1 - 1], GELL_MANN[index_2 - 1])
+        obs_mat = pnp.kron(GELL_MANN[index_1 - 1], GELL_MANN[index_2 - 1])
 
         s1 = obs.eigvals()
         p = dev.probability(wires=dev.map_wires(obs.wires))
 
         mean = s1 @ p
         expected = state.conj().T @ obs_mat @ state
-        assert np.allclose(mean, expected, atol=tol_stochastic, rtol=0)
+        assert pnp.allclose(mean, expected, atol=tol_stochastic, rtol=0)
 
         var = (s1**2) @ p - (s1 @ p) ** 2
         expected = (
             state.conj().T @ obs_mat @ obs_mat @ state - (state.conj().T @ obs_mat @ state) ** 2
         )
-        assert np.allclose(var, expected, atol=tol_stochastic, rtol=0)
+        assert pnp.allclose(var, expected, atol=tol_stochastic, rtol=0)
 
     @pytest.mark.parametrize("index", list(range(1, 9)))
     def test_hermitian(self, index, tol_stochastic, seed):
         """Tests that sampling on a tensor product of Hermitian observables with another observable works
         correctly"""
 
-        np.random.seed(seed)
+        pnp.random.seed(seed)
         dev = qml.device("default.qutrit", wires=3, shots=int(1e6))
 
-        A = np.array([[2, -0.5j, -1j], [0.5j, 1, -6], [1j, -6, 0]])
+        A = pnp.array([[2, -0.5j, -1j], [0.5j, 1, -6], [1j, -6, 0]])
 
         obs = qml.GellMann(wires=0, index=index) @ qml.THermitian(A, wires=1)
 
@@ -1130,19 +1130,19 @@ class TestTensorSample:
         s1 = obs.eigvals()
         p = dev.marginal_prob(dev.probability(), wires=obs.wires)
 
-        obs_mat = np.kron(GELL_MANN[index - 1], A)
-        state = np.array([[0, 0, 0, 0, 0, 1, 1, 0, 0]]) / np.sqrt(2)
+        obs_mat = pnp.kron(GELL_MANN[index - 1], A)
+        state = pnp.array([[0, 0, 0, 0, 0, 1, 1, 0, 0]]) / pnp.sqrt(2)
         state = state.T
 
         mean = s1 @ p
         expected = state.conj().T @ obs_mat @ state
-        assert np.allclose(mean, expected, atol=tol_stochastic, rtol=0)
+        assert pnp.allclose(mean, expected, atol=tol_stochastic, rtol=0)
 
         var = (s1**2) @ p - (s1 @ p) ** 2
         expected = (
             state.conj().T @ obs_mat @ obs_mat @ state - (state.conj().T @ obs_mat @ state) ** 2
         )
-        assert np.allclose(var, expected, atol=tol_stochastic, rtol=0)
+        assert pnp.allclose(var, expected, atol=tol_stochastic, rtol=0)
 
 
 class TestProbabilityIntegration:
@@ -1151,7 +1151,7 @@ class TestProbabilityIntegration:
     # pylint: disable=unused-argument
     def mock_analytic_counter(self, wires=None):
         self.analytic_counter += 1
-        return np.array([1, 0, 0, 0, 0, 0, 0, 0, 0], dtype=float)
+        return pnp.array([1, 0, 0, 0, 0, 0, 0, 0, 0], dtype=float)
 
     @pytest.mark.parametrize(
         "x", [[U_thadamard_01, TCLOCK], [TSHIFT, U_thadamard_01], [U_z_12, U_thadamard_01]]
@@ -1170,9 +1170,9 @@ class TestProbabilityIntegration:
         prob = qml.QNode(circuit, dev)
         prob_analytic = qml.QNode(circuit, dev_analytic)
 
-        assert np.isclose(prob(x).sum(), 1, atol=tol, rtol=0)
-        assert np.allclose(prob_analytic(x), prob(x), atol=0.1, rtol=0)
-        assert not np.array_equal(prob_analytic(x), prob(x))
+        assert pnp.isclose(prob(x).sum(), 1, atol=tol, rtol=0)
+        assert pnp.allclose(prob_analytic(x), prob(x), atol=0.1, rtol=0)
+        assert not pnp.array_equal(prob_analytic(x), prob(x))
 
     # pylint: disable=attribute-defined-outside-init
     def test_call_generate_samples(self, monkeypatch):
@@ -1244,14 +1244,14 @@ class TestWiresIntegration:
         circuit1 = self.make_circuit_probs(wires1)
         circuit2 = self.make_circuit_probs(wires2)
 
-        assert np.allclose(circuit1(), circuit2(), tol)
+        assert pnp.allclose(circuit1(), circuit2(), tol)
 
     def test_wires_not_found_exception(self):
         """Tests that an exception is raised when wires not present on the device are addressed."""
         dev = qml.device("default.qutrit", wires=["a", "b"])
 
         with qml.queuing.AnnotatedQueue() as q:
-            qml.QutritUnitary(np.eye(3), wires="c")
+            qml.QutritUnitary(pnp.eye(3), wires="c")
 
         tape = qml.tape.QuantumScript.from_queue(q)
         with pytest.raises(WireError, match="Did not find some of the wires"):
@@ -1289,7 +1289,7 @@ class TestApplyOps:
     """Tests for special methods listed in _apply_ops that use array manipulation tricks to apply
     gates in DefaultQutrit."""
 
-    state = np.arange(3**4, dtype=np.complex128).reshape((3, 3, 3, 3))
+    state = pnp.arange(3**4, dtype=pnp.complex128).reshape((3, 3, 3, 3))
     dev = qml.device("default.qutrit", wires=4)
 
     single_qutrit_ops = [
@@ -1308,8 +1308,8 @@ class TestApplyOps:
         state_out = method(self.state, axes=[1])
         op = op(wires=[1])
         matrix = op.matrix()
-        state_out_einsum = np.einsum("ab,ibjk->iajk", matrix, self.state)
-        assert np.allclose(state_out, state_out_einsum)
+        state_out_einsum = pnp.einsum("ab,ibjk->iajk", matrix, self.state)
+        assert pnp.allclose(state_out, state_out_einsum)
 
     @pytest.mark.parametrize("op, method", two_qutrit_ops)
     def test_apply_two_qutrit_op(self, op, method):
@@ -1318,8 +1318,8 @@ class TestApplyOps:
         op1 = op(wires=[0, 1])
         matrix = op1.matrix()
         matrix = matrix.reshape((3, 3, 3, 3))
-        state_out_einsum = np.einsum("abcd,cdjk->abjk", matrix, self.state)
-        assert np.allclose(state_out, state_out_einsum)
+        state_out_einsum = pnp.einsum("abcd,cdjk->abjk", matrix, self.state)
+        assert pnp.allclose(state_out, state_out_einsum)
 
     @pytest.mark.parametrize("op, method", two_qutrit_ops)
     def test_apply_two_qutrit_op_reverse(self, op, method):
@@ -1329,8 +1329,8 @@ class TestApplyOps:
         op2 = op(wires=[1, 0])
         matrix = op2.matrix()
         matrix = matrix.reshape((3, 3, 3, 3))
-        state_out_einsum = np.einsum("badc,cdjk->abjk", matrix, self.state)
-        assert np.allclose(state_out, state_out_einsum)
+        state_out_einsum = pnp.einsum("badc,cdjk->abjk", matrix, self.state)
+        assert pnp.allclose(state_out, state_out_einsum)
 
 
 class TestApplyOperationUnit:
@@ -1341,7 +1341,7 @@ class TestApplyOperationUnit:
         default.qutrit."""
         dev = qml.device("default.qutrit", wires=2)
 
-        test_state = np.array([1, 0, 0])
+        test_state = pnp.array([1, 0, 0])
         wires = [0, 1]
 
         class TestSwap(qml.operation.Operation):
@@ -1371,15 +1371,15 @@ class TestApplyOperationUnit:
 
             res_state, res_mat, res_wires = history[0]
 
-            assert np.allclose(res_state, test_state)
-            assert np.allclose(res_mat, op.matrix())
-            assert np.allclose(res_wires, wires)
+            assert pnp.allclose(res_state, test_state)
+            assert pnp.allclose(res_mat, op.matrix())
+            assert pnp.allclose(res_wires, wires)
 
     def test_identity_skipped(self, mocker):
         """Test that applying the identity operation does not perform any additional computations"""
         dev = qml.device("default.qutrit", wires=1)
 
-        starting_state = np.array([1, 0, 0])
+        starting_state = pnp.array([1, 0, 0])
         op = qml.Identity(0)
 
         spy_unitary = mocker.spy(dev, "_apply_unitary")
@@ -1401,7 +1401,7 @@ class TestApplyOperationUnit:
         dev = qml.device("default.qutrit", wires=1)
 
         # Create a dummy operation
-        expected_test_output = np.ones(1)
+        expected_test_output = pnp.ones(1)
 
         with monkeypatch.context() as m:
             # Set the internal ops implementations dict
@@ -1411,21 +1411,21 @@ class TestApplyOperationUnit:
                 {"QutritUnitary": lambda *args, **kwargs: expected_test_output},
             )
 
-            test_state = np.array([1, 0, 0])
+            test_state = pnp.array([1, 0, 0])
             op = qml.QutritUnitary(TSHIFT, wires=0)
             spy_unitary = mocker.spy(dev.target_device, "_apply_unitary")
 
             res = dev._apply_operation(test_state, op)
-            assert np.allclose(res, expected_test_output)
+            assert pnp.allclose(res, expected_test_output)
             spy_unitary.assert_not_called()
 
 
 class TestDensityMatrix:
     """Unit tests for the internal density_matrix method"""
 
-    output = np.array([[0, 1, 0, 0, 1, 0, 0, 0, 0]]) / np.sqrt(2)
-    output_0 = np.array([[1, 1, 0]]) / np.sqrt(2)
-    output_1 = np.array([[0, 1, 0]])
+    output = pnp.array([[0, 1, 0, 0, 1, 0, 0, 0, 0]]) / pnp.sqrt(2)
+    output_0 = pnp.array([[1, 1, 0]]) / pnp.sqrt(2)
+    output_1 = pnp.array([[0, 1, 0]])
     density_matrix_data = [
         (Wires([0, 1]), output.T @ output),
         (Wires([1, 0]), output.T @ output),
@@ -1443,7 +1443,7 @@ class TestDensityMatrix:
         ]
         qutrit_device_2_wires.apply(ops)
 
-        assert np.allclose(qutrit_device_2_wires.density_matrix(wires), expected)
+        assert pnp.allclose(qutrit_device_2_wires.density_matrix(wires), expected)
 
 
 # JAX integration tests
@@ -1473,9 +1473,9 @@ class TestQNodeIntegrationJax:
         if use_jit:
             circuit = jax.jit(circuit)
 
-        expected = -np.sin(p)
+        expected = -pnp.sin(p)
 
-        assert np.isclose(circuit(p), expected, atol=tol, rtol=0)
+        assert pnp.isclose(circuit(p), expected, atol=tol, rtol=0)
 
     def test_correct_state(self, tol, use_jit):
         """Test that the device state is correct after evaluating a
@@ -1488,9 +1488,9 @@ class TestQNodeIntegrationJax:
         dev = qml.device("default.qutrit", wires=1)
 
         state = dev.state
-        expected = np.zeros(3)
+        expected = pnp.zeros(3)
         expected[0] = 1
-        assert np.allclose(state, expected, atol=tol, rtol=0)
+        assert pnp.allclose(state, expected, atol=tol, rtol=0)
 
         @qml.qnode(dev, interface="jax", diff_method="backprop")
         def circuit(a):
@@ -1498,10 +1498,10 @@ class TestQNodeIntegrationJax:
             qml.TRZ(a, wires=0)
             return qml.expval(qml.GellMann(0, 3))
 
-        circuit(jnp.array(np.pi / 4))
+        circuit(jnp.array(pnp.pi / 4))
         state = dev.state
 
-        amplitude = jnp.exp(-1j * np.pi / 8)
+        amplitude = jnp.exp(-1j * pnp.pi / 8)
         expected = (-1j / jnp.sqrt(3)) * jnp.array([amplitude, jnp.conj(amplitude), 1])
 
         assert jnp.allclose(state, expected, atol=tol, rtol=0)
@@ -1513,7 +1513,7 @@ class TestDtypePreservedJax:
     """Test that the user-defined dtype of the device is preserved for QNode
     evaluation"""
 
-    @pytest.mark.parametrize("enable_x64, r_dtype", [(False, np.float32), (True, np.float64)])
+    @pytest.mark.parametrize("enable_x64, r_dtype", [(False, pnp.float32), (True, pnp.float64)])
     @pytest.mark.parametrize(
         "measurement",
         [
@@ -1544,7 +1544,7 @@ class TestDtypePreservedJax:
         res = circuit(p)
         assert res.dtype == r_dtype
 
-    @pytest.mark.parametrize("enable_x64, c_dtype", [(False, np.complex64), (True, np.complex128)])
+    @pytest.mark.parametrize("enable_x64, c_dtype", [(False, pnp.complex64), (True, pnp.complex128)])
     def test_complex_dtype(self, enable_x64, c_dtype, use_jit):
         """Test that the user-defined dtype of the device is preserved
         for QNodes with complex-valued outputs"""
@@ -1664,9 +1664,9 @@ class TestQNodeIntegrationTF:
             qml.TRX(x, wires=0, subspace=[0, 2])
             return qml.expval(qml.GellMann(0, 5))
 
-        expected = -np.sin(p)
+        expected = -pnp.sin(p)
 
-        assert np.isclose(circuit(p), expected, atol=tol, rtol=0)
+        assert pnp.isclose(circuit(p), expected, atol=tol, rtol=0)
 
     def test_correct_state(self, tol):
         """Test that the device state is correct after evaluating a
@@ -1681,13 +1681,13 @@ class TestQNodeIntegrationTF:
             qml.TRZ(a, wires=0)
             return qml.expval(qml.GellMann(0, 3))
 
-        circuit(tf.constant(np.pi / 4))
+        circuit(tf.constant(pnp.pi / 4))
         state = dev.state
 
-        amplitude = np.exp(-1j * np.pi / 8)
-        expected = (-1j / np.sqrt(3)) * np.array([amplitude, np.conj(amplitude), 1])
+        amplitude = pnp.exp(-1j * pnp.pi / 8)
+        expected = (-1j / pnp.sqrt(3)) * pnp.array([amplitude, pnp.conj(amplitude), 1])
 
-        assert np.allclose(state, expected, atol=tol, rtol=0)
+        assert pnp.allclose(state, expected, atol=tol, rtol=0)
 
 
 @pytest.mark.tf
@@ -1695,7 +1695,7 @@ class TestDtypePreservedTF:
     """Test that the user-defined dtype of the device is preserved for QNode
     evaluation"""
 
-    @pytest.mark.parametrize("r_dtype", [np.float32, np.float64])
+    @pytest.mark.parametrize("r_dtype", [pnp.float32, pnp.float64])
     @pytest.mark.parametrize(
         "measurement",
         [
@@ -1721,7 +1721,7 @@ class TestDtypePreservedTF:
         res = circuit(p)
         assert res.dtype == r_dtype
 
-    @pytest.mark.parametrize("c_dtype", [np.complex64, np.complex128])
+    @pytest.mark.parametrize("c_dtype", [pnp.complex64, pnp.complex128])
     def test_complex_dtype(self, c_dtype):
         """Test that the user-defined dtype of the device is preserved
         for QNodes with complex-valued outputs"""
@@ -1767,20 +1767,20 @@ class TestPassthruIntegrationTF:
             res = circuit(a_tf, b_tf)
 
         # the analytic result of evaluating circuit(a, b)
-        expected_cost = 0.25 * (np.cos(a) * np.cos(b) - np.cos(a) + np.cos(b) + 3)
+        expected_cost = 0.25 * (pnp.cos(a) * pnp.cos(b) - pnp.cos(a) + pnp.cos(b) + 3)
 
         # the analytic result of evaluating grad(circuit(a, b))
-        expected_grad = np.array(
+        expected_grad = pnp.array(
             [
-                -0.25 * (np.sin(a) * np.cos(b) - np.sin(a)),
-                -0.25 * (np.cos(a) * np.sin(b) + np.sin(b)),
+                -0.25 * (pnp.sin(a) * pnp.cos(b) - pnp.sin(a)),
+                -0.25 * (pnp.cos(a) * pnp.sin(b) + pnp.sin(b)),
             ]
         )
 
-        assert np.allclose(res.numpy(), expected_cost, atol=tol, rtol=0)
+        assert pnp.allclose(res.numpy(), expected_cost, atol=tol, rtol=0)
 
         res = tape.gradient(res, [a_tf, b_tf])
-        assert np.allclose(res, expected_grad, atol=tol, rtol=0)
+        assert pnp.allclose(res, expected_grad, atol=tol, rtol=0)
 
     def test_backprop_gradient_broadcasted(self, tol):
         """Tests that the gradient of the broadcasted qnode is correct"""
@@ -1795,8 +1795,8 @@ class TestPassthruIntegrationTF:
             qml.TRY(b, wires=1, subspace=[0, 2])
             return qml.expval(qml.GellMann(0, 3) @ qml.GellMann(1, 3))
 
-        a = np.array(0.12)
-        b = np.array([0.54, 0.32, 1.2])
+        a = pnp.array(0.12)
+        b = pnp.array([0.54, 0.32, 1.2])
 
         a_tf = tf.Variable(a, dtype=tf.float64)
         b_tf = tf.Variable(b, dtype=tf.float64)
@@ -1806,21 +1806,21 @@ class TestPassthruIntegrationTF:
             res = circuit(a_tf, b_tf)
 
         # the analytic result of evaluating circuit(a, b)
-        expected_cost = 0.25 * (np.cos(a) * np.cos(b) - np.cos(a) + np.cos(b) + 3)
+        expected_cost = 0.25 * (pnp.cos(a) * pnp.cos(b) - pnp.cos(a) + pnp.cos(b) + 3)
 
         # the analytic result of evaluating grad(circuit(a, b))
-        expected_jac = np.array(
+        expected_jac = pnp.array(
             [
-                -0.25 * (np.sin(a) * np.cos(b) - np.sin(a)),
-                -0.25 * (np.cos(a) * np.sin(b) + np.sin(b)),
+                -0.25 * (pnp.sin(a) * pnp.cos(b) - pnp.sin(a)),
+                -0.25 * (pnp.cos(a) * pnp.sin(b) + pnp.sin(b)),
             ]
         )
 
-        assert np.allclose(res.numpy(), expected_cost, atol=tol, rtol=0)
+        assert pnp.allclose(res.numpy(), expected_cost, atol=tol, rtol=0)
 
         jac = tape.jacobian(res, [a_tf, b_tf])
-        assert np.allclose(jac[0], expected_jac[0], atol=tol, rtol=0)
-        assert np.allclose(qml.math.diag(jac[1].numpy()), expected_jac[1], atol=tol, rtol=0)
+        assert pnp.allclose(jac[0], expected_jac[0], atol=tol, rtol=0)
+        assert pnp.allclose(qml.math.diag(jac[1].numpy()), expected_jac[1], atol=tol, rtol=0)
 
 
 # TORCH integration tests
@@ -1844,9 +1844,9 @@ class TestQNodeIntegrationTorch:
             qml.TRX(x, wires=0, subspace=[0, 2])
             return qml.expval(qml.GellMann(0, 5))
 
-        expected = -np.sin(p)
+        expected = -pnp.sin(p)
 
-        assert np.isclose(circuit(p), expected, atol=tol, rtol=0)
+        assert pnp.isclose(circuit(p), expected, atol=tol, rtol=0)
 
     def test_correct_state(self, tol):
         """Test that the device state is correct after evaluating a
@@ -1861,13 +1861,13 @@ class TestQNodeIntegrationTorch:
             qml.TRZ(a, wires=0)
             return qml.expval(qml.GellMann(0, 3))
 
-        circuit(torch.tensor(np.pi / 4))
+        circuit(torch.tensor(pnp.pi / 4))
         state = dev.state
 
-        amplitude = np.exp(-1j * np.pi / 8)
-        expected = (-1j / np.sqrt(3)) * np.array([amplitude, np.conj(amplitude), 1])
+        amplitude = pnp.exp(-1j * pnp.pi / 8)
+        expected = (-1j / pnp.sqrt(3)) * pnp.array([amplitude, pnp.conj(amplitude), 1])
 
-        assert np.allclose(state, expected, atol=tol, rtol=0)
+        assert pnp.allclose(state, expected, atol=tol, rtol=0)
 
 
 @pytest.mark.torch
@@ -1876,7 +1876,7 @@ class TestDtypePreservedTorch:
     evaluation"""
 
     @pytest.mark.parametrize(
-        "r_dtype, r_dtype_torch", [(np.float32, "torch32"), (np.float64, "torch64")]
+        "r_dtype, r_dtype_torch", [(pnp.float32, "torch32"), (pnp.float64, "torch64")]
     )
     @pytest.mark.parametrize(
         "measurement",
@@ -1911,7 +1911,7 @@ class TestDtypePreservedTorch:
 
     @pytest.mark.parametrize(
         "c_dtype, c_dtype_torch",
-        [(np.complex64, "torchc64"), (np.complex128, "torchc128")],
+        [(pnp.complex64, "torchc64"), (pnp.complex128, "torchc128")],
     )
     def test_complex_dtype(self, c_dtype, c_dtype_torch):
         """Test that the user-defined dtype of the device is preserved

--- a/tests/devices/test_lightning_qubit.py
+++ b/tests/devices/test_lightning_qubit.py
@@ -18,7 +18,7 @@ import pytest
 from flaky import flaky
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 
 
 def test_integration():
@@ -32,15 +32,15 @@ def test_integration():
         qml.templates.StronglyEntanglingLayers(weights, wires=range(wires))
         return qml.expval(qml.PauliZ(0))
 
-    weights = np.random.random(
+    weights = pnp.random.random(
         qml.templates.StronglyEntanglingLayers.shape(layers, wires), requires_grad=True
     )
 
     qn_l = qml.QNode(circuit, dev_l)
     qn_d = qml.QNode(circuit, dev_d)
 
-    assert np.allclose(qn_l(weights), qn_d(weights))
-    assert np.allclose(qml.grad(qn_l)(weights), qml.grad(qn_d)(weights))
+    assert pnp.allclose(qn_l(weights), qn_d(weights))
+    assert pnp.allclose(qml.grad(qn_l)(weights), qml.grad(qn_d)(weights))
 
 
 def test_no_backprop_auto_interface():
@@ -78,14 +78,14 @@ def test_finite_shots():
     dq = qml.device("default.qubit", shots=50000)
 
     def circuit():
-        qml.RX(np.pi / 4, 0)
-        qml.RY(-np.pi / 4, 1)
+        qml.RX(pnp.pi / 4, 0)
+        qml.RY(-pnp.pi / 4, 1)
         return qml.expval(qml.PauliY(0))
 
     circ0 = qml.QNode(circuit, dev, diff_method=None)
     circ1 = qml.QNode(circuit, dq, diff_method=None)
 
-    assert np.allclose(circ0(), circ1(), rtol=0.01)
+    assert pnp.allclose(circ0(), circ1(), rtol=0.01)
 
 
 class TestDtypePreserved:
@@ -97,8 +97,8 @@ class TestDtypePreserved:
     @pytest.mark.parametrize(
         "c_dtype",
         [
-            np.complex64,
-            np.complex128,
+            pnp.complex64,
+            pnp.complex128,
         ],
     )
     @pytest.mark.parametrize(
@@ -129,8 +129,8 @@ class TestDtypePreserved:
         if isinstance(measurement, (qml.measurements.StateMP, qml.measurements.DensityMatrixMP)):
             expected_dtype = c_dtype
         else:
-            expected_dtype = np.float64 if c_dtype == np.complex128 else np.float32
-        if isinstance(res, np.ndarray):
+            expected_dtype = pnp.float64 if c_dtype == pnp.complex128 else pnp.float32
+        if isinstance(res, pnp.ndarray):
             assert res.dtype == expected_dtype
         else:
             assert isinstance(res, float)

--- a/tests/docs/test_supported_confs.py
+++ b/tests/docs/test_supported_confs.py
@@ -28,7 +28,7 @@ import pytest
 
 import pennylane as qml
 from pennylane import QuantumFunctionError
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane.measurements import Expectation, MutualInfo, Probability, Sample, Variance, VnEntropy
 from pennylane.measurements.measurements import ObservableReturnTypes
 
@@ -129,11 +129,11 @@ def get_qnode(interface, diff_method, return_type, shots, wire_specs):
         if return_type == "Hermitian":
             return qml.expval(
                 qml.Hermitian(
-                    np.array([[1.0, 0.0], [0.0, -1.0]], requires_grad=False), wires=single_meas_wire
+                    pnp.array([[1.0, 0.0], [0.0, -1.0]], requires_grad=False), wires=single_meas_wire
                 )
             )
         if return_type == "Projector":
-            return qml.expval(qml.Projector(np.array([1]), wires=single_meas_wire))
+            return qml.expval(qml.Projector(pnp.array([1]), wires=single_meas_wire))
         if return_type == Variance:
             return qml.var(qml.PauliZ(wires=single_meas_wire))
         if return_type == VnEntropy:
@@ -151,12 +151,12 @@ def get_variable(interface, wire_specs, complex=False):
     num_wires = len(wire_specs[1])
 
     if interface is None:
-        return np.array([0.1] * num_wires)
+        return pnp.array([0.1] * num_wires)
     if interface == "autograd":
-        return np.array([0.1] * num_wires, requires_grad=True)
+        return pnp.array([0.1] * num_wires, requires_grad=True)
     if interface == "jax":
         # complex dtype is required for JAX when holomorphic gradient is used
-        return jnp.array([0.1] * num_wires, dtype=np.complex128 if complex else None)
+        return jnp.array([0.1] * num_wires, dtype=pnp.complex128 if complex else None)
     if interface == "tf":
         # complex dtype is required for TF when the gradients have non-zero
         # imaginary parts, otherwise they will be ignored

--- a/tests/drawer/test_tape_text.py
+++ b/tests/drawer/test_tape_text.py
@@ -19,7 +19,7 @@ Unit tests for the `pennylane.draw_text` function.
 import pytest
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane.drawer import tape_text
 from pennylane.drawer.tape_text import (
     _add_cond_grouping_symbols,
@@ -256,7 +256,7 @@ class TestHelperFunctions:  # pylint: disable=too-many-arguments
     def test_add_measurements_cache(self):
         """Test private _add_measurement function with a matrix cache."""
         cache = {"matrices": []}
-        op = qml.expval(qml.Hermitian(np.eye(2), wires=0))
+        op = qml.expval(qml.Hermitian(pnp.eye(2), wires=0))
         assert _add_measurement(
             op, ["", ""], _Config(wire_map={0: 0, 1: 1}, bit_map=default_bit_map, cache=cache)
         ) == [
@@ -264,9 +264,9 @@ class TestHelperFunctions:  # pylint: disable=too-many-arguments
             "",
         ]
 
-        assert qml.math.allclose(cache["matrices"][0], np.eye(2))
+        assert qml.math.allclose(cache["matrices"][0], pnp.eye(2))
 
-        op2 = qml.expval(qml.Hermitian(np.eye(2), wires=1))
+        op2 = qml.expval(qml.Hermitian(pnp.eye(2), wires=1))
         # new op with same matrix, should have same M0 designation
         assert _add_measurement(
             op2, ["", ""], _Config(wire_map={0: 0, 1: 1}, bit_map=default_bit_map, cache=cache)
@@ -377,13 +377,13 @@ class TestHelperFunctions:  # pylint: disable=too-many-arguments
     def test_add_op_cache(self):
         """Test private _add_op method functions with a matrix cache."""
         cache = {"matrices": []}
-        op1 = qml.QubitUnitary(np.eye(2), wires=0)
+        op1 = qml.QubitUnitary(pnp.eye(2), wires=0)
         assert _add_op(
             op1, ["", ""], _Config(wire_map={0: 0, 1: 1}, bit_map=default_bit_map, cache=cache)
         ) == ["U(M0)", ""]
 
-        assert qml.math.allclose(cache["matrices"][0], np.eye(2))
-        op2 = qml.QubitUnitary(np.eye(2), wires=1)
+        assert qml.math.allclose(cache["matrices"][0], pnp.eye(2))
+        op2 = qml.QubitUnitary(pnp.eye(2), wires=1)
         assert _add_op(
             op2, ["", ""], _Config(wire_map={0: 0, 1: 1}, bit_map=default_bit_map, cache=cache)
         ) == ["", "U(M0)"]
@@ -667,8 +667,8 @@ class TestLayering:
 
 
 tape_matrices = qml.tape.QuantumScript(
-    ops=[qml.StatePrep([1.0, 0.0, 0.0, 0.0], wires=(0, 1)), qml.QubitUnitary(np.eye(2), wires=0)],
-    measurements=[qml.expval(qml.Hermitian(np.eye(2), wires=0))],
+    ops=[qml.StatePrep([1.0, 0.0, 0.0, 0.0], wires=(0, 1)), qml.QubitUnitary(pnp.eye(2), wires=0)],
+    measurements=[qml.expval(qml.Hermitian(pnp.eye(2), wires=0))],
 )
 
 
@@ -697,7 +697,7 @@ class TestShowMatrices:
         """Providing an existing matrix cache determines numbering order of matrices.
         All matrices printed out regardless of use."""
 
-        cache = {"matrices": [np.eye(2), -np.eye(3)]}
+        cache = {"matrices": [pnp.eye(2), -pnp.eye(3)]}
 
         expected = (
             "0: ─╭|Ψ⟩──U(M0)─┤  <𝓗(M0)>\n"

--- a/tests/fourier/test_coefficients.py
+++ b/tests/fourier/test_coefficients.py
@@ -20,7 +20,7 @@ from functools import partial
 import pytest
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane.fourier import coefficients
 
 
@@ -42,8 +42,8 @@ def fourier_function(freq_dict, x):
     if 0 in freq_dict.keys():
         result = freq_dict[0]
 
-    _sum = sum(coeff * np.exp(1j * freq * x) for freq, coeff in freq_dict.items() if freq != 0)
-    result += _sum + np.conj(_sum)
+    _sum = sum(coeff * pnp.exp(1j * freq * x) for freq, coeff in freq_dict.items() if freq != 0)
+    result += _sum + pnp.conj(_sum)
     return result.real
 
 
@@ -76,10 +76,10 @@ class TestFourierCoefficientSingleVariable:
     @pytest.mark.parametrize(
         "freq_dict,expected_coeffs",
         [
-            ({0: 0.5, 1: 2.3, 3: 0.4}, np.array([0.5, 2.3, 0, 0.4, 0.4, 0, 2.3])),
+            ({0: 0.5, 1: 2.3, 3: 0.4}, pnp.array([0.5, 2.3, 0, 0.4, 0.4, 0, 2.3])),
             (
                 {3: 0.4, 4: 0.2 + 0.8j, 5: 1j},
-                np.array([0, 0, 0, 0.4, 0.2 + 0.8j, 1j, -1j, 0.2 - 0.8j, 0.4, 0.0, 0]),
+                pnp.array([0, 0, 0, 0.4, 0.2 + 0.8j, 1j, -1j, 0.2 - 0.8j, 0.4, 0.0, 0]),
             ),
         ],
     )
@@ -91,11 +91,11 @@ class TestFourierCoefficientSingleVariable:
         # Testing with a single degree provided as integer
         coeffs = coefficients(partial_func, 1, degree)
 
-        assert np.allclose(coeffs, expected_coeffs)
+        assert pnp.allclose(coeffs, expected_coeffs)
         # Testing with a single-entry sequence of degrees
         coeffs = coefficients(partial_func, 1, (degree,))
 
-        assert np.allclose(coeffs, expected_coeffs)
+        assert pnp.allclose(coeffs, expected_coeffs)
 
 
 dev_1 = qml.device("default.qubit", wires=1)
@@ -202,33 +202,33 @@ class TestFourierCoefficientCircuits:
     @pytest.mark.parametrize(
         "circuit,degree,expected_coeffs",
         [
-            (circuit_one_qubit_one_param_rx, 1, np.array([0, 0.5, 0.5])),
-            (circuit_one_qubit_one_param_rx, 2, np.array([0, 0.5, 0, 0, 0.5])),
-            (circuit_one_qubit_one_param_h_ry, (1,), np.array([0, 0.5j, -0.5j])),
+            (circuit_one_qubit_one_param_rx, 1, pnp.array([0, 0.5, 0.5])),
+            (circuit_one_qubit_one_param_rx, 2, pnp.array([0, 0.5, 0, 0, 0.5])),
+            (circuit_one_qubit_one_param_h_ry, (1,), pnp.array([0, 0.5j, -0.5j])),
             (
                 circuit_one_qubit_one_param_h_ry,
                 3,
-                np.array([0, 0.5j, 0, 0, 0, 0, -0.5j]),
+                pnp.array([0, 0.5j, 0, 0, 0, 0, -0.5j]),
             ),
             (
                 circuit_one_qubit_one_param_rx_ry,
                 2,
-                np.array([0.5, 0, 0.25, 0.25, 0]),
+                pnp.array([0.5, 0, 0.25, 0.25, 0]),
             ),
             (
                 circuit_one_qubit_one_param_rx_ry,
                 4,
-                np.array([0.5, 0, 0.25, 0, 0, 0, 0, 0.25, 0]),
+                pnp.array([0.5, 0, 0.25, 0, 0, 0, 0, 0.25, 0]),
             ),
             (
                 circuit_two_qubits_repeated_param,
                 (2,),
-                np.array([0.5, 0, 0.25, 0.25, 0]),
+                pnp.array([0.5, 0, 0.25, 0.25, 0]),
             ),
             (
                 circuit_two_qubits_repeated_param,
                 3,
-                np.array([0.5, 0, 0.25, 0, 0, 0.25, 0]),
+                pnp.array([0.5, 0, 0.25, 0, 0, 0.25, 0]),
             ),
         ],
     )
@@ -238,7 +238,7 @@ class TestFourierCoefficientCircuits:
         """Test that coeffs for a single instance of a single parameter match the by-hand
         results regardless of input degree (max degree is 1)."""
         coeffs = coefficients(circuit, circuit.n_inputs, degree, use_broadcasting=use_broadcasting)
-        assert np.allclose(coeffs, expected_coeffs)
+        assert pnp.allclose(coeffs, expected_coeffs)
 
     @pytest.mark.parametrize(
         "circuit,degree,expected_coeffs",
@@ -246,22 +246,22 @@ class TestFourierCoefficientCircuits:
             (
                 circuit_two_qubits_two_params,
                 1,
-                np.array([[0, 0, 0], [0, 0.25, 0.25], [0, 0.25, 0.25]]),
+                pnp.array([[0, 0, 0], [0, 0.25, 0.25], [0, 0.25, 0.25]]),
             ),
             (
                 circuit_two_qubits_two_params,
                 (1, 1),
-                np.array([[0, 0, 0], [0, 0.25, 0.25], [0, 0.25, 0.25]]),
+                pnp.array([[0, 0, 0], [0, 0.25, 0.25], [0, 0.25, 0.25]]),
             ),
             (
                 circuit_one_qubit_two_params,
                 1,
-                np.array([[0, 0, 0], [0, 0.25, 0.25], [0, 0.25, 0.25]]),
+                pnp.array([[0, 0, 0], [0, 0.25, 0.25], [0, 0.25, 0.25]]),
             ),
             (
                 circuit_one_qubit_two_params,
                 (2, 1),
-                np.array([[0, 0, 0], [0, 0.25, 0.25], [0, 0, 0], [0, 0, 0], [0, 0.25, 0.25]]),
+                pnp.array([[0, 0, 0], [0, 0.25, 0.25], [0, 0, 0], [0, 0, 0], [0, 0.25, 0.25]]),
             ),
         ],
     )
@@ -271,7 +271,7 @@ class TestFourierCoefficientCircuits:
         """Test that coeffs for a single instance of a single parameter match the by-hand
         results regardless of input degree (max degree is 1)."""
         coeffs = coefficients(circuit, circuit.n_inputs, degree, use_broadcasting=use_broadcasting)
-        assert np.allclose(coeffs, expected_coeffs)
+        assert pnp.allclose(coeffs, expected_coeffs)
 
 
 class TestAntiAliasing:
@@ -283,7 +283,7 @@ class TestAntiAliasing:
             (
                 circuit_two_qubits_repeated_param,
                 1,
-                np.array([0.5, 0, 0]),
+                pnp.array([0.5, 0, 0]),
             ),
         ],
     )
@@ -293,10 +293,10 @@ class TestAntiAliasing:
         coeffs_anti_aliased = coefficients(
             circuit, circuit.n_inputs, degree, lowpass_filter=True, filter_threshold=degree + 2
         )
-        assert np.allclose(coeffs_anti_aliased, expected_coeffs)
+        assert pnp.allclose(coeffs_anti_aliased, expected_coeffs)
 
         coeffs_regular = coefficients(circuit, circuit.n_inputs, degree)
-        assert not np.allclose(coeffs_regular, expected_coeffs)
+        assert not pnp.allclose(coeffs_regular, expected_coeffs)
 
     @pytest.mark.parametrize(
         "circuit,degree,threshold",
@@ -325,7 +325,7 @@ class TestAntiAliasing:
             filter_threshold=threshold,
         )
 
-        assert np.allclose(coeffs_regular, coeffs_anti_aliased)
+        assert pnp.allclose(coeffs_regular, coeffs_anti_aliased)
 
 
 class TestInterfaces:
@@ -343,7 +343,7 @@ class TestInterfaces:
 
     dev = qml.device("default.qubit", wires=2)
 
-    expected_result = np.array(
+    expected_result = pnp.array(
         [
             [0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j],
             [0.0 + 0.0j, 0.21502233 + 0.0j, 0.21502233 + 0.0j],
@@ -362,7 +362,7 @@ class TestInterfaces:
 
         obtained_result = coefficients(partial(qnode, weights), 2, 1)
 
-        assert np.allclose(obtained_result, self.expected_result)
+        assert pnp.allclose(obtained_result, self.expected_result)
 
     @pytest.mark.torch
     def test_coefficients_torch_interface(self):
@@ -375,7 +375,7 @@ class TestInterfaces:
 
         obtained_result = coefficients(partial(qnode, weights), 2, 1)
 
-        assert np.allclose(obtained_result, self.expected_result)
+        assert pnp.allclose(obtained_result, self.expected_result)
 
     @pytest.mark.jax
     def test_coefficients_jax_interface(self):
@@ -388,4 +388,4 @@ class TestInterfaces:
 
         obtained_result = coefficients(partial(qnode, weights), 2, 1)
 
-        assert np.allclose(obtained_result, self.expected_result)
+        assert pnp.allclose(obtained_result, self.expected_result)

--- a/tests/fourier/test_visualize.py
+++ b/tests/fourier/test_visualize.py
@@ -18,7 +18,7 @@ Unit tests for :mod:`fourier` visualization functions.
 
 import pytest
 
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane.fourier.visualize import _validate_coefficients, bar, box, panel, radial_box, violin
 
 matplotlib = pytest.importorskip("matplotlib")
@@ -26,13 +26,13 @@ matplotlib = pytest.importorskip("matplotlib")
 plt = matplotlib.pyplot
 
 
-coeffs_1D_valid_1 = np.array([0.5, 0, 0.25j, 0.25j, 0])
+coeffs_1D_valid_1 = pnp.array([0.5, 0, 0.25j, 0.25j, 0])
 coeffs_1D_valid_2 = [0.5, 0.1j, -0.25j, 0.25j, -0.1j]
-coeffs_1D_invalid = np.array([0.5, 0, 0.25j, 0.25j])
+coeffs_1D_invalid = pnp.array([0.5, 0, 0.25j, 0.25j])
 
 coeffs_1D_valid_list = [coeffs_1D_valid_1, coeffs_1D_valid_2]
 
-coeffs_2D_valid_1 = np.array(
+coeffs_2D_valid_1 = pnp.array(
     [
         [
             0.07469786 + 0.0000e00j,
@@ -72,7 +72,7 @@ coeffs_2D_valid_1 = np.array(
     ]
 )
 
-coeffs_2D_valid_2 = np.array(
+coeffs_2D_valid_2 = pnp.array(
     [
         [
             0.12707831 + 0.0j,
@@ -114,10 +114,10 @@ coeffs_2D_valid_2 = np.array(
 
 coeffs_2D_valid_list = [coeffs_2D_valid_1, coeffs_2D_valid_2]
 
-coeffs_2D_varying_degrees = np.zeros((5, 9), dtype=complex)
+coeffs_2D_varying_degrees = pnp.zeros((5, 9), dtype=complex)
 coeffs_2D_varying_degrees[:5, :5] = coeffs_2D_valid_2
 
-coeffs_2D_invalid = np.array(
+coeffs_2D_invalid = pnp.array(
     [
         [
             0.12707831 + 0.0j,
@@ -150,7 +150,7 @@ coeffs_2D_invalid = np.array(
     ]
 )
 
-coeffs_3D_valid = np.zeros((5, 5, 5), dtype=complex)
+coeffs_3D_valid = pnp.zeros((5, 5, 5), dtype=complex)
 data = {
     (0, 0, 1): -0.00882888 - 0.14568055j,
     (0, 0, 4): -0.00882888 + 0.14568055j,
@@ -183,7 +183,7 @@ data = {
     (3, 3, 4): -0.00098495 - 0.00146529j,
     (3, 4, 0): 0.00439013 + 0.00574692j,
 }
-coeffs_3D_varying_degrees = np.zeros((3, 7, 5), dtype=complex)
+coeffs_3D_varying_degrees = pnp.zeros((3, 7, 5), dtype=complex)
 
 for key, val in data.items():
     coeffs_3D_valid[key] = val
@@ -213,22 +213,22 @@ class TestValidateCoefficients:
     @pytest.mark.parametrize(
         "coeffs,n_inputs,can_be_list,expected_coeffs",
         [
-            (coeffs_1D_valid_1, 1, True, np.array([coeffs_1D_valid_1])),
-            (coeffs_1D_valid_1, 1, False, np.array(coeffs_1D_valid_1)),
-            (coeffs_1D_valid_2, 1, True, np.array([coeffs_1D_valid_2])),
+            (coeffs_1D_valid_1, 1, True, pnp.array([coeffs_1D_valid_1])),
+            (coeffs_1D_valid_1, 1, False, pnp.array(coeffs_1D_valid_1)),
+            (coeffs_1D_valid_2, 1, True, pnp.array([coeffs_1D_valid_2])),
             (coeffs_1D_valid_2, 1, False, coeffs_1D_valid_2),
-            (coeffs_2D_valid_1, 2, True, np.array([coeffs_2D_valid_1])),
-            (coeffs_2D_valid_list, 2, True, np.array(coeffs_2D_valid_list)),
-            (coeffs_3D_valid, 3, True, np.array([coeffs_3D_valid])),
+            (coeffs_2D_valid_1, 2, True, pnp.array([coeffs_2D_valid_1])),
+            (coeffs_2D_valid_list, 2, True, pnp.array(coeffs_2D_valid_list)),
+            (coeffs_3D_valid, 3, True, pnp.array([coeffs_3D_valid])),
             (coeffs_3D_valid, 3, False, coeffs_3D_valid),
-            (coeffs_3D_varying_degrees, 3, True, np.array([coeffs_3D_varying_degrees])),
+            (coeffs_3D_varying_degrees, 3, True, pnp.array([coeffs_3D_varying_degrees])),
             (coeffs_3D_varying_degrees, 3, False, coeffs_3D_varying_degrees),
         ],
     )
     def test_valid_fourier_coeffs(self, coeffs, n_inputs, can_be_list, expected_coeffs):
         """Check that valid parameters are properly processed."""
         obtained_coeffs = _validate_coefficients(coeffs, n_inputs, can_be_list)
-        assert np.allclose(obtained_coeffs, expected_coeffs)
+        assert pnp.allclose(obtained_coeffs, expected_coeffs)
 
     def test_incorrect_type_fourier_coeffs(self):
         """Check that invalid type of parameters is caught"""

--- a/tests/gate_data.py
+++ b/tests/gate_data.py
@@ -2,7 +2,7 @@
 
 import pennylane as qml
 from pennylane import math
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 
 # ========================================================
 #  fixed gates
@@ -17,9 +17,9 @@ Z = math.array([[1, 0], [0, -1]])  #: Pauli-Z matrix
 
 H = math.array([[1, 1], [1, -1]]) / math.sqrt(2)  #: Hadamard gate
 
-II = math.eye(4, dtype=np.complex128) + 0j
-XX = math.array(math.kron(X, X), dtype=np.complex128)
-YY = math.array(math.kron(Y, Y), dtype=np.complex128)
+II = math.eye(4, dtype=pnp.complex128) + 0j
+XX = math.array(math.kron(X, X), dtype=pnp.complex128)
+YY = math.array(math.kron(Y, Y), dtype=pnp.complex128)
 
 # Single-qubit projectors
 StateZeroProjector = math.array([[1, 0], [0, 0]])
@@ -40,7 +40,7 @@ SISWAP = math.array(
 CZ = math.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, -1]])  #: CZ gate
 CY = math.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, -1j], [0, 0, 1j, 0]])  #: CY gate
 S = math.array([[1, 0], [0, 1j]])  #: Phase Gate
-T = math.array([[1, 0], [0, math.exp(1j * np.pi / 4)]])  #: T Gate
+T = math.array([[1, 0], [0, math.exp(1j * pnp.pi / 4)]])  #: T Gate
 SX = 0.5 * math.array([[1 + 1j, 1 - 1j], [1 - 1j, 1 + 1j]])  #: SX Gate
 ECR = math.array(
     [
@@ -78,7 +78,7 @@ Toffoli[6:8, 6:8] = math.array([[0, 1], [1, 0]])
 
 CCZ = math.diag([1] * 7 + [-1])
 
-w = math.exp(2 * np.pi * 1j / 8)
+w = math.exp(2 * pnp.pi * 1j / 8)
 QFT = math.array(
     [
         [1, 1, 1, 1, 1, 1, 1, 1],
@@ -93,17 +93,17 @@ QFT = math.array(
 ) / math.sqrt(8)
 
 # Qutrit gates
-OMEGA = np.exp(2 * np.pi * 1j / 3)
+OMEGA = pnp.exp(2 * pnp.pi * 1j / 3)
 
-TSHIFT = np.array([[0, 0, 1], [1, 0, 0], [0, 1, 0]])  # Qutrit right-shift gate
+TSHIFT = pnp.array([[0, 0, 1], [1, 0, 0], [0, 1, 0]])  # Qutrit right-shift gate
 
-TCLOCK = np.array([[1, 0, 0], [0, OMEGA, 0], [0, 0, OMEGA**2]])  # Qutrit clock gate
+TCLOCK = pnp.array([[1, 0, 0], [0, OMEGA, 0], [0, 0, OMEGA**2]])  # Qutrit clock gate
 
-TH = (-1j / np.sqrt(3)) * np.array(
+TH = (-1j / pnp.sqrt(3)) * pnp.array(
     [[1, 1, 1], [1, OMEGA, OMEGA**2], [1, OMEGA**2, OMEGA]]
 )  # hadamard gate
 
-TSWAP = np.array(
+TSWAP = pnp.array(
     [
         [1, 0, 0, 0, 0, 0, 0, 0, 0],
         [0, 0, 0, 1, 0, 0, 0, 0, 0],
@@ -115,10 +115,10 @@ TSWAP = np.array(
         [0, 0, 0, 0, 0, 1, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0, 1],
     ],
-    dtype=np.complex128,
+    dtype=pnp.complex128,
 )  # Ternary swap gate
 
-TADD = np.array(
+TADD = pnp.array(
     [
         [1, 0, 0, 0, 0, 0, 0, 0, 0],
         [0, 1, 0, 0, 0, 0, 0, 0, 0],
@@ -130,18 +130,18 @@ TADD = np.array(
         [0, 0, 0, 0, 0, 0, 0, 0, 1],
         [0, 0, 0, 0, 0, 0, 1, 0, 0],
     ],
-    dtype=np.complex128,
+    dtype=pnp.complex128,
 )  # Ternary add gate
 
-GELL_MANN = np.zeros((8, 3, 3), dtype=np.complex128)
-GELL_MANN[0] = np.array([[0, 1, 0], [1, 0, 0], [0, 0, 0]])
-GELL_MANN[1] = np.array([[0, -1j, 0], [1j, 0, 0], [0, 0, 0]])
-GELL_MANN[2] = np.diag([1, -1, 0])
-GELL_MANN[3] = np.array([[0, 0, 1], [0, 0, 0], [1, 0, 0]])
-GELL_MANN[4] = np.array([[0, 0, -1j], [0, 0, 0], [1j, 0, 0]])
-GELL_MANN[5] = np.array([[0, 0, 0], [0, 0, 1], [0, 1, 0]])
-GELL_MANN[6] = np.array([[0, 0, 0], [0, 0, -1j], [0, 1j, 0]])
-GELL_MANN[7] = np.diag([1, 1, -2]) / np.sqrt(3)
+GELL_MANN = pnp.zeros((8, 3, 3), dtype=pnp.complex128)
+GELL_MANN[0] = pnp.array([[0, 1, 0], [1, 0, 0], [0, 0, 0]])
+GELL_MANN[1] = pnp.array([[0, -1j, 0], [1j, 0, 0], [0, 0, 0]])
+GELL_MANN[2] = pnp.diag([1, -1, 0])
+GELL_MANN[3] = pnp.array([[0, 0, 1], [0, 0, 0], [1, 0, 0]])
+GELL_MANN[4] = pnp.array([[0, 0, -1j], [0, 0, 0], [1j, 0, 0]])
+GELL_MANN[5] = pnp.array([[0, 0, 0], [0, 0, 1], [0, 1, 0]])
+GELL_MANN[6] = pnp.array([[0, 0, 0], [0, 0, -1j], [0, 1j, 0]])
+GELL_MANN[7] = pnp.diag([1, 1, -2]) / pnp.sqrt(3)
 
 
 # ========================================================
@@ -498,7 +498,7 @@ def CPhaseShift00(phi):
     Returns:
         array: the two-wire controlled-phase matrix
     """
-    return np.diag([np.exp(1j * phi), 1, 1, 1])
+    return pnp.diag([pnp.exp(1j * phi), 1, 1, 1])
 
 
 def CPhaseShift01(phi):
@@ -510,7 +510,7 @@ def CPhaseShift01(phi):
     Returns:
         array: the two-wire controlled-phase matrix
     """
-    return np.diag([1, np.exp(1j * phi), 1, 1])
+    return pnp.diag([1, pnp.exp(1j * phi), 1, 1])
 
 
 def CPhaseShift10(phi):
@@ -522,7 +522,7 @@ def CPhaseShift10(phi):
     Returns:
         array: the two-wire controlled-phase matrix
     """
-    return np.diag([1, 1, np.exp(1j * phi), 1])
+    return pnp.diag([1, 1, pnp.exp(1j * phi), 1])
 
 
 def SingleExcitation(phi):
@@ -620,7 +620,7 @@ def DoubleExcitationPlus(phi):
     s = math.sin(phi / 2)
     e = math.exp(1j * phi / 2)
 
-    U = e * math.eye(16, dtype=np.complex128)
+    U = e * math.eye(16, dtype=pnp.complex128)
     U[3, 3] = c  # 3 (dec) = 0011 (bin)
     U[3, 12] = -s  # 12 (dec) = 1100 (bin)
     U[12, 3] = s
@@ -642,7 +642,7 @@ def DoubleExcitationMinus(phi):
     s = math.sin(phi / 2)
     e = math.exp(-1j * phi / 2)
 
-    U = e * math.eye(16, dtype=np.complex128)
+    U = e * math.eye(16, dtype=pnp.complex128)
     U[3, 3] = c  # 3 (dec) = 0011 (bin)
     U[3, 12] = -s  # 12 (dec) = 1100 (bin)
     U[12, 3] = s

--- a/tests/gradients/core/test_adjoint_metric_tensor.py
+++ b/tests/gradients/core/test_adjoint_metric_tensor.py
@@ -22,7 +22,7 @@ import numpy as onp
 import pytest
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 
 
 @pytest.fixture(autouse=True)
@@ -156,7 +156,7 @@ def fubini_ansatz10(weights, wires=None):
     qml.templates.BasicEntanglerLayers(weights, wires=[wires[0], wires[1]])
 
 
-B = np.array(
+B = pnp.array(
     [
         [
             [0.73, 0.49, 0.04],
@@ -173,9 +173,9 @@ B = np.array(
 )
 fubini_ansatze_tape = [fubini_ansatz0, fubini_ansatz1, fubini_ansatz8]
 fubini_params_tape = [
-    (np.array([0.3434, -0.7245345], requires_grad=True),),
+    (pnp.array([0.3434, -0.7245345], requires_grad=True),),
     (B,),
-    (np.array(-0.1735, requires_grad=True),),
+    (pnp.array(-0.1735, requires_grad=True),),
 ]
 
 fubini_ansatze = [
@@ -193,23 +193,23 @@ fubini_ansatze = [
 ]
 
 fubini_params = [
-    (np.array([0.3434, -0.7245345], requires_grad=True),),
+    (pnp.array([0.3434, -0.7245345], requires_grad=True),),
     (B,),
-    (np.array([-0.1111, -0.2222], requires_grad=True),),
-    (np.array([-0.1111, -0.2222, 0.4554], requires_grad=True),),
+    (pnp.array([-0.1111, -0.2222], requires_grad=True),),
+    (pnp.array([-0.1111, -0.2222, 0.4554], requires_grad=True),),
     (
-        np.array(-0.1735, requires_grad=True),
-        np.array([-0.1735, -0.2846, -0.2846], requires_grad=True),
+        pnp.array(-0.1735, requires_grad=True),
+        pnp.array([-0.1735, -0.2846, -0.2846], requires_grad=True),
     ),
-    (np.array([-0.1735, -0.2846], requires_grad=True),),
-    (np.array([-0.1735, -0.2846], requires_grad=True),),
+    (pnp.array([-0.1735, -0.2846], requires_grad=True),),
+    (pnp.array([-0.1735, -0.2846], requires_grad=True),),
     (
-        np.array([-0.1735, -0.2846], requires_grad=True),
-        np.array([0.9812, -0.1492], requires_grad=True),
+        pnp.array([-0.1735, -0.2846], requires_grad=True),
+        pnp.array([0.9812, -0.1492], requires_grad=True),
     ),
-    (np.array(-0.1735, requires_grad=True),),
-    (np.array([-0.1111, 0.3333], requires_grad=True),),
-    (np.array([[0.21, 9.29], [-0.2, 0.12], [0.3, -2.1]], requires_grad=True),),
+    (pnp.array(-0.1735, requires_grad=True),),
+    (pnp.array([-0.1111, 0.3333], requires_grad=True),),
+    (pnp.array([[0.21, 9.29], [-0.2, 0.12], [0.3, -2.1]], requires_grad=True),),
 ]
 
 
@@ -227,10 +227,10 @@ def autodiff_metric_tensor(ansatz, num_wires):
         state = qnode(*params)
 
         def rqnode(*params):
-            return np.real(qnode(*params))
+            return pnp.real(qnode(*params))
 
         def iqnode(*params):
-            return np.imag(qnode(*params))
+            return pnp.imag(qnode(*params))
 
         rjac = qml.jacobian(rqnode)(*params)
         ijac = qml.jacobian(iqnode)(*params)
@@ -239,20 +239,20 @@ def autodiff_metric_tensor(ansatz, num_wires):
             out = []
             for rc, ic in zip(rjac, ijac):
                 c = rc + 1j * ic
-                psidpsi = np.tensordot(np.conj(state), c, axes=([0], [0]))
+                psidpsi = pnp.tensordot(pnp.conj(state), c, axes=([0], [0]))
                 out.append(
-                    np.real(
-                        np.tensordot(np.conj(c), c, axes=([0], [0]))
-                        - np.tensordot(np.conj(psidpsi), psidpsi, axes=0)
+                    pnp.real(
+                        pnp.tensordot(pnp.conj(c), c, axes=([0], [0]))
+                        - pnp.tensordot(pnp.conj(psidpsi), psidpsi, axes=0)
                     )
                 )
             return tuple(out)
 
         jac = rjac + 1j * ijac
-        psidpsi = np.tensordot(np.conj(state), jac, axes=([0], [0]))
-        return np.real(
-            np.tensordot(np.conj(jac), jac, axes=([0], [0]))
-            - np.tensordot(np.conj(psidpsi), psidpsi, axes=0)
+        psidpsi = pnp.tensordot(pnp.conj(state), jac, axes=([0], [0]))
+        return pnp.real(
+            pnp.tensordot(pnp.conj(jac), jac, axes=([0], [0]))
+            - pnp.tensordot(pnp.conj(psidpsi), psidpsi, axes=0)
         )
 
     return mt
@@ -647,7 +647,7 @@ def test_works_with_state_prep():
         ansatz(angles, wires=[0, 1])
         return qml.expval(qml.Z(0) @ qml.X(1))
 
-    angles = np.random.uniform(size=(2,), requires_grad=True)
+    angles = pnp.random.uniform(size=(2,), requires_grad=True)
     qfim = qml.adjoint_metric_tensor(circuit)(angles)
     autodiff_qfim = autodiff_metric_tensor(ansatz, 2)(angles)
     assert onp.allclose(qfim, autodiff_qfim)

--- a/tests/gradients/core/test_jvp.py
+++ b/tests/gradients/core/test_jvp.py
@@ -15,118 +15,118 @@
 import pytest
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane.gradients import param_shift
 from pennylane.measurements.shots import Shots
 
-_x = np.arange(12).reshape((2, 3, 2))
+_x = pnp.arange(12).reshape((2, 3, 2))
 
 tests_compute_jvp_single = [
     # Single scalar parameter, scalar output
-    (np.array(2), np.array([4]), np.array(8)),
-    (np.array(2), [np.array(4)], np.array(8)),
-    (np.array(2), (np.array(4),), np.array(8)),
+    (pnp.array(2), pnp.array([4]), pnp.array(8)),
+    (pnp.array(2), [pnp.array(4)], pnp.array(8)),
+    (pnp.array(2), (pnp.array(4),), pnp.array(8)),
     # Single scalar parameter, tensor output
-    (np.array([1, 2, 3]), np.array([4]), np.array([4, 8, 12])),
-    (np.array([1, 2, 3]), [np.array(4)], np.array([4, 8, 12])),
-    (np.array([1, 2, 3]), (np.array(4),), np.array([4, 8, 12])),
-    (_x.reshape((4, 3)), np.array([4]), 4 * _x.reshape((4, 3))),
-    (_x.reshape((4, 3)), [np.array(4)], 4 * _x.reshape((4, 3))),
-    (_x.reshape((4, 3)), (np.array(4),), 4 * _x.reshape((4, 3))),
-    (_x, np.array([4]), _x * 4),
-    (_x, [np.array(4)], _x * 4),
-    (_x, (np.array(4),), _x * 4),
+    (pnp.array([1, 2, 3]), pnp.array([4]), pnp.array([4, 8, 12])),
+    (pnp.array([1, 2, 3]), [pnp.array(4)], pnp.array([4, 8, 12])),
+    (pnp.array([1, 2, 3]), (pnp.array(4),), pnp.array([4, 8, 12])),
+    (_x.reshape((4, 3)), pnp.array([4]), 4 * _x.reshape((4, 3))),
+    (_x.reshape((4, 3)), [pnp.array(4)], 4 * _x.reshape((4, 3))),
+    (_x.reshape((4, 3)), (pnp.array(4),), 4 * _x.reshape((4, 3))),
+    (_x, pnp.array([4]), _x * 4),
+    (_x, [pnp.array(4)], _x * 4),
+    (_x, (pnp.array(4),), _x * 4),
     # Single tensor parameter, scalar output
-    (np.array([5, -2]), [np.array([4, 9])], np.array(2)),
-    (np.array([[5, -2]]), [np.array([[4, 9]])], np.array(2)),
-    (np.array([[4, 3], [5, -2]]), [np.array([[-1, 2], [4, 9]])], np.array(4)),
+    (pnp.array([5, -2]), [pnp.array([4, 9])], pnp.array(2)),
+    (pnp.array([[5, -2]]), [pnp.array([[4, 9]])], pnp.array(2)),
+    (pnp.array([[4, 3], [5, -2]]), [pnp.array([[-1, 2], [4, 9]])], pnp.array(4)),
     # Single tensor parameter, tensor output
-    (np.outer([-1, 3], [5, -2]), [np.array([4, 9])], np.array([-2, 6])),
-    (np.array([[[3, 2]], [[5, -2]]]), [np.array([[4, 9]])], np.array([30, 2])),
+    (pnp.outer([-1, 3], [5, -2]), [pnp.array([4, 9])], pnp.array([-2, 6])),
+    (pnp.array([[[3, 2]], [[5, -2]]]), [pnp.array([[4, 9]])], pnp.array([30, 2])),
     (
-        np.tensordot(_x.reshape((4, 3)), [[4, 3], [5, -2]], axes=0),
-        [np.array([[-1, 2], [4, 9]])],
+        pnp.tensordot(_x.reshape((4, 3)), [[4, 3], [5, -2]], axes=0),
+        [pnp.array([[-1, 2], [4, 9]])],
         4 * _x.reshape((4, 3)),
     ),
     # Multiple scalar parameters, scalar output
-    (tuple(np.array(x) for x in [2, 1, -9]), np.array([4, -3, 2]), np.array(-13)),
-    (tuple(np.array(x) for x in [2, 1, -9]), [np.array(x) for x in [4, -3, 2]], np.array(-13)),
-    (tuple(np.array(x) for x in [2, 1, -9]), tuple(np.array(x) for x in [4, -3, 2]), np.array(-13)),
+    (tuple(pnp.array(x) for x in [2, 1, -9]), pnp.array([4, -3, 2]), pnp.array(-13)),
+    (tuple(pnp.array(x) for x in [2, 1, -9]), [pnp.array(x) for x in [4, -3, 2]], pnp.array(-13)),
+    (tuple(pnp.array(x) for x in [2, 1, -9]), tuple(pnp.array(x) for x in [4, -3, 2]), pnp.array(-13)),
     # Multiple scalar parameters, tensor output
     (
-        tuple(np.array([1, 3, -2]) * x for x in [2, 1, -9]),
-        np.array([4, -3, 2]),
-        np.array([-13, -39, 26]),
+        tuple(pnp.array([1, 3, -2]) * x for x in [2, 1, -9]),
+        pnp.array([4, -3, 2]),
+        pnp.array([-13, -39, 26]),
     ),
     (
-        tuple(np.array([1, 3, -2]) * x for x in [2, 1, -9]),
-        [np.array(x) for x in [4, -3, 2]],
-        np.array([-13, -39, 26]),
+        tuple(pnp.array([1, 3, -2]) * x for x in [2, 1, -9]),
+        [pnp.array(x) for x in [4, -3, 2]],
+        pnp.array([-13, -39, 26]),
     ),
     (
-        tuple(np.array([1, 3, -2]) * x for x in [2, 1, -9]),
-        tuple(np.array(x) for x in [4, -3, 2]),
-        np.array([-13, -39, 26]),
+        tuple(pnp.array([1, 3, -2]) * x for x in [2, 1, -9]),
+        tuple(pnp.array(x) for x in [4, -3, 2]),
+        pnp.array([-13, -39, 26]),
     ),
     (
-        tuple(np.array([[1, 3, -2], [0, -4, 2]]) * x for x in [2, 1, -9]),
-        np.array([4, -3, 2]),
-        np.array([[-13, -39, 26], [0, 52, -26]]),
+        tuple(pnp.array([[1, 3, -2], [0, -4, 2]]) * x for x in [2, 1, -9]),
+        pnp.array([4, -3, 2]),
+        pnp.array([[-13, -39, 26], [0, 52, -26]]),
     ),
     (
-        tuple(np.array([[1, 3, -2], [0, -4, 2]]) * x for x in [2, 1, -9]),
-        [np.array(x) for x in [4, -3, 2]],
-        np.array([[-13, -39, 26], [0, 52, -26]]),
+        tuple(pnp.array([[1, 3, -2], [0, -4, 2]]) * x for x in [2, 1, -9]),
+        [pnp.array(x) for x in [4, -3, 2]],
+        pnp.array([[-13, -39, 26], [0, 52, -26]]),
     ),
     (
-        tuple(np.array([[1, 3, -2], [0, -4, 2]]) * x for x in [2, 1, -9]),
-        tuple(np.array(x) for x in [4, -3, 2]),
-        np.array([[-13, -39, 26], [0, 52, -26]]),
+        tuple(pnp.array([[1, 3, -2], [0, -4, 2]]) * x for x in [2, 1, -9]),
+        tuple(pnp.array(x) for x in [4, -3, 2]),
+        pnp.array([[-13, -39, 26], [0, 52, -26]]),
     ),
-    (tuple(_x * x for x in [2, 1, -9]), np.array([4, -3, 2]), -13 * _x),
-    (tuple(_x * x for x in [2, 1, -9]), [np.array(x) for x in [4, -3, 2]], -13 * _x),
-    (tuple(_x * x for x in [2, 1, -9]), tuple(np.array(x) for x in [4, -3, 2]), -13 * _x),
+    (tuple(_x * x for x in [2, 1, -9]), pnp.array([4, -3, 2]), -13 * _x),
+    (tuple(_x * x for x in [2, 1, -9]), [pnp.array(x) for x in [4, -3, 2]], -13 * _x),
+    (tuple(_x * x for x in [2, 1, -9]), tuple(pnp.array(x) for x in [4, -3, 2]), -13 * _x),
     # Multiple same-shape tensor parameters, scalar output
-    (tuple(np.array([1, 2, 3]) * x for x in [2, 1, -9]), [np.array([4, -3, 2])] * 3, np.array(-24)),
+    (tuple(pnp.array([1, 2, 3]) * x for x in [2, 1, -9]), [pnp.array([4, -3, 2])] * 3, pnp.array(-24)),
     (
-        tuple(np.array([[1, 2, 3], [-2, 1, 2]]) * x for x in [2, 1, -9]),
-        [np.array([[4, -3, 2], [0, 2, 1]])] * 3,
-        np.array(-48),
+        tuple(pnp.array([[1, 2, 3], [-2, 1, 2]]) * x for x in [2, 1, -9]),
+        [pnp.array([[4, -3, 2], [0, 2, 1]])] * 3,
+        pnp.array(-48),
     ),
-    (tuple(_x * x for x in [2, 1, -9]), [_x] * 3, -6 * np.sum(_x**2)),
+    (tuple(_x * x for x in [2, 1, -9]), [_x] * 3, -6 * pnp.sum(_x**2)),
     # Multiple mixed parameters, scalar output
     (
-        (np.array([1, 3]), np.array(2), np.array([[0, 5, 2, 1]])),
-        [np.array([2, -1]), np.array(-5), np.array([[1, 2, 3, -2]])],
-        np.array(3),
+        (pnp.array([1, 3]), pnp.array(2), pnp.array([[0, 5, 2, 1]])),
+        [pnp.array([2, -1]), pnp.array(-5), pnp.array([[1, 2, 3, -2]])],
+        pnp.array(3),
     ),
-    ((np.array(2), np.array(2), _x), [np.array(-1), np.array(5), _x], 8 + np.sum(_x**2)),
+    ((pnp.array(2), pnp.array(2), _x), [pnp.array(-1), pnp.array(5), _x], 8 + pnp.sum(_x**2)),
     # Multiple same-shape tensor parameters, tensor output
     (
-        tuple(np.outer([-4, 5, 2], [1, 2, 3]) * x for x in [2, 1, -9]),
-        [np.array([4, -3, 2])] * 3,
-        -24 * np.array([-4, 5, 2]),
+        tuple(pnp.outer([-4, 5, 2], [1, 2, 3]) * x for x in [2, 1, -9]),
+        [pnp.array([4, -3, 2])] * 3,
+        -24 * pnp.array([-4, 5, 2]),
     ),
     (
-        tuple(np.tensordot([-4, 5, 2], [[1, 2, 3], [-2, 1, 2]], axes=0) * x for x in [2, 1, -9]),
-        [np.array([[4, -3, 2], [0, 2, 1]])] * 3,
-        -48 * np.array([-4, 5, 2]),
+        tuple(pnp.tensordot([-4, 5, 2], [[1, 2, 3], [-2, 1, 2]], axes=0) * x for x in [2, 1, -9]),
+        [pnp.array([[4, -3, 2], [0, 2, 1]])] * 3,
+        -48 * pnp.array([-4, 5, 2]),
     ),
     (
-        tuple(np.tensordot([[-4, 5, 2], [1, 3, -2]], _x, axes=0) * x for x in [2, 1, -9]),
+        tuple(pnp.tensordot([[-4, 5, 2], [1, 3, -2]], _x, axes=0) * x for x in [2, 1, -9]),
         [_x] * 3,
-        -6 * np.sum(_x**2) * np.array([[-4, 5, 2], [1, 3, -2]]),
+        -6 * pnp.sum(_x**2) * pnp.array([[-4, 5, 2], [1, 3, -2]]),
     ),
     # Multiple mixed parameters, tensor output
     (
-        tuple(np.tensordot([-4, 5, 2], v, axes=0) for v in ([1, 3], 2, [[0, 5, 2, 1]])),
-        [np.array([2, -1]), np.array(-5), np.array([[1, 2, 3, -2]])],
-        3 * np.array([-4, 5, 2]),
+        tuple(pnp.tensordot([-4, 5, 2], v, axes=0) for v in ([1, 3], 2, [[0, 5, 2, 1]])),
+        [pnp.array([2, -1]), pnp.array(-5), pnp.array([[1, 2, 3, -2]])],
+        3 * pnp.array([-4, 5, 2]),
     ),
     (
-        tuple(np.tensordot([[-4, 5, 2], [1, 3, -2]], v, axes=0) for v in [2, 2, _x]),
-        [np.array(-1), np.array(5), _x],
-        (8 + np.sum(_x**2)) * np.array([[-4, 5, 2], [1, 3, -2]]),
+        tuple(pnp.tensordot([[-4, 5, 2], [1, 3, -2]], v, axes=0) for v in [2, 2, _x]),
+        [pnp.array(-1), pnp.array(5), _x],
+        (8 + pnp.sum(_x**2)) * pnp.array([[-4, 5, 2], [1, 3, -2]]),
     ),
 ]
 
@@ -210,21 +210,21 @@ class TestComputeJVPSingle:
     def test_compute_jvp_single(self, jac, tangent, exp):
         """Unit test for compute_jvp_single."""
         jvp = qml.gradients.compute_jvp_single(tangent, jac)
-        assert isinstance(jvp, np.ndarray)
-        assert np.array_equal(jvp, exp)
+        assert isinstance(jvp, pnp.ndarray)
+        assert pnp.array_equal(jvp, exp)
 
     @pytest.mark.parametrize("jac, tangent, exp", tests_compute_jvp_multi)
     def test_compute_jvp_multi(self, jac, tangent, exp):
         """Unit test for compute_jvp_multi."""
         jvp = qml.gradients.compute_jvp_multi(tangent, jac)
         assert isinstance(jvp, tuple)
-        assert all(isinstance(_jvp, np.ndarray) for _jvp in jvp)
-        assert all(np.array_equal(_jvp, _exp) for _jvp, _exp in zip(jvp, exp))
+        assert all(isinstance(_jvp, pnp.ndarray) for _jvp in jvp)
+        assert all(pnp.array_equal(_jvp, _exp) for _jvp, _exp in zip(jvp, exp))
 
     def test_jacobian_is_none_single(self):
         """A None Jacobian returns a None JVP"""
 
-        tangent = np.array([[1.0, 2.0], [3.0, 4.0]])
+        tangent = pnp.array([[1.0, 2.0], [3.0, 4.0]])
         jac = None
 
         jvp = qml.gradients.compute_jvp_single(tangent, jac)
@@ -233,7 +233,7 @@ class TestComputeJVPSingle:
     def test_jacobian_is_none_multi(self):
         """A None Jacobian returns a None JVP"""
 
-        tangent = np.array([[1.0, 2.0], [3.0, 4.0]])
+        tangent = pnp.array([[1.0, 2.0], [3.0, 4.0]])
         jac = None
 
         jvp = qml.gradients.compute_jvp_multi(tangent, jac)
@@ -247,36 +247,36 @@ class TestComputeJVPSingle:
 
     def test_zero_tangent_single_measurement_single_params(self):
         """A zero dy vector will return a zero matrix"""
-        tangent = np.zeros([1])
-        jac = np.array(0.1)
+        tangent = pnp.zeros([1])
+        jac = pnp.array(0.1)
 
         jvp = qml.gradients.compute_jvp_single(tangent, jac)
-        assert np.all(jvp == np.zeros([1]))
+        assert pnp.all(jvp == pnp.zeros([1]))
 
     def test_zero_tangent_single_measurement_multi_params(self):
         """A zero tangent vector will return a zero matrix"""
-        tangent = np.zeros([2])
-        jac = tuple([np.array(0.1), np.array(0.2)])
+        tangent = pnp.zeros([2])
+        jac = tuple([pnp.array(0.1), pnp.array(0.2)])
 
         jvp = qml.gradients.compute_jvp_single(tangent, jac)
 
-        assert np.all(jvp == np.zeros([2]))
+        assert pnp.all(jvp == pnp.zeros([2]))
 
     def test_zero_dy_multi(self):
         """A zero tangent vector will return a zero matrix"""
-        tangent = np.array([0.0, 0.0, 0.0])
+        tangent = pnp.array([0.0, 0.0, 0.0])
         jac = tuple(
             [
-                tuple([np.array(0.1), np.array(0.1), np.array(0.1)]),
-                tuple([np.array([0.1, 0.2]), np.array([0.1, 0.2]), np.array([0.1, 0.2])]),
+                tuple([pnp.array(0.1), pnp.array(0.1), pnp.array(0.1)]),
+                tuple([pnp.array([0.1, 0.2]), pnp.array([0.1, 0.2]), pnp.array([0.1, 0.2])]),
             ]
         )
 
         jvp = qml.gradients.compute_jvp_multi(tangent, jac)
 
         assert isinstance(jvp, tuple)
-        assert np.all(jvp[0] == np.zeros([1]))
-        assert np.all(jvp[1] == np.zeros([2]))
+        assert pnp.all(jvp[0] == pnp.zeros([1]))
+        assert pnp.all(jvp[1] == pnp.zeros([2]))
 
     @pytest.mark.jax
     @pytest.mark.parametrize("dtype1,dtype2", [("float32", "float64"), ("float64", "float32")])
@@ -296,15 +296,15 @@ class TestComputeJVPSingle:
 
     def test_no_trainable_params_adjoint_single(self):
         """An empty jacobian return empty array."""
-        tangent = np.array([1.0, 2.0])
+        tangent = pnp.array([1.0, 2.0])
         jac = tuple()
 
         jvp = qml.gradients.compute_jvp_single(tangent, jac)
-        assert np.allclose(jvp, qml.math.zeros(0))
+        assert pnp.allclose(jvp, qml.math.zeros(0))
 
     def test_no_trainable_params_adjoint_multi_measurement(self):
         """An empty jacobian return an empty tuple."""
-        tangent = np.array([1.0, 2.0])
+        tangent = pnp.array([1.0, 2.0])
         jac = tuple()
 
         jvp = qml.gradients.compute_jvp_multi(tangent, jac)
@@ -313,22 +313,22 @@ class TestComputeJVPSingle:
 
     def test_no_trainable_params_gradient_transform_single(self):
         """An empty jacobian return empty array."""
-        tangent = np.array([1.0, 2.0])
+        tangent = pnp.array([1.0, 2.0])
         jac = qml.math.zeros(0)
 
         jvp = qml.gradients.compute_jvp_single(tangent, jac)
-        assert np.allclose(jvp, qml.math.zeros(0))
+        assert pnp.allclose(jvp, qml.math.zeros(0))
 
     def test_no_trainable_params_gradient_transform_multi_measurement(self):
         """An empty jacobian return an empty tuple."""
-        tangent = np.array([1.0, 2.0])
+        tangent = pnp.array([1.0, 2.0])
         jac = tuple([qml.math.zeros(0), qml.math.zeros(0)])
 
         jvp = qml.gradients.compute_jvp_multi(tangent, jac)
         assert isinstance(jvp, tuple)
         assert len(jvp) == 2
         for j in jvp:
-            assert np.allclose(j, qml.math.zeros(0))
+            assert pnp.allclose(j, qml.math.zeros(0))
 
 
 @pytest.mark.parametrize("batch_dim", [None, 1, 3])
@@ -337,7 +337,7 @@ class TestJVP:
 
     def test_no_trainable_parameters(self, batch_dim):
         """A tape with no trainable parameters will simply return None"""
-        x = 0.4 if batch_dim is None else 0.4 * np.arange(1, 1 + batch_dim)
+        x = 0.4 if batch_dim is None else 0.4 * pnp.arange(1, 1 + batch_dim)
 
         with qml.queuing.AnnotatedQueue() as q:
             qml.RX(x, wires=0)
@@ -346,16 +346,16 @@ class TestJVP:
 
         tape = qml.tape.QuantumScript.from_queue(q)
         tape.trainable_params = {}
-        tangent = np.array([1.0])
+        tangent = pnp.array([1.0])
         tapes, fn = qml.gradients.jvp(tape, tangent, param_shift)
 
         assert tapes == tuple()
-        assert qml.math.allclose(fn(tapes), np.array(0.0))
+        assert qml.math.allclose(fn(tapes), pnp.array(0.0))
 
     def test_zero_tangent_single_measurement_single_param(self, batch_dim):
         """A zero tangent vector will return no tapes and a zero matrix"""
 
-        x = 0.4 if batch_dim is None else 0.4 * np.arange(1, 1 + batch_dim)
+        x = 0.4 if batch_dim is None else 0.4 * pnp.arange(1, 1 + batch_dim)
         with qml.queuing.AnnotatedQueue() as q:
             qml.RX(x, wires=0)
             qml.CNOT(wires=[0, 1])
@@ -363,16 +363,16 @@ class TestJVP:
 
         tape = qml.tape.QuantumScript.from_queue(q)
         tape.trainable_params = {0}
-        tangent = np.array([0.0])
+        tangent = pnp.array([0.0])
         tapes, fn = qml.gradients.jvp(tape, tangent, param_shift)
 
         assert tapes == []
-        assert np.all(fn(tapes) == np.zeros([1]))
+        assert pnp.all(fn(tapes) == pnp.zeros([1]))
 
     def test_zero_tangent_single_measurement_multiple_param(self, batch_dim):
         """A zero tangent vector will return no tapes and a zero matrix"""
 
-        x = 0.4 if batch_dim is None else 0.4 * np.arange(1, 1 + batch_dim)
+        x = 0.4 if batch_dim is None else 0.4 * pnp.arange(1, 1 + batch_dim)
         with qml.queuing.AnnotatedQueue() as q:
             qml.RX(x, wires=0)
             qml.RX(0.6, wires=0)
@@ -381,16 +381,16 @@ class TestJVP:
 
         tape = qml.tape.QuantumScript.from_queue(q)
         tape.trainable_params = {0, 1}
-        tangent = np.array([0.0, 0.0])
+        tangent = pnp.array([0.0, 0.0])
         tapes, fn = qml.gradients.jvp(tape, tangent, param_shift)
 
         assert tapes == []
-        assert np.all(fn(tapes) == np.zeros([1]))
+        assert pnp.all(fn(tapes) == pnp.zeros([1]))
 
     def test_zero_tangent_single_measurement_probs_multiple_param(self, batch_dim):
         """A zero tangent vector will return no tapes and a zero matrix"""
 
-        x = 0.6 if batch_dim is None else 0.6 * np.arange(1, 1 + batch_dim)
+        x = 0.6 if batch_dim is None else 0.6 * pnp.arange(1, 1 + batch_dim)
         with qml.queuing.AnnotatedQueue() as q:
             qml.RX(0.4, wires=0)
             qml.RX(x, wires=0)
@@ -399,16 +399,16 @@ class TestJVP:
 
         tape = qml.tape.QuantumScript.from_queue(q)
         tape.trainable_params = {0, 1}
-        tangent = np.array([0.0, 0.0])
+        tangent = pnp.array([0.0, 0.0])
         tapes, fn = qml.gradients.jvp(tape, tangent, param_shift)
 
         assert tapes == []
-        assert np.all(fn(tapes) == np.zeros([4]))
+        assert pnp.all(fn(tapes) == pnp.zeros([4]))
 
     def test_zero_tangent_multiple_measurement_single_param(self, batch_dim):
         """A zero tangent vector will return no tapes and a zero matrix"""
 
-        x = 0.4 if batch_dim is None else 0.4 * np.arange(1, 1 + batch_dim)
+        x = 0.4 if batch_dim is None else 0.4 * pnp.arange(1, 1 + batch_dim)
         with qml.queuing.AnnotatedQueue() as q:
             qml.RX(x, wires=0)
             qml.CNOT(wires=[0, 1])
@@ -417,7 +417,7 @@ class TestJVP:
 
         tape = qml.tape.QuantumScript.from_queue(q)
         tape.trainable_params = {0}
-        tangent = np.array([0.0])
+        tangent = pnp.array([0.0])
         tapes, fn = qml.gradients.jvp(tape, tangent, param_shift)
         res = fn(tapes)
 
@@ -426,16 +426,16 @@ class TestJVP:
         assert isinstance(res, tuple)
         assert len(res) == 2
 
-        assert isinstance(res[0], np.ndarray)
-        assert np.allclose(res[0], 0)
+        assert isinstance(res[0], pnp.ndarray)
+        assert pnp.allclose(res[0], 0)
 
-        assert isinstance(res[1], np.ndarray)
-        assert np.allclose(res[1], [0, 0])
+        assert isinstance(res[1], pnp.ndarray)
+        assert pnp.allclose(res[1], [0, 0])
 
     def test_zero_tangent_multiple_measurement_multiple_param(self, batch_dim):
         """A zero tangent vector will return no tapes and a zero matrix"""
 
-        x = 0.4 if batch_dim is None else 0.4 * np.arange(1, 1 + batch_dim)
+        x = 0.4 if batch_dim is None else 0.4 * pnp.arange(1, 1 + batch_dim)
         with qml.queuing.AnnotatedQueue() as q:
             qml.RX(x, wires=0)
             qml.RX(0.6, wires=0)
@@ -445,7 +445,7 @@ class TestJVP:
 
         tape = qml.tape.QuantumScript.from_queue(q)
         tape.trainable_params = {0, 1}
-        tangent = np.array([0.0, 0.0])
+        tangent = pnp.array([0.0, 0.0])
         tapes, fn = qml.gradients.jvp(tape, tangent, param_shift)
         res = fn(tapes)
 
@@ -454,11 +454,11 @@ class TestJVP:
         assert isinstance(res, tuple)
         assert len(res) == 2
 
-        assert isinstance(res[0], np.ndarray)
-        assert np.allclose(res[0], 0)
+        assert isinstance(res[0], pnp.ndarray)
+        assert pnp.allclose(res[0], 0)
 
-        assert isinstance(res[1], np.ndarray)
-        assert np.allclose(res[1], [0, 0])
+        assert isinstance(res[1], pnp.ndarray)
+        assert pnp.allclose(res[1], [0, 0])
 
     # Unskip batch_dim!=None cases once #4462 is resolved
     def test_single_expectation_value(self, tol, batch_dim):
@@ -467,7 +467,7 @@ class TestJVP:
         if batch_dim is not None:
             pytest.skip(reason="JVP computation of batched tapes is disallowed, see #4462")
         dev = qml.device("default.qubit", wires=2)
-        x = 0.543 if batch_dim is None else 0.543 * np.arange(1, 1 + batch_dim)
+        x = 0.543 if batch_dim is None else 0.543 * pnp.arange(1, 1 + batch_dim)
         y = -0.654
 
         with qml.queuing.AnnotatedQueue() as q:
@@ -478,7 +478,7 @@ class TestJVP:
 
         tape = qml.tape.QuantumScript.from_queue(q)
         tape.trainable_params = {0, 1}
-        tangent = np.array([1.0, 1.0])
+        tangent = pnp.array([1.0, 1.0])
 
         tapes, fn = qml.gradients.jvp(tape, tangent, param_shift)
         assert len(tapes) == 4
@@ -486,8 +486,8 @@ class TestJVP:
         res = fn(dev.execute(tapes))
         assert res.shape == () if batch_dim is None else (batch_dim,)
 
-        exp = np.sum(np.array([-np.sin(y) * np.sin(x), np.cos(y) * np.cos(x)]), axis=0)
-        assert np.allclose(res, exp, atol=tol, rtol=0)
+        exp = pnp.sum(pnp.array([-pnp.sin(y) * pnp.sin(x), pnp.cos(y) * pnp.cos(x)]), axis=0)
+        assert pnp.allclose(res, exp, atol=tol, rtol=0)
 
     # Unskip batch_dim!=None cases once #4462 is resolved
     def test_multiple_expectation_values(self, tol, batch_dim):
@@ -496,7 +496,7 @@ class TestJVP:
         if batch_dim is not None:
             pytest.skip(reason="JVP computation of batched tapes is disallowed, see #4462")
         dev = qml.device("default.qubit", wires=2)
-        x = 0.543 if batch_dim is None else 0.543 * np.arange(1, 1 + batch_dim)
+        x = 0.543 if batch_dim is None else 0.543 * pnp.arange(1, 1 + batch_dim)
         y = -0.654
 
         with qml.queuing.AnnotatedQueue() as q:
@@ -508,7 +508,7 @@ class TestJVP:
 
         tape = qml.tape.QuantumScript.from_queue(q)
         tape.trainable_params = {0, 1}
-        tangent = np.array([1.0, 2.0])
+        tangent = pnp.array([1.0, 2.0])
 
         tapes, fn = qml.gradients.jvp(tape, tangent, param_shift)
         assert len(tapes) == 4
@@ -518,10 +518,10 @@ class TestJVP:
         assert len(res) == 2
         assert all(r.shape == () if batch_dim is None else (batch_dim,) for r in res)
 
-        exp = [-np.sin(x), 2 * np.cos(y)]
+        exp = [-pnp.sin(x), 2 * pnp.cos(y)]
         if batch_dim is not None:
-            exp[1] = np.tensordot(np.ones(batch_dim), exp[1], axes=0)
-        assert np.allclose(res, exp, atol=tol, rtol=0)
+            exp[1] = pnp.tensordot(pnp.ones(batch_dim), exp[1], axes=0)
+        assert pnp.allclose(res, exp, atol=tol, rtol=0)
 
     # Unskip batch_dim!=None cases once #4462 is resolved
     def test_prob_expval_single_param(self, tol, batch_dim):
@@ -530,7 +530,7 @@ class TestJVP:
         if batch_dim is not None:
             pytest.skip(reason="JVP computation of batched tapes is disallowed, see #4462")
         dev = qml.device("default.qubit", wires=2)
-        x = 0.543 if batch_dim is None else 0.543 * np.arange(1, 1 + batch_dim)
+        x = 0.543 if batch_dim is None else 0.543 * pnp.arange(1, 1 + batch_dim)
 
         with qml.queuing.AnnotatedQueue() as q:
             qml.RX(x, wires=[0])
@@ -540,7 +540,7 @@ class TestJVP:
 
         tape = qml.tape.QuantumScript.from_queue(q)
         tape.trainable_params = {0}
-        tangent = np.array([1.0])
+        tangent = pnp.array([1.0])
 
         tapes, fn = qml.gradients.jvp(tape, tangent, param_shift)
         assert len(tapes) == 2
@@ -551,12 +551,12 @@ class TestJVP:
         assert res[0].shape == () if batch_dim is None else (batch_dim,)
         assert res[1].shape == (2,) if batch_dim is None else (batch_dim, 2)
 
-        expected_0 = -np.sin(x)
-        assert np.allclose(res[0], expected_0, atol=tol, rtol=0)
+        expected_0 = -pnp.sin(x)
+        assert pnp.allclose(res[0], expected_0, atol=tol, rtol=0)
 
         # Transpose for batch-dimension to be first if present
-        expected_1 = np.array([-np.sin(x) / 2, np.sin(x) / 2]).T
-        assert np.allclose(res[1], expected_1, atol=tol, rtol=0)
+        expected_1 = pnp.array([-pnp.sin(x) / 2, pnp.sin(x) / 2]).T
+        assert pnp.allclose(res[1], expected_1, atol=tol, rtol=0)
 
     # Unskip batch_dim!=None cases once #4462 is resolved
     def test_prob_expval_multi_param(self, tol, batch_dim):
@@ -565,7 +565,7 @@ class TestJVP:
         if batch_dim is not None:
             pytest.skip(reason="JVP computation of batched tapes is disallowed, see #4462")
         dev = qml.device("default.qubit", wires=2)
-        x = 0.543 if batch_dim is None else 0.543 * np.arange(1, 1 + batch_dim)
+        x = 0.543 if batch_dim is None else 0.543 * pnp.arange(1, 1 + batch_dim)
         y = -0.654
 
         with qml.queuing.AnnotatedQueue() as q:
@@ -577,7 +577,7 @@ class TestJVP:
 
         tape = qml.tape.QuantumScript.from_queue(q)
         tape.trainable_params = {0, 1}
-        tangent = np.array([1.0, 1.0])
+        tangent = pnp.array([1.0, 1.0])
 
         tapes, fn = qml.gradients.jvp(tape, tangent, param_shift)
         assert len(tapes) == 4
@@ -587,34 +587,34 @@ class TestJVP:
         assert len(res) == 2
 
         exp = [
-            -1 * np.sin(x),
-            np.array(
+            -1 * pnp.sin(x),
+            pnp.array(
                 [
-                    -(np.cos(y / 2) ** 2 * np.sin(x)) - (np.cos(x / 2) ** 2 * np.sin(y)),
-                    -(np.sin(x) * np.sin(y / 2) ** 2) + (np.cos(x / 2) ** 2 * np.sin(y)),
-                    (np.sin(x) * np.sin(y / 2) ** 2) + (np.sin(x / 2) ** 2 * np.sin(y)),
-                    (np.cos(y / 2) ** 2 * np.sin(x)) - (np.sin(x / 2) ** 2 * np.sin(y)),
+                    -(pnp.cos(y / 2) ** 2 * pnp.sin(x)) - (pnp.cos(x / 2) ** 2 * pnp.sin(y)),
+                    -(pnp.sin(x) * pnp.sin(y / 2) ** 2) + (pnp.cos(x / 2) ** 2 * pnp.sin(y)),
+                    (pnp.sin(x) * pnp.sin(y / 2) ** 2) + (pnp.sin(x / 2) ** 2 * pnp.sin(y)),
+                    (pnp.cos(y / 2) ** 2 * pnp.sin(x)) - (pnp.sin(x / 2) ** 2 * pnp.sin(y)),
                 ]
             ).T
             / 2,
         ]
 
-        assert np.allclose(res[0], exp[0], atol=tol, rtol=0)
-        assert np.allclose(res[1], exp[1], atol=tol, rtol=0)
+        assert pnp.allclose(res[0], exp[0], atol=tol, rtol=0)
+        assert pnp.allclose(res[1], exp[1], atol=tol, rtol=0)
 
-    @pytest.mark.parametrize("dtype", [np.float32, np.float64])
+    @pytest.mark.parametrize("dtype", [pnp.float32, pnp.float64])
     def test_dtype_matches_tangent(self, dtype, batch_dim):
         """Tests that the jvp function matches the dtype of tangent when tangent is
         zero-like."""
-        x = np.array([0.1], dtype=np.float64)
-        x = x if batch_dim is None else np.outer(x, np.arange(1, 1 + batch_dim))
+        x = pnp.array([0.1], dtype=pnp.float64)
+        x = x if batch_dim is None else pnp.outer(x, pnp.arange(1, 1 + batch_dim))
 
         with qml.queuing.AnnotatedQueue() as q:
             qml.RX(x[0], wires=0)
             qml.expval(qml.PauliZ(0))
 
         tape = qml.tape.QuantumScript.from_queue(q)
-        dy = np.zeros(1, dtype=dtype)
+        dy = pnp.zeros(1, dtype=dtype)
         _, func = qml.gradients.jvp(tape, dy, qml.gradients.param_shift)
 
         assert func([]).dtype == dtype
@@ -623,10 +623,10 @@ class TestJVP:
 def expected_probs(params):
     """Expected result of the below circuit ansatz."""
     x, y = params[..., 0], params[..., 1]
-    c_x, s_x = np.cos(x / 2), np.sin(x / 2)
-    c_y, s_y = np.cos(y / 2), np.sin(y / 2)
+    c_x, s_x = pnp.cos(x / 2), pnp.sin(x / 2)
+    c_y, s_y = pnp.cos(y / 2), pnp.sin(y / 2)
     # Transpose to put potential broadcasting axis first
-    return np.array([c_x * c_y, c_x * s_y, s_x * s_y, s_x * c_y]).T ** 2
+    return pnp.array([c_x * c_y, c_x * s_y, s_x * s_y, s_x * c_y]).T ** 2
 
 
 def expected_jvp(params, tangent):
@@ -635,9 +635,9 @@ def expected_jvp(params, tangent):
     if qml.math.ndim(params) > 1:
         # If there is broadcasting, take the diagonal over
         # the two axes corresponding to broadcasting
-        j = np.stack([j[i, :, i, :] for i in range(len(j))])
+        j = pnp.stack([j[i, :, i, :] for i in range(len(j))])
 
-    return np.tensordot(j, tangent, axes=1)
+    return pnp.tensordot(j, tangent, axes=1)
 
 
 def ansatz(x, y):
@@ -658,10 +658,10 @@ class TestJVPGradients:
         """Tests that the output of the JVP transform
         can be differentiated using autograd."""
         dev = qml.device("default.qubit", wires=2)
-        params = np.array([0.543, -0.654], requires_grad=True)
+        params = pnp.array([0.543, -0.654], requires_grad=True)
         if batch_dim is not None:
-            params = np.outer(np.arange(1, 1 + batch_dim), params, requires_grad=True)
-        tangent = np.array([1.0, 0.3], requires_grad=False)
+            params = pnp.outer(pnp.arange(1, 1 + batch_dim), params, requires_grad=True)
+        tangent = pnp.array([1.0, 0.3], requires_grad=False)
 
         def cost_fn(params, tangent):
             with qml.queuing.AnnotatedQueue() as q:
@@ -674,11 +674,11 @@ class TestJVPGradients:
 
         res = cost_fn(params, tangent)
         exp = expected_jvp(params, tangent)
-        assert np.allclose(res, exp, atol=tol, rtol=0)
+        assert pnp.allclose(res, exp, atol=tol, rtol=0)
 
         res = qml.jacobian(cost_fn)(params, tangent)
         exp = qml.jacobian(expected_jvp)(params, tangent)
-        assert np.allclose(res, exp, atol=tol, rtol=0)
+        assert pnp.allclose(res, exp, atol=tol, rtol=0)
 
     # Include batch_dim!=None cases once #4462 is resolved
     @pytest.mark.torch
@@ -690,10 +690,10 @@ class TestJVPGradients:
 
         dev = qml.device("default.qubit", wires=2)
 
-        params_np = np.array([0.543, -0.654], requires_grad=True)
+        params_np = pnp.array([0.543, -0.654], requires_grad=True)
         if batch_dim is not None:
-            params_np = np.outer(np.arange(1, 1 + batch_dim), params_np, requires_grad=True)
-        tangent_np = np.array([1.2, -0.3], requires_grad=False)
+            params_np = pnp.outer(pnp.arange(1, 1 + batch_dim), params_np, requires_grad=True)
+        tangent_np = pnp.array([1.2, -0.3], requires_grad=False)
         params = torch.tensor(params_np, requires_grad=True, dtype=torch.float64)
         tangent = torch.tensor(tangent_np, requires_grad=False, dtype=torch.float64)
 
@@ -708,11 +708,11 @@ class TestJVPGradients:
 
         res = cost_fn(params, tangent)
         exp = expected_jvp(params_np, tangent_np)
-        assert np.allclose(res.detach(), exp, atol=tol, rtol=0)
+        assert pnp.allclose(res.detach(), exp, atol=tol, rtol=0)
 
         res = torch.autograd.functional.jacobian(cost_fn, (params, tangent))[0]
         exp = qml.jacobian(expected_jvp)(params_np, tangent_np)
-        assert np.allclose(res, exp, atol=tol, rtol=0)
+        assert pnp.allclose(res, exp, atol=tol, rtol=0)
 
     # Include batch_dim!=None cases once #4462 is resolved
     @pytest.mark.tf
@@ -724,10 +724,10 @@ class TestJVPGradients:
         import tensorflow as tf
 
         dev = qml.device("default.qubit", wires=2)
-        params_np = np.array([0.543, -0.654], requires_grad=True)
+        params_np = pnp.array([0.543, -0.654], requires_grad=True)
         if batch_dim is not None:
-            params_np = np.outer(np.arange(1, 1 + batch_dim), params_np, requires_grad=True)
-        tangent_np = np.array([1.2, -0.3], requires_grad=False)
+            params_np = pnp.outer(pnp.arange(1, 1 + batch_dim), params_np, requires_grad=True)
+        tangent_np = pnp.array([1.2, -0.3], requires_grad=False)
         params = tf.Variable(params_np, dtype=tf.float64)
         tangent = tf.constant(tangent_np, dtype=tf.float64)
 
@@ -744,11 +744,11 @@ class TestJVPGradients:
             res = cost_fn(params, tangent)
 
         exp = expected_jvp(params_np, tangent_np)
-        assert np.allclose(res, exp, atol=tol, rtol=0)
+        assert pnp.allclose(res, exp, atol=tol, rtol=0)
 
         res = t.jacobian(res, params)
         exp = qml.jacobian(expected_jvp)(params_np, tangent_np)
-        assert np.allclose(res, exp, atol=tol, rtol=0)
+        assert pnp.allclose(res, exp, atol=tol, rtol=0)
 
     # Include batch_dim!=None cases once #4462 is resolved
     @pytest.mark.jax
@@ -760,10 +760,10 @@ class TestJVPGradients:
         from jax import numpy as jnp
 
         dev = qml.device("default.qubit")
-        params_np = np.array([0.543, -0.654], requires_grad=True)
+        params_np = pnp.array([0.543, -0.654], requires_grad=True)
         if batch_dim is not None:
-            params_np = np.outer(np.arange(1, 1 + batch_dim), params_np, requires_grad=True)
-        tangent_np = np.array([1.2, -0.3], requires_grad=False)
+            params_np = pnp.outer(pnp.arange(1, 1 + batch_dim), params_np, requires_grad=True)
+        tangent_np = pnp.array([1.2, -0.3], requires_grad=False)
         params = jnp.array(params_np)
         tangent = jnp.array(tangent_np)
 
@@ -778,11 +778,11 @@ class TestJVPGradients:
 
         res = cost_fn(params, tangent)
         exp = expected_jvp(params_np, tangent_np)
-        assert np.allclose(res, exp, atol=tol, rtol=0)
+        assert pnp.allclose(res, exp, atol=tol, rtol=0)
 
         res = jax.jacobian(cost_fn)(params, tangent)
         exp = qml.jacobian(expected_jvp)(params_np, tangent_np)
-        assert np.allclose(res, exp, atol=tol, rtol=0)
+        assert pnp.allclose(res, exp, atol=tol, rtol=0)
 
 
 class TestBatchJVP:
@@ -810,7 +810,7 @@ class TestBatchJVP:
         tape2.trainable_params = {0, 1}
 
         tapes = [tape1, tape2]
-        tangents = [np.array([1.0, 1.0]), np.array([1.0, 1.0])]
+        tangents = [pnp.array([1.0, 1.0]), pnp.array([1.0, 1.0])]
 
         v_tapes, fn = qml.gradients.batch_jvp(tapes, tangents, param_shift)
 
@@ -819,7 +819,7 @@ class TestBatchJVP:
         assert len(v_tapes) == 4
         res = fn(dev.execute(v_tapes))
 
-        assert qml.math.allclose(res[0], np.array(0.0))
+        assert qml.math.allclose(res[0], pnp.array(0.0))
         assert res[1] is not None
 
     @pytest.mark.parametrize("shots", [Shots(None), Shots(10), Shots([20, 10])])
@@ -843,13 +843,13 @@ class TestBatchJVP:
         tape2.trainable_params = set()
 
         tapes = [tape1, tape2]
-        tangents = [np.array([1.0, 0.0]), np.array([1.0, 0.0])]
+        tangents = [pnp.array([1.0, 0.0]), pnp.array([1.0, 0.0])]
 
         v_tapes, fn = qml.gradients.batch_jvp(tapes, tangents, param_shift)
 
         assert v_tapes == []
-        assert qml.math.allclose(fn([])[0], np.array(0.0))
-        assert qml.math.allclose(fn([])[1], np.array(0.0))
+        assert qml.math.allclose(fn([])[0], pnp.array(0.0))
+        assert qml.math.allclose(fn([])[1], pnp.array(0.0))
 
     def test_zero_tangent(self):
         """A zero dy vector will return no tapes and a zero matrix"""
@@ -872,7 +872,7 @@ class TestBatchJVP:
         tape2.trainable_params = {0, 1}
 
         tapes = [tape1, tape2]
-        tangents = [np.array([0.0]), np.array([1.0, 1.0])]
+        tangents = [pnp.array([0.0]), pnp.array([1.0, 1.0])]
 
         v_tapes, fn = qml.gradients.batch_jvp(tapes, tangents, param_shift)
         res = fn(dev.execute(v_tapes))
@@ -881,7 +881,7 @@ class TestBatchJVP:
         # to the JVP, so only 2*2=4 quantum evals
 
         assert len(v_tapes) == 4
-        assert np.allclose(res[0], 0)
+        assert pnp.allclose(res[0], 0)
 
     def test_reduction_append(self):
         """Test the 'append' reduction strategy"""
@@ -904,7 +904,7 @@ class TestBatchJVP:
         tape2.trainable_params = {0, 1}
 
         tapes = [tape1, tape2]
-        tangents = [np.array([1.0]), np.array([1.0, 1.0])]
+        tangents = [pnp.array([1.0]), pnp.array([1.0, 1.0])]
 
         v_tapes, fn = qml.gradients.batch_jvp(tapes, tangents, param_shift, reduction="append")
         res = fn(dev.execute(v_tapes))
@@ -912,7 +912,7 @@ class TestBatchJVP:
         # Returned JVPs will be appended to a list, one JVP per tape
 
         assert len(res) == 2
-        assert all(isinstance(r, np.ndarray) for r in res)
+        assert all(isinstance(r, pnp.ndarray) for r in res)
         assert res[0].shape == ()
         assert res[1].shape == ()
 
@@ -937,7 +937,7 @@ class TestBatchJVP:
         tape2.trainable_params = {1}
 
         tapes = [tape1, tape2]
-        tangents = [np.array([1.0]), np.array([1.0])]
+        tangents = [pnp.array([1.0]), pnp.array([1.0])]
 
         v_tapes, fn = qml.gradients.batch_jvp(tapes, tangents, param_shift, reduction="extend")
         res = fn(dev.execute(v_tapes))
@@ -965,7 +965,7 @@ class TestBatchJVP:
         tape2.trainable_params = {0, 1}
 
         tapes = [tape1, tape2]
-        tangents = [np.array([1.0]), np.array([1.0, 1.0])]
+        tangents = [pnp.array([1.0]), pnp.array([1.0, 1.0])]
 
         v_tapes, fn = qml.gradients.batch_jvp(
             tapes,
@@ -1003,7 +1003,7 @@ class TestBatchJVP:
         tape2.trainable_params = {0, 1}
 
         tapes = [tape1, tape2]
-        tangents = [np.array([1.0]), np.array([1.0, 1.0])]
+        tangents = [pnp.array([1.0]), pnp.array([1.0, 1.0])]
 
         v_tapes, fn = qml.gradients.batch_jvp(
             tapes, tangents, param_shift, reduction=lambda jvps, x: jvps.append(x)

--- a/tests/gradients/core/test_metric_tensor.py
+++ b/tests/gradients/core/test_metric_tensor.py
@@ -22,7 +22,7 @@ import pytest
 from scipy.linalg import block_diag
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane.gradients.metric_tensor import _get_aux_wire
 
 
@@ -36,7 +36,7 @@ class TestMetricTensor:
 
     def test_rot_decomposition(self):
         """Test that the rotation gate is correctly decomposed"""
-        params = np.array([1.0, 2.0, 3.0], requires_grad=True)
+        params = pnp.array([1.0, 2.0, 3.0], requires_grad=True)
 
         with qml.queuing.AnnotatedQueue() as q_circuit:
             qml.Rot(params[0], params[1], params[2], wires=0)
@@ -74,7 +74,7 @@ class TestMetricTensor:
             qml.MultiRZ(b, wires=[0, 1, 2])
             return qml.expval(qml.PauliX(0))
 
-        params = np.array([0.1, 0.2], requires_grad=True)
+        params = pnp.array([0.1, 0.2], requires_grad=True)
         result = qml.metric_tensor(circuit, approx="block-diag")(*params)
         assert isinstance(result, tuple) and len(result) == 2
         assert qml.math.shape(result[0]) == ()
@@ -83,10 +83,10 @@ class TestMetricTensor:
     def test_construct_subcircuit(self):
         """Test correct subcircuits constructed"""
         with qml.queuing.AnnotatedQueue() as q:
-            qml.RX(np.array(1.0, requires_grad=True), wires=0)
-            qml.RY(np.array(1.0, requires_grad=True), wires=0)
+            qml.RX(pnp.array(1.0, requires_grad=True), wires=0)
+            qml.RY(pnp.array(1.0, requires_grad=True), wires=0)
             qml.CNOT(wires=[0, 1])
-            qml.PhaseShift(np.array(1.0, requires_grad=True), wires=1)
+            qml.PhaseShift(pnp.array(1.0, requires_grad=True), wires=1)
             qml.expval(qml.PauliX(0))
             qml.expval(qml.PauliX(1))
 
@@ -114,7 +114,7 @@ class TestMetricTensor:
     def test_construct_subcircuit_layers(self):
         """Test correct subcircuits constructed
         when a layer structure exists"""
-        params = np.ones([8])
+        params = pnp.ones([8])
 
         with qml.queuing.AnnotatedQueue() as q:
             # section 1
@@ -197,7 +197,7 @@ class TestMetricTensor:
 
         circuit = qml.QNode(circuit, dev)
 
-        abc = np.array([0.432, 0.12, -0.432], requires_grad=True)
+        abc = pnp.array([0.432, 0.12, -0.432], requires_grad=True)
         a, b, _ = abc
 
         # evaluate metric tensor
@@ -206,13 +206,13 @@ class TestMetricTensor:
 
         # check that the metric tensor is correct
         expected = (
-            np.array(
-                [1, np.cos(a) ** 2, (3 - 2 * np.cos(a) ** 2 * np.cos(2 * b) - np.cos(2 * a)) / 4]
+            pnp.array(
+                [1, pnp.cos(a) ** 2, (3 - 2 * pnp.cos(a) ** 2 * pnp.cos(2 * b) - pnp.cos(2 * a)) / 4]
             )
             / 4
         )
-        assert qml.math.allclose(g_diag, np.diag(expected), atol=tol, rtol=0)
-        assert qml.math.allclose(g_blockdiag, np.diag(expected), atol=tol, rtol=0)
+        assert qml.math.allclose(g_diag, pnp.diag(expected), atol=tol, rtol=0)
+        assert qml.math.allclose(g_blockdiag, pnp.diag(expected), atol=tol, rtol=0)
 
     def test_template_integration(self):
         """Test that the metric tensor transform acts on QNodes
@@ -224,7 +224,7 @@ class TestMetricTensor:
             qml.templates.StronglyEntanglingLayers(weights, wires=[0, 1, 2])
             return qml.probs(wires=[0, 1])
 
-        weights = np.ones([2, 3, 3], dtype=np.float64, requires_grad=True)
+        weights = pnp.ones([2, 3, 3], dtype=pnp.float64, requires_grad=True)
         res = qml.metric_tensor(circuit, approx="block-diag")(weights)
         assert res.shape == (2, 3, 3, 2, 3, 3)
 
@@ -246,8 +246,8 @@ class TestMetricTensor:
 
         circuit = qml.QNode(circuit, dev)
 
-        a = np.array([0.432, 0.1], requires_grad=True)
-        b = np.array(0.12, requires_grad=True)
+        a = pnp.array([0.432, 0.1], requires_grad=True)
+        b = pnp.array(0.12, requires_grad=True)
 
         # evaluate metric tensor
         g = qml.metric_tensor(circuit, approx="block-diag")(a, b)
@@ -257,10 +257,10 @@ class TestMetricTensor:
         assert g[1].shape == tuple()
 
         # check that the metric tensor is correct
-        expected = np.array([np.cos(a[1]) ** 2, 1]) / 4
-        assert qml.math.allclose(g[0], np.diag(expected), atol=tol, rtol=0)
+        expected = pnp.array([pnp.cos(a[1]) ** 2, 1]) / 4
+        assert qml.math.allclose(g[0], pnp.diag(expected), atol=tol, rtol=0)
 
-        expected = (3 - 2 * np.cos(a[1]) ** 2 * np.cos(2 * a[0]) - np.cos(2 * a[1])) / 16
+        expected = (3 - 2 * pnp.cos(a[1]) ** 2 * pnp.cos(2 * a[0]) - pnp.cos(2 * a[1])) / 16
         assert qml.math.allclose(g[1], expected, atol=tol, rtol=0)
 
     @pytest.fixture(params=["parameter-shift", "backprop"])
@@ -307,7 +307,7 @@ class TestMetricTensor:
         computation."""
         dev, circuit, non_parametrized_layer, a, b, c = sample_circuit
 
-        params = np.array(
+        params = pnp.array(
             [-0.282203, 0.145554, 0.331624, -0.163907, 0.57662, 0.081272],
             requires_grad=True,
         )
@@ -323,30 +323,30 @@ class TestMetricTensor:
         #   qml.RY(y, wires=1)
         #   qml.RZ(z, wires=2)
 
-        G1 = np.zeros([3, 3])
+        G1 = pnp.zeros([3, 3])
 
         # diag elements
-        G1[0, 0] = np.sin(a) ** 2 / 4
+        G1[0, 0] = pnp.sin(a) ** 2 / 4
         G1[1, 1] = (
-            16 * np.cos(a) ** 2 * np.sin(b) ** 3 * np.cos(b) * np.sin(2 * c)
-            + np.cos(2 * b) * (2 - 8 * np.cos(a) ** 2 * np.sin(b) ** 2 * np.cos(2 * c))
-            + np.cos(2 * (a - b))
-            + np.cos(2 * (a + b))
-            - 2 * np.cos(2 * a)
+            16 * pnp.cos(a) ** 2 * pnp.sin(b) ** 3 * pnp.cos(b) * pnp.sin(2 * c)
+            + pnp.cos(2 * b) * (2 - 8 * pnp.cos(a) ** 2 * pnp.sin(b) ** 2 * pnp.cos(2 * c))
+            + pnp.cos(2 * (a - b))
+            + pnp.cos(2 * (a + b))
+            - 2 * pnp.cos(2 * a)
             + 14
         ) / 64
-        G1[2, 2] = (3 - np.cos(2 * a) - 2 * np.cos(a) ** 2 * np.cos(2 * (b + c))) / 16
+        G1[2, 2] = (3 - pnp.cos(2 * a) - 2 * pnp.cos(a) ** 2 * pnp.cos(2 * (b + c))) / 16
 
         # off diag elements
-        G1[0, 1] = G1[1, 0] = np.sin(a) ** 2 * np.sin(b) * np.cos(b + c) / 4
-        G1[0, 2] = G1[2, 0] = np.sin(a) ** 2 * np.cos(b + c) / 4
+        G1[0, 1] = G1[1, 0] = pnp.sin(a) ** 2 * pnp.sin(b) * pnp.cos(b + c) / 4
+        G1[0, 2] = G1[2, 0] = pnp.sin(a) ** 2 * pnp.cos(b + c) / 4
         G1[1, 2] = G1[2, 1] = (
-            -np.sin(b)
+            -pnp.sin(b)
             * (
-                np.cos(2 * (a - b - c))
-                + np.cos(2 * (a + b + c))
-                + 2 * np.cos(2 * a)
-                + 2 * np.cos(2 * (b + c))
+                pnp.cos(2 * (a - b - c))
+                + pnp.cos(2 * (a + b + c))
+                + 2 * pnp.cos(2 * a)
+                + 2 * pnp.cos(2 * (b + c))
                 - 6
             )
             / 32
@@ -396,7 +396,7 @@ class TestMetricTensor:
 
         # calculate the diagonal terms
         varK0, varK1 = layer2_diag(params)
-        G2 = np.diag([varK0 / 4, varK1 / 4])
+        G2 = pnp.diag([varK0 / 4, varK1 / 4])
 
         # calculate the off-diagonal terms
         exK0, exK1 = layer2_off_diag_first_order(params)
@@ -444,7 +444,7 @@ class TestMetricTensor:
         """Test that a metric tensor under the diagonal approximation evaluates
         correctly."""
         dev, circuit, non_parametrized_layer, a, b, c = sample_circuit
-        params = np.array(
+        params = pnp.array(
             [-0.282203, 0.145554, 0.331624, -0.163907, 0.57662, 0.081272],
             requires_grad=True,
         )
@@ -460,19 +460,19 @@ class TestMetricTensor:
         #   qml.RY(y, wires=1)
         #   qml.RZ(z, wires=2)
 
-        G1 = np.zeros([3, 3])
+        G1 = pnp.zeros([3, 3])
 
         # diag elements
-        G1[0, 0] = np.sin(a) ** 2 / 4
+        G1[0, 0] = pnp.sin(a) ** 2 / 4
         G1[1, 1] = (
-            16 * np.cos(a) ** 2 * np.sin(b) ** 3 * np.cos(b) * np.sin(2 * c)
-            + np.cos(2 * b) * (2 - 8 * np.cos(a) ** 2 * np.sin(b) ** 2 * np.cos(2 * c))
-            + np.cos(2 * (a - b))
-            + np.cos(2 * (a + b))
-            - 2 * np.cos(2 * a)
+            16 * pnp.cos(a) ** 2 * pnp.sin(b) ** 3 * pnp.cos(b) * pnp.sin(2 * c)
+            + pnp.cos(2 * b) * (2 - 8 * pnp.cos(a) ** 2 * pnp.sin(b) ** 2 * pnp.cos(2 * c))
+            + pnp.cos(2 * (a - b))
+            + pnp.cos(2 * (a + b))
+            - 2 * pnp.cos(2 * a)
             + 14
         ) / 64
-        G1[2, 2] = (3 - np.cos(2 * a) - 2 * np.cos(a) ** 2 * np.cos(2 * (b + c))) / 16
+        G1[2, 2] = (3 - pnp.cos(2 * a) - 2 * pnp.cos(a) ** 2 * pnp.cos(2 * (b + c))) / 16
 
         assert qml.math.allclose(G[:3, :3], G1, atol=tol, rtol=0)
 
@@ -486,7 +486,7 @@ class TestMetricTensor:
         # Observables are the generators of:
         #   qml.RY(f, wires=1)
         #   qml.RZ(g, wires=2)
-        G2 = np.zeros([2, 2])
+        G2 = pnp.zeros([2, 2])
 
         def layer2_diag(params):
             x, y, z, *_ = params
@@ -628,7 +628,7 @@ class TestMetricTensor:
             qml.RZ(weights[2], wires=1)
             qml.RZ(weights[3], wires=0)
 
-        weights = np.array([0.1, 0.2, 0.3, 0.5], requires_grad=True)
+        weights = pnp.array([0.1, 0.2, 0.3, 0.5], requires_grad=True)
 
         with qml.tape.QuantumTape() as tape:
             circuit(weights)
@@ -893,7 +893,7 @@ fubini_ansatze = [
     fubini_ansatz8,
 ]
 
-B = np.array(
+B = pnp.array(
     [
         [
             [0.73, 0.49, 0.04],
@@ -909,18 +909,18 @@ B = np.array(
     requires_grad=True,
 )
 fubini_params = [
-    (np.array([0.3434, -0.7245345], requires_grad=True),),
+    (pnp.array([0.3434, -0.7245345], requires_grad=True),),
     (B,),
-    (np.array([-0.1111, -0.2222], requires_grad=True),),
-    (np.array([-0.1111, -0.2222, 0.4554], requires_grad=True),),
+    (pnp.array([-0.1111, -0.2222], requires_grad=True),),
+    (pnp.array([-0.1111, -0.2222, 0.4554], requires_grad=True),),
     (
-        np.array(-0.1735, requires_grad=True),
-        np.array([-0.1735, -0.2846, -0.2846], requires_grad=True),
+        pnp.array(-0.1735, requires_grad=True),
+        pnp.array([-0.1735, -0.2846, -0.2846], requires_grad=True),
     ),
-    (np.array([-0.1735, -0.2846], requires_grad=True),),
-    (np.array([-0.1735, -0.2846], requires_grad=True),),
-    (np.array(-0.1735, requires_grad=True),),
-    (np.array([-0.1111, 0.3333], requires_grad=True),),
+    (pnp.array([-0.1735, -0.2846], requires_grad=True),),
+    (pnp.array([-0.1735, -0.2846], requires_grad=True),),
+    (pnp.array(-0.1735, requires_grad=True),),
+    (pnp.array([-0.1111, 0.3333], requires_grad=True),),
 ]
 
 
@@ -938,10 +938,10 @@ def autodiff_metric_tensor(ansatz, num_wires):
         state = qnode(*params)
 
         def rqnode(*params):
-            return np.real(qnode(*params))
+            return pnp.real(qnode(*params))
 
         def iqnode(*params):
-            return np.imag(qnode(*params))
+            return pnp.imag(qnode(*params))
 
         rjac = qml.jacobian(rqnode)(*params)
         ijac = qml.jacobian(iqnode)(*params)
@@ -950,20 +950,20 @@ def autodiff_metric_tensor(ansatz, num_wires):
             out = []
             for rc, ic in zip(rjac, ijac):
                 c = rc + 1j * ic
-                psidpsi = np.tensordot(np.conj(state), c, axes=([0], [0]))
+                psidpsi = pnp.tensordot(pnp.conj(state), c, axes=([0], [0]))
                 out.append(
-                    np.real(
-                        np.tensordot(np.conj(c), c, axes=([0], [0]))
-                        - np.tensordot(np.conj(psidpsi), psidpsi, axes=0)
+                    pnp.real(
+                        pnp.tensordot(pnp.conj(c), c, axes=([0], [0]))
+                        - pnp.tensordot(pnp.conj(psidpsi), psidpsi, axes=0)
                     )
                 )
             return tuple(out)
 
         jac = rjac + 1j * ijac
-        psidpsi = np.tensordot(np.conj(state), jac, axes=([0], [0]))
-        return np.real(
-            np.tensordot(np.conj(jac), jac, axes=([0], [0]))
-            - np.tensordot(np.conj(psidpsi), psidpsi, axes=0)
+        psidpsi = pnp.tensordot(pnp.conj(state), jac, axes=([0], [0]))
+        return pnp.real(
+            pnp.tensordot(pnp.conj(jac), jac, axes=([0], [0]))
+            - pnp.tensordot(pnp.conj(psidpsi), psidpsi, axes=0)
         )
 
     return mt
@@ -1118,13 +1118,13 @@ def diffability_ansatz_0(weights, wires=None):
 
 
 def expected_diag_jac_0(weights):
-    return np.array(
+    return pnp.array(
         [
             [0, 0, 0],
             [0, 0, 0],
             [
-                np.cos(weights[0] + weights[1]) * np.sin(weights[0] + weights[1]) / 2,
-                np.cos(weights[0] + weights[1]) * np.sin(weights[0] + weights[1]) / 2,
+                pnp.cos(weights[0] + weights[1]) * pnp.sin(weights[0] + weights[1]) / 2,
+                pnp.cos(weights[0] + weights[1]) * pnp.sin(weights[0] + weights[1]) / 2,
                 0,
             ],
         ]
@@ -1140,13 +1140,13 @@ def diffability_ansatz_1(weights, wires=None):
 
 
 def expected_diag_jac_1(weights):
-    return np.array(
+    return pnp.array(
         [
             [0, 0, 0],
-            [-np.sin(2 * weights[0]) / 4, 0, 0],
+            [-pnp.sin(2 * weights[0]) / 4, 0, 0],
             [
-                np.cos(weights[0]) * np.cos(weights[1]) ** 2 * np.sin(weights[0]) / 2,
-                np.cos(weights[0]) ** 2 * np.sin(2 * weights[1]) / 4,
+                pnp.cos(weights[0]) * pnp.cos(weights[1]) ** 2 * pnp.sin(weights[0]) / 2,
+                pnp.cos(weights[0]) ** 2 * pnp.sin(2 * weights[1]) / 4,
                 0,
             ],
         ]
@@ -1162,20 +1162,20 @@ def diffability_ansatz_2(weights, wires=None):
 
 
 def expected_diag_jac_2(weights):
-    return np.array(
+    return pnp.array(
         [
             [0, 0, 0],
             [0, 0, 0],
             [
-                np.cos(weights[1]) ** 2 * np.sin(2 * weights[0]) / 4,
-                np.cos(weights[0]) ** 2 * np.sin(2 * weights[1]) / 4,
+                pnp.cos(weights[1]) ** 2 * pnp.sin(2 * weights[0]) / 4,
+                pnp.cos(weights[0]) ** 2 * pnp.sin(2 * weights[1]) / 4,
                 0,
             ],
         ]
     )
 
 
-weights_diff = np.array([0.432, 0.12, -0.292], requires_grad=True)
+weights_diff = pnp.array([0.432, 0.12, -0.292], requires_grad=True)
 
 
 @pytest.mark.parametrize("diff_method", ["backprop", "parameter-shift"])
@@ -1331,10 +1331,10 @@ class TestDifferentiability:
         qnode = qml.QNode(circuit, self.dev, interface=interface, diff_method=diff_method)
 
         def cost_full(*weights):
-            return np.array(qml.metric_tensor(qnode, approx=None)(*weights))
+            return pnp.array(qml.metric_tensor(qnode, approx=None)(*weights))
 
         def _cost_full(*weights):
-            return np.array(autodiff_metric_tensor(ansatz, 3)(*weights))
+            return pnp.array(autodiff_metric_tensor(ansatz, 3)(*weights))
 
         _c = _cost_full(*weights)
         c = cost_full(*weights)
@@ -1419,7 +1419,7 @@ class TestDifferentiability:
 def test_invalid_value_for_approx(approx):
     """Test exception is raised if ``approx`` is invalid."""
     with qml.queuing.AnnotatedQueue() as q:
-        qml.RX(np.array(0.5, requires_grad=True), wires=0)
+        qml.RX(pnp.array(0.5, requires_grad=True), wires=0)
         qml.expval(qml.PauliX(0))
 
     tape = qml.tape.QuantumScript.from_queue(q)
@@ -1434,7 +1434,7 @@ def test_generator_no_expval(monkeypatch):
         m.setattr("pennylane.RX.generator", lambda self: qml.RX(0.1, wires=0))
 
         with qml.queuing.AnnotatedQueue() as q:
-            qml.RX(np.array(0.5, requires_grad=True), wires=0)
+            qml.RX(pnp.array(0.5, requires_grad=True), wires=0)
             qml.expval(qml.PauliX(0))
 
         tape = qml.tape.QuantumScript.from_queue(q)
@@ -1456,8 +1456,8 @@ def test_error_missing_aux_wire():
         qml.RZ(z, wires="wire2")
         return qml.expval(qml.PauliZ("wire2"))
 
-    x = np.array(0.5, requires_grad=True)
-    z = np.array(0.1, requires_grad=True)
+    x = pnp.array(0.5, requires_grad=True)
+    z = pnp.array(0.1, requires_grad=True)
 
     with pytest.raises(
         qml.wires.WireError, match="The device has no free wire for the auxiliary wire."
@@ -1469,7 +1469,7 @@ def test_error_not_available_aux_wire():
     """Tests that a special error is raised if aux wires is not available."""
 
     dev = qml.device("default.qubit", wires=1)
-    x = np.array(0.5, requires_grad=True)
+    x = pnp.array(0.5, requires_grad=True)
 
     @qml.qnode(dev)
     def circuit(x):
@@ -1489,8 +1489,8 @@ def test_error_generator_not_registered(allow_nonunitary):
     controlled-generator operation registered."""
     dev = qml.device("default.qubit", wires=qml.wires.Wires(["wire1", "wire2", "wire3"]))
 
-    x = np.array(0.5, requires_grad=True)
-    z = np.array(0.1, requires_grad=True)
+    x = pnp.array(0.5, requires_grad=True)
+    z = pnp.array(0.1, requires_grad=True)
 
     class RX(qml.RX):
         def generator(self):
@@ -1536,8 +1536,8 @@ def test_no_error_missing_aux_wire_not_used():
         qml.RZ(z, wires="wire2")
         return qml.expval(qml.PauliZ("wire2"))
 
-    x = np.array(0.5, requires_grad=True)
-    z = np.array(0.1, requires_grad=True)
+    x = pnp.array(0.5, requires_grad=True)
+    z = pnp.array(0.1, requires_grad=True)
 
     qml.metric_tensor(circuit_single_block, approx=None)(x, z)
     qml.metric_tensor(circuit_single_block, approx=None, aux_wire="aux_wire")(x, z)
@@ -1559,7 +1559,7 @@ def test_raises_circuit_that_uses_missing_wire():
         qml.RX(x[1], 0)
         return qml.expval(qml.PauliZ(0))
 
-    x = np.array([1.3, 0.2])
+    x = pnp.array([1.3, 0.2])
     with pytest.raises(qml.wires.WireError, match=r"contain wires not found on the device: \{1\}"):
         qml.metric_tensor(circuit)(x)
 
@@ -1578,7 +1578,7 @@ def aux_wire_ansatz_1(x, y):
 @pytest.mark.parametrize("ansatz", [aux_wire_ansatz_0, aux_wire_ansatz_1])
 def test_get_aux_wire(aux_wire, ansatz):
     """Test ``_get_aux_wire`` without device_wires."""
-    x, y = np.array([0.2, 0.1], requires_grad=True)
+    x, y = pnp.array([0.2, 0.1], requires_grad=True)
     with qml.queuing.AnnotatedQueue() as q:
         ansatz(x, y)
     tape = qml.tape.QuantumScript.from_queue(q)
@@ -1592,7 +1592,7 @@ def test_get_aux_wire(aux_wire, ansatz):
 
 def test_get_aux_wire_with_device_wires():
     """Test ``_get_aux_wire`` with device_wires."""
-    x, y = np.array([0.2, 0.1], requires_grad=True)
+    x, y = pnp.array([0.2, 0.1], requires_grad=True)
     with qml.queuing.AnnotatedQueue() as q:
         qml.RX(x, wires=0)
         qml.RX(y, wires="one")
@@ -1611,7 +1611,7 @@ def test_get_aux_wire_with_device_wires():
 
 def test_get_aux_wire_with_unavailable_aux():
     """Test ``_get_aux_wire`` with device_wires and a requested ``aux_wire`` that is missing."""
-    x, y = np.array([0.2, 0.1], requires_grad=True)
+    x, y = pnp.array([0.2, 0.1], requires_grad=True)
     with qml.queuing.AnnotatedQueue() as q:
         qml.RX(x, wires=0)
         qml.RX(y, wires="one")

--- a/tests/gradients/core/test_vjp.py
+++ b/tests/gradients/core/test_vjp.py
@@ -17,7 +17,7 @@ from functools import partial
 import pytest
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane.gradients import param_shift
 
 
@@ -26,73 +26,73 @@ class TestComputeVJP:
 
     def test_compute_single_measurement_single_params(self):
         """Test that the correct VJP is returned"""
-        dy = np.array(1.0)
-        jac = np.array(0.2)
+        dy = pnp.array(1.0)
+        jac = pnp.array(0.2)
 
         vjp = qml.gradients.compute_vjp_single(dy, jac)
 
-        assert isinstance(vjp, np.ndarray)
-        assert np.allclose(vjp, 0.2)
+        assert isinstance(vjp, pnp.ndarray)
+        assert pnp.allclose(vjp, 0.2)
 
     def test_compute_single_measurement_multi_dim_single_params(self):
         """Test that the correct VJP is returned"""
-        dy = np.array([1, 2])
-        jac = np.array([0.3, 0.3])
+        dy = pnp.array([1, 2])
+        jac = pnp.array([0.3, 0.3])
 
         vjp = qml.gradients.compute_vjp_single(dy, jac)
 
-        assert isinstance(vjp, np.ndarray)
-        assert np.allclose(vjp, 0.9)
+        assert isinstance(vjp, pnp.ndarray)
+        assert pnp.allclose(vjp, 0.9)
 
     def test_compute_single_measurement_multiple_params(self):
         """Test that the correct VJP is returned"""
-        dy = np.array(1.0)
-        jac = tuple([np.array(0.1), np.array(0.2)])
+        dy = pnp.array(1.0)
+        jac = tuple([pnp.array(0.1), pnp.array(0.2)])
 
         vjp = qml.gradients.compute_vjp_single(dy, jac)
 
-        assert isinstance(vjp, np.ndarray)
-        assert np.allclose(vjp, [0.1, 0.2])
+        assert isinstance(vjp, pnp.ndarray)
+        assert pnp.allclose(vjp, [0.1, 0.2])
 
     def test_compute_single_measurement_multi_dim_multiple_params(self):
         """Test that the correct VJP is returned"""
-        dy = np.array([1.0, 0.5])
-        jac = tuple([np.array([0.1, 0.3]), np.array([0.2, 0.4])])
+        dy = pnp.array([1.0, 0.5])
+        jac = tuple([pnp.array([0.1, 0.3]), pnp.array([0.2, 0.4])])
 
         vjp = qml.gradients.compute_vjp_single(dy, jac)
 
-        assert isinstance(vjp, np.ndarray)
-        assert np.allclose(vjp, [0.25, 0.4])
+        assert isinstance(vjp, pnp.ndarray)
+        assert pnp.allclose(vjp, [0.25, 0.4])
 
     def test_compute_multiple_measurement_single_params(self):
         """Test that the correct VJP is returned"""
-        dy = tuple([np.array([1.0]), np.array([1.0, 0.5])])
-        jac = tuple([np.array([0.3]), np.array([0.2, 0.5])])
+        dy = tuple([pnp.array([1.0]), pnp.array([1.0, 0.5])])
+        jac = tuple([pnp.array([0.3]), pnp.array([0.2, 0.5])])
 
         vjp = qml.gradients.compute_vjp_multi(dy, jac)
 
-        assert isinstance(vjp, np.ndarray)
-        assert np.allclose(vjp, [0.75])
+        assert isinstance(vjp, pnp.ndarray)
+        assert pnp.allclose(vjp, [0.75])
 
     def test_compute_multiple_measurement_multi_params(self):
         """Test that the correct VJP is returned"""
-        dy = tuple([np.array([1.0]), np.array([1.0, 0.5])])
+        dy = tuple([pnp.array([1.0]), pnp.array([1.0, 0.5])])
         jac = tuple(
             [
-                tuple([np.array([0.3]), np.array([0.4])]),
-                tuple([np.array([0.2, 0.5]), np.array([0.3, 0.8])]),
+                tuple([pnp.array([0.3]), pnp.array([0.4])]),
+                tuple([pnp.array([0.2, 0.5]), pnp.array([0.3, 0.8])]),
             ]
         )
 
         vjp = qml.gradients.compute_vjp_multi(dy, jac)
 
-        assert isinstance(vjp, np.ndarray)
-        assert np.allclose(vjp, [0.75, 1.1])
+        assert isinstance(vjp, pnp.ndarray)
+        assert pnp.allclose(vjp, [0.75, 1.1])
 
     def test_jacobian_is_none_single(self):
         """A None Jacobian returns a None VJP"""
 
-        dy = np.array([[1.0, 2.0], [3.0, 4.0]])
+        dy = pnp.array([[1.0, 2.0], [3.0, 4.0]])
         jac = None
 
         vjp = qml.gradients.compute_vjp_single(dy, jac)
@@ -101,7 +101,7 @@ class TestComputeVJP:
     def test_jacobian_is_none_multi(self):
         """A None Jacobian returns a None VJP"""
 
-        dy = np.array([[1.0, 2.0], [3.0, 4.0]])
+        dy = pnp.array([[1.0, 2.0], [3.0, 4.0]])
         jac = None
 
         vjp = qml.gradients.compute_vjp_multi(dy, jac)
@@ -109,32 +109,32 @@ class TestComputeVJP:
 
     def test_zero_dy_single_measurement_single_params(self):
         """A zero dy vector will return a zero matrix"""
-        dy = np.zeros([1])
-        jac = np.array(0.1)
+        dy = pnp.zeros([1])
+        jac = pnp.array(0.1)
 
         vjp = qml.gradients.compute_vjp_single(dy, jac)
-        assert np.all(vjp == np.zeros([1]))
+        assert pnp.all(vjp == pnp.zeros([1]))
 
     def test_zero_dy_single_measurement_multi_params(self):
         """A zero dy vector will return a zero matrix"""
-        dy = np.zeros(1)
-        jac = tuple([np.array(0.1), np.array(0.2)])
+        dy = pnp.zeros(1)
+        jac = tuple([pnp.array(0.1), pnp.array(0.2)])
 
         vjp = qml.gradients.compute_vjp_single(dy, jac)
-        assert np.all(vjp == np.zeros([2]))
+        assert pnp.all(vjp == pnp.zeros([2]))
 
     def test_zero_dy_multi(self):
         """A zero dy vector will return a zero matrix"""
-        dy = tuple([np.array(0.0), np.array([0.0, 0.0])])
+        dy = tuple([pnp.array(0.0), pnp.array([0.0, 0.0])])
         jac = tuple(
             [
-                tuple([np.array(0.1), np.array(0.1), np.array(0.1)]),
-                tuple([np.array([0.1, 0.2]), np.array([0.1, 0.2]), np.array([0.1, 0.2])]),
+                tuple([pnp.array(0.1), pnp.array(0.1), pnp.array(0.1)]),
+                tuple([pnp.array([0.1, 0.2]), pnp.array([0.1, 0.2]), pnp.array([0.1, 0.2])]),
             ]
         )
 
         vjp = qml.gradients.compute_vjp_multi(dy, jac)
-        assert np.all(vjp == np.zeros([3]))
+        assert pnp.all(vjp == pnp.zeros([3]))
 
     @pytest.mark.torch
     @pytest.mark.parametrize("dtype1,dtype2", [("float32", "float64"), ("float64", "float32")])
@@ -201,7 +201,7 @@ class TestVJP:
 
         tape = qml.tape.QuantumScript.from_queue(q)
         tape.trainable_params = {}
-        dy = np.array([1.0])
+        dy = pnp.array([1.0])
         tapes, fn = qml.gradients.vjp(tape, dy, param_shift)
 
         assert not tapes
@@ -218,11 +218,11 @@ class TestVJP:
 
         tape = qml.tape.QuantumScript.from_queue(q)
         tape.trainable_params = {0, 1}
-        dy = np.array([0.0])
+        dy = pnp.array([0.0])
         tapes, fn = qml.gradients.vjp(tape, dy, param_shift)
 
         assert not tapes
-        assert np.all(fn(tapes) == np.zeros([len(tape.trainable_params)]))
+        assert pnp.all(fn(tapes) == pnp.zeros([len(tape.trainable_params)]))
 
     def test_single_expectation_value(self, tol):
         """Tests correct output shape and evaluation for a tape
@@ -239,7 +239,7 @@ class TestVJP:
 
         tape = qml.tape.QuantumScript.from_queue(q)
         tape.trainable_params = {0, 1}
-        dy = np.array(1.0)
+        dy = pnp.array(1.0)
 
         tapes, fn = qml.gradients.vjp(tape, dy, param_shift)
         assert len(tapes) == 4
@@ -247,8 +247,8 @@ class TestVJP:
         res = fn(dev.execute(tapes))
         assert res.shape == (2,)
 
-        exp = np.array([-np.sin(y) * np.sin(x), np.cos(y) * np.cos(x)])
-        assert np.allclose(res, exp, atol=tol, rtol=0)
+        exp = pnp.array([-pnp.sin(y) * pnp.sin(x), pnp.cos(y) * pnp.cos(x)])
+        assert pnp.allclose(res, exp, atol=tol, rtol=0)
 
     def test_multiple_expectation_values(self, tol):
         """Tests correct output shape and evaluation for a tape
@@ -266,7 +266,7 @@ class TestVJP:
 
         tape = qml.tape.QuantumScript.from_queue(q)
         tape.trainable_params = {0, 1}
-        dy = np.array([1.0, 2.0])
+        dy = pnp.array([1.0, 2.0])
 
         tapes, fn = qml.gradients.vjp(tape, dy, param_shift)
         assert len(tapes) == 4
@@ -274,8 +274,8 @@ class TestVJP:
         res = fn(dev.execute(tapes))
         assert res.shape == (2,)
 
-        exp = np.array([-np.sin(x), 2 * np.cos(y)])
-        assert np.allclose(res, exp, atol=tol, rtol=0)
+        exp = pnp.array([-pnp.sin(x), 2 * pnp.cos(y)])
+        assert pnp.allclose(res, exp, atol=tol, rtol=0)
 
     def test_prob_expectation_values(self, tol):
         """Tests correct output shape and evaluation for a tape
@@ -293,7 +293,7 @@ class TestVJP:
 
         tape = qml.tape.QuantumScript.from_queue(q)
         tape.trainable_params = {0, 1}
-        dy = tuple([np.array(1.0), np.array([2.0, 3.0, 4.0, 5.0])])
+        dy = tuple([pnp.array(1.0), pnp.array([2.0, 3.0, 4.0, 5.0])])
 
         tapes, fn = qml.gradients.vjp(tape, dy, param_shift)
         assert len(tapes) == 4
@@ -302,44 +302,44 @@ class TestVJP:
         assert res.shape == (2,)
 
         exp = (
-            np.array(
+            pnp.array(
                 [
-                    [-2 * np.sin(x), 0],
+                    [-2 * pnp.sin(x), 0],
                     [
-                        -(np.cos(y / 2) ** 2 * np.sin(x)),
-                        -(np.cos(x / 2) ** 2 * np.sin(y)),
+                        -(pnp.cos(y / 2) ** 2 * pnp.sin(x)),
+                        -(pnp.cos(x / 2) ** 2 * pnp.sin(y)),
                     ],
                     [
-                        -(np.sin(x) * np.sin(y / 2) ** 2),
-                        (np.cos(x / 2) ** 2 * np.sin(y)),
+                        -(pnp.sin(x) * pnp.sin(y / 2) ** 2),
+                        (pnp.cos(x / 2) ** 2 * pnp.sin(y)),
                     ],
                     [
-                        (np.sin(x) * np.sin(y / 2) ** 2),
-                        (np.sin(x / 2) ** 2 * np.sin(y)),
+                        (pnp.sin(x) * pnp.sin(y / 2) ** 2),
+                        (pnp.sin(x / 2) ** 2 * pnp.sin(y)),
                     ],
                     [
-                        (np.cos(y / 2) ** 2 * np.sin(x)),
-                        -(np.sin(x / 2) ** 2 * np.sin(y)),
+                        (pnp.cos(y / 2) ** 2 * pnp.sin(x)),
+                        -(pnp.sin(x / 2) ** 2 * pnp.sin(y)),
                     ],
                 ]
             )
             / 2
         )
-        dy = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
-        assert np.allclose(res, dy @ exp, atol=tol, rtol=0)
+        dy = pnp.array([1.0, 2.0, 3.0, 4.0, 5.0])
+        assert pnp.allclose(res, dy @ exp, atol=tol, rtol=0)
 
-    @pytest.mark.parametrize("dtype", [np.float32, np.float64])
+    @pytest.mark.parametrize("dtype", [pnp.float32, pnp.float64])
     def test_dtype_matches_dy(self, dtype):
         """Tests that the vjp function matches the dtype of dy when dy is
         zero-like."""
-        x = np.array([0.1], dtype=np.float64)
+        x = pnp.array([0.1], dtype=pnp.float64)
 
         with qml.queuing.AnnotatedQueue() as q:
             qml.RX(x[0], wires=0)
             qml.expval(qml.PauliZ(0))
 
         tape = qml.tape.QuantumScript.from_queue(q)
-        dy = np.zeros(3, dtype=dtype)
+        dy = pnp.zeros(3, dtype=dtype)
         _, func = qml.gradients.vjp(tape, dy, qml.gradients.param_shift)
 
         assert func([]).dtype == dtype
@@ -357,10 +357,10 @@ def expected(params):
     """Compute the expected VJP for the ansatz above."""
     x, y = 1.0 * params
     return (
-        np.array(
+        pnp.array(
             [
-                (np.cos(y / 2) ** 2 * np.sin(x)) + (np.cos(y / 2) ** 2 * np.sin(x)),
-                (np.cos(x / 2) ** 2 * np.sin(y)) - (np.sin(x / 2) ** 2 * np.sin(y)),
+                (pnp.cos(y / 2) ** 2 * pnp.sin(x)) + (pnp.cos(y / 2) ** 2 * pnp.sin(x)),
+                (pnp.cos(x / 2) ** 2 * pnp.sin(y)) - (pnp.sin(x / 2) ** 2 * pnp.sin(y)),
             ]
         )
         / 2
@@ -375,7 +375,7 @@ class TestVJPGradients:
         """Tests that the output of the VJP transform
         can be differentiated using autograd."""
         dev = qml.device("default.qubit", wires=2)
-        params = np.array([0.543, -0.654], requires_grad=True)
+        params = pnp.array([0.543, -0.654], requires_grad=True)
 
         def cost_fn(x, dy):
             with qml.queuing.AnnotatedQueue() as q:
@@ -386,12 +386,12 @@ class TestVJPGradients:
             tapes, fn = qml.gradients.vjp(tape, dy, param_shift)
             return fn(dev.execute(tapes))
 
-        dy = np.array([-1.0, 0.0, 0.0, 1.0], requires_grad=False)
+        dy = pnp.array([-1.0, 0.0, 0.0, 1.0], requires_grad=False)
         res = cost_fn(params, dy)
-        assert np.allclose(res, expected(params), atol=tol, rtol=0)
+        assert pnp.allclose(res, expected(params), atol=tol, rtol=0)
 
         res = qml.jacobian(cost_fn)(params, dy)
-        assert np.allclose(res, qml.jacobian(expected)(params), atol=tol, rtol=0)
+        assert pnp.allclose(res, qml.jacobian(expected)(params), atol=tol, rtol=0)
 
     @pytest.mark.torch
     def test_torch(self, tol):
@@ -401,7 +401,7 @@ class TestVJPGradients:
 
         dev = qml.device("default.qubit", wires=2)
 
-        params_np = np.array([0.543, -0.654], requires_grad=True)
+        params_np = pnp.array([0.543, -0.654], requires_grad=True)
         params = torch.tensor(params_np, requires_grad=True, dtype=torch.float64)
         dy = torch.tensor([-1.0, 0.0, 0.0, 1.0], dtype=torch.float64)
 
@@ -413,13 +413,13 @@ class TestVJPGradients:
         tapes, fn = qml.gradients.vjp(tape, dy, param_shift)
         vjp = fn(qml.execute(tapes, dev, qml.gradients.param_shift))
 
-        assert np.allclose(vjp.detach(), expected(params.detach()), atol=tol, rtol=0)
+        assert pnp.allclose(vjp.detach(), expected(params.detach()), atol=tol, rtol=0)
 
         cost = vjp[0]
         cost.backward()
 
         exp = qml.jacobian(lambda x: expected(x)[0])(params_np)
-        assert np.allclose(params.grad, exp, atol=tol, rtol=0)
+        assert pnp.allclose(params.grad, exp, atol=tol, rtol=0)
 
     @pytest.mark.tf
     @pytest.mark.slow
@@ -430,7 +430,7 @@ class TestVJPGradients:
 
         dev = qml.device("default.qubit", wires=2, seed=seed)
 
-        params_np = np.array([0.543, -0.654], requires_grad=True)
+        params_np = pnp.array([0.543, -0.654], requires_grad=True)
         params = tf.Variable(params_np, dtype=tf.float64)
         dy = tf.constant([-1.0, 0.0, 0.0, 1.0], dtype=tf.float64)
 
@@ -443,10 +443,10 @@ class TestVJPGradients:
             tapes, fn = qml.gradients.vjp(tape, dy, param_shift)
             vjp = fn(dev.execute(tapes))
 
-        assert np.allclose(vjp, expected(params), atol=tol, rtol=0)
+        assert pnp.allclose(vjp, expected(params), atol=tol, rtol=0)
 
         res = t.jacobian(vjp, params)
-        assert np.allclose(res, qml.jacobian(expected)(params_np), atol=tol, rtol=0)
+        assert pnp.allclose(res, qml.jacobian(expected)(params_np), atol=tol, rtol=0)
 
     # TODO: to be added when lighting and TF compatible with return types
     # @pytest.mark.tf
@@ -493,7 +493,7 @@ class TestVJPGradients:
         from jax import numpy as jnp
 
         dev = qml.device("default.qubit", wires=2)
-        params_np = np.array([0.543, -0.654], requires_grad=True)
+        params_np = pnp.array([0.543, -0.654], requires_grad=True)
         params = jnp.array(params_np)
 
         @partial(jax.jit)
@@ -507,11 +507,11 @@ class TestVJPGradients:
             return fn(dev.execute(tapes))
 
         res = cost_fn(params)
-        assert np.allclose(res, expected(params), atol=tol, rtol=0)
+        assert pnp.allclose(res, expected(params), atol=tol, rtol=0)
 
         res = jax.jacobian(cost_fn, argnums=0)(params)
         exp = qml.jacobian(expected)(params_np)
-        assert np.allclose(res, exp, atol=tol, rtol=0)
+        assert pnp.allclose(res, exp, atol=tol, rtol=0)
 
 
 class TestBatchVJP:
@@ -538,7 +538,7 @@ class TestBatchVJP:
         tape2.trainable_params = {0, 1}
 
         tapes = [tape1, tape2]
-        dys = [np.array(1.0), np.array(1.0)]
+        dys = [pnp.array(1.0), pnp.array(1.0)]
 
         v_tapes, fn = qml.gradients.batch_vjp(tapes, dys, param_shift)
         assert len(v_tapes) == 4
@@ -568,7 +568,7 @@ class TestBatchVJP:
         tape2.trainable_params = set()
 
         tapes = [tape1, tape2]
-        dys = [np.array(1.0), np.array(1.0)]
+        dys = [pnp.array(1.0), pnp.array(1.0)]
 
         v_tapes, fn = qml.gradients.batch_vjp(tapes, dys, param_shift)
 
@@ -596,7 +596,7 @@ class TestBatchVJP:
         tape2.trainable_params = {0, 1}
 
         tapes = [tape1, tape2]
-        dys = [np.array(0.0), np.array(1.0)]
+        dys = [pnp.array(0.0), pnp.array(1.0)]
 
         v_tapes, fn = qml.gradients.batch_vjp(tapes, dys, param_shift)
         res = fn(dev.execute(v_tapes))
@@ -604,7 +604,7 @@ class TestBatchVJP:
         # Even though there are 3 parameters, only two contribute
         # to the VJP, so only 2*2=4 quantum evals
         assert len(v_tapes) == 4
-        assert np.allclose(res[0], 0)
+        assert pnp.allclose(res[0], 0)
 
     def test_reduction_append(self):
         """Test the 'append' reduction strategy"""
@@ -627,14 +627,14 @@ class TestBatchVJP:
         tape2.trainable_params = {0, 1}
 
         tapes = [tape1, tape2]
-        dys = [np.array(1.0), np.array(1.0)]
+        dys = [pnp.array(1.0), pnp.array(1.0)]
 
         v_tapes, fn = qml.gradients.batch_vjp(tapes, dys, param_shift, reduction="append")
         res = fn(dev.execute(v_tapes))
 
         # Returned VJPs will be appended to a list, one vjp per tape
         assert len(res) == 2
-        assert all(isinstance(r, np.ndarray) for r in res)
+        assert all(isinstance(r, pnp.ndarray) for r in res)
         assert all(len(r) == len(t.trainable_params) for t, r in zip(tapes, res))
 
     def test_reduction_extend(self):
@@ -658,7 +658,7 @@ class TestBatchVJP:
         tape2.trainable_params = {0, 1}
 
         tapes = [tape1, tape2]
-        dys = [np.array(1.0), np.array(1.0)]
+        dys = [pnp.array(1.0), pnp.array(1.0)]
 
         v_tapes, fn = qml.gradients.batch_vjp(tapes, dys, param_shift, reduction="extend")
         res = fn(dev.execute(v_tapes))
@@ -671,20 +671,20 @@ class TestBatchVJP:
     def test_batched_params_probs_jacobian(self):
         """Test that the VJP gets calculated correctly when inputs are batched, multiple
         trainable parameters are used and the measurement has a shape (probs)"""
-        data = np.array([1.2, 2.3, 3.4])
+        data = pnp.array([1.2, 2.3, 3.4])
         x0, x1 = 0.5, 0.8
         ops = [qml.RX(x0, 0), qml.RX(x1, 0), qml.RY(data, 0)]
         tape = qml.tape.QuantumScript(ops, [qml.probs(wires=0)], trainable_params=[0, 1])
-        dy = np.array([[0.6, -0.7], [0.2, -0.7], [-5.2, 0.6]])
+        dy = pnp.array([[0.6, -0.7], [0.2, -0.7], [-5.2, 0.6]])
         v_tapes, fn = qml.gradients.batch_vjp([tape], [dy], qml.gradients.param_shift)
 
         dev = qml.device("default.qubit")
         vjp = fn(dev.execute(v_tapes))
 
         # Analytically expected Jacobian and VJP
-        expected_jac = [-0.5 * np.cos(data) * np.sin(x0 + x1), 0.5 * np.cos(data) * np.sin(x0 + x1)]
-        expected_vjp = np.tensordot(expected_jac, dy, axes=[[0, 1], [1, 0]])
+        expected_jac = [-0.5 * pnp.cos(data) * pnp.sin(x0 + x1), 0.5 * pnp.cos(data) * pnp.sin(x0 + x1)]
+        expected_vjp = pnp.tensordot(expected_jac, dy, axes=[[0, 1], [1, 0]])
         assert qml.math.shape(vjp) == (1, 2)  # num tapes, num trainable tape parameters
-        assert np.allclose(
+        assert pnp.allclose(
             vjp, expected_vjp
         )  # Both parameters essentially feed into the same RX rotation

--- a/tests/gradients/finite_diff/test_finite_difference.py
+++ b/tests/gradients/finite_diff/test_finite_difference.py
@@ -20,14 +20,14 @@ import pytest
 from default_qubit_legacy import DefaultQubitLegacy
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane.gradients import finite_diff, finite_diff_coeffs
 from pennylane.operation import AnyWires, Observable
 
 
 def test_float32_warning():
     """Test that a warning is raised if provided float32 parameters."""
-    x = np.array(0.1, dtype=np.float32)
+    x = pnp.array(0.1, dtype=pnp.float32)
     tape = qml.tape.QuantumScript([qml.RX(x, 0)], [qml.expval(qml.PauliZ(0))])
     with pytest.warns(UserWarning, match="Finite differences with float32 detected."):
         finite_diff(tape)
@@ -63,38 +63,38 @@ class TestCoeffs:
     def test_correct_forward_order1(self):
         """Test that the correct forward order 1 method is returned"""
         coeffs, shifts = finite_diff_coeffs(1, 1, "forward")
-        assert np.allclose(coeffs, [-1, 1])
-        assert np.allclose(shifts, [0, 1])
+        assert pnp.allclose(coeffs, [-1, 1])
+        assert pnp.allclose(shifts, [0, 1])
 
     def test_correct_forward_order2(self):
         """Test that the correct forward order 2 method is returned"""
         coeffs, shifts = finite_diff_coeffs(1, 2, "forward")
-        assert np.allclose(coeffs, [-1.5, 2, -0.5])
-        assert np.allclose(shifts, [0, 1, 2])
+        assert pnp.allclose(coeffs, [-1.5, 2, -0.5])
+        assert pnp.allclose(shifts, [0, 1, 2])
 
     def test_correct_center_order2(self):
         """Test that the correct centered order 2 method is returned"""
         coeffs, shifts = finite_diff_coeffs(1, 2, "center")
-        assert np.allclose(coeffs, [-0.5, 0.5])
-        assert np.allclose(shifts, [-1, 1])
+        assert pnp.allclose(coeffs, [-0.5, 0.5])
+        assert pnp.allclose(shifts, [-1, 1])
 
     def test_correct_backward_order1(self):
         """Test that the correct backward order 1 method is returned"""
         coeffs, shifts = finite_diff_coeffs(1, 1, "backward")
-        assert np.allclose(coeffs, [1, -1])
-        assert np.allclose(shifts, [0, -1])
+        assert pnp.allclose(coeffs, [1, -1])
+        assert pnp.allclose(shifts, [0, -1])
 
     def test_correct_second_derivative_forward_order1(self):
         """Test that the correct forward order 1 method is returned"""
         coeffs, shifts = finite_diff_coeffs(2, 1, "forward")
-        assert np.allclose(coeffs, [1, -2, 1])
-        assert np.allclose(shifts, [0, 1, 2])
+        assert pnp.allclose(coeffs, [1, -2, 1])
+        assert pnp.allclose(shifts, [0, 1, 2])
 
     def test_correct_second_derivative_center_order4(self):
         """Test that the correct forward order 4 method is returned"""
         coeffs, shifts = finite_diff_coeffs(2, 4, "center")
-        assert np.allclose(coeffs, [-2.5, 4 / 3, 4 / 3, -1 / 12, -1 / 12])
-        assert np.allclose(shifts, [0, -1, 1, -2, 2])
+        assert pnp.allclose(coeffs, [-2.5, 4 / 3, 4 / 3, -1 / 12, -1 / 12])
+        assert pnp.allclose(shifts, [0, -1, 1, -2, 2])
 
 
 class TestFiniteDiff:
@@ -141,12 +141,12 @@ class TestFiniteDiff:
         ]
         separate_tapes_and_fns = [finite_diff(t) for t in separate_tapes]
         separate_grad = [_fn(dev.execute(_tapes)) for _tapes, _fn in separate_tapes_and_fns]
-        assert np.allclose(batched_grad, separate_grad)
+        assert pnp.allclose(batched_grad, separate_grad)
 
     def test_non_differentiable_error(self):
         """Test error raised if attempting to differentiate with
         respect to a non-differentiable argument"""
-        psi = np.array([1, 0, 1, 0], requires_grad=False) / np.sqrt(2)
+        psi = pnp.array([1, 0, 1, 0], requires_grad=False) / pnp.sqrt(2)
 
         with qml.queuing.AnnotatedQueue() as q:
             qml.StatePrep(psi, wires=[0, 1])
@@ -320,13 +320,13 @@ class TestFiniteDiff:
             qml.Rot(*(prefactor * params), wires=0)
             return qml.probs([2, 3])
 
-        params = np.array([0.5, 0.5, 0.5], requires_grad=True)
+        params = pnp.array([0.5, 0.5, 0.5], requires_grad=True)
 
         result = qml.gradients.finite_diff(circuit)(params)
 
-        assert isinstance(result, np.ndarray)
+        assert isinstance(result, pnp.ndarray)
         assert result.shape == (4, 3)
-        assert np.allclose(result, 0)
+        assert pnp.allclose(result, 0)
 
     def test_all_zero_diff_methods_multiple_returns(self):
         """Test that the transform works correctly when the diff method for every parameter is
@@ -339,7 +339,7 @@ class TestFiniteDiff:
             qml.Rot(*params, wires=0)
             return qml.expval(qml.PauliZ(wires=2)), qml.probs([2, 3])
 
-        params = np.array([0.5, 0.5, 0.5], requires_grad=True)
+        params = pnp.array([0.5, 0.5, 0.5], requires_grad=True)
 
         result = qml.gradients.finite_diff(circuit)(params)
 
@@ -348,9 +348,9 @@ class TestFiniteDiff:
         assert len(result) == 2
 
         for r, exp_shape in zip(result, [(3,), (4, 3)]):
-            assert isinstance(r, np.ndarray)
+            assert isinstance(r, pnp.ndarray)
             assert r.shape == exp_shape
-            assert np.allclose(r, 0)
+            assert pnp.allclose(r, 0)
 
     def test_y0(self):
         """Test that if first order finite differences is used, then
@@ -409,10 +409,10 @@ class TestFiniteDiff:
         tapes, fn = finite_diff(tape2, approx_order=1)
         j2 = fn(dev.execute(tapes))
 
-        exp = -np.sin(1)
+        exp = -pnp.sin(1)
 
-        assert np.allclose(j1, [exp, 0])
-        assert np.allclose(j2, [0, exp])
+        assert pnp.allclose(j1, [exp, 0])
+        assert pnp.allclose(j2, [0, exp])
 
     def test_output_shape_matches_qnode(self):
         """Test that the transform output shape matches that of the QNode."""
@@ -442,7 +442,7 @@ class TestFiniteDiff:
             qml.Rot(*x, wires=0)
             return qml.probs([0, 1]), qml.probs([2, 3])
 
-        x = np.random.rand(3)
+        x = pnp.random.rand(3)
         circuits = [qml.QNode(cost, dev) for cost in (cost1, cost2, cost3, cost4, cost5, cost6)]
 
         transform = [qml.math.shape(qml.gradients.finite_diff(c)(x)) for c in circuits]
@@ -512,7 +512,7 @@ class TestFiniteDiff:
             # pylint: disable=unused-argument
             @staticmethod
             def _asarray(arr, dtype=None):
-                return np.asarray(arr)
+                return pnp.asarray(arr)
 
             def __init__(self, *args, **kwargs):
                 super().__init__(*args, **kwargs)
@@ -538,9 +538,9 @@ class TestFiniteDiff:
             qml.RY(x, wires=0)
             return qml.expval(qml.PauliZ(wires=0))
 
-        par = np.array(0.2, requires_grad=True)
-        assert np.isclose(qnode(par).item().val, reference_qnode(par))
-        assert np.isclose(qml.jacobian(qnode)(par).item().val, qml.jacobian(reference_qnode)(par))
+        par = pnp.array(0.2, requires_grad=True)
+        assert pnp.isclose(qnode(par).item().val, reference_qnode(par))
+        assert pnp.isclose(qml.jacobian(qnode)(par).item().val, qml.jacobian(reference_qnode)(par))
 
 
 @pytest.mark.parametrize("approx_order", [2, 4])
@@ -611,8 +611,8 @@ class TestFiniteDiffIntegration:
         assert isinstance(res[1], numpy.ndarray)
         assert res[1].shape == ()
 
-        expected = np.array([[-np.sin(y) * np.sin(x), np.cos(y) * np.cos(x)]])
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        expected = pnp.array([[-pnp.sin(y) * pnp.sin(x), pnp.cos(y) * pnp.cos(x)]])
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
     def test_single_expectation_value_with_argnum_all(self, approx_order, strategy, validate, tol):
         """Tests correct output shape and evaluation for a tape
@@ -648,8 +648,8 @@ class TestFiniteDiffIntegration:
         assert isinstance(res[1], numpy.ndarray)
         assert res[1].shape == ()
 
-        expected = np.array([[-np.sin(y) * np.sin(x), np.cos(y) * np.cos(x)]])
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        expected = pnp.array([[-pnp.sin(y) * pnp.sin(x), pnp.cos(y) * pnp.cos(x)]])
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
     def test_single_expectation_value_with_argnum_one(self, approx_order, strategy, validate, tol):
         """Tests correct output shape and evaluation for a tape
@@ -685,9 +685,9 @@ class TestFiniteDiffIntegration:
         assert isinstance(res[1], numpy.ndarray)
         assert res[1].shape == ()
 
-        expected = [0, np.cos(y) * np.cos(x)]
+        expected = [0, pnp.cos(y) * pnp.cos(x)]
 
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
     def test_multiple_expectation_value_with_argnum_one(
         self, approx_order, strategy, validate, tol
@@ -719,9 +719,9 @@ class TestFiniteDiffIntegration:
 
         assert isinstance(res, tuple)
         assert isinstance(res[0], tuple)
-        assert np.allclose(res[0][0], 0, atol=tol, rtol=0)
+        assert pnp.allclose(res[0][0], 0, atol=tol, rtol=0)
         assert isinstance(res[1], tuple)
-        assert np.allclose(res[1][0], 0, atol=tol, rtol=0)
+        assert pnp.allclose(res[1][0], 0, atol=tol, rtol=0)
 
     def test_multiple_expectation_values(self, approx_order, strategy, validate, tol):
         """Tests correct output shape and evaluation for a tape
@@ -748,13 +748,13 @@ class TestFiniteDiffIntegration:
 
         assert isinstance(res[0], tuple)
         assert len(res[0]) == 2
-        assert np.allclose(res[0], [-np.sin(x), 0], atol=tol, rtol=0)
+        assert pnp.allclose(res[0], [-pnp.sin(x), 0], atol=tol, rtol=0)
         assert isinstance(res[0][0], numpy.ndarray)
         assert isinstance(res[0][1], numpy.ndarray)
 
         assert isinstance(res[1], tuple)
         assert len(res[1]) == 2
-        assert np.allclose(res[1], [0, np.cos(y)], atol=tol, rtol=0)
+        assert pnp.allclose(res[1], [0, pnp.cos(y)], atol=tol, rtol=0)
         assert isinstance(res[1][0], numpy.ndarray)
         assert isinstance(res[1][1], numpy.ndarray)
 
@@ -783,13 +783,13 @@ class TestFiniteDiffIntegration:
 
         assert isinstance(res[0], tuple)
         assert len(res[0]) == 2
-        assert np.allclose(res[0], [-np.sin(x), 0], atol=tol, rtol=0)
+        assert pnp.allclose(res[0], [-pnp.sin(x), 0], atol=tol, rtol=0)
         assert isinstance(res[0][0], numpy.ndarray)
         assert isinstance(res[0][1], numpy.ndarray)
 
         assert isinstance(res[1], tuple)
         assert len(res[1]) == 2
-        assert np.allclose(res[1], [0, -2 * np.cos(y) * np.sin(y)], atol=tol, rtol=0)
+        assert pnp.allclose(res[1], [0, -2 * pnp.cos(y) * pnp.sin(y)], atol=tol, rtol=0)
         assert isinstance(res[1][0], numpy.ndarray)
         assert isinstance(res[1][1], numpy.ndarray)
 
@@ -818,32 +818,32 @@ class TestFiniteDiffIntegration:
 
         assert isinstance(res[0], tuple)
         assert len(res[0]) == 2
-        assert np.allclose(res[0][0], -np.sin(x), atol=tol, rtol=0)
+        assert pnp.allclose(res[0][0], -pnp.sin(x), atol=tol, rtol=0)
         assert isinstance(res[0][0], numpy.ndarray)
-        assert np.allclose(res[0][1], 0, atol=tol, rtol=0)
+        assert pnp.allclose(res[0][1], 0, atol=tol, rtol=0)
         assert isinstance(res[0][1], numpy.ndarray)
 
         assert isinstance(res[1], tuple)
         assert len(res[1]) == 2
-        assert np.allclose(
+        assert pnp.allclose(
             res[1][0],
             [
-                -(np.cos(y / 2) ** 2 * np.sin(x)) / 2,
-                -(np.sin(x) * np.sin(y / 2) ** 2) / 2,
-                (np.sin(x) * np.sin(y / 2) ** 2) / 2,
-                (np.cos(y / 2) ** 2 * np.sin(x)) / 2,
+                -(pnp.cos(y / 2) ** 2 * pnp.sin(x)) / 2,
+                -(pnp.sin(x) * pnp.sin(y / 2) ** 2) / 2,
+                (pnp.sin(x) * pnp.sin(y / 2) ** 2) / 2,
+                (pnp.cos(y / 2) ** 2 * pnp.sin(x)) / 2,
             ],
             atol=tol,
             rtol=0,
         )
         assert isinstance(res[1][0], numpy.ndarray)
-        assert np.allclose(
+        assert pnp.allclose(
             res[1][1],
             [
-                -(np.cos(x / 2) ** 2 * np.sin(y)) / 2,
-                (np.cos(x / 2) ** 2 * np.sin(y)) / 2,
-                (np.sin(x / 2) ** 2 * np.sin(y)) / 2,
-                -(np.sin(x / 2) ** 2 * np.sin(y)) / 2,
+                -(pnp.cos(x / 2) ** 2 * pnp.sin(y)) / 2,
+                (pnp.cos(x / 2) ** 2 * pnp.sin(y)) / 2,
+                (pnp.sin(x / 2) ** 2 * pnp.sin(y)) / 2,
+                -(pnp.sin(x / 2) ** 2 * pnp.sin(y)) / 2,
             ],
             atol=tol,
             rtol=0,
@@ -861,7 +861,7 @@ class TestFiniteDiffGradients:
         """Tests that the output of the finite-difference transform
         can be differentiated using autograd, yielding second derivatives."""
         dev = qml.device("default.qubit", wires=2)
-        params = np.array([0.543, -0.654], requires_grad=True)
+        params = pnp.array([0.543, -0.654], requires_grad=True)
 
         def cost_fn(x):
             with qml.queuing.AnnotatedQueue() as q:
@@ -873,25 +873,25 @@ class TestFiniteDiffGradients:
             tape = qml.tape.QuantumScript.from_queue(q)
             tape.trainable_params = {0, 1}
             tapes, fn = finite_diff(tape, n=1, approx_order=approx_order, strategy=strategy)
-            return np.array(fn(dev.execute(tapes)))
+            return pnp.array(fn(dev.execute(tapes)))
 
         res = qml.jacobian(cost_fn)(params)
         x, y = params
-        expected = np.array(
+        expected = pnp.array(
             [
-                [-np.cos(x) * np.sin(y), -np.cos(y) * np.sin(x)],
-                [-np.cos(y) * np.sin(x), -np.cos(x) * np.sin(y)],
+                [-pnp.cos(x) * pnp.sin(y), -pnp.cos(y) * pnp.sin(x)],
+                [-pnp.cos(y) * pnp.sin(x), -pnp.cos(x) * pnp.sin(y)],
             ]
         )
 
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
     @pytest.mark.autograd
     def test_autograd_ragged(self, approx_order, strategy, tol):
         """Tests that the output of the finite-difference transform
         of a ragged tape can be differentiated using autograd, yielding second derivatives."""
         dev = qml.device("default.qubit", wires=2)
-        params = np.array([0.543, -0.654], requires_grad=True)
+        params = pnp.array([0.543, -0.654], requires_grad=True)
 
         def cost_fn(x):
             with qml.queuing.AnnotatedQueue() as q:
@@ -909,8 +909,8 @@ class TestFiniteDiffGradients:
 
         x, y = params
         res = qml.jacobian(cost_fn)(params)[0]
-        expected = np.array([-np.cos(x) * np.cos(y) / 2, np.sin(x) * np.sin(y) / 2])
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        expected = pnp.array([-pnp.cos(x) * pnp.cos(y) / 2, pnp.sin(x) * pnp.sin(y) / 2])
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
     @pytest.mark.tf
     @pytest.mark.slow
@@ -939,13 +939,13 @@ class TestFiniteDiffGradients:
         res_0 = t.jacobian(jac_0, params)
         res_1 = t.jacobian(jac_1, params)
 
-        expected = np.array(
+        expected = pnp.array(
             [
-                [-np.cos(x) * np.sin(y), -np.cos(y) * np.sin(x)],
-                [-np.cos(y) * np.sin(x), -np.cos(x) * np.sin(y)],
+                [-pnp.cos(x) * pnp.sin(y), -pnp.cos(y) * pnp.sin(x)],
+                [-pnp.cos(y) * pnp.sin(x), -pnp.cos(x) * pnp.sin(y)],
             ]
         )
-        assert np.allclose([res_0, res_1], expected, atol=tol, rtol=0)
+        assert pnp.allclose([res_0, res_1], expected, atol=tol, rtol=0)
 
     @pytest.mark.tf
     def test_tf_ragged(self, approx_order, strategy, tol):
@@ -974,9 +974,9 @@ class TestFiniteDiffGradients:
 
         res_01 = t.jacobian(jac_01, params)
 
-        expected = np.array([-np.cos(x) * np.cos(y) / 2, np.sin(x) * np.sin(y) / 2])
+        expected = pnp.array([-pnp.cos(x) * pnp.cos(y) / 2, pnp.sin(x) * pnp.sin(y) / 2])
 
-        assert np.allclose(res_01[0], expected, atol=tol, rtol=0)
+        assert pnp.allclose(res_01[0], expected, atol=tol, rtol=0)
 
     @pytest.mark.torch
     def test_torch(self, approx_order, strategy, tol):
@@ -1003,15 +1003,15 @@ class TestFiniteDiffGradients:
 
         x, y = params.detach().numpy()
 
-        expected = np.array(
+        expected = pnp.array(
             [
-                [-np.cos(x) * np.sin(y), -np.cos(y) * np.sin(x)],
-                [-np.cos(y) * np.sin(x), -np.cos(x) * np.sin(y)],
+                [-pnp.cos(x) * pnp.sin(y), -pnp.cos(y) * pnp.sin(x)],
+                [-pnp.cos(y) * pnp.sin(x), -pnp.cos(x) * pnp.sin(y)],
             ]
         )
 
-        assert np.allclose(hess[0].detach().numpy(), expected[0], atol=tol, rtol=0)
-        assert np.allclose(hess[1].detach().numpy(), expected[1], atol=tol, rtol=0)
+        assert pnp.allclose(hess[0].detach().numpy(), expected[0], atol=tol, rtol=0)
+        assert pnp.allclose(hess[1].detach().numpy(), expected[1], atol=tol, rtol=0)
 
     @pytest.mark.jax
     def test_jax(self, approx_order, strategy, tol):
@@ -1038,13 +1038,13 @@ class TestFiniteDiffGradients:
         res = jax.jacobian(cost_fn)(params)
         assert isinstance(res, tuple)
         x, y = params
-        expected = np.array(
+        expected = pnp.array(
             [
-                [-np.cos(x) * np.sin(y), -np.cos(y) * np.sin(x)],
-                [-np.cos(y) * np.sin(x), -np.cos(x) * np.sin(y)],
+                [-pnp.cos(x) * pnp.sin(y), -pnp.cos(y) * pnp.sin(x)],
+                [-pnp.cos(y) * pnp.sin(x), -pnp.cos(x) * pnp.sin(y)],
             ]
         )
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
     @pytest.mark.jax
     def test_jax_probs(self, approx_order, strategy, tol):  # pylint: disable=unused-argument
@@ -1112,16 +1112,16 @@ class TestJaxArgnums:
             circuit, argnums=argnums, approx_order=approx_order, strategy=strategy, h=1e-5
         )(x, y)
 
-        expected_0 = np.array([-np.sin(y) * np.sin(x[0]), 0])
-        expected_1 = np.array(np.cos(y) * np.cos(x[0]))
+        expected_0 = pnp.array([-pnp.sin(y) * pnp.sin(x[0]), 0])
+        expected_1 = pnp.array(pnp.cos(y) * pnp.cos(x[0]))
 
         if argnums == [0]:
-            assert np.allclose(res, expected_0)
+            assert pnp.allclose(res, expected_0)
         if argnums == [1]:
-            assert np.allclose(res, expected_1)
+            assert pnp.allclose(res, expected_1)
         if argnums == [0, 1]:
-            assert np.allclose(res[0], expected_0)
-            assert np.allclose(res[1], expected_1)
+            assert pnp.allclose(res[0], expected_0)
+            assert pnp.allclose(res[1], expected_1)
 
     def test_multi_expectation_values(self, argnums, interface, approx_order, strategy):
         """Test for multiple expectation values."""
@@ -1143,19 +1143,19 @@ class TestJaxArgnums:
             circuit, argnums=argnums, approx_order=approx_order, strategy=strategy, h=1e-5
         )(x, y)
 
-        expected_0 = np.array([[-np.sin(x[0]), 0.0], [0.0, 0.0]])
-        expected_1 = np.array([0, np.cos(y)])
+        expected_0 = pnp.array([[-pnp.sin(x[0]), 0.0], [0.0, 0.0]])
+        expected_1 = pnp.array([0, pnp.cos(y)])
 
         if argnums == [0]:
-            assert np.allclose(res[0], expected_0[0])
-            assert np.allclose(res[1], expected_0[1])
+            assert pnp.allclose(res[0], expected_0[0])
+            assert pnp.allclose(res[1], expected_0[1])
         if argnums == [1]:
-            assert np.allclose(res, expected_1)
+            assert pnp.allclose(res, expected_1)
         if argnums == [0, 1]:
-            assert np.allclose(res[0][0], expected_0[0])
-            assert np.allclose(res[0][1], expected_0[1])
-            assert np.allclose(res[1][0], expected_1[0])
-            assert np.allclose(res[1][1], expected_1[1])
+            assert pnp.allclose(res[0][0], expected_0[0])
+            assert pnp.allclose(res[0][1], expected_0[1])
+            assert pnp.allclose(res[1][0], expected_1[0])
+            assert pnp.allclose(res[1][1], expected_1[1])
 
     def test_hessian(self, argnums, interface, approx_order, strategy):
         """Test for hessian."""
@@ -1185,9 +1185,9 @@ class TestJaxArgnums:
 
         if len(argnums) == 1:
             # jax.hessian produces an additional tuple axis, which we have to index away here
-            assert np.allclose(res, res_expected[0], atol=tol)
+            assert pnp.allclose(res, res_expected[0], atol=tol)
         else:
             # The Hessian is a 2x2 nested tuple "matrix" for argnums=[0, 1]
             for r, r_e in zip(res, res_expected):
                 for r_, r_e_ in zip(r, r_e):
-                    assert np.allclose(r_, r_e_, atol=tol)
+                    assert pnp.allclose(r_, r_e_, atol=tol)

--- a/tests/gradients/finite_diff/test_finite_difference_shot_vec.py
+++ b/tests/gradients/finite_diff/test_finite_difference_shot_vec.py
@@ -19,7 +19,7 @@ import pytest
 from default_qubit_legacy import DefaultQubitLegacy
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane.gradients import finite_diff
 from pennylane.measurements import Shots
 from pennylane.operation import AnyWires, Observable
@@ -38,7 +38,7 @@ class TestFiniteDiff:
     def test_non_differentiable_error(self):
         """Test error raised if attempting to differentiate with
         respect to a non-differentiable argument"""
-        psi = np.array([1, 0, 1, 0], requires_grad=False) / np.sqrt(2)
+        psi = pnp.array([1, 0, 1, 0], requires_grad=False) / pnp.sqrt(2)
 
         with qml.queuing.AnnotatedQueue() as q:
             qml.StatePrep(psi, wires=[0, 1])
@@ -222,7 +222,7 @@ class TestFiniteDiff:
             qml.Rot(*params, wires=0)
             return qml.probs([2, 3])
 
-        params = np.array([0.5, 0.5, 0.5], requires_grad=True)
+        params = pnp.array([0.5, 0.5, 0.5], requires_grad=True)
 
         all_result = qml.gradients.finite_diff(circuit, h=h_val)(params)
 
@@ -230,9 +230,9 @@ class TestFiniteDiff:
         assert len(all_result) == len(default_shot_vector)
 
         for result in all_result:
-            assert isinstance(result, np.ndarray)
+            assert isinstance(result, pnp.ndarray)
             assert result.shape == (4, 3)
-            assert np.allclose(result, 0)
+            assert pnp.allclose(result, 0)
 
     def test_all_zero_diff_methods_multiple_returns(self):
         """Test that the transform works correctly when the diff method for every parameter is
@@ -245,7 +245,7 @@ class TestFiniteDiff:
             qml.Rot(*params, wires=0)
             return qml.expval(qml.PauliZ(wires=2)), qml.probs([2, 3])
 
-        params = np.array([0.5, 0.5, 0.5], requires_grad=True)
+        params = pnp.array([0.5, 0.5, 0.5], requires_grad=True)
 
         all_result = qml.gradients.finite_diff(circuit, h=h_val)(params)
         assert isinstance(all_result, tuple)
@@ -255,9 +255,9 @@ class TestFiniteDiff:
             assert isinstance(res, tuple)
             assert len(res) == 2
             for r, exp_shape in zip(res, [(3,), (4, 3)]):
-                assert isinstance(r, np.ndarray)
+                assert isinstance(r, pnp.ndarray)
                 assert r.shape == exp_shape
-                assert np.allclose(r, 0)
+                assert pnp.allclose(r, 0)
 
     def test_y0(self):
         """Test that if first order finite differences is used, then
@@ -316,7 +316,7 @@ class TestFiniteDiff:
         tapes, fn = finite_diff(tape2, approx_order=1, h=h_val)
         j2 = fn(dev.execute(tapes))
 
-        exp = -np.sin(1)
+        exp = -pnp.sin(1)
 
         assert isinstance(j1, tuple)
         assert len(j1) == len(many_shots_shot_vector)
@@ -324,8 +324,8 @@ class TestFiniteDiff:
         assert len(j2) == len(many_shots_shot_vector)
 
         for _j1, _j2 in zip(j1, j2):
-            assert np.allclose(_j1, [exp, 0], atol=0.07)
-            assert np.allclose(_j2, [0, exp], atol=0.07)
+            assert pnp.allclose(_j1, [exp, 0], atol=0.07)
+            assert pnp.allclose(_j2, [0, exp], atol=0.07)
 
     def test_output_shape_matches_qnode(self):
         """Test that the transform output shape matches that of the QNode."""
@@ -355,7 +355,7 @@ class TestFiniteDiff:
             qml.Rot(*x, wires=0)
             return qml.probs([0, 1]), qml.probs([2, 3])
 
-        x = np.random.rand(3)
+        x = pnp.random.rand(3)
         circuits = [qml.QNode(cost, dev) for cost in (cost1, cost2, cost3, cost4, cost5, cost6)]
 
         transform = [qml.math.shape(qml.gradients.finite_diff(c, h=h_val)(x)) for c in circuits]
@@ -374,7 +374,7 @@ class TestFiniteDiff:
             qml.Rot(x[0], 2 * y[1], -0.1 * z[0], wires=0)
             return qml.probs([0, 1]), qml.probs([2, 3])
 
-        x, y, z = np.random.rand(3, 2)
+        x, y, z = pnp.random.rand(3, 2)
         circuits = [qml.QNode(cost, dev) for cost in (cost1, cost2)]
 
         transform = [
@@ -432,7 +432,7 @@ class TestFiniteDiff:
             # pylint: disable=unused-argument
             @staticmethod
             def _asarray(arr, dtype=None):
-                return np.array(arr)
+                return pnp.array(arr)
 
             def __init__(self, *args, **kwargs):
                 super().__init__(*args, **kwargs)
@@ -458,9 +458,9 @@ class TestFiniteDiff:
             qml.RY(x, wires=0)
             return qml.expval(qml.PauliZ(wires=0))
 
-        par = np.array(0.2, requires_grad=True)
-        assert np.isclose(qnode(par).item().val, reference_qnode(par))
-        assert np.isclose(qml.jacobian(qnode)(par).item().val, qml.jacobian(reference_qnode)(par))
+        par = pnp.array(0.2, requires_grad=True)
+        assert pnp.isclose(qnode(par).item().val, reference_qnode(par))
+        assert pnp.isclose(qml.jacobian(qnode)(par).item().val, qml.jacobian(reference_qnode)(par))
 
 
 @pytest.mark.parametrize("approx_order", [2, 4])
@@ -535,7 +535,7 @@ class TestFiniteDiffIntegration:
         assert isinstance(all_res, tuple)
         assert len(all_res) == len(many_shots_shot_vector)
 
-        expected = np.array([[-np.sin(y) * np.sin(x), np.cos(y) * np.cos(x)]])
+        expected = pnp.array([[-pnp.sin(y) * pnp.sin(x), pnp.cos(y) * pnp.cos(x)]])
         for res in all_res:
             assert isinstance(res, tuple)
             assert len(res) == 2
@@ -546,7 +546,7 @@ class TestFiniteDiffIntegration:
             assert isinstance(res[1], numpy.ndarray)
             assert res[1].shape == ()
 
-            assert np.allclose(res, expected, atol=0.15, rtol=0)
+            assert pnp.allclose(res, expected, atol=0.15, rtol=0)
 
     def test_single_expectation_value_with_argnum_all(self, approx_order, strategy, validate, seed):
         """Tests correct output shape and evaluation for a tape
@@ -577,7 +577,7 @@ class TestFiniteDiffIntegration:
         assert isinstance(all_res, tuple)
         assert len(all_res) == len(many_shots_shot_vector)
 
-        expected = np.array([[-np.sin(y) * np.sin(x), np.cos(y) * np.cos(x)]])
+        expected = pnp.array([[-pnp.sin(y) * pnp.sin(x), pnp.cos(y) * pnp.cos(x)]])
         for res in all_res:
             assert isinstance(res, tuple)
             assert len(res) == 2
@@ -588,7 +588,7 @@ class TestFiniteDiffIntegration:
             assert isinstance(res[1], numpy.ndarray)
             assert res[1].shape == ()
 
-            assert np.allclose(res, expected, atol=0.15, rtol=0)
+            assert pnp.allclose(res, expected, atol=0.15, rtol=0)
 
     def test_single_expectation_value_with_argnum_one(self, approx_order, strategy, validate, seed):
         """Tests correct output shape and evaluation for a tape
@@ -623,7 +623,7 @@ class TestFiniteDiffIntegration:
         assert isinstance(all_res, tuple)
         assert len(all_res) == len(many_shots_shot_vector)
 
-        expected = [0, np.cos(y) * np.cos(x)]
+        expected = [0, pnp.cos(y) * pnp.cos(x)]
 
         for res in all_res:
             assert isinstance(res, tuple)
@@ -635,7 +635,7 @@ class TestFiniteDiffIntegration:
             assert isinstance(res[1], numpy.ndarray)
             assert res[1].shape == ()
 
-            assert np.allclose(res, expected, atol=0.12, rtol=0)
+            assert pnp.allclose(res, expected, atol=0.12, rtol=0)
 
     def test_probs_expval_with_argnum_one(self, approx_order, strategy, validate, seed):
         """Tests correct output shape and evaluation for a tape
@@ -672,18 +672,18 @@ class TestFiniteDiffIntegration:
         assert isinstance(all_res, tuple)
         assert len(all_res) == len(many_shots_shot_vector)
 
-        cx, sx, cy, sy = np.cos(x / 2), np.sin(x / 2), np.cos(y / 2), np.sin(y / 2)
+        cx, sx, cy, sy = pnp.cos(x / 2), pnp.sin(x / 2), pnp.cos(y / 2), pnp.sin(y / 2)
         # probability vector is [cx**2 * cy**2, cx**2 * sy**2, sx**2 * sy**2, sx**2 * cy**2]
-        exp_dprob = np.array([-(cx**2), cx**2, sx**2, -(sx**2)]) * (sy * cy)
-        exp_probs = [np.zeros(4), exp_dprob]
+        exp_dprob = pnp.array([-(cx**2), cx**2, sx**2, -(sx**2)]) * (sy * cy)
+        exp_probs = [pnp.zeros(4), exp_dprob]
         # expval is np.sin(y) * np.cos(x)
-        exp_expval = [0, np.cos(y) * np.cos(x)]
+        exp_expval = [0, pnp.cos(y) * pnp.cos(x)]
 
         for res in all_res:
             assert isinstance(res, tuple)
             assert len(res) == 2  # two measurements
-            assert np.allclose(res[0], exp_probs, atol=0.07)
-            assert np.allclose(res[1], exp_expval, atol=0.2)
+            assert pnp.allclose(res[0], exp_probs, atol=0.07)
+            assert pnp.allclose(res[1], exp_expval, atol=0.2)
 
     def test_multiple_expectation_values(self, approx_order, strategy, validate, seed):
         """Tests correct output shape and evaluation for a tape
@@ -718,13 +718,13 @@ class TestFiniteDiffIntegration:
 
             assert isinstance(res[0], tuple)
             assert len(res[0]) == 2
-            assert np.allclose(res[0], [-np.sin(x), 0], atol=0.15, rtol=0)
+            assert pnp.allclose(res[0], [-pnp.sin(x), 0], atol=0.15, rtol=0)
             assert isinstance(res[0][0], numpy.ndarray)
             assert isinstance(res[0][1], numpy.ndarray)
 
             assert isinstance(res[1], tuple)
             assert len(res[1]) == 2
-            assert np.allclose(res[1], [0, np.cos(y)], atol=0.15, rtol=0)
+            assert pnp.allclose(res[1], [0, pnp.cos(y)], atol=0.15, rtol=0)
             assert isinstance(res[1][0], numpy.ndarray)
             assert isinstance(res[1][1], numpy.ndarray)
 
@@ -761,13 +761,13 @@ class TestFiniteDiffIntegration:
 
             assert isinstance(res[0], tuple)
             assert len(res[0]) == 2
-            assert np.allclose(res[0], [-np.sin(x), 0], atol=0.2, rtol=0)
+            assert pnp.allclose(res[0], [-pnp.sin(x), 0], atol=0.2, rtol=0)
             assert isinstance(res[0][0], numpy.ndarray)
             assert isinstance(res[0][1], numpy.ndarray)
 
             assert isinstance(res[1], tuple)
             assert len(res[1]) == 2
-            assert np.allclose(res[1], [0, -2 * np.cos(y) * np.sin(y)], atol=0.2, rtol=0)
+            assert pnp.allclose(res[1], [0, -2 * pnp.cos(y) * pnp.sin(y)], atol=0.2, rtol=0)
             assert isinstance(res[1][0], numpy.ndarray)
             assert isinstance(res[1][1], numpy.ndarray)
 
@@ -804,32 +804,32 @@ class TestFiniteDiffIntegration:
 
             assert isinstance(res[0], tuple)
             assert len(res[0]) == 2
-            assert np.allclose(res[0][0], -np.sin(x), atol=0.1, rtol=0)
+            assert pnp.allclose(res[0][0], -pnp.sin(x), atol=0.1, rtol=0)
             assert isinstance(res[0][0], numpy.ndarray)
-            assert np.allclose(res[0][1], 0, atol=0.1, rtol=0)
+            assert pnp.allclose(res[0][1], 0, atol=0.1, rtol=0)
             assert isinstance(res[0][1], numpy.ndarray)
 
             assert isinstance(res[1], tuple)
             assert len(res[1]) == 2
-            assert np.allclose(
+            assert pnp.allclose(
                 res[1][0],
                 [
-                    -(np.cos(y / 2) ** 2 * np.sin(x)) / 2,
-                    -(np.sin(x) * np.sin(y / 2) ** 2) / 2,
-                    (np.sin(x) * np.sin(y / 2) ** 2) / 2,
-                    (np.cos(y / 2) ** 2 * np.sin(x)) / 2,
+                    -(pnp.cos(y / 2) ** 2 * pnp.sin(x)) / 2,
+                    -(pnp.sin(x) * pnp.sin(y / 2) ** 2) / 2,
+                    (pnp.sin(x) * pnp.sin(y / 2) ** 2) / 2,
+                    (pnp.cos(y / 2) ** 2 * pnp.sin(x)) / 2,
                 ],
                 atol=0.07,
                 rtol=0,
             )
             assert isinstance(res[1][0], numpy.ndarray)
-            assert np.allclose(
+            assert pnp.allclose(
                 res[1][1],
                 [
-                    -(np.cos(x / 2) ** 2 * np.sin(y)) / 2,
-                    (np.cos(x / 2) ** 2 * np.sin(y)) / 2,
-                    (np.sin(x / 2) ** 2 * np.sin(y)) / 2,
-                    -(np.sin(x / 2) ** 2 * np.sin(y)) / 2,
+                    -(pnp.cos(x / 2) ** 2 * pnp.sin(y)) / 2,
+                    (pnp.cos(x / 2) ** 2 * pnp.sin(y)) / 2,
+                    (pnp.sin(x / 2) ** 2 * pnp.sin(y)) / 2,
+                    -(pnp.sin(x / 2) ** 2 * pnp.sin(y)) / 2,
                 ],
                 atol=0.08,
                 rtol=0,
@@ -848,7 +848,7 @@ class TestFiniteDiffGradients:
         """Tests that the output of the finite-difference transform
         can be differentiated using autograd, yielding second derivatives."""
         dev = qml.device("default.qubit", wires=2, shots=many_shots_shot_vector)
-        params = np.array([0.543, -0.654], requires_grad=True)
+        params = pnp.array([0.543, -0.654], requires_grad=True)
 
         def cost_fn(x):
             with qml.queuing.AnnotatedQueue() as q:
@@ -866,7 +866,7 @@ class TestFiniteDiffGradients:
                 strategy=strategy,
                 h=h_val,
             )
-            return np.array(fn(dev.execute(tapes)))
+            return pnp.array(fn(dev.execute(tapes)))
 
         all_res = qml.jacobian(cost_fn)(params)
 
@@ -875,21 +875,21 @@ class TestFiniteDiffGradients:
 
         for res in all_res:
             x, y = params
-            expected = np.array(
+            expected = pnp.array(
                 [
-                    [-np.cos(x) * np.sin(y), -np.cos(y) * np.sin(x)],
-                    [-np.cos(y) * np.sin(x), -np.cos(x) * np.sin(y)],
+                    [-pnp.cos(x) * pnp.sin(y), -pnp.cos(y) * pnp.sin(x)],
+                    [-pnp.cos(y) * pnp.sin(x), -pnp.cos(x) * pnp.sin(y)],
                 ]
             )
 
-            assert np.allclose(res, expected, atol=0.3, rtol=0)
+            assert pnp.allclose(res, expected, atol=0.3, rtol=0)
 
     @pytest.mark.autograd
     def test_autograd_ragged(self, approx_order, strategy):
         """Tests that the output of the finite-difference transform
         of a ragged tape can be differentiated using autograd, yielding second derivatives."""
         dev = qml.device("default.qubit", wires=2, shots=many_shots_shot_vector)
-        params = np.array([0.543, -0.654], requires_grad=True)
+        params = pnp.array([0.543, -0.654], requires_grad=True)
 
         def cost_fn(x):
             with qml.queuing.AnnotatedQueue() as q:
@@ -918,8 +918,8 @@ class TestFiniteDiffGradients:
         assert len(all_res) == len(many_shots_shot_vector)
 
         for res in all_res:
-            expected = np.array([-np.cos(x) * np.cos(y) / 2, np.sin(x) * np.sin(y) / 2])
-            assert np.allclose(res, expected, atol=0.3, rtol=0)
+            expected = pnp.array([-pnp.cos(x) * pnp.cos(y) / 2, pnp.sin(x) * pnp.sin(y) / 2])
+            assert pnp.allclose(res, expected, atol=0.3, rtol=0)
 
     @pytest.mark.tf
     @pytest.mark.slow
@@ -954,13 +954,13 @@ class TestFiniteDiffGradients:
         res_0 = t.jacobian(jac_0, params)
         res_1 = t.jacobian(jac_1, params)
 
-        expected = np.array(
+        expected = pnp.array(
             [
-                [-np.cos(x) * np.sin(y), -np.cos(y) * np.sin(x)],
-                [-np.cos(y) * np.sin(x), -np.cos(x) * np.sin(y)],
+                [-pnp.cos(x) * pnp.sin(y), -pnp.cos(y) * pnp.sin(x)],
+                [-pnp.cos(y) * pnp.sin(x), -pnp.cos(x) * pnp.sin(y)],
             ]
         )
-        assert np.allclose([res_0, res_1], expected, atol=0.3, rtol=0)
+        assert pnp.allclose([res_0, res_1], expected, atol=0.3, rtol=0)
 
     @pytest.mark.tf
     def test_tf_ragged(self, approx_order, strategy):
@@ -995,9 +995,9 @@ class TestFiniteDiffGradients:
 
         res_01 = t.jacobian(jac_01, params)
 
-        expected = np.array([-np.cos(x) * np.cos(y) / 2, np.sin(x) * np.sin(y) / 2])
+        expected = pnp.array([-pnp.cos(x) * pnp.cos(y) / 2, pnp.sin(x) * pnp.sin(y) / 2])
 
-        assert np.allclose(res_01[0], expected, atol=0.3, rtol=0)
+        assert pnp.allclose(res_01[0], expected, atol=0.3, rtol=0)
 
     @pytest.mark.torch
     def test_torch(self, approx_order, strategy):
@@ -1029,15 +1029,15 @@ class TestFiniteDiffGradients:
 
         x, y = params.detach().numpy()
 
-        expected = np.array(
+        expected = pnp.array(
             [
-                [-np.cos(x) * np.sin(y), -np.cos(y) * np.sin(x)],
-                [-np.cos(y) * np.sin(x), -np.cos(x) * np.sin(y)],
+                [-pnp.cos(x) * pnp.sin(y), -pnp.cos(y) * pnp.sin(x)],
+                [-pnp.cos(y) * pnp.sin(x), -pnp.cos(x) * pnp.sin(y)],
             ]
         )
 
-        assert np.allclose(hess[0].detach().numpy(), expected[0], atol=0.3, rtol=0)
-        assert np.allclose(hess[1].detach().numpy(), expected[1], atol=0.3, rtol=0)
+        assert pnp.allclose(hess[0].detach().numpy(), expected[0], atol=0.3, rtol=0)
+        assert pnp.allclose(hess[1].detach().numpy(), expected[1], atol=0.3, rtol=0)
 
     @pytest.mark.jax
     def test_jax(self, approx_order, strategy):
@@ -1073,20 +1073,20 @@ class TestFiniteDiffGradients:
         assert len(all_res) == len(many_shots_shot_vector)
 
         x, y = params
-        expected = np.array(
+        expected = pnp.array(
             [
-                [-np.cos(x) * np.sin(y), -np.cos(y) * np.sin(x)],
-                [-np.cos(y) * np.sin(x), -np.cos(x) * np.sin(y)],
+                [-pnp.cos(x) * pnp.sin(y), -pnp.cos(y) * pnp.sin(x)],
+                [-pnp.cos(y) * pnp.sin(x), -pnp.cos(x) * pnp.sin(y)],
             ]
         )
         for res in all_res:
             assert isinstance(res, tuple)
-            assert np.allclose(res, expected, atol=0.3, rtol=0)
+            assert pnp.allclose(res, expected, atol=0.3, rtol=0)
 
 
 pauliz = qml.PauliZ(wires=0)
 proj = qml.Projector([1], wires=0)
-A = np.array([[4, -1 + 6j], [-1 - 6j, 2]])
+A = pnp.array([[4, -1 + 6j], [-1 - 6j, 2]])
 hermitian = qml.Hermitian(A, wires=0)
 
 expval = qml.expval(pauliz)
@@ -1143,7 +1143,7 @@ class TestReturn:
         assert isinstance(all_res, tuple)
 
         for res in all_res:
-            assert isinstance(res, np.ndarray)
+            assert isinstance(res, pnp.ndarray)
             assert res.shape == shape
 
     @pytest.mark.parametrize("op_wire", [0, 1])
@@ -1179,7 +1179,7 @@ class TestReturn:
         expected_shapes = [(), (4,), (), ()]
         for meas_res in all_res:
             for res, shape in zip(meas_res, expected_shapes):
-                assert isinstance(res, np.ndarray)
+                assert isinstance(res, pnp.ndarray)
                 assert res.shape == shape
 
     @pytest.mark.parametrize("meas, shape", single_meas_with_shape)
@@ -1212,14 +1212,14 @@ class TestReturn:
 
         for param_res in all_res:
             for res in param_res:
-                assert isinstance(res, np.ndarray)
+                assert isinstance(res, pnp.ndarray)
                 assert res.shape == shape
 
     @pytest.mark.parametrize("op_wires", [(0, 1, 2, 3, 4), (5, 5, 5, 5, 5)])
     def test_N_N(self, shot_vec, op_wires):
         """Test multi-param multi-measurement case"""
         dev = qml.device("default.qubit", wires=6, shots=shot_vec)
-        params = np.random.random(6)
+        params = pnp.random.random(6)
 
         with qml.queuing.AnnotatedQueue() as q:
             for idx, w in enumerate(op_wires):
@@ -1258,5 +1258,5 @@ class TestReturn:
             for idx, param_res in enumerate(meas_res):
                 assert len(param_res) == 5
                 for res in param_res:
-                    assert isinstance(res, np.ndarray)
+                    assert isinstance(res, pnp.ndarray)
                     assert res.shape == expected_shapes[idx]

--- a/tests/gradients/parameter_shift/test_parameter_shift.py
+++ b/tests/gradients/parameter_shift/test_parameter_shift.py
@@ -18,7 +18,7 @@ import pytest
 from default_qubit_legacy import DefaultQubitLegacy
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane.gradients import param_shift
 from pennylane.gradients.parameter_shift import (
     _evaluate_gradient,
@@ -31,27 +31,27 @@ from pennylane.operation import AnyWires, Observable
 
 # Constants for TestEvaluateGradient
 # Coefficients and expectation values
-X = np.arange(1, 5)
+X = pnp.arange(1, 5)
 # Expected "shift rule" result
-Z = np.sum(-np.arange(1, 5) ** 2)
+Z = pnp.sum(-pnp.arange(1, 5) ** 2)
 # Single coefficient/expectation value that leads to the same result as X
-w = np.sqrt(30)
+w = pnp.sqrt(30)
 # Prefactors to emulate a shot vector
-shv = np.array([0.1, 0.4, 0.7])
+shv = pnp.array([0.1, 0.4, 0.7])
 # Fake probability vector (just a 1d array)
-p = np.array([0.01, 0.06, -0.2, 0.5, -0.1, 0.7, -0.09])
+p = pnp.array([0.01, 0.06, -0.2, 0.5, -0.1, 0.7, -0.09])
 # Second fake probability vector (just a 1d array)
 p2 = p[1:5]
 # shifted probability evaluations
-P = np.outer(X, p)
+P = pnp.outer(X, p)
 # shifted probability evaluations for p2
-P2 = np.outer(X, p2)
+P2 = pnp.outer(X, p2)
 # Single unshifted result that lead to the same result as P
 v = w * p
 # Single unshifted result that lead to the same result as P2
 v2 = w * p2
 # Prefactors to emulate different shot values and multi measurement
-shv_m = np.outer([0.1, 0.4, 0.7], [1, 2])
+shv_m = pnp.outer([0.1, 0.4, 0.7], [1, 2])
 
 
 class TestEvaluateGradient:
@@ -68,15 +68,15 @@ class TestEvaluateGradient:
         (X, None, 4, -X, None, Z),
         (X[:-1], X[-1], None, tuple(-X[:-1]), -X[-1], Z),
         (X[:-1], X[-1], 4, -X[:-1], -X[-1], Z),
-        (np.ones(0), w, None, (), -w, Z),
-        (np.ones(0), w, 4, (), -w, Z),
+        (pnp.ones(0), w, None, (), -w, Z),
+        (pnp.ones(0), w, 4, (), -w, Z),
         # Probability
         (X, None, None, tuple(-P), None, p * Z),
         (X, None, 4, -P, None, p * Z),
         (X[:-1], X[-1], None, tuple(-P[:-1]), -P[-1], p * Z),
         (X[:-1], X[-1], 4, -P[:-1], -P[-1], p * Z),
-        (np.ones(0), w, None, (), -v, p * Z),
-        (np.ones(0), w, 4, (), -v, p * Z),
+        (pnp.ones(0), w, None, (), -v, p * Z),
+        (pnp.ones(0), w, 4, (), -v, p * Z),
     ]
 
     @pytest.mark.parametrize(
@@ -91,9 +91,9 @@ class TestEvaluateGradient:
         data = [None, coeffs, None, unshifted_coeff, None]
         grad = _evaluate_gradient(tape_specs, res, data, r0, batch_size)
 
-        assert isinstance(grad, np.ndarray)
+        assert isinstance(grad, pnp.ndarray)
         assert grad.shape == expected.shape
-        assert np.allclose(grad, expected)
+        assert pnp.allclose(grad, expected)
 
     exp_probs = (p2 * Z, 2 * p * Z)
     test_cases_single_shots_multi_meas = [
@@ -102,22 +102,22 @@ class TestEvaluateGradient:
         (X, None, 4, (-X, -2 * X), None, (Z, 2 * Z)),
         (X[:-1], X[-1], None, tuple(zip(-X[:-1], -2 * X[:-1])), (-X[-1], -2 * X[-1]), (Z, 2 * Z)),
         (X[:-1], X[-1], 4, (-X[:-1], -2 * X[:-1]), (-X[-1], -2 * X[-1]), (Z, 2 * Z)),
-        (np.ones(0), w, None, (), (-w, -2 * w), (Z, 2 * Z)),
-        (np.ones(0), w, 4, (), (-w, -2 * w), (Z, 2 * Z)),
+        (pnp.ones(0), w, None, (), (-w, -2 * w), (Z, 2 * Z)),
+        (pnp.ones(0), w, 4, (), (-w, -2 * w), (Z, 2 * Z)),
         # Expval and Probability
         (X, None, None, tuple(zip(-X, -2 * P)), None, (Z, 2 * p * Z)),
         (X, None, 4, (-X, -2 * P), None, (Z, 2 * p * Z)),
         (X[:-1], X[-1], None, tuple(zip(-X, -2 * P))[:-1], (-X[-1], -2 * P[-1]), (Z, 2 * p * Z)),
         (X[:-1], X[-1], 4, (-X[:-1], -2 * P[:-1]), (-X[-1], -2 * P[-1]), (Z, 2 * p * Z)),
-        (np.ones(0), w, None, (), (-w, -2 * v), (Z, 2 * p * Z)),
-        (np.ones(0), w, 4, (), (-w, -2 * v), (Z, 2 * p * Z)),
+        (pnp.ones(0), w, None, (), (-w, -2 * v), (Z, 2 * p * Z)),
+        (pnp.ones(0), w, 4, (), (-w, -2 * v), (Z, 2 * p * Z)),
         # Probabilities
         (X, None, None, tuple(zip(-P2, -2 * P)), None, exp_probs),
         (X, None, 4, (-P2, -2 * P), None, exp_probs),
         (X[:-1], X[-1], None, tuple(zip(-P2, -2 * P))[:-1], (-P2[-1], -2 * P[-1]), exp_probs),
         (X[:-1], X[-1], 4, (-P2[:-1], -2 * P[:-1]), (-P2[-1], -2 * P[-1]), exp_probs),
-        (np.ones(0), w, None, (), (-v2, -2 * v), exp_probs),
-        (np.ones(0), w, 4, (), (-v2, -2 * v), exp_probs),
+        (pnp.ones(0), w, None, (), (-v2, -2 * v), exp_probs),
+        (pnp.ones(0), w, 4, (), (-v2, -2 * v), exp_probs),
     ]
 
     @pytest.mark.parametrize(
@@ -134,29 +134,29 @@ class TestEvaluateGradient:
 
         assert isinstance(grad, tuple) and len(grad) == 2
         for g, e in zip(grad, expected):
-            assert isinstance(g, np.ndarray) and g.shape == e.shape
-            assert np.allclose(g, e)
+            assert isinstance(g, pnp.ndarray) and g.shape == e.shape
+            assert pnp.allclose(g, e)
 
     shot_vec_X = tuple(zip(*(-c * X for c in shv)))
     shot_vec_P = tuple(zip(*(-c * P for c in shv)))
     shot_vec_P_partial = tuple(-c * P[:-1] for c in shv)
 
-    exp_shot_vec_prob = np.outer(shv, p) * Z
+    exp_shot_vec_prob = pnp.outer(shv, p) * Z
     test_cases_multi_shots_single_meas = [
         # Expectation value
         (X, None, None, shot_vec_X, None, shv * Z),
         (X, None, 4, tuple(-c * X for c in shv), None, shv * Z),
         (X[:-1], X[-1], None, shot_vec_X[:-1], shot_vec_X[-1], shv * Z),
         (X[:-1], X[-1], 4, tuple(-c * X[:-1] for c in shv), tuple(-shv * X[-1]), shv * Z),
-        (np.ones(0), w, None, (), tuple(-c * w for c in shv), shv * Z),
-        (np.ones(0), w, 4, ((), (), ()), tuple(-c * w for c in shv), shv * Z),
+        (pnp.ones(0), w, None, (), tuple(-c * w for c in shv), shv * Z),
+        (pnp.ones(0), w, 4, ((), (), ()), tuple(-c * w for c in shv), shv * Z),
         # Probability
         (X, None, None, shot_vec_P, None, exp_shot_vec_prob),
         (X, None, 4, tuple(-c * P for c in shv), None, exp_shot_vec_prob),
         (X[:-1], X[-1], None, shot_vec_P[:-1], shot_vec_P[-1], exp_shot_vec_prob),
-        (X[:-1], X[-1], 4, shot_vec_P_partial, tuple(np.outer(-shv, P[-1])), exp_shot_vec_prob),
-        (np.ones(0), w, None, (), tuple(-c * v for c in shv), exp_shot_vec_prob),
-        (np.ones(0), w, 4, ((), (), ()), tuple(-c * v for c in shv), exp_shot_vec_prob),
+        (X[:-1], X[-1], 4, shot_vec_P_partial, tuple(pnp.outer(-shv, P[-1])), exp_shot_vec_prob),
+        (pnp.ones(0), w, None, (), tuple(-c * v for c in shv), exp_shot_vec_prob),
+        (pnp.ones(0), w, 4, ((), (), ()), tuple(-c * v for c in shv), exp_shot_vec_prob),
     ]
 
     @pytest.mark.parametrize(
@@ -173,8 +173,8 @@ class TestEvaluateGradient:
 
         assert isinstance(grad, tuple) and len(grad) == 3
         for g, e in zip(grad, expected):
-            assert isinstance(g, np.ndarray) and g.shape == e.shape
-            assert np.allclose(g, e)
+            assert isinstance(g, pnp.ndarray) and g.shape == e.shape
+            assert pnp.allclose(g, e)
 
     multi_X = tuple(tuple((-c * x, -2 * c * x) for c in shv) for x in X)
     batched_multi_X = tuple((-c * X, -2 * c * X) for c in shv)
@@ -199,22 +199,22 @@ class TestEvaluateGradient:
         (X, None, 4, batched_multi_X, None, shv_m * Z),
         (X[:-1], X[-1], None, multi_X[:-1], multi_X[-1], shv_m * Z),
         (X[:-1], X[-1], 4, partial_multi_X, multi_X[-1], shv_m * Z),
-        (np.ones(0), w, None, (), expvals_r0, shv_m * Z),
-        (np.ones(0), w, 4, ((), (), ()), expvals_r0, shv_m * Z),
+        (pnp.ones(0), w, None, (), expvals_r0, shv_m * Z),
+        (pnp.ones(0), w, 4, ((), (), ()), expvals_r0, shv_m * Z),
         # Probability and expectation
         (X, None, None, multi_X_P, None, exp_shot_vec_prob_expval),
         (X, None, 4, batched_multi_X_P, None, exp_shot_vec_prob_expval),
         (X[:-1], X[-1], None, multi_X_P[:-1], multi_X_P[-1], exp_shot_vec_prob_expval),
         (X[:-1], X[-1], 4, partial_multi_X_P, multi_X_P[-1], exp_shot_vec_prob_expval),
-        (np.ones(0), w, None, (), prob_expval_r0, exp_shot_vec_prob_expval),
-        (np.ones(0), w, 4, ((), (), ()), prob_expval_r0, exp_shot_vec_prob_expval),
+        (pnp.ones(0), w, None, (), prob_expval_r0, exp_shot_vec_prob_expval),
+        (pnp.ones(0), w, 4, ((), (), ()), prob_expval_r0, exp_shot_vec_prob_expval),
         # Probabilities
         (X, None, None, multi_P_P, None, exp_shot_vec_probs),
         (X, None, 4, batched_multi_P_P, None, exp_shot_vec_probs),
         (X[:-1], X[-1], None, multi_P_P[:-1], multi_P_P[-1], exp_shot_vec_probs),
         (X[:-1], X[-1], 4, partial_multi_P_P, multi_P_P[-1], exp_shot_vec_probs),
-        (np.ones(0), w, None, (), probs_r0, exp_shot_vec_probs),
-        (np.ones(0), w, 4, ((), (), ()), probs_r0, exp_shot_vec_probs),
+        (pnp.ones(0), w, None, (), probs_r0, exp_shot_vec_probs),
+        (pnp.ones(0), w, 4, ((), (), ()), probs_r0, exp_shot_vec_probs),
     ]
 
     @pytest.mark.parametrize(
@@ -233,8 +233,8 @@ class TestEvaluateGradient:
         for g, e in zip(grad, expected):
             assert isinstance(g, tuple) and len(g) == 2
             for _g, _e in zip(g, e):
-                assert isinstance(_g, np.ndarray) and _g.shape == _e.shape
-                assert np.allclose(_g, _e)
+                assert isinstance(_g, pnp.ndarray) and _g.shape == _e.shape
+                assert pnp.allclose(_g, _e)
 
 
 # pylint: disable=too-few-public-methods
@@ -260,7 +260,7 @@ class RX_par_dep_recipe(qml.RX):
         """The gradient is given by [f(2x) - f(0)] / (2 sin(x)), by subsituting
         shift = x into the two term parameter-shift rule."""
         x = self.data[0]
-        c = 0.5 / np.sin(x)
+        c = 0.5 / pnp.sin(x)
         return ([[c, 0.0, 2 * x], [-c, 0.0, 0.0]],)
 
 
@@ -272,7 +272,7 @@ class TestGetOperationRecipe:
         "orig_op, frequencies, shifts",
         [
             (qml.RX, (1.0,), None),
-            (qml.RX, (1.0,), (np.pi / 2,)),
+            (qml.RX, (1.0,), (pnp.pi / 2,)),
             (qml.CRY, (0.5, 1), None),
             (qml.CRY, (0.5, 1), (0.4, 0.8)),
             (qml.TRX, (0.5, 1), None),
@@ -282,7 +282,7 @@ class TestGetOperationRecipe:
     def test_custom_recipe_first_order(self, orig_op, frequencies, shifts):
         """Test that a custom recipe is returned correctly for first-order derivatives."""
         c, s = qml.gradients.generate_shift_rule(frequencies, shifts=shifts).T
-        recipe = list(zip(c, np.ones_like(c), s))
+        recipe = list(zip(c, pnp.ones_like(c), s))
 
         # pylint: disable=too-few-public-methods
         class DummyOp(orig_op):
@@ -296,20 +296,20 @@ class TestGetOperationRecipe:
         tape = qml.tape.QuantumScript.from_queue(q)
         out_recipe = _get_operation_recipe(tape, 0, shifts=shifts, order=1)
         assert qml.math.allclose(out_recipe[:, 0], c)
-        assert qml.math.allclose(out_recipe[:, 1], np.ones_like(c))
+        assert qml.math.allclose(out_recipe[:, 1], pnp.ones_like(c))
 
         if shifts is None:
             assert qml.math.allclose(out_recipe[:, 2], s)
         else:
             exp_out_shifts = [-s for s in shifts[::-1]] + list(shifts)
-            assert qml.math.allclose(np.sort(s), exp_out_shifts)
-            assert qml.math.allclose(np.sort(out_recipe[:, 2]), np.sort(exp_out_shifts))
+            assert qml.math.allclose(pnp.sort(s), exp_out_shifts)
+            assert qml.math.allclose(pnp.sort(out_recipe[:, 2]), pnp.sort(exp_out_shifts))
 
     def test_qnode_custom_recipe(self):
         """Test a custom recipe using a QNode."""
         dev = qml.device("default.qubit", wires=2)
 
-        x = np.array(0.4, requires_grad=True)
+        x = pnp.array(0.4, requires_grad=True)
         with qml.queuing.AnnotatedQueue() as q:
             qml.RX(x, 0)
             qml.expval(qml.PauliZ(0))
@@ -329,7 +329,7 @@ class TestGetOperationRecipe:
         "orig_op, frequencies, shifts",
         [
             (qml.RX, (1.0,), None),
-            (qml.RX, (1.0,), (np.pi / 2,)),
+            (qml.RX, (1.0,), (pnp.pi / 2,)),
             (qml.CRY, (0.5, 1), None),
             (qml.CRY, (0.5, 1), (0.4, 0.8)),
             (qml.TRX, (0.5, 1), None),
@@ -339,7 +339,7 @@ class TestGetOperationRecipe:
     def test_custom_recipe_second_order(self, orig_op, frequencies, shifts):
         """Test that a custom recipe is returned correctly for second-order derivatives."""
         c, s = qml.gradients.generate_shift_rule(frequencies, shifts=shifts).T
-        recipe = list(zip(c, np.ones_like(c), s))
+        recipe = list(zip(c, pnp.ones_like(c), s))
 
         # pylint: disable=too-few-public-methods
         class DummyOp(orig_op):
@@ -354,7 +354,7 @@ class TestGetOperationRecipe:
         out_recipe = _get_operation_recipe(tape, 0, shifts=shifts, order=2)
         c2, s2 = qml.gradients.generate_shift_rule(frequencies, shifts=shifts, order=2).T
         assert qml.math.allclose(out_recipe[:, 0], c2)
-        assert qml.math.allclose(out_recipe[:, 1], np.ones_like(c2))
+        assert qml.math.allclose(out_recipe[:, 1], pnp.ones_like(c2))
         assert qml.math.allclose(out_recipe[:, 2], s2)
 
     @pytest.mark.parametrize("order", [0, 3])
@@ -373,32 +373,32 @@ class TestMakeZeroRep:
     """Test that producing a zero-gradient representative with ``_make_zero_rep`` works."""
 
     # mimic an expectation value or variance, and a probs vector
-    @pytest.mark.parametrize("g", [np.array(0.6), np.array([0.6, 0.9])])
+    @pytest.mark.parametrize("g", [pnp.array(0.6), pnp.array([0.6, 0.9])])
     def test_single_measure_no_partitioned_shots(self, g):
         """Test the zero-gradient representative with a single measurement and single shots."""
         rep = _make_zero_rep(g, single_measure=True, has_partitioned_shots=False)
-        assert isinstance(rep, np.ndarray) and rep.shape == g.shape
+        assert isinstance(rep, pnp.ndarray) and rep.shape == g.shape
         assert qml.math.allclose(rep, 0.0)
 
     # mimic an expectation value or variance, and a probs vector
     @pytest.mark.parametrize(
-        "g", [(np.array(0.6), np.array(0.4)) * 3, (np.array([0.3, 0.1]), np.array([0.6, 0.9]))]
+        "g", [(pnp.array(0.6), pnp.array(0.4)) * 3, (pnp.array([0.3, 0.1]), pnp.array([0.6, 0.9]))]
     )
     def test_single_measure_partitioned_shots(self, g):
         """Test the zero-gradient representative with a single measurement and a shot vector."""
         rep = _make_zero_rep(g, single_measure=True, has_partitioned_shots=True)
         assert isinstance(rep, tuple) and len(rep) == len(g)
         for r, _g in zip(rep, g):
-            assert isinstance(r, np.ndarray) and r.shape == _g.shape
+            assert isinstance(r, pnp.ndarray) and r.shape == _g.shape
             assert qml.math.allclose(r, 0.0)
 
     # mimic an expectation value, a probs vector, or a mixture of them
     @pytest.mark.parametrize(
         "g",
         [
-            (np.array(0.6), np.array(0.4)) * 3,
-            (np.array([0.3, 0.1]), np.array([0.6, 0.9])),
-            (np.array(0.5), np.ones(4), np.array(0.2)),
+            (pnp.array(0.6), pnp.array(0.4)) * 3,
+            (pnp.array([0.3, 0.1]), pnp.array([0.6, 0.9])),
+            (pnp.array(0.5), pnp.ones(4), pnp.array(0.2)),
         ],
     )
     def test_multi_measure_no_partitioned_shots(self, g):
@@ -407,16 +407,16 @@ class TestMakeZeroRep:
 
         assert isinstance(rep, tuple) and len(rep) == len(g)
         for r, _g in zip(rep, g):
-            assert isinstance(r, np.ndarray) and r.shape == _g.shape
+            assert isinstance(r, pnp.ndarray) and r.shape == _g.shape
             assert qml.math.allclose(r, 0.0)
 
     # mimic an expectation value, a probs vector, or a mixture of them
     @pytest.mark.parametrize(
         "g",
         [
-            ((np.array(0.6), np.array(0.4)),) * 3,
-            ((np.array([0.3, 0.1]), np.array([0.6, 0.9])),) * 2,
-            ((np.array(0.5), np.ones(4), np.array(0.2)),) * 4,
+            ((pnp.array(0.6), pnp.array(0.4)),) * 3,
+            ((pnp.array([0.3, 0.1]), pnp.array([0.6, 0.9])),) * 2,
+            ((pnp.array(0.5), pnp.ones(4), pnp.array(0.2)),) * 4,
         ],
     )
     def test_multi_measure_partitioned_shots(self, g):
@@ -427,12 +427,12 @@ class TestMakeZeroRep:
         for _rep, _g in zip(rep, g):
             assert isinstance(_rep, tuple) and len(_rep) == len(_g)
             for r, __g in zip(_rep, _g):
-                assert isinstance(r, np.ndarray) and r.shape == __g.shape
+                assert isinstance(r, pnp.ndarray) and r.shape == __g.shape
                 assert qml.math.allclose(r, 0.0)
 
     # mimic an expectation value or variance, and a probs vector, but with 1d arguments
     @pytest.mark.parametrize(
-        "g", [np.array([0.6, 0.2, 0.1]), np.outer([0.4, 0.2, 0.1], [0.6, 0.9])]
+        "g", [pnp.array([0.6, 0.2, 0.1]), pnp.outer([0.4, 0.2, 0.1], [0.6, 0.9])]
     )
     @pytest.mark.parametrize(
         "par_shapes", [((), ()), ((), (2,)), ((), (3, 1)), ((3,), ()), ((3,), (3,)), ((3,), (4, 5))]
@@ -445,12 +445,12 @@ class TestMakeZeroRep:
         rep = _make_zero_rep(
             g, single_measure=True, has_partitioned_shots=False, par_shapes=par_shapes
         )
-        assert isinstance(rep, np.ndarray) and rep.shape == exp_shape
+        assert isinstance(rep, pnp.ndarray) and rep.shape == exp_shape
         assert qml.math.allclose(rep, 0.0)
 
     # mimic an expectation value or variance, and a probs vector, but with 1d arguments
     @pytest.mark.parametrize(
-        "g", [(np.array(0.6), np.array(0.4)) * 3, (np.array([0.3, 0.1]), np.array([0.6, 0.9]))]
+        "g", [(pnp.array(0.6), pnp.array(0.4)) * 3, (pnp.array([0.3, 0.1]), pnp.array([0.6, 0.9]))]
     )
     @pytest.mark.parametrize(
         "par_shapes", [((), ()), ((), (2,)), ((), (3, 1)), ((3,), ()), ((3,), (3,)), ((3,), (4, 5))]
@@ -465,16 +465,16 @@ class TestMakeZeroRep:
         assert isinstance(rep, tuple) and len(rep) == len(g)
         for r, _g in zip(rep, g):
             exp_shape = new_shape + _g.shape[len(old_shape) :]
-            assert isinstance(r, np.ndarray) and r.shape == exp_shape
+            assert isinstance(r, pnp.ndarray) and r.shape == exp_shape
             assert qml.math.allclose(r, 0.0)
 
     # mimic an expectation value, a probs vector, or a mixture of them, but with 1d arguments
     @pytest.mark.parametrize(
         "g",
         [
-            (np.array(0.6), np.array(0.4)) * 3,
-            (np.array([0.3, 0.1]), np.array([0.6, 0.9])),
-            (np.array(0.5), np.ones(4), np.array(0.2)),
+            (pnp.array(0.6), pnp.array(0.4)) * 3,
+            (pnp.array([0.3, 0.1]), pnp.array([0.6, 0.9])),
+            (pnp.array(0.5), pnp.ones(4), pnp.array(0.2)),
         ],
     )
     @pytest.mark.parametrize(
@@ -491,16 +491,16 @@ class TestMakeZeroRep:
         assert isinstance(rep, tuple) and len(rep) == len(g)
         for r, _g in zip(rep, g):
             exp_shape = new_shape + _g.shape[len(old_shape) :]
-            assert isinstance(r, np.ndarray) and r.shape == exp_shape
+            assert isinstance(r, pnp.ndarray) and r.shape == exp_shape
             assert qml.math.allclose(r, 0.0)
 
     # mimic an expectation value, a probs vector, or a mixture of them, but with 1d arguments
     @pytest.mark.parametrize(
         "g",
         [
-            ((np.array(0.6), np.array(0.4)),) * 3,
-            ((np.array([0.3, 0.1]), np.array([0.6, 0.9])),) * 2,
-            ((np.array(0.5), np.ones(4), np.array(0.2)),) * 4,
+            ((pnp.array(0.6), pnp.array(0.4)),) * 3,
+            ((pnp.array([0.3, 0.1]), pnp.array([0.6, 0.9])),) * 2,
+            ((pnp.array(0.5), pnp.ones(4), pnp.array(0.2)),) * 4,
         ],
     )
     @pytest.mark.parametrize(
@@ -519,7 +519,7 @@ class TestMakeZeroRep:
             assert isinstance(_rep, tuple) and len(_rep) == len(_g)
             for r, __g in zip(_rep, _g):
                 exp_shape = new_shape + __g.shape[len(old_shape) :]
-                assert isinstance(r, np.ndarray) and r.shape == exp_shape
+                assert isinstance(r, pnp.ndarray) and r.shape == exp_shape
                 assert qml.math.allclose(r, 0.0)
 
 
@@ -561,8 +561,8 @@ class TestParamShift:
 
         batch, _ = qml.gradients.param_shift(tape)
         assert len(batch) == 2
-        tape0 = qml.tape.QuantumScript((qml.RX(0.5 + np.pi / 2, 0),), ms, trainable_params=[0])
-        tape1 = qml.tape.QuantumScript((qml.RX(0.5 - np.pi / 2, 0),), ms, trainable_params=[0])
+        tape0 = qml.tape.QuantumScript((qml.RX(0.5 + pnp.pi / 2, 0),), ms, trainable_params=[0])
+        tape1 = qml.tape.QuantumScript((qml.RX(0.5 - pnp.pi / 2, 0),), ms, trainable_params=[0])
         qml.assert_equal(batch[0], tape0)
         qml.assert_equal(batch[1], tape1)
 
@@ -625,7 +625,7 @@ class TestParamShift:
         res = post_processing(qml.execute(g_tapes, dev, None))
 
         assert g_tapes == []
-        assert isinstance(res, np.ndarray)
+        assert isinstance(res, pnp.ndarray)
         assert res.shape == (0,)
 
     def test_no_trainable_params_multiple_return_tape(self):
@@ -649,7 +649,7 @@ class TestParamShift:
         assert g_tapes == []
         assert isinstance(res, tuple)
         for r in res:
-            assert isinstance(r, np.ndarray)
+            assert isinstance(r, pnp.ndarray)
             assert r.shape == (0,)
 
     def test_all_zero_diff_methods_tape(self):
@@ -657,7 +657,7 @@ class TestParamShift:
         identified to be 0, and that no tapes were generated."""
         dev = qml.device("default.qubit", wires=4)
 
-        params = np.array([0.5, 0.5, 0.5], requires_grad=True)
+        params = pnp.array([0.5, 0.5, 0.5], requires_grad=True)
 
         with qml.queuing.AnnotatedQueue() as q:
             qml.Rot(*params, wires=0)
@@ -673,17 +673,17 @@ class TestParamShift:
 
         assert len(result) == 3
 
-        assert isinstance(result[0], np.ndarray)
+        assert isinstance(result[0], pnp.ndarray)
         assert result[0].shape == (4,)
-        assert np.allclose(result[0], 0)
+        assert pnp.allclose(result[0], 0)
 
-        assert isinstance(result[1], np.ndarray)
+        assert isinstance(result[1], pnp.ndarray)
         assert result[1].shape == (4,)
-        assert np.allclose(result[1], 0)
+        assert pnp.allclose(result[1], 0)
 
-        assert isinstance(result[2], np.ndarray)
+        assert isinstance(result[2], pnp.ndarray)
         assert result[2].shape == (4,)
-        assert np.allclose(result[2], 0)
+        assert pnp.allclose(result[2], 0)
 
     def test_all_zero_diff_methods_multiple_returns_tape(self):
         """Test that the transform works correctly when the diff method for every parameter is
@@ -691,7 +691,7 @@ class TestParamShift:
 
         dev = qml.device("default.qubit", wires=4)
 
-        params = np.array([0.5, 0.5, 0.5], requires_grad=True)
+        params = pnp.array([0.5, 0.5, 0.5], requires_grad=True)
 
         with qml.queuing.AnnotatedQueue() as q:
             qml.Rot(*params, wires=0)
@@ -711,32 +711,32 @@ class TestParamShift:
         # First elem
         assert len(result[0]) == 3
 
-        assert isinstance(result[0][0], np.ndarray)
+        assert isinstance(result[0][0], pnp.ndarray)
         assert result[0][0].shape == ()
-        assert np.allclose(result[0][0], 0)
+        assert pnp.allclose(result[0][0], 0)
 
-        assert isinstance(result[0][1], np.ndarray)
+        assert isinstance(result[0][1], pnp.ndarray)
         assert result[0][1].shape == ()
-        assert np.allclose(result[0][1], 0)
+        assert pnp.allclose(result[0][1], 0)
 
-        assert isinstance(result[0][2], np.ndarray)
+        assert isinstance(result[0][2], pnp.ndarray)
         assert result[0][2].shape == ()
-        assert np.allclose(result[0][2], 0)
+        assert pnp.allclose(result[0][2], 0)
 
         # Second elem
         assert len(result[0]) == 3
 
-        assert isinstance(result[1][0], np.ndarray)
+        assert isinstance(result[1][0], pnp.ndarray)
         assert result[1][0].shape == (4,)
-        assert np.allclose(result[1][0], 0)
+        assert pnp.allclose(result[1][0], 0)
 
-        assert isinstance(result[1][1], np.ndarray)
+        assert isinstance(result[1][1], pnp.ndarray)
         assert result[1][1].shape == (4,)
-        assert np.allclose(result[1][1], 0)
+        assert pnp.allclose(result[1][1], 0)
 
-        assert isinstance(result[1][2], np.ndarray)
+        assert isinstance(result[1][2], pnp.ndarray)
         assert result[1][2].shape == (4,)
-        assert np.allclose(result[1][2], 0)
+        assert pnp.allclose(result[1][2], 0)
 
         tapes, _ = qml.gradients.param_shift(tape)
         assert tapes == []
@@ -752,10 +752,10 @@ class TestParamShift:
             qml.Rot(*params, wires=0)
             return qml.probs([2, 3])
 
-        params = np.array([0.5, 0.5, 0.5], requires_grad=True)
+        params = pnp.array([0.5, 0.5, 0.5], requires_grad=True)
 
         result = qml.gradients.param_shift(circuit)(params)
-        assert np.allclose(result, np.zeros((4, 3)), atol=0)
+        assert pnp.allclose(result, pnp.zeros((4, 3)), atol=0)
 
         tape = qml.workflow.construct_tape(circuit)(params)
         tapes, _ = qml.gradients.param_shift(tape, broadcast=broadcast)
@@ -783,13 +783,13 @@ class TestParamShift:
 
             shifted_batch = [0.2 * 1.0 + 0.3, 0.5 * 1.0 + 0.6]
             tape_par = tapes[0].get_parameters(trainable_only=False)
-            assert np.allclose(tape_par[0], shifted_batch)
+            assert pnp.allclose(tape_par[0], shifted_batch)
             assert tape_par[1:] == [2.0, 3.0, 4.0]
 
             shifted_batch = [1 * 3.0 + 1, 2 * 3.0 + 2, 3 * 3.0 + 3]
             tape_par = tapes[1].get_parameters(trainable_only=False)
             assert tape_par[:2] == [1.0, 2.0]
-            assert np.allclose(tape_par[2], shifted_batch)
+            assert pnp.allclose(tape_par[2], shifted_batch)
             assert tape_par[3:] == [4.0]
         else:
             assert len(tapes) == 5
@@ -830,7 +830,7 @@ class TestParamShift:
         assert len(tapes) == tapes_per_param * num_ops_standard_recipe + num_custom + 1
         # Test that executing the tapes and the postprocessing function works
         grad = fn(qml.execute(tapes, dev, None))
-        assert qml.math.allclose(grad, -np.sin(x[0] + x[1]), atol=1e-5)
+        assert qml.math.allclose(grad, -pnp.sin(x[0] + x[1]), atol=1e-5)
 
     @pytest.mark.parametrize("broadcast", [False, True])
     @pytest.mark.parametrize("ops_with_custom_recipe", [[0], [1], [0, 1]])
@@ -865,13 +865,13 @@ class TestParamShift:
         # Test that executing the tapes and the postprocessing function works
         grad = fn(qml.execute(tapes, dev, None))
         if multi_measure:
-            expected = np.array([[-np.sin(x[0] + x[1])] * 2, [0, 0]])
+            expected = pnp.array([[-pnp.sin(x[0] + x[1])] * 2, [0, 0]])
             # The custom recipe estimates gradients to be 0
             for i in ops_with_custom_recipe:
                 expected[0, i] = 0
         else:
             expected = [
-                -np.sin(x[0] + x[1]) if i not in ops_with_custom_recipe else 0 for i in range(2)
+                -pnp.sin(x[0] + x[1]) if i not in ops_with_custom_recipe else 0 for i in range(2)
             ]
         assert qml.math.allclose(grad, expected, atol=1e-5)
 
@@ -905,7 +905,7 @@ class TestParamShift:
 
         # Test that executing the tapes and the postprocessing function works
         grad = fn(qml.execute(tapes, dev, None))
-        assert qml.math.allclose(grad[0], -np.sin(x[0] + x[1]), atol=1e-5)
+        assert qml.math.allclose(grad[0], -pnp.sin(x[0] + x[1]), atol=1e-5)
         assert qml.math.allclose(grad[1], 0, atol=1e-5)
 
     @pytest.mark.parametrize("broadcast", [True, False])
@@ -936,7 +936,7 @@ class TestParamShift:
         its instantiated parameter values works correctly within the parameter
         shift rule. Also tests that grad_recipes supersedes paramter_frequencies.
         """
-        s = np.pi / 2
+        s = pnp.pi / 2
 
         # pylint: disable=too-few-public-methods
         class RX(qml.RX):
@@ -947,7 +947,7 @@ class TestParamShift:
 
             grad_recipe = ([[0.5, 1, s], [-0.5, 1, -s], [0.2, 1, 0]],)
 
-        x = np.array([-0.361, 0.654], requires_grad=True)
+        x = pnp.array([-0.361, 0.654], requires_grad=True)
         dev = qml.device("default.qubit", wires=2)
 
         with qml.queuing.AnnotatedQueue() as q:
@@ -967,13 +967,13 @@ class TestParamShift:
             assert tape.operations[1].data[0] == x[1] + expected[1]
 
         grad = fn(dev.execute(tapes))
-        exp = np.stack([-np.sin(x[0] + x[1]), -np.sin(x[0] + x[1]) + 0.2 * np.cos(x[0] + x[1])])
+        exp = pnp.stack([-pnp.sin(x[0] + x[1]), -pnp.sin(x[0] + x[1]) + 0.2 * pnp.cos(x[0] + x[1])])
         assert len(grad) == len(exp)
         for (
             a,
             b,
         ) in zip(grad, exp):
-            assert np.allclose(a, b)
+            assert pnp.allclose(a, b)
 
     def test_independent_parameters_analytic(self):
         """Test the case where expectation values are independent of some parameters. For those
@@ -1004,12 +1004,12 @@ class TestParamShift:
         tapes, fn = qml.gradients.param_shift(tape2)
         j2 = fn(dev.execute(tapes))
 
-        exp = -np.sin(1)
+        exp = -pnp.sin(1)
 
-        assert np.allclose(j1[0], exp)
-        assert np.allclose(j1[1], 0)
-        assert np.allclose(j2[0], 0)
-        assert np.allclose(j2[1], exp)
+        assert pnp.allclose(j1[0], exp)
+        assert pnp.allclose(j1[1], 0)
+        assert pnp.allclose(j2[0], 0)
+        assert pnp.allclose(j2[1], exp)
 
     def test_grad_recipe_parameter_dependent(self):
         """Test that an operation with a gradient recipe that depends on
@@ -1017,7 +1017,7 @@ class TestParamShift:
         shift rule. Also tests that `grad_recipe` supersedes `parameter_frequencies`.
         """
 
-        x = np.array(0.654, requires_grad=True)
+        x = pnp.array(0.654, requires_grad=True)
         dev = qml.device("default.qubit", wires=2)
 
         with qml.queuing.AnnotatedQueue() as q:
@@ -1033,7 +1033,7 @@ class TestParamShift:
         assert qml.math.allclose(tapes[1].operations[0].data[0], 2 * x)
 
         grad = fn(dev.execute(tapes))
-        assert np.allclose(grad, -np.sin(x))
+        assert pnp.allclose(grad, -pnp.sin(x))
 
     def test_error_no_diff_info(self):
         """Test that an error is raised if no grad_recipe, no parameter_frequencies
@@ -1058,7 +1058,7 @@ class TestParamShift:
             grad_method = "A"
             num_wires = 1
 
-        x = np.array(0.654, requires_grad=True)
+        x = pnp.array(0.654, requires_grad=True)
         for op in [RX, NewOp]:
             with qml.queuing.AnnotatedQueue() as q:
                 op(x, wires=0)
@@ -1098,7 +1098,7 @@ class TestParamShiftWithBroadcasted:
     def test_with_single_trainable_parameter_broadcasted(self, dim, pos):
         """Test that the parameter-shift transform works with a tape that has
         one of its parameters broadcasted already."""
-        x = np.array([0.23, 9.1, 2.3])
+        x = pnp.array([0.23, 9.1, 2.3])
         x = x[:dim]
         y = -0.654
         if pos == 1:
@@ -1113,7 +1113,7 @@ class TestParamShiftWithBroadcasted:
         assert tape.batch_size == dim
         tapes, fn = qml.gradients.param_shift(tape, argnum=[0, 1])
         assert len(tapes) == 4
-        assert np.allclose([t.batch_size for t in tapes], dim)
+        assert pnp.allclose([t.batch_size for t in tapes], dim)
 
         dev = qml.device("default.qubit", wires=2)
         res = fn(dev.execute(tapes))
@@ -1131,7 +1131,7 @@ class TestParamShiftWithBroadcasted:
     def test_with_multiple_parameters_broadcasted(self, dim, argnum):
         """Test that the parameter-shift transform works with a tape that has
         multiple of its parameters broadcasted already."""
-        x, y = np.array([[0.23, 9.1, 2.3], [0.2, 1.2, -0.6]])[:, :dim]
+        x, y = pnp.array([[0.23, 9.1, 2.3], [0.2, 1.2, -0.6]])[:, :dim]
         z = -0.654
 
         with qml.queuing.AnnotatedQueue() as q:
@@ -1144,7 +1144,7 @@ class TestParamShiftWithBroadcasted:
         assert tape.batch_size == dim
         tapes, fn = qml.gradients.param_shift(tape, argnum=argnum)
         assert len(tapes) == 2 * len(argnum)
-        assert np.allclose([t.batch_size for t in tapes], dim)
+        assert pnp.allclose([t.batch_size for t in tapes], dim)
 
         dev = qml.device("default.qubit", wires=2)
         res = fn(dev.execute(tapes))
@@ -1158,7 +1158,7 @@ class TestParamShiftWithBroadcasted:
     def test_with_single_nontrainable_parameter_broadcasted(self, dim, pos):
         """Test that the parameter-shift transform works with a tape that has
         one of its nontrainable parameters broadcasted."""
-        x = np.array([0.23, 9.1, 2.3])
+        x = pnp.array([0.23, 9.1, 2.3])
         x = x[:dim]
         y = -0.654
         if pos == 1:
@@ -1174,7 +1174,7 @@ class TestParamShiftWithBroadcasted:
         assert tape.batch_size == dim
         tapes, fn = qml.gradients.param_shift(tape, argnum=[0])
         assert len(tapes) == 2
-        assert np.allclose([t.batch_size for t in tapes], dim)
+        assert pnp.allclose([t.batch_size for t in tapes], dim)
 
         dev = qml.device("default.qubit", wires=2)
         res = fn(dev.execute(tapes))
@@ -1291,12 +1291,12 @@ class TestParamShiftUsingBroadcasting:
         tapes, fn = qml.gradients.param_shift(tape2, broadcast=True)
         j2 = fn(dev.execute(tapes))
 
-        exp = -np.sin(1)
+        exp = -pnp.sin(1)
 
-        assert np.allclose(j1[0], exp)
-        assert np.allclose(j1[1], 0)
-        assert np.allclose(j2[0], 0)
-        assert np.allclose(j2[1], exp)
+        assert pnp.allclose(j1[0], exp)
+        assert pnp.allclose(j1[1], 0)
+        assert pnp.allclose(j2[0], 0)
+        assert pnp.allclose(j2[1], exp)
 
     def test_grad_recipe_parameter_dependent(self, monkeypatch):
         """Test that an operation with a gradient recipe that depends on
@@ -1309,7 +1309,7 @@ class TestParamShiftUsingBroadcasting:
 
         monkeypatch.setattr(qml.RX, "parameter_frequencies", fail)
 
-        x = np.array(0.654, requires_grad=True)
+        x = pnp.array(0.654, requires_grad=True)
         dev = qml.device("default.qubit", wires=2)
 
         with qml.queuing.AnnotatedQueue() as q:
@@ -1324,7 +1324,7 @@ class TestParamShiftUsingBroadcasting:
         assert qml.math.allclose(tapes[0].operations[0].data[0], [0, 2 * x])
 
         grad = fn(dev.execute(tapes))
-        assert np.allclose(grad, -np.sin(x))
+        assert pnp.allclose(grad, -pnp.sin(x))
 
 
 # The first of the pylint disable is for cost1 through cost6
@@ -1334,8 +1334,8 @@ class TestParameterShiftRule:
     """Tests for the parameter shift implementation"""
 
     # pylint: disable=too-many-arguments
-    @pytest.mark.parametrize("theta", np.linspace(-2 * np.pi, 2 * np.pi, 7))
-    @pytest.mark.parametrize("shift", [np.pi / 2, 0.3, np.sqrt(2)])
+    @pytest.mark.parametrize("theta", pnp.linspace(-2 * pnp.pi, 2 * pnp.pi, 7))
+    @pytest.mark.parametrize("shift", [pnp.pi / 2, 0.3, pnp.sqrt(2)])
     @pytest.mark.parametrize("G", [qml.RX, qml.RY, qml.RZ, qml.PhaseShift])
     def test_pauli_rotation_gradient(self, mocker, G, theta, shift, tol):
         """Tests that the automatic gradients of Pauli rotations are correct."""
@@ -1344,7 +1344,7 @@ class TestParameterShiftRule:
         dev = qml.device("default.qubit", wires=1)
 
         with qml.queuing.AnnotatedQueue() as q:
-            qml.StatePrep(np.array([1.0, -1.0], requires_grad=False) / np.sqrt(2), wires=0)
+            qml.StatePrep(pnp.array([1.0, -1.0], requires_grad=False) / pnp.sqrt(2), wires=0)
             G(theta, wires=[0])
             qml.expval(qml.PauliZ(0))
 
@@ -1356,31 +1356,31 @@ class TestParameterShiftRule:
 
         autograd_val = fn(dev.execute(tapes))
 
-        tape_fwd = tape.bind_new_parameters([theta + np.pi / 2], [1])
-        tape_bwd = tape.bind_new_parameters([theta - np.pi / 2], [1])
+        tape_fwd = tape.bind_new_parameters([theta + pnp.pi / 2], [1])
+        tape_bwd = tape.bind_new_parameters([theta - pnp.pi / 2], [1])
 
-        manualgrad_val = np.subtract(*dev.execute([tape_fwd, tape_bwd])) / 2
-        assert np.allclose(autograd_val, manualgrad_val, atol=tol, rtol=0)
+        manualgrad_val = pnp.subtract(*dev.execute([tape_fwd, tape_bwd])) / 2
+        assert pnp.allclose(autograd_val, manualgrad_val, atol=tol, rtol=0)
 
-        assert isinstance(autograd_val, np.ndarray)
+        assert isinstance(autograd_val, pnp.ndarray)
         assert autograd_val.shape == ()
 
         assert spy.call_args[1]["shifts"] == (shift,)
 
         tapes, fn = qml.gradients.finite_diff(tape)
         numeric_val = fn(dev.execute(tapes))
-        assert np.allclose(autograd_val, numeric_val, atol=tol, rtol=0)
+        assert pnp.allclose(autograd_val, numeric_val, atol=tol, rtol=0)
 
-    @pytest.mark.parametrize("theta", np.linspace(-2 * np.pi, 2 * np.pi, 7))
-    @pytest.mark.parametrize("shift", [np.pi / 2, 0.3, np.sqrt(2)])
+    @pytest.mark.parametrize("theta", pnp.linspace(-2 * pnp.pi, 2 * pnp.pi, 7))
+    @pytest.mark.parametrize("shift", [pnp.pi / 2, 0.3, pnp.sqrt(2)])
     def test_Rot_gradient(self, mocker, theta, shift, tol):
         """Tests that the automatic gradient of an arbitrary Euler-angle-parametrized gate is correct."""
         spy = mocker.spy(qml.gradients.parameter_shift, "_get_operation_recipe")
         dev = qml.device("default.qubit", wires=1)
-        params = np.array([theta, theta**3, np.sqrt(2) * theta])
+        params = pnp.array([theta, theta**3, pnp.sqrt(2) * theta])
 
         with qml.queuing.AnnotatedQueue() as q:
-            qml.StatePrep(np.array([1.0, -1.0], requires_grad=False) / np.sqrt(2), wires=0)
+            qml.StatePrep(pnp.array([1.0, -1.0], requires_grad=False) / pnp.sqrt(2), wires=0)
             qml.Rot(*params, wires=[0])
             qml.expval(qml.PauliZ(0))
 
@@ -1396,9 +1396,9 @@ class TestParameterShiftRule:
         assert len(autograd_val) == num_params
 
         manualgrad_val = []
-        for idx in list(np.ndindex(*params.shape)):
-            s = np.zeros_like(params)
-            s[idx] += np.pi / 2
+        for idx in list(pnp.ndindex(*params.shape)):
+            s = pnp.zeros_like(params)
+            s[idx] += pnp.pi / 2
 
             tape = tape.bind_new_parameters(params + s, [1, 2, 3])
             forward = dev.execute(tape)
@@ -1412,13 +1412,13 @@ class TestParameterShiftRule:
         assert len(autograd_val) == len(manualgrad_val)
 
         for a_val, m_val in zip(autograd_val, manualgrad_val):
-            assert np.allclose(a_val, m_val, atol=tol, rtol=0)
+            assert pnp.allclose(a_val, m_val, atol=tol, rtol=0)
             assert spy.call_args[1]["shifts"] == (shift,)
 
         tapes, fn = qml.gradients.finite_diff(tape)
         numeric_val = fn(dev.execute(tapes))
         for a_val, n_val in zip(autograd_val, numeric_val):
-            assert np.allclose(a_val, n_val, atol=tol, rtol=0)
+            assert pnp.allclose(a_val, n_val, atol=tol, rtol=0)
 
     @pytest.mark.parametrize("G", [qml.CRX, qml.CRY, qml.CRZ])
     def test_controlled_rotation_gradient(self, G, tol):
@@ -1427,7 +1427,7 @@ class TestParameterShiftRule:
         b = 0.123
 
         with qml.queuing.AnnotatedQueue() as q:
-            qml.StatePrep(np.array([1.0, -1.0], requires_grad=False) / np.sqrt(2), wires=0)
+            qml.StatePrep(pnp.array([1.0, -1.0], requires_grad=False) / pnp.sqrt(2), wires=0)
             G(b, wires=[0, 1])
             qml.expval(qml.PauliX(0))
 
@@ -1435,26 +1435,26 @@ class TestParameterShiftRule:
         tape.trainable_params = {1}
 
         res = dev.execute(tape)
-        assert np.allclose(res, -np.cos(b / 2), atol=tol, rtol=0)
+        assert pnp.allclose(res, -pnp.cos(b / 2), atol=tol, rtol=0)
 
         tapes, fn = qml.gradients.param_shift(tape)
         grad = fn(dev.execute(tapes))
-        expected = np.sin(b / 2) / 2
-        assert np.allclose(grad, expected, atol=tol, rtol=0)
+        expected = pnp.sin(b / 2) / 2
+        assert pnp.allclose(grad, expected, atol=tol, rtol=0)
 
         tapes, fn = qml.gradients.finite_diff(tape)
         numeric_val = fn(dev.execute(tapes))
-        assert np.allclose(grad, numeric_val, atol=tol, rtol=0)
+        assert pnp.allclose(grad, numeric_val, atol=tol, rtol=0)
 
-    @pytest.mark.parametrize("theta", np.linspace(-2 * np.pi, np.pi, 7))
+    @pytest.mark.parametrize("theta", pnp.linspace(-2 * pnp.pi, pnp.pi, 7))
     def test_CRot_gradient(self, theta, tol):
         """Tests that the automatic gradient of an arbitrary controlled Euler-angle-parametrized
         gate is correct."""
         dev = qml.device("default.qubit", wires=2)
-        a, b, c = np.array([theta, theta**3, np.sqrt(2) * theta])
+        a, b, c = pnp.array([theta, theta**3, pnp.sqrt(2) * theta])
 
         with qml.queuing.AnnotatedQueue() as q:
-            qml.StatePrep(np.array([1.0, -1.0], requires_grad=False) / np.sqrt(2), wires=0)
+            qml.StatePrep(pnp.array([1.0, -1.0], requires_grad=False) / pnp.sqrt(2), wires=0)
             qml.CRot(a, b, c, wires=[0, 1])
             qml.expval(qml.PauliX(0))
 
@@ -1462,34 +1462,34 @@ class TestParameterShiftRule:
         tape.trainable_params = {1, 2, 3}
 
         res = dev.execute(tape)
-        expected = -np.cos(b / 2) * np.cos(0.5 * (a + c))
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        expected = -pnp.cos(b / 2) * pnp.cos(0.5 * (a + c))
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
         tapes, fn = qml.gradients.param_shift(tape)
         assert len(tapes) == 4 * len(tape.trainable_params)
 
         grad = fn(dev.execute(tapes))
-        expected = np.array(
+        expected = pnp.array(
             [
-                0.5 * np.cos(b / 2) * np.sin(0.5 * (a + c)),
-                0.5 * np.sin(b / 2) * np.cos(0.5 * (a + c)),
-                0.5 * np.cos(b / 2) * np.sin(0.5 * (a + c)),
+                0.5 * pnp.cos(b / 2) * pnp.sin(0.5 * (a + c)),
+                0.5 * pnp.sin(b / 2) * pnp.cos(0.5 * (a + c)),
+                0.5 * pnp.cos(b / 2) * pnp.sin(0.5 * (a + c)),
             ]
         )
         assert isinstance(grad, tuple)
         assert len(grad) == 3
         for idx, g in enumerate(grad):
-            assert np.allclose(g, expected[idx], atol=tol, rtol=0)
+            assert pnp.allclose(g, expected[idx], atol=tol, rtol=0)
 
         tapes, fn = qml.gradients.finite_diff(tape)
         numeric_val = fn(dev.execute(tapes))
         for idx, g in enumerate(grad):
-            assert np.allclose(g, numeric_val[idx], atol=tol, rtol=0)
+            assert pnp.allclose(g, numeric_val[idx], atol=tol, rtol=0)
 
     def test_gradients_agree_finite_differences(self, tol):
         """Tests that the parameter-shift rule agrees with the first and second
         order finite differences"""
-        params = np.array([0.1, -1.6, np.pi / 5])
+        params = pnp.array([0.1, -1.6, pnp.pi / 5])
 
         with qml.queuing.AnnotatedQueue() as q:
             qml.RX(params[0], wires=[0])
@@ -1512,13 +1512,13 @@ class TestParameterShiftRule:
         grad_A = grad_fn(tape, dev)
 
         # gradients computed with different methods must agree
-        assert np.allclose(grad_A, grad_F1, atol=tol, rtol=0)
-        assert np.allclose(grad_A, grad_F2, atol=tol, rtol=0)
+        assert pnp.allclose(grad_A, grad_F1, atol=tol, rtol=0)
+        assert pnp.allclose(grad_A, grad_F2, atol=tol, rtol=0)
 
     def test_variance_gradients_agree_finite_differences(self, tol):
         """Tests that the variance parameter-shift rule agrees with the first and second
         order finite differences"""
-        params = np.array([0.1, -1.6, np.pi / 5])
+        params = pnp.array([0.1, -1.6, pnp.pi / 5])
 
         with qml.queuing.AnnotatedQueue() as q:
             qml.RX(params[0], wires=[0])
@@ -1544,8 +1544,8 @@ class TestParameterShiftRule:
         # gradients computed with different methods must agree
         for idx1, _grad_A in enumerate(grad_A):
             for idx2, g in enumerate(_grad_A):
-                assert np.allclose(g, grad_F1[idx1][idx2], atol=tol, rtol=0)
-                assert np.allclose(g, grad_F2[idx1][idx2], atol=tol, rtol=0)
+                assert pnp.allclose(g, grad_F1[idx1][idx2], atol=tol, rtol=0)
+                assert pnp.allclose(g, grad_F2[idx1][idx2], atol=tol, rtol=0)
 
     @pytest.mark.autograd
     def test_fallback(self, mocker, tol):
@@ -1555,7 +1555,7 @@ class TestParameterShiftRule:
         x = 0.543
         y = -0.654
 
-        params = np.array([x, y], requires_grad=True)
+        params = pnp.array([x, y], requires_grad=True)
 
         def cost_fn(params):
             with qml.queuing.AnnotatedQueue() as q:
@@ -1586,13 +1586,13 @@ class TestParameterShiftRule:
             assert isinstance(r, tuple)
             assert len(r) == 2
 
-            assert isinstance(r[0], np.ndarray)
+            assert isinstance(r[0], pnp.ndarray)
             assert r[0].shape == ()
-            assert isinstance(r[1], np.ndarray)
+            assert isinstance(r[1], pnp.ndarray)
             assert r[1].shape == ()
 
-        expected = np.array([[-np.sin(x), 0], [0, -2 * np.cos(y) * np.sin(y)], [0, 0]])
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        expected = pnp.array([[-pnp.sin(x), 0], [0, -2 * pnp.cos(y) * pnp.sin(y)], [0, 0]])
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
         # TODO: support Hessian with the new return types
         # check the second derivative
@@ -1610,7 +1610,7 @@ class TestParameterShiftRule:
         x = 0.543
         y = -0.654
 
-        params = np.array([x, y], requires_grad=True)
+        params = pnp.array([x, y], requires_grad=True)
 
         def cost_fn(params):
             with qml.queuing.AnnotatedQueue() as q:
@@ -1634,12 +1634,12 @@ class TestParameterShiftRule:
         assert len(res) == 2
 
         for r in res:
-            assert isinstance(r, np.ndarray)
+            assert isinstance(r, pnp.ndarray)
             assert r.shape == ()
 
-        expval_expected = [-np.sin(x + y), -np.sin(x + y)]
-        assert np.allclose(res[0], expval_expected[0])
-        assert np.allclose(res[1], expval_expected[1])
+        expval_expected = [-pnp.sin(x + y), -pnp.sin(x + y)]
+        assert pnp.allclose(res[0], expval_expected[0])
+        assert pnp.allclose(res[1], expval_expected[1])
 
     @pytest.mark.autograd
     @pytest.mark.parametrize("RX, RY, argnum", [(RX_with_F, qml.RY, 0), (qml.RX, RY_with_F, 1)])
@@ -1650,7 +1650,7 @@ class TestParameterShiftRule:
         x = 0.543
         y = -0.654
 
-        params = np.array([x, y], requires_grad=True)
+        params = pnp.array([x, y], requires_grad=True)
 
         def cost_fn(params):
             with qml.queuing.AnnotatedQueue() as q:
@@ -1681,35 +1681,35 @@ class TestParameterShiftRule:
         assert len(expval_res) == 2
 
         for param_r in expval_res:
-            assert isinstance(param_r, np.ndarray)
+            assert isinstance(param_r, pnp.ndarray)
             assert param_r.shape == ()
 
         probs_res = res[1]
         assert isinstance(probs_res, tuple)
         assert len(probs_res) == 2
         for param_r in probs_res:
-            assert isinstance(param_r, np.ndarray)
+            assert isinstance(param_r, pnp.ndarray)
             assert param_r.shape == (4,)
 
-        expval_expected = [-2 * np.sin(x) / 2, 0]
+        expval_expected = [-2 * pnp.sin(x) / 2, 0]
         probs_expected = (
-            np.array(
+            pnp.array(
                 [
                     [
-                        -(np.cos(y / 2) ** 2 * np.sin(x)),
-                        -(np.cos(x / 2) ** 2 * np.sin(y)),
+                        -(pnp.cos(y / 2) ** 2 * pnp.sin(x)),
+                        -(pnp.cos(x / 2) ** 2 * pnp.sin(y)),
                     ],
                     [
-                        -(np.sin(x) * np.sin(y / 2) ** 2),
-                        (np.cos(x / 2) ** 2 * np.sin(y)),
+                        -(pnp.sin(x) * pnp.sin(y / 2) ** 2),
+                        (pnp.cos(x / 2) ** 2 * pnp.sin(y)),
                     ],
                     [
-                        (np.sin(x) * np.sin(y / 2) ** 2),
-                        (np.sin(x / 2) ** 2 * np.sin(y)),
+                        (pnp.sin(x) * pnp.sin(y / 2) ** 2),
+                        (pnp.sin(x / 2) ** 2 * pnp.sin(y)),
                     ],
                     [
-                        (np.cos(y / 2) ** 2 * np.sin(x)),
-                        -(np.sin(x / 2) ** 2 * np.sin(y)),
+                        (pnp.cos(y / 2) ** 2 * pnp.sin(x)),
+                        -(pnp.sin(x / 2) ** 2 * pnp.sin(y)),
                     ],
                 ]
             )
@@ -1717,12 +1717,12 @@ class TestParameterShiftRule:
         )
 
         # Expvals
-        assert np.allclose(res[0][0], expval_expected[0])
-        assert np.allclose(res[0][1], expval_expected[1])
+        assert pnp.allclose(res[0][0], expval_expected[0])
+        assert pnp.allclose(res[0][1], expval_expected[1])
 
         # Probs
-        assert np.allclose(res[1][0], probs_expected[:, 0])
-        assert np.allclose(res[1][1], probs_expected[:, 1])
+        assert pnp.allclose(res[1][0], probs_expected[:, 0])
+        assert pnp.allclose(res[1][1], probs_expected[:, 1])
 
     @pytest.mark.autograd
     def test_all_fallback(self, mocker, tol):
@@ -1755,8 +1755,8 @@ class TestParameterShiftRule:
         assert res[0].shape == ()
         assert res[1].shape == ()
 
-        expected = np.array([[-np.sin(y) * np.sin(x), np.cos(y) * np.cos(x)]])
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        expected = pnp.array([[-pnp.sin(y) * pnp.sin(x), pnp.cos(y) * pnp.cos(x)]])
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
     def test_single_expectation_value(self, tol):
         """Tests correct output shape and evaluation for a tape
@@ -1780,12 +1780,12 @@ class TestParameterShiftRule:
         assert not isinstance(res[0], tuple)
         assert not isinstance(res[1], tuple)
 
-        expected = np.array([-np.sin(y) * np.sin(x), np.cos(y) * np.cos(x)])
-        assert np.allclose(res[0], expected[0], atol=tol, rtol=0)
-        assert np.allclose(res[1], expected[1], atol=tol, rtol=0)
+        expected = pnp.array([-pnp.sin(y) * pnp.sin(x), pnp.cos(y) * pnp.cos(x)])
+        assert pnp.allclose(res[0], expected[0], atol=tol, rtol=0)
+        assert pnp.allclose(res[1], expected[1], atol=tol, rtol=0)
 
     @pytest.mark.parametrize(
-        "par", [0, 1, 2, 3, np.int8(1), np.int16(1), np.int32(1), np.int64(1)]
+        "par", [0, 1, 2, 3, pnp.int8(1), pnp.int16(1), pnp.int32(1), pnp.int64(1)]
     )  # integers, zero
     def test_integer_parameters(self, tol, par):
         """Test that the gradient of the RY gate matches the exact analytic formula."""
@@ -1795,12 +1795,12 @@ class TestParameterShiftRule:
         tape.trainable_params = {0}
 
         # gradients
-        exact = np.cos(par)
+        exact = pnp.cos(par)
         gtapes, fn = qml.gradients.param_shift(tape)
         grad_PS = fn(qml.execute(gtapes, dev, diff_method=None))
 
         # different methods must agree
-        assert np.allclose(grad_PS, exact, atol=tol, rtol=0)
+        assert pnp.allclose(grad_PS, exact, atol=tol, rtol=0)
 
     def test_multiple_expectation_values(self, tol):
         """Tests correct output shape and evaluation for a tape
@@ -1825,9 +1825,9 @@ class TestParameterShiftRule:
         assert len(res[0]) == 2
         assert len(res[1]) == 2
 
-        expected = np.array([[-np.sin(x), 0], [0, np.cos(y)]])
-        assert np.allclose(res[0], expected[0], atol=tol, rtol=0)
-        assert np.allclose(res[1], expected[1], atol=tol, rtol=0)
+        expected = pnp.array([[-pnp.sin(x), 0], [0, pnp.cos(y)]])
+        assert pnp.allclose(res[0], expected[0], atol=tol, rtol=0)
+        assert pnp.allclose(res[1], expected[1], atol=tol, rtol=0)
 
     def test_var_expectation_values(self, tol):
         """Tests correct output shape and evaluation for a tape
@@ -1852,10 +1852,10 @@ class TestParameterShiftRule:
         assert len(res[0]) == 2
         assert len(res[1]) == 2
 
-        expected = np.array([[-np.sin(x), 0], [0, -2 * np.cos(y) * np.sin(y)]])
+        expected = pnp.array([[-pnp.sin(x), 0], [0, -2 * pnp.cos(y) * pnp.sin(y)]])
 
         for a, e in zip(res, expected):
-            assert np.allclose(np.squeeze(np.stack(a)), e, atol=tol, rtol=0)
+            assert pnp.allclose(pnp.squeeze(pnp.stack(a)), e, atol=tol, rtol=0)
 
     def test_prob_expectation_values(self):
         """Tests correct output shape and evaluation for a tape
@@ -1882,25 +1882,25 @@ class TestParameterShiftRule:
         for r in res:
             assert len(r) == 2
 
-        expval_expected = [-2 * np.sin(x) / 2, 0]
+        expval_expected = [-2 * pnp.sin(x) / 2, 0]
         probs_expected = (
-            np.array(
+            pnp.array(
                 [
                     [
-                        -(np.cos(y / 2) ** 2 * np.sin(x)),
-                        -(np.cos(x / 2) ** 2 * np.sin(y)),
+                        -(pnp.cos(y / 2) ** 2 * pnp.sin(x)),
+                        -(pnp.cos(x / 2) ** 2 * pnp.sin(y)),
                     ],
                     [
-                        -(np.sin(x) * np.sin(y / 2) ** 2),
-                        (np.cos(x / 2) ** 2 * np.sin(y)),
+                        -(pnp.sin(x) * pnp.sin(y / 2) ** 2),
+                        (pnp.cos(x / 2) ** 2 * pnp.sin(y)),
                     ],
                     [
-                        (np.sin(x) * np.sin(y / 2) ** 2),
-                        (np.sin(x / 2) ** 2 * np.sin(y)),
+                        (pnp.sin(x) * pnp.sin(y / 2) ** 2),
+                        (pnp.sin(x / 2) ** 2 * pnp.sin(y)),
                     ],
                     [
-                        (np.cos(y / 2) ** 2 * np.sin(x)),
-                        -(np.sin(x / 2) ** 2 * np.sin(y)),
+                        (pnp.cos(y / 2) ** 2 * pnp.sin(x)),
+                        -(pnp.sin(x / 2) ** 2 * pnp.sin(y)),
                     ],
                 ]
             )
@@ -1908,12 +1908,12 @@ class TestParameterShiftRule:
         )
 
         # Expvals
-        assert np.allclose(res[0][0], expval_expected[0])
-        assert np.allclose(res[0][1], expval_expected[1])
+        assert pnp.allclose(res[0][0], expval_expected[0])
+        assert pnp.allclose(res[0][1], expval_expected[1])
 
         # Probs
-        assert np.allclose(res[1][0], probs_expected[:, 0])
-        assert np.allclose(res[1][1], probs_expected[:, 1])
+        assert pnp.allclose(res[1][0], probs_expected[:, 0])
+        assert pnp.allclose(res[1][1], probs_expected[:, 1])
 
     def test_involutory_variance_single_param(self, tol):
         """Tests qubit observables that are involutory with a single trainable param"""
@@ -1928,13 +1928,13 @@ class TestParameterShiftRule:
         tape.trainable_params = {0}
 
         res = dev.execute(tape)
-        expected = 1 - np.cos(a) ** 2
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        expected = 1 - pnp.cos(a) ** 2
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
         # circuit jacobians
         tapes, fn = qml.gradients.param_shift(tape)
         gradA = fn(dev.execute(tapes))
-        assert isinstance(gradA, np.ndarray)
+        assert isinstance(gradA, pnp.ndarray)
         assert gradA.shape == ()
         assert len(tapes) == 1 + 2 * 1
 
@@ -1942,7 +1942,7 @@ class TestParameterShiftRule:
         gradF = fn(dev.execute(tapes))
         assert len(tapes) == 2
 
-        expected = 2 * np.sin(a) * np.cos(a)
+        expected = 2 * pnp.sin(a) * pnp.cos(a)
         assert gradF == pytest.approx(expected, abs=tol)
         assert gradA == pytest.approx(expected, abs=tol)
 
@@ -1961,18 +1961,18 @@ class TestParameterShiftRule:
         tape.trainable_params = {0, 1}
 
         res = dev.execute(tape)
-        expected = 1 - np.cos(a + b) ** 2
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        expected = 1 - pnp.cos(a + b) ** 2
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
         # circuit jacobians
         tapes, fn = qml.gradients.param_shift(tape)
         gradA = fn(dev.execute(tapes))
         assert isinstance(gradA, tuple)
 
-        assert isinstance(gradA[0], np.ndarray)
+        assert isinstance(gradA[0], pnp.ndarray)
         assert gradA[0].shape == ()
 
-        assert isinstance(gradA[1], np.ndarray)
+        assert isinstance(gradA[1], pnp.ndarray)
         assert gradA[1].shape == ()
 
         assert len(tapes) == 1 + 2 * 2
@@ -1981,7 +1981,7 @@ class TestParameterShiftRule:
         gradF = fn(dev.execute(tapes))
         assert len(tapes) == 3
 
-        expected = 2 * np.sin(a + b) * np.cos(a + b)
+        expected = 2 * pnp.sin(a + b) * pnp.cos(a + b)
         assert gradF[0] == pytest.approx(expected, abs=tol)
         assert gradA[0] == pytest.approx(expected, abs=tol)
 
@@ -1991,7 +1991,7 @@ class TestParameterShiftRule:
     def test_non_involutory_variance_single_param(self, tol):
         """Tests a qubit Hermitian observable that is not involutory with a single trainable parameter"""
         dev = qml.device("default.qubit", wires=1)
-        A = np.array([[4, -1 + 6j], [-1 - 6j, 2]])
+        A = pnp.array([[4, -1 + 6j], [-1 - 6j, 2]])
         a = 0.54
 
         with qml.queuing.AnnotatedQueue() as q:
@@ -2002,13 +2002,13 @@ class TestParameterShiftRule:
         tape.trainable_params = {0}
 
         res = dev.execute(tape)
-        expected = (39 / 2) - 6 * np.sin(2 * a) + (35 / 2) * np.cos(2 * a)
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        expected = (39 / 2) - 6 * pnp.sin(2 * a) + (35 / 2) * pnp.cos(2 * a)
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
         # circuit jacobians
         tapes, fn = qml.gradients.param_shift(tape)
         gradA = fn(dev.execute(tapes))
-        assert isinstance(gradA, np.ndarray)
+        assert isinstance(gradA, pnp.ndarray)
         assert gradA.shape == ()
         assert len(tapes) == 1 + 4 * 1
 
@@ -2016,14 +2016,14 @@ class TestParameterShiftRule:
         gradF = fn(dev.execute(tapes))
         assert len(tapes) == 2
 
-        expected = -35 * np.sin(2 * a) - 12 * np.cos(2 * a)
+        expected = -35 * pnp.sin(2 * a) - 12 * pnp.cos(2 * a)
         assert gradA == pytest.approx(expected, abs=tol)
         assert gradF == pytest.approx(expected, abs=tol)
 
     def test_non_involutory_variance_multi_param(self, tol):
         """Tests a qubit Hermitian observable that is not involutory with multiple trainable parameters"""
         dev = qml.device("default.qubit", wires=1)
-        A = np.array([[4, -1 + 6j], [-1 - 6j, 2]])
+        A = pnp.array([[4, -1 + 6j], [-1 - 6j, 2]])
         a = 0.34
         b = 0.20
 
@@ -2036,18 +2036,18 @@ class TestParameterShiftRule:
         tape.trainable_params = {0, 1}
 
         res = dev.execute(tape)
-        expected = (39 / 2) - 6 * np.sin(2 * (a + b)) + (35 / 2) * np.cos(2 * (a + b))
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        expected = (39 / 2) - 6 * pnp.sin(2 * (a + b)) + (35 / 2) * pnp.cos(2 * (a + b))
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
         # circuit jacobians
         tapes, fn = qml.gradients.param_shift(tape)
         gradA = fn(dev.execute(tapes))
         assert isinstance(gradA, tuple)
 
-        assert isinstance(gradA[0], np.ndarray)
+        assert isinstance(gradA[0], pnp.ndarray)
         assert gradA[0].shape == ()
 
-        assert isinstance(gradA[1], np.ndarray)
+        assert isinstance(gradA[1], pnp.ndarray)
         assert gradA[1].shape == ()
         assert len(tapes) == 1 + 4 * 2
 
@@ -2055,7 +2055,7 @@ class TestParameterShiftRule:
         gradF = fn(dev.execute(tapes))
         assert len(tapes) == 3
 
-        expected = -35 * np.sin(2 * (a + b)) - 12 * np.cos(2 * (a + b))
+        expected = -35 * pnp.sin(2 * (a + b)) - 12 * pnp.cos(2 * (a + b))
         assert gradA[0] == pytest.approx(expected, abs=tol)
         assert gradF[0] == pytest.approx(expected, abs=tol)
 
@@ -2066,7 +2066,7 @@ class TestParameterShiftRule:
         """Tests a qubit Hermitian observable that is not involutory alongside
         an involutory observable when there's a single trainable parameter."""
         dev = qml.device("default.qubit", wires=2, seed=seed)
-        A = np.array([[4, -1 + 6j], [-1 - 6j, 2]])
+        A = pnp.array([[4, -1 + 6j], [-1 - 6j, 2]])
         a = 0.54
 
         with qml.queuing.AnnotatedQueue() as q:
@@ -2080,8 +2080,8 @@ class TestParameterShiftRule:
         tape.trainable_params = {0}
 
         res = dev.execute(tape)
-        expected = [1 - np.cos(a) ** 2, (39 / 2) - 6 * np.sin(2 * a) + (35 / 2) * np.cos(2 * a)]
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        expected = [1 - pnp.cos(a) ** 2, (39 / 2) - 6 * pnp.sin(2 * a) + (35 / 2) * pnp.cos(2 * a)]
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
         # circuit jacobians
         tapes, fn = qml.gradients.param_shift(tape)
@@ -2092,12 +2092,12 @@ class TestParameterShiftRule:
         gradF = fn(dev.execute(tapes))
         assert len(tapes) == 1 + 1
 
-        expected = [2 * np.sin(a) * np.cos(a), 0]
+        expected = [2 * pnp.sin(a) * pnp.cos(a), 0]
 
         assert isinstance(gradA, tuple)
         assert len(gradA) == 2
         for param_res in gradA:
-            assert isinstance(param_res, np.ndarray)
+            assert isinstance(param_res, pnp.ndarray)
             assert param_res.shape == ()
 
         assert gradA[0] == pytest.approx(expected[0], abs=tol)
@@ -2111,7 +2111,7 @@ class TestParameterShiftRule:
         """Tests a qubit Hermitian observable that is not involutory alongside an involutory observable and probs when
         there's one trainable parameter."""
         dev = qml.device("default.qubit", wires=4)
-        A = np.array([[4, -1 + 6j], [-1 - 6j, 2]])
+        A = pnp.array([[4, -1 + 6j], [-1 - 6j, 2]])
         a = 0.54
 
         x = 0.543
@@ -2147,22 +2147,22 @@ class TestParameterShiftRule:
         assert gradA[2].shape == (4,)
 
         # Vars
-        vars_expected = [2 * np.sin(a) * np.cos(a), -35 * np.sin(2 * a) - 12 * np.cos(2 * a)]
-        assert isinstance(gradA[0], np.ndarray)
-        assert np.allclose(gradA[0], vars_expected[0] if ind == 0 else 0)
+        vars_expected = [2 * pnp.sin(a) * pnp.cos(a), -35 * pnp.sin(2 * a) - 12 * pnp.cos(2 * a)]
+        assert isinstance(gradA[0], pnp.ndarray)
+        assert pnp.allclose(gradA[0], vars_expected[0] if ind == 0 else 0)
 
-        assert isinstance(gradA[1], np.ndarray)
-        assert np.allclose(gradA[1], vars_expected[1] if ind == 1 else 0)
+        assert isinstance(gradA[1], pnp.ndarray)
+        assert pnp.allclose(gradA[1], vars_expected[1] if ind == 1 else 0)
 
         # Probs
-        assert isinstance(gradA[2], np.ndarray)
-        assert np.allclose(gradA[2], 0)
+        assert isinstance(gradA[2], pnp.ndarray)
+        assert pnp.allclose(gradA[2], 0)
 
     def test_var_and_probs_multi_params(self):
         """Tests a qubit Hermitian observable that is not involutory alongside an involutory observable and probs when
         there are more trainable parameters."""
         dev = qml.device("default.qubit", wires=4)
-        A = np.array([[4, -1 + 6j], [-1 - 6j, 2]])
+        A = pnp.array([[4, -1 + 6j], [-1 - 6j, 2]])
         a = 0.54
 
         x = 0.543
@@ -2194,67 +2194,67 @@ class TestParameterShiftRule:
         assert len(gradA) == 3
         var1_res = gradA[0]
         for param_res in var1_res:
-            assert isinstance(param_res, np.ndarray)
+            assert isinstance(param_res, pnp.ndarray)
             assert param_res.shape == ()
 
         var2_res = gradA[1]
         for param_res in var2_res:
-            assert isinstance(param_res, np.ndarray)
+            assert isinstance(param_res, pnp.ndarray)
             assert param_res.shape == ()
 
         probs_res = gradA[2]
         for param_res in probs_res:
-            assert isinstance(param_res, np.ndarray)
+            assert isinstance(param_res, pnp.ndarray)
             assert param_res.shape == (4,)
 
         # Vars
-        vars_expected = [2 * np.sin(a) * np.cos(a), -35 * np.sin(2 * a) - 12 * np.cos(2 * a)]
+        vars_expected = [2 * pnp.sin(a) * pnp.cos(a), -35 * pnp.sin(2 * a) - 12 * pnp.cos(2 * a)]
         assert isinstance(gradA[0], tuple)
-        assert np.allclose(gradA[0][0], vars_expected[0])
-        assert np.allclose(gradA[0][1], 0)
-        assert np.allclose(gradA[0][2], 0)
-        assert np.allclose(gradA[0][3], 0)
+        assert pnp.allclose(gradA[0][0], vars_expected[0])
+        assert pnp.allclose(gradA[0][1], 0)
+        assert pnp.allclose(gradA[0][2], 0)
+        assert pnp.allclose(gradA[0][3], 0)
 
         assert isinstance(gradA[1], tuple)
-        assert np.allclose(gradA[1][0], 0)
-        assert np.allclose(gradA[1][1], vars_expected[1])
-        assert np.allclose(gradA[1][2], 0)
-        assert np.allclose(gradA[1][3], 0)
+        assert pnp.allclose(gradA[1][0], 0)
+        assert pnp.allclose(gradA[1][1], vars_expected[1])
+        assert pnp.allclose(gradA[1][2], 0)
+        assert pnp.allclose(gradA[1][3], 0)
 
         # Probs
         probs_expected = (
-            np.array(
+            pnp.array(
                 [
                     [
-                        -(np.cos(y / 2) ** 2 * np.sin(x)),
-                        -(np.cos(x / 2) ** 2 * np.sin(y)),
+                        -(pnp.cos(y / 2) ** 2 * pnp.sin(x)),
+                        -(pnp.cos(x / 2) ** 2 * pnp.sin(y)),
                     ],
                     [
-                        -(np.sin(x) * np.sin(y / 2) ** 2),
-                        (np.cos(x / 2) ** 2 * np.sin(y)),
+                        -(pnp.sin(x) * pnp.sin(y / 2) ** 2),
+                        (pnp.cos(x / 2) ** 2 * pnp.sin(y)),
                     ],
                     [
-                        (np.sin(x) * np.sin(y / 2) ** 2),
-                        (np.sin(x / 2) ** 2 * np.sin(y)),
+                        (pnp.sin(x) * pnp.sin(y / 2) ** 2),
+                        (pnp.sin(x / 2) ** 2 * pnp.sin(y)),
                     ],
                     [
-                        (np.cos(y / 2) ** 2 * np.sin(x)),
-                        -(np.sin(x / 2) ** 2 * np.sin(y)),
+                        (pnp.cos(y / 2) ** 2 * pnp.sin(x)),
+                        -(pnp.sin(x / 2) ** 2 * pnp.sin(y)),
                     ],
                 ]
             )
             / 2
         )
         assert isinstance(gradA[2], tuple)
-        assert np.allclose(gradA[2][0], 0)
-        assert np.allclose(gradA[2][1], 0)
-        assert np.allclose(gradA[2][2], probs_expected[:, 0])
-        assert np.allclose(gradA[2][3], probs_expected[:, 1])
+        assert pnp.allclose(gradA[2][0], 0)
+        assert pnp.allclose(gradA[2][1], 0)
+        assert pnp.allclose(gradA[2][2], probs_expected[:, 0])
+        assert pnp.allclose(gradA[2][3], probs_expected[:, 1])
 
     def test_put_zeros_in_pdA2_involutory(self):
         """Tests the _process_pdA2_involutory auxiliary function."""
-        params = np.array([0.1, -1.6, np.pi / 5])
-        A = np.array([[4, -1 + 6j], [-1 - 6j, 2]])
+        params = pnp.array([0.1, -1.6, pnp.pi / 5])
+        A = pnp.array([[4, -1 + 6j], [-1 - 6j, 2]])
 
         with qml.queuing.AnnotatedQueue() as q:
             qml.RX(params[0], wires=[0])
@@ -2268,9 +2268,9 @@ class TestParameterShiftRule:
         involutory_indices = [2]
 
         pdA2 = (
-            (np.array(-0.09983342), np.array(-4.44643859e-16)),
-            (np.array(-1.24098015e-15), np.array(6.17263875)),
-            (np.array(-1.10652721e-18), np.array(4.44328375e-16)),
+            (pnp.array(-0.09983342), pnp.array(-4.44643859e-16)),
+            (pnp.array(-1.24098015e-15), pnp.array(6.17263875)),
+            (pnp.array(-1.10652721e-18), pnp.array(4.44328375e-16)),
         )
         res = _put_zeros_in_pdA2_involutory(tape, pdA2, involutory_indices)
         assert len(res) == len(pdA2)
@@ -2280,7 +2280,7 @@ class TestParameterShiftRule:
         assert res[1] == pdA2[1]
 
         # Involutory obs (PauliZ) part is 0
-        assert res[2] == (np.array(0), np.array(0))
+        assert res[2] == (pnp.array(0), pnp.array(0))
 
     def test_expval_and_variance_single_param(self, tol):
         """Test an expectation value and the variance of involutory and non-involutory observables work well with a
@@ -2305,16 +2305,16 @@ class TestParameterShiftRule:
         tape.trainable_params = {0}
 
         res = dev.execute(tape)
-        expected = np.array(
+        expected = pnp.array(
             [
-                np.sin(a) ** 2,
-                np.cos(a) * np.cos(b),
-                0.25 * (3 - 2 * np.cos(b) ** 2 * np.cos(2 * c) - np.cos(2 * b)),
+                pnp.sin(a) ** 2,
+                pnp.cos(a) * pnp.cos(b),
+                0.25 * (3 - 2 * pnp.cos(b) ** 2 * pnp.cos(2 * c) - pnp.cos(2 * b)),
             ]
         )
 
         assert isinstance(res, tuple)
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
         # # circuit jacobians
         tapes, fn = qml.gradients.param_shift(tape)
@@ -2323,12 +2323,12 @@ class TestParameterShiftRule:
         tapes, fn = qml.gradients.finite_diff(tape)
         gradF = fn(dev.execute(tapes))
 
-        expected = np.array([2 * np.cos(a) * np.sin(a), -np.cos(b) * np.sin(a), 0])
+        expected = pnp.array([2 * pnp.cos(a) * pnp.sin(a), -pnp.cos(b) * pnp.sin(a), 0])
         assert isinstance(gradA, tuple)
         for a_comp, e_comp in zip(gradA, expected):
-            assert isinstance(a_comp, np.ndarray)
+            assert isinstance(a_comp, pnp.ndarray)
             assert a_comp.shape == ()
-            assert np.allclose(a_comp, e_comp, atol=tol, rtol=0)
+            assert pnp.allclose(a_comp, e_comp, atol=tol, rtol=0)
         assert gradF == pytest.approx(expected, abs=tol)
 
     def test_expval_and_variance_multi_param(self, tol):
@@ -2352,16 +2352,16 @@ class TestParameterShiftRule:
 
         tape = qml.tape.QuantumScript.from_queue(q)
         res = dev.execute(tape)
-        expected = np.array(
+        expected = pnp.array(
             [
-                np.sin(a) ** 2,
-                np.cos(a) * np.cos(b),
-                0.25 * (3 - 2 * np.cos(b) ** 2 * np.cos(2 * c) - np.cos(2 * b)),
+                pnp.sin(a) ** 2,
+                pnp.cos(a) * pnp.cos(b),
+                0.25 * (3 - 2 * pnp.cos(b) ** 2 * pnp.cos(2 * c) - pnp.cos(2 * b)),
             ]
         )
 
         assert isinstance(res, tuple)
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
         # # circuit jacobians
         tapes, fn = qml.gradients.param_shift(tape)
@@ -2370,23 +2370,23 @@ class TestParameterShiftRule:
         tapes, fn = qml.gradients.finite_diff(tape)
         gradF = fn(dev.execute(tapes))
 
-        expected = np.array(
+        expected = pnp.array(
             [
-                [2 * np.cos(a) * np.sin(a), -np.cos(b) * np.sin(a), 0],
+                [2 * pnp.cos(a) * pnp.sin(a), -pnp.cos(b) * pnp.sin(a), 0],
                 [
                     0,
-                    -np.cos(a) * np.sin(b),
-                    0.5 * (2 * np.cos(b) * np.cos(2 * c) * np.sin(b) + np.sin(2 * b)),
+                    -pnp.cos(a) * pnp.sin(b),
+                    0.5 * (2 * pnp.cos(b) * pnp.cos(2 * c) * pnp.sin(b) + pnp.sin(2 * b)),
                 ],
-                [0, 0, np.cos(b) ** 2 * np.sin(2 * c)],
+                [0, 0, pnp.cos(b) ** 2 * pnp.sin(2 * c)],
             ]
         ).T
         assert isinstance(gradA, tuple)
         for a, e in zip(gradA, expected):
             for a_comp, e_comp in zip(a, e):
-                assert isinstance(a_comp, np.ndarray)
+                assert isinstance(a_comp, pnp.ndarray)
                 assert a_comp.shape == ()
-                assert np.allclose(a_comp, e_comp, atol=tol, rtol=0)
+                assert pnp.allclose(a_comp, e_comp, atol=tol, rtol=0)
         assert gradF == pytest.approx(expected, abs=tol)
 
     def test_recycling_unshifted_tape_result(self):
@@ -2434,8 +2434,8 @@ class TestParameterShiftRule:
         tape.trainable_params = {0, 1}
 
         res = dev.execute(tape)
-        expected = 0.25 * np.sin(x / 2) ** 2 * (3 + np.cos(2 * y) + 2 * np.cos(x) * np.sin(y) ** 2)
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        expected = 0.25 * pnp.sin(x / 2) ** 2 * (3 + pnp.cos(2 * y) + 2 * pnp.cos(x) * pnp.sin(y) ** 2)
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
         # # circuit jacobians
         tapes, fn = qml.gradients.param_shift(tape)
@@ -2444,13 +2444,13 @@ class TestParameterShiftRule:
         tapes, fn = qml.gradients.finite_diff(tape)
         gradF = fn(dev.execute(tapes))
 
-        expected = np.array(
+        expected = pnp.array(
             [
-                0.5 * np.sin(x) * (np.cos(x / 2) ** 2 + np.cos(2 * y) * np.sin(x / 2) ** 2),
-                -2 * np.cos(y) * np.sin(x / 2) ** 4 * np.sin(y),
+                0.5 * pnp.sin(x) * (pnp.cos(x / 2) ** 2 + pnp.cos(2 * y) * pnp.sin(x / 2) ** 2),
+                -2 * pnp.cos(y) * pnp.sin(x / 2) ** 4 * pnp.sin(y),
             ]
         )
-        assert np.allclose(gradA, expected, atol=tol, rtol=0)
+        assert pnp.allclose(gradA, expected, atol=tol, rtol=0)
         assert gradF == pytest.approx(expected, abs=tol)
 
     def cost1(x):
@@ -2499,7 +2499,7 @@ class TestParameterShiftRule:
         return (qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliZ(1)))
 
     costs_and_expected_expval_scalar = [
-        (cost7, (), np.ndarray),
+        (cost7, (), pnp.ndarray),
         (cost8, (1,), list),
         (cost9, (2,), tuple),
     ]
@@ -2510,16 +2510,16 @@ class TestParameterShiftRule:
         expectation values and a scalar parameter."""
         dev = qml.device("default.qubit", wires=4)
 
-        x = np.array(0.419)
+        x = pnp.array(0.419)
         circuit = qml.QNode(cost, dev)
 
         res_parshift = qml.gradients.param_shift(circuit)(x)
 
         assert isinstance(res_parshift, exp_type)
-        assert np.array(res_parshift).shape == exp_shape
+        assert pnp.array(res_parshift).shape == exp_shape
 
     costs_and_expected_expval = [
-        (cost1, [3], np.ndarray),
+        (cost1, [3], pnp.ndarray),
         (cost2, [3], list),
         (cost3, [2, 3], tuple),
     ]
@@ -2530,7 +2530,7 @@ class TestParameterShiftRule:
         expectation values and an array-valued parameter."""
         dev = qml.device("default.qubit", wires=4)
 
-        x = np.random.rand(3)
+        x = pnp.random.rand(3)
         circuit = qml.QNode(cost, dev)
 
         res = qml.gradients.param_shift(circuit)(x)
@@ -2542,11 +2542,11 @@ class TestParameterShiftRule:
 
         if len(exp_shape) > 1:
             for r in res:
-                assert isinstance(r, np.ndarray)
+                assert isinstance(r, pnp.ndarray)
                 assert len(r) == exp_shape[1]
 
     costs_and_expected_probs = [
-        (cost4, [4, 3], np.ndarray),
+        (cost4, [4, 3], pnp.ndarray),
         (cost5, [4, 3], list),
         (cost6, [2, 4, 3], tuple),
     ]
@@ -2556,7 +2556,7 @@ class TestParameterShiftRule:
         """Test that the transform output shape matches that of the QNode."""
         dev = qml.device("default.qubit", wires=4)
 
-        x = np.random.rand(3)
+        x = pnp.random.rand(3)
         circuit = qml.QNode(cost, dev)
 
         res_parshift = qml.gradients.param_shift(circuit)(x)
@@ -2565,10 +2565,10 @@ class TestParameterShiftRule:
         assert isinstance(res_parshift, exp_type)
         if len(exp_shape) > 1:
             for r in res_parshift:
-                assert isinstance(r, np.ndarray)
+                assert isinstance(r, pnp.ndarray)
 
         # Check shape, result can be put into a single array by assumption
-        assert np.allclose(np.squeeze(np.array(res_parshift)).shape, exp_shape)
+        assert pnp.allclose(pnp.squeeze(pnp.array(res_parshift)).shape, exp_shape)
 
     # TODO: revisit the following test when the Autograd interface supports
     #       parameter-shift with the new return type system
@@ -2616,7 +2616,7 @@ class TestParameterShiftRule:
             # pylint: disable=unused-argument
             @staticmethod
             def _asarray(arr, dtype=None):
-                return np.array(arr)
+                return pnp.array(arr)
 
             def __init__(self, *args, **kwargs):
                 super().__init__(*args, **kwargs)
@@ -2642,9 +2642,9 @@ class TestParameterShiftRule:
             qml.RY(x, wires=0)
             return qml.expval(qml.PauliZ(wires=0))
 
-        par = np.array(0.2, requires_grad=True)
-        assert np.isclose(qnode(par).item().val, reference_qnode(par))
-        assert np.isclose(qml.jacobian(qnode)(par).item().val, qml.jacobian(reference_qnode)(par))
+        par = pnp.array(0.2, requires_grad=True)
+        assert pnp.isclose(qnode(par).item().val, reference_qnode(par))
+        assert pnp.isclose(qml.jacobian(qnode)(par).item().val, qml.jacobian(reference_qnode)(par))
 
     def test_multi_measure_no_warning(self):
         """Test computing the gradient of a tape that contains multiple
@@ -2676,8 +2676,8 @@ class TestParameterShiftRuleBroadcast:
     """Tests for the parameter shift implementation using broadcasting"""
 
     # pylint: disable=too-many-arguments
-    @pytest.mark.parametrize("theta", np.linspace(-2 * np.pi, 2 * np.pi, 7))
-    @pytest.mark.parametrize("shift", [np.pi / 2, 0.3, np.sqrt(2)])
+    @pytest.mark.parametrize("theta", pnp.linspace(-2 * pnp.pi, 2 * pnp.pi, 7))
+    @pytest.mark.parametrize("shift", [pnp.pi / 2, 0.3, pnp.sqrt(2)])
     @pytest.mark.parametrize("G", [qml.RX, qml.RY, qml.RZ, qml.PhaseShift])
     def test_pauli_rotation_gradient(self, mocker, G, theta, shift, tol):
         """Tests that the automatic gradients of Pauli rotations are correct with broadcasting."""
@@ -2685,7 +2685,7 @@ class TestParameterShiftRuleBroadcast:
         dev = qml.device("default.qubit", wires=1)
 
         with qml.queuing.AnnotatedQueue() as q:
-            qml.StatePrep(np.array([1.0, -1.0], requires_grad=False) / np.sqrt(2), wires=0)
+            qml.StatePrep(pnp.array([1.0, -1.0], requires_grad=False) / pnp.sqrt(2), wires=0)
             G(theta, wires=[0])
             qml.expval(qml.PauliZ(0))
 
@@ -2698,28 +2698,28 @@ class TestParameterShiftRuleBroadcast:
 
         autograd_val = fn(dev.execute(tapes))
 
-        tape_fwd = tape.bind_new_parameters([theta + np.pi / 2], [1])
-        tape_bwd = tape.bind_new_parameters([theta - np.pi / 2], [1])
+        tape_fwd = tape.bind_new_parameters([theta + pnp.pi / 2], [1])
+        tape_bwd = tape.bind_new_parameters([theta - pnp.pi / 2], [1])
 
-        manualgrad_val = np.subtract(*dev.execute([tape_fwd, tape_bwd])) / 2
-        assert np.allclose(autograd_val, manualgrad_val, atol=tol, rtol=0)
+        manualgrad_val = pnp.subtract(*dev.execute([tape_fwd, tape_bwd])) / 2
+        assert pnp.allclose(autograd_val, manualgrad_val, atol=tol, rtol=0)
 
         assert spy.call_args[1]["shifts"] == (shift,)
 
         tapes, fn = qml.gradients.finite_diff(tape)
         numeric_val = fn(dev.execute(tapes))
-        assert np.allclose(autograd_val, numeric_val, atol=tol, rtol=0)
+        assert pnp.allclose(autograd_val, numeric_val, atol=tol, rtol=0)
 
-    @pytest.mark.parametrize("theta", np.linspace(-2 * np.pi, 2 * np.pi, 7))
-    @pytest.mark.parametrize("shift", [np.pi / 2, 0.3, np.sqrt(2)])
+    @pytest.mark.parametrize("theta", pnp.linspace(-2 * pnp.pi, 2 * pnp.pi, 7))
+    @pytest.mark.parametrize("shift", [pnp.pi / 2, 0.3, pnp.sqrt(2)])
     def test_Rot_gradient(self, mocker, theta, shift, tol):
         """Tests that the automatic gradient of an arbitrary Euler-angle-parametrized gate is correct."""
         spy = mocker.spy(qml.gradients.parameter_shift, "_get_operation_recipe")
         dev = qml.device("default.qubit", wires=1)
-        params = np.array([theta, theta**3, np.sqrt(2) * theta])
+        params = pnp.array([theta, theta**3, pnp.sqrt(2) * theta])
 
         with qml.queuing.AnnotatedQueue() as q:
-            qml.StatePrep(np.array([1.0, -1.0], requires_grad=False) / np.sqrt(2), wires=0)
+            qml.StatePrep(pnp.array([1.0, -1.0], requires_grad=False) / pnp.sqrt(2), wires=0)
             qml.Rot(*params, wires=[0])
             qml.expval(qml.PauliZ(0))
 
@@ -2731,11 +2731,11 @@ class TestParameterShiftRuleBroadcast:
         assert [t.batch_size for t in tapes] == [2, 2, 2]
 
         autograd_val = fn(dev.execute(tapes))
-        manualgrad_val = np.zeros_like(autograd_val)
+        manualgrad_val = pnp.zeros_like(autograd_val)
 
-        for idx in list(np.ndindex(*params.shape)):
-            s = np.zeros_like(params)
-            s[idx] += np.pi / 2
+        for idx in list(pnp.ndindex(*params.shape)):
+            s = pnp.zeros_like(params)
+            s[idx] += pnp.pi / 2
 
             tape = tape.bind_new_parameters(params + s, [1, 2, 3])
             forward = dev.execute(tape)
@@ -2745,7 +2745,7 @@ class TestParameterShiftRuleBroadcast:
 
             manualgrad_val[idx] = (forward - backward) / 2
 
-        assert np.allclose(autograd_val, manualgrad_val, atol=tol, rtol=0)
+        assert pnp.allclose(autograd_val, manualgrad_val, atol=tol, rtol=0)
         assert spy.call_args[1]["shifts"] == (shift,)
 
         tapes, fn = qml.gradients.finite_diff(tape)
@@ -2753,7 +2753,7 @@ class TestParameterShiftRuleBroadcast:
 
         assert len(autograd_val) == len(numeric_val)
         for a, n in zip(autograd_val, numeric_val):
-            assert np.allclose(a, n, atol=tol, rtol=0)
+            assert pnp.allclose(a, n, atol=tol, rtol=0)
 
     @pytest.mark.parametrize("G", [qml.CRX, qml.CRY, qml.CRZ])
     def test_controlled_rotation_gradient(self, G, tol):
@@ -2762,7 +2762,7 @@ class TestParameterShiftRuleBroadcast:
         b = 0.123
 
         with qml.queuing.AnnotatedQueue() as q:
-            qml.StatePrep(np.array([1.0, -1.0], requires_grad=False) / np.sqrt(2), wires=0)
+            qml.StatePrep(pnp.array([1.0, -1.0], requires_grad=False) / pnp.sqrt(2), wires=0)
             G(b, wires=[0, 1])
             qml.expval(qml.PauliX(0))
 
@@ -2770,26 +2770,26 @@ class TestParameterShiftRuleBroadcast:
         tape.trainable_params = {1}
 
         res = dev.execute(tape)
-        assert np.allclose(res, -np.cos(b / 2), atol=tol, rtol=0)
+        assert pnp.allclose(res, -pnp.cos(b / 2), atol=tol, rtol=0)
 
         tapes, fn = qml.gradients.param_shift(tape, broadcast=True)
         grad = fn(dev.execute(tapes))
-        expected = np.sin(b / 2) / 2
-        assert np.allclose(grad, expected, atol=tol, rtol=0)
+        expected = pnp.sin(b / 2) / 2
+        assert pnp.allclose(grad, expected, atol=tol, rtol=0)
 
         tapes, fn = qml.gradients.finite_diff(tape)
         numeric_val = fn(dev.execute(tapes))
-        assert np.allclose(grad, numeric_val, atol=tol, rtol=0)
+        assert pnp.allclose(grad, numeric_val, atol=tol, rtol=0)
 
-    @pytest.mark.parametrize("theta", np.linspace(-2 * np.pi, np.pi, 7))
+    @pytest.mark.parametrize("theta", pnp.linspace(-2 * pnp.pi, pnp.pi, 7))
     def test_CRot_gradient(self, theta, tol):
         """Tests that the automatic gradient of an arbitrary controlled Euler-angle-parametrized
         gate is correct."""
         dev = qml.device("default.qubit", wires=2)
-        a, b, c = np.array([theta, theta**3, np.sqrt(2) * theta])
+        a, b, c = pnp.array([theta, theta**3, pnp.sqrt(2) * theta])
 
         with qml.queuing.AnnotatedQueue() as q:
-            qml.StatePrep(np.array([1.0, -1.0], requires_grad=False) / np.sqrt(2), wires=0)
+            qml.StatePrep(pnp.array([1.0, -1.0], requires_grad=False) / pnp.sqrt(2), wires=0)
             qml.CRot(a, b, c, wires=[0, 1])
             qml.expval(qml.PauliX(0))
 
@@ -2797,33 +2797,33 @@ class TestParameterShiftRuleBroadcast:
         tape.trainable_params = {1, 2, 3}
 
         res = dev.execute(tape)
-        expected = -np.cos(b / 2) * np.cos(0.5 * (a + c))
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        expected = -pnp.cos(b / 2) * pnp.cos(0.5 * (a + c))
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
         tapes, fn = qml.gradients.param_shift(tape, broadcast=True)
         assert len(tapes) == len(tape.trainable_params)
         assert [t.batch_size for t in tapes] == [4, 4, 4]
 
         grad = fn(dev.execute(tapes))
-        expected = np.array(
+        expected = pnp.array(
             [
-                0.5 * np.cos(b / 2) * np.sin(0.5 * (a + c)),
-                0.5 * np.sin(b / 2) * np.cos(0.5 * (a + c)),
-                0.5 * np.cos(b / 2) * np.sin(0.5 * (a + c)),
+                0.5 * pnp.cos(b / 2) * pnp.sin(0.5 * (a + c)),
+                0.5 * pnp.sin(b / 2) * pnp.cos(0.5 * (a + c)),
+                0.5 * pnp.cos(b / 2) * pnp.sin(0.5 * (a + c)),
             ]
         )
         assert len(grad) == len(expected)
         for g, e in zip(grad, expected):
-            assert np.allclose(g, e, atol=tol, rtol=0)
+            assert pnp.allclose(g, e, atol=tol, rtol=0)
 
         tapes, fn = qml.gradients.finite_diff(tape)
         numeric_val = fn(dev.execute(tapes))
-        assert np.allclose(grad, numeric_val, atol=tol, rtol=0)
+        assert pnp.allclose(grad, numeric_val, atol=tol, rtol=0)
 
     def test_gradients_agree_finite_differences(self, tol):
         """Tests that the parameter-shift rule agrees with the first and second
         order finite differences"""
-        params = np.array([0.1, -1.6, np.pi / 5])
+        params = pnp.array([0.1, -1.6, pnp.pi / 5])
 
         with qml.queuing.AnnotatedQueue() as q:
             qml.RX(params[0], wires=[0])
@@ -2846,13 +2846,13 @@ class TestParameterShiftRuleBroadcast:
         grad_A = grad_fn(tape, dev, broadcast=True)
 
         # gradients computed with different methods must agree
-        assert np.allclose(grad_A, grad_F1, atol=tol, rtol=0)
-        assert np.allclose(grad_A, grad_F2, atol=tol, rtol=0)
+        assert pnp.allclose(grad_A, grad_F1, atol=tol, rtol=0)
+        assert pnp.allclose(grad_A, grad_F2, atol=tol, rtol=0)
 
     def test_variance_gradients_agree_finite_differences(self, tol):
         """Tests that the variance parameter-shift rule agrees with the first and second
         order finite differences"""
-        params = np.array([0.1, -1.6, np.pi / 5])
+        params = pnp.array([0.1, -1.6, pnp.pi / 5])
 
         with qml.queuing.AnnotatedQueue() as q:
             qml.RX(params[0], wires=[0])
@@ -2878,8 +2878,8 @@ class TestParameterShiftRuleBroadcast:
         # gradients computed with different methods must agree
         for idx1, _grad_A in enumerate(grad_A):
             for idx2, g in enumerate(_grad_A):
-                assert np.allclose(g, grad_F1[idx1][idx2], atol=tol, rtol=0)
-                assert np.allclose(g, grad_F2[idx1][idx2], atol=tol, rtol=0)
+                assert pnp.allclose(g, grad_F1[idx1][idx2], atol=tol, rtol=0)
+                assert pnp.allclose(g, grad_F2[idx1][idx2], atol=tol, rtol=0)
 
     @pytest.mark.jax
     def test_fallback(self, mocker, tol):
@@ -2916,13 +2916,13 @@ class TestParameterShiftRuleBroadcast:
         res = cost_fn(params)
         assert len(res) == 2 and isinstance(res, tuple)
         assert all(len(r) == 2 and isinstance(r, tuple) for r in res)
-        expected = ((-np.sin(x), 0), (0, -2 * np.cos(y) * np.sin(y)))
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        expected = ((-pnp.sin(x), 0), (0, -2 * pnp.cos(y) * pnp.sin(y)))
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
         # double check the derivative
         jac = jax.jacobian(cost_fn)(params)
-        assert np.allclose(jac[0][0][0], -np.cos(x), atol=tol, rtol=0)
-        assert np.allclose(jac[1][1][1], -2 * np.cos(2 * y), atol=tol, rtol=0)
+        assert pnp.allclose(jac[0][0][0], -pnp.cos(x), atol=tol, rtol=0)
+        assert pnp.allclose(jac[1][1][1], -2 * pnp.cos(2 * y), atol=tol, rtol=0)
 
     @pytest.mark.autograd
     def test_all_fallback(self, mocker, tol):
@@ -2954,8 +2954,8 @@ class TestParameterShiftRuleBroadcast:
         assert res[0].shape == ()
         assert res[1].shape == ()
 
-        expected = np.array([[-np.sin(y) * np.sin(x), np.cos(y) * np.cos(x)]])
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        expected = pnp.array([[-pnp.sin(y) * pnp.sin(x), pnp.cos(y) * pnp.cos(x)]])
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
     def test_single_expectation_value(self, tol):
         """Tests correct output shape and evaluation for a tape
@@ -2980,10 +2980,10 @@ class TestParameterShiftRuleBroadcast:
         assert res[0].shape == ()
         assert res[1].shape == ()
 
-        expected = np.array([-np.sin(y) * np.sin(x), np.cos(y) * np.cos(x)])
+        expected = pnp.array([-pnp.sin(y) * pnp.sin(x), pnp.cos(y) * pnp.cos(x)])
         assert len(res) == len(expected)
         for r, e in zip(res, expected):
-            assert np.allclose(r, e, atol=tol, rtol=0)
+            assert pnp.allclose(r, e, atol=tol, rtol=0)
 
     def test_multiple_expectation_values(self, tol):
         """Tests correct output shape and evaluation for a tape
@@ -3003,8 +3003,8 @@ class TestParameterShiftRuleBroadcast:
         assert len(res) == 2
         assert all(len(r) == 2 for r in res)
 
-        expected = np.array([[-np.sin(x), 0], [0, np.cos(y)]])
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        expected = pnp.array([[-pnp.sin(x), 0], [0, pnp.cos(y)]])
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
     def test_var_expectation_values(self, tol):
         """Tests correct output shape and evaluation for a tape
@@ -3025,8 +3025,8 @@ class TestParameterShiftRuleBroadcast:
         assert len(res) == 2
         assert all(len(r) == 2 for r in res)
 
-        expected = np.array([[-np.sin(x), 0], [0, -2 * np.cos(y) * np.sin(y)]])
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        expected = pnp.array([[-pnp.sin(x), 0], [0, -2 * pnp.cos(y) * pnp.sin(y)]])
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
     def test_prob_expectation_values(self, tol):
         """Tests correct output shape and evaluation for a tape
@@ -3045,18 +3045,18 @@ class TestParameterShiftRuleBroadcast:
         res = fn(dev.execute(tapes))
         assert isinstance(res, tuple) and len(res) == 2
         assert all(isinstance(r, tuple) and len(r) == 2 for r in res)
-        assert all(isinstance(r, np.ndarray) and r.shape == () for r in res[0])
-        assert all(isinstance(r, np.ndarray) and r.shape == (4,) for r in res[1])
+        assert all(isinstance(r, pnp.ndarray) and r.shape == () for r in res[0])
+        assert all(isinstance(r, pnp.ndarray) and r.shape == (4,) for r in res[1])
 
-        expected_expval = (-np.sin(x), 0)
-        sx, cx, sy, cy = np.sin(x / 2), np.cos(x / 2), np.sin(y / 2), np.cos(y / 2)
+        expected_expval = (-pnp.sin(x), 0)
+        sx, cx, sy, cy = pnp.sin(x / 2), pnp.cos(x / 2), pnp.sin(y / 2), pnp.cos(y / 2)
         expected_probs = (
-            np.sin(x) / 2 * np.array([-(cy**2), -(sy**2), sy**2, cy**2]),
-            np.array([-(cx**2), cx**2, sx**2, -(sx**2)]) * np.sin(y) / 2,
+            pnp.sin(x) / 2 * pnp.array([-(cy**2), -(sy**2), sy**2, cy**2]),
+            pnp.array([-(cx**2), cx**2, sx**2, -(sx**2)]) * pnp.sin(y) / 2,
         )
 
-        assert np.allclose(res[0], expected_expval, atol=tol, rtol=0)
-        assert np.allclose(res[1], expected_probs, atol=tol, rtol=0)
+        assert pnp.allclose(res[0], expected_expval, atol=tol, rtol=0)
+        assert pnp.allclose(res[1], expected_probs, atol=tol, rtol=0)
 
     def test_involutory_variance(self, tol):
         """Tests qubit observables that are involutory"""
@@ -3069,13 +3069,13 @@ class TestParameterShiftRuleBroadcast:
 
         tape = qml.tape.QuantumScript.from_queue(q)
         res = dev.execute(tape)
-        expected = 1 - np.cos(a) ** 2
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        expected = 1 - pnp.cos(a) ** 2
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
         # circuit jacobians
         tapes, fn = qml.gradients.param_shift(tape, broadcast=True)
         gradA = fn(dev.execute(tapes))
-        assert isinstance(gradA, np.ndarray)
+        assert isinstance(gradA, pnp.ndarray)
         assert gradA.shape == ()
 
         assert len(tapes) == 2
@@ -3086,7 +3086,7 @@ class TestParameterShiftRuleBroadcast:
         gradF = fn(dev.execute(tapes))
         assert len(tapes) == 2
 
-        expected = 2 * np.sin(a) * np.cos(a)
+        expected = 2 * pnp.sin(a) * pnp.cos(a)
 
         assert gradF == pytest.approx(expected, abs=tol)
         assert gradA == pytest.approx(expected, abs=tol)
@@ -3094,7 +3094,7 @@ class TestParameterShiftRuleBroadcast:
     def test_non_involutory_variance(self, tol):
         """Tests a qubit Hermitian observable that is not involutory"""
         dev = qml.device("default.qubit", wires=1)
-        A = np.array([[4, -1 + 6j], [-1 - 6j, 2]])
+        A = pnp.array([[4, -1 + 6j], [-1 - 6j, 2]])
         a = 0.54
 
         with qml.queuing.AnnotatedQueue() as q:
@@ -3105,13 +3105,13 @@ class TestParameterShiftRuleBroadcast:
         tape.trainable_params = {0}
 
         res = dev.execute(tape)
-        expected = (39 / 2) - 6 * np.sin(2 * a) + (35 / 2) * np.cos(2 * a)
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        expected = (39 / 2) - 6 * pnp.sin(2 * a) + (35 / 2) * pnp.cos(2 * a)
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
         # circuit jacobians
         tapes, fn = qml.gradients.param_shift(tape, broadcast=True)
         gradA = fn(dev.execute(tapes))
-        assert isinstance(gradA, np.ndarray)
+        assert isinstance(gradA, pnp.ndarray)
         assert gradA.shape == ()
 
         assert len(tapes) == 1 + 2 * 1
@@ -3122,7 +3122,7 @@ class TestParameterShiftRuleBroadcast:
         gradF = fn(dev.execute(tapes))
         assert len(tapes) == 2
 
-        expected = -35 * np.sin(2 * a) - 12 * np.cos(2 * a)
+        expected = -35 * pnp.sin(2 * a) - 12 * pnp.cos(2 * a)
         assert gradA == pytest.approx(expected, abs=tol)
         assert gradF == pytest.approx(expected, abs=tol)
 
@@ -3130,7 +3130,7 @@ class TestParameterShiftRuleBroadcast:
         """Tests a qubit Hermitian observable that is not involutory alongside
         an involutory observable."""
         dev = qml.device("default.qubit", wires=2)
-        A = np.array([[4, -1 + 6j], [-1 - 6j, 2]])
+        A = pnp.array([[4, -1 + 6j], [-1 - 6j, 2]])
         a = 0.54
 
         meas = [qml.var(qml.Z(0)), qml.var(qml.Hermitian(A, 1))]
@@ -3138,8 +3138,8 @@ class TestParameterShiftRuleBroadcast:
         tape.trainable_params = {0, 1}
 
         res = dev.execute(tape)
-        expected = [1 - np.cos(a) ** 2, (39 / 2) - 6 * np.sin(2 * a) + (35 / 2) * np.cos(2 * a)]
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        expected = [1 - pnp.cos(a) ** 2, (39 / 2) - 6 * pnp.sin(2 * a) + (35 / 2) * pnp.cos(2 * a)]
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
         # circuit jacobians
         tapes, fn = qml.gradients.param_shift(tape, broadcast=True)
@@ -3151,9 +3151,9 @@ class TestParameterShiftRuleBroadcast:
         gradF = fn(dev.execute(tapes))
         assert len(tapes) == 1 + 2
 
-        expected = [2 * np.sin(a) * np.cos(a), -35 * np.sin(2 * a) - 12 * np.cos(2 * a)]
-        assert np.diag(gradA) == pytest.approx(expected, abs=tol)
-        assert np.diag(gradF) == pytest.approx(expected, abs=tol)
+        expected = [2 * pnp.sin(a) * pnp.cos(a), -35 * pnp.sin(2 * a) - 12 * pnp.cos(2 * a)]
+        assert pnp.diag(gradA) == pytest.approx(expected, abs=tol)
+        assert pnp.diag(gradF) == pytest.approx(expected, abs=tol)
 
     def test_expval_and_variance(self, tol):
         """Test that the gradient transform works for a combination of expectation
@@ -3168,14 +3168,14 @@ class TestParameterShiftRuleBroadcast:
 
         tape = qml.tape.QuantumScript(ops, meas)
         res = dev.execute(tape)
-        expected = np.array(
+        expected = pnp.array(
             [
-                np.sin(a) ** 2,
-                np.cos(a) * np.cos(b),
-                0.25 * (3 - 2 * np.cos(b) ** 2 * np.cos(2 * c) - np.cos(2 * b)),
+                pnp.sin(a) ** 2,
+                pnp.cos(a) * pnp.cos(b),
+                0.25 * (3 - 2 * pnp.cos(b) ** 2 * pnp.cos(2 * c) - pnp.cos(2 * b)),
             ]
         )
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
         # circuit jacobians
         tapes, fn = qml.gradients.param_shift(tape, broadcast=True)
@@ -3183,9 +3183,9 @@ class TestParameterShiftRuleBroadcast:
 
         tapes, fn = qml.gradients.finite_diff(tape)
         gradF = fn(dev.execute(tapes))
-        ca, sa, cb, sb = np.cos(a), np.sin(a), np.cos(b), np.sin(b)
-        c2c, s2c, s2b = np.cos(2 * c), np.sin(2 * c), np.sin(2 * b)
-        expected = np.array(
+        ca, sa, cb, sb = pnp.cos(a), pnp.sin(a), pnp.cos(b), pnp.sin(b)
+        c2c, s2c, s2b = pnp.cos(2 * c), pnp.sin(2 * c), pnp.sin(2 * b)
+        expected = pnp.array(
             [
                 [2 * ca * sa, -cb * sa, 0],
                 [0, -ca * sb, 0.5 * (2 * cb * c2c * sb + s2b)],
@@ -3211,8 +3211,8 @@ class TestParameterShiftRuleBroadcast:
         tape.trainable_params = {0, 1}
 
         res = dev.execute(tape)
-        expected = 0.25 * np.sin(x / 2) ** 2 * (3 + np.cos(2 * y) + 2 * np.cos(x) * np.sin(y) ** 2)
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        expected = 0.25 * pnp.sin(x / 2) ** 2 * (3 + pnp.cos(2 * y) + 2 * pnp.cos(x) * pnp.sin(y) ** 2)
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
         # circuit jacobians
         tapes, fn = qml.gradients.param_shift(tape, broadcast=True)
@@ -3221,15 +3221,15 @@ class TestParameterShiftRuleBroadcast:
         tapes, fn = qml.gradients.finite_diff(tape)
         gradF = fn(dev.execute(tapes))
 
-        expected = np.array(
+        expected = pnp.array(
             [
-                0.5 * np.sin(x) * (np.cos(x / 2) ** 2 + np.cos(2 * y) * np.sin(x / 2) ** 2),
-                -2 * np.cos(y) * np.sin(x / 2) ** 4 * np.sin(y),
+                0.5 * pnp.sin(x) * (pnp.cos(x / 2) ** 2 + pnp.cos(2 * y) * pnp.sin(x / 2) ** 2),
+                -2 * pnp.cos(y) * pnp.sin(x / 2) ** 4 * pnp.sin(y),
             ]
         )
         assert len(gradA) == len(expected)
         for a, e in zip(gradA, expected):
-            assert np.allclose(a, e, atol=tol, rtol=0)
+            assert pnp.allclose(a, e, atol=tol, rtol=0)
 
         assert gradF == pytest.approx(expected, abs=tol)
 
@@ -3267,7 +3267,7 @@ class TestParameterShiftRuleBroadcast:
             qml.Rot(*x, wires=0)
             return [qml.probs([0, 1]), qml.probs([2, 3])]
 
-        x = np.random.rand(3)
+        x = pnp.random.rand(3)
         single_measure_circuits = [
             qml.QNode(cost, dev) for cost in (cost1, cost2, cost4, cost5)
         ] + [qml.QNode(cost, dev) for cost in (cost3, cost6)]
@@ -3291,7 +3291,7 @@ class TestParamShiftGradients:
         """Tests that the output of the parameter-shift transform
         can be differentiated using autograd, yielding second derivatives."""
         dev = qml.device("default.qubit", wires=2)
-        params = np.array([0.543, -0.654], requires_grad=True)
+        params = pnp.array([0.543, -0.654], requires_grad=True)
         exp_num_tapes, exp_batch_sizes = expected
 
         def cost_fn(x):
@@ -3311,13 +3311,13 @@ class TestParamShiftGradients:
 
         res = qml.jacobian(cost_fn)(params)
         x, y = params
-        expected = np.array(
+        expected = pnp.array(
             [
-                [2 * np.cos(2 * x) * np.sin(y) ** 2, np.sin(2 * x) * np.sin(2 * y)],
-                [np.sin(2 * x) * np.sin(2 * y), -2 * np.cos(x) ** 2 * np.cos(2 * y)],
+                [2 * pnp.cos(2 * x) * pnp.sin(y) ** 2, pnp.sin(2 * x) * pnp.sin(2 * y)],
+                [pnp.sin(2 * x) * pnp.sin(2 * y), -2 * pnp.cos(x) ** 2 * pnp.cos(2 * y)],
             ]
         )
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
 
 @pytest.mark.parametrize("broadcast", [True, False])
@@ -3328,10 +3328,10 @@ class TestHamiltonianExpvalGradients:
     def test_not_var_or_exp_val_error(self, broadcast):
         """Tests error raised when the counts of the Hamiltonian is requested"""
         obs = [qml.PauliZ(0), qml.PauliZ(0) @ qml.PauliX(1), qml.PauliY(0)]
-        coeffs = np.array([0.1, 0.2, 0.3])
+        coeffs = pnp.array([0.1, 0.2, 0.3])
         H = qml.Hamiltonian(coeffs, obs)
 
-        weights = np.array([0.4, 0.5])
+        weights = pnp.array([0.4, 0.5])
 
         with qml.queuing.AnnotatedQueue() as q:
             qml.RX(weights[0], wires=0)
@@ -3349,10 +3349,10 @@ class TestHamiltonianExpvalGradients:
         """Test that if the variance of the Hamiltonian is requested,
         an error is raised"""
         obs = [qml.PauliZ(0), qml.PauliZ(0) @ qml.PauliX(1), qml.PauliY(0)]
-        coeffs = np.array([0.1, 0.2, 0.3])
+        coeffs = pnp.array([0.1, 0.2, 0.3])
         H = qml.Hamiltonian(coeffs, obs)
 
-        weights = np.array([0.4, 0.5])
+        weights = pnp.array([0.4, 0.5])
 
         with qml.queuing.AnnotatedQueue() as q:
             qml.RX(weights[0], wires=0)
@@ -3370,10 +3370,10 @@ class TestHamiltonianExpvalGradients:
         """Test that if the variance of a non-trainable Hamiltonian is requested,
         no error is raised"""
         obs = [qml.PauliZ(0), qml.PauliZ(0) @ qml.PauliX(1), qml.PauliY(0)]
-        coeffs = np.array([0.1, 0.2, 0.3])
+        coeffs = pnp.array([0.1, 0.2, 0.3])
         H = qml.Hamiltonian(coeffs, obs)
 
-        weights = np.array([0.4, 0.5])
+        weights = pnp.array([0.4, 0.5])
 
         with qml.queuing.AnnotatedQueue() as q:
             qml.RX(weights[0], wires=0)
@@ -3393,10 +3393,10 @@ class TestHamiltonianExpvalGradients:
         spy = mocker.spy(qml.gradients, "hamiltonian_grad")
 
         obs = [qml.PauliZ(0), qml.PauliZ(0) @ qml.PauliX(1), qml.PauliY(0)]
-        coeffs = np.array([0.1, 0.2, 0.3])
+        coeffs = pnp.array([0.1, 0.2, 0.3])
         H = qml.Hamiltonian(coeffs, obs)
 
-        weights = np.array([0.4, 0.5])
+        weights = pnp.array([0.4, 0.5])
 
         with qml.queuing.AnnotatedQueue() as q:
             qml.RX(weights[0], wires=0)
@@ -3410,8 +3410,8 @@ class TestHamiltonianExpvalGradients:
         tape.trainable_params = {0, 1}
 
         res = dev.execute([tape])
-        expected = -c * np.sin(x) * np.sin(y) + np.cos(x) * (a + b * np.sin(y))
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        expected = -c * pnp.sin(x) * pnp.sin(y) + pnp.cos(x) * (a + b * pnp.sin(y))
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
         tapes, fn = qml.gradients.param_shift(tape, broadcast=broadcast)
         # two (broadcasted if broadcast=True) shifts per rotation gate
@@ -3427,11 +3427,11 @@ class TestHamiltonianExpvalGradients:
         assert res[1].shape == ()
 
         expected = [
-            -c * np.cos(x) * np.sin(y) - np.sin(x) * (a + b * np.sin(y)),
-            b * np.cos(x) * np.cos(y) - c * np.cos(y) * np.sin(x),
+            -c * pnp.cos(x) * pnp.sin(y) - pnp.sin(x) * (a + b * pnp.sin(y)),
+            b * pnp.cos(x) * pnp.cos(y) - c * pnp.cos(y) * pnp.sin(x),
         ]
-        assert np.allclose(res[0], expected[0], atol=tol, rtol=0)
-        assert np.allclose(res[1], expected[1], atol=tol, rtol=0)
+        assert pnp.allclose(res[0], expected[0], atol=tol, rtol=0)
+        assert pnp.allclose(res[1], expected[1], atol=tol, rtol=0)
 
     def test_trainable_coeffs(self, mocker, tol, broadcast):
         """Test trainable Hamiltonian coefficients"""
@@ -3439,10 +3439,10 @@ class TestHamiltonianExpvalGradients:
         spy = mocker.spy(qml.gradients, "hamiltonian_grad")
 
         obs = [qml.PauliZ(0), qml.PauliZ(0) @ qml.PauliX(1), qml.PauliY(0)]
-        coeffs = np.array([0.1, 0.2, 0.3])
+        coeffs = pnp.array([0.1, 0.2, 0.3])
         H = qml.Hamiltonian(coeffs, obs)
 
-        weights = np.array([0.4, 0.5])
+        weights = pnp.array([0.4, 0.5])
 
         with qml.queuing.AnnotatedQueue() as q:
             qml.RX(weights[0], wires=0)
@@ -3456,8 +3456,8 @@ class TestHamiltonianExpvalGradients:
         tape.trainable_params = {0, 1, 2, 4}
 
         res = dev.execute([tape])
-        expected = -c * np.sin(x) * np.sin(y) + np.cos(x) * (a + b * np.sin(y))
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        expected = -c * pnp.sin(x) * pnp.sin(y) + pnp.cos(x) * (a + b * pnp.sin(y))
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
         tapes, fn = qml.gradients.param_shift(tape, broadcast=broadcast)
         # two (broadcasted if broadcast=True) shifts per rotation gate
@@ -3475,15 +3475,15 @@ class TestHamiltonianExpvalGradients:
         assert res[3].shape == ()
 
         expected = [
-            -c * np.cos(x) * np.sin(y) - np.sin(x) * (a + b * np.sin(y)),
-            b * np.cos(x) * np.cos(y) - c * np.cos(y) * np.sin(x),
-            np.cos(x),
-            -(np.sin(x) * np.sin(y)),
+            -c * pnp.cos(x) * pnp.sin(y) - pnp.sin(x) * (a + b * pnp.sin(y)),
+            b * pnp.cos(x) * pnp.cos(y) - c * pnp.cos(y) * pnp.sin(x),
+            pnp.cos(x),
+            -(pnp.sin(x) * pnp.sin(y)),
         ]
-        assert np.allclose(res[0], expected[0], atol=tol, rtol=0)
-        assert np.allclose(res[1], expected[1], atol=tol, rtol=0)
-        assert np.allclose(res[2], expected[2], atol=tol, rtol=0)
-        assert np.allclose(res[3], expected[3], atol=tol, rtol=0)
+        assert pnp.allclose(res[0], expected[0], atol=tol, rtol=0)
+        assert pnp.allclose(res[1], expected[1], atol=tol, rtol=0)
+        assert pnp.allclose(res[2], expected[2], atol=tol, rtol=0)
+        assert pnp.allclose(res[3], expected[3], atol=tol, rtol=0)
 
     def test_multiple_hamiltonians(self, mocker, tol, broadcast):
         """Test multiple trainable Hamiltonian coefficients"""
@@ -3491,16 +3491,16 @@ class TestHamiltonianExpvalGradients:
         spy = mocker.spy(qml.gradients, "hamiltonian_grad")
 
         obs = [qml.PauliZ(0), qml.PauliZ(0) @ qml.PauliX(1), qml.PauliY(0)]
-        coeffs = np.array([0.1, 0.2, 0.3])
+        coeffs = pnp.array([0.1, 0.2, 0.3])
         a, b, c = coeffs
         H1 = qml.Hamiltonian(coeffs, obs)
 
         obs = [qml.PauliZ(0)]
-        coeffs = np.array([0.7])
+        coeffs = pnp.array([0.7])
         d = coeffs[0]
         H2 = qml.Hamiltonian(coeffs, obs)
 
-        weights = np.array([0.4, 0.5])
+        weights = pnp.array([0.4, 0.5])
         x, y = weights
 
         with qml.queuing.AnnotatedQueue() as q:
@@ -3514,8 +3514,8 @@ class TestHamiltonianExpvalGradients:
         tape.trainable_params = {0, 1, 2, 4, 5}
 
         res = dev.execute([tape])
-        expected = [-c * np.sin(x) * np.sin(y) + np.cos(x) * (a + b * np.sin(y)), d * np.cos(x)]
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        expected = [-c * pnp.sin(x) * pnp.sin(y) + pnp.cos(x) * (a + b * pnp.sin(y)), d * pnp.cos(x)]
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
         tapes, fn = qml.gradients.param_shift(tape, broadcast=broadcast)
         # two shifts per rotation gate (in one batched tape if broadcasting),
@@ -3531,16 +3531,16 @@ class TestHamiltonianExpvalGradients:
 
         expected = [
             [
-                -c * np.cos(x) * np.sin(y) - np.sin(x) * (a + b * np.sin(y)),
-                b * np.cos(x) * np.cos(y) - c * np.cos(y) * np.sin(x),
-                np.cos(x),
-                -(np.sin(x) * np.sin(y)),
+                -c * pnp.cos(x) * pnp.sin(y) - pnp.sin(x) * (a + b * pnp.sin(y)),
+                b * pnp.cos(x) * pnp.cos(y) - c * pnp.cos(y) * pnp.sin(x),
+                pnp.cos(x),
+                -(pnp.sin(x) * pnp.sin(y)),
                 0,
             ],
-            [-d * np.sin(x), 0, 0, 0, np.cos(x)],
+            [-d * pnp.sin(x), 0, 0, 0, pnp.cos(x)],
         ]
 
-        assert np.allclose(np.stack(res), expected, atol=tol, rtol=0)
+        assert pnp.allclose(pnp.stack(res), expected, atol=tol, rtol=0)
 
     @staticmethod
     def cost_fn(weights, coeffs1, coeffs2, dev=None, broadcast=False):
@@ -3572,28 +3572,28 @@ class TestHamiltonianExpvalGradients:
         x, y = weights
         return [
             [
-                -c * np.cos(x) * np.sin(y) - np.sin(x) * (a + b * np.sin(y)),
-                b * np.cos(x) * np.cos(y) - c * np.cos(y) * np.sin(x),
-                np.cos(x),
-                np.cos(x) * np.sin(y),
-                -(np.sin(x) * np.sin(y)),
+                -c * pnp.cos(x) * pnp.sin(y) - pnp.sin(x) * (a + b * pnp.sin(y)),
+                b * pnp.cos(x) * pnp.cos(y) - c * pnp.cos(y) * pnp.sin(x),
+                pnp.cos(x),
+                pnp.cos(x) * pnp.sin(y),
+                -(pnp.sin(x) * pnp.sin(y)),
                 0,
             ],
-            [-d * np.sin(x), 0, 0, 0, 0, np.cos(x)],
+            [-d * pnp.sin(x), 0, 0, 0, 0, pnp.cos(x)],
         ]
 
     @pytest.mark.autograd
     def test_autograd(self, tol, broadcast):
         """Test gradient of multiple trainable Hamiltonian coefficients
         using autograd"""
-        coeffs1 = np.array([0.1, 0.2, 0.3], requires_grad=True)
-        coeffs2 = np.array([0.7], requires_grad=True)
-        weights = np.array([0.4, 0.5], requires_grad=True)
+        coeffs1 = pnp.array([0.1, 0.2, 0.3], requires_grad=True)
+        coeffs2 = pnp.array([0.7], requires_grad=True)
+        weights = pnp.array([0.4, 0.5], requires_grad=True)
         dev = qml.device("default.qubit", wires=2)
 
         res = self.cost_fn(weights, coeffs1, coeffs2, dev, broadcast)
         expected = self.cost_fn_expected(weights, coeffs1, coeffs2)
-        assert np.allclose(res, np.array(expected), atol=tol, rtol=0)
+        assert pnp.allclose(res, pnp.array(expected), atol=tol, rtol=0)
 
         # TODO: test when Hessians are supported with the new return types
         # second derivative wrt to Hamiltonian coefficients should be zero
@@ -3618,8 +3618,8 @@ class TestHamiltonianExpvalGradients:
             jac = self.cost_fn(weights, coeffs1, coeffs2, dev, broadcast)
 
         expected = self.cost_fn_expected(weights.numpy(), coeffs1.numpy(), coeffs2.numpy())
-        assert np.allclose(jac[0], np.array(expected)[0], atol=tol, rtol=0)
-        assert np.allclose(jac[1], np.array(expected)[1], atol=tol, rtol=0)
+        assert pnp.allclose(jac[0], pnp.array(expected)[0], atol=tol, rtol=0)
+        assert pnp.allclose(jac[1], pnp.array(expected)[1], atol=tol, rtol=0)
 
         # TODO: test when Hessians are supported with the new return types
         # second derivative wrt to Hamiltonian coefficients should be zero.
@@ -3646,7 +3646,7 @@ class TestHamiltonianExpvalGradients:
             weights.detach().numpy(), coeffs1.detach().numpy(), coeffs2.detach().numpy()
         )
         res = tuple(tuple(_r.detach() for _r in r) for r in res)
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
         # second derivative wrt to Hamiltonian coefficients should be zero
         # hess = torch.autograd.functional.jacobian(
@@ -3670,7 +3670,7 @@ class TestHamiltonianExpvalGradients:
 
         res = self.cost_fn(weights, coeffs1, coeffs2, dev, broadcast)
         expected = self.cost_fn_expected(weights, coeffs1, coeffs2)
-        assert np.allclose(res, np.array(expected), atol=tol, rtol=0)
+        assert pnp.allclose(res, pnp.array(expected), atol=tol, rtol=0)
 
         # TODO: test when Hessians are supported with the new return types
         # second derivative wrt to Hamiltonian coefficients should be zero
@@ -3707,7 +3707,7 @@ class TestQnodeAutograd:
         res_expected = qml.jacobian(circuit)(x)
 
         assert res.shape == res_expected.shape
-        assert np.allclose(res, res_expected)
+        assert pnp.allclose(res, res_expected)
 
     @pytest.mark.parametrize("interface", interfaces)
     def test_single_measurement_single_param_not_hybrid(self, interface):
@@ -3726,7 +3726,7 @@ class TestQnodeAutograd:
 
         res_expected = qml.jacobian(circuit)(x)
         assert res.shape == res_expected.shape
-        assert np.allclose(2 * res, res_expected)
+        assert pnp.allclose(2 * res, res_expected)
 
     @pytest.mark.parametrize("interface", interfaces)
     def test_single_measurement_single_param_2(self, interface):
@@ -3746,7 +3746,7 @@ class TestQnodeAutograd:
         res_expected = qml.jacobian(circuit)(x)
 
         assert res.shape == res_expected.shape
-        assert np.allclose(res, res_expected)
+        assert pnp.allclose(res, res_expected)
 
     @pytest.mark.parametrize("interface", interfaces)
     def test_single_measurement_prob_single_param(self, interface):
@@ -3766,7 +3766,7 @@ class TestQnodeAutograd:
         res_expected = qml.jacobian(circuit)(x)
 
         assert res.shape == res_expected.shape
-        assert np.allclose(res, res_expected)
+        assert pnp.allclose(res, res_expected)
 
     @pytest.mark.parametrize("interface", interfaces)
     def test_single_measurement_prob_single_param_2(self, interface):
@@ -3784,7 +3784,7 @@ class TestQnodeAutograd:
         res = qml.gradients.param_shift(circuit)(x)
         res_expected = qml.jacobian(circuit)(x)
 
-        assert np.allclose(res, res_expected)
+        assert pnp.allclose(res, res_expected)
 
     @pytest.mark.parametrize("interface", interfaces)
     def test_multi_measurement_single_param(self, interface):
@@ -3806,8 +3806,8 @@ class TestQnodeAutograd:
 
         res_expected = qml.jacobian(cost)(x)
 
-        assert np.allclose(res[0], res_expected[0])
-        assert np.allclose(res[1], res_expected[1])
+        assert pnp.allclose(res[0], res_expected[0])
+        assert pnp.allclose(res[1], res_expected[1])
 
     @pytest.mark.parametrize("interface", interfaces)
     def test_multi_measurement_expval_probs_single_param(self, interface):
@@ -3829,11 +3829,11 @@ class TestQnodeAutograd:
 
         res_expected = qml.jacobian(cost)(x)
 
-        assert np.allclose(res[0], res_expected[0])
-        assert np.allclose(res[1][0], res_expected[1])
-        assert np.allclose(res[1][1], res_expected[2])
-        assert np.allclose(res[1][2], res_expected[3])
-        assert np.allclose(res[1][3], res_expected[4])
+        assert pnp.allclose(res[0], res_expected[0])
+        assert pnp.allclose(res[1][0], res_expected[1])
+        assert pnp.allclose(res[1][1], res_expected[2])
+        assert pnp.allclose(res[1][2], res_expected[3])
+        assert pnp.allclose(res[1][3], res_expected[4])
 
     @pytest.mark.parametrize("interface", interfaces)
     def test_single_measurement_multiple_params(self, interface):
@@ -3853,8 +3853,8 @@ class TestQnodeAutograd:
         res = qml.gradients.param_shift(circuit)(x, y)
         res_expected = qml.jacobian(circuit)(x, y)
 
-        assert np.allclose(res[0], res_expected[0])
-        assert np.allclose(res[1], res_expected[1])
+        assert pnp.allclose(res[0], res_expected[0])
+        assert pnp.allclose(res[1], res_expected[1])
 
     @pytest.mark.parametrize("interface", interfaces)
     def test_single_measurement_probs_multiple_params(self, interface):
@@ -3874,8 +3874,8 @@ class TestQnodeAutograd:
         res = qml.gradients.param_shift(circuit)(x, y)
         res_expected = qml.jacobian(circuit)(x, y)
 
-        assert np.allclose(res[0], res_expected[0])
-        assert np.allclose(res[1], res_expected[1])
+        assert pnp.allclose(res[0], res_expected[0])
+        assert pnp.allclose(res[1], res_expected[1])
 
     @pytest.mark.parametrize("interface", interfaces)
     def test_multi_measurements_expval_multi_params(self, interface):
@@ -3900,10 +3900,10 @@ class TestQnodeAutograd:
 
         res_expected = qml.jacobian(cost)(x, y)
 
-        assert np.allclose(res[0][0], res_expected[0][0])
-        assert np.allclose(res[0][1], res_expected[1][0])
-        assert np.allclose(res[1][0], res_expected[0][1])
-        assert np.allclose(res[1][1], res_expected[1][1])
+        assert pnp.allclose(res[0][0], res_expected[0][0])
+        assert pnp.allclose(res[0][1], res_expected[1][0])
+        assert pnp.allclose(res[1][0], res_expected[0][1])
+        assert pnp.allclose(res[1][1], res_expected[1][1])
 
     @pytest.mark.parametrize("interface", interfaces)
     def test_multi_meas_expval_probs__multi_params(self, interface):
@@ -3928,16 +3928,16 @@ class TestQnodeAutograd:
 
         res_expected = qml.jacobian(cost)(x, y)
 
-        assert np.allclose(res[0][0], res_expected[0][0])
-        assert np.allclose(res[0][1], res_expected[1][0])
-        assert np.allclose(res[1][0][0], res_expected[0][1])
-        assert np.allclose(res[1][0][1], res_expected[0][2])
-        assert np.allclose(res[1][0][2], res_expected[0][3])
-        assert np.allclose(res[1][0][3], res_expected[0][4])
-        assert np.allclose(res[1][1][0], res_expected[1][1])
-        assert np.allclose(res[1][1][1], res_expected[1][2])
-        assert np.allclose(res[1][1][2], res_expected[1][3])
-        assert np.allclose(res[1][1][3], res_expected[1][4])
+        assert pnp.allclose(res[0][0], res_expected[0][0])
+        assert pnp.allclose(res[0][1], res_expected[1][0])
+        assert pnp.allclose(res[1][0][0], res_expected[0][1])
+        assert pnp.allclose(res[1][0][1], res_expected[0][2])
+        assert pnp.allclose(res[1][0][2], res_expected[0][3])
+        assert pnp.allclose(res[1][0][3], res_expected[0][4])
+        assert pnp.allclose(res[1][1][0], res_expected[1][1])
+        assert pnp.allclose(res[1][1][1], res_expected[1][2])
+        assert pnp.allclose(res[1][1][2], res_expected[1][3])
+        assert pnp.allclose(res[1][1][3], res_expected[1][4])
 
     @pytest.mark.parametrize("interface", interfaces)
     def test_identity_classical_jacobian(self, interface):
@@ -3956,7 +3956,7 @@ class TestQnodeAutograd:
         res = qml.gradients.param_shift(circuit)(x)
         res_expected = qml.jacobian(circuit)(x)
 
-        assert np.allclose(res, res_expected)
+        assert pnp.allclose(res, res_expected)
 
 
 @pytest.mark.torch
@@ -3986,7 +3986,7 @@ class TestQnodeTorch:
         res_expected = torch.autograd.functional.jacobian(circuit, x)
 
         assert res.shape == res_expected.shape
-        assert np.allclose(res.detach().numpy(), res_expected)
+        assert pnp.allclose(res.detach().numpy(), res_expected)
 
     @pytest.mark.parametrize("interface", interfaces)
     def test_single_measurement_single_param_2(self, interface):
@@ -4007,7 +4007,7 @@ class TestQnodeTorch:
         res_expected = torch.autograd.functional.jacobian(circuit, x)
 
         assert res.shape == res_expected.shape
-        assert np.allclose(res.detach().numpy(), res_expected)
+        assert pnp.allclose(res.detach().numpy(), res_expected)
 
     @pytest.mark.parametrize("interface", interfaces)
     def test_single_measurement_probs_single_param(self, interface):
@@ -4028,7 +4028,7 @@ class TestQnodeTorch:
         res_expected = torch.autograd.functional.jacobian(circuit, x)
 
         assert res.shape == res_expected.shape
-        assert np.allclose(res.detach().numpy(), res_expected)
+        assert pnp.allclose(res.detach().numpy(), res_expected)
 
     @pytest.mark.parametrize("interface", interfaces)
     def test_single_measurement_probs_single_param_2(self, interface):
@@ -4048,7 +4048,7 @@ class TestQnodeTorch:
         res = qml.gradients.param_shift(circuit)(x)
         res_expected = torch.autograd.functional.jacobian(circuit, x)
 
-        assert np.allclose(res.detach().numpy(), res_expected)
+        assert pnp.allclose(res.detach().numpy(), res_expected)
 
     @pytest.mark.parametrize("interface", interfaces)
     def test_multi_measurement_single_param(self, interface):
@@ -4068,8 +4068,8 @@ class TestQnodeTorch:
 
         res_expected = torch.autograd.functional.jacobian(circuit, x)
 
-        assert np.allclose(res[0].detach().numpy(), res_expected[0])
-        assert np.allclose(res[1].detach().numpy(), res_expected[1])
+        assert pnp.allclose(res[0].detach().numpy(), res_expected[0])
+        assert pnp.allclose(res[1].detach().numpy(), res_expected[1])
 
     @pytest.mark.parametrize("interface", interfaces)
     def test_multi_measurement_expval_probs_single_param(self, interface):
@@ -4089,8 +4089,8 @@ class TestQnodeTorch:
 
         res_expected = torch.autograd.functional.jacobian(circuit, x)
 
-        assert np.allclose(res[0].detach().numpy(), res_expected[0])
-        assert np.allclose(res[1].detach().numpy(), res_expected[1])
+        assert pnp.allclose(res[0].detach().numpy(), res_expected[0])
+        assert pnp.allclose(res[1].detach().numpy(), res_expected[1])
 
     @pytest.mark.parametrize("interface", interfaces)
     def test_single_measurement_multiple_params(self, interface):
@@ -4111,8 +4111,8 @@ class TestQnodeTorch:
         res = qml.gradients.param_shift(circuit)(x, y)
         res_expected = torch.autograd.functional.jacobian(circuit, (x, y))
 
-        assert np.allclose(res[0].detach().numpy(), res_expected[0])
-        assert np.allclose(res[1].detach().numpy(), res_expected[1])
+        assert pnp.allclose(res[0].detach().numpy(), res_expected[0])
+        assert pnp.allclose(res[1].detach().numpy(), res_expected[1])
 
     @pytest.mark.parametrize("interface", interfaces)
     def test_single_measurement_probs_multiple_params(self, interface):
@@ -4133,8 +4133,8 @@ class TestQnodeTorch:
         res = qml.gradients.param_shift(circuit)(x, y)
         res_expected = torch.autograd.functional.jacobian(circuit, (x, y))
 
-        assert np.allclose(res[0].detach().numpy(), res_expected[0])
-        assert np.allclose(res[1].detach().numpy(), res_expected[1])
+        assert pnp.allclose(res[0].detach().numpy(), res_expected[0])
+        assert pnp.allclose(res[1].detach().numpy(), res_expected[1])
 
     @pytest.mark.parametrize("interface", interfaces)
     def test_multiple_measurements_multiple_params(self, interface):
@@ -4156,10 +4156,10 @@ class TestQnodeTorch:
 
         res_expected = torch.autograd.functional.jacobian(circuit, (x, y))
 
-        assert np.allclose(res[0][0].detach().numpy(), res_expected[0][0])
-        assert np.allclose(res[0][1].detach().numpy(), res_expected[0][1])
-        assert np.allclose(res[1][0].detach().numpy(), res_expected[1][0])
-        assert np.allclose(res[1][1].detach().numpy(), res_expected[1][1])
+        assert pnp.allclose(res[0][0].detach().numpy(), res_expected[0][0])
+        assert pnp.allclose(res[0][1].detach().numpy(), res_expected[0][1])
+        assert pnp.allclose(res[1][0].detach().numpy(), res_expected[1][0])
+        assert pnp.allclose(res[1][1].detach().numpy(), res_expected[1][1])
 
     @pytest.mark.parametrize("interface", interfaces)
     def test_multiple_measurements_expval_probs_multiple_params(self, interface):
@@ -4182,10 +4182,10 @@ class TestQnodeTorch:
 
         res_expected = torch.autograd.functional.jacobian(circuit, (x, y))
 
-        assert np.allclose(res[0][0].detach().numpy(), res_expected[0][0])
-        assert np.allclose(res[0][1].detach().numpy(), res_expected[0][1])
-        assert np.allclose(res[1][0].detach().numpy(), res_expected[1][0])
-        assert np.allclose(res[1][1].detach().numpy(), res_expected[1][1])
+        assert pnp.allclose(res[0][0].detach().numpy(), res_expected[0][0])
+        assert pnp.allclose(res[0][1].detach().numpy(), res_expected[0][1])
+        assert pnp.allclose(res[1][0].detach().numpy(), res_expected[1][0])
+        assert pnp.allclose(res[1][1].detach().numpy(), res_expected[1][1])
 
     @pytest.mark.parametrize("interface", interfaces)
     def test_identity_classical_jacobian(self, interface):
@@ -4205,8 +4205,8 @@ class TestQnodeTorch:
         res = qml.gradients.param_shift(circuit)(x)
         res_expected = torch.autograd.functional.jacobian(circuit, x)
 
-        assert np.allclose(res[0].detach().numpy(), res_expected[0])
-        assert np.allclose(res[1].detach().numpy(), res_expected[1])
+        assert pnp.allclose(res[0].detach().numpy(), res_expected[0])
+        assert pnp.allclose(res[1].detach().numpy(), res_expected[1])
 
 
 @pytest.mark.jax
@@ -4236,7 +4236,7 @@ class TestQnodeJax:
         res_expected = jax.jacobian(circuit)(x)
 
         assert res.shape == res_expected.shape
-        assert np.allclose(res, res_expected)
+        assert pnp.allclose(res, res_expected)
 
     @pytest.mark.parametrize("interface", interfaces)
     def test_single_measurement_single_param_2(self, interface):
@@ -4256,7 +4256,7 @@ class TestQnodeJax:
 
         res_expected = jax.jacobian(circuit)(x)
         assert res.shape == res_expected.shape
-        assert np.allclose(res, res_expected)
+        assert pnp.allclose(res, res_expected)
 
     @pytest.mark.parametrize("interface", interfaces)
     def test_single_measurement_probs_single_param(self, interface):
@@ -4277,7 +4277,7 @@ class TestQnodeJax:
         res_expected = jax.jacobian(circuit)(x)
 
         assert res.shape == res_expected.shape
-        assert np.allclose(res, res_expected)
+        assert pnp.allclose(res, res_expected)
 
     @pytest.mark.parametrize("interface", interfaces)
     def test_single_measurement_probs_single_param_2(self, interface):
@@ -4297,7 +4297,7 @@ class TestQnodeJax:
         res = qml.gradients.param_shift(circuit)(x)
         res_expected = jax.jacobian(circuit)(x)
 
-        assert np.allclose(res, res_expected)
+        assert pnp.allclose(res, res_expected)
 
     @pytest.mark.parametrize("interface", interfaces)
     def test_multi_measurement_single_param(self, interface):
@@ -4317,8 +4317,8 @@ class TestQnodeJax:
 
         res_expected = jax.jacobian(circuit)(x)
 
-        assert np.allclose(res[0], res_expected[0])
-        assert np.allclose(res[1], res_expected[1])
+        assert pnp.allclose(res[0], res_expected[0])
+        assert pnp.allclose(res[1], res_expected[1])
 
     @pytest.mark.parametrize("interface", interfaces)
     def test_multi_measurement_expval_probs_single_param(self, interface):
@@ -4338,8 +4338,8 @@ class TestQnodeJax:
 
         res_expected = jax.jacobian(circuit)(x)
 
-        assert np.allclose(res[0], res_expected[0])
-        assert np.allclose(res[1], res_expected[1])
+        assert pnp.allclose(res[0], res_expected[0])
+        assert pnp.allclose(res[1], res_expected[1])
 
     @pytest.mark.parametrize("interface", interfaces)
     def test_single_measurement_multiple_params(self, interface):
@@ -4360,8 +4360,8 @@ class TestQnodeJax:
         res = qml.gradients.param_shift(circuit, argnums=[0, 1])(x, y)
         res_expected = jax.jacobian(circuit, argnums=[0, 1])(x, y)
 
-        assert np.allclose(res[0], res_expected[0])
-        assert np.allclose(res[1], res_expected[1])
+        assert pnp.allclose(res[0], res_expected[0])
+        assert pnp.allclose(res[1], res_expected[1])
 
     @pytest.mark.parametrize("interface", interfaces)
     def test_single_measurement_probs_multiple_params(self, interface):
@@ -4382,8 +4382,8 @@ class TestQnodeJax:
         res = qml.gradients.param_shift(circuit, argnums=[0, 1])(x, y)
         res_expected = jax.jacobian(circuit, argnums=[0, 1])(x, y)
 
-        assert np.allclose(res[0], res_expected[0])
-        assert np.allclose(res[1], res_expected[1])
+        assert pnp.allclose(res[0], res_expected[0])
+        assert pnp.allclose(res[1], res_expected[1])
 
     @pytest.mark.parametrize("interface", interfaces)
     def test_multiple_measurements_multi_params(self, interface, tol):
@@ -4405,10 +4405,10 @@ class TestQnodeJax:
 
         res_expected = jax.jacobian(circuit, argnums=[0, 1])(x, y)
 
-        assert np.allclose(res[0][0], res_expected[0][0], atol=tol)
-        assert np.allclose(res[0][1], res_expected[0][1], atol=tol)
-        assert np.allclose(res[1][0], res_expected[1][0], atol=tol)
-        assert np.allclose(res[1][1], res_expected[1][1], atol=tol)
+        assert pnp.allclose(res[0][0], res_expected[0][0], atol=tol)
+        assert pnp.allclose(res[0][1], res_expected[0][1], atol=tol)
+        assert pnp.allclose(res[1][0], res_expected[1][0], atol=tol)
+        assert pnp.allclose(res[1][1], res_expected[1][1], atol=tol)
 
     @pytest.mark.parametrize("interface", interfaces)
     def test_multiple_measurements_expval_probs_multi_params(self, interface, tol):
@@ -4431,10 +4431,10 @@ class TestQnodeJax:
 
         res_expected = jax.jacobian(circuit, argnums=[0, 1])(x, y)
 
-        assert np.allclose(res[0][0], res_expected[0][0], atol=tol)
-        assert np.allclose(res[0][1], res_expected[0][1], atol=tol)
-        assert np.allclose(res[1][0], res_expected[1][0], atol=tol)
-        assert np.allclose(res[1][1], res_expected[1][1], atol=tol)
+        assert pnp.allclose(res[0][0], res_expected[0][0], atol=tol)
+        assert pnp.allclose(res[0][1], res_expected[0][1], atol=tol)
+        assert pnp.allclose(res[1][0], res_expected[1][0], atol=tol)
+        assert pnp.allclose(res[1][1], res_expected[1][1], atol=tol)
 
     @pytest.mark.parametrize("interface", interfaces)
     def test_identity_classical_jacobian(self, interface, tol):
@@ -4454,8 +4454,8 @@ class TestQnodeJax:
         res = qml.gradients.param_shift(circuit)(x)
         res_expected = jax.jacobian(circuit)(x)
 
-        assert np.allclose(res[0], res_expected[0], atol=tol)
-        assert np.allclose(res[1], res_expected[1], atol=tol)
+        assert pnp.allclose(res[0], res_expected[0], atol=tol)
+        assert pnp.allclose(res[1], res_expected[1], atol=tol)
 
 
 @pytest.mark.jax
@@ -4485,7 +4485,7 @@ class TestQnodeJaxJit:
         res_expected = jax.jacobian(circuit)(x)
 
         assert res.shape == res_expected.shape
-        assert np.allclose(res, res_expected)
+        assert pnp.allclose(res, res_expected)
 
     @pytest.mark.parametrize("interface", interfaces)
     def test_single_measurement_single_param_2(self, interface):
@@ -4506,7 +4506,7 @@ class TestQnodeJaxJit:
         res_expected = jax.jacobian(circuit)(x)
 
         assert res.shape == res_expected.shape
-        assert np.allclose(res, res_expected)
+        assert pnp.allclose(res, res_expected)
 
     @pytest.mark.parametrize("interface", interfaces)
     def test_single_measurement_probs_single_param(self, interface):
@@ -4527,7 +4527,7 @@ class TestQnodeJaxJit:
         res_expected = jax.jacobian(circuit)(x)
 
         assert res.shape == res_expected.shape
-        assert np.allclose(res, res_expected)
+        assert pnp.allclose(res, res_expected)
 
     @pytest.mark.parametrize("interface", interfaces)
     def test_single_measurement_probs_single_param_2(self, interface):
@@ -4547,7 +4547,7 @@ class TestQnodeJaxJit:
         res = jax.jit(qml.gradients.param_shift(circuit))(x)
         res_expected = jax.jacobian(circuit)(x)
 
-        assert np.allclose(res, res_expected)
+        assert pnp.allclose(res, res_expected)
 
     @pytest.mark.parametrize("interface", interfaces)
     def test_multi_measurement_single_param(self, interface):
@@ -4567,8 +4567,8 @@ class TestQnodeJaxJit:
 
         res_expected = jax.jacobian(circuit)(x)
 
-        assert np.allclose(res[0], res_expected[0])
-        assert np.allclose(res[1], res_expected[1])
+        assert pnp.allclose(res[0], res_expected[0])
+        assert pnp.allclose(res[1], res_expected[1])
 
     @pytest.mark.parametrize("interface", interfaces)
     def test_multi_measurement_expval_probs_single_param(self, interface):
@@ -4588,8 +4588,8 @@ class TestQnodeJaxJit:
 
         res_expected = jax.jacobian(circuit)(x)
 
-        assert np.allclose(res[0], res_expected[0])
-        assert np.allclose(res[1], res_expected[1])
+        assert pnp.allclose(res[0], res_expected[0])
+        assert pnp.allclose(res[1], res_expected[1])
 
     @pytest.mark.parametrize("interface", interfaces)
     def test_single_measurement_multiple_params(self, interface):
@@ -4610,8 +4610,8 @@ class TestQnodeJaxJit:
         res = jax.jit(qml.gradients.param_shift(circuit, argnums=[0, 1]))(x, y)
         res_expected = jax.jacobian(circuit, argnums=[0, 1])(x, y)
 
-        assert np.allclose(res[0], res_expected[0])
-        assert np.allclose(res[1], res_expected[1])
+        assert pnp.allclose(res[0], res_expected[0])
+        assert pnp.allclose(res[1], res_expected[1])
 
     @pytest.mark.parametrize("interface", interfaces)
     def test_single_measurement_probs_multiple_params(self, interface):
@@ -4632,8 +4632,8 @@ class TestQnodeJaxJit:
         res = jax.jit(qml.gradients.param_shift(circuit, argnums=[0, 1]))(x, y)
         res_expected = jax.jacobian(circuit, argnums=[0, 1])(x, y)
 
-        assert np.allclose(res[0], res_expected[0])
-        assert np.allclose(res[1], res_expected[1])
+        assert pnp.allclose(res[0], res_expected[0])
+        assert pnp.allclose(res[1], res_expected[1])
 
     @pytest.mark.parametrize("interface", interfaces)
     def test_multiple_measurement_multi_params(self, interface, tol):
@@ -4655,10 +4655,10 @@ class TestQnodeJaxJit:
 
         res_expected = jax.jacobian(circuit, argnums=[0, 1])(x, y)
 
-        assert np.allclose(res[0][0], res_expected[0][0], atol=tol)
-        assert np.allclose(res[0][1], res_expected[0][1], atol=tol)
-        assert np.allclose(res[1][0], res_expected[1][0], atol=tol)
-        assert np.allclose(res[1][1], res_expected[1][1], atol=tol)
+        assert pnp.allclose(res[0][0], res_expected[0][0], atol=tol)
+        assert pnp.allclose(res[0][1], res_expected[0][1], atol=tol)
+        assert pnp.allclose(res[1][0], res_expected[1][0], atol=tol)
+        assert pnp.allclose(res[1][1], res_expected[1][1], atol=tol)
 
     @pytest.mark.parametrize("interface", interfaces)
     def test_multiple_measurements_expval_probs_multi_params(self, interface, tol):
@@ -4681,10 +4681,10 @@ class TestQnodeJaxJit:
 
         res_expected = jax.jacobian(circuit, argnums=[0, 1])(x, y)
 
-        assert np.allclose(res[0][0], res_expected[0][0], atol=tol)
-        assert np.allclose(res[0][1], res_expected[0][1], atol=tol)
-        assert np.allclose(res[1][0], res_expected[1][0], atol=tol)
-        assert np.allclose(res[1][1], res_expected[1][1], atol=tol)
+        assert pnp.allclose(res[0][0], res_expected[0][0], atol=tol)
+        assert pnp.allclose(res[0][1], res_expected[0][1], atol=tol)
+        assert pnp.allclose(res[1][0], res_expected[1][0], atol=tol)
+        assert pnp.allclose(res[1][1], res_expected[1][1], atol=tol)
 
     @pytest.mark.parametrize("interface", interfaces)
     def test_identity_classical_jacobian(self, interface, tol):
@@ -4704,8 +4704,8 @@ class TestQnodeJaxJit:
         res = jax.jit(qml.gradients.param_shift(circuit))(x)
         res_expected = jax.jacobian(circuit)(x)
 
-        assert np.allclose(res[0], res_expected[0], atol=tol)
-        assert np.allclose(res[1], res_expected[1], atol=tol)
+        assert pnp.allclose(res[0], res_expected[0], atol=tol)
+        assert pnp.allclose(res[1], res_expected[1], atol=tol)
 
     @pytest.mark.parametrize("interface", interfaces)
     def test_identity_classical_jacobian_multi_meas(self, interface, tol):
@@ -4725,8 +4725,8 @@ class TestQnodeJaxJit:
         res = jax.jit(qml.gradients.param_shift(circuit))(x)
         res_expected = jax.jacobian(circuit)(x)
 
-        assert np.allclose(res[0], res_expected[0], atol=tol)
-        assert np.allclose(res[1], res_expected[1], atol=tol)
+        assert pnp.allclose(res[0], res_expected[0], atol=tol)
+        assert pnp.allclose(res[1], res_expected[1], atol=tol)
 
 
 @pytest.mark.parametrize("argnums", [[0], [1], [0, 1]])
@@ -4778,16 +4778,16 @@ class TestJaxArgnums:
 
         res = qml.gradients.param_shift(circuit, argnums=argnums)(x, y)
 
-        expected_0 = np.array([-np.sin(y) * np.sin(x[0]), 0])
-        expected_1 = np.array(np.cos(y) * np.cos(x[0]))
+        expected_0 = pnp.array([-pnp.sin(y) * pnp.sin(x[0]), 0])
+        expected_1 = pnp.array(pnp.cos(y) * pnp.cos(x[0]))
 
         if argnums == [0]:
-            assert np.allclose(res, expected_0)
+            assert pnp.allclose(res, expected_0)
         if argnums == [1]:
-            assert np.allclose(res, expected_1)
+            assert pnp.allclose(res, expected_1)
         if argnums == [0, 1]:
-            assert np.allclose(res[0], expected_0)
-            assert np.allclose(res[1], expected_1)
+            assert pnp.allclose(res[0], expected_0)
+            assert pnp.allclose(res[1], expected_1)
 
     def test_multi_expectation_values(self, argnums, interface):
         """Test for multiple expectation values."""
@@ -4807,19 +4807,19 @@ class TestJaxArgnums:
 
         res = qml.gradients.param_shift(circuit, argnums=argnums)(x, y)
 
-        expected_0 = np.array([[-np.sin(x[0]), 0.0], [0.0, 0.0]])
-        expected_1 = np.array([0, np.cos(y)])
+        expected_0 = pnp.array([[-pnp.sin(x[0]), 0.0], [0.0, 0.0]])
+        expected_1 = pnp.array([0, pnp.cos(y)])
 
         if argnums == [0]:
-            assert np.allclose(res[0], expected_0[0])
-            assert np.allclose(res[1], expected_0[1])
+            assert pnp.allclose(res[0], expected_0[0])
+            assert pnp.allclose(res[1], expected_0[1])
         if argnums == [1]:
-            assert np.allclose(res, expected_1)
+            assert pnp.allclose(res, expected_1)
         if argnums == [0, 1]:
-            assert np.allclose(res[0][0], expected_0[0])
-            assert np.allclose(res[0][1], expected_0[1])
-            assert np.allclose(res[1][0], expected_1[0])
-            assert np.allclose(res[1][1], expected_1[1])
+            assert pnp.allclose(res[0][0], expected_0[0])
+            assert pnp.allclose(res[0][1], expected_0[1])
+            assert pnp.allclose(res[1][0], expected_1[0])
+            assert pnp.allclose(res[1][1], expected_1[1])
 
     def test_hessian(self, argnums, interface):
         """Test for hessian."""
@@ -4844,9 +4844,9 @@ class TestJaxArgnums:
 
         if len(argnums) == 1:
             # jax.hessian produces an additional tuple axis, which we have to index away here
-            assert np.allclose(res, res_expected[0])
+            assert pnp.allclose(res, res_expected[0])
         else:
             # The Hessian is a 2x2 nested tuple "matrix" for argnums=[0, 1]
             for r, r_e in zip(res, res_expected):
                 for r_, r_e_ in zip(r, r_e):
-                    assert np.allclose(r_, r_e_)
+                    assert pnp.allclose(r_, r_e_)

--- a/tests/gradients/parameter_shift/test_parameter_shift_hessian.py
+++ b/tests/gradients/parameter_shift/test_parameter_shift_hessian.py
@@ -19,7 +19,7 @@ from itertools import product
 import pytest
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane.gradients.parameter_shift_hessian import (
     _collect_recipes,
     _generate_offdiag_tapes,
@@ -166,21 +166,21 @@ class TestCollectRecipes:
         assert qml.math.allclose(offdiag[0], qml.math.array(channel_recipe))
         assert qml.math.allclose(offdiag[1], qml.math.array(dummy_recipe))
 
-    two_term_recipe = [(0.5, 1.0, np.pi / 2), (-0.5, 1.0, -np.pi / 2)]
-    c0 = (np.sqrt(2) + 1) / (4 * np.sqrt(2))
-    c1 = (np.sqrt(2) - 1) / (4 * np.sqrt(2))
+    two_term_recipe = [(0.5, 1.0, pnp.pi / 2), (-0.5, 1.0, -pnp.pi / 2)]
+    c0 = (pnp.sqrt(2) + 1) / (4 * pnp.sqrt(2))
+    c1 = (pnp.sqrt(2) - 1) / (4 * pnp.sqrt(2))
     four_term_recipe = [
-        (c0, 1.0, np.pi / 2),
-        (-c0, 1.0, -np.pi / 2),
-        (-c1, 1.0, 3 * np.pi / 2),
-        (c1, 1.0, -3 * np.pi / 2),
+        (c0, 1.0, pnp.pi / 2),
+        (-c0, 1.0, -pnp.pi / 2),
+        (-c1, 1.0, 3 * pnp.pi / 2),
+        (c1, 1.0, -3 * pnp.pi / 2),
     ]
-    two_term_2nd_order = [(-0.5, 1.0, 0.0), (0.5, 1.0, -np.pi)]
+    two_term_2nd_order = [(-0.5, 1.0, 0.0), (0.5, 1.0, -pnp.pi)]
     four_term_2nd_order = [
         (-0.375, 1.0, 0),
-        (0.25, 1.0, np.pi),
-        (0.25, 1.0, -np.pi),
-        (-0.125, 1.0, -2 * np.pi),
+        (0.25, 1.0, pnp.pi),
+        (0.25, 1.0, -pnp.pi),
+        (-0.125, 1.0, -2 * pnp.pi),
     ]
 
     expected_diag_recipes = [two_term_2nd_order, four_term_2nd_order, four_term_2nd_order]
@@ -225,30 +225,30 @@ class TestGenerateOffDiagTapes:
     def test_with_zero_shifts(self, add_unshifted):
         """Test that zero shifts are taken into account in _generate_offdiag_tapes."""
         with qml.queuing.AnnotatedQueue() as q:
-            qml.RX(np.array(0.2), wires=[0])
-            qml.RY(np.array(0.9), wires=[0])
+            qml.RX(pnp.array(0.2), wires=[0])
+            qml.RY(pnp.array(0.9), wires=[0])
 
         tape = qml.tape.QuantumScript.from_queue(q)
-        recipe_0 = np.array([[-0.5, 1.0, 0.0], [0.5, 1.0, np.pi]])
-        recipe_1 = np.array([[-0.25, 1.0, 0.0], [0.25, 1.0, np.pi]])
+        recipe_0 = pnp.array([[-0.5, 1.0, 0.0], [0.5, 1.0, pnp.pi]])
+        recipe_1 = pnp.array([[-0.25, 1.0, 0.0], [0.25, 1.0, pnp.pi]])
         t, c = [], []
         new_add_unshifted, unshifted_coeff = _generate_offdiag_tapes(
             tape, (0, 1), [recipe_0, recipe_1], add_unshifted, t, c
         )
 
         assert len(t) == 3 + int(add_unshifted)  # Four tapes of which the first is not shifted
-        assert np.allclose(c, [-0.125, -0.125, 0.125])
-        assert np.isclose(unshifted_coeff, 0.125)
+        assert pnp.allclose(c, [-0.125, -0.125, 0.125])
+        assert pnp.isclose(unshifted_coeff, 0.125)
         assert not new_add_unshifted
 
         orig_cls = [orig_op.__class__ for orig_op in tape.operations]
-        expected_pars = list(product([0.2, 0.2 + np.pi], [0.9, 0.9 + np.pi]))
+        expected_pars = list(product([0.2, 0.2 + pnp.pi], [0.9, 0.9 + pnp.pi]))
         if not add_unshifted:
             expected_pars = expected_pars[1:]
         for exp_par, h_tape in zip(expected_pars, t):
             assert len(h_tape.operations) == 2
             assert all(op.__class__ == cls for op, cls in zip(h_tape.operations, orig_cls))
-            assert np.allclose(h_tape.get_parameters(), exp_par)
+            assert pnp.allclose(h_tape.get_parameters(), exp_par)
 
 
 class TestParameterShiftHessian:
@@ -260,7 +260,7 @@ class TestParameterShiftHessian:
         and single expectation value output"""
         dev = qml.device("default.qubit", wires=2)
 
-        x = np.array(0.1, requires_grad=True)
+        x = pnp.array(0.1, requires_grad=True)
 
         with qml.queuing.AnnotatedQueue() as q:
             qml.RY(x, wires=0)
@@ -268,21 +268,21 @@ class TestParameterShiftHessian:
             qml.expval(qml.PauliZ(0))
 
         tape = qml.tape.QuantumScript.from_queue(q)
-        expected = -np.cos(x)
+        expected = -pnp.cos(x)
 
         tapes, fn = qml.gradients.param_shift_hessian(tape)
         hessian = fn(qml.execute(tapes, dev, diff_method=None))
 
-        assert isinstance(hessian, np.ndarray)
+        assert isinstance(hessian, pnp.ndarray)
         assert hessian.shape == ()
-        assert np.allclose(expected, hessian)
+        assert pnp.allclose(expected, hessian)
 
     def test_single_probs(self):
         """Test that the correct hessian is calculated for a tape with single RX operator
         and single probability output"""
         dev = qml.device("default.qubit", wires=2)
 
-        x = np.array(0.1, requires_grad=True)
+        x = pnp.array(0.1, requires_grad=True)
 
         with qml.queuing.AnnotatedQueue() as q:
             qml.RY(x, wires=0)
@@ -290,21 +290,21 @@ class TestParameterShiftHessian:
             qml.probs(wires=[0, 1])
 
         tape = qml.tape.QuantumScript.from_queue(q)
-        expected = 0.5 * np.cos(x) * np.array([-1, 0, 0, 1])
+        expected = 0.5 * pnp.cos(x) * pnp.array([-1, 0, 0, 1])
 
         tapes, fn = qml.gradients.param_shift_hessian(tape)
         hessian = fn(qml.execute(tapes, dev, diff_method=None))
 
-        assert isinstance(hessian, np.ndarray)
+        assert isinstance(hessian, pnp.ndarray)
         assert hessian.shape == (4,)
-        assert np.allclose(expected, hessian)
+        assert pnp.allclose(expected, hessian)
 
     def test_multi_expval(self):
         """Test that the correct hessian is calculated for a tape with single RX operator
         and multiple expval outputs"""
         dev = qml.device("default.qubit", wires=2)
 
-        x = np.array(0.1, requires_grad=True)
+        x = pnp.array(0.1, requires_grad=True)
 
         with qml.queuing.AnnotatedQueue() as q:
             qml.RY(x, wires=0)
@@ -313,7 +313,7 @@ class TestParameterShiftHessian:
             qml.expval(qml.Hadamard(1))
 
         tape = qml.tape.QuantumScript.from_queue(q)
-        expected = (-np.cos(x), -np.cos(x) / np.sqrt(2))
+        expected = (-pnp.cos(x), -pnp.cos(x) / pnp.sqrt(2))
 
         tapes, fn = qml.gradients.param_shift_hessian(tape)
         hessian = fn(qml.execute(tapes, dev, diff_method=None))
@@ -322,16 +322,16 @@ class TestParameterShiftHessian:
         assert len(hessian) == 2
 
         for hess, exp in zip(hessian, expected):
-            assert isinstance(hess, np.ndarray)
+            assert isinstance(hess, pnp.ndarray)
             assert hess.shape == ()
-            assert np.allclose(hess, exp)
+            assert pnp.allclose(hess, exp)
 
     def test_multi_expval_probs(self):
         """Test that the correct hessian is calculated for a tape with single RX operator
         and both expval and probability outputs"""
         dev = qml.device("default.qubit", wires=2)
 
-        x = np.array(0.1, requires_grad=True)
+        x = pnp.array(0.1, requires_grad=True)
 
         with qml.queuing.AnnotatedQueue() as q:
             qml.RY(x, wires=0)
@@ -340,7 +340,7 @@ class TestParameterShiftHessian:
             qml.probs(wires=[0, 1])
 
         tape = qml.tape.QuantumScript.from_queue(q)
-        expected = (-np.cos(x), 0.5 * np.cos(x) * np.array([-1, 0, 0, 1]))
+        expected = (-pnp.cos(x), 0.5 * pnp.cos(x) * pnp.array([-1, 0, 0, 1]))
 
         tapes, fn = qml.gradients.param_shift_hessian(tape)
         hessian = fn(qml.execute(tapes, dev, diff_method=None))
@@ -349,16 +349,16 @@ class TestParameterShiftHessian:
         assert len(hessian) == 2
 
         for hess, exp in zip(hessian, expected):
-            assert isinstance(hess, np.ndarray)
+            assert isinstance(hess, pnp.ndarray)
             assert hess.shape == exp.shape
-            assert np.allclose(hess, exp)
+            assert pnp.allclose(hess, exp)
 
     def test_multi_probs(self):
         """Test that the correct hessian is calculated for a tape with single RX operator
         and multiple probability outputs"""
         dev = qml.device("default.qubit", wires=2)
 
-        x = np.array(0.1, requires_grad=True)
+        x = pnp.array(0.1, requires_grad=True)
 
         with qml.queuing.AnnotatedQueue() as q:
             qml.RY(x, wires=0)
@@ -367,7 +367,7 @@ class TestParameterShiftHessian:
             qml.probs(wires=[0, 1])
 
         tape = qml.tape.QuantumScript.from_queue(q)
-        expected = (0.5 * np.cos(x) * np.array([-1, 1]), 0.5 * np.cos(x) * np.array([-1, 0, 0, 1]))
+        expected = (0.5 * pnp.cos(x) * pnp.array([-1, 1]), 0.5 * pnp.cos(x) * pnp.array([-1, 0, 0, 1]))
 
         tapes, fn = qml.gradients.param_shift_hessian(tape)
         hessian = fn(qml.execute(tapes, dev, diff_method=None))
@@ -376,16 +376,16 @@ class TestParameterShiftHessian:
         assert len(hessian) == 2
 
         for hess, exp in zip(hessian, expected):
-            assert isinstance(hess, np.ndarray)
+            assert isinstance(hess, pnp.ndarray)
             assert hess.shape == exp.shape
-            assert np.allclose(hess, exp)
+            assert pnp.allclose(hess, exp)
 
     def test_single_expval_multi_params(self):
         """Test that the correct hessian is calculated for a tape with multiple operators
         and single expectation value output"""
         dev = qml.device("default.qubit", wires=2)
 
-        x = np.array([0.1, 0.4], requires_grad=True)
+        x = pnp.array([0.1, 0.4], requires_grad=True)
 
         with qml.queuing.AnnotatedQueue() as q:
             qml.RY(x[0], wires=0)
@@ -394,7 +394,7 @@ class TestParameterShiftHessian:
             qml.expval(qml.PauliZ(0))
 
         tape = qml.tape.QuantumScript.from_queue(q)
-        expected = ((-np.cos(x[0]), 0), (0, 0))
+        expected = ((-pnp.cos(x[0]), 0), (0, 0))
 
         tapes, fn = qml.gradients.param_shift_hessian(tape)
         hessian = fn(qml.execute(tapes, dev, diff_method=None))
@@ -404,17 +404,17 @@ class TestParameterShiftHessian:
         assert all(isinstance(hess, tuple) for hess in hessian)
         assert all(len(hess) == 2 for hess in hessian)
         assert all(
-            all(isinstance(h, np.ndarray) and h.shape == () for h in hess) for hess in hessian
+            all(isinstance(h, pnp.ndarray) and h.shape == () for h in hess) for hess in hessian
         )
 
-        assert np.allclose(hessian, expected)
+        assert pnp.allclose(hessian, expected)
 
     def test_single_probs_multi_params(self):
         """Test that the correct hessian is calculated for a tape with multiple operators
         and single probability output"""
         dev = qml.device("default.qubit", wires=2)
 
-        x = np.array([0.1, 0.4], requires_grad=True)
+        x = pnp.array([0.1, 0.4], requires_grad=True)
 
         with qml.queuing.AnnotatedQueue() as q:
             qml.RY(x[0], wires=0)
@@ -424,19 +424,19 @@ class TestParameterShiftHessian:
 
         tape = qml.tape.QuantumScript.from_queue(q)
         a = [
-            np.cos(x[0] / 2) ** 2,
-            np.sin(x[0] / 2) ** 2,
-            np.cos(x[1] / 2) ** 2,
-            np.sin(x[1] / 2) ** 2,
+            pnp.cos(x[0] / 2) ** 2,
+            pnp.sin(x[0] / 2) ** 2,
+            pnp.cos(x[1] / 2) ** 2,
+            pnp.sin(x[1] / 2) ** 2,
         ]
         expected = (
             (
-                0.5 * np.cos(x[0]) * np.array([-a[2], -a[3], a[3], a[2]]),
-                0.25 * np.sin(x[0]) * np.sin(x[1]) * np.array([1, -1, 1, -1]),
+                0.5 * pnp.cos(x[0]) * pnp.array([-a[2], -a[3], a[3], a[2]]),
+                0.25 * pnp.sin(x[0]) * pnp.sin(x[1]) * pnp.array([1, -1, 1, -1]),
             ),
             (
-                0.25 * np.sin(x[0]) * np.sin(x[1]) * np.array([1, -1, 1, -1]),
-                0.5 * np.cos(x[1]) * np.array([-a[0], a[0], a[1], -a[1]]),
+                0.25 * pnp.sin(x[0]) * pnp.sin(x[1]) * pnp.array([1, -1, 1, -1]),
+                0.5 * pnp.cos(x[1]) * pnp.array([-a[0], a[0], a[1], -a[1]]),
             ),
         )
 
@@ -448,17 +448,17 @@ class TestParameterShiftHessian:
         assert all(isinstance(hess, tuple) for hess in hessian)
         assert all(len(hess) == 2 for hess in hessian)
         assert all(
-            all(isinstance(h, np.ndarray) and h.shape == (4,) for h in hess) for hess in hessian
+            all(isinstance(h, pnp.ndarray) and h.shape == (4,) for h in hess) for hess in hessian
         )
 
-        assert np.allclose(hessian, expected)
+        assert pnp.allclose(hessian, expected)
 
     def test_multi_expval_multi_params(self):
         """Test that the correct hessian is calculated for a tape with multiple operators
         and multiple expval outputs"""
         dev = qml.device("default.qubit", wires=2)
 
-        x = np.array([0.1, 0.4], requires_grad=True)
+        x = pnp.array([0.1, 0.4], requires_grad=True)
 
         with qml.queuing.AnnotatedQueue() as q:
             qml.RY(x[0], wires=0)
@@ -469,15 +469,15 @@ class TestParameterShiftHessian:
 
         tape = qml.tape.QuantumScript.from_queue(q)
         expected = (
-            ((-np.cos(x[0]), 0), (0, 0)),
+            ((-pnp.cos(x[0]), 0), (0, 0)),
             (
                 (
-                    -np.cos(x[0]) * np.cos(x[1]) / np.sqrt(2),
-                    np.sin(x[0]) * np.sin(x[1]) / np.sqrt(2),
+                    -pnp.cos(x[0]) * pnp.cos(x[1]) / pnp.sqrt(2),
+                    pnp.sin(x[0]) * pnp.sin(x[1]) / pnp.sqrt(2),
                 ),
                 (
-                    np.sin(x[0]) * np.sin(x[1]) / np.sqrt(2),
-                    (-np.sin(x[1]) - np.cos(x[0]) * np.cos(x[1])) / np.sqrt(2),
+                    pnp.sin(x[0]) * pnp.sin(x[1]) / pnp.sqrt(2),
+                    (-pnp.sin(x[1]) - pnp.cos(x[0]) * pnp.cos(x[1])) / pnp.sqrt(2),
                 ),
             ),
         )
@@ -493,15 +493,15 @@ class TestParameterShiftHessian:
             assert len(hess) == 2
             assert all(isinstance(h, tuple) for h in hess)
             assert all(len(h) == 2 for h in hess)
-            assert all(all(isinstance(h_, np.ndarray) and h_.shape == () for h_ in h) for h in hess)
-            assert np.allclose(hess, exp)
+            assert all(all(isinstance(h_, pnp.ndarray) and h_.shape == () for h_ in h) for h in hess)
+            assert pnp.allclose(hess, exp)
 
     def test_multi_expval_probs_multi_params(self):
         """Test that the correct hessian is calculated for a tape with multiple operators
         and both expval and probability outputs"""
         dev = qml.device("default.qubit", wires=2)
 
-        x = np.array([0.1, 0.4], requires_grad=True)
+        x = pnp.array([0.1, 0.4], requires_grad=True)
 
         with qml.queuing.AnnotatedQueue() as q:
             qml.RY(x[0], wires=0)
@@ -512,21 +512,21 @@ class TestParameterShiftHessian:
 
         tape = qml.tape.QuantumScript.from_queue(q)
         a = [
-            np.cos(x[0] / 2) ** 2,
-            np.sin(x[0] / 2) ** 2,
-            np.cos(x[1] / 2) ** 2,
-            np.sin(x[1] / 2) ** 2,
+            pnp.cos(x[0] / 2) ** 2,
+            pnp.sin(x[0] / 2) ** 2,
+            pnp.cos(x[1] / 2) ** 2,
+            pnp.sin(x[1] / 2) ** 2,
         ]
         expected = (
-            ((-np.cos(x[0]), 0), (0, 0)),
+            ((-pnp.cos(x[0]), 0), (0, 0)),
             (
                 (
-                    0.5 * np.cos(x[0]) * np.array([-a[2], -a[3], a[3], a[2]]),
-                    0.25 * np.sin(x[0]) * np.sin(x[1]) * np.array([1, -1, 1, -1]),
+                    0.5 * pnp.cos(x[0]) * pnp.array([-a[2], -a[3], a[3], a[2]]),
+                    0.25 * pnp.sin(x[0]) * pnp.sin(x[1]) * pnp.array([1, -1, 1, -1]),
                 ),
                 (
-                    0.25 * np.sin(x[0]) * np.sin(x[1]) * np.array([1, -1, 1, -1]),
-                    0.5 * np.cos(x[1]) * np.array([-a[0], a[0], a[1], -a[1]]),
+                    0.25 * pnp.sin(x[0]) * pnp.sin(x[1]) * pnp.array([1, -1, 1, -1]),
+                    0.5 * pnp.cos(x[1]) * pnp.array([-a[0], a[0], a[1], -a[1]]),
                 ),
             ),
         )
@@ -543,17 +543,17 @@ class TestParameterShiftHessian:
             assert all(isinstance(h, tuple) for h in hess)
             assert all(len(h) == 2 for h in hess)
             assert all(
-                all(isinstance(h_, np.ndarray) and h_.shape == exp[0][0].shape for h_ in h)
+                all(isinstance(h_, pnp.ndarray) and h_.shape == exp[0][0].shape for h_ in h)
                 for h in hess
             )
-            assert np.allclose(hess, exp)
+            assert pnp.allclose(hess, exp)
 
     def test_multi_probs_multi_params(self):
         """Test that the correct hessian is calculated for a tape with multiple operators
         and multiple probability outputs"""
         dev = qml.device("default.qubit", wires=2)
 
-        x = np.array([0.1, 0.4], requires_grad=True)
+        x = pnp.array([0.1, 0.4], requires_grad=True)
 
         with qml.queuing.AnnotatedQueue() as q:
             qml.RY(x[0], wires=0)
@@ -564,30 +564,30 @@ class TestParameterShiftHessian:
 
         tape = qml.tape.QuantumScript.from_queue(q)
         a = [
-            np.cos(x[0] / 2) ** 2,
-            np.sin(x[0] / 2) ** 2,
-            np.cos(x[1] / 2) ** 2,
-            np.sin(x[1] / 2) ** 2,
+            pnp.cos(x[0] / 2) ** 2,
+            pnp.sin(x[0] / 2) ** 2,
+            pnp.cos(x[1] / 2) ** 2,
+            pnp.sin(x[1] / 2) ** 2,
         ]
         expected = (
             (
                 (
-                    0.5 * np.cos(x[0]) * np.cos(x[1]) * np.array([-1, 1]),
-                    0.5 * np.sin(x[0]) * np.sin(x[1]) * np.array([1, -1]),
+                    0.5 * pnp.cos(x[0]) * pnp.cos(x[1]) * pnp.array([-1, 1]),
+                    0.5 * pnp.sin(x[0]) * pnp.sin(x[1]) * pnp.array([1, -1]),
                 ),
                 (
-                    0.5 * np.sin(x[0]) * np.sin(x[1]) * np.array([1, -1]),
-                    0.5 * np.cos(x[0]) * np.cos(x[1]) * np.array([-1, 1]),
+                    0.5 * pnp.sin(x[0]) * pnp.sin(x[1]) * pnp.array([1, -1]),
+                    0.5 * pnp.cos(x[0]) * pnp.cos(x[1]) * pnp.array([-1, 1]),
                 ),
             ),
             (
                 (
-                    0.5 * np.cos(x[0]) * np.array([-a[2], -a[3], a[3], a[2]]),
-                    0.25 * np.sin(x[0]) * np.sin(x[1]) * np.array([1, -1, 1, -1]),
+                    0.5 * pnp.cos(x[0]) * pnp.array([-a[2], -a[3], a[3], a[2]]),
+                    0.25 * pnp.sin(x[0]) * pnp.sin(x[1]) * pnp.array([1, -1, 1, -1]),
                 ),
                 (
-                    0.25 * np.sin(x[0]) * np.sin(x[1]) * np.array([1, -1, 1, -1]),
-                    0.5 * np.cos(x[1]) * np.array([-a[0], a[0], a[1], -a[1]]),
+                    0.25 * pnp.sin(x[0]) * pnp.sin(x[1]) * pnp.array([1, -1, 1, -1]),
+                    0.5 * pnp.cos(x[1]) * pnp.array([-a[0], a[0], a[1], -a[1]]),
                 ),
             ),
         )
@@ -604,17 +604,17 @@ class TestParameterShiftHessian:
             assert all(isinstance(h, tuple) for h in hess)
             assert all(len(h) == 2 for h in hess)
             assert all(
-                all(isinstance(h_, np.ndarray) and h_.shape == exp[0][0].shape for h_ in h)
+                all(isinstance(h_, pnp.ndarray) and h_.shape == exp[0][0].shape for h_ in h)
                 for h in hess
             )
-            assert np.allclose(hess, exp)
+            assert pnp.allclose(hess, exp)
 
     def test_multi_params_argnum(self):
         """Test that the correct hessian is calculated for a tape with multiple operators
         but not all parameters trainable"""
         dev = qml.device("default.qubit", wires=2)
 
-        x = np.array([0.1, 0.4, 0.7], requires_grad=True)
+        x = pnp.array([0.1, 0.4, 0.7], requires_grad=True)
 
         with qml.queuing.AnnotatedQueue() as q:
             qml.RY(x[0], wires=0)
@@ -624,7 +624,7 @@ class TestParameterShiftHessian:
             qml.expval(qml.PauliZ(0))
 
         tape = qml.tape.QuantumScript.from_queue(q)
-        expected = ((0, 0, 0), (0, 0, 0), (0, 0, -np.cos(x[2] + x[0])))
+        expected = ((0, 0, 0), (0, 0, 0), (0, 0, -pnp.cos(x[2] + x[0])))
 
         tapes, fn = qml.gradients.param_shift_hessian(tape, argnum=(1, 2))
         hessian = fn(qml.execute(tapes, dev, diff_method=None))
@@ -634,16 +634,16 @@ class TestParameterShiftHessian:
         assert all(isinstance(hess, tuple) for hess in hessian)
         assert all(len(hess) == 3 for hess in hessian)
         assert all(
-            all(isinstance(h, np.ndarray) and h.shape == () for h in hess) for hess in hessian
+            all(isinstance(h, pnp.ndarray) and h.shape == () for h in hess) for hess in hessian
         )
 
-        assert np.allclose(hessian, expected)
+        assert pnp.allclose(hessian, expected)
 
     def test_state_error(self):
         """Test that an error is raised when computing the gradient of a tape
         that returns state"""
 
-        x = np.array(0.1, requires_grad=True)
+        x = pnp.array(0.1, requires_grad=True)
 
         with qml.queuing.AnnotatedQueue() as q:
             qml.RY(x, wires=0)
@@ -659,7 +659,7 @@ class TestParameterShiftHessian:
         """Test that an error is raised when computing the gradient of a tape
         that returns variance"""
 
-        x = np.array(0.1, requires_grad=True)
+        x = pnp.array(0.1, requires_grad=True)
 
         with qml.queuing.AnnotatedQueue() as q:
             qml.RY(x, wires=0)
@@ -699,7 +699,7 @@ class TestParameterShiftHessian:
         assert tapes == []
         assert isinstance(res, tuple)
         assert len(res) == num_measurements
-        assert all(isinstance(r, np.ndarray) and r.shape == (0,) for r in res)
+        assert all(isinstance(r, pnp.ndarray) and r.shape == (0,) for r in res)
 
     @pytest.mark.parametrize("num_measurements", [1, 2])
     def test_all_zero_grads(self, num_measurements):
@@ -713,7 +713,7 @@ class TestParameterShiftHessian:
 
             grad_method = "0"
 
-        x = np.array(0.1, requires_grad=True)
+        x = pnp.array(0.1, requires_grad=True)
 
         with qml.queuing.AnnotatedQueue() as q:
             DummyOp(x, wires=[0, 1])
@@ -731,7 +731,7 @@ class TestParameterShiftHessian:
         assert isinstance(res, tuple)
         assert len(res) == num_measurements
         assert all(
-            isinstance(r, np.ndarray) and np.allclose(r, np.array([0, 0, 0, 0])) for r in res
+            isinstance(r, pnp.ndarray) and pnp.allclose(r, pnp.array([0, 0, 0, 0])) for r in res
         )
 
     def test_error_unsupported_op(self):
@@ -743,7 +743,7 @@ class TestParameterShiftHessian:
 
             grad_method = "F"
 
-        x = np.array([0.1, 0.2, 0.3], requires_grad=True)
+        x = pnp.array([0.1, 0.2, 0.3], requires_grad=True)
 
         with qml.queuing.AnnotatedQueue() as q:
             qml.RX(x[0], wires=0)
@@ -801,12 +801,12 @@ class TestParameterShiftHessianQNode:
             qml.CNOT(wires=[0, 1])
             return qml.expval(qml.PauliZ(0))
 
-        x = np.array(0.1, requires_grad=True)
+        x = pnp.array(0.1, requires_grad=True)
 
         expected = qml.jacobian(qml.grad(circuit))(x)
         hessian = qml.gradients.param_shift_hessian(circuit)(x)
 
-        assert np.allclose(expected, hessian)
+        assert pnp.allclose(expected, hessian)
 
     def test_fixed_params(self):
         """Test that the correct hessian is calculated for a QNode with single RX operator
@@ -822,12 +822,12 @@ class TestParameterShiftHessianQNode:
             qml.CNOT(wires=[0, 1])
             return qml.expval(qml.PauliZ(0))
 
-        x = np.array(0.1, requires_grad=True)
+        x = pnp.array(0.1, requires_grad=True)
 
         expected = qml.jacobian(qml.grad(circuit))(x)
         hessian = qml.gradients.param_shift_hessian(circuit)(x)
 
-        assert np.allclose(expected, hessian)
+        assert pnp.allclose(expected, hessian)
 
     def test_gate_without_impact(self):
         """Test that the correct hessian is calculated for a QNode with an operator
@@ -841,12 +841,12 @@ class TestParameterShiftHessianQNode:
             qml.RX(x[1], wires=1)
             return qml.expval(qml.PauliZ(0))
 
-        x = np.array([0.1, 0.2], requires_grad=True)
+        x = pnp.array([0.1, 0.2], requires_grad=True)
 
         expected = qml.jacobian(qml.grad(circuit))(x)
         hessian = qml.gradients.param_shift_hessian(circuit)(x)
 
-        assert np.allclose(expected, hessian)
+        assert pnp.allclose(expected, hessian)
 
     @pytest.mark.filterwarnings("ignore:Output seems independent of input.")
     def test_no_gate_with_impact(self):
@@ -861,12 +861,12 @@ class TestParameterShiftHessianQNode:
             qml.RX(x[1], wires=1)
             return qml.expval(qml.PauliZ(0))
 
-        x = np.array([0.1, 0.2], requires_grad=True)
+        x = pnp.array([0.1, 0.2], requires_grad=True)
 
         expected = qml.jacobian(qml.grad(circuit))(x)
         hessian = qml.gradients.param_shift_hessian(circuit)(x)
 
-        assert np.allclose(expected, hessian)
+        assert pnp.allclose(expected, hessian)
 
     def test_single_multi_term_gate(self):
         """Test that the correct hessian is calculated for a QNode with single operation
@@ -882,12 +882,12 @@ class TestParameterShiftHessianQNode:
             qml.CNOT(wires=[0, 1])
             return qml.expval(qml.PauliZ(0))
 
-        x = np.array(0.1, requires_grad=True)
+        x = pnp.array(0.1, requires_grad=True)
 
         expected = qml.jacobian(qml.grad(circuit))(x)
         hessian = qml.gradients.param_shift_hessian(circuit)(x)
 
-        assert np.allclose(expected, hessian)
+        assert pnp.allclose(expected, hessian)
 
     def test_single_gate_custom_recipe(self):
         """Test that the correct hessian is calculated for a QNode with single operation
@@ -897,7 +897,7 @@ class TestParameterShiftHessianQNode:
         dev = qml.device("default.qubit", wires=2)
 
         c, s = qml.gradients.generate_shift_rule((0.5, 1)).T
-        recipe = list(zip(c, np.ones_like(c), s))
+        recipe = list(zip(c, pnp.ones_like(c), s))
 
         # pylint: disable=too-few-public-methods
         class DummyOp(qml.CRX):
@@ -912,12 +912,12 @@ class TestParameterShiftHessianQNode:
             qml.CNOT(wires=[0, 1])
             return qml.expval(qml.PauliZ(0))
 
-        x = np.array(0.1, requires_grad=True)
+        x = pnp.array(0.1, requires_grad=True)
 
         expected = qml.jacobian(qml.grad(circuit))(x)
         hessian = qml.gradients.param_shift_hessian(circuit)(x)
 
-        assert np.allclose(expected, hessian)
+        assert pnp.allclose(expected, hessian)
 
     def test_single_two_term_gate_vector_output(self):
         """Test that the correct hessian is calculated for a QNode with single RY operator
@@ -931,12 +931,12 @@ class TestParameterShiftHessianQNode:
             qml.CNOT(wires=[0, 1])
             return qml.probs(wires=[0, 1])
 
-        x = np.array(0.1, requires_grad=True)
+        x = pnp.array(0.1, requires_grad=True)
 
         expected = qml.jacobian(qml.jacobian(circuit))(x)
         hessian = qml.gradients.param_shift_hessian(circuit)(x)
 
-        assert np.allclose(expected, hessian)
+        assert pnp.allclose(expected, hessian)
 
     def test_multiple_two_term_gates(self):
         """Test that the correct hessian is calculated for a QNode with two rotation operators
@@ -952,12 +952,12 @@ class TestParameterShiftHessianQNode:
             qml.RY(x[2], wires=1)
             return qml.expval(qml.PauliZ(1))
 
-        x = np.array([0.1, 0.2, -0.8], requires_grad=True)
+        x = pnp.array([0.1, 0.2, -0.8], requires_grad=True)
 
         expected = qml.jacobian(qml.jacobian(circuit))(x)
         hessian = qml.gradients.param_shift_hessian(circuit)(x)
 
-        assert np.allclose(expected, hessian)
+        assert pnp.allclose(expected, hessian)
 
     def test_multiple_two_term_gates_vector_output(self):
         """Test that the correct hessian is calculated for a QNode with two rotation operators
@@ -973,12 +973,12 @@ class TestParameterShiftHessianQNode:
             qml.RY(x[2], wires=1)
             return qml.probs(wires=1)
 
-        x = np.array([0.1, 0.2, -0.8], requires_grad=True)
+        x = pnp.array([0.1, 0.2, -0.8], requires_grad=True)
 
         expected = qml.jacobian(qml.jacobian(circuit))(x)
         hessian = qml.gradients.param_shift_hessian(circuit)(x)
 
-        assert np.allclose(qml.math.transpose(expected, (2, 1, 0)), hessian)
+        assert pnp.allclose(qml.math.transpose(expected, (2, 1, 0)), hessian)
 
     def test_quantum_hessian_shape_vector_input_vector_output(self):
         """Test that the purely "quantum" hessian has the correct shape (1d -> 1d)"""
@@ -994,7 +994,7 @@ class TestParameterShiftHessianQNode:
             qml.Rot(x[0], x[1], x[2], wires=1)
             return qml.probs(wires=[0, 1])
 
-        x = np.array([0.1, 0.2, 0.3], requires_grad=True)
+        x = pnp.array([0.1, 0.2, 0.3], requires_grad=True)
         shape = (3, 3, 4)  # (num_args, num_args, num_output_vals)
 
         hessian = qml.gradients.param_shift_hessian(circuit)(x)
@@ -1015,12 +1015,12 @@ class TestParameterShiftHessianQNode:
             qml.Rot(x[0], x[1], x[2], wires=1)
             return qml.probs(wires=[0, 1])
 
-        x = np.array([0.1, 0.2, 0.3], requires_grad=True)
+        x = pnp.array([0.1, 0.2, 0.3], requires_grad=True)
 
         expected = qml.jacobian(qml.jacobian(circuit))(x)
         hessian = qml.gradients.param_shift_hessian(circuit)(x)
 
-        assert np.allclose(qml.math.transpose(expected, (2, 1, 0)), hessian)
+        assert pnp.allclose(qml.math.transpose(expected, (2, 1, 0)), hessian)
 
     def test_multiple_two_term_gates_classical_processing(self):
         """Test that the correct hessian is calculated when manipulating parameters (1d -> 1d)"""
@@ -1035,12 +1035,12 @@ class TestParameterShiftHessianQNode:
             qml.RZ(x[2] / x[0] - x[1], wires=1)
             return qml.probs(wires=[0, 1])
 
-        x = np.array([0.1, 0.2, 0.3], requires_grad=True)
+        x = pnp.array([0.1, 0.2, 0.3], requires_grad=True)
 
         expected = qml.jacobian(qml.jacobian(circuit))(x)
         hessian = qml.gradients.param_shift_hessian(circuit)(x)
 
-        assert np.allclose(qml.math.transpose(expected, (2, 1, 0)), hessian)
+        assert pnp.allclose(qml.math.transpose(expected, (2, 1, 0)), hessian)
 
     def test_multiple_two_term_gates_matrix_output(self):
         """Test that the correct hessian is calculated for higher dimensional QNode outputs
@@ -1058,12 +1058,12 @@ class TestParameterShiftHessianQNode:
         def cost(x):
             return qml.math.stack(circuit(x))
 
-        x = np.ones([2], requires_grad=True)
+        x = pnp.ones([2], requires_grad=True)
 
         expected = qml.jacobian(qml.jacobian(cost))(x)
         hessian = qml.gradients.param_shift_hessian(circuit)(x)
 
-        assert np.allclose(qml.math.transpose(expected, (0, 3, 2, 1)), hessian)
+        assert pnp.allclose(qml.math.transpose(expected, (0, 3, 2, 1)), hessian)
 
     def test_multiple_two_term_gates_matrix_input(self):
         """Test that the correct hessian is calculated for higher dimensional cl. jacobians
@@ -1083,12 +1083,12 @@ class TestParameterShiftHessianQNode:
         def cost(x):
             return qml.math.stack(circuit(x))
 
-        x = np.ones([1, 3], requires_grad=True)
+        x = pnp.ones([1, 3], requires_grad=True)
 
         expected = qml.jacobian(qml.jacobian(cost))(x)
         hessian = qml.gradients.param_shift_hessian(circuit)(x)
 
-        assert np.allclose(qml.math.transpose(expected, (0, 2, 3, 4, 5, 1)), hessian)
+        assert pnp.allclose(qml.math.transpose(expected, (0, 2, 3, 4, 5, 1)), hessian)
 
     def test_multiple_qnode_arguments_scalar(self):
         """Test that the correct Hessian is calculated with multiple QNode arguments (0D->1D)"""
@@ -1106,9 +1106,9 @@ class TestParameterShiftHessianQNode:
         def wrapper(X):
             return circuit(*X)
 
-        x = np.array(0.1, requires_grad=True)
-        y = np.array(0.5, requires_grad=True)
-        z = np.array(0.3, requires_grad=True)
+        x = pnp.array(0.1, requires_grad=True)
+        y = pnp.array(0.5, requires_grad=True)
+        z = pnp.array(0.3, requires_grad=True)
         X = qml.math.stack([x, y, z])
 
         expected = qml.jacobian(qml.jacobian(wrapper))(X)
@@ -1116,7 +1116,7 @@ class TestParameterShiftHessianQNode:
         circuit.interface = "autograd"
         hessian = qml.gradients.param_shift_hessian(circuit)(x, y, z)
 
-        assert np.allclose(expected, hessian)
+        assert pnp.allclose(expected, hessian)
 
     def test_multiple_qnode_arguments_vector(self):
         """Test that the correct Hessian is calculated with multiple QNode arguments (1D->1D)"""
@@ -1134,9 +1134,9 @@ class TestParameterShiftHessianQNode:
         def wrapper(X):
             return circuit(*X)
 
-        x = np.array([0.1, 0.3], requires_grad=True)
-        y = np.array([0.5, 0.7], requires_grad=True)
-        z = np.array([0.3, 0.2], requires_grad=True)
+        x = pnp.array([0.1, 0.3], requires_grad=True)
+        y = pnp.array([0.5, 0.7], requires_grad=True)
+        z = pnp.array([0.3, 0.2], requires_grad=True)
         X = qml.math.stack([x, y, z])
 
         expected = qml.jacobian(qml.jacobian(wrapper))(X)
@@ -1145,7 +1145,7 @@ class TestParameterShiftHessianQNode:
         circuit.interface = "autograd"
         hessian = qml.gradients.param_shift_hessian(circuit)(x, y, z)
 
-        assert np.allclose(qml.math.transpose(expected, (0, 2, 3, 1)), hessian)
+        assert pnp.allclose(qml.math.transpose(expected, (0, 2, 3, 1)), hessian)
 
     def test_multiple_qnode_arguments_matrix(self):
         """Test that the correct Hessian is calculated with multiple QNode arguments (2D->1D)"""
@@ -1163,9 +1163,9 @@ class TestParameterShiftHessianQNode:
         def wrapper(X):
             return circuit(*X)
 
-        x = np.array([[0.1, 0.3], [0.2, 0.4]], requires_grad=True)
-        y = np.array([[0.5, 0.7], [0.2, 0.4]], requires_grad=True)
-        z = np.array([[0.3, 0.2], [0.2, 0.4]], requires_grad=True)
+        x = pnp.array([[0.1, 0.3], [0.2, 0.4]], requires_grad=True)
+        y = pnp.array([[0.5, 0.7], [0.2, 0.4]], requires_grad=True)
+        z = pnp.array([[0.3, 0.2], [0.2, 0.4]], requires_grad=True)
         X = qml.math.stack([x, y, z])
 
         expected = qml.jacobian(qml.jacobian(wrapper))(X)
@@ -1174,7 +1174,7 @@ class TestParameterShiftHessianQNode:
         circuit.interface = "autograd"
         hessian = qml.gradients.param_shift_hessian(circuit)(x, y, z)
 
-        assert np.allclose(qml.math.transpose(expected, (0, 2, 3, 4, 5, 1)), hessian)
+        assert pnp.allclose(qml.math.transpose(expected, (0, 2, 3, 4, 5, 1)), hessian)
 
     def test_multiple_qnode_arguments_mixed(self):
         """Test that the correct Hessian is calculated with multiple mixed-shape QNode arguments"""
@@ -1193,18 +1193,18 @@ class TestParameterShiftHessianQNode:
         def cost(x, y, z):
             return qml.math.stack(circuit(x, y, z))
 
-        x = np.array(0.1, requires_grad=True)
-        y = np.array([[0.5, 0.6], [0.2, 0.1]], requires_grad=True)
-        z = np.array([0.3, 0.4], requires_grad=True)
+        x = pnp.array(0.1, requires_grad=True)
+        y = pnp.array([[0.5, 0.6], [0.2, 0.1]], requires_grad=True)
+        z = pnp.array([0.3, 0.4], requires_grad=True)
 
         expected = tuple(
             qml.jacobian(qml.jacobian(cost, argnum=i), argnum=i)(x, y, z) for i in range(3)
         )
         hessian = qml.gradients.param_shift_hessian(circuit)(x, y, z)
 
-        assert np.allclose(expected[0], hessian[0])
-        assert np.allclose(qml.math.transpose(expected[1], (0, 2, 3, 4, 5, 1)), hessian[1])
-        assert np.allclose(qml.math.transpose(expected[2], (0, 2, 3, 1)), hessian[2])
+        assert pnp.allclose(expected[0], hessian[0])
+        assert pnp.allclose(qml.math.transpose(expected[1], (0, 2, 3, 4, 5, 1)), hessian[1])
+        assert pnp.allclose(qml.math.transpose(expected[2], (0, 2, 3, 1)), hessian[2])
 
     def test_with_channel(self):
         """Test that the Hessian is correctly computed for circuits
@@ -1220,12 +1220,12 @@ class TestParameterShiftHessianQNode:
             qml.CNOT(wires=[0, 1])
             return qml.probs(wires=[0, 1])
 
-        x = np.array([-0.4, 0.9, 0.1], requires_grad=True)
+        x = pnp.array([-0.4, 0.9, 0.1], requires_grad=True)
 
         expected = qml.jacobian(qml.jacobian(circuit))(x)
         hessian = qml.gradients.param_shift_hessian(circuit)(x)
 
-        assert np.allclose(qml.math.transpose(expected, (2, 1, 0)), hessian)
+        assert pnp.allclose(qml.math.transpose(expected, (2, 1, 0)), hessian)
 
     def test_hessian_transform_is_differentiable(self):
         """Test that the 3rd derivate can be calculated via auto-differentiation (1d -> 1d)"""
@@ -1239,7 +1239,7 @@ class TestParameterShiftHessianQNode:
             qml.CNOT(wires=[0, 1])
             return qml.probs(wires=[0, 1])
 
-        x = np.array([0.1, 0.2], requires_grad=True)
+        x = pnp.array([0.1, 0.2], requires_grad=True)
 
         expected = qml.jacobian(qml.jacobian(qml.jacobian(circuit)))(x)
 
@@ -1250,7 +1250,7 @@ class TestParameterShiftHessianQNode:
 
         derivative = qml.jacobian(cost_fn)(x)
 
-        assert np.allclose(qml.math.transpose(expected, (1, 2, 0, 3)), derivative)
+        assert pnp.allclose(qml.math.transpose(expected, (1, 2, 0, 3)), derivative)
 
     # Some bounds on the efficiency (device executions) of the hessian for 2-term shift rules:
     # - < jacobian(jacobian())
@@ -1270,7 +1270,7 @@ class TestParameterShiftHessianQNode:
             qml.CNOT(wires=[0, 1])
             return qml.expval(qml.PauliZ(1))
 
-        x = np.array(0.1, requires_grad=True)
+        x = pnp.array(0.1, requires_grad=True)
 
         with qml.Tracker(dev) as tracker:
             hessian = qml.gradients.param_shift_hessian(circuit)(x)
@@ -1278,7 +1278,7 @@ class TestParameterShiftHessianQNode:
             expected = qml.jacobian(qml.jacobian(circuit))(x)
             jacobian_qruns = tracker.totals["executions"] - hessian_qruns
 
-        assert np.allclose(hessian, expected)
+        assert pnp.allclose(hessian, expected)
         assert hessian_qruns < jacobian_qruns
         assert hessian_qruns <= 2**2 * 1  # 1 = (1+2-1)C(2)
         assert hessian_qruns <= 3**1
@@ -1296,7 +1296,7 @@ class TestParameterShiftHessianQNode:
             qml.RY(x[1], wires=0)
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
-        x = np.array([0.1, 0.2], requires_grad=True)
+        x = pnp.array([0.1, 0.2], requires_grad=True)
 
         with qml.Tracker(dev) as tracker:
             hessian = qml.gradients.param_shift_hessian(circuit)(x)
@@ -1304,7 +1304,7 @@ class TestParameterShiftHessianQNode:
             expected = qml.jacobian(qml.jacobian(circuit))(x)
             jacobian_qruns = tracker.totals["executions"] - hessian_qruns
 
-        assert np.allclose(hessian, expected)
+        assert pnp.allclose(hessian, expected)
         assert hessian_qruns < jacobian_qruns
         assert hessian_qruns <= 2**2 * 3  # 3 = (2+2-1)C(2)
         assert hessian_qruns <= 3**2
@@ -1324,7 +1324,7 @@ class TestParameterShiftHessianQNode:
             qml.RZ(x[2], wires=1)
             return qml.probs(wires=[0, 1])
 
-        x = np.array([0.1, 0.2, 0.3], requires_grad=True)
+        x = pnp.array([0.1, 0.2, 0.3], requires_grad=True)
 
         with qml.Tracker(dev) as tracker:
             hessian = qml.gradients.param_shift_hessian(circuit)(x)
@@ -1332,7 +1332,7 @@ class TestParameterShiftHessianQNode:
             expected = qml.jacobian(qml.jacobian(circuit))(x)
             jacobian_qruns = tracker.totals["executions"] - hessian_qruns
 
-        assert np.allclose(hessian, expected)
+        assert pnp.allclose(hessian, expected)
         assert hessian_qruns < jacobian_qruns
         assert hessian_qruns <= 2**2 * 6  # 6 = (3+2-1)C(2)
         assert hessian_qruns <= 3**3
@@ -1356,7 +1356,7 @@ class TestParameterShiftHessianQNode:
             DummyOp(x[2], wires=[0, 1])
             return qml.probs(wires=1)
 
-        x = np.array([0.1, 0.2, 0.3], requires_grad=True)
+        x = pnp.array([0.1, 0.2, 0.3], requires_grad=True)
 
         with pytest.raises(
             ValueError,
@@ -1376,7 +1376,7 @@ class TestParameterShiftHessianQNode:
             qml.CRZ(x[2], wires=[0, 1])
             return qml.var(qml.PauliZ(1))
 
-        x = np.array([0.1, 0.2, 0.3], requires_grad=True)
+        x = pnp.array([0.1, 0.2, 0.3], requires_grad=True)
 
         with pytest.raises(
             ValueError,
@@ -1396,7 +1396,7 @@ class TestParameterShiftHessianQNode:
             qml.CRZ(x[2], wires=[0, 1])
             return qml.state()
 
-        x = np.array([0.1, 0.2, 0.3], requires_grad=True)
+        x = pnp.array([0.1, 0.2, 0.3], requires_grad=True)
 
         with pytest.raises(
             ValueError,
@@ -1422,9 +1422,9 @@ class TestParameterShiftHessianQNode:
             DummyOp(z, wires=[0, 1])
             return qml.probs(wires=1)
 
-        x = np.array(0.1, requires_grad=True)
-        y = np.array(0.2, requires_grad=True)
-        z = np.array(0.3, requires_grad=False)
+        x = pnp.array(0.1, requires_grad=True)
+        y = pnp.array(0.2, requires_grad=True)
+        z = pnp.array(0.3, requires_grad=False)
 
         qml.gradients.param_shift_hessian(circuit)(x, y, z)
 
@@ -1506,11 +1506,11 @@ class TestParameterShiftHessianQNode:
             qml.Rot(*params, wires=0)
             return qml.probs([2, 3])
 
-        params = np.array([0.5, 0.5, 0.5], requires_grad=True)
+        params = pnp.array([0.5, 0.5, 0.5], requires_grad=True)
         circuit(params)
 
         result = qml.gradients.param_shift_hessian(circuit)(params)
-        assert np.allclose(result, np.zeros((3, 3, 4)), atol=0, rtol=0)
+        assert pnp.allclose(result, pnp.zeros((3, 3, 4)), atol=0, rtol=0)
 
         tapes, _ = qml.gradients.param_shift_hessian(circuit.qtape)
         assert tapes == []
@@ -1527,7 +1527,7 @@ class TestParameterShiftHessianQNode:
             qml.CNOT(wires=[0, 1])
             return qml.probs(wires=1)
 
-        x = np.array([0.1, 0.2], requires_grad=True)
+        x = pnp.array([0.1, 0.2], requires_grad=True)
 
         res = circuit(x)
 
@@ -1537,7 +1537,7 @@ class TestParameterShiftHessianQNode:
             hessian2 = qml.gradients.param_shift_hessian(circuit)(x)
             qruns2 = tracker.totals["executions"] - qruns1
 
-        assert np.allclose(hessian1, hessian2)
+        assert pnp.allclose(hessian1, hessian2)
         assert qruns1 < qruns2
 
     def test_output_shape_matches_qnode(self):
@@ -1568,7 +1568,7 @@ class TestParameterShiftHessianQNode:
             qml.Rot(*x, wires=0)
             return [qml.probs([0, 1]), qml.probs([2, 3])]
 
-        x = np.random.rand(3)
+        x = pnp.random.rand(3)
         circuits = [qml.QNode(cost, dev) for cost in (cost1, cost2, cost3, cost4, cost5, cost6)]
 
         transform = [qml.math.shape(qml.gradients.param_shift_hessian(c)(x)) for c in circuits]
@@ -1584,8 +1584,8 @@ class TestParamShiftHessianWithKwargs:
     @pytest.mark.parametrize(
         "diagonal_shifts",
         (
-            [(np.pi / 3,), (np.pi / 2,)],
-            [(np.pi / 3,), None],
+            [(pnp.pi / 3,), (pnp.pi / 2,)],
+            [(pnp.pi / 3,), None],
         ),
     )
     def test_with_diagonal_shifts(self, diagonal_shifts):
@@ -1599,7 +1599,7 @@ class TestParamShiftHessianWithKwargs:
             qml.CNOT(wires=[0, 1])
             return qml.probs(wires=0)
 
-        x = np.array([0.6, -0.2], requires_grad=True)
+        x = pnp.array([0.6, -0.2], requires_grad=True)
 
         expected = qml.math.transpose(qml.jacobian(qml.jacobian(circuit))(x), (1, 2, 0))
         circuit(x)
@@ -1613,22 +1613,22 @@ class TestParamShiftHessianWithKwargs:
         # - 4 for off-diagonal,
         # - 1 for second diagonal.
         assert len(tapes) == 1 + 2 + 4 + 1
-        assert np.allclose(tapes[0].get_parameters(), x)
-        assert np.allclose(tapes[1].get_parameters(), x + np.array([2 * np.pi / 3, 0.0]))
-        assert np.allclose(tapes[2].get_parameters(), x + np.array([-2 * np.pi / 3, 0.0]))
-        assert np.allclose(tapes[-1].get_parameters(), x + np.array([0.0, -np.pi]))
-        expected_shifts = np.array([[1, 1], [1, -1], [-1, 1], [-1, -1]]) * (np.pi / 2)
+        assert pnp.allclose(tapes[0].get_parameters(), x)
+        assert pnp.allclose(tapes[1].get_parameters(), x + pnp.array([2 * pnp.pi / 3, 0.0]))
+        assert pnp.allclose(tapes[2].get_parameters(), x + pnp.array([-2 * pnp.pi / 3, 0.0]))
+        assert pnp.allclose(tapes[-1].get_parameters(), x + pnp.array([0.0, -pnp.pi]))
+        expected_shifts = pnp.array([[1, 1], [1, -1], [-1, 1], [-1, -1]]) * (pnp.pi / 2)
         for _tape, exp_shift in zip(tapes[3:-1], expected_shifts):
-            assert np.allclose(_tape.get_parameters(), x + exp_shift)
+            assert pnp.allclose(_tape.get_parameters(), x + exp_shift)
 
         hessian = fn(qml.execute(tapes, dev, diff_method=qml.gradients.param_shift))
 
-        assert np.allclose(expected, hessian)
+        assert pnp.allclose(expected, hessian)
 
     @pytest.mark.parametrize(
         "off_diagonal_shifts",
         (
-            [(np.pi / 2,), (0.3, 0.6)],
+            [(pnp.pi / 2,), (0.3, 0.6)],
             [None, (0.3, 0.6)],
         ),
     )
@@ -1643,7 +1643,7 @@ class TestParamShiftHessianWithKwargs:
             qml.CNOT(wires=[0, 1])
             return qml.probs(wires=0)
 
-        x = np.array([0.6, -0.2], requires_grad=True)
+        x = pnp.array([0.6, -0.2], requires_grad=True)
 
         expected = qml.math.transpose(qml.jacobian(qml.jacobian(circuit))(x), (1, 2, 0))
         circuit(x)
@@ -1657,25 +1657,25 @@ class TestParamShiftHessianWithKwargs:
         # - 8 for off-diagonal,
         # - 3 for second diagonal.
         assert len(tapes) == 1 + 1 + 8 + 3
-        assert np.allclose(tapes[0].get_parameters(), x)
+        assert pnp.allclose(tapes[0].get_parameters(), x)
 
         # Check that the vanilla diagonal rule is used for the first diagonal entry
-        assert np.allclose(tapes[1].get_parameters(), x + np.array([-np.pi, 0.0]))
+        assert pnp.allclose(tapes[1].get_parameters(), x + pnp.array([-pnp.pi, 0.0]))
 
         # Check that the provided off-diagonal shift values are used
-        expected_shifts = np.array(
+        expected_shifts = pnp.array(
             [[1, 1], [1, -1], [1, 2], [1, -2], [-1, 1], [-1, -1], [-1, 2], [-1, -2]]
-        ) * np.array([[np.pi / 2, 0.3]])
+        ) * pnp.array([[pnp.pi / 2, 0.3]])
         for _tape, exp_shift in zip(tapes[2:10], expected_shifts):
-            assert np.allclose(_tape.get_parameters(), x + exp_shift)
+            assert pnp.allclose(_tape.get_parameters(), x + exp_shift)
 
         # Check that the vanilla diagonal rule is used for the second diagonal entry
         shift_order = [1, -1, -2]
         for mult, _tape in zip(shift_order, tapes[10:]):
-            assert np.allclose(_tape.get_parameters(), x + np.array([0.0, np.pi * mult]))
+            assert pnp.allclose(_tape.get_parameters(), x + pnp.array([0.0, pnp.pi * mult]))
 
         hessian = fn(qml.execute(tapes, dev, diff_method=qml.gradients.param_shift))
-        assert np.allclose(expected, hessian)
+        assert pnp.allclose(expected, hessian)
 
     @pytest.mark.parametrize("argnum", [(0,), (1,), (0, 1)])
     def test_with_1d_argnum(self, argnum):
@@ -1692,17 +1692,17 @@ class TestParamShiftHessianWithKwargs:
         def wrapper(X):
             return circuit(*X)
 
-        X = np.array([0.6, -0.2], requires_grad=True)
+        X = pnp.array([0.6, -0.2], requires_grad=True)
 
         expected = qml.jacobian(qml.jacobian(wrapper))(X)
         # Extract "diagonal" across arguments
-        expected = np.array([np.diag(sub) for i, sub in enumerate(expected)])
+        expected = pnp.array([pnp.diag(sub) for i, sub in enumerate(expected)])
         # Set non-argnum argument entries to 0
         for i in range(len(X)):
             if i not in argnum:
                 expected[:, i] = 0.0
         hessian = qml.gradients.param_shift_hessian(circuit, argnum=argnum)(*X)
-        assert np.allclose(hessian, expected.T)
+        assert pnp.allclose(hessian, expected.T)
 
     @pytest.mark.parametrize(
         "argnum",
@@ -1724,7 +1724,7 @@ class TestParamShiftHessianWithKwargs:
             qml.CRY(par[2], wires=[0, 1])
             return qml.probs(wires=[0, 1])
 
-        par = np.array([0.6, -0.2, 0.8], requires_grad=True)
+        par = pnp.array([0.6, -0.2, 0.8], requires_grad=True)
 
         expected = qml.jacobian(qml.jacobian(circuit))(par)
         # Set non-argnum argument entries to 0
@@ -1732,7 +1732,7 @@ class TestParamShiftHessianWithKwargs:
             expected * qml.math.array(argnum, dtype=float)[None], (1, 2, 0)
         )
         hessian = qml.gradients.param_shift_hessian(circuit, argnum=argnum)(par)
-        assert np.allclose(hessian, expected)
+        assert pnp.allclose(hessian, expected)
 
     @pytest.mark.parametrize("argnum", [(0,), (1,), (0, 1)])
     def test_with_argnum_and_shifts(self, argnum):
@@ -1751,11 +1751,11 @@ class TestParamShiftHessianWithKwargs:
         def wrapper(X):
             return circuit(*X)
 
-        X = np.array([0.6, -0.2], requires_grad=True)
+        X = pnp.array([0.6, -0.2], requires_grad=True)
 
         expected = qml.jacobian(qml.jacobian(wrapper))(X)
         # Extract "diagonal" across arguments
-        expected = np.array([np.diag(sub) for i, sub in enumerate(expected)])
+        expected = pnp.array([pnp.diag(sub) for i, sub in enumerate(expected)])
         # Set non-argnum argument entries to 0
         for i in range(len(X)):
             if i not in argnum:
@@ -1765,7 +1765,7 @@ class TestParamShiftHessianWithKwargs:
         hessian = qml.gradients.param_shift_hessian(
             circuit, argnum=argnum, diagonal_shifts=d_shifts, off_diagonal_shifts=od_shifts
         )(*X)
-        assert np.allclose(hessian, expected.T)
+        assert pnp.allclose(hessian, expected.T)
 
 
 class TestInterfaces:
@@ -1786,14 +1786,14 @@ class TestInterfaces:
             qml.CNOT(wires=[0, 1])
             return qml.probs(wires=[0, 1])
 
-        x_np = np.array([0.1, 0.2], requires_grad=True)
+        x_np = pnp.array([0.1, 0.2], requires_grad=True)
         x_torch = torch.tensor([0.1, 0.2], dtype=torch.float64, requires_grad=True)
 
         expected = qml.jacobian(qml.jacobian(circuit))(x_np)
         circuit.interface = "torch"
         hess = qml.gradients.param_shift_hessian(circuit)(x_torch)[0]
 
-        assert np.allclose(expected, hess.detach())
+        assert pnp.allclose(expected, hess.detach())
 
     @pytest.mark.skip("Requires Torch integration for new return types")
     @pytest.mark.torch
@@ -1811,7 +1811,7 @@ class TestInterfaces:
             qml.CNOT(wires=[0, 1])
             return qml.probs(wires=[0, 1])
 
-        x = np.array([0.1, 0.2], requires_grad=True)
+        x = pnp.array([0.1, 0.2], requires_grad=True)
         x_torch = torch.tensor([0.1, 0.2], dtype=torch.float64, requires_grad=True)
 
         expected = qml.jacobian(qml.jacobian(qml.jacobian(circuit)))(x)
@@ -1819,7 +1819,7 @@ class TestInterfaces:
         jacobian_fn = torch.autograd.functional.jacobian
         torch_deriv = jacobian_fn(qml.gradients.param_shift_hessian(circuit), x_torch)[0]
 
-        assert np.allclose(expected, torch_deriv)
+        assert pnp.allclose(expected, torch_deriv)
 
     @pytest.mark.jax
     @pytest.mark.slow
@@ -1836,14 +1836,14 @@ class TestInterfaces:
             qml.CNOT(wires=[0, 1])
             return qml.probs(wires=[0, 1])
 
-        x_np = np.array([0.1, 0.2], requires_grad=True)
+        x_np = pnp.array([0.1, 0.2], requires_grad=True)
         x_jax = jax.numpy.array([0.1, 0.2])
 
         expected = qml.jacobian(qml.jacobian(circuit))(x_np)
         circuit.interface = "jax"
         hess = qml.gradients.param_shift_hessian(circuit, argnums=[0])(x_jax)
 
-        assert np.allclose(qml.math.transpose(expected, (1, 2, 0)), hess)
+        assert pnp.allclose(qml.math.transpose(expected, (1, 2, 0)), hess)
 
     @pytest.mark.jax
     @pytest.mark.slow
@@ -1861,7 +1861,7 @@ class TestInterfaces:
             qml.CNOT(wires=[0, 1])
             return qml.probs(wires=[0, 1])
 
-        x = np.array([0.1, 0.2], requires_grad=True)
+        x = pnp.array([0.1, 0.2], requires_grad=True)
         x_jax = jax.numpy.array([0.1, 0.2])
 
         expected = qml.jacobian(qml.jacobian(qml.jacobian(circuit)))(x)
@@ -1874,7 +1874,7 @@ class TestInterfaces:
         circuit.interface = "jax"
         jax_deriv = jax.jacobian(cost_fn)(x_jax)
 
-        assert np.allclose(qml.math.transpose(expected, (1, 2, 0, 3)), jax_deriv)
+        assert pnp.allclose(qml.math.transpose(expected, (1, 2, 0, 3)), jax_deriv)
 
     @pytest.mark.tf
     @pytest.mark.slow
@@ -1891,7 +1891,7 @@ class TestInterfaces:
             qml.CNOT(wires=[0, 1])
             return qml.probs(wires=[0, 1])
 
-        x_np = np.array([0.1, 0.2], requires_grad=True)
+        x_np = pnp.array([0.1, 0.2], requires_grad=True)
         x_tf = tf.Variable([0.1, 0.2], dtype=tf.float64)
 
         expected = qml.jacobian(qml.jacobian(circuit))(x_np)
@@ -1899,7 +1899,7 @@ class TestInterfaces:
         with tf.GradientTape():
             hess = qml.gradients.param_shift_hessian(circuit)(x_tf)
 
-        assert np.allclose(qml.math.transpose(expected, (1, 2, 0)), hess)
+        assert pnp.allclose(qml.math.transpose(expected, (1, 2, 0)), hess)
 
     @pytest.mark.tf
     @pytest.mark.slow
@@ -1917,7 +1917,7 @@ class TestInterfaces:
             qml.CNOT(wires=[0, 1])
             return qml.probs(wires=[0, 1])
 
-        x = np.array([0.1, 0.2], requires_grad=True)
+        x = pnp.array([0.1, 0.2], requires_grad=True)
         x_tf = tf.Variable([0.1, 0.2], dtype=tf.float64)
 
         expected = qml.jacobian(qml.jacobian(qml.jacobian(circuit)))(x)
@@ -1928,4 +1928,4 @@ class TestInterfaces:
 
         tensorflow_deriv = tf_tape.jacobian(hessian, x_tf)
 
-        assert np.allclose(qml.math.transpose(expected, (1, 2, 0, 3)), tensorflow_deriv)
+        assert pnp.allclose(qml.math.transpose(expected, (1, 2, 0, 3)), tensorflow_deriv)

--- a/tests/gradients/parameter_shift/test_parameter_shift_shot_vec.py
+++ b/tests/gradients/parameter_shift/test_parameter_shift_shot_vec.py
@@ -19,7 +19,7 @@ import pytest
 from default_qubit_legacy import DefaultQubitLegacy
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane.gradients import param_shift
 from pennylane.measurements import Shots
 from pennylane.operation import AnyWires, Observable
@@ -66,7 +66,7 @@ class RX_par_dep_recipe(qml.RX):
         """The gradient is given by [f(2x) - f(0)] / (2 sin(x)), by subsituting
         shift = x into the two term parameter-shift rule."""
         x = self.data[0]
-        c = 0.5 / np.sin(x)
+        c = 0.5 / pnp.sin(x)
         return ([[c, 0.0, 2 * x], [-c, 0.0, 0.0]],)
 
 
@@ -125,7 +125,7 @@ class TestParamShift:
 
         assert g_tapes == []
         for res in all_res:
-            assert isinstance(res, np.ndarray)
+            assert isinstance(res, pnp.ndarray)
             assert res.shape == (0,)
 
     def test_no_trainable_params_multiple_return_tape(self):
@@ -154,7 +154,7 @@ class TestParamShift:
             assert isinstance(res, tuple)
             assert len(res) == len(tape.measurements)
             for r in res:
-                assert isinstance(r, np.ndarray)
+                assert isinstance(r, pnp.ndarray)
                 assert r.shape == (0,)
 
     def test_all_zero_diff_methods_tape(self):
@@ -163,7 +163,7 @@ class TestParamShift:
         shot_vec = default_shot_vector
         dev = qml.device("default.qubit", wires=4, shots=shot_vec)
 
-        params = np.array([0.5, 0.5, 0.5], requires_grad=True)
+        params = pnp.array([0.5, 0.5, 0.5], requires_grad=True)
 
         with qml.queuing.AnnotatedQueue() as q:
             qml.Rot(*params, wires=0)
@@ -183,17 +183,17 @@ class TestParamShift:
 
             assert len(result) == len(tape.trainable_params)
 
-            assert isinstance(result[0], np.ndarray)
+            assert isinstance(result[0], pnp.ndarray)
             assert result[0].shape == (4,)
-            assert np.allclose(result[0], 0)
+            assert pnp.allclose(result[0], 0)
 
-            assert isinstance(result[1], np.ndarray)
+            assert isinstance(result[1], pnp.ndarray)
             assert result[1].shape == (4,)
-            assert np.allclose(result[1], 0)
+            assert pnp.allclose(result[1], 0)
 
-            assert isinstance(result[2], np.ndarray)
+            assert isinstance(result[2], pnp.ndarray)
             assert result[2].shape == (4,)
-            assert np.allclose(result[2], 0)
+            assert pnp.allclose(result[2], 0)
 
     def test_all_zero_diff_methods_multiple_returns_tape(self):
         """Test that the transform works correctly when the diff method for every parameter is
@@ -201,7 +201,7 @@ class TestParamShift:
         shot_vec = default_shot_vector
         dev = qml.device("default.qubit", wires=4, shots=shot_vec)
 
-        params = np.array([0.5, 0.5, 0.5], requires_grad=True)
+        params = pnp.array([0.5, 0.5, 0.5], requires_grad=True)
 
         with qml.queuing.AnnotatedQueue() as q:
             qml.Rot(*params, wires=0)
@@ -222,32 +222,32 @@ class TestParamShift:
         for result in all_result:
             assert len(result[0]) == 3
 
-            assert isinstance(result[0][0], np.ndarray)
+            assert isinstance(result[0][0], pnp.ndarray)
             assert result[0][0].shape == ()
-            assert np.allclose(result[0][0], 0)
+            assert pnp.allclose(result[0][0], 0)
 
-            assert isinstance(result[0][1], np.ndarray)
+            assert isinstance(result[0][1], pnp.ndarray)
             assert result[0][1].shape == ()
-            assert np.allclose(result[0][1], 0)
+            assert pnp.allclose(result[0][1], 0)
 
-            assert isinstance(result[0][2], np.ndarray)
+            assert isinstance(result[0][2], pnp.ndarray)
             assert result[0][2].shape == ()
-            assert np.allclose(result[0][2], 0)
+            assert pnp.allclose(result[0][2], 0)
 
             # Second elem
             assert len(result[0]) == 3
 
-            assert isinstance(result[1][0], np.ndarray)
+            assert isinstance(result[1][0], pnp.ndarray)
             assert result[1][0].shape == (4,)
-            assert np.allclose(result[1][0], 0)
+            assert pnp.allclose(result[1][0], 0)
 
-            assert isinstance(result[1][1], np.ndarray)
+            assert isinstance(result[1][1], pnp.ndarray)
             assert result[1][1].shape == (4,)
-            assert np.allclose(result[1][1], 0)
+            assert pnp.allclose(result[1][1], 0)
 
-            assert isinstance(result[1][2], np.ndarray)
+            assert isinstance(result[1][2], pnp.ndarray)
             assert result[1][2].shape == (4,)
-            assert np.allclose(result[1][2], 0)
+            assert pnp.allclose(result[1][2], 0)
 
     @pytest.mark.parametrize("broadcast", [True, False])
     def test_all_zero_diff_methods(self, broadcast):
@@ -260,11 +260,11 @@ class TestParamShift:
             qml.Rot(*params, wires=0)
             return qml.probs([2, 3])
 
-        params = np.array([0.5, 0.5, 0.5], requires_grad=True)
+        params = pnp.array([0.5, 0.5, 0.5], requires_grad=True)
         circuit.construct((params,), {})
 
         result = qml.gradients.param_shift(circuit)(params)
-        assert np.allclose(result, np.zeros((4, 3)), atol=0, rtol=0)
+        assert pnp.allclose(result, pnp.zeros((4, 3)), atol=0, rtol=0)
 
         tapes, _ = qml.gradients.param_shift(circuit.tape, broadcast=broadcast)
         assert tapes == []
@@ -306,7 +306,7 @@ class TestParamShift:
             # Two trainable params
             assert len(shot_comp_grad) == 2
             for g in shot_comp_grad:
-                assert isinstance(g, np.ndarray)
+                assert isinstance(g, pnp.ndarray)
                 assert g.shape == ()
 
         # Due to shot-based stochasticity the analytic values are not checked (multiplier are significant and the
@@ -340,7 +340,7 @@ class TestParamShift:
         its instantiated parameter values works correctly within the parameter
         shift rule. Also tests that grad_recipes supersedes paramter_frequencies.
         """
-        s = np.pi / 2
+        s = pnp.pi / 2
 
         class RX(qml.RX):
             """RX operation with an additional term in the grad recipe.
@@ -350,7 +350,7 @@ class TestParamShift:
 
             grad_recipe = ([[0.5, 1, s], [-0.5, 1, -s], [0.2, 1, 0]],)
 
-        x = np.array([-0.361, 0.654], requires_grad=True)
+        x = pnp.array([-0.361, 0.654], requires_grad=True)
         shot_vec = many_shots_shot_vector
         dev = qml.device("default.qubit", wires=2, shots=shot_vec)
 
@@ -371,8 +371,8 @@ class TestParamShift:
             assert tape.operations[1].data[0] == x[1] + expected[1]
 
         grad = fn(dev.execute(tapes))
-        _expected = np.stack(
-            [-np.sin(x[0] + x[1]), -np.sin(x[0] + x[1]) + 0.2 * np.cos(x[0] + x[1])]
+        _expected = pnp.stack(
+            [-pnp.sin(x[0] + x[1]), -pnp.sin(x[0] + x[1]) + 0.2 * pnp.cos(x[0] + x[1])]
         )
         assert isinstance(grad, tuple)
         assert len(grad) == len(default_shot_vector)
@@ -383,7 +383,7 @@ class TestParamShift:
                 a,
                 b,
             ) in zip(g, _expected):
-                assert np.allclose(a, b, atol=shot_vec_tol)
+                assert pnp.allclose(a, b, atol=shot_vec_tol)
 
     @pytest.mark.slow
     def test_independent_parameters_analytic(self):
@@ -416,21 +416,21 @@ class TestParamShift:
         tapes, fn = qml.gradients.param_shift(tape2)
         j2 = fn(dev.execute(tapes))
 
-        _expected = -np.sin(1)
+        _expected = -pnp.sin(1)
 
         assert isinstance(j1, tuple)
         assert len(j1) == len(many_shots_shot_vector)
         for j in j1:
             assert isinstance(j, tuple)
             assert len(j) == len(tape1.trainable_params)
-            assert np.allclose(j[0], _expected, atol=shot_vec_tol)
-            assert np.allclose(j[1], 0, atol=shot_vec_tol)
+            assert pnp.allclose(j[0], _expected, atol=shot_vec_tol)
+            assert pnp.allclose(j[1], 0, atol=shot_vec_tol)
 
         for j in j2:
             assert isinstance(j, tuple)
             assert len(j) == len(tape1.trainable_params)
-            assert np.allclose(j[0], 0, atol=shot_vec_tol)
-            assert np.allclose(j[1], _expected, atol=shot_vec_tol)
+            assert pnp.allclose(j[0], 0, atol=shot_vec_tol)
+            assert pnp.allclose(j[1], _expected, atol=shot_vec_tol)
 
     def test_grad_recipe_parameter_dependent(self):
         """Test that an operation with a gradient recipe that depends on
@@ -438,7 +438,7 @@ class TestParamShift:
         shift rule. Also tests that `grad_recipe` supersedes `parameter_frequencies`.
         """
 
-        x = np.array(0.654, requires_grad=True)
+        x = pnp.array(0.654, requires_grad=True)
         shot_vec = many_shots_shot_vector
         dev = qml.device("default.qubit", wires=2, shots=shot_vec)
 
@@ -455,7 +455,7 @@ class TestParamShift:
         assert qml.math.allclose(tapes[1].operations[0].data[0], 2 * x)
 
         grad = fn(dev.execute(tapes))
-        assert np.allclose(grad, -np.sin(x), atol=shot_vec_tol)
+        assert pnp.allclose(grad, -pnp.sin(x), atol=shot_vec_tol)
 
     def test_error_no_diff_info(self):
         """Test that an error is raised if no grad_recipe, no parameter_frequencies
@@ -478,7 +478,7 @@ class TestParamShift:
             grad_method = "A"
             num_wires = 1
 
-        x = np.array(0.654, requires_grad=True)
+        x = pnp.array(0.654, requires_grad=True)
         shot_vec = many_shots_shot_vector
 
         for op in [RX, NewOp]:
@@ -507,7 +507,7 @@ class TestParameterShiftRule:
     shot vector defined"""
 
     @pytest.mark.parametrize("theta", angles)
-    @pytest.mark.parametrize("shift", [np.pi / 2, 0.3])
+    @pytest.mark.parametrize("shift", [pnp.pi / 2, 0.3])
     @pytest.mark.parametrize("G", [qml.RX, qml.RY, qml.RZ, qml.PhaseShift])
     def test_pauli_rotation_gradient(self, mocker, G, theta, shift, broadcast, seed):
         """Tests that the automatic gradients of Pauli rotations are correct."""
@@ -518,7 +518,7 @@ class TestParameterShiftRule:
         dev = qml.device("default.qubit", wires=1, shots=shot_vec, seed=seed)
 
         with qml.queuing.AnnotatedQueue() as q:
-            qml.StatePrep(np.array([1.0, -1.0], requires_grad=False) / np.sqrt(2), wires=0)
+            qml.StatePrep(pnp.array([1.0, -1.0], requires_grad=False) / pnp.sqrt(2), wires=0)
             G(theta, wires=[0])
             qml.expval(qml.PauliZ(0))
 
@@ -530,8 +530,8 @@ class TestParameterShiftRule:
 
         autograd_val = fn(dev.execute(tapes))
 
-        tape_fwd = tape.bind_new_parameters([theta + np.pi / 2], [1])
-        tape_bwd = tape.bind_new_parameters([theta - np.pi / 2], [1])
+        tape_fwd = tape.bind_new_parameters([theta + pnp.pi / 2], [1])
+        tape_bwd = tape.bind_new_parameters([theta - pnp.pi / 2], [1])
 
         shot_vec_manual_res = dev.execute([tape_fwd, tape_bwd])
 
@@ -541,10 +541,10 @@ class TestParameterShiftRule:
             tuple(comp[l] for comp in shot_vec_manual_res) for l in range(shot_vec_len)
         ]
         for r1, r2 in zip(autograd_val, shot_vec_manual_res):
-            manualgrad_val = np.subtract(*r2) / 2
-            assert np.allclose(r1, manualgrad_val, atol=shot_vec_tol, rtol=0)
+            manualgrad_val = pnp.subtract(*r2) / 2
+            assert pnp.allclose(r1, manualgrad_val, atol=shot_vec_tol, rtol=0)
 
-            assert isinstance(r1, np.ndarray)
+            assert isinstance(r1, pnp.ndarray)
             assert r1.shape == ()
 
         assert spy.call_args[1]["shifts"] == (shift,)
@@ -552,20 +552,20 @@ class TestParameterShiftRule:
         tapes, fn = qml.gradients.finite_diff(tape, h=h_val)
         numeric_val = fn(dev.execute(tapes))
         for a_val, n_val in zip(autograd_val, numeric_val):
-            assert np.allclose(a_val, n_val, atol=finite_diff_tol, rtol=0)
+            assert pnp.allclose(a_val, n_val, atol=finite_diff_tol, rtol=0)
 
     @pytest.mark.parametrize("theta", angles)
-    @pytest.mark.parametrize("shift", [np.pi / 2, 0.3])
+    @pytest.mark.parametrize("shift", [pnp.pi / 2, 0.3])
     def test_Rot_gradient(self, mocker, theta, shift, broadcast):
         """Tests that the automatic gradient of an arbitrary Euler-angle-parametrized gate is correct."""
         spy = mocker.spy(qml.gradients.parameter_shift, "_get_operation_recipe")
 
         shot_vec = tuple([1000000] * 2)
         dev = qml.device("default.qubit", wires=1, shots=shot_vec)
-        params = np.array([theta, theta**3, np.sqrt(2) * theta])
+        params = pnp.array([theta, theta**3, pnp.sqrt(2) * theta])
 
         with qml.queuing.AnnotatedQueue() as q:
-            qml.StatePrep(np.array([1.0, -1.0], requires_grad=False) / np.sqrt(2), wires=0)
+            qml.StatePrep(pnp.array([1.0, -1.0], requires_grad=False) / pnp.sqrt(2), wires=0)
             qml.Rot(*params, wires=[0])
             qml.expval(qml.PauliZ(0))
 
@@ -582,9 +582,9 @@ class TestParameterShiftRule:
         assert len(autograd_val) == len(shot_vec)
 
         manualgrad_val = []
-        for idx in list(np.ndindex(*params.shape)):
-            s = np.zeros_like(params)
-            s[idx] += np.pi / 2
+        for idx in list(pnp.ndindex(*params.shape)):
+            s = pnp.zeros_like(params)
+            s[idx] += pnp.pi / 2
 
             tape = tape.bind_new_parameters(params + s, [1, 2, 3])
             forward = dev.execute(tape)
@@ -606,13 +606,13 @@ class TestParameterShiftRule:
         for a_val, m_val in zip(autograd_val, manualgrad_val):
             assert isinstance(a_val, tuple)
             assert len(a_val) == num_params
-            assert np.allclose(a_val, m_val, atol=shot_vec_tol, rtol=0)
+            assert pnp.allclose(a_val, m_val, atol=shot_vec_tol, rtol=0)
             assert spy.call_args[1]["shifts"] == (shift,)
 
         tapes, fn = qml.gradients.finite_diff(tape, h=h_val)
         numeric_val = fn(dev.execute(tapes))
         for a_val, n_val in zip(autograd_val, numeric_val):
-            assert np.allclose(a_val, n_val, atol=finite_diff_tol, rtol=0)
+            assert pnp.allclose(a_val, n_val, atol=finite_diff_tol, rtol=0)
 
     @pytest.mark.parametrize("G", [qml.CRX, qml.CRY, qml.CRZ])
     def test_controlled_rotation_gradient(self, G, broadcast):
@@ -622,7 +622,7 @@ class TestParameterShiftRule:
         b = 0.123
 
         with qml.queuing.AnnotatedQueue() as q:
-            qml.StatePrep(np.array([1.0, -1.0], requires_grad=False) / np.sqrt(2), wires=0)
+            qml.StatePrep(pnp.array([1.0, -1.0], requires_grad=False) / pnp.sqrt(2), wires=0)
             G(b, wires=[0, 1])
             qml.expval(qml.PauliX(0))
 
@@ -630,20 +630,20 @@ class TestParameterShiftRule:
         tape.trainable_params = {1}
 
         res = dev.execute(tape)
-        assert np.allclose(res, -np.cos(b / 2), atol=shot_vec_tol, rtol=0)
+        assert pnp.allclose(res, -pnp.cos(b / 2), atol=shot_vec_tol, rtol=0)
 
         tapes, fn = qml.gradients.param_shift(tape, broadcast=broadcast)
         assert len(tapes) == (1 if broadcast else 4)
         grad = fn(dev.execute(tapes))
-        expected = np.sin(b / 2) / 2
+        expected = pnp.sin(b / 2) / 2
         assert isinstance(grad, tuple)
         assert len(grad) == len(shot_vec)
-        assert np.allclose(grad, expected, atol=shot_vec_tol, rtol=0)
+        assert pnp.allclose(grad, expected, atol=shot_vec_tol, rtol=0)
 
         tapes, fn = qml.gradients.finite_diff(tape, h=h_val)
         numeric_val = fn(dev.execute(tapes))
         for a_val, n_val in zip(grad, numeric_val):
-            assert np.allclose(a_val, n_val, atol=finite_diff_tol, rtol=0)
+            assert pnp.allclose(a_val, n_val, atol=finite_diff_tol, rtol=0)
 
     @pytest.mark.parametrize("theta", angles)
     def test_CRot_gradient(self, theta, broadcast):
@@ -651,10 +651,10 @@ class TestParameterShiftRule:
         gate is correct."""
         shot_vec = tuple([1000000] * 2)
         dev = qml.device("default.qubit", wires=2, shots=shot_vec)
-        a, b, c = np.array([theta, theta**3, np.sqrt(2) * theta])
+        a, b, c = pnp.array([theta, theta**3, pnp.sqrt(2) * theta])
 
         with qml.queuing.AnnotatedQueue() as q:
-            qml.StatePrep(np.array([1.0, -1.0], requires_grad=False) / np.sqrt(2), wires=0)
+            qml.StatePrep(pnp.array([1.0, -1.0], requires_grad=False) / pnp.sqrt(2), wires=0)
             qml.CRot(a, b, c, wires=[0, 1])
             qml.expval(qml.PauliX(0))
 
@@ -662,19 +662,19 @@ class TestParameterShiftRule:
         tape.trainable_params = {1, 2, 3}
 
         res = dev.execute(tape)
-        expected = -np.cos(b / 2) * np.cos(0.5 * (a + c))
-        assert np.allclose(res, expected, atol=shot_vec_tol, rtol=0)
+        expected = -pnp.cos(b / 2) * pnp.cos(0.5 * (a + c))
+        assert pnp.allclose(res, expected, atol=shot_vec_tol, rtol=0)
 
         tapes, fn = qml.gradients.param_shift(tape, broadcast=broadcast)
         tapes_per_param = 1 if broadcast else 4
         assert len(tapes) == tapes_per_param * len(tape.trainable_params)
 
         grad = fn(dev.execute(tapes))
-        expected = np.array(
+        expected = pnp.array(
             [
-                0.5 * np.cos(b / 2) * np.sin(0.5 * (a + c)),
-                0.5 * np.sin(b / 2) * np.cos(0.5 * (a + c)),
-                0.5 * np.cos(b / 2) * np.sin(0.5 * (a + c)),
+                0.5 * pnp.cos(b / 2) * pnp.sin(0.5 * (a + c)),
+                0.5 * pnp.sin(b / 2) * pnp.cos(0.5 * (a + c)),
+                0.5 * pnp.cos(b / 2) * pnp.sin(0.5 * (a + c)),
             ]
         )
         assert isinstance(grad, tuple)
@@ -684,17 +684,17 @@ class TestParameterShiftRule:
             assert isinstance(shot_vec_res, tuple)
             assert len(shot_vec_res) == len(tape.trainable_params)
             for idx, g in enumerate(shot_vec_res):
-                assert np.allclose(g, expected[idx], atol=shot_vec_tol, rtol=0)
+                assert pnp.allclose(g, expected[idx], atol=shot_vec_tol, rtol=0)
 
         tapes, fn = qml.gradients.finite_diff(tape, h=h_val)
         numeric_val = fn(dev.execute(tapes))
         for a_val, n_val in zip(grad, numeric_val):
-            assert np.allclose(a_val, n_val, atol=finite_diff_tol, rtol=0)
+            assert pnp.allclose(a_val, n_val, atol=finite_diff_tol, rtol=0)
 
     def test_gradients_agree_finite_differences(self, broadcast):
         """Tests that the parameter-shift rule agrees with the first and second
         order finite differences"""
-        params = np.array([0.1, -1.6, np.pi / 5])
+        params = pnp.array([0.1, -1.6, pnp.pi / 5])
 
         with qml.queuing.AnnotatedQueue() as q:
             qml.RX(params[0], wires=[0])
@@ -724,14 +724,14 @@ class TestParameterShiftRule:
 
         # gradients computed with different methods must agree
         for a_val, n_val in zip(grad_A, grad_F1):
-            assert np.allclose(a_val, n_val, atol=finite_diff_tol, rtol=0)
+            assert pnp.allclose(a_val, n_val, atol=finite_diff_tol, rtol=0)
         for a_val, n_val in zip(grad_A, grad_F2):
-            assert np.allclose(a_val, n_val, atol=finite_diff_tol, rtol=0)
+            assert pnp.allclose(a_val, n_val, atol=finite_diff_tol, rtol=0)
 
     def test_variance_gradients_agree_finite_differences(self, broadcast):
         """Tests that the variance parameter-shift rule agrees with the first and second
         order finite differences"""
-        params = np.array([0.1, -1.6, np.pi / 5])
+        params = pnp.array([0.1, -1.6, pnp.pi / 5])
 
         with qml.queuing.AnnotatedQueue() as q:
             qml.RX(params[0], wires=[0])
@@ -763,8 +763,8 @@ class TestParameterShiftRule:
         # gradients computed with different methods must agree
         for idx1, _grad_A in enumerate(grad_A):
             for idx2, g in enumerate(_grad_A):
-                assert np.allclose(g, grad_F1[idx1][idx2], atol=finite_diff_tol, rtol=0)
-                assert np.allclose(g, grad_F2[idx1][idx2], atol=finite_diff_tol, rtol=0)
+                assert pnp.allclose(g, grad_F1[idx1][idx2], atol=finite_diff_tol, rtol=0)
+                assert pnp.allclose(g, grad_F2[idx1][idx2], atol=finite_diff_tol, rtol=0)
 
     @pytest.mark.autograd
     def test_fallback(self, mocker, broadcast):
@@ -774,7 +774,7 @@ class TestParameterShiftRule:
         x = 0.543
         y = -0.654
 
-        params = np.array([x, y], requires_grad=True)
+        params = pnp.array([x, y], requires_grad=True)
 
         def cost_fn(params):
             with qml.queuing.AnnotatedQueue() as q:
@@ -799,7 +799,7 @@ class TestParameterShiftRule:
 
         all_res = cost_fn(params)
 
-        expected = np.array([[-np.sin(x), 0], [0, -2 * np.cos(y) * np.sin(y)], [0, 0]])
+        expected = pnp.array([[-pnp.sin(x), 0], [0, -2 * pnp.cos(y) * pnp.sin(y)], [0, 0]])
         for res in all_res:
             assert isinstance(res, tuple)
             assert len(res) == 3
@@ -808,12 +808,12 @@ class TestParameterShiftRule:
                 assert isinstance(r, tuple)
                 assert len(r) == 2
 
-                assert isinstance(r[0], np.ndarray)
+                assert isinstance(r[0], pnp.ndarray)
                 assert r[0].shape == ()
-                assert isinstance(r[1], np.ndarray)
+                assert isinstance(r[1], pnp.ndarray)
                 assert r[1].shape == ()
 
-            assert np.allclose(res, expected, atol=finite_diff_tol, rtol=0)
+            assert pnp.allclose(res, expected, atol=finite_diff_tol, rtol=0)
 
             # TODO: support Hessian with the new return types
             # check the second derivative
@@ -832,7 +832,7 @@ class TestParameterShiftRule:
         x = 0.543
         y = -0.654
 
-        params = np.array([x, y], requires_grad=True)
+        params = pnp.array([x, y], requires_grad=True)
 
         def cost_fn(params):
             with qml.queuing.AnnotatedQueue() as q:
@@ -853,17 +853,17 @@ class TestParameterShiftRule:
 
         all_res = cost_fn(params)
 
-        expval_expected = [-np.sin(x + y), -np.sin(x + y)]
+        expval_expected = [-pnp.sin(x + y), -pnp.sin(x + y)]
         for res in all_res:
             assert isinstance(res, tuple)
             assert len(res) == 2
 
             for r in res:
-                assert isinstance(r, np.ndarray)
+                assert isinstance(r, pnp.ndarray)
                 assert r.shape == ()
 
-            assert np.allclose(res[0], expval_expected[0], atol=finite_diff_tol)
-            assert np.allclose(res[1], expval_expected[1], atol=finite_diff_tol)
+            assert pnp.allclose(res[0], expval_expected[0], atol=finite_diff_tol)
+            assert pnp.allclose(res[1], expval_expected[1], atol=finite_diff_tol)
 
     @pytest.mark.parametrize("RX, RY, argnum", [(RX_with_F, qml.RY, 0), (qml.RX, RY_with_F, 1)])
     def test_fallback_probs(
@@ -875,7 +875,7 @@ class TestParameterShiftRule:
         x = 0.543
         y = -0.654
 
-        params = np.array([x, y], requires_grad=True)
+        params = pnp.array([x, y], requires_grad=True)
 
         def cost_fn(params):
             with qml.queuing.AnnotatedQueue() as q:
@@ -911,35 +911,35 @@ class TestParameterShiftRule:
             assert len(expval_res) == 2
 
             for param_r in expval_res:
-                assert isinstance(param_r, np.ndarray)
+                assert isinstance(param_r, pnp.ndarray)
                 assert param_r.shape == ()
 
             probs_res = res[1]
             assert isinstance(probs_res, tuple)
             assert len(probs_res) == 2
             for param_r in probs_res:
-                assert isinstance(param_r, np.ndarray)
+                assert isinstance(param_r, pnp.ndarray)
                 assert param_r.shape == (4,)
 
-            expval_expected = [-2 * np.sin(x) / 2, 0]
+            expval_expected = [-2 * pnp.sin(x) / 2, 0]
             probs_expected = (
-                np.array(
+                pnp.array(
                     [
                         [
-                            -(np.cos(y / 2) ** 2 * np.sin(x)),
-                            -(np.cos(x / 2) ** 2 * np.sin(y)),
+                            -(pnp.cos(y / 2) ** 2 * pnp.sin(x)),
+                            -(pnp.cos(x / 2) ** 2 * pnp.sin(y)),
                         ],
                         [
-                            -(np.sin(x) * np.sin(y / 2) ** 2),
-                            (np.cos(x / 2) ** 2 * np.sin(y)),
+                            -(pnp.sin(x) * pnp.sin(y / 2) ** 2),
+                            (pnp.cos(x / 2) ** 2 * pnp.sin(y)),
                         ],
                         [
-                            (np.sin(x) * np.sin(y / 2) ** 2),
-                            (np.sin(x / 2) ** 2 * np.sin(y)),
+                            (pnp.sin(x) * pnp.sin(y / 2) ** 2),
+                            (pnp.sin(x / 2) ** 2 * pnp.sin(y)),
                         ],
                         [
-                            (np.cos(y / 2) ** 2 * np.sin(x)),
-                            -(np.sin(x / 2) ** 2 * np.sin(y)),
+                            (pnp.cos(y / 2) ** 2 * pnp.sin(x)),
+                            -(pnp.sin(x / 2) ** 2 * pnp.sin(y)),
                         ],
                     ]
                 )
@@ -947,12 +947,12 @@ class TestParameterShiftRule:
             )
 
             # Expvals
-            assert np.allclose(res[0][0], expval_expected[0], atol=finite_diff_tol)
-            assert np.allclose(res[0][1], expval_expected[1], atol=finite_diff_tol)
+            assert pnp.allclose(res[0][0], expval_expected[0], atol=finite_diff_tol)
+            assert pnp.allclose(res[0][1], expval_expected[1], atol=finite_diff_tol)
 
             # Probs
-            assert np.allclose(res[1][0], probs_expected[:, 0], atol=finite_diff_tol)
-            assert np.allclose(res[1][1], probs_expected[:, 1], atol=finite_diff_tol)
+            assert pnp.allclose(res[1][0], probs_expected[:, 0], atol=finite_diff_tol)
+            assert pnp.allclose(res[1][1], probs_expected[:, 1], atol=finite_diff_tol)
 
     @pytest.mark.autograd
     def test_all_fallback(self, mocker, broadcast):
@@ -986,15 +986,15 @@ class TestParameterShiftRule:
         assert len(all_res) == len(fallback_shot_vec)
         assert isinstance(all_res, tuple)
 
-        expected = np.array([-np.sin(y) * np.sin(x), np.cos(y) * np.cos(x)])
+        expected = pnp.array([-pnp.sin(y) * pnp.sin(x), pnp.cos(y) * pnp.cos(x)])
         for res in all_res:
             assert isinstance(res, tuple)
             assert len(res) == 2
             assert res[0].shape == ()
             assert res[1].shape == ()
 
-            assert np.allclose(res[0], expected[0], atol=fallback_shot_vec, rtol=0)
-            assert np.allclose(res[1], expected[1], atol=fallback_shot_vec, rtol=0)
+            assert pnp.allclose(res[0], expected[0], atol=fallback_shot_vec, rtol=0)
+            assert pnp.allclose(res[1], expected[1], atol=fallback_shot_vec, rtol=0)
 
     def test_single_expectation_value(self, broadcast):
         """Tests correct output shape and evaluation for a tape
@@ -1020,14 +1020,14 @@ class TestParameterShiftRule:
         assert len(all_res) == len(many_shots_shot_vector)
         assert isinstance(all_res, tuple)
 
-        expected = np.array([-np.sin(y) * np.sin(x), np.cos(y) * np.cos(x)])
+        expected = pnp.array([-pnp.sin(y) * pnp.sin(x), pnp.cos(y) * pnp.cos(x)])
         for res in all_res:
             assert len(res) == 2
             assert not isinstance(res[0], tuple)
             assert not isinstance(res[1], tuple)
 
-            assert np.allclose(res[0], expected[0], atol=shot_vec_tol, rtol=0)
-            assert np.allclose(res[1], expected[1], atol=shot_vec_tol, rtol=0)
+            assert pnp.allclose(res[0], expected[0], atol=shot_vec_tol, rtol=0)
+            assert pnp.allclose(res[1], expected[1], atol=shot_vec_tol, rtol=0)
 
     def test_multiple_expectation_values(self, broadcast):
         """Tests correct output shape and evaluation for a tape
@@ -1053,15 +1053,15 @@ class TestParameterShiftRule:
         assert len(all_res) == len(many_shots_shot_vector)
         assert isinstance(all_res, tuple)
 
-        expected = np.array([[-np.sin(x), 0], [0, np.cos(y)]])
+        expected = pnp.array([[-pnp.sin(x), 0], [0, pnp.cos(y)]])
         for res in all_res:
             assert len(res) == 2
             assert isinstance(res, tuple)
             assert len(res[0]) == 2
             assert len(res[1]) == 2
 
-            assert np.allclose(res[0], expected[0], atol=shot_vec_tol, rtol=0)
-            assert np.allclose(res[1], expected[1], atol=shot_vec_tol, rtol=0)
+            assert pnp.allclose(res[0], expected[0], atol=shot_vec_tol, rtol=0)
+            assert pnp.allclose(res[1], expected[1], atol=shot_vec_tol, rtol=0)
 
     def test_var_expectation_values(self, broadcast):
         """Tests correct output shape and evaluation for a tape
@@ -1086,7 +1086,7 @@ class TestParameterShiftRule:
         assert len(all_res) == len(many_shots_shot_vector)
         assert isinstance(all_res, tuple)
 
-        expected = np.array([[-np.sin(x), 0], [0, -2 * np.cos(y) * np.sin(y)]])
+        expected = pnp.array([[-pnp.sin(x), 0], [0, -2 * pnp.cos(y) * pnp.sin(y)]])
         for res in all_res:
             assert isinstance(res, tuple)
             assert len(res) == 2
@@ -1094,7 +1094,7 @@ class TestParameterShiftRule:
             assert len(res[1]) == 2
 
             for a, e in zip(res, expected):
-                assert np.allclose(np.squeeze(np.stack(a)), e, atol=shot_vec_tol, rtol=0)
+                assert pnp.allclose(pnp.squeeze(pnp.stack(a)), e, atol=shot_vec_tol, rtol=0)
 
     def test_prob_expectation_values(self, broadcast):
         """Tests correct output shape and evaluation for a tape
@@ -1128,25 +1128,25 @@ class TestParameterShiftRule:
                 assert isinstance(r, tuple)
                 assert len(r) == len(tape.measurements)
 
-        expval_expected = [-2 * np.sin(x) / 2, 0]
+        expval_expected = [-2 * pnp.sin(x) / 2, 0]
         probs_expected = (
-            np.array(
+            pnp.array(
                 [
                     [
-                        -(np.cos(y / 2) ** 2 * np.sin(x)),
-                        -(np.cos(x / 2) ** 2 * np.sin(y)),
+                        -(pnp.cos(y / 2) ** 2 * pnp.sin(x)),
+                        -(pnp.cos(x / 2) ** 2 * pnp.sin(y)),
                     ],
                     [
-                        -(np.sin(x) * np.sin(y / 2) ** 2),
-                        (np.cos(x / 2) ** 2 * np.sin(y)),
+                        -(pnp.sin(x) * pnp.sin(y / 2) ** 2),
+                        (pnp.cos(x / 2) ** 2 * pnp.sin(y)),
                     ],
                     [
-                        (np.sin(x) * np.sin(y / 2) ** 2),
-                        (np.sin(x / 2) ** 2 * np.sin(y)),
+                        (pnp.sin(x) * pnp.sin(y / 2) ** 2),
+                        (pnp.sin(x / 2) ** 2 * pnp.sin(y)),
                     ],
                     [
-                        (np.cos(y / 2) ** 2 * np.sin(x)),
-                        -(np.sin(x / 2) ** 2 * np.sin(y)),
+                        (pnp.cos(y / 2) ** 2 * pnp.sin(x)),
+                        -(pnp.sin(x / 2) ** 2 * pnp.sin(y)),
                     ],
                 ]
             )
@@ -1160,14 +1160,14 @@ class TestParameterShiftRule:
 
             r_to_check = r[0][0]
             _expected = expval_expected[0]
-            assert np.allclose(r_to_check, _expected, atol=shot_vec_tol)
-            assert isinstance(r_to_check, np.ndarray)
+            assert pnp.allclose(r_to_check, _expected, atol=shot_vec_tol)
+            assert isinstance(r_to_check, pnp.ndarray)
             assert r_to_check.shape == ()
 
             r_to_check = r[0][1]
             _expected = expval_expected[1]
-            assert np.allclose(r_to_check, _expected, atol=shot_vec_tol)
-            assert isinstance(r_to_check, np.ndarray)
+            assert pnp.allclose(r_to_check, _expected, atol=shot_vec_tol)
+            assert isinstance(r_to_check, pnp.ndarray)
             assert r_to_check.shape == ()
 
             # Probs
@@ -1176,14 +1176,14 @@ class TestParameterShiftRule:
 
             r_to_check = r[1][0]
             _expected = probs_expected[:, 0]
-            assert np.allclose(r_to_check, _expected, atol=shot_vec_tol)
-            assert isinstance(r_to_check, np.ndarray)
+            assert pnp.allclose(r_to_check, _expected, atol=shot_vec_tol)
+            assert isinstance(r_to_check, pnp.ndarray)
             assert r_to_check.shape == (4,)
 
             r_to_check = r[1][1]
             _expected = probs_expected[:, 1]
-            assert np.allclose(r_to_check, _expected, atol=shot_vec_tol)
-            assert isinstance(r_to_check, np.ndarray)
+            assert pnp.allclose(r_to_check, _expected, atol=shot_vec_tol)
+            assert isinstance(r_to_check, pnp.ndarray)
             assert r_to_check.shape == (4,)
 
     def test_involutory_variance_single_param(self, broadcast):
@@ -1198,15 +1198,15 @@ class TestParameterShiftRule:
 
         tape = qml.tape.QuantumScript.from_queue(q, shots=shot_vec)
         res = dev.execute(tape)
-        expected = 1 - np.cos(a) ** 2
+        expected = 1 - pnp.cos(a) ** 2
         for r in res:
-            assert np.allclose(r, expected, atol=shot_vec_tol, rtol=0)
+            assert pnp.allclose(r, expected, atol=shot_vec_tol, rtol=0)
 
         # circuit jacobians
         tapes, fn = qml.gradients.param_shift(tape, broadcast=broadcast)
         gradA = fn(dev.execute(tapes))
         for _gA in gradA:
-            assert isinstance(_gA, np.ndarray)
+            assert isinstance(_gA, pnp.ndarray)
             assert _gA.shape == ()
 
         tapes_per_param = 1 if broadcast else 2
@@ -1216,7 +1216,7 @@ class TestParameterShiftRule:
         all_gradF = fn(dev.execute(tapes))
         assert len(tapes) == 2
 
-        expected = 2 * np.sin(a) * np.cos(a)
+        expected = 2 * pnp.sin(a) * pnp.cos(a)
 
         for gradF in all_gradF:
             assert gradF == pytest.approx(expected, abs=finite_diff_tol)
@@ -1240,8 +1240,8 @@ class TestParameterShiftRule:
         tape.trainable_params = {0, 1}
 
         res = dev.execute(tape)
-        expected = 1 - np.cos(a + b) ** 2
-        assert np.allclose(res, expected, atol=shot_vec_tol, rtol=0)
+        expected = 1 - pnp.cos(a + b) ** 2
+        assert pnp.allclose(res, expected, atol=shot_vec_tol, rtol=0)
 
         # circuit jacobians
         tapes, fn = qml.gradients.param_shift(tape, broadcast=broadcast)
@@ -1253,10 +1253,10 @@ class TestParameterShiftRule:
         assert isinstance(all_res, tuple)
 
         for gradA in all_res:
-            assert isinstance(gradA[0], np.ndarray)
+            assert isinstance(gradA[0], pnp.ndarray)
             assert gradA[0].shape == ()
 
-            assert isinstance(gradA[1], np.ndarray)
+            assert isinstance(gradA[1], pnp.ndarray)
             assert gradA[1].shape == ()
 
         tapes, fn = qml.gradients.finite_diff(tape, h=h_val)
@@ -1265,7 +1265,7 @@ class TestParameterShiftRule:
         all_Fres = fn(dev.execute(tapes))
         for gradF, gradA in zip(all_Fres, all_res):
 
-            expected = 2 * np.sin(a + b) * np.cos(a + b)
+            expected = 2 * pnp.sin(a + b) * pnp.cos(a + b)
             assert gradF[0] == pytest.approx(expected, abs=finite_diff_tol)
             assert gradA[0] == pytest.approx(expected, abs=finite_diff_tol)
 
@@ -1287,9 +1287,9 @@ class TestParameterShiftRule:
         tape.trainable_params = {0}
 
         res = dev.execute(tape)
-        expected = (39 / 2) - 6 * np.sin(2 * a) + (35 / 2) * np.cos(2 * a)
+        expected = (39 / 2) - 6 * pnp.sin(2 * a) + (35 / 2) * pnp.cos(2 * a)
         for r in res:
-            assert np.allclose(r, expected, atol=_herm_shot_vec_tol, rtol=0)
+            assert pnp.allclose(r, expected, atol=_herm_shot_vec_tol, rtol=0)
 
         # circuit jacobians
         tapes, fn = qml.gradients.param_shift(tape, broadcast=broadcast)
@@ -1302,13 +1302,13 @@ class TestParameterShiftRule:
         all_gradF = fn(dev.execute(tapes))
         assert len(tapes) == 2
 
-        expected = -35 * np.sin(2 * a) - 12 * np.cos(2 * a)
+        expected = -35 * pnp.sin(2 * a) - 12 * pnp.cos(2 * a)
         for _gA in gradA:
             assert _gA == pytest.approx(expected, abs=_herm_shot_vec_tol)
-            assert isinstance(_gA, np.ndarray)
+            assert isinstance(_gA, pnp.ndarray)
             assert _gA.shape == ()
         for gradF in all_gradF:
-            assert isinstance(gradF, np.ndarray)
+            assert isinstance(gradF, pnp.ndarray)
             assert gradF.shape == ()
             assert qml.math.allclose(gradF, expected, atol=2 * _herm_shot_vec_tol)
 
@@ -1328,11 +1328,11 @@ class TestParameterShiftRule:
         tape.trainable_params = {0, 1}
 
         all_res = dev.execute(tape)
-        expected = (39 / 2) - 6 * np.sin(2 * (a + b)) + (35 / 2) * np.cos(2 * (a + b))
+        expected = (39 / 2) - 6 * pnp.sin(2 * (a + b)) + (35 / 2) * pnp.cos(2 * (a + b))
         assert len(all_res) == len(many_shots_shot_vector)
         assert isinstance(all_res, tuple)
         for res in all_res:
-            assert np.allclose(res, expected, atol=herm_shot_vec_tol, rtol=0)
+            assert pnp.allclose(res, expected, atol=herm_shot_vec_tol, rtol=0)
 
         # circuit jacobians
         tapes, fn = qml.gradients.param_shift(tape, broadcast=broadcast)
@@ -1344,14 +1344,14 @@ class TestParameterShiftRule:
         assert len(all_res) == len(many_shots_shot_vector)
         assert isinstance(all_res, tuple)
 
-        expected = -35 * np.sin(2 * (a + b)) - 12 * np.cos(2 * (a + b))
+        expected = -35 * pnp.sin(2 * (a + b)) - 12 * pnp.cos(2 * (a + b))
         for gradA in all_res:
             assert isinstance(gradA, tuple)
 
-            assert isinstance(gradA[0], np.ndarray)
+            assert isinstance(gradA[0], pnp.ndarray)
             assert gradA[0].shape == ()
 
-            assert isinstance(gradA[1], np.ndarray)
+            assert isinstance(gradA[1], pnp.ndarray)
             assert gradA[1].shape == ()
             assert gradA[0] == pytest.approx(expected, abs=herm_shot_vec_tol)
             assert gradA[1] == pytest.approx(expected, abs=herm_shot_vec_tol)
@@ -1388,9 +1388,9 @@ class TestParameterShiftRule:
         tape.trainable_params = {0}
 
         res = dev.execute(tape)
-        expected = [1 - np.cos(a) ** 2, (39 / 2) - 6 * np.sin(2 * a) + (35 / 2) * np.cos(2 * a)]
+        expected = [1 - pnp.cos(a) ** 2, (39 / 2) - 6 * pnp.sin(2 * a) + (35 / 2) * pnp.cos(2 * a)]
         for r in res:
-            assert np.allclose(r, expected, atol=_herm_shot_vec_tol, rtol=0)
+            assert pnp.allclose(r, expected, atol=_herm_shot_vec_tol, rtol=0)
 
         # circuit jacobians
         tapes, fn = qml.gradients.param_shift(tape, broadcast=broadcast)
@@ -1403,12 +1403,12 @@ class TestParameterShiftRule:
         gradF = fn(dev.execute(tapes))
         assert len(tapes) == 1 + 1
 
-        expected = [2 * np.sin(a) * np.cos(a), 0]
+        expected = [2 * pnp.sin(a) * pnp.cos(a), 0]
 
         # Param-shift
         for shot_vec_result in gradA:
             for param_res in shot_vec_result:
-                assert isinstance(param_res, np.ndarray)
+                assert isinstance(param_res, pnp.ndarray)
                 assert param_res.shape == ()
 
             assert shot_vec_result[0] == pytest.approx(expected[0], abs=finite_diff_tol)
@@ -1416,7 +1416,7 @@ class TestParameterShiftRule:
 
         for shot_vec_result in gradF:
             for param_res in shot_vec_result:
-                assert isinstance(param_res, np.ndarray)
+                assert isinstance(param_res, pnp.ndarray)
                 assert param_res.shape == ()
 
             assert shot_vec_result[0] == pytest.approx(expected[0], abs=finite_diff_tol)
@@ -1440,9 +1440,9 @@ class TestParameterShiftRule:
         _herm_shot_vec_tol = shot_vec_tol * 100
 
         res = dev.execute(tape)
-        expected = [1 - np.cos(a) ** 2, (39 / 2) - 6 * np.sin(2 * a) + (35 / 2) * np.cos(2 * a)]
+        expected = [1 - pnp.cos(a) ** 2, (39 / 2) - 6 * pnp.sin(2 * a) + (35 / 2) * pnp.cos(2 * a)]
         for res_shot_item in res:
-            assert np.allclose(res_shot_item, expected, atol=_herm_shot_vec_tol, rtol=0)
+            assert pnp.allclose(res_shot_item, expected, atol=_herm_shot_vec_tol, rtol=0)
 
         # circuit jacobians
         tapes, fn = qml.gradients.param_shift(tape, broadcast=broadcast)
@@ -1460,43 +1460,43 @@ class TestParameterShiftRule:
                 assert isinstance(meas_res, tuple)
                 assert len(meas_res) == len(tape.trainable_params)
                 for param_res in meas_res:
-                    assert isinstance(param_res, np.ndarray)
+                    assert isinstance(param_res, pnp.ndarray)
                     assert param_res.shape == ()
 
         tapes, fn = qml.gradients.finite_diff(tape, h=h_val)
         gradF = fn(dev.execute(tapes))
         assert len(tapes) == 1 + 2
 
-        expected = [2 * np.sin(a) * np.cos(a), 0, 0, -35 * np.sin(2 * a) - 12 * np.cos(2 * a)]
+        expected = [2 * pnp.sin(a) * pnp.cos(a), 0, 0, -35 * pnp.sin(2 * a) - 12 * pnp.cos(2 * a)]
 
         # Param-shift
         for shot_vec_result in gradA:
-            assert isinstance(shot_vec_result[0][0], np.ndarray)
+            assert isinstance(shot_vec_result[0][0], pnp.ndarray)
             assert shot_vec_result[0][0].shape == ()
             assert shot_vec_result[0][0] == pytest.approx(expected[0], abs=_herm_shot_vec_tol)
 
-            assert isinstance(shot_vec_result[0][1], np.ndarray)
+            assert isinstance(shot_vec_result[0][1], pnp.ndarray)
             assert shot_vec_result[0][1].shape == ()
             assert shot_vec_result[0][1] == pytest.approx(expected[1], abs=_herm_shot_vec_tol)
 
-            assert isinstance(shot_vec_result[1][0], np.ndarray)
+            assert isinstance(shot_vec_result[1][0], pnp.ndarray)
             assert shot_vec_result[1][0].shape == ()
             assert shot_vec_result[1][0] == pytest.approx(expected[2], abs=_herm_shot_vec_tol)
 
-            assert isinstance(shot_vec_result[1][1], np.ndarray)
+            assert isinstance(shot_vec_result[1][1], pnp.ndarray)
             assert shot_vec_result[1][1].shape == ()
             assert shot_vec_result[1][1] == pytest.approx(expected[3], abs=_herm_shot_vec_tol)
 
         for shot_vec_result in gradF:
             for param_res in shot_vec_result:
                 for meas_res in param_res:
-                    assert isinstance(meas_res, np.ndarray)
+                    assert isinstance(meas_res, pnp.ndarray)
                     assert meas_res.shape == ()
 
-            assert np.allclose(shot_vec_result[0][0], expected[0], atol=1)
-            assert np.allclose(shot_vec_result[0][1], expected[1], atol=1)
-            assert np.allclose(shot_vec_result[1][0], expected[2], atol=1.5)
-            assert np.allclose(shot_vec_result[1][1], expected[3], atol=1.5)
+            assert pnp.allclose(shot_vec_result[0][0], expected[0], atol=1)
+            assert pnp.allclose(shot_vec_result[0][1], expected[1], atol=1)
+            assert pnp.allclose(shot_vec_result[1][0], expected[2], atol=1.5)
+            assert pnp.allclose(shot_vec_result[1][1], expected[3], atol=1.5)
 
     @pytest.mark.parametrize("ind", [0, 1])
     def test_var_and_probs_single_param(self, ind, broadcast):
@@ -1544,20 +1544,20 @@ class TestParameterShiftRule:
             assert gradA[2].shape == (4,)
 
             # Vars
-            vars_expected = [2 * np.sin(a) * np.cos(a), -35 * np.sin(2 * a) - 12 * np.cos(2 * a)]
-            assert isinstance(gradA[0], np.ndarray)
-            assert np.allclose(
+            vars_expected = [2 * pnp.sin(a) * pnp.cos(a), -35 * pnp.sin(2 * a) - 12 * pnp.cos(2 * a)]
+            assert isinstance(gradA[0], pnp.ndarray)
+            assert pnp.allclose(
                 gradA[0], vars_expected[0] if ind == 0 else 0, atol=shot_vec_tol, rtol=0
             )
 
-            assert isinstance(gradA[1], np.ndarray)
-            assert np.allclose(
+            assert isinstance(gradA[1], pnp.ndarray)
+            assert pnp.allclose(
                 gradA[1], vars_expected[1] if ind == 1 else 0, atol=herm_shot_vec_tol, rtol=0
             )
 
             # Probs
-            assert isinstance(gradA[2], np.ndarray)
-            assert np.allclose(gradA[2], 0, atol=shot_vec_tol, rtol=0)
+            assert isinstance(gradA[2], pnp.ndarray)
+            assert pnp.allclose(gradA[2], 0, atol=shot_vec_tol, rtol=0)
 
     def test_var_and_probs_multi_params(self, broadcast):
         """Tests a qubit Hermitian observable that is not involutory alongside an involutory observable and probs when
@@ -1600,62 +1600,62 @@ class TestParameterShiftRule:
             assert len(gradA) == 3
             var1_res = gradA[0]
             for param_res in var1_res:
-                assert isinstance(param_res, np.ndarray)
+                assert isinstance(param_res, pnp.ndarray)
                 assert param_res.shape == ()
 
             var2_res = gradA[1]
             for param_res in var2_res:
-                assert isinstance(param_res, np.ndarray)
+                assert isinstance(param_res, pnp.ndarray)
                 assert param_res.shape == ()
 
             probs_res = gradA[2]
             for param_res in probs_res:
-                assert isinstance(param_res, np.ndarray)
+                assert isinstance(param_res, pnp.ndarray)
                 assert param_res.shape == (4,)
 
             # Vars
-            vars_expected = [2 * np.sin(a) * np.cos(a), -35 * np.sin(2 * a) - 12 * np.cos(2 * a)]
+            vars_expected = [2 * pnp.sin(a) * pnp.cos(a), -35 * pnp.sin(2 * a) - 12 * pnp.cos(2 * a)]
             assert isinstance(gradA[0], tuple)
-            assert np.allclose(gradA[0][0], vars_expected[0], atol=shot_vec_tol, rtol=0)
-            assert np.allclose(gradA[0][1], 0, atol=shot_vec_tol, rtol=0)
-            assert np.allclose(gradA[0][2], 0, atol=shot_vec_tol, rtol=0)
-            assert np.allclose(gradA[0][3], 0, atol=shot_vec_tol, rtol=0)
+            assert pnp.allclose(gradA[0][0], vars_expected[0], atol=shot_vec_tol, rtol=0)
+            assert pnp.allclose(gradA[0][1], 0, atol=shot_vec_tol, rtol=0)
+            assert pnp.allclose(gradA[0][2], 0, atol=shot_vec_tol, rtol=0)
+            assert pnp.allclose(gradA[0][3], 0, atol=shot_vec_tol, rtol=0)
 
             assert isinstance(gradA[1], tuple)
-            assert np.allclose(gradA[1][0], 0, atol=herm_shot_vec_tol, rtol=0)
-            assert np.allclose(gradA[1][1], vars_expected[1], atol=herm_shot_vec_tol, rtol=0)
-            assert np.allclose(gradA[1][2], 0, atol=herm_shot_vec_tol, rtol=0)
-            assert np.allclose(gradA[1][3], 0, atol=herm_shot_vec_tol, rtol=0)
+            assert pnp.allclose(gradA[1][0], 0, atol=herm_shot_vec_tol, rtol=0)
+            assert pnp.allclose(gradA[1][1], vars_expected[1], atol=herm_shot_vec_tol, rtol=0)
+            assert pnp.allclose(gradA[1][2], 0, atol=herm_shot_vec_tol, rtol=0)
+            assert pnp.allclose(gradA[1][3], 0, atol=herm_shot_vec_tol, rtol=0)
 
             # Probs
             probs_expected = (
-                np.array(
+                pnp.array(
                     [
                         [
-                            -(np.cos(y / 2) ** 2 * np.sin(x)),
-                            -(np.cos(x / 2) ** 2 * np.sin(y)),
+                            -(pnp.cos(y / 2) ** 2 * pnp.sin(x)),
+                            -(pnp.cos(x / 2) ** 2 * pnp.sin(y)),
                         ],
                         [
-                            -(np.sin(x) * np.sin(y / 2) ** 2),
-                            (np.cos(x / 2) ** 2 * np.sin(y)),
+                            -(pnp.sin(x) * pnp.sin(y / 2) ** 2),
+                            (pnp.cos(x / 2) ** 2 * pnp.sin(y)),
                         ],
                         [
-                            (np.sin(x) * np.sin(y / 2) ** 2),
-                            (np.sin(x / 2) ** 2 * np.sin(y)),
+                            (pnp.sin(x) * pnp.sin(y / 2) ** 2),
+                            (pnp.sin(x / 2) ** 2 * pnp.sin(y)),
                         ],
                         [
-                            (np.cos(y / 2) ** 2 * np.sin(x)),
-                            -(np.sin(x / 2) ** 2 * np.sin(y)),
+                            (pnp.cos(y / 2) ** 2 * pnp.sin(x)),
+                            -(pnp.sin(x / 2) ** 2 * pnp.sin(y)),
                         ],
                     ]
                 )
                 / 2
             )
             assert isinstance(gradA[2], tuple)
-            assert np.allclose(gradA[2][0], 0, atol=shot_vec_tol, rtol=0)
-            assert np.allclose(gradA[2][1], 0, atol=shot_vec_tol, rtol=0)
-            assert np.allclose(gradA[2][2], probs_expected[:, 0], atol=shot_vec_tol, rtol=0)
-            assert np.allclose(gradA[2][3], probs_expected[:, 1], atol=shot_vec_tol, rtol=0)
+            assert pnp.allclose(gradA[2][0], 0, atol=shot_vec_tol, rtol=0)
+            assert pnp.allclose(gradA[2][1], 0, atol=shot_vec_tol, rtol=0)
+            assert pnp.allclose(gradA[2][2], probs_expected[:, 0], atol=shot_vec_tol, rtol=0)
+            assert pnp.allclose(gradA[2][3], probs_expected[:, 1], atol=shot_vec_tol, rtol=0)
 
     def test_expval_and_variance_single_param(self, broadcast):
         """Test an expectation value and the variance of involutory and non-involutory observables work well with a
@@ -1681,16 +1681,16 @@ class TestParameterShiftRule:
         tape.trainable_params = {0}
 
         res = dev.execute(tape)
-        expected = np.array(
+        expected = pnp.array(
             [
-                np.sin(a) ** 2,
-                np.cos(a) * np.cos(b),
-                0.25 * (3 - 2 * np.cos(b) ** 2 * np.cos(2 * c) - np.cos(2 * b)),
+                pnp.sin(a) ** 2,
+                pnp.cos(a) * pnp.cos(b),
+                0.25 * (3 - 2 * pnp.cos(b) ** 2 * pnp.cos(2 * c) - pnp.cos(2 * b)),
             ]
         )
 
         assert isinstance(res, tuple)
-        assert np.allclose(res, expected, atol=shot_vec_tol, rtol=0)
+        assert pnp.allclose(res, expected, atol=shot_vec_tol, rtol=0)
 
         # # circuit jacobians
         tapes, fn = qml.gradients.param_shift(tape, broadcast=broadcast)
@@ -1702,13 +1702,13 @@ class TestParameterShiftRule:
         assert len(all_res) == len(many_shots_shot_vector)
         assert isinstance(all_res, tuple)
 
-        expected = np.array([2 * np.cos(a) * np.sin(a), -np.cos(b) * np.sin(a), 0])
+        expected = pnp.array([2 * pnp.cos(a) * pnp.sin(a), -pnp.cos(b) * pnp.sin(a), 0])
         for gradA in all_res:
             assert isinstance(gradA, tuple)
             for a_comp, e_comp in zip(gradA, expected):
-                assert isinstance(a_comp, np.ndarray)
+                assert isinstance(a_comp, pnp.ndarray)
                 assert a_comp.shape == ()
-                assert np.allclose(a_comp, e_comp, atol=shot_vec_tol, rtol=0)
+                assert pnp.allclose(a_comp, e_comp, atol=shot_vec_tol, rtol=0)
 
         tapes, fn = qml.gradients.finite_diff(tape, h=h_val)
         all_gradF = fn(dev.execute(tapes))
@@ -1740,16 +1740,16 @@ class TestParameterShiftRule:
 
         tape = qml.tape.QuantumScript.from_queue(q, shots=shot_vec)
         res = dev.execute(tape)
-        expected = np.array(
+        expected = pnp.array(
             [
-                np.sin(a) ** 2,
-                np.cos(a) * np.cos(b),
-                0.25 * (3 - 2 * np.cos(b) ** 2 * np.cos(2 * c) - np.cos(2 * b)),
+                pnp.sin(a) ** 2,
+                pnp.cos(a) * pnp.cos(b),
+                0.25 * (3 - 2 * pnp.cos(b) ** 2 * pnp.cos(2 * c) - pnp.cos(2 * b)),
             ]
         )
 
         assert isinstance(res, tuple)
-        assert np.allclose(res, expected, atol=shot_vec_tol, rtol=0)
+        assert pnp.allclose(res, expected, atol=shot_vec_tol, rtol=0)
 
         # # circuit jacobians
         tapes, fn = qml.gradients.param_shift(tape, broadcast=broadcast)
@@ -1760,24 +1760,24 @@ class TestParameterShiftRule:
         assert len(all_res) == len(many_shots_shot_vector)
         assert isinstance(all_res, tuple)
 
-        expected = np.array(
+        expected = pnp.array(
             [
-                [2 * np.cos(a) * np.sin(a), -np.cos(b) * np.sin(a), 0],
+                [2 * pnp.cos(a) * pnp.sin(a), -pnp.cos(b) * pnp.sin(a), 0],
                 [
                     0,
-                    -np.cos(a) * np.sin(b),
-                    0.5 * (2 * np.cos(b) * np.cos(2 * c) * np.sin(b) + np.sin(2 * b)),
+                    -pnp.cos(a) * pnp.sin(b),
+                    0.5 * (2 * pnp.cos(b) * pnp.cos(2 * c) * pnp.sin(b) + pnp.sin(2 * b)),
                 ],
-                [0, 0, np.cos(b) ** 2 * np.sin(2 * c)],
+                [0, 0, pnp.cos(b) ** 2 * pnp.sin(2 * c)],
             ]
         ).T
         for gradA in all_res:
             assert isinstance(gradA, tuple)
             for a, e in zip(gradA, expected):
                 for a_comp, e_comp in zip(a, e):
-                    assert isinstance(a_comp, np.ndarray)
+                    assert isinstance(a_comp, pnp.ndarray)
                     assert a_comp.shape == ()
-                    assert np.allclose(a_comp, e_comp, atol=shot_vec_tol, rtol=0)
+                    assert pnp.allclose(a_comp, e_comp, atol=shot_vec_tol, rtol=0)
 
         tapes, fn = qml.gradients.finite_diff(tape, h=h_val)
         all_gradF = fn(dev.execute(tapes))
@@ -1801,12 +1801,12 @@ class TestParameterShiftRule:
         tape.trainable_params = {0, 1}
 
         res = dev.execute(tape)
-        expected = 0.25 * np.sin(x / 2) ** 2 * (3 + np.cos(2 * y) + 2 * np.cos(x) * np.sin(y) ** 2)
+        expected = 0.25 * pnp.sin(x / 2) ** 2 * (3 + pnp.cos(2 * y) + 2 * pnp.cos(x) * pnp.sin(y) ** 2)
 
         assert len(res) == len(many_shots_shot_vector)
         assert isinstance(res, tuple)
         for r in res:
-            assert np.allclose(r, expected, atol=shot_vec_tol, rtol=0)
+            assert pnp.allclose(r, expected, atol=shot_vec_tol, rtol=0)
 
         # # circuit jacobians
         tapes, fn = qml.gradients.param_shift(tape, broadcast=broadcast)
@@ -1817,14 +1817,14 @@ class TestParameterShiftRule:
         assert len(all_res) == len(many_shots_shot_vector)
         assert isinstance(all_res, tuple)
 
-        expected = np.array(
+        expected = pnp.array(
             [
-                0.5 * np.sin(x) * (np.cos(x / 2) ** 2 + np.cos(2 * y) * np.sin(x / 2) ** 2),
-                -2 * np.cos(y) * np.sin(x / 2) ** 4 * np.sin(y),
+                0.5 * pnp.sin(x) * (pnp.cos(x / 2) ** 2 + pnp.cos(2 * y) * pnp.sin(x / 2) ** 2),
+                -2 * pnp.cos(y) * pnp.sin(x / 2) ** 4 * pnp.sin(y),
             ]
         )
         for gradA in all_res:
-            assert np.allclose(gradA, expected, atol=shot_vec_tol, rtol=0)
+            assert pnp.allclose(gradA, expected, atol=shot_vec_tol, rtol=0)
 
         tapes, fn = qml.gradients.finite_diff(tape, h=h_val)
         all_gradF = fn(dev.execute(tapes))
@@ -1862,7 +1862,7 @@ class TestParameterShiftRule:
         return [qml.probs([0, 1]), qml.probs([2, 3])]
 
     costs_and_expected_expval = [
-        (cost1, (3,), np.ndarray),
+        (cost1, (3,), pnp.ndarray),
         (cost2, (1, 3), list),
         (cost3, (2, 3), list),
     ]
@@ -1874,7 +1874,7 @@ class TestParameterShiftRule:
         shot_vec = many_shots_shot_vector
         dev = qml.device("default.qubit", wires=4, shots=shot_vec)
 
-        x = np.random.rand(3)
+        x = pnp.random.rand(3)
         circuit = qml.QNode(cost, dev)
 
         all_res = qml.gradients.param_shift(circuit, broadcast=broadcast)(x)
@@ -1886,7 +1886,7 @@ class TestParameterShiftRule:
             assert qml.math.shape(res) == expected_shape
 
     costs_and_expected_probs = [
-        (cost4, (4, 3), np.ndarray),
+        (cost4, (4, 3), pnp.ndarray),
         (cost5, (1, 4, 3), list),
         (cost6, (2, 4, 3), list),
     ]
@@ -1897,7 +1897,7 @@ class TestParameterShiftRule:
         shot_vec = many_shots_shot_vector
         dev = qml.device("default.qubit", wires=4, shots=shot_vec)
 
-        x = np.random.rand(3)
+        x = pnp.random.rand(3)
         circuit = qml.QNode(cost, dev)
 
         all_res = qml.gradients.param_shift(circuit, broadcast=broadcast)(x)
@@ -1953,7 +1953,7 @@ class TestParameterShiftRule:
             # pylint: disable=unused-argument
             @staticmethod
             def _asarray(arr, dtype=None):
-                return np.array(arr)
+                return pnp.array(arr)
 
             def __init__(self, *args, **kwargs):
                 super().__init__(*args, **kwargs)
@@ -1979,9 +1979,9 @@ class TestParameterShiftRule:
             qml.RY(x, wires=0)
             return qml.expval(qml.PauliZ(wires=0))
 
-        par = np.array(0.2, requires_grad=True)
-        assert np.isclose(qnode(par).item().val, reference_qnode(par))
-        assert np.isclose(qml.jacobian(qnode)(par).item().val, qml.jacobian(reference_qnode)(par))
+        par = pnp.array(0.2, requires_grad=True)
+        assert pnp.isclose(qnode(par).item().val, reference_qnode(par))
+        assert pnp.isclose(qml.jacobian(qnode)(par).item().val, qml.jacobian(reference_qnode)(par))
 
     def test_multi_measure_no_warning(self, broadcast):
         """Test computing the gradient of a tape that contains multiple
@@ -2017,14 +2017,14 @@ class TestHamiltonianExpvalGradients:
         an error is raised"""
         shot_vec = many_shots_shot_vector
 
-        weights = np.array([0.4, 0.5])
+        weights = pnp.array([0.4, 0.5])
 
         with qml.queuing.AnnotatedQueue() as q:
             qml.RX(weights[0], wires=0)
             qml.RY(weights[1], wires=1)
             qml.CNOT(wires=[0, 1])
             obs = [qml.PauliZ(0), qml.PauliZ(0) @ qml.PauliX(1), qml.PauliY(0)]
-            coeffs = np.array([0.1, 0.2, 0.3])
+            coeffs = pnp.array([0.1, 0.2, 0.3])
             H = qml.dot(coeffs, obs)
             qml.var(H)
 
@@ -2040,9 +2040,9 @@ class TestHamiltonianExpvalGradients:
         dev = qml.device("default.qubit", wires=2, shots=shot_vec)
         spy = mocker.spy(qml.gradients, "hamiltonian_grad")
 
-        weights = np.array([0.4, 0.5])
+        weights = pnp.array([0.4, 0.5])
 
-        coeffs = np.array([0.1, 0.2, 0.3])
+        coeffs = pnp.array([0.1, 0.2, 0.3])
         a, b, c = coeffs
         with qml.queuing.AnnotatedQueue() as q:
             qml.RX(weights[0], wires=0)
@@ -2059,8 +2059,8 @@ class TestHamiltonianExpvalGradients:
         tape.trainable_params = {0, 1}
 
         res = dev.execute([tape])
-        expected = -c * np.sin(x) * np.sin(y) + np.cos(x) * (a + b * np.sin(y))
-        assert np.allclose(res, expected, atol=shot_vec_tol, rtol=0)
+        expected = -c * pnp.sin(x) * pnp.sin(y) + pnp.cos(x) * (a + b * pnp.sin(y))
+        assert pnp.allclose(res, expected, atol=shot_vec_tol, rtol=0)
 
         tapes, fn = qml.gradients.param_shift(tape, broadcast=broadcast)
         # two (broadcasted if broadcast=True) shifts per rotation gate
@@ -2073,8 +2073,8 @@ class TestHamiltonianExpvalGradients:
         assert len(all_res) == len(many_shots_shot_vector)
 
         expected = [
-            -c * np.cos(x) * np.sin(y) - np.sin(x) * (a + b * np.sin(y)),
-            b * np.cos(x) * np.cos(y) - c * np.cos(y) * np.sin(x),
+            -c * pnp.cos(x) * pnp.sin(y) - pnp.sin(x) * (a + b * pnp.sin(y)),
+            b * pnp.cos(x) * pnp.cos(y) - c * pnp.cos(y) * pnp.sin(x),
         ]
         for res in all_res:
             assert isinstance(res, tuple)
@@ -2082,8 +2082,8 @@ class TestHamiltonianExpvalGradients:
             assert res[0].shape == ()
             assert res[1].shape == ()
 
-            assert np.allclose(res[0], expected[0], atol=tol, rtol=0)
-            assert np.allclose(res[1], expected[1], atol=tol, rtol=0)
+            assert pnp.allclose(res[0], expected[0], atol=tol, rtol=0)
+            assert pnp.allclose(res[1], expected[1], atol=tol, rtol=0)
 
     def test_trainable_coeffs(self, mocker, broadcast, tol):
         """Test trainable Hamiltonian coefficients"""
@@ -2092,10 +2092,10 @@ class TestHamiltonianExpvalGradients:
         spy = mocker.spy(qml.gradients, "hamiltonian_grad")
 
         obs = [qml.PauliZ(0), qml.PauliZ(0) @ qml.PauliX(1), qml.PauliY(0)]
-        coeffs = np.array([0.1, 0.2, 0.3])
+        coeffs = pnp.array([0.1, 0.2, 0.3])
         H = qml.Hamiltonian(coeffs, obs)
 
-        weights = np.array([0.4, 0.5])
+        weights = pnp.array([0.4, 0.5])
 
         with qml.queuing.AnnotatedQueue() as q:
             qml.RX(weights[0], wires=0)
@@ -2109,8 +2109,8 @@ class TestHamiltonianExpvalGradients:
         tape.trainable_params = {0, 1, 2, 4}
 
         res = dev.execute([tape])
-        expected = -c * np.sin(x) * np.sin(y) + np.cos(x) * (a + b * np.sin(y))
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        expected = -c * pnp.sin(x) * pnp.sin(y) + pnp.cos(x) * (a + b * pnp.sin(y))
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
         tapes, fn = qml.gradients.param_shift(tape, broadcast=broadcast)
         # two (broadcasted if broadcast=True) shifts per rotation gate
@@ -2124,10 +2124,10 @@ class TestHamiltonianExpvalGradients:
         assert qml.math.shape(res) == (3, 4)
 
         expected = [
-            -c * np.cos(x) * np.sin(y) - np.sin(x) * (a + b * np.sin(y)),
-            b * np.cos(x) * np.cos(y) - c * np.cos(y) * np.sin(x),
-            np.cos(x),
-            -(np.sin(x) * np.sin(y)),
+            -c * pnp.cos(x) * pnp.sin(y) - pnp.sin(x) * (a + b * pnp.sin(y)),
+            b * pnp.cos(x) * pnp.cos(y) - c * pnp.cos(y) * pnp.sin(x),
+            pnp.cos(x),
+            -(pnp.sin(x) * pnp.sin(y)),
         ]
         for r in res:
             assert qml.math.allclose(r, expected, atol=shot_vec_tol)
@@ -2140,16 +2140,16 @@ class TestHamiltonianExpvalGradients:
         spy = mocker.spy(qml.gradients, "hamiltonian_grad")
 
         obs = [qml.PauliZ(0), qml.PauliZ(0) @ qml.PauliX(1), qml.PauliY(0)]
-        coeffs = np.array([0.1, 0.2, 0.3])
+        coeffs = pnp.array([0.1, 0.2, 0.3])
         a, b, c = coeffs
         H1 = qml.Hamiltonian(coeffs, obs)
 
         obs = [qml.PauliZ(0)]
-        coeffs = np.array([0.7])
+        coeffs = pnp.array([0.7])
         d = coeffs[0]
         H2 = qml.Hamiltonian(coeffs, obs)
 
-        weights = np.array([0.4, 0.5])
+        weights = pnp.array([0.4, 0.5])
         x, y = weights
 
         with qml.queuing.AnnotatedQueue() as q:
@@ -2163,8 +2163,8 @@ class TestHamiltonianExpvalGradients:
         tape.trainable_params = {0, 1, 2, 4, 5}
 
         res = dev.execute([tape])
-        expected = [-c * np.sin(x) * np.sin(y) + np.cos(x) * (a + b * np.sin(y)), d * np.cos(x)]
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        expected = [-c * pnp.sin(x) * pnp.sin(y) + pnp.cos(x) * (a + b * pnp.sin(y)), d * pnp.cos(x)]
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
         if broadcast:
             with pytest.raises(
@@ -2186,16 +2186,16 @@ class TestHamiltonianExpvalGradients:
 
         expected = [
             [
-                -c * np.cos(x) * np.sin(y) - np.sin(x) * (a + b * np.sin(y)),
-                b * np.cos(x) * np.cos(y) - c * np.cos(y) * np.sin(x),
-                np.cos(x),
-                -(np.sin(x) * np.sin(y)),
+                -c * pnp.cos(x) * pnp.sin(y) - pnp.sin(x) * (a + b * pnp.sin(y)),
+                b * pnp.cos(x) * pnp.cos(y) - c * pnp.cos(y) * pnp.sin(x),
+                pnp.cos(x),
+                -(pnp.sin(x) * pnp.sin(y)),
                 0,
             ],
-            [-d * np.sin(x), 0, 0, 0, np.cos(x)],
+            [-d * pnp.sin(x), 0, 0, 0, pnp.cos(x)],
         ]
 
-        assert np.allclose(np.stack(res), expected, atol=tol, rtol=0)
+        assert pnp.allclose(pnp.stack(res), expected, atol=tol, rtol=0)
 
     @staticmethod
     def cost_fn(weights, coeffs1, coeffs2, dev=None, broadcast=False):
@@ -2226,14 +2226,14 @@ class TestHamiltonianExpvalGradients:
         x, y = weights
         return [
             [
-                -c * np.cos(x) * np.sin(y) - np.sin(x) * (a + b * np.sin(y)),
-                b * np.cos(x) * np.cos(y) - c * np.cos(y) * np.sin(x),
-                np.cos(x),
-                np.cos(x) * np.sin(y),
-                -(np.sin(x) * np.sin(y)),
+                -c * pnp.cos(x) * pnp.sin(y) - pnp.sin(x) * (a + b * pnp.sin(y)),
+                b * pnp.cos(x) * pnp.cos(y) - c * pnp.cos(y) * pnp.sin(x),
+                pnp.cos(x),
+                pnp.cos(x) * pnp.sin(y),
+                -(pnp.sin(x) * pnp.sin(y)),
                 0,
             ],
-            [-d * np.sin(x), 0, 0, 0, 0, np.cos(x)],
+            [-d * pnp.sin(x), 0, 0, 0, 0, pnp.cos(x)],
         ]
 
     @pytest.mark.xfail(reason="TODO")
@@ -2241,9 +2241,9 @@ class TestHamiltonianExpvalGradients:
     def test_autograd(self, broadcast, tol):
         """Test gradient of multiple trainable Hamiltonian coefficients
         using autograd"""
-        coeffs1 = np.array([0.1, 0.2, 0.3], requires_grad=True)
-        coeffs2 = np.array([0.7], requires_grad=True)
-        weights = np.array([0.4, 0.5], requires_grad=True)
+        coeffs1 = pnp.array([0.1, 0.2, 0.3], requires_grad=True)
+        coeffs2 = pnp.array([0.7], requires_grad=True)
+        weights = pnp.array([0.4, 0.5], requires_grad=True)
         shot_vec = many_shots_shot_vector
         dev = qml.device("default.qubit", wires=2, shots=shot_vec)
 
@@ -2255,7 +2255,7 @@ class TestHamiltonianExpvalGradients:
             return
         res = self.cost_fn(weights, coeffs1, coeffs2, dev, broadcast)
         expected = self.cost_fn_expected(weights, coeffs1, coeffs2)
-        assert np.allclose(res, np.array(expected), atol=tol, rtol=0)
+        assert pnp.allclose(res, pnp.array(expected), atol=tol, rtol=0)
 
         # TODO: test when Hessians are supported with the new return types
         # second derivative wrt to Hamiltonian coefficients should be zero
@@ -2281,8 +2281,8 @@ class TestHamiltonianExpvalGradients:
             jac = self.cost_fn(weights, coeffs1, coeffs2, dev, broadcast)
 
         expected = self.cost_fn_expected(weights.numpy(), coeffs1.numpy(), coeffs2.numpy())
-        assert np.allclose(jac[0], np.array(expected)[0], atol=tol, rtol=0)
-        assert np.allclose(jac[1], np.array(expected)[1], atol=tol, rtol=0)
+        assert pnp.allclose(jac[0], pnp.array(expected)[0], atol=tol, rtol=0)
+        assert pnp.allclose(jac[1], pnp.array(expected)[1], atol=tol, rtol=0)
 
         # TODO: test when Hessians are supported with the new return types
         # second derivative wrt to Hamiltonian coefficients should be zero
@@ -2335,7 +2335,7 @@ class TestHamiltonianExpvalGradients:
 
         res = self.cost_fn(weights, coeffs1, coeffs2, dev, broadcast)
         expected = self.cost_fn_expected(weights, coeffs1, coeffs2)
-        assert np.allclose(res, np.array(expected), atol=tol, rtol=0)
+        assert pnp.allclose(res, pnp.array(expected), atol=tol, rtol=0)
 
         # TODO: test when Hessians are supported with the new return types
         # second derivative wrt to Hamiltonian coefficients should be zero
@@ -2350,7 +2350,7 @@ class TestHamiltonianExpvalGradients:
 
 pauliz = qml.PauliZ(wires=0)
 proj = qml.Projector([1], wires=0)
-A = np.array([[4, -1 + 6j], [-1 - 6j, 2]])
+A = pnp.array([[4, -1 + 6j], [-1 - 6j, 2]])
 hermitian = qml.Hermitian(A, wires=0)
 
 expval = qml.expval(pauliz)
@@ -2422,7 +2422,7 @@ class TestReturn:
         assert isinstance(all_res, tuple)
 
         for res in all_res:
-            assert isinstance(res, np.ndarray)
+            assert isinstance(res, pnp.ndarray)
             assert res.shape == shape
 
     @pytest.mark.parametrize("op_wire", [0, 1])
@@ -2458,7 +2458,7 @@ class TestReturn:
         expected_shapes = [(), (4,), (), ()]
         for meas_res in all_res:
             for res, shape in zip(meas_res, expected_shapes):
-                assert isinstance(res, np.ndarray)
+                assert isinstance(res, pnp.ndarray)
                 assert res.shape == shape
 
     @pytest.mark.parametrize("meas, shape", single_meas_with_shape)
@@ -2491,14 +2491,14 @@ class TestReturn:
 
         for param_res in all_res:
             for res in param_res:
-                assert isinstance(res, np.ndarray)
+                assert isinstance(res, pnp.ndarray)
                 assert res.shape == shape
 
     @pytest.mark.parametrize("op_wires", [(0, 1, 2, 3, 4), (5, 5, 5, 5, 5)])
     def test_N_N(self, shot_vec, op_wires):
         """Test multi-param multi-measurement case"""
         dev = qml.device("default.qubit", wires=6, shots=shot_vec)
-        params = np.random.random(6)
+        params = pnp.random.random(6)
 
         with qml.queuing.AnnotatedQueue() as q:
             for idx, w in enumerate(op_wires):
@@ -2535,5 +2535,5 @@ class TestReturn:
             for idx, param_res in enumerate(meas_res):
                 assert len(param_res) == 5
                 for res in param_res:
-                    assert isinstance(res, np.ndarray)
+                    assert isinstance(res, pnp.ndarray)
                     assert res.shape == expected_shapes[idx]

--- a/tests/math/test_basic_math.py
+++ b/tests/math/test_basic_math.py
@@ -17,7 +17,7 @@ import numpy as onp
 import pytest
 
 from pennylane import math as fn
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 
 pytestmark = pytest.mark.all_interfaces
 
@@ -49,14 +49,14 @@ class TestFrobeniusInnerProduct:
                 -0.7381450594,
             ),
             (
-                np.array([[1.0, 2.3], [-1.3, 2.4]]),
-                np.array([[0.7, -7.3], [-1.0, -2.9]]),
+                pnp.array([[1.0, 2.3], [-1.3, 2.4]]),
+                pnp.array([[0.7, -7.3], [-1.0, -2.9]]),
                 False,
                 -21.75,
             ),
             (
-                np.array([[1.0, 2.3], [-1.3, 2.4]]),
-                np.array([[0.7, -7.3], [-1.0, -2.9]]),
+                pnp.array([[1.0, 2.3], [-1.3, 2.4]]),
+                pnp.array([[0.7, -7.3], [-1.0, -2.9]]),
                 True,
                 -0.7381450594,
             ),
@@ -122,4 +122,4 @@ class TestFrobeniusInnerProduct:
         result.backward()
         grad = B.grad
 
-        assert np.allclose(grad, A)
+        assert pnp.allclose(grad, A)

--- a/tests/math/test_density_matrices.py
+++ b/tests/math/test_density_matrices.py
@@ -19,7 +19,7 @@ import numpy as onp
 import pytest
 
 from pennylane import math as fn
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 
 pytestmark = pytest.mark.all_interfaces
 
@@ -77,7 +77,7 @@ state_vectors = [
     (state_00_10, (mat_0_1, mat_0, mat_00_10)),
     (state_01_11, (mat_0_1, mat_1, mat_01_11))]
 
-array_funcs = [lambda x: x, onp.array, np.array, jnp.array, torch.tensor, tf.Variable, tf.constant]
+array_funcs = [lambda x: x, onp.array, pnp.array, jnp.array, torch.tensor, tf.Variable, tf.constant]
 
 single_wires_list = [
     [0],
@@ -110,7 +110,7 @@ class TestDensityMatrixFromStateVectors:
         """Test the density matrix from state vectors for single wires."""
         state_vector = array_func(state_vector)
         density_matrix = fn.quantum.reduce_statevector(state_vector, indices=wires)
-        assert np.allclose(density_matrix, expected_density_matrix[wires[0]])
+        assert pnp.allclose(density_matrix, expected_density_matrix[wires[0]])
 
     @pytest.mark.parametrize("array_func", array_funcs)
     @pytest.mark.parametrize("state_vector, expected_density_matrix", state_vectors)
@@ -124,7 +124,7 @@ class TestDensityMatrixFromStateVectors:
         expected = expected_density_matrix[2]
         if wires == [1, 0]:
             expected = permute_two_qubit_dm(expected)
-        assert np.allclose(density_matrix, expected)
+        assert pnp.allclose(density_matrix, expected)
 
     @pytest.mark.parametrize("array_func", array_funcs)
     @pytest.mark.parametrize("state_vector, expected_density_matrix", state_vectors)
@@ -135,7 +135,7 @@ class TestDensityMatrixFromStateVectors:
         """Test the reduced_dm with state vectors for single wires."""
         state_vector = array_func(state_vector)
         density_matrix = fn.reduce_statevector(state_vector, indices=wires)
-        assert np.allclose(density_matrix, expected_density_matrix[wires[0]])
+        assert pnp.allclose(density_matrix, expected_density_matrix[wires[0]])
 
     @pytest.mark.parametrize("array_func", array_funcs)
     @pytest.mark.parametrize("state_vector, expected_density_matrix", state_vectors)
@@ -149,7 +149,7 @@ class TestDensityMatrixFromStateVectors:
         expected = expected_density_matrix[2]
         if wires == [1, 0]:
             expected = permute_two_qubit_dm(expected)
-        assert np.allclose(density_matrix, expected)
+        assert pnp.allclose(density_matrix, expected)
 
     @pytest.mark.parametrize("array_func", array_funcs)
     @pytest.mark.parametrize("state_vector, expected_density_matrix", state_vectors)
@@ -166,7 +166,7 @@ class TestDensityMatrixFromStateVectors:
         if wires == [1, 0]:
             expected = permute_two_qubit_dm(expected)
 
-        assert np.allclose(density_matrix, expected)
+        assert pnp.allclose(density_matrix, expected)
 
     def test_state_vector_wrong_shape(self):
         """Test that wrong shaped state vector raises an error with check_state=True"""
@@ -192,7 +192,7 @@ class TestDensityMatrixFromStateVectors:
         jitted_dens_matrix_func = jit(fn.quantum.reduce_statevector, static_argnums=[1, 2])
 
         density_matrix = jitted_dens_matrix_func(state_vector, indices=(0, 1), check_state=True)
-        assert np.allclose(density_matrix, [[1, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]])
+        assert pnp.allclose(density_matrix, [[1, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]])
 
     def test_wrong_shape_jax_jit(self):
         """Test jitting the density matrix from state vector with wrong shape."""
@@ -220,7 +220,7 @@ class TestDensityMatrixFromStateVectors:
             input_signature=(tf.TensorSpec(shape=(4,), dtype=tf.complex128),),
         )
         density_matrix = density_matrix(state_vector)
-        assert np.allclose(density_matrix, [[1, 0], [0, 0]])
+        assert pnp.allclose(density_matrix, [[1, 0], [0, 0]])
 
     @pytest.mark.parametrize("c_dtype", c_dtypes)
     @pytest.mark.parametrize("array_func", array_funcs)
@@ -250,10 +250,10 @@ density_matrices = [
     (onp.array(mat_01), (mat_0, mat_1)),
     (onp.array(mat_10), (mat_1, mat_0)),
     (onp.array(mat_11), (mat_1, mat_1)),
-    (np.array(mat_00), (mat_0, mat_0)),
-    (np.array(mat_01), (mat_0, mat_1)),
-    (np.array(mat_10), (mat_1, mat_0)),
-    (np.array(mat_11), (mat_1, mat_1)),
+    (pnp.array(mat_00), (mat_0, mat_0)),
+    (pnp.array(mat_01), (mat_0, mat_1)),
+    (pnp.array(mat_10), (mat_1, mat_0)),
+    (pnp.array(mat_11), (mat_1, mat_1)),
     (jnp.array(mat_00), (mat_0, mat_0)),
     (jnp.array(mat_01), (mat_0, mat_1)),
     (jnp.array(mat_10), (mat_1, mat_0)),
@@ -287,7 +287,7 @@ class TestDensityMatrixFromMatrix:
     ):
         """Test the reduced_dm with matrix for single wires."""
         density_matrix = fn.reduce_dm(density_matrix, indices=wires)
-        assert np.allclose(density_matrix, expected_density_matrix[wires[0]])
+        assert pnp.allclose(density_matrix, expected_density_matrix[wires[0]])
 
     @pytest.mark.parametrize("density_matrix", list(zip(*density_matrices))[0])
     @pytest.mark.parametrize("wires", multiple_wires_list)
@@ -297,7 +297,7 @@ class TestDensityMatrixFromMatrix:
         expected = density_matrix
         if wires == [1, 0]:
             expected = permute_two_qubit_dm(expected)
-        assert np.allclose(returned_density_matrix, expected)
+        assert pnp.allclose(returned_density_matrix, expected)
 
     @pytest.mark.parametrize("density_matrix", list(zip(*density_matrices))[0])
     @pytest.mark.parametrize("wires", multiple_wires_list)
@@ -311,7 +311,7 @@ class TestDensityMatrixFromMatrix:
         if wires == [1, 0]:
             expected = permute_two_qubit_dm(expected)
 
-        assert np.allclose(returned_density_matrix, expected)
+        assert pnp.allclose(returned_density_matrix, expected)
 
     def test_matrix_wrong_shape(self):
         """Test that wrong shaped state vector raises an error with check_state=True"""
@@ -350,7 +350,7 @@ class TestDensityMatrixFromMatrix:
         jitted_dens_matrix_func = jit(fn.quantum.reduce_dm, static_argnums=[1, 2])
 
         density_matrix = jitted_dens_matrix_func(state_vector, indices=(0,), check_state=True)
-        assert np.allclose(density_matrix, [[1, 0], [0, 0]])
+        assert pnp.allclose(density_matrix, [[1, 0], [0, 0]])
 
     def test_wrong_shape_jax_jit(self):
         """Test jitting the density matrix from state vector with wrong shape."""
@@ -385,7 +385,7 @@ class TestDensityMatrixFromMatrix:
             input_signature=(tf.TensorSpec(shape=(4, 4), dtype=tf.complex128),),
         )
         density_matrix = density_matrix(d_mat)
-        assert np.allclose(density_matrix, [[1, 0], [0, 0]])
+        assert pnp.allclose(density_matrix, [[1, 0], [0, 0]])
 
     @pytest.mark.parametrize("c_dtype", c_dtypes)
     @pytest.mark.parametrize("density_matrix", list(zip(*density_matrices))[0])
@@ -414,7 +414,7 @@ class TestDensityMatrixBroadcasting:
         expected_density_matrices = array_func([sv[1][wires[0]] for sv in state_vectors])
 
         _density_matrices = fn.reduce_statevector(state_vector, indices=wires)
-        assert np.allclose(_density_matrices, expected_density_matrices)
+        assert pnp.allclose(_density_matrices, expected_density_matrices)
 
     @pytest.mark.parametrize("array_func", array_funcs)
     @pytest.mark.parametrize("wires", multiple_wires_list)
@@ -430,7 +430,7 @@ class TestDensityMatrixBroadcasting:
             )
 
         _density_matrices = fn.reduce_statevector(state_vector, indices=wires)
-        assert np.allclose(_density_matrices, expected_density_matrices)
+        assert pnp.allclose(_density_matrices, expected_density_matrices)
 
     @pytest.mark.parametrize("array_func", array_funcs)
     @pytest.mark.parametrize("wires", single_wires_list)
@@ -440,7 +440,7 @@ class TestDensityMatrixBroadcasting:
         expected_density_matrices = array_func([dm[1][wires[0]] for dm in density_matrices[:4]])
 
         density_matrix = fn.reduce_dm(density_matrix, indices=wires)
-        assert np.allclose(density_matrix, expected_density_matrices)
+        assert pnp.allclose(density_matrix, expected_density_matrices)
 
     @pytest.mark.parametrize("array_func", array_funcs)
     @pytest.mark.parametrize("wires", multiple_wires_list)
@@ -456,4 +456,4 @@ class TestDensityMatrixBroadcasting:
             )
 
         density_matrix = fn.reduce_dm(density_matrix, indices=wires)
-        assert np.allclose(density_matrix, expected_density_matrices)
+        assert pnp.allclose(density_matrix, expected_density_matrices)

--- a/tests/math/test_entropies_math.py
+++ b/tests/math/test_entropies_math.py
@@ -17,7 +17,7 @@
 import pytest
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 
 pytestmark = pytest.mark.all_interfaces
 
@@ -83,7 +83,7 @@ class TestVonNeumannEntropy:  # pylint: disable=too-few-public-methods
         [1],
     ]
 
-    base = [2, np.exp(1), 10]
+    base = [2, pnp.exp(1), 10]
 
     check_state = [True, False]
 
@@ -109,7 +109,7 @@ class TestVonNeumannEntropy:  # pylint: disable=too-few-public-methods
         if pure:
             expected_entropy = 0
         else:
-            expected_entropy = np.log(2) / np.log(base)
+            expected_entropy = pnp.log(2) / pnp.log(base)
 
         assert qml.math.allclose(entropy, expected_entropy)
 
@@ -123,8 +123,8 @@ class TestMutualInformation:
         [
             ([[1, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]], 0),
             ([[0.5, 0, 0.5, 0], [0, 0, 0, 0], [0.5, 0, 0.5, 0], [0, 0, 0, 0]], 0),
-            ([[0.5, 0, 0, 0.5], [0, 0, 0, 0], [0, 0, 0, 0], [0.5, 0, 0, 0.5]], 2 * np.log(2)),
-            (np.ones((4, 4)) * 0.25, 0),
+            ([[0.5, 0, 0, 0.5], [0, 0, 0, 0], [0, 0, 0, 0], [0.5, 0, 0, 0.5]], 2 * pnp.log(2)),
+            (pnp.ones((4, 4)) * 0.25, 0),
         ],
     )
     def test_density_matrix(self, interface, state, expected):
@@ -132,15 +132,15 @@ class TestMutualInformation:
         state = qml.math.asarray(state, like=interface)
 
         actual = qml.math.mutual_info(state, indices0=[0], indices1=[1])
-        assert np.allclose(actual, expected)
+        assert pnp.allclose(actual, expected)
 
     @pytest.mark.parametrize(
         "state, wires0, wires1",
         [
-            (np.diag([1, 0, 0, 0]), [0], [0]),
-            (np.diag([1, 0, 0, 0]), [0], [0, 1]),
-            (np.diag([1, 0, 0, 0, 0, 0, 0, 0]), [0, 1], [1]),
-            (np.diag([1, 0, 0, 0, 0, 0, 0, 0]), [0, 1], [1, 2]),
+            (pnp.diag([1, 0, 0, 0]), [0], [0]),
+            (pnp.diag([1, 0, 0, 0]), [0], [0, 1]),
+            (pnp.diag([1, 0, 0, 0, 0, 0, 0, 0]), [0, 1], [1]),
+            (pnp.diag([1, 0, 0, 0, 0, 0, 0, 0]), [0, 1], [1, 2]),
         ],
     )
     def test_subsystem_overlap(self, state, wires0, wires1):
@@ -150,7 +150,7 @@ class TestMutualInformation:
         ):
             qml.math.mutual_info(state, indices0=wires0, indices1=wires1)
 
-    @pytest.mark.parametrize("state", [np.array([5])])
+    @pytest.mark.parametrize("state", [pnp.array([5])])
     def test_invalid_type(self, state):
         """Test that an error is raised when an unsupported type is passed"""
         with pytest.raises(ValueError, match="Density matrix must be of shape"):
@@ -173,7 +173,7 @@ class TestEntanglementEntropy:
                 ],
                 0,
             ),
-            ([[0, 0, 0, 0], [0, 0.5, -0.5, 0], [0, -0.5, 0.5, 0], [0, 0, 0, 0]], np.log(2)),
+            ([[0, 0, 0, 0], [0, 0.5, -0.5, 0], [0, -0.5, 0.5, 0], [0, 0, 0, 0]], pnp.log(2)),
             (
                 [
                     [1 / 1.25, 0, 0, 0.5 / 1.25],
@@ -194,10 +194,10 @@ class TestEntanglementEntropy:
     @pytest.mark.parametrize(
         "state, wires0, wires1",
         [
-            (np.diag([1, 0, 0, 0]), [0], [0]),
-            (np.diag([1, 0, 0, 0]), [0], [0, 1]),
-            (np.diag([1, 0, 0, 0, 0, 0, 0, 0]), [0, 1], [1]),
-            (np.diag([1, 0, 0, 0, 0, 0, 0, 0]), [0, 1], [1, 2]),
+            (pnp.diag([1, 0, 0, 0]), [0], [0]),
+            (pnp.diag([1, 0, 0, 0]), [0], [0, 1]),
+            (pnp.diag([1, 0, 0, 0, 0, 0, 0, 0]), [0, 1], [1]),
+            (pnp.diag([1, 0, 0, 0, 0, 0, 0, 0]), [0, 1], [1, 2]),
         ],
     )
     def test_subsystem_overlap(self, state, wires0, wires1):
@@ -207,7 +207,7 @@ class TestEntanglementEntropy:
         ):
             qml.math.vn_entanglement_entropy(state, indices0=wires0, indices1=wires1)
 
-    @pytest.mark.parametrize("state", [np.array([5])])
+    @pytest.mark.parametrize("state", [pnp.array([5])])
     def test_invalid_type(self, state):
         """Test that an error is raised when an unsupported type is passed"""
         with pytest.raises(ValueError, match="Density matrix must be of shape"):
@@ -224,10 +224,10 @@ class TestRelativeEntropy:
     @pytest.mark.parametrize(
         "state0, state1, expected",
         [
-            ([[1, 0], [0, 0]], [[0, 0], [0, 1]], np.inf),
-            ([[1, 0], [0, 0]], np.ones((2, 2)) / 2, np.inf),
+            ([[1, 0], [0, 0]], [[0, 0], [0, 1]], pnp.inf),
+            ([[1, 0], [0, 0]], pnp.ones((2, 2)) / 2, pnp.inf),
             ([[0, 0], [0, 1]], [[0, 0], [0, 1]], 0),
-            ([[1, 0], [0, 0]], np.eye(2) / 2, np.log(2)),
+            ([[1, 0], [0, 0]], pnp.eye(2) / 2, pnp.log(2)),
         ],
     )
     @pytest.mark.parametrize("base", bases)
@@ -238,16 +238,16 @@ class TestRelativeEntropy:
         state1 = qml.math.asarray(state1, like=interface)
 
         actual = qml.math.relative_entropy(state0, state1, base=base, check_state=check_state)
-        div = 1 if base is None else np.log(base)
-        assert np.allclose(actual, expected / div, rtol=1e-06, atol=1e-07)
+        div = 1 if base is None else pnp.log(base)
+        assert pnp.allclose(actual, expected / div, rtol=1e-06, atol=1e-07)
 
     @pytest.mark.parametrize(
         "state0, state1",
         [
-            (np.array([[1, 0], [0, 0]]), np.diag([0, 1, 0, 0])),
+            (pnp.array([[1, 0], [0, 0]]), pnp.diag([0, 1, 0, 0])),
             (
-                np.array([[1, 0], [0, 0]]),
-                np.array([[0, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]]),
+                pnp.array([[1, 0], [0, 0]]),
+                pnp.array([[0, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]]),
             ),
         ],
     )
@@ -267,7 +267,7 @@ class TestMaxEntropy:
         [1],
     ]
 
-    base = [2, np.exp(1), 10]
+    base = [2, pnp.exp(1), 10]
 
     check_state = [True, False]
 
@@ -293,7 +293,7 @@ class TestMaxEntropy:
         if pure:
             expected_max_entropy = 0
         else:
-            expected_max_entropy = np.log(2) / np.log(base)
+            expected_max_entropy = pnp.log(2) / pnp.log(base)
 
         assert qml.math.allclose(entropy, expected_max_entropy)
 
@@ -308,7 +308,7 @@ class TestMaxEntropy:
     @pytest.mark.parametrize("check_state", check_state)
     def test_max_entropy_grad(self, params, wires, base, check_state):
         """Test `max_entropy` differentiability with autograd."""
-        params = np.tensor(params)
+        params = pnp.tensor(params)
 
         gradient = qml.grad(qml.math.max_entropy)(params, wires, base, check_state)
         assert qml.math.allclose(gradient, 0.0)
@@ -378,7 +378,7 @@ class TestMinEntropy:
         [1],
     ]
 
-    base = [2, np.exp(1), 10]
+    base = [2, pnp.exp(1), 10]
 
     check_state = [True, False]
 
@@ -404,7 +404,7 @@ class TestMinEntropy:
         if pure:
             expected_min_entropy = 0
         else:
-            expected_min_entropy = np.log(2) / np.log(base)
+            expected_min_entropy = pnp.log(2) / pnp.log(base)
 
         assert qml.math.allclose(entropy, expected_min_entropy)
 
@@ -420,10 +420,10 @@ class TestMinEntropy:
     def test_min_entropy_grad(self, params, wires, base, check_state):
         """Test `min_entropy` differentiability with autograd."""
 
-        params = np.tensor(params)
+        params = pnp.tensor(params)
 
         gradient = qml.grad(qml.math.min_entropy)(params, wires, base, check_state)
-        assert qml.math.allclose(gradient, -np.eye(4) / np.log(base))
+        assert qml.math.allclose(gradient, -pnp.eye(4) / pnp.log(base))
 
     @pytest.mark.torch
     @pytest.mark.parametrize("params", parameters)
@@ -439,7 +439,7 @@ class TestMinEntropy:
         min_entropy.backward()
         gradient = params.grad
 
-        assert qml.math.allclose(gradient, -np.eye(4) / np.log(base))
+        assert qml.math.allclose(gradient, -pnp.eye(4) / pnp.log(base))
 
     @pytest.mark.tf
     @pytest.mark.parametrize("params", parameters)
@@ -456,7 +456,7 @@ class TestMinEntropy:
 
         gradient = tape.gradient(min_entropy, params)
 
-        assert qml.math.allclose(gradient, -np.eye(4) / np.log(base))
+        assert qml.math.allclose(gradient, -pnp.eye(4) / pnp.log(base))
 
     @pytest.mark.jax
     @pytest.mark.parametrize("params", parameters)
@@ -482,7 +482,7 @@ class TestMinEntropy:
         else:
             gradient = min_entropy_grad(params, wires, base, check_state)
 
-        assert qml.math.allclose(gradient, -np.eye(4) / np.log(base))
+        assert qml.math.allclose(gradient, -pnp.eye(4) / pnp.log(base))
 
 
 class TestEntropyBroadcasting:
@@ -519,7 +519,7 @@ class TestEntropyBroadcasting:
             [[1 / 2, 0, 0, 1 / 2], [0, 0, 0, 0], [0, 0, 0, 0], [1 / 2, 0, 0, 1 / 2]],
             [[1, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]],
         ]
-        expected = [np.log(2), 0]
+        expected = [pnp.log(2), 0]
 
         if interface:
             density_matrix = qml.math.asarray(density_matrix, like=interface)
@@ -534,42 +534,42 @@ class TestEntropyBroadcasting:
             [[1, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]],
             [[0.5, 0, 0.5, 0], [0, 0, 0, 0], [0.5, 0, 0.5, 0], [0, 0, 0, 0]],
             [[0.5, 0, 0, 0.5], [0, 0, 0, 0], [0, 0, 0, 0], [0.5, 0, 0, 0.5]],
-            np.ones((4, 4)) * 0.25,
+            pnp.ones((4, 4)) * 0.25,
         ]
-        expected = [0, 0, 2 * np.log(2), 0]
+        expected = [0, 0, 2 * pnp.log(2), 0]
 
         state = qml.math.asarray(state, like=interface)
 
         actual = qml.math.mutual_info(state, indices0=[0], indices1=[1])
-        assert np.allclose(actual, expected)
+        assert pnp.allclose(actual, expected)
 
     @pytest.mark.parametrize("interface", ["autograd", "jax", "tensorflow", "torch"])
     @pytest.mark.parametrize("check_state", check_state)
     def test_relative_entropy_broadcast_dm(self, interface, check_state):
         """Test broadcasting for relative entropy and density matrices"""
         state0 = [[[1, 0], [0, 0]], [[1, 0], [0, 0]], [[0, 0], [0, 1]], [[1, 0], [0, 0]]]
-        state1 = [[[0, 0], [0, 1]], np.ones((2, 2)) / 2, [[0, 0], [0, 1]], np.eye(2) / 2]
-        expected = [np.inf, np.inf, 0, np.log(2)]
+        state1 = [[[0, 0], [0, 1]], pnp.ones((2, 2)) / 2, [[0, 0], [0, 1]], pnp.eye(2) / 2]
+        expected = [pnp.inf, pnp.inf, 0, pnp.log(2)]
 
         state0 = qml.math.asarray(state0, like=interface)
         state1 = qml.math.asarray(state1, like=interface)
 
         actual = qml.math.relative_entropy(state0, state1, check_state=check_state)
-        assert np.allclose(actual, expected, rtol=1e-06, atol=1e-07)
+        assert pnp.allclose(actual, expected, rtol=1e-06, atol=1e-07)
 
     @pytest.mark.parametrize("interface", ["autograd", "jax", "tensorflow", "torch"])
     @pytest.mark.parametrize("check_state", check_state)
     def test_relative_entropy_broadcast_dm_unbatched(self, interface, check_state):
         """Test broadcasting for relative entropy and density matrices when one input is unbatched"""
-        state0 = [[[0, 0], [0, 1]], np.ones((2, 2)) / 2, [[1, 0], [0, 0]], np.eye(2) / 2]
-        state1 = np.eye(2) / 2
-        expected = [np.log(2), np.log(2), np.log(2), 0]
+        state0 = [[[0, 0], [0, 1]], pnp.ones((2, 2)) / 2, [[1, 0], [0, 0]], pnp.eye(2) / 2]
+        state1 = pnp.eye(2) / 2
+        expected = [pnp.log(2), pnp.log(2), pnp.log(2), 0]
 
         state0 = qml.math.asarray(state0, like=interface)
         state1 = qml.math.asarray(state1, like=interface)
 
         actual = qml.math.relative_entropy(state0, state1, check_state=check_state)
-        assert np.allclose(actual, expected, rtol=1e-06, atol=1e-07)
+        assert pnp.allclose(actual, expected, rtol=1e-06, atol=1e-07)
 
     @pytest.mark.parametrize("wires", single_wires_list)
     @pytest.mark.parametrize("check_state", check_state)
@@ -580,7 +580,7 @@ class TestEntropyBroadcasting:
             [[1 / 2, 0, 0, 1 / 2], [0, 0, 0, 0], [0, 0, 0, 0], [1 / 2, 0, 0, 1 / 2]],
             [[1, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]],
         ]
-        expected = [np.log(2), 0]
+        expected = [pnp.log(2), 0]
 
         if interface:
             density_matrix = qml.math.asarray(density_matrix, like=interface)

--- a/tests/math/test_expectation_value.py
+++ b/tests/math/test_expectation_value.py
@@ -18,7 +18,7 @@ import numpy as onp
 import pytest
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 
 pytestmark = pytest.mark.all_interfaces
 
@@ -34,7 +34,7 @@ class TestExpectationValueMath:
     ops_vs_vecstates = [
         ([[1, 0], [0, 0]], [1, 0], 1),
         ([[0, 1], [1, 0]], [0, 1], 0),
-        ([[0.5, 0.5], [0.5, 0.5]], [1, 1] / np.sqrt(2), 1),
+        ([[0.5, 0.5], [0.5, 0.5]], [1, 1] / pnp.sqrt(2), 1),
         (
             [[0.40975111, 0.40751457], [0.40751457, 0.59024889]],
             [0.8660254, 0.5],
@@ -42,7 +42,7 @@ class TestExpectationValueMath:
         ),
         (
             [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, -1, 0], [0, 0, 0, -1]],
-            [1, 0, 1, 0] / np.sqrt(2),
+            [1, 0, 1, 0] / pnp.sqrt(2),
             0,
         ),
     ]
@@ -50,7 +50,7 @@ class TestExpectationValueMath:
     array_funcs = [
         lambda x: x,
         onp.array,
-        np.array,
+        pnp.array,
         jnp.array,
         torch.tensor,
         tf.Variable,
@@ -133,7 +133,7 @@ class TestExpectationValueMath:
 
     def test_same_number_wires_dm(self):
         """Test that the two states must act on the same number of wires"""
-        ops = np.diag([0, 1, 0, 0])
+        ops = pnp.diag([0, 1, 0, 0])
         state_vectors = [1, 0]
         with pytest.raises(
             qml.QuantumFunctionError,
@@ -156,7 +156,7 @@ class TestExpectationValueMath:
             [
                 func([0, 1]),
                 func([1, 0]),
-                func([1, 1] / np.sqrt(2)),
+                func([1, 1] / pnp.sqrt(2)),
                 func([0.8660254, 0.5]),
             ]
         )
@@ -173,7 +173,7 @@ class TestExpectationValueMath:
             [
                 func([0, 1]),
                 func([1, 0]),
-                func([1, 1] / np.sqrt(2)),
+                func([1, 1] / pnp.sqrt(2)),
                 func([0.8660254, 0.5]),
             ]
         )

--- a/tests/math/test_fidelity_math.py
+++ b/tests/math/test_fidelity_math.py
@@ -18,7 +18,7 @@ import numpy as onp
 import pytest
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 
 pytestmark = pytest.mark.all_interfaces
 
@@ -34,7 +34,7 @@ class TestFidelityMath:
     state_vectors = [
         ([1, 0], [0, 1], 0),
         ([0, 1], [0, 1], 1.0),
-        ([1, 0], [1, 1] / np.sqrt(2), 0.5),
+        ([1, 0], [1, 1] / pnp.sqrt(2), 0.5),
     ]
 
     density_mats = [
@@ -47,7 +47,7 @@ class TestFidelityMath:
     array_funcs = [
         lambda x: x,
         onp.array,
-        np.array,
+        pnp.array,
         jnp.array,
         torch.tensor,
         tf.Variable,
@@ -151,7 +151,7 @@ class TestFidelityMath:
 
     def test_same_number_wires_dm(self):
         """Test that the two states must act on the same number of wires"""
-        state0 = np.diag([0, 1, 0, 0])
+        state0 = pnp.diag([0, 1, 0, 0])
         state1 = [[1, 0], [0, 0]]
         with pytest.raises(
             qml.QuantumFunctionError, match="The two states must have the same number of wires"
@@ -163,7 +163,7 @@ class TestFidelityMath:
     def test_broadcast_sv_sv(self, check_state, func):
         """Test broadcasting works for fidelity and state vectors"""
         state0 = func([[1, 0], [0, 1], [1, 0]])
-        state1 = func([[0, 1], [0, 1], [1, 1] / np.sqrt(2)])
+        state1 = func([[0, 1], [0, 1], [1, 1] / pnp.sqrt(2)])
         expected = [0, 1, 0.5]
 
         fidelity = qml.math.fidelity_statevector(state0, state1, check_state)
@@ -174,7 +174,7 @@ class TestFidelityMath:
     def test_broadcast_sv_sv_unbatched(self, check_state, func):
         """Test broadcasting works for fidelity and state vectors when one input is unbatched"""
         state0 = func([1, 0])
-        state1 = func([[0, 1], [1, 0], [1, 1] / np.sqrt(2)])
+        state1 = func([[0, 1], [1, 0], [1, 1] / pnp.sqrt(2)])
         expected = [0, 1, 0.5]
 
         fidelity = qml.math.fidelity_statevector(state0, state1, check_state)
@@ -254,9 +254,9 @@ def cost_fn_multi1(x):
 
 
 def cost_fn_multi2(x):
-    first_term = qml.math.convert_like(np.ones((4, 4)) / 4, x)
-    second_term = np.zeros((4, 4))
-    second_term[1:3, 1:3] = np.array([[1, -1], [-1, 1]]) / 2
+    first_term = qml.math.convert_like(pnp.ones((4, 4)) / 4, x)
+    second_term = pnp.zeros((4, 4))
+    second_term[1:3, 1:3] = pnp.array([[1, -1], [-1, 1]]) / 2
     second_term = qml.math.convert_like(second_term, x)
 
     x = qml.math.cast_like(x, first_term)
@@ -309,11 +309,11 @@ class TestGradient:
     ]
 
     @pytest.mark.autograd
-    @pytest.mark.parametrize("x", [0.0, 1e-7, 0.456, np.pi / 2 - 1e-7, np.pi / 2])
+    @pytest.mark.parametrize("x", [0.0, 1e-7, 0.456, pnp.pi / 2 - 1e-7, pnp.pi / 2])
     @pytest.mark.parametrize("cost_fn, expected_res, expected_grad", cost_fns)
     def test_grad_autograd(self, x, cost_fn, expected_res, expected_grad, tol):
         """Test gradients are correct for autograd"""
-        x = np.array(x)
+        x = pnp.array(x)
         res = cost_fn(x)
         grad = qml.grad(cost_fn)(x)
 
@@ -321,7 +321,7 @@ class TestGradient:
         assert qml.math.allclose(grad, expected_grad(x), tol)
 
     @pytest.mark.jax
-    @pytest.mark.parametrize("x", [0.0, 1e-7, 0.456, np.pi / 2 - 1e-7, np.pi / 2])
+    @pytest.mark.parametrize("x", [0.0, 1e-7, 0.456, pnp.pi / 2 - 1e-7, pnp.pi / 2])
     @pytest.mark.parametrize("cost_fn, expected_res, expected_grad", cost_fns)
     def test_grad_jax(self, x, cost_fn, expected_res, expected_grad, tol):
         """Test gradients are correct for jax"""
@@ -333,7 +333,7 @@ class TestGradient:
         assert qml.math.allclose(grad, expected_grad(x), tol)
 
     @pytest.mark.jax
-    @pytest.mark.parametrize("x", [0.0, 1e-7, 0.456, np.pi / 2 - 1e-7, np.pi / 2])
+    @pytest.mark.parametrize("x", [0.0, 1e-7, 0.456, pnp.pi / 2 - 1e-7, pnp.pi / 2])
     @pytest.mark.parametrize("cost_fn, expected_res, expected_grad", cost_fns)
     def test_grad_jax_jit(self, x, cost_fn, expected_res, expected_grad, tol):
         """Test gradients are correct for jax-jit"""
@@ -347,11 +347,11 @@ class TestGradient:
         assert qml.math.allclose(grad, expected_grad(x), tol)
 
     @pytest.mark.torch
-    @pytest.mark.parametrize("x", [0.0, 1e-7, 0.456, np.pi / 2 - 1e-7, np.pi / 2])
+    @pytest.mark.parametrize("x", [0.0, 1e-7, 0.456, pnp.pi / 2 - 1e-7, pnp.pi / 2])
     @pytest.mark.parametrize("cost_fn, expected_res, expected_grad", cost_fns)
     def test_grad_torch(self, x, cost_fn, expected_res, expected_grad, tol):
         """Test gradients are correct for torch"""
-        x = torch.from_numpy(np.array(x)).requires_grad_()
+        x = torch.from_numpy(pnp.array(x)).requires_grad_()
         res = cost_fn(x)
         res.backward()
         grad = x.grad
@@ -360,7 +360,7 @@ class TestGradient:
         assert qml.math.allclose(grad, expected_grad(x), tol)
 
     @pytest.mark.tf
-    @pytest.mark.parametrize("x", [0.0, 1e-7, 0.456, np.pi / 2 - 1e-7, np.pi / 2])
+    @pytest.mark.parametrize("x", [0.0, 1e-7, 0.456, pnp.pi / 2 - 1e-7, pnp.pi / 2])
     @pytest.mark.parametrize("cost_fn, expected_res, expected_grad", cost_fns)
     def test_grad_tf(self, x, cost_fn, expected_res, expected_grad, tol):
         """Test gradients are correct for tf"""
@@ -378,7 +378,7 @@ class TestGradient:
     @pytest.mark.parametrize("cost_fn, expected_res, expected_grad", cost_fns)
     def test_broadcast_autograd(self, cost_fn, expected_res, expected_grad, tol):
         """Test gradients are correct for a broadcasted input for autograd"""
-        x = np.array([0.0, 1e-7, 0.456, np.pi / 2 - 1e-7, np.pi / 2])
+        x = pnp.array([0.0, 1e-7, 0.456, pnp.pi / 2 - 1e-7, pnp.pi / 2])
         res = cost_fn(x)
         grad = qml.math.diag(qml.jacobian(cost_fn)(x))
 
@@ -389,7 +389,7 @@ class TestGradient:
     @pytest.mark.parametrize("cost_fn, expected_res, expected_grad", cost_fns)
     def test_broadcast_jax(self, cost_fn, expected_res, expected_grad, tol):
         """Test gradients are correct for a broadcasted input for jax"""
-        x = jnp.array([0.0, 1e-7, 0.456, np.pi / 2 - 1e-7, np.pi / 2])
+        x = jnp.array([0.0, 1e-7, 0.456, pnp.pi / 2 - 1e-7, pnp.pi / 2])
         res = cost_fn(x)
         grad = qml.math.diag(jax.jacobian(cost_fn)(x))
 
@@ -400,7 +400,7 @@ class TestGradient:
     @pytest.mark.parametrize("cost_fn, expected_res, expected_grad", cost_fns)
     def test_broadcast_jax_jit(self, cost_fn, expected_res, expected_grad, tol):
         """Test gradients are correct for a broadcasted input for jax-jit"""
-        x = jnp.array([0.0, 1e-7, 0.456, np.pi / 2 - 1e-7, np.pi / 2])
+        x = jnp.array([0.0, 1e-7, 0.456, pnp.pi / 2 - 1e-7, pnp.pi / 2])
 
         jitted_cost = jax.jit(cost_fn)
         res = jitted_cost(x)
@@ -414,7 +414,7 @@ class TestGradient:
     def test_broadcast_torch(self, cost_fn, expected_res, expected_grad, tol):
         """Test gradients are correct for a broadcasted input for torch"""
         x = torch.from_numpy(
-            np.array([0.0, 1e-7, 0.456, np.pi / 2 - 1e-7, np.pi / 2])
+            pnp.array([0.0, 1e-7, 0.456, pnp.pi / 2 - 1e-7, pnp.pi / 2])
         ).requires_grad_()
 
         res = cost_fn(x)
@@ -428,7 +428,7 @@ class TestGradient:
     def test_broadcast_tf(self, cost_fn, expected_res, expected_grad, tol):
         """Test gradients are correct for a broadcasted input for tf"""
         x = tf.Variable(
-            [0.0, 1e-7, 0.456, np.pi / 2 - 1e-7, np.pi / 2], trainable=True, dtype="float64"
+            [0.0, 1e-7, 0.456, pnp.pi / 2 - 1e-7, pnp.pi / 2], trainable=True, dtype="float64"
         )
 
         with tf.GradientTape() as tape:

--- a/tests/math/test_functions.py
+++ b/tests/math/test_functions.py
@@ -24,7 +24,7 @@ from autograd.numpy.numpy_boxes import ArrayBox
 
 import pennylane as qml
 from pennylane import math as fn
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 
 pytestmark = pytest.mark.all_interfaces
 
@@ -62,7 +62,7 @@ class TestGetMultiTensorbox:
         """Test that a warning is raised if the sequence of tensors contains
         both tensorflow and autograd tensors."""
         x = tf.Variable([1.0, 2.0, 3.0])
-        y = np.array([0.5, 0.1])
+        y = pnp.array([0.5, 0.1])
 
         with pytest.warns(UserWarning, match="Consider replacing Autograd with vanilla NumPy"):
             fn.get_interface(x, y)
@@ -71,7 +71,7 @@ class TestGetMultiTensorbox:
         """Test that a warning is raised if the sequence of tensors contains
         both torch and autograd tensors."""
         x = torch.tensor([1.0, 2.0, 3.0])
-        y = np.array([0.5, 0.1])
+        y = pnp.array([0.5, 0.1])
 
         with pytest.warns(UserWarning, match="Consider replacing Autograd with vanilla NumPy"):
             fn.get_interface(x, y)
@@ -80,7 +80,7 @@ class TestGetMultiTensorbox:
         """Test that a warning is raised if the sequence of tensors contains
         both jax and autograd tensors."""
         x = jnp.array([1.0, 2.0, 3.0])
-        y = np.array([0.5, 0.1])
+        y = pnp.array([0.5, 0.1])
 
         with pytest.warns(UserWarning, match="Consider replacing Autograd with vanilla NumPy"):
             fn.get_interface(x, y)
@@ -90,7 +90,7 @@ class TestGetMultiTensorbox:
         """Test that no warning is raised if the sequence of tensors contains
         SciPy sparse matrices and autograd tensors."""
         x = sci.sparse.eye(3)
-        y = np.array([0.5, 0.1])
+        y = pnp.array([0.5, 0.1])
 
         fn.get_interface(x, y)
 
@@ -112,7 +112,7 @@ class TestGetMultiTensorbox:
 
     def test_return_autograd_box(self):
         """Test that autograd is correctly identified as the dispatching library."""
-        x = np.array([1.0, 2.0, 3.0])
+        x = pnp.array([1.0, 2.0, 3.0])
         y = [0.5, 0.1]
 
         res = fn.get_interface(y, x)
@@ -139,14 +139,14 @@ class TestGetMultiTensorbox:
         assert fn.get_deep_interface([()]) == "numpy"
         assert fn.get_deep_interface(([1, 2], [3, 4])) == "numpy"
         assert fn.get_deep_interface([[jnp.array(1.1)]]) == "jax"
-        assert fn.get_deep_interface([[np.array(1.3, requires_grad=False)]]) == "autograd"
+        assert fn.get_deep_interface([[pnp.array(1.3, requires_grad=False)]]) == "autograd"
 
 
 test_abs_data = [
     (1, -2, 3 + 4j),
     [1, -2, 3 + 4j],
     onp.array([1, -2, 3 + 4j]),
-    np.array([1, -2, 3 + 4j]),
+    pnp.array([1, -2, 3 + 4j]),
     torch.tensor([1, -2, 3 + 4j], dtype=torch.complex128),
     tf.Variable([1, -2, 3 + 4j], dtype=tf.complex128),
     tf.constant([1, -2, 3 + 4j], dtype=tf.complex128),
@@ -165,7 +165,7 @@ test_data = [
     (1, 2, 3),
     [1, 2, 3],
     onp.array([1, 2, 3]),
-    np.array([1, 2, 3]),
+    pnp.array([1, 2, 3]),
     torch.tensor([1, 2, 3]),
     tf.Variable([1, 2, 3]),
     tf.constant([1, 2, 3]),
@@ -175,7 +175,7 @@ unequal_test_data = [
     (2, 2, 3),
     [1, 21, 3],
     onp.array([1, 2, 39]),
-    np.array([1, 2, 4]),
+    pnp.array([1, 2, 4]),
     torch.tensor([1, 20, 3]),
     tf.Variable([2, 21, 3]),
     tf.constant([2, 1, 3]),
@@ -205,7 +205,7 @@ test_all_vectors = [
 
 
 @pytest.mark.parametrize(
-    "array_fn", [tuple, list, onp.array, np.array, torch.tensor, tf.Variable, tf.constant]
+    "array_fn", [tuple, list, onp.array, pnp.array, torch.tensor, tf.Variable, tf.constant]
 )
 @pytest.mark.parametrize("t1, expected", test_all_vectors)
 def test_all(array_fn, t1, expected):
@@ -223,7 +223,7 @@ test_any_vectors = [
 
 
 @pytest.mark.parametrize(
-    "array_fn", [tuple, list, onp.array, np.array, torch.tensor, tf.Variable, tf.constant]
+    "array_fn", [tuple, list, onp.array, pnp.array, torch.tensor, tf.Variable, tf.constant]
 )
 @pytest.mark.parametrize("t1, expected", test_any_vectors)
 def test_any(array_fn, t1, expected):
@@ -258,7 +258,7 @@ test_angle_data = [
     [1.0, 1.0j, 1 + 1j],
     [1.0, 1.0j, 1 + 1j],
     onp.array([1.0, 1.0j, 1 + 1j]),
-    np.array([1.0, 1.0j, 1 + 1j]),
+    pnp.array([1.0, 1.0j, 1 + 1j]),
     torch.tensor([1.0, 1.0j, 1 + 1j], dtype=torch.complex128),
     tf.Variable([1.0, 1.0j, 1 + 1j], dtype=tf.complex128),
     tf.constant([1.0, 1.0j, 1 + 1j], dtype=tf.complex128),
@@ -270,14 +270,14 @@ def test_angle(t):
     """Test that the angle function works for a variety
     of input"""
     res = fn.angle(t)
-    assert fn.allequal(res, [0, np.pi / 2, np.pi / 4])
+    assert fn.allequal(res, [0, pnp.pi / 2, pnp.pi / 4])
 
 
 test_arcsin_data = [
     (1, 0.2, -0.5),
     [1, 0.2, -0.5],
     onp.array([1, 0.2, -0.5]),
-    np.array([1, 0.2, -0.5]),
+    pnp.array([1, 0.2, -0.5]),
     torch.tensor([1, 0.2, -0.5], dtype=torch.float64),
     tf.Variable([1, 0.2, -0.5], dtype=tf.float64),
     tf.constant([1, 0.2, -0.5], dtype=tf.float64),
@@ -289,13 +289,13 @@ def test_arcsin(t):
     """Test that the arcsin function works for a variety
     of input"""
     res = fn.arcsin(t)
-    assert fn.allequal(res, np.arcsin([1, 0.2, -0.5]))
+    assert fn.allequal(res, pnp.arcsin([1, 0.2, -0.5]))
 
 
 test_conj_data = [
     [1.0, 1.0j, 1 + 1j],
     onp.array([1.0, 1.0j, 1 + 1j]),
-    np.array([1.0, 1.0j, 1 + 1j]),
+    pnp.array([1.0, 1.0j, 1 + 1j]),
     jnp.array([1.0, 1.0j, 1 + 1j]),
     torch.tensor([1.0, 1.0j, 1 + 1j], dtype=torch.complex128),
     tf.Variable([1.0, 1.0j, 1 + 1j], dtype=tf.complex128),
@@ -307,7 +307,7 @@ test_conj_data = [
 def test_conj(t):
     """Test the qml.math.conj function."""
     res = fn.conj(t)
-    assert fn.allequal(res, np.conj(t))
+    assert fn.allequal(res, pnp.conj(t))
 
 
 class TestCast:
@@ -379,14 +379,14 @@ cast_like_test_data = [
     (1, 2, 3),
     [1, 2, 3],
     onp.array([1, 2, 3], dtype=onp.int64),
-    np.array([1, 2, 3], dtype=np.int64),
+    pnp.array([1, 2, 3], dtype=pnp.int64),
     torch.tensor([1, 2, 3], dtype=torch.int64),
     tf.Variable([1, 2, 3], dtype=tf.int64),
     tf.constant([1, 2, 3], dtype=tf.int64),
     (1.0, 2.0, 3.0),
     [1.0, 2.0, 3.0],
     onp.array([1, 2, 3], dtype=onp.float64),
-    np.array([1, 2, 3], dtype=np.float64),
+    pnp.array([1, 2, 3], dtype=pnp.float64),
     torch.tensor([1, 2, 3], dtype=torch.float64),
     tf.Variable([1, 2, 3], dtype=tf.float64),
     tf.constant([1, 2, 3], dtype=tf.float64),
@@ -416,12 +416,12 @@ class TestConcatenate:
         """Test that concatenate, called without the axis arguments,
         concatenates across the 0th dimension"""
         t1 = [0.6, 0.1, 0.6]
-        t2 = np.array([0.1, 0.2, 0.3])
+        t2 = pnp.array([0.1, 0.2, 0.3])
         t3 = onp.array([5.0, 8.0, 101.0])
 
         res = fn.concatenate([t1, t2, t3])
-        assert isinstance(res, np.ndarray)
-        assert np.all(res == np.concatenate([t1, t2, t3]))
+        assert isinstance(res, pnp.ndarray)
+        assert pnp.all(res == pnp.concatenate([t1, t2, t3]))
 
     def test_concatenate_jax(self):
         """Test that concatenate, called without the axis arguments,
@@ -442,18 +442,18 @@ class TestConcatenate:
 
         res = fn.concatenate([t1, t2, t3])
         assert isinstance(res, tf.Tensor)
-        assert np.all(res.numpy() == np.concatenate([t1.numpy(), t2.numpy(), t3]))
+        assert pnp.all(res.numpy() == pnp.concatenate([t1.numpy(), t2.numpy(), t3]))
 
     def test_concatenate_torch(self):
         """Test that concatenate, called without the axis arguments,
         concatenates across the 0th dimension"""
-        t1 = onp.array([5.0, 8.0, 101.0], dtype=np.float64)
+        t1 = onp.array([5.0, 8.0, 101.0], dtype=pnp.float64)
         t2 = torch.tensor([0.6, 0.1, 0.6], dtype=torch.float64)
         t3 = torch.tensor([0.1, 0.2, 0.3], dtype=torch.float64)
 
         res = fn.concatenate([t1, t2, t3])
         assert isinstance(res, torch.Tensor)
-        assert np.all(res.numpy() == np.concatenate([t1, t2.numpy(), t3.numpy()]))
+        assert pnp.all(res.numpy() == pnp.concatenate([t1, t2.numpy(), t3.numpy()]))
 
     @pytest.mark.parametrize(
         "t1", [onp.array([[1], [2]]), torch.tensor([[1], [2]]), tf.constant([[1], [2]])]
@@ -468,7 +468,7 @@ class TestConcatenate:
         if hasattr(res, "numpy"):
             res = res.numpy()
 
-        assert fn.allclose(res, np.array([[1, 3], [2, 4]]))
+        assert fn.allclose(res, pnp.array([[1, 3], [2, 4]]))
         assert list(res.shape) == [2, 2]
 
     @pytest.mark.parametrize(
@@ -483,7 +483,7 @@ class TestConcatenate:
         if hasattr(res, "numpy"):
             res = res.numpy()
 
-        assert fn.allclose(res, np.array([1, 2, 5]))
+        assert fn.allclose(res, pnp.array([1, 2, 5]))
         assert list(res.shape) == [3]
 
 
@@ -503,9 +503,9 @@ class TestConvertLike:
             t2 = t2.numpy()
 
         assert fn.allequal(res, t1)
-        assert isinstance(res, np.ndarray if isinstance(t2, (list, tuple)) else t2.__class__)
+        assert isinstance(res, pnp.ndarray if isinstance(t2, (list, tuple)) else t2.__class__)
 
-    @pytest.mark.parametrize("t_like", [np.array([1]), tf.constant([1]), torch.tensor([1])])
+    @pytest.mark.parametrize("t_like", [pnp.array([1]), tf.constant([1]), torch.tensor([1])])
     def test_convert_scalar(self, t_like):
         """Test that a python scalar is converted to a scalar tensor"""
         res = fn.convert_like(5, t_like)
@@ -519,7 +519,7 @@ class TestDot:
 
     scalar_product_data = [
         [2, 6],
-        [np.array(2), np.array(6)],
+        [pnp.array(2), pnp.array(6)],
         [torch.tensor(2), onp.array(6)],
         [torch.tensor(2), torch.tensor(6)],
         [tf.Variable(2), onp.array(6)],
@@ -536,7 +536,7 @@ class TestDot:
 
     vector_product_data = [
         [[1, 2, 3], [1, 2, 3]],
-        [np.array([1, 2, 3]), np.array([1, 2, 3])],
+        [pnp.array([1, 2, 3]), pnp.array([1, 2, 3])],
         [torch.tensor([1, 2, 3]), onp.array([1, 2, 3])],
         [torch.tensor([1, 2, 3]), torch.tensor([1, 2, 3])],
         [tf.Variable([1, 2, 3]), onp.array([1, 2, 3])],
@@ -553,7 +553,7 @@ class TestDot:
 
     matrix_vector_product_data = [
         [[[1, 2], [3, 4]], [6, 7]],
-        [np.array([[1, 2], [3, 4]]), np.array([6, 7])],
+        [pnp.array([[1, 2], [3, 4]]), pnp.array([6, 7])],
         [torch.tensor([[1, 2], [3, 4]]), onp.array([6, 7])],
         [torch.tensor([[1, 2], [3, 4]]), torch.tensor([6, 7])],
         [tf.Variable([[1, 2], [3, 4]]), onp.array([6, 7])],
@@ -579,7 +579,7 @@ class TestDot:
     def test_matrix_matrix_product(self, t1, t2):
         """Test that the matrix-matrix dot product of two vectors results in a matrix"""
         res = fn.dot(t1, t1)
-        assert fn.allequal(res, np.array([[7, 10], [15, 22]]))
+        assert fn.allequal(res, pnp.array([[7, 10], [15, 22]]))
         res = fn.dot(t2, t2)
         assert fn.allequal(res, 85)
 
@@ -599,8 +599,8 @@ class TestDot:
 
     multidim_product_data = [
         [
-            np.array([[[1, 2], [3, 4], [-1, 1]], [[5, 6], [0, -1], [2, 1]]]),
-            np.array([[[1, 1], [3, 3]], [[3, 1], [3, 2]]]),
+            pnp.array([[[1, 2], [3, 4], [-1, 1]], [[5, 6], [0, -1], [2, 1]]]),
+            pnp.array([[[1, 1], [3, 3]], [[3, 1], [3, 2]]]),
         ],
         [
             torch.tensor([[[1, 2], [3, 4], [-1, 1]], [[5, 6], [0, -1], [2, 1]]]),
@@ -633,7 +633,7 @@ class TestDot:
         """Test that the multi-dimensional dot product reduces across the last dimension of the first
         tensor, and the second-to-last dimension of the second tensor."""
         res = fn.dot(t1, t2)
-        expected = np.array(
+        expected = pnp.array(
             [
                 [[[7, 7], [9, 5]], [[15, 15], [21, 11]], [[2, 2], [0, 1]]],
                 [[[23, 23], [33, 17]], [[-3, -3], [-3, -2]], [[5, 5], [9, 4]]],
@@ -649,8 +649,8 @@ class TestTensordotTorch:
 
     v1 = torch.tensor([0.1, 0.5, -0.9, 1.0, -4.2, 0.1], dtype=torch.float64)
     v2 = torch.tensor([4.3, -1.2, 8.2, 0.6, -4.2, -11.0], dtype=torch.float64)
-    _arange = np.arange(0, 54).reshape((9, 6)).astype(np.float64)
-    _shuffled_arange = np.array(
+    _arange = pnp.arange(0, 54).reshape((9, 6)).astype(pnp.float64)
+    _shuffled_arange = pnp.array(
         [
             [42.0, 43.0, 44.0, 45.0, 46.0, 47.0],
             [6.0, 7.0, 8.0, 9.0, 10.0, 11.0],
@@ -662,15 +662,15 @@ class TestTensordotTorch:
             [18.0, 19.0, 20.0, 21.0, 22.0, 23.0],
             [36.0, 37.0, 38.0, 39.0, 40.0, 41.0],
         ],
-        dtype=np.float64,
+        dtype=pnp.float64,
     )
     M1 = torch.tensor(_arange)
     M2 = torch.tensor(_shuffled_arange)
-    T1 = np.arange(0, 3 * 6 * 9 * 2).reshape((3, 6, 9, 2)).astype(np.float64)
-    T1 = torch.tensor(np.array([T1[1], T1[0], T1[2]]), dtype=torch.float64)
+    T1 = pnp.arange(0, 3 * 6 * 9 * 2).reshape((3, 6, 9, 2)).astype(pnp.float64)
+    T1 = torch.tensor(pnp.array([T1[1], T1[0], T1[2]]), dtype=torch.float64)
 
     v1_dot_v2 = 9.59
-    v1_outer_v2 = np.array(
+    v1_outer_v2 = pnp.array(
         [
             [0.43, -0.12, 0.82, 0.06, -0.42, -1.1],
             [2.15, -0.6, 4.1, 0.3, -2.1, -5.5],
@@ -679,7 +679,7 @@ class TestTensordotTorch:
             [-18.06, 5.04, -34.44, -2.52, 17.64, 46.2],
             [0.43, -0.12, 0.82, 0.06, -0.42, -1.1],
         ],
-        dtype=np.float64,
+        dtype=pnp.float64,
     )
 
     M1_dot_v1 = torch.tensor(
@@ -871,11 +871,11 @@ class TestTensordotTorch:
 class TestTensordotDifferentiability:
     """Test the differentiability of qml.math.tensordot."""
 
-    v0 = np.array([0.1, 5.3, -0.9, 1.1])
-    v1 = np.array([0.5, -1.7, -2.9, 0.0])
-    v2 = np.array([-0.4, 9.1, 1.6])
+    v0 = pnp.array([0.1, 5.3, -0.9, 1.1])
+    v1 = pnp.array([0.5, -1.7, -2.9, 0.0])
+    v2 = pnp.array([-0.4, 9.1, 1.6])
     exp_shapes = ((len(v0), len(v2), len(v0)), (len(v0), len(v2), len(v2)))
-    exp_jacs = (np.zeros(exp_shapes[0]), np.zeros(exp_shapes[1]))
+    exp_jacs = (pnp.zeros(exp_shapes[0]), pnp.zeros(exp_shapes[1]))
     for i in range(len(v0)):
         exp_jacs[0][i, :, i] = v2
     for i in range(len(v2)):
@@ -883,9 +883,9 @@ class TestTensordotDifferentiability:
 
     def test_autograd(self):
         """Tests differentiability of tensordot with Autograd."""
-        v0 = np.array(self.v0, requires_grad=True)
-        v1 = np.array(self.v1, requires_grad=True)
-        v2 = np.array(self.v2, requires_grad=True)
+        v0 = pnp.array(self.v0, requires_grad=True)
+        v1 = pnp.array(self.v1, requires_grad=True)
+        v2 = pnp.array(self.v2, requires_grad=True)
 
         # Test inner product
         jac = qml.jacobian(partial(fn.tensordot, axes=[0, 0]), argnum=(0, 1))(v0, v1)
@@ -974,17 +974,17 @@ class TestExpandDims:
         if not shape:
             pytest.skip("Cannot expand the dimensions of a Python scalar!")
 
-        t1 = np.empty(shape).tolist()
+        t1 = pnp.empty(shape).tolist()
         t2 = fn.expand_dims(t1, axis=axis)
         assert t2.shape == new_shape
 
     def test_expand_dims_array(self, shape, axis, new_shape):
         """Test that expand_dimensions works correctly
         when given an array"""
-        t1 = np.empty(shape)
+        t1 = pnp.empty(shape)
         t2 = fn.expand_dims(t1, axis=axis)
         assert t2.shape == new_shape
-        assert isinstance(t2, np.ndarray)
+        assert isinstance(t2, pnp.ndarray)
 
     def test_expand_dims_torch(self, shape, axis, new_shape):
         """Test that the expand dimensions works correctly
@@ -1007,7 +1007,7 @@ interface_test_data = [
     [(1, 2, 3), "numpy"],
     [[1, 2, 3], "numpy"],
     [onp.array([1, 2, 3]), "numpy"],
-    [np.array([1, 2, 3]), "autograd"],
+    [pnp.array([1, 2, 3]), "autograd"],
     [torch.tensor([1, 2, 3]), "torch"],
     [tf.Variable([1, 2, 3]), "tensorflow"],
     [tf.constant([1, 2, 3]), "tensorflow"],
@@ -1046,7 +1046,7 @@ def test_numpy(t):
 def test_numpy_arraybox(t):
     """Test that the to_numpy method correctly converts the input
     ArrayBox into a NumPy array."""
-    val = np.array(5.0)
+    val = pnp.array(5.0)
     t = ArrayBox(val, None, None)
     res = fn.to_numpy(t)
     assert res == val
@@ -1087,7 +1087,7 @@ class TestOnesLike:
 
         assert res.shape == t.shape
         assert fn.get_interface(res) == fn.get_interface(t)
-        assert fn.allclose(res, np.ones(t.shape))
+        assert fn.allclose(res, pnp.ones(t.shape))
 
         # if tensorflow or pytorch, extract view of underlying data
         if hasattr(res, "numpy"):
@@ -1100,21 +1100,21 @@ class TestOnesLike:
     def test_ones_like_explicit_dtype(self, t):
         """Test that the ones like function creates the correct
         shape and type tensor."""
-        res = fn.ones_like(t, dtype=np.float16)
+        res = fn.ones_like(t, dtype=pnp.float16)
 
         if isinstance(t, (list, tuple)):
             t = onp.asarray(t)
 
         assert res.shape == t.shape
         assert fn.get_interface(res) == fn.get_interface(t)
-        assert fn.allclose(res, np.ones(t.shape))
+        assert fn.allclose(res, pnp.ones(t.shape))
 
         # if tensorflow or pytorch, extract view of underlying data
         if hasattr(res, "numpy"):
             res = res.numpy()
             t = t.numpy()
 
-        assert onp.asarray(res).dtype.type is np.float16
+        assert onp.asarray(res).dtype.type is pnp.float16
 
 
 class TestRequiresGrad:
@@ -1172,10 +1172,10 @@ class TestRequiresGrad:
 
     def test_autograd(self):
         """Autograd arrays will simply return their requires_grad attribute"""
-        t = np.array([1.0, 2.0], requires_grad=True)
+        t = pnp.array([1.0, 2.0], requires_grad=True)
         assert fn.requires_grad(t)
 
-        t = np.array([1.0, 2.0], requires_grad=False)
+        t = pnp.array([1.0, 2.0], requires_grad=False)
         assert not fn.requires_grad(t)
 
     def test_autograd_backwards(self):
@@ -1185,10 +1185,10 @@ class TestRequiresGrad:
         def cost_fn(t, s):
             nonlocal res
             res = [fn.requires_grad(t), fn.requires_grad(s)]
-            return np.sum(t * s)
+            return pnp.sum(t * s)
 
-        t = np.array([1.0, 2.0, 3.0])
-        s = np.array([-2.0, -3.0, -4.0])
+        t = pnp.array([1.0, 2.0, 3.0])
+        s = pnp.array([-2.0, -3.0, -4.0])
 
         qml.grad(cost_fn)(t, s)
         assert res == [True, True]
@@ -1273,10 +1273,10 @@ class TestInBackprop:
         def cost_fn(t, s):
             nonlocal res
             res = [fn.in_backprop(t), fn.in_backprop(s)]
-            return np.sum(t * s)
+            return pnp.sum(t * s)
 
-        t = np.array([1.0, 2.0, 3.0], requires_grad=True)
-        s = np.array([-2.0, -3.0, -4.0], requires_grad=True)
+        t = pnp.array([1.0, 2.0, 3.0], requires_grad=True)
+        s = pnp.array([-2.0, -3.0, -4.0], requires_grad=True)
 
         qml.grad(cost_fn)(t, s)
         assert res == [True, True]
@@ -1364,8 +1364,8 @@ shape_test_data = [
 @pytest.mark.parametrize(
     "interface,create_array",
     [
-        ("sequence", lambda shape: np.empty(shape).tolist()),
-        ("autograd", np.empty),
+        ("sequence", lambda shape: pnp.empty(shape).tolist()),
+        ("autograd", pnp.empty),
         ("torch", torch.empty),
         ("jax", jnp.ones),
         ("tf", tf.ones),
@@ -1396,8 +1396,8 @@ def test_shape_and_ndim_deep(interface):
         (onp.array(0.5), "float64"),
         (onp.array(1.0, dtype="float32"), "float32"),
         (ArrayBox(1, "a", "b"), "int64"),
-        (np.array(0.5), "float64"),
-        (np.array(0.5, dtype="complex64"), "complex64"),
+        (pnp.array(0.5), "float64"),
+        (pnp.array(0.5, dtype="complex64"), "complex64"),
         # skip jax as output is dependent on global configuration
         (tf.Variable(0.1, dtype="float32"), "float32"),
         (tf.Variable(0.1, dtype="float64"), "float64"),
@@ -1416,7 +1416,7 @@ def test_sqrt(t):
     """Test that the square root function works for a variety
     of input"""
     res = fn.sqrt(t)
-    assert fn.allclose(res, [1, np.sqrt(2), np.sqrt(3)])
+    assert fn.allclose(res, [1, pnp.sqrt(2), pnp.sqrt(3)])
 
 
 class TestStack:
@@ -1425,12 +1425,12 @@ class TestStack:
     def test_stack_array(self):
         """Test that stack, called without the axis arguments, stacks vertically"""
         t1 = [0.6, 0.1, 0.6]
-        t2 = np.array([0.1, 0.2, 0.3])
+        t2 = pnp.array([0.1, 0.2, 0.3])
         t3 = onp.array([5.0, 8.0, 101.0])
 
         res = fn.stack([t1, t2, t3])
-        assert isinstance(res, np.ndarray)
-        assert np.all(res == np.stack([t1, t2, t3]))
+        assert isinstance(res, pnp.ndarray)
+        assert pnp.all(res == pnp.stack([t1, t2, t3]))
 
     def test_stack_array_jax(self):
         """Test that stack, called without the axis arguments, stacks vertically"""
@@ -1439,7 +1439,7 @@ class TestStack:
         t3 = jnp.array([5.0, 8.0, 101.0])
 
         res = fn.stack([t1, t2, t3])
-        assert np.all(res == np.stack([t1, t2, t3]))
+        assert pnp.all(res == pnp.stack([t1, t2, t3]))
 
     def test_stack_tensorflow(self):
         """Test that stack, called without the axis arguments, stacks vertically"""
@@ -1449,17 +1449,17 @@ class TestStack:
 
         res = fn.stack([t1, t2, t3])
         assert isinstance(res, tf.Tensor)
-        assert np.all(res.numpy() == np.stack([t1.numpy(), t2.numpy(), t3]))
+        assert pnp.all(res.numpy() == pnp.stack([t1.numpy(), t2.numpy(), t3]))
 
     def test_stack_torch(self):
         """Test that stack, called without the axis arguments, stacks vertically"""
-        t1 = onp.array([5.0, 8.0, 101.0], dtype=np.float64)
+        t1 = onp.array([5.0, 8.0, 101.0], dtype=pnp.float64)
         t2 = torch.tensor([0.6, 0.1, 0.6], dtype=torch.float64)
         t3 = torch.tensor([0.1, 0.2, 0.3], dtype=torch.float64)
 
         res = fn.stack([t1, t2, t3])
         assert isinstance(res, torch.Tensor)
-        assert np.all(res.numpy() == np.stack([t1, t2.numpy(), t3.numpy()]))
+        assert pnp.all(res.numpy() == pnp.stack([t1, t2.numpy(), t3.numpy()]))
 
     @pytest.mark.parametrize("t1", [onp.array([1, 2]), torch.tensor([1, 2]), tf.constant([1, 2])])
     def test_stack_axis(self, t1):
@@ -1472,7 +1472,7 @@ class TestStack:
         if hasattr(res, "numpy"):
             res = res.numpy()
 
-        assert fn.allclose(res, np.array([[1, 3], [2, 4]]))
+        assert fn.allclose(res, pnp.array([[1, 3], [2, 4]]))
         assert list(res.shape) == [2, 2]
 
 
@@ -1481,9 +1481,9 @@ class TestSum:
 
     def test_array(self):
         """Test that sum, called without the axis arguments, returns a scalar"""
-        t = np.array([[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]])
+        t = pnp.array([[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]])
         res = fn.sum(t)
-        assert isinstance(res, np.ndarray)
+        assert isinstance(res, pnp.ndarray)
         assert fn.allclose(res, 2.1)
 
     def test_tensorflow(self):
@@ -1509,7 +1509,7 @@ class TestSum:
     @pytest.mark.parametrize(
         "t1",
         [
-            np.array([[[1, 2], [3, 4], [-1, 1]], [[5, 6], [0, -1], [2, 1]]]),
+            pnp.array([[[1, 2], [3, 4], [-1, 1]], [[5, 6], [0, -1], [2, 1]]]),
             torch.tensor([[[1, 2], [3, 4], [-1, 1]], [[5, 6], [0, -1], [2, 1]]]),
             tf.constant([[[1, 2], [3, 4], [-1, 1]], [[5, 6], [0, -1], [2, 1]]]),
             jnp.array([[[1, 2], [3, 4], [-1, 1]], [[5, 6], [0, -1], [2, 1]]]),
@@ -1524,13 +1524,13 @@ class TestSum:
         if hasattr(res, "numpy"):
             res = res.numpy()
 
-        assert fn.allclose(res, np.array([14, 6, 3]))
+        assert fn.allclose(res, pnp.array([14, 6, 3]))
         assert res.shape == (3,)
 
     @pytest.mark.parametrize(
         "t1",
         [
-            np.array([[[1, 2], [3, 4], [-1, 1]], [[5, 6], [0, -1], [2, 1]]]),
+            pnp.array([[[1, 2], [3, 4], [-1, 1]], [[5, 6], [0, -1], [2, 1]]]),
             torch.tensor([[[1, 2], [3, 4], [-1, 1]], [[5, 6], [0, -1], [2, 1]]]),
             tf.constant([[[1, 2], [3, 4], [-1, 1]], [[5, 6], [0, -1], [2, 1]]]),
             jnp.array([[[1, 2], [3, 4], [-1, 1]], [[5, 6], [0, -1], [2, 1]]]),
@@ -1545,7 +1545,7 @@ class TestSum:
         if hasattr(res, "numpy"):
             res = res.numpy()
 
-        assert fn.allclose(res, np.array([[[14], [6], [3]]]))
+        assert fn.allclose(res, pnp.array([[[14], [6], [3]]]))
         assert res.shape == (1, 3, 1)
 
 
@@ -1564,14 +1564,14 @@ def test_T(t):
         res = res.numpy()
         t = t.numpy()
 
-    assert np.all(res.T == t.T)
+    assert pnp.all(res.T == t.T)
 
 
 class TestTake:
     """Tests for the qml.take function"""
 
     take_data = [
-        np.array([[[1, 2], [3, 4], [-1, 1]], [[5, 6], [0, -1], [2, 1]]]),
+        pnp.array([[[1, 2], [3, 4], [-1, 1]], [[5, 6], [0, -1], [2, 1]]]),
         torch.tensor([[[1, 2], [3, 4], [-1, 1]], [[5, 6], [0, -1], [2, 1]]]),
         onp.array([[[1, 2], [3, 4], [-1, 1]], [[5, 6], [0, -1], [2, 1]]]),
         tf.constant([[[1, 2], [3, 4], [-1, 1]], [[5, 6], [0, -1], [2, 1]]]),
@@ -1598,14 +1598,14 @@ class TestTake:
     def test_array_indexing_autograd(self):
         """Test that indexing with a sequence properly extracts
         the elements from the flattened tensor"""
-        t = np.array([[[1, 2], [3, 4], [-1, 1]], [[5, 6], [0, -1], [2, 1]]], dtype=np.float64)
+        t = pnp.array([[[1, 2], [3, 4], [-1, 1]], [[5, 6], [0, -1], [2, 1]]], dtype=pnp.float64)
         indices = [0, 2, 3, 6, -2]
 
         def cost_fn(t):
-            return np.sum(fn.take(t, indices))
+            return pnp.sum(fn.take(t, indices))
 
         grad = qml.grad(cost_fn)(t)
-        expected = np.array([[[1, 0], [1, 1], [0, 0]], [[1, 0], [0, 0], [1, 0]]])
+        expected = pnp.array([[[1, 0], [1, 1], [0, 0]], [[1, 0], [0, 0], [1, 0]]])
         assert fn.allclose(grad, expected)
 
     @pytest.mark.parametrize("t", take_data)
@@ -1622,7 +1622,7 @@ class TestTake:
         the elements from the specified tensor axis"""
         indices = [0, 1, -2]
         res = fn.take(t, indices, axis=2)
-        expected = np.array(
+        expected = pnp.array(
             [[[1, 2, 1], [3, 4, 3], [-1, 1, -1]], [[5, 6, 5], [0, -1, 0], [2, 1, 2]]]
         )
         assert fn.allclose(res, expected)
@@ -1631,9 +1631,9 @@ class TestTake:
     def test_multidimensional_indexing_along_axis(self, t):
         """Test that indexing with a sequence properly extracts
         the elements from the specified tensor axis"""
-        indices = np.array([[0, 0], [1, 0]])
+        indices = pnp.array([[0, 0], [1, 0]])
         res = fn.take(t, indices, axis=1)
-        expected = np.array(
+        expected = pnp.array(
             [[[[1, 2], [1, 2]], [[3, 4], [1, 2]]], [[[5, 6], [5, 6]], [[0, -1], [5, 6]]]]
         )
         assert fn.allclose(res, expected)
@@ -1641,31 +1641,31 @@ class TestTake:
     def test_multidimensional_indexing_along_axis_autograd(self):
         """Test that indexing with a sequence properly extracts
         the elements from the specified tensor axis"""
-        t = np.array([[[1, 2], [3, 4], [-1, 1]], [[5, 6], [0, -1], [2, 1]]], dtype=np.float64)
-        indices = np.array([[0, 0], [1, 0]])
+        t = pnp.array([[[1, 2], [3, 4], [-1, 1]], [[5, 6], [0, -1], [2, 1]]], dtype=pnp.float64)
+        indices = pnp.array([[0, 0], [1, 0]])
 
         def cost_fn(t):
             return fn.sum(fn.take(t, indices, axis=1))
 
         res = cost_fn(t)
-        expected = np.sum(
-            np.array([[[[1, 2], [1, 2]], [[3, 4], [1, 2]]], [[[5, 6], [5, 6]], [[0, -1], [5, 6]]]])
+        expected = pnp.sum(
+            pnp.array([[[[1, 2], [1, 2]], [[3, 4], [1, 2]]], [[[5, 6], [5, 6]], [[0, -1], [5, 6]]]])
         )
         assert fn.allclose(res, expected)
 
         grad = qml.grad(cost_fn)(t)
-        expected = np.array([[[3, 3], [1, 1], [0, 0]], [[3, 3], [1, 1], [0, 0]]])
+        expected = pnp.array([[[3, 3], [1, 1], [0, 0]], [[3, 3], [1, 1], [0, 0]]])
         assert fn.allclose(grad, expected)
 
     @pytest.mark.torch
     def test_last_axis_support_torch(self):
         """Test that _torch_take correctly sets the last axis"""
         x = fn.arange(8, like="torch").reshape((2, 4))
-        assert np.array_equal(fn.take(x, indices=3, axis=-1), [3, 7])
+        assert pnp.array_equal(fn.take(x, indices=3, axis=-1), [3, 7])
 
 
 where_data = [
-    np.array([[[1, 2], [3, 4], [-1, 1]], [[5, 6], [0, -1], [2, 1]]]),
+    pnp.array([[[1, 2], [3, 4], [-1, 1]], [[5, 6], [0, -1], [2, 1]]]),
     torch.tensor([[[1, 2], [3, 4], [-1, 1]], [[5, 6], [0, -1], [2, 1]]]),
     onp.array([[[1, 2], [3, 4], [-1, 1]], [[5, 6], [0, -1], [2, 1]]]),
     tf.constant([[[1, 2], [3, 4], [-1, 1]], [[5, 6], [0, -1], [2, 1]]]),
@@ -1679,7 +1679,7 @@ def test_where(t):
     """Test that the qml.math.where function works as expected"""
     # With output values
     res = fn.where(t < 0, 100 * fn.ones_like(t), t)
-    expected = np.array([[[1, 2], [3, 4], [100, 1]], [[5, 6], [0, 100], [2, 1]]])
+    expected = pnp.array([[[1, 2], [3, 4], [100, 1]], [[5, 6], [0, 100], [2, 1]]])
     assert fn.allclose(res, expected)
 
     # Without output values
@@ -1693,7 +1693,7 @@ def test_where(t):
 
 
 squeeze_data = [
-    np.ones((1, 2, 3, 1, 5, 1)),
+    pnp.ones((1, 2, 3, 1, 5, 1)),
     torch.ones((1, 2, 3, 1, 5, 1)),
     tf.ones((1, 2, 3, 1, 5, 1)),
     jnp.ones((1, 2, 3, 1, 5, 1)),
@@ -1711,7 +1711,7 @@ def test_squeeze(t):
 class TestScatterElementAdd:
     """Tests for the scatter_element_add function"""
 
-    x = onp.ones((2, 3), dtype=np.float64)
+    x = onp.ones((2, 3), dtype=pnp.float64)
     y = onp.array(0.56)
     index = [1, 2]
     expected_val = onp.array([[1.0, 1.0, 1.0], [1.0, 1.0, 1.3136]])
@@ -1722,14 +1722,14 @@ class TestScatterElementAdd:
 
     def test_array(self):
         """Test that a NumPy array is differentiable when using scatter addition"""
-        x = np.array(self.x, requires_grad=True)
-        y = np.array(self.y, requires_grad=True)
+        x = pnp.array(self.x, requires_grad=True)
+        y = pnp.array(self.y, requires_grad=True)
 
         def cost(*weights):
             return fn.scatter_element_add(weights[0], self.index, weights[1] ** 2)
 
         res = cost(x, y)
-        assert isinstance(res, np.ndarray)
+        assert isinstance(res, pnp.ndarray)
         assert fn.allclose(res, self.expected_val)
 
         def grab_cost_entry(*weights):
@@ -1743,14 +1743,14 @@ class TestScatterElementAdd:
     def test_array_multi(self):
         """Test that a NumPy array and the addend are differentiable when using
         scatter addition (multi dispatch)."""
-        x = np.array(self.x, requires_grad=True)
-        y = np.array(self.y, requires_grad=True)
+        x = pnp.array(self.x, requires_grad=True)
+        y = pnp.array(self.y, requires_grad=True)
 
         def cost_multi(weight_0, weight_1):
             return fn.scatter_element_add(weight_0, self.index, weight_1**2)
 
         res = cost_multi(x, y)
-        assert isinstance(res, np.ndarray)
+        assert isinstance(res, pnp.ndarray)
         assert fn.allclose(res, self.expected_val)
 
         jac = qml.jacobian(cost_multi)(x, y)
@@ -1760,14 +1760,14 @@ class TestScatterElementAdd:
     def test_array_batch(self):
         """Test that a NumPy array and the addend are differentiable when using
         scatter addition (multi dispatch)."""
-        x = np.ones((2, 3), requires_grad=True)
-        y = np.array([0.56, 0.3], requires_grad=True)
+        x = pnp.ones((2, 3), requires_grad=True)
+        y = pnp.array([0.56, 0.3], requires_grad=True)
 
         def cost_multi(weight_0, weight_1):
             return fn.scatter_element_add(weight_0, [(0, 1), (1, 2)], weight_1**2)
 
         res = cost_multi(x, y)
-        assert isinstance(res, np.ndarray)
+        assert isinstance(res, pnp.ndarray)
         assert fn.allclose(res, onp.array([[1.0, 1.3136, 1.0], [1.0, 1.0, 1.09]]))
 
         jac = qml.jacobian(cost_multi)(x, y)
@@ -1850,7 +1850,7 @@ class TestScatterElementAddMultiValue:
     """Tests for the scatter_element_add function when adding
     multiple values at multiple positions."""
 
-    x = onp.ones((2, 3), dtype=np.float64)
+    x = onp.ones((2, 3), dtype=pnp.float64)
     y = onp.array(0.56)
     indices = [[1, 0], [2, 1]]
     expected_val = onp.array([[1.0, 1.3136, 1.0], [1.0, 1.0, 1.27636]])
@@ -1860,8 +1860,8 @@ class TestScatterElementAddMultiValue:
     def test_array(self):
         """Test that a NumPy array is differentiable when using scatter addition
         with multiple values."""
-        x = np.array(self.x, requires_grad=True)
-        y = np.array(self.y, requires_grad=True)
+        x = pnp.array(self.x, requires_grad=True)
+        y = pnp.array(self.y, requires_grad=True)
 
         def cost(*weights):
             return fn.scatter_element_add(
@@ -1869,7 +1869,7 @@ class TestScatterElementAddMultiValue:
             )
 
         res = cost(x, y)
-        assert isinstance(res, np.ndarray)
+        assert isinstance(res, pnp.ndarray)
         assert fn.allclose(res, self.expected_val)
 
         def add_cost_entries(*weights):
@@ -1960,7 +1960,7 @@ class TestDiag:
     @pytest.mark.parametrize(
         "a, interface",
         [
-            [np.array(0.5), "autograd"],
+            [pnp.array(0.5), "autograd"],
             [tf.Variable(0.5), "tensorflow"],
             [torch.tensor(0.5), "torch"],
         ],
@@ -1976,9 +1976,9 @@ class TestDiag:
     def test_array(self):
         """Test that a NumPy array is automatically converted into
         a diagonal tensor"""
-        t = np.array([0.1, 0.2, 0.3])
+        t = pnp.array([0.1, 0.2, 0.3])
         res = fn.diag(t)
-        assert isinstance(res, np.ndarray)
+        assert isinstance(res, pnp.ndarray)
         assert fn.allclose(res, onp.diag([0.1, 0.2, 0.3]))
 
         res = fn.diag(t, k=1)
@@ -2050,12 +2050,12 @@ class TestCovMatrix:
     def expected_cov(weights):
         """Analytic covariance matrix for ansatz and obs_list"""
         a, b, c = weights
-        return np.array(
+        return pnp.array(
             [
-                [np.sin(b) ** 2, -np.cos(a) * np.sin(b) ** 2 * np.sin(c)],
+                [pnp.sin(b) ** 2, -pnp.cos(a) * pnp.sin(b) ** 2 * pnp.sin(c)],
                 [
-                    -np.cos(a) * np.sin(b) ** 2 * np.sin(c),
-                    1 - np.cos(a) ** 2 * np.cos(b) ** 2 * np.sin(c) ** 2,
+                    -pnp.cos(a) * pnp.sin(b) ** 2 * pnp.sin(c),
+                    1 - pnp.cos(a) ** 2 * pnp.cos(b) ** 2 * pnp.sin(c) ** 2,
                 ],
             ]
         )
@@ -2064,11 +2064,11 @@ class TestCovMatrix:
     def expected_grad(weights):
         """Analytic covariance matrix gradient for ansatz and obs_list"""
         a, b, c = weights
-        return np.array(
+        return pnp.array(
             [
-                np.sin(a) * np.sin(b) ** 2 * np.sin(c),
-                -2 * np.cos(a) * np.cos(b) * np.sin(b) * np.sin(c),
-                -np.cos(a) * np.cos(c) * np.sin(b) ** 2,
+                pnp.sin(a) * pnp.sin(b) ** 2 * pnp.sin(c),
+                -2 * pnp.cos(a) * pnp.cos(b) * pnp.sin(b) * pnp.sin(c),
+                -pnp.cos(a) * pnp.cos(c) * pnp.sin(b) ** 2,
             ]
         )
 
@@ -2093,10 +2093,10 @@ class TestCovMatrix:
             probs = circuit(weights)
             return fn.cov_matrix(probs, obs_list, wires=dev.wires)
 
-        weights = np.array([0.1, 0.2, 0.3])
+        weights = pnp.array([0.1, 0.2, 0.3])
         res = cov(weights)
         expected = self.expected_cov(weights)
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
         def grab_cov_entry(weights):
             """Grab an entry of the cov output."""
@@ -2105,7 +2105,7 @@ class TestCovMatrix:
         grad_fn = qml.grad(grab_cov_entry)
         res = grad_fn(weights)
         expected = self.expected_grad(weights)
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
     def test_autograd(self, tol):
         """Test that the covariance matrix computes the correct
@@ -2127,10 +2127,10 @@ class TestCovMatrix:
             probs = circuit(weights)
             return fn.cov_matrix(probs, self.obs_list)
 
-        weights = np.array([0.1, 0.2, 0.3])
+        weights = pnp.array([0.1, 0.2, 0.3])
         res = cov(weights)
         expected = self.expected_cov(weights)
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
         def grab_cov_entry(weights):
             """Grab an entry of the cov output."""
@@ -2139,7 +2139,7 @@ class TestCovMatrix:
         grad_fn = qml.grad(grab_cov_entry)
         res = grad_fn(weights)
         expected = self.expected_grad(weights)
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
     def test_torch(self, tol):
         """Test that the covariance matrix computes the correct
@@ -2157,18 +2157,18 @@ class TestCovMatrix:
 
             return qml.probs(wires=[0, 1, 2])
 
-        weights = np.array([0.1, 0.2, 0.3])
+        weights = pnp.array([0.1, 0.2, 0.3])
         weights_t = torch.tensor(weights, requires_grad=True)
         probs = circuit(weights_t)
         res = fn.cov_matrix(probs, self.obs_list)
         expected = self.expected_cov(weights)
-        assert np.allclose(res.detach().numpy(), expected, atol=tol, rtol=0)
+        assert pnp.allclose(res.detach().numpy(), expected, atol=tol, rtol=0)
 
         loss = res[0, 1]
         loss.backward()
         res = weights_t.grad
         expected = self.expected_grad(weights)
-        assert np.allclose(res.detach().numpy(), expected, atol=tol, rtol=0)
+        assert pnp.allclose(res.detach().numpy(), expected, atol=tol, rtol=0)
 
     def test_tf(self, tol):
         """Test that the covariance matrix computes the correct
@@ -2186,7 +2186,7 @@ class TestCovMatrix:
 
             return qml.probs(wires=[0, 1, 2])
 
-        weights = np.array([0.1, 0.2, 0.3])
+        weights = pnp.array([0.1, 0.2, 0.3])
         weights_t = tf.Variable(weights)
 
         with tf.GradientTape() as tape:
@@ -2195,11 +2195,11 @@ class TestCovMatrix:
             loss = cov[0, 1]
 
         expected = self.expected_cov(weights)
-        assert np.allclose(cov, expected, atol=tol, rtol=0)
+        assert pnp.allclose(cov, expected, atol=tol, rtol=0)
 
         grad = tape.gradient(loss, weights_t)
         expected = self.expected_grad(weights)
-        assert np.allclose(grad, expected, atol=tol, rtol=0)
+        assert pnp.allclose(grad, expected, atol=tol, rtol=0)
 
     @pytest.mark.slow
     def test_jax(self, tol):
@@ -2240,7 +2240,7 @@ class TestCovMatrix:
 block_diag_data = [
     [onp.array([[1, 2], [3, 4]]), torch.tensor([[1, 2], [-1, -6]]), torch.tensor([[5]])],
     [onp.array([[1, 2], [3, 4]]), tf.Variable([[1, 2], [-1, -6]]), tf.constant([[5]])],
-    [np.array([[1, 2], [3, 4]]), np.array([[1, 2], [-1, -6]]), np.array([[5]])],
+    [pnp.array([[1, 2], [3, 4]]), pnp.array([[1, 2], [-1, -6]]), pnp.array([[5]])],
     [jnp.array([[1, 2], [3, 4]]), jnp.array([[1, 2], [-1, -6]]), jnp.array([[5]])],
 ]
 
@@ -2249,7 +2249,7 @@ block_diag_data = [
 def test_block_diag(tensors):
     """Tests for the block diagonal function"""
     res = fn.block_diag(tensors)
-    expected = np.array(
+    expected = pnp.array(
         [[1, 2, 0, 0, 0], [3, 4, 0, 0, 0], [0, 0, 1, 2, 0], [0, 0, -1, -6, 0], [0, 0, 0, 0, 5]]
     )
     assert fn.allclose(res, expected)
@@ -2280,12 +2280,12 @@ class TestBlockDiagDiffability:
         def f(x, y):
             return fn.block_diag(
                 [
-                    np.array([[fn.cos(x * y)]]),
-                    np.array([[x, 1.2 * y], [x**2 - y / 3, -x / y]]),
+                    pnp.array([[fn.cos(x * y)]]),
+                    pnp.array([[x, 1.2 * y], [x**2 - y / 3, -x / y]]),
                 ]
             )
 
-        x, y = np.array([0.2, 1.5], requires_grad=True)
+        x, y = pnp.array([0.2, 1.5], requires_grad=True)
         res = qml.jacobian(f)(x, y)
         exp = self.expected(x, y)
         assert fn.allclose(res[0], exp[0])
@@ -2314,9 +2314,9 @@ class TestBlockDiagDiffability:
         with tf.GradientTape() as tape:
             out = fn.block_diag([x, y])
         res = tape.jacobian(out, (x, y))
-        exp_0 = np.zeros((3, 3, 1, 1))
+        exp_0 = pnp.zeros((3, 3, 1, 1))
         exp_0[0, 0, 0, 0] = 1.0
-        exp_1 = np.zeros((3, 3, 2, 2))
+        exp_1 = pnp.zeros((3, 3, 2, 2))
         exp_1[1, 1, 0, 0] = exp_1[1, 2, 0, 1] = exp_1[2, 1, 1, 0] = exp_1[2, 2, 1, 1] = 1.0
         assert fn.allclose(exp_0, res[0])
         assert fn.allclose(exp_1, res[1])
@@ -2329,9 +2329,9 @@ class TestBlockDiagDiffability:
             return fn.block_diag([x, y])
 
         res = torch.autograd.functional.jacobian(f, (x, y))
-        exp_0 = np.zeros((3, 3, 1, 1))
+        exp_0 = pnp.zeros((3, 3, 1, 1))
         exp_0[0, 0, 0, 0] = 1.0
-        exp_1 = np.zeros((3, 3, 2, 2))
+        exp_1 = pnp.zeros((3, 3, 2, 2))
         exp_1[1, 1, 0, 0] = exp_1[1, 2, 0, 1] = exp_1[2, 1, 1, 0] = exp_1[2, 2, 1, 1] = 1.0
         assert fn.allclose(exp_0, res[0])
         assert fn.allclose(exp_1, res[1])
@@ -2341,7 +2341,7 @@ gather_data = [
     torch.tensor([[1, 2, 3], [-1, -6, -3]]),
     tf.Variable([[1, 2, 3], [-1, -6, -3]]),
     jnp.array([[1, 2, 3], [-1, -6, -3]]),
-    np.array([[1, 2, 3], [-1, -6, -3]]),
+    pnp.array([[1, 2, 3], [-1, -6, -3]]),
 ]
 
 
@@ -2350,7 +2350,7 @@ def test_gather(tensor):
     """Tests for the gather function"""
     indices = [1, 0]
     res = fn.gather(tensor, indices)
-    expected = np.array([[-1, -6, -3], [1, 2, 3]])
+    expected = pnp.array([[-1, -6, -3], [1, 2, 3]])
     assert fn.allclose(res, expected)
 
 
@@ -2359,7 +2359,7 @@ class TestCoercion:
 
     def test_tensorflow_coercion(self):
         """Test tensorflow coercion"""
-        tensors = [tf.Variable([0.2]), np.array([1, 2, 3]), tf.constant(1 + 3j, dtype=tf.complex64)]
+        tensors = [tf.Variable([0.2]), pnp.array([1, 2, 3]), tf.constant(1 + 3j, dtype=tf.complex64)]
         res = qml.math.coerce(tensors, like="tensorflow")
         dtypes = [r.dtype for r in res]
         assert all(d is tf.complex64 for d in dtypes)
@@ -2368,7 +2368,7 @@ class TestCoercion:
         """Test Torch coercion"""
         tensors = [
             torch.tensor([0.2]),
-            np.array([1, 2, 3]),
+            pnp.array([1, 2, 3]),
             torch.tensor(1 + 3j, dtype=torch.complex64),
         ]
         res = qml.math.coerce(tensors, like="torch")
@@ -2384,7 +2384,7 @@ class TestCoercion:
 
         tensors = [
             torch.tensor([0.2], device="cpu"),
-            np.array([1, 2, 3]),
+            pnp.array([1, 2, 3]),
             torch.tensor(1 + 3j, dtype=torch.complex64, device="cuda"),
         ]
 
@@ -2406,8 +2406,8 @@ class TestUnwrap:
             tf.constant([0.5, 0.2]),
         ]
         res = qml.math.unwrap(values)
-        expected = [np.array([0.1, 0.2]), 0.1, np.array([0.5, 0.2])]
-        assert all(np.allclose(a, b) for a, b in zip(res, expected))
+        expected = [pnp.array([0.1, 0.2]), 0.1, pnp.array([0.5, 0.2])]
+        assert all(pnp.allclose(a, b) for a, b in zip(res, expected))
 
     def test_torch_unwrapping(self):
         """Test that a sequence of Torch values is properly unwrapped"""
@@ -2417,8 +2417,8 @@ class TestUnwrap:
             torch.tensor([0.5, 0.2]),
         ]
         res = qml.math.unwrap(values)
-        expected = [np.array([0.1, 0.2]), 0.1, np.array([0.5, 0.2])]
-        assert all(np.allclose(a, b) for a, b in zip(res, expected))
+        expected = [pnp.array([0.1, 0.2]), 0.1, pnp.array([0.5, 0.2])]
+        assert all(pnp.allclose(a, b) for a, b in zip(res, expected))
 
     def test_autograd_unwrapping_forward(self):
         """Test that a sequence of Autograd values is properly unwrapped
@@ -2429,14 +2429,14 @@ class TestUnwrap:
         def cost_fn(params):
             nonlocal unwrapped_params
             unwrapped_params = qml.math.unwrap(params)
-            return np.sum(np.sin(params[0] * params[2])) + params[1]
+            return pnp.sum(pnp.sin(params[0] * params[2])) + params[1]
 
-        values = [onp.array([0.1, 0.2]), np.tensor(0.1, dtype=np.float64), np.tensor([0.5, 0.2])]
+        values = [onp.array([0.1, 0.2]), pnp.tensor(0.1, dtype=pnp.float64), pnp.tensor([0.5, 0.2])]
         cost_fn(values)
 
-        expected = [np.array([0.1, 0.2]), 0.1, np.array([0.5, 0.2])]
-        assert all(np.allclose(a, b) for a, b in zip(unwrapped_params, expected))
-        assert all(not isinstance(a, np.tensor) for a in unwrapped_params)
+        expected = [pnp.array([0.1, 0.2]), 0.1, pnp.array([0.5, 0.2])]
+        assert all(pnp.allclose(a, b) for a, b in zip(unwrapped_params, expected))
+        assert all(not isinstance(a, pnp.tensor) for a in unwrapped_params)
 
     def test_autograd_unwrapping_backward(self):
         """Test that a sequence of Autograd values is properly unwrapped
@@ -2447,17 +2447,17 @@ class TestUnwrap:
         def cost_fn(*params):
             nonlocal unwrapped_params
             unwrapped_params = qml.math.unwrap(params)
-            return np.sum(np.sin(params[0] * params[2])) + params[1]
+            return pnp.sum(pnp.sin(params[0] * params[2])) + params[1]
 
         values = [
             onp.array([0.1, 0.2]),
-            np.tensor(0.1, dtype=np.float64, requires_grad=True),
-            np.tensor([0.5, 0.2], requires_grad=True),
+            pnp.tensor(0.1, dtype=pnp.float64, requires_grad=True),
+            pnp.tensor([0.5, 0.2], requires_grad=True),
         ]
         _ = qml.grad(cost_fn, argnum=[1, 2])(*values)
 
-        expected = [np.array([0.1, 0.2]), 0.1, np.array([0.5, 0.2])]
-        assert all(np.allclose(a, b) for a, b in zip(unwrapped_params, expected))
+        expected = [pnp.array([0.1, 0.2]), 0.1, pnp.array([0.5, 0.2])]
+        assert all(pnp.allclose(a, b) for a, b in zip(unwrapped_params, expected))
         assert not any(isinstance(a, ArrayBox) for a in unwrapped_params)
 
     def test_autograd_unwrapping_backward_nested(self):
@@ -2469,13 +2469,13 @@ class TestUnwrap:
         def cost_fn(p, max_depth=None):
             nonlocal unwrapped_params
             unwrapped_params = qml.math.unwrap(p, max_depth)
-            return np.sum(np.sin(np.prod(p)))
+            return pnp.sum(pnp.sin(pnp.prod(p)))
 
-        values = np.tensor([0.1, 0.2, 0.3])
+        values = pnp.tensor([0.1, 0.2, 0.3])
         _ = qml.jacobian(qml.grad(cost_fn))(values)
 
-        expected = np.array([0.1, 0.2, 0.3])
-        assert np.allclose(unwrapped_params, expected)
+        expected = pnp.array([0.1, 0.2, 0.3])
+        assert pnp.allclose(unwrapped_params, expected)
         assert not isinstance(unwrapped_params, ArrayBox)
 
         # Specifying max_depth=1 will result in the second backward
@@ -2492,14 +2492,14 @@ class TestUnwrap:
         def cost_fn(params):
             nonlocal unwrapped_params
             unwrapped_params = qml.math.unwrap(params)
-            return np.sum(np.sin(params[0])) + params[2]
+            return pnp.sum(pnp.sin(params[0])) + params[2]
 
-        values = [jnp.array([0.1, 0.2]), onp.array(0.1, dtype=np.float64), jnp.array([0.5, 0.2])]
+        values = [jnp.array([0.1, 0.2]), onp.array(0.1, dtype=pnp.float64), jnp.array([0.5, 0.2])]
         cost_fn(values)
 
-        expected = [np.array([0.1, 0.2]), 0.1, np.array([0.5, 0.2])]
-        assert all(np.allclose(a, b) for a, b in zip(unwrapped_params, expected))
-        assert all(not isinstance(a, np.tensor) for a in unwrapped_params)
+        expected = [pnp.array([0.1, 0.2]), 0.1, pnp.array([0.5, 0.2])]
+        assert all(pnp.allclose(a, b) for a, b in zip(unwrapped_params, expected))
+        assert all(not isinstance(a, pnp.tensor) for a in unwrapped_params)
 
 
 class TestGetTrainable:
@@ -2550,9 +2550,9 @@ class TestGetTrainable:
         def cost_fn(params):
             nonlocal res
             res = qml.math.get_trainable_indices(params)
-            return np.sum(np.sin(params[0] * params[2])) + params[1]
+            return pnp.sum(pnp.sin(params[0] * params[2])) + params[1]
 
-        values = [[0.1, 0.2], np.tensor(0.1, requires_grad=True), np.tensor([0.5, 0.2])]
+        values = [[0.1, 0.2], pnp.tensor(0.1, requires_grad=True), pnp.tensor([0.5, 0.2])]
         cost_fn(values)
 
         assert res == {1, 2}
@@ -2565,12 +2565,12 @@ class TestGetTrainable:
         def cost_fn(*params):
             nonlocal res
             res = qml.math.get_trainable_indices(params)
-            return np.sum(np.sin(params[0] * params[2])) + params[1]
+            return pnp.sum(pnp.sin(params[0] * params[2])) + params[1]
 
         values = [
-            np.array([0.1, 0.2]),
-            np.tensor(0.1, requires_grad=True),
-            np.tensor([0.5, 0.2], requires_grad=False),
+            pnp.array([0.1, 0.2]),
+            pnp.tensor(0.1, requires_grad=True),
+            pnp.tensor([0.5, 0.2], requires_grad=False),
         ]
         _ = qml.grad(cost_fn)(*values)
 
@@ -2580,7 +2580,7 @@ class TestGetTrainable:
 test_sort_data = [
     ([1, 3, 4, 2], [1, 2, 3, 4]),
     (onp.array([1, 3, 4, 2]), onp.array([1, 2, 3, 4])),
-    (np.array([1, 3, 4, 2]), np.array([1, 2, 3, 4])),
+    (pnp.array([1, 3, 4, 2]), pnp.array([1, 2, 3, 4])),
     (jnp.array([1, 3, 4, 2]), jnp.array([1, 2, 3, 4])),
     (torch.tensor([1, 3, 4, 2]), torch.tensor([1, 2, 3, 4])),
     (tf.Variable([1, 3, 4, 2]), tf.Variable([1, 2, 3, 4])),
@@ -2610,11 +2610,11 @@ class TestExpm:
         """Computes expm via taylor expansion."""
         if self._compare_mat is None:
             mat = qml.RX.compute_matrix(0.3)
-            out = np.eye(2, dtype=complex)
+            out = pnp.eye(2, dtype=complex)
             coeff = 1
             for i in range(1, 8):
                 coeff *= i
-                out += np.linalg.matrix_power(mat, i) / coeff
+                out += pnp.linalg.matrix_power(mat, i) / coeff
 
             self._compare_mat = out
 
@@ -2664,13 +2664,13 @@ class TestFft:
     """Test qml.math.fft functions and their differentiability."""
 
     arg = {
-        "fft": onp.sin(onp.linspace(0, np.pi, 5)) - onp.cos(onp.linspace(0, np.pi, 5)) / 2,
-        "ifft": onp.linspace(0, np.pi, 5),
+        "fft": onp.sin(onp.linspace(0, pnp.pi, 5)) - onp.cos(onp.linspace(0, pnp.pi, 5)) / 2,
+        "ifft": onp.linspace(0, pnp.pi, 5),
         "fft2": onp.outer(
-            0.4 * onp.sin(onp.linspace(0, onp.pi, 3)), np.cos(onp.linspace(onp.pi, 0, 2)) / 2
+            0.4 * onp.sin(onp.linspace(0, onp.pi, 3)), pnp.cos(onp.linspace(onp.pi, 0, 2)) / 2
         ),
         "ifft2": onp.outer(
-            0.4 * onp.sin(onp.linspace(0, onp.pi, 3)), np.cos(onp.linspace(onp.pi, 0, 2)) / 2
+            0.4 * onp.sin(onp.linspace(0, onp.pi, 3)), pnp.cos(onp.linspace(onp.pi, 0, 2)) / 2
         ),
     }
 
@@ -2807,7 +2807,7 @@ class TestFft:
     def test_autograd(self, name):
         """Test that the functions are available in Autograd."""
         func = getattr(qml.math.fft, name)
-        arg = np.array(self.arg[name], requires_grad=True)
+        arg = pnp.array(self.arg[name], requires_grad=True)
         out = func(arg)
         assert qml.math.allclose(out, self.exp_fft[name])
         jac_real = qml.jacobian(self.fft_real)(arg, func=func)
@@ -2872,7 +2872,7 @@ class TestIfft2Tensorflow:
     def test_casting(self, dtype_in, exp_dtype_out):
         """Test that qml.math.fft.ifft2 casts real-valued inputs correctly to the
         corresponding complex values."""
-        x = onp.outer([0, np.pi / 2, np.pi], [0, np.pi])
+        x = onp.outer([0, pnp.pi / 2, pnp.pi], [0, pnp.pi])
         x = tf.Variable(x, dtype=dtype_in)
         out = qml.math.fft.ifft2(x)
         assert out.dtype == exp_dtype_out
@@ -2897,7 +2897,7 @@ class TestSetIndex:
         original array, with the value at the specified index updated"""
 
         array2 = qml.math.set_index(array, (1, 1), 3)
-        assert qml.math.allclose(array2, np.array([[0, 0], [0, 3]]))
+        assert qml.math.allclose(array2, pnp.array([[0, 0], [0, 3]]))
         # since idx and val have no interface, we expect the returned array type to match initial type
         assert isinstance(array2, type(array))
 
@@ -2907,13 +2907,13 @@ class TestSetIndex:
         original array, with the value at the specified index updated"""
 
         array2 = qml.math.set_index(array, 3, 3)
-        assert qml.math.allclose(array2, np.array([[0, 0, 0, 3]]))
+        assert qml.math.allclose(array2, pnp.array([[0, 0, 0, 3]]))
         # since idx and val have no interface, we expect the returned array type to match initial type
         assert isinstance(array2, type(array))
 
     @pytest.mark.parametrize(
         "array",
-        [jnp.array([[1, 2], [3, 4]]), onp.array([[1, 2], [3, 4]]), np.array([[1, 2], [3, 4]])],
+        [jnp.array([[1, 2], [3, 4]]), onp.array([[1, 2], [3, 4]]), pnp.array([[1, 2], [3, 4]])],
     )
     def test_set_index_with_val_tracer(self, array):
         """Test that for both jax and numpy arrays, if the val to set is a tracer,
@@ -2933,7 +2933,7 @@ class TestSetIndex:
 
     @pytest.mark.parametrize(
         "array",
-        [jnp.array([[1, 2], [3, 4]]), onp.array([[1, 2], [3, 4]]), np.array([[1, 2], [3, 4]])],
+        [jnp.array([[1, 2], [3, 4]]), onp.array([[1, 2], [3, 4]]), pnp.array([[1, 2], [3, 4]])],
     )
     def test_set_index_with_idx_tracer_2D_array(self, array):
         """Test that for both jax and numpy 2d arrays, if the idx to set is a tracer,
@@ -2952,7 +2952,7 @@ class TestSetIndex:
         assert isinstance(array2, jnp.ndarray)
 
     @pytest.mark.parametrize(
-        "array", [jnp.array([1, 2, 3, 4]), onp.array([1, 2, 3, 4]), np.array([1, 2, 3, 4])]
+        "array", [jnp.array([1, 2, 3, 4]), onp.array([1, 2, 3, 4]), pnp.array([1, 2, 3, 4])]
     )
     def test_set_index_with_idx_tracer_1D_array(self, array):
         """Test that for both jax and numpy 1d arrays, if the idx to set is a tracer,

--- a/tests/math/test_multi_dispatch.py
+++ b/tests/math/test_multi_dispatch.py
@@ -21,7 +21,7 @@ from autoray import numpy as anp
 
 from pennylane import grad as qml_grad
 from pennylane import math as fn
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 
 pytestmark = pytest.mark.all_interfaces
 
@@ -35,7 +35,7 @@ test_multi_dispatch_stack_data = [
     ([1.0, 0.0], [2.0, 3.0]),
     onp.array([[1.0, 0.0], [2.0, 3.0]]),
     anp.array([[1.0, 0.0], [2.0, 3.0]]),
-    np.array([[1.0, 0.0], [2.0, 3.0]]),
+    pnp.array([[1.0, 0.0], [2.0, 3.0]]),
     jnp.array([[1.0, 0.0], [2.0, 3.0]]),
     tf.constant([[1.0, 0.0], [2.0, 3.0]]),
 ]
@@ -70,7 +70,7 @@ def test_multi_dispatch_decorate(x):
 
     @fn.multi_dispatch(argnum=[0], tensor_list=[0])
     def tensordot(x, like, axes=None):
-        return np.tensordot(x[0], x[1], axes=axes)
+        return pnp.tensordot(x[0], x[1], axes=axes)
 
     assert fn.allequal(tensordot(x, axes=(0, 0)).numpy(), 2)
 
@@ -80,7 +80,7 @@ test_data0 = [
     [1, 2, 3],
     onp.array([1, 2, 3]),
     anp.array([1, 2, 3]),
-    np.array([1, 2, 3]),
+    pnp.array([1, 2, 3]),
     torch.tensor([1, 2, 3]),
     jnp.array([1, 2, 3]),
     tf.constant([1, 2, 3]),
@@ -95,7 +95,7 @@ def test_multi_dispatch_decorate_argnum_none(t1, t2):
 
     @fn.multi_dispatch(argnum=None, tensor_list=None)
     def tensordot(tensor1, tensor2, like, axes=None):
-        return np.tensordot(tensor1, tensor2, axes=axes)
+        return pnp.tensordot(tensor1, tensor2, axes=axes)
 
     assert fn.allequal(tensordot(t1, t2, axes=(0, 0)).numpy(), 14)
 
@@ -103,7 +103,7 @@ def test_multi_dispatch_decorate_argnum_none(t1, t2):
 test_data_values = [
     [[1, 2, 3] for _ in range(5)],
     [(1, 2, 3) for _ in range(5)],
-    [np.array([1, 2, 3]) for _ in range(5)],
+    [pnp.array([1, 2, 3]) for _ in range(5)],
     [onp.array([1, 2, 3]) for _ in range(5)],
     [anp.array([1, 2, 3]) for _ in range(5)],
     [torch.tensor([1, 2, 3]) for _ in range(5)],
@@ -124,7 +124,7 @@ def test_multi_dispatch_decorate_non_dispatch(values):
         values is a list of vectors
         like can force the interface (optional)
         """
-        return coefficient * np.sum([fn.dot(v, v) for v in values])
+        return coefficient * pnp.sum([fn.dot(v, v) for v in values])
 
     assert fn.allequal(custom_function(values), 700)
 
@@ -144,14 +144,14 @@ def test_unwrap():
 
     assert out[0] == [2]
     assert out[1][0] == [3, 4]
-    assert fn.allclose(out[1][1], np.array([5, 6]))
+    assert fn.allclose(out[1][1], pnp.array([5, 6]))
     assert fn.get_interface(out[1][1]) == "numpy"
 
-    assert fn.allclose(out[2], np.array([-1.0, -2.0]))
+    assert fn.allclose(out[2], pnp.array([-1.0, -2.0]))
     assert fn.get_interface(out[2]) == "numpy"
 
     assert out[3][0] == 0.5
-    assert fn.allclose(out[3][1], np.array([6, 7]))
+    assert fn.allclose(out[3][1], pnp.array([6, 7]))
     assert fn.get_interface(out[3][1]) == "numpy"
 
     assert out[4] == 0.5
@@ -167,8 +167,8 @@ def test_unwrap():
         ),
         (
             0.1,
-            np.array([0.2, 0.3, 0.4]),
-            np.array([0.87941963, 0.90835799, 0.92757383]),
+            pnp.array([0.2, 0.3, 0.4]),
+            pnp.array([0.87941963, 0.90835799, 0.92757383]),
         ),
         (
             0.1,
@@ -181,16 +181,16 @@ def test_gammainc(n, t, gamma_ref):
     """Test that the lower incomplete Gamma function is computed correctly."""
     gamma = fn.gammainc(n, t)
 
-    assert np.allclose(gamma, gamma_ref)
+    assert pnp.allclose(gamma, gamma_ref)
 
 
 def test_dot_autograd():
 
-    x = np.array([1.0, 2.0], requires_grad=False)
-    y = np.array([2.0, 3.0], requires_grad=True)
+    x = pnp.array([1.0, 2.0], requires_grad=False)
+    y = pnp.array([2.0, 3.0], requires_grad=True)
 
     res = fn.dot(x, y)
-    assert isinstance(res, np.tensor)
+    assert isinstance(res, pnp.tensor)
     assert res.requires_grad
     assert fn.allclose(res, 8)
 
@@ -199,16 +199,16 @@ def test_dot_autograd():
 
 def test_dot_autograd_with_scalar():
 
-    x = np.array(1.0, requires_grad=False)
-    y = np.array([2.0, 3.0], requires_grad=True)
+    x = pnp.array(1.0, requires_grad=False)
+    y = pnp.array([2.0, 3.0], requires_grad=True)
 
     res = fn.dot(x, y)
-    assert isinstance(res, np.tensor)
+    assert isinstance(res, pnp.tensor)
     assert res.requires_grad
     assert fn.allclose(res, [2.0, 3.0])
 
     res = fn.dot(y, x)
-    assert isinstance(res, np.tensor)
+    assert isinstance(res, pnp.tensor)
     assert res.requires_grad
     assert fn.allclose(res, [2.0, 3.0])
 
@@ -244,7 +244,7 @@ def test_dot_torch_with_scalar():
 def test_kron():
     """Test the kronecker product function."""
     x = torch.tensor([[1, 2], [3, 4]])
-    y = np.array([[0, 5], [6, 7]])
+    y = pnp.array([[0, 5], [6, 7]])
 
     res = fn.kron(x, y)
     expected = torch.tensor([[0, 5, 0, 10], [6, 7, 12, 14], [0, 15, 0, 20], [18, 21, 24, 28]])
@@ -259,7 +259,7 @@ class TestMatmul:
         m2 = [[1, 2], [3, 4]]
         assert fn.allequal(fn.matmul(m1, m2), m2)
         assert fn.allequal(fn.matmul(m2, m1), m2)
-        assert fn.allequal(fn.matmul(m2, m2, like="torch"), np.matmul(m2, m2))
+        assert fn.allequal(fn.matmul(m2, m2, like="torch"), pnp.matmul(m2, m2))
         assert fn.allequal(fn.matmul(m1, m1), m1)
 
 
@@ -276,7 +276,7 @@ class TestDetach:
         """Test that detach works with Autograd."""
         import autograd
 
-        x = np.array(0.3, requires_grad=True)
+        x = pnp.array(0.3, requires_grad=True)
         assert fn.requires_grad(x) is True
         detached_x = fn.detach(x)
         assert fn.requires_grad(detached_x) is False
@@ -319,8 +319,8 @@ class TestDetach:
 @pytest.mark.all_interfaces
 class TestNorm:
     mats_intrf_norm = (
-        (np.array([0.5, -1, 2]), "numpy", np.array(2), {}),
-        (np.array([[5, 6], [-2, 3]]), "numpy", np.array(11), {}),
+        (pnp.array([0.5, -1, 2]), "numpy", pnp.array(2), {}),
+        (pnp.array([[5, 6], [-2, 3]]), "numpy", pnp.array(11), {}),
         (torch.tensor([0.5, -1, 2]), "torch", torch.tensor(2), {}),
         (torch.tensor([[5.0, 6.0], [-2.0, 3.0]]), "torch", torch.tensor(11), {"axis": (0, 1)}),
         (tf.Variable([0.5, -1, 2]), "tensorflow", tf.Variable(2), {}),
@@ -332,21 +332,21 @@ class TestNorm:
     @pytest.mark.parametrize("arr, expected_intrf, expected_norm, kwargs", mats_intrf_norm)
     def test_inf_norm(self, arr, expected_intrf, expected_norm, kwargs):
         """Test that inf norm is correct and works for each interface."""
-        computed_norm = fn.norm(arr, ord=np.inf, **kwargs)
-        assert np.allclose(computed_norm, expected_norm)
+        computed_norm = fn.norm(arr, ord=pnp.inf, **kwargs)
+        assert pnp.allclose(computed_norm, expected_norm)
         assert fn.get_interface(computed_norm) == expected_intrf
 
     @pytest.mark.parametrize(
         "arr",
         [
-            np.array([1.0, 2.0, 3.0, 4.0, 5.0]),
-            np.array(
+            pnp.array([1.0, 2.0, 3.0, 4.0, 5.0]),
+            pnp.array(
                 [
                     [[0.123, 0.456, 0.789], [-0.123, -0.456, -0.789]],
                     [[1.23, 4.56, 7.89], [-1.23, -4.56, -7.89]],
                 ]
             ),
-            np.array(
+            pnp.array(
                 [
                     [
                         [0.123 - 0.789j, 0.456 + 0.456j, 0.789 - 0.123j],
@@ -365,7 +365,7 @@ class TestNorm:
         when the order and axis are not specified."""
         norm = fn.norm(arr)
         expected_norm = onp.linalg.norm(arr)
-        assert np.isclose(norm, expected_norm)
+        assert pnp.isclose(norm, expected_norm)
 
         grad = qml_grad(fn.norm)(arr)
         expected_grad = (norm**-1) * arr.conj()
@@ -423,7 +423,7 @@ class TestSVD:
             recovered_matrix = fn.matmul(
                 fn.matmul(
                     results_svd[0],
-                    fn.diag(np.array(results_svd[1], dtype="complex128"), like=expected_intrf),
+                    fn.diag(pnp.array(results_svd[1], dtype="complex128"), like=expected_intrf),
                 ),
                 results_svd[2],
                 like=expected_intrf,
@@ -438,7 +438,7 @@ class TestSVD:
                 like=expected_intrf,
             )
 
-        assert np.allclose(mat, recovered_matrix, rtol=1e-04)
+        assert pnp.allclose(mat, recovered_matrix, rtol=1e-04)
 
     @pytest.mark.parametrize("mat, expected_intrf", mats_interface)
     @pytest.mark.parametrize(
@@ -451,5 +451,5 @@ class TestSVD:
         """Test that svd is correct and works for each interface. Asking only for singular values."""
         results_svd = fn.svd(mat, compute_uv=False)
 
-        assert np.allclose(results_svd, expected_results)
+        assert pnp.allclose(results_svd, expected_results)
         assert fn.get_interface(results_svd) == expected_intrf

--- a/tests/math/test_trace_distance_math.py
+++ b/tests/math/test_trace_distance_math.py
@@ -18,7 +18,7 @@ import numpy as onp
 import pytest
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 
 pytestmark = pytest.mark.all_interfaces
 
@@ -35,21 +35,21 @@ class TestTraceDistanceMath:
         (
             (
                 [[1, 0], [0, 0]],
-                qml.math.reduce_statevector([x, np.sqrt(1 - x**2)], indices=[0]),
+                qml.math.reduce_statevector([x, pnp.sqrt(1 - x**2)], indices=[0]),
             ),
-            np.sqrt(1 - x**2),
+            pnp.sqrt(1 - x**2),
         )
-        for x in np.linspace(0, 1, 10)
+        for x in pnp.linspace(0, 1, 10)
     ]
     state0_state1_td += [
         (
             (
                 [[0.5, 0.5], [0.5, 0.5]],
-                qml.math.reduce_statevector([x, np.sqrt(1 - x**2) * 1j], indices=[0]),
+                qml.math.reduce_statevector([x, pnp.sqrt(1 - x**2) * 1j], indices=[0]),
             ),
-            np.sqrt(2) / 2,
+            pnp.sqrt(2) / 2,
         )
-        for x in np.linspace(0, 1, 10)
+        for x in pnp.linspace(0, 1, 10)
     ]
     state0_state1_td.append(
         (
@@ -62,14 +62,14 @@ class TestTraceDistanceMath:
                     [0.25, 0.25, 0.25, 0.25],
                 ],
             ),
-            np.sqrt(2) / 2,
+            pnp.sqrt(2) / 2,
         )
     )
 
     array_funcs = [
         lambda x: x,
         onp.array,
-        np.array,
+        pnp.array,
         jnp.array,
         torch.tensor,
         tf.Variable,
@@ -102,7 +102,7 @@ class TestTraceDistanceMath:
                 ],
                 [[0.5, 0.5], [0.5, 0.5]],
             ),
-            [np.sqrt(2) / 2, 0.5, 1, 0],
+            [pnp.sqrt(2) / 2, 0.5, 1, 0],
         ),
         (
             (
@@ -123,7 +123,7 @@ class TestTraceDistanceMath:
                     [0.25, 0.25, 0.25, 0.25],
                 ],
             ),
-            [np.sqrt(2) / 2, 0, 0.75],
+            [pnp.sqrt(2) / 2, 0, 0.75],
         ),
         # Batch-Batch-TD
         (
@@ -161,7 +161,7 @@ class TestTraceDistanceMath:
                     [[0.5, 0, 0, 0.5], [0, 0, 0, 0], [0, 0, 0, 0], [0.5, 0, 0, 0.5]],
                 ],
             ),
-            [np.sqrt(2) / 2, np.sqrt(3) / 2, 1],
+            [pnp.sqrt(2) / 2, pnp.sqrt(3) / 2, 1],
         ),
     ]
 

--- a/tests/measurements/test_classical_shadow.py
+++ b/tests/measurements/test_classical_shadow.py
@@ -20,7 +20,7 @@ import autograd.numpy
 import pytest
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane.measurements import ClassicalShadowMP
 from pennylane.measurements.classical_shadow import ShadowExpvalMP
 
@@ -79,7 +79,7 @@ def get_y_basis_circuit(wires, shots, interface="autograd"):
     def circuit():
         for wire in range(wires):
             qml.Hadamard(wire)
-            qml.RZ(np.pi / 2, wire)
+            qml.RZ(pnp.pi / 2, wire)
         return qml.classical_shadow(wires=range(wires))
 
     return circuit
@@ -108,66 +108,66 @@ class TestProcessState:
     def test_shape_and_dtype(self):
         """Test that the shape and dtype of the measurement is correct"""
         mp = qml.classical_shadow(wires=[0, 1])
-        res = mp.process_state_with_shots(np.ones((2, 2)) / 2, qml.wires.Wires([0, 1]), shots=100)
+        res = mp.process_state_with_shots(pnp.ones((2, 2)) / 2, qml.wires.Wires([0, 1]), shots=100)
 
         assert res.shape == (2, 100, 2)
-        assert res.dtype == np.int8
+        assert res.dtype == pnp.int8
 
         # test that the bits are either 0 and 1
-        assert np.all(np.logical_or(res[0] == 0, res[0] == 1))
+        assert pnp.all(pnp.logical_or(res[0] == 0, res[0] == 1))
 
         # test that the recipes are either 0, 1, or 2 (X, Y, or Z)
-        assert np.all(np.logical_or(np.logical_or(res[1] == 0, res[1] == 1), res[1] == 2))
+        assert pnp.all(pnp.logical_or(pnp.logical_or(res[1] == 0, res[1] == 1), res[1] == 2))
 
     def test_wire_order(self):
         """Test that the wire order is respected"""
-        state = np.array([[1, 1], [0, 0]]) / np.sqrt(2)
+        state = pnp.array([[1, 1], [0, 0]]) / pnp.sqrt(2)
 
         mp = qml.classical_shadow(wires=[0, 1])
         res = mp.process_state_with_shots(state, qml.wires.Wires([0, 1]), shots=1000)
 
         assert res.shape == (2, 1000, 2)
-        assert res.dtype == np.int8
+        assert res.dtype == pnp.int8
 
         # test that the first qubit samples are all 0s when the recipe is Z
-        assert np.all(res[0][res[1, ..., 0] == 2][:, 0] == 0)
+        assert pnp.all(res[0][res[1, ..., 0] == 2][:, 0] == 0)
 
         # test that the second qubit samples contain 1s when the recipe is Z
-        assert np.any(res[0][res[1, ..., 1] == 2][:, 1] == 1)
+        assert pnp.any(res[0][res[1, ..., 1] == 2][:, 1] == 1)
 
         res = mp.process_state_with_shots(state, qml.wires.Wires([1, 0]), shots=1000)
 
         assert res.shape == (2, 1000, 2)
-        assert res.dtype == np.int8
+        assert res.dtype == pnp.int8
 
         # now test that the first qubit samples contain 1s when the recipe is Z
-        assert np.any(res[0][res[1, ..., 0] == 2][:, 0] == 1)
+        assert pnp.any(res[0][res[1, ..., 0] == 2][:, 0] == 1)
 
         # now test that the second qubit samples are all 0s when the recipe is Z
-        assert np.all(res[0][res[1, ..., 1] == 2][:, 1] == 0)
+        assert pnp.all(res[0][res[1, ..., 1] == 2][:, 1] == 0)
 
     def test_subset_wires(self):
         """Test that the measurement is correct when only a subset of wires is measured"""
         mp = qml.classical_shadow(wires=[0, 1])
 
         # GHZ state
-        state = np.zeros((2, 2, 2))
-        state[np.array([0, 1]), np.array([0, 1]), np.array([0, 1])] = 1 / np.sqrt(2)
+        state = pnp.zeros((2, 2, 2))
+        state[pnp.array([0, 1]), pnp.array([0, 1]), pnp.array([0, 1])] = 1 / pnp.sqrt(2)
 
         res = mp.process_state_with_shots(state, qml.wires.Wires([0, 1]), shots=100)
 
         assert res.shape == (2, 100, 2)
-        assert res.dtype == np.int8
+        assert res.dtype == pnp.int8
 
         # test that the bits are either 0 and 1
-        assert np.all(np.logical_or(res[0] == 0, res[0] == 1))
+        assert pnp.all(pnp.logical_or(res[0] == 0, res[0] == 1))
 
         # test that the recipes are either 0, 1, or 2 (X, Y, or Z)
-        assert np.all(np.logical_or(np.logical_or(res[1] == 0, res[1] == 1), res[1] == 2))
+        assert pnp.all(pnp.logical_or(pnp.logical_or(res[1] == 0, res[1] == 1), res[1] == 2))
 
     def test_same_rng(self):
         """Test results when the rng is the same"""
-        state = np.ones((2, 2)) / 2
+        state = pnp.ones((2, 2)) / 2
 
         mp1 = qml.classical_shadow(wires=[0, 1], seed=123)
         mp2 = qml.classical_shadow(wires=[0, 1], seed=123)
@@ -176,44 +176,44 @@ class TestProcessState:
         res2 = mp2.process_state_with_shots(state, qml.wires.Wires([0, 1]), shots=100)
 
         # test recipes are the same but bits are different
-        assert np.all(res1[1] == res2[1])
-        assert np.any(res1[0] != res2[0])
+        assert pnp.all(res1[1] == res2[1])
+        assert pnp.any(res1[0] != res2[0])
 
         res1 = mp1.process_state_with_shots(state, qml.wires.Wires([0, 1]), shots=100, rng=456)
         res2 = mp2.process_state_with_shots(state, qml.wires.Wires([0, 1]), shots=100, rng=456)
 
         # now test everything is the same
-        assert np.all(res1[1] == res2[1])
-        assert np.all(res1[0] == res2[0])
+        assert pnp.all(res1[1] == res2[1])
+        assert pnp.all(res1[0] == res2[0])
 
     def test_expval_shape_and_val(self):
         """Test that shadow expval measurements work as expected"""
         mp = qml.shadow_expval(qml.PauliX(0) @ qml.PauliX(1), seed=200)
         res = mp.process_state_with_shots(
-            np.ones((2, 2)) / 2, qml.wires.Wires([0, 1]), shots=1000, rng=100
+            pnp.ones((2, 2)) / 2, qml.wires.Wires([0, 1]), shots=1000, rng=100
         )
 
         assert res.shape == ()
-        assert np.allclose(res, 1.0, atol=0.05)
+        assert pnp.allclose(res, 1.0, atol=0.05)
 
     def test_expval_wire_order(self):
         """Test that shadow expval respects the wire order"""
-        state = np.array([[1, 1], [0, 0]]) / np.sqrt(2)
+        state = pnp.array([[1, 1], [0, 0]]) / pnp.sqrt(2)
 
         mp = qml.shadow_expval(qml.PauliZ(0), seed=200)
         res = mp.process_state_with_shots(state, qml.wires.Wires([0, 1]), shots=3000, rng=100)
 
         assert res.shape == ()
-        assert np.allclose(res, 1.0, atol=0.05)
+        assert pnp.allclose(res, 1.0, atol=0.05)
 
         res = mp.process_state_with_shots(state, qml.wires.Wires([1, 0]), shots=3000, rng=100)
 
         assert res.shape == ()
-        assert np.allclose(res, 0.0, atol=0.05)
+        assert pnp.allclose(res, 0.0, atol=0.05)
 
     def test_expval_same_rng(self):
         """Test expval results when the rng is the same"""
-        state = np.ones((2, 2)) / 2
+        state = pnp.ones((2, 2)) / 2
 
         mp1 = qml.shadow_expval(qml.PauliZ(0) @ qml.PauliZ(1), seed=123)
         mp2 = qml.shadow_expval(qml.PauliZ(0) @ qml.PauliZ(1), seed=123)
@@ -299,7 +299,7 @@ class TestClassicalShadow:
         assert shadow.shape == (2, shots, wires)
 
         # test dtype is correct
-        expected_dtype = np.int8
+        expected_dtype = pnp.int8
         if interface == "tf":
             expected_dtype = tf.int8
         elif interface == "torch":
@@ -310,8 +310,8 @@ class TestClassicalShadow:
         bits, recipes = shadow  # pylint: disable=unpacking-non-sequence
 
         # test allowed values of bits and recipes
-        assert qml.math.all(np.logical_or(bits == 0, bits == 1))
-        assert qml.math.all(np.logical_or(recipes == 0, np.logical_or(recipes == 1, recipes == 2)))
+        assert qml.math.all(pnp.logical_or(bits == 0, bits == 1))
+        assert qml.math.all(pnp.logical_or(recipes == 0, pnp.logical_or(recipes == 1, recipes == 2)))
 
     @pytest.mark.all_interfaces
     @pytest.mark.parametrize("interface", ["autograd", "jax", "tf", "torch"])
@@ -329,20 +329,20 @@ class TestClassicalShadow:
         bits, recipes = circuit()
 
         # test that the recipes follow a rough uniform distribution
-        ratios = np.unique(recipes, return_counts=True)[1] / (wires * shots)
-        assert np.allclose(ratios, 1 / 3, atol=1e-1)
+        ratios = pnp.unique(recipes, return_counts=True)[1] / (wires * shots)
+        assert pnp.allclose(ratios, 1 / 3, atol=1e-1)
 
         # test that the bit is 0 for all X measurements
         assert qml.math.allequal(bits[recipes == basis_recipe], 0)
 
         # test that the bits are uniformly distributed for all Y and Z measurements
         bits1 = bits[recipes == (basis_recipe + 1) % 3]
-        ratios1 = np.unique(bits1, return_counts=True)[1] / bits1.shape[0]
-        assert np.allclose(ratios1, 1 / 2, atol=1e-1)
+        ratios1 = pnp.unique(bits1, return_counts=True)[1] / bits1.shape[0]
+        assert pnp.allclose(ratios1, 1 / 2, atol=1e-1)
 
         bits2 = bits[recipes == (basis_recipe + 2) % 3]
-        ratios2 = np.unique(bits2, return_counts=True)[1] / bits2.shape[0]
-        assert np.allclose(ratios2, 1 / 2, atol=1e-1)
+        ratios2 = pnp.unique(bits2, return_counts=True)[1] / bits2.shape[0]
+        assert pnp.allclose(ratios2, 1 / 2, atol=1e-1)
 
     @pytest.mark.parametrize("seed", seed_recipes_list)
     def test_shots_none_error(self, wires, seed):
@@ -388,7 +388,7 @@ class TestClassicalShadow:
         result = circuit(params)
         sequential_result = [circuit(i) for i in params]
 
-        assert isinstance(result, np.ndarray)
+        assert isinstance(result, pnp.ndarray)
         assert qml.math.shape(result) == (len(params), 2, shots, wires)
         for seq_res, res in zip(sequential_result, result):
             assert qml.math.shape(seq_res) == qml.math.shape(res)
@@ -422,7 +422,7 @@ def max_entangled_circuit(wires, shots=10000, interface="autograd"):
 def qft_circuit(wires, shots=10000, interface="autograd"):
     dev = qml.device("default.qubit", wires=wires, shots=shots)
 
-    one_state = np.zeros(wires)
+    one_state = pnp.zeros(wires)
     one_state[-1] = 1
 
     @qml.qnode(dev, interface=interface)
@@ -528,7 +528,7 @@ class TestExpvalMeasurement:
         result = circuit(params)
         sequential_result = [circuit(i) for i in params]
 
-        assert isinstance(result, np.ndarray)
+        assert isinstance(result, pnp.ndarray)
         assert qml.math.shape(result)[0] == len(params)
         for seq_res, res in zip(sequential_result, result):
             assert qml.math.shape(seq_res) == qml.math.shape(res)
@@ -572,13 +572,13 @@ obs_qft = [
 expected_qft = [
     -1,
     0,
-    -1 / np.sqrt(2),
-    -1 / np.sqrt(2),
+    -1 / pnp.sqrt(2),
+    -1 / pnp.sqrt(2),
     0,
     0,
-    1 / np.sqrt(2),
-    1 / np.sqrt(2),
-    -1 / np.sqrt(2),
+    1 / pnp.sqrt(2),
+    1 / pnp.sqrt(2),
+    -1 / pnp.sqrt(2),
     0,
 ]
 
@@ -594,7 +594,7 @@ class TestExpvalForward:
         actual = circuit(obs, k=k)
 
         assert actual.shape == (len(obs_hadamard),)
-        assert actual.dtype == np.float64
+        assert actual.dtype == pnp.float64
         assert qml.math.allclose(actual, expected, atol=1e-1)
 
     def test_max_entangled_expval(
@@ -606,7 +606,7 @@ class TestExpvalForward:
         actual = circuit(obs, k=k)
 
         assert actual.shape == (len(obs_max_entangled),)
-        assert actual.dtype == np.float64
+        assert actual.dtype == pnp.float64
         assert qml.math.allclose(actual, expected, atol=1e-1)
 
     def test_non_pauli_error(self):
@@ -629,7 +629,7 @@ class TestExpvalForwardInterfaces:
         actual = circuit(obs, k=k)
 
         assert actual.shape == (len(obs_qft),)
-        assert actual.dtype == torch.float64 if interface == "torch" else np.float64
+        assert actual.dtype == torch.float64 if interface == "torch" else pnp.float64
         assert qml.math.allclose(actual, expected, atol=1e-1)
 
 
@@ -680,7 +680,7 @@ class TestExpvalBackward:
             return autograd.numpy.hstack(exact_circuit(x, obs))
 
         # make rotations close to pi / 2 to ensure gradients are not too small
-        x = np.random.uniform(
+        x = pnp.random.uniform(
             0.8, 2, size=qml.StronglyEntanglingLayers.shape(n_layers=2, n_wires=3)
         )
         actual = qml.jacobian(shadow_circuit)(x, obs, k=1)
@@ -700,7 +700,7 @@ class TestExpvalBackward:
 
         # make rotations close to pi / 2 to ensure gradients are not too small
         x = jnp.array(
-            np.random.uniform(
+            pnp.random.uniform(
                 0.8, 2, size=qml.StronglyEntanglingLayers.shape(n_layers=2, n_wires=3)
             )
         )
@@ -721,7 +721,7 @@ class TestExpvalBackward:
 
         # make rotations close to pi / 2 to ensure gradients are not too small
         x = tf.Variable(
-            np.random.uniform(
+            pnp.random.uniform(
                 0.8, 2, size=qml.StronglyEntanglingLayers.shape(n_layers=2, n_wires=3)
             )
         )
@@ -749,7 +749,7 @@ class TestExpvalBackward:
 
         # make rotations close to pi / 2 to ensure gradients are not too small
         x = torch.tensor(
-            np.random.uniform(
+            pnp.random.uniform(
                 0.8, 2, size=qml.StronglyEntanglingLayers.shape(n_layers=2, n_wires=3)
             ),
             requires_grad=True,
@@ -774,7 +774,7 @@ def get_basis_circuit(wires, shots, basis, interface="autograd", device="default
             if basis in ("x", "y"):
                 qml.Hadamard(wire)
             if basis == "y":
-                qml.RZ(np.pi / 2, wire)
+                qml.RZ(pnp.pi / 2, wire)
 
         return qml.classical_shadow(wires=range(wires))
 
@@ -805,10 +805,10 @@ def test_return_distribution(wires, interface, circuit_basis, basis_recipe):
     )
 
     # test that the recipes follow a rough uniform distribution
-    ratios = np.unique(recipes, return_counts=True)[1] / (wires * shots)
-    assert np.allclose(ratios, 1 / 3, atol=1e-1)
-    new_ratios = np.unique(new_recipes, return_counts=True)[1] / (wires * shots)
-    assert np.allclose(new_ratios, 1 / 3, atol=1e-1)
+    ratios = pnp.unique(recipes, return_counts=True)[1] / (wires * shots)
+    assert pnp.allclose(ratios, 1 / 3, atol=1e-1)
+    new_ratios = pnp.unique(new_recipes, return_counts=True)[1] / (wires * shots)
+    assert pnp.allclose(new_ratios, 1 / 3, atol=1e-1)
 
     # test that the bit is 0 for all X measurements
     assert qml.math.allequal(bits[recipes == basis_recipe], 0)
@@ -816,19 +816,19 @@ def test_return_distribution(wires, interface, circuit_basis, basis_recipe):
 
     # test that the bits are uniformly distributed for all Y and Z measurements
     bits1 = bits[recipes == (basis_recipe + 1) % 3]
-    ratios1 = np.unique(bits1, return_counts=True)[1] / bits1.shape[0]
-    assert np.allclose(ratios1, 1 / 2, atol=1e-1)
+    ratios1 = pnp.unique(bits1, return_counts=True)[1] / bits1.shape[0]
+    assert pnp.allclose(ratios1, 1 / 2, atol=1e-1)
     new_bits1 = new_bits[new_recipes == (basis_recipe + 1) % 3]
-    new_ratios1 = np.unique(new_bits1, return_counts=True)[1] / new_bits1.shape[0]
-    assert np.allclose(new_ratios1, 1 / 2, atol=1e-1)
+    new_ratios1 = pnp.unique(new_bits1, return_counts=True)[1] / new_bits1.shape[0]
+    assert pnp.allclose(new_ratios1, 1 / 2, atol=1e-1)
 
     bits2 = bits[recipes == (basis_recipe + 2) % 3]
-    ratios2 = np.unique(bits2, return_counts=True)[1] / bits2.shape[0]
-    assert np.allclose(ratios2, 1 / 2, atol=1e-1)
+    ratios2 = pnp.unique(bits2, return_counts=True)[1] / bits2.shape[0]
+    assert pnp.allclose(ratios2, 1 / 2, atol=1e-1)
 
     new_bits2 = new_bits[new_recipes == (basis_recipe + 2) % 3]
-    new_ratios2 = np.unique(new_bits2, return_counts=True)[1] / new_bits2.shape[0]
-    assert np.allclose(new_ratios2, 1 / 2, atol=1e-1)
+    new_ratios2 = pnp.unique(new_bits2, return_counts=True)[1] / new_bits2.shape[0]
+    assert pnp.allclose(new_ratios2, 1 / 2, atol=1e-1)
 
 
 def hadamard_circuit_legacy(wires, shots=10000, interface="autograd"):
@@ -853,6 +853,6 @@ def test_hadamard_expval(k=1, obs=obs_hadamard, expected=expected_hadamard):
     new_actual = circuit.tape.measurements[0].process(circuit.tape, circuit.device.target_device)
 
     assert actual.shape == (len(obs_hadamard),)
-    assert actual.dtype == np.float64
+    assert actual.dtype == pnp.float64
     assert qml.math.allclose(actual, expected, atol=1e-1)
     assert qml.math.allclose(new_actual, expected, atol=1e-1)

--- a/tests/measurements/test_mid_measure.py
+++ b/tests/measurements/test_mid_measure.py
@@ -18,7 +18,7 @@ from itertools import product
 import pytest
 
 import pennylane as qml
-import pennylane.numpy as np
+import pennylane.numpy as pnp
 from pennylane.measurements import MeasurementValue, MidMeasureMP
 from pennylane.wires import Wires
 
@@ -95,9 +95,9 @@ class TestMeasurementValueManipulation:
 
         m = MeasurementValue([mp1], lambda v: v)
 
-        sin_of_m = m._apply(np.sin)  # pylint: disable=protected-access
+        sin_of_m = m._apply(pnp.sin)  # pylint: disable=protected-access
         assert sin_of_m[0] == 0.0
-        assert sin_of_m[1] == np.sin(1)
+        assert sin_of_m[1] == pnp.sin(1)
 
     def test_and_with_bool(self):
         """Test the __add__ dunder method between MeasurementValue and scalar."""
@@ -239,8 +239,8 @@ class TestMeasurementValueManipulation:
         assert qml.math.allclose(m_inversion.concretize(values), False)
         values = {mp1: False}
         assert qml.math.allclose(m_inversion.concretize(values), True)
-        values = {mp1: np.random.rand(10) < 0.5}
-        assert all(m_inversion.concretize(values) != np.array(values.values()))
+        values = {mp1: pnp.random.rand(10) < 0.5}
+        assert all(m_inversion.concretize(values) != pnp.array(values.values()))
 
     def test_lt(self):
         """Test the __lt__ dunder method between a MeasurementValue and a float."""
@@ -504,7 +504,7 @@ class TestMeasurementCompositeValueManipulation:
         assert isinstance(boolean_of_measurements, MeasurementValue)
 
     @pytest.mark.parametrize("div", divisions)
-    @pytest.mark.parametrize("other", [MeasurementValue([mp3], lambda v: v) + 5, np.pi])
+    @pytest.mark.parametrize("other", [MeasurementValue([mp3], lambda v: v) + 5, pnp.pi])
     @pytest.mark.parametrize("binary", binary_dunders)
     def test_composition_with_division(self, binary, div, other):
         """Test the composition of dunder methods with division."""

--- a/tests/numpy/test_numpy_random.py
+++ b/tests/numpy/test_numpy_random.py
@@ -19,7 +19,7 @@ additional property, ``requires_grad``, that marks them as trainable/ non-traina
 
 import pytest
 
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane.numpy import random
 
 # distributions that require no extra parameters
@@ -53,7 +53,7 @@ class TestGeneratorDistributions:
         size = (3,)
         output = getattr(general_gen, distribution)(size=size)
 
-        assert isinstance(output, np.tensor)
+        assert isinstance(output, pnp.tensor)
 
         assert output.shape == size
         assert output.requires_grad is True
@@ -72,7 +72,7 @@ class Test_default_rng:
         assert isinstance(rng, random.Generator)
 
         output = rng.random((3,))
-        assert isinstance(output, np.tensor)
+        assert isinstance(output, pnp.tensor)
 
     @pytest.mark.parametrize("bitgen_cls", bit_generator_classes)
     def test_bit_generators(self, bitgen_cls):
@@ -87,7 +87,7 @@ class Test_default_rng:
         assert isinstance(rng.bit_generator, bitgen_cls)
 
         output = rng.random((3,))
-        assert isinstance(output, np.tensor)
+        assert isinstance(output, pnp.tensor)
 
     def test_generator_input(self):
         """Tests that ``np.random.default_rng`` passes through a Generator when its passed as input."""
@@ -112,9 +112,9 @@ class Test_default_rng:
         mat1 = rng1.random(size=size)
         mat2 = rng2.random(size=size)
 
-        assert np.all(mat1 == mat2)
+        assert pnp.all(mat1 == mat2)
 
         mat1_2 = rng1.normal(size=size)
         mat2_2 = rng2.normal(size=size)
 
-        assert np.all(mat1_2 == mat2_2)
+        assert pnp.all(mat1_2 == mat2_2)

--- a/tests/numpy/test_numpy_wrapper.py
+++ b/tests/numpy/test_numpy_wrapper.py
@@ -23,7 +23,7 @@ import pytest
 from autograd.numpy.numpy_boxes import ArrayBox
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane.numpy.tensor import tensor_to_arraybox
 
 
@@ -40,15 +40,15 @@ class TestExtractTensors:
 
     def test_empty_terable(self):
         """Test that an empty iterable returns nothing"""
-        res = list(np.extract_tensors([]))
+        res = list(pnp.extract_tensors([]))
         assert res == []
 
     def test_iterable_with_strings(self):
         """Test that strings are not treated as a sequence"""
-        arr1 = np.array([0.4, 0.1])
-        arr2 = np.array([1])
+        arr1 = pnp.array([0.4, 0.1])
+        arr2 = pnp.array([1])
 
-        res = list(np.extract_tensors([arr1, ["abc", [arr2]]]))
+        res = list(pnp.extract_tensors([arr1, ["abc", [arr2]]]))
 
         assert len(res) == 2
         assert res[0] is arr1
@@ -56,10 +56,10 @@ class TestExtractTensors:
 
     def test_iterable_with_unpatched_numpy_arrays(self):
         """Test that the extraction ignores unpatched numpy arrays"""
-        arr1 = np.array([0.4, 0.1])
-        arr2 = np.array([1])
+        arr1 = pnp.array([0.4, 0.1])
+        arr2 = pnp.array([1])
 
-        res = list(np.extract_tensors([arr1, [onp.array([1, 2]), [arr2]]]))
+        res = list(pnp.extract_tensors([arr1, [onp.array([1, 2]), [arr2]]]))
 
         assert len(res) == 2
         assert res[0] is arr1
@@ -74,20 +74,20 @@ class TestTensor:
         """Test that you can instantiate the Tensor class with the
         requires_grad argument"""
         # default value is true
-        x = np.tensor([0, 1, 2])
+        x = pnp.tensor([0, 1, 2])
         assert x.requires_grad
 
-        x = np.tensor([0, 1, 2], requires_grad=True)
+        x = pnp.tensor([0, 1, 2], requires_grad=True)
         assert x.requires_grad
 
-        x = np.tensor([0, 1, 2], requires_grad=False)
+        x = pnp.tensor([0, 1, 2], requires_grad=False)
         assert not x.requires_grad
 
     def test_requires_grad_setter(self):
         """Test that the value of requires_grad can be changed
         on an instantiated object"""
         # default value is true
-        x = np.tensor([0, 1, 2])
+        x = pnp.tensor([0, 1, 2])
         assert x.requires_grad
 
         x.requires_grad = False
@@ -95,7 +95,7 @@ class TestTensor:
 
     def test_string_representation(self, capsys):
         """Test the string representation is correct"""
-        x = np.tensor([0, 1, 2])
+        x = pnp.tensor([0, 1, 2])
         print(x.__repr__())
         captured = capsys.readouterr()
         assert "tensor([0, 1, 2], requires_grad=True)" in captured.out
@@ -108,12 +108,12 @@ class TestTensor:
     @pytest.mark.parametrize("grad", [True, False])
     def test_indexing(self, grad):
         """Test that indexing into a tensor always returns a tensor"""
-        x = np.tensor([[0, 1, 2], [3, 4, 5]], requires_grad=grad)
+        x = pnp.tensor([[0, 1, 2], [3, 4, 5]], requires_grad=grad)
 
-        assert isinstance(x[0], np.tensor)
+        assert isinstance(x[0], pnp.tensor)
         assert x[0].requires_grad is grad
 
-        assert isinstance(x[0, 0], np.tensor)
+        assert isinstance(x[0, 0], pnp.tensor)
         assert x[0, 0].requires_grad is grad
         assert x[0, 0].shape == tuple()
         assert x[0, 0].item() == 0
@@ -130,25 +130,25 @@ class TestTensor:
 # arguments required for the function are provided
 # as an optional dictionary.
 ARRAY_CREATION_FNS = [
-    [np.array, {}],
-    [np.asarray, {}],
-    [np.fromiter, {"dtype": np.int64}],
-    [np.empty_like, {}],
-    [np.ones_like, {}],
-    [np.zeros_like, {}],
-    [np.full_like, {"fill_value": 5}],
+    [pnp.array, {}],
+    [pnp.asarray, {}],
+    [pnp.fromiter, {"dtype": pnp.int64}],
+    [pnp.empty_like, {}],
+    [pnp.ones_like, {}],
+    [pnp.zeros_like, {}],
+    [pnp.full_like, {"fill_value": 5}],
 ]
 
 # The following NumPy functions all create
 # arrays based on shape input.
 ARRAY_SHAPE_FNS = [
-    [np.empty, {}],
-    [np.identity, {}],
-    [np.ones, {}],
-    [np.zeros, {}],
-    [np.full, {"fill_value": 5}],
-    [np.arange, {}],
-    [np.eye, {}],
+    [pnp.empty, {}],
+    [pnp.identity, {}],
+    [pnp.ones, {}],
+    [pnp.zeros, {}],
+    [pnp.full, {"fill_value": 5}],
+    [pnp.arange, {}],
+    [pnp.eye, {}],
 ]
 
 
@@ -164,7 +164,7 @@ class TestNumpyIntegration:
         # default value is true
         x = fn([1, 1, 2], **kwargs)
 
-        assert isinstance(x, np.tensor)
+        assert isinstance(x, pnp.tensor)
         assert x.requires_grad
 
         x = fn([1, 1, 2], requires_grad=True, **kwargs)
@@ -184,7 +184,7 @@ class TestNumpyIntegration:
         shape = 4
         x = fn(shape, **kwargs)
 
-        assert isinstance(x, np.tensor)
+        assert isinstance(x, pnp.tensor)
         assert x.requires_grad
 
         x = fn(shape, requires_grad=True, **kwargs)
@@ -199,227 +199,227 @@ class TestNumpyIntegration:
     def test_tensor_creation_from_string(self):
         """Test that a tensor is properly created from a string."""
         string = "5, 4, 1, 2"
-        x = np.fromstring(string, dtype=int, sep=",")
+        x = pnp.fromstring(string, dtype=int, sep=",")
 
-        assert isinstance(x, np.tensor)
+        assert isinstance(x, pnp.tensor)
         assert x.requires_grad
 
-        x = np.fromstring(string, requires_grad=True, dtype=int, sep=",")
+        x = pnp.fromstring(string, requires_grad=True, dtype=int, sep=",")
         assert x.requires_grad
 
         x.requires_grad = False
         assert not x.requires_grad
 
-        x = np.fromstring(string, requires_grad=False, dtype=int, sep=",")
+        x = pnp.fromstring(string, requires_grad=False, dtype=int, sep=",")
         assert not x.requires_grad
 
     def test_wrapped_docstring(self, capsys):
         """Test that wrapped NumPy functions retains the original
         docstring."""
-        print(np.sin.__doc__)
+        print(pnp.sin.__doc__)
         captured = capsys.readouterr()
         assert "Trigonometric sine, element-wise." in captured.out
 
     def test_wrapped_function_on_tensor(self):
         """Test that wrapped functions work correctly"""
-        x = np.array([0, 1, 2], requires_grad=True)
-        res = np.sin(x)
+        x = pnp.array([0, 1, 2], requires_grad=True)
+        res = pnp.sin(x)
         expected = onp.sin(onp.array([0, 1, 2]))
-        assert np.all(res == expected)
+        assert pnp.all(res == expected)
         assert res.requires_grad
 
         # since the wrapping is dynamic, even ``sin`` will
         # now accept the requires_grad keyword argument.
-        x = np.array([0, 1, 2], requires_grad=True)
-        res = np.sin(x, requires_grad=False)
+        x = pnp.array([0, 1, 2], requires_grad=True)
+        res = pnp.sin(x, requires_grad=False)
         expected = onp.sin(onp.array([0, 1, 2]))
-        assert np.all(res == expected)
+        assert pnp.all(res == expected)
         assert not res.requires_grad
 
     def test_wrapped_function_nontrainable_list_input(self):
         """Test that a wrapped function with signature of the form
         func([arr1, arr2, ...]) acting on non-trainable input returns non-trainable output"""
-        arr1 = np.array([0, 1], requires_grad=False)
-        arr2 = np.array([2, 3], requires_grad=False)
-        arr3 = np.array([4, 5], requires_grad=False)
+        arr1 = pnp.array([0, 1], requires_grad=False)
+        arr2 = pnp.array([2, 3], requires_grad=False)
+        arr3 = pnp.array([4, 5], requires_grad=False)
 
-        res = np.vstack([arr1, arr2, arr3])
+        res = pnp.vstack([arr1, arr2, arr3])
         assert not res.requires_grad
 
         # If one of the inputs is trainable, the output always is.
         arr1.requires_grad = True
-        res = np.vstack([arr1, arr2, arr3])
+        res = pnp.vstack([arr1, arr2, arr3])
         assert res.requires_grad
 
     def test_wrapped_function_nontrainable_variable_args(self):
         """Test that a wrapped function with signature of the form
         func(arr1, arr2, ...) acting on non-trainable input returns non-trainable output"""
-        arr1 = np.array([0, 1], requires_grad=False)
-        arr2 = np.array([2, 3], requires_grad=False)
+        arr1 = pnp.array([0, 1], requires_grad=False)
+        arr2 = pnp.array([2, 3], requires_grad=False)
 
-        res = np.arctan2(arr1, arr2)
+        res = pnp.arctan2(arr1, arr2)
         assert not res.requires_grad
 
         # If one of the inputs is trainable, the output always is.
         arr1.requires_grad = True
-        res = np.arctan2(arr1, arr2)
+        res = pnp.arctan2(arr1, arr2)
         assert res.requires_grad
 
     def test_wrapped_function_on_array(self):
         """Test behaviour of a wrapped function on a vanilla NumPy
         array."""
-        res = np.sin(onp.array([0, 1, 2]))
+        res = pnp.sin(onp.array([0, 1, 2]))
         expected = onp.sin(onp.array([0, 1, 2]))
-        assert np.all(res == expected)
+        assert pnp.all(res == expected)
 
         # the result has been converted into a tensor
-        assert isinstance(res, np.tensor)
+        assert isinstance(res, pnp.tensor)
         assert res.requires_grad
 
     def test_classes_not_wrapped(self):
         """Test that NumPy classes are not wrapped"""
-        x = np.ndarray([0, 1, 2])
-        assert not isinstance(x, np.tensor)
+        x = pnp.ndarray([0, 1, 2])
+        assert not isinstance(x, pnp.tensor)
         assert not hasattr(x, "requires_grad")
 
     def test_random_subpackage(self):
         """Test that the random subpackage is correctly wrapped"""
-        x = np.random.normal(size=[2, 3])
-        assert isinstance(x, np.tensor)
+        x = pnp.random.normal(size=[2, 3])
+        assert isinstance(x, pnp.tensor)
 
     def test_linalg_subpackage(self):
         """Test that the linalg subpackage is correctly wrapped"""
-        x = np.linalg.eigvals([[1, 1], [1, 1]])
-        assert isinstance(x, np.tensor)
+        x = pnp.linalg.eigvals([[1, 1], [1, 1]])
+        assert isinstance(x, pnp.tensor)
 
     def test_fft_subpackage(self):
         """Test that the fft subpackage is correctly wrapped"""
-        x = np.fft.fft(np.arange(8))
-        assert isinstance(x, np.tensor)
+        x = pnp.fft.fft(pnp.arange(8))
+        assert isinstance(x, pnp.tensor)
 
     def test_unary_operators(self):
         """Test that unary operators (negate, power)
         correctly work on tensors."""
-        x = np.array([[1, 2], [3, 4]])
+        x = pnp.array([[1, 2], [3, 4]])
         res = -x
-        assert isinstance(res, np.tensor)
+        assert isinstance(res, pnp.tensor)
         assert res.requires_grad
 
-        x = np.array([[1, 2], [3, 4]], requires_grad=False)
+        x = pnp.array([[1, 2], [3, 4]], requires_grad=False)
         res = -x
-        assert isinstance(res, np.tensor)
+        assert isinstance(res, pnp.tensor)
         assert not res.requires_grad
 
-        x = np.array([[1, 2], [3, 4]])
+        x = pnp.array([[1, 2], [3, 4]])
         res = x**2
-        assert isinstance(res, np.tensor)
+        assert isinstance(res, pnp.tensor)
         assert res.requires_grad
 
-        x = np.array([[1, 2], [3, 4]], requires_grad=False)
+        x = pnp.array([[1, 2], [3, 4]], requires_grad=False)
         res = x**2
-        assert isinstance(res, np.tensor)
+        assert isinstance(res, pnp.tensor)
         assert not res.requires_grad
 
     def test_binary_operators(self):
         """Test that binary operators (add, subtract, divide, multiply, matmul)
         correctly work on tensors."""
-        x = np.array([[1, 2], [3, 4]])
-        y = np.array([[5, 6], [7, 8]])
+        x = pnp.array([[1, 2], [3, 4]])
+        y = pnp.array([[5, 6], [7, 8]])
         res = x + y
-        assert isinstance(res, np.tensor)
+        assert isinstance(res, pnp.tensor)
         assert res.requires_grad
 
         res = x - y
-        assert isinstance(res, np.tensor)
+        assert isinstance(res, pnp.tensor)
         assert res.requires_grad
 
         res = x / y
-        assert isinstance(res, np.tensor)
+        assert isinstance(res, pnp.tensor)
         assert res.requires_grad
 
         res = x * y
-        assert isinstance(res, np.tensor)
+        assert isinstance(res, pnp.tensor)
         assert res.requires_grad
 
         res = x @ y
-        assert isinstance(res, np.tensor)
+        assert isinstance(res, pnp.tensor)
         assert res.requires_grad
 
     def test_binary_operator_nontrainable(self):
         """Test that binary operators on two non-trainable
         arrays result in non-trainable output."""
-        x = np.array([[1, 2], [3, 4]], requires_grad=False)
-        y = np.array([[5, 6], [7, 8]], requires_grad=False)
+        x = pnp.array([[1, 2], [3, 4]], requires_grad=False)
+        y = pnp.array([[5, 6], [7, 8]], requires_grad=False)
         res = x + y
-        assert isinstance(res, np.tensor)
+        assert isinstance(res, pnp.tensor)
         assert not res.requires_grad
 
         res = x - y
-        assert isinstance(res, np.tensor)
+        assert isinstance(res, pnp.tensor)
         assert not res.requires_grad
 
         res = x / y
-        assert isinstance(res, np.tensor)
+        assert isinstance(res, pnp.tensor)
         assert not res.requires_grad
 
         res = x * y
-        assert isinstance(res, np.tensor)
+        assert isinstance(res, pnp.tensor)
         assert not res.requires_grad
 
         res = x @ y
-        assert isinstance(res, np.tensor)
+        assert isinstance(res, pnp.tensor)
         assert not res.requires_grad
 
     def test_binary_operator_mixed_trainable_left(self):
         """Test that binary operators on one trainable and one non-trainable
         arrays result in trainable output."""
-        x = np.array([[1, 2], [3, 4]], requires_grad=True)
-        y = np.array([[5, 6], [7, 8]], requires_grad=False)
+        x = pnp.array([[1, 2], [3, 4]], requires_grad=True)
+        y = pnp.array([[5, 6], [7, 8]], requires_grad=False)
 
         res = x + y
-        assert isinstance(res, np.tensor)
+        assert isinstance(res, pnp.tensor)
         assert res.requires_grad
 
         res = x - y
-        assert isinstance(res, np.tensor)
+        assert isinstance(res, pnp.tensor)
         assert res.requires_grad
 
         res = x / y
-        assert isinstance(res, np.tensor)
+        assert isinstance(res, pnp.tensor)
         assert res.requires_grad
 
         res = x * y
-        assert isinstance(res, np.tensor)
+        assert isinstance(res, pnp.tensor)
         assert res.requires_grad
 
         res = x @ y
-        assert isinstance(res, np.tensor)
+        assert isinstance(res, pnp.tensor)
         assert res.requires_grad
 
     def test_binary_operator_mixed_trainable_right(self):
         """Test that binary operators on one non-trainable and one trainable
         arrays result in trainable output."""
-        x = np.array([[1, 2], [3, 4]], requires_grad=False)
-        y = np.array([[5, 6], [7, 8]], requires_grad=True)
+        x = pnp.array([[1, 2], [3, 4]], requires_grad=False)
+        y = pnp.array([[5, 6], [7, 8]], requires_grad=True)
 
         res = x + y
-        assert isinstance(res, np.tensor)
+        assert isinstance(res, pnp.tensor)
         assert res.requires_grad
 
         res = x - y
-        assert isinstance(res, np.tensor)
+        assert isinstance(res, pnp.tensor)
         assert res.requires_grad
 
         res = x / y
-        assert isinstance(res, np.tensor)
+        assert isinstance(res, pnp.tensor)
         assert res.requires_grad
 
         res = x * y
-        assert isinstance(res, np.tensor)
+        assert isinstance(res, pnp.tensor)
         assert res.requires_grad
 
         res = x @ y
-        assert isinstance(res, np.tensor)
+        assert isinstance(res, pnp.tensor)
         assert res.requires_grad
 
     def test_multi_output_array_ufunc(self):
@@ -434,7 +434,7 @@ class TestNumpyIntegration:
             def __call__(self, *args, **kwargs):
                 return [True, True]
 
-        x = np.array([[1, 2], [3, 4]], requires_grad=False)
+        x = pnp.array([[1, 2], [3, 4]], requires_grad=False)
         res = x.__array_ufunc__(_ufunc(), "__call__")
         assert isinstance(res, tuple)
         assert len(res) == 2
@@ -448,26 +448,26 @@ class TestAutogradIntegration:
         """Test gradient computations continue to work"""
 
         def cost(x):
-            return np.sum(np.sin(x))
+            return pnp.sum(pnp.sin(x))
 
         grad_fn = qml.grad(cost, argnum=[0])
-        arr1 = np.array([0.0, 1.0, 2.0])
+        arr1 = pnp.array([0.0, 1.0, 2.0])
 
         res = grad_fn(arr1)
-        expected = np.cos(arr1)
+        expected = pnp.cos(arr1)
 
-        assert np.all(res == expected)
+        assert pnp.all(res == expected)
 
     def test_non_differentiable_gradient(self):
         """Test gradient computation with requires_grad=False raises an error"""
 
         def cost(x):
-            return np.sum(np.sin(x))
+            return pnp.sum(pnp.sin(x))
 
         grad_fn = qml.grad(cost, argnum=[0])
-        arr1 = np.array([0.0, 1.0, 2.0], requires_grad=False)
+        arr1 = pnp.array([0.0, 1.0, 2.0], requires_grad=False)
 
-        with pytest.raises(np.NonDifferentiableError, match="non-differentiable"):
+        with pytest.raises(pnp.NonDifferentiableError, match="non-differentiable"):
             grad_fn(arr1)
 
 
@@ -478,42 +478,42 @@ class TestScalarHashing:
     def test_create_set_scalar_arrays(self):
         """Test that a collection of scalar arrays can be properly hashed
         when creating a set"""
-        data = [np.array(1), np.array(2), np.array(1), np.array(3)]
+        data = [pnp.array(1), pnp.array(2), pnp.array(1), pnp.array(3)]
         res = set(data)
-        expected = {np.array(1), np.array(2), np.array(3)}
+        expected = {pnp.array(1), pnp.array(2), pnp.array(3)}
         assert res == expected
 
     def test_requires_grad_hashing(self):
         """Test that the gradient information is correctly taken into account when hashing"""
-        data = [np.array(1), np.array(2), np.array(1, requires_grad=False), np.array(3)]
+        data = [pnp.array(1), pnp.array(2), pnp.array(1, requires_grad=False), pnp.array(3)]
         res = set(data)
-        expected = {np.array(1, requires_grad=False), np.array(1), np.array(2), np.array(3)}
+        expected = {pnp.array(1, requires_grad=False), pnp.array(1), pnp.array(2), pnp.array(3)}
         assert res == expected
 
     def test_create_set_from_array_iteration(self):
         """Test that a one dimensional array correctly produces a set via iteration"""
-        data = np.array([1, 2, 1, 3], requires_grad=True)
+        data = pnp.array([1, 2, 1, 3], requires_grad=True)
         res = set(data)
         expected = {
-            np.array(1, requires_grad=True),
-            np.array(2, requires_grad=True),
-            np.array(3, requires_grad=True),
+            pnp.array(1, requires_grad=True),
+            pnp.array(2, requires_grad=True),
+            pnp.array(3, requires_grad=True),
         }
         assert res == expected
 
-        data = np.array([1, 2, 1, 3], requires_grad=False)
+        data = pnp.array([1, 2, 1, 3], requires_grad=False)
         res = set(data)
         expected = {
-            np.array(1, requires_grad=False),
-            np.array(2, requires_grad=False),
-            np.array(3, requires_grad=False),
+            pnp.array(1, requires_grad=False),
+            pnp.array(2, requires_grad=False),
+            pnp.array(3, requires_grad=False),
         }
         assert res == expected
 
     def test_nonzero_dim_arrays_non_hashable(self):
         """Test that a non-scalar array continues to remain non-hashable"""
         with pytest.raises(TypeError, match=r"unhashable type: 'numpy\.tensor'"):
-            set(np.array([[1, 2], [3, 4]]))
+            set(pnp.array([[1, 2], [3, 4]]))
 
 
 class TestNumpyConversion:
@@ -522,7 +522,7 @@ class TestNumpyConversion:
     @pytest.mark.unit
     def test_convert_scalar_array(self):
         """Test that a scalar array converts to a python literal"""
-        data = np.array(1.543)
+        data = pnp.array(1.543)
         res = data.unwrap()
         assert res == data.item()
         assert isinstance(res, float)
@@ -530,13 +530,13 @@ class TestNumpyConversion:
     @pytest.mark.unit
     def test_convert_array(self):
         """Test that a numpy array successfully converts"""
-        data = np.array([1, 2, 3])
+        data = pnp.array([1, 2, 3])
         res = data.numpy()
 
-        assert np.shares_memory(res, data)
-        assert np.all(res == data)
-        assert isinstance(res, np.ndarray)
-        assert not isinstance(res, np.tensor)
+        assert pnp.shares_memory(res, data)
+        assert pnp.all(res == data)
+        assert isinstance(res, pnp.ndarray)
+        assert not isinstance(res, pnp.tensor)
 
     @pytest.mark.system
     def test_single_gate_parameter(self):
@@ -551,7 +551,7 @@ class TestNumpyConversion:
                     qml.RX(x, wires=idx)
             return qml.expval(qml.PauliZ(0))
 
-        phi = np.tensor([[0.04439891, 0.14490549, 3.29725643, 2.51240058]])
+        phi = pnp.tensor([[0.04439891, 0.14490549, 3.29725643, 2.51240058]])
 
         circuit(phi=phi)
 
@@ -574,7 +574,7 @@ class TestNumpyConversion:
                 qml.Rot(*x, wires=idx)
             return qml.expval(qml.PauliZ(0))
 
-        phi = np.tensor([[0.04439891, 0.14490549, 3.29725643]])
+        phi = pnp.tensor([[0.04439891, 0.14490549, 3.29725643]])
 
         circuit(phi=phi)
 
@@ -582,4 +582,4 @@ class TestNumpyConversion:
         ops = circuit.tape.operations
         assert len(ops) == 1
         assert ops[0].name == "Rot"
-        assert np.array_equal(ops[0].parameters, phi[0])
+        assert pnp.array_equal(ops[0].parameters, phi[0])

--- a/tests/ops/functions/test_eigvals.py
+++ b/tests/ops/functions/test_eigvals.py
@@ -22,7 +22,7 @@ import scipy
 from gate_data import CNOT, H, I, S, X, Y, Z
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane.transforms import TransformError
 
 one_qubit_no_parameter = [
@@ -55,7 +55,7 @@ class TestSingleOperation:
         op = op_class(wires=0)
         res = qml.eigvals(op)
         expected = op.eigvals()
-        assert np.allclose(res, expected)
+        assert pnp.allclose(res, expected)
 
     @pytest.mark.parametrize("op_class", one_qubit_no_parameter)
     def test_non_parametric_gates_qfunc(self, op_class):
@@ -63,7 +63,7 @@ class TestSingleOperation:
         when provided as a qfunc"""
         res = qml.eigvals(op_class)(wires=0)
         expected = op_class(wires=0).eigvals()
-        assert np.allclose(res, expected)
+        assert pnp.allclose(res, expected)
 
     @pytest.mark.parametrize("op_class", one_qubit_no_parameter)
     def test_non_parametric_gates_qnode(self, op_class):
@@ -73,7 +73,7 @@ class TestSingleOperation:
         qnode = qml.QNode(lambda: op_class(wires=0) and qml.probs(wires=0), dev)
         res = qml.eigvals(qnode)()
         expected = op_class(wires=0).eigvals()
-        assert np.allclose(res, expected)
+        assert pnp.allclose(res, expected)
 
     @pytest.mark.parametrize("op_class", one_qubit_one_parameter)
     def test_parametric_gates_instantiated(self, op_class):
@@ -82,7 +82,7 @@ class TestSingleOperation:
         op = op_class(0.54, wires=0)
         res = qml.eigvals(op)
         expected = op.eigvals()
-        assert np.allclose(res, expected)
+        assert pnp.allclose(res, expected)
 
     @pytest.mark.parametrize("op_class", one_qubit_one_parameter)
     def test_parametric_gates_qfunc(self, op_class):
@@ -90,7 +90,7 @@ class TestSingleOperation:
         when provided as a qfunc"""
         res = qml.eigvals(op_class)(0.54, wires=0)
         expected = op_class(0.54, wires=0).eigvals()
-        assert np.allclose(res, expected)
+        assert pnp.allclose(res, expected)
 
     @pytest.mark.parametrize("op_class", one_qubit_one_parameter)
     def test_parametric_gates_qnode(self, op_class):
@@ -100,7 +100,7 @@ class TestSingleOperation:
         qnode = qml.QNode(lambda x: op_class(x, wires=0) and qml.probs(wires=0), dev)
         res = qml.eigvals(qnode)(0.54)
         expected = op_class(0.54, wires=0).eigvals()
-        assert np.allclose(res, expected)
+        assert pnp.allclose(res, expected)
 
     @pytest.mark.parametrize("op_class", one_qubit_one_parameter)
     def test_adjoint(self, op_class):
@@ -108,21 +108,21 @@ class TestSingleOperation:
         rounding_precision = 6
         res = qml.eigvals(qml.adjoint(op_class))(0.54, wires=0)
         expected = op_class(-0.54, wires=0).eigvals()
-        assert set(np.around(res, rounding_precision)) == set(
-            np.around(expected, rounding_precision)
+        assert set(pnp.around(res, rounding_precision)) == set(
+            pnp.around(expected, rounding_precision)
         )
 
     def test_ctrl(self):
         """Test that the ctrl is correctly taken into account"""
         res = qml.eigvals(qml.ctrl(qml.PauliX, 0))(wires=1)
-        expected = np.linalg.eigvals(qml.matrix(qml.CNOT(wires=[0, 1])))
-        assert np.allclose(np.sort(res), np.sort(expected))
+        expected = pnp.linalg.eigvals(qml.matrix(qml.CNOT(wires=[0, 1])))
+        assert pnp.allclose(pnp.sort(res), pnp.sort(expected))
 
     def test_tensor_product(self):
         """Test a tensor product"""
         res = qml.eigvals(qml.prod(qml.PauliX(0), qml.Identity(1), qml.PauliZ(1), lazy=False))
         expected = [1.0, -1.0, -1.0, 1.0]
-        assert np.allclose(res, expected)
+        assert pnp.allclose(res, expected)
 
     def test_hamiltonian(self):
         """Test that the matrix of a Hamiltonian is correctly returned"""
@@ -130,8 +130,8 @@ class TestSingleOperation:
 
         res = qml.eigvals(ham)
 
-        expected = np.linalg.eigvalsh(reduce(np.kron, [Z, Y]) - 0.5 * reduce(np.kron, [I, X]))
-        assert np.allclose(res, expected)
+        expected = pnp.linalg.eigvalsh(reduce(pnp.kron, [Z, Y]) - 0.5 * reduce(pnp.kron, [I, X]))
+        assert pnp.allclose(res, expected)
 
     @pytest.mark.xfail(
         reason="This test will fail because Hamiltonians are not queued to tapes yet!"
@@ -147,8 +147,8 @@ class TestSingleOperation:
         with pytest.warns(UserWarning, match="the eigenvalues will be computed numerically"):
             res = qml.eigvals(ansatz)(x)
 
-        expected = np.linalg.eigvalsh(reduce(np.kron, [Z, Y]) - 0.5 * reduce(np.kron, [I, X]))
-        assert np.allclose(res, expected)
+        expected = pnp.linalg.eigvalsh(reduce(pnp.kron, [Z, Y]) - 0.5 * reduce(pnp.kron, [I, X]))
+        assert pnp.allclose(res, expected)
 
     @pytest.mark.parametrize(
         ("row", "col", "dat"),
@@ -156,9 +156,9 @@ class TestSingleOperation:
             (
                 # coordinates and values of a sparse Hamiltonian computed for H2
                 # with geometry: np.array([[0.0, 0.0, 0.3674625962], [0.0, 0.0, -0.3674625962]])
-                np.array([0, 1, 2, 3, 3, 4, 5, 6, 6, 7, 8, 9, 9, 10, 11, 12, 12, 13, 14, 15]),
-                np.array([0, 1, 2, 3, 12, 4, 5, 6, 9, 7, 8, 6, 9, 10, 11, 3, 12, 13, 14, 15]),
-                np.array(
+                pnp.array([0, 1, 2, 3, 3, 4, 5, 6, 6, 7, 8, 9, 9, 10, 11, 12, 12, 13, 14, 15]),
+                pnp.array([0, 1, 2, 3, 12, 4, 5, 6, 9, 7, 8, 6, 9, 10, 11, 3, 12, 13, 14, 15]),
+                pnp.array(
                     [
                         0.72004228 + 0.0j,
                         0.2481941 + 0.0j,
@@ -192,19 +192,19 @@ class TestSingleOperation:
         h_sparse = qml.SparseHamiltonian(h_mat, wires=range(4))
 
         dense_mat = h_mat.todense()
-        dense_eigvals = np.sort(np.linalg.eigvals(dense_mat))
+        dense_eigvals = pnp.sort(pnp.linalg.eigvals(dense_mat))
 
         # k = 1  (< N-1) scipy.sparse.linalg is used:
         val_groundstate = qml.eigvals(h_sparse, k=1)
-        assert np.allclose(val_groundstate, dense_eigvals[0])
+        assert pnp.allclose(val_groundstate, dense_eigvals[0])
 
         # k = 14  (< N-1) scipy.sparse.linalg is used:
-        val_n_sparse = np.sort(qml.eigvals(h_sparse, k=14))
-        assert np.allclose(val_n_sparse, dense_eigvals[0:-2])
+        val_n_sparse = pnp.sort(qml.eigvals(h_sparse, k=14))
+        assert pnp.allclose(val_n_sparse, dense_eigvals[0:-2])
 
         # k = 16 (> N-1) qml.math.linalg is used:
-        val_all = np.sort(qml.eigvals(h_sparse, k=16))
-        assert np.allclose(val_all, dense_eigvals)
+        val_all = pnp.sort(qml.eigvals(h_sparse, k=16))
+        assert pnp.allclose(val_all, dense_eigvals)
 
 
 class TestMultipleOperations:
@@ -219,10 +219,10 @@ class TestMultipleOperations:
 
         tape = qml.tape.QuantumScript.from_queue(q)
         res = qml.eigvals(tape)
-        expected = np.linalg.eigvals(np.kron(X, np.kron(S, H)))
+        expected = pnp.linalg.eigvals(pnp.kron(X, pnp.kron(S, H)))
 
-        assert np.allclose(np.sort(res.real), np.sort(expected.real))
-        assert np.allclose(np.sort(res.imag), np.sort(expected.imag))
+        assert pnp.allclose(pnp.sort(res.real), pnp.sort(expected.real))
+        assert pnp.allclose(pnp.sort(res.imag), pnp.sort(expected.imag))
 
     def test_multiple_operations_tape(self):
         """Check the eigenvalues for a tape containing multiple gates"""
@@ -237,8 +237,8 @@ class TestMultipleOperations:
         with pytest.warns(UserWarning, match="the eigenvalues will be computed numerically"):
             res = qml.eigvals(tape)
 
-        expected = np.linalg.eigvals(np.kron(I, CNOT) @ np.kron(X, np.kron(S, H)))
-        assert np.allclose(res, expected)
+        expected = pnp.linalg.eigvals(pnp.kron(I, CNOT) @ pnp.kron(X, pnp.kron(S, H)))
+        assert pnp.allclose(res, expected)
 
     def test_multiple_operations_qfunc(self):
         """Check the eigenvalues for a qfunc containing multiple gates"""
@@ -252,8 +252,8 @@ class TestMultipleOperations:
         with pytest.warns(UserWarning, match="the eigenvalues will be computed numerically"):
             res = qml.eigvals(testcircuit)()
 
-        expected = np.linalg.eigvals(np.kron(I, CNOT) @ np.kron(X, np.kron(S, H)))
-        assert np.allclose(res, expected)
+        expected = pnp.linalg.eigvals(pnp.kron(I, CNOT) @ pnp.kron(X, pnp.kron(S, H)))
+        assert pnp.allclose(res, expected)
 
     def test_multiple_operations_qnode(self):
         """Check the eigenvalues for a QNode containing multiple gates"""
@@ -270,8 +270,8 @@ class TestMultipleOperations:
         with pytest.warns(UserWarning, match="the eigenvalues will be computed numerically"):
             res = qml.eigvals(testcircuit)()
 
-        expected = np.linalg.eigvals(np.kron(I, CNOT) @ np.kron(X, np.kron(np.linalg.inv(S), H)))
-        assert np.allclose(res, expected)
+        expected = pnp.linalg.eigvals(pnp.kron(I, CNOT) @ pnp.kron(X, pnp.kron(pnp.linalg.inv(S), H)))
+        assert pnp.allclose(res, expected)
 
 
 class TestCompositeOperations:
@@ -283,10 +283,10 @@ class TestCompositeOperations:
         sum_op = qml.sum(qml.s_prod(1j, qml.PauliZ(wires=0)), qml.Identity(wires=0))
         sum_eigvals = qml.eigvals(sum_op)
 
-        mat_rep = np.array([[1 + 1j, 0], [0, 1 - 1j]])
-        mat_eigvals = np.linalg.eig(mat_rep)[0]
+        mat_rep = pnp.array([[1 + 1j, 0], [0, 1 - 1j]])
+        mat_eigvals = pnp.linalg.eig(mat_rep)[0]
 
-        assert np.allclose(mat_eigvals, sum_eigvals)
+        assert pnp.allclose(mat_eigvals, sum_eigvals)
 
     def test_prod_eigvals(self):
         """Test that a prod op returns the correct eigvals."""
@@ -294,10 +294,10 @@ class TestCompositeOperations:
         prod_op = qml.prod(qml.s_prod(1j, qml.PauliZ(wires=0)), qml.Identity(wires=1))
         prod_eigvals = qml.eigvals(prod_op)
 
-        mat_rep = np.array([[1j, 0, 0, 0], [0, 1j, 0, 0], [0, 0, -1j, 0], [0, 0, 0, -1j]])
-        mat_eigvals = np.linalg.eig(mat_rep)[0]
+        mat_rep = pnp.array([[1j, 0, 0, 0], [0, 1j, 0, 0], [0, 0, -1j, 0], [0, 0, 0, -1j]])
+        mat_eigvals = pnp.linalg.eig(mat_rep)[0]
 
-        assert np.allclose(mat_eigvals, prod_eigvals)
+        assert pnp.allclose(mat_eigvals, prod_eigvals)
 
     def test_composite_eigvals(self):
         """Test that an arithmetic op with non-hermitian base ops produces the correct eigen-values."""
@@ -306,10 +306,10 @@ class TestCompositeOperations:
         imag_op = -0.5j * (op - op_adj)
         op_eigvals = qml.eigvals(imag_op)
 
-        mat_rep = np.array([[1.0, 0.0], [0.0, -1.0]])
-        mat_eigvals = np.linalg.eig(mat_rep)[0]
+        mat_rep = pnp.array([[1.0, 0.0], [0.0, -1.0]])
+        mat_eigvals = pnp.linalg.eig(mat_rep)[0]
 
-        assert np.allclose(mat_eigvals, op_eigvals)
+        assert pnp.allclose(mat_eigvals, op_eigvals)
 
 
 class TestTemplates:
@@ -318,7 +318,7 @@ class TestTemplates:
 
     def test_instantiated(self):
         """Test an instantiated template"""
-        weights = np.array([[[0.1, 0.2, 0.3], [0.1, 0.2, 0.3]]])
+        weights = pnp.array([[[0.1, 0.2, 0.3], [0.1, 0.2, 0.3]]])
         op = qml.StronglyEntanglingLayers(weights, wires=[0, 1])
 
         with pytest.warns(UserWarning, match="the eigenvalues will be computed numerically"):
@@ -331,7 +331,7 @@ class TestTemplates:
         with pytest.warns(UserWarning, match="the eigenvalues will be computed numerically"):
             expected = qml.eigvals(tape)
 
-        assert np.allclose(res, expected)
+        assert pnp.allclose(res, expected)
 
     def test_qfunc(self):
         """Test a template used within a qfunc"""
@@ -340,7 +340,7 @@ class TestTemplates:
             qml.StronglyEntanglingLayers(weights, wires=[0, 1])
             qml.RX(x, wires=0)
 
-        weights = np.array([[[0.1, 0.2, 0.3], [0.1, 0.2, 0.3]]])
+        weights = pnp.array([[[0.1, 0.2, 0.3], [0.1, 0.2, 0.3]]])
         x = 0.54
 
         with pytest.warns(UserWarning, match="the eigenvalues will be computed numerically"):
@@ -356,7 +356,7 @@ class TestTemplates:
         with pytest.warns(UserWarning, match="the eigenvalues will be computed numerically"):
             expected = qml.eigvals(tape)
 
-        assert np.allclose(res, expected)
+        assert pnp.allclose(res, expected)
 
     def test_nested_instantiated(self):
         """Test an operation that must be decomposed twice"""
@@ -369,7 +369,7 @@ class TestTemplates:
             def compute_decomposition(weights, wires):
                 return [qml.StronglyEntanglingLayers(weights, wires=wires)]
 
-        weights = np.array([[[0.1, 0.2, 0.3], [0.1, 0.2, 0.3]]])
+        weights = pnp.array([[[0.1, 0.2, 0.3], [0.1, 0.2, 0.3]]])
         op = CustomOp(weights, wires=[0, 1])
 
         with pytest.warns(UserWarning, match="the eigenvalues will be computed numerically"):
@@ -383,7 +383,7 @@ class TestTemplates:
         with pytest.warns(UserWarning, match="the eigenvalues will be computed numerically"):
             expected = qml.eigvals(tape)
 
-        assert np.allclose(res, expected)
+        assert pnp.allclose(res, expected)
 
     def test_nested_qfunc(self):
         """Test an operation that must be decomposed twice"""
@@ -400,7 +400,7 @@ class TestTemplates:
             CustomOp(weights, wires=[0, 1])
             qml.RX(x, wires=0)
 
-        weights = np.array([[[0.1, 0.2, 0.3], [0.1, 0.2, 0.3]]])
+        weights = pnp.array([[[0.1, 0.2, 0.3], [0.1, 0.2, 0.3]]])
         x = 0.54
 
         with pytest.warns(UserWarning, match="the eigenvalues will be computed numerically"):
@@ -416,14 +416,14 @@ class TestTemplates:
         with pytest.warns(UserWarning, match="the eigenvalues will be computed numerically"):
             expected = qml.eigvals(tape)
 
-        assert np.allclose(res, expected)
+        assert pnp.allclose(res, expected)
 
 
 class TestDifferentiation:
     """Differentiation tests"""
 
     @pytest.mark.jax
-    @pytest.mark.parametrize("v", np.linspace(0.2, 1.6, 8))
+    @pytest.mark.parametrize("v", pnp.linspace(0.2, 1.6, 8))
     def test_jax(self, v):
         """Test that differentiation works correctly when using JAX"""
 
@@ -445,11 +445,11 @@ class TestDifferentiation:
             dl = jax.grad(loss)(x)
 
         assert isinstance(l, jax.numpy.ndarray)
-        assert np.allclose(l, 2 * np.cos(v / 2))
-        assert np.allclose(dl, -np.sin(v / 2))
+        assert pnp.allclose(l, 2 * pnp.cos(v / 2))
+        assert pnp.allclose(dl, -pnp.sin(v / 2))
 
     @pytest.mark.torch
-    @pytest.mark.parametrize("v", np.linspace(0.2, 1.6, 8))
+    @pytest.mark.parametrize("v", pnp.linspace(0.2, 1.6, 8))
     def test_torch(self, v):
         """Test that differentiation works correctly when using Torch"""
 
@@ -473,11 +473,11 @@ class TestDifferentiation:
         dl = x.grad
 
         assert isinstance(l, torch.Tensor)
-        assert np.allclose(l.detach(), 2 * np.cos(v / 2))
-        assert np.allclose(dl.detach(), -np.sin(v / 2))
+        assert pnp.allclose(l.detach(), 2 * pnp.cos(v / 2))
+        assert pnp.allclose(dl.detach(), -pnp.sin(v / 2))
 
     @pytest.mark.tf
-    @pytest.mark.parametrize("v", np.linspace(0.2, 1.6, 8))
+    @pytest.mark.parametrize("v", pnp.linspace(0.2, 1.6, 8))
     def test_tensorflow(self, v):
         """Test that differentiation works correctly when using TF"""
         import tensorflow as tf
@@ -498,12 +498,12 @@ class TestDifferentiation:
         dl = tape.gradient(l, x)
 
         assert isinstance(l, tf.Tensor)
-        assert np.allclose(l, 2 * np.cos(v / 2))
-        assert np.allclose(dl, -np.sin(v / 2))
+        assert pnp.allclose(l, 2 * pnp.cos(v / 2))
+        assert pnp.allclose(dl, -pnp.sin(v / 2))
 
     @pytest.mark.autograd
     @pytest.mark.xfail(reason="np.linalg.eigvals not differentiable using Autograd")
-    @pytest.mark.parametrize("v", np.linspace(0.2, 1.6, 8))
+    @pytest.mark.parametrize("v", pnp.linspace(0.2, 1.6, 8))
     def test_autograd(self, v):
         """Test that differentiation works correctly when using Autograd"""
 
@@ -516,12 +516,12 @@ class TestDifferentiation:
             U = qml.eigvals(circuit)(theta)
             return qml.math.sum(qml.math.real(U))
 
-        x = np.array(v, requires_grad=True)
+        x = pnp.array(v, requires_grad=True)
 
         with pytest.warns(UserWarning, match="the eigenvalues will be computed numerically"):
             l = loss(x)
             dl = qml.grad(loss)(x)
 
         assert isinstance(l, qml.numpy.tensor)
-        assert np.allclose(l, 2 * np.cos(v / 2))
-        assert np.allclose(dl, -np.sin(v / 2))
+        assert pnp.allclose(l, 2 * pnp.cos(v / 2))
+        assert pnp.allclose(dl, -pnp.sin(v / 2))

--- a/tests/ops/functions/test_equal.py
+++ b/tests/ops/functions/test_equal.py
@@ -25,7 +25,7 @@ import numpy as np
 import pytest
 
 import pennylane as qml
-from pennylane import numpy as npp
+from pennylane import numpy as pnp
 from pennylane.measurements import ExpectationMP
 from pennylane.measurements.probs import ProbabilityMP
 from pennylane.operation import Operator
@@ -383,7 +383,7 @@ class TestEqual:
         param_torch = torch.tensor(0.123)
         param_tf = tf.Variable(0.123)
         param_jax = jax.numpy.array(0.123)
-        param_qml = npp.array(0.123)
+        param_qml = pnp.array(0.123)
         param_np = np.array(0.123)
 
         param_list = [param_qml, param_torch, param_jax, param_tf, param_np]
@@ -437,7 +437,7 @@ class TestEqual:
         param_torch = torch.tensor(0.123)
         param_tf = tf.Variable(0.123)
         param_jax = jax.numpy.array(0.123)
-        param_qml = npp.array(0.123)
+        param_qml = pnp.array(0.123)
         param_np = np.array(0.123)
 
         param_list = [param_qml, param_torch, param_jax, param_tf, param_np]
@@ -507,7 +507,7 @@ class TestEqual:
         param_torch = torch.tensor(0.123)
         param_tf = tf.Variable(0.123)
         param_jax = jax.numpy.array(0.123)
-        param_qml = npp.array(0.123)
+        param_qml = pnp.array(0.123)
         param_np = np.array(0.123)
 
         param_list = [param_qml, param_torch, param_jax, param_tf, param_np]
@@ -577,7 +577,7 @@ class TestEqual:
         param_torch = torch.tensor([1, 2, 3])
         param_tf = tf.Variable([1, 2, 3])
         param_jax = jax.numpy.array([1, 2, 3])
-        param_qml = npp.array([1, 2, 3])
+        param_qml = pnp.array([1, 2, 3])
         param_np = np.array([1, 2, 3])
 
         param_list = [param_qml, param_torch, param_jax, param_tf, param_np]
@@ -647,7 +647,7 @@ class TestEqual:
         param_torch = torch.tensor([1, 2])
         param_tf = tf.Variable([1, 2])
         param_jax = jax.numpy.array([1, 2])
-        param_qml = npp.array([1, 2])
+        param_qml = pnp.array([1, 2])
         param_np = np.array([1, 2])
 
         op1 = PARAMETRIZED_OPERATIONS_2P_1W[0]
@@ -685,7 +685,7 @@ class TestEqual:
         param_torch = torch.tensor(1)
         param_tf = tf.Variable(1)
         param_jax = jax.numpy.array(1)
-        param_qml = npp.array(1)
+        param_qml = pnp.array(1)
         param_np = np.array(1)
 
         op1 = PARAMETRIZED_OPERATIONS_1P_3W[0]
@@ -723,7 +723,7 @@ class TestEqual:
         param_torch = torch.tensor([1, 2, 3])
         param_tf = tf.Variable([1, 2, 3])
         param_jax = jax.numpy.array([1, 2, 3])
-        param_qml = npp.array([1, 2, 3])
+        param_qml = pnp.array([1, 2, 3])
         param_np = np.array([1, 2, 3])
 
         op1 = PARAMETRIZED_OPERATIONS_3P_2W[0]
@@ -761,7 +761,7 @@ class TestEqual:
         param_torch = torch.tensor(1)
         param_tf = tf.Variable(1)
         param_jax = jax.numpy.array(1)
-        param_qml = npp.array(1)
+        param_qml = pnp.array(1)
         param_np = np.array(1)
 
         op1 = PARAMETRIZED_OPERATIONS_Remaining[0]
@@ -799,7 +799,7 @@ class TestEqual:
         param_torch = torch.tensor([[1, 0], [0, 1]]) * 1j
         param_tf = tf.Variable([[1, 0], [0, 1]], dtype=tf.complex64) * 1j
         param_jax = jax.numpy.eye(2) * 1j
-        param_qml = npp.eye(2) * 1j
+        param_qml = pnp.eye(2) * 1j
         param_np = np.eye(2) * 1j
 
         op1 = PARAMETRIZED_OPERATIONS_Remaining[1]
@@ -837,7 +837,7 @@ class TestEqual:
         param_torch = torch.tensor([1.0, 1.0j])
         param_tf = tf.Variable([1.0 + 0j, 1.0j])
         param_jax = jax.numpy.array([1.0, 1.0j])
-        param_qml = npp.array([1.0, 1.0j])
+        param_qml = pnp.array([1.0, 1.0j])
         param_np = np.array([1.0, 1.0j])
 
         op1 = PARAMETRIZED_OPERATIONS_Remaining[2]
@@ -875,7 +875,7 @@ class TestEqual:
         param_torch = torch.tensor([[1, 0], [0, 1]]) * 1j
         param_tf = tf.Variable([[1, 0], [0, 1]], dtype=tf.complex64) * 1j
         param_jax = jax.numpy.eye(2) * 1j
-        param_qml = npp.eye(2) * 1j
+        param_qml = pnp.eye(2) * 1j
         param_np = np.eye(2) * 1j
 
         op1 = PARAMETRIZED_OPERATIONS_Remaining[3]
@@ -1684,15 +1684,15 @@ class TestSymbolicOpComparison:
     def test_adjoint_base_op_comparison_with_interface(self):
         """Test that equal compares the parameters within a provided interface of the base operator of Adjoint class."""
         op1 = qml.adjoint(qml.RX(1.2, wires=0))
-        op2 = qml.adjoint(qml.RX(npp.array(1.2), wires=0))
+        op2 = qml.adjoint(qml.RX(pnp.array(1.2), wires=0))
 
         assert qml.equal(op1, op2, check_interface=False, check_trainability=False)
         assert not qml.equal(op1, op2, check_interface=True, check_trainability=False)
 
     def test_adjoint_base_op_comparison_with_trainability(self):
         """Test that equal compares the parameters within a provided trainability of the base operator of Adjoint class."""
-        op1 = qml.adjoint(qml.RX(npp.array(1.2, requires_grad=False), wires=0))
-        op2 = qml.adjoint(qml.RX(npp.array(1.2, requires_grad=True), wires=0))
+        op1 = qml.adjoint(qml.RX(pnp.array(1.2, requires_grad=False), wires=0))
+        op2 = qml.adjoint(qml.RX(pnp.array(1.2, requires_grad=True), wires=0))
 
         assert qml.equal(op1, op2, check_interface=False, check_trainability=False)
         assert not qml.equal(op1, op2, check_interface=False, check_trainability=True)
@@ -1745,7 +1745,7 @@ class TestSymbolicOpComparison:
         """Test that equal compares the parameters within a provided interface of the base operator of Conditional class."""
         m = qml.measure(0)
         base1 = qml.RX(1.2, wires=0)
-        base2 = qml.RX(npp.array(1.2), wires=0)
+        base2 = qml.RX(pnp.array(1.2), wires=0)
         op1 = Conditional(m, base1)
         op2 = Conditional(m, base2)
 
@@ -1756,8 +1756,8 @@ class TestSymbolicOpComparison:
         """Test that equal compares the parameters within a provided trainability of the base operator of Conditional class."""
 
         m = qml.measure(0)
-        base1 = qml.RX(npp.array(1.2, requires_grad=False), wires=0)
-        base2 = qml.RX(npp.array(1.2, requires_grad=True), wires=0)
+        base1 = qml.RX(pnp.array(1.2, requires_grad=False), wires=0)
+        base2 = qml.RX(pnp.array(1.2, requires_grad=True), wires=0)
         op1 = Conditional(m, base1)
         op2 = Conditional(m, base2)
 
@@ -1795,7 +1795,7 @@ class TestSymbolicOpComparison:
     def test_pow_comparison_with_interface(self):
         """Test that equal compares the parameters within a provided interface of the Pow class."""
         op1 = qml.pow(qml.RX(1.2, wires=0), 2)
-        op2 = qml.pow(qml.RX(1.2, wires=0), npp.array(2))
+        op2 = qml.pow(qml.RX(1.2, wires=0), pnp.array(2))
 
         assert qml.equal(op1, op2, check_interface=False, check_trainability=False)
         assert not qml.equal(op1, op2, check_interface=True, check_trainability=False)
@@ -1804,8 +1804,8 @@ class TestSymbolicOpComparison:
 
     def test_pow_comparison_with_trainability(self):
         """Test that equal compares the parameters within a provided trainability of the Pow class."""
-        op1 = qml.pow(qml.RX(1.2, wires=0), npp.array(2, requires_grad=False))
-        op2 = qml.pow(qml.RX(1.2, wires=0), npp.array(2, requires_grad=True))
+        op1 = qml.pow(qml.RX(1.2, wires=0), pnp.array(2, requires_grad=False))
+        op2 = qml.pow(qml.RX(1.2, wires=0), pnp.array(2, requires_grad=True))
 
         assert qml.equal(op1, op2, check_interface=False, check_trainability=False)
         assert not qml.equal(op1, op2, check_interface=False, check_trainability=True)
@@ -1815,15 +1815,15 @@ class TestSymbolicOpComparison:
     def test_pow_base_op_comparison_with_interface(self):
         """Test that equal compares the parameters within a provided interface of the base operator of Pow class."""
         op1 = qml.pow(qml.RX(1.2, wires=0), 2)
-        op2 = qml.pow(qml.RX(npp.array(1.2), wires=0), 2)
+        op2 = qml.pow(qml.RX(pnp.array(1.2), wires=0), 2)
 
         assert qml.equal(op1, op2, check_interface=False, check_trainability=False)
         assert not qml.equal(op1, op2, check_interface=True, check_trainability=False)
 
     def test_pow_base_op_comparison_with_trainability(self):
         """Test that equal compares the parameters within a provided trainability of the base operator of Pow class."""
-        op1 = qml.pow(qml.RX(npp.array(1.2, requires_grad=False), wires=0), 2)
-        op2 = qml.pow(qml.RX(npp.array(1.2, requires_grad=True), wires=0), 2)
+        op1 = qml.pow(qml.RX(pnp.array(1.2, requires_grad=False), wires=0), 2)
+        op2 = qml.pow(qml.RX(pnp.array(1.2, requires_grad=True), wires=0), 2)
 
         assert qml.equal(op1, op2, check_interface=False, check_trainability=False)
         assert not qml.equal(op1, op2, check_interface=False, check_trainability=True)
@@ -1868,7 +1868,7 @@ class TestSymbolicOpComparison:
     def test_exp_comparison_with_interface(self):
         """Test that equal compares the parameters within a provided interface of the Exp class."""
         op1 = qml.exp(qml.PauliX(0), 1.2)
-        op2 = qml.exp(qml.PauliX(0), npp.array(1.2))
+        op2 = qml.exp(qml.PauliX(0), pnp.array(1.2))
 
         assert qml.equal(op1, op2, check_interface=False, check_trainability=False)
         assert not qml.equal(op1, op2, check_interface=True, check_trainability=False)
@@ -1879,8 +1879,8 @@ class TestSymbolicOpComparison:
 
     def test_exp_comparison_with_trainability(self):
         """Test that equal compares the parameters within a provided trainability of the Exp class."""
-        op1 = qml.exp(qml.PauliX(0), npp.array(1.2, requires_grad=False))
-        op2 = qml.exp(qml.PauliX(0), npp.array(1.2, requires_grad=True))
+        op1 = qml.exp(qml.PauliX(0), pnp.array(1.2, requires_grad=False))
+        op2 = qml.exp(qml.PauliX(0), pnp.array(1.2, requires_grad=True))
 
         assert qml.equal(op1, op2, check_interface=False, check_trainability=False)
         assert not qml.equal(op1, op2, check_interface=False, check_trainability=True)
@@ -1892,7 +1892,7 @@ class TestSymbolicOpComparison:
     def test_exp_base_op_comparison_with_interface(self):
         """Test that equal compares the parameters within a provided interface of the base operator of Exp class."""
         op1 = qml.exp(qml.RX(0.5, wires=0), 1.2)
-        op2 = qml.exp(qml.RX(npp.array(0.5), wires=0), 1.2)
+        op2 = qml.exp(qml.RX(pnp.array(0.5), wires=0), 1.2)
 
         assert qml.equal(op1, op2, check_interface=False, check_trainability=False)
         assert not qml.equal(op1, op2, check_interface=True, check_trainability=False)
@@ -1903,8 +1903,8 @@ class TestSymbolicOpComparison:
 
     def test_exp_base_op_comparison_with_trainability(self):
         """Test that equal compares the parameters within a provided trainability of the base operator of Exp class."""
-        op1 = qml.exp(qml.RX(npp.array(0.5, requires_grad=False), wires=0), 1.2)
-        op2 = qml.exp(qml.RX(npp.array(0.5, requires_grad=True), wires=0), 1.2)
+        op1 = qml.exp(qml.RX(pnp.array(0.5, requires_grad=False), wires=0), 1.2)
+        op2 = qml.exp(qml.RX(pnp.array(0.5, requires_grad=True), wires=0), 1.2)
 
         assert qml.equal(op1, op2, check_interface=False, check_trainability=False)
         assert not qml.equal(op1, op2, check_interface=False, check_trainability=True)
@@ -1960,7 +1960,7 @@ class TestSymbolicOpComparison:
     def test_s_prod_comparison_with_interface(self):
         """Test that equal compares the parameters within a provided interface of the SProd class."""
         op1 = qml.s_prod(0.12, qml.PauliX(0))
-        op2 = qml.s_prod(npp.array(0.12), qml.PauliX(0))
+        op2 = qml.s_prod(pnp.array(0.12), qml.PauliX(0))
 
         assert qml.equal(op1, op2, check_interface=False, check_trainability=False)
         assert not qml.equal(op1, op2, check_interface=True, check_trainability=False)
@@ -1969,8 +1969,8 @@ class TestSymbolicOpComparison:
 
     def test_s_prod_comparison_with_trainability(self):
         """Test that equal compares the parameters within a provided trainability of the SProd class."""
-        op1 = qml.s_prod(npp.array(0.12, requires_grad=False), qml.PauliX(0))
-        op2 = qml.s_prod(npp.array(0.12, requires_grad=True), qml.PauliX(0))
+        op1 = qml.s_prod(pnp.array(0.12, requires_grad=False), qml.PauliX(0))
+        op2 = qml.s_prod(pnp.array(0.12, requires_grad=True), qml.PauliX(0))
 
         assert qml.equal(op1, op2, check_interface=False, check_trainability=False)
         assert not qml.equal(op1, op2, check_interface=False, check_trainability=True)
@@ -1980,15 +1980,15 @@ class TestSymbolicOpComparison:
     def test_s_prod_base_op_comparison_with_interface(self):
         """Test that equal compares the parameters within a provided interface of the base operator of SProd class."""
         op1 = qml.s_prod(0.12, qml.RX(0.5, wires=0))
-        op2 = qml.s_prod(0.12, qml.RX(npp.array(0.5), wires=0))
+        op2 = qml.s_prod(0.12, qml.RX(pnp.array(0.5), wires=0))
 
         assert qml.equal(op1, op2, check_interface=False, check_trainability=False)
         assert not qml.equal(op1, op2, check_interface=True, check_trainability=False)
 
     def test_s_prod_base_op_comparison_with_trainability(self):
         """Test that equal compares the parameters within a provided trainability of the base operator of SProd class."""
-        op1 = qml.s_prod(0.12, qml.RX(npp.array(0.5, requires_grad=False), wires=0))
-        op2 = qml.s_prod(0.12, qml.RX(npp.array(0.5, requires_grad=True), wires=0))
+        op1 = qml.s_prod(0.12, qml.RX(pnp.array(0.5, requires_grad=False), wires=0))
+        op2 = qml.s_prod(0.12, qml.RX(pnp.array(0.5, requires_grad=True), wires=0))
 
         assert qml.equal(op1, op2, check_interface=False, check_trainability=False)
         assert not qml.equal(op1, op2, check_interface=False, check_trainability=True)
@@ -2528,15 +2528,15 @@ class TestHilbertSchmidt:
 
     u_tape1 = qml.tape.QuantumScript([qml.RX(0.2, 0)])
     u_tape1_eps = qml.tape.QuantumScript([qml.RX(0.2 + 1e-7, 0)])
-    u_tape1_trainable = qml.tape.QuantumScript([qml.RX(npp.array(0.2, requires_grad=True), 0)])
-    u_tape1_untrainable = qml.tape.QuantumScript([qml.RX(npp.array(0.2, requires_grad=False), 0)])
+    u_tape1_trainable = qml.tape.QuantumScript([qml.RX(pnp.array(0.2, requires_grad=True), 0)])
+    u_tape1_untrainable = qml.tape.QuantumScript([qml.RX(pnp.array(0.2, requires_grad=False), 0)])
     u_tape2 = qml.tape.QuantumScript([qml.Hadamard(2)])
 
     v_params1 = [0.2, 0.3]
     v_params2 = [0.1, 0.5]
     v_params1_eps = [0.2 + 1e-7, 0.3]
-    v_params1_trainable = npp.array(v_params1, requires_grad=True)
-    v_params1_untrainable = npp.array(v_params1, requires_grad=False)
+    v_params1_trainable = pnp.array(v_params1, requires_grad=True)
+    v_params1_untrainable = pnp.array(v_params1, requires_grad=False)
 
     op1 = qml.HilbertSchmidt(v_params1, v_function=v_function1, v_wires=v_wires1, u_tape=u_tape1)
     op1_trainable = qml.HilbertSchmidt(

--- a/tests/ops/functions/test_generator.py
+++ b/tests/ops/functions/test_generator.py
@@ -22,7 +22,7 @@ import pytest
 from scipy import sparse
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane.ops import Prod, SProd, Sum
 
 ###################################################################
@@ -135,7 +135,7 @@ class SumOpSameAbsCoeff(CustomOp):
 class HermitianOp(CustomOp):
     """Returns the generator as a Hermitian observable"""
 
-    H = np.array([[1.0, 2.0], [2.0, 3.0]])
+    H = pnp.array([[1.0, 2.0], [2.0, 3.0]])
 
     def generator(self):
         return qml.Hermitian(self.H, wires=self.wires[0])
@@ -144,7 +144,7 @@ class HermitianOp(CustomOp):
 class SparseOp(CustomOp):
     """Returns the generator as a SparseHamiltonian observable"""
 
-    H = sparse.csr_matrix(np.array([[1.0, 2.0], [2.0, 3.0]]))
+    H = sparse.csr_matrix(pnp.array([[1.0, 2.0], [2.0, 3.0]]))
 
     def generator(self):
         return qml.SparseHamiltonian(self.H, wires=self.wires[0])
@@ -221,7 +221,7 @@ class TestBackwardsCompatibility:
         continues to work but also raises a deprecation warning."""
 
         class DeprecatedClassOp(CustomOp):
-            generator = [np.diag([0, 1]), -0.6]
+            generator = [pnp.diag([0, 1]), -0.6]
 
         op = DeprecatedClassOp(0.5, wires="a")
 
@@ -326,7 +326,7 @@ class TestPrefactorReturn:
         gen, prefactor = qml.generator(HermitianOp, format="prefactor")(0.5, wires=0)
         assert prefactor == 1.0
         assert gen.name == "Hermitian"
-        assert np.all(gen.parameters[0] == HermitianOp.H)
+        assert pnp.all(gen.parameters[0] == HermitianOp.H)
 
     def test_sparse_hamiltonian(self):
         """Test a generator that returns a SparseHamiltonian observable
@@ -334,7 +334,7 @@ class TestPrefactorReturn:
         gen, prefactor = qml.generator(SparseOp, format="prefactor")(0.5, wires=0)
         assert prefactor == 1.0
         assert gen.name == "SparseHamiltonian"
-        assert np.all(gen.parameters[0].toarray() == SparseOp.H.toarray())
+        assert pnp.all(gen.parameters[0].toarray() == SparseOp.H.toarray())
 
 
 class TestObservableReturn:
@@ -364,14 +364,14 @@ class TestObservableReturn:
         is correct"""
         gen = qml.generator(HermitianOp, format="observable")(0.5, wires=0)
         assert gen.name == "Hermitian"
-        assert np.all(gen.parameters[0] == HermitianOp.H)
+        assert pnp.all(gen.parameters[0] == HermitianOp.H)
 
     def test_sparse_hamiltonian(self):
         """Test a generator that returns a SparseHamiltonian observable
         is correct"""
         gen = qml.generator(SparseOp, format="observable")(0.5, wires=0)
         assert gen.name == "SparseHamiltonian"
-        assert np.all(gen.parameters[0].toarray() == SparseOp.H.toarray())
+        assert pnp.all(gen.parameters[0].toarray() == SparseOp.H.toarray())
 
 
 class TestHamiltonianReturn:
@@ -438,7 +438,7 @@ class TestArithmeticReturn:
     def test_observable_no_coeff(self):
         """Test a generator that returns an observable with no coefficient is correct"""
         gen = qml.generator(qml.PhaseShift, format="arithmetic")(0.5, wires=0)
-        qml.assert_equal(gen, qml.Projector(np.array([1]), wires=0))
+        qml.assert_equal(gen, qml.Projector(pnp.array([1]), wires=0))
 
     def test_observable(self):
         """Test a generator that returns a single observable is correct"""
@@ -451,7 +451,7 @@ class TestArithmeticReturn:
         result = qml.s_prod(0.5, qml.PauliX(0) @ qml.PauliY(1))
 
         assert not isinstance(gen, qml.Hamiltonian)
-        assert np.allclose(
+        assert pnp.allclose(
             qml.matrix(gen, wire_order=[0, 1]),
             qml.matrix(result, wire_order=[0, 1]),
         )
@@ -464,7 +464,7 @@ class TestArithmeticReturn:
             qml.s_prod(0.5, qml.PauliX(0) @ qml.PauliY(1)),
         )
         assert not isinstance(gen, qml.Hamiltonian)
-        assert np.allclose(
+        assert pnp.allclose(
             qml.matrix(gen, wire_order=[0, 1]),
             qml.matrix(result, wire_order=[0, 1]),
         )
@@ -476,7 +476,7 @@ class TestArithmeticReturn:
         expected = qml.pauli_decompose(HermitianOp.H, hide_identity=True, pauli=True).operation()
 
         assert not isinstance(gen, qml.Hamiltonian)
-        assert np.allclose(
+        assert pnp.allclose(
             qml.matrix(gen),
             qml.matrix(expected),
         )
@@ -490,7 +490,7 @@ class TestArithmeticReturn:
         ).operation()
 
         assert not isinstance(gen, qml.Hamiltonian)
-        assert np.allclose(
+        assert pnp.allclose(
             qml.matrix(gen),
             qml.matrix(expected),
         )

--- a/tests/ops/functions/test_is_commuting.py
+++ b/tests/ops/functions/test_is_commuting.py
@@ -18,7 +18,7 @@ Unittests for is_commuting
 import pytest
 
 import pennylane as qml
-import pennylane.numpy as np
+import pennylane.numpy as pnp
 from pennylane.ops.functions.is_commuting import _check_mat_commutation, _get_target_name
 
 control_base_map_data = [
@@ -474,7 +474,7 @@ class TestCommutingFunction:
     def test_rot_x_simplified(self, wires, res):
         """Commutation between Rot(np.pi / 2, 0.1, -np.pi / 2) and PauliX."""
         commutation = qml.is_commuting(
-            qml.Rot(np.pi / 2, 0.1, -np.pi / 2, wires=wires[0]), qml.PauliX(wires=wires[1])
+            qml.Rot(pnp.pi / 2, 0.1, -pnp.pi / 2, wires=wires[0]), qml.PauliX(wires=wires[1])
         )
         assert commutation == res
 
@@ -516,7 +516,7 @@ class TestCommutingFunction:
     def test_rot_hadamard_simplified(self, wires, res):
         """Commutation between Rot(np.pi, np.pi / 2, 0) and Hadamard."""
         commutation = qml.is_commuting(
-            qml.Rot(np.pi, np.pi / 2, 0, wires=wires[0]), qml.Hadamard(wires=wires[1])
+            qml.Rot(pnp.pi, pnp.pi / 2, 0, wires=wires[0]), qml.Hadamard(wires=wires[1])
         )
         assert commutation == res
 
@@ -544,7 +544,7 @@ class TestCommutingFunction:
     def test_crot_x_simplified(self, wires, res):
         """Commutation between CRot(np.pi / 2, 0.1, -np.pi / 2) and PauliX."""
         commutation = qml.is_commuting(
-            qml.CRot(np.pi / 2, 0.1, -np.pi / 2, wires=wires[0]), qml.PauliX(wires=wires[1])
+            qml.CRot(pnp.pi / 2, 0.1, -pnp.pi / 2, wires=wires[0]), qml.PauliX(wires=wires[1])
         )
         assert commutation == res
 
@@ -585,7 +585,7 @@ class TestCommutingFunction:
     )
     def test_crot_hadamard_simplified(self, wires, res):
         """Commutation between CRot(np.pi, np.pi / 2, 0) and Hadamard."""
-        op1 = qml.CRot(np.pi, np.pi / 2, 0, wires=wires[0])
+        op1 = qml.CRot(pnp.pi, pnp.pi / 2, 0, wires=wires[0])
         op2 = qml.Hadamard(wires=wires[1])
         assert qml.is_commuting(op1, op2) == res
         assert qml.is_commuting(op2, op1) == res
@@ -614,7 +614,7 @@ class TestCommutingFunction:
     def test_u2_y_simplified(self, wires, res):
         """Commutation between U2(2*np.pi, -2*np.pi) and PauliY."""
         commutation = qml.is_commuting(
-            qml.U2(2 * np.pi, -2 * np.pi, wires=wires[0]), qml.PauliY(wires=wires[1])
+            qml.U2(2 * pnp.pi, -2 * pnp.pi, wires=wires[0]), qml.PauliY(wires=wires[1])
         )
         assert commutation == res
 
@@ -628,7 +628,7 @@ class TestCommutingFunction:
     def test_u2_x_simplified(self, wires, res):
         """Commutation between U2(np.pi/2, -np.pi/2) and PauliX."""
         commutation = qml.is_commuting(
-            qml.U2(np.pi / 2, -np.pi / 2, wires=wires[0]), qml.PauliX(wires=wires[1])
+            qml.U2(pnp.pi / 2, -pnp.pi / 2, wires=wires[0]), qml.PauliX(wires=wires[1])
         )
         assert commutation == res
 
@@ -728,7 +728,7 @@ class TestCommutingFunction:
     def test_u3_simplified_x(self, wires, res):
         """Commutation between U3(0.1, -np.pi/2, np.pi/2) and PauliX."""
         commutation = qml.is_commuting(
-            qml.U3(0.1, -np.pi / 2, np.pi / 2, wires=wires[0]), qml.PauliX(wires=wires[1])
+            qml.U3(0.1, -pnp.pi / 2, pnp.pi / 2, wires=wires[0]), qml.PauliX(wires=wires[1])
         )
         assert commutation == res
 
@@ -831,7 +831,7 @@ class TestCommutingFunction:
 
     def test_operation_1_not_supported(self):
         """Test that giving a non supported operation raises an error."""
-        rho = np.zeros((2**1, 2**1), dtype=np.complex128)
+        rho = pnp.zeros((2**1, 2**1), dtype=pnp.complex128)
         rho[0, 0] = 1
         with pytest.raises(
             qml.QuantumFunctionError, match="Operation QubitDensityMatrix not supported."

--- a/tests/ops/functions/test_simplify.py
+++ b/tests/ops/functions/test_simplify.py
@@ -20,7 +20,7 @@ import warnings
 import pytest
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane.tape import QuantumScript
 
 
@@ -45,11 +45,11 @@ def build_op():
 
 
 simplified_op = qml.prod(
-    qml.RX(4 * np.pi - 1, 0),
-    qml.RZ(4 * np.pi - 1, 0),
+    qml.RX(4 * pnp.pi - 1, 0),
+    qml.RZ(4 * pnp.pi - 1, 0),
     qml.PauliX(0),
-    qml.RY(4 * np.pi - 1, 0),
-    qml.RX(4 * np.pi - 1, 0),
+    qml.RY(4 * pnp.pi - 1, 0),
+    qml.RX(4 * pnp.pi - 1, 0),
 )
 
 

--- a/tests/ops/op_math/test_adjoint.py
+++ b/tests/ops/op_math/test_adjoint.py
@@ -15,11 +15,11 @@
 
 import pickle
 
-import numpy as np
+import numpy as pnp
 import pytest
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane.ops.op_math.adjoint import Adjoint, AdjointOperation, adjoint
 
 
@@ -161,7 +161,7 @@ class TestInitialization:
 
     def test_template_base(self, seed):
         """Test adjoint initialization for a template."""
-        rng = np.random.default_rng(seed=seed)
+        rng = pnp.random.default_rng(seed=seed)
         shape = qml.StronglyEntanglingLayers.shape(n_layers=2, n_wires=2)
         params = rng.random(shape)
 
@@ -184,7 +184,7 @@ class TestProperties:
 
     def test_data(self):
         """Test base data can be get and set through Adjoint class."""
-        x = np.array(1.234)
+        x = pnp.array(1.234)
 
         base = qml.RX(x, wires="a")
         adj = Adjoint(base)
@@ -192,13 +192,13 @@ class TestProperties:
         assert adj.data == (x,)
 
         # update parameters through adjoint
-        x_new = np.array(2.3456)
+        x_new = pnp.array(2.3456)
         adj.data = (x_new,)
         assert base.data == (x_new,)
         assert adj.data == (x_new,)
 
         # update base data updates Adjoint data
-        x_new2 = np.array(3.456)
+        x_new2 = pnp.array(3.456)
         base.data = (x_new2,)
         assert adj.data == (x_new2,)
 
@@ -315,7 +315,7 @@ class TestProperties:
     def test_batching_properties(self):
         """Test the batching properties and methods."""
 
-        base = qml.RX(np.array([1.2, 2.3, 3.4]), 0)
+        base = qml.RX(pnp.array([1.2, 2.3, 3.4]), 0)
         op = Adjoint(base)
         assert op.batch_size == 3
         assert op.ndim_params == (0,)
@@ -332,7 +332,7 @@ class TestSimplify:
     def test_simplify_method(self):
         """Test that the simplify method reduces complexity to the minimum."""
         adj_op = Adjoint(Adjoint(Adjoint(qml.RZ(1.32, wires=0))))
-        final_op = qml.RZ(4 * np.pi - 1.32, wires=0)
+        final_op = qml.RZ(4 * pnp.pi - 1.32, wires=0)
         simplified_op = adj_op.simplify()
         qml.assert_equal(simplified_op, final_op)
 
@@ -340,7 +340,7 @@ class TestSimplify:
         """Test that the simplify methods converts an adjoint of sums to a sum of adjoints."""
         adj_op = Adjoint(qml.sum(qml.RX(1, 0), qml.RY(1, 0), qml.RZ(1, 0)))
         sum_op = qml.sum(
-            qml.RX(4 * np.pi - 1, 0), qml.RY(4 * np.pi - 1, 0), qml.RZ(4 * np.pi - 1, 0)
+            qml.RX(4 * pnp.pi - 1, 0), qml.RY(4 * pnp.pi - 1, 0), qml.RZ(4 * pnp.pi - 1, 0)
         )
         simplified_op = adj_op.simplify()
         qml.assert_equal(simplified_op, sum_op)
@@ -350,7 +350,7 @@ class TestSimplify:
         of adjoints."""
         adj_op = Adjoint(qml.prod(qml.RX(1, 0), qml.RY(1, 0), qml.RZ(1, 0)))
         final_op = qml.prod(
-            qml.RZ(4 * np.pi - 1, 0), qml.RY(4 * np.pi - 1, 0), qml.RX(4 * np.pi - 1, 0)
+            qml.RZ(4 * pnp.pi - 1, 0), qml.RY(4 * pnp.pi - 1, 0), qml.RX(4 * pnp.pi - 1, 0)
         )
         simplified_op = adj_op.simplify()
         qml.assert_equal(simplified_op, final_op)
@@ -396,7 +396,7 @@ class TestMiscMethods:
         diag_gate = Adjoint(base).diagonalizing_gates()[0]
 
         assert isinstance(diag_gate, qml.RY)
-        assert qml.math.allclose(diag_gate.data[0], -np.pi / 4)
+        assert qml.math.allclose(diag_gate.data[0], -pnp.pi / 4)
 
     # pylint: disable=protected-access
     def test_flatten_unflatten(self):
@@ -561,7 +561,7 @@ class TestMatrix:
     @pytest.mark.autograd
     def test_matrix_autograd(self):
         """Test the matrix of an Adjoint operator with an autograd parameter."""
-        self.check_matrix(np.array(1.2345), "autograd")
+        self.check_matrix(pnp.array(1.2345), "autograd")
 
     @pytest.mark.jax
     def test_matrix_jax(self):
@@ -586,7 +586,7 @@ class TestMatrix:
 
     def test_no_matrix_defined(self, seed):
         """Test that if the base has no matrix defined, then Adjoint.matrix also raises a MatrixUndefinedError."""
-        rng = np.random.default_rng(seed=seed)
+        rng = pnp.random.default_rng(seed=seed)
         shape = qml.StronglyEntanglingLayers.shape(n_layers=2, n_wires=2)
         params = rng.random(shape)
 
@@ -602,14 +602,14 @@ class TestMatrix:
         mat = adj_op.matrix()
 
         true_mat = qml.matrix(U)
-        assert np.allclose(mat, true_mat)
+        assert pnp.allclose(mat, true_mat)
 
 
 def test_sparse_matrix():
     """Test that the spare_matrix method returns the adjoint of the base sparse matrix."""
     from scipy.sparse import coo_matrix, csr_matrix
 
-    H = np.array([[6 + 0j, 1 - 2j], [1 + 2j, -1]])
+    H = pnp.array([[6 + 0j, 1 - 2j], [1 + 2j, -1]])
     H = csr_matrix(H)
     base = qml.SparseHamiltonian(H, wires=0)
 
@@ -629,7 +629,7 @@ class TestEigvals:
     """Test the Adjoint class adjoint methods."""
 
     @pytest.mark.parametrize(
-        "base", (qml.PauliX(0), qml.Hermitian(np.array([[6 + 0j, 1 - 2j], [1 + 2j, -1]]), wires=0))
+        "base", (qml.PauliX(0), qml.Hermitian(pnp.array([[6 + 0j, 1 - 2j], [1 + 2j, -1]]), wires=0))
     )
     def test_hermitian_eigvals(self, base):
         """Test adjoint's eigvals are the same as base eigvals when op is Hermitian."""
@@ -648,7 +648,7 @@ class TestEigvals:
 
     def test_batching_eigvals(self):
         """Test that eigenvalues work with batched parameters."""
-        x = np.array([1.2, 2.3, 3.4])
+        x = pnp.array([1.2, 2.3, 3.4])
         base = qml.RX(x, 0)
         adj = Adjoint(base)
         compare = qml.RX(-x, 0)
@@ -709,7 +709,7 @@ class TestDecompositionExpand:
         """Test that when the base gate doesn't have a decomposition, the Adjoint decomposition
         method raises the proper error."""
         nr_wires = 2
-        rho = np.zeros((2**nr_wires, 2**nr_wires), dtype=np.complex128)
+        rho = pnp.zeros((2**nr_wires, 2**nr_wires), dtype=pnp.complex128)
         rho[0, 0] = 1  # initialize the pure state density matrix for the |0><0| state
         base = qml.QubitDensityMatrix(rho, wires=(0, 1))
 
@@ -741,14 +741,14 @@ class TestIntegration:
             Adjoint(qml.RX(x, wires=0))
             return qml.expval(qml.PauliY(0))
 
-        x = np.array(1.2345, requires_grad=True)
+        x = pnp.array(1.2345, requires_grad=True)
 
         res = circuit(x)
-        expected = np.sin(x)
+        expected = pnp.sin(x)
         assert qml.math.allclose(res, expected)
 
         grad = qml.grad(circuit)(x)
-        expected_grad = np.cos(x)
+        expected_grad = pnp.cos(x)
 
         assert qml.math.allclose(grad, expected_grad)
 
@@ -764,7 +764,7 @@ class TestIntegration:
         x = qml.numpy.array([1.234, 2.34, 3.456])
         res = circuit(x)
 
-        expected = np.sin(x)
+        expected = pnp.sin(x)
         assert qml.math.allclose(res, expected)
 
 
@@ -1047,9 +1047,9 @@ class TestAdjointConstructorIntegration:
             return qml.state()
 
         res = circ()
-        expected = np.array([0, -1j])
+        expected = pnp.array([0, -1j])
 
-        assert np.allclose(res, expected)
+        assert pnp.allclose(res, expected)
 
     @pytest.mark.autograd
     @pytest.mark.parametrize("diff_method", ("backprop", "adjoint", "parameter-shift"))
@@ -1063,8 +1063,8 @@ class TestAdjointConstructorIntegration:
             return qml.expval(qml.PauliY(0))
 
         x = autograd.numpy.array(0.234)
-        expected_res = np.sin(x)
-        expected_grad = np.cos(x)
+        expected_res = pnp.sin(x)
+        expected_grad = pnp.cos(x)
         assert qml.math.allclose(circ(x), expected_res)
         assert qml.math.allclose(
             autograd.grad(circ)(x), expected_grad  # pylint: disable=no-value-for-parameter

--- a/tests/ops/op_math/test_decompositions.py
+++ b/tests/ops/op_math/test_decompositions.py
@@ -22,7 +22,7 @@ import pytest
 from gate_data import CNOT, SWAP, H, I, S, T, X, Y, Z
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane.ops.op_math.decompositions import one_qubit_decomposition, two_qubit_decomposition
 from pennylane.ops.op_math.decompositions.two_qubit_unitary import (
     _compute_num_cnots,
@@ -63,7 +63,7 @@ def _run_assertions(U, expected_gates, expected_params, obtained_gates):
         ), "Incorrect gate parameters"
 
     obtained_mat = reduce(
-        np.matmul, [op.matrix(wire_order=["a"]) for op in reversed(obtained_gates)]
+        pnp.matmul, [op.matrix(wire_order=["a"]) for op in reversed(obtained_gates)]
     )
 
     if len(obtained_mat.shape) == 2:
@@ -92,36 +92,36 @@ typeof_gates_zyz = (qml.RZ, qml.RY, qml.RZ, qml.GlobalPhase)
 test_cases_zyz = [
     # Special unitaries
     (I, [0.0, 0.0, 0.0, 0]),
-    (Z, [np.pi / 2, 0.0, np.pi / 2, -np.pi / 2]),
-    (S, [np.pi / 4, 0.0, np.pi / 4, -np.pi / 4]),
-    (T, [np.pi / 8, 0.0, np.pi / 8, -np.pi / 8]),
-    (H, [np.pi, np.pi / 2, 0.0, -np.pi / 2]),
-    (X, [np.pi / 2, np.pi, 7 * np.pi / 2, -np.pi / 2]),
+    (Z, [pnp.pi / 2, 0.0, pnp.pi / 2, -pnp.pi / 2]),
+    (S, [pnp.pi / 4, 0.0, pnp.pi / 4, -pnp.pi / 4]),
+    (T, [pnp.pi / 8, 0.0, pnp.pi / 8, -pnp.pi / 8]),
+    (H, [pnp.pi, pnp.pi / 2, 0.0, -pnp.pi / 2]),
+    (X, [pnp.pi / 2, pnp.pi, 7 * pnp.pi / 2, -pnp.pi / 2]),
     # Single rotations
     (qml.RZ(0.3, wires=0).matrix(), [0.15, 0.0, 0.15, 0]),
-    (qml.RZ(-0.5, wires=0).matrix(), [4 * np.pi - 0.25, 0.0, 4 * np.pi - 0.25, 0]),
-    (qml.Rot(0.2, 0.5, -0.3, wires=0).matrix(), [0.2, 0.5, 4 * np.pi - 0.3, 0]),
+    (qml.RZ(-0.5, wires=0).matrix(), [4 * pnp.pi - 0.25, 0.0, 4 * pnp.pi - 0.25, 0]),
+    (qml.Rot(0.2, 0.5, -0.3, wires=0).matrix(), [0.2, 0.5, 4 * pnp.pi - 0.3, 0]),
     # Other random unitaries
     (
-        np.array(
+        pnp.array(
             [
                 [0, -9.831019270939975e-01 + 0.1830590094588862j],
                 [9.831019270939975e-01 + 0.1830590094588862j, 0],
             ]
         ),
-        [12.382273469673908, np.pi, 0.18409714468526372, 0],
+        [12.382273469673908, pnp.pi, 0.18409714468526372, 0],
     ),
     (
-        np.exp(1j * 0.02) * qml.Rot(-1.0, 2.0, -3.0, wires=0).matrix(),
-        [4 * np.pi - 1.0, 2.0, 4 * np.pi - 3.0, -0.02],
+        pnp.exp(1j * 0.02) * qml.Rot(-1.0, 2.0, -3.0, wires=0).matrix(),
+        [4 * pnp.pi - 1.0, 2.0, 4 * pnp.pi - 3.0, -0.02],
     ),
     # Broadcasted unitaries, one coming from RZ and another from Rot
     (
-        qml.QubitUnitary(qml.RZ.compute_matrix(np.array([np.pi, np.pi / 2])), wires=0).matrix(),
-        [[np.pi / 2, np.pi / 4], [0.0, 0.0], [np.pi / 2, np.pi / 4], [0, 0]],
+        qml.QubitUnitary(qml.RZ.compute_matrix(pnp.array([pnp.pi, pnp.pi / 2])), wires=0).matrix(),
+        [[pnp.pi / 2, pnp.pi / 4], [0.0, 0.0], [pnp.pi / 2, pnp.pi / 4], [0, 0]],
     ),
     (
-        qml.Rot(np.array([1.2, 2.3]), np.array([1.2, 2.3]), np.array([1.2, 2.3]), wires=0).matrix(),
+        qml.Rot(pnp.array([1.2, 2.3]), pnp.array([1.2, 2.3]), pnp.array([1.2, 2.3]), wires=0).matrix(),
         [[1.2, 2.3], [1.2, 2.3], [1.2, 2.3], [0, 0]],
     ),
 ]
@@ -174,7 +174,7 @@ typeof_gates_xyx = (qml.RX, qml.RY, qml.RX, qml.GlobalPhase)
 test_cases_xyx = [
     # Try a random dense unitary
     (
-        np.array(
+        pnp.array(
             [
                 [-0.28829348 - 0.78829734j, 0.30364367 + 0.45085995j],
                 [0.53396245 - 0.10177564j, 0.76279558 - 0.35024096j],
@@ -184,17 +184,17 @@ test_cases_xyx = [
     ),
     # Try a few specific special unitaries
     (I, [0, 0, 0, 0]),  # This triggers the if-conditional trivially
-    (X, [np.pi * 3 / 2, 0.0, 7 * np.pi / 2, -np.pi / 2]),
-    (Y, [np.pi / 2, np.pi, np.pi / 2, -np.pi / 2]),
-    (Z, [7 * np.pi / 2, np.pi, np.pi / 2, -np.pi / 2]),
+    (X, [pnp.pi * 3 / 2, 0.0, 7 * pnp.pi / 2, -pnp.pi / 2]),
+    (Y, [pnp.pi / 2, pnp.pi, pnp.pi / 2, -pnp.pi / 2]),
+    (Z, [7 * pnp.pi / 2, pnp.pi, pnp.pi / 2, -pnp.pi / 2]),
     # Add two instances of broadcasted unitaries, one coming from RZ and another from Rot
     (
-        qml.QubitUnitary(qml.RZ.compute_matrix(np.array([np.pi, np.pi / 2])), wires=0).matrix(),
-        [[7 * np.pi / 2, 7 * np.pi / 2], [np.pi, np.pi / 2], [np.pi / 2, np.pi / 2], [0, 0]],
+        qml.QubitUnitary(qml.RZ.compute_matrix(pnp.array([pnp.pi, pnp.pi / 2])), wires=0).matrix(),
+        [[7 * pnp.pi / 2, 7 * pnp.pi / 2], [pnp.pi, pnp.pi / 2], [pnp.pi / 2, pnp.pi / 2], [0, 0]],
     ),
     (
         # This triggers the if-conditional non-trivially
-        qml.Rot(np.array([1.2, 1.5]), np.array([1.2, 1.5]), np.array([1.2, 1.5]), wires=0).matrix(),
+        qml.Rot(pnp.array([1.2, 1.5]), pnp.array([1.2, 1.5]), pnp.array([1.2, 1.5]), wires=0).matrix(),
         [
             [11.62877054, 11.74682533],
             [2.53416365, 3.03803113],
@@ -251,7 +251,7 @@ class TestQubitUnitaryXYXDecomposition:
 typeof_gates_xzx = (qml.RX, qml.RZ, qml.RX, qml.GlobalPhase)
 test_cases_xzx = [
     (
-        np.array(
+        pnp.array(
             [
                 [-0.28829348 - 0.78829734j, 0.30364367 + 0.45085995j],
                 [0.53396245 - 0.10177564j, 0.76279558 - 0.35024096j],
@@ -260,16 +260,16 @@ test_cases_xzx = [
         [12.416147693665032, 1.3974974090935608, 11.448040119199066, 1.1759220332464762],
     ),
     (I, [0, 0, 0, 0]),
-    (X, [np.pi / 2, 0, np.pi / 2, -np.pi / 2]),
-    (Y, [np.pi / 2, np.pi, 7 * np.pi / 2, -np.pi / 2]),
-    (Z, [0, np.pi, 0, -np.pi / 2]),
-    (H, [np.pi / 2, np.pi / 2, np.pi / 2, -np.pi / 2]),
+    (X, [pnp.pi / 2, 0, pnp.pi / 2, -pnp.pi / 2]),
+    (Y, [pnp.pi / 2, pnp.pi, 7 * pnp.pi / 2, -pnp.pi / 2]),
+    (Z, [0, pnp.pi, 0, -pnp.pi / 2]),
+    (H, [pnp.pi / 2, pnp.pi / 2, pnp.pi / 2, -pnp.pi / 2]),
     (
-        qml.QubitUnitary(qml.RZ.compute_matrix(np.array([np.pi, np.pi / 2])), wires=0).matrix(),
-        [[0, 0], [np.pi, np.pi / 2], [0, 0], [0, 0]],
+        qml.QubitUnitary(qml.RZ.compute_matrix(pnp.array([pnp.pi, pnp.pi / 2])), wires=0).matrix(),
+        [[0, 0], [pnp.pi, pnp.pi / 2], [0, 0], [0, 0]],
     ),
     (
-        qml.Rot(np.array([1.2, 1.5]), np.array([1.2, 1.5]), np.array([1.2, 1.5]), wires=0).matrix(),
+        qml.Rot(pnp.array([1.2, 1.5]), pnp.array([1.2, 1.5]), pnp.array([1.2, 1.5]), wires=0).matrix(),
         [
             [0.63319625, 0.75125105],
             [2.53416365, 3.03803113],
@@ -326,39 +326,39 @@ class TestQubitUnitaryXZXDecomposition:
 typeof_gates_zxz = (qml.RZ, qml.RX, qml.RZ, qml.GlobalPhase)
 test_cases_zxz = [
     (I, [0.0, 0.0, 0.0, 0]),
-    (Z, [np.pi / 2, 0.0, np.pi / 2, -np.pi / 2]),
-    (S, [np.pi / 4, 0.0, np.pi / 4, -np.pi / 4]),
-    (T, [np.pi / 8, 0.0, np.pi / 8, -np.pi / 8]),
-    (H, [np.pi / 2, np.pi / 2, np.pi / 2, -np.log(1j) / 1j]),
-    (X, [0, np.pi, 4 * np.pi, -np.log(1j) / 1j]),
+    (Z, [pnp.pi / 2, 0.0, pnp.pi / 2, -pnp.pi / 2]),
+    (S, [pnp.pi / 4, 0.0, pnp.pi / 4, -pnp.pi / 4]),
+    (T, [pnp.pi / 8, 0.0, pnp.pi / 8, -pnp.pi / 8]),
+    (H, [pnp.pi / 2, pnp.pi / 2, pnp.pi / 2, -pnp.log(1j) / 1j]),
+    (X, [0, pnp.pi, 4 * pnp.pi, -pnp.log(1j) / 1j]),
     (qml.RZ(0.3, wires=0).matrix(), [0.15, 0.0, 0.15, 0]),
-    (qml.RZ(-0.5, wires=0).matrix(), [4 * np.pi - 0.25, 0.0, 4 * np.pi - 0.25, 0]),
+    (qml.RZ(-0.5, wires=0).matrix(), [4 * pnp.pi - 0.25, 0.0, 4 * pnp.pi - 0.25, 0]),
     (qml.Rot(0.2, 0.5, -0.3, wires=0).matrix(), [11.195574287564275, 0.5, 1.2707963267948965, 0]),
     (
-        np.array(
+        pnp.array(
             [
                 [0, -9.831019270939975e-01 + 0.1830590094588862j],
                 [9.831019270939975e-01 + 0.1830590094588862j, 0],
             ]
         ),
-        [10.811477142879012, np.pi, 1.7548934714801607, 0],
+        [10.811477142879012, pnp.pi, 1.7548934714801607, 0],
     ),
     (
-        np.exp(1j * 0.02) * qml.Rot(-1.0, 2.0, -3.0, wires=0).matrix(),
+        pnp.exp(1j * 0.02) * qml.Rot(-1.0, 2.0, -3.0, wires=0).matrix(),
         [
             9.995574287564276,
             2.0,
             11.137166941154069,
-            -np.log(0.9998000066665778 + 0.019998666693333122j) / 1j,
+            -pnp.log(0.9998000066665778 + 0.019998666693333122j) / 1j,
         ],
     ),
     # Add two instances of broadcasted unitaries, one coming from RZ and another from Rot
     (
-        qml.QubitUnitary(qml.RZ.compute_matrix(np.array([np.pi, np.pi / 2])), wires=0).matrix(),
-        [[np.pi / 2, np.pi / 4], [0.0, 0.0], [np.pi / 2, np.pi / 4], [0, 0]],
+        qml.QubitUnitary(qml.RZ.compute_matrix(pnp.array([pnp.pi, pnp.pi / 2])), wires=0).matrix(),
+        [[pnp.pi / 2, pnp.pi / 4], [0.0, 0.0], [pnp.pi / 2, pnp.pi / 4], [0, 0]],
     ),
     (
-        qml.Rot(np.array([1.2, 2.3]), np.array([1.2, 2.3]), np.array([1.2, 2.3]), wires=0).matrix(),
+        qml.Rot(pnp.array([1.2, 2.3]), pnp.array([1.2, 2.3]), pnp.array([1.2, 2.3]), wires=0).matrix(),
         [
             [12.19557429, 0.72920367],
             [1.2, 2.3],
@@ -415,16 +415,16 @@ class TestQubitUnitaryZXZDecomposition:
 test_cases_rot = [
     # These will be decomposed to RZ
     (I, [qml.RZ, qml.GlobalPhase], [0.0, 0.0]),
-    (Z, [qml.RZ, qml.GlobalPhase], [np.pi, -np.pi / 2]),
-    (S, [qml.RZ, qml.GlobalPhase], [np.pi / 2, -np.pi / 4]),
-    (T, [qml.RZ, qml.GlobalPhase], [np.pi / 4, -np.pi / 8]),
+    (Z, [qml.RZ, qml.GlobalPhase], [pnp.pi, -pnp.pi / 2]),
+    (S, [qml.RZ, qml.GlobalPhase], [pnp.pi / 2, -pnp.pi / 4]),
+    (T, [qml.RZ, qml.GlobalPhase], [pnp.pi / 4, -pnp.pi / 8]),
     (qml.RZ(0.3, wires=0).matrix(), [qml.RZ, qml.GlobalPhase], [0.3, 0.0]),
-    (qml.RZ(-0.5, wires=0).matrix(), [qml.RZ, qml.GlobalPhase], [4 * np.pi - 0.5, 0.0]),
+    (qml.RZ(-0.5, wires=0).matrix(), [qml.RZ, qml.GlobalPhase], [4 * pnp.pi - 0.5, 0.0]),
     # # This will be decomposed to Rot
     (
         qml.Rot(0.2, 0.5, -0.3, wires=0).matrix(),
         [qml.Rot, qml.GlobalPhase],
-        [[0.2, 0.5, 4 * np.pi - 0.3], 0.0],
+        [[0.2, 0.5, 4 * pnp.pi - 0.3], 0.0],
     ),
 ]
 
@@ -919,7 +919,7 @@ samples_su2_su2 = [
             [0.257810302107603 + 0.3791450460627684j, 0.7491086034534051 - 0.478141383280444j],
             [-0.6878868994174759 + 0.5626673047041733j, -0.2798521896663711 - 0.3631802166496543j],
         ],
-        [[np.exp(-1j * np.pi / 3), 0], [0, np.exp(1j * np.pi / 3)]],
+        [[pnp.exp(-1j * pnp.pi / 3), 0], [0, pnp.exp(1j * pnp.pi / 3)]],
     ),
     (
         [
@@ -951,17 +951,17 @@ class TestTwoQubitUnitaryDecomposition:
     def test_convert_to_su4(self, U):
         """Test a matrix in U(4) is correct converted to SU(4)."""
 
-        U_su4 = _convert_to_su4(np.array(U))
+        U_su4 = _convert_to_su4(pnp.array(U))
 
         # Ensure the determinant is correct and the mats are equivalent up to a phase
         assert qml.math.isclose(qml.math.linalg.det(U_su4), 1.0)
-        assert check_matrix_equivalence(np.array(U), U_su4)
+        assert check_matrix_equivalence(pnp.array(U), U_su4)
 
     @pytest.mark.parametrize("U_pair", samples_su2_su2)
     def test_su2su2_to_tensor_products(self, U_pair):
         """Test SU(2) x SU(2) can be correctly factored into tensor products."""
 
-        true_matrix = qml.math.kron(np.array(U_pair[0]), np.array(U_pair[1]))
+        true_matrix = qml.math.kron(pnp.array(U_pair[0]), pnp.array(U_pair[1]))
         A, B = _su2su2_to_tensor_products(true_matrix)
         assert check_matrix_equivalence(qml.math.kron(A, B), true_matrix)
 
@@ -970,7 +970,7 @@ class TestTwoQubitUnitaryDecomposition:
     def test_two_qubit_decomposition_3_cnots(self, U, wires):
         """Test that a two-qubit matrix using 3 CNOTs is correctly decomposed."""
 
-        U = _convert_to_su4(np.array(U))
+        U = _convert_to_su4(pnp.array(U))
 
         assert _compute_num_cnots(U) == 3
 
@@ -993,7 +993,7 @@ class TestTwoQubitUnitaryDecomposition:
     def test_two_qubit_decomposition_2_cnots(self, U, wires):
         """Test that a two-qubit matrix using 2 CNOTs isolation is correctly decomposed."""
 
-        U = _convert_to_su4(np.array(U))
+        U = _convert_to_su4(pnp.array(U))
 
         assert _compute_num_cnots(U) == 2
 
@@ -1014,7 +1014,7 @@ class TestTwoQubitUnitaryDecomposition:
     def test_two_qubit_decomposition_1_cnot(self, U, wires):
         """Test that a two-qubit matrix using one CNOT is correctly decomposed."""
 
-        U = _convert_to_su4(np.array(U))
+        U = _convert_to_su4(pnp.array(U))
 
         assert _compute_num_cnots(U) == 1
 
@@ -1035,7 +1035,7 @@ class TestTwoQubitUnitaryDecomposition:
     def test_two_qubit_decomposition_tensor_products(self, U_pair, wires):
         """Test that a two-qubit tensor product matrix is correctly decomposed."""
 
-        U = _convert_to_su4(qml.math.kron(np.array(U_pair[0]), np.array(U_pair[1])))
+        U = _convert_to_su4(qml.math.kron(pnp.array(U_pair[0]), pnp.array(U_pair[1])))
 
         assert _compute_num_cnots(U) == 0
 
@@ -1262,28 +1262,28 @@ def test_two_qubit_decomposition_special_case_discontinuity():
             theta1
             / 2
             * (
-                np.cos(0.2)
+                pnp.cos(0.2)
                 / 2
-                * (np.array([[0, 0, 0, 0], [0, 0, 2, 0], [0, 2, 0, 0], [0, 0, 0, 0]]))
-                + np.sin(0.2)
+                * (pnp.array([[0, 0, 0, 0], [0, 0, 2, 0], [0, 2, 0, 0], [0, 0, 0, 0]]))
+                + pnp.sin(0.2)
                 / 2
-                * (np.array([[0, 0, 0, 0], [0, 0, 2j, 0], [0, -2j, 0, 0], [0, 0, 0, 0]]))
+                * (pnp.array([[0, 0, 0, 0], [0, 0, 2j, 0], [0, -2j, 0, 0], [0, 0, 0, 0]]))
             )
         )
 
         def expm(val):
-            d, U = np.linalg.eigh(-1.0j * val)
-            return np.dot(U, np.dot(np.diag(np.exp(1.0j * d)), np.conj(U).T))
+            d, U = pnp.linalg.eigh(-1.0j * val)
+            return pnp.dot(U, pnp.dot(pnp.diag(pnp.exp(1.0j * d)), pnp.conj(U).T))
 
         mat = expm(-1j * generator)
 
-        assert np.allclose(
-            np.dot(np.transpose(np.conj(mat)), mat), np.eye(len(mat))
+        assert pnp.allclose(
+            pnp.dot(pnp.transpose(pnp.conj(mat)), mat), pnp.eye(len(mat))
         ), "mat is not unitary"
 
         return mat
 
-    mat = make_unitary(np.pi / 2)
+    mat = make_unitary(pnp.pi / 2)
     decomp_mat = qml.matrix(two_qubit_decomposition, wire_order=(0, 1))(mat, wires=(0, 1))
     assert qml.math.allclose(mat, decomp_mat)
 
@@ -1296,7 +1296,7 @@ class TestTwoQubitDecompositionWarnings:
         dev = qml.device("default.qubit", wires=2)
 
         def my_qfunc(params):
-            U = qml.numpy.array(np.eye(4, dtype=np.complex128), requires_grad=True) * params
+            U = qml.numpy.array(pnp.eye(4, dtype=pnp.complex128), requires_grad=True) * params
             ops = qml.ops.two_qubit_decomposition(U, wires=[0, 1])
             for op in ops:
                 qml.apply(op)
@@ -1376,7 +1376,7 @@ class TestTwoQubitDecompositionWarnings:
         dev = qml.device("default.qubit", wires=2)
 
         def my_qfunc(params):
-            U = jnp.array(np.eye(4, dtype=np.complex128)) * params
+            U = jnp.array(pnp.eye(4, dtype=pnp.complex128)) * params
             ops = qml.ops.two_qubit_decomposition(U, wires=[0, 1])
             for op in ops:
                 qml.apply(op)
@@ -1399,7 +1399,7 @@ class TestTwoQubitDecompositionWarnings:
         dev = qml.device("default.qubit", wires=2)
 
         def my_qfunc(params):
-            U = qml.numpy.array(np.eye(4, dtype=np.complex128), requires_grad=True) * params
+            U = qml.numpy.array(pnp.eye(4, dtype=pnp.complex128), requires_grad=True) * params
             ops = qml.ops.two_qubit_decomposition(U, wires=[0, 1])
             for op in ops:
                 qml.apply(op)

--- a/tests/ops/op_math/test_evolution.py
+++ b/tests/ops/op_math/test_evolution.py
@@ -15,7 +15,7 @@
 import pytest
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane.ops.op_math import Evolution, Exp
 
 
@@ -52,7 +52,7 @@ class TestEvolution:
         op1 = Exp(base_op, 1j)
         op2 = Evolution(base_op, -1)
 
-        assert np.all(op1.matrix() == op2.matrix())
+        assert pnp.all(op1.matrix() == op2.matrix())
 
     def test_has_generator_true(self):
         """Test that has_generator returns True if the coefficient is purely imaginary."""
@@ -81,7 +81,7 @@ class TestEvolution:
     def test_data(self):
         """Test initializing and accessing the data property."""
 
-        param = np.array(1.234)
+        param = pnp.array(1.234)
 
         base = qml.PauliX(0)
         op = Evolution(base, param)
@@ -90,7 +90,7 @@ class TestEvolution:
         assert op.coeff == -1j * op.data[0]
         assert op.param == op.data[0]
 
-        new_param = np.array(2.345)
+        new_param = pnp.array(2.345)
         op.data = (new_param,)
 
         assert op.data == (new_param,)
@@ -156,7 +156,7 @@ class TestEvolution:
 
         dev = qml.device("default.qubit", wires=2)
         base = qml.PauliX(0)
-        x = np.array(1.234)
+        x = pnp.array(1.234)
 
         @qml.qnode(dev, diff_method=qml.gradients.param_shift)
         def circ_param_shift(x):
@@ -201,7 +201,7 @@ class TestEvolution:
 
     def test_generator_error_if_not_hermitian(self):
         """Tests that an error is raised if the generator is not hermitian."""
-        op = Evolution(qml.RX(np.pi / 3, 0), 1)
+        op = Evolution(qml.RX(pnp.pi / 3, 0), 1)
 
         with pytest.raises(
             qml.QuantumFunctionError, match="of operation Evolution is not hermitian"

--- a/tests/ops/op_math/test_exp.py
+++ b/tests/ops/op_math/test_exp.py
@@ -19,7 +19,7 @@ import warnings
 import pytest
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane.operation import (
     AllWires,
     AnyWires,
@@ -63,7 +63,7 @@ class TestInitialization:
     def test_provided_coeff(self, constructor):
         """Test initialization with a provided coefficient and a Tensor base."""
         base = qml.PauliZ("b") @ qml.PauliZ("c")
-        coeff = np.array(1.234)
+        coeff = pnp.array(1.234)
 
         op = constructor(base, coeff)
 
@@ -82,7 +82,7 @@ class TestInitialization:
 
         base_coeff = 1.23
         base = qml.RX(base_coeff, wires=5)
-        coeff = np.array(-2.0)
+        coeff = pnp.array(-2.0)
 
         op = constructor(base, coeff)
 
@@ -120,16 +120,16 @@ class TestProperties:
     def test_data(self):
         """Test intializaing and accessing the data property."""
 
-        phi = np.array(1.234)
-        coeff = np.array(2.345)
+        phi = pnp.array(1.234)
+        coeff = pnp.array(2.345)
 
         base = qml.RX(phi, wires=0)
         op = Exp(base, coeff)
 
         assert op.data == (coeff, phi)
 
-        new_phi = np.array(0.1234)
-        new_coeff = np.array(3.456)
+        new_phi = pnp.array(0.1234)
+        new_coeff = pnp.array(3.456)
         op.data = (new_coeff, new_phi)
 
         assert op.data == (new_coeff, new_phi)
@@ -157,24 +157,24 @@ class TestProperties:
         """Test the batching properties and methods."""
 
         # base is batched
-        base = qml.RX(np.array([1.2, 2.3, 3.4]), 0)
+        base = qml.RX(pnp.array([1.2, 2.3, 3.4]), 0)
         op = Exp(base)
         assert op.batch_size == 3
 
         # coeff is batched
         base = qml.RX(1, 0)
-        op = Exp(base, coeff=np.array([1.2, 2.3, 3.4]))
+        op = Exp(base, coeff=pnp.array([1.2, 2.3, 3.4]))
         assert op.batch_size == 3
 
         # both are batched
-        base = qml.RX(np.array([1.2, 2.3, 3.4]), 0)
-        op = Exp(base, coeff=np.array([1.2, 2.3, 3.4]))
+        base = qml.RX(pnp.array([1.2, 2.3, 3.4]), 0)
+        op = Exp(base, coeff=pnp.array([1.2, 2.3, 3.4]))
         assert op.batch_size == 3
 
     def test_different_batch_sizes_raises_error(self):
         """Test that using different batch sizes for base and scalar raises an error."""
-        base = qml.RX(np.array([1.2, 2.3, 3.4]), 0)
-        op = Exp(base, np.array([0.1, 1.2, 2.3, 3.4]))
+        base = qml.RX(pnp.array([1.2, 2.3, 3.4]), 0)
+        op = Exp(base, pnp.array([0.1, 1.2, 2.3, 3.4]))
         with pytest.raises(
             ValueError, match="Broadcasting was attempted but the broadcasted dimensions"
         ):
@@ -186,7 +186,7 @@ class TestMatrix:
 
     def test_base_batching_support(self):
         """Test that Exp matrix has base batching support."""
-        x = np.array([-1, -2, -3])
+        x = pnp.array([-1, -2, -3])
         op = Exp(qml.RX(x, 0), 3)
         mat = op.matrix()
         true_mat = qml.math.stack([Exp(qml.RX(i, 0), 3).matrix() for i in x])
@@ -195,7 +195,7 @@ class TestMatrix:
 
     def test_coeff_batching_support(self):
         """Test that Exp matrix has coeff batching support."""
-        x = np.array([-1, -2, -3])
+        x = pnp.array([-1, -2, -3])
         op = Exp(qml.PauliX(0), x)
         mat = op.matrix()
         true_mat = qml.math.stack([Exp(qml.PauliX(0), i).matrix() for i in x])
@@ -204,8 +204,8 @@ class TestMatrix:
 
     def test_base_and_coeff_batching_support(self):
         """Test that Exp matrix has base and coeff batching support."""
-        x = np.array([-1, -2, -3])
-        y = np.array([1, 2, 3])
+        x = pnp.array([-1, -2, -3])
+        y = pnp.array([1, 2, 3])
         op = Exp(qml.RX(x, 0), y)
         mat = op.matrix()
         true_mat = qml.math.stack([Exp(qml.RX(i, 0), j).matrix() for i, j in zip(x, y)])
@@ -276,7 +276,7 @@ class TestMatrix:
     @pytest.mark.parametrize("requires_grad", (True, False))
     def test_matrix_autograd_rx(self, requires_grad):
         """Test the matrix comparing to the rx gate."""
-        phi = np.array(1.234, requires_grad=requires_grad)
+        phi = pnp.array(1.234, requires_grad=requires_grad)
         exp_rx = Exp(qml.PauliX(0), -0.5j * phi)
         rx = qml.RX(phi, 0)
 
@@ -287,7 +287,7 @@ class TestMatrix:
     def test_matrix_autograd_rz(self, requires_grad):
         """Test the matrix comparing to the rz gate. This is a gate with an
         autograd coefficient but empty diagonalizing gates."""
-        phi = np.array(1.234, requires_grad=requires_grad)
+        phi = pnp.array(1.234, requires_grad=requires_grad)
         exp_rz = Exp(qml.PauliZ(0), -0.5j * phi)
         rz = qml.RZ(phi, 0)
 
@@ -308,7 +308,7 @@ class TestMatrix:
     @pytest.mark.autograd
     def test_base_no_diagonalizing_gates_autograd_coeff(self):
         """Test the matrix when the base matrix doesn't define the diagonalizing gates."""
-        coeff = np.array(0.4)
+        coeff = pnp.array(0.4)
         base = qml.RX(2.0, wires=0)
         op = Exp(base, coeff)
 
@@ -370,7 +370,7 @@ class TestMatrix:
         """Test the sparse matrix function."""
         from scipy.sparse import csr_matrix
 
-        H = np.array([[6 + 0j, 1 - 2j], [1 + 2j, -1]])
+        H = pnp.array([[6 + 0j, 1 - 2j], [1 + 2j, -1]])
         H = csr_matrix(H)
         base = qml.SparseHamiltonian(H, wires=0)
 
@@ -388,7 +388,7 @@ class TestMatrix:
         """Test that sparse_matrix raises an error if wire_order provided."""
         from scipy.sparse import csr_matrix
 
-        H = np.array([[6 + 0j, 1 - 2j], [1 + 2j, -1]])
+        H = pnp.array([[6 + 0j, 1 - 2j], [1 + 2j, -1]])
         H = csr_matrix(H)
         base = qml.SparseHamiltonian(H, wires=0)
 
@@ -506,7 +506,7 @@ class TestDecomposition:
         elif op_class is qml.GlobalPhase:
             # exp(qml.GlobalPhase.generator(), phi) decomposes to PauliRot
             # cannot compare GlobalPhase and PauliRot with qml.equal
-            assert np.allclose(op.matrix(wire_order=op.wires), dec[0].matrix(wire_order=op.wires))
+            assert pnp.allclose(op.matrix(wire_order=op.wires), dec[0].matrix(wire_order=op.wires))
         else:
             qml.assert_equal(op, dec[0])
 
@@ -792,9 +792,9 @@ class TestIntegration:
             return qml.expval(qml.Z(0))
 
         res = func(phi)
-        assert qml.math.allclose(res, np.cos(phi))
+        assert qml.math.allclose(res, pnp.cos(phi))
         grad = qml.grad(func)(phi)
-        assert qml.math.allclose(grad, -np.sin(phi))
+        assert qml.math.allclose(grad, -pnp.sin(phi))
 
     @pytest.mark.jax
     def test_jax_jit_qnode(self):
@@ -910,11 +910,11 @@ class TestIntegration:
             return qml.expval(Exp(qml.PauliZ(0), x))
 
         res = circuit(x)
-        expected = 0.5 * (np.exp(x) + np.exp(-x))
+        expected = 0.5 * (pnp.exp(x) + pnp.exp(-x))
         assert qml.math.allclose(res, expected)
 
         grad = qml.grad(circuit)(x)
-        expected_grad = 0.5 * (np.exp(x) - np.exp(-x))
+        expected_grad = 0.5 * (pnp.exp(x) - pnp.exp(-x))
         assert qml.math.allclose(grad, expected_grad)
 
     @pytest.mark.torch
@@ -1007,7 +1007,7 @@ class TestIntegration:
         x = qml.numpy.array([1.234, 2.34, 3.456])
         res = circuit(x)
 
-        expected = np.sin(x)
+        expected = pnp.sin(x)
         assert qml.math.allclose(res, expected)
 
 
@@ -1088,5 +1088,5 @@ class TestDifferentiation:
             return qml.expval(qml.PauliZ(0))
 
         with pytest.warns(UserWarning):
-            circuit(np.array(2.0), np.array(0.5))
+            circuit(pnp.array(2.0), pnp.array(0.5))
         assert circuit.tape.trainable_params == [0, 1]

--- a/tests/ops/op_math/test_pow_op.py
+++ b/tests/ops/op_math/test_pow_op.py
@@ -19,7 +19,7 @@ from copy import copy
 import pytest
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane.operation import AdjointUndefinedError, DecompositionUndefinedError
 from pennylane.ops.op_math.controlled import ControlledOp
 from pennylane.ops.op_math.pow import Pow, PowOperation
@@ -47,7 +47,7 @@ def test_basic_validity():
     op = qml.pow(qml.PauliX(0), 2.5)
     qml.ops.functions.assert_valid(op)
 
-    op = qml.pow(qml.Hermitian(np.eye(2), 0), 2)
+    op = qml.pow(qml.Hermitian(pnp.eye(2), 0), 2)
     qml.ops.functions.assert_valid(op)
 
 
@@ -214,7 +214,7 @@ class TestInitialization:
 
     def test_template_base(self, power_method, seed):
         """Test pow initialization for a template."""
-        rng = np.random.default_rng(seed=seed)
+        rng = pnp.random.default_rng(seed=seed)
         shape = qml.StronglyEntanglingLayers.shape(n_layers=2, n_wires=2)
         params = rng.random(shape)  # pylint:disable=no-member
 
@@ -242,7 +242,7 @@ class TestProperties:
 
     def test_data(self, power_method):
         """Test base data can be get and set through Pow class."""
-        x = np.array(1.234)
+        x = pnp.array(1.234)
 
         base = qml.RX(x, wires="a")
         op: Pow = power_method(base=base, z=3.21)
@@ -250,13 +250,13 @@ class TestProperties:
         assert op.data == (x,)
 
         # update parameters through pow
-        x_new = np.array(2.3456)
+        x_new = pnp.array(2.3456)
         op.data = (x_new,)
         assert base.data == (x_new,)
         assert op.data == (x_new,)
 
         # update base data updates pow data
-        x_new2 = np.array(3.456)
+        x_new2 = pnp.array(3.456)
         base.data = (x_new2,)
         assert op.data == (x_new2,)
 
@@ -328,7 +328,7 @@ class TestProperties:
             def pow(self, z):
                 return super().pow(z % 2)
 
-        pow_op = power_method(base=MyOp(wires=0), z=np.array([1.0, 2.0]))
+        pow_op = power_method(base=MyOp(wires=0), z=pnp.array([1.0, 2.0]))
         assert not pow_op.has_decomposition
 
         with pytest.raises(DecompositionUndefinedError):
@@ -383,27 +383,27 @@ class TestProperties:
         """Test the batching properties and methods."""
 
         # base is batched
-        base = qml.RX(np.array([1.2, 2.3, 3.4]), 0)
+        base = qml.RX(pnp.array([1.2, 2.3, 3.4]), 0)
         op = power_method(base, z=1)
         assert op.ndim_params == base.ndim_params
         assert op.batch_size == 3
 
         # coeff is batched
         base = qml.RX(1, 0)
-        op = power_method(base, z=np.array([1.2, 2.3, 3.4]))
+        op = power_method(base, z=pnp.array([1.2, 2.3, 3.4]))
         assert op.ndim_params == base.ndim_params
         assert op.batch_size == 3
 
         # both are batched
-        base = qml.RX(np.array([1.2, 2.3, 3.4]), 0)
-        op = power_method(base, z=np.array([1.2, 2.3, 3.4]))
+        base = qml.RX(pnp.array([1.2, 2.3, 3.4]), 0)
+        op = power_method(base, z=pnp.array([1.2, 2.3, 3.4]))
         assert op.ndim_params == base.ndim_params
         assert op.batch_size == 3
 
     def test_different_batch_sizes_raises_error(self, power_method):
         """Test that using different batch sizes for base and scalar raises an error."""
-        base = qml.RX(np.array([1.2, 2.3, 3.4]), 0)
-        op = power_method(base, np.array([0.1, 1.2, 2.3, 3.4]))
+        base = qml.RX(pnp.array([1.2, 2.3, 3.4]), 0)
+        op = power_method(base, pnp.array([0.1, 1.2, 2.3, 3.4]))
         with pytest.raises(
             ValueError, match="Broadcasting was attempted but the broadcasted dimensions"
         ):
@@ -565,7 +565,7 @@ class TestMiscMethods:
 
     def test_label_matrix_param(self):
         """Test that when passed a matrix op, the matrix is cached into passed dictionary."""
-        base = qml.QubitUnitary(np.eye(2), wires=0)
+        base = qml.QubitUnitary(pnp.eye(2), wires=0)
         op = Pow(base, -1.2)
 
         cache = {"matrices": []}
@@ -666,7 +666,7 @@ class TestMatrix:
 
     def test_base_batching_support(self):
         """Test that Pow matrix has base batching support."""
-        x = np.array([-1, -2, -3])
+        x = pnp.array([-1, -2, -3])
         op = Pow(qml.RX(x, 0), z=3)
         mat = op.matrix()
         true_mat = qml.math.stack([Pow(qml.RX(i, 0), z=3).matrix() for i in x])
@@ -675,7 +675,7 @@ class TestMatrix:
 
     def test_coeff_batching_support(self):
         """Test that Pow matrix has coeff batching support."""
-        x = np.array([-1, -2, -3])
+        x = pnp.array([-1, -2, -3])
         op = Pow(qml.PauliX(0), z=x)
         mat = op.matrix()
         true_mat = qml.math.stack([Pow(qml.PauliX(0), i).matrix() for i in x])
@@ -684,8 +684,8 @@ class TestMatrix:
 
     def test_base_and_coeff_batching_support(self):
         """Test that Pow matrix has base and coeff batching support."""
-        x = np.array([-1, -2, -3])
-        y = np.array([1, 2, 3])
+        x = pnp.array([-1, -2, -3])
+        y = pnp.array([1, 2, 3])
         op = Pow(qml.RX(x, 0), z=y)
         mat = op.matrix()
         true_mat = qml.math.stack([Pow(qml.RX(i, 0), j).matrix() for i, j in zip(x, y)])
@@ -814,7 +814,7 @@ class TestMatrix:
         mat = pow_op.matrix()
 
         true_mat = [[1, 0], [0, 1]]
-        assert np.allclose(mat, true_mat)
+        assert pnp.allclose(mat, true_mat)
 
 
 class TestSparseMatrix:
@@ -825,7 +825,7 @@ class TestSparseMatrix:
         sparse matrix and the exponennt is an int."""
         from scipy.sparse import csr_matrix
 
-        H = np.array([[6 + 0j, 1 - 2j], [1 + 2j, -1]])
+        H = pnp.array([[6 + 0j, 1 - 2j], [1 + 2j, -1]])
         H = csr_matrix(H)
         base = qml.SparseHamiltonian(H, wires=0)
 
@@ -844,7 +844,7 @@ class TestSparseMatrix:
         raises a SparseMatrixUndefinedError error."""
         from scipy.sparse import csr_matrix
 
-        H = np.array([[6 + 0j, 1 - 2j], [1 + 2j, -1]])
+        H = pnp.array([[6 + 0j, 1 - 2j], [1 + 2j, -1]])
         H = csr_matrix(H)
         base = qml.SparseHamiltonian(H, wires=0)
 
@@ -974,11 +974,11 @@ class TestIntegration:
 
         x = qml.numpy.array(1.234, requires_grad=True)
 
-        expected = -np.sin(x * z)
+        expected = -pnp.sin(x * z)
         assert qml.math.allclose(circuit(x, z), expected)
 
         grad = qml.grad(circuit)(x, z)
-        expected_grad = -z * np.cos(x * z)
+        expected_grad = -z * pnp.cos(x * z)
         assert qml.math.allclose(grad, expected_grad)
 
     def test_batching_execution(self):
@@ -993,7 +993,7 @@ class TestIntegration:
         x = qml.numpy.array([1.234, 2.34, 3.456])
         res = circuit(x)
 
-        expected = -np.sin(x * 2.5)
+        expected = -pnp.sin(x * 2.5)
         assert qml.math.allclose(res, expected)
 
     def test_non_decomposable_power(self):
@@ -1037,5 +1037,5 @@ class TestIntegration:
             expected = expected_circuit(x)
         expected_grad = expected_tape.gradient(expected, x)
 
-        assert np.allclose(res, expected)
-        assert np.allclose(res_grad, expected_grad)
+        assert pnp.allclose(res, expected)
+        assert pnp.allclose(res_grad, expected_grad)

--- a/tests/ops/op_math/test_symbolic_op.py
+++ b/tests/ops/op_math/test_symbolic_op.py
@@ -17,7 +17,7 @@ from copy import copy
 import pytest
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane.operation import Operator
 from pennylane.ops.op_math import ScalarSymbolicOp, SymbolicOp
 from pennylane.wires import Wires
@@ -95,7 +95,7 @@ class TestProperties:
     def test_data(self):
         """Test that the data property for symbolic ops allows for the getting
         and setting of the base operator's data."""
-        x = np.array(1.234)
+        x = pnp.array(1.234)
 
         base = Operator(x, "a")
         op = SymbolicOp(base)
@@ -103,19 +103,19 @@ class TestProperties:
         assert op.data == (x,)
 
         # update parameters through op
-        x_new = np.array(2.345)
+        x_new = pnp.array(2.345)
         op.data = (x_new,)
         assert base.data == (x_new,)
         assert op.data == (x_new,)
 
         # update base data updates symbolic data
-        x_new2 = np.array(3.45)
+        x_new2 = pnp.array(3.45)
         base.data = (x_new2,)
         assert op.data == (x_new2,)
 
     def test_parameters(self):
         """Test parameter property is a list of the base's trainable parameters."""
-        x = np.array(9.876)
+        x = pnp.array(9.876)
         base = Operator(x, "b")
         op = SymbolicOp(base)
         assert op.parameters == [x]
@@ -229,9 +229,9 @@ class TestScalarSymbolicOp:
         base = Operator(1.1, wires=[0])
         scalar = [2.2, 3.3]
         op = TempScalar(base, scalar)
-        assert isinstance(op.scalar, np.ndarray)
-        assert np.all(op.scalar == [2.2, 3.3])
-        assert np.all(op.data[0] == op.scalar)
+        assert isinstance(op.scalar, pnp.ndarray)
+        assert pnp.all(op.scalar == [2.2, 3.3])
+        assert pnp.all(op.data[0] == op.scalar)
         assert op.data[1] == 1.1
 
     def test_data(self):

--- a/tests/ops/qubit/test_parametric_ops.py
+++ b/tests/ops/qubit/test_parametric_ops.py
@@ -24,7 +24,7 @@ from gate_data import CPhaseShift00, CPhaseShift01, CPhaseShift10, Z
 from scipy import sparse
 
 import pennylane as qml
-from pennylane import numpy as npp
+from pennylane import numpy as pnp
 from pennylane.ops.qubit import RX as old_loc_RX
 from pennylane.ops.qubit import MultiRZ as old_loc_MultiRZ
 from pennylane.wires import Wires
@@ -1764,7 +1764,7 @@ class TestGrad:
 
     for phi in phis:
         for device, method in device_methods:
-            configuration.append([device, method, npp.array(phi, requires_grad=True)])
+            configuration.append([device, method, pnp.array(phi, requires_grad=True)])
 
     @pytest.mark.autograd
     @pytest.mark.parametrize("dev_name,diff_method,phi", configuration)
@@ -1782,7 +1782,7 @@ class TestGrad:
         psi_2 = 0.3
         psi_3 = 0.4
 
-        init_state = npp.array([psi_0, psi_1, psi_2, psi_3], requires_grad=False)
+        init_state = pnp.array([psi_0, psi_1, psi_2, psi_3], requires_grad=False)
         norm = np.linalg.norm(init_state)
         init_state /= norm
 
@@ -1923,7 +1923,7 @@ class TestGrad:
         psi_2 = 0.3
         psi_3 = 0.4
 
-        init_state = npp.array([psi_0, psi_1, psi_2, psi_3], requires_grad=False)
+        init_state = pnp.array([psi_0, psi_1, psi_2, psi_3], requires_grad=False)
         norm = np.linalg.norm(init_state)
         init_state /= norm
 
@@ -1959,7 +1959,7 @@ class TestGrad:
         psi_2 = 0.3
         psi_3 = 0.4
 
-        init_state = npp.array([psi_0, psi_1, psi_2, psi_3], requires_grad=False)
+        init_state = pnp.array([psi_0, psi_1, psi_2, psi_3], requires_grad=False)
         norm = np.linalg.norm(init_state)
         init_state /= norm
 
@@ -1995,7 +1995,7 @@ class TestGrad:
         psi_2 = 0.3
         psi_3 = 0.4
 
-        init_state = npp.array([psi_0, psi_1, psi_2, psi_3], requires_grad=False)
+        init_state = pnp.array([psi_0, psi_1, psi_2, psi_3], requires_grad=False)
         norm = np.linalg.norm(init_state)
         init_state /= norm
 
@@ -2005,7 +2005,7 @@ class TestGrad:
             qml.IsingZZ(phi, wires=[0, 1])
             return qml.expval(qml.PauliX(0))
 
-        phi = npp.array(phi, requires_grad=True)
+        phi = pnp.array(phi, requires_grad=True)
 
         expected = (1 / norm**2) * (-2 * (psi_0 * psi_2 + psi_1 * psi_3) * np.sin(phi))
 
@@ -2023,7 +2023,7 @@ class TestGrad:
         psi_2 = 0.3
         psi_3 = 0.4
 
-        init_state = npp.array([psi_0, psi_1, psi_2, psi_3], requires_grad=False)
+        init_state = pnp.array([psi_0, psi_1, psi_2, psi_3], requires_grad=False)
         norm = np.linalg.norm(init_state)
         init_state /= norm
 
@@ -2033,7 +2033,7 @@ class TestGrad:
             qml.IsingXY(phi, wires=[0, 1])
             return qml.expval(qml.PauliZ(0))
 
-        phi = npp.array(phi, requires_grad=True)
+        phi = pnp.array(phi, requires_grad=True)
 
         expected = (1 / norm**2) * (psi_2**2 - psi_1**2) * np.sin(phi)
 
@@ -2057,7 +2057,7 @@ class TestGrad:
             qml.Hadamard(wires[1])
             return qml.expval(qml.PauliZ(wires[1]))
 
-        phi = npp.array(2.1, requires_grad=True)
+        phi = pnp.array(2.1, requires_grad=True)
 
         expected = [-0.8632093]
 
@@ -2438,7 +2438,7 @@ class TestGrad:
             pytest.skip("PCPhase does not support adjoint diff")
 
         dev = qml.device(dev_name, wires=[0, 1])
-        expected_grad = -4 * npp.cos(phi) * npp.sin(phi)  # computed by hand
+        expected_grad = -4 * pnp.cos(phi) * pnp.sin(phi)  # computed by hand
 
         @qml.qnode(dev, diff_method=diff_method)
         def circ(phi):
@@ -2451,7 +2451,7 @@ class TestGrad:
             qml.Hadamard(wires=1)
             return qml.expval(qml.PauliZ(wires=0))
 
-        phi = npp.array(phi, requires_grad=True)
+        phi = pnp.array(phi, requires_grad=True)
         computed_grad = qml.grad(circ)(phi)
         assert np.isclose(computed_grad, expected_grad)
 
@@ -2465,7 +2465,7 @@ class TestGrad:
         import tensorflow as tf
 
         dev = qml.device(dev_name, wires=[0, 1])
-        expected_grad = tf.Variable(-4 * npp.cos(phi) * npp.sin(phi))  # computed by hand
+        expected_grad = tf.Variable(-4 * pnp.cos(phi) * pnp.sin(phi))  # computed by hand
         phi = tf.Variable(phi)
 
         @qml.qnode(dev, diff_method=diff_method)
@@ -2495,7 +2495,7 @@ class TestGrad:
         import torch
 
         dev = qml.device(dev_name, wires=[0, 1])
-        expected_grad = torch.tensor(-4 * npp.cos(phi) * npp.sin(phi))  # computed by hand
+        expected_grad = torch.tensor(-4 * pnp.cos(phi) * pnp.sin(phi))  # computed by hand
         phi = torch.tensor(phi, requires_grad=True)
 
         @qml.qnode(dev, diff_method=diff_method)
@@ -2524,7 +2524,7 @@ class TestGrad:
         import jax.numpy as jnp
 
         dev = qml.device(dev_name, wires=[0, 1])
-        expected_grad = jnp.array(-4 * npp.cos(phi) * npp.sin(phi))  # computed by hand
+        expected_grad = jnp.array(-4 * pnp.cos(phi) * pnp.sin(phi))  # computed by hand
         phi = jnp.array(phi)
 
         @qml.qnode(dev, diff_method=diff_method)
@@ -2898,7 +2898,7 @@ class TestPauliRot:
         assert decomp_ops[4].wires == Wires([2])
         assert decomp_ops[4].data[0] == -np.pi / 2
 
-    @pytest.mark.parametrize("angle", npp.linspace(0, 2 * np.pi, 7, requires_grad=True))
+    @pytest.mark.parametrize("angle", pnp.linspace(0, 2 * np.pi, 7, requires_grad=True))
     @pytest.mark.parametrize("pauli_word", ["XX", "YY", "ZZ"])
     def test_differentiability(self, angle, pauli_word, tol):
         """Test that differentiation of PauliRot works."""
@@ -2928,7 +2928,7 @@ class TestPauliRot:
             qml.PauliRot(theta, pauli_word, wires=[0, 1])
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
-        angle = npp.linspace(0, 2 * np.pi, 7, requires_grad=True)
+        angle = pnp.linspace(0, 2 * np.pi, 7, requires_grad=True)
         jac = qml.jacobian(circuit)(angle)
 
         assert np.allclose(
@@ -2937,7 +2937,7 @@ class TestPauliRot:
             atol=tol,
         )
 
-    @pytest.mark.parametrize("angle", npp.linspace(0, 2 * np.pi, 7, requires_grad=True))
+    @pytest.mark.parametrize("angle", pnp.linspace(0, 2 * np.pi, 7, requires_grad=True))
     def test_decomposition_integration(self, angle):
         """Test that the decompositon of PauliRot yields the same results."""
 
@@ -3169,7 +3169,7 @@ class TestMultiRZ:
         assert decomp_ops[4].name == "CNOT"
         assert decomp_ops[4].wires == Wires([3, 2])
 
-    @pytest.mark.parametrize("angle", npp.linspace(0, 2 * np.pi, 7, requires_grad=True))
+    @pytest.mark.parametrize("angle", pnp.linspace(0, 2 * np.pi, 7, requires_grad=True))
     def test_differentiability(self, angle, tol):
         """Test that differentiation of MultiRZ works."""
 
@@ -3201,14 +3201,14 @@ class TestMultiRZ:
 
             return qml.expval(qml.PauliX(0) @ qml.PauliX(1))
 
-        angle = npp.linspace(0, 2 * np.pi, 7, requires_grad=True)
+        angle = pnp.linspace(0, 2 * np.pi, 7, requires_grad=True)
         jac = qml.jacobian(circuit)(angle)
 
         assert np.allclose(
             jac, 0.5 * (circuit(angle + np.pi / 2) - circuit(angle - np.pi / 2)), atol=tol
         )
 
-    @pytest.mark.parametrize("angle", npp.linspace(0, 2 * np.pi, 7, requires_grad=True))
+    @pytest.mark.parametrize("angle", pnp.linspace(0, 2 * np.pi, 7, requires_grad=True))
     def test_decomposition_integration(self, angle):
         """Test that the decompositon of MultiRZ yields the same results."""
         angle = qml.numpy.array(angle)
@@ -3310,11 +3310,11 @@ class TestSimplify:
     def get_unsimplified_op(op_class):
         # construct the parameters of the op
         if op_class.num_params == 1:
-            params = npp.array([[-50.0, 3.0, 50.0]])
+            params = pnp.array([[-50.0, 3.0, 50.0]])
         elif op_class.num_params == 2:
-            params = npp.array([[-50.0, 3.0, 50.0], [3.0, 50.0, -50.0]])
+            params = pnp.array([[-50.0, 3.0, 50.0], [3.0, 50.0, -50.0]])
         else:
-            params = npp.array([[-50.0, 3.0, 50.0], [3.0, 50.0, -50.0], [50.0, -50.0, 3.0]])
+            params = pnp.array([[-50.0, 3.0, 50.0], [3.0, 50.0, -50.0], [50.0, -50.0, 3.0]])
 
         # construct the wires
         if op_class.num_wires == 1:

--- a/tests/ops/qubit/test_state_prep.py
+++ b/tests/ops/qubit/test_state_prep.py
@@ -17,17 +17,17 @@ Unit tests for the available qubit state preparation operations.
 import pytest
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane.wires import WireError
 
-densitymat0 = np.array([[1.0, 0.0], [0.0, 0.0]])
+densitymat0 = pnp.array([[1.0, 0.0], [0.0, 0.0]])
 
 
 @pytest.mark.parametrize(
     "op",
     [
-        qml.BasisState(np.array([0, 1]), wires=[0, 1]),
-        qml.StatePrep(np.array([1.0, 0.0]), wires=0),
+        qml.BasisState(pnp.array([0, 1]), wires=[0, 1]),
+        qml.StatePrep(pnp.array([1.0, 0.0]), wires=0),
         qml.QubitDensityMatrix(densitymat0, wires=0),
     ],
 )
@@ -60,7 +60,7 @@ class TestDecomposition:
     def test_BasisState_decomposition(self):
         """Test the decomposition for BasisState"""
 
-        n = np.array([0, 1, 0])
+        n = pnp.array([0, 1, 0])
         wires = (0, 1, 2)
         ops1 = qml.BasisState.compute_decomposition(n, wires)
         ops2 = qml.BasisState(n, wires=wires).decomposition()
@@ -72,7 +72,7 @@ class TestDecomposition:
     def test_StatePrep_decomposition(self):
         """Test the decomposition for StatePrep."""
 
-        U = np.array([1, 0, 0, 0])
+        U = pnp.array([1, 0, 0, 0])
         wires = (0, 1)
 
         ops1 = qml.StatePrep.compute_decomposition(U, wires)
@@ -85,10 +85,10 @@ class TestDecomposition:
     @pytest.mark.parametrize(
         "state, pad_with, expected",
         [
-            (np.array([1, 0]), 0, np.array([1, 0, 0, 0])),
-            (np.array([1j, 1]) / np.sqrt(2), 0, np.array([1j, 1, 0, 0]) / np.sqrt(2)),
-            (np.array([1, 1]) / 2, 0.5, np.array([1, 1, 1, 1]) / 2),
-            (np.array([1, 1]) / 2, 0.5j, np.array([1, 1, 1j, 1j]) / 2),
+            (pnp.array([1, 0]), 0, pnp.array([1, 0, 0, 0])),
+            (pnp.array([1j, 1]) / pnp.sqrt(2), 0, pnp.array([1j, 1, 0, 0]) / pnp.sqrt(2)),
+            (pnp.array([1, 1]) / 2, 0.5, pnp.array([1, 1, 1, 1]) / 2),
+            (pnp.array([1, 1]) / 2, 0.5j, pnp.array([1, 1, 1j, 1j]) / 2),
         ],
     )
     def test_StatePrep_padding(self, state, pad_with, expected):
@@ -101,13 +101,13 @@ class TestDecomposition:
             qml.StatePrep(state, pad_with=pad_with, wires=wires)
             return qml.state()
 
-        assert np.allclose(circuit(), expected)
+        assert pnp.allclose(circuit(), expected)
 
     @pytest.mark.parametrize(
         "state",
         [
-            (np.array([1, 1, 1, 1])),
-            (np.array([1, 1j, 1j, 1])),
+            (pnp.array([1, 1, 1, 1])),
+            (pnp.array([1, 1j, 1j, 1])),
         ],
     )
     def test_StatePrep_normalize(self, state):
@@ -120,12 +120,12 @@ class TestDecomposition:
             qml.StatePrep(state, normalize=True, wires=wires)
             return qml.state()
 
-        assert np.allclose(circuit(), state / 2)
+        assert pnp.allclose(circuit(), state / 2)
 
     def test_StatePrep_broadcasting(self):
         """Test broadcasting for StatePrep."""
 
-        U = np.eye(4)[:3]
+        U = pnp.eye(4)[:3]
         wires = (0, 1)
 
         op = qml.StatePrep(U, wires=wires)
@@ -154,7 +154,7 @@ class TestStateVector:
         ket = qsv_op.state_vector(wire_order=wire_order)
         assert ket[one_position] == 1
         ket[one_position] = 0  # everything else should be zero, as we assert below
-        assert np.allclose(np.zeros((2,) * num_wires), ket)
+        assert pnp.allclose(pnp.zeros((2,) * num_wires), ket)
 
     @pytest.mark.parametrize(
         "num_wires,wire_order,one_positions",
@@ -176,24 +176,24 @@ class TestStateVector:
         assert ket[one_positions[0]] == 1 == ket[one_positions[1]]
         ket[one_positions[0]] = ket[one_positions[1]] = 0
         # everything else should be zero, as we assert below
-        assert np.allclose(np.zeros((2,) * (num_wires + 1)), ket)
+        assert pnp.allclose(pnp.zeros((2,) * (num_wires + 1)), ket)
 
     def test_StatePrep_reordering(self):
         """Tests that wires get re-ordered as expected."""
-        qsv_op = qml.StatePrep(np.array([1, -1, 1j, -1j]) / 2, wires=[0, 1])
+        qsv_op = qml.StatePrep(pnp.array([1, -1, 1j, -1j]) / 2, wires=[0, 1])
         ket = qsv_op.state_vector(wire_order=[2, 1, 3, 0])
-        expected = np.zeros((2, 2, 2, 2), dtype=np.complex128)
-        expected[0, :, 0, :] = np.array([[1, 1j], [-1, -1j]]) / 2
-        assert np.array_equal(ket, expected)
+        expected = pnp.zeros((2, 2, 2, 2), dtype=pnp.complex128)
+        expected[0, :, 0, :] = pnp.array([[1, 1j], [-1, -1j]]) / 2
+        assert pnp.array_equal(ket, expected)
 
     def test_StatePrep_reordering_broadcasted(self):
         """Tests that wires get re-ordered as expected with broadcasting."""
-        qsv_op = qml.StatePrep(np.array([[1, -1, 1j, -1j], [1, -1j, -1, 1j]]) / 2, wires=[0, 1])
+        qsv_op = qml.StatePrep(pnp.array([[1, -1, 1j, -1j], [1, -1j, -1, 1j]]) / 2, wires=[0, 1])
         ket = qsv_op.state_vector(wire_order=[2, 1, 3, 0])
-        expected = np.zeros((2,) * 5, dtype=np.complex128)
-        expected[0, 0, :, 0, :] = np.array([[1, 1j], [-1, -1j]]) / 2
-        expected[1, 0, :, 0, :] = np.array([[1, -1], [-1j, 1j]]) / 2
-        assert np.array_equal(ket, expected)
+        expected = pnp.zeros((2,) * 5, dtype=pnp.complex128)
+        expected[0, 0, :, 0, :] = pnp.array([[1, 1j], [-1, -1j]]) / 2
+        expected[1, 0, :, 0, :] = pnp.array([[1, -1], [-1j, 1j]]) / 2
+        assert pnp.array_equal(ket, expected)
 
     @pytest.mark.all_interfaces
     @pytest.mark.parametrize("interface", ["autograd", "jax", "torch", "tensorflow"])
@@ -274,7 +274,7 @@ class TestStateVector:
 
         state = qml.numpy.array([1.0, 0.0])
         grad = qml.jacobian(circuit)(state)
-        assert np.array_equal(grad, [2.0, 0.0])
+        assert pnp.array_equal(grad, [2.0, 0.0])
 
     @pytest.mark.torch
     def test_StatePrep_backprop_torch(self):
@@ -292,7 +292,7 @@ class TestStateVector:
         res.backward()
         grad = state.grad
         assert qml.math.get_interface(grad) == "torch"
-        assert np.array_equal(grad, [2.0, 0.0])
+        assert pnp.array_equal(grad, [2.0, 0.0])
 
     @pytest.mark.jax
     def test_StatePrep_backprop_jax(self):
@@ -308,7 +308,7 @@ class TestStateVector:
         state = jax.numpy.array([1.0, 0.0])
         grad = jax.jacobian(circuit)(state)
         assert qml.math.get_interface(grad) == "jax"
-        assert np.array_equal(grad, [2.0, 0.0])
+        assert pnp.array_equal(grad, [2.0, 0.0])
 
     @pytest.mark.tf
     def test_StatePrep_backprop_tf(self):
@@ -327,7 +327,7 @@ class TestStateVector:
 
         grad = tape.jacobian(res, state)
         assert qml.math.get_interface(grad) == "tensorflow"
-        assert np.array_equal(grad, [2.0, 0.0])
+        assert pnp.array_equal(grad, [2.0, 0.0])
 
     @pytest.mark.parametrize(
         "num_wires,wire_order,one_position",
@@ -348,15 +348,15 @@ class TestStateVector:
         assert qml.math.shape(ket) == (2,) * num_wires
         assert ket[one_position] == 1
         ket[one_position] = 0  # everything else should be zero, as we assert below
-        assert np.allclose(np.zeros((2,) * num_wires), ket)
+        assert pnp.allclose(pnp.zeros((2,) * num_wires), ket)
 
     @pytest.mark.parametrize(
         "state",
         [
-            np.array([0, 0]),
-            np.array([1, 0]),
-            np.array([0, 1]),
-            np.array([1, 1]),
+            pnp.array([0, 0]),
+            pnp.array([1, 0]),
+            pnp.array([0, 1]),
+            pnp.array([1, 1]),
         ],
     )
     @pytest.mark.parametrize("device_wires", [3, 4, 5])
@@ -374,7 +374,7 @@ class TestStateVector:
 
         assert basis_state[one_index] == 1
         basis_state[one_index] = 0
-        assert not np.any(basis_state)
+        assert not pnp.any(basis_state)
 
     @pytest.mark.all_interfaces
     @pytest.mark.parametrize("interface", ["autograd", "jax", "torch", "tensorflow"])

--- a/tests/ops/qutrit/test_qutrit_parametric_ops.py
+++ b/tests/ops/qutrit/test_qutrit_parametric_ops.py
@@ -24,7 +24,7 @@ import pytest
 from gate_data import TCLOCK, TSHIFT
 
 import pennylane as qml
-from pennylane import numpy as npp
+from pennylane import numpy as pnp
 from pennylane.ops.qutrit import validate_subspace
 from pennylane.wires import Wires
 
@@ -443,7 +443,7 @@ class TestGrad:
     diff_methods = ["parameter-shift", "finite-diff", "best", "backprop"]
 
     @pytest.mark.autograd
-    @pytest.mark.parametrize("phi", npp.linspace(0, 2 * np.pi, 7, requires_grad=True))
+    @pytest.mark.parametrize("phi", pnp.linspace(0, 2 * np.pi, 7, requires_grad=True))
     @pytest.mark.parametrize("diff_method", diff_methods)
     def test_differentiability(self, op, obs, grad_fn, phi, diff_method, tol):
         """Test that parametrized rotations are differentiable and the gradient is correct"""
@@ -468,7 +468,7 @@ class TestGrad:
         if diff_method in ("finite-diff", "parameter-shift"):
             pytest.xfail()
 
-        phi = npp.linspace(0, 2 * np.pi, 7, requires_grad=True)
+        phi = pnp.linspace(0, 2 * np.pi, 7, requires_grad=True)
 
         dev = qml.device("default.qutrit", wires=1)
 
@@ -485,7 +485,7 @@ class TestGrad:
         assert np.allclose(jac, np.diag(grad_fn(phi)), atol=tol, rtol=0)
 
     @pytest.mark.jax
-    @pytest.mark.parametrize("phi", npp.linspace(0, 2 * np.pi, 7))
+    @pytest.mark.parametrize("phi", pnp.linspace(0, 2 * np.pi, 7))
     @pytest.mark.parametrize("diff_method", diff_methods)
     def test_differentiability_jax(self, op, obs, grad_fn, phi, diff_method, tol):
         """Test that parametrized operations are differentiable with JAX and the gradient is correct"""
@@ -533,7 +533,7 @@ class TestGrad:
         assert np.allclose(jac, np.diag(grad_fn(phi)), atol=tol, rtol=0)
 
     @pytest.mark.torch
-    @pytest.mark.parametrize("phi", npp.linspace(0, 2 * np.pi, 7))
+    @pytest.mark.parametrize("phi", pnp.linspace(0, 2 * np.pi, 7))
     @pytest.mark.parametrize("diff_method", diff_methods)
     def test_differentiability_torch(self, op, obs, grad_fn, phi, diff_method, tol):
         """Test that parametrized operations are differentiable with Torch and the gradient is correct"""
@@ -580,7 +580,7 @@ class TestGrad:
         assert qml.math.allclose(jac, np.diag(grad_fn(phi)), atol=tol, rtol=0)
 
     @pytest.mark.tf
-    @pytest.mark.parametrize("phi", npp.linspace(0, 2 * np.pi, 7))
+    @pytest.mark.parametrize("phi", pnp.linspace(0, 2 * np.pi, 7))
     @pytest.mark.parametrize("diff_method", diff_methods)
     def test_differentiability_tf(self, op, obs, grad_fn, phi, diff_method, tol):
         """Test that parametrized operations are differentiable with TensorFlow and the gradient is correct"""

--- a/tests/ops/qutrit/test_qutrit_state_prep.py
+++ b/tests/ops/qutrit/test_qutrit_state_prep.py
@@ -17,14 +17,14 @@ Unit tests for the available qubit state preparation operations.
 import pytest
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane.wires import WireError
 
 
 def test_QutritBasisState_decomposition():
     """Test the decomposition for QutritBasisState"""
 
-    n = np.array([0, 1, 0])
+    n = pnp.array([0, 1, 0])
     wires = (0, 1, 2)
     ops1 = qml.QutritBasisState.compute_decomposition(n, wires)
     ops2 = qml.QutritBasisState(n, wires=wires).decomposition()
@@ -56,15 +56,15 @@ class TestStateVector:
         assert qml.math.shape(ket) == (3,) * num_wires
         assert ket[one_position] == 1
         ket[one_position] = 0  # everything else should be zero, as we assert below
-        assert np.allclose(np.zeros((3,) * num_wires), ket)
+        assert pnp.allclose(pnp.zeros((3,) * num_wires), ket)
 
     @pytest.mark.parametrize(
         "state",
         [
-            np.array([0, 0]),
-            np.array([1, 0]),
-            np.array([0, 1]),
-            np.array([1, 1]),
+            pnp.array([0, 0]),
+            pnp.array([1, 0]),
+            pnp.array([0, 1]),
+            pnp.array([1, 1]),
         ],
     )
     @pytest.mark.parametrize("device_wires", [3, 4, 5])
@@ -82,7 +82,7 @@ class TestStateVector:
 
         assert basis_state[one_index] == 1
         basis_state[one_index] = 0
-        assert not np.any(basis_state)
+        assert not pnp.any(basis_state)
 
     @pytest.mark.all_interfaces
     @pytest.mark.parametrize("interface", ["numpy", "jax", "torch", "tensorflow"])

--- a/tests/ops/test_cv_ops.py
+++ b/tests/ops/test_cv_ops.py
@@ -19,14 +19,14 @@ Unit tests for the :mod:`pennylane.plugin.DefaultGaussian` device.
 import numpy.testing as np_testing
 import pytest
 
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane.operation import AnyWires
 from pennylane.ops import cv
 from pennylane.wires import Wires
 
-s_vals = np.linspace(-3, 3, 13)
-phis = np.linspace(-2 * np.pi, 2 * np.pi, 11)
-mags = np.linspace(0.0, 1.0, 7)
+s_vals = pnp.linspace(-3, 3, 13)
+phis = pnp.linspace(-2 * pnp.pi, 2 * pnp.pi, 11)
+mags = pnp.linspace(0.0, 1.0, 7)
 
 
 class TestCV:
@@ -36,10 +36,10 @@ class TestCV:
     def test_rotation_heisenberg(self, phi):
         """ops: Tests the Heisenberg representation of the Rotation gate."""
         matrix = cv.Rotation._heisenberg_rep([phi])
-        true_matrix = np.array(
-            [[1, 0, 0], [0, np.cos(phi), -np.sin(phi)], [0, np.sin(phi), np.cos(phi)]]
+        true_matrix = pnp.array(
+            [[1, 0, 0], [0, pnp.cos(phi), -pnp.sin(phi)], [0, pnp.sin(phi), pnp.cos(phi)]]
         )
-        assert np.allclose(matrix, true_matrix)
+        assert pnp.allclose(matrix, true_matrix)
 
     @pytest.mark.parametrize(
         "op,size",
@@ -56,7 +56,7 @@ class TestCV:
             (cv.TwoModeSqueezing(2.532, 1.778, wires=[1, 2]), 5),
             (
                 cv.InterferometerUnitary(
-                    np.array([[1, 1], [1, -1]]) * -1.0j / np.sqrt(2.0), wires=1
+                    pnp.array([[1, 1], [1, -1]]) * -1.0j / pnp.sqrt(2.0), wires=1
                 ),
                 5,
             ),
@@ -68,10 +68,10 @@ class TestCV:
         op_d = op.adjoint()
         op_heis = op._heisenberg_rep(op.parameters)
         op_d_heis = op_d._heisenberg_rep(op_d.parameters)
-        res1 = np.dot(op_heis, op_d_heis)
-        res2 = np.dot(op_d_heis, op_heis)
-        np_testing.assert_allclose(res1, np.eye(size), atol=tol)
-        np_testing.assert_allclose(res2, np.eye(size), atol=tol)
+        res1 = pnp.dot(op_heis, op_d_heis)
+        res2 = pnp.dot(op_d_heis, op_heis)
+        np_testing.assert_allclose(res1, pnp.eye(size), atol=tol)
+        np_testing.assert_allclose(res2, pnp.eye(size), atol=tol)
         assert op.wires == op_d.wires
 
     @pytest.mark.parametrize(
@@ -92,14 +92,14 @@ class TestCV:
         """ops: Tests the Heisenberg representation of the Squeezing gate."""
         r = mag
         matrix = cv.Squeezing._heisenberg_rep([r, phi])
-        true_matrix = np.array(
+        true_matrix = pnp.array(
             [
                 [1, 0, 0],
-                [0, np.cosh(r) - np.cos(phi) * np.sinh(r), -np.sin(phi) * np.sinh(r)],
-                [0, -np.sin(phi) * np.sinh(r), np.cosh(r) + np.cos(phi) * np.sinh(r)],
+                [0, pnp.cosh(r) - pnp.cos(phi) * pnp.sinh(r), -pnp.sin(phi) * pnp.sinh(r)],
+                [0, -pnp.sin(phi) * pnp.sinh(r), pnp.cosh(r) + pnp.cos(phi) * pnp.sinh(r)],
             ]
         )
-        assert np.allclose(matrix, true_matrix)
+        assert pnp.allclose(matrix, true_matrix)
 
     @pytest.mark.parametrize("phi", phis)
     @pytest.mark.parametrize("mag", mags)
@@ -108,30 +108,30 @@ class TestCV:
         r = mag
         hbar = 2
         matrix = cv.Displacement._heisenberg_rep([r, phi])
-        true_matrix = np.array(
+        true_matrix = pnp.array(
             [
                 [1, 0, 0],
-                [np.sqrt(2 * hbar) * r * np.cos(phi), 1, 0],
-                [np.sqrt(2 * hbar) * r * np.sin(phi), 0, 1],
+                [pnp.sqrt(2 * hbar) * r * pnp.cos(phi), 1, 0],
+                [pnp.sqrt(2 * hbar) * r * pnp.sin(phi), 0, 1],
             ]
         )
-        assert np.allclose(matrix, true_matrix)
+        assert pnp.allclose(matrix, true_matrix)
 
     @pytest.mark.parametrize("phi", phis)
     @pytest.mark.parametrize("theta", phis)
     def test_beamsplitter_heisenberg(self, phi, theta):
         """ops: Tests the Heisenberg representation of the Beamsplitter gate."""
         matrix = cv.Beamsplitter._heisenberg_rep([theta, phi])
-        true_matrix = np.array(
+        true_matrix = pnp.array(
             [
                 [1, 0, 0, 0, 0],
-                [0, np.cos(theta), 0, -np.cos(phi) * np.sin(theta), -np.sin(phi) * np.sin(theta)],
-                [0, 0, np.cos(theta), np.sin(phi) * np.sin(theta), -np.cos(phi) * np.sin(theta)],
-                [0, np.cos(phi) * np.sin(theta), -np.sin(phi) * np.sin(theta), np.cos(theta), 0],
-                [0, np.sin(phi) * np.sin(theta), np.cos(phi) * np.sin(theta), 0, np.cos(theta)],
+                [0, pnp.cos(theta), 0, -pnp.cos(phi) * pnp.sin(theta), -pnp.sin(phi) * pnp.sin(theta)],
+                [0, 0, pnp.cos(theta), pnp.sin(phi) * pnp.sin(theta), -pnp.cos(phi) * pnp.sin(theta)],
+                [0, pnp.cos(phi) * pnp.sin(theta), -pnp.sin(phi) * pnp.sin(theta), pnp.cos(theta), 0],
+                [0, pnp.sin(phi) * pnp.sin(theta), pnp.cos(phi) * pnp.sin(theta), 0, pnp.cos(theta)],
             ]
         )
-        assert np.allclose(matrix, true_matrix)
+        assert pnp.allclose(matrix, true_matrix)
 
     @pytest.mark.parametrize("phi", phis)
     @pytest.mark.parametrize("mag", mags)
@@ -139,48 +139,48 @@ class TestCV:
         """ops: Tests the Heisenberg representation of the Beamsplitter gate."""
         r = mag
         matrix = cv.TwoModeSqueezing._heisenberg_rep([r, phi])
-        true_matrix = np.array(
+        true_matrix = pnp.array(
             [
                 [1, 0, 0, 0, 0],
-                [0, np.cosh(r), 0, np.cos(phi) * np.sinh(r), np.sin(phi) * np.sinh(r)],
-                [0, 0, np.cosh(r), np.sin(phi) * np.sinh(r), -np.cos(phi) * np.sinh(r)],
-                [0, np.cos(phi) * np.sinh(r), np.sin(phi) * np.sinh(r), np.cosh(r), 0],
-                [0, np.sin(phi) * np.sinh(r), -np.cos(phi) * np.sinh(r), 0, np.cosh(r)],
+                [0, pnp.cosh(r), 0, pnp.cos(phi) * pnp.sinh(r), pnp.sin(phi) * pnp.sinh(r)],
+                [0, 0, pnp.cosh(r), pnp.sin(phi) * pnp.sinh(r), -pnp.cos(phi) * pnp.sinh(r)],
+                [0, pnp.cos(phi) * pnp.sinh(r), pnp.sin(phi) * pnp.sinh(r), pnp.cosh(r), 0],
+                [0, pnp.sin(phi) * pnp.sinh(r), -pnp.cos(phi) * pnp.sinh(r), 0, pnp.cosh(r)],
             ]
         )
-        assert np.allclose(matrix, true_matrix)
+        assert pnp.allclose(matrix, true_matrix)
 
     @pytest.mark.parametrize("s", s_vals)
     def test_quadratic_phase_heisenberg(self, s):
         """ops: Tests the Heisenberg representation of the QuadraticPhase gate."""
         matrix = cv.QuadraticPhase._heisenberg_rep([s])
-        true_matrix = np.array([[1, 0, 0], [0, 1, 0], [0, s, 1]])
-        assert np.allclose(matrix, true_matrix)
+        true_matrix = pnp.array([[1, 0, 0], [0, 1, 0], [0, s, 1]])
+        assert pnp.allclose(matrix, true_matrix)
 
     @pytest.mark.parametrize("s", s_vals)
     def test_controlled_addition_heisenberg(self, s):
         """ops: Tests the Heisenberg representation of ControlledAddition gate."""
         matrix = cv.ControlledAddition._heisenberg_rep([s])
-        true_matrix = np.array(
+        true_matrix = pnp.array(
             [[1, 0, 0, 0, 0], [0, 1, 0, 0, 0], [0, 0, 1, 0, -s], [0, s, 0, 1, 0], [0, 0, 0, 0, 1]]
         )
-        assert np.allclose(matrix, true_matrix)
+        assert pnp.allclose(matrix, true_matrix)
 
     @pytest.mark.parametrize("s", s_vals)
     def test_controlled_phase_heisenberg(self, s):
         """Tests the Heisenberg representation of the ControlledPhase gate."""
         matrix = cv.ControlledPhase._heisenberg_rep([s])
-        true_matrix = np.array(
+        true_matrix = pnp.array(
             [[1, 0, 0, 0, 0], [0, 1, 0, 0, 0], [0, 0, 1, s, 0], [0, 0, 0, 1, 0], [0, s, 0, 0, 1]]
         )
-        assert np.allclose(matrix, true_matrix)
+        assert pnp.allclose(matrix, true_matrix)
 
     @pytest.mark.parametrize("phi", phis)
     def test_quadoperator_heisenberg(self, phi):
         """ops: Tests the Heisenberg representation of the QuadOperator gate."""
         matrix = cv.QuadOperator._heisenberg_rep([phi])
-        true_matrix = np.array([0, np.cos(phi), np.sin(phi)])
-        assert np.allclose(matrix, true_matrix)
+        true_matrix = pnp.array([0, pnp.cos(phi), pnp.sin(phi)])
+        assert pnp.allclose(matrix, true_matrix)
 
 
 class TestNonGaussian:
@@ -220,7 +220,7 @@ state_prep_data = [
     (cv.GaussianState(0.1, 0.2, wires=(0, 1, 2, 3, 4)), 2, AnyWires, "F"),
     (cv.FockState(1, wires=0), 1, 1, None),
     (cv.FockStateVector([0, 0, 1, 0], wires=0), 1, AnyWires, "F"),
-    (cv.FockDensityMatrix(np.eye(2), wires=0), 1, AnyWires, "F"),
+    (cv.FockDensityMatrix(pnp.eye(2), wires=0), 1, AnyWires, "F"),
     (cv.CatState(0.1, 0.2, 0.3, wires=0), 3, 1, "F"),
 ]
 
@@ -246,10 +246,10 @@ label_data = [
     (cv.Kerr(1.234, wires=0), "Kerr", "Kerr\n(1.23)"),
     (cv.CrossKerr(1.234, wires=(0, 1)), "CrossKerr", "CrossKerr\n(1.23)"),
     (cv.CubicPhase(1.234, wires=0), "V", "V\n(1.23)"),
-    (cv.InterferometerUnitary(np.eye(2), wires=0), "U", "U"),
+    (cv.InterferometerUnitary(pnp.eye(2), wires=0), "U", "U"),
     (cv.ThermalState(1.234, wires=0), "Thermal", "Thermal\n(1.23)"),
     (
-        cv.GaussianState(np.array([[2, 0], [0, 2]]), np.array([1, 2]), wires=[1]),
+        cv.GaussianState(pnp.array([[2, 0], [0, 2]]), pnp.array([1, 2]), wires=[1]),
         "Gaussian",
         "Gaussian",
     ),

--- a/tests/optimize/test_adagrad.py
+++ b/tests/optimize/test_adagrad.py
@@ -16,7 +16,7 @@ Unit tests for the ``AdagradOptimizer``.
 """
 import pytest
 
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane.optimize import AdagradOptimizer
 
 
@@ -39,13 +39,13 @@ class TestAdagradOptimizer:
         stepsize, eps = 0.1, 1e-8
         sgd_opt = AdagradOptimizer(stepsize, eps=eps)
 
-        grad = (np.array(grad),)
-        args = (np.array(args, requires_grad=True),)
+        grad = (pnp.array(grad),)
+        args = (pnp.array(args, requires_grad=True),)
 
         a1 = grad[0] ** 2
-        expected = args[0] - stepsize / np.sqrt(a1 + eps) * grad[0]
+        expected = args[0] - stepsize / pnp.sqrt(a1 + eps) * grad[0]
         res = sgd_opt.apply_grad(grad, args)
-        assert np.allclose(res, expected, atol=tol)
+        assert pnp.allclose(res, expected, atol=tol)
 
         # Simulate a new step
         grad = (grad[0] + args[0],)
@@ -54,34 +54,34 @@ class TestAdagradOptimizer:
         res = sgd_opt.apply_grad(grad, args)
 
         a2 = a1 + grad[0] ** 2
-        expected = args - stepsize / np.sqrt(a2 + eps) * grad[0]
+        expected = args - stepsize / pnp.sqrt(a2 + eps) * grad[0]
 
-        assert np.allclose(res, expected, atol=tol)
+        assert pnp.allclose(res, expected, atol=tol)
 
-    @pytest.mark.parametrize("x_start", np.linspace(-10, 10, 16, endpoint=False))
+    @pytest.mark.parametrize("x_start", pnp.linspace(-10, 10, 16, endpoint=False))
     def test_adagrad_optimizer_univar(self, x_start, tol):
         """Tests that adagrad optimizer takes one and two steps correctly
         for univariate functions."""
         stepsize = 0.1
         adag_opt = AdagradOptimizer(stepsize)
 
-        univariate_funcs = [np.sin, lambda x: np.exp(x / 10.0), lambda x: x**2]
-        grad_uni_fns = [np.cos, lambda x: np.exp(x / 10.0) / 10.0, lambda x: 2 * x]
+        univariate_funcs = [pnp.sin, lambda x: pnp.exp(x / 10.0), lambda x: x**2]
+        grad_uni_fns = [pnp.cos, lambda x: pnp.exp(x / 10.0) / 10.0, lambda x: 2 * x]
 
         for gradf, f in zip(grad_uni_fns, univariate_funcs):
             adag_opt.reset()
 
             x_onestep = adag_opt.step(f, x_start)
             past_grads = gradf(x_start) * gradf(x_start)
-            adapt_stepsize = stepsize / np.sqrt(past_grads + 1e-8)
+            adapt_stepsize = stepsize / pnp.sqrt(past_grads + 1e-8)
             x_onestep_target = x_start - gradf(x_start) * adapt_stepsize
-            assert np.allclose(x_onestep, x_onestep_target, atol=tol)
+            assert pnp.allclose(x_onestep, x_onestep_target, atol=tol)
 
             x_twosteps = adag_opt.step(f, x_onestep)
             past_grads = gradf(x_start) * gradf(x_start) + gradf(x_onestep) * gradf(x_onestep)
-            adapt_stepsize = stepsize / np.sqrt(past_grads + 1e-8)
+            adapt_stepsize = stepsize / pnp.sqrt(past_grads + 1e-8)
             x_twosteps_target = x_onestep - gradf(x_onestep) * adapt_stepsize
-            assert np.allclose(x_twosteps, x_twosteps_target, atol=tol)
+            assert pnp.allclose(x_twosteps, x_twosteps_target, atol=tol)
 
     def test_adagrad_optimizer_multivar(self, tol):
         """Tests that adagrad optimizer takes one and two steps correctly
@@ -90,24 +90,24 @@ class TestAdagradOptimizer:
         adag_opt = AdagradOptimizer(stepsize)
 
         multivariate_funcs = [
-            lambda x: np.sin(x[0]) + np.cos(x[1]),
-            lambda x: np.exp(x[0] / 3) * np.tanh(x[1]),
-            lambda x: np.sum([x_**2 for x_ in x]),
+            lambda x: pnp.sin(x[0]) + pnp.cos(x[1]),
+            lambda x: pnp.exp(x[0] / 3) * pnp.tanh(x[1]),
+            lambda x: pnp.sum([x_**2 for x_ in x]),
         ]
         grad_multi_funcs = [
-            lambda x: (np.array([np.cos(x[0]), -np.sin(x[1])]),),
+            lambda x: (pnp.array([pnp.cos(x[0]), -pnp.sin(x[1])]),),
             lambda x: (
-                np.array(
+                pnp.array(
                     [
-                        np.exp(x[0] / 3) / 3 * np.tanh(x[1]),
-                        np.exp(x[0] / 3) * (1 - np.tanh(x[1]) ** 2),
+                        pnp.exp(x[0] / 3) / 3 * pnp.tanh(x[1]),
+                        pnp.exp(x[0] / 3) * (1 - pnp.tanh(x[1]) ** 2),
                     ]
                 ),
             ),
-            lambda x: (np.array([2 * x_ for x_ in x]),),
+            lambda x: (pnp.array([2 * x_ for x_ in x]),),
         ]
 
-        x_vals = np.linspace(-10, 10, 16, endpoint=False)
+        x_vals = pnp.linspace(-10, 10, 16, endpoint=False)
 
         for gradf, f in zip(grad_multi_funcs, multivariate_funcs):
             for jdx in range(len(x_vals[:-1])):
@@ -116,14 +116,14 @@ class TestAdagradOptimizer:
                 x_vec = x_vals[jdx : jdx + 2]
                 x_onestep = adag_opt.step(f, x_vec)
                 past_grads = gradf(x_vec)[0] * gradf(x_vec)[0]
-                adapt_stepsize = stepsize / np.sqrt(past_grads + 1e-8)
+                adapt_stepsize = stepsize / pnp.sqrt(past_grads + 1e-8)
                 x_onestep_target = x_vec - gradf(x_vec)[0] * adapt_stepsize
-                assert np.allclose(x_onestep, x_onestep_target, atol=tol)
+                assert pnp.allclose(x_onestep, x_onestep_target, atol=tol)
 
                 x_twosteps = adag_opt.step(f, x_onestep)
                 past_grads = (
                     gradf(x_vec)[0] * gradf(x_vec)[0] + gradf(x_onestep)[0] * gradf(x_onestep)[0]
                 )
-                adapt_stepsize = stepsize / np.sqrt(past_grads + 1e-8)
+                adapt_stepsize = stepsize / pnp.sqrt(past_grads + 1e-8)
                 x_twosteps_target = x_onestep - gradf(x_onestep)[0] * adapt_stepsize
-                assert np.allclose(x_twosteps, x_twosteps_target, atol=tol)
+                assert pnp.allclose(x_twosteps, x_twosteps_target, atol=tol)

--- a/tests/optimize/test_momentum.py
+++ b/tests/optimize/test_momentum.py
@@ -16,7 +16,7 @@ Unit tests for the ``MomentumOptimizer``.
 """
 import pytest
 
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane.optimize import MomentumOptimizer
 
 
@@ -38,12 +38,12 @@ class TestMomentumOptimizer:
         """
         stepsize, gamma = 0.1, 0.5
         sgd_opt = MomentumOptimizer(stepsize, momentum=gamma)
-        grad, args = np.array(grad), np.array(args, requires_grad=True)
+        grad, args = pnp.array(grad), pnp.array(args, requires_grad=True)
 
         a1 = stepsize * grad
         expected = args - a1
         res = sgd_opt.apply_grad(grad, args)
-        assert np.allclose(res, expected)
+        assert pnp.allclose(res, expected)
 
         # Simulate a new step
         grad = grad + args
@@ -52,19 +52,19 @@ class TestMomentumOptimizer:
         a2 = gamma * a1 + stepsize * grad
         expected = args - a2
         res = sgd_opt.apply_grad(grad, args)
-        assert np.allclose(res, expected, atol=tol)
+        assert pnp.allclose(res, expected, atol=tol)
 
-    @pytest.mark.parametrize("x_start", np.linspace(-10, 10, 16, endpoint=False))
+    @pytest.mark.parametrize("x_start", pnp.linspace(-10, 10, 16, endpoint=False))
     def test_momentum_optimizer_univar(self, x_start, tol):
         """Tests that momentum optimizer takes one and two steps correctly
         for univariate functions."""
         stepsize, gamma = 0.1, 0.5
         mom_opt = MomentumOptimizer(stepsize, momentum=gamma)
 
-        univariate_funcs = [np.sin, lambda x: np.exp(x / 10.0), lambda x: x**2]
+        univariate_funcs = [pnp.sin, lambda x: pnp.exp(x / 10.0), lambda x: x**2]
         grad_uni_fns = [
-            lambda x: (np.cos(x),),
-            lambda x: (np.exp(x / 10.0) / 10.0,),
+            lambda x: (pnp.cos(x),),
+            lambda x: (pnp.exp(x / 10.0) / 10.0,),
             lambda x: (2 * x,),
         ]
 
@@ -73,12 +73,12 @@ class TestMomentumOptimizer:
 
             x_onestep = mom_opt.step(f, x_start)
             x_onestep_target = x_start - gradf(x_start)[0] * stepsize
-            assert np.allclose(x_onestep, x_onestep_target, atol=tol)
+            assert pnp.allclose(x_onestep, x_onestep_target, atol=tol)
 
             x_twosteps = mom_opt.step(f, x_onestep)
             momentum_term = gamma * gradf(x_start)[0]
             x_twosteps_target = x_onestep - (gradf(x_onestep)[0] + momentum_term) * stepsize
-            assert np.allclose(x_twosteps, x_twosteps_target, atol=tol)
+            assert pnp.allclose(x_twosteps, x_twosteps_target, atol=tol)
 
     def test_momentum_optimizer_multivar(self, tol):
         """Tests that momentum optimizer takes one and two steps correctly
@@ -87,24 +87,24 @@ class TestMomentumOptimizer:
         mom_opt = MomentumOptimizer(stepsize, momentum=gamma)
 
         multivariate_funcs = [
-            lambda x: np.sin(x[0]) + np.cos(x[1]),
-            lambda x: np.exp(x[0] / 3) * np.tanh(x[1]),
-            lambda x: np.sum([x_**2 for x_ in x]),
+            lambda x: pnp.sin(x[0]) + pnp.cos(x[1]),
+            lambda x: pnp.exp(x[0] / 3) * pnp.tanh(x[1]),
+            lambda x: pnp.sum([x_**2 for x_ in x]),
         ]
         grad_multi_funcs = [
-            lambda x: (np.array([np.cos(x[0]), -np.sin(x[1])]),),
+            lambda x: (pnp.array([pnp.cos(x[0]), -pnp.sin(x[1])]),),
             lambda x: (
-                np.array(
+                pnp.array(
                     [
-                        np.exp(x[0] / 3) / 3 * np.tanh(x[1]),
-                        np.exp(x[0] / 3) * (1 - np.tanh(x[1]) ** 2),
+                        pnp.exp(x[0] / 3) / 3 * pnp.tanh(x[1]),
+                        pnp.exp(x[0] / 3) * (1 - pnp.tanh(x[1]) ** 2),
                     ]
                 ),
             ),
-            lambda x: (np.array([2 * x_ for x_ in x]),),
+            lambda x: (pnp.array([2 * x_ for x_ in x]),),
         ]
 
-        x_vals = np.linspace(-10, 10, 16, endpoint=False)
+        x_vals = pnp.linspace(-10, 10, 16, endpoint=False)
 
         for gradf, f in zip(grad_multi_funcs, multivariate_funcs):
             for jdx in range(len(x_vals[:-1])):
@@ -113,9 +113,9 @@ class TestMomentumOptimizer:
                 x_vec = x_vals[jdx : jdx + 2]
                 x_onestep = mom_opt.step(f, x_vec)
                 x_onestep_target = x_vec - gradf(x_vec)[0] * stepsize
-                assert np.allclose(x_onestep, x_onestep_target, atol=tol)
+                assert pnp.allclose(x_onestep, x_onestep_target, atol=tol)
 
                 x_twosteps = mom_opt.step(f, x_onestep)
                 momentum_term = gamma * gradf(x_vec)[0]
                 x_twosteps_target = x_onestep - (gradf(x_onestep)[0] + momentum_term) * stepsize
-                assert np.allclose(x_twosteps, x_twosteps_target, atol=tol)
+                assert pnp.allclose(x_twosteps, x_twosteps_target, atol=tol)

--- a/tests/optimize/test_optimize.py
+++ b/tests/optimize/test_optimize.py
@@ -18,7 +18,7 @@ Unit tests for the :mod:`pennylane` optimizers.
 import pytest
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane.optimize import (
     AdagradOptimizer,
     AdamOptimizer,
@@ -59,7 +59,7 @@ class TestOverOpts:
             def func(x, c=1.0):
                 return (x - c) ** 2
 
-        x = np.array(1.0, requires_grad=True)
+        x = pnp.array(1.0, requires_grad=True)
 
         wrapper = func_wrapper()
         spy = mocker.spy(wrapper, "func")
@@ -80,7 +80,7 @@ class TestOverOpts:
         assert kwargs2 == {"c": 2.0}
         assert kwargs3 == {"c": 3.0}
 
-        assert np.allclose(cost_three, wrapper.func(x, c=3.0), atol=tol)
+        assert pnp.allclose(cost_three, wrapper.func(x, c=3.0), atol=tol)
 
     def test_multi_args(self, mocker, opt, opt_name, tol):
         """Test passing multiple arguments to function"""
@@ -93,9 +93,9 @@ class TestOverOpts:
         wrapper = func_wrapper()
         spy = mocker.spy(wrapper, "func")
 
-        x = np.array([1.0])
-        y = np.array([2.0])
-        z = np.array([3.0])
+        x = pnp.array([1.0])
+        y = pnp.array([2.0])
+        z = pnp.array([3.0])
 
         (x_new, y_new, z_new), cost = opt.step_and_cost(wrapper.func, x, y, z)
         self.reset(opt)
@@ -111,7 +111,7 @@ class TestOverOpts:
         assert kwargs1 == {}
         assert kwargs2 == {}
 
-        assert np.allclose(cost, wrapper.func(x, y, z), atol=tol)
+        assert pnp.allclose(cost, wrapper.func(x, y, z), atol=tol)
 
     def test_nontrainable_data(self, opt):
         """Check non-trainable argument does not get updated"""
@@ -120,10 +120,10 @@ class TestOverOpts:
             assert qml.math.allclose(b, 1.0)
             return a * b * c * d
 
-        a = np.array(0.1, requires_grad=True)
-        b = np.array(1.0, requires_grad=False)
+        a = pnp.array(0.1, requires_grad=True)
+        b = pnp.array(1.0, requires_grad=False)
         c = 1.0
-        d = np.array(0.2, requires_grad=True)
+        d = pnp.array(0.2, requires_grad=True)
 
         args1 = opt.step(func, a, b, c, d)
         args2 = opt.step(func, *args1)
@@ -141,10 +141,10 @@ class TestOverOpts:
         def func2(args):
             return args[0][0] * args[1][0] * args[2][0]
 
-        x = np.array([1.0], requires_grad=True)
-        y = np.array([2.0], requires_grad=True)
-        z = np.array([3.0], requires_grad=True)
-        args = np.array((x, y, z), requires_grad=True)
+        x = pnp.array([1.0], requires_grad=True)
+        y = pnp.array([2.0], requires_grad=True)
+        z = pnp.array([3.0], requires_grad=True)
+        args = pnp.array((x, y, z), requires_grad=True)
 
         x_seperate, y_seperate, z_seperate = opt.step(func1, x, y, z)
         self.reset(opt)
@@ -152,9 +152,9 @@ class TestOverOpts:
         args_new = opt.step(func2, args)
         self.reset(opt)
 
-        assert np.allclose(x_seperate, args_new[0], atol=tol)
-        assert np.allclose(y_seperate, args_new[1], atol=tol)
-        assert np.allclose(z_seperate, args_new[2], atol=tol)
+        assert pnp.allclose(x_seperate, args_new[0], atol=tol)
+        assert pnp.allclose(y_seperate, args_new[1], atol=tol)
+        assert pnp.allclose(z_seperate, args_new[2], atol=tol)
 
     def test_one_trainable_one_non_trainable(self, opt):
         """Tests that a cost function that takes one trainable and one
@@ -169,8 +169,8 @@ class TestOverOpts:
         def cost(x, target):
             return (circuit(x) - target) ** 2
 
-        ev = np.tensor(0.7781, requires_grad=False)
-        x = np.tensor(0.0, requires_grad=True)
+        ev = pnp.tensor(0.7781, requires_grad=False)
+        x = pnp.tensor(0.0, requires_grad=True)
 
         original_ev = ev
 
@@ -193,8 +193,8 @@ class TestOverOpts:
         def cost(target, x):  # Note: the order of the arguments has been swapped
             return (circuit(x) - target) ** 2
 
-        ev = np.tensor(0.7781, requires_grad=False)
-        x = np.tensor(0.0, requires_grad=True)
+        ev = pnp.tensor(0.7781, requires_grad=False)
+        x = pnp.tensor(0.0, requires_grad=True)
 
         original_ev = ev
 
@@ -217,9 +217,9 @@ class TestOverOpts:
         def cost(x, y, target):
             return (circuit(x, y) - target) ** 2
 
-        ev = np.tensor(0.7781, requires_grad=False)
-        x = np.tensor(0.0, requires_grad=True)
-        y = np.tensor(0.0, requires_grad=True)
+        ev = pnp.tensor(0.7781, requires_grad=False)
+        x = pnp.tensor(0.0, requires_grad=True)
+        y = pnp.tensor(0.0, requires_grad=True)
 
         original_ev = ev
 

--- a/tests/optimize/test_qng.py
+++ b/tests/optimize/test_qng.py
@@ -17,7 +17,7 @@ import pytest
 import scipy as sp
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane.optimize.qng import _flatten_np, _unflatten_np
 
 
@@ -58,20 +58,20 @@ class TestAttrsAffectingMetricTensor:
 
         opt = qml.QNGOptimizer(approx=None)
         eta = 0.7
-        params = np.array([0.11, 0.412])
+        params = pnp.array([0.11, 0.412])
         new_params_no_approx = opt.step(circuit, params)
         opt_with_approx = qml.QNGOptimizer()
         new_params_block_approx = opt_with_approx.step(circuit, params)
         # Expected result, requires some manual calculation, compare analytic test cases page
         x = params[0]
-        first_term = np.eye(2) / 4
-        vec_potential = np.array([-0.5j * np.sin(eta), 0.5j * np.sin(x) * np.cos(eta)])
-        second_term = np.real(np.outer(vec_potential.conj(), vec_potential))
+        first_term = pnp.eye(2) / 4
+        vec_potential = pnp.array([-0.5j * pnp.sin(eta), 0.5j * pnp.sin(x) * pnp.cos(eta)])
+        second_term = pnp.real(pnp.outer(vec_potential.conj(), vec_potential))
         exp_mt = first_term - second_term
 
-        assert np.allclose(opt.metric_tensor, exp_mt)
-        assert np.allclose(opt_with_approx.metric_tensor, np.diag(np.diag(exp_mt)))
-        assert not np.allclose(new_params_no_approx, new_params_block_approx)
+        assert pnp.allclose(opt.metric_tensor, exp_mt)
+        assert pnp.allclose(opt_with_approx.metric_tensor, pnp.diag(pnp.diag(exp_mt)))
+        assert not pnp.allclose(new_params_no_approx, new_params_block_approx)
 
     def test_lam(self):
         """Test that the regularization ``lam`` is used correctly."""
@@ -86,23 +86,23 @@ class TestAttrsAffectingMetricTensor:
 
         lam = 1e-9
         opt = qml.QNGOptimizer(lam=lam, stepsize=1.0)
-        eta = np.pi
-        params = np.array([np.pi / 2, 0.412])
+        eta = pnp.pi
+        params = pnp.array([pnp.pi / 2, 0.412])
         new_params_with_lam = opt.step(circuit, params)
         opt_without_lam = qml.QNGOptimizer(stepsize=1.0)
         new_params_without_lam = opt_without_lam.step(circuit, params)
         # Expected result, requires some manual calculation, compare analytic test cases page
         x, y = params
-        first_term = np.eye(2) / 4
-        vec_potential = np.array([-0.5j * np.sin(eta), 0.5j * np.sin(x) * np.cos(eta)])
-        second_term = np.real(np.outer(vec_potential.conj(), vec_potential))
+        first_term = pnp.eye(2) / 4
+        vec_potential = pnp.array([-0.5j * pnp.sin(eta), 0.5j * pnp.sin(x) * pnp.cos(eta)])
+        second_term = pnp.real(pnp.outer(vec_potential.conj(), vec_potential))
         exp_mt = first_term - second_term
 
-        assert np.allclose(opt.metric_tensor, exp_mt + np.eye(2) * lam)
-        assert np.allclose(opt_without_lam.metric_tensor, np.diag(np.diag(exp_mt)))
+        assert pnp.allclose(opt.metric_tensor, exp_mt + pnp.eye(2) * lam)
+        assert pnp.allclose(opt_without_lam.metric_tensor, pnp.diag(pnp.diag(exp_mt)))
         # With regularization, y can be updated. Without regularization it can not.
-        assert np.isclose(new_params_without_lam[1], y)
-        assert not np.isclose(new_params_with_lam[1], y, atol=1e-11, rtol=0.0)
+        assert pnp.isclose(new_params_without_lam[1], y)
+        assert not pnp.isclose(new_params_with_lam[1], y, atol=1e-11, rtol=0.0)
 
 
 class TestExceptions:
@@ -146,21 +146,21 @@ class TestOptimize:
             qml.RY(params[1], wires=0)
             return qml.expval(qml.PauliZ(0))
 
-        var = np.array([0.31, 0.842])
+        var = pnp.array([0.31, 0.842])
         opt = qml.QNGOptimizer(stepsize=0.05)
 
-        expected_mt_diag = np.array([0.25, (np.cos(var[0]) ** 2) / 4])
+        expected_mt_diag = pnp.array([0.25, (pnp.cos(var[0]) ** 2) / 4])
         expected_res = circuit(var)
         expected_step = var - opt.stepsize * qml.grad(circuit)(var) / expected_mt_diag
 
         step1, res = opt.step_and_cost(circuit, var)
-        assert np.allclose(opt.metric_tensor, np.diag(expected_mt_diag))
+        assert pnp.allclose(opt.metric_tensor, pnp.diag(expected_mt_diag))
         step2 = opt.step(circuit, var)
-        assert np.allclose(opt.metric_tensor, np.diag(expected_mt_diag))
+        assert pnp.allclose(opt.metric_tensor, pnp.diag(expected_mt_diag))
 
-        assert np.allclose(res, expected_res)
-        assert np.allclose(step1, expected_step)
-        assert np.allclose(step2, expected_step)
+        assert pnp.allclose(res, expected_res)
+        assert pnp.allclose(step1, expected_step)
+        assert pnp.allclose(step2, expected_step)
 
     def test_step_and_cost_autograd_with_gen_hamiltonian(self):
         """Test that the correct cost and step is returned via the
@@ -175,21 +175,21 @@ class TestOptimize:
             qml.RY(params[1], wires=0)
             return qml.expval(qml.PauliZ(0))
 
-        var = np.array([0.311, -0.52])
+        var = pnp.array([0.311, -0.52])
         opt = qml.QNGOptimizer(stepsize=0.05)
 
-        expected_mt = np.diag([1 / 16, 1 / 4])
+        expected_mt = pnp.diag([1 / 16, 1 / 4])
         expected_res = circuit(var)
-        expected_step = var - opt.stepsize * np.linalg.pinv(expected_mt) @ qml.grad(circuit)(var)
+        expected_step = var - opt.stepsize * pnp.linalg.pinv(expected_mt) @ qml.grad(circuit)(var)
 
         step1, res = opt.step_and_cost(circuit, var)
-        assert np.allclose(opt.metric_tensor, expected_mt)
+        assert pnp.allclose(opt.metric_tensor, expected_mt)
         step2 = opt.step(circuit, var)
-        assert np.allclose(opt.metric_tensor, expected_mt)
+        assert pnp.allclose(opt.metric_tensor, expected_mt)
 
-        assert np.allclose(res, expected_res)
-        assert np.allclose(step1, expected_step)
-        assert np.allclose(step2, expected_step)
+        assert pnp.allclose(res, expected_res)
+        assert pnp.allclose(step1, expected_step)
+        assert pnp.allclose(step2, expected_step)
 
     @pytest.mark.parametrize("split_input", [False, True])
     def test_step_and_cost_with_grad_fn_grouped_and_split(self, split_input):
@@ -197,7 +197,7 @@ class TestOptimize:
         method for the QNG optimizer when providing an explicit grad_fn."""
         dev = qml.device("default.qubit", wires=1)
 
-        var = np.array([0.911, 0.512])
+        var = pnp.array([0.911, 0.512])
         if split_input:
 
             @qml.qnode(dev)
@@ -228,26 +228,26 @@ class TestOptimize:
 
         # With more custom gradient function, forward has to be computed explicitly.
         def grad_fn2(*args):
-            return np.array(qml.grad(circuit)(*args))
+            return pnp.array(qml.grad(circuit)(*args))
 
         step3, cost2 = opt.step_and_cost(circuit, *args, grad_fn=grad_fn2)
         mt3 = opt.metric_tensor
         step4 = opt.step(circuit, *args, grad_fn=grad_fn2)
         mt4 = opt.metric_tensor
 
-        expected_mt_diag = np.array([0.25, (np.cos(var[0]) ** 2) / 4])
+        expected_mt_diag = pnp.array([0.25, (pnp.cos(var[0]) ** 2) / 4])
         expected_step = var - opt.stepsize * grad_fn2(*args) / expected_mt_diag
-        expected_mt = np.diag(expected_mt_diag)
+        expected_mt = pnp.diag(expected_mt_diag)
         if split_input:
             expected_mt = (expected_mt[:1, :1], expected_mt[1:, 1:])
         expected_cost = circuit(*args)
 
         for step in [step1, step2, step3, step4]:
-            assert np.allclose(step, expected_step)
+            assert pnp.allclose(step, expected_step)
         for mt in [mt1, mt2, mt3, mt4]:
-            assert np.allclose(mt, expected_mt)
-        assert np.isclose(cost1, expected_cost)
-        assert np.isclose(cost2, expected_cost)
+            assert pnp.allclose(mt, expected_mt)
+        assert pnp.isclose(cost1, expected_cost)
+        assert pnp.isclose(cost2, expected_cost)
 
     @pytest.mark.parametrize("trainable_idx", [0, 1])
     def test_step_and_cost_split_input_one_trainable(self, trainable_idx):
@@ -267,7 +267,7 @@ class TestOptimize:
         grad_fn = qml.grad(circuit)
         mt_fn = qml.metric_tensor(circuit)
 
-        params = np.array(0.2, requires_grad=False), np.array(-0.8, requires_grad=False)
+        params = pnp.array(0.2, requires_grad=False), pnp.array(-0.8, requires_grad=False)
         params[trainable_idx].requires_grad = True
         opt = qml.QNGOptimizer(stepsize=0.01)
 
@@ -286,7 +286,7 @@ class TestOptimize:
 
         # Expectations
         if trainable_idx == 1:
-            mt_inv = 1 / (np.cos(2 * params[0]) + 1) * 8
+            mt_inv = 1 / (pnp.cos(2 * params[0]) + 1) * 8
         else:
             mt_inv = 4
         exact_update = -opt.stepsize * grad_fn(*params) * mt_inv
@@ -298,9 +298,9 @@ class TestOptimize:
                 par + exact_update * factor if i == trainable_idx else par
                 for i, par in enumerate(params)
             )
-            assert np.allclose(step, expected_step)
-        assert np.isclose(cost1, expected_cost)
-        assert np.isclose(cost2, expected_cost)
+            assert pnp.allclose(step, expected_step)
+        assert pnp.isclose(cost1, expected_cost)
+        assert pnp.isclose(cost2, expected_cost)
 
     def test_qubit_rotation(self, tol):
         """Test qubit rotation has the correct QNG value
@@ -316,12 +316,12 @@ class TestOptimize:
 
         def gradient(params):
             """Returns the gradient of the above circuit"""
-            da = -np.sin(params[0]) * np.cos(params[1])
-            db = -np.cos(params[0]) * np.sin(params[1])
-            return np.array([da, db])
+            da = -pnp.sin(params[0]) * pnp.cos(params[1])
+            db = -pnp.cos(params[0]) * pnp.sin(params[1])
+            return pnp.array([da, db])
 
         eta = 0.2
-        init_params = np.array([0.011, 0.012])
+        init_params = pnp.array([0.011, 0.012])
         num_steps = 15
 
         opt = qml.QNGOptimizer(eta)
@@ -332,17 +332,17 @@ class TestOptimize:
 
             # check metric tensor
             res = opt.metric_tensor
-            exp = np.diag([0.25, (np.cos(theta[0]) ** 2) / 4])
-            assert np.allclose(res, exp, atol=tol, rtol=0)
+            exp = pnp.diag([0.25, (pnp.cos(theta[0]) ** 2) / 4])
+            assert pnp.allclose(res, exp, atol=tol, rtol=0)
 
             # check parameter update
             dtheta = eta * sp.linalg.pinvh(exp) @ gradient(theta)
-            assert np.allclose(dtheta, theta - theta_new, atol=tol, rtol=0)
+            assert pnp.allclose(dtheta, theta - theta_new, atol=tol, rtol=0)
 
             theta = theta_new
 
         # check final cost
-        assert np.allclose(circuit(theta), -1)
+        assert pnp.allclose(circuit(theta), -1)
 
     def test_single_qubit_vqe_using_expval_h_multiple_input_params(self, tol, recwarn):
         """Test single-qubit VQE by returning qml.expval(H) in the QNode and
@@ -361,14 +361,14 @@ class TestOptimize:
             return qml.expval(H)
 
         eta = 0.01
-        x = np.array(0.011, requires_grad=True)
-        y = np.array(0.022, requires_grad=True)
+        x = pnp.array(0.011, requires_grad=True)
+        y = pnp.array(0.022, requires_grad=True)
 
         def gradient(params):
             """Returns the gradient"""
-            da = -np.sin(params[0]) * (np.cos(params[1]) + np.sin(params[1]))
-            db = np.cos(params[0]) * (np.cos(params[1]) - np.sin(params[1]))
-            return np.array([da, db])
+            da = -pnp.sin(params[0]) * (pnp.cos(params[1]) + pnp.sin(params[1]))
+            db = pnp.cos(params[0]) * (pnp.cos(params[1]) - pnp.sin(params[1]))
+            return pnp.array([da, db])
 
         eta = 0.2
         num_steps = 10
@@ -376,26 +376,26 @@ class TestOptimize:
         opt = qml.QNGOptimizer(eta)
 
         for _ in range(num_steps):
-            theta = np.array([x, y])
+            theta = pnp.array([x, y])
             x, y = opt.step(circuit, x, y)
 
             # check metric tensor
             res = opt.metric_tensor
-            exp = (np.array([[0.25]]), np.array([[(np.cos(2 * theta[0]) + 1) / 8]]))
-            assert np.allclose(res, exp)
+            exp = (pnp.array([[0.25]]), pnp.array([[(pnp.cos(2 * theta[0]) + 1) / 8]]))
+            assert pnp.allclose(res, exp)
 
             # check parameter update
             theta_new = (x, y)
             grad = gradient(theta)
             dtheta = tuple(eta * g / e[0, 0] for e, g in zip(exp, grad))
-            assert np.allclose(dtheta, theta - theta_new)
+            assert pnp.allclose(dtheta, theta - theta_new)
 
         # check final cost
-        assert np.allclose(circuit(x, y), qml.eigvals(H).min(), atol=tol, rtol=0)
+        assert pnp.allclose(circuit(x, y), qml.eigvals(H).min(), atol=tol, rtol=0)
         assert len(recwarn) == 0
 
 
-flat_dummy_array = np.linspace(-1, 1, 64)
+flat_dummy_array = pnp.linspace(-1, 1, 64)
 test_shapes = [
     (64,),
     (64, 1),
@@ -416,21 +416,21 @@ class TestFlatten:
     def test_flatten(self, shape):
         """Tests that _flatten successfully flattens multidimensional arrays."""
 
-        reshaped = np.reshape(flat_dummy_array, shape)
-        flattened = np.array(list(_flatten_np(reshaped)))
+        reshaped = pnp.reshape(flat_dummy_array, shape)
+        flattened = pnp.array(list(_flatten_np(reshaped)))
 
         assert flattened.shape == flat_dummy_array.shape
-        assert np.array_equal(flattened, flat_dummy_array)
+        assert pnp.array_equal(flattened, flat_dummy_array)
 
     @pytest.mark.parametrize("shape", test_shapes)
     def test_unflatten(self, shape):
         """Tests that _unflatten successfully unflattens multidimensional arrays."""
 
-        reshaped = np.reshape(flat_dummy_array, shape)
-        unflattened = np.array(list(_unflatten_np(flat_dummy_array, reshaped)))
+        reshaped = pnp.reshape(flat_dummy_array, shape)
+        unflattened = pnp.array(list(_unflatten_np(flat_dummy_array, reshaped)))
 
         assert unflattened.shape == reshaped.shape
-        assert np.array_equal(unflattened, reshaped)
+        assert pnp.array_equal(unflattened, reshaped)
 
     def test_unflatten_error_unsupported_model(self):
         """Tests that unflatten raises an error if the given model is not supported"""
@@ -443,10 +443,10 @@ class TestFlatten:
         """Tests that unflatten raises an error if the given iterable has
         more elements than the model"""
 
-        reshaped = np.reshape(flat_dummy_array, (16, 2, 2))
+        reshaped = pnp.reshape(flat_dummy_array, (16, 2, 2))
 
         with pytest.raises(ValueError, match="Flattened iterable has more elements than the model"):
-            _unflatten_np(np.concatenate([flat_dummy_array, flat_dummy_array]), reshaped)
+            _unflatten_np(pnp.concatenate([flat_dummy_array, flat_dummy_array]), reshaped)
 
     def test_flatten_wires(self):
         """Tests flattening a Wires object."""

--- a/tests/optimize/test_rotoselect.py
+++ b/tests/optimize/test_rotoselect.py
@@ -20,7 +20,7 @@ import numpy as onp
 import pytest
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane.optimize import RotoselectOptimizer
 
 
@@ -61,7 +61,7 @@ class TestRotoselectOptimizer:
         _, _, res = rotoselect_opt.step_and_cost(cost_fn, params, generators)
         expected = cost_fn(params, generators)
 
-        assert np.all(res == expected)
+        assert pnp.all(res == expected)
 
     @pytest.mark.slow
     @pytest.mark.parametrize("x_start", [[1.2, 0.2], [-0.62, -2.1], [0.05, 0.8]])
@@ -112,7 +112,7 @@ class TestRotoselectOptimizer:
             x_start, generators = rotoselect_opt.step(cost_fn, x_start, generators)
             optimal_x_start = self.rotosolve_step(f_best_gen, optimal_x_start)
 
-        assert np.allclose(x_start, optimal_x_start, atol=tol)
+        assert pnp.allclose(x_start, optimal_x_start, atol=tol)
         assert generators == optimal_generators
 
     def test_rotoselect_optimizer_raises(self):
@@ -161,15 +161,15 @@ class TestRotoselectOptimizer:
             cost_fn, x_start, generators, shift=1.0
         )
 
-        assert not np.allclose(params_new, params_new2, atol=tol)
-        assert np.allclose(res_new2, cost_fn(x_start, generators, shift=1.0), atol=tol)
+        assert not pnp.allclose(params_new, params_new2, atol=tol)
+        assert pnp.allclose(res_new2, cost_fn(x_start, generators, shift=1.0), atol=tol)
 
     @staticmethod
     def rotosolve_step(f, x):
         """Helper function to test the Rotosolve and Rotoselect optimizers"""
         # make sure that x is an array
-        if np.ndim(x) == 0:
-            x = np.array([x])
+        if pnp.ndim(x) == 0:
+            x = pnp.array([x])
 
         # helper function for x[d] = theta
         def insert(xf, d, theta):
@@ -178,12 +178,12 @@ class TestRotoselectOptimizer:
 
         for d, _ in enumerate(x):
             H_0 = float(f(insert(x, d, 0)))
-            H_p = float(f(insert(x, d, np.pi / 2)))
-            H_m = float(f(insert(x, d, -np.pi / 2)))
+            H_p = float(f(insert(x, d, pnp.pi / 2)))
+            H_m = float(f(insert(x, d, -pnp.pi / 2)))
             a = onp.arctan2(2 * H_0 - H_p - H_m, H_p - H_m)
 
-            x[d] = -np.pi / 2 - a
+            x[d] = -pnp.pi / 2 - a
 
-            if x[d] <= -np.pi:
-                x[d] += 2 * np.pi
+            if x[d] <= -pnp.pi:
+                x[d] += 2 * pnp.pi
         return x

--- a/tests/optimize/test_spsa.py
+++ b/tests/optimize/test_spsa.py
@@ -15,14 +15,14 @@
 import pytest
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 
-univariate = [(np.sin), (lambda x: np.exp(x / 10.0)), (lambda x: x**2)]
+univariate = [(pnp.sin), (lambda x: pnp.exp(x / 10.0)), (lambda x: x**2)]
 
 multivariate = [
-    (lambda x: np.sin(x[0]) + np.cos(x[1])),
-    (lambda x: np.exp(x[0] / 3) * np.tanh(x[1])),
-    (lambda x: np.sum([x_**2 for x_ in x])),
+    (lambda x: pnp.sin(x[0]) + pnp.cos(x[1])),
+    (lambda x: pnp.exp(x[0] / 3) * pnp.tanh(x[1])),
+    (lambda x: pnp.sum([x_**2 for x_ in x])),
 ]
 
 
@@ -37,7 +37,7 @@ class TestSPSAOptimizer:
         gamma = 0.3
         c = 0.1
         spsa_opt = qml.SPSAOptimizer(maxiter=10, c=c, gamma=gamma)
-        args = np.array([args], requires_grad=True)
+        args = pnp.array([args], requires_grad=True)
 
         alpha = 0.602
         A = 1.0
@@ -54,7 +54,7 @@ class TestSPSAOptimizer:
 
         res = spsa_opt.apply_grad(grad, args)
         expected = args - ak * grad
-        assert np.allclose(res, expected)
+        assert pnp.allclose(res, expected)
 
     @pytest.mark.parametrize("f", multivariate)
     def test_apply_grad_multivar(self, f):
@@ -68,11 +68,11 @@ class TestSPSAOptimizer:
         k = 1
         ck = c / k**gamma
         ak = a / (A + k) ** alpha
-        deltas = np.array(np.meshgrid([1, -1], [1, -1])).T.reshape(-1, 2)
+        deltas = pnp.array(pnp.meshgrid([1, -1], [1, -1])).T.reshape(-1, 2)
 
         spsa_opt = qml.SPSAOptimizer(A=A)
 
-        x_vals = np.linspace(-10, 10, 16, endpoint=False)
+        x_vals = pnp.linspace(-10, 10, 16, endpoint=False)
 
         for jdx in range(len(x_vals[:-1])):
             args = x_vals[jdx : jdx + 2]
@@ -89,22 +89,22 @@ class TestSPSAOptimizer:
                 y_pm.append(yplus - yminus)
             # choose one delta
             d = 0
-            grad = np.array([y_pm[d] / (2 * ck * di) for di in deltas[d]])
-            tol = ak * max(np.abs(y_pm)) / ck
+            grad = pnp.array([y_pm[d] / (2 * ck * di) for di in deltas[d]])
+            tol = ak * max(pnp.abs(y_pm)) / ck
             args_res = spsa_opt.apply_grad(grad, args)
             expected = args - ak * grad
-            assert np.allclose(args_res, expected, atol=tol)
+            assert pnp.allclose(args_res, expected, atol=tol)
 
     @pytest.mark.parametrize("args", [0, -3, 42])
     @pytest.mark.parametrize("f", univariate)
     def test_step_and_cost_supplied_univar_cost(self, args, f):
         """Test that returned cost is correct."""
         spsa_opt = qml.SPSAOptimizer(10)
-        args = np.array(args, requires_grad=True)
+        args = pnp.array(args, requires_grad=True)
 
         _, res = spsa_opt.step_and_cost(f, args)
         expected = f(args)
-        assert np.all(res == expected)
+        assert pnp.all(res == expected)
 
     def test_step_and_cost_supplied_cost(self):
         """Test that the correct cost is returned via the step_and_cost method
@@ -118,12 +118,12 @@ class TestSPSAOptimizer:
             qml.RY(variables[2], wires=[0])
             return qml.expval(qml.PauliZ(0))
 
-        inputs = np.array([0.4, 0.2, 0.4], requires_grad=True)
+        inputs = pnp.array([0.4, 0.2, 0.4], requires_grad=True)
 
         expected = quant_fun(inputs)
         _, res = spsa_opt.step_and_cost(quant_fun, inputs)
 
-        assert np.all(res == expected)
+        assert pnp.all(res == expected)
 
     def test_step_and_cost_hamiltonian(self):
         """Test that the correct cost is returned via the step_and_cost method
@@ -135,12 +135,12 @@ class TestSPSAOptimizer:
             obs = [qml.PauliX(0) @ qml.PauliZ(0), qml.PauliZ(0) @ qml.Hadamard(0)]
             return qml.expval(qml.Hamiltonian(variables, obs))
 
-        inputs = np.array([0.2, -0.543], requires_grad=True)
+        inputs = pnp.array([0.2, -0.543], requires_grad=True)
 
         expected = quant_fun(inputs)
         _, res = spsa_opt.step_and_cost(quant_fun, inputs)
 
-        assert np.all(res == expected)
+        assert pnp.all(res == expected)
 
     def test_step_spsa(self):
         """Test that the correct param is returned via the step method."""
@@ -153,7 +153,7 @@ class TestSPSAOptimizer:
             qml.RY(params[2], wires=[0])
             return qml.expval(qml.PauliZ(0))
 
-        args = np.array([0.4, 0.2, 0.8], requires_grad=True)
+        args = pnp.array([0.4, 0.2, 0.8], requires_grad=True)
 
         alpha = 0.602
         gamma = 0.101
@@ -163,7 +163,7 @@ class TestSPSAOptimizer:
         k = 1
         ck = c / k**gamma
         ak = a / (A + k) ** alpha
-        deltas = np.array(np.meshgrid([1, -1], [1, -1], [1, -1])).T.reshape(-1, 3)
+        deltas = pnp.array(pnp.meshgrid([1, -1], [1, -1], [1, -1])).T.reshape(-1, 3)
 
         y_pm = []
         for delta in deltas:
@@ -178,20 +178,20 @@ class TestSPSAOptimizer:
             y_pm.append(yplus - yminus)
         # choose one delta
         d = 0
-        grad = np.array([y_pm[d] / (2 * ck * di) for di in deltas[d]])
-        tol = ak * max(np.abs(y_pm)) / ck
+        grad = pnp.array([y_pm[d] / (2 * ck * di) for di in deltas[d]])
+        tol = ak * max(pnp.abs(y_pm)) / ck
 
         expected = args - ak * grad
 
         res = spsa_opt.step(quant_fun, args)
 
-        assert np.allclose(res, expected, atol=tol)
+        assert pnp.allclose(res, expected, atol=tol)
 
     def test_step_and_cost_spsa_single_multid_input(self):
         """Test that the correct cost is returned via the step_and_cost method
         with a multidimensional input."""
         spsa_opt = qml.SPSAOptimizer(maxiter=10)
-        multid_array = np.array([[0.1, 0.2], [-0.1, -0.4]])
+        multid_array = pnp.array([[0.1, 0.2], [-0.1, -0.4]])
 
         @qml.qnode(qml.device("default.qubit", wires=1))
         def quant_fun_mdarr(var):
@@ -203,13 +203,13 @@ class TestSPSAOptimizer:
         _, res = spsa_opt.step_and_cost(quant_fun_mdarr, multid_array)
         expected = quant_fun_mdarr(multid_array)
 
-        assert np.all(res == expected)
+        assert pnp.all(res == expected)
 
     def test_step_spsa_single_multid_input(self):
         """Test that the correct param is returned via the step method
         with a multidimensional input."""
         spsa_opt = qml.SPSAOptimizer(maxiter=10)
-        multid_array = np.array([[0.1, 0.2], [-0.1, -0.4]])
+        multid_array = pnp.array([[0.1, 0.2], [-0.1, -0.4]])
 
         @qml.qnode(qml.device("default.qubit", wires=1))
         def quant_fun_mdarr(var):
@@ -228,7 +228,7 @@ class TestSPSAOptimizer:
         ck = c / k**gamma
         ak = a / (A + k) ** alpha
         # pylint:disable=too-many-function-args
-        deltas = np.array(np.meshgrid([1, -1], [1, -1], [1, -1], [1, -1])).T.reshape(-1, 2, 2)
+        deltas = pnp.array(pnp.meshgrid([1, -1], [1, -1], [1, -1], [1, -1])).T.reshape(-1, 2, 2)
 
         args = (multid_array,)
         y_pm = []
@@ -239,19 +239,19 @@ class TestSPSAOptimizer:
                 multiplier = ck * delta
                 thetaplus[index] = arg + multiplier
                 thetaminus[index] = arg - multiplier
-            yplus = np.array([quant_fun_mdarr(p) for p in thetaplus])
-            yminus = np.array([quant_fun_mdarr(p) for p in thetaminus])
+            yplus = pnp.array([quant_fun_mdarr(p) for p in thetaplus])
+            yminus = pnp.array([quant_fun_mdarr(p) for p in thetaminus])
             y_pm.append(yplus - yminus)
         # choose one delta
         d = 0
-        grad = np.array([y_pm[d] / (2 * ck * deltas[d])])
-        tol = ak * max(np.abs(y_pm)) / ck
+        grad = pnp.array([y_pm[d] / (2 * ck * deltas[d])])
+        tol = ak * max(pnp.abs(y_pm)) / ck
 
         expected = multid_array - ak * grad
 
         res = spsa_opt.step(quant_fun_mdarr, multid_array)
 
-        assert np.allclose(res, expected, atol=tol)
+        assert pnp.allclose(res, expected, atol=tol)
 
     @pytest.mark.parametrize("args", [0, -3, 42])
     @pytest.mark.parametrize("f", univariate)
@@ -259,7 +259,7 @@ class TestSPSAOptimizer:
         """Test that a gradient step can be applied correctly with a univariate
         function."""
         spsa_opt = qml.SPSAOptimizer(maxiter=10)
-        args = np.array([args], requires_grad=True)
+        args = pnp.array([args], requires_grad=True)
 
         alpha = 0.602
         gamma = 0.101
@@ -279,7 +279,7 @@ class TestSPSAOptimizer:
 
         res = spsa_opt.step(f, args)
         expected = args - ak * grad
-        assert np.allclose(res, expected)
+        assert pnp.allclose(res, expected)
 
     @pytest.mark.parametrize("args", [0, -3, 42])
     @pytest.mark.parametrize("f", univariate)
@@ -287,7 +287,7 @@ class TestSPSAOptimizer:
         """Test that a gradient step can be applied correctly with a univariate
         function."""
         spsa_opt = qml.SPSAOptimizer(maxiter=10)
-        args = np.array([args], requires_grad=True)
+        args = pnp.array([args], requires_grad=True)
 
         alpha = 0.602
         gamma = 0.101
@@ -307,8 +307,8 @@ class TestSPSAOptimizer:
 
         res, rescost = spsa_opt.step_and_cost(f, args)
         expected = args - ak * grad
-        assert np.allclose(res, expected)
-        assert np.allclose(y, rescost)
+        assert pnp.allclose(res, expected)
+        assert pnp.allclose(y, rescost)
 
     def test_parameters_not_a_tensor_and_not_all_require_grad(self):
         """Test execution of list of parameters of different sizes
@@ -323,15 +323,15 @@ class TestSPSAOptimizer:
             return qml.expval(qml.PauliZ(0))
 
         inputs = [
-            np.array((0.2, 0.3), requires_grad=True),
-            np.array([0.4, 0.2, 0.4], requires_grad=False),
-            np.array(0.1, requires_grad=True),
+            pnp.array((0.2, 0.3), requires_grad=True),
+            pnp.array([0.4, 0.2, 0.4], requires_grad=False),
+            pnp.array(0.1, requires_grad=True),
         ]
 
         res, _ = spsa_opt.step_and_cost(quant_fun, *inputs)
         assert isinstance(res, list)
-        assert np.all(res[1] == inputs[1])
-        assert np.all(res[0] != inputs[0])
+        assert pnp.all(res[1] == inputs[1])
+        assert pnp.all(res[0] != inputs[0])
 
     def test_parameters_in_step(self):
         """Test execution of list of parameters of different sizes
@@ -346,15 +346,15 @@ class TestSPSAOptimizer:
             return qml.expval(qml.PauliZ(0))
 
         inputs = [
-            np.array((0.2, 0.3), requires_grad=True),
-            np.array([0.4, 0.2, 0.4], requires_grad=False),
-            np.array(0.1, requires_grad=True),
+            pnp.array((0.2, 0.3), requires_grad=True),
+            pnp.array([0.4, 0.2, 0.4], requires_grad=False),
+            pnp.array(0.1, requires_grad=True),
         ]
 
         res = spsa_opt.step(quant_fun, *inputs)
         assert isinstance(res, list)
-        assert np.all(res[1] == inputs[1])
-        assert np.all(res[0] != inputs[0])
+        assert pnp.all(res[1] == inputs[1])
+        assert pnp.all(res[0] != inputs[0])
 
     def test_parameter_not_an_array(self):
         """Test function when there is only one float parameter that doesn't
@@ -394,7 +394,7 @@ class TestSPSAOptimizer:
             return qml.probs(wires=[0, 1, 2, 3])
 
         opt = qml.SPSAOptimizer(maxiter=10)
-        params = np.random.normal(scale=0.1, size=(n_layers, n_wires, 3), requires_grad=True)
+        params = pnp.random.normal(scale=0.1, size=(n_layers, n_wires, 3), requires_grad=True)
 
         with pytest.raises(
             ValueError,
@@ -407,7 +407,7 @@ class TestSPSAOptimizer:
         """Test that if the objective function is not a
         scalar function, an error is raised."""
         spsa_opt = qml.SPSAOptimizer(10)
-        args = np.array([[0.1, 0.2], [-0.1, -0.4]])
+        args = pnp.array([[0.1, 0.2], [-0.1, -0.4]])
 
         with pytest.raises(
             ValueError,
@@ -433,7 +433,7 @@ class TestSPSAOptimizer:
             return qml.probs(wires=[0, 1, 2, 3])
 
         opt = qml.SPSAOptimizer(maxiter=10)
-        params = np.random.normal(scale=0.1, size=(n_layers, n_wires, 3), requires_grad=True)
+        params = pnp.random.normal(scale=0.1, size=(n_layers, n_wires, 3), requires_grad=True)
 
         with pytest.raises(
             ValueError,
@@ -467,7 +467,7 @@ class TestSPSAOptimizer:
                 qml.CNOT(wires=[3, 1])
             return qml.expval(H)
 
-        init_params = np.random.normal(0, np.pi, (num_qubits, 3), requires_grad=True)
+        init_params = pnp.random.normal(0, pnp.pi, (num_qubits, 3), requires_grad=True)
         params = init_params
 
         init_energy = cost_fun(init_params, num_qubits)
@@ -477,7 +477,7 @@ class TestSPSAOptimizer:
         for _ in range(max_iterations):
             params, energy = opt.step_and_cost(cost_fun, params, num_qubits=num_qubits)
 
-        assert np.all(params != init_params)
+        assert pnp.all(params != init_params)
         assert energy < init_energy
 
     @pytest.mark.slow
@@ -496,14 +496,14 @@ class TestSPSAOptimizer:
 
         opt = qml.SPSAOptimizer(maxiter=max_iterations, c=0.3)
 
-        init_params = np.random.normal(scale=0.1, size=(2,), requires_grad=True)
+        init_params = pnp.random.normal(scale=0.1, size=(2,), requires_grad=True)
         params = init_params
         init_circuit_res = circuit(params)
 
         for _ in range(max_iterations):
             params, circuit_res = opt.step_and_cost(circuit, params)
 
-        assert np.all(params != init_params)
+        assert pnp.all(params != init_params)
         assert circuit_res < init_circuit_res
 
     def test_not_A_nor_maxiter_provided(self):

--- a/tests/pauli/test_pauli_arithmetic.py
+++ b/tests/pauli/test_pauli_arithmetic.py
@@ -21,13 +21,13 @@ import pytest
 from scipy import sparse
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane.pauli.pauli_arithmetic import I, PauliSentence, PauliWord, X, Y, Z
 
-matI = np.eye(2)
-matX = np.array([[0, 1], [1, 0]])
-matY = np.array([[0, -1j], [1j, 0]])
-matZ = np.array([[1, 0], [0, -1]])
+matI = pnp.eye(2)
+matX = pnp.array([[0, 1], [1, 0]])
+matY = pnp.array([[0, -1j], [1j, 0]])
+matZ = pnp.array([[1, 0], [0, -1]])
 
 sparse_matI = sparse.eye(2, format="csr")
 sparse_matX = sparse.csr_matrix([[0, 1], [1, 0]])
@@ -302,7 +302,7 @@ class TestPauliWord:
         assert copy_pw2 == word2
 
     @pytest.mark.parametrize("pw", words)
-    @pytest.mark.parametrize("scalar", [0.0, 0.5, 1, 1j, 0.5j + 1.0, np.int64(1), np.float32(0.5)])
+    @pytest.mark.parametrize("scalar", [0.0, 0.5, 1, 1j, 0.5j + 1.0, pnp.int64(1), pnp.float32(0.5)])
     def test_mul(self, pw, scalar):
         """Test scalar multiplication"""
         res1 = scalar * pw
@@ -342,16 +342,16 @@ class TestPauliWord:
             _ = pw1 / "0.5"
 
     tup_pws_mat_wire = (
-        (pw1, [2, 0, 1], np.kron(np.kron(matY, matI), matX)),
-        (pw1, [2, 1, 0], np.kron(np.kron(matY, matX), matI)),
-        (pw2, ["c", "b", "a"], np.kron(np.kron(matZ, matX), matX)),
-        (pw3, [0, "b", "c"], np.kron(np.kron(matZ, matZ), matZ)),
+        (pw1, [2, 0, 1], pnp.kron(pnp.kron(matY, matI), matX)),
+        (pw1, [2, 1, 0], pnp.kron(pnp.kron(matY, matX), matI)),
+        (pw2, ["c", "b", "a"], pnp.kron(pnp.kron(matZ, matX), matX)),
+        (pw3, [0, "b", "c"], pnp.kron(pnp.kron(matZ, matZ), matZ)),
     )
 
     def test_to_mat_empty(self):
         """Test that an empty PauliWord is turned to the trivial 1 matrix"""
         res = pw4.to_mat(wire_order=[])
-        assert res == np.ones((1, 1))
+        assert res == pnp.ones((1, 1))
 
     pw_wire_order = ((pw1, [0, 1]), (pw1, [0, 1, 3]), (pw2, [0]))
 
@@ -365,7 +365,7 @@ class TestPauliWord:
 
     def test_to_mat_identity(self):
         """Test that an identity matrix is return if wire_order is provided."""
-        assert np.allclose(pw4.to_mat(wire_order=[0, 1]), np.eye(4))
+        assert pnp.allclose(pw4.to_mat(wire_order=[0, 1]), pnp.eye(4))
         assert sparse.issparse(pw4.to_mat(wire_order=[0, 1], format="csr"))
         assert not (pw4.to_mat(wire_order=[0, 1], format="csr") != sparse.eye(4)).sum()
 
@@ -373,7 +373,7 @@ class TestPauliWord:
     def test_to_mat(self, pw, wire_order, true_matrix):
         """Test that the wire_order is correctly incorporated in computing the
         matrix representation."""
-        assert np.allclose(pw.to_mat(wire_order=wire_order), true_matrix)
+        assert pnp.allclose(pw.to_mat(wire_order=wire_order), true_matrix)
 
     @pytest.mark.parametrize("pw, wire_order, true_matrix", tup_pws_mat_wire)
     def test_to_mat_format(self, pw, wire_order, true_matrix):
@@ -381,7 +381,7 @@ class TestPauliWord:
         format kwarg."""
         sparse_mat = pw.to_mat(wire_order, format="csr")
         assert sparse.issparse(sparse_mat)
-        assert np.allclose(sparse_mat.toarray(), true_matrix)
+        assert pnp.allclose(sparse_mat.toarray(), true_matrix)
 
     tup_pw_operation = (
         (PauliWord({0: X}), qml.PauliX(wires=0)),
@@ -559,13 +559,13 @@ class TestPauliSentence:
         (ps5, ps1, ps5),
         (
             PauliSentence(
-                {PauliWord({0: "Z"}): np.array(1.0), PauliWord({0: "Z", 1: "X"}): np.array(1.0)}
+                {PauliWord({0: "Z"}): pnp.array(1.0), PauliWord({0: "Z", 1: "X"}): pnp.array(1.0)}
             ),
-            PauliSentence({PauliWord({1: "Z"}): np.array(1.0), PauliWord({1: "Y"}): np.array(1.0)}),
+            PauliSentence({PauliWord({1: "Z"}): pnp.array(1.0), PauliWord({1: "Y"}): pnp.array(1.0)}),
             PauliSentence(
                 {
-                    PauliWord({0: "Z", 1: "Z"}): np.array(1.0 + 1.0j),
-                    PauliWord({0: "Z", 1: "Y"}): np.array(1.0 - 1.0j),
+                    PauliWord({0: "Z", 1: "Z"}): pnp.array(1.0 + 1.0j),
+                    PauliWord({0: "Z", 1: "Y"}): pnp.array(1.0 - 1.0j),
                 }
             ),
         ),
@@ -627,7 +627,7 @@ class TestPauliSentence:
         assert pauli2 == copy_ps2
 
     @pytest.mark.parametrize("ps", sentences)
-    @pytest.mark.parametrize("scalar", [0.0, 0.5, 1, 1j, 0.5j + 1.0, np.int64(1), np.float64(1.0)])
+    @pytest.mark.parametrize("scalar", [0.0, 0.5, 1, 1j, 0.5j + 1.0, pnp.int64(1), pnp.float64(1.0)])
     def test_mul(self, ps, scalar):
         """Test scalar multiplication"""
         res1 = scalar * ps
@@ -970,7 +970,7 @@ class TestPauliSentence:
         word1 = PauliWord({2: "X", 3: "Y", 4: "Z"})
         word2 = PauliWord({2: "Y", 3: "Z"})
         ps = PauliSentence({word1: 1.5, word2: -0.5})
-        vector = np.random.rand(2)
+        vector = pnp.random.rand(2)
         with pytest.raises(
             ValueError,
             match="get the matrix for the specified wire order because it does not contain all the Pauli",
@@ -986,13 +986,13 @@ class TestPauliSentence:
         ps = PauliSentence({word1: 1.5, word2: -0.5})
         psmat = ps.to_mat(wire_order=wire_order)
         vector = (
-            np.random.rand(psmat.shape[0])
+            pnp.random.rand(psmat.shape[0])
             if batch_size is None
-            else np.random.rand(batch_size, psmat.shape[0])
+            else pnp.random.rand(batch_size, psmat.shape[0])
         )
         v0 = ps.dot(vector, wire_order=wire_order)
         v1 = (psmat @ vector.T).T
-        assert np.allclose(v0, v1)
+        assert pnp.allclose(v0, v1)
 
     def test_map_wires(self):
         """Test the map_wires conversion method."""
@@ -1021,12 +1021,12 @@ class TestPauliSentenceMatrix:
     """Tests for calculating the matrix of a pauli sentence."""
 
     PS_EMPTY_CASES = (
-        (PauliSentence({}), np.zeros((1, 1))),
-        (PauliSentence({PauliWord({}): 1.0}), np.ones((1, 1))),
-        (PauliSentence({PauliWord({}): 2.5}), 2.5 * np.ones((1, 1))),
+        (PauliSentence({}), pnp.zeros((1, 1))),
+        (PauliSentence({PauliWord({}): 1.0}), pnp.ones((1, 1))),
+        (PauliSentence({PauliWord({}): 2.5}), 2.5 * pnp.ones((1, 1))),
         (
             PauliSentence({PauliWord({}): 2.5, PauliWord({0: "X"}): 1.0}),
-            2.5 * np.eye(2) + qml.matrix(qml.PauliX(0)),
+            2.5 * pnp.eye(2) + qml.matrix(qml.PauliX(0)),
         ),
     )
 
@@ -1035,7 +1035,7 @@ class TestPauliSentenceMatrix:
         """Test that empty PauliSentences and PauliSentences with empty PauliWords are handled correctly"""
 
         res_dense = ps.to_mat()
-        assert np.allclose(res_dense, true_res)
+        assert pnp.allclose(res_dense, true_res)
         res_sparse = ps.to_mat(format="csr")
         assert sparse.issparse(res_sparse)
         assert qml.math.allclose(res_sparse.todense(), true_res)
@@ -1043,7 +1043,7 @@ class TestPauliSentenceMatrix:
     def test_empty_pauli_to_mat_with_wire_order(self):
         """Test the to_mat method with an empty PauliSentence and PauliWord and an external wire order."""
         actual = PauliSentence({PauliWord({}): 1.5}).to_mat([0, 1])
-        assert np.allclose(actual, 1.5 * np.eye(4))
+        assert pnp.allclose(actual, 1.5 * pnp.eye(4))
 
     ps_wire_order = ((ps1, []), (ps1, [0, 1, 2, "a", "b"]), (ps3, [0, 1, "c"]))
 
@@ -1057,9 +1057,9 @@ class TestPauliSentenceMatrix:
 
     def test_to_mat_empty_sentence_with_wires(self):
         """Test that a zero matrix is returned if wire_order is provided on an empty PauliSentence."""
-        true_res = np.zeros((4, 4))
+        true_res = pnp.zeros((4, 4))
         res_dense = ps5.to_mat(wire_order=[0, 1])
-        assert np.allclose(res_dense, true_res)
+        assert pnp.allclose(res_dense, true_res)
         res_sparse = ps5.to_mat(wire_order=[0, 1], format="csr")
         assert sparse.issparse(res_sparse)
         assert qml.math.allclose(res_sparse.todense(), true_res)
@@ -1068,21 +1068,21 @@ class TestPauliSentenceMatrix:
         (
             ps1,
             [0, 1, 2, "a", "b", "c"],
-            1.23 * np.kron(np.kron(matI, np.kron(matX, matY)), np.eye(8))
-            + 4j * np.kron(np.eye(8), np.kron(matX, np.kron(matX, matZ)))
-            - 0.5 * np.kron(matZ, np.kron(np.eye(8), np.kron(matZ, matZ))),
+            1.23 * pnp.kron(pnp.kron(matI, pnp.kron(matX, matY)), pnp.eye(8))
+            + 4j * pnp.kron(pnp.eye(8), pnp.kron(matX, pnp.kron(matX, matZ)))
+            - 0.5 * pnp.kron(matZ, pnp.kron(pnp.eye(8), pnp.kron(matZ, matZ))),
         ),
         (
             ps2,
             ["a", "b", "c", 0, 1, 2],
-            -1.23 * np.kron(np.eye(8), np.kron(matI, np.kron(matX, matY)))
-            - 4j * np.kron(np.kron(matX, np.kron(matX, matZ)), np.eye(8))
-            + 0.5 * np.kron(np.kron(matI, np.kron(matZ, np.kron(matZ, matZ))), np.eye(4)),
+            -1.23 * pnp.kron(pnp.eye(8), pnp.kron(matI, pnp.kron(matX, matY)))
+            - 4j * pnp.kron(pnp.kron(matX, pnp.kron(matX, matZ)), pnp.eye(8))
+            + 0.5 * pnp.kron(pnp.kron(matI, pnp.kron(matZ, pnp.kron(matZ, matZ))), pnp.eye(4)),
         ),
         (
             ps3,
             [0, "b", "c"],
-            -0.5 * np.kron(matZ, np.kron(matZ, matZ)) + 1 * np.eye(8),
+            -0.5 * pnp.kron(matZ, pnp.kron(matZ, matZ)) + 1 * pnp.eye(8),
         ),
     )
 
@@ -1090,14 +1090,14 @@ class TestPauliSentenceMatrix:
     def test_to_mat_wire_order(self, ps, wire_order, true_matrix):
         """Test that the wire_order is correctly incorporated in computing the
         matrix representation."""
-        assert np.allclose(ps.to_mat(wire_order), true_matrix)
+        assert pnp.allclose(ps.to_mat(wire_order), true_matrix)
 
     @pytest.mark.parametrize("ps, wire_order, true_matrix", tup_ps_mat)
     def test_to_mat_format(self, ps, wire_order, true_matrix):
         """Test that the correct type of matrix is returned given the format kwarg."""
         sparse_mat = ps.to_mat(wire_order, format="csr")
         assert sparse.issparse(sparse_mat)
-        assert np.allclose(sparse_mat.toarray(), true_matrix)
+        assert pnp.allclose(sparse_mat.toarray(), true_matrix)
 
     @pytest.mark.parametrize("ps,wire_order,true_matrix", tup_ps_mat)
     def test_to_mat_buffer(self, ps, wire_order, true_matrix):
@@ -1105,7 +1105,7 @@ class TestPauliSentenceMatrix:
         size is reached."""
         buffer_size = 2 ** len(wire_order) * 48  # Buffer size for 2 matrices
         sparse_mat = ps.to_mat(wire_order, format="csr", buffer_size=buffer_size)
-        assert np.allclose(sparse_mat.toarray(), true_matrix)
+        assert pnp.allclose(sparse_mat.toarray(), true_matrix)
 
     @pytest.mark.tf
     def test_dense_matrix_tf(self):
@@ -1123,8 +1123,8 @@ class TestPauliSentenceMatrix:
 
         gx, gy = tape.jacobian(mat, [x, y])
 
-        pw1_mat = np.array([[0, 0, 0, -1j], [0, 0, 1j, 0], [0, -1j, 0, 0], [1j, 0, 0, 0]])
-        pw2_mat = np.array([[0, 0, 0, -1j], [0, 0, -1j, 0], [0, 1j, 0, 0], [1j, 0, 0, 0]])
+        pw1_mat = pnp.array([[0, 0, 0, -1j], [0, 0, 1j, 0], [0, -1j, 0, 0], [1j, 0, 0, 0]])
+        pw2_mat = pnp.array([[0, 0, 0, -1j], [0, 0, -1j, 0], [0, 1j, 0, 0], [1j, 0, 0, 0]])
 
         assert qml.math.allclose(mat, x * pw1_mat + y * pw2_mat)
         assert qml.math.allclose(gx, qml.math.conj(pw1_mat))  # tf complex number convention
@@ -1175,8 +1175,8 @@ class TestPauliSentenceMatrix:
         x = jax.numpy.array(0.1 + 0j)
         y = jax.numpy.array(0.2 + 0j)
 
-        pw1_mat = np.array([[0, 0, 0, -1j], [0, 0, 1j, 0], [0, -1j, 0, 0], [1j, 0, 0, 0]])
-        pw2_mat = np.array([[0, 0, 0, -1j], [0, 0, -1j, 0], [0, 1j, 0, 0], [1j, 0, 0, 0]])
+        pw1_mat = pnp.array([[0, 0, 0, -1j], [0, 0, 1j, 0], [0, -1j, 0, 0], [1j, 0, 0, 0]])
+        pw2_mat = pnp.array([[0, 0, 0, -1j], [0, 0, -1j, 0], [0, 1j, 0, 0], [1j, 0, 0, 0]])
 
         mat = f(x, y)
         assert qml.math.allclose(mat, x * pw1_mat + y * pw2_mat)
@@ -1192,7 +1192,7 @@ class TestPaulicomms:
     def test_pauli_word_comm_raises_NotImplementedError(self):
         """Test that a NotImplementedError is raised when a PauliWord.commutator() for type that is not PauliWord, PauliSentence or Operator"""
         op1 = PauliWord({0: "X"})
-        matrix = np.eye(2)
+        matrix = pnp.eye(2)
         with pytest.raises(NotImplementedError, match="Cannot compute natively a commutator"):
             op1.commutator(matrix)
 
@@ -1442,9 +1442,9 @@ class TestPauliArithmeticWithADInterfaces:
     def test_autograd_initialization(self, scalar):
         """Test initializing PauliSentence from autograd array"""
 
-        tensor = scalar * np.ones(4)
+        tensor = scalar * pnp.ones(4)
         res = PauliSentence(dict(zip(words, tensor)))
-        assert all(isinstance(val, np.ndarray) for val in res.values())
+        assert all(isinstance(val, pnp.ndarray) for val in res.values())
 
     @pytest.mark.jax
     @pytest.mark.parametrize("scalar", [0.0, 0.5, 1, 1j, 0.5j + 1.0])
@@ -1492,18 +1492,18 @@ class TestPauliArithmeticWithADInterfaces:
     def test_autograd_scalar_multiplication(self, ps, scalar):
         """Test that multiplying with an autograd array works and results in the correct types"""
 
-        res1 = np.array(scalar) * ps
-        res2 = ps * np.array(scalar)
-        res3 = ps / np.array(scalar)
+        res1 = pnp.array(scalar) * ps
+        res2 = ps * pnp.array(scalar)
+        res3 = ps / pnp.array(scalar)
         assert isinstance(res1, PauliSentence)
         assert isinstance(res2, PauliSentence)
         assert isinstance(res3, PauliSentence)
         assert list(res1.values()) == [scalar * coeff for coeff in ps.values()]
         assert list(res2.values()) == [scalar * coeff for coeff in ps.values()]
         assert list(res3.values()) == [coeff / scalar for coeff in ps.values()]
-        assert all(isinstance(val, np.ndarray) for val in res1.values())
-        assert all(isinstance(val, np.ndarray) for val in res2.values())
-        assert all(isinstance(val, np.ndarray) for val in res3.values())
+        assert all(isinstance(val, pnp.ndarray) for val in res1.values())
+        assert all(isinstance(val, pnp.ndarray) for val in res2.values())
+        assert all(isinstance(val, pnp.ndarray) for val in res3.values())
 
     @pytest.mark.jax
     @pytest.mark.parametrize("ps", sentences)

--- a/tests/pulse/test_parametrized_hamiltonian.py
+++ b/tests/pulse/test_parametrized_hamiltonian.py
@@ -19,19 +19,19 @@ Unit tests for the ParametrizedHamiltonian class
 import pytest
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane.pulse import ParametrizedHamiltonian
 from pennylane.wires import Wires
 
 
 def f1(p, t):
     """Compute the function p * sin(t) * (t - 1)."""
-    return p * np.sin(t) * (t - 1)
+    return p * pnp.sin(t) * (t - 1)
 
 
 def f2(p, t):
     """Compute the function p * cos(t**2)."""
-    return p * np.cos(t**2)
+    return p * pnp.cos(t**2)
 
 
 param = [1.2, 2.3]
@@ -236,9 +236,9 @@ class TestCall:
         assert (
             repr(H([2], t=4)) == "(\n    2 * GellMann2(wires=[0])\n  + 10 * GellMann1(wires=[0])\n)"
         )
-        assert np.all(
+        assert pnp.all(
             qml.matrix(H([2], 4))
-            == np.array(
+            == pnp.array(
                 [
                     [0.0 + 0.0j, 10.0 - 2.0j, 0.0 + 0.0j],
                     [10.0 + 2.0j, 0.0 + 0.0j, 0.0 + 0.0j],

--- a/tests/qchem/openfermion_pyscf_tests/test_convert.py
+++ b/tests/qchem/openfermion_pyscf_tests/test_convert.py
@@ -22,7 +22,7 @@ import sys
 import pytest
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane import qchem
 
 openfermion = pytest.importorskip("openfermion")
@@ -403,7 +403,7 @@ def test_operation_conversion(pl_op, of_op, wire_order):
 
     assert all(isinstance(term, pauli_ops_and_prod) for term in converted_of_op_terms)
 
-    assert np.allclose(
+    assert pnp.allclose(
         qml.matrix(qml.dot(*pl_op), wire_order=wire_order),
         qml.matrix(qml.dot(*converted_of_op), wire_order=wire_order),
     )
@@ -439,7 +439,7 @@ def test_not_xyz_pennylane_to_openfermion(op):
     _match = "Expected a Pennylane operator with a valid Pauli word representation,"
     with pytest.raises(ValueError, match=_match):
         qml.qchem.convert._pennylane_to_openfermion(
-            np.array([0.1 + 0.0j, 0.0]),
+            pnp.array([0.1 + 0.0j, 0.0]),
             [
                 qml.prod(qml.PauliX(0)),
                 op,
@@ -454,7 +454,7 @@ def test_wires_not_covered_pennylane_to_openfermion():
         match="Supplied `wires` does not cover all wires defined in `ops`.",
     ):
         qml.qchem.convert._pennylane_to_openfermion(
-            np.array([0.1, 0.2]),
+            pnp.array([0.1, 0.2]),
             [
                 qml.prod(qml.PauliX(wires=["w0"])),
                 qml.prod(qml.PauliY(wires=["w0"]), qml.PauliZ(wires=["w2"])),
@@ -536,7 +536,7 @@ def test_import_operator(of_op, pl_h, pl_op, wires):
             isinstance(term, qml.ops.SProd) and isinstance(term.base, pauli_ops_and_prod)
             for term in of_h.operands
         )
-    assert np.allclose(qml.matrix(of_h, wire_order=wires), qml.matrix(pl_op, wire_order=wires))
+    assert pnp.allclose(qml.matrix(of_h, wire_order=wires), qml.matrix(pl_op, wire_order=wires))
 
 
 op_1 = (
@@ -593,7 +593,7 @@ def test_singlewire_pennylane_to_openfermion():
     """Test that _pennylane_to_openfermion function returns the correct Hamiltonian for a
     single-wire case.
     """
-    coeffs = np.array([0.5])
+    coeffs = pnp.array([0.5])
     obs_list = [qml.PauliZ(wires=[0])]
 
     op_str = str(qml.qchem.convert._pennylane_to_openfermion(coeffs, obs_list))
@@ -605,7 +605,7 @@ def test_singlewire_pennylane_to_openfermion():
 
 def test_pennylane_to_openfermion_no_decomp():
     """Test the _pennylane_to_openfermion function with custom wires."""
-    coeffs = np.array([0.1, 0.2])
+    coeffs = pnp.array([0.1, 0.2])
     ops = [
         qml.prod(qml.PauliX(wires=["w0"])),
         qml.prod(qml.PauliY(wires=["w0"]), qml.PauliZ(wires=["w2"])),
@@ -679,7 +679,7 @@ def test_integration_observable_to_vqe_cost(
     params = [0.1 * i for i in range(num_qubits)]
     res = dummy_cost(params)
 
-    assert np.allclose(res, expected_cost, **tol)
+    assert pnp.allclose(res, expected_cost, **tol)
 
 
 @pytest.mark.parametrize("n_wires", [None, 6])
@@ -727,7 +727,7 @@ def test_fail_import_openfermion(monkeypatch):
 
         with pytest.raises(ImportError, match="This feature requires openfermion"):
             qml.qchem.convert._pennylane_to_openfermion(
-                np.array([0.1 + 0.0j, 0.0]),
+                pnp.array([0.1 + 0.0j, 0.0]),
                 [
                     qml.prod(qml.PauliX(0)),
                     qml.prod(qml.PauliZ(0), qml.QuadOperator(0.1, wires=1)),
@@ -776,7 +776,7 @@ def test_integration_mol_file_to_vqe_cost(
         wires = custom_wires[:num_qubits]
 
     dev = qml.device("default.qubit", wires=wires)
-    phis = np.load(os.path.join(ref_dir, "dummy_ansatz_parameters.npy"))
+    phis = pnp.load(os.path.join(ref_dir, "dummy_ansatz_parameters.npy"))
 
     @qml.qnode(dev)
     def dummy_cost(params):
@@ -786,7 +786,7 @@ def test_integration_mol_file_to_vqe_cost(
 
     res = dummy_cost(phis)
 
-    assert np.abs(res - expected_cost) < tol["atol"]
+    assert pnp.abs(res - expected_cost) < tol["atol"]
 
 
 @pytest.mark.parametrize(
@@ -814,23 +814,23 @@ def test_excitations(electrons, orbitals, singles_ref, doubles_ref):
             3,
             8,
             1,
-            np.array([14, 22, 38, 70, 134, 13, 21, 37, 69, 133, 11, 19, 35, 67, 131]),
-            np.array([1, 1, 1, 1, 1, -1, -1, -1, -1, -1, 1, 1, 1, 1, 1]),
+            pnp.array([14, 22, 38, 70, 134, 13, 21, 37, 69, 133, 11, 19, 35, 67, 131]),
+            pnp.array([1, 1, 1, 1, 1, -1, -1, -1, -1, -1, 1, 1, 1, 1, 1]),
         ),
         (
             3,
             6,
             2,
-            np.array([28, 44, 52, 26, 42, 50, 25, 41, 49]),
-            np.array([1, 1, 1, -1, -1, -1, 1, 1, 1]),
+            pnp.array([28, 44, 52, 26, 42, 50, 25, 41, 49]),
+            pnp.array([1, 1, 1, -1, -1, -1, 1, 1, 1]),
         ),
     ],
 )
 def test_excited_configurations(electrons, orbitals, excitation, states_ref, signs_ref):
     r"""Test if the _excited_configurations function returns correct states and signs."""
     states, signs = qchem.convert._excited_configurations(electrons, orbitals, excitation)
-    assert np.allclose(states, states_ref)
-    assert np.allclose(signs, signs_ref)
+    assert pnp.allclose(states, states_ref)
+    assert pnp.allclose(signs, signs_ref)
 
 
 @pytest.mark.parametrize(
@@ -852,13 +852,13 @@ def test_excited_configurations(electrons, orbitals, excitation, states_ref, sig
 )
 def test_wfdict_to_statevector(wf_dict, n_orbitals, string_ref, coeff_ref):
     r"""Test that _wfdict_to_statevector returns the correct state vector."""
-    wf_ref = np.zeros(2 ** (n_orbitals * 2))
+    wf_ref = pnp.zeros(2 ** (n_orbitals * 2))
     idx_nonzero = [int(s, 2) for s in string_ref]
     wf_ref[idx_nonzero] = coeff_ref
 
     wf_comp = qchem.convert._wfdict_to_statevector(wf_dict, n_orbitals)
 
-    assert np.allclose(wf_comp, wf_ref)
+    assert pnp.allclose(wf_comp, wf_ref)
 
 
 @pytest.mark.parametrize(
@@ -868,7 +868,7 @@ def test_wfdict_to_statevector(wf_dict, n_orbitals, string_ref, coeff_ref):
             [["H", (0, 0, 0)], ["H", (0, 0, 0.71)]],
             "sto6g",
             "d2h",
-            np.array(
+            pnp.array(
                 [
                     0.0,
                     0.0,
@@ -913,7 +913,7 @@ def test_import_state_pyscf(molecule, basis, symm, method, wf_ref):
     wf_comp = qchem.convert.import_state(solver)
 
     # overall sign could be different in each PySCF run
-    assert np.allclose(wf_comp, wf_ref) or np.allclose(wf_comp, -wf_ref)
+    assert pnp.allclose(wf_comp, wf_ref) or pnp.allclose(wf_comp, -wf_ref)
 
 
 @pytest.mark.parametrize(
@@ -921,8 +921,8 @@ def test_import_state_pyscf(molecule, basis, symm, method, wf_ref):
     [
         (
             # dmrg
-            ([[0, 3], [3, 0]], np.array([-0.10660077, 0.9943019])),
-            np.array(
+            ([[0, 3], [3, 0]], pnp.array([-0.10660077, 0.9943019])),
+            pnp.array(
                 [
                     0.0,
                     0.0,
@@ -945,8 +945,8 @@ def test_import_state_pyscf(molecule, basis, symm, method, wf_ref):
         ),
         (
             # shci
-            (["02", "20"], np.array([-0.1066467, 0.99429698])),
-            np.array(
+            (["02", "20"], pnp.array([-0.1066467, 0.99429698])),
+            pnp.array(
                 [
                     0.0,
                     0.0,
@@ -975,7 +975,7 @@ def test_import_state_nonpyscf(detscoeffs, wf_ref):
     wf_comp = qchem.convert.import_state(detscoeffs)
 
     # overall sign could be different in each PySCF run
-    assert np.allclose(wf_comp, wf_ref) or np.allclose(wf_comp, -wf_ref)
+    assert pnp.allclose(wf_comp, wf_ref) or pnp.allclose(wf_comp, -wf_ref)
 
 
 def test_import_state_error():
@@ -986,7 +986,7 @@ def test_import_state_error():
     with pytest.raises(ValueError, match="The supported objects"):
         qchem.convert.import_state(myci)
 
-    mytuple = (np.array([[3, 0], [0, 3]]), np.array([0]))
+    mytuple = (pnp.array([[3, 0], [0, 3]]), pnp.array([0]))
 
     with pytest.raises(ValueError, match="For tuple input"):
         qchem.convert.import_state(mytuple)
@@ -1032,7 +1032,7 @@ li2_wf_sto6g = {  # tol = 1e-1
 # shci
 h3p_shci_dets_coeffs = (
     ["200", "020", "002", "b0a", "a0b"],
-    np.array([0.9389761486, -0.278704004, -0.1838389711, -0.0585282123, -0.0585282123]),
+    pnp.array([0.9389761486, -0.278704004, -0.1838389711, -0.0585282123, -0.0585282123]),
 )
 h3p_shci_e = -1.0862426041366735
 lihpp_shci_dets_coeffs = (
@@ -1050,7 +1050,7 @@ lihpp_shci_dets_coeffs = (
         "0000ba",
         "0000ab",
     ],
-    np.array(
+    pnp.array(
         [
             0.9999782547,
             -0.0035481253,
@@ -1070,7 +1070,7 @@ lihpp_shci_dets_coeffs = (
 lihpp_shci_e = -6.781988968692473
 h3_shci_dets_coeffs = (
     ["2a0", "aba", "0a2", "aab", "baa"],
-    np.array([0.8614786698, 0.322024811, 0.319505036, 0.1715258542, 0.1504989567]),
+    pnp.array([0.8614786698, 0.322024811, 0.319505036, 0.1715258542, 0.1504989567]),
 )
 h3_shci_e = -1.454861277373169
 lih_shci_dets_coeffs = (
@@ -1110,7 +1110,7 @@ lih_shci_dets_coeffs = (
         "0ba002",
         "0ab002",
     ],
-    np.array(
+    pnp.array(
         [
             -0.9911126427,
             0.0971352826,
@@ -1197,7 +1197,7 @@ behp_shci_dets_coeffs = (
         "0ba002",
         "0ab002",
     ],
-    np.array(
+    pnp.array(
         [
             0.9916223775,
             -0.0701573082,
@@ -1303,7 +1303,7 @@ beh_shci_dets_coeffs = (
         "aa020b",
         "aa002b",
     ],
-    np.array(
+    pnp.array(
         [
             -0.9884697344,
             -0.0746546627,
@@ -1366,7 +1366,7 @@ beh_shci_e = -15.11001775498381
 # dmrg
 h3p_dmrg_dets_coeffs = (
     [[0, 0, 3], [0, 3, 0], [1, 0, 2], [2, 0, 1], [3, 0, 0]],
-    np.array(
+    pnp.array(
         [
             0.1838436556640729,
             0.27869890041510864,
@@ -1398,7 +1398,7 @@ lihpp_dmrg_dets_coeffs = (
         [0, 0, 0, 3, 0, 0],
         [0, 0, 3, 0, 0, 0],
     ],
-    np.array(
+    pnp.array(
         [
             -0.0007085379968001104,
             -0.0025498996125903938,
@@ -1424,7 +1424,7 @@ lihpp_dmrg_dets_coeffs = (
 lihpp_dmrg_e = -6.781990152954243
 h3_dmrg_dets_coeffs = (
     [[0, 1, 3], [1, 1, 2], [1, 2, 1], [2, 1, 1], [3, 1, 0]],
-    np.array(
+    pnp.array(
         [
             -0.319505629799915,
             -0.1715263012109641,
@@ -1517,7 +1517,7 @@ lih_dmrg_dets_coeffs = (
         [0, 0, 1, 0, 3, 2],
         [0, 0, 1, 3, 0, 2],
     ],
-    np.array(
+    pnp.array(
         [
             -0.044171641132296,
             3.1795384687324654e-06,
@@ -1676,7 +1676,7 @@ behp_dmrg_dets_coeffs = (
         [0, 0, 0, 3, 0, 3],
         [0, 0, 0, 3, 3, 0],
     ],
-    np.array(
+    pnp.array(
         [
             -0.04574644026032889,
             0.04574537386192611,
@@ -1832,7 +1832,7 @@ beh_dmrg_dets_coeffs = (
         [0, 0, 1, 3, 3, 0],
         [0, 0, 3, 0, 3, 1],
     ],
-    np.array(
+    pnp.array(
         [
             -0.024715466767529778,
             0.06840073088385241,
@@ -1936,22 +1936,22 @@ def test_rcisd_state_energy(molecule, basis, symm, charge, spin, tol):
     myci = pyscf.ci.CISD(myhf).run(verbose=0)
     wf_cisd = qchem.convert.import_state(myci, tol=tol)
 
-    core_constant = np.array([mol.energy_nuc()])
+    core_constant = pnp.array([mol.energy_nuc()])
     # molecular integrals in AO basis
     one_ao = mol.intor_symmetric("int1e_kin") + mol.intor_symmetric("int1e_nuc")
     two_ao = mol.intor("int2e_sph")
     # rotate to MO basis
-    one_mo = np.einsum("pi,pq,qj->ij", myhf.mo_coeff, one_ao, myhf.mo_coeff)
+    one_mo = pnp.einsum("pi,pq,qj->ij", myhf.mo_coeff, one_ao, myhf.mo_coeff)
     two_mo = pyscf.ao2mo.incore.full(two_ao, myhf.mo_coeff)
     # physicist ordering convention
-    two_mo = np.swapaxes(two_mo, 1, 3)
+    two_mo = pnp.swapaxes(two_mo, 1, 3)
 
     h_ferm = qchem.fermionic_observable(core_constant, one_mo, two_mo)
     H = qchem.qubit_observable(h_ferm)
     H_mat = H.sparse_matrix().toarray()
-    energy_pl = np.conj(wf_cisd.T).dot(H_mat.dot(wf_cisd))
+    energy_pl = pnp.conj(wf_cisd.T).dot(H_mat.dot(wf_cisd))
 
-    assert np.allclose(energy_pl, myci.e_tot, atol=1e-6)
+    assert pnp.allclose(energy_pl, myci.e_tot, atol=1e-6)
 
 
 @pytest.mark.parametrize(
@@ -1973,22 +1973,22 @@ def test_ucisd_state_energy(molecule, basis, symm, charge, spin, tol):
     myci = pyscf.ci.UCISD(myhf).run(verbose=0)
     wf_cisd = qchem.convert.import_state(myci, tol=tol)
 
-    core_constant = np.array([mol.energy_nuc()])
+    core_constant = pnp.array([mol.energy_nuc()])
     # molecular integrals in AO basis
     one_ao = mol.intor_symmetric("int1e_kin") + mol.intor_symmetric("int1e_nuc")
     two_ao = mol.intor("int2e_sph")
     # rotate to MO basis
-    one_mo = np.einsum("pi,pq,qj->ij", myhf.mo_coeff, one_ao, myhf.mo_coeff)
+    one_mo = pnp.einsum("pi,pq,qj->ij", myhf.mo_coeff, one_ao, myhf.mo_coeff)
     two_mo = pyscf.ao2mo.incore.full(two_ao, myhf.mo_coeff)
     # physicist ordering convention
-    two_mo = np.swapaxes(two_mo, 1, 3)
+    two_mo = pnp.swapaxes(two_mo, 1, 3)
 
     h_ferm = qchem.fermionic_observable(core_constant, one_mo, two_mo)
     H = qchem.qubit_observable(h_ferm)
     H_mat = H.sparse_matrix().toarray()
-    energy_pl = np.conj(wf_cisd.T).dot(H_mat.dot(wf_cisd))
+    energy_pl = pnp.conj(wf_cisd.T).dot(H_mat.dot(wf_cisd))
 
-    assert np.allclose(energy_pl, myci.e_tot, atol=1e-6)
+    assert pnp.allclose(energy_pl, myci.e_tot, atol=1e-6)
 
 
 @pytest.mark.parametrize(
@@ -2011,22 +2011,22 @@ def test_rccsd_state_energy(molecule, basis, symm, charge, spin, tol):
     mycc = pyscf.cc.CCSD(myhf).run(verbose=0)
     wf_ccsd = qchem.convert.import_state(mycc, tol=tol)
 
-    core_constant = np.array([mol.energy_nuc()])
+    core_constant = pnp.array([mol.energy_nuc()])
     # molecular integrals in AO basis
     one_ao = mol.intor_symmetric("int1e_kin") + mol.intor_symmetric("int1e_nuc")
     two_ao = mol.intor("int2e_sph")
     # rotate to MO basis
-    one_mo = np.einsum("pi,pq,qj->ij", myhf.mo_coeff, one_ao, myhf.mo_coeff)
+    one_mo = pnp.einsum("pi,pq,qj->ij", myhf.mo_coeff, one_ao, myhf.mo_coeff)
     two_mo = pyscf.ao2mo.incore.full(two_ao, myhf.mo_coeff)
     # physicist ordering convention
-    two_mo = np.swapaxes(two_mo, 1, 3)
+    two_mo = pnp.swapaxes(two_mo, 1, 3)
 
     h_ferm = qchem.fermionic_observable(core_constant, one_mo, two_mo)
     H = qchem.qubit_observable(h_ferm)
     H_mat = H.sparse_matrix().toarray()
-    energy_pl = np.conj(wf_ccsd.T).dot(H_mat.dot(wf_ccsd))
+    energy_pl = pnp.conj(wf_ccsd.T).dot(H_mat.dot(wf_ccsd))
 
-    assert np.allclose(energy_pl, mycc.e_tot, atol=1e-4)
+    assert pnp.allclose(energy_pl, mycc.e_tot, atol=1e-4)
 
 
 @pytest.mark.parametrize(
@@ -2048,22 +2048,22 @@ def test_uccsd_state_energy(molecule, basis, symm, charge, spin, tol):
     mycc = pyscf.cc.UCCSD(myhf).run(verbose=0)
     wf_ccsd = qchem.convert.import_state(mycc, tol=tol)
 
-    core_constant = np.array([mol.energy_nuc()])
+    core_constant = pnp.array([mol.energy_nuc()])
     # molecular integrals in AO basis
     one_ao = mol.intor_symmetric("int1e_kin") + mol.intor_symmetric("int1e_nuc")
     two_ao = mol.intor("int2e_sph")
     # rotate to MO basis
-    one_mo = np.einsum("pi,pq,qj->ij", myhf.mo_coeff, one_ao, myhf.mo_coeff)
+    one_mo = pnp.einsum("pi,pq,qj->ij", myhf.mo_coeff, one_ao, myhf.mo_coeff)
     two_mo = pyscf.ao2mo.incore.full(two_ao, myhf.mo_coeff)
     # physicist ordering convention
-    two_mo = np.swapaxes(two_mo, 1, 3)
+    two_mo = pnp.swapaxes(two_mo, 1, 3)
 
     h_ferm = qchem.fermionic_observable(core_constant, one_mo, two_mo)
     H = qchem.qubit_observable(h_ferm)
     H_mat = H.sparse_matrix().toarray()
-    energy_pl = np.conj(wf_ccsd.T).dot(H_mat.dot(wf_ccsd))
+    energy_pl = pnp.conj(wf_ccsd.T).dot(H_mat.dot(wf_ccsd))
 
-    assert np.allclose(energy_pl, mycc.e_tot, atol=1e-2)
+    assert pnp.allclose(energy_pl, mycc.e_tot, atol=1e-2)
 
 
 @pytest.mark.parametrize(
@@ -2086,22 +2086,22 @@ def test_dmrg_state_energy(molecule, basis, charge, spin, dmrg_dets_coeffs, dmrg
 
     mol = pyscf.gto.M(atom=molecule, basis=basis, charge=charge, spin=spin, symmetry=None)
     myhf = pyscf.scf.ROHF(mol).run(verbose=0)
-    core_constant = np.array([mol.energy_nuc()])
+    core_constant = pnp.array([mol.energy_nuc()])
     # molecular integrals in AO basis
     one_ao = mol.intor_symmetric("int1e_kin") + mol.intor_symmetric("int1e_nuc")
     two_ao = mol.intor("int2e_sph")
     # rotate to MO basis
-    one_mo = np.einsum("pi,pq,qj->ij", myhf.mo_coeff, one_ao, myhf.mo_coeff)
+    one_mo = pnp.einsum("pi,pq,qj->ij", myhf.mo_coeff, one_ao, myhf.mo_coeff)
     two_mo = pyscf.ao2mo.incore.full(two_ao, myhf.mo_coeff)
     # physicist ordering convention
-    two_mo = np.swapaxes(two_mo, 1, 3)
+    two_mo = pnp.swapaxes(two_mo, 1, 3)
 
     h_ferm = qchem.fermionic_observable(core_constant, one_mo, two_mo)
     H = qchem.qubit_observable(h_ferm)
     H_mat = H.sparse_matrix().toarray()
-    energy_pl = np.conj(wf_dmrg.T).dot(H_mat.dot(wf_dmrg))
+    energy_pl = pnp.conj(wf_dmrg.T).dot(H_mat.dot(wf_dmrg))
 
-    assert np.allclose(energy_pl, dmrg_e, atol=1e-6)
+    assert pnp.allclose(energy_pl, dmrg_e, atol=1e-6)
 
 
 @pytest.mark.parametrize(
@@ -2125,22 +2125,22 @@ def test_shci_state_energy(molecule, basis, charge, spin, shci_dets_coeffs, shci
     mol = pyscf.gto.M(atom=molecule, basis=basis, charge=charge, spin=spin, symmetry=None)
     myhf = pyscf.scf.ROHF(mol).run(verbose=0)
 
-    core_constant = np.array([mol.energy_nuc()])
+    core_constant = pnp.array([mol.energy_nuc()])
     # molecular integrals in AO basis
     one_ao = mol.intor_symmetric("int1e_kin") + mol.intor_symmetric("int1e_nuc")
     two_ao = mol.intor("int2e_sph")
     # rotate to MO basis
-    one_mo = np.einsum("pi,pq,qj->ij", myhf.mo_coeff, one_ao, myhf.mo_coeff)
+    one_mo = pnp.einsum("pi,pq,qj->ij", myhf.mo_coeff, one_ao, myhf.mo_coeff)
     two_mo = pyscf.ao2mo.incore.full(two_ao, myhf.mo_coeff)
     # physicist ordering convention
-    two_mo = np.swapaxes(two_mo, 1, 3)
+    two_mo = pnp.swapaxes(two_mo, 1, 3)
 
     h_ferm = qchem.fermionic_observable(core_constant, one_mo, two_mo)
     H = qchem.qubit_observable(h_ferm)
     H_mat = H.sparse_matrix().toarray()
-    energy_pl = np.conj(wf_shci.T).dot(H_mat.dot(wf_shci))
+    energy_pl = pnp.conj(wf_shci.T).dot(H_mat.dot(wf_shci))
 
-    assert np.allclose(energy_pl, shci_e, atol=1e-6)
+    assert pnp.allclose(energy_pl, shci_e, atol=1e-6)
 
 
 @pytest.mark.parametrize(
@@ -2160,7 +2160,7 @@ def test_ucisd_state(molecule, basis, symm, tol, wf_ref):
     wf_cisd = qchem.convert._ucisd_state(myci, tol=tol)
 
     assert wf_cisd.keys() == wf_ref.keys()
-    assert np.allclose(abs(np.array(list(wf_cisd.values()))), abs(np.array(list(wf_ref.values()))))
+    assert pnp.allclose(abs(pnp.array(list(wf_cisd.values()))), abs(pnp.array(list(wf_ref.values()))))
 
 
 @pytest.mark.parametrize(
@@ -2198,7 +2198,7 @@ def test_rcisd_state(molecule, basis, symm, tol, wf_ref):
     wf_cisd = qchem.convert._rcisd_state(myci, tol=tol)
 
     assert wf_cisd.keys() == wf_ref.keys()
-    assert np.allclose(abs(np.array(list(wf_cisd.values()))), abs(np.array(list(wf_ref.values()))))
+    assert pnp.allclose(abs(pnp.array(list(wf_cisd.values()))), abs(pnp.array(list(wf_ref.values()))))
 
 
 @pytest.mark.parametrize(
@@ -2218,7 +2218,7 @@ def test_uccsd_state(molecule, basis, symm, tol, wf_ref):
     wf_ccsd = qchem.convert._uccsd_state(mycc, tol=tol)
 
     assert wf_ccsd.keys() == wf_ref.keys()
-    assert np.allclose(abs(np.array(list(wf_ccsd.values()))), abs(np.array(list(wf_ref.values()))))
+    assert pnp.allclose(abs(pnp.array(list(wf_ccsd.values()))), abs(pnp.array(list(wf_ref.values()))))
 
 
 @pytest.mark.parametrize(
@@ -2238,7 +2238,7 @@ def test_rccsd_state(molecule, basis, symm, tol, wf_ref):
     wf_ccsd = qchem.convert._rccsd_state(mycc, tol=tol)
 
     assert wf_ccsd.keys() == wf_ref.keys()
-    assert np.allclose(abs(np.array(list(wf_ccsd.values()))), abs(np.array(list(wf_ref.values()))))
+    assert pnp.allclose(abs(pnp.array(list(wf_ccsd.values()))), abs(pnp.array(list(wf_ref.values()))))
 
 
 @pytest.mark.parametrize(
@@ -2246,8 +2246,8 @@ def test_rccsd_state(molecule, basis, symm, tol, wf_ref):
     [
         # h2
         (
-            ([[0, 3], [3, 0]], np.array([-0.10660077, 0.9943019])),
-            {(2, 2): np.array([-0.10660077]), (1, 1): np.array([0.9943019])},
+            ([[0, 3], [3, 0]], pnp.array([-0.10660077, 0.9943019])),
+            {(2, 2): pnp.array([-0.10660077]), (1, 1): pnp.array([0.9943019])},
         ),
         # li2
         (
@@ -2258,15 +2258,15 @@ def test_rccsd_state(molecule, basis, symm, tol, wf_ref):
                     [3, 3, 0, 0, 3, 0, 0, 0, 0, 0],
                     [3, 3, 0, 0, 0, 3, 0, 0, 0, 0],
                 ],
-                np.array(
+                pnp.array(
                     [-0.887277400314367, 0.308001203411555, 0.307470727263604, 0.145118175734375]
                 ),
             ),
             {
-                (7, 7): np.array([-0.887277400314367]),
-                (11, 11): np.array([0.308001203411555]),
-                (19, 19): np.array([0.307470727263604]),
-                (35, 35): np.array([0.145118175734375]),
+                (7, 7): pnp.array([-0.887277400314367]),
+                (11, 11): pnp.array([0.308001203411555]),
+                (19, 19): pnp.array([0.307470727263604]),
+                (35, 35): pnp.array([0.145118175734375]),
             },
         ),
     ],
@@ -2285,16 +2285,16 @@ def test_dmrg_state(wavefunction, state_ref):
         (
             (
                 ["02", "20"],
-                np.array([-0.10660077, 0.9943019]),
+                pnp.array([-0.10660077, 0.9943019]),
             ),
-            {(2, 2): np.array([-0.10660077]), (1, 1): np.array([0.9943019])},
+            {(2, 2): pnp.array([-0.10660077]), (1, 1): pnp.array([0.9943019])},
         ),
         (
-            (["02", "ab", "20"], np.array([0.69958765, 0.70211014, 0.1327346])),
+            (["02", "ab", "20"], pnp.array([0.69958765, 0.70211014, 0.1327346])),
             {
-                (2, 2): np.array([0.69958765]),
-                (1, 2): np.array([0.70211014]),
-                (1, 1): np.array([0.1327346]),
+                (2, 2): pnp.array([0.69958765]),
+                (1, 2): pnp.array([0.70211014]),
+                (1, 1): pnp.array([0.1327346]),
             },
         ),
         (
@@ -2307,7 +2307,7 @@ def test_dmrg_state(wavefunction, state_ref):
                     "22b00000a0",
                     "22a00000b0",
                 ],
-                np.array(
+                pnp.array(
                     [
                         0.8874197325,
                         -0.3075732772,
@@ -2319,12 +2319,12 @@ def test_dmrg_state(wavefunction, state_ref):
                 ),
             ),
             {
-                (7, 7): np.array([-0.8874197325]),
-                (11, 11): np.array([0.3075732772]),
-                (19, 19): np.array([0.3075732772]),
-                (35, 35): np.array([0.1450493028]),
-                (259, 7): np.array([-0.0226602105]),
-                (7, 259): np.array([0.0226602105]),
+                (7, 7): pnp.array([-0.8874197325]),
+                (11, 11): pnp.array([0.3075732772]),
+                (19, 19): pnp.array([0.3075732772]),
+                (35, 35): pnp.array([0.1450493028]),
+                (259, 7): pnp.array([-0.0226602105]),
+                (7, 259): pnp.array([0.0226602105]),
             },
         ),
     ],

--- a/tests/qchem/openfermion_pyscf_tests/test_convert_openfermion.py
+++ b/tests/qchem/openfermion_pyscf_tests/test_convert_openfermion.py
@@ -22,7 +22,7 @@ import pytest
 
 import pennylane as qml
 from pennylane import fermi
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 
 openfermion = pytest.importorskip("openfermion")
 
@@ -112,10 +112,10 @@ class TestFromOpenFermion:
         )
 
         pl_op = qml.from_openfermion(q_op, tol=1e-6)
-        assert not np.any(pl_op.coeffs.imag)
+        assert not pnp.any(pl_op.coeffs.imag)
 
         pl_op = qml.from_openfermion(q_op, tol=1e-10)
-        assert np.any(pl_op.coeffs.imag)
+        assert pnp.any(pl_op.coeffs.imag)
 
     def test_type_qubit(self):
         """Test that from_openfermion yields a ``LinearCombination`` object."""
@@ -288,12 +288,12 @@ class TestToOpenFermion:
     def test_tol(self, pl_op):
         """Test whether the to_openfermion function removes the imaginary parts if they are all smaller than tol."""
         q_op = qml.to_openfermion(pl_op, tol=1e-6)
-        coeffs = np.array(list(q_op.terms.values()))
-        assert not np.any(coeffs.imag)
+        coeffs = pnp.array(list(q_op.terms.values()))
+        assert not pnp.any(coeffs.imag)
 
         q_op = qml.to_openfermion(pl_op, tol=1e-10)
-        coeffs = np.array(list(q_op.terms.values()))
-        assert np.any(coeffs.imag)
+        coeffs = pnp.array(list(q_op.terms.values()))
+        assert pnp.any(coeffs.imag)
 
     MAPPED_OPS = (
         (
@@ -321,7 +321,7 @@ class TestToOpenFermion:
         _match = "Expected a Pennylane operator with a valid Pauli word representation,"
 
         pl_op = qml.ops.LinearCombination(
-            np.array([0.1 + 0.0j, 0.0]), [qml.prod(qml.PauliX(0)), op]
+            pnp.array([0.1 + 0.0j, 0.0]), [qml.prod(qml.PauliX(0)), op]
         )
         with pytest.raises(ValueError, match=_match):
             qml.to_openfermion(qml.to_openfermion(pl_op))

--- a/tests/qchem/openfermion_pyscf_tests/test_molecular_dipole.py
+++ b/tests/qchem/openfermion_pyscf_tests/test_molecular_dipole.py
@@ -19,11 +19,11 @@ import pytest
 
 import pennylane as qml
 from pennylane import I, X, Y, Z
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane import qchem
 
 h2 = ["H", "H"]
-x_h2 = np.array([0.0, 0.0, -0.661, 0.0, 0.0, 0.661])
+x_h2 = pnp.array([0.0, 0.0, -0.661, 0.0, 0.0, 0.661])
 # Reference dipole operator
 coeffs_h2 = []
 coeffs_h2.append([0.0])
@@ -70,7 +70,7 @@ eig_h2.append([-1.81780062, -0.90890031, -0.90890031])
 
 
 h3p = ["H", "H", "H"]
-x_h3p = np.array([[0.028, 0.054, 0.0], [0.986, 1.610, 0.0], [1.855, 0.002, 0.0]])
+x_h3p = pnp.array([[0.028, 0.054, 0.0], [0.986, 1.610, 0.0], [1.855, 0.002, 0.0]])
 # Reference dipole operator
 coeffs_h3p = []
 coeffs_h3p.append(
@@ -174,7 +174,7 @@ eig_h3p.append([0.0, 0.0])
 
 
 h2o = ["H", "H", "O"]
-x_h2o = np.array([0.0, 1.431, -0.887, 0.0, -1.431, -0.887, 0.0, 0.0, 0.222])
+x_h2o = pnp.array([0.0, 1.431, -0.887, 0.0, -1.431, -0.887, 0.0, 0.0, 0.222])
 
 # Reference dipole operator
 coeffs_h2o = []
@@ -246,9 +246,9 @@ def test_openfermion_molecular_dipole(
 
     for i, _dip in enumerate(dip):
         d_coeffs, d_ops = _dip.terms()
-        calc_coeffs = np.array(d_coeffs)
-        exp_coeffs = np.array(coeffs[i])
-        assert np.allclose(calc_coeffs, exp_coeffs, **tol)
+        calc_coeffs = pnp.array(d_coeffs)
+        exp_coeffs = pnp.array(coeffs[i])
+        assert pnp.allclose(calc_coeffs, exp_coeffs, **tol)
 
         r_ops = ops[i]
 
@@ -295,7 +295,7 @@ def test_differentiable_molecular_dipole(
             eig = [0, 0]
         else:
             eig = qml.eigvals(qml.SparseHamiltonian(dip.sparse_matrix(), wires=wires), k=3)
-        assert np.allclose(np.sort(eig), np.sort(eig_ref[idx]))
+        assert pnp.allclose(pnp.sort(eig), pnp.sort(eig_ref[idx]))
 
 
 @pytest.mark.parametrize(
@@ -310,7 +310,7 @@ def test_custom_wiremap_dipole(wiremap, tmpdir):
     r"""Test that the generated dipole operator has the correct wire labels given by a custom wiremap."""
 
     symbols = ["H", "H"]
-    geometry = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 2.0]])
+    geometry = pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 2.0]])
     method = "dhf"
 
     mol = qchem.Molecule(symbols, geometry)
@@ -337,7 +337,7 @@ def test_molecular_dipole_error():
     r"""Test that molecular_dipole raises an error with unsupported backend and open-shell systems."""
 
     symbols = ["H", "H"]
-    geometry = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 1.0])
+    geometry = pnp.array([0.0, 0.0, 0.0, 0.0, 0.0, 1.0])
     molecule = qchem.Molecule(symbols, geometry)
     with pytest.raises(ValueError, match="Only 'dhf', and 'openfermion' backends are supported"):
         qchem.molecular_dipole(molecule, method="psi4")
@@ -363,7 +363,7 @@ def test_molecular_dipole_error():
         ),
         (
             "dhf",
-            [np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 2.0]])],
+            [pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 2.0]])],
         ),
     ],
 )
@@ -372,7 +372,7 @@ def test_real_dipole(method, args, tmpdir):
     r"""Test that the generated operator has real coefficients."""
 
     symbols = ["H", "H"]
-    geometry = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 2.0]])
+    geometry = pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 2.0]])
     molecule = qchem.Molecule(symbols, geometry)
 
     dipole = qchem.molecular_dipole(
@@ -382,7 +382,7 @@ def test_real_dipole(method, args, tmpdir):
         outpath=tmpdir.strpath,
     )
 
-    assert all(np.isrealobj(op.terms()[0]) for op in dipole)
+    assert all(pnp.isrealobj(op.terms()[0]) for op in dipole)
 
 
 @pytest.mark.parametrize(
@@ -396,8 +396,8 @@ def test_coordinate_units_for_molecular_dipole(method, tmpdir):
     r"""Test that molecular_dipole generates correct operator for both Bohr and Angstrom units."""
 
     symbols = ["H", "H"]
-    geometry_bohr = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
-    geometry_ang = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 0.529177210903]])
+    geometry_bohr = pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
+    geometry_ang = pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 0.529177210903]])
 
     molecule_bohr = qchem.Molecule(symbols, geometry_bohr, unit="bohr")
     dipole_bohr = qchem.molecular_dipole(

--- a/tests/qchem/openfermion_pyscf_tests/test_molecular_hamiltonian.py
+++ b/tests/qchem/openfermion_pyscf_tests/test_molecular_hamiltonian.py
@@ -19,11 +19,11 @@ import pytest
 
 import pennylane as qml
 from pennylane import I, X, Y, Z
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane import qchem
 
 test_symbols = ["C", "C", "N", "H", "H", "H", "H", "H"]
-test_coordinates = np.array(
+test_coordinates = pnp.array(
     [
         0.68219113,
         -0.85415621,
@@ -152,14 +152,14 @@ def test_building_hamiltonian_molecule_class(
     [
         (
             ["H", "H"],
-            np.array([0.0, 0.0, 0.0, 0.0, 0.0, 1.0]),
+            pnp.array([0.0, 0.0, 0.0, 0.0, 0.0, 1.0]),
             "jordan_wigner",
             # computed with OpenFermion; data reordered
             # h_mol = molecule.get_molecular_hamiltonian()
             # h_f = openfermion.transforms.get_fermion_operator(h_mol)
             # h_q = openfermion.transforms.jordan_wigner(h_f)
             (
-                np.array(
+                pnp.array(
                     [
                         0.2981788017,
                         0.2081336485,
@@ -199,7 +199,7 @@ def test_building_hamiltonian_molecule_class(
         ),
         (
             ["H", "H"],
-            np.array([0.0, 0.0, 0.0, 0.0, 0.0, 1.0]),
+            pnp.array([0.0, 0.0, 0.0, 0.0, 0.0, 1.0]),
             "parity",
             # computed with OpenFermion; data reordered
             # h_mol = molecule.get_molecular_hamiltonian()
@@ -207,7 +207,7 @@ def test_building_hamiltonian_molecule_class(
             # binary_code = openfermion.parity_code(molecule.n_qubits)
             # h_q = openfermion.transforms.binary_code_transform(h_f, binary_code)
             (
-                np.array(
+                pnp.array(
                     [
                         0.2981787007221673,
                         0.04256036141425139,
@@ -247,14 +247,14 @@ def test_building_hamiltonian_molecule_class(
         ),
         (
             ["H", "H"],
-            np.array([0.0, 0.0, 0.0, 0.0, 0.0, 1.0]),
+            pnp.array([0.0, 0.0, 0.0, 0.0, 0.0, 1.0]),
             "bravyi_kitaev",
             # computed with OpenFermion; data reordered
             # h_mol = molecule.get_molecular_hamiltonian()
             # h_f = openfermion.transforms.get_fermion_operator(h_mol)
             # h_q = openfermion.transforms.bravyi_kitaev(h_f)
             (
-                np.array(
+                pnp.array(
                     [
                         0.2981787007221673,
                         0.04256036141425139,
@@ -294,14 +294,14 @@ def test_building_hamiltonian_molecule_class(
         ),
         (
             ["H", "H"],
-            np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]]),
+            pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]]),
             "jordan_wigner",
             # computed with OpenFermion; data reordered
             # h_mol = molecule.get_molecular_hamiltonian()
             # h_f = openfermion.transforms.get_fermion_operator(h_mol)
             # h_q = openfermion.transforms.jordan_wigner(h_f)
             (
-                np.array(
+                pnp.array(
                     [
                         0.2981788017,
                         0.2081336485,
@@ -364,14 +364,14 @@ def test_differentiable_hamiltonian(symbols, geometry, mapping, h_ref_data):
     assert all(coeff.requires_grad is True for coeff in h_args_coeffs)
     assert all(coeff.requires_grad is False for coeff in h_noargs_coeffs)
 
-    assert np.allclose(np.sort(h_args_coeffs), np.sort(h_ref_coeffs))
-    assert qml.Hamiltonian(np.ones(len(h_args_coeffs)), h_args_ops).compare(
-        qml.Hamiltonian(np.ones(len(h_ref_coeffs)), h_ref_ops)
+    assert pnp.allclose(pnp.sort(h_args_coeffs), pnp.sort(h_ref_coeffs))
+    assert qml.Hamiltonian(pnp.ones(len(h_args_coeffs)), h_args_ops).compare(
+        qml.Hamiltonian(pnp.ones(len(h_ref_coeffs)), h_ref_ops)
     )
 
-    assert np.allclose(np.sort(h_noargs_coeffs), np.sort(h_ref_coeffs))
-    assert qml.Hamiltonian(np.ones(len(h_noargs_coeffs)), h_noargs_ops).compare(
-        qml.Hamiltonian(np.ones(len(h_ref_coeffs)), h_ref_ops)
+    assert pnp.allclose(pnp.sort(h_noargs_coeffs), pnp.sort(h_ref_coeffs))
+    assert qml.Hamiltonian(pnp.ones(len(h_noargs_coeffs)), h_noargs_ops).compare(
+        qml.Hamiltonian(pnp.ones(len(h_ref_coeffs)), h_ref_ops)
     )
 
 
@@ -380,14 +380,14 @@ def test_differentiable_hamiltonian(symbols, geometry, mapping, h_ref_data):
     [
         (
             ["H", "H"],
-            np.array([0.0, 0.0, 0.0, 0.0, 0.0, 1.0]),
+            pnp.array([0.0, 0.0, 0.0, 0.0, 0.0, 1.0]),
             "jordan_wigner",
             # computed with OpenFermion; data reordered
             # h_mol = molecule.get_molecular_hamiltonian()
             # h_f = openfermion.transforms.get_fermion_operator(h_mol)
             # h_q = openfermion.transforms.jordan_wigner(h_f)
             (
-                np.array(
+                pnp.array(
                     [
                         0.2981788017,
                         0.2081336485,
@@ -427,7 +427,7 @@ def test_differentiable_hamiltonian(symbols, geometry, mapping, h_ref_data):
         ),
         (
             ["H", "H"],
-            np.array([0.0, 0.0, 0.0, 0.0, 0.0, 1.0]),
+            pnp.array([0.0, 0.0, 0.0, 0.0, 0.0, 1.0]),
             "parity",
             # computed with OpenFermion; data reordered
             # h_mol = molecule.get_molecular_hamiltonian()
@@ -435,7 +435,7 @@ def test_differentiable_hamiltonian(symbols, geometry, mapping, h_ref_data):
             # binary_code = openfermion.parity_code(molecule.n_qubits)
             # h_q = openfermion.transforms.binary_code_transform(h_f, binary_code)
             (
-                np.array(
+                pnp.array(
                     [
                         0.2981787007221673,
                         0.04256036141425139,
@@ -475,14 +475,14 @@ def test_differentiable_hamiltonian(symbols, geometry, mapping, h_ref_data):
         ),
         (
             ["H", "H"],
-            np.array([0.0, 0.0, 0.0, 0.0, 0.0, 1.0]),
+            pnp.array([0.0, 0.0, 0.0, 0.0, 0.0, 1.0]),
             "bravyi_kitaev",
             # computed with OpenFermion; data reordered
             # h_mol = molecule.get_molecular_hamiltonian()
             # h_f = openfermion.transforms.get_fermion_operator(h_mol)
             # h_q = openfermion.transforms.bravyi_kitaev(h_f)
             (
-                np.array(
+                pnp.array(
                     [
                         0.2981787007221673,
                         0.04256036141425139,
@@ -522,14 +522,14 @@ def test_differentiable_hamiltonian(symbols, geometry, mapping, h_ref_data):
         ),
         (
             ["H", "H"],
-            np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]]),
+            pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]]),
             "jordan_wigner",
             # computed with OpenFermion; data reordered
             # h_mol = molecule.get_molecular_hamiltonian()
             # h_f = openfermion.transforms.get_fermion_operator(h_mol)
             # h_q = openfermion.transforms.jordan_wigner(h_f)
             (
-                np.array(
+                pnp.array(
                     [
                         0.2981788017,
                         0.2081336485,
@@ -592,14 +592,14 @@ def test_differentiable_hamiltonian_molecule_class(symbols, geometry, mapping, h
     assert all(coeff.requires_grad is True for coeff in h_args_coeffs)
     assert all(coeff.requires_grad is False for coeff in h_noargs_coeffs)
 
-    assert np.allclose(np.sort(h_args_coeffs), np.sort(h_ref_coeffs))
-    assert qml.Hamiltonian(np.ones(len(h_args_coeffs)), h_args_ops).compare(
-        qml.Hamiltonian(np.ones(len(h_ref_coeffs)), h_ref_ops)
+    assert pnp.allclose(pnp.sort(h_args_coeffs), pnp.sort(h_ref_coeffs))
+    assert qml.Hamiltonian(pnp.ones(len(h_args_coeffs)), h_args_ops).compare(
+        qml.Hamiltonian(pnp.ones(len(h_ref_coeffs)), h_ref_ops)
     )
 
-    assert np.allclose(np.sort(h_noargs_coeffs), np.sort(h_ref_coeffs))
-    assert qml.Hamiltonian(np.ones(len(h_noargs_coeffs)), h_noargs_ops).compare(
-        qml.Hamiltonian(np.ones(len(h_ref_coeffs)), h_ref_ops)
+    assert pnp.allclose(pnp.sort(h_noargs_coeffs), pnp.sort(h_ref_coeffs))
+    assert qml.Hamiltonian(pnp.ones(len(h_noargs_coeffs)), h_noargs_ops).compare(
+        qml.Hamiltonian(pnp.ones(len(h_ref_coeffs)), h_ref_ops)
     )
 
 
@@ -615,7 +615,7 @@ def test_custom_wiremap_hamiltonian_pyscf(wiremap, tmpdir):
     r"""Test that the generated Hamiltonian has the correct wire labels given by a custom wiremap."""
 
     symbols = ["H", "H"]
-    geometry = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 2.0]])
+    geometry = pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 2.0]])
     method = "pyscf"
 
     hamiltonian, _ = qchem.molecular_hamiltonian(
@@ -641,7 +641,7 @@ def test_custom_wiremap_hamiltonian_pyscf_molecule_class(wiremap, tmpdir):
     r"""Test that the generated Hamiltonian has the correct wire labels given by a custom wiremap."""
 
     symbols = ["H", "H"]
-    geometry = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 2.0]])
+    geometry = pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 2.0]])
     method = "pyscf"
     molecule = qchem.Molecule(symbols, geometry)
     hamiltonian, _ = qchem.molecular_hamiltonian(
@@ -663,7 +663,7 @@ def test_custom_wiremap_hamiltonian_pyscf_molecule_class(wiremap, tmpdir):
         ),
         (
             [0, "z", 3, "ancilla"],
-            [np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 2.0]])],
+            [pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 2.0]])],
         ),
     ],
 )
@@ -671,7 +671,7 @@ def test_custom_wiremap_hamiltonian_dhf(wiremap, args, tmpdir):
     r"""Test that the generated Hamiltonian has the correct wire labels given by a custom wiremap."""
 
     symbols = ["H", "H"]
-    geometry = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 2.0]])
+    geometry = pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 2.0]])
     wiremap_dict = dict(zip(range(len(wiremap)), wiremap))
 
     hamiltonian_ref, _ = qchem.molecular_hamiltonian(
@@ -703,7 +703,7 @@ def test_custom_wiremap_hamiltonian_dhf(wiremap, args, tmpdir):
         ),
         (
             [0, "z", 3, "ancilla"],
-            [np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 2.0]])],
+            [pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 2.0]])],
         ),
     ],
 )
@@ -711,7 +711,7 @@ def test_custom_wiremap_hamiltonian_dhf_molecule_class(wiremap, args, tmpdir):
     r"""Test that the generated Hamiltonian has the correct wire labels given by a custom wiremap."""
 
     symbols = ["H", "H"]
-    geometry = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 2.0]])
+    geometry = pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 2.0]])
     wiremap_dict = dict(zip(range(len(wiremap)), wiremap))
 
     molecule = qchem.Molecule(symbols, geometry)
@@ -777,7 +777,7 @@ def test_diff_hamiltonian_error():
     r"""Test that molecular_hamiltonian raises an error with unsupported mapping."""
 
     symbols = ["H", "H"]
-    geometry = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 1.0])
+    geometry = pnp.array([0.0, 0.0, 0.0, 0.0, 0.0, 1.0])
 
     with pytest.raises(
         ValueError, match="Only 'dhf', 'pyscf' and 'openfermion' backends are supported"
@@ -792,7 +792,7 @@ def test_pyscf_hamiltonian_error():
     r"""Test that molecular_hamiltonian raises an error for open-shell systems."""
 
     symbols = ["H", "H"]
-    geometry = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 1.0])
+    geometry = pnp.array([0.0, 0.0, 0.0, 0.0, 0.0, 1.0])
 
     with pytest.raises(ValueError, match="Open-shell systems are not supported"):
         qchem.molecular_hamiltonian(symbols, geometry, mult=3, method="pyscf")
@@ -806,7 +806,7 @@ def test_diff_hamiltonian_error_molecule_class():
     r"""Test that molecular_hamiltonian raises an error with unsupported mapping."""
 
     symbols = ["H", "H"]
-    geometry = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 1.0])
+    geometry = pnp.array([0.0, 0.0, 0.0, 0.0, 0.0, 1.0])
 
     molecule = qchem.Molecule(symbols, geometry)
     with pytest.raises(
@@ -831,7 +831,7 @@ def test_diff_hamiltonian_error_molecule_class():
         ),
         (
             "dhf",
-            [np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 2.0]])],
+            [pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 2.0]])],
         ),
     ],
 )
@@ -840,7 +840,7 @@ def test_real_hamiltonian(method, args, tmpdir):
     r"""Test that the generated Hamiltonian has real coefficients."""
 
     symbols = ["H", "H"]
-    geometry = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 2.0]])
+    geometry = pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 2.0]])
 
     hamiltonian, _ = qchem.molecular_hamiltonian(
         symbols=symbols,
@@ -850,7 +850,7 @@ def test_real_hamiltonian(method, args, tmpdir):
         outpath=tmpdir.strpath,
     )
 
-    assert np.isrealobj(hamiltonian.terms()[0])
+    assert pnp.isrealobj(hamiltonian.terms()[0])
 
 
 @pytest.mark.parametrize(
@@ -866,7 +866,7 @@ def test_real_hamiltonian(method, args, tmpdir):
         ),
         (
             "dhf",
-            [np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 2.0]])],
+            [pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 2.0]])],
         ),
     ],
 )
@@ -875,7 +875,7 @@ def test_real_hamiltonian_molecule_class(method, args, tmpdir):
     r"""Test that the generated Hamiltonian has real coefficients."""
 
     symbols = ["H", "H"]
-    geometry = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 2.0]])
+    geometry = pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 2.0]])
 
     molecule = qchem.Molecule(symbols, geometry)
     hamiltonian, _ = qchem.molecular_hamiltonian(
@@ -885,7 +885,7 @@ def test_real_hamiltonian_molecule_class(method, args, tmpdir):
         outpath=tmpdir.strpath,
     )
 
-    assert np.isrealobj(hamiltonian.terms()[0])
+    assert pnp.isrealobj(hamiltonian.terms()[0])
 
 
 @pytest.mark.parametrize(
@@ -893,10 +893,10 @@ def test_real_hamiltonian_molecule_class(method, args, tmpdir):
     [
         (
             ["H", "H"],
-            np.array([0.0, 0.0, 0.0, 0.0, 0.0, 2.0]),
-            np.array([0.5]),
-            np.array([[-1.08269537e00, 1.88626892e-13], [1.88848936e-13, -6.04947784e-01]]),
-            np.array(
+            pnp.array([0.0, 0.0, 0.0, 0.0, 0.0, 2.0]),
+            pnp.array([0.5]),
+            pnp.array([[-1.08269537e00, 1.88626892e-13], [1.88848936e-13, -6.04947784e-01]]),
+            pnp.array(
                 [
                     [
                         [[6.16219836e-01, -1.93289829e-13], [-1.93373095e-13, 2.00522469e-01]],
@@ -917,9 +917,9 @@ def test_pyscf_integrals(symbols, geometry, core_ref, one_ref, two_ref):
 
     core, one, two = qchem.openfermion_pyscf._pyscf_integrals(symbols, geometry)
 
-    assert np.allclose(core, core_ref)
-    assert np.allclose(one, one_ref)
-    assert np.allclose(two, two_ref)
+    assert pnp.allclose(core, core_ref)
+    assert pnp.allclose(one, one_ref)
+    assert pnp.allclose(two, two_ref)
 
 
 @pytest.mark.usefixtures("skip_if_no_openfermion_support")
@@ -973,7 +973,7 @@ def test_error_raised_for_missing_molecule_information():
     [
         (
             ["H", "H", "H"],
-            np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, 2.0]]),
+            pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, 2.0]]),
             1,
             "jordan_wigner",
             # computed with OpenFermion; data reordered
@@ -981,7 +981,7 @@ def test_error_raised_for_missing_molecule_information():
             # h_f = openfermion.transforms.get_fermion_operator(h_mol)
             # h_q = openfermion.transforms.jordan_wigner(h_f)
             (
-                np.array(
+                pnp.array(
                     [
                         1.3657458030310135,
                         -0.03586487568545097,
@@ -1115,7 +1115,7 @@ def test_error_raised_for_missing_molecule_information():
         ),
         (
             ["H", "H"],
-            np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 2.0]]),
+            pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 2.0]]),
             0,
             "parity",
             # computed with OpenFermion; data reordered
@@ -1124,7 +1124,7 @@ def test_error_raised_for_missing_molecule_information():
             # binary_code = openfermion.parity_code(molecule.n_qubits)
             # h_q = openfermion.transforms.binary_code_transform(h_f, binary_code)
             (
-                np.array(
+                pnp.array(
                     [
                         -0.3596823978788041,
                         0.050130618654510024,
@@ -1164,7 +1164,7 @@ def test_error_raised_for_missing_molecule_information():
         ),
         (
             ["H", "H"],
-            np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 2.0]]),
+            pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 2.0]]),
             0,
             "bravyi_kitaev",
             # computed with OpenFermion; data reordered
@@ -1172,7 +1172,7 @@ def test_error_raised_for_missing_molecule_information():
             # h_f = openfermion.transforms.get_fermion_operator(h_mol)
             # h_q = openfermion.transforms.bravyi_kitaev(h_f)
             (
-                np.array(
+                pnp.array(
                     [
                         -0.3596823978788041,
                         0.050130618654510024,
@@ -1231,9 +1231,9 @@ def test_mapped_hamiltonian_pyscf_openfermion(
         h_ref_coeffs, h_ref_ops = h_ref.terms()
         h_coeffs, h_ops = h.terms()
 
-        assert np.allclose(np.sort(h_coeffs), np.sort(h_ref_coeffs))
-        assert qml.Hamiltonian(np.ones(len(h_coeffs)), h_ops).compare(
-            qml.Hamiltonian(np.ones(len(h_ref_coeffs)), h_ref_ops)
+        assert pnp.allclose(pnp.sort(h_coeffs), pnp.sort(h_ref_coeffs))
+        assert qml.Hamiltonian(pnp.ones(len(h_coeffs)), h_ops).compare(
+            qml.Hamiltonian(pnp.ones(len(h_ref_coeffs)), h_ref_ops)
         )
 
 
@@ -1249,8 +1249,8 @@ def test_coordinate_units_for_molecular_hamiltonian(method, tmpdir):
     r"""Test that molecular_hamiltonian generates the Hamiltonian for both Bohr and Angstrom units."""
 
     symbols = ["H", "H"]
-    geometry_bohr = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
-    geometry_ang = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 0.529177210903]])
+    geometry_bohr = pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
+    geometry_ang = pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 0.529177210903]])
 
     hamiltonian_bohr, _ = qchem.molecular_hamiltonian(
         symbols,
@@ -1282,8 +1282,8 @@ def test_coordinate_units_for_molecular_hamiltonian_molecule_class(method, tmpdi
     r"""Test that molecular_hamiltonian generates the Hamiltonian for both Bohr and Angstrom units."""
 
     symbols = ["H", "H"]
-    geometry_bohr = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
-    geometry_ang = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 0.529177210903]])
+    geometry_bohr = pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
+    geometry_ang = pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 0.529177210903]])
 
     molecule_bohr = qchem.Molecule(symbols, geometry_bohr, unit="bohr")
     hamiltonian_bohr, _ = qchem.molecular_hamiltonian(
@@ -1305,7 +1305,7 @@ def test_unit_error_molecular_hamiltonian():
     r"""Test that an error is raised if a wrong/not-supported unit for coordinates is entered."""
 
     symbols = ["H", "H"]
-    geometry = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
+    geometry = pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
 
     with pytest.raises(ValueError, match="The provided unit 'degrees' is not supported."):
         qchem.molecular_hamiltonian(symbols, geometry, unit="degrees")

--- a/tests/qchem/test_basis_set.py
+++ b/tests/qchem/test_basis_set.py
@@ -19,7 +19,7 @@ import sys
 
 import pytest
 
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane import qchem
 
 
@@ -45,13 +45,13 @@ class TestBasis:
 
         basis_function = qchem.BasisFunction(l, alpha, coeff, r)
 
-        assert np.allclose(np.array(basis_function.alpha), np.array(alpha))
-        assert np.allclose(np.array(basis_function.coeff), np.array(coeff))
-        assert np.allclose(np.array(basis_function.r), np.array(r))
+        assert pnp.allclose(pnp.array(basis_function.alpha), pnp.array(alpha))
+        assert pnp.allclose(pnp.array(basis_function.coeff), pnp.array(coeff))
+        assert pnp.allclose(pnp.array(basis_function.r), pnp.array(r))
 
-        assert np.allclose(basis_function.params[0], alpha)
-        assert np.allclose(basis_function.params[1], coeff)
-        assert np.allclose(basis_function.params[2], r)
+        assert pnp.allclose(basis_function.params[0], alpha)
+        assert pnp.allclose(basis_function.params[1], coeff)
+        assert pnp.allclose(basis_function.params[2], r)
 
     @pytest.mark.parametrize(
         ("basis_name", "atom_name", "params_ref"),
@@ -475,7 +475,7 @@ class TestBasis:
 
         assert n_basis == n_ref
 
-        assert np.allclose(params, params_ref)
+        assert pnp.allclose(params, params_ref)
 
     def test_mol_basis_data_error(self):
         """Test that correct error is raised if the element is not present in the internal basis-sets"""

--- a/tests/qchem/test_dipole.py
+++ b/tests/qchem/test_dipole.py
@@ -19,7 +19,7 @@ import pytest
 
 import pennylane as qml
 from pennylane import PauliX, PauliY, PauliZ
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane import qchem
 from pennylane.fermi import from_string
 
@@ -29,7 +29,7 @@ from pennylane.fermi import from_string
     [
         (
             ["H", "H", "H"],
-            np.array(
+            pnp.array(
                 [[0.028, 0.054, 0.0], [0.986, 1.610, 0.0], [1.855, 0.002, 0.0]], requires_grad=False
             ),
             1,
@@ -37,7 +37,7 @@ from pennylane.fermi import from_string
             None,
             [0.000, 0.000, 0.000],  # computed with PL-QChem dipole function
             # computed with PL-QChem dipole function using OpenFermion and PySCF
-            np.array(
+            pnp.array(
                 [
                     [
                         [0.95622463, -0.7827277, -0.53222294],
@@ -55,7 +55,7 @@ from pennylane.fermi import from_string
         ),
         (
             ["H", "H", "H"],
-            np.array(
+            pnp.array(
                 [[0.028, 0.054, 0.0], [0.986, 1.610, 0.0], [1.855, 0.002, 0.0]], requires_grad=True
             ),
             1,
@@ -64,7 +64,7 @@ from pennylane.fermi import from_string
             # computed manually from data obtained with PL-QChem dipole function
             [2 * 0.95622463, 2 * 0.55538736, 0.000],
             # computed manually from data obtained with PL-QChem dipole function
-            np.array(
+            pnp.array(
                 [
                     [
                         [1.42895581, -0.23469918],
@@ -87,8 +87,8 @@ def test_dipole_integrals(symbols, geometry, charge, core, active, core_ref, int
     constants, integrals = qchem.dipole_integrals(mol, core=core, active=active)(*args)
 
     for i in range(3):  # loop on x, y, z components
-        assert np.allclose(constants[i], core_ref[i])
-        assert np.allclose(integrals[i], int_ref[i])
+        assert pnp.allclose(constants[i], core_ref[i])
+        assert pnp.allclose(integrals[i], int_ref[i])
 
 
 @pytest.mark.parametrize(
@@ -96,7 +96,7 @@ def test_dipole_integrals(symbols, geometry, charge, core, active, core_ref, int
     [
         (
             ["H", "H", "H"],
-            np.array(
+            pnp.array(
                 [[0.028, 0.054, 0.0], [0.986, 1.610, 0.0], [1.855, 0.002, 0.0]], requires_grad=False
             ),
             1,
@@ -126,7 +126,7 @@ def test_dipole_integrals(symbols, geometry, charge, core, active, core_ref, int
         ),
         (
             ["H", "H", "H"],
-            np.array(
+            pnp.array(
                 [[0.028, 0.054, 0.0], [0.986, 1.610, 0.0], [1.855, 0.002, 0.0]], requires_grad=False
             ),
             1,
@@ -153,7 +153,7 @@ def test_fermionic_dipole(symbols, geometry, core, charge, active, f_ref):
     args = [p for p in [geometry] if p.requires_grad]
     f = qchem.fermionic_dipole(mol, core=core, active=active)(*args)[0]
 
-    assert np.allclose(f[0], f_ref[0])  # fermionic coefficients
+    assert pnp.allclose(f[0], f_ref[0])  # fermionic coefficients
     assert f[1] == f_ref[1]  # fermionic operators
 
 
@@ -162,13 +162,13 @@ def test_fermionic_dipole(symbols, geometry, core, charge, active, f_ref):
     [
         (
             ["H", "H"],
-            np.array([[0.0, 0.0, 0.0], [2.0, 0.0, 0.0]], requires_grad=False),
+            pnp.array([[0.0, 0.0, 0.0], [2.0, 0.0, 0.0]], requires_grad=False),
             0,
             None,
             None,
             # coefficients and operators of the dipole observable computed with
             # PL-QChem dipole function using OpenFermion and PySCF
-            np.array([0.5, 0.5, -0.5640321, -0.5640321, -0.5640321, -0.5640321, 0.5, 0.5]),
+            pnp.array([0.5, 0.5, -0.5640321, -0.5640321, -0.5640321, -0.5640321, 0.5, 0.5]),
             [
                 PauliZ(wires=[0]),
                 PauliZ(wires=[1]),
@@ -193,11 +193,11 @@ def test_dipole_moment(symbols, geometry, core, charge, active, coeffs, ops):
     d_coeff, d_ops = d.terms()
     dref_coeff, dref_ops = d_ref.terms()
 
-    assert np.allclose(sorted(d_coeff), sorted(dref_coeff))
-    assert qml.Hamiltonian(np.ones(len(d_coeff)), d_ops).compare(
-        qml.Hamiltonian(np.ones(len(dref_coeff)), dref_ops)
+    assert pnp.allclose(sorted(d_coeff), sorted(dref_coeff))
+    assert qml.Hamiltonian(pnp.ones(len(d_coeff)), d_ops).compare(
+        qml.Hamiltonian(pnp.ones(len(dref_coeff)), dref_ops)
     )
-    assert np.allclose(
+    assert pnp.allclose(
         qml.matrix(d, wire_order=[0, 1, 2, 3]),
         qml.matrix(d_ref, wire_order=[0, 1, 2, 3]),
     )
@@ -208,7 +208,7 @@ def test_dipole_moment(symbols, geometry, core, charge, active, coeffs, ops):
     [
         (
             ["H", "H"],
-            np.array([[0.0, 0.0, 0.0], [2.0, 0.0, 0.0]], requires_grad=False),
+            pnp.array([[0.0, 0.0, 0.0], [2.0, 0.0, 0.0]], requires_grad=False),
             None,
             None,
         ),
@@ -218,10 +218,10 @@ def test_dipole_moment_631g_basis(symbols, geometry, core, active):
     r"""Test that the dipole moment is constructed properly with basis sets having different numbers
     of primitive Gaussian functions."""
     alpha = [
-        np.array([18.73113696, 2.82539437, 0.64012169], requires_grad=True),
-        np.array([0.16127776], requires_grad=True),
-        np.array([18.73113696, 2.82539437, 0.64012169], requires_grad=True),
-        np.array([0.16127776], requires_grad=True),
+        pnp.array([18.73113696, 2.82539437, 0.64012169], requires_grad=True),
+        pnp.array([0.16127776], requires_grad=True),
+        pnp.array([18.73113696, 2.82539437, 0.64012169], requires_grad=True),
+        pnp.array([0.16127776], requires_grad=True),
     ]
     mol = qml.qchem.Molecule(symbols, geometry, alpha=alpha, basis_name="6-31g")
     args = [alpha]
@@ -234,7 +234,7 @@ def test_dipole_moment_631g_basis(symbols, geometry, core, active):
     [
         (
             ["H", "H", "H"],
-            np.array(
+            pnp.array(
                 [[0.028, 0.054, 0.0], [0.986, 1.610, 0.0], [1.855, 0.002, 0.0]], requires_grad=False
             ),
             1,
@@ -262,15 +262,15 @@ def test_expvalD(symbols, geometry, charge, d_ref):
 
     for i in range(3):  # loop on x, y, z components
         d = dipole(mol, i)(*args)
-        assert np.allclose(d, d_ref[i])
+        assert pnp.allclose(d, d_ref[i])
 
 
 def test_gradient_expvalD():
     r"""Test that the gradient of expval(D) computed with ``qml.grad`` is equal to the value
     obtained with the finite difference method."""
     symbols = ["H", "H", "H"]
-    geometry = np.array([[0.0, 0.0, 0.0], [1.0, 1.7, 0.0], [2.0, 0.0, 0.0]], requires_grad=False)
-    alpha = np.array(
+    geometry = pnp.array([[0.0, 0.0, 0.0], [1.0, 1.7, 0.0], [2.0, 0.0, 0.0]], requires_grad=False)
+    alpha = pnp.array(
         [
             [3.42525091, 0.62391373, 0.1688554],
             [3.42525091, 0.62391373, 0.1688554],
@@ -297,7 +297,7 @@ def test_gradient_expvalD():
 
     grad_qml = qml.grad(dipole(mol))(*args)
 
-    alpha_1 = np.array(
+    alpha_1 = pnp.array(
         [
             [3.42515091, 0.62391373, 0.1688554],
             [3.42525091, 0.62391373, 0.1688554],
@@ -306,7 +306,7 @@ def test_gradient_expvalD():
         requires_grad=False,
     )  # alpha[0][0] -= 0.0001
 
-    alpha_2 = np.array(
+    alpha_2 = pnp.array(
         [
             [3.42535091, 0.62391373, 0.1688554],
             [3.42525091, 0.62391373, 0.1688554],
@@ -320,4 +320,4 @@ def test_gradient_expvalD():
 
     grad_finitediff = (d_2 - d_1) / 0.0002
 
-    assert np.allclose(grad_qml[0][0], grad_finitediff)
+    assert pnp.allclose(grad_qml[0][0], grad_finitediff)

--- a/tests/qchem/test_factorization.py
+++ b/tests/qchem/test_factorization.py
@@ -18,7 +18,7 @@ Unit tests for functions needed for two-electron integral tensor factorization.
 import pytest
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 
 
 @pytest.mark.parametrize(
@@ -31,7 +31,7 @@ from pennylane import numpy as np
         # core, one, two = qml.qchem.electron_integrals(mol)()
         # two = np.swapaxes(two, 1, 3) # convert to chemist notation
         (
-            np.array(
+            pnp.array(
                 [
                     [
                         [[6.74755872e-01, -2.85826918e-13], [-2.85799162e-13, 6.63711349e-01]],
@@ -46,7 +46,7 @@ from pennylane import numpy as np
             1.0e-5,
             1.0e-5,
             # factors computed with openfermion (rearranged)
-            np.array(
+            pnp.array(
                 [
                     [[1.06723441e-01, 6.58493593e-17], [6.58493593e-17, -1.04898533e-01]],
                     [[-1.11022302e-16, -4.25688222e-01], [-4.25688222e-01, -1.11022302e-16]],
@@ -55,7 +55,7 @@ from pennylane import numpy as np
             ),
         ),
         (
-            np.array(
+            pnp.array(
                 [
                     [
                         [[6.74755872e-01, -2.85826918e-13], [-2.85799162e-13, 6.63711349e-01]],
@@ -69,7 +69,7 @@ from pennylane import numpy as np
             ),
             1.0e-1,
             1.0e-1,
-            np.array(
+            pnp.array(
                 [
                     [[-1.11022302e-16, -4.25688222e-01], [-4.25688222e-01, -1.11022302e-16]],
                     [[-8.14472857e-01, 1.40518540e-16], [1.40518540e-16, -8.28642144e-01]],
@@ -81,11 +81,11 @@ from pennylane import numpy as np
 def test_factorize(two_tensor, tol_f, tol_s, factors_ref):
     r"""Test that factorize function returns the correct values."""
     factors, eigvals, eigvecs = qml.qchem.factorize(two_tensor, tol_f, tol_s)
-    eigvals_ref, eigvecs_ref = np.linalg.eigh(factors_ref)
+    eigvals_ref, eigvecs_ref = pnp.linalg.eigh(factors_ref)
 
-    assert np.allclose(factors, factors_ref)
-    assert np.allclose(eigvals, np.einsum("ti,tj->tij", eigvals_ref, eigvals_ref))
-    assert np.allclose(eigvecs, eigvecs_ref)
+    assert pnp.allclose(factors, factors_ref)
+    assert pnp.allclose(eigvals, pnp.einsum("ti,tj->tij", eigvals_ref, eigvals_ref))
+    assert pnp.allclose(eigvecs, eigvecs_ref)
 
 
 @pytest.mark.parametrize(
@@ -97,7 +97,7 @@ def test_factorize(two_tensor, tol_f, tol_s, factors_ref):
         # mol = qml.qchem.Molecule(symbols, geometry, basis_name='sto-3g')
         # core, one, two = qml.qchem.electron_integrals(mol)()
         # two = np.swapaxes(two, 1, 3) # convert to chemist notation
-        np.array(
+        pnp.array(
             [
                 [
                     [[6.74755872e-01, -2.85826918e-13], [-2.85799162e-13, 6.63711349e-01]],
@@ -116,8 +116,8 @@ def test_factorize_reproduce(two_tensor):
     factors1, _, _ = qml.qchem.factorize(two_tensor, 1e-5, 1e-5, cholesky=False)
     factors2, _, _ = qml.qchem.factorize(two_tensor, 1e-5, 1e-5, cholesky=True)
 
-    assert qml.math.allclose(np.tensordot(factors1, factors1, axes=([0], [0])), two_tensor)
-    assert qml.math.allclose(np.tensordot(factors2, factors2, axes=([0], [0])), two_tensor)
+    assert qml.math.allclose(pnp.tensordot(factors1, factors1, axes=([0], [0])), two_tensor)
+    assert qml.math.allclose(pnp.tensordot(factors2, factors2, axes=([0], [0])), two_tensor)
 
 
 @pytest.mark.external
@@ -130,7 +130,7 @@ def test_factorize_reproduce(two_tensor):
         # mol = qml.qchem.Molecule(symbols, geometry, basis_name='sto-3g')
         # core, one, two = qml.qchem.electron_integrals(mol)()
         # two = np.swapaxes(two, 1, 3) # convert to chemist notation
-        np.array(
+        pnp.array(
             [
                 [
                     [[6.74755872e-01, -2.85826918e-13], [-2.85799162e-13, 6.63711349e-01]],
@@ -158,7 +158,7 @@ def test_factorize_compressed_reproduce(two_tensor, cholesky, regularization):
         optimizer=optax.adam(learning_rate=0.001),
     )
 
-    assert qml.math.allclose(np.einsum("tpqi,trsi->pqrs", factors, factors), two_tensor, atol=1e-3)
+    assert qml.math.allclose(pnp.einsum("tpqi,trsi->pqrs", factors, factors), two_tensor, atol=1e-3)
     assert qml.math.allclose(
         qml.math.einsum("tpk,tqk,tkl,trl,tsl->pqrs", leaves, leaves, cores, leaves, leaves),
         two_tensor,
@@ -176,7 +176,7 @@ def test_factorize_compressed_reproduce(two_tensor, cholesky, regularization):
         # mol = qml.qchem.Molecule(symbols, geometry, basis_name='sto-3g')
         # core, one, two = qml.qchem.electron_integrals(mol)()
         # two = np.swapaxes(two, 1, 3) # convert to chemist notation
-        np.array(
+        pnp.array(
             [
                 [
                     [[6.74755872e-01, -2.85826918e-13], [-2.85799162e-13, 6.63711349e-01]],
@@ -201,7 +201,7 @@ def test_regularization_error(two_tensor):
 @pytest.mark.parametrize(
     "two_tensor",
     [
-        np.array(
+        pnp.array(
             [
                 [6.74755872e-01, -2.85826918e-13, -2.85799162e-13, 6.63711349e-01],
                 [-2.85965696e-13, 1.81210478e-01, 1.81210478e-01, -2.63900013e-13],
@@ -221,7 +221,7 @@ def test_shape_error(two_tensor):
 @pytest.mark.parametrize(
     "two_tensor",
     [
-        np.array(
+        pnp.array(
             [
                 [
                     [[6.74755872e-01, -2.85826918e-13], [-2.85799162e-13, 6.63711349e-01]],
@@ -253,8 +253,8 @@ def test_empty_error(two_tensor):
             # geometry = np.array([[0.0, 0.0, 0.0], [1.39839789, 0.0, 0.0]], requires_grad = False)
             # mol = qml.qchem.Molecule(symbols, geometry)
             # core, one_matrix, two_tensor = qml.qchem.electron_integrals(mol)()
-            np.array([[-1.25330978e00, -2.11164419e-13], [-2.10831352e-13, -4.75068865e-01]]),
-            np.array(  # two-electron integral tensor in physicist notation
+            pnp.array([[-1.25330978e00, -2.11164419e-13], [-2.10831352e-13, -4.75068865e-01]]),
+            pnp.array(  # two-electron integral tensor in physicist notation
                 [
                     [
                         [[6.74755925e-01, 2.43333131e-13], [2.43333131e-13, 1.81210462e-01]],
@@ -268,8 +268,8 @@ def test_empty_error(two_tensor):
             ),
             1.0e-5,
             [  # computed manually, multiplied by 2 to account for spin
-                np.array([0.84064649, -2.59579282, 0.84064649, 0.45724992, 0.45724992]),
-                np.array(
+                pnp.array([0.84064649, -2.59579282, 0.84064649, 0.45724992, 0.45724992]),
+                pnp.array(
                     [
                         -9.73801723e-05,
                         5.60006390e-03,
@@ -284,7 +284,7 @@ def test_empty_error(two_tensor):
                         2.75092558e-03,
                     ]
                 ),
-                np.array(
+                pnp.array(
                     [
                         0.04530262,
                         -0.04530262,
@@ -295,7 +295,7 @@ def test_empty_error(two_tensor):
                         0.04530262,
                     ]
                 ),
-                np.array(
+                pnp.array(
                     [
                         -0.68077716,
                         1.6874169,
@@ -356,7 +356,7 @@ def test_empty_error(two_tensor):
                 ],
             ],
             [  # computed manually
-                np.array(
+                pnp.array(
                     [
                         [-1.00000000e00, 0.00000000e00, -5.71767345e-13, -0.00000000e00],
                         [0.00000000e00, 1.00000000e00, 0.00000000e00, 5.71767345e-13],
@@ -364,7 +364,7 @@ def test_empty_error(two_tensor):
                         [0.00000000e00, 5.71767345e-13, -0.00000000e00, -1.00000000e00],
                     ]
                 ),
-                np.array(
+                pnp.array(
                     [
                         [-0.0, -0.0, 0.0, -1.0],
                         [-0.0, 0.0, -1.0, 0.0],
@@ -372,7 +372,7 @@ def test_empty_error(two_tensor):
                         [-1.0, -0.0, 0.0, 0.0],
                     ]
                 ),
-                np.array(
+                pnp.array(
                     [
                         [-0.70710678, 0.0, -0.0, -0.70710678],
                         [0.0, -0.70710678, -0.70710678, 0.0],
@@ -380,7 +380,7 @@ def test_empty_error(two_tensor):
                         [0.0, 0.70710678, -0.70710678, -0.0],
                     ]
                 ),
-                np.array(
+                pnp.array(
                     [
                         [-0.0, 1.0, 0.0, 0.0],
                         [1.0, 0.0, 0.0, -0.0],
@@ -399,7 +399,7 @@ def test_basis_rotation_output(
     coeffs, ops, eigvecs = qml.qchem.basis_rotation(one_matrix, two_tensor, tol_factor)
 
     for i, coeff in enumerate(coeffs):
-        assert np.allclose(np.sort(coeff), np.sort(coeffs_ref[i]))
+        assert pnp.allclose(pnp.sort(coeff), pnp.sort(coeffs_ref[i]))
 
     for j, op in enumerate(ops):
         ops_ref_str = [qml.pauli.pauli_word_to_string(t) for t in ops_ref[j]]
@@ -411,20 +411,20 @@ def test_basis_rotation_output(
         for vec in vecs.T:
             check = False
             for rf_vec in eigvecs_ref[i].T:
-                if np.allclose(rf_vec, vec) or np.allclose(-rf_vec, vec):
+                if pnp.allclose(rf_vec, vec) or pnp.allclose(-rf_vec, vec):
                     check = True
                     break
             checks.append(check)
-        assert np.all(checks)
+        assert pnp.all(checks)
 
 
 @pytest.mark.parametrize(
     ("core", "one_electron", "two_electron"),
     [
         (
-            np.array([0.71510405]),
-            np.array([[-1.25330961e00, 4.13891144e-13], [4.14002166e-13, -4.75069041e-01]]),
-            np.array(
+            pnp.array([0.71510405]),
+            pnp.array([[-1.25330961e00, 4.13891144e-13], [4.14002166e-13, -4.75069041e-01]]),
+            pnp.array(
                 [
                     [
                         [[6.74755872e-01, -4.78089790e-13], [-4.77978768e-13, 1.81210478e-01]],
@@ -449,19 +449,19 @@ def test_basis_rotation_utransform(core, one_electron, two_electron):
     *_, u_transform = qml.qchem.basis_rotation(one_electron, two_electron)
 
     a_cr = [  # fermionic creation operators
-        np.array(
+        pnp.array(
             [[0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]]
         ),
-        np.array(
+        pnp.array(
             [[0.0, 0.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0]]
         ),
     ]
 
     a_an = [  # fermionic annihilation operators
-        np.array(
+        pnp.array(
             [[0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0], [0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0]]
         ),
-        np.array(
+        pnp.array(
             [[0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 1.0], [0.0, 0.0, 0.0, 0.0]]
         ),
     ]
@@ -469,14 +469,14 @@ def test_basis_rotation_utransform(core, one_electron, two_electron):
     # compute matrix representation of the factorized Hamiltonian. Only the one-body part is
     # included to keep the test simple.
 
-    t_matrix = one_electron - 0.5 * np.einsum("illj", two_electron)
+    t_matrix = one_electron - 0.5 * pnp.einsum("illj", two_electron)
 
     h1 = 0.0
     for i, ac in enumerate(a_cr):
         for j, aa in enumerate(a_an):
             h1 += t_matrix[i, j] * ac @ aa
 
-    h1 += np.identity(len(h1)) * core
+    h1 += pnp.identity(len(h1)) * core
 
     # compute matrix representation of the basis-rotated Hamiltonian. Only the one-body part is
     # included to keep the test simple.
@@ -497,21 +497,21 @@ def test_basis_rotation_utransform(core, one_electron, two_electron):
             aa_new += u_[i] * aa
         aa_rot.append(aa_new)
 
-    val, _ = np.linalg.eigh(t_matrix)
+    val, _ = pnp.linalg.eigh(t_matrix)
     h2 = 0.0
     for i, v in enumerate(val):
         h2 += v * ac_rot[i] @ aa_rot[i]
 
-    h2 += np.identity(len(h2)) * core
+    h2 += pnp.identity(len(h2)) * core
 
-    assert np.allclose(h1, h2)
+    assert pnp.allclose(h1, h2)
 
 
 @pytest.mark.parametrize(
     ("two_body_tensor", "spatial_basis", "one_body_correction", "chemist_two_body_coeffs"),
     [
         (
-            np.array(
+            pnp.array(
                 [
                     [
                         [[6.74755925e-01, 2.43333131e-13], [2.43333131e-13, 1.81210462e-01]],
@@ -524,13 +524,13 @@ def test_basis_rotation_utransform(core, one_electron, two_electron):
                 ]
             ),
             True,
-            np.array(
+            pnp.array(
                 [
                     [-4.27983194e-01, -2.33965625e-13],
                     [-2.33882358e-13, -4.39430980e-01],
                 ]
             ),
-            np.array(
+            pnp.array(
                 [
                     [
                         [[3.37377963e-01, 1.21666566e-13], [1.21666566e-13, 3.31855699e-01]],
@@ -544,7 +544,7 @@ def test_basis_rotation_utransform(core, one_electron, two_electron):
             ),
         ),
         (
-            np.array(
+            pnp.array(
                 [
                     [
                         [
@@ -653,7 +653,7 @@ def test_basis_rotation_utransform(core, one_electron, two_electron):
                 ]
             ),
             False,
-            np.array(
+            pnp.array(
                 [
                     [-4.27983194e-01, -0.00000000e00, -2.33965625e-13, -0.00000000e00],
                     [-0.00000000e00, -4.27983194e-01, -0.00000000e00, -2.33965625e-13],
@@ -661,7 +661,7 @@ def test_basis_rotation_utransform(core, one_electron, two_electron):
                     [-0.00000000e00, -2.33882358e-13, -0.00000000e00, -4.39430980e-01],
                 ]
             ),
-            np.array(
+            pnp.array(
                 [
                     [
                         [
@@ -781,13 +781,13 @@ def test_chemist_transform(
     one_body_corr, chemist_two_body = qml.qchem.factorization._chemist_transform(
         two_body_tensor=two_body_tensor, spatial_basis=spatial_basis
     )
-    assert np.allclose(one_body_corr, one_body_correction)
-    assert np.allclose(chemist_two_body, chemist_two_body_coeffs)
+    assert pnp.allclose(one_body_corr, one_body_correction)
+    assert pnp.allclose(chemist_two_body, chemist_two_body_coeffs)
 
     (chemist_one_body,) = qml.qchem.factorization._chemist_transform(
         one_body_tensor=one_body_correction, spatial_basis=spatial_basis
     )
-    assert np.allclose(chemist_one_body, one_body_correction)
+    assert pnp.allclose(chemist_one_body, one_body_correction)
 
     chemist_one_body, chemist_two_body = qml.qchem.factorization._chemist_transform(
         one_body_tensor=one_body_correction,
@@ -795,7 +795,7 @@ def test_chemist_transform(
         spatial_basis=spatial_basis,
     )
 
-    assert np.allclose(one_body_corr, one_body_correction)
+    assert pnp.allclose(one_body_corr, one_body_correction)
 
 
 @pytest.mark.parametrize(
@@ -815,9 +815,9 @@ def test_chemist_transform(
         # ...        break
         # -2.688647053431185
         (
-            np.array([0.14782753]),
-            np.array([[-1.55435269, 0.08134727], [0.08134727, -0.0890333]]),
-            np.array(
+            pnp.array([0.14782753]),
+            pnp.array([[-1.55435269, 0.08134727], [0.08134727, -0.0890333]]),
+            pnp.array(
                 [
                     [
                         [[0.02932015, -0.04067343], [-0.04067343, -0.02931994]],
@@ -843,6 +843,6 @@ def test_symmetry_shift(core_shifted, one_body_shifted, two_body_shifted):
     cone, ctwo = qml.qchem.factorization._chemist_transform(one, two, spatial_basis=True)
     score, sone, stwo = qml.qchem.symmetry_shift(core, cone, ctwo, n_elec=mol.n_electrons)
 
-    assert np.allclose(score, core_shifted)
-    assert np.allclose(sone, one_body_shifted)
-    assert np.allclose(stwo, two_body_shifted)
+    assert pnp.allclose(score, core_shifted)
+    assert pnp.allclose(sone, one_body_shifted)
+    assert pnp.allclose(stwo, two_body_shifted)

--- a/tests/qchem/test_hamiltonians.py
+++ b/tests/qchem/test_hamiltonians.py
@@ -19,7 +19,7 @@ import pytest
 
 import pennylane as qml
 from pennylane import I, X, Y, Z
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane import qchem
 from pennylane.fermi import from_string
 
@@ -29,14 +29,14 @@ from pennylane.fermi import from_string
     [
         (
             ["H", "H"],
-            np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False),
+            pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False),
             None,
             None,
-            np.array([1.0000000000321256]),
+            pnp.array([1.0000000000321256]),
             # computed with OpenFermion using molecule.one_body_integrals
-            np.array([[-1.39021927e00, -1.28555566e-16], [-3.52805508e-16, -2.91653305e-01]]),
+            pnp.array([[-1.39021927e00, -1.28555566e-16], [-3.52805508e-16, -2.91653305e-01]]),
             # computed with OpenFermion using molecule.two_body_integrals
-            np.array(
+            pnp.array(
                 [
                     [
                         [[7.14439079e-01, 6.62555256e-17], [2.45552260e-16, 1.70241444e-01]],
@@ -51,14 +51,14 @@ from pennylane.fermi import from_string
         ),
         (
             ["H", "H"],
-            np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False),
+            pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False),
             [],
             [0, 1],
-            np.array([1.0000000000321256]),
+            pnp.array([1.0000000000321256]),
             # computed with OpenFermion using molecule.one_body_integrals
-            np.array([[-1.39021927e00, -1.28555566e-16], [-3.52805508e-16, -2.91653305e-01]]),
+            pnp.array([[-1.39021927e00, -1.28555566e-16], [-3.52805508e-16, -2.91653305e-01]]),
             # computed with OpenFermion using molecule.two_body_integrals
-            np.array(
+            pnp.array(
                 [
                     [
                         [[7.14439079e-01, 6.62555256e-17], [2.45552260e-16, 1.70241444e-01]],
@@ -73,13 +73,13 @@ from pennylane.fermi import from_string
         ),
         (
             ["Li", "H"],
-            np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False),
+            pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False),
             [0, 1, 2, 3],
             [4, 5],
             # reference values of e_core, one and two are computed with our initial prototype code
-            np.array([-5.141222763432437]),
-            np.array([[1.17563204e00, -5.75186616e-18], [-5.75186616e-18, 1.78830226e00]]),
-            np.array(
+            pnp.array([-5.141222763432437]),
+            pnp.array([[1.17563204e00, -5.75186616e-18], [-5.75186616e-18, 1.78830226e00]]),
+            pnp.array(
                 [
                     [
                         [[3.12945511e-01, 4.79898448e-19], [4.79898448e-19, 9.78191587e-03]],
@@ -112,9 +112,9 @@ def test_electron_integrals(symbols, geometry, core, active, e_core, one_ref, tw
 
     e, one, two = qchem.electron_integrals(mol, core=core, active=active)(*args)
 
-    assert np.allclose(e, e_core)
-    assert np.allclose(one, one_ref)
-    assert np.allclose(two, two_ref)
+    assert pnp.allclose(e, e_core)
+    assert pnp.allclose(one, one_ref)
+    assert pnp.allclose(two, two_ref)
 
 
 @pytest.mark.parametrize(
@@ -129,8 +129,8 @@ def test_electron_integrals(symbols, geometry, core, active, e_core, one_ref, tw
     [
         (
             ["H", "H"],
-            np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False),
-            np.array(
+            pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False),
+            pnp.array(
                 [[3.42525091, 0.62391373, 0.1688554], [3.42525091, 0.62391373, 0.1688554]],
                 requires_grad=True,
             ),
@@ -191,7 +191,7 @@ def test_fermionic_hamiltonian(use_jax, symbols, geometry, alpha, h_ref):
 
     h.simplify(tol=1e-7)
 
-    assert np.allclose(list(h.values()), list(h_ref.values()))
+    assert pnp.allclose(list(h.values()), list(h_ref.values()))
     assert h.keys() == h_ref.keys()
 
 
@@ -207,14 +207,14 @@ def test_fermionic_hamiltonian(use_jax, symbols, geometry, alpha, h_ref):
     [
         (
             ["H", "H"],
-            np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False),
+            pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False),
             # computed with qchem.convert_observable and an OpenFermion Hamiltonian; data reordered
             # h_mol = molecule.get_molecular_hamiltonian()
             # h_f = openfermion.transforms.get_fermion_operator(h_mol)
             # h_q = openfermion.transforms.jordan_wigner(h_f)
             # h_pl = qchem.convert_observable(h_q, wires=[0, 1, 2, 3], tol=(5e-5))
             (
-                np.array(
+                pnp.array(
                     [
                         0.2981788017,
                         0.2081336485,
@@ -267,15 +267,15 @@ def test_diff_hamiltonian(use_jax, symbols, geometry, h_ref_data):
     ops = list(map(qml.simplify, h_ref_data[1]))
     h_ref_data = qml.Hamiltonian(h_ref_data[0], ops)
 
-    assert np.allclose(np.sort(h.terms()[0]), np.sort(h_ref_data.terms()[0]))
-    assert qml.Hamiltonian(np.ones(len(h.terms()[0])), h.terms()[1]).compare(
-        qml.Hamiltonian(np.ones(len(h_ref_data.terms()[0])), h_ref_data.terms()[1])
+    assert pnp.allclose(pnp.sort(h.terms()[0]), pnp.sort(h_ref_data.terms()[0]))
+    assert qml.Hamiltonian(pnp.ones(len(h.terms()[0])), h.terms()[1]).compare(
+        qml.Hamiltonian(pnp.ones(len(h_ref_data.terms()[0])), h_ref_data.terms()[1])
     )
 
     assert isinstance(h, qml.ops.Sum)
 
     wire_order = h_ref_data.wires
-    assert np.allclose(
+    assert pnp.allclose(
         qml.matrix(h, wire_order=wire_order),
         qml.matrix(h_ref_data, wire_order=wire_order),
     )
@@ -292,7 +292,7 @@ def test_diff_hamiltonian_active_space(use_jax):
     r"""Test that diff_hamiltonian works when an active space is defined."""
 
     symbols = ["H", "H", "H"]
-    geometry = np.array([[0.0, 0.0, 0.0], [2.0, 0.0, 1.0], [0.0, 2.0, 0.0]])
+    geometry = pnp.array([[0.0, 0.0, 0.0], [2.0, 0.0, 1.0], [0.0, 2.0, 0.0]])
     if use_jax:
         geometry = qml.math.array(geometry, like="jax")
 
@@ -309,14 +309,14 @@ def test_diff_hamiltonian_active_space(use_jax):
     [
         (
             ["H", "H"],
-            np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 2.0]]),
+            pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 2.0]]),
             None,
             None,
             0,
         ),
         (
             ["H", "H", "H"],
-            np.array([[0.0, 0.0, 0.0], [2.0, 0.0, 1.0], [0.0, 2.0, 0.0]]),
+            pnp.array([[0.0, 0.0, 0.0], [2.0, 0.0, 1.0], [0.0, 2.0, 0.0]]),
             [0],
             [1, 2],
             1,
@@ -348,10 +348,10 @@ def test_gradient_expvalH():
     obtained with the finite difference method."""
     symbols = ["H", "H"]
     geometry = (
-        np.array([[0.0, 0.0, -0.3674625962], [0.0, 0.0, 0.3674625962]], requires_grad=False)
+        pnp.array([[0.0, 0.0, -0.3674625962], [0.0, 0.0, 0.3674625962]], requires_grad=False)
         / 0.529177210903
     )
-    alpha = np.array(
+    alpha = pnp.array(
         [[3.42525091, 0.62391373, 0.1688554], [3.42525091, 0.62391373, 0.1688554]],
         requires_grad=True,
     )
@@ -373,12 +373,12 @@ def test_gradient_expvalH():
 
     grad_qml = qml.grad(energy(mol), argnum=0)(*args)
 
-    alpha_1 = np.array(
+    alpha_1 = pnp.array(
         [[3.42515091, 0.62391373, 0.1688554], [3.42525091, 0.62391373, 0.1688554]],
         requires_grad=False,
     )  # alpha[0][0] -= 0.0001
 
-    alpha_2 = np.array(
+    alpha_2 = pnp.array(
         [[3.42535091, 0.62391373, 0.1688554], [3.42525091, 0.62391373, 0.1688554]],
         requires_grad=False,
     )  # alpha[0][0] += 0.0001
@@ -388,7 +388,7 @@ def test_gradient_expvalH():
 
     grad_finitediff = (e_2 - e_1) / 0.0002
 
-    assert np.allclose(grad_qml[0][0], grad_finitediff)
+    assert pnp.allclose(grad_qml[0][0], grad_finitediff)
 
 
 @pytest.mark.jax

--- a/tests/qchem/test_hartree_fock.py
+++ b/tests/qchem/test_hartree_fock.py
@@ -18,7 +18,7 @@ Unit tests for Hartree-Fock functions.
 import pytest
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane import qchem
 
 
@@ -26,20 +26,20 @@ def test_scf_leaves_random_seed_unchanged():
     """Tests that the scf function leaves the global numpy sampling state unchanged."""
 
     symbols = ["H", "H"]
-    geometry = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False)
-    alpha = np.array(
+    geometry = pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False)
+    alpha = pnp.array(
         [[3.42525091, 0.62391373, 0.1688554], [3.42525091, 0.62391373, 0.1688554]],
         requires_grad=True,
     )
     mol = qchem.Molecule(symbols, geometry, alpha=alpha)
     args = [alpha]
 
-    initial_numpy_state = np.random.get_state()
+    initial_numpy_state = pnp.random.get_state()
     qchem.scf(mol)(*args)
-    final_numpy_state = np.random.get_state()
+    final_numpy_state = pnp.random.get_state()
 
     assert initial_numpy_state[0] == final_numpy_state[0]
-    assert np.all(initial_numpy_state[1] == final_numpy_state[1])
+    assert pnp.all(initial_numpy_state[1] == final_numpy_state[1])
 
 
 @pytest.mark.parametrize(
@@ -47,12 +47,12 @@ def test_scf_leaves_random_seed_unchanged():
     [
         (
             ["H", "H"],
-            np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False),
-            np.array([-0.67578019, 0.94181155]),
-            np.array([[-0.52754647, -1.56782303], [-0.52754647, 1.56782303]]),
-            np.array([[-0.51126165, -0.70283714], [-0.70283714, -0.51126165]]),
-            np.array([[-1.27848869, -1.21916299], [-1.21916299, -1.27848869]]),
-            np.array(
+            pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False),
+            pnp.array([-0.67578019, 0.94181155]),
+            pnp.array([[-0.52754647, -1.56782303], [-0.52754647, 1.56782303]]),
+            pnp.array([[-0.51126165, -0.70283714], [-0.70283714, -0.51126165]]),
+            pnp.array([[-1.27848869, -1.21916299], [-1.21916299, -1.27848869]]),
+            pnp.array(
                 [
                     [
                         [[0.77460595, 0.56886144], [0.56886144, 0.65017747]],
@@ -72,17 +72,17 @@ def test_scf(symbols, geometry, v_fock, coeffs, fock_matrix, h_core, repulsion_t
     mol = qchem.Molecule(symbols, geometry)
     v, c, f, h, e = qchem.scf(mol)()
 
-    assert np.allclose(v, v_fock)
-    assert np.allclose(c, coeffs)
-    assert np.allclose(f, fock_matrix)
-    assert np.allclose(h, h_core)
-    assert np.allclose(e, repulsion_tensor)
+    assert pnp.allclose(v, v_fock)
+    assert pnp.allclose(c, coeffs)
+    assert pnp.allclose(f, fock_matrix)
+    assert pnp.allclose(h, h_core)
+    assert pnp.allclose(e, repulsion_tensor)
 
 
 def test_scf_openshell_error():
     r"""Test that scf raises an error when an open-shell molecule is provided."""
     symbols = ["H", "H", "H"]
-    geometry = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, 2.0]], requires_grad=False)
+    geometry = pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, 2.0]], requires_grad=False)
     mol = qchem.Molecule(symbols, geometry)
 
     with pytest.raises(ValueError, match="Open-shell systems are not supported."):
@@ -94,51 +94,51 @@ def test_scf_openshell_error():
     [
         (
             ["H", "H"],
-            np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False),
+            pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False),
             0,
             "sto-3g",
             # HF energy computed with pyscf using scf.hf.SCF(mol_pyscf).kernel()
-            np.array([-1.06599931664376]),
+            pnp.array([-1.06599931664376]),
         ),
         (
             ["H", "H", "H"],
-            np.array([[0.0, 1.0, 0.0], [0.0, 0.0, 0.0], [1.0, 0.0, 0.0]], requires_grad=False),
+            pnp.array([[0.0, 1.0, 0.0], [0.0, 0.0, 0.0], [1.0, 0.0, 0.0]], requires_grad=False),
             1,
             "sto-3g",
             # HF energy computed with pyscf using scf.hf.SCF(mol_pyscf).kernel()
-            np.array([-0.948179228995941]),
+            pnp.array([-0.948179228995941]),
         ),
         (
             ["H", "F"],
-            np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False),
+            pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False),
             0,
             "sto-3g",
             # HF energy computed with pyscf using scf.hf.SCF(mol_pyscf).kernel()
-            np.array([-97.8884541671664]),
+            pnp.array([-97.8884541671664]),
         ),
         (
             ["H", "He"],
-            np.array([[1.0, 0.0, 0.0], [0.0, 0.0, 0.0]], requires_grad=False),
+            pnp.array([[1.0, 0.0, 0.0], [0.0, 0.0, 0.0]], requires_grad=False),
             1,
             "6-31G",
             # HF energy computed with pyscf using scf.hf.SCF(mol_pyscf).kernel()
-            np.array([-2.83655236013837]),
+            pnp.array([-2.83655236013837]),
         ),
         (
             ["H", "He"],
-            np.array([[1.0, 0.0, 0.0], [0.0, 0.0, 0.0]], requires_grad=False),
+            pnp.array([[1.0, 0.0, 0.0], [0.0, 0.0, 0.0]], requires_grad=False),
             1,
             "6-311G",
             # HF energy computed with pyscf using scf.hf.SCF(mol_pyscf).kernel()
-            np.array([-2.84429553346549]),
+            pnp.array([-2.84429553346549]),
         ),
         (
             ["H", "He"],
-            np.array([[1.0, 0.0, 0.0], [0.0, 0.0, 0.0]], requires_grad=False),
+            pnp.array([[1.0, 0.0, 0.0], [0.0, 0.0, 0.0]], requires_grad=False),
             1,
             "cc-pvdz",
             # HF energy computed with pyscf using scf.hf.SCF(mol_pyscf).kernel()
-            np.array([-2.84060925839206]),
+            pnp.array([-2.84060925839206]),
         ),
     ],
 )
@@ -147,7 +147,7 @@ def test_hf_energy(symbols, geometry, charge, basis_name, e_ref):
     mol = qchem.Molecule(symbols, geometry, charge=charge, basis_name=basis_name)
     e = qchem.hf_energy(mol)()
 
-    assert np.allclose(e, e_ref)
+    assert pnp.allclose(e, e_ref)
 
 
 @pytest.mark.parametrize(
@@ -155,31 +155,31 @@ def test_hf_energy(symbols, geometry, charge, basis_name, e_ref):
     [
         (
             ["H", "H"],
-            np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=True),
+            pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=True),
             [
-                np.array([3.42525091, 0.62391373, 0.1688554], requires_grad=True),
-                np.array([3.42525091, 0.62391373, 0.1688554], requires_grad=True),
+                pnp.array([3.42525091, 0.62391373, 0.1688554], requires_grad=True),
+                pnp.array([3.42525091, 0.62391373, 0.1688554], requires_grad=True),
             ],
             0,
             "sto-3g",
             # HF energy computed with pyscf using scf.hf.SCF(mol_pyscf).kernel()
-            np.array([-1.06599931664376]),
+            pnp.array([-1.06599931664376]),
         ),
         (
             ["H", "H", "H"],
-            np.array([[0.0, 1.0, 0.0], [0.0, 0.0, 0.0], [1.0, 0.0, 0.0]], requires_grad=True),
+            pnp.array([[0.0, 1.0, 0.0], [0.0, 0.0, 0.0], [1.0, 0.0, 0.0]], requires_grad=True),
             [
-                np.array([18.73113696, 2.82539437, 0.64012169], requires_grad=True),
-                np.array([0.16127776], requires_grad=True),
-                np.array([18.73113696, 2.82539437, 0.64012169], requires_grad=True),
-                np.array([0.16127776], requires_grad=True),
-                np.array([18.73113696, 2.82539437, 0.64012169], requires_grad=True),
-                np.array([0.16127776], requires_grad=True),
+                pnp.array([18.73113696, 2.82539437, 0.64012169], requires_grad=True),
+                pnp.array([0.16127776], requires_grad=True),
+                pnp.array([18.73113696, 2.82539437, 0.64012169], requires_grad=True),
+                pnp.array([0.16127776], requires_grad=True),
+                pnp.array([18.73113696, 2.82539437, 0.64012169], requires_grad=True),
+                pnp.array([0.16127776], requires_grad=True),
             ],
             1,
             "6-31g",
             # HF energy computed with pyscf using scf.hf.SCF(mol_pyscf).kernel()
-            np.array([-1.11631458846075]),
+            pnp.array([-1.11631458846075]),
         ),
     ],
 )
@@ -189,7 +189,7 @@ def test_hf_energy_diff(symbols, geometry, alpha, charge, basis_name, e_ref):
     args = [geometry, alpha]
     e = qchem.hf_energy(mol)(*args)
 
-    assert np.allclose(e, e_ref)
+    assert pnp.allclose(e, e_ref)
 
 
 @pytest.mark.parametrize(
@@ -197,15 +197,15 @@ def test_hf_energy_diff(symbols, geometry, alpha, charge, basis_name, e_ref):
     [
         (
             ["H", "H"],
-            np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=True),
+            pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=True),
             # HF gradient computed with pyscf using rnuc_grad_method().kernel()
-            np.array([[0.0, 0.0, 0.3650435], [0.0, 0.0, -0.3650435]]),
+            pnp.array([[0.0, 0.0, 0.3650435], [0.0, 0.0, -0.3650435]]),
         ),
         (
             ["H", "Li"],
-            np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 2.0]], requires_grad=True),
+            pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 2.0]], requires_grad=True),
             # HF gradient computed with pyscf using rnuc_grad_method().kernel()
-            np.array([[0.0, 0.0, 0.21034957], [0.0, 0.0, -0.21034957]]),
+            pnp.array([[0.0, 0.0, 0.21034957], [0.0, 0.0, -0.21034957]]),
         ),
     ],
 )
@@ -216,7 +216,7 @@ def test_hf_energy_gradient(symbols, geometry, g_ref):
     args = [mol.coordinates]
     g = qml.grad(qchem.hf_energy(mol))(*args)
 
-    assert np.allclose(g, g_ref)
+    assert pnp.allclose(g, g_ref)
 
 
 @pytest.mark.parametrize(
@@ -225,18 +225,18 @@ def test_hf_energy_gradient(symbols, geometry, g_ref):
         # e_repulsion = \sum_{ij} (q_i * q_j / r_{ij})
         (
             ["H", "H"],
-            np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False),
-            np.array([1.0]),
+            pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False),
+            pnp.array([1.0]),
         ),
         (
             ["H", "F"],
-            np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 2.0]], requires_grad=True),
-            np.array([4.5]),
+            pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 2.0]], requires_grad=True),
+            pnp.array([4.5]),
         ),
         (
             ["H", "O", "H"],
-            np.array([[0.0, 1.0, 0.0], [0.0, 0.0, 0.0], [1.0, 0.0, 0.0]], requires_grad=True),
-            np.array([16.707106781186546]),
+            pnp.array([[0.0, 1.0, 0.0], [0.0, 0.0, 0.0], [1.0, 0.0, 0.0]], requires_grad=True),
+            pnp.array([16.707106781186546]),
         ),
     ],
 )
@@ -245,7 +245,7 @@ def test_nuclear_energy(symbols, geometry, e_ref):
     mol = qchem.Molecule(symbols, geometry)
     args = [mol.coordinates]
     e = qchem.nuclear_energy(mol.nuclear_charges, mol.coordinates)(*args)
-    assert np.allclose(e, e_ref)
+    assert pnp.allclose(e, e_ref)
 
 
 @pytest.mark.parametrize(
@@ -254,13 +254,13 @@ def test_nuclear_energy(symbols, geometry, e_ref):
         # gradient = d(q_i * q_j / (xi - xj)) / dxi, ...
         (
             ["H", "H"],
-            np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=True),
-            np.array([[0.0, 0.0, 1.0], [0.0, 0.0, -1.0]]),
+            pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=True),
+            pnp.array([[0.0, 0.0, 1.0], [0.0, 0.0, -1.0]]),
         ),
         (
             ["H", "F"],
-            np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 2.0]], requires_grad=True),
-            np.array([[0.0, 0.0, 2.25], [0.0, 0.0, -2.25]]),
+            pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 2.0]], requires_grad=True),
+            pnp.array([[0.0, 0.0, 2.25], [0.0, 0.0, -2.25]]),
         ),
     ],
 )
@@ -269,7 +269,7 @@ def test_nuclear_energy_gradient(symbols, geometry, g_ref):
     mol = qchem.Molecule(symbols, geometry)
     args = [mol.coordinates]
     g = qml.grad(qchem.nuclear_energy(mol.nuclear_charges, mol.coordinates))(*args)
-    assert np.allclose(g, g_ref)
+    assert pnp.allclose(g, g_ref)
 
 
 @pytest.mark.jax
@@ -280,18 +280,18 @@ class TestJax:
             # e_repulsion = \sum_{ij} (q_i * q_j / r_{ij})
             (
                 ["H", "H"],
-                np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]]),
-                np.array([1.0]),
+                pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]]),
+                pnp.array([1.0]),
             ),
             (
                 ["H", "F"],
-                np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 2.0]]),
-                np.array([4.5]),
+                pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 2.0]]),
+                pnp.array([4.5]),
             ),
             (
                 ["H", "O", "H"],
-                np.array([[0.0, 1.0, 0.0], [0.0, 0.0, 0.0], [1.0, 0.0, 0.0]]),
-                np.array([16.707106781186546]),
+                pnp.array([[0.0, 1.0, 0.0], [0.0, 0.0, 0.0], [1.0, 0.0, 0.0]]),
+                pnp.array([16.707106781186546]),
             ),
         ],
     )

--- a/tests/qchem/test_integrals.py
+++ b/tests/qchem/test_integrals.py
@@ -18,7 +18,7 @@ Unit tests for functions needed to computing integrals over basis functions.
 import pytest
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane import qchem
 
 
@@ -29,12 +29,12 @@ class TestNorm:
         ("l", "alpha", "n"),
         [
             # normalization constant for an s orbital is :math:`(\frac {2 \alpha}{\pi})^{{3/4}}`.
-            ((0, 0, 0), np.array([3.425250914]), np.array([1.79444183])),
+            ((0, 0, 0), pnp.array([3.425250914]), pnp.array([1.79444183])),
         ],
     )
     def test_gaussian_norm(self, l, alpha, n):
         r"""Test that the computed normalization constant of a Gaussian function is correct."""
-        assert np.allclose(qchem.primitive_norm(l, alpha), n)
+        assert pnp.allclose(qchem.primitive_norm(l, alpha), n)
 
     @pytest.mark.parametrize(
         ("l", "alpha", "a", "n"),
@@ -43,16 +43,16 @@ class TestNorm:
             # s orbital is :math:`1/3`.
             (
                 (0, 0, 0),
-                np.array([3.425250914, 3.425250914, 3.425250914]),
-                np.array([1.79444183, 1.79444183, 1.79444183]),
-                np.array([0.33333333]),
+                pnp.array([3.425250914, 3.425250914, 3.425250914]),
+                pnp.array([1.79444183, 1.79444183, 1.79444183]),
+                pnp.array([0.33333333]),
             )
         ],
     )
     def test_contraction_norm(self, l, alpha, a, n):
         r"""Test that the computed normalization constant of a contracted Gaussian function is
         correct."""
-        assert np.allclose(qchem.contracted_norm(l, alpha, a), n)
+        assert pnp.allclose(qchem.contracted_norm(l, alpha, a), n)
 
 
 class TestParams:
@@ -62,14 +62,14 @@ class TestParams:
         ("alpha", "coeff", "r"),
         [
             (
-                np.array([3.42525091, 0.62391373, 0.1688554], requires_grad=True),
-                np.array([0.15432897, 0.53532814, 0.44463454], requires_grad=True),
-                np.array([0.0, 0.0, 0.0], requires_grad=False),
+                pnp.array([3.42525091, 0.62391373, 0.1688554], requires_grad=True),
+                pnp.array([0.15432897, 0.53532814, 0.44463454], requires_grad=True),
+                pnp.array([0.0, 0.0, 0.0], requires_grad=False),
             ),
             (
-                np.array([3.42525091, 0.62391373, 0.1688554], requires_grad=False),
-                np.array([0.15432897, 0.53532814, 0.44463454], requires_grad=False),
-                np.array([0.0, 0.0, 0.0], requires_grad=True),
+                pnp.array([3.42525091, 0.62391373, 0.1688554], requires_grad=False),
+                pnp.array([0.15432897, 0.53532814, 0.44463454], requires_grad=False),
+                pnp.array([0.0, 0.0, 0.0], requires_grad=True),
             ),
         ],
     )
@@ -79,7 +79,7 @@ class TestParams:
         args = [p for p in [alpha, coeff, r] if p.requires_grad]
         basis_params = qchem.integrals._generate_params(params, args)
 
-        assert np.allclose(basis_params, (alpha, coeff, r))
+        assert pnp.allclose(basis_params, (alpha, coeff, r))
 
 
 class TestAuxiliary:
@@ -91,66 +91,66 @@ class TestAuxiliary:
             (
                 0,
                 0,
-                np.array([1.2]),
-                np.array([1.2]),
-                np.array([3.42525091]),
-                np.array([3.42525091]),
+                pnp.array([1.2]),
+                pnp.array([1.2]),
+                pnp.array([3.42525091]),
+                pnp.array([3.42525091]),
                 0,
-                np.array([1.0]),
+                pnp.array([1.0]),
             ),
             (
                 1,
                 0,
-                np.array([0.0]),
-                np.array([0.0]),
-                np.array([3.42525091]),
-                np.array([3.42525091]),
+                pnp.array([0.0]),
+                pnp.array([0.0]),
+                pnp.array([3.42525091]),
+                pnp.array([3.42525091]),
                 0,
-                np.array([0.0]),
+                pnp.array([0.0]),
             ),
             (
                 1,
                 1,
-                np.array([0.0]),
-                np.array([10.0]),
-                np.array([3.42525091]),
-                np.array([3.42525091]),
+                pnp.array([0.0]),
+                pnp.array([10.0]),
+                pnp.array([3.42525091]),
+                pnp.array([3.42525091]),
                 0,
-                np.array([0.0]),
+                pnp.array([0.0]),
             ),
         ],
     )
     def test_expansion(self, la, lb, ra, rb, alpha, beta, t, c):
         r"""Test that expansion function returns correct value."""
-        assert np.allclose(qchem.expansion(la, lb, ra, rb, alpha, beta, t), c)
-        assert np.allclose(qchem.expansion(la, lb, ra, rb, alpha, beta, -1), np.array([0.0]))
-        assert np.allclose(qchem.expansion(0, 1, ra, rb, alpha, beta, 2), np.array([0.0]))
+        assert pnp.allclose(qchem.expansion(la, lb, ra, rb, alpha, beta, t), c)
+        assert pnp.allclose(qchem.expansion(la, lb, ra, rb, alpha, beta, -1), pnp.array([0.0]))
+        assert pnp.allclose(qchem.expansion(0, 1, ra, rb, alpha, beta, 2), pnp.array([0.0]))
 
     @pytest.mark.parametrize(
         ("n", "t", "f_ref"),
-        [(2.75, np.array([0.0, 1.23]), np.array([0.15384615384615385, 0.061750771828252976]))],
+        [(2.75, pnp.array([0.0, 1.23]), pnp.array([0.15384615384615385, 0.061750771828252976]))],
     )
     def test_boys(self, n, t, f_ref):
         r"""Test that the Boys function is evaluated correctly."""
         f = qchem.integrals._boys(n, t)
-        assert np.allclose(f, f_ref)
+        assert pnp.allclose(f, f_ref)
 
     @pytest.mark.parametrize(
         ("t", "u", "v", "n", "p", "dr", "h_ref"),
         [
-            (0, 0, 0, 0, 6.85050183, np.array([0.0, 0.0, 0.0]), 1.0),
-            (0, 0, 1, 0, 6.85050183, np.array([0.0, 0.0, 0.0]), 0.0),
-            (0, 0, 2, 0, 6.85050183, np.array([0.0, 0.0, 0.0]), -4.56700122),
-            (0, 2, 0, 0, 6.85050183, np.array([0.0, 0.0, 0.0]), -4.56700122),
-            (0, 1, 0, 0, 6.85050183, np.array([0.0, 0.0, 0.0]), 0.0),
-            (2, 1, 0, 0, 6.85050183, np.array([0.0, 0.0, 0.0]), 0.0),
-            (1, 1, 0, 0, 6.85050183, np.array([0.0, 0.0, 0.0]), 0.0),
+            (0, 0, 0, 0, 6.85050183, pnp.array([0.0, 0.0, 0.0]), 1.0),
+            (0, 0, 1, 0, 6.85050183, pnp.array([0.0, 0.0, 0.0]), 0.0),
+            (0, 0, 2, 0, 6.85050183, pnp.array([0.0, 0.0, 0.0]), -4.56700122),
+            (0, 2, 0, 0, 6.85050183, pnp.array([0.0, 0.0, 0.0]), -4.56700122),
+            (0, 1, 0, 0, 6.85050183, pnp.array([0.0, 0.0, 0.0]), 0.0),
+            (2, 1, 0, 0, 6.85050183, pnp.array([0.0, 0.0, 0.0]), 0.0),
+            (1, 1, 0, 0, 6.85050183, pnp.array([0.0, 0.0, 0.0]), 0.0),
         ],
     )
     def test_hermite_coulomb(self, t, u, v, n, p, dr, h_ref):
         r"""Test that the _hermite_coulomb function returns a correct value."""
         h = qchem.integrals._hermite_coulomb(t, u, v, n, p, dr)
-        assert np.allclose(h, h_ref)
+        assert pnp.allclose(h, h_ref)
 
     @pytest.mark.parametrize(
         ("n", "result"),
@@ -180,80 +180,80 @@ class TestOverlap:
             (
                 (0, 0, 0),
                 (0, 0, 0),
-                np.array([0.0, 0.0, 0.0]),
-                np.array([0.0, 0.0, 0.0]),
-                np.array([np.pi / 2]),
-                np.array([np.pi / 2]),
-                np.array([1.0]),
+                pnp.array([0.0, 0.0, 0.0]),
+                pnp.array([0.0, 0.0, 0.0]),
+                pnp.array([pnp.pi / 2]),
+                pnp.array([pnp.pi / 2]),
+                pnp.array([1.0]),
             ),
             (
                 (0, 0, 0),
                 (0, 0, 0),
-                np.array([0.0, 0.0, 0.0]),
-                np.array([20.0, 0.0, 0.0]),
-                np.array([3.42525091]),
-                np.array([3.42525091]),
-                np.array([0.0]),
+                pnp.array([0.0, 0.0, 0.0]),
+                pnp.array([20.0, 0.0, 0.0]),
+                pnp.array([3.42525091]),
+                pnp.array([3.42525091]),
+                pnp.array([0.0]),
             ),
             (
                 (1, 0, 0),
                 (0, 0, 1),
-                np.array([0.0, 0.0, 0.0]),
-                np.array([0.0, 0.0, 0.0]),
-                np.array([6.46480325]),
-                np.array([6.46480325]),
-                np.array([0.0]),
+                pnp.array([0.0, 0.0, 0.0]),
+                pnp.array([0.0, 0.0, 0.0]),
+                pnp.array([6.46480325]),
+                pnp.array([6.46480325]),
+                pnp.array([0.0]),
             ),
         ],
     )
     def test_gaussian_overlap(self, la, lb, ra, rb, alpha, beta, o):
         r"""Test that gaussian overlap function returns a correct value."""
-        assert np.allclose(qchem.gaussian_overlap(la, lb, ra, rb, alpha, beta), o)
+        assert pnp.allclose(qchem.gaussian_overlap(la, lb, ra, rb, alpha, beta), o)
 
     @pytest.mark.parametrize(
         ("symbols", "geometry", "alpha", "coef", "r", "o_ref"),
         [
             (
                 ["H", "H"],
-                np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 20.0]], requires_grad=False),
-                np.array(
+                pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 20.0]], requires_grad=False),
+                pnp.array(
                     [[3.42525091, 0.62391373, 0.1688554], [3.42525091, 0.62391373, 0.1688554]],
                     requires_grad=False,
                 ),
-                np.array(
+                pnp.array(
                     [[0.15432897, 0.53532814, 0.44463454], [0.15432897, 0.53532814, 0.44463454]],
                     requires_grad=True,
                 ),
-                np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 20.0]], requires_grad=True),
-                np.array([0.0]),
+                pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 20.0]], requires_grad=True),
+                pnp.array([0.0]),
             ),
             (
                 ["H", "H"],
-                np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]], requires_grad=False),
-                np.array(
+                pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]], requires_grad=False),
+                pnp.array(
                     [[3.42525091, 0.62391373, 0.1688554], [3.42525091, 0.62391373, 0.1688554]],
                     requires_grad=False,
                 ),
-                np.array(
+                pnp.array(
                     [[0.15432897, 0.53532814, 0.44463454], [0.15432897, 0.53532814, 0.44463454]],
                     requires_grad=False,
                 ),
-                np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]], requires_grad=True),
-                np.array([1.0]),
+                pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]], requires_grad=True),
+                pnp.array([1.0]),
             ),
             (
                 ["H", "H"],
-                np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]], requires_grad=True),
-                np.array(
+                pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]], requires_grad=True),
+                pnp.array(
                     [[3.42525091, 0.62391373, 0.1688554], [3.42525091, 0.62391373, 0.1688554]],
                     requires_grad=True,
                 ),
-                np.array(
+                pnp.array(
                     [[0.15432897, 0.53532814, 0.44463454], [0.15432897, 0.53532814, 0.44463454]],
                     requires_grad=True,
                 ),
-                np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]], requires_grad=True),
-                np.array([1.0]),
+                pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]], requires_grad=True),
+                pnp.array([1.0]),
             ),
         ],
     )
@@ -265,19 +265,19 @@ class TestOverlap:
         args = [p for p in [alpha, coef, r] if p.requires_grad]
 
         o = qchem.overlap_integral(basis_a, basis_b)(*args)
-        assert np.allclose(o, o_ref)
+        assert pnp.allclose(o, o_ref)
 
     @pytest.mark.parametrize(
         ("symbols", "geometry", "alpha", "coeff"),
         [
             (
                 ["H", "H"],
-                np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False),
-                np.array(
+                pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False),
+                pnp.array(
                     [[3.42525091, 0.62391373, 0.1688554], [3.42525091, 0.62391373, 0.1688554]],
                     requires_grad=True,
                 ),
-                np.array(
+                pnp.array(
                     [[0.15432897, 0.53532814, 0.44463454], [0.15432897, 0.53532814, 0.44463454]],
                     requires_grad=True,
                 ),
@@ -297,8 +297,8 @@ class TestOverlap:
 
         # compute overlap gradients with respect to alpha and coeff using finite diff
         delta = 0.0001
-        g_ref_alpha = np.zeros(6).reshape(alpha.shape)
-        g_ref_coeff = np.zeros(6).reshape(coeff.shape)
+        g_ref_alpha = pnp.zeros(6).reshape(alpha.shape)
+        g_ref_coeff = pnp.zeros(6).reshape(coeff.shape)
 
         for i in range(len(alpha)):
             for j in range(len(alpha[0])):
@@ -318,8 +318,8 @@ class TestOverlap:
                 o_plus = qchem.overlap_integral(basis_a, basis_b)(*[alpha, coeff_plus])
                 g_ref_coeff[i][j] = (o_plus - o_minus) / (2 * delta)
 
-        assert np.allclose(g_alpha, g_ref_alpha)
-        assert np.allclose(g_coeff, g_ref_coeff)
+        assert pnp.allclose(g_alpha, g_ref_alpha)
+        assert pnp.allclose(g_coeff, g_ref_coeff)
 
 
 class TestMoment:
@@ -329,42 +329,42 @@ class TestMoment:
         ("alpha", "beta", "t", "e", "rc", "ref"),
         [
             (  # trivial case, ref = 0.0 for t > e
-                np.array([3.42525091]),
-                np.array([3.42525091]),
+                pnp.array([3.42525091]),
+                pnp.array([3.42525091]),
                 2,
                 1,
-                np.array([1.5]),
-                np.array([0.0]),
+                pnp.array([1.5]),
+                pnp.array([0.0]),
             ),
             (  # trivial case, ref = 0.0 for e == 0 and t != 0
-                np.array([3.42525091]),
-                np.array([3.42525091]),
+                pnp.array([3.42525091]),
+                pnp.array([3.42525091]),
                 -1,
                 0,
-                np.array([1.5]),
-                np.array([0.0]),
+                pnp.array([1.5]),
+                pnp.array([0.0]),
             ),
             (  # trivial case, ref = np.sqrt(np.pi / (alpha + beta))
-                np.array([3.42525091]),
-                np.array([3.42525091]),
+                pnp.array([3.42525091]),
+                pnp.array([3.42525091]),
                 0,
                 0,
-                np.array([1.5]),
-                np.array([0.677195]),
+                pnp.array([1.5]),
+                pnp.array([0.677195]),
             ),
             (  # manually computed, ref = 1.0157925
-                np.array([3.42525091]),
-                np.array([3.42525091]),
+                pnp.array([3.42525091]),
+                pnp.array([3.42525091]),
                 0,
                 1,
-                np.array([1.5]),
-                np.array([1.0157925]),
+                pnp.array([1.5]),
+                pnp.array([1.0157925]),
             ),
         ],
     )
     def test_hermite_moment(self, alpha, beta, t, e, rc, ref):
         r"""Test that hermite_moment function returns correct values."""
-        assert np.allclose(qchem.hermite_moment(alpha, beta, t, e, rc), ref)
+        assert pnp.allclose(qchem.hermite_moment(alpha, beta, t, e, rc), ref)
 
     @pytest.mark.parametrize(
         ("la", "lb", "ra", "rb", "alpha", "beta", "e", "rc", "ref"),
@@ -372,40 +372,40 @@ class TestMoment:
             (  # manually computed, ref = 1.0157925
                 0,
                 0,
-                np.array([2.0]),
-                np.array([2.0]),
-                np.array([3.42525091]),
-                np.array([3.42525091]),
+                pnp.array([2.0]),
+                pnp.array([2.0]),
+                pnp.array([3.42525091]),
+                pnp.array([3.42525091]),
                 1,
-                np.array([1.5]),
-                np.array([1.0157925]),
+                pnp.array([1.5]),
+                pnp.array([1.0157925]),
             ),
         ],
     )
     def test_gaussian_moment(self, la, lb, ra, rb, alpha, beta, e, rc, ref):
         r"""Test that gaussian_moment function returns correct values."""
-        assert np.allclose(qchem.gaussian_moment(la, lb, ra, rb, alpha, beta, e, rc), ref)
+        assert pnp.allclose(qchem.gaussian_moment(la, lb, ra, rb, alpha, beta, e, rc), ref)
 
     @pytest.mark.parametrize(
         ("symbols", "geometry", "e", "idx", "ref"),
         [
             (
                 ["H", "Li"],
-                np.array([[0.0, 0.0, 0.0], [2.0, 0.0, 0.0]], requires_grad=False),
+                pnp.array([[0.0, 0.0, 0.0], [2.0, 0.0, 0.0]], requires_grad=False),
                 1,
                 0,  # 'x' component
                 3.12846324e-01,  # obtained from pyscf using mol.intor_symmetric("int1e_r")
             ),
             (
                 ["H", "Li"],
-                np.array([[0.5, 0.1, -0.2], [2.1, -0.3, 0.1]], requires_grad=True),
+                pnp.array([[0.5, 0.1, -0.2], [2.1, -0.3, 0.1]], requires_grad=True),
                 1,
                 0,  # 'x' component
                 4.82090830e-01,  # obtained from pyscf using mol.intor_symmetric("int1e_r")
             ),
             (
                 ["N", "N"],
-                np.array([[0.5, 0.1, -0.2], [2.1, -0.3, 0.1]], requires_grad=False),
+                pnp.array([[0.5, 0.1, -0.2], [2.1, -0.3, 0.1]], requires_grad=False),
                 1,
                 2,  # 'z' component
                 -4.70075530e-02,  # obtained from pyscf using mol.intor_symmetric("int1e_r")
@@ -420,19 +420,19 @@ class TestMoment:
         args = [p for p in [geometry] if p.requires_grad]
         s = qchem.moment_integral(basis_a, basis_b, e, idx, normalize=False)(*args)
 
-        assert np.allclose(s, ref)
+        assert pnp.allclose(s, ref)
 
     @pytest.mark.parametrize(
         ("symbols", "geometry", "alpha", "coeff", "e", "idx"),
         [
             (
                 ["H", "H"],
-                np.array([[0.1, 0.2, 0.3], [2.0, 0.1, 0.2]], requires_grad=False),
-                np.array(
+                pnp.array([[0.1, 0.2, 0.3], [2.0, 0.1, 0.2]], requires_grad=False),
+                pnp.array(
                     [[3.42525091, 0.62391373, 0.1688554], [3.42525091, 0.62391373, 0.1688554]],
                     requires_grad=True,
                 ),
-                np.array(
+                pnp.array(
                     [[0.15432897, 0.53532814, 0.44463454], [0.15432897, 0.53532814, 0.44463454]],
                     requires_grad=True,
                 ),
@@ -454,8 +454,8 @@ class TestMoment:
 
         # compute moment gradients with respect to alpha and coeff using finite diff
         delta = 0.0001
-        g_ref_alpha = np.zeros(6).reshape(alpha.shape)
-        g_ref_coeff = np.zeros(6).reshape(coeff.shape)
+        g_ref_alpha = pnp.zeros(6).reshape(alpha.shape)
+        g_ref_coeff = pnp.zeros(6).reshape(coeff.shape)
 
         for i in range(len(alpha)):
             for j in range(len(alpha[0])):
@@ -475,8 +475,8 @@ class TestMoment:
                 o_plus = qchem.moment_integral(basis_a, basis_b, e, idx)(*[alpha, coeff_plus])
                 g_ref_coeff[i][j] = (o_plus - o_minus) / (2 * delta)
 
-        assert np.allclose(g_alpha, g_ref_alpha)
-        assert np.allclose(g_coeff, g_ref_coeff)
+        assert pnp.allclose(g_alpha, g_ref_alpha)
+        assert pnp.allclose(g_coeff, g_ref_coeff)
 
 
 class TestKinetic:
@@ -489,27 +489,27 @@ class TestKinetic:
             (
                 0,
                 1,
-                np.array([0.0]),
-                np.array([20.0]),
-                np.array([3.42525091]),
-                np.array([3.42525091]),
-                np.array([0.0]),
+                pnp.array([0.0]),
+                pnp.array([20.0]),
+                pnp.array([3.42525091]),
+                pnp.array([3.42525091]),
+                pnp.array([0.0]),
             ),
             # computed manually
             (
                 0,
                 0,
-                np.array([0.0]),
-                np.array([1.0]),
-                np.array([3.42525091]),
-                np.array([3.42525091]),
-                np.array([1.01479665]),
+                pnp.array([0.0]),
+                pnp.array([1.0]),
+                pnp.array([3.42525091]),
+                pnp.array([3.42525091]),
+                pnp.array([1.01479665]),
             ),
         ],
     )
     def test_diff2(self, i, j, ri, rj, alpha, beta, d):
         r"""Test that _diff2 function returns a correct value."""
-        assert np.allclose(qchem.integrals._diff2(i, j, ri, rj, alpha, beta), d)
+        assert pnp.allclose(qchem.integrals._diff2(i, j, ri, rj, alpha, beta), d)
 
     @pytest.mark.parametrize(
         ("la", "lb", "ra", "rb", "alpha", "beta", "t"),
@@ -518,17 +518,17 @@ class TestKinetic:
             (
                 (0, 0, 0),
                 (0, 0, 0),
-                np.array([0.0, 0.0, 0.0]),
-                np.array([20.0, 0.0, 0.0]),
-                np.array([3.42525091]),
-                np.array([3.42525091]),
-                np.array([0.0]),
+                pnp.array([0.0, 0.0, 0.0]),
+                pnp.array([20.0, 0.0, 0.0]),
+                pnp.array([3.42525091]),
+                pnp.array([3.42525091]),
+                pnp.array([0.0]),
             ),
         ],
     )
     def test_gaussian_kinetic(self, la, lb, ra, rb, alpha, beta, t):
         r"""Test that gaussian_kinetic function returns a correct value."""
-        assert np.allclose(qchem.gaussian_kinetic(la, lb, ra, rb, alpha, beta), t)
+        assert pnp.allclose(qchem.gaussian_kinetic(la, lb, ra, rb, alpha, beta), t)
 
     @pytest.mark.parametrize(
         ("symbols", "geometry", "alpha", "coeff", "t_ref"),
@@ -536,30 +536,30 @@ class TestKinetic:
             # kinetic_integral must return 0.0 for two Gaussians centered far apart
             (
                 ["H", "H"],
-                np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 20.0]], requires_grad=False),
-                np.array(
+                pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 20.0]], requires_grad=False),
+                pnp.array(
                     [[3.42525091, 0.62391373, 0.1688554], [3.42525091, 0.62391373, 0.1688554]],
                     requires_grad=False,
                 ),
-                np.array(
+                pnp.array(
                     [[0.15432897, 0.53532814, 0.44463454], [0.15432897, 0.53532814, 0.44463454]],
                     requires_grad=True,
                 ),
-                np.array([0.0]),
+                pnp.array([0.0]),
             ),
             # kinetic integral obtained from pyscf using mol.intor('int1e_kin')
             (
                 ["H", "H"],
-                np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False),
-                np.array(
+                pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False),
+                pnp.array(
                     [[3.42525091, 0.62391373, 0.1688554], [3.42525091, 0.62391373, 0.1688554]],
                     requires_grad=False,
                 ),
-                np.array(
+                pnp.array(
                     [[0.15432897, 0.53532814, 0.44463454], [0.15432897, 0.53532814, 0.44463454]],
                     requires_grad=True,
                 ),
-                np.array([0.38325384]),
+                pnp.array([0.38325384]),
             ),
         ],
     )
@@ -571,19 +571,19 @@ class TestKinetic:
         args = [p for p in [alpha, coeff] if p.requires_grad]
 
         t = qchem.kinetic_integral(basis_a, basis_b)(*args)
-        assert np.allclose(t, t_ref)
+        assert pnp.allclose(t, t_ref)
 
     @pytest.mark.parametrize(
         ("symbols", "geometry", "alpha", "coeff"),
         [
             (
                 ["H", "H"],
-                np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False),
-                np.array(
+                pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False),
+                pnp.array(
                     [[3.42525091, 0.62391373, 0.1688554], [3.42525091, 0.62391373, 0.1688554]],
                     requires_grad=True,
                 ),
-                np.array(
+                pnp.array(
                     [[0.15432897, 0.53532814, 0.44463454], [0.15432897, 0.53532814, 0.44463454]],
                     requires_grad=True,
                 ),
@@ -603,8 +603,8 @@ class TestKinetic:
 
         # compute kinetic gradients with respect to alpha, coeff and r using finite diff
         delta = 0.0001
-        g_ref_alpha = np.zeros(6).reshape(alpha.shape)
-        g_ref_coeff = np.zeros(6).reshape(coeff.shape)
+        g_ref_alpha = pnp.zeros(6).reshape(alpha.shape)
+        g_ref_coeff = pnp.zeros(6).reshape(coeff.shape)
 
         for i in range(len(alpha)):
             for j in range(len(alpha[0])):
@@ -624,8 +624,8 @@ class TestKinetic:
                 t_plus = qchem.kinetic_integral(basis_a, basis_b)(*[alpha, coeff_plus])
                 g_ref_coeff[i][j] = (t_plus - t_minus) / (2 * delta)
 
-        assert np.allclose(g_alpha, g_ref_alpha)
-        assert np.allclose(g_coeff, g_ref_coeff)
+        assert pnp.allclose(g_alpha, g_ref_alpha)
+        assert pnp.allclose(g_coeff, g_ref_coeff)
 
 
 class TestAttraction:
@@ -637,30 +637,30 @@ class TestAttraction:
             # trivial case: integral should be zero since atoms are located very far apart
             (
                 ["H", "H"],
-                np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 20.0]], requires_grad=False),
-                np.array(
+                pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 20.0]], requires_grad=False),
+                pnp.array(
                     [[3.42525091, 0.62391373, 0.1688554], [3.42525091, 0.62391373, 0.1688554]],
                     requires_grad=True,
                 ),
-                np.array(
+                pnp.array(
                     [[0.15432897, 0.53532814, 0.44463454], [0.15432897, 0.53532814, 0.44463454]],
                     requires_grad=True,
                 ),
-                np.array([0.0]),
+                pnp.array([0.0]),
             ),
             # nuclear attraction integral obtained from pyscf using mol.intor('int1e_nuc')
             (
                 ["H", "H"],
-                np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=True),
-                np.array(
+                pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=True),
+                pnp.array(
                     [[3.42525091, 0.62391373, 0.1688554], [3.42525091, 0.62391373, 0.1688554]],
                     requires_grad=True,
                 ),
-                np.array(
+                pnp.array(
                     [[0.15432897, 0.53532814, 0.44463454], [0.15432897, 0.53532814, 0.44463454]],
                     requires_grad=True,
                 ),
-                np.array([0.80120855]),
+                pnp.array([0.80120855]),
             ),
         ],
     )
@@ -676,19 +676,19 @@ class TestAttraction:
             args = [geometry[0]] + args + [geometry]
 
         a = qchem.attraction_integral(geometry[0], basis_a, basis_b)(*args)
-        assert np.allclose(a, a_ref)
+        assert pnp.allclose(a, a_ref)
 
     @pytest.mark.parametrize(
         ("symbols", "geometry", "alpha", "coeff"),
         [
             (
                 ["H", "H"],
-                np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False),
-                np.array(
+                pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False),
+                pnp.array(
                     [[3.42525091, 0.62391373, 0.1688554], [3.42525091, 0.62391373, 0.1688554]],
                     requires_grad=True,
                 ),
-                np.array(
+                pnp.array(
                     [[0.15432897, 0.53532814, 0.44463454], [0.15432897, 0.53532814, 0.44463454]],
                     requires_grad=True,
                 ),
@@ -709,8 +709,8 @@ class TestAttraction:
 
         # compute attraction gradients with respect to alpha and coeff using finite diff
         delta = 0.0001
-        g_ref_alpha = np.zeros(6).reshape(alpha.shape)
-        g_ref_coeff = np.zeros(6).reshape(coeff.shape)
+        g_ref_alpha = pnp.zeros(6).reshape(alpha.shape)
+        g_ref_coeff = pnp.zeros(6).reshape(coeff.shape)
 
         for i in range(len(alpha)):
             for j in range(len(alpha[0])):
@@ -730,8 +730,8 @@ class TestAttraction:
                 a_plus = qchem.attraction_integral(r_nuc, basis_a, basis_b)(*[alpha, coeff_plus])
                 g_ref_coeff[i][j] = (a_plus - a_minus) / (2 * delta)
 
-        assert np.allclose(g_alpha, g_ref_alpha)
-        assert np.allclose(g_coeff, g_ref_coeff)
+        assert pnp.allclose(g_alpha, g_ref_alpha)
+        assert pnp.allclose(g_coeff, g_ref_coeff)
 
 
 class TestRepulsion:
@@ -742,8 +742,8 @@ class TestRepulsion:
         [
             (
                 ["H", "H"],
-                np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 20.0]], requires_grad=False),
-                np.array(
+                pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 20.0]], requires_grad=False),
+                pnp.array(
                     [
                         [3.42525091, 0.62391373, 0.1688554],
                         [3.42525091, 0.62391373, 0.1688554],
@@ -752,7 +752,7 @@ class TestRepulsion:
                     ],
                     requires_grad=False,
                 ),
-                np.array(
+                pnp.array(
                     [
                         [0.15432897, 0.53532814, 0.44463454],
                         [0.15432897, 0.53532814, 0.44463454],
@@ -761,12 +761,12 @@ class TestRepulsion:
                     ],
                     requires_grad=True,
                 ),
-                np.array([0.0]),
+                pnp.array([0.0]),
             ),
             (
                 ["H", "H"],
-                np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False),
-                np.array(
+                pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False),
+                pnp.array(
                     [
                         [3.42525091, 0.62391373, 0.1688554],
                         [3.42525091, 0.62391373, 0.1688554],
@@ -775,7 +775,7 @@ class TestRepulsion:
                     ],
                     requires_grad=False,
                 ),
-                np.array(
+                pnp.array(
                     [
                         [0.15432897, 0.53532814, 0.44463454],
                         [0.15432897, 0.53532814, 0.44463454],
@@ -784,7 +784,7 @@ class TestRepulsion:
                     ],
                     requires_grad=True,
                 ),
-                np.array([0.45590169]),
+                pnp.array([0.45590169]),
             ),
         ],
     )
@@ -798,15 +798,15 @@ class TestRepulsion:
 
         a = qchem.repulsion_integral(basis_a, basis_b, basis_a, basis_b)(*args)
 
-        assert np.allclose(a, e_ref)
+        assert pnp.allclose(a, e_ref)
 
     @pytest.mark.parametrize(
         ("symbols", "geometry", "alpha", "coeff"),
         [
             (
                 ["H", "H"],
-                np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False),
-                np.array(
+                pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False),
+                pnp.array(
                     [
                         [3.42525091, 0.62391373, 0.1688554],
                         [3.42525091, 0.62391373, 0.1688554],
@@ -815,7 +815,7 @@ class TestRepulsion:
                     ],
                     requires_grad=True,
                 ),
-                np.array(
+                pnp.array(
                     [
                         [0.15432897, 0.53532814, 0.44463454],
                         [0.15432897, 0.53532814, 0.44463454],
@@ -844,8 +844,8 @@ class TestRepulsion:
 
         # compute repulsion gradients with respect to alpha and coeff using finite diff
         delta = 0.0001
-        g_ref_alpha = np.zeros(12).reshape(alpha.shape)
-        g_ref_coeff = np.zeros(12).reshape(coeff.shape)
+        g_ref_alpha = pnp.zeros(12).reshape(alpha.shape)
+        g_ref_coeff = pnp.zeros(12).reshape(coeff.shape)
 
         for i in range(len(alpha)):
             for j in range(len(alpha[0])):
@@ -872,8 +872,8 @@ class TestRepulsion:
                 )
                 g_ref_coeff[i][j] = (e_plus - e_minus) / (2 * delta)
 
-        assert np.allclose(g_alpha, g_ref_alpha)
-        assert np.allclose(g_coeff, g_ref_coeff)
+        assert pnp.allclose(g_alpha, g_ref_alpha)
+        assert pnp.allclose(g_coeff, g_ref_coeff)
 
 
 def generate_symbols_alpha_coeff():
@@ -1016,12 +1016,12 @@ class TestJax:
         [
             (
                 ["H", "H"],
-                np.array([[0.1, 0.2, 0.3], [2.0, 0.1, 0.2]], requires_grad=False),
-                np.array(
+                pnp.array([[0.1, 0.2, 0.3], [2.0, 0.1, 0.2]], requires_grad=False),
+                pnp.array(
                     [[3.42525091, 0.62391373, 0.1688554], [3.42525091, 0.62391373, 0.1688554]],
                     requires_grad=True,
                 ),
-                np.array(
+                pnp.array(
                     [[0.15432897, 0.53532814, 0.44463454], [0.15432897, 0.53532814, 0.44463454]],
                     requires_grad=True,
                 ),

--- a/tests/qchem/test_matrices.py
+++ b/tests/qchem/test_matrices.py
@@ -18,7 +18,7 @@ Unit tests for functions needed for computing matrices.
 import pytest
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane import qchem
 
 
@@ -30,16 +30,16 @@ class TestMoldensMat:
         [
             (
                 2,
-                np.array([[-0.54828771, 1.21848441], [-0.54828771, -1.21848441]]),
+                pnp.array([[-0.54828771, 1.21848441], [-0.54828771, -1.21848441]]),
                 # all P elements are computed as 0.54828771**2 = 0.3006194129370441
-                np.array([[0.30061941, 0.30061941], [0.30061941, 0.30061941]]),
+                pnp.array([[0.30061941, 0.30061941], [0.30061941, 0.30061941]]),
             ),
         ],
     )
     def test_molecular_density_matrix(self, n_electron, c, p_ref):
         r"""Test that molecular_density_matrix returns the correct matrix."""
         p = qchem.mol_density_matrix(n_electron, c)
-        assert np.allclose(p, p_ref)
+        assert pnp.allclose(p, p_ref)
 
 
 class TestOverlapMat:
@@ -50,12 +50,12 @@ class TestOverlapMat:
         [
             (
                 ["H", "H"],
-                np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False),
-                np.array(
+                pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False),
+                pnp.array(
                     [[3.42525091, 0.62391373, 0.1688554], [3.42525091, 0.62391373, 0.1688554]],
                     requires_grad=True,
                 ),
-                np.array([[1.0, 0.7965883009074122], [0.7965883009074122, 1.0]]),
+                pnp.array([[1.0, 0.7965883009074122], [0.7965883009074122, 1.0]]),
             )
         ],
     )
@@ -64,15 +64,15 @@ class TestOverlapMat:
         mol = qchem.Molecule(symbols, geometry, alpha=alpha)
         args = [alpha]
         s = qchem.overlap_matrix(mol.basis_set)(*args)
-        assert np.allclose(s, s_ref)
+        assert pnp.allclose(s, s_ref)
 
     @pytest.mark.parametrize(
         ("symbols", "geometry", "s_ref"),
         [
             (
                 ["H", "H"],
-                np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False),
-                np.array([[1.0, 0.7965883009074122], [0.7965883009074122, 1.0]]),
+                pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False),
+                pnp.array([[1.0, 0.7965883009074122], [0.7965883009074122, 1.0]]),
             )
         ],
     )
@@ -81,24 +81,24 @@ class TestOverlapMat:
         used."""
         mol = qchem.Molecule(symbols, geometry)
         s = qchem.overlap_matrix(mol.basis_set)()
-        assert np.allclose(s, s_ref)
+        assert pnp.allclose(s, s_ref)
 
     @pytest.mark.parametrize(
         ("symbols", "geometry", "alpha", "coeff", "g_alpha_ref", "g_coeff_ref"),
         [
             (
                 ["H", "H"],
-                np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False),
-                np.array(
+                pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False),
+                pnp.array(
                     [[3.42525091, 0.62391373, 0.1688554], [3.42525091, 0.62391373, 0.1688554]],
                     requires_grad=True,
                 ),
-                np.array(
+                pnp.array(
                     [[0.15432897, 0.53532814, 0.44463454], [0.15432897, 0.53532814, 0.44463454]],
                     requires_grad=True,
                 ),
                 # Jacobian matrix contains gradient of S11, S12, S21, S22 wrt arg_1, arg_2.
-                np.array(
+                pnp.array(
                     [
                         [
                             [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
@@ -116,7 +116,7 @@ class TestOverlapMat:
                         ],
                     ]
                 ),
-                np.array(
+                pnp.array(
                     [
                         [
                             [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
@@ -145,8 +145,8 @@ class TestOverlapMat:
         args = [mol.alpha, mol.coeff]
         g_alpha = qml.jacobian(qchem.overlap_matrix(mol.basis_set), argnum=[0])(*args)
         g_coeff = qml.jacobian(qchem.overlap_matrix(mol.basis_set), argnum=[1])(*args)
-        assert np.allclose(g_alpha, g_alpha_ref)
-        assert np.allclose(g_coeff, g_coeff_ref)
+        assert pnp.allclose(g_alpha, g_alpha_ref)
+        assert pnp.allclose(g_coeff, g_coeff_ref)
 
 
 class TestMomentMat:
@@ -157,14 +157,14 @@ class TestMomentMat:
         [
             (
                 ["H", "H"],
-                np.array([[0.0, 0.0, 0.0], [2.0, 0.0, 0.0]], requires_grad=False),
-                np.array(
+                pnp.array([[0.0, 0.0, 0.0], [2.0, 0.0, 0.0]], requires_grad=False),
+                pnp.array(
                     [[3.42525091, 0.62391373, 0.1688554], [3.42525091, 0.62391373, 0.1688554]],
                     requires_grad=True,
                 ),
                 1,
                 0,
-                np.array([[0.0, 0.4627777], [0.4627777, 2.0]]),
+                pnp.array([[0.0, 0.4627777], [0.4627777, 2.0]]),
             )
         ],
     )
@@ -173,17 +173,17 @@ class TestMomentMat:
         mol = qchem.Molecule(symbols, geometry, alpha=alpha)
         args = [alpha]
         s = qchem.moment_matrix(mol.basis_set, e, idx)(*args)
-        assert np.allclose(s, s_ref)
+        assert pnp.allclose(s, s_ref)
 
     @pytest.mark.parametrize(
         ("symbols", "geometry", "e", "idx", "s_ref"),
         [
             (
                 ["H", "H"],
-                np.array([[0.0, 0.0, 0.0], [2.0, 0.0, 0.0]], requires_grad=False),
+                pnp.array([[0.0, 0.0, 0.0], [2.0, 0.0, 0.0]], requires_grad=False),
                 1,
                 0,
-                np.array([[0.0, 0.4627777], [0.4627777, 2.0]]),
+                pnp.array([[0.0, 0.4627777], [0.4627777, 2.0]]),
             )
         ],
     )
@@ -192,19 +192,19 @@ class TestMomentMat:
         used."""
         mol = qchem.Molecule(symbols, geometry)
         s = qchem.moment_matrix(mol.basis_set, e, idx)()
-        assert np.allclose(s, s_ref)
+        assert pnp.allclose(s, s_ref)
 
     @pytest.mark.parametrize(
         ("symbols", "geometry", "alpha", "coeff", "e", "idx", "g_alpha_ref", "g_coeff_ref"),
         [
             (
                 ["H", "H"],
-                np.array([[0.0, 0.0, 0.0], [2.0, 0.0, 0.0]], requires_grad=False),
-                np.array(
+                pnp.array([[0.0, 0.0, 0.0], [2.0, 0.0, 0.0]], requires_grad=False),
+                pnp.array(
                     [[3.42525091, 0.62391373, 0.1688554], [3.42525091, 0.62391373, 0.1688554]],
                     requires_grad=True,
                 ),
-                np.array(
+                pnp.array(
                     [[0.15432897, 0.53532814, 0.44463454], [0.15432897, 0.53532814, 0.44463454]],
                     requires_grad=True,
                 ),
@@ -212,7 +212,7 @@ class TestMomentMat:
                 0,
                 # Jacobian matrix contains gradient of S11, S12, S21, S22 wrt arg_1, arg_2, computed
                 # with finite difference.
-                np.array(
+                pnp.array(
                     [
                         [
                             [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
@@ -230,7 +230,7 @@ class TestMomentMat:
                         ],
                     ]
                 ),
-                np.array(
+                pnp.array(
                     [
                         [
                             [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
@@ -260,8 +260,8 @@ class TestMomentMat:
         g_alpha = qml.jacobian(qchem.moment_matrix(mol.basis_set, e, idx), argnum=[0])(*args)
         g_coeff = qml.jacobian(qchem.moment_matrix(mol.basis_set, e, idx), argnum=[1])(*args)
 
-        assert np.allclose(g_alpha, g_alpha_ref)
-        assert np.allclose(g_coeff, g_coeff_ref)
+        assert pnp.allclose(g_alpha, g_alpha_ref)
+        assert pnp.allclose(g_coeff, g_coeff_ref)
 
 
 class TestKineticMat:
@@ -272,12 +272,12 @@ class TestKineticMat:
         [
             (
                 ["H", "H"],
-                np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False),
-                np.array(
+                pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False),
+                pnp.array(
                     [[3.42525091, 0.62391373, 0.1688554], [3.42525091, 0.62391373, 0.1688554]],
                     requires_grad=True,
                 ),
-                np.array(
+                pnp.array(
                     [
                         [0.7600318862777408, 0.38325367405372557],
                         [0.38325367405372557, 0.7600318862777408],
@@ -291,15 +291,15 @@ class TestKineticMat:
         mol = qchem.Molecule(symbols, geometry, alpha=alpha)
         args = [alpha]
         t = qchem.kinetic_matrix(mol.basis_set)(*args)
-        assert np.allclose(t, t_ref)
+        assert pnp.allclose(t, t_ref)
 
     @pytest.mark.parametrize(
         ("symbols", "geometry", "t_ref"),
         [
             (
                 ["H", "H"],
-                np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False),
-                np.array(
+                pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False),
+                pnp.array(
                     [
                         [0.7600318862777408, 0.38325367405372557],
                         [0.38325367405372557, 0.7600318862777408],
@@ -313,24 +313,24 @@ class TestKineticMat:
         used."""
         mol = qchem.Molecule(symbols, geometry)
         t = qchem.kinetic_matrix(mol.basis_set)()
-        assert np.allclose(t, t_ref)
+        assert pnp.allclose(t, t_ref)
 
     @pytest.mark.parametrize(
         ("symbols", "geometry", "alpha", "coeff", "g_alpha_ref", "g_coeff_ref"),
         [
             (
                 ["H", "H"],
-                np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False),
-                np.array(
+                pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False),
+                pnp.array(
                     [[3.42525091, 0.62391373, 0.1688554], [3.42525091, 0.62391373, 0.1688554]],
                     requires_grad=True,
                 ),
-                np.array(
+                pnp.array(
                     [[0.15432897, 0.53532814, 0.44463454], [0.15432897, 0.53532814, 0.44463454]],
                     requires_grad=True,
                 ),
                 # Jacobian matrix contains gradient of T11, T12, T21, T22 wrt arg_1, arg_2.
-                np.array(
+                pnp.array(
                     [
                         [
                             [[0.03263157, 0.85287851, 0.68779528], [0.0, 0.0, 0.0]],
@@ -348,7 +348,7 @@ class TestKineticMat:
                         ],
                     ]
                 ),
-                np.array(
+                pnp.array(
                     [
                         [
                             [[1.824217, 0.10606991, -0.76087597], [0.0, 0.0, 0.0]],
@@ -377,8 +377,8 @@ class TestKineticMat:
         args = [mol.alpha, mol.coeff]
         g_alpha = qml.jacobian(qchem.kinetic_matrix(mol.basis_set), argnum=[0])(*args)
         g_coeff = qml.jacobian(qchem.kinetic_matrix(mol.basis_set), argnum=[1])(*args)
-        assert np.allclose(g_alpha, g_alpha_ref)
-        assert np.allclose(g_coeff, g_coeff_ref)
+        assert pnp.allclose(g_alpha, g_alpha_ref)
+        assert pnp.allclose(g_coeff, g_coeff_ref)
 
 
 class TestAttractionMat:
@@ -389,13 +389,13 @@ class TestAttractionMat:
         [
             (
                 ["H", "H"],
-                np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False),
-                np.array(
+                pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False),
+                pnp.array(
                     [[3.42525091, 0.62391373, 0.1688554], [3.42525091, 0.62391373, 0.1688554]],
                     requires_grad=True,
                 ),
                 # attraction matrix obtained from pyscf using mol.intor('int1e_nuc')
-                np.array(
+                pnp.array(
                     [
                         [-2.03852075, -1.6024171],
                         [-1.6024171, -2.03852075],
@@ -409,20 +409,20 @@ class TestAttractionMat:
         mol = qchem.Molecule(symbols, geometry, alpha=alpha)
         args = [mol.alpha]
         v = qchem.attraction_matrix(mol.basis_set, mol.nuclear_charges, mol.coordinates)(*args)
-        assert np.allclose(v, v_ref)
+        assert pnp.allclose(v, v_ref)
 
     @pytest.mark.parametrize(
         ("symbols", "geometry", "alpha", "v_ref"),
         [
             (
                 ["H", "H"],
-                np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=True),
-                np.array(
+                pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=True),
+                pnp.array(
                     [[3.42525091, 0.62391373, 0.1688554], [3.42525091, 0.62391373, 0.1688554]],
                     requires_grad=True,
                 ),
                 # attraction matrix obtained from pyscf using mol.intor('int1e_nuc')
-                np.array(
+                pnp.array(
                     [
                         [-2.03852075, -1.6024171],
                         [-1.6024171, -2.03852075],
@@ -438,16 +438,16 @@ class TestAttractionMat:
         r_basis = mol.coordinates
         args = [mol.coordinates, mol.alpha, r_basis]
         v = qchem.attraction_matrix(mol.basis_set, mol.nuclear_charges, mol.coordinates)(*args)
-        assert np.allclose(v, v_ref)
+        assert pnp.allclose(v, v_ref)
 
     @pytest.mark.parametrize(
         ("symbols", "geometry", "v_ref"),
         [
             (
                 ["H", "H"],
-                np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False),
+                pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False),
                 # attraction matrix obtained from pyscf using mol.intor('int1e_nuc')
-                np.array(
+                pnp.array(
                     [
                         [-2.03852075, -1.6024171],
                         [-1.6024171, -2.03852075],
@@ -460,23 +460,23 @@ class TestAttractionMat:
         r"""Test that attraction_matrix returns the correct matrix."""
         mol = qchem.Molecule(symbols, geometry)
         v = qchem.attraction_matrix(mol.basis_set, mol.nuclear_charges, mol.coordinates)()
-        assert np.allclose(v, v_ref)
+        assert pnp.allclose(v, v_ref)
 
     @pytest.mark.parametrize(
         ("symbols", "geometry", "alpha", "coeff", "g_r_ref"),
         [
             (
                 ["H", "H"],
-                np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=True),
-                np.array(
+                pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=True),
+                pnp.array(
                     [[3.42525091, 0.62391373, 0.1688554], [3.42525091, 0.62391373, 0.1688554]],
                     requires_grad=True,
                 ),
-                np.array(
+                pnp.array(
                     [[0.15432897, 0.53532814, 0.44463454], [0.15432897, 0.53532814, 0.44463454]],
                     requires_grad=True,
                 ),
-                np.array(
+                pnp.array(
                     [
                         [
                             [[0.0, 0.0, 0.0], [0.0, 0.0, 0.44900112]],
@@ -506,7 +506,7 @@ class TestAttractionMat:
         g_r = qml.jacobian(
             qchem.attraction_matrix(mol.basis_set, mol.nuclear_charges, mol.coordinates), argnum=[0]
         )(*args)
-        assert np.allclose(g_r, g_r_ref)
+        assert pnp.allclose(g_r, g_r_ref)
 
 
 class TestRepulsionMat:
@@ -517,13 +517,13 @@ class TestRepulsionMat:
         [
             (
                 ["H", "H"],
-                np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False),
-                np.array(
+                pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False),
+                pnp.array(
                     [[3.42525091, 0.62391373, 0.1688554], [3.42525091, 0.62391373, 0.1688554]],
                     requires_grad=True,
                 ),
                 # electron repulsion tensor obtained from pyscf with mol.intor('int2e')
-                np.array(
+                pnp.array(
                     [
                         [
                             [[0.77460594, 0.56886157], [0.56886157, 0.65017755]],
@@ -543,16 +543,16 @@ class TestRepulsionMat:
         mol = qchem.Molecule(symbols, geometry, alpha=alpha)
         args = [mol.alpha]
         e = qchem.repulsion_tensor(mol.basis_set)(*args)
-        assert np.allclose(e, e_ref)
+        assert pnp.allclose(e, e_ref)
 
     @pytest.mark.parametrize(
         ("symbols", "geometry", "e_ref"),
         [
             (
                 ["H", "H"],
-                np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False),
+                pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False),
                 # electron repulsion tensor obtained from pyscf with mol.intor('int2e')
-                np.array(
+                pnp.array(
                     [
                         [
                             [[0.77460594, 0.56886157], [0.56886157, 0.65017755]],
@@ -572,7 +572,7 @@ class TestRepulsionMat:
         is used."""
         mol = qchem.Molecule(symbols, geometry)
         e = qchem.repulsion_tensor(mol.basis_set)()
-        assert np.allclose(e, e_ref)
+        assert pnp.allclose(e, e_ref)
 
 
 class TestCoreMat:
@@ -583,13 +583,13 @@ class TestCoreMat:
         [
             (
                 ["H", "H"],
-                np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False),
-                np.array(
+                pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False),
+                pnp.array(
                     [[3.42525091, 0.62391373, 0.1688554], [3.42525091, 0.62391373, 0.1688554]],
                     requires_grad=True,
                 ),
                 # core matrix obtained from pyscf using scf.RHF(mol).get_hcore()
-                np.array(
+                pnp.array(
                     [
                         [-1.27848886, -1.21916326],
                         [-1.21916326, -1.27848886],
@@ -603,16 +603,16 @@ class TestCoreMat:
         mol = qchem.Molecule(symbols, geometry, alpha=alpha)
         args = [mol.alpha]
         c = qchem.core_matrix(mol.basis_set, mol.nuclear_charges, mol.coordinates)(*args)
-        assert np.allclose(c, c_ref)
+        assert pnp.allclose(c, c_ref)
 
     @pytest.mark.parametrize(
         ("symbols", "geometry", "c_ref"),
         [
             (
                 ["H", "H"],
-                np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False),
+                pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False),
                 # core matrix obtained from pyscf using scf.RHF(mol).get_hcore()
-                np.array(
+                pnp.array(
                     [
                         [-1.27848886, -1.21916326],
                         [-1.21916326, -1.27848886],
@@ -626,20 +626,20 @@ class TestCoreMat:
         used."""
         mol = qchem.Molecule(symbols, geometry)
         c = qchem.core_matrix(mol.basis_set, mol.nuclear_charges, mol.coordinates)()
-        assert np.allclose(c, c_ref)
+        assert pnp.allclose(c, c_ref)
 
     @pytest.mark.parametrize(
         ("symbols", "geometry", "alpha", "c_ref"),
         [
             (
                 ["H", "H"],
-                np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=True),
-                np.array(
+                pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=True),
+                pnp.array(
                     [[3.42525091, 0.62391373, 0.1688554], [3.42525091, 0.62391373, 0.1688554]],
                     requires_grad=True,
                 ),
                 # core matrix obtained from pyscf using scf.RHF(mol).get_hcore()
-                np.array(
+                pnp.array(
                     [
                         [-1.27848886, -1.21916326],
                         [-1.21916326, -1.27848886],
@@ -654,7 +654,7 @@ class TestCoreMat:
         r_basis = mol.coordinates
         args = [mol.coordinates, mol.alpha, r_basis]
         c = qchem.core_matrix(mol.basis_set, mol.nuclear_charges, mol.coordinates)(*args)
-        assert np.allclose(c, c_ref)
+        assert pnp.allclose(c, c_ref)
 
 
 def generate_symbols_geometry_alpha():
@@ -672,7 +672,7 @@ def generate_symbols_geometry_alpha():
 class TestJax:
     def test_overlap_matrix_jax(self):
         r"""Test that overlap_matrix returns the correct matrix when using jax."""
-        s_ref = np.array([[1.0, 0.7965883009074122], [0.7965883009074122, 1.0]])
+        s_ref = pnp.array([[1.0, 0.7965883009074122], [0.7965883009074122, 1.0]])
         symbols, geometry, alpha = generate_symbols_geometry_alpha()
 
         mol = qchem.Molecule(symbols, geometry, alpha=alpha)
@@ -685,17 +685,17 @@ class TestJax:
         [
             (
                 ["H", "H"],
-                np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False),
-                np.array(
+                pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False),
+                pnp.array(
                     [[3.42525091, 0.62391373, 0.1688554], [3.42525091, 0.62391373, 0.1688554]],
                     requires_grad=True,
                 ),
-                np.array(
+                pnp.array(
                     [[0.15432897, 0.53532814, 0.44463454], [0.15432897, 0.53532814, 0.44463454]],
                     requires_grad=True,
                 ),
                 # Jacobian matrix contains gradient of S11, S12, S21, S22 wrt arg_1, arg_2.
-                np.array(
+                pnp.array(
                     [
                         [
                             [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
@@ -713,7 +713,7 @@ class TestJax:
                         ],
                     ]
                 ),
-                np.array(
+                pnp.array(
                     [
                         [
                             [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
@@ -758,7 +758,7 @@ class TestJax:
         geometry = qml.math.array([[0.0, 0.0, 0.0], [2.0, 0.0, 0.0]], like="jax")
         e = 1
         idx = 0
-        s_ref = np.array([[0.0, 0.4627777], [0.4627777, 2.0]])
+        s_ref = pnp.array([[0.0, 0.4627777], [0.4627777, 2.0]])
 
         mol = qchem.Molecule(symbols, geometry, alpha=alpha)
         args = [geometry, mol.coeff, alpha]
@@ -770,12 +770,12 @@ class TestJax:
         [
             (
                 ["H", "H"],
-                np.array([[0.0, 0.0, 0.0], [2.0, 0.0, 0.0]], requires_grad=False),
-                np.array(
+                pnp.array([[0.0, 0.0, 0.0], [2.0, 0.0, 0.0]], requires_grad=False),
+                pnp.array(
                     [[3.42525091, 0.62391373, 0.1688554], [3.42525091, 0.62391373, 0.1688554]],
                     requires_grad=True,
                 ),
-                np.array(
+                pnp.array(
                     [[0.15432897, 0.53532814, 0.44463454], [0.15432897, 0.53532814, 0.44463454]],
                     requires_grad=True,
                 ),
@@ -783,7 +783,7 @@ class TestJax:
                 0,
                 # Jacobian matrix contains gradient of S11, S12, S21, S22 wrt arg_1, arg_2, computed
                 # with finite difference.
-                np.array(
+                pnp.array(
                     [
                         [
                             [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
@@ -801,7 +801,7 @@ class TestJax:
                         ],
                     ]
                 ),
-                np.array(
+                pnp.array(
                     [
                         [
                             [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
@@ -844,7 +844,7 @@ class TestJax:
     def test_kinetic_matrix_jax(self):
         r"""Test that kinetic_matrix returns the correct matrix when using jax."""
         symbols, geometry, alpha = generate_symbols_geometry_alpha()
-        t_ref = np.array(
+        t_ref = pnp.array(
             [
                 [0.7600318862777408, 0.38325367405372557],
                 [0.38325367405372557, 0.7600318862777408],
@@ -861,17 +861,17 @@ class TestJax:
         [
             (
                 ["H", "H"],
-                np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False),
-                np.array(
+                pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False),
+                pnp.array(
                     [[3.42525091, 0.62391373, 0.1688554], [3.42525091, 0.62391373, 0.1688554]],
                     requires_grad=True,
                 ),
-                np.array(
+                pnp.array(
                     [[0.15432897, 0.53532814, 0.44463454], [0.15432897, 0.53532814, 0.44463454]],
                     requires_grad=True,
                 ),
                 # Jacobian matrix contains gradient of T11, T12, T21, T22 wrt arg_1, arg_2.
-                np.array(
+                pnp.array(
                     [
                         [
                             [[0.03263157, 0.85287851, 0.68779528], [0.0, 0.0, 0.0]],
@@ -889,7 +889,7 @@ class TestJax:
                         ],
                     ]
                 ),
-                np.array(
+                pnp.array(
                     [
                         [
                             [[1.824217, 0.10606991, -0.76087597], [0.0, 0.0, 0.0]],
@@ -931,7 +931,7 @@ class TestJax:
         r"""Test that core_matrix returns the correct matrix when positions are differentiable
         when using jax."""
         symbols, geometry, alpha = generate_symbols_geometry_alpha()
-        c_ref = np.array(
+        c_ref = pnp.array(
             [
                 [-1.27848886, -1.21916326],
                 [-1.21916326, -1.27848886],
@@ -946,7 +946,7 @@ class TestJax:
     def test_repulsion_tensor_jax(self):
         r"""Test that repulsion_tensor returns the correct matrix when using jax."""
         symbols, geometry, alpha = generate_symbols_geometry_alpha()
-        e_ref = np.array(
+        e_ref = pnp.array(
             [
                 [
                     [[0.77460594, 0.56886157], [0.56886157, 0.65017755]],
@@ -968,7 +968,7 @@ class TestJax:
         r"""Test that attraction_matrix returns the correct matrix when positions are
         differentiable when using jax."""
         symbols, geometry, alpha = generate_symbols_geometry_alpha()
-        v_ref = np.array(
+        v_ref = pnp.array(
             [
                 [-2.03852075, -1.6024171],
                 [-1.6024171, -2.03852075],
@@ -984,8 +984,8 @@ class TestJax:
         [
             (
                 ["H", "H"],
-                np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=True),
-                np.array(
+                pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=True),
+                pnp.array(
                     [
                         [
                             [[0.0, 0.0, 0.0], [0.0, 0.0, 0.44900112]],

--- a/tests/qchem/test_molecule.py
+++ b/tests/qchem/test_molecule.py
@@ -17,7 +17,7 @@ Unit tests for the molecule object.
 # pylint: disable=too-many-arguments
 import pytest
 
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane import qchem
 
 
@@ -27,7 +27,7 @@ class TestMolecule:
     @pytest.mark.parametrize(
         ("symbols", "geometry"),
         [
-            (["H", "F"], np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]])),
+            (["H", "F"], pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]])),
         ],
     )
     def test_build_molecule(self, symbols, geometry):
@@ -41,7 +41,7 @@ class TestMolecule:
         import jax
 
         symbols = ["H", "F"]
-        geometry = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False)
+        geometry = pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False)
         alpha = jax.numpy.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
 
         with pytest.warns(UserWarning, match="The parameters"):
@@ -50,7 +50,7 @@ class TestMolecule:
     @pytest.mark.parametrize(
         ("symbols", "geometry"),
         [
-            (["H", "F"], np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]])),
+            (["H", "F"], pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]])),
         ],
     )
     def test_basis_error(self, symbols, geometry):
@@ -61,7 +61,7 @@ class TestMolecule:
     @pytest.mark.parametrize(
         ("symbols", "geometry"),
         [
-            (["H", "Ox"], np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]])),
+            (["H", "Ox"], pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]])),
         ],
     )
     def test_symbol_error(self, symbols, geometry):
@@ -72,7 +72,7 @@ class TestMolecule:
     @pytest.mark.parametrize(
         ("symbols", "geometry", "charge", "mult", "basis_name"),
         [
-            (["H", "F"], np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]]), 0, 1, "sto-3g"),
+            (["H", "F"], pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]]), 0, 1, "sto-3g"),
         ],
     )
     def test_default_inputs(self, symbols, geometry, charge, mult, basis_name):
@@ -80,7 +80,7 @@ class TestMolecule:
         mol = qchem.Molecule(symbols, geometry)
 
         assert mol.symbols == symbols
-        assert np.allclose(mol.coordinates, geometry)
+        assert pnp.allclose(mol.coordinates, geometry)
         assert mol.charge == charge
         assert mol.mult == mult
         assert mol.basis_name == basis_name
@@ -90,7 +90,7 @@ class TestMolecule:
         [
             (
                 ["H", "F"],
-                np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]]),
+                pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]]),
                 10,
                 6,
                 [1, 9],
@@ -110,7 +110,7 @@ class TestMolecule:
         [
             (
                 ["H", "H"],
-                np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]]),
+                pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]]),
                 [1, 1],
                 (
                     (
@@ -132,32 +132,32 @@ class TestMolecule:
         mol = qchem.Molecule(symbols, geometry)
 
         assert mol.n_basis == n_basis
-        assert np.allclose(mol.basis_data, basis_data)
+        assert pnp.allclose(mol.basis_data, basis_data)
 
     @pytest.mark.parametrize(
         ("symbols", "geometry", "l", "alpha", "coeff", "r", "load_data"),
         [
             (
                 ["H", "H"],
-                np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]]),
+                pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]]),
                 [(0, 0, 0), (0, 0, 0)],
                 [[3.42525091, 0.62391373, 0.1688554], [3.42525091, 0.62391373, 0.1688554]],
                 [[0.15432897, 0.53532814, 0.44463454], [0.15432897, 0.53532814, 0.44463454]],
-                np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]]),
+                pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]]),
                 False,
             ),
             (
                 ["H", "H"],
-                np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]]),
+                pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]]),
                 [(0, 0, 0), (0, 0, 0)],
                 [[3.42525091, 0.62391373, 0.1688554], [3.42525091, 0.62391373, 0.1688554]],
                 [[0.15432897, 0.53532814, 0.44463454], [0.15432897, 0.53532814, 0.44463454]],
-                np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]]),
+                pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]]),
                 True,
             ),
             (
                 ["H", "F"],
-                np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]]),
+                pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]]),
                 [(0, 0, 0), (0, 0, 0), (0, 0, 0), (1, 0, 0), (0, 1, 0), (0, 0, 1)],
                 [
                     [0.3425250914e01, 0.6239137298e00, 0.1688554040e00],
@@ -175,7 +175,7 @@ class TestMolecule:
                     [0.1559162750e00, 0.6076837186e00, 0.3919573931e00],
                     [0.1559162750e00, 0.6076837186e00, 0.3919573931e00],
                 ],
-                np.array(
+                pnp.array(
                     [
                         [0.0, 0.0, 0.0],
                         [0.0, 0.0, 1.0],
@@ -198,9 +198,9 @@ class TestMolecule:
 
         assert set(map(type, mol.basis_set)) == {qchem.BasisFunction}
         assert mol.l == l
-        assert np.allclose(mol.alpha, alpha)
-        assert np.allclose(mol.coeff, coeff)
-        assert np.allclose(mol.r, r)
+        assert pnp.allclose(mol.alpha, alpha)
+        assert pnp.allclose(mol.coeff, coeff)
+        assert pnp.allclose(mol.r, r)
 
     @pytest.mark.parametrize(
         ("symbols", "geometry", "alpha", "coeff", "index", "position", "ref_value"),
@@ -208,15 +208,15 @@ class TestMolecule:
             (
                 # normalized primitive Gaussians centered at 0, G(0, 0, 0) = coeff * exp(alpha * 0)
                 ["H", "H"],
-                np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]]),
-                np.array(
+                pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]]),
+                pnp.array(
                     [
                         [3.425250914, 3.425250914, 3.425250914],
                         [3.425250914, 3.425250914, 3.425250914],
                     ],
                     requires_grad=False,
                 ),
-                np.array(
+                pnp.array(
                     [[1.79444183, 1.79444183, 1.79444183], [1.79444183, 1.79444183, 1.79444183]],
                     requires_grad=False,
                 ),
@@ -227,15 +227,15 @@ class TestMolecule:
             (
                 # normalized primitive Gaussians centered at z=1, G(0, 0, 0) = coeff * exp(alpha *1)
                 ["H", "H"],
-                np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]]),
-                np.array(
+                pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]]),
+                pnp.array(
                     [
                         [3.425250914, 3.425250914, 3.425250914],
                         [3.425250914, 3.425250914, 3.425250914],
                     ],
                     requires_grad=False,
                 ),
-                np.array(
+                pnp.array(
                     [[1.79444183, 1.79444183, 1.79444183], [1.79444183, 1.79444183, 1.79444183]],
                     requires_grad=False,
                 ),
@@ -253,14 +253,14 @@ class TestMolecule:
         ao = mol.atomic_orbital(index)
         ao_value = ao(x, y, z)
 
-        assert np.allclose(ao_value, ref_value)
+        assert pnp.allclose(ao_value, ref_value)
 
     @pytest.mark.parametrize(
         ("symbols", "geometry", "index", "position", "ref_value"),
         [
             (
                 ["H", "H"],
-                np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False),
+                pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], requires_grad=False),
                 1,
                 (0.0, 0.0, 0.0),
                 0.01825128,
@@ -276,28 +276,28 @@ class TestMolecule:
         mo = mol.molecular_orbital(index)
         mo_value = mo(x, y, z)
 
-        assert np.allclose(mo_value, ref_value)
+        assert pnp.allclose(mo_value, ref_value)
 
     def test_repr(self):
         """Test that __repr__ for Molecule returns correct representation."""
 
         symbols, geometry = (
             ["H", "H", "H"],
-            np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, 2.0]]),
+            pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, 2.0]]),
         )
         mol = qchem.Molecule(symbols, geometry, 1)
         assert repr(mol) == "<Molecule = H3, Charge: 1, Basis: STO-3G, Orbitals: 3, Electrons: 2>"
 
         symbols, geometry = (
             ["H", "C", "O"],
-            np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, 2.0]]),
+            pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, 2.0]]),
         )
         mol = qchem.Molecule(symbols, geometry, 1)
         assert (
             repr(mol) == "<Molecule = CHO, Charge: 1, Basis: STO-3G, Orbitals: 11, Electrons: 14>"
         )
 
-        symbols, geometry = (["C", "O"], np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]]))
+        symbols, geometry = (["C", "O"], pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]]))
         mol = qchem.Molecule(symbols, geometry, 0)
         assert repr(mol) == "<Molecule = CO, Charge: 0, Basis: STO-3G, Orbitals: 10, Electrons: 14>"
 
@@ -306,7 +306,7 @@ class TestMolecule:
         [  # data manually copied from https://www.basissetexchange.org/
             (
                 ["H", "H"],
-                np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]]),
+                pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]]),
                 "6-31+g",
                 (
                     (
@@ -359,7 +359,7 @@ class TestMolecule:
         r"""Test that an error is raised if a wrong/not-supported unit for coordinates is entered."""
 
         symbols = ["H", "H"]
-        geometry = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
+        geometry = pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
 
         with pytest.raises(ValueError, match="The provided unit 'degrees' is not supported."):
             qchem.Molecule(symbols, geometry, unit="degrees")

--- a/tests/qchem/test_observable_hf.py
+++ b/tests/qchem/test_observable_hf.py
@@ -17,7 +17,7 @@ Unit tests for functions needed for computing the Hamiltonian.
 import pytest
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane import qchem
 from pennylane.fermi import from_string
 
@@ -29,9 +29,9 @@ from pennylane.fermi import from_string
             # H2 bond length: 1 Angstrom, basis = 'sto-3g', multiplicity = 1, charge = 0
             # molecule = openfermion.MolecularData(geometry, basis, multiplicity, charge)
             # run_pyscf(molecule).get_integrals()
-            np.array([0.529177210903]),  # nuclear repulsion 1 / 1.88973 Bohr
-            np.array([[-1.11084418e00, 1.01781501e-16], [7.32122533e-17, -5.89121004e-01]]),
-            np.array(
+            pnp.array([0.529177210903]),  # nuclear repulsion 1 / 1.88973 Bohr
+            pnp.array([[-1.11084418e00, 1.01781501e-16], [7.32122533e-17, -5.89121004e-01]]),
+            pnp.array(
                 [
                     [
                         [[6.26402500e-01, -1.84129592e-16], [-2.14279171e-16, 1.96790583e-01]],
@@ -84,8 +84,8 @@ from pennylane.fermi import from_string
             + 0.32653537347128725 * from_string("3+ 3+ 3- 3-"),
         ),
         (
-            np.array([2.869]),
-            np.array(
+            pnp.array([2.869]),
+            pnp.array(
                 [
                     [0.95622463, 0.7827277, -0.53222294],
                     [0.7827277, 1.42895581, 0.23469918],
@@ -120,7 +120,7 @@ def test_fermionic_observable(core_constant, integral_one, integral_two, f_ref):
     r"""Test that fermionic_observable returns the correct fermionic observable."""
     f = qchem.fermionic_observable(core_constant, integral_one, integral_two)
 
-    assert np.allclose(list(f.values()), list(f_ref.values()))
+    assert pnp.allclose(list(f.values()), list(f_ref.values()))
     assert f.keys() == f_ref.keys()
 
 
@@ -173,7 +173,7 @@ def test_qubit_observable(f_observable, q_observable):
     h_ref = qml.Hamiltonian(q_observable[0], ops)
 
     assert h_ref.compare(h_as_op)
-    assert np.allclose(
+    assert pnp.allclose(
         qml.matrix(h_as_op, wire_order=[0, 1, 2]), qml.matrix(h_ref, wire_order=[0, 1, 2])
     )
 
@@ -197,6 +197,6 @@ def test_qubit_observable_cutoff(f_observable, cut_off):
     h_as_op = qchem.qubit_observable(f_observable, cutoff=cut_off)
 
     assert h_ref.compare(h_as_op)
-    assert np.allclose(
+    assert pnp.allclose(
         qml.matrix(h_ref_op, wire_order=[0, 1, 2]), qml.matrix(h_as_op, wire_order=[0, 1, 2])
     )

--- a/tests/qchem/test_particle_number.py
+++ b/tests/qchem/test_particle_number.py
@@ -18,7 +18,7 @@ import pytest
 
 import pennylane as qml
 from pennylane import Identity, PauliZ
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane import qchem
 
 
@@ -27,7 +27,7 @@ from pennylane import qchem
     [
         (  # computed with PL-QChem using OpenFermion
             4,
-            np.array([2.0, -0.5, -0.5, -0.5, -0.5]),
+            pnp.array([2.0, -0.5, -0.5, -0.5, -0.5]),
             [
                 Identity(wires=[0]),
                 PauliZ(wires=[0]),
@@ -38,7 +38,7 @@ from pennylane import qchem
         ),
         (
             6,
-            np.array([3.0, -0.5, -0.5, -0.5, -0.5, -0.5, -0.5]),
+            pnp.array([3.0, -0.5, -0.5, -0.5, -0.5, -0.5, -0.5]),
             [
                 Identity(wires=[0]),
                 PauliZ(wires=[0]),
@@ -61,7 +61,7 @@ def test_particle_number(orbitals, coeffs_ref, ops_ref):
     assert isinstance(n, qml.ops.Sum)
 
     wire_order = n_ref.wires
-    assert np.allclose(
+    assert pnp.allclose(
         qml.matrix(n, wire_order=wire_order),
         qml.matrix(n_ref, wire_order=wire_order),
     )

--- a/tests/qchem/test_spin.py
+++ b/tests/qchem/test_spin.py
@@ -18,7 +18,7 @@ import pytest
 
 import pennylane as qml
 from pennylane import Identity, PauliX, PauliY, PauliZ
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane import qchem, simplify
 
 
@@ -108,11 +108,11 @@ def test_spin2_matrix_elements(n_spin_orbs, matrix_ref):
     :math:`\hat{s}_1 \cdot \hat{s}_2` implemented by the function `'_spin2_matrix_elements'`"""
     # pylint: disable=protected-access
 
-    sz = np.where(np.arange(n_spin_orbs) % 2 == 0, 0.5, -0.5)
+    sz = pnp.where(pnp.arange(n_spin_orbs) % 2 == 0, 0.5, -0.5)
 
     s2_me_result = qchem.spin._spin2_matrix_elements(sz)
 
-    assert np.allclose(s2_me_result, matrix_ref)
+    assert pnp.allclose(s2_me_result, matrix_ref)
 
 
 @pytest.mark.parametrize(
@@ -121,7 +121,7 @@ def test_spin2_matrix_elements(n_spin_orbs, matrix_ref):
         (  # computed with PL-QChem using OpenFermion
             2,
             4,
-            np.array(
+            pnp.array(
                 [
                     0.75,
                     0.375,
@@ -179,7 +179,7 @@ def test_spin2(electrons, orbitals, coeffs_ref, ops_ref):
     assert isinstance(s2, qml.ops.Sum)
 
     wire_order = s2_ref.wires
-    assert np.allclose(
+    assert pnp.allclose(
         qml.matrix(s2, wire_order=wire_order),
         qml.matrix(s2_ref, wire_order=wire_order),
     )
@@ -207,12 +207,12 @@ def test_exception_spin2(electrons, orbitals, msg_match):
     [
         (  # computed with PL-QChem using OpenFermion
             4,
-            np.array([-0.25, 0.25, -0.25, 0.25]),
+            pnp.array([-0.25, 0.25, -0.25, 0.25]),
             [PauliZ(wires=[0]), PauliZ(wires=[1]), PauliZ(wires=[2]), PauliZ(wires=[3])],
         ),
         (
             6,
-            np.array([-0.25, 0.25, -0.25, 0.25, -0.25, 0.25]),
+            pnp.array([-0.25, 0.25, -0.25, 0.25, -0.25, 0.25]),
             [
                 PauliZ(wires=[0]),
                 PauliZ(wires=[1]),
@@ -234,7 +234,7 @@ def test_spinz(orbitals, coeffs_ref, ops_ref):
     assert isinstance(sz, qml.ops.Sum)
 
     wire_order = sz_ref.wires
-    assert np.allclose(
+    assert pnp.allclose(
         qml.matrix(sz, wire_order=wire_order),
         qml.matrix(sz_ref, wire_order=wire_order),
     )

--- a/tests/qchem/test_structure.py
+++ b/tests/qchem/test_structure.py
@@ -24,7 +24,7 @@ from unittest.mock import patch
 import pytest
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane import qchem
 from pennylane.fermi import FermiWord
 from pennylane.templates.subroutines import UCCSD
@@ -36,7 +36,7 @@ def test_reading_xyz_file(tmpdir):
     r"""Test reading of the generated file 'structure.xyz'"""
 
     ref_symbols = ["C", "C", "N", "H", "H", "H", "H", "H"]
-    ref_coords = np.array(
+    ref_coords = pnp.array(
         [
             0.68219113,
             -0.85415621,
@@ -68,7 +68,7 @@ def test_reading_xyz_file(tmpdir):
     symbols, coordinates = qchem.read_structure(name, outpath=tmpdir)
 
     assert symbols == ref_symbols
-    assert np.allclose(coordinates, ref_coords)
+    assert pnp.allclose(coordinates, ref_coords)
 
 
 @pytest.mark.parametrize(
@@ -278,7 +278,7 @@ def test_excitations_to_wires_exceptions(singles, doubles, wires, message_match)
     ("weights", "singles", "doubles", "expected"),
     [
         (
-            np.array([3.90575761, -1.89772083, -1.36689032]),
+            pnp.array([3.90575761, -1.89772083, -1.36689032]),
             [[0, 2], [1, 3]],
             [[0, 1, 2, 3]],
             [0.14619406, 0.06502792, -0.14619406, -0.06502792],
@@ -295,11 +295,11 @@ def test_excitation_integration_with_uccsd(weights, singles, doubles, expected):
 
     @qml.qnode(dev)
     def circuit(weights):
-        UCCSD(weights, wires, s_wires=s_wires, d_wires=d_wires, init_state=np.array([1, 1, 0, 0]))
+        UCCSD(weights, wires, s_wires=s_wires, d_wires=d_wires, init_state=pnp.array([1, 1, 0, 0]))
         return [qml.expval(qml.PauliZ(w)) for w in range(n)]
 
     res = circuit(weights)
-    assert np.allclose(res, np.array(expected))
+    assert pnp.allclose(res, pnp.array(expected))
 
 
 @pytest.mark.parametrize(
@@ -308,18 +308,18 @@ def test_excitation_integration_with_uccsd(weights, singles, doubles, expected):
     # [`Tranter et al. Int. J. Quantum Chem. 115, 1431 (2015)
     # <https://doi.org/10.1002/qua.24969>`_]
     [
-        (1, 1, "occupation_number", np.array([1])),
-        (2, 5, "occupation_number", np.array([1, 1, 0, 0, 0])),
-        (1, 5, "occupation_number", np.array([1, 0, 0, 0, 0])),
-        (5, 5, "occupation_number", np.array([1, 1, 1, 1, 1])),
-        (1, 1, "parity", np.array([1])),
-        (2, 5, "parity", np.array([1, 0, 0, 0, 0])),
-        (1, 5, "parity", np.array([1, 1, 1, 1, 1])),
-        (5, 5, "parity", np.array([1, 0, 1, 0, 1])),
-        (1, 1, "bravyi_kitaev", np.array([1])),
-        (2, 5, "bravyi_kitaev", np.array([1, 0, 0, 0, 0])),
-        (1, 5, "bravyi_kitaev", np.array([1, 1, 0, 1, 0])),
-        (5, 5, "bravyi_kitaev", np.array([1, 0, 1, 0, 1])),
+        (1, 1, "occupation_number", pnp.array([1])),
+        (2, 5, "occupation_number", pnp.array([1, 1, 0, 0, 0])),
+        (1, 5, "occupation_number", pnp.array([1, 0, 0, 0, 0])),
+        (5, 5, "occupation_number", pnp.array([1, 1, 1, 1, 1])),
+        (1, 1, "parity", pnp.array([1])),
+        (2, 5, "parity", pnp.array([1, 0, 0, 0, 0])),
+        (1, 5, "parity", pnp.array([1, 1, 1, 1, 1])),
+        (5, 5, "parity", pnp.array([1, 0, 1, 0, 1])),
+        (1, 1, "bravyi_kitaev", pnp.array([1])),
+        (2, 5, "bravyi_kitaev", pnp.array([1, 0, 0, 0, 0])),
+        (1, 5, "bravyi_kitaev", pnp.array([1, 1, 0, 1, 0])),
+        (5, 5, "bravyi_kitaev", pnp.array([1, 0, 1, 0, 1])),
     ],
 )
 def test_hf_state(electrons, orbitals, basis, exp_state):
@@ -328,17 +328,17 @@ def test_hf_state(electrons, orbitals, basis, exp_state):
     res_state = qchem.hf_state(electrons, orbitals, basis)
 
     assert len(res_state) == len(exp_state)
-    assert np.allclose(res_state, exp_state)
+    assert pnp.allclose(res_state, exp_state)
 
 
 @pytest.mark.parametrize(
     ("electrons", "symbols", "geometry", "charge"),
     [
-        (2, ["H", "H"], np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.4]], requires_grad=False), 0),
+        (2, ["H", "H"], pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.4]], requires_grad=False), 0),
         (
             2,
             ["H", "H", "H"],
-            np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, 2.0]], requires_grad=False),
+            pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, 2.0]], requires_grad=False),
             1,
         ),
     ],
@@ -529,7 +529,7 @@ def test_consistent_pubchem_mol_data(identifier, identifier_type):
 
     ref_mol_data_3d = (
         ["C", "H", "H", "H", "H"],
-        np.array(
+        pnp.array(
             [
                 [0.0, 0.0, 0.0],
                 [1.04709725, 1.51102501, 0.93824902],
@@ -539,7 +539,7 @@ def test_consistent_pubchem_mol_data(identifier, identifier_type):
             ]
         ),
     )
-    ref_mol_data_2d = (["H", "H"], np.array([[3.77945225, 0.0, 0.0], [5.66917837, 0.0, 0.0]]))
+    ref_mol_data_2d = (["H", "H"], pnp.array([[3.77945225, 0.0, 0.0], [5.66917837, 0.0, 0.0]]))
 
     mock_gc, mock_fc = ft.partial(mock_get_cids, pcp=pcp), ft.partial(mock_from_cid, pcp=pcp)
     with patch.dict(sys.modules, {"pubchempy": pcp}) and patch.object(
@@ -550,7 +550,7 @@ def test_consistent_pubchem_mol_data(identifier, identifier_type):
         ref_mol_data = ref_mol_data_2d if pub_mol_data[0] == ["H", "H"] else ref_mol_data_3d
 
         assert ref_mol_data[0] == pub_mol_data[0]
-        assert np.allclose(ref_mol_data[1], pub_mol_data[1])
+        assert pnp.allclose(ref_mol_data[1], pub_mol_data[1])
 
 
 @pytest.mark.parametrize(

--- a/tests/qchem/test_tapering.py
+++ b/tests/qchem/test_tapering.py
@@ -21,7 +21,7 @@ import pytest
 import scipy
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane.pauli import pauli_sentence
 from pennylane.qchem.tapering import (
     _kernel,
@@ -39,7 +39,7 @@ from pennylane.qchem.tapering import (
     ("binary_matrix", "result"),
     [
         (
-            np.array(
+            pnp.array(
                 [
                     [0, 0, 0, 0, 0, 0, 0, 0],
                     [1, 0, 0, 0, 0, 0, 0, 0],
@@ -58,7 +58,7 @@ from pennylane.qchem.tapering import (
                     [0, 0, 1, 1, 0, 0, 0, 0],
                 ]
             ),
-            np.array(
+            pnp.array(
                 [
                     [1, 0, 0, 0, 0, 0, 0, 0],
                     [0, 1, 0, 0, 0, 0, 0, 0],
@@ -87,8 +87,8 @@ def test_reduced_row_echelon(binary_matrix, result):
     shape = binary_matrix.shape
     for irow in range(shape[0]):
         pivot_index = 0
-        if np.count_nonzero(binary_matrix[irow, :]):
-            pivot_index = np.nonzero(binary_matrix[irow, :])[0][0]
+        if pnp.count_nonzero(binary_matrix[irow, :]):
+            pivot_index = pnp.nonzero(binary_matrix[irow, :])[0][0]
 
         for jrow in range(shape[0]):
             if jrow != irow and binary_matrix[jrow, pivot_index]:
@@ -97,19 +97,19 @@ def test_reduced_row_echelon(binary_matrix, result):
     indices = [
         irow
         for irow in range(shape[0] - 1)
-        if np.array_equal(binary_matrix[irow, :], np.zeros(shape[1]))
+        if pnp.array_equal(binary_matrix[irow, :], pnp.zeros(shape[1]))
     ]
 
     temp_row_echelon_matrix = binary_matrix.copy()
     for row in indices[::-1]:
-        temp_row_echelon_matrix = np.delete(temp_row_echelon_matrix, row, axis=0)
+        temp_row_echelon_matrix = pnp.delete(temp_row_echelon_matrix, row, axis=0)
 
-    row_echelon_matrix = np.zeros(shape, dtype=int)
+    row_echelon_matrix = pnp.zeros(shape, dtype=int)
     row_echelon_matrix[: shape[0] - len(indices), :] = temp_row_echelon_matrix
 
     # build reduced row echelon form of the matrix from row echelon form
     for idx in range(len(row_echelon_matrix))[:0:-1]:
-        nonzeros = np.nonzero(row_echelon_matrix[idx])[0]
+        nonzeros = pnp.nonzero(row_echelon_matrix[idx])[0]
         if len(nonzeros) > 0:
             redrow = (row_echelon_matrix[idx, :] % 2).reshape(1, -1)
             coeffs = (
@@ -130,7 +130,7 @@ def test_reduced_row_echelon(binary_matrix, result):
     ("binary_matrix", "result"),
     [
         (
-            np.array(
+            pnp.array(
                 [
                     [1, 0, 0, 0, 0, 0, 0, 0],
                     [0, 1, 0, 0, 0, 0, 0, 0],
@@ -149,7 +149,7 @@ def test_reduced_row_echelon(binary_matrix, result):
                     [0, 0, 0, 0, 0, 0, 0, 0],
                 ]
             ),
-            np.array(
+            pnp.array(
                 [[0, 0, 0, 0, 1, 1, 0, 0], [0, 0, 0, 0, 1, 0, 1, 0], [0, 0, 0, 0, 1, 0, 0, 1]]
             ),
         ),
@@ -160,15 +160,15 @@ def test_kernel(binary_matrix, result):
 
     # get the kernel from the gaussian elimination.
     pivots = (binary_matrix.T != 0).argmax(axis=0)
-    nonpivots = np.setdiff1d(range(len(binary_matrix[0])), pivots)
+    nonpivots = pnp.setdiff1d(range(len(binary_matrix[0])), pivots)
 
     kernel = []
     for col in nonpivots:
         col_vector = binary_matrix[:, col]
-        null_vector = np.zeros((binary_matrix.shape[1]), dtype=int)
+        null_vector = pnp.zeros((binary_matrix.shape[1]), dtype=int)
         null_vector[col] = 1
         for i in pivots:
-            first_entry = np.where(binary_matrix[:, i] == 1)[0][0]
+            first_entry = pnp.where(binary_matrix[:, i] == 1)[0][0]
             if col_vector[first_entry] == 1:
                 null_vector[i] = 1
         kernel.append(null_vector.tolist())
@@ -215,7 +215,7 @@ def test_generate_paulis(generators, num_qubits, result):
     [
         (
             ["H", "H"],
-            np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.40104295]], requires_grad=False),
+            pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.40104295]], requires_grad=False),
             [
                 qml.Hamiltonian([1.0], [qml.PauliZ(0) @ qml.PauliZ(1)]),
                 qml.Hamiltonian([1.0], [qml.PauliZ(0) @ qml.PauliZ(2)]),
@@ -239,17 +239,17 @@ def test_symmetry_generators(symbols, geometry, res_generators):
     [
         (
             [
-                qml.Hamiltonian(np.array([1.0]), [qml.PauliZ(0)]),
-                qml.Hamiltonian(np.array([1.0]), [qml.PauliZ(1)]),
+                qml.Hamiltonian(pnp.array([1.0]), [qml.PauliZ(0)]),
+                qml.Hamiltonian(pnp.array([1.0]), [qml.PauliZ(1)]),
             ],
             [qml.PauliX(0), qml.PauliX(1)],
             qml.Hamiltonian(
-                np.array(
+                pnp.array(
                     [
-                        (1 / np.sqrt(2)) ** 2,
-                        (1 / np.sqrt(2)) ** 2,
-                        (1 / np.sqrt(2)) ** 2,
-                        (1 / np.sqrt(2)) ** 2,
+                        (1 / pnp.sqrt(2)) ** 2,
+                        (1 / pnp.sqrt(2)) ** 2,
+                        (1 / pnp.sqrt(2)) ** 2,
+                        (1 / pnp.sqrt(2)) ** 2,
                     ]
                 ),
                 [
@@ -278,7 +278,7 @@ def test_clifford(generator, paulixops, result):
     [
         (
             ["H", "H"],
-            np.array([[0.0, 0.0, -0.69440367], [0.0, 0.0, 0.69440367]], requires_grad=False),
+            pnp.array([[0.0, 0.0, -0.69440367], [0.0, 0.0, 0.69440367]], requires_grad=False),
             [
                 qml.Hamiltonian([1.0], [qml.PauliZ(0) @ qml.PauliZ(1)]),
                 qml.Hamiltonian([1.0], [qml.PauliZ(0) @ qml.PauliZ(2)]),
@@ -287,7 +287,7 @@ def test_clifford(generator, paulixops, result):
             [qml.PauliX(1), qml.PauliX(2), qml.PauliX(3)],
             [1, -1, -1],
             qml.Hamiltonian(
-                np.array([-0.3210344, 0.18092703, 0.79596785]),
+                pnp.array([-0.3210344, 0.18092703, 0.79596785]),
                 [qml.Identity(0), qml.PauliX(0), qml.PauliZ(0)],
             ),
         ),
@@ -303,7 +303,7 @@ def test_transform_hamiltonian(symbols, geometry, generator, paulixops, paulix_s
     hamref_terms = list(zip(*ham_ref.terms()))
 
     for term, ref_term in zip(sorted_terms, hamref_terms):
-        assert np.allclose(term[0], ref_term[0])
+        assert pnp.allclose(term[0], ref_term[0])
         assert pauli_sentence(term[1]) == pauli_sentence(ref_term[1])
 
 
@@ -312,7 +312,7 @@ def test_transform_hamiltonian(symbols, geometry, generator, paulixops, paulix_s
     [
         (
             ["H", "H"],
-            np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.40104295]], requires_grad=False),
+            pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.40104295]], requires_grad=False),
             0,
             [
                 qml.Hamiltonian([1.0], [qml.PauliZ(0) @ qml.PauliZ(1)]),
@@ -324,7 +324,7 @@ def test_transform_hamiltonian(symbols, geometry, generator, paulixops, paulix_s
         ),
         (
             ["He", "H"],
-            np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.4588684632]], requires_grad=False),
+            pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.4588684632]], requires_grad=False),
             1,
             [
                 qml.Hamiltonian([1.0], [qml.PauliZ(0) @ qml.PauliZ(2)]),
@@ -335,7 +335,7 @@ def test_transform_hamiltonian(symbols, geometry, generator, paulixops, paulix_s
         ),
         (
             ["H", "H", "H"],
-            np.array(
+            pnp.array(
                 [[-0.84586466, 0.0, 0.0], [0.84586466, 0.0, 0.0], [0.0, 1.46508057, 0.0]],
                 requires_grad=False,
             ),
@@ -363,7 +363,7 @@ def test_optimal_sector(symbols, geometry, charge, generators, num_electrons, re
     [
         (
             ["H", "H"],
-            np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.40104295]], requires_grad=False),
+            pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.40104295]], requires_grad=False),
             [
                 qml.Hamiltonian([1.0], [qml.PauliZ(0) @ qml.PauliZ(1)]),
                 qml.Hamiltonian([1.0], [qml.PauliZ(0) @ qml.PauliZ(2)]),
@@ -401,7 +401,7 @@ def test_exceptions_optimal_sector(symbols, geometry, generators, num_electrons,
             (1, -1, -1),
             2,
             4,
-            np.array([1]),
+            pnp.array([1]),
         ),
         (
             [
@@ -412,7 +412,7 @@ def test_exceptions_optimal_sector(symbols, geometry, generators, num_electrons,
             (-1, -1),
             2,
             6,
-            np.array([1, 1, 0, 0]),
+            pnp.array([1, 1, 0, 0]),
         ),
         (
             [
@@ -450,7 +450,7 @@ def test_exceptions_optimal_sector(symbols, geometry, generators, num_electrons,
             (1, 1, 1, 1),
             4,
             12,
-            np.array([1, 1, 0, 0, 0, 0, 0, 0]),
+            pnp.array([1, 1, 0, 0, 0, 0, 0, 0]),
         ),
     ],
 )
@@ -464,7 +464,7 @@ def test_transform_hf(generators, paulixops, paulix_sector, num_electrons, num_w
         num_electrons,
         num_wires,
     )
-    assert np.all(tapered_hf_state == result)
+    assert pnp.all(tapered_hf_state == result)
 
 
 @pytest.mark.parametrize(
@@ -472,12 +472,12 @@ def test_transform_hf(generators, paulixops, paulix_sector, num_electrons, num_w
     [
         (
             ["H", "H"],
-            np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.40104295]], requires_grad=True),
+            pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.40104295]], requires_grad=True),
             0,
         ),
         (
             ["He", "H"],
-            np.array(
+            pnp.array(
                 [[0.0, 0.0, 0.0], [0.0, 0.0, 1.4588684632]],
                 requires_grad=True,
             ),
@@ -485,7 +485,7 @@ def test_transform_hf(generators, paulixops, paulix_sector, num_electrons, num_w
         ),
         (
             ["H", "H", "H"],
-            np.array(
+            pnp.array(
                 [[-0.84586466, 0.0, 0.0], [0.84586466, 0.0, 0.0], [0.0, 1.46508057, 0.0]],
                 requires_grad=True,
             ),
@@ -493,7 +493,7 @@ def test_transform_hf(generators, paulixops, paulix_sector, num_electrons, num_w
         ),
         (
             ["H", "H", "H", "H"],
-            np.array(
+            pnp.array(
                 [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, 2.0], [0.0, 0.0, 3.0]],
                 requires_grad=True,
             ),
@@ -507,7 +507,7 @@ def test_taper_obs(symbols, geometry, charge):
 
     mol = qml.qchem.Molecule(symbols, geometry, charge)
     hamiltonian = qml.qchem.diff_hamiltonian(mol)(geometry)
-    hf_state = np.where(np.arange(len(hamiltonian.wires)) < mol.n_electrons, 1, 0)
+    hf_state = pnp.where(pnp.arange(len(hamiltonian.wires)) < mol.n_electrons, 1, 0)
     generators = qml.symmetry_generators(hamiltonian)
     paulixops = qml.paulix_ops(generators, len(hamiltonian.wires))
     paulix_sector = optimal_sector(hamiltonian, generators, mol.n_electrons)
@@ -516,10 +516,10 @@ def test_taper_obs(symbols, geometry, charge):
     )
 
     # calculate the HF energy <\psi_{HF}| H |\psi_{HF}> for tapered and untapered Hamiltonian
-    o = np.array([1, 0])
-    l = np.array([0, 1])
-    state = functools.reduce(np.kron, [l if s else o for s in hf_state])
-    state_tapered = functools.reduce(np.kron, [l if s else o for s in hf_state_tapered])
+    o = pnp.array([1, 0])
+    l = pnp.array([0, 1])
+    state = functools.reduce(pnp.kron, [l if s else o for s in hf_state])
+    state_tapered = functools.reduce(pnp.kron, [l if s else o for s in hf_state_tapered])
 
     observables = [
         hamiltonian,
@@ -544,7 +544,7 @@ def test_taper_obs(symbols, geometry, charge):
             @ scipy.sparse.coo_matrix(state_tapered).T
         ).toarray()
 
-        assert np.isclose(obs_val, obs_val_tapered)
+        assert pnp.isclose(obs_val, obs_val_tapered)
         qml.assert_equal(tapered_obs, tapered_ps)
 
 
@@ -553,7 +553,7 @@ def test_taper_obs(symbols, geometry, charge):
     [
         (
             ["H", "H"],
-            np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.40104295]], requires_grad=True),
+            pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.40104295]], requires_grad=True),
             0,
             [
                 qml.Hamiltonian([1.0], [qml.PauliZ(0) @ qml.PauliZ(1)]),
@@ -566,7 +566,7 @@ def test_taper_obs(symbols, geometry, charge):
         ),
         (
             ["He", "H"],
-            np.array(
+            pnp.array(
                 [[0.0, 0.0, 0.0], [0.0, 0.0, 1.4588684632]],
                 requires_grad=True,
             ),
@@ -581,7 +581,7 @@ def test_taper_obs(symbols, geometry, charge):
         ),
         (
             ["H", "H", "H"],
-            np.array(
+            pnp.array(
                 [[-0.84586466, 0.0, 0.0], [0.84586466, 0.0, 0.0], [0.0, 1.46508057, 0.0]],
                 requires_grad=True,
             ),
@@ -604,7 +604,7 @@ def test_taper_excitations(
 
     mol = qml.qchem.Molecule(symbols, geometry, charge)
     num_electrons, num_wires = mol.n_electrons, 2 * mol.n_orbitals
-    hf_state = np.where(np.arange(num_wires) < num_electrons, 1, 0)
+    hf_state = pnp.where(pnp.arange(num_wires) < num_electrons, 1, 0)
     hf_tapered = taper_hf(generators, paulixops, paulix_sector, num_electrons, num_wires)
 
     observables = [
@@ -618,16 +618,16 @@ def test_taper_excitations(
         qml.taper(observale, generators, paulixops, paulix_sector) for observale in observables
     ]
 
-    o = np.array([1, 0])
-    l = np.array([0, 1])
-    state = functools.reduce(np.kron, [l if s else o for s in hf_state])
-    state_tapered = functools.reduce(np.kron, [l if s else o for s in hf_tapered])
+    o = pnp.array([1, 0])
+    l = pnp.array([0, 1])
+    state = functools.reduce(pnp.kron, [l if s else o for s in hf_state])
+    state_tapered = functools.reduce(pnp.kron, [l if s else o for s in hf_tapered])
 
     singles, doubles = qml.qchem.excitations(num_electrons, num_wires)
     exc_fnc = [qml.SingleExcitation, qml.DoubleExcitation]
     exc_obs, exc_tap = [[], []], [[], []]
     for idx, exc in enumerate([singles, doubles]):
-        exc_obs[idx] = [exc_fnc[idx](np.pi, wires=wire) for wire in exc]
+        exc_obs[idx] = [exc_fnc[idx](pnp.pi, wires=wire) for wire in exc]
         exc_tap[idx] = [
             taper_operation(op, generators, paulixops, paulix_sector, range(num_wires))
             for op in exc_obs[idx]
@@ -639,12 +639,12 @@ def test_taper_excitations(
     obs_all, obs_tap = exc_obs[0] + exc_obs[1], exc_tap[0] + exc_tap[1]
     for op_all, op_tap in zip(obs_all, obs_tap):
         if op_tap:
-            excited_state = np.matmul(qml.matrix(op_all, wire_order=range(len(hf_state))), state)
+            excited_state = pnp.matmul(qml.matrix(op_all, wire_order=range(len(hf_state))), state)
             ob_tap_mat = functools.reduce(
-                np.matmul,
+                pnp.matmul,
                 [qml.matrix(op, wire_order=range(len(hf_tapered))) for op in op_tap],
             )
-            excited_state_tapered = np.matmul(ob_tap_mat, state_tapered)
+            excited_state_tapered = pnp.matmul(ob_tap_mat, state_tapered)
             # check if tapered excitation gates remains spin and particle-number conserving,
             # and also evolves the tapered-state to have consistent energy values
             for obs, tap_obs in zip(observables, tapered_obs):
@@ -658,7 +658,7 @@ def test_taper_excitations(
                     @ tap_obs.sparse_matrix(wire_order=range(len(hf_tapered)))
                     @ scipy.sparse.coo_matrix(excited_state_tapered).getH()
                 ).toarray()
-                assert np.isclose(expec_val, expec_val_tapered)
+                assert pnp.isclose(expec_val, expec_val_tapered)
 
 
 @pytest.mark.parametrize(
@@ -667,7 +667,7 @@ def test_taper_excitations(
         (qml.U2(1, 1, 2), None, "is not implemented, please provide it with 'op_gen' args"),
         (
             qml.U2(1, 1, 2),
-            np.identity(16),
+            pnp.identity(16),
             "Generator for the operation needs to be a valid operator",
         ),
         (
@@ -682,7 +682,7 @@ def test_inconsistent_taper_ops(operation, op_gen, message_match):
 
     symbols, geometry, charge = (
         ["He", "H"],
-        np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.4588684632]]),
+        pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.4588684632]]),
         1,
     )
     mol = qml.qchem.Molecule(symbols, geometry, charge)
@@ -700,11 +700,11 @@ def test_inconsistent_taper_ops(operation, op_gen, message_match):
 @pytest.mark.parametrize(
     ("operation", "op_gen"),
     [
-        (qml.PauliX(1), qml.Hamiltonian((np.pi / 2,), [qml.PauliX(wires=[1])])),
-        (qml.PauliY(2), qml.Hamiltonian((np.pi / 2,), [qml.PauliY(wires=[2])])),
-        (qml.PauliZ(3), qml.Hamiltonian((np.pi / 2,), [qml.PauliZ(wires=[3])])),
+        (qml.PauliX(1), qml.Hamiltonian((pnp.pi / 2,), [qml.PauliX(wires=[1])])),
+        (qml.PauliY(2), qml.Hamiltonian((pnp.pi / 2,), [qml.PauliY(wires=[2])])),
+        (qml.PauliZ(3), qml.Hamiltonian((pnp.pi / 2,), [qml.PauliZ(wires=[3])])),
         (
-            qml.OrbitalRotation(np.pi, wires=[0, 1, 2, 3]),
+            qml.OrbitalRotation(pnp.pi, wires=[0, 1, 2, 3]),
             qml.Hamiltonian(
                 (0.25, -0.25, 0.25, -0.25),
                 [
@@ -716,7 +716,7 @@ def test_inconsistent_taper_ops(operation, op_gen, message_match):
             ),
         ),
         (
-            qml.FermionicSWAP(np.pi, wires=[0, 1]),
+            qml.FermionicSWAP(pnp.pi, wires=[0, 1]),
             qml.Hamiltonian(
                 (0.5, -0.25, -0.25, -0.25, -0.25),
                 [
@@ -735,7 +735,7 @@ def test_consistent_taper_ops(operation, op_gen):
 
     symbols, geometry, charge = (
         ["He", "H"],
-        np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.4588684632]]),
+        pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.4588684632]]),
         1,
     )
     mol = qml.qchem.Molecule(symbols, geometry, charge)
@@ -782,19 +782,19 @@ def test_consistent_taper_ops(operation, op_gen):
             qml.taper(observale, generators, paulixops, paulix_sector) for observale in observables
         ]
 
-        hf_state = np.where(np.arange(len(hamiltonian.wires)) < mol.n_electrons, 1, 0)
+        hf_state = pnp.where(pnp.arange(len(hamiltonian.wires)) < mol.n_electrons, 1, 0)
         hf_tapered = taper_hf(
             generators, paulixops, paulix_sector, mol.n_electrons, len(hamiltonian.wires)
         )
-        o, l = np.array([1, 0]), np.array([0, 1])
-        state = functools.reduce(np.kron, [l if s else o for s in hf_state])
-        state_tapered = functools.reduce(np.kron, [l if s else o for s in hf_tapered])
-        evolved_state = np.matmul(qml.matrix(operation, wire_order=range(len(hf_state))), state)
+        o, l = pnp.array([1, 0]), pnp.array([0, 1])
+        state = functools.reduce(pnp.kron, [l if s else o for s in hf_state])
+        state_tapered = functools.reduce(pnp.kron, [l if s else o for s in hf_tapered])
+        evolved_state = pnp.matmul(qml.matrix(operation, wire_order=range(len(hf_state))), state)
         ob_tap_mat = functools.reduce(
-            np.matmul,
+            pnp.matmul,
             [qml.matrix(op, wire_order=range(len(hf_tapered))) for op in taper_op1],
         )
-        evolved_state_tapered = np.matmul(ob_tap_mat, state_tapered)
+        evolved_state_tapered = pnp.matmul(ob_tap_mat, state_tapered)
 
         for obs, tap_obs in zip(observables, tapered_obs):
             expec_val = (
@@ -807,7 +807,7 @@ def test_consistent_taper_ops(operation, op_gen):
                 @ scipy.sparse.coo_matrix(qml.matrix(tap_obs, wire_order=range(len(hf_tapered))))
                 @ scipy.sparse.coo_matrix(evolved_state_tapered).getH()
             ).toarray()
-            assert np.isclose(expec_val, expec_val_tapered)
+            assert pnp.isclose(expec_val, expec_val_tapered)
 
 
 @pytest.mark.parametrize(
@@ -836,7 +836,7 @@ def test_taper_callable_ops(operation, op_wires, op_gen):
 
     symbols, geometry, charge = (
         ["He", "H"],
-        np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.4588684632]]),
+        pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.4588684632]]),
         1,
     )
     mol = qml.qchem.Molecule(symbols, geometry, charge)
@@ -852,7 +852,7 @@ def test_taper_callable_ops(operation, op_wires, op_gen):
     )
     assert callable(taper_op_fn)
 
-    for params in [0.0, 1.3, np.pi / 2, 2.37, np.pi]:
+    for params in [0.0, 1.3, pnp.pi / 2, 2.37, pnp.pi]:
         if callable(op_gen):
             op_gen = op_gen(op_wires)
         taper_op = taper_operation(
@@ -893,7 +893,7 @@ def test_taper_matrix_ops(operation, op_wires, op_gen):
 
     symbols, geometry, charge = (
         ["He", "H"],
-        np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.4588684632]]),
+        pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.4588684632]]),
         1,
     )
     mol = qml.qchem.Molecule(symbols, geometry, charge)
@@ -914,7 +914,7 @@ def test_taper_matrix_ops(operation, op_wires, op_gen):
     )
     assert callable(taper_op1)
 
-    for params in [0.0, 1.3, np.pi / 2, 2.37, np.pi]:
+    for params in [0.0, 1.3, pnp.pi / 2, 2.37, pnp.pi]:
         taper_op2 = taper_operation(
             operation(params, wires=op_wires),
             generators,
@@ -958,7 +958,7 @@ def test_inconsistent_callable_ops(operation, op_wires, op_gen, message_match):
 
     symbols, geometry, charge = (
         ["He", "H"],
-        np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.4588684632]]),
+        pnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.4588684632]]),
         1,
     )
     mol = qml.qchem.Molecule(symbols, geometry, charge)

--- a/tests/resource/test_first_quantization.py
+++ b/tests/resource/test_first_quantization.py
@@ -19,7 +19,7 @@ for quantum algorithms in first quantization using a plane-wave basis.
 import pytest
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 
 
 @pytest.mark.parametrize(
@@ -32,12 +32,12 @@ def test_fq_params(n, eta, omega, error, charge, br):
     r"""Test that the FirstQuantization class initiates correct parameters."""
     est = qml.resource.FirstQuantization(n, eta, omega)
 
-    assert np.allclose(est.n, n)
-    assert np.allclose(est.eta, eta)
-    assert np.allclose(est.omega, omega)
-    assert np.allclose(est.error, error)
-    assert np.allclose(est.charge, charge)
-    assert np.allclose(est.br, br)
+    assert pnp.allclose(est.n, n)
+    assert pnp.allclose(est.eta, eta)
+    assert pnp.allclose(est.omega, omega)
+    assert pnp.allclose(est.error, error)
+    assert pnp.allclose(est.charge, charge)
+    assert pnp.allclose(est.br, br)
 
 
 @pytest.mark.parametrize(
@@ -50,9 +50,9 @@ def test_fq_vals(n, eta, omega, lamb, g_cost, q_cost):
     r"""Test that the FirstQuantization class computes correct attributes."""
     est = qml.resource.FirstQuantization(n, eta, omega)
 
-    assert np.allclose(est.lamb, lamb)
-    assert np.allclose(est.gates, g_cost)
-    assert np.allclose(est.qubits, q_cost)
+    assert pnp.allclose(est.lamb, lamb)
+    assert pnp.allclose(est.gates, g_cost)
+    assert pnp.allclose(est.qubits, q_cost)
 
 
 @pytest.mark.parametrize(
@@ -246,7 +246,7 @@ def test_norm(n, eta, omega, error, br, charge, norm_ref):
     r"""Test that norm returns the correct value."""
     norm = qml.resource.FirstQuantization.norm(n, eta, omega, error, br, charge)
 
-    assert np.allclose(norm, norm_ref)
+    assert pnp.allclose(norm, norm_ref)
 
 
 @pytest.mark.parametrize(
@@ -275,7 +275,7 @@ def test_norm_error(n, eta, omega, error, br, charge):
             100000,
             156,
             None,
-            np.array(
+            pnp.array(
                 [
                     [9.44862994, 0.0, 0.0],
                     [0.0, 10.39349294, 0.0],
@@ -290,7 +290,7 @@ def test_norm_error(n, eta, omega, error, br, charge):
             10000,
             312,
             None,
-            np.array(
+            pnp.array(
                 [
                     [18.89725988, 0.0, 0.0],
                     [0.0, 10.39349294, 0.0],
@@ -305,7 +305,7 @@ def test_norm_error(n, eta, omega, error, br, charge):
             100000,
             156,
             None,
-            np.array(
+            pnp.array(
                 [
                     [9.44862994, 0.0, 0.0],
                     [0.0, 10.39349294, 0.0],
@@ -322,9 +322,9 @@ def test_fq_vals_non_qubic(n, eta, omega, vectors, lamb, g_cost, q_cost):
     r"""Test that the FirstQuantization class computes correct attributes."""
     est = qml.resource.FirstQuantization(n, eta, omega, vectors=vectors)
 
-    assert np.allclose(est.lamb, lamb)
-    assert np.allclose(est.gates, g_cost)
-    assert np.allclose(est.qubits, q_cost)
+    assert pnp.allclose(est.lamb, lamb)
+    assert pnp.allclose(est.gates, g_cost)
+    assert pnp.allclose(est.qubits, q_cost)
 
 
 @pytest.mark.parametrize(
@@ -349,7 +349,7 @@ def test_init_error_1(n, eta, omega, error, br, charge, vectors):
             0.001,
             7,
             0,
-            np.array(
+            pnp.array(
                 [
                     [9.0, 0.0, 0.0],
                     [0.0, 9.0, 0.0],
@@ -374,7 +374,7 @@ def test_init_error_2(n, eta, omega, error, br, charge, vectors):
             0.0016,
             7,
             0,
-            np.array(
+            pnp.array(
                 [
                     [10.0, 0.0, 0.0],
                     [0.0, 10.0, 0.0],

--- a/tests/resource/test_measurement.py
+++ b/tests/resource/test_measurement.py
@@ -17,9 +17,9 @@ Unit tests for functions needed for estimating the complexity of measuring expec
 import pytest
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 
-coeffs = [np.array([-0.32707061, 0.7896887]), np.array([0.18121046])]
+coeffs = [pnp.array([-0.32707061, 0.7896887]), pnp.array([0.18121046])]
 error = 0.0016  # chemical accuracy
 shots = 419218  # computed manually
 variances = [0.73058343, 0.03283723]  # obtained with the upper bound var(pauli_word) = 1
@@ -51,5 +51,5 @@ def test_estimate_error(coefficients, err, shots_, var):
     e_novar = qml.resource.estimate_error(coefficients, shots=shots_)
     e_var = qml.resource.estimate_error(coefficients, variances=var, shots=shots_)
 
-    assert np.allclose(e_novar, err)
-    assert np.allclose(e_var, err)
+    assert pnp.allclose(e_novar, err)
+    assert pnp.allclose(e_var, err)

--- a/tests/resource/test_second_quantization.py
+++ b/tests/resource/test_second_quantization.py
@@ -18,11 +18,11 @@ Unit tests for functions needed for resource estimation with the double factoriz
 import pytest
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 
-one_h2 = np.array([[-1.25330961e00, 3.46833673e-13], [3.46944695e-13, -4.75069041e-01]])
+one_h2 = pnp.array([[-1.25330961e00, 3.46833673e-13], [3.46944695e-13, -4.75069041e-01]])
 
-two_h2 = np.array(  # in chemist notation
+two_h2 = pnp.array(  # in chemist notation
     [
         [
             [[6.74755872e-01, -4.00346423e-13], [-4.00290912e-13, 6.63711349e-01]],
@@ -35,7 +35,7 @@ two_h2 = np.array(  # in chemist notation
     ]
 )
 
-two_h2_ph = np.array(  # in physicist notation
+two_h2_ph = pnp.array(  # in physicist notation
     [
         [
             [[6.74755872e-01, 8.45989945e-14], [8.47655279e-14, 1.81210478e-01]],
@@ -58,14 +58,14 @@ two_h2_ph = np.array(  # in physicist notation
 def test_df_params(one, two, error, tol_factor, tol_eigval, br, alpha, beta):
     r"""Test that the DoubleFactorization class initiates correct parameters."""
     est = qml.resource.DoubleFactorization(one, two, chemist_notation=True)
-    assert np.allclose(est.one_electron, one)
-    assert np.allclose(est.two_electron, two)
-    assert np.allclose(est.error, error)
-    assert np.allclose(est.tol_factor, tol_factor)
-    assert np.allclose(est.tol_eigval, tol_eigval)
-    assert np.allclose(est.br, br)
-    assert np.allclose(est.alpha, alpha)
-    assert np.allclose(est.beta, beta)
+    assert pnp.allclose(est.one_electron, one)
+    assert pnp.allclose(est.two_electron, two)
+    assert pnp.allclose(est.error, error)
+    assert pnp.allclose(est.tol_factor, tol_factor)
+    assert pnp.allclose(est.tol_eigval, tol_eigval)
+    assert pnp.allclose(est.br, br)
+    assert pnp.allclose(est.alpha, alpha)
+    assert pnp.allclose(est.beta, beta)
 
 
 @pytest.mark.parametrize(
@@ -77,7 +77,7 @@ def test_df_params(one, two, error, tol_factor, tol_eigval, br, alpha, beta):
 def test_df_notation_conversion(one, two_phys, two_chem):
     r"""Test that the DoubleFactorization class initiates correct two-electron integrals."""
     est = qml.resource.DoubleFactorization(one, two_phys, chemist_notation=False)
-    assert np.allclose(est.two_electron, two_chem)
+    assert pnp.allclose(est.two_electron, two_chem)
 
 
 @pytest.mark.parametrize(
@@ -87,7 +87,7 @@ def test_df_notation_conversion(one, two_phys, two_chem):
             one_h2,
             two_h2,
             4,
-            np.array(
+            pnp.array(
                 [
                     [[1.06723431e-01, 3.28955607e-15], [3.34805476e-15, -1.04898524e-01]],
                     [[-7.89837537e-14, -4.25688240e-01], [-4.25688240e-01, -1.07150807e-13]],
@@ -95,14 +95,14 @@ def test_df_notation_conversion(one, two_phys, two_chem):
                 ]
             ),
             [
-                np.array([-0.10489852, 0.10672343]),
-                np.array([-0.42568824, 0.42568824]),
-                np.array([-0.82864211, -0.81447282]),
+                pnp.array([-0.10489852, 0.10672343]),
+                pnp.array([-0.42568824, 0.42568824]),
+                pnp.array([-0.82864211, -0.81447282]),
             ],
             [
-                np.array([[1.58209235e-14, -1.00000000e00], [-1.00000000e00, -1.58209235e-14]]),
-                np.array([[0.70710678, -0.70710678], [0.70710678, 0.70710678]]),
-                np.array([[-1.26896915e-11, -1.00000000e00], [1.00000000e00, -1.26896915e-11]]),
+                pnp.array([[1.58209235e-14, -1.00000000e00], [-1.00000000e00, -1.58209235e-14]]),
+                pnp.array([[0.70710678, -0.70710678], [0.70710678, 0.70710678]]),
+                pnp.array([[-1.26896915e-11, -1.00000000e00], [1.00000000e00, -1.26896915e-11]]),
             ],
             3,
             2,
@@ -114,13 +114,13 @@ def test_df_factorization(one, two, n, factors, eigvals, eigvecs, rank_r, rank_m
     r"""Test that DoubleFactorization class returns correct factorization values."""
     est = qml.resource.DoubleFactorization(one, two, chemist_notation=True)
 
-    assert np.allclose(est.n, n)
-    assert np.allclose(est.factors, factors)
-    assert np.allclose(np.array(est.eigvals), np.array(eigvals))
-    assert np.allclose(np.array(est.eigvecs), np.array(eigvecs))
-    assert np.allclose(est.rank_r, rank_r)
-    assert np.allclose(est.rank_m, rank_m)
-    assert np.allclose(est.rank_max, rank_max)
+    assert pnp.allclose(est.n, n)
+    assert pnp.allclose(est.factors, factors)
+    assert pnp.allclose(pnp.array(est.eigvals), pnp.array(eigvals))
+    assert pnp.allclose(pnp.array(est.eigvecs), pnp.array(eigvecs))
+    assert pnp.allclose(est.rank_r, rank_r)
+    assert pnp.allclose(est.rank_m, rank_m)
+    assert pnp.allclose(est.rank_max, rank_max)
 
 
 @pytest.mark.parametrize(("one", "two", "lamb"), [(one_h2, two_h2_ph, 1.6570518796336895)])
@@ -128,7 +128,7 @@ def test_df_lamb(one, two, lamb):
     r"""Test that DoubleFactorization class returns a correct norm."""
     est = qml.resource.DoubleFactorization(one, two)
 
-    assert np.allclose(est.lamb, lamb)
+    assert pnp.allclose(est.lamb, lamb)
 
 
 @pytest.mark.parametrize(("one", "two", "g_cost", "q_cost"), [(one_h2, two_h2, 876953, 113)])
@@ -136,8 +136,8 @@ def test_df_costs(one, two, g_cost, q_cost):
     r"""Test that DoubleFactorization class returns correct costs."""
     est = qml.resource.DoubleFactorization(one, two, chemist_notation=True)
 
-    assert np.allclose(est.gates, g_cost)
-    assert np.allclose(est.qubits, q_cost)
+    assert pnp.allclose(est.gates, g_cost)
+    assert pnp.allclose(est.qubits, q_cost)
 
 
 # cost_ref is computed manually
@@ -335,7 +335,7 @@ def test_qubit_cost_error(n, norm, error, rank_r, rank_m, rank_max, br, alpha, b
             one_h2,
             # two-electron integral is arranged in chemist notation
             two_h2,
-            np.tensor(
+            pnp.tensor(
                 [[-0.10489852, 0.10672343], [-0.42568824, 0.42568824], [-0.82864211, -0.81447282]]
             ),
             1.6570518796336895,  # lambda value obtained from openfermion
@@ -346,4 +346,4 @@ def test_df_norm(one, two, eigvals, lamb_ref):
     r"""Test that the norm function returns the correct 1-norm."""
     lamb = qml.resource.DoubleFactorization.norm(one, two, eigvals)
 
-    assert np.allclose(lamb, lamb_ref)
+    assert pnp.allclose(lamb, lamb_ref)

--- a/tests/shadow/test_shadow_class.py
+++ b/tests/shadow/test_shadow_class.py
@@ -19,7 +19,7 @@ import numpy as onp
 import pytest
 
 import pennylane as qml
-import pennylane.numpy as np
+import pennylane.numpy as pnp
 from pennylane.shadows import ClassicalShadow, median_of_means, pauli_expval
 
 wires = range(3)
@@ -53,8 +53,8 @@ class TestUnitTestClassicalShadows:
     def test_shape_mismatch_error(self):
         """Test than an error is raised when a ClassicalShadow object
         is created using bits and recipes with different shapes"""
-        bits = np.random.randint(0, 1, size=(3, 4))
-        recipes = np.random.randint(0, 2, size=(3, 5))
+        bits = pnp.random.randint(0, 1, size=(3, 4))
+        recipes = pnp.random.randint(0, 2, size=(3, 5))
 
         msg = "Bits and recipes but have the same shape"
         with pytest.raises(ValueError, match=msg):
@@ -63,8 +63,8 @@ class TestUnitTestClassicalShadows:
     def test_wire_mismatch_error(self):
         """Test that an error is raised when a ClassicalShadow object
         is created using a wire map with the incorrect size"""
-        bits = np.random.randint(0, 1, size=(3, 4))
-        recipes = np.random.randint(0, 2, size=(3, 4))
+        bits = pnp.random.randint(0, 1, size=(3, 4))
+        recipes = pnp.random.randint(0, 2, size=(3, 4))
         wire_map = [0, 1, 2]
 
         msg = "The 1st axis of bits must have the same size as wire_map"
@@ -120,13 +120,13 @@ class TestIntegrationShadows:
         shadow = ClassicalShadow(bits, recipes)
         global_snapshots = shadow.global_snapshots()
 
-        state = np.sum(global_snapshots, axis=0) / shadow.snapshots
-        bell_state = np.array([[0.5, 0, 0, 0.5], [0, 0, 0, 0], [0, 0, 0, 0], [0.5, 0, 0, 0.5]])
+        state = pnp.sum(global_snapshots, axis=0) / shadow.snapshots
+        bell_state = pnp.array([[0.5, 0, 0, 0.5], [0, 0, 0, 0], [0, 0, 0, 0], [0.5, 0, 0, 0.5]])
         assert qml.math.allclose(state, bell_state, atol=1e-1)
 
         # reduced state should yield maximally mixed state
         local_snapshots = shadow.local_snapshots(wires=[0])
-        assert qml.math.allclose(np.mean(local_snapshots, axis=0)[0], 0.5 * np.eye(2), atol=1e-1)
+        assert qml.math.allclose(pnp.mean(local_snapshots, axis=0)[0], 0.5 * pnp.eye(2), atol=1e-1)
 
         # alternative computation
         bits, recipes = qnode(1)
@@ -134,9 +134,9 @@ class TestIntegrationShadows:
         global_snapshots = shadow.global_snapshots()
         local_snapshots = shadow.local_snapshots(wires=[0])
 
-        state = np.sum(global_snapshots, axis=0) / shadow.snapshots
-        assert qml.math.allclose(state, 0.5 * np.eye(2), atol=1e-1)
-        assert np.all(local_snapshots[:, 0] == global_snapshots)
+        state = pnp.sum(global_snapshots, axis=0) / shadow.snapshots
+        assert qml.math.allclose(state, 0.5 * pnp.eye(2), atol=1e-1)
+        assert pnp.all(local_snapshots[:, 0] == global_snapshots)
 
 
 def hadamard_circuit(wires, shots=10000, interface="autograd"):
@@ -170,7 +170,7 @@ def qft_circuit(wires, shots=10000, interface="autograd"):
     """Quantum Fourier Transform circuit"""
     dev = qml.device("default.qubit", wires=wires, shots=shots)
 
-    one_state = np.zeros(wires)
+    one_state = pnp.zeros(wires)
     one_state[-1] = 1
 
     @qml.qnode(dev, interface=interface)
@@ -197,8 +197,8 @@ class TestStateReconstruction:
         state = shadow.global_snapshots()
         assert state.shape == (10000, 2**wires, 2**wires)
 
-        state = np.mean(state, axis=0)
-        expected = np.ones((2**wires, 2**wires)) / (2**wires)
+        state = pnp.mean(state, axis=0)
+        expected = pnp.ones((2**wires, 2**wires)) / (2**wires)
 
         assert qml.math.allclose(state, expected, atol=1e-1)
 
@@ -213,9 +213,9 @@ class TestStateReconstruction:
         state = shadow.global_snapshots()
         assert state.shape == (10000, 2**wires, 2**wires)
 
-        state = np.mean(state, axis=0)
-        expected = np.zeros((2**wires, 2**wires))
-        expected[np.array([0, 0, -1, -1]), np.array([0, -1, 0, -1])] = 0.5
+        state = pnp.mean(state, axis=0)
+        expected = pnp.zeros((2**wires, 2**wires))
+        expected[pnp.array([0, 0, -1, -1]), pnp.array([0, -1, 0, -1])] = 0.5
 
         assert qml.math.allclose(state, expected, atol=1e-1)
 
@@ -240,14 +240,14 @@ class TestStateReconstruction:
         shadow = ClassicalShadow(bits, recipes)
 
         # choose 1000 random indices
-        snapshots = np.random.choice(np.arange(10000, dtype=np.int64), size=1000, replace=False)
+        snapshots = pnp.random.choice(pnp.arange(10000, dtype=pnp.int64), size=1000, replace=False)
         state = shadow.global_snapshots(snapshots=snapshots)
         assert state.shape == (len(snapshots), 2**wires, 2**wires)
 
         # check the results against obtaining the full global snapshots
         expected = shadow.global_snapshots()
         for i, t in enumerate(snapshots):
-            assert np.allclose(expected[t], state[i])
+            assert pnp.allclose(expected[t], state[i])
 
     def test_large_state_warning(self, monkeypatch):
         """Test that a warning is raised when a very large state is reconstructed"""
@@ -278,9 +278,9 @@ class TestStateReconstructionInterfaces:
         state = shadow.global_snapshots()
         assert state.shape == (10000, 8, 8)
 
-        state = np.mean(state, axis=0)
-        expected = np.exp(np.arange(8) * 2j * np.pi / 8) / np.sqrt(8)
-        expected = np.outer(expected, np.conj(expected))
+        state = pnp.mean(state, axis=0)
+        expected = pnp.exp(pnp.arange(8) * 2j * pnp.pi / 8) / pnp.sqrt(8)
+        expected = pnp.outer(expected, pnp.conj(expected))
 
         assert qml.math.allclose(state, expected, atol=1e-1)
 
@@ -309,7 +309,7 @@ class TestExpvalEstimation:
 
         actual = shadow.expval(obs, k=10)
         assert actual.shape == (7,)
-        assert actual.dtype == np.float64
+        assert actual.dtype == pnp.float64
         assert qml.math.allclose(actual, expected, atol=1e-1)
 
     def test_max_entangled_expval(self):
@@ -334,7 +334,7 @@ class TestExpvalEstimation:
 
         actual = shadow.expval(obs, k=10)
         assert actual.shape == (8,)
-        assert actual.dtype == np.float64
+        assert actual.dtype == pnp.float64
         assert qml.math.allclose(actual, expected, atol=1e-1)
 
     def test_non_pauli_error(self):
@@ -385,19 +385,19 @@ class TestExpvalEstimationInterfaces:
         expected = [
             -1,
             0,
-            -1 / np.sqrt(2),
-            -1 / np.sqrt(2),
+            -1 / pnp.sqrt(2),
+            -1 / pnp.sqrt(2),
             0,
             0,
-            1 / np.sqrt(2),
-            1 / np.sqrt(2),
-            -1 / np.sqrt(2),
+            1 / pnp.sqrt(2),
+            1 / pnp.sqrt(2),
+            -1 / pnp.sqrt(2),
             0,
         ]
 
         actual = shadow.expval(obs, k=10)
         assert actual.shape == (10,)
-        assert actual.dtype == np.float64
+        assert actual.dtype == pnp.float64
         assert qml.math.allclose(actual, expected, atol=1e-1)
 
 
@@ -429,12 +429,12 @@ class TestMedianOfMeans:
     @pytest.mark.parametrize(
         "arr, num_batches, expected",
         [
-            (np.array([0.1]), 1, 0.1),
-            (np.array([0.1, 0.2]), 1, 0.15),
-            (np.array([0.1, 0.2]), 2, 0.15),
-            (np.array([0.2, 0.1, 0.4]), 1, 0.7 / 3),
-            (np.array([0.2, 0.1, 0.4]), 2, 0.275),
-            (np.array([0.2, 0.1, 0.4]), 3, 0.2),
+            (pnp.array([0.1]), 1, 0.1),
+            (pnp.array([0.1, 0.2]), 1, 0.15),
+            (pnp.array([0.1, 0.2]), 2, 0.15),
+            (pnp.array([0.2, 0.1, 0.4]), 1, 0.7 / 3),
+            (pnp.array([0.2, 0.1, 0.4]), 2, 0.275),
+            (pnp.array([0.2, 0.1, 0.4]), 3, 0.2),
         ],
     )
     @pytest.mark.parametrize("interface", ["autograd", "jax", "tf", "torch"])
@@ -444,7 +444,7 @@ class TestMedianOfMeans:
 
         actual = median_of_means(arr, num_batches)
         assert actual.shape == ()
-        assert np.allclose(actual, expected)
+        assert pnp.allclose(actual, expected)
 
 
 @pytest.mark.all_interfaces
@@ -455,15 +455,15 @@ class TestPauliExpval:
     @pytest.mark.parametrize("interface", ["autograd", "jax", "tf", "torch"])
     def test_word_not_present(self, word, interface):
         """Test that the output is 0 if the Pauli word is not present in the recipes"""
-        bits = convert_to_interface(np.array([[0, 0, 0]]), interface)
-        recipes = convert_to_interface(np.array([[0, 0, 0]]), interface)
+        bits = convert_to_interface(pnp.array([[0, 0, 0]]), interface)
+        recipes = convert_to_interface(pnp.array([[0, 0, 0]]), interface)
 
-        actual = pauli_expval(bits, recipes, np.array([word]))
+        actual = pauli_expval(bits, recipes, pnp.array([word]))
         assert actual.shape == (1, 1)
         assert actual[0][0] == 0
 
-    single_bits = np.array([[1, 0, 1]])
-    single_recipes = np.array([[0, 1, 2]])
+    single_bits = pnp.array([[1, 0, 1]])
+    single_recipes = pnp.array([[0, 1, 2]])
 
     @pytest.mark.parametrize(
         "word, expected", [([0, 1, 2], 27), ([0, 1, -1], -9), ([-1, -1, 2], -3), ([-1, -1, -1], 1)]
@@ -474,12 +474,12 @@ class TestPauliExpval:
         bits = convert_to_interface(self.single_bits, interface)
         recipes = convert_to_interface(self.single_recipes, interface)
 
-        actual = pauli_expval(bits, recipes, np.array([word]))
+        actual = pauli_expval(bits, recipes, pnp.array([word]))
         assert actual.shape == (1, 1)
         assert actual[0][0] == expected
 
-    multi_bits = np.array([[1, 0, 1], [0, 0, 1], [1, 1, 1]])
-    multi_recipes = np.array([[0, 1, 2], [0, 1, 2], [0, 1, 0]])
+    multi_bits = pnp.array([[1, 0, 1], [0, 0, 1], [1, 1, 1]])
+    multi_recipes = pnp.array([[0, 1, 2], [0, 1, 2], [0, 1, 0]])
 
     @pytest.mark.parametrize(
         "word, expected",
@@ -497,6 +497,6 @@ class TestPauliExpval:
         bits = convert_to_interface(self.multi_bits, interface)
         recipes = convert_to_interface(self.multi_recipes, interface)
 
-        actual = pauli_expval(bits, recipes, np.array([word]))
+        actual = pauli_expval(bits, recipes, pnp.array([word]))
         assert actual.shape == (self.multi_bits.shape[0], 1)
         assert qml.math.allclose(actual[:, 0], expected)

--- a/tests/shadow/test_shadow_transforms.py
+++ b/tests/shadow/test_shadow_transforms.py
@@ -18,7 +18,7 @@ import warnings
 import pytest
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane.shadows.transforms import _replace_obs
 
 
@@ -60,7 +60,7 @@ def qft_circuit(wires, shots=10000, interface="autograd"):
     """Quantum Fourier Transform circuit"""
     dev = qml.device("default.qubit", wires=wires, shots=shots)
 
-    one_state = np.zeros(wires)
+    one_state = pnp.zeros(wires)
     one_state[-1] = 1
 
     @qml.qnode(dev, interface=interface)
@@ -124,7 +124,7 @@ class TestReplaceObs:
         circuit = _replace_obs(circuit, qml.probs, wires=[0, 1])
         res = circuit()
 
-        assert isinstance(res, np.ndarray)
+        assert isinstance(res, pnp.ndarray)
         assert res.shape == (4,)
 
 
@@ -141,7 +141,7 @@ class TestStateForward:
         circuit = qml.shadows.shadow_state(circuit, wires=range(wires), diffable=diffable)
 
         actual = circuit()
-        expected = np.ones((2**wires, 2**wires)) / (2**wires)
+        expected = pnp.ones((2**wires, 2**wires)) / (2**wires)
 
         assert qml.math.allclose(actual, expected, atol=1e-1)
 
@@ -153,8 +153,8 @@ class TestStateForward:
         circuit = qml.shadows.shadow_state(circuit, wires=range(wires), diffable=diffable)
 
         actual = circuit()
-        expected = np.zeros((2**wires, 2**wires))
-        expected[np.array([0, 0, -1, -1]), np.array([0, -1, 0, -1])] = 0.5
+        expected = pnp.zeros((2**wires, 2**wires))
+        expected[pnp.array([0, 0, -1, -1]), pnp.array([0, -1, 0, -1])] = 0.5
 
         assert qml.math.allclose(actual, expected, atol=1e-1)
 
@@ -170,8 +170,8 @@ class TestStateForward:
         actual = circuit()
 
         expected = [
-            np.array([[0.5, 0], [0, 0.5]]),
-            np.array([[0.5, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0.5]]),
+            pnp.array([[0.5, 0], [0, 0.5]]),
+            pnp.array([[0.5, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0.5]]),
         ]
 
         assert qml.math.allclose(actual[0], expected[0], atol=1e-1)
@@ -223,8 +223,8 @@ class TestStateForwardInterfaces:
         circuit = qml.shadows.shadow_state(circuit, wires=[0, 1, 2], diffable=diffable)
 
         actual = circuit()
-        expected = np.exp(np.arange(8) * 2j * np.pi / 8) / np.sqrt(8)
-        expected = np.outer(expected, np.conj(expected))
+        expected = pnp.exp(pnp.arange(8) * 2j * pnp.pi / 8) / pnp.sqrt(8)
+        expected = pnp.outer(expected, pnp.conj(expected))
 
         assert qml.math.allclose(actual, expected, atol=1e-1)
 
@@ -233,7 +233,7 @@ class TestStateBackward:
     """Test that the gradient of the state reconstruction is correct"""
 
     # make rotations close to pi / 2 to ensure gradients are not too small
-    x = np.random.uniform(
+    x = pnp.random.uniform(
         0.8, 2, size=qml.BasicEntanglerLayers.shape(n_layers=1, n_wires=3)
     ).tolist()
 
@@ -246,7 +246,7 @@ class TestStateBackward:
         sub_wires = [[0, 1], [1, 2]]
         shadow_circuit = qml.shadows.shadow_state(shadow_circuit, wires=sub_wires, diffable=True)
 
-        x = np.array(self.x, requires_grad=True)
+        x = pnp.array(self.x, requires_grad=True)
 
         # for autograd in particular, take only the real part since it doesn't
         # support complex differentiation

--- a/tests/templates/test_subroutines/test_adder.py
+++ b/tests/templates/test_subroutines/test_adder.py
@@ -18,7 +18,7 @@ Tests for the Adder template.
 import pytest
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 
 
 def test_standard_validity_Adder():
@@ -120,7 +120,7 @@ class TestAdder:
 
         # pylint: disable=bad-reversed-sequence
         result = sum(bit * (2**i) for i, bit in enumerate(reversed(circuit(x))))
-        assert np.allclose(result, (x + k) % mod)
+        assert pnp.allclose(result, (x + k) % mod)
 
     @pytest.mark.parametrize(
         ("k", "x_wires", "mod", "work_wires", "msg_match"),

--- a/tests/templates/test_subroutines/test_commuting_evolution.py
+++ b/tests/templates/test_subroutines/test_commuting_evolution.py
@@ -19,7 +19,7 @@ import pytest
 from scipy.linalg import expm
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 
 
 def test_standard_validity():
@@ -61,7 +61,7 @@ def test_adjoint():
     res2, state2 = adjoint_evolution_circuit(-0.13)
 
     assert res1 == res2
-    assert all(np.isclose(state1, state2))
+    assert all(pnp.isclose(state1, state2))
 
 
 def test_queuing():
@@ -123,8 +123,8 @@ def test_forward_execution():
 
     t = 1.0
     res = circuit(t)
-    expected = -np.cos(4)
-    assert np.allclose(res, expected)
+    expected = -pnp.cos(4)
+    assert pnp.allclose(res, expected)
 
 
 @pytest.mark.jax
@@ -157,7 +157,7 @@ class TestInputs:
     def test_invalid_hamiltonian(self):
         """Tests TypeError is raised if `hamiltonian` does not have a pauli rep."""
 
-        invalid_operator = qml.Hermitian(np.eye(2), 0)
+        invalid_operator = qml.Hermitian(pnp.eye(2), 0)
         assert pytest.raises(TypeError, qml.CommutingEvolution, invalid_operator, 1)
 
 
@@ -210,13 +210,13 @@ class TestGradients:
             qml.CommutingEvolution(hamiltonian, time, frequencies)
             return qml.expval(qml.PauliZ(0))
 
-        x_vals = np.linspace(-np.pi, np.pi, num=10)
+        x_vals = pnp.linspace(-pnp.pi, pnp.pi, num=10)
 
         # pylint: disable=not-callable
         grads_finite_diff = [qml.gradients.finite_diff(circuit)(x) for x in x_vals]
         grads_param_shift = [qml.gradients.param_shift(circuit)(x) for x in x_vals]
 
-        assert all(np.isclose(grads_finite_diff, grads_param_shift, atol=1e-4))
+        assert all(pnp.isclose(grads_finite_diff, grads_param_shift, atol=1e-4))
 
     # pylint: disable=not-callable
     def test_four_term_case(self):
@@ -237,12 +237,12 @@ class TestGradients:
             qml.CommutingEvolution(hamiltonian, time, frequencies)
             return qml.expval(qml.PauliZ(0))
 
-        x_vals = [np.array(x, requires_grad=True) for x in np.linspace(-np.pi, np.pi, num=10)]
+        x_vals = [pnp.array(x, requires_grad=True) for x in pnp.linspace(-pnp.pi, pnp.pi, num=10)]
 
         grads_finite_diff = [qml.gradients.finite_diff(circuit)(x) for x in x_vals]
         grads_param_shift = [qml.gradients.param_shift(circuit)(x) for x in x_vals]
 
-        assert all(np.isclose(grads_finite_diff, grads_param_shift, atol=1e-4))
+        assert all(pnp.isclose(grads_finite_diff, grads_param_shift, atol=1e-4))
 
     # pylint: disable=not-callable
     def test_differentiable_hamiltonian(self):
@@ -251,7 +251,7 @@ class TestGradients:
         n_wires = 2
         dev = qml.device("default.qubit", wires=n_wires)
         obs = [qml.PauliX(0) @ qml.PauliY(1), qml.PauliY(0) @ qml.PauliX(1)]
-        diff_coeffs = np.array([1.0, -1.0], requires_grad=True)
+        diff_coeffs = pnp.array([1.0, -1.0], requires_grad=True)
         frequencies = (2, 4)
 
         def parametrized_hamiltonian(coeffs):
@@ -263,13 +263,13 @@ class TestGradients:
             qml.CommutingEvolution(parametrized_hamiltonian(coeffs), time, frequencies)
             return qml.expval(qml.PauliZ(0))
 
-        x_vals = [np.array(x, requires_grad=True) for x in np.linspace(-np.pi, np.pi, num=10)]
+        x_vals = [pnp.array(x, requires_grad=True) for x in pnp.linspace(-pnp.pi, pnp.pi, num=10)]
 
         grads_finite_diff = [
-            np.hstack(qml.gradients.finite_diff(circuit)(x, diff_coeffs)) for x in x_vals
+            pnp.hstack(qml.gradients.finite_diff(circuit)(x, diff_coeffs)) for x in x_vals
         ]
         grads_param_shift = [
-            np.hstack(qml.gradients.param_shift(circuit)(x, diff_coeffs)) for x in x_vals
+            pnp.hstack(qml.gradients.param_shift(circuit)(x, diff_coeffs)) for x in x_vals
         ]
 
-        assert np.isclose(grads_finite_diff, grads_param_shift, atol=1e-6).all()
+        assert pnp.isclose(grads_finite_diff, grads_param_shift, atol=1e-6).all()

--- a/tests/templates/test_subroutines/test_flip_sign.py
+++ b/tests/templates/test_subroutines/test_flip_sign.py
@@ -17,7 +17,7 @@ Tests for the FlipSign template.
 import pytest
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 
 
 def test_standarad_checks():
@@ -75,11 +75,11 @@ class TestFlipSign:
         statuses = []
         for ind, x in enumerate(circuit()):
             if ind == n_status:
-                statuses.append(bool(np.sign(x) == -1))
+                statuses.append(bool(pnp.sign(x) == -1))
             else:
-                statuses.append(bool(np.sign(x) == 1))
+                statuses.append(bool(pnp.sign(x) == 1))
 
-        assert np.all(np.array(statuses))
+        assert pnp.all(pnp.array(statuses))
 
     @pytest.mark.parametrize(
         ("n_status, n_wires"),

--- a/tests/templates/test_subroutines/test_gqsp.py
+++ b/tests/templates/test_subroutines/test_gqsp.py
@@ -20,7 +20,7 @@ import pytest
 from numpy.linalg import matrix_power
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 
 
 class TestGQSP:
@@ -29,7 +29,7 @@ class TestGQSP:
     def test_standard_validity(self):
         """Test standard validity criteria with assert_valid."""
 
-        angles = np.ones([3, 5])
+        angles = pnp.ones([3, 5])
 
         @qml.prod
         def unitary(wires):
@@ -65,7 +65,7 @@ class TestGQSP:
         )
         generated_output = qml.matrix(circuit, wire_order=[0, 1])(angles)[:2, :2]
 
-        assert np.allclose(expected_output, generated_output)
+        assert pnp.allclose(expected_output, generated_output)
 
     @pytest.mark.parametrize(
         ("unitary"),
@@ -80,9 +80,9 @@ class TestGQSP:
 
         # Precalucated angles for polynomial p(x) = 0.1 + 0.2x + 0.3x^2
         angles = [
-            np.array([0.10798862, 0.22107159, 1.25635543]),
-            np.array([-3.14159265, 0.0, 0.0]),
-            np.array([3.14159265, 0.0, 0.0]),
+            pnp.array([0.10798862, 0.22107159, 1.25635543]),
+            pnp.array([-3.14159265, 0.0, 0.0]),
+            pnp.array([3.14159265, 0.0, 0.0]),
         ]
 
         dev = qml.device("default.qubit")
@@ -98,20 +98,20 @@ class TestGQSP:
         )
         generated_output = qml.matrix(circuit, wire_order=[0, 1])(angles)[:2, :2]
 
-        assert np.allclose(expected_output, generated_output)
+        assert pnp.allclose(expected_output, generated_output)
 
     def test_queueing(self):
         """Test that no additional gates are being queued"""
 
         with qml.queuing.AnnotatedQueue() as q:
-            qml.GQSP(qml.Z(1), np.ones([3, 3]), control=0)
+            qml.GQSP(qml.Z(1), pnp.ones([3, 3]), control=0)
 
         assert len(q.queue) == 1
         assert q.queue[0].name == "GQSP"
 
     def test_decomposition(self):
 
-        angles = np.array([[1, 2], [3, 4], [5, 6]])
+        angles = pnp.array([[1, 2], [3, 4], [5, 6]])
 
         qml.GQSP(qml.Z(1), angles, control=0)
 
@@ -138,7 +138,7 @@ class TestGQSP:
 
         import jax.numpy as jnp
 
-        angles = np.array([[1, 2], [3, 4], [5, 6]])
+        angles = pnp.array([[1, 2], [3, 4], [5, 6]])
 
         dev = qml.device("default.qubit")
 
@@ -150,7 +150,7 @@ class TestGQSP:
         expected_output = jnp.array(qml.matrix(circuit, wire_order=[0, 1])(angles))
         generated_output = qml.matrix(circuit, wire_order=[0, 1])(jnp.array(angles))
 
-        assert np.allclose(expected_output, generated_output)
+        assert pnp.allclose(expected_output, generated_output)
         assert qml.math.get_interface(generated_output) == "jax"
 
     @pytest.mark.torch
@@ -159,7 +159,7 @@ class TestGQSP:
 
         import torch
 
-        angles = np.array([[1, 2], [3, 4], [5, 6]])
+        angles = pnp.array([[1, 2], [3, 4], [5, 6]])
 
         dev = qml.device("default.qubit")
 
@@ -171,7 +171,7 @@ class TestGQSP:
         expected_output = torch.tensor(qml.matrix(circuit, wire_order=[0, 1])(angles))
         generated_output = qml.matrix(circuit, wire_order=[0, 1])(torch.tensor(angles))
 
-        assert np.allclose(expected_output, generated_output)
+        assert pnp.allclose(expected_output, generated_output)
         assert qml.math.get_interface(generated_output) == "torch"
 
     @pytest.mark.tf
@@ -180,7 +180,7 @@ class TestGQSP:
 
         import tensorflow as tf
 
-        angles = np.array([[1, 2], [3, 4], [5, 6]])
+        angles = pnp.array([[1, 2], [3, 4], [5, 6]])
 
         dev = qml.device("default.qubit")
 
@@ -192,7 +192,7 @@ class TestGQSP:
         expected_output = tf.Variable(qml.matrix(circuit, wire_order=[0, 1])(angles))
         generated_output = qml.matrix(circuit, wire_order=[0, 1])(tf.Variable(angles))
 
-        assert np.allclose(expected_output, generated_output)
+        assert pnp.allclose(expected_output, generated_output)
         assert qml.math.get_interface(generated_output) == "tensorflow"
 
     @pytest.mark.jax
@@ -216,5 +216,5 @@ class TestGQSP:
         jit_circuit = jax.jit(circuit)
         generated_output = jit_circuit(angles)
 
-        assert np.allclose(expected_output, generated_output)
+        assert pnp.allclose(expected_output, generated_output)
         assert qml.math.get_interface(generated_output) == "jax"

--- a/tests/templates/test_subroutines/test_mod_exp.py
+++ b/tests/templates/test_subroutines/test_mod_exp.py
@@ -18,7 +18,7 @@ Tests for the ModExp template.
 import pytest
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 
 
 def test_standard_validity_ModExp():
@@ -72,7 +72,7 @@ class TestModExp:
             mod = 2 ** len(output_wires)
 
         # pylint: disable=bad-reversed-sequence
-        assert np.allclose(
+        assert pnp.allclose(
             sum(bit * (2**i) for i, bit in enumerate(reversed(circuit(x, k)))),
             (k * (base**x)) % mod,
         )

--- a/tests/templates/test_subroutines/test_out_adder.py
+++ b/tests/templates/test_subroutines/test_out_adder.py
@@ -18,7 +18,7 @@ Tests for the OutAdder template.
 import pytest
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 
 
 def test_standard_validity_OutAdder():
@@ -81,7 +81,7 @@ class TestOutAdder:
             mod = 2 ** len(output_wires)
 
         # pylint: disable=bad-reversed-sequence
-        assert np.allclose(
+        assert pnp.allclose(
             sum(bit * (2**i) for i, bit in enumerate(reversed(circuit(x, y, z)))),
             (x + y + z) % mod,
         )

--- a/tests/templates/test_subroutines/test_out_multiplier.py
+++ b/tests/templates/test_subroutines/test_out_multiplier.py
@@ -18,7 +18,7 @@ Tests for the OutMultiplier template.
 import pytest
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane.templates.subroutines.out_multiplier import OutMultiplier
 
 
@@ -112,7 +112,7 @@ class TestOutMultiplier:
             mod = 2 ** len(output_wires)
 
         # pylint: disable=bad-reversed-sequence
-        assert np.allclose(
+        assert pnp.allclose(
             sum(bit * (2**i) for i, bit in enumerate(reversed(circuit(x, y)))), (x * y) % mod
         )
 

--- a/tests/templates/test_subroutines/test_out_poly.py
+++ b/tests/templates/test_subroutines/test_out_poly.py
@@ -18,7 +18,7 @@ Tests for the OutPoly template.
 import pytest
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane.templates.subroutines.out_poly import (
     _get_polynomial,
     _mobius_inversion_of_zeta_transform,
@@ -107,7 +107,7 @@ class TestOutPoly:
 
         if mod is None:
             mod = int(2 ** len(output_wires))
-        assert np.isclose(np.argmax(circuit()), polynomial_function(2, 1) % mod)
+        assert pnp.isclose(pnp.argmax(circuit()), polynomial_function(2, 1) % mod)
 
     @pytest.mark.parametrize(
         ("input_registers", "output_wires", "mod", "work_wires", "msg_match"),
@@ -219,4 +219,4 @@ class TestOutPoly:
             )
             return qml.sample(wires=wires["output"])
 
-        assert np.allclose(circuit(), [0, 0, 1])
+        assert pnp.allclose(circuit(), [0, 0, 1])

--- a/tests/templates/test_subroutines/test_phase_adder.py
+++ b/tests/templates/test_subroutines/test_phase_adder.py
@@ -18,7 +18,7 @@ Tests for the PhaseAdder template.
 import pytest
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane.templates.subroutines.phase_adder import _add_k_fourier
 
 
@@ -39,8 +39,8 @@ def test_add_k_fourier():
     assert len(ops) == 2
     assert ops[0].name == "PhaseShift"
     assert ops[1].name == "PhaseShift"
-    assert np.isclose(ops[0].parameters[0], 2 * np.pi)
-    assert np.isclose(ops[1].parameters[0], np.pi)
+    assert pnp.isclose(ops[0].parameters[0], 2 * pnp.pi)
+    assert pnp.isclose(ops[1].parameters[0], pnp.pi)
 
 
 class TestPhaseAdder:
@@ -132,7 +132,7 @@ class TestPhaseAdder:
             mod = 2 ** len(x_wires)
 
         # pylint: disable=bad-reversed-sequence
-        assert np.allclose(
+        assert pnp.allclose(
             sum(bit * (2**i) for i, bit in enumerate(reversed(circuit(x)))), (x + k) % mod
         )
 

--- a/tests/templates/test_subroutines/test_qrom.py
+++ b/tests/templates/test_subroutines/test_qrom.py
@@ -18,7 +18,7 @@ Tests for the QROM template.
 import pytest
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 
 
 def test_assert_valid_qrom():
@@ -86,7 +86,7 @@ class TestQROM:
             return qml.sample(wires=target_wires)
 
         for j in range(2 ** len(control_wires)):
-            assert np.allclose(circuit(j), [int(bit) for bit in bitstrings[j]])
+            assert pnp.allclose(circuit(j), [int(bit) for bit in bitstrings[j]])
 
     @pytest.mark.parametrize(
         ("bitstrings", "target_wires", "control_wires", "work_wires"),
@@ -138,7 +138,7 @@ class TestQROM:
 
             return qml.probs(wires=work_wires)
 
-        assert np.isclose(circuit()[0], 1.0)
+        assert pnp.isclose(circuit()[0], 1.0)
 
     def test_decomposition(self):
         """Test that compute_decomposition and decomposition work as expected."""

--- a/tests/templates/test_subroutines/test_qsvt.py
+++ b/tests/templates/test_subroutines/test_qsvt.py
@@ -21,7 +21,7 @@ import pytest
 from numpy.linalg import matrix_power
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane.templates.subroutines.qsvt import _complementary_poly
 
 
@@ -107,7 +107,7 @@ class TestQSVT:
                 qml.apply(op)
             return qml.expval(qml.PauliZ(wires=0))
 
-        assert np.isclose(circuit(), circuit_correct())
+        assert pnp.isclose(circuit(), circuit_correct())
 
     @pytest.mark.parametrize(
         ("U_A", "lst_projectors", "results"),
@@ -117,7 +117,7 @@ class TestQSVT:
                 [qml.PCPhase(0.2, dim=1, wires=0), qml.PCPhase(0.3, dim=1, wires=0)],
                 [
                     qml.PCPhase(0.2, dim=2, wires=[0]),
-                    qml.BlockEncode(np.array([[0.1]]), wires=[0]),
+                    qml.BlockEncode(pnp.array([[0.1]]), wires=[0]),
                     qml.PCPhase(0.3, dim=2, wires=[0]),
                 ],
             ),
@@ -185,8 +185,8 @@ class TestQSVT:
             (
                 qfunc,
                 lst_phis,
-                np.array([[0.1, 0.2], [0.3, 0.4]]),
-                np.array([0.2, 0.3]),
+                pnp.array([[0.1, 0.2], [0.3, 0.4]]),
+                pnp.array([0.2, 0.3]),
                 [
                     qml.PCPhase(0.2, dim=2, wires=[0]),
                     qml.RX(0.1, wires=[0]),
@@ -196,8 +196,8 @@ class TestQSVT:
             (
                 qfunc2,
                 lst_phis,
-                np.array([[0.1, 0.2], [0.3, 0.4]]),
-                np.array([0.1, 0.2]),
+                pnp.array([[0.1, 0.2], [0.3, 0.4]]),
+                pnp.array([0.1, 0.2]),
                 [
                     qml.PCPhase(0.1, dim=2, wires=[0]),
                     qml.prod(qml.PauliX(wires=0), qml.RZ(0.1, wires=0)),
@@ -238,7 +238,7 @@ class TestQSVT:
             [qml.PCPhase(phi, 2, wires) for phi in angles],
         )
 
-        assert np.allclose(qml.matrix(op), default_matrix)
+        assert pnp.allclose(qml.matrix(op), default_matrix)
         assert qml.math.get_interface(qml.matrix(op)) == "torch"
 
     @pytest.mark.jax
@@ -263,7 +263,7 @@ class TestQSVT:
             [qml.PCPhase(phi, 2, wires) for phi in angles],
         )
 
-        assert np.allclose(qml.matrix(op), default_matrix)
+        assert pnp.allclose(qml.matrix(op), default_matrix)
         assert qml.math.get_interface(qml.matrix(op)) == "jax"
 
     @pytest.mark.jax
@@ -299,7 +299,7 @@ class TestQSVT:
         matrix = qml.matrix(qml.qsvt(input_matrix, poly, wires, "embedding"))
         matrix_with_identity = get_matrix_with_identity(angles)
 
-        assert np.allclose(matrix, matrix_with_identity)
+        assert pnp.allclose(matrix, matrix_with_identity)
 
     @pytest.mark.tf
     @pytest.mark.parametrize(
@@ -321,7 +321,7 @@ class TestQSVT:
             [qml.PCPhase(phi, 2, wires) for phi in angles],
         )
 
-        assert np.allclose(qml.matrix(op), default_matrix)
+        assert pnp.allclose(qml.matrix(op), default_matrix)
         assert qml.math.get_interface(qml.matrix(op)) == "tensorflow"
 
     @pytest.mark.parametrize(
@@ -344,8 +344,8 @@ class TestQSVT:
             )
             return qml.expval(qml.PauliZ(wires=0))
 
-        A = np.array([[0.1, 0.2], [0.3, 0.4]], dtype=complex, requires_grad=True)
-        phis = np.array([0.1, 0.2, 0.3], dtype=complex, requires_grad=True)
+        A = pnp.array([[0.1, 0.2], [0.3, 0.4]], dtype=complex, requires_grad=True)
+        phis = pnp.array([0.1, 0.2, 0.3], dtype=complex, requires_grad=True)
         y = circuit(A, phis)
 
         mat_grad_results, phi_grad_results = qml.grad(circuit)(A, phis)
@@ -353,23 +353,23 @@ class TestQSVT:
         diff = 1e-8
 
         manual_mat_results = [
-            (circuit(A + np.array([[diff, 0], [0, 0]]), phis) - y) / diff,
-            (circuit(A + np.array([[0, diff], [0, 0]]), phis) - y) / diff,
-            (circuit(A + np.array([[0, 0], [diff, 0]]), phis) - y) / diff,
-            (circuit(A + np.array([[0, 0], [0, diff]]), phis) - y) / diff,
+            (circuit(A + pnp.array([[diff, 0], [0, 0]]), phis) - y) / diff,
+            (circuit(A + pnp.array([[0, diff], [0, 0]]), phis) - y) / diff,
+            (circuit(A + pnp.array([[0, 0], [diff, 0]]), phis) - y) / diff,
+            (circuit(A + pnp.array([[0, 0], [0, diff]]), phis) - y) / diff,
         ]
 
         for idx, result in enumerate(manual_mat_results):
-            assert np.isclose(result, np.real(mat_grad_results.flatten()[idx]), atol=1e-6)
+            assert pnp.isclose(result, pnp.real(mat_grad_results.flatten()[idx]), atol=1e-6)
 
         manual_phi_results = [
-            (circuit(A, phis + np.array([diff, 0, 0])) - y) / diff,
-            (circuit(A, phis + np.array([0, diff, 0])) - y) / diff,
-            (circuit(A, phis + np.array([0, 0, diff])) - y) / diff,
+            (circuit(A, phis + pnp.array([diff, 0, 0])) - y) / diff,
+            (circuit(A, phis + pnp.array([0, diff, 0])) - y) / diff,
+            (circuit(A, phis + pnp.array([0, 0, diff])) - y) / diff,
         ]
 
         for idx, result in enumerate(manual_phi_results):
-            assert np.isclose(result, np.real(phi_grad_results[idx]), atol=1e-6)
+            assert pnp.isclose(result, pnp.real(phi_grad_results[idx]), atol=1e-6)
 
     def test_label(self):
         """Test that the label method returns the correct string label"""
@@ -441,12 +441,12 @@ class Testqsvt_legacy:
             qml.qsvt_legacy(A, phis, wires)
             return qml.expval(qml.PauliZ(wires=0))
 
-        observable_mat = np.kron(qml.matrix(qml.PauliZ(0)), np.eye(2))
-        true_expval = (np.conj(true_mat).T @ observable_mat @ true_mat)[0, 0]
+        observable_mat = pnp.kron(qml.matrix(qml.PauliZ(0)), pnp.eye(2))
+        true_expval = (pnp.conj(true_mat).T @ observable_mat @ true_mat)[0, 0]
 
         with pytest.warns(qml.PennyLaneDeprecationWarning, match="`qml.qsvt_legacy` is deprecated"):
-            assert np.isclose(circuit(), true_expval)
-            assert np.allclose(qml.matrix(circuit)(), true_mat)
+            assert pnp.isclose(circuit(), true_expval)
+            assert pnp.allclose(qml.matrix(circuit)(), true_mat)
 
     @pytest.mark.parametrize(
         ("A", "phis", "wires", "result"),
@@ -481,7 +481,7 @@ class Testqsvt_legacy:
             return qml.expval(qml.PauliZ(wires=0))
 
         with pytest.warns(qml.PennyLaneDeprecationWarning, match="`qml.qsvt_legacy` is deprecated"):
-            assert np.isclose(np.real(qml.matrix(circuit)())[0][0], result, rtol=1e-3)
+            assert pnp.isclose(pnp.real(qml.matrix(circuit)())[0][0], result, rtol=1e-3)
 
     @pytest.mark.parametrize(
         ("A", "phis", "wires", "result"),
@@ -513,8 +513,8 @@ class Testqsvt_legacy:
             m1 = qml.matrix(qml.qsvt_legacy(A, phis, wires, convention="Wx"))
             m2 = qml.matrix(qml.qsvt_legacy, wire_order=wires)(A, phis, wires, convention="Wx")
 
-            assert np.isclose(np.real(m1[0, 0]), result, rtol=1e-3)
-            assert np.allclose(m1, m2)
+            assert pnp.isclose(pnp.real(m1[0, 0]), result, rtol=1e-3)
+            assert pnp.allclose(m1, m2)
 
     @pytest.mark.torch
     @pytest.mark.parametrize(
@@ -533,7 +533,7 @@ class Testqsvt_legacy:
 
             op = qml.qsvt_legacy(input_matrix, angles, wires)
 
-            assert np.allclose(qml.matrix(op), default_matrix)
+            assert pnp.allclose(qml.matrix(op), default_matrix)
             assert qml.math.get_interface(qml.matrix(op)) == "torch"
 
     @pytest.mark.jax
@@ -554,7 +554,7 @@ class Testqsvt_legacy:
 
             op = qml.qsvt_legacy(input_matrix, angles, wires)
 
-            assert np.allclose(qml.matrix(op), default_matrix)
+            assert pnp.allclose(qml.matrix(op), default_matrix)
             assert qml.math.get_interface(qml.matrix(op)) == "jax"
 
     @pytest.mark.tf
@@ -575,7 +575,7 @@ class Testqsvt_legacy:
 
             op = qml.qsvt_legacy(input_matrix, angles, wires)
 
-            assert np.allclose(qml.matrix(op), default_matrix)
+            assert pnp.allclose(qml.matrix(op), default_matrix)
             assert qml.math.get_interface(qml.matrix(op)) == "tensorflow"
 
     def test_qsvt_grad(self):
@@ -592,8 +592,8 @@ class Testqsvt_legacy:
 
         with pytest.warns(qml.PennyLaneDeprecationWarning, match="`qml.qsvt_legacy` is deprecated"):
 
-            A = np.array([[0.1, 0.2], [0.3, 0.4]], dtype=complex, requires_grad=True)
-            phis = np.array([0.1, 0.2, 0.3], dtype=complex, requires_grad=True)
+            A = pnp.array([[0.1, 0.2], [0.3, 0.4]], dtype=complex, requires_grad=True)
+            phis = pnp.array([0.1, 0.2, 0.3], dtype=complex, requires_grad=True)
             y = circuit(A, phis)
 
             mat_grad_results, phi_grad_results = qml.grad(circuit)(A, phis)
@@ -601,33 +601,33 @@ class Testqsvt_legacy:
             diff = 1e-8
 
             manual_mat_results = [
-                (circuit(A + np.array([[diff, 0], [0, 0]]), phis) - y) / diff,
-                (circuit(A + np.array([[0, diff], [0, 0]]), phis) - y) / diff,
-                (circuit(A + np.array([[0, 0], [diff, 0]]), phis) - y) / diff,
-                (circuit(A + np.array([[0, 0], [0, diff]]), phis) - y) / diff,
+                (circuit(A + pnp.array([[diff, 0], [0, 0]]), phis) - y) / diff,
+                (circuit(A + pnp.array([[0, diff], [0, 0]]), phis) - y) / diff,
+                (circuit(A + pnp.array([[0, 0], [diff, 0]]), phis) - y) / diff,
+                (circuit(A + pnp.array([[0, 0], [0, diff]]), phis) - y) / diff,
             ]
 
             for idx, result in enumerate(manual_mat_results):
-                assert np.isclose(result, np.real(mat_grad_results.flatten()[idx]), atol=1e-6)
+                assert pnp.isclose(result, pnp.real(mat_grad_results.flatten()[idx]), atol=1e-6)
 
             manual_phi_results = [
-                (circuit(A, phis + np.array([diff, 0, 0])) - y) / diff,
-                (circuit(A, phis + np.array([0, diff, 0])) - y) / diff,
-                (circuit(A, phis + np.array([0, 0, diff])) - y) / diff,
+                (circuit(A, phis + pnp.array([diff, 0, 0])) - y) / diff,
+                (circuit(A, phis + pnp.array([0, diff, 0])) - y) / diff,
+                (circuit(A, phis + pnp.array([0, 0, diff])) - y) / diff,
             ]
 
             for idx, result in enumerate(manual_phi_results):
-                assert np.isclose(result, np.real(phi_grad_results[idx]), atol=1e-6)
+                assert pnp.isclose(result, pnp.real(phi_grad_results[idx]), atol=1e-6)
 
 
 phase_angle_data = (
     (
         [0, 0, 0],
-        [3 * np.pi / 4, np.pi / 2, -np.pi / 4],
+        [3 * pnp.pi / 4, pnp.pi / 2, -pnp.pi / 4],
     ),
     (
         [1.0, 2.0, 3.0, 4.0],
-        [1.0 + 3 * np.pi / 4, 2.0 + np.pi / 2, 3.0 + np.pi / 2, 4.0 - np.pi / 4],
+        [1.0 + 3 * pnp.pi / 4, 2.0 + pnp.pi / 2, 3.0 + pnp.pi / 2, 4.0 - pnp.pi / 4],
     ),
 )
 
@@ -717,7 +717,7 @@ class Testqsvt:
         # Calculation of the polynomial transformation on the input matrix
         expected = sum(coef * matrix_power(A_matrix, i) for i, coef in enumerate(poly))
 
-        assert np.allclose(qml.matrix(circuit)()[: len(A_matrix), : len(A_matrix)].real, expected)
+        assert pnp.allclose(qml.matrix(circuit)()[: len(A_matrix), : len(A_matrix)].real, expected)
 
     @pytest.mark.parametrize(
         ("A", "poly", "block_encoding", "encoding_wires"),
@@ -752,7 +752,7 @@ class Testqsvt:
         """Test that qml.qsvt produces the correct output when A is a hamiltonian."""
 
         coeffs = A.terms()[0]
-        coeffs /= np.linalg.norm(coeffs, 1)
+        coeffs /= pnp.linalg.norm(coeffs, 1)
 
         A = qml.dot(coeffs, A.terms()[1])
         A_matrix = qml.matrix(A)
@@ -766,7 +766,7 @@ class Testqsvt:
         # Calculation of the polynomial transformation on the input matrix
         expected = sum(coef * matrix_power(A_matrix, i) for i, coef in enumerate(poly))
 
-        assert np.allclose(qml.matrix(circuit)()[: len(A_matrix), : len(A_matrix)].real, expected)
+        assert pnp.allclose(qml.matrix(circuit)()[: len(A_matrix), : len(A_matrix)].real, expected)
 
     @pytest.mark.parametrize(
         ("A", "poly", "block_encoding", "encoding_wires", "msg_match"),
@@ -865,8 +865,8 @@ class Testqsvt:
             qml.qsvt(A, poly, [0, 1, 2], "embedding")
             return qml.expval(qml.Z(0) @ qml.Z(1))
 
-        assert np.allclose(qml.grad(circuit)(np.array(A)), jax.grad(circuit)(jnp.array(A)))
-        assert not np.allclose(qml.grad(circuit)(np.array(A)), 0.0)
+        assert pnp.allclose(qml.grad(circuit)(pnp.array(A)), jax.grad(circuit)(jnp.array(A)))
+        assert not pnp.allclose(qml.grad(circuit)(pnp.array(A)), 0.0)
 
     @pytest.mark.jax
     def test_qsvt_jit(self):
@@ -910,17 +910,17 @@ class TestRootFindingSolver:
         Q = _complementary_poly(P)  # Calculate complementary polynomial Q
 
         # Define points on the unit circle
-        theta_vals = np.linspace(0, 2 * np.pi, 100)
-        unit_circle_points = np.exp(1j * theta_vals)
+        theta_vals = pnp.linspace(0, 2 * pnp.pi, 100)
+        unit_circle_points = pnp.exp(1j * theta_vals)
 
         for z in unit_circle_points:
-            P_val = np.polyval(P, z)
-            P_magnitude_squared = np.abs(P_val) ** 2
+            P_val = pnp.polyval(P, z)
+            P_magnitude_squared = pnp.abs(P_val) ** 2
 
-            Q_val = np.polyval(Q, z)
-            Q_magnitude_squared = np.abs(Q_val) ** 2
+            Q_val = pnp.polyval(Q, z)
+            Q_magnitude_squared = pnp.abs(Q_val) ** 2
 
-            assert np.isclose(P_magnitude_squared + Q_magnitude_squared, 1, atol=1e-7)
+            assert pnp.isclose(P_magnitude_squared + Q_magnitude_squared, 1, atol=1e-7)
 
     @pytest.mark.parametrize(
         "angles",
@@ -934,10 +934,10 @@ class TestRootFindingSolver:
         """Test the transform_angles function"""
 
         new_angles = qml.transform_angles(angles, "QSP", "QSVT")
-        assert np.allclose(angles, qml.transform_angles(new_angles, "QSVT", "QSP"))
+        assert pnp.allclose(angles, qml.transform_angles(new_angles, "QSVT", "QSP"))
 
         new_angles = qml.transform_angles(angles, "QSVT", "QSP")
-        assert np.allclose(angles, qml.transform_angles(new_angles, "QSP", "QSVT"))
+        assert pnp.allclose(angles, qml.transform_angles(new_angles, "QSP", "QSVT"))
 
         with pytest.raises(AssertionError, match="Invalid conversion"):
             _ = qml.transform_angles(angles, "QFT", "QSVT")
@@ -960,14 +960,14 @@ class TestRootFindingSolver:
         def circuit_qsp():
             qml.RX(2 * angles[0], wires=0)
             for angle in angles[1:]:
-                qml.RZ(-2 * np.arccos(x), wires=0)
+                qml.RZ(-2 * pnp.arccos(x), wires=0)
                 qml.RX(2 * angle, wires=0)
 
             return qml.state()
 
         output = qml.matrix(circuit_qsp, wire_order=[0])()[0, 0]
         expected = sum(coef * (x**i) for i, coef in enumerate(poly))
-        assert np.isclose(output.real, expected.real)
+        assert pnp.isclose(output.real, expected.real)
 
     @pytest.mark.parametrize(
         "poly",
@@ -983,7 +983,7 @@ class TestRootFindingSolver:
         angles = qml.poly_to_angles(poly, "QSVT")
         x = 0.5
 
-        block_encoding = qml.RX(-2 * np.arccos(x), wires=0)
+        block_encoding = qml.RX(-2 * pnp.arccos(x), wires=0)
         projectors = [qml.PCPhase(angle, dim=1, wires=0) for angle in angles]
 
         @qml.qnode(qml.device("default.qubit"))
@@ -993,7 +993,7 @@ class TestRootFindingSolver:
 
         output = qml.matrix(circuit_qsvt, wire_order=[0])()[0, 0]
         expected = sum(coef * (x**i) for i, coef in enumerate(poly))
-        assert np.isclose(output.real, expected.real)
+        assert pnp.isclose(output.real, expected.real)
 
     @pytest.mark.parametrize(
         ("poly", "routine", "angle_solver", "msg_match"),

--- a/tests/templates/test_subroutines/test_qubitization.py
+++ b/tests/templates/test_subroutines/test_qubitization.py
@@ -20,7 +20,7 @@ import copy
 import pytest
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 
 
 @pytest.mark.parametrize(
@@ -54,15 +54,15 @@ def test_operator_definition_qpe(hamiltonian):
 
         return qml.probs(op=measurements)
 
-    theta = np.array([0.1, 0.2, 0.3, 0.4, 0.5]) * 100
+    theta = pnp.array([0.1, 0.2, 0.3, 0.4, 0.5]) * 100
 
     peaks, _ = find_peaks(circuit(theta))
 
     # Calculates the eigenvalues from the obtained output
     lamb = sum(abs(c) for c in hamiltonian.terms()[0])
-    estimated_eigenvalues = lamb * np.cos(2 * np.pi * peaks / 2**8)
+    estimated_eigenvalues = lamb * pnp.cos(2 * pnp.pi * peaks / 2**8)
 
-    assert np.allclose(np.sort(estimated_eigenvalues), qml.eigvals(hamiltonian), atol=0.1)
+    assert pnp.allclose(pnp.sort(estimated_eigenvalues), qml.eigvals(hamiltonian), atol=0.1)
 
 
 @pytest.mark.parametrize(
@@ -83,22 +83,22 @@ def test_standard_validity(lcu, control, skip_diff):
     "hamiltonian, expected_decomposition",
     (
         (
-            qml.ops.LinearCombination(np.array([1.0, 1.0]), [qml.PauliX(0), qml.PauliZ(0)]),
+            qml.ops.LinearCombination(pnp.array([1.0, 1.0]), [qml.PauliX(0), qml.PauliZ(0)]),
             [
                 qml.Reflection(qml.I([1]), 3.141592653589793),
                 qml.PrepSelPrep(
-                    qml.ops.LinearCombination(np.array([1.0, 1.0]), [qml.PauliX(0), qml.PauliZ(0)]),
+                    qml.ops.LinearCombination(pnp.array([1.0, 1.0]), [qml.PauliX(0), qml.PauliZ(0)]),
                     control=[1],
                 ),
             ],
         ),
         (
-            qml.ops.LinearCombination(np.array([-1.0, 1.0]), [qml.PauliX(0), qml.PauliZ(0)]),
+            qml.ops.LinearCombination(pnp.array([-1.0, 1.0]), [qml.PauliX(0), qml.PauliZ(0)]),
             [
                 qml.Reflection(qml.I(1), 3.141592653589793),
                 qml.PrepSelPrep(
                     qml.ops.LinearCombination(
-                        np.array([-1.0, 1.0]), [qml.PauliX(0), qml.PauliZ(0)]
+                        pnp.array([-1.0, 1.0]), [qml.PauliX(0), qml.PauliZ(0)]
                     ),
                     control=[1],
                 ),
@@ -129,7 +129,7 @@ def test_lightning_qubit():
         qml.Qubitization(H, control=[3, 4])
         return qml.expval(qml.PauliZ(0) @ qml.PauliZ(4))
 
-    assert np.allclose(circuit_lightning(), circuit_default())
+    assert pnp.allclose(circuit_lightning(), circuit_default())
 
 
 class TestDifferentiability:
@@ -144,9 +144,9 @@ class TestDifferentiability:
         return qml.expval(qml.PauliZ(3) @ qml.PauliZ(4))
 
     # calculated numerically with finite diff method (h = 1e-4)
-    exp_grad = np.array([0.41177729, -0.21262358, 1.64370464, -0.74256522])
+    exp_grad = pnp.array([0.41177729, -0.21262358, 1.64370464, -0.74256522])
 
-    params = np.array([0.4, 0.5, 0.1, 0.3])
+    params = pnp.array([0.4, 0.5, 0.1, 0.3])
 
     @pytest.mark.autograd
     def test_qnode_autograd(self):
@@ -158,7 +158,7 @@ class TestDifferentiability:
         params = qml.numpy.array(self.params, requires_grad=True)
         res = qml.grad(qnode)(params)
         assert qml.math.shape(res) == (4,)
-        assert np.allclose(res, self.exp_grad, atol=1e-5)
+        assert pnp.allclose(res, self.exp_grad, atol=1e-5)
 
     @pytest.mark.jax
     @pytest.mark.parametrize("use_jit", (False, True))
@@ -185,7 +185,7 @@ class TestDifferentiability:
 
         jac = jac_fn(params)
         assert jac.shape == (4,)
-        assert np.allclose(jac, self.exp_grad, atol=0.05)
+        assert pnp.allclose(jac, self.exp_grad, atol=0.05)
 
     @pytest.mark.torch
     @pytest.mark.parametrize("shots", [None, 50000])

--- a/tests/templates/test_swapnetworks/test_ccl2.py
+++ b/tests/templates/test_swapnetworks/test_ccl2.py
@@ -18,7 +18,7 @@ Tests for the TwoLocalSwapNetwork template.
 import pytest
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 
 
 # pylint: disable=protected-access
@@ -28,7 +28,7 @@ def test_flatten_unflatten():
     def acquaintances(index, *_, use_CNOT=True, **__):
         return qml.CNOT(index) if use_CNOT else qml.CZ(index)
 
-    weights = np.array([0.5, 0.6, 0.7])
+    weights = pnp.array([0.5, 0.6, 0.7])
     wires = qml.wires.Wires((0, 1, 2))
 
     op = qml.templates.TwoLocalSwapNetwork(
@@ -62,8 +62,8 @@ class TestDecomposition:
             (4, None, None, True, False),
             (5, lambda index, wires, param: qml.Identity(index), None, True, False),
             (5, lambda index, wires, param: qml.CNOT(index), None, False, False),
-            (6, lambda index, wires, param: qml.CRX(param, index), np.random.rand(15), True, False),
-            (6, lambda index, wires, param: qml.CRY(param, index), np.random.rand(15), True, True),
+            (6, lambda index, wires, param: qml.CRX(param, index), pnp.random.rand(15), True, False),
+            (6, lambda index, wires, param: qml.CRY(param, index), pnp.random.rand(15), True, True),
         ],
     )
     def test_ccl2_operations(self, wires, acquaintances, weights, fermionic, shift):
@@ -99,7 +99,7 @@ class TestDecomposition:
             for pair in pairs:
                 if ac_op and ac_op([0, 1], [0, 1], 0.0):
                     gate_order.append(ac_op(pair, pair, next(itrweights, 0.0)))
-                sw_op = qml.FermionicSWAP(np.pi, pair) if fermionic else qml.SWAP(pair)
+                sw_op = qml.FermionicSWAP(pnp.pi, pair) if fermionic else qml.SWAP(pair)
                 gate_order.append(sw_op)
 
         for op1, op2 in zip(queue, gate_order):
@@ -111,7 +111,7 @@ class TestDecomposition:
         def acquaintances(index, *_, **___):
             return qml.CNOT(index)
 
-        weights = np.random.random(size=10)
+        weights = pnp.random.random(size=10)
 
         dev = qml.device("default.qubit", wires=5)
         dev2 = qml.device("default.qubit", wires=["z", "a", "k", "e", "y"])
@@ -130,7 +130,7 @@ class TestDecomposition:
             )
             return qml.state()
 
-        assert np.allclose(circuit(), circuit2(), atol=tol, rtol=0)
+        assert pnp.allclose(circuit(), circuit2(), atol=tol, rtol=0)
 
     @pytest.mark.parametrize(
         ("num_wires", "acquaintances", "weights", "fermionic", "shift", "exp_state"),
@@ -196,7 +196,7 @@ class TestDecomposition:
         wires = range(num_wires)
 
         shape = qml.templates.TwoLocalSwapNetwork.shape(num_wires)
-        weights = np.pi / 2 * qml.math.ones(shape) if weights else None
+        weights = pnp.pi / 2 * qml.math.ones(shape) if weights else None
 
         dev = qml.device("default.qubit", wires=wires)
 
@@ -237,7 +237,7 @@ class TestInputs:
             (
                 6,
                 qml.CNOT(wires=[0, 1]),
-                np.random.rand(18),
+                pnp.random.rand(18),
                 True,
                 False,
                 "Acquaintances must either be a callable or None",
@@ -245,7 +245,7 @@ class TestInputs:
             (
                 6,
                 lambda index, wires, param: qml.CRX(param, index),
-                np.random.rand(12),
+                pnp.random.rand(12),
                 True,
                 False,
                 "Weight tensor must be of length",
@@ -274,7 +274,7 @@ class TestInputs:
             qml.templates.TwoLocalSwapNetwork(
                 wires=range(4),
                 acquaintances=None,
-                weights=np.array([1]),
+                weights=pnp.array([1]),
                 fermionic=True,
                 shif=False,
             )
@@ -378,7 +378,7 @@ class TestInterfaces:
         grad_fn2 = qml.grad(circuit2)
         grads2 = grad_fn2(weights)
 
-        assert np.allclose(grads, grads2, atol=tol, rtol=0)
+        assert pnp.allclose(grads, grads2, atol=tol, rtol=0)
 
     @pytest.mark.jax
     def test_jax(self, tol):
@@ -387,7 +387,7 @@ class TestInterfaces:
         import jax
         import jax.numpy as jnp
 
-        weights = jnp.array(np.random.random(size=6))
+        weights = jnp.array(pnp.random.random(size=6))
 
         dev = qml.device("default.qubit", wires=4)
 
@@ -404,7 +404,7 @@ class TestInterfaces:
         grad_fn2 = jax.grad(circuit2)
         grads2 = grad_fn2(weights)
 
-        assert np.allclose(grads[0], grads2[0], atol=tol, rtol=0)
+        assert pnp.allclose(grads[0], grads2[0], atol=tol, rtol=0)
 
     @pytest.mark.jax
     def test_jax_jit(self, tol):
@@ -413,7 +413,7 @@ class TestInterfaces:
         import jax
         import jax.numpy as jnp
 
-        weights = jnp.array(np.random.random(size=6))
+        weights = jnp.array(pnp.random.random(size=6))
 
         dev = qml.device("default.qubit", wires=4)
 
@@ -438,7 +438,7 @@ class TestInterfaces:
 
         import tensorflow as tf
 
-        weights = tf.Variable(np.random.random(size=6))
+        weights = tf.Variable(pnp.random.random(size=6))
 
         dev = qml.device("default.qubit", wires=4)
 
@@ -457,7 +457,7 @@ class TestInterfaces:
             res2 = circuit2(weights)
         grads2 = tape2.gradient(res2, [weights])
 
-        assert np.allclose(grads[0], grads2[0], atol=tol, rtol=0)
+        assert pnp.allclose(grads[0], grads2[0], atol=tol, rtol=0)
 
     @pytest.mark.torch
     def test_torch(self, tol):
@@ -465,7 +465,7 @@ class TestInterfaces:
 
         import torch
 
-        weights = torch.tensor(np.random.random(size=6), requires_grad=True)
+        weights = torch.tensor(pnp.random.random(size=6), requires_grad=True)
 
         dev = qml.device("default.qubit", wires=4)
 
@@ -484,7 +484,7 @@ class TestInterfaces:
         res2.backward()
         grads2 = [weights.grad]
 
-        assert np.allclose(grads[0], grads2[0], atol=tol, rtol=0)
+        assert pnp.allclose(grads[0], grads2[0], atol=tol, rtol=0)
 
 
 # pylint: disable=too-few-public-methods

--- a/tests/test_classical_gradients.py
+++ b/tests/test_classical_gradients.py
@@ -18,7 +18,7 @@ import autograd
 import pytest
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 
 
 def test_grad_no_ints():
@@ -42,32 +42,32 @@ class TestGradientUnivar:
 
     def test_sin(self, tol):
         """Tests with sin function."""
-        x_vals = np.linspace(-10, 10, 16, endpoint=False)
-        g = qml.grad(np.sin, 0)
+        x_vals = pnp.linspace(-10, 10, 16, endpoint=False)
+        g = qml.grad(pnp.sin, 0)
         auto_grad = [g(x) for x in x_vals]
-        correct_grad = np.cos(x_vals)
+        correct_grad = pnp.cos(x_vals)
 
-        assert np.allclose(auto_grad, correct_grad, atol=tol, rtol=0)
+        assert pnp.allclose(auto_grad, correct_grad, atol=tol, rtol=0)
 
     def test_exp(self, tol):
         """Tests exp function."""
-        x_vals = np.linspace(-10, 10, 16, endpoint=False)
-        func = lambda x: np.exp(x / 10.0) / 10.0
+        x_vals = pnp.linspace(-10, 10, 16, endpoint=False)
+        func = lambda x: pnp.exp(x / 10.0) / 10.0
         g = qml.grad(func, 0)
         auto_grad = [g(x) for x in x_vals]
-        correct_grad = np.exp(x_vals / 10.0) / 100.0
+        correct_grad = pnp.exp(x_vals / 10.0) / 100.0
 
-        assert np.allclose(auto_grad, correct_grad, atol=tol, rtol=0)
+        assert pnp.allclose(auto_grad, correct_grad, atol=tol, rtol=0)
 
     def test_poly(self, tol):
         """Tests a polynomial function."""
-        x_vals = np.linspace(-10, 10, 16, endpoint=False)
+        x_vals = pnp.linspace(-10, 10, 16, endpoint=False)
         func = lambda x: 2 * x**2 + 3 * x + 4
         g = qml.grad(func, 0)
         auto_grad = [g(x) for x in x_vals]
         correct_grad = 4 * x_vals + 3
 
-        assert np.allclose(auto_grad, correct_grad, atol=tol, rtol=0)
+        assert pnp.allclose(auto_grad, correct_grad, atol=tol, rtol=0)
 
 
 class TestGradientMultiVar:
@@ -75,42 +75,42 @@ class TestGradientMultiVar:
 
     def test_sin(self, tol):
         """Tests gradients with multivariate sin and cosine."""
-        multi_var = lambda x: np.sin(x[0]) + np.cos(x[1])
-        grad_multi_var = lambda x: np.array([np.cos(x[0]), -np.sin(x[1])])
+        multi_var = lambda x: pnp.sin(x[0]) + pnp.cos(x[1])
+        grad_multi_var = lambda x: pnp.array([pnp.cos(x[0]), -pnp.sin(x[1])])
 
         x_vec = [1.5, -2.5]
         g = qml.grad(multi_var, 0)
         auto_grad = g(x_vec)
         correct_grad = grad_multi_var(x_vec)
 
-        assert np.allclose(auto_grad, correct_grad, atol=tol, rtol=0)
+        assert pnp.allclose(auto_grad, correct_grad, atol=tol, rtol=0)
 
     def test_exp(self, tol):
         """Tests gradients with a multivariate exp and tanh."""
-        multi_var = lambda x: np.exp(x[0] / 3) * np.tanh(x[1])
-        grad_multi_var = lambda x: np.array(
+        multi_var = lambda x: pnp.exp(x[0] / 3) * pnp.tanh(x[1])
+        grad_multi_var = lambda x: pnp.array(
             [
-                np.exp(x[0] / 3) / 3 * np.tanh(x[1]),
-                np.exp(x[0] / 3) * (1 - np.tanh(x[1]) ** 2),
+                pnp.exp(x[0] / 3) / 3 * pnp.tanh(x[1]),
+                pnp.exp(x[0] / 3) * (1 - pnp.tanh(x[1]) ** 2),
             ]
         )
-        x_vec = np.random.uniform(-5, 5, size=(2))
+        x_vec = pnp.random.uniform(-5, 5, size=(2))
         g = qml.grad(multi_var, 0)
         auto_grad = g(x_vec)
         correct_grad = grad_multi_var(x_vec)
 
-        assert np.allclose(auto_grad, correct_grad, atol=tol, rtol=0)
+        assert pnp.allclose(auto_grad, correct_grad, atol=tol, rtol=0)
 
     def test_quadratic(self, tol):
         """Tests gradients with a quadratic function."""
-        multi_var = lambda x: np.sum([x_**2 for x_ in x])
-        grad_multi_var = lambda x: np.array([2 * x_ for x_ in x])
-        x_vec = np.random.uniform(-5, 5, size=(2))
+        multi_var = lambda x: pnp.sum([x_**2 for x_ in x])
+        grad_multi_var = lambda x: pnp.array([2 * x_ for x_ in x])
+        x_vec = pnp.random.uniform(-5, 5, size=(2))
         g = qml.grad(multi_var, 0)
         auto_grad = g(x_vec)
         correct_grad = grad_multi_var(x_vec)
 
-        assert np.allclose(auto_grad, correct_grad, atol=tol, rtol=0)
+        assert pnp.allclose(auto_grad, correct_grad, atol=tol, rtol=0)
 
 
 class TestGradientMultiargs:
@@ -120,80 +120,80 @@ class TestGradientMultiargs:
         """Tests multiarg gradients with sin and cos functions."""
         x = -2.5
         y = 1.5
-        gradf = lambda x, y: (np.cos(x), -np.sin(y))
-        f = lambda x, y: np.sin(x) + np.cos(y)
+        gradf = lambda x, y: (pnp.cos(x), -pnp.sin(y))
+        f = lambda x, y: pnp.sin(x) + pnp.cos(y)
 
         # gradient wrt first argument
         gx = qml.grad(f, 0)
 
         auto_gradx = gx(x, y)
         correct_gradx = gradf(x, y)[0]
-        assert np.allclose(auto_gradx, correct_gradx, atol=tol, rtol=0)
+        assert pnp.allclose(auto_gradx, correct_gradx, atol=tol, rtol=0)
 
         # gradient wrt second argument
         gy = qml.grad(f, 1)
         auto_grady = gy(x, y)
         correct_grady = gradf(x, y)[1]
-        assert np.allclose(auto_grady, correct_grady, atol=tol, rtol=0)
+        assert pnp.allclose(auto_grady, correct_grady, atol=tol, rtol=0)
 
         # gradient wrt both arguments
         gxy = qml.grad(f, [0, 1])
         auto_gradxy = gxy(x, y)
         correct_gradxy = gradf(x, y)
-        assert np.allclose(auto_gradxy, correct_gradxy, atol=tol, rtol=0)
+        assert pnp.allclose(auto_gradxy, correct_gradxy, atol=tol, rtol=0)
 
     def test_exp(self, tol):
         """Tests multiarg gradients with exp and tanh functions."""
         x = -2.5
         y = 1.5
         gradf = lambda x, y: (
-            np.exp(x / 3) / 3 * np.tanh(y),
-            np.exp(x / 3) * (1 - np.tanh(y) ** 2),
+            pnp.exp(x / 3) / 3 * pnp.tanh(y),
+            pnp.exp(x / 3) * (1 - pnp.tanh(y) ** 2),
         )
-        f = lambda x, y: np.exp(x / 3) * np.tanh(y)
+        f = lambda x, y: pnp.exp(x / 3) * pnp.tanh(y)
 
         # gradient wrt first argument
         gx = qml.grad(f, 0)
         auto_gradx = gx(x, y)
         correct_gradx = gradf(x, y)[0]
-        assert np.allclose(auto_gradx, correct_gradx, atol=tol, rtol=0)
+        assert pnp.allclose(auto_gradx, correct_gradx, atol=tol, rtol=0)
 
         # gradient wrt second argument
         gy = qml.grad(f, 1)
         auto_grady = gy(x, y)
         correct_grady = gradf(x, y)[1]
-        assert np.allclose(auto_grady, correct_grady, atol=tol, rtol=0)
+        assert pnp.allclose(auto_grady, correct_grady, atol=tol, rtol=0)
 
         # gradient wrt both arguments
         gxy = qml.grad(f, [0, 1])
         auto_gradxy = gxy(x, y)
         correct_gradxy = gradf(x, y)
-        assert np.allclose(auto_gradxy, correct_gradxy, atol=tol, rtol=0)
+        assert pnp.allclose(auto_gradxy, correct_gradxy, atol=tol, rtol=0)
 
     def test_linear(self, tol):
         """Tests multiarg gradients with a linear function."""
         x = -2.5
         y = 1.5
         gradf = lambda x, y: (2 * x, 2 * y)
-        f = lambda x, y: np.sum([x_**2 for x_ in [x, y]])
+        f = lambda x, y: pnp.sum([x_**2 for x_ in [x, y]])
 
         # gradient wrt first argument
         gx = qml.grad(f, 0)
         auto_gradx = gx(x, y)
         correct_gradx = gradf(x, y)[0]
-        assert np.allclose(auto_gradx, correct_gradx, atol=tol, rtol=0)
+        assert pnp.allclose(auto_gradx, correct_gradx, atol=tol, rtol=0)
 
         # gradient wrt second argument
         gy = qml.grad(f, 1)
         auto_grady = gy(x, y)
         correct_grady = gradf(x, y)[1]
-        assert np.allclose(auto_grady, correct_grady, atol=tol, rtol=0)
+        assert pnp.allclose(auto_grady, correct_grady, atol=tol, rtol=0)
 
         # gradient wrt both arguments
         gxy = qml.grad(f, [0, 1])
         auto_gradxy = gxy(x, y)
         correct_gradxy = gradf(x, y)
-        assert np.allclose(auto_gradxy, correct_gradxy, atol=tol, rtol=0)
+        assert pnp.allclose(auto_gradxy, correct_gradxy, atol=tol, rtol=0)
 
 
 class TestGradientMultivarMultidim:
@@ -201,48 +201,48 @@ class TestGradientMultivarMultidim:
 
     def test_sin(self, tol):
         """Tests gradients with multivariate multidimensional sin and cos."""
-        x_vec = np.random.uniform(-5, 5, size=(2))
-        x_vec_multidim = np.expand_dims(x_vec, axis=1)
+        x_vec = pnp.random.uniform(-5, 5, size=(2))
+        x_vec_multidim = pnp.expand_dims(x_vec, axis=1)
 
-        gradf = lambda x: ([[np.cos(x[0, 0])], [-np.sin(x[[1]])]])
-        f = lambda x: np.sin(x[0, 0]) + np.cos(x[1, 0])
+        gradf = lambda x: ([[pnp.cos(x[0, 0])], [-pnp.sin(x[[1]])]])
+        f = lambda x: pnp.sin(x[0, 0]) + pnp.cos(x[1, 0])
 
         g = qml.grad(f, 0)
         auto_grad = g(x_vec_multidim)
         correct_grad = gradf(x_vec_multidim)
-        assert np.allclose(auto_grad[0], correct_grad[0], atol=tol, rtol=0)
-        assert np.allclose(auto_grad[1], correct_grad[1], atol=tol, rtol=0)
+        assert pnp.allclose(auto_grad[0], correct_grad[0], atol=tol, rtol=0)
+        assert pnp.allclose(auto_grad[1], correct_grad[1], atol=tol, rtol=0)
 
     def test_exp(self, tol):
         """Tests gradients with multivariate multidimensional exp and tanh."""
-        x_vec = np.random.uniform(-5, 5, size=(2))
-        x_vec_multidim = np.expand_dims(x_vec, axis=1)
+        x_vec = pnp.random.uniform(-5, 5, size=(2))
+        x_vec_multidim = pnp.expand_dims(x_vec, axis=1)
 
-        gradf = lambda x: np.array(
+        gradf = lambda x: pnp.array(
             [
-                [np.exp(x[0, 0] / 3) / 3 * np.tanh(x[1, 0])],
-                [np.exp(x[0, 0] / 3) * (1 - np.tanh(x[1, 0]) ** 2)],
+                [pnp.exp(x[0, 0] / 3) / 3 * pnp.tanh(x[1, 0])],
+                [pnp.exp(x[0, 0] / 3) * (1 - pnp.tanh(x[1, 0]) ** 2)],
             ]
         )
-        f = lambda x: np.exp(x[0, 0] / 3) * np.tanh(x[1, 0])
+        f = lambda x: pnp.exp(x[0, 0] / 3) * pnp.tanh(x[1, 0])
 
         g = qml.grad(f, 0)
         auto_grad = g(x_vec_multidim)
         correct_grad = gradf(x_vec_multidim)
-        assert np.allclose(auto_grad, correct_grad, atol=tol, rtol=0)
+        assert pnp.allclose(auto_grad, correct_grad, atol=tol, rtol=0)
 
     def test_linear(self, tol):
         """Tests gradients with multivariate multidimensional linear func."""
-        x_vec = np.random.uniform(-5, 5, size=(2))
-        x_vec_multidim = np.expand_dims(x_vec, axis=1)
+        x_vec = pnp.random.uniform(-5, 5, size=(2))
+        x_vec_multidim = pnp.expand_dims(x_vec, axis=1)
 
-        gradf = lambda x: np.array([[2 * x_[0]] for x_ in x])
-        f = lambda x: np.sum([x_[0] ** 2 for x_ in x])
+        gradf = lambda x: pnp.array([[2 * x_[0]] for x_ in x])
+        f = lambda x: pnp.sum([x_[0] ** 2 for x_ in x])
 
         g = qml.grad(f, 0)
         auto_grad = g(x_vec_multidim)
         correct_grad = gradf(x_vec_multidim)
-        assert np.allclose(auto_grad, correct_grad, atol=tol, rtol=0)
+        assert pnp.allclose(auto_grad, correct_grad, atol=tol, rtol=0)
 
 
 class TestGrad:
@@ -252,10 +252,10 @@ class TestGrad:
         """Test gradient computation with a non-scalar cost function raises an error"""
 
         def cost(x):
-            return np.sin(x)
+            return pnp.sin(x)
 
         grad_fn = qml.grad(cost, argnum=[0])
-        arr1 = np.array([0.0, 1.0, 2.0], requires_grad=True)
+        arr1 = pnp.array([0.0, 1.0, 2.0], requires_grad=True)
 
         with pytest.raises(TypeError, match="only applies to real scalar-output functions"):
             grad_fn(arr1)
@@ -265,23 +265,23 @@ class TestGrad:
         """Test that the grad function agrees with autograd"""
 
         def cost(x):
-            return np.sum(np.sin(x) * x[0] ** 3)
+            return pnp.sum(pnp.sin(x) * x[0] ** 3)
 
         grad_fn = qml.grad(cost)
-        params = np.array([0.5, 1.0, 2.0], requires_grad=True)
+        params = pnp.array([0.5, 1.0, 2.0], requires_grad=True)
         res = grad_fn(params)
         expected = autograd.grad(cost)(params)
 
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
     def test_forward_pass_value_storing(self, tol):
         """Test that the intermediate forward pass value is accessible and correct"""
 
         def cost(x):
-            return np.sum(np.sin(x) * x[0] ** 3)
+            return pnp.sum(pnp.sin(x) * x[0] ** 3)
 
         grad_fn = qml.grad(cost)
-        params = np.array([-0.654, 1.0, 2.0], requires_grad=True)
+        params = pnp.array([-0.654, 1.0, 2.0], requires_grad=True)
 
         assert grad_fn.forward is None
 
@@ -289,38 +289,38 @@ class TestGrad:
 
         res = grad_fn.forward
         expected = cost(params)
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
         # change the parameters
-        params2 = np.array([1.4, 1.0, 2.0], requires_grad=True)
+        params2 = pnp.array([1.4, 1.0, 2.0], requires_grad=True)
         grad_fn(params2)
 
         res = grad_fn.forward
         expected = cost(params2)
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
     def test_no_argnum_grad(self, mocker, tol):
         """Test the qml.grad function for inferred argnums"""
-        cost_fn = lambda x, y: np.sin(x) * np.cos(y) + x * y**2
+        cost_fn = lambda x, y: pnp.sin(x) * pnp.cos(y) + x * y**2
 
-        x = np.array(0.5, requires_grad=True)
-        y = np.array(0.2, requires_grad=True)
+        x = pnp.array(0.5, requires_grad=True)
+        y = pnp.array(0.2, requires_grad=True)
 
         grad_fn = qml.grad(cost_fn)
         spy = mocker.spy(grad_fn, "_grad_with_forward")
 
         res = grad_fn(x, y)
-        expected = np.array([np.cos(x) * np.cos(y) + y**2, -np.sin(x) * np.sin(y) + 2 * x * y])
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        expected = pnp.array([pnp.cos(x) * pnp.cos(y) + y**2, -pnp.sin(x) * pnp.sin(y) + 2 * x * y])
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
         assert spy.call_args_list[0][1]["argnum"] == [0, 1]
 
-        x = np.array(0.5, requires_grad=True)
-        y = np.array(0.2, requires_grad=False)
+        x = pnp.array(0.5, requires_grad=True)
+        y = pnp.array(0.2, requires_grad=False)
         spy.call_args_list = []
 
         res = grad_fn(x, y)
-        expected = np.array([np.cos(x) * np.cos(y) + y**2])
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        expected = pnp.array([pnp.cos(x) * pnp.cos(y) + y**2])
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
         assert spy.call_args_list[0][1]["argnum"] == 0
 
 
@@ -329,48 +329,48 @@ class TestJacobian:
 
     def test_single_argnum_jacobian(self, tol):
         """Test the qml.jacobian function for a single argnum"""
-        cost_fn = lambda x, y: np.array([np.sin(x) * np.cos(y), x * y**2])
+        cost_fn = lambda x, y: pnp.array([pnp.sin(x) * pnp.cos(y), x * y**2])
 
-        x = np.array(0.5, requires_grad=True)
-        y = np.array(0.2, requires_grad=True)
+        x = pnp.array(0.5, requires_grad=True)
+        y = pnp.array(0.2, requires_grad=True)
 
         jac_fn = qml.jacobian(cost_fn, argnum=0)
         res = jac_fn(x, y)
-        expected = np.array([np.cos(x) * np.cos(y), y**2])
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        expected = pnp.array([pnp.cos(x) * pnp.cos(y), y**2])
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
     def test_multiple_argnum_jacobian(self, tol):
         """Test the qml.jacobian function for multiple argnums"""
-        cost_fn = lambda x, y: np.array([np.sin(x) * np.cos(y), x * y**2])
+        cost_fn = lambda x, y: pnp.array([pnp.sin(x) * pnp.cos(y), x * y**2])
 
-        x = np.array(0.5, requires_grad=True)
-        y = np.array(0.2, requires_grad=True)
+        x = pnp.array(0.5, requires_grad=True)
+        y = pnp.array(0.2, requires_grad=True)
 
         jac_fn = qml.jacobian(cost_fn, argnum=[0, 1])
         res = jac_fn(x, y)
         expected = (
-            np.array([np.cos(x) * np.cos(y), y**2]),
-            np.array([-np.sin(x) * np.sin(y), 2 * x * y]),
+            pnp.array([pnp.cos(x) * pnp.cos(y), y**2]),
+            pnp.array([-pnp.sin(x) * pnp.sin(y), 2 * x * y]),
         )
-        assert all(np.allclose(_r, _e, atol=tol, rtol=0) for _r, _e in zip(res, expected))
+        assert all(pnp.allclose(_r, _e, atol=tol, rtol=0) for _r, _e in zip(res, expected))
 
     def test_no_argnum_jacobian(self, tol):
         """Test the qml.jacobian function for inferred argnums"""
-        cost_fn = lambda x, y: np.array([np.sin(x) * np.cos(y), x * y**2])
+        cost_fn = lambda x, y: pnp.array([pnp.sin(x) * pnp.cos(y), x * y**2])
 
-        x = np.array(0.5, requires_grad=True)
-        y = np.array(0.2, requires_grad=True)
+        x = pnp.array(0.5, requires_grad=True)
+        y = pnp.array(0.2, requires_grad=True)
 
         jac_fn = qml.jacobian(cost_fn)
         res = jac_fn(x, y)
         expected = (
-            np.array([np.cos(x) * np.cos(y), y**2]),
-            np.array([-np.sin(x) * np.sin(y), 2 * x * y]),
+            pnp.array([pnp.cos(x) * pnp.cos(y), y**2]),
+            pnp.array([-pnp.sin(x) * pnp.sin(y), 2 * x * y]),
         )
-        assert all(np.allclose(_r, _e, atol=tol, rtol=0) for _r, _e in zip(res, expected))
+        assert all(pnp.allclose(_r, _e, atol=tol, rtol=0) for _r, _e in zip(res, expected))
 
-        x = np.array(0.5, requires_grad=False)
-        y = np.array(0.2, requires_grad=True)
+        x = pnp.array(0.5, requires_grad=False)
+        y = pnp.array(0.2, requires_grad=True)
 
         res = jac_fn(x, y)
-        assert np.allclose(res, expected[1], atol=tol, rtol=0)
+        assert pnp.allclose(res, expected[1], atol=tol, rtol=0)

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -20,11 +20,11 @@ import warnings
 from unittest.mock import patch
 
 import mcm_utils
-import numpy as np
+import numpy as pnp
 import pytest
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane.compiler.compiler import CompileError
 from pennylane.transforms.dynamic_one_shot import fill_in_value
 
@@ -418,8 +418,8 @@ class TestCatalystControlFlow:
             loop_fn()
             return qml.state()
 
-        expected = np.zeros(2**6)
-        expected[[0, 2**6 - 1]] = 1 / np.sqrt(2)
+        expected = pnp.zeros(2**6)
+        expected[[0, 2**6 - 1]] = 1 / pnp.sqrt(2)
 
         assert jnp.allclose(circuit(6), expected)
 
@@ -442,7 +442,7 @@ class TestCatalystControlFlow:
 
                 @qml.for_loop(i + 1, n, 1)
                 def inner(j):
-                    qml.ControlledPhaseShift(np.pi / 2 ** (n - j + 1), [i, j])
+                    qml.ControlledPhaseShift(pnp.pi / 2 ** (n - j + 1), [i, j])
 
                 inner()
 
@@ -631,9 +631,9 @@ class TestCatalystControlFlow:
 
             return conditional()
 
-        assert np.allclose(f(0.5), (0.5 + 1) ** 2)
-        assert np.allclose(f(-0.5), -(-0.5 + 1))
-        assert np.allclose(f(-2.5), (-2.5 + 1))
+        assert pnp.allclose(f(0.5), (0.5 + 1) ** 2)
+        assert pnp.allclose(f(-0.5), -(-0.5 + 1))
+        assert pnp.allclose(f(-2.5), (-2.5 + 1))
 
 
 class TestCatalystGrad:
@@ -744,7 +744,7 @@ class TestCatalystGrad:
             g = qml.jacobian(circuit)
             return g(x)
 
-        reference = workflow(np.array([2.0, 1.0]))
+        reference = workflow(pnp.array([2.0, 1.0]))
         result = qml.qjit(workflow)(jnp.array([2.0, 1.0]))
 
         assert jnp.allclose(result, reference)
@@ -756,22 +756,22 @@ class TestCatalystGrad:
         def workflow(x):
             @qml.qnode(dev)
             def circuit(x):
-                qml.RX(np.pi * x[0], wires=0)
+                qml.RX(pnp.pi * x[0], wires=0)
                 qml.RY(x[1], wires=0)
                 return qml.probs()
 
             g = qml.jacobian(circuit, method="fd", h=0.3)
             return g(x)
 
-        result = qml.qjit(workflow)(np.array([2.0, 1.0]))
-        reference = np.array([[-0.37120096, -0.45467246], [0.37120096, 0.45467246]])
+        result = qml.qjit(workflow)(pnp.array([2.0, 1.0]))
+        reference = pnp.array([[-0.37120096, -0.45467246], [0.37120096, 0.45467246]])
         assert jnp.allclose(result, reference)
 
         with pytest.raises(
             ValueError,
             match="Invalid values 'method='fd'' and 'h=0.3' without QJIT",
         ):
-            workflow(np.array([2.0, 1.0]))
+            workflow(pnp.array([2.0, 1.0]))
 
     def test_jvp(self):
         """Test that the correct JVP is returned with QJIT."""

--- a/tests/transforms/test_batch_input.py
+++ b/tests/transforms/test_batch_input.py
@@ -20,7 +20,7 @@ from functools import partial
 import pytest
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 
 
 def test_simple_circuit():
@@ -36,8 +36,8 @@ def test_simple_circuit():
         return qml.expval(qml.PauliZ(1))
 
     batch_size = 5
-    inputs = np.random.uniform(0, np.pi, (batch_size, 2), requires_grad=False)
-    weights = np.random.uniform(-np.pi, np.pi, (2,))
+    inputs = pnp.random.uniform(0, pnp.pi, (batch_size, 2), requires_grad=False)
+    weights = pnp.random.uniform(-pnp.pi, pnp.pi, (2,))
 
     res = circuit(inputs, weights)
     assert res.shape == (batch_size,)
@@ -56,8 +56,8 @@ def test_simple_circuit_one_batch():
         return qml.expval(qml.PauliZ(1))
 
     batch_size = 1
-    inputs = np.random.uniform(0, np.pi, (batch_size, 2), requires_grad=False)
-    weights = np.random.uniform(-np.pi, np.pi, (2,))
+    inputs = pnp.random.uniform(0, pnp.pi, (batch_size, 2), requires_grad=False)
+    weights = pnp.random.uniform(-pnp.pi, pnp.pi, (2,))
 
     res = circuit(inputs, weights)
     assert res.shape == (batch_size,)
@@ -70,15 +70,15 @@ def test_simple_circuit_with_prep():
     @partial(qml.batch_input, argnum=1)
     @qml.qnode(dev)
     def circuit(inputs, weights):
-        qml.StatePrep(np.array([0, 0, 1, 0]), wires=[0, 1])
+        qml.StatePrep(pnp.array([0, 0, 1, 0]), wires=[0, 1])
         qml.RX(inputs, wires=0)
         qml.RY(weights[0], wires=0)
         qml.RY(weights[1], wires=1)
         return qml.expval(qml.PauliZ(1))
 
     batch_size = 5
-    inputs = np.random.uniform(0, np.pi, (batch_size,), requires_grad=False)
-    weights = np.random.uniform(-np.pi, np.pi, (2,))
+    inputs = pnp.random.uniform(0, pnp.pi, (batch_size,), requires_grad=False)
+    weights = pnp.random.uniform(-pnp.pi, pnp.pi, (2,))
 
     res = circuit(inputs, weights)
     assert res.shape == (batch_size,)
@@ -98,7 +98,7 @@ def test_circuit_non_param_operator_before_batched_operator():
 
     batch_size = 3
 
-    input = np.linspace(0.1, 0.5, batch_size, requires_grad=False)
+    input = pnp.linspace(0.1, 0.5, batch_size, requires_grad=False)
 
     res = circuit(input)
 
@@ -129,9 +129,9 @@ def test_value_error():
         return qml.expval(qml.PauliZ(1))
 
     batch_size = 5
-    input1 = np.random.uniform(0, np.pi, (batch_size, 2), requires_grad=False)
-    input2 = np.random.uniform(0, np.pi, (4, 1), requires_grad=False)
-    weights = np.random.uniform(-np.pi, np.pi, (2,))
+    input1 = pnp.random.uniform(0, pnp.pi, (batch_size, 2), requires_grad=False)
+    input2 = pnp.random.uniform(0, pnp.pi, (4, 1), requires_grad=False)
+    weights = pnp.random.uniform(-pnp.pi, pnp.pi, (2,))
 
     with pytest.raises(ValueError, match="Batch dimension for all gate arguments"):
         circuit(input1, input2, weights)
@@ -151,7 +151,7 @@ def test_batch_input_with_trainable_parameters_raises_error():
 
     batch_size = 3
 
-    input = np.linspace(0.1, 0.5, batch_size, requires_grad=True)
+    input = pnp.linspace(0.1, 0.5, batch_size, requires_grad=True)
 
     with pytest.raises(
         ValueError,
@@ -176,11 +176,11 @@ def test_mottonenstate_preparation(mocker):
     batch_size = 3
 
     # create a batched input statevector
-    data = np.random.random((batch_size, 2**3), requires_grad=False)
-    data /= np.linalg.norm(data, axis=1).reshape(-1, 1)  # normalize
+    data = pnp.random.random((batch_size, 2**3), requires_grad=False)
+    data /= pnp.linalg.norm(data, axis=1).reshape(-1, 1)  # normalize
 
     # weights is not batched
-    weights = np.random.random((10, 3, 3), requires_grad=True)
+    weights = pnp.random.random((10, 3, 3), requires_grad=True)
 
     spy = mocker.spy(circuit.device, "execute")
     res = circuit(data, weights)
@@ -197,7 +197,7 @@ def test_mottonenstate_preparation(mocker):
     indiv_res = []
     for state in data:
         indiv_res.append(circuit2(state, weights))
-    assert np.allclose(res, indiv_res)
+    assert pnp.allclose(res, indiv_res)
 
 
 def test_qubit_state_prep(mocker):
@@ -215,11 +215,11 @@ def test_qubit_state_prep(mocker):
     batch_size = 3
 
     # create a batched input statevector
-    data = np.random.random((batch_size, 2**3), requires_grad=False)
-    data /= np.linalg.norm(data, axis=1).reshape(-1, 1)  # normalize
+    data = pnp.random.random((batch_size, 2**3), requires_grad=False)
+    data /= pnp.linalg.norm(data, axis=1).reshape(-1, 1)  # normalize
 
     # weights is not batched
-    weights = np.random.random((10, 3, 3), requires_grad=True)
+    weights = pnp.random.random((10, 3, 3), requires_grad=True)
 
     spy = mocker.spy(circuit.device, "execute")
     res = circuit(data, weights)
@@ -237,7 +237,7 @@ def test_qubit_state_prep(mocker):
     for state in data:
         indiv_res.append(circuit2(state, weights))
 
-    assert np.allclose(res, indiv_res)
+    assert pnp.allclose(res, indiv_res)
 
 
 def test_multi_returns():
@@ -253,8 +253,8 @@ def test_multi_returns():
         return qml.expval(qml.PauliZ(1)), qml.probs(wires=[0, 1])
 
     batch_size = 6
-    inputs = np.random.uniform(0, np.pi, (batch_size, 2), requires_grad=False)
-    weights = np.random.uniform(-np.pi, np.pi, (2,))
+    inputs = pnp.random.uniform(0, pnp.pi, (batch_size, 2), requires_grad=False)
+    weights = pnp.random.uniform(-pnp.pi, pnp.pi, (2,))
 
     res = circuit(inputs, weights)
     assert isinstance(res, tuple)
@@ -277,8 +277,8 @@ def test_shot_vector():
         return qml.probs(wires=[0, 1])
 
     batch_size = 6
-    inputs = np.random.uniform(0, np.pi, (batch_size, 2), requires_grad=False)
-    weights = np.random.uniform(-np.pi, np.pi, (2,))
+    inputs = pnp.random.uniform(0, pnp.pi, (batch_size, 2), requires_grad=False)
+    weights = pnp.random.uniform(-pnp.pi, pnp.pi, (2,))
 
     res = circuit(inputs, weights)
 
@@ -302,8 +302,8 @@ def test_multi_returns_shot_vector():
         return qml.expval(qml.PauliZ(1)), qml.probs(wires=[0, 1])
 
     batch_size = 6
-    inputs = np.random.uniform(0, np.pi, (batch_size, 2), requires_grad=False)
-    weights = np.random.uniform(-np.pi, np.pi, (2,))
+    inputs = pnp.random.uniform(0, pnp.pi, (batch_size, 2), requires_grad=False)
+    weights = pnp.random.uniform(-pnp.pi, pnp.pi, (2,))
 
     res = circuit(inputs, weights)
 
@@ -335,14 +335,14 @@ class TestDiffSingle:
         batch_size = 3
 
         def cost(input, x):
-            return np.sum(circuit(input, x))
+            return pnp.sum(circuit(input, x))
 
-        input = np.linspace(0.1, 0.5, batch_size, requires_grad=False)
-        x = np.array(0.1, requires_grad=True)
+        input = pnp.linspace(0.1, 0.5, batch_size, requires_grad=False)
+        x = pnp.array(0.1, requires_grad=True)
 
         res = qml.grad(cost)(input, x)
-        expected = -np.sin(0.1) * sum(np.sin(input))
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        expected = -pnp.sin(0.1) * sum(pnp.sin(input))
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
     @pytest.mark.jax
     @pytest.mark.parametrize("diff_method", ["backprop", "adjoint", "parameter-shift"])
@@ -371,8 +371,8 @@ class TestDiffSingle:
         x = jnp.array(0.1)
 
         res = jax.grad(cost, argnums=1)(input, x)
-        expected = -np.sin(0.1) * sum(np.sin(input))
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        expected = -pnp.sin(0.1) * sum(pnp.sin(input))
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
     @pytest.mark.jax
     @pytest.mark.parametrize("diff_method", ["adjoint", "parameter-shift"])
@@ -404,8 +404,8 @@ class TestDiffSingle:
         x = jnp.array(0.1)
 
         res = jax.grad(cost, argnums=1)(input, x)
-        expected = -np.sin(0.1) * sum(np.sin(input))
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        expected = -pnp.sin(0.1) * sum(pnp.sin(input))
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
     @pytest.mark.torch
     @pytest.mark.parametrize("diff_method", ["backprop", "adjoint", "parameter-shift"])
@@ -436,7 +436,7 @@ class TestDiffSingle:
         loss.backward()
 
         res = x.grad
-        expected = -np.sin(0.1) * torch.sum(torch.sin(input))
+        expected = -pnp.sin(0.1) * torch.sum(torch.sin(input))
         assert qml.math.allclose(res, expected, atol=tol, rtol=0)
 
     @pytest.mark.tf
@@ -457,15 +457,15 @@ class TestDiffSingle:
             return qml.expval(qml.PauliZ(0) @ qml.PauliX(1))
 
         batch_size = 3
-        input = tf.Variable(np.linspace(0.1, 0.5, batch_size), trainable=False)
+        input = tf.Variable(pnp.linspace(0.1, 0.5, batch_size), trainable=False)
         x = tf.Variable(0.1, trainable=True)
 
         with tf.GradientTape() as tape:
             loss = tf.reduce_sum(circuit(input, x))
 
         res = tape.gradient(loss, x)
-        expected = -np.sin(0.1) * tf.reduce_sum(tf.sin(input))
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        expected = -pnp.sin(0.1) * tf.reduce_sum(tf.sin(input))
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
     @pytest.mark.tf
     @pytest.mark.parametrize("diff_method", ["backprop", "adjoint", "parameter-shift"])
@@ -486,15 +486,15 @@ class TestDiffSingle:
             return qml.expval(qml.PauliZ(0) @ qml.PauliX(1))
 
         batch_size = 3
-        input = tf.Variable(np.linspace(0.1, 0.5, batch_size), trainable=False)
+        input = tf.Variable(pnp.linspace(0.1, 0.5, batch_size), trainable=False)
         x = tf.Variable(0.1, trainable=True, dtype=tf.float64)
 
         with tf.GradientTape() as tape:
             loss = tf.reduce_sum(circuit(input, x))
 
         res = tape.gradient(loss, x)
-        expected = -np.sin(0.1) * tf.reduce_sum(tf.sin(input))
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        expected = -pnp.sin(0.1) * tf.reduce_sum(tf.sin(input))
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
 
 class TestDiffMulti:
@@ -519,18 +519,18 @@ class TestDiffMulti:
             return qml.math.concatenate([qml.math.expand_dims(res[0], 1), res[1]], axis=1)
 
         batch_size = 3
-        input = np.linspace(0.1, 0.5, batch_size, requires_grad=False)
-        x = np.array(0.1, requires_grad=True)
+        input = pnp.linspace(0.1, 0.5, batch_size, requires_grad=False)
+        x = pnp.array(0.1, requires_grad=True)
 
         res = cost(input, x)
         expected = qml.math.transpose(
             qml.math.stack(
                 [
-                    np.cos(input + x),
-                    np.cos((input + x) / 2) ** 2,
-                    np.zeros_like(input),
-                    np.zeros_like(input),
-                    np.sin((input + x) / 2) ** 2,
+                    pnp.cos(input + x),
+                    pnp.cos((input + x) / 2) ** 2,
+                    pnp.zeros_like(input),
+                    pnp.zeros_like(input),
+                    pnp.sin((input + x) / 2) ** 2,
                 ]
             )
         )
@@ -540,11 +540,11 @@ class TestDiffMulti:
         expected = qml.math.transpose(
             qml.math.stack(
                 [
-                    -np.sin(input + x),
-                    -np.sin(input + x) / 2,
-                    np.zeros_like(input),
-                    np.zeros_like(input),
-                    np.sin(input + x) / 2,
+                    -pnp.sin(input + x),
+                    -pnp.sin(input + x) / 2,
+                    pnp.zeros_like(input),
+                    pnp.zeros_like(input),
+                    pnp.sin(input + x) / 2,
                 ]
             )
         )
@@ -578,10 +578,10 @@ class TestDiffMulti:
             qml.math.transpose(
                 qml.math.stack(
                     [
-                        np.cos((input + x) / 2) ** 2,
-                        np.zeros_like(input),
-                        np.zeros_like(input),
-                        np.sin((input + x) / 2) ** 2,
+                        pnp.cos((input + x) / 2) ** 2,
+                        pnp.zeros_like(input),
+                        pnp.zeros_like(input),
+                        pnp.sin((input + x) / 2) ** 2,
                     ]
                 )
             ),
@@ -643,10 +643,10 @@ class TestDiffMulti:
             qml.math.transpose(
                 qml.math.stack(
                     [
-                        np.cos((input + x) / 2) ** 2,
-                        np.zeros_like(input),
-                        np.zeros_like(input),
-                        np.sin((input + x) / 2) ** 2,
+                        pnp.cos((input + x) / 2) ** 2,
+                        pnp.zeros_like(input),
+                        pnp.zeros_like(input),
+                        pnp.sin((input + x) / 2) ** 2,
                     ]
                 )
             ),
@@ -695,7 +695,7 @@ class TestDiffMulti:
             return qml.expval(qml.PauliZ(0)), qml.probs(wires=[0, 1])
 
         batch_size = 3
-        input = torch.tensor(np.linspace(0.1, 0.5, batch_size), requires_grad=False)
+        input = torch.tensor(pnp.linspace(0.1, 0.5, batch_size), requires_grad=False)
         x = torch.tensor(0.1, requires_grad=True)
 
         res = circuit(input, x)
@@ -756,7 +756,7 @@ class TestDiffMulti:
             return qml.expval(qml.PauliZ(0)), qml.probs(wires=[0, 1])
 
         batch_size = 3
-        input = tf.Variable(np.linspace(0.1, 0.5, batch_size), trainable=False)
+        input = tf.Variable(pnp.linspace(0.1, 0.5, batch_size), trainable=False)
         x = tf.Variable(0.1, trainable=True, dtype=tf.float64)
 
         with tf.GradientTape() as tape:
@@ -766,11 +766,11 @@ class TestDiffMulti:
         expected = qml.math.transpose(
             qml.math.stack(
                 [
-                    np.cos(input + x),
-                    np.cos((input + x) / 2) ** 2,
-                    np.zeros_like(input),
-                    np.zeros_like(input),
-                    np.sin((input + x) / 2) ** 2,
+                    pnp.cos(input + x),
+                    pnp.cos((input + x) / 2) ** 2,
+                    pnp.zeros_like(input),
+                    pnp.zeros_like(input),
+                    pnp.sin((input + x) / 2) ** 2,
                 ]
             )
         )
@@ -780,11 +780,11 @@ class TestDiffMulti:
         expected = qml.math.transpose(
             qml.math.stack(
                 [
-                    -np.sin(input + x),
-                    -np.sin(input + x) / 2,
-                    np.zeros_like(input),
-                    np.zeros_like(input),
-                    np.sin(input + x) / 2,
+                    -pnp.sin(input + x),
+                    -pnp.sin(input + x) / 2,
+                    pnp.zeros_like(input),
+                    pnp.zeros_like(input),
+                    pnp.sin(input + x) / 2,
                 ]
             )
         )
@@ -809,7 +809,7 @@ class TestDiffMulti:
             return qml.expval(qml.PauliZ(0)), qml.probs(wires=[0, 1])
 
         batch_size = 3
-        input = tf.Variable(np.linspace(0.1, 0.5, batch_size), trainable=False)
+        input = tf.Variable(pnp.linspace(0.1, 0.5, batch_size), trainable=False)
         x = tf.Variable(0.1, trainable=True, dtype=tf.float64)
 
         with tf.GradientTape() as tape:
@@ -819,11 +819,11 @@ class TestDiffMulti:
         expected = qml.math.transpose(
             qml.math.stack(
                 [
-                    np.cos(input + x),
-                    np.cos((input + x) / 2) ** 2,
-                    np.zeros_like(input),
-                    np.zeros_like(input),
-                    np.sin((input + x) / 2) ** 2,
+                    pnp.cos(input + x),
+                    pnp.cos((input + x) / 2) ** 2,
+                    pnp.zeros_like(input),
+                    pnp.zeros_like(input),
+                    pnp.sin((input + x) / 2) ** 2,
                 ]
             )
         )
@@ -833,11 +833,11 @@ class TestDiffMulti:
         expected = qml.math.transpose(
             qml.math.stack(
                 [
-                    -np.sin(input + x),
-                    -np.sin(input + x) / 2,
-                    np.zeros_like(input),
-                    np.zeros_like(input),
-                    np.sin(input + x) / 2,
+                    -pnp.sin(input + x),
+                    -pnp.sin(input + x) / 2,
+                    pnp.zeros_like(input),
+                    pnp.zeros_like(input),
+                    pnp.sin(input + x) / 2,
                 ]
             )
         )
@@ -847,8 +847,8 @@ class TestDiffMulti:
 def test_unbatched_not_copied():
     """Test that operators containing unbatched parameters are not copied"""
     batch_size = 5
-    inputs = np.random.uniform(0, np.pi, (batch_size, 2), requires_grad=False)
-    weights = np.random.uniform(-np.pi, np.pi, (2,))
+    inputs = pnp.random.uniform(0, pnp.pi, (batch_size, 2), requires_grad=False)
+    weights = pnp.random.uniform(-pnp.pi, pnp.pi, (2,))
 
     ops = [
         qml.RY(weights[0], wires=0),

--- a/tests/transforms/test_batch_params.py
+++ b/tests/transforms/test_batch_params.py
@@ -20,7 +20,7 @@ import functools
 import pytest
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 
 
 def test_simple_circuit(mocker):
@@ -37,9 +37,9 @@ def test_simple_circuit(mocker):
         return qml.probs(wires=[0, 2])
 
     batch_size = 5
-    data = np.random.random((batch_size, 8))
-    x = np.linspace(0.1, 0.5, batch_size, requires_grad=True)
-    weights = np.ones((batch_size, 10, 3, 3), requires_grad=True)
+    data = pnp.random.random((batch_size, 8))
+    x = pnp.linspace(0.1, 0.5, batch_size, requires_grad=True)
+    weights = pnp.ones((batch_size, 10, 3, 3), requires_grad=True)
 
     spy = mocker.spy(circuit.device, "execute")
     res = circuit(data, x, weights)
@@ -61,9 +61,9 @@ def test_simple_circuit_one_batch(mocker):
         return qml.probs(wires=[0, 2])
 
     batch_size = 1
-    data = np.random.random((batch_size, 8))
-    x = np.linspace(0.1, 0.5, batch_size, requires_grad=True)
-    weights = np.ones((batch_size, 10, 3, 3), requires_grad=True)
+    data = pnp.random.random((batch_size, 8))
+    x = pnp.linspace(0.1, 0.5, batch_size, requires_grad=True)
+    weights = pnp.ones((batch_size, 10, 3, 3), requires_grad=True)
 
     spy = mocker.spy(circuit.device, "execute")
     res = circuit(data, x, weights)
@@ -75,7 +75,7 @@ def test_simple_circuit_with_prep(mocker):
     """Test that batching works for a simple circuit with a state preparation"""
     dev = qml.device("default.qubit", wires=3)
 
-    init_state = np.array([0, 0, 0, 0, 1, 0, 0, 0], requires_grad=False)
+    init_state = pnp.array([0, 0, 0, 0, 1, 0, 0, 0], requires_grad=False)
 
     @qml.batch_params
     @qml.qnode(dev, interface="autograd")
@@ -88,9 +88,9 @@ def test_simple_circuit_with_prep(mocker):
         return qml.probs(wires=[0, 2])
 
     batch_size = 5
-    data = np.random.random((batch_size,))
-    x = np.linspace(0.1, 0.5, batch_size, requires_grad=True)
-    weights = np.ones((batch_size, 10, 3, 3), requires_grad=True)
+    data = pnp.random.random((batch_size,))
+    x = pnp.linspace(0.1, 0.5, batch_size, requires_grad=True)
+    weights = pnp.ones((batch_size, 10, 3, 3), requires_grad=True)
 
     spy = mocker.spy(circuit.device, "execute")
     res = circuit(data, x, weights)
@@ -110,7 +110,7 @@ def test_basic_entangler_layers(mocker):
         return qml.probs(wires=[0, 1])
 
     batch_size = 5
-    weights = np.random.random((batch_size, 2, 2))
+    weights = pnp.random.random((batch_size, 2, 2))
 
     spy = mocker.spy(circuit.device, "execute")
     res = circuit(weights)
@@ -130,7 +130,7 @@ def test_angle_embedding(mocker):
         return qml.probs(wires=[0, 2])
 
     batch_size = 5
-    data = np.random.random((batch_size, 3))
+    data = pnp.random.random((batch_size, 3))
 
     spy = mocker.spy(circuit.device, "execute")
     res = circuit(data)
@@ -152,9 +152,9 @@ def test_mottonenstate_preparation(mocker):
     batch_size = 3
 
     # create a batched input statevector
-    data = np.random.random((batch_size, 2**3))
-    data /= np.linalg.norm(data, axis=1).reshape(-1, 1)  # normalize
-    weights = np.random.random((batch_size, 10, 3, 3))
+    data = pnp.random.random((batch_size, 2**3))
+    data /= pnp.linalg.norm(data, axis=1).reshape(-1, 1)  # normalize
+    weights = pnp.random.random((batch_size, 10, 3, 3))
 
     spy = mocker.spy(circuit.device, "execute")
     res = circuit(data, weights)
@@ -171,7 +171,7 @@ def test_mottonenstate_preparation(mocker):
     indiv_res = []
     for state, weight in zip(data, weights):
         indiv_res.append(circuit2(state, weight))
-    assert np.allclose(res, indiv_res)
+    assert pnp.allclose(res, indiv_res)
 
 
 def test_qubit_state_prep(mocker):
@@ -188,9 +188,9 @@ def test_qubit_state_prep(mocker):
     batch_size = 3
 
     # create a batched input statevector
-    data = np.random.random((batch_size, 2**3))
-    data /= np.linalg.norm(data, axis=1).reshape(-1, 1)  # normalize
-    weights = np.random.random((batch_size, 10, 3, 3))
+    data = pnp.random.random((batch_size, 2**3))
+    data /= pnp.linalg.norm(data, axis=1).reshape(-1, 1)  # normalize
+    weights = pnp.random.random((batch_size, 10, 3, 3))
 
     spy = mocker.spy(circuit.device, "execute")
     res = circuit(data, weights)
@@ -207,7 +207,7 @@ def test_qubit_state_prep(mocker):
     indiv_res = []
     for state, weight in zip(data, weights):
         indiv_res.append(circuit2(state, weight))
-    assert np.allclose(res, indiv_res)
+    assert pnp.allclose(res, indiv_res)
 
 
 def test_multi_returns():
@@ -224,9 +224,9 @@ def test_multi_returns():
         return qml.expval(qml.PauliZ(0)), qml.probs(wires=[0, 2])
 
     batch_size = 6
-    data = np.random.random((batch_size, 8))
-    x = np.linspace(0.1, 0.5, batch_size, requires_grad=True)
-    weights = np.ones((batch_size, 10, 3, 3), requires_grad=True)
+    data = pnp.random.random((batch_size, 8))
+    x = pnp.linspace(0.1, 0.5, batch_size, requires_grad=True)
+    weights = pnp.ones((batch_size, 10, 3, 3), requires_grad=True)
 
     res = circuit(data, x, weights)
 
@@ -252,9 +252,9 @@ def test_shot_vector():
         return qml.probs(wires=[0, 2])
 
     batch_size = 6
-    data = np.random.random((batch_size, 3))
-    x = np.linspace(0.1, 0.5, batch_size, requires_grad=True)
-    weights = np.ones((batch_size, 10, 3, 3), requires_grad=True)
+    data = pnp.random.random((batch_size, 3))
+    x = pnp.linspace(0.1, 0.5, batch_size, requires_grad=True)
+    weights = pnp.ones((batch_size, 10, 3, 3), requires_grad=True)
 
     res = circuit(data, x, weights)
 
@@ -279,9 +279,9 @@ def test_multi_returns_shot_vector():
         return qml.expval(qml.PauliZ(0)), qml.probs(wires=[0, 2])
 
     batch_size = 6
-    data = np.random.random((batch_size, 3))
-    x = np.linspace(0.1, 0.5, batch_size, requires_grad=True)
-    weights = np.ones((batch_size, 10, 3, 3), requires_grad=True)
+    data = pnp.random.random((batch_size, 3))
+    x = pnp.linspace(0.1, 0.5, batch_size, requires_grad=True)
+    weights = pnp.ones((batch_size, 10, 3, 3), requires_grad=True)
 
     res = circuit(data, x, weights)
 
@@ -311,14 +311,14 @@ class TestDiffSingle:
             return qml.expval(qml.PauliZ(0) @ qml.PauliX(1))
 
         def cost(x):
-            return np.sum(circuit(x))
+            return pnp.sum(circuit(x))
 
         batch_size = 3
-        x = np.linspace(0.1, 0.5, batch_size, requires_grad=True)
+        x = pnp.linspace(0.1, 0.5, batch_size, requires_grad=True)
 
         res = qml.grad(cost)(x)
-        expected = -np.sin(0.1) * np.sin(x)
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        expected = -pnp.sin(0.1) * pnp.sin(x)
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
     @pytest.mark.jax
     @pytest.mark.parametrize("diff_method", ["backprop", "adjoint", "parameter-shift"])
@@ -345,8 +345,8 @@ class TestDiffSingle:
         x = jnp.linspace(0.1, 0.5, batch_size)
 
         res = jax.grad(cost)(x)
-        expected = -np.sin(0.1) * np.sin(x)
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        expected = -pnp.sin(0.1) * pnp.sin(x)
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
     @pytest.mark.jax
     @pytest.mark.parametrize("diff_method", ["adjoint", "parameter-shift"])
@@ -376,8 +376,8 @@ class TestDiffSingle:
         x = jnp.linspace(0.1, 0.5, batch_size)
 
         res = jax.grad(cost)(x)
-        expected = -np.sin(0.1) * np.sin(x)
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        expected = -pnp.sin(0.1) * pnp.sin(x)
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
     @pytest.mark.torch
     @pytest.mark.parametrize("diff_method", ["backprop", "adjoint", "parameter-shift"])
@@ -406,7 +406,7 @@ class TestDiffSingle:
         loss.backward()
 
         res = x.grad
-        expected = -np.sin(0.1) * torch.sin(x)
+        expected = -pnp.sin(0.1) * torch.sin(x)
         assert torch.allclose(res, expected, atol=tol, rtol=0)
 
     @pytest.mark.tf
@@ -436,8 +436,8 @@ class TestDiffSingle:
             loss = cost(x)
 
         res = tape.gradient(loss, x)
-        expected = -np.sin(0.1) * tf.sin(x)
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        expected = -pnp.sin(0.1) * tf.sin(x)
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
     @pytest.mark.tf
     @pytest.mark.parametrize("interface", ["auto", "tf", "tf-autograph"])
@@ -466,8 +466,8 @@ class TestDiffSingle:
             loss = cost(x)
 
         res = tape.gradient(loss, x)
-        expected = -np.sin(0.1) * tf.sin(x)
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        expected = -pnp.sin(0.1) * tf.sin(x)
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
 
 class TestDiffMulti:
@@ -491,17 +491,17 @@ class TestDiffMulti:
             return qml.math.concatenate([qml.math.expand_dims(res[0], 1), res[1]], axis=1)
 
         batch_size = 3
-        x = np.linspace(0.1, 0.5, batch_size, requires_grad=True)
+        x = pnp.linspace(0.1, 0.5, batch_size, requires_grad=True)
 
         res = cost(x)
         expected = qml.math.transpose(
             qml.math.stack(
                 [
-                    np.cos(x),
-                    np.cos(x / 2) ** 2,
-                    np.zeros_like(x),
-                    np.zeros_like(x),
-                    np.sin(x / 2) ** 2,
+                    pnp.cos(x),
+                    pnp.cos(x / 2) ** 2,
+                    pnp.zeros_like(x),
+                    pnp.zeros_like(x),
+                    pnp.sin(x / 2) ** 2,
                 ]
             )
         )
@@ -509,10 +509,10 @@ class TestDiffMulti:
 
         grad = qml.jacobian(cost)(x)
         expected = qml.math.stack(
-            [-np.sin(x), -np.sin(x) / 2, np.zeros_like(x), np.zeros_like(x), np.sin(x) / 2]
-        ) * qml.math.expand_dims(np.eye(batch_size), 1)
+            [-pnp.sin(x), -pnp.sin(x) / 2, pnp.zeros_like(x), pnp.zeros_like(x), pnp.sin(x) / 2]
+        ) * qml.math.expand_dims(pnp.eye(batch_size), 1)
 
-        assert np.allclose(grad, expected, atol=tol, rtol=0)
+        assert pnp.allclose(grad, expected, atol=tol, rtol=0)
 
     @pytest.mark.jax
     @pytest.mark.parametrize("diff_method", ["backprop", "parameter-shift"])
@@ -552,9 +552,9 @@ class TestDiffMulti:
 
         grad = jax.jacobian(circuit)(x)
         expected = (
-            -np.sin(x) * np.eye(batch_size),
-            qml.math.stack([-np.sin(x) / 2, np.zeros_like(x), np.zeros_like(x), np.sin(x) / 2])
-            * qml.math.expand_dims(np.eye(batch_size), 1),
+            -pnp.sin(x) * pnp.eye(batch_size),
+            qml.math.stack([-pnp.sin(x) / 2, pnp.zeros_like(x), pnp.zeros_like(x), pnp.sin(x) / 2])
+            * qml.math.expand_dims(pnp.eye(batch_size), 1),
         )
 
         assert isinstance(grad, tuple)
@@ -602,9 +602,9 @@ class TestDiffMulti:
 
         grad = jax.jacobian(circuit)(x)
         expected = (
-            -np.sin(x) * np.eye(batch_size),
-            qml.math.stack([-np.sin(x) / 2, np.zeros_like(x), np.zeros_like(x), np.sin(x) / 2])
-            * qml.math.expand_dims(np.eye(batch_size), 1),
+            -pnp.sin(x) * pnp.eye(batch_size),
+            qml.math.stack([-pnp.sin(x) / 2, pnp.zeros_like(x), pnp.zeros_like(x), pnp.sin(x) / 2])
+            * qml.math.expand_dims(pnp.eye(batch_size), 1),
         )
 
         assert isinstance(grad, tuple)
@@ -629,7 +629,7 @@ class TestDiffMulti:
             return qml.expval(qml.PauliZ(0)), qml.probs(wires=[0, 1])
 
         batch_size = 3
-        x = torch.tensor(np.linspace(0.1, 0.5, batch_size), requires_grad=True)
+        x = torch.tensor(pnp.linspace(0.1, 0.5, batch_size), requires_grad=True)
 
         res = circuit(x)
         expected = (
@@ -682,7 +682,7 @@ class TestDiffMulti:
             return qml.expval(qml.PauliZ(0)), qml.probs(wires=[0, 1])
 
         batch_size = 3
-        x = tf.Variable(np.linspace(0.1, 0.5, batch_size))
+        x = tf.Variable(pnp.linspace(0.1, 0.5, batch_size))
 
         with tf.GradientTape() as tape:
             res = circuit(x)
@@ -691,11 +691,11 @@ class TestDiffMulti:
         expected = qml.math.transpose(
             qml.math.stack(
                 [
-                    np.cos(x),
-                    np.cos(x / 2) ** 2,
-                    np.zeros_like(x),
-                    np.zeros_like(x),
-                    np.sin(x / 2) ** 2,
+                    pnp.cos(x),
+                    pnp.cos(x / 2) ** 2,
+                    pnp.zeros_like(x),
+                    pnp.zeros_like(x),
+                    pnp.sin(x / 2) ** 2,
                 ]
             )
         )
@@ -703,10 +703,10 @@ class TestDiffMulti:
 
         grad = tape.jacobian(res, x)
         expected = qml.math.stack(
-            [-np.sin(x), -np.sin(x) / 2, np.zeros_like(x), np.zeros_like(x), np.sin(x) / 2]
-        ) * qml.math.expand_dims(np.eye(batch_size), 1)
+            [-pnp.sin(x), -pnp.sin(x) / 2, pnp.zeros_like(x), pnp.zeros_like(x), pnp.sin(x) / 2]
+        ) * qml.math.expand_dims(pnp.eye(batch_size), 1)
 
-        assert np.allclose(grad, expected, atol=tol, rtol=0)
+        assert pnp.allclose(grad, expected, atol=tol, rtol=0)
 
     @pytest.mark.tf
     @pytest.mark.parametrize("diff_method", ["backprop", "parameter-shift"])
@@ -726,7 +726,7 @@ class TestDiffMulti:
             return qml.expval(qml.PauliZ(0)), qml.probs(wires=[0, 1])
 
         batch_size = 3
-        x = tf.Variable(np.linspace(0.1, 0.5, batch_size))
+        x = tf.Variable(pnp.linspace(0.1, 0.5, batch_size))
 
         with tf.GradientTape() as tape:
             res = circuit(x)
@@ -735,11 +735,11 @@ class TestDiffMulti:
         expected = qml.math.transpose(
             qml.math.stack(
                 [
-                    np.cos(x),
-                    np.cos(x / 2) ** 2,
-                    np.zeros_like(x),
-                    np.zeros_like(x),
-                    np.sin(x / 2) ** 2,
+                    pnp.cos(x),
+                    pnp.cos(x / 2) ** 2,
+                    pnp.zeros_like(x),
+                    pnp.zeros_like(x),
+                    pnp.sin(x / 2) ** 2,
                 ]
             )
         )
@@ -747,10 +747,10 @@ class TestDiffMulti:
 
         grad = tape.jacobian(res, x)
         expected = qml.math.stack(
-            [-np.sin(x), -np.sin(x) / 2, np.zeros_like(x), np.zeros_like(x), np.sin(x) / 2]
-        ) * qml.math.expand_dims(np.eye(batch_size), 1)
+            [-pnp.sin(x), -pnp.sin(x) / 2, pnp.zeros_like(x), pnp.zeros_like(x), pnp.sin(x) / 2]
+        ) * qml.math.expand_dims(pnp.eye(batch_size), 1)
 
-        assert np.allclose(grad, expected, atol=tol, rtol=0)
+        assert pnp.allclose(grad, expected, atol=tol, rtol=0)
 
 
 def test_all_operations(mocker):
@@ -766,8 +766,8 @@ def test_all_operations(mocker):
         return qml.probs(wires=[0, 2])
 
     batch_size = 3
-    x = np.linspace(0.1, 0.5, batch_size, requires_grad=True)
-    weights = np.ones((batch_size, 10, 3, 3), requires_grad=False)
+    x = pnp.linspace(0.1, 0.5, batch_size, requires_grad=True)
+    weights = pnp.ones((batch_size, 10, 3, 3), requires_grad=False)
 
     spy = mocker.spy(circuit.device, "execute")
     res = circuit(x, weights)
@@ -788,8 +788,8 @@ def test_unbatched_parameter():
         qml.RX(y, wires=[0])
         return qml.expval(qml.PauliZ(0))
 
-    x = np.array([0.3, 0.4, 0.5])
-    y = np.array(0.2)
+    x = pnp.array([0.3, 0.4, 0.5])
+    y = pnp.array(0.2)
 
     with pytest.raises(ValueError, match="0.2 has incorrect batch dimension"):
         circuit(x, y)
@@ -808,8 +808,8 @@ def test_initial_unbatched_parameter():
         qml.RX(y, wires=[0])
         return qml.expval(qml.PauliZ(0))
 
-    x = np.array(0.2)
-    y = np.array([0.3, 0.4, 0.5])
+    x = pnp.array(0.2)
+    y = pnp.array([0.3, 0.4, 0.5])
 
     with pytest.raises(ValueError, match="Parameter 0.2 does not contain a batch"):
         circuit(x, y)
@@ -834,9 +834,9 @@ def test_unbatched_not_copied():
     """Test that operators containing unbatched parameters are not copied"""
 
     batch_size = 5
-    data = np.random.random((batch_size, 8))
-    weights = np.ones((batch_size, 10, 3, 3), requires_grad=True)
-    x = np.array(0.4, requires_grad=False)
+    data = pnp.random.random((batch_size, 8))
+    weights = pnp.ones((batch_size, 10, 3, 3), requires_grad=True)
+    x = pnp.array(0.4, requires_grad=False)
 
     ops = [
         qml.templates.AmplitudeEmbedding(data, wires=[0, 1, 2], normalize=True),

--- a/tests/transforms/test_batch_partial.py
+++ b/tests/transforms/test_batch_partial.py
@@ -20,7 +20,7 @@ import re
 import pytest
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 
 
 def test_partial_evaluation():
@@ -37,10 +37,10 @@ def test_partial_evaluation():
     batch_size = 4
 
     # the partial argument to construct a new circuit with
-    y = np.random.uniform(size=2)
+    y = pnp.random.uniform(size=2)
 
     # the batched argument to the new partial circuit
-    x = np.random.uniform(size=batch_size)
+    x = pnp.random.uniform(size=batch_size)
 
     batched_partial_circuit = qml.batch_partial(circuit, y=y)
     res = batched_partial_circuit(x)
@@ -50,7 +50,7 @@ def test_partial_evaluation():
     for x_indiv in x:
         indiv_res.append(circuit(x_indiv, y))
 
-    assert np.allclose(res, indiv_res)
+    assert pnp.allclose(res, indiv_res)
 
 
 def test_partial_evaluation_kwargs():
@@ -68,10 +68,10 @@ def test_partial_evaluation_kwargs():
     batch_size = 4
 
     # the partial argument to construct a new circuit with
-    y = np.random.uniform(size=2)
+    y = pnp.random.uniform(size=2)
 
     # the batched argument to the new partial circuit
-    x = np.random.uniform(size=batch_size)
+    x = pnp.random.uniform(size=batch_size)
 
     batched_partial_circuit = qml.batch_partial(circuit, y=y)
     res = batched_partial_circuit(x=x)
@@ -81,7 +81,7 @@ def test_partial_evaluation_kwargs():
     for x_indiv in x:
         indiv_res.append(circuit(x_indiv, y))
 
-    assert np.allclose(res, indiv_res)
+    assert pnp.allclose(res, indiv_res)
 
 
 def test_partial_evaluation_multi_args():
@@ -100,11 +100,11 @@ def test_partial_evaluation_multi_args():
     batch_size = 4
 
     # the partial arguments to construct a new circuit with
-    y = np.random.uniform(size=2)
-    z = np.random.uniform(size=())
+    y = pnp.random.uniform(size=2)
+    z = pnp.random.uniform(size=())
 
     # the batched argument to the new partial circuit
-    x = np.random.uniform(size=batch_size)
+    x = pnp.random.uniform(size=batch_size)
 
     batched_partial_circuit = qml.batch_partial(circuit, y=y, z=z)
     res = batched_partial_circuit(x)
@@ -114,7 +114,7 @@ def test_partial_evaluation_multi_args():
     for x_indiv in x:
         indiv_res.append(circuit(x_indiv, y, z))
 
-    assert np.allclose(res, indiv_res)
+    assert pnp.allclose(res, indiv_res)
 
 
 def test_partial_evaluation_nonnumeric1():
@@ -132,11 +132,11 @@ def test_partial_evaluation_nonnumeric1():
     batch_size = 4
 
     # the partial arguments to construct a new circuit with
-    y = np.random.uniform(size=2)
+    y = pnp.random.uniform(size=2)
     measurement = qml.expval(qml.PauliZ(wires=0) @ qml.PauliZ(wires=1))
 
     # the batched argument to the new partial circuit
-    x = np.random.uniform(size=batch_size)
+    x = pnp.random.uniform(size=batch_size)
 
     batched_partial_circuit = qml.batch_partial(circuit, y=y, measurement=measurement)
     res = batched_partial_circuit(x)
@@ -146,7 +146,7 @@ def test_partial_evaluation_nonnumeric1():
     for x_indiv in x:
         indiv_res.append(circuit(x_indiv, y, measurement))
 
-    assert np.allclose(res, indiv_res)
+    assert pnp.allclose(res, indiv_res)
 
 
 def test_partial_evaluation_nonnumeric2():
@@ -164,11 +164,11 @@ def test_partial_evaluation_nonnumeric2():
     batch_size = 4
 
     # the partial arguments to construct a new circuit with
-    y = np.random.uniform(size=2)
-    func = np.cos
+    y = pnp.random.uniform(size=2)
+    func = pnp.cos
 
     # the batched argument to the new partial circuit
-    x = np.random.uniform(size=batch_size)
+    x = pnp.random.uniform(size=batch_size)
 
     batched_partial_circuit = qml.batch_partial(circuit, y=y, func=func)
     res = batched_partial_circuit(x)
@@ -178,7 +178,7 @@ def test_partial_evaluation_nonnumeric2():
     for x_indiv in x:
         indiv_res.append(circuit(x_indiv, y, func))
 
-    assert np.allclose(res, indiv_res)
+    assert pnp.allclose(res, indiv_res)
 
 
 def test_partial_evaluation_nonnumeric3():
@@ -196,11 +196,11 @@ def test_partial_evaluation_nonnumeric3():
     batch_size = 4
 
     # the partial arguments to construct a new circuit with
-    y = np.random.uniform(size=2)
+    y = pnp.random.uniform(size=2)
     op = qml.RX
 
     # the batched argument to the new partial circuit
-    x = np.random.uniform(size=batch_size)
+    x = pnp.random.uniform(size=batch_size)
 
     batched_partial_circuit = qml.batch_partial(circuit, y=y, op=op)
     res = batched_partial_circuit(x)
@@ -210,7 +210,7 @@ def test_partial_evaluation_nonnumeric3():
     for x_indiv in x:
         indiv_res.append(circuit(x_indiv, y, op))
 
-    assert np.allclose(res, indiv_res)
+    assert pnp.allclose(res, indiv_res)
 
 
 @pytest.mark.autograd
@@ -230,23 +230,23 @@ def test_partial_evaluation_autograd(diff_method):
     batch_size = 4
 
     # the partial argument to construct a new circuit with
-    y = np.random.uniform(size=2)
+    y = pnp.random.uniform(size=2)
 
     # the batched argument to the new partial circuit
-    x = np.random.uniform(size=batch_size, requires_grad=True)
+    x = pnp.random.uniform(size=batch_size, requires_grad=True)
 
     batched_partial_circuit = qml.batch_partial(circuit, y=y)
 
     # we could also sum over the batch dimension and use the regular
     # gradient instead of the jacobian, but either works
-    grad = np.diagonal(qml.jacobian(batched_partial_circuit)(x))
+    grad = pnp.diagonal(qml.jacobian(batched_partial_circuit)(x))
 
     # check the results against individually executed circuits
     indiv_grad = []
     for x_indiv in x:
         indiv_grad.append(qml.grad(circuit, argnum=0)(x_indiv, y))
 
-    assert np.allclose(grad, indiv_grad)
+    assert pnp.allclose(grad, indiv_grad)
 
 
 @pytest.mark.jax
@@ -269,10 +269,10 @@ def test_partial_evaluation_jax(diff_method):
     batch_size = 4
 
     # the partial argument to construct a new circuit with
-    y = jnp.asarray(np.random.uniform(size=2))
+    y = jnp.asarray(pnp.random.uniform(size=2))
 
     # the batched argument to the new partial circuit
-    x = jnp.asarray(np.random.uniform(size=batch_size))
+    x = jnp.asarray(pnp.random.uniform(size=batch_size))
 
     batched_partial_circuit = qml.batch_partial(circuit, all_operations=True, y=y)
 
@@ -285,7 +285,7 @@ def test_partial_evaluation_jax(diff_method):
     for x_indiv in x:
         indiv_grad.append(jax.grad(circuit, argnums=0)(x_indiv, y))
 
-    assert np.allclose(grad, indiv_grad)
+    assert pnp.allclose(grad, indiv_grad)
 
 
 @pytest.mark.tf
@@ -307,10 +307,10 @@ def test_partial_evaluation_tf(diff_method):
     batch_size = 4
 
     # the partial argument to construct a new circuit with
-    y = tf.Variable(np.random.uniform(size=2), trainable=True)
+    y = tf.Variable(pnp.random.uniform(size=2), trainable=True)
 
     # the batched argument to the new partial circuit
-    x = tf.Variable(np.random.uniform(size=batch_size), trainable=True)
+    x = tf.Variable(pnp.random.uniform(size=batch_size), trainable=True)
 
     batched_partial_circuit = qml.batch_partial(circuit, y=y)
 
@@ -332,7 +332,7 @@ def test_partial_evaluation_tf(diff_method):
             out_indiv = circuit(x_indiv, y)
         indiv_grad.append(tape.gradient(out_indiv, x_indiv))
 
-    assert np.allclose(grad, indiv_grad)
+    assert pnp.allclose(grad, indiv_grad)
 
 
 @pytest.mark.torch
@@ -355,10 +355,10 @@ def test_partial_evaluation_torch(diff_method):
     batch_size = 4
 
     # the partial argument to construct a new circuit with
-    y = torch.tensor(np.random.uniform(size=2), requires_grad=True)
+    y = torch.tensor(pnp.random.uniform(size=2), requires_grad=True)
 
     # the batched argument to the new partial circuit
-    x = torch.tensor(np.random.uniform(size=batch_size), requires_grad=True)
+    x = torch.tensor(pnp.random.uniform(size=batch_size), requires_grad=True)
 
     batched_partial_circuit = qml.batch_partial(circuit, y=y)
 
@@ -378,7 +378,7 @@ def test_partial_evaluation_torch(diff_method):
 
         indiv_grad.append(x_indiv.grad)
 
-    assert np.allclose(grad, indiv_grad)
+    assert pnp.allclose(grad, indiv_grad)
 
 
 def test_lambda_evaluation():
@@ -395,16 +395,16 @@ def test_lambda_evaluation():
     batch_size = 4
 
     # the first partial argument
-    x = np.random.uniform(size=())
+    x = pnp.random.uniform(size=())
 
     # the base value of the second partial argument
-    y = np.random.uniform(size=2)
+    y = pnp.random.uniform(size=2)
 
     # the second partial argument as a function of the inputs
-    fn = lambda y0: y + y0 * np.ones(2)
+    fn = lambda y0: y + y0 * pnp.ones(2)
 
     # values for the second argument
-    y0 = np.random.uniform(size=batch_size)
+    y0 = pnp.random.uniform(size=batch_size)
 
     batched_partial_circuit = qml.batch_partial(circuit, x=x, preprocess={"y": fn})
     res = batched_partial_circuit(y0)
@@ -412,9 +412,9 @@ def test_lambda_evaluation():
     # check the results against individually executed circuits
     indiv_res = []
     for y0_indiv in y0:
-        indiv_res.append(circuit(x, y + y0_indiv * np.ones(2)))
+        indiv_res.append(circuit(x, y + y0_indiv * pnp.ones(2)))
 
-    assert np.allclose(res, indiv_res)
+    assert pnp.allclose(res, indiv_res)
 
 
 @pytest.mark.autograd
@@ -434,16 +434,16 @@ def test_lambda_evaluation_autograd(diff_method):
     batch_size = 4
 
     # the first partial argument
-    x = np.random.uniform(size=())
+    x = pnp.random.uniform(size=())
 
     # the base value of the second partial argument
-    y = np.random.uniform(size=2)
+    y = pnp.random.uniform(size=2)
 
     # the second partial argument as a function of the inputs
-    fn = lambda y0: y + y0 * np.ones(2)
+    fn = lambda y0: y + y0 * pnp.ones(2)
 
     # values for the second argument
-    y0 = np.random.uniform(size=batch_size, requires_grad=True)
+    y0 = pnp.random.uniform(size=batch_size, requires_grad=True)
 
     batched_partial_circuit = qml.batch_partial(circuit, x=x, preprocess={"y": fn})
 
@@ -454,11 +454,11 @@ def test_lambda_evaluation_autograd(diff_method):
     # check the results against individually executed circuits
     indiv_grad = []
     for y0_indiv in y0:
-        grad_wrt_second_arg = qml.grad(circuit, argnum=1)(x, y + y0_indiv * np.ones(2))
+        grad_wrt_second_arg = qml.grad(circuit, argnum=1)(x, y + y0_indiv * pnp.ones(2))
         grad_wrt_y0 = qml.math.sum(grad_wrt_second_arg)
         indiv_grad.append(grad_wrt_y0)
 
-    assert np.allclose(grad, indiv_grad)
+    assert pnp.allclose(grad, indiv_grad)
 
 
 @pytest.mark.jax
@@ -481,16 +481,16 @@ def test_lambda_evaluation_jax(diff_method):
     batch_size = 4
 
     # the first partial argument
-    x = jnp.asarray(np.random.uniform(size=()))
+    x = jnp.asarray(pnp.random.uniform(size=()))
 
     # the base value of the second partial argument
-    y = jnp.asarray(np.random.uniform(size=2))
+    y = jnp.asarray(pnp.random.uniform(size=2))
 
     # the second partial argument as a function of the inputs
     fn = lambda y0: y + y0 * jnp.ones(2)
 
     # values for the second argument
-    y0 = jnp.asarray(np.random.uniform(size=batch_size))
+    y0 = jnp.asarray(pnp.random.uniform(size=batch_size))
 
     batched_partial_circuit = qml.batch_partial(
         circuit, all_operations=True, x=x, preprocess={"y": fn}
@@ -503,11 +503,11 @@ def test_lambda_evaluation_jax(diff_method):
     # check the results against individually executed circuits
     indiv_grad = []
     for y0_indiv in y0:
-        grad_wrt_second_arg = jax.grad(circuit, argnums=1)(x, y + y0_indiv * np.ones(2))
+        grad_wrt_second_arg = jax.grad(circuit, argnums=1)(x, y + y0_indiv * pnp.ones(2))
         grad_wrt_y0 = jnp.sum(grad_wrt_second_arg)
         indiv_grad.append(grad_wrt_y0)
 
-    assert np.allclose(grad, indiv_grad)
+    assert pnp.allclose(grad, indiv_grad)
 
 
 @pytest.mark.tf
@@ -529,16 +529,16 @@ def test_lambda_evaluation_tf(diff_method):
     batch_size = 4
 
     # the first partial argument
-    x = tf.Variable(np.random.uniform(size=()))
+    x = tf.Variable(pnp.random.uniform(size=()))
 
     # the base value of the second partial argument
-    y = tf.Variable(np.random.uniform(size=2))
+    y = tf.Variable(pnp.random.uniform(size=2))
 
     # the second partial argument as a function of the inputs
     fn = lambda y0: y + y0 * tf.ones(2, dtype=tf.float64)
 
     # values for the second argument
-    y0 = tf.Variable(np.random.uniform(size=batch_size), trainable=True)
+    y0 = tf.Variable(pnp.random.uniform(size=batch_size), trainable=True)
 
     batched_partial_circuit = qml.batch_partial(circuit, x=x, preprocess={"y": fn})
 
@@ -561,7 +561,7 @@ def test_lambda_evaluation_tf(diff_method):
 
         indiv_grad.append(tape.gradient(out_indiv, y0_indiv))
 
-    assert np.allclose(grad, indiv_grad)
+    assert pnp.allclose(grad, indiv_grad)
 
 
 @pytest.mark.torch
@@ -584,16 +584,16 @@ def test_lambda_evaluation_torch(diff_method):
     batch_size = 4
 
     # the first partial argument
-    x = torch.tensor(np.random.uniform(size=()), requires_grad=True)
+    x = torch.tensor(pnp.random.uniform(size=()), requires_grad=True)
 
     # the base value of the second partial argument
-    y = torch.tensor(np.random.uniform(size=2), requires_grad=True)
+    y = torch.tensor(pnp.random.uniform(size=2), requires_grad=True)
 
     # the second partial argument as a function of the inputs
     fn = lambda y0: y + y0 * torch.ones(2)
 
     # values for the second argument
-    y0 = torch.tensor(np.random.uniform(size=batch_size), requires_grad=True)
+    y0 = torch.tensor(pnp.random.uniform(size=batch_size), requires_grad=True)
 
     batched_partial_circuit = qml.batch_partial(circuit, x=x, preprocess={"y": fn})
 
@@ -613,7 +613,7 @@ def test_lambda_evaluation_torch(diff_method):
 
         indiv_grad.append(y0_indiv.grad)
 
-    assert np.allclose(grad, indiv_grad)
+    assert pnp.allclose(grad, indiv_grad)
 
 
 def test_full_evaluation_error():
@@ -629,8 +629,8 @@ def test_full_evaluation_error():
         return qml.expval(qml.PauliZ(wires=0) @ qml.PauliZ(wires=1))
 
     # the partial arguments
-    x = np.random.uniform(size=())
-    y = np.random.uniform(size=2)
+    x = pnp.random.uniform(size=())
+    y = pnp.random.uniform(size=2)
 
     with pytest.raises(
         ValueError, match="Partial evaluation must leave at least one unevaluated parameter"
@@ -651,8 +651,8 @@ def test_incomplete_evaluation_error():
         return qml.expval(qml.PauliZ(wires=0) @ qml.PauliZ(wires=1))
 
     # the second partial argument as a function of the inputs
-    y = np.random.uniform(size=2)
-    fn = lambda y0: y + y0 * np.ones(2)
+    y = pnp.random.uniform(size=2)
+    fn = lambda y0: y + y0 * pnp.ones(2)
 
     with pytest.raises(
         ValueError, match="Callable argument requires all other arguments to QNode be provided"
@@ -675,11 +675,11 @@ def test_kwargs_callable_error():
     batch_size = 4
 
     # the partial arguments
-    x = np.random.uniform(size=())
+    x = pnp.random.uniform(size=())
 
-    y = np.random.uniform(size=2)
-    fn = lambda y0: y + y0 * np.ones(2)
-    y0 = np.random.uniform(size=batch_size)
+    y = pnp.random.uniform(size=2)
+    fn = lambda y0: y + y0 * pnp.ones(2)
+    y0 = pnp.random.uniform(size=batch_size)
 
     batched_partial_circuit = qml.batch_partial(circuit, x=x, preprocess={"y": fn})
 
@@ -709,10 +709,10 @@ def test_no_batchdim_error():
         return qml.expval(qml.PauliZ(wires=0) @ qml.PauliZ(wires=1))
 
     # the second partial argument
-    y = np.random.uniform(size=2)
+    y = pnp.random.uniform(size=2)
 
     # the incorrectly batched argument to the new partial circuit
-    x = np.random.uniform(size=())
+    x = pnp.random.uniform(size=())
 
     batched_partial_circuit = qml.batch_partial(circuit, y=y)
 
@@ -746,11 +746,11 @@ def test_different_batchdim_error():
     batch_size1, batch_size2 = 5, 4
 
     # the second partial argument
-    y = np.random.uniform(size=2)
+    y = pnp.random.uniform(size=2)
 
     # the batched arguments to the new partial circuit
-    x = np.random.uniform(size=batch_size1)
-    z = np.random.uniform(size=batch_size2)
+    x = pnp.random.uniform(size=batch_size1)
+    z = pnp.random.uniform(size=batch_size2)
 
     batched_partial_circuit = qml.batch_partial(circuit, y=y)
 

--- a/tests/transforms/test_commutation_dag.py
+++ b/tests/transforms/test_commutation_dag.py
@@ -19,7 +19,7 @@ from collections import OrderedDict
 import pytest
 
 import pennylane as qml
-import pennylane.numpy as np
+import pennylane.numpy as pnp
 from pennylane.wires import Wires
 
 
@@ -247,7 +247,7 @@ class TestCommutationDAG:
             qml.RY(-y, wires=1)
             return qml.expval(qml.PauliZ(0))
 
-        x = np.array([np.pi / 4, np.pi / 3, np.pi / 2], requires_grad=False)
+        x = pnp.array([pnp.pi / 4, pnp.pi / 3, pnp.pi / 2], requires_grad=False)
 
         get_dag = qml.transforms.commutation_dag(circuit)
         dag = get_dag(x[0], x[1], x[2])
@@ -306,7 +306,7 @@ class TestCommutationDAG:
             qml.RY(-y, wires=1)
             return qml.expval(qml.PauliZ(0))
 
-        x = tf.Variable([np.pi / 4, np.pi / 3, np.pi / 2], dtype=tf.float64)
+        x = tf.Variable([pnp.pi / 4, pnp.pi / 3, pnp.pi / 2], dtype=tf.float64)
 
         get_dag = qml.transforms.commutation_dag(circuit)
         dag = get_dag(x[0], x[1], x[2])
@@ -365,7 +365,7 @@ class TestCommutationDAG:
             qml.RY(-y, wires=1)
             return qml.expval(qml.PauliZ(0))
 
-        x = torch.tensor([np.pi / 4, np.pi / 3, np.pi / 2], requires_grad=False)
+        x = torch.tensor([pnp.pi / 4, pnp.pi / 3, pnp.pi / 2], requires_grad=False)
 
         get_dag = qml.transforms.commutation_dag(circuit)
         dag = get_dag(x[0], x[1], x[2])
@@ -425,7 +425,7 @@ class TestCommutationDAG:
             qml.RY(-y, wires=1)
             return qml.expval(qml.PauliZ(0))
 
-        x = jnp.array([np.pi / 4, np.pi / 3, np.pi / 2], dtype=jnp.float64)
+        x = jnp.array([pnp.pi / 4, pnp.pi / 3, pnp.pi / 2], dtype=jnp.float64)
         get_dag = qml.transforms.commutation_dag(circuit)
         dag = get_dag(x[0], x[1], x[2])
 

--- a/tests/transforms/test_compile.py
+++ b/tests/transforms/test_compile.py
@@ -21,7 +21,7 @@ import pytest
 from test_optimization.utils import compare_operation_lists
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane.transforms import unitary_to_rot
 from pennylane.transforms.compile import compile
 from pennylane.transforms.optimization import (
@@ -147,7 +147,7 @@ class TestCompileIntegration:
 
         original_result = qnode(0.3, 0.4, 0.5)
         transformed_result = transformed_qnode(0.3, 0.4, 0.5)
-        assert np.allclose(original_result, transformed_result)
+        assert pnp.allclose(original_result, transformed_result)
 
         names_expected = [op.name for op in qnode.qtape.operations]
         wires_expected = [op.wires for op in qnode.qtape.operations]
@@ -168,7 +168,7 @@ class TestCompileIntegration:
 
         original_result = qnode(0.3, 0.4, 0.5)
         transformed_result = transformed_qnode(0.3, 0.4, 0.5)
-        assert np.allclose(original_result, transformed_result)
+        assert pnp.allclose(original_result, transformed_result)
 
         names_expected = ["Hadamard", "CNOT", "RX", "CY", "PauliY"]
         wires_expected = [
@@ -197,7 +197,7 @@ class TestCompileIntegration:
         qfun_res = transformed_qnode(0.1, 0.2, 0.3)
         qnode_res = transformed_qnode_direct(0.1, 0.2, 0.3)
 
-        assert np.allclose(qfun_res, qnode_res)
+        assert pnp.allclose(qfun_res, qnode_res)
 
     def test_compile_default_pipeline_removes_barrier(self):
         """Test that the default pipeline removes Barriers."""
@@ -226,7 +226,7 @@ class TestCompileIntegration:
 
         original_result = qnode(0.3, 0.4, 0.5)
         transformed_result = transformed_qnode(0.3, 0.4, 0.5)
-        assert np.allclose(original_result, transformed_result)
+        assert pnp.allclose(original_result, transformed_result)
 
         names_expected = ["Hadamard", "CNOT", "RX", "PauliY", "CY"]
         wires_expected = [
@@ -276,7 +276,7 @@ class TestCompileIntegration:
 
         original_result = qnode(0.3, 0.4, 0.5)
         transformed_result = transformed_qnode(0.3, 0.4, 0.5)
-        assert np.allclose(original_result, transformed_result)
+        assert pnp.allclose(original_result, transformed_result)
 
         names_expected = ["Hadamard", "CNOT", "RX", "PauliY", "CY"]
         wires_expected = [
@@ -307,7 +307,7 @@ class TestCompileIntegration:
 
         original_result = qnode(0.3, 0.4, 0.5)
         transformed_result = transformed_qnode(0.3, 0.4, 0.5)
-        assert np.allclose(original_result, transformed_result)
+        assert pnp.allclose(original_result, transformed_result)
 
         names_expected = [
             "RZ",
@@ -366,12 +366,12 @@ class TestCompileIntegration:
         transformed_qfunc = compile(qfunc, pipeline=pipeline)
         transformed_qnode = qml.QNode(transformed_qfunc, dev)
 
-        x = np.array([0.1, 0.2, 0.3])
-        params = np.ones((2, 3))
+        x = pnp.array([0.1, 0.2, 0.3])
+        params = pnp.ones((2, 3))
 
         original_result = qnode(x, params)
         transformed_result = transformed_qnode(x, params)
-        assert np.allclose(original_result, transformed_result)
+        assert pnp.allclose(original_result, transformed_result)
 
         names_expected = ["RX", "CNOT"] * 12
         wires_expected = [
@@ -427,8 +427,8 @@ class TestCompileInterfaces:
         original_qnode = qml.QNode(qfunc_emb, dev_3wires, diff_method=diff_method)
         transformed_qnode = qml.QNode(transformed_qfunc_emb, dev_3wires, diff_method=diff_method)
 
-        x = np.array([0.1, 0.2, 0.3], requires_grad=False)
-        params = np.ones((2, 3))
+        x = pnp.array([0.1, 0.2, 0.3], requires_grad=False)
+        params = pnp.ones((2, 3))
 
         # Check that the numerical output is the same
         assert qml.math.allclose(original_qnode(x, params), transformed_qnode(x, params))

--- a/tests/transforms/test_defer_measurements.py
+++ b/tests/transforms/test_defer_measurements.py
@@ -23,7 +23,7 @@ from functools import partial
 import pytest
 
 import pennylane as qml
-import pennylane.numpy as np
+import pennylane.numpy as pnp
 from pennylane.devices import DefaultQubit
 from pennylane.measurements import MeasurementValue, MidMeasureMP
 from pennylane.ops import Controlled
@@ -135,14 +135,14 @@ def test_postselect_mode(postselect_mode, mocker):
         _ = qml.measure(0, postselect=postselect_value)
         return qml.sample(wires=[0])
 
-    res = f(np.pi / 4)
+    res = f(pnp.pi / 4)
     spy.assert_called_once()
 
     if postselect_mode == "hw-like":
         assert len(res) < shots
     else:
         assert len(res) == shots
-    assert np.allclose(res, postselect_value)
+    assert pnp.allclose(res, postselect_value)
 
 
 @pytest.mark.parametrize(
@@ -269,7 +269,7 @@ class TestQNode:
         spy = mocker.spy(qml.defer_measurements, "_transform")
 
         # Outputs should match
-        assert np.isclose(qnode1(np.pi / 4), qnode2(np.pi / 4))
+        assert pnp.isclose(qnode1(pnp.pi / 4), qnode2(pnp.pi / 4))
         assert spy.call_count == 2  # once per device preprocessing
 
         deferred_tapes, _ = qml.defer_measurements(qnode1.qtape)
@@ -297,7 +297,7 @@ class TestQNode:
             qml.cond(m1, qml.RY)(-theta, 2)
             return qml.expval(qml.PauliZ(2))
 
-        res1 = qnode1(np.pi / 4, 3 * np.pi / 4)
+        res1 = qnode1(pnp.pi / 4, 3 * pnp.pi / 4)
 
         @qml.defer_measurements
         @qml.qnode(dev)
@@ -310,7 +310,7 @@ class TestQNode:
             qml.cond(m1, qml.RY)(-theta, 2)
             return qml.expval(qml.PauliZ(2))
 
-        res2 = qnode2(np.pi / 4, 3 * np.pi / 4)
+        res2 = qnode2(pnp.pi / 4, 3 * pnp.pi / 4)
 
         assert spy.call_count == 4
 
@@ -319,7 +319,7 @@ class TestQNode:
         assert len(deferred_tape1.wires) == 4
         assert len(deferred_tape1.operations) == 6
 
-        assert np.allclose(res1, res2)
+        assert pnp.allclose(res1, res2)
 
         deferred_tapes2, _ = qml.defer_measurements(qnode2.qtape)
         deferred_tape2 = deferred_tapes2[0]
@@ -328,7 +328,7 @@ class TestQNode:
 
     @pytest.mark.parametrize("reduce_postselected", [None, True, False])
     @pytest.mark.parametrize("shots", [None, 1000])
-    @pytest.mark.parametrize("phi", np.linspace(np.pi / 2, 7 * np.pi / 2, 6))
+    @pytest.mark.parametrize("phi", pnp.linspace(pnp.pi / 2, 7 * pnp.pi / 2, 6))
     def test_single_postselection_qnode(self, phi, shots, reduce_postselected):
         """Test that a qnode with a single mid-circuit measurements with postselection
         is transformed correctly by defer_measurements"""
@@ -352,7 +352,7 @@ class TestQNode:
             # Probability of measuring |1> on wire 1 should be 1
             return qml.probs(wires=1)
 
-        assert np.allclose(circ1(phi, shots=shots), [0, 1])
+        assert pnp.allclose(circ1(phi, shots=shots), [0, 1])
 
         expected_circuit = [
             qml.RX(phi, 0),
@@ -367,7 +367,7 @@ class TestQNode:
 
     @pytest.mark.parametrize("reduce_postselected", [None, True, False])
     @pytest.mark.parametrize("shots", [None, 1000])
-    @pytest.mark.parametrize("phi", np.linspace(np.pi / 2, 7 * np.pi / 2, 6))
+    @pytest.mark.parametrize("phi", pnp.linspace(pnp.pi / 2, 7 * pnp.pi / 2, 6))
     def test_some_postselection_qnode(
         self, phi, shots, reduce_postselected, tol, tol_stochastic, seed
     ):
@@ -396,8 +396,8 @@ class TestQNode:
             return qml.probs(wires=1)
 
         atol = tol if shots is None else tol_stochastic
-        expected_out = [np.cos(phi / 2) ** 2, np.sin(phi / 2) ** 2]
-        assert np.allclose(circ1(phi, shots=shots), expected_out, atol=atol, rtol=0)
+        expected_out = [pnp.cos(phi / 2) ** 2, pnp.sin(phi / 2) ** 2]
+        assert pnp.allclose(circ1(phi, shots=shots), expected_out, atol=atol, rtol=0)
 
         expected_circuit = [
             qml.RX(phi, 0),
@@ -413,8 +413,8 @@ class TestQNode:
 
     @pytest.mark.parametrize("reduce_postselected", [None, True, False])
     @pytest.mark.parametrize("shots", [None, 1000])
-    @pytest.mark.parametrize("phi", np.linspace(np.pi / 4, 4 * np.pi, 4))
-    @pytest.mark.parametrize("theta", np.linspace(np.pi / 3, 3 * np.pi, 4))
+    @pytest.mark.parametrize("phi", pnp.linspace(pnp.pi / 4, 4 * pnp.pi, 4))
+    @pytest.mark.parametrize("theta", pnp.linspace(pnp.pi / 3, 3 * pnp.pi, 4))
     def test_all_postselection_qnode(
         self, phi, theta, shots, reduce_postselected, tol, tol_stochastic
     ):
@@ -459,7 +459,7 @@ class TestQNode:
             return qml.probs(wires=[0, 1, 2])
 
         atol = tol if shots is None else tol_stochastic
-        assert np.allclose(circ1(phi, theta, shots=shots), circ2(), atol=atol, rtol=0)
+        assert pnp.allclose(circ1(phi, theta, shots=shots), circ2(), atol=atol, rtol=0)
 
         expected_first_cond_block = (
             [qml.RY(theta, wires=[2])]
@@ -513,7 +513,7 @@ class TestQNode:
             return qml.probs(wires=[0])
 
         param = 1.5
-        assert np.allclose(circ1(param, shots=shots), circ2(param, shots=shots))
+        assert pnp.allclose(circ1(param, shots=shots), circ2(param, shots=shots))
 
     @pytest.mark.parametrize("shots", [None, 2000, [2000, 2000]])
     def test_measured_value_wires_mapped(self, shots, tol, tol_stochastic):
@@ -538,7 +538,7 @@ class TestQNode:
 
         param = 1.5
         atol = tol if shots is None else tol_stochastic
-        assert np.allclose(circ1(param, shots=shots), circ2(param, shots=shots), atol=atol, rtol=0)
+        assert pnp.allclose(circ1(param, shots=shots), circ2(param, shots=shots), atol=atol, rtol=0)
 
         expected_ops = [qml.RX(param, 0), qml.CNOT([0, 1]), qml.PauliX(0)]
         assert circ1.qtape.operations == expected_ops
@@ -576,10 +576,10 @@ class TestQNode:
         if isinstance(shots, list):
             for out1, out2 in zip(circ1(*params, shots=shots), circ2(*params, shots=shots)):
                 for o1, o2 in zip(out1, out2):
-                    assert np.allclose(o1, o2)
+                    assert pnp.allclose(o1, o2)
         else:
             assert all(
-                np.allclose(out1, out2)
+                pnp.allclose(out1, out2)
                 for out1, out2 in zip(circ1(*params, shots=shots), circ2(*params, shots=shots))
             )
 
@@ -772,7 +772,7 @@ class TestConditionalOperations:
         assert isinstance(ctrl_op, Controlled)
         qml.assert_equal(ctrl_op.base, qml.RY(first_par, 1))
 
-    @pytest.mark.parametrize("rads", np.linspace(0.0, np.pi, 3))
+    @pytest.mark.parametrize("rads", pnp.linspace(0.0, pnp.pi, 3))
     def test_quantum_teleportation(self, rads):
         """Test quantum teleportation."""
 
@@ -859,7 +859,7 @@ class TestConditionalOperations:
         # Check the measurement
         qml.assert_equal(tape.measurements[0], terminal_measurement)
 
-    @pytest.mark.parametrize("r", np.linspace(0.1, 2 * np.pi - 0.1, 4))
+    @pytest.mark.parametrize("r", pnp.linspace(0.1, 2 * pnp.pi - 0.1, 4))
     @pytest.mark.parametrize(
         "device",
         [
@@ -893,14 +893,14 @@ class TestConditionalOperations:
         normal_probs = normal_circuit(r)
         cond_probs = quantum_control_circuit(r)
 
-        assert np.allclose(normal_probs, cond_probs)
+        assert pnp.allclose(normal_probs, cond_probs)
 
     def test_hermitian_queued(self):
         """Test that the defer_measurements transform works with
         qml.Hermitian."""
         rads = 0.3
 
-        mat = np.eye(8)
+        mat = pnp.eye(8)
         measurement = qml.expval(qml.Hermitian(mat, wires=[3, 1, 2]))
 
         with qml.queuing.AnnotatedQueue() as q:
@@ -999,7 +999,7 @@ class TestConditionalOperations:
         normal_probs = normal_circuit(r)
         cond_probs = quantum_control_circuit(r)
 
-        assert np.allclose(normal_probs, cond_probs)
+        assert pnp.allclose(normal_probs, cond_probs)
 
     @pytest.mark.parametrize(
         "device",
@@ -1038,7 +1038,7 @@ class TestConditionalOperations:
         exp = normal_circuit(r)
         cond_probs = quantum_control_circuit(r)
 
-        assert np.allclose(exp, cond_probs)
+        assert pnp.allclose(exp, cond_probs)
 
     def test_keyword_syntax(self):
         """Test that passing an argument to the conditioned operation using the
@@ -1061,9 +1061,9 @@ class TestConditionalOperations:
             qml.cond(m_0, op)(phi=par, wires=1)
             return qml.expval(qml.PauliZ(1))
 
-        par = np.array(0.3)
+        par = pnp.array(0.3)
 
-        assert np.allclose(qnode1(par), qnode2(par))
+        assert pnp.allclose(qnode1(par), qnode2(par))
 
     @pytest.mark.parametrize("control_val, expected", [(0, -1), (1, 1)])
     def test_condition_using_measurement_outcome(self, control_val, expected):
@@ -1117,7 +1117,7 @@ class TestConditionalOperations:
         exp = normal_circuit(r)
         cond_probs = quantum_control_circuit(r)
 
-        assert np.allclose(exp, cond_probs)
+        assert pnp.allclose(exp, cond_probs)
 
     @pytest.mark.parametrize(
         "device",
@@ -1160,7 +1160,7 @@ class TestConditionalOperations:
             qml.cond(m_0, f, g)(y)
             return qml.probs(wires=[0])
 
-        assert np.allclose(normal_circuit(x, y), cond_qnode(x, y))
+        assert pnp.allclose(normal_circuit(x, y), cond_qnode(x, y))
 
     def test_cond_on_measured_wire(self):
         """Test that applying a conditional operation on the same wire
@@ -1178,14 +1178,14 @@ class TestConditionalOperations:
         # Above circuit will cause wire 0 to go back to the |0> computational
         # basis state. We can inspect the reduced density matrix to confirm this
         # without inspecting the extra wires
-        expected_dmat = np.array([[1, 0], [0, 0]])
-        assert np.allclose(qnode(), expected_dmat)
+        expected_dmat = pnp.array([[1, 0], [0, 0]])
+        assert pnp.allclose(qnode(), expected_dmat)
 
 
 class TestExpressionConditionals:
     """Test Conditionals that rely on expressions of mid-circuit measurements."""
 
-    @pytest.mark.parametrize("r", np.linspace(0.1, 2 * np.pi - 0.1, 4))
+    @pytest.mark.parametrize("r", pnp.linspace(0.1, 2 * pnp.pi - 0.1, 4))
     @pytest.mark.parametrize("op", [qml.RX, qml.RY, qml.RZ])
     def test_conditional_rotations(self, r, op):
         """Test that the quantum conditional operations match the output of
@@ -1212,9 +1212,9 @@ class TestExpressionConditionals:
         normal_probs = normal_circuit(r)
         cond_probs = quantum_control_circuit(r)
 
-        assert np.allclose(normal_probs, cond_probs)
+        assert pnp.allclose(normal_probs, cond_probs)
 
-    @pytest.mark.parametrize("r", np.linspace(0.1, 2 * np.pi - 0.1, 4))
+    @pytest.mark.parametrize("r", pnp.linspace(0.1, 2 * pnp.pi - 0.1, 4))
     def test_triple_measurement_condition_expression(self, r):
         """Test that combining the results of three mid-circuit measurements works as expected."""
         dev = qml.device("default.qubit", wires=7)
@@ -1253,7 +1253,7 @@ class TestExpressionConditionals:
         normal_probs = normal_circuit(r)
         cond_probs = quantum_control_circuit(r)
 
-        assert np.allclose(normal_probs, cond_probs)
+        assert pnp.allclose(normal_probs, cond_probs)
 
     def test_multiple_conditions(self):
         """Test that when multiple "branches" of the mid-circuit measurements all satisfy the criteria then
@@ -1298,7 +1298,7 @@ class TestExpressionConditionals:
         normal_probs = normal_circuit(1.0)
         cond_probs = quantum_control_circuit(1.0)
 
-        assert np.allclose(normal_probs, cond_probs)
+        assert pnp.allclose(normal_probs, cond_probs)
 
     def test_composed_conditions(self):
         """Test that a complex nested expression gets resolved correctly to the corresponding correct control gates."""
@@ -1343,7 +1343,7 @@ class TestExpressionConditionals:
         normal_probs = normal_circuit(1.0)
         cond_probs = quantum_control_circuit(1.0)
 
-        assert np.allclose(normal_probs, cond_probs)
+        assert pnp.allclose(normal_probs, cond_probs)
 
 
 class TestTemplates:
@@ -1374,7 +1374,7 @@ class TestTemplates:
         res1 = qnode1()
         res2 = qnode2()
 
-        assert np.allclose(res1, res2)
+        assert pnp.allclose(res1, res2)
 
         assert len(qnode2.qtape.operations) == len(qnode1.qtape.operations)
         assert len(qnode1.qtape.measurements) == len(qnode2.qtape.measurements)
@@ -1382,7 +1382,7 @@ class TestTemplates:
         # Check the operations
         for op1, op2 in zip(qnode1.qtape.operations, qnode2.qtape.operations):
             assert isinstance(op1, type(op2))
-            assert np.allclose(op1.data, op2.data)
+            assert pnp.allclose(op1.data, op2.data)
 
         # Check the measurements
         for op1, op2 in zip(qnode1.qtape.measurements, qnode2.qtape.measurements):
@@ -1410,9 +1410,9 @@ class TestTemplates:
             return qml.expval(qml.PauliZ(1) @ qml.PauliZ(2))
 
         shape = template.shape(n_layers=2, n_wires=num_wires)
-        weights = np.random.random(size=shape)
+        weights = pnp.random.random(size=shape)
 
-        assert np.allclose(qnode1(weights), qnode2(weights))
+        assert pnp.allclose(qnode1(weights), qnode2(weights))
 
         assert len(qnode2.qtape.operations) == len(qnode1.qtape.operations)
         assert len(qnode1.qtape.measurements) == len(qnode2.qtape.measurements)
@@ -1420,7 +1420,7 @@ class TestTemplates:
         # Check the operations
         for op1, op2 in zip(qnode1.qtape.operations, qnode2.qtape.operations):
             assert isinstance(op1, type(op2))
-            assert np.allclose(op1.data, op2.data)
+            assert pnp.allclose(op1.data, op2.data)
 
         # Check the measurements
         for op1, op2 in zip(qnode1.qtape.measurements, qnode2.qtape.measurements):
@@ -1477,7 +1477,7 @@ class TestQubitReuseAndReset:
             qml.cond(m0, qml.RX)(x, 1)
             return qml.expval(qml.PauliZ(1))
 
-        assert np.allclose(qnode1(0.123), qnode2(0.123))
+        assert pnp.allclose(qnode1(0.123), qnode2(0.123))
 
         expected_circuit = [
             qml.Hadamard(0),
@@ -1497,14 +1497,14 @@ class TestQubitReuseAndReset:
         tape = qml.tape.QuantumScript(
             ops=[qml.Hadamard(0), MidMeasureMP(0)], measurements=[qml.density_matrix(wires=[0])]
         )
-        expected = np.eye(2) / 2
+        expected = pnp.eye(2) / 2
 
         tapes, _ = qml.defer_measurements(tape)
 
         dev = qml.device("default.qubit")
         res = qml.execute(tapes, dev)
 
-        assert np.allclose(res, expected)
+        assert pnp.allclose(res, expected)
 
         deferred_tape = tapes[0]
         assert deferred_tape.operations == [qml.Hadamard(0), qml.CNOT([0, 1])]
@@ -1519,14 +1519,14 @@ class TestQubitReuseAndReset:
         @qml.qnode(dev)
         def qnode(x):
             qml.Hadamard(0)
-            qml.PhaseShift(np.pi / 4, 0)
+            qml.PhaseShift(pnp.pi / 4, 0)
             m = qml.measure(0, reset=True)
             qml.cond(m, qml.RX)(x, 1)
             return qml.density_matrix(wires=[0])
 
         # Expected reduced density matrix on wire 0
-        expected_mat = np.array([[1, 0], [0, 0]])
-        assert np.allclose(qnode(0.123), expected_mat)
+        expected_mat = pnp.array([[1, 0], [0, 0]])
+        assert pnp.allclose(qnode(0.123), expected_mat)
 
     def test_multiple_measurements_mixed_reset(self, mocker):
         """Test that a QNode with multiple mid-circuit measurements with

--- a/tests/transforms/test_mitigate.py
+++ b/tests/transforms/test_mitigate.py
@@ -21,7 +21,7 @@ import pytest
 from packaging import version
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane.tape import QuantumScript
 from pennylane.transforms import (
     exponential_extrapolate,
@@ -57,7 +57,7 @@ def same_tape(tape1, tape2):
     assert all(o1.name == o2.name for o1, o2 in zip(tape1.operations, tape2.operations))
     assert all(o1.wires == o2.wires for o1, o2 in zip(tape1.operations, tape2.operations))
     assert all(
-        np.allclose(o1.parameters, o2.parameters)
+        pnp.allclose(o1.parameters, o2.parameters)
         for o1, o2 in zip(tape1.operations, tape2.operations)
     )
     assert len(tape1.measurements) == len(tape2.measurements)
@@ -109,7 +109,7 @@ class TestMitigateWithZNE:
 
         args = spy.call_args
         assert args[0][0] == scale_factors
-        assert np.allclose(args[0][1], random_results)
+        assert pnp.allclose(args[0][1], random_results)
 
         assert args[1] == extrapolate_kwargs
 
@@ -138,7 +138,7 @@ class TestMitigateWithZNE:
         n_layers = 2
 
         shapes = qml.SimplifiedTwoDesign.shape(n_layers, n_wires)
-        w1, w2 = [np.random.random(s) for s in shapes]
+        w1, w2 = [pnp.random.random(s) for s in shapes]
 
         @partial(
             qml.transforms.mitigate_with_zne,
@@ -172,7 +172,7 @@ class TestMitigateWithZNE:
         res_ideal = qml.math.stack(res_ideal)
 
         assert res_mitigated.shape == res_ideal.shape
-        assert not np.allclose(res_mitigated, res_ideal)
+        assert not pnp.allclose(res_mitigated, res_ideal)
 
     def test_reps_per_factor_not_1(self, mocker):
         """Tests if mitigation proceeds as expected when reps_per_factor is not 1 (default)"""
@@ -194,7 +194,7 @@ class TestMitigateWithZNE:
         args = spy_extrapolate.call_args
 
         assert args[0][0] == scale_factors
-        assert np.allclose(args[0][1], np.mean(np.reshape(random_results, (3, 2)), axis=1))
+        assert pnp.allclose(args[0][1], pnp.mean(pnp.reshape(random_results, (3, 2)), axis=1))
 
     def test_broadcasting(self, seed):
         """Tests that mitigate_with_zne supports batch arguments"""
@@ -214,7 +214,7 @@ class TestMitigateWithZNE:
         mitigated_qnode_expanded = qml.transforms.mitigate_with_zne(
             expanded_qnode, [1, 2, 3], fold_global, richardson_extrapolate
         )
-        rng = np.random.default_rng(seed=seed)
+        rng = pnp.random.default_rng(seed=seed)
         inputs = rng.uniform(0, 1, size=(batch_size, 2**2))
         result_orig = mitigated_qnode_orig(inputs)
         result_expanded = mitigated_qnode_expanded(inputs)
@@ -306,7 +306,7 @@ class TestMitiqIntegration:
         n_layers = 2
 
         shapes = qml.SimplifiedTwoDesign.shape(n_layers, n_wires)
-        w1, w2 = [np.random.random(s) for s in shapes]
+        w1, w2 = [pnp.random.random(s) for s in shapes]
 
         @partial(
             qml.transforms.mitigate_with_zne,
@@ -341,7 +341,7 @@ class TestMitiqIntegration:
         res_ideal = qml.math.stack(res_ideal)
 
         assert res_mitigated.shape == res_ideal.shape
-        assert not np.allclose(res_mitigated, res_ideal)
+        assert not pnp.allclose(res_mitigated, res_ideal)
 
     def test_single_return(self):
         """Tests if the expected shape is returned when mitigating a circuit with a single return"""
@@ -356,7 +356,7 @@ class TestMitiqIntegration:
         n_layers = 2
 
         shapes = qml.SimplifiedTwoDesign.shape(n_layers, n_wires)
-        w1, w2 = [np.random.random(s) for s in shapes]
+        w1, w2 = [pnp.random.random(s) for s in shapes]
 
         @partial(
             qml.transforms.mitigate_with_zne,
@@ -379,7 +379,7 @@ class TestMitiqIntegration:
         res_ideal = ideal_circuit(w1, w2)
 
         assert res_mitigated.shape == res_ideal.shape
-        assert not np.allclose(res_mitigated, res_ideal)
+        assert not pnp.allclose(res_mitigated, res_ideal)
 
     def test_with_reps_per_factor(self):
         """Tests if the expected shape is returned when mitigating a circuit with a reps_per_factor
@@ -396,7 +396,7 @@ class TestMitiqIntegration:
         n_layers = 2
 
         shapes = qml.SimplifiedTwoDesign.shape(n_layers, n_wires)
-        w1, w2 = [np.random.random(s) for s in shapes]
+        w1, w2 = [pnp.random.random(s) for s in shapes]
 
         @partial(
             qml.transforms.mitigate_with_zne,
@@ -420,7 +420,7 @@ class TestMitiqIntegration:
         res_ideal = ideal_circuit(w1, w2)
 
         assert res_mitigated.shape == res_ideal.shape
-        assert not np.allclose(res_mitigated, res_ideal)
+        assert not pnp.allclose(res_mitigated, res_ideal)
 
     def test_integration(self):
         """Test if the error of the mitigated result is less than the error of the unmitigated
@@ -436,7 +436,7 @@ class TestMitiqIntegration:
         n_layers = 2
 
         shapes = qml.SimplifiedTwoDesign.shape(n_layers, n_wires)
-        w1, w2 = [np.random.random(s) for s in shapes]
+        w1, w2 = [pnp.random.random(s) for s in shapes]
 
         def circuit(w1, w2):
             qml.SimplifiedTwoDesign(w1, w2, wires=range(2))
@@ -472,10 +472,10 @@ class TestMitiqIntegration:
         noisy_val = qml.math.stack(noisy_val)
         mitigated_val = qml.math.stack(mitigated_val)
 
-        mitigated_err = np.abs(exact_val - mitigated_val)
-        noisy_err = np.abs(exact_val - noisy_val)
+        mitigated_err = pnp.abs(exact_val - mitigated_val)
+        noisy_err = pnp.abs(exact_val - noisy_val)
 
-        assert np.allclose(exact_val, [1, 1])
+        assert pnp.allclose(exact_val, [1, 1])
         assert all(mitigated_err < noisy_err)
 
     @pytest.mark.xfail(
@@ -494,7 +494,7 @@ class TestMitiqIntegration:
         n_layers = 2
 
         shapes = qml.SimplifiedTwoDesign.shape(n_layers, n_wires)
-        w1, w2 = [np.random.random(s, requires_grad=True) for s in shapes]
+        w1, w2 = [pnp.random.random(s, requires_grad=True) for s in shapes]
 
         @partial(
             qml.transforms.mitigate_with_zne,
@@ -510,7 +510,7 @@ class TestMitiqIntegration:
 
         g = qml.grad(mitigated_circuit)(w1, w2)
         for g_ in g:
-            assert not np.allclose(g_, 0)
+            assert not pnp.allclose(g_, 0)
 
 
 # qnodes for the diffable ZNE error mitigation
@@ -532,11 +532,11 @@ noise_gate = qml.PhaseDamping
 # Load devices
 dev_noisy = qml.transforms.insert(dev_ideal, noise_gate, 0.05)
 
-out_ideal = np.sqrt(2) / 2 + np.sqrt(2)
-grad_ideal_0 = [-np.sqrt(2) / 2, -np.sqrt(2)]
+out_ideal = pnp.sqrt(2) / 2 + pnp.sqrt(2)
+grad_ideal_0 = [-pnp.sqrt(2) / 2, -pnp.sqrt(2)]
 
-out_ideal_multi = np.array([np.sqrt(2) / 2, np.sqrt(3) / 2])
-grad_ideal_0_multi = np.array([[-np.sqrt(2) / 2, 0], [0, -0.5]])
+out_ideal_multi = pnp.array([pnp.sqrt(2) / 2, pnp.sqrt(3) / 2])
+grad_ideal_0_multi = pnp.array([[-pnp.sqrt(2) / 2, 0], [0, -0.5]])
 
 
 class TestDifferentiableZNE:
@@ -552,7 +552,7 @@ class TestDifferentiableZNE:
         n_wires = 3
         template = qml.SimplifiedTwoDesign
         weights_shape = template.shape(n_layers, n_wires)
-        w1, w2 = [np.arange(np.prod(s)).reshape(s) for s in weights_shape]
+        w1, w2 = [pnp.arange(pnp.prod(s)).reshape(s) for s in weights_shape]
 
         dev = qml.device("default.qubit", wires=range(n_wires))
 
@@ -567,12 +567,12 @@ class TestDifferentiableZNE:
         res = [
             fold_global(circuit, scale_factor=scale_factor)(w1, w2) for scale_factor in range(1, 5)
         ]
-        assert np.allclose(res, 1)
+        assert pnp.allclose(res, 1)
 
     def test_polyfit(self):
         """Testing the custom diffable _polyfit function"""
         # pylint: disable=protected-access
-        x = np.linspace(1, 4, 4)
+        x = pnp.linspace(1, 4, 4)
         y = 3.0 * x**2 + 2.0 * x + 1.0
         coeffs = qml.transforms.mitigate._polyfit(x, y, 2)
         assert qml.math.allclose(qml.math.squeeze(coeffs), [3, 2, 1])
@@ -581,8 +581,8 @@ class TestDifferentiableZNE:
     def test_exponential_extrapolation_accuracy(self, exp_params):
         """Testing the exponential extrapolation works as expected for known exponential models."""
         A, B, asymptote = exp_params
-        x = np.linspace(1, 4, 4)
-        y = A * np.exp(B * x) + asymptote
+        x = pnp.linspace(1, 4, 4)
+        y = A * pnp.exp(B * x) + asymptote
         zne_val = qml.transforms.exponential_extrapolate(x, y, asymptote=asymptote)
         assert qml.math.allclose(zne_val, A + asymptote, atol=1e-3)
 
@@ -590,9 +590,9 @@ class TestDifferentiableZNE:
     def test_exponential_extrapolation_autograd(self):
         """Test exponential extrapolation works with expvals stored as a numpy array."""
         scale_factors = [1, 3, 5]
-        noise_scaled_expvals = np.array([0.9, 0.8, 0.7])
+        noise_scaled_expvals = pnp.array([0.9, 0.8, 0.7])
         zne_val = qml.transforms.exponential_extrapolate(scale_factors, noise_scaled_expvals)
-        assert isinstance(zne_val, np.ndarray)
+        assert isinstance(zne_val, pnp.ndarray)
         assert zne_val.ndim == 0
 
     @pytest.mark.tf
@@ -639,7 +639,7 @@ class TestDifferentiableZNE:
 
         mitigated_qnode = mitigate_with_zne(qnode_noisy, scale_factors, fold_global, extrapolate)
 
-        theta = np.array([np.pi / 4, np.pi / 4], requires_grad=True)
+        theta = pnp.array([pnp.pi / 4, pnp.pi / 4], requires_grad=True)
 
         res = mitigated_qnode(theta)
         assert qml.math.allclose(res, out_ideal, atol=1e-2)
@@ -665,7 +665,7 @@ class TestDifferentiableZNE:
         mitigated_qnode = mitigate_with_zne(qnode_noisy, scale_factors, fold_global, extrapolate)
 
         theta = jnp.array(
-            [np.pi / 4, np.pi / 4],
+            [pnp.pi / 4, pnp.pi / 4],
         )
 
         res = mitigated_qnode(theta)
@@ -694,7 +694,7 @@ class TestDifferentiableZNE:
         )
 
         theta = jnp.array(
-            [np.pi / 4, np.pi / 4],
+            [pnp.pi / 4, pnp.pi / 4],
         )
 
         res = mitigated_qnode(theta)
@@ -719,14 +719,14 @@ class TestDifferentiableZNE:
 
         mitigated_qnode = mitigate_with_zne(qnode_noisy, scale_factors, fold_global, extrapolate)
 
-        theta = torch.tensor([np.pi / 4, np.pi / 4], requires_grad=True)
+        theta = torch.tensor([pnp.pi / 4, pnp.pi / 4], requires_grad=True)
 
         res = mitigated_qnode(theta)
 
         assert qml.math.allclose(res, out_ideal, atol=1e-2)
         res.backward()
         grad = theta.grad
-        theta0 = torch.tensor([np.pi / 4, np.pi / 4], requires_grad=True)
+        theta0 = torch.tensor([pnp.pi / 4, pnp.pi / 4], requires_grad=True)
         res_ideal = qnode_ideal(theta0)
         res_ideal.backward()
         grad_ideal = theta0.grad
@@ -747,7 +747,7 @@ class TestDifferentiableZNE:
 
         mitigated_qnode = mitigate_with_zne(qnode_noisy, scale_factors, fold_global, extrapolate)
 
-        theta = tf.Variable([np.pi / 4, np.pi / 4])
+        theta = tf.Variable([pnp.pi / 4, pnp.pi / 4])
 
         with tf.GradientTape() as t:
             res = mitigated_qnode(theta)
@@ -774,7 +774,7 @@ class TestDifferentiableZNE:
 
         mitigated_qnode = mitigate_with_zne(qnode_noisy, scale_factors, fold_global, extrapolate)
 
-        theta = np.array([np.pi / 4, np.pi / 6], requires_grad=True)
+        theta = pnp.array([pnp.pi / 4, pnp.pi / 6], requires_grad=True)
 
         res = qml.math.stack(mitigated_qnode(theta))
         assert qml.math.allclose(res, out_ideal_multi, atol=1e-2)
@@ -801,7 +801,7 @@ class TestDifferentiableZNE:
         mitigated_qnode = mitigate_with_zne(qnode_noisy, scale_factors, fold_global, extrapolate)
 
         theta = jnp.array(
-            [np.pi / 4, np.pi / 6],
+            [pnp.pi / 4, pnp.pi / 6],
         )
 
         res = qml.math.stack(mitigated_qnode(theta))
@@ -831,7 +831,7 @@ class TestDifferentiableZNE:
         )
 
         theta = jnp.array(
-            [np.pi / 4, np.pi / 6],
+            [pnp.pi / 4, pnp.pi / 6],
         )
 
         res = qml.math.stack(mitigated_qnode(theta))
@@ -857,7 +857,7 @@ class TestDifferentiableZNE:
 
         mitigated_qnode = mitigate_with_zne(qnode_noisy, scale_factors, fold_global, extrapolate)
 
-        theta = torch.tensor([np.pi / 4, np.pi / 6], requires_grad=True)
+        theta = torch.tensor([pnp.pi / 4, pnp.pi / 6], requires_grad=True)
 
         res = qml.math.stack(mitigated_qnode(theta))
         assert qml.math.allclose(res, out_ideal_multi, atol=1e-2)
@@ -885,7 +885,7 @@ class TestDifferentiableZNE:
 
         mitigated_qnode = mitigate_with_zne(qnode_noisy, scale_factors, fold_global, extrapolate)
 
-        theta = tf.Variable([np.pi / 4, np.pi / 6])
+        theta = tf.Variable([pnp.pi / 4, pnp.pi / 6])
 
         with tf.GradientTape() as t:
             res = qml.math.stack(mitigated_qnode(theta))

--- a/tests/transforms/test_optimization/test_cancel_inverses.py
+++ b/tests/transforms/test_optimization/test_cancel_inverses.py
@@ -20,7 +20,7 @@ import pytest
 from utils import compare_operation_lists
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane.transforms.optimization import cancel_inverses
 from pennylane.wires import Wires
 
@@ -239,7 +239,7 @@ class TestCancelInversesInterfaces:
         original_qnode = qml.QNode(qfunc_all_ops, dev)
         transformed_qnode = qml.QNode(transformed_qfunc_all_ops, dev)
 
-        input = np.array([0.1, 0.2], requires_grad=True)
+        input = pnp.array([0.1, 0.2], requires_grad=True)
 
         # Check that the numerical output is the same
         assert qml.math.allclose(original_qnode(input), transformed_qnode(input))
@@ -419,7 +419,7 @@ class TestTransformDispatch:
         params = [0.1, 0.2]
         res = transformed_qnode(params)
         expected = qnode_circuit(params)
-        assert np.allclose(res, expected)
+        assert pnp.allclose(res, expected)
 
     @pytest.mark.jax
     def test_qnode_diff_jax(self):

--- a/tests/transforms/test_optimization/test_commute_controlled.py
+++ b/tests/transforms/test_optimization/test_commute_controlled.py
@@ -20,7 +20,7 @@ import pytest
 from utils import check_matrix_equivalence, compare_operation_lists
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane.transforms.optimization import commute_controlled
 from pennylane.wires import Wires
 
@@ -54,7 +54,7 @@ class TestCommuteControlled:
 
         def qfunc():
             qml.PauliX(wires=2)
-            qml.ControlledQubitUnitary(np.array([[0, 1], [1, 0]]), control_wires=0, wires=2)
+            qml.ControlledQubitUnitary(pnp.array([[0, 1], [1, 0]]), control_wires=0, wires=2)
             qml.PauliX(wires=2)
 
         transformed_qfunc = commute_controlled(qfunc, direction=direction)
@@ -352,7 +352,7 @@ class TestCommuteControlledInterfaces:
         original_qnode = qml.QNode(qfunc_all_ops, dev)
         transformed_qnode = qml.QNode(transformed_qfunc_all_ops, dev)
 
-        input = np.array([0.1, 0.2], requires_grad=True)
+        input = pnp.array([0.1, 0.2], requires_grad=True)
 
         # Check that the numerical output is the same
         assert qml.math.allclose(original_qnode(input), transformed_qnode(input))
@@ -542,4 +542,4 @@ class TestTransformDispatch:
         assert len(transformed_qnode.transform_program) == 1
         res = transformed_qnode()
         expected = qnode_circuit()
-        assert np.allclose(res, expected)
+        assert pnp.allclose(res, expected)

--- a/tests/transforms/test_optimization/test_merge_amplitude_embedding.py
+++ b/tests/transforms/test_optimization/test_merge_amplitude_embedding.py
@@ -19,7 +19,7 @@ import warnings
 import pytest
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane.transforms.optimization import merge_amplitude_embedding
 
 
@@ -50,7 +50,7 @@ class TestMergeAmplitudeEmbedding:
 
         # Check that the solution is as expected.
         dev = qml.device("default.qubit", wires=2)
-        assert np.allclose(qml.QNode(transformed_qfunc, dev)()[-1], 1)
+        assert pnp.allclose(qml.QNode(transformed_qfunc, dev)()[-1], 1)
 
     def test_multi_amplitude_embedding_qnode(self):
         """Test that the transformation is working correctly by joining two AmplitudeEmbedding."""
@@ -66,7 +66,7 @@ class TestMergeAmplitudeEmbedding:
             qml.Hadamard(wires=1)
             return qml.state()
 
-        assert qml.math.allclose(circuit(), np.array([1, -1, -1, 1]) / 2)
+        assert qml.math.allclose(circuit(), pnp.array([1, -1, -1, 1]) / 2)
 
     def test_repeated_qubit(self):
         """Check that AmplitudeEmbedding cannot be applied if the qubit has already been used."""
@@ -113,8 +113,8 @@ class TestMergeAmplitudeEmbedding:
         assert qnode.tape.batch_size == 2
 
         # |001> and |100>
-        expected = np.array([[0, 1, 0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 1, 0, 0, 0]])
-        assert np.allclose(res, expected)
+        expected = pnp.array([[0, 1, 0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 1, 0, 0, 0]])
+        assert pnp.allclose(res, expected)
 
 
 class TestMergeAmplitudeEmbeddingInterfaces:
@@ -133,7 +133,7 @@ class TestMergeAmplitudeEmbeddingInterfaces:
         optimized_qfunc = qml.transforms.merge_amplitude_embedding(qfunc)
         optimized_qnode = qml.QNode(optimized_qfunc, dev)
 
-        amplitude = np.array([0.0, 1.0], requires_grad=True)
+        amplitude = pnp.array([0.0, 1.0], requires_grad=True)
         # Check the state |11> is being generated.
         assert optimized_qnode(amplitude)[-1] == 1
 

--- a/tests/transforms/test_optimization/test_merge_rotations.py
+++ b/tests/transforms/test_optimization/test_merge_rotations.py
@@ -22,7 +22,7 @@ import pytest
 from utils import compare_operation_lists
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane.transforms.optimization import merge_rotations
 from pennylane.wires import Wires
 
@@ -61,7 +61,7 @@ class TestMergeRotations:
         # Check that all operations and parameter values are as expected
         for op_obtained, op_expected in zip(ops, expected_ops):
             assert op_obtained.name == op_expected.name
-            assert np.allclose(op_obtained.parameters, op_expected.parameters)
+            assert pnp.allclose(op_obtained.parameters, op_expected.parameters)
 
     @pytest.mark.parametrize(
         ("theta_1", "theta_2", "expected_ops"),
@@ -86,7 +86,7 @@ class TestMergeRotations:
 
         for op_obtained, op_expected in zip(ops, expected_ops):
             assert op_obtained.name == op_expected.name
-            assert np.allclose(op_obtained.parameters, op_expected.parameters)
+            assert pnp.allclose(op_obtained.parameters, op_expected.parameters)
 
     def test_two_qubits_rotation_merge_tolerance(self):
         """Test whether tolerance argument is respected for merging."""
@@ -133,7 +133,7 @@ class TestMergeRotations:
 
         for op_obtained, op_expected in zip(ops, expected_ops):
             assert op_obtained.name == op_expected.name
-            assert np.allclose(op_obtained.parameters, op_expected.parameters)
+            assert pnp.allclose(op_obtained.parameters, op_expected.parameters)
 
     @pytest.mark.parametrize(
         ("theta_11", "theta_12", "theta_21", "theta_22", "expected_ops"),
@@ -161,7 +161,7 @@ class TestMergeRotations:
 
         for op_obtained, op_expected in zip(ops, expected_ops):
             assert op_obtained.name == op_expected.name
-            assert np.allclose(op_obtained.parameters, op_expected.parameters)
+            assert pnp.allclose(op_obtained.parameters, op_expected.parameters)
 
     def test_two_qubits_merge_gate_subset(self):
         """Test that specifying a subset of operations to include merges correctly."""
@@ -250,7 +250,7 @@ class TestMergeRotations:
         # Check that all operations and parameter values are as expected
         for op_obtained, op_expected in zip(ops, expected_ops):
             assert op_obtained.name == op_expected.name
-            assert np.allclose(op_obtained.parameters, op_expected.parameters)
+            assert pnp.allclose(op_obtained.parameters, op_expected.parameters)
 
     def test_controlled_rotation_no_merge(self):
         """Test that adjacent controlled rotations on the same wires in different order don't merge."""
@@ -326,7 +326,7 @@ class TestMergeRotationsInterfaces:
         original_qnode = qml.QNode(qfunc_all_ops, dev)
         transformed_qnode = qml.QNode(transformed_qfunc_all_ops, dev)
 
-        input = np.array([0.1, 0.2, 0.3, 0.4], requires_grad=True)
+        input = pnp.array([0.1, 0.2, 0.3, 0.4], requires_grad=True)
 
         # Check that the numerical output is the same
         assert qml.math.allclose(original_qnode(input), transformed_qnode(input))
@@ -527,7 +527,7 @@ class TestTransformDispatch:
         assert len(transformed_qnode.transform_program) == 1
         res = transformed_qnode([0.1, 0.2, 0.3, 0.4])
         exp_res = qnode_circuit([0.1, 0.2, 0.3, 0.4])
-        assert np.allclose(res, exp_res)
+        assert pnp.allclose(res, exp_res)
 
 
 @pytest.mark.xfail

--- a/tests/transforms/test_optimization/test_optimization_utils.py
+++ b/tests/transforms/test_optimization/test_optimization_utils.py
@@ -21,7 +21,7 @@ from itertools import product
 import pytest
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane.transforms.optimization.optimization_utils import find_next_gate, fuse_rot_angles
 
 sample_op_list = [
@@ -70,9 +70,9 @@ class TestRotGateFusion:
         ([0.05, 0.2, 0.0], [0.0, -0.6, 0.12]),
         ([0.05, -1.34, 4.12], [0.0, 0.2, 0.12]),
         ([0.05, -1.34, 4.12], [0.3, 0.0, 0.12]),
-        ([np.pi, np.pi / 2, 0.0], [0.0, -np.pi / 2, 0.0]),
-        ([0.9, np.pi / 2, 0.0], [0.0, -np.pi / 2, 0.0]),
-        ([0.9, np.pi / 2, np.pi / 2], [-np.pi / 2, -np.pi / 2, 0.0]),
+        ([pnp.pi, pnp.pi / 2, 0.0], [0.0, -pnp.pi / 2, 0.0]),
+        ([0.9, pnp.pi / 2, 0.0], [0.0, -pnp.pi / 2, 0.0]),
+        ([0.9, pnp.pi / 2, pnp.pi / 2], [-pnp.pi / 2, -pnp.pi / 2, 0.0]),
     ]
 
     def run_interface_test(self, angles_1, angles_2):
@@ -115,8 +115,8 @@ class TestRotGateFusion:
         applying the Rots sequentially when the input angles are batched
         with mixed batching shapes."""
 
-        reshaped_angles_1 = np.reshape(angles_1, (-1, 3) if np.ndim(angles_1) > 1 else (3,))
-        reshaped_angles_2 = np.reshape(angles_2, (-1, 3) if np.ndim(angles_2) > 1 else (3,))
+        reshaped_angles_1 = pnp.reshape(angles_1, (-1, 3) if pnp.ndim(angles_1) > 1 else (3,))
+        reshaped_angles_2 = pnp.reshape(angles_2, (-1, 3) if pnp.ndim(angles_2) > 1 else (3,))
         self.run_interface_test(reshaped_angles_1, reshaped_angles_2)
 
     @pytest.mark.autograd
@@ -167,9 +167,9 @@ class TestRotGateFusion:
         Do not change the test to non-broadcasted evaluation, as this will
         increase the runtime significantly."""
 
-        special_points = np.array([3 / 2, 1, 1 / 2, 0, -1 / 2, -1, -3 / 2]) * np.pi
-        special_angles = np.array(list(product(special_points, repeat=6))).reshape((-1, 2, 3))
-        angles_1, angles_2 = np.transpose(special_angles, (1, 0, 2))
+        special_points = pnp.array([3 / 2, 1, 1 / 2, 0, -1 / 2, -1, -3 / 2]) * pnp.pi
+        special_angles = pnp.array(list(product(special_points, repeat=6))).reshape((-1, 2, 3))
+        angles_1, angles_2 = pnp.transpose(special_angles, (1, 0, 2))
         self.run_interface_test(angles_1, angles_2)
 
     # pylint: disable=too-many-arguments
@@ -234,9 +234,9 @@ class TestRotGateFusion:
         """
         import jax
 
-        special_points = np.array([3 / 2, 1, 1 / 2, 0, -1 / 2, -1, -3 / 2]) * np.pi
-        special_angles = np.array(list(product(special_points, repeat=6))).reshape((-1, 2, 3))
-        random_angles = np.random.random((1000, 2, 3))
+        special_points = pnp.array([3 / 2, 1, 1 / 2, 0, -1 / 2, -1, -3 / 2]) * pnp.pi
+        special_angles = pnp.array(list(product(special_points, repeat=6))).reshape((-1, 2, 3))
+        random_angles = pnp.random.random((1000, 2, 3))
         # Need holomorphic derivatives and complex inputs because the output matrices are complex
         all_angles = jax.numpy.concatenate([special_angles, random_angles])
 
@@ -265,10 +265,10 @@ class TestRotGateFusion:
         import torch
 
         # Testing fewer points than with batching to limit test runtimes
-        special_points = np.array([1, 0, -1]) * np.pi
-        special_angles = np.array(list(product(special_points, repeat=6))).reshape((-1, 2, 3))
-        random_angles = np.random.random((10, 2, 3))
-        all_angles = np.concatenate([special_angles, random_angles])
+        special_points = pnp.array([1, 0, -1]) * pnp.pi
+        special_angles = pnp.array(list(product(special_points, repeat=6))).reshape((-1, 2, 3))
+        random_angles = pnp.random.random((10, 2, 3))
+        all_angles = pnp.concatenate([special_angles, random_angles])
 
         # Need holomorphic derivatives and complex inputs because the output matrices are complex
         all_angles = torch.tensor(all_angles, requires_grad=True)
@@ -293,9 +293,9 @@ class TestRotGateFusion:
          - If it is 1, the derivative of arccos becomes infinite (evaluated at 1), and
          - if its square is 0, the derivative of sqrt becomes infinite (evaluated at 0).
         """
-        special_points = np.array([1, 0, -1]) * np.pi
-        special_angles = np.array(list(product(special_points, repeat=6))).reshape((-1, 2, 3))
-        random_angles = np.random.random((100, 2, 3))
+        special_points = pnp.array([1, 0, -1]) * pnp.pi
+        special_angles = pnp.array(list(product(special_points, repeat=6))).reshape((-1, 2, 3))
+        random_angles = pnp.random.random((100, 2, 3))
         # Need holomorphic derivatives and complex inputs because the output matrices are complex
         all_angles = qml.numpy.concatenate([special_angles, random_angles], requires_grad=True)
 
@@ -322,10 +322,10 @@ class TestRotGateFusion:
         import tensorflow as tf
 
         # Testing fewer points than with batching to limit test runtimes
-        special_points = np.array([0, 1]) * np.pi
-        special_angles = np.array(list(product(special_points, repeat=6))).reshape((-1, 2, 3))
-        random_angles = np.random.random((3, 2, 3))
-        all_angles = np.concatenate([special_angles, random_angles])
+        special_points = pnp.array([0, 1]) * pnp.pi
+        special_angles = pnp.array(list(product(special_points, repeat=6))).reshape((-1, 2, 3))
+        random_angles = pnp.random.random((3, 2, 3))
+        all_angles = pnp.concatenate([special_angles, random_angles])
 
         def jacobian(fn):
 

--- a/tests/transforms/test_optimization/test_pattern_matching.py
+++ b/tests/transforms/test_optimization/test_pattern_matching.py
@@ -20,7 +20,7 @@ import warnings
 import pytest
 
 import pennylane as qml
-import pennylane.numpy as np
+import pennylane.numpy as pnp
 from pennylane.transforms.commutation_dag import commutation_dag
 from pennylane.transforms.optimization.pattern_matching import (
     BackwardMatch,
@@ -82,7 +82,7 @@ class TestPatternMatchingOptimization:
         assert cnots_optimized_qnode == 3
 
         assert qnode_res == optimized_qnode_res
-        assert np.allclose(qml.matrix(optimized_qnode)(), qml.matrix(qnode)())
+        assert pnp.allclose(qml.matrix(optimized_qnode)(), qml.matrix(qnode)())
 
     def test_simple_quantum_function_pattern_matching_qnode(self):
         """Test pattern matching algorithm for circuit optimization with a CNOTs template."""
@@ -111,7 +111,7 @@ class TestPatternMatchingOptimization:
 
         optimized_qnode = pattern_matching_optimization(circuit, pattern_tapes=[template])
         optimized_qnode()
-        assert np.allclose(qml.matrix(optimized_qnode)(), qml.matrix(circuit)())
+        assert pnp.allclose(qml.matrix(optimized_qnode)(), qml.matrix(circuit)())
 
     def test_custom_quantum_cost(self):
         """Test pattern matching algorithm for circuit optimization with a CNOTs template with custom quantum dict."""
@@ -157,7 +157,7 @@ class TestPatternMatchingOptimization:
         assert cnots_optimized_qnode == 3
 
         assert qnode_res == optimized_qnode_res
-        assert np.allclose(qml.matrix(optimized_qnode)(), qml.matrix(qnode)())
+        assert pnp.allclose(qml.matrix(optimized_qnode)(), qml.matrix(qnode)())
 
     def test_no_match_not_optimized(self):
         """Test pattern matching algorithm for circuit optimization with no match and therefore no optimization."""
@@ -197,7 +197,7 @@ class TestPatternMatchingOptimization:
         assert cnots_optimized_qnode == 4
 
         assert qnode_res == optimized_qnode_res
-        assert np.allclose(qml.matrix(optimized_qnode)(), qml.matrix(qnode)())
+        assert pnp.allclose(qml.matrix(optimized_qnode)(), qml.matrix(qnode)())
 
     def test_adjoint_s(self):
         def circuit():
@@ -238,7 +238,7 @@ class TestPatternMatchingOptimization:
         assert s_adjoint_optimized_qnode == 1
 
         assert qnode_res == optimized_qnode_res
-        assert np.allclose(qml.matrix(optimized_qnode)(), qml.matrix(qnode)())
+        assert pnp.allclose(qml.matrix(optimized_qnode)(), qml.matrix(qnode)())
 
     def test_template_with_toffoli(self):
         """Test pattern matching algorithm for circuit optimization with a template having Toffoli gates."""
@@ -284,7 +284,7 @@ class TestPatternMatchingOptimization:
         assert toffolis_optimized_qnode == 0
 
         assert qnode_res == optimized_qnode_res
-        assert np.allclose(qml.matrix(optimized_qnode)(), qml.matrix(qnode)())
+        assert pnp.allclose(qml.matrix(optimized_qnode)(), qml.matrix(qnode)())
 
     def test_template_with_swap(self):
         """Test pattern matching algorithm for circuit optimization with a template having swap gates."""
@@ -336,7 +336,7 @@ class TestPatternMatchingOptimization:
         assert cnot_optimized_qnode == 4
 
         assert qnode_res == optimized_qnode_res
-        assert np.allclose(qml.matrix(optimized_qnode)(), qml.matrix(qnode)())
+        assert pnp.allclose(qml.matrix(optimized_qnode)(), qml.matrix(qnode)())
 
     def test_template_with_multiple_swap(self):
         """Test pattern matching algorithm for circuit optimization with a template having multiple swap gates."""
@@ -386,7 +386,7 @@ class TestPatternMatchingOptimization:
         assert cnot_optimized_qnode == 1
 
         assert qnode_res == optimized_qnode_res
-        assert np.allclose(qml.matrix(optimized_qnode)(), qml.matrix(qnode)())
+        assert pnp.allclose(qml.matrix(optimized_qnode)(), qml.matrix(qnode)())
 
     def test_template_with_multiple_control_swap(self):
         """Test pattern matching algorithm for circuit optimization with a template having multiple cswap gates."""
@@ -436,7 +436,7 @@ class TestPatternMatchingOptimization:
         assert cnot_optimized_qnode == 1
 
         assert qnode_res == optimized_qnode_res
-        assert np.allclose(qml.matrix(optimized_qnode)(), qml.matrix(qnode)())
+        assert pnp.allclose(qml.matrix(optimized_qnode)(), qml.matrix(qnode)())
 
     def test_parametrized_pattern_matching(self):
         """Test pattern matching algorithm for circuit optimization with parameters."""
@@ -494,7 +494,7 @@ class TestPatternMatchingOptimization:
         assert rz_optimized_qnode == 0
 
         assert qnode_res == optimized_qnode_res
-        assert np.allclose(qml.matrix(optimized_qnode)(0.1, 0.2), qml.matrix(qnode)(0.1, 0.2))
+        assert pnp.allclose(qml.matrix(optimized_qnode)(0.1, 0.2), qml.matrix(qnode)(0.1, 0.2))
 
     def test_multiple_patterns(self):
         """Test pattern matching algorithm for circuit optimization with three different templates."""
@@ -545,7 +545,7 @@ class TestPatternMatchingOptimization:
         assert cnots_optimized_qnode == 1
 
         assert qnode_res == optimized_qnode_res
-        assert np.allclose(qml.matrix(optimized_qnode)(), qml.matrix(qnode)())
+        assert pnp.allclose(qml.matrix(optimized_qnode)(), qml.matrix(qnode)())
 
     def test_mod_5_4_pattern_matching(self):
         """Test pattern matching algorithm for mod_5_4 with a CNOTs template."""
@@ -631,7 +631,7 @@ class TestPatternMatchingOptimization:
         assert cnots_optimized_qnode == 26
 
         assert qnode_res == optimized_qnode_res
-        assert np.allclose(qml.matrix(optimized_qnode)(), qml.matrix(qnode)())
+        assert pnp.allclose(qml.matrix(optimized_qnode)(), qml.matrix(qnode)())
 
     @pytest.mark.slow
     def test_vbe_adder_3_pattern_matching(self):
@@ -756,7 +756,7 @@ class TestPatternMatchingOptimization:
         assert cnots_optimized_qnode == 45
 
         assert qnode_res == optimized_qnode_res
-        assert np.allclose(qml.matrix(optimized_qnode)(), qml.matrix(qnode)())
+        assert pnp.allclose(qml.matrix(optimized_qnode)(), qml.matrix(qnode)())
 
     def test_transform_tape(self):
         """Test that the transform works as expected with a tape."""
@@ -792,7 +792,7 @@ class TestPatternMatchingOptimization:
             qml.CZ([1, 2]),
         ]
 
-        assert np.allclose(result, 0.0)
+        assert pnp.allclose(result, 0.0)
 
         # pattern_matching_optimization returns a null postprocessing function
         assert postprocessing_fn(result) == result[0]

--- a/tests/transforms/test_optimization/test_single_qubit_fusion.py
+++ b/tests/transforms/test_optimization/test_single_qubit_fusion.py
@@ -20,7 +20,7 @@ import pytest
 from utils import check_matrix_equivalence, compare_operation_lists
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane.transforms.optimization import single_qubit_fusion
 from pennylane.wires import Wires
 
@@ -222,7 +222,7 @@ class TestSingleQubitFusionInterfaces:
         original_qnode = qml.QNode(qfunc_all_ops, dev)
         transformed_qnode = qml.QNode(transformed_qfunc_all_ops, dev)
 
-        input = np.array([0.1, 0.2, 0.3, 0.4], requires_grad=True)
+        input = pnp.array([0.1, 0.2, 0.3, 0.4], requires_grad=True)
 
         # Check that the numerical output is the same
         assert qml.math.allclose(original_qnode(input), transformed_qnode(input))

--- a/tests/transforms/test_optimization/test_undo_swaps.py
+++ b/tests/transforms/test_optimization/test_undo_swaps.py
@@ -20,7 +20,7 @@ import pytest
 from utils import compare_operation_lists
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane.transforms.optimization import undo_swaps
 from pennylane.wires import Wires
 
@@ -75,7 +75,7 @@ class TestUndoSwaps:
         tape = qml.tape.make_qscript(transformed_qfunc)()
         res = qml.device("default.qubit", wires=2).execute(tape)
         assert len(tape.operations) == 2
-        assert np.allclose(res[0], 0.5)
+        assert pnp.allclose(res[0], 0.5)
 
     def test_one_qubit_gates_transform_qnode(self):
         """Test that a single-qubit gate changes correctly with a SWAP."""
@@ -89,7 +89,7 @@ class TestUndoSwaps:
 
         transformed_qnode = undo_swaps(circuit)
         res = transformed_qnode()
-        assert np.allclose(res[0], 0.5)
+        assert pnp.allclose(res[0], 0.5)
 
     def test_two_qubits_gates_transform(self):
         """Test that a two-qubit gate changes correctly with a SWAP."""
@@ -105,7 +105,7 @@ class TestUndoSwaps:
         tape = qml.tape.make_qscript(transformed_qfunc)()
         res = qml.device("default.qubit", wires=2).execute(tape)
         assert len(tape.operations) == 2
-        assert np.allclose(res[2], 1.0)
+        assert pnp.allclose(res[2], 1.0)
 
     def test_templates_transform(self):
         """Test that a template changes correctly with a SWAP."""
@@ -131,7 +131,7 @@ class TestUndoSwaps:
         tape2 = qml.tape.make_qscript(qfunc2)()
         res2 = qml.device("default.qubit", wires=3).execute(tape2)
 
-        assert np.allclose(res1, res2)
+        assert pnp.allclose(res1, res2)
 
     def test_multi_swaps(self):
         """Test that transform works with several SWAPs."""
@@ -158,7 +158,7 @@ class TestUndoSwaps:
         tape2 = qml.tape.make_qscript(qfunc2)()
         res2 = qml.device("default.qubit", wires=3).execute(tape2)
 
-        assert np.allclose(res1, res2)
+        assert pnp.allclose(res1, res2)
 
     def test_decorator(self, mocker):
         """Test that the decorator works on a QNode."""
@@ -175,7 +175,7 @@ class TestUndoSwaps:
             qml.PauliY(wires=0)
             return qml.expval(qml.PauliZ(0))
 
-        assert np.allclose(qfunc(), -1)
+        assert pnp.allclose(qfunc(), -1)
         [[tape]], _ = spy.call_args
         assert tape.operations == [qml.Hadamard(1), qml.PauliX(2), qml.PauliY(0)]
 
@@ -214,7 +214,7 @@ class TestUndoSwapsInterfaces:
         original_qnode = qml.QNode(qfunc_all_ops, dev)
         transformed_qnode = qml.QNode(transformed_qfunc_all_ops, dev)
 
-        input = np.array([0.1, 0.2], requires_grad=True)
+        input = pnp.array([0.1, 0.2], requires_grad=True)
 
         # Check that the numerical output is the same
         assert qml.math.allclose(original_qnode(input), transformed_qnode(input))

--- a/tests/transforms/test_qcut.py
+++ b/tests/transforms/test_qcut.py
@@ -35,7 +35,7 @@ from networkx import number_of_selfloops
 from scipy.stats import unitary_group
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane import qcut
 from pennylane.queuing import WrappedObj
 from pennylane.wires import Wires
@@ -51,17 +51,17 @@ def suppress_tape_property_deprecation_warning():
 pytestmark = pytest.mark.qcut
 
 I, X, Y, Z = (
-    np.eye(2),
+    pnp.eye(2),
     qml.PauliX.compute_matrix(),
     qml.PauliY.compute_matrix(),
     qml.PauliZ.compute_matrix(),
 )
 
 states_pure = [
-    np.array([1, 0]),
-    np.array([0, 1]),
-    np.array([1, 1]) / np.sqrt(2),
-    np.array([1, 1j]) / np.sqrt(2),
+    pnp.array([1, 0]),
+    pnp.array([0, 1]),
+    pnp.array([1, 1]) / pnp.sqrt(2),
+    pnp.array([1, 1j]) / pnp.sqrt(2),
 ]
 
 with qml.queuing.AnnotatedQueue() as q_no_cut:
@@ -116,8 +116,8 @@ def kron(*args):
     if len(args) == 1:
         return args[0]
     if len(args) == 2:
-        return np.kron(args[0], args[1])
-    return np.kron(args[0], kron(*args[1:]))
+        return pnp.kron(args[0], args[1])
+    return pnp.kron(args[0], kron(*args[1:]))
 
 
 def fn(x):
@@ -291,7 +291,7 @@ def compare_measurements(meas1, meas2):
     assert get_name(meas1.return_type) == get_name(meas2.return_type)
     obs1 = meas1.obs
     obs2 = meas2.obs
-    assert np.array(get_name(obs1) == get_name(obs2)).all()
+    assert pnp.array(get_name(obs1) == get_name(obs2)).all()
     assert obs1.wires.tolist() == obs2.wires.tolist()
 
 
@@ -453,8 +453,8 @@ class TestTapeToGraph:
                 ],
             ),
             (
-                qml.Hermitian(np.array([[1, 0], [0, -1]]), wires=[0]),
-                [qml.expval(qml.Hermitian(np.array([[1, 0], [0, -1]]), wires=[0]))],
+                qml.Hermitian(pnp.array([[1, 0], [0, -1]]), wires=[0]),
+                [qml.expval(qml.Hermitian(pnp.array([[1, 0], [0, -1]]), wires=[0]))],
             ),
             (
                 qml.Projector([0, 1], wires=[0, 1]) @ qml.Projector([1, 0], wires=[0, 2]),
@@ -1899,7 +1899,7 @@ class TestExpandFragmentTapesMC:
         }
         communication_graph = MultiDiGraph([(0, 1, edge_data)])
 
-        fixed_choice = np.array([[4, 0, 1]])
+        fixed_choice = pnp.array([[4, 0, 1]])
 
         class _MockRNG:
 
@@ -1912,7 +1912,7 @@ class TestExpandFragmentTapesMC:
                 tapes, communication_graph, 3
             )
 
-        assert np.allclose(settings, fixed_choice)
+        assert pnp.allclose(settings, fixed_choice)
 
         frag_0_ops = [qml.Hadamard(wires=0), qml.CNOT(wires=[0, 1])]
         frag_0_expected_meas = [
@@ -1970,7 +1970,7 @@ class TestExpandFragmentTapesMC:
 
         communication_graph = MultiDiGraph(frag_edge_data)
 
-        fixed_choice = np.array([[4, 6], [1, 2], [2, 3], [3, 0]])
+        fixed_choice = pnp.array([[4, 6], [1, 2], [2, 3], [3, 0]])
 
         class _MockRNG:
 
@@ -1987,7 +1987,7 @@ class TestExpandFragmentTapesMC:
                 frags, communication_graph, 2
             )
 
-        assert np.allclose(settings, fixed_choice)
+        assert pnp.allclose(settings, fixed_choice)
 
         with qml.queuing.AnnotatedQueue() as q1:
             qml.Hadamard(wires=[0])
@@ -2111,12 +2111,12 @@ class TestMCPostprocessing:
         shots = 3
 
         fixed_samples = [
-            np.array([[1.0], [0.0], [1.0], [1.0]]),
-            np.array([[0.0], [0.0], [1.0], [-1.0]]),
-            np.array([[0.0], [1.0], [1.0], [-1.0]]),
-            np.array([[0.0], [-1.0], [1.0]]),
-            np.array([[0.0], [-1.0], [-1.0]]),
-            np.array([[1.0], [1.0], [1.0]]),
+            pnp.array([[1.0], [0.0], [1.0], [1.0]]),
+            pnp.array([[0.0], [0.0], [1.0], [-1.0]]),
+            pnp.array([[0.0], [1.0], [1.0], [-1.0]]),
+            pnp.array([[0.0], [-1.0], [1.0]]),
+            pnp.array([[0.0], [-1.0], [-1.0]]),
+            pnp.array([[1.0], [1.0], [1.0]]),
         ]
         convert_fixed_samples = [
             qml.math.convert_like(fs, autograd.numpy.ones(1)) for fs in fixed_samples
@@ -2125,9 +2125,9 @@ class TestMCPostprocessing:
         postprocessed = qcut.qcut_processing_fn_sample(
             convert_fixed_samples, communication_graph, shots
         )
-        expected_postprocessed = [np.array([[1.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 1.0, 1.0]])]
+        expected_postprocessed = [pnp.array([[1.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 1.0, 1.0]])]
 
-        assert np.allclose(postprocessed[0], expected_postprocessed[0])
+        assert pnp.allclose(postprocessed[0], expected_postprocessed[0])
         assert isinstance(convert_fixed_samples[0], type(postprocessed[0]))
 
     @pytest.mark.tf
@@ -2142,21 +2142,21 @@ class TestMCPostprocessing:
         shots = 3
 
         fixed_samples = [
-            np.array([[1.0], [0.0], [1.0], [1.0]]),
-            np.array([[0.0], [0.0], [1.0], [-1.0]]),
-            np.array([[0.0], [1.0], [1.0], [-1.0]]),
-            np.array([[0.0], [-1.0], [1.0]]),
-            np.array([[0.0], [-1.0], [-1.0]]),
-            np.array([[1.0], [1.0], [1.0]]),
+            pnp.array([[1.0], [0.0], [1.0], [1.0]]),
+            pnp.array([[0.0], [0.0], [1.0], [-1.0]]),
+            pnp.array([[0.0], [1.0], [1.0], [-1.0]]),
+            pnp.array([[0.0], [-1.0], [1.0]]),
+            pnp.array([[0.0], [-1.0], [-1.0]]),
+            pnp.array([[1.0], [1.0], [1.0]]),
         ]
         convert_fixed_samples = [qml.math.convert_like(fs, tf.ones(1)) for fs in fixed_samples]
 
         postprocessed = qcut.qcut_processing_fn_sample(
             convert_fixed_samples, communication_graph, shots
         )
-        expected_postprocessed = [np.array([[1.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 1.0, 1.0]])]
+        expected_postprocessed = [pnp.array([[1.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 1.0, 1.0]])]
 
-        assert np.allclose(postprocessed[0], expected_postprocessed[0])
+        assert pnp.allclose(postprocessed[0], expected_postprocessed[0])
         assert isinstance(convert_fixed_samples[0], type(postprocessed[0]))
 
     @pytest.mark.torch
@@ -2171,21 +2171,21 @@ class TestMCPostprocessing:
         shots = 3
 
         fixed_samples = [
-            np.array([[1.0], [0.0], [1.0], [1.0]]),
-            np.array([[0.0], [0.0], [1.0], [-1.0]]),
-            np.array([[0.0], [1.0], [1.0], [-1.0]]),
-            np.array([[0.0], [-1.0], [1.0]]),
-            np.array([[0.0], [-1.0], [-1.0]]),
-            np.array([[1.0], [1.0], [1.0]]),
+            pnp.array([[1.0], [0.0], [1.0], [1.0]]),
+            pnp.array([[0.0], [0.0], [1.0], [-1.0]]),
+            pnp.array([[0.0], [1.0], [1.0], [-1.0]]),
+            pnp.array([[0.0], [-1.0], [1.0]]),
+            pnp.array([[0.0], [-1.0], [-1.0]]),
+            pnp.array([[1.0], [1.0], [1.0]]),
         ]
         convert_fixed_samples = [qml.math.convert_like(fs, torch.ones(1)) for fs in fixed_samples]
 
         postprocessed = qcut.qcut_processing_fn_sample(
             convert_fixed_samples, communication_graph, shots
         )
-        expected_postprocessed = [np.array([[1.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 1.0, 1.0]])]
+        expected_postprocessed = [pnp.array([[1.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 1.0, 1.0]])]
 
-        assert np.allclose(postprocessed[0], expected_postprocessed[0])
+        assert pnp.allclose(postprocessed[0], expected_postprocessed[0])
         assert isinstance(convert_fixed_samples[0], type(postprocessed[0]))
 
     @pytest.mark.jax
@@ -2200,12 +2200,12 @@ class TestMCPostprocessing:
         shots = 3
 
         fixed_samples = [
-            np.array([[1.0], [0.0], [1.0], [1.0]]),
-            np.array([[0.0], [0.0], [1.0], [-1.0]]),
-            np.array([[0.0], [1.0], [1.0], [-1.0]]),
-            np.array([[0.0], [-1.0], [1.0]]),
-            np.array([[0.0], [-1.0], [-1.0]]),
-            np.array([[1.0], [1.0], [1.0]]),
+            pnp.array([[1.0], [0.0], [1.0], [1.0]]),
+            pnp.array([[0.0], [0.0], [1.0], [-1.0]]),
+            pnp.array([[0.0], [1.0], [1.0], [-1.0]]),
+            pnp.array([[0.0], [-1.0], [1.0]]),
+            pnp.array([[0.0], [-1.0], [-1.0]]),
+            pnp.array([[1.0], [1.0], [1.0]]),
         ]
         convert_fixed_samples = [
             qml.math.convert_like(fs, jax.numpy.ones(1)) for fs in fixed_samples
@@ -2214,9 +2214,9 @@ class TestMCPostprocessing:
         postprocessed = qcut.qcut_processing_fn_sample(
             convert_fixed_samples, communication_graph, shots
         )
-        expected_postprocessed = [np.array([[1.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 1.0, 1.0]])]
+        expected_postprocessed = [pnp.array([[1.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 1.0, 1.0]])]
 
-        assert np.allclose(postprocessed[0], expected_postprocessed[0])
+        assert pnp.allclose(postprocessed[0], expected_postprocessed[0])
         assert isinstance(convert_fixed_samples[0], type(postprocessed[0]))
 
     @pytest.mark.autograd
@@ -2231,21 +2231,21 @@ class TestMCPostprocessing:
         shots = 3
 
         fixed_samples = [
-            np.array([[1.0], [0.0], [1.0], [1.0]]),
-            np.array([[0.0], [0.0], [1.0], [-1.0]]),
-            np.array([[0.0], [1.0], [1.0], [-1.0]]),
-            np.array([[0.0], [-1.0], [1.0]]),
-            np.array([[0.0], [-1.0], [-1.0]]),
-            np.array([[1.0], [1.0], [1.0]]),
+            pnp.array([[1.0], [0.0], [1.0], [1.0]]),
+            pnp.array([[0.0], [0.0], [1.0], [-1.0]]),
+            pnp.array([[0.0], [1.0], [1.0], [-1.0]]),
+            pnp.array([[0.0], [-1.0], [1.0]]),
+            pnp.array([[0.0], [-1.0], [-1.0]]),
+            pnp.array([[1.0], [1.0], [1.0]]),
         ]
         convert_fixed_samples = [
             qml.math.convert_like(fs, autograd.numpy.ones(1)) for fs in fixed_samples
         ]
 
-        fixed_settings = np.array([[0, 7, 1], [5, 7, 2], [1, 0, 3], [5, 1, 1]])
+        fixed_settings = pnp.array([[0, 7, 1], [5, 7, 2], [1, 0, 3], [5, 1, 1]])
 
-        spy_prod = mocker.spy(np, "prod")
-        spy_hstack = mocker.spy(np, "hstack")
+        spy_prod = mocker.spy(pnp, "prod")
+        spy_hstack = mocker.spy(pnp, "hstack")
 
         postprocessed = qcut.qcut_processing_fn_mc(
             convert_fixed_samples, communication_graph, fixed_settings, shots, fn
@@ -2254,31 +2254,31 @@ class TestMCPostprocessing:
         expected = -85.33333333333333
 
         prod_args = [
-            np.array([1.0, 1.0, -1.0, 1.0]),
+            pnp.array([1.0, 1.0, -1.0, 1.0]),
             [0.5, -0.5, 0.5, -0.5],
-            np.array([1.0, -1.0, -1.0, -1.0]),
+            pnp.array([1.0, -1.0, -1.0, -1.0]),
             [-0.5, -0.5, 0.5, 0.5],
-            np.array([1.0, -1.0, 1.0, 1.0]),
+            pnp.array([1.0, -1.0, 1.0, 1.0]),
             [0.5, 0.5, -0.5, 0.5],
         ]
 
         hstack_args = [
-            [np.array([1.0, 0.0]), np.array([0.0])],
-            [np.array([1.0, 1.0]), np.array([-1.0, 1.0])],
-            [np.array([0.0, 0.0]), np.array([0.0])],
-            [np.array([1.0, -1.0]), np.array([-1.0, -1.0])],
-            [np.array([0.0, 1.0]), np.array([1.0])],
-            [np.array([1.0, -1.0]), np.array([1.0, 1.0])],
+            [pnp.array([1.0, 0.0]), pnp.array([0.0])],
+            [pnp.array([1.0, 1.0]), pnp.array([-1.0, 1.0])],
+            [pnp.array([0.0, 0.0]), pnp.array([0.0])],
+            [pnp.array([1.0, -1.0]), pnp.array([-1.0, -1.0])],
+            [pnp.array([0.0, 1.0]), pnp.array([1.0])],
+            [pnp.array([1.0, -1.0]), pnp.array([1.0, 1.0])],
         ]
 
         for arg, expected_arg in zip(spy_prod.call_args_list, prod_args):
-            assert np.allclose(arg[0][0], expected_arg)
+            assert pnp.allclose(arg[0][0], expected_arg)
 
         for args, expected_args in zip(spy_hstack.call_args_list, hstack_args):
             for arg, expected_arg in zip(args[0][0], expected_args):
-                assert np.allclose(arg, expected_arg)
+                assert pnp.allclose(arg, expected_arg)
 
-        assert np.isclose(postprocessed, expected)
+        assert pnp.isclose(postprocessed, expected)
         assert isinstance(convert_fixed_samples[0], type(postprocessed))
 
     @pytest.mark.tf
@@ -2293,19 +2293,19 @@ class TestMCPostprocessing:
         shots = 3
 
         fixed_samples = [
-            np.array([[1.0], [0.0], [1.0], [1.0]]),
-            np.array([[0.0], [0.0], [1.0], [-1.0]]),
-            np.array([[0.0], [1.0], [1.0], [-1.0]]),
-            np.array([[0.0], [-1.0], [1.0]]),
-            np.array([[0.0], [-1.0], [-1.0]]),
-            np.array([[1.0], [1.0], [1.0]]),
+            pnp.array([[1.0], [0.0], [1.0], [1.0]]),
+            pnp.array([[0.0], [0.0], [1.0], [-1.0]]),
+            pnp.array([[0.0], [1.0], [1.0], [-1.0]]),
+            pnp.array([[0.0], [-1.0], [1.0]]),
+            pnp.array([[0.0], [-1.0], [-1.0]]),
+            pnp.array([[1.0], [1.0], [1.0]]),
         ]
         convert_fixed_samples = [qml.math.convert_like(fs, tf.ones(1)) for fs in fixed_samples]
 
-        fixed_settings = np.array([[0, 7, 1], [5, 7, 2], [1, 0, 3], [5, 1, 1]])
+        fixed_settings = pnp.array([[0, 7, 1], [5, 7, 2], [1, 0, 3], [5, 1, 1]])
 
-        spy_prod = mocker.spy(np, "prod")
-        spy_hstack = mocker.spy(np, "hstack")
+        spy_prod = mocker.spy(pnp, "prod")
+        spy_hstack = mocker.spy(pnp, "hstack")
 
         postprocessed = qcut.qcut_processing_fn_mc(
             convert_fixed_samples, communication_graph, fixed_settings, shots, fn
@@ -2314,31 +2314,31 @@ class TestMCPostprocessing:
         expected = -85.33333333333333
 
         prod_args = [
-            np.array([1.0, 1.0, -1.0, 1.0]),
+            pnp.array([1.0, 1.0, -1.0, 1.0]),
             [0.5, -0.5, 0.5, -0.5],
-            np.array([1.0, -1.0, -1.0, -1.0]),
+            pnp.array([1.0, -1.0, -1.0, -1.0]),
             [-0.5, -0.5, 0.5, 0.5],
-            np.array([1.0, -1.0, 1.0, 1.0]),
+            pnp.array([1.0, -1.0, 1.0, 1.0]),
             [0.5, 0.5, -0.5, 0.5],
         ]
 
         hstack_args = [
-            [np.array([1.0, 0.0]), np.array([0.0])],
-            [np.array([1.0, 1.0]), np.array([-1.0, 1.0])],
-            [np.array([0.0, 0.0]), np.array([0.0])],
-            [np.array([1.0, -1.0]), np.array([-1.0, -1.0])],
-            [np.array([0.0, 1.0]), np.array([1.0])],
-            [np.array([1.0, -1.0]), np.array([1.0, 1.0])],
+            [pnp.array([1.0, 0.0]), pnp.array([0.0])],
+            [pnp.array([1.0, 1.0]), pnp.array([-1.0, 1.0])],
+            [pnp.array([0.0, 0.0]), pnp.array([0.0])],
+            [pnp.array([1.0, -1.0]), pnp.array([-1.0, -1.0])],
+            [pnp.array([0.0, 1.0]), pnp.array([1.0])],
+            [pnp.array([1.0, -1.0]), pnp.array([1.0, 1.0])],
         ]
 
         for arg, expected_arg in zip(spy_prod.call_args_list, prod_args):
-            assert np.allclose(arg[0][0], expected_arg)
+            assert pnp.allclose(arg[0][0], expected_arg)
 
         for args, expected_args in zip(spy_hstack.call_args_list, hstack_args):
             for arg, expected_arg in zip(args[0][0], expected_args):
-                assert np.allclose(arg, expected_arg)
+                assert pnp.allclose(arg, expected_arg)
 
-        assert np.isclose(postprocessed, expected)
+        assert pnp.isclose(postprocessed, expected)
         assert isinstance(convert_fixed_samples[0], type(postprocessed))
 
     @pytest.mark.torch
@@ -2353,19 +2353,19 @@ class TestMCPostprocessing:
         shots = 3
 
         fixed_samples = [
-            np.array([[1.0], [0.0], [1.0], [1.0]]),
-            np.array([[0.0], [0.0], [1.0], [-1.0]]),
-            np.array([[0.0], [1.0], [1.0], [-1.0]]),
-            np.array([[0.0], [-1.0], [1.0]]),
-            np.array([[0.0], [-1.0], [-1.0]]),
-            np.array([[1.0], [1.0], [1.0]]),
+            pnp.array([[1.0], [0.0], [1.0], [1.0]]),
+            pnp.array([[0.0], [0.0], [1.0], [-1.0]]),
+            pnp.array([[0.0], [1.0], [1.0], [-1.0]]),
+            pnp.array([[0.0], [-1.0], [1.0]]),
+            pnp.array([[0.0], [-1.0], [-1.0]]),
+            pnp.array([[1.0], [1.0], [1.0]]),
         ]
         convert_fixed_samples = [qml.math.convert_like(fs, torch.ones(1)) for fs in fixed_samples]
 
-        fixed_settings = np.array([[0, 7, 1], [5, 7, 2], [1, 0, 3], [5, 1, 1]])
+        fixed_settings = pnp.array([[0, 7, 1], [5, 7, 2], [1, 0, 3], [5, 1, 1]])
 
-        spy_prod = mocker.spy(np, "prod")
-        spy_hstack = mocker.spy(np, "hstack")
+        spy_prod = mocker.spy(pnp, "prod")
+        spy_hstack = mocker.spy(pnp, "hstack")
 
         postprocessed = qcut.qcut_processing_fn_mc(
             convert_fixed_samples, communication_graph, fixed_settings, shots, fn
@@ -2374,31 +2374,31 @@ class TestMCPostprocessing:
         expected = -85.33333333333333
 
         prod_args = [
-            np.array([1.0, 1.0, -1.0, 1.0]),
+            pnp.array([1.0, 1.0, -1.0, 1.0]),
             [0.5, -0.5, 0.5, -0.5],
-            np.array([1.0, -1.0, -1.0, -1.0]),
+            pnp.array([1.0, -1.0, -1.0, -1.0]),
             [-0.5, -0.5, 0.5, 0.5],
-            np.array([1.0, -1.0, 1.0, 1.0]),
+            pnp.array([1.0, -1.0, 1.0, 1.0]),
             [0.5, 0.5, -0.5, 0.5],
         ]
 
         hstack_args = [
-            [np.array([1.0, 0.0]), np.array([0.0])],
-            [np.array([1.0, 1.0]), np.array([-1.0, 1.0])],
-            [np.array([0.0, 0.0]), np.array([0.0])],
-            [np.array([1.0, -1.0]), np.array([-1.0, -1.0])],
-            [np.array([0.0, 1.0]), np.array([1.0])],
-            [np.array([1.0, -1.0]), np.array([1.0, 1.0])],
+            [pnp.array([1.0, 0.0]), pnp.array([0.0])],
+            [pnp.array([1.0, 1.0]), pnp.array([-1.0, 1.0])],
+            [pnp.array([0.0, 0.0]), pnp.array([0.0])],
+            [pnp.array([1.0, -1.0]), pnp.array([-1.0, -1.0])],
+            [pnp.array([0.0, 1.0]), pnp.array([1.0])],
+            [pnp.array([1.0, -1.0]), pnp.array([1.0, 1.0])],
         ]
 
         for arg, expected_arg in zip(spy_prod.call_args_list, prod_args):
-            assert np.allclose(arg[0][0], expected_arg)
+            assert pnp.allclose(arg[0][0], expected_arg)
 
         for args, expected_args in zip(spy_hstack.call_args_list, hstack_args):
             for arg, expected_arg in zip(args[0][0], expected_args):
-                assert np.allclose(arg, expected_arg)
+                assert pnp.allclose(arg, expected_arg)
 
-        assert np.isclose(postprocessed, expected)
+        assert pnp.isclose(postprocessed, expected)
         assert isinstance(convert_fixed_samples[0], type(postprocessed))
 
     @pytest.mark.jax
@@ -2413,21 +2413,21 @@ class TestMCPostprocessing:
         shots = 3
 
         fixed_samples = [
-            np.array([[1.0], [0.0], [1.0], [1.0]]),
-            np.array([[0.0], [0.0], [1.0], [-1.0]]),
-            np.array([[0.0], [1.0], [1.0], [-1.0]]),
-            np.array([[0.0], [-1.0], [1.0]]),
-            np.array([[0.0], [-1.0], [-1.0]]),
-            np.array([[1.0], [1.0], [1.0]]),
+            pnp.array([[1.0], [0.0], [1.0], [1.0]]),
+            pnp.array([[0.0], [0.0], [1.0], [-1.0]]),
+            pnp.array([[0.0], [1.0], [1.0], [-1.0]]),
+            pnp.array([[0.0], [-1.0], [1.0]]),
+            pnp.array([[0.0], [-1.0], [-1.0]]),
+            pnp.array([[1.0], [1.0], [1.0]]),
         ]
         convert_fixed_samples = [
             qml.math.convert_like(fs, jax.numpy.ones(1)) for fs in fixed_samples
         ]
 
-        fixed_settings = np.array([[0, 7, 1], [5, 7, 2], [1, 0, 3], [5, 1, 1]])
+        fixed_settings = pnp.array([[0, 7, 1], [5, 7, 2], [1, 0, 3], [5, 1, 1]])
 
-        spy_prod = mocker.spy(np, "prod")
-        spy_hstack = mocker.spy(np, "hstack")
+        spy_prod = mocker.spy(pnp, "prod")
+        spy_hstack = mocker.spy(pnp, "hstack")
 
         postprocessed = qcut.qcut_processing_fn_mc(
             convert_fixed_samples, communication_graph, fixed_settings, shots, fn
@@ -2436,31 +2436,31 @@ class TestMCPostprocessing:
         expected = -85.33333333333333
 
         prod_args = [
-            np.array([1.0, 1.0, -1.0, 1.0]),
+            pnp.array([1.0, 1.0, -1.0, 1.0]),
             [0.5, -0.5, 0.5, -0.5],
-            np.array([1.0, -1.0, -1.0, -1.0]),
+            pnp.array([1.0, -1.0, -1.0, -1.0]),
             [-0.5, -0.5, 0.5, 0.5],
-            np.array([1.0, -1.0, 1.0, 1.0]),
+            pnp.array([1.0, -1.0, 1.0, 1.0]),
             [0.5, 0.5, -0.5, 0.5],
         ]
 
         hstack_args = [
-            [np.array([1.0, 0.0]), np.array([0.0])],
-            [np.array([1.0, 1.0]), np.array([-1.0, 1.0])],
-            [np.array([0.0, 0.0]), np.array([0.0])],
-            [np.array([1.0, -1.0]), np.array([-1.0, -1.0])],
-            [np.array([0.0, 1.0]), np.array([1.0])],
-            [np.array([1.0, -1.0]), np.array([1.0, 1.0])],
+            [pnp.array([1.0, 0.0]), pnp.array([0.0])],
+            [pnp.array([1.0, 1.0]), pnp.array([-1.0, 1.0])],
+            [pnp.array([0.0, 0.0]), pnp.array([0.0])],
+            [pnp.array([1.0, -1.0]), pnp.array([-1.0, -1.0])],
+            [pnp.array([0.0, 1.0]), pnp.array([1.0])],
+            [pnp.array([1.0, -1.0]), pnp.array([1.0, 1.0])],
         ]
 
         for arg, expected_arg in zip(spy_prod.call_args_list, prod_args):
-            assert np.allclose(arg[0][0], expected_arg)
+            assert pnp.allclose(arg[0][0], expected_arg)
 
         for args, expected_args in zip(spy_hstack.call_args_list, hstack_args):
             for arg, expected_arg in zip(args[0][0], expected_args):
-                assert np.allclose(arg, expected_arg)
+                assert pnp.allclose(arg, expected_arg)
 
-        assert np.isclose(postprocessed, expected)
+        assert pnp.isclose(postprocessed, expected)
         assert isinstance(convert_fixed_samples[0], type(postprocessed))
 
     def test_reshape_results(self):
@@ -2470,18 +2470,18 @@ class TestMCPostprocessing:
         """
 
         results = [
-            np.array([[0.0], [-1.0]]),
-            np.array([[1.0], [1.0]]),
-            np.array([[1.0], [1.0]]),
-            np.array([[1.0], [1.0]]),
-            np.array([[1.0], [1.0]]),
-            np.array([[0.0], [0.0]]),
+            pnp.array([[0.0], [-1.0]]),
+            pnp.array([[1.0], [1.0]]),
+            pnp.array([[1.0], [1.0]]),
+            pnp.array([[1.0], [1.0]]),
+            pnp.array([[1.0], [1.0]]),
+            pnp.array([[0.0], [0.0]]),
         ]
 
         expected_reshaped = [
-            [np.array([0.0, -1.0]), np.array([1.0, 1.0])],
-            [np.array([1.0, 1.0]), np.array([1.0, 1.0])],
-            [np.array([1.0, 1.0]), np.array([0.0, 0.0])],
+            [pnp.array([0.0, -1.0]), pnp.array([1.0, 1.0])],
+            [pnp.array([1.0, 1.0]), pnp.array([1.0, 1.0])],
+            [pnp.array([1.0, 1.0]), pnp.array([0.0, 0.0])],
         ]
 
         shots = 3
@@ -2490,7 +2490,7 @@ class TestMCPostprocessing:
 
         for resh, exp_resh in zip(reshaped, expected_reshaped):
             for arr, exp_arr in zip(resh, exp_resh):
-                assert np.allclose(arr, exp_arr)
+                assert pnp.allclose(arr, exp_arr)
 
     def test_classical_processing_error(self):
         """
@@ -2501,18 +2501,18 @@ class TestMCPostprocessing:
         shots = 3
 
         fixed_samples = [
-            np.array([[1.0], [0.0], [1.0], [1.0]]),
-            np.array([[0.0], [0.0], [1.0], [-1.0]]),
-            np.array([[0.0], [1.0], [1.0], [-1.0]]),
-            np.array([[0.0], [-1.0], [1.0]]),
-            np.array([[0.0], [-1.0], [-1.0]]),
-            np.array([[1.0], [1.0], [1.0]]),
+            pnp.array([[1.0], [0.0], [1.0], [1.0]]),
+            pnp.array([[0.0], [0.0], [1.0], [-1.0]]),
+            pnp.array([[0.0], [1.0], [1.0], [-1.0]]),
+            pnp.array([[0.0], [-1.0], [1.0]]),
+            pnp.array([[0.0], [-1.0], [-1.0]]),
+            pnp.array([[1.0], [1.0], [1.0]]),
         ]
 
         def func(x):
             return 2 * (-1) ** (x[0] + x[1])
 
-        fixed_settings = np.array([[0, 7, 1], [5, 7, 2], [1, 0, 3], [5, 1, 1]])
+        fixed_settings = pnp.array([[0, 7, 1], [5, 7, 2], [1, 0, 3], [5, 1, 1]])
 
         with pytest.raises(ValueError, match="The classical processing function supplied must "):
             qcut.qcut_processing_fn_mc(
@@ -2571,7 +2571,7 @@ class TestCutCircuitMCTransform:
         cut_res_mc = circuit(v)
 
         target = target_circuit(v)
-        assert np.isclose(cut_res_mc, target, atol=0.15)  # not guaranteed to pass each time
+        assert pnp.isclose(cut_res_mc, target, atol=0.15)  # not guaranteed to pass each time
 
     def test_cut_circuit_mc_sample(self, dev_fn):
         """
@@ -2827,7 +2827,7 @@ class TestCutCircuitMCTransform:
         v = 0.319
         res = cut_circuit(v)
         assert res.shape == (shots, 2)
-        assert isinstance(res, np.ndarray)
+        assert isinstance(res, pnp.ndarray)
 
     @pytest.mark.autograd
     def test_samples_autograd(self, dev_fn):
@@ -3116,14 +3116,14 @@ class TestCutCircuitMCTransform:
             qml.RX(x, wires=0)
             qml.CNOT(wires=[0, 1])
             qml.WireCut(wires=1)
-            qml.RX(np.sin(x) ** 2, wires=1)
+            qml.RX(pnp.sin(x) ** 2, wires=1)
             qml.CNOT(wires=[1, 2])
             qml.WireCut(wires=1)
             qml.CNOT(wires=[0, 1])
             return qml.sample(wires=[0, 1])
 
         spy = mocker.spy(qcut.cutcircuit_mc, "qcut_processing_fn_mc")
-        x = np.array(0.531, requires_grad=True)
+        x = pnp.array(0.531, requires_grad=True)
         res = circuit(x)
 
         spy.assert_called_once()
@@ -3197,7 +3197,7 @@ class TestCutCircuitMCTransform:
         @partial(qml.cut_circuit_mc, classical_processing_fn=fn)
         @qml.qnode(dev)
         def circuit(params):
-            qml.BasisState(np.array([1]), wires=[0])
+            qml.BasisState(pnp.array([1]), wires=[0])
             qml.WireCut(wires=0)
 
             qml.CNOT(wires=[0, 1])
@@ -3215,18 +3215,18 @@ class TestCutCircuitMCTransform:
             qml.WireCut(wires=3)
             two_qubit_unitary(params[2] ** 2, wires=[3, 4])
             qml.WireCut(wires=3)
-            two_qubit_unitary(np.sin(params[3]), wires=[3, 2])
+            two_qubit_unitary(pnp.sin(params[3]), wires=[3, 2])
             qml.WireCut(wires=3)
-            two_qubit_unitary(np.sqrt(params[4]), wires=[4, 3])
+            two_qubit_unitary(pnp.sqrt(params[4]), wires=[4, 3])
             qml.WireCut(wires=3)
-            two_qubit_unitary(np.cos(params[1]), wires=[3, 2])
+            two_qubit_unitary(pnp.cos(params[1]), wires=[3, 2])
             qml.CRX(params[2], wires=[4, 1])
 
             return qml.sample(wires=[1, 2, 3])
 
         spy = mocker.spy(qcut.cutcircuit_mc, "qcut_processing_fn_mc")
 
-        params = np.array([0.4, 0.5, 0.6, 0.7, 0.8], requires_grad=True)
+        params = pnp.array([0.4, 0.5, 0.6, 0.7, 0.8], requires_grad=True)
         res = circuit(params)
 
         spy.assert_called_once()
@@ -3236,14 +3236,14 @@ class TestCutCircuitMCTransform:
 class TestContractTensors:
     """Tests for the contract_tensors function"""
 
-    t = [np.arange(4), np.arange(4, 8)]
+    t = [pnp.arange(4), pnp.arange(4, 8)]
     # make copies of nodes to ensure id comparisons work correctly
     m = [[qcut.MeasureNode(wires=0)], []]
     p = [[], [qcut.PrepareNode(wires=0)]]
     m_copy, p_copy = copy.copy(m), copy.copy(p)
     edge_dict = {"pair": (WrappedObj(m_copy[0][0]), WrappedObj(p_copy[1][0]))}
     g = MultiDiGraph([(0, 1, edge_dict)])
-    expected_result = np.dot(*t)
+    expected_result = pnp.dot(*t)
 
     @pytest.mark.parametrize("use_opt_einsum", [False, True])
     def test_basic(self, use_opt_einsum):
@@ -3252,7 +3252,7 @@ class TestContractTensors:
             pytest.importorskip("opt_einsum")
         res = qcut.contract_tensors(self.t, self.g, self.p, self.m, use_opt_einsum=use_opt_einsum)
 
-        assert np.allclose(res, self.expected_result)
+        assert pnp.allclose(res, self.expected_result)
 
     def test_fail_import(self, monkeypatch):
         """Test if an ImportError is raised when opt_einsum is requested but not installed"""
@@ -3275,16 +3275,16 @@ class TestContractTensors:
     params = [0.3, 0.5]
 
     expected_grad_0 = (
-        np.cos(params[0]) * np.cos(params[1])
-        + 2 * np.cos(params[0]) * np.sin(params[0]) * np.cos(params[1]) ** 2
-        + 3 * np.cos(params[0]) * np.sin(params[0]) ** 2 * np.cos(params[1]) ** 3
+        pnp.cos(params[0]) * pnp.cos(params[1])
+        + 2 * pnp.cos(params[0]) * pnp.sin(params[0]) * pnp.cos(params[1]) ** 2
+        + 3 * pnp.cos(params[0]) * pnp.sin(params[0]) ** 2 * pnp.cos(params[1]) ** 3
     )
     expected_grad_1 = (
-        -np.sin(params[0]) * np.sin(params[1])
-        - 2 * np.sin(params[0]) ** 2 * np.sin(params[1]) * np.cos(params[1])
-        - 3 * np.sin(params[0]) ** 3 * np.sin(params[1]) * np.cos(params[1]) ** 2
+        -pnp.sin(params[0]) * pnp.sin(params[1])
+        - 2 * pnp.sin(params[0]) ** 2 * pnp.sin(params[1]) * pnp.cos(params[1])
+        - 3 * pnp.sin(params[0]) ** 3 * pnp.sin(params[1]) * pnp.cos(params[1]) ** 2
     )
-    expected_grad = np.array([expected_grad_0, expected_grad_1])
+    expected_grad = pnp.array([expected_grad_0, expected_grad_1])
 
     @pytest.mark.autograd
     @pytest.mark.parametrize("use_opt_einsum", [True, False])
@@ -3294,16 +3294,16 @@ class TestContractTensors:
             pytest.importorskip("opt_einsum")
 
         def contract(params):
-            t1 = np.asarray([np.sin(params[0]) ** i for i in range(4)])
-            t2 = np.asarray([np.cos(params[1]) ** i for i in range(4)])
+            t1 = pnp.asarray([pnp.sin(params[0]) ** i for i in range(4)])
+            t2 = pnp.asarray([pnp.cos(params[1]) ** i for i in range(4)])
             t = [t1, t2]
             r = qcut.contract_tensors(t, self.g, self.p, self.m, use_opt_einsum=use_opt_einsum)
             return r
 
-        params = np.array(self.params, requires_grad=True)
+        params = pnp.array(self.params, requires_grad=True)
         grad = qml.grad(contract)(params)
 
-        assert np.allclose(grad, self.expected_grad)
+        assert pnp.allclose(grad, self.expected_grad)
 
     @pytest.mark.torch
     @pytest.mark.parametrize("use_opt_einsum", [True, False])
@@ -3323,7 +3323,7 @@ class TestContractTensors:
         r.backward()
         grad = params.grad
 
-        assert np.allclose(grad, self.expected_grad)
+        assert pnp.allclose(grad, self.expected_grad)
 
     @pytest.mark.tf
     @pytest.mark.parametrize("use_opt_einsum", [True, False])
@@ -3344,7 +3344,7 @@ class TestContractTensors:
 
         grad = tape.gradient(r, params)
 
-        assert np.allclose(grad, self.expected_grad)
+        assert pnp.allclose(grad, self.expected_grad)
 
     @pytest.mark.jax
     @pytest.mark.parametrize("use_opt_einsum", [True, False])
@@ -3396,9 +3396,9 @@ class TestContractTensors:
             spy = mocker.spy(qml.math, "einsum")
 
         t = [
-            np.arange(4**8).reshape((4,) * 8),
-            np.arange(4**4).reshape((4,) * 4),
-            np.arange(4**2).reshape((4,) * 2),
+            pnp.arange(4**8).reshape((4,) * 8),
+            pnp.arange(4**4).reshape((4,) * 4),
+            pnp.arange(4**2).reshape((4,) * 2),
         ]
         m = [
             [
@@ -3446,7 +3446,7 @@ class TestContractTensors:
         expected_eqn = "abccdegf,deab,fg"
 
         assert eqn == expected_eqn
-        assert np.allclose(res, np.einsum(eqn, *t))
+        assert pnp.allclose(res, pnp.einsum(eqn, *t))
 
 
 class TestQCutProcessingFn:
@@ -3459,12 +3459,12 @@ class TestQCutProcessingFn:
         prepare_nodes = [[None] * 3, [None] * 2, [None] * 1, [None] * 4]
         measure_nodes = [[None] * 2, [None] * 2, [None] * 3, [None] * 3]
         tensors = [
-            np.arange(4**5).reshape((4,) * 5),
-            np.arange(4**4).reshape((4,) * 4),
-            np.arange(4**4).reshape((4,) * 4),
-            np.arange(4**7).reshape((4,) * 7),
+            pnp.arange(4**5).reshape((4,) * 5),
+            pnp.arange(4**4).reshape((4,) * 4),
+            pnp.arange(4**4).reshape((4,) * 4),
+            pnp.arange(4**7).reshape((4,) * 7),
         ]
-        results = np.concatenate([t.flatten() for t in tensors])
+        results = pnp.concatenate([t.flatten() for t in tensors])
 
         def mock_process_tensor(r, num_prep, num_meas):
             return qml.math.reshape(r, (4,) * (num_prep + num_meas))
@@ -3474,15 +3474,15 @@ class TestQCutProcessingFn:
             tensors_out = qcut._to_tensors(results, prepare_nodes, measure_nodes)
 
         for t1, t2 in zip(tensors, tensors_out):
-            assert np.allclose(t1, t2)
+            assert pnp.allclose(t1, t2)
 
     def test_to_tensors_raises(self):
         """Tests if a ValueError is raised when a results vector is passed to _to_tensors with a
         size that is incompatible with the prepare_nodes and measure_nodes arguments"""
         prepare_nodes = [[None] * 3]
         measure_nodes = [[None] * 2]
-        tensors = [np.arange(4**5).reshape((4,) * 5), np.arange(4)]
-        results = np.concatenate([t.flatten() for t in tensors])
+        tensors = [pnp.arange(4**5).reshape((4,) * 5), pnp.arange(4)]
+        results = pnp.concatenate([t.flatten() for t in tensors])
 
         with pytest.raises(ValueError, match="should be a flat list of length 1024"):
             qcut._to_tensors(results, prepare_nodes, measure_nodes)
@@ -3496,7 +3496,7 @@ class TestQCutProcessingFn:
         U = unitary_group.rvs(2**n, random_state=1967)
 
         # First, create target process tensor
-        basis = np.array([I, X, Y, Z]) / np.sqrt(2)
+        basis = pnp.array([I, X, Y, Z]) / pnp.sqrt(2)
         prod_inp = itertools.product(range(4), repeat=n)
         prod_out = itertools.product(range(4), repeat=n)
 
@@ -3507,9 +3507,9 @@ class TestQCutProcessingFn:
         for inp, out in itertools.product(prod_inp, prod_out):
             input = kron(*[basis[i] for i in inp])
             output = kron(*[basis[i] for i in out])
-            results.append(np.trace(output @ U @ input @ U.conj().T))
+            results.append(pnp.trace(output @ U @ input @ U.conj().T))
 
-        target_tensor = np.array(results).reshape((4,) * (2 * n))
+        target_tensor = pnp.array(results).reshape((4,) * (2 * n))
 
         # Now, create the input results vector found from executing over the product of |0>, |1>,
         # |+>, |+i> inputs and using the grouped Pauli terms for measurements
@@ -3530,11 +3530,11 @@ class TestQCutProcessingFn:
             input = kron(*[states_pure[i] for i in inp])
             results.append(f(input, out))
 
-        results = qml.math.cast_like(np.concatenate(results), autograd.numpy.ones(1))
+        results = qml.math.cast_like(pnp.concatenate(results), autograd.numpy.ones(1))
 
         # Now apply _process_tensor
         tensor = qcut._process_tensor(results, n, n)
-        assert np.allclose(tensor, target_tensor)
+        assert pnp.allclose(tensor, target_tensor)
 
     @pytest.mark.tf
     @pytest.mark.parametrize("n", [1, 2])
@@ -3545,7 +3545,7 @@ class TestQCutProcessingFn:
         U = unitary_group.rvs(2**n, random_state=1967)
 
         # First, create target process tensor
-        basis = np.array([I, X, Y, Z]) / np.sqrt(2)
+        basis = pnp.array([I, X, Y, Z]) / pnp.sqrt(2)
         prod_inp = itertools.product(range(4), repeat=n)
         prod_out = itertools.product(range(4), repeat=n)
 
@@ -3556,9 +3556,9 @@ class TestQCutProcessingFn:
         for inp, out in itertools.product(prod_inp, prod_out):
             input = kron(*[basis[i] for i in inp])
             output = kron(*[basis[i] for i in out])
-            results.append(np.trace(output @ U @ input @ U.conj().T))
+            results.append(pnp.trace(output @ U @ input @ U.conj().T))
 
-        target_tensor = np.array(results).reshape((4,) * (2 * n))
+        target_tensor = pnp.array(results).reshape((4,) * (2 * n))
 
         # Now, create the input results vector found from executing over the product of |0>, |1>,
         # |+>, |+i> inputs and using the grouped Pauli terms for measurements
@@ -3579,11 +3579,11 @@ class TestQCutProcessingFn:
             input = kron(*[states_pure[i] for i in inp])
             results.append(f(input, out))
 
-        results = qml.math.cast_like(np.concatenate(results), tf.ones(1))
+        results = qml.math.cast_like(pnp.concatenate(results), tf.ones(1))
 
         # Now apply _process_tensor
         tensor = qcut._process_tensor(results, n, n)
-        assert np.allclose(tensor, target_tensor)
+        assert pnp.allclose(tensor, target_tensor)
 
     @pytest.mark.torch
     @pytest.mark.parametrize("n", [1, 2])
@@ -3594,7 +3594,7 @@ class TestQCutProcessingFn:
         U = unitary_group.rvs(2**n, random_state=1967)
 
         # First, create target process tensor
-        basis = np.array([I, X, Y, Z]) / np.sqrt(2)
+        basis = pnp.array([I, X, Y, Z]) / pnp.sqrt(2)
         prod_inp = itertools.product(range(4), repeat=n)
         prod_out = itertools.product(range(4), repeat=n)
 
@@ -3605,9 +3605,9 @@ class TestQCutProcessingFn:
         for inp, out in itertools.product(prod_inp, prod_out):
             input = kron(*[basis[i] for i in inp])
             output = kron(*[basis[i] for i in out])
-            results.append(np.trace(output @ U @ input @ U.conj().T))
+            results.append(pnp.trace(output @ U @ input @ U.conj().T))
 
-        target_tensor = np.array(results).reshape((4,) * (2 * n))
+        target_tensor = pnp.array(results).reshape((4,) * (2 * n))
 
         # Now, create the input results vector found from executing over the product of |0>, |1>,
         # |+>, |+i> inputs and using the grouped Pauli terms for measurements
@@ -3628,11 +3628,11 @@ class TestQCutProcessingFn:
             input = kron(*[states_pure[i] for i in inp])
             results.append(f(input, out))
 
-        results = qml.math.cast_like(np.concatenate(results), torch.ones(1))
+        results = qml.math.cast_like(pnp.concatenate(results), torch.ones(1))
 
         # Now apply _process_tensor
         tensor = qcut._process_tensor(results, n, n)
-        assert np.allclose(tensor, target_tensor)
+        assert pnp.allclose(tensor, target_tensor)
 
     @pytest.mark.jax
     @pytest.mark.parametrize("n", [1, 2])
@@ -3643,7 +3643,7 @@ class TestQCutProcessingFn:
         U = unitary_group.rvs(2**n, random_state=1967)
 
         # First, create target process tensor
-        basis = np.array([I, X, Y, Z]) / np.sqrt(2)
+        basis = pnp.array([I, X, Y, Z]) / pnp.sqrt(2)
         prod_inp = itertools.product(range(4), repeat=n)
         prod_out = itertools.product(range(4), repeat=n)
 
@@ -3654,9 +3654,9 @@ class TestQCutProcessingFn:
         for inp, out in itertools.product(prod_inp, prod_out):
             input = kron(*[basis[i] for i in inp])
             output = kron(*[basis[i] for i in out])
-            results.append(np.trace(output @ U @ input @ U.conj().T))
+            results.append(pnp.trace(output @ U @ input @ U.conj().T))
 
-        target_tensor = np.array(results).reshape((4,) * (2 * n))
+        target_tensor = pnp.array(results).reshape((4,) * (2 * n))
 
         # Now, create the input results vector found from executing over the product of |0>, |1>,
         # |+>, |+i> inputs and using the grouped Pauli terms for measurements
@@ -3677,11 +3677,11 @@ class TestQCutProcessingFn:
             input = kron(*[states_pure[i] for i in inp])
             results.append(f(input, out))
 
-        results = qml.math.cast_like(np.concatenate(results), jax.numpy.ones(1))
+        results = qml.math.cast_like(pnp.concatenate(results), jax.numpy.ones(1))
 
         # Now apply _process_tensor
         tensor = qcut._process_tensor(results, n, n)
-        assert np.allclose(tensor, target_tensor)
+        assert pnp.allclose(tensor, target_tensor)
 
     @pytest.mark.parametrize("use_opt_einsum", [True, False])
     def test_qcut_processing_fn(self, use_opt_einsum):
@@ -3710,15 +3710,15 @@ class TestQCutProcessingFn:
         ### Find the result using qcut_processing_fn
 
         meas_basis = [I, Z, X, Y]
-        states = [np.outer(s, s.conj()) for s in states_pure]
+        states = [pnp.outer(s, s.conj()) for s in states_pure]
         zero_proj = states[0]
 
         u1 = qml.RX.compute_matrix(x)
         u2 = qml.RY.compute_matrix(y)
         u3 = qml.RX.compute_matrix(z)
-        t1 = np.array([np.trace(b @ u1 @ zero_proj @ u1.conj().T) for b in meas_basis])
-        t2 = np.array([[np.trace(b @ u2 @ s @ u2.conj().T) for b in meas_basis] for s in states])
-        t3 = np.array([np.trace(Z @ u3 @ s @ u3.conj().T) for s in states])
+        t1 = pnp.array([pnp.trace(b @ u1 @ zero_proj @ u1.conj().T) for b in meas_basis])
+        t2 = pnp.array([[pnp.trace(b @ u2 @ s @ u2.conj().T) for b in meas_basis] for s in states])
+        t3 = pnp.array([pnp.trace(Z @ u3 @ s @ u3.conj().T) for s in states])
 
         res = [t1, t2.flatten(), t3]
         p = [[], [qcut.PrepareNode(wires=0)], [qcut.PrepareNode(wires=0)]]
@@ -3731,7 +3731,7 @@ class TestQCutProcessingFn:
         g = MultiDiGraph(edges)
 
         result = qcut.qcut_processing_fn(res, g, p, m, use_opt_einsum=use_opt_einsum)
-        assert np.allclose(result, expected_result)
+        assert pnp.allclose(result, expected_result)
 
     @pytest.mark.autograd
     @pytest.mark.parametrize("use_opt_einsum", [True, False])
@@ -3741,12 +3741,12 @@ class TestQCutProcessingFn:
         if use_opt_einsum:
             pytest.importorskip("opt_einsum")
 
-        x = np.array(0.9, requires_grad=True)
+        x = pnp.array(0.9, requires_grad=True)
 
         def f(x):
-            t1 = x * np.arange(4)
-            t2 = x**2 * np.arange(16).reshape((4, 4))
-            t3 = np.sin(x * np.pi / 2) * np.arange(4)
+            t1 = x * pnp.arange(4)
+            t2 = x**2 * pnp.arange(16).reshape((4, 4))
+            t3 = pnp.sin(x * pnp.pi / 2) * pnp.arange(4)
 
             res = [t1, t2.flatten(), t3]
             p = [[], [qcut.PrepareNode(wires=0)], [qcut.PrepareNode(wires=0)]]
@@ -3762,10 +3762,10 @@ class TestQCutProcessingFn:
 
         grad = qml.grad(f)(x)
         expected_grad = (
-            3 * x**2 * np.sin(x * np.pi / 2) + x**3 * np.cos(x * np.pi / 2) * np.pi / 2
+            3 * x**2 * pnp.sin(x * pnp.pi / 2) + x**3 * pnp.cos(x * pnp.pi / 2) * pnp.pi / 2
         ) * f(1)
 
-        assert np.allclose(grad, expected_grad)
+        assert pnp.allclose(grad, expected_grad)
 
     @pytest.mark.tf
     @pytest.mark.parametrize("use_opt_einsum", [True, False])
@@ -3783,7 +3783,7 @@ class TestQCutProcessingFn:
             x = tf.cast(x, dtype=tf.float64)  # pylint:disable=unexpected-keyword-arg
             t1 = x * tf.range(4, dtype=tf.float64)
             t2 = x**2 * tf.range(16, dtype=tf.float64)
-            t3 = tf.sin(x * np.pi / 2) * tf.range(4, dtype=tf.float64)
+            t3 = tf.sin(x * pnp.pi / 2) * tf.range(4, dtype=tf.float64)
 
             res = [t1, t2, t3]
             p = [[], [qcut.PrepareNode(wires=0)], [qcut.PrepareNode(wires=0)]]
@@ -3802,10 +3802,10 @@ class TestQCutProcessingFn:
 
         grad = tape.gradient(res, x)
         expected_grad = (
-            3 * x**2 * np.sin(x * np.pi / 2) + x**3 * np.cos(x * np.pi / 2) * np.pi / 2
+            3 * x**2 * pnp.sin(x * pnp.pi / 2) + x**3 * pnp.cos(x * pnp.pi / 2) * pnp.pi / 2
         ) * f(1)
 
-        assert np.allclose(grad, expected_grad)
+        assert pnp.allclose(grad, expected_grad)
 
     @pytest.mark.torch
     @pytest.mark.parametrize("use_opt_einsum", [True, False])
@@ -3821,7 +3821,7 @@ class TestQCutProcessingFn:
         def f(x):
             t1 = x * torch.arange(4)
             t2 = x**2 * torch.arange(16)
-            t3 = torch.sin(x * np.pi / 2) * torch.arange(4)
+            t3 = torch.sin(x * pnp.pi / 2) * torch.arange(4)
 
             res = [t1, t2, t3]
             p = [[], [qcut.PrepareNode(wires=0)], [qcut.PrepareNode(wires=0)]]
@@ -3842,10 +3842,10 @@ class TestQCutProcessingFn:
         x_ = x.detach().numpy()
         f1 = f(torch.tensor(1, dtype=torch.float64))
         expected_grad = (
-            3 * x_**2 * np.sin(x_ * np.pi / 2) + x_**3 * np.cos(x_ * np.pi / 2) * np.pi / 2
+            3 * x_**2 * pnp.sin(x_ * pnp.pi / 2) + x_**3 * pnp.cos(x_ * pnp.pi / 2) * pnp.pi / 2
         ) * f1
 
-        assert np.allclose(grad.detach().numpy(), expected_grad)
+        assert pnp.allclose(grad.detach().numpy(), expected_grad)
 
     @pytest.mark.jax
     @pytest.mark.parametrize("use_opt_einsum", [True, False])
@@ -3862,7 +3862,7 @@ class TestQCutProcessingFn:
         def f(x):
             t1 = x * jnp.arange(4)
             t2 = x**2 * jnp.arange(16).reshape((4, 4))
-            t3 = jnp.sin(x * np.pi / 2) * jnp.arange(4)
+            t3 = jnp.sin(x * pnp.pi / 2) * jnp.arange(4)
 
             res = [t1, t2.flatten(), t3]
             p = [[], [qcut.PrepareNode(wires=0)], [qcut.PrepareNode(wires=0)]]
@@ -3878,10 +3878,10 @@ class TestQCutProcessingFn:
 
         grad = jax.grad(f)(x)
         expected_grad = (
-            3 * x**2 * np.sin(x * np.pi / 2) + x**3 * np.cos(x * np.pi / 2) * np.pi / 2
+            3 * x**2 * pnp.sin(x * pnp.pi / 2) + x**3 * pnp.cos(x * pnp.pi / 2) * pnp.pi / 2
         ) * f(1)
 
-        assert np.allclose(grad, expected_grad)
+        assert pnp.allclose(grad, expected_grad)
 
 
 @pytest.mark.parametrize("use_opt_einsum", [True, False])
@@ -3912,17 +3912,17 @@ class TestCutCircuitTransform:
             return qml.expval(qml.PauliZ(wires=[0]))
 
         spy = mocker.spy(qcut.cutcircuit, "qcut_processing_fn")
-        x = np.array(0.531, requires_grad=True)
+        x = pnp.array(0.531, requires_grad=True)
         cut_circuit = qcut.cut_circuit(circuit, use_opt_einsum=use_opt_einsum)
 
         atol = 1e-2 if shots else 1e-8
-        assert np.isclose(cut_circuit(x), float(circuit(x)), atol=atol)
+        assert pnp.isclose(cut_circuit(x), float(circuit(x)), atol=atol)
         spy.assert_called_once()
 
         gradient = qml.grad(circuit)(x)
         cut_gradient = qml.grad(cut_circuit)(x)
 
-        assert np.isclose(gradient, cut_gradient, atol=atol)
+        assert pnp.isclose(gradient, cut_gradient, atol=atol)
 
     @pytest.mark.torch
     def test_simple_cut_circuit_torch(self, use_opt_einsum):
@@ -3952,7 +3952,7 @@ class TestCutCircuitTransform:
 
         res = cut_circuit(x)
         res_expected = circuit(x)
-        assert np.isclose(res.detach().numpy(), res_expected.detach().numpy())
+        assert pnp.isclose(res.detach().numpy(), res_expected.detach().numpy())
 
         res.backward()
         grad = x.grad.detach().numpy()
@@ -3961,7 +3961,7 @@ class TestCutCircuitTransform:
         res_expected.backward()
         grad_expected = x.grad.detach().numpy()
 
-        assert np.isclose(grad, grad_expected)
+        assert pnp.isclose(grad, grad_expected)
 
     @pytest.mark.tf
     def test_simple_cut_circuit_tf(self, use_opt_einsum):
@@ -3999,8 +3999,8 @@ class TestCutCircuitTransform:
 
         grad_expected = tape.gradient(res_expected, x)
 
-        assert np.isclose(res, res_expected)
-        assert np.isclose(grad, grad_expected)
+        assert pnp.isclose(res, res_expected)
+        assert pnp.isclose(grad, grad_expected)
 
     @pytest.mark.jax
     def test_simple_cut_circuit_jax(self, use_opt_einsum):
@@ -4035,8 +4035,8 @@ class TestCutCircuitTransform:
         grad = jax.grad(cut_circuit)(x)
         grad_expected = jax.grad(circuit)(x)
 
-        assert np.isclose(res, res_expected)
-        assert np.isclose(grad, grad_expected)
+        assert pnp.isclose(res, res_expected)
+        assert pnp.isclose(grad, grad_expected)
 
     def test_with_mid_circuit_measurement(self, mocker, use_opt_einsum):
         """Tests the full circuit cutting pipeline returns the correct value and gradient for a
@@ -4051,23 +4051,23 @@ class TestCutCircuitTransform:
             qml.RX(x, wires=0)
             qml.CNOT(wires=[0, 1])
             qml.WireCut(wires=1)
-            qml.RX(np.sin(x) ** 2, wires=1)
+            qml.RX(pnp.sin(x) ** 2, wires=1)
             qml.CNOT(wires=[1, 2])
             qml.WireCut(wires=1)
             qml.CNOT(wires=[0, 1])
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
         spy = mocker.spy(qcut.cutcircuit, "qcut_processing_fn")
-        x = np.array(0.531, requires_grad=True)
+        x = pnp.array(0.531, requires_grad=True)
         cut_circuit = qcut.cut_circuit(circuit, use_opt_einsum=use_opt_einsum)
 
-        assert np.isclose(cut_circuit(x), float(circuit(x)))
+        assert pnp.isclose(cut_circuit(x), float(circuit(x)))
         spy.assert_called_once()
 
         gradient = qml.grad(circuit)(x)
         cut_gradient = qml.grad(cut_circuit)(x)
 
-        assert np.isclose(gradient, cut_gradient)
+        assert pnp.isclose(gradient, cut_gradient)
 
     @pytest.mark.torch
     def test_simple_cut_circuit_torch_trace(self, mocker, use_opt_einsum):
@@ -4109,7 +4109,7 @@ class TestCutCircuitTransform:
         spy.assert_not_called()
 
         res_expected = circuit(x)
-        assert np.isclose(res.detach().numpy(), res_expected.detach().numpy())
+        assert pnp.isclose(res.detach().numpy(), res_expected.detach().numpy())
 
         res.backward()
         grad = x.grad.detach().numpy()
@@ -4118,15 +4118,15 @@ class TestCutCircuitTransform:
         res_expected.backward()
         grad_expected = x.grad.detach().numpy()
 
-        assert np.isclose(grad, grad_expected)
+        assert pnp.isclose(grad, grad_expected)
 
         # Run more times over a range of values
-        for x in np.linspace(-1, 1, 10):
+        for x in pnp.linspace(-1, 1, 10):
             x = torch.tensor(x, requires_grad=True)
             res = cut_circuit_trace(x)
 
             res_expected = circuit(x)
-            assert np.isclose(res.detach().numpy(), res_expected.detach().numpy())
+            assert pnp.isclose(res.detach().numpy(), res_expected.detach().numpy())
 
             res.backward()
             grad = x.grad.detach().numpy()
@@ -4135,7 +4135,7 @@ class TestCutCircuitTransform:
             res_expected.backward()
             grad_expected = x.grad.detach().numpy()
 
-            assert np.isclose(grad, grad_expected)
+            assert pnp.isclose(grad, grad_expected)
 
         spy.assert_not_called()
 
@@ -4191,11 +4191,11 @@ class TestCutCircuitTransform:
 
         grad_expected = tape.gradient(res_expected, x)
 
-        assert np.isclose(res, res_expected)
-        assert np.isclose(grad, grad_expected)
+        assert pnp.isclose(res, res_expected)
+        assert pnp.isclose(grad, grad_expected)
 
         # Run more times over a range of values
-        for x in np.linspace(-1, 1, 10):
+        for x in pnp.linspace(-1, 1, 10):
             x = tf.Variable(x, dtype=tf.float32)
 
             cut_circuit_jit(x)
@@ -4210,8 +4210,8 @@ class TestCutCircuitTransform:
 
             grad_expected = tape.gradient(res_expected, x)
 
-            assert np.isclose(res, res_expected)
-            assert np.isclose(grad, grad_expected)
+            assert pnp.isclose(res, res_expected)
+            assert pnp.isclose(grad, grad_expected)
 
         spy.assert_called_once()
 
@@ -4254,30 +4254,30 @@ class TestCutCircuitTransform:
         res_expected = circuit(x)
 
         spy.assert_called_once()
-        assert np.isclose(res, res_expected)
+        assert pnp.isclose(res, res_expected)
 
         jax.grad(cut_circuit_jit)(x)
         grad = jax.grad(cut_circuit_jit)(x)
         grad_expected = jax.grad(circuit)(x)
 
-        assert np.isclose(grad, grad_expected)
+        assert pnp.isclose(grad, grad_expected)
         assert spy.call_count == 1
 
         # Run more times over a range of values
-        for x in np.linspace(-1, 1, 10):
+        for x in pnp.linspace(-1, 1, 10):
             x = jnp.array(x)
 
             cut_circuit_jit(x)
             res = cut_circuit_jit(x)
             res_expected = circuit(x)
 
-            assert np.isclose(res, res_expected)
+            assert pnp.isclose(res, res_expected)
 
             jax.grad(cut_circuit_jit)(x)
             grad = jax.grad(cut_circuit_jit)(x)
             grad_expected = jax.grad(circuit)(x)
 
-            assert np.isclose(grad, grad_expected)
+            assert pnp.isclose(grad, grad_expected)
 
         assert spy.call_count == 2
 
@@ -4310,8 +4310,8 @@ class TestCutCircuitTransform:
         res_1 = cut_circuit_1()
         res_2 = cut_circuit_2()
 
-        assert np.isclose(res_expected, res_1)
-        assert np.isclose(res_expected, res_2)
+        assert pnp.isclose(res_expected, res_1)
+        assert pnp.isclose(res_expected, res_2)
 
     def test_circuit_with_disconnected_components(self, use_opt_einsum):
         """Tests if a circuit that is fragmented into subcircuits such that some of the subcircuits
@@ -4333,7 +4333,7 @@ class TestCutCircuitTransform:
 
         x = 0.4
         res = circuit(x)
-        assert np.allclose(res, np.cos(x))
+        assert pnp.allclose(res, pnp.cos(x))
 
     def test_circuit_with_trivial_wire_cut(self, use_opt_einsum, mocker):
         """Tests that a circuit with a trivial wire cut (not separating the circuit into
@@ -4356,7 +4356,7 @@ class TestCutCircuitTransform:
 
         x = 0.4
         res = circuit(x)
-        assert np.allclose(res, np.cos(x))
+        assert pnp.allclose(res, pnp.cos(x))
         assert len(spy.call_args[0][0]) == 1  # there should be 1 tensor for wire 0
         assert spy.call_args[0][0][0].shape == ()
 
@@ -4391,7 +4391,7 @@ class TestCutCircuitTransform:
             qml.CRY(param, wires=[wires[0], wires[1]])
 
         def f(params):
-            qml.BasisState(np.array([1]), wires=[0])
+            qml.BasisState(pnp.array([1]), wires=[0])
             qml.WireCut(wires=0)
 
             qml.CNOT(wires=[0, 1])
@@ -4409,16 +4409,16 @@ class TestCutCircuitTransform:
             qml.WireCut(wires=3)
             two_qubit_unitary(params[2] ** 2, wires=[3, 4])
             qml.WireCut(wires=3)
-            two_qubit_unitary(np.sin(params[3]), wires=[3, 2])
+            two_qubit_unitary(pnp.sin(params[3]), wires=[3, 2])
             qml.WireCut(wires=3)
-            two_qubit_unitary(np.sqrt(params[4]), wires=[4, 3])
+            two_qubit_unitary(pnp.sqrt(params[4]), wires=[4, 3])
             qml.WireCut(wires=3)
-            two_qubit_unitary(np.cos(params[1]), wires=[3, 2])
+            two_qubit_unitary(pnp.cos(params[1]), wires=[3, 2])
             qml.CRX(params[2], wires=[4, 1])
 
             return qml.expval(qml.PauliZ(1) @ qml.PauliZ(2) @ qml.PauliZ(3))
 
-        params = np.array([0.4, 0.5, 0.6, 0.7, 0.8], requires_grad=True)
+        params = pnp.array([0.4, 0.5, 0.6, 0.7, 0.8], requires_grad=True)
 
         circuit = qml.QNode(f, dev_original)
         cut_circuit = qcut.cut_circuit(qml.QNode(f, dev_cut), use_opt_einsum=use_opt_einsum)
@@ -4431,8 +4431,8 @@ class TestCutCircuitTransform:
         spy.assert_called_once()
         grad = qml.grad(cut_circuit)(params)
 
-        assert np.isclose(res, res_expected)
-        assert np.allclose(grad, grad_expected)
+        assert pnp.isclose(res, res_expected)
+        assert pnp.allclose(grad, grad_expected)
 
     @pytest.mark.parametrize("shots", [None, int(1e7)])
     def test_standard_circuit(self, mocker, use_opt_einsum, shots, seed):
@@ -4478,7 +4478,7 @@ class TestCutCircuitTransform:
         spy.assert_called_once()
 
         atol = 1e-2 if shots else 1e-8
-        assert np.isclose(res, res_expected, atol=atol)
+        assert pnp.isclose(res, res_expected, atol=atol)
 
 
 class TestCutCircuitTransformValidation:
@@ -4622,7 +4622,7 @@ class TestCutCircuitExpansion:
         spy_tapes.assert_called_once()
         spy_cc.assert_called_once()
 
-        assert np.isclose(res, qnode(template_weights))
+        assert pnp.isclose(res, qnode(template_weights))
 
     def test_expansion_mc_ttn(self, mocker):
         """Test if wire cutting is compatible with the tree tensor network operation"""
@@ -4864,7 +4864,7 @@ def make_weakly_connected_tape(
         fragment_wire_sizes = [3, 5]
     if inter_fragment_gate_wires == "default":
         inter_fragment_gate_wires = {(0, 1): 1}
-    rng = np.random.default_rng(seed)
+    rng = pnp.random.default_rng(seed)
     inter_fragment_gate_wires = inter_fragment_gate_wires or {}
     with qml.queuing.AnnotatedQueue() as q:
         for _ in range(repeats):
@@ -5231,7 +5231,7 @@ class TestAutoCutCircuit:
             qml.CRY(param, wires=[wires[0], wires[1]])
 
         def f(params):
-            qml.BasisState(np.array([1]), wires=[0])
+            qml.BasisState(pnp.array([1]), wires=[0])
 
             qml.CNOT(wires=[0, 1])
             qml.RX(params[0], wires=0)
@@ -5240,14 +5240,14 @@ class TestAutoCutCircuit:
 
             two_qubit_unitary(params[1], wires=[2, 3])
             two_qubit_unitary(params[2] ** 2, wires=[3, 4])
-            two_qubit_unitary(np.sin(params[3]), wires=[3, 2])
-            two_qubit_unitary(np.sqrt(params[4]), wires=[4, 3])
-            two_qubit_unitary(np.cos(params[1]), wires=[3, 2])
+            two_qubit_unitary(pnp.sin(params[3]), wires=[3, 2])
+            two_qubit_unitary(pnp.sqrt(params[4]), wires=[4, 3])
+            two_qubit_unitary(pnp.cos(params[1]), wires=[3, 2])
             qml.CRX(params[2], wires=[4, 1])
 
             return qml.expval(qml.PauliZ(1) @ qml.PauliZ(2) @ qml.PauliZ(3))
 
-        params = np.array([0.4, 0.5, 0.6, 0.7, 0.8], requires_grad=True)
+        params = pnp.array([0.4, 0.5, 0.6, 0.7, 0.8], requires_grad=True)
 
         circuit = qml.QNode(f, dev_original)
         cut_circuit = qcut.cut_circuit(qml.QNode(f, dev_cut), auto_cutter=True, max_depth=max_depth)
@@ -5260,8 +5260,8 @@ class TestAutoCutCircuit:
         spy.assert_called_once()
         grad = qml.grad(cut_circuit)(params)
 
-        assert np.isclose(res, res_expected)
-        assert np.allclose(grad, grad_expected)
+        assert pnp.isclose(res, res_expected)
+        assert pnp.allclose(grad, grad_expected)
 
     @pytest.mark.parametrize("shots", [None])  # using analytic mode only to save time.
     def test_standard_circuit(self, mocker, shots):
@@ -5303,7 +5303,7 @@ class TestAutoCutCircuit:
         spy.assert_called_once()
 
         atol = 1e-2 if shots else 1e-8
-        assert np.isclose(res, res_expected, atol=atol)
+        assert pnp.isclose(res, res_expected, atol=atol)
 
     def test_circuit_with_disconnected_components(self):
         """Tests if a circuit that is fragmented into subcircuits such that some of the subcircuits
@@ -5324,7 +5324,7 @@ class TestAutoCutCircuit:
 
         x = 0.4
         res = circuit(x)
-        assert np.allclose(res, np.cos(x))
+        assert pnp.allclose(res, pnp.cos(x))
 
     def test_circuit_with_trivial_wire_cut(self):
         """Tests that a circuit with a trivial wire cut (not separating the circuit into
@@ -5344,7 +5344,7 @@ class TestAutoCutCircuit:
 
         x = 0.4
         res = circuit(x)
-        assert np.allclose(res, np.cos(x))
+        assert pnp.allclose(res, pnp.cos(x))
 
     def test_cut_circuit_mc_sample(self):
         """
@@ -5478,7 +5478,7 @@ class TestCutCircuitWithHamiltonians:
             qml.CRY(param, wires=[wires[0], wires[1]])
 
         def f(params):
-            qml.BasisState(np.array([1]), wires=[0])
+            qml.BasisState(pnp.array([1]), wires=[0])
             qml.WireCut(wires=0)
 
             qml.CNOT(wires=[0, 1])
@@ -5496,16 +5496,16 @@ class TestCutCircuitWithHamiltonians:
             qml.WireCut(wires=3)
             two_qubit_unitary(params[2] ** 2, wires=[3, 4])
             qml.WireCut(wires=3)
-            two_qubit_unitary(np.sin(params[3]), wires=[3, 2])
+            two_qubit_unitary(pnp.sin(params[3]), wires=[3, 2])
             qml.WireCut(wires=3)
-            two_qubit_unitary(np.sqrt(params[4]), wires=[4, 3])
+            two_qubit_unitary(pnp.sqrt(params[4]), wires=[4, 3])
             qml.WireCut(wires=3)
-            two_qubit_unitary(np.cos(params[1]), wires=[3, 2])
+            two_qubit_unitary(pnp.cos(params[1]), wires=[3, 2])
             qml.CRX(params[2], wires=[4, 1])
 
             return qml.expval(hamiltonian)
 
-        params = np.array([0.4, 0.5, 0.6, 0.7, 0.8], requires_grad=True)
+        params = pnp.array([0.4, 0.5, 0.6, 0.7, 0.8], requires_grad=True)
 
         circuit = qml.QNode(f, dev_original)
         cut_circuit = qcut.cut_circuit(qml.QNode(f, dev_cut))
@@ -5519,8 +5519,8 @@ class TestCutCircuitWithHamiltonians:
 
         grad = qml.grad(cut_circuit)(params)
 
-        assert np.isclose(res, res_expected)
-        assert np.allclose(grad, grad_expected)
+        assert pnp.isclose(res, res_expected)
+        assert pnp.allclose(grad, grad_expected)
 
     def test_autoscale_and_grouped_with_hamiltonian(self, mocker):
         """
@@ -5569,7 +5569,7 @@ class TestCutCircuitWithHamiltonians:
         spy = mocker.spy(qcut.cutcircuit, "qcut_processing_fn")
         res = cut_circuit()
         assert spy.call_count == len(hamiltonian.ops)
-        assert np.isclose(res, res_expected, atol=1e-8)
+        assert pnp.isclose(res, res_expected, atol=1e-8)
         assert cut_circuit.tape.measurements[0].obs.grouping_indices == hamiltonian.grouping_indices
 
     def test_template_with_hamiltonian(self, seed):
@@ -5641,7 +5641,7 @@ class TestCutCircuitWithHamiltonians:
         tape = qml.tape.QuantumScript(circuit, measurements=[qml.expval(H)])
         cut_tapes, proc_fn = qml.cut_circuit(tape, device_wires=range(3))
 
-        assert np.allclose(
+        assert pnp.allclose(
             qml.execute([tape], dev, None)[0], proc_fn(qml.execute(cut_tapes, dev, None))
         )
 

--- a/tests/transforms/test_transpile.py
+++ b/tests/transforms/test_transpile.py
@@ -8,7 +8,7 @@ from math import isclose
 import pytest
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane.transforms.transpile import transpile
 
 
@@ -135,7 +135,7 @@ class TestTranspile:
         transpiled_qnode = qml.QNode(transpiled_qfunc, dev)
         transpiled_expectation = transpiled_qnode(0.1, 0.2, 0.3)
 
-        assert isclose(original_expectation, transpiled_expectation, abs_tol=np.finfo(float).eps)
+        assert isclose(original_expectation, transpiled_expectation, abs_tol=pnp.finfo(float).eps)
 
     def test_transpile_qfunc_transpiled_mmt_probs(self):
         """test that transpile does not alter output for probs measurement"""
@@ -152,7 +152,7 @@ class TestTranspile:
         transpiled_probs = transpiled_qnode(0.1, 0.2, 0.3)
 
         assert all(
-            isclose(po, pt, abs_tol=np.finfo(float).eps)
+            isclose(po, pt, abs_tol=pnp.finfo(float).eps)
             for po, pt in zip(original_probs, transpiled_probs)
         )
 
@@ -170,7 +170,7 @@ class TestTranspile:
 
         transpiled_circ = transpile(circuit, coupling_map=[(0, 1), (1, 2)])
         transpiled_qnode = qml.QNode(transpiled_circ, dev)
-        params = np.array([0.5, 0.1, 0.2], requires_grad=True)
+        params = pnp.array([0.5, 0.1, 0.2], requires_grad=True)
         qml.gradients.param_shift(transpiled_qnode)(params)
 
     def test_more_than_2_qubits_raises_anywires(self):
@@ -247,7 +247,7 @@ class TestTranspile:
         assert transpiled_ops[4].wires == qml.wires.Wires([0, 2])
 
         assert qml.math.allclose(
-            original_expectation, transpiled_expectation, atol=np.finfo(float).eps
+            original_expectation, transpiled_expectation, atol=pnp.finfo(float).eps
         )
 
     def test_transpile_ops_anywires_1_qubit(self):
@@ -290,7 +290,7 @@ class TestTranspile:
         assert transpiled_ops[4].wires == qml.wires.Wires([0, 2])
 
         assert qml.math.allclose(
-            original_expectation, transpiled_expectation, atol=np.finfo(float).eps
+            original_expectation, transpiled_expectation, atol=pnp.finfo(float).eps
         )
 
     def test_transpile_mcm(self):
@@ -327,7 +327,7 @@ class TestTranspile:
         transpiled_expectation = transpiled_qnode(param)
 
         assert qml.math.allclose(
-            original_expectation, transpiled_expectation, atol=np.finfo(float).eps
+            original_expectation, transpiled_expectation, atol=pnp.finfo(float).eps
         )
 
     def test_transpile_state(self):
@@ -353,9 +353,9 @@ class TestTranspile:
         tape = qml.tape.QuantumScript([qml.PauliX(0), qml.CNOT(wires=(0, 2))], [qml.state()])
         batch, fn = qml.transforms.transpile(tape, coupling_map=[(0, 1), (1, 2)], device=dev)
 
-        original_mat = np.arange(8)
+        original_mat = pnp.arange(8)
         new_mat = fn((original_mat,))
-        expected_new_mat = np.swapaxes(np.reshape(original_mat, [2, 2, 2]), 1, 2).flatten()
+        expected_new_mat = pnp.swapaxes(pnp.reshape(original_mat, [2, 2, 2]), 1, 2).flatten()
         assert qml.math.allclose(new_mat, expected_new_mat)
 
         assert batch[0][0] == qml.PauliX(0)
@@ -378,9 +378,9 @@ class TestTranspile:
         )
         batch, fn = qml.transforms.transpile(tape, coupling_map=[(0, 1), (1, 2)], device=dev)
 
-        original_mat = np.arange(8)
+        original_mat = pnp.arange(8)
         new_mat, _ = fn(((original_mat, 2.0),))
-        expected_new_mat = np.swapaxes(np.reshape(original_mat, [2, 2, 2]), 1, 2).flatten()
+        expected_new_mat = pnp.swapaxes(pnp.reshape(original_mat, [2, 2, 2]), 1, 2).flatten()
         assert qml.math.allclose(new_mat, expected_new_mat)
 
         assert batch[0][0] == qml.PauliX(0)

--- a/tests/transforms/test_unitary_to_rot.py
+++ b/tests/transforms/test_unitary_to_rot.py
@@ -22,7 +22,7 @@ from gate_data import H, I, S, T, X, Z
 from test_optimization.utils import check_matrix_equivalence
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane.transforms import unitary_to_rot
 from pennylane.wires import Wires
 
@@ -37,32 +37,32 @@ def suppress_tape_property_deprecation_warning():
 typeof_gates_zyz = (qml.RZ, qml.RY, qml.RZ)
 single_qubit_decompositions = [
     (I, typeof_gates_zyz, [0.0, 0.0, 0.0]),
-    (Z, typeof_gates_zyz, [np.pi / 2, 0.0, np.pi / 2]),
-    (S, typeof_gates_zyz, [np.pi / 4, 0.0, np.pi / 4]),
-    (T, typeof_gates_zyz, [np.pi / 8, 0.0, np.pi / 8]),
-    (H, typeof_gates_zyz, [np.pi, np.pi / 2, 0.0]),
-    (X, typeof_gates_zyz, [np.pi / 2, np.pi, 7 * np.pi / 2]),
+    (Z, typeof_gates_zyz, [pnp.pi / 2, 0.0, pnp.pi / 2]),
+    (S, typeof_gates_zyz, [pnp.pi / 4, 0.0, pnp.pi / 4]),
+    (T, typeof_gates_zyz, [pnp.pi / 8, 0.0, pnp.pi / 8]),
+    (H, typeof_gates_zyz, [pnp.pi, pnp.pi / 2, 0.0]),
+    (X, typeof_gates_zyz, [pnp.pi / 2, pnp.pi, 7 * pnp.pi / 2]),
     (qml.RZ(0.3, wires=0).matrix(), typeof_gates_zyz, [0.15, 0.0, 0.15]),
     (
         qml.RZ(-0.5, wires=0).matrix(),
         typeof_gates_zyz,
-        [4 * np.pi - 0.25, 0.0, 4 * np.pi - 0.25],
+        [4 * pnp.pi - 0.25, 0.0, 4 * pnp.pi - 0.25],
     ),
-    (qml.Rot(0.2, 0.5, -0.3, wires=0).matrix(), typeof_gates_zyz, [0.2, 0.5, 4 * np.pi - 0.3]),
+    (qml.Rot(0.2, 0.5, -0.3, wires=0).matrix(), typeof_gates_zyz, [0.2, 0.5, 4 * pnp.pi - 0.3]),
     (
-        np.array(
+        pnp.array(
             [
                 [0, -9.831019270939975e-01 + 0.1830590094588862j],
                 [9.831019270939975e-01 + 0.1830590094588862j, 0],
             ]
         ),
         typeof_gates_zyz,
-        [12.382273469673908, np.pi, 0.18409714468526417],
+        [12.382273469673908, pnp.pi, 0.18409714468526417],
     ),
     (
-        np.exp(1j * 0.02) * qml.Rot(-1.0, 2.0, -3.0, wires=0).matrix(),
+        pnp.exp(1j * 0.02) * qml.Rot(-1.0, 2.0, -3.0, wires=0).matrix(),
         typeof_gates_zyz,
-        [4 * np.pi - 1.0, 2.0, 4 * np.pi - 3.0],
+        [4 * pnp.pi - 1.0, 2.0, 4 * pnp.pi - 3.0],
     ),
 ]
 
@@ -81,7 +81,7 @@ class TestDecomposeSingleQubitUnitaryTransform:
         """Test for applying the transform on a QNode."""
         dev = qml.device("default.qubit", wires=2)
 
-        U = np.exp(1j * 0.02) * qml.Rot(-1.0, 2.0, -3.0, wires=0).matrix()
+        U = pnp.exp(1j * 0.02) * qml.Rot(-1.0, 2.0, -3.0, wires=0).matrix()
 
         @qml.qnode(device=dev)
         def circuit(U):
@@ -93,7 +93,7 @@ class TestDecomposeSingleQubitUnitaryTransform:
         transformed_qnode = unitary_to_rot(circuit)
         res_trans = transformed_qnode(U)
         res = circuit(U)
-        assert np.allclose(res_trans, res)
+        assert pnp.allclose(res_trans, res)
 
     @pytest.mark.parametrize("U,expected_gates,expected_params", single_qubit_decompositions)
     def test_unitary_to_rot(self, U, expected_gates, expected_params):
@@ -248,8 +248,8 @@ class TestDecomposeSingleQubitUnitaryTransform:
         original_result = original_qnode(U)
         transformed_result = transformed_qnode(U)
         jitted_result = jitted_qnode(U)
-        assert np.allclose(transformed_result, original_result)
-        assert np.allclose(jitted_result, original_result)
+        assert pnp.allclose(transformed_result, original_result)
+        assert pnp.allclose(jitted_result, original_result)
 
 
 # A simple circuit; we will test QubitUnitary on matrices constructed using trainable
@@ -262,7 +262,7 @@ def original_qfunc_for_grad(angles):
     return qml.expval(qml.PauliX(wires="a"))
 
 
-angle_pairs = [[0.3, 0.3], [np.pi, -0.65], [0.0, np.pi / 2], [np.pi / 3, 0.0]]
+angle_pairs = [[0.3, 0.3], [pnp.pi, -0.65], [0.0, pnp.pi / 2], [pnp.pi / 3, 0.0]]
 diff_methods = ["parameter-shift", "backprop"]
 angle_diff_pairs = list(product(angle_pairs, diff_methods))
 
@@ -280,11 +280,11 @@ class TestQubitUnitaryDifferentiability:
             z = angles[0]
             x = angles[1]
 
-            Z_mat = np.array([[np.exp(-1j * z / 2), 0.0], [0.0, np.exp(1j * z / 2)]])
+            Z_mat = pnp.array([[pnp.exp(-1j * z / 2), 0.0], [0.0, pnp.exp(1j * z / 2)]])
 
-            c = np.cos(x / 2)
-            s = np.sin(x / 2) * 1j
-            X_mat = np.array([[c, -s], [-s, c]])
+            c = pnp.cos(x / 2)
+            s = pnp.sin(x / 2) * 1j
+            X_mat = pnp.array([[c, -s], [-s, c]])
 
             qml.Hadamard(wires="a")
             qml.QubitUnitary(Z_mat, wires="a")
@@ -299,7 +299,7 @@ class TestQubitUnitaryDifferentiability:
         transformed_qfunc = unitary_to_rot(qfunc_with_qubit_unitary)
         transformed_qnode = qml.QNode(transformed_qfunc, dev, diff_method=diff_method)
 
-        angles = np.array(rot_angles, requires_grad=True)
+        angles = pnp.array(rot_angles, requires_grad=True)
         assert qml.math.allclose(original_qnode(angles), transformed_qnode(angles), atol=1e-7)
 
         original_grad = qml.grad(original_qnode)(angles)
@@ -447,8 +447,8 @@ class TestQubitUnitaryDifferentiability:
         # Check that we can also JIT
         grad_of_jit = jax.grad(jax.jit(transformed_qnode))(angles)
         jit_of_grad = jax.jit(jax.grad(transformed_qnode))(angles)
-        assert np.allclose(original_grad, jit_of_grad, atol=1e-7)
-        assert np.allclose(original_grad, grad_of_jit, atol=1e-7)
+        assert pnp.allclose(original_grad, jit_of_grad, atol=1e-7)
+        assert pnp.allclose(original_grad, grad_of_jit, atol=1e-7)
 
 
 test_two_qubit_unitaries = [
@@ -515,7 +515,7 @@ def test_unitary_to_rot_multiple_two_qubit(num_reps):
 
     dev = qml.device("default.qubit", wires=2)
 
-    U = np.array(test_two_qubit_unitaries[1], dtype=np.complex128)
+    U = pnp.array(test_two_qubit_unitaries[1], dtype=pnp.complex128)
 
     def my_circuit():
         for _ in range(num_reps):
@@ -544,8 +544,8 @@ class TestTwoQubitUnitaryDifferentiability:
     @pytest.mark.parametrize("diff_method", ["parameter-shift", "backprop"])
     def test_gradient_unitary_to_rot_two_qubit(self, diff_method):
         """Tests differentiability in autograd interface."""
-        U0 = np.array(test_two_qubit_unitaries[0], requires_grad=False, dtype=np.complex128)
-        U1 = np.array(test_two_qubit_unitaries[1], requires_grad=False, dtype=np.complex128)
+        U0 = pnp.array(test_two_qubit_unitaries[0], requires_grad=False, dtype=pnp.complex128)
+        U1 = pnp.array(test_two_qubit_unitaries[1], requires_grad=False, dtype=pnp.complex128)
 
         def two_qubit_decomp_qnode(x, y, z):
             qml.RX(x, wires=0)
@@ -555,9 +555,9 @@ class TestTwoQubitUnitaryDifferentiability:
             qml.QubitUnitary(U1, wires=[1, 2])
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1) @ qml.PauliZ(2))
 
-        x = np.array(0.1, requires_grad=True)
-        y = np.array(0.2, requires_grad=True)
-        z = np.array(0.3, requires_grad=True)
+        x = pnp.array(0.1, requires_grad=True)
+        y = pnp.array(0.2, requires_grad=True)
+        z = pnp.array(0.3, requires_grad=True)
 
         dev = qml.device("default.qubit", wires=3)
 

--- a/tests/workflow/interfaces/qnode/test_autograd_qnode.py
+++ b/tests/workflow/interfaces/qnode/test_autograd_qnode.py
@@ -22,7 +22,7 @@ import pytest
 from param_shift_dev import ParamShiftDerivativesDevice
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane import qnode
 from pennylane.devices import DefaultQubit
 
@@ -103,12 +103,12 @@ class TestQNode:
             qml.RX(0.2, wires=0)
             return qml.expval(qml.PauliZ(0))
 
-        a = np.array(0.1, requires_grad=True)
+        a = pnp.array(0.1, requires_grad=True)
 
         res = circuit(a)
 
         # without the interface, the QNode simply returns a scalar array or float
-        assert isinstance(res, (np.ndarray, float))
+        assert isinstance(res, (pnp.ndarray, float))
         assert qml.math.shape(res) == tuple()  # pylint: disable=comparison-with-callable
 
     def test_execution_with_interface(
@@ -130,7 +130,7 @@ class TestQNode:
             qml.RX(0.2, wires=0)
             return qml.expval(qml.PauliZ(0))
 
-        a = np.array(0.1, requires_grad=True)
+        a = pnp.array(0.1, requires_grad=True)
         assert circuit.interface == interface
         # gradients should work
         grad = qml.grad(circuit)(a)
@@ -147,11 +147,11 @@ class TestQNode:
         )
 
         if diff_method == "spsa":
-            kwargs["sampler_rng"] = np.random.default_rng(seed)
+            kwargs["sampler_rng"] = pnp.random.default_rng(seed)
             tol = TOL_FOR_SPSA
 
-        a = np.array(0.1, requires_grad=True)
-        b = np.array(0.2, requires_grad=True)
+        a = pnp.array(0.1, requires_grad=True)
+        b = pnp.array(0.2, requires_grad=True)
 
         @qnode(dev, **kwargs)
         def circuit(a, b):
@@ -169,19 +169,19 @@ class TestQNode:
         assert isinstance(res, tuple)
         assert len(res) == 2
 
-        expected = [np.cos(a), -np.cos(a) * np.sin(b)]
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        expected = [pnp.cos(a), -pnp.cos(a) * pnp.sin(b)]
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
         res = qml.jacobian(cost)(a, b)
         assert isinstance(res, tuple) and len(res) == 2
-        expected = ([-np.sin(a), np.sin(a) * np.sin(b)], [0, -np.cos(a) * np.cos(b)])
-        assert isinstance(res[0], np.ndarray)
+        expected = ([-pnp.sin(a), pnp.sin(a) * pnp.sin(b)], [0, -pnp.cos(a) * pnp.cos(b)])
+        assert isinstance(res[0], pnp.ndarray)
         assert res[0].shape == (2,)
-        assert np.allclose(res[0], expected[0], atol=tol, rtol=0)
+        assert pnp.allclose(res[0], expected[0], atol=tol, rtol=0)
 
-        assert isinstance(res[1], np.ndarray)
+        assert isinstance(res[1], pnp.ndarray)
         assert res[1].shape == (2,)
-        assert np.allclose(res[1], expected[1], atol=tol, rtol=0)
+        assert pnp.allclose(res[1], expected[1], atol=tol, rtol=0)
 
     def test_jacobian_no_evaluate(
         self, interface, dev, diff_method, grad_on_execution, tol, device_vjp, seed
@@ -194,11 +194,11 @@ class TestQNode:
             device_vjp=device_vjp,
         )
         if diff_method == "spsa":
-            kwargs["sampler_rng"] = np.random.default_rng(seed)
+            kwargs["sampler_rng"] = pnp.random.default_rng(seed)
             tol = TOL_FOR_SPSA
 
-        a = np.array(0.1, requires_grad=True)
-        b = np.array(0.2, requires_grad=True)
+        a = pnp.array(0.1, requires_grad=True)
+        b = pnp.array(0.2, requires_grad=True)
 
         @qnode(dev, **kwargs)
         def circuit(a, b):
@@ -212,25 +212,25 @@ class TestQNode:
 
         jac_fn = qml.jacobian(cost)
         res = jac_fn(a, b)
-        expected = ([-np.sin(a), np.sin(a) * np.sin(b)], [0, -np.cos(a) * np.cos(b)])
-        assert np.allclose(res[0], expected[0], atol=tol, rtol=0)
-        assert np.allclose(res[1], expected[1], atol=tol, rtol=0)
+        expected = ([-pnp.sin(a), pnp.sin(a) * pnp.sin(b)], [0, -pnp.cos(a) * pnp.cos(b)])
+        assert pnp.allclose(res[0], expected[0], atol=tol, rtol=0)
+        assert pnp.allclose(res[1], expected[1], atol=tol, rtol=0)
 
         # call the Jacobian with new parameters
-        a = np.array(0.6, requires_grad=True)
-        b = np.array(0.832, requires_grad=True)
+        a = pnp.array(0.6, requires_grad=True)
+        b = pnp.array(0.832, requires_grad=True)
 
         res = jac_fn(a, b)
-        expected = ([-np.sin(a), np.sin(a) * np.sin(b)], [0, -np.cos(a) * np.cos(b)])
-        assert np.allclose(res[0], expected[0], atol=tol, rtol=0)
-        assert np.allclose(res[1], expected[1], atol=tol, rtol=0)
+        expected = ([-pnp.sin(a), pnp.sin(a) * pnp.sin(b)], [0, -pnp.cos(a) * pnp.cos(b)])
+        assert pnp.allclose(res[0], expected[0], atol=tol, rtol=0)
+        assert pnp.allclose(res[1], expected[1], atol=tol, rtol=0)
 
     def test_jacobian_options(self, interface, dev, diff_method, grad_on_execution, device_vjp):
         """Test setting jacobian options"""
         if diff_method != "finite-diff":
             pytest.skip("Test only supports finite diff.")
 
-        a = np.array([0.1, 0.2], requires_grad=True)
+        a = pnp.array([0.1, 0.2], requires_grad=True)
 
         @qnode(
             dev,
@@ -255,8 +255,8 @@ class TestQNode:
         if diff_method != "parameter-shift":
             pytest.skip("Test only supports parameter-shift")
 
-        a = np.array(0.1, requires_grad=True)
-        b = np.array(0.2, requires_grad=True)
+        a = pnp.array(0.1, requires_grad=True)
+        b = pnp.array(0.2, requires_grad=True)
 
         @qnode(
             dev,
@@ -272,7 +272,7 @@ class TestQNode:
             return qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliY(1))
 
         def loss(a, b):
-            return np.sum(autograd.numpy.hstack(circuit(a, b)))
+            return pnp.sum(autograd.numpy.hstack(circuit(a, b)))
 
         grad_fn = qml.grad(loss)
         res = grad_fn(a, b)
@@ -280,32 +280,32 @@ class TestQNode:
         # the tape has reported both arguments as trainable
         assert circuit.qtape.trainable_params == [0, 1]
 
-        expected = [-np.sin(a) + np.sin(a) * np.sin(b), -np.cos(a) * np.cos(b)]
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        expected = [-pnp.sin(a) + pnp.sin(a) * pnp.sin(b), -pnp.cos(a) * pnp.cos(b)]
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
         # make the second QNode argument a constant
-        a = np.array(0.54, requires_grad=True)
-        b = np.array(0.8, requires_grad=False)
+        a = pnp.array(0.54, requires_grad=True)
+        b = pnp.array(0.8, requires_grad=False)
 
         res = grad_fn(a, b)
 
         # the tape has reported only the first argument as trainable
         assert circuit.qtape.trainable_params == [0]
 
-        expected = [-np.sin(a) + np.sin(a) * np.sin(b)]
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        expected = [-pnp.sin(a) + pnp.sin(a) * pnp.sin(b)]
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
         # trainability also updates on evaluation
-        a = np.array(0.54, requires_grad=False)
-        b = np.array(0.8, requires_grad=True)
+        a = pnp.array(0.54, requires_grad=False)
+        b = pnp.array(0.8, requires_grad=True)
         circuit(a, b)
         assert circuit.qtape.trainable_params == [1]
 
     def test_classical_processing(self, interface, dev, diff_method, grad_on_execution, device_vjp):
         """Test classical processing within the quantum tape"""
-        a = np.array(0.1, requires_grad=True)
-        b = np.array(0.2, requires_grad=False)
-        c = np.array(0.3, requires_grad=True)
+        a = pnp.array(0.1, requires_grad=True)
+        b = pnp.array(0.2, requires_grad=False)
+        c = pnp.array(0.3, requires_grad=True)
 
         @qnode(
             dev,
@@ -317,14 +317,14 @@ class TestQNode:
         def circuit(a, b, c):
             qml.RY(a * c, wires=0)
             qml.RZ(b, wires=0)
-            qml.RX(c + c**2 + np.sin(a), wires=0)
+            qml.RX(c + c**2 + pnp.sin(a), wires=0)
             return qml.expval(qml.PauliZ(0))
 
         res = qml.jacobian(circuit)(a, b, c)
 
         assert circuit.qtape.trainable_params == [0, 2]
-        tape_params = np.array(circuit.qtape.get_parameters())
-        assert np.all(tape_params == [a * c, c + c**2 + np.sin(a)])
+        tape_params = pnp.array(circuit.qtape.get_parameters())
+        assert pnp.all(tape_params == [a * c, c + c**2 + pnp.sin(a)])
 
         assert isinstance(res, tuple) and len(res) == 2
         assert res[0].shape == ()
@@ -348,8 +348,8 @@ class TestQNode:
             qml.CNOT(wires=[0, 1])
             return qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliZ(1))
 
-        a = np.array(0.1, requires_grad=False)
-        b = np.array(0.2, requires_grad=False)
+        a = pnp.array(0.1, requires_grad=False)
+        b = pnp.array(0.2, requires_grad=False)
 
         res = circuit(a, b)
 
@@ -366,7 +366,7 @@ class TestQNode:
             assert not qml.jacobian(cost)(a, b)
 
         def cost2(a, b):
-            return np.sum(circuit(a, b))
+            return pnp.sum(circuit(a, b))
 
         with pytest.warns(UserWarning, match="Attempted to differentiate a function with no"):
             grad = qml.grad(cost2)(a, b)
@@ -378,8 +378,8 @@ class TestQNode:
     ):
         """Test that the autograd interface works correctly
         with a matrix parameter"""
-        U = np.array([[0, 1], [1, 0]], requires_grad=False)
-        a = np.array(0.1, requires_grad=True)
+        U = pnp.array([[0, 1], [1, 0]], requires_grad=False)
+        a = pnp.array(0.1, requires_grad=True)
 
         @qnode(
             dev,
@@ -399,7 +399,7 @@ class TestQNode:
             assert circuit.qtape.trainable_params == [1]
 
         res = qml.grad(circuit)(U, a)
-        assert np.allclose(res, np.sin(a), atol=tol, rtol=0)
+        assert pnp.allclose(res, pnp.sin(a), atol=tol, rtol=0)
 
     def test_gradient_non_differentiable_exception(
         self, interface, dev, diff_method, grad_on_execution, device_vjp
@@ -419,7 +419,7 @@ class TestQNode:
             return qml.expval(qml.PauliZ(0))
 
         grad_fn = qml.grad(circuit, argnum=0)
-        data1 = np.array([0, 1, 1, 0], requires_grad=False) / np.sqrt(2)
+        data1 = pnp.array([0, 1, 1, 0], requires_grad=False) / pnp.sqrt(2)
 
         with pytest.raises(qml.numpy.NonDifferentiableError, match="is non-differentiable"):
             grad_fn(data1)
@@ -437,7 +437,7 @@ class TestQNode:
         )
 
         if diff_method == "spsa":
-            kwargs["sampler_rng"] = np.random.default_rng(seed)
+            kwargs["sampler_rng"] = pnp.random.default_rng(seed)
             kwargs["num_directions"] = 10
             tol = TOL_FOR_SPSA
 
@@ -453,8 +453,8 @@ class TestQNode:
                     qml.PhaseShift(phi + lam, wires=wires),
                 ]
 
-        a = np.array(0.1, requires_grad=False)
-        p = np.array([0.1, 0.2, 0.3], requires_grad=True)
+        a = pnp.array(0.1, requires_grad=False)
+        p = pnp.array([0.1, 0.2, 0.3], requires_grad=True)
 
         @qnode(dev, **kwargs)
         def circuit(a, p):
@@ -463,29 +463,29 @@ class TestQNode:
             return qml.expval(qml.PauliX(0))
 
         res = circuit(a, p)
-        expected = np.cos(a) * np.cos(p[1]) * np.sin(p[0]) + np.sin(a) * (
-            np.cos(p[2]) * np.sin(p[1]) + np.cos(p[0]) * np.cos(p[1]) * np.sin(p[2])
+        expected = pnp.cos(a) * pnp.cos(p[1]) * pnp.sin(p[0]) + pnp.sin(a) * (
+            pnp.cos(p[2]) * pnp.sin(p[1]) + pnp.cos(p[0]) * pnp.cos(p[1]) * pnp.sin(p[2])
         )
         # assert isinstance(res, np.ndarray)
         # assert res.shape == ()
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
         res = qml.grad(circuit)(a, p)
 
         # assert isinstance(res, np.ndarray)
         # assert len(res) == 3
 
-        expected = np.array(
+        expected = pnp.array(
             [
-                np.cos(p[1]) * (np.cos(a) * np.cos(p[0]) - np.sin(a) * np.sin(p[0]) * np.sin(p[2])),
-                np.cos(p[1]) * np.cos(p[2]) * np.sin(a)
-                - np.sin(p[1])
-                * (np.cos(a) * np.sin(p[0]) + np.cos(p[0]) * np.sin(a) * np.sin(p[2])),
-                np.sin(a)
-                * (np.cos(p[0]) * np.cos(p[1]) * np.cos(p[2]) - np.sin(p[1]) * np.sin(p[2])),
+                pnp.cos(p[1]) * (pnp.cos(a) * pnp.cos(p[0]) - pnp.sin(a) * pnp.sin(p[0]) * pnp.sin(p[2])),
+                pnp.cos(p[1]) * pnp.cos(p[2]) * pnp.sin(a)
+                - pnp.sin(p[1])
+                * (pnp.cos(a) * pnp.sin(p[0]) + pnp.cos(p[0]) * pnp.sin(a) * pnp.sin(p[2])),
+                pnp.sin(a)
+                * (pnp.cos(p[0]) * pnp.cos(p[1]) * pnp.cos(p[2]) - pnp.sin(p[1]) * pnp.sin(p[2])),
             ]
         )
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
 
 class TestShotsIntegration:
@@ -495,7 +495,7 @@ class TestShotsIntegration:
     def test_changing_shots(self):
         """Test that changing shots works on execution"""
         dev = DefaultQubit()
-        a, b = np.array([0.543, -0.654], requires_grad=True)
+        a, b = pnp.array([0.543, -0.654], requires_grad=True)
 
         @qnode(dev, diff_method=qml.gradients.param_shift)
         def circuit(a, b):
@@ -517,7 +517,7 @@ class TestShotsIntegration:
         """Test that temporarily setting the shots works
         for gradient computations"""
         dev = DefaultQubit()
-        a, b = np.array([0.543, -0.654], requires_grad=True)
+        a, b = pnp.array([0.543, -0.654], requires_grad=True)
 
         @qnode(dev, diff_method=qml.gradients.param_shift)
         def cost_fn(a, b):
@@ -532,14 +532,14 @@ class TestShotsIntegration:
         assert isinstance(res, tuple) and len(res) == 2
         assert all(r.shape == (3,) for r in res)
 
-        expected = [np.sin(a) * np.sin(b), -np.cos(a) * np.cos(b)]
+        expected = [pnp.sin(a) * pnp.sin(b), -pnp.cos(a) * pnp.cos(b)]
         assert all(
-            np.allclose(np.mean(r, axis=0), e, atol=0.1, rtol=0) for r, e in zip(res, expected)
+            pnp.allclose(pnp.mean(r, axis=0), e, atol=0.1, rtol=0) for r, e in zip(res, expected)
         )
 
     def test_update_diff_method(self, mocker):
         """Test that temporarily setting the shots updates the diff method"""
-        a, b = np.array([0.543, -0.654], requires_grad=True)
+        a, b = pnp.array([0.543, -0.654], requires_grad=True)
 
         spy = mocker.spy(qml, "execute")
 
@@ -585,11 +585,11 @@ class TestQubitIntegration:
         )
 
         if diff_method == "spsa":
-            kwargs["sampler_rng"] = np.random.default_rng(seed)
+            kwargs["sampler_rng"] = pnp.random.default_rng(seed)
             tol = TOL_FOR_SPSA
 
-        x = np.array(0.543, requires_grad=True)
-        y = np.array(-0.654, requires_grad=True)
+        x = pnp.array(0.543, requires_grad=True)
+        y = pnp.array(-0.654, requires_grad=True)
 
         @qnode(dev, **kwargs)
         def circuit(x, y):
@@ -602,10 +602,10 @@ class TestQubitIntegration:
         assert isinstance(res, tuple) and len(res) == 2
 
         expected = (
-            np.array([-np.sin(x) * np.cos(y) / 2, np.cos(y) * np.sin(x) / 2]),
-            np.array([-np.cos(x) * np.sin(y) / 2, np.cos(x) * np.sin(y) / 2]),
+            pnp.array([-pnp.sin(x) * pnp.cos(y) / 2, pnp.cos(y) * pnp.sin(x) / 2]),
+            pnp.array([-pnp.cos(x) * pnp.sin(y) / 2, pnp.cos(x) * pnp.sin(y) / 2]),
         )
-        assert all(np.allclose(r, e, atol=tol, rtol=0) for r, e in zip(res, expected))
+        assert all(pnp.allclose(r, e, atol=tol, rtol=0) for r, e in zip(res, expected))
 
     def test_multiple_probability_differentiation(
         self, interface, dev, diff_method, grad_on_execution, device_vjp, tol, seed
@@ -622,11 +622,11 @@ class TestQubitIntegration:
         )
 
         if diff_method == "spsa":
-            kwargs["sampler_rng"] = np.random.default_rng(seed)
+            kwargs["sampler_rng"] = pnp.random.default_rng(seed)
             tol = TOL_FOR_SPSA
 
-        x = np.array(0.543, requires_grad=True)
-        y = np.array(-0.654, requires_grad=True)
+        x = pnp.array(0.543, requires_grad=True)
+        y = pnp.array(-0.654, requires_grad=True)
 
         @qnode(dev, **kwargs)
         def circuit(x, y):
@@ -637,13 +637,13 @@ class TestQubitIntegration:
 
         res = circuit(x, y)
 
-        expected = np.array(
+        expected = pnp.array(
             [
-                [np.cos(x / 2) ** 2, np.sin(x / 2) ** 2],
-                [(1 + np.cos(x) * np.cos(y)) / 2, (1 - np.cos(x) * np.cos(y)) / 2],
+                [pnp.cos(x / 2) ** 2, pnp.sin(x / 2) ** 2],
+                [(1 + pnp.cos(x) * pnp.cos(y)) / 2, (1 - pnp.cos(x) * pnp.cos(y)) / 2],
             ]
         )
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
         def cost(x, y):
             return autograd.numpy.hstack(circuit(x, y))
@@ -655,23 +655,23 @@ class TestQubitIntegration:
         assert res[1].shape == (4,)
 
         expected = (
-            np.array(
+            pnp.array(
                 [
                     [
-                        -np.sin(x) / 2,
-                        np.sin(x) / 2,
-                        -np.sin(x) * np.cos(y) / 2,
-                        np.sin(x) * np.cos(y) / 2,
+                        -pnp.sin(x) / 2,
+                        pnp.sin(x) / 2,
+                        -pnp.sin(x) * pnp.cos(y) / 2,
+                        pnp.sin(x) * pnp.cos(y) / 2,
                     ],
                 ]
             ),
-            np.array(
+            pnp.array(
                 [
-                    [0, 0, -np.cos(x) * np.sin(y) / 2, np.cos(x) * np.sin(y) / 2],
+                    [0, 0, -pnp.cos(x) * pnp.sin(y) / 2, pnp.cos(x) * pnp.sin(y) / 2],
                 ]
             ),
         )
-        assert all(np.allclose(r, e, atol=tol, rtol=0) for r, e in zip(res, expected))
+        assert all(pnp.allclose(r, e, atol=tol, rtol=0) for r, e in zip(res, expected))
 
     def test_ragged_differentiation(
         self, interface, dev, diff_method, grad_on_execution, device_vjp, tol, seed
@@ -689,11 +689,11 @@ class TestQubitIntegration:
         )
 
         if diff_method == "spsa":
-            kwargs["sampler_rng"] = np.random.default_rng(seed)
+            kwargs["sampler_rng"] = pnp.random.default_rng(seed)
             tol = TOL_FOR_SPSA
 
-        x = np.array(0.543, requires_grad=True)
-        y = np.array(-0.654, requires_grad=True)
+        x = pnp.array(0.543, requires_grad=True)
+        y = pnp.array(-0.654, requires_grad=True)
 
         @qnode(dev, **kwargs)
         def circuit(x, y):
@@ -704,9 +704,9 @@ class TestQubitIntegration:
 
         res = circuit(x, y)
         assert isinstance(res, tuple)
-        expected = [np.cos(x), [(1 + np.cos(x) * np.cos(y)) / 2, (1 - np.cos(x) * np.cos(y)) / 2]]
-        assert np.allclose(res[0], expected[0], atol=tol, rtol=0)
-        assert np.allclose(res[1], expected[1], atol=tol, rtol=0)
+        expected = [pnp.cos(x), [(1 + pnp.cos(x) * pnp.cos(y)) / 2, (1 - pnp.cos(x) * pnp.cos(y)) / 2]]
+        assert pnp.allclose(res[0], expected[0], atol=tol, rtol=0)
+        assert pnp.allclose(res[1], expected[1], atol=tol, rtol=0)
 
         def cost(x, y):
             return autograd.numpy.hstack(circuit(x, y))
@@ -719,11 +719,11 @@ class TestQubitIntegration:
         assert res[1].shape == (3,)
 
         expected = (
-            np.array([-np.sin(x), -np.sin(x) * np.cos(y) / 2, np.sin(x) * np.cos(y) / 2]),
-            np.array([0, -np.cos(x) * np.sin(y) / 2, np.cos(x) * np.sin(y) / 2]),
+            pnp.array([-pnp.sin(x), -pnp.sin(x) * pnp.cos(y) / 2, pnp.sin(x) * pnp.cos(y) / 2]),
+            pnp.array([0, -pnp.cos(x) * pnp.sin(y) / 2, pnp.cos(x) * pnp.sin(y) / 2]),
         )
-        assert np.allclose(res[0], expected[0], atol=tol, rtol=0)
-        assert np.allclose(res[1], expected[1], atol=tol, rtol=0)
+        assert pnp.allclose(res[0], expected[0], atol=tol, rtol=0)
+        assert pnp.allclose(res[1], expected[1], atol=tol, rtol=0)
 
     def test_ragged_differentiation_variance(
         self, interface, dev, diff_method, grad_on_execution, device_vjp, tol, seed
@@ -740,13 +740,13 @@ class TestQubitIntegration:
         )
 
         if diff_method == "spsa":
-            kwargs["sampler_rng"] = np.random.default_rng(seed)
+            kwargs["sampler_rng"] = pnp.random.default_rng(seed)
             tol = TOL_FOR_SPSA
         elif diff_method == "hadamard":
             pytest.skip("Hadamard gradient does not support variances.")
 
-        x = np.array(0.543, requires_grad=True)
-        y = np.array(-0.654, requires_grad=True)
+        x = pnp.array(0.543, requires_grad=True)
+        y = pnp.array(-0.654, requires_grad=True)
 
         @qnode(dev, **kwargs)
         def circuit(x, y):
@@ -757,9 +757,9 @@ class TestQubitIntegration:
 
         res = circuit(x, y)
 
-        expected_var = np.array(np.sin(x) ** 2)
-        expected_probs = np.array(
-            [(1 + np.cos(x) * np.cos(y)) / 2, (1 - np.cos(x) * np.cos(y)) / 2]
+        expected_var = pnp.array(pnp.sin(x) ** 2)
+        expected_probs = pnp.array(
+            [(1 + pnp.cos(x) * pnp.cos(y)) / 2, (1 - pnp.cos(x) * pnp.cos(y)) / 2]
         )
 
         assert isinstance(res, tuple)
@@ -767,11 +767,11 @@ class TestQubitIntegration:
 
         # assert isinstance(res[0], np.ndarray)
         # assert res[0].shape == ()
-        assert np.allclose(res[0], expected_var, atol=tol, rtol=0)
+        assert pnp.allclose(res[0], expected_var, atol=tol, rtol=0)
 
         # assert isinstance(res[1], np.ndarray)
         # assert res[1].shape == (2,)
-        assert np.allclose(res[1], expected_probs, atol=tol, rtol=0)
+        assert pnp.allclose(res[1], expected_probs, atol=tol, rtol=0)
 
         def cost(x, y):
             return autograd.numpy.hstack(circuit(x, y))
@@ -780,8 +780,8 @@ class TestQubitIntegration:
         assert isinstance(res, tuple) and len(res) == 2
 
         expected = (
-            np.array([np.sin(2 * x), -np.sin(x) * np.cos(y) / 2, np.sin(x) * np.cos(y) / 2]),
-            np.array([0, -np.cos(x) * np.sin(y) / 2, np.cos(x) * np.sin(y) / 2]),
+            pnp.array([pnp.sin(2 * x), -pnp.sin(x) * pnp.cos(y) / 2, pnp.sin(x) * pnp.cos(y) / 2]),
+            pnp.array([0, -pnp.cos(x) * pnp.sin(y) / 2, pnp.cos(x) * pnp.sin(y) / 2]),
         )
 
         assert isinstance(jac, tuple)
@@ -789,11 +789,11 @@ class TestQubitIntegration:
 
         # assert isinstance(jac[0], np.ndarray)
         # assert jac[0].shape == (3,)
-        assert np.allclose(jac[0], expected[0], atol=tol, rtol=0)
+        assert pnp.allclose(jac[0], expected[0], atol=tol, rtol=0)
 
         # assert isinstance(jac[1], np.ndarray)
         # assert jac[1].shape == (3,)
-        assert np.allclose(jac[1], expected[1], atol=tol, rtol=0)
+        assert pnp.allclose(jac[1], expected[1], atol=tol, rtol=0)
 
     def test_chained_qnodes(self, interface, dev, diff_method, grad_on_execution, device_vjp):
         """Test that the gradient of chained QNodes works without error"""
@@ -827,14 +827,14 @@ class TestQubitIntegration:
         def cost(w1, w2):
             c1 = circuit1(w1)
             c2 = circuit2(c1, w2)
-            return np.sum(c2) ** 2
+            return pnp.sum(c2) ** 2
 
         w1 = qml.templates.StronglyEntanglingLayers.shape(n_wires=2, n_layers=3)
         w2 = qml.templates.StronglyEntanglingLayers.shape(n_wires=2, n_layers=4)
 
         weights = [
-            np.random.random(w1, requires_grad=True),
-            np.random.random(w2, requires_grad=True),
+            pnp.random.random(w1, requires_grad=True),
+            pnp.random.random(w2, requires_grad=True),
         ]
 
         grad_fn = qml.grad(cost)
@@ -855,7 +855,7 @@ class TestQubitIntegration:
         )
 
         if diff_method == "spsa":
-            kwargs["sampler_rng"] = np.random.default_rng(seed)
+            kwargs["sampler_rng"] = pnp.random.default_rng(seed)
             tol = TOL_FOR_SPSA
         dev1 = qml.device("default.qubit")
 
@@ -888,12 +888,12 @@ class TestQubitIntegration:
         grad_fn = qml.grad(cost)
 
         # Set the first parameter of circuit1 as non-differentiable.
-        a = np.array(0.4, requires_grad=False)
+        a = pnp.array(0.4, requires_grad=False)
 
         # The remaining free parameters are all differentiable.
-        b = np.array(0.5, requires_grad=True)
-        c = np.array(0.1, requires_grad=True)
-        weights = np.array([0.2, 0.3], requires_grad=True)
+        b = pnp.array(0.5, requires_grad=True)
+        c = pnp.array(0.1, requires_grad=True)
+        weights = pnp.array([0.2, 0.3], requires_grad=True)
 
         res = grad_fn(a, b, c, weights)
 
@@ -904,26 +904,26 @@ class TestQubitIntegration:
         assert res[1].shape == tuple()  # scalar
         assert res[2].shape == (2,)  # vector
 
-        cacbsc = np.cos(a) * np.cos(b) * np.sin(c)
+        cacbsc = pnp.cos(a) * pnp.cos(b) * pnp.sin(c)
 
-        expected = np.array(
+        expected = pnp.array(
             [
                 # analytic expression for dcost/db
-                -np.cos(a)
-                * np.sin(b)
-                * np.sin(c)
-                * np.cos(cacbsc)
-                * np.sin(weights[0])
-                * np.sin(np.cos(a)),
+                -pnp.cos(a)
+                * pnp.sin(b)
+                * pnp.sin(c)
+                * pnp.cos(cacbsc)
+                * pnp.sin(weights[0])
+                * pnp.sin(pnp.cos(a)),
                 # analytic expression for dcost/dc
-                np.cos(a)
-                * np.cos(b)
-                * np.cos(c)
-                * np.cos(cacbsc)
-                * np.sin(weights[0])
-                * np.sin(np.cos(a)),
+                pnp.cos(a)
+                * pnp.cos(b)
+                * pnp.cos(c)
+                * pnp.cos(cacbsc)
+                * pnp.sin(weights[0])
+                * pnp.sin(pnp.cos(a)),
                 # analytic expression for dcost/dw[0]
-                np.sin(cacbsc) * np.cos(weights[0]) * np.sin(np.cos(a)),
+                pnp.sin(cacbsc) * pnp.cos(weights[0]) * pnp.sin(pnp.cos(a)),
                 # analytic expression for dcost/dw[1]
                 0,
             ]
@@ -931,7 +931,7 @@ class TestQubitIntegration:
 
         # np.hstack 'flattens' the ragged gradient array allowing it
         # to be compared with the expected result
-        assert np.allclose(np.hstack(res), expected, atol=tol, rtol=0)
+        assert pnp.allclose(pnp.hstack(res), expected, atol=tol, rtol=0)
 
         if diff_method != "backprop":
             # Check that the gradient was computed
@@ -962,28 +962,28 @@ class TestQubitIntegration:
             qml.RX(x[1], wires=0)
             return qml.expval(qml.PauliZ(0))
 
-        x = np.array([1.0, 2.0], requires_grad=True)
+        x = pnp.array([1.0, 2.0], requires_grad=True)
         res = circuit(x)
         g = qml.grad(circuit)(x)
-        g2 = qml.grad(lambda x: np.sum(qml.grad(circuit)(x)))(x)
+        g2 = qml.grad(lambda x: pnp.sum(qml.grad(circuit)(x)))(x)
 
         a, b = x
 
-        expected_res = np.cos(a) * np.cos(b)
-        assert np.allclose(res, expected_res, atol=tol, rtol=0)
+        expected_res = pnp.cos(a) * pnp.cos(b)
+        assert pnp.allclose(res, expected_res, atol=tol, rtol=0)
 
-        expected_g = [-np.sin(a) * np.cos(b), -np.cos(a) * np.sin(b)]
-        assert np.allclose(g, expected_g, atol=tol, rtol=0)
+        expected_g = [-pnp.sin(a) * pnp.cos(b), -pnp.cos(a) * pnp.sin(b)]
+        assert pnp.allclose(g, expected_g, atol=tol, rtol=0)
 
         expected_g2 = [
-            -np.cos(a) * np.cos(b) + np.sin(a) * np.sin(b),
-            np.sin(a) * np.sin(b) - np.cos(a) * np.cos(b),
+            -pnp.cos(a) * pnp.cos(b) + pnp.sin(a) * pnp.sin(b),
+            pnp.sin(a) * pnp.sin(b) - pnp.cos(a) * pnp.cos(b),
         ]
 
         if diff_method in {"finite-diff"}:
             tol = 10e-2
 
-        assert np.allclose(g2, expected_g2, atol=tol, rtol=0)
+        assert pnp.allclose(g2, expected_g2, atol=tol, rtol=0)
 
     def test_hessian(self, interface, dev, diff_method, grad_on_execution, device_vjp, tol):
         """Test hessian calculation of a scalar valued QNode"""
@@ -1003,40 +1003,40 @@ class TestQubitIntegration:
             qml.RX(x[1], wires=0)
             return qml.expval(qml.PauliZ(0))
 
-        x = np.array([1.0, 2.0], requires_grad=True)
+        x = pnp.array([1.0, 2.0], requires_grad=True)
         res = circuit(x)
 
         a, b = x
 
-        expected_res = np.cos(a) * np.cos(b)
+        expected_res = pnp.cos(a) * pnp.cos(b)
 
         # assert isinstance(res, np.ndarray)
         # assert res.shape == ()
-        assert np.allclose(res, expected_res, atol=tol, rtol=0)
+        assert pnp.allclose(res, expected_res, atol=tol, rtol=0)
 
         grad_fn = qml.grad(circuit)
         g = grad_fn(x)
 
-        expected_g = [-np.sin(a) * np.cos(b), -np.cos(a) * np.sin(b)]
+        expected_g = [-pnp.sin(a) * pnp.cos(b), -pnp.cos(a) * pnp.sin(b)]
 
-        assert isinstance(g, np.ndarray)
+        assert isinstance(g, pnp.ndarray)
         assert g.shape == (2,)
-        assert np.allclose(g, expected_g, atol=tol, rtol=0)
+        assert pnp.allclose(g, expected_g, atol=tol, rtol=0)
 
         hess = qml.jacobian(grad_fn)(x)
 
         expected_hess = [
-            [-np.cos(a) * np.cos(b), np.sin(a) * np.sin(b)],
-            [np.sin(a) * np.sin(b), -np.cos(a) * np.cos(b)],
+            [-pnp.cos(a) * pnp.cos(b), pnp.sin(a) * pnp.sin(b)],
+            [pnp.sin(a) * pnp.sin(b), -pnp.cos(a) * pnp.cos(b)],
         ]
 
-        assert isinstance(hess, np.ndarray)
+        assert isinstance(hess, pnp.ndarray)
         assert hess.shape == (2, 2)
 
         if diff_method in {"finite-diff"}:
             tol = 10e-2
 
-        assert np.allclose(hess, expected_hess, atol=tol, rtol=0)
+        assert pnp.allclose(hess, expected_hess, atol=tol, rtol=0)
 
     def test_hessian_unused_parameter(
         self, interface, dev, diff_method, grad_on_execution, device_vjp, tol
@@ -1057,27 +1057,27 @@ class TestQubitIntegration:
             qml.RY(x[0], wires=0)
             return qml.expval(qml.PauliZ(0))
 
-        x = np.array([1.0, 2.0], requires_grad=True)
+        x = pnp.array([1.0, 2.0], requires_grad=True)
         res = circuit(x)
 
         a, _ = x
 
-        expected_res = np.cos(a)
-        assert np.allclose(res, expected_res, atol=tol, rtol=0)
+        expected_res = pnp.cos(a)
+        assert pnp.allclose(res, expected_res, atol=tol, rtol=0)
 
         grad_fn = qml.grad(circuit)
 
         hess = qml.jacobian(grad_fn)(x)
 
         expected_hess = [
-            [-np.cos(a), 0],
+            [-pnp.cos(a), 0],
             [0, 0],
         ]
 
         if diff_method in {"finite-diff"}:
             tol = 10e-2
 
-        assert np.allclose(hess, expected_hess, atol=tol, rtol=0)
+        assert pnp.allclose(hess, expected_hess, atol=tol, rtol=0)
 
     def test_hessian_vector_valued(
         self, interface, dev, diff_method, grad_on_execution, device_vjp, tol
@@ -1100,49 +1100,49 @@ class TestQubitIntegration:
             qml.RX(x[1], wires=0)
             return qml.probs(wires=0)
 
-        x = np.array([1.0, 2.0], requires_grad=True)
+        x = pnp.array([1.0, 2.0], requires_grad=True)
         res = circuit(x)
 
         a, b = x
 
-        expected_res = [0.5 + 0.5 * np.cos(a) * np.cos(b), 0.5 - 0.5 * np.cos(a) * np.cos(b)]
+        expected_res = [0.5 + 0.5 * pnp.cos(a) * pnp.cos(b), 0.5 - 0.5 * pnp.cos(a) * pnp.cos(b)]
 
-        assert isinstance(res, np.ndarray)
+        assert isinstance(res, pnp.ndarray)
         assert res.shape == (2,)  # pylint: disable=comparison-with-callable
-        assert np.allclose(res, expected_res, atol=tol, rtol=0)
+        assert pnp.allclose(res, expected_res, atol=tol, rtol=0)
 
         jac_fn = qml.jacobian(circuit)
         jac = jac_fn(x)
 
         expected_res = [
-            [-0.5 * np.sin(a) * np.cos(b), -0.5 * np.cos(a) * np.sin(b)],
-            [0.5 * np.sin(a) * np.cos(b), 0.5 * np.cos(a) * np.sin(b)],
+            [-0.5 * pnp.sin(a) * pnp.cos(b), -0.5 * pnp.cos(a) * pnp.sin(b)],
+            [0.5 * pnp.sin(a) * pnp.cos(b), 0.5 * pnp.cos(a) * pnp.sin(b)],
         ]
 
-        assert isinstance(jac, np.ndarray)
+        assert isinstance(jac, pnp.ndarray)
         assert jac.shape == (2, 2)
-        assert np.allclose(jac, expected_res, atol=tol, rtol=0)
+        assert pnp.allclose(jac, expected_res, atol=tol, rtol=0)
 
         hess = qml.jacobian(jac_fn)(x)
 
         expected_hess = [
             [
-                [-0.5 * np.cos(a) * np.cos(b), 0.5 * np.sin(a) * np.sin(b)],
-                [0.5 * np.sin(a) * np.sin(b), -0.5 * np.cos(a) * np.cos(b)],
+                [-0.5 * pnp.cos(a) * pnp.cos(b), 0.5 * pnp.sin(a) * pnp.sin(b)],
+                [0.5 * pnp.sin(a) * pnp.sin(b), -0.5 * pnp.cos(a) * pnp.cos(b)],
             ],
             [
-                [0.5 * np.cos(a) * np.cos(b), -0.5 * np.sin(a) * np.sin(b)],
-                [-0.5 * np.sin(a) * np.sin(b), 0.5 * np.cos(a) * np.cos(b)],
+                [0.5 * pnp.cos(a) * pnp.cos(b), -0.5 * pnp.sin(a) * pnp.sin(b)],
+                [-0.5 * pnp.sin(a) * pnp.sin(b), 0.5 * pnp.cos(a) * pnp.cos(b)],
             ],
         ]
 
-        assert isinstance(hess, np.ndarray)
+        assert isinstance(hess, pnp.ndarray)
         assert hess.shape == (2, 2, 2)
 
         if diff_method in {"finite-diff"}:
             tol = 10e-2
 
-        assert np.allclose(hess, expected_hess, atol=tol, rtol=0)
+        assert pnp.allclose(hess, expected_hess, atol=tol, rtol=0)
 
     def test_hessian_vector_valued_postprocessing(
         self, interface, dev, diff_method, grad_on_execution, device_vjp, tol
@@ -1167,27 +1167,27 @@ class TestQubitIntegration:
         def cost_fn(x):
             return x @ autograd.numpy.hstack(circuit(x))
 
-        x = np.array([0.76, -0.87], requires_grad=True)
+        x = pnp.array([0.76, -0.87], requires_grad=True)
         res = cost_fn(x)
 
         a, b = x
 
-        expected_res = x @ [np.cos(a) * np.cos(b), np.cos(a) * np.cos(b)]
+        expected_res = x @ [pnp.cos(a) * pnp.cos(b), pnp.cos(a) * pnp.cos(b)]
 
-        assert isinstance(res, np.ndarray)
+        assert isinstance(res, pnp.ndarray)
         assert res.shape == ()
-        assert np.allclose(res, expected_res, atol=tol, rtol=0)
+        assert pnp.allclose(res, expected_res, atol=tol, rtol=0)
 
         hess = qml.jacobian(qml.grad(cost_fn))(x)
 
         expected_hess = [
             [
-                -(np.cos(b) * ((a + b) * np.cos(a) + 2 * np.sin(a))),
-                -(np.cos(b) * np.sin(a)) + (-np.cos(a) + (a + b) * np.sin(a)) * np.sin(b),
+                -(pnp.cos(b) * ((a + b) * pnp.cos(a) + 2 * pnp.sin(a))),
+                -(pnp.cos(b) * pnp.sin(a)) + (-pnp.cos(a) + (a + b) * pnp.sin(a)) * pnp.sin(b),
             ],
             [
-                -(np.cos(b) * np.sin(a)) + (-np.cos(a) + (a + b) * np.sin(a)) * np.sin(b),
-                -(np.cos(a) * ((a + b) * np.cos(b) + 2 * np.sin(b))),
+                -(pnp.cos(b) * pnp.sin(a)) + (-pnp.cos(a) + (a + b) * pnp.sin(a)) * pnp.sin(b),
+                -(pnp.cos(a) * ((a + b) * pnp.cos(b) + 2 * pnp.sin(b))),
             ],
         ]
 
@@ -1196,7 +1196,7 @@ class TestQubitIntegration:
         if diff_method in {"finite-diff"}:
             tol = 10e-2
 
-        assert np.allclose(hess, expected_hess, atol=tol, rtol=0)
+        assert pnp.allclose(hess, expected_hess, atol=tol, rtol=0)
 
     def test_hessian_vector_valued_separate_args(
         self, interface, dev, diff_method, grad_on_execution, device_vjp, tol
@@ -1218,28 +1218,28 @@ class TestQubitIntegration:
             qml.RX(b, wires=0)
             return qml.probs(wires=0)
 
-        a = np.array(1.0, requires_grad=True)
-        b = np.array(2.0, requires_grad=True)
+        a = pnp.array(1.0, requires_grad=True)
+        b = pnp.array(2.0, requires_grad=True)
         res = circuit(a, b)
 
-        expected_res = [0.5 + 0.5 * np.cos(a) * np.cos(b), 0.5 - 0.5 * np.cos(a) * np.cos(b)]
-        assert isinstance(res, np.ndarray)
+        expected_res = [0.5 + 0.5 * pnp.cos(a) * pnp.cos(b), 0.5 - 0.5 * pnp.cos(a) * pnp.cos(b)]
+        assert isinstance(res, pnp.ndarray)
         assert res.shape == (2,)  # pylint: disable=comparison-with-callable
-        assert np.allclose(res, expected_res, atol=tol, rtol=0)
+        assert pnp.allclose(res, expected_res, atol=tol, rtol=0)
 
         jac_fn = qml.jacobian(circuit)
         g = jac_fn(a, b)
         assert isinstance(g, tuple) and len(g) == 2
 
         expected_g = (
-            [-0.5 * np.sin(a) * np.cos(b), 0.5 * np.sin(a) * np.cos(b)],
-            [-0.5 * np.cos(a) * np.sin(b), 0.5 * np.cos(a) * np.sin(b)],
+            [-0.5 * pnp.sin(a) * pnp.cos(b), 0.5 * pnp.sin(a) * pnp.cos(b)],
+            [-0.5 * pnp.cos(a) * pnp.sin(b), 0.5 * pnp.cos(a) * pnp.sin(b)],
         )
         assert g[0].shape == (2,)
-        assert np.allclose(g[0], expected_g[0], atol=tol, rtol=0)
+        assert pnp.allclose(g[0], expected_g[0], atol=tol, rtol=0)
 
         assert g[1].shape == (2,)
-        assert np.allclose(g[1], expected_g[1], atol=tol, rtol=0)
+        assert pnp.allclose(g[1], expected_g[1], atol=tol, rtol=0)
 
         def jac_fn_a(*args):
             return jac_fn(*args)[0]
@@ -1253,20 +1253,20 @@ class TestQubitIntegration:
         assert isinstance(hess_b, tuple) and len(hess_b) == 2
 
         exp_hess_a = (
-            [-0.5 * np.cos(a) * np.cos(b), 0.5 * np.cos(a) * np.cos(b)],
-            [0.5 * np.sin(a) * np.sin(b), -0.5 * np.sin(a) * np.sin(b)],
+            [-0.5 * pnp.cos(a) * pnp.cos(b), 0.5 * pnp.cos(a) * pnp.cos(b)],
+            [0.5 * pnp.sin(a) * pnp.sin(b), -0.5 * pnp.sin(a) * pnp.sin(b)],
         )
         exp_hess_b = (
-            [0.5 * np.sin(a) * np.sin(b), -0.5 * np.sin(a) * np.sin(b)],
-            [-0.5 * np.cos(a) * np.cos(b), 0.5 * np.cos(a) * np.cos(b)],
+            [0.5 * pnp.sin(a) * pnp.sin(b), -0.5 * pnp.sin(a) * pnp.sin(b)],
+            [-0.5 * pnp.cos(a) * pnp.cos(b), 0.5 * pnp.cos(a) * pnp.cos(b)],
         )
 
         if diff_method in {"finite-diff"}:
             tol = 10e-2
 
         for hess, exp_hess in zip([hess_a, hess_b], [exp_hess_a, exp_hess_b]):
-            assert np.allclose(hess[0], exp_hess[0], atol=tol, rtol=0)
-            assert np.allclose(hess[1], exp_hess[1], atol=tol, rtol=0)
+            assert pnp.allclose(hess[0], exp_hess[0], atol=tol, rtol=0)
+            assert pnp.allclose(hess[1], exp_hess[1], atol=tol, rtol=0)
 
     def test_hessian_ragged(self, interface, dev, diff_method, grad_on_execution, device_vjp, tol):
         """Test hessian calculation of a ragged QNode"""
@@ -1288,14 +1288,14 @@ class TestQubitIntegration:
             qml.RX(x[1], wires=1)
             return qml.expval(qml.PauliZ(0)), qml.probs(wires=1)
 
-        x = np.array([1.0, 2.0], requires_grad=True)
+        x = pnp.array([1.0, 2.0], requires_grad=True)
 
         a, b = x
 
         expected_res = [
-            np.cos(a) * np.cos(b),
-            0.5 + 0.5 * np.cos(a) * np.cos(b),
-            0.5 - 0.5 * np.cos(a) * np.cos(b),
+            pnp.cos(a) * pnp.cos(b),
+            0.5 + 0.5 * pnp.cos(a) * pnp.cos(b),
+            0.5 - 0.5 * pnp.cos(a) * pnp.cos(b),
         ]
 
         def cost_fn(x):
@@ -1309,23 +1309,23 @@ class TestQubitIntegration:
         hess = qml.jacobian(jac_fn)(x)
         expected_hess = [
             [
-                [-np.cos(a) * np.cos(b), np.sin(a) * np.sin(b)],
-                [np.sin(a) * np.sin(b), -np.cos(a) * np.cos(b)],
+                [-pnp.cos(a) * pnp.cos(b), pnp.sin(a) * pnp.sin(b)],
+                [pnp.sin(a) * pnp.sin(b), -pnp.cos(a) * pnp.cos(b)],
             ],
             [
-                [-0.5 * np.cos(a) * np.cos(b), 0.5 * np.sin(a) * np.sin(b)],
-                [0.5 * np.sin(a) * np.sin(b), -0.5 * np.cos(a) * np.cos(b)],
+                [-0.5 * pnp.cos(a) * pnp.cos(b), 0.5 * pnp.sin(a) * pnp.sin(b)],
+                [0.5 * pnp.sin(a) * pnp.sin(b), -0.5 * pnp.cos(a) * pnp.cos(b)],
             ],
             [
-                [0.5 * np.cos(a) * np.cos(b), -0.5 * np.sin(a) * np.sin(b)],
-                [-0.5 * np.sin(a) * np.sin(b), 0.5 * np.cos(a) * np.cos(b)],
+                [0.5 * pnp.cos(a) * pnp.cos(b), -0.5 * pnp.sin(a) * pnp.sin(b)],
+                [-0.5 * pnp.sin(a) * pnp.sin(b), 0.5 * pnp.cos(a) * pnp.cos(b)],
             ],
         ]
 
         if diff_method in {"finite-diff"}:
             tol = 10e-2
 
-        assert np.allclose(hess, expected_hess, atol=tol, rtol=0)
+        assert pnp.allclose(hess, expected_hess, atol=tol, rtol=0)
 
     def test_state(self, interface, dev, diff_method, grad_on_execution, device_vjp, tol):
         """Test that the state can be returned and differentiated"""
@@ -1333,8 +1333,8 @@ class TestQubitIntegration:
         if "lightning" in getattr(dev, "name", "").lower():
             pytest.xfail("Lightning does not support state adjoint diff.")
 
-        x = np.array(0.543, requires_grad=True)
-        y = np.array(-0.654, requires_grad=True)
+        x = pnp.array(0.543, requires_grad=True)
+        y = pnp.array(-0.654, requires_grad=True)
 
         @qnode(
             dev,
@@ -1351,8 +1351,8 @@ class TestQubitIntegration:
 
         def cost_fn(x, y):
             res = circuit(x, y)
-            assert res.dtype is np.dtype("complex128")
-            probs = np.abs(res) ** 2
+            assert res.dtype is pnp.dtype("complex128")
+            probs = pnp.abs(res) ** 2
             return probs[0] + probs[2]
 
         res = cost_fn(x, y)
@@ -1361,15 +1361,15 @@ class TestQubitIntegration:
             pytest.skip("Test only supports backprop")
 
         res = qml.jacobian(cost_fn)(x, y)
-        expected = np.array([-np.sin(x) * np.cos(y) / 2, -np.cos(x) * np.sin(y) / 2])
+        expected = pnp.array([-pnp.sin(x) * pnp.cos(y) / 2, -pnp.cos(x) * pnp.sin(y) / 2])
         assert isinstance(res, tuple)
         assert len(res) == 2
 
-        assert isinstance(res[0], np.ndarray)
+        assert isinstance(res[0], pnp.ndarray)
         assert res[0].shape == ()
-        assert isinstance(res[1], np.ndarray)
+        assert isinstance(res[1], pnp.ndarray)
         assert res[1].shape == ()
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
     @pytest.mark.parametrize("state", [[1], [0, 1]])  # Basis state and state vector
     def test_projector(
@@ -1388,13 +1388,13 @@ class TestQubitIntegration:
         )
 
         if diff_method == "spsa":
-            kwargs["sampler_rng"] = np.random.default_rng(seed)
+            kwargs["sampler_rng"] = pnp.random.default_rng(seed)
             tol = TOL_FOR_SPSA
         elif diff_method == "hadamard":
             pytest.skip("Hadamard gradient does not support variances.")
 
-        P = np.array(state, requires_grad=False)
-        x, y = np.array([0.765, -0.654], requires_grad=True)
+        P = pnp.array(state, requires_grad=False)
+        x, y = pnp.array([0.765, -0.654], requires_grad=True)
 
         @qnode(dev, **kwargs)
         def circuit(x, y):
@@ -1404,17 +1404,17 @@ class TestQubitIntegration:
             return qml.var(qml.Projector(P, wires=0) @ qml.PauliX(1))
 
         res = circuit(x, y)
-        expected = 0.25 * np.sin(x / 2) ** 2 * (3 + np.cos(2 * y) + 2 * np.cos(x) * np.sin(y) ** 2)
+        expected = 0.25 * pnp.sin(x / 2) ** 2 * (3 + pnp.cos(2 * y) + 2 * pnp.cos(x) * pnp.sin(y) ** 2)
         # assert isinstance(res, np.ndarray)
         # assert res.shape == ()
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
         jac = qml.jacobian(circuit)(x, y)
-        expected = np.array(
+        expected = pnp.array(
             [
                 [
-                    0.5 * np.sin(x) * (np.cos(x / 2) ** 2 + np.cos(2 * y) * np.sin(x / 2) ** 2),
-                    -2 * np.cos(y) * np.sin(x / 2) ** 4 * np.sin(y),
+                    0.5 * pnp.sin(x) * (pnp.cos(x / 2) ** 2 + pnp.cos(2 * y) * pnp.sin(x / 2) ** 2),
+                    -2 * pnp.cos(y) * pnp.sin(x / 2) ** 4 * pnp.sin(y),
                 ]
             ]
         )
@@ -1422,13 +1422,13 @@ class TestQubitIntegration:
         assert isinstance(jac, tuple)
         assert len(jac) == 2
 
-        assert isinstance(jac[0], np.ndarray)
+        assert isinstance(jac[0], pnp.ndarray)
         assert jac[0].shape == ()
 
-        assert isinstance(jac[1], np.ndarray)
+        assert isinstance(jac[1], pnp.ndarray)
         assert jac[1].shape == ()
 
-        assert np.allclose(jac, expected, atol=tol, rtol=0)
+        assert pnp.allclose(jac, expected, atol=tol, rtol=0)
 
     def test_postselection_differentiation(
         self, interface, dev, diff_method, grad_on_execution, device_vjp
@@ -1466,14 +1466,14 @@ class TestQubitIntegration:
             qml.RX(theta, wires=1)
             return qml.expval(qml.PauliZ(1))
 
-        phi = np.array(1.23, requires_grad=True)
-        theta = np.array(4.56, requires_grad=True)
+        phi = pnp.array(1.23, requires_grad=True)
+        theta = pnp.array(4.56, requires_grad=True)
 
-        assert np.allclose(circuit(phi, theta), expected_circuit(theta))
+        assert pnp.allclose(circuit(phi, theta), expected_circuit(theta))
 
         gradient = qml.grad(circuit)(phi, theta)
         exp_theta_grad = qml.grad(expected_circuit)(theta)
-        assert np.allclose(gradient, [0.0, exp_theta_grad])
+        assert pnp.allclose(gradient, [0.0, exp_theta_grad])
 
 
 @pytest.mark.parametrize(
@@ -1516,8 +1516,8 @@ class TestTapeExpansion:
             PhaseShift(2 * y, wires=0)
             return qml.expval(qml.PauliX(0))
 
-        x = np.array(0.5, requires_grad=True)
-        y = np.array(0.7, requires_grad=False)
+        x = pnp.array(0.5, requires_grad=True)
+        y = pnp.array(0.7, requires_grad=False)
         circuit(x, y)
 
         _ = qml.grad(circuit)(x, y)
@@ -1538,7 +1538,7 @@ class TestTapeExpansion:
         if diff_method in ["adjoint", "hadamard"]:
             pytest.skip("The diff method requested does not yet support Hamiltonians")
         elif diff_method == "spsa":
-            kwargs["sampler_rng"] = np.random.default_rng(seed)
+            kwargs["sampler_rng"] = pnp.random.default_rng(seed)
             kwargs["num_directions"] = 10
             tol = TOL_FOR_SPSA
 
@@ -1551,24 +1551,24 @@ class TestTapeExpansion:
             qml.templates.BasicEntanglerLayers(weights, wires=[0, 1])
             return qml.expval(qml.Hamiltonian(coeffs, obs))
 
-        d = np.array([0.1, 0.2], requires_grad=False)
-        w = np.array([0.654, -0.734], requires_grad=True)
-        c = np.array([-0.6543, 0.24, 0.54], requires_grad=True)
+        d = pnp.array([0.1, 0.2], requires_grad=False)
+        w = pnp.array([0.654, -0.734], requires_grad=True)
+        c = pnp.array([-0.6543, 0.24, 0.54], requires_grad=True)
 
         # test output
         res = circuit(d, w, c)
-        expected = c[2] * np.cos(d[1] + w[1]) - c[1] * np.sin(d[0] + w[0]) * np.sin(d[1] + w[1])
-        assert np.allclose(res, expected, atol=tol)
+        expected = c[2] * pnp.cos(d[1] + w[1]) - c[1] * pnp.sin(d[0] + w[0]) * pnp.sin(d[1] + w[1])
+        assert pnp.allclose(res, expected, atol=tol)
 
         # test gradients
         grad = qml.grad(circuit)(d, w, c)
         expected_w = [
-            -c[1] * np.cos(d[0] + w[0]) * np.sin(d[1] + w[1]),
-            -c[1] * np.cos(d[1] + w[1]) * np.sin(d[0] + w[0]) - c[2] * np.sin(d[1] + w[1]),
+            -c[1] * pnp.cos(d[0] + w[0]) * pnp.sin(d[1] + w[1]),
+            -c[1] * pnp.cos(d[1] + w[1]) * pnp.sin(d[0] + w[0]) - c[2] * pnp.sin(d[1] + w[1]),
         ]
-        expected_c = [0, -np.sin(d[0] + w[0]) * np.sin(d[1] + w[1]), np.cos(d[1] + w[1])]
-        assert np.allclose(grad[0], expected_w, atol=tol)
-        assert np.allclose(grad[1], expected_c, atol=tol)
+        expected_c = [0, -pnp.sin(d[0] + w[0]) * pnp.sin(d[1] + w[1]), pnp.cos(d[1] + w[1])]
+        assert pnp.allclose(grad[0], expected_w, atol=tol)
+        assert pnp.allclose(grad[1], expected_c, atol=tol)
 
         # test second-order derivatives
         if (
@@ -1581,15 +1581,15 @@ class TestTapeExpansion:
                     grad2_c = qml.jacobian(qml.grad(circuit, argnum=2), argnum=2)(d, w, c)
             else:
                 grad2_c = qml.jacobian(qml.grad(circuit, argnum=2), argnum=2)(d, w, c)
-            assert np.allclose(grad2_c, 0, atol=tol)
+            assert pnp.allclose(grad2_c, 0, atol=tol)
 
             grad2_w_c = qml.jacobian(qml.grad(circuit, argnum=1), argnum=2)(d, w, c)
-            expected = [0, -np.cos(d[0] + w[0]) * np.sin(d[1] + w[1]), 0], [
+            expected = [0, -pnp.cos(d[0] + w[0]) * pnp.sin(d[1] + w[1]), 0], [
                 0,
-                -np.cos(d[1] + w[1]) * np.sin(d[0] + w[0]),
-                -np.sin(d[1] + w[1]),
+                -pnp.cos(d[1] + w[1]) * pnp.sin(d[0] + w[0]),
+                -pnp.sin(d[1] + w[1]),
             ]
-            assert np.allclose(grad2_w_c, expected, atol=tol)
+            assert pnp.allclose(grad2_w_c, expected, atol=tol)
 
     @pytest.mark.slow
     @pytest.mark.parametrize("max_diff", [1, 2])
@@ -1606,7 +1606,7 @@ class TestTapeExpansion:
         elif diff_method == "spsa":
             gradient_kwargs = {
                 "h": H_FOR_SPSA,
-                "sampler_rng": np.random.default_rng(seed),
+                "sampler_rng": pnp.random.default_rng(seed),
                 "num_directions": 10,
             }
             tol = TOL_FOR_SPSA
@@ -1631,14 +1631,14 @@ class TestTapeExpansion:
             H.compute_grouping()
             return qml.expval(H)
 
-        d = np.array([0.1, 0.2], requires_grad=False)
-        w = np.array([0.654, -0.734], requires_grad=True)
-        c = np.array([-0.6543, 0.24, 0.54], requires_grad=True)
+        d = pnp.array([0.1, 0.2], requires_grad=False)
+        w = pnp.array([0.654, -0.734], requires_grad=True)
+        c = pnp.array([-0.6543, 0.24, 0.54], requires_grad=True)
 
         # test output
         res = circuit(d, w, c, shots=50000)
-        expected = c[2] * np.cos(d[1] + w[1]) - c[1] * np.sin(d[0] + w[0]) * np.sin(d[1] + w[1])
-        assert np.allclose(res, expected, atol=tol)
+        expected = c[2] * pnp.cos(d[1] + w[1]) - c[1] * pnp.sin(d[0] + w[0]) * pnp.sin(d[1] + w[1])
+        assert pnp.allclose(res, expected, atol=tol)
 
         # test gradients
         if diff_method in ["finite-diff", "spsa"]:
@@ -1646,25 +1646,25 @@ class TestTapeExpansion:
 
         grad = qml.grad(circuit)(d, w, c, shots=50000)
         expected_w = [
-            -c[1] * np.cos(d[0] + w[0]) * np.sin(d[1] + w[1]),
-            -c[1] * np.cos(d[1] + w[1]) * np.sin(d[0] + w[0]) - c[2] * np.sin(d[1] + w[1]),
+            -c[1] * pnp.cos(d[0] + w[0]) * pnp.sin(d[1] + w[1]),
+            -c[1] * pnp.cos(d[1] + w[1]) * pnp.sin(d[0] + w[0]) - c[2] * pnp.sin(d[1] + w[1]),
         ]
-        expected_c = [0, -np.sin(d[0] + w[0]) * np.sin(d[1] + w[1]), np.cos(d[1] + w[1])]
-        assert np.allclose(grad[0], expected_w, atol=tol)
-        assert np.allclose(grad[1], expected_c, atol=tol)
+        expected_c = [0, -pnp.sin(d[0] + w[0]) * pnp.sin(d[1] + w[1]), pnp.cos(d[1] + w[1])]
+        assert pnp.allclose(grad[0], expected_w, atol=tol)
+        assert pnp.allclose(grad[1], expected_c, atol=tol)
 
         # test second-order derivatives
         if diff_method == "parameter-shift" and max_diff == 2 and dev.name != "param_shift.qubit":
             grad2_c = qml.jacobian(qml.grad(circuit, argnum=2), argnum=2)(d, w, c, shots=50000)
-            assert np.allclose(grad2_c, 0, atol=tol)
+            assert pnp.allclose(grad2_c, 0, atol=tol)
 
             grad2_w_c = qml.jacobian(qml.grad(circuit, argnum=1), argnum=2)(d, w, c, shots=50000)
-            expected = [0, -np.cos(d[0] + w[0]) * np.sin(d[1] + w[1]), 0], [
+            expected = [0, -pnp.cos(d[0] + w[0]) * pnp.sin(d[1] + w[1]), 0], [
                 0,
-                -np.cos(d[1] + w[1]) * np.sin(d[0] + w[0]),
-                -np.sin(d[1] + w[1]),
+                -pnp.cos(d[1] + w[1]) * pnp.sin(d[0] + w[0]),
+                -pnp.sin(d[1] + w[1]),
             ]
-            assert np.allclose(grad2_w_c, expected, atol=tol)
+            assert pnp.allclose(grad2_w_c, expected, atol=tol)
 
 
 class TestSample:
@@ -1701,10 +1701,10 @@ class TestSample:
         assert len(res) == 2
 
         assert res[0].shape == (10,)  # pylint: disable=comparison-with-callable
-        assert isinstance(res[0], np.ndarray)
+        assert isinstance(res[0], pnp.ndarray)
 
         assert res[1].shape == (10,)  # pylint: disable=comparison-with-callable
-        assert isinstance(res[1], np.ndarray)
+        assert isinstance(res[1], pnp.ndarray)
 
     def test_sample_combination(self):
         """Test the output of combining expval, var and sample"""
@@ -1724,10 +1724,10 @@ class TestSample:
         assert isinstance(result, tuple)
         assert len(result) == 3
 
-        assert np.array_equal(result[0].shape, (n_sample,))
-        assert isinstance(result[1], (float, np.ndarray))
-        assert isinstance(result[2], (float, np.ndarray))
-        assert result[0].dtype == np.dtype("float")
+        assert pnp.array_equal(result[0].shape, (n_sample,))
+        assert isinstance(result[1], (float, pnp.ndarray))
+        assert isinstance(result[2], (float, pnp.ndarray))
+        assert result[0].dtype == pnp.dtype("float")
 
     def test_single_wire_sample(self):
         """Test the return type and shape of sampling a single wire"""
@@ -1743,8 +1743,8 @@ class TestSample:
 
         result = circuit(shots=n_sample)
 
-        assert isinstance(result, np.ndarray)
-        assert np.array_equal(result.shape, (n_sample,))
+        assert isinstance(result, pnp.ndarray)
+        assert pnp.array_equal(result.shape, (n_sample,))
 
     def test_multi_wire_sample_regular_shape(self):
         """Test the return type and shape of sampling multiple wires
@@ -1764,13 +1764,13 @@ class TestSample:
         assert len(result) == 3
 
         assert result[0].shape == (10,)  # pylint: disable=comparison-with-callable
-        assert isinstance(result[0], np.ndarray)
+        assert isinstance(result[0], pnp.ndarray)
 
         assert result[1].shape == (10,)  # pylint: disable=comparison-with-callable
-        assert isinstance(result[1], np.ndarray)
+        assert isinstance(result[1], pnp.ndarray)
 
         assert result[2].shape == (10,)  # pylint: disable=comparison-with-callable
-        assert isinstance(result[2], np.ndarray)
+        assert isinstance(result[2], pnp.ndarray)
 
 
 @pytest.mark.parametrize(
@@ -1794,11 +1794,11 @@ class TestReturn:
             qml.RX(0.2, wires=0)
             return qml.expval(qml.PauliZ(0))
 
-        a = np.array(0.1, requires_grad=True)
+        a = pnp.array(0.1, requires_grad=True)
 
         grad = qml.grad(circuit)(a)
 
-        assert isinstance(grad, np.tensor if diff_method == "backprop" else float)
+        assert isinstance(grad, pnp.tensor if diff_method == "backprop" else float)
 
     def test_grad_single_measurement_multiple_param(
         self, dev, diff_method, grad_on_execution, device_vjp
@@ -1817,8 +1817,8 @@ class TestReturn:
             qml.RX(b, wires=0)
             return qml.expval(qml.PauliZ(0))
 
-        a = np.array(0.1, requires_grad=True)
-        b = np.array(0.2, requires_grad=True)
+        a = pnp.array(0.1, requires_grad=True)
+        b = pnp.array(0.2, requires_grad=True)
 
         grad = qml.grad(circuit)(a, b)
 
@@ -1844,11 +1844,11 @@ class TestReturn:
             qml.RX(a[1], wires=0)
             return qml.expval(qml.PauliZ(0))
 
-        a = np.array([0.1, 0.2], requires_grad=True)
+        a = pnp.array([0.1, 0.2], requires_grad=True)
 
         grad = qml.grad(circuit)(a)
 
-        assert isinstance(grad, np.ndarray)
+        assert isinstance(grad, pnp.ndarray)
         assert len(grad) == 2
         assert grad.shape == (2,)
 
@@ -1870,11 +1870,11 @@ class TestReturn:
             qml.RX(0.2, wires=0)
             return qml.probs(wires=[0, 1])
 
-        a = np.array(0.1, requires_grad=True)
+        a = pnp.array(0.1, requires_grad=True)
 
         jac = qml.jacobian(circuit)(a)
 
-        assert isinstance(jac, np.ndarray)
+        assert isinstance(jac, pnp.ndarray)
         assert jac.shape == (4,)
 
     def test_jacobian_single_measurement_probs_multiple_param(
@@ -1895,17 +1895,17 @@ class TestReturn:
             qml.RX(b, wires=0)
             return qml.probs(wires=[0, 1])
 
-        a = np.array(0.1, requires_grad=True)
-        b = np.array(0.2, requires_grad=True)
+        a = pnp.array(0.1, requires_grad=True)
+        b = pnp.array(0.2, requires_grad=True)
 
         jac = qml.jacobian(circuit)(a, b)
 
         assert isinstance(jac, tuple)
 
-        assert isinstance(jac[0], np.ndarray)
+        assert isinstance(jac[0], pnp.ndarray)
         assert jac[0].shape == (4,)
 
-        assert isinstance(jac[1], np.ndarray)
+        assert isinstance(jac[1], pnp.ndarray)
         assert jac[1].shape == (4,)
 
     def test_jacobian_single_measurement_probs_multiple_param_single_array(
@@ -1925,10 +1925,10 @@ class TestReturn:
             qml.RX(a[1], wires=0)
             return qml.probs(wires=[0, 1])
 
-        a = np.array([0.1, 0.2], requires_grad=True)
+        a = pnp.array([0.1, 0.2], requires_grad=True)
         jac = qml.jacobian(circuit)(a)
 
-        assert isinstance(jac, np.ndarray)
+        assert isinstance(jac, pnp.ndarray)
         assert jac.shape == (4, 2)
 
     def test_jacobian_multiple_measurement_single_param(
@@ -1948,14 +1948,14 @@ class TestReturn:
             qml.RX(0.2, wires=0)
             return qml.expval(qml.PauliZ(0)), qml.probs(wires=[0, 1])
 
-        a = np.array(0.1, requires_grad=True)
+        a = pnp.array(0.1, requires_grad=True)
 
         def cost(x):
             return anp.hstack(circuit(x))
 
         jac = qml.jacobian(cost)(a)
 
-        assert isinstance(jac, np.ndarray)
+        assert isinstance(jac, pnp.ndarray)
         assert jac.shape == (5,)
 
     def test_jacobian_multiple_measurement_multiple_param(
@@ -1975,8 +1975,8 @@ class TestReturn:
             qml.RX(b, wires=0)
             return qml.expval(qml.PauliZ(0)), qml.probs(wires=[0, 1])
 
-        a = np.array(0.1, requires_grad=True)
-        b = np.array(0.2, requires_grad=True)
+        a = pnp.array(0.1, requires_grad=True)
+        b = pnp.array(0.2, requires_grad=True)
 
         def cost(x, y):
             return anp.hstack(circuit(x, y))
@@ -1986,10 +1986,10 @@ class TestReturn:
         assert isinstance(jac, tuple)
         assert len(jac) == 2
 
-        assert isinstance(jac[0], np.ndarray)
+        assert isinstance(jac[0], pnp.ndarray)
         assert jac[0].shape == (5,)
 
-        assert isinstance(jac[1], np.ndarray)
+        assert isinstance(jac[1], pnp.ndarray)
         assert jac[1].shape == (5,)
 
     def test_jacobian_multiple_measurement_multiple_param_array(
@@ -2009,14 +2009,14 @@ class TestReturn:
             qml.RX(a[1], wires=0)
             return qml.expval(qml.PauliZ(0)), qml.probs(wires=[0, 1])
 
-        a = np.array([0.1, 0.2], requires_grad=True)
+        a = pnp.array([0.1, 0.2], requires_grad=True)
 
         def cost(x):
             return anp.hstack(circuit(x))
 
         jac = qml.jacobian(cost)(a)
 
-        assert isinstance(jac, np.ndarray)
+        assert isinstance(jac, pnp.ndarray)
         assert jac.shape == (5, 2)
 
     def test_hessian_expval_multiple_params(self, dev, diff_method, grad_on_execution, device_vjp):
@@ -2050,10 +2050,10 @@ class TestReturn:
         assert isinstance(hess, tuple)
         assert len(hess) == 2
 
-        assert isinstance(hess[0], np.ndarray)
+        assert isinstance(hess[0], pnp.ndarray)
         assert hess[0].shape == (2,)
 
-        assert isinstance(hess[1], np.ndarray)
+        assert isinstance(hess[1], pnp.ndarray)
         assert hess[1].shape == (2,)
 
     def test_hessian_expval_multiple_param_array(
@@ -2082,7 +2082,7 @@ class TestReturn:
 
         hess = qml.jacobian(qml.grad(circuit))(params)
 
-        assert isinstance(hess, np.ndarray)
+        assert isinstance(hess, pnp.ndarray)
         assert hess.shape == (2, 2)
 
     def test_hessian_var_multiple_params(self, dev, diff_method, grad_on_execution, device_vjp):
@@ -2118,10 +2118,10 @@ class TestReturn:
         assert isinstance(hess, tuple)
         assert len(hess) == 2
 
-        assert isinstance(hess[0], np.ndarray)
+        assert isinstance(hess[0], pnp.ndarray)
         assert hess[0].shape == (2,)
 
-        assert isinstance(hess[1], np.ndarray)
+        assert isinstance(hess[1], pnp.ndarray)
         assert hess[1].shape == (2,)
 
     def test_hessian_var_multiple_param_array(
@@ -2151,7 +2151,7 @@ class TestReturn:
 
         hess = qml.jacobian(qml.grad(circuit))(params)
 
-        assert isinstance(hess, np.ndarray)
+        assert isinstance(hess, pnp.ndarray)
         assert hess.shape == (2, 2)
 
     def test_hessian_probs_expval_multiple_params(
@@ -2189,10 +2189,10 @@ class TestReturn:
         assert isinstance(hess, tuple)
         assert len(hess) == 2
 
-        assert isinstance(hess[0], np.ndarray)
+        assert isinstance(hess[0], pnp.ndarray)
         assert hess[0].shape == (6,)
 
-        assert isinstance(hess[1], np.ndarray)
+        assert isinstance(hess[1], pnp.ndarray)
         assert hess[1].shape == (6,)
 
     def test_hessian_expval_probs_multiple_param_array(
@@ -2224,7 +2224,7 @@ class TestReturn:
 
         hess = qml.jacobian(qml.jacobian(cost))(params)
 
-        assert isinstance(hess, np.ndarray)
+        assert isinstance(hess, pnp.ndarray)
         assert hess.shape == (3, 2, 2)  # pylint: disable=no-member
 
     def test_hessian_probs_var_multiple_params(
@@ -2265,10 +2265,10 @@ class TestReturn:
         assert isinstance(hess, tuple)
         assert len(hess) == 2
 
-        assert isinstance(hess[0], np.ndarray)
+        assert isinstance(hess[0], pnp.ndarray)
         assert hess[0].shape == (6,)
 
-        assert isinstance(hess[1], np.ndarray)
+        assert isinstance(hess[1], pnp.ndarray)
         assert hess[1].shape == (6,)
 
     def test_hessian_var_multiple_param_array2(
@@ -2301,7 +2301,7 @@ class TestReturn:
 
         hess = qml.jacobian(qml.jacobian(cost))(params)
 
-        assert isinstance(hess, np.ndarray)
+        assert isinstance(hess, pnp.ndarray)
         assert hess.shape == (3, 2, 2)  # pylint: disable=no-member
 
 
@@ -2317,4 +2317,4 @@ def test_no_ops():
         return qml.state()
 
     res = circuit()
-    assert isinstance(res, np.tensor)
+    assert isinstance(res, pnp.tensor)

--- a/tests/workflow/interfaces/qnode/test_autograd_qnode_shot_vector.py
+++ b/tests/workflow/interfaces/qnode/test_autograd_qnode_shot_vector.py
@@ -17,7 +17,7 @@
 import pytest
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane import qnode
 
 pytestmark = pytest.mark.autograd
@@ -26,7 +26,7 @@ shots_and_num_copies = [(((5, 2), 1, 10), 4), ((1, 10, (5, 2)), 4)]
 shots_and_num_copies_hess = [(((5, 1), 10), 2), ((10, (5, 1)), 2)]
 
 SEED_FOR_SPSA = 42
-spsa_kwargs = {"h": 0.05, "num_directions": 20, "sampler_rng": np.random.default_rng(SEED_FOR_SPSA)}
+spsa_kwargs = {"h": 0.05, "num_directions": 20, "sampler_rng": pnp.random.default_rng(SEED_FOR_SPSA)}
 
 qubit_device_and_diff_method = [
     ["default.qubit", "finite-diff", {"h": 0.05}],
@@ -58,14 +58,14 @@ class TestReturnWithShotVectors:
             qml.RX(0.2, wires=0)
             return qml.expval(qml.PauliZ(0))
 
-        a = np.array(0.1)
+        a = pnp.array(0.1)
 
         def cost(a):
             return qml.math.stack(circuit(a))
 
         jac = qml.jacobian(cost)(a)
 
-        assert isinstance(jac, np.ndarray)
+        assert isinstance(jac, pnp.ndarray)
         assert jac.shape == (num_copies,)
 
     def test_jac_single_measurement_multiple_param(
@@ -80,8 +80,8 @@ class TestReturnWithShotVectors:
             qml.RX(b, wires=0)
             return qml.expval(qml.PauliZ(0))
 
-        a = np.array(0.1)
-        b = np.array(0.2)
+        a = pnp.array(0.1)
+        b = pnp.array(0.2)
 
         def cost(a, b):
             return qml.math.stack(circuit(a, b))
@@ -91,7 +91,7 @@ class TestReturnWithShotVectors:
         assert isinstance(jac, tuple)
         assert len(jac) == 2
         for j in jac:
-            assert isinstance(j, np.ndarray)
+            assert isinstance(j, pnp.ndarray)
             assert j.shape == (num_copies,)
 
     def test_jacobian_single_measurement_multiple_param_array(
@@ -106,14 +106,14 @@ class TestReturnWithShotVectors:
             qml.RX(a[1], wires=0)
             return qml.expval(qml.PauliZ(0))
 
-        a = np.array([0.1, 0.2])
+        a = pnp.array([0.1, 0.2])
 
         def cost(a):
             return qml.math.stack(circuit(a))
 
         jac = qml.jacobian(cost)(a)
 
-        assert isinstance(jac, np.ndarray)
+        assert isinstance(jac, pnp.ndarray)
         assert jac.shape == (num_copies, 2)
 
     def test_jacobian_single_measurement_param_probs(
@@ -129,14 +129,14 @@ class TestReturnWithShotVectors:
             qml.RX(0.2, wires=0)
             return qml.probs(wires=[0, 1])
 
-        a = np.array(0.1)
+        a = pnp.array(0.1)
 
         def cost(a):
             return qml.math.stack(circuit(a))
 
         jac = qml.jacobian(cost)(a)
 
-        assert isinstance(jac, np.ndarray)
+        assert isinstance(jac, pnp.ndarray)
         assert jac.shape == (num_copies, 4)
 
     def test_jacobian_single_measurement_probs_multiple_param(
@@ -152,8 +152,8 @@ class TestReturnWithShotVectors:
             qml.RX(b, wires=0)
             return qml.probs(wires=[0, 1])
 
-        a = np.array(0.1)
-        b = np.array(0.2)
+        a = pnp.array(0.1)
+        b = pnp.array(0.2)
 
         def cost(a, b):
             return qml.math.stack(circuit(a, b))
@@ -163,7 +163,7 @@ class TestReturnWithShotVectors:
         assert isinstance(jac, tuple)
         assert len(jac) == 2
         for j in jac:
-            assert isinstance(j, np.ndarray)
+            assert isinstance(j, pnp.ndarray)
             assert j.shape == (num_copies, 4)
 
     def test_jacobian_single_measurement_probs_multiple_param_single_array(
@@ -179,14 +179,14 @@ class TestReturnWithShotVectors:
             qml.RX(a[1], wires=0)
             return qml.probs(wires=[0, 1])
 
-        a = np.array([0.1, 0.2])
+        a = pnp.array([0.1, 0.2])
 
         def cost(a):
             return qml.math.stack(circuit(a))
 
         jac = qml.jacobian(cost)(a)
 
-        assert isinstance(jac, np.ndarray)
+        assert isinstance(jac, pnp.ndarray)
         assert jac.shape == (num_copies, 4, 2)
 
     def test_jacobian_expval_expval_multiple_params(
@@ -195,8 +195,8 @@ class TestReturnWithShotVectors:
         """The gradient of multiple measurements with multiple params return a tuple of arrays."""
         dev = qml.device(dev_name, wires=2, shots=shots)
 
-        par_0 = np.array(0.1)
-        par_1 = np.array(0.2)
+        par_0 = pnp.array(0.1)
+        par_1 = pnp.array(0.2)
 
         @qnode(dev, diff_method=diff_method, max_diff=1, **gradient_kwargs)
         def circuit(x, y):
@@ -214,7 +214,7 @@ class TestReturnWithShotVectors:
         assert isinstance(jac, tuple)
         assert len(jac) == 2
         for j in jac:
-            assert isinstance(j, np.ndarray)
+            assert isinstance(j, pnp.ndarray)
             assert j.shape == (num_copies, 2)
 
     def test_jacobian_expval_expval_multiple_params_array(
@@ -230,7 +230,7 @@ class TestReturnWithShotVectors:
             qml.RY(a[2], wires=0)
             return qml.expval(qml.PauliZ(0) @ qml.PauliX(1)), qml.expval(qml.PauliZ(0))
 
-        a = np.array([0.1, 0.2, 0.3])
+        a = pnp.array([0.1, 0.2, 0.3])
 
         def cost(a):
             res = circuit(a)
@@ -238,7 +238,7 @@ class TestReturnWithShotVectors:
 
         jac = qml.jacobian(cost)(a)
 
-        assert isinstance(jac, np.ndarray)
+        assert isinstance(jac, pnp.ndarray)
         assert jac.shape == (num_copies, 2, 3)
 
     def test_jacobian_var_var_multiple_params(
@@ -247,8 +247,8 @@ class TestReturnWithShotVectors:
         """The jacobian of multiple measurements with multiple params return a tuple of arrays."""
         dev = qml.device(dev_name, wires=2, shots=shots)
 
-        par_0 = np.array(0.1)
-        par_1 = np.array(0.2)
+        par_0 = pnp.array(0.1)
+        par_1 = pnp.array(0.2)
 
         @qnode(dev, diff_method=diff_method, **gradient_kwargs)
         def circuit(x, y):
@@ -266,7 +266,7 @@ class TestReturnWithShotVectors:
         assert isinstance(jac, tuple)
         assert len(jac) == 2
         for j in jac:
-            assert isinstance(j, np.ndarray)
+            assert isinstance(j, pnp.ndarray)
             assert j.shape == (num_copies, 2)
 
     def test_jacobian_var_var_multiple_params_array(
@@ -282,7 +282,7 @@ class TestReturnWithShotVectors:
             qml.RY(a[2], wires=0)
             return qml.var(qml.PauliZ(0) @ qml.PauliX(1)), qml.var(qml.PauliZ(0))
 
-        a = np.array([0.1, 0.2, 0.3])
+        a = pnp.array([0.1, 0.2, 0.3])
 
         def cost(a):
             res = circuit(a)
@@ -290,7 +290,7 @@ class TestReturnWithShotVectors:
 
         jac = qml.jacobian(cost)(a)
 
-        assert isinstance(jac, np.ndarray)
+        assert isinstance(jac, pnp.ndarray)
         assert jac.shape == (num_copies, 2, 3)
 
     def test_jacobian_multiple_measurement_single_param(
@@ -305,7 +305,7 @@ class TestReturnWithShotVectors:
             qml.RX(0.2, wires=0)
             return qml.expval(qml.PauliZ(0)), qml.probs(wires=[0, 1])
 
-        a = np.array(0.1)
+        a = pnp.array(0.1)
 
         def cost(a):
             res = circuit(a)
@@ -313,7 +313,7 @@ class TestReturnWithShotVectors:
 
         jac = qml.jacobian(cost)(a)
 
-        assert isinstance(jac, np.ndarray)
+        assert isinstance(jac, pnp.ndarray)
         assert jac.shape == (num_copies, 5)
 
     def test_jacobian_multiple_measurement_multiple_param(
@@ -328,8 +328,8 @@ class TestReturnWithShotVectors:
             qml.RX(b, wires=0)
             return qml.expval(qml.PauliZ(0)), qml.probs(wires=[0, 1])
 
-        a = np.array(0.1, requires_grad=True)
-        b = np.array(0.2, requires_grad=True)
+        a = pnp.array(0.1, requires_grad=True)
+        b = pnp.array(0.2, requires_grad=True)
 
         def cost(a, b):
             res = circuit(a, b)
@@ -340,7 +340,7 @@ class TestReturnWithShotVectors:
         assert isinstance(jac, tuple)
         assert len(jac) == 2
         for j in jac:
-            assert isinstance(j, np.ndarray)
+            assert isinstance(j, pnp.ndarray)
             assert j.shape == (num_copies, 5)
 
     def test_jacobian_multiple_measurement_multiple_param_array(
@@ -355,7 +355,7 @@ class TestReturnWithShotVectors:
             qml.RX(a[1], wires=0)
             return qml.expval(qml.PauliZ(0)), qml.probs(wires=[0, 1])
 
-        a = np.array([0.1, 0.2])
+        a = pnp.array([0.1, 0.2])
 
         def cost(a):
             res = circuit(a)
@@ -363,7 +363,7 @@ class TestReturnWithShotVectors:
 
         jac = qml.jacobian(cost)(a)
 
-        assert isinstance(jac, np.ndarray)
+        assert isinstance(jac, pnp.ndarray)
         assert jac.shape == (num_copies, 5, 2)
 
 
@@ -379,8 +379,8 @@ class TestReturnShotVectorHessian:
         """The hessian of a single measurement with multiple params return a tuple of arrays."""
         dev = qml.device(dev_name, wires=2, shots=shots)
 
-        par_0 = np.array(0.1)
-        par_1 = np.array(0.2)
+        par_0 = pnp.array(0.1)
+        par_1 = pnp.array(0.2)
 
         @qnode(dev, diff_method=diff_method, max_diff=2, **gradient_kwargs)
         def circuit(x, y):
@@ -401,7 +401,7 @@ class TestReturnShotVectorHessian:
         assert isinstance(hess, tuple)
         assert len(hess) == 2
         for h in hess:
-            assert isinstance(h, np.ndarray)
+            assert isinstance(h, pnp.ndarray)
             assert h.shape == (2, num_copies)
 
     def test_hessian_expval_multiple_param_array(
@@ -410,7 +410,7 @@ class TestReturnShotVectorHessian:
         """The hessian of single measurement with a multiple params array return a single array."""
         dev = qml.device(dev_name, wires=2, shots=shots)
 
-        params = np.array([0.1, 0.2])
+        params = pnp.array([0.1, 0.2])
 
         @qnode(dev, diff_method=diff_method, max_diff=2, **gradient_kwargs)
         def circuit(x):
@@ -428,7 +428,7 @@ class TestReturnShotVectorHessian:
 
         hess = qml.jacobian(cost)(params)
 
-        assert isinstance(hess, np.ndarray)
+        assert isinstance(hess, pnp.ndarray)
         assert hess.shape == (num_copies, 2, 2)
 
     def test_hessian_var_multiple_params(
@@ -437,8 +437,8 @@ class TestReturnShotVectorHessian:
         """The hessian of a single measurement with multiple params return a tuple of arrays."""
         dev = qml.device(dev_name, wires=2, shots=shots)
 
-        par_0 = np.array(0.1)
-        par_1 = np.array(0.2)
+        par_0 = pnp.array(0.1)
+        par_1 = pnp.array(0.2)
 
         @qnode(dev, diff_method=diff_method, max_diff=2, **gradient_kwargs)
         def circuit(x, y):
@@ -459,7 +459,7 @@ class TestReturnShotVectorHessian:
         assert isinstance(hess, tuple)
         assert len(hess) == 2
         for h in hess:
-            assert isinstance(h, np.ndarray)
+            assert isinstance(h, pnp.ndarray)
             assert h.shape == (2, num_copies)
 
     def test_hessian_var_multiple_param_array(
@@ -468,7 +468,7 @@ class TestReturnShotVectorHessian:
         """The hessian of single measurement with a multiple params array return a single array."""
         dev = qml.device(dev_name, wires=2, shots=shots)
 
-        params = np.array([0.1, 0.2])
+        params = pnp.array([0.1, 0.2])
 
         @qnode(dev, diff_method=diff_method, max_diff=2, **gradient_kwargs)
         def circuit(x):
@@ -486,7 +486,7 @@ class TestReturnShotVectorHessian:
 
         hess = qml.jacobian(cost)(params)
 
-        assert isinstance(hess, np.ndarray)
+        assert isinstance(hess, pnp.ndarray)
         assert hess.shape == (num_copies, 2, 2)
 
     def test_hessian_probs_expval_multiple_params(
@@ -497,8 +497,8 @@ class TestReturnShotVectorHessian:
             pytest.skip("SPSA does not support iterated differentiation in Autograd.")
         dev = qml.device(dev_name, wires=2, shots=shots)
 
-        par_0 = np.array(0.1)
-        par_1 = np.array(0.2)
+        par_0 = pnp.array(0.1)
+        par_1 = pnp.array(0.2)
 
         @qnode(dev, diff_method=diff_method, max_diff=2, **gradient_kwargs)
         def circuit(x, y):
@@ -519,7 +519,7 @@ class TestReturnShotVectorHessian:
         assert isinstance(hess, tuple)
         assert len(hess) == 2
         for h in hess:
-            assert isinstance(h, np.ndarray)
+            assert isinstance(h, pnp.ndarray)
             assert h.shape == (2, num_copies, 3)
 
     def test_hessian_expval_probs_multiple_param_array(
@@ -531,7 +531,7 @@ class TestReturnShotVectorHessian:
 
         dev = qml.device(dev_name, wires=2, shots=shots)
 
-        params = np.array([0.1, 0.2])
+        params = pnp.array([0.1, 0.2])
 
         @qnode(dev, diff_method=diff_method, max_diff=2, **gradient_kwargs)
         def circuit(x):
@@ -549,7 +549,7 @@ class TestReturnShotVectorHessian:
 
         hess = qml.jacobian(cost)(params)
 
-        assert isinstance(hess, np.ndarray)
+        assert isinstance(hess, pnp.ndarray)
         assert hess.shape == (num_copies, 3, 2, 2)
 
 
@@ -568,8 +568,8 @@ class TestReturnShotVectorIntegration:
         """Tests correct output shape and evaluation for a tape
         with a single expval output"""
         dev = qml.device(dev_name, wires=2, shots=shots)
-        x = np.array(0.543)
-        y = np.array(-0.654)
+        x = pnp.array(0.543)
+        y = pnp.array(-0.654)
 
         @qnode(dev, diff_method=diff_method, **gradient_kwargs)
         def circuit(x, y):
@@ -587,13 +587,13 @@ class TestReturnShotVectorIntegration:
         assert isinstance(all_res, tuple)
         assert len(all_res) == 2
 
-        expected = np.array([-np.sin(y) * np.sin(x), np.cos(y) * np.cos(x)])
+        expected = pnp.array([-pnp.sin(y) * pnp.sin(x), pnp.cos(y) * pnp.cos(x)])
         tol = TOLS[diff_method]
 
         for res, exp in zip(all_res, expected):
-            assert isinstance(res, np.ndarray)
+            assert isinstance(res, pnp.ndarray)
             assert res.shape == (num_copies,)
-            assert np.allclose(res, exp, atol=tol, rtol=0)
+            assert pnp.allclose(res, exp, atol=tol, rtol=0)
 
     def test_prob_expectation_values(
         self, dev_name, diff_method, gradient_kwargs, shots, num_copies
@@ -601,8 +601,8 @@ class TestReturnShotVectorIntegration:
         """Tests correct output shape and evaluation for a tape
         with prob and expval outputs"""
         dev = qml.device(dev_name, wires=2, shots=shots)
-        x = np.array(0.543)
-        y = np.array(-0.654)
+        x = pnp.array(0.543)
+        y = pnp.array(-0.654)
 
         @qnode(dev, diff_method=diff_method, **gradient_kwargs)
         def circuit(x, y):
@@ -620,21 +620,21 @@ class TestReturnShotVectorIntegration:
         assert isinstance(all_res, tuple)
         assert len(all_res) == 2
 
-        expected = np.array(
+        expected = pnp.array(
             [
                 [
-                    -np.sin(x),
-                    -(np.cos(y / 2) ** 2 * np.sin(x)) / 2,
-                    -(np.sin(x) * np.sin(y / 2) ** 2) / 2,
-                    (np.sin(x) * np.sin(y / 2) ** 2) / 2,
-                    (np.cos(y / 2) ** 2 * np.sin(x)) / 2,
+                    -pnp.sin(x),
+                    -(pnp.cos(y / 2) ** 2 * pnp.sin(x)) / 2,
+                    -(pnp.sin(x) * pnp.sin(y / 2) ** 2) / 2,
+                    (pnp.sin(x) * pnp.sin(y / 2) ** 2) / 2,
+                    (pnp.cos(y / 2) ** 2 * pnp.sin(x)) / 2,
                 ],
                 [
                     0,
-                    -(np.cos(x / 2) ** 2 * np.sin(y)) / 2,
-                    (np.cos(x / 2) ** 2 * np.sin(y)) / 2,
-                    (np.sin(x / 2) ** 2 * np.sin(y)) / 2,
-                    -(np.sin(x / 2) ** 2 * np.sin(y)) / 2,
+                    -(pnp.cos(x / 2) ** 2 * pnp.sin(y)) / 2,
+                    (pnp.cos(x / 2) ** 2 * pnp.sin(y)) / 2,
+                    (pnp.sin(x / 2) ** 2 * pnp.sin(y)) / 2,
+                    -(pnp.sin(x / 2) ** 2 * pnp.sin(y)) / 2,
                 ],
             ]
         )
@@ -642,6 +642,6 @@ class TestReturnShotVectorIntegration:
         tol = TOLS[diff_method]
 
         for res, exp in zip(all_res, expected):
-            assert isinstance(res, np.ndarray)
+            assert isinstance(res, pnp.ndarray)
             assert res.shape == (num_copies, 5)
-            assert np.allclose(res, exp, atol=tol, rtol=0)
+            assert pnp.allclose(res, exp, atol=tol, rtol=0)

--- a/tests/workflow/interfaces/qnode/test_jax_jit_qnode.py
+++ b/tests/workflow/interfaces/qnode/test_jax_jit_qnode.py
@@ -22,7 +22,7 @@ import pytest
 from param_shift_dev import ParamShiftDerivativesDevice
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane import qnode
 from pennylane.devices import DefaultQubit
 
@@ -145,8 +145,8 @@ class TestQNode:
         # the tape has reported both arguments as trainable
         assert circuit.qtape.trainable_params == [0, 1]
 
-        expected = [-np.sin(a) + np.sin(a) * np.sin(b), -np.cos(a) * np.cos(b)]
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        expected = [-pnp.sin(a) + pnp.sin(a) * pnp.sin(b), -pnp.cos(a) * pnp.cos(b)]
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
         # make the second QNode argument a constant
         grad_fn = jax.grad(circuit, argnums=0)
@@ -155,12 +155,12 @@ class TestQNode:
         # the tape has reported only the first argument as trainable
         assert circuit.qtape.trainable_params == [0]
 
-        expected = [-np.sin(a) + np.sin(a) * np.sin(b)]
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        expected = [-pnp.sin(a) + pnp.sin(a) * pnp.sin(b)]
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
         # trainability also updates on evaluation
-        a = np.array(0.54, requires_grad=False)
-        b = np.array(0.8, requires_grad=True)
+        a = pnp.array(0.54, requires_grad=False)
+        b = pnp.array(0.8, requires_grad=True)
         circuit(a, b)
         assert circuit.qtape.trainable_params == [1]
 
@@ -221,7 +221,7 @@ class TestQNode:
             return qml.expval(qml.PauliZ(0))
 
         res = jax.grad(circuit, argnums=1)(U, a)
-        assert np.allclose(res, np.sin(a), atol=tol, rtol=0)
+        assert pnp.allclose(res, pnp.sin(a), atol=tol, rtol=0)
 
         if diff_method == "finite-diff":
             assert circuit.qtape.trainable_params == [1]
@@ -237,7 +237,7 @@ class TestQNode:
 
         gradient_kwargs = {}
         if diff_method == "spsa":
-            gradient_kwargs["sampler_rng"] = np.random.default_rng(seed)
+            gradient_kwargs["sampler_rng"] = pnp.random.default_rng(seed)
             gradient_kwargs["num_directions"] = 20
             tol = TOL_FOR_SPSA
 
@@ -267,23 +267,23 @@ class TestQNode:
             return qml.expval(qml.PauliX(0))
 
         res = jax.jit(circuit)(a, p)
-        expected = np.cos(a) * np.cos(p[1]) * np.sin(p[0]) + np.sin(a) * (
-            np.cos(p[2]) * np.sin(p[1]) + np.cos(p[0]) * np.cos(p[1]) * np.sin(p[2])
+        expected = pnp.cos(a) * pnp.cos(p[1]) * pnp.sin(p[0]) + pnp.sin(a) * (
+            pnp.cos(p[2]) * pnp.sin(p[1]) + pnp.cos(p[0]) * pnp.cos(p[1]) * pnp.sin(p[2])
         )
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
         res = jax.jit(jax.grad(circuit, argnums=1))(a, p)
-        expected = np.array(
+        expected = pnp.array(
             [
-                np.cos(p[1]) * (np.cos(a) * np.cos(p[0]) - np.sin(a) * np.sin(p[0]) * np.sin(p[2])),
-                np.cos(p[1]) * np.cos(p[2]) * np.sin(a)
-                - np.sin(p[1])
-                * (np.cos(a) * np.sin(p[0]) + np.cos(p[0]) * np.sin(a) * np.sin(p[2])),
-                np.sin(a)
-                * (np.cos(p[0]) * np.cos(p[1]) * np.cos(p[2]) - np.sin(p[1]) * np.sin(p[2])),
+                pnp.cos(p[1]) * (pnp.cos(a) * pnp.cos(p[0]) - pnp.sin(a) * pnp.sin(p[0]) * pnp.sin(p[2])),
+                pnp.cos(p[1]) * pnp.cos(p[2]) * pnp.sin(a)
+                - pnp.sin(p[1])
+                * (pnp.cos(a) * pnp.sin(p[0]) + pnp.cos(p[0]) * pnp.sin(a) * pnp.sin(p[2])),
+                pnp.sin(a)
+                * (pnp.cos(p[0]) * pnp.cos(p[1]) * pnp.cos(p[2]) - pnp.sin(p[1]) * pnp.sin(p[2])),
             ]
         )
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
     def test_jacobian_options(
         self, dev_name, diff_method, grad_on_execution, device_vjp, interface, seed
@@ -293,7 +293,7 @@ class TestQNode:
         if diff_method != "finite-diff":
             pytest.skip("Test only applies to finite diff.")
 
-        a = np.array([0.1, 0.2], requires_grad=True)
+        a = pnp.array([0.1, 0.2], requires_grad=True)
 
         @qnode(
             get_device(dev_name, wires=1, seed=seed),
@@ -339,12 +339,12 @@ class TestVectorValuedQNode:
         gradient_kwargs = {}
 
         if diff_method == "spsa":
-            gradient_kwargs["sampler_rng"] = np.random.default_rng(seed)
+            gradient_kwargs["sampler_rng"] = pnp.random.default_rng(seed)
             gradient_kwargs["num_directions"] = 20
             tol = TOL_FOR_SPSA
 
-        a = np.array(0.1, requires_grad=True)
-        b = np.array(0.2, requires_grad=True)
+        a = pnp.array(0.1, requires_grad=True)
+        b = pnp.array(0.2, requires_grad=True)
 
         @qnode(
             get_device(dev_name, wires=2, seed=seed),
@@ -366,32 +366,32 @@ class TestVectorValuedQNode:
         assert isinstance(res, tuple)
         assert len(res) == 2
 
-        expected = [np.cos(a), -np.cos(a) * np.sin(b)]
-        assert np.allclose(res[0], expected[0], atol=tol, rtol=0)
-        assert np.allclose(res[1], expected[1], atol=tol, rtol=0)
+        expected = [pnp.cos(a), -pnp.cos(a) * pnp.sin(b)]
+        assert pnp.allclose(res[0], expected[0], atol=tol, rtol=0)
+        assert pnp.allclose(res[1], expected[1], atol=tol, rtol=0)
 
         res = jax.jit(jax.jacobian(circuit, argnums=[0, 1]))(a, b)
         assert circuit.qtape.trainable_params == [0, 1]
 
-        expected = np.array([[-np.sin(a), 0], [np.sin(a) * np.sin(b), -np.cos(a) * np.cos(b)]])
+        expected = pnp.array([[-pnp.sin(a), 0], [pnp.sin(a) * pnp.sin(b), -pnp.cos(a) * pnp.cos(b)]])
         assert isinstance(res, tuple)
         assert len(res) == 2
 
         assert isinstance(res[0], tuple)
         assert isinstance(res[0][0], jax.numpy.ndarray)
         assert res[0][0].shape == ()
-        assert np.allclose(res[0][0], expected[0][0], atol=tol, rtol=0)
+        assert pnp.allclose(res[0][0], expected[0][0], atol=tol, rtol=0)
         assert isinstance(res[0][1], jax.numpy.ndarray)
         assert res[0][1].shape == ()
-        assert np.allclose(res[0][1], expected[0][1], atol=tol, rtol=0)
+        assert pnp.allclose(res[0][1], expected[0][1], atol=tol, rtol=0)
 
         assert isinstance(res[1], tuple)
         assert isinstance(res[1][0], jax.numpy.ndarray)
         assert res[1][0].shape == ()
-        assert np.allclose(res[1][0], expected[1][0], atol=tol, rtol=0)
+        assert pnp.allclose(res[1][0], expected[1][0], atol=tol, rtol=0)
         assert isinstance(res[1][1], jax.numpy.ndarray)
         assert res[1][1].shape == ()
-        assert np.allclose(res[1][1], expected[1][1], atol=tol, rtol=0)
+        assert pnp.allclose(res[1][1], expected[1][1], atol=tol, rtol=0)
 
     def test_jacobian_no_evaluate(
         self, dev_name, diff_method, grad_on_execution, device_vjp, interface, tol, seed
@@ -407,7 +407,7 @@ class TestVectorValuedQNode:
         gradient_kwargs = {}
 
         if diff_method == "spsa":
-            gradient_kwargs["sampler_rng"] = np.random.default_rng(seed)
+            gradient_kwargs["sampler_rng"] = pnp.random.default_rng(seed)
             gradient_kwargs["num_directions"] = 20
             tol = TOL_FOR_SPSA
 
@@ -435,13 +435,13 @@ class TestVectorValuedQNode:
         assert isinstance(res, tuple)
         assert len(res) == 2
 
-        expected = np.array([[-np.sin(a), 0], [np.sin(a) * np.sin(b), -np.cos(a) * np.cos(b)]])
+        expected = pnp.array([[-pnp.sin(a), 0], [pnp.sin(a) * pnp.sin(b), -pnp.cos(a) * pnp.cos(b)]])
 
         for _res, _exp in zip(res, expected):
             for r, e in zip(_res, _exp):
                 assert isinstance(r, jax.numpy.ndarray)
                 assert r.shape == ()
-                assert np.allclose(r, e, atol=tol, rtol=0)
+                assert pnp.allclose(r, e, atol=tol, rtol=0)
 
         # call the Jacobian with new parameters
         a = jax.numpy.array(0.6)
@@ -452,13 +452,13 @@ class TestVectorValuedQNode:
         assert isinstance(res, tuple)
         assert len(res) == 2
 
-        expected = np.array([[-np.sin(a), 0], [np.sin(a) * np.sin(b), -np.cos(a) * np.cos(b)]])
+        expected = pnp.array([[-pnp.sin(a), 0], [pnp.sin(a) * pnp.sin(b), -pnp.cos(a) * pnp.cos(b)]])
 
         for _res, _exp in zip(res, expected):
             for r, e in zip(_res, _exp):
                 assert isinstance(r, jax.numpy.ndarray)
                 assert r.shape == ()
-                assert np.allclose(r, e, atol=tol, rtol=0)
+                assert pnp.allclose(r, e, atol=tol, rtol=0)
 
     def test_diff_single_probs(
         self, dev_name, diff_method, grad_on_execution, device_vjp, interface, tol, seed
@@ -474,7 +474,7 @@ class TestVectorValuedQNode:
 
         gradient_kwargs = {}
         if diff_method == "spsa":
-            gradient_kwargs["sampler_rng"] = np.random.default_rng(seed)
+            gradient_kwargs["sampler_rng"] = pnp.random.default_rng(seed)
             gradient_kwargs["num_directions"] = 20
             tol = TOL_FOR_SPSA
 
@@ -497,10 +497,10 @@ class TestVectorValuedQNode:
 
         res = jax.jit(jax.jacobian(circuit, argnums=[0, 1]))(x, y)
 
-        expected = np.array(
+        expected = pnp.array(
             [
-                [-np.sin(x) * np.cos(y) / 2, -np.cos(x) * np.sin(y) / 2],
-                [np.cos(y) * np.sin(x) / 2, np.cos(x) * np.sin(y) / 2],
+                [-pnp.sin(x) * pnp.cos(y) / 2, -pnp.cos(x) * pnp.sin(y) / 2],
+                [pnp.cos(y) * pnp.sin(x) / 2, pnp.cos(x) * pnp.sin(y) / 2],
             ]
         )
 
@@ -513,8 +513,8 @@ class TestVectorValuedQNode:
         assert isinstance(res[1], jax.numpy.ndarray)
         assert res[1].shape == (2,)
 
-        assert np.allclose(res[0], expected.T[0], atol=tol, rtol=0)
-        assert np.allclose(res[1], expected.T[1], atol=tol, rtol=0)
+        assert pnp.allclose(res[0], expected.T[0], atol=tol, rtol=0)
+        assert pnp.allclose(res[1], expected.T[1], atol=tol, rtol=0)
 
     def test_diff_multi_probs(
         self, dev_name, diff_method, grad_on_execution, device_vjp, interface, tol, seed
@@ -530,7 +530,7 @@ class TestVectorValuedQNode:
 
         gradient_kwargs = {}
         if diff_method == "spsa":
-            gradient_kwargs["sampler_rng"] = np.random.default_rng(seed)
+            gradient_kwargs["sampler_rng"] = pnp.random.default_rng(seed)
             gradient_kwargs["num_directions"] = 20
             tol = TOL_FOR_SPSA
 
@@ -557,30 +557,30 @@ class TestVectorValuedQNode:
         assert len(res) == 2
 
         expected = [
-            [np.cos(x / 2) ** 2, np.sin(x / 2) ** 2],
-            [(1 + np.cos(x) * np.cos(y)) / 2, 0, (1 - np.cos(x) * np.cos(y)) / 2, 0],
+            [pnp.cos(x / 2) ** 2, pnp.sin(x / 2) ** 2],
+            [(1 + pnp.cos(x) * pnp.cos(y)) / 2, 0, (1 - pnp.cos(x) * pnp.cos(y)) / 2, 0],
         ]
 
         assert isinstance(res[0], jax.numpy.ndarray)
         assert res[0].shape == (2,)  # pylint:disable=comparison-with-callable
-        assert np.allclose(res[0], expected[0], atol=tol, rtol=0)
+        assert pnp.allclose(res[0], expected[0], atol=tol, rtol=0)
 
         assert isinstance(res[1], jax.numpy.ndarray)
         assert res[1].shape == (4,)  # pylint:disable=comparison-with-callable
-        assert np.allclose(res[1], expected[1], atol=tol, rtol=0)
+        assert pnp.allclose(res[1], expected[1], atol=tol, rtol=0)
 
         jac = jax.jit(jax.jacobian(circuit, argnums=[0, 1]))(x, y)
-        expected_0 = np.array(
+        expected_0 = pnp.array(
             [
-                [-np.sin(x) / 2, np.sin(x) / 2],
+                [-pnp.sin(x) / 2, pnp.sin(x) / 2],
                 [0, 0],
             ]
         )
 
-        expected_1 = np.array(
+        expected_1 = pnp.array(
             [
-                [-np.cos(y) * np.sin(x) / 2, 0, np.sin(x) * np.cos(y) / 2, 0],
-                [-np.cos(x) * np.sin(y) / 2, 0, np.cos(x) * np.sin(y) / 2, 0],
+                [-pnp.cos(y) * pnp.sin(x) / 2, 0, pnp.sin(x) * pnp.cos(y) / 2, 0],
+                [-pnp.cos(x) * pnp.sin(y) / 2, 0, pnp.cos(x) * pnp.sin(y) / 2, 0],
             ]
         )
 
@@ -590,20 +590,20 @@ class TestVectorValuedQNode:
         assert len(jac[0]) == 2
         assert isinstance(jac[0][0], jax.numpy.ndarray)
         assert jac[0][0].shape == (2,)
-        assert np.allclose(jac[0][0], expected_0[0], atol=tol, rtol=0)
+        assert pnp.allclose(jac[0][0], expected_0[0], atol=tol, rtol=0)
         assert isinstance(jac[0][1], jax.numpy.ndarray)
         assert jac[0][1].shape == (2,)
-        assert np.allclose(jac[0][1], expected_0[1], atol=tol, rtol=0)
+        assert pnp.allclose(jac[0][1], expected_0[1], atol=tol, rtol=0)
 
         assert isinstance(jac[1], tuple)
         assert len(jac[1]) == 2
         assert isinstance(jac[1][0], jax.numpy.ndarray)
         assert jac[1][0].shape == (4,)
 
-        assert np.allclose(jac[1][0], expected_1[0], atol=tol, rtol=0)
+        assert pnp.allclose(jac[1][0], expected_1[0], atol=tol, rtol=0)
         assert isinstance(jac[1][1], jax.numpy.ndarray)
         assert jac[1][1].shape == (4,)
-        assert np.allclose(jac[1][1], expected_1[1], atol=tol, rtol=0)
+        assert pnp.allclose(jac[1][1], expected_1[1], atol=tol, rtol=0)
 
     def test_diff_expval_probs(
         self, dev_name, diff_method, grad_on_execution, device_vjp, interface, tol, seed
@@ -619,7 +619,7 @@ class TestVectorValuedQNode:
 
         gradient_kwargs = {}
         if diff_method == "spsa":
-            gradient_kwargs["sampler_rng"] = np.random.default_rng(seed)
+            gradient_kwargs["sampler_rng"] = pnp.random.default_rng(seed)
             gradient_kwargs["num_directions"] = 20
             tol = TOL_FOR_SPSA
 
@@ -641,25 +641,25 @@ class TestVectorValuedQNode:
             return qml.expval(qml.PauliZ(0)), qml.probs(wires=[1])
 
         res = jax.jit(circuit)(x, y)
-        expected = [np.cos(x), [(1 + np.cos(x) * np.cos(y)) / 2, (1 - np.cos(x) * np.cos(y)) / 2]]
+        expected = [pnp.cos(x), [(1 + pnp.cos(x) * pnp.cos(y)) / 2, (1 - pnp.cos(x) * pnp.cos(y)) / 2]]
 
         assert isinstance(res, tuple)
         assert len(res) == 2
 
         assert isinstance(res[0], jax.numpy.ndarray)
         assert res[0].shape == ()
-        assert np.allclose(res[0], expected[0], atol=tol, rtol=0)
+        assert pnp.allclose(res[0], expected[0], atol=tol, rtol=0)
 
         assert isinstance(res[1], jax.numpy.ndarray)
         assert res[1].shape == (2,)
-        assert np.allclose(res[1], expected[1], atol=tol, rtol=0)
+        assert pnp.allclose(res[1], expected[1], atol=tol, rtol=0)
 
         jac = jax.jit(jax.jacobian(circuit, argnums=[0, 1]))(x, y)
         expected = [
-            [-np.sin(x), 0],
+            [-pnp.sin(x), 0],
             [
-                [-np.sin(x) * np.cos(y) / 2, np.cos(y) * np.sin(x) / 2],
-                [-np.cos(x) * np.sin(y) / 2, np.cos(x) * np.sin(y) / 2],
+                [-pnp.sin(x) * pnp.cos(y) / 2, pnp.cos(y) * pnp.sin(x) / 2],
+                [-pnp.cos(x) * pnp.sin(y) / 2, pnp.cos(x) * pnp.sin(y) / 2],
             ],
         ]
 
@@ -670,19 +670,19 @@ class TestVectorValuedQNode:
         assert len(jac[0]) == 2
         assert isinstance(jac[0][0], jax.numpy.ndarray)
         assert jac[0][0].shape == ()
-        assert np.allclose(jac[0][0], expected[0][0], atol=tol, rtol=0)
+        assert pnp.allclose(jac[0][0], expected[0][0], atol=tol, rtol=0)
         assert isinstance(jac[0][1], jax.numpy.ndarray)
         assert jac[0][1].shape == ()
-        assert np.allclose(jac[0][1], expected[0][1], atol=tol, rtol=0)
+        assert pnp.allclose(jac[0][1], expected[0][1], atol=tol, rtol=0)
 
         assert isinstance(jac[1], tuple)
         assert len(jac[1]) == 2
         assert isinstance(jac[1][0], jax.numpy.ndarray)
         assert jac[1][0].shape == (2,)
-        assert np.allclose(jac[1][0], expected[1][0], atol=tol, rtol=0)
+        assert pnp.allclose(jac[1][0], expected[1][0], atol=tol, rtol=0)
         assert isinstance(jac[1][1], jax.numpy.ndarray)
         assert jac[1][1].shape == (2,)
-        assert np.allclose(jac[1][1], expected[1][1], atol=tol, rtol=0)
+        assert pnp.allclose(jac[1][1], expected[1][1], atol=tol, rtol=0)
 
     def test_diff_expval_probs_sub_argnums(
         self, dev_name, diff_method, grad_on_execution, device_vjp, interface, tol, seed
@@ -698,7 +698,7 @@ class TestVectorValuedQNode:
 
         kwargs = {}
         if diff_method == "spsa":
-            kwargs["sampler_rng"] = np.random.default_rng(seed)
+            kwargs["sampler_rng"] = pnp.random.default_rng(seed)
             tol = TOL_FOR_SPSA
 
         x = jax.numpy.array(0.543)
@@ -721,10 +721,10 @@ class TestVectorValuedQNode:
         jac = jax.jit(jax.jacobian(circuit, argnums=[0]))(x, y)
 
         expected = [
-            [-np.sin(x), 0],
+            [-pnp.sin(x), 0],
             [
-                [-np.sin(x) * np.cos(y) / 2, np.cos(y) * np.sin(x) / 2],
-                [-np.cos(x) * np.sin(y) / 2, np.cos(x) * np.sin(y) / 2],
+                [-pnp.sin(x) * pnp.cos(y) / 2, pnp.cos(y) * pnp.sin(x) / 2],
+                [-pnp.cos(x) * pnp.sin(y) / 2, pnp.cos(x) * pnp.sin(y) / 2],
             ],
         ]
         assert isinstance(jac, tuple)
@@ -734,13 +734,13 @@ class TestVectorValuedQNode:
         assert len(jac[0]) == 1
         assert isinstance(jac[0][0], jax.numpy.ndarray)
         assert jac[0][0].shape == ()
-        assert np.allclose(jac[0][0], expected[0][0], atol=tol, rtol=0)
+        assert pnp.allclose(jac[0][0], expected[0][0], atol=tol, rtol=0)
 
         assert isinstance(jac[1], tuple)
         assert len(jac[1]) == 1
         assert isinstance(jac[1][0], jax.numpy.ndarray)
         assert jac[1][0].shape == (2,)
-        assert np.allclose(jac[1][0], expected[1][0], atol=tol, rtol=0)
+        assert pnp.allclose(jac[1][0], expected[1][0], atol=tol, rtol=0)
 
     def test_diff_var_probs(
         self, dev_name, diff_method, grad_on_execution, device_vjp, interface, tol, seed
@@ -758,7 +758,7 @@ class TestVectorValuedQNode:
         if diff_method == "hadamard":
             pytest.skip("Hadamard does not support var")
         elif diff_method == "spsa":
-            gradient_kwargs["sampler_rng"] = np.random.default_rng(seed)
+            gradient_kwargs["sampler_rng"] = pnp.random.default_rng(seed)
             gradient_kwargs["num_directions"] = 20
             tol = TOL_FOR_SPSA
 
@@ -782,24 +782,24 @@ class TestVectorValuedQNode:
         res = jax.jit(circuit)(x, y)
 
         expected = [
-            np.sin(x) ** 2,
-            [(1 + np.cos(x) * np.cos(y)) / 2, (1 - np.cos(x) * np.cos(y)) / 2],
+            pnp.sin(x) ** 2,
+            [(1 + pnp.cos(x) * pnp.cos(y)) / 2, (1 - pnp.cos(x) * pnp.cos(y)) / 2],
         ]
 
         assert isinstance(res[0], jax.numpy.ndarray)
         assert res[0].shape == ()
-        assert np.allclose(res[0], expected[0], atol=tol, rtol=0)
+        assert pnp.allclose(res[0], expected[0], atol=tol, rtol=0)
 
         assert isinstance(res[1], jax.numpy.ndarray)
         assert res[1].shape == (2,)
-        assert np.allclose(res[1], expected[1], atol=tol, rtol=0)
+        assert pnp.allclose(res[1], expected[1], atol=tol, rtol=0)
 
         jac = jax.jit(jax.jacobian(circuit, argnums=[0, 1]))(x, y)
         expected = [
-            [2 * np.cos(x) * np.sin(x), 0],
+            [2 * pnp.cos(x) * pnp.sin(x), 0],
             [
-                [-np.sin(x) * np.cos(y) / 2, np.cos(y) * np.sin(x) / 2],
-                [-np.cos(x) * np.sin(y) / 2, np.cos(x) * np.sin(y) / 2],
+                [-pnp.sin(x) * pnp.cos(y) / 2, pnp.cos(y) * pnp.sin(x) / 2],
+                [-pnp.cos(x) * pnp.sin(y) / 2, pnp.cos(x) * pnp.sin(y) / 2],
             ],
         ]
 
@@ -810,19 +810,19 @@ class TestVectorValuedQNode:
         assert len(jac[0]) == 2
         assert isinstance(jac[0][0], jax.numpy.ndarray)
         assert jac[0][0].shape == ()
-        assert np.allclose(jac[0][0], expected[0][0], atol=tol, rtol=0)
+        assert pnp.allclose(jac[0][0], expected[0][0], atol=tol, rtol=0)
         assert isinstance(jac[0][1], jax.numpy.ndarray)
         assert jac[0][1].shape == ()
-        assert np.allclose(jac[0][1], expected[0][1], atol=tol, rtol=0)
+        assert pnp.allclose(jac[0][1], expected[0][1], atol=tol, rtol=0)
 
         assert isinstance(jac[1], tuple)
         assert len(jac[1]) == 2
         assert isinstance(jac[1][0], jax.numpy.ndarray)
         assert jac[1][0].shape == (2,)
-        assert np.allclose(jac[1][0], expected[1][0], atol=tol, rtol=0)
+        assert pnp.allclose(jac[1][0], expected[1][0], atol=tol, rtol=0)
         assert isinstance(jac[1][1], jax.numpy.ndarray)
         assert jac[1][1].shape == (2,)
-        assert np.allclose(jac[1][1], expected[1][1], atol=tol, rtol=0)
+        assert pnp.allclose(jac[1][1], expected[1][1], atol=tol, rtol=0)
 
 
 @pytest.mark.parametrize("interface", ["auto", "jax", "jax-jit"])
@@ -878,8 +878,8 @@ class TestShotsIntegration:
         jit_cost_fn = jax.jit(cost_fn, static_argnames=["shots"])
         res = jax.grad(jit_cost_fn, argnums=[0, 1])(a, b, shots=30000)
 
-        expected = [np.sin(a) * np.sin(b), -np.cos(a) * np.cos(b)]
-        assert np.allclose(res, expected, atol=0.1, rtol=0)
+        expected = [pnp.sin(a) * pnp.sin(b), -pnp.cos(a) * pnp.cos(b)]
+        assert pnp.allclose(res, expected, atol=0.1, rtol=0)
 
     def test_update_diff_method(self, mocker, interface):
         """Test that temporarily setting the shots updates the diff method"""
@@ -920,12 +920,12 @@ class TestShotsIntegration:
             return qml.var(qml.PauliZ(0))
 
         res = circuit(0.5)
-        expected = 1 - np.cos(0.5) ** 2
+        expected = 1 - pnp.cos(0.5) ** 2
         assert qml.math.allclose(res[0], expected, atol=5e-2)
         assert qml.math.allclose(res[1], expected, rtol=5e-2)
 
         g = jax.jacobian(circuit)(0.5)
-        expected_g = 2 * np.cos(0.5) * np.sin(0.5)
+        expected_g = 2 * pnp.cos(0.5) * pnp.sin(0.5)
         assert qml.math.allclose(g[0], expected_g, rtol=5e-2)
         assert qml.math.allclose(g[1], expected_g, rtol=5e-2)
 
@@ -942,10 +942,10 @@ class TestShotsIntegration:
             return qml.expval(qml.PauliZ(0)), qml.probs(wires=0)
 
         res = circuit(0.5)
-        assert qml.math.allclose(res[0][0], np.cos(0.5), rtol=5e-2)
-        assert qml.math.allclose(res[1][0], np.cos(0.5), rtol=5e-2)
+        assert qml.math.allclose(res[0][0], pnp.cos(0.5), rtol=5e-2)
+        assert qml.math.allclose(res[1][0], pnp.cos(0.5), rtol=5e-2)
 
-        expected_probs = np.array([np.cos(0.25) ** 2, np.sin(0.25) ** 2])
+        expected_probs = pnp.array([pnp.cos(0.25) ** 2, pnp.sin(0.25) ** 2])
         assert qml.math.allclose(res[0][1], expected_probs, atol=1e-2)
         assert qml.math.allclose(res[1][1][0], expected_probs[0], rtol=5e-2)
         assert qml.math.allclose(res[1][1][1], expected_probs[1], atol=5e-3)
@@ -1074,8 +1074,8 @@ class TestQubitIntegration:
         w2 = qml.templates.StronglyEntanglingLayers.shape(n_wires=2, n_layers=4)
 
         weights = [
-            jax.numpy.array(np.random.random(w1)),
-            jax.numpy.array(np.random.random(w2)),
+            jax.numpy.array(pnp.random.random(w1)),
+            jax.numpy.array(pnp.random.random(w2)),
         ]
 
         grad_fn = jax.jit(jax.grad(cost))
@@ -1124,11 +1124,11 @@ class TestQubitIntegration:
         phi = jax.numpy.array(1.23)
         theta = jax.numpy.array(4.56)
 
-        assert np.allclose(jax.jit(circuit)(phi, theta), jax.jit(expected_circuit)(theta))
+        assert pnp.allclose(jax.jit(circuit)(phi, theta), jax.jit(expected_circuit)(theta))
 
         gradient = jax.jit(jax.grad(circuit, argnums=[0, 1]))(phi, theta)
         exp_theta_grad = jax.jit(jax.grad(expected_circuit))(theta)
-        assert np.allclose(gradient, [0.0, exp_theta_grad])
+        assert pnp.allclose(gradient, [0.0, exp_theta_grad])
 
 
 @pytest.mark.parametrize("interface", ["auto", "jax-jit"])
@@ -1148,7 +1148,7 @@ class TestQubitIntegrationHigherOrder:
         if diff_method in {"adjoint", "device"}:
             pytest.skip("Adjoint does not support second derivatives.")
         elif diff_method == "spsa":
-            gradient_kwargs["sampler_rng"] = np.random.default_rng(seed)
+            gradient_kwargs["sampler_rng"] = pnp.random.default_rng(seed)
             gradient_kwargs["num_directions"] = 20
             gradient_kwargs["h"] = H_FOR_SPSA
             tol = TOL_FOR_SPSA
@@ -1176,20 +1176,20 @@ class TestQubitIntegrationHigherOrder:
 
         a, b = x
 
-        expected_res = np.cos(a) * np.cos(b)
-        assert np.allclose(res, expected_res, atol=tol, rtol=0)
+        expected_res = pnp.cos(a) * pnp.cos(b)
+        assert pnp.allclose(res, expected_res, atol=tol, rtol=0)
 
-        expected_g = [-np.sin(a) * np.cos(b), -np.cos(a) * np.sin(b)]
-        assert np.allclose(g, expected_g, atol=tol, rtol=0)
+        expected_g = [-pnp.sin(a) * pnp.cos(b), -pnp.cos(a) * pnp.sin(b)]
+        assert pnp.allclose(g, expected_g, atol=tol, rtol=0)
 
         expected_g2 = [
-            -np.cos(a) * np.cos(b) + np.sin(a) * np.sin(b),
-            np.sin(a) * np.sin(b) - np.cos(a) * np.cos(b),
+            -pnp.cos(a) * pnp.cos(b) + pnp.sin(a) * pnp.sin(b),
+            pnp.sin(a) * pnp.sin(b) - pnp.cos(a) * pnp.cos(b),
         ]
         if diff_method == "finite-diff":
-            assert np.allclose(g2, expected_g2, atol=10e-2, rtol=0)
+            assert pnp.allclose(g2, expected_g2, atol=10e-2, rtol=0)
         else:
-            assert np.allclose(g2, expected_g2, atol=tol, rtol=0)
+            assert pnp.allclose(g2, expected_g2, atol=tol, rtol=0)
 
     def test_hessian(
         self, dev_name, diff_method, grad_on_execution, device_vjp, interface, tol, seed
@@ -1202,7 +1202,7 @@ class TestQubitIntegrationHigherOrder:
             gradient_kwargs = {
                 "h": H_FOR_SPSA,
                 "num_directions": 40,
-                "sampler_rng": np.random.default_rng(seed),
+                "sampler_rng": pnp.random.default_rng(seed),
             }
             tol = TOL_FOR_SPSA
 
@@ -1227,25 +1227,25 @@ class TestQubitIntegrationHigherOrder:
 
         a, b = x
 
-        expected_res = np.cos(a) * np.cos(b)
-        assert np.allclose(res, expected_res, atol=tol, rtol=0)
+        expected_res = pnp.cos(a) * pnp.cos(b)
+        assert pnp.allclose(res, expected_res, atol=tol, rtol=0)
 
         grad_fn = jax.jit(jax.grad(circuit))
         g = grad_fn(x)
 
-        expected_g = [-np.sin(a) * np.cos(b), -np.cos(a) * np.sin(b)]
-        assert np.allclose(g, expected_g, atol=tol, rtol=0)
+        expected_g = [-pnp.sin(a) * pnp.cos(b), -pnp.cos(a) * pnp.sin(b)]
+        assert pnp.allclose(g, expected_g, atol=tol, rtol=0)
 
         hess = jax.jit(jax.jacobian(grad_fn))(x)
 
         expected_hess = [
-            [-np.cos(a) * np.cos(b), np.sin(a) * np.sin(b)],
-            [np.sin(a) * np.sin(b), -np.cos(a) * np.cos(b)],
+            [-pnp.cos(a) * pnp.cos(b), pnp.sin(a) * pnp.sin(b)],
+            [pnp.sin(a) * pnp.sin(b), -pnp.cos(a) * pnp.cos(b)],
         ]
         if diff_method == "finite-diff":
-            assert np.allclose(hess, expected_hess, atol=10e-2, rtol=0)
+            assert pnp.allclose(hess, expected_hess, atol=10e-2, rtol=0)
         else:
-            assert np.allclose(hess, expected_hess, atol=tol, rtol=0)
+            assert pnp.allclose(hess, expected_hess, atol=tol, rtol=0)
 
     def test_hessian_vector_valued(
         self, dev_name, diff_method, grad_on_execution, device_vjp, interface, tol, seed
@@ -1258,7 +1258,7 @@ class TestQubitIntegrationHigherOrder:
             gradient_kwargs = {
                 "h": H_FOR_SPSA,
                 "num_directions": 20,
-                "sampler_rng": np.random.default_rng(seed),
+                "sampler_rng": pnp.random.default_rng(seed),
             }
             tol = TOL_FOR_SPSA
 
@@ -1281,34 +1281,34 @@ class TestQubitIntegrationHigherOrder:
 
         a, b = x
 
-        expected_res = [0.5 + 0.5 * np.cos(a) * np.cos(b), 0.5 - 0.5 * np.cos(a) * np.cos(b)]
-        assert np.allclose(res, expected_res, atol=tol, rtol=0)
+        expected_res = [0.5 + 0.5 * pnp.cos(a) * pnp.cos(b), 0.5 - 0.5 * pnp.cos(a) * pnp.cos(b)]
+        assert pnp.allclose(res, expected_res, atol=tol, rtol=0)
 
         jac_fn = jax.jit(jax.jacobian(circuit))
         g = jac_fn(x)
 
         expected_g = [
-            [-0.5 * np.sin(a) * np.cos(b), -0.5 * np.cos(a) * np.sin(b)],
-            [0.5 * np.sin(a) * np.cos(b), 0.5 * np.cos(a) * np.sin(b)],
+            [-0.5 * pnp.sin(a) * pnp.cos(b), -0.5 * pnp.cos(a) * pnp.sin(b)],
+            [0.5 * pnp.sin(a) * pnp.cos(b), 0.5 * pnp.cos(a) * pnp.sin(b)],
         ]
-        assert np.allclose(g, expected_g, atol=tol, rtol=0)
+        assert pnp.allclose(g, expected_g, atol=tol, rtol=0)
 
         hess = jax.jit(jax.jacobian(jac_fn))(x)
 
         expected_hess = [
             [
-                [-0.5 * np.cos(a) * np.cos(b), 0.5 * np.sin(a) * np.sin(b)],
-                [0.5 * np.sin(a) * np.sin(b), -0.5 * np.cos(a) * np.cos(b)],
+                [-0.5 * pnp.cos(a) * pnp.cos(b), 0.5 * pnp.sin(a) * pnp.sin(b)],
+                [0.5 * pnp.sin(a) * pnp.sin(b), -0.5 * pnp.cos(a) * pnp.cos(b)],
             ],
             [
-                [0.5 * np.cos(a) * np.cos(b), -0.5 * np.sin(a) * np.sin(b)],
-                [-0.5 * np.sin(a) * np.sin(b), 0.5 * np.cos(a) * np.cos(b)],
+                [0.5 * pnp.cos(a) * pnp.cos(b), -0.5 * pnp.sin(a) * pnp.sin(b)],
+                [-0.5 * pnp.sin(a) * pnp.sin(b), 0.5 * pnp.cos(a) * pnp.cos(b)],
             ],
         ]
         if diff_method == "finite-diff":
-            assert np.allclose(hess, expected_hess, atol=10e-2, rtol=0)
+            assert pnp.allclose(hess, expected_hess, atol=10e-2, rtol=0)
         else:
-            assert np.allclose(hess, expected_hess, atol=tol, rtol=0)
+            assert pnp.allclose(hess, expected_hess, atol=tol, rtol=0)
 
     def test_hessian_vector_valued_postprocessing(
         self, dev_name, diff_method, interface, device_vjp, grad_on_execution, tol, seed
@@ -1321,7 +1321,7 @@ class TestQubitIntegrationHigherOrder:
             gradient_kwargs = {
                 "h": H_FOR_SPSA,
                 "num_directions": 20,
-                "sampler_rng": np.random.default_rng(seed),
+                "sampler_rng": pnp.random.default_rng(seed),
             }
             tol = TOL_FOR_SPSA
 
@@ -1347,34 +1347,34 @@ class TestQubitIntegrationHigherOrder:
 
         a, b = x
 
-        expected_res = x @ jax.numpy.array([np.cos(a) * np.cos(b), np.cos(a) * np.cos(b)])
-        assert np.allclose(res, expected_res, atol=tol, rtol=0)
+        expected_res = x @ jax.numpy.array([pnp.cos(a) * pnp.cos(b), pnp.cos(a) * pnp.cos(b)])
+        assert pnp.allclose(res, expected_res, atol=tol, rtol=0)
 
         grad_fn = jax.jit(jax.grad(cost_fn))
         g = grad_fn(x)
 
         expected_g = [
-            np.cos(b) * (np.cos(a) - (a + b) * np.sin(a)),
-            np.cos(a) * (np.cos(b) - (a + b) * np.sin(b)),
+            pnp.cos(b) * (pnp.cos(a) - (a + b) * pnp.sin(a)),
+            pnp.cos(a) * (pnp.cos(b) - (a + b) * pnp.sin(b)),
         ]
-        assert np.allclose(g, expected_g, atol=tol, rtol=0)
+        assert pnp.allclose(g, expected_g, atol=tol, rtol=0)
         hess = jax.jit(jax.jacobian(grad_fn))(x)
 
         expected_hess = [
             [
-                -(np.cos(b) * ((a + b) * np.cos(a) + 2 * np.sin(a))),
-                -(np.cos(b) * np.sin(a)) + (-np.cos(a) + (a + b) * np.sin(a)) * np.sin(b),
+                -(pnp.cos(b) * ((a + b) * pnp.cos(a) + 2 * pnp.sin(a))),
+                -(pnp.cos(b) * pnp.sin(a)) + (-pnp.cos(a) + (a + b) * pnp.sin(a)) * pnp.sin(b),
             ],
             [
-                -(np.cos(b) * np.sin(a)) + (-np.cos(a) + (a + b) * np.sin(a)) * np.sin(b),
-                -(np.cos(a) * ((a + b) * np.cos(b) + 2 * np.sin(b))),
+                -(pnp.cos(b) * pnp.sin(a)) + (-pnp.cos(a) + (a + b) * pnp.sin(a)) * pnp.sin(b),
+                -(pnp.cos(a) * ((a + b) * pnp.cos(b) + 2 * pnp.sin(b))),
             ],
         ]
 
         if diff_method == "finite-diff":
-            assert np.allclose(hess, expected_hess, atol=10e-2, rtol=0)
+            assert pnp.allclose(hess, expected_hess, atol=10e-2, rtol=0)
         else:
-            assert np.allclose(hess, expected_hess, atol=tol, rtol=0)
+            assert pnp.allclose(hess, expected_hess, atol=tol, rtol=0)
 
     def test_hessian_vector_valued_separate_args(
         self, dev_name, diff_method, grad_on_execution, device_vjp, interface, tol, seed
@@ -1387,7 +1387,7 @@ class TestQubitIntegrationHigherOrder:
             gradient_kwargs = {
                 "h": H_FOR_SPSA,
                 "num_directions": 20,
-                "sampler_rng": np.random.default_rng(seed),
+                "sampler_rng": pnp.random.default_rng(seed),
             }
             tol = TOL_FOR_SPSA
 
@@ -1409,38 +1409,38 @@ class TestQubitIntegrationHigherOrder:
         b = jax.numpy.array(2.0)
         res = circuit(a, b)
 
-        expected_res = [0.5 + 0.5 * np.cos(a) * np.cos(b), 0.5 - 0.5 * np.cos(a) * np.cos(b)]
-        assert np.allclose(res, expected_res, atol=tol, rtol=0)
+        expected_res = [0.5 + 0.5 * pnp.cos(a) * pnp.cos(b), 0.5 - 0.5 * pnp.cos(a) * pnp.cos(b)]
+        assert pnp.allclose(res, expected_res, atol=tol, rtol=0)
 
         jac_fn = jax.jit(jax.jacobian(circuit, argnums=[0, 1]))
         g = jac_fn(a, b)
 
-        expected_g = np.array(
+        expected_g = pnp.array(
             [
-                [-0.5 * np.sin(a) * np.cos(b), -0.5 * np.cos(a) * np.sin(b)],
-                [0.5 * np.sin(a) * np.cos(b), 0.5 * np.cos(a) * np.sin(b)],
+                [-0.5 * pnp.sin(a) * pnp.cos(b), -0.5 * pnp.cos(a) * pnp.sin(b)],
+                [0.5 * pnp.sin(a) * pnp.cos(b), 0.5 * pnp.cos(a) * pnp.sin(b)],
             ]
         )
-        assert np.allclose(g, expected_g.T, atol=tol, rtol=0)
+        assert pnp.allclose(g, expected_g.T, atol=tol, rtol=0)
 
         hess = jax.jit(jax.jacobian(jac_fn, argnums=[0, 1]))(a, b)
 
-        expected_hess = np.array(
+        expected_hess = pnp.array(
             [
                 [
-                    [-0.5 * np.cos(a) * np.cos(b), 0.5 * np.cos(a) * np.cos(b)],
-                    [0.5 * np.sin(a) * np.sin(b), -0.5 * np.sin(a) * np.sin(b)],
+                    [-0.5 * pnp.cos(a) * pnp.cos(b), 0.5 * pnp.cos(a) * pnp.cos(b)],
+                    [0.5 * pnp.sin(a) * pnp.sin(b), -0.5 * pnp.sin(a) * pnp.sin(b)],
                 ],
                 [
-                    [0.5 * np.sin(a) * np.sin(b), -0.5 * np.sin(a) * np.sin(b)],
-                    [-0.5 * np.cos(a) * np.cos(b), 0.5 * np.cos(a) * np.cos(b)],
+                    [0.5 * pnp.sin(a) * pnp.sin(b), -0.5 * pnp.sin(a) * pnp.sin(b)],
+                    [-0.5 * pnp.cos(a) * pnp.cos(b), 0.5 * pnp.cos(a) * pnp.cos(b)],
                 ],
             ]
         )
         if diff_method == "finite-diff":
-            assert np.allclose(hess, expected_hess, atol=10e-2, rtol=0)
+            assert pnp.allclose(hess, expected_hess, atol=10e-2, rtol=0)
         else:
-            assert np.allclose(hess, expected_hess, atol=tol, rtol=0)
+            assert pnp.allclose(hess, expected_hess, atol=tol, rtol=0)
 
     def test_state(
         self, dev_name, diff_method, grad_on_execution, device_vjp, interface, tol, seed
@@ -1470,7 +1470,7 @@ class TestQubitIntegrationHigherOrder:
 
         def cost_fn(x, y):
             res = circuit(x, y)
-            assert res.dtype is np.dtype("complex128")
+            assert res.dtype is pnp.dtype("complex128")
             probs = jax.numpy.abs(res) ** 2
             return probs[0] + probs[2]
 
@@ -1480,8 +1480,8 @@ class TestQubitIntegrationHigherOrder:
             pytest.skip("Test only supports backprop")
 
         res = jax.jit(jax.grad(cost_fn, argnums=[0, 1]))(x, y)
-        expected = np.array([-np.sin(x) * np.cos(y) / 2, -np.cos(x) * np.sin(y) / 2])
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        expected = pnp.array([-pnp.sin(x) * pnp.cos(y) / 2, -pnp.cos(x) * pnp.sin(y) / 2])
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
     @pytest.mark.parametrize("state", [[1], [0, 1]])  # Basis state and state vector
     def test_projector(
@@ -1496,7 +1496,7 @@ class TestQubitIntegrationHigherOrder:
         elif diff_method == "hadamard":
             pytest.skip("Hadamard does not support var")
         elif diff_method == "spsa":
-            gradient_kwargs = {"h": H_FOR_SPSA, "sampler_rng": np.random.default_rng(seed)}
+            gradient_kwargs = {"h": H_FOR_SPSA, "sampler_rng": pnp.random.default_rng(seed)}
             tol = TOL_FOR_SPSA
         if dev_name == "reference.qubit":
             pytest.xfail("diagonalize_measurements do not support projectors (sc-72911)")
@@ -1519,17 +1519,17 @@ class TestQubitIntegrationHigherOrder:
             return qml.var(qml.Projector(P, wires=0) @ qml.PauliX(1))
 
         res = jax.jit(circuit)(x, y)
-        expected = 0.25 * np.sin(x / 2) ** 2 * (3 + np.cos(2 * y) + 2 * np.cos(x) * np.sin(y) ** 2)
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        expected = 0.25 * pnp.sin(x / 2) ** 2 * (3 + pnp.cos(2 * y) + 2 * pnp.cos(x) * pnp.sin(y) ** 2)
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
         res = jax.jit(jax.grad(circuit, argnums=[0, 1]))(x, y)
-        expected = np.array(
+        expected = pnp.array(
             [
-                0.5 * np.sin(x) * (np.cos(x / 2) ** 2 + np.cos(2 * y) * np.sin(x / 2) ** 2),
-                -2 * np.cos(y) * np.sin(x / 2) ** 4 * np.sin(y),
+                0.5 * pnp.sin(x) * (pnp.cos(x / 2) ** 2 + pnp.cos(2 * y) * pnp.sin(x / 2) ** 2),
+                -2 * pnp.cos(y) * pnp.sin(x / 2) ** 4 * pnp.sin(y),
             ]
         )
-        assert np.allclose(res, expected, atol=tol, rtol=0)
+        assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
 
 @pytest.mark.parametrize("interface", ["auto", "jax-jit"])
@@ -1610,7 +1610,7 @@ class TestTapeExpansion:
             gradient_kwargs = {
                 "h": H_FOR_SPSA,
                 "num_directions": 20,
-                "sampler_rng": np.random.default_rng(seed),
+                "sampler_rng": pnp.random.default_rng(seed),
             }
             tol = TOL_FOR_SPSA
 
@@ -1639,33 +1639,33 @@ class TestTapeExpansion:
 
         # test output
         res = circuit(d, w, c)
-        expected = c[2] * np.cos(d[1] + w[1]) - c[1] * np.sin(d[0] + w[0]) * np.sin(d[1] + w[1])
-        assert np.allclose(res, expected, atol=tol)
+        expected = c[2] * pnp.cos(d[1] + w[1]) - c[1] * pnp.sin(d[0] + w[0]) * pnp.sin(d[1] + w[1])
+        assert pnp.allclose(res, expected, atol=tol)
         spy.assert_not_called()
 
         # test gradients
         grad = jax.grad(circuit, argnums=[1, 2])(d, w, c)
         expected_w = [
-            -c[1] * np.cos(d[0] + w[0]) * np.sin(d[1] + w[1]),
-            -c[1] * np.cos(d[1] + w[1]) * np.sin(d[0] + w[0]) - c[2] * np.sin(d[1] + w[1]),
+            -c[1] * pnp.cos(d[0] + w[0]) * pnp.sin(d[1] + w[1]),
+            -c[1] * pnp.cos(d[1] + w[1]) * pnp.sin(d[0] + w[0]) - c[2] * pnp.sin(d[1] + w[1]),
         ]
-        expected_c = [0, -np.sin(d[0] + w[0]) * np.sin(d[1] + w[1]), np.cos(d[1] + w[1])]
-        assert np.allclose(grad[0], expected_w, atol=tol)
-        assert np.allclose(grad[1], expected_c, atol=tol)
+        expected_c = [0, -pnp.sin(d[0] + w[0]) * pnp.sin(d[1] + w[1]), pnp.cos(d[1] + w[1])]
+        assert pnp.allclose(grad[0], expected_w, atol=tol)
+        assert pnp.allclose(grad[1], expected_c, atol=tol)
 
         # TODO: Add parameter shift when the bug with trainable params and hamiltonian_grad is solved.
         # test second-order derivatives
         if diff_method in "backprop" and max_diff == 2:
             grad2_c = jax.jacobian(jax.grad(circuit, argnums=[2]), argnums=[2])(d, w, c)
-            assert np.allclose(grad2_c, 0, atol=tol)
+            assert pnp.allclose(grad2_c, 0, atol=tol)
 
             grad2_w_c = jax.jacobian(jax.grad(circuit, argnums=[1]), argnums=[2])(d, w, c)
-            expected = [0, -np.cos(d[0] + w[0]) * np.sin(d[1] + w[1]), 0], [
+            expected = [0, -pnp.cos(d[0] + w[0]) * pnp.sin(d[1] + w[1]), 0], [
                 0,
-                -np.cos(d[1] + w[1]) * np.sin(d[0] + w[0]),
-                -np.sin(d[1] + w[1]),
+                -pnp.cos(d[1] + w[1]) * pnp.sin(d[0] + w[0]),
+                -pnp.sin(d[1] + w[1]),
             ]
-            assert np.allclose(grad2_w_c, expected, atol=tol)
+            assert pnp.allclose(grad2_w_c, expected, atol=tol)
 
     @pytest.mark.parametrize("max_diff", [1, 2])
     def test_hamiltonian_finite_shots(
@@ -1711,18 +1711,18 @@ class TestTapeExpansion:
 
         # test output
         res = circuit(d, w, c, shots=50000)  # pylint:disable=unexpected-keyword-arg
-        expected = c[2] * np.cos(d[1] + w[1]) - c[1] * np.sin(d[0] + w[0]) * np.sin(d[1] + w[1])
-        assert np.allclose(res, expected, atol=tol)
+        expected = c[2] * pnp.cos(d[1] + w[1]) - c[1] * pnp.sin(d[0] + w[0]) * pnp.sin(d[1] + w[1])
+        assert pnp.allclose(res, expected, atol=tol)
 
         # test gradients
         grad = jax.grad(circuit, argnums=[1, 2])(d, w, c, shots=50000)
         expected_w = [
-            -c[1] * np.cos(d[0] + w[0]) * np.sin(d[1] + w[1]),
-            -c[1] * np.cos(d[1] + w[1]) * np.sin(d[0] + w[0]) - c[2] * np.sin(d[1] + w[1]),
+            -c[1] * pnp.cos(d[0] + w[0]) * pnp.sin(d[1] + w[1]),
+            -c[1] * pnp.cos(d[1] + w[1]) * pnp.sin(d[0] + w[0]) - c[2] * pnp.sin(d[1] + w[1]),
         ]
-        expected_c = [0, -np.sin(d[0] + w[0]) * np.sin(d[1] + w[1]), np.cos(d[1] + w[1])]
-        assert np.allclose(grad[0], expected_w, atol=tol)
-        assert np.allclose(grad[1], expected_c, atol=tol)
+        expected_c = [0, -pnp.sin(d[0] + w[0]) * pnp.sin(d[1] + w[1]), pnp.cos(d[1] + w[1])]
+        assert pnp.allclose(grad[0], expected_w, atol=tol)
+        assert pnp.allclose(grad[1], expected_c, atol=tol)
 
     #     TODO: Fix hamiltonian grad for parameter shift and jax
     #     # test second-order derivatives
@@ -1754,7 +1754,7 @@ class TestTapeExpansion:
         interface = "jax-jit"
 
         n_configs = 5
-        pars_q = np.random.rand(n_configs, 2)
+        pars_q = pnp.random.rand(n_configs, 2)
 
         def minimal_circ(params):
             @qml.qnode(
@@ -1775,7 +1775,7 @@ class TestTapeExpansion:
 
         res1 = jax.jit(minimal_circ)(pars_q)
         res2 = jax.jit(jax.vmap(minimal_circ))(pars_q)
-        assert np.allclose(res1, res2, tol)
+        assert pnp.allclose(res1, res2, tol)
 
     def test_vmap_compared_param_broadcasting_multi_output(
         self, dev_name, diff_method, grad_on_execution, device_vjp, interface, tol, seed
@@ -1793,7 +1793,7 @@ class TestTapeExpansion:
         interface = "jax-jit"
 
         n_configs = 5
-        pars_q = np.random.rand(n_configs, 2)
+        pars_q = pnp.random.rand(n_configs, 2)
 
         def minimal_circ(params):
             @qml.qnode(
@@ -1814,8 +1814,8 @@ class TestTapeExpansion:
 
         res1, res2 = jax.jit(minimal_circ)(pars_q)
         vres1, vres2 = jax.jit(jax.vmap(minimal_circ))(pars_q)
-        assert np.allclose(res1, vres1, tol)
-        assert np.allclose(res2, vres2, tol)
+        assert pnp.allclose(res1, vres1, tol)
+        assert pnp.allclose(res2, vres2, tol)
 
     def test_vmap_compared_param_broadcasting_probs(
         self, dev_name, diff_method, grad_on_execution, device_vjp, interface, tol, seed
@@ -1835,7 +1835,7 @@ class TestTapeExpansion:
         interface = "jax-jit"
 
         n_configs = 5
-        pars_q = np.random.rand(n_configs, 2)
+        pars_q = pnp.random.rand(n_configs, 2)
 
         def minimal_circ(params):
             @qml.qnode(
@@ -1856,8 +1856,8 @@ class TestTapeExpansion:
 
         res1, res2 = jax.jit(minimal_circ)(pars_q)
         vres1, vres2 = jax.jit(jax.vmap(minimal_circ))(pars_q)
-        assert np.allclose(res1, vres1, tol)
-        assert np.allclose(res2, vres2, tol)
+        assert pnp.allclose(res1, vres1, tol)
+        assert pnp.allclose(res2, vres2, tol)
 
 
 jacobian_fn = [jax.jacobian, jax.jacrev, jax.jacfwd]
@@ -1885,7 +1885,7 @@ class TestJIT:
         if device_vjp and jacobian == jax.jacfwd:
             pytest.skip("device vjps not compatible with forward diff.")
         elif diff_method == "spsa":
-            gradient_kwargs = {"h": H_FOR_SPSA, "sampler_rng": np.random.default_rng(seed)}
+            gradient_kwargs = {"h": H_FOR_SPSA, "sampler_rng": pnp.random.default_rng(seed)}
             tol = TOL_FOR_SPSA
 
         @qnode(
@@ -1907,11 +1907,11 @@ class TestJIT:
 
         a, b = x
 
-        expected_res = np.cos(a) * np.cos(b)
-        assert np.allclose(res, expected_res, atol=tol, rtol=0)
+        expected_res = pnp.cos(a) * pnp.cos(b)
+        assert pnp.allclose(res, expected_res, atol=tol, rtol=0)
 
-        expected_g = [-np.sin(a) * np.cos(b), -np.cos(a) * np.sin(b)]
-        assert np.allclose(g, expected_g, atol=tol, rtol=0)
+        expected_g = [-pnp.sin(a) * pnp.cos(b), -pnp.cos(a) * pnp.sin(b)]
+        assert pnp.allclose(g, expected_g, atol=tol, rtol=0)
 
     @pytest.mark.filterwarnings(
         "ignore:Requested adjoint differentiation to be computed with finite shots."
@@ -1936,7 +1936,7 @@ class TestJIT:
         if diff_method == "adjoint":
             pytest.skip("Computing the gradient for observables is not supported with adjoint.")
 
-        projector = np.array(qml.matrix(qml.PauliZ(0) @ qml.PauliZ(1)))
+        projector = pnp.array(qml.matrix(qml.PauliZ(0) @ qml.PauliZ(1)))
 
         @qml.qnode(
             get_device(dev_name, wires=2, seed=seed),
@@ -2011,12 +2011,12 @@ class TestJIT:
             return qml.expval(qml.PauliZ(0))
 
         res = jax.jit(circuit)(a, b, 0.0)
-        expected_res = np.cos(a) * np.cos(b)
-        assert np.allclose(res, expected_res, atol=tol, rtol=0)
+        expected_res = pnp.cos(a) * pnp.cos(b)
+        assert pnp.allclose(res, expected_res, atol=tol, rtol=0)
 
         g = jax.jit(jacobian(circuit, argnums=[0, 1]))(a, b, 0.0)
-        expected_g = [-np.sin(a) * np.cos(b), -np.cos(a) * np.sin(b)]
-        assert np.allclose(g, expected_g, atol=tol, rtol=0)
+        expected_g = [-pnp.sin(a) * pnp.cos(b), -pnp.cos(a) * pnp.sin(b)]
+        assert pnp.allclose(g, expected_g, atol=tol, rtol=0)
 
     def test_gradient_scalar_cost_vector_valued_qnode(
         self, dev_name, diff_method, grad_on_execution, device_vjp, jacobian, tol, interface, seed
@@ -2036,7 +2036,7 @@ class TestJIT:
             pytest.skip("device vjps are not compatible with forward differentiation.")
 
         elif diff_method == "spsa":
-            gradient_kwargs = {"h": H_FOR_SPSA, "sampler_rng": np.random.default_rng(seed)}
+            gradient_kwargs = {"h": H_FOR_SPSA, "sampler_rng": pnp.random.default_rng(seed)}
             tol = TOL_FOR_SPSA
 
         @qnode(
@@ -2060,22 +2060,22 @@ class TestJIT:
         x = jax.numpy.array(1.0)
         y = jax.numpy.array(2.0)
         expected_g = (
-            np.array([-np.sin(x) * np.cos(y) / 2, np.cos(y) * np.sin(x) / 2]),
-            np.array([-np.cos(x) * np.sin(y) / 2, np.cos(x) * np.sin(y) / 2]),
+            pnp.array([-pnp.sin(x) * pnp.cos(y) / 2, pnp.cos(y) * pnp.sin(x) / 2]),
+            pnp.array([-pnp.cos(x) * pnp.sin(y) / 2, pnp.cos(x) * pnp.sin(y) / 2]),
         )
 
         idx = 0
         g0 = jax.jit(jacobian(cost, argnums=0))(x, y, idx)
         g1 = jax.jit(jacobian(cost, argnums=1))(x, y, idx)
-        assert np.allclose(g0, expected_g[0][idx], atol=tol, rtol=0)
-        assert np.allclose(g1, expected_g[1][idx], atol=tol, rtol=0)
+        assert pnp.allclose(g0, expected_g[0][idx], atol=tol, rtol=0)
+        assert pnp.allclose(g1, expected_g[1][idx], atol=tol, rtol=0)
 
         idx = 1
         g0 = jax.jit(jacobian(cost, argnums=0))(x, y, idx)
         g1 = jax.jit(jacobian(cost, argnums=1))(x, y, idx)
 
-        assert np.allclose(g0, expected_g[0][idx], atol=tol, rtol=0)
-        assert np.allclose(g1, expected_g[1][idx], atol=tol, rtol=0)
+        assert pnp.allclose(g0, expected_g[0][idx], atol=tol, rtol=0)
+        assert pnp.allclose(g1, expected_g[1][idx], atol=tol, rtol=0)
 
     # pylint: disable=unused-argument
     def test_matrix_parameter(
@@ -2108,11 +2108,11 @@ class TestJIT:
         p = jax.numpy.array(0.1)
         U = jax.numpy.array([[0, 1], [1, 0]])
         res = jax.jit(circ)(p, U)
-        assert np.allclose(res, -np.cos(p), atol=tol, rtol=0)
+        assert pnp.allclose(res, -pnp.cos(p), atol=tol, rtol=0)
 
         jac_fn = jax.jit(jacobian(circ, argnums=0))
         res = jac_fn(p, U)
-        assert np.allclose(res, np.sin(p), atol=tol, rtol=0)
+        assert pnp.allclose(res, pnp.sin(p), atol=tol, rtol=0)
 
 
 @pytest.mark.parametrize("shots", [None, 10000])
@@ -2634,8 +2634,8 @@ class TestReturn:
             qml.RX(b, wires=0)
             return qml.expval(qml.PauliZ(0)), qml.probs(wires=[0, 1])
 
-        a = np.array(0.1, requires_grad=True)
-        b = np.array(0.2, requires_grad=True)
+        a = pnp.array(0.1, requires_grad=True)
+        b = pnp.array(0.2, requires_grad=True)
 
         jac = jax.jit(jacobian(circuit, argnums=[0, 1]), static_argnames="shots")(a, b, shots=shots)
 
@@ -3046,11 +3046,11 @@ def test_jax_device_hessian_shots(hessian, diff_method):
     hess = jax.jit(hessian(circuit), static_argnames="shots")(x, shots=10000)
 
     expected_hess = [
-        [-np.cos(a) * np.cos(b), np.sin(a) * np.sin(b)],
-        [np.sin(a) * np.sin(b), -np.cos(a) * np.cos(b)],
+        [-pnp.cos(a) * pnp.cos(b), pnp.sin(a) * pnp.sin(b)],
+        [pnp.sin(a) * pnp.sin(b), -pnp.cos(a) * pnp.cos(b)],
     ]
     shots_tol = 0.1
-    assert np.allclose(hess, expected_hess, atol=shots_tol, rtol=0)
+    assert pnp.allclose(hess, expected_hess, atol=shots_tol, rtol=0)
 
 
 @pytest.mark.parametrize("jit_inside", [True, False])
@@ -3084,7 +3084,7 @@ class TestSubsetArgnums:
         if dev_name == "param_shift.qubit":
             pytest.xfail("gradient transform have a different vjp shape convention.")
         if diff_method == "spsa":
-            kwargs["sampler_rng"] = np.random.default_rng(seed)
+            kwargs["sampler_rng"] = pnp.random.default_rng(seed)
             tol = TOL_FOR_SPSA
 
         @qml.qnode(
@@ -3110,15 +3110,15 @@ class TestSubsetArgnums:
         else:
             jac = jax.jit(jacobian(circuit, argnums=argnums))(a, b)
 
-        expected = np.array([-np.sin(a), 0])
+        expected = pnp.array([-pnp.sin(a), 0])
 
         if argnums == 0:
-            assert np.allclose(jac, expected[0], atol=tol)
+            assert pnp.allclose(jac, expected[0], atol=tol)
         elif argnums == 1:
-            assert np.allclose(jac, expected[1], atol=tol)
+            assert pnp.allclose(jac, expected[1], atol=tol)
         else:
-            assert np.allclose(jac[0], expected[0], atol=tol)
-            assert np.allclose(jac[1], expected[1], atol=tol)
+            assert pnp.allclose(jac[0], expected[0], atol=tol)
+            assert pnp.allclose(jac[1], expected[1], atol=tol)
 
     def test_multi_measurements(
         self,
@@ -3146,7 +3146,7 @@ class TestSubsetArgnums:
 
         kwargs = {}
         if diff_method == "spsa":
-            kwargs["sampler_rng"] = np.random.default_rng(seed)
+            kwargs["sampler_rng"] = pnp.random.default_rng(seed)
             tol = TOL_FOR_SPSA
 
         @qml.qnode(
@@ -3171,15 +3171,15 @@ class TestSubsetArgnums:
         else:
             jac = jax.jit(jacobian(circuit, argnums=argnums))(a, b)
 
-        expected = np.array([[-np.sin(a), 0], [np.sin(a) * np.sin(b), -np.cos(a) * np.cos(b)]])
+        expected = pnp.array([[-pnp.sin(a), 0], [pnp.sin(a) * pnp.sin(b), -pnp.cos(a) * pnp.cos(b)]])
 
         if argnums == 0:
-            assert np.allclose(jac, expected.T[0], atol=tol)
+            assert pnp.allclose(jac, expected.T[0], atol=tol)
         elif argnums == 1:
-            assert np.allclose(jac, expected.T[1], atol=tol)
+            assert pnp.allclose(jac, expected.T[1], atol=tol)
         else:
-            assert np.allclose(jac[0], expected[0], atol=tol)
-            assert np.allclose(jac[1], expected[1], atol=tol)
+            assert pnp.allclose(jac[0], expected[0], atol=tol)
+            assert pnp.allclose(jac[1], expected[1], atol=tol)
 
 
 class TestSinglePrecision:
@@ -3206,7 +3206,7 @@ class TestSinglePrecision:
                 return qml.expval(qml.PauliZ(0))
 
             grad = jax.grad(circuit)(jax.numpy.array(0.1))
-            assert qml.math.allclose(grad, -np.sin(0.1))
+            assert qml.math.allclose(grad, -pnp.sin(0.1))
         finally:
             jax.config.update("jax_enable_x64", True)
         jax.config.update("jax_enable_x64", True)
@@ -3226,7 +3226,7 @@ class TestSinglePrecision:
                 return qml.state()
 
             j = jax.jacobian(circuit, holomorphic=True)(jax.numpy.array(0.1 + 0j))
-            assert qml.math.allclose(j, [-np.sin(0.05) / 2, -np.cos(0.05) / 2 * 1j], atol=tol)
+            assert qml.math.allclose(j, [-pnp.sin(0.05) / 2, -pnp.cos(0.05) / 2 * 1j], atol=tol)
 
         finally:
             jax.config.update("jax_enable_x64", True)

--- a/tests/workflow/interfaces/qnode/test_jax_qnode_shot_vector.py
+++ b/tests/workflow/interfaces/qnode/test_jax_qnode_shot_vector.py
@@ -17,7 +17,7 @@ import pytest
 from flaky import flaky
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane import qnode
 
 pytestmark = pytest.mark.jax
@@ -404,8 +404,8 @@ class TestReturnWithShotVectors:
             qml.RX(b, wires=0)
             return qml.expval(qml.PauliZ(0)), qml.probs(wires=[0, 1])
 
-        a = np.array(0.1, requires_grad=True)
-        b = np.array(0.2, requires_grad=True)
+        a = pnp.array(0.1, requires_grad=True)
+        b = pnp.array(0.2, requires_grad=True)
 
         jac = jacobian(circuit, argnums=[0, 1])(a, b)
 
@@ -799,7 +799,7 @@ class TestReturnShotVectorIntegration:
             qml.CNOT(wires=[0, 1])
             return qml.expval(qml.PauliZ(0) @ qml.PauliX(1))
 
-        expected = np.array([[-np.sin(y) * np.sin(x), np.cos(y) * np.cos(x)]])
+        expected = pnp.array([[-pnp.sin(y) * pnp.sin(x), pnp.cos(y) * pnp.cos(x)]])
         all_res = jacobian(circuit, argnums=[0, 1])(x, y)
 
         assert isinstance(all_res, tuple)
@@ -815,7 +815,7 @@ class TestReturnShotVectorIntegration:
             assert isinstance(res[1], jax.numpy.ndarray)
             assert res[1].shape == ()
             tol = TOLS[diff_method]
-            assert np.allclose(res, expected, atol=tol, rtol=0)
+            assert pnp.allclose(res, expected, atol=tol, rtol=0)
 
     @pytest.mark.parametrize("jacobian", jacobian_fn)
     def test_prob_expectation_values(
@@ -850,32 +850,32 @@ class TestReturnShotVectorIntegration:
 
             assert isinstance(res[0], tuple)
             assert len(res[0]) == 2
-            assert np.allclose(res[0][0], -np.sin(x), atol=tol, rtol=0)
+            assert pnp.allclose(res[0][0], -pnp.sin(x), atol=tol, rtol=0)
             assert isinstance(res[0][0], jax.numpy.ndarray)
-            assert np.allclose(res[0][1], 0, atol=tol, rtol=0)
+            assert pnp.allclose(res[0][1], 0, atol=tol, rtol=0)
             assert isinstance(res[0][1], jax.numpy.ndarray)
 
             assert isinstance(res[1], tuple)
             assert len(res[1]) == 2
-            assert np.allclose(
+            assert pnp.allclose(
                 res[1][0],
                 [
-                    -(np.cos(y / 2) ** 2 * np.sin(x)) / 2,
-                    -(np.sin(x) * np.sin(y / 2) ** 2) / 2,
-                    (np.sin(x) * np.sin(y / 2) ** 2) / 2,
-                    (np.cos(y / 2) ** 2 * np.sin(x)) / 2,
+                    -(pnp.cos(y / 2) ** 2 * pnp.sin(x)) / 2,
+                    -(pnp.sin(x) * pnp.sin(y / 2) ** 2) / 2,
+                    (pnp.sin(x) * pnp.sin(y / 2) ** 2) / 2,
+                    (pnp.cos(y / 2) ** 2 * pnp.sin(x)) / 2,
                 ],
                 atol=tol,
                 rtol=0,
             )
             assert isinstance(res[1][0], jax.numpy.ndarray)
-            assert np.allclose(
+            assert pnp.allclose(
                 res[1][1],
                 [
-                    -(np.cos(x / 2) ** 2 * np.sin(y)) / 2,
-                    (np.cos(x / 2) ** 2 * np.sin(y)) / 2,
-                    (np.sin(x / 2) ** 2 * np.sin(y)) / 2,
-                    -(np.sin(x / 2) ** 2 * np.sin(y)) / 2,
+                    -(pnp.cos(x / 2) ** 2 * pnp.sin(y)) / 2,
+                    (pnp.cos(x / 2) ** 2 * pnp.sin(y)) / 2,
+                    (pnp.sin(x / 2) ** 2 * pnp.sin(y)) / 2,
+                    -(pnp.sin(x / 2) ** 2 * pnp.sin(y)) / 2,
                 ],
                 atol=tol,
                 rtol=0,

--- a/tests/workflow/interfaces/qnode/test_tensorflow_autograph_qnode_shot_vector.py
+++ b/tests/workflow/interfaces/qnode/test_tensorflow_autograph_qnode_shot_vector.py
@@ -16,7 +16,7 @@
 import pytest
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane import qnode
 
 pytestmark = pytest.mark.tf
@@ -50,7 +50,7 @@ def gradient_kwargs(request):
     diff_method = request.node.funcargs["diff_method"]
     seed = request.getfixturevalue("seed")
     return kwargs[diff_method] | (
-        {"sampler_rng": np.random.default_rng(seed)} if diff_method == "spsa" else {}
+        {"sampler_rng": pnp.random.default_rng(seed)} if diff_method == "spsa" else {}
     )
 
 
@@ -488,13 +488,13 @@ class TestReturnShotVectorIntegration:
         assert isinstance(all_res, tuple)
         assert len(all_res) == 2
 
-        expected = np.array([-np.sin(y) * np.sin(x), np.cos(y) * np.cos(x)])
+        expected = pnp.array([-pnp.sin(y) * pnp.sin(x), pnp.cos(y) * pnp.cos(x)])
         tol = TOLS[diff_method]
 
         for res, exp in zip(all_res, expected):
             assert isinstance(res, tf.Tensor)
             assert res.shape == (num_copies,)
-            assert np.allclose(res, exp, atol=tol, rtol=0)
+            assert pnp.allclose(res, exp, atol=tol, rtol=0)
 
     def test_prob_expectation_values(
         self, dev_name, seed, diff_method, gradient_kwargs, shots, num_copies, decorator, interface
@@ -526,21 +526,21 @@ class TestReturnShotVectorIntegration:
         assert isinstance(all_res, tuple)
         assert len(all_res) == 2
 
-        expected = np.array(
+        expected = pnp.array(
             [
                 [
-                    -np.sin(x),
-                    -(np.cos(y / 2) ** 2 * np.sin(x)) / 2,
-                    -(np.sin(x) * np.sin(y / 2) ** 2) / 2,
-                    (np.sin(x) * np.sin(y / 2) ** 2) / 2,
-                    (np.cos(y / 2) ** 2 * np.sin(x)) / 2,
+                    -pnp.sin(x),
+                    -(pnp.cos(y / 2) ** 2 * pnp.sin(x)) / 2,
+                    -(pnp.sin(x) * pnp.sin(y / 2) ** 2) / 2,
+                    (pnp.sin(x) * pnp.sin(y / 2) ** 2) / 2,
+                    (pnp.cos(y / 2) ** 2 * pnp.sin(x)) / 2,
                 ],
                 [
                     0,
-                    -(np.cos(x / 2) ** 2 * np.sin(y)) / 2,
-                    (np.cos(x / 2) ** 2 * np.sin(y)) / 2,
-                    (np.sin(x / 2) ** 2 * np.sin(y)) / 2,
-                    -(np.sin(x / 2) ** 2 * np.sin(y)) / 2,
+                    -(pnp.cos(x / 2) ** 2 * pnp.sin(y)) / 2,
+                    (pnp.cos(x / 2) ** 2 * pnp.sin(y)) / 2,
+                    (pnp.sin(x / 2) ** 2 * pnp.sin(y)) / 2,
+                    -(pnp.sin(x / 2) ** 2 * pnp.sin(y)) / 2,
                 ],
             ]
         )
@@ -550,4 +550,4 @@ class TestReturnShotVectorIntegration:
         for res, exp in zip(all_res, expected):
             assert isinstance(res, tf.Tensor)
             assert res.shape == (num_copies, 5)
-            assert np.allclose(res, exp, atol=tol, rtol=0)
+            assert pnp.allclose(res, exp, atol=tol, rtol=0)

--- a/tests/workflow/interfaces/qnode/test_tensorflow_qnode_shot_vector.py
+++ b/tests/workflow/interfaces/qnode/test_tensorflow_qnode_shot_vector.py
@@ -16,7 +16,7 @@
 import pytest
 
 import pennylane as qml
-from pennylane import numpy as np
+from pennylane import numpy as pnp
 from pennylane import qnode
 from pennylane.devices import DefaultQubit
 
@@ -54,7 +54,7 @@ interface_and_qubit_device_and_diff_method = [
 def gradient_kwargs(request):
     diff_method = request.node.funcargs["diff_method"]
     return kwargs[diff_method] | (
-        {"sampler_rng": np.random.default_rng(request.getfixturevalue("seed"))}
+        {"sampler_rng": pnp.random.default_rng(request.getfixturevalue("seed"))}
         if diff_method == "spsa"
         else {}
     )
@@ -483,13 +483,13 @@ class TestReturnShotVectorIntegration:
         assert isinstance(all_res, tuple)
         assert len(all_res) == 2
 
-        expected = np.array([-np.sin(y) * np.sin(x), np.cos(y) * np.cos(x)])
+        expected = pnp.array([-pnp.sin(y) * pnp.sin(x), pnp.cos(y) * pnp.cos(x)])
         tol = TOLS[diff_method]
 
         for res, exp in zip(all_res, expected):
             assert isinstance(res, tf.Tensor)
             assert res.shape == (num_copies,)
-            assert np.allclose(res, exp, atol=tol, rtol=0)
+            assert pnp.allclose(res, exp, atol=tol, rtol=0)
 
     def test_prob_expectation_values(
         self, dev, diff_method, gradient_kwargs, shots, num_copies, interface, seed
@@ -516,21 +516,21 @@ class TestReturnShotVectorIntegration:
         assert isinstance(all_res, tuple)
         assert len(all_res) == 2
 
-        expected = np.array(
+        expected = pnp.array(
             [
                 [
-                    -np.sin(x),
-                    -(np.cos(y / 2) ** 2 * np.sin(x)) / 2,
-                    -(np.sin(x) * np.sin(y / 2) ** 2) / 2,
-                    (np.sin(x) * np.sin(y / 2) ** 2) / 2,
-                    (np.cos(y / 2) ** 2 * np.sin(x)) / 2,
+                    -pnp.sin(x),
+                    -(pnp.cos(y / 2) ** 2 * pnp.sin(x)) / 2,
+                    -(pnp.sin(x) * pnp.sin(y / 2) ** 2) / 2,
+                    (pnp.sin(x) * pnp.sin(y / 2) ** 2) / 2,
+                    (pnp.cos(y / 2) ** 2 * pnp.sin(x)) / 2,
                 ],
                 [
                     0,
-                    -(np.cos(x / 2) ** 2 * np.sin(y)) / 2,
-                    (np.cos(x / 2) ** 2 * np.sin(y)) / 2,
-                    (np.sin(x / 2) ** 2 * np.sin(y)) / 2,
-                    -(np.sin(x / 2) ** 2 * np.sin(y)) / 2,
+                    -(pnp.cos(x / 2) ** 2 * pnp.sin(y)) / 2,
+                    (pnp.cos(x / 2) ** 2 * pnp.sin(y)) / 2,
+                    (pnp.sin(x / 2) ** 2 * pnp.sin(y)) / 2,
+                    -(pnp.sin(x / 2) ** 2 * pnp.sin(y)) / 2,
                 ],
             ]
         )
@@ -540,4 +540,4 @@ class TestReturnShotVectorIntegration:
         for res, exp in zip(all_res, expected):
             assert isinstance(res, tf.Tensor)
             assert res.shape == (num_copies, 5)
-            assert np.allclose(res, exp, atol=tol, rtol=0)
+            assert pnp.allclose(res, exp, atol=tol, rtol=0)


### PR DESCRIPTION
**Context:**
Too many places where we `import pennylane.numpy as np` or `from pennylane import numpy as np`, which is very confusing and conflicting with common `import numpy as np`. The standard is either `pnp` (prefered), `qnp` or `anp`.

**Description of the Change:**
Change most of `np` to `pnp`. In one file there's `npp` also changed to `pnp`

**Benefits:**
Less confusion. More standardization.

**Possible Drawbacks:**
How do we deal with docstr and docs?

**Related GitHub Issues:**
