### PR TITLE
[WIP] Normalize two_qubit_decomposition for odd CNOTs to preserve determinant 1

### DIFF
--- a/pennylane/ops/op_math/decompositions/two_qubit_unitary.py
+++ b/pennylane/ops/op_math/decompositions/two_qubit_unitary.py
@@ -353,7 +353,10 @@ def _decomposition_1_cnot(U, wires):
     C_ops = one_qubit_decomposition(C, wires[0])
     D_ops = one_qubit_decomposition(D, wires[1])
 
-    return C_ops + D_ops + [qml.CNOT(wires=wires)] + A_ops + B_ops
+    # GlobalPhase added to preserve the determinant 1
+    # (as CNOT has determinant -1, see paragraph below
+    # Lemma II.1 in https://arxiv.org/abs/quant-ph/0308033)
+    return C_ops + D_ops + [qml.CNOT(wires=wires)] + A_ops + B_ops + [qml.GlobalPhase(np.pi / 4)]
 
 
 def _decomposition_2_cnots(U, wires):
@@ -532,7 +535,10 @@ def _decomposition_3_cnots(U, wires):
     D_ops = one_qubit_decomposition(D, wires[1])
 
     # Return the full decomposition
-    return C_ops + D_ops + interior_decomp + A_ops + B_ops
+    # GlobalPhase added to preserve the determinant 1
+    # (as CNOT has determinant -1, see paragraph below
+    # Lemma II.1 in https://arxiv.org/abs/quant-ph/0308033)
+    return C_ops + D_ops + interior_decomp + A_ops + B_ops + [qml.GlobalPhase(np.pi / 4)]
 
 
 def two_qubit_decomposition(U, wires):


### PR DESCRIPTION
The determinant is changed from 1 to -1 when the returned circuit uses an odd number of CNOT gates. This can be normalized by a global phase $\xi^4 = -1$, e.g. $e^{-i \pi /4}$ as indicated in https://arxiv.org/pdf/quant-ph/0308033 in the paragraph below Lemma II.1

~~Not sure we actually want this change, as it adds GlobalPhases that on a quantum computational level don't matter~~
Actually might have implications when doing a controlled op like this, so we should add this.

TODO

- [x] decide if we actually want this, then
- [ ] changelog
- [ ] tests

An alternative approach could be to remove the `_convert_to_su4` step in the first place (not sure this works)