### PR TITLE
[WIP] Fix  `Hermitian` bug having its eigs disordered

### DIFF
--- a/pennylane/ops/qubit/observables.py
+++ b/pennylane/ops/qubit/observables.py
@@ -155,7 +155,7 @@ class Hermitian(Observable):
         Hmat = qml.math.to_numpy(Hmat)
         Hkey = tuple(Hmat.flatten().tolist())
         if Hkey not in Hermitian._eigs:
-            w, U = np.linalg.eigh(Hmat)
+            w, U = np.linalg.eig(Hmat)
             Hermitian._eigs[Hkey] = {"eigvec": U, "eigval": w}
 
         return Hermitian._eigs[Hkey]


### PR DESCRIPTION
**Context:**
`qml.Hermitian` uses `eigh` to get eigendecompositions for itself. However, `eigh` is known to optimize a lot but also re-order the results under the hood. Simply run the following on `master` branch to see the drastic difference:
```python
dev = qml.device("default.qubit", wires=1)

H = 1 / np.sqrt(2) * np.array([[1, 1], [1, -1]])
opH = qml.Hermitian(H, wires=0)

@qml.qnode(dev)
def circuit():
    return qml.probs(op=opH), qml.probs(op=qml.H(0))

assert np.allclose(opH.matrix(), H)
print(circuit())
```
A change `eigh` -> `eig` would be able to save this scenario.

However, this is not enough since `Hermitian` on multiple wires still fails.

**Description of the Change:**

**Benefits:**
Much more as most of users expectation.

**Possible Drawbacks:**
`eig` is almost guaranteed to be *slower* than `eigh`. We need to make sure we do not actually heavily depend on the decomposition of `Hermitian` so that we can easily approve this change.

**Related GitHub Issues:**
https://github.com/PennyLaneAI/pennylane/issues/6878