### PR TITLE
[CI] Enforce matrix positivity in Denman Beavers iterations tests

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -507,7 +507,7 @@
 
 <h3>Internal changes ⚙️</h3>
 
-* Improve a test `tests/math/test_matrix_manipulation.py::TestDenmanBeaversIterations::test_valid_positive_definite` such that it is more robust.
+* The test for `qml.math.quantum._denman_beavers_iterations` has been improved such that tested random matrices are guaranteed positive.
   [(#7071)](https://github.com/PennyLaneAI/pennylane/pull/7071)
 
 * Replace `matrix_power` dispatch for `scipy` interface with an in-place implementation.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -503,6 +503,9 @@
 
 <h3>Internal changes ⚙️</h3>
 
+* Improve a test `tests/math/test_matrix_manipulation.py::TestDenmanBeaversIterations::test_valid_positive_definite` such that it is more robust.
+  [(#7054)](
+
 * Replace `matrix_power` dispatch for `scipy` interface with an in-place implementation.
   [(#7055)](https://github.com/PennyLaneAI/pennylane/pull/7055)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -39,7 +39,7 @@
       return qml.expval(qml.Z(0))
   ```
 
-* Added class `qml.capture.transforms.UnitaryToRotInterpreter` that decomposes `qml.QubitUnitary` operators 
+* Added class `qml.capture.transforms.UnitaryToRotInterpreter` that decomposes `qml.QubitUnitary` operators
   following the same API as `qml.transforms.unitary_to_rot` when experimental program capture is enabled.
   [(#6916)](https://github.com/PennyLaneAI/pennylane/pull/6916)
   [(#6977)](https://github.com/PennyLaneAI/pennylane/pull/6977)
@@ -53,7 +53,7 @@
 
 <h3>Improvements 🛠</h3>
 
-* The `default.mixed` device now adheres to the newer device API introduced in 
+* The `default.mixed` device now adheres to the newer device API introduced in
   [v0.33](https://docs.pennylane.ai/en/stable/development/release_notes.html#release-0-33-0).
   This means that `default.mixed` now supports not having to specify the number of wires,
   more predictable behaviour with interfaces, support for `qml.Snapshot`, and more.
@@ -130,7 +130,7 @@
 
 * Add a decomposition for multi-controlled global phases into a one-less-controlled phase shift.
   [(#6936)](https://github.com/PennyLaneAI/pennylane/pull/6936)
- 
+
 * `qml.StatePrep` now accepts sparse state vectors. Users can create `StatePrep` using `scipy.sparse.csr_matrix`. Note that non-zero `pad_with` is forbidden.
   [(#6863)](https://github.com/PennyLaneAI/pennylane/pull/6863)
 
@@ -237,7 +237,7 @@
 
 * The `qml.clifford_t_decomposition` has been improved to use less gates when decomposing `qml.PhaseShift`.
   [(#6842)](https://github.com/PennyLaneAI/pennylane/pull/6842)
- 
+
 * `qml.qchem.taper` now handles wire ordering for the tapered observables more robustly.
   [(#6954)](https://github.com/PennyLaneAI/pennylane/pull/6954)
 
@@ -247,12 +247,12 @@
   [(#6938)](https://github.com/PennyLaneAI/pennylane/pull/6938)
   [(#6953)](https://github.com/PennyLaneAI/pennylane/pull/6953)
 
-* A `diagonalize_mcms` transform is added that diagonalizes any `ParametrizedMidMeasure`, for devices 
+* A `diagonalize_mcms` transform is added that diagonalizes any `ParametrizedMidMeasure`, for devices
   that only natively support mid-circuit measurements in the computational basis.
   [(#6938)](https://github.com/PennyLaneAI/pennylane/pull/6938)
 
-* Measurement functions `measure_x`, `measure_y` and `measure_arbitrary_basis` are added in the experimental `ftqc` module. These functions 
-  apply a mid-circuit measurement and return a `MeasurementValue`. They are analogous to `qml.measure` for 
+* Measurement functions `measure_x`, `measure_y` and `measure_arbitrary_basis` are added in the experimental `ftqc` module. These functions
+  apply a mid-circuit measurement and return a `MeasurementValue`. They are analogous to `qml.measure` for
   the computational basis, but instead measure in the X-basis, Y-basis, or an arbitrary basis, respectively.
   Function `qml.ftqc.measure_z` is also added as an alias for `qml.measure`.
   [(#6953)](https://github.com/PennyLaneAI/pennylane/pull/6953)
@@ -291,6 +291,7 @@
       new_tape = tape.copy(operations=operations)
       return [new_tape], lambda res: res[0]
   ```
+
   A requirement for tape transforms to be compatible with program capture is to further decorate QNodes with the experimental
   `qml.capture.expand_plxpr_transforms` decorator.
 
@@ -329,7 +330,7 @@
   [(#6945)](https://github.com/PennyLaneAI/pennylane/pull/6945)
   [(#7020)](https://github.com/PennyLaneAI/pennylane/pull/7020)
 
-* Added class `qml.capture.transforms.CommuteControlledInterpreter` that moves commuting gates past control 
+* Added class `qml.capture.transforms.CommuteControlledInterpreter` that moves commuting gates past control
   and target qubits of controlled operations when experimental program capture is enabled.
   It follows the same API as `qml.transforms.commute_controlled`.
   [(#6946)](https://github.com/PennyLaneAI/pennylane/pull/6946)
@@ -343,7 +344,7 @@
   should be considered static when capturing the quantum program.
   [(#6923)](https://github.com/PennyLaneAI/pennylane/pull/6923)
 
-* A new, experimental `Operator` method called `compute_qfunc_decomposition` has been added to represent decompositions with structure (e.g., control flow). 
+* A new, experimental `Operator` method called `compute_qfunc_decomposition` has been added to represent decompositions with structure (e.g., control flow).
   This method is only used when capture is enabled with `qml.capture.enable()`.
   [(#6859)](https://github.com/PennyLaneAI/pennylane/pull/6859)
   [(#6881)](https://github.com/PennyLaneAI/pennylane/pull/6881)
@@ -356,8 +357,8 @@
   * Add a `qml.capture.pause()` context manager for pausing program capture in an error-safe way.
   [(#6911)](https://github.com/PennyLaneAI/pennylane/pull/6911)
 
-* Python control flow (`if/else`, `for`, `while`) is now supported when program capture is enabled by setting 
-  `autograph=True` at the QNode level. 
+* Python control flow (`if/else`, `for`, `while`) is now supported when program capture is enabled by setting
+  `autograph=True` at the QNode level.
   [(#6837)](https://github.com/PennyLaneAI/pennylane/pull/6837)
 
   ```python
@@ -504,7 +505,7 @@
 <h3>Internal changes ⚙️</h3>
 
 * Improve a test `tests/math/test_matrix_manipulation.py::TestDenmanBeaversIterations::test_valid_positive_definite` such that it is more robust.
-  [(#7054)](
+  [(#7071)](https://github.com/PennyLaneAI/pennylane/pull/7071)
 
 * Replace `matrix_power` dispatch for `scipy` interface with an in-place implementation.
   [(#7055)](https://github.com/PennyLaneAI/pennylane/pull/7055)
@@ -512,17 +513,17 @@
 * Add support to `CollectOpsandMeas` for handling `qnode` primitives.
   [(#6922)](https://github.com/PennyLaneAI/pennylane/pull/6922)
 
-* Change some `scipy` imports from submodules to whole module to reduce memory footprint of importing pennylane. 
+* Change some `scipy` imports from submodules to whole module to reduce memory footprint of importing pennylane.
   [(#7040)](https://github.com/PennyLaneAI/pennylane/pull/7040)
 
 * Add `NotImplementedError`s for `grad` and `jacobian` in `CollectOpsandMeas`.
   [(#7041)](https://github.com/PennyLaneAI/pennylane/pull/7041)
 
-* Quantum transform interpreters now perform argument validation and will no longer 
+* Quantum transform interpreters now perform argument validation and will no longer
   check if the equation in the `jaxpr` is a transform primitive.
   [(#7023)](https://github.com/PennyLaneAI/pennylane/pull/7023)
 
-* `qml.for_loop` and `qml.while_loop` have been moved from the `compiler` module 
+* `qml.for_loop` and `qml.while_loop` have been moved from the `compiler` module
   to a new `control_flow` module.
   [(#7017)](https://github.com/PennyLaneAI/pennylane/pull/7017)
 
@@ -578,7 +579,7 @@
 * Fixed a typo in the code example for `qml.labs.dla.lie_closure_dense`.
   [(#6858)](https://github.com/PennyLaneAI/pennylane/pull/6858)
 
-* The code example in the docstring for `qml.BasisRotation` was corrected by including `wire_order` in the 
+* The code example in the docstring for `qml.BasisRotation` was corrected by including `wire_order` in the
   call to `qml.matrix`.
   [(#6891)](https://github.com/PennyLaneAI/pennylane/pull/6891)
 
@@ -592,7 +593,7 @@
   [(#7020)](https://github.com/PennyLaneAI/pennylane/pull/7020)
 
 * `qml.math.get_interface` now correctly extracts the `"scipy"` interface if provided a list/array
-  of sparse matrices. 
+  of sparse matrices.
   [(#7015)](https://github.com/PennyLaneAI/pennylane/pull/7015)
 
 * `qml.ops.Controlled.has_sparse_matrix` now provides the correct information
@@ -637,8 +638,8 @@
 * The `QROM` template is upgraded to decompose more efficiently when `work_wires` are not used.
   [#6967)](https://github.com/PennyLaneAI/pennylane/pull/6967)
 
-* Processing mid-circuit measurements inside conditionals is not supported and previously resulted in 
-  unclear error messages or incorrect results. It is now explicitly not allowed, and raises an error when 
+* Processing mid-circuit measurements inside conditionals is not supported and previously resulted in
+  unclear error messages or incorrect results. It is now explicitly not allowed, and raises an error when
   processing the tape.
   [(#7027)](https://github.com/PennyLaneAI/pennylane/pull/7027)
 

--- a/tests/math/test_matrix_manipulation.py
+++ b/tests/math/test_matrix_manipulation.py
@@ -1204,7 +1204,7 @@ def _enforce_positivity(mat):
 class TestDenmanBeaversIterations:
     """Tests for the Denman-Beavers iteration method for matrix square root"""
 
-    def test_singular_matrix(self, seed):
+    def test_singular_matrix(self):
         """Test that singular matrix raises appropriate error"""
         n = 4
         mat = csr_matrix(np.diag([0.0] + [1.0] * (n - 1)))
@@ -1243,7 +1243,7 @@ class TestDenmanBeaversIterations:
             _denman_beavers_iterations(mat)
 
     @pytest.mark.parametrize("size", [2, 3, 4, 5])
-    def test_valid_positive_definite(self, size):
+    def test_valid_positive_definite(self, size, seed):
         """Test that valid real, positive definite matrices work correctly"""
         # Create a positive definite matrix
         rng = np.random.default_rng(seed)

--- a/tests/math/test_matrix_manipulation.py
+++ b/tests/math/test_matrix_manipulation.py
@@ -1188,8 +1188,32 @@ class TestSqrtMatrix:
 CONVERGENCE_ERROR = "Convergence threshold not reached"
 
 
+def _reverse_det_hermitian(mat):
+    """Helper function to reverse determinant sign of Hermitian matrix"""
+    eigvals, eigvecs = np.linalg.eigh(mat)
+    eigvals[0] *= -1
+    return eigvecs @ np.diag(eigvals) @ eigvecs.T.conj()
+
+
+def _enforce_positivity(mat):
+    """Helper function to ensure matrix is positive definite"""
+    det_mat = np.linalg.det(mat)
+    return mat if det_mat > 0 else _reverse_det_hermitian(mat)
+
+
 class TestDenmanBeaversIterations:
     """Tests for the Denman-Beavers iteration method for matrix square root"""
+
+    @staticmethod
+    def _reverse_det_hermitian(mat):
+        eigvals, eigvecs = np.linalg.eigh(mat)
+        eigvals[0] *= -1
+        return eigvecs @ np.diag(eigvals) @ eigvecs.T.conj()
+
+    @staticmethod
+    def _enforce_positivity(mat):
+        det_mat = np.linalg.det(mat)
+        return mat if det_mat > 0 else _reverse_det_hermitian(mat)
 
     def test_singular_matrix(self):
         """Test that singular matrix raises appropriate error"""
@@ -1234,7 +1258,9 @@ class TestDenmanBeaversIterations:
         """Test that valid real, positive definite matrices work correctly"""
         # Create a positive definite matrix
         A = np.random.random((size, size))
-        mat = csr_matrix(np.eye(size) - 0.1 * (A @ A.T))
+        mat = np.eye(size) - 0.1 * (A @ A.T)
+        mat = _enforce_positivity(mat)
+        mat = csr_matrix(mat)
 
         result = _denman_beavers_iterations(mat)
         # Check that result is a valid square root
@@ -1249,11 +1275,6 @@ class TestDenmanBeaversIterations:
         n = 4
         A = np.random.random((n, n)) + 1j * np.random.random((n, n))
         mat = np.eye(n) - 0.2 * (A @ A.T.conj())
-
-        def _reverse_det_hermitian(mat):
-            eigvals, eigvecs = np.linalg.eigh(mat)
-            eigvals[0] *= -1
-            return eigvecs @ np.diag(eigvals) @ eigvecs.T.conj()
 
         det_mat = np.real(np.linalg.det(mat))
         good_mat = mat if det_mat > 0 else _reverse_det_hermitian(mat)

--- a/tests/math/test_matrix_manipulation.py
+++ b/tests/math/test_matrix_manipulation.py
@@ -1204,18 +1204,7 @@ def _enforce_positivity(mat):
 class TestDenmanBeaversIterations:
     """Tests for the Denman-Beavers iteration method for matrix square root"""
 
-    @staticmethod
-    def _reverse_det_hermitian(mat):
-        eigvals, eigvecs = np.linalg.eigh(mat)
-        eigvals[0] *= -1
-        return eigvecs @ np.diag(eigvals) @ eigvecs.T.conj()
-
-    @staticmethod
-    def _enforce_positivity(mat):
-        det_mat = np.linalg.det(mat)
-        return mat if det_mat > 0 else _reverse_det_hermitian(mat)
-
-    def test_singular_matrix(self):
+    def test_singular_matrix(self, seed):
         """Test that singular matrix raises appropriate error"""
         n = 4
         mat = csr_matrix(np.diag([0.0] + [1.0] * (n - 1)))
@@ -1257,7 +1246,8 @@ class TestDenmanBeaversIterations:
     def test_valid_positive_definite(self, size):
         """Test that valid real, positive definite matrices work correctly"""
         # Create a positive definite matrix
-        A = np.random.random((size, size))
+        rng = np.random.default_rng(seed)
+        A = rng.random((size, size))
         mat = np.eye(size) - 0.1 * (A @ A.T)
         mat = _enforce_positivity(mat)
         mat = csr_matrix(mat)


### PR DESCRIPTION
**Context:**
A recent test error https://github.com/PennyLaneAI/pennylane/actions/runs/13790909397/job/38570702961?pr=7042 was caused by the fact that there are chances in a recently added test `tests/math/test_matrix_manipulation.py::TestDenmanBeaversIterations::test_valid_positive_definite` to have improper input matrices for this test suite.
For context, this test suite should take a matrix with positive determinant. However, one can check the mentioned test fail to see the error info matrix is negative.
Therefore, we would like to make use of the existing helpers to help this test suite to gaurantee to get positive input.

**Description of the Change:**
In the mentioned test file, we made:
 - The helper method to be separated from another specific test suite for convenience
 - A new method to enforce any input square hermitian metrix to have positive det
 - Make the erorring test suite enforce input positivity.

**Benefits:**
Stable CI. Should have no more related error in the future.

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-86230]