### PR TITLE
Add docs for qml.ftqc module

### DIFF
--- a/doc/code/qml_ftqc.rst
+++ b/doc/code/qml_ftqc.rst
@@ -1,0 +1,12 @@
+qml.ftqc
+========
+
+.. currentmodule:: pennylane.ftqc
+
+.. warning::
+
+    This module is currently experimental and will not maintain API stability between releases.
+
+.. automodapi:: pennylane.ftqc
+    :no-heading:
+    :include-all-objects:

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -228,6 +228,7 @@ PennyLane is **free** and **open source**, released under the Apache License, Ve
 
    code/qml_capture
    code/qml_devices
+   code/qml_ftqc
    code/qml_measurements
    code/qml_pytrees
    code/qml_operation


### PR DESCRIPTION
Adds the `qml.ftqc` module to the docs index so that Sphinx captures the documentation therein.
