### PR TITLE
Add a decomposition for multi-controlled global phases

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -6,6 +6,9 @@
 
 <h3>Improvements 🛠</h3>
 
+* Add a decomposition for multi-controlled global phases into a one-less-controlled phase shift.
+  [(#6936)](https://github.com/PennyLaneAI/pennylane/pull/6936)
+ 
 * Add a `qml.capture.pause()` context manager for pausing program capture in an error-safe way.
   [(#6911)](https://github.com/PennyLaneAI/pennylane/pull/6911)
 
@@ -294,4 +297,5 @@ Pietropaolo Frisoni,
 Marcus Gisslén,
 Christina Lee,
 Mudit Pandey,
-Andrija Paurevic
+Andrija Paurevic,
+David Wierichs

--- a/pennylane/ops/op_math/controlled.py
+++ b/pennylane/ops/op_math/controlled.py
@@ -869,7 +869,7 @@ def _decompose_custom_ops(op: Controlled) -> list["operation.Operator"]:
         phase_shift = qml.PhaseShift(phi=-op.data[0], wires=op.control_wires[-1])
         if len(op.control_wires) > 1:
             phase_shift = ctrl(phase_shift, control=op.control_wires[:-1])
-        return phase_shift
+        return [phase_shift]
 
     # A multi-wire controlled PhaseShift should be decomposed first using the decomposition
     # of ControlledPhaseShift. This is because the decomposition of PhaseShift contains a

--- a/tests/ops/op_math/test_controlled.py
+++ b/tests/ops/op_math/test_controlled.py
@@ -2021,11 +2021,8 @@ class TestTapeExpansionWithControlled:
         ]
 
         assert tape.expand(depth=2).circuit == [
-            qml.ControlledPhaseShift(np.pi / 4, wires=[3, 7]),
-            qml.Toffoli(wires=[3, 7, 0]),
-            qml.ControlledPhaseShift(-np.pi / 4, wires=[3, 0]),
-            qml.Toffoli(wires=[3, 7, 0]),
-            qml.ControlledPhaseShift(np.pi / 4, wires=[3, 0]),
+            Controlled(qml.RZ(np.pi / 2, wires=[0]), control_wires=[3, 7]),
+            Controlled(qml.GlobalPhase(-np.pi / 4, wires=[]), control_wires=[3, 7]),
         ]
 
     def test_adjoint_of_ctrl(self):
@@ -2173,7 +2170,7 @@ class TestTapeExpansionWithControlled:
     @pytest.mark.parametrize(
         "op, params, depth, expected",
         [
-            (qml.templates.QFT, [], 2, 14),
+            (qml.templates.QFT, [], 2, 11),
             (qml.templates.BasicEntanglerLayers, [pnp.ones([3, 2])], 1, 9),
         ],
     )


### PR DESCRIPTION
**Context:**
Currently singly-controlled `GlobalPhase` operations are decomposed into an uncontrolled `PhaseShift` operation.
Multi-controlled `GlobalPhase` operations are decomposed into nothing, raising a warning about this being wrong.

**Description of the Change:**
This PR decomposes multi-controlled `GlobalPhase` operations into one-less-controlled `PhaseShift` operations instead.

**Benefits:**
Correct decomposition

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**


[sc-84163]
