### PR TITLE
`QubitUnitary` docstring link fix

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -607,6 +607,9 @@ same information.
 * Updated the documentation of `QSVT` to include examples for different block encodings.
   [(#6673)](https://github.com/PennyLaneAI/pennylane/pull/6673)
 
+* The link to `qml.ops.one_qubit_transform` was fixed in the `QubitUnitary` docstring.
+  [(#6745)](https://github.com/PennyLaneAI/pennylane/pull/6745)
+
 <h3>Bug fixes 🐛</h3>
 
 * `qml.ControlledQubitUnitary` has consistent behaviour with program capture enabled. 

--- a/pennylane/ops/qubit/matrix_ops.py
+++ b/pennylane/ops/qubit/matrix_ops.py
@@ -189,7 +189,7 @@ class QubitUnitary(Operation):
         A decomposition is only defined for matrices that act on either one or two wires. For more
         than two wires, this method raises a ``DecompositionUndefined``.
 
-        See :func:`~.transforms.one_qubit_decomposition` and :func:`~.ops.two_qubit_decomposition`
+        See :func:`~.ops.one_qubit_decomposition` and :func:`~.ops.two_qubit_decomposition`
         for more information on how the decompositions are computed.
 
         .. seealso:: :meth:`~.QubitUnitary.decomposition`.


### PR DESCRIPTION
**Context:** 

**Description of the Change:** Link fix to `one_qubit_decomposition`

**Benefits:** Link works

**Possible Drawbacks:** Absolutely none—zip—zilch—zéro

**Related GitHub Issues:**
