### PR TITLE
Replace ConcreteArray with Array for JAX >= 0.5.0

### DIFF
--- a/pennylane/math/utils.py
+++ b/pennylane/math/utils.py
@@ -357,9 +357,9 @@ def is_abstract(tensor, like=None):
             ),
         ):
             # Tracer objects will be used when computing gradients or applying transforms.
-            # If the value of the tracer is known, it will contain a ConcreteArray.
+            # If the value of the tracer is known, it will contain a jax.Array.
             # Otherwise, it will be abstract.
-            return not isinstance(tensor.aval, jax.core.ConcreteArray)
+            return not isinstance(tensor.aval, jax.Array)
 
         return isinstance(tensor, DynamicJaxprTracer)
 


### PR DESCRIPTION
 Fix error: "[AttributeError: module ‘jax.core’ has no attribute ‘ConcreteArray’
------------------------------------------------------------------------------------------------------------

**Context:** Replace ConcreteArray with Array for JAX >= 0.5.0

**Description of the Change:**  The ConcreteArray was removed in new JAX versions and Array is used as the primary type for representing arrays in JAX. Old examples work without errors after replacing ConcreteArray.

**Benefits:** PennyLane will be able to work with new versions of JAX. Fix error: "[AttributeError: module ‘jax.core’ has no attribute ‘ConcreteArray’ - Problems using jax.grad(circuit)](https://discuss.pennylane.ai/t/attributeerror-module-jax-core-has-no-attribute-concretearray-problems-using-jax-grad-circuit/8053)"

**Possible Drawbacks:** Not found

**Related GitHub Issues:** Not found
