### PR TITLE
Update decomposition check in assert_valid

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -348,8 +348,8 @@
   abstractions between logical qubits and physical qubits.
   [(#6962)](https://github.com/PennyLaneAI/pennylane/pull/6962)
 
-* The `assert_valid` method can now optionally skip the check that a decomposition must not contain 
-  operators of the same class as the `Operation` being decomposed.
+* The `assert_valid` method now validates that an operator's decomposition does not contain 
+  the operator itself, instead of checking that it does not contain any operators of the same class as the operator.
   [(#7099)](https://github.com/PennyLaneAI/pennylane/pull/7099)
 
 <h4>Capturing and representing hybrid programs</h4>

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -281,6 +281,10 @@
   abstractions between logical qubits and physical qubits.
   [(#6962)](https://github.com/PennyLaneAI/pennylane/pull/6962)
 
+* The `assert_valid` method can now optionally skip the check that a decomposition must not contain 
+  operators of the same class as the `Operation` being decomposed.
+  [(#7099)](https://github.com/PennyLaneAI/pennylane/pull/7099)
+
 <h4>Capturing and representing hybrid programs</h4>
 
 * Traditional tape transforms in PennyLane can be automatically converted to work with program capture enabled.

--- a/pennylane/ops/functions/assert_valid.py
+++ b/pennylane/ops/functions/assert_valid.py
@@ -39,7 +39,7 @@ def _assert_error_raised(func, error, failure_comment):
     return inner_func
 
 
-def _check_decomposition(op, skip_wire_mapping, decomposition_to_same_class):
+def _check_decomposition(op, skip_wire_mapping):
     """Checks involving the decomposition."""
     if op.has_decomposition:
         decomp = op.decomposition()
@@ -63,21 +63,6 @@ def _check_decomposition(op, skip_wire_mapping, decomposition_to_same_class):
             assert o1 == o2, "decomposition must match compute_decomposition"
             assert o1 == o3, "decomposition must match queued operations"
             assert isinstance(o1, qml.operation.Operator), "decomposition must contain operators"
-            if not decomposition_to_same_class:
-                try:
-                    assert not isinstance(o1, op.__class__)
-                except AssertionError as e:
-                    raise AssertionError(
-                        f"The operator {op} provides a decomposition that includes "
-                        f"operators of the same class as itself. For many operators, "
-                        f"this indicates a problem with the decomposition. However, "
-                        f"for some operators that have another operator as their base, "
-                        f"the decomposition may focus on decomposing the base operator, "
-                        f"leaving the overall operator class intact. "
-                        f"If this is the case for {op}, this validtion check can be "
-                        f"skipped by adding `decomposition_to_same_class=True` to the "
-                        f"`assert_valid` call"
-                    ) from e
 
         if skip_wire_mapping:
             return
@@ -374,7 +359,6 @@ def assert_valid(
     skip_pickle=False,
     skip_wire_mapping=False,
     skip_differentiation=False,
-    decomposition_to_same_class=False,
 ) -> None:
     """Runs basic validation checks on an :class:`~.operation.Operator` to make
     sure it has been correctly defined.
@@ -436,7 +420,7 @@ def assert_valid(
     if not skip_pickle:
         _check_pickle(op)
     _check_bind_new_parameters(op)
-    _check_decomposition(op, skip_wire_mapping, decomposition_to_same_class)
+    _check_decomposition(op, skip_wire_mapping)
     _check_matrix(op)
     _check_matrix_matches_decomp(op)
     _check_sparse_matrix(op)

--- a/pennylane/ops/functions/assert_valid.py
+++ b/pennylane/ops/functions/assert_valid.py
@@ -67,13 +67,13 @@ def _check_decomposition(op, skip_wire_mapping, decomposition_to_same_class):
                 try:
                     assert not isinstance(o1, op.__class__)
                 except AssertionError as e:
-                    raise RuntimeError(
+                    raise AssertionError(
                         f"The operator {op} provides a decomposition that includes "
-                        f"operators of the same class as {op}. For many operators, "
+                        f"operators of the same class as itself. For many operators, "
                         f"this indicates a problem with the decomposition. However, "
-                        f"for some SymbolicOp operators that have another operator as "
-                        f"their base, the decomposition may focus on decomposing the "
-                        f"base operator, leaving the overall operator class intact. "
+                        f"for some operators that have another operator as their base, "
+                        f"the decomposition may focus on decomposing the base operator, "
+                        f"leaving the overall operator class intact. "
                         f"If this is the case for {op}, this validtion check can be "
                         f"skipped by adding `decomposition_to_same_class=True` to the "
                         f"`assert_valid` call"

--- a/pennylane/ops/functions/assert_valid.py
+++ b/pennylane/ops/functions/assert_valid.py
@@ -352,7 +352,6 @@ def _check_wires(op, skip_wire_mapping):
     assert mapped_op.wires == new_wires, "wires must be mappable with map_wires"
 
 
-# pylint: disable = too-many-arguments, too-many-positional-arguments
 def assert_valid(
     op: qml.operation.Operator,
     skip_deepcopy=False,

--- a/tests/ops/functions/test_assert_valid.py
+++ b/tests/ops/functions/test_assert_valid.py
@@ -92,28 +92,6 @@ class TestDecompositionErrors:
         with pytest.raises(AssertionError, match="should not be included in its own decomposition"):
             assert_valid(BadDecomp(wires=0), skip_pickle=True)
 
-    def test_decomposition_must_not_contain_op_class(self):
-        """Test that by default, assert_valid checks that a decomposition of an
-        operator doesn't include the operator class itself, and that the decomposition_to_same_class
-        argument can be used to skip this check"""
-
-        class GenericOp(Operator):
-            @staticmethod
-            def compute_decomposition(wires):
-                return [qml.PhaseShift(1.23, wires), qml.H(wires)]
-
-        with pytest.raises(
-            AssertionError,
-            match="decomposition that includes operators of the same class as itself",
-        ):
-            assert_valid(qml.ctrl(GenericOp(wires=0), control=1), skip_pickle=True)
-
-        assert_valid(
-            qml.ctrl(GenericOp(wires=0), control=1),
-            skip_pickle=True,
-            decomposition_to_same_class=True,
-        )
-
 
 class TestBadMatrix:
     """Tests involving matrix validation."""

--- a/tests/ops/functions/test_assert_valid.py
+++ b/tests/ops/functions/test_assert_valid.py
@@ -92,6 +92,28 @@ class TestDecompositionErrors:
         with pytest.raises(AssertionError, match="should not be included in its own decomposition"):
             assert_valid(BadDecomp(wires=0), skip_pickle=True)
 
+    def test_decomposition_must_not_contain_op_class(self):
+        """Test that by default, assert_valid checks that a decomposition of an
+        operator doesn't include the operator class itself, and that the decomposition_to_same_class
+        argument can be used to skip this check"""
+
+        class GenericOp(Operator):
+            @staticmethod
+            def compute_decomposition(wires):
+                return [qml.PhaseShift(1.23, wires), qml.H(wires)]
+
+        with pytest.raises(
+            AssertionError,
+            match="decomposition that includes operators of the same class as itself",
+        ):
+            assert_valid(qml.ctrl(GenericOp(wires=0), control=1), skip_pickle=True)
+
+        assert_valid(
+            qml.ctrl(GenericOp(wires=0), control=1),
+            skip_pickle=True,
+            decomposition_to_same_class=True,
+        )
+
 
 class TestBadMatrix:
     """Tests involving matrix validation."""


### PR DESCRIPTION
**Context:**
We have a check in `assert_valid` that ensures that an operator decomposition doesn't include the same type of operator again. This is a relevant check for operators types where a given class will be either supported or not by devices - in this case, a decomposition that returns another instance of the same type of operation will lead to an infinite recursion. 

However, for some operators, this check doesn't make sense. Specifically, an operator with another operation as its base may decompose based on the base operator, leaving the overall operator type intact (for example, `Controlled` operations with an unsupported base). 

This has come up in PR #6921 for the `FromBloq` operator.

**Description of the Change:**

- We check that the operator _itself_ is not present in its own decomposition in all cases. 
- We keep the check that the decomposition doesn't include any operators of the same type as the original operator, but make it optional via a new argument in `assert_valid`. 
- We add an error message with instructions for how to skip that part of the decomposition check, and when it would be valid to do so.

**Benefits:**
More flexibility for asserting validity of the group of operators where specific instances may decompose into other operators of the same type.

**Possible Drawbacks:**
- We're starting to add a lot of different kinds of exceptions to `assert_valid`.
- The added argument is currently called `decomposition_to_same_class`, which is long and not that helpful, but I'm coming up blank when I try to think of something better


[sc-86860]