### PR TITLE
add pauli_rep for adjoint op 

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -36,7 +36,7 @@
 <h3>Improvements 🛠</h3>
 
 * `pauli_rep` property is now accessible for `Adjoint` operator when there is a Pauli representation.
-  [(#6876)](https://github.com/PennyLaneAI/pennylane/pull/6876)
+  [(#6871)](https://github.com/PennyLaneAI/pennylane/pull/6871)
 
 * `qml.SWAP` now has sparse representation.
   [(#6965)](https://github.com/PennyLaneAI/pennylane/pull/6965)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -35,7 +35,8 @@
 
 <h3>Improvements 🛠</h3>
 
-* `pauli_rep` property is now accessible for `Adjoint` operator when there is a Pauli representation. [(#6876)](https://github.com/PennyLaneAI/pennylane/pull/6876)
+* `pauli_rep` property is now accessible for `Adjoint` operator when there is a Pauli representation.
+  [(#6876)](https://github.com/PennyLaneAI/pennylane/pull/6876)
 
 * `qml.SWAP` now has sparse representation.
   [(#6965)](https://github.com/PennyLaneAI/pennylane/pull/6965)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -10,6 +10,8 @@
 
 <h3>Improvements 🛠</h3>
 
+* `pauli_rep` property is now accessible for `Adjoint` operator when there is a puali representation. [(#6876)](https://github.com/PennyLaneAI/pennylane/pull/6876)
+
 * `qml.SWAP` now has sparse representation.
   [(#6965)](https://github.com/PennyLaneAI/pennylane/pull/6965)
 
@@ -364,6 +366,7 @@
 This release contains contributions from (in alphabetical order):
 
 Utkarsh Azad,
+Henry Chang,
 Yushao Chen,
 Isaac De Vlugt,
 Diksha Dhawan,

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -35,7 +35,7 @@
 
 <h3>Improvements 🛠</h3>
 
-* `pauli_rep` property is now accessible for `Adjoint` operator when there is a puali representation. [(#6876)](https://github.com/PennyLaneAI/pennylane/pull/6876)
+* `pauli_rep` property is now accessible for `Adjoint` operator when there is a Pauli representation. [(#6876)](https://github.com/PennyLaneAI/pennylane/pull/6876)
 
 * `qml.SWAP` now has sparse representation.
   [(#6965)](https://github.com/PennyLaneAI/pennylane/pull/6965)

--- a/pennylane/ops/op_math/adjoint.py
+++ b/pennylane/ops/op_math/adjoint.py
@@ -356,6 +356,11 @@ class Adjoint(SymbolicOp):
     def __init__(self, base=None, id=None):
         self._name = f"Adjoint({base.name})"
         super().__init__(base, id=id)
+        if self.base.pauli_rep:
+            pr = {pw: qml.math.conjugate(coeff) for pw, coeff in self.base.pauli_rep.items()}
+            self._pauli_rep = qml.pauli.PauliSentence(pr)
+        else:
+            self._pauli_rep = None
 
     def __repr__(self):
         return f"Adjoint({self.base})"

--- a/tests/ops/op_math/test_adjoint.py
+++ b/tests/ops/op_math/test_adjoint.py
@@ -320,6 +320,14 @@ class TestProperties:
         assert op.batch_size == 3
         assert op.ndim_params == (0,)
 
+    def test_pauli_rep(self): 
+        """Test pauli_rep works after adjoint operation."""
+        coeffs = [1-.5j , .2, -3j]
+        paulis = [qml.X(0), qml.Y(0), qml.Z(0)]
+        op = qml.dot(coeffs, paulis)
+        adjoint_ps = qml.adjoint(op).pauli_rep
+        assert (list(adjoint_ps.values()) == qml.math.conjugate(coeffs)).all()
+        assert (qml.adjoint(adjoint_ps.operation()).matrix() == op.matrix()).all()
 
 class TestSimplify:
     """Test Adjoint simplify method and depth property."""

--- a/tests/ops/op_math/test_adjoint.py
+++ b/tests/ops/op_math/test_adjoint.py
@@ -320,14 +320,15 @@ class TestProperties:
         assert op.batch_size == 3
         assert op.ndim_params == (0,)
 
-    def test_pauli_rep(self): 
+    def test_pauli_rep(self):
         """Test pauli_rep works after adjoint operation."""
-        coeffs = [1-.5j , .2, -3j]
+        coeffs = [1 - 0.5j, 0.2, -3j]
         paulis = [qml.X(0), qml.Y(0), qml.Z(0)]
         op = qml.dot(coeffs, paulis)
         adjoint_ps = qml.adjoint(op).pauli_rep
         assert (list(adjoint_ps.values()) == qml.math.conjugate(coeffs)).all()
         assert (qml.adjoint(adjoint_ps.operation()).matrix() == op.matrix()).all()
+
 
 class TestSimplify:
     """Test Adjoint simplify method and depth property."""


### PR DESCRIPTION
**Context:** #6876

**Description of the Change:** add pauli_rep property for adjoint operation

**Benefits:** pauli_rep property is available after adjoint operation

**Possible Drawbacks:** impact downstream functions that relies on pauli_rep 

**Related GitHub Issues:** #6876
