### PR TITLE
Mudit's QA fixes for v0.40.0

### DIFF
--- a/pennylane/devices/_legacy_device.py
+++ b/pennylane/devices/_legacy_device.py
@@ -813,7 +813,10 @@ class Device(abc.ABC, metaclass=_LegacyMeta):
                 # Some measurements are not observable based.
                 continue
 
-            if mp.obs.name == "LinearCombination" and not self.supports_observable("Hamiltonian"):
+            if mp.obs.name == "LinearCombination" and not (
+                self.supports_observable("Hamiltonian")
+                or self.supports_observable("LinearCombination")
+            ):
                 return False
 
             if mp.obs.name in (

--- a/tests/devices/test_legacy_device.py
+++ b/tests/devices/test_legacy_device.py
@@ -278,6 +278,20 @@ class TestDeviceSupportedLogic:
         ):
             dev.supports_observable(operation)
 
+    @pytest.mark.parametrize("supported_multi_term_obs", ["Hamiltonian", "LinearCombination"])
+    @pytest.mark.parametrize("obs_type", [qml.ops.LinearCombination, qml.Hamiltonian])
+    def test_all_multi_term_obs_supported_linear_combination(
+        self, mock_device, supported_multi_term_obs, obs_type
+    ):
+        """Test that LinearCombination is supported when the device supports either
+        LinearCombination or Hamiltonian."""
+        dev = mock_device()
+        dev.observables = dev.observables + [supported_multi_term_obs]
+
+        obs = obs_type([1.0, 2.0], [qml.Z(0), qml.Z(0)])
+        circuit = qml.tape.QuantumScript([], [qml.expval(obs)])
+        assert dev._all_multi_term_obs_supported(circuit)  # pylint: disable=protected-access
+
 
 class TestInternalFunctions:  # pylint:disable=too-many-public-methods
     """Test the internal functions of the abstract Device class"""


### PR DESCRIPTION
Update logic in `LegacyDevice` to check for whether the device supports `LinearCombination` or not.