### PR TITLE
sc-81896-disable-search-page-redirect-on-all-docs-projects-except-pennylane-oss

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -260,6 +260,7 @@ html_theme_options = {
         "TensorFlow, the TensorFlow logo, and any related marks are trademarks " "of Google Inc."
     ],
     "google_analytics_tracking_id": "G-C480Z9JL0D",
+    "search_on_pennylane_ai": True,
 }
 
 edit_on_github_project = "PennyLaneAI/pennylane"


### PR DESCRIPTION
## Changes
- Explicitly enable `search_on_pennylane_ai` feature from PennyLane Docs

## Related PR
- https://github.com/PennyLaneAI/pennylane-sphinx-theme/pull/85
- This related PR can be released separately