### PR TITLE
Fix mistakes in docs examples for diagonalize_mcms

### DIFF
--- a/pennylane/ftqc/parametric_midmeasure.py
+++ b/pennylane/ftqc/parametric_midmeasure.py
@@ -573,7 +573,7 @@ def diagonalize_mcms(tape):
         dev = qml.device("default.qubit", shots=1000)
 
         @diagonalize_mcms
-        @qml.qnode(dev, method="one-shot")
+        @qml.qnode(dev, mcm_method="one-shot")
         def circuit(x):
             qml.RX(x, wires=0)
             m = measure_y(0)
@@ -591,7 +591,7 @@ def diagonalize_mcms(tape):
     becomes
 
     >>> print(qml.draw(circuit)(np.pi/4))
-    0: ──RY(0.79)──S†──H──┤↗├────┤
+    0: ──RX(0.79)──S†──H──┤↗├────┤
     1: ────────────────────║───X─┤  <Z>
                            ╚═══╝
 


### PR DESCRIPTION
**Context:**

There are a couple of typos in the docstring examples for `diagonalize_mcms`

**Description of the Change:**

We fix the typos

**Benefits:**

The examples are correct
