### PR TITLE
add qml.math.grad and qml.math.jacobian for differentiating any interface

### DIFF
--- a/doc/introduction/interfaces/numpy.rst
+++ b/doc/introduction/interfaces/numpy.rst
@@ -3,8 +3,6 @@
 NumPy interface
 ===============
 
-.. note:: This interface is the default interface supported by PennyLane's :class:`QNode <pennylane.QNode>`.
-
 
 Using the NumPy interface
 -------------------------
@@ -275,10 +273,10 @@ we would get an error message. This is because the `gradient <https://en.wikiped
 only defined for scalar functions, i.e., functions which return a single value. In the case where the QNode
 returns multiple expectation values, the correct differential operator to use is
 the `Jacobian matrix <https://en.wikipedia.org/wiki/Jacobian_matrix_and_determinant>`_.
-This can be accessed in PennyLane as :func:`~.jacobian`.
+This can be accessed in PennyLane as :func:`~pennylane.jacobian`.
 
 As the ``circuit5`` returns a tuple of numpy arrays instead of a single numpy array, the results need
-to be stacked into a single array before use with :func:`~.jacobian`.
+to be stacked into a single array before use with :func:`~pennylane.jacobian`.
 
 >>> j1 = qml.jacobian(lambda x: np.stack(circuit5(x)))
 >>> j1(params)
@@ -286,7 +284,7 @@ array([[ 0.        , -0.98006658],
        [-0.98006658,  0.        ]])
 
 
-The output of :func:`~.jacobian` is a two-dimensional vector, with the first/second element being
+The output of :func:`~pennylane.jacobian` is a two-dimensional vector, with the first/second element being
 the partial derivative of the first/second expectation value with respect to the input parameter.
 
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -341,7 +341,8 @@ such as `shots`, `rng` and `prng_key`.
 
 <h4>Other Improvements</h4>
 
-* `qml.math.grad` cannot differentiate a function with inputs of any interface in a jax-like manner.
+* `qml.math.grad` and `qml.math.jacobian` added to differentiate a function with inputs of any
+  interface in a jax-like manner.
   [(#6741)](https://github.com/PennyLaneAI/pennylane/pull/6741)
 
 * `qml.GroverOperator` now has a `work_wires` property.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -341,6 +341,8 @@ such as `shots`, `rng` and `prng_key`.
 
 <h4>Other Improvements</h4>
 
+* `qml.math.grad` cannot differentiate a function with inputs of any interface in a jax-like manner.
+
 * `qml.GroverOperator` now has a `work_wires` property.
   [(#6738)](https://github.com/PennyLaneAI/pennylane/pull/6738)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -342,6 +342,7 @@ such as `shots`, `rng` and `prng_key`.
 <h4>Other Improvements</h4>
 
 * `qml.math.grad` cannot differentiate a function with inputs of any interface in a jax-like manner.
+  [(#6741)](https://github.com/PennyLaneAI/pennylane/pull/6741)
 
 * `qml.GroverOperator` now has a `work_wires` property.
   [(#6738)](https://github.com/PennyLaneAI/pennylane/pull/6738)

--- a/pennylane/_grad.py
+++ b/pennylane/_grad.py
@@ -251,6 +251,21 @@ class grad:
         return grad_value, ans
 
 
+def _error_if_not_array(f):
+    """A function decorator that raises an error in the function output is not an autograd, pennylane, or numpy array."""
+
+    @wraps(f)
+    def new_f(*args, **kwargs):
+        output = f(*args, **kwargs)
+        if output.__class__.__module__.split(".")[0] not in {"autograd", "pennylane", "numpy"}:
+            raise ValueError(
+                f"autograd can only differentiate with respect to arrays, not {type(output)}"
+            )
+        return output
+
+    return new_f
+
+
 def jacobian(func, argnum=None, method=None, h=None):
     """Returns the Jacobian as a callable function of vector-valued (functions of) QNodes.
     This function is compatible with Autograd and :func:`~.qjit`.
@@ -514,7 +529,7 @@ def jacobian(func, argnum=None, method=None, h=None):
                 "If this is unintended, please add trainable parameters via the "
                 "'requires_grad' attribute or 'argnum' keyword."
             )
-        jac = tuple(_jacobian(func, arg)(*args, **kwargs) for arg in _argnum)
+        jac = tuple(_jacobian(_error_if_not_array(func), arg)(*args, **kwargs) for arg in _argnum)
 
         return jac[0] if unpack else jac
 

--- a/pennylane/_grad.py
+++ b/pennylane/_grad.py
@@ -252,14 +252,14 @@ class grad:
 
 
 def _error_if_not_array(f):
-    """A function decorator that raises an error in the function output is not an autograd, pennylane, or numpy array."""
+    """A function decorator that raises an error if the function output is not an autograd, pennylane, or numpy array."""
 
     @wraps(f)
     def new_f(*args, **kwargs):
         output = f(*args, **kwargs)
         if output.__class__.__module__.split(".")[0] not in {"autograd", "pennylane", "numpy"}:
             raise ValueError(
-                f"autograd can only differentiate with respect to arrays, not {type(output)}"
+                f"autograd can only differentiate with respect to arrays, not {type(output)}. Ensure the output class is an autograd array."
             )
         return output
 

--- a/pennylane/gradients/classical_jacobian.py
+++ b/pennylane/gradients/classical_jacobian.py
@@ -113,7 +113,7 @@ def classical_jacobian(qnode, argnum=None, expand_fn=None, trainable_only=True):
          - ``tuple(array)``
 
     [1] If there only is one trainable QNode argument, the tuple is unpacked to a
-    single ``array``, as is the case for :func:`.jacobian`.
+    single ``array``, as is the case for :func:`pennylane.jacobian`.
 
     [2] For JAX, ``argnum=None`` defaults to ``argnum=0`` in contrast to all other
     interfaces. This means that only the classical Jacobian with respect to the first
@@ -158,7 +158,7 @@ def classical_jacobian(qnode, argnum=None, expand_fn=None, trainable_only=True):
         if qnode.interface == "autograd":
             jac = qml.jacobian(classical_preprocessing, argnum=wrapper_argnum)(*args, **kwargs)
 
-        if qnode.interface == "torch":
+        elif qnode.interface == "torch":
             import torch
 
             def _jacobian(*args, **kwargs):  # pylint: disable=unused-argument
@@ -177,7 +177,7 @@ def classical_jacobian(qnode, argnum=None, expand_fn=None, trainable_only=True):
 
             jac = _jacobian(*args, **kwargs)
 
-        if qnode.interface in ["jax", "jax-jit"]:
+        elif qnode.interface in ["jax", "jax-jit"]:
             import jax
 
             argnum = 0 if wrapper_argnum is None else wrapper_argnum
@@ -187,7 +187,7 @@ def classical_jacobian(qnode, argnum=None, expand_fn=None, trainable_only=True):
 
             jac = _jacobian(*args, **kwargs)
 
-        if qnode.interface == "tf":
+        elif qnode.interface == "tf":
             import tensorflow as tf
 
             def _jacobian(*args, **kwargs):
@@ -205,6 +205,9 @@ def classical_jacobian(qnode, argnum=None, expand_fn=None, trainable_only=True):
                 return jac
 
             jac = _jacobian(*args, **kwargs)
+
+        else:
+            raise ValueError(f"Undifferentiable interface {qnode.interface}")
 
         if old_interface == "auto":
             qnode.interface = "auto"

--- a/pennylane/gradients/classical_jacobian.py
+++ b/pennylane/gradients/classical_jacobian.py
@@ -207,7 +207,7 @@ def classical_jacobian(qnode, argnum=None, expand_fn=None, trainable_only=True):
             jac = _jacobian(*args, **kwargs)
 
         else:
-            raise ValueError(f"Undifferentiable interface {qnode.interface}")
+            raise ValueError(f"Undifferentiable interface {qnode.interface}.")
 
         if old_interface == "auto":
             qnode.interface = "auto"

--- a/pennylane/math/__init__.py
+++ b/pennylane/math/__init__.py
@@ -101,7 +101,7 @@ from .interface_utils import (
     get_interface,
     Interface,
 )
-from .grad import grad
+from .grad import grad, jacobian
 
 sum = ar.numpy.sum
 toarray = ar.numpy.to_numpy
@@ -174,6 +174,7 @@ __all__ = [
     "is_abstract",
     "is_independent",
     "iscomplex",
+    "jacobian",
     "marginal_prob",
     "max_entropy",
     "min_entropy",

--- a/pennylane/math/__init__.py
+++ b/pennylane/math/__init__.py
@@ -101,6 +101,7 @@ from .interface_utils import (
     get_interface,
     Interface,
 )
+from .grad import grad
 
 sum = ar.numpy.sum
 toarray = ar.numpy.to_numpy
@@ -168,6 +169,7 @@ __all__ = [
     "get_canonical_interface_name",
     "get_deep_interface",
     "get_trainable_indices",
+    "grad",
     "in_backprop",
     "is_abstract",
     "is_independent",

--- a/pennylane/math/grad.py
+++ b/pennylane/math/grad.py
@@ -102,11 +102,12 @@ def grad(f: Callable, argnums: Union[Sequence[int], int] = 0) -> Callable:
 
 
 def _error_if_not_array(f):
+   """Raises an error if the function output is not an autograd or numpy array."""
     def new_f(*args, **kwargs):
         output = f(*args, **kwargs)
         if get_interface(output) not in {"autograd", "numpy"}:
             raise ValueError(
-                f"autograd can only differentiate with respect to arrays, not {type(output)}"
+                f"autograd can only differentiate with respect to arrays, not {type(output)}. Ensure the output interface is an autograd array."
             )
         return output
 
@@ -165,7 +166,7 @@ def _tensorflow_jac(f, argnums, args, kwargs):
 
 # pylint: disable=import-outside-toplevel
 def jacobian(f: Callable, argnums: Union[Sequence[int], int] = 0) -> Callable:
-    """Compute the gradient in a jax-like manner for any interface.
+    """Compute the Jacobian in a jax-like manner for any interface.
 
     Args:
         f (Callable): a function with a vector valued output
@@ -184,19 +185,19 @@ def jacobian(f: Callable, argnums: Union[Sequence[int], int] = 0) -> Callable:
     ...     return  x * y
     >>> qml.math.jacobian(f)(qml.numpy.array([2.0, 3.0]), qml.numpy.array(3.0))
     array([[3., 0.],
-    [0., 3.]])
+              [0., 3.]])
     >>> qml.math.jacobian(f)(jax.numpy.array([2.0, 3.0]), jax.numpy.array(3.0))
     Array([[3., 0.],
-    [0., 3.]], dtype=float32)
+               [0., 3.]], dtype=float32)
     >>> x_torch = torch.tensor([2.0, 3.0], requires_grad=True)
     >>> y_torch = torch.tensor(3.0, requires_grad=True)
     >>> qml.math.jacobian(f)(x_torch, y_torch)
     tensor([[3., 0.],
-        [0., 3.]])
+                [0., 3.]])
     >>> qml.math.jacobian(f)(tf.Variable([2.0, 3.0]), tf.Variable(3.0))
     <tf.Tensor: shape=(2, 2), dtype=float32, numpy=
     array([[3., 0.],
-        [0., 3.]], dtype=float32)>
+              [0., 3.]], dtype=float32)>
 
     ``argnums`` can be provided to differentiate multiple arguments.
 
@@ -216,7 +217,7 @@ def jacobian(f: Callable, argnums: Union[Sequence[int], int] = 0) -> Callable:
     Torch can only differentiate arrays and tuples:
 
     >>> def tuple_f(x):
-    ... return x**2, x**3
+    ...     return x**2, x**3
     >>> qml.math.jacobian(tuple_f)(torch.tensor(2.0))
     (tensor(4.), tensor(12.))
     >>> qml.math.jacobian(pytree_f)(torch.tensor(2.0))

--- a/pennylane/math/grad.py
+++ b/pennylane/math/grad.py
@@ -101,20 +101,6 @@ def grad(f: Callable, argnums: Union[Sequence[int], int] = 0) -> Callable:
     return compute_grad
 
 
-def _error_if_not_array(f):
-    """Raises an error if the function output is not an autograd or numpy array."""
-
-    def new_f(*args, **kwargs):
-        output = f(*args, **kwargs)
-        if get_interface(output) not in {"autograd", "numpy"}:
-            raise ValueError(
-                f"autograd can only differentiate with respect to arrays, not {type(output)}. Ensure the output interface is an autograd array."
-            )
-        return output
-
-    return new_f
-
-
 # pylint: disable=import-outside-toplevel
 def _torch_jac(f, argnums, args, kwargs):
     """Calculate a jacobian via torch."""
@@ -242,7 +228,7 @@ def jacobian(f: Callable, argnums: Union[Sequence[int], int] = 0) -> Callable:
         interface = get_interface(*args)
 
         if interface == "autograd":
-            return _autograd_jacobian(_error_if_not_array(f), argnum=argnums)(*args, **kwargs)
+            return _autograd_jacobian(f, argnum=argnums)(*args, **kwargs)
 
         if interface == "jax":
             import jax

--- a/pennylane/math/grad.py
+++ b/pennylane/math/grad.py
@@ -107,7 +107,7 @@ def jacobian(f: Callable, argnums: Sequence[int] | int = 0) -> Callable:
     """Compute the gradient in a jax-like manner for any interface.
 
     Args:
-        f (Callable): a function with a single 0-D scalar output
+        f (Callable): a function with a vector valued output
         argnums (Sequence[int] | int ) = 0 : which arguments to differentiate
 
     Returns:
@@ -137,6 +137,7 @@ def jacobian(f: Callable, argnums: Sequence[int] | int = 0) -> Callable:
 
         if interface == "torch":
             from torch.autograd.functional import jacobian as _torch_jac
+
             g = _torch_jac(partial(f, **kwargs), args)
             g = tuple(g[i] for i in argnums)
             return g[0] if argnums_integer else g
@@ -153,4 +154,3 @@ def jacobian(f: Callable, argnums: Sequence[int] | int = 0) -> Callable:
         raise ValueError(f"Interface {interface} is not differentiatble.")
 
     return compute_jacobian
-

--- a/pennylane/math/grad.py
+++ b/pennylane/math/grad.py
@@ -16,7 +16,6 @@ This submodule defines grad and jacobian for differentiating circuits in an inte
 independent way.
 """
 
-from functools import partial
 from typing import Callable, Sequence, Union
 
 from pennylane._grad import grad as _autograd_grad
@@ -41,9 +40,10 @@ def grad(f: Callable, argnums: Union[Sequence[int], int] = 0) -> Callable:
     Note that this function follows the same design as jax. By default, the function will return the gradient
     of the first argument, whether or not other arguments are trainable.
 
+    >>> import jax, torch, tensorflow as tf
     >>> def f(x, y):
     ...     return  x * y
-    >>> qml.math.grad(f)(qml.numpy.array(2.0). qml.numpy.array(3.0))
+    >>> qml.math.grad(f)(qml.numpy.array(2.0), qml.numpy.array(3.0))
     tensor(3., requires_grad=True)
     >>> qml.math.grad(f)(jax.numpy.array(2.0), jax.numpy.array(3.0))
     Array(3., dtype=float32, weak_type=True)
@@ -102,32 +102,137 @@ def grad(f: Callable, argnums: Union[Sequence[int], int] = 0) -> Callable:
     return compute_grad
 
 
+def _error_if_not_array(f):
+    def new_f(*args, **kwargs):
+        output = f(*args, **kwargs)
+        if get_interface(output) not in {"autograd", "numpy"}:
+            raise ValueError(
+                f"autograd can only differentiate with respect to arrays, not {type(output)}"
+            )
+        return output
+
+    return new_f
+
+
+def _torch_jac(f, argnums, args, kwargs):
+    """Calculate a jacobian via torch."""
+    from torch.autograd.functional import jacobian as _torch_jac
+
+    argnums_torch = (argnums,) if isinstance(argnums, int) else argnums
+    trainable_args = tuple(args[i] for i in argnums_torch)
+
+    # keep track of output type to know how to unpack
+    output_type_cache = []
+
+    def partial_f(*_trainables):
+        full_args = list(args)
+        for argnum, value in zip(argnums_torch, _trainables, strict=True):
+            full_args[argnum] = value
+        result = f(*full_args, **kwargs)
+        output_type_cache.append(type(result))
+        return result
+
+    jac = _torch_jac(partial_f, trainable_args)
+    if output_type_cache[-1] is tuple:
+        return tuple(j[0] for j in jac) if isinstance(argnums, int) else jac
+    # else array
+    return jac[0] if isinstance(argnums, int) else jac
+
+
+def _tensorflow_jac(f, argnums, args, kwargs):
+    """Calculate a jacobian via tensorflow"""
+    import tensorflow as tf
+
+    with tf.GradientTape() as tape:
+        y = f(*args, **kwargs)
+
+    if get_interface(y) != "tensorflow":
+        raise ValueError(
+            f"qml.math.jacobian does not work with tensorflow and non-tensor outputs. Got {y} of type {type(y)}."
+        )
+
+    argnums_integer = False
+    if isinstance(argnums, int):
+        argnums_tf = (argnums,)
+        argnums_integer = True
+    else:
+        argnums_tf = argnums
+
+    g = tape.jacobian(y, tuple(args[i] for i in argnums_tf))
+    return g[0] if argnums_integer else g
+
+
 # pylint: disable=import-outside-toplevel
 def jacobian(f: Callable, argnums: Union[Sequence[int], int] = 0) -> Callable:
     """Compute the gradient in a jax-like manner for any interface.
 
-    Args:
-        f (Callable): a function with a vector valued output
-        argnums (Sequence[int] | int ) = 0 : which arguments to differentiate
+     Args:
+         f (Callable): a function with a vector valued output
+         argnums (Sequence[int] | int ) = 0 : which arguments to differentiate
 
-    Returns:
-        Callable: a function with the same signature as ``f`` that returns the jacobian
+     Returns:
+         Callable: a function with the same signature as ``f`` that returns the jacobian
 
-    .. seealso:: :func:`pennylane.math.grad`
+     .. seealso:: :func:`pennylane.math.grad`
 
-    >>> import jax, torch, tensorflow as tf
-    >>> def f(x, y):
-    ...     return x * y
-    >>> qml.math.jacobian(f)(jax.numpy.array([1.0, 2.0]), jax.numpy.array(2.0))
-    Array([[2., 0.],
-       [0., 2.]], dtype=float32)
-    >>> qml.math.jacobian(f)(torch.tensor([1.0, 2.0]), torch.tensor(2.0))
-    tensor([[2., 0.],
-        [0., 2.]])
-    >>> qml.math.jacobian(f)(tf.Variable([1.0, 2.0]), tf.constant(2.0))
+
+     Note that this function follows the same design as jax. By default, the function will return the gradient
+     of the first argument, whether or not other arguments are trainable.
+
+     >>> import jax, torch, tensorflow as tf
+     >>> def f(x, y):
+     ...     return  x * y
+     >>> qml.math.jacobian(f)(qml.numpy.array([2.0, 3.0]), qml.numpy.array(3.0))
+     array([[3., 0.],
+        [0., 3.]])
+     >>> qml.math.jacobian(f)(jax.numpy.array([2.0, 3.0]), jax.numpy.array(3.0))
+     Array([[3., 0.],
+        [0., 3.]], dtype=float32)
+     >>> x_torch = torch.tensor([2.0, 3.0], requires_grad=True)
+     >>> y_torch = torch.tensor(3.0, requires_grad=True)
+     >>> qml.math.jacobian(f)(x_torch, y_torch)
+     tensor([[3., 0.],
+         [0., 3.]])
+     >>> qml.math.jacobian(f)(tf.Variable([2.0, 3.0]), tf.Variable(3.0))
     <tf.Tensor: shape=(2, 2), dtype=float32, numpy=
-    array([[2., 0.],
-        [0., 2.]], dtype=float32)>
+     array([[3., 0.],
+         [0., 3.]], dtype=float32)>
+
+     ``argnums`` can be provided to differentiate multiple arguments.
+
+     >>> qml.math.jacobian(f, argnums=(0,1))(x_torch, y_torch)
+     (tensor([[3., 0.],
+             [0., 3.]]),
+     tensor([2., 3.]))
+
+     While jax can handle taking jacobians of outputs with any pytree shape:
+
+     >>> def pytree_f(x):
+     ...     return {"a": 2*x, "b": 3*x}
+     >>> qml.math.jacobian(pytree_f)(jax.numpy.array(2.0))
+     {'a': Array(2., dtype=float32, weak_type=True),
+     'b': Array(3., dtype=float32, weak_type=True)}
+
+     Torch can only differentiate arrays and tuples:
+
+     >>> def tuple_f(x):
+     ... return x**2, x**3
+     >>> qml.math.jacobian(tuple_f)(torch.tensor(2.0))
+     (tensor(4.), tensor(12.))
+     >>> qml.math.jacobian(pytree_f)(torch.tensor(2.0))
+     TypeError: The outputs of the user-provided function given to jacobian must be
+     either a Tensor or a tuple of Tensors but the given outputs of the user-provided
+     function has type <class 'dict'>.
+
+
+     But tensorflow and autograd can only handle array-valued outputs:
+
+     >>> qml.math.jacobian(tuple_f)(qml.numpy.array(2.0))
+     ValueError: autograd can only differentiate with respect to arrays, not <class 'tuple'>
+     >>> qml.math.jacobian(tuple_f)(tf.Variable(2.0))
+     ValueError: qml.math.jacobian does not work with tensorflow and non-tensor outputs.
+     Got (<tf.Tensor: shape=(), dtype=float32, numpy=4.0>,
+     <tf.Tensor: shape=(), dtype=float32, numpy=8.0>) of type <class 'tuple'>.
 
     """
 
@@ -135,7 +240,7 @@ def jacobian(f: Callable, argnums: Union[Sequence[int], int] = 0) -> Callable:
         interface = get_interface(*args)
 
         if interface == "autograd":
-            return _autograd_jacobian(f, argnum=argnums)(*args, **kwargs)
+            return _autograd_jacobian(_error_if_not_array(f), argnum=argnums)(*args, **kwargs)
 
         if interface == "jax":
             import jax
@@ -143,33 +248,10 @@ def jacobian(f: Callable, argnums: Union[Sequence[int], int] = 0) -> Callable:
             return jax.jacobian(f, argnums=argnums)(*args, **kwargs)
 
         if interface == "torch":
-            from torch.autograd.functional import jacobian as _torch_jac
+            return _torch_jac(f, argnums, args, kwargs)
 
-            if set(argnums) != set(range(len(args))):
-                # do to potential pytree output from function, cant just slice into gradient to get
-                # subset
-                raise ValueError("qml.math.jacobian must differentiate all arguments with torch.")
-            return _torch_jac(partial(f, **kwargs), args)
         if interface == "tensorflow":
-            import tensorflow as tf
-
-            with tf.GradientTape() as tape:
-                y = f(*args, **kwargs)
-
-            if get_interface(y) != "tensorflow":
-                raise ValueError(
-                    f"qml.math.jacobian does not work with tensorflow and non-tensor outputs. Got {y} of type {type(y)}."
-                )
-
-            argnums_integer = False
-            if isinstance(argnums, int):
-                argnums_tf = (argnums,)
-                argnums_integer = True
-            else:
-                argnums_tf = argnums
-
-            g = tape.jacobian(y, tuple(args[i] for i in argnums_tf))
-            return g[0] if argnums_integer else g
+            return _tensorflow_jac(f, argnums, args, kwargs)
 
         raise ValueError(f"Interface {interface} is not differentiable.")
 

--- a/pennylane/math/grad.py
+++ b/pennylane/math/grad.py
@@ -17,7 +17,7 @@ independent way.
 """
 
 from functools import partial
-from typing import Callable, Sequence
+from typing import Callable, Sequence, Union
 
 from pennylane._grad import grad as _autograd_grad
 from pennylane._grad import jacobian as _autograd_jacobian
@@ -26,7 +26,7 @@ from .interface_utils import get_interface
 
 
 # pylint: disable=import-outside-toplevel
-def grad(f: Callable, argnums: Sequence[int] | int = 0) -> Callable:
+def grad(f: Callable, argnums: Union[Sequence[int], int] = 0) -> Callable:
     """Compute the gradient in a jax-like manner for any interface.
 
     Args:
@@ -97,13 +97,13 @@ def grad(f: Callable, argnums: Sequence[int] | int = 0) -> Callable:
             g = tape.gradient(y, tuple(args[i] for i in argnums))
             return g[0] if argnums_integer else g
 
-        raise ValueError(f"Interface {interface} is not differentiatble.")
+        raise ValueError(f"Interface {interface} is not differentiable.")
 
     return compute_grad
 
 
 # pylint: disable=import-outside-toplevel
-def jacobian(f: Callable, argnums: Sequence[int] | int = 0) -> Callable:
+def jacobian(f: Callable, argnums: Union[Sequence[int], int] = 0) -> Callable:
     """Compute the gradient in a jax-like manner for any interface.
 
     Args:
@@ -151,6 +151,6 @@ def jacobian(f: Callable, argnums: Sequence[int] | int = 0) -> Callable:
             g = tape.jacobian(y, tuple(args[i] for i in argnums))
             return g[0] if argnums_integer else g
 
-        raise ValueError(f"Interface {interface} is not differentiatble.")
+        raise ValueError(f"Interface {interface} is not differentiable.")
 
     return compute_jacobian

--- a/pennylane/math/grad.py
+++ b/pennylane/math/grad.py
@@ -102,7 +102,8 @@ def grad(f: Callable, argnums: Union[Sequence[int], int] = 0) -> Callable:
 
 
 def _error_if_not_array(f):
-   """Raises an error if the function output is not an autograd or numpy array."""
+    """Raises an error if the function output is not an autograd or numpy array."""
+
     def new_f(*args, **kwargs):
         output = f(*args, **kwargs)
         if get_interface(output) not in {"autograd", "numpy"}:

--- a/pennylane/math/grad.py
+++ b/pennylane/math/grad.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-This submodule defines grad and jacobian for differentiating circuits in an interface
-independent way.
+This submodule defines grad and jacobian for differentiating circuits in an interface-independent way.
 """
 
 from typing import Callable, Sequence, Union

--- a/tests/math/test_grad.py
+++ b/tests/math/test_grad.py
@@ -15,11 +15,20 @@
 Test the qml.math.grad and qml.math.jacobian functions.
 """
 
+import numpy as np
 import pytest
 
 from pennylane import math
 
 pytestmark = pytest.mark.all_interfaces
+
+
+@pytest.mark.parametrize("grad_fn", (math.grad, math.jacobian))
+def test_no_interface_error_numpy(grad_fn):
+    """Test that an error is raised for an unknown interface."""
+
+    with pytest.raises(ValueError, match="Interface numpy is not differentiable"):
+        grad_fn(lambda x: x**2)(np.array(2.0))
 
 
 @pytest.mark.parametrize("interface", ("autograd", "jax", "tensorflow", "torch"))

--- a/tests/math/test_grad.py
+++ b/tests/math/test_grad.py
@@ -63,8 +63,8 @@ class TestGrad:
             assert math.get_interface(g1) == interface
             assert math.get_interface(g2) == interface
 
-        assert math.allclose(g1, 2)
-        assert math.allclose(g2, 3)
+        assert math.allclose(g1, 2.0)
+        assert math.allclose(g2, 3.0)
 
     def test_keyword_arguments(self, interface):
         """Test that keyword arguments are considered."""

--- a/tests/math/test_grad.py
+++ b/tests/math/test_grad.py
@@ -1,0 +1,70 @@
+# Copyright 2024 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Test the qml.math.grad and qml.math.jacobian functions.
+"""
+
+import pytest
+
+from pennylane import math
+
+pytestmark = pytest.mark.all_interfaces
+
+
+@pytest.mark.parametrize("interface", ("autograd", "jax", "tensorflow", "torch"))
+def test_differentiate_first_arg(interface):
+    """Test taht we just differentiate the first argument by default."""
+
+    def f(x, y):
+        return x * y
+
+    x = math.asarray(2.0, like=interface, requires_grad=True)
+    y = math.asarray(3.0, like=interface, requires_grad=True)
+
+    g = math.grad(f)(x, y)
+    if interface != "autograd":
+        assert math.get_interface(g) == interface
+    assert math.allclose(g, 3.0)
+
+
+@pytest.mark.parametrize("interface", ("autograd", "jax", "tensorflow", "torch"))
+def test_multiple_argnums(interface):
+    """Test that we can differentiate multiple arguments."""
+
+    def g(x, y):
+        return 2 * x + 3 * y
+
+    x = math.asarray(0.5, like=interface, requires_grad=True)
+    y = math.asarray(2.5, like=interface, requires_grad=True)
+
+    g1, g2 = math.grad(g, argnums=(0, 1))(x, y)
+    if interface != "autograd":
+        assert math.get_interface(g1) == interface
+        assert math.get_interface(g2) == interface
+
+    assert math.allclose(g1, 2)
+    assert math.allclose(g2, 3)
+
+
+@pytest.mark.parametrize("interface", ("autograd", "jax", "tensorflow", "torch"))
+def test_keyword_arguments(interface):
+    """Test that keyword arguments are considered."""
+
+    def f(x, *, constant):
+        return constant * x
+
+    x = math.asarray(2.0, like=interface, requires_grad=True)
+
+    g = math.grad(f)(x, constant=2.0)
+    assert math.allclose(g, 2.0)

--- a/tests/math/test_grad.py
+++ b/tests/math/test_grad.py
@@ -40,7 +40,6 @@ class TestGrad:
             assert math.get_interface(g) == interface
         assert math.allclose(g, 3.0)
 
-
     def test_multiple_argnums(self, interface):
         """Test that we can differentiate multiple arguments."""
 
@@ -57,7 +56,6 @@ class TestGrad:
 
         assert math.allclose(g1, 2)
         assert math.allclose(g2, 3)
-
 
     def test_keyword_arguments(self, interface):
         """Test that keyword arguments are considered."""
@@ -106,7 +104,6 @@ class TestJacobian:
 
         assert math.allclose(g1, 2 * math.eye(2))
         assert math.allclose(g2, 3 * math.eye(2))
-
 
     def test_keyword_arguments(self, interface):
         """Test that keyword arguments are considered."""

--- a/tests/test_autograd_grad.py
+++ b/tests/test_autograd_grad.py
@@ -1,0 +1,29 @@
+# Copyright 2018-2021 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Unit tests for qml.grad and qml.jacobian
+"""
+import pytest
+
+import pennylane as qml
+
+
+def test_informative_error_on_bad_shape():
+    """Test that an informative error is raised if taking the jacobian of a non-array."""
+
+    def f(x):
+        return (2 * x,)
+
+    with pytest.raises(ValueError, match="autograd can only differentiate with"):
+        qml.jacobian(f)(qml.numpy.array(2.0))

--- a/tests/transforms/test_classical_jacobian.py
+++ b/tests/transforms/test_classical_jacobian.py
@@ -145,6 +145,18 @@ def test_autograd_without_argnum(circuit, args, expected_jac, diff_method, inter
 interfaces = ["tf"]
 
 
+def test_error_undefined_interface():
+    """Test that an error is raised in the qnode interface is not differentiable."""
+
+    @qml.qnode(qml.device("default.qubit"), interface=None)
+    def circuit(a):
+        qml.RX(a, 0)
+        return qml.expval(qml.Z(0))
+
+    with pytest.raises(ValueError, match="Undifferentiable interface numpy"):
+        classical_jacobian(circuit)(np.array(0.5))
+
+
 @pytest.mark.tf
 @pytest.mark.parametrize("diff_method", ["backprop", "parameter-shift"])
 @pytest.mark.parametrize("circuit, args, expected_jac", zip(circuits, all_args, class_jacs))

--- a/tests/transforms/test_classical_jacobian.py
+++ b/tests/transforms/test_classical_jacobian.py
@@ -149,8 +149,8 @@ def test_error_undefined_interface():
     """Test that an error is raised in the qnode interface is not differentiable."""
 
     @qml.qnode(qml.device("default.qubit"), interface=None)
-    def circuit(a):
-        qml.RX(a, 0)
+    def circuit(_var):
+        qml.RX(_var, 0)
         return qml.expval(qml.Z(0))
 
     with pytest.raises(ValueError, match="Undifferentiable interface numpy"):


### PR DESCRIPTION
**Context:**

We often have to rewrite tests four different ways to test differentiability for each different interface.  This is rather time-intensive and annoying.  By adding and using a `qml.math.grad`, we can write one test that applies to all interfaces.

**Description of the Change:**

Adds a `qml.math.grad` and `qml.math.jacobian` with a jax-like interface that can differentiate with respect to any argument inputs.

**Benefits:**

**Possible Drawbacks:**

We have several different options for interface, but I decided to do my best to mirror the jax interface.

**Related GitHub Issues:**
