### PR TITLE
Update GPU workflow to use the new self-hosted GPU runner infrastructure

### DIFF
--- a/.github/workflows/tests-gpu.yml
+++ b/.github/workflows/tests-gpu.yml
@@ -23,20 +23,21 @@ env:
 jobs:
   gpu-tests:
     runs-on:
-      - self-hosted
-      - ubuntu-22.04
-      - gpu
-
-    if: >-
-      ${{
-        github.event_name == 'push' ||
-        (
-          github.event_name == 'pull_request' &&
-          github.event.pull_request.draft == false &&
-          contains(github.event.pull_request.labels.*.name, 'gpu') &&
-          github.event.pull_request.state == 'open'
-        )
-      }}
+      - single-gpu-x64
+    
+    # Updated so I can test gpu runner while PR is in draft mode
+    if: contains(github.event.pull_request.labels.*.name, 'gpu')
+    
+    # TODO: Revert back to this before merging
+    # ${{
+    #   github.event_name == 'push' ||
+    #   (
+    #     github.event_name == 'pull_request' &&
+    #     github.event.pull_request.draft == false &&
+    #     contains(github.event.pull_request.labels.*.name, 'gpu') &&
+    #     github.event.pull_request.state == 'open'
+    #   )
+    # }}
 
     strategy:
       max-parallel: 2

--- a/.github/workflows/tests-gpu.yml
+++ b/.github/workflows/tests-gpu.yml
@@ -25,19 +25,16 @@ jobs:
     runs-on:
       - single-gpu-x64
     
-    # Updated so I can test gpu runner while PR is in draft mode
-    if: contains(github.event.pull_request.labels.*.name, 'gpu')
-    
-    # TODO: Revert back to this before merging
-    # ${{
-    #   github.event_name == 'push' ||
-    #   (
-    #     github.event_name == 'pull_request' &&
-    #     github.event.pull_request.draft == false &&
-    #     contains(github.event.pull_request.labels.*.name, 'gpu') &&
-    #     github.event.pull_request.state == 'open'
-    #   )
-    # }}
+    if: >-
+      ${{
+        github.event_name == 'push' ||
+        (
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.draft == false &&
+          contains(github.event.pull_request.labels.*.name, 'gpu') &&
+          github.event.pull_request.state == 'open'
+        )
+      }}
 
     strategy:
       max-parallel: 2
@@ -58,13 +55,13 @@ jobs:
           echo "LD_LIBRARY_PATH=/usr/local/cuda/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}" >> $GITHUB_ENV
 
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
       - name: Setup Python
         id: setup_python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
**Context:**
Swap `tests-gpu.yml` to using the new self-hosted GPU runner infrastructure.

**Description of the Change:**

The current GPU tests use runner infrastructure that is quite old and have accumulated a fair amount of technical debt. As part of an overhaul of the infrastructure, net-new instances have been deployed. 

This pull request updates the tests-gpu workflow to use the newly deployed runners.

**IMPORTANT NOTE** Other than the minor change to `runs-on` the backend changes should be transparent for users of pennylane. Any and all behaviors related to gpu workflows should continue working as they are today.

**Benefits:**

Enable us to use newer infrastructure that have non-deprecated runtimes (backend).

**Possible Drawbacks:**

It's possible for a test to fail that used to pass on previous gpu runners. I have taken steps to ensure the build environment between the outgoing runners and incoming runners have as much parity as possible.

Of course, we will ensure the gpu tests pass before merging this PR, but maintainers are encouraged to keep an eye on failing gpu tests over the next couple days to ensure no failures are happening that are specifically related to build environment changes.

**Related GitHub Issues:**
[sc-83176](https://app.shortcut.com/xanaduai/story/83176/investigate-and-try-updating-lambda-runtime-for-pl-runners-pennylane-lightning)