### PR TITLE
Natively sampling in torch in with default.qubit

### DIFF
--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -591,7 +591,11 @@ class DefaultQubit(Device):
         """
         updated_values = {}
 
-        jax_interfaces = {qml.math.Interface.JAX, qml.math.Interface.JAX_JIT}
+        jax_interfaces = {
+            qml.math.Interface.JAX,
+            qml.math.Interface.JAX_JIT,
+            qml.math.Interface.TORCH,
+        }
         updated_values["convert_to_numpy"] = (
             execution_config.interface not in jax_interfaces
             or execution_config.gradient_method == "adjoint"

--- a/pennylane/devices/qubit/sampling.py
+++ b/pennylane/devices/qubit/sampling.py
@@ -505,18 +505,18 @@ def sample_probs(probs, shots, num_wires, is_state_batched, rng, prng_key=None):
         return _sample_probs_jax(probs, shots, num_wires, is_state_batched, prng_key, seed=rng)
 
     if qml.math.get_interface(probs) == "torch":
-        return _sample_probs_torch(probs, shots, num_wires, is_state_batched, rng)
+        return _sample_probs_torch(probs, shots, num_wires, rng)
 
     return _sample_probs_numpy(probs, shots, num_wires, is_state_batched, rng)
 
 
-def _sample_probs_torch(probs, shots, num_wires, is_state_batched, rng):
+def _sample_probs_torch(probs, shots, num_wires, rng):
+    """Sample from the give probabilities using torch."""
     import torch
 
     rng = np.random.default_rng(rng)
     seed = int(rng.integers(1, high=1000000))
     g = torch.Generator(probs.device).manual_seed(seed)
-    # ? probs natively supports broadcasting?
     samples = torch.multinomial(probs, shots, replacement=True, generator=g)
     powers_of_two = 1 << np.arange(num_wires)[::-1]
     states_sampled_base_ten = qml.math.expand_dims(samples, axis=-1) & powers_of_two

--- a/pennylane/devices/qubit/sampling.py
+++ b/pennylane/devices/qubit/sampling.py
@@ -504,7 +504,21 @@ def sample_probs(probs, shots, num_wires, is_state_batched, rng, prng_key=None):
     if qml.math.get_interface(probs) == "jax" or prng_key is not None:
         return _sample_probs_jax(probs, shots, num_wires, is_state_batched, prng_key, seed=rng)
 
+    if qml.math.get_interface(probs) == "torch":
+        return _sample_probs_torch(probs, shots, num_wires, is_state_batched)
+
     return _sample_probs_numpy(probs, shots, num_wires, is_state_batched, rng)
+
+
+def _sample_probs_torch(probs, shots, num_wires, is_state_batched):
+    import torch
+
+    g = torch.Generator(probs.device)
+    # ? probs natively supports broadcasting?
+    samples = torch.multinomial(probs, shots, replacement=True, generator=g)
+    powers_of_two = 1 << np.arange(num_wires)[::-1]
+    states_sampled_base_ten = qml.math.expand_dims(samples, axis=-1) & powers_of_two
+    return (states_sampled_base_ten > 0).to(int)
 
 
 def _sample_probs_numpy(probs, shots, num_wires, is_state_batched, rng):

--- a/pennylane/devices/qubit/sampling.py
+++ b/pennylane/devices/qubit/sampling.py
@@ -505,15 +505,17 @@ def sample_probs(probs, shots, num_wires, is_state_batched, rng, prng_key=None):
         return _sample_probs_jax(probs, shots, num_wires, is_state_batched, prng_key, seed=rng)
 
     if qml.math.get_interface(probs) == "torch":
-        return _sample_probs_torch(probs, shots, num_wires, is_state_batched)
+        return _sample_probs_torch(probs, shots, num_wires, is_state_batched, rng)
 
     return _sample_probs_numpy(probs, shots, num_wires, is_state_batched, rng)
 
 
-def _sample_probs_torch(probs, shots, num_wires, is_state_batched):
+def _sample_probs_torch(probs, shots, num_wires, is_state_batched, rng):
     import torch
 
-    g = torch.Generator(probs.device)
+    rng = np.random.default_rng(rng)
+    seed = int(rng.integers(1, high=1000000))
+    g = torch.Generator(probs.device).manual_seed(seed)
     # ? probs natively supports broadcasting?
     samples = torch.multinomial(probs, shots, replacement=True, generator=g)
     powers_of_two = 1 << np.arange(num_wires)[::-1]

--- a/pennylane/gradients/finite_difference.py
+++ b/pennylane/gradients/finite_difference.py
@@ -496,7 +496,7 @@ def finite_diff(
 
             if len(tape.measurements) > 1:
                 pre_grads = tuple(
-                    qml.math.convert_like(i * coeff_div, coeff_div) for i in pre_grads
+                    qml.math.convert_like(i, coeff_div) * coeff_div for i in pre_grads
                 )
             else:
                 pre_grads = qml.math.convert_like(pre_grads[0] * coeff_div, coeff_div)

--- a/pennylane/measurements/counts.py
+++ b/pennylane/measurements/counts.py
@@ -304,7 +304,7 @@ class CountsMP(SampleMeasurement):
                     return qml.counts(all_outcomes=True)
 
         """
-
+        samples = qml.math.unwrap(samples)
         outcomes = []
 
         # if an observable was provided, batched samples will have shape (batch_size, shots)

--- a/tests/devices/default_qubit/test_default_qubit_preprocessing.py
+++ b/tests/devices/default_qubit/test_default_qubit_preprocessing.py
@@ -141,8 +141,8 @@ class TestConfigSetup:
 
         assert dev.tracker.totals["execute_and_derivative_batches"] == 1
 
-    @pytest.mark.parametrize("interface", ("jax", "jax-jit"))
-    def test_not_convert_to_numpy_with_jax(self, interface):
+    @pytest.mark.parametrize("interface", ("jax", "jax-jit", "torch"))
+    def test_not_convert_to_numpy(self, interface):
         """Test that we will not convert to numpy when working with jax."""
 
         dev = qml.device("default.qubit")
@@ -159,7 +159,7 @@ class TestConfigSetup:
         processed = dev.setup_execution_config(config)
         assert processed.convert_to_numpy
 
-    @pytest.mark.parametrize("interface", ("autograd", "torch", "tf"))
+    @pytest.mark.parametrize("interface", ("autograd", "tf"))
     def test_convert_to_numpy_non_jax(self, interface):
         """Test that other interfaces are still converted to numpy."""
         config = qml.devices.ExecutionConfig(gradient_method="adjoint", interface=interface)


### PR DESCRIPTION
**Context:**

In #6788  we are starting to natively sample with jax on default qubit. We were not doing so with any of the other interfaces because we didn't have logic for sampling using the other interfaces.

**Description of the Change:**

Adds sampling logic for torch, allowing us to have full default qubit simulations end to end with torch. 

**Benefits:**

Performance improvements:

```
n_wires = 20
n_layers = 2

shape = qml.StronglyEntanglingLayers.shape(n_wires=n_wires, n_layers=n_layers)

rng = np.random.default_rng()
params = torch.tensor(rng.random(shape))

@qml.qnode(qml.device('default.qubit', shots=1000, seed=12345))
def circuit(params):
    qml.StronglyEntanglingLayers(params, wires=range(n_wires))
    return qml.expval(qml.Z(0))

circuit(params)
```

![Screenshot 2025-01-13 at 1 43 26 PM](https://github.com/user-attachments/assets/ed985550-ebf1-447e-9e56-19b2d51d861e)

This also opens us up to having end-to-end gpu simulations with torch.  We should investigate whether or not we can have end-to-end sampling simulations with default qubit on a GPU.

**Possible Drawbacks:**

**Related GitHub Issues:**
