### PR TITLE
Fix `too-many-arguments` pylint errors

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -319,7 +319,7 @@
 * Globally silences `no-member` pylint issues from jax.
   [(#6987)](https://github.com/PennyLaneAI/pennylane/pull/6987)
 
-* Fix certain `pylint` errors in source code.
+* Fix `pylint=3.3.4` errors in source code.
   [(#6980)](https://github.com/PennyLaneAI/pennylane/pull/6980)
   [(#6988)](https://github.com/PennyLaneAI/pennylane/pull/6988)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -321,6 +321,7 @@
 
 * Fix certain `pylint` errors in source code.
   [(#6980)](https://github.com/PennyLaneAI/pennylane/pull/6980)
+  [(#6988)](https://github.com/PennyLaneAI/pennylane/pull/6988)
 
 * Remove `QNode.get_gradient_fn` from source code.
   [(#6898)](https://github.com/PennyLaneAI/pennylane/pull/6898)

--- a/pennylane/data/data_manager/progress/_default/__init__.py
+++ b/pennylane/data/data_manager/progress/_default/__init__.py
@@ -108,6 +108,7 @@ class DefaultProgress:
         elif task_id < self._term_info.max_display_lines:
             self._task_display_lines[task_id] = self._get_task_display_line(self.tasks[task_id])
 
+    # pylint: disable = too-many-arguments
     def update(
         self,
         task_id: int,

--- a/pennylane/devices/qubit_mixed/einsum_manpulation.py
+++ b/pennylane/devices/qubit_mixed/einsum_manpulation.py
@@ -72,6 +72,7 @@ def get_einsum_mapping(
     )
 
 
+# pylint: disable=too-many-arguments
 def _map_indices_apply_channel(
     *, state_indices, kraus_index, new_row_indices, row_indices, new_col_indices, col_indices
 ):

--- a/pennylane/optimize/rotosolve.py
+++ b/pennylane/optimize/rotosolve.py
@@ -341,6 +341,7 @@ class RotosolveOptimizer:
         else:
             self.substep_optimizer = substep_optimizer
 
+    # pylint: disable=too-many-arguments
     def step_and_cost(
         self,
         objective_fn,
@@ -502,6 +503,7 @@ class RotosolveOptimizer:
 
         return args, fun_at_zero
 
+    # pylint: disable=too-many-arguments
     def step(
         self,
         objective_fn,

--- a/pennylane/templates/subroutines/trotter.py
+++ b/pennylane/templates/subroutines/trotter.py
@@ -593,6 +593,7 @@ class TrotterizedQfunc(Operation):
 
     """
 
+    # pylint: disable = too-many-arguments
     def __init__(
         self,
         time,


### PR DESCRIPTION
**Context:**

After running the latest `pylint=3.3.4` version on our repository, a few `too-many-arguments` errors were uncovered.

**Description of the Change:**

Suppress the errors.

**Benefits:** Closer to being able to upgrade pylint.

**Possible Drawbacks:** None

[sc-84896]
