### PR TITLE
Removing htmlzip

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -21,8 +21,8 @@ sphinx:
 #  configuration: mkdocs.yml
 
 # Optionally build your docs in additional formats such as PDF and ePub
-formats:
-  - htmlzip
+# formats:
+#   - htmlzip
 
 # Optionally set the version of Python and requirements required to build your docs
 python:


### PR DESCRIPTION

------------------------------------------------------------------------------------------------------------

**Context:**
HTMLZip is an optional file format for readthedocs builds. It adds an additional step in the readthedocs build pipeline that adds ~120s of extra build time. These files are not being used and the extra time is unnecessary.

**Description of the Change:**
This PR will remove the following optional format block.
``` 
formats:
   - htmlzip
```

**Benefits:**
Saves build time.
**Possible Drawbacks:**
None
**Related GitHub Issues:**
