### PR TITLE
[Capture] Improve support for array wires

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -284,6 +284,8 @@
   abstractions between logical qubits and physical qubits.
   [(#6962)](https://github.com/PennyLaneAI/pennylane/pull/6962)
 
+* Improves support for specifying wires as jax numpy arrays when program capture is enabled.
+
 <h4>Capturing and representing hybrid programs</h4>
 
 * Traditional tape transforms in PennyLane can be automatically converted to work with program capture enabled.

--- a/pennylane/capture/capture_measurements.py
+++ b/pennylane/capture/capture_measurements.py
@@ -214,10 +214,13 @@ def create_measurement_wires_primitive(
     @primitive.def_impl
     def _(*args, has_eigvals=False, **kwargs):
         if has_eigvals:
-            wires = qml.wires.Wires(args[:-1])
+            wires = qml.wires.Wires(
+                tuple(w if qml.math.is_abstract(w) else int(w) for w in args[:-1])
+            )
             kwargs["eigvals"] = args[-1]
         else:
-            wires = qml.wires.Wires(args)
+            wires = tuple(w if qml.math.is_abstract(w) else int(w) for w in args)
+            wires = qml.wires.Wires(wires)
         return type.__call__(measurement_type, wires=wires, **kwargs)
 
     abstract_type = _get_abstract_measurement()

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -697,14 +697,23 @@ class Operator(abc.ABC, metaclass=ABCCaptureMeta):
 
         import jax  # pylint: disable=import-outside-toplevel
 
-        iterable_wires_types = (list, tuple, qml.wires.Wires, range, set, jax.numpy.ndarray)
+        array_types = (jax.numpy.ndarray, np.ndarray)
+        iterable_wires_types = (
+            list,
+            tuple,
+            qml.wires.Wires,
+            range,
+            set,
+            jax.numpy.ndarray,
+            np.ndarray,
+        )
 
         # process wires so that we can handle them either as a final argument or as a keyword argument.
         # Stick `n_wires` as a keyword argument so we have enough information to repack them during
         # the implementation call defined by `primitive.def_impl`.
         if "wires" in kwargs:
             wires = kwargs.pop("wires")
-            if isinstance(wires, jax.numpy.ndarray) and wires.shape == ():
+            if isinstance(wires, array_types) and wires.shape == ():
                 wires = (wires,)
             elif isinstance(wires, iterable_wires_types):
                 wires = tuple(wires)
@@ -712,7 +721,7 @@ class Operator(abc.ABC, metaclass=ABCCaptureMeta):
                 wires = (wires,)
             kwargs["n_wires"] = len(wires)
             args += wires
-        elif args and isinstance(args[-1], jax.numpy.ndarray) and args[-1].shape == ():
+        elif args and isinstance(args[-1], array_types) and args[-1].shape == ():
             kwargs["n_wires"] = 1
         elif args and isinstance(args[-1], iterable_wires_types):
             wires = tuple(args[-1])

--- a/tests/capture/test_measurements_capture.py
+++ b/tests/capture/test_measurements_capture.py
@@ -316,7 +316,9 @@ class TestExpvalVar:
 
 class TestProbs:
 
-    @pytest.mark.parametrize("wires, shape", [([0, 1, 2], 8), ([], 16)])
+    @pytest.mark.parametrize(
+        "wires, shape", [([0, 1, 2], 8), ([], 16), (jax.numpy.array([0, 1, 2]), 8)]
+    )
     def test_wires(self, wires, shape):
         """Tests capturing probabilities on wires."""
 
@@ -328,7 +330,7 @@ class TestProbs:
         assert len(jaxpr.eqns) == 1
 
         assert jaxpr.eqns[0].primitive == ProbabilityMP._wires_primitive
-        assert [x.val for x in jaxpr.eqns[0].invars] == wires
+        assert [x.val for x in jaxpr.eqns[0].invars] == list(wires)
         mp = jaxpr.eqns[0].outvars[0].aval
         assert isinstance(mp, AbstractMeasurement)
         assert mp.n_wires == len(wires)
@@ -392,7 +394,9 @@ class TestProbs:
 
 class TestSample:
 
-    @pytest.mark.parametrize("wires, dim1_len", [([0, 1, 2], 3), ([], 4), (1, 1)])
+    @pytest.mark.parametrize(
+        "wires, dim1_len", [([0, 1, 2], 3), ([], 4), (1, 1), (jax.numpy.array([0, 1, 2]), 3)]
+    )
     def test_wires(self, wires, dim1_len):
         """Tests capturing samples on wires."""
         if isinstance(wires, list):
@@ -408,20 +412,21 @@ class TestSample:
 
             jaxpr = jax.make_jaxpr(f)(wires)
 
-        assert len(jaxpr.eqns) == 1
+        if not isinstance(wires, jax.numpy.ndarray):
+            assert len(jaxpr.eqns) == 1
 
-        assert jaxpr.eqns[0].primitive == SampleMP._wires_primitive
+        assert jaxpr.eqns[-1].primitive == SampleMP._wires_primitive
         assert [x.aval for x in jaxpr.eqns[0].invars] == jaxpr.in_avals
-        mp = jaxpr.eqns[0].outvars[0].aval
+        mp = jaxpr.eqns[-1].outvars[0].aval
         assert isinstance(mp, AbstractMeasurement)
-        assert mp.n_wires == len(wires) if isinstance(wires, list) else 1
+        assert mp.n_wires == len(wires) if isinstance(wires, (list, jax.numpy.ndarray)) else 1
         assert mp._abstract_eval == SampleMP._abstract_eval
 
         shapes = _get_shapes_for(
             *jaxpr.out_avals, shots=qml.measurements.Shots(50), num_device_wires=4
         )
         assert len(shapes) == 1
-        shape = (50, dim1_len) if isinstance(wires, list) else (50,)
+        shape = (50, dim1_len) if isinstance(wires, (list, jax.numpy.ndarray)) else (50,)
         assert shapes[0] == jax.core.ShapedArray(
             shape, jax.numpy.int64 if jax.config.jax_enable_x64 else jax.numpy.int32
         )

--- a/tests/capture/test_measurements_capture.py
+++ b/tests/capture/test_measurements_capture.py
@@ -395,7 +395,14 @@ class TestProbs:
 class TestSample:
 
     @pytest.mark.parametrize(
-        "wires, dim1_len", [([0, 1, 2], 3), ([], 4), (1, 1), (jax.numpy.array([0, 1, 2]), 3)]
+        "wires, dim1_len",
+        [
+            ([0, 1, 2], 3),
+            ([], 4),
+            (1, 1),
+            (jax.numpy.array([0, 1, 2]), 3),
+            (np.array([0, 1, 2]), 3),
+        ],
     )
     def test_wires(self, wires, dim1_len):
         """Tests capturing samples on wires."""
@@ -412,21 +419,27 @@ class TestSample:
 
             jaxpr = jax.make_jaxpr(f)(wires)
 
-        if not isinstance(wires, jax.numpy.ndarray):
+        if not isinstance(wires, (jax.numpy.ndarray, np.ndarray)):
             assert len(jaxpr.eqns) == 1
 
         assert jaxpr.eqns[-1].primitive == SampleMP._wires_primitive
         assert [x.aval for x in jaxpr.eqns[0].invars] == jaxpr.in_avals
         mp = jaxpr.eqns[-1].outvars[0].aval
         assert isinstance(mp, AbstractMeasurement)
-        assert mp.n_wires == len(wires) if isinstance(wires, (list, jax.numpy.ndarray)) else 1
+        assert (
+            mp.n_wires == len(wires)
+            if isinstance(wires, (list, jax.numpy.ndarray, np.ndarray))
+            else 1
+        )
         assert mp._abstract_eval == SampleMP._abstract_eval
 
         shapes = _get_shapes_for(
             *jaxpr.out_avals, shots=qml.measurements.Shots(50), num_device_wires=4
         )
         assert len(shapes) == 1
-        shape = (50, dim1_len) if isinstance(wires, (list, jax.numpy.ndarray)) else (50,)
+        shape = (
+            (50, dim1_len) if isinstance(wires, (list, jax.numpy.ndarray, np.ndarray)) else (50,)
+        )
         assert shapes[0] == jax.core.ShapedArray(
             shape, jax.numpy.int64 if jax.config.jax_enable_x64 else jax.numpy.int32
         )

--- a/tests/capture/test_operators.py
+++ b/tests/capture/test_operators.py
@@ -14,6 +14,8 @@
 """
 Integration tests for the capture of pennylane operations into jaxpr.
 """
+import numpy as np
+
 # pylint: disable=protected-access
 import pytest
 
@@ -132,7 +134,19 @@ def test_hybrid_capture_parametrization():
 
 @pytest.mark.parametrize("as_kwarg", (True, False))
 @pytest.mark.parametrize(
-    "w", (0, (0,), [0], range(1), qml.wires.Wires(0), {0}, jax.numpy.array(0), jax.numpy.array([0]))
+    "w",
+    (
+        0,
+        (0,),
+        [0],
+        range(1),
+        qml.wires.Wires(0),
+        {0},
+        jax.numpy.array(0),
+        jax.numpy.array([0]),
+        np.array(0),
+        np.array([0]),
+    ),
 )
 def test_different_wires(w, as_kwarg):
     """Test that wires can be passed positionally and as a keyword in a variety of different types."""
@@ -172,14 +186,15 @@ def test_different_wires(w, as_kwarg):
 
 
 @pytest.mark.parametrize("as_kwarg", (True, False))
-def test_ndarray_multiple_wires(as_kwarg):
+@pytest.mark.parametrize("interface", ("numpy", "jax"))
+def test_ndarray_multiple_wires(as_kwarg, interface):
     """Test that wires can be provided as an ndarray."""
 
     def qfunc():
         if as_kwarg:
-            qml.GroverOperator(wires=jax.numpy.arange(4))
+            qml.GroverOperator(wires=qml.math.arange(4, like=interface))
         else:
-            qml.GroverOperator(jax.numpy.arange(4))
+            qml.GroverOperator(qml.math.arange(4, like=interface))
 
     jaxpr = jax.make_jaxpr(qfunc)()
 

--- a/tests/capture/test_operators.py
+++ b/tests/capture/test_operators.py
@@ -131,7 +131,9 @@ def test_hybrid_capture_parametrization():
 
 
 @pytest.mark.parametrize("as_kwarg", (True, False))
-@pytest.mark.parametrize("w", (0, (0,), [0], range(1), qml.wires.Wires(0), {0}))
+@pytest.mark.parametrize(
+    "w", (0, (0,), [0], range(1), qml.wires.Wires(0), {0}, jax.numpy.array(0), jax.numpy.array([0]))
+)
 def test_different_wires(w, as_kwarg):
     """Test that wires can be passed positionally and as a keyword in a variety of different types."""
 
@@ -143,13 +145,19 @@ def test_different_wires(w, as_kwarg):
 
     jaxpr = jax.make_jaxpr(qfunc)()
 
-    assert len(jaxpr.eqns) == 1
+    if isinstance(w, jax.numpy.ndarray) and w.shape != ():
+        offset = 1
+    else:
+        offset = 0
 
-    eqn = jaxpr.eqns[0]
+    assert len(jaxpr.eqns) == 1 + offset
+
+    eqn = jaxpr.eqns[offset + 0]
     assert eqn.primitive == qml.X._primitive
     assert len(eqn.invars) == 1
-    assert isinstance(eqn.invars[0], jax.core.Literal)
-    assert eqn.invars[0].val == 0
+    if not isinstance(w, jax.numpy.ndarray):
+        assert isinstance(eqn.invars[0], jax.core.Literal)
+        assert eqn.invars[0].val == 0
 
     assert isinstance(eqn.outvars[0].aval, AbstractOperator)
     assert isinstance(eqn.outvars[0], jax.core.DropVar)
@@ -161,6 +169,29 @@ def test_different_wires(w, as_kwarg):
 
     assert len(q) == 1
     qml.assert_equal(q.queue[0], qml.X(0))
+
+
+@pytest.mark.parametrize("as_kwarg", (True, False))
+def test_ndarray_multiple_wires(as_kwarg):
+    """Test that wires can be provided as an ndarray."""
+
+    def qfunc():
+        if as_kwarg:
+            qml.GroverOperator(wires=jax.numpy.arange(4))
+        else:
+            qml.GroverOperator(jax.numpy.arange(4))
+
+    jaxpr = jax.make_jaxpr(qfunc)()
+
+    assert jaxpr.eqns[-1].primitive == qml.GroverOperator._primitive
+    assert jaxpr.eqns[-1].params == {"n_wires": 4}
+    assert len(jaxpr.eqns[-1].invars) == 4
+
+    with qml.queuing.AnnotatedQueue() as q:
+        qml.capture.eval_jaxpr(jaxpr.jaxpr, jaxpr.consts)
+
+    assert len(q) == 1
+    qml.assert_equal(q.queue[0], qml.GroverOperator(wires=(0, 1, 2, 3)))
 
 
 def test_parametrized_op():
@@ -268,6 +299,7 @@ class TestSpecialOps:
 
 
 class TestTemplates:
+
     def test_variable_wire_non_parametrized_template(self):
         """Test capturing a variable wire count, non-parametrized template like GroverOperator."""
 


### PR DESCRIPTION
**Context:**

We had some issues with wires being specified as jax or numpy arrays. 

**Description of the Change:**

We now correctly handle wires that are specified either as a jax or a numpy array.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**

Fixes #7088 [sc-86485]