### PR TITLE
Fix the wrongly placed op wires.

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -771,6 +771,8 @@
 
 <h3>Internal changes ⚙️</h3>
 
+* Adjusted `test_no_operator_matrix_defined` to correctly yield the documented, expected error.
+
 * All use of `ABC` for intermediate variables will be renamed to preserve the label for the Python abstract base class `abc.ABC`.
   [(#7156)](https://github.com/PennyLaneAI/pennylane/pull/7156)
 

--- a/tests/resource/test_error/test_error.py
+++ b/tests/resource/test_error/test_error.py
@@ -155,7 +155,7 @@ class TestSpectralNormError:
                 return self.__class__.__name__
 
         approx_op = MyOp(0)
-        exact_op = qml.RX(0.1, 1)
+        exact_op = qml.RX(0.1, 0)
 
         with pytest.raises(qml.operation.DecompositionUndefinedError):
             SpectralNormError.get_error(approx_op, exact_op)


### PR DESCRIPTION
**Context:**
The test suite `test_no_operator_matrix_defined` was supposed to test only against an empty op without provided decomposition, but actually it contains extra wire Mismatch error. This won't be revealed until we improved the `qml.matrix()` internal logic at https://github.com/PennyLaneAI/pennylane/actions/runs/14182294940/job/39730979271?pr=7147, since the decomposition error always comes first and stops execution.

**Description of the Change:**
matched the two wires.

**Benefits:**
Less unexpected bug in future dev.

**Possible Drawbacks:**
No

**Related GitHub Issues:**

