### PR TITLE
[Bug fix] Use qnode mcm_method information when creating transform program for construct batch

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -156,6 +156,10 @@
 * `BasisState` now casts its input to integers.
   [(#6844)](https://github.com/PennyLaneAI/pennylane/pull/6844)
 
+* The `workflow.contstruct_batch` and `workflow.construct_tape` functions now correctly reflect the `mcm_method`
+  passed to the `QNode`, instead of assuming the method is always `deferred`.
+  [(#6903)](https://github.com/PennyLaneAI/pennylane/pull/6903)
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):
@@ -163,6 +167,7 @@ This release contains contributions from (in alphabetical order):
 Yushao Chen,
 Isaac De Vlugt,
 Diksha Dhawan,
+Lillian M.A. Frederiksen,
 Pietropaolo Frisoni,
 Marcus Gisslén,
 Christina Lee,

--- a/pennylane/workflow/construct_batch.py
+++ b/pennylane/workflow/construct_batch.py
@@ -65,7 +65,12 @@ def _get_full_transform_program(
             **qnode.gradient_kwargs,
         )
 
-    config = _make_execution_config(qnode, gradient_fn)
+    mcm_config = qml.devices.MCMConfig(
+        postselect_mode=qnode.execute_kwargs["postselect_mode"],
+        mcm_method=qnode.execute_kwargs["mcm_method"],
+    )
+
+    config = _make_execution_config(qnode, gradient_fn, mcm_config)
     return program + qnode.device.preprocess_transforms(config)
 
 

--- a/tests/workflow/test_construct_batch.py
+++ b/tests/workflow/test_construct_batch.py
@@ -448,3 +448,20 @@ class TestConstructBatch:
         )
         qml.assert_equal(batch[0], expected)
         assert fn(("a",)) == ("a",)
+
+    @pytest.mark.parametrize(
+        "mcm_method, expected_op",
+        [("deferred", qml.CNOT), ("tree-traversal", qml.measurements.MidMeasureMP)],
+    )
+    def test_mcm_method(self, mcm_method, expected_op):
+        """Test that the tape is constructed using the mcm_method specified on the QNode"""
+
+        @qml.qnode(qml.device("default.qubit"), mcm_method=mcm_method)
+        def circuit():
+            qml.measure(0)
+            return qml.expval(qml.Z(0))
+
+        (tape,), _ = qml.workflow.construct_batch(circuit, level="device")()
+
+        assert len(tape.operations) == 1
+        assert isinstance(tape.operations[0], expected_op)


### PR DESCRIPTION
**Context:**
A bug was found in `construct_tape` (and `construct_batch`) while testing behaviour of circuits with mid-circuit measurements for another task: the QNode's `mcm_method` information is never passed to the `construct_batch` function, so it always constructs a tape as if deferred measurements were used.

**Description of the Change:**
Create an `mcm_config` from the information stored in `qnode.execution_kwargs` and use it when getting the transform program to apply.

**Related GitHub Issues:**
#6902


[sc-83393]