### PR TITLE
Remove redundant overload for MCM mod

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -613,6 +613,9 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Modulo operator calls on MCMs now correctly offload to the autoray-backed `qml.math.mod` dispatch.
+  [(#7085)](https://github.com/PennyLaneAI/pennylane/pull/7085)
+
 * Dynamic one-shot workloads are now faster for `null.qubit`.
   Removed a redundant `functools.lru_cache` call that was capturing all `SampleMP` objects in a workload.
   [(#7077)](https://github.com/PennyLaneAI/pennylane/pull/7077)

--- a/pennylane/math/single_dispatch.py
+++ b/pennylane/math/single_dispatch.py
@@ -57,7 +57,6 @@ def _builtins_shape(x):
 ar.register_function("builtins", "ndim", _builtins_ndim)
 ar.register_function("builtins", "shape", _builtins_shape)
 ar.register_function("builtins", "coerce", lambda x: x)
-ar.register_function("builtins", "logical_mod", lambda x, y: x % y)
 ar.register_function("builtins", "logical_xor", lambda x, y: x ^ y)
 
 # -------------------------------- SciPy --------------------------------- #

--- a/pennylane/measurements/mid_measure.py
+++ b/pennylane/measurements/mid_measure.py
@@ -515,7 +515,7 @@ class MeasurementValue(Generic[T]):
         return self._transform_bin_op(qml.math.logical_or, other)
 
     def __mod__(self, other):
-        return self._transform_bin_op(qml.math.logical_mod, other)
+        return self._transform_bin_op(qml.math.mod, other)
 
     def __xor__(self, other):
         return self._transform_bin_op(qml.math.logical_xor, other)

--- a/tests/measurements/test_mid_measure.py
+++ b/tests/measurements/test_mid_measure.py
@@ -421,7 +421,7 @@ class TestMeasurementValueManipulation:
         assert new_meas.id == mp1.id
 
     def test_mod(self):
-        """Test the __xor__ dunder method between two measurement values"""
+        """Test the __mod__ dunder method between two measurement values"""
         m1 = MeasurementValue([mp1], lambda v: v)
         mod_val = m1 % 2
         assert mod_val[0] == 0


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      test directory!

- [x] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `doc/releases/changelog-dev.md` file, summarizing the
      change, and including a link back to the PR.

- [x] The PennyLane source code conforms to
      [PEP8 standards](https://www.python.org/dev/peps/pep-0008/).
      We check all of our code against [Pylint](https://www.pylint.org/).
      To lint modified files, simply `pip install pylint`, and then
      run `pylint pennylane/path/to/file.py`.

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:** PR https://github.com/PennyLaneAI/pennylane/pull/6981 added support for MOD and XOR with MCMs. An incorrect offload name was assigned to `mod`, which defined an autoray dispatch as `logical_mod`. This naming is nonsensical, and causes issues with dispatch due to the disparate naming from the numpy APIs `numpy.mod`, such as
`ImportError: autoray couldn't find function 'logical_mod' for backend 'numpy'.` when called using LightningQubit.

**Description of the Change:** This PR reassigns the MCM `__mod__` dunder to call into `qml.math.mod`, which should implicitly work with the outcome of measures and offloads to native frameworks, be they built-in or numpy.

**Benefits:** Fixes error observed with executing dynamic MCM workloads with LightningQubit, due to the naming and data type mismatch.

**Possible Drawbacks:**

**Related GitHub Issues:**
