### PR TITLE
Fix gen_is_multi_term_hamiltonian

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -713,7 +713,11 @@
 
 <h3>Bug fixes 🐛</h3>
 
-* Fixes `qml.operation.gen_is_multi_term_hamiltonian` to work with more complicated generators.
+
+* Fixes a bug that caused the output of `qml.fourier.qnode_spectrum()` to
+  differ depending if equivalent gate generators are defined using
+  different PennyLane operators. This was resolved by updating
+  `qml.operation.gen_is_multi_term_hamiltonian` to work with more complicated generators.
   [(#7121)])(https://github.com/PennyLaneAI/pennylane/pull/7121)
 
 * Modulo operator calls on MCMs now correctly offload to the autoray-backed `qml.math.mod` dispatch.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -713,7 +713,6 @@
 
 <h3>Bug fixes 🐛</h3>
 
-
 * Fixes a bug that caused the output of `qml.fourier.qnode_spectrum()` to
   differ depending if equivalent gate generators are defined using
   different PennyLane operators. This was resolved by updating

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -713,6 +713,8 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Fixes `qml.operation.gen_is_multi_term_hamiltonian` to work with more complicated generators.
+
 * Modulo operator calls on MCMs now correctly offload to the autoray-backed `qml.math.mod` dispatch.
   [(#7085)](https://github.com/PennyLaneAI/pennylane/pull/7085)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -714,6 +714,7 @@
 <h3>Bug fixes 🐛</h3>
 
 * Fixes `qml.operation.gen_is_multi_term_hamiltonian` to work with more complicated generators.
+  [(#7121)])(https://github.com/PennyLaneAI/pennylane/pull/7121)
 
 * Modulo operator calls on MCMs now correctly offload to the autoray-backed `qml.math.mod` dispatch.
   [(#7085)](https://github.com/PennyLaneAI/pennylane/pull/7085)

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -2419,7 +2419,9 @@ def gen_is_multi_term_hamiltonian(obj):
     if not isinstance(obj, Operator) or not obj.has_generator:
         return False
     try:
-        return len(obj.generator().terms()[1]) > 1
+        generator = obj.generator()
+        _, ops = generator.terms() # len(coeffs) can be weird sometimes
+        return len(ops) > 1
     except TermsUndefinedError:
         return False
 

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -2416,13 +2416,12 @@ def defines_diagonalizing_gates(obj):
 def gen_is_multi_term_hamiltonian(obj):
     """Returns ``True`` if an operator has a generator defined and it is a Hamiltonian
     with more than one term."""
-
-    try:
-        o = obj.generator()
-    except (AttributeError, OperatorPropertyUndefined, GeneratorUndefinedError):
+    if not isinstance(obj, Operator) or not obj.has_generator:
         return False
-
-    return isinstance(o, qml.ops.LinearCombination) and len(o.coeffs) > 1
+    try:
+        return len(obj.generator().terms()[1]) > 1
+    except TermsUndefinedError:
+        return False
 
 
 def __getattr__(name):

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -2420,7 +2420,7 @@ def gen_is_multi_term_hamiltonian(obj):
         return False
     try:
         generator = obj.generator()
-        _, ops = generator.terms() # len(coeffs) can be weird sometimes
+        _, ops = generator.terms()  # len(coeffs) can be weird sometimes
         return len(ops) > 1
     except TermsUndefinedError:
         return False

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -1611,6 +1611,20 @@ class TestCriteria:
         assert not qml.operation.gen_is_multi_term_hamiltonian(self.rot)
         assert not qml.operation.gen_is_multi_term_hamiltonian(self.exp)
 
+        class SProdGen(Operator):
+
+            def generator(self):
+                return 2.0 * (qml.X(0) + qml.Y(0))
+
+        assert qml.operation.gen_is_multi_term_hamiltonian(SProdGen(wires=0))
+
+        class SumGen(Operator):
+
+            def generator(self):
+                return qml.X(0) + qml.Y(1)
+
+        assert qml.operation.gen_is_multi_term_hamiltonian(SumGen(wires=0))
+
     def test_has_multipar(self):
         """Test has_multipar criterion."""
         assert not qml.operation.has_multipar(self.rx)


### PR DESCRIPTION
**Context:**

`qml.operation.gen_is_multiterm_hamiltonian` was never properly updated for new operator arithmetic.

**Description of the Change:**

Allow is to work with general generators.

**Benefits:**

The `fourier.qnode_spectrum` works for general generators.

**Possible Drawbacks:**

**Related GitHub Issues:**
Fixes #7116 

**Related Shortcut Stories:**
[sc-86870]
