### PR TITLE
Put truth values on the right side of `allclose`

### DIFF
--- a/pennylane/devices/tests/test_measurements.py
+++ b/pennylane/devices/tests/test_measurements.py
@@ -1475,7 +1475,7 @@ class TestTensorVar:
             sub_routine(label_map=range(3))
             return qml.var(ob)
 
-        assert np.allclose(circ(base_obs), circ(permuted_obs), atol=tol(dev.shots), rtol=0)
+        assert np.allclose(circ(permuted_obs), circ(base_obs), atol=tol(dev.shots), rtol=0)
 
     @pytest.mark.parametrize("label_map", label_maps)
     def test_wire_label_in_tensor_prod_observables(self, device, label_map, tol, skip_if):
@@ -1505,8 +1505,8 @@ class TestTensorVar:
         circ_custom_label = qml.QNode(circ, device=dev_custom_labels)
 
         assert np.allclose(
-            circ_base_label(wire_labels=range(3)),
             circ_custom_label(wire_labels=label_map),
+            circ_base_label(wire_labels=range(3)),
             atol=tol(dev.shots),
             rtol=0,
         )

--- a/pennylane/devices/tests/test_measurements.py
+++ b/pennylane/devices/tests/test_measurements.py
@@ -524,7 +524,7 @@ class TestTensorExpval:
             sub_routine(label_map=range(3))
             return qml.expval(ob)
 
-        assert np.allclose(circ(base_obs), circ(permuted_obs), atol=tol(dev.shots), rtol=0)
+        assert np.allclose(circ(permuted_obs), circ(base_obs), atol=tol(dev.shots), rtol=0)
 
     @pytest.mark.parametrize("label_map", label_maps)
     def test_wire_label_in_tensor_prod_observables(self, device, label_map, tol, skip_if):

--- a/pennylane/devices/tests/test_measurements.py
+++ b/pennylane/devices/tests/test_measurements.py
@@ -555,8 +555,8 @@ class TestTensorExpval:
         circ_custom_label = qml.QNode(circ, device=dev_custom_labels)
 
         assert np.allclose(
-            circ_base_label(wire_labels=range(3)),
             circ_custom_label(wire_labels=label_map),
+            circ_base_label(wire_labels=range(3)),
             atol=tol(dev.shots),
             rtol=0,
         )

--- a/pennylane/devices/tests/test_templates.py
+++ b/pennylane/devices/tests/test_templates.py
@@ -575,7 +575,7 @@ class TestTemplates:  # pylint:disable=too-many-public-methods
         # GlobalPhase not supported
         global_phase = qml.math.sum(-1 * qml.math.angle(expected) / len(expected))
         global_phase = np.exp(-1j * global_phase)
-        assert np.allclose(expected / res, global_phase)
+        assert np.allclose(global_phase, expected / res)
 
     def test_Permute(self, device, tol):
         """Test the Permute template."""

--- a/pennylane/gradients/general_shift_rules.py
+++ b/pennylane/gradients/general_shift_rules.py
@@ -164,7 +164,8 @@ def _get_shift_rule(frequencies, shifts=None):
         if len(set(shifts)) != n_freqs:
             raise ValueError(f"Shift values must be unique, instead got {shifts}")
 
-        equ_shifts = np.allclose(shifts, (2 * mu - 1) * np.pi / (2 * n_freqs * freq_min))
+        expected = (2 * mu - 1) * np.pi / (2 * n_freqs * freq_min)
+        equ_shifts = np.allclose(shifts, expected)
 
     if len(set(np.round(np.diff(frequencies), 10))) <= 1 and equ_shifts:  # equidistant case
         coeffs = (

--- a/pennylane/ops/functions/assert_valid.py
+++ b/pennylane/ops/functions/assert_valid.py
@@ -195,7 +195,7 @@ def _check_generator(op):
         assert isinstance(gen, qml.operation.Operator)
         new_op = qml.exp(gen, 1j * op.data[0])
         assert qml.math.allclose(
-            qml.matrix(op, wire_order=op.wires), qml.matrix(new_op, wire_order=op.wires)
+            qml.matrix(new_op, wire_order=op.wires), qml.matrix(op, wire_order=op.wires)
         )
     else:
         failure_comment = (

--- a/pennylane/ops/op_math/controlled_decompositions.py
+++ b/pennylane/ops/op_math/controlled_decompositions.py
@@ -145,7 +145,7 @@ def _multi_controlled_zyz(
     # The decomposition of zyz for special unitaries with multiple control wires
     # defined in Lemma 7.9 of https://arxiv.org/pdf/quant-ph/9503016
 
-    if not qml.math.allclose(0.0, global_phase, atol=1e-6, rtol=0):
+    if not qml.math.allclose(global_phase, 0.0, atol=1e-6, rtol=0):
         raise ValueError(f"The global_phase should be zero, instead got: {global_phase}.")
 
     # Unpack the rotation angles
@@ -157,23 +157,23 @@ def _multi_controlled_zyz(
     cop_wires = (control_wires[-1], target_wire[0])
 
     # Add operator A
-    if not qml.math.allclose(0.0, phi, atol=1e-8, rtol=0):
+    if not qml.math.allclose(phi, 0.0, atol=1e-8, rtol=0):
         decomp.append(qml.CRZ(phi, wires=cop_wires))
-    if not qml.math.allclose(0.0, theta / 2, atol=1e-8, rtol=0):
+    if not qml.math.allclose(theta / 2, 0.0, atol=1e-8, rtol=0):
         decomp.append(qml.CRY(theta / 2, wires=cop_wires))
 
     decomp.append(qml.ctrl(qml.X(target_wire), control=control_wires[:-1], work_wires=work_wires))
 
     # Add operator B
-    if not qml.math.allclose(0.0, theta / 2, atol=1e-8, rtol=0):
+    if not qml.math.allclose(theta / 2, 0.0, atol=1e-8, rtol=0):
         decomp.append(qml.CRY(-theta / 2, wires=cop_wires))
-    if not qml.math.allclose(0.0, -(phi + omega) / 2, atol=1e-6, rtol=0):
+    if not qml.math.allclose(-(phi + omega) / 2, 0.0, atol=1e-6, rtol=0):
         decomp.append(qml.CRZ(-(phi + omega) / 2, wires=cop_wires))
 
     decomp.append(qml.ctrl(qml.X(target_wire), control=control_wires[:-1], work_wires=work_wires))
 
     # Add operator C
-    if not qml.math.allclose(0.0, (omega - phi) / 2, atol=1e-8, rtol=0):
+    if not qml.math.allclose((omega - phi) / 2, 0.0, atol=1e-8, rtol=0):
         decomp.append(qml.CRZ((omega - phi) / 2, wires=cop_wires))
 
     return decomp
@@ -188,28 +188,28 @@ def _single_control_zyz(rot_angles, global_phase, target_wire, control_wires: Wi
     # We use the conditional statements to account when decomposition is ran within a queue
     decomp = []
     # Add negative of global phase. Compare definition of qml.GlobalPhase and Ph(delta) from section 4.1 of Barenco et al.
-    if not qml.math.allclose(0.0, global_phase, atol=1e-8, rtol=0):
+    if not qml.math.allclose(global_phase, 0.0, atol=1e-8, rtol=0):
         decomp.append(
             qml.ctrl(qml.GlobalPhase(phi=-global_phase, wires=target_wire), control=control_wires)
         )
     # Add operator A
-    if not qml.math.allclose(0.0, phi, atol=1e-8, rtol=0):
+    if not qml.math.allclose(phi, 0.0, atol=1e-8, rtol=0):
         decomp.append(qml.RZ(phi, wires=target_wire))
-    if not qml.math.allclose(0.0, theta / 2, atol=1e-8, rtol=0):
+    if not qml.math.allclose(theta / 2, 0.0, atol=1e-8, rtol=0):
         decomp.append(qml.RY(theta / 2, wires=target_wire))
 
     decomp.append(qml.ctrl(qml.X(target_wire), control=control_wires))
 
     # Add operator B
-    if not qml.math.allclose(0.0, theta / 2, atol=1e-8, rtol=0):
+    if not qml.math.allclose(theta / 2, 0.0, atol=1e-8, rtol=0):
         decomp.append(qml.RY(-theta / 2, wires=target_wire))
-    if not qml.math.allclose(0.0, -(phi + omega) / 2, atol=1e-6, rtol=0):
+    if not qml.math.allclose(-(phi + omega) / 2, 0.0, atol=1e-6, rtol=0):
         decomp.append(qml.RZ(-(phi + omega) / 2, wires=target_wire))
 
     decomp.append(qml.ctrl(qml.X(target_wire), control=control_wires))
 
     # Add operator C
-    if not qml.math.allclose(0.0, (omega - phi) / 2, atol=1e-8, rtol=0):
+    if not qml.math.allclose((omega - phi) / 2, 0.0, atol=1e-8, rtol=0):
         decomp.append(qml.RZ((omega - phi) / 2, wires=target_wire))
 
     return decomp

--- a/tests/devices/default_qubit/test_default_qubit_preprocessing.py
+++ b/tests/devices/default_qubit/test_default_qubit_preprocessing.py
@@ -735,7 +735,7 @@ class TestPreprocessingIntegration:
         assert qml.math.allclose(processed_results[0][1], expected_entropy)
 
         expected_expval = np.cos(y)
-        assert qml.math.allclose(expected_expval, processed_results[1])
+        assert qml.math.allclose(processed_results[1], expected_expval)
 
 
 class TestAdjointDiffTapeValidation:

--- a/tests/devices/qubit/test_adjoint_jacobian.py
+++ b/tests/devices/qubit/test_adjoint_jacobian.py
@@ -326,7 +326,7 @@ class TestAdjointJacobianState:
         dy = np.array([0.5, 2.0], dtype=np.complex128)
         vjp = adjoint_vjp(tape, dy)
         expected_vjp = dy[0] * expected[0] + dy[1] * expected[1]
-        assert qml.math.allclose(expected_vjp, vjp)
+        assert qml.math.allclose(vjp, expected_vjp)
 
     def test_two_wires_two_parameters(self):
         """Test a more complicated circuit with two parameters and two wires."""

--- a/tests/devices/qubit/test_apply_operation.py
+++ b/tests/devices/qubit/test_apply_operation.py
@@ -916,7 +916,7 @@ class TestLargerOperations:
         for _op in op.decomposition():
             expected_state = method(_op, expected_state)
 
-        assert qml.math.allclose(expected_state, new_state)
+        assert qml.math.allclose(new_state, expected_state)
 
 
 class TestApplyGroverOperator:

--- a/tests/devices/qubit/test_simulate.py
+++ b/tests/devices/qubit/test_simulate.py
@@ -1065,7 +1065,7 @@ class TestQInfoMeasurements:
 
         for i in (0, 1, 3, 4, 5):  # skip density matrix on both wires
             g = qml.jacobian(f)(phi, i, real=True)
-            assert qml.math.allclose(expected_grads[i], g)
+            assert qml.math.allclose(g, expected_grads[i])
 
         # density matrix on both wires case
         g_real = qml.jacobian(f)(phi, 2, True)

--- a/tests/devices/qubit_mixed/test_qubit_mixed_measure.py
+++ b/tests/devices/qubit_mixed/test_qubit_mixed_measure.py
@@ -486,7 +486,7 @@ class TestSumOfTermsDifferentiability:
 
         gradient = qml.grad(self.f)(x, coeffs)
         expected_gradient = qml.grad(self.expected)(x, coeffs)
-        assert qml.math.allclose(expected_gradient, gradient)
+        assert qml.math.allclose(gradient, expected_gradient)
 
     @pytest.mark.autograd
     def test_autograd_backprop_coeffs(self):
@@ -498,7 +498,7 @@ class TestSumOfTermsDifferentiability:
         expected_gradient = qml.grad(self.expected)(self.x, coeffs)
 
         assert len(gradient) == 2
-        assert qml.math.allclose(expected_gradient, gradient)
+        assert qml.math.allclose(gradient, expected_gradient)
 
     @pytest.mark.jax
     @pytest.mark.parametrize("use_jit", (True, False))
@@ -519,7 +519,7 @@ class TestSumOfTermsDifferentiability:
 
         gradient = jax.grad(f)(x, coeffs)
         expected_gradient = jax.grad(self.expected)(x, coeffs)
-        assert qml.math.allclose(expected_gradient, gradient)
+        assert qml.math.allclose(gradient, expected_gradient)
 
     @pytest.mark.jax
     def test_jax_backprop_coeffs(self):
@@ -533,7 +533,7 @@ class TestSumOfTermsDifferentiability:
         gradient = jax.grad(self.f, argnums=1)(self.x, coeffs)
         expected_gradient = jax.grad(self.expected, argnums=1)(self.x, coeffs)
         assert len(gradient) == 2
-        assert qml.math.allclose(expected_gradient, gradient)
+        assert qml.math.allclose(gradient, expected_gradient)
 
     @pytest.mark.torch
     def test_torch_backprop(self):
@@ -593,7 +593,7 @@ class TestSumOfTermsDifferentiability:
         assert qml.math.allclose(out, expected_out)
         gradient = tape1.gradient(out, x)
         expected_gradient = tape2.gradient(expected_out, x)
-        assert qml.math.allclose(expected_gradient, gradient)
+        assert qml.math.allclose(gradient, expected_gradient)
 
     @pytest.mark.tf
     def test_tf_backprop_coeffs(self):
@@ -612,7 +612,7 @@ class TestSumOfTermsDifferentiability:
         gradient = tape1.gradient(out, coeffs)
         expected_gradient = tape2.gradient(expected_out, coeffs)
         assert len(gradient) == 2
-        assert qml.math.allclose(expected_gradient, gradient)
+        assert qml.math.allclose(gradient, expected_gradient)
 
 
 # pylint: disable=too-few-public-methods

--- a/tests/devices/qutrit_mixed/test_qutrit_mixed_measure.py
+++ b/tests/devices/qutrit_mixed/test_qutrit_mixed_measure.py
@@ -473,7 +473,7 @@ class TestSumOfTermsDifferentiability:
 
         gradient = qml.grad(self.f)(x, coeffs)
         expected_gradient = qml.grad(self.expected)(x, coeffs)
-        assert qml.math.allclose(expected_gradient, gradient)
+        assert qml.math.allclose(gradient, expected_gradient)
 
     @pytest.mark.autograd
     def test_autograd_backprop_coeffs(self):
@@ -485,7 +485,7 @@ class TestSumOfTermsDifferentiability:
         expected_gradient = qml.grad(self.expected)(self.x, coeffs)
 
         assert len(gradient) == 2
-        assert qml.math.allclose(expected_gradient, gradient)
+        assert qml.math.allclose(gradient, expected_gradient)
 
     @pytest.mark.jax
     @pytest.mark.parametrize("use_jit", (True, False))
@@ -506,7 +506,7 @@ class TestSumOfTermsDifferentiability:
 
         gradient = jax.grad(f)(x, coeffs)
         expected_gradient = jax.grad(self.expected)(x, coeffs)
-        assert qml.math.allclose(expected_gradient, gradient)
+        assert qml.math.allclose(gradient, expected_gradient)
 
     @pytest.mark.jax
     def test_jax_backprop_coeffs(self):
@@ -520,7 +520,7 @@ class TestSumOfTermsDifferentiability:
         gradient = jax.grad(self.f, argnums=1)(self.x, coeffs)
         expected_gradient = jax.grad(self.expected, argnums=1)(self.x, coeffs)
         assert len(gradient) == 2
-        assert qml.math.allclose(expected_gradient, gradient)
+        assert qml.math.allclose(gradient, expected_gradient)
 
     @pytest.mark.torch
     def test_torch_backprop(self):
@@ -580,7 +580,7 @@ class TestSumOfTermsDifferentiability:
         assert qml.math.allclose(out, expected_out)
         gradient = tape1.gradient(out, x)
         expected_gradient = tape2.gradient(expected_out, x)
-        assert qml.math.allclose(expected_gradient, gradient)
+        assert qml.math.allclose(gradient, expected_gradient)
 
     @pytest.mark.tf
     def test_tf_backprop_coeffs(self):
@@ -599,4 +599,4 @@ class TestSumOfTermsDifferentiability:
         gradient = tape1.gradient(out, coeffs)
         expected_gradient = tape2.gradient(expected_out, coeffs)
         assert len(gradient) == 2
-        assert qml.math.allclose(expected_gradient, gradient)
+        assert qml.math.allclose(gradient, expected_gradient)

--- a/tests/devices/test_default_mixed_jax.py
+++ b/tests/devices/test_default_mixed_jax.py
@@ -847,7 +847,7 @@ class TestHighLevelIntegration:
         for x_indiv in x:
             expected.append(circuit(x_indiv))
 
-        assert np.allclose(expected, res)
+        assert np.allclose(res, expected)
 
     @pytest.mark.parametrize("gradient_func", [qml.gradients.param_shift, "device", None])
     def test_tapes(self, gradient_func):

--- a/tests/devices/test_default_mixed_torch.py
+++ b/tests/devices/test_default_mixed_torch.py
@@ -663,8 +663,8 @@ class TestPassthruIntegration:
             [0, -torch.cos(x) * torch.sin(y) / 2, torch.cos(x) * torch.sin(y) / 2]
         )
 
-        assert torch.allclose(expected_x, qml.math.hstack([res_x[0], res_y[0]]), atol=tol, rtol=0)
-        assert torch.allclose(expected_y, qml.math.hstack([res_x[1], res_y[1]]), atol=tol, rtol=0)
+        assert torch.allclose(qml.math.hstack([res_x[0], res_y[0]]), expected_x, atol=tol, rtol=0)
+        assert torch.allclose(qml.math.hstack([res_x[1], res_y[1]]), expected_y, atol=tol, rtol=0)
 
     def test_batching(self, tol):
         """Tests that the gradient of the qnode is correct with batching parameters"""

--- a/tests/devices/test_default_qutrit_mixed.py
+++ b/tests/devices/test_default_qutrit_mixed.py
@@ -797,7 +797,7 @@ class TestSumOfTermsDifferentiability:
 
         gradient = qml.grad(self.f)(x, coeffs)
         expected_gradient = qml.grad(self.expected)(x, coeffs)
-        assert qml.math.allclose(expected_gradient, gradient)
+        assert qml.math.allclose(gradient, expected_gradient)
 
     @pytest.mark.autograd
     def test_autograd_backprop_coeffs(self):
@@ -809,7 +809,7 @@ class TestSumOfTermsDifferentiability:
         expected_gradient = qml.grad(self.expected)(self.x, coeffs)
 
         assert len(gradient) == 2
-        assert qml.math.allclose(expected_gradient, gradient)
+        assert qml.math.allclose(gradient, expected_gradient)
 
     @pytest.mark.jax
     @pytest.mark.parametrize("use_jit", (True, False))
@@ -830,7 +830,7 @@ class TestSumOfTermsDifferentiability:
 
         gradient = jax.grad(f)(x, coeffs)
         expected_gradient = jax.grad(self.expected)(x, coeffs)
-        assert qml.math.allclose(expected_gradient, gradient)
+        assert qml.math.allclose(gradient, expected_gradient)
 
     @pytest.mark.jax
     def test_jax_backprop_coeffs(self):
@@ -844,7 +844,7 @@ class TestSumOfTermsDifferentiability:
         gradient = jax.grad(self.f, argnums=1)(self.x, coeffs)
         expected_gradient = jax.grad(self.expected, argnums=1)(self.x, coeffs)
         assert len(gradient) == 2
-        assert qml.math.allclose(expected_gradient, gradient)
+        assert qml.math.allclose(gradient, expected_gradient)
 
     @pytest.mark.torch
     def test_torch_backprop(self):
@@ -904,7 +904,7 @@ class TestSumOfTermsDifferentiability:
         assert qml.math.allclose(out, expected_out)
         gradient = tape1.gradient(out, x)
         expected_gradient = tape2.gradient(expected_out, x)
-        assert qml.math.allclose(expected_gradient, gradient)
+        assert qml.math.allclose(gradient, expected_gradient)
 
     @pytest.mark.tf
     def test_tf_backprop_coeffs(self):
@@ -923,7 +923,7 @@ class TestSumOfTermsDifferentiability:
         gradient = tape1.gradient(out, coeffs)
         expected_gradient = tape2.gradient(expected_out, coeffs)
         assert len(gradient) == 2
-        assert qml.math.allclose(expected_gradient, gradient)
+        assert qml.math.allclose(gradient, expected_gradient)
 
 
 class TestRandomSeed:

--- a/tests/gradients/core/test_metric_tensor.py
+++ b/tests/gradients/core/test_metric_tensor.py
@@ -1344,7 +1344,7 @@ class TestDifferentiability:
         for argnum in range(len(weights)):
             expected_full = qml.jacobian(_cost_full, argnum=argnum)(*weights)
             jac = qml.jacobian(cost_full, argnum=argnum)(*weights)
-            assert qml.math.allclose(expected_full, jac, atol=tol, rtol=0)
+            assert qml.math.allclose(jac, expected_full, atol=tol, rtol=0)
 
     @pytest.mark.jax
     def test_jax(self, diff_method, tol, ansatz, weights):
@@ -1367,7 +1367,7 @@ class TestDifferentiability:
         assert qml.math.allclose(v1, v2, atol=tol, rtol=0)
         jac = jax.jacobian(cost_full)(*weights_jax)
         expected_full = qml.jacobian(_cost_full_autograd)(*weights)
-        assert qml.math.allclose(expected_full, jac, atol=tol, rtol=0)
+        assert qml.math.allclose(jac, expected_full, atol=tol, rtol=0)
 
     @pytest.mark.tf
     @pytest.mark.parametrize("interface", ["auto", "tf"])
@@ -1385,7 +1385,7 @@ class TestDifferentiability:
         _cost_full = autodiff_metric_tensor(ansatz, num_wires=3)
         assert qml.math.allclose(_cost_full(*weights), loss_full, atol=tol, rtol=0)
         expected_full = qml.jacobian(_cost_full)(*weights)
-        assert qml.math.allclose(expected_full, jac, atol=tol, rtol=0)
+        assert qml.math.allclose(jac, expected_full, atol=tol, rtol=0)
 
     @pytest.mark.torch
     @pytest.mark.parametrize("interface", ["auto", "torch"])

--- a/tests/gradients/parameter_shift/test_parameter_shift_hessian.py
+++ b/tests/gradients/parameter_shift/test_parameter_shift_hessian.py
@@ -267,7 +267,7 @@ class TestParameterShiftHessian:
 
         assert isinstance(hessian, np.ndarray)
         assert hessian.shape == ()
-        assert np.allclose(expected, hessian)
+        assert np.allclose(hessian, expected)
 
     def test_single_probs(self):
         """Test that the correct hessian is calculated for a tape with single RX operator
@@ -289,7 +289,7 @@ class TestParameterShiftHessian:
 
         assert isinstance(hessian, np.ndarray)
         assert hessian.shape == (4,)
-        assert np.allclose(expected, hessian)
+        assert np.allclose(hessian, expected)
 
     def test_multi_expval(self):
         """Test that the correct hessian is calculated for a tape with single RX operator
@@ -798,7 +798,7 @@ class TestParameterShiftHessianQNode:
         expected = qml.jacobian(qml.grad(circuit))(x)
         hessian = qml.gradients.param_shift_hessian(circuit)(x)
 
-        assert np.allclose(expected, hessian)
+        assert np.allclose(hessian, expected)
 
     def test_fixed_params(self):
         """Test that the correct hessian is calculated for a QNode with single RX operator
@@ -819,7 +819,7 @@ class TestParameterShiftHessianQNode:
         expected = qml.jacobian(qml.grad(circuit))(x)
         hessian = qml.gradients.param_shift_hessian(circuit)(x)
 
-        assert np.allclose(expected, hessian)
+        assert np.allclose(hessian, expected)
 
     def test_gate_without_impact(self):
         """Test that the correct hessian is calculated for a QNode with an operator
@@ -838,7 +838,7 @@ class TestParameterShiftHessianQNode:
         expected = qml.jacobian(qml.grad(circuit))(x)
         hessian = qml.gradients.param_shift_hessian(circuit)(x)
 
-        assert np.allclose(expected, hessian)
+        assert np.allclose(hessian, expected)
 
     @pytest.mark.filterwarnings("ignore:Output seems independent of input.")
     def test_no_gate_with_impact(self):
@@ -858,7 +858,7 @@ class TestParameterShiftHessianQNode:
         expected = qml.jacobian(qml.grad(circuit))(x)
         hessian = qml.gradients.param_shift_hessian(circuit)(x)
 
-        assert np.allclose(expected, hessian)
+        assert np.allclose(hessian, expected)
 
     def test_single_multi_term_gate(self):
         """Test that the correct hessian is calculated for a QNode with single operation
@@ -879,7 +879,7 @@ class TestParameterShiftHessianQNode:
         expected = qml.jacobian(qml.grad(circuit))(x)
         hessian = qml.gradients.param_shift_hessian(circuit)(x)
 
-        assert np.allclose(expected, hessian)
+        assert np.allclose(hessian, expected)
 
     def test_single_gate_custom_recipe(self):
         """Test that the correct hessian is calculated for a QNode with single operation
@@ -909,7 +909,7 @@ class TestParameterShiftHessianQNode:
         expected = qml.jacobian(qml.grad(circuit))(x)
         hessian = qml.gradients.param_shift_hessian(circuit)(x)
 
-        assert np.allclose(expected, hessian)
+        assert np.allclose(hessian, expected)
 
     def test_single_two_term_gate_vector_output(self):
         """Test that the correct hessian is calculated for a QNode with single RY operator
@@ -928,7 +928,7 @@ class TestParameterShiftHessianQNode:
         expected = qml.jacobian(qml.jacobian(circuit))(x)
         hessian = qml.gradients.param_shift_hessian(circuit)(x)
 
-        assert np.allclose(expected, hessian)
+        assert np.allclose(hessian, expected)
 
     def test_multiple_two_term_gates(self):
         """Test that the correct hessian is calculated for a QNode with two rotation operators
@@ -949,7 +949,7 @@ class TestParameterShiftHessianQNode:
         expected = qml.jacobian(qml.jacobian(circuit))(x)
         hessian = qml.gradients.param_shift_hessian(circuit)(x)
 
-        assert np.allclose(expected, hessian)
+        assert np.allclose(hessian, expected)
 
     def test_multiple_two_term_gates_vector_output(self):
         """Test that the correct hessian is calculated for a QNode with two rotation operators
@@ -1108,7 +1108,7 @@ class TestParameterShiftHessianQNode:
         circuit.interface = "autograd"
         hessian = qml.gradients.param_shift_hessian(circuit)(x, y, z)
 
-        assert np.allclose(expected, hessian)
+        assert np.allclose(hessian, expected)
 
     def test_multiple_qnode_arguments_vector(self):
         """Test that the correct Hessian is calculated with multiple QNode arguments (1D->1D)"""
@@ -1194,9 +1194,11 @@ class TestParameterShiftHessianQNode:
         )
         hessian = qml.gradients.param_shift_hessian(circuit)(x, y, z)
 
-        assert np.allclose(expected[0], hessian[0])
-        assert np.allclose(qml.math.transpose(expected[1], (0, 2, 3, 4, 5, 1)), hessian[1])
-        assert np.allclose(qml.math.transpose(expected[2], (0, 2, 3, 1)), hessian[2])
+        assert np.allclose(hessian[0], expected[0])
+        expected_1 = qml.math.transpose(expected[1], (0, 2, 3, 4, 5, 1))
+        assert np.allclose(hessian[1], expected_1)
+        expected_2 = qml.math.transpose(expected[2], (0, 2, 3, 1))
+        assert np.allclose(hessian[2], expected_2)
 
     def test_with_channel(self):
         """Test that the Hessian is correctly computed for circuits
@@ -1613,7 +1615,7 @@ class TestParamShiftHessianWithKwargs:
 
         hessian = fn(qml.execute(tapes, dev, diff_method=qml.gradients.param_shift))
 
-        assert np.allclose(expected, hessian)
+        assert np.allclose(hessian, expected)
 
     @pytest.mark.parametrize(
         "off_diagonal_shifts",
@@ -1664,7 +1666,7 @@ class TestParamShiftHessianWithKwargs:
             assert np.allclose(_tape.get_parameters(), x + np.array([0.0, np.pi * mult]))
 
         hessian = fn(qml.execute(tapes, dev, diff_method=qml.gradients.param_shift))
-        assert np.allclose(expected, hessian)
+        assert np.allclose(hessian, expected)
 
     @pytest.mark.parametrize("argnum", [(0,), (1,), (0, 1)])
     def test_with_1d_argnum(self, argnum):
@@ -1782,7 +1784,7 @@ class TestInterfaces:
         circuit.interface = "torch"
         hess = qml.gradients.param_shift_hessian(circuit)(x_torch)[0]
 
-        assert np.allclose(expected, hess.detach())
+        assert np.allclose(hess.detach(), expected)
 
     @pytest.mark.skip("Requires Torch integration for new return types")
     @pytest.mark.torch
@@ -1808,7 +1810,7 @@ class TestInterfaces:
         jacobian_fn = torch.autograd.functional.jacobian
         torch_deriv = jacobian_fn(qml.gradients.param_shift_hessian(circuit), x_torch)[0]
 
-        assert np.allclose(expected, torch_deriv)
+        assert np.allclose(torch_deriv, expected)
 
     @pytest.mark.jax
     @pytest.mark.slow

--- a/tests/math/test_expectation_value.py
+++ b/tests/math/test_expectation_value.py
@@ -65,7 +65,7 @@ class TestExpectationValueMath:
         ops = func(ops)
         state_vectors = func(state_vectors)
         overlap = qml.math.expectation_value(ops, state_vectors)
-        assert qml.math.allclose(expected, overlap)
+        assert qml.math.allclose(overlap, expected)
 
     state_wrong_amp = [
         ([[1, 0], [0, 1]], [0.5, 0]),

--- a/tests/math/test_functions.py
+++ b/tests/math/test_functions.py
@@ -2305,8 +2305,8 @@ class TestBlockDiagDiffability:
         x, y = 0.2, 1.5
         res = jax.jacobian(f, argnums=[0, 1])(x, y)
         exp = self.expected(x, y)
-        assert fn.allclose(exp[0], res[0])
-        assert fn.allclose(exp[1], res[1])
+        assert fn.allclose(res[0], exp[0])
+        assert fn.allclose(res[1], exp[1])
 
     def test_tf(self):
         """Tests for differentiating the block diagonal function with Tensorflow."""
@@ -2318,8 +2318,8 @@ class TestBlockDiagDiffability:
         exp_0[0, 0, 0, 0] = 1.0
         exp_1 = np.zeros((3, 3, 2, 2))
         exp_1[1, 1, 0, 0] = exp_1[1, 2, 0, 1] = exp_1[2, 1, 1, 0] = exp_1[2, 2, 1, 1] = 1.0
-        assert fn.allclose(exp_0, res[0])
-        assert fn.allclose(exp_1, res[1])
+        assert fn.allclose(res[0], exp_0)
+        assert fn.allclose(res[1], exp_1)
 
     def test_torch(self):
         """Tests for differentiating the block diagonal function with Torch."""
@@ -2333,8 +2333,8 @@ class TestBlockDiagDiffability:
         exp_0[0, 0, 0, 0] = 1.0
         exp_1 = np.zeros((3, 3, 2, 2))
         exp_1[1, 1, 0, 0] = exp_1[1, 2, 0, 1] = exp_1[2, 1, 1, 0] = exp_1[2, 2, 1, 1] = 1.0
-        assert fn.allclose(exp_0, res[0])
-        assert fn.allclose(exp_1, res[1])
+        assert fn.allclose(res[0], exp_0)
+        assert fn.allclose(res[1], exp_1)
 
 
 gather_data = [
@@ -2628,7 +2628,7 @@ class TestExpm:
         orig_mat = qml.RX.compute_matrix(phi)
         exp_mat = qml.math.expm(orig_mat)
 
-        assert qml.math.allclose(exp_mat, self.get_compare_mat(), atol=1e-4)
+        assert qml.math.allclose(self.get_compare_mat(), exp_mat, atol=1e-4)
 
 
 class TestSize:

--- a/tests/math/test_matrix_manipulation.py
+++ b/tests/math/test_matrix_manipulation.py
@@ -70,7 +70,7 @@ class TestExpandMatrix:
         res = qml.math.expand_matrix(self.base_matrix_2, wires=[0, 2], wire_order=[2, 0])
 
         expected = np.array([[1, 3, 2, 4], [9, 11, 10, 12], [5, 7, 6, 8], [13, 15, 14, 16]])
-        assert np.allclose(expected, res)
+        assert np.allclose(res, expected)
 
     def test_permutation_broadcasted(self):
         """Tests the case where the broadcasted original matrix is permuted"""
@@ -80,17 +80,17 @@ class TestExpandMatrix:
 
         perm = [0, 2, 1, 3]
         expected = self.base_matrix_2_broadcasted[:, perm][:, :, perm]
-        assert np.allclose(expected, res)
+        assert np.allclose(res, expected)
 
     def test_expansion(self):
         """Tests the case where the original matrix is expanded"""
         res = qml.math.expand_matrix(self.base_matrix_1, wires=[2], wire_order=[0, 2])
         expected = np.array([[1, 2, 0, 0], [3, 4, 0, 0], [0, 0, 1, 2], [0, 0, 3, 4]])
-        assert np.allclose(expected, res)
+        assert np.allclose(res, expected)
 
         res = qml.math.expand_matrix(self.base_matrix_1, wires=[2], wire_order=[2, 0])
         expected = np.array([[1, 0, 2, 0], [0, 1, 0, 2], [3, 0, 4, 0], [0, 3, 0, 4]])
-        assert np.allclose(expected, res)
+        assert np.allclose(res, expected)
 
     def test_expansion_broadcasted(self):
         """Tests the case where the broadcasted original matrix is expanded"""
@@ -117,7 +117,7 @@ class TestExpandMatrix:
                 ],
             ]
         )
-        assert np.allclose(expected, res)
+        assert np.allclose(res, expected)
 
         res = qml.math.expand_matrix(self.base_matrix_1_broadcasted, wires=[2], wire_order=[2, 0])
         expected = np.array(
@@ -142,7 +142,7 @@ class TestExpandMatrix:
                 ],
             ]
         )
-        assert np.allclose(expected, res)
+        assert np.allclose(res, expected)
 
     @staticmethod
     def func_for_autodiff(mat):
@@ -851,14 +851,14 @@ class TestExpandMatrixSparse:
                     expected_mat = qml.SWAP(wires=[i, j]).matrix()
                     expected_mat = qml.math.expand_matrix(expected_mat, [i, j], wire_order=range(n))
                     computed_mat = qml.math.matrix_manipulation._sparse_swap_mat(i, j, n).toarray()
-                    assert np.allclose(expected_mat, computed_mat)
+                    assert np.allclose(computed_mat, expected_mat)
 
     def test_sparse_swap_mat_same_index(self):
         """Test that if the indices are the same then the identity is returned."""
         # pylint: disable=protected-access
         computed_mat = qml.math.matrix_manipulation._sparse_swap_mat(2, 2, 3).toarray()
         expected_mat = np.eye(8)
-        assert np.allclose(expected_mat, computed_mat)
+        assert np.allclose(computed_mat, expected_mat)
 
 
 class TestReduceMatrices:

--- a/tests/measurements/test_state.py
+++ b/tests/measurements/test_state.py
@@ -134,7 +134,7 @@ class TestStateMP:
         expected = np.zeros((2, 2))
         expected[0, 1] = 1  # zero for wire order, 1 for wire 1
         expected = np.reshape(expected, (4,))
-        assert qml.math.allclose(expected, new_state)
+        assert qml.math.allclose(new_state, expected)
 
     @pytest.mark.parametrize(
         "dm",
@@ -589,7 +589,7 @@ class TestDensityMatrix:
 
         density_mat = func()
         expected = np.array([[0.5 + 0.0j, 0.5 + 0.0j], [0.5 + 0.0j, 0.5 + 0.0j]])
-        assert np.allclose(expected, density_mat)
+        assert np.allclose(density_mat, expected)
 
     @pytest.mark.jax
     @pytest.mark.parametrize("dev_name", ["default.qubit", "default.mixed"])
@@ -606,7 +606,7 @@ class TestDensityMatrix:
         density_mat = func()
         expected = np.array([[0.5 + 0.0j, 0.5 + 0.0j], [0.5 + 0.0j, 0.5 + 0.0j]])
 
-        assert np.allclose(expected, density_mat)
+        assert np.allclose(density_mat, expected)
 
     @pytest.mark.tf
     @pytest.mark.parametrize("diff_method", [None, "backprop"])
@@ -622,7 +622,7 @@ class TestDensityMatrix:
         density_mat = func()
         expected = np.array([[0.5 + 0.0j, 0.5 + 0.0j], [0.5 + 0.0j, 0.5 + 0.0j]])
 
-        assert np.allclose(expected, density_mat)
+        assert np.allclose(density_mat, expected)
 
     @pytest.mark.tf
     @pytest.mark.parametrize("diff_method", [None, "backprop"])
@@ -638,7 +638,7 @@ class TestDensityMatrix:
         density_mat, dev_state = func()
         expected = np.array([[0.5 + 0.0j, 0.5 + 0.0j], [0.5 + 0.0j, 0.5 + 0.0j]])
 
-        assert np.allclose(expected, density_mat)
+        assert np.allclose(density_mat, expected)
 
         assert np.allclose(
             expected,
@@ -660,7 +660,7 @@ class TestDensityMatrix:
         density_first = func()
         expected = np.array([[0.0 + 0.0j, 0.0 + 0.0j], [0.0 + 0.0j, 1.0 + 0.0j]])
 
-        assert np.allclose(expected, density_first)
+        assert np.allclose(density_first, expected)
 
     def test_correct_density_matrix_product_state_first_default_qubit(self):
         """Test that the correct density matrix is returned when
@@ -677,7 +677,7 @@ class TestDensityMatrix:
         density_first, dev_state = func()
         expected = np.array([[0.0 + 0.0j, 0.0 + 0.0j], [0.0 + 0.0j, 1.0 + 0.0j]])
 
-        assert np.allclose(expected, density_first)
+        assert np.allclose(density_first, expected)
         assert np.allclose(
             expected,
             qml.density_matrix(wires=0).process_state(state=dev_state, wire_order=dev.wires),
@@ -697,7 +697,7 @@ class TestDensityMatrix:
 
         density_second = func()
         expected = np.array([[0.5 + 0.0j, 0.5 + 0.0j], [0.5 + 0.0j, 0.5 + 0.0j]])
-        assert np.allclose(expected, density_second)
+        assert np.allclose(density_second, expected)
 
     def test_correct_density_matrix_product_state_second_default_qubit(self):
         """Test that the correct density matrix is returned when
@@ -713,7 +713,7 @@ class TestDensityMatrix:
 
         density_second, dev_state = func()
         expected = np.array([[0.5 + 0.0j, 0.5 + 0.0j], [0.5 + 0.0j, 0.5 + 0.0j]])
-        assert np.allclose(expected, density_second)
+        assert np.allclose(density_second, expected)
 
         assert np.allclose(
             expected,
@@ -738,7 +738,7 @@ class TestDensityMatrix:
         expected_statevector = np.kron(*[single_statevectors[w] for w in return_wire_order])
         expected = np.outer(expected_statevector.conj(), expected_statevector)
 
-        assert np.allclose(expected, density_both)
+        assert np.allclose(density_both, expected)
 
     @pytest.mark.parametrize("return_wire_order", ([0, 1], [1, 0]))
     def test_correct_density_matrix_product_state_both_default_qubit(self, return_wire_order):
@@ -758,7 +758,7 @@ class TestDensityMatrix:
         expected_statevector = np.kron(*[single_statevectors[w] for w in return_wire_order])
         expected = np.outer(expected_statevector.conj(), expected_statevector)
 
-        assert np.allclose(expected, density_both)
+        assert np.allclose(density_both, expected)
 
         assert np.allclose(
             expected,
@@ -788,7 +788,7 @@ class TestDensityMatrix:
                 [0.0 + 0.0j, 0.0 + 0.0j, 0.5 + 0.0j, 0.5 + 0.0j],
             ]
         )
-        assert np.allclose(expected, density_full)
+        assert np.allclose(density_full, expected)
 
     def test_correct_density_matrix_three_wires_first_two_default_qubit(self):
         """Test that the correct density matrix is returned for an example with three wires,
@@ -811,7 +811,7 @@ class TestDensityMatrix:
                 [0.0 + 0.0j, 0.0 + 0.0j, 0.5 + 0.0j, 0.5 + 0.0j],
             ]
         )
-        assert np.allclose(expected, density_full)
+        assert np.allclose(density_full, expected)
         assert np.allclose(
             expected,
             qml.density_matrix(wires=[0, 1]).process_state(state=dev_state, wire_order=dev.wires),
@@ -843,7 +843,7 @@ class TestDensityMatrix:
             ]
         )
 
-        assert np.allclose(expected, density)
+        assert np.allclose(density, expected)
 
     @pytest.mark.parametrize(
         "return_wire_order", ([0], [1], [2], [0, 1], [1, 0], [0, 2], [2, 0], [1, 2, 0], [2, 1, 0])
@@ -874,7 +874,7 @@ class TestDensityMatrix:
             exp_statevector = np.kron(np.kron(single_states[i], single_states[j]), single_states[k])
 
         expected = np.outer(exp_statevector.conj(), exp_statevector)
-        assert np.allclose(expected, density_full)
+        assert np.allclose(density_full, expected)
 
     @pytest.mark.parametrize(
         "return_wire_order", ([0], [1], [2], [0, 1], [1, 0], [0, 2], [2, 0], [1, 2, 0], [2, 1, 0])
@@ -905,7 +905,7 @@ class TestDensityMatrix:
             exp_statevector = np.kron(np.kron(single_states[i], single_states[j]), single_states[k])
 
         expected = np.outer(exp_statevector.conj(), exp_statevector)
-        assert np.allclose(expected, density_full)
+        assert np.allclose(density_full, expected)
 
         assert np.allclose(
             expected,
@@ -951,7 +951,7 @@ class TestDensityMatrix:
             ]
         )
 
-        assert np.allclose(expected, density)
+        assert np.allclose(density, expected)
 
     def test_correct_density_matrix_all_wires_default_qubit(self):
         """Test that the correct density matrix is returned when all wires are given"""
@@ -974,7 +974,7 @@ class TestDensityMatrix:
             ]
         )
 
-        assert np.allclose(expected, density)
+        assert np.allclose(density, expected)
         assert np.allclose(
             expected,
             qml.density_matrix(wires=[0, 1]).process_state(state=dev_state, wire_order=dev.wires),
@@ -1058,7 +1058,7 @@ class TestDensityMatrix:
         density = func()
         expected = np.array([[0.5 + 0.0j, 0.0 + 0.0j], [0.0 + 0.0j, 0.5 + 0.0j]])
 
-        assert np.allclose(expected, density)
+        assert np.allclose(density, expected)
 
     @pytest.mark.parametrize("wires", [[3, 1], ["b", 1000]])
     @pytest.mark.parametrize("dev_name", ["default.qubit", "default.mixed"])

--- a/tests/ops/op_math/test_adjoint.py
+++ b/tests/ops/op_math/test_adjoint.py
@@ -555,7 +555,7 @@ class TestMatrix:
 
         mat = Adjoint(base).matrix()
 
-        assert qml.math.allclose(expected, mat)
+        assert qml.math.allclose(mat, expected)
         assert qml.math.get_interface(mat) == interface
 
     @pytest.mark.autograd

--- a/tests/ops/op_math/test_controlled_decompositions.py
+++ b/tests/ops/op_math/test_controlled_decompositions.py
@@ -201,7 +201,7 @@ class TestControlledDecompositionZYZ:
         res = qml.matrix(ctrl_decomp_zyz, wire_order=control_wires + [0])(op, control_wires)
         expected = expected_op.matrix()
 
-        assert np.allclose(expected, res, atol=tol, rtol=0)
+        assert np.allclose(res, expected, atol=tol, rtol=0)
 
     def test_correct_decomp(self):
         """Test that the operations in the decomposition are correct."""

--- a/tests/ops/op_math/test_sprod.py
+++ b/tests/ops/op_math/test_sprod.py
@@ -452,7 +452,7 @@ class TestMatrix:
 
         expected_mat = sprod_op.matrix()
         true_mat = scalar * mat
-        assert np.allclose(expected_mat, true_mat)
+        assert np.allclose(true_mat, expected_mat)
 
     def test_sprod_qchem_ops(self):
         """Test that we can scale qchem operations and the generated matrix is correct."""

--- a/tests/ops/qubit/test_parametric_ops.py
+++ b/tests/ops/qubit/test_parametric_ops.py
@@ -653,7 +653,7 @@ class TestDecompositions:
 
         expected_mat = qml.matrix(op)
         decomp_mat = qml.matrix(decomp_op)
-        assert np.allclose(expected_mat, decomp_mat)
+        assert np.allclose(decomp_mat, expected_mat)
 
     def test_pc_phase_decomposition_broadcasted(self):
         """Test that the broadcasted PCPhase decomposition produces the same unitary"""
@@ -665,7 +665,7 @@ class TestDecompositions:
         decomp_mats = qml.matrix(decomp_op)
 
         for expected_mat, decomp_mat in zip(expected_mats, decomp_mats):
-            assert np.allclose(expected_mat, decomp_mat)
+            assert np.allclose(decomp_mat, expected_mat)
 
     @pytest.mark.parametrize("phi", [-0.1, 0.2, 0.5])
     @pytest.mark.parametrize(

--- a/tests/shadow/test_shadow_class.py
+++ b/tests/shadow/test_shadow_class.py
@@ -247,7 +247,7 @@ class TestStateReconstruction:
         # check the results against obtaining the full global snapshots
         expected = shadow.global_snapshots()
         for i, t in enumerate(snapshots):
-            assert np.allclose(expected[t], state[i])
+            assert np.allclose(state[i], expected[t])
 
     def test_large_state_warning(self, monkeypatch):
         """Test that a warning is raised when a very large state is reconstructed"""

--- a/tests/spin/test_lattice.py
+++ b/tests/spin/test_lattice.py
@@ -141,7 +141,7 @@ def test_positions(vectors, positions, n_cells, expected_points):
     r"""Test that the lattice points are translated according to coordinates provided in the positions."""
 
     lattice = Lattice(n_cells=n_cells, vectors=vectors, positions=positions)
-    assert np.allclose(expected_points, lattice.lattice_points)
+    assert np.allclose(lattice.lattice_points, expected_points)
 
 
 @pytest.mark.parametrize(
@@ -1126,4 +1126,4 @@ def test_lattice_points_templates(shape, n_cells, expected_points):
     r"""Test that the correct lattice points are generated for a given template."""
 
     lattice = generate_lattice(lattice=shape, n_cells=n_cells)
-    assert np.allclose(expected_points, lattice.lattice_points)
+    assert np.allclose(lattice.lattice_points, expected_points)

--- a/tests/templates/test_layers/test_basic_entangler.py
+++ b/tests/templates/test_layers/test_basic_entangler.py
@@ -91,7 +91,7 @@ class TestDecomposition:
             return [qml.expval(qml.PauliZ(i)) for i in range(n_wires)]
 
         expectations = circuit(weights)
-        np.testing.assert_allclose(expectations, target, atol=tol, rtol=0)
+        np.testing.assert_allclose(target, expectations, atol=tol, rtol=0)
 
     def test_custom_wire_labels(self, tol):
         """Test that template can deal with non-numeric, nonconsecutive wire labels."""

--- a/tests/templates/test_subroutines/test_gqsp.py
+++ b/tests/templates/test_subroutines/test_gqsp.py
@@ -65,7 +65,7 @@ class TestGQSP:
         )
         generated_output = qml.matrix(circuit, wire_order=[0, 1])(angles)[:2, :2]
 
-        assert np.allclose(expected_output, generated_output)
+        assert np.allclose(generated_output, expected_output)
 
     @pytest.mark.parametrize(
         ("unitary"),
@@ -98,7 +98,7 @@ class TestGQSP:
         )
         generated_output = qml.matrix(circuit, wire_order=[0, 1])(angles)[:2, :2]
 
-        assert np.allclose(expected_output, generated_output)
+        assert np.allclose(generated_output, expected_output)
 
     def test_queueing(self):
         """Test that no additional gates are being queued"""
@@ -150,7 +150,7 @@ class TestGQSP:
         expected_output = jnp.array(qml.matrix(circuit, wire_order=[0, 1])(angles))
         generated_output = qml.matrix(circuit, wire_order=[0, 1])(jnp.array(angles))
 
-        assert np.allclose(expected_output, generated_output)
+        assert np.allclose(generated_output, expected_output)
         assert qml.math.get_interface(generated_output) == "jax"
 
     @pytest.mark.torch
@@ -171,7 +171,7 @@ class TestGQSP:
         expected_output = torch.tensor(qml.matrix(circuit, wire_order=[0, 1])(angles))
         generated_output = qml.matrix(circuit, wire_order=[0, 1])(torch.tensor(angles))
 
-        assert np.allclose(expected_output, generated_output)
+        assert np.allclose(generated_output, expected_output)
         assert qml.math.get_interface(generated_output) == "torch"
 
     @pytest.mark.tf
@@ -192,7 +192,7 @@ class TestGQSP:
         expected_output = tf.Variable(qml.matrix(circuit, wire_order=[0, 1])(angles))
         generated_output = qml.matrix(circuit, wire_order=[0, 1])(tf.Variable(angles))
 
-        assert np.allclose(expected_output, generated_output)
+        assert np.allclose(generated_output, expected_output)
         assert qml.math.get_interface(generated_output) == "tensorflow"
 
     @pytest.mark.jax
@@ -216,5 +216,5 @@ class TestGQSP:
         jit_circuit = jax.jit(circuit)
         generated_output = jit_circuit(angles)
 
-        assert np.allclose(expected_output, generated_output)
+        assert np.allclose(generated_output, expected_output)
         assert qml.math.get_interface(generated_output) == "jax"

--- a/tests/templates/test_subroutines/test_qdrift.py
+++ b/tests/templates/test_subroutines/test_qdrift.py
@@ -205,7 +205,7 @@ class TestIntegration:
         )
         state = circ()
 
-        assert allclose(expected_state, state)
+        assert allclose(state, expected_state)
 
     @pytest.mark.local_salt(8)
     @pytest.mark.autograd
@@ -237,7 +237,7 @@ class TestIntegration:
         )
         state = circ(time)
 
-        assert allclose(expected_state, state)
+        assert allclose(state, expected_state)
 
     @pytest.mark.torch
     @pytest.mark.parametrize("coeffs, ops", test_hamiltonians)
@@ -267,7 +267,7 @@ class TestIntegration:
         )
         state = circ(time)
 
-        assert allclose(expected_state, state)
+        assert allclose(state, expected_state)
 
     @pytest.mark.tf
     @pytest.mark.parametrize("coeffs, ops", test_hamiltonians)
@@ -297,7 +297,7 @@ class TestIntegration:
         )
         state = circ(time)
 
-        assert allclose(expected_state, state)
+        assert allclose(state, expected_state)
 
     @pytest.mark.jax
     @pytest.mark.parametrize("coeffs, ops", test_hamiltonians)
@@ -327,7 +327,7 @@ class TestIntegration:
         )
         state = circ(time)
 
-        assert allclose(expected_state, state)
+        assert allclose(state, expected_state)
 
     @pytest.mark.jax
     @pytest.mark.parametrize("coeffs, ops", test_hamiltonians)
@@ -359,7 +359,7 @@ class TestIntegration:
         )
         state = circ(time)
 
-        assert allclose(expected_state, state)
+        assert allclose(state, expected_state)
 
     @pytest.mark.autograd
     def test_error_gradient_workflow_autograd(self):

--- a/tests/templates/test_subroutines/test_trotter.py
+++ b/tests/templates/test_subroutines/test_trotter.py
@@ -836,7 +836,7 @@ class TestIntegration:
         )
         state = circ()
 
-        assert qnp.allclose(expected_state, state)
+        assert qnp.allclose(state, expected_state)
 
     @pytest.mark.parametrize("order", (1, 2))
     @pytest.mark.parametrize("num_steps", (1, 2, 3))
@@ -878,7 +878,7 @@ class TestIntegration:
             @ initial_state
         )
         state = circ()
-        assert qnp.allclose(expected_state, state)
+        assert qnp.allclose(state, expected_state)
 
     @pytest.mark.jax
     @pytest.mark.parametrize("time", (0.5, 1, 2))
@@ -911,7 +911,7 @@ class TestIntegration:
         )
 
         state = circ(time, coeffs)
-        assert allclose(expected_state, state)
+        assert allclose(state, expected_state)
 
     @pytest.mark.jax
     @pytest.mark.parametrize("time", (0.5, 1, 2))
@@ -950,7 +950,7 @@ class TestIntegration:
         )
 
         state = circ(time, c1, c2)
-        assert allclose(expected_state, state)
+        assert allclose(state, expected_state)
 
     @pytest.mark.tf
     @pytest.mark.parametrize("time", (0.5, 1, 2))
@@ -987,7 +987,7 @@ class TestIntegration:
         )
 
         state = circ(time, coeffs)
-        assert allclose(expected_state, state)
+        assert allclose(state, expected_state)
 
     @pytest.mark.torch
     @pytest.mark.parametrize("time", (0.5, 1, 2))
@@ -1020,7 +1020,7 @@ class TestIntegration:
         )
 
         state = circ(time, coeffs)
-        assert allclose(expected_state, state)
+        assert allclose(state, expected_state)
 
     @pytest.mark.autograd
     @pytest.mark.parametrize("time", (0.5, 1, 2))
@@ -1051,7 +1051,7 @@ class TestIntegration:
         )
 
         state = circ(time, coeffs)
-        assert qnp.allclose(expected_state, state)
+        assert qnp.allclose(state, expected_state)
 
     @pytest.mark.autograd
     @pytest.mark.parametrize("order, n", ((1, 1), (1, 2), (2, 1), (4, 1)))
@@ -1852,7 +1852,7 @@ class TestTrotterizedQfuncIntegration:
         )
 
         state = circ(time, *args, wires=wires, **kwargs)
-        assert qnp.allclose(expected_state, state)
+        assert qnp.allclose(state, expected_state)
 
     @pytest.mark.jax
     @pytest.mark.parametrize("n", (1, 2, 3))
@@ -1918,7 +1918,7 @@ class TestTrotterizedQfuncIntegration:
         )
 
         state = circ(time, *args, wires=wires, **kwargs)
-        assert allclose(expected_state, state)
+        assert allclose(state, expected_state)
 
     @pytest.mark.jax
     @pytest.mark.parametrize("n", (1, 2, 3))
@@ -1987,7 +1987,7 @@ class TestTrotterizedQfuncIntegration:
         )
 
         state = circ(time, *args, wires=wires, **kwargs)
-        assert allclose(expected_state, state)
+        assert allclose(state, expected_state)
 
     #   Circuit gradient tests:
     @pytest.mark.parametrize("n", (1, 2, 3))

--- a/tests/test_debugging.py
+++ b/tests/test_debugging.py
@@ -847,7 +847,7 @@ class TestPLDB:
         """Test that the _execute method works as expected."""
         PLDB.add_device(dev)
         executed_results = PLDB._execute((tape,))
-        assert qnp.allclose(expected_result, executed_results)
+        assert qnp.allclose(executed_results, expected_result)
         PLDB.reset_active_dev()
 
 

--- a/tests/test_qaoa.py
+++ b/tests/test_qaoa.py
@@ -1643,7 +1643,7 @@ class TestCycles:
         ]
         expected_coeffs = [np.log(0.5), np.log(1), np.log(1.5), np.log(2), np.log(2.5), np.log(3)]
 
-        assert np.allclose(expected_coeffs, h.coeffs)
+        assert np.allclose(h.coeffs, expected_coeffs)
         assert all(op.wires == exp.wires for op, exp in zip(h.ops, expected_ops))
         assert all(type(op) is type(exp) for op, exp in zip(h.ops, expected_ops))
 
@@ -1703,7 +1703,7 @@ class TestCycles:
             np.log(7),
         ]
 
-        assert np.allclose(expected_coeffs, h.coeffs)
+        assert np.allclose(h.coeffs, expected_coeffs)
         assert all(op.wires == exp.wires for op, exp in zip(h.ops, expected_ops))
         assert all(type(op) is type(exp) for op, exp in zip(h.ops, expected_ops))
 
@@ -1871,7 +1871,7 @@ class TestCycles:
         expected_coeffs = [0, 0]
 
         coeffs, ops = h.terms()
-        assert qml.math.allclose(expected_coeffs, coeffs)
+        assert qml.math.allclose(coeffs, expected_coeffs)
         for op, expected_op in zip(ops, expected_ops):
             assert op.pauli_rep == expected_op.pauli_rep
 

--- a/tests/transforms/test_diagonalize_measurements.py
+++ b/tests/transforms/test_diagonalize_measurements.py
@@ -581,4 +581,4 @@ class TestDiagonalizeTapeMeasurements:
             for r_diagonalized, r in zip(res, expected_res):
                 assert np.allclose(r_diagonalized, r, rtol=0.1)
         else:
-            assert np.allclose(expected_res, res, rtol=0.1)
+            assert np.allclose(res, expected_res, rtol=0.1)

--- a/tests/workflow/interfaces/execute/test_autograd.py
+++ b/tests/workflow/interfaces/execute/test_autograd.py
@@ -76,7 +76,7 @@ class TestCaching:
                     [np.sin(2 * x) * np.sin(2 * y), -2 * np.cos(x) ** 2 * np.cos(2 * y)],
                 ]
             )
-            assert np.allclose(expected, hess1)
+            assert np.allclose(hess1, expected)
 
         expected_runs = 1  # forward pass
 

--- a/tests/workflow/interfaces/execute/test_jax.py
+++ b/tests/workflow/interfaces/execute/test_jax.py
@@ -94,7 +94,7 @@ class TestCaching:
                     [jnp.sin(2 * x) * jnp.sin(2 * y), -2 * jnp.cos(x) ** 2 * jnp.cos(2 * y)],
                 ]
             )
-            assert np.allclose(expected, hess1)
+            assert np.allclose(hess1, expected)
 
         expected_runs = 1  # forward pass
 

--- a/tests/workflow/interfaces/execute/test_tensorflow.py
+++ b/tests/workflow/interfaces/execute/test_tensorflow.py
@@ -71,7 +71,7 @@ class TestCaching:
                     [tf.sin(2 * x) * tf.sin(2 * y), -2 * tf.cos(x) ** 2 * tf.cos(2 * y)],
                 ]
             )
-            assert np.allclose(expected, hess1)
+            assert np.allclose(hess1, expected)
 
         expected_runs = 1  # forward pass
 

--- a/tests/workflow/interfaces/execute/test_torch.py
+++ b/tests/workflow/interfaces/execute/test_torch.py
@@ -96,7 +96,7 @@ class TestCaching:
                     ],
                 ]
             )
-            assert torch.allclose(expected, hess1)
+            assert torch.allclose(hess1, expected)
 
         expected_runs = 1  # forward pass
 

--- a/tests/workflow/interfaces/test_jacobian_products.py
+++ b/tests/workflow/interfaces/test_jacobian_products.py
@@ -614,10 +614,10 @@ class TestProbsTransformJacobians:
         res0dx = 0.5 * np.array([-np.sin(x) * np.cos(y), np.sin(x) * np.cos(y)])
         res0dy = 0.5 * np.array([-np.cos(x) * np.sin(y), np.cos(x) * np.sin(y)])
         expected_jvp00 = 2.5 * res0dx + 1.5 * res0dy
-        assert qml.math.allclose(expected_jvp00, jvp[0][0])
+        assert qml.math.allclose(jvp[0][0], expected_jvp00)
 
         expected_jvp01 = -2.5 * np.sin(x) * np.cos(y) - 1.5 * np.cos(x) * np.sin(y)
-        assert qml.math.allclose(expected_jvp01, jvp[0][1])
+        assert qml.math.allclose(jvp[0][1], expected_jvp01)
 
         assert qml.math.allclose(jvp[1][0], 0)
         assert qml.math.allclose(jvp[1][1], -0.6 * np.sin(phi))


### PR DESCRIPTION
**Context:**
There used to be lots of asymmetric `allclose` calls that put truth value on the first argument, which should be corrected although no essential difference

**Description of the Change:**
1. Use the regex `allclose\((expe[^,]*), ([^),]*)\)` to match two-arg call of (all variants of) `allclose` and replace with `allclose($2, $1)`
2. Use the regex `allclose\((expe[^,]*), ([^),]*)(,?.*?)?\)` to match more-than-two-arg call of `allclose` containing `atol` and `rtol` options, and replace with `allclose($2, $1$3)`
3. Other scattered occurences that do not following this pattern were manually adjusted
4. Some special cases where the expected vars were too complicated and hardcoded inside the call of allclose, are adjusted such that there are extra lines e.g. `expected=` as temporary var there.

**Benefits:**
Make our codebase more standardized. Clean-up level work. Much better readibility and less confusion for future dev.

**Possible Drawbacks:**
Not known. Perhaps there are still missing out after this search but should be very few.

**Related GitHub Issues:**
[sc-80540]