### PR TITLE
Remove num_diagonalizing_gates from specs

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -325,6 +325,9 @@
 
 <h3>Breaking changes 💔</h3>
 
+* `num_diagonalizing_gates` is no longer accessible in `qml.specs` or `QuantumScript.specs`. The calculation of
+  this quantity is extremely expensive, and the definition is ambiguous for non-commuting observables.
+
 * `qml.gradients.gradient_transform.choose_trainable_params` has been renamed to `choose_trainable_param_indices`
   to better reflect what it actually does.
   [(#6928)](https://github.com/PennyLaneAI/pennylane/pull/6928)

--- a/pennylane/resource/specs.py
+++ b/pennylane/resource/specs.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Code for resource estimation"""
 import inspect
+from copy import copy
 from typing import Any, Callable, Literal, Union
 
 import pennylane as qml
@@ -66,7 +67,6 @@ def specs(
     {'resources': Resources(num_wires=2, num_gates=98, gate_types=defaultdict(<class 'int'>, {'RX': 1, 'CNOT': 1, 'Exp': 96}), gate_sizes=defaultdict(<class 'int'>, {1: 97, 2: 1}), depth=98, shots=Shots(total_shots=None, shot_vector=())),
     'errors': {'SpectralNormError': SpectralNormError(0.42998560822421455)},
     'num_observables': 1,
-    'num_diagonalizing_gates': 0,
     'num_trainable_params': 1,
     'num_device_wires': 2,
     'num_tape_wires': 2,
@@ -169,7 +169,6 @@ def specs(
         Dictionary keys:
             * ``"num_operations"`` number of operations in the qnode
             * ``"num_observables"`` number of observables in the qnode
-            * ``"num_diagonalizing_gates"`` number of diagonalizing gates required for execution of the qnode
             * ``"resources"``: a :class:`~.resource.Resources` object containing resource quantities used by the qnode
             * ``"errors"``: combined algorithmic errors from the quantum operations executed by the qnode
             * ``"num_used_wires"``: number of wires used by the circuit
@@ -195,13 +194,8 @@ def specs(
 
         for tape in batch:
 
-            program = qml.workflow.get_transform_program(qnode, level=level)
-            (diag_tape,), _ = program((qml.tape.QuantumScript(tape.diagonalizing_gates, []),))
-
-            info = tape.specs.copy()
-
-            info["num_diagonalizing_gates"] = len(diag_tape.operations)
-
+            info = copy(tape.specs)
+            print(info, type(info))
             info["num_device_wires"] = len(qnode.device.wires or tape.wires)
             info["num_tape_wires"] = tape.num_wires
             info["device_name"] = qnode.device.name

--- a/pennylane/tape/qscript.py
+++ b/pennylane/tape/qscript.py
@@ -74,6 +74,21 @@ https://github.com/Qiskit/openqasm/blob/master/examples/stdgates.inc
 QS = TypeVar("QS", bound="QuantumScript")
 
 
+class SpecsDict(dict):
+    """A special dictionary for storing the specs of a circuit. Used to custom KeyError's."""
+
+    def __getitem__(self, __k):
+        if __k == "num_diagonalizing_gates":
+            raise KeyError(
+                "num_diagonalizing_gates is no longer in specs due to the ambiguity of the definition "
+                "and extreme performance costs."
+            )
+        try:
+            return super().__getitem__(__k)
+        except KeyError as e:
+            raise KeyError(f"key {__k} not available. Options are {set(self.keys())}") from e
+
+
 class QuantumScript:
     r"""The operations and measurements that represent instructions for
     execution on a quantum device.
@@ -1102,7 +1117,7 @@ class QuantumScript:
         return self._graph
 
     @property
-    def specs(self) -> dict[str, Any]:
+    def specs(self) -> SpecsDict[str, Any]:
         """Resource information about a quantum circuit.
 
         Returns:
@@ -1134,17 +1149,18 @@ class QuantumScript:
             resources = qml.resource.resource._count_resources(self)
             algo_errors = qml.resource.error._compute_algo_error(self)
 
-            self._specs = {
-                "resources": resources,
-                "errors": algo_errors,
-                "num_observables": len(self.observables),
-                "num_diagonalizing_gates": len(self.diagonalizing_gates),
-                "num_trainable_params": self.num_params,
-            }
+            self._specs = SpecsDict(
+                {
+                    "resources": resources,
+                    "errors": algo_errors,
+                    "num_observables": len(self.observables),
+                    "num_trainable_params": self.num_params,
+                }
+            )
 
         return self._specs
 
-    # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-arguments, too-many-positional-arguments
     def draw(
         self,
         wire_order: Optional[Iterable[Hashable]] = None,

--- a/tests/resource/test_specs.py
+++ b/tests/resource/test_specs.py
@@ -29,6 +29,18 @@ devices_list = [
 ]
 
 
+def test_error_with_bad_key():
+    """Test that a helpful error message is raised if key does not exist."""
+
+    @qml.qnode(qml.device("null.qubit"))
+    def c():
+        return qml.state()
+
+    out = qml.specs(c)()
+    with pytest.raises(KeyError, match="Options are {"):
+        _ = out["bad_value"]
+
+
 class TestSpecsTransform:
     """Tests for the transform specs using the QNode"""
 
@@ -90,7 +102,7 @@ class TestSpecsTransform:
         assert specs1 == specs2
 
     @pytest.mark.parametrize(
-        "diff_method, len_info", [("backprop", 13), ("parameter-shift", 14), ("adjoint", 13)]
+        "diff_method, len_info", [("backprop", 12), ("parameter-shift", 13), ("adjoint", 12)]
     )
     def test_empty(self, diff_method, len_info):
         dev = qml.device("default.qubit", wires=1)
@@ -111,7 +123,6 @@ class TestSpecsTransform:
         expected_resources = qml.resource.Resources(num_wires=1, gate_types=defaultdict(int))
         assert info["resources"] == expected_resources
         assert info["num_observables"] == 1
-        assert info["num_diagonalizing_gates"] == 0
         assert info["num_device_wires"] == 1
         assert info["diff_method"] == diff_method
         assert info["num_trainable_params"] == 0
@@ -123,7 +134,7 @@ class TestSpecsTransform:
             assert info["gradient_fn"] == "pennylane.gradients.parameter_shift.param_shift"
 
     @pytest.mark.parametrize(
-        "diff_method, len_info", [("backprop", 13), ("parameter-shift", 14), ("adjoint", 13)]
+        "diff_method, len_info", [("backprop", 12), ("parameter-shift", 13), ("adjoint", 12)]
     )
     def test_specs(self, diff_method, len_info):
         """Test the specs transforms works in standard situations"""
@@ -154,7 +165,6 @@ class TestSpecsTransform:
         assert info["resources"] == expected_resources
 
         assert info["num_observables"] == 2
-        assert info["num_diagonalizing_gates"] == 1
         assert info["num_device_wires"] == 4
         assert info["diff_method"] == diff_method
         assert info["num_trainable_params"] == 4
@@ -165,7 +175,7 @@ class TestSpecsTransform:
             assert info["num_gradient_executions"] == 6
 
     @pytest.mark.parametrize(
-        "diff_method, len_info", [("backprop", 13), ("parameter-shift", 14), ("adjoint", 13)]
+        "diff_method, len_info", [("backprop", 12), ("parameter-shift", 13), ("adjoint", 12)]
     )
     def test_specs_state(self, diff_method, len_info):
         """Test specs works when state returned"""
@@ -182,7 +192,6 @@ class TestSpecsTransform:
         assert info["resources"] == qml.resource.Resources(gate_types=defaultdict(int))
 
         assert info["num_observables"] == 1
-        assert info["num_diagonalizing_gates"] == 0
         assert info["level"] == "gradient"
 
     def test_level_with_diagonalizing_gates(self):
@@ -214,11 +223,9 @@ class TestSpecsTransform:
 
         specs = qml.specs(circ)()
         assert specs["resources"].num_gates == 1
-        assert specs["num_diagonalizing_gates"] == 1
 
         specs = qml.specs(circ, level="device")()
         assert specs["resources"].num_gates == 3
-        assert specs["num_diagonalizing_gates"] == 3
 
     def test_splitting_transforms(self):
         coeffs = [0.2, -0.543, 0.1]
@@ -248,10 +255,6 @@ class TestSpecsTransform:
         specs_list = qml.specs(circuit, level=2)(pnp.array([1.23, -1]))
 
         assert len(specs_list) == len(H)
-
-        assert specs_list[0]["num_diagonalizing_gates"] == 1
-        assert specs_list[1]["num_diagonalizing_gates"] == 3
-        assert specs_list[2]["num_diagonalizing_gates"] == 4
 
         assert specs_list[0]["num_device_wires"] == specs_list[0]["num_tape_wires"] == 2
         assert specs_list[1]["num_device_wires"] == specs_list[1]["num_tape_wires"] == 3

--- a/tests/tape/test_qscript.py
+++ b/tests/tape/test_qscript.py
@@ -466,10 +466,12 @@ class TestInfomationProperties:
         assert qs.specs["resources"] == qml.resource.Resources()
 
         assert qs.specs["num_observables"] == 0
-        assert qs.specs["num_diagonalizing_gates"] == 0
         assert qs.specs["num_trainable_params"] == 0
 
-        assert len(qs.specs) == 5
+        with pytest.raises(KeyError, match="is no longer in specs"):
+            _ = qs.specs["num_diagonalizing_gates"]
+
+        assert len(qs.specs) == 4
 
         assert qs._specs is qs.specs
 
@@ -481,7 +483,7 @@ class TestInfomationProperties:
         specs = qs.specs
         assert qs._specs is specs
 
-        assert len(specs) == 5
+        assert len(specs) == 4
 
         gate_types = defaultdict(int, {"RX": 2, "Rot": 1, "CNOT": 1})
         gate_sizes = defaultdict(int, {1: 3, 2: 1})
@@ -490,7 +492,6 @@ class TestInfomationProperties:
         )
         assert specs["resources"] == expected_resources
         assert specs["num_observables"] == 2
-        assert specs["num_diagonalizing_gates"] == 1
         assert specs["num_trainable_params"] == 5
 
     @pytest.mark.parametrize(

--- a/tests/tape/test_tape.py
+++ b/tests/tape/test_tape.py
@@ -526,10 +526,9 @@ class TestResourceEstimation:
         assert tape.specs["resources"] == expected_resources
 
         assert tape.specs["num_observables"] == 1
-        assert tape.specs["num_diagonalizing_gates"] == 0
         assert tape.specs["num_trainable_params"] == 0
 
-        assert len(tape.specs) == 5
+        assert len(tape.specs) == 4
 
     def test_specs_tape(self, make_tape):
         """Tests that regular tapes return correct specifications"""
@@ -537,7 +536,7 @@ class TestResourceEstimation:
 
         specs = tape.specs
 
-        assert len(specs) == 5
+        assert len(specs) == 4
 
         gate_sizes = defaultdict(int, {1: 3, 2: 1})
         gate_types = defaultdict(int, {"RX": 2, "Rot": 1, "CNOT": 1})
@@ -546,7 +545,6 @@ class TestResourceEstimation:
         )
         assert specs["resources"] == expected_resources
         assert specs["num_observables"] == 2
-        assert specs["num_diagonalizing_gates"] == 1
         assert specs["num_trainable_params"] == 5
 
     def test_specs_add_to_tape(self, make_extendible_tape):
@@ -555,7 +553,7 @@ class TestResourceEstimation:
         tape = make_extendible_tape
         specs1 = tape.specs
 
-        assert len(specs1) == 5
+        assert len(specs1) == 4
 
         gate_sizes = defaultdict(int, {1: 3, 2: 1})
         gate_types = defaultdict(int, {"RX": 2, "Rot": 1, "CNOT": 1})
@@ -566,7 +564,6 @@ class TestResourceEstimation:
         assert specs1["resources"] == expected_resoures
 
         assert specs1["num_observables"] == 0
-        assert specs1["num_diagonalizing_gates"] == 0
         assert specs1["num_trainable_params"] == 5
 
         with tape as tape:
@@ -577,7 +574,7 @@ class TestResourceEstimation:
 
         specs2 = tape.specs
 
-        assert len(specs2) == 5
+        assert len(specs2) == 4
 
         gate_sizes = defaultdict(int, {1: 4, 2: 2})
         gate_types = defaultdict(int, {"RX": 2, "Rot": 1, "CNOT": 2, "RZ": 1})
@@ -588,7 +585,6 @@ class TestResourceEstimation:
         assert specs2["resources"] == expected_resoures
 
         assert specs2["num_observables"] == 2
-        assert specs2["num_diagonalizing_gates"] == 1
         assert specs2["num_trainable_params"] == 6
 
 


### PR DESCRIPTION
**Context:**

`num_diagonalizing_gates` gets exceedingly expensive for observables that don't have a hard coded diagonalization or belong to subset of easily diagonalizable situations. Therefore we fallback to exact diagonalization, which takes forever and consumes massive amounts of memory.  It's not a lightweight, like most other things in `specs`.

It also isn't even very well defined for composite observables.  What's the "diagonalizing gates" for `X(0) + Y(0)`, especially if the device is going to split it up into two separate executions?

If the device does need to apply the diagonalizing gates, it will apply `split_non_commuting` and `diagoanlize_measurements` as part of its preprocessing, and the diagonalizing gates will be absorbed into the number of operations in the circuit.

**Description of the Change:**

Removes `num_diagonalizing_gates` from `QuantumScript.specs` and `qml.specs`.  This property and function now also return a special `SpecsDict` that raises more informative errors if the user requests either `num_diagonalizing_gates` or some key not present in the dictionary.

**Benefits:**

`specs` is usable for larger problems.

**Possible Drawbacks:**

Someone might have actually been wanting it.

**Related GitHub Issues:**
Fixes #6735 [sc-80996]