### PR TITLE
[Capture] add `eval_jaxpr` method to `null.qubit`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -151,6 +151,8 @@
 * The `qml.clifford_t_decomposition` has been improved to use less gates when decomposing `qml.PhaseShift`.
   [(#6842)](https://github.com/PennyLaneAI/pennylane/pull/6842)
 
+* `null.qubit` can now execute jaxpr.
+
 <h3>Breaking changes 💔</h3>
 
 * `MultiControlledX` no longer accepts strings as control values.

--- a/pennylane/devices/null_qubit.py
+++ b/pennylane/devices/null_qubit.py
@@ -404,3 +404,17 @@ class NullQubit(Device):
         results = tuple(self._simulate(c, _interface(execution_config)) for c in circuits)
         vjps = tuple(self._vjp(c, _interface(execution_config)) for c in circuits)
         return results, vjps
+
+    def eval_jaxpr(self, jaxpr: "jax.core.Jaxpr", consts: list, *args) -> list:
+        from pennylane.capture.primitives import (  # pylint: disable=import-outside-toplevel
+            AbstractMeasurement,
+        )
+
+        def zeros_like(var):
+            if isinstance(var.aval, AbstractMeasurement):
+                shots = self.shots.total_shots
+                s, dtype = var.aval.abstract_eval(num_device_wires=len(self.wires), shots=shots)
+                return math.zeros(s, dtype=dtype, like="jax")
+            return math.zeros(var.aval.shape, dtype=var.aval.dtype, like="jax")
+
+        return [zeros_like(var) for var in jaxpr.outvars]


### PR DESCRIPTION
**Context:**

I'm starting to some information about the pros and cons of program capture and how to use it.

I'd like to just demonstrate some basics about the classical overheads and scaling, and would like to use null.qubit to do so.

**Description of the Change:**

Adds an `eval_jaxpr` method to `null.qubit`.

**Benefits:**

We can examine the classical overheads associated with null.qubit.

**Possible Drawbacks:**

**Related GitHub Issues:**
