### PR TITLE
[QA] v0.40 Release Improvements

### DIFF
--- a/doc/code/qml_fermi.rst
+++ b/doc/code/qml_fermi.rst
@@ -68,7 +68,7 @@ FermiWord and FermiSentence
 ---------------------------
 
 Fermi words and Fermi sentences can also be constructed directly with
-:class:`~pennylane.fermi.FermiWord` and :class:`~pennylane.fermi.FermiSentence` by passing
+:class:`~pennylane.FermiWord` and :class:`~pennylane.FermiSentence` by passing
 dictionaries that define the fermionic operators.
 
 For Fermi words, the dictionary items define the fermionic creation and annihilation operators.
@@ -78,15 +78,15 @@ the orbital it acts on. The values of the dictionary are one of ``'+'`` or ``'-'
 denote creation and annihilation operators, respectively. The operator
 :math:`a^{\dagger}_0 a_3 a^{\dagger}_1` can then be constructed with
 
->>> qml.fermi.FermiWord({(0, 0): '+', (1, 3): '-', (2, 1): '+'})
+>>> qml.FermiWord({(0, 0): '+', (1, 3): '-', (2, 1): '+'})
 a⁺(0) a(3) a⁺(1)
 
 A Fermi sentence can be constructed directly by passing a dictionary of Fermi words and their
 corresponding coefficients to the :class:`~pennylane.fermi.FermiSentence` class. For instance, the
 Fermi sentence :math:`1.2 a^{\dagger}_0 a_0  + 2.3 a^{\dagger}_3 a_3` can be constructed as
 
->>> fw1 = qml.fermi.FermiWord({(0, 0): '+', (1, 0): '-'})
->>> fw2 = qml.fermi.FermiWord({(0, 3): '+', (1, 3): '-'})
->>> qml.fermi.FermiSentence({fw1: 1.2, fw2: 2.3})
+>>> fw1 = qml.FermiWord({(0, 0): '+', (1, 0): '-'})
+>>> fw2 = qml.FermiWord({(0, 3): '+', (1, 3): '-'})
+>>> qml.FermiSentence({fw1: 1.2, fw2: 2.3})
 1.2 * a⁺(0) a(0)
 + 2.3 * a⁺(3) a(3)

--- a/pennylane/__init__.py
+++ b/pennylane/__init__.py
@@ -35,6 +35,8 @@ import pennylane.qchem
 from pennylane.fermi import (
     FermiC,
     FermiA,
+    FermiWord,
+    FermiSentence,
     jordan_wigner,
     parity_transform,
     bravyi_kitaev,

--- a/pennylane/bose/bosonic.py
+++ b/pennylane/bose/bosonic.py
@@ -30,7 +30,7 @@ class BoseWord(dict):
     symbols that denote creation and annihilation operators, respectively. The operator
     :math:`b^{\dagger}_0 b_1` can then be constructed as
 
-    >>> w = qml.bose.BoseWord({(0, 0) : '+', (1, 1) : '-'})
+    >>> w = qml.BoseWord({(0, 0) : '+', (1, 1) : '-'})
     >>> print(w)
     b⁺(0) b(1)
     """
@@ -112,7 +112,7 @@ class BoseWord(dict):
         represented by the number of the wire it operates on, and a `+` or `-` to indicate either
         a creation or annihilation operator.
 
-        >>> w = qml.bose.BoseWord({(0, 0) : '+', (1, 1) : '-'})
+        >>> w = qml.BoseWord({(0, 0) : '+', (1, 1) : '-'})
         >>> w.to_string()
         'b⁺(0) b(1)'
         """
@@ -209,7 +209,7 @@ class BoseWord(dict):
     def __mul__(self, other):
         r"""Multiply a BoseWord with another BoseWord, a BoseSentence, or a constant.
 
-        >>> w = qml.bose.BoseWord({(0, 0) : '+', (1, 1) : '-'})
+        >>> w = qml.BoseWord({(0, 0) : '+', (1, 1) : '-'})
         >>> print(w * w)
         b⁺(0) b(1) b⁺(0) b(1)
         """
@@ -263,7 +263,7 @@ class BoseWord(dict):
     def __pow__(self, value):
         r"""Exponentiate a Bose word to an integer power.
 
-        >>> w = qml.bose.BoseWord({(0, 0) : '+', (1, 1) : '-'})
+        >>> w = qml.BoseWord({(0, 0) : '+', (1, 1) : '-'})
         >>> print(w**3)
         b⁺(0) b(1) b⁺(0) b(1) b⁺(0) b(1)
         """
@@ -280,7 +280,7 @@ class BoseWord(dict):
     def normal_order(self):
         r"""Convert a BoseWord to its normal-ordered form.
 
-        >>> bw = qml.bose.BoseWord({(0, 0): "-", (1, 0): "-", (2, 0): "+", (3, 0): "+"})
+        >>> bw = qml.BoseWord({(0, 0): "-", (1, 0): "-", (2, 0): "+", (3, 0): "+"})
         >>> print(bw.normal_order())
         4.0 * b⁺(0) b(0)
         + 2.0 * I
@@ -420,8 +420,8 @@ class BoseSentence(dict):
     r"""Dictionary used to represent a Bose sentence, a linear combination of Bose words,
     with the keys as BoseWord instances and the values correspond to coefficients.
 
-    >>> w1 = qml.bose.BoseWord({(0, 0) : '+', (1, 1) : '-'})
-    >>> w2 = qml.bose.BoseWord({(0, 1) : '+', (1, 2) : '-'})
+    >>> w1 = qml.BoseWord({(0, 0) : '+', (1, 1) : '-'})
+    >>> w2 = qml.BoseWord({(0, 1) : '+', (1, 2) : '-'})
     >>> s = BoseSentence({w1 : 1.2, w2: 3.1})
     >>> print(s)
     1.2 * b⁺(0) b(1)
@@ -608,8 +608,8 @@ class BoseSentence(dict):
     def normal_order(self):
         r"""Convert a BoseSentence to its normal-ordered form.
 
-        >>> bw = qml.bose.BoseWord({(0, 0): "-", (1, 0): "-", (2, 0): "+", (3, 0): "+"})
-        >>> bs = qml.bose.BoseSentence({bw: 1})
+        >>> bw = qml.BoseWord({(0, 0): "-", (1, 0): "-", (2, 0): "+", (3, 0): "+"})
+        >>> bs = qml.BoseSentence({bw: 1})
         >>> print(bw.normal_order())
         4.0 * b⁺(0) b(0)
         + 2.0 * I

--- a/pennylane/bose/bosonic_mapping.py
+++ b/pennylane/bose/bosonic_mapping.py
@@ -65,7 +65,7 @@ def binary_mapping(
 
     **Example**
 
-    >>> w = qml.bose.BoseWord({(0, 0): "+"})
+    >>> w = qml.BoseWord({(0, 0): "+"})
     >>> qml.binary_mapping(w, n_states=4)
     0.6830127018922193 * X(0)
     + -0.1830127018922193 * X(0) @ Z(1)
@@ -188,7 +188,7 @@ def unary_mapping(
 
     **Example**
 
-    >>> w = qml.bose.BoseWord({(0, 0): "+"})
+    >>> w = qml.BoseWord({(0, 0): "+"})
     >>> qml.unary_mapping(w, n_states=4)
     0.25 * X(0) @ X(1)
     + -0.25j * X(0) @ Y(1)

--- a/pennylane/bose/bosonic_mapping.py
+++ b/pennylane/bose/bosonic_mapping.py
@@ -93,7 +93,7 @@ def binary_mapping(
 @singledispatch
 def _binary_mapping_dispatch(bose_operator, n_states, tol):
     """Dispatches to appropriate function if bose_operator is a BoseWord or BoseSentence."""
-    raise ValueError(f"bose_operator must be a BoseWord or BoseSentence, got: {bose_operator}")
+    raise TypeError(f"bose_operator must be a BoseWord or BoseSentence, got: {bose_operator}")
 
 
 @_binary_mapping_dispatch.register
@@ -220,7 +220,7 @@ def unary_mapping(
 @singledispatch
 def _unary_mapping_dispatch(bose_operator, n_states, ps=False, wires_map=None, tol=None):
     """Dispatches to appropriate function if bose_operator is a BoseWord or BoseSentence."""
-    raise ValueError(f"bose_operator must be a BoseWord or BoseSentence, got: {bose_operator}")
+    raise TypeError(f"bose_operator must be a BoseWord or BoseSentence, got: {bose_operator}")
 
 
 @_unary_mapping_dispatch.register
@@ -352,7 +352,7 @@ def christiansen_mapping(
 @singledispatch
 def _christiansen_mapping_dispatch(bose_operator, tol):
     """Dispatches to appropriate function if bose_operator is a BoseWord or BoseSentence."""
-    raise ValueError(f"bose_operator must be a BoseWord or BoseSentence, got: {bose_operator}")
+    raise TypeError(f"bose_operator must be a BoseWord or BoseSentence, got: {bose_operator}")
 
 
 @_christiansen_mapping_dispatch.register

--- a/pennylane/fermi/fermionic.py
+++ b/pennylane/fermi/fermionic.py
@@ -348,7 +348,7 @@ class FermiWord(dict):
 
         **Example**
 
-        >>> w = qml.fermi.FermiWord({(0, 0): '+', (1, 1): '-'})
+        >>> w = qml.FermiWord({(0, 0): '+', (1, 1): '-'})
         >>> w.shift_operator(0, 1)
         -1 * a(1) a⁺(0)
         """

--- a/pennylane/qchem/convert_openfermion.py
+++ b/pennylane/qchem/convert_openfermion.py
@@ -126,9 +126,9 @@ def to_openfermion(
     **Example**
 
     >>> import pennylane as qml
-    >>> w1 = qml.fermi.FermiWord({(0, 0) : '+', (1, 1) : '-'})
-    >>> w2 = qml.fermi.FermiWord({(0, 1) : '+', (1, 2) : '-'})
-    >>> fermi_s = qml.fermi.FermiSentence({w1 : 1.2, w2: 3.1})
+    >>> w1 = qml.FermiWord({(0, 0) : '+', (1, 1) : '-'})
+    >>> w2 = qml.FermiWord({(0, 1) : '+', (1, 2) : '-'})
+    >>> fermi_s = qml.FermiSentence({w1 : 1.2, w2: 3.1})
     >>> of_fermi_op = qml.to_openfermion(fermi_s)
     >>> of_fermi_op
     1.2 [0^ 1] +

--- a/pennylane/qchem/observable_hf.py
+++ b/pennylane/qchem/observable_hf.py
@@ -107,9 +107,9 @@ def qubit_observable(o_ferm, cutoff=1.0e-12, mapping="jordan_wigner"):
 
     **Example**
 
-    >>> w1 = qml.fermi.FermiWord({(0, 0) : '+', (1, 1) : '-'})
-    >>> w2 = qml.fermi.FermiWord({(0, 0) : '+', (1, 1) : '-'})
-    >>> s = qml.fermi.FermiSentence({w1 : 1.2, w2: 3.1})
+    >>> w1 = qml.FermiWord({(0, 0) : '+', (1, 1) : '-'})
+    >>> w2 = qml.FermiWord({(0, 0) : '+', (1, 1) : '-'})
+    >>> s = qml.FermiSentence({w1 : 1.2, w2: 3.1})
     >>> print(qubit_observable(s))
     -0.775j * (Y(0) @ X(1)) + 0.775 * (Y(0) @ Y(1)) + 0.775 * (X(0) @ X(1)) + 0.775j * (X(0) @ Y(1))
     """

--- a/pennylane/qchem/structure.py
+++ b/pennylane/qchem/structure.py
@@ -292,9 +292,9 @@ def excitations(electrons, orbitals, delta_sz=0, fermionic=False):
     if not fermionic:
         return singles, doubles
 
-    fermionic_singles = [qml.fermi.FermiWord({(0, x[0]): "+", (1, x[1]): "-"}) for x in singles]
+    fermionic_singles = [qml.FermiWord({(0, x[0]): "+", (1, x[1]): "-"}) for x in singles]
     fermionic_doubles = [
-        qml.fermi.FermiWord({(0, x[0]): "+", (1, x[1]): "+", (2, x[2]): "-", (3, x[3]): "-"})
+        qml.FermiWord({(0, x[0]): "+", (1, x[1]): "+", (2, x[2]): "-", (3, x[3]): "-"})
         for x in doubles
     ]
 

--- a/tests/bose/test_binary_mapping.py
+++ b/tests/bose/test_binary_mapping.py
@@ -548,7 +548,7 @@ def test_binary_mapping_wiremap(bose_op, wire_map, result):
 def test_error_is_raised_for_incompatible_type():
     """Test that an error is raised if the input is not a BoseWord or BoseSentence"""
 
-    with pytest.raises(ValueError, match="bose_operator must be a BoseWord or BoseSentence"):
+    with pytest.raises(TypeError, match="bose_operator must be a BoseWord or BoseSentence"):
         binary_mapping(X(0))
 
 

--- a/tests/bose/test_christiansen_mapping.py
+++ b/tests/bose/test_christiansen_mapping.py
@@ -388,5 +388,5 @@ def test_christiansen_mapping_tolerance(bose_op, qubit_op_data, tol):
 def test_error_is_raised_for_incompatible_type():
     """Test that an error is raised if the input is not a BoseWord or BoseSentence"""
 
-    with pytest.raises(ValueError, match="bose_operator must be a BoseWord or BoseSentence"):
+    with pytest.raises(TypeError, match="bose_operator must be a BoseWord or BoseSentence"):
         christiansen_mapping(X(0))

--- a/tests/bose/test_unary_mapping.py
+++ b/tests/bose/test_unary_mapping.py
@@ -517,7 +517,7 @@ def test_n_states_error_unary():
 def test_error_is_raised_for_incompatible_type():
     """Test that an error is raised if the input is not a BoseWord or BoseSentence"""
 
-    with pytest.raises(ValueError, match="bose_operator must be a BoseWord or BoseSentence"):
+    with pytest.raises(TypeError, match="bose_operator must be a BoseWord or BoseSentence"):
         unary_mapping(X(0))
 
 

--- a/tests/qchem/openfermion_pyscf_tests/test_convert_openfermion.py
+++ b/tests/qchem/openfermion_pyscf_tests/test_convert_openfermion.py
@@ -183,7 +183,7 @@ class TestFromOpenFermion:
         of_op = openfermion.FermionOperator("2^ 3")
         converted_op = qml.qchem.from_openfermion(of_op)
 
-        assert isinstance(converted_op, qml.fermi.FermiWord)
+        assert isinstance(converted_op, qml.FermiWord)
 
     def test_convert_fermionic_type_fs(self):
         r"""Test that FermiSentence object is returned when there are multiple
@@ -192,7 +192,7 @@ class TestFromOpenFermion:
         of_op = openfermion.FermionOperator("2^ 3") + openfermion.FermionOperator("1^ 2")
         converted_op = qml.qchem.from_openfermion(of_op)
 
-        assert isinstance(converted_op, qml.fermi.FermiSentence)
+        assert isinstance(converted_op, qml.FermiSentence)
 
     def test_tol_fermionic(self):
         r"""Test that terms with coefficients larger than tolerance are discarded"""
@@ -226,19 +226,17 @@ class TestFromOpenFermion:
 class TestToOpenFermion:
 
     FERMI_AND_OF_OPS = (
-        ((qml.fermi.FermiWord({(0, 0): "+", (1, 1): "-"})), (openfermion.FermionOperator("0^ 1"))),
+        ((qml.FermiWord({(0, 0): "+", (1, 1): "-"})), (openfermion.FermionOperator("0^ 1"))),
         (
-            (qml.fermi.FermiWord({(1, 0): "+", (0, 1): "-", (2, 3): "+", (3, 2): "-"})),
+            (qml.FermiWord({(1, 0): "+", (0, 1): "-", (2, 3): "+", (3, 2): "-"})),
             (openfermion.FermionOperator("1 0^ 3^ 2")),
         ),
         (
             (
-                qml.fermi.FermiSentence(
+                qml.FermiSentence(
                     {
-                        qml.fermi.FermiWord(
-                            {(1, 0): "+", (0, 1): "-", (2, 3): "+", (3, 2): "-"}
-                        ): 0.5,
-                        qml.fermi.FermiWord({(0, 0): "+", (1, 1): "-"}): 0.3,
+                        qml.FermiWord({(1, 0): "+", (0, 1): "-", (2, 3): "+", (3, 2): "-"}): 0.5,
+                        qml.FermiWord({(0, 0): "+", (1, 1): "-"}): 0.3,
                     }
                 )
             ),
@@ -272,12 +270,10 @@ class TestToOpenFermion:
 
     COMPLEX_OPS = (
         (
-            qml.fermi.FermiSentence(
+            qml.FermiSentence(
                 {
-                    qml.fermi.FermiWord(
-                        {(1, 0): "+", (0, 1): "-", (2, 3): "+", (3, 2): "-"}
-                    ): 1e-08j,
-                    qml.fermi.FermiWord({(0, 0): "+", (1, 1): "-"}): 0.3,
+                    qml.FermiWord({(1, 0): "+", (0, 1): "-", (2, 3): "+", (3, 2): "-"}): 1e-08j,
+                    qml.FermiWord({(0, 0): "+", (1, 1): "-"}): 0.3,
                 }
             )
         ),
@@ -339,9 +335,9 @@ class TestToOpenFermion:
             )
 
     OPS_FERMI_WIRE = (
-        ((qml.fermi.FermiWord({(0, 0): "+", (1, 1): "-"})), ({0: "a", 1: 2})),
+        ((qml.FermiWord({(0, 0): "+", (1, 1): "-"})), ({0: "a", 1: 2})),
         (
-            (qml.fermi.FermiSentence({qml.fermi.FermiWord({(0, 0): "+", (1, 1): "-"}): 1.2})),
+            (qml.FermiSentence({qml.FermiWord({(0, 0): "+", (1, 1): "-"}): 1.2})),
             ({0: "a", 1: 2}),
         ),
     )


### PR DESCRIPTION
**Context:**

Sources of error found during the v0.40 quality assurance process.

**Description of the Change:**

A few things were adjusted in this PR,

**Bosonic Operators**

- `BoseX` was top-level but `FermiX` was not (adjusted in this PR).
- `BoseX` raised a `ValueError` rather than a `TypeError` for an inappropriate input (was suggested in the original PR but was never implemented). 

