### PR TITLE
Fix `InterfaceEnum` object

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -100,6 +100,9 @@
 
 <h3>Internal changes ⚙️</h3>
 
+* Improved the `InterfaceEnum` object to prevent direct comparisons to `str` objects.
+  [(#6877)](https://github.com/PennyLaneAI/pennylane/pull/6877)
+
 * Added a `QmlPrimitive` class that inherits `jax.core.Primitive` to a new `qml.capture.custom_primitives` module.
   This class contains a `prim_type` property so that we can differentiate between different sets of PennyLane primitives.
   Consequently, `QmlPrimitive` is now used to define all PennyLane primitives.

--- a/pennylane/math/interface_utils.py
+++ b/pennylane/math/interface_utils.py
@@ -52,6 +52,7 @@ class Interface(Enum):
         return super().__eq__(interface)
 
     def __hash__(self):
+        # pylint: disable=useless-super-delegation
         return super().__hash__()
 
 

--- a/pennylane/math/interface_utils.py
+++ b/pennylane/math/interface_utils.py
@@ -46,6 +46,14 @@ class Interface(Enum):
         }
         return mapping[self]
 
+    def __eq__(self, interface):
+        if isinstance(interface, str):
+            raise TypeError("Cannot compare Interface with str")
+        return super().__eq__(interface)
+
+    def __hash__(self):
+        return super().__hash__()
+
 
 InterfaceLike = Union[str, Interface, None]
 
@@ -225,7 +233,7 @@ def get_canonical_interface_name(user_input: InterfaceLike) -> Interface:
         Interface: canonical interface
     """
 
-    if user_input in SUPPORTED_INTERFACE_NAMES:
+    if isinstance(user_input, Interface) and user_input in SUPPORTED_INTERFACE_NAMES:
         return user_input
     try:
         return INTERFACE_MAP[user_input]

--- a/pennylane/workflow/qnode.py
+++ b/pennylane/workflow/qnode.py
@@ -60,11 +60,11 @@ def _convert_to_interface(result, interface: Interface):
 def _make_execution_config(
     circuit: Optional["QNode"], diff_method=None, mcm_config=None
 ) -> "qml.devices.ExecutionConfig":
-    circuit_interface = getattr(circuit, "interface", Interface.NUMPY)
+    circuit_interface = getattr(circuit, "interface", "numpy")
     execute_kwargs = getattr(circuit, "execute_kwargs", {})
     gradient_kwargs = getattr(circuit, "gradient_kwargs", {})
     grad_on_execution = execute_kwargs.get("grad_on_execution")
-    if circuit_interface == Interface.JAX:
+    if circuit_interface == "jax":
         grad_on_execution = False
     elif grad_on_execution == "best":
         grad_on_execution = None
@@ -288,6 +288,8 @@ class QNode:
         gradient_kwargs (dict): A dictionary of keyword arguments that are passed to the differentiation
             method. Please refer to the :mod:`qml.gradients <.gradients>` module for details
             on supported options for your chosen gradient transform.
+        autograph (bool): Whether to use AutoGraph to convert Python control flow to native PennyLane
+            control flow. For more information, refer to :doc:`Autograph </development/autograph>`. Defaults to True.
 
     **Example**
 
@@ -505,6 +507,7 @@ class QNode:
         postselect_mode: Literal[None, "hw-like", "fill-shots"] = None,
         mcm_method: Literal[None, "deferred", "one-shot", "tree-traversal"] = None,
         gradient_kwargs: Optional[dict] = None,
+        autograph: bool = True,
         **kwargs,
     ):
         self._init_args = locals()
@@ -559,6 +562,7 @@ class QNode:
             self._qfunc_uses_shots_arg = False
 
         # input arguments
+        self._autograph = autograph
         self.func = func
         self.device = device
         self._interface = get_canonical_interface_name(interface)

--- a/pennylane/workflow/qnode.py
+++ b/pennylane/workflow/qnode.py
@@ -60,11 +60,11 @@ def _convert_to_interface(result, interface: Interface):
 def _make_execution_config(
     circuit: Optional["QNode"], diff_method=None, mcm_config=None
 ) -> "qml.devices.ExecutionConfig":
-    circuit_interface = getattr(circuit, "interface", "numpy")
+    circuit_interface = getattr(circuit, "interface", Interface.NUMPY)
     execute_kwargs = getattr(circuit, "execute_kwargs", {})
     gradient_kwargs = getattr(circuit, "gradient_kwargs", {})
     grad_on_execution = execute_kwargs.get("grad_on_execution")
-    if circuit_interface == "jax":
+    if circuit_interface == Interface.JAX:
         grad_on_execution = False
     elif grad_on_execution == "best":
         grad_on_execution = None
@@ -288,8 +288,6 @@ class QNode:
         gradient_kwargs (dict): A dictionary of keyword arguments that are passed to the differentiation
             method. Please refer to the :mod:`qml.gradients <.gradients>` module for details
             on supported options for your chosen gradient transform.
-        autograph (bool): Whether to use AutoGraph to convert Python control flow to native PennyLane
-            control flow. For more information, refer to :doc:`Autograph </development/autograph>`. Defaults to True.
 
     **Example**
 
@@ -507,7 +505,6 @@ class QNode:
         postselect_mode: Literal[None, "hw-like", "fill-shots"] = None,
         mcm_method: Literal[None, "deferred", "one-shot", "tree-traversal"] = None,
         gradient_kwargs: Optional[dict] = None,
-        autograph: bool = True,
         **kwargs,
     ):
         self._init_args = locals()
@@ -562,7 +559,6 @@ class QNode:
             self._qfunc_uses_shots_arg = False
 
         # input arguments
-        self._autograph = autograph
         self.func = func
         self.device = device
         self._interface = get_canonical_interface_name(interface)

--- a/pennylane/workflow/qnode.py
+++ b/pennylane/workflow/qnode.py
@@ -60,11 +60,11 @@ def _convert_to_interface(result, interface: Interface):
 def _make_execution_config(
     circuit: Optional["QNode"], diff_method=None, mcm_config=None
 ) -> "qml.devices.ExecutionConfig":
-    circuit_interface = getattr(circuit, "interface", Interface.NUMPY)
+    circuit_interface = getattr(circuit, "interface", "numpy")
     execute_kwargs = getattr(circuit, "execute_kwargs", {})
     gradient_kwargs = getattr(circuit, "gradient_kwargs", {})
     grad_on_execution = execute_kwargs.get("grad_on_execution")
-    if circuit_interface == Interface.JAX:
+    if circuit_interface == "jax":
         grad_on_execution = False
     elif grad_on_execution == "best":
         grad_on_execution = None

--- a/pennylane/workflow/qnode.py
+++ b/pennylane/workflow/qnode.py
@@ -60,11 +60,11 @@ def _convert_to_interface(result, interface: Interface):
 def _make_execution_config(
     circuit: Optional["QNode"], diff_method=None, mcm_config=None
 ) -> "qml.devices.ExecutionConfig":
-    circuit_interface = getattr(circuit, "interface", "numpy")
+    circuit_interface = getattr(circuit, "interface", Interface.NUMPY.value)
     execute_kwargs = getattr(circuit, "execute_kwargs", {})
     gradient_kwargs = getattr(circuit, "gradient_kwargs", {})
     grad_on_execution = execute_kwargs.get("grad_on_execution")
-    if circuit_interface == "jax":
+    if circuit_interface in {Interface.JAX.value, Interface.JAX_JIT.value}:
         grad_on_execution = False
     elif grad_on_execution == "best":
         grad_on_execution = None

--- a/pennylane/workflow/resolution.py
+++ b/pennylane/workflow/resolution.py
@@ -96,19 +96,17 @@ def _resolve_interface(interface: Union[str, Interface], tapes: QuantumScriptBat
     Returns:
         Interface: resolved interface
     """
-
     interface = get_canonical_interface_name(interface)
 
     if interface == Interface.AUTO:
         params = []
         for tape in tapes:
             params.extend(tape.get_parameters(trainable_only=False))
-        interface = get_canonical_interface_name(get_interface(*params))
-        if interface != Interface.NUMPY:
-            try:
-                interface = get_canonical_interface_name(interface)
-            except ValueError:
-                interface = Interface.NUMPY
+        interface = get_interface(*params)
+        try:
+            interface = get_canonical_interface_name(interface)
+        except ValueError:
+            interface = Interface.NUMPY
     if interface == Interface.TF and _use_tensorflow_autograph():
         interface = Interface.TF_AUTOGRAPH
     if interface == Interface.JAX:

--- a/pennylane/workflow/resolution.py
+++ b/pennylane/workflow/resolution.py
@@ -106,6 +106,7 @@ def _resolve_interface(interface: Union[str, Interface], tapes: QuantumScriptBat
         try:
             interface = get_canonical_interface_name(interface)
         except ValueError:
+            # If the interface is not recognized, default to numpy, like networkx
             interface = Interface.NUMPY
     if interface == Interface.TF and _use_tensorflow_autograph():
         interface = Interface.TF_AUTOGRAPH

--- a/pennylane/workflow/resolution.py
+++ b/pennylane/workflow/resolution.py
@@ -103,7 +103,7 @@ def _resolve_interface(interface: Union[str, Interface], tapes: QuantumScriptBat
         params = []
         for tape in tapes:
             params.extend(tape.get_parameters(trainable_only=False))
-        interface = get_interface(*params)
+        interface = get_canonical_interface_name(get_interface(*params))
         if interface != Interface.NUMPY:
             try:
                 interface = get_canonical_interface_name(interface)

--- a/tests/math/test_functions.py
+++ b/tests/math/test_functions.py
@@ -1024,11 +1024,16 @@ def test_get_interface(t, interface):
     assert res == interface
 
 
-def test_interface_enum_error():
-    """Test that an error is raised if comparing to string"""
-    with pytest.raises(TypeError, match="Cannot compare Interface with str"):
-        # pylint: disable=pointless-statement
-        "numpy" == fn.Interface.NUMPY
+# pylint: disable=too-few-public-methods
+class TestInterfaceEnum:
+    """Test the Interface enum class"""
+
+    def test_eq(self):
+        """Test that an error is raised if comparing to string"""
+        assert fn.Interface.NUMPY == fn.Interface.NUMPY
+        with pytest.raises(TypeError, match="Cannot compare Interface with str"):
+            # pylint: disable=pointless-statement
+            "numpy" == fn.Interface.NUMPY
 
 
 @pytest.mark.parametrize("t", test_data)

--- a/tests/math/test_functions.py
+++ b/tests/math/test_functions.py
@@ -1024,6 +1024,13 @@ def test_get_interface(t, interface):
     assert res == interface
 
 
+def test_interface_enum_error():
+    """Test that an error is raised if comparing to string"""
+    with pytest.raises(TypeError, match="Cannot compare Interface with str"):
+        # pylint: disable=pointless-statement
+        "numpy" == fn.Interface.NUMPY
+
+
 @pytest.mark.parametrize("t", test_data)
 def test_toarray(t):
     """Test that the toarray method correctly converts the input

--- a/tests/math/test_functions.py
+++ b/tests/math/test_functions.py
@@ -1033,7 +1033,7 @@ class TestInterfaceEnum:
         assert fn.Interface.NUMPY == fn.Interface.NUMPY
         with pytest.raises(TypeError, match="Cannot compare Interface with str"):
             # pylint: disable=pointless-statement
-            "numpy" == fn.Interface.NUMPY
+            fn.Interface.NUMPY == "numpy"
 
 
 @pytest.mark.parametrize("t", test_data)

--- a/tests/test_qnode.py
+++ b/tests/test_qnode.py
@@ -29,6 +29,7 @@ from pennylane import numpy as pnp
 from pennylane import qnode
 from pennylane.tape import QuantumScript, QuantumScriptBatch
 from pennylane.typing import PostprocessingFn
+from pennylane.workflow.qnode import _make_execution_config
 
 
 def dummyfunc():
@@ -2070,3 +2071,52 @@ def test_resets_after_execution_error():
         circuit(qml.numpy.array(0.1))
 
     assert circuit.interface == "auto"
+
+
+class TestPrivateFunctions:
+    """Tests for private functions in the QNode class."""
+
+    def test_make_execution_config_with_no_qnode(self):
+        """Test that the _make_execution_config function correctly creates an execution config."""
+        diff_method = "best"
+        mcm_config = qml.devices.MCMConfig(postselect_mode="fill-shots", mcm_method="deferred")
+        config = _make_execution_config(None, diff_method, mcm_config)
+
+        expected_config = qml.devices.ExecutionConfig(
+            interface="numpy",
+            gradient_keyword_arguments={},
+            use_device_jacobian_product=False,
+            grad_on_execution=None,
+            gradient_method=diff_method,
+            mcm_config=mcm_config,
+        )
+
+        assert config == expected_config
+
+    @pytest.mark.parametrize("interface", ["autograd", "torch", "tf", "jax", "jax-jit"])
+    def test_make_execution_config_with_qnode(self, interface):
+        """Test that a execution config is made correctly with no QNode."""
+        if "jax" in interface:
+            grad_on_execution = False
+        else:
+            grad_on_execution = None
+
+        @qml.qnode(qml.device("default.qubit"), interface=interface)
+        def circuit():
+            qml.H(0)
+            return qml.probs()
+
+        diff_method = "best"
+        mcm_config = qml.devices.MCMConfig(postselect_mode="fill-shots", mcm_method="deferred")
+        config = _make_execution_config(circuit, diff_method, mcm_config)
+
+        expected_config = qml.devices.ExecutionConfig(
+            interface=interface,
+            gradient_keyword_arguments={},
+            use_device_jacobian_product=False,
+            grad_on_execution=grad_on_execution,
+            gradient_method=diff_method,
+            mcm_config=mcm_config,
+        )
+
+        assert config == expected_config


### PR DESCRIPTION
**Context:**

`QNode.interface` returns a `str` type,
```python
    @property
    def interface(self) -> str:
        """The interface used by the QNode"""
        return self._interface.value
```
Therefore, this equality will never be true,
```python
from pennylane.math.interface_utils import Interface

>>> "jax" == Interface.JAX
False
```

Moreover, `str` cannot be compared with `Enum` objects at all. 🤯 

**Description of the Change:**

- Adjust the `InterfaceEnum` class to have dunder methods to overwrite comparisons. This way it will error out if you try to compare it with a string. 
- Add test coverage for the private helpers in `qnode.py`

Now we have,
```python
from pennylane.math.interface_utils import Interface

>>> "jax" == Interface.JAX
TypeError: Cannot compare Interface with str
```

**Benefits:** Logic is correct.

**Possible Drawbacks:** None identified.

[sc-83034]
