### PR TITLE
Enforce the positivity of prob inside `ProbMP.process_density_matrix`

### DIFF
--- a/pennylane/measurements/probs.py
+++ b/pennylane/measurements/probs.py
@@ -266,9 +266,12 @@ class ProbabilityMP(SampleMeasurement, StateMeasurement):
         # Since we only care about the probabilities, we can simplify the task here by creating a 'pseudo-state' to carry the diagonal elements and reuse the process_state method
         # Introduce a small epsilon to avoid sqrt(0) to ensure absolute positivity.
         prob = qml.math.real(prob)
-        prob = qml.math.where(prob < 0, -prob, prob)
-        prob = qml.math.where(prob == 0, prob + np.finfo(float).eps, prob)
         p_state = qml.math.sqrt(prob)
+        precision_issue_indices = qml.math.isnan(p_state) & list(
+            qml.math.allclose(p, 0) for p in prob
+        )
+        p_state = qml.math.where(precision_issue_indices, 0, p_state)
+
         return self.process_state(p_state, wire_order)
 
     @staticmethod

--- a/pennylane/measurements/probs.py
+++ b/pennylane/measurements/probs.py
@@ -265,6 +265,7 @@ class ProbabilityMP(SampleMeasurement, StateMeasurement):
 
         # Since we only care about the probabilities, we can simplify the task here by creating a 'pseudo-state' to carry the diagonal elements and reuse the process_state method
         # Introduce a small epsilon to avoid sqrt(0) to ensure absolute positivity.
+        prob = qml.math.real(prob)
         prob = qml.math.clip(prob, 1e-14, 1.0)
         p_state = qml.math.sqrt(prob)
         return self.process_state(p_state, wire_order)

--- a/pennylane/measurements/probs.py
+++ b/pennylane/measurements/probs.py
@@ -267,7 +267,7 @@ class ProbabilityMP(SampleMeasurement, StateMeasurement):
         # Introduce a small epsilon to avoid sqrt(0) to ensure absolute positivity.
         prob = qml.math.real(prob)
         prob = qml.math.where(prob < 0, -prob, prob)
-        prob = qml.math.where(prob == 0, prob + 1e-14, prob)
+        prob = qml.math.where(prob == 0, prob + np.finfo(float).eps, prob)
         p_state = qml.math.sqrt(prob)
         return self.process_state(p_state, wire_order)
 

--- a/pennylane/measurements/probs.py
+++ b/pennylane/measurements/probs.py
@@ -266,7 +266,7 @@ class ProbabilityMP(SampleMeasurement, StateMeasurement):
         # Since we only care about the probabilities, we can simplify the task here by creating a 'pseudo-state' to carry the diagonal elements and reuse the process_state method
         # Introduce a small epsilon to avoid sqrt(0) to ensure absolute positivity.
         prob = qml.math.real(prob)
-        prob = qml.math.clip(prob, 1e-14, 1.0)
+        prob = qml.math.where(prob==0, prob+1e-14, prob)
         p_state = qml.math.sqrt(prob)
         return self.process_state(p_state, wire_order)
 

--- a/pennylane/measurements/probs.py
+++ b/pennylane/measurements/probs.py
@@ -266,12 +266,9 @@ class ProbabilityMP(SampleMeasurement, StateMeasurement):
         # Since we only care about the probabilities, we can simplify the task here by creating a 'pseudo-state' to carry the diagonal elements and reuse the process_state method
         # Introduce a small epsilon to avoid sqrt(0) to ensure absolute positivity.
         prob = qml.math.real(prob)
+        prob = qml.math.where(prob < 0, -prob, prob)
+        prob = qml.math.where(prob == 0, prob + np.finfo(float).eps, prob)
         p_state = qml.math.sqrt(prob)
-        precision_issue_indices = qml.math.isnan(p_state) & list(
-            qml.math.allclose(p, 0) for p in prob
-        )
-        p_state = qml.math.where(precision_issue_indices, 0, p_state)
-
         return self.process_state(p_state, wire_order)
 
     @staticmethod

--- a/pennylane/measurements/probs.py
+++ b/pennylane/measurements/probs.py
@@ -264,6 +264,8 @@ class ProbabilityMP(SampleMeasurement, StateMeasurement):
             )
 
         # Since we only care about the probabilities, we can simplify the task here by creating a 'pseudo-state' to carry the diagonal elements and reuse the process_state method
+        # Introduce a small epsilon to avoid sqrt(0) to ensure absolute positivity.
+        prob = qml.math.clip(prob, 1e-14, 1.0)
         p_state = qml.math.sqrt(prob)
         return self.process_state(p_state, wire_order)
 

--- a/pennylane/measurements/probs.py
+++ b/pennylane/measurements/probs.py
@@ -266,7 +266,8 @@ class ProbabilityMP(SampleMeasurement, StateMeasurement):
         # Since we only care about the probabilities, we can simplify the task here by creating a 'pseudo-state' to carry the diagonal elements and reuse the process_state method
         # Introduce a small epsilon to avoid sqrt(0) to ensure absolute positivity.
         prob = qml.math.real(prob)
-        prob = qml.math.where(prob==0, prob+1e-14, prob)
+        prob = qml.math.where(prob < 0, -prob, prob)
+        prob = qml.math.where(prob == 0, prob + 1e-14, prob)
         p_state = qml.math.sqrt(prob)
         return self.process_state(p_state, wire_order)
 


### PR DESCRIPTION
**Context:**
This missing line might lead to specific `nan` error in the downstreaming gradient process especially ag/jax related. Check out https://github.com/PennyLaneAI/pennylane/actions/runs/12360643306/job/34496071685?pr=6684 and https://github.com/PennyLaneAI/pennylane/actions/runs/12360643306/job/34496077651?pr=6684 for concrete examples

P.S. How did the legacy device deal with this issue? It explicitly calls its own analytic prob method and did similar things https://github.com/PennyLaneAI/pennylane/blob/6383dfcf3f4e4877ce2b0fa39630635ba405ae1e/pennylane/devices/default_mixed.py#L386

**Description of the Change:**
use `clip` with min value `eps` to enforce the positivity.

**Benefits:**
More reliability

**Possible Drawbacks:**
None realized

**Related GitHub Issues:**
