### PR TITLE
Call 'eval' from the base interpreter when evaluating 'pjit'

### DIFF
--- a/pennylane/capture/base_interpreter.py
+++ b/pennylane/capture/base_interpreter.py
@@ -437,7 +437,7 @@ def _(self, x, *dyn_shape, shape, broadcast_dimensions):
 def _(self, *invals, jaxpr, **params):
     if jax.config.jax_dynamic_shapes:
         # just evaluate it so it doesn't throw dynamic shape errors
-        return copy(self).eval(jaxpr.jaxpr, jaxpr.consts, *invals)
+        return PlxprInterpreter().eval(jaxpr.jaxpr, jaxpr.consts, *invals)
 
     subfuns, params = jax._src.pjit.pjit_p.get_bind_params({"jaxpr": jaxpr, **params})
     return jax._src.pjit.pjit_p.bind(*subfuns, *invals, **params)


### PR DESCRIPTION
**Context:** Catalyst's `BranchInterpreter` has overridden the `eval` method of the base `PlxprInterpreter` in order to be able to insert and remove a QReg when necessary. The new `pjit` primitive at the PL side will call that overridden `eval` method when found inside a nested loop, which will wrongly assume the last argument is the QReg, and then will remove it from the list. Hence the error: `zip() argument 2 is longer than argument 1`

**Description of the Change:** Call the `PlxprInterpreter().eval()` method instead.

**Benefits:** Recover nested loops interpretation.

**Possible Drawbacks:** What if the `pjit` primitive is inside a different context related to a different derived `PlxprInterpreter`? Would we lose the specificity of that interpretation?
