### PR TITLE
Replace deprecated `jax.core.ConcreteArray`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -130,6 +130,9 @@
 * The `RiemannianGradientOptimizer` has been updated to take advantage of newer features.
   [(#6882)](https://github.com/PennyLaneAI/pennylane/pull/6882)
 
+*  Replace deprecated `jax.core.ConcreteArray` from `is_abstract`. 
+  [(#6890)](https://github.com/PennyLaneAI/pennylane/pull/6890)
+
 <h3>Documentation 📝</h3>
 
 * The docstrings for `qml.unary_mapping`, `qml.binary_mapping`, `qml.christiansen_mapping`, 
@@ -149,6 +152,7 @@
 
 This release contains contributions from (in alphabetical order):
 
+Oriol Balló,
 Yushao Chen,
 Isaac De Vlugt,
 Diksha Dhawan,

--- a/pennylane/math/utils.py
+++ b/pennylane/math/utils.py
@@ -276,10 +276,13 @@ def is_abstract(tensor, like=None):
                 jax.interpreters.partial_eval.JaxprTracer,
             ),
         ):
-            # Tracer objects will be used when computing gradients or applying transforms.
-            # If the value of the tracer is known, it will contain a ConcreteArray.
-            # Otherwise, it will be abstract.
-            return not isinstance(tensor.aval, jax.core.ConcreteArray)
+            # To avoid relying on jax core internals, which are subject to change, we use
+            # the conversion to a jnp array to check if the tensor has a concrete value.
+            try: 
+                jax.numpy.asarray(tensor)
+                return True
+            except Exeption:
+                    return False
 
         return isinstance(tensor, DynamicJaxprTracer)
 

--- a/pennylane/math/utils.py
+++ b/pennylane/math/utils.py
@@ -280,9 +280,9 @@ def is_abstract(tensor, like=None):
             # the conversion to a jnp array to check if the tensor has a concrete value.
             try: 
                 jax.numpy.asarray(tensor)
+                return False
+            except Exception:
                 return True
-            except Exeption:
-                    return False
 
         return isinstance(tensor, DynamicJaxprTracer)
 


### PR DESCRIPTION
**Context:** Replace the deprecated `jax.core.ConcreteArray` from the `is_abstract` function in `utils.py` by a check with `jax.numpy`.

**Description of the Change:** APIs in `jax.core` are not considered public, and may be changed in future releases without warning (see the [API compatibility policy](https://jax.readthedocs.io/en/latest/api_compatibility.html)) -> [Issue from jax repo](https://github.com/jax-ml/jax/discussions/25337)

**Benefits:** We no longer use `jax.core` private API.

**Possible Drawbacks:** Maybe could be made more efficient. 

**Related GitHub Issues:** N/A
