### PR TITLE
Fix the issue that ctrl a sparse QubitUnitary doesn't work

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -222,6 +222,7 @@
   
 * `default.qubit` now supports the sparse matrices to be applied to the state vector. Specifically, `QubitUnitary` initialized with a sparse matrix can now be applied to the state vector in the `default.qubit` device.
   [(#6883)](https://github.com/PennyLaneAI/pennylane/pull/6883)
+  [(#7139)](https://github.com/PennyLaneAI/pennylane/pull/7139)
 
 * `merge_rotations` now correctly simplifies merged `qml.Rot` operators whose angles yield the identity operator.
   [(#7011)](https://github.com/PennyLaneAI/pennylane/pull/7011)

--- a/pennylane/ops/op_math/controlled.py
+++ b/pennylane/ops/op_math/controlled.py
@@ -321,7 +321,7 @@ def _try_wrap_in_custom_ctrl_op(op, control, control_values=None, work_wires=Non
     if isinstance(op, qml.QubitUnitary):
         qml.QueuingManager.remove(op)
         return qml.ControlledQubitUnitary(
-            op.matrix(),
+            op.matrix() if op.has_matrix else op.sparse_matrix(),
             wires=control + op.wires,
             control_values=control_values,
             work_wires=work_wires,

--- a/tests/ops/op_math/test_controlled.py
+++ b/tests/ops/op_math/test_controlled.py
@@ -18,6 +18,7 @@ from functools import partial
 
 import numpy as np
 import pytest
+import scipy as sp
 from gate_data import (
     CCZ,
     CH,
@@ -1704,6 +1705,18 @@ custom_ctrl_ops = [
 
 class TestCtrl:
     """Tests for the ctrl transform."""
+
+    def test_sparse_qubit_unitary(self):
+        """Test that the controlled sparse QubitUnitary works correctly"""
+        data = sp.sparse.eye(2)
+        op = qml.QubitUnitary(data, wires=2)
+        c_op = qml.ctrl(op, 3)
+
+        data_dense = data.toarray()
+        op_dense = qml.QubitUnitary(data_dense, wires=2)
+        c_op_dense = qml.ctrl(op_dense, 3)
+
+        assert qml.math.allclose(c_op.sparse_matrix(), c_op_dense.matrix())
 
     def test_no_redundant_queue(self):
         """Test that the ctrl transform does not add redundant operations to the queue. https://github.com/PennyLaneAI/pennylane/pull/6926"""

--- a/tests/ops/op_math/test_controlled_ops.py
+++ b/tests/ops/op_math/test_controlled_ops.py
@@ -17,6 +17,7 @@ Unit tests for Operators inheriting from ControlledOp.
 
 import numpy as np
 import pytest
+import scipy as sp
 from gate_data import CY, CZ, ControlledPhaseShift, CRot3, CRotx, CRoty, CRotz
 from scipy.linalg import fractional_matrix_power
 from scipy.stats import unitary_group
@@ -52,6 +53,16 @@ X_broadcasted = np.array([X] * 3)
 # pylint: disable=too-many-public-methods
 class TestControlledQubitUnitary:
     """Tests specific to the ControlledQubitUnitary operation"""
+
+    def test_sparse_matrix(self):
+        """Test that the controlled sparse QubitUnitary works correctly"""
+        data = sp.sparse.eye(2)
+        c_op = qml.ControlledQubitUnitary(data, wires=[0, 1])
+
+        data_dense = data.toarray()
+        c_op_dense = qml.ControlledQubitUnitary(data_dense, wires=[0, 1])
+
+        assert qml.math.allclose(c_op.sparse_matrix(), c_op_dense.matrix())
 
     def test_flatten_unflatten(self):
         """Test that the operation can be flattened and unflattened"""

--- a/tests/ops/op_math/test_controlled_ops.py
+++ b/tests/ops/op_math/test_controlled_ops.py
@@ -17,7 +17,6 @@ Unit tests for Operators inheriting from ControlledOp.
 
 import numpy as np
 import pytest
-import scipy as sp
 from gate_data import CY, CZ, ControlledPhaseShift, CRot3, CRotx, CRoty, CRotz
 from scipy.linalg import fractional_matrix_power
 from scipy.stats import unitary_group
@@ -53,16 +52,6 @@ X_broadcasted = np.array([X] * 3)
 # pylint: disable=too-many-public-methods
 class TestControlledQubitUnitary:
     """Tests specific to the ControlledQubitUnitary operation"""
-
-    def test_sparse_matrix(self):
-        """Test that the controlled sparse QubitUnitary works correctly"""
-        data = sp.sparse.eye(2)
-        c_op = qml.ControlledQubitUnitary(data, wires=[0, 1])
-
-        data_dense = data.toarray()
-        c_op_dense = qml.ControlledQubitUnitary(data_dense, wires=[0, 1])
-
-        assert qml.math.allclose(c_op.sparse_matrix(), c_op_dense.matrix())
 
     def test_flatten_unflatten(self):
         """Test that the operation can be flattened and unflattened"""


### PR DESCRIPTION
**Context:**
After implementing the sparse `QubitUnitary`, the `qml.ctrl` over a sparse QU does not work:

```python
>>> op = qml.QubitUnitary(sparse.eye(2), wires=2)
>>> qml.ctrl(op, 3)
MatrixUndefinedError: U is sparse matrix. Use sparse_matrix method instead.
```

**Description of the Change:**
Added a conditional branch in `ctrl`

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
