### PR TITLE
sc-81896-disable-search-page-redirect-on-all-docs-projects-except-pennylane-oss

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -260,7 +260,7 @@ html_theme_options = {
         "TensorFlow, the TensorFlow logo, and any related marks are trademarks " "of Google Inc."
     ],
     "google_analytics_tracking_id": "G-C480Z9JL0D",
-    "search_on_pennylane_ai": True
+    "search_on_pennylane_ai": False
 }
 
 edit_on_github_project = "PennyLaneAI/pennylane"

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -260,6 +260,7 @@ html_theme_options = {
         "TensorFlow, the TensorFlow logo, and any related marks are trademarks " "of Google Inc."
     ],
     "google_analytics_tracking_id": "G-C480Z9JL0D",
+    "search_on_pennylane_ai": True
 }
 
 edit_on_github_project = "PennyLaneAI/pennylane"

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -260,7 +260,7 @@ html_theme_options = {
         "TensorFlow, the TensorFlow logo, and any related marks are trademarks " "of Google Inc."
     ],
     "google_analytics_tracking_id": "G-C480Z9JL0D",
-    "search_on_pennylane_ai": False
+    "search_on_pennylane_ai": True
 }
 
 edit_on_github_project = "PennyLaneAI/pennylane"

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -32,7 +32,7 @@ networkx==2.6
 requests~=2.28.1
 # we do not pin the sphinx theme, to allow the
 # navbar and header data to be updated at the source
-pennylane-sphinx-theme
+pennylane-sphinx-theme @ git+https://github.com/PennyLaneAI/pennylane-sphinx-theme@sc-81896-disable-search-page-redirect-on-all-docs
 tomli~=2.0.0 # Drop once minimum Python version is 3.11
 sphinxext-opengraph==0.6.3 # Note: latest version 0.9.0 requires Sphinx >=4.0
 matplotlib==3.8.0

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -32,7 +32,7 @@ networkx==2.6
 requests~=2.28.1
 # we do not pin the sphinx theme, to allow the
 # navbar and header data to be updated at the source
-pennylane-sphinx-theme @ git+https://github.com/PennyLaneAI/pennylane-sphinx-theme@sc-81896-disable-search-page-redirect-on-all-docs
+pennylane-sphinx-theme
 tomli~=2.0.0 # Drop once minimum Python version is 3.11
 sphinxext-opengraph==0.6.3 # Note: latest version 0.9.0 requires Sphinx >=4.0
 matplotlib==3.8.0


### PR DESCRIPTION
## Changes
- Explicitly enable `search_on_pennylane_ai` feature from PennyLane Docs

## Related PR
- https://github.com/PennyLaneAI/pennylane-sphinx-theme/pull/85
- This related PR can be released separately