### PR TITLE
remove subprocess and popen

### DIFF
--- a/doc/releases/changelog-0.40.0.md
+++ b/doc/releases/changelog-0.40.0.md
@@ -111,10 +111,6 @@
 * Added support to build a vibrational Hamiltonian in Taylor form.
   [(#6523)](https://github.com/PennyLaneAI/pennylane/pull/6523)
 
-* Added support to build a vibrational Hamiltonian in the Christiansen form.
-  [(#6560)](https://github.com/PennyLaneAI/pennylane/pull/6560)
-  [(#6792)](https://github.com/PennyLaneAI/pennylane/pull/6792)
-
 <h3>Improvements 🛠</h3>
 
 <h4>QChem improvements</h4>
@@ -494,6 +490,12 @@ such as `shots`, `rng` and `prng_key`.
 * Improved documentation by fixing broken links and latex issues. Also consistently use `$\mathfrak{a}$`
   for the horizontal Cartan subalgebra instead of `$\mathfrak{h}$`.
   [(#6747)](https://github.com/PennyLaneAI/pennylane/pull/6747)
+
+<h4>Construct vibrational Hamiltonians 🫨</h4>
+
+* Added support to build a vibrational Hamiltonian in the Christiansen form.
+  [(#6560)](https://github.com/PennyLaneAI/pennylane/pull/6560)
+  [(#6792)](https://github.com/PennyLaneAI/pennylane/pull/6792)
 
 <h3>Breaking changes 💔</h3>
 

--- a/doc/releases/changelog-0.40.0.md
+++ b/doc/releases/changelog-0.40.0.md
@@ -113,6 +113,7 @@
 
 * Added support to build a vibrational Hamiltonian in the Christiansen form.
   [(#6560)](https://github.com/PennyLaneAI/pennylane/pull/6560)
+  [(#6792)](https://github.com/PennyLaneAI/pennylane/pull/6792)
 
 <h3>Improvements 🛠</h3>
 


### PR DESCRIPTION
Remake of #6791
Context:
Had subprocess.Popen in the original code and should be removed for security purposes

Description of the Change:
Changed to use Python standard lib

Benefits:
Security