### PR TITLE
Clarify "type of measurement process" in the `qml.noise.meas_eq` docstring

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -253,6 +253,9 @@
 * Fixed a typo in the code example for `qml.labs.dla.lie_closure_dense`.
   [(#6858)](https://github.com/PennyLaneAI/pennylane/pull/6858)
 
+* The docstring of `qml.noise.meas_eq` has been updated to make its functionality clearer.
+  [(#)](https://github.com/PennyLaneAI/pennylane/pull/)
+
 <h3>Bug fixes 🐛</h3>
 
 * The interface is now detected from the data in the circuit, not the arguments to the `QNode`. This allows

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -254,7 +254,7 @@
   [(#6858)](https://github.com/PennyLaneAI/pennylane/pull/6858)
 
 * The docstring of `qml.noise.meas_eq` has been updated to make its functionality clearer.
-  [(#)](https://github.com/PennyLaneAI/pennylane/pull/)
+  [(#6920)](https://github.com/PennyLaneAI/pennylane/pull/6920)
 
 <h3>Bug fixes 🐛</h3>
 

--- a/pennylane/noise/conditionals.py
+++ b/pennylane/noise/conditionals.py
@@ -466,11 +466,12 @@ def op_eq(ops):
 
 
 class MeasEq(qml.BooleanFn):
-    """A conditional for evaluating if a given measurement process is equal to the specified measurement process.
+    """A conditional for evaluating if a given measurement process is of the same type
+    as the specified measurement process.
 
     Args:
-        mp(Union[Iterable[MeasurementProcess], MeasurementProcess, Callable]): A measurement process instance or
-            a measurement function to build the measurement set.
+        mp(Union[Iterable[MeasurementProcess], MeasurementProcess, Callable]): A measurement
+            process instance or a measurement function to build the measurement set.
 
     .. seealso:: Users are advised to use :func:`~.meas_eq` for a functional construction.
     """

--- a/pennylane/noise/conditionals.py
+++ b/pennylane/noise/conditionals.py
@@ -537,7 +537,7 @@ def meas_eq(mps):
     **Example**
 
     One may use ``meas_eq`` with an instance of
-    :class:`MeasurementProcess <pennylane.operation.MeasurementProcess>`:
+    :class:`MeasurementProcess <pennylane.measurements.MeasurementProcess>`:
 
     >>> cond_func = qml.noise.meas_eq(qml.expval(qml.Y(0)))
     >>> cond_func(qml.expval(qml.Z(9)))

--- a/pennylane/noise/conditionals.py
+++ b/pennylane/noise/conditionals.py
@@ -518,8 +518,8 @@ class MeasEq(qml.BooleanFn):
 
 
 def meas_eq(mps):
-    """Builds a conditional as a :class:`~.BooleanFn` for evaluating
-    if a given measurement process is equal to the specified measurement process.
+    """Builds a conditional as a :class:`~.BooleanFn` for evaluating if a given
+    measurement process is of the same type as the specified measurement process.
 
     Args:
         mps (MeasurementProcess, Callable): An instance(s) of any class that inherits from


### PR DESCRIPTION
**Context:**  `qml.noise.meas_eq` compares the types of measurement processes, neglecting the wires or operator.

**Description of the Change:** Clarifies the `type` of measurement in the docstring

**Benefits:** N/A

**Possible Drawbacks:** N/A

**Related GitHub Issues:** [sc-83710]
