### PR TITLE
Fix issue with trigger_benchmark being too strict with the permission check

### DIFF
--- a/.github/workflows/trigger_benchmarks.yml
+++ b/.github/workflows/trigger_benchmarks.yml
@@ -47,9 +47,9 @@ jobs:
               username: user
             });
             const userPermissions = data.user.permissions;
-            const permission = userPermissions.admin || userPermissions.maintain;
+            const permission = userPermissions.admin || userPermissions.maintain || (userPermissions.write || userPermissions.push);
 
-            console.log(`User '${user}' has admin/maintain access => ${permission}`);
+            console.log(`User '${user}' has admin/maintain/write access => ${permission}`);
 
             return permission;
       
@@ -85,7 +85,7 @@ jobs:
             }
           
       - name: React to original comment indicating webhook sent
-        if: steps.comment_user.outputs.result == 'true' 
+        if: steps.comment_body.outputs.triggers_benchmark == 'true' && steps.comment_user.outputs.result == 'true'
         uses: actions/github-script@v7
         env:
           REPO_OWNER: ${{ steps.repo_info.outputs.REPO_OWNER }}


### PR DESCRIPTION
**Context:**
This pull request updates the `trigger_benchmarks` workflow to allow users with write permissions to this repository to trigger benchmarks.

Previously, you needed at least `maintain` permissions, which a lot of pennylane development teams did not have.

**Description of the Change:**
The workflow after first verifying that the command issued was `/benchmark`, will hit `/repos/OWNER/REPO/collaborators/USERNAME/permission` endpoint for this repo.

Then, check if the user object returns has at least `push` permission:
```json
"permissions": {
    "admin": false,
    "maintain": false,
    "push": false,
    "triage": true,
    "pull": true
}
```
If `admin`/`maintain`/`push` is true, the webhook will be triggered.

**Benefits:**
More people are able to trigger benchmarks.

**Possible Drawbacks:**
More people are able to trigger benchmarks.

... Ideally we want to have a custom role created, then assign that role to specific teams/users and you would need to have that role in order to trigger benchmark. However, custom roles are only offered on the GitHub Enterprise plan. If we do upgrade to that in the future, we can revisit this logic.

**Related GitHub Issues:**
None. [sc-80243](https://app.shortcut.com/xanaduai/story/80243/update-benchmark-trigger-on-pennylane-to-check-for-write-access)