### PR TITLE
Support Adjoint in DecomposeInterpreter

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -195,6 +195,9 @@
 
 <h3>Improvements 🛠</h3>
 
+* `qml.adjoint` can be now applied in the execution pipeline for program capture.
+  [(#)](https://github.com/PennyLaneAI/pennylane/pull/)
+
 * `PrepSelPrep` now has a concise representation when drawn with `qml.draw` or `qml.draw_mpl`.
   [(#7164)](https://github.com/PennyLaneAI/pennylane/pull/7164)
 

--- a/tests/capture/transforms/test_capture_decompose.py
+++ b/tests/capture/transforms/test_capture_decompose.py
@@ -292,15 +292,15 @@ class TestDecomposeInterpreter:
             qml.adjoint(g, lazy=lazy)(x, y, z)
 
         jaxpr = jax.make_jaxpr(f)(1.2, 3.4, 5.6)
-        assert len(jaxpr.eqns) == 1
-        assert jaxpr.eqns[0].primitive == adjoint_transform_prim
-        assert jaxpr.eqns[0].params["lazy"] == lazy
+        assert len(jaxpr.eqns) == 6
 
-        inner_jaxpr = jaxpr.eqns[0].params["jaxpr"]
-        assert len(inner_jaxpr.eqns) == 3
-        assert inner_jaxpr.eqns[0].primitive == qml.RZ._primitive
-        assert inner_jaxpr.eqns[1].primitive == qml.RY._primitive
-        assert inner_jaxpr.eqns[2].primitive == qml.RZ._primitive
+        assert jaxpr.eqns[0].primitive.name == "neg"
+        assert jaxpr.eqns[1].primitive.name == "neg"
+        assert jaxpr.eqns[2].primitive.name == "neg"
+
+        assert jaxpr.eqns[3].primitive == qml.RZ._primitive
+        assert jaxpr.eqns[4].primitive == qml.RY._primitive
+        assert jaxpr.eqns[5].primitive == qml.RZ._primitive
 
     def test_cond_higher_order_primitive(self):
         """Test that the cond primitive is correctly interpreted"""

--- a/tests/capture/transforms/test_capture_graph_decompose.py
+++ b/tests/capture/transforms/test_capture_graph_decompose.py
@@ -209,7 +209,6 @@ class TestDecomposeInterpreterGraphEnabled:
             qml.CNOT(wires=[2, 0]),
         ]
 
-    @pytest.mark.xfail(reason="DecomposeInterpreter cannot handle adjoint transforms [sc-87096]")
     @pytest.mark.integration
     def test_decompose_adjoint(self):
         """Tests that an adjoint operation is decomposed."""
@@ -244,12 +243,11 @@ class TestDecomposeInterpreterGraphEnabled:
             qml.CNOT(wires=[1, 0]),
             qml.RZ(0.1, wires=[0]),
             qml.CNOT(wires=[1, 0]),
-            qml.RZ(qml.math.array(-0.3, like="jax"), wires=[0]),
-            qml.RY(qml.math.array(-0.2, like="jax"), wires=[0]),
             qml.RX(qml.math.array(-0.1, like="jax"), wires=[0]),
+            qml.RY(qml.math.array(-0.2, like="jax"), wires=[0]),
+            qml.RZ(qml.math.array(-0.3, like="jax"), wires=[0]),
         ]
 
-    @pytest.mark.xfail(reason="DecomposeInterpreter cannot handle adjoint transforms [sc-87096]")
     @pytest.mark.integration
     def test_adjoint_transform(self):
         """Tests that an adjoint transform can be decomposed correctly."""
@@ -267,7 +265,7 @@ class TestDecomposeInterpreterGraphEnabled:
         collector = CollectOpsandMeas()
         collector.eval(jaxpr.jaxpr, jaxpr.consts, 0.1, 0.2, 0.3)
         assert collector.state["ops"] == [
-            qml.RZ(qml.math.array(-0.3, like="jax"), wires=[0]),
-            qml.RY(qml.math.array(-0.2, like="jax"), wires=[0]),
             qml.RX(qml.math.array(-0.1, like="jax"), wires=[0]),
+            qml.RY(qml.math.array(-0.2, like="jax"), wires=[0]),
+            qml.RZ(qml.math.array(-0.3, like="jax"), wires=[0]),
         ]


### PR DESCRIPTION
**Context:**
The Adjoint operator is not currently supported in `DecomposeInterpreter` as a result the `qml.adjoint(CustomOp)` cannot be decomposed using the new graph-based decomposition system. 

**The Issue**

```python
import jax
import pennylane as qml
from pennylane.transforms.decompose import DecomposeInterpreter
from pennylane.tape.plxpr_conversion import CollectOpsandMeas

qml.capture.enable()

def inner_f():
    qml.RX(0.5, wires=[0])

@DecomposeInterpreter(gate_set={"RX"})
def f():
    qml.adjoint(inner_f)()
```
```pycon
>>> jaxpr = jax.make_jaxpr(f)()
>>> collector = CollectOpsandMeas()
>>> collector.eval(jaxpr.jaxpr, jaxpr.consts)
>>> collector.state["ops"]
[Adjoint(RX(0.5, wires=[0]))]
```
We are expecting `[RX(-0.5, wires=[0]]` here because
```pycon
>>> qml.adjoint(qml.RX(0.5, wires=[0])).decomposition()
[RX(-0.5, wires=[0])]
```
This decomposition exists, but isn't applied.

**Description of the Change:**

- Add `AdjointTransformInterpreter` to `DecomposeInterpreter`
- Update tests

**Benefits:**
- Apply `qml.adjoint` can be now applied in the execution pipeline for program capture.

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-87096]