### PR TITLE
[tests] Fix compile test which checks for intermediate representation

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -343,6 +343,7 @@
   [(#6882)](https://github.com/PennyLaneAI/pennylane/pull/6882)
 
 * Use `keep_intermediate=True` flag to keep Catalyst's IR when testing.
+  Also use a different way of testing to see if something was compiled.
   [(#6990)](https://github.com/PennyLaneAI/pennylane/pull/6990)
 
 <h3>Documentation 📝</h3>

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -342,6 +342,9 @@
 * The `RiemannianGradientOptimizer` has been updated to take advantage of newer features.
   [(#6882)](https://github.com/PennyLaneAI/pennylane/pull/6882)
 
+* Use `keep_intermediate=True` flag to keep Catalyst's IR when testing.
+  [(#6990)](https://github.com/PennyLaneAI/pennylane/pull/6990)
+
 <h3>Documentation 📝</h3>
 
 * The code example in the docstring for `qml.PauliSentence` now properly copy-pastes.

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -142,9 +142,7 @@ class TestCatalyst:
             return qml.state()
 
         # Check that the compilation happens at definition
-        assert circuit.jaxpr
-        assert circuit.mlir
-        assert circuit.qir
+        assert circuit.compiled_function
 
         result = circuit(0.2j, jnp.array([0.3, 0.6, 0.9]))
         expected = jnp.array(

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -239,7 +239,7 @@ class TestCatalyst:
         """Test user-configurable compilation options"""
         dev = qml.device("lightning.qubit", wires=2)
 
-        @qml.qjit(target="mlir")
+        @qml.qjit(target="mlir", keep_intermediate=True)
         @qml.qnode(dev)
         def circuit(x: float):
             qml.RX(x, wires=0)
@@ -249,6 +249,7 @@ class TestCatalyst:
         mlir_str = str(circuit.mlir)
         result_header = "func.func public @circuit(%arg0: tensor<f64>) -> tensor<f64>"
         assert result_header in mlir_str
+        circuit.workspace.cleanup()
 
     def test_qjit_adjoint(self):
         """Test JIT compilation with adjoint support"""


### PR DESCRIPTION
**Context:** [This PR removes unnecessary IO unless explicitly requested by the user, therefore it breaks tests which check for the IR representation.](https://github.com/PennyLaneAI/catalyst/commit/f1ac6b785b5d0d82d9dd9864afef4d35208695f6)

**Description of the Change:** Use `keep_intermediate=True` to output the representation. Cleans up the workspace after it is done.

**Benefits:** Test passes.

**Possible Drawbacks:** Relies on Catalyst internals.

