### PR TITLE
Add `work_wires` property to `GroverOperator`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -341,6 +341,9 @@ such as `shots`, `rng` and `prng_key`.
 
 <h4>Other Improvements</h4>
 
+* `GroverOperator` now has a `work_wires` property.
+  [(#6738)](https://github.com/PennyLaneAI/pennylane/pull/6738)
+
 * `Wires` object usage across Pennylane source code has been tidied up.
   [(#6689)](https://github.com/PennyLaneAI/pennylane/pull/6689)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -341,7 +341,7 @@ such as `shots`, `rng` and `prng_key`.
 
 <h4>Other Improvements</h4>
 
-* `GroverOperator` now has a `work_wires` property.
+* `qml.GroverOperator` now has a `work_wires` property.
   [(#6738)](https://github.com/PennyLaneAI/pennylane/pull/6738)
 
 * `Wires` object usage across Pennylane source code has been tidied up.

--- a/pennylane/templates/subroutines/grover.py
+++ b/pennylane/templates/subroutines/grover.py
@@ -125,7 +125,7 @@ class GroverOperator(Operation):
 
     @property
     def work_wires(self):
-            """Additional auxiliary wires that can be used in the decomposition of :class:`~.MultiControlledX`."""
+        """Additional auxiliary wires that can be used in the decomposition of :class:`~.MultiControlledX`."""
         return self.hyperparameters["work_wires"]
 
     @property

--- a/pennylane/templates/subroutines/grover.py
+++ b/pennylane/templates/subroutines/grover.py
@@ -124,6 +124,10 @@ class GroverOperator(Operation):
         super().__init__(wires=wires, id=id)
 
     @property
+    def work_wires(self):
+        return self.hyperparameters["work_wires"]
+
+    @property
     def num_params(self):
         return 0
 

--- a/pennylane/templates/subroutines/grover.py
+++ b/pennylane/templates/subroutines/grover.py
@@ -125,6 +125,7 @@ class GroverOperator(Operation):
 
     @property
     def work_wires(self):
+            """Additional auxiliary wires that can be used in the decomposition of :class:`~.MultiControlledX`."""
         return self.hyperparameters["work_wires"]
 
     @property

--- a/tests/templates/test_subroutines/test_grover.py
+++ b/tests/templates/test_subroutines/test_grover.py
@@ -31,6 +31,12 @@ def test_repr():
     assert repr(op) == expected
 
 
+def test_work_wire_property():
+    op = qml.GroverOperator(wires=(0, 1, 2), work_wires=(3, 4))
+    expected = qml.wires.Wires((3, 4))
+    assert op.work_wires == expected
+
+
 def test_standard_validity():
     """Test the standard criteria for a valid operation."""
     work_wires = qml.wires.Wires((3, 4))


### PR DESCRIPTION
**Context:**

`qml.GroverOperator` now has a `work_wires` property similar to `MultiControlledX`.

**Benefits:** Nice to have.

**Possible Drawbacks:** None identified.

**Related GitHub Issues:** Fixes #6591 

[sc-78409]
