### PR TITLE
Fix deprecations that weren't caught by CI

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -97,6 +97,7 @@
 * The ``inner_transform_program`` and ``config`` keyword arguments in ``qml.execute`` have been deprecated.
   If more detailed control over the execution is required, use ``qml.workflow.run`` with these arguments instead.
   [(#6822)](https://github.com/PennyLaneAI/pennylane/pull/6822)
+  [(#6879)](https://github.com/PennyLaneAI/pennylane/pull/6879)
 
 <h3>Internal changes ⚙️</h3>
 

--- a/pennylane/optimize/qnspsa.py
+++ b/pennylane/optimize/qnspsa.py
@@ -221,19 +221,7 @@ class QNSPSAOptimizer:
             all_grad_dirs.append(grad_dirs)
             all_tensor_dirs.append(tensor_dirs)
 
-        if isinstance(cost.device, qml.devices.Device):
-            program, config = cost.device.preprocess()
-
-            raw_results = qml.workflow.run(
-                all_grad_tapes + all_metric_tapes,
-                cost.device,
-                config=config,
-                inner_transform_program=program,
-            )
-        else:
-            raw_results = qml.execute(
-                all_grad_tapes + all_metric_tapes, cost.device, None
-            )  # pragma: no cover
+        raw_results = qml.execute(all_grad_tapes + all_metric_tapes, cost.device)
         grads = [
             self._post_process_grad(raw_results[2 * i : 2 * i + 2], all_grad_dirs[i])
             for i in range(self.resamplings)

--- a/pennylane/optimize/qnspsa.py
+++ b/pennylane/optimize/qnspsa.py
@@ -224,12 +224,11 @@ class QNSPSAOptimizer:
         if isinstance(cost.device, qml.devices.Device):
             program, config = cost.device.preprocess()
 
-            raw_results = qml.execute(
+            raw_results = qml.workflow.run(
                 all_grad_tapes + all_metric_tapes,
                 cost.device,
-                None,
-                transform_program=program,
                 config=config,
+                inner_transform_program=program,
             )
         else:
             raw_results = qml.execute(

--- a/pennylane/optimize/riemannian_gradient.py
+++ b/pennylane/optimize/riemannian_gradient.py
@@ -392,30 +392,16 @@ class RiemannianGradientOptimizer:
             self.nqubits,
         )
 
-        if isinstance(self.circuit.device, qml.devices.Device):
-            program, config = self.circuit.device.preprocess()
+        raw_results = qml.execute(circuits, self.circuit.device)
 
-            circuits = qml.workflow.run(
-                circuits,
-                self.circuit.device,
-                config=config,
-                inner_transform_program=program,
-            )
-        else:
-            circuits = qml.execute(
-                circuits, self.circuit.device, diff_method=None
-            )  # pragma: no cover
-
-        program = self.circuit.device.preprocess_transforms()
-
-        circuits_plus = np.array(circuits[: len(circuits) // 2]).reshape(
+        results_plus = np.array(raw_results[: len(raw_results) // 2]).reshape(
             len(self.coeffs), len(self.lie_algebra_basis_names)
         )
-        circuits_min = np.array(circuits[len(circuits) // 2 :]).reshape(
+        results_min = np.array(raw_results[len(raw_results) // 2 :]).reshape(
             len(self.coeffs), len(self.lie_algebra_basis_names)
         )
 
         # For each observable O_i in the Hamiltonian, we have to calculate all Lie coefficients
-        omegas = circuits_plus - circuits_min
+        omegas = results_plus - results_min
 
         return np.dot(self.coeffs, omegas)

--- a/pennylane/optimize/riemannian_gradient.py
+++ b/pennylane/optimize/riemannian_gradient.py
@@ -395,12 +395,11 @@ class RiemannianGradientOptimizer:
         if isinstance(self.circuit.device, qml.devices.Device):
             program, config = self.circuit.device.preprocess()
 
-            circuits = qml.execute(
+            circuits = qml.workflow.run(
                 circuits,
                 self.circuit.device,
-                transform_program=program,
                 config=config,
-                diff_method=None,
+                inner_transform_program=program,
             )
         else:
             circuits = qml.execute(

--- a/pennylane/workflow/execution.py
+++ b/pennylane/workflow/execution.py
@@ -162,7 +162,7 @@ def execute(
             "The config argument has been deprecated and will be removed in v0.42. "
             "The provided config argument will be ignored. "
             "If more detailed control over the execution is required, use ``qml.workflow.run`` with these arguments instead.",
-            ValueError,
+            qml.PennyLaneDeprecationWarning,
         )
 
     if inner_transform != "unset":
@@ -170,7 +170,7 @@ def execute(
             "The inner_transform argument has been deprecated and will be removed in v0.42. "
             "The provided inner_transform argument will be ignored. "
             "If more detailed control over the execution is required, use ``qml.workflow.run`` with these arguments instead.",
-            ValueError,
+            qml.PennyLaneDeprecationWarning,
         )
 
     if logger.isEnabledFor(logging.DEBUG):

--- a/pennylane/workflow/execution.py
+++ b/pennylane/workflow/execution.py
@@ -162,7 +162,7 @@ def execute(
             "The config argument has been deprecated and will be removed in v0.42. "
             "The provided config argument will be ignored. "
             "If more detailed control over the execution is required, use ``qml.workflow.run`` with these arguments instead.",
-            qml.PennyLaneDeprecationWarning,
+            ValueError,
         )
 
     if inner_transform != "unset":
@@ -170,7 +170,7 @@ def execute(
             "The inner_transform argument has been deprecated and will be removed in v0.42. "
             "The provided inner_transform argument will be ignored. "
             "If more detailed control over the execution is required, use ``qml.workflow.run`` with these arguments instead.",
-            qml.PennyLaneDeprecationWarning,
+            ValueError,
         )
 
     if logger.isEnabledFor(logging.DEBUG):


### PR DESCRIPTION
**Context:**

PR #6822 deprecated the arguments `config` and `inner_transform_program` to `qml.execute`. However, because of some bug in our CI, the `qml.PennyLaneDeprecationWarning` are not being treated as errors. I just happened to find this warning in our CI logs.

**Description of the Change:**

Promoted `qml.PennyLaneDeprecationWarning` to a `ValueError` to fish out any deprecated code. Updated said code to use `qml.workflow.run` instead of `qml.execute`. 

[sc-81529]
