### PR TITLE
Fix decomposition of two qubit sparse qubitunitary

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -190,6 +190,8 @@
 
 <h3>Improvements 🛠</h3>
 
+* The decomposition of a single qubit `qml.QubitUnitary` now includes the global phase.
+
 * A new utility module `qml.ftqc.utils` is provided, with support for functionality such as dynamic qubit recycling.
   [(#7075)](https://github.com/PennyLaneAI/pennylane/pull/7075/)
   

--- a/pennylane/ops/op_math/controlled.py
+++ b/pennylane/ops/op_math/controlled.py
@@ -480,7 +480,7 @@ class Controlled(SymbolicOp):
             return object.__new__(ControlledOp)
         return object.__new__(Controlled)
 
-    # pylint: disable=arguments-differ
+    # pylint: disable=arguments-differ, too-many-positional-arguments
     @classmethod
     def _primitive_bind_call(
         cls, base, control_wires, control_values=None, work_wires=None, id=None
@@ -490,7 +490,7 @@ class Controlled(SymbolicOp):
             base, *control_wires, control_values=control_values, work_wires=work_wires
         )
 
-    # pylint: disable=too-many-function-args
+    # pylint: disable=too-many-function-args, too-many-positional-arguments
     def __init__(
         self,
         base,
@@ -734,7 +734,12 @@ class Controlled(SymbolicOp):
             return True
         if not all(self.control_values):
             return True
-        if len(self.control_wires) == 1 and hasattr(self.base, "_controlled"):
+        # not already the simplified version
+        if (
+            len(self.control_wires) == 1
+            and hasattr(self.base, "_controlled")
+            and type(self) in {Controlled, ControlledOp}
+        ):
             return True
         is_su2 = _is_single_qubit_special_unitary(self.base)
         if not qml.math.is_abstract(is_su2) and is_su2:
@@ -932,7 +937,7 @@ class ControlledOp(Controlled, operation.Operation):
         # overrides dispatch behaviour of ``Controlled``
         return object.__new__(cls)
 
-    # pylint: disable=too-many-function-args
+    # pylint: disable=too-many-function-args, too-many-positional-arguments
     def __init__(self, base, control_wires, control_values=None, work_wires=None, id=None):
         super().__init__(base, control_wires, control_values, work_wires, id)
         # check the grad_recipe validity

--- a/pennylane/ops/op_math/controlled_ops.py
+++ b/pennylane/ops/op_math/controlled_ops.py
@@ -256,19 +256,6 @@ class ControlledQubitUnitary(ControlledOp):
             work_wires=self.work_wires,
         )
 
-    @property
-    def has_decomposition(self):
-        if not super().has_decomposition:
-            return False
-        with qml.QueuingManager.stop_recording():
-            # we know this is using try-except as logical control, but are favouring
-            # certainty in it being correct over explicitness in an edge case.
-            try:
-                self.decomposition()
-            except qml.operation.DecompositionUndefinedError:
-                return False
-        return True
-
 
 class CH(ControlledOp):
     r"""CH(wires)

--- a/pennylane/ops/op_math/decompositions/two_qubit_unitary.py
+++ b/pennylane/ops/op_math/decompositions/two_qubit_unitary.py
@@ -626,10 +626,9 @@ def two_qubit_decomposition(U, wires):
     # First, we note that this method works only for SU(4) gates, meaning that
     # we need to rescale the matrix by its determinant.
     if sp.sparse.issparse(U):
-        # Convert all the global elements to sparse matrices in-place
-        for name in global_arrays_name:
-            array = globals()[name]
-            globals()[name] = sp.sparse.csr_matrix(array)
+        raise qml.operation.DecompositionUndefinedError(
+            "two_qubit_decomposition does not accept sparse matrics."
+        )
     U = _convert_to_su4(U)
 
     # The next thing we will do is compute the number of CNOTs needed, as this affects

--- a/pennylane/ops/qubit/matrix_ops.py
+++ b/pennylane/ops/qubit/matrix_ops.py
@@ -275,7 +275,7 @@ class QubitUnitary(Operation):
         shape_without_batch_dim = shape[1:] if is_batched else shape
 
         if shape_without_batch_dim == (2, 2):
-            return qml.ops.one_qubit_decomposition(U, Wires(wires)[0])
+            return qml.ops.one_qubit_decomposition(U, Wires(wires)[0], return_global_phase=True)
 
         if shape_without_batch_dim == (4, 4):
             # TODO[dwierichs]: Implement decomposition of broadcasted unitary
@@ -283,7 +283,10 @@ class QubitUnitary(Operation):
                 raise DecompositionUndefinedError(
                     "The decomposition of a two-qubit QubitUnitary does not support broadcasting."
                 )
-
+            if sp.sparse.issparse(U):
+                raise DecompositionUndefinedError(
+                    "The decomposition of a two-qubit sparse QubitUnitary is undefined."
+                )
             return qml.ops.two_qubit_decomposition(U, Wires(wires))
 
         return super(QubitUnitary, QubitUnitary).compute_decomposition(U, wires=wires)
@@ -301,7 +304,7 @@ class QubitUnitary(Operation):
     # pylint: disable=arguments-renamed, invalid-overridden-method
     @property
     def has_decomposition(self) -> bool:
-        return len(self.wires) < 3
+        return len(self.wires) < 3 if self.has_matrix else len(self.wires) == 1
 
     def adjoint(self) -> "QubitUnitary":
         if self.has_matrix:

--- a/tests/ops/qubit/test_matrix_ops.py
+++ b/tests/ops/qubit/test_matrix_ops.py
@@ -21,6 +21,7 @@ import numpy as np
 import pytest
 from gate_data import H, I, S, T, X, Z
 from scipy.sparse import coo_matrix, csc_matrix, csr_matrix, lil_matrix
+from scipy.stats import unitary_group
 
 import pennylane as qml
 from pennylane import numpy as pnp
@@ -175,18 +176,20 @@ class TestQubitUnitaryCSR:
     def test_csr_matrix_decomposition(self):
         """Test that QubitUnitary.decomposition() works with csr_matrix."""
         # 4x4 Identity as a csr_matrix
-        dense = np.eye(4)
-        sparse = csr_matrix(dense)
-        op = qml.QubitUnitary(sparse, wires=[0, 1])
-        decomp = op.decomposition()
-        assert len(decomp) == 6
+        U = csr_matrix(unitary_group.rvs(4))
+        op = qml.QubitUnitary(U, wires=[0, 1])
+        assert not op.has_decomposition
+        with pytest.raises(DecompositionUndefinedError):
+            op.decomposition()
 
         # 2x2 Identity as a csr_matrix
-        dense = np.eye(2)
-        sparse = csr_matrix(dense)
-        op = qml.QubitUnitary(sparse, wires=[0])
+        mat = csr_matrix(unitary_group.rvs(2))
+        op = qml.QubitUnitary(mat, wires=[0])
+        assert op.has_decomposition
         decomp = op.decomposition()
-        assert len(decomp) == 3
+        assert len(decomp) == 4
+        mat2 = qml.matrix(op.decomposition, wire_order=[0])()
+        assert qml.math.allclose(mat2, mat.todense())
 
 
 class TestQubitUnitary:
@@ -418,17 +421,16 @@ class TestQubitUnitary:
         assert qml.math.allclose(out, qml.QubitUnitary(U, wires=range(num_wires)).matrix())
 
     @pytest.mark.parametrize(
-        "U,expected_gates,expected_params",
+        "U, expected_params",
         [
-            (I, (qml.RZ, qml.RY, qml.RZ), [0.0, 0.0, 0.0]),
-            (Z, (qml.RZ, qml.RY, qml.RZ), [np.pi / 2, 0.0, np.pi / 2]),
-            (S, (qml.RZ, qml.RY, qml.RZ), [np.pi / 4, 0.0, np.pi / 4]),
-            (T, (qml.RZ, qml.RY, qml.RZ), [np.pi / 8, 0.0, np.pi / 8]),
-            (qml.matrix(qml.RZ(0.3, wires=0)), (qml.RZ, qml.RY, qml.RZ), [0.15, 0.0, 0.15]),
+            (I, [0.0, 0.0, 0.0, 0.0]),
+            (Z, [np.pi / 2, 0.0, np.pi / 2, -np.pi / 2]),
+            (S, [np.pi / 4, 0.0, np.pi / 4, -np.pi / 4]),
+            (T, [np.pi / 8, 0.0, np.pi / 8, -np.pi / 8]),
+            (qml.matrix(qml.RZ(0.3, wires=0)), [0.15, 0.0, 0.15, 0.0]),
             (
                 qml.matrix(qml.RZ(-0.5, wires=0)),
-                (qml.RZ, qml.RY, qml.RZ),
-                [4 * np.pi - 0.25, 0.0, 4 * np.pi - 0.25],
+                [4 * np.pi - 0.25, 0.0, 4 * np.pi - 0.25, 0.0],
             ),
             (
                 np.array(
@@ -437,20 +439,17 @@ class TestQubitUnitary:
                         [9.831019270939975e-01 + 0.1830590094588862j, 0],
                     ]
                 ),
-                (qml.RZ, qml.RY, qml.RZ),
-                [12.382273469673908, np.pi, 0.18409714468526372],
+                [12.382273469673908, np.pi, 0.18409714468526372, 0.0],
             ),
-            (H, (qml.RZ, qml.RY, qml.RZ), [np.pi, np.pi / 2, 0.0]),
-            (X, (qml.RZ, qml.RY, qml.RZ), [np.pi / 2, np.pi, 7 * np.pi / 2]),
+            (H, [np.pi, np.pi / 2, 0.0, -np.pi / 2]),
+            (X, [np.pi / 2, np.pi, 7 * np.pi / 2, -np.pi / 2]),
             (
                 qml.matrix(qml.Rot(0.2, 0.5, -0.3, wires=0)),
-                (qml.RZ, qml.RY, qml.RZ),
-                [0.2, 0.5, 4 * np.pi - 0.3],
+                [0.2, 0.5, 4 * np.pi - 0.3, 0.0],
             ),
             (
                 np.exp(1j * 0.02) * qml.matrix(qml.Rot(-1.0, 2.0, -3.0, wires=0)),
-                (qml.RZ, qml.RY, qml.RZ),
-                [4 * np.pi - 1.0, 2.0, 4 * np.pi - 3.0],
+                [4 * np.pi - 1.0, 2.0, 4 * np.pi - 3.0, -0.02],
             ),
             # An instance of a broadcast unitary
             (
@@ -458,19 +457,23 @@ class TestQubitUnitary:
                 * qml.Rot(
                     np.array([1.2, 2.3]), np.array([0.12, 0.5]), np.array([0.98, 0.567]), wires=0
                 ).matrix(),
-                (qml.RZ, qml.RY, qml.RZ),
-                [[1.2, 2.3], [0.12, 0.5], [0.98, 0.567]],
+                [[1.2, 2.3], [0.12, 0.5], [0.98, 0.567], [-0.02, -0.02]],
             ),
         ],
     )
-    def test_qubit_unitary_decomposition(self, U, expected_gates, expected_params):
+    def test_qubit_unitary_decomposition(self, U, expected_params):
         """Tests that single-qubit QubitUnitary decompositions are performed."""
+
+        expected_gates = (qml.RZ, qml.RY, qml.RZ, qml.GlobalPhase)
 
         decomp = qml.QubitUnitary.compute_decomposition(U, wires=0)
         decomp2 = qml.QubitUnitary(U, wires=0).decomposition()
 
-        assert len(decomp) == 3 == len(decomp2)
-        for i in range(3):
+        mat1 = qml.matrix(qml.QubitUnitary.compute_decomposition, wire_order=[0])(U, wires=0)
+        assert qml.math.allclose(mat1, U)
+
+        assert len(decomp) == 4 == len(decomp2)
+        for i in range(4):
             assert isinstance(decomp[i], expected_gates[i])
             assert np.allclose(decomp[i].parameters, expected_params[i], atol=1e-7)
             assert isinstance(decomp2[i], expected_gates[i])


### PR DESCRIPTION
**Context:**

We were getting errors with:
```
op = qml.ControlledQubitUnitary(sparse.csr_matrix(U), wires=(0,1,2))
op.has_decomposition
```
Due to some problems with the decomposition for a two-qubit sparse qubit unitary.

**Description of the Change:**

Single qubit `qml.QubitUnitary` decompositions now always include the relevant global phase.

Two qubit sparse `qml.QubitUnitary` 's no longer can decompose. Later we may be able to fix `two_qubit_decomposition`, but not right now.

**Benefits:**

We can query whether or not `qml.QubitUnitary` and `qml.ControlledQubitUnitary` have a decomposition without it error-ing out.

**Possible Drawbacks:**

**Related GitHub Issues:**
