### PR TITLE
Update `cancel_inverses` to have better support for `Adjoint`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -340,6 +340,8 @@ such as `shots`, `rng` and `prng_key`.
 
 <h4>Other Improvements</h4>
 
+* `qml.transforms.cancel_inverses` is now better at handling cancellation of `Adjoint` operators.
+
 * `qml.math.grad` and `qml.math.jacobian` added to differentiate a function with inputs of any
   interface in a jax-like manner.
   [(#6741)](https://github.com/PennyLaneAI/pennylane/pull/6741)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -340,7 +340,7 @@ such as `shots`, `rng` and `prng_key`.
 
 <h4>Other Improvements</h4>
 
-* `qml.transforms.cancel_inverses` is now better at handling cancellation of `Adjoint` operators.
+* `qml.transforms.cancel_inverses` now has improved handling of `Adjoint` operator cancellation.
   [(#6752)](https://github.com/PennyLaneAI/pennylane/pull/6752)
 
 * `qml.math.grad` and `qml.math.jacobian` added to differentiate a function with inputs of any

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -341,6 +341,7 @@ such as `shots`, `rng` and `prng_key`.
 <h4>Other Improvements</h4>
 
 * `qml.transforms.cancel_inverses` is now better at handling cancellation of `Adjoint` operators.
+  [(#6752)](https://github.com/PennyLaneAI/pennylane/pull/6752)
 
 * `qml.math.grad` and `qml.math.jacobian` added to differentiate a function with inputs of any
   interface in a jax-like manner.

--- a/pennylane/transforms/optimization/cancel_inverses.py
+++ b/pennylane/transforms/optimization/cancel_inverses.py
@@ -270,7 +270,7 @@ def cancel_inverses(tape: QuantumScript) -> tuple[QuantumScriptBatch, Postproces
 
     .. code-block:: python
 
-        @cancel_inverses
+        @qml.transforms.cancel_inverses
         @qml.qnode(device=dev)
         def circuit(x, y, z):
             qml.Hadamard(wires=0)
@@ -286,7 +286,7 @@ def cancel_inverses(tape: QuantumScript) -> tuple[QuantumScriptBatch, Postproces
             return qml.expval(qml.Z(0))
 
     >>> circuit(0.1, 0.2, 0.3)
-    0.999999999999999
+    1.0
 
     .. details::
         :title: Usage Details
@@ -321,7 +321,7 @@ def cancel_inverses(tape: QuantumScript) -> tuple[QuantumScriptBatch, Postproces
         second qubit that should cancel. We can obtain a simplified circuit by running
         the ``cancel_inverses`` transform:
 
-        >>> optimized_qfunc = cancel_inverses(qfunc)
+        >>> optimized_qfunc = qml.transforms.cancel_inverses(qfunc)
         >>> optimized_qnode = qml.QNode(optimized_qfunc, dev)
         >>> print(qml.draw(optimized_qnode)(1, 2, 3))
         0: ──RZ(3.00)───────────╭●─┤  <Z>

--- a/pennylane/transforms/optimization/cancel_inverses.py
+++ b/pennylane/transforms/optimization/cancel_inverses.py
@@ -30,12 +30,11 @@ from .optimization_utils import find_next_gate
 
 
 def _ops_equal(op1, op2):
-    """Checks if two operators are equal up to class, data, hyperparameters, and wires"""
+    """Checks if two operators are equal up to class, data, and hyperparameters"""
     return (
         op1.__class__ is op2.__class__
         and (op1.data == op2.data)
         and (op1.hyperparameters == op2.hyperparameters)
-        and (op1.wires == op2.wires)
     )
 
 
@@ -60,6 +59,45 @@ def _are_inverses(op1, op2):
     # op2 is an `Adjoint` class and its base is equal to op1
     if isinstance(op2, Adjoint) and _ops_equal(op2.base, op1):
         return True
+
+    return False
+
+
+def _can_cancel_ops(op1, op2):
+    """Checks if two operators can be cancelled
+
+    Args:
+        op1 (~.Operator)
+        op2 (~.Operator)
+
+    Returns:
+        Bool
+    """
+    if _are_inverses(op1, op2):
+        # Make sure that if one of the ops is Adjoint, it is always op2 by swapping
+        # the ops if op1 is Adjoint
+        if isinstance(op1, Adjoint):
+            op1, op2 = op2, op1
+
+        # If the wires are the same, then we can safely cancel both
+        if op1.wires == op2.wires:
+            return True
+        # If wires are not equal, there are two things that can happen.
+        # 1. There is not full overlap in the wires; we cannot cancel
+        if len(Wires.shared_wires([op1.wires, op2.wires])) != len(op1.wires):
+            return False
+
+        # 2. There is full overlap, but the wires are in a different order.
+        # If the wires are in a different order, gates that are "symmetric"
+        # over all wires (e.g., CZ), can be cancelled.
+        if op1 in symmetric_over_all_wires:
+            return True
+        # For other gates, as long as the control wires are the same, we can still
+        # cancel (e.g., the Toffoli gate).
+        if op1 in symmetric_over_control_wires:
+            # TODO[David Wierichs]: This assumes single-qubit targets of controlled gates
+            if len(Wires.shared_wires([op1.wires[:-1], op2.wires[:-1]])) == len(op1.wires) - 1:
+                return True
 
     return False
 
@@ -123,24 +161,7 @@ def _get_plxpr_cancel_inverses():  # pylint: disable=missing-function-docstring,
                     self.previous_ops[w] = op
                 return []
 
-            cancel = False
-            if _are_inverses(op, prev_op):
-                # Same wires, cancel
-                if op.wires == prev_op.wires:
-                    cancel = True
-                # Full overlap over wires
-                elif len(Wires.shared_wires([op.wires, prev_op.wires])) == len(op.wires):
-                    # symmetric op + full wire overlap; cancel
-                    if op in symmetric_over_all_wires:
-                        cancel = True
-                    # symmetric over control wires, full overlap over control wires; cancel
-                    elif op in symmetric_over_control_wires and (
-                        len(Wires.shared_wires([op.wires[:-1], prev_op.wires[:-1]]))
-                        == len(op.wires) - 1
-                    ):
-                        cancel = True
-                # No or partial overlap over wires; can't cancel
-
+            cancel = _can_cancel_ops(op, prev_op)
             if cancel:
                 for w in op.wires:
                     self.previous_ops.pop(w)
@@ -353,42 +374,15 @@ def cancel_inverses(tape: QuantumScript) -> tuple[QuantumScriptBatch, Postproces
         # Otherwise, get the next gate
         next_gate = list_copy[next_gate_idx]
 
-        # If either of the two flags is true, we can potentially cancel the gates
-        if _are_inverses(current_gate, next_gate):
-            # If the wires are the same, then we can safely remove both
-            if current_gate.wires == next_gate.wires:
-                list_copy.pop(next_gate_idx)
-                continue
-            # If wires are not equal, there are two things that can happen.
-            # 1. There is not full overlap in the wires; we cannot cancel
-            if len(Wires.shared_wires([current_gate.wires, next_gate.wires])) != len(
-                current_gate.wires
-            ):
-                operations.append(current_gate)
-                continue
-
-            # 2. There is full overlap, but the wires are in a different order.
-            # If the wires are in a different order, gates that are "symmetric"
-            # over all wires (e.g., CZ), can be cancelled.
-            if current_gate in symmetric_over_all_wires:
-                list_copy.pop(next_gate_idx)
-                continue
-            # For other gates, as long as the control wires are the same, we can still
-            # cancel (e.g., the Toffoli gate).
-            if current_gate in symmetric_over_control_wires:
-                # TODO[David Wierichs]: This assumes single-qubit targets of controlled gates
-                if (
-                    len(Wires.shared_wires([current_gate.wires[:-1], next_gate.wires[:-1]]))
-                    == len(current_gate.wires) - 1
-                ):
-                    list_copy.pop(next_gate_idx)
-                    continue
+        # If operators are inverses, cancel
+        if _can_cancel_ops(current_gate, next_gate):
+            list_copy.pop(next_gate_idx)
+            continue
         # Apply gate any cases where
         # - there is no wire symmetry
         # - the control wire symmetry does not apply because the control wires are not the same
         # - neither of the flags are_self_inverses and are_inverses are true
         operations.append(current_gate)
-        continue
 
     new_tape = tape.copy(operations=operations)
 

--- a/tests/transforms/test_optimization/test_cancel_inverses.py
+++ b/tests/transforms/test_optimization/test_cancel_inverses.py
@@ -194,6 +194,26 @@ class TestCancelInverses:
 
         assert len(ops) == 0
 
+    @pytest.mark.parametrize("adjoint_first", [True, False])
+    def test_symmetric_over_all_wires(self, adjoint_first):
+        """Test that adjacent adjoint ops are cancelled due to wire symmetry."""
+
+        def qfunc(x):
+            if adjoint_first:
+                qml.adjoint(qml.MultiRZ(x, [2, 0, 1]))
+                qml.MultiRZ(x, [0, 1, 2])
+            else:
+                qml.MultiRZ(x, [2, 0, 1])
+                qml.adjoint(qml.MultiRZ(x, [0, 1, 2]))
+
+        transformed_qfunc = cancel_inverses(qfunc)
+
+        ops = qml.tape.make_qscript(transformed_qfunc)(1.5).operations
+
+        names_expected = []
+        wires_expected = []
+        compare_operation_lists(ops, names_expected, wires_expected)
+
 
 # Example QNode and device for interface testing
 dev = qml.device("default.qubit", wires=3)


### PR DESCRIPTION
**Context:**
`cancel_inverses` does not cancel `Adjoint` ops if the ops to be cancelled are symmetric on all wires. This PR fixes that, and also cleans up the code in `cancel_inverses.py` a bit.

**Description of the Change:**
* Remove check from `_ops_equal` for wires as we check for wire equality/symmetry later.
* Move cancellation logic into helper `_can_cancel_ops` function, which can be used by both `cancel_inverses` and `CancelInversesInterpreter`.

**Benefits:**
`cancel_inverses` is better at cancelling `Adjoint` ops.

**Possible Drawbacks:**

**Related GitHub Issues:**
#6729 
[sc-80821]