### PR TITLE
Cast input to `BasisState` to an int

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -78,7 +78,7 @@
 
 <h3>Bug fixes 🐛</h3>
 
-* `BasisState` now casts it's input to int.
+* `BasisState` now casts its input to integers.
   [(#6844)](https://github.com/PennyLaneAI/pennylane/pull/6844)
 
 <h3>Contributors ✍️</h3>

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -78,6 +78,8 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* `BasisState` now casts it's input to int.
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -79,6 +79,7 @@
 <h3>Bug fixes 🐛</h3>
 
 * `BasisState` now casts it's input to int.
+  [(#6844)](https://github.com/PennyLaneAI/pennylane/pull/6844)
 
 <h3>Contributors ✍️</h3>
 

--- a/pennylane/ops/qubit/state_preparation.py
+++ b/pennylane/ops/qubit/state_preparation.py
@@ -102,7 +102,7 @@ class BasisState(StatePrepBase):
             state_list = list(qml.math.toarray(state))
             if not set(state_list).issubset({0, 1}):
                 raise ValueError(f"Basis state must only consist of 0s and 1s; got {state_list}")
-
+        state = qml.math.cast(state, int)
         super().__init__(state, wires=wires, id=id)
 
     def _flatten(self):
@@ -287,7 +287,7 @@ class StatePrep(StatePrepBase):
     ndim_params = (1,)
     """int: Number of dimensions per trainable parameter of the operator."""
 
-    # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-arguments,too-many-positional-arguments
     def __init__(
         self,
         state: TensorLike,

--- a/tests/ops/qubit/test_state_prep.py
+++ b/tests/ops/qubit/test_state_prep.py
@@ -14,13 +14,21 @@
 """
 Unit tests for the available qubit state preparation operations.
 """
+import numpy as np
 import pytest
 
 import pennylane as qml
-from pennylane import numpy as np
 from pennylane.wires import WireError
 
 densitymat0 = np.array([[1.0, 0.0], [0.0, 0.0]])
+
+
+def test_basis_state_input_cast_to_int():
+    """Test that the input to BasisState is cast to an int."""
+
+    state = np.array([1.0, 0.0], dtype=np.float64)
+    op = qml.BasisState(state, wires=(0, 1))
+    assert op.data[0].dtype == np.int64
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
**Context:**

PR #6770  accidentally broke lightning, becasue we are now sending numpy data to lightning instead of autograd.  The autograd arrays had slightly different casting rules. With numpy, we are no longer implicitly casting to integers.

**Description of the Change:**

Always cast the input to `BasisState` to integers.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
