### PR TITLE
Try `numpy.linalg.norm` as default function

### DIFF
--- a/pennylane/math/multi_dispatch.py
+++ b/pennylane/math/multi_dispatch.py
@@ -874,7 +874,7 @@ def norm(tensor, like=None, **kwargs):
         norm = _flat_autograd_norm
 
     else:
-        from scipy.linalg import norm
+        from numpy.linalg import norm
 
     return norm(tensor, **kwargs)
 


### PR DESCRIPTION
**Context:**
This PR is for observing what is the impact if we do rely on `numpy.linalg.norm` instead of `scipy.linalg.norm` for our math dispatch.
We realized that it might be `BlockEncode` to be taken care of, but local tests couldn't reveal any breaking. Therefore, we would like to see if it breaks any other.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-86277]