### PR TITLE
Upgrading tj-actions version to 46

### DIFF
--- a/.github/workflows/tests-labs.yml
+++ b/.github/workflows/tests-labs.yml
@@ -23,7 +23,7 @@ jobs:
         
       - name: Assess changed files
         id: changed-files
-        uses: tj-actions/changed-files@v45
+        uses: tj-actions/changed-files@v46
         with:
           files: pennylane/labs/**
 


### PR DESCRIPTION
------------------------------------------------------------------------------------------------------------

**Context:**
- Harden-Runner detection: tj-actions/changed-files action is compromised. This vulnerability exposed build secrets by printing CI/CD secrets in GitHub Actions build logs. [Security Issue Summary](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised).

**Description of the Change:**
- This PR upgrades tj-actions from version 45 to version 46 with the vulnerability fix.

**Benefits:**
- Removes tj-actions/changed-files vulnerability.
**Possible Drawbacks:**
- None
**Related GitHub Issues:**
