### PR TITLE
Fix `PlxprInterpreter.__call__` to flatten arguments

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -332,6 +332,7 @@
 <h3>Bug fixes 🐛</h3>
 
 * `qml.capture.PlxprInterpreter` now flattens pytree arguments before evaluation.
+  [(#6975)](https://github.com/PennyLaneAI/pennylane/pull/6975)
 
 * `qml.GlobalPhase.sparse_matrix` now correctly returns a sparse matrix of the same shape as `matrix`.
   [(#6940)](https://github.com/PennyLaneAI/pennylane/pull/6940)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -331,6 +331,8 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* `qml.capture.PlxprInterpreter` now flattens pytree arguments before evaluation.
+
 * `qml.GlobalPhase.sparse_matrix` now correctly returns a sparse matrix of the same shape as `matrix`.
   [(#6940)](https://github.com/PennyLaneAI/pennylane/pull/6940)
 

--- a/pennylane/capture/base_interpreter.py
+++ b/pennylane/capture/base_interpreter.py
@@ -396,7 +396,9 @@ class PlxprInterpreter:
         def wrapper(*args, **kwargs):
             with qml.QueuingManager.stop_recording():
                 jaxpr = jax.make_jaxpr(partial(flat_f, **kwargs))(*args)
-            results = self.eval(jaxpr.jaxpr, jaxpr.consts, *args)
+
+            flat_args = jax.tree_util.tree_leaves(args)
+            results = self.eval(jaxpr.jaxpr, jaxpr.consts, *flat_args)
             assert flat_f.out_tree
             # slice out any dynamic shape variables
             results = results[-flat_f.out_tree.num_leaves :]

--- a/tests/capture/test_base_interpreter.py
+++ b/tests/capture/test_base_interpreter.py
@@ -210,6 +210,31 @@ def test_measurement_handling():
     qml.assert_equal(m2, qml.probs(wires=0))
 
 
+def test_call_with_pytree_arguments():
+    """Test that pytree arguments are correctly flattened when calling a
+    decorated function"""
+
+    @PlxprInterpreter()
+    def f(angles):
+        qml.Rot(*angles["1"], 0)
+        qml.Rot(*angles["2"], 0)
+        return qml.state()
+
+    args = ({"1": (1.0, 2.0, 3.0), "2": (4.0, 5.0, 6.0)},)
+    jaxpr = jax.make_jaxpr(f)(*args)
+
+    assert len(jaxpr.jaxpr.invars) == 6
+    expected_primitives = [
+        qml.Rot._primitive,
+        qml.Rot._primitive,
+        qml.measurements.StateMP._wires_primitive,
+    ]
+    assert all(eqn.primitive == ep for eqn, ep in zip(jaxpr.eqns, expected_primitives))
+
+    assert jaxpr.eqns[0].invars[0:3] == jaxpr.jaxpr.invars[0:3]
+    assert jaxpr.eqns[1].invars[0:3] == jaxpr.jaxpr.invars[3:]
+
+
 def test_overriding_measurements():
     """Test usage of an interpreter with a custom way of handling measurements."""
 


### PR DESCRIPTION
**Context:**
`PlxprInterpreter__call__` was not flattening arguments before calling `PlxprInterpreter.eval`, which assumes that the arguments are already flat. This caused failures when using pytree arguments.

**Description of the Change:**
* Flatten arguments in `PlxprInterpreter.__call__` before calling `PlxprInterpreter.eval`.

**Benefits:**
* Correct behaviour of interpreter

**Possible Drawbacks:**

**Related GitHub Issues:**

[sc-84650]