### PR TITLE
Deprecate pipeline=None with qml.compile

### DIFF
--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -9,6 +9,11 @@ deprecations are listed below.
 Pending deprecations
 --------------------
 
+* Specifying ``pipeline=None`` with ``qml.compile`` is now deprecated.
+
+  - Deprecated in v0.41
+  - Will be removed in v0.42
+
 * The ``ControlledQubitUnitary`` will stop accepting `QubitUnitary` objects as arguments as its ``base``. Instead, use ``qml.ctrl`` to construct a controlled `QubitUnitary`.
 
   - Deprecated in v0.41

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -301,6 +301,9 @@
 
 <h3>Deprecations 👋</h3>
 
+* Specifying `pipeline=None` with `qml.compile` is now deprecated. A sequence of
+  transforms should always be specified.
+
 * The ``ControlledQubitUnitary`` will stop accepting `QubitUnitary` objects as arguments as its ``base``. Instead, use ``qml.ctrl`` to construct a controlled `QubitUnitary`.
   A folllow-on PR fixed accidental double-queuing when using `qml.ctrl` with `QubitUnitary`.
   [(#6840)](https://github.com/PennyLaneAI/pennylane/pull/6840)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -303,6 +303,7 @@
 
 * Specifying `pipeline=None` with `qml.compile` is now deprecated. A sequence of
   transforms should always be specified.
+  [(#7004)](https://github.com/PennyLaneAI/pennylane/pull/7004)
 
 * The ``ControlledQubitUnitary`` will stop accepting `QubitUnitary` objects as arguments as its ``base``. Instead, use ``qml.ctrl`` to construct a controlled `QubitUnitary`.
   A folllow-on PR fixed accidental double-queuing when using `qml.ctrl` with `QubitUnitary`.

--- a/tests/transforms/test_compile.py
+++ b/tests/transforms/test_compile.py
@@ -50,6 +50,14 @@ def build_qfunc(wires):
     return qfunc
 
 
+def test_deprecation_pipeline_None():
+    """Test that specifying `pipeline=None` is deprecated."""
+
+    tape = qml.tape.QuantumScript()
+    with pytest.warns(qml.PennyLaneDeprecationWarning, match="pipeline=None is now deprecated"):
+        qml.compile(tape, pipeline=None)
+
+
 class TestCompile:
     """Unit tests for compile function."""
 


### PR DESCRIPTION
**Context:**

Currently, `qml.compile` has a default of `pipeline=None`, where `None` implies `(commute_controlled, cancel_inverses, merge_rotations, remove_barrier)`.  This is confusing, as `None` usually means "nothing".

**Description of the Change:**

Sets the default value to `(commute_controlled, cancel_inverses, merge_rotations, remove_barrier)` and deprecates passing `pipeline=None`.

**Benefits:**

Easier to determine default value from the call siganture.

**Possible Drawbacks:**

Just to make sure this looks good in the docs.

<img width="801" alt="Screenshot 2025-02-25 at 12 03 08 PM" src="https://github.com/user-attachments/assets/c975363a-cb01-442b-9ed7-a0b732800cf0" />

Is a deprecation.

**Related GitHub Issues:**

[sc-85186]
