### PR TITLE
[v0.41 Dep & Rmv] Documentation Audit

### DIFF
--- a/doc/development/guide/architecture.rst
+++ b/doc/development/guide/architecture.rst
@@ -114,12 +114,6 @@ which are themselves operators.
 >>> m.obs
 PauliZ(wires=['a'])
 
-Furthermore, it specifies a "return type" which defines the kind of measurement performed,
-such as expectation, variance, probability, state, or sample.
-
->>> m.return_type
-ObservableReturnTypes.Expectation
-
 For more information, check out the documentation on :doc:`measurements </introduction/measurements>`
 
 QuantumTape

--- a/pennylane/ops/op_math/controlled_ops.py
+++ b/pennylane/ops/op_math/controlled_ops.py
@@ -180,7 +180,7 @@ class ControlledQubitUnitary(ControlledOp):
         if hasattr(base, "wires"):
             warnings.warn(
                 "QubitUnitary input to ControlledQubitUnitary is deprecated and will be removed in v0.42. "
-                "Instead, please use a full matrix as input.",
+                "Instead, please use a full matrix as input, or try qml.ctrl for controlled QubitUnitary.",
                 qml.PennyLaneDeprecationWarning,
             )
             base = base.matrix()

--- a/pennylane/workflow/qnode.py
+++ b/pennylane/workflow/qnode.py
@@ -578,7 +578,8 @@ class QNode:
         if kwargs:
             if any(k in qml.gradients.SUPPORTED_GRADIENT_KWARGS for k in list(kwargs.keys())):
                 warnings.warn(
-                    f"Specifying gradient keyword arguments {list(kwargs.keys())} is deprecated and will be removed in v0.42. Instead, please specify all arguments in the gradient_kwargs argument.",
+                    f"Specifying gradient keyword arguments {list(kwargs.keys())} as additional kwargs has been deprecated and will be removed in v0.42. \
+                    Instead, please specify these arguments through the `gradient_kwargs` dictionary argument.",
                     qml.PennyLaneDeprecationWarning,
                 )
             gradient_kwargs |= kwargs

--- a/tests/capture/test_base_interpreter.py
+++ b/tests/capture/test_base_interpreter.py
@@ -143,7 +143,6 @@ def test_default_operator_handling():
 @pytest.mark.parametrize(
     "op_class, args, kwargs",
     [
-        # (qml.ControlledQubitUnitary, (jnp.eye(2), [0, 1]), {}),
         (qml.CH, ([0, 1],), {}),
         (qml.CY, ([0, 1],), {}),
         (qml.CZ, ([0, 1],), {}),

--- a/tests/ops/op_math/test_controlled_ops.py
+++ b/tests/ops/op_math/test_controlled_ops.py
@@ -163,14 +163,14 @@ class TestControlledQubitUnitary:
         """Test that both combinations of control and target wires lead to the same operator"""
         base_op = [[0, 1], [1, 0]]
 
-        control_wires_1, wires_1 = [0, 1], [2]
-        op_1 = qml.ControlledQubitUnitary(base_op, wires=control_wires_1 + wires_1)
+        control_wires_1, target_wires_1 = [0, 1], [2]
+        op_1 = qml.ControlledQubitUnitary(base_op, wires=control_wires_1 + target_wires_1)
 
         assert op_1.base.wires == Wires(2)
         assert op_1.control_wires == Wires([0, 1])
 
-        control_wires_2, wires_2 = [0, 1, 2], ()
-        op_2 = qml.ControlledQubitUnitary(base_op, wires=Wires(control_wires_2) + Wires(wires_2))
+        control_wires_2, target_wires_2 = [0, 1, 2], ()
+        op_2 = qml.ControlledQubitUnitary(base_op, wires=Wires(control_wires_2) + Wires(target_wires_2))
 
         assert op_2.base.wires == Wires(2)
         assert op_2.control_wires == Wires([0, 1])

--- a/tests/ops/op_math/test_controlled_ops.py
+++ b/tests/ops/op_math/test_controlled_ops.py
@@ -170,7 +170,9 @@ class TestControlledQubitUnitary:
         assert op_1.control_wires == Wires([0, 1])
 
         control_wires_2, target_wires_2 = [0, 1, 2], ()
-        op_2 = qml.ControlledQubitUnitary(base_op, wires=Wires(control_wires_2) + Wires(target_wires_2))
+        op_2 = qml.ControlledQubitUnitary(
+            base_op, wires=Wires(control_wires_2) + Wires(target_wires_2)
+        )
 
         assert op_2.base.wires == Wires(2)
         assert op_2.control_wires == Wires([0, 1])

--- a/tests/test_qnode.py
+++ b/tests/test_qnode.py
@@ -43,7 +43,7 @@ def test_additional_kwargs_is_deprecated():
 
     with pytest.warns(
         qml.PennyLaneDeprecationWarning,
-        match=r"Specifying gradient keyword arguments \[\'atol\'\] is deprecated",
+        match=r"Specifying gradient keyword arguments \[\'atol\'\] as additional kwargs has been deprecated",
     ):
         QNode(dummyfunc, dev, atol=1)
 

--- a/tests/transforms/test_qmc_transform.py
+++ b/tests/transforms/test_qmc_transform.py
@@ -148,7 +148,7 @@ class TestApplyControlledQ:
         a_mat and r_mat."""
         n_all_wires = n_wires + 1
 
-        target_wires = range(n_wires)
+        wires = range(n_wires)
         target_wire = n_wires - 1
         control_wire = n_wires
 
@@ -157,22 +157,16 @@ class TestApplyControlledQ:
         q_mat = make_Q(a_mat, r_mat)
 
         def fn():
-            qml.QubitUnitary(a_mat, wires=target_wires[:-1])
-            qml.QubitUnitary(r_mat, wires=target_wires)
+            qml.QubitUnitary(a_mat, wires=wires[:-1])
+            qml.QubitUnitary(r_mat, wires=wires)
 
         circ = apply_controlled_Q(
-            fn,
-            wires=target_wires,
-            target_wire=target_wire,
-            control_wire=control_wire,
-            work_wires=None,
+            fn, wires=wires, target_wire=target_wire, control_wire=control_wire, work_wires=None
         )
 
         u = get_unitary(circ, n_all_wires)
 
-        circ = lambda: qml.ControlledQubitUnitary(
-            q_mat, wires=Wires(control_wire) + Wires(target_wires)
-        )
+        circ = lambda: qml.ControlledQubitUnitary(q_mat, wires=Wires(control_wire) + Wires(wires))
         u_ideal = get_unitary(circ, n_all_wires)
 
         assert np.allclose(u_ideal, u)

--- a/tests/transforms/test_qmc_transform.py
+++ b/tests/transforms/test_qmc_transform.py
@@ -161,12 +161,18 @@ class TestApplyControlledQ:
             qml.QubitUnitary(r_mat, wires=target_wires)
 
         circ = apply_controlled_Q(
-            fn, wires=target_wires, target_wire=target_wire, control_wire=control_wire, work_wires=None
+            fn,
+            wires=target_wires,
+            target_wire=target_wire,
+            control_wire=control_wire,
+            work_wires=None,
         )
 
         u = get_unitary(circ, n_all_wires)
 
-        circ = lambda: qml.ControlledQubitUnitary(q_mat, wires=Wires(control_wire) + Wires(target_wires))
+        circ = lambda: qml.ControlledQubitUnitary(
+            q_mat, wires=Wires(control_wire) + Wires(target_wires)
+        )
         u_ideal = get_unitary(circ, n_all_wires)
 
         assert np.allclose(u_ideal, u)

--- a/tests/transforms/test_qmc_transform.py
+++ b/tests/transforms/test_qmc_transform.py
@@ -96,12 +96,12 @@ def test_apply_controlled_z(n_wires):
     unitary and comparing against the one provided in _make_Z."""
     n_all_wires = n_wires + 1
 
-    wires = Wires(range(n_wires))
+    target_wires = Wires(range(n_wires))
     control_wire = n_wires
     work_wires = None
 
     circ = lambda: _apply_controlled_z(
-        wires=wires, control_wire=control_wire, work_wires=work_wires
+        wires=target_wires, control_wire=control_wire, work_wires=work_wires
     )
     u = get_unitary(circ, n_all_wires)
 
@@ -109,7 +109,7 @@ def test_apply_controlled_z(n_wires):
     # because two Zs are used.
     z_ideal = -_make_Z(2**n_wires)
 
-    circ = lambda: qml.ControlledQubitUnitary(z_ideal, wires=control_wire + wires)
+    circ = lambda: qml.ControlledQubitUnitary(z_ideal, wires=control_wire + target_wires)
     u_ideal = get_unitary(circ, n_all_wires)
 
     assert np.allclose(u, u_ideal)
@@ -121,7 +121,7 @@ def test_apply_controlled_v(n_wires):
     unitary and comparing against the one provided in _make_V."""
     n_all_wires = n_wires + 1
 
-    wires = Wires(range(n_wires))
+    target_wires = Wires(range(n_wires))
     control_wire = Wires(n_wires)
 
     circ = lambda: _apply_controlled_v(target_wire=Wires([n_wires - 1]), control_wire=control_wire)
@@ -131,7 +131,7 @@ def test_apply_controlled_v(n_wires):
     # because two Vs are used.
     v_ideal = -_make_V(2**n_wires)
 
-    circ = lambda: qml.ControlledQubitUnitary(v_ideal, wires=control_wire + wires)
+    circ = lambda: qml.ControlledQubitUnitary(v_ideal, wires=control_wire + target_wires)
     u_ideal = get_unitary(circ, n_all_wires)
 
     assert np.allclose(u, u_ideal)
@@ -148,7 +148,7 @@ class TestApplyControlledQ:
         a_mat and r_mat."""
         n_all_wires = n_wires + 1
 
-        wires = range(n_wires)
+        target_wires = range(n_wires)
         target_wire = n_wires - 1
         control_wire = n_wires
 
@@ -157,16 +157,16 @@ class TestApplyControlledQ:
         q_mat = make_Q(a_mat, r_mat)
 
         def fn():
-            qml.QubitUnitary(a_mat, wires=wires[:-1])
-            qml.QubitUnitary(r_mat, wires=wires)
+            qml.QubitUnitary(a_mat, wires=target_wires[:-1])
+            qml.QubitUnitary(r_mat, wires=target_wires)
 
         circ = apply_controlled_Q(
-            fn, wires=wires, target_wire=target_wire, control_wire=control_wire, work_wires=None
+            fn, wires=target_wires, target_wire=target_wire, control_wire=control_wire, work_wires=None
         )
 
         u = get_unitary(circ, n_all_wires)
 
-        circ = lambda: qml.ControlledQubitUnitary(q_mat, wires=Wires(control_wire) + Wires(wires))
+        circ = lambda: qml.ControlledQubitUnitary(q_mat, wires=Wires(control_wire) + Wires(target_wires))
         u_ideal = get_unitary(circ, n_all_wires)
 
         assert np.allclose(u_ideal, u)


### PR DESCRIPTION
**Context:**

This release had some rather large scope deprecations and removals. This PR aims to address any potential fuzz that was accidentally missed in the source code.

**Description of the Change:**

This PR includes minor adjustments to the deprecation message for,
- `gradient_kwargs` to the `QNode`
- Controlled qubit unitary arguments

**Benefits:** Cleaner code.

**Possible Drawbacks:** None identified.

[sc-82824]
