### PR TITLE
Clean up redundancy on `qutrit_mixed` tests

### DIFF
--- a/tests/devices/qutrit_mixed/test_qutrit_mixed_simulate.py
+++ b/tests/devices/qutrit_mixed/test_qutrit_mixed_simulate.py
@@ -249,7 +249,7 @@ class TestBroadcasting:
 
     @staticmethod
     def get_expected_state(x, subspace):
-        """Gets the expected final state of the circuit described in `get_ops_and_measurements`."""
+        """Gets the expected final state of the circuit."""
         state = []
         for x_val in x:
             vec = np.zeros(9, dtype=complex)
@@ -260,7 +260,7 @@ class TestBroadcasting:
 
     @staticmethod
     def get_expectation_values(x, subspace):
-        """Gets the expected final expvals of the circuit described in `get_ops_and_measurements`."""
+        """Gets the expected final expvals of the circuit."""
         if subspace == (0, 1):
             return [np.cos(x), -np.cos(x / 2) ** 2]
         if subspace == (0, 2):
@@ -345,7 +345,7 @@ class TestStatePadding:
 
     @staticmethod
     def get_expected_dm(x, extra_wires):
-        """Gets the final density matrix of the circuit described in `get_ops_and_measurements`."""
+        """Gets the final density matrix of the circuit."""
         vec = np.zeros(9, dtype=complex)
         vec[1] = -1j * np.cos(x / 2)
         vec[6] = -1j * np.sin(x / 2)

--- a/tests/devices/qutrit_mixed/test_qutrit_mixed_simulate.py
+++ b/tests/devices/qutrit_mixed/test_qutrit_mixed_simulate.py
@@ -108,7 +108,7 @@ def test_result_has_correct_interface(op, interface):
 
 # pylint: disable=too-few-public-methods
 class TestStatePrepBase:
-    """Tests integration with various state prep methods."""
+    """Tests with state prep methods."""
 
     def test_basis_state(self):
         """Test that the BasisState operator prepares the desired state."""

--- a/tests/test_debugging.py
+++ b/tests/test_debugging.py
@@ -656,7 +656,7 @@ class TestSnapshotUnsupportedQNode:
         assert qml.math.allclose(out[0], out["execution_results"])
 
     # pylint: disable=protected-access
-    @pytest.mark.flaky(reruns=2, reruns_delay=1)
+    @pytest.mark.flaky(max_runs=3)
     @pytest.mark.parametrize("method", [None, "parameter-shift"])
     def test_default_qutrit(self, method):
         """Test that multiple snapshots are returned correctly on the pure qutrit simulator."""

--- a/tests/test_debugging.py
+++ b/tests/test_debugging.py
@@ -656,6 +656,7 @@ class TestSnapshotUnsupportedQNode:
         assert qml.math.allclose(out[0], out["execution_results"])
 
     # pylint: disable=protected-access
+    @pytest.mark.flaky(reruns=2, reruns_delay=1)
     @pytest.mark.parametrize("method", [None, "parameter-shift"])
     def test_default_qutrit(self, method):
         """Test that multiple snapshots are returned correctly on the pure qutrit simulator."""


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      test directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `doc/releases/changelog-dev.md` file, summarizing the
      change, and including a link back to the PR.

- [x] The PennyLane source code conforms to
      [PEP8 standards](https://www.python.org/dev/peps/pep-0008/).
      We check all of our code against [Pylint](https://www.pylint.org/).
      To lint modified files, simply `pip install pylint`, and then
      run `pylint pennylane/path/to/file.py`.

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
Clean up the chaos inside test suites of `qutrit_mixed`

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-79348]