### PR TITLE
Update how PL is installed

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -132,7 +132,7 @@ jobs:
           done <<< "$ADDITIONAL_OS_PACKAGES"
 
       - name: Upgrade PIP and install wheel
-        run: uv pip install --upgrade pip wheel
+        run: uv pip install --upgrade pip wheel setuptools>=75.8.1
       
       - name: Install PennyLane dependencies
         run: |
@@ -158,7 +158,7 @@ jobs:
         shell: bash
         run: |
           uv build --wheel  
-          uv pip install dist/PennyLane*.whl
+          uv pip install dist/pennylane*.whl
 
       - name: Install additional PIP packages (Post PennyLane Install)
         shell: bash


### PR DESCRIPTION
**Context:**
setuptools has had a release recently that normalizes package names:

References:
- pypa/setuptools#4766
- https://packaging.python.org/en/latest/specifications/name-normalization/#name-normalization


**Description of the Change:**
Due setuptools 75.8.0 and 75.8.1 outputting completely different package names, we cannot support both, so CI now "pins" to >=75.8.1.

**Benefits:**
Fix CI failures.

**Possible Drawbacks:**
We may need to update docs.

This is also another situation where moving away from setup.py to pyproject would yield benefits. As then you can specify the minimum setuptools version as part of the build-backend configuration.

**Related GitHub Issues:**
None. [sc-85195](https://app.shortcut.com/xanaduai/story/85195/investigate-issue-with-pennylane-ci-failing-with-uv-build-outputting-package-that-doesn-t-match-name-in-setup-py)