### PR TITLE
Update GQSP docs

### DIFF
--- a/pennylane/templates/subroutines/gqsp.py
+++ b/pennylane/templates/subroutines/gqsp.py
@@ -39,7 +39,7 @@ class GQSP(Operation):
          * & * \\
          \end{pmatrix}
 
-    The implementation requires one auxiliary qubit.
+    The implementation requires one control qubit.
 
     Args:
 


### PR DESCRIPTION
Minor tweak to the docstring wording to unify terminology used to describe the control wire