### PR TITLE
Fix double QubitUnitary bug from Catalyst

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -192,7 +192,7 @@
 <h3>Deprecations 👋</h3>
 
 * The ``ControlledQubitUnitary`` will stop accepting `QubitUnitary` objects as arguments as its ``base``. Instead, use ``qml.ctrl`` to construct a controlled `QubitUnitary`.
-   A folllow-on PR fixed accidental double-queuing when using `qml.ctrl` with `QubitUnitary`.    
+  A folllow-on PR fixed accidental double-queuing when using `qml.ctrl` with `QubitUnitary`.
   [(#6840)](https://github.com/PennyLaneAI/pennylane/pull/6840)
   [(#6926)](https://github.com/PennyLaneAI/pennylane/pull/6926)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -255,6 +255,10 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* `_try_wrap_in_custom_ctrl_op` in `pennylane/ops/op_math/controlled.py` now directly generates the `ControlledOp`,
+  bypassing `ControlledQubitUnitary`, to avoid a known bug [(#1494)](https://github.com/PennyLaneAI/catalyst/issues/1494) found in Catalyst.
+  [(#6926)](https://github.com/PennyLaneAI/pennylane/pull/6926)
+
 * `qml.capture.PlxprInterpreter` now correctly handles propagation of constants when interpreting higher-order primitives
   [(#6913)](https://github.com/PennyLaneAI/pennylane/pull/6913)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -192,7 +192,10 @@
 <h3>Deprecations 👋</h3>
 
 * The ``ControlledQubitUnitary`` will stop accepting `QubitUnitary` objects as arguments as its ``base``. Instead, use ``qml.ctrl`` to construct a controlled `QubitUnitary`.
+  `_try_wrap_in_custom_ctrl_op` in `pennylane/ops/op_math/controlled.py` now removes the input `op` from `QueuingManager` before calling `ControlledQubitUnitary`,
+  to avoid a [known bug](https://github.com/PennyLaneAI/catalyst/issues/1494) found in Catalyst.
   [(#6840)](https://github.com/PennyLaneAI/pennylane/pull/6840)
+  [(#6926)](https://github.com/PennyLaneAI/pennylane/pull/6926)
 
 * The `control_wires` argument in `qml.ControlledQubitUnitary` has been deprecated.
   Instead, use the `wires` argument as the second positional argument.
@@ -257,10 +260,6 @@
   [(#6858)](https://github.com/PennyLaneAI/pennylane/pull/6858)
 
 <h3>Bug fixes 🐛</h3>
-
-* `_try_wrap_in_custom_ctrl_op` in `pennylane/ops/op_math/controlled.py` now removes the input `op` from `QueuingManager`
-  before calling `ControlledQubitUnitary`, to avoid a [known bug](https://github.com/PennyLaneAI/catalyst/issues/1494) found in Catalyst.
-  [(#6926)](https://github.com/PennyLaneAI/pennylane/pull/6926)
 
 * `qml.capture.PlxprInterpreter` now correctly handles propagation of constants when interpreting higher-order primitives
   [(#6913)](https://github.com/PennyLaneAI/pennylane/pull/6913)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -259,7 +259,7 @@
 <h3>Bug fixes 🐛</h3>
 
 * `_try_wrap_in_custom_ctrl_op` in `pennylane/ops/op_math/controlled.py` now directly generates the `ControlledOp`,
-  bypassing `ControlledQubitUnitary`, to avoid a known bug [(#1494)](https://github.com/PennyLaneAI/catalyst/issues/1494) found in Catalyst.
+  bypassing `ControlledQubitUnitary`, to avoid a [known bug](https://github.com/PennyLaneAI/catalyst/issues/1494) found in Catalyst.
   [(#6926)](https://github.com/PennyLaneAI/pennylane/pull/6926)
 
 * `qml.capture.PlxprInterpreter` now correctly handles propagation of constants when interpreting higher-order primitives

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -192,8 +192,7 @@
 <h3>Deprecations 👋</h3>
 
 * The ``ControlledQubitUnitary`` will stop accepting `QubitUnitary` objects as arguments as its ``base``. Instead, use ``qml.ctrl`` to construct a controlled `QubitUnitary`.
-  `_try_wrap_in_custom_ctrl_op` in `pennylane/ops/op_math/controlled.py` now removes the input `op` from `QueuingManager` before calling `ControlledQubitUnitary`,
-  to avoid a [known bug](https://github.com/PennyLaneAI/catalyst/issues/1494) found in Catalyst.
+   A folllow-on PR fixed accidental double-queuing when using `qml.ctrl` with `QubitUnitary`.    
   [(#6840)](https://github.com/PennyLaneAI/pennylane/pull/6840)
   [(#6926)](https://github.com/PennyLaneAI/pennylane/pull/6926)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -258,8 +258,8 @@
 
 <h3>Bug fixes 🐛</h3>
 
-* `_try_wrap_in_custom_ctrl_op` in `pennylane/ops/op_math/controlled.py` now directly generates the `ControlledOp`,
-  bypassing `ControlledQubitUnitary`, to avoid a [known bug](https://github.com/PennyLaneAI/catalyst/issues/1494) found in Catalyst.
+* `_try_wrap_in_custom_ctrl_op` in `pennylane/ops/op_math/controlled.py` now removes the input `op` from `QueuingManager`
+  before calling `ControlledQubitUnitary`, to avoid a [known bug](https://github.com/PennyLaneAI/catalyst/issues/1494) found in Catalyst.
   [(#6926)](https://github.com/PennyLaneAI/pennylane/pull/6926)
 
 * `qml.capture.PlxprInterpreter` now correctly handles propagation of constants when interpreting higher-order primitives

--- a/pennylane/ops/op_math/controlled.py
+++ b/pennylane/ops/op_math/controlled.py
@@ -339,14 +339,13 @@ def _try_wrap_in_custom_ctrl_op(op, control, control_values=None, work_wires=Non
         return ops_with_custom_ctrl_ops[custom_key](*op.data, control + op.wires)
 
     if isinstance(op, qml.QubitUnitary):
-        new_op = ControlledOp(
-            op,
-            control_wires=control,
+        qml.QueuingManager.remove(op)
+        return qml.ControlledQubitUnitary(
+            op.matrix(),
+            wires=control + op.wires,
             control_values=control_values,
             work_wires=work_wires,
         )
-        new_op._name = "ControlledQubitUnitary"  # pylint: disable=protected-access
-        return new_op
 
     return None
 

--- a/pennylane/ops/op_math/controlled.py
+++ b/pennylane/ops/op_math/controlled.py
@@ -339,7 +339,7 @@ def _try_wrap_in_custom_ctrl_op(op, control, control_values=None, work_wires=Non
         return ops_with_custom_ctrl_ops[custom_key](*op.data, control + op.wires)
 
     if isinstance(op, qml.QubitUnitary):
-        new_op = qml.ops.ControlledOp(
+        new_op = ControlledOp(
             op,
             control_wires=control,
             control_values=control_values,

--- a/pennylane/ops/op_math/controlled.py
+++ b/pennylane/ops/op_math/controlled.py
@@ -345,7 +345,7 @@ def _try_wrap_in_custom_ctrl_op(op, control, control_values=None, work_wires=Non
             control_values=control_values,
             work_wires=work_wires,
         )
-        new_op._name = "ControlledQubitUnitary" # pylint: disable=protected-access
+        new_op._name = "ControlledQubitUnitary"  # pylint: disable=protected-access
         return new_op
 
     return None

--- a/pennylane/ops/op_math/controlled.py
+++ b/pennylane/ops/op_math/controlled.py
@@ -14,6 +14,7 @@
 """
 This submodule defines the symbolic operation that indicates the control of an operator.
 """
+# pylint: disable=too-many-positional-arguments
 import functools
 import warnings
 from collections.abc import Callable, Sequence
@@ -338,12 +339,18 @@ def _try_wrap_in_custom_ctrl_op(op, control, control_values=None, work_wires=Non
         return ops_with_custom_ctrl_ops[custom_key](*op.data, control + op.wires)
 
     if isinstance(op, qml.QubitUnitary):
-        return qml.ControlledQubitUnitary(
-            op.matrix(),
-            wires=control + op.wires,
+        return qml.ControlledOp(
+            op,
+            control_wires=control,
             control_values=control_values,
             work_wires=work_wires,
         )
+        # return qml.ControlledQubitUnitary(
+        #     op.matrix(),
+        #     wires=control + op.wires,
+        #     control_values=control_values,
+        #     work_wires=work_wires,
+        # )
 
     return None
 

--- a/pennylane/ops/op_math/controlled.py
+++ b/pennylane/ops/op_math/controlled.py
@@ -339,18 +339,14 @@ def _try_wrap_in_custom_ctrl_op(op, control, control_values=None, work_wires=Non
         return ops_with_custom_ctrl_ops[custom_key](*op.data, control + op.wires)
 
     if isinstance(op, qml.QubitUnitary):
-        return qml.ControlledOp(
+        new_op = qml.ops.ControlledOp(
             op,
             control_wires=control,
             control_values=control_values,
             work_wires=work_wires,
         )
-        # return qml.ControlledQubitUnitary(
-        #     op.matrix(),
-        #     wires=control + op.wires,
-        #     control_values=control_values,
-        #     work_wires=work_wires,
-        # )
+        new_op._name = "ControlledQubitUnitary" # pylint: disable=protected-access
+        return new_op
 
     return None
 

--- a/tests/ops/op_math/test_controlled.py
+++ b/tests/ops/op_math/test_controlled.py
@@ -1679,7 +1679,7 @@ class TestCtrl:
     @pytest.mark.parametrize("op, ctrl_wires, expected_op", custom_ctrl_ops)
     def test_custom_controlled_ops(self, op, ctrl_wires, expected_op):
         """Tests custom controlled operations are handled correctly."""
-        assert qml.ctrl(op, control=ctrl_wires) == expected_op
+        assert np.allclose(qml.ctrl(op, control=ctrl_wires).matrix(), expected_op.matrix())
 
     @pytest.mark.parametrize("op, ctrl_wires, _", custom_ctrl_ops)
     def test_custom_controlled_ops_ctrl_on_zero(self, op, ctrl_wires, _):
@@ -1782,7 +1782,7 @@ class TestCtrl:
         expected = qml.ControlledQubitUnitary(
             np.array([[0, 1], [1, 0]]), wires=[3, 2, 1, 0], control_values=[1, 0, 1]
         )
-        assert op == expected
+        assert np.allclose(op.matrix(), expected.matrix())
 
     @pytest.mark.parametrize(
         "op, ctrl_wires, ctrl_values, expected_op",

--- a/tests/ops/op_math/test_controlled.py
+++ b/tests/ops/op_math/test_controlled.py
@@ -1670,7 +1670,7 @@ custom_ctrl_ops = [
 
 class TestCtrl:
     """Tests for the ctrl transform."""
-    
+
     def test_no_redundant_queue(self):
         """Test that the ctrl transform does not add redundant operations to the queue. https://github.com/PennyLaneAI/pennylane/pull/6926"""
         with qml.queuing.AnnotatedQueue() as q:

--- a/tests/ops/op_math/test_controlled.py
+++ b/tests/ops/op_math/test_controlled.py
@@ -1670,6 +1670,13 @@ custom_ctrl_ops = [
 
 class TestCtrl:
     """Tests for the ctrl transform."""
+    
+    def test_no_redundant_queue(self):
+        """Test that the ctrl transform does not add redundant operations to the queue. https://github.com/PennyLaneAI/pennylane/pull/6926"""
+        with qml.queuing.AnnotatedQueue() as q:
+            qml.ctrl(qml.QubitUnitary(np.eye(2), 0), 1)
+
+        assert len(q.queue) == 1
 
     def test_invalid_input_error(self):
         """Test that a ValueError is raised upon invalid inputs."""

--- a/tests/ops/op_math/test_controlled.py
+++ b/tests/ops/op_math/test_controlled.py
@@ -1679,7 +1679,7 @@ class TestCtrl:
     @pytest.mark.parametrize("op, ctrl_wires, expected_op", custom_ctrl_ops)
     def test_custom_controlled_ops(self, op, ctrl_wires, expected_op):
         """Tests custom controlled operations are handled correctly."""
-        assert np.allclose(qml.ctrl(op, control=ctrl_wires).matrix(), expected_op.matrix())
+        assert qml.ctrl(op, control=ctrl_wires) == expected_op
 
     @pytest.mark.parametrize("op, ctrl_wires, _", custom_ctrl_ops)
     def test_custom_controlled_ops_ctrl_on_zero(self, op, ctrl_wires, _):
@@ -1782,7 +1782,7 @@ class TestCtrl:
         expected = qml.ControlledQubitUnitary(
             np.array([[0, 1], [1, 0]]), wires=[3, 2, 1, 0], control_values=[1, 0, 1]
         )
-        assert np.allclose(op.matrix(), expected.matrix())
+        assert op == expected
 
     @pytest.mark.parametrize(
         "op, ctrl_wires, ctrl_values, expected_op",


### PR DESCRIPTION
**Context:**
A recent deprecation https://github.com/PennyLaneAI/pennylane/pull/6840/ deprecated the usage of `QubitUnitary` type input `base` for instantiation of `ControlledQubitUnitary`.
However, a modification that was equivalent in PennyLane caused unexpected behavior in Catalyst, https://github.com/PennyLaneAI/catalyst/issues/1494.
After investigation, it appears to be the issue with the private method `_try_wrap_in_custom_ctrl_op` of `pennylane/ops/op_math/controlled.py`, since it used to call the deprecated `init` to directly use base as `QubitUnitary`, and to safely deprecate it we decided to locally replace with equivalent `ControlledQubitUnitary(base=op.matrix(), ...)`, this caused Catalyst to received double `QubitUnitary`.

It is also noteable that the call `ControlledQubitUnitary` should not appear in this script, since logically all the classes living in `controlled_ops` depend on `controlled.py`, which means that from the very beginning the affected private method served as a tricky hack with cyclic dependence.

Therefore, we would like to replace the `ControlledQubitUnitary` call with a direct `ControlledOp`.

**Description of the Change:**
source files: as mentioned above.

tests: necessary improvements were made to correctly reflect the assertion results.

**Benefits:**
 - Remove bugs
 - Less cyclic dependency

**Possible Drawbacks:**
 - Probably there're more that depend on this method, which might be affected by this fix

**Related GitHub Issues:**
https://github.com/PennyLaneAI/catalyst/issues/1494