### PR TITLE
Remove redundant commutator computations from `lie_closure`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -201,6 +201,9 @@ such as `shots`, `rng` and `prng_key`.
 
 <h3>Improvements 🛠</h3>
 
+* Remove redundant commutator computations from `qml.lie_closure`.
+  [(#6724)](https://github.com/PennyLaneAI/pennylane/pull/6724)
+
 * Raises a comprehensive error when using `qml.fourier.qnode_spectrum` with standard numpy
   arguments and `interface="auto"`.
   [(#6622)](https://github.com/PennyLaneAI/pennylane/pull/6622)

--- a/pennylane/pauli/dla/lie_closure.py
+++ b/pennylane/pauli/dla/lie_closure.py
@@ -12,12 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """A function to compute the Lie closure of a set of operators"""
-# pylint: disable=too-many-arguments
-import itertools
 import warnings
 from collections.abc import Iterable
 from copy import copy
 from functools import reduce
+
+# pylint: disable=too-many-arguments
+from itertools import product
 from typing import Union
 
 import numpy as np
@@ -132,13 +133,17 @@ def lie_closure(
 
     epoch = 0
     old_length = 0  # dummy value
-    new_length = len(vspace)
+    new_length = initial_length = len(vspace)
 
     while (new_length > old_length) and (epoch < max_iterations):
         if verbose:
             print(f"epoch {epoch+1} of lie_closure, DLA size is {new_length}")
 
-        for ps1, ps2 in itertools.combinations(vspace.basis, 2):
+        # compute all commutators. We compute the commutators between all newly added operators
+        # and all original generators. This limits the number of commutators added in each
+        # iteration, but it gives us a correspondence between the while loop iteration and the
+        # nesting level of the commutators.
+        for ps1, ps2 in product(vspace.basis[old_length:], vspace.basis[:initial_length]):
             com = ps1.commutator(ps2)
             com.simplify(tol=vspace.tol)
 


### PR DESCRIPTION
**Context:**
`qml.lie_closure` computes redundant commutators, as described in #6414.

**Description of the Change:**
Change the computation to only consider each operator combination once, avoiding redundant commutator computations. We essentially follow the approach linked in #6414, which is also taking in `qml.labs.dla.lie_closure_dense`.

**Benefits:**
Performance.

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
closes #6414