### PR TITLE
Fix for a bug inside of christiansen_integrals_dipole

### DIFF
--- a/pennylane/labs/vibrational/christiansen_utils.py
+++ b/pennylane/labs/vibrational/christiansen_utils.py
@@ -848,7 +848,7 @@ def christiansen_integrals_dipole(pes, n_states=16):
     comm.Barrier()
     dipole_cform_onebody = comm.bcast(dipole_cform_onebody, root=0)
 
-    if pes.localized is True or pes.dipole_level > 1:
+    if pes.localized and pes.dipole_level > 1:
         local_dipole_cform_twobody = _cform_twomode_dipole(pes, n_states)
         comm.Barrier()
 
@@ -865,7 +865,7 @@ def christiansen_integrals_dipole(pes, n_states=16):
         comm.Barrier()
         dipole_cform_twobody = comm.bcast(dipole_cform_twobody, root=0)
 
-    if pes.localized is True or pes.dipole_level > 2:
+    if pes.localized and pes.dipole_level > 2:
         local_dipole_cform_threebody = _cform_threemode_dipole(pes, n_states)
         comm.Barrier()
 


### PR DESCRIPTION
**Context:**
If there isn't a twomode/threemode dipole, we shouldn't be computing the integral coefficients.

**Description of the Change:**
Change `or` to `and`. It should be that it's both localized AND that the dipole_level is greater than the minimum needed.