### PR TITLE
Reserve ABC for abstract base classes in codebase

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -725,6 +725,9 @@
 
 <h3>Internal changes ⚙️</h3>
 
+* All use of `ABC` for intermediate variables will be renamed to preserve the label for the Python abstract base class `abc.ABC`.
+  [(#7156)](https://github.com/PennyLaneAI/pennylane/pull/7156)
+
 * The error message when device wires are not specified when program capture is enabled is more clear.
   [(#7130)](https://github.com/PennyLaneAI/pennylane/pull/7130)
 

--- a/pennylane/gradients/parameter_shift_hessian.py
+++ b/pennylane/gradients/parameter_shift_hessian.py
@@ -64,15 +64,13 @@ def _process_jacs(jac, qhess):
         # contracting the quantum Hessian with the classical jacobian twice gives
         # a result with shape (num_qnode_args, num_qnode_args, output_shape)
 
-        qh_indices = "ab..."
 
         # contract the first axis of the jacobian with the first and second axes of the Hessian
-        first_jac_indices = f"a{ascii_letters[2:2 + jac_ndim - 1]}"
-        second_jac_indices = f"b{ascii_letters[2 + jac_ndim - 1:2 + 2 * jac_ndim - 2]}"
+        qnode_ids_0 = ascii_letters[2:2 + jac_ndim - 1]
+        qnode_ids_1 = ascii_letters[2 + jac_ndim - 1:2 + 2 * jac_ndim - 2]
 
-        result_indices = f"{ascii_letters[2:2 + 2 * jac_ndim - 2]}..."
         qh = qml.math.einsum(
-            f"{qh_indices},{first_jac_indices},{second_jac_indices}->{result_indices}",
+            f"ab...,a{qnode_ids_0},b{qnode_ids_1}->{qnode_ids_0}{qnode_ids_1}...",
             qh,
             jac,
             jac,

--- a/pennylane/gradients/parameter_shift_hessian.py
+++ b/pennylane/gradients/parameter_shift_hessian.py
@@ -18,7 +18,7 @@ of a qubit-based quantum tape.
 import itertools as it
 import warnings
 from functools import partial
-from string import ascii_letters as ABC
+from string import ascii_letters
 
 import numpy as np
 
@@ -67,10 +67,10 @@ def _process_jacs(jac, qhess):
         qh_indices = "ab..."
 
         # contract the first axis of the jacobian with the first and second axes of the Hessian
-        first_jac_indices = f"a{ABC[2:2 + jac_ndim - 1]}"
-        second_jac_indices = f"b{ABC[2 + jac_ndim - 1:2 + 2 * jac_ndim - 2]}"
+        first_jac_indices = f"a{ascii_letters[2:2 + jac_ndim - 1]}"
+        second_jac_indices = f"b{ascii_letters[2 + jac_ndim - 1:2 + 2 * jac_ndim - 2]}"
 
-        result_indices = f"{ABC[2:2 + 2 * jac_ndim - 2]}..."
+        result_indices = f"{ascii_letters[2:2 + 2 * jac_ndim - 2]}..."
         qh = qml.math.einsum(
             f"{qh_indices},{first_jac_indices},{second_jac_indices}->{result_indices}",
             qh,

--- a/pennylane/gradients/parameter_shift_hessian.py
+++ b/pennylane/gradients/parameter_shift_hessian.py
@@ -64,10 +64,9 @@ def _process_jacs(jac, qhess):
         # contracting the quantum Hessian with the classical jacobian twice gives
         # a result with shape (num_qnode_args, num_qnode_args, output_shape)
 
-
         # contract the first axis of the jacobian with the first and second axes of the Hessian
-        qnode_ids_0 = ascii_letters[2:2 + jac_ndim - 1]
-        qnode_ids_1 = ascii_letters[2 + jac_ndim - 1:2 + 2 * jac_ndim - 2]
+        qnode_ids_0 = ascii_letters[2 : 2 + jac_ndim - 1]
+        qnode_ids_1 = ascii_letters[2 + jac_ndim - 1 : 2 + 2 * jac_ndim - 2]
 
         qh = qml.math.einsum(
             f"ab...,a{qnode_ids_0},b{qnode_ids_1}->{qnode_ids_0}{qnode_ids_1}...",

--- a/pennylane/math/quantum.py
+++ b/pennylane/math/quantum.py
@@ -16,7 +16,7 @@ import functools
 
 # pylint: disable=import-outside-toplevel
 import itertools
-from string import ascii_letters as ABC
+from string import ascii_letters
 
 import scipy as sp
 import scipy.sparse.linalg as spla
@@ -32,7 +32,7 @@ from .matrix_manipulation import _permute_dense_matrix
 from .multi_dispatch import diag, dot, einsum, scatter_element_add
 from .utils import allclose, cast, cast_like, convert_like, is_abstract
 
-ABC_ARRAY = np.array(list(ABC))
+ascii_letter_arr = np.array(list(ascii_letters))
 
 
 def cov_matrix(prob, obs, wires=None, diag_approx=False):
@@ -325,7 +325,7 @@ def partial_trace(matrix, indices, c_dtype="complex128"):
     # For loop over wires
     for i, target_index in enumerate(indices):
         target_index = target_index - i
-        state_indices = ABC[1 : rho_dim - 2 * i + 1]
+        state_indices = ascii_letters[1 : rho_dim - 2 * i + 1]
         state_indices = list(state_indices)
 
         target_letter = state_indices[target_index]
@@ -361,21 +361,21 @@ def _batched_partial_trace_nonrep_indices(matrix, is_batched, indices, batch_dim
     # For loop over wires
     for target_wire in indices:
         # Tensor indices of density matrix
-        state_indices = ABC[1 : rho_dim + 1]
+        state_indices = ascii_letters[1 : rho_dim + 1]
         # row indices of the quantum state affected by this operation
         row_wires_list = [target_wire + 1]
-        row_indices = "".join(ABC_ARRAY[row_wires_list].tolist())
+        row_indices = "".join(ascii_letter_arr[row_wires_list].tolist())
         # column indices are shifted by the number of wires
         col_wires_list = [w + num_indices for w in row_wires_list]
-        col_indices = "".join(ABC_ARRAY[col_wires_list].tolist())
+        col_indices = "".join(ascii_letter_arr[col_wires_list].tolist())
         # indices in einsum must be replaced with new ones
         num_partial_trace_wires = 1
-        new_row_indices = ABC[rho_dim + 1 : rho_dim + num_partial_trace_wires + 1]
-        new_col_indices = ABC[
+        new_row_indices = ascii_letters[rho_dim + 1 : rho_dim + num_partial_trace_wires + 1]
+        new_col_indices = ascii_letters[
             rho_dim + num_partial_trace_wires + 1 : rho_dim + 2 * num_partial_trace_wires + 1
         ]
         # index for summation over Kraus operators
-        kraus_index = ABC[
+        kraus_index = ascii_letters[
             rho_dim + 2 * num_partial_trace_wires + 1 : rho_dim + 2 * num_partial_trace_wires + 2
         ]
         # new state indices replace row and column indices with new ones
@@ -470,12 +470,16 @@ def reduce_statevector(state, indices, check_state=False, c_dtype="complex128"):
     # traced_system = [x + 1 for x in consecutive_wires if x not in indices]
 
     # trace out the subsystem
-    indices1 = ABC[1 : num_wires + 1]
+    indices1 = ascii_letters[1 : num_wires + 1]
     indices2 = "".join(
-        [ABC[num_wires + i + 1] if i in indices else ABC[i + 1] for i in consecutive_wires]
+        [
+            ascii_letters[num_wires + i + 1] if i in indices else ascii_letters[i + 1]
+            for i in consecutive_wires
+        ]
     )
     target = "".join(
-        [ABC[i + 1] for i in sorted(indices)] + [ABC[num_wires + i + 1] for i in sorted(indices)]
+        [ascii_letters[i + 1] for i in sorted(indices)]
+        + [ascii_letters[num_wires + i + 1] for i in sorted(indices)]
     )
     density_matrix = einsum(
         f"a{indices1},a{indices2}->a{target}",

--- a/pennylane/measurements/classical_shadow.py
+++ b/pennylane/measurements/classical_shadow.py
@@ -16,7 +16,7 @@ This module contains the qml.classical_shadow measurement.
 """
 import copy
 from collections.abc import Iterable, Sequence
-from string import ascii_letters as ABC
+from string import ascii_letters
 from typing import Optional, Union
 
 import numpy as np
@@ -407,11 +407,13 @@ class ClassicalShadowMP(MeasurementTransform):
 
             # trace out every qubit except the first
             num_remaining_qubits = num_dev_qubits - active_qubit
-            conj_state_first_qubit = ABC[num_remaining_qubits]
-            stacked_dim = ABC[num_remaining_qubits + 1]
+            conj_state_first_qubit = ascii_letters[num_remaining_qubits]
+            stacked_dim = ascii_letters[num_remaining_qubits + 1]
 
-            state_str = f"{stacked_dim}{ABC[:num_remaining_qubits]}"
-            conj_state_str = f"{stacked_dim}{conj_state_first_qubit}{ABC[1:num_remaining_qubits]}"
+            state_str = f"{stacked_dim}{ascii_letters[:num_remaining_qubits]}"
+            conj_state_str = (
+                f"{stacked_dim}{conj_state_first_qubit}{ascii_letters[1:num_remaining_qubits]}"
+            )
             target_str = f"{stacked_dim}a{conj_state_first_qubit}"
 
             first_qubit_state = np.einsum(

--- a/pennylane/shadows/classical_shadow.py
+++ b/pennylane/shadows/classical_shadow.py
@@ -15,7 +15,7 @@
 # pylint: disable = too-many-arguments
 import warnings
 from collections.abc import Iterable
-from string import ascii_letters as ABC
+from string import ascii_letters
 
 import numpy as np
 
@@ -221,8 +221,8 @@ class ClassicalShadow:
 
         transposed_snapshots = np.transpose(local_snapshot, axes=(1, 0, 2, 3))
 
-        old_indices = [f"a{ABC[1 + 2 * i: 3 + 2 * i]}" for i in range(n)]
-        new_indices = f"a{ABC[1:2 * n + 1:2]}{ABC[2:2 * n + 1:2]}"
+        old_indices = [f"a{ascii_letters[1 + 2 * i: 3 + 2 * i]}" for i in range(n)]
+        new_indices = f"a{ascii_letters[1:2 * n + 1:2]}{ascii_letters[2:2 * n + 1:2]}"
 
         return np.reshape(
             np.einsum(f'{",".join(old_indices)}->{new_indices}', *transposed_snapshots),

--- a/tests/default_qubit_legacy.py
+++ b/tests/default_qubit_legacy.py
@@ -20,7 +20,7 @@ simulation of a qubit-based quantum circuit architecture.
 """
 import functools
 import itertools
-from string import ascii_letters as ABC
+from string import ascii_letters
 
 import numpy as np
 from scipy.sparse import coo_matrix, csr_matrix
@@ -38,7 +38,7 @@ from pennylane.pulse import ParametrizedEvolution
 from pennylane.typing import TensorLike
 from pennylane.wires import WireError
 
-ABC_ARRAY = np.array(list(ABC))
+ascii_letter_arr = np.array(list(ascii_letters))
 
 # tolerance for numerical errors
 tolerance = 1e-10
@@ -888,13 +888,13 @@ class DefaultQubitLegacy(QubitDevice):
         mat = self._cast(self._reshape(mat, shape), dtype=self.C_DTYPE)
 
         # Tensor indices of the quantum state
-        state_indices = ABC[: self.num_wires]
+        state_indices = ascii_letters[: self.num_wires]
 
         # Indices of the quantum state affected by this operation
-        affected_indices = "".join(ABC_ARRAY[list(device_wires)].tolist())
+        affected_indices = "".join(ascii_letter_arr[list(device_wires)].tolist())
 
         # All affected indices will be summed over, so we need the same number of new indices
-        new_indices = ABC[self.num_wires : self.num_wires + len(device_wires)]
+        new_indices = ascii_letters[self.num_wires : self.num_wires + len(device_wires)]
 
         # The new indices of the state are given by the old ones with the affected indices
         # replaced by the new_indices
@@ -936,8 +936,8 @@ class DefaultQubitLegacy(QubitDevice):
             shape.insert(0, batch_size)
         phases = self._cast(self._reshape(phases, shape), dtype=self.C_DTYPE)
 
-        state_indices = ABC[: self.num_wires]
-        affected_indices = "".join(ABC_ARRAY[list(device_wires)].tolist())
+        state_indices = ascii_letters[: self.num_wires]
+        affected_indices = "".join(ascii_letter_arr[list(device_wires)].tolist())
 
         einsum_indices = f"...{affected_indices},...{state_indices}->...{state_indices}"
         return self._einsum(einsum_indices, phases, state)
@@ -1058,8 +1058,8 @@ class DefaultQubitLegacy(QubitDevice):
         for i in range(n_qubits):
             # trace out every qubit except the first
             first_qubit_state = self._einsum(
-                f"{ABC[device_qubits - i + 1]}{ABC[:device_qubits - i]},{ABC[device_qubits - i + 1]}{ABC[device_qubits - i]}{ABC[1:device_qubits - i]}"
-                f"->{ABC[device_qubits - i + 1]}a{ABC[device_qubits - i]}",
+                f"{ascii_letters[device_qubits - i + 1]}{ascii_letters[:device_qubits - i]},{ascii_letters[device_qubits - i + 1]}{ascii_letters[device_qubits - i]}{ascii_letters[1:device_qubits - i]}"
+                f"->{ascii_letters[device_qubits - i + 1]}a{ascii_letters[device_qubits - i]}",
                 stacked_state,
                 self._conj(stacked_state),
             )


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      test directory!

- [x] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `doc/releases/changelog-dev.md` file, summarizing the
      change, and including a link back to the PR.

- [x] The PennyLane source code conforms to
      [PEP8 standards](https://www.python.org/dev/peps/pep-0008/).
      We check all of our code against [Pylint](https://www.pylint.org/).
      To lint modified files, simply `pip install pylint`, and then
      run `pylint pennylane/path/to/file.py`.

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:** Searching and filtering of implementations can be simplified if a convention is maintained for naming specific entities. Given the standard practice of `import abc; abc.ABC` being used for Pythonic abstract base classes, it can be challenging to filter abstract classes under search when the same `ABC` naming is used elsewhere. This PR ensures the original ASCII lettering users of the `ABC` label no longer do so. 

**Description of the Change:** As above.

**Benefits:** This allows a simplified approach for analysing the number of abstract base classes within PennyLane through search and filtering of the `ABC` label.

**Possible Drawbacks:** None.

**Related GitHub Issues:**
