### PR TITLE
Force usage of large runners on merge queue

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,6 +38,7 @@ jobs:
     uses: ./.github/workflows/determine-workflow-runner.yml
     with:
       default_runner: ubuntu-latest
+      force_large_runner: ${{ github.event_name == 'merge_group' }}
 
   sphinx:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -21,6 +21,7 @@ jobs:
     uses: ./.github/workflows/determine-workflow-runner.yml
     with:
       default_runner: ubuntu-latest
+      force_large_runner: ${{ github.event_name == 'merge_group' }}
 
   black-pylint:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/tests-labs.yml
+++ b/.github/workflows/tests-labs.yml
@@ -38,6 +38,7 @@ jobs:
     uses: ./.github/workflows/determine-workflow-runner.yml
     with:
       default_runner: ubuntu-latest
+      force_large_runner: ${{ github.event_name == 'merge_group' }}
   
   default-dependency-versions:
     needs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,7 @@ jobs:
       codecov_token: ${{ secrets.CODECOV_TOKEN }}
     with:
       branch: ${{ github.ref }}
+      use_large_runner: ${{ github.event_name == 'merge_group' }}
 
       # Run a 'lightened' version of the CI on Pull Requests by default
       # Unless the label `ci:run-full-test-suite` is attached to the PR.


### PR DESCRIPTION
**Context:**

Merge queues trigger builds across all items enqueued at once, this is "hogging" the concurrency limit of the org and slowing down time it takes to get a runner.

**Description of the Change:**

For the workflows calling `determine-workflow-runner`, swap them over to using large runners if the workflow was triggered by `merge_group` event.

**Benefits:**

Merge queue will not use up the concurrency limit of standard runners.

**Possible Drawbacks:**


**Related GitHub Issues:**
[sc-88275](https://app.shortcut.com/xanaduai/story/88275/update-merge-queue-to-use-large-runners)