### PR TITLE
Silence all `no-member` pylint warnings from jax

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -10,12 +10,12 @@ extension-pkg-whitelist=numpy,scipy,autograd,toml,appdir,autograd.numpy,autograd
 # (useful for modules/projects where namespaces are manipulated during runtime
 # and thus existing member attributes cannot be deduced by static analysis. It
 # supports qualified module names, as well as Unix pattern matching.
-ignored-modules=numpy,scipy,autograd,toml,appdir,autograd.numpy,autograd.numpy.linalg,autograd.numpy.builtins,packaging,torch,tensorflow,tensorflow.contrib,tensorflow.contrib.eager,LazyLoader,networkx,networkx.dag,math,pennylane.numpy
+ignored-modules=jax,numpy,scipy,autograd,toml,appdir,autograd.numpy,autograd.numpy.linalg,autograd.numpy.builtins,packaging,torch,tensorflow,tensorflow.contrib,tensorflow.contrib.eager,LazyLoader,networkx,networkx.dag,math,pennylane.numpy
 
 # List of classes names for which member attributes should not be checked
 # (useful for classes with attributes dynamically set). This supports can work
 # with qualified names.
-ignored-classes=numpy,scipy,autograd,toml,appdir,autograd.numpy,autograd.numpy.linalg,autograd.numpy.builtins,packaging,torch,tensorflow,tensorflow.contrib,tensorflow.contrib.eager,LazyLoader,networkx,networkx.dag,math,pennylane.numpy,pennylane.numpy.random,pennylane.numpy.linalg,pennylane.numpy.builtins,pennylane.operation,rustworkx,kahypar
+ignored-classes=jax,numpy,scipy,autograd,toml,appdir,autograd.numpy,autograd.numpy.linalg,autograd.numpy.builtins,packaging,torch,tensorflow,tensorflow.contrib,tensorflow.contrib.eager,LazyLoader,networkx,networkx.dag,math,pennylane.numpy,pennylane.numpy.random,pennylane.numpy.linalg,pennylane.numpy.builtins,pennylane.operation,rustworkx,kahypar
 
 [MESSAGES CONTROL]
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -317,6 +317,7 @@
 <h3>Internal changes ⚙️</h3>
 
 * Globally silences `no-member` pylint issues from jax.
+  [(#6987)](https://github.com/PennyLaneAI/pennylane/pull/6987)
 
 * Fix certain `pylint` errors in source code.
   [(#6980)](https://github.com/PennyLaneAI/pennylane/pull/6980)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -316,6 +316,8 @@
 
 <h3>Internal changes ⚙️</h3>
 
+* Globally silences `no-member` pylint issues from jax.
+
 * Fix certain `pylint` errors in source code.
   [(#6980)](https://github.com/PennyLaneAI/pennylane/pull/6980)
 

--- a/pennylane/measurements/mid_measure.py
+++ b/pennylane/measurements/mid_measure.py
@@ -256,11 +256,7 @@ def _create_mid_measure_primitive():
 
     @mid_measure_p.def_abstract_eval
     def _(*_, **__):
-        dtype = (
-            jax.numpy.int64
-            if jax.config.jax_enable_x64  # pylint: disable=no-member
-            else jax.numpy.int32
-        )
+        dtype = jax.numpy.int64 if jax.config.jax_enable_x64 else jax.numpy.int32
         return jax.core.ShapedArray((), dtype)
 
     return mid_measure_p


### PR DESCRIPTION

**Context:**

Jax routinely causes `no-member` pylint issues, and jax is outside our control. We shouldn't care about whether or not jax is setting up modules correctly.

**Description of the Change:**

Silences all `no-member` warnings from jax.

**Benefits:**

Less developer annoyance.

**Possible Drawbacks:**

**Related GitHub Issues:**

[sc-84891]
