### PR TITLE
Remove unnecessary LRU cache

### DIFF
--- a/pennylane/measurements/sample.py
+++ b/pennylane/measurements/sample.py
@@ -215,7 +215,6 @@ class SampleMP(SampleMeasurement):
         return tuple(shape), dtype
 
     @property
-    @functools.lru_cache()
     def numeric_type(self):
         if self.obs is None:
             # Computational basis samples


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      test directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `doc/releases/changelog-dev.md` file, summarizing the
      change, and including a link back to the PR.

- [ ] The PennyLane source code conforms to
      [PEP8 standards](https://www.python.org/dev/peps/pep-0008/).
      We check all of our code against [Pylint](https://www.pylint.org/).
      To lint modified files, simply `pip install pylint`, and then
      run `pylint pennylane/path/to/file.py`.

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:** This removes a rate-limiting LRU cache call that is unnecessary. Calls to the cache were unbounded, and capturing the entire object due to the `self` argument. Removing this will ensure the following workload no longer slows-down on each subsequent execution in the iteration:

```python
import pennylane as qml                                                                                                                                                                       
import sys                                                                                                                                                                                    
from timeit import default_timer as timer                                                                                                                                                     
dev = qml.device("null.qubit")                                                                                                                                                                
                                                                                                                                                                                              
num_iter = int(sys.argv[1])                                                                                                                                                                   
shots = int(sys.argv[2])                                                                                                                                                                      
                                                                                                                                                                                              
@qml.qnode(dev, mcm_method="one-shot")                                                                                                                                                        
def circ():                                                                                                                                                                                   
    m0 = qml.measure(0)                                                                                                                                                                       
    qml.cond(m0 == 0, qml.PauliX, qml.PauliY)(0)                                                                                                                                              
    return qml.sample(qml.PauliZ(0))                                                                                                                                                          
                                                                                                                                                                                              
res = []                                                                                                                                                                                      
for i in range(num_iter):                                                                                                                                                                     
    start = timer()                                                                                                                                                                           
    circ(shots=shots)                                                                                                                                                                         
    end = timer()                                                                                                                                                                             
    res.append(end-start)                                                                                                                                                                     
                                                                                                                                                                                              
print(res)  
```

**Description of the Change:** Removes an LRU cache from a method.

**Benefits:** Prevents unbounded caching of sample MPs.

**Possible Drawbacks:** None.

**Related GitHub Issues:**
