### PR TITLE
Pin `pyzx==0.8.0` in CI

### DIFF
--- a/.github/workflows/interface-unit-tests.yml
+++ b/.github/workflows/interface-unit-tests.yml
@@ -465,7 +465,7 @@ jobs:
       pytest_markers: external
       pytest_additional_args: -W ${{ inputs.python_warning_level }} ${{ inputs.python_warning_level != 'default' && '--continue-on-collection-errors' || '' }}
       additional_pip_packages: |
-        pyzx matplotlib stim quimb mitiq ply optax scipy-openblas32>=0.3.26
+        pyzx==0.8.0 matplotlib stim quimb mitiq ply optax scipy-openblas32>=0.3.26
         git+https://github.com/PennyLaneAI/pennylane-qiskit.git@master
         ${{ needs.default-dependency-versions.outputs.jax-version }}
         ${{ needs.default-dependency-versions.outputs.tensorflow-version }}


### PR DESCRIPTION
Pinning `pyzx` to version `0.8.0` in the workflow file since version `0.9.0` (released on 2025-01-30) broke our CI.
