### PR TITLE
Fixes `Wires` objects as wire labels bug

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -266,7 +266,7 @@
 
 <h3>Bug fixes 🐛</h3>
 
-* Fix `qml.wires.Wires` initialization to disallow `Wires` objects as wires labels.
+* Fixed `qml.wires.Wires` initialization to disallow `Wires` objects as wires labels.
   Now, `Wires` is idempotent, e.g. `Wires([Wires([0]), Wires([1])])==Wires([0, 1])`.
   [(#6933)](https://github.com/PennyLaneAI/pennylane/pull/6933)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -227,6 +227,9 @@
 
 <h3>Internal changes ⚙️</h3>
 
+* Fix `qml.wires.Wires` initialization to disallow `Wires` objects as wires labels.
+  [(#6933)](https://github.com/PennyLaneAI/pennylane/pull/6933)
+
 * Remove `QNode.get_gradient_fn` from source code.
   [(#6898)](https://github.com/PennyLaneAI/pennylane/pull/6898)
   

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -230,10 +230,6 @@
 
 <h3>Internal changes ⚙️</h3>
 
-* Fix `qml.wires.Wires` initialization to disallow `Wires` objects as wires labels.
-  Now, `Wires` is idempotent, e.g. `Wires([Wires([0]), Wires([1])])==Wires([0, 1])`.
-  [(#6933)](https://github.com/PennyLaneAI/pennylane/pull/6933)
-
 * Remove `QNode.get_gradient_fn` from source code.
   [(#6898)](https://github.com/PennyLaneAI/pennylane/pull/6898)
   
@@ -269,6 +265,10 @@
   [(#6920)](https://github.com/PennyLaneAI/pennylane/pull/6920)
 
 <h3>Bug fixes 🐛</h3>
+
+* Fix `qml.wires.Wires` initialization to disallow `Wires` objects as wires labels.
+  Now, `Wires` is idempotent, e.g. `Wires([Wires([0]), Wires([1])])==Wires([0, 1])`.
+  [(#6933)](https://github.com/PennyLaneAI/pennylane/pull/6933)
 
 * `qml.capture.PlxprInterpreter` now correctly handles propagation of constants when interpreting higher-order primitives
   [(#6913)](https://github.com/PennyLaneAI/pennylane/pull/6913)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -228,6 +228,7 @@
 <h3>Internal changes ⚙️</h3>
 
 * Fix `qml.wires.Wires` initialization to disallow `Wires` objects as wires labels.
+  Now, `Wires` is idempotent, e.g. `Wires([Wires([0]), Wires([1])])==Wires([0, 1])`.
   [(#6933)](https://github.com/PennyLaneAI/pennylane/pull/6933)
 
 * Remove `QNode.get_gradient_fn` from source code.

--- a/pennylane/wires.py
+++ b/pennylane/wires.py
@@ -93,8 +93,7 @@ def _process(wires):
     if len(set_of_wires) != len(tuple_of_wires):
         raise WireError(f"Wires must be unique; got {wires}.")
 
-    tuple_of_wires = tuple(itertools.chain(*(wire_map(x) for x in tuple_of_wires)))
-    return tuple_of_wires
+    return tuple(itertools.chain(*(wire_map(x) for x in tuple_of_wires)))
 
 
 def wire_map(wires):

--- a/pennylane/wires.py
+++ b/pennylane/wires.py
@@ -93,6 +93,9 @@ def _process(wires):
     if len(set_of_wires) != len(tuple_of_wires):
         raise WireError(f"Wires must be unique; got {wires}.")
 
+    # Tuple of wires are flattened by iterating through each wire label and
+    # checking if it is a Wires object. If so, flatten the Wires object into a tuple of wire labels.
+    # The nested tuple of wires are then stitched together using itertools.chain.
     return tuple(itertools.chain(*(_flatten_wires_object(x) for x in tuple_of_wires)))
 
 

--- a/pennylane/wires.py
+++ b/pennylane/wires.py
@@ -93,14 +93,14 @@ def _process(wires):
     if len(set_of_wires) != len(tuple_of_wires):
         raise WireError(f"Wires must be unique; got {wires}.")
 
-    return tuple(itertools.chain(*(wire_map(x) for x in tuple_of_wires)))
+    return tuple(itertools.chain(*(flatten_wires_object(x) for x in tuple_of_wires)))
 
 
-def wire_map(wires):
+def flatten_wires_object(wire_label):
     """Converts the input to a tuple of wire labels."""
-    if isinstance(wires, Wires):
-        return wires.labels
-    return [wires]
+    if isinstance(wire_label, Wires):
+        return wire_label.labels
+    return [wire_label]
 
 
 class Wires(Sequence):

--- a/pennylane/wires.py
+++ b/pennylane/wires.py
@@ -96,13 +96,6 @@ def _process(wires):
     return tuple(itertools.chain(*(flatten_wires_object(x) for x in tuple_of_wires)))
 
 
-def flatten_wires_object(wire_label):
-    """Converts the input to a tuple of wire labels."""
-    if isinstance(wire_label, Wires):
-        return wire_label.labels
-    return [wire_label]
-
-
 class Wires(Sequence):
     r"""
     A bookkeeping class for wires, which are ordered collections of unique objects.
@@ -737,6 +730,14 @@ class Wires(Sequence):
 
 
 WiresLike = Union[Wires, Iterable[Hashable], Hashable]
+
+
+def flatten_wires_object(wire_label):
+    """Converts the input to a tuple of wire labels."""
+    if isinstance(wire_label, Wires):
+        return wire_label.labels
+    return [wire_label]
+
 
 # Register Wires as a PyTree-serializable class
 register_pytree(Wires, Wires._flatten, Wires._unflatten)  # pylint: disable=protected-access

--- a/pennylane/wires.py
+++ b/pennylane/wires.py
@@ -93,7 +93,7 @@ def _process(wires):
     if len(set_of_wires) != len(tuple_of_wires):
         raise WireError(f"Wires must be unique; got {wires}.")
 
-    return tuple(itertools.chain(*(flatten_wires_object(x) for x in tuple_of_wires)))
+    return tuple(itertools.chain(*(_flatten_wires_object(x) for x in tuple_of_wires)))
 
 
 class Wires(Sequence):
@@ -732,7 +732,7 @@ class Wires(Sequence):
 WiresLike = Union[Wires, Iterable[Hashable], Hashable]
 
 
-def flatten_wires_object(wire_label):
+def _flatten_wires_object(wire_label):
     """Converts the input to a tuple of wire labels."""
     if isinstance(wire_label, Wires):
         return wire_label.labels

--- a/pennylane/wires.py
+++ b/pennylane/wires.py
@@ -93,8 +93,15 @@ def _process(wires):
     if len(set_of_wires) != len(tuple_of_wires):
         raise WireError(f"Wires must be unique; got {wires}.")
 
-    tuple_of_wires = tuple(qml.pytrees.flatten(tuple(wires), is_leaf=lambda x: False)[0])
+    tuple_of_wires = tuple(itertools.chain(*(wire_map(x) for x in tuple_of_wires)))
     return tuple_of_wires
+
+
+def wire_map(wires):
+    """Converts the input to a tuple of wire labels."""
+    if isinstance(wires, Wires):
+        return wires.labels
+    return [wires]
 
 
 class Wires(Sequence):
@@ -121,7 +128,7 @@ class Wires(Sequence):
     """
 
     def _flatten(self):
-        """Serialize Wires into a flattened representation according to the PyTree convension."""
+        """Serialize Wires into a flattened representation according to the PyTree convention."""
         return self._labels, ()
 
     @classmethod
@@ -156,7 +163,6 @@ class Wires(Sequence):
     def contains_wires(self, wires):
         """Method to determine if Wires object contains wires in another Wires object."""
         if isinstance(wires, Wires):
-            wires = Wires(tuple(qml.pytrees.flatten(tuple(wires), is_leaf=lambda x: False)[0]))
             return set(wires.labels).issubset(set(self._labels))
         return False
 

--- a/pennylane/wires.py
+++ b/pennylane/wires.py
@@ -93,9 +93,7 @@ def _process(wires):
     if len(set_of_wires) != len(tuple_of_wires):
         raise WireError(f"Wires must be unique; got {wires}.")
 
-    # Tuple of wires are flattened by iterating through each wire label and
-    # checking if it is a Wires object. If so, flatten the Wires object into a tuple of wire labels.
-    # The nested tuple of wires are then stitched together using itertools.chain.
+    # required to make `Wires` object idempotent
     return tuple(itertools.chain(*(_flatten_wires_object(x) for x in tuple_of_wires)))
 
 

--- a/pennylane/wires.py
+++ b/pennylane/wires.py
@@ -93,6 +93,7 @@ def _process(wires):
     if len(set_of_wires) != len(tuple_of_wires):
         raise WireError(f"Wires must be unique; got {wires}.")
 
+    tuple_of_wires = tuple(qml.pytrees.flatten(tuple(wires), is_leaf=lambda x: False)[0])
     return tuple_of_wires
 
 
@@ -155,6 +156,7 @@ class Wires(Sequence):
     def contains_wires(self, wires):
         """Method to determine if Wires object contains wires in another Wires object."""
         if isinstance(wires, Wires):
+            wires = Wires(tuple(qml.pytrees.flatten(tuple(wires), is_leaf=lambda x: False)[0]))
             return set(wires.labels).issubset(set(self._labels))
         return False
 

--- a/tests/test_wires.py
+++ b/tests/test_wires.py
@@ -34,6 +34,11 @@ else:
 class TestWires:
     """Tests for the ``Wires`` class."""
 
+    def test_wires_object_as_label(self):
+        """Tests that a Wires object can be used as a label for another Wires object."""
+        assert Wires([0, 1]) == Wires([Wires([0]), Wires([1])])
+        assert Wires(["a", "b", 1]) == Wires([Wires(["a", "b"]), Wires([1])])
+
     def test_error_if_wires_none(self):
         """Tests that a TypeError is raised if None is given as wires."""
         with pytest.raises(TypeError, match="Must specify a set of wires."):

--- a/tests/test_wires.py
+++ b/tests/test_wires.py
@@ -74,7 +74,7 @@ class TestWires:
         """Tests that a Wires object can be created from a list of Wires."""
 
         wires = Wires([Wires([0]), Wires([1]), Wires([2])])
-        assert wires.labels == (Wires([0]), Wires([1]), Wires([2]))
+        assert wires.labels == (0, 1, 2)
 
     @pytest.mark.parametrize(
         "iterable", [[1, 0, 4], ["a", "b", "c"], [0, 1, None], ["a", 1, "ancilla"]]
@@ -148,7 +148,7 @@ class TestWires:
         wires = Wires([0, 1, 2, 3, Wires([4, 5]), None])
 
         assert 0 in wires
-        assert Wires([4, 5]) in wires
+        assert Wires([4, 5]) not in wires
         assert None in wires
         assert Wires([1]) not in wires
         assert Wires([0, 3]) not in wires
@@ -170,7 +170,7 @@ class TestWires:
 
         assert not wires.contains_wires(0)  # wrong type
         assert not wires.contains_wires([0, 1])  # wrong type
-        assert not wires.contains_wires(
+        assert wires.contains_wires(
             Wires([4, 5])
         )  # looks up 4 and 5 in wires, which are not present
 

--- a/tests/test_wires.py
+++ b/tests/test_wires.py
@@ -38,6 +38,7 @@ class TestWires:
         """Tests that a Wires object can be used as a label for another Wires object."""
         assert Wires([0, 1]) == Wires([Wires([0]), Wires([1])])
         assert Wires(["a", "b", 1]) == Wires([Wires(["a", "b"]), Wires([1])])
+        assert Wires([Wires([(0, 0), (0, 1)])]) == Wires([(0, 0), (0, 1)])
 
     def test_error_if_wires_none(self):
         """Tests that a TypeError is raised if None is given as wires."""


### PR DESCRIPTION
**Context:**

Prior to this PR we had the following behaviour,
```python
a = qml.wires.Wires("a")
b = qml.wires.Wires("b")
wires = [a,b,"c"]

>>> print(qml.wires.Wires(wires))
Wires([Wires(['a']), Wires(['b']), 'c'])

>>> print(qml.wires.Wires([0, 1, 2, 3, qml.wires.Wires([4, 5]), None]))
Wires([0, 1, 2, 3, Wires([4, 5]), None])

>>> print(qml.wires.Wires([qml.wires.Wires([(0,0), (0,1)])]))
Wires([Wires([(0, 0), (0, 1)])])
```

**Description of the Change:**

Add handling to `_process` that dissolves any `Wires` objects that survived to that point. This results in improved behaviour like,
```python
a = qml.wires.Wires("a")
b = qml.wires.Wires("b")
wires = [a,b,"c"]

>>> print(qml.wires.Wires(wires))
Wires(['a', 'b', 'c'])

>>> print(qml.wires.Wires([0, 1, 2, 3, qml.wires.Wires([4, 5]), None]))
Wires([0, 1, 2, 3, 4, 5, None])

>>> print(qml.wires.Wires([qml.wires.Wires([(0,0), (0,1)])]))
Wires([(0, 0), (0, 1)])
```

**Benefits:**

Better visualization of wire objects.

**Possible Drawbacks:** Wire objects will look slightly different depending on your workflow.

**Related GitHub Issues:** Fixes #6669 

[sc-79749]
