### PR TITLE
Fix return type

### DIFF
--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -9,6 +9,12 @@ deprecations are listed below.
 Pending deprecations
 --------------------
 
+* The property ```MeasurementProcess.return_type``` has been deprecated.
+  If observable type checking is needed, please use direct ```isinstance```; if other text information is needed, please use class name, or another internal temporary private member ``_shortname``.
+
+  - Deprecated in v0.41
+  - Will be removed in v0.42
+
 * The ``mcm_config`` argument to ``qml.execute`` has been deprecated.
   Instead, use the ``mcm_method`` and ``postselect_mode`` arguments.
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -149,6 +149,9 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* `qml.noise` is still using `MeasurementProcess.return_type` which was deprecated. Replaced the problematic parts with equivalent code.
+  [(#6906)](https://github.com/PennyLaneAI/pennylane/pull/6906)
+
 * The interface is now detected from the data in the circuit, not the arguments to the `QNode`. This allows
   interface data to be strictly passed as closure variables and still be detected.
   [(#6892)](https://github.com/PennyLaneAI/pennylane/pull/6892)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -117,6 +117,11 @@
   [(#6822)](https://github.com/PennyLaneAI/pennylane/pull/6822)
   [(#6879)](https://github.com/PennyLaneAI/pennylane/pull/6879)
 
+* The property `MeasurementProcess.return_type` has been deprecated.
+  If observable type checking is needed, please use direct `isinstance`; if other text information is needed, please use class name, or another internal temporary private member `_shortname`.
+  [(#6841)](https://github.com/PennyLaneAI/pennylane/pull/6841)
+  [(#6906)](https://github.com/PennyLaneAI/pennylane/pull/6906)
+
 <h3>Internal changes ⚙️</h3>
 
 * The source code has been updated use black 25.1.0
@@ -148,9 +153,6 @@
   [(#6858)](https://github.com/PennyLaneAI/pennylane/pull/6858)
 
 <h3>Bug fixes 🐛</h3>
-
-* `qml.noise` is still using `MeasurementProcess.return_type` which was deprecated. Replaced the problematic parts with equivalent code.
-  [(#6906)](https://github.com/PennyLaneAI/pennylane/pull/6906)
 
 * The interface is now detected from the data in the circuit, not the arguments to the `QNode`. This allows
   interface data to be strictly passed as closure variables and still be detected.

--- a/pennylane/noise/conditionals.py
+++ b/pennylane/noise/conditionals.py
@@ -21,8 +21,7 @@ from inspect import isclass, signature
 
 import pennylane as qml
 from pennylane.boolean_fn import BooleanFn
-from pennylane.measurements import (MeasurementProcess, MeasurementValue,
-                                    MidMeasureMP)
+from pennylane.measurements import MeasurementProcess, MeasurementValue, MidMeasureMP
 from pennylane.operation import AnyWires
 from pennylane.ops import Adjoint, Controlled
 from pennylane.templates import ControlledSequence

--- a/pennylane/noise/conditionals.py
+++ b/pennylane/noise/conditionals.py
@@ -489,7 +489,7 @@ class MeasEq(qml.BooleanFn):
             self.condition.append(mp)
             self._cmps.append(mp if isclass(mp) else mp.__class__)
 
-        mp_ops = list(op._shortname if op._shortname else op.__class__.__name__ for op in self.condition) # pylint: disable=protected_access
+        mp_ops = list(op._shortname or op.__class__.__name__ for op in self.condition) # pylint: disable=protected_access
         mp_names = [
             repr(op) if not isinstance(op, property) else repr(self.condition[idx].__name__)
             for idx, op in enumerate(mp_ops)

--- a/pennylane/noise/conditionals.py
+++ b/pennylane/noise/conditionals.py
@@ -488,7 +488,6 @@ class MeasEq(qml.BooleanFn):
                 )
             self.condition.append(mp)
             self._cmps.append(mp if isclass(mp) else mp.__class__)
-            
         mp_ops = list(op._shortname if op._shortname else op.__class__.__name__ for op in self.condition) # pylint: disable=protected_access
         mp_names = [
             repr(op) if not isinstance(op, property) else repr(self.condition[idx].__name__)

--- a/pennylane/noise/conditionals.py
+++ b/pennylane/noise/conditionals.py
@@ -21,7 +21,8 @@ from inspect import isclass, signature
 
 import pennylane as qml
 from pennylane.boolean_fn import BooleanFn
-from pennylane.measurements import MeasurementProcess, MeasurementValue, MidMeasureMP
+from pennylane.measurements import (MeasurementProcess, MeasurementValue,
+                                    MidMeasureMP)
 from pennylane.operation import AnyWires
 from pennylane.ops import Adjoint, Controlled
 from pennylane.templates import ControlledSequence
@@ -490,7 +491,7 @@ class MeasEq(qml.BooleanFn):
             self._cmps.append(mp if isclass(mp) else mp.__class__)
 
         mp_ops = list(
-            op._shortname or op.__class__.__name__ for op in self.condition
+            getattr(op, "_shortname", op.__class__.__name__) for op in self.condition
         )  # pylint: disable=protected_access
         mp_names = [
             repr(op) if not isinstance(op, property) else repr(self.condition[idx].__name__)

--- a/pennylane/noise/conditionals.py
+++ b/pennylane/noise/conditionals.py
@@ -489,7 +489,9 @@ class MeasEq(qml.BooleanFn):
             self.condition.append(mp)
             self._cmps.append(mp if isclass(mp) else mp.__class__)
 
-        mp_ops = list(op._shortname or op.__class__.__name__ for op in self.condition) # pylint: disable=protected_access
+        mp_ops = list(
+            op._shortname or op.__class__.__name__ for op in self.condition
+        )  # pylint: disable=protected_access
         mp_names = [
             repr(op) if not isinstance(op, property) else repr(self.condition[idx].__name__)
             for idx, op in enumerate(mp_ops)

--- a/pennylane/noise/conditionals.py
+++ b/pennylane/noise/conditionals.py
@@ -488,6 +488,7 @@ class MeasEq(qml.BooleanFn):
                 )
             self.condition.append(mp)
             self._cmps.append(mp if isclass(mp) else mp.__class__)
+
         mp_ops = list(op._shortname if op._shortname else op.__class__.__name__ for op in self.condition) # pylint: disable=protected_access
         mp_names = [
             repr(op) if not isinstance(op, property) else repr(self.condition[idx].__name__)

--- a/pennylane/noise/conditionals.py
+++ b/pennylane/noise/conditionals.py
@@ -488,8 +488,8 @@ class MeasEq(qml.BooleanFn):
                 )
             self.condition.append(mp)
             self._cmps.append(mp if isclass(mp) else mp.__class__)
-
-        mp_ops = list(getattr(op, "return_type", op.__class__.__name__) for op in self.condition)
+            
+        mp_ops = list(op._shortname if op._shortname else op.__class__.__name__ for op in self.condition) # pylint: disable=protected_access
         mp_names = [
             repr(op) if not isinstance(op, property) else repr(self.condition[idx].__name__)
             for idx, op in enumerate(mp_ops)

--- a/pennylane/noise/conditionals.py
+++ b/pennylane/noise/conditionals.py
@@ -489,6 +489,7 @@ class MeasEq(qml.BooleanFn):
             self.condition.append(mp)
             self._cmps.append(mp if isclass(mp) else mp.__class__)
 
+        # Temporrary fix from PR6906, Should be refactored in 0.42
         mp_ops = list(
             getattr(op, "_shortname", op.__class__.__name__) for op in self.condition
         )  # pylint: disable=protected_access


### PR DESCRIPTION
**Context:**
A recently merged PR to deprecate `MP.return_type` missed a line that exists inside `pennylane/noise`, which caused GPU tests failure.

**Description of the Change:**
Fixing it in the most straightforward way, replacing the `return_type` with the in-use private attribute `_shortname` that carries the same info. This should be refactored in next cycle.

**Benefits:**
Bug fix

**Possible Drawbacks:**
None

**Related GitHub Issues:**
