### PR TITLE
[FTQC] Improve robustness of GraphStatePrep wire mapping

### DIFF
--- a/pennylane/ftqc/graph_state_preparation.py
+++ b/pennylane/ftqc/graph_state_preparation.py
@@ -47,11 +47,15 @@ class GraphStatePrep(Operation):
         (:class:`~.pennylane.CZ` gate) operation.
 
     Args:
-        graph (Union[QubitGraph, networkx.Graph]): QubitGraph or networkx.Graph object mapping qubit to wires.
-        one_qubit_ops (Operation): Operator to prepare the initial state of each qubit. Default to :class:`~.pennylane.H`.
-        two_qubit_ops (Operation): Operator to entangle nearest qubits. Default to :class:`~.pennylane.CZ`.
-        wires (Optional[Wires]): Wires the operator applies on. Wires will be mapped 1:1 to graph nodes. Optional only `graph`
-          is a QubitGraph. If no wires are provided, the ``children`` of the provided ``QubitGraph`` will be used as wires.
+        graph (Union[QubitGraph, networkx.Graph]): QubitGraph or networkx.Graph object mapping qubit
+            to wires.
+        one_qubit_ops (Operation): Operator to prepare the initial state of each qubit. Defaults to
+            :class:`~.pennylane.Hadamard`.
+        two_qubit_ops (Operation): Operator to entangle nearest qubits. Defaults to
+            :class:`~.pennylane.CZ`.
+        wires (Optional[Wires]): Wires the operator applies on. Wires are be mapped 1:1 to the graph
+            nodes sorted in ascending order. Optional only `graph` is a QubitGraph. If no wires are
+            provided, the ``children`` of the provided ``QubitGraph`` will be used as wires.
 
     .. todo::
 
@@ -99,6 +103,72 @@ class GraphStatePrep(Operation):
         2: ──Y─╰X────│──╭●─┤  Probs
         3: ──Y───────╰X─╰X─┤  Probs
 
+    .. details::
+        :title: A Note on Node Ordering
+
+        The graph structures used for defining qubit connectivity are inherently *unordered* data
+        structures. Mapping the nodes in the graph to the *ordered* sequence of wires can therefore
+        result in ambiguity. To ensure this mapping is reliable and deterministic, the sequence of
+        wires is mapped to the list of graph nodes sorted in ascending order.
+
+        Consider the following example:
+
+        .. code-block:: python3
+
+            import networkx as nx
+            import pennylane as qml
+            from pennylane.ftqc import GraphStatePrep
+
+            dev = qml.device("default.qubit")
+
+            @qml.qnode(dev)
+            def circuit(graph, wires):
+                GraphStatePrep(graph=graph, one_qubit_ops=qml.H, two_qubit_ops=qml.CZ, wires=wires)
+                return qml.state()
+
+        Defining a graph structure and drawing the circuit shows how the graph node labels have been
+        mapped to wires:
+
+        >>> g1 = nx.Graph([("a", "b"), ("b", "c"), ("c", "d")])  # (a) -- (b) -- (c) -- (d)
+        >>> print(qml.draw(circuit, level="device")(g1, wires=range(4)))
+        0: ──H─╭●───────┤  State
+        1: ──H─╰Z─╭●────┤  State
+        2: ──H────╰Z─╭●─┤  State
+        3: ──H───────╰Z─┤  State
+
+        In other words, ``GraphStatePrep`` has defined the node-label-to-wire mapping::
+
+            {"a": 0, "b": 1, "c": 2, "d": 3}
+
+        which corresponds to the graph structure with wire indices::
+
+            (0) -- (1) -- (2) -- (3)
+
+        as shown in the circuit diagram with ``CZ`` operations applied along each edge in the graph.
+
+        Drawing the circuit for a graph with the same structure but with different node labels
+        gives:
+
+        >>> g2 = nx.Graph([("b", "a"), ("a", "c"), ("c", "d")])  # (b) -- (a) -- (c) -- (d)
+        >>> print(qml.draw(circuit, level="device")(g2, wires=range(4)))
+        0: ──H─╭Z─╭●────┤  State
+        1: ──H─╰●─│─────┤  State
+        2: ──H────╰Z─╭●─┤  State
+        3: ──H───────╰Z─┤  State
+
+        As before, ``GraphStatePrep`` defined the node-label-to-wire mapping to be::
+
+            {"a": 0, "b": 1, "c": 2, "d": 3}
+
+        but now, this corresponds to the graph structure with wire indices::
+
+            (1) -- (0) -- (2) -- (3)
+
+        as shown in the circuit diagram.
+
+        While these two circuit might appear to be the same, they are indeed distinct for this
+        sequence of wires, and result in different state vectors. It is therefore important to
+        remember that the node labels influence how nearest-neighbour wires are interpreted.
     """
 
     def __init__(
@@ -171,12 +241,11 @@ class GraphStatePrep(Operation):
 
         op_list = []
 
-        edges = graph.edge_labels if isinstance(graph, QubitGraph) else graph.edges
         nodes = graph.node_labels if isinstance(graph, QubitGraph) else graph.nodes
+        wire_map = dict(zip(sorted(nodes), wires))
 
-        if set(wires) != set(nodes):
-            wire_map = dict(zip(nodes, wires))
-            edges = [(wire_map[edge[0]], wire_map[edge[1]]) for edge in edges]
+        edges = graph.edge_labels if isinstance(graph, QubitGraph) else graph.edges
+        edges = [(wire_map[edge[0]], wire_map[edge[1]]) for edge in edges]
 
         for wire in wires:
             op_list.append(one_qubit_ops(wires=wire))

--- a/tests/ftqc/test_ftqc_graph_state_prep.py
+++ b/tests/ftqc/test_ftqc_graph_state_prep.py
@@ -399,3 +399,22 @@ class TestGraphStateInvariantUnderInternalGraphOrdering:
         result_ref = circuit(graph_ref)
         result = circuit(graph)
         assert np.all(result_ref == result)
+
+    def test_unsortable_graph_node_labels_raise_type_error(self):
+        """Test that using a graph with unsortable node labels (in this case, the node labels are a
+        mix of integers and strings) as input to GraphStatePrep raises a TypeError.
+        """
+        # Graph structure: (0) -- (a) -- (1)
+        graph = nx.Graph({0: {"a"}, "a": (0, 1), 1: {"a"}})
+        dev = qml.device("default.qubit")
+
+        @qml.qnode(dev)
+        def circuit():
+            GraphStatePrep(graph=graph, wires=[0, 1, 2])
+            return qml.state()
+
+        with pytest.raises(
+            TypeError,
+            match="GraphStatePrep requires the node labels of the input graph to be sortable",
+        ):
+            circuit()

--- a/tests/ftqc/test_ftqc_graph_state_prep.py
+++ b/tests/ftqc/test_ftqc_graph_state_prep.py
@@ -367,6 +367,219 @@ class TestGraphStateInvariantUnderInternalGraphOrdering:
 
         self._check_graphs_yield_same_state(graph, graph_ref, wires, one_qubit_op, two_qubit_op)
 
+    @pytest.mark.parametrize(
+        "graph",
+        [
+            # Permute the node order in the adjacency list
+            nx.Graph({1: {0, 3}, 2: {0, 3}, 3: {1, 2}, 0: {1, 2}}),
+            nx.Graph({2: {0, 3}, 3: {1, 2}, 0: {1, 2}, 1: {0, 3}}),
+            nx.Graph({3: {1, 2}, 0: {1, 2}, 1: {0, 3}, 2: {0, 3}}),
+            nx.Graph({0: {1, 2}, 1: {0, 3}, 3: {1, 2}, 2: {0, 3}}),
+            nx.Graph({0: {1, 2}, 2: {0, 3}, 1: {0, 3}, 3: {1, 2}}),
+            nx.Graph({1: {0, 3}, 0: {1, 2}, 2: {0, 3}, 3: {1, 2}}),
+        ],
+    )
+    @pytest.mark.parametrize("one_qubit_op", [qml.H, qml.X, qml.Y, qml.Z, qml.S])
+    @pytest.mark.parametrize("two_qubit_op", [qml.CZ])
+    def test_graph_state_invariant_under_internal_ordering_2d_grid_same_wires_indices(
+        self, graph, one_qubit_op, two_qubit_op
+    ):
+        """Test that the state returned by GraphStatePrep is invariant under the internal ordering
+        of the nodes and edges in the graph.
+
+        The graph structure is a 2D grid and the sets of node and wire labels are the same.
+        """
+        # Graph structure: (0) -- (1)
+        #                   |      |
+        #                  (2) -- (3)
+        graph_ref = nx.Graph({0: {1, 2}, 1: {0, 3}, 2: {0, 3}, 3: {1, 2}})
+
+        # The sequence of wires is constant
+        wires = [0, 1, 2, 3]
+
+        self._check_graphs_yield_same_state(graph, graph_ref, wires, one_qubit_op, two_qubit_op)
+
+    @pytest.mark.parametrize(
+        "graph",
+        [
+            # Permute the node order in the adjacency list
+            nx.Graph(
+                {
+                    (0, 1): {(0, 0), (1, 1)},
+                    (1, 0): {(0, 0), (1, 1)},
+                    (1, 1): {(0, 1), (1, 0)},
+                    (0, 0): {(1, 0), (0, 1)},
+                }
+            ),
+            nx.Graph(
+                {
+                    (1, 0): {(0, 0), (1, 1)},
+                    (1, 1): {(0, 1), (1, 0)},
+                    (0, 0): {(1, 0), (0, 1)},
+                    (0, 1): {(0, 0), (1, 1)},
+                }
+            ),
+            nx.Graph(
+                {
+                    (1, 1): {(0, 1), (1, 0)},
+                    (0, 0): {(1, 0), (0, 1)},
+                    (0, 1): {(0, 0), (1, 1)},
+                    (1, 0): {(0, 0), (1, 1)},
+                }
+            ),
+        ],
+    )
+    @pytest.mark.parametrize("one_qubit_op", [qml.H, qml.X, qml.Y, qml.Z, qml.S])
+    @pytest.mark.parametrize("two_qubit_op", [qml.CZ])
+    def test_graph_state_invariant_under_internal_ordering_2d_grid_diff_wires_indices(
+        self, graph, one_qubit_op, two_qubit_op
+    ):
+        """Test that the state returned by GraphStatePrep is invariant under the internal ordering
+        of the nodes and edges in the graph.
+
+        The graph structure is a 2D grid and the sets of node and wire labels are different.
+        """
+        # Graph structure: (0,0) -- (0,1)
+        #                    |        |
+        #                  (1,0) -- (1,1)
+        graph_ref = nx.Graph(
+            {
+                (0, 0): {(1, 0), (0, 1)},
+                (0, 1): {(0, 0), (1, 1)},
+                (1, 0): {(0, 0), (1, 1)},
+                (1, 1): {(0, 1), (1, 0)},
+            }
+        )
+
+        # The sequence of wires is constant
+        wires = [0, 1, 2, 3]
+
+        self._check_graphs_yield_same_state(graph, graph_ref, wires, one_qubit_op, two_qubit_op)
+
+    @pytest.mark.parametrize(
+        "graph",
+        [
+            # Permute the node order in the adjacency list
+            nx.Graph(
+                {
+                    1: {0, 3, 5},
+                    2: {0, 3, 6},
+                    3: {1, 2, 7},
+                    4: {0, 5, 6},
+                    5: {1, 4, 7},
+                    6: {2, 4, 7},
+                    7: {3, 5, 6},
+                    0: {1, 2, 4},
+                }
+            ),
+            nx.Graph(
+                {
+                    2: {0, 3, 6},
+                    3: {1, 2, 7},
+                    4: {0, 5, 6},
+                    5: {1, 4, 7},
+                    6: {2, 4, 7},
+                    7: {3, 5, 6},
+                    0: {1, 2, 4},
+                    1: {0, 3, 5},
+                }
+            ),
+            nx.Graph(
+                {
+                    3: {1, 2, 7},
+                    4: {0, 5, 6},
+                    5: {1, 4, 7},
+                    6: {2, 4, 7},
+                    7: {3, 5, 6},
+                    0: {1, 2, 4},
+                    1: {0, 3, 5},
+                    2: {0, 3, 6},
+                }
+            ),
+            nx.Graph(
+                {
+                    4: {0, 5, 6},
+                    5: {1, 4, 7},
+                    6: {2, 4, 7},
+                    7: {3, 5, 6},
+                    0: {1, 2, 4},
+                    1: {0, 3, 5},
+                    2: {0, 3, 6},
+                    3: {1, 2, 7},
+                }
+            ),
+            nx.Graph(
+                {
+                    5: {1, 4, 7},
+                    6: {2, 4, 7},
+                    7: {3, 5, 6},
+                    0: {1, 2, 4},
+                    1: {0, 3, 5},
+                    2: {0, 3, 6},
+                    3: {1, 2, 7},
+                    4: {0, 5, 6},
+                }
+            ),
+            nx.Graph(
+                {
+                    6: {2, 4, 7},
+                    7: {3, 5, 6},
+                    0: {1, 2, 4},
+                    1: {0, 3, 5},
+                    2: {0, 3, 6},
+                    3: {1, 2, 7},
+                    4: {0, 5, 6},
+                    5: {1, 4, 7},
+                }
+            ),
+            nx.Graph(
+                {
+                    7: {3, 5, 6},
+                    0: {1, 2, 4},
+                    1: {0, 3, 5},
+                    2: {0, 3, 6},
+                    3: {1, 2, 7},
+                    4: {0, 5, 6},
+                    5: {1, 4, 7},
+                    6: {2, 4, 7},
+                }
+            ),
+        ],
+    )
+    @pytest.mark.parametrize("one_qubit_op", [qml.H, qml.X, qml.Y, qml.Z, qml.S])
+    @pytest.mark.parametrize("two_qubit_op", [qml.CZ])
+    def test_graph_state_invariant_under_internal_ordering_3d_grid_same_wires_indices(
+        self, graph, one_qubit_op, two_qubit_op
+    ):
+        """Test that the state returned by GraphStatePrep is invariant under the internal ordering
+        of the nodes and edges in the graph.
+
+        The graph structure is a 3D chain and the set of node and wire labels are the same.
+        """
+        # Graph structure:    (4)-----(5)
+        #                     /|      /|
+        #                  (0)-----(1) |
+        #                   | (6)---|-(7)
+        #                   | /     | /
+        #                  (2)-----(3)
+        graph_ref = nx.Graph(
+            {
+                0: {1, 2, 4},
+                1: {0, 3, 5},
+                2: {0, 3, 6},
+                3: {1, 2, 7},
+                4: {0, 5, 6},
+                5: {1, 4, 7},
+                6: {2, 4, 7},
+                7: {3, 5, 6},
+            }
+        )
+
+        # The sequence of wires is constant
+        wires = [0, 1, 2, 3, 4, 5, 6, 7]
+
+        self._check_graphs_yield_same_state(graph, graph_ref, wires, one_qubit_op, two_qubit_op)
+
     @staticmethod
     def _check_graphs_yield_same_state(graph, graph_ref, wires, one_qubit_op, two_qubit_op):
         """Helper function for the above tests.

--- a/tests/ftqc/test_ftqc_graph_state_prep.py
+++ b/tests/ftqc/test_ftqc_graph_state_prep.py
@@ -327,7 +327,7 @@ class TestGraphStateInvariantUnderInternalGraphOrdering:
         """Test that the state returned by GraphStatePrep is invariant under the internal ordering
         of the nodes and edges in the graph.
 
-        The graph structure is a 1D chain and the set of node and wire labels are the same.
+        The graph structure is a 1D chain and the sets of node and wire labels are the same.
         """
         # Graph structure: (0) -- (1) -- (2) -- (3)
         graph_ref = nx.Graph({0: {1}, 1: {0, 2}, 2: {1, 3}, 3: {2}})
@@ -357,7 +357,7 @@ class TestGraphStateInvariantUnderInternalGraphOrdering:
         """Test that the state returned by GraphStatePrep is invariant under the internal ordering
         of the nodes and edges in the graph.
 
-        The graph structure is a 1D chain and the set of node and wire labels are different.
+        The graph structure is a 1D chain and the sets of node and wire labels are different.
         """
         # Graph structure: ("a") -- ("b") -- ("c") -- ("d")
         graph_ref = nx.Graph({"a": {"b"}, "b": {"a", "c"}, "c": {"b", "d"}, "d": {"c"}})
@@ -554,7 +554,7 @@ class TestGraphStateInvariantUnderInternalGraphOrdering:
         """Test that the state returned by GraphStatePrep is invariant under the internal ordering
         of the nodes and edges in the graph.
 
-        The graph structure is a 3D chain and the set of node and wire labels are the same.
+        The graph structure is a 3D chain and the sets of node and wire labels are the same.
         """
         # Graph structure:    (4)-----(5)
         #                     /|      /|

--- a/tests/ftqc/test_ftqc_graph_state_prep.py
+++ b/tests/ftqc/test_ftqc_graph_state_prep.py
@@ -310,30 +310,27 @@ class TestGraphStateInvariantUnderInternalGraphOrdering:
     @pytest.mark.parametrize(
         "graph",
         [
-            # Permute the edges
-            nx.Graph([(1, 2), (2, 3), (0, 1)]),
-            nx.Graph([(2, 3), (0, 1), (1, 2)]),
-            nx.Graph([(0, 1), (2, 3), (1, 2)]),
-            # Permute the nodes within an edge
-            nx.Graph([(1, 0), (1, 2), (2, 3)]),
-            nx.Graph([(0, 1), (2, 1), (2, 3)]),
-            nx.Graph([(0, 1), (1, 2), (3, 2)]),
-            nx.Graph([(0, 1), (2, 1), (3, 2)]),
-            nx.Graph([(1, 0), (2, 1), (3, 2)]),
+            # Permute the node order in the adjacency list
+            nx.Graph({1: {0, 2}, 2: {1, 3}, 3: {2}, 0: {1}}),
+            nx.Graph({2: {1, 3}, 3: {2}, 0: {1}, 1: {0, 2}}),
+            nx.Graph({3: {2}, 0: {1}, 1: {0, 2}, 2: {1, 3}}),
+            nx.Graph({0: {1}, 1: {0, 2}, 3: {2}, 2: {1, 3}}),
+            nx.Graph({0: {1}, 2: {1, 3}, 1: {0, 2}, 3: {2}}),
+            nx.Graph({1: {0, 2}, 0: {1}, 2: {1, 3}, 3: {2}}),
         ],
     )
     @pytest.mark.parametrize("one_qubit_op", [qml.H, qml.X, qml.Y, qml.Z, qml.S])
     @pytest.mark.parametrize("two_qubit_op", [qml.CZ])
-    def test_graph_state_invariant_under_internal_ordering_same_wires_indices(
+    def test_graph_state_invariant_under_internal_ordering_1d_chain_same_wires_indices(
         self, graph, one_qubit_op, two_qubit_op
     ):
         """Test that the state returned by GraphStatePrep is invariant under the internal ordering
         of the nodes and edges in the graph.
 
-        The set of node and wire labels are the same in this test.
+        The graph structure is a 1D chain and the set of node and wire labels are the same.
         """
         # Graph structure: (0) -- (1) -- (2) -- (3)
-        graph_ref = nx.Graph([(0, 1), (1, 2), (2, 3)])
+        graph_ref = nx.Graph({0: {1}, 1: {0, 2}, 2: {1, 3}, 3: {2}})
 
         # The sequence of wires is constant
         wires = [0, 1, 2, 3]
@@ -343,30 +340,27 @@ class TestGraphStateInvariantUnderInternalGraphOrdering:
     @pytest.mark.parametrize(
         "graph",
         [
-            # Permute the edges
-            nx.Graph([("b", "c"), ("c", "d"), ("a", "b")]),
-            nx.Graph([("c", "d"), ("a", "b"), ("b", "c")]),
-            nx.Graph([("a", "b"), ("c", "d"), ("b", "c")]),
-            # Permute the nodes within an edge
-            nx.Graph([("b", "a"), ("b", "c"), ("c", "d")]),
-            nx.Graph([("a", "b"), ("c", "b"), ("c", "d")]),
-            nx.Graph([("a", "b"), ("b", "c"), ("d", "c")]),
-            nx.Graph([("a", "b"), ("c", "b"), ("d", "c")]),
-            nx.Graph([("b", "a"), ("c", "b"), ("d", "c")]),
+            # Permute the node order in the adjacency list
+            nx.Graph({"b": {"a", "c"}, "c": {"b", "d"}, "d": {"c"}, "a": {"b"}}),
+            nx.Graph({"c": {"b", "d"}, "d": {"c"}, "a": {"b"}, "b": {"a", "c"}}),
+            nx.Graph({"d": {"c"}, "a": {"b"}, "b": {"a", "c"}, "c": {"b", "d"}}),
+            nx.Graph({"a": {"b"}, "b": {"a", "c"}, "d": {"c"}, "c": {"b", "d"}}),
+            nx.Graph({"a": {"b"}, "c": {"b", "d"}, "b": {"a", "c"}, "d": {"c"}}),
+            nx.Graph({"b": {"a", "c"}, "a": {"b"}, "c": {"b", "d"}, "d": {"c"}}),
         ],
     )
     @pytest.mark.parametrize("one_qubit_op", [qml.H, qml.X, qml.Y, qml.Z, qml.S])
     @pytest.mark.parametrize("two_qubit_op", [qml.CZ])
-    def test_graph_state_invariant_under_internal_ordering_diff_wires_indices(
+    def test_graph_state_invariant_under_internal_ordering_1d_chain_diff_wires_indices(
         self, graph, one_qubit_op, two_qubit_op
     ):
         """Test that the state returned by GraphStatePrep is invariant under the internal ordering
         of the nodes and edges in the graph.
 
-        The set of node and wire labels are different in this test.
+        The graph structure is a 1D chain and the set of node and wire labels are different.
         """
-        # Graph structure: (a) -- (b) -- (c) -- (d)
-        graph_ref = nx.Graph([("a", "b"), ("b", "c"), ("c", "d")])
+        # Graph structure: ("a") -- ("b") -- ("c") -- ("d")
+        graph_ref = nx.Graph({"a": {"b"}, "b": {"a", "c"}, "c": {"b", "d"}, "d": {"c"}})
 
         # The sequence of wires is constant
         wires = [0, 1, 2, 3]

--- a/tests/ftqc/test_ftqc_graph_state_prep.py
+++ b/tests/ftqc/test_ftqc_graph_state_prep.py
@@ -319,7 +319,7 @@ class TestGraphStateInvariantUnderInternalGraphOrdering:
             nx.Graph({1: {0, 2}, 0: {1}, 2: {1, 3}, 3: {2}}),
         ],
     )
-    @pytest.mark.parametrize("one_qubit_op", [qml.H, qml.X, qml.Y, qml.Z, qml.S])
+    @pytest.mark.parametrize("one_qubit_op", [qml.H, qml.X, qml.Y, qml.Z, qml.S, qml.SX])
     @pytest.mark.parametrize("two_qubit_op", [qml.CZ])
     def test_graph_state_invariant_under_internal_ordering_1d_chain_same_wires_indices(
         self, graph, one_qubit_op, two_qubit_op
@@ -349,7 +349,7 @@ class TestGraphStateInvariantUnderInternalGraphOrdering:
             nx.Graph({"b": {"a", "c"}, "a": {"b"}, "c": {"b", "d"}, "d": {"c"}}),
         ],
     )
-    @pytest.mark.parametrize("one_qubit_op", [qml.H, qml.X, qml.Y, qml.Z, qml.S])
+    @pytest.mark.parametrize("one_qubit_op", [qml.H, qml.X, qml.Y, qml.Z, qml.S, qml.SX])
     @pytest.mark.parametrize("two_qubit_op", [qml.CZ])
     def test_graph_state_invariant_under_internal_ordering_1d_chain_diff_wires_indices(
         self, graph, one_qubit_op, two_qubit_op
@@ -379,7 +379,7 @@ class TestGraphStateInvariantUnderInternalGraphOrdering:
             nx.Graph({1: {0, 3}, 0: {1, 2}, 2: {0, 3}, 3: {1, 2}}),
         ],
     )
-    @pytest.mark.parametrize("one_qubit_op", [qml.H, qml.X, qml.Y, qml.Z, qml.S])
+    @pytest.mark.parametrize("one_qubit_op", [qml.H, qml.X, qml.Y, qml.Z, qml.S, qml.SX])
     @pytest.mark.parametrize("two_qubit_op", [qml.CZ])
     def test_graph_state_invariant_under_internal_ordering_2d_grid_same_wires_indices(
         self, graph, one_qubit_op, two_qubit_op
@@ -429,7 +429,7 @@ class TestGraphStateInvariantUnderInternalGraphOrdering:
             ),
         ],
     )
-    @pytest.mark.parametrize("one_qubit_op", [qml.H, qml.X, qml.Y, qml.Z, qml.S])
+    @pytest.mark.parametrize("one_qubit_op", [qml.H, qml.X, qml.Y, qml.Z, qml.S, qml.SX])
     @pytest.mark.parametrize("two_qubit_op", [qml.CZ])
     def test_graph_state_invariant_under_internal_ordering_2d_grid_diff_wires_indices(
         self, graph, one_qubit_op, two_qubit_op
@@ -546,7 +546,7 @@ class TestGraphStateInvariantUnderInternalGraphOrdering:
             ),
         ],
     )
-    @pytest.mark.parametrize("one_qubit_op", [qml.H, qml.X, qml.Y, qml.Z, qml.S])
+    @pytest.mark.parametrize("one_qubit_op", [qml.H, qml.X, qml.Y, qml.Z, qml.S, qml.SX])
     @pytest.mark.parametrize("two_qubit_op", [qml.CZ])
     def test_graph_state_invariant_under_internal_ordering_3d_grid_same_wires_indices(
         self, graph, one_qubit_op, two_qubit_op


### PR DESCRIPTION
**Context:** The order of the nodes in a graph is not well defined since the graph structures used for defining qubit connectivity are inherently *unordered* data structures. Mapping the nodes in the graph to the *ordered* sequence of wires can therefore result in ambiguity. This is especially troublesome given that NetworkX uses Python `dict` objects to store a graph's adjacency list. Python `dict` objects are insertion-ordered ([since Python 3.7](https://docs.python.org/3/whatsnew/3.7.html#summary-release-highlights)), therefore it's possible to define the same graph structure with different internal node ordering, depending on the order in which the nodes were inserted into the graph.

`GraphStatePrep` requires a robust, deterministic method to map node labels to wire indices that do not depend on such things as the node-insertion order into the graph.

**Description of the Change:** To ensure this mapping is reliable and deterministic, the sequence of wires is mapped to the list of graph nodes *sorted in ascending order*. Additional tests and documentation explaining node ordering have also been added.