### PR TITLE
Minor performance improvements for DQInterpreter

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -291,6 +291,8 @@
 
 <h3>Internal changes ⚙️</h3>
 
+* Minor changes to `DQInterpreter` for speedups with program capture execution.
+
 * Remove `QNode.get_gradient_fn` from source code.
   [(#6898)](https://github.com/PennyLaneAI/pennylane/pull/6898)
   

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -292,6 +292,7 @@
 <h3>Internal changes ⚙️</h3>
 
 * Minor changes to `DQInterpreter` for speedups with program capture execution.
+  [(#6984)](https://github.com/PennyLaneAI/pennylane/pull/6984)
 
 * Remove `QNode.get_gradient_fn` from source code.
   [(#6898)](https://github.com/PennyLaneAI/pennylane/pull/6898)

--- a/pennylane/devices/qubit/dq_interpreter.py
+++ b/pennylane/devices/qubit/dq_interpreter.py
@@ -66,6 +66,12 @@ class DefaultQubitInterpreter(PlxprInterpreter):
     Array(0.54030231, dtype=float64)
     """
 
+    def __copy__(self):
+        inst = DefaultQubitInterpreter.__new__(DefaultQubitInterpreter)
+        inst.stateref = self.stateref
+        inst.shots = self.shots
+        return inst
+
     def __init__(
         self, num_wires: int, shots: int | None = None, key: None | jax.numpy.ndarray = None
     ):
@@ -82,20 +88,50 @@ class DefaultQubitInterpreter(PlxprInterpreter):
         self.stateref = None
         super().__init__()
 
-    def __getattr__(self, key):
-        if key in {"state", "key", "is_state_batched"}:
-            if self.stateref is None:
-                raise AttributeError("execution not yet initialized.")
-            return self.stateref[key]
-        raise AttributeError(f"No attribute {key}")
+    @property
+    def state(self):
+        """The statevector"""
+        try:
+            return self.stateref["state"]
+        except TypeError as e:
+            raise AttributeError("execution not yet initialized.") from e
 
-    def __setattr__(self, __name: str, __value) -> None:
-        if __name in {"state", "key", "is_state_batched"}:
-            if self.stateref is None:
-                raise AttributeError("execution not yet initialized")
-            self.stateref[__name] = __value
-        else:
-            super().__setattr__(__name, __value)
+    @state.setter
+    def state(self, new_val):
+        try:
+            self.stateref["state"] = new_val
+        except TypeError as e:
+            raise AttributeError("execution not yet initialized.") from e
+
+    @property
+    def key(self):
+        """A jax PRNGKey for random number generation."""
+        try:
+            return self.stateref["key"]
+        except TypeError as e:
+            raise AttributeError("execution not yet initialized.") from e
+
+    @key.setter
+    def key(self, new_val):
+        try:
+            self.stateref["key"] = new_val
+        except TypeError as e:
+            raise AttributeError("execution not yet initialized.") from e
+
+    @property
+    def is_state_batched(self) -> bool:
+        """Whether or not the state vector is batched."""
+        try:
+            return self.stateref["is_state_batched"]
+        except TypeError as e:
+            raise AttributeError("execution not yet initialized.") from e
+
+    @is_state_batched.setter
+    def is_state_batched(self, new_val):
+        try:
+            self.stateref["is_state_batched"] = new_val
+        except TypeError as e:
+            raise AttributeError("execution not yet initialized.") from e
 
     def setup(self) -> None:
         if self.stateref is None:

--- a/tests/devices/qubit/test_dq_interpreter.py
+++ b/tests/devices/qubit/test_dq_interpreter.py
@@ -77,7 +77,8 @@ def test_setup_and_cleanup():
     assert dq.stateref is None
 
 
-def test_working_state_key_before_setup():
+@pytest.mark.parametrize("name", ("state", "key", "is_state_batched"))
+def test_working_state_key_before_setup(name):
     """Test that state and key can't be accessed before setup."""
 
     key = jax.random.PRNGKey(9876)
@@ -85,10 +86,10 @@ def test_working_state_key_before_setup():
     dq = DefaultQubitInterpreter(num_wires=1, key=key)
 
     with pytest.raises(AttributeError, match="execution not yet initialized"):
-        dq.state = [1.0, 0.0]
+        setattr(dq, name, [1.0, 0.0])
 
     with pytest.raises(AttributeError, match="execution not yet initialized"):
-        dq.key = jax.random.PRNGKey(8765)
+        getattr(dq, name)
 
 
 def test_simple_execution():


### PR DESCRIPTION
**Context:**

Saw performance numbers demonstrating that flattened control flow was a bit faster than structured control flow. This got me curious and I investigated.  Looking at the profile generated by PyInstrument, I was able to make a couple changes.

![Screenshot 2025-02-20 at 10 21 59 AM](https://github.com/user-attachments/assets/217054d0-f1aa-4146-95cb-9084663cf96a)

**Description of the Change:**

Speed up the copy a little bit by having a manual copy.

Speed up accessing and setting attributes by using manual properties instead of a generic `__getattr__` and `__setattr__`.

**Benefits:**

Performance gets a little bit closer to the flattened version.

![Screenshot 2025-02-20 at 10 18 16 AM](https://github.com/user-attachments/assets/1769e3bf-3de2-4f4b-92e7-03054e178f96)

**Possible Drawbacks:**

The `__getattr__` and `__setattr__` methods were nice and tidy and extensible.

**Related GitHub Issues:**

[sc-84834]