### PR TITLE
Ensure probability normalization (sum to one) while using `reference.qubit`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -53,6 +53,8 @@
 
 <h3>Improvements 🛠</h3>
 
+* The `reference.qubit` device now enforce `sum(probs)==1` in `sample_state`
+
 * The `default.mixed` device now adheres to the newer device API introduced in
   [v0.33](https://docs.pennylane.ai/en/stable/development/release_notes.html#release-0-33-0).
   This means that `default.mixed` now supports not having to specify the number of wires,

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -53,7 +53,8 @@
 
 <h3>Improvements 🛠</h3>
 
-* The `reference.qubit` device now enforce `sum(probs)==1` in `sample_state`
+* The `reference.qubit` device now enforce `sum(probs)==1` in `sample_state`.
+  [(#7076)](https://github.com/PennyLaneAI/pennylane/pull/7076)
 
 * The `default.mixed` device now adheres to the newer device API introduced in
   [v0.33](https://docs.pennylane.ai/en/stable/development/release_notes.html#release-0-33-0).

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -53,7 +53,7 @@
 
 <h3>Improvements 🛠</h3>
 
-* The `reference.qubit` device now enforce `sum(probs)==1` in `sample_state`.
+* The `reference.qubit` device now enforces `sum(probs)==1` in `sample_state`.
   [(#7076)](https://github.com/PennyLaneAI/pennylane/pull/7076)
 
 * The `default.mixed` device now adheres to the newer device API introduced in

--- a/pennylane/devices/reference_qubit.py
+++ b/pennylane/devices/reference_qubit.py
@@ -35,6 +35,7 @@ def sample_state(state: np.ndarray, shots: int, seed=None):
     num_wires = int(np.log2(len(probs)))
 
     rng = np.random.default_rng(seed)
+    probs /= np.sum(probs)  # Fix: Normalize to prevent sum ≠ 1 errors in NumPy 2.0+
     basis_samples = rng.choice(basis_states, shots, p=probs)
 
     # convert basis state integers to array of booleans


### PR DESCRIPTION
**Context:**
With the release of NumPy 2.0, stricter validation has been introduced for numpy.random.Generator.choice, which now requires that the probability vector p must sum to exactly 1 when cast to float64.
Reference: [NumPy 2.0 documentation – Generator.choice](https://numpy.org/doc/2.0/reference/random/generated/numpy.random.Generator.choice.html#numpy.random.Generator.choice)

> "p must sum to 1 when cast to float64. To ensure this, you may wish to normalize using p = p / np.sum(p, dtype=float)."

This stricter behavior causes our reference.qubit device to fail under NumPy > 2.0, as minor numerical deviations in probability sums can lead to a ValueError: Probabilities do not sum to 1 (see [here](https://github.com/PennyLaneAI/pennylane/actions/runs/13818577424/job/38658179112?pr=7039) for an example)

**Description of the Change:**
Enforce probs normalization

**Benefits:**
Better compatibility

**Possible Drawbacks:**

**Related GitHub Issues:**
