### PR TITLE
Adding push master and renaming sphinx job

### DIFF
--- a/.github/workflows/rtd-check.yml
+++ b/.github/workflows/rtd-check.yml
@@ -9,9 +9,12 @@ on:
       - reopened
       - synchronize
       - ready_for_review
+  push:
+    branches:
+      - master
 
 jobs:
-  sphinx:
+  rtd_check:
     runs-on: ubuntu-22.04
     env:
       PYTHON_VERSION: "3.10"


### PR DESCRIPTION
**Context:**
There are two jobs named sphinx in pennylane which has made it difficult to identify the right one to turn on in merge queues. The job in rtd-check is a required step and needs to run on merge to master.

**Description of the Change:**
Rename sphinx->rtd_check. Add on:push:master to rtd-check.yml

**Benefits:**
merge queues can be activated.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
