### PR TITLE
Adds a recommendation to use `clifford_t_decomposition` in the `decompose` docstring.

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -846,6 +846,9 @@
 
 <h3>Documentation 📝</h3>
 
+* The docstring for `qml.transforms.decompose` now recommends the `qml.clifford_t_decomposition` 
+  transform when decomposing to the Clifford + T gate set.
+
 * The docstring for `qml.prod` has been updated to explain that the order of the output may seem reversed but it is correct.
   [(#7083)](https://github.com/PennyLaneAI/pennylane/pull/7083)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -848,6 +848,7 @@
 
 * The docstring for `qml.transforms.decompose` now recommends the `qml.clifford_t_decomposition` 
   transform when decomposing to the Clifford + T gate set.
+  [(#7177)](https://github.com/PennyLaneAI/pennylane/pull/7177)
 
 * The docstring for `qml.prod` has been updated to explain that the order of the output may seem reversed but it is correct.
   [(#7083)](https://github.com/PennyLaneAI/pennylane/pull/7083)

--- a/pennylane/transforms/decompose.py
+++ b/pennylane/transforms/decompose.py
@@ -429,9 +429,12 @@ def decompose(
 
     .. seealso::
 
-        :func:`qml.devices.preprocess.decompose <.pennylane.devices.preprocess.decompose>` for a
+        For decomposing into Clifford + T, check out :func:`~.pennylane.clifford_t_decomposition`.
+
+        :func:`qml.devices.preprocess.decompose <.pennylane.devices.preprocess.decompose>` is a
         transform that is intended for device developers. This function will decompose a quantum
         circuit into a set of basis gates available on a specific device architecture.
+        
 
     .. details::
         :title: Integration with the Graph-Based Decomposition System


### PR DESCRIPTION
**Context:** Recommendation to use `clifford_t_decomposition` in the `decompose` docstring.

**Description of the Change:** Docstring of `qml.transforms.decompose`

**Benefits:** Users hopefully use the "correct" transform when decomposing into Clifford + T.

**Possible Drawbacks:** `clifford_t_decomposition` might be less efficient (more gates and longer runtime) than the decomposition algorithm.

**Related GitHub Issues:**
