### PR TITLE
Bump `torch` version in CI to 2.5.0

### DIFF
--- a/.github/workflows/interface-dependency-versions.yml
+++ b/.github/workflows/interface-dependency-versions.yml
@@ -26,7 +26,7 @@ on:
         description: The version of PyTorch to use for testing
         required: false
         type: string
-        default: '2.3.0'
+        default: '2.5.0'
     outputs:
       jax-version:
         description: The version of JAX to use
@@ -72,6 +72,6 @@ jobs:
     outputs:
       jax-version: jax==${{ steps.jax.outputs.version }} jaxlib==${{ steps.jax.outputs.version }}
       tensorflow-version: tensorflow~=${{ steps.tensorflow.outputs.version }} tf-keras~=${{ steps.tensorflow.outputs.version }}
-      pytorch-version: torch==${{ steps.pytorch.outputs.version }}
+      pytorch-version: torch~=${{ steps.pytorch.outputs.version }}
       catalyst-nightly: ${{ steps.catalyst.outputs.nightly }}
       pennylane-lightning-latest: ${{ steps.pennylane-lightning.outputs.latest }}


### PR DESCRIPTION
As name says. We should be testing against the latest version of `torch`. This PR updates the torch version used in CI to `2.5.0`.