### PR TITLE
Fix flaky tests in `test_capture_qnode.py`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -7,6 +7,7 @@
 * Device preprocessing is now being performed in the execution pipeline for program capture.
   [(#7057)](https://github.com/PennyLaneAI/pennylane/pull/7057)
   [(#7089)](https://github.com/PennyLaneAI/pennylane/pull/7089)
+  [(#7131)](https://github.com/PennyLaneAI/pennylane/pull/7131)
 
 * Added method `qml.math.sqrt_matrix_sparse` to compute the square root of a sparse Hermitian matrix.
   [(#6976)](https://github.com/PennyLaneAI/pennylane/pull/6976)

--- a/tests/capture/workflow/test_capture_qnode.py
+++ b/tests/capture/workflow/test_capture_qnode.py
@@ -435,7 +435,7 @@ class TestDevicePreprocessing:
             assert len(shots_res) == shots
             # Check it's roughly 50/50 by counting the second column of bits
             counts = qml.numpy.bincount(shots_res[:, 1].astype(int))
-            assert qml.math.isclose(counts[0] / counts[1], 1, atol=0.2)
+            assert qml.math.isclose(counts[0] / counts[1], 1, atol=0.3)
 
     @pytest.mark.parametrize("mcm_method", [None, "deferred"])
     def test_mcm_execution_deferred_hw_like(self, dev_name, mcm_method, seed):
@@ -481,7 +481,8 @@ class TestDevicePreprocessing:
             return qml.sample(wires=[0])
 
         # pylint: disable = not-an-iterable
-        assert all(sample == 0 for sample in circuit()) or all(sample == 1 for sample in circuit())
+        results = circuit()
+        assert all(sample == 0 for sample in results) or all(sample == 1 for sample in results)
 
 
 class TestDifferentiation:


### PR DESCRIPTION
**Context:**

Noticed some flaky test [errors](https://github.com/PennyLaneAI/pennylane/actions/runs/13971550371/job/39114663419?pr=7099) in our CI,

```
FAILED tests/capture/workflow/test_capture_qnode.py::TestDevicePreprocessing::test_mcm_execution_deferred_fill_shots[deferred-lightning.qubit] - AssertionError: assert tensor(False, requires_grad=True)
 +  where tensor(False, requires_grad=True) = functools.partial(<function do at 0x7f615dfb70a0>, 'isclose')((tensor(441, requires_grad=True) / tensor(559, requires_grad=True)), 1, atol=0.2)
 +    where functools.partial(<function do at 0x7f615dfb70a0>, 'isclose') = <module 'pennylane.math' from '/home/runner/work/pennylane/pennylane/pennylane/math/__init__.py'>.isclose
 +      where <module 'pennylane.math' from '/home/runner/work/pennylane/pennylane/pennylane/math/__init__.py'> = qml.math
FAILED tests/capture/workflow/test_capture_qnode.py::TestDevicePreprocessing::test_mcms_execution_single_branch_statistics[lightning.qubit] - assert (False or False)
 +  where False = all(<generator object TestDevicePreprocessing.test_mcms_execution_single_branch_statistics.<locals>.<genexpr> at 0x7f617af29fc0>)
 +  and   False = all(<generator object TestDevicePreprocessing.test_mcms_execution_single_branch_statistics.<locals>.<genexpr> at 0x7f617af2bc30>)
```


**Description of the Change:**

Made two changes to two different tests,

- Bump `atol` that is checking for a roughly 50/50 distribution.
- Store circuit execution results into a variable. This assert called the `circuit` twice, and sometimes there is a chance that both of the asserts could be false lol. 🤦🏼 
```python
assert all(sample == 0 for sample in circuit()) or all(sample == 1 for sample in circuit())
```

**Benefits:** No more flaky test.

**Possible Drawbacks:** None identified.

[sc-86992]
