### PR TITLE
Bugfix for wire_options

### DIFF
--- a/doc/releases/changelog-0.40.0.md
+++ b/doc/releases/changelog-0.40.0.md
@@ -575,6 +575,12 @@ following 4 sets of functions have been either moved or removed[(#6588)](https:/
   [(#6530)](https://github.com/PennyLaneAI/pennylane/pull/6530)
   [(#6561)](https://github.com/PennyLaneAI/pennylane/pull/6561)
 
+* The developer-facing ``qml.drawer.MPLDrawer`` argument `n_wires` has been replaced with `wires`. 
+  It can now accept a list of all wire labels. Providing an integer number of wires continues to 
+  work as before, but is not compatible with the new functionality to specify `wire_options` for 
+  specific wires.
+  [(#6805)](https://github.com/PennyLaneAI/pennylane/pull/6805)
+
 <h3>Deprecations 👋</h3>
 
 * The `tape` and `qtape` properties of `QNode` have been deprecated.

--- a/doc/releases/changelog-0.40.0.md
+++ b/doc/releases/changelog-0.40.0.md
@@ -575,10 +575,9 @@ following 4 sets of functions have been either moved or removed[(#6588)](https:/
   [(#6530)](https://github.com/PennyLaneAI/pennylane/pull/6530)
   [(#6561)](https://github.com/PennyLaneAI/pennylane/pull/6561)
 
-* The developer-facing ``qml.drawer.MPLDrawer`` argument `n_wires` has been replaced with `wires`. 
-  It can now accept a list of all wire labels. Providing an integer number of wires continues to 
-  work as before, but is not compatible with the new functionality to specify `wire_options` for 
-  specific wires.
+* The developer-facing ``qml.drawer.MPLDrawer`` argument `n_wires` has been replaced with `wire_map`,
+  which contains more complete information about wire labels and order. This allows the new functionality 
+  to specify `wire_options` for specific wires when using string wire labels or non-sequential wire ordering.
   [(#6805)](https://github.com/PennyLaneAI/pennylane/pull/6805)
 
 <h3>Deprecations 👋</h3>

--- a/pennylane/drawer/mpldrawer.py
+++ b/pennylane/drawer/mpldrawer.py
@@ -25,6 +25,8 @@ try:
 except (ModuleNotFoundError, ImportError) as e:  # pragma: no cover
     has_mpl = False
 
+# pylint: disable=too-many-positional-arguments
+
 
 def _to_tuple(a):
     """Converts int or iterable to tuple"""
@@ -255,7 +257,7 @@ class MPLDrawer:
     _cwire_scaling = 0.25
     """The distance between successive control wires."""
 
-    def __init__(self, n_layers, n_wires, c_wires=0, wire_options=None, figsize=None, fig=None):
+    def __init__(self, n_layers, wires, c_wires=0, wire_options=None, figsize=None, fig=None):
         if not has_mpl:  # pragma: no cover
             raise ImportError(
                 "Module matplotlib is required for ``MPLDrawer`` class. "
@@ -263,7 +265,7 @@ class MPLDrawer:
             )
 
         self.n_layers = n_layers
-        self.n_wires = n_wires
+        self.n_wires = wires if isinstance(wires, int) else len(wires)
 
         ## Creating figure and ax
 
@@ -297,17 +299,18 @@ class MPLDrawer:
         # Separate global options from per wire options
         global_options = {k: v for k, v in wire_options.items() if not isinstance(v, dict)}
         wire_specific_options = {k: v for k, v in wire_options.items() if isinstance(v, dict)}
+        wire_order = wires if isinstance(wires, Iterable) else range(wires)
 
         # Adding wire lines with individual styles based on wire_options
         self._wire_lines = []
-        for wire in range(self.n_wires):
+        for i, wire in enumerate(wire_order):
             specific_options = wire_specific_options.get(wire, {})
             line_options = {**global_options, **specific_options}
 
             # Create Line2D with the combined options
             line = plt.Line2D(
                 (-1, self.n_layers),
-                (wire, wire),
+                (i, i),
                 zorder=1,
                 **line_options,
             )

--- a/pennylane/drawer/mpldrawer.py
+++ b/pennylane/drawer/mpldrawer.py
@@ -257,7 +257,7 @@ class MPLDrawer:
     _cwire_scaling = 0.25
     """The distance between successive control wires."""
 
-    def __init__(self, n_layers, wires, c_wires=0, wire_options=None, figsize=None, fig=None):
+    def __init__(self, n_layers, wire_map, c_wires=0, wire_options=None, figsize=None, fig=None):
         if not has_mpl:  # pragma: no cover
             raise ImportError(
                 "Module matplotlib is required for ``MPLDrawer`` class. "
@@ -265,7 +265,7 @@ class MPLDrawer:
             )
 
         self.n_layers = n_layers
-        self.n_wires = wires if isinstance(wires, int) else len(wires)
+        self.n_wires = len(wire_map)
 
         ## Creating figure and ax
 
@@ -299,18 +299,17 @@ class MPLDrawer:
         # Separate global options from per wire options
         global_options = {k: v for k, v in wire_options.items() if not isinstance(v, dict)}
         wire_specific_options = {k: v for k, v in wire_options.items() if isinstance(v, dict)}
-        wire_order = wires if isinstance(wires, Iterable) else range(wires)
 
         # Adding wire lines with individual styles based on wire_options
         self._wire_lines = []
-        for i, wire in enumerate(wire_order):
-            specific_options = wire_specific_options.get(wire, {})
+        for wire_label, idx in wire_map.items():
+            specific_options = wire_specific_options.get(wire_label, {})
             line_options = {**global_options, **specific_options}
 
             # Create Line2D with the combined options
             line = plt.Line2D(
                 (-1, self.n_layers),
-                (i, i),
+                (idx, idx),
                 zorder=1,
                 **line_options,
             )

--- a/pennylane/drawer/mpldrawer.py
+++ b/pennylane/drawer/mpldrawer.py
@@ -78,7 +78,7 @@ class MPLDrawer:
 
     .. code-block:: python
 
-        drawer = qml.drawer.MPLDrawer(n_wires=5, n_layers=6)
+        drawer = qml.drawer.MPLDrawer(wire_map={i: i for i in range(5)}, n_layers=6)
 
         drawer.label(["0", "a", r"$|\Psi\rangle$", r"$|\theta\rangle$", "aux"])
 
@@ -167,7 +167,7 @@ class MPLDrawer:
     .. code-block:: python
 
         wire_options = {"color": "indigo", "linewidth": 4}
-        drawer = MPLDrawer(n_wires=2, n_layers=4, wire_options=wire_options)
+        drawer = MPLDrawer(wire_map={0: 0, 1: 1}, n_layers=4, wire_options=wire_options)
 
         label_options = {"fontsize": "x-large", 'color': 'indigo'}
         drawer.label(["0", "a"], text_options=label_options)
@@ -205,7 +205,7 @@ class MPLDrawer:
 
     .. code-block:: python
 
-        drawer = MPLDrawer(2, 2)
+        drawer = MPLDrawer(2, {0:0, 1:1})
         drawer.box_gate(layer=0, wires=1, text="X")
         drawer.box_gate(layer=1, wires=1, text="Y")
 
@@ -351,7 +351,7 @@ class MPLDrawer:
 
         .. code-block:: python
 
-            drawer = MPLDrawer(n_wires=2, n_layers=1)
+            drawer = MPLDrawer(wire_map={0:0, 1:1}, n_layers=1)
             drawer.label(["a", "b"])
 
         .. figure:: ../../_static/drawer/labels.png
@@ -365,7 +365,7 @@ class MPLDrawer:
 
         .. code-block:: python
 
-            drawer = MPLDrawer(n_wires=2, n_layers=1)
+            drawer = MPLDrawer(wire_map={0:0, 1:1}, n_layers=1)
             drawer.label(["a", "b"], text_options={"color": "indigo", "fontsize": "xx-large"})
 
         .. figure:: ../../_static/drawer/labels_formatted.png
@@ -421,7 +421,7 @@ class MPLDrawer:
 
         .. code-block:: python
 
-            drawer = MPLDrawer(n_wires=2, n_layers=1)
+            drawer = MPLDrawer(wire_map={0:0, 1:1}, n_layers=1)
 
             drawer.box_gate(layer=0, wires=(0, 1), text="CY")
 
@@ -443,7 +443,7 @@ class MPLDrawer:
             box_options = {'facecolor': 'lightcoral', 'edgecolor': 'maroon', 'linewidth': 5}
             text_options = {'fontsize': 'xx-large', 'color': 'maroon'}
 
-            drawer = MPLDrawer(n_wires=2, n_layers=1)
+            drawer = MPLDrawer(wire_map={0:0, 1:1}, n_layers=1)
 
             drawer.box_gate(layer=0, wires=(0, 1), text="CY",
                 box_options=box_options, text_options=text_options)
@@ -458,7 +458,7 @@ class MPLDrawer:
 
         .. code-block:: python
 
-            drawer = MPLDrawer(n_layers=4, n_wires=2)
+            drawer = MPLDrawer(n_layers=4, wire_map={0:0, 1:1})
 
             drawer.box_gate(layer=0, wires=0, text="A longer label")
             drawer.box_gate(layer=0, wires=1, text="Label")
@@ -617,7 +617,7 @@ class MPLDrawer:
 
         .. code-block:: python
 
-            drawer = MPLDrawer(n_wires=2, n_layers=3)
+            drawer = MPLDrawer(wire_map={0:0, 1:1}, n_layers=3)
 
             drawer.ctrl(layer=0, wires=0, wires_target=1)
             drawer.ctrl(layer=1, wires=(0, 1), control_values=[0, 1])
@@ -716,7 +716,7 @@ class MPLDrawer:
 
         .. code-block:: python
 
-            drawer = MPLDrawer(n_wires=2, n_layers=2)
+            drawer = MPLDrawer(wire_map={0:0, 1:1}, n_layers=2)
 
             drawer.CNOT(0, (0, 1))
 
@@ -780,7 +780,7 @@ class MPLDrawer:
 
         .. code-block:: python
 
-            drawer = MPLDrawer(n_wires=2, n_layers=2)
+            drawer = MPLDrawer(wire_map={0:0, 1:1}, n_layers=2)
 
             drawer.SWAP(0, (0, 1))
 
@@ -850,7 +850,7 @@ class MPLDrawer:
 
         .. code-block:: python
 
-            drawer = MPLDrawer(n_wires=2, n_layers=1)
+            drawer = MPLDrawer(wire_map={0:0, 1:1}, n_layers=1)
             drawer.measure(layer=0, wires=0)
 
             measure_box = {'facecolor': 'white', 'edgecolor': 'indigo'}
@@ -998,7 +998,7 @@ class MPLDrawer:
 
         .. code-block:: python
 
-            drawer = MPLDrawer(n_wires=3, n_layers=4)
+            drawer = MPLDrawer(wire_map={0:0, 1:1, 2:2}, n_layers=4)
 
             drawer.cond(layer=1, measured_layer=0, wires=[0], wires_target=[1])
 

--- a/pennylane/drawer/tape_mpl.py
+++ b/pennylane/drawer/tape_mpl.py
@@ -241,7 +241,7 @@ def _tape_mpl(tape, wire_order=None, show_all_wires=False, decimals=None, *, fig
 
     drawer = MPLDrawer(
         n_layers=n_layers,
-        wires=wire_order,
+        wire_map=wire_map,
         c_wires=len(bit_map),
         wire_options=wire_options,
         fig=fig,

--- a/pennylane/drawer/tape_mpl.py
+++ b/pennylane/drawer/tape_mpl.py
@@ -241,7 +241,7 @@ def _tape_mpl(tape, wire_order=None, show_all_wires=False, decimals=None, *, fig
 
     drawer = MPLDrawer(
         n_layers=n_layers,
-        n_wires=n_wires,
+        wires=wire_order,
         c_wires=len(bit_map),
         wire_options=wire_options,
         fig=fig,

--- a/tests/drawer/test_draw_mpl.py
+++ b/tests/drawer/test_draw_mpl.py
@@ -319,7 +319,7 @@ class TestWireBehaviour:
         assert ax.texts[2].get_text() == "0"
         plt.close()
 
-    def test_wire_options(self):
+    def test_uniform_wire_options(self):
         """Test wire options modifies wire styling"""
 
         _, ax = qml.draw_mpl(circuit1, wire_options={"color": "black", "linewidth": 4})(1.23, 2.34)
@@ -327,6 +327,11 @@ class TestWireBehaviour:
         for w in ax.lines[:3]:  # three wires
             assert w.get_color() == "black"
             assert w.get_linewidth() == 4
+
+        plt.close()
+
+    def test_individual_wire_options(self):
+        """Test wire option styling when individual wires have their own options specified"""
 
         @qml.qnode(dev)
         def f_circ(x):
@@ -398,6 +403,14 @@ class TestWireBehaviour:
                 assert w.get_linewidth() == 5
 
         plt.close()
+
+    def individual_wire_options_with_string_labels(self):
+        """Test that individual wire options work with string wire labels"""
+        raise RuntimeError
+
+    def wire_options_and_wire_order(self):
+        """Test that individual wire options work with specifying a wire_order"""
+        raise RuntimeError
 
 
 class TestMPLIntegration:

--- a/tests/drawer/test_draw_mpl.py
+++ b/tests/drawer/test_draw_mpl.py
@@ -404,13 +404,57 @@ class TestWireBehaviour:
 
         plt.close()
 
-    def individual_wire_options_with_string_labels(self):
+    def test_individual_wire_options_with_string_labels(self):
         """Test that individual wire options work with string wire labels"""
-        raise RuntimeError
 
-    def wire_options_and_wire_order(self):
+        @qml.qnode(qml.device("default.qubit"))
+        def circuit():
+            qml.X("a")
+            qml.Y("b")
+            return qml.expval(qml.Z("a"))
+
+        wire_options = {
+            "color": "teal",
+            "linewidth": 5,
+            "b": {"color": "orange", "linestyle": "--"},
+        }
+        _, ax = qml.draw_mpl(circuit, wire_options=wire_options)()
+
+        for i, w in enumerate(ax.lines):
+            assert w.get_linewidth() == 5
+            if i == 0:
+                assert w.get_color() == "teal"
+                assert w.get_linestyle() == "-"
+            if i == 1:
+                assert w.get_color() == "orange"
+                assert w.get_linestyle() == "--"
+
+    def test_wire_options_and_wire_order(self):
         """Test that individual wire options work with specifying a wire_order"""
-        raise RuntimeError
+
+        device = qml.device("default.qubit", wires=4)
+
+        @qml.qnode(device)
+        def circuit():
+            for w in device.wires:
+                qml.X(w)
+            return qml.expval(qml.Z(0))
+
+        wire_options = {
+            "color": "teal",
+            "linewidth": 5,
+            3: {"color": "orange", "linestyle": "--"},  # wire 3 should be orange and dashed
+        }
+        _, ax = qml.draw_mpl(circuit, wire_order=[1, 3, 0, 2], wire_options=wire_options)()
+
+        for i, w in enumerate(ax.lines):
+            assert w.get_linewidth() == 5
+            if i == 1:
+                assert w.get_color() == "orange"
+                assert w.get_linestyle() == "--"
+            else:
+                assert w.get_color() == "teal"
+                assert w.get_linestyle() == "-"
 
 
 class TestMPLIntegration:


### PR DESCRIPTION
**Context:**
When using wire labels that aren't integers ordered from largest to smallest (like strings, or a wire_order that isn't "in order"), the custom wire options are applied to the incorrect wire.

```
dev = qml.device('default.qubit', wires=4)

@qml.qnode(dev)
def circuit():
    for w in dev.wires:
        qml.X(w)
    return qml.expval(qml.Z(0))

wire_options = {'color': 'teal',
                'linewidth': 5,
                3: {'color': 'orange', 'linestyle': '--'}, # wire 3 should be orange and dashed
}
fig, ax = qml.draw_mpl(circuit, wire_order=[1, 3, 0, 2], wire_options=wire_options)()
```

This should make wire 3 orange, but instead makes the wire at _index_ 3 orange:
![image](https://github.com/user-attachments/assets/193925cb-ee97-43e7-9d3a-22b0da700589)

**Description of the Change:**
We update it to fix the bug. This involves modifying the signature of `MPLDrawer`.

**Benefits:**
It works as expected now.

**Possible Drawbacks:**
While MPLDrawer is internal, and even other PL libraries should be using `draw_mpl` (whose signature is unchanged), this is technically a small breaking change. However, a search in Catalyst, Lightning and QML confirms that none of our other packages are calling this, and the only tests that needed modification were the ones directly testing the class, so it seems safe to say we've kept it very isolated and this shouldn't cause any problems.