### PR TITLE
Just update pjit call on `FlattenedInterpreter`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -505,6 +505,7 @@
 
 * Execution interpreters and `qml.capture.eval_jaxpr` can now handle jax `pjit` primitives when dynamic shapes are being used.
   [(#7078)](https://github.com/PennyLaneAI/pennylane/pull/7078)
+  [(#7117)](https://github.com/PennyLaneAI/pennylane/pull/7117)
 
 <h3>Labs: a place for unified and rapid prototyping of research software 🧪</h3>
 

--- a/pennylane/capture/base_interpreter.py
+++ b/pennylane/capture/base_interpreter.py
@@ -432,17 +432,6 @@ def _(self, x, *dyn_shape, shape, broadcast_dimensions):
     return jax.lax.broadcast_in_dim(x, new_shape, broadcast_dimensions=broadcast_dimensions)
 
 
-# pylint: disable=protected-access
-@PlxprInterpreter.register_primitive(jax._src.pjit.pjit_p)
-def _(self, *invals, jaxpr, **params):
-    if jax.config.jax_dynamic_shapes:
-        # just evaluate it so it doesn't throw dynamic shape errors
-        return copy(self).eval(jaxpr.jaxpr, jaxpr.consts, *invals)
-
-    subfuns, params = jax._src.pjit.pjit_p.get_bind_params({"jaxpr": jaxpr, **params})
-    return jax._src.pjit.pjit_p.bind(*subfuns, *invals, **params)
-
-
 # pylint: disable=unused-argument
 @PlxprInterpreter.register_primitive(jax.lax.iota_p)
 def _(self, *dyn_shape, dimension, dtype, shape):
@@ -648,6 +637,17 @@ class FlattenedInterpreter(PlxprInterpreter):
     ``for_prim``, ``while_prim``, and ``cond_prim``. Useful for evaluating, instead
     of just transforming.
     """
+
+
+# pylint: disable=protected-access
+@FlattenedInterpreter.register_primitive(jax._src.pjit.pjit_p)
+def _(self, *invals, jaxpr, **params):
+    if jax.config.jax_dynamic_shapes:
+        # just evaluate it so it doesn't throw dynamic shape errors
+        return copy(self).eval(jaxpr.jaxpr, jaxpr.consts, *invals)
+
+    subfuns, params = jax._src.pjit.pjit_p.get_bind_params({"jaxpr": jaxpr, **params})
+    return jax._src.pjit.pjit_p.bind(*subfuns, *invals, **params)
 
 
 @FlattenedInterpreter.register_primitive(while_loop_prim)


### PR DESCRIPTION
**Context:**

The custom pjit call was causing issues in catalyst, as they use the `BaseInterpreter` class. So I've just moved it to `FlattenedInterpreter` so that only execution-style interpreters will have a custom pjit logic.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
