### PR TITLE
[CI] bump `uv` to `v0.6.5` and enable `cache` clean-up

### DIFF
--- a/.github/workflows/tests-gpu.yml
+++ b/.github/workflows/tests-gpu.yml
@@ -92,7 +92,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip wheel setuptools>=75.8.1,<76.0.0
+          python -m pip install --upgrade pip wheel 'setuptools>=75.8.1,<76'
           pip install -r requirements-ci.txt --upgrade
           pip install -r requirements-dev.txt --upgrade
 

--- a/.github/workflows/tests-gpu.yml
+++ b/.github/workflows/tests-gpu.yml
@@ -92,7 +92,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip wheel setuptools>=75.8.1
+          python -m pip install --upgrade pip wheel setuptools>=75.8.1,<76
           pip install -r requirements-ci.txt --upgrade
           pip install -r requirements-dev.txt --upgrade
 

--- a/.github/workflows/tests-gpu.yml
+++ b/.github/workflows/tests-gpu.yml
@@ -92,7 +92,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip wheel 'setuptools>=75.8.1,<76'
+          python -m pip install --upgrade pip wheel 'setuptools==75.8.1'
           pip install -r requirements-ci.txt --upgrade
           pip install -r requirements-dev.txt --upgrade
 

--- a/.github/workflows/tests-gpu.yml
+++ b/.github/workflows/tests-gpu.yml
@@ -92,7 +92,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip wheel setuptools>=75.8.1,<76
+          python -m pip install --upgrade pip wheel setuptools>=75.8.1,<76.0.0
           pip install -r requirements-ci.txt --upgrade
           pip install -r requirements-dev.txt --upgrade
 

--- a/.github/workflows/tests-gpu.yml
+++ b/.github/workflows/tests-gpu.yml
@@ -92,7 +92,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip wheel 'setuptools==75.8.1'
+          python -m pip install --upgrade pip wheel 'setuptools>=75.8.1'
           pip install -r requirements-ci.txt --upgrade
           pip install -r requirements-dev.txt --upgrade
 

--- a/.github/workflows/tests-gpu.yml
+++ b/.github/workflows/tests-gpu.yml
@@ -92,7 +92,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip wheel 'setuptools>=75.8.1'
+          python -m pip install --upgrade pip wheel setuptools>=75.8.1
           pip install -r requirements-ci.txt --upgrade
           pip install -r requirements-dev.txt --upgrade
 

--- a/.github/workflows/tests-gpu.yml
+++ b/.github/workflows/tests-gpu.yml
@@ -122,3 +122,4 @@ jobs:
           rm -rf .gitignore
           rm -rf .github
           pip cache purge
+          uv cache prune --ci

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -132,7 +132,7 @@ jobs:
           done <<< "$ADDITIONAL_OS_PACKAGES"
 
       - name: Upgrade PIP and install wheel
-        run: uv pip install --upgrade pip wheel setuptools>=75.8.1
+        run: uv pip install --upgrade pip wheel setuptools>=75.8.1,<76
       
       - name: Install PennyLane dependencies
         run: |

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -132,7 +132,7 @@ jobs:
           done <<< "$ADDITIONAL_OS_PACKAGES"
 
       - name: Upgrade PIP and install wheel
-        run: uv pip install --upgrade pip wheel setuptools>=75.8.1,<76.0.0
+        run: uv pip install --upgrade pip wheel 'setuptools>=75.8.1,<76'
       
       - name: Install PennyLane dependencies
         run: |

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -132,7 +132,7 @@ jobs:
           done <<< "$ADDITIONAL_OS_PACKAGES"
 
       - name: Upgrade PIP and install wheel
-        run: uv pip install --upgrade pip wheel 'setuptools>=75.8.1'
+        run: uv pip install --upgrade pip wheel setuptools>=75.8.1
       
       - name: Install PennyLane dependencies
         run: |

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -222,3 +222,6 @@ jobs:
         with:
           name: ${{ inputs.coverage_artifact_name }}
           path: coverage.xml
+
+      - name: Minimize uv cache
+        run: uv cache prune --ci

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -26,7 +26,7 @@ on:
         description: The version of uv (docs.astral.sh/uv/) to use to install dependencies
         required: false
         type: string
-        default: 0.5.5
+        default: 0.6.5
       job_runner_name:
         description: The name of the runner to use for the job
         required: false
@@ -132,7 +132,7 @@ jobs:
           done <<< "$ADDITIONAL_OS_PACKAGES"
 
       - name: Upgrade PIP and install wheel
-        run: uv pip install --upgrade pip wheel 'setuptools==75.8.1'
+        run: uv pip install --upgrade pip wheel 'setuptools>=75.8.1'
       
       - name: Install PennyLane dependencies
         run: |

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -132,7 +132,7 @@ jobs:
           done <<< "$ADDITIONAL_OS_PACKAGES"
 
       - name: Upgrade PIP and install wheel
-        run: uv pip install --upgrade pip wheel setuptools>=75.8.1,<76
+        run: uv pip install --upgrade pip wheel setuptools>=75.8.1,<76.0.0
       
       - name: Install PennyLane dependencies
         run: |

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -132,7 +132,7 @@ jobs:
           done <<< "$ADDITIONAL_OS_PACKAGES"
 
       - name: Upgrade PIP and install wheel
-        run: uv pip install --upgrade pip wheel 'setuptools>=75.8.1,<76'
+        run: uv pip install --upgrade pip wheel 'setuptools==75.8.1'
       
       - name: Install PennyLane dependencies
         run: |

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -105,7 +105,7 @@ jobs:
           repository: PennyLaneAI/pennylane
       
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v5
         with:
           version: ${{ inputs.uv_version }}
           enable-cache: true


### PR DESCRIPTION
**Context:**

Encountered CI errors [here](https://github.com/PennyLaneAI/pennylane/actions/runs/13774640399/job/38521082003?pr=7042). After speaking with tools, seems like the issue was cache related.

**Description of the Change:**

Update `uv` version to latest (0.6.5) and enable efficient cache clean-up.

**Benefits:** Un-blocks CI

**Possible Drawbacks:** None identified

[sc-86173]
