### PR TITLE
Make `PSWAP` support parameter broadcasting

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -876,7 +876,7 @@
 
 <h3>Bug fixes 🐛</h3>
 
-* `PSWAP` now supports parameter broadcasting.
+* `PSWAP.matrix()` and `PSWAP.eigvals()` now support parameter broadcasting.
   [(#7179)](https://github.com/PennyLaneAI/pennylane/pull/7179)
 
 * Revert [(#6933)](https://github.com/PennyLaneAI/pennylane/pull/6933) to remove non-negligible performance impact due to wire flattening.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -876,6 +876,9 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* `PSWAP` now supports parameter broadcasting.
+  [(#7179)](https://github.com/PennyLaneAI/pennylane/pull/7179)
+
 * Revert [(#6933)](https://github.com/PennyLaneAI/pennylane/pull/6933) to remove non-negligible performance impact due to wire flattening.
   [(#7136)](https://github.com/PennyLaneAI/pennylane/pull/7136)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -194,6 +194,9 @@
 
 <h3>Improvements 🛠</h3>
 
+* `PSWAP.matrix()` and `PSWAP.eigvals()` now support parameter broadcasting.
+  [(#7179)](https://github.com/PennyLaneAI/pennylane/pull/7179)
+
 * `PrepSelPrep` now has a concise representation when drawn with `qml.draw` or `qml.draw_mpl`.
   [(#7164)](https://github.com/PennyLaneAI/pennylane/pull/7164)
 
@@ -875,9 +878,6 @@
   [(#7150)](https://github.com/PennyLaneAI/pennylane/pull/7150)
 
 <h3>Bug fixes 🐛</h3>
-
-* `PSWAP.matrix()` and `PSWAP.eigvals()` now support parameter broadcasting.
-  [(#7179)](https://github.com/PennyLaneAI/pennylane/pull/7179)
 
 * Revert [(#6933)](https://github.com/PennyLaneAI/pennylane/pull/6933) to remove non-negligible performance impact due to wire flattening.
   [(#7136)](https://github.com/PennyLaneAI/pennylane/pull/7136)

--- a/pennylane/ops/qubit/parametric_ops_multi_qubit.py
+++ b/pennylane/ops/qubit/parametric_ops_multi_qubit.py
@@ -1586,6 +1586,9 @@ class PSWAP(Operation):
     num_params = 1
     """int: Number of trainable parameters that the operator depends on."""
 
+    ndim_params = (0,)
+    """tuple[int]: Number of dimensions per trainable parameter that the operator depends on."""
+
     resource_keys = set()
 
     grad_method = "A"
@@ -1654,13 +1657,15 @@ class PSWAP(Operation):
             phi = qml.math.cast_like(phi, 1j)
 
         e = qml.math.exp(1j * phi)
+        zero = qml.math.zeros_like(phi)
+        one = qml.math.ones_like(phi)
 
         return qml.math.stack(
             [
-                stack_last([1, 0, 0, 0]),
-                stack_last([0, 0, e, 0]),
-                stack_last([0, e, 0, 0]),
-                stack_last([0, 0, 0, 1]),
+                stack_last([one, zero, zero, zero]),
+                stack_last([zero, zero, e, zero]),
+                stack_last([zero, e, zero, zero]),
+                stack_last([zero, zero, zero, one]),
             ],
             axis=-2,
         )

--- a/pennylane/ops/qubit/parametric_ops_multi_qubit.py
+++ b/pennylane/ops/qubit/parametric_ops_multi_qubit.py
@@ -1700,7 +1700,9 @@ class PSWAP(Operation):
         if qml.math.get_interface(phi) == "tensorflow":
             phi = qml.math.cast_like(phi, 1j)
 
-        return qml.math.stack([1, 1, -qml.math.exp(1j * phi), qml.math.exp(1j * phi)])
+        e = qml.math.exp(1j * phi)
+        one = qml.math.ones_like(phi)
+        return qml.math.stack([one, one, -e, e])
 
     def adjoint(self) -> "PSWAP":
         (phi,) = self.parameters

--- a/tests/ops/qubit/test_parametric_ops.py
+++ b/tests/ops/qubit/test_parametric_ops.py
@@ -103,6 +103,7 @@ BROADCASTED_OPERATIONS = [
         wires=[0, 1],
     ),
     qml.QubitUnitary(1j * np.array([[[1, 0], [0, -1]], [[0, 1], [1, 0]]]), wires=0),
+    qml.PSWAP(np.array([0.123, -0.63, 0.235]), wires=["a", -1]),
     qml.DiagonalQubitUnitary(np.array([[1.0, 1.0j], [1.0j, 1.0j]]), wires=1),
 ]
 
@@ -2781,7 +2782,7 @@ class TestPauliRot:
         self, theta, pauli_word, compressed_pauli_word, wires, compressed_wires, tol
     ):
         """Test PauliRot matrix correctly accounts for identities."""
-        # pylint: disable=too-many-arguments
+        # pylint: disable=too-many-arguments, too-many-positional-arguments
 
         res = qml.PauliRot.compute_matrix(theta, pauli_word)
         expected = qml.math.expand_matrix(


### PR DESCRIPTION
**Context:**
`PSWAP` does not support parameter broadcasting in its `compute_matrix` and `compute_eigvals` methods.

**Description of the Change:**
Add support for parameter broadcasting.

**Benefits:**
More support for broadcasting.

**Possible Drawbacks:**
Tiny code/computation growth.

**Related GitHub Issues:**
#7180 

[sc-87781]